### PR TITLE
Don't check if W node equals E node for grids that dont repeat

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -1311,7 +1311,7 @@ GMT_LOCAL void doctor_geo_increments (struct GMT_CTRL *GMT, struct GMT_GRID_HEAD
 		if (slop > 0 && slop < GMT_CONV4_LIMIT) {
 			inc = header->inc[side];
 			header->inc[side] = round_inc / scale;
-			GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Round-off patrol changed geographic grid increment for %s from %.16g to %.16g\n",
+			GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Round-off patrol changed geographic grid increment for %s from %.18g to %.18g\n",
 				type[side], inc, header->inc[side]);
 		}
 	}

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -10633,6 +10633,7 @@ int gmt_BC_init (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h) {
 	}
 	else if (gmt_grd_is_global (GMT, h)) {	/* Grid is truly global */
 		double xtest = fmod (180.0, h->inc[GMT_X]) * HH->r_inc[GMT_X];
+		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Grid is considered to have a 360-degree longitude range.\n");
 		/* xtest should be within GMT_CONV4_LIMIT of zero or of one.  */
 		if (xtest > GMT_CONV4_LIMIT && xtest < (1.0 - GMT_CONV4_LIMIT) ) {
 			/* Error.  We need it to divide into 180 so we can phase-shift at poles.  */
@@ -10963,10 +10964,11 @@ int gmt_grd_BC_set (struct GMT_CTRL *GMT, struct GMT_GRID *G, unsigned int direc
 		/* DONE with all X not periodic cases  */
 	}
 	else {	/* X is periodic.  Load x cols first, then do Y cases.  */
+		bool check_repeat = (G->header->registration == GMT_GRID_NODE_REG && HH->grdtype == GMT_GRID_GEOGRAPHIC_EXACT360_REPEAT);
 		if (set[XLO]) HH->BC[XLO] = GMT_BC_IS_PERIODIC;
 		if (set[XHI]) HH->BC[XHI] = GMT_BC_IS_PERIODIC;
 		for (jmx = jn, bok = 0; jmx <= js; jmx += mx) {
-			if (G->header->registration == GMT_GRID_NODE_REG && !doubleAlmostEqualZero (G->data[jmx+iw], G->data[jmx+ie]))
+			if (check_repeat && !doubleAlmostEqualZero (G->data[jmx+iw], G->data[jmx+ie]))
 				++bok;
 			if (set[XLO]) {
 				G->data[iwo1 + jmx] = G->data[iwo1k + jmx];


### PR DESCRIPTION
Some global grids claim gridline registration but do not have the repeating values at the periodic boundary because they really are pixel-registered grids masquerading as gridline registrered grids.  In that case we should not check if the node on the west equals the node on the east as this will yield fake news such as these:

> grdimage [WARNING]: 1356 (of 1701) inconsistent grid values at West and East boundaries for repeated nodes.


Also, I increased the precision in a warning message to show that a value was changed.  Relates to #521 but does not fix it yet.