### PR TITLE
Allow Travis script to have existing build directory

### DIFF
--- a/ci/build-gmt.sh
+++ b/ci/build-gmt.sh
@@ -28,7 +28,7 @@ echo "Using the following cmake configuration:"
 cat cmake/ConfigUser.cmake
 echo ""
 
-mkdir build && cd build
+mkdir -p build && cd build
 
 cmake ..
 


### PR DESCRIPTION
Travis allows caching of certain directories. For GMT/Python, we're
using the build script from this repo to build the latest GMT master
branch and test against it. But we cache the `build` directory to
speedup the build process (GenericMappingTools/gmt-python#261).


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
