### PR TITLE
Finalize how BB clipping works for test placed via +c<just>

### DIFF
--- a/doc_modern/scripts/GMT_mag_rose.ps
+++ b/doc_modern/scripts/GMT_mag_rose.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from psbasemap
+%%Title: GMT v6.0.0_859b107-dirty [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:51:34 2018
+%%CreationDate: Sun Dec 16 15:39:27 2018
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -672,7 +672,7 @@ O0
 1500 1200 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -R-10/-2/12.8812380332/0.661018975345r -JOc0/0/50/60/7i -Baf -BWSne -X1.25i --MAP_ANNOT_OBLIQUE=34 --FONT_ANNOT_PRIMARY=12p
+%@GMT: gmt psbasemap -R-10/-2/12.8812380332/0.661018975345+r -JOc0/0/50/60/7i -Baf -BWSne -X1.25i --MAP_ANNOT_OBLIQUE=34 --FONT_ANNOT_PRIMARY=12p
 %@PROJ: omerc -10.10000000 12.98123803 -10.22321349 8.34006485 -947770.939 1401801.397 -700427.426 642185.338 +unavailable +a=6371007.181 +b=6371007.180918 +units=m +no_defs
 %GMTBoundingBox: 90 72 504 288
 %%BeginObject PSL_Layer_1
@@ -774,7 +774,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Tmg-2/0.5+w2.5i+d-14.5+t45/10/5+i0.25p,blue+p0.25p,red+l+jCM --FONT_ANNOT_PRIMARY=9p,Helvetica,blue --FONT_ANNOT_SECONDARY=12p,Helvetica,red --FONT_LABEL=14p,Times-Italic,darkgreen --FONT_TITLE=24p --MAP_TITLE_OFFSET=7p --MAP_FRAME_WIDTH=10p --COLOR_BACKGROUND=green --MAP_DEFAULT_PEN=2p,darkgreen --COLOR_BACKGROUND=darkgreen --MAP_VECTOR_SHAPE=0.5 --MAP_TICK_PEN_SECONDARY=thinner,red --MAP_TICK_PEN_PRIMARY=thinner,blue -R-10/-2/12.8812380332/0.661018975345r -JOc0/0/50/60/7i
+%@GMT: gmt psbasemap -Tmg-2/0.5+w2.5i+d-14.5+t45/10/5+i0.25p,blue+p0.25p,red+l+jCM --FONT_ANNOT_PRIMARY=9p,Helvetica,blue --FONT_ANNOT_SECONDARY=12p,Helvetica,red --FONT_LABEL=14p,Times-Italic,darkgreen --FONT_TITLE=24p --MAP_TITLE_OFFSET=7p --MAP_FRAME_WIDTH=10p --COLOR_BACKGROUND=green --MAP_DEFAULT_PEN=2p,darkgreen --COLOR_BACKGROUND=darkgreen --MAP_VECTOR_SHAPE=0.5 --MAP_TICK_PEN_SECONDARY=thinner,red --MAP_TICK_PEN_PRIMARY=thinner,blue -R-10/-2/12.8812380332/0.661018975345+r -JOc0/0/50/60/7i
 %@PROJ: omerc -10.10000000 12.98123803 -10.22321349 8.34006485 -947770.939 1401801.397 -700427.426 642185.338 +unavailable +a=6371007.181 +b=6371007.180918 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -1294,16 +1294,18 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -DjTR+w2.9i/3.9i+o0.05i -F+p+ggray95 -R-10/-2/12.8812380332/0.661018975345r -JOc0/0/50/60/7i
+%@GMT: gmt inset begin -DjTR+w2.9i/3.9i+o0.05i -F+p+ggray95 -R-10/-2/12.8812380332/0.661018975345+r -JOc0/0/50/60/7i
 %@PROJ: omerc -10.10000000 12.98123803 -10.22321349 8.34006485 -947770.939 1401801.397 -700427.426 642185.338 +unavailable +a=6371007.181 +b=6371007.180918 +units=m +no_defs
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
+V % Begin inset
 25 W
 {0.949 A} FS
 O1
 4680 3480 6600 2400 Sr
+5096 296 T
 %%EndObject
 0 A
 FQ
@@ -1311,16 +1313,30 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -R0/7/0/5 -Jx1i -F+f14p,Helvetica-Bold+jCM
-%@PROJ: xy 0.00000000 7.00000000 0.00000000 5.00000000 0.000 7.000 0.000 5.000 +xy
+%@GMT: gmt inset end -R-10/-2/12.8812380332/0.661018975345+r -JOc0/0/50/60/7i
+%@PROJ: omerc -10.00000000 12.88123803 -2.00000000 0.66101898 0.000 0.000 0.000 0.000 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+U % End inset
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R0/7/0/4 -Jx1i -F+f14p,Helvetica-Bold+jCM
+%@PROJ: xy 0.00000000 7.00000000 0.00000000 4.00000000 0.000 7.000 0.000 4.000 +xy
+%%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 clipsave
 0 0 M
 8400 0 D
-0 6000 D
+0 4800 D
 -8400 0 D
 P
 PSL_clip N
@@ -1335,56 +1351,56 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -F+f12p+jLM -R0/7/0/5 -Jx1i
-%@PROJ: xy 0.00000000 7.00000000 0.00000000 5.00000000 0.000 7.000 0.000 5.000 +xy
-%%BeginObject PSL_Layer_5
+%@GMT: gmt pstext -F+f11.5p+jLM -R0/7/0/4 -Jx1i
+%@PROJ: xy 0.00000000 7.00000000 0.00000000 4.00000000 0.000 7.000 0.000 4.000 +xy
+%%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 clipsave
 0 0 M
 8400 0 D
-0 6000 D
+0 4800 D
 -8400 0 D
 P
 PSL_clip N
 4920 4200 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
+192 F0
 (FONT_TITLE) ml Z
 4920 3900 M (MAP_TITLE_OFFSET) ml Z
 4920 3600 M (MAP_DEGREE_SYMBOL) ml Z
-4920 3300 M V MU 0 0 M 200 F0 (FONT_ANNOT_PRIMARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
-0 0 1 C 200 F0 (FONT_ANNOT_PRIMARY) Z
-0 A 4920 3000 M 200 F0
-V MU 0 0 M 200 F0 (MAP_TICK_PEN_PRIMARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
-0 0 1 C 200 F0 (MAP_TICK_PEN_PRIMARY) Z
-0 A 4920 2700 M 200 F0
-V MU 0 0 M 200 F0 (MAP_ANNOT_OFFSET_PRIMARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
-0 0 1 C 200 F0 (MAP_ANNOT_OFFSET_PRIMARY) Z
-0 A 4920 2400 M 200 F0
-V MU 0 0 M 200 F0 (MAP_TICK_LENGTH_PRIMARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
-0 0 1 C 200 F0 (MAP_TICK_LENGTH_PRIMARY) Z
-0 A 4920 2100 M 200 F0
-V MU 0 0 M 200 F0 (FONT_ANNOT_SECONDARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
-1 0 0 C 200 F0 (FONT_ANNOT_SECONDARY) Z
-0 A 4920 1800 M 200 F0
-V MU 0 0 M 200 F0 (MAP_TICK_PEN_SECONDARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
-1 0 0 C 200 F0 (MAP_TICK_PEN_SECONDARY) Z
-0 A 4920 1500 M 200 F0
-V MU 0 0 M 200 F0 (MAP_ANNOT_OFFSET_SECONDARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
-1 0 0 C 200 F0 (MAP_ANNOT_OFFSET_SECONDARY) Z
-0 A 4920 1200 M 200 F0
-V MU 0 0 M 200 F0 (MAP_TICK_LENGTH_SECONDARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
-1 0 0 C 200 F0 (MAP_TICK_LENGTH_SECONDARY) Z
-0 A 4920 900 M 200 F0
-V MU 0 0 M 200 F0 (FONT_LABEL) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
-0 0.392 0 C 200 F0 (FONT_LABEL) Z
-0 A 4920 600 M 200 F0
-V MU 0 0 M 200 F0 (MAP_DEFAULT_PEN) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
-0 0.392 0 C 200 F0 (MAP_DEFAULT_PEN) Z
-0 A 4920 300 M 200 F0
-V MU 0 0 M 200 F0 (COLOR_BACKGROUND) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
-0 0.392 0 C 200 F0 (COLOR_BACKGROUND) Z
+4920 3300 M V MU 0 0 M 192 F0 (FONT_ANNOT_PRIMARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
+0 0 1 C 192 F0 (FONT_ANNOT_PRIMARY) Z
+0 A 4920 3000 M 192 F0
+V MU 0 0 M 192 F0 (MAP_TICK_PEN_PRIMARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
+0 0 1 C 192 F0 (MAP_TICK_PEN_PRIMARY) Z
+0 A 4920 2700 M 192 F0
+V MU 0 0 M 192 F0 (MAP_ANNOT_OFFSET_PRIMARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
+0 0 1 C 192 F0 (MAP_ANNOT_OFFSET_PRIMARY) Z
+0 A 4920 2400 M 192 F0
+V MU 0 0 M 192 F0 (MAP_TICK_LENGTH_PRIMARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
+0 0 1 C 192 F0 (MAP_TICK_LENGTH_PRIMARY) Z
+0 A 4920 2100 M 192 F0
+V MU 0 0 M 192 F0 (FONT_ANNOT_SECONDARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
+1 0 0 C 192 F0 (FONT_ANNOT_SECONDARY) Z
+0 A 4920 1800 M 192 F0
+V MU 0 0 M 192 F0 (MAP_TICK_PEN_SECONDARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
+1 0 0 C 192 F0 (MAP_TICK_PEN_SECONDARY) Z
+0 A 4920 1500 M 192 F0
+V MU 0 0 M 192 F0 (MAP_ANNOT_OFFSET_SECONDARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
+1 0 0 C 192 F0 (MAP_ANNOT_OFFSET_SECONDARY) Z
+0 A 4920 1200 M 192 F0
+V MU 0 0 M 192 F0 (MAP_TICK_LENGTH_SECONDARY) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
+1 0 0 C 192 F0 (MAP_TICK_LENGTH_SECONDARY) Z
+0 A 4920 900 M 192 F0
+V MU 0 0 M 192 F0 (FONT_LABEL) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
+0 0.392 0 C 192 F0 (FONT_LABEL) Z
+0 A 4920 600 M 192 F0
+V MU 0 0 M 192 F0 (MAP_DEFAULT_PEN) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
+0 0.392 0 C 192 F0 (MAP_DEFAULT_PEN) Z
+0 A 4920 300 M 192 F0
+V MU 0 0 M 192 F0 (COLOR_BACKGROUND) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
+0 0.392 0 C 192 F0 (COLOR_BACKGROUND) Z
 0 A PSL_cliprestore
 %%EndObject
 

--- a/doc_modern/scripts/GMT_mag_rose.sh
+++ b/doc_modern/scripts/GMT_mag_rose.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 gmt begin GMT_mag_rose ps
 # Magnetic rose with a specified declination
-gmt basemap -R-10/-2/12.8812380332/0.661018975345r -JOc0/0/50/60/7i -Baf -BWSne -X1.25i --MAP_ANNOT_OBLIQUE=34 --FONT_ANNOT_PRIMARY=12p 
+gmt basemap -R-10/-2/12.8812380332/0.661018975345+r -JOc0/0/50/60/7i -Baf -BWSne -X1.25i --MAP_ANNOT_OBLIQUE=34 --FONT_ANNOT_PRIMARY=12p 
 gmt basemap -Tmg-2/0.5+w2.5i+d-14.5+t45/10/5+i0.25p,blue+p0.25p,red+l+jCM \
 	--FONT_ANNOT_PRIMARY=9p,Helvetica,blue --FONT_ANNOT_SECONDARY=12p,Helvetica,red --FONT_LABEL=14p,Times-Italic,darkgreen --FONT_TITLE=24p \
 	--MAP_TITLE_OFFSET=7p --MAP_FRAME_WIDTH=10p --COLOR_BACKGROUND=green --MAP_DEFAULT_PEN=2p,darkgreen --COLOR_BACKGROUND=darkgreen \
 	--MAP_VECTOR_SHAPE=0.5 --MAP_TICK_PEN_SECONDARY=thinner,red --MAP_TICK_PEN_PRIMARY=thinner,blue 
 gmt inset begin -DjTR+w2.9i/3.9i+o0.05i -F+p+ggray95 
 gmt inset end
-echo "5.5 3.8 GMT DEFAULTS" | gmt text -R0/7/0/5 -Jx1i -F+f14p,Helvetica-Bold+jCM 
-gmt text -F+f12p+jLM << EOF 
+echo "5.5 3.8 GMT DEFAULTS" | gmt text -R0/7/0/4 -Jx1i -F+f14p,Helvetica-Bold+jCM 
+gmt text -F+f11.5p+jLM << EOF 
 4.1 3.50 FONT_TITLE
 4.1 3.25 MAP_TITLE_OFFSET
 4.1 3.00 MAP_DEGREE_SYMBOL

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -40,6 +40,7 @@
  *	gmt_map_basemap 	 : Generic basemap function
  *	gmt_map_clip_off 	 : Deactivate map region clip path
  *	gmt_map_clip_on 	 : Activate map region clip path
+ *	gmt_BB_clip_on		 : Activate Bounding Box clip path
  *	gmt_plane_perspective	 : Adds PS matrix to simulate perspective plotting
  *	gmt_plot_line 		 : Plots path (in projected coordinates), takes care of boundary crossings
  *	gmt_vertical_axis 	 : Draw 3-D vertical axes
@@ -47,7 +48,7 @@
  *	gmt_linearx_grid 	 : Draw linear x grid lines
  *	gmt_setfill              :
  *	gmt_setfont              :
- *	gmt_draw_map_inset      :
+ *	gmt_draw_map_inset       :
  *	gmt_setpen               :
  *	gmt_draw_custom_symbol   :
  *	gmt_add_label_record     :
@@ -4702,7 +4703,7 @@ void gmt_map_clip_on (struct GMT_CTRL *GMT, double rgb[], unsigned int flag) {
 	 * must have been called first.  If r >= 0, the map area will
 	 * first be painted in the r,g,b colors specified.  flag can
 	 * be 0-3, as described in PSL_beginclipping():
-	 * flag : 0 = continue adding pieces to the curent clipping path
+	 * flag : 0 = continue adding pieces to the current clipping path
 	 *        1 = start new clipping path (more must follows)
 	 *        2 = end clipping path (this is the last segment added)
 	 *        3 = this is the complete clipping path (start to end)
@@ -4733,6 +4734,31 @@ void gmt_map_clip_off (struct GMT_CTRL *GMT) {
 
 	PSL_comment (GMT->PSL, "Deactivate Map clip path\n");
 	PSL_endclipping (GMT->PSL, 1);		/* Reduce polygon clipping by one level */
+}
+
+void gmt_BB_clip_on (struct GMT_CTRL *GMT, double rgb[], unsigned int flag) {
+	/* This function sets up a clip path so that only plotting
+	 * inside the bounding box rectangular area will be drawn on paper. map_setup
+	 * must have been called first.  If r >= 0, the map area will
+	 * first be painted in the r,g,b colors specified.  flag can
+	 * be 0-3, as described in PSL_beginclipping():
+	 * flag : 0 = continue adding pieces to the current clipping path
+	 *        1 = start new clipping path (more must follows)
+	 *        2 = end clipping path (this is the last segment added)
+	 *        3 = this is the complete clipping path (start to end)
+	 * 	  Add 4 to select even-odd clipping [nonzero-winding rule].
+	 */
+
+	double work_x[5], work_y[5];
+	struct PSL_CTRL *PSL= GMT->PSL;
+
+	work_x[0] = work_x[3] = work_x[4] = GMT->current.proj.rect[XLO];
+	work_x[1] = work_x[2] = GMT->current.proj.rect[XHI];
+	work_y[0] = work_y[1] = work_y[4] = GMT->current.proj.rect[YLO];
+	work_y[2] = work_y[3] = GMT->current.proj.rect[YHI];
+	
+	PSL_comment (PSL, "Activate BoundingBox Map clip path\n");
+	PSL_beginclipping (PSL, work_x, work_y, 5, rgb, flag);
 }
 
 void gmt_setfill (struct GMT_CTRL *GMT, struct GMT_FILL *fill, int outline) {

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -202,6 +202,7 @@ EXTERN_MSC void gmt_draw_front (struct GMT_CTRL *GMT, double x[], double y[], ui
 EXTERN_MSC void gmt_map_basemap (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmt_map_clip_off (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmt_map_clip_on (struct GMT_CTRL *GMT, double rgb[], unsigned int flag);
+EXTERN_MSC void gmt_BB_clip_on (struct GMT_CTRL *GMT, double rgb[], unsigned int flag);
 EXTERN_MSC void gmt_plot_line (struct GMT_CTRL *GMT, double *x, double *y, unsigned int *pen, uint64_t n, unsigned int mode);
 EXTERN_MSC void gmt_setpen (struct GMT_CTRL *GMT, struct GMT_PEN *pen);
 EXTERN_MSC void gmt_setfill (struct GMT_CTRL *GMT, struct GMT_FILL *fill, int outline);

--- a/src/inset.c
+++ b/src/inset.c
@@ -258,11 +258,9 @@ int GMT_inset (void *V_API, int mode, void *args) {
 		 * draw the panel. */
 		
 		char *cmd = NULL;
-		
-		if (gmt_M_err_pass (GMT, gmt_map_setup (GMT, GMT->common.R.wesn), "")) Return (GMT_PROJECTION_ERROR);
 
 		/* OK, no other inset set for this figure (or panel).  Save graphics state before we draw the inset */
-		PSL_command (PSL, "V %% (inset)\n");
+		PSL_command (PSL, "V %% Begin inset\n");
 
 		gmt_draw_map_inset (GMT, &Ctrl->D.inset);	/* Draw the inset background */
 
@@ -295,7 +293,7 @@ int GMT_inset (void *V_API, int mode, void *args) {
 		int id, j_id;
 		char line[GMT_LEN128] = {""}, str[3] = {"J"};
 			
-		PSL_command (PSL, "U %% (inset)\n");	/* Restore graphics state to what it was before the map inset */
+		PSL_command (PSL, "U %% End inset\n");	/* Restore graphics state to what it was before the map inset */
 		
 		/* Extract previous -R -J from the inset information file */
 		if ((fp = fopen (file, "r")) == NULL) {	/* Not good */

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -726,7 +726,8 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 	row_base_y = Ctrl->D.refpoint->y + Ctrl->D.dim[GMT_Y] - Ctrl->C.off[GMT_Y];	/* Top justification edge of items inside legend box accounting for clearance  */
 	column_number = 0;	/* Start at first column in multi-column setup */
 	n_columns = 1;		/* Reset to default number of columns */
-	txtcolor[0] = '0';	/* Reset to black text color */
+	/* Reset to annotation font text color */
+	sprintf (txtcolor, "%s", gmt_putcolor (GMT, GMT->current.setting.font_annot[GMT_PRIMARY].fill.rgb));
 	x_off_col[0] = 0.0;	/* The x-coordinate of left side of first column */
 	x_off_col[n_columns] = Ctrl->D.dim[GMT_X];	/* Holds width of a row */
 

--- a/test/modern/inset.ps
+++ b/test/modern/inset.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_12fed32-dirty [64-bit] Document from psbasemap
+%%Title: GMT v6.0.0_859b107-dirty [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sat Dec 15 17:17:19 2018
+%%CreationDate: Sun Dec 16 14:44:20 2018
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -864,28 +864,28 @@ N 7883 10693 M -7966 0 D S
 N 7883 10776 M -7966 0 D S
 N 0 10776 M 0 -10859 D S
 N -83 10776 M 0 -10859 D S
-0 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 -167 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(0∞) tc Z
-0 10860 M (0∞) bc Z
-1950 -167 M (10∞) tc Z
-1950 10860 M (10∞) bc Z
-3900 -167 M (20∞) tc Z
-3900 10860 M (20∞) bc Z
-5850 -167 M (30∞) tc Z
-5850 10860 M (30∞) bc Z
-7800 -167 M (40∞) tc Z
-7800 10860 M (40∞) bc Z
--167 0 M (20∞) mr Z
-7967 0 M (20∞) ml Z
--167 2144 M (30∞) mr Z
-7967 2144 M (30∞) ml Z
--167 4520 M (40∞) mr Z
-7967 4520 M (40∞) ml Z
--167 7279 M (50∞) mr Z
-7967 7279 M (50∞) ml Z
--167 10693 M (60∞) mr Z
-7967 10693 M (60∞) ml Z
+(0è) tc Z
+0 10860 M (0è) bc Z
+1950 -167 M (10è) tc Z
+1950 10860 M (10è) bc Z
+3900 -167 M (20è) tc Z
+3900 10860 M (20è) bc Z
+5850 -167 M (30è) tc Z
+5850 10860 M (30è) bc Z
+7800 -167 M (40è) tc Z
+7800 10860 M (40è) bc Z
+-167 0 M (20è) mr Z
+7967 0 M (20è) ml Z
+-167 2144 M (30è) mr Z
+7967 2144 M (30è) ml Z
+-167 4520 M (40è) mr Z
+7967 4520 M (40è) ml Z
+-167 7279 M (50è) mr Z
+7967 7279 M (50è) ml Z
+-167 10693 M (60è) mr Z
+7967 10693 M (60è) ml Z
 %%EndObject
 0 A
 FQ
@@ -893,7 +893,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt inset begin -DjTR+w2.5i+o0.2i -F+gpink+p0.5p -M0.25i -R0/40/20/60 -JM6.5i
+%@GMT: gmt inset begin -DjTR+w2.5i+o0.2i -F+gpink+p0.5p -M0.1i -R0/40/20/60 -JM6.5i
 %@PROJ: merc 0.00000000 40.00000000 20.00000000 60.00000000 -2226389.816 2226389.816 2258423.649 8362698.549 +proj=merc +lon_0=20 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -904,7 +904,7 @@ V % (inset)
 {1 0.753 0.796 C} FS
 O1
 3000 3000 6060 8953 Sr
-4860 7753 T
+4680 7573 T
 %%EndObject
 0 A
 FQ
@@ -912,7 +912,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Rg -JA20/20/2i -Bafg
+%@GMT: gmt psbasemap -Rg -JA20/20/2.3i -Bafg
 %@PROJ: laea 0.00000000 360.00000000 -90.00000000 90.00000000 -9009964.761 9009964.761 -9009964.761 9009964.761 +proj=laea +lat_0=20 +lon_0=20 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -920,169 +920,186 @@ O0
 3.32551 setmiterlimit
 25 W
 4 W
-1052 10 M
--23 49 D
--30 74 D
--25 78 D
--16 58 D
--18 84 D
+1210 12 M
+-35 74 D
+-29 75 D
+-18 56 D
+-26 92 D
+-23 108 D
 -17 99 D
--12 101 D
--8 112 D
--3 86 D
--1 122 D
-5 130 D
-9 117 D
-11 103 D
+-13 108 D
+-8 98 D
+-5 106 D
+-2 101 D
+1 116 D
+7 144 D
+11 131 D
+12 104 D
 20 144 D
-25 136 D
-15 67 D
-31 126 D
-38 128 D
-39 111 D
-31 78 D
-33 74 D
-14 28 D
+22 123 D
+34 155 D
+27 105 D
+26 91 D
+32 101 D
+38 104 D
+39 95 D
+34 74 D
+8 16 D
 S
-1272 3 M
-23 99 D
-19 109 D
-14 116 D
-13 146 D
-6 126 D
-3 111 D
-1 187 D
--5 177 D
--8 150 D
--13 171 D
--17 170 D
--17 132 D
--26 174 D
--32 166 D
--18 76 D
+1463 4 M
+22 94 D
+11 53 D
+19 122 D
+15 129 D
+8 85 D
+9 150 D
+5 149 D
+2 180 D
+-4 210 D
+-8 178 D
+-15 213 D
+-14 150 D
+-16 141 D
+-21 159 D
+-18 115 D
+-29 155 D
+-31 142 D
 S
-1530 47 M
-33 41 D
-25 34 D
-34 52 D
-27 48 D
+1760 54 M
+40 50 D
+52 74 D
+45 78 D
 31 62 D
-26 64 D
-16 45 D
-19 60 D
-21 88 D
-11 61 D
-13 98 D
-5 84 D
-1 120 D
--6 93 D
--7 64 D
--5 43 D
--16 92 D
--21 92 D
--29 104 D
--28 82 D
--26 68 D
--53 118 D
--47 89 D
--8 12 D
--14 25 D
--42 67 D
--32 46 D
--21 29 D
+32 77 D
+14 38 D
+33 106 D
+19 82 D
+15 82 D
+11 84 D
+6 77 D
+3 92 D
+-1 100 D
+-4 64 D
+-9 93 D
+-6 50 D
+-17 99 D
+-20 92 D
+-20 77 D
+-31 104 D
+-29 82 D
+-41 101 D
+-43 92 D
+-29 57 D
+-28 51 D
+-22 37 D
+-34 55 D
+-56 82 D
+-17 23 D
 -9 11 D
--49 60 D
--23 27 D
--58 61 D
--41 38 D
+-17 23 D
+-59 70 D
+-48 52 D
+-75 73 D
 S
-2021 325 M
-38 65 D
-31 63 D
-20 47 D
-24 64 D
-21 73 D
-12 49 D
-15 91 D
-6 57 D
-3 66 D
-1 24 D
--3 82 D
--8 81 D
--12 71 D
--14 63 D
--19 70 D
--24 69 D
--30 74 D
--28 58 D
--34 63 D
--47 75 D
--47 65 D
--45 56 D
--54 60 D
+2324 373 M
+42 72 D
+39 79 D
+26 63 D
+21 56 D
+22 73 D
+23 99 D
+16 107 D
+6 90 D
+1 98 D
+-5 74 D
+-10 88 D
+-13 72 D
+-20 87 D
+-26 85 D
+-25 68 D
+-21 52 D
+-38 80 D
+-46 84 D
+-34 55 D
+-46 66 D
+-39 51 D
+-46 56 D
+-27 30 D
 -6 5 D
--11 12 D
+-27 30 D
 -12 11 D
 -5 6 D
--78 69 D
--57 45 D
--60 41 D
--55 34 D
--49 28 D
--15 7 D
--51 25 D
--44 19 D
--61 24 D
--39 13 D
+-24 22 D
+-5 6 D
+-48 43 D
+-63 51 D
+-32 24 D
+-67 46 D
+-76 46 D
+-64 35 D
+-88 41 D
+-99 38 D
+-31 10 D
 S
-2267 1751 M
--52 60 D
--12 13 D
+2607 2014 M
+-69 79 D
 -7 6 D
 -12 13 D
 -7 6 D
 -6 7 D
--53 48 D
--63 49 D
--43 30 D
--22 15 D
--83 48 D
--78 37 D
--72 29 D
--25 8 D
--73 22 D
--58 14 D
--76 13 D
--33 5 D
--93 7 D
--84 1 D
--8 -1 D
+-20 18 D
+-6 7 D
+-33 30 D
+-77 61 D
+-57 41 D
+-23 14 D
+-75 45 D
+-54 28 D
+-63 29 D
+-96 37 D
+-82 25 D
+-108 25 D
+-84 13 D
+-76 8 D
+-84 3 D
 -9 0 D
 -8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 -1 D
+-9 0 D
 S
-1652 2311 M
--3 0 D
--7 -1 D
+1900 2657 M
+-1 0 D
+-7 0 D
 -8 -1 D
 -8 0 D
 -8 -1 D
 -7 -1 D
 -8 -1 D
 -8 0 D
+-8 -1 D
 -7 -1 D
 -8 -1 D
+-8 -1 D
+-7 -1 D
 -8 -2 D
 -7 -1 D
 -8 -1 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
 -7 -1 D
--8 -1 D
+-8 -2 D
+-7 -1 D
 -7 -2 D
--8 -1 D
--7 -2 D
--8 -1 D
--7 -2 D
--8 -1 D
--7 -2 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
 -7 -2 D
 -8 -2 D
 -7 -1 D
@@ -1095,329 +1112,356 @@ S
 -7 -2 D
 -7 -2 D
 -7 -2 D
--7 -3 D
 -7 -2 D
--8 -2 D
--7 -3 D
--7 -3 D
+-8 -3 D
 -7 -2 D
 -7 -3 D
 -7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
 -7 -3 D
 -7 -3 D
 -13 -6 D
--7 -2 D
 -7 -3 D
 -7 -3 D
--13 -7 D
 -7 -3 D
--7 -3 D
+-6 -3 D
 S
-1348 2390 M
--43 -52 D
--27 -37 D
+1550 2748 M
+-33 -39 D
+-48 -64 D
 -38 -59 D
--8 -13 D
+-14 -22 D
 S
-1128 2397 M
-27 -73 D
+1297 2756 M
+29 -76 D
 23 -72 D
-6 -20 D
+12 -41 D
 S
-870 2353 M
-69 -25 D
-58 -26 D
-49 -25 D
-60 -36 D
-34 -23 D
+1000 2706 M
+60 -21 D
+71 -30 D
+62 -31 D
+78 -46 D
+40 -27 D
 S
-379 2075 M
-71 35 D
-56 23 D
-74 26 D
-74 20 D
-92 17 D
-92 10 D
-74 2 D
-58 -1 D
-83 -7 D
-61 -9 D
+436 2387 M
+88 43 D
+89 35 D
+83 26 D
+66 17 D
+75 14 D
+92 12 D
+92 5 D
+92 -1 D
+90 -7 D
+78 -11 D
 S
-133 649 M
--18 74 D
--10 53 D
--12 97 D
--3 79 D
-1 62 D
-6 69 D
-10 77 D
-20 92 D
-22 73 D
-32 87 D
+153 746 M
+-23 93 D
+-16 98 D
+-8 80 D
+-3 88 D
+4 96 D
+10 95 D
+14 76 D
+17 75 D
+25 82 D
+35 95 D
 28 62 D
-43 81 D
-45 71 D
-29 41 D
-36 46 D
-26 32 D
-17 18 D
-11 13 D
-35 36 D
-54 51 D
-71 58 D
-68 48 D
-56 35 D
-43 25 D
-75 37 D
-61 26 D
-71 26 D
-63 19 D
+38 74 D
+43 73 D
+42 62 D
+50 67 D
+60 70 D
+58 60 D
+42 40 D
+19 16 D
+51 43 D
+67 50 D
+41 28 D
+35 22 D
+65 38 D
+22 12 D
+15 7 D
+22 12 D
+76 34 D
+70 28 D
+103 33 D
 73 18 D
-25 5 D
+50 11 D
 S
-748 89 M
--34 39 D
--50 68 D
--33 51 D
--39 72 D
--25 54 D
--20 48 D
--30 91 D
--18 71 D
--11 58 D
--12 80 D
--6 80 D
--2 89 D
-4 88 D
-9 81 D
-12 80 D
-17 80 D
-25 93 D
-26 78 D
-30 76 D
-27 62 D
-7 13 D
-6 14 D
-7 13 D
+860 103 M
+-64 77 D
+-35 49 D
+-41 64 D
+-39 73 D
+-37 81 D
+-29 76 D
+-26 85 D
+-17 72 D
+-11 57 D
+-13 88 D
+-7 88 D
+-2 66 D
+1 96 D
+6 81 D
+11 96 D
+20 110 D
+29 115 D
+29 93 D
+26 70 D
+37 89 D
+32 68 D
 46 85 D
-12 19 D
-7 13 D
-24 38 D
-38 55 D
-50 65 D
-24 29 D
-34 39 D
-20 22 D
+50 84 D
+59 86 D
+36 48 D
+67 80 D
+40 44 D
 11 10 D
-15 16 D
-6 5 D
-10 11 D
-66 60 D
-58 46 D
-60 43 D
-13 8 D
+31 32 D
+60 56 D
+23 19 D
+40 33 D
+35 27 D
+37 26 D
+36 25 D
 S
-1170 2115 M
-30 58 D
+1345 2432 M
+35 67 D
 S
-1284 2150 M
--35 11 D
--49 12 D
+1477 2472 M
+-66 20 D
+-31 7 D
 S
-1232 2229 M
--28 -47 D
+1417 2564 M
+-33 -56 D
 -4 -9 D
 S
-1114 2191 M
-49 -9 D
-37 -9 D
+1281 2520 M
+68 -13 D
+31 -8 D
 S
-1170 2115 M
-22 -3 D
-29 1 D
-19 5 D
-12 4 D
-19 12 D
-12 13 D
-7 15 D
-1 14 D
--5 16 D
--9 13 D
+1345 2432 M
+25 -3 D
+15 -1 D
+28 4 D
+26 8 D
+21 13 D
+4 3 D
+1 2 D
+4 3 D
+1 2 D
+2 1 D
+8 13 D
+4 13 D
+1 8 D
+-4 18 D
+-9 15 D
+-6 7 D
 -2 1 D
--3 4 D
--10 7 D
--23 10 D
--17 5 D
+-1 2 D
+-13 9 D
+-9 5 D
+-24 9 D
+-27 4 D
 -3 0 D
--34 1 D
+-3 0 D
+-3 0 D
+-3 0 D
+-3 0 D
+-3 0 D
+-3 0 D
+-3 0 D
 -3 -1 D
 -3 0 D
--2 -1 D
+-3 0 D
+-3 -1 D
 -3 0 D
 -3 -1 D
 -3 -1 D
 -3 0 D
+-3 -1 D
+-5 -2 D
 -3 -1 D
 -3 -1 D
 -5 -2 D
 -5 -2 D
--5 -3 D
--5 -2 D
+-7 -4 D
+-8 -6 D
 -10 -8 D
--4 -3 D
 -1 -2 D
 -2 -1 D
 -5 -8 D
 -2 -1 D
--6 -18 D
-1 -14 D
-6 -15 D
-10 -12 D
-19 -12 D
-19 -8 D
+-6 -14 D
+-2 -14 D
+4 -17 D
+9 -15 D
+7 -8 D
+6 -4 D
+1 -2 D
+20 -11 D
+15 -6 D
 P S
-729 97 M
-116 8 D
-136 5 D
+839 112 M
+156 10 D
+164 5 D
 170 2 D
-242 -1 D
-146 -5 D
-120 -8 D
-12 -1 D
+252 -1 D
+164 -5 D
+122 -7 D
+54 -4 D
 S
-181 565 M
-189 -27 D
-163 -18 D
-223 -19 D
-169 -9 D
-124 -4 D
-152 -2 D
-171 2 D
-157 6 D
-159 10 D
-203 18 D
-184 22 D
-144 21 D
+209 649 M
+218 -30 D
+175 -20 D
+171 -16 D
+178 -12 D
+183 -8 D
+145 -3 D
+185 -1 D
+203 5 D
+194 10 D
+176 13 D
+181 18 D
+193 24 D
+140 20 D
 S
--1 1200 M
-55 -37 D
-60 -35 D
-75 -37 D
-90 -37 D
-89 -31 D
-48 -15 D
-120 -31 D
-111 -22 D
-107 -18 D
-116 -14 D
-128 -10 D
-112 -5 D
-154 -1 D
-126 5 D
+-1 1380 M
+62 -42 D
+71 -41 D
+31 -16 D
+76 -36 D
+91 -36 D
+106 -37 D
+25 -7 D
+93 -26 D
+109 -25 D
+98 -19 D
+148 -23 D
+141 -15 D
+132 -9 D
+76 -3 D
+113 -2 D
+119 1 D
+126 6 D
 104 8 D
 103 11 D
-108 15 D
-92 17 D
-122 28 D
+168 24 D
+131 26 D
+83 20 D
 93 26 D
-55 17 D
-11 5 D
-36 12 D
-90 37 D
-33 15 D
+85 27 D
+75 27 D
+101 43 D
 21 11 D
-72 39 D
-48 31 D
-23 16 D
+73 38 D
+79 48 D
+29 21 D
 S
-181 1835 M
-18 -46 D
-13 -27 D
-25 -43 D
-36 -48 D
-41 -44 D
-53 -46 D
-33 -25 D
-44 -28 D
-46 -26 D
-58 -29 D
-82 -33 D
-75 -25 D
-66 -18 D
-80 -17 D
-117 -19 D
-107 -10 D
-84 -3 D
-60 -1 D
-84 3 D
-83 6 D
+209 2111 M
+12 -35 D
+25 -55 D
+20 -34 D
+23 -33 D
+37 -46 D
+49 -50 D
+31 -27 D
+57 -43 D
+35 -23 D
+45 -27 D
+57 -30 D
+90 -39 D
+74 -27 D
+109 -32 D
+125 -27 D
+88 -14 D
+118 -13 D
+108 -6 D
+84 -1 D
+108 4 D
+96 7 D
 106 14 D
-93 17 D
-89 22 D
-76 24 D
-62 23 D
-60 27 D
-39 19 D
-64 38 D
-42 29 D
-32 25 D
-38 34 D
-41 44 D
+46 7 D
+92 19 D
+111 29 D
+85 29 D
+92 37 D
+77 39 D
+55 32 D
+51 35 D
+33 25 D
+45 40 D
+29 28 D
+32 38 D
 30 40 D
-21 33 D
-18 35 D
-22 55 D
+26 42 D
+30 63 D
+11 34 D
 S
-729 2303 M
--27 -39 D
--19 -37 D
--13 -36 D
--8 -42 D
+839 2648 M
+-18 -23 D
+-25 -43 D
+-14 -30 D
+-12 -37 D
+-9 -48 D
 -1 -36 D
 4 -34 D
-5 -22 D
-17 -43 D
-17 -30 D
-29 -37 D
-8 -9 D
-42 -36 D
-31 -22 D
-33 -20 D
-49 -23 D
-51 -19 D
-68 -19 D
-65 -11 D
-50 -6 D
-74 -3 D
+7 -33 D
+12 -33 D
+21 -40 D
+20 -29 D
+31 -36 D
+51 -44 D
+37 -25 D
+40 -22 D
+36 -18 D
+58 -22 D
+53 -17 D
+63 -14 D
+87 -13 D
+66 -4 D
+44 -1 D
 66 3 D
-80 10 D
-63 14 D
-67 21 D
-44 19 D
-24 11 D
-11 7 D
-12 6 D
-32 21 D
+80 9 D
+64 13 D
+55 14 D
+26 9 D
+45 17 D
+37 17 D
+41 21 D
+43 28 D
 39 31 D
-9 8 D
-31 36 D
-20 29 D
-16 30 D
-15 43 D
+34 34 D
+22 28 D
+19 29 D
+20 41 D
+13 44 D
 5 34 D
 1 35 D
--5 36 D
--10 37 D
--16 36 D
--22 37 D
--15 20 D
+-4 36 D
+-7 30 D
+-15 43 D
+-22 42 D
+-29 42 D
+-2 2 D
 S
-1200 2173 M
+1380 2499 M
 0 0 D
 P S
 8 W
 25 W
-N 1200 1200 1200 0 360 arc S
+N 1380 1380 1380 0 360 arc S
 %%EndObject
 0 A
 FQ
@@ -1425,15 +1469,23 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -F+f18p+cTR -Dj-0.15i -Rg -JA20/20/2i
+%@GMT: gmt pstext -F+f12p+cTR -Rg -JA20/20/2.3i
 %@PROJ: laea 0.00000000 360.00000000 -90.00000000 90.00000000 -9009964.761 9009964.761 -9009964.761 9009964.761 +proj=laea +lat_0=20 +lon_0=20 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-2580 2580 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-300 F0
+clipsave
+0 0 M
+2760 0 D
+0 2760 D
+-2760 0 D
+P
+PSL_clip N
+2760 2760 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
 (INSET) tr Z
+PSL_cliprestore
 %%EndObject
 0 A
 FQ
@@ -1441,7 +1493,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt inset end -Rg -JA20/20/2i
+%@GMT: gmt inset end -Rg -JA20/20/2.3i
 %@PROJ: laea 0.00000000 360.00000000 -90.00000000 90.00000000 0.000 0.000 0.000 0.000 +proj=laea +lat_0=20 +lon_0=20 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_5
 0 setlinecap
@@ -1461,9 +1513,17 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-240 240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+clipsave
+0 0 M
+7800 0 D
+0 10693 D
+-7800 0 D
+P
+PSL_clip N
+240 240 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
 (MAP) bl Z
+PSL_cliprestore
 %%EndObject
 
 grestore

--- a/test/modern/inset.sh
+++ b/test/modern/inset.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 gmt begin inset ps
 	gmt psbasemap -R0/40/20/60 -JM6.5i -Bafg -B+glightgreen
-	gmt inset begin -DjTR+w2.5i+o0.2i -F+gpink+p0.5p -M0.25i
-		gmt psbasemap -Rg -JA20/20/2i -Bafg
-		echo INSET | gmt pstext -F+f18p+cTR -Dj-0.15i
+	gmt inset begin -DjTR+w2.5i+o0.2i -F+gpink+p0.5p -M0.1i
+		gmt psbasemap -Rg -JA20/20/2.3i -Bafg
+		echo INSET | gmt pstext -F+f12p+cTR
 	gmt inset end
 	echo MAP | gmt pstext -F+f18p+cBL -Dj0.2i
 gmt end


### PR DESCRIPTION
When computing the coordinates for text via justification codes we want those codes to relate to the rectangular bounding box and not the actual map outline, and we want the "throw away of outside" check deactivated since round-off sometimes catches such on-the-border coordinates.  The text itself is still subject to clipping by the BB unless -N is used as well.

Also a bit of a follow up on #220 