### PR TITLE
Forgot to add -Q to docs usage

### DIFF
--- a/src/docs.c
+++ b/src/docs.c
@@ -35,8 +35,9 @@
 GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s <module-name> [<-option>]\n\n", name);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s [-Q] <module-name> [<-option>]\n\n", name);
 	GMT_Message (API, GMT_TIME_NONE, "\t<module-name> is one of the core or supplemental modules\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-Q will only display the URL and not open it in a browser\n");
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 


### PR DESCRIPTION
While I remembered to add it to the documentation, I forgot to add **-Q** to the module synopsis and usage.
