### PR TITLE
Confused PNG for psconvert option

### DIFF
--- a/src/figure.c
+++ b/src/figure.c
@@ -95,7 +95,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
 		pos = 0;
 		while (gmt_strtok (opt->arg, ",", &pos, p)) {	/* Check args to determine what kind it is */
 			if (arg_category == GMT_NOTSET)
-				arg_category = (strlen (p) == 1 || strchr (p, '+') || isupper (p[0])) ? GMT_IS_OPT : GMT_IS_FMT;
+				arg_category = (strlen (p) == 1 || strchr (p, '+') || (isupper (p[0]) && strcmp (p, "PNG"))) ? GMT_IS_OPT : GMT_IS_FMT;
 			if (arg_category == GMT_IS_FMT) {	/* Got format specifications, check if OK */
 				int k = gmt_get_graphics_id (GMT, p);
 				if (k == GMT_NOTSET) {


### PR DESCRIPTION
Need to be careful checking for upper case options when format PNG is used so that PNG by itself is not seen as a psconvert option.
