### PR TITLE
Supress warnings on Windows

### DIFF
--- a/src/gmt_dev.h
+++ b/src/gmt_dev.h
@@ -77,6 +77,11 @@ extern "C" {
 #endif
 #endif
 
+#ifdef _MSC_VER
+#	pragma warning( disable : 4091 )	/* 'static ': ignored on left of 'XXX' when no variable is declared */
+#	pragma warning( disable : 4244 )	/* conversion from 'uint64_t' to '::size_t', possible loss of data */
+#endif
+
 /* Used to restrict the scope of a function to the file it was declared in */
 #define GMT_LOCAL static
 


### PR DESCRIPTION
When I build the Win 32 bits version I get tons of warnings ``conversion from 'uint64_t' to '::size_t', possible loss of data``. This PR shuts it down, but the question is: should we replace the 'uint64_t' by '::size_t', or are there instances where we don't want that?