### PR TITLE
Modernize options in mgd77 supplement

### DIFF
--- a/doc_classic/rst/source/supplements/mgd77/mgd77convert.rst
+++ b/doc_classic/rst/source/supplements/mgd77/mgd77convert.rst
@@ -14,10 +14,10 @@ Synopsis
 .. include:: ../../common_SYN_OPTs.rst_
 
 **mgd77convert** *NGDC-ids* |-F|\ **a**\ \|\ **c**\ \|\ **m** \|\ **t**
-|-T|\ [**+**]\ **a**\ \|\ **c**\ \|\ **m**\ \|\ **t**
+|-T|\ **a**\ \|\ **c**\ \|\ **m**\ \|\ **t**\ [**+f**]
 [ |-C| ]
 [ |-D| ]
-[ |-L|\ [**w**][**e**][**+**] ]
+[ |-L|\ [**w**][**e**][**+l**] ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT--| ]
 
@@ -48,14 +48,14 @@ Required Arguments
 
 .. _-T:
 
-**-T**\ [**+**]\ **a**\ \|\ **c**\ \|\ **m** \|\ **t**
+**-T**\ **a**\ \|\ **c**\ \|\ **m**\ \|\ **t**\ [**+f**]
     Specifies the format of the output (To) files. Choose from **a** for
     standard MGD77 ASCII table (with extension .mgd77), **c** for the
     new MGD77+ netCDF format (with extension .nc), **m** for the
     new MGD77T format (extension .m77t) and **t** for a plain
     ASCII tab-separated table dump (with extension .dat). We will refuse
     to create the file(s) if they already exist in the current
-    directory. Prepend **+** to override this policy.
+    directory. Append **+f** to force an override of this policy.
 
 Optional Arguments
 ------------------
@@ -81,10 +81,10 @@ Optional Arguments
 
 .. _-L:
 
-**-L**\ [**w**\ ][**e**\ ][**+**\ ]
+**-L**\ [**w**\ ][**e**\ ][**+l**\ ]
     Set the level of verification reporting [none] and where to send
-    such reports [stderr]. Append a combination of **w** for warnings,
-    **e** for errors, and **+** to send such log information to stdout.
+    such reports [stderr]. Append a combination of **w** for warnings and
+    **e** for errors, and append **+l** to send such log information to stdout.
  
 .. _-V:
 
@@ -107,7 +107,7 @@ and capture all verification messages, try
 
    ::
 
-    gmt mgd77convert 01010047 01010008 -Fa -Tc -V -Lew+ > log.lis
+    gmt mgd77convert 01010047 01010008 -Fa -Tc -V -Lew+l > log.lis
 
 To convert 01010047.nc back to MGD77 ASCII and make sure it is identical
 to the original file, try (Bourne shell syntax)
@@ -123,7 +123,7 @@ overwriting any existing table, try
 
    ::
 
-    gmt mgd77convert 01010047 -Fc -T+t -V
+    gmt mgd77convert 01010047 -Fc -Tt+f -V
 
 To recover the original NGDC MGD77 version of 01020051.nc and ignore any
 E77 corrections, use

--- a/doc_classic/rst/source/supplements/mgd77/mgd77list.rst
+++ b/doc_classic/rst/source/supplements/mgd77/mgd77list.rst
@@ -14,7 +14,7 @@ Synopsis
 .. include:: ../../common_SYN_OPTs.rst_
 
 **mgd77list** *NGDC-ids* |-F|\ *columns*\ [,\ *logic*][:\ *bittests*]
-[ |-A|\ [**+**\ ]\ **c**\ \|\ **d**\ \|\ **f**\ \|\ **m**\ \|\ **t**\ *code* ]
+[ |-A|\ **c**\ \|\ **d**\ \|\ **f**\ \|\ **m**\ \|\ **t**\ *code*\ [**+f**\ ] ]
 [ |-C|\ **f**\ \|\ **g**\ \|\ **e** ]
 [ |-D|\ **A**\ \|\ **a**\ *startdate* ]
 [ |-D|\ **B**\ \|\ **b**\ *stopdate* ]
@@ -31,7 +31,7 @@ Synopsis
 [ |-T|\ [**m**\ \|\ **e**] ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *weight* ]
-[ |-Z|\ *+*\ \|\ **-** ]
+[ |-Z|\ **n**\ \|\ **p** ]
 [ |SYN_OPT-bo| ]
 [ |SYN_OPT-h| ]
 [ |SYN_OPT--| ]
@@ -247,7 +247,7 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ [**+**\ ]\ **c**\ \|\ **d**\ \|\ **f**\ \|\ **m**\ \|\ **t**\ *code*
+**-A**\ **c**\ \|\ **d**\ \|\ **f**\ \|\ **m**\ \|\ **t**\ *code*\ [**+f**\ ]
     By default, corrected depth (**depth**), magnetic residual anomaly
     (**mag**), free-air gravity anomaly (**faa**), and the derived
     quantity Carter depth correction (**carter**) are all output as is
@@ -261,7 +261,7 @@ Optional Arguments
     we will next try **-Ac**\ 2 which only uses **twt**. In all cases,
     if any of the values required by an adjustment procedure is NaN then
     the result will be NaN. This is also true if the original anomaly is
-    NaN. Specify **-A+** to recalculate anomalies even if the anomaly in
+    NaN. Append **+f** to recalculate anomalies even if the anomaly in
     the file is NaN. Additionally, you can use **-At** to create fake
     times for cruises that has no time; these are based on distances and
     cruise duration.
@@ -476,10 +476,10 @@ Optional Arguments
 
 .. _-Z:
 
-**-Z**\ *+*\ \|\ **-**
+**-Z**\ **n**\ \|\ **p**
     Append the sign you want for **depth**, **carter**, and **msd**
-    values below sea level (**-Z-** gives negative bathymetry) [Default
-    is positive down]. 
+    values below sea level (**-Zn** gives negative bathymetry) [Default
+    is **-Zp** for positive down]. 
 
 .. |Add_-bo| replace:: ignored if **-bo** is selected. Likewise,
     string-fields cannot be selected. Note that if time is one of the

--- a/doc_classic/rst/source/supplements/mgd77/mgd77path.rst
+++ b/doc_classic/rst/source/supplements/mgd77/mgd77path.rst
@@ -13,7 +13,7 @@ Synopsis
 
 .. include:: ../../common_SYN_OPTs.rst_
 
-**mgd77path** *NGDC-ids* [ |-A|\ [**-**] ] [ |-D| ]
+**mgd77path** *NGDC-ids* [ |-A|\ [**c**] ] [ |-D| ]
 [ |-I|\ *ignore* ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT--| ]
@@ -37,9 +37,9 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ [**-**]
+**-A**\ [**c**]
     Display the full path to each cruise [Default]. Optionally, append
-    **-** which will list just the cruise IDs instead.
+    **c** which will list just the cruise IDs instead.
 
 .. _-D:
 

--- a/doc_classic/rst/source/supplements/mgd77/mgd77track.rst
+++ b/doc_classic/rst/source/supplements/mgd77/mgd77track.rst
@@ -16,7 +16,7 @@ Synopsis
 **mgd77track** *NGDC-ids*
 |SYN_OPT-R|
 |-J|\ *parameters*
-[ |-A|\ [**c**][*size*][,\ *spacing*] ]
+[ |-A|\ [**c**][*size*][**+i**\ *spacing*] ]
 [ |SYN_OPT-B| ]
 [ |-C|\ **f**\ \|\ **g**\ \|\ **e** ] [ **-Da**\ *startdate* ] 
 [ |-D|\ **b**\ *stopdate* ]
@@ -68,12 +68,12 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ [**c**][*size*][,\ *spacing*]
+**-A**\ [**c**][*size*][**+i**\ *spacing*]
     Append **c** to annotate using the MGD77 cruise ID [Default uses the
     filename prefix]. Optional *size* is the font size in points. The
     leg annotation font is controlled by :ref:`FONT_LABEL <FONT_LABEL>`. By default,
     each leg is annotated every time it enters the map region.
-    Alternatively, append ,\ *spacing* to place this label every
+    Alternatively, append **+i**\ *spacing* to place this label every
     *spacing* units apart along the track. Append one of the units **k**
     (km), **n** (nautical mile), **d** (day), or **h** (hour).
 

--- a/doc_modern/rst/source/supplements/mgd77/mgd77convert.rst
+++ b/doc_modern/rst/source/supplements/mgd77/mgd77convert.rst
@@ -14,10 +14,10 @@ Synopsis
 .. include:: ../../common_SYN_OPTs.rst_
 
 **gmt mgd77convert** *NGDC-ids* |-F|\ **a**\ \|\ **c**\ \|\ **m** \|\ **t**
-|-T|\ [**+**]\ **a**\ \|\ **c**\ \|\ **m**\ \|\ **t**
+|-T|\ **a**\ \|\ **c**\ \|\ **m**\ \|\ **t**\ [**+f**]
 [ |-C| ]
 [ |-D| ]
-[ |-L|\ [**w**][**e**][**+**] ]
+[ |-L|\ [**w**][**e**][**+l**] ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT--| ]
 
@@ -48,14 +48,14 @@ Required Arguments
 
 .. _-T:
 
-**-T**\ [**+**]\ **a**\ \|\ **c**\ \|\ **m** \|\ **t**
+**-T**\ **a**\ \|\ **c**\ \|\ **m**\ \|\ **t**\ [**+f**]
     Specifies the format of the output (To) files. Choose from **a** for
     standard MGD77 ASCII table (with extension .mgd77), **c** for the
     new MGD77+ netCDF format (with extension .nc), **m** for the
     new MGD77T format (extension .m77t) and **t** for a plain
     ASCII tab-separated table dump (with extension .dat). We will refuse
     to create the file(s) if they already exist in the current
-    directory. Prepend **+** to override this policy.
+    directory. Append **+f** to force an override of this policy.
 
 Optional Arguments
 ------------------
@@ -81,10 +81,10 @@ Optional Arguments
 
 .. _-L:
 
-**-L**\ [**w**\ ][**e**\ ][**+**\ ]
+**-L**\ [**w**\ ][**e**\ ][**+l**\ ]
     Set the level of verification reporting [none] and where to send
-    such reports [stderr]. Append a combination of **w** for warnings,
-    **e** for errors, and **+** to send such log information to stdout.
+    such reports [stderr]. Append a combination of **w** for warnings and
+    **e** for errors, and append **+l** to send such log information to stdout.
  
 .. _-V:
 
@@ -107,7 +107,7 @@ and capture all verification messages, try
 
    ::
 
-    gmt mgd77convert 01010047 01010008 -Fa -Tc -V -Lew+ > log.lis
+    gmt mgd77convert 01010047 01010008 -Fa -Tc -V -Lew+l > log.lis
 
 To convert 01010047.nc back to MGD77 ASCII and make sure it is identical
 to the original file, try (Bourne shell syntax)
@@ -123,7 +123,7 @@ overwriting any existing table, try
 
    ::
 
-    gmt mgd77convert 01010047 -Fc -T+t -V
+    gmt mgd77convert 01010047 -Fc -Tt+f -V
 
 To recover the original NGDC MGD77 version of 01020051.nc and ignore any
 E77 corrections, use

--- a/doc_modern/rst/source/supplements/mgd77/mgd77list.rst
+++ b/doc_modern/rst/source/supplements/mgd77/mgd77list.rst
@@ -14,7 +14,7 @@ Synopsis
 .. include:: ../../common_SYN_OPTs.rst_
 
 **gmt mgd77list** *NGDC-ids* |-F|\ *columns*\ [,\ *logic*][:\ *bittests*]
-[ |-A|\ [**+**\ ]\ **c**\ \|\ **d**\ \|\ **f**\ \|\ **m**\ \|\ **t**\ *code* ]
+[ |-A|\ **c**\ \|\ **d**\ \|\ **f**\ \|\ **m**\ \|\ **t**\ *code*\ [**+f**\ ] ]
 [ |-C|\ **f**\ \|\ **g**\ \|\ **e** ]
 [ |-D|\ **A**\ \|\ **a**\ *startdate* ]
 [ |-D|\ **B**\ \|\ **b**\ *stopdate* ]
@@ -31,7 +31,7 @@ Synopsis
 [ |-T|\ [**m**\ \|\ **e**] ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *weight* ]
-[ |-Z|\ *+*\ \|\ **-** ]
+[ |-Z|\ **n**\ \|\ **p** ]
 [ |SYN_OPT-bo| ]
 [ |SYN_OPT-h| ]
 [ |SYN_OPT--| ]
@@ -247,7 +247,7 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ [**+**\ ]\ **c**\ \|\ **d**\ \|\ **f**\ \|\ **m**\ \|\ **t**\ *code*
+**-A**\ **c**\ \|\ **d**\ \|\ **f**\ \|\ **m**\ \|\ **t**\ *code*\ [**+f**\ ]
     By default, corrected depth (**depth**), magnetic residual anomaly
     (**mag**), free-air gravity anomaly (**faa**), and the derived
     quantity Carter depth correction (**carter**) are all output as is
@@ -261,7 +261,7 @@ Optional Arguments
     we will next try **-Ac**\ 2 which only uses **twt**. In all cases,
     if any of the values required by an adjustment procedure is NaN then
     the result will be NaN. This is also true if the original anomaly is
-    NaN. Specify **-A+** to recalculate anomalies even if the anomaly in
+    NaN. Append **+f** to recalculate anomalies even if the anomaly in
     the file is NaN. Additionally, you can use **-At** to create fake
     times for cruises that has no time; these are based on distances and
     cruise duration.
@@ -476,10 +476,10 @@ Optional Arguments
 
 .. _-Z:
 
-**-Z**\ *+*\ \|\ **-**
+**-Z**\ **n**\ \|\ **p**
     Append the sign you want for **depth**, **carter**, and **msd**
-    values below sea level (**-Z-** gives negative bathymetry) [Default
-    is positive down]. 
+    values below sea level (**-Zn** gives negative bathymetry) [Default
+    is **-Zp** for positive down]. 
 
 .. |Add_-bo| replace:: ignored if **-bo** is selected. Likewise,
     string-fields cannot be selected. Note that if time is one of the

--- a/doc_modern/rst/source/supplements/mgd77/mgd77path.rst
+++ b/doc_modern/rst/source/supplements/mgd77/mgd77path.rst
@@ -13,7 +13,7 @@ Synopsis
 
 .. include:: ../../common_SYN_OPTs.rst_
 
-**gmt mgd77path** *NGDC-ids* [ |-A|\ [**-**] ] [ |-D| ]
+**gmt mgd77path** *NGDC-ids* [ |-A|\ [**c**] ] [ |-D| ]
 [ |-I|\ *ignore* ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT--| ]
@@ -37,9 +37,9 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ [**-**]
+**-A**\ [**c**]
     Display the full path to each cruise [Default]. Optionally, append
-    **-** which will list just the cruise IDs instead.
+    **c** which will list just the cruise IDs instead.
 
 .. _-D:
 

--- a/doc_modern/rst/source/supplements/mgd77/mgd77track.rst
+++ b/doc_modern/rst/source/supplements/mgd77/mgd77track.rst
@@ -16,7 +16,7 @@ Synopsis
 **gmt mgd77track** *NGDC-ids*
 |SYN_OPT-R|
 |-J|\ *parameters*
-[ |-A|\ [**c**][*size*][,\ *spacing*] ]
+[ |-A|\ [**c**][*size*][**+i**\ *spacing*] ]
 [ |SYN_OPT-B| ]
 [ |-C|\ **f**\ \|\ **g**\ \|\ **e** ] [ **-Da**\ *startdate* ] 
 [ |-D|\ **b**\ *stopdate* ]
@@ -65,12 +65,12 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ [**c**][*size*][,\ *spacing*]
+**-A**\ [**c**][*size*][**+i**\ *spacing*]
     Append **c** to annotate using the MGD77 cruise ID [Default uses the
     filename prefix]. Optional *size* is the font size in points. The
     leg annotation font is controlled by :ref:`FONT_LABEL <FONT_LABEL>`. By default,
     each leg is annotated every time it enters the map region.
-    Alternatively, append ,\ *spacing* to place this label every
+    Alternatively, append **+i**\ *spacing* to place this label every
     *spacing* units apart along the track. Append one of the units **k**
     (km), **n** (nautical mile), **d** (day), or **h** (hour).
 

--- a/src/mgd77/mgd77convert.c
+++ b/src/mgd77/mgd77convert.c
@@ -77,7 +77,7 @@ GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct MGD77CONVERT_CTRL *C) {	/
 GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s <cruise(s)> -Fa|c|m|t -T[+]a|c|m|t [-C] [-D] [-L[e][w][+]] [%s] [%s]\n\n", name, GMT_V_OPT, GMT_PAR_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s <cruise(s)> -Fa|c|m|t -Ta|c|m|t[+f] [-C] [-D] [-L[e][w][+l]] [%s] [%s]\n\n", name, GMT_V_OPT, GMT_PAR_OPT);
         
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
              
@@ -86,14 +86,14 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-F Convert from a file that is either (a) MGD77 ASCII, (c) MGD77+ netCDF, (m) MGD77T ASCII, or (t) plain table.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use -FC to recover the original MGD77 setting from the MGD77+ file [Default applies E77 corrections].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-T Convert to a file that is either (a) MGD77 ASCII, (c) MGD77+ netCDF, (m) MGD77T ASCII, or (t) plain table.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   By default we will refuse to overwrite existing files.  Prepend + to override this policy.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   By default we will refuse to overwrite existing files.  Append +f to force an override this policy.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Convert from NGDC (*.h77, *.a77) to *.mgd77 format; no other options allowed.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Give one or more names of h77-files, a77-files, or just cruise prefixes.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-D Select high-resolution, 4-byte storage for mag, diur, faa, eot, and msd with precision\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   of 10 fTesla, 1 nGal, 0.01 mm [Default is 2-byte with 0.1 nTesla, 0.1 mGal, m precision].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-L Set log level and destination setting for verification reporting.  Append a combination\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   of w for warnings, e for errors, and + to send log to stdout [Default is stderr].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   of w for warnings and e for errors, and append +l to send log to stdout [Default is stderr].\n");
 	GMT_Option (API, "V,.");
 
 	return (GMT_MODULE_USAGE);
@@ -107,6 +107,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77CONVERT_CTRL *Ctrl, struc
 	 */
 
 	unsigned int n_errors = 0, code_pos, i;
+	char *c = NULL;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
@@ -124,7 +125,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77CONVERT_CTRL *Ctrl, struc
 				for (i = 0; opt->arg[i]; i++) {
 					if (opt->arg[i] == 'e') Ctrl->L.mode |= 2;
 					if (opt->arg[i] == 'w') Ctrl->L.mode |= 1;
-					if (opt->arg[i] == '+') Ctrl->L.dest = 1;
+					if (opt->arg[i] == '+' && (opt->arg[i+1] == '\0' || opt->arg[i+1] == 'l')) Ctrl->L.dest = 1;
 				}
 				break;
 			case 'F':
@@ -153,7 +154,12 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77CONVERT_CTRL *Ctrl, struc
 			case 'T':
 				Ctrl->T.active = true;
 				code_pos = 0;
-				if (opt->arg[code_pos] == '+') Ctrl->T.mode = true, code_pos++;	/* Force overwriting existing files */
+				if (opt->arg[code_pos] == '+')
+					Ctrl->T.mode = true, code_pos++;	/* Force overwriting existing files */
+				else if ((c = strstr (opt->arg, "+f"))) {
+					Ctrl->T.mode = true;	/* Force overwriting existing files */
+					c[0] = '\0';	/* Chop off modifier */
+				}
 				switch (opt->arg[code_pos]) {									
 					case 'a':		/* Standard ASCII MGD77 file */
 						Ctrl->T.format = MGD77_FORMAT_M77;
@@ -168,10 +174,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77CONVERT_CTRL *Ctrl, struc
 						Ctrl->T.format = MGD77_FORMAT_TBL;
 						break;
 					default:
-						GMT_Report (API, GMT_MSG_NORMAL, "Option -T Bad format (%c)!\n", opt->arg[0]);
+						GMT_Report (API, GMT_MSG_NORMAL, "Option -T Bad format (%c)!\n", opt->arg[code_pos]);
 						n_errors++;
 						break;
 				}
+				if (c) c[0] = '\0';	/* Restore modifier */
 				break;
 			case '4':	/* Selected high-resolution 4-byte integer MGD77+ format for mag, diur, faa, eot [2-byte integer] */
 				if (gmt_M_compat_check (GMT, 4)) {
@@ -341,7 +348,7 @@ int GMT_mgd77convert (void *V_API, int mode, void *args) {
 				}
 			}
 			else {	/* Cowardly refuse to do this */
-				GMT_Report (API, GMT_MSG_NORMAL, "\nOutput file already exists.  Use -T+%c to force overwriting\n", fcode[Ctrl->T.format]);
+				GMT_Report (API, GMT_MSG_NORMAL, "\nOutput file already exists.  Use -T%c+f to force overwriting\n", fcode[Ctrl->T.format]);
 				MGD77_Close_File (GMT, &M);
 				MGD77_Free_Dataset (GMT, &D);	/* Free memory allocated by MGD77_Read_File */
 				continue;

--- a/src/mgd77/mgd77path.c
+++ b/src/mgd77/mgd77path.c
@@ -58,12 +58,12 @@ GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct MGD77PATH_CTRL *C) {	/* D
 GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s <cruise(s)> A[-] -D [-I<code>] [%s] [%s]\n\n", name, GMT_V_OPT, GMT_PAR_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s <cruise(s)> A[c] -D [-I<code>] [%s] [%s]\n\n", name, GMT_V_OPT, GMT_PAR_OPT);
         
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
              
 	MGD77_Cruise_Explain (API->GMT);
-	GMT_Message (API, GMT_TIME_NONE, "\t-A List full cruise pAths [Default].  Append - to only get cruise names.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-A List full cruise pAths [Default].  Append c to only get cruise names.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-D List all directories with MGD77 files instead.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Ignore certain data file formats from consideration. Append combination of act to ignore\n");
@@ -104,7 +104,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77PATH_CTRL *Ctrl, struct G
 				}
 			case 'A':	/* Show list of paths to MGD77 files */
 				Ctrl->A.active = true;
-				if (opt->arg[0] == '-') Ctrl->A.mode = true;
+				if (opt->arg[0] == 'c' || opt->arg[0] == '-') Ctrl->A.mode = true;
 				break;
 				
 			case 'D':	/* Show list of directories with MGD77 files */

--- a/src/mgd77/mgd77track.c
+++ b/src/mgd77/mgd77track.c
@@ -164,7 +164,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 		strcpy (dist_marker_size, "0.06i");
 	}
 	
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s cruise(s) %s %s\n\t[-A[c][<size>]][,<inc><unit>] [%s] ", name, GMT_Rgeo_OPT, GMT_J_OPT, GMT_B_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s cruise(s) %s %s\n\t[-A[c][<size>]][+i<inc><unit>] [%s] ", name, GMT_Rgeo_OPT, GMT_J_OPT, GMT_B_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "[-Cf|g|e] [-Da<startdate>] [-Db<stopdate>] [-F]\n\t[-Gt|d|n<gap>] [-I<code>] %s[-L<trackticks>] [-N] %s%s[-Sa<startdist>[<unit>]]\n", GMT_K_OPT, GMT_O_OPT, GMT_P_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-Sb<stopdist>[<unit>]] [-TT|t|d<ms,mc,mfs,mf,mfc>] [%s]\n\t[%s] [-W<pen>] [%s] [%s]\n",
 	             GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT);
@@ -177,7 +177,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-A Annotate legs when they enter the grid. Append c for cruise ID [Default is file prefix];\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   <size> is optional text size in points [9].  The font used is controlled by FONT_LABEL.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally, append ,<inc>[unit] to place label every <inc> units apart; <unit> may be\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally, append +i<inc>[unit] to place label every <inc> units apart; <unit> may be\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   k (km) or n (nautical miles), or d (days), h (hours).\n");
 	GMT_Option (API, "B-");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Select procedure for along-track distance calculations:\n");
@@ -317,13 +317,26 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77TRACK_CTRL *Ctrl, struct 
 			case 'A':
 				Ctrl->A.active = true;
 				Ctrl->A.mode = 1;
+				if ((t = strstr (opt->arg, "+i"))) t[0] = '\0';	/* Chop off modifier */
 				j = 0;
 				if (opt->arg[0] == 'c') j++, Ctrl->A.mode = 2;
 				if (opt->arg[j] && opt->arg[j] != ',')
 					Ctrl->A.size = atof (&opt->arg[j]) * GMT->session.u2u[GMT_PT][GMT_INCH];
-				if ((t = strchr (opt->arg, ','))) {	/* Want label at regular spacing */
-					if (get_annotinfo (&t[1], &Ctrl->A.info)) n_errors++;
+				if (t) {
+					if (get_annotinfo (&t[2], &Ctrl->A.info)) n_errors++;
 					Ctrl->A.mode = -Ctrl->A.mode;	/* Flag to tell machinery not to annot at entry */
+					t[0] = '+';	/* Restore modifier */
+				}
+				else if ((t = strchr (opt->arg, ','))) {	/* Want label at regular spacing */
+					if (gmt_M_compat_check (GMT, 5)) {
+						GMT_Report (API, GMT_MSG_COMPAT, "Warning -A: ,<inc> is deprecated, use +i<inc> instead\n");
+						if (get_annotinfo (&t[1], &Ctrl->A.info)) n_errors++;
+						Ctrl->A.mode = -Ctrl->A.mode;	/* Flag to tell machinery not to annot at entry */
+					}
+					else {
+						GMT_Report (API, GMT_MSG_NORMAL, "Error -A: Unexpected string %s\n", t);
+						n_errors++;
+					}
 				}
 				break;
 


### PR DESCRIPTION
Avoid directives such as **-** and **+** and use modifiers instead.  Also replace things like **,**_inc_ with **+i**_inc_.  Backwards compatible.
