### PR TITLE
Finalize custom symbols with text comparisons

### DIFF
--- a/doc/rst/source/GMT_Docs.rst
+++ b/doc/rst/source/GMT_Docs.rst
@@ -7990,7 +7990,8 @@ out parameters for pre-processing. The available types are
   Use octal \\040 to include spaces to ensure the text string remains a single word.
 
 To use the extra parameters in your macro you address them as $1, $2, etc.  There
-is no limit on how many parameters your symbol may use.
+is no limit on how many parameters your symbol may use. To access the trailing text in
+the input file you use $t.
 
 Macro commands
 ~~~~~~~~~~~~~~
@@ -8214,6 +8215,10 @@ Using a comparison between variables is similarly straightforward:
     ::
 
      if $2 > $3 then 0.2 0.3 0.4 c -Ggreen
+
+
+If you are comparing text strings then $t can be on either side of the operator and
+the other side would be a string constant (in quotes if containing spaces).
 
 Complete conditional test
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/rst/source/GMT_Docs_classic.rst
+++ b/doc/rst/source/GMT_Docs_classic.rst
@@ -8045,7 +8045,8 @@ out parameters for pre-processing. The available types are
   Use octal \\040 to include spaces to ensure the text string remains a single word.
 
 To use the extra parameters in your macro you address them as $1, $2, etc.  There
-is no limit on how many parameters your symbol may use.
+is no limit on how many parameters your symbol may use. To access the trailing text in
+the input file you use $t.
 
 Macro commands
 ~~~~~~~~~~~~~~
@@ -8269,6 +8270,9 @@ Using a comparison between variables is similarly straightforward:
     ::
 
      if $2 > $3 then 0.2 0.3 0.4 c -Ggreen
+
+If you are comparing text strings then $t can be on either side of the operator and
+the other side would be a string constant (in quotes if containing spaces).
 
 Complete conditional test
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4745,9 +4745,13 @@ GMT_LOCAL int support_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name, s
 					size_t len = strlen (arg[k]) - 1;
 					s->is_var[k] = false;
 					if (gmt_not_numeric (GMT, arg[k])) {	/* Got a text item for string comparison */
+						size_t len = strlen (arg[k]);
 						s->var[k] = GMT_CONST_STRING;
-						s->string = gmt_M_memory (GMT, NULL, strlen (arg[k]) + 1, char);
-						strcpy (s->string, arg[k]);
+						s->string = gmt_M_memory (GMT, NULL, len + 1, char);
+						if ((arg[k][0] == '\"' && arg[k][len-1] == '\"') || (arg[k][0] == '\'' && arg[k][len-1] == '\''))	/* Get rid of quotes */
+							strncpy (s->string, &arg[k][1], len-2);
+						else
+							strcpy (s->string, arg[k]);
 					}
 					else {	/* Numerical value */
 						s->var[k] = GMT_CONST_VAR;

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4748,7 +4748,7 @@ GMT_LOCAL int support_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name, s
 						size_t len = strlen (arg[k]);
 						s->var[k] = GMT_CONST_STRING;
 						s->string = gmt_M_memory (GMT, NULL, len + 1, char);
-						if ((arg[k][0] == '\"' && arg[k][len-1] == '\"') || (arg[k][0] == '\'' && arg[k][len-1] == '\''))	/* Get rid of quotes */
+						if (len > 2 && ((arg[k][0] == '\"' && arg[k][len-1] == '\"') || (arg[k][0] == '\'' && arg[k][len-1] == '\'')))	/* Get rid of quotes */
 							strncpy (s->string, &arg[k][1], len-2);
 						else
 							strcpy (s->string, arg[k]);


### PR DESCRIPTION
This builds on #323 and is discussed in #316.  Made sure a simple example works and updated the documentation.  Also remove any quotes used in specifying the fixed text in any comparisons in the custom symbol file.
