### PR TITLE
Start a contributing guide with basic information

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -4,9 +4,13 @@
 newIssueWelcomeComment: |
   👋 Thanks for opening your first issue here! Please make sure you filled out the template with as much detail as possible. We appreciate that you took the time to contribute!
 
+  Please make sure you read our [Contributing Guide](https://github.com/GenericMappingTools/gmt/blob/master/CONTRIBUTING.md) and abide by our [Code of Conduct](https://github.com/GenericMappingTools/gmt/blob/master/CODE_OF_CONDUCT.md).
+
 # Comment to be posted to on PRs from first time contributors in your repository
 newPRWelcomeComment: |
   💖 Thanks for opening this pull request! 💖
+
+  Please make sure you read our [Contributing Guide](https://github.com/GenericMappingTools/gmt/blob/master/CONTRIBUTING.md) and abide by our [Code of Conduct](https://github.com/GenericMappingTools/gmt/blob/master/CODE_OF_CONDUCT.md).
 
   A few things to keep in mind:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,143 @@
+# Contributing Guidelines
+
+**First of all, thank you for considering contributing to the project.**
+
+This is a community-driven project, so it's people like you that make it useful and
+successful.
+These are some of the many ways to contribute:
+
+* :bug: Submitting bug reports and feature requests
+* :memo: Writing tutorials or examples
+* :mag: Fixing typos and improving to the documentation
+* :bulb: Writing code for everyone to use
+
+If you get stuck at any point you can create an issue on GitHub (look for the *Issues*
+tab in the repository) or contact us at one of the other channels mentioned below.
+
+For more information on contributing to open source projects,
+[GitHub's own guide](https://guides.github.com/activities/contributing-to-open-source/)
+is a great starting point if you are new to version control.
+
+
+## Ground Rules
+
+The goal is to maintain a diverse community that's pleasant for everyone.
+**Please be considerate and respectful of others**.
+Everyone must abide by our [Code of Conduct](CODE_OF_CONDUCT.md) and we encourage all to
+read it carefully.
+
+
+## Contents
+
+* [What Can I Do?](#what-can-i-do)
+* [How Can I Talk to You?](#how-can-i-talk-to-you)
+* [Reporting a Bug](#reporting-a-bug)
+* [Editing the Documentation](#editing-the-documentation)
+* [Contributing Code](#contributing-code)
+  - [General guidelines](#general-guidelines)
+  - [Code Review](#code-review)
+
+
+## What Can I Do?
+
+* Tackle any [issue](https://github.com/GenericMappingTools/gmt/issues) that you wish!
+  Please leave a comment on the issue indicating that you want to work on it.
+  Some issues are labeled as
+  ["good first issues"](https://github.com/GenericMappingTools/gmt/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+  to indicate that they are beginner friendly, meaning that they don't require extensive
+  knowledge of the project.
+* Report a bug you found through the [Github issues](https://github.com/GenericMappingTools/gmt/issues).
+* Make a tutorial or example of how to do something.
+* Provide feedback about how we can improve the project or about your particular use
+  case.
+* Contribute code you already have. It doesn't need to be perfect! We will help you
+  clean things up, test it, etc.
+
+
+## How Can I Talk to You?
+
+Discussion often happens in the issues and pull requests.
+We don't have a good solution for a user forum yet but we're working on it.
+
+
+## Reporting a Bug
+
+Find the [Issues](https://github.com/GenericMappingTools/gmt/issues) tab on the top of
+the Github repository and click *New Issue*.
+You'll be prompted to choose between different types of issue, like bug reports and
+feature requests.
+Choose the one that best matches your need.
+The Issue will be populated with one of our templates.
+**Please try to fillout the template with as much detail as you can**.
+Remember: the more information we have, the easier it will be for us to solve your
+problem.
+
+
+## Editing the Documentation
+
+If you're browsing the documentation and notice a typo or something that could be
+improved, please consider letting us know by [creating an issue](#reporting-a-bug) or
+submitting a fix (even better :star2:).
+
+
+## Contributing Code
+
+**Is this your first contribution?**
+Please take a look at these resources to learn about git and pull requests (don't
+hesitate to [ask questions](#how-can-i-talk-to-you)):
+
+* [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/).
+* Aaron Meurer's [tutorial on the git workflow](http://www.asmeurer.com/git-workflow/)
+* [How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
+
+### General guidelines
+
+We follow the [git pull request workflow](http://www.asmeurer.com/git-workflow/) to
+make changes to our codebase.
+Every change made goes through a pull request, even our own, so that our
+[continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) services
+have a change to check that the code is up to standards and passes all our tests.
+This way, the *master* branch is always stable.
+
+General guidelines for pull requests (PRs):
+
+* **Open an issue first** describing what you want to do. If there is already an issue
+  that matches your PR, leave a comment there instead to let us know what you plan to
+  do.
+* Each pull request should consist of a **small** and logical collection of changes.
+* Larger changes should be broken down into smaller components and integrated
+  separately.
+* Bug fixes should be submitted in separate PRs.
+* Describe what your PR changes and *why* this is a good thing. Be as specific as you
+  can. The PR description is how we keep track of the changes made to the project over
+  time.
+* Do not commit changes to files that are irrelevant to your feature or bugfix (eg:
+  `.gitignore`, IDE project files, etc).
+* Write descriptive commit messages. Chris Beams has written a
+  [guide](https://chris.beams.io/posts/git-commit/) on how to write good commit
+  messages.
+* Be willing to accept criticism and work on improving your code; we don't want to break
+  other users' code, so care must be taken not to introduce bugs.
+* Be aware that the pull request review process is not immediate, and is generally
+  proportional to the size of the pull request.
+
+### Code Review
+
+After you've submitted a pull request, you should expect to hear at least a comment
+within a couple of days.
+We may suggest some changes or improvements or alternatives.
+
+Some things that will increase the chance that your pull request is accepted quickly:
+
+* Write a good and detailed description of what the PR does.
+* Write tests for the code you wrote/modified.
+* Readable code is better than clever code (even with comments).
+* Write documentation for your code and leave comments explaining the *reason* behind
+  non-obvious things.
+* Include an example of new features in the gallery or tutorials.
+
+Pull requests will automatically have tests run by TravisCI.
+Github will show the status of these checks on the pull request.
+Try to get them all passing (green).
+If you have any trouble, leave a comment in the PR or
+[get in touch](#how-can-i-talk-to-you).


### PR DESCRIPTION
The guide is written in Markdown in the `CONTRIBUTING.md` file in the
base directory. This is standard across Github and it will automatically
detect this file and include links to it in issues and pull requests.
The guide has basic info about creating an issue, making a PR, and
getting in contact. It's based on the one I use for my python projects:
https://github.com/fatiando/contributing/blob/master/CONTRIBUTING.md

There is no GMT specific information, which has to be added later, but
it's a start.

Also included links to the guide in the comments left by the welcome bot.