### PR TITLE
Stop doing a "verify_sharedir_version"

### DIFF
--- a/src/common_runpath.c
+++ b/src/common_runpath.c
@@ -29,7 +29,6 @@
  *  GMT_runtime_bindir_win32     Windows implementation
  *  gmt_runtime_libdir           Get the directory that contains the shared libs
  *  gmt_guess_sharedir           Determine GMT_SHAREDIR relative to current runtime location
- *  gmt_verify_sharedir_version  Verifies the correct version of the share directory
  */
 
 /* CMake definitions: This must be first! */
@@ -364,53 +363,5 @@ char *gmt_guess_sharedir (char *sharedir, const char *runtime_bindir) {
 			return NULL;
 	}
 
-#ifdef DEBUG_RUNPATH
-	fprintf (stderr, "guessed share dir '%s'.\n", sharedir);
-#endif
-
-	/* Test if the directory exists and is of correct version */
-	if ( gmt_verify_sharedir_version (sharedir) )
-		/* Return sharedir */
-		return sharedir;
-
-	return NULL;
-}
-
-/* Verifies the correct version of the share directory */
-int gmt_verify_sharedir_version (const char *dir) {
-
-#ifdef NO_SHAREDIR_VERIFY
-	/* For Mirone and probably other future external program call one cannot impose
-	 * a certain sharedir version. */
-	gmt_M_unused(dir);
-	return true;
-#else
-	static char *required_version = GMT_PACKAGE_VERSION_WITH_SVN_REVISION;
-	char version_file[PATH_MAX];
-
-#ifdef DEBUG_RUNPATH
-	fprintf (stderr, "gmt_verify_sharedir_version: got dir '%s'.\n", dir);
-#endif
-
-	/* If the directory exists */
-	if (access (dir, R_OK | X_OK) == 0) {
-		snprintf (version_file, PATH_MAX-1, "%s/VERSION", dir);
-		/* Check correct version */
-		if (gmt_match_string_in_file (version_file, required_version)) {
-#ifdef DEBUG_RUNPATH
-			fprintf (stderr, "gmt_verify_sharedir_version: found '%s' (%s).\n",
-				version_file, required_version);
-#endif
-			return true;
-		}
-		else {
-			/* Special case: accept share dir in source tree.
-			 * Needed when running GMT from build dir. */
-			snprintf (version_file, PATH_MAX-1, "%s/VERSION.in", dir);
-			if (access (version_file, R_OK) == 0)
-				return true;
-		}
-	}
-	return false;
-#endif /* NO_SHAREDIR_VERIFY */
+	return sharedir;
 }

--- a/src/common_runpath.h
+++ b/src/common_runpath.h
@@ -54,7 +54,6 @@ extern "C" {
 
 EXTERN_MSC char *gmt_runtime_libdir (char *result);
 EXTERN_MSC char *gmt_guess_sharedir (char *sharedir, const char *runpath);
-EXTERN_MSC int gmt_verify_sharedir_version (const char *dir);
 
 #ifdef __cplusplus
 }

--- a/src/common_string.c
+++ b/src/common_string.c
@@ -40,7 +40,6 @@
  *  strsepz                 Like strsep but ignores empty fields
  *  stresep                 Like strsep but takes an additional argument esc in order
  *                          to ignore escaped chars (from NetBSD)
- *  gmt_match_string_in_file    Return true if a string is found in file
  *  basename                Extract the base portion of a pathname
  */
 
@@ -622,28 +621,6 @@ char *stresep(char **stringp, const char *delim, int esc) {
 			}
 		} while (sc != 0);
 	}
-}
-
-/* Return true if a string is found in file */
-int gmt_match_string_in_file (const char *filename, const char *string) {
-	FILE *fp;
-	char line[BUF_SIZE] = {""};
-
-	fp = fopen (filename, "r");
-	if (fp == NULL) return false;
-
-	/* search for string in each line */
-	while (fgets (line, BUF_SIZE-1, fp)) {
-		if (strstr (line, string)) {
-			/* line matches */
-			fclose (fp);
-			return true;
-		}
-	}
-
-	/* string not found in file */
-	fclose (fp);
-	return false;
 }
 
 /* $OpenBSD: basename.c,v 1.14 2005/08/08 08:05:33 espie Exp $

--- a/src/common_string.h
+++ b/src/common_string.h
@@ -80,8 +80,6 @@ EXTERN_MSC char *strsepz  (char **stringp, const char *delim, size_t *pos);
 EXTERN_MSC char *strsepzp (char **stringp, const char *delim, size_t *pos);
 EXTERN_MSC char *stresep (char **stringp, const char *delim, int esc);
 
-EXTERN_MSC int gmt_match_string_in_file (const char *filename, const char *string);
-
 #ifndef HAVE_BASENAME
 EXTERN_MSC char *basename(char *path);
 #endif

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -2538,28 +2538,18 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 
 	/* Note: gmtinit_set_env cannot use GMT_Report because the verbose level is not yet set */
 
-	if ((this_c = getenv ("GMT5_SHAREDIR")) != NULL && gmt_verify_sharedir_version (this_c))	/* GMT5_SHAREDIR was set */
+	if ((this_c = getenv ("GMT5_SHAREDIR")) != NULL)	/* GMT5_SHAREDIR was set */
 		GMT->session.SHAREDIR = strdup (this_c);
-	else if ((this_c = getenv ("GMT_SHAREDIR")) != NULL && gmt_verify_sharedir_version (this_c)) /* GMT_SHAREDIR was set */
+	else if ((this_c = getenv ("GMT_SHAREDIR")) != NULL) /* GMT_SHAREDIR was set */
 		GMT->session.SHAREDIR = strdup (this_c);
 #ifdef SUPPORT_EXEC_IN_BINARY_DIR
-	else if ( running_in_bindir_src && gmt_verify_sharedir_version (GMT_SHARE_DIR_DEBUG) )
+	else if (running_in_bindir_src)
 		/* Use ${GMT_SOURCE_DIR}/share to simplify debugging and running in GMT_BINARY_DIR */
 		GMT->session.SHAREDIR = strdup (GMT_SHARE_DIR_DEBUG);
 #endif
-	else if (gmt_verify_sharedir_version (GMT_SHARE_DIR))		/* Found in hardcoded GMT_SHARE_DIR */
-		GMT->session.SHAREDIR = strdup (GMT_SHARE_DIR);
-	else {
-		/* SHAREDIR still not found, make a smart guess based on runpath: */
-		if (gmt_guess_sharedir (path, GMT->init.runtime_bindir))
-			GMT->session.SHAREDIR = strdup (path);
-		else {
-			/* Still not found */
-			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Could not locate share directory that matches the current GMT version %s.\n",
-			         GMT_PACKAGE_VERSION_WITH_SVN_REVISION);
-			GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
-		}
-	}
+	else
+		GMT->session.SHAREDIR = strdup (GMT_SHARE_DIR);		/* Hardcoded GMT_SHARE_DIR */
+
 	gmt_dos_path_fix (GMT->session.SHAREDIR);
 	trim_off_any_slash_at_end (GMT->session.SHAREDIR);
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "GMT->session.SHAREDIR = %s\n", GMT->session.SHAREDIR);


### PR DESCRIPTION
Since we hard-coded most of the postscript stuff we don't need this check anymore, which can even be harmfull on Win if no /DNO_SHAREDIR_VERIFY is used and only the gmt dll is updated.
