### PR TITLE
Fix several typos in documentation

### DIFF
--- a/doc/rst/source/explain_-f_full.rst_
+++ b/doc/rst/source/explain_-f_full.rst_
@@ -6,7 +6,7 @@
     to input or output [Default applies to both]. Give one or more
     columns (or column ranges) separated by commas, or use **-f**
     multiple times (column ranges must be given
-    in the format *start*\ [:*inc* \]:*stop*, where *inc* defaults to 1 if
+    in the format *start*\ [:*inc*]:*stop*, where *inc* defaults to 1 if
     not specified).  Append **T** (absolute calendar time), **t**
     (relative time in chosen :ref:`TIME_UNIT <TIME_UNIT>` since :ref:`TIME_EPOCH <TIME_EPOCH>`),
     **x** (longitude), **y** (latitude), **p**\ [*unit*] (projected

--- a/doc/rst/source/explain_-icols_full.rst_
+++ b/doc/rst/source/explain_-icols_full.rst_
@@ -3,7 +3,7 @@
 **-i**\ *cols*\ [**+l**\ ][\ **+s**\ *scale*][\ **+o**\ *offset*][,\ *...*]
     Select specific data columns for primary input, in arbitrary order. Columns
     not listed will be skipped. Give individual columns (or column ranges
-    in the format *start*\ [:*inc* \]:*stop*, where *inc* defaults to 1 if
+    in the format *start*\ [:*inc*]:*stop*, where *inc* defaults to 1 if
     not specified) separated by commas [Default reads all columns in order,
     starting with the first column (0)]. Columns may be repeated.  To each
     column, optionally add any of  the following: **+l** takes **log10** of

--- a/doc/rst/source/explain_-ocols_full.rst_
+++ b/doc/rst/source/explain_-ocols_full.rst_
@@ -3,7 +3,7 @@
 **-o**\ *cols*\ [,...]
     Select specific data columns for primary output, in arbitrary order. Columns
     not listed will be skipped. Give columns (or column ranges
-    in the format *start*\ [:*inc* \]:*stop*, where *inc* defaults to 1 if
+    in the format *start*\ [:*inc*]:*stop*, where *inc* defaults to 1 if
     not specified) separated by commas.  Columns may be repeated.
     [Default writes all columns in order].
     Normally, any trailing text in the internal records will be written but

--- a/doc/rst/source/explain_-s_full.rst_
+++ b/doc/rst/source/explain_-s_full.rst_
@@ -7,5 +7,5 @@
     only output the records whose *z*-value equals NaN. Alternatively,
     indicate a comma-separated list of all columns or column ranges to
     consider for this NaN test (Column ranges must be given
-    in the format *start*\ [:*inc* \]:*stop*, where *inc* defaults to 1 if
+    in the format *start*\ [:*inc*]:*stop*, where *inc* defaults to 1 if
     not specified).

--- a/doc/rst/source/gallery/ex44.rst
+++ b/doc/rst/source/gallery/ex44.rst
@@ -20,4 +20,4 @@ example requires us to compute the dimensions of the inset first, via
    :width: 500 px
    :align: center
 
-   Map Inserts.
+   Map Insets.

--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -701,7 +701,7 @@ assign it to a variable, try
 
    ::
 
-    gmt set mode_age = `gmt math -S -T ages.txt MODE =`
+    mode_age=`gmt math -S -T ages.txt MODE =`
 
 To evaluate the dilog(x) function for coordinates given in the file t.txt:
 


### PR DESCRIPTION
**Description of proposed changes**

Before:
![image](https://user-images.githubusercontent.com/3974108/54240053-609aa500-44f3-11e9-989a-55d54672864c.png)

After:
![image](https://user-images.githubusercontent.com/3974108/54240030-511b5c00-44f3-11e9-9983-730f827f6ec4.png)
