### PR TITLE
Remove GMT_TEST_DATA that is no longer used

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -114,12 +114,6 @@ if (NOT DEFINED GMT_RELEASE_PREFIX)
 	set (GMT_RELEASE_PREFIX ${GMT_BINARY_DIR}/gmt-${GMT_PACKAGE_VERSION})
 endif (NOT DEFINED GMT_RELEASE_PREFIX)
 
-# Default location of optional third-party files used by test suite
-# available from svn://gmtserver.soest.hawaii.edu/gmt-data
-if (NOT DEFINED GMT_TEST_DATA)
-	set (GMT_TEST_DATA ${GMT_SOURCE_DIR}/test/data)
-endif (NOT DEFINED GMT_TEST_DATA)
-
 # Default location of remote data server
 if (NOT DEFINED GMT_DATA_URL)
 	set (GMT_DATA_URL "http://www.soest.hawaii.edu/gmt/data")

--- a/cmake/ConfigUserTemplate.cmake
+++ b/cmake/ConfigUserTemplate.cmake
@@ -18,7 +18,7 @@
 # Use this file to override variables in 'ConfigDefault.cmake' on a per-user
 # basis.  First copy 'ConfigUserTemplate.cmake' to 'ConfigUser.cmake', then
 # edit 'ConfigUser.cmake'.  'ConfigUser.cmake' is not version controlled
-# (currently listed in svn:ignore property)
+# (currently listed in .gitignore).
 #
 # Note: CMake considers an empty string, "FALSE", "OFF", "NO", or any string
 # ending in "-NOTFOUND" to be false (this happens to be case-insensitive, so
@@ -214,10 +214,6 @@
 #set (MODERNIZE_TESTS TRUE)
 # Number of parallel test jobs with "make check":
 #set (N_TEST_JOBS 4)
-
-# Location of optional third-party files used by test suite available from
-# svn://gmtserver.soest.hawaii.edu/gmt-data [${GMT_SOURCE_DIR}/test/data]
-#set (GMT_TEST_DATA "test_data_path")
 
 # Enable this option to run GMT programs from within ${GMT_BINARY_DIR} without
 # installing or setting GMT_SHAREDIR and GMT_USERDIR first. This is required


### PR DESCRIPTION
GMT_TEST_DATA is no longer used in GMT.