### PR TITLE
Avoid passing stride = NULL to io_nc_varm_grdfloat

### DIFF
--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -173,6 +173,7 @@ GMT_LOCAL int gmtnc_io_nc_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *he
 	size_t start[5] = {0,0,0,0,0}, count[5] = {1,1,1,1,1};
 	size_t n_contiguous_chunk_rows = 0;  /* that are processed at once, 0 = all */
 	ptrdiff_t imap[5] = {1,1,1,1,1}; /* mapping between dims of netCDF and in-memory grid */
+	const ptrdiff_t onestride[5] = {1,1,1,1,1};	/* Passing this instead of NULL bypasses netCDF bug in 4.6.2 */
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (header);
 
 	/* catch illegal io_mode in debug */
@@ -220,7 +221,7 @@ GMT_LOCAL int gmtnc_io_nc_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *he
 #endif
 			/* get/put chunked rows */
 			if (stride)
-				status = io_nc_varm_grdfloat (HH->ncid, HH->z_id, start, count, NULL, imap, grid, io_mode);
+				status = io_nc_varm_grdfloat (HH->ncid, HH->z_id, start, count, onestride, imap, grid, io_mode);
 			else
 				status = io_nc_vara_grdfloat (HH->ncid, HH->z_id, start, count, grid, io_mode);
 
@@ -241,7 +242,7 @@ GMT_LOCAL int gmtnc_io_nc_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *he
 					++row_num, start[yx_dim[0]], count[yx_dim[0]]);
 #endif
 			if (stride)
-				status = io_nc_varm_grdfloat (HH->ncid, HH->z_id, start, count, NULL, imap, grid, io_mode);
+				status = io_nc_varm_grdfloat (HH->ncid, HH->z_id, start, count, onestride, imap, grid, io_mode);
 			else
 				status = io_nc_vara_grdfloat (HH->ncid, HH->z_id, start, count, grid, io_mode);
 		}
@@ -251,7 +252,7 @@ GMT_LOCAL int gmtnc_io_nc_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *he
 		count[yx_dim[0]] = height_t;
 		count[yx_dim[1]] = width_t;
 		if (stride)
-			status = io_nc_varm_grdfloat (HH->ncid, HH->z_id, start, count, NULL, imap, grid, io_mode);
+			status = io_nc_varm_grdfloat (HH->ncid, HH->z_id, start, count, onestride, imap, grid, io_mode);
 		else
 			status = io_nc_vara_grdfloat (HH->ncid, HH->z_id, start, count, grid, io_mode);
 	}


### PR DESCRIPTION
netCDF introduced a bug in 4.6.2 and fixed it in 4.6.3.  However, macports just now released 4.6.2 and GMT scripts involving netcdf grids would in some cases crash due to the bug.  A fix is to not pass a stride of NULL (which was meant that netCDF would create unit strides - but that is the bug) and instead pass the unit strides directly.  This prevents the crashes.  Closes # 512.
