### PR TITLE
Numbering of internal PS images off by one

### DIFF
--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -1613,8 +1613,8 @@ static int psl_pattern_cleanup (struct PSL_CTRL *PSL) {
 	PSL_comment (PSL, "Undefine patterns and images\n");
 	for (image_no = 0; image_no < PSL_N_PATTERNS * 2; image_no++) {
 		if (PSL->internal.pattern[image_no].status) {
-			PSL_command (PSL, "currentdict /image%d undef\n", image_no);
-			PSL_command (PSL, "currentdict /pattern%d undef\n", image_no);
+			PSL_command (PSL, "currentdict /image%d undef\n", image_no+1);
+			PSL_command (PSL, "currentdict /pattern%d undef\n", image_no+1);
 		}
 	}
 	return (PSL_NO_ERROR);


### PR DESCRIPTION
When we use a pattern, say number 10, then we define internally something like

`/image10 { ...lots of bits. def
`

and when done we remove from the dictionary:

`currentdict /image10 undef
`

Except in our code the number was off by one (we undef number 9 instead) since the loop starts at 0 but the image number starts at 1.  A bug with no apparent side-effects but a bug nonetheless.
