### PR TITLE
Add new modifier +e to 1-D array creation option -T to handle rounding

### DIFF
--- a/doc_classic/rst/source/explain_array.rst_
+++ b/doc_classic/rst/source/explain_array.rst_
@@ -24,3 +24,7 @@ geospatial distance unit from the list
 **d**\ egree (arc), **m**\ inute (arc), **s**\ econd (arc), m\ **e**\ ter, **f**\ oot, **k**\ ilometer,
 **M**\ iles (statute), **n**\ autical miles, or s\ **u**\ rvey foot.  For Cartesian distances, you must
 use the special unit **c**.
+
+Finally, if you are only providing an increment and obtain *min* and *max* from the data, then it is
+possible (*max* - *min*)/*inc* is not an integer, as required.  If so then *inc* will be adjusted to accordingly.
+Alternatively, append **+e** to keep *inc* exact and adjust *max* instead.

--- a/doc_classic/rst/source/filter1d.rst
+++ b/doc_classic/rst/source/filter1d.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-D|\ *increment* ] [ |-E| ]
 [ |-L|\ *lack\_width* ] [ |-N|\ *t\_col* ] [ |-Q|\ *q\_factor* ]
 [ |-S|\ *symmetry\_factor* ]
-[ |-T|\ [\ *min/max*\ /]\ *inc*\ [**+a**\ \|\ **n**] \|\ |-T|\ *file*\ \|\ *list* ]
+[ |-T|\ [\ *min/max*\ /]\ *inc*\ [**+e**\ \|\ **+a**\ \|\ **n**] \|\ |-T|\ *file*\ \|\ *list* ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
@@ -138,7 +138,7 @@ Optional Arguments
 
 .. _-T:
 
-**-T**\ [\ *min/max*\ /]\ *inc*\ [**+a**\ \|\ **n**] \|\ |-T|\ *file*\ \|\ *list*
+**-T**\ [\ *min/max*\ /]\ *inc*\ [**+e**\ \|\ **+a**\ \|\ **n**] \|\ |-T|\ *file*\ \|\ *list*
     Make evenly spaced time-steps from *min* to *max* by *inc* [Default uses input times].
     For details on array creation, see `Generate 1D Array`_.
 

--- a/doc_modern/rst/source/explain_array.rst_
+++ b/doc_modern/rst/source/explain_array.rst_
@@ -24,3 +24,7 @@ geospatial distance unit from the list
 **d**\ egree (arc), **m**\ inute (arc), **s**\ econd (arc), m\ **e**\ ter, **f**\ oot, **k**\ ilometer,
 **M**\ iles (statute), **n**\ autical miles, or s\ **u**\ rvey foot.  For Cartesian distances, you must
 use the special unit **c**.
+
+Finally, if you are only providing an increment and obtain *min* and *max* from the data, then it is
+possible (*max* - *min*)/*inc* is not an integer, as required.  If so then *inc* will be adjusted to accordingly.
+Alternatively, append **+e** to keep *inc* exact and adjust *max* instead.

--- a/doc_modern/rst/source/filter1d.rst
+++ b/doc_modern/rst/source/filter1d.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-D|\ *increment* ] [ |-E| ]
 [ |-L|\ *lack\_width* ] [ |-N|\ *t\_col* ] [ |-Q|\ *q\_factor* ]
 [ |-S|\ *symmetry\_factor* ]
-[ |-T|\ [\ *min/max*\ /]\ *inc*\ [**+a**\ \|\ **n**] \|\ |-T|\ *file*\ \|\ *list* ]
+[ |-T|\ [\ *min/max*\ /]\ *inc*\ [**+e**\ \|\ **+a**\ \|\ **n**] \|\ |-T|\ *file*\ \|\ *list* ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
@@ -138,7 +138,7 @@ Optional Arguments
 
 .. _-T:
 
-**-T**\ [\ *min/max*\ /]\ *inc*\ [**+a**\ \|\ **n**] \|\ |-T|\ *file*\ \|\ *list*
+**-T**\ [\ *min/max*\ /]\ *inc*\ [**+e**\ \|\ **+a**\ \|\ **n**] \|\ |-T|\ *file*\ \|\ *list*
     Make evenly spaced time-steps from *min* to *max* by *inc* [Default uses input times].
     For details on array creation, see `Generate 1D Array`_.
 

--- a/src/filter1d.c
+++ b/src/filter1d.c
@@ -181,7 +181,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] -F<type><width>[<modifiers>] [-D<increment>] [-E] [-I<ignore_val>]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-L<lack_width>] [-N<t_col>] [-Q<q_factor>] [-S<symmetry>] [-T[<min>/<max>/][-|+]<inc>[<unit>][+n|a]]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t[-L<lack_width>] [-N<t_col>] [-Q<q_factor>] [-S<symmetry>] [-T[<min>/<max>/][-|+]<inc>[<unit>][+e|n|a]]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s] [%s]\n\n",
 		GMT_V_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT, GMT_i_OPT, GMT_o_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
@@ -228,6 +228,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   then no output will be given at this point [Default does not check Symmetry].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-T Make evenly spaced output time steps from <min> to <max> by <inc> [Default uses input times].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +n to indicate <inc> is the number of t-values to produce instead.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   If only <inc< is given, optionally append +e to keep increment exact [Default will adjust to fit range].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   For absolute time filtering, append a valid time unit (%s) to the increment.\n", GMT_TIME_UNITS_DISPLAY);
 	GMT_Message (API, GMT_TIME_NONE, "\t   For spatial filtering with distance computed from the first two columns, specify increment as\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   [-|+][<unit>]<inc>, with - for fast (Flat Earth) or + for slow (ellipsoidal) calculations [great circle].\n");
@@ -384,7 +385,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct FILTER1D_CTRL *Ctrl, struct GM
 	}
 
 	if (Ctrl->T.active)	/* Do this one here since we need Ctrl->N.col to be set first, if selected */
-		n_errors += gmt_parse_array (GMT, 'T', t_arg, &(Ctrl->T.T), GMT_ARRAY_TIME | GMT_ARRAY_DIST, Ctrl->N.col);
+		n_errors += gmt_parse_array (GMT, 'T', t_arg, &(Ctrl->T.T), GMT_ARRAY_TIME | GMT_ARRAY_DIST | GMT_ARRAY_ROUND, Ctrl->N.col);
 	if (Ctrl->N.spatial) Ctrl->T.T.spatial = Ctrl->N.spatial;	/* Obsolete -N settings propagated to -T */
 	if (Ctrl->N.add_col) Ctrl->T.T.add = true;	/* Obsolete -N+a settings propagated to -T */
 	

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -137,7 +137,8 @@ enum GMT_enum_array {
 	GMT_ARRAY_DIST  = 4,
 	GMT_ARRAY_NOINC = 8,
 	GMT_ARRAY_SCALAR = 16,
-	GMT_ARRAY_NOMINMAX = 32};
+	GMT_ARRAY_NOMINMAX = 32,
+	GMT_ARRAY_ROUND = 64};
 
 /*! Handling of swap/no swap in i/o */
 enum GMT_swap_direction {

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -90,6 +90,8 @@ struct GMT_ARRAY {	/* Used by modules that needs to set up 1-D output/bin arrays
 	bool count;	/* true if we got number of items rather than increment */
 	bool add;	/* true if we are asked to add a computed spatial distance column to output */
 	bool reverse;	/* true if we want to reverse the array to give high to low on output */
+	bool round;	/* true if we want to adjust increment to ensure min/max range is a multiple of inc */
+	bool exact_inc;	/* true if we want the increment to be exact and to adjust min/max intstead */
 	bool logarithmic;	/* true if inc = 1,2,3 and we want logarithmic scale */
 	bool logarithmic2;	/* true if inc = integer and we want log2 scale */
 	bool delay[2];	/* true if min and/or max shall be set from data set extremes after read [false] */


### PR DESCRIPTION
When inc is specified and min/max are determined from data there is the chance that (max-min)/inc is NOT an integer, which is required. By default we adjust the increment to fit, while +e changes this to adjust max instead.  This matches the behavior we use for grid setup.

This modification derives from the troubles encountered at http://gmt.soest.hawaii.edu/boards/1/topics/7714.