### PR TITLE
Let gmtwhich honor the -Gl option

### DIFF
--- a/src/gmtwhich.c
+++ b/src/gmtwhich.c
@@ -198,6 +198,7 @@ int GMT_gmtwhich (void *V_API, int mode, void *args) {
 		else
 			strcpy (file, opt->arg);
 		if (gmt_getdatapath (GMT, &file[first], path, fmode)) {	/* Found the file */
+			char *L = NULL;
 			if (Ctrl->D.active) {
 				p = strstr (path, &file[first]);	/* Start of filename */
 				if (!strcmp (p, path)) /* Found in current directory */
@@ -208,6 +209,11 @@ int GMT_gmtwhich (void *V_API, int mode, void *args) {
 			else if (Ctrl->C.active)	/* Just want a Yes */
 				strcpy (path, Yes);
 			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+			if (Ctrl->G.active && Ctrl->G.mode == GMT_LOCAL_DIR && path[0] == '/' && (L = strrchr(path, '/'))) {
+				/* File found on system but we want a copy in the current directory */
+				if (gmt_rename_file (GMT, path, &L[1], GMT_COPY_FILE))
+					Return (GMT_RUNTIME_ERROR);
+			}
 		}
 		else {	/* Did not find.  Report no or be quiet */
 			if (Ctrl->C.active) {


### PR DESCRIPTION
gmtwhich was inconsistent in writing the desired file to current directory.  It only did so if the file was _not_ found in the data directory, but if it _was_ found it did not copy to current directory.  Now fixed, addressing #432.
