### PR TITLE
WIP: Appveyor for Windows builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ environment:
     #  CMAKE_PREFIX_PATH: "%CONDA_INSTALL_DIR%\\Library"
 
 cache:
-  - "%APPVEYOR_BUILD_FOLDER%\\build" -> .appveyor.yml
+  - "%APPVEYOR_BUILD_FOLDER%\\build"
 
 install:
   # install netcdf, curl, gdal, pcre via conda

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ environment:
     #  CMAKE_PREFIX_PATH: "%CONDA_INSTALL_DIR%\\Library"
 
 cache:
-  - "%APPVEYOR_BUILD_FOLDER%\\build"
+  - "C:\\projects\\gmt\\build -> .appveyor.yml"
 
 install:
   # install netcdf, curl, gdal, pcre via conda

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ environment:
     #  CMAKE_PREFIX_PATH: "%CONDA_INSTALL_DIR%\\Library"
 
 cache:
-  - "%APPVEYOR_BUILD_FOLDER%\\build" -> appveyor.yml
+  - "%APPVEYOR_BUILD_FOLDER%\\build" -> .appveyor.yml
 
 install:
   # install netcdf, curl, gdal, pcre via conda

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,6 +66,7 @@ build_script:
   - cmake --build . --config Release --target install
 
 after_build:
+  - which gmt
   - gmt --version
   - gmt defaults -Vd
   - gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,69 @@
+image: Visual Studio 2017
+
+version: 'build-{build}'
+
+clone_depth: 1
+
+# Only build pushes to select branches and tags.
+branches:
+  only:
+    - master
+    # Regex to build tagged commits with version numbers
+    - /\d+\.\d+(\.\d+)?(\S*)?$/
+
+environment:
+  global:
+    CMAKE_INSTALL_PREFIX: "C:\\programs\\gmt6"
+    PATH: "%CMAKE_INSTALL_PREFIX%\\bin;%PATH%"
+    GMT_MIRROR: "https://mirrors.ustc.edu.cn/gmt/"
+    GSHHG: gshhg-gmt-2.3.7.tar.gz
+    DCW: dcw-gmt-1.1.4.tar.gz
+  matrix:
+    # 32 bit
+    - CMAKE_GENERATOR: "Visual Studio 15 2017"
+      CONDA_INSTALL_DIR: "C:\\Miniconda3"
+      CMAKE_PREFIX_PATH: "%CONDA_INSTALL_DIR%\\Library"
+    # 64 bit
+    #- CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
+    #  CONDA_INSTALL_DIR: "C:\\Miniconda3-x64"
+    #  CMAKE_PREFIX_PATH: "%CONDA_INSTALL_DIR%\\Library"
+
+install:
+  # install netcdf, curl, gdal, pcre via conda
+  - call %CONDA_INSTALL_DIR%\Scripts\activate.bat
+  - conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
+  - conda install libnetcdf libcurl libgdal pcre
+  # install ghostscropt and graphicsmagick via chocolatey
+  - cinst ghostscript graphicsmagick
+  # download gshhg data
+  - appveyor DownloadFile %GMT_MIRROR%/%GSHHG%
+  - mkdir gmt-gshhg
+  - tar xvf %GSHHG% -C gmt-gshhg --strip-components=1
+  # download dcw data
+  - appveyor DownloadFile %GMT_MIRROR%/%DCW%
+  - mkdir gmt-dcw
+  - tar xvf %DCW% -C gmt-dcw --strip-components=1
+  - del %GSHHG% %DCW%
+
+# No tests because cmake cannot find graphicsmagick correctly
+before_build:
+  - echo set (CMAKE_C_FLAGS "/D_CRT_SECURE_NO_WARNINGS /D_CRT_SECURE_NO_DEPRECATE ${CMAKE_C_FLAGS}") > cmake/ConfigUser.cmake
+  - echo set (CMAKE_C_FLAGS "/D_CRT_NONSTDC_NO_DEPRECATE /D_SCL_SECURE_NO_DEPRECATE ${CMAKE_C_FLAGS}") >> cmake/ConfigUser.cmake
+#  - echo enable_testing() > cmake/ConfigUser.cmake
+#  - echo set (DO_EXAMPLES TRUE) >> cmake/ConfigUser.cmake
+#  - echo set (DO_TESTS TRUE) >> cmake/ConfigUser.cmake
+#  - echo set (N_TEST_JOBS 2) >> cmake/ConfigUser.cmake
+  - cat cmake/ConfigUser.cmake
+
+build_script:
+  - if not exist "build" mkdir build
+  - cd build
+  - cmake .. -G "%CMAKE_GENERATOR%" -DCMAKE_INSTALL_PREFIX=%CMAKE_INSTALL_PREFIX% -DCMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%
+  - cmake --build . --config Release
+  - cmake --build . --config Release --target install
+
+after_build:
+  - gmt --version
+  - gmt defaults -Vd
+  - gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
+  - gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -Vd && gmt end

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,6 +28,9 @@ environment:
     #  CONDA_INSTALL_DIR: "C:\\Miniconda3-x64"
     #  CMAKE_PREFIX_PATH: "%CONDA_INSTALL_DIR%\\Library"
 
+cache:
+  - "%APPVEYOR_BUILD_FOLDER%\\build" -> appveyor.yml
+
 install:
   # install netcdf, curl, gdal, pcre via conda
   - call %CONDA_INSTALL_DIR%\Scripts\activate.bat

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Generic Mapping Tools
 
 [![TravisCI](http://img.shields.io/travis/GenericMappingTools/gmt/master.svg?label=TravisCI)](https://travis-ci.org/GenericMappingTools/gmt)
+[![AppVeyor](https://ci.appveyor.com/api/projects/status/github/GenericMappingTools/gmt?svg=true)](https://ci.appveyor.com/project/seisman/gmt)
 [![CodeCov](https://img.shields.io/codecov/c/github/GenericMappingTools/gmt.svg)](https://codecov.io/gh/GenericMappingTools/gmt/)
 [![Coverity](https://scan.coverity.com/projects/7153/badge.svg)](https://scan.coverity.com/projects/gmt)
 [![Documentation (development version)](https://img.shields.io/badge/docs-development-green.svg)](https://genericmappingtools.github.io/gmt/dev/)


### PR DESCRIPTION
This PR setups appveyor CI for windows builds. It uses conda to install all the dependencies (netcdf, pcre, gdal and curl) and uses Visual Studio 2017 to build.

See https://ci.appveyor.com/project/seisman/gmt for build reports.
