### PR TITLE
Set degree symbol as default, handle hyphens and minus

### DIFF
--- a/doc_classic/examples/anim01/anim_01.sh
+++ b/doc_classic/examples/anim01/anim_01.sh
@@ -20,7 +20,7 @@ ps=${name}.ps
 angle_step=`gmt math -Q 360 ${n_frames} DIV =`
 angle_inc=`gmt math -Q ${angle_step} 10 DIV =`
 gmt psbasemap -R0/360/-1.2/1.6 -JX3.5i/1.65i -P -K -X0.35i -Y0.25i \
-	-BWSne+glightgreen -Bxa90g90f30+u\\312 -Bya0.5f0.1g1 \
+	-BWSne+glightgreen -Bxa90g90f30+u@. -Bya0.5f0.1g1 \
 	--PS_MEDIA=${width}x${height} --FONT_ANNOT_PRIMARY=9p > $$.map.ps
 # 2. Main frame loop
 mkdir -p $$

--- a/doc_classic/examples/ex30/example_30.bat
+++ b/doc_classic/examples/ex30/example_30.bat
@@ -9,7 +9,7 @@ echo GMT EXAMPLE 30
 set ps=example_30.ps
 gmt set PS_CHAR_ENCODING	Standard+
 
-gmt psbasemap -R0/360/-1.25/1.75 -JX8i/6i -Bx90f30+u"\312" -By1g10 -BWS+t"Two Trigonometric Functions" -K --MAP_FRAME_TYPE=graph --MAP_VECTOR_SHAPE=0.5 > %ps%
+gmt psbasemap -R0/360/-1.25/1.75 -JX8i/6i -Bx90f30+u@. -By1g10 -BWS+t"Two Trigonometric Functions" -K --MAP_FRAME_TYPE=graph --MAP_VECTOR_SHAPE=0.5 > %ps%
 
 REM Draw sine an cosine curves
 
@@ -23,7 +23,7 @@ gmt psxy -R -J -O -K -W0.5p,- tmp >> %ps%
 
 echo 360 1 18p,Times-Roman RB x = cos(@%%12%%a@%%%%) > tmp
 echo 360 0 18p,Times-Roman RB y = sin(@%%12%%a@%%%%) >> tmp
-echo 120 -1.25 14p,Times-Roman LB 120\312 >> tmp
+echo 120 -1.25 14p,Times-Roman LB 120@. >> tmp
 echo 370 -1.35 24p,Symbol LT a >> tmp
 echo -5 1.85 24p,Times-Roman RT x,y >> tmp
 gmt pstext -R -J -O -K -Dj0.2c -N tmp -F+f+j >> %ps%
@@ -53,7 +53,7 @@ gmt psxy -R -J -O -K -W2p tmp >> %ps%
 echo -0.16666 0 12p,5 0 CT x > tmp
 echo -0.3333 0.2888675 12p,Times-Roman 0 RM y >> tmp
 echo 0.22 0.27 12p,Symbol -30 CB a >> tmp
-echo -0.33333 0.6 12p,Times-Roman 30 LB 120\312 >> tmp
+echo -0.33333 0.6 12p,Times-Roman 30 LB 120@. >> tmp
 gmt pstext -R -J -O -K -Dj0.05i tmp -F+f+a+j >> %ps%
 
 echo 0 0 0.5i 0 120 | gmt psxy -R -J -O -Sm0.15i+e -W1p -Gblack >> %ps%

--- a/doc_classic/examples/ex30/example_30.sh
+++ b/doc_classic/examples/ex30/example_30.sh
@@ -8,7 +8,7 @@
 # Draw generic x-y axes with arrows
 ps=example_30.ps
 
-gmt psbasemap -R0/360/-1.25/1.75 -JX8i/6i -Bx90f30+u"\\312" -By1g10 -BWS+t"Two Trigonometric Functions" \
+gmt psbasemap -R0/360/-1.25/1.75 -JX8i/6i -Bx90f30+u@. -By1g10 -BWS+t"Two Trigonometric Functions" \
 	-K --MAP_FRAME_TYPE=graph --MAP_VECTOR_SHAPE=0.5 > $ps
 
 # Draw sine an cosine curves
@@ -25,7 +25,7 @@ EOF
 gmt pstext -R -J -O -K -Dj0.2c -N -F+f+j << EOF >> $ps
 360 1 18p,Times-Roman RB x = cos(@%12%a@%%)
 360 0 18p,Times-Roman RB y = sin(@%12%a@%%)
-120 -1.25 14p,Times-Roman LB 120\\312
+120 -1.25 14p,Times-Roman LB 120@.
 370 -1.35 24p,Symbol LT a
 -5 1.85 24p,Times-Roman RT x,y
 EOF
@@ -58,7 +58,7 @@ gmt pstext -R -J -O -K -Dj0.05i -F+f+a+j << EOF >> $ps
 -0.16666 0 12p,Times-Roman 0 CT x
 -0.3333 0.2888675 12p,Times-Roman 0 RM y
 0.22 0.27 12p,Symbol -30 CB a
--0.33333 0.6 12p,Times-Roman 30 LB 120\\312
+-0.33333 0.6 12p,Times-Roman 30 LB 120@.
 EOF
 
 echo 0 0 0.5 0 120 | gmt psxy -R -J -O -Sm0.15i+e -W1p -Gblack --PROJ_LENGTH_UNIT=inch >> $ps

--- a/doc_classic/rst/source/GMT_Docs.rst
+++ b/doc_classic/rst/source/GMT_Docs.rst
@@ -3125,6 +3125,8 @@ sequence for font switching.
 +-------------------+----------------------------------------------------------------+
 | @!                | Creates one composite character of the next two characters     |
 +-------------------+----------------------------------------------------------------+
+| @.                | Prints the degree symbol                                       |
++-------------------+----------------------------------------------------------------+
 | @@                | Prints the @ sign itself                                       |
 +-------------------+----------------------------------------------------------------+
 
@@ -8796,7 +8798,7 @@ inverse-video the label:
      gmt pscoast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 -K -P > GMT_App_O_7.ps
      gmt grdcontour geoid.nc -J -O -K -B20f10 -BWSne -C10 -A20+d+u" m"+f8p -Gl50/10S/160/10S -S10 \
      -T+l"-+" >> GMT_App_O_7.ps
-     gmt psxy -R -J -O -SqD15d:+gblack+fwhite+Ld+o+u\\260 -Wthick transect.txt >> GMT_App_O_7.ps
+     gmt psxy -R -J -O -SqD15d:+gblack+fwhite+Ld+o+u@. -Wthick transect.txt >> GMT_App_O_7.ps
 
 The output is presented as Figure :ref:`Contour label 7 <Contour_label_7>`.
 

--- a/doc_classic/scripts/GMT_App_O_7.sh
+++ b/doc_classic/scripts/GMT_App_O_7.sh
@@ -5,4 +5,4 @@
 gmt pscoast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 -K -P > GMT_App_O_7.ps
 gmt grdcontour @App_O_geoid.nc -J -O -K -B20f10 -BWSne -C10 -A20+d+u" m"+f8p -Gl50/10S/160/10S -S10 \
 	-T+l >> GMT_App_O_7.ps
-gmt psxy -R -J -O -SqD15d:+gblack+fwhite+Ld+o+u\\260 -Wthick @App_O_transect.txt >> GMT_App_O_7.ps
+gmt psxy -R -J -O -SqD15d:+gblack+fwhite+Ld+o+u@. -Wthick @App_O_transect.txt >> GMT_App_O_7.ps

--- a/doc_modern/examples/ex30/example_30.bat
+++ b/doc_modern/examples/ex30/example_30.bat
@@ -9,7 +9,7 @@ echo GMT EXAMPLE 30
 set ps=example_30.ps
 gmt set PS_CHAR_ENCODING	Standard+
 
-gmt psbasemap -R0/360/-1.25/1.75 -JX8i/6i -Bx90f30+u"\312" -By1g10 -BWS+t"Two Trigonometric Functions" -K --MAP_FRAME_TYPE=graph --MAP_VECTOR_SHAPE=0.5 > %ps%
+gmt psbasemap -R0/360/-1.25/1.75 -JX8i/6i -Bx90f30+u@. -By1g10 -BWS+t"Two Trigonometric Functions" -K --MAP_FRAME_TYPE=graph --MAP_VECTOR_SHAPE=0.5 > %ps%
 
 REM Draw sine an cosine curves
 
@@ -23,7 +23,7 @@ gmt psxy -R -J -O -K -W0.5p,- tmp >> %ps%
 
 echo 360 1 18p,Times-Roman RB x = cos(@%%12%%a@%%%%) > tmp
 echo 360 0 18p,Times-Roman RB y = sin(@%%12%%a@%%%%) >> tmp
-echo 120 -1.25 14p,Times-Roman LB 120\312 >> tmp
+echo 120 -1.25 14p,Times-Roman LB 120@. >> tmp
 echo 370 -1.35 24p,Symbol LT a >> tmp
 echo -5 1.85 24p,Times-Roman RT x,y >> tmp
 gmt pstext -R -J -O -K -Dj0.2c -N tmp -F+f+j >> %ps%
@@ -53,7 +53,7 @@ gmt psxy -R -J -O -K -W2p tmp >> %ps%
 echo -0.16666 0 12p,5 0 CT x > tmp
 echo -0.3333 0.2888675 12p,Times-Roman 0 RM y >> tmp
 echo 0.22 0.27 12p,Symbol -30 CB a >> tmp
-echo -0.33333 0.6 12p,Times-Roman 30 LB 120\312 >> tmp
+echo -0.33333 0.6 12p,Times-Roman 30 LB 120@. >> tmp
 gmt pstext -R -J -O -K -Dj0.05i tmp -F+f+a+j >> %ps%
 
 echo 0 0 0.5i 0 120 | gmt psxy -R -J -O -Sm0.15i+e -W1p -Gblack >> %ps%

--- a/doc_modern/examples/ex30/example_30.sh
+++ b/doc_modern/examples/ex30/example_30.sh
@@ -8,7 +8,7 @@
 # Draw generic x-y axes with arrows
 ps=example_30.ps
 
-gmt psbasemap -R0/360/-1.25/1.75 -JX8i/6i -Bx90f30+u"\\312" -By1g10 -BWS+t"Two Trigonometric Functions" \
+gmt psbasemap -R0/360/-1.25/1.75 -JX8i/6i -Bx90f30+u@. -By1g10 -BWS+t"Two Trigonometric Functions" \
 	-K --MAP_FRAME_TYPE=graph --MAP_VECTOR_SHAPE=0.5 > $ps
 
 # Draw sine an cosine curves
@@ -25,7 +25,7 @@ EOF
 gmt pstext -R -J -O -K -Dj0.2c -N -F+f+j << EOF >> $ps
 360 1 18p,Times-Roman RB x = cos(@%12%a@%%)
 360 0 18p,Times-Roman RB y = sin(@%12%a@%%)
-120 -1.25 14p,Times-Roman LB 120\\312
+120 -1.25 14p,Times-Roman LB 120@.
 370 -1.35 24p,Symbol LT a
 -5 1.85 24p,Times-Roman RT x,y
 EOF
@@ -58,7 +58,7 @@ gmt pstext -R -J -O -K -Dj0.05i -F+f+a+j << EOF >> $ps
 -0.16666 0 12p,Times-Roman 0 CT x
 -0.3333 0.2888675 12p,Times-Roman 0 RM y
 0.22 0.27 12p,Symbol -30 CB a
--0.33333 0.6 12p,Times-Roman 30 LB 120\\312
+-0.33333 0.6 12p,Times-Roman 30 LB 120@.
 EOF
 
 echo 0 0 0.5 0 120 | gmt psxy -R -J -O -Sm0.15i+e -W1p -Gblack --PROJ_LENGTH_UNIT=inch >> $ps

--- a/doc_modern/rst/source/GMT_Docs.rst
+++ b/doc_modern/rst/source/GMT_Docs.rst
@@ -3065,6 +3065,8 @@ sequence for font switching.
 +-------------------+----------------------------------------------------------------+
 | @!                | Creates one composite character of the next two characters     |
 +-------------------+----------------------------------------------------------------+
+| @.                | Prints the degree symbol                                       |
++-------------------+----------------------------------------------------------------+
 | @@                | Prints the @ sign itself                                       |
 +-------------------+----------------------------------------------------------------+
 
@@ -8742,7 +8744,7 @@ inverse-video the label:
      gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 -K -P > GMT_App_O_7.ps
      gmt grdcontour geoid.nc -J -O -K -B20f10 -BWSne -C10 -A20+d+u" m"+f8p -Gl50/10S/160/10S -S10 \
      -T+l"-+" >> GMT_App_O_7.ps
-     gmt plot -R -J -O -SqD15d:+gblack+fwhite+Ld+o+u\\260 -Wthick transect.txt >> GMT_App_O_7.ps
+     gmt plot -R -J -O -SqD15d:+gblack+fwhite+Ld+o+u@. -Wthick transect.txt >> GMT_App_O_7.ps
 
 The output is presented as Figure :ref:`Contour label 7 <Contour_label_7>`.
 

--- a/doc_modern/scripts/GMT_App_O_7.sh
+++ b/doc_modern/scripts/GMT_App_O_7.sh
@@ -5,5 +5,5 @@
 gmt begin GMT_App_O_7 ps
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+u" m"+f8p -Gl50/10S/160/10S -S10 -T+l
-gmt plot -SqD15d:+gblack+fwhite+Ld+o+u\\260 -Wthick @App_O_transect.txt
+gmt plot -SqD15d:+gblack+fwhite+Ld+o+u@. -Wthick @App_O_transect.txt
 gmt end

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -5039,8 +5039,8 @@ void gmtinit_conf (struct GMT_CTRL *GMT) {
 	GMT->current.setting.given_unit[GMTCASE_MAP_ANNOT_MIN_SPACING] = 'p';
 	/* MAP_ANNOT_ORTHO */
 	strcpy (GMT->current.setting.map_annot_ortho, "we");
-	/* MAP_DEGREE_SYMBOL (ring) */
-	GMT->current.setting.map_degree_symbol = gmt_ring;
+	/* MAP_DEGREE_SYMBOL (degree) */
+	GMT->current.setting.map_degree_symbol = gmt_degree;
 	/* MAP_FRAME_AXES */
 	strcpy (GMT->current.setting.map_frame_axes, "WESNZ");
 	for (i = 0; i < 5; i++) GMT->current.map.frame.side[i] = 0;	/* Unset default settings */
@@ -8384,10 +8384,10 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			GMT_COMPAT_TRANSLATE ("MAP_DEGREE_SYMBOL");
 			break;
 		case GMTCASE_MAP_DEGREE_SYMBOL:
-			if (value[0] == '\0' || !strcmp (lower_value, "ring"))	/* Default */
-				GMT->current.setting.map_degree_symbol = gmt_ring;
-			else if (!strcmp (lower_value, "degree"))
+			if (value[0] == '\0' || !strcmp (lower_value, "degree"))	/* Default */
 				GMT->current.setting.map_degree_symbol = gmt_degree;
+			else if (!strcmp (lower_value, "ring"))
+				GMT->current.setting.map_degree_symbol = gmt_ring;
 			else if (!strcmp (lower_value, "colon"))
 				GMT->current.setting.map_degree_symbol = gmt_colon;
 			else if (!strcmp (lower_value, "none"))

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -1847,7 +1847,12 @@ GMT_LOCAL void plot_map_annotate (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, do
 		if (gmt_M_is_geographic (GMT, GMT_IN) || GMT->current.map.frame.side[N_SIDE] & GMT_AXIS_ANNOT) {
 			PSL_setfont (PSL, GMT->current.setting.font_annot[GMT_PRIMARY].id);
 			PSL_command (PSL, "/PSL_H_y %d ", PSL_IZ (PSL, GMT->current.setting.map_tick_length[GMT_PRIMARY] + GMT->current.setting.map_annot_offset[GMT_PRIMARY] + GMT->current.setting.map_title_offset));
-			PSL_deftextdim (PSL, "-h", GMT->current.setting.font_annot[GMT_PRIMARY].size, "100\\312");
+			if (GMT->current.setting.map_degree_symbol == gmt_none)
+				PSL_deftextdim (PSL, "-h", GMT->current.setting.font_annot[GMT_PRIMARY].size, "100");
+			else {
+				snprintf (label, GMT_LEN16, "100%c",  (int)GMT->current.setting.ps_encoding.code[GMT->current.setting.map_degree_symbol]);
+				PSL_deftextdim (PSL, "-h", GMT->current.setting.font_annot[GMT_PRIMARY].size, label);
+			}
 			PSL_command (PSL, "add def\n");
 		}
 		else

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -428,6 +428,7 @@ EXTERN_MSC int PSL_defunits (struct PSL_CTRL *PSL, const char *param, double val
 EXTERN_MSC unsigned char *psl_gray_encode (struct PSL_CTRL *PSL, size_t *nbytes, unsigned char *input);
 EXTERN_MSC void psl_set_txt_array (struct PSL_CTRL *PSL, const char *param, char *array[], int n);
 EXTERN_MSC void psl_set_int_array (struct PSL_CTRL *PSL, const char *param, int *array, int n);
+EXTERN_MSC char *psl_prepare_text (struct PSL_CTRL *PSL, char *text);
 
 /* Used indirectly by FORTRAN wrapper PSL_free_ . */
 EXTERN_MSC int PSL_free_nonmacro (void *addr);

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -633,7 +633,7 @@ GMT_LOCAL void gmt_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctr
 	int this_just, p_val;
 	bool reverse, all = true, use_image, center = false, const_width = true, do_annot, use_labels, cpt_auto_fmt = true;
 	bool B_set = GMT->current.map.frame.draw, skip_lines = Ctrl->S.active, need_image;
-	char format[GMT_LEN256] = {""}, text[GMT_LEN256] = {""}, test[GMT_LEN256] = {""}, unit[GMT_LEN256] = {""}, label[GMT_LEN256] = {""};
+	char format[GMT_LEN256] = {""}, text[GMT_LEN256] = {""}, test[GMT_LEN256] = {""}, unit[GMT_LEN256] = {""}, label[GMT_LEN256] = {""}, endash;
 	static char *method[2] = {"polygons", "colorimage"};
 	unsigned char *bar = NULL, *tmp = NULL;
 	double hor_annot_width, annot_off, label_off = 0.0, len, len2, size, x0, x1, dx, xx, dir, y_base, y_annot, y_label, xd = 0.0, yd = 0.0, xt = 0.0;
@@ -752,13 +752,19 @@ GMT_LOCAL void gmt_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctr
 	
 	if (Ctrl->D.emode & (reverse+1)) elength[XLO] =  Ctrl->D.elength;
 	if (Ctrl->D.emode & (2-reverse)) elength[XHI] =  Ctrl->D.elength;
+	if (!strncmp (PSL->init.encoding, "Standard", 8U))
+		endash = 0261;	/* endash code in Standard[+] charset */
+	else if (!strncmp (PSL->init.encoding, "ISOLatin1+", 10U))
+		endash = 0035;	/* endash code in ISOLatin1 charset */
+	else
+		endash = '-';	/* Use hyphen */
 
 	if ((gap >= 0.0 || Ctrl->L.interval) && !P->is_continuous) {	/* Want to center annotations for discrete colortable, using lower z0 value */
 		center = (Ctrl->L.interval || gap >= 0.0);
 		if (gap > 0.0) skip_lines = true;
 		gap *= 0.5;
 		if (Ctrl->L.interval) {
-			sprintf (text, "%s - %s", format, format);
+			sprintf (text, "%s%c%s", format, endash, format);
 			strncpy (format, text, GMT_LEN256-1);
 		}
 	}

--- a/src/pstext.c
+++ b/src/pstext.c
@@ -294,6 +294,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   @# toggles between normal and Small Caps mode.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   @_ toggles between normal and underlined text.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   @!<char1><char2> makes one composite character.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   @. prints the degree symbol.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   @@ prints the @ sign itself.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use @a, @c, @e, @i, @n, @o, @s, @u, @A, @C @E, @N, @O, @U for accented European characters.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t(See manual page for more information).\n\n");

--- a/test/gmtregress/regress_1.sh
+++ b/test/gmtregress/regress_1.sh
@@ -11,7 +11,7 @@ ps=regress_1.ps
 function plot_one {	# 5 args are: -E -N axes -X -Y
 	# Use negative angle since we are plotting data in regress_2.sh against -x
 	gmt regress -A-90/90/0.1 $1 $2 data | awk '{if (NR > 1) print -$1, $2}' > tmp
-	gmt psxy -R -W0.5p,blue -J -Bxa45f15g45+u\\312 -Bya1pg1 -B$3 -O -K $4 $5 tmp
+	gmt psxy -R -W0.5p,blue -J -Bxa45f15g45+u@. -Bya1pg1 -B$3 -O -K $4 $5 tmp
 	gmt math tmp -i0,1 DUP DUP LOWER EQ MUL = | awk '{if (NF == 2 && $2 > 0) printf "%s %s %s 0.001\n", $1, $2, $1}' | gmt psxy -R -J -O -K -Sv0.2i+s+b+h1 -Gred $4 $5
 }
 # Allow outliers to be included in the analysis:

--- a/test/grdcontour/periodic.sh
+++ b/test/grdcontour/periodic.sh
@@ -7,7 +7,7 @@ gmt grdmath -Rg -I1 32 22 SBAZ = t.nc
 # Plot as non-periodic.  This plots labels.  The pile of blue contours around
 # 180 occurs because the grid goes rapidly from -180 to +180 here and -Z+p is not used
 # This is expected and correct.
-gmt grdcontour t.nc -JG0/0/5.0i -A20+u"\312" -Bgaf -K -Wa1,blue -Gl-90/0/0/0,0/0/90/0 -P -Xc -Y0.3i > $ps
+gmt grdcontour t.nc -JG0/0/5.0i -A20+u@. -Bgaf -K -Wa1,blue -Gl-90/0/0/0,0/0/90/0 -P -Xc -Y0.3i > $ps
 # Plot as periodic with -Zp.  Transition from -180 to +180 goes well for contouring
 # but we have no contour labels anymore. This is the main issue here.
-gmt grdcontour t.nc -J -A20+u"\312" -Wa1,blue -Bgaf -Gl-90/0/0/0,0/0/90/0 -Z+p -O -Y5.2i >> $ps
+gmt grdcontour t.nc -J -A20+u@. -Wa1,blue -Bgaf -Gl-90/0/0/0,0/0/90/0 -Z+p -O -Y5.2i >> $ps

--- a/test/grdedit/grdflip.sh
+++ b/test/grdedit/grdflip.sh
@@ -10,7 +10,7 @@ gmt grdedit w.nc -Gh.nc -Eh
 gmt grdimage h.nc -Ct.cpt -J -Baf -BWSne+tFLIPLR -Y-2.5i -O -K --FONT_TITLE=18p >> $ps
 # grid after 180 rotation
 gmt grdedit w.nc -Ga.nc -Ea
-gmt grdimage a.nc -Ct.cpt -J -O -K -Baf -BWSne+t"180\312" -Y-2.5i --FONT_TITLE=18p >> $ps
+gmt grdimage a.nc -Ct.cpt -J -O -K -Baf -BWSne+t180@. -Y-2.5i --FONT_TITLE=18p >> $ps
 # Flip grid top-to-bottom
 gmt grdedit w.nc -Gv.nc -Ev
 gmt grdimage v.nc -Ct.cpt -J -O -Baf -BWSne+tFLIPUD -Y-2.5i --FONT_TITLE=18p >> $ps

--- a/test/grdedit/transrot.sh
+++ b/test/grdedit/transrot.sh
@@ -10,7 +10,7 @@ gmt grdedit w.nc -Gt.nc -Et
 gmt grdimage t.nc -Ct.cpt -J -Baf -BWSne+tTRANSPOSE -Y-7.5i -O -K >> $ps
 # grid after 90 CCW rotation
 gmt grdedit w.nc -Gp.nc -El
-gmt grdimage p.nc -Ct.cpt -J -O -K -Baf -BWSne+t"90\312 CCW" -X2.363632i >> $ps
+gmt grdimage p.nc -Ct.cpt -J -O -K -Baf -BWSne+t"90@. CCW" -X2.363632i >> $ps
 # grid after 90 CW rotation
 gmt grdedit w.nc -Gm.nc -Er
-gmt grdimage m.nc -Ct.cpt -J -O -Baf -BWSne+t"90\312 CW" -X2.363632i >> $ps
+gmt grdimage m.nc -Ct.cpt -J -O -Baf -BWSne+t"90@. CW" -X2.363632i >> $ps

--- a/test/grdfft/cylundulation.sh
+++ b/test/grdfft/cylundulation.sh
@@ -39,8 +39,8 @@ gmt psxy -R -J -O -K -Sm0.1i+e+b -W0.25p -Gblack << EOF >> $ps
 0 0 1.5i -60 0
 EOF
 gmt pstext -R -J -O -K -F+f12p << EOF >> $ps
-0.65 -0.35 60\232
-0.52 0.08 18\232
+0.65 -0.35 60@.
+0.52 0.08 18@.
 EOF
 gmt psscale -DJRM+w4.5i/0.1i -Ct.cpt -R -J -O -K >> $ps
 gmt psxy -R -J -O -T >> $ps

--- a/test/grdgradient/aspect.sh
+++ b/test/grdgradient/aspect.sh
@@ -22,7 +22,7 @@ gmt grdgradient piramide.nc -D -Gaspect.nc
 gmt makecpt -Cred,green,blue,yellow -T-45/315/90 -N > pal.cpt
 
 gmt grdimage aspect.nc -JX10c -Cpal.cpt -P -K -B2 -BWSne -Xc > $ps
-gmt psscale -D11c/5c+w6c/0.6c+jML+e+n -Cpal.cpt -B90+u"\\312" -O -K >> $ps
+gmt psscale -D11c/5c+w6c/0.6c+jML+e+n -Cpal.cpt -B90+u@. -O -K >> $ps
 gmt makecpt -Cjet -T0/1/0.1 > t.cpt
 gmt grdimage piramide.nc -J -O -K -Ct.cpt -B2 -BWSne -Y13c >> $ps
 gmt psscale -D11c/5c+w8c/0.6c+jML -Ct.cpt -O >> $ps

--- a/test/mapproject/waypoints.sh
+++ b/test/mapproject/waypoints.sh
@@ -18,6 +18,6 @@ L 16 0 C Distance
 L 16 0 C Time
 D 0 0.5p
 EOF
-awk '{if (NR > 1) printf "L 16 0 C P-%d\nL 16 0 R %s\\312\nL 16 0 R %s nm\nL 16 0 R %s hr\n", int($1), $2, $3, $4}' tmp >> legend
+awk '{if (NR > 1) printf "L 16 0 C P-%d\nL 16 0 R %s@.\nL 16 0 R %s nm\nL 16 0 R %s hr\n", int($1), $2, $3, $4}' tmp >> legend
 echo "V 0 0.25p" >> legend
 gmt pslegend -R -J -O -DjTL+w3.75i+o0.1i -F+p1p+gwhite+s legend >> $ps

--- a/test/project/generate.sh
+++ b/test/project/generate.sh
@@ -12,7 +12,7 @@ gmt psxy -R0/25/0/25 -JX4i -P -K -X2i tt.xy -W2p,red > $ps
 echo 10 10 | gmt psxy -R -J -O -K -Sc0.1i -Gred >> $ps
 echo 10 10 0.4i 0 90 | gmt psxy -R -J -O -K -Sm0.15i+b -W0.75p,red -Gred >> $ps
 gmt pstext -R -J -F+f12p,Helvetica-Bold,red+jBL -O -K >> $ps <<< "21 11 E-W"
-gmt pstext -R -J -F+f12p,Helvetica-Bold,red+jBL -O -K >> $ps <<< "12 12 90\312"
+gmt pstext -R -J -F+f12p,Helvetica-Bold,red+jBL -O -K >> $ps <<< "12 12 90@."
 
 # 30 degrees azimuth
 gmt project -C5/5 -A30 -G1 -L-3/12 -N > tt.xy
@@ -20,7 +20,7 @@ gmt psxy -R -J -O -K tt.xy -W2p,green >> $ps
 echo 5 5 | gmt psxy -R -J -O -K -Sc0.1i -Ggreen >> $ps
 echo 5 5 0.4i 60 90 | gmt psxy -R -J -O -K -Sm0.15i+b -W0.75p,green -Ggreen >> $ps
 gmt pstext -R -J -F+f12p,Helvetica-Bold,green+jTR -O -K >> $ps <<< "3 2 -A30"
-gmt pstext -R -J -F+f12p,Helvetica-Bold,green+jTR -O -K >> $ps <<< "6.6 9 30\312"
+gmt pstext -R -J -F+f12p,Helvetica-Bold,green+jTR -O -K >> $ps <<< "6.6 9 3@."
 
 # Between two given points
 gmt project -C15/5 -E2/20 -G1 -N > tt.xy

--- a/test/psbasemap/mapbarlat.sh
+++ b/test/psbasemap/mapbarlat.sh
@@ -30,6 +30,6 @@ gmt psxy -R -J -O -K -: t.txt -W0.25p >> $ps
 gmt math -T0/80/1 T COSD INV $dlon MUL NEG = t.txt
 gmt psxy -R -J -O -K -: t.txt -W0.25p >> $ps
 for lat in 76 70 60 45 30 10; do
-	gmt psbasemap -R -J -Lg0/$lat+c$lat+f/+w5000k+l"5000 km at ${lat}\312N"+jTC -O -K >> $ps
+	gmt psbasemap -R -J -Lg0/$lat+c$lat+f/+w5000k+l"5000 km at ${lat}@.N"+jTC -O -K >> $ps
 done
 gmt psxy -R -J -O -T >> $ps

--- a/test/psscale/autoscale.sh
+++ b/test/psscale/autoscale.sh
@@ -3,11 +3,11 @@
 ps=autoscale.ps
 gmt makecpt -Cjet -T0/100 > t.cpt
 gmt psbasemap -R0/30/0/45 -JM5i -P -Xc -Yc -Baf -Bwsne -K --MAP_FRAME_TYPE=plain > $ps
-gmt psscale -R -J -DjBC -Ct.cpt -F+p0.25p,red -Bxaf -By+l"\312C" -O -K >> $ps
-gmt psscale -R -J -DJBC -Ct.cpt -F+p0.25p,red -Bxaf -By+l"\312C" -O -K >> $ps
-gmt psscale -R -J -DjTC -Ct.cpt -F+p0.25p,red -Bxaf -By+l"\312C" -O -K >> $ps
-gmt psscale -R -J -DJTC -Ct.cpt -F+p0.25p,red -Bxaf -By+l"\312C" -O -K >> $ps
-gmt psscale -R -J -DjML -Ct.cpt -F+p0.25p,red -Bxaf -By+l"\312C" -O -K >> $ps
-gmt psscale -R -J -DJML -Ct.cpt -F+p0.25p,red -Bxaf -By+l"\312C" -O -K >> $ps
-gmt psscale -R -J -DjMR -Ct.cpt -F+p0.25p,red -Bxaf -By+l"\312C" -O -K >> $ps
-gmt psscale -R -J -DJMR -Ct.cpt -F+p0.25p,red -Bxaf -By+l"\312C" -O >> $ps
+gmt psscale -R -J -DjBC -Ct.cpt -F+p0.25p,red -Bxaf -By+l"@.C" -O -K >> $ps
+gmt psscale -R -J -DJBC -Ct.cpt -F+p0.25p,red -Bxaf -By+l"@.C" -O -K >> $ps
+gmt psscale -R -J -DjTC -Ct.cpt -F+p0.25p,red -Bxaf -By+l"@.C" -O -K >> $ps
+gmt psscale -R -J -DJTC -Ct.cpt -F+p0.25p,red -Bxaf -By+l"@.C" -O -K >> $ps
+gmt psscale -R -J -DjML -Ct.cpt -F+p0.25p,red -Bxaf -By+l"@.C" -O -K >> $ps
+gmt psscale -R -J -DJML -Ct.cpt -F+p0.25p,red -Bxaf -By+l"@.C" -O -K >> $ps
+gmt psscale -R -J -DjMR -Ct.cpt -F+p0.25p,red -Bxaf -By+l"@.C" -O -K >> $ps
+gmt psscale -R -J -DJMR -Ct.cpt -F+p0.25p,red -Bxaf -By+l"@.C" -O >> $ps

--- a/test/pstext/labeler.sh
+++ b/test/pstext/labeler.sh
@@ -5,6 +5,6 @@ echo 3 2.5 > t.txt
 gmt convert points.txt -o0,1 > p.txt
 gmt psxy -R0/7/-0.5/6.5 -JX6i -P -Baf -Sc0.25i -Gred -Wfaint points.txt -K > $ps
 gmt pstext -R -J -O -K -F+r+f10p,Helvetica-Bold,white p.txt >> $ps
-gmt pstext -R -J -O -K -F+z"z = %.1f\312"+f9p,Times-Italic+jTC -Dj0/0.2i points.txt >> $ps
+gmt pstext -R -J -O -K -F+z"z = %.1f@."+f9p,Times-Italic+jTC -Dj0/0.2i points.txt >> $ps
 gmt pstext -R -J -O -K -F+t"Some text label"+f24p,Courier-Bold t.txt >> $ps
 gmt psxy -R -J -O -T >> $ps

--- a/test/pstext/supersub.sh
+++ b/test/pstext/supersub.sh
@@ -3,8 +3,8 @@
 # font changes, colors, and underline in sub/super scripts.
 ps=supersub.ps
 cat << EOF > t.txt
-0	-3	The depth to Z@+300\312@+@-  p@- is used
-0	-2	The depth to Z@-p@-@+300\312@+ is used
+0	-3	The depth to Z@+300@.@+@-  p@- is used
+0	-2	The depth to Z@-p@-@+300@.@+ is used
 0	-1	The range is W \234 @-75@-@+135@+ km
 0	0	The stress @~s@~@-xx@-@+@%6%exact@%%@+ = 450 MPa
 0	1	The stress @~s@~@-xx@-@+*@+ = 450 MPa

--- a/test/psxy/line_geo.sh
+++ b/test/psxy/line_geo.sh
@@ -9,11 +9,11 @@ echo "0 0 150 30" > q2.txt
 echo "0 0 240 30" > q3.txt
 echo "0 0 330 30" > q4.txt
 gmt psxy -R-0.7/0.7/-0.7/0.7 -JM7c -Skgeo-lineation/5c -P -N -W2p,red -Gred -Bag0.5 -BWSne q3.txt -K > $ps
-awk '{printf "@~a@~ = %s\\312\n", $3}' q3.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q3.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -Skgeo-lineation/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q4.txt -K -Y10c >> $ps
-awk '{printf "@~a@~ = %s\\312\n", $3}' q4.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q4.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -Skgeo-lineation/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q1.txt -K -X9c >> $ps
-awk '{printf "@~a@~ = %s\\312\n", $3}' q1.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q1.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -Skgeo-lineation/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q2.txt -K -Y-10c >> $ps
-awk '{printf "@~a@~ = %s\\312\n", $3}' q2.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q2.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -O -T >> $ps

--- a/test/psxy/matharcvar.sh
+++ b/test/psxy/matharcvar.sh
@@ -14,10 +14,10 @@ N: 1 o
 0 0 1 y
 0 0 0.3 0 \$1 m
 EOF
-echo "0 0 60_fixed" > q1.txt
-echo "0 0 90" > q2.txt
-echo "0 0 140" > q3.txt
-echo "0 0 20 270" > q4.txt
+echo "0 0 60 fixed" > q1.txt
+echo "0 0 90 one" > q2.txt
+echo "0 0 140 one " > q3.txt
+echo "0 0 20 270 two" > q4.txt
 gmt psxy -R-0.7/0.7/-0.7/0.7 -JX7c -Skmatharc-one/5c -P -N -W2p,red -Gred -Bag0.5 -BWSne q3.txt -K -X1.25i > $ps
 awk '{printf "@~a@~ = %s\n", $3}' q3.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -Skmatharc-two/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q4.txt -K -Y10c >> $ps

--- a/test/psxy/plane_c.def
+++ b/test/psxy/plane_c.def
@@ -1,10 +1,10 @@
 N: 2 ao
 # Note: $1 is azimuth
 # Note: For now assumes Standard+ encoding for degree symbol
-if $1 [> 0:90 then 0.5 -0.5 0.2 $2\312 l+fHelvetica-Oblique -W-
-if $1 [> 90:180 then -0.5 -0.5 0.2 $2\312 l+fHelvetica-Oblique -W-
-if $1 [> 180:270 then -0.5 0.5 0.2 $2\312 l+fHelvetica-Oblique -W-
-if $1 [> 270:360 then 0.5 0.5 0.2 $2\312 l+fHelvetica-Oblique -W-
+if $1 [> 0:90 then 0.5 -0.5 0.2 $2@. l+fHelvetica-Oblique -W-
+if $1 [> 90:180 then -0.5 -0.5 0.2 $2@. l+fHelvetica-Oblique -W-
+if $1 [> 180:270 then -0.5 0.5 0.2 $2@. l+fHelvetica-Oblique -W-
+if $1 [> 270:360 then 0.5 0.5 0.2 $2@. l+fHelvetica-Oblique -W-
 $1 R
 0 0 1 y
 0.125 0 0.25 -

--- a/test/psxy/plane_cart.sh
+++ b/test/psxy/plane_cart.sh
@@ -7,11 +7,11 @@ echo "0 0 150 30" > q2.txt
 echo "0 0 240 30" > q3.txt
 echo "0 0 330 30" > q4.txt
 gmt psxy -R-0.7/0.7/-0.7/0.7 -JX7c -Sk${src:-.}/plane_c/5c -P -N -W2p,red -Gred -Bag0.5 -BWSne q3.txt -K > $ps
-awk '{printf "@~a@~ = %s\\312\n", $3}' q3.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q3.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -Sk${src:-.}/plane_c/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q4.txt -K -Y10c >> $ps
-awk '{printf "@~a@~ = %s\\312\n", $3}' q4.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q4.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -Sk${src:-.}/plane_c/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q1.txt -K -X9c >> $ps
-awk '{printf "@~a@~ = %s\\312\n", $3}' q1.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q1.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -Sk${src:-.}/plane_c/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q2.txt -K -Y-10c >> $ps
-awk '{printf "@~a@~ = %s\\312\n", $3}' q2.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q2.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -O -T >> $ps

--- a/test/psxy/plane_geo.sh
+++ b/test/psxy/plane_geo.sh
@@ -7,11 +7,11 @@ echo "0 0 150 30" > q2.txt
 echo "0 0 240 30" > q3.txt
 echo "0 0 330 30" > q4.txt
 gmt psxy -R-0.7/0.7/-0.7/0.7 -JM7c -Sk${src:-.}/plane_c/5c -P -N -W2p,red -Gred -Bag0.5 -BWSne q3.txt -K > $ps
-awk '{printf "@~a@~ = %s\\312\n", $3}' q3.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q3.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -Sk${src:-.}/plane_c/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q4.txt -K -Y10c >> $ps
-awk '{printf "@~a@~ = %s\\312\n", $3}' q4.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q4.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -Sk${src:-.}/plane_c/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q1.txt -K -X9c >> $ps
-awk '{printf "@~a@~ = %s\\312\n", $3}' q1.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q1.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -Sk${src:-.}/plane_c/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q2.txt -K -Y-10c >> $ps
-awk '{printf "@~a@~ = %s\\312\n", $3}' q2.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q2.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -O -T >> $ps


### PR DESCRIPTION
Change the GMT default to use proper degree symbol for its intended use. We declare a bug on our usage of the ring symbol. MAP_DEGREE_SYMBOL can be used by those who prefers the wrong, smaller symbol.  Also properly set negative numbers plotted using the minus symbol, use hyphen symbol otherwise, and use endash to indicate ranges.  Also introduce the "@." shorthand to indicate degree symbol in free-form text so that it can be independent of the character set (and updated the documentation for such short-hands).  Made changes in scripts that needed to set degree symbol via octal codes.  Majority of PostScript originals will need to change (another PR).

