### PR TITLE
Add option -Z to project for generating coordinates of ellipse

### DIFF
--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -21,6 +21,7 @@ Synopsis
 [ |-T|\ *px*/*py* ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *w\_min*/*w\_max* ]
+[ |-Z|\ *major*/*minor*/*azimuth*\ [**+e**\ ] ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
 [ |SYN_OPT-e| ]
@@ -198,6 +199,15 @@ Optional Arguments
     Width controls. Project only those points whose *q* coordinate is
     within *w\_min* < *q* < *w\_max*. 
 
+**-Z**\  *major*/*minor*/*azimuth*\ [**+e**\ ] ]
+    Used in conjunction with **-C** (sets its center) and **-G** (sets the
+    distance increment) to create the coordinates of a geographic ellipse
+    with *major* and *minor* axes given in km and the *azimuth* of the
+    major axis in degrees.  Append **+e** to adjust the increment set via
+    **-G** so that the the ellipse has equal distance increments [Default
+    uses the given increment and closes the ellipse].
+
+
 .. |Add_-bi| replace:: [Default is 2 input columns]. 
 .. include:: explain_-bi.rst_
 
@@ -260,6 +270,13 @@ defined by the great circle from the pole to a point 15E,15N, try
    ::
 
     gmt project -C15/15 -T40/85 -G1/80 -L-45/45 > some_circle.xyp
+
+To generate points approximately every 10km along a an ellipse centered on (30W,70N) with
+major axis of 1500 km with azimuth of 30 degree and a minor axis of 600 km, try
+
+   ::
+
+    gmt project -C-30/70 -G10 -Z1500/600/30+e > ellipse.xyp
 
 To project the shiptrack gravity, magnetics, and bathymetry in
 c2610.xygmb along a great circle through an origin at 30S, 30W, the

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -9459,7 +9459,7 @@ GMT_LOCAL void ellipse_point (struct GMT_CTRL *GMT, double lon, double lat, doub
 
 #define GMT_ELLIPSE_APPROX 72
 
-struct GMT_DATASEGMENT * gmt_get_geo_ellipse (struct GMT_CTRL *GMT, double lon, double lat, double major, double minor, double azimuth, uint64_t m) {
+struct GMT_DATASEGMENT * gmt_get_geo_ellipse (struct GMT_CTRL *GMT, double lon, double lat, double major_km, double minor_km, double azimuth, uint64_t m) {
 	/* gmt_get_geo_ellipse takes the location, axes (in km), and azimuth of the ellipse's major axis
 	   and computes coordinates for an approximate ellipse using N-sided polygon.
 	   If m > 0 then we l\set N = m and use that many points.  Otherwise (m == 0), we will
@@ -9468,11 +9468,11 @@ struct GMT_DATASEGMENT * gmt_get_geo_ellipse (struct GMT_CTRL *GMT, double lon, 
 
 	uint64_t i, N;
 	double delta_azimuth, sin_azimuth, cos_azimuth, sinp, cosp, ax, ay, axx, ayy, bx, by, bxx, byy, L;
-	double center, *px = NULL, *py = NULL;
+	double major, minor, center, *px = NULL, *py = NULL;
 	char header[GMT_LEN256] = {""};
 	struct GMT_DATASEGMENT *S = NULL;
 
-	major *= 500.0, minor *= 500.0;	/* Convert to meters (x1000) of semi-major (/2) and semi-minor axes */
+	major = major_km * 500.0, minor = minor_km * 500.0;	/* Convert to meters (x1000) of semi-major (/2) and semi-minor axes */
 	/* Set up local azimuthal equidistant projection */
 	sincosd (90.0 - azimuth, &sin_azimuth, &cos_azimuth);
 	sincosd (lat, &sinp, &cosp);
@@ -9503,7 +9503,7 @@ struct GMT_DATASEGMENT * gmt_get_geo_ellipse (struct GMT_CTRL *GMT, double lon, 
 
 	/* Explicitly close the polygon */
 	px[N] = px[0], py[N] = py[0];
-	sprintf (header, "Ellipse around %g/%g with major/minor axes %g/%g km and azimuth %g approximate by %" PRIu64 "points", lon, lat, major, minor, azimuth, N);
+	sprintf (header, "Ellipse around %g/%g with major/minor axes %g/%g km and major axis azimuth %g approximated by %" PRIu64 " points", lon, lat, major_km, minor_km, azimuth, N);
 	S->header = strdup (header);
 	return (S);
 }


### PR DESCRIPTION
In conjunction with setting a center (**-C**) and an increment in km (**-G**), the new **-Z**_major_/_minor_/_azimuth_ option can specify the parameters of a geographic ellipse and return the coordinates that define its perimeter.  A modifier **+e** can be used to adjust the initial increment so that the adjusted increment fits exactly into the perimeter.

See discussion in issue #474 for some background.