### PR TITLE
Allow -r to take optional g or p

### DIFF
--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -42,7 +42,7 @@ endif (NOT CMAKE_BUILD_TYPE)
 set (GMT_PACKAGE_VERSION_WITH_SVN_REVISION ${GMT_PACKAGE_VERSION})
 # Add the Subversion version number to the package filename if this is a non-public release.
 # A non-public release has an empty 'GMT_SOURCE_CODE_CONTROL_VERSION_STRING' variable in 'ConfigDefault.cmake'.
-set (HAVE_GIT_VERSION)
+#set (HAVE_GIT_VERSION)
 if (NOT GMT_SOURCE_CODE_CONTROL_VERSION_STRING)
 	# Get the location, inside the staging area location, to copy the application bundle to.
 	execute_process (

--- a/doc_classic/rst/source/GMT_Docs.rst
+++ b/doc_classic/rst/source/GMT_Docs.rst
@@ -896,7 +896,7 @@ importance (some are used a lot more than others).
 +----------+--------------------------------------------------------------------+
 | **-p**   | Control perspective views for plots                                |
 +----------+--------------------------------------------------------------------+
-| **-r**   | Set the grid registration to pixel [Default is gridline]           |
+| **-r**   | Set grid registration [Default is gridline]                        |
 +----------+--------------------------------------------------------------------+
 | **-s**   | Control output of records containing one or more NaNs              |
 +----------+--------------------------------------------------------------------+
@@ -2047,7 +2047,7 @@ Grid registration: The **-r** option
 All 2-D grids in GMT have their nodes
 organized in one of two ways, known as *gridline*- and *pixel*-
 registration. The GMT default is gridline registration; programs that
-allow for the creation of grids can use the **-r** option to select
+allow for the creation of grids can use the **-r** option (or **-rp**) to select
 pixel registration instead.  Most observed data tend to be in gridline
 registration while processed data sometime may be distributed in
 pixel registration.  While you may convert between the two registrations

--- a/doc_classic/rst/source/explain_nodereg.rst_
+++ b/doc_classic/rst/source/explain_nodereg.rst_
@@ -1,2 +1,2 @@
 **-r** :ref:`(more ...) <nodereg_full>` 
-    Set pixel node registration [gridline]. |Add_nodereg|
+    Set node registration [gridline]. |Add_nodereg|

--- a/doc_classic/rst/source/explain_nodereg_full.rst_
+++ b/doc_classic/rst/source/explain_nodereg_full.rst_
@@ -1,6 +1,7 @@
 .. _nodereg_full:
 
-**-r**
-    Force pixel node registration [Default is gridline registration].
+**-r**\ [**g**\ \|\ **p**\ ]
+    Force **g**\ridline or **p**\ ixel node registration [Default is pixel registration].
+    If no **-r** is given then gridline registration is selected.
     (Node registrations are defined in Section :ref:`grid-registration`
     of the GMT Technical Reference and Cookbook.)

--- a/doc_modern/rst/source/GMT_Docs.rst
+++ b/doc_modern/rst/source/GMT_Docs.rst
@@ -890,7 +890,7 @@ importance (some are used a lot more than others).
 +----------+--------------------------------------------------------------------+
 | **-p**   | Control perspective views for plots                                |
 +----------+--------------------------------------------------------------------+
-| **-r**   | Set the grid registration to pixel [Default is gridline]           |
+| **-r**   | Set grid registration [Default is gridline]                        |
 +----------+--------------------------------------------------------------------+
 | **-s**   | Control output of records containing one or more NaNs              |
 +----------+--------------------------------------------------------------------+
@@ -1987,7 +1987,7 @@ Grid registration: The **-r** option
 All 2-D grids in GMT have their nodes
 organized in one of two ways, known as *gridline*- and *pixel*-
 registration. The GMT default is gridline registration; programs that
-allow for the creation of grids can use the **-r** option to select
+allow for the creation of grids can use the **-r** option (or **-rp**) to select
 pixel registration instead.  Most observed data tend to be in gridline
 registration while processed data sometime may be distributed in
 pixel registration.  While you may convert between the two registrations

--- a/doc_modern/rst/source/explain_nodereg.rst_
+++ b/doc_modern/rst/source/explain_nodereg.rst_
@@ -1,2 +1,2 @@
 **-r** :ref:`(more ...) <nodereg_full>` 
-    Set pixel node registration [gridline]. |Add_nodereg|
+    Set node registration [gridline]. |Add_nodereg|

--- a/doc_modern/rst/source/explain_nodereg_full.rst_
+++ b/doc_modern/rst/source/explain_nodereg_full.rst_
@@ -1,6 +1,7 @@
 .. _nodereg_full:
 
-**-r**
-    Force pixel node registration [Default is gridline registration].
+**-r**\ [**g**\ \|\ **p**\ ]
+    Force **g**\ridline or **p**\ ixel node registration [Default is pixel registration].
+    If no **-r** is given then gridline registration is selected.
     (Node registrations are defined in Section :ref:`grid-registration`
     of the GMT Technical Reference and Cookbook.)

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6457,7 +6457,8 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 
 		case 'F':	/* -r Pixel registration option  */
 
-			gmt_message (GMT, "\t-r Set pixel registration [Default is grid registration].\n");
+			gmt_message (GMT, "\t-r Set (g)ridline- or (p)ixel-registration [Default].\n");
+			gmt_message (GMT, "\t   If not given we default to gridline registration\n");
 			break;
 
 		case 't':	/* -t layer transparency option  */
@@ -14192,7 +14193,18 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 		case 'r':
 			error += GMT_more_than_once (GMT, GMT->common.R.active[GSET]);
 			GMT->common.R.active[GSET] = true;
-			GMT->common.R.registration = GMT_GRID_PIXEL_REG;
+			if (item[0]) {	/* Gave argument for specific registration */
+				switch (item[0]) {
+					case 'p': GMT->common.R.registration = GMT_GRID_PIXEL_REG; break;
+					case 'g': GMT->common.R.registration = GMT_GRID_NODE_REG; break;
+					default:
+						GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Error -r: Syntax is -r[g|p]\n");
+						error++;
+						break;
+				}
+			}
+			else	/* By default, -r means pixel registration */
+				GMT->common.R.registration = GMT_GRID_PIXEL_REG;
 			break;
 
 		case 's':

--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -113,7 +113,7 @@
 #define GMT_n_OPT	"-n[b|c|l|n][+a][+b<BC>][+c][+t<threshold>]"
 #define GMT_o_OPT	"-o<cols>[,...]"
 #define GMT_p_OPT	"-p[x|y|z]<azim>[/<elev>[/<zlevel>]][+w<lon0>/<lat0>[/<z0>][+v<x0>/<y0>]"
-#define GMT_r_OPT	"-r"
+#define GMT_r_OPT	"-r[g|p]"
 #define GMT_s_OPT	"-s[<cols>][+a|r]"
 #define GMT_t_OPT	"-t<transp>"
 #define GMT_colon_OPT	"-:[i|o]"

--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -122,7 +122,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s <ingrid> -G<outgrid> [%s]\n", name, GMT_I_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-T] [%s] [%s]\n\t[%s] [%s]%s [%s]\n\n", GMT_Rgeo_OPT,
+	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-T] [%s] [%s]\n\t[%s] [%s]%s[%s]\n\n", GMT_Rgeo_OPT,
 		GMT_V_OPT, GMT_f_OPT, GMT_n_OPT, GMT_r_OPT, GMT_x_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);


### PR DESCRIPTION
In anticipation of longer-format options it works better if the **-r** option can take explicit directives **g** (for gridline) and **p** (for pixel) registration.  The **-r** option with no argument is equivalent to **-rp**.  This makes it easier as well for developers who wish to issue **-r** but using variables **g** or **p** as needed.  Implementation is backwards compatible.
