### PR TITLE
Lay groundwork for doing text comparisons in custom symbols

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -2554,11 +2554,59 @@ enum plot_operand {
 	RIGHT_OPERAND2 = 2
 };
 
-GMT_LOCAL bool plot_custum_failed_bool_test (struct GMT_CTRL *GMT, struct GMT_CUSTOM_SYMBOL_ITEM *s, double size[]) {
+GMT_LOCAL bool plot_custum_failed_bool_test_string (struct GMT_CTRL *GMT, struct GMT_CUSTOM_SYMBOL_ITEM *s, double size[], char *text) {
+	unsigned int k;
+	bool result;
+	char *arg[2];
+	gmt_M_unused (size);	/* Numerical values not used here */
+	for (k = 0; k < 2; k++) {	/* Load up the left and right operands */
+		switch (s->var[k]) {
+			case GMT_VAR_STRING:	/* training text comparison */
+				arg[k] = text;		break;
+			case GMT_CONST_STRING:	/* Constant text comparison */
+				arg[k] = s->string;	break;
+			default:	/* Should not get here */
+				GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unrecognized text variable type (%d) passed to plot_custum_failed_bool_test_string\n", s->var[k]);
+				return true;		break;
+		}
+	}
+	switch (s->operator) {
+		case '<':	/* < */
+			result = (strcmp (arg[LEFT_OPERAND], arg[RIGHT_OPERAND1]) < 0);
+			break;
+		case 'L':	/* <= */
+			result = (strcmp (arg[LEFT_OPERAND], arg[RIGHT_OPERAND1]) <= 0);
+			break;
+		case '=':	/* == */
+			result = (strcmp (arg[LEFT_OPERAND], arg[RIGHT_OPERAND1]) == 0);
+			break;
+		case 'G':	/* >= */
+			result = (strcmp (arg[LEFT_OPERAND], arg[RIGHT_OPERAND1]) >= 0);
+			break;
+		case '>':	/* > */
+			result = (strcmp (arg[LEFT_OPERAND], arg[RIGHT_OPERAND1]) > 0);
+			break;
+		default:
+			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unrecognized symbol macro text operator (%d = '%c') passed to gmt_draw_custom_symbol\n", s->operator, (char)s->operator);
+			GMT_exit (GMT, GMT_PARSE_ERROR); return false;
+			break;
+	}
+	if (s->negate) result = !result;	/* Negate the test since we used a ! operator , e.g., != */
+	return (!result);			/* Return the opposite of the test result */
+}
+
+GMT_LOCAL bool plot_custum_failed_bool_test (struct GMT_CTRL *GMT, struct GMT_CUSTOM_SYMBOL_ITEM *s, double size[], char *text) {
 	unsigned int k;
 	bool result;
 	double arg[3];
 
+	/* Determine if we have text comparisions to deal with, if so, call the string version of this function */
+	
+	for (k = 0; k < 2; k++)
+		if (s->var[k] == GMT_VAR_STRING) return (plot_custum_failed_bool_test_string (GMT, s, size, text));
+	
+	/* Here we have numerical comparisons only */
+	
 	/* Perform the boolean comparison and return false if test is true */
 
 	for (k = 0; k < 3; k++) {	/* Load up the left and 1-2 right operands */
@@ -2610,7 +2658,7 @@ GMT_LOCAL bool plot_custum_failed_bool_test (struct GMT_CTRL *GMT, struct GMT_CU
 			result = gmt_M_is_dnan (arg[LEFT_OPERAND]);
 			break;
 		default:
-			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unrecognized symbol macro operator (%d = '%c') passed to gmt_draw_custom_symbol\n", s->operator, (char)s->operator);
+			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unrecognized symbol macro numerical operator (%d = '%c') passed to gmt_draw_custom_symbol\n", s->operator, (char)s->operator);
 			GMT_exit (GMT, GMT_PARSE_ERROR); return false;
 			break;
 
@@ -5306,7 +5354,7 @@ GMT_LOCAL void get_the_fill (struct GMT_FILL *f, struct GMT_CUSTOM_SYMBOL_ITEM *
 	if (f->rgb[0] >= 0.0 && s->var_pen < 0 && (abs(s->var_pen) & GMT_USE_PEN_RGB) && cp) gmt_M_rgb_copy (f->rgb, cp->rgb);
 }
 
-int gmt_draw_custom_symbol (struct GMT_CTRL *GMT, double x0, double y0, double size[], struct GMT_CUSTOM_SYMBOL *symbol, struct GMT_PEN *pen, struct GMT_FILL *fill, unsigned int outline) {
+int gmt_draw_custom_symbol (struct GMT_CTRL *GMT, double x0, double y0, double size[], char *tr_text, struct GMT_CUSTOM_SYMBOL *symbol, struct GMT_PEN *pen, struct GMT_FILL *fill, unsigned int outline) {
 	int action, ifs;
 	unsigned int na, i, id = 0, level;
 	bool flush = false, this_outline = false, skip[GMT_N_COND_LEVELS+1], done[GMT_N_COND_LEVELS+1];
@@ -5387,7 +5435,7 @@ int gmt_draw_custom_symbol (struct GMT_CTRL *GMT, double x0, double y0, double s
 			 * a series if if,elseif,else at the same level then we consult the done[level] array.  This is set to true if we pass a test and actually
 			 * draw something and once that is done none of the other tests at the same level can pass. */
 			if (s->conditional == GMT_BEGIN_BLOCK_IF) {	/* Beginning of a new if branch. If we are inside an earlier branch whose test was false then all inside shall be false */
-				skip[level+1] = (level > 0 && skip[level]) ? true : plot_custum_failed_bool_test (GMT, s, size), level++;
+				skip[level+1] = (level > 0 && skip[level]) ? true : plot_custum_failed_bool_test (GMT, s, size, tr_text), level++;
 				if (level == GMT_N_COND_LEVELS) {
 					GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Symbol macro (%s) logical nesting too deep [> %d]\n", symbol->name, GMT_N_COND_LEVELS);
 					GMT_exit (GMT, GMT_DIM_TOO_LARGE); return GMT_DIM_TOO_LARGE;
@@ -5399,7 +5447,7 @@ int gmt_draw_custom_symbol (struct GMT_CTRL *GMT, double x0, double y0, double s
 			else if (s->conditional == GMT_END_IF_ELSE)	/* else branch */
 				skip[level] = (!done[level] && skip[level] && !skip[level-1]) ? false : true;
 			else if (s->conditional == GMT_BEGIN_ELSEIF)	/* Skip if prior if/elseif was true, otherwise evaluate test at this level */
-				skip[level] = (!done[level] && skip[level] && !skip[level-1]) ? plot_custum_failed_bool_test (GMT, s, size) : true;
+				skip[level] = (!done[level] && skip[level] && !skip[level-1]) ? plot_custum_failed_bool_test (GMT, s, size, tr_text) : true;
 			s = s->next;
 			continue;
 		}
@@ -5408,7 +5456,7 @@ int gmt_draw_custom_symbol (struct GMT_CTRL *GMT, double x0, double y0, double s
 			continue;
 		}
 		/* Finally, check for 1-line if tests */
-		if (s->conditional == GMT_BEGIN_SINGLE_IF && plot_custum_failed_bool_test (GMT, s, size)) {	/* Done here, move to next item */
+		if (s->conditional == GMT_BEGIN_SINGLE_IF && plot_custum_failed_bool_test (GMT, s, size, tr_text)) {	/* Done here, move to next item */
 			s = s->next;
 			continue;
 		}

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -208,7 +208,7 @@ EXTERN_MSC void gmt_setpen (struct GMT_CTRL *GMT, struct GMT_PEN *pen);
 EXTERN_MSC void gmt_setfill (struct GMT_CTRL *GMT, struct GMT_FILL *fill, int outline);
 EXTERN_MSC void gmt_vertical_axis (struct GMT_CTRL *GMT, unsigned int mode);
 EXTERN_MSC void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, double val0, double val1, struct GMT_PLOT_AXIS *A, bool below, unsigned int side);
-EXTERN_MSC int gmt_draw_custom_symbol (struct GMT_CTRL *GMT, double x0, double y0, double size[], struct GMT_CUSTOM_SYMBOL *symbol, struct GMT_PEN *pen, struct GMT_FILL *fill, unsigned int outline);
+EXTERN_MSC int gmt_draw_custom_symbol (struct GMT_CTRL *GMT, double x0, double y0, double size[], char *text, struct GMT_CUSTOM_SYMBOL *symbol, struct GMT_PEN *pen, struct GMT_FILL *fill, unsigned int outline);
 EXTERN_MSC void gmt_contlabel_plot (struct GMT_CTRL *GMT, struct GMT_CONTOUR *G);
 EXTERN_MSC void gmt_plane_perspective (struct GMT_CTRL *GMT, int plane, double level);
 EXTERN_MSC void gmt_plotcanvas (struct GMT_CTRL *GMT);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4729,21 +4729,30 @@ GMT_LOCAL int support_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name, s
 			for (k = 0; k < nv + 1; k++) {
 				if (arg[k][0] == '$') {	/* Left or right hand side value is a variable */
 					s->is_var[k] = true;
-					if (arg[k][1] == 'x' || arg[k][1] == 'X')	/* Test on x or longitude */
+					if (arg[k][1] == 'x')	/* Test on x or longitude */
 						s->var[k] = GMT_VAR_IS_X;
-					else if (arg[k][1] == 'y' || arg[k][1] == 'Y')	/* Test on y or latitude */
+					else if (arg[k][1] == 'y')	/* Test on y or latitude */
 						s->var[k] = GMT_VAR_IS_Y;
-					else if (arg[k][1] == 's' || arg[k][1] == 'S')	/* Test on symbol size */
+					else if (arg[k][1] == 's')	/* Test on symbol size */
 						s->var[k] = GMT_VAR_SIZE;
+					else if (arg[k][1] == 't')	/* Test on trailing text */
+						s->var[k] = GMT_VAR_STRING;
 					else
 						s->var[k] = atoi (&arg[k][1]);	/* Get the variable number $<varno> */
 					s->const_val[k] = 0.0;
 				}
-				else {
+				else {	/* A constant */
 					size_t len = strlen (arg[k]) - 1;
 					s->is_var[k] = false;
-					s->var[k] = GMT_CONST_VAR;
-					s->const_val[k] = (strchr (GMT_DIM_UNITS, arg[k][len])) ? gmt_M_to_inch (GMT, arg[k]) : atof (arg[k]);	/* A constant, posibly a length unit */
+					if (gmt_not_numeric (GMT, arg[k])) {	/* Got a text item for string comparison */
+						s->var[k] = GMT_CONST_STRING;
+						s->string = gmt_M_memory (GMT, NULL, strlen (arg[k]) + 1, char);
+						strcpy (s->string, arg[k]);
+					}
+					else {	/* Numerical value */
+						s->var[k] = GMT_CONST_VAR;
+						s->const_val[k] = (strchr (GMT_DIM_UNITS, arg[k][len])) ? gmt_M_to_inch (GMT, arg[k]) : atof (arg[k]);	/* A constant, possibly a length unit */
+					}
 				}
 			}
 			k = 0;

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1531,7 +1531,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 						if (S.custom->type[j] == GMT_IS_ANGLE && dim[j+1] < 0.0) dim[j+1] += 360.0;
 					}
 					if (!S.custom->start) S.custom->start = (get_rgb) ? 3 : 2;
-					gmt_draw_custom_symbol (GMT, xpos[item], plot_y, dim, S.custom, &current_pen, &current_fill, outline_active);
+					gmt_draw_custom_symbol (GMT, xpos[item], plot_y, dim, In->text, S.custom, &current_pen, &current_fill, outline_active);
 					break;
 			}
 			}

--- a/src/psxy_new.c
+++ b/src/psxy_new.c
@@ -1877,7 +1877,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 									}
 								}
 								if (!S.custom->start) S.custom->start = (get_rgb) ? 3 : 2;
-								gmt_draw_custom_symbol (GMT, xpos[item], plot_y, dim, S.custom, &current_pen, &current_fill, outline_active);
+								gmt_draw_custom_symbol (GMT, xpos[item], plot_y, dim, In->text, S.custom, &current_pen, &current_fill, outline_active);
 								break;
 						} /* End of switch */
 					} /* End of item loop */

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1149,6 +1149,7 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 				case GMT_SYMBOL_CUSTOM:
 					data[n].custom = gmt_M_memory (GMT, NULL, 1, struct GMT_CUSTOM_SYMBOL);
 					gmt_M_memcpy (data[n].custom, S.custom, 1, struct GMT_CUSTOM_SYMBOL);
+					if (In->text) data[n].string = strdup (In->text);
 					break;
 			}
 			if (S.user_unit[GMT_X]) data[n].flag |= 4;
@@ -1380,8 +1381,9 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 							if (S.custom->type[j] == GMT_IS_ANGLE && dim[j+1] < 0.0) dim[j+1] += 360.0;
 						}
 						if (!S.custom->start) S.custom->start = (get_rgb) ? 4 : 3;
-						gmt_draw_custom_symbol (GMT, xpos[item], data[i].y, dim, data[i].custom, &data[i].p, &data[i].f, data[i].outline);
+						gmt_draw_custom_symbol (GMT, xpos[item], data[i].y, dim, data[i].string, data[i].custom, &data[i].p, &data[i].f, data[i].outline);
 						gmt_M_free (GMT, data[i].custom);
+						if (data[i].string) gmt_M_str_free (data[i].string);
 						break;
 				}
 			}

--- a/test/psxy/macros.sh
+++ b/test/psxy/macros.sh
@@ -16,7 +16,7 @@ N: 2
 if \$1 <= 70 then T -Gred
 if \$1 [> 70:300 then {
 	T -Ggreen
-	0 0 1 s -W1,cyan -G-
+	0 0 1 s -W1p,cyan -G-
 }
 if \$1 >= 300 then T -Gblue
 # Then draw a circle width diameter based on magnitude ranges


### PR DESCRIPTION
This follows up on #316.  Does not break anything but also not tested for the new feature yet.
