### PR TITLE
Enhance mapproject -W to return reference point coordinates

### DIFF
--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -27,7 +27,7 @@ Synopsis
 [ |-S| ]
 [ |-T|\ [**h**\ ]\ *from*\ [/*to*] ]
 [ |SYN_OPT-V| ]
-[ |-W|\ [**w**\ \|\ **h**] ]
+[ |-W|\ [**g**\ \|\ **h**\ \|\ **j**\ \|\ **n**\ \|\ **w**\ \|\ **x**] ]
 [ |-Z|\ [*speed*][**+a**][**+i**][**+f**][**+t**\ *epoch*] ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
@@ -216,10 +216,15 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ [**w**\ \|\ **h**]
+**-W**\ [**g**\ \|\ **h**\ \|\ **j**\ \|\ **n**\ \|\ **w**\ \|\ **x**]
     Prints map width and height on standard output.  No input files are read.
     To only output the width or the height, append **w** or **h**, respectively.
-    The units of the dimensions may be changed via **-D**.
+    To output the plot coordinates of a map point, give **g**\ *lon*\*lat*.
+    The units of reported plot dimensions may be changed via **-D**.
+    To output the map coordinates of a reference point, select **j**\ *code* (with
+    standard two-character justification codes), **n**\ *rx*/*ry*, where the reference
+    point is given as normalized positions in the 0-1 range, or **x**\ *px*/*py*,
+    where a plot point is given directly [Default returns the width and height of the map]
 
 .. _-Z:
 
@@ -334,6 +339,14 @@ where :ref:`TIME_UNIT <TIME_UNIT>` is set to hour so that the speed is
 measured in nm (set by **-G**) per hour (set by :ref:`TIME_UNIT <TIME_UNIT>`).
 Elapsed times will be reported in hours (unless **+f** is added to **-Z**
 for ISO elapsed time).
+
+To determine the geographic coordinates of the mid-point of this transverse Mercator map, try
+
+   ::
+
+    gmt mapproject -R-80/-70/20/40 -Jt-75/1:500000 -WjCM > mid_point.txt
+
+where :ref:`TIME_UNIT <TIME_UNIT>` is set to hour so that the speed is
 
 Restrictions
 ------------


### PR DESCRIPTION
The **-W** option is used to obtain a map's width or height.  I have expanded it to take typical reference points (as used when placing embellishments, such as colorbar or roses) so that mapproject can return the geographic coordinates of the reference point.  For instance, if you need to map coordinates of the center of an oblique map, you use **-Wj**CM. Users can specify the reference point via **j**_code_, **n**_relx/rely_, or **x**_plotx/ploty_.  The inverse is also possible, i.e., using **g**_lon/lat_ and return the plot coordinates of the map point.
This format simplifies scripting by avoiding sending one-line coordinates into mapproject and using **-I** for such common calculations.
