### PR TITLE
Add full in/out options to *ingrid* and *outgrid*

### DIFF
--- a/doc_classic/rst/source/grdconvert.rst
+++ b/doc_classic/rst/source/grdconvert.rst
@@ -32,7 +32,7 @@ be written and to specify scaling, translation, and NaN-value.
 Required Arguments
 ------------------
 
-*ingrdfile*
+*ingrdfile* [=id[+sscale][+ooffset][+ninvalid]]
     The grid file to be read. Append format =\ *id* code if not a
     standard COARDS-compliant netCDF grid file. If =\ *id* is set (see
     below), you may optionally append any of **+s**\ *scale*, **+o**\ *offset*,
@@ -49,7 +49,7 @@ Required Arguments
     *id=gd* forces a read via GDAL.
     See Section :ref:`grid-file-format` of the GMT Technical Reference and Cookbook for more information.
 
-**-G**\ *outgrdfile*
+**-G**\ *outgrdfile* [=id[+sscale][+ooffset][+ninvalid]][:driver[/datatype]]]
     The grid file to be written. Append format =\ *id* code if not a
     standard COARDS-compliant netCDF grid file. If =\ *id* is set (see
     below), you may optionally append  any of **+s**\ *scale*, 

--- a/doc_modern/rst/source/grdconvert.rst
+++ b/doc_modern/rst/source/grdconvert.rst
@@ -32,7 +32,7 @@ be written and to specify scaling, translation, and NaN-value.
 Required Arguments
 ------------------
 
-*ingrdfile*
+*ingrdfile* [=id[+sscale][+ooffset][+ninvalid]]
     The grid file to be read. Append format =\ *id* code if not a
     standard COARDS-compliant netCDF grid file. If =\ *id* is set (see
     below), you may optionally append any of **+s**\ *scale*, **+o**\ *offset*,
@@ -49,7 +49,7 @@ Required Arguments
     *id=gd* forces a read via GDAL.
     See Section :ref:`grid-file-format` of the GMT Technical Reference and Cookbook for more information.
 
-**-G**\ *outgrdfile*
+**-G**\ *outgrdfile* [=id[+sscale][+ooffset][+ninvalid]][:driver[/datatype]]]
     The grid file to be written. Append format =\ *id* code if not a
     standard COARDS-compliant netCDF grid file. If =\ *id* is set (see
     below), you may optionally append  any of **+s**\ *scale*, 

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -912,7 +912,7 @@ int GMT_grdimage (void *V_API, int mode, void *args) {
 			if (GMT_Create_Data (API, GMT_IS_IMAGE, GMT_IS_SURFACE, GMT_DATA_ONLY, NULL, NULL, NULL, 0, 0, Img_proj) == NULL)
 				Return (API->error);	/* Failed to allocate memory for the projected image */
 			gmt_img_project (GMT, I, Img_proj, false);	/* Now project the image onto the projected rectangle */
-			if (GMT_Destroy_Data (API, &I) != GMT_NOERROR) {	/* Free the original image now we have projected.  Use Img_proj from now on */
+			if (!API->external && (GMT_Destroy_Data (API, &I) != GMT_NOERROR)) {	/* Free the original image now we have projected.  Use Img_proj from now on */
 				Return (API->error);	/* Failed to free the image */
 			}
 		}


### PR DESCRIPTION
But we have a problem. As it stands ``grdconvert`` says we need to state ``=ID`` in order to access to **+s**scale, etc. But that's not what we have in https://gmt.soest.hawaii.edu/doc/latest/GMT_Docs.html#grid-file-format-specifications where ``=ID``  is optional.