### PR TITLE
standardize the local usage functions

### DIFF
--- a/src/mgd77/mgd77track.c
+++ b/src/mgd77/mgd77track.c
@@ -150,9 +150,20 @@ GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct MGD77TRACK_CTRL *C) {	/* 
 	gmt_M_free (GMT, C);	
 }
 
-GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level, struct MGD77TRACK_CTRL *Ctrl) {
+GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
+	char day_marker_size[8], dist_marker_size[8];
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
+	
+	if (API->GMT->current.setting.proj_length_unit == GMT_CM) {
+		strcpy (day_marker_size, "0.1c");	/* 1 mm */
+		strcpy (dist_marker_size, "0.15c");	/* 1.5 mm */
+	}
+	else {	/* Assume we think in inches */
+		strcpy (day_marker_size, "0.04i");
+		strcpy (dist_marker_size, "0.06i");
+	}
+	
 	GMT_Message (API, GMT_TIME_NONE, "usage: gmt %s cruise(s) %s %s\n\t[-A[c][<size>]][,<inc><unit>] [%s] ", name, GMT_Rgeo_OPT, GMT_J_OPT, GMT_B_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "[-Cf|g|e] [-Da<startdate>] [-Db<stopdate>] [-F]\n\t[-Gt|d|n<gap>] [-I<code>] %s[-L<trackticks>] [-N] %s%s[-Sa<startdist>[<unit>]]\n", GMT_K_OPT, GMT_O_OPT, GMT_P_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-Sb<stopdist>[<unit>]] [-TT|t|d<ms,mc,mfs,mf,mfc>] [%s]\n\t[%s] [-W<pen>] [%s] [%s]\n",
@@ -192,17 +203,17 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level, struct MGD77TRACK_CTRL 
 	GMT_Message (API, GMT_TIME_NONE, "\t   day marker, and d for distance marker.  Then, append 5 comma-separated items:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   <markersize>[unit],<markercolor>,<markerfontsize,<markerfont>,<markerfontcolor>\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Default settings for the three marker types are:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     -TT%g,black,%g,%d,black\n",
-	             Ctrl->T.marker[MGD77TRACK_MARK_NEWDAY].marker_size, Ctrl->T.marker[MGD77TRACK_MARK_NEWDAY].font.size,
-	             Ctrl->T.marker[MGD77TRACK_MARK_NEWDAY].font.id);
-	GMT_Message (API, GMT_TIME_NONE, "\t     -Tt%g,white,%g,%d,black\n",
-	             Ctrl->T.marker[MGD77TRACK_MARK_SAMEDAY].marker_size, Ctrl->T.marker[MGD77TRACK_MARK_SAMEDAY].font.size,
-	             Ctrl->T.marker[MGD77TRACK_MARK_SAMEDAY].font.id);
-	GMT_Message (API, GMT_TIME_NONE, "\t     -Td%g,black,%g,%d,black\n",
-	             Ctrl->T.marker[MGD77TRACK_MARK_DIST].marker_size, Ctrl->T.marker[MGD77TRACK_MARK_DIST].font.size,
-	             Ctrl->T.marker[MGD77TRACK_MARK_DIST].font.id);
+	GMT_Message (API, GMT_TIME_NONE, "\t     -TT%s,black,%g,%d,black\n",
+	             day_marker_size, API->GMT->current.setting.font_annot[GMT_PRIMARY].size,
+	             API->GMT->current.setting.font_annot[GMT_PRIMARY].id);
+	GMT_Message (API, GMT_TIME_NONE, "\t     -Tt%s,white,%g,%d,black\n",
+	             day_marker_size, API->GMT->current.setting.font_annot[GMT_PRIMARY].size,
+	             API->GMT->current.setting.font_annot[GMT_PRIMARY].id);
+	GMT_Message (API, GMT_TIME_NONE, "\t     -Td%s,black,%g,%d,black\n",
+	             dist_marker_size, API->GMT->current.setting.font_annot[GMT_PRIMARY].size,
+	             API->GMT->current.setting.font_annot[GMT_PRIMARY].id);
 	GMT_Option (API, "U,V");
-	GMT_Message (API, GMT_TIME_NONE, "\t-W Set track pen attributes [%s].\n", gmt_putpen (API->GMT, &Ctrl->W.pen));
+	GMT_Message (API, GMT_TIME_NONE, "\t-W Set track pen attributes [%s].\n", gmt_putpen (API->GMT, &API->GMT->current.setting.map_default_pen));
 	GMT_Option (API, "X,p,t,.");
 	
 	return (GMT_MODULE_USAGE);
@@ -586,13 +597,13 @@ int GMT_mgd77track (void *V_API, int mode, void *args) {
 	/*----------------------- Standard module initialization and parsing ----------------------*/
 
 	if (API == NULL) return (GMT_NOT_A_SESSION);
-	if (mode == GMT_MODULE_PURPOSE) return (usage (API, GMT_MODULE_PURPOSE, NULL));	/* Return the purpose of program */
+	if (mode == GMT_MODULE_PURPOSE) return (usage (API, GMT_MODULE_PURPOSE));	/* Return the purpose of program */
 	options = GMT_Create_Options (API, mode, args);	if (API->error) return (API->error);	/* Set or get option list */
 
 	if ((GMT = gmt_init_module (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_KEYS, THIS_MODULE_NEEDS, &options, &GMT_cpy)) == NULL) bailout (API->error); /* Save current state */
 	Ctrl = New_Ctrl (GMT);	/* Allocate and initialize a new control structure */
-	if (!options || options->option == GMT_OPT_USAGE) Return (usage (API, GMT_USAGE, Ctrl));	/* Return the usage message */
-	if (options->option == GMT_OPT_SYNOPSIS) Return (usage (API, GMT_SYNOPSIS, Ctrl));	/* Return the synopsis */
+	if (!options || options->option == GMT_OPT_USAGE) Return (usage (API, GMT_USAGE));	/* Return the usage message */
+	if (options->option == GMT_OPT_SYNOPSIS) Return (usage (API, GMT_SYNOPSIS));	/* Return the synopsis */
 
 	/* Parse the command-line arguments */
 

--- a/src/pstext.c
+++ b/src/pstext.c
@@ -39,6 +39,8 @@ EXTERN_MSC void gmtlib_enforce_rgb_triplets (struct GMT_CTRL *GMT, char *text, u
 #define PSTEXT_CLIPPLOT		1
 #define PSTEXT_CLIPONLY		2
 
+#define PSTEXT_SHOW_FONTS	128
+
 #define GET_REC_TEXT	0	/* Free-form text as trailing text in the record */
 #define GET_SEG_LABEL	1	/* Use the curent segment label (-L<label>) as the text */
 #define GET_SEG_HEADER	2	/* Use the curent segment header as the text */
@@ -266,10 +268,12 @@ GMT_LOCAL int get_input_format_version (struct GMT_CTRL *GMT, char *buffer, int 
 	return (4);
 }
 
-GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level, int show_fonts) {
+GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	/* This displays the pstext synopsis and optionally full usage information */
+	bool show_fonts = false;
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
+	if (level & PSTEXT_SHOW_FONTS) show_fonts = true, level -= PSTEXT_SHOW_FONTS;	/* Deal with the special bitflag for showing the fonts */
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: gmt %s [<table>] %s %s [-A] [%s]\n", name, GMT_J_OPT, GMT_Rgeoz_OPT, GMT_B_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-C<dx>/<dy>] [-D[j|J]<dx>[/<dy>][+v[<pen>]]\n");
@@ -709,16 +713,16 @@ int GMT_pstext (void *V_API, int mode, void *args) {
 	/*----------------------- Standard module initialization and parsing ----------------------*/
 
 	if (API == NULL) return (GMT_NOT_A_SESSION);
-	if (mode == GMT_MODULE_PURPOSE) return (usage (API, GMT_MODULE_PURPOSE, false));	/* Return the purpose of program */
+	if (mode == GMT_MODULE_PURPOSE) return (usage (API, GMT_MODULE_PURPOSE));	/* Return the purpose of program */
 	options = GMT_Create_Options (API, mode, args);	if (API->error) return (API->error);	/* Set or get option list */
 
 	if (API->GMT->current.setting.run_mode == GMT_CLASSIC) {	/* Classic requires options, while modern does not */
-		if (!options || options->option == GMT_OPT_USAGE) bailout (usage (API, GMT_USAGE, false));	/* Return the usage message */
-		if (options->option == GMT_OPT_SYNOPSIS) bailout (usage (API, GMT_SYNOPSIS, false));	/* Return the synopsis */
+		if (!options || options->option == GMT_OPT_USAGE) bailout (usage (API, GMT_USAGE));	/* Return the usage message */
+		if (options->option == GMT_OPT_SYNOPSIS) bailout (usage (API, GMT_SYNOPSIS));	/* Return the synopsis */
 	}
 	else {
-		if (options && options->option == GMT_OPT_USAGE) bailout (usage (API, GMT_USAGE, false));	/* Return the usage message */
-		if (options && options->option == GMT_OPT_SYNOPSIS) bailout (usage (API, GMT_SYNOPSIS, false));	/* Return the synopsis */
+		if (options && options->option == GMT_OPT_USAGE) bailout (usage (API, GMT_USAGE));	/* Return the usage message */
+		if (options && options->option == GMT_OPT_SYNOPSIS) bailout (usage (API, GMT_SYNOPSIS));	/* Return the synopsis */
 	}
 
 	/* Parse the command-line arguments; return if errors are encountered */
@@ -727,7 +731,7 @@ int GMT_pstext (void *V_API, int mode, void *args) {
 	if (GMT_Parse_Common (API, THIS_MODULE_OPTIONS, options)) Return (API->error);
 	Ctrl = New_Ctrl (GMT);	/* Allocate and initialize a new control structure */
 	if ((error = parse (GMT, Ctrl, options)) != 0) Return (error);
-	if (Ctrl->L.active) Return (usage (API, GMT_SYNOPSIS, true));	/* Return the synopsis with font listing */
+	if (Ctrl->L.active) Return (usage (API, GMT_SYNOPSIS | PSTEXT_SHOW_FONTS));	/* Return the synopsis with font listing */
 
 	/*---------------------------- This is the pstext main code ----------------------------*/
 


### PR DESCRIPTION
All modules define a local function call usage () that reports the module usage.  It normally takes the API pointer and a mode argument.  However, a few took an arbitrary 3rd argument as well.  My plan is to introduce a new function that will accept the usage function as an argument and do the right things depending on modern or classic mode, hence all usage functions needed to have the same number of arguments.  This change to pstext and mgd77track. accomplishes that.