### PR TITLE
Use GMT_SESSION_NAME instead of GMT_PPID for modern mode

### DIFF
--- a/doc_classic/examples/animate.in
+++ b/doc_classic/examples/animate.in
@@ -87,8 +87,8 @@ if [ "X$script_mode" = "XM" ]; then
 	if [ $classic -eq 0 ]; then
 		echo "Modernizing $script to $local_script before testing"
 		gmtmodernize "$script" > ./${local_script}
-		export GMT_PPID=$$
-		echo "Set GMT_PPID = $GMT_PPID"
+		export GMT_SESSION_NAME=$$
+		echo "Set GMT_SESSION_NAME = $GMT_SESSION_NAME"
 		. "${local_script}" animate
 	else
 		echo "Cannot modernize classic GMT script ${script}. Run in classic mode" >&2

--- a/doc_classic/examples/gmtest.in
+++ b/doc_classic/examples/gmtest.in
@@ -192,8 +192,8 @@ export GS_FONTPATH="@CMAKE_CURRENT_SOURCE_DIR@/ex31/fonts"
 gmt set -Du FORMAT_TIME_STAMP "Version 6"
 # Modern mode needs a stable PPID but ctest messes that up when pipes are used
 if [ "X$script_mode" = "XM" ]; then
-	export GMT_PPID=\$\$
-	echo "Set GMT_PPID = \$GMT_PPID"
+	export GMT_SESSION_NAME=\$\$
+	echo "Set GMT_SESSION_NAME = \$GMT_SESSION_NAME"
 fi
 # Now run the script
 . "${local_script}"

--- a/doc_classic/rst/source/GMT_Docs.rst
+++ b/doc_classic/rst/source/GMT_Docs.rst
@@ -494,6 +494,12 @@ We will discuss these two commands later.  Finally, there are some new features 
 are only accessible under modern mode, such as subplots, new ways to specify the map domain and to
 get multiple output formats from the same plot.
 
+The modern mode relies on know what session is being run. If your script is explicitly or
+inadvertently creating sub-shells under UNIX then the script could fail.  If this is the
+case then you will need to add
+	export GMT_SESSION_NAME=<some unique string>
+before gmt begin starts the script.
+
 
 GMT Overview and Quick Reference
 ================================

--- a/doc_classic/scripts/gmtest.in
+++ b/doc_classic/scripts/gmtest.in
@@ -183,8 +183,8 @@ gmt set -Du PS_CHAR_ENCODING ISOLatin1+
 ps="${script_name%.sh}.ps"
 # Modern mode needs a stable PPID but ctest messes that up when pipes are used
 if [ "X$script_mode" = "XM" ]; then
-	export GMT_PPID=\$\$
-	echo "Set GMT_PPID = \$GMT_PPID"
+	export GMT_SESSION_NAME=\$\$
+	echo "Set GMT_SESSION_NAME = \$GMT_SESSION_NAME"
 fi
 # Now run the script
 . "${local_script}"

--- a/doc_modern/examples/animate.in
+++ b/doc_modern/examples/animate.in
@@ -87,8 +87,8 @@ if [ "X$script_mode" = "XM" ]; then
 	if [ $classic -eq 0 ]; then
 		echo "Modernizing $script to $local_script before testing"
 		gmtmodernize "$script" > ./${local_script}
-		export GMT_PPID=$$
-		echo "Set GMT_PPID = $GMT_PPID"
+		export GMT_SESSION_NAME=$$
+		echo "Set GMT_SESSION_NAME = $GMT_SESSION_NAME"
 		. "${local_script}" animate
 	else
 		echo "Cannot modernize classic GMT script ${script}. Run in classic mode" >&2

--- a/doc_modern/examples/gmtest.in
+++ b/doc_modern/examples/gmtest.in
@@ -192,8 +192,8 @@ export GS_FONTPATH="@CMAKE_CURRENT_SOURCE_DIR@/ex31/fonts"
 gmt set -Du FORMAT_TIME_STAMP "Version 6"
 # Modern mode needs a stable PPID but ctest messes that up when pipes are used
 if [ "X$script_mode" = "XM" ]; then
-	export GMT_PPID=\$\$
-	echo "Set GMT_PPID = \$GMT_PPID"
+	export GMT_SESSION_NAME=\$\$
+	echo "Set GMT_SESSION_NAME = \$GMT_SESSION_NAME"
 fi
 # Now run the script
 . "${local_script}"

--- a/doc_modern/rst/source/GMT_Docs.rst
+++ b/doc_modern/rst/source/GMT_Docs.rst
@@ -494,6 +494,12 @@ We will discuss these two commands later.  Finally, there are some new features 
 are only accessible under modern mode, such as subplots, new ways to specify the map domain, map insets, and to
 get multiple output formats from the same plot.
 
+The modern mode relies on know what session is being run. If your script is explicitly or
+inadvertently creating sub-shells under UNIX then the script could fail.  If this is the
+case then you will need to add
+	export GMT_SESSION_NAME=<some unique string>
+before gmt begin starts the script.
+
 
 GMT Overview and Quick Reference
 ================================

--- a/doc_modern/scripts/gmtest.in
+++ b/doc_modern/scripts/gmtest.in
@@ -183,8 +183,8 @@ gmt set -Du PS_CHAR_ENCODING ISOLatin1+
 ps="${script_name%.sh}.ps"
 # Modern mode needs a stable PPID but ctest messes that up when pipes are used
 #if [ "X$script_mode" = "XM" ]; then
-	export GMT_PPID=\$\$
-	echo "Set GMT_PPID = \$GMT_PPID"
+	export GMT_SESSION_NAME=\$\$
+	echo "Set GMT_SESSION_NAME = \$GMT_SESSION_NAME"
 #fi
 # Now run the script
 . "${local_script}"

--- a/src/clear.c
+++ b/src/clear.c
@@ -120,7 +120,7 @@ GMT_LOCAL int clear_sessions (struct GMTAPI_CTRL *API) {
 		perror (API->session_dir);
 		return GMT_RUNTIME_ERROR;
 	}
-	if ((n_dirs = (unsigned int)gmtlib_glob_list (API->GMT, "gmt*", &dirlist))) {	/* Find the gmt.<PPID> directories */
+	if ((n_dirs = (unsigned int)gmtlib_glob_list (API->GMT, "gmt*", &dirlist))) {	/* Find the gmt.<session_name> directories */
 		for (k = 0; k < n_dirs; k++) {
 			if (gmt_remove_dir (API, dirlist[k], false))
 				GMT_Report (API, GMT_MSG_NORMAL, "Unable to remove directory %s [permissions?]\n", dirlist[k]);

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15175,7 +15175,7 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 	int err = 0, fig, error = GMT_NOERROR;
 	struct stat S;
 
-	sprintf (dir, "%s/gmt%d.%d", API->session_dir, GMT_MAJOR_VERSION, API->PPID);
+	sprintf (dir, "%s/gmt%d.%s", API->session_dir, GMT_MAJOR_VERSION, API->session_name);
 	API->gwf_dir = strdup (dir);
 	err = stat (API->gwf_dir, &S);	/* Stat the gwf_dir path (which may not exist) */
 
@@ -15216,7 +15216,7 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 			API->GMT->current.setting.run_mode = GMT_MODERN;	/* Enable modern mode */
 			API->GMT->current.setting.history_orig = API->GMT->current.setting.history;	/* Temporarily turn off history so nothing is copied into the workflow dir */
 			API->GMT->current.setting.history = GMT_HISTORY_OFF;	/* Turn off so that no history is copied into the workflow directory */
-			GMT_Report (API, GMT_MSG_DEBUG, "%s Workflow.  PPID = %d. Directory %s %s.\n", smode[mode], API->PPID, API->gwf_dir, fstatus[2]);
+			GMT_Report (API, GMT_MSG_DEBUG, "%s Workflow.  Session Name = %s. Directory %s %s.\n", smode[mode], API->session_name, API->gwf_dir, fstatus[2]);
 			break;
 		case GMT_USE_WORKFLOW:
 			/* We always get here except when gmt begin | end are called. */
@@ -15230,7 +15230,7 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 			sprintf (file, "%s/gmt.subplot.%d", API->gwf_dir, fig);
 			if (!access (file, R_OK))	/* subplot end was never called */
 				GMT_Report (API, GMT_MSG_NORMAL, "subplot was never completed - plot items in last panel may be missing\n");
-			GMT_Report (API, GMT_MSG_DEBUG, "%s Workflow.  PPID = %d. Directory %s %s.\n", smode[mode], API->PPID, API->gwf_dir, fstatus[3]);
+			GMT_Report (API, GMT_MSG_DEBUG, "%s Workflow.  Session Name = %s. Directory %s %s.\n", smode[mode], API->session_name, API->gwf_dir, fstatus[3]);
 			if ((error = process_figures (API)))
 				GMT_Report (API, GMT_MSG_NORMAL, "process_figures returned error %d\n", error);
 			GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Destroying the current workflow directory %s\n", API->gwf_dir);
@@ -15243,7 +15243,7 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 			break;
 	}
 	if (API->GMT->current.setting.run_mode == GMT_MODERN) {
-		GMT_Report (API, GMT_MSG_DEBUG, "GMT now running in %s mode [PPID = %d]\n", type[API->GMT->current.setting.run_mode], API->PPID);
+		GMT_Report (API, GMT_MSG_DEBUG, "GMT now running in %s mode [Session Name = %s]\n", type[API->GMT->current.setting.run_mode], API->session_name);
 		API->GMT->current.setting.use_modern_name = true;
 	}
 	return error;
@@ -15357,7 +15357,7 @@ void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int j
 	}
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Determined colorbar side = %c and axis = %c\n", side, axis);
 
-	sprintf (file, "%s/gmt%d.%d/gmt.frame", GMT->parent->session_dir, GMT_MAJOR_VERSION, GMT->parent->PPID);
+	sprintf (file, "%s/gmt%d.%s/gmt.frame", GMT->parent->session_dir, GMT_MAJOR_VERSION, GMT->parent->session_name);
 	if ((fp = fopen (file, "r")) == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "No file %s with frame information - no adjustments made\n", file);
 		return;

--- a/src/gmt_parse.c
+++ b/src/gmt_parse.c
@@ -272,7 +272,7 @@ GMT_LOCAL int parse_complete_options (struct GMT_CTRL *GMT, struct GMT_OPTION *o
 	if (GMT->current.setting.run_mode == GMT_MODERN && n_B && strncmp (GMT->init.module_name, "psscale", 7U)) {	/* Write gmt.frame file unless module is psscale, overwriting any previous file */
 		char file[PATH_MAX] = {""};
 		FILE *fp = NULL;
-		sprintf (file, "%s/gmt%d.%d/gmt.frame", GMT->parent->session_dir, GMT_MAJOR_VERSION, GMT->parent->PPID);
+		sprintf (file, "%s/gmt%d.%s/gmt.frame", GMT->parent->session_dir, GMT_MAJOR_VERSION, GMT->parent->session_name);
 		if ((fp = fopen (file, "w")) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Unable to create file %s\n", file);
 			return (-1);

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -280,33 +280,6 @@ struct GMT_CIRCLE {	/* Helper variables needed to draw great or small circle hea
 
 /* Local functions */
 
-#if 0
-/* This code has not been used. See gmt_api.c instead for api_get_ppid */
-GMT_LOCAL int gmt_get_ppid (struct GMT_CTRL *GMT) {
-	/* Return the parent process ID [i.e., shell for command line use or gmt app for API] */
-	int ppid = -1;
-	if (GMT->parent->external) return (getpid());	/* Return ID of the gmt application */
-	/* Here we are probably running from the command line and want the shell's PID */
-#ifdef _WIN32
-	int pid = GetCurrentProcessId ();
-	HANDLE h = CreateToolhelp32Snapshot (TH32CS_SNAPPROCESS, 0);
-	PROCESSENTRY32 pe = { 0 };
-	pe.dwSize = sizeof (PROCESSENTRY32);
-
-	if (Process32First(h, &pe)) {
-		do {
-			if (pe.th32ProcessID == pid)
-				ppid = pe.th32ParentProcessID;
-		} while (ppid == -1 && Process32Next(h, &pe));
-	}
-	CloseHandle (h);
-#else
-	ppid = getppid(); /* parent process id */
-#endif
-	return ppid;
-}
-#endif
-
 /*	GMT_LINEAR PROJECTION MAP BOUNDARY	*/
 
 GMT_LOCAL void plot_linear_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double w, double e, double s, double n) {

--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -152,6 +152,7 @@ struct GMTAPI_CTRL {
 	struct GMT_CTRL *GMT;			/* Key structure with low-level GMT internal parameters */
 	struct GMTAPI_DATA_OBJECT **object;	/* List of registered data objects */
 	char *session_tag;			/* Name tag for this session (or NULL) */
+	char *session_name;			/* Unique name for modern mode session (NULL for classic) */
 	char *tmp_dir;				/* System tmp_dir (NULL if not found) */
 	char *session_dir;			/* GMT Session dir (NULL if not running in modern mode) */
 	char *gwf_dir;				/* GMT WorkFlow dir (NULL if not running in modern mode) */

--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -146,7 +146,6 @@ struct GMTAPI_CTRL {
 	int error;				/* Error code from latest API call [GMT_OK] */
 	int last_error;				/* Error code from previous API call [GMT_OK] */
 	int shelf;				/* Place to pass hidden values within API */
-	int PPID;				/* The Process ID of the parent (e.g., shell) or the external caller */
 	unsigned int log_level;			/* 0 = stderr, 1 = just this module, 2 = set until unset */
 	unsigned int io_mode[2];		/* 1 if access as set, 0 if record-by-record */
 	struct GMT_CTRL *GMT;			/* Key structure with low-level GMT internal parameters */

--- a/src/movie.c
+++ b/src/movie.c
@@ -1064,11 +1064,11 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		}
 		set_script (fp, Ctrl->In.mode);				/* Write 1st line of a script */
 		set_comment (fp, Ctrl->In.mode, "Preflight script");
-		fprintf (fp, "%s", export[Ctrl->In.mode]);		/* Hardwire a PPID since subshells may mess things up */
-		if (Ctrl->In.mode == DOS_MODE)	/* Set PPID under Windows to 1 since we run this separately first */
-			fprintf (fp, "set GMT_PPID=1\n");
-		else	/* On UNIX we may use the calling terminal or script's PID as the PPID */
-			set_tvalue (fp, Ctrl->In.mode, "GMT_PPID", "$$");
+		fprintf (fp, "%s", export[Ctrl->In.mode]);		/* Hardwire a Session Name since subshells may mess things up */
+		if (Ctrl->In.mode == DOS_MODE)	/* Set GMT_SESSION_NAME under Windows to 1 since we run this separately first */
+			fprintf (fp, "set GMT_SESSION_NAME=1\n");
+		else	/* On UNIX we may use the calling terminal or script's PID as the GMT_SESSION_NAME */
+			set_tvalue (fp, Ctrl->In.mode, "GMT_SESSION_NAME", "$$");
 		fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 		while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->S[MOVIE_PREFLIGHT].fp)) {	/* Read the background script and copy to preflight script with some exceptions */
 			if ((is_classic && rec == 0) || strstr (line, "gmt begin")) {	/* Need to insert gmt figure after this line (or as first line) in case a background plot will be made */
@@ -1153,11 +1153,11 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		}
 		set_script (fp, Ctrl->In.mode);					/* Write 1st line of a script */
 		set_comment (fp, Ctrl->In.mode, "Postflight script");
-		fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Hardwire a PPID since subshells may mess things up */
-		if (Ctrl->In.mode == DOS_MODE)	/* Set PPID under Windows to 1 since we run this separately */
-			fprintf (fp, "set GMT_PPID=1\n");
-		else	/* On UNIX we may use the script's PID as PPID */
-			set_tvalue (fp, Ctrl->In.mode, "GMT_PPID", "$$");
+		fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Hardwire a SESSION_NAME since subshells may mess things up */
+		if (Ctrl->In.mode == DOS_MODE)	/* Set GMT_SESSION_NAME under Windows to 1 since we run this separately */
+			fprintf (fp, "set GMT_SESSION_NAME=1\n");
+		else	/* On UNIX we may use the script's PID as GMT_SESSION_NAME */
+			set_tvalue (fp, Ctrl->In.mode, "GMT_SESSION_NAME", "$$");
 		fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 		while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->S[MOVIE_POSTFLIGHT].fp)) {	/* Read the foreground script and copy to postflight script with some exceptions */
 			if (strstr (line, "gmt begin")) {	/* Need to insert gmt figure after this line */
@@ -1376,11 +1376,11 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		}
 		set_script (fp, Ctrl->In.mode);					/* Write 1st line of a script */
 		set_comment (fp, Ctrl->In.mode, "Master frame loop script");
-		fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Hardwire a PPID since subshells may mess things up */
-		if (Ctrl->In.mode == DOS_MODE)	/* Set PPID under Windows to be the frame number */
-			fprintf (fp, "set GMT_PPID=%c1\n", var_token[Ctrl->In.mode]);
-		else	/* On UNIX we use the script's PID as PPID */
-			set_tvalue (fp, Ctrl->In.mode, "GMT_PPID", "$$");
+		fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Hardwire a GMT_SESSION_NAME since subshells may mess things up */
+		if (Ctrl->In.mode == DOS_MODE)	/* Set GMT_SESSION_NAME under Windows to be the frame number */
+			fprintf (fp, "set GMT_SESSION_NAME=%c1\n", var_token[Ctrl->In.mode]);
+		else	/* On UNIX we use the script's PID as GMT_SESSION_NAME */
+			set_tvalue (fp, Ctrl->In.mode, "GMT_SESSION_NAME", "$$");
 		set_comment (fp, Ctrl->In.mode, "Include static and frame-specific parameters");
 		fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 		fprintf (fp, "%s movie_params_%c1.%s\n", load[Ctrl->In.mode], var_token[Ctrl->In.mode], extension[Ctrl->In.mode]);	/* Include the frame parameters */
@@ -1490,11 +1490,11 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	}
 	set_script (fp, Ctrl->In.mode);					/* Write 1st line of a script */
 	set_comment (fp, Ctrl->In.mode, "Main frame loop script");
-	fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Hardwire a PPID since subshells may mess things up */
-	if (Ctrl->In.mode == DOS_MODE)	/* Set PPID under Windows to be the frame number */
-		fprintf (fp, "set GMT_PPID=%c1\n", var_token[Ctrl->In.mode]);
-	else	/* On UNIX we use the script's PID as PPID */
-		set_tvalue (fp, Ctrl->In.mode, "GMT_PPID", "$$");
+	fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Hardwire a GMT_SESSION_NAME since subshells may mess things up */
+	if (Ctrl->In.mode == DOS_MODE)	/* Set GMT_SESSION_NAME under Windows to be the frame number */
+		fprintf (fp, "set GMT_SESSION_NAME=%c1\n", var_token[Ctrl->In.mode]);
+	else	/* On UNIX we use the script's PID as GMT_SESSION_NAME */
+		set_tvalue (fp, Ctrl->In.mode, "GMT_SESSION_NAME", "$$");
 	set_comment (fp, Ctrl->In.mode, "Include static and frame-specific parameters");
 	fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 	fprintf (fp, "%s movie_params_%c1.%s\n", load[Ctrl->In.mode], var_token[Ctrl->In.mode], extension[Ctrl->In.mode]);	/* Include the frame parameters */

--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -245,8 +245,8 @@ export HAVE_GLIB_GTHREAD="@HAVE_GLIB_GTHREAD@"
 gmt set -Du
 # Modern mode needs a stable PPID but ctest messes that up when pipes are used
 if [ "X$script_mode" = "XM" ] || [ "X$script_mode" = "Xm" ]; then
-	export GMT_PPID=\$\$
-	echo "Set GMT_PPID = \$GMT_PPID"
+	export GMT_SESSION_NAME=\$\$
+	echo "Set GMT_SESSION_NAME = \$GMT_SESSION_NAME"
 	script_mode=M
 fi
 # Now run the script

--- a/test/pslegend/stacklegendmod.sh
+++ b/test/pslegend/stacklegendmod.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Testing gmt pslegend absolute offsets in modern mode
-export GMT_PPID=$$
+export GMT_SESSION_NAME=$$
 cat << EOF > legend.txt
 S 0.1i T 0.07i red  - 0.3i Ship
 S 0.1i c 0.07i blue - 0.3i Satellite


### PR DESCRIPTION
Expert users may wish to supply a unique session name which will allow then to use sub-shells while running modern mode.  Thus, we allow this name to be a string and hence are renaming the GMT_PPID environmental variable to the more generic name GMT_SESSION_NAME.  Under the hood, if no such variable is set we will create one as before from the parent process id (ppid).