### PR TITLE
Avoid using a colon as modifier

### DIFF
--- a/doc_modern/rst/source/subplot.rst_
+++ b/doc_modern/rst/source/subplot.rst_
@@ -15,7 +15,7 @@ Synopsis (begin mode)
 .. include:: common_SYN_OPTs.rst_
 
 **gmt subplot begin** *nrows*\ **x**\ *ncols*
-**-F**\ [**f**\ \|\ **s**\ ]\ *width*\ /*height*
+**-F**\ [**f**\ \|\ **s**\ ]\ *width*\ /*height*\ [**+f**\ *wfracs*\ /*hfracs*\ ]
 [ **-A**\ *autolabel* ]
 [ |SYN_OPT-B| ]
 [ |-J|\ *parameters* ]
@@ -45,7 +45,7 @@ Required Arguments
 
 .. _subplot_begin-F:
 
-**-F**\ [**f**\ \|\ **s**\ ]\ *width(s)*\ /*height(s)*\ [:*wfracs*\ /*hfracs*\ ]
+**-F**\ [**f**\ \|\ **s**\ ]\ *width(s)*\ /*height(s)*\ \ [**+f**\ *wfracs*\ /*hfracs*\ ]
     Specify the dimensions of the figure.  There are two different ways to do this:
     (**f**) Specify overall figure dimensions or (**s**) specify the dimensions of
     a single panel.
@@ -54,8 +54,8 @@ Required Arguments
     Specify the final figure dimensions.  The subplot dimensions are then calculated from the figure
     dimensions after accounting for the space that optional tick marks, annotations, labels, and margins occupy between panels.
     The annotations, ticks, and labels along the outside perimeter are not counted as part of the figure dimensions.
-    To specify different subplot dimensions for each row (or column), append a colon followed by a comma-separated list of width
-    fractions, a slash, and then the list of height fractions.  For example **–Ff**\ 4i/4i:3,1/1,2 will make the first column
+    To specify different subplot dimensions for each row (or column), append **+f** followed by a comma-separated list of width
+    fractions, a slash, and then the list of height fractions.  For example **–Ff**\ 4i/4i\ **+f**\ 3,1/1,2 will make the first column
     three times as wide as the second, while the second row will be twice as tall as the first row.
     A single number means constant widths (or heights) [Default].
 

--- a/test/modern/varfracs.sh
+++ b/test/modern/varfracs.sh
@@ -2,7 +2,7 @@
 # Test the variable widths and heights options for subplots
 # This test uses a fixed figure size and fractional dims
 gmt begin varfracs ps
-  gmt subplot begin 3x2 -Ff6.5i/9i:1,2/1,2,0.5 -SRl+p -SCb -BWSne -M0 -A -T"Variable fractions"
+  gmt subplot begin 3x2 -Ff6.5i/9i+f1,2/1,2,0.5 -SRl+p -SCb -BWSne -M0 -A -T"Variable fractions"
   gmt psbasemap -R0/5/0/5 -B+gpink -c1,1
   gmt psbasemap -R10/15/0/5 -B+gyellow -c1,2
   gmt psbasemap -R0/5/10/15 -B+gcyan -c2,1


### PR DESCRIPTION
The **-Ff** option used an optional **:**_arguments_ setting but it needs to be a real modifier for the long-format parser to be robust; using **+f**_arguments_ instead.  Not backwards compatible simply because subplot has not yet been released.