### PR TITLE
gmtinfo improvements in syntax

### DIFF
--- a/doc_classic/rst/source/gmtinfo.rst
+++ b/doc_classic/rst/source/gmtinfo.rst
@@ -18,7 +18,7 @@ Synopsis
 [ |-D|\ [*dx*\ [/*dy*\ ]] ]
 [ |-E|\ **L**\ \|\ **l**\ \|\ **H**\ \|\ **h**\ *col* ]
 [ |-F|\ [**i**\ \|\ **d**\ \|\ **t**\ ] ]
-[ |-I|\ [**b**\ \|\ **p**\ \|\ **f**\ \|\ **s**]\ *dx*\ [/*dy*\ [/*dz*...] ]
+[ |-I|\ [**b**\ \|\ **e**\ \|\ **f**\ \|\ **p**\ \|\ **s**]\ *dx*\ [/*dy*\ [/*dz*...] ]
 [ |-L| ]
 [ |-S|\ [**x**\ ][**y**] ]
 [ |-T|\ *dz*\ [\ **+c**\ *col*] ]
@@ -108,7 +108,7 @@ Optional Arguments
 
 .. _-I:
 
-**-I**\ [**b**\ \|\ **p**\ \|\ **f**\ \|\ **s**]\ *dx*\ [/*dy*\ [/*dz*...]
+**-I**\ [**b**\ \|\ **e**\ \|\ **f**\ \|\ **p**\ \|\ **s**]\ *dx*\ [/*dy*\ [/*dz*...]
     Report the min/max of the first *n* columns to the nearest multiple
     of the provided increments (separate the *n* increments by slashes),
     and output results in the form **-R**\ *w/e/s/n* (unless **-C** is
@@ -126,7 +126,7 @@ Optional Arguments
     Use **-Ib** to write the bounding box of the data table or segments (see **-A**)
     as a closed polygon segment. Note: for oblique projections you should
     use the **-Ap** option in :doc:`psxy` to draw the box properly.
-    If *dx* is given as - then the actual min/max of the input is given in the **-R** string.
+    If **-Ie** is given then the exact min/max of the input is given in the **-R** string.
 
 .. _-L:
 

--- a/doc_modern/rst/source/gmtinfo.rst
+++ b/doc_modern/rst/source/gmtinfo.rst
@@ -18,7 +18,7 @@ Synopsis
 [ |-D|\ [*dx*\ [/*dy*\ ]] ]
 [ |-E|\ **L**\ \|\ **l**\ \|\ **H**\ \|\ **h**\ *col* ]
 [ |-F|\ [**i**\ \|\ **d**\ \|\ **t**\ ] ]
-[ |-I|\ [**b**\ \|\ **p**\ \|\ **f**\ \|\ **s**]\ *dx*\ [/*dy*\ [/*dz*...] ]
+[ |-I|\ [**b**\ \|\ **e**\ \|\ **f**\ \|\ **p**\ \|\ **s**]\ *dx*\ [/*dy*\ [/*dz*...] ]
 [ |-L| ]
 [ |-S|\ [**x**\ ][**y**] ]
 [ |-T|\ *dz*\ [\ **+c**\ *col*] ]
@@ -108,7 +108,7 @@ Optional Arguments
 
 .. _-I:
 
-**-I**\ [**b**\ \|\ **p**\ \|\ **f**\ \|\ **s**]\ *dx*\ [/*dy*\ [/*dz*...]
+**-I**\ [**b**\ \|\ **e**\ \|\ **f**\ \|\ **p**\ \|\ **s**]\ *dx*\ [/*dy*\ [/*dz*...]
     Report the min/max of the first *n* columns to the nearest multiple
     of the provided increments (separate the *n* increments by slashes),
     and output results in the form **-R**\ *w/e/s/n* (unless **-C** is
@@ -126,7 +126,7 @@ Optional Arguments
     Use **-Ib** to write the bounding box of the data table or segments (see **-A**)
     as a closed polygon segment. Note: for oblique projections you should
     use the **-Ap** option in :doc:`plot` to draw the box properly.
-    If *dx* is given as - then the actual min/max of the input is given in the **-R** string.
+    If **-Ie** is given then the exact min/max of the input is given in the **-R** string.
 
 .. _-L:
 

--- a/src/gmtinfo.c
+++ b/src/gmtinfo.c
@@ -74,7 +74,7 @@ struct MINMAX_CTRL {	/* All control options for this program (except common args
 		bool active;
 		int mode;	/*  */
 	} F;
-	struct I {	/* -I[f|p|s]dx[/dy[/<dz>..]] */
+	struct I {	/* -I[b|e|f|p|s]dx[/dy[/<dz>..]] */
 		bool active;
 		unsigned int ncol;
 		unsigned int mode;	/* Nominally 0, unless set to BEST_FOR_SURF, BEST_FOR_FFT or ACTUAL_BOUNDS */
@@ -122,7 +122,7 @@ GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct MINMAX_CTRL *C) {	/* Deal
 GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] [-Aa|f|s] [-C] [-D[<dx>[/<dy>]] [-E<L|l|H|h><col>] [-Fi|d|t] [-I[b|p|f|s]<dx>[/<dy>[/<dz>..]]\n", name);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] [-Aa|f|s] [-C] [-D[<dx>[/<dy>]] [-E<L|l|H|h><col>] [-Fi|d|t] [-I[b|e|f|p|s]<dx>[/<dy>[/<dz>..]]\n", name);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-L] [-S[x][y]] [-T<dz>[+c<col>]] [%s] [%s] [%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s] [%s] [%s]\n\n",
 		GMT_V_OPT, GMT_a_OPT, GMT_bi_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT, GMT_i_OPT, GMT_o_OPT, GMT_r_OPT, GMT_s_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
@@ -142,7 +142,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   d: Dataset: One record per segment with tbl_no, seg_no, nrows, start_rec, stop_rec.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   t: Tables:  Same as D but the counts resets per table.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Return textstring -Rw/e/s/n to nearest multiple of dx/dy (assumes at least 2 columns).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Give -I- to just report the min/max extent in the -Rw/e/s/n string (no multiples).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Give -Ie to just report the min/max extent in the -Rw/e/s/n string (no multiples).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If -C is set then no -R string is issued.  Instead, the number of increments\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   given determines how many columns are rounded off to the nearest multiple.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If only one increment is given we also use it for the second column (for backwards compatibility).\n");
@@ -259,7 +259,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MINMAX_CTRL *Ctrl, struct GMT_
 					case 'f': Ctrl->I.mode = BEST_FOR_FFT; break;
 					case 's': Ctrl->I.mode = BEST_FOR_SURF; break;
 					case 'b': Ctrl->I.mode = BOUNDBOX; break;
-					case '-': Ctrl->I.mode = ACTUAL_BOUNDS; break;
+					case 'e': case '-': Ctrl->I.mode = ACTUAL_BOUNDS; break;	/* -I- is backwards compatible */
 					default: j = 0;	break;
 				}
 				Ctrl->I.ncol = (Ctrl->I.mode == ACTUAL_BOUNDS || Ctrl->I.mode == BOUNDBOX) ? 2 : gmt_getincn (GMT, &opt->arg[j], Ctrl->I.inc, GMT_MAX_COLUMNS);


### PR DESCRIPTION
The **-I-** is problematic and was not listed in synopsis. Renamed **-Ie** for exact region, but backwards compatibility maintained.
