### PR TITLE
Let the QR symbol honor -G and -W if set

### DIFF
--- a/share/custom/QR.eps
+++ b/share/custom/QR.eps
@@ -1,10 +1,12 @@
 %!PS-Adobe-3.0 EPSF-3.0
 %%BoundingBox: 0 0 200 200
 % Made by Kristof Koch, February 28, 2019
+% psxy will define both QR_outline [false], QR_pen [undefined], and QR_fill [black]
 /QR {M 0 -6 D 6 0 D 0 6 D P F} bind def
 1 A
 0 200 M 0 -200 D 200 0 D 0 200 D P F
-0 A
+QR_outline {0 200 M 0 -200 D 200 0 D 0 200 D P V F U QR_pen S} {0 200 M 0 -200 D 200 0 D 0 200 D P F} ifelse
+QR_fill
 13 187 QR
 19 187 QR
 25 187 QR

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1091,6 +1091,18 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 			gmt_set_column (GMT, GMT_IN, ex1, GMT_IS_FLOAT);
 			delayed_unit_scaling = (S.u_set && S.u != GMT_INCH);
 		}
+		if (S.symbol == GMT_SYMBOL_CUSTOM && !strcmp (S.custom->name, "QR")) {
+			if (Ctrl->G.active)	/* Change color of QR code */
+				PSL_command (PSL, "/QR_fill {%s} def\n", PSL_makecolor (PSL, Ctrl->G.fill.rgb));
+			else	/* Default to black */
+				PSL_command (PSL, "/QR_fill {0 A} def\n");
+			if (Ctrl->W.active) {	/* Draw outline of QR code */
+				PSL_command (PSL, "/QR_outline true def\n");
+				PSL_command (PSL, "/QR_pen {%s} def\n",  PSL_makepen (PSL, Ctrl->W.pen.width, Ctrl->W.pen.rgb, Ctrl->W.pen.style, Ctrl->W.pen.offset));
+			}
+			else
+				PSL_command (PSL, "/QR_outline false def\n");
+		}
 		
 		do {	/* Keep returning records until we reach EOF */
 			if ((In = GMT_Get_Record (API, GMT_READ_DATA, NULL)) == NULL) {	/* Read next record, get NULL if special case */

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -787,6 +787,18 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 				gmt_set_column (GMT, GMT_IN, ex3, GMT_IS_GEODIMENSION);
 			}
 		}
+		else if (S.symbol == GMT_SYMBOL_CUSTOM && !strcmp (S.custom->name, "QR")) {
+			if (Ctrl->G.active)	/* Change color of QR code */
+				PSL_command (PSL, "/QR_fill {%s} def\n", PSL_makecolor (PSL, Ctrl->G.fill.rgb));
+			else	/* Default to black */
+				PSL_command (PSL, "/QR_fill {0 A} def\n");
+			if (Ctrl->W.active) {	/* Draw outline of QR code */
+				PSL_command (PSL, "/QR_outline true def\n");
+				PSL_command (PSL, "/QR_pen {%s} def\n",  PSL_makepen (PSL, Ctrl->W.pen.width, Ctrl->W.pen.rgb, Ctrl->W.pen.style, Ctrl->W.pen.offset));
+			}
+			else
+				PSL_command (PSL, "/QR_outline false def\n");
+		}
 		if (S.read_size && GMT->current.io.col[GMT_IN][ex1].convert) {	/* Doing math on the size column, must delay unit conversion unless inch */
 			gmt_set_column (GMT, GMT_IN, ex1, GMT_IS_FLOAT);
 			delayed_unit_scaling[GMT_X] = (S.u_set && S.u != GMT_INCH);


### PR DESCRIPTION
This way the QR code can be set in a different color.  If **-W** is used then we also draw the outline of the quiet box around the code.  The quiet area is still painted white always.  We could decide to let users paint the quite area separately.  In most cases the background is probably white already but if it is a map or something it is probably OK to ask the user to paint that square.  Thoughts?