### PR TITLE
Simplify synopsis by removing the optional grid parameters.

### DIFF
--- a/doc_classic/rst/source/grdconvert.rst
+++ b/doc_classic/rst/source/grdconvert.rst
@@ -13,8 +13,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**grdconvert** *ingrdfile*\ [=\ *id*\ [**+s**\ *scale*][**+o**\ *offset*][**+n**\ *invalid*]]
-|-G|\ *outgrdfile*\ [=\ *id*\ [**+s**\ *scale*][**+o**\ *offset*][**+n**\ *invalid*]][\ *:driver*\ [*/datatype*]]]
+**gmt grdconvert** *ingrdfile* |-G|\ *outgrdfile*
 [ |-N| ]
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]

--- a/doc_modern/rst/source/grdconvert.rst
+++ b/doc_modern/rst/source/grdconvert.rst
@@ -13,8 +13,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt grdconvert** *ingrdfile*\ [=\ *id*\ [**+s**\ *scale*][**+o**\ *offset*][**+n**\ *invalid*]]
-|-G|\ *outgrdfile*\ [=\ *id*\ [**+s**\ *scale*][**+o**\ *offset*][**+n**\ *invalid*]][\ *:driver*\ [*/datatype*]]]
+**gmt grdconvert** *ingrdfile* |-G|\ *outgrdfile*
 [ |-N| ]
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]


### PR DESCRIPTION
None of the other modules shows them in synopsis.