### PR TITLE
Set the BFN colors earlier so that external interfaces can see them too.

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -2666,6 +2666,14 @@ GMT_LOCAL int api_export_palette (struct GMTAPI_CTRL *API, int object_ID, unsign
 
 	/* Passed sanity and allowed to write */
 
+	/* If need to assign non-default BFN do it now sow external interfaces can access that too */
+	if (mode & GMT_CPT_EXTEND_BNF) {	/* Use low and high colors as back and foreground */
+		gmt_M_rgb_copy (P_obj->bfn[GMT_BGD].rgb, P_obj->data[0].rgb_low);
+		gmt_M_rgb_copy (P_obj->bfn[GMT_FGD].rgb, P_obj->data[P_obj->n_colors-1].rgb_high);
+		gmt_M_rgb_copy (P_obj->bfn[GMT_BGD].hsv, P_obj->data[0].hsv_low);
+		gmt_M_rgb_copy (P_obj->bfn[GMT_FGD].hsv, P_obj->data[P_obj->n_colors-1].hsv_high);
+	}
+	
 	switch (S_obj->method) {	/* File, array, stream etc ? */
 		case GMT_IS_FILE:
 			/* gmtlib_write_cpt will report where it is writing from if level is GMT_MSG_LONG_VERBOSE */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -8229,13 +8229,6 @@ int gmtlib_write_cpt (struct GMT_CTRL *GMT, void *dest, unsigned int dest_type, 
 		return (GMT_NOERROR);
 	}
 
-	if (cpt_flags & GMT_CPT_EXTEND_BNF) {	/* Use low and high colors as back and foreground */
-		gmt_M_rgb_copy (P->bfn[GMT_BGD].rgb, P->data[0].rgb_low);
-		gmt_M_rgb_copy (P->bfn[GMT_FGD].rgb, P->data[P->n_colors-1].rgb_high);
-		gmt_M_rgb_copy (P->bfn[GMT_BGD].hsv, P->data[0].hsv_low);
-		gmt_M_rgb_copy (P->bfn[GMT_FGD].hsv, P->data[P->n_colors-1].hsv_high);
-	}
-
 	for (i = 0; i < 3; i++) {
 		if (P->bfn[i].skip)
 			fprintf (fp, "%c\t-\n", code[i]);


### PR DESCRIPTION
So far we used to set the BFN colors only in the ``gmtlib_write_cpt()`` but that is not used by external interfaces and as a consequences ``makecpt -D`` did not work for them (see this [issue](gmtlib_write_cpt)). This PR moves the setting to an earlier position so that everybody is happy now.