### PR TITLE
Allow gmt text to list fonts

### DIFF
--- a/src/pstext.c
+++ b/src/pstext.c
@@ -679,9 +679,17 @@ GMT_LOCAL int validate_coord_and_text (struct GMT_CTRL *GMT, struct PSTEXT_CTRL 
 int GMT_text (void *V_API, int mode, void *args) {
 	/* This is the GMT6 modern mode name */
 	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);	/* Cast from void to GMTAPI_CTRL pointer */
+	if (API == NULL) return (GMT_NOT_A_SESSION);
 	if (API->GMT->current.setting.run_mode == GMT_CLASSIC) {
-		GMT_Report (API, GMT_MSG_NORMAL, "Shared GMT module not found: text\n");
-		return (GMT_NOT_A_VALID_MODULE);
+		struct GMT_OPTION *options = options = GMT_Create_Options (API, mode, args);
+		bool list_fonts = false;
+		if (API->error) return (API->error);	/* Set or get option list */
+		list_fonts = (GMT_Find_Option (API, 'L', options) != NULL);
+		gmt_M_free_options (mode);
+		if (!list_fonts) {
+			GMT_Report (API, GMT_MSG_NORMAL, "Shared GMT module not found: text\n");
+			return (GMT_NOT_A_VALID_MODULE);
+		}
 	}
 	return GMT_pstext (V_API, mode, args);
 }


### PR DESCRIPTION
Basically, the -L option should be allowed under modern mode.
Addresses issue #384.