### PR TITLE
Catch the case where lon, lat are NaN

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -13074,6 +13074,8 @@ uint64_t gmt_crossover (struct GMT_CTRL *GMT, double xa[], double ya[], uint64_t
 						}
 					}
 				}
+				else if (gmt_M_is_dnan(del_yb)) {}	/* Just do nothing and prevent call to doubleAlmostEqual() which would assert fail with NaNs */
+
 				else {	/* General case */
 
 					i_del_xa = 1.0 / del_xa;


### PR DESCRIPTION
This relates with #407. If in x2sys_cross the file has rows with NaNs for lon & lat ``gmt_crossover()`` would crash (well, assert fail in ``doubleAlmostEqual()`` which make a crash when in debug mode).

As a bonus for this, one can now have a file with NaNs indicating line breaks (like it was a multi-segment file) and x2sy_cross can operate on it to detect internal COEs. 

An annoying side effect is I'm getting warnings like this
```
x2sys_cross [ERROR]: Column selected for latitude-formatting has values that exceed +/- 90; set to NaN
```
There might be a better solution to the auto-crossing issue but at least this prevents a crash.