### PR TITLE
Fix broken link to Units

### DIFF
--- a/doc/rst/source/contour_common.rst_
+++ b/doc/rst/source/contour_common.rst_
@@ -130,7 +130,7 @@ Optional Arguments
 **-Q**\ [*cut*\ [*unit*]][\ **+z**]
     Do not draw contours with less than *cut* number of points [Draw all contours].
     Alternatively, give instead a minimum contour length in distance units
-    (see UNITS for available units and how distances are computed),
+    (see :ref:`Unit_attributes` for available units and how distances are computed),
     including **c** (Cartesian distances using user coordinates) or **C** for plot
     length units in current plot units after projecting the coordinates.
     Optionally, append **z** to exclude the zero contour.

--- a/doc/rst/source/explain_clabelinfo.rst_
+++ b/doc/rst/source/explain_clabelinfo.rst_
@@ -37,7 +37,7 @@
         Nudges the placement of labels by the specified amount (append
         **c**\ \|\ **i**\ \|\ **p** to specify the units). Increments
         are considered in the coordinate system defined by the
-        orientation of the contour (contour is *x*, normal to contour is *y);
+        orientation of the contour (contour is *x*, normal to contour is *y*);
         use **+N** to force increments in the overall
         plot x/y coordinates system [no nudging]. Not allowed with **+v**.
 

--- a/doc/rst/source/explain_distunits.rst_
+++ b/doc/rst/source/explain_distunits.rst_
@@ -1,5 +1,7 @@
-`Units <#toc9>`_
-----------------
+.. _Unit_attributes:
+
+Units
+-----
 
 For map distance unit, append *unit* **d** for arc degree, **m** for arc
 minute, and **s** for arc second, or **e** for meter [Default], **f**
@@ -8,4 +10,5 @@ and **u** for US survey foot. By default we compute such distances using
 a spherical approximation with great circles. Prepend **-** to a
 distance (or the unit is no distance is given) to perform "Flat Earth"
 calculations (quicker but less accurate) or prepend **+** to perform
-exact geodesic calculations (slower but more accurate).
+exact geodesic calculations (slower but more accurate; see
+:ref:`PROJ_GEODESIC <PROJ_GEODESIC>` for method used).

--- a/doc/rst/source/gmtconnect.rst
+++ b/doc/rst/source/gmtconnect.rst
@@ -103,7 +103,7 @@ Optional Arguments
 
 **-T**\ [*cutoff*\ [*unit*][/\ *nn\_dist*]]
     Specifies the separation tolerance in the data coordinate units [0];
-    append distance unit (see UNITS). If two lines has end-points that
+    append distance unit (see :ref:`Unit_attributes`). If two lines has end-points that
     are closer than this cutoff they will be joined. Optionally, append
     /*nn_dist* which adds the requirement that a link will only be made
     if the second closest connection exceeds the *nn_dist*. The latter

--- a/doc/rst/source/gmtselect.rst
+++ b/doc/rst/source/gmtselect.rst
@@ -77,7 +77,7 @@ Optional Arguments
     column of *pointfile* must have each point's individual radius of
     influence. Distances are Cartesian and in user units; specify
     **-fg** to indicate spherical distances and append a distance unit
-    (see UNITS). Alternatively, if **-R** and **-J** are used then
+    (see :ref:`Unit_attributes`). Alternatively, if **-R** and **-J** are used then
     geographic coordinates are projected to map coordinates (in cm,
     inch, or points, as determined by :ref:`PROJ_LENGTH_UNIT <PROJ_LENGTH_UNIT>`) before
     Cartesian distances are compared to *dist*.
@@ -152,7 +152,7 @@ Optional Arguments
     embedded **-D**\ *dist* setting that sets each line's individual
     distance value. Distances are Cartesian and in user units; specify
     **-fg** to indicate spherical distances append a distance unit (see
-    UNITS). Alternatively, if **-R** and **-J** are used then geographic
+    :ref:`Unit_attributes`). Alternatively, if **-R** and **-J** are used then geographic
     coordinates are projected to map coordinates (in cm, inch, m, or
     points, as determined by :ref:`PROJ_LENGTH_UNIT <PROJ_LENGTH_UNIT>`) before Cartesian
     distances are compared to *dist*. Append **+p** to ensure only points

--- a/doc/rst/source/gmtsimplify.rst
+++ b/doc/rst/source/gmtsimplify.rst
@@ -46,7 +46,7 @@ Required Arguments
 
 **-T**\ *tolerance*\ [*unit*]
     Specifies the maximum mismatch tolerance in the user units. If the
-    data is not Cartesian then append the distance unit (see UNITS).
+    data is not Cartesian then append the distance unit (see :ref:`Unit_attributes`).
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/gmtspatial.rst
+++ b/doc/rst/source/gmtspatial.rst
@@ -89,7 +89,7 @@ Optional Arguments
     distance between nearest points of two features is less than a
     threshold). We also consider that some features may have been
     reversed. Features are considered approximate matches if their
-    minimum distance is less than *dmax* [0] (see UNITS) and their
+    minimum distance is less than *dmax* [0] (see :ref:`Unit_attributes`) and their
     closeness (defined as the ratio between the average distance between
     the features divided by their average length) is less than *cmax*
     [0.01]. For each duplicate found, the output record begins with the
@@ -152,7 +152,7 @@ Optional Arguments
     simply writes the area to stdout]. For polygons we also compute the
     centroid location while for line data we compute the mid-point
     (half-length) position. Append a distance unit to select the unit
-    used (see UNITS). Note that the area will depend on the current
+    used (see :ref:`Unit_attributes`). Note that the area will depend on the current
     setting of :ref:`PROJ_ELLIPSOID <PROJ_ELLIPSOID>`; this should be a
     recent ellipsoid to get accurate results. The centroid is computed
     using the mean of the 3-D Cartesian vectors making up the polygon

--- a/doc/rst/source/grdcontour_common.rst_
+++ b/doc/rst/source/grdcontour_common.rst_
@@ -125,7 +125,7 @@ Optional Arguments
 **-Q**\ [*cut*\ [*unit*]][\ **+z**]
     Do not draw contours with less than *cut* number of points [Draw all contours].
     Alternatively, give instead a minimum contour length in distance units
-    (see UNITS for available units and how distances are computed),
+    (see :ref:`Unit_attributes` for available units and how distances are computed),
     including **c** (Cartesian distances using user coordinates) or **C** for plot
     length units in current plot units after projecting the coordinates.
     Optionally, append **z** to exclude the zero contour.

--- a/doc/rst/source/grdcut.rst
+++ b/doc/rst/source/grdcut.rst
@@ -72,7 +72,7 @@ Optional Arguments
 .. _-S:
 
 **-S**\ *lon/lat/radius*\ [*unit*]\ [**+n**]
-    Specify an origin and radius; append a distance unit (see UNITS) and
+    Specify an origin and radius; append a distance unit (see :ref:`Unit_attributes`) and
     we determine the corresponding rectangular region so that all grid
     nodes on or inside the circle are contained in the subset. If
     **+n** is appended we set all nodes outside the circle to NaN. 

--- a/doc/rst/source/grdmask.rst
+++ b/doc/rst/source/grdmask.rst
@@ -107,7 +107,7 @@ Optional Arguments
     Set nodes to inside, on edge, or outside depending on their distance
     to the nearest data point. Nodes within *radius* [0] from the
     nearest data point are considered inside; append a distance unit
-    (see UNITS). If *radius* is given as **z** then we instead read
+    (see :ref:`Unit_attributes`). If *radius* is given as **z** then we instead read
     individual radii from the 3rd input column.  Unless Cartesian data,
     specify the unit of these radii by appending it after **-Sz**.
     If **-S** is not set then we consider the input data to define

--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -114,7 +114,7 @@ Optional Arguments
     profiles are output.  Choose to only output the left or right halves
     of the profiles by appending **+l** or **+r**, respectively.  Append suitable units
     to *length*; it sets the unit used for *ds* [and *spacing*] (See
-    UNITS below). The default unit for geographic grids is meter while
+    :ref:`Unit_attributes` below). The default unit for geographic grids is meter while
     Cartesian grids implies the user unit.  The output columns will be
     *lon*, *lat*, *dist*, *azimuth*, *z1*, *z2*, ..., *zn* (The *zi* are
     the sampled values for each of the *n* grids)

--- a/doc/rst/source/grdvector_common.rst_
+++ b/doc/rst/source/grdvector_common.rst_
@@ -88,7 +88,7 @@ Optional Arguments
     via plot unit scaling will plot as straight vectors and their lengths are not
     affected by map projection and coordinate locations.
     For geographic data you may alternatively give *scale* in data units per
-    map distance unit (see UNITS). Then, your user units are scaled to map distances in the given unit
+    map distance unit (see :ref:`Unit_attributes`). Then, your user units are scaled to map distances in the given unit
     which are projected to plot dimensions.  These are geo-vectors that follow
     great circle paths and their lengths are affected by the map projection and their
     coordinates.  Finally, use **-Si** if it is simpler to give the reciprocal scale in

--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -134,7 +134,7 @@ Optional Arguments
 **-F**\ [*unit*\ ]
     Force 1:1 scaling, i.e., output (or input, see **-I**) data are in
     actual projected meters. To specify other units, append the desired
-    unit (see UNITS). Without **-F**, the output (or input, see **-I**)
+    unit (see :ref:`Unit_attributes`). Without **-F**, the output (or input, see **-I**)
     are in the units specified by :ref:`PROJ_LENGTH_UNIT <PROJ_LENGTH_UNIT>` (but see
     **-D**).
 
@@ -142,7 +142,7 @@ Optional Arguments
 
 **-G**\ [*lon0*/*lat0*][**+a**][**+i**][**+u**\ [**+**\ \|\ **-**]\ *unit*][**+v**]
     Calculate distances along track *or* to the optional *fixed* point set
-    with **-G**\ *lon0*/*lat0*. Append the distance unit with **+u** (see UNITS for available
+    with **-G**\ *lon0*/*lat0*. Append the distance unit with **+u** (see :ref:`Unit_attributes` for available
     units and how distances are computed), including
     **c** (Cartesian distance using input coordinates) or **C**
     (Cartesian distance using projected coordinates). The **C** unit
@@ -164,7 +164,7 @@ Optional Arguments
     Determine the shortest distance from the input data points to the
     line(s) given in the ASCII multisegment file *line.xy*. The distance
     and the coordinates of the nearest point will be appended to the
-    output as three new columns. Append the distance unit (see UNITS
+    output as three new columns. Append the distance unit (see :ref:`Unit_attributes`
     for available units and how distances are computed),
     including **c** (Cartesian distance using input coordinates) or
     **C** (Cartesian distance using projected coordinates). The **C**

--- a/doc/rst/source/mask_common.rst_
+++ b/doc/rst/source/mask_common.rst_
@@ -102,7 +102,7 @@ Optional Arguments
 **-S**\ *search\_radius*\ [*unit*\ ]
     Sets radius of influence. Grid nodes within *radius* of a data point
     are considered reliable. [Default is 0, which means that only grid
-    cells with data in them are reliable]. Append the distance unit (see UNITS).
+    cells with data in them are reliable]. Append the distance unit (see :ref:`Unit_attributes`).
 
 .. _-T:
 

--- a/doc/rst/source/nearneighbor.rst
+++ b/doc/rst/source/nearneighbor.rst
@@ -81,7 +81,7 @@ Required Arguments
 
 **-S**\ *search_radius*\ [*unit*]
     Sets the *search_radius* that determines which data points are
-    considered close to a node. Append the distance unit (see UNITS).
+    considered close to a node. Append the distance unit (see :ref:`Unit_attributes`).
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/supplements/mgd77/mgd77manage.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77manage.rst
@@ -207,7 +207,7 @@ Optional Arguments
 .. _-N:
 
 **-N**\ *unit*
-    Append the distance unit (see UNITS). [Default is **-Nk** (km)].
+    Append the distance unit (see :ref:`Unit_attributes`). [Default is **-Nk** (km)].
     Only relevant when **-Ag**\ \|\ **i** is selected. 
 
 .. _-R:

--- a/doc/rst/source/supplements/potential/grdseamount.rst
+++ b/doc/rst/source/supplements/potential/grdseamount.rst
@@ -85,7 +85,7 @@ Optional Arguments
 .. _-D:
 
 **-D**\ *unit*
-    Append the unit used for horizontal distances in the input file (see UNITS).
+    Append the unit used for horizontal distances in the input file (see :ref:`Unit_attributes`).
     Does not apply for geographic data (|SYN_OPT-f|) which we convert to km.
 
 .. _-E:


### PR DESCRIPTION
References to how to specify units, geodesic vs flat earth calculations, etc, were not active links.  Also fixed some formatting errors.
Still more work to do given the merging of classic modules and duplicate references...