### PR TITLE
Add undocumented option to write a multi-segment as single segment fi…

### DIFF
--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -108,6 +108,7 @@ struct PSCOAST_CTRL {
 	} L;
 	struct M {	/* -M */
 		bool active;
+		bool single;
 	} M;
 	struct N {	/* -N<feature>[/<pen>] */
 		bool active;
@@ -414,6 +415,8 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOAST_CTRL *Ctrl, struct GMT
 				}
 			case 'M':
 				Ctrl->M.active = true;
+				if (opt->arg[0] == 's') 	/* Write a single segment. Afects only external interfaces. */
+					Ctrl->M.single = true;
 				break;
 			case 'N':
 				Ctrl->N.active = true;
@@ -816,7 +819,10 @@ int GMT_pscoast (void *V_API, int mode, void *args) {
 		gmt_set_geographic (GMT, GMT_OUT);	/* Output lon/lat */
 		if (Ctrl->N.active) id = 1;
 		else if (Ctrl->I.active) id = 2;
-		gmt_set_segmentheader (GMT, GMT_OUT, true);	/* Turn on segment headers on output */
+		
+		if (!Ctrl->M.single)
+			gmt_set_segmentheader (GMT, GMT_OUT, true);	/* Turn on segment headers on output */
+
 		if ((error = GMT_Set_Columns (API, GMT_OUT, 2, GMT_COL_FIX_NO_TEXT)) != GMT_NOERROR) {
 			Return (error);
 		}
@@ -1069,8 +1075,14 @@ int GMT_pscoast (void *V_API, int mode, void *args) {
 
 			for (i = 0; i < np; i++) {
 				if (Ctrl->M.active) {
-					sprintf (GMT->current.io.segment_header, "Shore Bin # %d, Level %d", bin, p[i].level);
-					GMT_Put_Record (API, GMT_WRITE_SEGMENT_HEADER, NULL);
+					if (!Ctrl->M.single) {
+						sprintf (GMT->current.io.segment_header, "Shore Bin # %d, Level %d", bin, p[i].level);
+						GMT_Put_Record (API, GMT_WRITE_SEGMENT_HEADER, NULL);
+					}
+					else {
+						out[GMT_X] = out[GMT_Y] = GMT->session.d_NaN;
+						GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+					}
 					for (k = 0; k < p[i].n; k++) {
 						out[GMT_X] = p[i].lon[k];
 						out[GMT_Y] = p[i].lat[k];
@@ -1104,7 +1116,8 @@ int GMT_pscoast (void *V_API, int mode, void *args) {
 		GMT->current.map.coastline = false;
 	}
 	
-	if (Ctrl->E.info.mode > GMT_DCW_REGION) (void)gmt_DCW_operation (GMT, &Ctrl->E.info, NULL, Ctrl->M.active ? GMT_DCW_DUMP : GMT_DCW_PLOT);
+	if (Ctrl->E.info.mode > GMT_DCW_REGION)
+		(void)gmt_DCW_operation (GMT, &Ctrl->E.info, NULL, Ctrl->M.active ? GMT_DCW_DUMP : GMT_DCW_PLOT);
 
 	if (clipping) PSL_beginclipping (PSL, xtmp, ytmp, 0, GMT->session.no_rgb, 2);	/* End clippath */
 
@@ -1133,8 +1146,14 @@ int GMT_pscoast (void *V_API, int mode, void *args) {
 
 			for (i = 0; i < np; i++) {
 				if (Ctrl->M.active) {
-					sprintf (GMT->current.io.segment_header, "River Bin # %d, Level %d", bin, p[i].level);
-					GMT_Put_Record (API, GMT_WRITE_SEGMENT_HEADER, NULL);
+					if (!Ctrl->M.single) {
+						sprintf (GMT->current.io.segment_header, "River Bin # %d, Level %d", bin, p[i].level);
+						GMT_Put_Record (API, GMT_WRITE_SEGMENT_HEADER, NULL);
+					}
+					else {
+						out[GMT_X] = out[GMT_Y] = GMT->session.d_NaN;
+						GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+					}
 					for (k = 0; k < p[i].n; k++) {
 						out[GMT_X] = p[i].lon[k];
 						out[GMT_Y] = p[i].lat[k];
@@ -1194,8 +1213,14 @@ int GMT_pscoast (void *V_API, int mode, void *args) {
 
 			for (i = 0; i < np; i++) {
 				if (Ctrl->M.active) {
-					sprintf (GMT->current.io.segment_header, "Border Bin # %d, Level %d", bin, p[i].level);
-					GMT_Put_Record (API, GMT_WRITE_SEGMENT_HEADER, NULL);
+					if (!Ctrl->M.single) {
+						sprintf (GMT->current.io.segment_header, "Border Bin # %d, Level %d", bin, p[i].level);
+						GMT_Put_Record (API, GMT_WRITE_SEGMENT_HEADER, NULL);
+					}
+					else {
+						out[GMT_X] = out[GMT_Y] = GMT->session.d_NaN;
+						GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+					}
 					for (k = 0; k < p[i].n; k++) {
 						out[GMT_X] = p[i].lon[k];
 						out[GMT_Y] = p[i].lat[k];


### PR DESCRIPTION
This new **-Ms** option makes almost no difference for command line but has a radical effect when called from external interfaces. From the MEX and Julia interfaces a multi-segment file is a struct array with each element carrying a segment. Plotting this in Matlab is annoying so we added the function ``catseg`` to the ``gmt.m`` helper file to join all segments in a multi-segment struct array. This PR just avoids this step and saves also from having to duplicate the dataset.

Ideally this should be done at a more basic level and so be available to all multi-segment producing modules.