### PR TITLE
Initial parsing was vulnerable to mistakes

### DIFF
--- a/src/blockmedian.c
+++ b/src/blockmedian.c
@@ -156,10 +156,10 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct BLOCKMEDIAN_CTRL *Ctrl, struct
 						case '+':	/* New syntax with +h or +l to parse */
 							if (opt->arg[2] == 'l')
 								Ctrl->E.mode = BLK_DO_INDEX_LO;
-							else if (opt->arg[2] == 'h')
+							else if (opt->arg[2] == 'h' || opt->arg[2] == '\0')	/* E.g., let Er+ be thought of as -Er+h */
 								Ctrl->E.mode = BLK_DO_INDEX_HI;
-							else {	/* Neither +l or +h is bad */
-								GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unrecognized modifier %s for -E%c!\n", opt->arg[0]);
+							else {	/* Neither +l, +h, or just + is bad */
+								GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unrecognized argument -E%s!\n", opt->arg);
 								n_errors++;
 							}
 							break;

--- a/src/blockmode.c
+++ b/src/blockmode.c
@@ -178,10 +178,10 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct BLOCKMODE_CTRL *Ctrl, struct G
 						case '+':	/* New syntax with +h or +l to parse */
 							if (opt->arg[2] == 'l')
 								Ctrl->E.mode = BLK_DO_INDEX_LO;
-							else if (opt->arg[2] == 'h')
+							else if (opt->arg[2] == 'h' || opt->arg[2] == '\0')	/* E.g., let Er+ be thought of as -Er+h */
 								Ctrl->E.mode = BLK_DO_INDEX_HI;
-							else {	/* Neither +l or +h is bad */
-								GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unrecognized modifier %s for -E%c!\n", opt->arg[0]);
+							else {	/* Neither +l, +h, or just + is bad */
+								GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unrecognized argument -E%s!\n", opt->arg);
 								n_errors++;
 							}
 							break;


### PR DESCRIPTION
The recently revised parsing of **-Er+** in blockmedian and blockmode (#522) lead to a SEGV that is now fixed.   Also, the new parsing of **-L** in psmask.c (#523) failed when the old syntax **-L+**_pname_ was given (it thought **+p** was a modifier).  FInally, psmask source code did not show **-F** in neither synopsis nor usage.
