### PR TITLE
Add config for stale Github bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,16 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 30
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - discussion
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had activity in
+  the last 30 days. It will be closed if no further activity occurs within 7 days. Thank
+  you for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,6 +5,7 @@ daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - discussion
+  - longterm
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
The bot closes issues automatically if there is no activity.
Configuration for the bot is in `.github/stale.yml`.
Issues marked with `discussion` or `longterm` are left alone.