### PR TITLE
Cannot allow -J if -G or -L are used in most cases

### DIFF
--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -636,6 +636,10 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct 
 	/* Must have -J */
 	n_errors += gmt_M_check_condition (GMT, !GMT->common.J.active && (Ctrl->G.mode || Ctrl->L.active) && Ctrl->G.unit == 'C',
 	                                   "Syntax error: Must specify -J option with selected form of -G or -L when unit is C\n");
+	n_errors += gmt_M_check_condition (GMT, GMT->common.J.active && Ctrl->G.active && Ctrl->G.unit != 'C',
+	                                   "Syntax error: Cannot specify -J option with selected form of -G\n");
+	n_errors += gmt_M_check_condition (GMT, GMT->common.J.active && Ctrl->L.active && Ctrl->L.unit != 'C',
+	                                   "Syntax error: Cannot specify -J option with selected form of -L\n");
 	if (!GMT->common.R.active[RSET] && GMT->current.proj.projection_GMT == GMT_UTM && Ctrl->C.active) {	/* Set default UTM region from zone info */
 		if (GMT->current.proj.utm_hemisphere == 0)		/* Default to N hemisphere if nothing is known */
 			GMT->current.proj.utm_hemisphere = 1;


### PR DESCRIPTION
Exception is when the unit specified is **C** for Cartesian distance after projection.
