### PR TITLE
Add coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ script:
         cd build; make -j docs_html; cd ..;
         cd build; make -j check; cd ..;
       fi
+    - export COVERAGE=true
+    - cd build; make -j check; cd ..;
 
 after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,8 @@ script:
         cd build; make -j docs_html; cd ..;
       fi
     # Build tests and check coverage
-    # - cd build; make -j check; cd ..
-    - cd build; ctest -R pssac; cd ..
-
-after_success:
+    - cd build; make -j check; cd ..
     - bash <(curl -s https://codecov.io/bash)
-
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ env:
         - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
             export PYTHON=3.6
             export CONDA_INSTALL_EXTRA="sphinx"
+            export COVERAGE=true
           fi
-        - COVERAGE=true
 
 before_install:
     # Install GMT dependencies
@@ -42,12 +42,13 @@ install:
 script:
     - gmt defaults -Vd
     - gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
-    # Build GMT documentations
+    # Build documentations, tests and coverage reports
     - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
         cd build; make -j docs_html; cd ..;
+        cd build; make -j check; cd ..;
       fi
-    # Build tests and check coverage
-    - cd build; make -j check; cd ..
+
+after_success:
     - bash <(curl -s https://codecov.io/bash)
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ branches:
     only:
         - master
         - 5.4
-        - codecov
         # Regex to build tagged commits with version numbers
         - /\d+\.\d+(\.\d+)?(\S*)?$/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ script:
         cd build; make -j docs_html; cd ..;
         cd build; make -j check; cd ..;
       fi
+    # remove it before merge
     - export COVERAGE=true
     - cd build; make -j check; cd ..;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
     only:
         - master
         - 5.4
+        - codecov
         # Regex to build tagged commits with version numbers
         - /\d+\.\d+(\.\d+)?(\S*)?$/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
             export PYTHON=3.6
             export CONDA_INSTALL_EXTRA="sphinx"
           fi
+        - COVERAGE=true
 
 before_install:
     # Install GMT dependencies
@@ -43,8 +44,15 @@ script:
     - gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
     # Build GMT documentations
     - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
-        cd build; make -j docs_html;
+        cd build; make -j docs_html; cd ..;
       fi
+    # Build tests and check coverage
+    # - cd build; make -j check; cd ..
+    - cd build; ctest -R pssac; cd ..
+
+after_success:
+    - bash <(curl -s https://codecov.io/bash)
+
 
 notifications:
     email: false

--- a/ci/travis-build.sh
+++ b/ci/travis-build.sh
@@ -17,6 +17,13 @@ set (DO_TESTS TRUE)
 set (DO_ANIMATIONS TRUE)
 EOF
 
+if [ "$COVERAGE" == "true" ]; then
+    cat >> cmake/ConfigUser.cmake << 'EOF'
+set (CMAKE_BUILD_TYPE Debug)
+set (CMAKE_C_FLAGS "-Wall -Wdeclaration-after-statement -coverage -O0")
+EOF
+fi
+
 cat cmake/ConfigUser.cmake
 
 mkdir build && cd build

--- a/ci/travis-build.sh
+++ b/ci/travis-build.sh
@@ -15,6 +15,7 @@ enable_testing()
 set (DO_EXAMPLES TRUE)
 set (DO_TESTS TRUE)
 set (DO_ANIMATIONS TRUE)
+set (N_TEST_JOBS 2)
 EOF
 
 if [ "$COVERAGE" == "true" ]; then

--- a/ci/travis-build.sh
+++ b/ci/travis-build.sh
@@ -4,16 +4,26 @@
 # To return a failure if any commands inside fail
 set -e
 
+cat > cmake/ConfigUser.cmake << 'EOF'
+set (CMAKE_INSTALL_PREFIX "$ENV{INSTALLDIR}")
+set (GMT_LIBDIR "$ENV{INSTALLDIR}/lib")
+set (DCW_ROOT "$ENV{COASTLINEDIR}")
+set (GSHHG_ROOT "$ENV{COASTLINEDIR}")
+
+set (CMAKE_BUILD_TYPE Debug)
+enable_testing()
+set (DO_EXAMPLES TRUE)
+set (DO_TESTS TRUE)
+set (DO_ANIMATIONS TRUE)
+EOF
+
+cat cmake/ConfigUser.cmake
+
 mkdir build && cd build
 
-cmake -D CMAKE_INSTALL_PREFIX=$INSTALLDIR \
-      -D GMT_LIBDIR=$INSTALLDIR/lib \
-      -D DCW_ROOT=$COASTLINEDIR \
-      -D GSHHG_ROOT=$COASTLINEDIR \
-      ..
+cmake ..
 
 make -j
-make check
 make install
 
 # Turn off exit on failure.

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -8,7 +8,8 @@ set -e
 if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     sudo apt-get update
     sudo apt-get install -y build-essential cmake libcurl4-gnutls-dev libnetcdf-dev \
-        libgdal1-dev libfftw3-dev libpcre3-dev liblapack-dev ghostscript curl
+        libgdal1-dev libfftw3-dev libpcre3-dev liblapack-dev ghostscript curl \
+        graphicsmagick
 else
     echo "OSX not supported yet";
 fi


### PR DESCRIPTION
This PR adds coverage reports for gmt C codes.

We need to run the whole tests to generate the coverage reports. Because these tests take too long (~30 min on travis), we cannot build the coverage reports for every commit. Currently, the tests and coverage are only activated by cron jobs, so we don't need to wait the reports for every commit, but still get latest coverage reports every day.

Although there're some failing tests, we still get coverage reports. You can check the coverage reports generated by this PR here (https://codecov.io/gh/GenericMappingTools/gmt/tree/561266b5cdce0699f8fff53068691e7e38942e26). Currently, the coverage is 57%.

@GenericMappingTools/core Any comments or suggestions?

**Please don't merge this PR even after approval, I still need to do some cleanup before merging.**