### PR TITLE
Remove shell comments with tags

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/cmake/ConfigUserTemplate.cmake
+++ b/cmake/ConfigUserTemplate.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/cmake/dist/CMakeLists.txt
+++ b/cmake/dist/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/cmake/modules/CheckPrototypeExists.cmake
+++ b/cmake/modules/CheckPrototypeExists.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # - Check if the prototype for a function exists.
 # CHECK_PROTOTYPE_EXISTS (FUNCTION HEADER VARIABLE)

--- a/cmake/modules/CheckTypeExists.cmake
+++ b/cmake/modules/CheckTypeExists.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # - Check if the given struct or class has the specified member variable
 # CHECK_STRUCT_MEMBER (STRUCT MEMBER HEADER VARIABLE)

--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Useful CMake variables.
 #

--- a/cmake/modules/ConfigureChecks.cmake
+++ b/cmake/modules/ConfigureChecks.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 
 if(NOT DEFINED _INCLUDED_CHECK_MACROS_)

--- a/cmake/modules/CopyDirIfDifferent.cmake
+++ b/cmake/modules/CopyDirIfDifferent.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/cmake/modules/CreateDebugSym.cmake
+++ b/cmake/modules/CreateDebugSym.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # - Generates Mac .dSYM bundle
 # CREATE_DEBUG_SYM ( DESTINATION TARGETS )

--- a/cmake/modules/FindDCW.cmake
+++ b/cmake/modules/FindDCW.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Locate DCW Digital Chart of the World for GMT
 #

--- a/cmake/modules/FindFFTW3.cmake
+++ b/cmake/modules/FindFFTW3.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Locate fftw3
 #

--- a/cmake/modules/FindGDAL.cmake
+++ b/cmake/modules/FindGDAL.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Locate gdal
 #

--- a/cmake/modules/FindGLIB.cmake
+++ b/cmake/modules/FindGLIB.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # - Try to find Glib and its components (gio, gobject etc)
 # Once done, this will define

--- a/cmake/modules/FindGSHHG.cmake
+++ b/cmake/modules/FindGSHHG.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Locate GSHHG shorelines
 #

--- a/cmake/modules/FindNETCDF.cmake
+++ b/cmake/modules/FindNETCDF.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Locate netcdf
 #

--- a/cmake/modules/FindPCRE.cmake
+++ b/cmake/modules/FindPCRE.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Locate pcre
 #

--- a/cmake/modules/FindPCRE2.cmake
+++ b/cmake/modules/FindPCRE2.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Locate pcre2
 #

--- a/cmake/modules/FindREGEX.cmake
+++ b/cmake/modules/FindREGEX.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # - Find regex
 # Find the native REGEX includes and library

--- a/cmake/modules/FindSphinx.cmake
+++ b/cmake/modules/FindSphinx.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Locate Sphinx documentation generator
 #

--- a/cmake/modules/GmtGenExtraHeaders.cmake
+++ b/cmake/modules/GmtGenExtraHeaders.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # - Generates extra header files
 # GMT_CREATE_HEADERS ()

--- a/cmake/modules/GmtHelperMacros.cmake
+++ b/cmake/modules/GmtHelperMacros.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # - Useful CMake macros
 #

--- a/cmake/modules/ManageString.cmake
+++ b/cmake/modules/ManageString.cmake
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # - Collection of String utility macros.
 # Defines the following macros:

--- a/cmake/modules/UseLATEX.cmake
+++ b/cmake/modules/UseLATEX.cmake
@@ -1,4 +1,3 @@
-# $Id$
 #
 # CMAKE commands to actually use the LaTeX compiler
 # Version: 1.9.1

--- a/doc_classic/CMakeLists.txt
+++ b/doc_classic/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2017 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/doc_classic/examples/CMakeLists.txt
+++ b/doc_classic/examples/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2017 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/doc_classic/examples/animate.in
+++ b/doc_classic/examples/animate.in
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # Bash script for creating videos of the animation examples.
 # The videos will optionally be included in the RST gallery.

--- a/doc_classic/examples/gmtest.in
+++ b/doc_classic/examples/gmtest.in
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # Bash script inclusion to test all GMT examples.
 # It sets the environment such that the examples are created as in the manual.

--- a/doc_classic/fig/CMakeLists.txt
+++ b/doc_classic/fig/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2017 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/doc_classic/rst/CMakeLists.txt
+++ b/doc_classic/rst/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2017 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/doc_classic/scripts/CMakeLists.txt
+++ b/doc_classic/scripts/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2017 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/doc_classic/scripts/GMT_chunking.sh
+++ b/doc_classic/scripts/GMT_chunking.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #
 # Make an illustration of grid chunking
 #

--- a/doc_classic/scripts/gen_data_App_O.sh
+++ b/doc_classic/scripts/gen_data_App_O.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 # Makes the data for GMT_App_O_[1-9].sh
 #
 gmt grdcut @osu91a1f_16.nc -R50/160/-15/15 -GApp_O_geoid.nc

--- a/doc_classic/scripts/gen_data_dummy.sh
+++ b/doc_classic/scripts/gen_data_dummy.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 # This script makes the dummy data sets needed in GMT_linear.sh GMT_log.sh GMT_pow.sh
 #
 gmt math -T0/100/1  T SQRT = sqrt.txt

--- a/doc_classic/scripts/gmtest.in
+++ b/doc_classic/scripts/gmtest.in
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # Functions to be used with test scripts
 

--- a/doc_modern/CMakeLists.txt
+++ b/doc_modern/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/doc_modern/examples/CMakeLists.txt
+++ b/doc_modern/examples/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/doc_modern/examples/animate.in
+++ b/doc_modern/examples/animate.in
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # Bash script for creating videos of the animation examples.
 # The videos will optionally be included in the RST gallery.

--- a/doc_modern/examples/gmtest.in
+++ b/doc_modern/examples/gmtest.in
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # Bash script inclusion to test all GMT examples.
 # It sets the environment such that the examples are created as in the manual.

--- a/doc_modern/fig/CMakeLists.txt
+++ b/doc_modern/fig/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/doc_modern/rst/CMakeLists.txt
+++ b/doc_modern/rst/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/doc_modern/scripts/CMakeLists.txt
+++ b/doc_modern/scripts/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/doc_modern/scripts/GMT_chunking.sh
+++ b/doc_modern/scripts/GMT_chunking.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #
 # Make an illustration of grid chunking
 #

--- a/doc_modern/scripts/gen_data_App_O.sh
+++ b/doc_modern/scripts/gen_data_App_O.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 # Makes the data for GMT_App_O_[1-9].sh
 #
 gmt grdcut @osu91a1f_16.nc -R50/160/-15/15 -GApp_O_geoid.nc

--- a/doc_modern/scripts/gen_data_dummy.sh
+++ b/doc_modern/scripts/gen_data_dummy.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 # This script makes the dummy data sets needed in GMT_linear.sh GMT_log.sh GMT_pow.sh
 #
 gmt math -T0/100/1  T SQRT = sqrt.txt

--- a/doc_modern/scripts/gmtest.in
+++ b/doc_modern/scripts/gmtest.in
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # Functions to be used with test scripts
 

--- a/prog_use.sh
+++ b/prog_use.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Returns a count of how many time a GMT program is used in our test scripts
 # including doc and examples.  Give -l to see which scripts [Default returns the count]
 #

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/share/coastline.conf.in
+++ b/share/coastline.conf.in
@@ -1,5 +1,4 @@
 #
-# $Id$
 # GSHHG shoreline search path for in-build-dir tests
 #
 @GSHHG_PATH@

--- a/share/localization/gmt_gr.locale
+++ b/share/localization/gmt_gr.locale
@@ -1,6 +1,5 @@
 # GMT Time language file for GR (Greece) mode [GR]
 #
-# $Id$
 #-------------------------------------------------
 # Monthnames, with 3-char and 1-char abbreviations
 M	1	Ιανουάριος	Ιαν	Ι

--- a/share/localization/gmt_ru.locale
+++ b/share/localization/gmt_ru.locale
@@ -1,6 +1,5 @@
 # GMT Time language file for RU (Russion) mode [RU]
 #
-# $Id$
 #-------------------------------------------------
 # Monthnames, with 3-char and 1-char abbreviations
 M 1 январь   янв я

--- a/share/tools/CMakeLists.txt
+++ b/share/tools/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/share/tools/gmt5syntax.in
+++ b/share/tools/gmt5syntax.in
@@ -2,7 +2,6 @@
 #! -*-perl-*-
 eval 'exec perl -x -wS $0 ${1+"$@"}'
   if 0;
-# $Id$
 #
 #  Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo,
 #  J. Luis, and F. Wobbe

--- a/share/tools/gmt_aliases.csh
+++ b/share/tools/gmt_aliases.csh
@@ -1,4 +1,3 @@
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo,
 # J. Luis, and F. Wobbe

--- a/share/tools/gmt_completion.bash
+++ b/share/tools/gmt_completion.bash
@@ -1,4 +1,3 @@
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo,
 # J. Luis, and F. Wobbe

--- a/share/tools/gmt_functions.sh
+++ b/share/tools/gmt_functions.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo,
 # J. Luis, and F. Wobbe

--- a/share/tools/gmt_links.sh
+++ b/share/tools/gmt_links.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo,
 # J. Luis, and F. Wobbe

--- a/share/tools/gmt_prepmex.sh
+++ b/share/tools/gmt_prepmex.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo,
 # J. Luis, and F. Wobbe

--- a/share/tools/gmt_uninstall.sh
+++ b/share/tools/gmt_uninstall.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo,
 # J. Luis, and F. Wobbe

--- a/share/tools/ncdeflate
+++ b/share/tools/ncdeflate
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo,
 # J. Luis, and F. Wobbe

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/src/Datums.txt
+++ b/src/Datums.txt
@@ -1,4 +1,3 @@
-# $Id$
 #
 # List of Datums available in GMT
 # The (Dx,Dy,Dz) values are in meters relative to WGS-84

--- a/src/Ellipsoids.txt
+++ b/src/Ellipsoids.txt
@@ -1,4 +1,3 @@
-# $Id$
 #
 # This is the core listing of supported ellipsoids in GMT map projections.
 # Please adhere to the format.

--- a/src/gmt_make_PSL_strings.sh
+++ b/src/gmt_make_PSL_strings.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # Copyright (c) 2012-2018
 # by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe

--- a/src/gmt_make_enum_dicts.sh
+++ b/src/gmt_make_enum_dicts.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # Copyright (c) 2012-2018
 # by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe

--- a/src/gshhg/CMakeLists.txt
+++ b/src/gshhg/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/src/img/CMakeLists.txt
+++ b/src/img/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/src/img/img2google
+++ b/src/img/img2google
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # Copyright (c) 2009-2018 by David Sandwell and Paul Wessel
 # Credit to Joaquim Luis for adding KML output from ps2raster

--- a/src/meca/CMakeLists.txt
+++ b/src/meca/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/src/mgd77/CMakeLists.txt
+++ b/src/mgd77/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/src/misc/CMakeLists.txt
+++ b/src/misc/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/src/misc/dim.template.sh
+++ b/src/misc/dim.template.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # Seung-Sep Kim, Chungnam National University, Daejeon, South Korea [seungsep@cnu.kr]
 # $Revision$    $Date$

--- a/src/potential/CMakeLists.txt
+++ b/src/potential/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/src/segy/CMakeLists.txt
+++ b/src/segy/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/src/spotter/CMakeLists.txt
+++ b/src/spotter/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/src/x2sys/CMakeLists.txt
+++ b/src/x2sys/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,4 @@
 #
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo, J. Luis, and F. Wobbe
 # See LICENSE.TXT file for copying and redistribution conditions.

--- a/test/blockmean/gmean.sh
+++ b/test/blockmean/gmean.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test that the grid option in blockmean matches the table output to ~EPS
 # If max fractional difference is < 1e-7 we assume it is good and write 1
 # else it is 0.  If any of the 4 outputs fail then the test fails, and

--- a/test/blockmedian/gmedian.sh
+++ b/test/blockmedian/gmedian.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test that the grid option in blockmedian matches the table output to ~EPS
 # If max fractional difference is < 1e-7 we assume it is good and write 1
 # else it is 0.  If any of the 6 outputs fail then the test fails, and

--- a/test/blockmode/gmode.sh
+++ b/test/blockmode/gmode.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test that the grid option in blockmode matches the table output to ~EPS
 # If max fractional difference is < 1e-7 we assume it is good and write 1
 # else it is 0.  If any of the 4 outputs fail then the test fails, and

--- a/test/byteswap/bswap16.sh
+++ b/test/byteswap/bswap16.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 
 # test byteswapping 16 bit integers
 

--- a/test/byteswap/bswap32.sh
+++ b/test/byteswap/bswap32.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 
 # test byteswapping 32 bit integers
 

--- a/test/byteswap/bswap64.sh
+++ b/test/byteswap/bswap64.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 
 # test byteswapping 64 bit integers
 exit 0 # not implemented yet, disabled for the time being

--- a/test/byteswap/gmtconvert.sh
+++ b/test/byteswap/gmtconvert.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 
 # test byteswapping with gmt convert
 

--- a/test/gdal/gdal_readwrite.sh
+++ b/test/gdal/gdal_readwrite.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # test reading and writing via gdal
 

--- a/test/gdal/gdal_smallgrid.sh
+++ b/test/gdal/gdal_smallgrid.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # test reading and writing a very small grid via gdal
 

--- a/test/gmt_core/testsuite.sh
+++ b/test/gmt_core/testsuite.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 
 # test if testsuite is up to date and setup correctly
 # make sure we are using the gmt executable from the build tree

--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # Functions to be used with test scripts
 

--- a/test/gmtsimplify/GSHHS_h_Australia.txt
+++ b/test/gmtsimplify/GSHHS_h_Australia.txt
@@ -1,4 +1,3 @@
-# $Id$
 #
 # GSHHS Master File: Resolution = high Continent = Australia
 #

--- a/test/gmtspatial/measure.sh
+++ b/test/gmtspatial/measure.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #
 
 cat << EOF > area.txt

--- a/test/grdgradient/aspect.sh
+++ b/test/grdgradient/aspect.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test the generation of aspect maps
 
 ps=aspect.ps

--- a/test/grdgradient/illum_classic.sh
+++ b/test/grdgradient/illum_classic.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test the generation of illumination with the GMT original algorithm
 
 ps=illum_classic.ps

--- a/test/grdgradient/illum_lambert.sh
+++ b/test/grdgradient/illum_lambert.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test the generation of illumination with the lambertian (same one as in Matlab) algorithm
 
 ps=illum_lambert.ps

--- a/test/grdgradient/illum_manip.sh
+++ b/test/grdgradient/illum_manip.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test the generation of illumination with yet another algorithm
 
 ps=illum_manip.ps

--- a/test/grdgradient/illum_var.sh
+++ b/test/grdgradient/illum_var.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test the generation of illumination for variable azimuth
 
 ps=illum_var.ps

--- a/test/grdmath/F.sh
+++ b/test/grdmath/F.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 ps=F.ps
 gmt grdmath -R1/10/1/15 -I1 0.95 X Y FCRIT = F.nc
 gmt psbasemap -R0.5/10.5/0.5/15.5 -JX6i/-9i -Bg1+0.5 -P -K -X1.5i -Y0.5i > $ps

--- a/test/grdmath/ldist.sh
+++ b/test/grdmath/ldist.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #
 # Purpose:  Compute Cartesian distances from square and triangular polygons
 ps=ldist.ps

--- a/test/grdmath/ops.sh
+++ b/test/grdmath/ops.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 ps=ops.ps
 # Create a unit spike at (0,0)
 echo 0 0 1 | gmt xyz2grd -GA.grd -R-2/2/-2/2 -I1 -di0

--- a/test/grdmath/taper.sh
+++ b/test/grdmath/taper.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 ps=taper.ps
 gmt grdmath -R0/10/0/10 -I0.1 2 0 TAPER = x.nc
 gmt grdmath -R0/10/0/10 -I0.1 0 2 TAPER = y.nc

--- a/test/grdvector/cartvec.sh
+++ b/test/grdvector/cartvec.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Switch sign for scaling and try with/without -T
 # Red is original, blue subject to -T
 ps=cartvec.ps

--- a/test/grdvector/plate.sh
+++ b/test/grdvector/plate.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Plot r,az vectors on the globe.  The issue here is that some tools
 # such as psvelo, scales the user lengths to inches and thus vectors
 # of the same user length become the same scaled lengthon the plot.

--- a/test/grdvector/sample.sh
+++ b/test/grdvector/sample.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test sub-sampling of grids for vectors
 ps=sample.ps
 gmt pscoast -R60/105/-20/40 -JM95.0/35/16c -Gbisque -K -Bafg8 -P -Xc > $ps

--- a/test/grdvector/shrink.sh
+++ b/test/grdvector/shrink.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test shrinking of line and heads with/without +n for grdvector
 ps=shrink.ps
 gmt grdmath -R0/360/-30/60 -I30/30 -r 7 X MUL = x.nc

--- a/test/grdvector/vectors.sh
+++ b/test/grdvector/vectors.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Plot r,az vectors on the globe
 ps=vectors.ps
 gmt grdmath -Rg -I30 -r 0.5 Y COSD ADD = r.nc

--- a/test/grdvector/wrapped.sh
+++ b/test/grdvector/wrapped.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test wrapping of geovector's head across periodic boundary
 ps=wrapped.ps
 L=6000

--- a/test/invalidate_modules.sh
+++ b/test/invalidate_modules.sh
@@ -1,4 +1,3 @@
-# $Id$
 #
 # Copyright (c) 1991-2018 by P. Wessel, W. H. F. Smith, R. Scharroo,
 # J. Luis, and F. Wobbe

--- a/test/modern/imagepluscpt.sh
+++ b/test/modern/imagepluscpt.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test automatic CPT scaling
 gmt begin imagepluscpt ps
 	gmt grdimage @earth_relief_01m -RMG+r2 -Cgeo -I+

--- a/test/modern/viewpluscpt.sh
+++ b/test/modern/viewpluscpt.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test automatic CPT scaling
 gmt begin viewpluscpt ps
 	gmt grdview @earth_relief_01m -RMG+r2 -Cgeo -I+ -Qi

--- a/test/postscriptlight/psldemo.sh
+++ b/test/postscriptlight/psldemo.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# $Id$
 #
 # Purpose:      Test all PSL functions at least once
 # GMT progs:    libpostscriptlight, psldemo

--- a/test/potential/cyltest.sh
+++ b/test/potential/cyltest.sh
@@ -1,5 +1,4 @@
 #! /bin/bash
-# $Id$
 #
 # Computes the gravity and VGG anomaly over a cylinder and compares
 # with theory and brute (sum of tiny cubes) results in cylinder25.txt

--- a/test/potential/fc_okb.sh
+++ b/test/potential/fc_okb.sh
@@ -1,5 +1,4 @@
 #! /bin/bash
-# $Id$
 #
 # Compute the gravity anomaly of the Flemish Cap Guyot
 

--- a/test/potential/grdgravmag3D_grav_sph.sh
+++ b/test/potential/grdgravmag3D_grav_sph.sh
@@ -1,5 +1,4 @@
 #! /bin/bash
-# $Id$
 #
 # Computes the gravity anomaly over a sphere with radius r = 15 m and center at -15 m.
 # The sphere is aproximated by two hemi-spheres

--- a/test/potential/grdokb_grav.sh
+++ b/test/potential/grdokb_grav.sh
@@ -1,5 +1,4 @@
 #! /bin/bash
-# $Id$
 #
 # Compute the gravity anomaly of the whater layer above the Gorringe bank
 

--- a/test/potential/sombrero_mag.sh
+++ b/test/potential/sombrero_mag.sh
@@ -1,5 +1,4 @@
 #! /bin/bash
-# $Id$
 #
 # Compute the magnetic anomaly of our Mexican hat split in two halves
 

--- a/test/potential/spheres.sh
+++ b/test/potential/spheres.sh
@@ -1,5 +1,4 @@
 #! /bin/bash
-# $Id$
 #
 # Computes the gravity anomaly of a sphere both analytical and descrete triangles
 

--- a/test/potential/sphtest.sh
+++ b/test/potential/sphtest.sh
@@ -1,5 +1,4 @@
 #! /bin/bash
-# $Id$
 #
 # Computes the gravity and VGG anomaly over a sphere and compares
 # with theory a

--- a/test/psbasemap/mapscales.sh
+++ b/test/psbasemap/mapscales.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Testing that map scales with various labels have reasonable panels behind them
 ps=mapscales.ps
 gmt psbasemap -R-10/10/-15/15 -JM15c -Bafg90 -BWSne+gazure1 -Lg0/14+c14+f+w1000k+l+ar+jTC -F+gcornsilk1+p0.5p,black -P -K -Xc > $ps

--- a/test/pshistogram/varbins.sh
+++ b/test/pshistogram/varbins.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test pshistogram with monthly (variable) bins
 ps=varbins.ps
 gmt set FORMAT_TIME_PRIMARY_MAP Abbrev FORMAT_DATE_MAP "o"

--- a/test/pssolar/shading.sh
+++ b/test/pssolar/shading.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test pssolar with shading
 
 ps=shading.ps

--- a/test/pstext/caption.sh
+++ b/test/pstext/caption.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test gmt pstext paragraph with outline vs outline/fill
 # Making sure issue # 893 is dealt with.
 ps=caption.ps

--- a/test/pstext/delay.sh
+++ b/test/pstext/delay.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test gmt pstext with text clip delay
 
 ps=delay.ps

--- a/test/pstext/escape.sh
+++ b/test/pstext/escape.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Check postscriptlight escape functions
 
 ps=escape.ps

--- a/test/pstext/filled_font.sh
+++ b/test/pstext/filled_font.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test gmt pstext with filled and outline fonts
 
 ps=filled_font.ps

--- a/test/pstext/textclip.sh
+++ b/test/pstext/textclip.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test gmt pstext with text path clipping
 
 ps=textclip.ps

--- a/test/psxy/GSHHS_l_Antarctica.txt
+++ b/test/psxy/GSHHS_l_Antarctica.txt
@@ -1,4 +1,3 @@
-# $Id$
 #
 # GSHHS Master File: Resolution = low Continent = Antarctica
 #

--- a/test/psxy/all_psxy_symbols.txt
+++ b/test/psxy/all_psxy_symbols.txt
@@ -1,4 +1,3 @@
-# $Id$
 # All the basic psxy symbols + two customs to fill the table
 # ALl dimensions hardwired to be in inches
 0.5	0.5	1i	-

--- a/test/psxy/comet.def
+++ b/test/psxy/comet.def
@@ -1,4 +1,3 @@
-# $Id$
 # Macro for comet takes strike (azimuth) and label (string) from input file
 N:	2	as
 # First rotate so strike is horizontal

--- a/test/psxy/condcust_symbol.sh
+++ b/test/psxy/condcust_symbol.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test custom symbol with conditional statements.  From Kristof
 # http://gmt.soest.hawaii.edu/boards/1/topics/7399
 

--- a/test/psxy/condcust_symbol_xy.sh
+++ b/test/psxy/condcust_symbol_xy.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test custom symbol with conditional statements accessing lon, lat or x,y
 
 ps=condcust_symbol_xy.ps

--- a/test/psxy/dip.def
+++ b/test/psxy/dip.def
@@ -1,4 +1,3 @@
-# $Id$
 # Macro for geologic strike/dip takes strike (azimuth) and dip (angle) from input file
 N:	2	ao
 # First rotate so strike is horizontal

--- a/test/psxy/japquakes.sh
+++ b/test/psxy/japquakes.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Plot data reusing a columm
 ps=japquakes.ps
 

--- a/test/psxy/urlquakes.sh
+++ b/test/psxy/urlquakes.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 # Test reading directly from URL
 # Note: The URL tends to change every few years...
 ps=urlquakes.ps

--- a/test/psxy/windbarb.def
+++ b/test/psxy/windbarb.def
@@ -1,4 +1,3 @@
-# $Id$
 # Definition file to make wind barbs used in Meteorology.
 # Created by Time Hume, Australian Bureau of Meteorology
 # [Timothy Hume <T.Hume@bom.gov.au>]

--- a/test/x2sys/x2sys_01.sh
+++ b/test/x2sys/x2sys_01.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #
 # This is original Figure 1 script from
 # Wessel, P. (2010), Tools for analyzing intersecting tracks: the x2sys package,

--- a/test/x2sys/x2sys_02.sh
+++ b/test/x2sys/x2sys_02.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #
 # This is original Figure 2 script from
 # Wessel, P. (2010), Tools for analyzing intersecting tracks: the x2sys package,

--- a/test/x2sys/x2sys_03.sh
+++ b/test/x2sys/x2sys_03.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #
 # This is original Figure 3 script from
 # Wessel, P. (2010), Tools for analyzing intersecting tracks: the x2sys package,

--- a/test/x2sys/x2sys_04.sh
+++ b/test/x2sys/x2sys_04.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #
 # This is original Figure 4 script from
 # Wessel, P. (2010), Tools for analyzing intersecting tracks: the x2sys package,

--- a/test/x2sys/x2sys_05.sh
+++ b/test/x2sys/x2sys_05.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #
 
 ln -fs "${GMT_SRCDIR:-.}"/../mgd77/01010221.mgd77 .

--- a/test/x2sys/x2sys_06.sh
+++ b/test/x2sys/x2sys_06.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #
 # Testing absolute gravity crossovers from c2308 near Oahu.
 

--- a/test/x2sys/x2sys_07.sh
+++ b/test/x2sys/x2sys_07.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# $Id$
 #
 # Testing crossings near a pole.
 


### PR DESCRIPTION
Gets rid of all files with shell comments like

# $Id$

This affects lots of shell scripts but also some data files where #-comments were used to indicate a SVN version number.  I found the files and then ran a in-line sed command to delete the matching lines.
