### PR TITLE
Allow -E+l|L when using modern mode name coast

### DIFF
--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -684,9 +684,16 @@ GMT_LOCAL int check_antipode_status (struct GMT_CTRL *GMT, struct GMT_SHORE *c, 
 int GMT_coast (void *V_API, int mode, void *args) {
 	/* This is the GMT6 modern mode name */
 	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);	/* Cast from void to GMTAPI_CTRL pointer */
-	if (API->GMT->current.setting.run_mode == GMT_CLASSIC) {
-		GMT_Report (API, GMT_MSG_NORMAL, "Shared GMT module not found: coast\n");
-		return (GMT_NOT_A_VALID_MODULE);
+	if (API->GMT->current.setting.run_mode == GMT_CLASSIC) {	/* See if -E+l|L was given, which is part of usage */
+		struct GMT_OPTION *opt = NULL, *options = options = GMT_Create_Options (API, mode, args);
+		bool list_items = false;
+		if (API->error) return (API->error);	/* Set or get option list */
+		list_items = ((opt = GMT_Find_Option (API, 'E', options)) && opt->arg[0] == '+' && strchr ("lL", opt->arg[1]));
+		gmt_M_free_options (mode);
+		if (!list_items) {
+			GMT_Report (API, GMT_MSG_NORMAL, "Shared GMT module not found: coast\n");
+			return (GMT_NOT_A_VALID_MODULE);
+		}
 	}
 	return GMT_pscoast (V_API, mode, args);
 }


### PR DESCRIPTION
Just like text **-L** works in modern mode without gmt begin/end, so shall coast **-E** when used to list countries and states.

