### PR TITLE
Add all modules to invalidate_modules script

### DIFF
--- a/test/invalidate_modules.sh
+++ b/test/invalidate_modules.sh
@@ -10,23 +10,34 @@
 # executable from the build dir.
 #
 
-gmt_modules="backtracker blockmean blockmedian blockmode dimfilter filter1d \
-fitcircle gmt2kml gmtconvert gmtdefaults gmtflexure gmtget gmtgravmag3d gmtinfo gmtmath \
-gmtpmodeler gmtregress gmtselect gmtset gmtsimplify gmtspatial gmtstitch \
-gmtvector gmtwhich gpsgridder gravfft \
-grd2cpt grd2xyz grdblend grdclip grdcontour grdcut grdedit grdfft \
-grdflexure grdfilter grdgradient grdgravmag3d grdhisteq grdimage grdinfo grdlandmask \
-grdmask grdmath grdpaste grdpmodeler grdproject grdredpol grdconvert \
-grdrotater grdsample grdseamount grdspotter grdtrack grdtrend grdvector \
-grdview grdvolume greenspline gshhg hotspotter img2grd kml2gmt makecpt \
-mapproject mgd77convert mgd77info mgd77list mgd77magref mgd77manage mgd77path \
-mgd77sniffer mgd77track minmax nearneighbor originater project psconvert \
-psbasemap psclip pscoast pscontour pscoupe pshistogram psimage pslegend \
-psmask psmeca pspolar psrose psscale pssegy pssegyz pssolar psternary pstext psvelo pswiggle \
-psxy psxyz rotconverter rotsmoother sample1d segy2grd spectrum1d sph2grd sphdistance \
-sphinterpolate sphtriangulate splitxyz surface trend1d trend2d triangulate \
-x2sys_binlist x2sys_cross x2sys_datalist x2sys_get x2sys_init x2sys_list \
-x2sys_merge x2sys_put x2sys_report x2sys_solve xyz2grd"
+gmt_modules="blockmean blockmedian blockmode filter1d fitcircle 
+	gmt2kml gmtconnect gmtconvert gmtdefaults gmtget 
+	gmtinfo gmtlogo gmtmath gmtregress gmtselect 
+	gmtset gmtsimplify gmtspatial gmtvector gmtwhich 
+	grd2cpt grd2kml grd2xyz grdblend grdclip 
+	grdcontour grdconvert grdcut grdedit grdfft 
+	grdfill grdfilter grdgradient grdhisteq grdimage 
+	grdinfo grdlandmask grdmask grdmath grdpaste 
+	grdproject grdsample grdtrack grdtrend grdvector 
+	grdview grdvolume greenspline inset kml2gmt 
+	makecpt mapproject movie nearneighbor project 
+	psbasemap psclip pscoast pscontour psconvert 
+	pshistogram psimage pslegend psmask psrose 
+	psscale pssolar psternary pstext pswiggle 
+	psxyz psxy revert sample1d spectrum1d 
+	sph2grd sphdistance sphinterpolate sphtriangulate splitxyz 
+	subplot surface trend1d 
+	trend2d triangulate xyz2grd gshhg img2grd 
+	pscoupe psmeca pspolar pssac psvelo 
+	mgd77convert mgd77header mgd77info mgd77list mgd77magref 
+	mgd77manage mgd77path mgd77sniffer mgd77track dimfilter 
+	grdppa earthtide gmtflexure gmtgravmag3d gpsgridder 
+	gravfft grdflexure grdgravmag3d grdredpol grdseamount 
+	talwani2d talwani3d pssegyz pssegy segy2grd 
+	backtracker gmtpmodeler grdpmodeler grdrotater grdspotter 
+	hotspotter originater polespotter rotconverter rotsmoother 
+	x2sys_binlist x2sys_cross x2sys_datalist x2sys_get x2sys_init 
+	x2sys_list x2sys_merge x2sys_put x2sys_report x2sys_solve"
 
 for module in ${gmt_modules}; do
   eval "function ${module} () { false; }"


### PR DESCRIPTION
The invalidate_modules.sh script used to detect wrong use of gmt modules in scripts (i.e., without leading gmt call) had fallen behind and did not list several modules.
