### PR TITLE
Let -T option be a modifer under -C

### DIFF
--- a/doc_classic/examples/ex17/example_17.sh
+++ b/doc_classic/examples/ex17/example_17.sh
@@ -31,7 +31,7 @@ gmt psscale -DjTR+o0.3i/0.1i+w4i/0.2i+h -R -J -Cgeoid.cpt -Bx5f1 -By+lm -I -O -K
 
 # Add a text paragraph
 
-gmt pstext -R -J -O -M -Gwhite -Wthinner -TO -D-0.1i/0.1i -F+f12,Times-Roman+jRB >> $ps << END
+gmt pstext -R -J -O -M -Gwhite -Wthinner -C+tO -D-0.1i/0.1i -F+f12,Times-Roman+jRB >> $ps << END
 > 90 -10 12p 3i j
 @_@%5%Example 17.@%%@_  We first plot the color geoid image
 for the entire region, followed by a gray-shaded @#etopo5@#

--- a/doc_classic/examples/ex31/example_31.sh
+++ b/doc_classic/examples/ex31/example_31.sh
@@ -50,7 +50,7 @@ gmt psxy -R -J -Sc0.15c -W1.25p -O -K >> $ps
 
 # label big EU cities
 $AWK 'BEGIN {FS=","} $4 > 1000000 {print $1, $2, $3}' $capitals | \
-gmt pstext -R -J -F+f7p,LinBiolinumOI+jBL -Dj0.1c -Gwhite -C5% -Qu -TO -O -K >> $ps
+gmt pstext -R -J -F+f7p,LinBiolinumOI+jBL -Dj0.1c -Gwhite -C5%+tO -Qu -O -K >> $ps
 
 # construct legend
 cat << EOF > legend.txt

--- a/doc_classic/examples/ex48/example_48.sh
+++ b/doc_classic/examples/ex48/example_48.sh
@@ -35,7 +35,7 @@ while read lon lat az1 az2 label just off; do
 	az2=`gmt math -Q $az2 $daz DIV FLOOR $daz MUL =`
 	gmt math -T${az1}/${az2}/$daz -N4/2 -fg -C0 0 $lon ADD -C1 $lat ADD -C3 2000 ADD = | gmt psxy -Rg -JG205/-10/7i -O -K -S=0.1 -W0.5p >> $ps
 	echo $lon $lat $label | gmt pstext -Rg -JG205/-10/7i -O -K -DJ${off}+v0.5p,white -F+f16p+j${just} -N >> $ps
-	echo $lon $lat $label | gmt pstext -Rg -JG205/-10/7i -O -K -DJ${off}+v0.25p -F+f16p+j${just} -N -Gwhite -W0.25p -TO >> $ps
+	echo $lon $lat $label | gmt pstext -Rg -JG205/-10/7i -O -K -DJ${off}+v0.25p -F+f16p+j${just} -N -Gwhite -W0.25p -C+tO >> $ps
 done < airports.txt
 # Plot trimmed lines and overlay airport locations
 gmt psxy airports.txt -R -J -O -K -Fn -W1.5p+o250k+v0.2i+gred+h0.5 >> $ps

--- a/doc_classic/rst/source/pstext.rst
+++ b/doc_classic/rst/source/pstext.rst
@@ -17,13 +17,13 @@ Synopsis
 |SYN_OPT-Rz|
 [ |-A| ]
 |SYN_OPT-B|
+[ |-C|\ [\ **\ *dx/dy*\ ][\ **+t**\ o\|\O\|\c\|C] ]
 [ |-D|\ [**j**\ \|\ **J**]\ *dx*\ [/*dy*][\ **+v**\ [*pen*]] ]
 [ |-F|\ [**+a**\ [*angle*]][\ **+c**\ [*justify*]][\ **+f**\ [*font*]][\ **+j**\ [*justify*]][\ **+h**\ \|\ **+l**\|\ **+r**\ [*first*] \|\ **+t**\ *text*\ \|\ **+z**\ [*format*]] ] 
 [ |-G|\ *color* ]
 [ |-K| ]
 [ |-L| ] [ |-M| ] [ |-N| ] [ |-O| ] [ |-P| ]
 [ |-Q|\ **l**\ \|\ **u** ]
-[ |-T|\ **o**\ \|\ **O**\ \|\ **c**\ \|\ **C** ] [
 [ |-W|\ *pen* ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
@@ -111,11 +111,16 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ *dx/dy*
-    Sets the clearance between the text and the surrounding box [15%].
+**-C\ [\ **\ *dx/dy*\ ][\ **+t**\ o\|\O\|\c\|C]
+    Adjust the clearance between the text and the surrounding box [15%].
     Only used if **-W** or **-G** are specified. Append the unit you
     want (**c**\ m, **i**\ nch, or **p**\ oint; if not given we consult
     :ref:`PROJ_LENGTH_UNIT <PROJ_LENGTH_UNIT>`) or % for a percentage of the font size.
+    Optionally, use modifier **+t** to set the shape of the textbox when using **-G** and/or **-W**.
+    Choose lower case o to get a straight rectangle [Default].
+    Choose upper case O to get a rounded rectangle. In paragraph
+    mode (**-M**) you can also choose lower case c to get a concave
+    rectangle or upper case C to get a convex rectangle. 
 
 .. _-D:
 
@@ -218,15 +223,6 @@ Optional Arguments
     Change all text to either **l**\ ower or **u**\ pper case [Default
     leaves all text as is].
 
-.. _-T:
-
-**-T**
-    Specify the shape of the textbox when using **-G** and/or **-W**.
-    Choose lower case **o** to get a straight rectangle [Default].
-    Choose upper case **O** to get a rounded rectangle. In paragraph
-    mode (**-M**) you can also choose lower case **c** to get a concave
-    rectangle or upper case **C** to get a convex rectangle. 
-
 .. _-U:
 
 .. include:: explain_-U.rst_
@@ -240,7 +236,7 @@ Optional Arguments
 
 **-W**\ *pen*
     Sets the pen used to draw a rectangle around the text string (see
-    **-T**) [Default is width = default, color = black, style = solid].
+    **-C**) [Default is width = default, color = black, style = solid].
 
 .. _-X:
 

--- a/doc_classic/scripts/GMT_pstext_clearance.sh
+++ b/doc_classic/scripts/GMT_pstext_clearance.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-gmt pstext -R0/3/-0.1/1.5 -Jx1i -P -K -C0.2i -TO -Wthick -F+f36p,Helvetica-Bold << EOF > GMT_pstext_clearance.ps
+gmt pstext -R0/3/-0.1/1.5 -Jx1i -P -K -C0.2i+tO -Wthick -F+f36p,Helvetica-Bold << EOF > GMT_pstext_clearance.ps
 1.5	0.5	My Text
 EOF
 gmt pstext -R -J -O -K -C0 -Wthin,- -F+f36p,Helvetica-Bold << EOF >> GMT_pstext_clearance.ps

--- a/doc_modern/examples/ex17/example_17.sh
+++ b/doc_modern/examples/ex17/example_17.sh
@@ -31,7 +31,7 @@ gmt psscale -DjTR+o0.3i/0.1i+w4i/0.2i+h -R -J -Cgeoid.cpt -Bx5f1 -By+lm -I -O -K
 
 # Add a text paragraph
 
-gmt pstext -R -J -O -M -Gwhite -Wthinner -TO -D-0.1i/0.1i -F+f12,Times-Roman+jRB >> $ps << END
+gmt pstext -R -J -O -M -Gwhite -Wthinner -C+tO -D-0.1i/0.1i -F+f12,Times-Roman+jRB >> $ps << END
 > 90 -10 12p 3i j
 @_@%5%Example 17.@%%@_  We first plot the color geoid image
 for the entire region, followed by a gray-shaded @#etopo5@#

--- a/doc_modern/examples/ex31/example_31.sh
+++ b/doc_modern/examples/ex31/example_31.sh
@@ -50,7 +50,7 @@ gmt psxy -R -J -Sc0.15c -W1.25p -O -K >> $ps
 
 # label big EU cities
 $AWK 'BEGIN {FS=","} $4 > 1000000 {print $1, $2, $3}' $capitals | \
-gmt pstext -R -J -F+f7p,LinBiolinumOI+jBL -Dj0.1c -Gwhite -C5% -Qu -TO -O -K >> $ps
+gmt pstext -R -J -F+f7p,LinBiolinumOI+jBL -Dj0.1c -Gwhite -C5%+tO -Qu -O -K >> $ps
 
 # construct legend
 cat << EOF > legend.txt

--- a/doc_modern/examples/ex48/example_48.sh
+++ b/doc_modern/examples/ex48/example_48.sh
@@ -35,7 +35,7 @@ while read lon lat az1 az2 label just off; do
 	az2=`gmt math -Q $az2 $daz DIV FLOOR $daz MUL =`
 	gmt math -T${az1}/${az2}/$daz -N4/2 -fg -C0 0 $lon ADD -C1 $lat ADD -C3 2000 ADD = | gmt psxy -Rg -JG205/-10/7i -O -K -S=0.1 -W0.5p >> $ps
 	echo $lon $lat $label | gmt pstext -Rg -JG205/-10/7i -O -K -DJ${off}+v0.5p,white -F+f16p+j${just} -N >> $ps
-	echo $lon $lat $label | gmt pstext -Rg -JG205/-10/7i -O -K -DJ${off}+v0.25p -F+f16p+j${just} -N -Gwhite -W0.25p -TO >> $ps
+	echo $lon $lat $label | gmt pstext -Rg -JG205/-10/7i -O -K -DJ${off}+v0.25p -F+f16p+j${just} -N -Gwhite -W0.25p -C+tO >> $ps
 done < airports.txt
 # Plot trimmed lines and overlay airport locations
 gmt psxy airports.txt -R -J -O -K -Fn -W1.5p+o250k+v0.2i+gred+h0.5 >> $ps

--- a/doc_modern/rst/source/text.rst
+++ b/doc_modern/rst/source/text.rst
@@ -17,12 +17,12 @@ Synopsis
 |SYN_OPT-Rz|
 [ |-A| ]
 |SYN_OPT-B|
+[ |-C|\ [\ **\ *dx/dy*\ ][\ **+t**\ o\|\O\|\c\|C] ]
 [ |-D|\ [**j**\ \|\ **J**]\ *dx*\ [/*dy*][\ **+v**\ [*pen*]] ]
 [ |-F|\ [**+a**\ [*angle*]][\ **+c**\ [*justify*]][\ **+f**\ [*font*]][\ **+j**\ [*justify*]][\ **+h**\ \|\ **+l**\|\ **+r**\ [*first*] \|\ **+t**\ *text*\ \|\ **+z**\ [*format*]] ] 
 [ |-G|\ *color* ]
 [ |-L| ] [ |-M| ] [ |-N| ]
 [ |-Q|\ **l**\ \|\ **u** ]
-[ |-T|\ **o**\ \|\ **O**\ \|\ **c**\ \|\ **C** ] [
 [ |-W|\ *pen* ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
@@ -110,11 +110,16 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ *dx/dy*
-    Sets the clearance between the text and the surrounding box [15%].
+**-C\ [\ **\ *dx/dy*\ ][\ **+t**\ o\|\O\|\c\|C]
+    Adjust the clearance between the text and the surrounding box [15%].
     Only used if **-W** or **-G** are specified. Append the unit you
     want (**c**\ m, **i**\ nch, or **p**\ oint; if not given we consult
     :ref:`PROJ_LENGTH_UNIT <PROJ_LENGTH_UNIT>`) or % for a percentage of the font size.
+    Optionally, use modifier **+t** to set the shape of the textbox when using **-G** and/or **-W**.
+    Choose lower case o to get a straight rectangle [Default].
+    Choose upper case O to get a rounded rectangle. In paragraph
+    mode (**-M**) you can also choose lower case c to get a concave
+    rectangle or upper case C to get a convex rectangle. 
 
 .. _-D:
 
@@ -205,15 +210,6 @@ Optional Arguments
     Change all text to either **l**\ ower or **u**\ pper case [Default
     leaves all text as is].
 
-.. _-T:
-
-**-T**
-    Specify the shape of the textbox when using **-G** and/or **-W**.
-    Choose lower case **o** to get a straight rectangle [Default].
-    Choose upper case **O** to get a rounded rectangle. In paragraph
-    mode (**-M**) you can also choose lower case **c** to get a concave
-    rectangle or upper case **C** to get a convex rectangle. 
-
 .. _-U:
 
 .. include:: explain_-U.rst_
@@ -227,7 +223,7 @@ Optional Arguments
 
 **-W**\ *pen*
     Sets the pen used to draw a rectangle around the text string (see
-    **-T**) [Default is width = default, color = black, style = solid].
+    **-C**) [Default is width = default, color = black, style = solid].
 
 .. _-X:
 

--- a/doc_modern/scripts/GMT_pstext_clearance.sh
+++ b/doc_modern/scripts/GMT_pstext_clearance.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 gmt begin GMT_pstext_clearance ps
-gmt text -R0/3/-0.1/1.5 -Jx1i -C0.2i -TO -Wthick -F+f36p,Helvetica-Bold << EOF 
+gmt text -R0/3/-0.1/1.5 -Jx1i -C0.2i+tO -Wthick -F+f36p,Helvetica-Bold << EOF 
 1.5	0.5	My Text
 EOF
 gmt text -C0 -Wthin,- -F+f36p,Helvetica-Bold << EOF 

--- a/test/potential/deflections.sh
+++ b/test/potential/deflections.sh
@@ -15,7 +15,7 @@ gmt grdimage smt.nc -R-100/100/-100/100 -JX3i -P -Bag -BWSne -Ct.cpt -K > $ps
 gmt grdtrack -Gsmt.nc -ELM/RM+d > smt.trk
 gmt psxy -R -J -O -K -W5p,white smt.trk >> $ps
 gmt psxy -R -J -O -K -W1p smt.trk >> $ps
-echo "-100 100 BATHYMETRY" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -TO >> $ps
+echo "-100 100 BATHYMETRY" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -C+tO >> $ps
 # 2. Compute the E-W deflection anomaly
 gmt gravfft smt.nc+uk -D1670 -Nf+a -Fe -E$order -Gdef_e.nc
 # ML plot the E-W deflection anomaly
@@ -24,7 +24,7 @@ gmt grdimage def_e.nc -R-100/100/-100/100 -JX3i -O -Bag -BWSne -Ct.cpt -K -X3.5i
 gmt grdtrack -Gdef_e.nc -ELM/RM+d > def_e.trk
 gmt psxy -R -J -O -K -W5p,white def_e.trk >> $ps
 gmt psxy -R -J -O -K -W1p,blue def_e.trk >> $ps
-echo "-100 100 @~h@~" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -TO >> $ps
+echo "-100 100 @~h@~" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -C+tO >> $ps
 # 3. Compute the VGG anomaly
 gmt gravfft smt.nc+uk -D1670 -Nf+a -Fv -E$order -Gvgg.nc
 # BR plot the VGG anomaly
@@ -33,7 +33,7 @@ gmt grdimage vgg.nc -R-100/100/-100/100 -JX3i -O -Bag -BWsne -Ct.cpt -K -X-3.5i 
 gmt grdtrack -Gvgg.nc -ELM/RM+d > vgg.trk
 gmt psxy -R -J -O -K -W5p,white vgg.trk >> $ps
 gmt psxy -R -J -O -K -W1p,red vgg.trk >> $ps
-echo "-100 100 VGG" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -TO >> $ps
+echo "-100 100 VGG" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -C+tO >> $ps
 # 4. Compute the N-S deflection anomaly anomaly
 gmt gravfft smt.nc+uk -D1670 -Nf+a -Fn -E$order -Gdef_n.nc
 # MR plot the N-S deflection anomaly
@@ -42,7 +42,7 @@ gmt grdimage def_n.nc -R-100/100/-100/100 -JX3i -O -Bag -BWsne -Ct.cpt -K -X3.5i
 gmt grdtrack -Gdef_n.nc -EBL/TR+d > def_n.trk
 gmt psxy -R -J -O -K -W5p,white def_n.trk >> $ps
 gmt psxy -R -J -O -K -W1p,orange def_n.trk >> $ps
-echo "-100 100 @~x@~" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -TO >> $ps
+echo "-100 100 @~x@~" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -C+tO >> $ps
 # 5 Plot crossections of bathy and vgg crossections
 # TL plot the bathy and vgg anomaly
 gmt psxy -R-100/100/-5100/1000 -JX3i/2.5i -O -K -W1p -i0,3 smt.trk -Baf -BWsN -X-3.5i -Y3.2i >> $ps

--- a/test/potential/fields.sh
+++ b/test/potential/fields.sh
@@ -34,7 +34,7 @@ gmt grdimage smt.nc -R-100/100/-100/100 -JX3i -P -Bag -BWSne -Ct.cpt -K > $ps
 gmt grdtrack -Gsmt.nc -ELM/RM+d > smt.trk
 gmt psxy -R -J -O -K -W5p,white smt.trk >> $ps
 gmt psxy -R -J -O -K -W1p smt.trk >> $ps
-echo "-100 100 BATHYMETRY" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -TO >> $ps
+echo "-100 100 BATHYMETRY" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -C+tO >> $ps
 # 2. Compute the VGG anomaly
 gmt gravfft smt.nc+uk -D1670 -Nf+a -Fv -E$order -Gvgg.nc
 # BR plot the VGG anomaly
@@ -43,7 +43,7 @@ gmt grdimage vgg.nc -R-100/100/-100/100 -JX3i -O -Bag -BwSne -Ct.cpt -K -X3.5i >
 gmt grdtrack -Gvgg.nc -ELM/RM+d > vgg.trk
 gmt psxy -R -J -O -K -W5p,white vgg.trk >> $ps
 gmt psxy -R -J -O -K -W1p,blue vgg.trk >> $ps
-echo "-100 100 VGG" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -TO >> $ps
+echo "-100 100 VGG" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -C+tO >> $ps
 # 3. Compute the FAA anomaly
 gmt gravfft smt.nc+uk -D1670 -Nf+a -Ff -E$order -Gfaa.nc
 # Compute the exact analytical result for peak amplitude at center
@@ -64,7 +64,7 @@ gmt grdimage faa.nc -R-100/100/-100/100 -JX3i -O -Bag -BWsne -Ct.cpt -K -X-3.5i 
 gmt grdtrack -Gfaa.nc -ELM/RM+d > faa.trk
 gmt psxy -R -J -O -K -W5p,white faa.trk >> $ps
 gmt psxy -R -J -O -K -W1p,red faa.trk >> $ps
-echo "-100 100 FAA" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -TO >> $ps
+echo "-100 100 FAA" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -C+tO >> $ps
 # 4. Compute the geoid anomaly
 gmt gravfft smt.nc+uk -D1670 -Nf+a -Fg -E$order -Ggeoid.nc
 # MR plot the VGG anomaly
@@ -73,7 +73,7 @@ gmt grdimage geoid.nc -R-100/100/-100/100 -JX3i -O -Bag -Bwsne -Ct.cpt -K -X3.5i
 gmt grdtrack -Ggeoid.nc -ELM/RM+d > geoid.trk
 gmt psxy -R -J -O -K -W5p,white geoid.trk >> $ps
 gmt psxy -R -J -O -K -W1p,orange geoid.trk >> $ps
-echo "-100 100 GEOID" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -TO >> $ps
+echo "-100 100 GEOID" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -C+tO >> $ps
 # 5 Plot crossections of bathy and faa crossections
 # TL plot the bathy and faa canomaly
 gmt psxy -R-100/100/-5100/1000 -JX3i/2.5i -O -K -W1p -i0,3 smt.trk -Baf -BWsN -X-3.5i -Y3.2i >> $ps

--- a/test/potential/variablerho.sh
+++ b/test/potential/variablerho.sh
@@ -18,7 +18,7 @@ gmt grdmath -Rplateau.nc 50 0 0 CDIST SUB 25 DIV 0 MAX 400 MUL 1300 ADD 1700 MIN
 # BL Plot the bathymetry
 gmt grdtrack -Gplateau.nc -ELM/RM -o0,2 -nn > plateau.trk
 gmt psxy -R-256/256/-5000/0 -JX5.5i/2.75i -P -K -Ggray -L+yb -BWSn -Baf -Bx+ukm -By+l"Depth (m)" plateau.trk -X1.5i > $ps
-echo "-256 0 BATHYMETRY" | gmt pstext -R -J -O -K -F+jTL+f14p,gray -Dj0.1i -Gwhite -TO >> $ps
+echo "-256 0 BATHYMETRY" | gmt pstext -R -J -O -K -F+jTL+f14p,gray -Dj0.1i -Gwhite -C+tO >> $ps
 # Plot the variable density profile in red and constant in blue
 gmt grdtrack -Grho.nc -ELM/RM -o0,2 -nn > rho.trk
 gmt psxy -R-256/256/0/1800 -J -O -K -W1p,red rho.trk -BE -Baf -By+l"Density (kg/m@+3@+)" >> $ps
@@ -30,8 +30,8 @@ gmt psxy -R -J -O -K -W1p,blue << EOF >> $ps
 50	0
 256	0
 EOF
-echo "+256 1800 CONSTANT DENSITY" | gmt pstext -R -J -O -K -F+jTR+f14p,blue -Dj0.1i -Gwhite -TO >> $ps
-echo "+256 1800 VARIABLE DENSITY" | gmt pstext -R -J -O -K -F+jTR+f14p,red -Dj0.1i/0.4i -Gwhite -TO >> $ps
+echo "+256 1800 CONSTANT DENSITY" | gmt pstext -R -J -O -K -F+jTR+f14p,blue -Dj0.1i -Gwhite -C+tO >> $ps
+echo "+256 1800 VARIABLE DENSITY" | gmt pstext -R -J -O -K -F+jTR+f14p,red -Dj0.1i/0.4i -Gwhite -C+tO >> $ps
 # 2a. Compute the VGG anomaly for variable density
 gmt gravfft plateau.nc+uk -Drho.nc+uk -Nf+a -Fv -E$order -Gvgg.nc
 # BR plot the VGG anomaly
@@ -42,9 +42,9 @@ gmt gravfft plateau.nc+uk -D$rhoc -Nf+a -Fv -E$order -Gvgg.nc
 # BR plot the VGG anomaly
 gmt grdtrack -Gvgg.nc -ELM/RM -o0,2 -nn > vgg.trk
 gmt psxy -R -J -O -K -W1p,blue vgg.trk >> $ps
-echo "-256 250 VGG" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -TO >> $ps
-echo "+256 250 CONSTANT DENSITY" | gmt pstext -R -J -O -K -F+jTR+f14p,blue -Dj0.1i -Gwhite -TO >> $ps
-echo "+256 250 VARIABLE DENSITY" | gmt pstext -R -J -O -K -F+jTR+f14p,red -Dj0.1i/0.4i -Gwhite -TO >> $ps
+echo "-256 250 VGG" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -C+tO >> $ps
+echo "+256 250 CONSTANT DENSITY" | gmt pstext -R -J -O -K -F+jTR+f14p,blue -Dj0.1i -Gwhite -C+tO >> $ps
+echo "+256 250 VARIABLE DENSITY" | gmt pstext -R -J -O -K -F+jTR+f14p,red -Dj0.1i/0.4i -Gwhite -C+tO >> $ps
 # 3a. Compute the FAA anomaly for variable density
 gmt gravfft plateau.nc+uk -Drho.nc+uk -Nf+a -Ff -E$order -Gfaa.nc
 # ML plot the FAA anomaly
@@ -56,8 +56,8 @@ gmt grdmath faa.nc DUP LOWER SUB = faa.nc
 # ML plot the FAA anomaly
 gmt grdtrack -Gfaa.nc -ELM/RM -o0,2 -nn > faa.trk
 gmt psxy -R -J -O -K -W1p,blue faa.trk >> $ps
-echo "-256 250 FAA" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -TO >> $ps
-echo "+256 250 CONSTANT DENSITY" | gmt pstext -R -J -O -K -F+jTR+f14p,blue -Dj0.1i -Gwhite -TO >> $ps
-echo "+256 250 VARIABLE DENSITY" | gmt pstext -R -J -O -K -F+jTR+f14p,red -Dj0.1i/0.4i -Gwhite -TO >> $ps
+echo "-256 250 FAA" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -C+tO >> $ps
+echo "+256 250 CONSTANT DENSITY" | gmt pstext -R -J -O -K -F+jTR+f14p,blue -Dj0.1i -Gwhite -C+tO >> $ps
+echo "+256 250 VARIABLE DENSITY" | gmt pstext -R -J -O -K -F+jTR+f14p,red -Dj0.1i/0.4i -Gwhite -C+tO >> $ps
 gmt psxy -R -J -O -T >> $ps
 rm -f vgg.trk faa.trk plateau.trk rho.trk rho.nc plateau.nc vgg.nc faa.nc

--- a/test/pstext/boxtext.sh
+++ b/test/pstext/boxtext.sh
@@ -4,10 +4,10 @@
 # (upper): Plain text with textbox clip path, then red paint
 ps=boxtext.ps
 gmt set PS_COMMENTS true
-gmt pstext -R0/6/0/4 -Jx1i -Ba1 -P -Dj0.5i/0.5i -F+f32p+jLB -Gyellow -W0.25p,green -TO -K -C1c << EOF > $ps
+gmt pstext -R0/6/0/4 -Jx1i -Ba1 -P -Dj0.5i/0.5i -F+f32p+jLB -Gyellow -W0.25p,green -K -C1c+tO << EOF > $ps
 2	2	TEXT
 EOF
-gmt pstext -R -J -O -K -Dj0.5i/0.5i -F+f32p+jLB -Gc -C1c -TO -Y5i << EOF >> $ps
+gmt pstext -R -J -O -K -Dj0.5i/0.5i -F+f32p+jLB -Gc -C1c+tO -Y5i << EOF >> $ps
 2	2	TEXT
 EOF
 gmt psxy -R -J -O -K -Sri -Gred << EOF >> $ps


### PR DESCRIPTION
The **-T** and **-C** options are dealing with the same issue: The text bounding box attributes.  I have combined these with **-T** now being a modifier **+t***shape* under **-C**.  Tests pass, documentation has been updated.  Parsing is backwards compatible.