### PR TITLE
Modernize -G option is psimage

### DIFF
--- a/doc_classic/rst/source/psimage.rst
+++ b/doc_classic/rst/source/psimage.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |SYN_OPT-B| ]
 [ |-D|\ *refpoint* ]
 [ |-F|\ *box* ]
-[ |-G|\ [**b**\ \|\ **f**\ \|\ **t**]\ *color* ]
+[ |-G|\ [*color*\ ][**+b**\ \|\ **+f**\ \|\ **+t**] ]
 [ |-I| ]
 [ |-J|\ *parameters* ]
 [ |-J|\ **z**\ \|\ **Z**\ *parameters* ]
@@ -110,6 +110,22 @@ Optional Arguments
     indicates the shift relative to the foreground frame
     [4\ **p**/-4\ **p**] and *shade* sets the fill style to use for shading [gray50].
 
+.. _-G:
+
+**-G**\ [*color*\ ][**+b**\ \|\ **+f**\ \|\ **+t**]
+    Change certain pixel values to another color or make them transparent.
+    For 1-bit images you can specify an alternate *color* for the background (**+b**)
+    or the foreground (**+f**) pixels, or give no color to make those pixels
+    transparent.  Alternatively, for color images you can select a single *color*
+    that should be made transparent instead.
+
+.. _-I:
+
+**-I**
+   Invert 1-bit image before plotting. This is what is done when you
+   use **-GP** to invert patterns in other GMT plotting programs.  Ignored
+   if used with color images.
+
 .. _-J:
 
 .. |Add_-J| replace:: (Used only with **-p**)
@@ -156,31 +172,6 @@ Optional Arguments
 
 .. include:: explain_-XY.rst_
 
-The following options are for 1-bit images only. They have no effect when
-plotting other images or PostScript files.
-
-.. _-G:
-
-**-G**\ [**b**\ \|\ **f**\ \|\ **t**]\ *color*
-    **-Gb**
-        Sets background color (replace white pixel) of 1-bit images. Use -
-        for transparency (and set **-Gf** to the desired color).
-    **-Gf**
-        Sets foreground color (replace black pixel) of 1-bit images. Use -
-        for transparency (and set **-Gb** to the desired color).
-
-.. _-I:
-
-**-I**
-   Invert 1-bit image before plotting. This is what is done when you
-   use **-GP** to invert patterns in other GMT plotting programs.
-
-These options are for 8-, 24-, and 32-bit raster images only. They have
-no effect when plotting 1-bit images or PostScript files.
-
-**-Gt**
-    Assigns the color that is to be made transparent.
-
 .. |Add_perspective| replace:: (Requires **-R** and **-J** for proper functioning).
 .. include:: explain_perspective.rst_
 
@@ -188,7 +179,15 @@ no effect when plotting 1-bit images or PostScript files.
 
 .. include:: explain_help.rst_
 
-:doc:`gmt`, :doc:`pslegend`,
+Notes
+-----
+
+The **-G** and **-I** options are for raster images only. They have
+no effect when placing Encapsulated *PostScript* files.
+
+Examples
+--------
+
 To plot the image logo.jpg, scaling it be 1 inch wide (height is scaled
 accordingly), and outline with a thin, blue pen, use
 
@@ -211,7 +210,7 @@ to be 1 cm wide, use
 
    ::
 
-    gmt psimage 1_bit.ras -Gbbrown -Gfred -Dx0/0+w1c+n5 > image.ps
+    gmt psimage 1_bit.ras -Gbrown+b -Gred+f -Dx0/0+w1c+n5 > image.ps
 
 See Also
 --------
@@ -219,5 +218,4 @@ See Also
 :doc:`gmt`,
 :doc:`gmtcolors`, :doc:`gmtlogo`
 :doc:`pslegend`, :doc:`psscale`
-:doc:`psxy`,
-:manpage:`convert(1)`
+:doc:`psxy`

--- a/doc_modern/rst/source/image.rst
+++ b/doc_modern/rst/source/image.rst
@@ -1,8 +1,8 @@
 .. index:: ! image
 
-*******
+*****
 image
-*******
+*****
 
 .. only:: not man
 
@@ -17,7 +17,7 @@ Synopsis
 [ |SYN_OPT-B| ]
 [ |-D|\ *refpoint* ]
 [ |-F|\ *box* ]
-[ |-G|\ [**b**\ \|\ **f**\ \|\ **t**]\ *color* ]
+[ |-G|\ [*color*\ ][**+b**\ \|\ **+f**\ \|\ **+t**] ]
 [ |-I| ]
 [ |-J|\ *parameters* ]
 [ |-J|\ **z**\ \|\ **Z**\ *parameters* ]
@@ -107,6 +107,22 @@ Optional Arguments
     indicates the shift relative to the foreground frame
     [4\ **p**/-4\ **p**] and *shade* sets the fill style to use for shading [gray50].
 
+.. _-G:
+
+**-G**\ [*color*\ ][**+b**\ \|\ **+f**\ \|\ **+t**]
+    Change certain pixel values to another color or make them transparent.
+    For 1-bit images you can specify an alternate *color* for the background (**+b**)
+    or the foreground (**+f**) pixels, or give no color to make those pixels
+    transparent.  Alternatively, for color images you can select a single *color*
+    that should be made transparent instead.
+
+.. _-I:
+
+**-I**
+   Invert 1-bit image before plotting. This is what is done when you
+   use **-GP** to invert patterns in other GMT plotting programs.  Ignored
+   if used with color images.
+
 .. _-J:
 
 .. |Add_-J| replace:: (Used only with **-p**)
@@ -141,31 +157,6 @@ Optional Arguments
 
 .. include:: explain_-XY.rst_
 
-The following options are for 1-bit images only. They have no effect when
-plotting other images or PostScript files.
-
-.. _-G:
-
-**-G**\ [**b**\ \|\ **f**\ \|\ **t**]\ *color*
-    **-Gb**
-        Sets background color (replace white pixel) of 1-bit images. Use -
-        for transparency (and set **-Gf** to the desired color).
-    **-Gf**
-        Sets foreground color (replace black pixel) of 1-bit images. Use -
-        for transparency (and set **-Gb** to the desired color).
-
-.. _-I:
-
-**-I**
-   Invert 1-bit image before plotting. This is what is done when you
-   use **-GP** to invert patterns in other GMT plotting programs.
-
-These options are for 8-, 24-, and 32-bit raster images only. They have
-no effect when plotting 1-bit images or PostScript files.
-
-**-Gt**
-    Assigns the color that is to be made transparent.
-
 .. |Add_perspective| replace:: (Requires **-R** and **-J** for proper functioning).
 .. include:: explain_perspective.rst_
 
@@ -173,7 +164,15 @@ no effect when plotting 1-bit images or PostScript files.
 
 .. include:: explain_help.rst_
 
-:doc:`gmt`, :doc:`legend`,
+Notes
+-----
+
+The **-G** and **-I** options are for raster images only. They have
+no effect when placing Encapsulated *PostScript* files.
+
+Examples
+--------
+
 To plot the image logo.jpg, scaling it be 1 inch wide (height is scaled
 accordingly), and outline with a thin, blue pen, use
 
@@ -196,7 +195,7 @@ to be 1 cm wide, use
 
    ::
 
-    gmt image 1_bit.ras -Gbbrown -Gfred -Dx0/0+w1c+n5 -pdf image
+    gmt image 1_bit.ras -Gbrown+b -Gred+f -Dx0/0+w1c+n5 -pdf image
 
 See Also
 --------

--- a/test/psimage/transparent_gif.ps
+++ b/test/psimage/transparent_gif.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from psbasemap
+%%Title: GMT v6.0.0_7b301d7 [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:52:48 2018
+%%CreationDate: Sat Jan 12 19:08:15 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -736,7 +736,7 @@ O0
 0 -4252 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Y-9c -R0/1/0/1 -JX7c -B+glightblue+t-Gtblack -O -K
+%@GMT: gmt psbasemap -Y-9c -R0/1/0/1 -JX7c -B+glightblue+t-Gblack\053t -O -K
 %@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -749,7 +749,7 @@ O0
 1654 3307 PSL_H_y add M
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
-(”Gtblack) bc Z
+(”Gblack\053t) bc Z
 %%EndObject
 0 A
 FQ
@@ -757,7 +757,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psimage @warning.gif -Gtblack -Dx0.5c/0.5c+jBL+w6c -O -K
+%@GMT: gmt psimage @warning.gif -Gblack+t -Dx0.5c/0.5c+jBL+w6c -O -K
 %@PROJ: xy 0.00000000 2.55905512 0.00000000 2.56777174 0.000 2.559 0.000 2.568 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -798,7 +798,7 @@ O0
 3780 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -X8c -R0/1/0/1 -JX7c -B+glightblue+t-Gtwhite -O -K
+%@GMT: gmt psbasemap -X8c -R0/1/0/1 -JX7c -B+glightblue+t-Gwhite\053t -O -K
 %@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
@@ -811,7 +811,7 @@ O0
 1654 3307 PSL_H_y add M
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
-(”Gtwhite) bc Z
+(”Gwhite\053t) bc Z
 %%EndObject
 0 A
 FQ
@@ -819,7 +819,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psimage @warning.gif -Gtwhite -D0.5c/0.5c+jBL+w6c -O -K
+%@GMT: gmt psimage @warning.gif -Gwhite+t -D0.5c/0.5c+jBL+w6c -O -K
 %@PROJ: xy 0.00000000 2.55905512 0.00000000 2.56777174 0.000 2.559 0.000 2.568 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
@@ -860,7 +860,7 @@ O0
 -3780 -4252 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -X-8c -Y-9c -R0/1/0/1 -JX7c -B+glightblue+t-Gtred -O -K
+%@GMT: gmt psbasemap -X-8c -Y-9c -R0/1/0/1 -JX7c -B+glightblue+t-Gred\053t -O -K
 %@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_7
 0 setlinecap
@@ -873,7 +873,7 @@ O0
 1654 3307 PSL_H_y add M
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
-(”Gtred) bc Z
+(”Gred\053t) bc Z
 %%EndObject
 0 A
 FQ
@@ -881,7 +881,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psimage @warning.gif -Gtred -Dx0.5c/0.5c+jBL+w6c -O -K
+%@GMT: gmt psimage @warning.gif -Gred+t -Dx0.5c/0.5c+jBL+w6c -O -K
 %@PROJ: xy 0.00000000 2.55905512 0.00000000 2.56777174 0.000 2.559 0.000 2.568 +xy
 %%BeginObject PSL_Layer_8
 0 setlinecap
@@ -922,7 +922,7 @@ O0
 3780 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -X8c -R0/1/0/1 -JX7c -B+glightblue+t-Gtblue -O -K
+%@GMT: gmt psbasemap -X8c -R0/1/0/1 -JX7c -B+glightblue+t-Gblue\053t -O -K
 %@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_9
 0 setlinecap
@@ -935,7 +935,7 @@ O0
 1654 3307 PSL_H_y add M
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
-(”Gtblue) bc Z
+(”Gblue\053t) bc Z
 %%EndObject
 0 A
 FQ
@@ -943,7 +943,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psimage @warning.gif -Gtblue -Dx0.5c/0.5c+jBL+w6c -O
+%@GMT: gmt psimage @warning.gif -Gblue+t -Dx0.5c/0.5c+jBL+w6c -O
 %@PROJ: xy 0.00000000 2.55905512 0.00000000 2.56777174 0.000 2.559 0.000 2.568 +xy
 %%BeginObject PSL_Layer_10
 0 setlinecap

--- a/test/psimage/transparent_gif.sh
+++ b/test/psimage/transparent_gif.sh
@@ -10,14 +10,14 @@ ps=transparent_gif.ps
 gmt psbasemap -R0/1/0/1 -JX7c -Y19c -B+glightblue+t"no option" -K -P > $ps
 gmt psimage @warning.gif -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -Y-9c -R -J -B+glightblue+t"-Gtblack" -O -K >> $ps
-gmt psimage @warning.gif -Gtblack -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
+gmt psbasemap -Y-9c -R -J -B+glightblue+t"-Gblack\053t" -O -K >> $ps
+gmt psimage @warning.gif -Gblack+t -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -X8c -R -J -B+glightblue+t"-Gtwhite" -O -K >> $ps
-gmt psimage @warning.gif -Gtwhite -D0.5c/0.5c+jBL+w6c -O -K >> $ps
+gmt psbasemap -X8c -R -J -B+glightblue+t"-Gwhite\053t" -O -K >> $ps
+gmt psimage @warning.gif -Gwhite+t -D0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -X-8c -Y-9c -R -J -B+glightblue+t"-Gtred" -O -K >> $ps
-gmt psimage @warning.gif -Gtred -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
+gmt psbasemap -X-8c -Y-9c -R -J -B+glightblue+t"-Gred\053t" -O -K >> $ps
+gmt psimage @warning.gif -Gred+t -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -X8c -R -J -B+glightblue+t"-Gtblue" -O -K >> $ps
-gmt psimage @warning.gif -Gtblue -Dx0.5c/0.5c+jBL+w6c -O >> $ps
+gmt psbasemap -X8c -R -J -B+glightblue+t"-Gblue\053t" -O -K >> $ps
+gmt psimage @warning.gif -Gblue+t -Dx0.5c/0.5c+jBL+w6c -O >> $ps

--- a/test/psimage/transparent_png.ps
+++ b/test/psimage/transparent_png.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from psbasemap
+%%Title: GMT v6.0.0_7b301d7 [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:52:37 2018
+%%CreationDate: Sat Jan 12 19:08:16 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -736,7 +736,7 @@ O0
 0 -4252 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Y-9c -R0/1/0/1 -JX7c -B+glightblue+t-Gtblack -O -K
+%@GMT: gmt psbasemap -Y-9c -R0/1/0/1 -JX7c -B+glightblue+t-Gblack\053t -O -K
 %@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -749,7 +749,7 @@ O0
 1654 3307 PSL_H_y add M
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
-(”Gtblack) bc Z
+(”Gblack\053t) bc Z
 %%EndObject
 0 A
 FQ
@@ -757,7 +757,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psimage @warning.png -Gtblack -Dx0.5c/0.5c+jBL+w6c -O -K
+%@GMT: gmt psimage @warning.png -Gblack+t -Dx0.5c/0.5c+jBL+w6c -O -K
 %@PROJ: xy 0.00000000 2.55905512 0.00000000 2.56777174 0.000 2.559 0.000 2.568 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -798,7 +798,7 @@ O0
 3780 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -X8c -R0/1/0/1 -JX7c -B+glightblue+t-Gtwhite -O -K
+%@GMT: gmt psbasemap -X8c -R0/1/0/1 -JX7c -B+glightblue+t-Gwhite\053t -O -K
 %@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
@@ -811,7 +811,7 @@ O0
 1654 3307 PSL_H_y add M
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
-(”Gtwhite) bc Z
+(”Gwhite\053t) bc Z
 %%EndObject
 0 A
 FQ
@@ -819,7 +819,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psimage @warning.png -Gtwhite -Dx0.5c/0.5c+jBL+w6c -O -K
+%@GMT: gmt psimage @warning.png -Gwhite+t -Dx0.5c/0.5c+jBL+w6c -O -K
 %@PROJ: xy 0.00000000 2.55905512 0.00000000 2.56777174 0.000 2.559 0.000 2.568 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
@@ -860,7 +860,7 @@ O0
 -3780 -4252 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -X-8c -Y-9c -R0/1/0/1 -JX7c -B+glightblue+t-Gtred -O -K
+%@GMT: gmt psbasemap -X-8c -Y-9c -R0/1/0/1 -JX7c -B+glightblue+t-Gred\053t -O -K
 %@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_7
 0 setlinecap
@@ -873,7 +873,7 @@ O0
 1654 3307 PSL_H_y add M
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
-(”Gtred) bc Z
+(”Gred\053t) bc Z
 %%EndObject
 0 A
 FQ
@@ -881,7 +881,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psimage @warning.png -Gtred -Dx0.5c/0.5c+jBL+w6c -O -K
+%@GMT: gmt psimage @warning.png -Gred+t -Dx0.5c/0.5c+jBL+w6c -O -K
 %@PROJ: xy 0.00000000 2.55905512 0.00000000 2.56777174 0.000 2.559 0.000 2.568 +xy
 %%BeginObject PSL_Layer_8
 0 setlinecap
@@ -922,7 +922,7 @@ O0
 3780 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -X8c -R0/1/0/1 -JX7c -B+glightblue+t-Gtblue -O -K
+%@GMT: gmt psbasemap -X8c -R0/1/0/1 -JX7c -B+glightblue+t-Gblue\053t -O -K
 %@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_9
 0 setlinecap
@@ -935,7 +935,7 @@ O0
 1654 3307 PSL_H_y add M
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
-(”Gtblue) bc Z
+(”Gblue\053t) bc Z
 %%EndObject
 0 A
 FQ
@@ -943,7 +943,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psimage @warning.png -Gtblue -Dx0.5c/0.5c+jBL+w6c -O
+%@GMT: gmt psimage @warning.png -Gblue+t -Dx0.5c/0.5c+jBL+w6c -O
 %@PROJ: xy 0.00000000 2.55905512 0.00000000 2.56777174 0.000 2.559 0.000 2.568 +xy
 %%BeginObject PSL_Layer_10
 0 setlinecap

--- a/test/psimage/transparent_png.sh
+++ b/test/psimage/transparent_png.sh
@@ -9,14 +9,14 @@ ps=transparent_png.ps
 gmt psbasemap -R0/1/0/1 -JX7c -Y19c -B+glightblue+t"no option" -K -P > $ps
 gmt psimage @warning.png -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -Y-9c -R -J -B+glightblue+t"-Gtblack" -O -K >> $ps
-gmt psimage @warning.png -Gtblack -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
+gmt psbasemap -Y-9c -R -J -B+glightblue+t"-Gblack\053t" -O -K >> $ps
+gmt psimage @warning.png -Gblack+t -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -X8c -R -J -B+glightblue+t"-Gtwhite" -O -K >> $ps
-gmt psimage @warning.png -Gtwhite -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
+gmt psbasemap -X8c -R -J -B+glightblue+t"-Gwhite\053t" -O -K >> $ps
+gmt psimage @warning.png -Gwhite+t -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -X-8c -Y-9c -R -J -B+glightblue+t"-Gtred" -O -K >> $ps
-gmt psimage @warning.png -Gtred -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
+gmt psbasemap -X-8c -Y-9c -R -J -B+glightblue+t"-Gred\053t" -O -K >> $ps
+gmt psimage @warning.png -Gred+t -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -X8c -R -J -B+glightblue+t"-Gtblue" -O -K >> $ps
-gmt psimage @warning.png -Gtblue -Dx0.5c/0.5c+jBL+w6c -O >> $ps
+gmt psbasemap -X8c -R -J -B+glightblue+t"-Gblue\053t" -O -K >> $ps
+gmt psimage @warning.png -Gblue+t -Dx0.5c/0.5c+jBL+w6c -O >> $ps


### PR DESCRIPTION
Like grdimage, the psimage option **-G** started with a letter **b**, **f**, or **t** possibly followed by a color name, making parsing tricky.  Now, these letters are part of modifiers and the color name or specification follows **-G** immediately, unless not given at all for transparency.  Backwards compatible up to and including GMT 5.  Updated man pages and fixed formatting errors in them as well.
