### PR TITLE
Avoid leading - or + as directives since confusing for modifiers

### DIFF
--- a/doc_classic/rst/source/grdcontour.rst
+++ b/doc_classic/rst/source/grdcontour.rst
@@ -27,7 +27,7 @@ Synopsis
 [ |-Q|\ [*cut*\ [*unit*]][\ **+z**] ]
 [ |SYN_OPT-Rz| ]
 [ |-S|\ *smoothfactor* ]
-[ |-T|\ [**+\|-**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]] ]
+[ |-T|\ [**h**\ \|\ **l**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ [*type*]\ *pen* ][**+c**\ [**l**\ \|\ **f**]]
@@ -203,13 +203,13 @@ Optional Arguments
 
 .. _-T:
 
-**-T**\ [**+\|-**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]]
+**-T**\ [**h**\ \|\ **l**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]]
     Will draw tick marks pointing in the downward direction every *gap*
     along the innermost closed contours only; append **+a** to tick all closed
     contours. Append **+d**\ *gap* and optionally tick
     mark *length* (append units as **c**, **i**, or **p**) or use defaults
     [15\ **p**/3\ **p**]. User may choose to tick only local highs or local
-    lows by specifying **-T+** or **-T-**, respectively. Append
+    lows by specifying **-Th** or **-Tl**, respectively. Append
     **+l**\ *labels* to annotate the centers of closed innermost contours
     (i.e., the local lows and highs). If no *labels* is appended we use -
     and + as the labels. Appending exactly two characters, e.g., **+l**\ *LH*,

--- a/doc_classic/rst/source/pscontour.rst
+++ b/doc_classic/rst/source/pscontour.rst
@@ -28,7 +28,7 @@ Synopsis
 [ |-P| ]
 [ |-Q|\ [*cut*\ [*unit*]][\ **+z**] ]
 [ |-S|\ [\ *p*\ \|\ *t*] ]
-[ |-T|\ [**+\|-**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]] ]
+[ |-T|\ [**h**\ \|\ **l**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ [*type*]\ *pen* ][**+c**\ [**l**\ \|\ **f**]]
@@ -203,13 +203,13 @@ Optional Arguments
 
 .. _-T:
 
-**-T**\ [**+\|-**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]]
+**-T**\ [**h**\ \|\ **l**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]]
     Will draw tick marks pointing in the downward direction every *gap*
     along the innermost closed contours only; append **+a** to tick all closed
     contours. Append **+d**\ *gap* and optionally tick
     mark *length* (append units as **c**, **i**, or **p**) or use defaults
     [15\ **p**/3\ **p**]. User may choose to tick only local highs or local
-    lows by specifying **-T+** or **-T-**, respectively. Append
+    lows by specifying **-Th** or **-Tl**, respectively. Append
     **+l**\ *labels* to annotate the centers of closed innermost contours
     (i.e., the local lows and highs). If no *labels* is appended we use -
     and + as the labels. Appending exactly two characters, e.g., **+l**\ *LH*,

--- a/doc_modern/rst/source/contour.rst
+++ b/doc_modern/rst/source/contour.rst
@@ -25,7 +25,7 @@ Synopsis
 [ |-L|\ *pen* ] [ |-N| ]
 [ |-Q|\ [*cut*\ [*unit*]][\ **+z**] ]
 [ |-S|\ [\ *p*\ \|\ *t*] ]
-[ |-T|\ [**+\|-**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]] ]
+[ |-T|\ [**h**\ \|\ **l**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ [*type*]\ *pen* ][**+c**\ [**l**\ \|\ **f**]]
@@ -188,13 +188,13 @@ Optional Arguments
 
 .. _-T:
 
-**-T**\ [**+\|-**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]]
+**-T**\ [**h**\ \|\ **l**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]]
     Will draw tick marks pointing in the downward direction every *gap*
     along the innermost closed contours only; append **+a** to tick all closed
     contours. Append **+d**\ *gap* and optionally tick
     mark *length* (append units as **c**, **i**, or **p**) or use defaults
     [15\ **p**/3\ **p**]. User may choose to tick only local highs or local
-    lows by specifying **-T+** or **-T-**, respectively. Append
+    lows by specifying **-Th** or **-Tl**, respectively. Append
     **+l**\ *labels* to annotate the centers of closed innermost contours
     (i.e., the local lows and highs). If no *labels* is appended we use -
     and + as the labels. Appending exactly two characters, e.g., **+l**\ *LH*,

--- a/doc_modern/rst/source/grdcontour.rst
+++ b/doc_modern/rst/source/grdcontour.rst
@@ -26,7 +26,7 @@ Synopsis
 [ |-Q|\ [*cut*\ [*unit*]][\ **+z**] ]
 [ |SYN_OPT-Rz| ]
 [ |-S|\ *smoothfactor* ]
-[ |-T|\ [**+\|-**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]] ]
+[ |-T|\ [**h**\ \|\ **l**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ [*type*]\ *pen* ][**+c**\ [**l**\ \|\ **f**]]
@@ -190,13 +190,13 @@ Optional Arguments
 
 .. _-T:
 
-**-T**\ [**+\|-**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]]
+**-T**\ [**h**\ \|\ **l**][**+a**][**+d**\ *gap*\ [/*length*]][\ **+l**\ [*labels*]]
     Will draw tick marks pointing in the downward direction every *gap*
     along the innermost closed contours only; append **+a** to tick all closed
     contours. Append **+d**\ *gap* and optionally tick
     mark *length* (append units as **c**, **i**, or **p**) or use defaults
     [15\ **p**/3\ **p**]. User may choose to tick only local highs or local
-    lows by specifying **-T+** or **-T-**, respectively. Append
+    lows by specifying **-Th** or **-Tl**, respectively. Append
     **+l**\ *labels* to annotate the centers of closed innermost contours
     (i.e., the local lows and highs). If no *labels* is appended we use -
     and + as the labels. Appending exactly two characters, e.g., **+l**\ *LH*,


### PR DESCRIPTION
The **-T**[**-**|**+**] directive has been changed to **-T**[**l**|**h**] but is backwards compatible.
