### PR TITLE
Add missing KEYs to x2sys_cross

### DIFF
--- a/src/gmt_supplements_module.c
+++ b/src/gmt_supplements_module.c
@@ -84,7 +84,7 @@ static struct Gmt_moduleinfo g_supplements_module[] = {
 	{"rotconverter", "spotter", "Manipulate total reconstruction and stage rotations", ">D}"},
 	{"rotsmoother", "spotter", "Get mean rotations and covariance matrices from set of finite rotations", "<D{,>D}"},
 	{"x2sys_binlist", "x2sys", "Create bin index listing from track data files", ">D}"},
-	{"x2sys_cross", "x2sys", "Calculate crossovers between track data files", ">D}"},
+	{"x2sys_cross", "x2sys", "Calculate crossovers between track data files", "<D{,>D}"},
 	{"x2sys_datalist", "x2sys", "Extract content of track data files", ">D}"},
 	{"x2sys_get", "x2sys", "Get track listing from track index database", ">D}"},
 	{"x2sys_init", "x2sys", "Initialize a new x2sys track database", ""},

--- a/src/x2sys/x2sys_cross.c
+++ b/src/x2sys/x2sys_cross.c
@@ -34,7 +34,7 @@
 #define THIS_MODULE_NAME	"x2sys_cross"
 #define THIS_MODULE_LIB		"x2sys"
 #define THIS_MODULE_PURPOSE	"Calculate crossovers between track data files"
-#define THIS_MODULE_KEYS	">D}"
+#define THIS_MODULE_KEYS	"<D{,>D}"
 #define THIS_MODULE_NEEDS	""
 #define THIS_MODULE_OPTIONS "->RVbd"
 


### PR DESCRIPTION
Missed KEYs for input but things still don't work and external calls ends up crashing. The problem is that ``x2sys_read_file()`` calls ``x2sys_get_data_path (GMT, path, fname, s->suffix)`` but ofc there are no suffixes for in-memory data files. But other than this, ``x2sys_read_file()`` doesn't seem fit to read in-mem files.