### PR TITLE
Wrong array index used for drawing arrow tails at end of vector

### DIFF
--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -2700,32 +2700,32 @@ static int psl_vector (struct PSL_CTRL *PSL, double x, double y, double param[])
 				PSL_command (PSL, "U\n");
 				break;
 			case PSL_VEC_TAIL:
-				xx[0] = xp - tailwidth - off[PSL_BEGIN]; yy[0] = -yshift[PSL_END];	n = 1;	/* Vector tip */
+				xx[0] = xp - tailwidth - off[PSL_END]; yy[0] = -yshift[PSL_END];	n = 1;	/* Vector tip */
 				if (asymmetry[PSL_END] != +1) {	/* Need left side */
-					xx[n] = xp - tailwidth + FIN_SLANT_COS * headwidth - off[PSL_BEGIN]; yy[n++] = -FIN_HEIGHT_SCALE * headwidth;
+					xx[n] = xp - tailwidth + FIN_SLANT_COS * headwidth - off[PSL_END]; yy[n++] = -FIN_HEIGHT_SCALE * headwidth;
 					xx[n] = xx[n-1] + FIN_LENGTH_SCALE * headlength; yy[n++] = -FIN_HEIGHT_SCALE * headwidth;
 				}
-				xx[n] = xp - tailwidth + FIN_LENGTH_SCALE * headlength - off[PSL_BEGIN]; yy[n++] = -yshift[PSL_END];
+				xx[n] = xp - tailwidth + FIN_LENGTH_SCALE * headlength - off[PSL_END]; yy[n++] = -yshift[PSL_END];
 				if (asymmetry[PSL_END] != -1) {	/* Need right side */
-					xx[n] = xp - tailwidth + FIN_SLANT_COS * headwidth + FIN_LENGTH_SCALE * headlength - off[PSL_BEGIN]; yy[n++] = FIN_HEIGHT_SCALE * headwidth;
+					xx[n] = xp - tailwidth + FIN_SLANT_COS * headwidth + FIN_LENGTH_SCALE * headlength - off[PSL_END]; yy[n++] = FIN_HEIGHT_SCALE * headwidth;
 					xx[n] = xx[n-1] - FIN_LENGTH_SCALE * headlength; yy[n++] = FIN_HEIGHT_SCALE * headwidth;
 				}
 				PSL_plotline (PSL, xx, yy, n, PSL_MOVE);	/* Set up path */
 				PSL_command (PSL, "P clip %s %s ", dump[fill], line[outline]);
 				if (asymmetry[PSL_END] == 0) {	/* Draw feather center */
 					PSL_command (PSL, "V 0 W ");
-					xx[1] = xp - tailwidth + headlength - off[PSL_BEGIN]; yy[1] = -yshift[PSL_END];
+					xx[1] = xp - tailwidth + headlength - off[PSL_END]; yy[1] = -yshift[PSL_END];
 					PSL_plotsegment (PSL, xx[0], yy[0], xx[1], yy[1]);				/* Draw vector line body */
 					PSL_command (PSL, "U\n");
 				}
 				break;
 			case PSL_VEC_TAIL_PLAIN:
 				n = 0;
-				if (asymmetry[PSL_BEGIN] != +1) {	/* Need left side */
+				if (asymmetry[PSL_END] != +1) {	/* Need left side */
 					xx[n] = xp + headlength; yy[n++] = -headwidth;
 				}
-				xx[n] = xp; yy[n++] = -yshift[PSL_BEGIN];	/* Vector tip */
-				if (asymmetry[PSL_BEGIN] != -1) {	/* Need right side */
+				xx[n] = xp; yy[n++] = -yshift[PSL_END];	/* Vector tip */
+				if (asymmetry[PSL_END] != -1) {	/* Need right side */
 					xx[n] = xp + headlength; yy[n++] = headwidth;
 				}
 				PSL_plotline (PSL, xx, yy, n, PSL_MOVE+PSL_STROKE);	/* Set up path */


### PR DESCRIPTION
The various offsets and lengths for the two ends are computed and stored in a 2-vector accessed with indices PSL_BEGIN (1) and PSL_END (2).  For the end tail symbols the wrong (PSL_BEGIN) index was used, leading to offsets such as shown in #186.