### PR TITLE
Do not try to check if option is in gmt.history

### DIFF
--- a/src/docs.c
+++ b/src/docs.c
@@ -92,8 +92,6 @@ int GMT_docs (void *V_API, int mode, void *args) {
 	/* Parse the command-line arguments */
 
 	if ((GMT = gmt_init_module (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_KEYS, THIS_MODULE_NEEDS, &options, &GMT_cpy)) == NULL) bailout (API->error); /* Save current state */
-	if (GMT_Parse_Common (API, THIS_MODULE_OPTIONS, options)) Return (API->error);
-	if ((error = parse (GMT, options)) != 0) Return (error);
 
 	/*---------------------------- This is the docs main code ----------------------------*/
 


### PR DESCRIPTION
Fix #496
Even if the passed option does not exist, it will open the docs of the stated module.