### PR TITLE
Let grdvector -Vl report some statistics on scaled vector length

### DIFF
--- a/doc_classic/rst/source/grdvector.rst
+++ b/doc_classic/rst/source/grdvector.rst
@@ -138,7 +138,8 @@ Optional Arguments
     which are projected to plot dimensions.  These are geo-vectors that follow
     great circle paths and their lengths are affected by the map projection and their
     coordinates.  Finally, use **-Si** if it is simpler to give the reciprocal scale in
-    measurement unit per data unit or km per data unit.
+    measurement unit per data unit or km per data unit.  To report the minimum, maximum,
+    and mean scaled vector length, use **-Vl**.
 
 .. _-T:
 

--- a/doc_modern/rst/source/grdvector.rst
+++ b/doc_modern/rst/source/grdvector.rst
@@ -126,7 +126,8 @@ Optional Arguments
     which are projected to plot dimensions.  These are geo-vectors that follow
     great circle paths and their lengths are affected by the map projection and their
     coordinates.  Finally, use **-Si** if it is simpler to give the reciprocal scale in
-    measurement unit per data unit or km per data unit.
+    measurement unit per data unit or km per data unit.  To report the minimum, maximum,
+    and mean scaled vector length, use **-Vl**.
 
 .. _-T:
 


### PR DESCRIPTION
This is useful for knowing what threshold length might be set via +n<threshold>.  Currently the user would not necessarily know that. With -Vl we print the min, max, and mean scaled vector lengths.  For geographic geo-vectors these are in km while for Cartesian vectors they are in the selected length unit (inch, cm, points).
