### PR TITLE
Finalize QR handling in psxy and psxyz

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -819,7 +819,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 	bool polygon, penset_OK = true, not_line, old_is_world, rgb_from_z = false;
 	bool get_rgb = false, clip_set = false, fill_active, may_intrude_inside = false;
 	bool error_x = false, error_y = false, def_err_xy = false, can_update_headpen = true;
-	bool default_outline, outline_active, geovector = false, save_W, save_G;
+	bool default_outline, outline_active, geovector = false, save_W, save_G, QR_symbol = false;
 	unsigned int n_needed, n_cols_start = 2, justify, tbl;
 	unsigned int n_total_read = 0, j, geometry;
 	unsigned int bcol, ex1, ex2, ex3, change, pos2x, pos2y, save_u = false;
@@ -1052,9 +1052,10 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 
 	if (penset_OK) gmt_setpen (GMT, &current_pen);
 
+	QR_symbol = (S.symbol == GMT_SYMBOL_CUSTOM && !strcmp (S.custom->name, "QR"));
 	fill_active = Ctrl->G.active;	/* Make copies because we will change the values */
 	outline_active =  Ctrl->W.active;
-	if (not_line && !outline_active && !fill_active && !get_rgb) outline_active = true;	/* If no fill nor outline for symbols then turn outline on */
+	if (not_line && !outline_active && !fill_active && !get_rgb && !QR_symbol) outline_active = true;	/* If no fill nor outline for symbols then turn outline on */
 
 	if (Ctrl->D.active) PSL_setorigin (PSL, Ctrl->D.dx, Ctrl->D.dy, 0.0, PSL_FWD);	/* Shift plot a bit */
 
@@ -1091,16 +1092,10 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 			gmt_set_column (GMT, GMT_IN, ex1, GMT_IS_FLOAT);
 			delayed_unit_scaling = (S.u_set && S.u != GMT_INCH);
 		}
-		if (S.symbol == GMT_SYMBOL_CUSTOM && !strcmp (S.custom->name, "QR")) {
-			if (Ctrl->G.active)	/* Change color of QR code */
-				PSL_command (PSL, "/QR_fill {%s} def\n", PSL_makecolor (PSL, Ctrl->G.fill.rgb));
-			else	/* Default to black */
+		if (QR_symbol) {
+			if (!Ctrl->G.active)	/* Default to black */
 				PSL_command (PSL, "/QR_fill {0 A} def\n");
-			if (Ctrl->W.active) {	/* Draw outline of QR code */
-				PSL_command (PSL, "/QR_outline true def\n");
-				PSL_command (PSL, "/QR_pen {%s} def\n",  PSL_makepen (PSL, Ctrl->W.pen.width, Ctrl->W.pen.rgb, Ctrl->W.pen.style, Ctrl->W.pen.offset));
-			}
-			else
+			if (!Ctrl->W.active)	/* No outline of QR code */
 				PSL_command (PSL, "/QR_outline false def\n");
 		}
 		
@@ -1202,6 +1197,16 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 					else
 						continue;
 				}
+			}
+			if (QR_symbol) {
+				if (Ctrl->G.active)	/* Change color of QR code */
+					PSL_command (PSL, "/QR_fill {%s} def\n", PSL_makecolor (PSL, current_fill.rgb));
+				if (outline_active) {	/* Draw outline of QR code */
+					PSL_command (PSL, "/QR_outline true def\n");
+					PSL_command (PSL, "/QR_pen {%s} def\n",  PSL_makepen (PSL, (1.0/6.0) * Ctrl->W.pen.width, Ctrl->W.pen.rgb, Ctrl->W.pen.style, Ctrl->W.pen.offset));
+				}
+				else
+					PSL_command (PSL, "/QR_outline false def\n");
 			}
 			if (S.symbol == GMT_SYMBOL_BARX && (S.base_set & 4))
 				in[GMT_X] += S.base;


### PR DESCRIPTION
Finalized the implementation of letting **-G** set the QR color and allow **-W** to draw the outline of the quiet zone (the latter required changing the pen width by 1/6 as it gets scaled up inside the QR symbol by 6).  The only remaining issue is whether or not we consider the white square background part of the symbol or not.  I am leaning towards the solution that it is up to the user to ensure a contrasting background, otherwise we have no way of eliminating the white rectangle if we wanted to.  Deals with issue #463.
