### PR TITLE
Backport fix to -I- option

### DIFF
--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -448,9 +448,9 @@ int GMT_grdinfo (void *V_API, int mode, void *args) {
 
 		GMT_Report (API, GMT_MSG_VERBOSE, "Processing grid %s\n", G->header->name);
 
-		if (G->header->ProjRefPROJ4 && !Ctrl->C.active && !Ctrl->T.active)
+		if (G->header->ProjRefPROJ4 && !Ctrl->C.active && !Ctrl->T.active && !Ctrl->I.active)
 			projStr = strdup(G->header->ProjRefPROJ4);		/* Copy proj string to print at the end */
-		else if (G->header->ProjRefWKT && !Ctrl->C.active && !Ctrl->T.active) 
+		else if (G->header->ProjRefWKT && !Ctrl->C.active && !Ctrl->T.active && !Ctrl->I.active) 
 			projStr = strdup(G->header->ProjRefWKT);
 
 		for (n = 0; n < GMT_Z; n++) GMT->current.io.col_type[GMT_OUT][n] = GMT->current.io.col_type[GMT_IN][n];	/* Since grids may differ in types */


### PR DESCRIPTION
 Do to not show the WKT info when it exists in a nc grid and -I- is set

