### PR TITLE
Clarify that grdview -N+gfill does not apply to oblique projections

### DIFF
--- a/doc/rst/source/grdview_common.rst_
+++ b/doc/rst/source/grdview_common.rst_
@@ -74,7 +74,7 @@ Optional Arguments
 
 **-N**\ *level*\ [**+g**\ *fill*]
     Draws a plane at this z-level. If the optional *color* is provided
-    via the **+g** modifier,
+    via the **+g** modifier, and the projection is not oblique,
     the frontal facade between the plane and the data perimeter is
     colored. See **-Wf** for setting the pen used for the outline. 
 

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -439,8 +439,8 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   To derive intensities from <grd_z> instead, append +a<azim> [-45] and +n<method> [t1].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use -I+ to accept the default values (see grdgradient for details).\n");
 	GMT_Option (API, "K");
-	GMT_Message (API, GMT_TIME_NONE, "\t-N Draw a horizontal plane at z = <level>. Append +g<fill> to paint\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   the facade between the plane and the data perimeter.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-N Draw a horizontal plane at z = <level>. For rectangular projections, append +g<fill>\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   to paint the facade between the plane and the data perimeter.\n");
 	GMT_Option (API, "O,P");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Q Set plot request. Choose one of the following:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   -Qm for Mesh plot [Default]. Append <color> for mesh paint [%s].\n",
@@ -729,7 +729,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT
 		if (Ctrl->G.n == 3)
 			Ctrl->G.image = true;
 	}
-	
+	if (Ctrl->N.facade && GMT->common.R.oblique) {	/* Cannot yet do facade with oblique grid */
+		GMT_Report (API, GMT_MSG_VERBOSE, "Cannot paint facade for oblique projection\n");
+		Ctrl->N.facade = false;
+	}
+		
 	n_errors += gmt_M_check_condition (GMT, !Ctrl->In.file, "Syntax error: Must specify input file\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->In.file && !strcmp (Ctrl->In.file, "="),
 	                                   "Error: Piping of topofile not supported!\n");


### PR DESCRIPTION
Since we need to sample the grid along the boundaries, the facade fill option **-N+g**_fill_ does not yet handle cases where the grid is oblique with respect to the map boundaries (i.e., when **+r** is used in **-R**).  The usage and documentation have been updated to state this.  Related to #553 which also pointed out a problem in reading grids via GDAL.