### PR TITLE
The -W+c had issues

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -6419,9 +6419,13 @@ bool gmt_getpen (struct GMT_CTRL *GMT, char *buffer, struct GMT_PEN *P) {
 			switch (p[0]) {
 				case 'c':	/* Effect of CPT on lines and fills */
 					switch (p[1]) {
-						case 'l': P->cptmode = 1; break;
-						case 'f': P->cptmode = 2; break;
-						default:  P->cptmode = 3; break;
+						case 'l':   P->cptmode = 1; break;
+						case 'f':   P->cptmode = 2; break;
+						case '\0':  P->cptmode = 3; break;
+						default: 
+							GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error parsing pen modification +%s\n", p);
+							return false;
+						break;
 					}
 					break;
 				case 's':


### PR DESCRIPTION
When -Zz from a header was parsed then -W+c settings where ignored.

Andreas posted an example on the old Issues case.  The problem was that parsing of -Zz and assignment to a fill color via a CPT partially worked: Without also giving -L it would not fill a polygon even though -W+c was in effect.  Adding -L would give the fill but now the pen was not set...
Now, when -W...+c is given it will handle this correctly.