### PR TITLE
Need to determine octal codes for minus and hyphen

### DIFF
--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -53,7 +53,7 @@ struct DATUM {
 
 struct GMT_ENCODING {
 	char name[GMT_LEN64];
-	int code[5]; /* Codes for symbols we print. */
+	int code[8]; /* Codes for 7 symbols we plot but whose code depends on character set (ring, degree, colon, squote, dquote, minus, hyphen). */
 };
 
 /*! Holds all variables directly controlled by GMT Default parameters */
@@ -148,7 +148,7 @@ struct GMT_DEFAULTS {
 	struct GMT_PEN map_tick_pen[2];		/* Pen attributes for primary and secondary tickmarks [thinner,black] */
 	char map_frame_axes[6];			/* Which axes to draw and annotate ["WESNZ"]  */
 	char map_annot_ortho[6];		/* Which axes have orthogonal annotations in linear projections ["we"] */
-	enum GMT_enum_symbol { gmt_none = -1, gmt_ring, gmt_degree, gmt_colon, gmt_squote, gmt_dquote, gmt_lastsym } map_degree_symbol;
+	enum GMT_enum_symbol { gmt_none = -1, gmt_ring, gmt_degree, gmt_colon, gmt_squote, gmt_dquote, gmt_minus, gmt_hyphen, gmt_lastsym } map_degree_symbol;
 	/* PROJ group */
 	double proj_scale_factor;		/* Central mapscale factor, typically 0.9996-1 (or -1 for default action) */
 	unsigned int proj_ellipsoid;		/* Which ellipsoid to use [0 = GRS 80] */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -4737,7 +4737,10 @@ GMT_LOCAL int gmtinit_scanf_epoch (struct GMT_CTRL *GMT, char *s, int64_t *rata_
 
 /*! Scan a PostScript encoding string and look for degree, ring and other special encodings.
  * Use Brute Force and Ignorance.
+ * Scanning to find the codes for 7 symbols we plot but whose code depends on character set
+ * (ring, degree, colon, squote, dquote, minus, hyphen).
  */
+
 GMT_LOCAL int gmtinit_load_encoding (struct GMT_CTRL *GMT) {
 	char symbol[GMT_LEN256] = {""};
 	unsigned int code = 0, pos = 0;
@@ -4764,6 +4767,10 @@ GMT_LOCAL int gmtinit_load_encoding (struct GMT_CTRL *GMT) {
 			enc->code[gmt_squote] = code;
 		else if (strcmp (symbol, "colon") == 0)
 			enc->code[gmt_colon] = code;
+		else if (strcmp (symbol, "minus") == 0)
+			enc->code[gmt_minus] = code;
+		else if (strcmp (symbol, "hyphen") == 0)
+			enc->code[gmt_hyphen] = code;
 		code++;
 	}
 

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -6360,7 +6360,7 @@ void gmtlib_plot_C_format (struct GMT_CTRL *GMT) {
 
 	if (S->decimal) {	/* Plain decimal degrees */
 		int len;
-		 /* here we depend on FORMAT_FLOAT_OUT begin set.  This will not be true when FORMAT_GEO_MAP is parsed but will be
+		 /* Here we depend on FORMAT_FLOAT_OUT being set.  This will not be true when FORMAT_GEO_MAP is parsed but will be
 		  * handled at the end of gmt_begin.  For gmtset and --PAR later we will be OK as well. */
 		if (!GMT->current.setting.format_float_out[0]) return; /* Quietly return and deal with this later in gmt_begin */
 


### PR DESCRIPTION
Like our search for the octal code for ring and degree,, we need to also search for minus and hyphen.  This lays the groundwork for applying a proper minus later (to be implemented).

Next steps are to insert the proper code for minus when plotting negative numbers and to replace  '-' in user strings with the proper hyphen char code.