### PR TITLE
Pin version of CI scripts to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,7 @@ script:
 # Things to do if the build is successful
 after_success:
     - if [ "$DEPLOY_DOCS" == "true" ]; then
-        git clone https://github.com/fatiando/continuous-integration.git;
+        git clone --branch=1.0.0 --depth=1 https://github.com/fatiando/continuous-integration.git;
       fi
 
 # Deploy build artifacts to external services


### PR DESCRIPTION
Don't clone the `fatiando/continuous-integration` repository from master to
avoid breaking the builds when the scripts update.

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
