### PR TITLE
pslegend could not plot custom symbol

### DIFF
--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -1214,7 +1214,10 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 							S[SYM]->data[GMT_X][0] = x_off + off_ss;
 							S[SYM]->data[GMT_Y][0] = row_base_y;
 							S[SYM]->n_rows = 1;
-							sprintf (sub, "%c", symbol[0]);
+							if (symbol[0] == 'k' || symbol[0] == 'K')	/* Custom symbols need the full name after k */
+								sprintf (sub, "%s", symbol);
+							else	/* Just the symbol code is needed */
+								sprintf (sub, "%c", symbol[0]);
 							if (symbol[0] == 'E' || symbol[0] == 'e') {	/* Ellipse */
 								if (strchr (size, ',')) {	/* We got dir,major,minor instead of just size; parse and use */
 									sscanf (size, "%[^,],%[^,],%s", A, B, C);


### PR DESCRIPTION
There was no provision in symbol parsing in pslegend that looked for the custom symbol, with result that the name of the custom symbol was dropped before passing to psxy.  Now fixed and addresses issue #442.
