### PR TITLE
Add commit date to gmt version for development

### DIFF
--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -54,9 +54,17 @@ if (NOT GMT_SOURCE_CODE_CONTROL_VERSION_STRING)
 		if (GIT_RETURN_CODE)
 			message (STATUS "Unable to determine git commit hash for non-public release - ignoring.")
 		else (GIT_RETURN_CODE)
-			if (GIT_COMMIT_HASH)
-				# Set the updated package version.
-				set (GMT_PACKAGE_VERSION_WITH_GIT_REVISION "${GMT_PACKAGE_VERSION}_${GIT_COMMIT_HASH}")
+			if (GIT_COMMIT_HASH)				# Set the updated package version.
+				# get commit date
+				execute_process (
+					COMMAND ${GIT} log -1 --date=short --pretty=format:%cd
+					WORKING_DIRECTORY ${GMT_SOURCE_DIR}
+					RESULT_VARIABLE GIT_DATE_RETURN_CODE
+					OUTPUT_VARIABLE GIT_COMMIT_DATE
+					OUTPUT_STRIP_TRAILING_WHITESPACE)
+				string(REPLACE "-" "." GIT_COMMIT_DATE "${GIT_COMMIT_DATE}")
+
+				set (GMT_PACKAGE_VERSION_WITH_GIT_REVISION "${GMT_PACKAGE_VERSION}_${GIT_COMMIT_HASH}_${GIT_COMMIT_DATE}")
 				set (HAVE_GIT_VERSION TRUE)
 			endif (GIT_COMMIT_HASH)
 		endif (GIT_RETURN_CODE)


### PR DESCRIPTION
**Description of proposed changes**

This PR adds commit date to gmt version. The commit date is obtained from
`git log -1 --date=short --pretty=format:%cd`.


```
$ gmt --version
6.0.0_00442fc_2019.03.05
$ gmt psxy -                                                                                         
psxy [core] 6.0.0_00442fc_2019.03.05 [64-bit] - Plot lines, polygons, and symbols on maps
```
<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #59.