### PR TITLE
Update x2sys tools and docs

### DIFF
--- a/doc/rst/source/supplements/x2sys/x2sys_list.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_list.rst
@@ -99,7 +99,10 @@ Optional Arguments
     specified track only (except for **n**,\ **N** which then refers to
     the other track). The sign convention for **c**,\ **i** is track one
     minus track two (lexically sorted). Time intervals will be returned
-    according to the **TIME_UNIT** GMT defaults setting.
+    according to the **TIME_UNIT** GMT defaults setting.  The output order
+    of the columns follows the order they were given in *flags* with the
+    exception that **n**, if chosen, will always be placed after all
+    numeric columns (it becomes part of the trailing text).
 
 .. _-i:
 
@@ -160,6 +163,14 @@ Optional Arguments
 .. include:: ../../explain_-bo.rst_
 
 .. include:: ../../explain_help.rst_
+
+Input Format
+------------
+
+In moving to a more robust data record definition in GMT 6, all text
+items are now placed after all numerical items.  For **x2sys_list**, this
+means that whereas the *ID1, ID2* track ids used to be written to the first two
+columns, they are now placed at the end as part of the trailing text.
 
 Examples
 --------

--- a/doc/rst/source/supplements/x2sys/x2sys_solve.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_solve.rst
@@ -58,33 +58,31 @@ Required Arguments
     The correction type you wish to model. Choose among the following
     functions f(*p*) , where *p* are the *m*
     parameters per track that we will fit simultaneously using a least
-    squares approach:
+    squares approach.  Each type implies a certain input data record
+    format:
 
     **c** will fit f(*p*) = *a* (a constant offset);
-    records must contain track ID1, ID2, COE.
+    records must contain track COE, ID1, ID2.
 
     **d** will fit f(*p*) = *a* + *b* \* *d* (linear
-    drift; *d* is distance; records must contain track ID1, ID2, d1,
-    d2, COE.
+    drift; *d* is distance; records must contain track d1, d2, COE, ID1, ID2.
 
     **g** will fit f(*p*) = *a* + *b* sin(y)^2
-    (1980-1930 gravity correction); records must contain track ID1,
-    ID2, latitude y, COE.
+    (1980-1930 gravity correction); records must contain track latitude y, COE, ID1, ID2.
 
     **h** will fit f(*p*) = *a* + *b* cos(H) + *c*
     cos(2H) + *d* sin(H) + *e* sin(2H)
-    (magnetic heading correction); records must contain track ID1, ID2,
-    heading H, COE.
+    (magnetic heading correction); records must contain track heading H, COE, ID1, ID2.
 
     **s** will fit f(*p*) = *a* \* z (a unit scale
-    correction); records must contain track ID1, ID2, z1, z2.
+    correction); records must contain track z1, z2, ID1, ID2.
 
     **t** will fit f(*p*) = *a* + *b* \* (*t - t0*)
     (linear drift; *t0* is the start time of the track); records must
-    contain track ID1, ID2, t1-t0, t2-t0, COE.
+    contain track It1-t0, t2-t0, COE, D1, ID2.
 
     **z** will fit f(*p*) = *a* + *b* \* z (an offset plus a unit scale
-    correction); records must contain track ID1, ID2, z1, z2.
+    correction); records must contain track z1, z2, ID1, ID2.
 
 
 Optional Arguments
@@ -98,8 +96,8 @@ Optional Arguments
 .. _-W:
 
 **-W**
-    Means that each input records has an extra column with the composite
-    weight for each crossover record. These are used to obtain a
+    Means that each input records has an extra column just before the ID columns
+    with the composite weight for each crossover record. These are used to obtain a
     weighted least squares solution [no weights]. Append **u** to report
     unweighted mean/std [Default, report weighted stats].
 
@@ -128,6 +126,15 @@ determine the number of clusters and automatically add the required
 constraint equations.  If you need a particular reference track to have
 a particular offset (e.g., 0) then you can subtract the offset you
 found from every track correction and add in the desired offset.
+
+Input Format
+------------
+
+In moving to a more robust data record definition in GMT 6, all text
+items are now placed after the numerical columns.  For **x2sys_solve**, this
+means that whereas the *ID1, ID2* track ids used to be expected in the first two
+columns, they are now expected at the end.  Thus, you cannot use this module with
+crossover tables produced by an earlier GMT version without reformatting.
 
 Examples
 --------

--- a/src/x2sys/x2sys_list.c
+++ b/src/x2sys/x2sys_list.c
@@ -132,7 +132,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   asymmetry = (n_right - n_left)/(n_right + n_left) [1, i.e., use all tracks].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-E Enhanced ASCII output: Add segment header with track names and number of crossovers [no segment headers].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-F Specify any combination of %s in the order of desired output:\n", LETTERS);
-	GMT_Message (API, GMT_TIME_NONE, "\t   Note: n, if chosen, will always be trailing text at the end of the output record\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Exception: n, if chosen, will always be placed at the end of the output record.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   a Angle (<= 90) between the two tracks at the crossover.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   c Crossover error in chosen observable (see -C).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   d Distance along tracks at the crossover.\n");

--- a/src/x2sys/x2sys_solve.c
+++ b/src/x2sys/x2sys_solve.c
@@ -412,7 +412,7 @@ int GMT_x2sys_solve (void *V_API, int mode, void *args) {
 
 	bin_expect = n_in + 2;
 	w_col = n_in - 1;
-	id_col = w_col;
+	id_col = w_col;		/* For binary files, ID columns start at end of record */
 	min_ID = INT_MAX;	max_ID = -INT_MAX;
 
 	if (GMT->common.b.active[GMT_IN] && GMT->common.b.ncol[GMT_IN] < bin_expect) {
@@ -439,8 +439,8 @@ int GMT_x2sys_solve (void *V_API, int mode, void *args) {
 				gmt_M_free (GMT, trk_list);
 				Return (GMT_RUNTIME_ERROR);
 			}
-			if (gmt_M_rec_is_table_header (GMT)) {
-				if (first) {
+			else if (gmt_M_rec_is_table_header (GMT)) {
+				if (first) {	/* Must parse the first header to see if content matches tag and selected column */
 					sscanf (&GMT->current.io.curr_text[6], "%s %s", file_TAG, file_column);
 					if (strcmp (Ctrl->T.TAG, file_TAG) && strcmp (Ctrl->C.col, file_column)) {
 						GMT_Report (API, GMT_MSG_NORMAL,
@@ -450,10 +450,10 @@ int GMT_x2sys_solve (void *V_API, int mode, void *args) {
 					}
 					first = false;
 				}
-				continue;
 			}
-			if (gmt_M_rec_is_eof (GMT)) 		/* Reached end of file */
+			else if (gmt_M_rec_is_eof (GMT)) 		/* Reached end of file */
 				break;
+			continue;
 		}
 		in = In->data;
 		if (In->text) {


### PR DESCRIPTION
The switch to a modern data record with text at the end was not explained in the docs, and somewhat unrelated, x2sys_solve had no protection against a segment header record.  I have clarified in x2sys_list that track IDs are always written at the end of the record whereas all other selected (numerical) items are written in the order requested in **-F**.  Likewise, x2sys_solve documentation now states that the track IDs are to be in the trailing text (ASCII) or the last two columns (binary id values).  This PR closes #566 