### PR TITLE
Default -F did not set key internal bool variable

### DIFF
--- a/src/gmtlogo.c
+++ b/src/gmtlogo.c
@@ -284,9 +284,10 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMTLOGO_CTRL *Ctrl, struct GMT
 				break;
 		}
 	}
-	if (!Ctrl->D.active) {
-		Ctrl->D.refpoint = gmt_get_refpoint (GMT, "x0/0+w2i", 'D');	/* Default if no -D given */
-		if (gmt_get_modifier (Ctrl->D.refpoint->args, 'w', string))	/* Get logo width */
+	if (!Ctrl->D.active) {	/* Default to -Dx0/0+w2i if no -D given */
+		if ((Ctrl->D.refpoint = gmt_get_refpoint (GMT, "x0/0+w2i", 'D')) == NULL)	/* Cannot happen but Coverity thinks so */
+			n_errors++;
+		else if (gmt_get_modifier (Ctrl->D.refpoint->args, 'w', string))	/* Get logo width */
 			Ctrl->D.width = gmt_M_to_inch (GMT, string);
 		Ctrl->D.active = true;
 	}

--- a/src/grdmask.c
+++ b/src/grdmask.c
@@ -223,8 +223,10 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDMASK_CTRL *Ctrl, struct GMT
 					Ctrl->S.mode = GRDMASK_N_CART_MASK;
 				}
 				else {		/* Gave -S[-|=|+]<radius>[d|e|f|k|m|M|n|c] which means radius is fixed or 0 */ 
-					if (opt->arg[strlen(opt->arg)-1] == 'c') 	/* A n of cells request for radius. The problem is that */
-						S_copy = strdup (opt->arg);				/* we can't process it yet because we need -I. So, delay it */
+					if (opt->arg[strlen(opt->arg)-1] == 'c') { 	/* A n of cells request for radius. The problem is that */
+						if (S_copy) free (S_copy);
+						S_copy = strdup (opt->arg);		/* we can't process it yet because we need -I. So, delay it */
+					}
 					else
 						Ctrl->S.mode = gmt_get_distance (GMT, opt->arg, &(Ctrl->S.radius), &(Ctrl->S.unit));
 				}

--- a/src/mgd77/mgd77track.c
+++ b/src/mgd77/mgd77track.c
@@ -613,8 +613,9 @@ int GMT_mgd77track (void *V_API, int mode, void *args) {
 	if (mode == GMT_MODULE_PURPOSE) return (usage (API, GMT_MODULE_PURPOSE));	/* Return the purpose of program */
 	options = GMT_Create_Options (API, mode, args);	if (API->error) return (API->error);	/* Set or get option list */
 
-	if ((GMT = gmt_init_module (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_KEYS, THIS_MODULE_NEEDS, &options, &GMT_cpy)) == NULL) bailout (API->error); /* Save current state */
 	if ((error = gmt_report_usage (API, options, 0, usage)) != GMT_NOERROR) bailout (error);	/* Give usage if requested */
+
+	if ((GMT = gmt_init_module (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_KEYS, THIS_MODULE_NEEDS, &options, &GMT_cpy)) == NULL) bailout (API->error); /* Save current state */
 
 	/* Parse the command-line arguments */
 

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -872,6 +872,7 @@ void psl_set_txt_array (struct PSL_CTRL *PSL, const char *prefix, char *array[],
 	for (i = 0; i < n; i++) {
 		outtext = psl_prepare_text (PSL, array[i]);	/* Expand escape codes and fix utf-8 characters */
 		PSL_command (PSL, "\t(%s)\n", outtext);
+		PSL_free (outtext);
 	}
 	PSL_command (PSL, "] def\n", n);
 }

--- a/src/project.c
+++ b/src/project.c
@@ -998,8 +998,10 @@ int GMT_project (void *V_API, int mode, void *args) {
 			if (z_first) {
 				uint64_t n_cols = gmt_get_cols (GMT, GMT_IN), n_tot_cols;
 				if (n_cols == 2 && P.want_z_output && In->text == NULL) {
-					if (z_set_auto) {	/* Implicitly set all output options earlier but input file has no z values... */
+					if (z_set_auto) {	/* Implicitly set -Fxyzpqrs earlier but input file has no z values so roll back to -Fxypqrs */
 						P.want_z_output = z_set_auto = false;
+						for (col = 3; col < P.n_outputs; col++) P.output_choice[col-1] = P.output_choice[col];	/* Shuffle pqrs to the left */
+						P.n_outputs--;
 					}
 					else {
 						GMT_Report (API, GMT_MSG_NORMAL, "No data columns or trailing text after leading coordinates, cannot use z flag in -F\n");

--- a/src/project.c
+++ b/src/project.c
@@ -705,11 +705,12 @@ int GMT_project (void *V_API, int mode, void *args) {
 		P.n_outputs++;
 	}
 
-	if (P.n_outputs == 0 && !Ctrl->G.active) {	/* Generate default -F setting (all) */
+	if (P.n_outputs == 0 && !Ctrl->G.active) {	/* Generate default -F setting (xyzpqrs) */
 		P.n_outputs = PROJECT_N_FARGS;
-		for (col = 0; col < 2; col++) P.output_choice[col] = (int)col;
-		P.output_choice[2] = -1;
-		for (col = 3; col < P.n_outputs; col++) P.output_choice[col] = (int)col - 1;
+		for (col = 0; col < 2; col++) P.output_choice[col] = (int)col;	/* Do xy */
+		P.output_choice[2] = -1;	/* Do z as col 2 */
+		P.want_z_output = true;
+		for (col = 3; col < P.n_outputs; col++) P.output_choice[col] = (int)col - 1;	/* Do pqrs */
 		P.find_new_point = true;
 	}
 	if (Ctrl->G.active) {	/* Hardwire 3 output columns and set their types */

--- a/src/psimage.c
+++ b/src/psimage.c
@@ -131,7 +131,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSIMAGE_CTRL *Ctrl, struct GMT
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int n_errors = 0, n_files = 0, ind, k = 0;
+	unsigned int n_errors = 0, n_files = 0, ind = PSIMG_FGD, k = 0;
 	int n;
 	bool p_fail = false;
 	char string[GMT_LEN256] = {""}, *p = NULL;


### PR DESCRIPTION
When no **-F** is given we default to  **-Fxyzpqrs**, and when **z** is included we need to set P.want_z_output = true; for proper processing. This was done when **-F** was processed but not if -F was not given.  Closes #486.
