### PR TITLE
Update the docs relating to user fonts

### DIFF
--- a/doc/rst/source/GMT_Docs.rst
+++ b/doc/rst/source/GMT_Docs.rst
@@ -6936,14 +6936,14 @@ Using non-default fonts with GMT
 --------------------------------
 
 To add additional fonts that you may have purchased or that are
-available freely in the internet or at your institution, see the
-instructions in the ``PSL_custom_fonts.txt`` under the ``share/postscriptlight`` directory and continue reading. GMT does
-not read or process any font files and thus does not know anything about
+available freely in the internet or at your institution, you will need
+to tell GMT some basic information about such fonts. GMT does
+not actually read or process any font files and thus does not know anything about
 installed fonts and their metrics. In order to use extra fonts in
 GMT you need to specify the PostScript name of the relevant fonts in
-the file ``PSL_custom_fonts.txt``. You can either edit the existing file distributed with
-GMT to make the changes global or you can create a new file in the
-current working directory, e.g.,
+the file ``PSL_custom_fonts.txt``. We recommend you place this file in
+your GMT user directory (~/.gmt) as GMT will look there as well as in your
+home directory.  Below is an example of a typical entry for two separate fonts:
 
    ::
 
@@ -6951,13 +6951,14 @@ current working directory, e.g.,
     LinLibertineOB    0.700    0
 
 The format is a space delimited list of the PostScript font name, the
-font height-point size-ratio, and a boolean variable that tells GMT to
+font's height-point size-ratio, and a boolean variable that tells GMT to
 re-encode the font (if set to zero). The latter has to be set to zero as
 additional fonts will most likely not come in standard
 PostScript encoding. GMT determines how tall typical annotations
 might be from the font size ratio so that the vertical position of
-labels and titles can be adjusted to a more uniform typesetting. Now,
-you can set the GMT font parameters to your non-standard fonts:
+labels and titles can be adjusted to a more uniform typesetting. This
+ratio can be estimated from the height of the letter A for a unit font size.
+Now, you can set the GMT font parameters to your non-standard fonts:
 
    ::
 

--- a/doc/rst/source/GMT_Docs_classic.rst
+++ b/doc/rst/source/GMT_Docs_classic.rst
@@ -6991,9 +6991,6 @@ plotting of text-strings, see the man page for :doc:`pstext`.
 Using non-default fonts with GMT
 --------------------------------
 
-Using non-default fonts with GMT
---------------------------------
-
 To add additional fonts that you may have purchased or that are
 available freely in the internet or at your institution, you will need
 to tell GMT some basic information about such fonts. GMT does

--- a/doc/rst/source/GMT_Docs_classic.rst
+++ b/doc/rst/source/GMT_Docs_classic.rst
@@ -6991,15 +6991,18 @@ plotting of text-strings, see the man page for :doc:`pstext`.
 Using non-default fonts with GMT
 --------------------------------
 
+Using non-default fonts with GMT
+--------------------------------
+
 To add additional fonts that you may have purchased or that are
-available freely in the internet or at your institution, see the
-instructions in the ``PSL_custom_fonts.txt`` under the ``share/postscriptlight`` directory and continue reading. GMT does
-not read or process any font files and thus does not know anything about
+available freely in the internet or at your institution, you will need
+to tell GMT some basic information about such fonts. GMT does
+not actually read or process any font files and thus does not know anything about
 installed fonts and their metrics. In order to use extra fonts in
 GMT you need to specify the PostScript name of the relevant fonts in
-the file ``PSL_custom_fonts.txt``. You can either edit the existing file distributed with
-GMT to make the changes global or you can create a new file in the
-current working directory, e.g.,
+the file ``PSL_custom_fonts.txt``. We recommend you place this file in
+your GMT user directory (~/.gmt) as GMT will look there as well as in your
+home directory.  Below is an example of a typical entry for two separate fonts:
 
    ::
 
@@ -7007,13 +7010,14 @@ current working directory, e.g.,
     LinLibertineOB    0.700    0
 
 The format is a space delimited list of the PostScript font name, the
-font height-point size-ratio, and a boolean variable that tells GMT to
+font's height-point size-ratio, and a boolean variable that tells GMT to
 re-encode the font (if set to zero). The latter has to be set to zero as
 additional fonts will most likely not come in standard
 PostScript encoding. GMT determines how tall typical annotations
 might be from the font size ratio so that the vertical position of
-labels and titles can be adjusted to a more uniform typesetting. Now,
-you can set the GMT font parameters to your non-standard fonts:
+labels and titles can be adjusted to a more uniform typesetting. This
+ratio can be estimated from the height of the letter A for a unit font size.
+Now, you can set the GMT font parameters to your non-standard fonts:
 
    ::
 

--- a/doc/rst/source/text_notes.rst_
+++ b/doc/rst/source/text_notes.rst_
@@ -27,3 +27,8 @@ input), if specified, must appear before either of **+f** (read font from input)
 (read justification from input), if these are present.  This is necessary because the
 angle is a numerical column while font and justification must be encoded as part of the
 trailing text.
+
+Adding more fonts
+-----------------
+
+To add custom fonts, please see :ref:`General Features <non-default-fonts>`.

--- a/src/pstext.c
+++ b/src/pstext.c
@@ -302,6 +302,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 		GMT_Message (API, GMT_TIME_NONE, "\t------------------------------------\n");
 		for (i = 0; i < API->GMT->session.n_fonts; i++)
 			GMT_Message (API, GMT_TIME_NONE, "\t%3ld\t%s\n", i, API->GMT->session.font[i].name);
+		GMT_Message (API, GMT_TIME_NONE, "For additional fonts, see \"Using non-default fonts with GMT\" in the documentation.\n");
 	}
 
 	if (show_fonts) return (GMT_NOERROR);


### PR DESCRIPTION
Since the old share/postscriptlight directory is gone we had to update the instructions for what to do.
Fixes #470.
