### PR TITLE
Separate the making ellipse coordinates from plotting them

### DIFF
--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -60,7 +60,6 @@
  *	gmt_project_init :	Initialize parameters for grid/image transformations\n
  *	gmt_xy_to_geo :		Generic inverse x/y to lon/lat projection\n
  *	gmt_xyz_to_xy :		Generic xyz to xy projection\n
- *	map_xyz_to_xy_n :	Same for an array
  *
  * Internal GMT Functions include:
  *
@@ -247,7 +246,6 @@ enum GMT_side {
  */
 #define VAR_TO_STR(arg)      #arg
 #define Return(err) { GMT_Report(GMT->parent,GMT_MSG_NORMAL,"Internal Error = %s\n",VAR_TO_STR(err)); return (err);}
-
 
 /* Note by P. Wessel, 18-Oct-2012, updated 08-JAN-2014:
  * In the olden days, GMT only did great circle distances.  In GMT 4 we implemented geodesic
@@ -9433,4 +9431,79 @@ struct GMT_DATASEGMENT * gmt_get_smallcircle (struct GMT_CTRL *GMT, double plon,
 	S->n_rows = n;
 	gmt_set_seg_polar (GMT, S);				/* Prepare if a polar cap */
 	return (S);	/* Pass out the results */
+}
+
+GMT_LOCAL void ellipse_point (struct GMT_CTRL *GMT, double lon, double lat, double center, double sinp, double cosp, double major, double minor, double cos_azimuth, double sin_azimuth, double angle, double *plon, double *plat)
+{
+	/* Lon, lat is center of ellipse, our point is making an angle with the major axis. */
+	double x, y, x_prime, y_prime, rho, c, sin_c, cos_c;
+	sincos (angle, &y, &x);
+	x *= major;	y *= minor;
+	/* Get rotated coordinates in m */
+	x_prime = x * cos_azimuth - y * sin_azimuth;
+	y_prime = x * sin_azimuth + y * cos_azimuth;
+	/* Convert m back to lon lat */
+	rho = hypot (x_prime, y_prime);
+	c = rho / GMT->current.proj.EQ_RAD;
+	sincos (c, &sin_c, &cos_c);
+	*plat = d_asind (cos_c * sinp + (y_prime * sin_c * cosp / rho));
+	if ((lat - 90.0) > -GMT_CONV8_LIMIT)	/* origin in Northern hemisphere */
+		*plon = lon + d_atan2d (x_prime, -y_prime);
+	else if ((lat + 90.0) < GMT_CONV8_LIMIT)	/* origin in Southern hemisphere */
+		*plon = lon + d_atan2d (x_prime, y_prime);
+	else
+		*plon = lon + d_atan2d (x_prime * sin_c, (rho * cosp * cos_c - y_prime * sinp * sin_c));
+	while ((*plon - center) < -180.0) *plon += 360.0;
+	while ((*plon - center) > +180.0) *plon -= 360.0;
+}
+
+#define GMT_ELLIPSE_APPROX 72
+
+struct GMT_DATASEGMENT * gmt_get_geo_ellipse (struct GMT_CTRL *GMT, double lon, double lat, double major, double minor, double azimuth, uint64_t m) {
+	/* gmt_get_geo_ellipse takes the location, axes (in km), and azimuth of the ellipse's major axis
+	   and computes coordinates for an approximate ellipse using N-sided polygon.
+	   If m > 0 then we l\set N = m and use that many points.  Otherwise (m == 0), we will
+	   determine N by looking at the spacing between successive points for a trial N and
+	   then scale N up or down to satisfy the minimum point spacing criteria. */
+
+	uint64_t i, N;
+	double delta_azimuth, sin_azimuth, cos_azimuth, sinp, cosp, ax, ay, axx, ayy, bx, by, bxx, byy, L;
+	double center, *px = NULL, *py = NULL;
+	char header[GMT_LEN256] = {""};
+	struct GMT_DATASEGMENT *S = NULL;
+
+	major *= 500.0, minor *= 500.0;	/* Convert to meters (x1000) of semi-major (/2) and semi-minor axes */
+	/* Set up local azimuthal equidistant projection */
+	sincosd (90.0 - azimuth, &sin_azimuth, &cos_azimuth);
+	sincosd (lat, &sinp, &cosp);
+
+	center = (GMT->current.proj.central_meridian < GMT->common.R.wesn[XLO] || GMT->current.proj.central_meridian > GMT->common.R.wesn[XHI]) ? 0.5 * (GMT->common.R.wesn[XLO] + GMT->common.R.wesn[XHI]) : GMT->current.proj.central_meridian;
+
+	if (m == 0) {	/* Determine N */
+		delta_azimuth = 2.0 * M_PI / GMT_ELLIPSE_APPROX;	/* Initial guess of angular spacing */
+		/* Compute distance between first two points and compare to map_line_step to determine angular spacing */
+		ellipse_point (GMT, lon, lat, center, sinp, cosp, major, minor, cos_azimuth, sin_azimuth, 0.0, &ax, &ay);
+		ellipse_point (GMT, lon, lat, center, sinp, cosp, major, minor, cos_azimuth, sin_azimuth, delta_azimuth, &bx, &by);
+		gmt_geo_to_xy (GMT, ax, ay, &axx, &ayy);
+		gmt_geo_to_xy (GMT, bx, by, &bxx, &byy);
+		L = hypot (axx - bxx, ayy - byy);
+		N = (uint64_t) irint (GMT_ELLIPSE_APPROX * L / GMT->current.setting.map_line_step);
+		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Ellipse will be approximated by %d-sided polygon\n", N);
+		/* Approximate ellipse by a N-sided polygon */
+	}
+	else	/* Approximate ellipse by a m-sided polygon */
+		N = m;
+	delta_azimuth = 2.0 * M_PI / N;
+	/* Allocate datasetgment of the right size */
+	S = GMT_Alloc_Segment (GMT->parent, GMT_NO_STRINGS, N+1, 2, NULL, NULL);
+	px = S->data[GMT_X];	py = S->data[GMT_Y];
+
+	for (i = 0; i < N; i++)
+		ellipse_point (GMT, lon, lat, center, sinp, cosp, major, minor, cos_azimuth, sin_azimuth, i * delta_azimuth, &px[i], &py[i]);
+
+	/* Explicitly close the polygon */
+	px[N] = px[0], py[N] = py[0];
+	sprintf (header, "Ellipse around %g/%g with major/minor axes %g/%g km and azimuth %g approximate by %" PRIu64 "points", lon, lat, major, minor, azimuth, N);
+	S->header = strdup (header);
+	return (S);
 }

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -197,7 +197,7 @@ EXTERN_MSC void gmt_draw_map_inset (struct GMT_CTRL *GMT, struct GMT_MAP_INSET *
 EXTERN_MSC void gmt_draw_map_panel (struct GMT_CTRL *GMT, double x, double y, unsigned int mode, struct GMT_MAP_PANEL *P);
 EXTERN_MSC void gmt_geo_line (struct GMT_CTRL *GMT, double *lon, double *lat, uint64_t n);
 EXTERN_MSC void gmt_geo_polygons (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S);
-EXTERN_MSC void gmt_geo_ellipse (struct GMT_CTRL *GMT, double lon, double lat, double major, double minor, double azimuth);
+EXTERN_MSC void gmt_plot_geo_ellipse (struct GMT_CTRL *GMT, double lon, double lat, double major, double minor, double azimuth);
 EXTERN_MSC void gmt_geo_wedge (struct GMT_CTRL *GMT, double xlon, double xlat, double radius, char unit, double az_start, double az_stop, unsigned int mode);
 EXTERN_MSC void gmt_geo_rectangle (struct GMT_CTRL *GMT, double lon, double lat, double width, double height, double azimuth);
 EXTERN_MSC unsigned int gmt_geo_vector (struct GMT_CTRL *GMT, double lon0, double lat0, double azimuth, double length, struct GMT_PEN *pen, struct GMT_SYMBOL *S);
@@ -423,6 +423,7 @@ EXTERN_MSC void gmt_gcal_from_dt (struct GMT_CTRL *GMT, double t, struct GMT_GCA
 
 /* gmt_map.c: */
 
+EXTERN_MSC struct GMT_DATASEGMENT * gmt_get_geo_ellipse (struct GMT_CTRL *GMT, double lon, double lat, double major, double minor, double azimuth, uint64_t m);
 EXTERN_MSC double gmt_half_map_width (struct GMT_CTRL *GMT, double y);
 EXTERN_MSC double gmt_line_length (struct GMT_CTRL *GMT, double x[], double y[], uint64_t n, bool project);
 EXTERN_MSC void gmt_wesn_search (struct GMT_CTRL *GMT, double xmin, double xmax, double ymin, double ymax, double *west, double *east, double *south, double *north);

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1384,13 +1384,13 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 						else if (S.symbol == PSL_ELLIPSE) {	/* Got axis in km */
 							if (may_intrude_inside) {	/* Must plot fill and outline separately */
 								gmt_setfill (GMT, &current_fill, 0);
-								gmt_geo_ellipse (GMT, in[GMT_X], in[GMT_Y], in[ex2], in[ex3], in[ex1]);
+								gmt_plot_geo_ellipse (GMT, in[GMT_X], in[GMT_Y], in[ex2], in[ex3], in[ex1]);
 								gmt_setpen (GMT, &current_pen);
 								PSL_setfill (PSL, GMT->session.no_rgb, outline_active);
-								gmt_geo_ellipse (GMT, in[GMT_X], in[GMT_Y], in[ex2], in[ex3], in[ex1]);
+								gmt_plot_geo_ellipse (GMT, in[GMT_X], in[GMT_Y], in[ex2], in[ex3], in[ex1]);
 							}
 							else
-								gmt_geo_ellipse (GMT, in[GMT_X], in[GMT_Y], in[ex2], in[ex3], in[ex1]);
+								gmt_plot_geo_ellipse (GMT, in[GMT_X], in[GMT_Y], in[ex2], in[ex3], in[ex1]);
 						}
 						else {
 							if (may_intrude_inside) {	/* Must plot fill and outline separately */

--- a/src/psxy_new.c
+++ b/src/psxy_new.c
@@ -1679,13 +1679,13 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 								else if (S.symbol == PSL_ELLIPSE) {	/* Got axis in km */
 									if (may_intrude_inside) {	/* Must plot fill and outline separately */
 										gmt_setfill (GMT, &current_fill, 0);
-										gmt_geo_ellipse (GMT, in[GMT_X], in[GMT_Y], in[ex2], in[ex3], in[ex1]);
+										gmt_plot_geo_ellipse (GMT, in[GMT_X], in[GMT_Y], in[ex2], in[ex3], in[ex1]);
 										gmt_setpen (GMT, &current_pen);
 										PSL_setfill (PSL, GMT->session.no_rgb, outline_active);
-										gmt_geo_ellipse (GMT, in[GMT_X], in[GMT_Y], in[ex2], in[ex3], in[ex1]);
+										gmt_plot_geo_ellipse (GMT, in[GMT_X], in[GMT_Y], in[ex2], in[ex3], in[ex1]);
 									}
 									else
-										gmt_geo_ellipse (GMT, in[GMT_X], in[GMT_Y], in[ex2], in[ex3], in[ex1]);
+										gmt_plot_geo_ellipse (GMT, in[GMT_X], in[GMT_Y], in[ex2], in[ex3], in[ex1]);
 								}
 								else {
 									if (may_intrude_inside) {	/* Must plot fill and outline separately */

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1335,7 +1335,7 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 					case PSL_ELLIPSE:
 						gmt_plane_perspective (GMT, GMT_Z, data[i].z);
 						if (data[i].flag & 2)
-							gmt_geo_ellipse (GMT, xpos[item], data[i].y, data[i].dim[1], data[i].dim[2], data[i].dim[0]);
+							gmt_plot_geo_ellipse (GMT, xpos[item], data[i].y, data[i].dim[1], data[i].dim[2], data[i].dim[0]);
 						else
 							PSL_plotsymbol (PSL, xpos[item], data[i].y, data[i].dim, PSL_ELLIPSE);
 						break;

--- a/src/t.lis
+++ b/src/t.lis
@@ -1,5 +1,0 @@
-./gmt_plot.c
-./gmt_prototypes.h
-./psxy.c
-./psxy_new.c
-./psxyz.c

--- a/src/t.lis
+++ b/src/t.lis
@@ -1,0 +1,5 @@
+./gmt_plot.c
+./gmt_prototypes.h
+./psxy.c
+./psxy_new.c
+./psxyz.c


### PR DESCRIPTION
The old _gmt_geo_ellipse_ would create coordinates for an ellipse and plot them on a geographic map in psxy and psxyz.  However, there are times when we may want to output such coordinates.  I have split that function into two functions _gmt_get_geo_ellipse_ and _gmt_plot_geo_ellipse_ where the latter calls the former.  We can now consider other uses of gmt_get_geo_ellipse.  Test run the same after as before my changes.
