### PR TITLE
bash completion: return progs as an array

### DIFF
--- a/share/tools/gmt_completion.bash
+++ b/share/tools/gmt_completion.bash
@@ -41,7 +41,7 @@ _gmt()
     opts=( --help --show-datadir --show-bindir --version )
 
     # strip off any leading "gmt" in module names:
-    progs=`gmt --show-modules | sed -e 's/^gmt//g'`
+    progs=(`gmt --show-modules | sed -e 's/^gmt//g'`)
 
     # complete first arg
     if [[ ${COMP_CWORD} -eq 1 ]]; then


### PR DESCRIPTION
**Description of proposed changes**

to get options completion the progs variable needs to be of array type.

Now

    gmt <tab><tab>

complete the list of modules, but for example (name any module)

    gmt pscoast -<tab><tab>

does not provide completion of possible switches.

Embracing assignment of gmt modules in parenthesis resolves this issue.