### PR TITLE
pre and post flight system calls assumed things about PATH

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -1098,7 +1098,8 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		}
 #endif
 		/* Run the pre-flight now which may or may not create a <timefile> needed later via -T, as well as a background plot */
-		if ((error = system (pre_file))) {
+		sprintf (cmd, "%s %s", sc_call[Ctrl->In.mode], pre_file);
+		if ((error = system (cmd))) {
 			GMT_Report (API, GMT_MSG_NORMAL, "Running preflight script %s returned error %d - exiting.\n", pre_file, error);
 			fclose (Ctrl->In.fp);
 			Return (GMT_RUNTIME_ERROR);
@@ -1181,7 +1182,8 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		}
 #endif
 		/* Run post-flight now before dealing with the loop so the overlay exists */
-		if ((error = run_script (post_file))) {
+		sprintf (cmd, "%s %s", sc_call[Ctrl->In.mode], post_file);
+		if ((error = run_script (cmd))) {
 			GMT_Report (API, GMT_MSG_NORMAL, "Running postflight script %s returned error %d - exiting.\n", post_file, error);
 			fclose (Ctrl->In.fp);
 			Return (GMT_RUNTIME_ERROR);

--- a/src/movie.c
+++ b/src/movie.c
@@ -1420,7 +1420,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			Return (GMT_RUNTIME_ERROR);
 		}
 #endif
-		sprintf (cmd, "%s %*.*d", master_file, precision, precision, Ctrl->M.frame);
+		sprintf (cmd, "%s %s %*.*d", sc_call[Ctrl->In.mode], master_file, precision, precision, Ctrl->M.frame);
 		if ((error = run_script (cmd))) {
 			GMT_Report (API, GMT_MSG_NORMAL, "Running script %s returned error %d - exiting.\n", cmd, error);
 			fclose (Ctrl->In.fp);


### PR DESCRIPTION
Must use sc_call as in the other system calls to use bash, csh or start to execute the script and not rely on PATH containing the current directory.

Fixes #83
