### PR TITLE
Replace literal constants with enums to improve code readability

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -2563,15 +2563,15 @@ GMT_LOCAL bool plot_custum_failed_bool_test (struct GMT_CTRL *GMT, struct GMT_CU
 
 	for (k = 0; k < 3; k++) {	/* Load up the left and 1-2 right operands */
 		switch (s->var[k]) {
-			case -3:	/* Symbol size */
+			case GMT_VAR_SIZE:	/* Symbol size */
 				arg[k] = size[0];	break;
-			case -2:	/* User y-coordinate */
+			case GMT_VAR_IS_Y:	/* User y-coordinate */
 				arg[k] = GMT->current.io.curr_rec[GMT_Y];	break;
-			case -1:	/* User x-coordinate */
+			case GMT_VAR_IS_X:	/* User x-coordinate */
 				arg[k] = GMT->current.io.curr_rec[GMT_X];	break;
-			case 0:		/* A constant */
+			case GMT_CONST_VAR:	/* A numeric constant */
 				arg[k] = s->const_val[k];	break;
-			default:	/* One of the variables 1-* */
+			default:		/* One of the variables 1-n */
 				arg[k] = size[s->var[k]];	break;
 		}
 	}

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4730,11 +4730,11 @@ GMT_LOCAL int support_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name, s
 				if (arg[k][0] == '$') {	/* Left or right hand side value is a variable */
 					s->is_var[k] = true;
 					if (arg[k][1] == 'x' || arg[k][1] == 'X')	/* Test on x or longitude */
-						s->var[k] = -1;
+						s->var[k] = GMT_VAR_IS_X;
 					else if (arg[k][1] == 'y' || arg[k][1] == 'Y')	/* Test on y or latitude */
-						s->var[k] = -2;
+						s->var[k] = GMT_VAR_IS_Y;
 					else if (arg[k][1] == 's' || arg[k][1] == 'S')	/* Test on symbol size */
-						s->var[k] = -3;
+						s->var[k] = GMT_VAR_SIZE;
 					else
 						s->var[k] = atoi (&arg[k][1]);	/* Get the variable number $<varno> */
 					s->const_val[k] = 0.0;
@@ -4742,7 +4742,7 @@ GMT_LOCAL int support_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name, s
 				else {
 					size_t len = strlen (arg[k]) - 1;
 					s->is_var[k] = false;
-					s->var[k] = 0;
+					s->var[k] = GMT_CONST_VAR;
 					s->const_val[k] = (strchr (GMT_DIM_UNITS, arg[k][len])) ? gmt_M_to_inch (GMT, arg[k]) : atof (arg[k]);	/* A constant, posibly a length unit */
 				}
 			}

--- a/src/gmt_symbol.h
+++ b/src/gmt_symbol.h
@@ -65,11 +65,17 @@ struct GMT_REFPOINT {	/* Used to hold items relevant for a reference point */
 #define CUSTOM_SYMBOL_MAXVAR	3	/* So we can check in the code if we exceed this */
 
 enum gmt_enum_custsymb {
-	GMT_BEGIN_SINGLE_IF	= 1,	/* We have a single, 1-liner if condition, with no end if */
-	GMT_BEGIN_BLOCK_IF	= 2,	/* Starting a new if branch */
-	GMT_END_IF		= 4,	/* Ending an if branch */
-	GMT_END_IF_ELSE		= 6,	/* Ending an if-branch and start the else branch */
-	GMT_BEGIN_ELSEIF	= 8	/* Ending the if-branch and start another if branch */
+	GMT_CONST_STRING	= -5,	/* We have a constant string in a conditional test */
+	GMT_VAR_STRING		= -4,	/* We have a variable string (the trailing text) in a conditional test */
+	GMT_VAR_SIZE		= -3,	/* We have the symbol size $s in a conditional test */
+	GMT_VAR_IS_Y		= -2,	/* We have y or latitude in a conditional test */
+	GMT_VAR_IS_X		= -1,	/* We have x or longitude in a conditional test */
+	GMT_CONST_VAR		=  0,	/* We have a constant factor in a conditional test */
+	GMT_BEGIN_SINGLE_IF	=  1,	/* We have a single, 1-liner if condition, with no end if */
+	GMT_BEGIN_BLOCK_IF	=  2,	/* Starting a new if branch */
+	GMT_END_IF		=  4,	/* Ending an if branch */
+	GMT_END_IF_ELSE		=  6,	/* Ending an if-branch and start the else branch */
+	GMT_BEGIN_ELSEIF	=  8	/* Ending the if-branch and start another if branch */
 };
 
 struct GMT_CUSTOM_SYMBOL_ITEM {


### PR DESCRIPTION
Before adding conditional tests involving strings in the custom symbol machinery (#316) I want to improve the readability of the code by replacing cases like "-3" with **GMT_VAR_SIZE** so it is easier to follow the logic.
