### PR TITLE
Disallow negative contour intervals

### DIFF
--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -401,8 +401,12 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDCONTOUR_CTRL *Ctrl, struct 
 				}
 				else if (opt->arg[0] == '+' && (isdigit(opt->arg[1]) || strchr ("-+.", opt->arg[1])))
 					Ctrl->C.single_cont = atof (&opt->arg[1]);
-				else
+				else if (opt->arg[0] != '-')
 					Ctrl->C.interval = atof (opt->arg);
+				else {
+					GMT_Report (API, GMT_MSG_NORMAL, "Syntax error -C: Countour interval cannot be negative (%s)\n", opt->arg);
+					n_errors++;
+				}
 				break;
 			case 'D':	/* Dump file name */
 				Ctrl->D.active = true;

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -559,8 +559,12 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCONTOUR_CTRL *Ctrl, struct G
 				}
 				else if (opt->arg[0] == '+' && (isdigit(opt->arg[1]) || strchr ("-+.", opt->arg[1])))
 					Ctrl->C.single_cont = atof (&opt->arg[1]);
-				else
+				else if (opt->arg[0] != '-')
 					Ctrl->C.interval = atof (opt->arg);
+				else {
+					GMT_Report (API, GMT_MSG_NORMAL, "Syntax error -C: Countour interval cannot be negative (%s)\n", opt->arg);
+					n_errors++;
+				}
 				break;
 			case 'D':	/* Dump contours */
 				Ctrl->D.active = true;


### PR DESCRIPTION
Stuff like **-C**-100 should result in  an error since intervals cannot be negative.
Fixes #456