### PR TITLE
Handle unit for vector shrinking in grdvector

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12523,9 +12523,9 @@ int gmt_parse_vector (struct GMT_CTRL *GMT, char symbol, char *text, struct GMT_
 				break;
 			case 'n':	/* Vector shrinking head */
 				len = strlen (p);
-				j = (symbol == 'v' || symbol == 'V') ? gmtinit_get_unit (GMT, p[len]) : -1;	/* Only -Sv|V takes unit */
-				if (j >= 0) { S->u = j; S->u_set = true; }
-				S->v.v_norm = (float)atof (&p[1]);
+				j = (symbol == 'v' || symbol == 'V') ? gmtinit_get_unit (GMT, p[len-1]) : -1;	/* Only -Sv|V takes unit */
+				if (j >= GMT_CM) { S->u = j; S->u_set = true; }	/* Save the unit if given */
+				S->v.v_norm = (float)atof (&p[1]);	/* This is normalizing length in given units, not (yet) converted to inches or degrees (but see next line) */
 				if (symbol == '=') S->v.v_norm /= (float)GMT->current.proj.DIST_KM_PR_DEG;	/* Since norm distance is in km and we compute spherical degrees later */
 				break;
 			case 'o':	/* Sets oblique pole for small or great circles */

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -232,7 +232,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDVECTOR_CTRL *Ctrl, struct G
 					Ctrl->Q.S.v.pen = GMT->current.setting.map_default_pen;
 					for (j = 0; opt->arg[j] && opt->arg[j] != 'n'; j++);
 					if (opt->arg[j]) {	/* Normalize option used */
-						Ctrl->Q.S.v.v_norm = (float)gmt_M_to_inch (GMT, &opt->arg[j+1]);
+						Ctrl->Q.S.v.v_norm = (float)gmt_M_to_inch (GMT, &opt->arg[j+1]);	/* Getting inches directly here */
 						n_errors += gmt_M_check_condition (GMT, Ctrl->Q.S.v.v_norm <= 0.0, "Syntax error -Qn option: No reference length given\n");
 						opt->arg[j] = '\0';	/* Temporarily chop of the n<norm> string */
 					}
@@ -262,6 +262,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDVECTOR_CTRL *Ctrl, struct G
 						if (j == 1) txt_b[0] = 0;	/* No modifiers present, set txt_b to empty */
 						Ctrl->Q.S.size_x = gmt_M_to_inch (GMT, txt_a);	/* Length of vector */
 						n_errors += gmt_parse_vector (GMT, symbol, txt_b, &Ctrl->Q.S);
+					}
+					/* Must possibly change v_norm to inches if given in another Cartesian unit */
+					if (Ctrl->Q.S.u_set && Ctrl->Q.S.u != GMT_INCH) {
+						Ctrl->Q.S.v.v_norm *= GMT->session.u2u[Ctrl->Q.S.u][GMT_INCH];	/* Since we are not reading this again we change to inches */
+						Ctrl->Q.S.u = GMT_INCH;
 					}
 				}
 				break;


### PR DESCRIPTION
The vector attribute processing keeps track of normalizing length and unit and applies the conversion later since some programs (like psxy) may read such instructions from the command line.  In grdcontour, however, there is no such reading and we must convert any length to inches before plotting.

The initial problem was detected by @joa-quim when comparing
-Q0.1i+e+n0.63c
-Q0.1i+e+n0.25c
which should be identical.  This PR makes them so.