### PR TITLE
Improve -Q option directives for sphinterpolate

### DIFF
--- a/doc_classic/rst/source/sphinterpolate.rst
+++ b/doc_classic/rst/source/sphinterpolate.rst
@@ -15,7 +15,7 @@ sphinterpolate
 
 **sphinterpolate** [ *table* ] |-G|\ *grdfile*
 [ |SYN_OPT-I| ]
-[ |-Q|\ *mode*\ [/*options*] ]
+[ |-Q|\ *mode*\ [*options*] ]
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]
 [ |-Z| ]
@@ -61,26 +61,28 @@ Optional Arguments
 
 .. _-Q:
 
-**-Q**\ *mode*\ [/*options*]
+**-Q**\ *mode*\ [*options*]
     Specify one of four ways to calculate tension factors to preserve
     local shape properties or satisfy arc constraints [Default is no
     tension].
-**-Q**\ 0
-    Piecewise linear interpolation; no tension is applied.
-**-Q**\ 1
-    Smooth interpolation with local gradient estimates.
-**-Q**\ 2
-    Smooth interpolation with global gradient estimates. You may
-    optionally append /*N*/*M*/*U*, where *N* is the number of
+**-Qp**
+    Use **p**\ iecewise linear interpolation; no tension is applied.
+**-Ql**
+    Smooth interpolation with **l**\ ocal gradient estimates.
+**-Qg**
+    Smooth interpolation with **g**\ lobal gradient estimates. You may
+    optionally append *N*/*M*/*U*, where *N* is the number of
     iterations used to converge at solutions for gradients when variable
     tensions are selected (e.g., **-T** only) [3], *M* is the number of
     Gauss-Seidel iterations used when determining the global gradients
     [10], and *U* is the maximum change in a gradient at the last
     iteration [0.01].
-**-Q**\ 3
-    Smoothing. Optionally append */E/U* [/0/0], where *E* is Expected
+**-Qs**
+    Use **s**\ moothing. Optionally append *E*/*U*/*N* [/0/0/3], where *E* is Expected
     squared error in a typical (scaled) data value, and *U* is Upper
-    bound on weighted sum of squares of deviations from data.
+    bound on weighted sum of squares of deviations from data. Here, *N* is the number of
+    iterations used to converge at solutions for gradients when variable
+    tensions are selected (e.g., **-T** only) [3]
 
 .. _-R:
 
@@ -90,7 +92,7 @@ Optional Arguments
 .. _-T:
 
 **-T**
-    Use variable tension (ignored with **-Q**\ 0 [constant]
+    Use variable tension (ignored with **-Qp** [constant]
 
 .. _-V:
 

--- a/doc_modern/rst/source/sphinterpolate.rst
+++ b/doc_modern/rst/source/sphinterpolate.rst
@@ -15,7 +15,7 @@ sphinterpolate
 
 **gmt sphinterpolate** [ *table* ] |-G|\ *grdfile*
 [ |SYN_OPT-I| ]
-[ |-Q|\ *mode*\ [/*options*] ]
+[ |-Q|\ *mode*\ [*options*] ]
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]
 [ |-Z| ]
@@ -61,26 +61,28 @@ Optional Arguments
 
 .. _-Q:
 
-**-Q**\ *mode*\ [/*options*]
+**-Q**\ *mode*\ [*options*]
     Specify one of four ways to calculate tension factors to preserve
     local shape properties or satisfy arc constraints [Default is no
     tension].
-**-Q**\ 0
-    Piecewise linear interpolation; no tension is applied.
-**-Q**\ 1
-    Smooth interpolation with local gradient estimates.
-**-Q**\ 2
-    Smooth interpolation with global gradient estimates. You may
-    optionally append /*N*/*M*/*U*, where *N* is the number of
+**-Qp**
+    Use **p**\ iecewise linear interpolation; no tension is applied.
+**-Ql**
+    Smooth interpolation with **l**\ ocal gradient estimates.
+**-Qg**
+    Smooth interpolation with **g**\ lobal gradient estimates. You may
+    optionally append *N*/*M*/*U*, where *N* is the number of
     iterations used to converge at solutions for gradients when variable
     tensions are selected (e.g., **-T** only) [3], *M* is the number of
     Gauss-Seidel iterations used when determining the global gradients
     [10], and *U* is the maximum change in a gradient at the last
     iteration [0.01].
-**-Q**\ 3
-    Smoothing. Optionally append */E/U* [/0/0], where *E* is Expected
+**-Qs**
+    Use **s**\ moothing. Optionally append *E*/*U*/*N* [/0/0/3], where *E* is Expected
     squared error in a typical (scaled) data value, and *U* is Upper
-    bound on weighted sum of squares of deviations from data.
+    bound on weighted sum of squares of deviations from data. Here, *N* is the number of
+    iterations used to converge at solutions for gradients when variable
+    tensions are selected (e.g., **-T** only) [3]
 
 .. _-R:
 

--- a/src/sphinterpolate.c
+++ b/src/sphinterpolate.c
@@ -92,7 +92,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "==> The hard work is done by algorithms 772 (STRIPACK) & 773 (SSRFPACK) by R. J. Renka [1997] <==\n\n");
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] -G<outgrid> %s\n", name, GMT_I_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-Q<mode>][/<args>] [%s] [-T] [%s] [-Z] [%s]\n\t[%s] [%s] [%s] [%s]\n\t[%s] [%s] [%s] [%s]\n\n",
+	GMT_Message (API, GMT_TIME_NONE, "\t[-Q<mode>][<args>] [%s] [-T] [%s] [-Z] [%s]\n\t[%s] [%s] [%s] [%s]\n\t[%s] [%s] [%s] [%s]\n\n",
 		GMT_Rgeo_OPT, GMT_V_OPT, GMT_bi_OPT, GMT_di_OPT, GMT_e_OPT, GMT_h_OPT, GMT_i_OPT, GMT_r_OPT, GMT_s_OPT, GMT_colon_OPT, GMT_PAR_OPT);
                
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -103,20 +103,20 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t<table> is one or more data file (in ASCII, binary, netCDF) with (x,y,z[,w]).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If no files are given, standard input is read.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-Q Select tension factors to achieve the following [Default is no tension]:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   0: Piecewise linear interpolation ; no tension [Default]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   1: Smooth interpolation with local gradient estimates.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   2: Smooth interpolation with global gradient estimates and tension.  Optionally append /N/M/U:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      N = Number of iterations to converge solutions for gradients and variable tensions (-T only) [3],\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      M = Number of Gauss-Seidel iterations when determining gradients [10],\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      U = Maximum change in a gradient at the last iteration [0.01].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   3: Smoothing.  Optionally append /<E>/<U>/<N>, where\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-Q Compute tension factors to achieve the following [Default is no tension]:\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   p: Piecewise linear interpolation ; no tension [Default]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   l: Smooth interpolation with local gradient estimates.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   g: Smooth interpolation with global gradient estimates and tension.  Optionally append <N>/<M>/<U>:\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t      <N> = Number of iterations to converge solutions for gradients and variable tensions (-T only) [3],\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t      <M> = Number of Gauss-Seidel iterations when determining gradients [10],\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t      <U> = Maximum change in a gradient at the last iteration [0.01].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   s: Smoothing.  Optionally append <E>/<U>/<N>, where\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      <E> = Expected squared error in a typical (scaled) data value [0.01],\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      <U> = Upper bound on  weighted sum of squares of deviations from data [npoints],\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      <N> = Number of iterations to converge solutions for gradients and variable tensions (-T only) [3].\n");
 	GMT_Option (API, "Rg");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If no region is specified we default to the entire world [-Rg].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-T Use variable tension (ignored for -Q0) [constant].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-T Use variable tension (ignored for -Qp) [constant].\n");
 	GMT_Option (API, "V");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Z Scale data by 1/(max-min) prior to gridding [no scaling].\n");
 	GMT_Option (API, "bi3,di,e,h,i,r,s,:,.");
@@ -131,7 +131,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct SPHINTERPOLATE_CTRL *Ctrl, str
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int n_errors = 0;
+	unsigned int n_errors = 0, k;
 	int m;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
@@ -157,25 +157,27 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct SPHINTERPOLATE_CTRL *Ctrl, str
 			case 'Q':
 				Ctrl->Q.active = true;
 				switch (opt->arg[0]) {
-					case '0':	/* Linear */
+					case 'p':	case '0':	/* Piecewise Linear p (0 is old mode)*/
 						Ctrl->Q.mode = 0;	break;
-					case '1':
+					case 'l':	case '1':	/* Local gradients l (1 is old mode) */
 						Ctrl->Q.mode = 1;	break;
-					case '2':
+					case 'g':	case '2':	/* Global gradients g (2 is old mode) */
 						Ctrl->Q.mode = 2;
-						if (opt->arg[1] == '/') {	/* Gave optional n/m/dgmx */
-							if ((m = get_args (GMT, &opt->arg[2], Ctrl->Q.value, "-Q3/N[/M[/U]]")) < 0) n_errors++;
+						if (opt->arg[1]) {	/* Gave optional n/m/dgmx */
+							k = (opt->arg[1] == '/') ? 2 : 1;	/* Gave optional /n/m/dgmx */
+							if ((m = get_args (GMT, &opt->arg[k], Ctrl->Q.value, "-Qg<N>[/<M>[/<U>]]")) < 0) n_errors++;
 						}
 						break;
-					case '3':
+					case 's':	case '3':	/* Smoothing s (3 is old mode) */
 						Ctrl->Q.mode = 3;
-						if (opt->arg[1] == '/') {	/* Gave optional e/sm/niter */
-							if ((m = get_args (GMT, &opt->arg[2], Ctrl->Q.value, "-Q3/E[/U[/niter]]")) < 0) n_errors++;
+						if (opt->arg[1]) {	/* Gave optional e/sm/niter */
+							k = (opt->arg[1] == '/') ? 2 : 1;	/* Gave optional /e/sm/niter */
+							if ((m = get_args (GMT, &opt->arg[k], Ctrl->Q.value, "-Qs<E>[/<U>[/<niter>]]")) < 0) n_errors++;
 						}
 						break;
 					default:
 						n_errors++;
-						GMT_Report (API, GMT_MSG_NORMAL, "-%c Mode must be in 0-3 range\n", (int)opt->option);
+						GMT_Report (API, GMT_MSG_NORMAL, "-%c Mode must be one of p,l,g,s\n", (int)opt->option);
 						break;
 				}
 				break;

--- a/test/sph/sph_1.ps
+++ b/test/sph/sph_1.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from grdimage
+%%Title: GMT v6.0.0_8cc086f [64-bit] Document from grdimage
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:51:17 2018
+%%CreationDate: Mon Dec 31 19:17:11 2018
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Landscape
@@ -672,7 +672,7 @@ O0
 840 6600 TM
 
 % PostScript produced by:
-%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Q0 -Ctt.cpt -X0.7i -Y5.5i -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
+%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Qp -Ctt.cpt -X0.7i -Y5.5i -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %GMTBoundingBox: 50.4 396 324 162
 %%BeginObject PSL_Layer_1
@@ -2988,7 +2988,7 @@ P S
 (100è) sh add def
 2700 2700 PSL_H_y add M
 300 F0
-(îQ0) bc Z
+(îQp) bc Z
 1179 182 M 200 F0
 V -0.045 R (î60è) mr Z U
 4221 182 M V 0.045 R (î60è) ml Z U
@@ -3007,7 +3007,7 @@ O0
 6120 0 TM
 
 % PostScript produced by:
-%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Q1 -Ctt.cpt -X5.1i -O -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
+%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Ql -Ctt.cpt -X5.1i -O -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -5390,7 +5390,7 @@ P S
 (100è) sh add def
 2700 2700 PSL_H_y add M
 300 F0
-(îQ1) bc Z
+(îQl) bc Z
 1179 182 M 200 F0
 V -0.045 R (î60è) mr Z U
 4221 182 M V 0.045 R (î60è) ml Z U
@@ -5409,7 +5409,7 @@ O0
 -6120 -6000 TM
 
 % PostScript produced by:
-%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Q2 -Ctt.cpt -X-5.1i -Y-5i -O -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
+%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Qg -Ctt.cpt -X-5.1i -Y-5i -O -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -7807,7 +7807,7 @@ P S
 (100è) sh add def
 2700 2700 PSL_H_y add M
 300 F0
-(îQ2) bc Z
+(îQg) bc Z
 1179 182 M 200 F0
 V -0.045 R (î60è) mr Z U
 4221 182 M V 0.045 R (î60è) ml Z U
@@ -7826,7 +7826,7 @@ O0
 6120 0 TM
 
 % PostScript produced by:
-%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Q3 -Ctt.cpt -X5.1i -O -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
+%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Qs -Ctt.cpt -X5.1i -O -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -10224,7 +10224,7 @@ P S
 (100è) sh add def
 2700 2700 PSL_H_y add M
 300 F0
-(îQ3) bc Z
+(îQs) bc Z
 1179 182 M 200 F0
 V -0.045 R (î60è) mr Z U
 4221 182 M V 0.045 R (î60è) ml Z U

--- a/test/sph/sph_1.sh
+++ b/test/sph/sph_1.sh
@@ -5,14 +5,14 @@ ps=sph_1.ps
 mars370=@mars370d.txt
 
 gmt makecpt -Crainbow -T-7000/15000 > tt.cpt
-gmt sphinterpolate ${mars370} -Rg -I1 -Q0 -Gtt.nc
-gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t"-Q0" -Ctt.cpt -X0.7i -Y5.5i -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p > $ps
-gmt sphinterpolate ${mars370} -Rg -I1 -Q1 -Gtt.nc
-gmt grdimage tt.nc -J -B30g30 -B+t"-Q1" -Ctt.cpt -X5.1i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
-gmt sphinterpolate ${mars370} -Rg -I1 -Q2 -Gtt.nc
-gmt grdimage tt.nc -J -B30g30 -B+t"-Q2" -Ctt.cpt -X-5.1i -Y-5i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
-gmt sphinterpolate ${mars370} -Rg -I1 -Q3 -Gtt.nc
-gmt grdimage tt.nc -J -B30g30 -B+t"-Q3" -Ctt.cpt -X5.1i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
+gmt sphinterpolate ${mars370} -Rg -I1 -Qp -Gtt.nc
+gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t"-Qp" -Ctt.cpt -X0.7i -Y5.5i -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p > $ps
+gmt sphinterpolate ${mars370} -Rg -I1 -Ql -Gtt.nc
+gmt grdimage tt.nc -J -B30g30 -B+t"-Ql" -Ctt.cpt -X5.1i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
+gmt sphinterpolate ${mars370} -Rg -I1 -Qg -Gtt.nc
+gmt grdimage tt.nc -J -B30g30 -B+t"-Qg" -Ctt.cpt -X-5.1i -Y-5i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
+gmt sphinterpolate ${mars370} -Rg -I1 -Qs -Gtt.nc
+gmt grdimage tt.nc -J -B30g30 -B+t"-Qs" -Ctt.cpt -X5.1i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
 gmt psxy -Rg -J -O -K ${mars370} -Sc0.05i -G0 -B30g30 -X-2.55i -Y2.5i >> $ps
 gmt psxy -Rg -J -O -T >> $ps
 

--- a/test/sph/sph_2.ps
+++ b/test/sph/sph_2.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from grdimage
+%%Title: GMT v6.0.0_8cc086f [64-bit] Document from grdimage
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:50:26 2018
+%%CreationDate: Mon Dec 31 19:16:18 2018
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Landscape
@@ -672,7 +672,7 @@ O0
 840 6600 TM
 
 % PostScript produced by:
-%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Q0 -Ctt.cpt -X0.7i -Y5.5i -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
+%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Qp -Ctt.cpt -X0.7i -Y5.5i -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %GMTBoundingBox: 50.4 396 324 162
 %%BeginObject PSL_Layer_1
@@ -3152,7 +3152,7 @@ P S
 (100è) sh add def
 2700 2700 PSL_H_y add M
 300 F0
-(îQ0) bc Z
+(îQp) bc Z
 1179 182 M 200 F0
 V -0.045 R (î60è) mr Z U
 4221 182 M V 0.045 R (î60è) ml Z U
@@ -3171,7 +3171,7 @@ O0
 6120 0 TM
 
 % PostScript produced by:
-%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Q1 -Ctt.cpt -X5.1i -O -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
+%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Ql -Ctt.cpt -X5.1i -O -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -5656,7 +5656,7 @@ P S
 (100è) sh add def
 2700 2700 PSL_H_y add M
 300 F0
-(îQ1) bc Z
+(îQl) bc Z
 1179 182 M 200 F0
 V -0.045 R (î60è) mr Z U
 4221 182 M V 0.045 R (î60è) ml Z U
@@ -5675,7 +5675,7 @@ O0
 -6120 -6000 TM
 
 % PostScript produced by:
-%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Q2 -Ctt.cpt -X-5.1i -Y-5i -O -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
+%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Qg -Ctt.cpt -X-5.1i -Y-5i -O -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -8177,7 +8177,7 @@ P S
 (100è) sh add def
 2700 2700 PSL_H_y add M
 300 F0
-(îQ2) bc Z
+(îQg) bc Z
 1179 182 M 200 F0
 V -0.045 R (î60è) mr Z U
 4221 182 M V 0.045 R (î60è) ml Z U
@@ -8196,7 +8196,7 @@ O0
 6120 0 TM
 
 % PostScript produced by:
-%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Q3 -Ctt.cpt -X5.1i -O -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
+%@GMT: gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t-Qs -Ctt.cpt -X5.1i -O -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -10698,7 +10698,7 @@ P S
 (100è) sh add def
 2700 2700 PSL_H_y add M
 300 F0
-(îQ3) bc Z
+(îQs) bc Z
 1179 182 M 200 F0
 V -0.045 R (î60è) mr Z U
 4221 182 M V 0.045 R (î60è) ml Z U

--- a/test/sph/sph_2.sh
+++ b/test/sph/sph_2.sh
@@ -4,14 +4,14 @@
 ps=sph_2.ps
 
 gmt makecpt -Crainbow -T-9000/9000 > tt.cpt
-gmt sphinterpolate lun2.txt -Rg -I1 -Q0 -Gtt.nc
-gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t"-Q0" -Ctt.cpt -X0.7i -Y5.5i -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p > $ps
-gmt sphinterpolate lun2.txt -Rg -I1 -Q1 -Gtt.nc
-gmt grdimage tt.nc -J -B30g30 -B+t"-Q1" -Ctt.cpt -X5.1i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
-gmt sphinterpolate lun2.txt -Rg -I1 -Q2 -Gtt.nc
-gmt grdimage tt.nc -J -B30g30 -B+t"-Q2" -Ctt.cpt -X-5.1i -Y-5i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
-gmt sphinterpolate lun2.txt -Rg -I1 -Q3 -Gtt.nc
-gmt grdimage tt.nc -J -B30g30 -B+t"-Q3" -Ctt.cpt -X5.1i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
+gmt sphinterpolate lun2.txt -Rg -I1 -Qp -Gtt.nc
+gmt grdimage tt.nc -JH0/4.5i -B30g30 -B+t"-Qp" -Ctt.cpt -X0.7i -Y5.5i -K --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p > $ps
+gmt sphinterpolate lun2.txt -Rg -I1 -Ql -Gtt.nc
+gmt grdimage tt.nc -J -B30g30 -B+t"-Ql" -Ctt.cpt -X5.1i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
+gmt sphinterpolate lun2.txt -Rg -I1 -Qg -Gtt.nc
+gmt grdimage tt.nc -J -B30g30 -B+t"-Qg" -Ctt.cpt -X-5.1i -Y-5i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
+gmt sphinterpolate lun2.txt -Rg -I1 -Qs -Gtt.nc
+gmt grdimage tt.nc -J -B30g30 -B+t"-Qs" -Ctt.cpt -X5.1i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
 gmt psxy -Rg -J -O -K lun2.txt -Sc0.02i -G0 -B30g30 -X-2.55i -Y2.5i >> $ps
 gmt psxy -Rg -J -O -T >> $ps
 


### PR DESCRIPTION
The old **-Q** option took numbers 0-3 which does not remind users what they stand for.  Replaced with character codes p, l, g, s (piecewise, local, global, smoothing) that at least has some mnemonic power.  Backwards compatible parsing.
