### PR TITLE
Add commit date to gmt version for development

### DIFF
--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -37,36 +37,6 @@ if (NOT CMAKE_BUILD_TYPE)
 	set (CMAKE_BUILD_TYPE Release)
 endif (NOT CMAKE_BUILD_TYPE)
 
-# Here we change it to add the git commit hash for non-public releases
-set (GMT_PACKAGE_VERSION_WITH_GIT_REVISION ${GMT_PACKAGE_VERSION})
-# Add the git commit hash to the package version if this is a non-public release.
-# A non-public release has an empty 'GMT_SOURCE_CODE_CONTROL_VERSION_STRING' variable in 'ConfigDefault.cmake'.
-#set (HAVE_GIT_VERSION)
-if (NOT GMT_SOURCE_CODE_CONTROL_VERSION_STRING)
-	# Get the location, inside the staging area location, to copy the application bundle to.
-	execute_process (
-		COMMAND ${GIT} describe --abbrev=7 --always --dirty
-		WORKING_DIRECTORY ${GMT_SOURCE_DIR}
-		RESULT_VARIABLE GIT_RETURN_CODE
-		OUTPUT_VARIABLE GIT_COMMIT_HASH
-		OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-		if (GIT_RETURN_CODE)
-			message (STATUS "Unable to determine git commit hash for non-public release - ignoring.")
-		else (GIT_RETURN_CODE)
-			if (GIT_COMMIT_HASH)
-				# Set the updated package version.
-				set (GMT_PACKAGE_VERSION_WITH_GIT_REVISION "${GMT_PACKAGE_VERSION}_${GIT_COMMIT_HASH}")
-				set (HAVE_GIT_VERSION TRUE)
-			endif (GIT_COMMIT_HASH)
-		endif (GIT_RETURN_CODE)
-endif (NOT GMT_SOURCE_CODE_CONTROL_VERSION_STRING)
-
-# The current GMT version.
-set (GMT_VERSION_STRING "${GMT_PACKAGE_NAME} ${GMT_PACKAGE_VERSION_WITH_GIT_REVISION}")
-
-set (GMT_LONG_VERSION_STRING "${GMT_PACKAGE_NAME} - ${GMT_PACKAGE_DESCRIPTION_SUMMARY}, Version ${GMT_PACKAGE_VERSION_WITH_GIT_REVISION}")
-
 # Get date
 if(DEFINED ENV{SOURCE_DATE_EPOCH})
 	EXECUTE_PROCESS(
@@ -98,6 +68,36 @@ set (_today)
 if (NOT GMT_VERSION_YEAR)
 	set (GMT_VERSION_YEAR ${YEAR})
 endif (NOT GMT_VERSION_YEAR)
+
+# Here we change it to add the git commit hash and date for non-public releases
+set (GMT_PACKAGE_VERSION_WITH_GIT_REVISION ${GMT_PACKAGE_VERSION})
+# Add the git commit hash and date to the package version if this is a non-public release.
+# A non-public release has an empty 'GMT_SOURCE_CODE_CONTROL_VERSION_STRING' variable in 'ConfigDefault.cmake'.
+#set (HAVE_GIT_VERSION)
+if (NOT GMT_SOURCE_CODE_CONTROL_VERSION_STRING)
+	# Get the location, inside the staging area location, to copy the application bundle to.
+	execute_process (
+		COMMAND ${GIT} describe --abbrev=7 --always --dirty
+		WORKING_DIRECTORY ${GMT_SOURCE_DIR}
+		RESULT_VARIABLE GIT_RETURN_CODE
+		OUTPUT_VARIABLE GIT_COMMIT_HASH
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+		if (GIT_RETURN_CODE)
+			message (STATUS "Unable to determine git commit hash for non-public release - ignoring.")
+		else (GIT_RETURN_CODE)
+			if (GIT_COMMIT_HASH)
+				# Set the updated package version.
+				set (GMT_PACKAGE_VERSION_WITH_GIT_REVISION "${GMT_PACKAGE_VERSION}_${GIT_COMMIT_HASH}_${YEAR}.${MONTH}.${DAY}")
+				set (HAVE_GIT_VERSION TRUE)
+			endif (GIT_COMMIT_HASH)
+		endif (GIT_RETURN_CODE)
+endif (NOT GMT_SOURCE_CODE_CONTROL_VERSION_STRING)
+
+# The current GMT version.
+set (GMT_VERSION_STRING "${GMT_PACKAGE_NAME} ${GMT_PACKAGE_VERSION_WITH_GIT_REVISION}")
+
+set (GMT_LONG_VERSION_STRING "${GMT_PACKAGE_NAME} - ${GMT_PACKAGE_DESCRIPTION_SUMMARY}, Version ${GMT_PACKAGE_VERSION_WITH_GIT_REVISION}")
 
 # apply license restrictions
 if (LICENSE_RESTRICTED) # on


### PR DESCRIPTION
**Description of proposed changes**

Adding commit date to gmt version:
```
$ gmt --version
6.0.0_b1eb4c7_2019.03.05

$ gmt psxy -  
psxy [core] 6.0.0_b1eb4c7_2019.03.05 [64-bit] - Plot lines, polygons, and symbols on maps
```



<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #59.


