### PR TITLE
Avoid using - or + as directive in options

### DIFF
--- a/doc_classic/rst/source/gmtconvert.rst
+++ b/doc_classic/rst/source/gmtconvert.rst
@@ -18,7 +18,7 @@ Synopsis
 [ |-E|\ [**f**\ \|\ **l**\ \|\ **m**\ \|\ **M**\ *stride*] ] [ |-L| ]
 [ |-F|\ [**c**\ \|\ **n**\ \|\ **r**\ \|\ **v**\ ][**a**\ \|\ **f**\ \|\ **s**\ \|\ **r**\ \|\ *refpoint*] ]
 [ |-I|\ [**tsr**] ]
-[ |-N|\ [**-** \|\ **+**\ ]\ *col* ]
+[ |-N|\ *col*\ [**+a** \|\ **d**\ ] ]
 [ |-Q|\ [**~**]\ *selection*]
 [ |-S|\ [**~**]\ *"search string"* \| |-S|\ [**~**]/\ *regexp*/[**i**] ]
 [ |-T|\ [**h**\ \|\ **d**\ ] ]
@@ -152,10 +152,10 @@ Optional Arguments
 
 .. _-N:
 
-**-N**\ [**-** \|\ **+**\ ]\ *col*
+**-N**\ *col*\ [**+a** \|\ **d**\ ]
     Numerically sort each segment based on values in column *col*.
     The data records will be sorted such that the chosen column will
-    fall into ascending order [Default].  Give a negative column number
+    fall into ascending order [**+a**\ , which is Default].  Append **+d**
     to sort into descending order instead.  The **-N** option can be
     combined with any other ordering scheme except **-F** (segmentation)
     and is applied at the end.

--- a/doc_modern/rst/source/gmtconvert.rst
+++ b/doc_modern/rst/source/gmtconvert.rst
@@ -18,7 +18,7 @@ Synopsis
 [ |-E|\ [**f**\ \|\ **l**\ \|\ **m**\ \|\ **M**\ *stride*] ] [ |-L| ]
 [ |-F|\ [**c**\ \|\ **n**\ \|\ **r**\ \|\ **v**\ ][**a**\ \|\ **f**\ \|\ **s**\ \|\ **r**\ \|\ *refpoint*] ]
 [ |-I|\ [**tsr**] ]
-[ |-N|\ [**-** \|\ **+**\ ]\ *col* ]
+[ |-N|\ *col*\ [**+a** \|\ **d**\ ] ]
 [ |-Q|\ [**~**]\ *selection*]
 [ |-S|\ [**~**]\ *"search string"* \| |-S|\ [**~**]/\ *regexp*/[**i**] ]
 [ |-T|\ [**h**\ \|\ **d**\ ] ]
@@ -153,10 +153,10 @@ Optional Arguments
 
 .. _-N:
 
-**-N**\ [**-** \|\ **+**\ ]\ *col*
+**-N**\ *col*\ [**+a** \|\ **d**\ ]
     Numerically sort each segment based on values in column *col*.
     The data records will be sorted such that the chosen column will
-    fall into ascending order [Default].  Give a negative column number
+    fall into ascending order [**+a**\ , which is Default].  Append **+d**
     to sort into descending order instead.  The **-N** option can be
     combined with any other ordering scheme except **-F** (segmentation)
     and is applied at the end.

--- a/src/gmtconvert.c
+++ b/src/gmtconvert.c
@@ -80,7 +80,7 @@ struct GMTCONVERT_CTRL {
 	struct L {	/* -L */
 		bool active;
 	} L;
-	struct N {	/* -N[+|-]<col> sorting */
+	struct N {	/* -N<col>[+a|d] sorting */
 		bool active;
 		int dir;	/* +1 ascending [default], -1 descending */
 		uint64_t col;
@@ -130,7 +130,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] [-A] [-C[+l<min>][+u<max>][+i]] [-D[<template>[+o<orig>]]] [-E[f|l|m|M<stride>]] [-F<arg>] [-I[tsr]]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-L] [-N[+|-]<col>] [-Q[~]<selection>] [-S[~]\"search string\"] [-T[hd]] [%s] [-W[+n]] [-Z[<first>][:<last>]] [%s]\n\t[%s] [%s] [%s] [%s] [%s]\n", GMT_V_OPT, GMT_a_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-L] [-N<col>[+a|d]] [-Q[~]<selection>] [-S[~]\"search string\"] [-T[hd]] [%s] [-W[+n]] [-Z[<first>][:<last>]] [%s]\n\t[%s] [%s] [%s] [%s] [%s]\n", GMT_V_OPT, GMT_a_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s]\n\t[%s] [%s] [%s] [%s]\n\n", GMT_h_OPT, GMT_i_OPT, GMT_o_OPT, GMT_s_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -164,7 +164,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-L Output only segment headers and skip all data records.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Requires ASCII input data [Output headers and data].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Numerically sort all records per segment based on data in column <col>.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Prepend - to <col> for descending order [ascending].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Append +a for ascending or +d for descending order [ascending].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Q Only output specified segment numbers in <selection> [All].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   <selection> syntax is [~]<range>[,<range>,...] where each <range> of items is\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   either a single number, start-stop (for range), start:step:stop (for stepped range),\n");
@@ -307,8 +307,15 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMTCONVERT_CTRL *Ctrl, struct 
 				break;
 			case 'N':	/* Sort per segment on specified column */
 				Ctrl->N.active = true;
+				if ((c = strstr (opt->arg, "+a")) || (c = strstr (opt->arg, "+d"))) {	/* New syntax */
+					Ctrl->N.dir = (c[1] == 'd') ? -1 : +1;
+					c[0] = '\0';	/* Chop off modifier */
+				}
 				value = atol (opt->arg);
-				Ctrl->N.dir = (value < 0 || opt->arg[0] == '-') ? -1 : +1;
+				if (c)
+					c[0] = '+';	/* Restore modifier */
+				else
+					Ctrl->N.dir = (value < 0 || opt->arg[0] == '-') ? -1 : +1;
 				Ctrl->N.col = int64_abs (value);
 				break;
 			case 'Q':	/* Only report for specified segment numbers */


### PR DESCRIPTION
The **-N** option in gmtconvert now uses modifiers **+a** and **+d** for sorting into ascending or descending order, respectively.  Backwards compatible.
