### PR TITLE
Modernize -E in gmtspatial

### DIFF
--- a/doc_classic/rst/source/gmtspatial.rst
+++ b/doc_classic/rst/source/gmtspatial.rst
@@ -16,7 +16,7 @@ Synopsis
 **gmtspatial** [ *table* ] [ |-A|\ [**a**\ *min_dist*][*unit*]]
 [ |-C| ]
 [ |-D|\ [**+f**\ *file*][\ **+a**\ *amax*][\ **+d**\ *dmax*][\ **+c\|C**\ *cmax*][\ **+s**\ *fact*] ]
-[ |-E|\ **+**\ \|\ **-** ]
+[ |-E|\ **+p**\ \|\ **n** ]
 [ |-F|\ [**l**] ]
 [ |-I|\ [**e**\ \|\ **i**] ]
 [ |-N|\ *pfile*\ [**+a**][\ **+p**\ *start*][**+r**][**+z**] ]
@@ -109,9 +109,9 @@ Optional Arguments
 
 .. _-E:
 
-**-E**\ **+**\ \|\ **-** ]
-    Reset the handedness of all polygons to match the given **+**
-    (counter-clockwise) or **-** (clockwise). Implies **-Q+**.
+**-E**\ **+p**\ \|\ **n** ]
+    Reset the handedness of all polygons to match the given **+p**
+    (counter-clockwise; positive) or **+n** (clockwise; negative). Implies **-Q+**.
 
 .. _-F:
 
@@ -256,7 +256,7 @@ their areas to the segment headers, run
 
    ::
 
-    gmt spatial polygons.txt -Q+h -E+ > areas.txt
+    gmt spatial polygons.txt -Q+h -E+p > areas.txt
 
 To determine the areas of all the polygon segments in the file janmayen_land_full.txt,
 add this information to the segment headers, sort the segments from largest

--- a/doc_modern/rst/source/gmtspatial.rst
+++ b/doc_modern/rst/source/gmtspatial.rst
@@ -16,7 +16,7 @@ Synopsis
 **gmt spatial** [ *table* ] [ |-A|\ [**a**\ *min_dist*][*unit*]]
 [ |-C| ]
 [ |-D|\ [**+f**\ *file*][\ **+a**\ *amax*][\ **+d**\ *dmax*][\ **+c\|C**\ *cmax*][\ **+s**\ *fact*] ]
-[ |-E|\ **+**\ \|\ **-** ]
+[ |-E|\ **+p**\ \|\ **n** ]
 [ |-F|\ [**l**] ]
 [ |-I|\ [**e**\ \|\ **i**] ]
 [ |-N|\ *pfile*\ [**+a**][\ **+p**\ *start*][**+r**][**+z**] ]
@@ -109,9 +109,9 @@ Optional Arguments
 
 .. _-E:
 
-**-E**\ **+**\ \|\ **-** ]
-    Reset the handedness of all polygons to match the given **+**
-    (counter-clockwise) or **-** (clockwise). Implies **-Q+**.
+**-E**\ **+p**\ \|\ **n** ]
+    Reset the handedness of all polygons to match the given **+p**
+    (counter-clockwise; positive) or **+n** (clockwise; negative). Implies **-Q+**.
 
 .. _-F:
 
@@ -258,7 +258,7 @@ their areas to the segment headers, run
 
    ::
 
-    gmt spatial polygons.txt -Q+h -E+ > areas.txt
+    gmt spatial polygons.txt -Q+h -E+p > areas.txt
 
 To determine the areas of all the polygon segments in the file janmayen_land_full.txt,
 add this information to the segment headers, sort the segments from largest

--- a/src/gmtspatial.c
+++ b/src/gmtspatial.c
@@ -707,9 +707,9 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 #ifdef PW_TESTING
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] [-A[a<min_dist>][unit]] [-C]\n\t[-D[+f<file>][+a<amax>][+d%s][+c|C<cmax>][+l][+s<sfact>][+p]]\n\t[-E+|-] [-F[l]] [-I[i|e]] [-L%s/<pnoise>/<offset>] [-N<pfile>[+a][+p<ID>][+r][+z]] [-Q[[-|+]<unit>][+c<min>[/<max>]][+h][+l][+p][+s[a|d]]]\n", name, GMT_DIST_OPT, GMT_DIST_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] [-A[a<min_dist>][unit]] [-C]\n\t[-D[+f<file>][+a<amax>][+d%s][+c|C<cmax>][+l][+s<sfact>][+p]]\n\t[-E+p|n] [-F[l]] [-I[i|e]] [-L%s/<pnoise>/<offset>] [-N<pfile>[+a][+p<ID>][+r][+z]] [-Q[[-|+]<unit>][+c<min>[/<max>]][+h][+l][+p][+s[a|d]]]\n", name, GMT_DIST_OPT, GMT_DIST_OPT);
 #else
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] [-A[a<min_dist>][unit]] [-C]\n\t[-D[+f<file>][+a<amax>][+d%s][+c|C<cmax>][+l][+s<sfact>][+p]]\n\t[-E+|-] [-F[l]] [-I[i|e]] [-N<pfile>[+a][+p<ID>][+r][+z]] [-Q[[-|+]<unit>][+c<min>[/<max>]][+h][+l][+p][+s[a|d]]]\n", name, GMT_DIST_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] [-A[a<min_dist>][unit]] [-C]\n\t[-D[+f<file>][+a<amax>][+d%s][+c|C<cmax>][+l][+s<sfact>][+p]]\n\t[-E+p|n] [-F[l]] [-I[i|e]] [-N<pfile>[+a][+p<ID>][+r][+z]] [-Q[[-|+]<unit>][+c<min>[/<max>]][+h][+l][+p][+s[a|d]]]\n", name, GMT_DIST_OPT);
 #endif
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-Sh|i|j|s|u] [-T[<cpol>]] [%s]\n\t[%s] [%s] [%s] [%s] [%s]\n\t[%s] [%s] [%s]\n\t[%s] [%s] [%s]\n\n",
 		GMT_Rgeo_OPT, GMT_V_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT, GMT_i_OPT, GMT_o_OPT, GMT_s_OPT, GMT_colon_OPT, GMT_PAR_OPT);
@@ -734,7 +734,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   By default we consider all points when comparing two lines.  Use +p to limit\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   the comparison to points that project perpendicularly on to the other line.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-E Orient all polygons to have the same handedness.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append + for counter-clockwise or - for clockwise handedness.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Append +p for counter-clockwise (positive) or +n for clockwise (negative) handedness.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-F Force all input segments to become closed polygons on output by adding repeated point if needed.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use -Fl instead to ensure input lines are not treated as polygons.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Compute Intersection locations between input polygon(s).\n");
@@ -867,11 +867,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMTSPATIAL_CTRL *Ctrl, struct 
 					}
 				}
 				break;
-			case 'E':	/* Orient polygons */
+			case 'E':	/* Orient polygons -E+n|p  (old -E-|+) */
 			 	Ctrl->E.active = true;
-				if (opt->arg[0] == '-')
+				if (opt->arg[0] == '-' || strstr (opt->arg, "+n"))
 					Ctrl->E.mode = POL_IS_CW;
-				else if (opt->arg[0] == '+')
+				else if (opt->arg[0] == '+' || strstr (opt->arg, "+p"))
 					Ctrl->E.mode = POL_IS_CCW;
 				else
 					n_errors++;


### PR DESCRIPTION
Was just **-E**+|**-** but now have proper modifiers **+p** and **+n**.  Backwards compatible.
