### PR TITLE
enable -Bwesn with no -B increments to draw blank frame

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -3371,6 +3371,7 @@ GMT_LOCAL int gmtinit_decode5_wesnz (struct GMT_CTRL *GMT, const char *in, bool 
 	if (s_given) {
 		gmt_M_memcpy (GMT->current.map.frame.side, f_side, 5, unsigned int);	/* Overwrite the GMT defaults */
 		GMT->current.map.frame.no_frame = false;
+		GMT->current.map.frame.draw = true;
 	}
 	if (GMT->current.map.frame.no_frame) gmt_M_memset (GMT->current.map.frame.side, 5, unsigned int);	/* Set all to nothing */
 	if (z_axis[0] || z_axis[1] || z_axis[2] || z_axis[3]) gmt_M_memcpy (GMT->current.map.frame.z_axis, z_axis, 4, unsigned int);	/* Overwrite the GMT defaults */

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -1524,6 +1524,7 @@ int GMT_psscale (void *V_API, int mode, void *args) {
 	if ((GMT = gmt_init_module (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_KEYS, THIS_MODULE_NEEDS, &options, &GMT_cpy)) == NULL) bailout (API->error); /* Save current state */
 	/* Overrule GMT settings of MAP_FRAME_AXES. Use WESN */
 	GMT->current.map.frame.side[S_SIDE] = GMT->current.map.frame.side[E_SIDE] = GMT->current.map.frame.side[N_SIDE] = GMT->current.map.frame.side[W_SIDE] = GMT_AXIS_ALL;
+	GMT->current.map.frame.draw = false;	/* No -B parsed explicitly yet */
 	if (GMT_Parse_Common (API, THIS_MODULE_OPTIONS, options)) Return (API->error);
 	Ctrl = New_Ctrl (GMT);	/* Allocate and initialize a new control structure */
 	if ((error = parse (GMT, Ctrl, options)) != 0) Return (error);

--- a/test/psxy/struct_geo.sh
+++ b/test/psxy/struct_geo.sh
@@ -5,7 +5,7 @@ reg=-R0/10/0/10
 # Must temporarily change GMT_USERDIR to the gallery documentation dir
 export GMT_USERDIR=`gmt --show-sharedir`/../doc_classic/rst/source/gallery/users_contrib_symbols
 
-gmt psbasemap $reg -JM12c -Bwesn -K -P > $ps
+gmt psxy $reg -JM12c -T -K -P > $ps
 
 echo 1 9 60 40 | gmt psxy -R -J -Skgeo-plane/24p -Wthin -O -K >> $ps
 echo 1 9 1 | gmt pstext -R -J -F+f9p,29+jBC -D0/0.5c -O -K >> $ps


### PR DESCRIPTION
While this has typically been done with -B0, it may make more sense to just selected which sides but not specifying any increments.

This addresses #134 