### PR TITLE
Forgot string.h include

### DIFF
--- a/src/testgmtshell.c
+++ b/src/testgmtshell.c
@@ -24,6 +24,7 @@
  */
 
 #include "gmt.h"
+#include <string.h>
 
 int main () {
 


### PR DESCRIPTION
Uses strncpy so string.h is required


testgmtshell.c is a test program used by developers to simulate a shell script via a single GMT session; it is not part of the GMT distro.