### PR TITLE
Standardize psmask option and fix rst errors

### DIFF
--- a/doc/rst/source/mask.rst
+++ b/doc/rst/source/mask.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-D|\ *dumpfile* ]
 [ |-F|\ [**l**\ \|\ **r**] ]
 [ |-G|\ *fill* ] [ |-J|\ **z**\ \|\ **Z**\ *parameters* ]
-[ |-L|\ [**+**\ \|\ **-**]\ *nodegrid* ]
+[ |-L|\ *nodegrid*\ [**+i**\ \|\ **o**\ ] ]
 [ |-N| ]
 [ |-Q|\ *cut* ]
 [ |-S|\ *search\_radius*\ [*unit*] ]
@@ -42,7 +42,7 @@ Synopsis
 [ |SYN_OPT-:| ]
 [ |SYN_OPT--| ]
 
-.. include:: image_common.rst_
+.. include:: mask_common.rst_
 
 Examples
 --------

--- a/doc/rst/source/mask_common.rst_
+++ b/doc/rst/source/mask_common.rst_
@@ -80,11 +80,11 @@ Optional Arguments
 
 .. _-L:
 
-**-L**\ [**+**\ \|\ **-**]\ *nodegrid*
+**-L**\ *nodegrid*\ [**+i**\ \|\ **o**\ ]
     Save the internal grid with ones (data constraint) and zeros (no data) to
-    the named *nodegrid* [no grid saved].  Use **L+** to convert the no data
-    flags to NaNs before writing the grid, while **L-** will instead convert
-    the data flags to NaNs.
+    the named *nodegrid* [no grid saved].  Append **+o** to convert the outside (no data)
+    nodes to NaNs before writing the grid, while appending **+i** will instead convert
+    the inside (data) flags to NaNs.
 
 .. _-N:
 

--- a/doc/rst/source/psmask.rst
+++ b/doc/rst/source/psmask.rst
@@ -23,7 +23,7 @@ Synopsis
 [ |-F|\ [**l**\ \|\ **r**] ]
 [ |-G|\ *fill* ] [ |-J|\ **z**\ \|\ **Z**\ *parameters* ]
 [ |-K| ]
-[ |-L|\ [**+**\ \|\ **-**]\ *nodegrid* ]
+[ |-L|\ *nodegrid*\ [**+i**\ \|\ **o**\ ] ]
 [ |-N| ] [ |-O| ]
 [ |-P| ] [ |-Q|\ *cut* ]
 [ |-S|\ *search\_radius*\ [*unit*] ]
@@ -45,7 +45,7 @@ Synopsis
 
 **psmask** **-C** [ **-K** ] [ **-O** ]
 
-.. include:: image_common.rst_
+.. include:: mask_common.rst_
 
 .. include:: common_classic.rst_
 

--- a/src/psmask.c
+++ b/src/psmask.c
@@ -60,9 +60,9 @@ struct PSMASK_CTRL {
 		bool active;
 		struct GMT_FILL fill;
 	} G;
-	struct L {	/* -L[+|-]<file> */
+	struct L {	/* -L<file>[+i|o] */
 		bool active;
-		int mode;	/* -1 = set inside node to NaN, 0 as is, +1 set outside node to NaN */
+		int mode;	/* -1 = set inside node to NaN (+i), 0 as is, +1 set outside node to NaN (+o) */
 		char *file;
 	} L;
 	struct N {	/* -N */
@@ -426,7 +426,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s <table> %s %s\n", name, GMT_I_OPT, GMT_J_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t%s [%s] [-C] [-D<template>] [-G<fill>]\n\t[%s] %s[-L<grid>] [-N] %s%s[-Q<min>] [-S%s] [-T]\n", GMT_Rgeoz_OPT, GMT_B_OPT, GMT_Jz_OPT, GMT_K_OPT, GMT_O_OPT, GMT_P_OPT, GMT_RADIUS_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t%s [%s] [-C] [-D<template>] [-G<fill>]\n\t[%s] %s[-L<grid>[+i|o]] [-N] %s%s[-Q<min>] [-S%s] [-T]\n", GMT_Rgeoz_OPT, GMT_B_OPT, GMT_Jz_OPT, GMT_K_OPT, GMT_O_OPT, GMT_P_OPT, GMT_RADIUS_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [%s]\n", GMT_U_OPT, GMT_V_OPT, GMT_X_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [%s] [%s]\n\t[%s] [%s]\n", GMT_Y_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_h_OPT, GMT_i_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s]\n\t[%s] [%s] [%s] [%s]\n\n", GMT_p_OPT, GMT_r_OPT, GMT_s_OPT, GMT_t_OPT, GMT_colon_OPT, GMT_PAR_OPT);
@@ -447,7 +447,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	gmt_fill_syntax (API->GMT, 'G', "Select fill color/pattern [Default is no fill].");
 	GMT_Option (API, "K");
 	GMT_Message (API, GMT_TIME_NONE, "\t-L Save internal on/off node grid to <grid> for testing [no grid saved].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Use -L+ to change inside nodes to NaNs or -L- to change outside nodes to NaNs.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Append +i to change inside nodes to NaNs or +o to change outside nodes to NaNs.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Invert the sense of the clipping [or tiling].\n");
 	GMT_Option (API, "O,P");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Q Do not dump contours with less than <cut> points [Dump all contours].\n");
@@ -475,6 +475,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSMASK_CTRL *Ctrl, struct GMT_
 	unsigned int n_errors = 0;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
+	char *c = NULL;
 
 	for (opt = options; opt; opt = opt->next) {	/* Process all the options given */
 
@@ -534,13 +535,26 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSMASK_CTRL *Ctrl, struct GMT_
 				break;
 			case 'L':
 				Ctrl->L.active = true;
-				k = 1;
-				switch (opt->arg[0]) {
-					case '-': Ctrl->L.mode = -1;	break;
-					case '+': Ctrl->L.mode = +1;	break;
-					default: k = 0;	break;
+				if ((c = strchr (opt->arg, '+'))) {	/* Gave a modifier +i or +o */
+					k = 0;
+					c[0] = '\0';	/* Temporarily chop off modifier */
+					if (c[1] == 'i') Ctrl->L.mode = -1;
+					else if (c[1] == 'o') Ctrl->L.mode = +1;
+					else {
+						GMT_Report (API, GMT_MSG_NORMAL, "Expected -L<grdfile>[+i|o]\n");
+						n_errors++;
+					}
+				}
+				else {	/* Perhaps old style leading ± */
+					switch (opt->arg[0]) {
+						k = 1;
+						case '-': Ctrl->L.mode = -1;	break;
+						case '+': Ctrl->L.mode = +1;	break;
+						default: k = 0;	break;
+					}
 				}
 				if (opt->arg[k]) Ctrl->L.file = strdup (&opt->arg[k]);
+				if (c) c[0] = '+';	/* Restore modifier */
 				break;
 			case 'N':
 				Ctrl->N.active = true;


### PR DESCRIPTION
The **-L** option in (ps)mask started with an optional ± symbol which complicates processing of modifiers.  A backwards compatible solution has been implemented where we instead append **+i** or **+o** to turn inside or outside nodes to NaN.
Separately, the (ps)mask man pages were including the common options for psimage rather than psmask so none of the listed synopsis options were explained.