### PR TITLE
Fix access to remote files in 5.4.x

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13088,7 +13088,9 @@ bool gmtlib_file_is_downloadable (struct GMT_CTRL *GMT, const char *file, unsign
 	 * Otherwise, it is just a file that does not exist and will yield an error upstream */
 	if (!strncmp (file, GMT_DATA_PREFIX, strlen(GMT_DATA_PREFIX)) && strstr (file, ".grd"))	/* Useful data set distributed by GMT */
 		*kind = GMT_DATA_FILE;
-	return (*kind) ? true : false;	/* Download if flagged as special file, else not */
+    else if (file[0] == '@' && !strncmp (&file[1], GMT_DATA_PREFIX, strlen(GMT_DATA_PREFIX)) && strstr (file, ".grd"))    /* Useful data set distributed by GMT */
+        *kind = GMT_DATA_FILE;
+return (*kind) ? true : false;	/* Download if flagged as special file, else not */
 }
 
 /*! . */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13088,9 +13088,9 @@ bool gmtlib_file_is_downloadable (struct GMT_CTRL *GMT, const char *file, unsign
 	 * Otherwise, it is just a file that does not exist and will yield an error upstream */
 	if (!strncmp (file, GMT_DATA_PREFIX, strlen(GMT_DATA_PREFIX)) && strstr (file, ".grd"))	/* Useful data set distributed by GMT */
 		*kind = GMT_DATA_FILE;
-    else if (file[0] == '@' && !strncmp (&file[1], GMT_DATA_PREFIX, strlen(GMT_DATA_PREFIX)) && strstr (file, ".grd"))    /* Useful data set distributed by GMT */
-        *kind = GMT_DATA_FILE;
-return (*kind) ? true : false;	/* Download if flagged as special file, else not */
+	else if (file[0] == '@' && !strncmp (&file[1], GMT_DATA_PREFIX, strlen(GMT_DATA_PREFIX)) && strstr (file, ".grd"))    /* Useful data set distributed by GMT */
+		*kind = GMT_DATA_FILE;
+	return (*kind) ? true : false;	/* Download if flagged as special file, else not */
 }
 
 /*! . */


### PR DESCRIPTION
I think we updated syntax on remote files in 6 and decided to always use the leading @ symbol.  In 5.4 just giving earth_relief_xxm.grd was OK but now it tries to read from the cachhe dir rather than the top dir.  This change fixes the #298.

