### PR TITLE
Module begin's usage message did not list the transparent PNG format

### DIFF
--- a/src/begin.c
+++ b/src/begin.c
@@ -48,7 +48,8 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     eps:	Encapsulated PostScript.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     jpg:	Joint Photographic Experts Group format.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     pdf:	Portable Document Format [Default].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     png:	Portable Network Graphics.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     png:	Portable Network Graphics (opaque).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     PNG:	Portable Network Graphics (transparent).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     ppm:	Portable Pixel Map.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     ps:	PostScript.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     tif:	Tagged Image Format File.\n");


### PR DESCRIPTION
While the RST documentation had it correct, the usage message from gmt begin only listed png (the opaque kind) and not PNG (the transparent kind).
