### PR TITLE
Improve quality of GeoPDF referencing for landscape.

### DIFF
--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -1979,7 +1979,7 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 
 		/* Do the math on the BoundingBox and translation coordinates */
 
-		if (Ctrl->P.active && landscape)
+		if ((Ctrl->P.active && landscape) || (landscape && Ctrl->A.crop))
 			xt = -x1, yt = -y0, w = y1-y0, h = x1-x0, r = -90;
 		else
 			xt = -x0, yt = -y0, w = x1-x0, h = y1-y0, r = 0;
@@ -2237,6 +2237,10 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 							v0 = gmtBB_y0 + yt_bak;
 							x1 = h0 / w;	x2 = (h0 + gmtBB_width) / w;
 							y1 = v0 / h;	y2 = (v0 + gmtBB_height) / h;
+							if (landscape_orig) {		/* Uggly hack but so far have no better solution */
+								x2 = gmtBB_width / w;		x1 = 1 - x2;	
+								y2 = gmtBB_height / h;		y1 = 1 - y2;	
+							}
 							fprintf (fpo, "\t\t\t/LPTS[%f %f %f %f %f %f %f %f]\n", x1,y1, x1,y2, x2,y2, x2,y1);
 						}
 						fprintf (fpo, "\t\t\t/GCS <<\n");


### PR DESCRIPTION
This addresses the issue brought by @KristofKoch in the forum topic [7992 ](https://gmt.soest.hawaii.edu/boards/1/topics/7992).
It improves the referencing for landscpae files, but still no so good as the Portrait one. Specially when not using **--MAP_FRAME_TYPE=inside**. And I don't understand the why. The landscape case is much more confuse as the x & y axis are swapped and I get lost with offsets.

This PR also changes one aspect of the _psconvert_ previous behavior. Before, landscape files were always left unrotated. Now, when **-A** (cropping) a landscape file, the image is converted to Portrait