### PR TITLE
Fix a few backport issues

### DIFF
--- a/src/grdfilter_mt.c
+++ b/src/grdfilter_mt.c
@@ -1000,7 +1000,7 @@ int GMT_grdfilter (void *V_API, int mode, void *args)
 	if (GMT_n_multiples > 0) GMT_Report (API, GMT_MSG_VERBOSE, "Warning: %d multiple modes found by the mode filter\n", GMT_n_multiples);
 
 	if (Ctrl->F.highpass) {
-		if (GMT->common.R.active[RSET] || GMT->common.R.active[ISET] || GMT->common.r.active) {	/* Must resample result so grids are coregistered */
+		if (GMT->common.R.active[RSET] || GMT->common.R.active[ISET] || GMT->common.R.active[GSET]) {	/* Must resample result so grids are coregistered */
 			char in_string[GMT_STR16], out_string[GMT_STR16], cmd[GMT_LEN256];
 			/* Here we low-passed filtered onto a coarse grid but to get high-pass we must sample the low-pass result at the original resolution */
 			/* Create a virtual file for the low-pass filtered grid */

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -762,7 +762,7 @@ int GMT_pscoast (void *V_API, int mode, void *args) {
 	}
 	else if (Ctrl->M.active && !GMT->common.J.active)	/* Set fake linear projection */
 		gmt_parse_common_options (GMT, "J", 'J', "x1d");
-	else if (GMT->common.J.active && gmt_M_is_cartesian (GMT, GMT_IN)) {	/* Gave -J but forgot the "d" */
+	else if (GMT->common.J.active && !gmt_M_is_geographic (GMT, GMT_IN)) {	/* Gave -J but forgot the "d" */
 		gmt_set_geographic (GMT, GMT_IN);
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Switching to -Jx|X...d[/...d] for geographic data\n");
 	}


### PR DESCRIPTION
There were a few things in the 5.4 code that prevented compilation as they referred to macros or variables only available in master.

