### PR TITLE
grdimage and nonpolar azimuthal grids issues

### DIFF
--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -521,6 +521,7 @@ GMT_LOCAL void GMT_set_proj_limits (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER
 	gmt_M_memcpy (r->wesn, GMT->current.proj.rect, 4, double);
 	
 	if (GMT->current.proj.projection_GMT == GMT_GENPER && GMT->current.proj.g_width != 0.0) return;
+	if (gmt_M_is_azimuthal (GMT) && !GMT->current.proj.polar) return;
 
 	/* This fails when -R is not the entire grid region and projected is false. */
 	if (projected && gmt_M_is_geographic (GMT, GMT_IN)) {


### PR DESCRIPTION
See #521 for context.  The original grid is poorly presented since it is actually a global (in longitude, not latitude) pixel-registered grid saved as a nonglobal gridline-registered grid.  However, converting it to a pixel grid with proper header still failed (int only worked for a full range of latitudes).  This PR addresses the problem with the range of latitude since these nonpolar azimuthal grids with 360 range of longitude must be projected as the full square.  With proper global and pixel registration it now works.  I will see if I can figure out if we can handle to badly designed grid but it is tempting to blame the format.
So this PR fixes part of a the problem and can be committed.