### PR TITLE
Reduce chance of PostScript clipping if exceeding canvas in modern mode

### DIFF
--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -81,8 +81,8 @@
 #define GMT_CONTROLLER	0	/* func_level of controlling process (gmt.c or external API) */
 #define GMT_TOP_MODULE	1	/* func_level of top-level module being called */
 
-#define GMT_PAPER_DIM		32767	/* Upper limit on PostScript paper size under modern mode */
-#define GMT_PAPER_MARGIN	5	/* Default paper margin in inches under modern mode */
+#define GMT_PAPER_DIM		32767	/* Upper limit on PostScript paper size under modern mode, in points (~11.6 meters) */
+#define GMT_PAPER_MARGIN	40	/* Default paper margin under modern mode, in inches (~1 meter) */
 
 /*! whether to ignore/read/write history file gmt.history */
 enum GMT_enum_history {

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -6333,7 +6333,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 				GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Also changing to landscape orientation based on plot dimensions but again not sure.\n");
 			}
 		}
-		if (!wants_PS && !O_active) {	/* Not desiring PS output so we can add safety margin of 5 inch for initial layer */
+		if (!wants_PS && !O_active) {	/* Not desiring PS output so we can add safety margin of GMT_PAPER_MARGIN inches for initial layer */
 			if (!(GMT->common.X.active || GMT->common.Y.active))
 				GMT->current.setting.map_origin[GMT_X] = GMT->current.setting.map_origin[GMT_Y] = GMT_PAPER_MARGIN;
 		}


### PR DESCRIPTION
Modern mode allows the max 32767x32767 point canvase (~11.6 x  11.6 m) but we only set the initial origin at (5 inch, 5 inch).  If users are not careful and use -X -Y with negative values they may be plotting outside the canvas and that is lost.  We now move to (40,40) inches instead.

Fixes #195.
