### PR TITLE
pslegend calls psxy and needs to state units

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13125,7 +13125,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 			break;
 		case 'o':	/*3-D symbol */
 			p->shade3D = true;
-		case 'O':	/* Same but noe enabling shading */
+		case 'O':	/* Same but now enabling shading */
 			p->symbol = GMT_SYMBOL_COLUMN;
 			if (n_z) {
 				p->n_required = n_z;	/* Need more than one z value from file */

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -1504,7 +1504,8 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 		if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_POINT, GMT_IN, D[SYM], string) != GMT_NOERROR) {
 			Return (API->error);
 		}
-		sprintf (buffer, "-R0/%g/0/%g -Jx1i -O -K -N -S %s --GMT_HISTORY=false", GMT->current.proj.rect[XHI], GMT->current.proj.rect[YHI], string);
+		/* Because the sizes internally are in inches we must tell psxy that inch is the current length unit */
+		sprintf (buffer, "-R0/%g/0/%g -Jx1i -O -K -N -S %s --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=false", GMT->current.proj.rect[XHI], GMT->current.proj.rect[YHI], string);
 		GMT_Report (API, GMT_MSG_DEBUG, "RUNNING: SYM: gmt psxy %s\n", buffer);
 		if (GMT_Call_Module (API, "psxy", GMT_MODULE_CMD, buffer) != GMT_NOERROR) {	/* Plot the symbols */
 			Return (API->error);


### PR DESCRIPTION
Since pslegend will internally convert length units to inches (regardless of what it was given) and passes that via virtual files to psxy we need to tell psxy that INCH is the current unit and override whatever the user has in the defaults file.
