### PR TITLE
Address issue in -T when there are no NaNs

### DIFF
--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -204,8 +204,10 @@ Optional Arguments
    the nearest non-NaN node and report that value instead.  Optionally specify
    a search radius which limits the consideration to points within this distance
    from the input point.  To report the location of the nearest node and its
-   distance from the input point, append **+e**. To instead replace the input
-   point with the coordinates of the nearest node, append **+p**.
+   distance from the input point, append **+e**. The default unit for geographic
+   grid distances is spherical degrees.  Use *radius*\ [**u**] to change the unit
+   and give *radius* = 0 if you do not want to limit the radius search.
+   To instead replace the input point with the coordinates of the nearest node, append **+p**.
 
 .. _-V:
 


### PR DESCRIPTION
See http://gmt.soest.hawaii.edu/boards/1/topics/8061?r=8075 for background. Basically, when **-T+e** was used and there was no NaN node near the input point then no nearest node coordinate and distance to it were set.

