### PR TITLE
Add -O0 to fix coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
           if: type != cron
         - name: "Linux (cron)"
           os: linux
-          if: type = cron
+          #if: type = cron
           env:
             - TEST="true"
         - name: "Mac (compile only)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
           if: type != cron
         - name: "Linux (cron)"
           os: linux
-          #if: type = cron
+          if: type = cron
           env:
             - TEST="true"
         - name: "Mac (compile only)"

--- a/ci/build-gmt.sh
+++ b/ci/build-gmt.sh
@@ -17,7 +17,7 @@ enable_testing()
 set (DO_EXAMPLES TRUE)
 set (DO_TESTS TRUE)
 set (N_TEST_JOBS 2)
-set (CMAKE_C_FLAGS "-Wextra -coverage ${CMAKE_C_FLAGS}")
+set (CMAKE_C_FLAGS "-Wextra -coverage -O0 ${CMAKE_C_FLAGS}")
 EOF
 fi
 


### PR DESCRIPTION
**Description of proposed changes**

Currently, codecov only checks the coverage of one or several source files. This PR fixes this issue.

We need `-O0` to generate a coverage report. See the build logs [before](https://travis-ci.org/GenericMappingTools/gmt/jobs/493593250) and [after](https://travis-ci.org/GenericMappingTools/gmt/jobs/493791220) adding `-O0` for comparisons.
