### PR TITLE
Default parsing would indiscriminately pick last char as unit for some lengths

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9732,7 +9732,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 
 	/* Store possible unit.  For most cases these are irrelevant as no unit is expected */
 	if (case_val >= 0) {
-		if (len) GMT->current.setting.given_unit[case_val] = value[len-1];
+		if (len && strchr (GMT_DIM_UNITS, value[len-1])) GMT->current.setting.given_unit[case_val] = value[len-1];
 
 		if (error)
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error: %s given illegal value (%s)!\n", keyword, value);


### PR DESCRIPTION
This is not a good strategy if no unit is given.  Thus, a length of 7 is assigned a unit of '7' and printed out as 77.  The fix checks if units is one of c|i|p. Closes #511.
