### PR TITLE
Handle the +s modifier in input

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1123,6 +1123,10 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 					else if (S.v.status & PSL_VEC_FILL) {
 						current_fill = default_fill, Ctrl->G.active = true;	/* Return to default fill */
 					}
+					if (S.v.status & PSL_VEC_JUST_S) {	/* Got coordinates of tip instead of dir/length so need to undo dimension scaling */
+						in[pos2x] *= GMT->session.u2u[GMT_INCH][GMT->current.setting.proj_length_unit];
+						in[pos2y] *= GMT->session.u2u[GMT_INCH][GMT->current.setting.proj_length_unit];
+					}
 				}
 				else if (S.symbol == PSL_DOT && !Ctrl->G.active)	/* Must switch on default black fill */
 					current_fill = black;

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -844,6 +844,10 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 					else if (S.v.status & PSL_VEC_FILL) {
 						current_fill = default_fill, Ctrl->G.active = true;	/* Return to default fill */
 					}
+					if (S.v.status & PSL_VEC_JUST_S) {	/* Got coordinates of tip instead of dir/length so need to undo dimension scaling */
+						in[pos2x] *= GMT->session.u2u[GMT_INCH][GMT->current.setting.proj_length_unit];
+						in[pos2y] *= GMT->session.u2u[GMT_INCH][GMT->current.setting.proj_length_unit];
+					}
 				}
 				else if (S.symbol == PSL_DOT && !Ctrl->G.active) {	/* Must switch on default black fill */
 					current_fill = black;


### PR DESCRIPTION
WHen symbol code is given via trailing text and +s is used then we need to undo any dimension scaling to recover the original coordinates.


Fixes #66.


