### PR TITLE
Do not crash when not providing a symbol in psternary -S

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1095,13 +1095,17 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 
 			if (S.read_symbol_cmd) {	/* Must do special processing depending on variable symbol */
 				/* First establish the symbol type given at the end of the record */
+				if (!In->text) {
+					GMT_Report (API, GMT_MSG_NORMAL, "ERROR: no symbol code was provided in the -S option.\n");
+					Return (GMT_RUNTIME_ERROR);
+				}
 				if (S.read_symbol_cmd == 1) gmt_parse_symbol_option (GMT, In->text, &S, 0, false);
 				/* Since we only now know if some of the input columns should NOT be considered dimensions we
 				 * must visit such columns and if the current length unit is NOT inch then we must undo the scaling */
 				if (S.n_nondim && GMT->current.setting.proj_length_unit != GMT_INCH) {	/* Since these are not dimensions but angles or other quantities */
 					for (j = 0; j < S.n_nondim; j++) in[S.nondim_col[j]+rgb_from_z] *= GMT->session.u2u[GMT_INCH][GMT->current.setting.proj_length_unit];
 				}
-				
+
 				if (S.symbol == PSL_VECTOR || S.symbol == GMT_SYMBOL_GEOVECTOR || S.symbol == PSL_MARC) {	/* One of the vector symbols */
 					if (S.v.status & PSL_VEC_OUTLINE2) {
 						current_pen = S.v.pen, Ctrl->W.active = true;	/* Override -W (if set) with specified pen */


### PR DESCRIPTION
For example if from Julia we do
```
ternary([0.16 0.331 0.509 3.344], R="0/100/0/100/0/100", J="X6i", B=:a, S="", show=1, Vd=1)
```
it crashes because no symbol was selected. This PR catch that case and errors instead of crashing. But maybe user error should be catch at a most lower level.