### PR TITLE
Promote a function from library to module use

### DIFF
--- a/src/gmt_gdalread.c
+++ b/src/gmt_gdalread.c
@@ -1185,11 +1185,11 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 					else if (copy_flipud) {
 						/* We could copy and flip but the idea here is also to not use a tmp array too */
 						memcpy (&Ctrl->UInt8.data[i_x_nXYSize], tmp, (size_t)nBufYSize * (size_t)nBufXSize);
-						gmtlib_grd_flip_vertical (&Ctrl->UInt8.data[i_x_nXYSize], (unsigned)nX, (unsigned)nY, 0, 1);
+						gmt_grd_flip_vertical (&Ctrl->UInt8.data[i_x_nXYSize], (unsigned)nX, (unsigned)nY, 0, 1);
 					}
 #else
 					if (copy_flipud)
-						gmtlib_grd_flip_vertical (&Ctrl->UInt8.data[i_x_nXYSize], (unsigned)nX, (unsigned)nY, 0, 1);
+						gmt_grd_flip_vertical (&Ctrl->UInt8.data[i_x_nXYSize], (unsigned)nX, (unsigned)nY, 0, 1);
 #endif
 					else if (fliplr) {				/* No BIP option yet, and maybe never */
 						for (m = row_i; m < row_e; m++) {

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -74,7 +74,7 @@
  *  gmt_decode_grd_h_info   : Decodes a -Dstring into header text components
  *  gmt_grd_RI_verify       : Test to see if region and incs are compatible
  *  gmt_scale_and_offset_f  : Routine that scales and offsets the data in a vector
- *  gmtlib_grd_flip_vertical  : Flips the grid in vertical direction
+ *  gmt_grd_flip_vertical  : Flips the grid in vertical direction
  *  grdio_pack_grid         : Packs or unpacks a grid by calling gmt_scale_and_offset_f()
  *
  *  Reading images via GDAL (if enabled):
@@ -3014,7 +3014,7 @@ bool gmtlib_init_complex (struct GMT_GRID_HEADER *header, unsigned int complex_m
 }
 
 /* Reverses the grid vertically, that is, from north up to south up or vice versa. */
-void gmtlib_grd_flip_vertical (void *gridp, const unsigned n_cols32, const unsigned n_rows32, const unsigned n_stride32, size_t cell_size) {
+void gmt_grd_flip_vertical (void *gridp, const unsigned n_cols32, const unsigned n_rows32, const unsigned n_stride32, size_t cell_size) {
 	/* Note: when grid is complex, pass 2x n_rows */
 	size_t row, n_cols = n_cols32, n_rows = n_rows32;
 	size_t rows_over_2 = (size_t) floor (n_rows / 2.0);

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -173,7 +173,6 @@ EXTERN_MSC struct GMT_POSTSCRIPT * gmtlib_read_ps (struct GMT_CTRL *GMT, void *s
 EXTERN_MSC int gmtlib_write_ps (struct GMT_CTRL *GMT, void *dest, unsigned int dest_type, unsigned int mode, struct GMT_POSTSCRIPT *P);
 EXTERN_MSC void gmtlib_copy_ps (struct GMT_CTRL *GMT, struct GMT_POSTSCRIPT *P_copy, struct GMT_POSTSCRIPT *P_obj);
 EXTERN_MSC void gmtlib_inplace_transpose (gmt_grdfloat *A, unsigned int n_rows, unsigned int n_cols);
-EXTERN_MSC void gmtlib_grd_flip_vertical (void *gridp, const unsigned n_cols, const unsigned n_rows, const unsigned n_stride, size_t cell_size);
 EXTERN_MSC void gmtlib_free_dataset_ptr (struct GMT_CTRL *GMT, struct GMT_DATASET *data);
 EXTERN_MSC void gmtlib_free_cpt_ptr (struct GMT_CTRL *GMT, struct GMT_PALETTE *P);
 EXTERN_MSC void gmtlib_free_ps_ptr (struct GMT_CTRL *GMT, struct GMT_POSTSCRIPT *P);

--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -1554,7 +1554,7 @@ int gmt_nc_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_g
 
 	/* Flip grid upside down */
 	if (HH->row_order == k_nc_start_south)
-		gmtlib_grd_flip_vertical (pgrid + HH->data_offset, width, height, HH->stride, sizeof(grid[0]));
+		gmt_grd_flip_vertical (pgrid + HH->data_offset, width, height, HH->stride, sizeof(grid[0]));
 
 	/* Add padding with border replication */
 	gmtnc_pad_grid (pgrid, width, height, pad, sizeof(grid[0]), k_pad_fill_zero);
@@ -1661,7 +1661,7 @@ int gmt_nc_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_
 
 	/* Flip grid upside down */
 	if (HH->row_order == k_nc_start_south)
-		gmtlib_grd_flip_vertical (pgrid, width, height, 0, sizeof(grid[0]));
+		gmt_grd_flip_vertical (pgrid, width, height, 0, sizeof(grid[0]));
 
 	/* Get stats */
 	header->z_min = DBL_MAX;

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -147,6 +147,7 @@ EXTERN_MSC bool gmt_file_is_srtmtile (struct GMTAPI_CTRL *API, const char *file,
 
 /* gmt_grdio.c: */
 
+EXTERN_MSC void gmt_grd_flip_vertical (void *gridp, const unsigned n_cols, const unsigned n_rows, const unsigned n_stride, size_t cell_size);
 EXTERN_MSC int gmt_raster_type (struct GMT_CTRL *GMT, char *file);
 EXTERN_MSC void gmt_copy_gridheader (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *to, struct GMT_GRID_HEADER *from);
 EXTERN_MSC struct GMT_GRID *gmt_get_grid (struct GMT_CTRL *GMT);

--- a/src/misc/grdppa.c
+++ b/src/misc/grdppa.c
@@ -37,8 +37,6 @@
 #define ij(h,i,j) ((i) + ((j)-1)*(h->mx) -1)
 #define ijk(h,i,j,k) ((i) + ((j)-1)*(h->mx) + ((k)-1)*(h->mx)*(h->my) -1)
 
-EXTERN_MSC void gmtlib_grd_flip_vertical (void *gridp, const unsigned n_cols, const unsigned n_rows, const unsigned n_stride, size_t cell_size);
-
 /* Control structure */
 
 struct GRDPPA_CTRL {
@@ -502,7 +500,7 @@ int GMT_grdppa (void *V_API, int mode, void *args) {
 	z_scale = 499.0 / (G->header->z_max - G->header->z_min);
 
 	/* Regarding the original fortran algo we need to flipud the grid */
-	gmtlib_grd_flip_vertical (G->data, G->header->mx, G->header->my, 0, sizeof(G->data[0]));
+	gmt_grd_flip_vertical (G->data, G->header->mx, G->header->my, 0, sizeof(G->data[0]));
 
 	tgrcon(API, Ctrl, G);
 	segko(API, Ctrl, G, z_scale);


### PR DESCRIPTION
Rebaptized gmtlib_grd_flip_vertical as gmt_grd_flip_vertical and move prototype to gmt_prototypes.h so modules can use this function.  This was used in grdppa which caused some warnings.