### PR TITLE
Avoid compiler warnings related to not heeding errors

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -2442,7 +2442,7 @@ GMT_LOCAL int gmtinit_put_history (struct GMT_CTRL *GMT) {
 		GMT->parent->clear = false;
 		return (GMT_NOERROR); /* gmt.history mechanism has been disabled */
 	}
-	
+
 	if (!(GMT->current.setting.history & GMT_HISTORY_WRITE)) {
 		if (GMT->current.setting.run_mode == GMT_MODERN && GMT->current.setting.history == GMT_HISTORY_OFF)
 			GMT->current.setting.history = GMT->current.setting.history_orig;
@@ -12315,7 +12315,7 @@ void gmt_check_if_modern_mode_oneliner (struct GMTAPI_CTRL *API, int argc, char 
 	 * This is needed since there is not gmt begin | end sequence in this case.
 	 * Also, if a user wants to get the usage message for a modern mode module then it is also a type
 	 * of one-liner and thus we set to GMT_MODERN as well, but only for modern module names. */
-	
+
 	unsigned modern = 0, pos, k = 0;
 	int n_args = argc - 1;
 	char figure[GMT_LEN128] = {""}, p[GMT_LEN16] = {""}, *c = NULL;
@@ -12327,7 +12327,7 @@ void gmt_check_if_modern_mode_oneliner (struct GMTAPI_CTRL *API, int argc, char 
 		k = 1;
 	}
 	API->GMT->current.setting.use_modern_name = gmtlib_is_modern_name (API, argv[k]);
-	
+
 	if (API->GMT->current.setting.use_modern_name) {
 		if (n_args == 0) {	/* Gave none or a single argument */
 			API->GMT->current.setting.run_mode = GMT_MODERN;
@@ -14962,7 +14962,7 @@ int gmt_add_legend_item (struct GMTAPI_CTRL *API, char *symbol, char *size, stru
 	(pen)  ? fprintf (fp, "%s ", gmt_putpen (API->GMT, pen))      : fprintf (fp, "- ");
 	fprintf (fp, "- %s\n", label);
 	fclose (fp);
-	
+
 	return GMT_NOERROR;
 }
 
@@ -15146,6 +15146,7 @@ void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int j
 	unsigned int pos = 0;
 	bool add_label = false, add_annot = false, axis_set = false;
 	double GMT_LETTER_HEIGHT = 0.736;
+	char *dummy;
 	FILE *fp = NULL;
 	/* Initialize the default settings before considering any -B history */
 	offset[GMT_OUT] = GMT->current.setting.map_label_offset + GMT->current.setting.map_frame_width;
@@ -15167,7 +15168,7 @@ void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int j
 		GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "No file %s with frame information - no adjustments made\n", file);
 		return;
 	}
-	fgets (file, PATH_MAX, fp);	fclose (fp);	/* Recycle file to hold the -B arguments */
+	dummy = fgets (file, PATH_MAX, fp);	fclose (fp);	/* Recycle file to hold the -B arguments */
 	while (file[0] && gmt_strtok (file, B_delim, &pos, p)) {	/* Parse the -B options from last call */
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "B item = %s\n", p);
 		if (p[0] == axis && strstr (p, "+l")) add_label = true;	/* User specified a axis label on that side */
@@ -15268,8 +15269,8 @@ int gmt_report_usage (struct GMTAPI_CTRL *API, struct GMT_OPTION *options, unsig
 		else if (options->option == GMT_OPT_SYNOPSIS)
 			code = GMT_SYNOPSIS;
 	}
-	
+
 	if (code)	/* Must call the usage function */
 		usage (API, code);
-	return (code);	
+	return (code);
 }

--- a/src/movie.c
+++ b/src/movie.c
@@ -34,7 +34,7 @@
 
 #include "gmt_dev.h"
 #ifdef WIN32
-#include <windows.h> 
+#include <windows.h>
 #endif
 
 #define THIS_MODULE_NAME	"movie"
@@ -426,7 +426,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   -x<n>  Select <n> cores (up to all available).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   -x-<n> Select (all - <n>) cores (or at least 1).\n");
 	GMT_Option (API, ".");
-	
+
 	return (GMT_MODULE_USAGE);
 }
 
@@ -444,7 +444,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_O
 	struct GMT_FILL fill;	/* Only used to make sure any fill is given with correct syntax */
 	struct GMT_PEN pen;	/* Only used to make sure any pen is given with correct syntax */
 	struct GMT_OPTION *opt = NULL;
-	
+
 	if (GMT->current.setting.proj_length_unit == GMT_INCH) {	/* Switch from SI to US dimensions in inch given format names */
 		width = 9.6;	height16x9 = 5.4;	height4x3 = 7.2;	dpu = 400.0;
 		Ctrl->C.unit = 'i';
@@ -460,7 +460,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_O
 				else
 					n_errors++;
 				break;
-				
+
 			case 'A':	/* Animated GIF */
 				Ctrl->A.active = Ctrl->animate = true;
 				if ((c = gmt_first_modifier (GMT, opt->arg, "ls"))) {	/* Process any modifiers */
@@ -468,7 +468,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_O
 					while (gmt_getmodopt (GMT, 'A', c, "ls", &pos, p, &n_errors) && n_errors == 0) {
 						switch (p[0]) {
 							case 'l':	/* Specify loops */
-								Ctrl->A.loop = true; 
+								Ctrl->A.loop = true;
 								Ctrl->A.loops = (p[1]) ? atoi (&p[1]) : 0;
 								break;
 							case 's':	/* Specify GIF stride, 2,5,10,20,50,100,200,500 etc. */
@@ -479,7 +479,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_O
 								if (!(k == 1 || k == 2 || k == 5)) {
 									GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error option -A+s: Allowable strides are 2,5,10,20,50,100,200,500,...\n");
 									n_errors++;
-								}	
+								}
 								break;
 							default:
 								break;	/* These are caught in gmt_getmodopt so break is just for Coverity */
@@ -539,7 +539,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_O
 						n_errors++;
 					}
 					else {	/* Got three items; lets check */
-						Ctrl->C.dim[GMT_X] = atof (txt_a);	
+						Ctrl->C.dim[GMT_X] = atof (txt_a);
 						Ctrl->C.dim[GMT_Y] = atof (txt_b);
 						if (strchr ("cip", txt_a[strlen(txt_a)-1]))	/* Width had recognized unit, set it */
 							Ctrl->C.unit = txt_a[strlen(txt_a)-1];
@@ -555,7 +555,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_O
 				Ctrl->D.active = true;
 				Ctrl->D.framerate = atof (opt->arg);
 				break;
-				
+
 			case 'F':	/* Set movie format and optional ffmpeg options */
 				if ((c = strchr (opt->arg, '+')) && c[1] == 'o') {	/* Gave encoding options */
 					s = &c[2];	/* Retain start of encoding options for later */
@@ -691,7 +691,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_O
 				Ctrl->N.active = true;
 				Ctrl->N.prefix = strdup (opt->arg);
 				break;
-			
+
 			case 'Q':	/* Debug - leave temp files and directories behind; Use -Qs tp only write scripts */
 				Ctrl->Q.active = true;
 				if (opt->arg[0] == 's') Ctrl->Q.scripts = true;
@@ -715,7 +715,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_O
 					n_errors++;
 				}
 				break;
-	
+
 			case 'T':	/* Number of frames or the name of file with frame information (note: file may not exist yet) */
 				Ctrl->T.active = true;
 				if ((c = gmt_first_modifier (GMT, opt->arg, "psw"))) {	/* Process any modifiers */
@@ -740,12 +740,12 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_O
 				Ctrl->T.file = strdup (opt->arg);
 				if (c) c[0] = '+';	/* Restore modifiers */
 				break;
-				
+
 			case 'W':	/* Work dir where data files may be found */
 				Ctrl->W.active = true;
 				Ctrl->W.dir = strdup (opt->arg);
 				break;
-				
+
 			case 'Z':	/* Erase frames after movie has been made */
 				Ctrl->Z.active = true;
 				break;
@@ -757,7 +757,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_O
 				GMT->common.x.active = true;
 				break;
 #endif
-		
+
 			default:	/* Report bad options */
 				n_errors += gmt_default_error (GMT, opt->option);
 				break;
@@ -788,11 +788,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_O
 					"Syntax error -A: Cannot specify a GIF stride > 1 without selecting a movie product (-F)\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->M.active && Ctrl->M.frame < Ctrl->T.start_frame,
 					"Syntax error -M: Cannot specify a frame before the first frame number set via -T\n");
-	
+
 	if (n_errors) return (GMT_PARSE_ERROR);	/* No point going further */
-	
+
 	/* Note: We open script files for reading below since we are changing cwd later and sometimes need to rewind and re-read */
-	
+
 	if (n_files == 1) {	/* Determine scripting language from file extension and open the main script file */
 		if (strstr (Ctrl->In.file, ".bash") || strstr (Ctrl->In.file, ".sh"))	/* Treat both as bash since sh is subset of bash */
 			Ctrl->In.mode = BASH_MODE;
@@ -843,13 +843,13 @@ void close_files (struct MOVIE_CTRL *Ctrl) {
 int GMT_movie (void *V_API, int mode, void *args) {
 	int error = 0, precision;
 	int (*run_script)(const char *);	/* pointer to system function or a dummy */
-	
+
 	unsigned int n_values = 0, n_frames = 0, frame, i_frame, col, p_width, p_height, k, T;
 	unsigned int n_frames_not_started = 0, n_frames_completed = 0, first_frame = 0, n_cores_unused;
 	unsigned int dd, hh, mm, ss, flavor = 0;
-	
+
 	bool done = false, layers = false, one_frame = false, has_text = false, is_classic = false, upper_case = false;
-	
+
 	char *extension[3] = {"sh", "csh", "bat"}, *load[3] = {"source", "source", "call"}, *rmfile[3] = {"rm -f", "rm -f", "del"};
 	char *rmdir[3] = {"rm -rf", "rm -rf", "rd /s /q"}, *export[3] = {"export ", "export ", ""};
 	char *mvfile[3] = {"mv -f", "mv -rf", "move"}, *sc_call[3] = {"bash ", "csh ", "start /B"};
@@ -864,9 +864,9 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	char dir_sep = '/';
 #endif
 	double percent = 0.0, L_col = 0;
-	
+
 	FILE *fp = NULL;
-	
+
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;
 	struct GMT_DATASET *D = NULL;
 	struct GMT_OPTION *options = NULL;
@@ -897,7 +897,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	one_frame = (Ctrl->M.active && (Ctrl->Q.scripts || !Ctrl->animate || Ctrl->M.exit));	/* true if we want to create a single master plot only */
 	if (Ctrl->C.unit == 'c') Ctrl->C.dim[GMT_Z] *= 2.54;		/* Since gs requires dots per inch but we gave dots per cm */
 	else if (Ctrl->C.unit == 'p') Ctrl->C.dim[GMT_Z] *= 72.0;	/* Since gs requires dots per inch but we gave dots per point */
-	
+
 	if (Ctrl->L.active) {	/* Compute auto label placement */
 		int col, row, justify;
 		for (T = 0; T < Ctrl->L.n_tags; T++) {
@@ -921,7 +921,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			}
 		}
 	}
-	
+
 	if (Ctrl->Q.scripts) {	/* No movie, but scripts will be produced */
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Dry-run enabled - Movie scripts will be created and any pre/post scripts will be executed.\n");
 		if (Ctrl->M.active) GMT_Report (API, GMT_MSG_LONG_VERBOSE, "A single plot for frame %d will be create and named %s.%s\n", Ctrl->M.frame, Ctrl->N.prefix, Ctrl->M.format);
@@ -929,7 +929,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	}
 	else {	/* Will run scripts and may even need to make a movie */
 		run_script = system;	/* The standard system function will be used */
-	
+
 		if (Ctrl->A.active) {	/* Ensure we have the GraphicsMagick executable "gm" installed in the path*/
 			sprintf (cmd, "gm version");
 			if ((fp = popen (cmd, "r")) == NULL) {
@@ -953,7 +953,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			}
 		}
 	}
-	
+
 	GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Paper dimensions: Width = %g%c Height = %g%c\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
 	GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Pixel dimensions: %u x %u\n", p_width, p_height);
 
@@ -978,14 +978,14 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			Return (GMT_RUNTIME_ERROR);
 		}
 	}
-	
+
 	/* Get full path to the current working directory */
 	if (getcwd (topdir, PATH_MAX) == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Unable to determine current working directory - exiting.\n");
 		close_files (Ctrl);
 		Return (GMT_RUNTIME_ERROR);
 	}
-	
+
 	/* Create a working directory which will house every local file and all subdirectories created */
 	if (gmt_mkdir (Ctrl->N.prefix)) {
 		GMT_Report (API, GMT_MSG_NORMAL, "An old directory named %s exists OR we were unable to create new working directory %s - exiting.\n", Ctrl->N.prefix, Ctrl->N.prefix);
@@ -1024,16 +1024,16 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			sprintf (work_dir, "%c%s", path_sep[Ctrl->In.mode], Ctrl->W.dir);
 		strcat (datadir, work_dir);
 	}
-		
+
 	/* Create the initialization file with settings common to all frames */
-	
+
 	sprintf (init_file, "movie_init.%s", extension[Ctrl->In.mode]);
 	if ((fp = fopen (init_file, "w")) == NULL) {
 		GMT_Report (API, GMT_MSG_NORMAL, "Unable to create file %s - exiting\n", init_file);
 		close_files (Ctrl);
 		Return (GMT_ERROR_ON_FOPEN);
 	}
-	
+
 	sprintf (string, "Static parameters set for animation sequence %s", Ctrl->N.prefix);
 	set_comment (fp, Ctrl->In.mode, string);
 	set_dvalue (fp, Ctrl->In.mode, "MOVIE_WIDTH",  Ctrl->C.dim[GMT_X], Ctrl->C.unit);
@@ -1051,7 +1051,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		fclose (Ctrl->I.fp);	/* Done reading the include script */
 	}
 	fclose (fp);	/* Done writing the init script */
-	
+
 	if (Ctrl->S[MOVIE_PREFLIGHT].active) {	/* Create the preflight script from the user's background script */
 		/* The background script is allowed to be classic if no plot is generated */
 		unsigned int rec = 0;
@@ -1104,9 +1104,9 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			Return (GMT_RUNTIME_ERROR);
 		}
 	}
-	
+
 	/* Now we can complete the -T parsing since any given file has now been created by pre_file */
-	
+
 	if (n_frames == 0) {	/* Must check again for a file or decode the argument as a number */
 		if (!gmt_access (GMT, Ctrl->T.file, R_OK)) {	/* A file by that name was indeed created by preflight and is now available */
 			if ((D = GMT_Read_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, Ctrl->T.file, NULL)) == NULL) {
@@ -1137,7 +1137,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		precision = Ctrl->T.precision;
 	else	/* Compute from largest frame number */
 		precision = irint (ceil (log10 ((double)(Ctrl->T.start_frame+n_frames))));	/* Width needed to hold largest frame number */
-	
+
 	if (Ctrl->S[MOVIE_POSTFLIGHT].active) {	/* Prepare the postflight script */
 		is_classic = script_is_classic (GMT, Ctrl->S[MOVIE_POSTFLIGHT].fp);
 		if (is_classic) {
@@ -1188,7 +1188,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			Return (GMT_RUNTIME_ERROR);
 		}
 	}
-	
+
 
 	if (Ctrl->L.active) {	/* Set elapse time label format if chosen */
 		char *format = NULL;
@@ -1232,7 +1232,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	}
 
 	/* Create parameter include files, one for each frame */
-	
+
 	for (i_frame = 0; i_frame < n_frames; i_frame++) {
 		frame = i_frame + Ctrl->T.start_frame;	/* Actual frame number */
 		if (one_frame && frame != Ctrl->M.frame) continue;	/* Just doing a single frame for debugging */
@@ -1372,7 +1372,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		}
 		if (Ctrl->H.active) {	/* Must pass the DownScaleFactor option to psconvert */
 			sprintf (line, ",H%d", Ctrl->H.factor);
-			strncat (extra, line, GMT_LEN128);
+			strncat (extra, line, sizeof(extra) - strlen(extra) - 1);
 		}
 		set_script (fp, Ctrl->In.mode);					/* Write 1st line of a script */
 		set_comment (fp, Ctrl->In.mode, "Master frame loop script");
@@ -1452,10 +1452,10 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			Return (GMT_NOERROR);
 		}
 	}
-	
+
 	/* Now build the main loop script from the mainscript */
 	if (Ctrl->Q.active) strcat (frame_products, MOVIE_DEBUG_FORMAT);	/* Want to save original PS file for debug */
-	
+
 	sprintf (main_file, "movie_frame.%s", extension[Ctrl->In.mode]);
 	if ((fp = fopen (main_file, "w")) == NULL) {
 		GMT_Report (API, GMT_MSG_NORMAL, "Unable to create loop frame script file %s - exiting\n", main_file);
@@ -1523,7 +1523,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	if (Ctrl->In.mode == DOS_MODE)	/* This is crucial to the "start /B ..." statement below to ensure the DOS process terminates */
 		fprintf (fp, "exit\n");
 	fclose (fp);	/* Done writing loop script */
-	
+
 #ifndef WIN32
 	/* Set executable bit if not Windows */
 	if (chmod (main_file, S_IRWXU)) {
@@ -1531,7 +1531,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		Return (GMT_RUNTIME_ERROR);
 	}
 #endif
-	
+
 	if (Ctrl->Q.scripts) {	/* No animation sequence generated */
 		Return (GMT_NOERROR);	/* We are done */
 	}
@@ -1579,7 +1579,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	/* END PARALLEL EXECUTION OF FRAME SCRIPTS */
 
 	gmt_M_free (GMT, status);	/* Done with this structure array */
-	
+
 	/* Cd back up to the parent directory */
 	if (chdir ("..")) {	/* Should never happen but we should check */
 		GMT_Report (API, GMT_MSG_NORMAL, "Unable to change directory to parent directory - exiting.\n");
@@ -1675,7 +1675,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			fprintf (fp, "%s %s%c%s\n", rmfile[Ctrl->In.mode], Ctrl->N.prefix, dir_sep, post_file);
 		fprintf (fp, "%s %s%c%s\n", rmfile[Ctrl->In.mode], Ctrl->N.prefix, dir_sep, init_file);	/* Delete the init script */
 		fprintf (fp, "%s %s%c%s\n", rmfile[Ctrl->In.mode], Ctrl->N.prefix, dir_sep, main_file);	/* Delete the main script */
-		if (layers) 
+		if (layers)
 			fprintf (fp, "%s %s%c*.ps\n", rmfile[Ctrl->In.mode], Ctrl->N.prefix, dir_sep);	/* Delete any PostScript layers */
 	}
 	fclose (fp);

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -78,7 +78,7 @@ EXTERN_MSC void gmt_handle5_plussign (struct GMT_CTRL *GMT, char *in, char *mods
 	struct popen2 {
 		int fd[2];		/* The input [0] and output [1] file descriptors */
 		int n_closed;	/* Number of times we have called gmt_pclose */
-	    pid_t child_pid;	/* Pid of child */
+		pid_t child_pid;	/* Pid of child */
 	};
 #endif
 
@@ -213,31 +213,31 @@ struct PS2RASTER_CTRL {
 struct popen2 * gmt_popen2 (const char *cmdline) {
 	struct popen2 *F = NULL;
 	/* Must implement a bidirectional popen instead */
-    pid_t p;
-    int pipe_stdin[2] = {0, 0}, pipe_stdout[2] = {0, 0};
+	pid_t p;
+	int pipe_stdin[2] = {0, 0}, pipe_stdout[2] = {0, 0};
 
-    if (pipe(pipe_stdin))  return NULL;
-    if (pipe(pipe_stdout)) return NULL;
+	if (pipe(pipe_stdin))  return NULL;
+	if (pipe(pipe_stdout)) return NULL;
 
-    printf("pipe_stdin[0] = %d,  pipe_stdin[1]  = %d\n", pipe_stdin[0], pipe_stdin[1]);
-    printf("pipe_stdout[0] = %d, pipe_stdout[1] = %d\n", pipe_stdout[0], pipe_stdout[1]);
+	printf("pipe_stdin[0] = %d,  pipe_stdin[1]  = %d\n", pipe_stdin[0], pipe_stdin[1]);
+	printf("pipe_stdout[0] = %d, pipe_stdout[1] = %d\n", pipe_stdout[0], pipe_stdout[1]);
 
-    if ((p = fork()) < 0) return NULL; /* Fork failed */
+	if ((p = fork()) < 0) return NULL; /* Fork failed */
 
-    if(p == 0) { /* child */
-        close (pipe_stdin[1]);
-        dup2 (pipe_stdin[0], 0);
-        close (pipe_stdout[0]);
-        dup2 (pipe_stdout[1], 1);
-        execl ("/bin/sh", "sh", "-c", cmdline, NULL);
-        perror ("execl"); exit (99);
-    }
+	if(p == 0) { /* child */
+		close (pipe_stdin[1]);
+		dup2 (pipe_stdin[0], 0);
+		close (pipe_stdout[0]);
+		dup2 (pipe_stdout[1], 1);
+		execl ("/bin/sh", "sh", "-c", cmdline, NULL);
+		perror ("execl"); exit (99);
+	}
 	/* Return the file handles back via structure */
 	F = calloc (1, sizeof (struct popen2));
-    F->child_pid = p;
-    F->fd[1] = pipe_stdin[1];
-    F->fd[0] = pipe_stdout[0];
-    return F;
+	F->child_pid = p;
+	F->fd[1] = pipe_stdin[1];
+	F->fd[0] = pipe_stdout[0];
+	return F;
 }
 
 #ifndef _WIN32
@@ -252,9 +252,9 @@ void gmt_pclose2 (struct popen2 **Faddr, int dir) {
 	if (F->n_closed == 2) {	/* Done so free object */
 		/* Done, kill child */
 #ifndef _WIN32
-    	printf("kill(%d, 0) -> %d\n", F->child_pid, kill(F->child_pid, 0));
-    	printf("waitpid() -> %d\n", waitpid(F->child_pid, NULL, 0));
-    	printf("kill(%d, 0) -> %d\n", F->child_pid, kill(F->child_pid, 0));
+		printf("kill(%d, 0) -> %d\n", F->child_pid, kill(F->child_pid, 0));
+		printf("waitpid() -> %d\n", waitpid(F->child_pid, NULL, 0));
+		printf("kill(%d, 0) -> %d\n", F->child_pid, kill(F->child_pid, 0));
 #endif
 		free (F);
 		*Faddr = NULL;
@@ -277,7 +277,7 @@ GMT_LOCAL int parse_A_settings (struct GMT_CTRL *GMT, char *arg, struct PS2RASTE
 	Ctrl->A.active = Ctrl->A.crop = true;	/* The default is to crop unless we get -A- */
 
 	/* For historical reasons we may encounter -A-<stuff> or -Au- so check for both */
-	
+
 	/* The next lines down to NEW is simply backwards compatible parsing */
 	if (arg[k] == 'u') {Ctrl->A.strip = true; k++;}		/* Eliminate GMT time stamp */
 	else if (arg[k] == '-') {Ctrl->A.crop = false; k++;}	/* No cropping requested */
@@ -544,13 +544,13 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     <woff>[u]/<eoff>[u]/<soff>[u]/<noff>[u] for separate w-,e-,s-,n-margins.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +n to leave the BoundingBox as is.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +p[<pen>] to outline the BoundingBox [%s].\n",
-	             gmt_putpen (API->GMT, &API->GMT->current.setting.map_default_pen));
+		gmt_putpen (API->GMT, &API->GMT->current.setting.map_default_pen));
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +r to force rounding of HighRes BoundingBox instead of ceil.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +s[m]<width[u]>[/<height>[u]] option the select a new image size\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     but maintaining the DPI set by -E (ghostscript does the re-interpolation work).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Use +sm to only change size if figure size exceeds the new maximum size(s).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Append unit u (%s) [%c].\n",
-	             GMT_DIM_UNITS_DISPLAY, &API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit][0]);
+		GMT_DIM_UNITS_DISPLAY, &API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit][0]);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Alternatively, use -A+S<scale> to scale the image by the <scale> factor.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +u to strip out time-stamps (produced by GMT -U options).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Specify a single, custom option that will be passed on to GhostScript\n");
@@ -866,28 +866,28 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PS2RASTER_CTRL *Ctrl, struct G
 	}
 
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.on[0] && (Ctrl->Q.bits[0] < 1 || Ctrl->Q.bits[0] > 4),
-	                                   "Syntax error: Anti-aliasing for graphics requires sub-sampling box of 1,2, or 4\n");
+		"Syntax error: Anti-aliasing for graphics requires sub-sampling box of 1,2, or 4\n");
 
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.on[1] && (Ctrl->Q.bits[1] < 1 || Ctrl->Q.bits[1] > 4),
-	                                   "Syntax error: Anti-aliasing for text requires sub-sampling box of 1,2, or 4\n");
+		"Syntax error: Anti-aliasing for text requires sub-sampling box of 1,2, or 4\n");
 
 	n_errors += gmt_M_check_condition (GMT, Ctrl->In.n_files > 1 && Ctrl->L.active,
-	                                   "Syntax error: Cannot handle both a file list and multiple ps files in input\n");
+		"Syntax error: Cannot handle both a file list and multiple ps files in input\n");
 
 	n_errors += gmt_M_check_condition (GMT, Ctrl->L.active && access (Ctrl->L.file, R_OK),
-	                                   "Error: Cannot read list file %s\n", Ctrl->L.file);
+		"Error: Cannot read list file %s\n", Ctrl->L.file);
 
 	n_errors += gmt_M_check_condition (GMT, Ctrl->T.device == -GS_DEV_PDF && !Ctrl->F.active,
-	                                   "Syntax error: Creation of Multipage PDF requires setting -F option\n");
+		"Syntax error: Creation of Multipage PDF requires setting -F option\n");
 
 	n_errors += gmt_M_check_condition (GMT, Ctrl->L.active && (GMT->current.setting.run_mode == GMT_MODERN),
-	                                   "Error: Cannot use -L for list file under modern GMT mode\n");
+		"Error: Cannot use -L for list file under modern GMT mode\n");
 
 	n_errors += gmt_M_check_condition (GMT, GMT->current.setting.run_mode == GMT_MODERN && !(Ctrl->In.n_files == 0 || (Ctrl->In.n_files == 1 && halfbaked)),
-	                                   "Syntax error: No listed input files allowed under modern GMT mode\n");
+		"Syntax error: No listed input files allowed under modern GMT mode\n");
 
 	n_errors += gmt_M_check_condition (GMT, !Ctrl->F.active && GMT->current.setting.run_mode == GMT_MODERN,
-	                                   "Syntax error: Modern GMT mode requires the -F option\n");
+		"Syntax error: Modern GMT mode requires the -F option\n");
 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
@@ -1025,15 +1025,19 @@ GMT_LOCAL int pipe_HR_BB(struct GMTAPI_CTRL *API, struct PS2RASTER_CTRL *Ctrl, c
 
 	/* Send the PS down ghostscripts throat */
 #ifdef _WIN32
-	fwrite (PS->data, sizeof(char), PS->n_bytes, fp);
-	fflush (fp);
+	if ((n_bytes = fwrite (PS->data, sizeof(char), PS->n_bytes, fp)) != PS->n_bytes)
+		GMT_Report (API, GMT_MSG_NORMAL,
+			"Error writing PostScript buffer to GhostScript process. Bytes written = %ld, should have been %ld\n", n_bytes, PS->n_bytes);
+	if (fflush (fp) == EOF)
+		GMT_Report (API, GMT_MSG_NORMAL, "Error flushing GhostScript process.\n");
 	if (pclose (fp) == -1)
-		GMT_Report(API, GMT_MSG_NORMAL, "Error closing pipe used for GhostScript command.\n");
+		GMT_Report (API, GMT_MSG_NORMAL, "Error closing GhostScript process.\n");
 	fh = fd[0];	/* File handle for reading */
 #else
- 	write (H->fd[1], PS->data, PS->n_bytes);
+ 	if (write (H->fd[1], PS->data, PS->n_bytes) == -1)
+		GMT_Report (API, GMT_MSG_NORMAL, "Error writing PostScript buffer to GhostScript process.\n");
 	/* Now closed for writing */
-    gmt_pclose2 (&H, 1);
+	gmt_pclose2 (&H, 1);
 	fh = H->fd[0];	/* File handle for reading */
 #endif
 
@@ -1076,7 +1080,7 @@ GMT_LOCAL int pipe_HR_BB(struct GMTAPI_CTRL *API, struct PS2RASTER_CTRL *Ctrl, c
 		}
 		else {
 			sscanf (&pch[20], "%lf %lf %lf %lf", &x0, &y0, &x1, &y1);
-			if (landscape)	
+			if (landscape)
 				*w = y1, *h = x1, r = -90;
 			else
 				*w = x1, *h = y1, r = 0;
@@ -1208,7 +1212,7 @@ GMT_LOCAL int pipe_ghost (struct GMTAPI_CTRL *API, struct PS2RASTER_CTRL *Ctrl, 
 #ifdef _WIN32
 	if ((n_bytes = fwrite (PS->data, sizeof(char), PS->n_bytes, fp)) != PS->n_bytes)
 		GMT_Report (API, GMT_MSG_NORMAL,
-		            "Error writing PostScript buffer to GhostScript process. Bytes written = %ld, should have been %ld\n", n_bytes, PS->n_bytes);
+			"Error writing PostScript buffer to GhostScript process. Bytes written = %ld, should have been %ld\n", n_bytes, PS->n_bytes);
 	if (fflush (fp) == EOF)
 		GMT_Report (API, GMT_MSG_NORMAL, "Error flushing GhostScript process.\n");
 	if (pclose (fp) == -1)
@@ -1224,9 +1228,10 @@ GMT_LOCAL int pipe_ghost (struct GMTAPI_CTRL *API, struct PS2RASTER_CTRL *Ctrl, 
 			GMT_Report (API, GMT_MSG_NORMAL, "Error closing GhostScript process.\n");
 	}
 	else {	/* On non-Windows and want a raster back */
- 		write (H->fd[1], PS->data, PS->n_bytes);
+		if (write (H->fd[1], PS->data, PS->n_bytes) == -1)
+			GMT_Report (API, GMT_MSG_NORMAL, "Error writing PostScript buffer to GhostScript process.\n");
 		/* Now closed for writing */
-    	gmt_pclose2 (&H, 1);
+		gmt_pclose2 (&H, 1);
 		fh = H->fd[0];	/* File handle for reading */
 	}
 #endif
@@ -1317,7 +1322,7 @@ GMT_LOCAL int in_mem_PS_convert(struct GMTAPI_CTRL *API, struct PS2RASTER_CTRL *
 
 	if (API->GMT->PSL->internal.pmode != 3) {
 		GMT_Report (API, GMT_MSG_NORMAL, "Internal PSL PostScript is only half-baked [mode = %d]\n",
-		            API->GMT->PSL->internal.pmode);
+			API->GMT->PSL->internal.pmode);
 		error++;
 	}
 	if (error) 			/* Return in error state */
@@ -1360,7 +1365,7 @@ GMT_LOCAL int wrap_the_sandwich (struct GMT_CTRL *GMT, char *main, char *bfile, 
 	   one of bfile or ffile exists, as do main. */
 	char newfile[PATH_MAX] = {""};
 	FILE *fp = NULL;
-	
+
 	/* Create a temporary file name for the sandwich file and open it for writing */
 	sprintf (newfile, "%s/psconvert_sandwich_%d.ps", GMT->parent->tmp_dir, (int)getpid());
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Creating %s\n", newfile);
@@ -1382,7 +1387,7 @@ GMT_LOCAL int wrap_the_sandwich (struct GMT_CTRL *GMT, char *main, char *bfile, 
 		gmt_ps_append (GMT, ffile, 2, fp);	/* Append foreground file but exclude header */
 	}
 	fclose (fp);	/* Completed */
-	
+
 	/* Now remove original ps_file and rename the new file to main */
 	if (gmt_remove_file (GMT, main)) {
 		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Failed to remove original file %s.\n", main);
@@ -1507,7 +1512,7 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 		if (n != 2) {
 			/* command execution failed or cannot parse response */
 			GMT_Report (API, GMT_MSG_NORMAL, "Failed to parse response to GhostScript version query [n = %d %d %d].\n",
-			            n, gsVersion.major, gsVersion.minor);
+				n, gsVersion.major, gsVersion.minor);
 			Return (GMT_RUNTIME_ERROR);
 		}
 	}
@@ -1518,7 +1523,7 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 
 	if (Ctrl->T.device == GS_DEV_SVG && (gsVersion.major > 9 || (gsVersion.major == 9 && gsVersion.minor >= 16))) {
 		GMT_Report (API, GMT_MSG_NORMAL, "Your ghostscript version (%d.%d) no longer supports the SVG device.\n",
-		            gsVersion.major, gsVersion.minor);
+			gsVersion.major, gsVersion.minor);
 		GMT_Report (API, GMT_MSG_NORMAL, "We recommend converting to PDF and then installing the pdf2svg package.\n");
 		Return (GMT_RUNTIME_ERROR);
 	}
@@ -1561,9 +1566,9 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 	add_to_list (Ctrl->C.arg, "-dMaxBitmap=2147483647");	/* Add this as GS option to fix bug in GS */
 
 	if (Ctrl->W.kml && !(Ctrl->T.device == GS_DEV_JPG ||
-	    Ctrl->T.device == GS_DEV_JPGG || Ctrl->T.device == GS_DEV_TIF ||
-	    Ctrl->T.device == GS_DEV_TIFG || Ctrl->T.device == GS_DEV_PNG ||
-	    Ctrl->T.device == GS_DEV_TPNG || Ctrl->T.device == GS_DEV_PNGG) ) {
+		Ctrl->T.device == GS_DEV_JPGG || Ctrl->T.device == GS_DEV_TIF ||
+		Ctrl->T.device == GS_DEV_TIFG || Ctrl->T.device == GS_DEV_PNG ||
+		Ctrl->T.device == GS_DEV_TPNG || Ctrl->T.device == GS_DEV_PNGG) ) {
 		GMT_Report (API, GMT_MSG_NORMAL, "As far as we know selected raster type is unsupported by GE.\n");
 	}
 
@@ -1777,7 +1782,7 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 			sprintf (BB_file, "%s/psconvert_%dc.bb", Ctrl->D.dir, (int)getpid());
 			psfile_to_use = Ctrl->A.strip ? no_U_file : ((strlen (clean_PS_file) > 0) ? clean_PS_file : ps_file);
 			sprintf (cmd, "%s%s %s %s %c%s%c 2> %c%s%c",
-			         at_sign, Ctrl->G.file, gs_BB, Ctrl->C.arg, quote, psfile_to_use, quote, quote, BB_file, quote);
+				at_sign, Ctrl->G.file, gs_BB, Ctrl->C.arg, quote, psfile_to_use, quote, quote, BB_file, quote);
 			GMT_Report (API, GMT_MSG_DEBUG, "Running: %s\n", cmd);
 			sys_retval = system (cmd);		/* Execute the command that computes the tight BB */
 			if (sys_retval) {
@@ -1846,10 +1851,10 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 					}
 					got_BB = got_HRBB = true;
 					GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Figure dimensions: Width: %g points [%g %s]  Height: %g points [%g %s]\n",
-					            x1-x0, (x1-x0)*GMT->session.u2u[GMT_PT][GMT->current.setting.proj_length_unit],
-					            API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit],
-					            y1-y0, (y1-y0)*GMT->session.u2u[GMT_PT][GMT->current.setting.proj_length_unit],
-					            API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit]);
+						x1-x0, (x1-x0)*GMT->session.u2u[GMT_PT][GMT->current.setting.proj_length_unit],
+						API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit],
+						y1-y0, (y1-y0)*GMT->session.u2u[GMT_PT][GMT->current.setting.proj_length_unit],
+						API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit]);
 				}
 			}
 			if (fpb != NULL) { /* don't close twice */
@@ -1944,7 +1949,7 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 
 		if (!got_BB) {
 			GMT_Report (API, GMT_MSG_NORMAL,
-			            "The file %s has no BoundingBox in the first 20 lines or last 256 bytes. Use -A option.\n", ps_file);
+				"The file %s has no BoundingBox in the first 20 lines or last 256 bytes. Use -A option.\n", ps_file);
 			if (!Ctrl->T.eps && gmt_remove_file (GMT, tmp_file)) {	/* Remove the temporary EPS file */
 				fclose (fp);	fclose (fp2);	fclose (fpo);
 				Return (GMT_RUNTIME_ERROR);
@@ -2202,7 +2207,7 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 					fprintf (fpo, "\t\t\t/Subtype /GEO\n");
 					fprintf (fpo, "\t\t\t/Bounds[0 0 0 1 1 1 1 0]\n");
 					fprintf (fpo, "\t\t\t/GPTS[%f %f %f %f %f %f %f %f]\n",
-					         south, west, north, west, north, east, south, east);
+						south, west, north, west, north, east, south, east);
 					if (gmtBB_width == 0)	/* Older PS files that do not have yet the GMTBoundingBox */
 						fprintf (fpo, "\t\t\t/LPTS[0 0 0 1 1 1 1 0]\n");
 					else {
@@ -2299,7 +2304,7 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 				API->print_func (GMT->session.std[GMT_ERR], cmd);
 				API->print_func (GMT->session.std[GMT_ERR], "\n");
 			}
-			
+
 			/* Execute the GhostScript command */
 			GMT_Report (API, GMT_MSG_DEBUG, "Running: %s\n", cmd);
 			sys_retval = system (cmd);
@@ -2314,18 +2319,18 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 				if (isGMT_PS && excessK)
 					/* non-closed GMT input PS file */
 					GMT_Report (API, GMT_MSG_NORMAL,
-					            "%s: GMT PS format detected but file is not finalized. Maybe a -K in excess? No output created.\n", ps_file);
+						"%s: GMT PS format detected but file is not finalized. Maybe a -K in excess? No output created.\n", ps_file);
 				else
 					/* Either a bad closed GMT PS file or one of unknown origin */
 					GMT_Report (API, GMT_MSG_NORMAL,
-					            "Could not create %s. Maybe input file does not fulfill PS specifications.\n", out_file);
+						"Could not create %s. Maybe input file does not fulfill PS specifications.\n", out_file);
 			}
 			else {								/* output file exists */
 				if (isGMT_PS && excessK)
 					/* non-closed GMT input PS file */
 					GMT_Report (API, GMT_MSG_NORMAL,
-					            "%s: GMT PS format detected but file is not finalized. Maybe a -K in excess? %s could be messed up.\n",
-					            ps_file, out_file);
+						"%s: GMT PS format detected but file is not finalized. Maybe a -K in excess? %s could be messed up.\n",
+						ps_file, out_file);
 				/* else: Either a good closed GMT PS file or one of unknown origin */
 			}
 			if (transparency) {	/* Now convert temporary PDF to desired format */
@@ -2470,11 +2475,11 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 				y_inc = (north - south) / pix_h;
 			}
 			GMT_Report (API, GMT_MSG_LONG_VERBOSE, "width = %d\theight = %d\tX res = %f\tY res = %f\n",
-			                                        pix_w, pix_h, x_inc, y_inc);
+				pix_w, pix_h, x_inc, y_inc);
 
 			/* West and North of the world file contain the coordinates of the center of the pixel
 				but our current values are of the NW corner of the pixel (pixel registration).
-				So we'll move halph pixel inward. */ 
+				So we'll move halph pixel inward. */
 			west  += x_inc / 2.0;	north -= y_inc / 2.0;
 
 			if (Ctrl->D.active) sprintf (world_file, "%s/", Ctrl->D.dir);	/* Use specified output directory */
@@ -2518,7 +2523,7 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 					quiet = "";
 
 				sprintf (cmd, "gdal_translate -mo TIFFTAG_XRESOLUTION=%g -mo TIFFTAG_YRESOLUTION=%g -a_srs %c%s%c "
-				              "-co COMPRESS=LZW -co TILED=YES %s %c%s%c %c%s%c",
+					"-co COMPRESS=LZW -co TILED=YES %s %c%s%c %c%s%c",
 					Ctrl->E.dpi, Ctrl->E.dpi, quote, proj4_cmd, quote, quiet, quote, out_file, quote, quote, world_file, quote);
 				gmt_M_str_free (proj4_cmd);
 				sys_retval = system (cmd);		/* Execute the gdal_translate command */


### PR DESCRIPTION
This kills a number of compiler warnings. In response to issue #128.
(Note: my editor kills empty spaces at end of line, so hence additional chunks of changes).
