### PR TITLE
Fix the reduce.sh test for grdmath

### DIFF
--- a/test/grdmath/reduce.ps
+++ b/test/grdmath/reduce.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_re913b2a-dirty [64-bit] Document from pstext
+%%Title: GMT v6.0.0_r01f8b1f [64-bit] Document from pstext
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Fri Aug 17 20:12:12 2018
+%%CreationDate: Sun Aug 19 15:19:39 2018
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -686,7 +686,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (43) mc Z
 1575 1575 M (31) mc Z
@@ -760,7 +760,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (96) mc Z
 1575 1575 M (74) mc Z
@@ -834,7 +834,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (77) mc Z
 1575 1575 M (71) mc Z
@@ -908,7 +908,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (72.0) mc Z
 1575 1575 M (58.7) mc Z
@@ -982,7 +982,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (77.0) mc Z
 1575 1575 M (71.0) mc Z
@@ -1056,7 +1056,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (86.5) mc Z
 1575 1575 M (72.5) mc Z
@@ -1130,7 +1130,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (26.9) mc Z
 1575 1575 M (24.0) mc Z
@@ -1204,7 +1204,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (28.2) mc Z
 1575 1575 M (4.4) mc Z
@@ -1278,7 +1278,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (14.1) mc Z
 1575 1575 M (2.2) mc Z
@@ -1352,7 +1352,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (43.0) mc Z
 1575 1575 M (31.0) mc Z
@@ -1426,7 +1426,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (96.0) mc Z
 1575 1575 M (74.0) mc Z
@@ -1500,7 +1500,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (75.3) mc Z
 1575 1575 M (61.9) mc Z
@@ -1574,7 +1574,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (216.0) mc Z
 1575 1575 M (176.0) mc Z
@@ -1648,7 +1648,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (-130.0) mc Z
 1575 1575 M (-114.0) mc Z
@@ -1709,7 +1709,7 @@ O0
 2700 0 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -R0/2/0/2 -JX1.75i -O -K -B0g1 -B+tAND -X2.25i -F+f18p+jCM+z%0.1f
+%@GMT: gmt pstext -R0/2/0/2 -JX1.75i -O -B0g1 -B+tAND -X2.25i -F+f18p+jCM+z%0.1f
 %@PROJ: xy 0.00000000 2.00000000 0.00000000 2.00000000 0.000 2.000 0.000 2.000 +xy
 %%BeginObject PSL_Layer_15
 0 setlinecap
@@ -1722,7 +1722,7 @@ clipsave
 -2100 0 D
 P
 PSL_clip N
-525 1575 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+525 1575 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (43.0) mc Z
 1575 1575 M (31.0) mc Z
@@ -1776,19 +1776,6 @@ N 0 0 M 2100 0 D S
 1050 2100 PSL_H_y add M
 200 F0
 (AND) bc Z
-%%EndObject
-0 A
-FQ
-O0
-0 0 TM
-
-% PostScript produced by:
-%@GMT: gmt psxy -R0/2/0/2 -JX1.75i -O -T
-%@PROJ: xy 0.00000000 2.00000000 0.00000000 2.00000000 0.000 2.000 0.000 2.000 +xy
-%%BeginObject PSL_Layer_16
-0 setlinecap
-0 setlinejoin
-3.32551 setmiterlimit
 %%EndObject
 
 grestore

--- a/test/grdmath/reduce.sh
+++ b/test/grdmath/reduce.sh
@@ -1,12 +1,26 @@
 #!/bin/bash
-# $Id$
+# Test grdmath stacking mode -S for available operators
 ps=reduce.ps
 gmt set PS_MEDIA letter MAP_TITLE_OFFSET 4p FONT_TITLE 12p
 # Create 3 small grids with integers in 0-100 range
-gmt grdmath -R0/2/0/2 -I1 -r 0 100 RAND RINT = 1.grd
-gmt grdmath -R0/2/0/2 -I1 -r 0 100 RAND RINT = 2.grd
-gmt grdmath -R0/2/0/2 -I1 -r 0 100 RAND RINT = 3.grd
-
+cat << EOF | gmt xyz2grd -R0/2/0/2 -I1 -r -Z -G1.grd
+43
+31
+82
+82
+EOF
+cat << EOF | gmt xyz2grd -R0/2/0/2 -I1 -r -Z -G2.grd
+96
+74
+78
+79
+EOF
+cat << EOF | gmt xyz2grd -R0/2/0/2 -I1 -r -Z -G3.grd
+77
+71
+2
+48
+EOF
 # Plot the three grids on top
 gmt grd2xyz 1.grd | gmt pstext -R0/2/0/2 -JX1.75i -P -B0g1 -B+t1 -K -Y8.5i -F+f18p+jCM > $ps
 gmt grd2xyz 2.grd | gmt pstext -R -J -O -K -B0g1 -B+t2 -X2.25i -F+f18p+jCM >> $ps
@@ -38,8 +52,4 @@ gmt grd2xyz tmp.grd | gmt pstext -R -J -O -B0g1 -B+tADD -K -Y-2i -X-4.5i -F+f18p
 gmt grdmath [123].grd -S SUB = tmp.grd
 gmt grd2xyz tmp.grd | gmt pstext -R -J -O -K -B0g1 -B+tSUB -X2.25i -F+f18p+jCM+z%0.1f >> $ps
 gmt grdmath [123].grd -S AND = tmp.grd
-gmt grd2xyz tmp.grd | gmt pstext -R -J -O -K -B0g1 -B+tAND -X2.25i -F+f18p+jCM+z%0.1f >> $ps
-
-gmt psxy -R -J -O -T >> $ps
-gmt psconvert -Tf $ps -P
-open reduce.pdf
+gmt grd2xyz tmp.grd | gmt pstext -R -J -O -B0g1 -B+tAND -X2.25i -F+f18p+jCM+z%0.1f >> $ps


### PR DESCRIPTION
Create input on the fly instead of storing small grids, remove psconvert and open statements, and update the PS file after running the test.
