### PR TITLE
Fix current time and a memory leak

### DIFF
--- a/src/potential/earthtide.c
+++ b/src/potential/earthtide.c
@@ -1082,6 +1082,7 @@ GMT_LOCAL void sun_moon_track(struct GMT_CTRL *GMT, struct GMT_GCAL *Cal, struct
 		fmjd = (int)(round(fmjd * 86400)) / 86400.0;		/* force 1 sec. granularity */
 		GMT_Put_Record (GMT->parent, GMT_WRITE_DATA, Out);	/* Write this to output */
 	}
+	gmt_M_free (GMT, Out);
 }
 
 /* ----------------------------------------------------------------------- */
@@ -1435,6 +1436,7 @@ int GMT_earthtide (void *V_API, int mode, void *args) {
 		cal_start.hour = timeinfo->tm_hour;
 		cal_start.min  = timeinfo->tm_min;
 		cal_start.sec  = timeinfo->tm_sec;
+		Ctrl->T.T.min = Ctrl->T.T.max = gmt_rdc2dt (GMT, GMT->current.time.today_rata_die, (cal_start.hour * 60 + cal_start.min) * 60 + cal_start.sec);
 	}
 	else
 		gmt_gcal_from_dt (GMT, Ctrl->T.T.min, &cal_start);


### PR DESCRIPTION
The time was never properly set when -T was not given.  There was also a memory leak:

gmt [ERROR]: Memory not freed first allocated in gmt_support.c:15219(gmt_new_record) (ID = 14): 0.016 kb [16 bytes]

Fixes issue #203.