### PR TITLE
Update cmake files with GIT instead of SVN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,30 +102,51 @@ endif (EXISTS ${GMT_SOURCE_DIR}/test/)
 add_subdirectory (cmake/dist) # make distribution bundles (always last)
 
 # Source release target
-if (GIT AND HAVE_SVN_VERSION)
-	if (GZIP AND XZ)
+if (GIT AND HAVE_GIT_VERSION)
+	# Export git working tree
+	add_custom_target (git_export_release
+		COMMAND ${GIT} -C ${GMT_SOURCE_DIR} checkout-index -a -f --prefix=${GMT_RELEASE_PREFIX}/)
+	# Remove the test dir, so that it is not included in the final release tarball
+	add_custom_target (git_prune_dirs
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${GMT_RELEASE_PREFIX}/.git
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${GMT_RELEASE_PREFIX}/.github
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${GMT_RELEASE_PREFIX}/ci
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${GMT_RELEASE_PREFIX}/test)
+	add_custom_target (git_prune_files
+		COMMAND ${CMAKE_COMMAND} -E remove
+			${GMT_RELEASE_PREFIX}/.gitattributes
+			${GMT_RELEASE_PREFIX}/.gitignore
+			${GMT_RELEASE_PREFIX}/.travis.yml)
+	add_depend_to_target (git_prune_dirs git_export_release)
+	add_depend_to_target (gmt_release git_prune_dirs)
+	add_depend_to_target (git_prune_files git_export_release)
+	add_depend_to_target (gmt_release git_prune_files)
+	find_program (GNUTAR NAMES gnutar gtar tar)
+	find_program (XZ NAMES xz)
+	if (GNUTAR AND GZIP AND XZ)
 		# Targets for creating tarballs
 		string (REGEX REPLACE ".*/" "" _release_dirname "${GMT_RELEASE_PREFIX}")
 		add_custom_command (OUTPUT ${_release_dirname}-src.tar
-			COMMAND ${GIT} archive --prefix=gmt-${GMT_PACKAGE_VERSION}/ -o ${GMT_RELEASE_PREFIX}-src.tar master
-			WORKING_DIRECTORY ..
+			COMMAND ${GNUTAR} -c --owner 0 --group 0 --mode a=rX,u=rwX
+			-f ${GMT_BINARY_DIR}/${_release_dirname}-src.tar ${_release_dirname}
+			DEPENDS ${GMT_RELEASE_PREFIX}
+			WORKING_DIRECTORY ${GMT_RELEASE_PREFIX}/..
 			VERBATIM)
 		add_custom_command (OUTPUT ${_release_dirname}-src.tar.gz
 			COMMAND ${GZIP} -9 --keep --force ${GMT_BINARY_DIR}/${_release_dirname}-src.tar
-			DEPENDS ${_release_dirname}-src.tar
+			DEPENDS ${GMT_RELEASE_PREFIX} ${_release_dirname}-src.tar
 			WORKING_DIRECTORY ${GMT_RELEASE_PREFIX}/..
 			VERBATIM)
 		add_custom_command (OUTPUT ${_release_dirname}-src.tar.xz
-			COMMAND ${XZ} -9 --keep --force ${GMT_BINARY_DIR}/${_release_dirname}-src.tar
-			DEPENDS ${_release_dirname}-src.tar
+			COMMAND ${XZ} -9 -T 0 --keep --force ${GMT_BINARY_DIR}/${_release_dirname}-src.tar
+			DEPENDS ${GMT_RELEASE_PREFIX} ${_release_dirname}-src.tar
 			WORKING_DIRECTORY ${GMT_RELEASE_PREFIX}/..
 			VERBATIM)
 		add_custom_target (gmt_release_tar
-			DEPENDS ${_release_dirname}-src.tar
+			DEPENDS ${GMT_RELEASE_PREFIX}
 			${_release_dirname}-src.tar.gz ${_release_dirname}-src.tar.xz)
-		add_depend_to_target (gmt_release gmt_release_tar)
-	endif (GZIP AND XZ)
-endif (GIT AND HAVE_SVN_VERSION)
+	endif (GNUTAR AND GZIP AND XZ)
+endif (GIT AND HAVE_GIT_VERSION)
 
 get_target_property (_location gmtlib LOCATION)
 get_filename_component (GMT_CORE_LIB_NAME ${_location} NAME)

--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -42,11 +42,11 @@ endif (NOT CMAKE_BUILD_TYPE)
 set (GMT_PACKAGE_VERSION_WITH_SVN_REVISION ${GMT_PACKAGE_VERSION})
 # Add the Subversion version number to the package filename if this is a non-public release.
 # A non-public release has an empty 'GMT_SOURCE_CODE_CONTROL_VERSION_STRING' variable in 'ConfigDefault.cmake'.
-set (HAVE_SVN_VERSION)
+set (HAVE_GIT_VERSION)
 if (NOT GMT_SOURCE_CODE_CONTROL_VERSION_STRING)
 	# Get the location, inside the staging area location, to copy the application bundle to.
 	execute_process (
-		COMMAND git describe --abbrev=7 --always --dirty
+		COMMAND ${GIT} describe --abbrev=7 --always --dirty
         WORKING_DIRECTORY  ${GMT_SOURCE_DIR}
 		RESULT_VARIABLE SVN_VERSION_RESULT
 		OUTPUT_VARIABLE SVN_VERSION_OUTPUT
@@ -65,7 +65,7 @@ if (NOT GMT_SOURCE_CODE_CONTROL_VERSION_STRING)
 			if (NOT SVN_VERSION STREQUAL exported)
 				# Set the updated package version.
 				set (GMT_PACKAGE_VERSION_WITH_SVN_REVISION "${GMT_PACKAGE_VERSION}_${SVN_VERSION}")
-				set (HAVE_SVN_VERSION TRUE)
+				set (HAVE_GIT_VERSION TRUE)
 			endif (NOT SVN_VERSION STREQUAL exported)
 		endif (SVN_VERSION_OUTPUT MATCHES "Unversioned")
 	endif (SVN_VERSION_RESULT)

--- a/doc_classic/rst/CMakeLists.txt
+++ b/doc_classic/rst/CMakeLists.txt
@@ -116,13 +116,13 @@ if (SPHINX_FOUND)
 	endif (GZIP)
 
 	# Install targets for realease documentation
-	if (SVN AND HAVE_SVN_VERSION)
+	if (GIT AND HAVE_GIT_VERSION)
 		# HTML
 		add_custom_target (_html_release
 			COMMAND ${CMAKE_COMMAND} -E copy_directory
 			${CMAKE_CURRENT_BINARY_DIR}/html/
 			${GMT_RELEASE_PREFIX}/doc_release/html
-			DEPENDS docs_html svn_export_release)
+			DEPENDS docs_html git_export_release)
 		add_depend_to_target (gmt_release _html_release)
 		# PDF
 		add_custom_target (_pdf_release
@@ -138,16 +138,16 @@ if (SPHINX_FOUND)
 			COMMAND ${CMAKE_COMMAND} -E copy_if_different
 			${CMAKE_CURRENT_BINARY_DIR}/latex/GMT_Manpages.pdf
 			${GMT_RELEASE_PREFIX}/doc_release/pdf/GMT_Manpages.pdf
-			DEPENDS docs_pdf_shrink svn_export_release)
+			DEPENDS docs_pdf_shrink git_export_release)
 		#add_depend_to_target (gmt_release _pdf_release)
 		# Manpages
 		add_custom_target (_man_release
 			COMMAND ${CMAKE_COMMAND} -E copy_directory
 			${CMAKE_CURRENT_BINARY_DIR}/man/
 			${GMT_RELEASE_PREFIX}/man_release
-			DEPENDS docs_man svn_export_release)
+			DEPENDS docs_man git_export_release)
 		add_depend_to_target (gmt_release _man_release)
-	endif (SVN AND HAVE_SVN_VERSION)
+	endif (GIT AND HAVE_GIT_VERSION)
 endif (SPHINX_FOUND)
 
 # Install targets

--- a/doc_classic/rst/source/GMT_Docs.rst
+++ b/doc_classic/rst/source/GMT_Docs.rst
@@ -497,9 +497,8 @@ get multiple output formats from the same plot.
 The modern mode relies on know what session is being run. If your script is explicitly or
 inadvertently creating sub-shells under UNIX then the script could fail.  If this is the
 case then you will need to add
-	export GMT_SESSION_NAME=<some unique string>
+export GMT_SESSION_NAME=<some unique string>
 before gmt begin starts the script.
-
 
 GMT Overview and Quick Reference
 ================================

--- a/doc_classic/scripts/CMakeLists.txt
+++ b/doc_classic/scripts/CMakeLists.txt
@@ -192,15 +192,15 @@ if (NOT EXISTS ${GMT_INSTALL_EXTERNAL_DOC})
 endif (NOT EXISTS ${GMT_INSTALL_EXTERNAL_DOC})
 
 # Install target for release documentation
-if (SVN AND HAVE_SVN_VERSION)
+if (GIT AND HAVE_GIT_VERSION)
 	foreach (_fig ${_install_pdf})
 		add_custom_target (_${_fig}_release
 			COMMAND ${CMAKE_COMMAND} -E copy_if_different
 			${RST_BINARY_DIR}/_images/${_fig}
 			${GMT_RELEASE_PREFIX}/doc_release/pdf/${_fig}
-			DEPENDS ${RST_BINARY_DIR}/_images/${_fig} svn_export_release)
+			DEPENDS ${RST_BINARY_DIR}/_images/${_fig} git_export_release)
 		add_depend_to_target (gmt_release _${_fig}_release)
 	endforeach (_fig ${_install_pdf})
-endif (SVN AND HAVE_SVN_VERSION)
+endif (GIT AND HAVE_GIT_VERSION)
 
 # vim: textwidth=78 noexpandtab tabstop=2 softtabstop=2 shiftwidth=2

--- a/doc_modern/rst/CMakeLists.txt
+++ b/doc_modern/rst/CMakeLists.txt
@@ -115,14 +115,14 @@ if (SPHINX_FOUND)
 		add_dependencies (docs_man docs_depends)
 	endif (GZIP)
 
-	# Install targets for realease documentation
-	if (SVN AND HAVE_SVN_VERSION)
+	# Install targets for release documentation
+	if (GIT AND HAVE_GIT_VERSION)
 		# HTML
 		add_custom_target (_html_release
 			COMMAND ${CMAKE_COMMAND} -E copy_directory
 			${CMAKE_CURRENT_BINARY_DIR}/html/
 			${GMT_RELEASE_PREFIX}/doc_release/html
-			DEPENDS docs_html svn_export_release)
+			DEPENDS docs_html git_export_release)
 		add_depend_to_target (gmt_release _html_release)
 		# PDF
 		add_custom_target (_pdf_release
@@ -138,16 +138,16 @@ if (SPHINX_FOUND)
 			COMMAND ${CMAKE_COMMAND} -E copy_if_different
 			${CMAKE_CURRENT_BINARY_DIR}/latex/GMT_Manpages.pdf
 			${GMT_RELEASE_PREFIX}/doc_release/pdf/GMT_Manpages.pdf
-			DEPENDS docs_pdf_shrink svn_export_release)
+			DEPENDS docs_pdf_shrink git_export_release)
 		#add_depend_to_target (gmt_release _pdf_release)
 		# Manpages
 		add_custom_target (_man_release
 			COMMAND ${CMAKE_COMMAND} -E copy_directory
 			${CMAKE_CURRENT_BINARY_DIR}/man/
 			${GMT_RELEASE_PREFIX}/man_release
-			DEPENDS docs_man svn_export_release)
+			DEPENDS docs_man git_export_release)
 		add_depend_to_target (gmt_release _man_release)
-	endif (SVN AND HAVE_SVN_VERSION)
+	endif (GIT AND HAVE_GIT_VERSION)
 endif (SPHINX_FOUND)
 
 # Install targets

--- a/doc_modern/rst/source/GMT_Docs.rst
+++ b/doc_modern/rst/source/GMT_Docs.rst
@@ -497,9 +497,8 @@ get multiple output formats from the same plot.
 The modern mode relies on know what session is being run. If your script is explicitly or
 inadvertently creating sub-shells under UNIX then the script could fail.  If this is the
 case then you will need to add
-	export GMT_SESSION_NAME=<some unique string>
+export GMT_SESSION_NAME=<some unique string>
 before gmt begin starts the script.
-
 
 GMT Overview and Quick Reference
 ================================

--- a/doc_modern/scripts/CMakeLists.txt
+++ b/doc_modern/scripts/CMakeLists.txt
@@ -192,15 +192,15 @@ if (NOT EXISTS ${GMT_INSTALL_EXTERNAL_DOC})
 endif (NOT EXISTS ${GMT_INSTALL_EXTERNAL_DOC})
 
 # Install target for release documentation
-if (SVN AND HAVE_SVN_VERSION)
+if (GIT AND HAVE_GIT_VERSION)
 	foreach (_fig ${_install_pdf})
 		add_custom_target (_${_fig}_release
 			COMMAND ${CMAKE_COMMAND} -E copy_if_different
 			${RST_BINARY_DIR}/_images/${_fig}
 			${GMT_RELEASE_PREFIX}/doc_release/pdf/${_fig}
-			DEPENDS ${RST_BINARY_DIR}/_images/${_fig} svn_export_release)
+			DEPENDS ${RST_BINARY_DIR}/_images/${_fig} git_export_release)
 		add_depend_to_target (gmt_release _${_fig}_release)
 	endforeach (_fig ${_install_pdf})
-endif (SVN AND HAVE_SVN_VERSION)
+endif (GIT AND HAVE_GIT_VERSION)
 
 # vim: textwidth=78 noexpandtab tabstop=2 softtabstop=2 shiftwidth=2


### PR DESCRIPTION
Lots of variables named SVN* was changed to GIT* and a few checks on SVN now checks for GIT instead.  This restores the doc and man releases to the tar ball.
