### PR TITLE
Add new option to change longitude range for geographic grids

### DIFF
--- a/doc_classic/rst/source/grdedit.rst
+++ b/doc_classic/rst/source/grdedit.rst
@@ -18,6 +18,7 @@ Synopsis
 [ |-E|\ [**a**\ \|\ **h**\ \|\ **l**\ \|\ **r**\ \|\ **t**\ \|\ **v**] ]
 [ |-G|\ *outgrid* ]
 [ |-J|\ *parameters* ]
+[ |-L|\ [**-**\ \|\ **+**\ ] ]
 [ |-N|\ *table* ]
 [ |SYN_OPT-R| ]
 [ |-S| ] [ |-T| ]
@@ -94,6 +95,14 @@ Optional Arguments
 .. |Add_-J| replace:: Use the **-J** syntax to save the georeferencing info as CF-1 compliant
     metadata in netCDF grids. This metadata will be recognized by GDAL.
 .. include:: explain_-J.rst_
+
+.. _-L:
+
+**-L**\ [**-**\ \|\ **+**\ ]
+    Adjust the longitude values in the grid (only applies to geographic grids).  By default we will
+    try to adjust *west* and *east* so that *west* >= -180 or *east* <= +180, but this depends on
+    the range of the longitudes. Append **-** to force negative longitude values and **+** to
+    force positive longitude values.
 
 .. _-N:
 
@@ -189,6 +198,12 @@ the rotated grid to a new file, run
    ::
 
     gmt grdedit oblique.nc -El -Goblique_rot.nc
+
+To ensure that the grid depths.nc only has positive longitude values, run
+
+   ::
+
+    gmt grdedit depths.nc -L+
 
 See Also
 --------

--- a/doc_modern/rst/source/grdedit.rst
+++ b/doc_modern/rst/source/grdedit.rst
@@ -18,6 +18,7 @@ Synopsis
 [ |-E|\ [**a**\ \|\ **h**\ \|\ **l**\ \|\ **r**\ \|\ **t**\ \|\ **v**] ]
 [ |-G|\ *outgrid* ]
 [ |-J|\ *parameters* ]
+[ |-L|\ [**-**\ \|\ **+**\ ] ]
 [ |-N|\ *table* ]
 [ |SYN_OPT-R| ]
 [ |-S| ] [ |-T| ]
@@ -94,6 +95,14 @@ Optional Arguments
 .. |Add_-J| replace:: Use the **-J** syntax to save the georeferencing info as CF-1 compliant
     metadata in netCDF grids. This metadata will be recognized by GDAL.
 .. include:: explain_-J.rst_
+
+.. _-L:
+
+**-L**\ [**-**\ \|\ **+**\ ]
+    Adjust the longitude values in the grid (only applies to geographic grids).  By default we will
+    try to adjust *west* and *east* so that *west* >= -180 or *east* <= +180, but this depends on
+    the range of the longitudes. Append **-** to force negative longitude values and **+** to
+    force positive longitude values.
 
 .. _-N:
 
@@ -189,6 +198,12 @@ the rotated grid to a new file, run
    ::
 
     gmt grdedit oblique.nc -El -Goblique_rot.nc
+
+To ensure that the grid depths.nc only has positive longitude values, run
+
+   ::
+
+    gmt grdedit depths.nc -L+
 
 See Also
 --------

--- a/src/grdedit.c
+++ b/src/grdedit.c
@@ -64,6 +64,10 @@ struct GRDEDIT_CTRL {
 		bool active;
 		char *file;
 	} G;
+	struct L {	/* -L[-|+] */
+		bool active;
+		int mode;
+	} L;
 	struct N {	/* N<xyzfile> */
 		bool active;
 		char *file;
@@ -99,7 +103,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s <grid> [-A] [-C] [%s]\n", name, GMT_GRDEDIT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-E[a|h|l|r|t|v]] [-G<outgrid>] [-N<table>] [%s] [-S] [-T]\n", GMT_Rgeo_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-E[a|h|l|r|t|v]] [-G<outgrid>] [-L[-|+]] [-N<table>] [%s] [-S] [-T]\n", GMT_Rgeo_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s]\n\n", GMT_V_OPT, GMT_bi_OPT, GMT_di_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -118,6 +122,10 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t  v Flip grid top-to-bottom (as grdmath FLIPUD).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-E Transpose the entire grid (this will exchange x and y).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Specify new output grid file [Default updates given grid file].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-L Shift the grid\'s longitude range (geographic grids only):\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     -L- Adjust <west>/<east> so <east> <= 0\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     -L+ Adjust <west>/<east> so <west> >= 0\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Default adjusts <west>/<east> <west> >= -180 or <east> <= +180\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N <table> has new xyz values to replace existing grid nodes.\n");
 	GMT_Option (API, "R");
 	GMT_Message (API, GMT_TIME_NONE, "\t-S For global grids of 360 degree longitude range.\n");
@@ -182,6 +190,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDEDIT_CTRL *Ctrl, struct GMT
 					Ctrl->G.file = strdup (opt->arg);
 				else
 					n_errors++;
+				break;
+			case 'L':	/* Rotate w/e */
+				Ctrl->L.active = true;
+				if (opt->arg[0] == '-') Ctrl->L.mode = -1;
+				else if (opt->arg[0] == '+') Ctrl->L.mode = +1;
 				break;
 			case 'N':	/* Replace nodes */
 				if ((Ctrl->N.active = gmt_check_filearg (GMT, 'N', opt->arg, GMT_IN, GMT_IS_DATASET)))
@@ -474,6 +487,38 @@ int GMT_grdedit (void *V_API, int mode, void *args) {
 		}
 		G->data = save_grid_pointer;
 		gmt_M_free (GMT, a_tr);
+	}
+	else if (Ctrl->L.active) {	/* Wrap the longitude boundaries */
+		double wesn[4];
+		
+		if (GMT_End_IO (API, GMT_IN, 0) != GMT_NOERROR) {	/* Disables further data input */
+			Return (API->error);
+		}
+		gmt_M_memcpy (wesn, G->header->wesn, 4, double);	/* Copy */
+		if (Ctrl->L.mode == -1) {
+			while (G->header->wesn[XHI] > 0.0) G->header->wesn[XLO] -= 360.0, G->header->wesn[XHI] -= 360.0;
+		}
+		else if (Ctrl->L.mode == +1) {
+			while (G->header->wesn[XLO] < 0.0) G->header->wesn[XLO] += 360.0, G->header->wesn[XHI] += 360.0;
+		}
+		else {	/* Aim for a reasonable w/e range */
+			if (G->header->wesn[XHI] < -180.0) G->header->wesn[XLO] += 360.0, G->header->wesn[XHI] += 360.0;
+			if (G->header->wesn[XLO] < -180.0 && (G->header->wesn[XHI] + 360.0) <= 180.0) G->header->wesn[XLO] += 360.0, G->header->wesn[XHI] += 360.0;
+			if (G->header->wesn[XLO] >  360.0) G->header->wesn[XLO] -= 360.0, G->header->wesn[XHI] -= 360.0;
+			if (G->header->wesn[XHI] >  180.0 && (G->header->wesn[XLO] - 360.0) >= -180.0) G->header->wesn[XLO] -= 360.0, G->header->wesn[XHI] -= 360.0;
+		}
+		if (doubleAlmostEqual (G->header->wesn[XLO], wesn[XLO])) {
+			GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Change region in file %s from %g/%g/%g/%g to %g/%g/%g/%g\n", out_file,
+				G->header->wesn[XLO], G->header->wesn[XHI], G->header->wesn[YLO], G->header->wesn[YHI],
+				wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI]);
+		}
+		else {
+			GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Region in file remains unchanged: %g/%g/%g/%g\n", out_file,
+				G->header->wesn[XLO], G->header->wesn[XHI], G->header->wesn[YLO], G->header->wesn[YHI]);
+		}
+		if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, Ctrl->G.active ? GMT_CONTAINER_AND_DATA : GMT_CONTAINER_ONLY, NULL, out_file, G) != GMT_NOERROR) {
+			Return (API->error);
+		}
 	}
 	else {	/* Change the domain boundaries */
 		if (GMT_End_IO (API, GMT_IN, 0) != GMT_NOERROR) {	/* Disables further data input */


### PR DESCRIPTION
Basically, the new option -L will set a reasonable longitude range but -L- and -L+ can force completely negative or positive longitudes, respectively.

This addresses http://gmt.soest.hawaii.edu/boards/1/topics/7646?r=7696#message-7696 on the old wiki site.