### PR TITLE
Revert to old shorten path

### DIFF
--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -104,8 +104,6 @@
  *
  */
 
-#define OLD_shorten_path	/* Until bug in psl_shorten_path is fixed */
-
 /*--------------------------------------------------------------------
  *			SYSTEM HEADER FILES
  *--------------------------------------------------------------------*/
@@ -702,7 +700,7 @@ static int psl_shorten_path (struct PSL_CTRL *PSL, double *x, double *y, int n, 
 	   "close" is defined as less than 1 "dot" (the PostScript resolution) in either direction.
 	   A point is always close when it coincides with one of the end points (i or j).
 	   An intermediate point is also considered "far" when it is beyond i or j.
-	   Algorithm requires that |dx by - bx dy| < max(|dx|,dy|).
+	   Algorithm requires that |dx by - bx dy| >= max(|dx|,|dy|) for points to be "far".
 	*/
 	for (i = k = 0, j = 2; j < n; j++) {
 		dx = ix[j] - ix[i];
@@ -721,6 +719,15 @@ static int psl_shorten_path (struct PSL_CTRL *PSL, double *x, double *y, int n, 
 				if (bx > 0 || bx < dx) break;
 			}
 			by = iy[ij] - iy[i];
+			/* Check if the intermediate point is outside the y-range between points i and j.
+			   In case of a horizontal line, any point with a different y-coordinate is "far" */
+			if (dy > 0) {
+				if (by < 0 || by > dy) break;
+			}
+			else {
+				if (by > 0 || bx < dy) break;
+			}
+			/* Generic case where the intermediate point is within the x- and y-range */
 			db = abs((int)(dx * by) - (int)(bx * dy));
 			if (db >= d) break; /* Point ij is "far" from line connecting i and j */
 		}

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -104,6 +104,8 @@
  *
  */
 
+#define OLD_shorten_path	/* Until bug in psl_shorten_path is fixed */
+
 /*--------------------------------------------------------------------
  *			SYSTEM HEADER FILES
  *--------------------------------------------------------------------*/
@@ -652,7 +654,7 @@ static int psl_shorten_path (struct PSL_CTRL *PSL, double *x, double *y, int n, 
 	int i, k, dx, dy;
 #ifdef OLD_shorten_path
 	int old_dir = 0, new_dir;
-	double old_slope = 1.0e200, new_slope;
+	double old_slope = -DBL_MAX, new_slope;
 	/* These seeds for old_slope and old_dir make sure that first point gets saved */
 #else
 	int d, db, bx, by, j, ij;
@@ -675,7 +677,7 @@ static int psl_shorten_path (struct PSL_CTRL *PSL, double *x, double *y, int n, 
 		dx = ix[i+1] - ix[i];
 		dy = iy[i+1] - iy[i];
 		if (dx == 0 && dy == 0) continue;	/* Skip duplicates */
-		new_slope = (dx == 0) ? copysign (1.0e100, (double)dy) : ((double)dy) / ((double)dx);
+		new_slope = (dx == 0) ? copysign (DBL_MAX, (double)dy) : ((double)dy) / ((double)dx);
 		new_dir = (dx >= 0) ? 1 : -1;
 		if (new_slope != old_slope || new_dir != old_dir) {
 			ix[k] = ix[i];


### PR DESCRIPTION
The psl_shorten_path function has a bug so I am reverting to the old algorithm while we work on a solution.

**The problem**

given this file (t.txt) with content

0.1486E+03 0.1429E-04
0.1486E+03 0.3521E-04
0.1486E+03 0.3167E-04
0.1486E+03 0.2029E-04
0.1404E+03 0.5148E-05

the following command

gmt psxy -JX15/10.6l -R140/150/4.285e-06/0.0045  t.txt > gmt5.ps

simplifies the path to the point that the critical 2nd point is excluded.

Until we can fix the problem I have added "#define OLD_shorten_path" to postscriptlight.c so that we rely on the older (slightly slower but correct) line simplification algorithm.