### PR TITLE
Use ? to indicate scale or width in projections in subplots under modern mode

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12250,12 +12250,19 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 				if ((opt = GMT_Make_Option (API, 'Y', arg)) == NULL) return NULL;	/* Failure to make option */
 				if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
 				if (opt_J && !(strchr ("xX", opt_J->arg[0]) && (strchr (opt_J->arg, 'l') || strchr (opt_J->arg, 'p') || strchr (opt_J->arg, '/')))) {
+					char *c = NULL;
 					/* Gave -J that passed the log/power/special check, must append /1 as dummy scale/width */
 					if (P->dir[GMT_X] == -1 || P->dir[GMT_Y] == -1)	/* Nonstandard Cartesian directions */
 						sprintf (scl, "%gi/%gi",  P->dir[GMT_X]*P->w, P->dir[GMT_Y]*P->h);
 					else	/* Just append dummy width */
 						sprintf (scl, "%gi",  P->w);
-					if (strlen (opt_J->arg) == 1  || !strchr (opt_J->arg, '/'))
+					if ((c = strchr (opt_J->arg, '?'))) {	/* Scale or width was marked with ? */
+						c[0] = '\0';
+						sprintf (arg, "%s%s", opt_J->arg, scl);	/* Replace the ? with actual width */
+						strcat (arg, &c[1]);	/* Append the rest of the arguments */
+						c[0] = '?';
+					}
+					else if (strlen (opt_J->arg) == 1  || !strchr (opt_J->arg, '/'))	/* No markings, assume we just append */
 						sprintf (arg, "%s%s", opt_J->arg, scl);	/* Append the dummy width as only argument */
 					else
 						sprintf (arg, "%s/%s", opt_J->arg, scl);	/* Append the dummy width to other arguments */


### PR DESCRIPTION
We cannot specify the actual width or scale in subplots, and because some projections have many arguments and the width may not be the last one, we will use ? to indicate where the computed scale or width should be placed.  Addresses #389.
