### PR TITLE
Fix meca documentation and replace old hard-to-parse syntax

### DIFF
--- a/doc_classic/rst/source/supplements/meca/psmeca.rst
+++ b/doc_classic/rst/source/supplements/meca/psmeca.rst
@@ -15,7 +15,7 @@ Synopsis
 
 psmeca [ *table* ] |-J|\ *parameters* |SYN_OPT-R|
 [ |SYN_OPT-B| ]
-[ |-C|\ [*pen*\ ][\ **P**\ *pointsize*] ] [ |-D|\ *depmin*/*depmax* ]
+[ |-C|\ [*pen*\ ][\ **+s**\ *pointsize*] ] [ |-D|\ *depmin*/*depmax* ]
 [ |-E|\ *fill*]
 [ |-F|\ *mode*\ [*args*] ] [ |-G|\ *fill*] [ |-K| ] [ |-L|\ [*pen*\ ] ]
 [ |-M| ]
@@ -241,13 +241,13 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ [*pen*\ ][\ **P**\ *pointsize*]
+**-C**\ [*pen*\ ][\ **+s**\ *pointsize*]
     Offsets focal mechanisms to the longitude, latitude specified in the
     last two columns of the input file before the (optional) text
     string. A small circle is plotted at the initial location and a line
-    connects the beachball to the circle. Specify *pen* and/or
-    *pointsize* to change the line style and/or size of the circle.
-    [Defaults: *pen* as given by **-W**; *pointsize* 0].
+    connects the beachball to the circle. Specify *pen* and optionally append
+    **+s**\ *pointsize* to change the line style and/or size of the circle.
+    [Defaults: *pen* as given by **-W**; *pointsize* is 0].
 
 .. _-D:
 

--- a/doc_classic/rst/source/supplements/meca/pspolar.rst
+++ b/doc_classic/rst/source/supplements/meca/pspolar.rst
@@ -17,7 +17,7 @@ pspolar [ *table* ] |-D|\ *lon/lat* |-J|\ *parameters*
 |SYN_OPT-R|
 |-M|\ *size* |-S|\ *<symbol><size>*
 [ |SYN_OPT-B| ]
-[ |-C|\ *lon*/*lat*\ [/*dash\_width*/*pointsize*] ]
+[ |-C|\ *lon*/*lat*\ [**+p**\ *pen*\ ][**+s**\ /*pointsize*] ]
 [ |-E|\ *color* ]
 [ |-F|\ *color* ]
 [ |-G|\ *color* ]
@@ -104,9 +104,10 @@ Optional Arguments
 
 .. _-C:
 
-**-C**
+**-C**\ *lon*/*lat*\ [**+p**\ *pen*\ ][**+s**\ /*pointsize*]
     Offsets focal mechanisms to the latitude and longitude specified in
-    the last two columns of the input file.
+    the last two columns of the input file.  Optionally set the pen and
+    symbol point size.
 
 .. _-E:
 
@@ -172,8 +173,8 @@ Optional Arguments
 
 .. _-Y:
 
-**-T**\ *angle/form/justify/fontsize in points*
-    To write station code. [Default is 0.0/0/5/12].
+**-T**\ *angle*/*form*/*justify*/*fontsize*
+    To write station code; *fontsize* must be given in points [Default is 0.0/0/5/12].
 
 .. _-U:
 

--- a/doc_classic/rst/source/supplements/meca/psvelo.rst
+++ b/doc_classic/rst/source/supplements/meca/psvelo.rst
@@ -23,7 +23,7 @@ Synopsis
 [ |-K| ]
 [ |-L| ]
 [ |-N| ] [ |-O| ] [ |-P| ]
-[ |-S|\ *symbol*/*scale*/*conf*/*font_size* ] [
+[ |-S|\ *symbol*/*scale*\ [/*args* ] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]
@@ -72,10 +72,10 @@ Selects the meaning of the columns in the data file and the figure to be plotted
 
     **-Se**\ *velscale/confidence/fontsize*.
 
-        Velocity ellipses in (N,E) convention. *Vscale* sets the scaling of the
+        Velocity ellipses in (N,E) convention. *velscale* sets the scaling of the
         velocity arrows. This scaling gives inches (unless **c**, **i**,
-        or **p** is appended). *Confidence* sets the 2-dimensional confidence
-        limit for the ellipse, e.g., 0.95 for 95% confidence ellipse. *Fontsize*
+        or **p** is appended). *confidence* sets the 2-dimensional confidence
+        limit for the ellipse, e.g., 0.95 for 95% confidence ellipse. *fontsize*
         sets the size of the text in points. The ellipse will be filled with the
         color or shade specified by the |-G| option [default transparent]. The
         arrow and the circumference of the ellipse will be drawn with the pen
@@ -95,7 +95,7 @@ Selects the meaning of the columns in the data file and the figure to be plotted
 
     **-Sn**\ *barscale.*
 
-        Anisotropy bars. *Barscale* sets the scaling of the bars This scaling
+        Anisotropy bars. *barscale* sets the scaling of the bars This scaling
         gives inches (unless **c**, **i**, or **p** is appended).
         Parameters are expected to be in the following columns:
 
@@ -106,11 +106,11 @@ Selects the meaning of the columns in the data file and the figure to be plotted
 
     **-Sr**\ *velscale/confidence/fontsize*
 
-        Velocity ellipses in rotated convention. *Vscale* sets the scaling of
+        Velocity ellipses in rotated convention. *velscale* sets the scaling of
         the velocity arrows. This scaling gives inches (unless **c**, **i**,
-        or **p** is appended). *Confidence* sets the 2-dimensional
+        or **p** is appended). *confidence* sets the 2-dimensional
         confidence limit for the ellipse, e.g., 0.95 for 95% confidence ellipse.
-        *Fontsize* sets the size of the text in points. The ellipse will be
+        *fontsize* sets the size of the text in points. The ellipse will be
         filled with the color or shade specified by the |-G| option [default
         transparent]. The arrow and the circumference of the ellipse will be
         drawn with the pen attributes specified by the |-W| option. Parameters
@@ -127,12 +127,12 @@ Selects the meaning of the columns in the data file and the figure to be plotted
             **8**:
             name of station (optional)
 
-    **-Sw**\ *wedge\_scale/wedge\_mag*.
+    **-Sw**\ *wedgescale/wedgemag*.
 
-        Rotational wedges. *Wedge\_scale* sets the size of the wedges in inches
+        Rotational wedges. The *wedgescale* sets the size of the wedges in inches
         (unless **c**, **i**, or **p** is appended). Values are
-        multiplied by *Wedge\_mag* before plotting. For example, setting
-        *Wedge\_mag* to 1.e7 works well for rotations of the order of 100
+        multiplied by *wedgemag* before plotting. For example, setting
+        *wedgemag* to 1.e7 works well for rotations of the order of 100
         nanoradians/yr. Use **-G** to set the fill color or shade for the wedge,
         and **-E** to set the color or shade for the uncertainty. Parameters are
         expected to be in the following columns:
@@ -146,7 +146,7 @@ Selects the meaning of the columns in the data file and the figure to be plotted
 
     **-Sx**\ *cross_scale*
 
-        gives Strain crosses. *Cross\_scale* sets the size of the cross in
+        gives Strain crosses. Here, *cross_scale* sets the size of the cross in
         inches (unless **c**, **i**, or **p** is appended). Parameters
         are expected to be in the following columns:
 

--- a/doc_modern/rst/source/supplements/meca/meca.rst
+++ b/doc_modern/rst/source/supplements/meca/meca.rst
@@ -15,7 +15,7 @@ Synopsis
 
 **gmt meca** [ *table* ] |-J|\ *parameters* |SYN_OPT-R|
 [ |SYN_OPT-B| ]
-[ |-C|\ [*pen*\ ][\ **P**\ *pointsize*] ] [ |-D|\ *depmin*/*depmax* ]
+[ |-C|\ [*pen*\ ][\ **+s**\ *pointsize*] ] [ |-D|\ *depmin*/*depmax* ]
 [ |-E|\ *fill*]
 [ |-F|\ *mode*\ [*args*] ] [ |-G|\ *fill*] [ |-L|\ [*pen*\ ] ]
 [ |-M| ]
@@ -241,13 +241,13 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ [*pen*\ ][\ **P**\ *pointsize*]
+**-C**\ [*pen*\ ][\ **+s**\ *pointsize*]
     Offsets focal mechanisms to the longitude, latitude specified in the
     last two columns of the input file before the (optional) text
     string. A small circle is plotted at the initial location and a line
-    connects the beachball to the circle. Specify *pen* and/or
-    *pointsize* to change the line style and/or size of the circle.
-    [Defaults: *pen* as given by **-W**; *pointsize* 0].
+    connects the beachball to the circle. Specify *pen* and optionally append
+    **+s**\ *pointsize* to change the line style and/or size of the circle.
+    [Defaults: *pen* as given by **-W**; *pointsize* is 0].
 
 .. _-D:
 

--- a/doc_modern/rst/source/supplements/meca/polar.rst
+++ b/doc_modern/rst/source/supplements/meca/polar.rst
@@ -1,8 +1,8 @@
 .. index:: ! polar
 
-*******
+*****
 polar
-*******
+*****
 
 .. only:: not man
 
@@ -15,9 +15,10 @@ Synopsis
 
 **gmt polar** [ *table* ] |-D|\ *lon/lat* |-J|\ *parameters*
 |SYN_OPT-R|
-|-M|\ *size* |-S|\ *<symbol><size>*
+|-M|\ *size*
+|-S|\ *<symbol><size>*
 [ |SYN_OPT-B| ]
-[ |-C|\ *lon*/*lat*\ [/*dash\_width*/*pointsize*] ]
+[ |-C|\ *lon*/*lat*\ [**+p**\ *pen*\ ][**+s**\ /*pointsize*] ]
 [ |-E|\ *color* ]
 [ |-F|\ *color* ]
 [ |-G|\ *color* ]
@@ -103,9 +104,10 @@ Optional Arguments
 
 .. _-C:
 
-**-C**
+**-C**\ *lon*/*lat*\ [**+p**\ *pen*\ ][**+s**\ /*pointsize*]
     Offsets focal mechanisms to the latitude and longitude specified in
-    the last two columns of the input file.
+    the last two columns of the input file.  Optionally set the pen and
+    symbol point size.
 
 .. _-E:
 
@@ -159,8 +161,8 @@ Optional Arguments
 
 .. _-Y:
 
-**-T**\ *angle/form/justify/fontsize in points*
-    To write station code. [Default is 0.0/0/5/12].
+**-T**\ *angle*/*form*/*justify*/*fontsize*
+    To write station code; *fontsize* must be given in points [Default is 0.0/0/5/12].
 
 .. _-U:
 

--- a/doc_modern/rst/source/supplements/meca/velo.rst
+++ b/doc_modern/rst/source/supplements/meca/velo.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-G|\ *color* ]
 [ |-L| ]
 [ |-N| ]
-[ |-S|\ *symbol*/*scale*/*conf*/*font_size* ] [
+[ |-S|\ *symbol*/*scale*\ [/*args* ] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]
@@ -71,10 +71,10 @@ Selects the meaning of the columns in the data file and the figure to be plotted
 
     **-Se**\ *velscale/confidence/fontsize*.
 
-        Velocity ellipses in (N,E) convention. *Vscale* sets the scaling of the
+        Velocity ellipses in (N,E) convention. *velscale* sets the scaling of the
         velocity arrows. This scaling gives inches (unless **c**, **i**,
-        or **p** is appended). *Confidence* sets the 2-dimensional confidence
-        limit for the ellipse, e.g., 0.95 for 95% confidence ellipse. *Fontsize*
+        or **p** is appended). *confidence* sets the 2-dimensional confidence
+        limit for the ellipse, e.g., 0.95 for 95% confidence ellipse. *fontsize*
         sets the size of the text in points. The ellipse will be filled with the
         color or shade specified by the |-G| option [default transparent]. The
         arrow and the circumference of the ellipse will be drawn with the pen
@@ -94,7 +94,7 @@ Selects the meaning of the columns in the data file and the figure to be plotted
 
     **-Sn**\ *barscale.*
 
-        Anisotropy bars. *Barscale* sets the scaling of the bars This scaling
+        Anisotropy bars. *barscale* sets the scaling of the bars. This scaling
         gives inches (unless **c**, **i**, or **p** is appended).
         Parameters are expected to be in the following columns:
 
@@ -105,11 +105,11 @@ Selects the meaning of the columns in the data file and the figure to be plotted
 
     **-Sr**\ *velscale/confidence/fontsize*
 
-        Velocity ellipses in rotated convention. *Vscale* sets the scaling of
+        Velocity ellipses in rotated convention. *velscale* sets the scaling of
         the velocity arrows. This scaling gives inches (unless **c**, **i**,
-        or **p** is appended). *Confidence* sets the 2-dimensional
+        or **p** is appended). *confidence* sets the 2-dimensional
         confidence limit for the ellipse, e.g., 0.95 for 95% confidence ellipse.
-        *Fontsize* sets the size of the text in points. The ellipse will be
+        *fontsize* sets the size of the text in points. The ellipse will be
         filled with the color or shade specified by the |-G| option [default
         transparent]. The arrow and the circumference of the ellipse will be
         drawn with the pen attributes specified by the |-W| option. Parameters
@@ -126,12 +126,12 @@ Selects the meaning of the columns in the data file and the figure to be plotted
             **8**:
             name of station (optional)
 
-    **-Sw**\ *wedge\_scale/wedge\_mag*.
+    **-Sw**\ *wedgescale/wedgemag*.
 
-        Rotational wedges. *Wedge\_scale* sets the size of the wedges in inches
+        Rotational wedges. *wedgescale* sets the size of the wedges in inches
         (unless **c**, **i**, or **p** is appended). Values are
-        multiplied by *Wedge\_mag* before plotting. For example, setting
-        *Wedge\_mag* to 1.e7 works well for rotations of the order of 100
+        multiplied by *wedgemag* before plotting. For example, setting
+        *wedgemag* to 1.e7 works well for rotations of the order of 100
         nanoradians/yr. Use **-G** to set the fill color or shade for the wedge,
         and **-E** to set the color or shade for the uncertainty. Parameters are
         expected to be in the following columns:
@@ -145,7 +145,7 @@ Selects the meaning of the columns in the data file and the figure to be plotted
 
     **-Sx**\ *cross_scale*
 
-        gives Strain crosses. *Cross\_scale* sets the size of the cross in
+        gives Strain crosses. *cross_scale* sets the size of the cross in
         inches (unless **c**, **i**, or **p** is appended). Parameters
         are expected to be in the following columns:
 

--- a/src/meca/psmeca.c
+++ b/src/meca/psmeca.c
@@ -48,7 +48,7 @@ PostScript code is written to stdout.
 /* Control structure for psmeca */
 
 struct PSMECA_CTRL {
-	struct C {	/* -C[<pen>][P<pointsize>] */
+	struct C {	/* -C[<pen>][+s<pointsize>] */
 		bool active;
 		double size;
 		struct GMT_PEN pen;
@@ -174,7 +174,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] %s %s\n", name, GMT_J_OPT, GMT_Rgeo_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t-S<format><scale>[/<fontsize>[/<justify>/<offset>/<angle>/<form>]] [%s]\n", GMT_B_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-C[<pen>][P<pointsize>]] [-D<depmin>/<depmax>] [-E<fill>] [-G<fill>] %s[-L<pen>] [-M]\n", GMT_K_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-C[<pen>][+s<pointsize>]] [-D<depmin>/<depmax>] [-E<fill>] [-G<fill>] %s[-L<pen>] [-M]\n", GMT_K_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-Fa[<size>[/<Psymbol>[<Tsymbol>]]] [-Fe<fill>] [-Fg<fill>] [-Fo] [-Fr<fill>] [-Fp[<pen>]] [-Ft[<pen>]] [-Fz[<pen>]]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t[-N] %s%s[-T<nplane>[/<pen>]] [%s] [%s] [-W<pen>]\n", GMT_O_OPT, GMT_P_OPT, GMT_U_OPT, GMT_V_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [-Z<cpt>]\n", GMT_X_OPT, GMT_Y_OPT);
@@ -188,7 +188,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Offset focal mechanisms to the latitude and longitude specified in the last two columns of the input file before label.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Default pen attributes are set by -W.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   A line is plotted between both positions.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   A small circle is plotted at the initial location. Add P<pointsize> to change the size of the circle.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   A small circle is plotted at the initial location. Append +s<pointsize> to change the size of the circle.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-D Plot events between <depmin> and <depmax> deep.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-E Set color used for extensive parts [default is white].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-F Sets various attributes of symbols depending on <mode>:\n");
@@ -278,8 +278,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_
 				Ctrl->C.active = true;
 				if (!opt->arg[0]) break;
 				strncpy (txt, opt->arg, GMT_LEN256-1);
-				if ((p = strchr (txt, 'P')) != NULL) Ctrl->C.size = gmt_M_to_inch (GMT, (p+1));
-				if (txt[0] != 'P') {	/* Have a pen up front */
+				if ((p = strstr (txt, "+s")) != NULL) Ctrl->C.size = gmt_M_to_inch (GMT, (p+2));
+				else if ((p = strchr (txt, 'P')) != NULL) Ctrl->C.size = gmt_M_to_inch (GMT, (p+1));
+				if (txt[0] != 'P' && strncmp (txt, "+s", 2U)) {	/* Have a pen up front */
 					if (p) p[0] = '\0';
 					if (gmt_getpen (GMT, txt, &Ctrl->C.pen)) {
 						gmt_pen_syntax (GMT, 'C', " ", 0);

--- a/src/meca/psvelo.c
+++ b/src/meca/psvelo.c
@@ -127,7 +127,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] %s %s [-A<vecpar>] [%s] [-D<sigscale>]\n", name, GMT_J_OPT, GMT_Rgeo_OPT, GMT_B_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-G<fill>] %s[-L] [-N] %s%s[-S<symbol><scale><fontsize>]\n", GMT_K_OPT, GMT_O_OPT, GMT_P_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-G<fill>] %s[-L] [-N] %s%s[-S<symbol><scale>[/<args>]]\n", GMT_K_OPT, GMT_O_OPT, GMT_P_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-V] [-W<pen>] [%s]\n", GMT_U_OPT, GMT_X_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [%s] [%s]\n\t[%s] [%s] [%s] [%s]\n\n", GMT_Y_OPT, GMT_di_OPT, GMT_e_OPT, GMT_h_OPT, GMT_i_OPT, GMT_t_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
@@ -148,7 +148,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-L Draw line or symbol outline using the current pen (see -W).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Do Not skip/clip symbols that fall outside map border [Default will ignore those outside].\n");
 	GMT_Option (API, "O,P");
-	GMT_Message (API, GMT_TIME_NONE, "\t-S Select symbol type and scale. Choose between:\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-S Select symbol type and scale (plus optional args; see documentation). Choose between:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     e  Velocity ellipses: in X,Y,Vx,Vy,SigX,SigY,CorXY,name format.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     r  Velocity ellipses: in X,Y,Vx,Vy,a,b,theta,name format.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     n  Anisotropy : in X,Y,Vx,Vy.\n");


### PR DESCRIPTION
For instance **-C**_pen_[**P**_size_] is now **-C**_pen_[**+s**_size_].  Backwards compatible.
