### PR TITLE
Remove unused .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,0 @@
-/test export-ignore
-/ci export-ignore
-/.github export-ignore
-.gitignore export-ignore
-.gitattributes export-ignore
-.travis.yml export-ignore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,6 @@ if (GIT AND HAVE_GIT_VERSION)
 		COMMAND ${CMAKE_COMMAND} -E remove_directory ${GMT_RELEASE_PREFIX}/test)
 	add_custom_target (git_prune_files
 		COMMAND ${CMAKE_COMMAND} -E remove
-			${GMT_RELEASE_PREFIX}/.gitattributes
 			${GMT_RELEASE_PREFIX}/.gitignore
 			${GMT_RELEASE_PREFIX}/.travis.yml)
 	add_depend_to_target (git_prune_dirs git_export_release)


### PR DESCRIPTION
GMT no longer uses `git archive` to build source package since 0478cd0261163e239fabe1379a81bcba289d2c65, thus .gitattributes is no longer needed.