### PR TITLE
Disable smart quotes transform of -- and ---

### DIFF
--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -92,6 +92,8 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
+# Set smartquotes_action to 'qe' to disable Smart Quotes transform of -- and ---
+smartquotes_action = 'qe'
 
 # -- Options for HTML output ---------------------------------------------------
 


### PR DESCRIPTION
**Description of proposed changes**
Sphinx transforms double hyphens `--` to en dash `–` by default. This PR fix such issue by setting `
smartquotes_action = 'qe'`. See [sphinx documentation](http://www.sphinx-doc.org/en/master/usage/configuration.html#confval-smartquotes_action) for detailed explanations.

**Before:**
![image](https://user-images.githubusercontent.com/3974108/51794430-122e8280-21a1-11e9-96fc-c3aa14338957.png)

**After:**
![image](https://user-images.githubusercontent.com/3974108/51794429-0cd13800-21a1-11e9-8ff6-4c3ae2c79d11.png)



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->