### PR TITLE
Add option to suppress logo label

### DIFF
--- a/doc/rst/source/gmtlogo.rst
+++ b/doc/rst/source/gmtlogo.rst
@@ -18,6 +18,7 @@ Synopsis
 [ |-J|\ *parameters* ] [ |-J|\ **z**\ \|\ **Z**\ *parameters* ] [ |-K| ]
 [ |-O| ] [ |-P| ]
 [ |SYN_OPT-Rz| ]
+[ |-S|\ [\ **l**\ \|\ **n**\ \|\ **u**\ ] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT-X| ]

--- a/doc/rst/source/gmtlogo_common.rst_
+++ b/doc/rst/source/gmtlogo_common.rst_
@@ -55,6 +55,14 @@ Optional Arguments
 .. |Add_-R| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-R.rst_
 
+.. _-S:
+
+**-S**\ [\ **l**\ \|\ **n**\ \|\ **u**\ ]
+    Control what is written beneath the map portion of the logo.
+    Append **l** (or skip **-S** entirely) to plot the text label "The Generic Mapping Tools"
+    beneath the logo.  Append **n** to skip the label placement, and append
+    **u** to place the URL to the GMT site instead [plot the label].
+
 .. |Add_-Rz| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-Rz.rst_
 

--- a/doc/rst/source/logo.rst
+++ b/doc/rst/source/logo.rst
@@ -17,6 +17,7 @@ Synopsis
 [ |-F|\ [\ **+c**\ *clearances*][\ **+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]][\ **+p**\ [*pen*]][\ **+r**\ [*radius*\ ]][\ **+s**\ [[*dx*/*dy*/][*shade*\ ]]] ]
 [ |-J|\ *parameters* ] [ |-J|\ **z**\ \|\ **Z**\ *parameters* ]
 [ |SYN_OPT-Rz| ]
+[ |-S|\ [\ **l**\ \|\ **n**\ \|\ **u**\ ] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT-X| ]


### PR DESCRIPTION
There are times when we want to place the the GMT logo without the text beneat, or perhaps we want to list the URL to the main GMT site.  This new option **-S** allows for those three scenarios.  The default (no **-S**, or -**Sl**) gives the original result.
