### PR TITLE
Find git and unix commands before including ConfigCMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,14 +69,14 @@ project (GMT C)
 set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/"
 	CACHE INTERNAL "Location of our custom CMake modules." FORCE)
 
-# Include configuration options (default options and options overridden by user).
-include (ConfigCMake)
-
 # Find UNIX commands
 include (FindUnixCommands)
 find_program (GIT git)
 find_program (GS gs gswin64)
 find_program (XZ NAMES xz)
+
+# Include configuration options (default options and options overridden by user).
+include (ConfigCMake)
 
 # Global test target
 add_custom_target (check


### PR DESCRIPTION
This PR fixes #352.

ConfigCMake needs GIT to determine the short SHA. However, the GIT variable is set after including ConfigCMake.cmake. This explains why the short SHA is missing. 

This PR changes the order of including ConfigCMake and finding git.

