### PR TITLE
Less strict on the dx = dy checking

### DIFF
--- a/src/gmt_grd.h
+++ b/src/gmt_grd.h
@@ -179,6 +179,8 @@ enum gmt_enum_wesnids {
 #define gmt_M_grd_same_region(C,G1,G2) (G1->header->wesn[XLO] == G2->header->wesn[XLO] && G1->header->wesn[XHI] == G2->header->wesn[XHI] && G1->header->wesn[YLO] == G2->header->wesn[YLO] && G1->header->wesn[YHI] == G2->header->wesn[YHI])
 /*! gmt_M_grd_same_inc is true if two grids have the exact same grid increments */
 #define gmt_M_grd_same_inc(C,G1,G2) (G1->header->inc[GMT_X] == G2->header->inc[GMT_X] && G1->header->inc[GMT_Y] == G2->header->inc[GMT_Y])
+/*! gmt_M_grd_equal_inc is true if a grid has approximately the same x and y grid increments (within 1e-6) */
+#define gmt_M_grd_equal_xy_inc(C,G) (fabs (1.0 - G->header->inc[GMT_X] / G->header->inc[GMT_Y]) < 1.0e-6)
 /*! GMT_grd_same_dim is true if two grids have the exact same dimensions and registrations */
 #define gmt_M_grd_same_shape(C,G1,G2) (G1->header->n_columns == G2->header->n_columns && G1->header->n_rows == G2->header->n_rows && G1->header->registration == G2->header->registration)
 /*! gmt_M_y_is_outside is true if y is outside the given range */

--- a/src/grd2kml.c
+++ b/src/grd2kml.c
@@ -402,13 +402,13 @@ int GMT_grd2kml (void *V_API, int mode, void *args) {
 	}
 	if (!gmt_M_is_geographic (GMT, GMT_IN)) {
 		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Grid must be geographic (lon, lat)\n");
-		Return (API->error);
+		Return (GMT_RUNTIME_ERROR);
 	}
-	if (!doubleAlmostEqual (G->header->inc[GMT_X], G->header->inc[GMT_Y])) {
+	if (!gmt_M_grd_equal_xy_inc (GMT, G)) {
 		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Grid spacing must be the same in longitude and latitude!\n");
-		Return (API->error);
+		Return (GMT_RUNTIME_ERROR);
 	}
-	
+
 	Ctrl->L.size /= Ctrl->M.magnify;
 	dpi = 100 * Ctrl->M.magnify;
 	/* Set specific grdimage option -Q or -Ei or neither */


### PR DESCRIPTION
The  code was a bit harsh checking if xinc == yinc so even 1e-13 differences would trigger an exit.

This addresses http://gmt.soest.hawaii.edu/boards/1/topics/7669?r=7670#message-7670 partly.