### PR TITLE
Avoid names reserved for the compiler

### DIFF
--- a/src/gmt_common.h
+++ b/src/gmt_common.h
@@ -28,8 +28,8 @@
  * \brief Holds current selections for the family of common GMT options
  */
 
-#ifndef _GMT_COMMON_H
-#define _GMT_COMMON_H
+#ifndef GMT_COMMON_H
+#define GMT_COMMON_H
 
 /*! Constants related to detecting data gaps which should be treated as segment boundaries */
 enum GMT_enum_gaps {GMT_NEGGAP_IN_COL = 0,	/* Check if previous minus current column value exceeds <gap> */
@@ -224,4 +224,4 @@ struct GMT_COMMON {
 	} colon;
 };
 
-#endif /* _GMT_COMMON_H */
+#endif /* GMT_COMMON_H */

--- a/src/gmt_config.h.in
+++ b/src/gmt_config.h.in
@@ -35,8 +35,8 @@
  */
 
 #pragma once
-#ifndef _GMT_CONFIG_H
-#define _GMT_CONFIG_H
+#ifndef GMT_CONFIG_H
+#define GMT_CONFIG_H
 
 #include "config.h"
 
@@ -339,6 +339,6 @@
 #	define NO_SIGHANDLER
 #endif
 
-#endif /* !_GMT_CONFIG_H */
+#endif /* !GMT_CONFIG_H */
 
 /* vim: set ft=c: */

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -27,8 +27,8 @@
  * \brief Definitions of constants used through GMT.
  */
 
-#ifndef _GMT_CONSTANTS_H
-#define _GMT_CONSTANTS_H
+#ifndef GMT_CONSTANTS_H
+#define GMT_CONSTANTS_H
 
 /*=====================================================================================
  *	GMT API CONSTANTS DEFINITIONS
@@ -467,4 +467,4 @@ enum GMT_enum_curl {GMT_REGULAR_FILE = 0,	/* Regular file the may or may not exi
 
 #define GMT_DEFAULT_CPT "rainbow"				/* When no CPT is given we choose this one */
 
-#endif  /* _GMT_CONSTANTS_H */
+#endif  /* GMT_CONSTANTS_H */

--- a/src/gmt_contour.h
+++ b/src/gmt_contour.h
@@ -28,8 +28,8 @@
  * \brief Structures and variables needed for contour labels.
  */
 
-#ifndef _GMT_CONTOUR_H
-#define _GMT_CONTOUR_H
+#ifndef GMT_CONTOUR_H
+#define GMT_CONTOUR_H
 
 /*! Various settings for contour label placements at crossing lines */
 enum GMT_enum_contline {
@@ -158,4 +158,4 @@ struct GMT_CONTOUR {
 	struct GMT_CONTOUR_LINE **segment;	/* Array of segments */
 };
 
-#endif /* _GMT_CONTOUR_H */
+#endif /* GMT_CONTOUR_H */

--- a/src/gmt_core_module.h
+++ b/src/gmt_core_module.h
@@ -12,8 +12,8 @@
  */
 
 #pragma once
-#ifndef _GMT_CORE_MODULE_H
-#define _GMT_CORE_MODULE_H
+#ifndef GMT_CORE_MODULE_H
+#define GMT_CORE_MODULE_H
 
 #ifdef __cplusplus /* Basic C++ support */
 extern "C" {
@@ -132,4 +132,4 @@ EXTERN_MSC const char * gmt_core_module_group (void *API, char *candidate);
 }
 #endif
 
-#endif /* !_GMT_CORE_MODULE_H */
+#endif /* !GMT_CORE_MODULE_H */

--- a/src/gmt_dcw.h
+++ b/src/gmt_dcw.h
@@ -28,8 +28,8 @@
  * \brief Definitions for using the DCW 
  */
 
-#ifndef _GMT_DCW_H
-#define _GMT_DCW_H
+#ifndef GMT_DCW_H
+#define GMT_DCW_H
 
 #define DCW_OPT "<code1,code2,...>[+l|L][+g<fill>][+p<pen>][+r|R[<incs>]]"
 
@@ -64,4 +64,4 @@ EXTERN_MSC void gmt_DCW_option (struct GMTAPI_CTRL *API, char option, unsigned i
 EXTERN_MSC struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SELECT *F, double wesn[], unsigned int mode);
 EXTERN_MSC void gmt_DCW_free (struct GMT_CTRL *GMT, struct GMT_DCW_SELECT *F);
 
-#endif /* _GMT_DCW_H */
+#endif /* GMT_DCW_H */

--- a/src/gmt_decorate.h
+++ b/src/gmt_decorate.h
@@ -28,8 +28,8 @@
  * \brief Structures and variables needed for decorating lines.
  */
 
-#ifndef _GMT_DECORATE_H
-#define _GMT_DECORATE_H
+#ifndef GMT_DECORATE_H
+#define GMT_DECORATE_H
 
 /*! Various settings for symbol placements along lines */
 enum GMT_enum_decorate {
@@ -77,4 +77,4 @@ struct GMT_DECORATE {
 	struct GMT_XOVER XC;		/* Structure with resulting crossovers */
 };
 
-#endif /* _GMT_DECORATE_H */
+#endif /* GMT_DECORATE_H */

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -27,8 +27,8 @@
  * \brief Definition of the structure with default settings.
  */
 
-#ifndef _GMT_DEFAULTS_H
-#define _GMT_DEFAULTS_H
+#ifndef GMT_DEFAULTS_H
+#define GMT_DEFAULTS_H
 
 /*--------------------------------------------------------------------
  *			GMT DEFAULTS STRUCTURE DEFINITION
@@ -185,4 +185,4 @@ struct GMT_DEFAULTS {
 	char given_unit[GMT_N_KEYS];		/* Unit given or implied for each setting */
 };
 
-#endif  /* _GMT_DEFAULTS_H */
+#endif  /* GMT_DEFAULTS_H */

--- a/src/gmt_dev.h
+++ b/src/gmt_dev.h
@@ -43,8 +43,8 @@
  */
 
 #pragma once
-#ifndef _GMT_DEV_H
-#define _GMT_DEV_H
+#ifndef GMT_DEV_H
+#define GMT_DEV_H
 
 #ifdef __cplusplus	/* Basic C++ support */
 extern "C" {
@@ -176,4 +176,4 @@ struct GMT_CTRL; /* forward declaration of GMT_CTRL */
 }
 #endif
 
-#endif  /* !_GMT_DEV_H */
+#endif  /* !GMT_DEV_H */

--- a/src/gmt_gdalread.h
+++ b/src/gmt_gdalread.h
@@ -20,8 +20,8 @@
  * \brief Define structures to interface with gdalread|write
  */
 
-#ifndef _GMT_GDALREAD_H
-#define _GMT_GDALREAD_H
+#ifndef GMT_GDALREAD_H
+#define GMT_GDALREAD_H
 
 #include <gdal.h>
 #include <ogr_srs_api.h>
@@ -199,4 +199,4 @@ struct GMT_GDALREAD_OUT_CTRL {
 	struct GDAL_BAND_FNAMES *band_field_names;
 };
 
-#endif  /* _GMT_GDALREAD_H */
+#endif  /* GMT_GDALREAD_H */

--- a/src/gmt_glib.h
+++ b/src/gmt_glib.h
@@ -29,7 +29,7 @@
 /* Include glib header and define mutex calls that are no-op when not linking against glib
    These are used only GLIB based multi-threading */
 
-#ifndef _GMT_GLIB_H
+#ifndef GMT_GLIB_H
 
 #ifdef HAVE_GLIB_GTHREAD
 #include <glib.h>

--- a/src/gmt_grd.h
+++ b/src/gmt_grd.h
@@ -31,8 +31,8 @@
  * \brief Definition for a GMT-SYSTEM Version >= 2 grd file 
  */
 
-#ifndef _GMT_GRID_H
-#define _GMT_GRID_H
+#ifndef GMT_GRID_H
+#define GMT_GRID_H
 
 /* netcdf convention */
 #define GMT_NC_CONVENTION "CF-1.7"
@@ -189,4 +189,4 @@ enum gmt_enum_wesnids {
 /*! gmt_M_grd_duplicate_column is true for geographical global grid where first and last data columns are identical */
 #define gmt_M_grd_duplicate_column(C,h,way) (C->current.io.col_type[way][GMT_X] == GMT_IS_LON && gmt_M_360_range (h->wesn[XHI], h->wesn[XLO]) && h->registration == GMT_GRID_NODE_REG)
 
-#endif /* _GMT_GRID_H */
+#endif /* GMT_GRID_H */

--- a/src/gmt_gsformats.h
+++ b/src/gmt_gsformats.h
@@ -25,10 +25,10 @@
  * \brief List of gs formats for modern mode.
  */
 
-#ifndef _GMT_GSFORMATS_H
-#define _GMT_GSFORMATS_H
+#ifndef GMT_GSFORMATS_H
+#define GMT_GSFORMATS_H
 
 /* List ps at end since it causes a renaming of ps- to ps only.  Also allow jpeg and tiff spellings */
 static char *gmt_session_format[] = {"pdf", "jpg", "jpeg", "png", "PNG", "ppm", "tif", "tiff", "bmp", "eps", "ps", NULL};
 
-#endif  /* _GMT_GSFORMATS_H */
+#endif  /* GMT_GSFORMATS_H */

--- a/src/gmt_hash.h
+++ b/src/gmt_hash.h
@@ -27,8 +27,8 @@
  * \brief Definition of the structure used for hashing
  */
 
-#ifndef _GMT_HASH_H
-#define _GMT_HASH_H
+#ifndef GMT_HASH_H
+#define GMT_HASH_H
 
 /*--------------------------------------------------------------------
  *			GMT HASH STRUCTURE DEFINITION
@@ -50,4 +50,4 @@ struct GMT_HASH {
 	char *key[GMT_HASH_MAXDEPTH];		/* Name of these entries */
 };
 
-#endif  /* _GMT_HASH_H */
+#endif  /* GMT_HASH_H */

--- a/src/gmt_hidden.h
+++ b/src/gmt_hidden.h
@@ -29,8 +29,8 @@
  * \brief Definitions for the GMT resources (GMT_GRID, GMT_DATASET, etc...)
  */
 
-#ifndef _GMT_HIDDEN_H
-#define _GMT_HIDDEN_H
+#ifndef GMT_HIDDEN_H
+#define GMT_HIDDEN_H
 
 GMT_LOCAL inline struct GMT_DATASET_HIDDEN     * gmt_get_DD_hidden (struct GMT_DATASET *p)     {return (p->hidden);}
 GMT_LOCAL inline struct GMT_DATATABLE_HIDDEN   * gmt_get_DT_hidden (struct GMT_DATATABLE *p)   {return (p->hidden);}
@@ -205,4 +205,4 @@ struct GMT_IMAGE_HIDDEN {	/* Supporting information hidden from the API */
 /* Get the segments next segment (for holes in perimeters */
 GMT_LOCAL inline struct GMT_DATASEGMENT * gmt_get_next_S (struct GMT_DATASEGMENT *S) {struct GMT_DATASEGMENT_HIDDEN *SH = gmt_get_DS_hidden (S); return (SH->next);}
 
-#endif /* _GMT_HIDDEN_H */
+#endif /* GMT_HIDDEN_H */

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -27,8 +27,8 @@
 
 */
 
-#ifndef _GMT_INTERNALS_H
-#define _GMT_INTERNALS_H
+#ifndef GMT_INTERNALS_H
+#define GMT_INTERNALS_H
 
 #ifdef HAVE_FFTW3F
 /* FFTW_planner_flags: FFTW_ESTIMATE, FFTW_MEASURE, FFTW_PATIENT, FFTW_EXHAUSTIVE */
@@ -258,4 +258,4 @@ int gmtlib_read_image_info (struct GMT_CTRL *GMT, char *file, bool must_be_image
 #define gmt_M_pole_is_point(C) ((C->current.proj.projection == GMT_OBLIQUE_MERC || C->current.proj.projection == GMT_OBLIQUE_MERC_POLE) || (C->current.proj.projection >= GMT_LAMBERT && C->current.proj.projection <= GMT_VANGRINTEN && C->current.proj.projection != GMT_POLAR))
 #define gmt_M_is_grdmapproject(C) (!strncmp (C->init.module_name, "grdproject", 10U) || !strncmp (C->init.module_name, "mapproject", 10U))
 
-#endif /* _GMT_INTERNALS_H */
+#endif /* GMT_INTERNALS_H */

--- a/src/gmt_io.h
+++ b/src/gmt_io.h
@@ -32,8 +32,8 @@
  * \brief  
  */
 
-#ifndef _GMT_IO_H
-#define _GMT_IO_H
+#ifndef GMT_IO_H
+#define GMT_IO_H
 
 #ifdef HAVE_SETLOCALE
 #	include <locale.h>
@@ -340,4 +340,4 @@ struct GMT_PLOT_CALCLOCK {
 
 /* For the GMT_GRID container, see gmt_grdio.h */
 
-#endif /* _GMT_IO_H */
+#endif /* GMT_IO_H */

--- a/src/gmt_macros.h
+++ b/src/gmt_macros.h
@@ -27,8 +27,8 @@
  * \brief Definitions of macros used through GMT.
  */
 
-#ifndef _GMT_MACROS_H
-#define _GMT_MACROS_H
+#ifndef GMT_MACROS_H
+#define GMT_MACROS_H
 
 /*--------------------------------------------------------------------
  *			GMT MACROS DEFINITIONS
@@ -196,4 +196,4 @@
 /*! Set the correct column mode (trailing vs no trailing text) based on the given string is NULL or not */
 #define gmt_M_colmode(text) ((text == NULL) ? GMT_COL_FIX_NO_TEXT : GMT_COL_FIX)
 
-#endif  /* _GMT_MACROS_H */
+#endif  /* GMT_MACROS_H */

--- a/src/gmt_make_module_src.sh
+++ b/src/gmt_make_module_src.sh
@@ -78,8 +78,8 @@ cat << EOF > ${FILE_GMT_MODULE_H}
  */
 
 #pragma once
-#ifndef _GMT_${U_TAG}_MODULE_H
-#define _GMT_${U_TAG}_MODULE_H
+#ifndef GMT_${U_TAG}_MODULE_H
+#define GMT_${U_TAG}_MODULE_H
 
 #ifdef __cplusplus /* Basic C++ support */
 extern "C" {
@@ -106,7 +106,7 @@ EXTERN_MSC const char * gmt_${L_TAG}_module_group (void *API, char *candidate);
 }
 #endif
 
-#endif /* !_GMT_${U_TAG}_MODULE_H */
+#endif /* !GMT_${U_TAG}_MODULE_H */
 EOF
 
 #

--- a/src/gmt_mbsystem_module.h
+++ b/src/gmt_mbsystem_module.h
@@ -11,8 +11,8 @@
  */
 
 #pragma once
-#ifndef _GMT_MBSYSTEM_MODULE_H
-#define _GMT_MBSYSTEM_MODULE_H
+#ifndef GMT_MBSYSTEM_MODULE_H
+#define GMT_MBSYSTEM_MODULE_H
 
 #ifdef __cplusplus /* Basic C++ support */
 extern "C" {
@@ -37,4 +37,4 @@ EXTERN_MSC const char * gmt_mbsystem_module_info (void *API, char *candidate);
 }
 #endif
 
-#endif /* !_GMT_MBSYSTEM_MODULE_H */
+#endif /* !GMT_MBSYSTEM_MODULE_H */

--- a/src/gmt_memory.h
+++ b/src/gmt_memory.h
@@ -20,8 +20,8 @@
  * \brief 
  */
 
-#ifndef _GMT_MEMORY_H
-#define _GMT_MEMORY_H
+#ifndef GMT_MEMORY_H
+#define GMT_MEMORY_H
 
 enum GMT_enum_mem_alloc {	/* Initial memory for 2 double columns is 32 Mb */
 	GMT_INITIAL_MEM_COL_ALLOC	= 2U,
@@ -96,4 +96,4 @@ EXTERN_MSC void gmt_memtrack_report (struct GMT_CTRL *GMT);
 
 #endif
 
-#endif /* _GMT_MEMORY_H */
+#endif /* GMT_MEMORY_H */

--- a/src/gmt_modern.h
+++ b/src/gmt_modern.h
@@ -25,8 +25,8 @@
  * \brief Definitions of constants used through GMT for modern mode.
  */
 
-#ifndef _GMT_MODERN_H
-#define _GMT_MODERN_H
+#ifndef GMT_MODERN_H
+#define GMT_MODERN_H
 
 #define GMT_HISTORY_FILE	"gmt.history"
 #define GMT_SESSION_FILE	"gmt.session"
@@ -72,4 +72,4 @@ EXTERN_MSC int GMT_segy (void *API, int mode, void *args);
 
 EXTERN_MSC const char *gmt_current_name (const char *module, char modname[]);
 
-#endif  /* _GMT_MODERN_H */
+#endif  /* GMT_MODERN_H */

--- a/src/gmt_nan.h
+++ b/src/gmt_nan.h
@@ -34,8 +34,8 @@
  * \brief Machine-dependent macros for generation and testing of NaNs
  */
 
-#ifndef _GMT_NAN_H
-#define _GMT_NAN_H
+#ifndef GMT_NAN_H
+#define GMT_NAN_H
 
 #include "gmt_notposix.h"
 
@@ -55,4 +55,4 @@
 #	define gmt_M_is_dinf isinf
 #endif
 
-#endif /* _GMT_NAN_H */
+#endif /* GMT_NAN_H */

--- a/src/gmt_notposix.h
+++ b/src/gmt_notposix.h
@@ -31,8 +31,8 @@
  * \brief Contains ifdefs to tell us if this system has functions not in POSIX but part of ANSI C
  */
 
-#ifndef _GMT_NOTPOSIX_H
-#define _GMT_NOTPOSIX_H
+#ifndef GMT_NOTPOSIX_H
+#define GMT_NOTPOSIX_H
 
 /* HAVE_<func> is undefined or defined as 1 depending on
  * whether or not <func> is available on this system.
@@ -593,4 +593,4 @@
 /* define custom function */
 #endif
 
-#endif /* _GMT_NOTPOSIX_H */
+#endif /* GMT_NOTPOSIX_H */

--- a/src/gmt_plot.h
+++ b/src/gmt_plot.h
@@ -20,8 +20,8 @@
  * \brief 
  */
 
-#ifndef _GMT_PLOT_H
-#define _GMT_PLOT_H
+#ifndef GMT_PLOT_H
+#define GMT_PLOT_H
 
 /*! Identifier for gmt_plane_perspective. The others come from GMT_io.h */
 
@@ -161,4 +161,4 @@ struct GMT_SYMBOL {
 	struct GMT_DECORATE D;	/* For decorated lines */
 };
 
-#endif /* _GMT_PLOT_H */
+#endif /* GMT_PLOT_H */

--- a/src/gmt_project.h
+++ b/src/gmt_project.h
@@ -29,8 +29,8 @@
  * \brief Include file for programs that use the map-projections functions.
  */
 
-#ifndef _GMT_PROJECT_H
-#define _GMT_PROJECT_H
+#ifndef GMT_PROJECT_H
+#define GMT_PROJECT_H
 
 #define HALF_DBL_MAX (DBL_MAX/2.0)
 
@@ -508,4 +508,4 @@ struct GMT_PLOT_FRAME {		/* Various parameters for plotting of time axis boundar
 	unsigned int z_axis[4];		/* Which axes to use for the 3-D z-axis [auto] */
 };
 
-#endif /* _GMT_PROJECT_H */
+#endif /* GMT_PROJECT_H */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -27,8 +27,8 @@
  * \brief All low-level GMT API function prototypes.
  */
 
-#ifndef _GMT_PROTOTYPES_H
-#define _GMT_PROTOTYPES_H
+#ifndef GMT_PROTOTYPES_H
+#define GMT_PROTOTYPES_H
 
 #ifdef DEBUG
 EXTERN_MSC void gmt_grd_dump (struct GMT_GRID_HEADER *header, gmt_grdfloat *grid, bool is_complex, char *txt);
@@ -657,4 +657,4 @@ EXTERN_MSC double gmt_grd_mad (struct GMT_CTRL *GMT, struct GMT_GRID *G, struct 
 EXTERN_MSC double gmt_grd_lmsscl (struct GMT_CTRL *GMT, struct GMT_GRID *G, struct GMT_GRID *W, double *mode, bool overwrite);
 EXTERN_MSC void gmt_get_cellarea (struct GMT_CTRL *GMT, struct GMT_GRID *G);
 
-#endif /* _GMT_PROTOTYPES_H */
+#endif /* GMT_PROTOTYPES_H */

--- a/src/gmt_psl.h
+++ b/src/gmt_psl.h
@@ -27,8 +27,8 @@
  * \brief Definition of the structure with PostScript settings 
  */
 
-#ifndef _GMT_PSL_H
-#define _GMT_PSL_H
+#ifndef GMT_PSL_H
+#define GMT_PSL_H
 
 /*--------------------------------------------------------------------
  *			GMT PS STRUCTURE DEFINITION
@@ -74,4 +74,4 @@ struct GMT_PSL {
 	FILE *fp;			/* Pointer to open but hidden PS file for RUNMODE = modern */
 };
 
-#endif  /* _GMT_PSL_H */
+#endif  /* GMT_PSL_H */

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -30,8 +30,8 @@
  * \brief Definitions for the GMT resources (GMT_GRID, GMT_DATASET, etc...)
  */
 
-#ifndef _GMT_RESOURCES_H
-#define _GMT_RESOURCES_H
+#ifndef GMT_RESOURCES_H
+#define GMT_RESOURCES_H
 
 #define GMT_BACKWARDS_API	/* Try to be backwards compatible with API naming for now */
 
@@ -776,4 +776,4 @@ struct GMT_RESOURCE {	/* Information related to passing resources between GMT an
 	void *object;			/* Pointer to the actual GMT object */
 };
 
-#endif /* _GMT_RESOURCES_H */
+#endif /* GMT_RESOURCES_H */

--- a/src/gmt_sharedlibs.h
+++ b/src/gmt_sharedlibs.h
@@ -10,8 +10,8 @@
  */
 
 #pragma once
-#ifndef _GMT_SHAREDLIBS_H
-#define _GMT_SHAREDLIBS_H
+#ifndef GMT_SHAREDLIBS_H
+#define GMT_SHAREDLIBS_H
 
 #ifdef __cplusplus /* Basic C++ support */
 extern "C" {
@@ -43,4 +43,4 @@ struct Gmt_libinfo {
 }
 #endif
 
-#endif /* !_GMT_SHAREDLIBS_H */
+#endif /* !GMT_SHAREDLIBS_H */

--- a/src/gmt_shore.h
+++ b/src/gmt_shore.h
@@ -27,8 +27,8 @@
  * \brief Include file for gmt_shore.c
  */
 
-#ifndef _GMT_SHORE_H
-#define _GMT_SHORE_H
+#ifndef GMT_SHORE_H
+#define GMT_SHORE_H
 
 /* Declaration modifier for netcdf DLL support
  * annoying: why can't netcdf.h do this on its own? */
@@ -248,4 +248,4 @@ struct GMT_GSHHS_POL {
 	double *lat;
 };
 
-#endif /* _GMT_SHORE_H */
+#endif /* GMT_SHORE_H */

--- a/src/gmt_supplements_module.h
+++ b/src/gmt_supplements_module.h
@@ -12,8 +12,8 @@
  */
 
 #pragma once
-#ifndef _GMT_SUPPLEMENTS_MODULE_H
-#define _GMT_SUPPLEMENTS_MODULE_H
+#ifndef GMT_SUPPLEMENTS_MODULE_H
+#define GMT_SUPPLEMENTS_MODULE_H
 
 #ifdef __cplusplus /* Basic C++ support */
 extern "C" {
@@ -89,4 +89,4 @@ EXTERN_MSC const char * gmt_supplements_module_group (void *API, char *candidate
 }
 #endif
 
-#endif /* !_GMT_SUPPLEMENTS_MODULE_H */
+#endif /* !GMT_SUPPLEMENTS_MODULE_H */

--- a/src/gmt_symbol.h
+++ b/src/gmt_symbol.h
@@ -31,8 +31,8 @@
  * \brief Miscellaneous definitions and structures related to symbols 
  */
 
-#ifndef _GMT_SYMBOLS_H
-#define _GMT_SYMBOLS_H
+#ifndef GMT_SYMBOLS_H
+#define GMT_SYMBOLS_H
 
 /* VECTOR attributes are used by psxy, psxyz, psrose, grdvector */
 #define VECTOR_LINE_WIDTH	2.0	/* Default vector attributes in points */
@@ -171,4 +171,4 @@ struct GMT_MAP_ROSE {
 	struct GMT_MAP_PANEL *panel;	/* Everything about optional back panel */
 };
 
-#endif	/* _GMT_SYMBOLS_H */
+#endif	/* GMT_SYMBOLS_H */

--- a/src/gmt_texture.h
+++ b/src/gmt_texture.h
@@ -27,8 +27,8 @@
  * \brief Definitions of structures for pens, fills, and fonts.
  */
 
-#ifndef _GMT_TEXTURE_H
-#define _GMT_TEXTURE_H
+#ifndef GMT_TEXTURE_H
+#define GMT_TEXTURE_H
 
 /*--------------------------------------------------------------------
  *			GMT TEXTURE STRUCTURE DEFINITIONS
@@ -95,4 +95,4 @@ struct GMT_MEDIA {
 	double height;		/* Height in points */
 };
 
-#endif  /* _GMT_TEXTURE_H */
+#endif  /* GMT_TEXTURE_H */

--- a/src/gmt_time.h
+++ b/src/gmt_time.h
@@ -27,8 +27,8 @@
  * \brief Definitions of structures dealing with time.
  */
 
-#ifndef _GMT_TIME_H
-#define _GMT_TIME_H
+#ifndef GMT_TIME_H
+#define GMT_TIME_H
 
 /*--------------------------------------------------------------------
  *			GMT TIME STRUCTURES
@@ -43,4 +43,4 @@ struct GMT_TIME_SYSTEM {
 	char unit;			/* User-defined time unit */
 };
 
-#endif  /* _GMT_TIME_H */
+#endif  /* GMT_TIME_H */

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -27,8 +27,8 @@
  * \brief Definitions of special types used by GMT.
  */
 
-#ifndef _GMT_TYPES_H
-#define _GMT_TYPES_H
+#ifndef GMT_TYPES_H
+#define GMT_TYPES_H
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -439,4 +439,4 @@ static inline void GMT_exit (struct GMT_CTRL *GMT, int code) {
 		exit (code);
 }
 
-#endif  /* _GMT_TYPES_H */
+#endif  /* GMT_TYPES_H */

--- a/src/gshhg_version.h
+++ b/src/gshhg_version.h
@@ -27,8 +27,8 @@
  * \brief 
  */
 
-#ifndef _GMT_GSHHG_VERSION_H
-#define _GMT_GSHHG_VERSION_H
+#ifndef GMT_GSHHG_VERSION_H
+#define GMT_GSHHG_VERSION_H
 
 #ifdef __cplusplus      /* Basic C++ support */
 extern "C" {
@@ -59,4 +59,4 @@ EXTERN_MSC int gshhg_require_min_version (const char* filename, const struct GSH
 }
 #endif
 
-#endif  /* _GMT_GSHHG_VERSION_H */
+#endif  /* GMT_GSHHG_VERSION_H */


### PR DESCRIPTION
We use defines like **_GMT_H** but anything that starts with underscore is reserved for compilers.
