### PR TITLE
Ensure polar projection only has one scale in subplots

### DIFF
--- a/doc/rst/source/subplot.rst_
+++ b/doc/rst/source/subplot.rst_
@@ -160,7 +160,7 @@ Synopsis (set mode)
 **gmt subplot set** *row,col* [ **-A**\ *fixedlabel*] [ **-C**\ *side*\ /*clearance*\ [**u**\ ] ] [ |SYN_OPT-V| ]
 
 Before you start plotting you must first select the active subplot panel.
-Note: Any **-J** option passed when plotting subplots must not give the width or scale
+Note: Any **-J** option passed when plotting subplots must give ? as scale of width
 since the dimensions of the map are completely determined by the subplot size and your region.
 Specifying map width will result in an error.  For Cartesian plots: If you want the scale
 to apply *equally* to both dimensions then you must specify **-Jx** [The default **-JX** will

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -2184,7 +2184,7 @@ GMT_LOCAL void map_setxy (struct GMT_CTRL *GMT, double xmin, double xmax, double
 		w = GMT->current.proj.rect[XHI];	h = GMT->current.proj.rect[YHI];
 		adjust_panel_for_gaps (GMT, P);	/* Deal with any gaps: shrink w/h and adjust origin */
 		fw = w / P->w;	fh = h / P->h;
-		if (gmt_M_is_geographic (GMT, GMT_IN) || GMT->current.proj.gave_map_width == 0) {	/* Giving -Jx will end up here with map projections */
+		if (gmt_M_is_geographic (GMT, GMT_IN) || GMT->current.proj.projection == GMT_POLAR || GMT->current.proj.gave_map_width == 0) {	/* Giving -Jx will end up here with map projections */
 			if (fw > fh) {	/* Wider than taller given panel dims; adjust width to fit exactly */
 				fx = fy = 1.0 / fw;	P->dx = 0.0;	P->dy = 0.5 * (P->h - h * fy);
 			}


### PR DESCRIPTION
See issue #389.  The problem was the polar (theta,radius) projection is not geographic but still needs the same scaling in both x and y.  Also updated the subplot man page to mention that scale or width in map projections should be given as ? (i.e., question mark).
