### PR TITLE
Improve/fix the gmt_ogrread function and include in the lib code.

### DIFF
--- a/src/gmt_customio.c
+++ b/src/gmt_customio.c
@@ -1723,7 +1723,7 @@ int gmt_srf_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 #include "gmt_gdalread.c"
 #include "gmt_gdalwrite.c"
 #include "gmt_ogrproj.c"		/* For coordinate conversions but can "enter" here too */
-#if (GDAL_VERSION_NUM >= 2000)
+#if GDAL_VERSION_MAJOR >= 2
 #include "gmt_ogrread.c"
 #endif
 /* GDAL support */

--- a/src/gmt_customio.c
+++ b/src/gmt_customio.c
@@ -1723,7 +1723,9 @@ int gmt_srf_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 #include "gmt_gdalread.c"
 #include "gmt_gdalwrite.c"
 #include "gmt_ogrproj.c"		/* For coordinate conversions but can "enter" here too */
+#if (GDAL_VERSION_NUM >= 2000)
 #include "gmt_ogrread.c"
+#endif
 /* GDAL support */
 /*-----------------------------------------------------------
  * Format :	gd

--- a/src/gmt_customio.c
+++ b/src/gmt_customio.c
@@ -1723,6 +1723,7 @@ int gmt_srf_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 #include "gmt_gdalread.c"
 #include "gmt_gdalwrite.c"
 #include "gmt_ogrproj.c"		/* For coordinate conversions but can "enter" here too */
+#include "gmt_ogrread.c"
 /* GDAL support */
 /*-----------------------------------------------------------
  * Format :	gd

--- a/src/gmt_gdalread.h
+++ b/src/gmt_gdalread.h
@@ -199,4 +199,21 @@ struct GMT_GDALREAD_OUT_CTRL {
 	struct GDAL_BAND_FNAMES *band_field_names;
 };
 
+struct OGR_FEATURES {
+	int     n_rows, n_cols, n_layers;	/* n_rows, n_column, n_layers of the struct array */
+	int     n_filled;   /* Number of actually filled elements in the matrix */
+	int     is3D;       /* True when geometries have a z component */
+	unsigned int np;    /* Number of data points in this feature */
+	int     att_number; /* Feature's number of attributes */
+	char   *name, *wkt, *proj4; 
+	char   *type;	    /* Geometry type. E.g. Point, Polygon or LineString */
+	char  **att_names;	/* Names of the attributes of a Feature */
+	char  **att_values;	/* Values of the attributes of a Feature as strings */
+	int    *att_types;
+	int    *islands;
+	double  BoundingBox[6];
+	double *BBgeom;     /* Not currently assigned (would be the BoundingBox of each individual geometry) */
+	double *x, *y, *z;
+};
+
 #endif  /* GMT_GDALREAD_H */

--- a/src/gmt_notposix.h
+++ b/src/gmt_notposix.h
@@ -178,6 +178,7 @@
 #		pragma warning( disable : 4127 )	/* conditional expression is constant */
 #		pragma warning( disable : 4706 )	/* assignment within conditional expression */
 #		pragma warning( disable : 4204 )	/* nonstandard extension used : non-constant aggregate initializer */
+#		pragma warning( disable : 6334 )	/* sizeof operator applied to an expression with an operator might ... */
 		/* Issue warning 4244 (conversion of int64_t to int32_t) only once */
 /*#		pragma warning( once : 4244 4267 ) */
 #	 	if (_MSC_VER <= 1600)

--- a/src/gmt_ogrread.c
+++ b/src/gmt_ogrread.c
@@ -77,6 +77,7 @@
  */
 
 #include "gmt_gdalread.h"
+#include <ogr_api.h>
 
 GMT_LOCAL int get_data(struct GMT_CTRL *GMT, struct OGR_FEATURES *out, OGRFeatureH hFeature,
                        OGRFeatureDefnH hFeatureDefn, OGRGeometryH hGeom, int iLayer, int nFeature, int nLayers,

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -131,6 +131,7 @@ EXTERN_MSC OGRCoordinateTransformationH gmt_OGRCoordinateTransformation (struct 
 EXTERN_MSC int gmt_ogrproj (struct GMT_CTRL *GMT, char *pszSrcSRS, char *pszDstSRS, int n_pts,
                             double *xi, double *yi, double *zi, bool insitu, double *xo, double *yo, double *zo);
 EXTERN_MSC void gmt_ogrproj_one_pt (OGRCoordinateTransformationH hCT, double *xi, double *yi, double *zi);
+EXTERN_MSC struct OGR_FEATURES *gmt_ogrread(struct GMT_CTRL *GMT, char *ogr_filename);
 void gmt_proj4_fwd (struct GMT_CTRL *GMT, double xi, double yi, double *xo, double *yo);
 void gmt_proj4_inv (struct GMT_CTRL *GMT, double *xi, double *yi, double xo, double yo);
 #endif

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -131,9 +131,11 @@ EXTERN_MSC OGRCoordinateTransformationH gmt_OGRCoordinateTransformation (struct 
 EXTERN_MSC int gmt_ogrproj (struct GMT_CTRL *GMT, char *pszSrcSRS, char *pszDstSRS, int n_pts,
                             double *xi, double *yi, double *zi, bool insitu, double *xo, double *yo, double *zo);
 EXTERN_MSC void gmt_ogrproj_one_pt (OGRCoordinateTransformationH hCT, double *xi, double *yi, double *zi);
-EXTERN_MSC struct OGR_FEATURES *gmt_ogrread(struct GMT_CTRL *GMT, char *ogr_filename);
 void gmt_proj4_fwd (struct GMT_CTRL *GMT, double xi, double yi, double *xo, double *yo);
 void gmt_proj4_inv (struct GMT_CTRL *GMT, double *xi, double *yi, double xo, double yo);
+#	if (GDAL_VERSION_NUM >= 2000)
+		EXTERN_MSC struct OGR_FEATURES *gmt_ogrread(struct GMT_CTRL *GMT, char *ogr_filename);
+#	endif
 #endif
 
 /* gmt_fft.c: */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -133,7 +133,7 @@ EXTERN_MSC int gmt_ogrproj (struct GMT_CTRL *GMT, char *pszSrcSRS, char *pszDstS
 EXTERN_MSC void gmt_ogrproj_one_pt (OGRCoordinateTransformationH hCT, double *xi, double *yi, double *zi);
 void gmt_proj4_fwd (struct GMT_CTRL *GMT, double xi, double yi, double *xo, double *yo);
 void gmt_proj4_inv (struct GMT_CTRL *GMT, double *xi, double *yi, double xo, double yo);
-#	if (GDAL_VERSION_NUM >= 2000)
+#	if GDAL_VERSION_MAJOR >= 2
 		EXTERN_MSC struct OGR_FEATURES *gmt_ogrread(struct GMT_CTRL *GMT, char *ogr_filename);
 #	endif
 #endif


### PR DESCRIPTION
Start the work of reading the OGR vector formats directly via GDAL. The ``gmt_ogrreaf()`` uses a design inherited from it's Matlab ancestor in Mirone and hence it's structure must be improved to fit better with the GMT needs. But as it is we can already load data directly. We still need to write code to parse its contents and feed the corresponding GMT data structures, so as it is we can't use it yet but as a proof o concept I added one such type of function parser in Julia that converts the gmt_ogrreaf() output into a ``GMTdataset``. It works like this.

```
# Create an API session
API = GMT.GMT_Create_Session("GMT", 2, GMT.GMT_SESSION_NOEXIT + GMT.GMT_SESSION_EXTERNAL + GMT.GMT_SESSION_COLMAJOR);

# Read a shape file directly from ... wherever it is
ex = GMT.gmt_ogrread(API, "/vsicurl/https://raw.githubusercontent.com/OSGeo/gdal/master/autotest/ogr/data/poly.shp");

# Plot it
plot(GMT.ogr2GMTdataset(ex), show=1, fmt=:png)
```
![gmtjl_tmp](https://user-images.githubusercontent.com/537321/53456581-d5b3a800-3a26-11e9-911e-8a48d3a51e38.png)
