### PR TITLE
Address various gcc compiler warnings

### DIFF
--- a/src/blockmean.c
+++ b/src/blockmean.c
@@ -285,7 +285,7 @@ int GMT_blockmean (void *V_API, int mode, void *args) {
 	int error;
 	bool use_xy, use_weight, duplicate_col;
 	double weight, weight_s2 = 0, weight_pos, weighted_z, iw, half_dx, wesn[4], out[7], *in = NULL;
-	char format[GMT_LEN256] = {""}, *fcode[BLK_N_FIELDS] = {"z", "s", "l", "h", "w", "", "", ""}, *code[BLK_N_FIELDS];
+	char format[GMT_LEN512] = {""}, *fcode[BLK_N_FIELDS] = {"z", "s", "l", "h", "w", "", "", ""}, *code[BLK_N_FIELDS];
 
 	struct GMT_OPTION *options = NULL;
 	struct GMT_GRID *Grid = NULL, *G = NULL, *GridOut[BLK_N_FIELDS];
@@ -347,7 +347,7 @@ int GMT_blockmean (void *V_API, int mode, void *args) {
 	gmt_set_xy_domain (GMT, wesn, Grid->header);	/* wesn may include some padding if gridline-registered */
 
 	if (gmt_M_is_verbose (GMT, GMT_MSG_LONG_VERBOSE)) {
-		snprintf (format, GMT_LEN256, "W: %s E: %s S: %s N: %s n_columns: %%d n_rows: %%d\n",
+		snprintf (format, GMT_LEN512, "W: %s E: %s S: %s N: %s n_columns: %%d n_rows: %%d\n",
 		          GMT->current.setting.format_float_out, GMT->current.setting.format_float_out,
 				  GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, format, Grid->header->wesn[XLO], Grid->header->wesn[XHI],

--- a/src/blockmedian.c
+++ b/src/blockmedian.c
@@ -374,7 +374,7 @@ int GMT_blockmedian (void *V_API, int mode, void *args) {
 	unsigned int row, col, emode = 0, n_input, n_output, n_quantiles = 1, go_quickly = 0;
 	unsigned int k, NF = 0, fcol[BLK_N_FIELDS] = {2,3,4,5,6,7,0,0}, field[BLK_N_FIELDS];
 	double out[8], wesn[4], quantile[3] = {0.25, 0.5, 0.75}, extra[8], weight, half_dx, *in = NULL, *z_tmp = NULL;
-	char format[GMT_LEN256] = {""}, *old_format = NULL, *fcode[BLK_N_FIELDS] = {"z", "s", "l", "q25", "q75", "h", "w", ""}, *code[BLK_N_FIELDS];
+	char format[GMT_LEN512] = {""}, *old_format = NULL, *fcode[BLK_N_FIELDS] = {"z", "s", "l", "q25", "q75", "h", "w", ""}, *code[BLK_N_FIELDS];
 
 	struct GMT_OPTION *options = NULL;
 	struct GMT_GRID *Grid = NULL, *G = NULL, *GridOut[BLK_N_FIELDS];
@@ -438,7 +438,7 @@ int GMT_blockmedian (void *V_API, int mode, void *args) {
 	if (!(Ctrl->E.mode & BLK_DO_EXTEND4)) quantile[0] = Ctrl->T.quantile;	/* Just get the single quantile [median] */
 
 	if (gmt_M_is_verbose (GMT, GMT_MSG_LONG_VERBOSE)) {
-		snprintf (format, GMT_LEN256, "W: %s E: %s S: %s N: %s n_columns: %%d n_rows: %%d\n", GMT->current.setting.format_float_out, GMT->current.setting.format_float_out, GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
+		snprintf (format, GMT_LEN512, "W: %s E: %s S: %s N: %s n_columns: %%d n_rows: %%d\n", GMT->current.setting.format_float_out, GMT->current.setting.format_float_out, GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, format, Grid->header->wesn[XLO], Grid->header->wesn[XHI], Grid->header->wesn[YLO], Grid->header->wesn[YHI], Grid->header->n_columns, Grid->header->n_rows);
 	}
 

--- a/src/blockmode.c
+++ b/src/blockmode.c
@@ -498,7 +498,7 @@ int GMT_blockmode (void *V_API, int mode, void *args) {
 	double out[7], wesn[4], i_n_in_cell, d_intval, weight, half_dx, *in = NULL, *z_tmp = NULL;
 	double z_min = DBL_MAX, z_max = -DBL_MAX;
 
-	char format[GMT_LEN256] = {""}, *old_format = NULL, *fcode[BLK_N_FIELDS] = {"z", "s", "l", "h", "w", "", "", ""}, *code[BLK_N_FIELDS];
+	char format[GMT_LEN512] = {""}, *old_format = NULL, *fcode[BLK_N_FIELDS] = {"z", "s", "l", "h", "w", "", "", ""}, *code[BLK_N_FIELDS];
 
 	struct GMT_OPTION *options = NULL;
 	struct GMT_GRID *Grid = NULL, *G = NULL, *GridOut[BLK_N_FIELDS];
@@ -542,7 +542,7 @@ int GMT_blockmode (void *V_API, int mode, void *args) {
 	mode_xy = !Ctrl->C.active;
 
 	if (gmt_M_is_verbose (GMT, GMT_MSG_LONG_VERBOSE)) {
-		snprintf (format, GMT_LEN256, "W: %s E: %s S: %s N: %s n_columns: %%d n_rows: %%d\n", GMT->current.setting.format_float_out, GMT->current.setting.format_float_out, GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
+		snprintf (format, GMT_LEN512, "W: %s E: %s S: %s N: %s n_columns: %%d n_rows: %%d\n", GMT->current.setting.format_float_out, GMT->current.setting.format_float_out, GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, format, Grid->header->wesn[XLO], Grid->header->wesn[XHI], Grid->header->wesn[YLO], Grid->header->wesn[YHI], Grid->header->n_columns, Grid->header->n_rows);
 	}
 

--- a/src/gmt2kml.c
+++ b/src/gmt2kml.c
@@ -380,6 +380,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT2KML_CTRL *Ctrl, struct GMT
 				break;
 			case 'G':	/* Set fill for symbols or polygon */
 				ind = F_ID;	/* Default is fill if not overridden below */
+				k = 0;
 				if ((c = strstr (opt->arg, "+f"))) 	/* Polygon fill */
 					ind = F_ID, k = 0, c[0] = '\0';
 				else if ((c = strstr (opt->arg, "+n")))	/* Label color */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -10455,7 +10455,7 @@ struct GMT_RESOURCE *GMT_Encode_Options (void *V_API, const char *module_name, i
 	/* 1m. Check if this is the grdgradient module, where primary dataset output should be turned off if -Qc and no -G is set */
 	else if (!strncmp (module, "grdgradient", 11U) && (opt = GMT_Find_Option (API, 'G', *head)) == NULL) {
 		/* Found no -G<grid> option; determine if -Qc is set */
-		if ((opt = GMT_Find_Option (API, 'Q', *head)) && opt->arg == 'c')
+		if ((opt = GMT_Find_Option (API, 'Q', *head)) && opt->arg[0] == 'c')
 			deactivate_output = true;	/* Turn off implicit output since none is in effect */
 	}
 

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -1528,6 +1528,7 @@ size_t gmt_grd_data_size (struct GMT_CTRL *GMT, unsigned int format, gmt_grdfloa
 			break;
 		case 'i':
 			if (isnan (*nan_value)) *nan_value = INT_MIN;
+			/* Fall through on purpose */
 		case 'm':
 			return (sizeof (int32_t));
 			break;
@@ -2200,7 +2201,7 @@ int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_
 
 	bool global, error = false;
 	double val, dx, small;
-	char format[GMT_LEN64] = {""};
+	char format[GMT_LEN256] = {""};
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (header);
 
 	switch (gmt_minmaxinc_verify (GMT, wesn[XLO], wesn[XHI], header->inc[GMT_X], GMT_CONV4_LIMIT)) {	/* Check if range is compatible with x_inc */
@@ -2252,7 +2253,7 @@ int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_
 		if (dx > small) {
 			GMT_Report (GMT->parent, GMT_MSG_VERBOSE,
 			            "(w - x_min) must equal (NX + eps) * x_inc), where NX is an integer and |eps| <= %g.\n", GMT_CONV4_LIMIT);
-			snprintf (format, GMT_LEN64, "w reset from %s to %s\n",
+			snprintf (format, GMT_LEN256, "w reset from %s to %s\n",
 			          GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 			GMT_Report (GMT->parent, GMT_MSG_VERBOSE, format, wesn[XLO], val);
 			wesn[XLO] = val;
@@ -2264,7 +2265,7 @@ int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_
 		if (dx > small) {
 			GMT_Report (GMT->parent, GMT_MSG_VERBOSE,
 			            "(e - x_min) must equal (NX + eps) * x_inc), where NX is an integer and |eps| <= %g.\n", GMT_CONV4_LIMIT);
-			snprintf (format, GMT_LEN64, "e reset from %s to %s\n",
+			snprintf (format, GMT_LEN256, "e reset from %s to %s\n",
 			          GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 			GMT_Report (GMT->parent, GMT_MSG_VERBOSE, format, wesn[XHI], val);
 			wesn[XHI] = val;
@@ -2278,7 +2279,7 @@ int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_
 	if (fabs (wesn[YLO] - val) > small) {
 		GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "(s - y_min) must equal (NY + eps) * y_inc), where NY is an integer and |eps| <= %g.\n",
 		            GMT_CONV4_LIMIT);
-		snprintf (format, GMT_LEN64, "s reset from %s to %s\n",
+		snprintf (format, GMT_LEN256, "s reset from %s to %s\n",
 		          GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 		GMT_Report (GMT->parent, GMT_MSG_VERBOSE, format, wesn[YLO], val);
 		wesn[YLO] = val;
@@ -2288,7 +2289,7 @@ int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_
 	if (fabs (wesn[YHI] - val) > small) {
 		GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "(n - y_min) must equal (NY + eps) * y_inc), where NY is an integer and |eps| <= %g.\n",
 		            GMT_CONV4_LIMIT);
-		snprintf (format, GMT_LEN64, "n reset from %s to %s\n",
+		snprintf (format, GMT_LEN256, "n reset from %s to %s\n",
 		          GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 		GMT_Report (GMT->parent, GMT_MSG_VERBOSE, format, wesn[YHI], val);
 		wesn[YHI] = val;

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -4542,7 +4542,7 @@ FILE * gmt_fopen (struct GMT_CTRL *GMT, const char *filename, const char *mode) 
 				char *ext = gmt_get_ext (c);	/* Get pointer to extension (or NULL if no extension) */
 				if (ext && mode[0] == 'r' && !strncmp (ext, "shp", 3U)) {	/* Got a shapefile for reading */
 					/* We will do a system call to ogr2ogr in order to read the shapefile */
-					char cmd[GMT_LEN256] = {""};
+					char cmd[GMT_BUFSIZ+GMT_LEN256] = {""};
 					int error = 0;
 					if (GMT->parent->tmp_dir)	/* Make unique file in temp dir */
 						sprintf (GMT->current.io.tempfile, "%s/gmt_ogr_%d.gmt", GMT->parent->tmp_dir, (int)getpid());

--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -1650,7 +1650,7 @@ int gmt_nc_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_
 #ifndef DOUBLE_PRECISION_GRID
 			GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Precision loss! GMT's internal grid representation is 32-bit float.\n");
 #endif
-			/* no break! */
+			/* Intentially no break here! */
 		default: /* don't round float */
 			do_round = false;
 	}

--- a/src/gmt_parse.c
+++ b/src/gmt_parse.c
@@ -133,13 +133,21 @@ GMT_LOCAL int parse_B_arg_inspector (struct GMT_CTRL *GMT, char *in) {
 				else if (k < last && in[k+1] == 'o') {mod = 'o'; ignore5 = false; gmt5++;}	/* oblique pole settings */
 				else if (k < last && in[k+1] == 'p') {mod = 'p'; ignore5 = true;  gmt5++;}	/* prefix settings */
 				else if (k < last && in[k+1] == 'l') {mod = 'l'; ignore5 = true;  gmt5++;}	/* Label */
+				else if (k < last && in[k+1] == 'L') {mod = 'L'; ignore5 = true;  gmt5++;}	/* Forced horizontal Label */
+				else if (k < last && in[k+1] == 's') {mod = 's'; ignore5 = true;  gmt5++;}	/* Secondary label */
+				else if (k < last && in[k+1] == 'S') {mod = 'S'; ignore5 = true;  gmt5++;}	/* Forced horizontal Secondary lLabel */
 				else if (k < last && in[k+1] == 't') {mod = 't'; ignore5 = true;  gmt5++;}	/* title */
+				else if (k < last && in[k+1] == 'n') {mod = 'n'; ignore5 = true;  gmt5++;}	/* Turn off frames and annotations */
 				else if (k && (in[k-1] == 'Z' || in[k-1] == 'z')) {ignore5 = false; gmt4++;}	/* Z-axis with 3-D box */
 				break;
 			case 'c':	/* If following a number this is unit c for seconds in GMT4 */
 				if (!custom && k && (in[k-1] == '.' || isdigit (in[k-1]))) gmt4++;	/* Old-style second unit */
-			case 'W': case 'E': case 'S': case 'N': case 'Z': case 'w': case 'e': case 'n': case 'z':	/* Not checking s as confusion with seconds */
+				break;
+			case 'W': case 'E': case 'S': case 'N': case 'Z': case 'w': case 'e': case 'z':	/* Not checking s as confusion with seconds and n because of +n */
 				if (k > 1) wesn_at_end++;	/* GMT5 has -B<WESNwesn> up front while GMT4 usually has them at the end */
+				break;
+			case 'n':	/* Tell this apart from +n */
+				if (!(k && in[k-1] == '+') && k > 1) wesn_at_end++;	/* GMT5 has -B<WESNwesn> up front while GMT4 usually has them at the end */
 				break;
 		}
 	}

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -2133,7 +2133,7 @@ GMT_LOCAL void plot_timestamp (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, doubl
 	 */
 
 	time_t right_now;
-	char label[GMT_LEN256] = {""}, text[GMT_LEN256] = {""};
+	char label[GMT_LEN512] = {""}, text[GMT_LEN256] = {""};
 	double dim[3] = {0.365, 0.15, 0.032};	/* Predefined dimensions in inches */
 	double unset_rgb[4] = {-1.0, -1.0, -1.0, 0.0};
 
@@ -2179,7 +2179,7 @@ GMT_LOCAL void plot_timestamp (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, doubl
 	/* Optionally, add additional label to the right of the box */
 
 	if (U_label && U_label[0]) {
-		snprintf (label, GMT_LEN256, "   %s", U_label);
+		snprintf (label, GMT_LEN512, "   %s", U_label);
 		PSL_plottext (PSL, 0.0, 0.0, -7.0, label, 0.0, PSL_BL, 0);
 	}
 
@@ -5157,7 +5157,7 @@ int gmt_draw_map_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *ms) {
 void gmt_draw_vertical_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *ms) {
 	/* Draws a basic vertical scale bar at given refpoint and labels it as specified , */
 	double half_scale_length, scale, x0, y0, xx[4], yy[4], off, dim[2], sign = 1.0;
-	char txt[GMT_LEN64] = {""};
+	char txt[GMT_LEN256] = {""};
 	int form, just = PSL_ML;
 
 	if (ms->label[0]) /* Append data unit to the scale length */
@@ -5344,7 +5344,7 @@ int gmt_draw_custom_symbol (struct GMT_CTRL *GMT, double x0, double y0, double s
 	bool flush = false, this_outline = false, skip[GMT_N_COND_LEVELS+1], done[GMT_N_COND_LEVELS+1];
 	uint64_t n = 0;
 	size_t n_alloc = 0;
-	double x, y, lon, lat, az, angle1, angle2, p_width, *xx = NULL, *yy = NULL, *xp = NULL, *yp = NULL, dim[PSL_MAX_DIMS];
+	double x, y, lon, lat, az, angle1, angle2, p_width = 0.0, *xx = NULL, *yy = NULL, *xp = NULL, *yp = NULL, dim[PSL_MAX_DIMS];
 	char user_text[GMT_LEN256] = {""};
 	struct GMT_CUSTOM_SYMBOL_ITEM *s = NULL;
 	struct GMT_FILL f, *current_fill = fill;
@@ -5530,7 +5530,7 @@ int gmt_draw_custom_symbol (struct GMT_CTRL *GMT, double x0, double y0, double s
 				break;
 
 			case (int)'C':
-				if (gmt_M_compat_check (GMT, 4)) {	/* Warn and fall through */
+				if (gmt_M_compat_check (GMT, 4)) {	/* Warn and purposefully fall through to assign the rest of the statements */
 					GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Circle macro symbol C is deprecated; use c instead\n");
 					action = s->action = PSL_CIRCLE;	/* Backwards compatibility, circles are now 'c' */
 				}

--- a/src/gmtconvert.c
+++ b/src/gmtconvert.c
@@ -264,7 +264,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMTCONVERT_CTRL *Ctrl, struct 
 					case 'l':		/* Get last point only */
 						Ctrl->E.mode = -2; break;
 					case 'M':		/* Set modulo step */
-						Ctrl->E.end = true;	/* Include last point; fall through to set the step */
+						Ctrl->E.end = true;	/* Include last point; fall through on purpose to set the step */
 					case 'm':		/* Set modulo step */
 						Ctrl->E.mode = atoi (&opt->arg[1]); break;
 					default:		/* Get first and last point only */

--- a/src/gmtinfo.c
+++ b/src/gmtinfo.c
@@ -224,11 +224,13 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MINMAX_CTRL *Ctrl, struct GMT_
 				switch (opt->arg[0]) {
 					case 'L':
 						Ctrl->E.abs = true;
+						/* fall through on purpose to 'l' */
 					case 'l':
 						Ctrl->E.mode = -1;
 						break;
 					case 'H':
 						Ctrl->E.abs = true;
+						/* fall through on purpose to 'h' */
 					case 'h':
 						Ctrl->E.mode = +1;
 						break;
@@ -300,6 +302,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MINMAX_CTRL *Ctrl, struct GMT_
 
 			case 'b':	/* -b[i]c will land here */
 				if (gmt_M_compat_check (GMT, 4)) break;
+				/* Otherwise we fall through on purpose to get an error */
 
 			default:	/* Report bad options */
 				n_errors += gmt_default_error (GMT, opt->option);

--- a/src/gmtspatial.c
+++ b/src/gmtspatial.c
@@ -849,6 +849,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMTSPATIAL_CTRL *Ctrl, struct 
 							break;
 						case 'C':	/* Gave a new +C<cmax> value */
 							Ctrl->D.I.mode = 1;	/* Median instead of mean */
+							/* Fall through on purpose */
 						case 'c':	/* Gave a new +c<cmax> value */
 							if (p[1]) Ctrl->D.I.c_threshold = atof (&p[1]);	/* This allows +C by itself just to change to median */
 							break;
@@ -1319,7 +1320,7 @@ int GMT_gmtspatial (void *V_API, int mode, void *args) {
 	
 	if (Ctrl->Q.active) {	/* Calculate centroid and polygon areas or line lengths and place in segment headers */
 		double out[3];
-		static char *type[2] = {"length", "area"}, upper[GMT_LEN16] = {"infinity"};
+		static char *type[2] = {"length", "area"}, upper[GMT_LEN32] = {"infinity"};
 		bool new_data = (Ctrl->Q.header || Ctrl->Q.sort || Ctrl->E.active);
 		uint64_t seg, row_f, row_l, tbl, col, n_seg = 0, n_alloc_seg = 0;
 		unsigned int handedness = 0;

--- a/src/gmtvector.c
+++ b/src/gmtvector.c
@@ -211,6 +211,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMTVECTOR_CTRL *Ctrl, struct G
 						break;
 					case 'D':	/* Angle between vectors */
 						Ctrl->T.degree = true;
+						/* Fall through on purpose to 'd' */
 					case 'd':	/* dot-product of two vectors */
 						Ctrl->T.mode = DO_DOT;
 						break;

--- a/src/grdclip.c
+++ b/src/grdclip.c
@@ -189,6 +189,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDCLIP_CTRL *Ctrl, struct GMT
 					break;
 				case 'i':
 					n_to_expect = 3;	/* Since only two for -Sr */
+					/* Fall through on purpose to 'r' */
 				case 'r':
 					Ctrl->S.mode |= GRDCLIP_BETWEEN;
 					if (n_class == Ctrl->S.n_class) {	/* Need more memory */

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -982,7 +982,7 @@ int GMT_grdcontour (void *V_API, int mode, void *args) {
 		/* If -N[<cpt>] is given then we split the call into a grdview + grdcontour sequence.
 	 	 * We DO NOT parse any options here or initialize GMT, and just bail after running the two modules */
 	
-		char cmd1[GMT_LEN512] = {""}, cmd2[GMT_LEN512] = {""}, string[GMT_LEN128] = {""}, cptfile[PATH_MAX] = {""};
+		char cmd1[GMT_LEN512] = {""}, cmd2[GMT_LEN512] = {""}, string[GMT_LEN128] = {""}, cptfile[PATH_MAX] = {""}, *ptr = NULL;
 		struct GMT_OPTION *opt = NULL;
 		bool got_cpt = (optN->arg[0]), is_continuous, got_C_cpt = false;
 		size_t L;
@@ -1077,7 +1077,8 @@ int GMT_grdcontour (void *V_API, int mode, void *args) {
 		}
 		is_continuous = P->is_continuous;
 		/* Free the P object unless it was an input memory object */
-		if (!gmt_M_file_is_memory (cptfile) && GMT_Destroy_Data (API, &P) != GMT_NOERROR) {
+		ptr = cptfile;	/* To avoid warning message from gmt_M_file_is_memory */
+		if (!gmt_M_file_is_memory (ptr) && GMT_Destroy_Data (API, &P) != GMT_NOERROR) {
 			Return (API->error);
 		}
 		if (is_continuous) {	/* More bad news */

--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -449,7 +449,7 @@ int GMT_grdinfo (void *V_API, int mode, void *args) {
 	double global_xmin, global_xmax, global_ymin, global_ymax, global_zmin, global_zmax;
 	double z_mean = 0.0, z_median = 0.0, z_mode = 0.0, z_stdev = 0.0, z_scale = 0.0, z_lmsscl = 0.0, z_rms = 0.0, out[22];
 
-	char format[GMT_BUFSIZ] = {""}, text[GMT_LEN64] = {""}, record[GMT_BUFSIZ] = {""}, grdfile[GMT_LEN256] = {""};
+	char format[GMT_BUFSIZ] = {""}, text[GMT_LEN512] = {""}, record[GMT_BUFSIZ] = {""}, grdfile[GMT_LEN256] = {""};
 	char *type[2] = { "Gridline", "Pixel"}, *sep = NULL, *projStr = NULL, *answer[2] = {"", " no"};
 
 	struct GRDINFO_CTRL *Ctrl = NULL;

--- a/src/grdtrend.c
+++ b/src/grdtrend.c
@@ -491,9 +491,9 @@ GMT_LOCAL void load_gtg_and_gtd (struct GMT_CTRL *GMT, struct GMT_GRID *G, doubl
 int GMT_grdtrend (void *V_API, int mode, void *args) {
 	/* High-level function that implements the grdcontour task */
 
-	bool trivial, weighted,iterations, set_ones = true;
+	bool trivial, weighted, set_ones = true;
 	int error = 0;
-	unsigned int row, col;
+	unsigned int row, col, iterations;
 
 	uint64_t ij;
 

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -336,7 +336,7 @@ int GMT_grdvector (void *V_API, int mode, void *args) {
 	
 	uint64_t ij;
 
-	double tmp, x, y, plot_x, plot_y, x_off, y_off, f, headpen_width;
+	double tmp, x, y, plot_x, plot_y, x_off, y_off, f, headpen_width = 0.0;
 	double x2, y2, wesn[4], value, vec_length, vec_azim, scaled_vec_length, c, s, dim[PSL_MAX_DIMS];
 
 	struct GMT_GRID *Grid[2] = {NULL, NULL};

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -625,7 +625,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT
 						break;
 					case 't':	/* Image without color interpolation */
 						Ctrl->Q.special = true;
-						/* Deliberate fall-through */
+						/* Deliberate fall-through to 'i' */
 					case 'i':	/* Image with clipmask */
 						Ctrl->Q.mode = GRDVIEW_IMAGE;
 						if (opt->arg[1] && isdigit ((int)opt->arg[1])) Ctrl->Q.dpi = atoi (&opt->arg[1]);
@@ -764,9 +764,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
 int GMT_grdview (void *V_API, int mode, void *args) {
-	bool get_contours, bad, good, pen_set, begin, saddle, drape_resample = false;
+	bool get_contours, bad, pen_set, begin, saddle, drape_resample = false;
 	bool nothing_inside = false, use_intensity_grid, do_G_reading = true;
-	unsigned int c, nk, n4, row, col, n_edges, d_reg[3], i_reg = 0, id[2];
+	unsigned int c, nk, n4, row, col, n_edges, d_reg[3], i_reg = 0, id[2], good;
 	unsigned int t_reg, n_out, k, k1, ii, jj, PS_colormask_off = 0, *edge = NULL;
 	int i, j, i_bin, j_bin, i_bin_old, j_bin_old, way, bin_inc[4], ij_inc[4], error = 0;
 	int start[2], stop[2], inc[2];

--- a/src/img/img2grd.c
+++ b/src/img/img2grd.c
@@ -259,7 +259,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct IMG2GRD_CTRL *Ctrl, struct GMT
 					n_errors++;
 				break;
 			case 'm':
-				if (gmt_M_compat_check (GMT, 4))	/* Warn and fall through */
+				if (gmt_M_compat_check (GMT, 4))	/* Warn and fall through to 'I' on purpose */
 					GMT_Report (API, GMT_MSG_COMPAT, "-m<inc> is deprecated; use -I<inc> instead.\n");
 				else {
 					n_errors += gmt_default_error (GMT, opt->option);

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -390,15 +390,18 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct 
 					switch (c) {
 						case 'B':
 							Ctrl->A.geodesic = true;
+							/* fall through on purpose to 'b' */
 						case 'b':
 							Ctrl->A.reverse = true;
 							break;
 						case 'F':
 							Ctrl->A.geodesic = true;
+							/* fall through on purpose to 'f' */
 						case 'f':
 							break;
 						case 'O':
 							Ctrl->A.geodesic = true;
+							/* fall through on purpose to 'o' */
 						case 'o':
 							Ctrl->A.orient = true;
 							break;

--- a/src/meca/psvelo.c
+++ b/src/meca/psvelo.c
@@ -325,7 +325,7 @@ int GMT_psvelo (void *V_API, int mode, void *args) {
 	double plot_x, plot_y, vxy[2], plot_vx, plot_vy, dim[PSL_MAX_DIMS];
 	double eps1 = 0.0, eps2 = 0.0, spin = 0.0, spinsig = 0.0, theta = 0.0, *in = NULL;
 	double direction = 0, small_axis = 0, great_axis = 0, sigma_x, sigma_y, corr_xy;
-	double t11 = 1.0, t12 = 0.0, t21 = 0.0, t22 = 1.0, hl, hw, vw, ssize, headpen_width;
+	double t11 = 1.0, t12 = 0.0, t21 = 0.0, t22 = 1.0, hl, hw, vw, ssize, headpen_width = 0.0;
 
 	char *station_name = NULL;
 
@@ -505,7 +505,7 @@ int GMT_psvelo (void *V_API, int mode, void *args) {
 					else {
 						dim[6] = (double)Ctrl->A.S.v.status;
 						dim[7] = (double)Ctrl->A.S.v.v_kind[0];	dim[8] = (double)Ctrl->A.S.v.v_kind[1];
-						dim[11] = headpen_width;
+						dim[11] = (headpen_width > 0.0) ? headpen_width : 0.5 * Ctrl->W.pen.width;
 						if (Ctrl->A.S.v.status & PSL_VEC_FILL2)
 							gmt_setfill (GMT, &Ctrl->A.S.v.fill, Ctrl->L.active);
 						else if (Ctrl->G.active)

--- a/src/mgd77/mgd77convert.c
+++ b/src/mgd77/mgd77convert.c
@@ -136,7 +136,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77CONVERT_CTRL *Ctrl, struc
 						break;
 					case 'C':		/* Enhanced MGD77+ netCDF file */
 						Ctrl->F.mode = true;	/* Overlook revisions */
-					case 'c':
+					case 'c':	/* Falling through from 'C' to 'c' on purpose */
 						Ctrl->F.format = MGD77_FORMAT_CDF;
 						break;
 					case 'm':		/* New ASCII MGD77T file */

--- a/src/mgd77/mgd77list.c
+++ b/src/mgd77/mgd77list.c
@@ -482,6 +482,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77LIST_CTRL *Ctrl, struct G
 				switch (opt->arg[0]) {
 				 	case 'A':		/* Start date, skip records with time = NaN */
 						Ctrl->D.mode = true;
+						/* Fall through on purpose to 'a' */
 				 	case 'a':		/* Start date */
 						t = &opt->arg[1];
 						if (t && gmt_verify_expectations (GMT, GMT_IS_ABSTIME, gmt_scanf (GMT, t, GMT_IS_ABSTIME, &Ctrl->D.start), t)) {
@@ -491,6 +492,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77LIST_CTRL *Ctrl, struct G
 						break;
 					case 'B':		/* Stop date, skip records with time = NaN */
 						Ctrl->D.mode = true;
+						/* Fall through on purpose to 'b' */
 					case 'b':		/* Stop date */
 						t = &opt->arg[1];
 						if (t && gmt_verify_expectations (GMT, GMT_IS_ABSTIME, gmt_scanf (GMT, t, GMT_IS_ABSTIME, &Ctrl->D.stop), t)) {
@@ -626,6 +628,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77LIST_CTRL *Ctrl, struct G
 						break;
 					case 'C':	/* Course change min/max using absolute value of cc */
 						Ctrl->Q.c_abs = true;
+						/* Fall through on purpose to 'c' */
 					case 'c':	/* Course change min/max */
 						if (sscanf (&opt->arg[1], "%lf/%lf", &Ctrl->Q.min[Q_C], &Ctrl->Q.max[Q_C]) != 2) {
 							GMT_Report (API, GMT_MSG_NORMAL, "Syntax error -Qc: append min/max course change limits [-360/+360]\n");

--- a/src/mgd77/mgd77manage.c
+++ b/src/mgd77/mgd77manage.c
@@ -358,12 +358,14 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77MANAGE_CTRL *Ctrl, struct
 						break;
 					case 'D':	/* dist,val data file - interpolate to get values at all records */
 						Ctrl->A.interpolate = true;
+						/* Fall through on purpose to 'd' */
 					case 'd':	/* dist,val data file - only update records with matching distances */
 						Ctrl->A.mode = MODE_d;
 						n_errors += decode_A_options (0, &opt->arg[k+1], file, Ctrl->A.parameters);
 						break;
 					case 'E':	/* Plain E77 error flag file from mgd77sniffer */
 						Ctrl->A.ignore_verify = true;	/* Process raw e77 files that have not been verified */
+						/* Fall through on purpose to 'e' */
 					case 'e':	/* Plain E77 error flag file from mgd77sniffer */
 						Ctrl->A.mode = MODE_e;
 						while (opt->arg[++k]) {
@@ -404,6 +406,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77MANAGE_CTRL *Ctrl, struct
 						break;
 					case 'T':	/* abstime,val data file - interpolate to get values at all records */
 						Ctrl->A.interpolate = true;
+						/* Fall through on purpose to 't' */
 					case 't':	/* abstime,val data file - only update records with matching times */
 						Ctrl->A.mode = MODE_t;
 						Ctrl->A.kind = GMT_IS_ABSTIME;
@@ -787,7 +790,7 @@ int GMT_mgd77manage (void *V_API, int mode, void *args) {
 		if (Ctrl->D.active) {	/* Must create a new file with everything except the fields to be deleted */
 			int id, c;
 			bool reset_column = false;
-			char oldfile[GMT_BUFSIZ] = {""};
+			char oldfile[GMT_BUFSIZ+4] = {""};
 			
 			if (column != MGD77_NOT_SET) {	/* Get info about this existing column to see if it is compatible with new data */
 				n_dims = (D->H.info[In.order[column].set].col[In.order[column].item].constant) ? 0 : 1;
@@ -1276,7 +1279,7 @@ int GMT_mgd77manage (void *V_API, int mode, void *args) {
 									GMT_Message (API, GMT_TIME_NONE, "Warning: Correction implied for %s which is not in this cruise?\n", field);
 									break;
 								}
-								/* no break - we want to fall through and also set depth adjustment */
+								/* No break! - we want to fall through and also set depth adjustment */
 							case E77_HDR_CARTER:	/* Recalculate Carter depth from twt */
 								cdf_adjust = MGD77_COL_ADJ_DEPTH;
 								MGD77_nc_status (GMT, nc_put_att_int (In.nc_id, D->H.info[set].col[id].var_id, "adjust", NC_INT, 1U, &cdf_adjust));

--- a/src/mgd77/mgd77path.c
+++ b/src/mgd77/mgd77path.c
@@ -97,6 +97,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77PATH_CTRL *Ctrl, struct G
 				if (gmt_M_compat_check (GMT, 4)) {
 					GMT_Report (API, GMT_MSG_COMPAT, "-P is deprecated; use -A instead mext time.\n");
 					Ctrl->A.active = true;
+					/* Purposfully falling through to catch 'A' instead */
 				}
 				else {
 					n_errors += gmt_default_error (GMT, opt->option);

--- a/src/mgd77/mgd77sniffer.c
+++ b/src/mgd77/mgd77sniffer.c
@@ -573,7 +573,7 @@ int GMT_mgd77sniffer (void *V_API, int mode, void *args) {
 	double thisLon, thisLat, lastLon, lastLat, *MaxDiff = NULL, **diff = NULL, *decimated_orig, wrapsum, tcrit, se,  n_days;
 	double *offsetLength, *decimated_new, recommended_scale, *new_anom = NULL, *old_anom = NULL, IGRF[8], lastCorr = 0.0;
 
-	char timeStr[32] = {""}, placeStr[128] = {""}, errorStr[128] = {""}, outfile[32] = {""}, abbrev[8] = {""}, fstats[MGD77_N_STATS][GMT_LEN64], text[GMT_LEN64] = {""};
+	char timeStr[32] = {""}, placeStr[128] = {""}, errorStr[128] = {""}, outfile[128] = {""}, abbrev[8] = {""}, fstats[MGD77_N_STATS][GMT_LEN64], text[GMT_LEN64] = {""};
 
 	bool *prevOffsetSign, prevFlag, prevType, decimated = false;
 	bool gotTime, landcruise, *offsetSign, newScale = false, mtf1, nav_error;

--- a/src/mgd77/mgd77track.c
+++ b/src/mgd77/mgd77track.c
@@ -76,7 +76,6 @@ struct MGD77TRACK_CTRL {	/* All control options for this program (except common 
 	} C;
 	struct D {	/* -D */
 		bool active;
-		bool mode;	/* true to skip recs with time == NaN */
 		double start;	/* Start time */
 		double stop;	/* Stop time */
 	} D;
@@ -353,8 +352,6 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77TRACK_CTRL *Ctrl, struct 
 			case 'D':		/* Assign start/stop times for sub-section */
 				Ctrl->D.active = true;
 				switch (opt->arg[0]) {
-				 	case 'A':		/* Start date, skip records with time = NaN */
-						Ctrl->D.mode = true;
 				 	case 'a':		/* Start date */
 						t = &opt->arg[1];
 						if (t && gmt_verify_expectations (GMT, GMT_IS_ABSTIME, gmt_scanf (GMT, t, GMT_IS_ABSTIME, &Ctrl->D.start), t)) {
@@ -362,8 +359,6 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77TRACK_CTRL *Ctrl, struct 
 							n_errors++;
 						}
 						break;
-					case 'B':		/* Stop date, skip records with time = NaN */
-						Ctrl->D.mode = true;
 					case 'b':		/* Stop date */
 						t = &opt->arg[1];
 						if (t && gmt_verify_expectations (GMT, GMT_IS_ABSTIME, gmt_scanf (GMT, t, GMT_IS_ABSTIME, &Ctrl->D.stop), t)) {

--- a/src/movie.c
+++ b/src/movie.c
@@ -1213,16 +1213,19 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		switch (format[0]) {	/* This parameter controls which version of month/day textstrings we use for plotting */
 			case 'F':	/* Full name, upper case */
 				upper_case = true;
+				/* fall through on purpose to 'f' */
 			case 'f':	/* Full name, lower case */
 				flavor = 0;
 				break;
 			case 'A':	/* Abbreviated name, upper case */
 				upper_case = true;
+				/* fall through on purpose to 'a' */
 			case 'a':	/* Abbreviated name, lower case */
 				flavor = 1;
 				break;
 			case 'C':	/* 1-char name, upper case */
 				upper_case = true;
+				/* fall through on purpose to 'c' */
 			case 'c':	/* 1-char name, lower case */
 				flavor = 2;
 				break;

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -1570,6 +1570,7 @@ char *psl_prepare_text (struct PSL_CTRL *PSL, char *text) {
 					break;
 				case '~':	/* Symbol font toggle */
 					psl_encodefont (PSL, PSL_SYMBOL_FONT);
+					/* Fall through and place the text? */
 				default:
 					string[j++] = '@';
 					string[j++] = text[i++];

--- a/src/potential/earthtide.c
+++ b/src/potential/earthtide.c
@@ -452,7 +452,7 @@ GMT_LOCAL void step2diu(double *xsta, double fhr, double t, double *xcorsta) {
 		0.,0.,1.,0.,0.,.01,0.,0. };
 
 	int i, j;
-	double h, t2, t3, t4, cosphi2, sinphi2, sin_tf, cos_tf;
+	double h, t2, t3, cosphi2, sinphi2, sin_tf, cos_tf;
 	double p, s, de, dn, dr, pr, ps, zla, tau, zns, rsta, cosla, sinla, thetaf, cosphi, sinphi;
 
 	/* ** note, following table is derived from dehanttideinelMJD.f (2000oct30 16:10) */
@@ -493,7 +493,6 @@ GMT_LOCAL void step2diu(double *xsta, double fhr, double t, double *xcorsta) {
 	/* *** v.dehant 2 */
 	t2 = t * t;
 	t3 = t * t2;
-	t4 = t2 * t2;
 	s = 218.31664563 + 481267.88194 * t - .0014663889 * t2 + 1.85139e-6 * t3;
 	tau = fhr * 15. + 280.4606184 + t * 36000.7700536 + t * 3.8793e-4 * t - t3 * 2.58e-8 - s;
 	pr = t * 1.396971278f + t * 3.08889e-4f * t + t3 * 2.1e-8f + t2 * 7e-9f;

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -407,7 +407,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOAST_CTRL *Ctrl, struct GMT
 				n_errors += gmt_getscale (GMT, 'L', opt->arg, GMT_SCALE_MAP, &Ctrl->L.scale);
 				break;
 			case 'm':
-				if (gmt_M_compat_check (GMT, 4))	/* Warn and fall through */
+				if (gmt_M_compat_check (GMT, 4))	/* Warn and fall through on purpose */
 					GMT_Report (API, GMT_MSG_COMPAT, "-m option is deprecated and reverted back to -M.\n");
 				else {
 					n_errors += gmt_default_error (GMT, opt->option);

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -271,8 +271,7 @@ GMT_LOCAL int parse_A_settings (struct GMT_CTRL *GMT, char *arg, struct PS2RASTE
 	 * Old : -A[-][u][<margins>][+g<fill>][+p<pen>][+r][+s|S[m]<width>[u][/<height>[u]]]
 	 */
 
-	bool error = false;
-	unsigned int pos = 0;
+	unsigned int pos = 0, error = 0;
 	int j, k = 0, trim_j = -1;
 	char txt[GMT_LEN128] = {""}, p[GMT_LEN128] = {""};
 	char txt_a[GMT_LEN64] = {""}, txt_b[GMT_LEN64] = {""}, txt_c[GMT_LEN64] = {""}, txt_d[GMT_LEN64] = {""};
@@ -996,7 +995,7 @@ GMT_LOCAL void possibly_fill_or_outline_BoundingBox (struct GMT_CTRL *GMT, struc
 /* ---------------------------------------------------------------------------------------------- */
 GMT_LOCAL int pipe_HR_BB(struct GMTAPI_CTRL *API, struct PS2RASTER_CTRL *Ctrl, char *gs_BB, double margin, double *w, double *h) {
 	/* Do what we do in the main code for the -A (if used here) option but on a in-memory PS 'file' */
-	char      cmd[GMT_LEN256] = {""}, buf[GMT_LEN128] = {""}, t[32] = {""}, *pch, c;
+	char      cmd[GMT_LEN512] = {""}, buf[GMT_LEN128] = {""}, t[32] = {""}, *pch, c;
 	int       fh, r, c_begin = 0;
 	size_t    n;
 	bool      landscape = false;

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -599,7 +599,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 						break;
 
 					case '>':	/* Paragraph text header */
-						if (gmt_M_compat_check (GMT, 4)) /* Warn and fall through */
+						if (gmt_M_compat_check (GMT, 4)) /* Warn and fall through on purpose */
 							GMT_Report (API, GMT_MSG_COMPAT, "Paragraph text header flag > is deprecated; use P instead\n");
 						else {
 							GMT_Report (API, GMT_MSG_NORMAL, "Unrecognized record (%s)\n", line);
@@ -1055,7 +1055,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 						break;
 
 					case '>':	/* Paragraph text header */
-						if (gmt_M_compat_check (GMT, 4)) {	/* Warn and fall through */
+						if (gmt_M_compat_check (GMT, 4)) {	/* Warn and fall through on purpose */
 							GMT_Report (API, GMT_MSG_COMPAT, "Paragraph text header flag > is deprecated; use P instead\n");
 							n = sscanf (&line[1], "%s %s %s %s %s %s %s %s %s", xx, yy, size, angle, font, key, lspace, tw, jj);
 							if (n < 0) n = 0;	/* Since -1 is returned if no arguments */

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -819,7 +819,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 	bool polygon, penset_OK = true, not_line, old_is_world, rgb_from_z = false;
 	bool get_rgb = false, clip_set = false, fill_active, may_intrude_inside = false;
 	bool error_x = false, error_y = false, def_err_xy = false, can_update_headpen = true;
-	bool default_outline, outline_active, geovector = false, save_W, save_G, QR_symbol = false;
+	bool default_outline, outline_active, geovector = false, save_W = false, save_G = false, QR_symbol = false;
 	unsigned int n_needed, n_cols_start = 2, justify, tbl;
 	unsigned int n_total_read = 0, j, geometry;
 	unsigned int bcol, ex1, ex2, ex3, change, pos2x, pos2y, save_u = false;
@@ -1345,6 +1345,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 							GMT_Report (API, GMT_MSG_VERBOSE, "Rounded rectangle corner radius = NaN near line %d\n", n_total_read);
 							continue;
 						}
+						/* Fall through on purpose to pick up the other parameters */
 					case PSL_RECT:
 						dim[0] = in[ex1];
 						if (gmt_M_is_dnan (dim[0])) {
@@ -1915,7 +1916,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 							gmt_M_memcpy (GMT->hidden.mem_coord[GMT_Y], L->data[GMT_Y], end, double);
 							/* Now add 2 anchor points and explicitly close by repeating 1st point */
 							switch (Ctrl->L.mode) {
-								case XHI:	off = 1;	/* To select the x max entry */
+								case XHI:	off = 1;	/* To select the x max entry then fall through */
 								case XLO:
 								case ZLO:
 									value = (Ctrl->L.mode == ZLO) ? Ctrl->L.value : GMT->common.R.wesn[XLO+off];
@@ -1923,7 +1924,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 									GMT->hidden.mem_coord[GMT_Y][end] = L->data[GMT_Y][end-1];
 									GMT->hidden.mem_coord[GMT_Y][end+1] = L->data[GMT_Y][0];
 									break;
-								case YHI:	off = 1;	/* To select the y max entry */
+								case YHI:	off = 1;	/* To select the y max entry then fall through */
 								case YLO:
 								case ZHI:
 									value = (Ctrl->L.mode == ZHI) ? Ctrl->L.value : GMT->common.R.wesn[YLO+off];

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1008,6 +1008,7 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 						continue;
 					}
 					data[n].dim[2] = in[ex3];	/* radius */
+					/* Now fall through to do the rest under regular rectangle */
 				case PSL_RECT:
 					if (gmt_M_is_dnan (in[ex1])) {
 						GMT_Report (API, GMT_MSG_VERBOSE, "Rounded rectangle width = NaN near line %d\n", n_total_read);
@@ -1590,7 +1591,7 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 							gmt_M_memcpy (GMT->hidden.mem_coord[GMT_Z], L->data[GMT_Z], end, double);
 							/* Now add 2 anchor points and explicitly close by repeating 1st point */
 							switch (Ctrl->L.mode) {
-								case XHI:	off = 1;	/* To select the x max entry */
+								case XHI:	off = 1;	/* To select the x max entry, then call through */
 								case XLO:
 								case ZLO:
 									value = (Ctrl->L.mode == ZLO) ? Ctrl->L.value : GMT->common.R.wesn[XLO+off];
@@ -1599,7 +1600,7 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 									GMT->hidden.mem_coord[GMT_Y][end] = L->data[GMT_Y][end-1];
 									GMT->hidden.mem_coord[GMT_Y][end+1] = L->data[GMT_Y][0];
 									break;
-								case YHI:	off = 1;	/* To select the y max entry */
+								case YHI:	off = 1;	/* To select the y max entry, then fall through */
 								case YLO:
 								case ZHI:
 									value = (Ctrl->L.mode == ZHI) ? Ctrl->L.value : GMT->common.R.wesn[YLO+off];

--- a/src/spotter/backtracker.c
+++ b/src/spotter/backtracker.c
@@ -267,7 +267,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct BACKTRACKER_CTRL *Ctrl, struct
 				break;
 
 			case 'e':
-				GMT_Report (API, GMT_MSG_COMPAT, "-e is deprecated and will be removed in 5.2.x. Use -E instead.\n");
+				GMT_Report (API, GMT_MSG_COMPAT, "-e is deprecated and was removed in 5.3. Use -E instead.\n");
 				/* Fall-through on purpose */
 			case 'E':	/* File with stage poles or a single rotation pole */
 				Ctrl->E.active = true;
@@ -286,11 +286,13 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct BACKTRACKER_CTRL *Ctrl, struct
 				switch (opt->arg[0]) {
 					case 'F':	/* Calculate flowlines */
 						Ctrl->L.stage_id = true;
+						/* Fall through on purpose tp 'f' */
 					case 'f':
 						Ctrl->L.mode = SPOTTER_FLOWLINE;
 						break;
 					case 'B':	/* Calculate hotspot tracks */
 						Ctrl->L.stage_id = true;
+						/* Fall through on purpose tp 'b' */
 					case 'b':
 						Ctrl->L.mode = SPOTTER_TRAILLINE;
 						break;

--- a/src/spotter/grdrotater.c
+++ b/src/spotter/grdrotater.c
@@ -205,7 +205,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDROTATER_CTRL *Ctrl, struct 
 				Ctrl->D.file = strdup (opt->arg);
 				break;
 			case 'e':
-				GMT_Report (API, GMT_MSG_COMPAT, "-e is deprecated and will be removed in 5.2.x. Use -E instead.\n");
+				GMT_Report (API, GMT_MSG_COMPAT, "-e is deprecated and was removed in 5.3. Use -E instead.\n");
 				/* Fall-through on purpose */
 			case 'E':	/* File with stage poles or a single rotation pole */
 				Ctrl->E.active = true;

--- a/src/spotter/originater.c
+++ b/src/spotter/originater.c
@@ -294,6 +294,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct ORIGINATOR_CTRL *Ctrl, struct 
 				switch (opt->arg[0]) {
 					case 'L':
 						Ctrl->L.degree = true;
+						/* Fall through on purpose to 'l' */
 					case 'l':
 						Ctrl->L.mode = 3;
 						break;
@@ -303,6 +304,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct ORIGINATOR_CTRL *Ctrl, struct 
 						break;
 					case 'T':
 						Ctrl->L.degree = true;
+						/* Fall through on purpose to 't' */
 					case 't':
 						Ctrl->L.mode = 1;
 						break;

--- a/src/spotter/rotconverter.c
+++ b/src/spotter/rotconverter.c
@@ -202,6 +202,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct ROTCONVERTER_CTRL *Ctrl, struc
 					case 'f':
 						if (gmt_M_compat_check (GMT, 4)) /* Warn and fall through */
 							GMT_Report (API, GMT_MSG_COMPAT, "-Ff is deprecated; use -Ft instead.\n");
+							/* Fall through on purpose to 't' */
 						else {
 							GMT_Report (API, GMT_MSG_NORMAL, "Must specify t|s\n");
 							n_errors++;

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -642,7 +642,7 @@ int GMT_subplot (void *V_API, int mode, void *args) {
 		uint64_t seg;
 		double x, y, width = 0.0, height = 0.0, tick_height, annot_height, label_height, title_height, y_header_off = 0.0;
 		double *px = NULL, *py = NULL, y_heading, fluff[2] = {0.0, 0.0}, off[2] = {0.0, 0.0}, GMT_LETTER_HEIGHT = 0.736;
-		char **Bx = NULL, **By = NULL, *cmd = NULL, axes[3] = {""}, Bopt[GMT_LEN64] = {""};
+		char **Bx = NULL, **By = NULL, *cmd = NULL, axes[3] = {""}, Bopt[GMT_LEN256] = {""};
 		char vfile[GMT_STR16] = {""}, xymode = 'r', report[GMT_LEN256] = {""}, txt[GMT_LEN32] = {""};
 		bool add_annot;
 		FILE *fp = NULL;

--- a/src/triangulate.c
+++ b/src/triangulate.c
@@ -248,7 +248,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct TRIANGULATE_CTRL *Ctrl, struct
 				n_errors += gmt_parse_inc_option (GMT, 'I', opt->arg);
 				break;
 			case 'm':
-				if (gmt_M_compat_check (GMT, 4)) /* Warn and fall through */
+				if (gmt_M_compat_check (GMT, 4)) /* Warn and fall through on purpose */
 					GMT_Report (API, GMT_MSG_COMPAT, "-m option is deprecated and reverted back to -M.\n");
 				else {
 					n_errors += gmt_default_error (GMT, opt->option);

--- a/src/x2sys/x2sys_cross.c
+++ b/src/x2sys/x2sys_cross.c
@@ -260,7 +260,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct X2SYS_CROSS_CTRL *Ctrl, struct
 					GMT_Report (API, GMT_MSG_COMPAT, "Option -J is no longer needed or used in x2sys_cross, ignored\n");
 					break;
 				}
-				/* If not compat mode we fall down here and fail I think */
+				/* If not compat mode we fall down here on purpose and fail I think */
 			default:	/* Report bad options */
 				n_errors += gmt_default_error (GMT, opt->option);
 				break;
@@ -358,7 +358,7 @@ int GMT_x2sys_cross (void *V_API, int mode, void *args) {
 	uint64_t add_chunk;
 	int scol;
 	int error = 0;				/* nonzero for invalid arguments */
-	int iplat;				/* Sign of pole for reprojections */
+	int iplat = 0;				/* Sign of pole for reprojections */
 	unsigned int *ok = NULL;
 
 	bool xover_locations_only = false;	/* true if only x,y (and possible indices) to be output */
@@ -392,8 +392,8 @@ int GMT_x2sys_cross (void *V_API, int mode, void *args) {
 	double dist_scale;			/* Scale to give selected distance units */
 	double vel_scale;			/* Scale to give selected velocity units */
 	double t_scale;				/* Scale to give time in seconds */
-	double plat[2];				/* Pole latitude for polar reprojections */
-	double ymin[2], ymax[2];		/* Latitude range of each file */
+	double plat[2] = {0.0, 0.0};		/* Pole latitude for polar reprojections */
+	double ymin[2] = {0.0, 0.0}, ymax[2] = {0.0, 0.0};	/* Latitude range of each file */
 
 	clock_t tic = 0, toc = 0;
 

--- a/src/x2sys/x2sys_datalist.c
+++ b/src/x2sys/x2sys_datalist.c
@@ -316,6 +316,7 @@ int GMT_x2sys_datalist (void *V_API, int mode, void *args) {
 		case 'm':
 			if (gmt_M_compat_check (GMT, 4)) /* Warn and fall through */
 				GMT_Report (API, GMT_MSG_COMPAT, "Unit m for miles is deprecated; use unit M instead\n");
+				/* Fall through on purpose to 'M' */
 			else {
 				GMT_Report (API, GMT_MSG_NORMAL, "Unit m for miles is not recognized\n");
 				x2sys_end (GMT, s);
@@ -352,6 +353,7 @@ int GMT_x2sys_datalist (void *V_API, int mode, void *args) {
 		case 'm':
 			if (gmt_M_compat_check (GMT, 4)) /* Warn and fall through */
 				GMT_Report (API, GMT_MSG_COMPAT, "Unit m for miles is deprecated; use unit M instead\n");
+				/* Fall through on purpose to 'M' */
 			else {
 				GMT_Report (API, GMT_MSG_NORMAL, "Unit m for miles is not recognized\n");
 				x2sys_end (GMT, s);

--- a/src/x2sys/x2sys_solve.c
+++ b/src/x2sys/x2sys_solve.c
@@ -289,7 +289,7 @@ GMT_LOCAL uint64_t next_unused_track (uint64_t *cluster, uint64_t n) {
 }
 
 int GMT_x2sys_solve (void *V_API, int mode, void *args) {
-	char **trk_list = NULL, text[GMT_BUFSIZ] = {""}, frmt_name[8] = {""};
+	char **trk_list = NULL, text[GMT_BUFSIZ] = {""}, frmt_name[16] = {""};
 	char trk[2][GMT_LEN64], line[GMT_BUFSIZ] = {""};
 	char file_TAG[GMT_LEN64] = {""}, file_column[GMT_LEN64] = {""};
 	bool grow_list = false, normalize = false, first = true, active_col[N_COE_PARS];

--- a/src/xyz2grd.c
+++ b/src/xyz2grd.c
@@ -676,7 +676,7 @@ int GMT_xyz2grd (void *V_API, int mode, void *args) {
 					flag[ij]++;
 					break;
 				case 'S': 	/* Add up squares and means to compute standard deviation */
-					data[ij] += (gmt_grdfloat)in[zcol];	/* This adds up the means; we fall through to next case to also add up squares */
+					data[ij] += (gmt_grdfloat)in[zcol];	/* This adds up the means; we fall through to next case on purpose to also add up squares */
 				case 'r': 	/* Add up squares in case we must rms */
 					Grid->data[ij] += (gmt_grdfloat)in[zcol] * (gmt_grdfloat)in[zcol];
 					flag[ij]++;
@@ -738,12 +738,14 @@ int GMT_xyz2grd (void *V_API, int mode, void *args) {
 							break;
 						case 'd':	/* Keep the lowest in 'data' */
 							if (data[ij_east] < data[ij_west]) data[ij_west] = data[ij_east];
+							/* Fall through on purpose since range also needs the highsets */
 						case 'u':	/* Keep the highest */
 							if (Grid->data[ij_east] > Grid->data[ij_west]) Grid->data[ij_west] = Grid->data[ij_east];
 							flag[ij_west] += flag[ij_east];
 							break;
 						case 'S':	/* Sum up the sums in 'data' */
 							data[ij_west] += data[ij_east];
+							/* Fall through on purpose */
 						default:	/* Add up in case we must sum, rms, mean, or standard deviation */
 							Grid->data[ij_west] += Grid->data[ij_east];
 							flag[ij_west] += flag[ij_east];


### PR DESCRIPTION
This PR fixes a bunch of issues that yielded compiler warnings with gcc but not with clang on OSX.  The types of issues addressed are:

- Instances where a bool variable was used for counting (bool error++)
- Instances with sprintf printing text that could potentially be longer than the buffer
- Statements fall through in switches.  While these are all intentional, I have made sure each instance has a comment to that effect.
- A few uninitialized variables
- A few set but unused variables.

No change to the number of tests that pass.