### PR TITLE
Initialize to NULL

### DIFF
--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -341,7 +341,7 @@ int GMT_grdvector (void *V_API, int mode, void *args) {
 
 	struct GMT_GRID *Grid[2] = {NULL, NULL};
 	struct GMT_PALETTE *P = NULL;
-	struct GMT_PEN last_headpen = NULL;
+	struct GMT_PEN last_headpen;
 	struct GRDVECTOR_CTRL *Ctrl = NULL;
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;	/* General GMT internal parameters */
 	struct GMT_OPTION *options = NULL;
@@ -365,6 +365,7 @@ int GMT_grdvector (void *V_API, int mode, void *args) {
 	
 	/*---------------------------- This is the grdvector main code ----------------------------*/
 
+	gmt_M_memset (&last_headpen, 1, struct GMT_PEN);		/* Initilaize members to zero */
 	GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Processing input grids\n");
 	d_col = d_row = 1;
 	col_0 = row_0 = 0;

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -341,7 +341,7 @@ int GMT_grdvector (void *V_API, int mode, void *args) {
 
 	struct GMT_GRID *Grid[2] = {NULL, NULL};
 	struct GMT_PALETTE *P = NULL;
-	struct GMT_PEN last_headpen;
+	struct GMT_PEN last_headpen = NULL;
 	struct GRDVECTOR_CTRL *Ctrl = NULL;
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;	/* General GMT internal parameters */
 	struct GMT_OPTION *options = NULL;


### PR DESCRIPTION
This is in response to this compiler warning. But I'm not certain that's the only fix.
``c:\progs_cygw\gmtdev\gmt5\master\src\grdvector.c(650) : warning C4700: uninitialized local variable 'last_headpen' used``


