### PR TITLE
Add a CITATION file

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -1,0 +1,25 @@
+# Citing GMT
+
+If you think it is appropriate, you may consider paying us back by including
+our latest EOS article in the reference list of your future publications that 
+will benefit from the availability of GMT:
+
+> Wessel, P., W. H. F. Smith, R. Scharroo, J. F. Luis, and F. Wobbe (2013), 
+> Generic Mapping Tools: Improved version released, Eos Trans. AGU, 94(45), 
+> 409-410, doi:[10.1002/2013EO450001](https://doi.org/10.1002/2013EO450001)
+
+Here is a Bibtex entry for LaTeX users:
+
+```
+@article{wesseletal2013,
+  title = {Generic {{Mapping Tools}}: {{Improved Version Released}}},
+  author = {Wessel, Paul and Smith, Walter H. F. and Scharroo, Remko and Luis, Joaquim and Wobbe, Florian},
+  year = {2013},
+  journal = {Eos, Transactions American Geophysical Union},
+  volume = {94},
+  number = {45},
+  pages = {409-410},
+  issn = {2324-9250},
+  doi = {10.1002/2013EO450001},
+}
+```


### PR DESCRIPTION
**Description of proposed changes**

The Software Sustainability Institute proposes CITATION files as a standard way of informing users how you want to be cited:
https://www.software.ac.uk/blog/2016-10-06-encouraging-citation-software-introducing-citation-files

This adds such a file and included a Bibtex entry to make it easier for Latex users.