### PR TITLE
Delete nonexistent parameters: MAP_GRID_CROSS_PEN

### DIFF
--- a/doc_classic/rst/source/gmt.conf.rst
+++ b/doc_classic/rst/source/gmt.conf.rst
@@ -773,12 +773,6 @@ fonts can be found in the :doc:`gmt` man page.
     Size (>= 0) of grid cross at secondary lon-lat intersections. 0
     means draw continuous gridlines instead [0p].
 
-.. _MAP_GRID_CROSS_PEN:
-
-**MAP_GRID_CROSS_PEN**
-    Sets both **MAP_GRID_CROSS_PEN_PRIMARY** and **MAP_GRID_CROSS_PEN_SECONDARY** to the value specified.
-    This setting is not included in the **gmt.conf** file.
-
 .. _MAP_GRID_PEN_PRIMARY:
 
 **MAP_GRID_PEN_PRIMARY**

--- a/doc_modern/rst/source/gmt.conf.rst
+++ b/doc_modern/rst/source/gmt.conf.rst
@@ -785,12 +785,6 @@ fonts can be found in the :doc:`gmt` man page.
     Size (>= 0) of grid cross at secondary lon-lat intersections. 0
     means draw continuous gridlines instead [0p].
 
-.. _MAP_GRID_CROSS_PEN:
-
-**MAP_GRID_CROSS_PEN**
-    Sets both **MAP_GRID_CROSS_PEN_PRIMARY** and **MAP_GRID_CROSS_PEN_SECONDARY** to the value specified.
-    This setting is not included in the **gmt.conf** file.
-
 .. _MAP_GRID_PEN_PRIMARY:
 
 **MAP_GRID_PEN_PRIMARY**


### PR DESCRIPTION
Parameters `MAP_GRID_CROSS_PEN`, `MAP_GRID_CROSS_PEN_PRIMARY` and `MAP_GRID_CROSS_PEN_SECONDARY` do not exist in the source code.

