### PR TITLE
Finalize all character adjustments for UTF-8

### DIFF
--- a/doc_classic/rst/source/GMT_Docs.rst
+++ b/doc_classic/rst/source/GMT_Docs.rst
@@ -3150,6 +3150,10 @@ you must use the full octal code):
 | @s       | ß          | @i       | í          |
 +----------+------------+----------+------------+
 
+However, if your input text contains UTF-8 code characters (e.g., ü, Î)
+and you select the ISOLatin1+ character encoding then GMT will substitute
+the correct PostScript octal codes for you automatically.
+
 PostScript fonts used in GMT may be re-encoded to include several
 accented characters used in many European languages. To access these,
 you must specify the full octal code \\xxx allowed for

--- a/doc_modern/rst/source/GMT_Docs.rst
+++ b/doc_modern/rst/source/GMT_Docs.rst
@@ -3090,6 +3090,10 @@ you must use the full octal code):
 | @s       | ß          | @i       | í          |
 +----------+------------+----------+------------+
 
+However, if your input text contains UTF-8 code characters (e.g., ü, Î)
+and you select the ISOLatin1+ character encoding then GMT will substitute
+the correct PostScript octal codes for you automatically.
+
 PostScript fonts used in GMT may be re-encoded to include several
 accented characters used in many European languages. To access these,
 you must specify the full octal code \\xxx allowed for

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -649,9 +649,11 @@ void psl_fix_utf8 (struct PSL_CTRL *PSL, char *string) {
 				strcat (out, tmp);
 			}
 		}
-		else if ((unsigned char)(string[k]) == 0305) {    /* Found Ydieresis, ae, AE, the S,Z,s,z carons */
+		else if ((unsigned char)(string[k]) == 0305) {    /* Found Ydieresis, ae, AE, L&l-slash and the S,Z,s,z carons */
 			k++;	/* Skip the control code */
-			switch ((unsigned char)string[k]) {	/* These 7 chars are placed all over the table so must have individual cases */
+			switch ((unsigned char)string[k]) {	/* These 9 chars are placed all over the table so must have individual cases */
+				case 0201: use = 0203; break;	/* Lslash */
+				case 0202: use = 0213; break;	/* lslash */
 				case 0222: use = 0200; break;	/* ae */
 				case 0223: use = 0210; break;	/* AE */
 				case 0240: use = 0206; break;	/* Scaron */

--- a/test/pstext/utf8.ps
+++ b/test/pstext/utf8.ps
@@ -5,7 +5,7 @@
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sat Dec  1 16:57:34 2018
+%%CreationDate: Sat Dec  1 17:20:24 2018
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -688,7 +688,7 @@ P
 PSL_clip N
 1080 9072 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
-(\206 \212 \177 \37 \200 \210 \211) bl Z
+(\206 \212 \177 \37 \200 \210 \211 \203 \213) bl Z
 1080 7992 M (\300 \301 \302 \303 \304 \305 \306 \307) bl Z
 1080 6912 M (\310 \311 \312 E \314 \315 \316 \317) bl Z
 1080 5832 M (\320 \321 \322 \323 \324 \325 \326 \327) bl Z

--- a/test/pstext/utf8.ps
+++ b/test/pstext/utf8.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_08d25a9-dirty [64-bit] Document from pstext
+%%Title: GMT v6.0.0_a675167 [64-bit] Document from pstext
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Nov 29 20:08:14 2018
+%%CreationDate: Sat Dec  1 16:57:34 2018
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -672,54 +672,58 @@ O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -R-1/6/0/9 -Jx1i -P -B0 -F+f24p+jBL
-%@PROJ: xy -1.00000000 6.00000000 0.00000000 9.00000000 -1.000 6.000 0.000 9.000 +xy
-%GMTBoundingBox: 72 72 504 648
+%@GMT: gmt pstext -R-1/6/0.6/9.6 -Jx0.9i -P -B0 '-B+tUTF-8 via ISOLatin1+' -F+f24p+jBL --PS_CHAR_ENCODING=ISOLatin1+
+%@PROJ: xy -1.00000000 6.00000000 0.60000000 9.60000000 -1.000 6.000 0.600 9.600 +xy
+%GMTBoundingBox: 72 72 453.6 583.2
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 clipsave
 0 0 M
-8400 0 D
-0 10800 D
--8400 0 D
+7560 0 D
+0 9720 D
+-7560 0 D
 P
 PSL_clip N
-1200 9600 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+1080 9072 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
-(\300\301\302\303\304\305\306\307) bl Z
-1200 8400 M (\310\311\312E\314\315\316\317) bl Z
-1200 7200 M (\320\321\322\323\324\325\326\327\211) bl Z
-1200 6000 M (\330\331\332\333\334\335\336\337) bl Z
-1200 4800 M (\340\341\342\343\344\345\346\347) bl Z
-1200 3600 M (\350\351\352e\354\355\356\357) bl Z
-1200 2400 M (\360\361\362\363\364\365\366\367) bl Z
-1200 1200 M (\370\371\372\373\374\375\376\377) bl Z
+(\206 \212 \177 \37 \200 \210 \211) bl Z
+1080 7992 M (\300 \301 \302 \303 \304 \305 \306 \307) bl Z
+1080 6912 M (\310 \311 \312 E \314 \315 \316 \317) bl Z
+1080 5832 M (\320 \321 \322 \323 \324 \325 \326 \327) bl Z
+1080 4752 M (\330 \331 \332 \333 \334 \335 \336 \337) bl Z
+1080 3672 M (\340 \341 \342 \343 \344 \345 \346 \347) bl Z
+1080 2592 M (\350 \351 \352 e \354 \355 \356 \357) bl Z
+1080 1512 M (\360 \361 \362 \363 \364 \365 \366 \367) bl Z
+1080 432 M (\370 \371 \372 \373 \374 \375 \376 \377) bl Z
 PSL_cliprestore
 25 W
 2 setlinecap
-N 0 10800 M 0 -10800 D S
+N 0 9720 M 0 -9720 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-8400 0 T
-N 0 10800 M 0 -10800 D S
+7560 0 T
+N 0 9720 M 0 -9720 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--8400 0 T
-N 0 0 M 8400 0 D S
+-7560 0 T
+N 0 0 M 7560 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 10800 T
-N 0 0 M 8400 0 D S
+0 9720 T
+N 0 0 M 7560 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -10800 T
+0 -9720 T
 0 setlinecap
+/PSL_H_y PSL_L_y PSL_LH add 233 add def
+3780 9720 PSL_H_y add M
+(UTF-8 via ISOLatin1) bc Z
 %%EndObject
 
 grestore

--- a/test/pstext/utf8.sh
+++ b/test/pstext/utf8.sh
@@ -4,7 +4,7 @@
 
 ps=utf8.ps
 gmt pstext -R-1/6/0.6/9.6 -Jx0.9i -P -B0 -B+t"UTF-8 via ISOLatin1+" -F+f24p+jBL --PS_CHAR_ENCODING=ISOLatin1+ << EOF > utf8.ps
-0 9 Š Ž š ž Œ œ Ÿ
+0 9 Š Ž š ž Œ œ Ÿ Ł ł
 0 8 À Á Â Ã Ä Å Æ Ç
 0 7 È É Ê E Ì Í Î Ï
 0 6 Ð Ñ Ò Ó Ô Õ Ö ×

--- a/test/pstext/utf8.sh
+++ b/test/pstext/utf8.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 # Test that our UTF8 to PostScript code works.  We are using all the
-# codes in the ISOLatin1+ table.  Not yet covered are what seems to
-# be Serbian S, Z with inverted hat
+# letter codes in the ISOLatin1+ table.
 
 ps=utf8.ps
-gmt pstext -R-1/6/0/9 -Jx1i -P  -B0 -F+f24p+jBL --PS_CHAR_ENCODING=ISOLatin1+ << EOF > utf8.ps
-0 8 ÀÁÂÃÄÅÆÇ
-0 7 ÈÉÊEÌÍÎÏ
-0 6 ÐÑÒÓÔÕÖ×Ÿ
-0 5 ØÙÚÛÜÝÞß
-0 4 àáâãäåæç
-0 3 èéêeìíîï
-0 2 ðñòóôõö÷
-0 1 øùúûüýþÿ
+gmt pstext -R-1/6/0.6/9.6 -Jx0.9i -P -B0 -B+t"UTF-8 via ISOLatin1+" -F+f24p+jBL --PS_CHAR_ENCODING=ISOLatin1+ << EOF > utf8.ps
+0 9 Š Ž š ž Œ œ Ÿ
+0 8 À Á Â Ã Ä Å Æ Ç
+0 7 È É Ê E Ì Í Î Ï
+0 6 Ð Ñ Ò Ó Ô Õ Ö ×
+0 5 Ø Ù Ú Û Ü Ý Þ ß
+0 4 à á â ã ä å æ ç
+0 3 è é ê e ì í î ï
+0 2 ð ñ ò ó ô õ ö ÷
+0 1 ø ù ú û ü ý þ ÿ
 EOF


### PR DESCRIPTION
This PR includes the 7 missing characters not handled previously: ae, AE, Ydieresis, and the s,z,S,Z carons.  With this, all European letters present in the ISOLatin1+ encoding will be automatically converted from UTF-8 to their equivalent octal codes in our  character encoding tables.
