### PR TITLE
My fix for -A was a red herring

### DIFF
--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -980,7 +980,7 @@ int GMT_grdcontour (void *V_API, int mode, void *args) {
 	
 		char cmd1[GMT_LEN512] = {""}, cmd2[GMT_LEN512] = {""}, string[GMT_LEN128] = {""}, cptfile[PATH_MAX] = {""};
 		struct GMT_OPTION *opt = NULL;
-		bool got_cpt = (optN->arg[0]), is_continuous, got_A = false, got_C_cpt = false;
+		bool got_cpt = (optN->arg[0]), is_continuous, got_C_cpt = false;
 		size_t L;
 		
 		/* Make sure we dont pass options not compatible with -N */
@@ -1005,7 +1005,6 @@ int GMT_grdcontour (void *V_API, int mode, void *args) {
 			sprintf (string, " -%c%s", opt->option, opt->arg);
 			switch (opt->option) {
 				case 'A' : case 'D': case 'F': case 'G': case 'K': case 'L': case 'Q': case 'T': case 'U': case 'W': case 'Z':	/* Only for grdcontour */
-					if (opt->option == 'A') got_A = true;
 					strcat (cmd2, string); break;
 				case 'B':	/* Must worry about spaces*/
 					if (strchr (opt->arg, ' ') || strchr (opt->arg, '\t')) {	/* Must place all string arguments in quotes */
@@ -1067,7 +1066,7 @@ int GMT_grdcontour (void *V_API, int mode, void *args) {
 		/* Required options for grdview */
 		strcat (cmd1, " -Qs");
 		if (API->GMT->current.setting.run_mode == GMT_CLASSIC) strcat (cmd1, " -K");
-		if (got_A && !got_C_cpt) {	/* Must pass -N<cpt> via -C since no -C was given yet -A was set */
+		if (!got_C_cpt) {	/* Must pass -N<cpt> via -C since no -C was given */
 			strcat (cmd1, " -C");
 			strcat (cmd1, optN->arg);
 		}


### PR DESCRIPTION
The real issues was just what happened with -C.

Fixes #90

There really are just these scenarios when -N is given:
1) -N is given without a cpt.  Then -C<cpt> must be given, otherwise there is no CPT
2) -N<cpt> is given.  Then we are these cases:
   a) No -C and no -A:  Pass -C<cpt> to select the contours
   b) No -C but -A: No difference, still need -C<cpt> and pass -A as well
   c) Got -C<cpt or #>: Pass that -C to grdcontour.