### PR TITLE
Not give error if -Ns is selected

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -9277,7 +9277,6 @@ void *GMT_FFT_Parse (void *V_API, char option, unsigned int dim, const char *arg
 	}
 	if (info->info_mode == GMT_FFT_LIST) {
 		fft_Singleton_list (API);
-		n_errors++;	/* So parsing fails and stops the program after this listing */
 	}
 	if (n_errors) {
 		gmt_M_free (API->GMT, info);

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -266,6 +266,7 @@ GMT_LOCAL int init_blend_job (struct GMT_CTRL *GMT, char **files, unsigned int n
 	}
 	
 	B = gmt_M_memory (GMT, NULL, n_files, struct GRDBLEND_INFO);
+	wesn[XLO] = wesn[YLO] = DBL_MAX;	wesn[XHI] = wesn[YHI] = -DBL_MAX;
 	
 	for (n = 0; n < n_files; n++) {	/* Process each input grid */
 
@@ -320,14 +321,14 @@ GMT_LOCAL int init_blend_job (struct GMT_CTRL *GMT, char **files, unsigned int n
 			            "Must specify -I if input grids have different increments\n");
 			return (-1);
 		}
-		/* Create the h structure */
+		/* Create the h structure and initialize it */
 		h = gmt_get_header (GMT);
 		gmt_M_memcpy (h->wesn, wesn, 4, double);
 		gmt_M_memcpy (h->inc, B[0].G->header->inc, 2, double);
 		h->registration = B[0].G->header->registration;
 		gmt_M_grd_setpad (GMT, h, GMT->current.io.pad); /* Assign default pad */
 		gmt_set_grddim (GMT, h);	/* Update dimensions */
-		*h_ptr = h;			/* Pass out the settings */
+		*h_ptr = h;			/* Pass out the updated settings */
 	}
 	
 	HH = gmt_get_H_hidden (h);


### PR DESCRIPTION
grdfft should just print the results and exit if that option was selected

Problem was that the GMT_FFT_Parse function would write the results then increment an error counter so the function would fail.  However, with the error it also removed the structure that was allocated and hence grdfft could not take any action and gave more errors.  Now fixed.