### PR TITLE
Handle large longitude range report

### DIFF
--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -626,6 +626,8 @@ int GMT_grdinfo (void *V_API, int mode, void *args) {
 		if (gmt_M_is_geographic (GMT, GMT_IN)) {
 			if (gmt_grd_is_global(GMT, G->header) || (G->header->wesn[XLO] < 0.0 && G->header->wesn[XHI] <= 0.0))
 				GMT->current.io.geo.range = GMT_IS_GIVEN_RANGE;
+			else if ((G->header->wesn[XHI] - G->header->wesn[XLO]) > 180.0)
+				GMT->current.io.geo.range = GMT_IS_GIVEN_RANGE;
 			else if (G->header->wesn[XLO] < 0.0 && G->header->wesn[XHI] >= 0.0)
 				GMT->current.io.geo.range = GMT_IS_M180_TO_P180_RANGE;
 			else


### PR DESCRIPTION
We failed for cases of longitude range less than global but over 180.  For instance, a grid with west = -9 and east = 191 ended up being reported as -9/-169 and not -9/191.

Should fix #138 