### PR TITLE
Improve grdedit documentation

### DIFF
--- a/doc/rst/source/grdedit.rst
+++ b/doc/rst/source/grdedit.rst
@@ -205,6 +205,15 @@ To ensure that the grid depths.nc only has positive longitude values, run
 
     gmt grdedit depths.nc -L+p
 
+Notes:
+------
+
+This module is not a general editor for netCDF files.  If your netCDF file
+contains more than one 2-D (or higher dimension) data layer, then only the
+selected layer will be written out if changes are requested.  Likewise,
+if you have additional netCDF attributes then those will also be lost in
+any revised output.
+
 See Also
 --------
 


### PR DESCRIPTION
Make it clear that grdedit is not a general purpose netCDF file editor and that revised grid output is restricted to the selected (or implicitly selected) 2-D grid layer and its basic attributes, not additional meta data information that may be present in the original file.  Partly addresses issue #209.