### PR TITLE
Must temporarily reduce margin

### DIFF
--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -82,7 +82,7 @@
 #define GMT_TOP_MODULE	1	/* func_level of top-level module being called */
 
 #define GMT_PAPER_DIM		32767	/* Upper limit on PostScript paper size under modern mode, in points (~11.6 meters) */
-#define GMT_PAPER_MARGIN	40	/* Default paper margin under modern mode, in inches (~1 meter) */
+#define GMT_PAPER_MARGIN	5	/* Default paper margin under modern mode, in inches (~1 meter) */
 
 /*! whether to ignore/read/write history file gmt.history */
 enum GMT_enum_history {


### PR DESCRIPTION
Until ghostscript 9.27 comes and fixes the bounding box issue #199 we must live with a 5 inch padded margin instead of 40 inches.

The bug has been reported to ghostscript.  it affects modern mode usage only (except when PostScript output is requested - which is why our examples did not start failing).  Rather than have users be confused about massive white space to the left of their plots we have reduced that padding to 5 inches until the bug is fixed in ghostscript.