### PR TITLE
Replace directives using + with trailing modifiers instead

### DIFF
--- a/doc_classic/rst/source/supplements/x2sys/x2sys_get.rst
+++ b/doc_classic/rst/source/supplements/x2sys/x2sys_get.rst
@@ -14,7 +14,7 @@ Synopsis
 .. include:: ../../common_SYN_OPTs.rst_
 
 **x2sys_get** |-T|\ *TAG* [ |-C| ] [ |-F|\ *flags* ] [ |-G| ]
-[ |-L|\ [**+**\ ][*list*] ]
+[ |-L|\ [*list*]\ [**+i**\ ] ]
 [ |-N|\ *flags* ] [
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]
@@ -65,7 +65,7 @@ Optional Arguments
 
 .. _-L:
 
-**-L**\ [**+**\ ][*list*]
+**-L**\ [*list*]\ [**+i**\ ]
     Crossover mode. Return a list of track pairs that should be checked
     for possible crossovers. The list is determined from the bin-index
     data base on the assumption that tracks occupying the same bin are
@@ -74,7 +74,7 @@ Optional Arguments
     you want to limit the output to those pairs that involve at least
     one of the track names in your list. The output is suitable for the
     **-A** option in :doc:`x2sys_cross`. By default, only external
-    crossover pairs are listed. Use **-L+** to include internal pairs in the list.
+    crossover pairs are listed. Append **+i** to include internal pairs in the list.
 
 .. _-N:
 

--- a/doc_classic/rst/source/supplements/x2sys/x2sys_list.rst
+++ b/doc_classic/rst/source/supplements/x2sys/x2sys_list.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-N|\ *nx_min* ]
 [ |-Q|\ **e**\ \|\ **i** ]
 [ |SYN_OPT-R| ]
-[ |-S|\ *track* ]
+[ |-S|\ *track*\ [**+b**\ ] ]
 [ |SYN_OPT-V| ]
 [ |-W|\ [*list*] ]
 [ |SYN_OPT-bo| ]
@@ -137,10 +137,11 @@ Optional Arguments
 
 .. _-S:
 
-**-S**\ *track*
+**-S**\ *track*\ [**+b**\ ]
     Name of a single track. If given we restrict output to those
     crossovers involving this track [Default output is crossovers
-    involving any track pair].
+    involving any track pair].  Append **+b** to print info relative
+    to both tracks in the pair.
 
 .. _-V:
 

--- a/doc_modern/rst/source/supplements/x2sys/x2sys_get.rst
+++ b/doc_modern/rst/source/supplements/x2sys/x2sys_get.rst
@@ -14,7 +14,7 @@ Synopsis
 .. include:: ../../common_SYN_OPTs.rst_
 
 **gmt x2sys_get** |-T|\ *TAG* [ |-C| ] [ |-F|\ *flags* ] [ |-G| ]
-[ |-L|\ [**+**\ ][*list*] ]
+[ |-L|\ [*list*]\ [**+i**\ ] ]
 [ |-N|\ *flags* ] [
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]
@@ -65,7 +65,7 @@ Optional Arguments
 
 .. _-L:
 
-**-L**\ [**+**\ ][*list*]
+**-L**\ [*list*]\ [**+i**\ ]
     Crossover mode. Return a list of track pairs that should be checked
     for possible crossovers. The list is determined from the bin-index
     data base on the assumption that tracks occupying the same bin are
@@ -74,7 +74,7 @@ Optional Arguments
     you want to limit the output to those pairs that involve at least
     one of the track names in your list. The output is suitable for the
     **-A** option in :doc:`x2sys_cross`. By default, only external
-    crossover pairs are listed. Use **-L+** to include internal pairs in the list.
+    crossover pairs are listed. Append **+i** to include internal pairs in the list.
 
 .. _-N:
 

--- a/doc_modern/rst/source/supplements/x2sys/x2sys_list.rst
+++ b/doc_modern/rst/source/supplements/x2sys/x2sys_list.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-N|\ *nx_min* ]
 [ |-Q|\ **e**\ \|\ **i** ]
 [ |SYN_OPT-R| ]
-[ |-S|\ *track* ]
+[ |-S|\ *track*\ [**+b**\ ] ]
 [ |SYN_OPT-V| ]
 [ |-W|\ [*list*] ]
 [ |SYN_OPT-bo| ]
@@ -137,10 +137,11 @@ Optional Arguments
 
 .. _-S:
 
-**-S**\ *track*
+**-S**\ *track*\ [**+b**\ ]
     Name of a single track. If given we restrict output to those
     crossovers involving this track [Default output is crossovers
-    involving any track pair].
+    involving any track pair].  Append **+b** to print info relative
+    to both tracks in the pair.
 
 .. _-V:
 

--- a/src/x2sys/x2sys_get.c
+++ b/src/x2sys/x2sys_get.c
@@ -92,7 +92,7 @@ GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct X2SYS_GET_CTRL *C) {	/* D
 GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s -T<TAG> [-C] [-D] [-F<fflags>] [-G] [-L[+][list]] [-N<nflags>]\n\t[%s] [%s] [%s]\n\n", name, GMT_Rgeo_OPT, GMT_V_OPT, GMT_PAR_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s -T<TAG> [-C] [-D] [-F<fflags>] [-G] [-L[<list>][+i]] [-N<nflags>]\n\t[%s] [%s] [%s]\n\n", name, GMT_Rgeo_OPT, GMT_V_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -104,7 +104,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-L Setup mode: Return all pairs of tracks that might intersect given\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   the bin distribution.  Optionally, give file with a list of tracks.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Then, only pairs with at least one track from the list is output.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Use -L+ to include internal pairs in the list [external only].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Append +i to include internal pairs in the list [external only].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Comma-separated list of column field names that ALL must be missing.\n");
 	GMT_Option (API, "R");
 	GMT_Message (API, GMT_TIME_NONE, "\t   [Default region is the entire data domain].\n");
@@ -122,6 +122,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct X2SYS_GET_CTRL *Ctrl, struct G
 	 */
 
 	unsigned int n_errors = 0, k = 0, n_files = 0;
+	char *c = NULL;
 	struct GMT_OPTION *opt = NULL;
 
 	for (opt = options; opt; opt = opt->next) {	/* Process all the options given */
@@ -156,8 +157,10 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct X2SYS_GET_CTRL *Ctrl, struct G
 				break;
 			case 'L':
 				if (opt->arg[0] == '+') {k = 1; Ctrl->L.mode = 0;}
+				else if ((c = strstr (opt->arg, "+i"))) {k = 0; Ctrl->L.mode = 0; c[0] = '\0';}
 				if (opt->arg[k]) Ctrl->L.file = strdup (&opt->arg[k]);
 				Ctrl->L.active = true;
+				if (c) c[0] = '+';	/* Restore */
 				break;
 			case 'N':
 				Ctrl->N.active = true;

--- a/src/x2sys/x2sys_init.c
+++ b/src/x2sys/x2sys_init.c
@@ -114,7 +114,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 #endif
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s <TAG> [-Cc|f|g|e] [-D<deffile>] [-E<suffix>] [-F] [-G[d/g]] [-I[<binsize>]]\n", name);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s <TAG> [-Cc|f|g|e] [-D<deffile>] [-E<suffix>] [-F] [-G[d|g]] [-I[<binsize>]]\n", name);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-N[d|s][c|e|f|k|M|n]]] [%s] [%s] [-Wt|d|n<gap>]\n\t[-m] [%s]\n\n", GMT_Rgeo_OPT, GMT_V_OPT, GMT_PAR_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t<TAG> is the unique system identifier.  Files created will be placed in the directory %s/<TAG>.\n", par);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Note: The environmental parameter %s must be defined.\n\n", par);
@@ -133,7 +133,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   [Default equals the prefix for the definition file].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-F Force creating new files if old ones are present [Default will abort if old files are found].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Geographical coordinates; append g for discontinuity at Greenwich (output 0/360 [Default])\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   and append d for discontinuity at Dateline (output -180/+180).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   or append d for discontinuity at Dateline (output -180/+180).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Set bin size for track bin index output [1/1].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Append (d)istances or (s)peed, and your choice for unit. Choose among:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   c Cartesian distance (user-dist-units, user-dist-units/user-time-units).\n");


### PR DESCRIPTION
To avoid complications with parsing modifiers, any directive just being a plus or minus symbol have been given modifiers instead. Backwards compatible.
