### PR TITLE
Improve representation of pi fractions

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -3632,6 +3632,7 @@ GMT_LOCAL int gmtinit_parse5_B_option (struct GMT_CTRL *GMT, char *in) {
 
 		if (orig_string[0] == '\0') continue;	/* Got nothing */
 		GMT->current.map.frame.set = true;	/* Got here so we are setting intervals */
+		if (strstr (orig_string, "pi")) GMT->current.map.frame.axis[no].substitute_pi = true;	/* Use pi in formatting labels */
 
 		gmt_M_memset (string, GMT_BUFSIZ, char);
 		strcpy (string, orig_string);	/* Make a copy of string as it gets messed with below */

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -316,7 +316,6 @@ GMT_LOCAL void plot_linear_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL *
 	y_length = GMT->current.proj.rect[YHI] - GMT->current.proj.rect[YLO];
 
 	if (GMT->current.map.frame.draw) {
-
 		/* Temporarily change to square cap so rectangular frames have neat corners */
 		PSL_setlinecap (PSL, PSL_SQUARE_CAP);
 
@@ -4223,6 +4222,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 	bool ortho = false;		/* true if annotations are orthogonal to axes */
 	bool flip = false;		/* true if annotations are inside axes */
 	bool MM_set = false;		/* true after we define the MM PS macro for label offsets */
+	bool save_pi = GMT->current.plot.substitute_pi;
 	double *knots = NULL, *knots_p = NULL;	/* Array pointers with tick/annotation knots, the latter for primary annotations */
 	double x, t_use, text_angle;		/* Misc. variables */
 	struct GMT_FONT font;			/* Annotation font (FONT_ANNOT_PRIMARY or FONT_ANNOT_SECONDARY) */
@@ -4304,6 +4304,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		return;
 	}
 
+	GMT->current.plot.substitute_pi = A->substitute_pi;
 	np = gmtlib_coordinate_array (GMT, val0, val1, &A->item[primary], &knots_p, NULL);	/* Get all the primary tick annotation knots */
 
 	/* Axis items are in order: GMT_ANNOT_UPPER, GMT_ANNOT_LOWER, GMT_TICK_UPPER, GMT_TICK_LOWER, GMT_GRID_UPPER, GMT_GRID_LOWER */
@@ -4426,6 +4427,8 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 	else
 		PSL_comment (PSL, below ? "End of front z-axis\n" : "End of back z-axis\n");
 	PSL_setorigin (PSL, -x0, -y0, 0.0, PSL_INV);
+
+	GMT->current.plot.substitute_pi = save_pi;
 }
 
 void gmt_plot_line (struct GMT_CTRL *GMT, double *x, double *y, unsigned int *pen, uint64_t n, unsigned int mode) {

--- a/src/gmt_project.h
+++ b/src/gmt_project.h
@@ -476,6 +476,7 @@ struct GMT_PLOT_AXIS {		/* Information for one time axis */
 	unsigned int type;		/* GMT_LINEAR, GMT_LOG10, GMT_POW, GMT_TIME */
 	unsigned int special;		/* See gmt_enum_annot values */
 	unsigned int label_mode;	/* 0 = parallel to all axes, 1 = always horizontal on map */
+	bool substitute_pi;		/* True if we need to plot fractions of pi on this axis */
 	struct GMT_PLOT_AXIS_ITEM item[6];	/* see above defines for which is which */
 	double phase;			/* Phase offset for strides: (knot-phase)%interval = 0  */
 	char label[GMT_LEN256];	/* Label of the axis */

--- a/test/psbasemap/radians.ps
+++ b/test/psbasemap/radians.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612 792             
-%%Title: GMT v6.0.0_r19508 [64-bit] Document from psbasemap
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_0270f8e [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Dec 18 17:02:31 2017
+%%CreationDate: Thu Nov  8 17:09:16 2018
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -336,7 +336,9 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ PSL_fnt k get cvx exec
+{ /psl_fnt PSL_fnt k get def
+  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  psl_fnt cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -592,7 +594,9 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  PSL_label_font psl_k get cvx exec
+  /psl_fnt PSL_label_font psl_k get def
+  psl_fnt cvx exec
+  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -635,7 +639,8 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G show
+    psl_label dup sd neg 0 exch G
+    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
     U
 } def
 /PSL_nclip 0 def
@@ -658,13 +663,16 @@ V 0.06 0.06 scale
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_completion {} def
+/PSL_movie_completion {} def
+%PSL_End_Header
+gsave
 0 A
 FQ
 O0
 -3600 PSL_xorig sub PSL_page_xsize 2 div add 1800 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R-12pi/12pi/0/100 -JX6i/7i -P -Bxa4pi -Byaf -K -Xc -Y1.5i
+%@GMT: gmt psbasemap -R-12pi/12pi/0/100 -JX6i/7i -P -Bxa4pi -Byaf -K -Xc -Y1.5i
 %@PROJ: xy -37.69911184 37.69911184 0.00000000 100.00000000 -37.699 37.699 0.000 100.000 +xy
 %GMTBoundingBox: -216 108 432 504
 %%BeginObject PSL_Layer_1
@@ -769,46 +777,46 @@ N 6000 0 M 0 -83 D S
 N 7200 0 M 0 -83 D S
 /PSL_AH0 0
 /MM {neg M} def
-V MU 0 0 M (-) FP 200 F12 (12p) FP pathbbox N 4 1 roll pop pop pop U mx
-V MU 0 0 M (-) FP 200 F12 (8p) FP pathbbox N 4 1 roll pop pop pop U mx
-V MU 0 0 M (-) FP 200 F12 (4p) FP pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (-12) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (-8) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (-4) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
 (0) sh mx
-V MU 0 0 M (+) FP 200 F12 (4p) FP pathbbox N 4 1 roll pop pop pop U mx
-V MU 0 0 M (+) FP 200 F12 (8p) FP pathbbox N 4 1 roll pop pop pop U mx
-V MU 0 0 M (+) FP 200 F12 (12p) FP pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (+4) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (+8) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (+12) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
 def
 /PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
 0 PSL_A0_y MM
-V MU 0 0 M (-) FP 200 F12 (12p) FP pathbbox N pop exch pop add U -2 div 0 G
-(-) Z
-200 F12 (12p) Z
+V MU 0 0 M (-12) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
+(-12) Z
+200 F12 (p) Z
 1200 PSL_A0_y MM
 200 F0
-V MU 0 0 M (-) FP 200 F12 (8p) FP pathbbox N pop exch pop add U -2 div 0 G
-(-) Z
-200 F12 (8p) Z
+V MU 0 0 M (-8) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
+(-8) Z
+200 F12 (p) Z
 2400 PSL_A0_y MM
 200 F0
-V MU 0 0 M (-) FP 200 F12 (4p) FP pathbbox N pop exch pop add U -2 div 0 G
-(-) Z
-200 F12 (4p) Z
+V MU 0 0 M (-4) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
+(-4) Z
+200 F12 (p) Z
 3600 PSL_A0_y MM
 200 F0
 (0) bc Z
 4800 PSL_A0_y MM
-V MU 0 0 M (+) FP 200 F12 (4p) FP pathbbox N pop exch pop add U -2 div 0 G
-(+) Z
-200 F12 (4p) Z
+V MU 0 0 M (+4) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
+(+4) Z
+200 F12 (p) Z
 6000 PSL_A0_y MM
 200 F0
-V MU 0 0 M (+) FP 200 F12 (8p) FP pathbbox N pop exch pop add U -2 div 0 G
-(+) Z
-200 F12 (8p) Z
+V MU 0 0 M (+8) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
+(+8) Z
+200 F12 (p) Z
 7200 PSL_A0_y MM
 200 F0
-V MU 0 0 M (+) FP 200 F12 (12p) FP pathbbox N pop exch pop add U -2 div 0 G
-(+) Z
-200 F12 (12p) Z
+V MU 0 0 M (+12) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
+(+12) Z
+200 F12 (p) Z
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 8400 T
 25 W
@@ -826,46 +834,46 @@ N 7200 0 M 0 83 D S
 /PSL_AH0 0
 /MM {M} def
 200 F0
-V MU 0 0 M (-) FP 200 F12 (12p) FP pathbbox N 4 1 roll pop pop pop U mx
-V MU 0 0 M (-) FP 200 F12 (8p) FP pathbbox N 4 1 roll pop pop pop U mx
-V MU 0 0 M (-) FP 200 F12 (4p) FP pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (-12) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (-8) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (-4) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
 (0) sh mx
-V MU 0 0 M (+) FP 200 F12 (4p) FP pathbbox N 4 1 roll pop pop pop U mx
-V MU 0 0 M (+) FP 200 F12 (8p) FP pathbbox N 4 1 roll pop pop pop U mx
-V MU 0 0 M (+) FP 200 F12 (12p) FP pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (+4) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (+8) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (+12) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
 def
 /PSL_A0_y PSL_A0_y 83 add def
 0 PSL_A0_y MM
-V MU 0 0 M (-) FP 200 F12 (12p) FP pathbbox N pop exch pop add U -2 div 0 G
-(-) Z
-200 F12 (12p) Z
+V MU 0 0 M (-12) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
+(-12) Z
+200 F12 (p) Z
 1200 PSL_A0_y MM
 200 F0
-V MU 0 0 M (-) FP 200 F12 (8p) FP pathbbox N pop exch pop add U -2 div 0 G
-(-) Z
-200 F12 (8p) Z
+V MU 0 0 M (-8) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
+(-8) Z
+200 F12 (p) Z
 2400 PSL_A0_y MM
 200 F0
-V MU 0 0 M (-) FP 200 F12 (4p) FP pathbbox N pop exch pop add U -2 div 0 G
-(-) Z
-200 F12 (4p) Z
+V MU 0 0 M (-4) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
+(-4) Z
+200 F12 (p) Z
 3600 PSL_A0_y MM
 200 F0
 (0) bc Z
 4800 PSL_A0_y MM
-V MU 0 0 M (+) FP 200 F12 (4p) FP pathbbox N pop exch pop add U -2 div 0 G
-(+) Z
-200 F12 (4p) Z
+V MU 0 0 M (+4) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
+(+4) Z
+200 F12 (p) Z
 6000 PSL_A0_y MM
 200 F0
-V MU 0 0 M (+) FP 200 F12 (8p) FP pathbbox N pop exch pop add U -2 div 0 G
-(+) Z
-200 F12 (8p) Z
+V MU 0 0 M (+8) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
+(+8) Z
+200 F12 (p) Z
 7200 PSL_A0_y MM
 200 F0
-V MU 0 0 M (+) FP 200 F12 (12p) FP pathbbox N pop exch pop add U -2 div 0 G
-(+) Z
-200 F12 (12p) Z
+V MU 0 0 M (+12) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
+(+12) Z
+200 F12 (p) Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 -8400 T
@@ -877,7 +885,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: psxy -R-12pi/12pi/0/100 -JX6i/7i -O -K -W2p cos.txt
+%@GMT: gmt psxy -R-12pi/12pi/0/100 -JX6i/7i -O -K -W2p cos.txt
 %@PROJ: xy -37.69911184 37.69911184 0.00000000 100.00000000 -37.699 37.699 0.000 100.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -1048,7 +1056,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: psscale -R-12pi/12pi/0/100 -JX6i/7i -DjRM+w4i/0.2i+o0.5i/0 -Ct.cpt -Bxapi -O -K
+%@GMT: gmt psscale -R-12pi/12pi/0/100 -JX6i/7i -DjRM+w4i/0.2i+o0.5i/0 -Ct.cpt -Bxapi -O -K
 %@PROJ: xy -37.69911184 37.69911184 0.00000000 100.00000000 -37.699 37.699 0.000 100.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -1142,7 +1150,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: psscale -R-12pi/12pi/0/100 -JX6i/7i -DJCB+w5i/0.2i+o0/0.5i -Ct.cpt -Bxapi2 -O
+%@GMT: gmt psscale -R-12pi/12pi/0/100 -JX6i/7i -DJCB+w5i/0.2i+o0/0.5i -Ct.cpt -Bxapi2 -O
 %@PROJ: xy -37.69911184 37.69911184 0.00000000 100.00000000 -37.699 37.699 0.000 100.000 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -1185,9 +1193,9 @@ N 6000 0 M 0 -83 D S
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V MU 0 0 M (-) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
-V MU 0 0 M (-) FP 200 F12 (p/2) FP pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (-) FP 200 F12 (p) FP 200 F0 (/2) FP pathbbox N 4 1 roll pop pop pop U mx
 (0) sh mx
-V MU 0 0 M (+) FP 200 F12 (p/2) FP pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (+) FP 200 F12 (p) FP 200 F0 (/2) FP pathbbox N 4 1 roll pop pop pop U mx
 V MU 0 0 M (+) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
 def
 /PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
@@ -1197,16 +1205,18 @@ V MU 0 0 M (-) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
 200 F12 (p) Z
 1500 PSL_A0_y MM
 200 F0
-V MU 0 0 M (-) FP 200 F12 (p/2) FP pathbbox N pop exch pop add U -2 div 0 G
+V MU 0 0 M (-) FP 200 F12 (p) FP 200 F0 (/2) FP pathbbox N pop exch pop add U -2 div 0 G
 (-) Z
-200 F12 (p/2) Z
+200 F12 (p) Z
+200 F0 (/2) Z
 3000 PSL_A0_y MM
 200 F0
 (0) bc Z
 4500 PSL_A0_y MM
-V MU 0 0 M (+) FP 200 F12 (p/2) FP pathbbox N pop exch pop add U -2 div 0 G
+V MU 0 0 M (+) FP 200 F12 (p) FP 200 F0 (/2) FP pathbbox N pop exch pop add U -2 div 0 G
 (+) Z
-200 F12 (p/2) Z
+200 F12 (p) Z
+200 F0 (/2) Z
 6000 PSL_A0_y MM
 200 F0
 V MU 0 0 M (+) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
@@ -1235,6 +1245,10 @@ U
 0 setlinecap
 -600 840 T
 %%EndObject
+
+grestore
+PSL_movie_completion /PSL_movie_completion {} def
+%PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage


### PR DESCRIPTION
The original algorithm only dealt with certain fractions and only if <= 2 pi.  Now we handle anything value with a granularity up to multiples of 1/20th of pi, and we also ensure this labeling is only applied on the axes that requested increments in pi.

*Fixes #172 , but note you probably want to use -Bpxa1pi2 to avoid pi on the y-axis as well.