### PR TITLE
Fixes the -J+proj=stere test

### DIFF
--- a/test/mapproject/proj4.sh
+++ b/test/mapproject/proj4.sh
@@ -25,7 +25,7 @@ gmt mapproject pt.txt -J+proj=oea+ellps=WGS84+units=m+lat_1=20n+lat_2=60n+lon_1=
 gmt mapproject pt.txt -J+proj=airy+ellps=WGS84+units=m | gmt math -o1 STDIN -C0 328249.003313 SUB -C1 4987937.101447 SUB 0 COL HYPOT 0.01 GT = >> results.txt
 # gmt mapproject pt.txt -J+proj=aeqd+ellps=WGS84+units=m | gmt math -o1 STDIN -C0 384923.723428 SUB -C1 5809986.497118 SUB 0 COL HYPOT 0.01 GT = >> results.txt
 gmt mapproject pt.txt -J+proj=laea+ellps=WGS84+units=m | gmt math -o1 STDIN -C0 371541.476735 SUB -C1 5608007.251007 SUB 0 COL HYPOT 0.01 GT = >> results.txt
-gmt mapproject pt.txt -J+proj=stere+ellps=WGS84+units=m+lat_ts=30n | gmt math -o1 STDIN -C0 828919.243654 SUB -C1 12511653.499743 SUB 0 COL HYPOT 0.01 GT = >> results.txt
+gmt mapproject pt.txt -J+proj=stere+ellps=WGS84+units=m+lat_ts=30n | gmt math -o1 STDIN -C0 414459.6218269 SUB -C1 6255826.7498713 SUB 0 COL HYPOT 0.01 GT = >> results.txt
 gmt mapproject pt.txt -J+proj=sterea+lat_0=52.15616055555555+lon_0=5.38763888888889+k=0.9999079+x_0=155000+y_0=463000+ellps=bessel+units=m | gmt math -o1 STDIN -C0 121590.388077 SUB -C1 487013.903377 SUB 0 COL HYPOT 0.01 GT = >> results.txt
 let errors=`gmt math -T -Sl results.txt SUM =`
 if [ $errors -ne 0 ]; then


### PR DESCRIPTION
Somehow the ``stere`` test was comparing against some crazy numbers. Now checked that either gdaltransform or proj directly give same result as mapproject.


