### PR TITLE
Handle single array item

### DIFF
--- a/doc_classic/rst/source/explain_array.rst_
+++ b/doc_classic/rst/source/explain_array.rst_
@@ -9,7 +9,8 @@ array where *inc* can be 1 (every magnitude), 2, (1, 2, 5 times magnitude) or 3
 (1-9 times magnitude).  For less than every magnitude, use a negative integer *inc*.
 Append **+n** if *inc* is meant to indicate the number of equidistant coordinates
 instead.   Alternatively, give a *file* with output coordinates in the first column,
-or provide a comma-separated *list* of coordinates.
+or provide a comma-separated *list* of coordinates.  If you only want a *single* value
+then you must append a comma to distinguish the list from the setting of *inc*.
 
 If the module allows you to set up an absolute time series, append a valid time unit from the list
 **y**\ ear, m\ **o**\ nth, **w**\ eek, **d**\ ay, **h**\ our, **m**\ inute, and **s**\ econd

--- a/doc_modern/rst/source/explain_array.rst_
+++ b/doc_modern/rst/source/explain_array.rst_
@@ -9,7 +9,8 @@ array where *inc* can be 1 (every magnitude), 2, (1, 2, 5 times magnitude) or 3
 (1-9 times magnitude).  For less than every magnitude, use a negative integer *inc*.
 Append **+n** if *inc* is meant to indicate the number of equidistant coordinates
 instead.   Alternatively, give a *file* with output coordinates in the first column,
-or provide a comma-separated *list* of coordinates.
+or provide a comma-separated *list* of coordinates.  If you only want a *single* value
+then you must append a comma to distinguish the list from the setting of *inc*.
 
 If the module allows you to set up an absolute time series, append a valid time unit from the list
 **y**\ ear, m\ **o**\ nth, **w**\ eek, **d**\ ay, **h**\ our, **m**\ inute, and **s**\ econd

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15615,7 +15615,10 @@ unsigned int gmt_create_array (struct GMT_CTRL *GMT, char option, struct GMT_ARR
 		uint64_t k;
 		unsigned int pos = 0;
 		char p[GMT_LEN64] = {""};
-		for (k = 0, T->n = 1; k < strlen (T->list); k++) if (T->list[k] == ',' && T->list[k+1]) T->n++;	/* Count the commas */
+		for (k = 0, T->n = 1; k < strlen (T->list); k++) {
+			if (T->list[k] == ',' && T->list[k+1])
+				T->n++;	/* Count the commas */
+		}
 		T->array = gmt_M_memory (GMT, NULL, T->n, double);
 		k = 0;
 		while ((gmt_strtok (T->list, ",", &pos, p))) {

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15615,7 +15615,7 @@ unsigned int gmt_create_array (struct GMT_CTRL *GMT, char option, struct GMT_ARR
 		uint64_t k;
 		unsigned int pos = 0;
 		char p[GMT_LEN64] = {""};
-		for (k = 0, T->n = 1; k < strlen (T->list); k++) if (T->list[k] == ',') T->n++;	/* Count the commas */
+		for (k = 0, T->n = 1; k < strlen (T->list); k++) if (T->list[k] == ',' && T->list[k+1]) T->n++;	/* Count the commas */
 		T->array = gmt_M_memory (GMT, NULL, T->n, double);
 		k = 0;
 		while ((gmt_strtok (T->list, ",", &pos, p))) {


### PR DESCRIPTION
In order to give an array list via -T with a single value we must end with a comma, otherwise it is seen as a fixed increment instead. For instance, -T5 means use array increment of 5 while -T5, means "create an array with one element which is 5".  The -T option is used in many modules, such as sample1d.
