### PR TITLE
Comment out PDF build in cron jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,7 +156,6 @@ script:
         cmake --build . --target animation;
         kill %1;
         cmake --build . --target docs_html;
-        cmake --build . --target docs_pdf;
       fi
     - set +e
     - cd ..


### PR DESCRIPTION
the PDF build should only be triggered during a release, not the regular builds.