### PR TITLE
A variety of rst fixes plus a few code standardizations

### DIFF
--- a/doc/rst/source/begin.rst_
+++ b/doc/rst/source/begin.rst_
@@ -18,10 +18,14 @@ Synopsis
 Description
 -----------
 
-The **begin** module tells GMT to begin a new modern session.  If your script only makes
-a single plot then this is the most straightforward way to specify the name
+The **begin** module instructs GMT to begin a new modern session.  If your script only makes
+a single plot then this is the most opportune time to specify the name
 and format(s) of your plot.  However, if multiple illustrations will be made
-then you will need to use :doc:`figure` as well.
+then you will instead use :doc:`figure` for each figure you wish to make.  The session
+keeps track of all default and history settings and isolates them from any other session
+that may run concurrently.  Thus unlike in classic mode you can run multiple modern sessions
+simultaneously without having destructive interference in updating the history of common
+options.
 
 Optional Arguments
 ------------------
@@ -30,12 +34,13 @@ Optional Arguments
 
 *prefix*
     Name-stem used to construct the single final figure name.  The extension is appended
-    automatically from your *formats* selection(s) [gmtsession].
+    automatically from your *formats* selection(s) [gmtsession].  If your script only
+    performs calculations or needs to make several figures then you will not use this argument.
 
 .. _begin-formats:
 
 *formats*
-    Give one or more comma-separated graphics extensions from the list of allowable graphics
+    Give one or more comma-separated graphics extensions from the list of allowable graphics formats
     :ref:`formats <tbl-formats>` [pdf].
 
 .. _begin-V:
@@ -90,16 +95,7 @@ are produced then we do not need to give any further arguments:
 Should we give such a command and still produce a plot then it will automatically
 be called gmtsession.pdf.
 
-Note on PostScript
-------------------
-
-If the user selects **ps** as one of the formats, then please be aware that
-it is recommended you first set the desired paper size.  GMT needs to
-work with a fixed paper size since, unlike the **eps** format, there will be
-no cropping to BoundingBox.  If no paper size is specified via :ref:`PS_MEDIA <PS_MEDIA>`
-then GMT will default to A4 and issue a warning; GMT is unable to determine if that
-size is adequate for your plot but if the plot width exceeds A4 paper width we will
-switch page orientation to landscape.
+.. include:: explain_postscript.rst_
 
 See Also
 --------

--- a/doc/rst/source/clear.rst_
+++ b/doc/rst/source/clear.rst_
@@ -19,7 +19,7 @@ Description
 -----------
 
 The clear command allows users to delete their current history, conf,
-or cpt file, remove the entire user cache, data, or sessions directory, or all of the above.
+or cpt files, remove the entire user cache, data, or sessions directory, or all of the above.
 
 Optional Arguments
 ------------------
@@ -32,7 +32,7 @@ Optional Arguments
 .. _clear-conf:
 
 *conf*
-    Delete the current gmt.conf file used for the modern session.
+    Delete the current gmt.conf file used for the current modern session.
 
 .. _clear-cpt:
 
@@ -42,12 +42,12 @@ Optional Arguments
 .. _clear-cache:
 
 *cache*
-    Delete the user's cache directory and its contents.
+    Delete the user's cache directory and all of its contents.
 
 .. _clear-data:
 
 *data*
-    Delete the user's data download directory and its contents.
+    Delete the user's data download directory and all of its contents.
 
 .. _clear-history:
 

--- a/doc/rst/source/docs.rst_
+++ b/doc/rst/source/docs.rst_
@@ -9,7 +9,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt docs** [ **-Q** ] *<module-name>* [*-option*]
+**gmt docs** [ **-Q** ] *module-name* [*-option*]
 
 |No-spaces|
 
@@ -18,10 +18,10 @@ Description
 
 **docs** tells GMT to display the HTML version of a module's documentation using the default browser.
 For the time being, only modern mode module names are displayed. That is, if user asks for
-*gmt docs psxy* she will see the *plot* documentation. Besides the modules names, the special
+*gmt docs psxy* she will see the (near-equivalent) *plot* documentation. Besides the modules names, the special
 forms *cookbook*, *gallery*, *gmt.conf*, *api* and *tutorial* are also accepted.
 
-However, **docs** can also be used to open local files such as PDF or image files or
+However, **docs** can also be used to open local files such as PDF or image files or even
 web link addresses.
 
 Optional Arguments
@@ -29,7 +29,8 @@ Optional Arguments
 
 **-Q**
     This option means we are doing a "dry-run" and simply want the final URL to be
-    printed to standard output.  No browser command will take place.
+    printed to standard output.  No browser command will take place. This is useful
+    if you are working remotely on a server and do not wish to launch a GUI browser.
 
 
 Optional Module Arguments
@@ -37,7 +38,7 @@ Optional Module Arguments
 
 *-option*
     Where *-option* is the one-letter option of the module in question (e.g, **-R**).
-    It then displays the documentation positioned at that specific option.
+    We then display the *module* documentation positioned at that specific option.
 
 Examples
 --------
@@ -73,6 +74,12 @@ To see the beautiful figure that I just created with GMT.
    ::
 
     gmt docs my_beautiful_figure.pdf
+
+To display the URL to the surface man page,.run
+
+   ::
+
+    gmt docs -Q surface
 
 See Also
 --------

--- a/doc/rst/source/end.rst_
+++ b/doc/rst/source/end.rst_
@@ -18,8 +18,9 @@ Synopsis
 Description
 -----------
 
-This **end** module terminates the modern mode and finalizes the processing of all registered
-figures.  The final graphics will be placed in the current directory.
+This **end** module terminates the modern mode session created with **begin** and finalizes the processing of all registered
+figures.  The final graphics will be placed in the current directory and the hidden sessions directory
+will be removed.
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/explain_distcalc.rst_
+++ b/doc/rst/source/explain_distcalc.rst_
@@ -1,2 +1,2 @@
-**-je**\ \|\ **f**\ \|\ **g** :ref:`(more ...) <-j_full>`
-    Determine how spherical distances are calculated. |Add_-j|
+**-je**\ \|\ **f**\ \|\ **g** :ref:`(more ...) <distcalc_full>`
+    Determine how spherical distances are calculated.

--- a/doc/rst/source/explain_distcalc_full.rst_
+++ b/doc/rst/source/explain_distcalc_full.rst_
@@ -1,4 +1,4 @@
-.. _-j_full:
+.. _distcalc_full:
 
 **-je**\ \|\ **f**\ \|\ **g**
     Determine how spherical distances are calculated in modules that support this.

--- a/doc/rst/source/explain_postscript.rst_
+++ b/doc/rst/source/explain_postscript.rst_
@@ -1,0 +1,11 @@
+Note on PostScript
+------------------
+
+If the user selects **ps** as one of the formats, then please be aware that
+it is recommended you first set the desired paper size.  With *ps, GMT needs to
+work with a fixed paper size since, unlike the **eps** format, there will be
+no cropping to BoundingBox.  If no paper size is specified via :ref:`PS_MEDIA <PS_MEDIA>`
+then GMT will default to A4 and issue a warning; GMT is unable to determine if that
+size is adequate for your plot but if the canvas width exceeds A4 paper width we will
+switch page orientation to landscape. For all other formats the final dimension will
+be determined automatically.

--- a/doc/rst/source/figure.rst_
+++ b/doc/rst/source/figure.rst_
@@ -19,21 +19,22 @@ Description
 -----------
 
 A GMT modern session can make any number of illustrations (including none).
-In situations when many illustrations will be made during the session,
-the **figure** module specifies the name and format(s) to use for the current plot.
-It must be issued before you start plotting to the current figure, and each
+In situations when many illustrations will be made during a single session,
+the **figure** module is used to specify the name and format(s) to use for the next plot.
+It must be issued before you start plotting to the intended figure, and each
 new **figure** call changes plotting focus to the next figure.  You may go back and forth between
-different figure but the optional arguments (*formats* and *options*) can only
+different figures but the optional arguments (*formats* and *options*) can only
 be given the first time you specify a new figure.
 In addition to *prefix* and *formats*, you can supply a comma-separated series of
 :doc:`psconvert` options that will override the default settings provided via
-:ref:`PS_CONVERT <PS_CONVERT>`. The only other available option controls verbosity.
+:ref:`PS_CONVERT <PS_CONVERT>` [**A**]. The only other available options control verbosity
+and default parameter settings.
 
 Required Arguments
 ------------------
 
 *prefix*
-    Name stem used to construct final figure names,  The extension is appended
+    Name stem used to construct the figure name.  The extension(s) are appended
     automatically from your *formats* selection(s).
 
 Optional Arguments
@@ -48,8 +49,8 @@ Optional Arguments
 .. _figure-options:
 
 *options*
-    Sets one or more comma-separated options arguments that
-    can be passed to :doc:`psconvert` when preparing this figure [A].
+    Sets one or more comma-separated options (and possibly arguments) that
+    can be passed to :doc:`psconvert` when preparing this figure [**A**].
     The valid subset of options are
     **A**\ [*args*],\ **C**\ *args*,\ **D**\ *dir*,\ **E**\ *dpi*,\ **H**\ *factor*,\ **M**\ *args*,\ **Q**\ *args*,\ **S**.
     See the :doc:`psconvert` documentation for details on these options.
@@ -60,6 +61,8 @@ Optional Arguments
 .. include:: explain_-V.rst_
 
 .. include:: explain_help.rst_
+
+.. include:: explain_postscript.rst_
 
 Examples
 --------

--- a/doc/rst/source/inset.rst_
+++ b/doc/rst/source/inset.rst_
@@ -4,11 +4,11 @@
 
     Manage figure inset setup and completion
 
-The **inset** module is used to carve out a sub-region of the current plot and
-limit further plotting to that section of the canvas.  The inset setup is started with the **begin**
-mode that defines the placement and size of the inset.  Subsequent plot commands will be directed
-to that window.  The inset is completed via the **end** mode, which reverts operations to the full
-canvas and restores the plot region and projection that was in effect prior to the setup of the inset.
+The **inset** module is used to carve out a sub-region of the current plot canvas and
+restrict further plotting to that section of the canvas.  The inset setup is started with the **begin**
+directive that defines the placement and size of the inset.  Subsequent plot commands will be directed
+to that window.  The inset is completed via the **end** directive, which reverts operations to the full
+canvas and restores the plot region and map projection that was in effect prior to the setup of the inset.
 
 Synopsis (begin mode)
 ---------------------
@@ -27,8 +27,8 @@ Synopsis (begin mode)
 Description
 -----------
 
-The **begin** mode of inset defines the dimension and placement of the inset canvas.  It
-makes a note of the current region and projection so that we may return to the initial
+The **begin** directive of **inset** defines the dimension and placement of the inset canvas.  It
+records the current region and projection so that we may return to the initial
 plot environment when  the inset is completed.
 
 Required Arguments
@@ -98,8 +98,8 @@ Synopsis (end mode)
 
 **gmt inset end** [ |SYN_OPT-V| ]
 
-This command finalizes the current inset, which returns the plotting environment to
-the state prior to the start of the inset.  The previous region and projection will be
+The **end** directive finalizes the current inset, which returns the plotting environment to
+the state prior to the start of the inset.  The previous region and map projection will be
 in effect going forward.
 
 Optional Arguments
@@ -114,7 +114,7 @@ Optional Arguments
 Examples
 --------
 
-To make a simple basemap layout with an inset called inset.pdf, try
+To make a simple basemap plot called inset.pdf that demonstrates the inset module, try
 
    ::
 

--- a/doc/rst/source/subplot.rst_
+++ b/doc/rst/source/subplot.rst_
@@ -4,10 +4,10 @@
 
     Manage modern mode figure subplot configuration and selection
 
-The **subplot** module is used to split the current figure into a matrix of subplots
+The **subplot** module is used to split the current figure into a rectangular layout of subplots
 that each may contain a single panel figure.  A subplot setup is started with the **begin**
-mode that defines the layout of the subplots, while positioning to a particular panel for
-plotting is done via the **set** mode.  The subplot is completed via the **end** mode.
+directive that defines the layout of the subplots, while positioning to a particular panel for
+plotting is done via the **set** directive.  The subplot is completed via the **end** directive.
 
 Synopsis (begin mode)
 ---------------------
@@ -32,8 +32,8 @@ Synopsis (begin mode)
 Description
 -----------
 
-The **begin** mode of subplot defines the layout of the entire multi-panel illustration.  Several
-options are available to specify the systematic layout, labeling, dimensions, and more.
+The **begin** directive of subplot defines the layout of the entire multi-panel illustration.  Several
+options are available to specify the systematic layout, labeling, dimensions, and more for the panels.
 
 Required Arguments
 ------------------
@@ -52,7 +52,7 @@ Required Arguments
     a single panel.
 
 **-Ff**
-    Specify the final figure dimensions.  The subplot dimensions are then calculated from the figure
+    Specify the final **f**igure dimensions.  The subplot dimensions are then calculated from the figure
     dimensions after accounting for the space that optional tick marks, annotations, labels, and margins occupy between panels.
     The annotations, ticks, and labels along the outside perimeter are not counted as part of the figure dimensions.
     To specify different subplot dimensions for each row (or column), append **+f** followed by a comma-separated list of width
@@ -61,7 +61,7 @@ Required Arguments
     A single number means constant widths (or heights) [Default].
 
 **-Fs**
-    Specify the dimensions of each subplot directly.  Then, the figure dimensions are computed from the
+    Specify the dimensions of each **s**ubplot directly.  Then, the figure dimensions are computed from the
     subplot dimensions after adding the space that optional tick marks, annotations, labels, and margins occupy between panels.
     The annotations, ticks, and labels along the outside perimeter are not counted as part of the figure dimensions.
     To specify different subplot dimensions for each row (or column),  append a colon followed by a comma-separated list of widths,
@@ -87,7 +87,7 @@ Optional Arguments
     Note: **+j** sets the justification of the tag to *refpoint* (suitable for interior tags)
     while **+J** instead selects the mirror opposite (suitable for exterior tags).
     Append **+c**\ *dx*\ [/*dy*] to set the clearance between the tag and a surrounding text box
-    requested via **+g** or **p** [3pt/3pt, i.e., 15% of the :ref:`FONT_TAG size <FONT_TAG>` size].
+    requested via **+g** or **+p** [3pt/3pt, i.e., 15% of the :ref:`FONT_TAG size <FONT_TAG>` dimension].
     Append **+g**\ *fill* to paint the tag's text box with *fill* [no painting].
     Append **+o**\ *dx*\ [/*dy*] to offset the tag's reference point in the direction implied
     by the justification [4pt/4pt, i.e., 20% of the :ref:`FONT_TAG size <FONT_TAG>`].
@@ -104,7 +104,7 @@ Optional Arguments
     Reserve a space of dimension *clearance* between the margin and the subplot on the specified
     side, using *side* values from **w**, **e**, **s**, or **n**.  The option is repeatable to set aside space
     on more than one side.  Such space will be left untouched by the main map plotting but can
-    be accessed by modules that plot scales, bars, text, etc.  Settings specified under **begin** mode apply to all panels.
+    be accessed by modules that plot scales, bars, text, etc.  Settings specified under **begin** directive apply to all panels.
 
 .. _-J:
 
@@ -114,7 +114,7 @@ Optional Arguments
 .. _subplot_begin-M:
 
 **-M**\ *margins*
-    This is clearance that is added around each subplot beyond the automatic space allocated for tick marks,
+    This is margin space that is added around each subplot beyond the automatic space allocated for tick marks,
     annotations, and labels.  The margins can be a single value, a pair of values separated by slashes
     (for setting separate horizontal and vertical margins), or the full set of four margins (for setting
     separate left, right, bottom, and top margins) [0.5c].
@@ -123,20 +123,21 @@ Optional Arguments
 
 .. |Add_-R| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-R.rst_
+    This is useful when all subplots share a common plot domain.
 
 .. _subplot_begin-S:
 
 **-S**\ *layout*
     Set subplot layout for shared axes. May be set separately for rows (**-SR**) and columns (**-SC**).
-    **-SC**: Use when all subplots in a **C**\ olumn share a common *x*-range. The first (i.e., **t**\ op) and the last
+    Considerations for **-SC**: Use when all subplots in a **C**\ olumn share a common *x*-range. The first (i.e., **t**\ op) and the last
     (i.e., **b**\ ottom) rows will have *x* annotations; append **t** or **b** to select only one of those two rows [both].
     Append **+l** if annotated *x*-axes should have a label [none]; optionally append the label if it is the same
     for the entire subplot.
-    **-SR**: Use when all subplots in a **R**\ ow share a common *y*-range. The first (i.e., **l**\ eft) and the last
+    Considerations for **-SR**: Use when all subplots in a **R**\ ow share a common *y*-range. The first (i.e., **l**\ eft) and the last
     (i.e., **r**\ ight) columns will have *y*-annotations; append **l** or **r** to select only one of those two columns [both].
     Append **+l** if annotated *y*-axes will have a label [none]; optionally, append the label if it is the same
     for the entire subplot.
-    Append **+p** to make all annotations axis-parallel [horizontal]; if used you may have to set **-C** to secure
+    Append **+p** to make all annotations axis-parallel [horizontal]; if not used you may have to set **-C** to secure
     extra space for long horizontal annotations.
     Append **+t** to make space for subplot titles for each row; use **+tc** for top row titles only [no subplot titles].
     Labels and titles that depends on which row or column are specified as usual via a panel's **-B** setting.
@@ -213,7 +214,7 @@ Synopsis (end mode)
 
 This command finalizes the current subplot, including any placement of tags, and updates the
 dimensions of the last plot to that of the entire subplot. This allows **-X** and **-Y** to
-use *w* and *h* in setting the current point relative to the entire subplot.  We also reset
+use the codes *w* and *h* in setting the current point relative to the entire subplot.  We also reset
 the current plot location to where it was prior to the subplot.
 
 Optional Arguments

--- a/doc/rst/source/supplements/img/img2grd.rst
+++ b/doc/rst/source/supplements/img/img2grd.rst
@@ -15,10 +15,10 @@ Synopsis
 
 **gmt img2grd** *imgfile* |-G|\ *grdfile*
 |SYN_OPT-R|
-|-T|\ *type*
 [ |-C| ]
 [ |-D|\ [*minlat/maxlat*] ] [ |-E| ] [ |-I|\ *inc* ]
 [ |-M| ] [ |-N|\ *navg* ] [ |-S|\ [*scale*] ]
+[ |-T|\ *type* ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *maxlon* ]
 [ |SYN_OPT-n| ]

--- a/doc/rst/source/supplements/meca/coupe_common.rst_
+++ b/doc/rst/source/supplements/meca/coupe_common.rst_
@@ -41,25 +41,25 @@ Required Arguments
 **-A**
   selects the cross-section.
 
-  **-Aa**\ *lon1/lat1/lon2/lat2/dip/p\_width/dmin/dmax*\ [**f**]
+  **-Aa**\ *lon1/lat1/lon2/lat2/dip/p\_width/dmin/dmax*\ [**+f**]
      *lon* and *lat* are the longitude and latitude of points 1 and 2
      limiting the length of the cross-section. *dip* is the dip of the plane
      on which the cross-section is made. *p\_width* is the width of the
      cross-section on each side of a vertical plane or above and under an
      oblique plane. *dmin* and *dmax* are the distances min and max from
-     horizontal plane, along steepest descent direction. Add **f** to get the
+     horizontal plane, along steepest descent direction. Add **+f** to get the
      frame from the cross-section parameters.
 
-  **-Ab**\ *lon1/lat1/strike/p\_length/dip/p\_width/dmin/dmax*\ [**f**\ ]
+  **-Ab**\ *lon1/lat1/strike/p\_length/dip/p\_width/dmin/dmax*\ [**+f**\ ]
      *lon1* and *lat1* are the longitude and latitude of the beginning of the
      cross-section. *strike* is the azimuth of the direction of the
      cross-section. *p\_length* is the length along which the cross-section
      is made. The other parameters are the same as for **-Aa** option.
 
-  **-Ac**\ *x1/y1/x2/y2/dip/p\_width/dmin/dmax*\ [**f**\ ]
+  **-Ac**\ *x1/y1/x2/y2/dip/p\_width/dmin/dmax*\ [**+f**\ ]
      The same as **-Aa** option with *x* and *y* cartesian coordinates.
 
-  **-Ad**\ *x1/y1/strike/p\_length/dip/p\_width/dmin/dmax*\ [**f**\ ]
+  **-Ad**\ *x1/y1/strike/p\_length/dip/p\_width/dmin/dmax*\ [**+f**\ ]
      The same as **-Ab** option with *x* and *y* cartesian coordinates.
 
 .. _-S:
@@ -67,8 +67,8 @@ Required Arguments
 **-S**
   selects the meaning of the columns in the data file and the figure to be plotted.
 
-  **-Sa**\ *scale[/fontsize[/offset*\ [**u**]]]
-     Focal mechanisms in Aki and Richards convention. *scale* adjusts the
+  **-Sa**\ *scale[/fontsize[/offset*\ [**+u**]]]
+     Focal mechanisms in Aki and Richards convention. The *scale* adjusts the
      scaling of the radius of the "beach ball", which will be proportional to
      the magnitude. The *scale* is the size for magnitude = 5 in
      **PROJ_LENGTH_UNIT** (unless **c**, **i**, or **p** is appended
@@ -91,7 +91,7 @@ Required Arguments
       **8**,\ **9**:
         not used; can be 0 0; allows use of the :doc:`meca` file format
       **10**:
-        text string to appear above the beach ball (default) or under (add **u**).
+        text string to appear above the beach ball [Default] or under (add **+u**).
 
   **-Sc**\ *scale*
      Focal mechanisms in Harvard CMT convention. *scale* adjusts the scaling
@@ -122,7 +122,7 @@ Required Arguments
       **14**:
         text string to appear above the beach ball (default) or under (add **u**).
 
-  **-Sp**\ *scale[/fontsize[/offset*\ [**u**]]]
+  **-Sp**\ *scale[/fontsize[/offset*\ [**+u**]]]
      Focal mechanisms given with partial data on both planes. *scale* adjusts
      the scaling of the radius of the "beach ball", which will be
      proportional to the magnitude. The *scale* is the size for magnitude = 5
@@ -148,9 +148,9 @@ Required Arguments
       **9**,\ **10**:
         not used; can be 0 0; allows use of the :doc:`meca` file format
       **11**:
-        text string to appear above the beach ball (default) or under (add **u**).
+        text string to appear above the beach ball (default) or under (add **+u**).
 
-  **-Sm\|d\|z**\ *scale[/fontsize[/offset*\ [**u**]]]
+  **-Sm\|d\|z**\ *scale[/fontsize[/offset*\ [**+u**]]]
      Seismic moment tensor (Harvard CMT, with zero trace). *scale* adjusts
      the scaling of the radius of the "beach ball", which will be
      proportional to the magnitude. The *scale* is the size for magnitude = 5
@@ -159,9 +159,9 @@ Required Arguments
      to indicate that the size information is in units of cm, inches, meters,
      or points, respectively). (**-T**\ *0* option overlays best double
      couple transparently.)
-  **-Sd**\ *scale[/fontsize[/offset*\ [**u**]]]
+  **-Sd**\ *scale[/fontsize[/offset*\ [**+u**]]]
      to plot the only double couple part of moment tensor.
-  **-Sz**\ *scale[/fontsize[/offset*\ [**u**]]]
+  **-Sz**\ *scale[/fontsize[/offset*\ [**+u**]]]
      to plot anisotropic part
      of moment tensor (zero trace). The color or shade of the compressive
      quadrants can be specified with the **-G** option. The color or shade of
@@ -179,19 +179,19 @@ Required Arguments
       **11**,\ **12**:
          Not used; can be 0 0; allows use of the :doc:`meca` file format 
       **13**:
-         Text string to appear above the beach ball (default) or under (add **u**).
+         Text string to appear above the beach ball (default) or under (add **+u**).
 
-  **-Sx**\ *scale[/fontsize[/offset*\ [**u**]]]
+  **-Sx**\ *scale[/fontsize[/offset*\ [**+u**]]]
      Principal axis. *scale* adjusts the scaling of the radius of the "beach
      ball", which will be proportional to the magnitude. The *scale* is the
      size for magnitude = 5 (that is seismic scalar moment = 4\*10e+23
      dynes-cm) in **PROJ\_LENGTH\_UNIT** (unless **c**, **i**, or
      **p** is appended to indicate that the size information is in units of
-     cm, inches, meters, or points, respectively). (**-T0** option overlays
+     cm, inches, meters, or points, respectively). (**-T**0 option overlays
      best double couple transparently.)
-  **-Sy**\ *scale[/fontsize[/offset*\ [**u**]]]
+  **-Sy**\ *scale[/fontsize[/offset*\ [**+u**]]]
      to plot the only double couple part of moment tensor.
-  **-St**\ *scale[/fontsize[/offset*\ [**u**]]]
+  **-St**\ *scale[/fontsize[/offset*\ [**+u**]]]
      to plot anisotropic part
      of moment tensor (zero trace). The color or shade of the compressive
      quadrants can be specified with the **-G** option. The color or shade of
@@ -232,7 +232,7 @@ Optional Arguments
 **-F**\ *mode*\ [*args*]
     Sets one or more attributes; repeatable. The various combinations are
 
-**-Fs**\ *symbol[size[/fontsize[/offset*\ [**u**]]]
+**-Fs**\ *symbol[size[/fontsize[/offset*\ [**+u**]]]
    selects a symbol instead of mechanism. Choose from the following:
    (**c**) circle, (**d**) diamond, (**i**) itriangle, (**s**) square,
    (**t**) triangle, (**x**) cross. *size* is the symbol size in
@@ -247,7 +247,7 @@ Optional Arguments
     **3**:
       depth of event in kilometers
     **4**:
-      Text string to appear above the beach ball (default) or under (add **u**).
+      Text string to appear above the beach ball (default) or under (add **+u**).
 
 **-Fa**\ [*size*][/\ *P\_symbol*\ [/\ *T\_symbol*]]
     Computes and plots P and T axes with symbols. Optionally specify

--- a/doc/rst/source/supplements/meca/meca_common.rst_
+++ b/doc/rst/source/supplements/meca/meca_common.rst_
@@ -32,7 +32,7 @@ the same file to plot cross-sections, depth is in third column.
 Nevertheless, it is possible to use "old style" **psvelomeca** input
 files without depth in third column using the **-o** option.
 
-**-Sa**\ *scale[/fontsize[/offset*\ [**u**\ ]]]
+**-Sa**\ *scale[/fontsize[/offset*\ [**+u**\ ]]]
 
 Focal mechanisms in Aki and Richards convention. *scale* adjusts the
 scaling of the radius of the "beach ball", which will be proportional to
@@ -41,7 +41,7 @@ the magnitude. Scale is the size for magnitude = 5 in inch (unless
 render the beach ball transparent by drawing only the nodal planes and
 the circumference. The color or shade of the compressive quadrants can
 be specified with the **-G** option. The color or shade of the extensive
-quadrants can be specified with the **-E** option. Append **u** to have
+quadrants can be specified with the **-E** option. Append **+u** to have
 the text appear below the beach ball (default is above). Parameters are
 expected to be in the following columns:
 
@@ -62,7 +62,7 @@ expected to be in the following columns:
     **10**:
     Text string to appear above or below the beach ball (optional).
 
-**-Sc**\ *scale[/fontsize[/offset*\ [**u**\ ]]]
+**-Sc**\ *scale[/fontsize[/offset*\ [**+u**\ ]]]
 
 Focal mechanisms in Harvard CMT convention. *scale* adjusts the scaling
 of the radius of the "beach ball", which will be proportional to the
@@ -72,7 +72,7 @@ Use the **-T** option to render the beach ball transparent by drawing
 only the nodal planes and the circumference. The color or shade of the
 compressive quadrants can be specified with the **-G** option. The color
 or shade of the extensive quadrants can be specified with the **-E**
-option. Append **u** to have the text appear below the beach ball
+option. Append **+u** to have the text appear below the beach ball
 (default is above). Parameters are expected to be in the following
 columns:
 
@@ -95,7 +95,7 @@ columns:
     **14**:
     Text string to appear above or below the beach ball (optional).
 
-**-Sm\|d\|z**\ *scale[/fontsize[/offset*\ [**u**\ ]]]
+**-Sm\|d\|z**\ *scale[/fontsize[/offset*\ [**+u**\ ]]]
 
 Seismic moment tensor (Harvard CMT, with zero trace). *scale* adjusts
 the scaling of the radius of the "beach ball", which will be
@@ -108,7 +108,7 @@ double couple part of moment tensor. Use **-Sz** to plot the anisotropic
 part of moment tensor (zero trace). The color or shade of the
 compressive quadrants can be specified with the **-G** option. The color
 or shade of the extensive quadrants can be specified with the **-E**
-option. Append **u** to have the text appear below the beach ball
+option. Append **+u** to have the text appear below the beach ball
 (default is above). Parameters are expected to be in the following
 columns:
 
@@ -129,7 +129,7 @@ columns:
     **13**:
     Text string to appear above or below the beach ball (optional).
 
-**-Sp**\ *scale[/fontsize[/offset*\ [**u**\ ]]]
+**-Sp**\ *scale[/fontsize[/offset*\ [**+u**\ ]]]
 
 Focal mechanisms given with partial data on both planes. *scale* adjusts
 the scaling of the radius of the "beach ball", which will be
@@ -137,7 +137,7 @@ proportional to the magnitude. Scale is the size for magnitude = 5 in
 inch (unless **c**, **i**, or **p** is appended). The color or
 shade of the compressive quadrants can be specified with the **-G**
 option. The color or shade of the extensive quadrants can be specified
-with the **-E** option. Append **u** to have the text appear below the
+with the **-E** option. Append **+u** to have the text appear below the
 beach ball (default is above). Parameters are expected to be in the
 following columns:
 
@@ -162,7 +162,7 @@ following columns:
     **11**:
     Text string to appear above or below the beach ball (optional).
 
-**-Sx\|y\|t**\ *scale[/fontsize[/offset*\ [**u**\ ]]]
+**-Sx\|y\|t**\ *scale[/fontsize[/offset*\ [**+u**\ ]]]
 
 Principal axis. *scale* adjusts the scaling of the radius of the "beach
 ball", which will be proportional to the magnitude. Scale is the size
@@ -173,7 +173,7 @@ standard Harvard CMT. Use **-Sy** to plot only the double couple part of
 moment tensor. Use **-St** to plot zero trace moment tensor. The color
 or shade of the compressive quadrants can be specified with the **-G**
 option. The color or shade of the extensive quadrants can be specified
-with the **-E** option. Append **u** to have the text appear below the
+with the **-E** option. Append **+u** to have the text appear below the
 beach ball (default is above). Parameters are expected to be in the
 following columns:
 

--- a/doc/rst/source/supplements/meca/psvelo.rst
+++ b/doc/rst/source/supplements/meca/psvelo.rst
@@ -81,8 +81,6 @@ gray wedges to represent the 2-sigma uncertainties.
     241.1084 34.2565 2.17E-08 3.53E-08
     END
 
-.. include:: meca_common.rst_
-
 `Kurt L. Feigl <http://www.geology.wisc.edu/~feigl/>`_, Department of Geology and
 Geophysics at University of Wisconsin-Madison, Madison, Wisconsin, USA
 

--- a/doc/rst/source/supplements/meca/velo.rst
+++ b/doc/rst/source/supplements/meca/velo.rst
@@ -78,8 +78,6 @@ gray wedges to represent the 2-sigma uncertainties.
     241.1084 34.2565 2.17E-08 3.53E-08
     END
 
-.. include:: meca_common.rst_
-
 `Kurt L. Feigl <http://www.geology.wisc.edu/~feigl/>`_, Department of Geology and
 Geophysics at University of Wisconsin-Madison, Madison, Wisconsin, USA
 

--- a/doc/rst/source/supplements/mgd77/mgd77convert.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77convert.rst
@@ -13,7 +13,7 @@ Synopsis
 
 .. include:: ../../common_SYN_OPTs.rst_
 
-**gmt mgd77convert** *NGDC-ids* |-F|\ **a**\ \|\ **c**\ \|\ **m** \|\ **t**
+**gmt mgd77convert** *NGDC-ids* |-F|\ **a**\ \|\ **c**\ \|\ **m**\ \|\ **t**
 |-T|\ **a**\ \|\ **c**\ \|\ **m**\ \|\ **t**\ [**+f**]
 [ |-C| ]
 [ |-D| ]
@@ -37,7 +37,7 @@ Required Arguments
 
 .. _-F:
 
-**-Fa**\ \|\ **c**\ \|\ **m** \|\ **t**
+**-Fa**\ \|\ **c**\ \|\ **m**\ \|\ **t**
     Specifies the format of the input (From) files. Choose from **a**
     for standard MGD77 ASCII table (with extension .mgd77), **c** for
     the new MGD77+ netCDF format (with extension .nc), **m** for the

--- a/doc/rst/source/supplements/mgd77/mgd77header.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77header.rst
@@ -49,7 +49,7 @@ Optional Arguments
 
 .. _-M:
 
-**-Mf**\ [*item*]\|\ **r**\ \|\ **r**
+**-Mf**\ [*item*]\|\ **r**\ \|\ **t**
     List the meta-data (header) for
     each cruise. Append **f** for a formatted display. This will list
     individual parameters and their values, one entry per output line,

--- a/doc/rst/source/supplements/mgd77/mgd77list.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77list.rst
@@ -15,7 +15,6 @@ Synopsis
 
 **gmt mgd77list** *NGDC-ids* |-F|\ *columns*\ [,\ *logic*][:\ *bittests*]
 [ |-A|\ **c**\ \|\ **d**\ \|\ **f**\ \|\ **m**\ \|\ **t**\ *code*\ [**+f**\ ] ]
-[ |-C|\ **f**\ \|\ **g**\ \|\ **e** ]
 [ |-D|\ **A**\ \|\ **a**\ *startdate* ]
 [ |-D|\ **B**\ \|\ **b**\ *stopdate* ]
 [ |-E| ]
@@ -34,6 +33,7 @@ Synopsis
 [ |-Z|\ **n**\ \|\ **p** ]
 [ |SYN_OPT-bo| ]
 [ |SYN_OPT-h| ]
+[ |SYN_OPT-j| ]
 [ |SYN_OPT--| ]
 
 |No-spaces|
@@ -158,7 +158,7 @@ Required Arguments
         The decimal seconds of each record.
     **dist**
         Along-track distance from start of leg. For method of calculation,
-        see **-C** [spherical great circle distances], and for distance
+        see **-j** [spherical great circle distances], and for distance
         units, see **-N** [km].
     **az**
         Ship azimuth (heading) measured clockwise from north (in degrees).
@@ -346,18 +346,6 @@ Optional Arguments
     for feet, **k** for km, **M** for miles, **n** for nautical miles,
     or **u** for survey feet [Default is **e** (meters)].
 
-.. _-C:
-
-**-C**\ **f**\ \|\ **g**\ \|\ **e**
-    Append a one-letter code to select the procedure for along-track
-    distance calculation (see **-N** for selecting units):
-
-    **f** Flat Earth distances.
-
-    **g** Great circle distances [Default].
-
-    **e** Geodesic distances on current GMT ellipsoid.
-
 .. _-D:
 
 **-Da**\ *startdate*
@@ -490,6 +478,8 @@ Optional Arguments
 
 .. |Add_-h| unicode:: 0x20 .. just an invisible code
 .. include:: ../../explain_-h.rst_
+
+.. include:: ../../explain_distcalc.rst_
 
 .. include:: ../../explain_help.rst_
 

--- a/doc/rst/source/supplements/mgd77/mgd77track.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77track.rst
@@ -29,7 +29,7 @@ Synopsis
 [ |-T|\ **T**\ \|\ **t**\ \|\ **d**\ *ms*,\ *mc*,\ *mfs*,\ *mf*,\ *mfc* ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
-[ |-W|\ [**-**\ \|\ **+**][*pen*] ]
+[ |-W|\ [*pen*] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
 [ |SYN_OPT-p| ]

--- a/doc/rst/source/supplements/mgd77/mgd77track_classic.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77track_classic.rst
@@ -32,7 +32,7 @@ Synopsis
 [ |-T|\ **T**\ \|\ **t**\ \|\ **d**\ *ms*,\ *mc*,\ *mfs*,\ *mf*,\ *mfc* ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
-[ |-W|\ [**-**\ \|\ **+**][*pen*] ]
+[ |-W|\ [*pen*] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
 [ |SYN_OPT-p| ]

--- a/doc/rst/source/supplements/mgd77/mgd77track_common.rst_
+++ b/doc/rst/source/supplements/mgd77/mgd77track_common.rst_
@@ -109,7 +109,7 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ [**-**\ \|\ **+**][*pen*]
+**-W**\ [*pen*]
     Append *pen* used for the trackline. [Defaults:
     width = default, color = black, style = solid].
 

--- a/doc/rst/source/supplements/potential/earthtide.rst
+++ b/doc/rst/source/supplements/potential/earthtide.rst
@@ -16,7 +16,7 @@ Synopsis
 **gmt earthtide**
 |-T|\ [\ *min/max*\ /]\ *inc*\ [**+n**] \|\ |-T|\ *file*\ \|\ *list*
 |-G|\ *grdfile*
-[ |-C|\ *x|e,y|n,z|v* ]
+[ |-C|\ *components* ]
 [ |SYN_OPT-I| ]
 [ |-L|\ *lon/lat* ] 
 [ |SYN_OPT-R| ]
@@ -46,7 +46,7 @@ Specify either **-G**, **-S** or **-L**.
     Write one or more tide component directly to grids; no table data are written to standard output.
     If more than one component are specified via **-C** then *grdfile* must contain the format flag %s
     so that we can embed the component code in the file names (*n* for north; *e* for east and *v* for vertical).
-    If only one component is selected with **-C** than no code is appended to grid name (an no need to 
+    If only one component is selected with **-C** then no code is appended to grid name (and no need to 
     set the format flag %s). The grid(s) are computed at the time set by **-T**, if that option is used, or
     at the *now* time calculated in UTC from the computer clock.
 
@@ -73,16 +73,16 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ *x|e,y|n,z|v*
+**-C**\ *components*
     Select which component to write to individual grids. Requires **-G**.
-    Append comma-separated codes for available components: **x** or **e** for the east component;
-    **y** or **n** for the north component; and **z** or **v** for the vertical component.
-    For example, **-C**\ *e,v*, will write 2 grids. One with east and other with the vertical components.
-    If **-G** is set but not **-C** then the default is to write the vertical component.
+    Append comma-separated codes for available components: **x** or **e** for the east component,
+    **y** or **n** for the north component, and **z** or **v** for the vertical component.
+    For example, **-Ce**\ ,**v**, will write two grids: one with east and the other with the vertical components.
+    If **-G** is set but not **-C** then the default is to write the vertical component only.
 
 .. _-I:
 
-.. |Add_-I| replace:: Used only with **-G**. If not set, defaults to **-I30m**
+.. |Add_-I| replace:: Used only with **-G**. If not set, defaults to **-I**\ 30**m**
 .. include:: ../../explain_-I.rst_
 
 .. _-L:

--- a/doc/rst/source/supplements/potential/grdredpol.rst
+++ b/doc/rst/source/supplements/potential/grdredpol.rst
@@ -16,7 +16,7 @@ Synopsis
 **gmt grdredpol** *anom_grd* |-G|\ *rtp_grd* [|-C|\ *dec/dip*]
 [ |-E|\ **i**\ *inc_grd*]
 [ |-E|\ **d**\ *dec_grd*]
-[ |-F|\ *<m/n>*]
+[ |-F|\ *m/n*]
 [ |-M|\ *m\|r*]
 [ |-N| ]
 [ |-W|\ *win_width*]

--- a/doc/rst/source/supplements/potential/talwani3d.rst
+++ b/doc/rst/source/supplements/potential/talwani3d.rst
@@ -15,7 +15,7 @@ Synopsis
 
 **gmt talwani3d** [ *modeltable* ]
 [ |-A| ] [ |-D|\ *rho* ] ]
-[ |-F|\ **f**\ \|\ **n**\ \|\ **v** ]
+[ |-F|\ **f**\ \|\ **n**\ [*lat*]\ \|\ **v** ] 
 [ |-G|\ *outfile* ]
 [ |SYN_OPT-I| ]
 [ |-M|\ [**h**]\ [**v**] ]
@@ -85,8 +85,8 @@ Optional Arguments
 
 **-F**\ **f**\ \|\ **n**\ \|\ **v**
     Specify desired gravitational field component.  Choose between **f** (free-air anomaly) [Default],
-    **n** (geoid; optionally append average latitude for normal gravity reference value [45])
-    or **v** (vertical gravity gradient).
+    **n** (geoid; optionally append average latitude for normal gravity reference value [Default is
+    mid-grid (or mid-profile if **-N**)]) or **v** (vertical gravity gradient).
 
 .. _-G:
 

--- a/doc/rst/source/supplements/segy/segy2grd.rst
+++ b/doc/rst/source/supplements/segy/segy2grd.rst
@@ -100,7 +100,7 @@ Optional Arguments
 **-Q**\ *<mode><value>*
     Can be used to change two different settings depending on *mode*:
        **-Qx**\ *x-scale* applies scalar *x-scale* to coordinates in trace
-       header to match the coordinates specified in -R.
+       header to match the coordinates specified in **-R**.
 
        **-Qy**\ *s_int* specifies sample interval as *s_int* if incorrect in the SEGY file.
 

--- a/doc/rst/source/supplements/segy/segyz_common.rst_
+++ b/doc/rst/source/supplements/segy/segyz_common.rst_
@@ -109,7 +109,7 @@ Optional Arguments
 
        **-Qi**\ *dpi* sets the dots-per-inch resolution of the image [300].
 
-       **-Qu**\ *redvel* to apply reduction velocity (-ve removes reduction already present).
+       **-Qu**\ *redvel* to apply reduction velocity (negative removes reduction already present).
 
        **-Qx**\ *mult* to multiply trace locations by *mult*.
 
@@ -119,7 +119,7 @@ Optional Arguments
 
 **-S**\ *header_x*/*header_y*
     Read trace locations from trace headers: headers is either **c** for CDP,
-    **o** for offset, **b** \*num* to read a long starting at byte *num* in the
+    **o** for offset, **b**\ *num* to read a long starting at byte *num* in the
     header (first byte corresponds to num=0), or a number to fix the
     location. First parameter for x, second for y. Default has X and Y
     given by trace number.

--- a/doc/rst/source/supplements/spotter/grdrotater.rst
+++ b/doc/rst/source/supplements/spotter/grdrotater.rst
@@ -91,7 +91,7 @@ Optional Arguments
 
 .. _-A:
 
-[ **-A**\ *region* ]
+**-A**\ *region*
     Specify directly the region of the rotated grid.  By default, the
     output grid has a region that exactly matches the extent of the rotated
     domain, but **-A** can be used to crop or extend this region to that
@@ -135,7 +135,8 @@ Optional Arguments
 **-T**\ *ages*
     Sets the desired reconstruction times.  For a single time append
     the desired time.  For an equidistant range of reconstruction times
-    give **-T**\ *start*\ /\ *stop*\ /\ *inc* or **-T**\ *start*\ /\ *stop*\ /\ *npoints*\ **+**.
+    give **-T**\ *start*\ /\ *stop*\ /\ *inc*. Append **+n** if *inc* should
+    be interpreted to mean *npoints* instead.
     For an non-equidistant set of reconstruction times please pass them
     via the first column in a file, e.g., **-T**\ *agefile*.  If no **-T**
     option is given and **-E** specified a rotation file then we equate

--- a/doc/rst/source/supplements/x2sys/x2sys_cross.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_cross.rst
@@ -68,7 +68,7 @@ Optional Arguments
 
 .. _-D:
 
-**-D**\ [**S**\ \|\ **N**\ ] ]
+**-D**\ [**S**\ \|\ **N**\ ]
     Control how geographic coordinates are handled (Cartesian data are unaffected).
     By default, we determine if the data are closer to one pole than the other, and
     then we use a cylindrical polar conversion to avoid problems with longitude jumps.

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -5730,7 +5730,7 @@ GMT_LOCAL bool api_file_with_netcdf_directive (struct GMTAPI_CTRL *API, const ch
 }
 
 /* Several lower-level API function are needed in a few other gmt_*.c library codes and are thus NOT local.
- * They are listed here and declared via MSC_EXTERN where they occur:
+ * They are listed here and declared via EXTERN_MSC where they occur:
  *   gmtapi_report_error
  *   gmtapi_validate_id
  *   gmtapi_unregister_io

--- a/src/meca/pscoupe.c
+++ b/src/meca/pscoupe.c
@@ -439,11 +439,11 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
 	GMT_Message (API, GMT_TIME_NONE, "\t-A Specify cross-section parameters. Choose between\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   -Aa<lon1/lat1/lon2/lat2/dip/p_width/dmin/dmax>[f]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   -Ab<lon1/lat1/strike/p_length/dip/p_width/dmin/dmax>[f]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   -Ac<x1/y1/x2/y2/dip/p_width/dmin/dmax>[f]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   -Ad<x1/y1/strike/p_length/dip/p_width/dmin/max>[f]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Add f to get the frame from the cross-section parameters.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   -Aa<lon1/lat1/lon2/lat2/dip/p_width/dmin/dmax>[+f]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   -Ab<lon1/lat1/strike/p_length/dip/p_width/dmin/dmax>[+f]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   -Ac<x1/y1/x2/y2/dip/p_width/dmin/dmax>[+f]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   -Ad<x1/y1/strike/p_length/dip/p_width/dmin/max>[+f]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Add +f to get the frame from the cross-section parameters.\n");
 	GMT_Option (API, "J-,R");
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Option (API, "<,B-");
@@ -490,9 +490,9 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t        P_value P_azim P_plunge exp newX newY [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   z  Anisotropic part of seismic moment tensor (Harvard CMT, with zero trace):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp [event_title]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally add /fontsize[/offset][u] [Default values are /%g/%f].\n", DEFAULT_FONTSIZE, DEFAULT_OFFSET);
+	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally add /fontsize[/offset][+u] [Default values are /%g/%f].\n", DEFAULT_FONTSIZE, DEFAULT_OFFSET);
 	GMT_Message (API, GMT_TIME_NONE, "\t   fontsize < 0 : no label written; offset is from the limit of the beach ball.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   By default label is above the beach ball. Add u to plot it under.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   By default label is above the beach ball. Append +u to plot it under.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Tn[/<pen>] draw nodal planes and circumference only to provide a transparent beach ball\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   using the current pen (see -W) or sets pen attribute.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   n = 1 the only first nodal plane is plotted.\n");
@@ -534,7 +534,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 			case 'A':	/* Cross-section definition */
 				Ctrl->A.active = true;
 				Ctrl->A.proj_type = opt->arg[0];
-				if (opt->arg[strlen(opt->arg)-1] == 'f') Ctrl->A.frame = true;
+				if ((p = strstr (opt->arg, "+f"))) {	/* Get the frame from the cross-section parameters */
+					Ctrl->A.frame = true;
+					p[0] = '\0';	/* Chop off modifier */
+				}
+				else if (opt->arg[strlen(opt->arg)-1] == 'f') Ctrl->A.frame = true;
 				if (Ctrl->A.proj_type == 'a' || Ctrl->A.proj_type == 'c') {
 					sscanf (&opt->arg[1], "%lf/%lf/%lf/%lf/%lf/%lf/%lf/%lf",
 						&lon1, &lat1, &lon2, &lat2, &Ctrl->A.PREF.dip, &Ctrl->A.p_width, &Ctrl->A.dmin, &Ctrl->A.dmax);
@@ -561,6 +565,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 					Ctrl->A.ylatref = lat1;
 				}
 				Ctrl->A.polygon = true;
+				if (p) p[0] = '+';	/* Restore modifier */
 				break;
 
 			case 'E':	/* Set color for extensive parts  */
@@ -622,7 +627,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 					case 's':	/* Only points : get symbol [and size] */
 						Ctrl->S.active = true;
 						Ctrl->S.symbol = opt->arg[1];
-						if (opt->arg[strlen(opt->arg)-1] == 'u') Ctrl->S.justify = PSL_TC, opt->arg[strlen(opt->arg)-1] = '\0';
+						if ((p = strstr (opt->arg, "+u"))) {	/* Plot label under symbol [over] */
+							Ctrl->S.justify = PSL_TC;
+							p[0] = '\0';	/* Chop off modifier */
+						}
+						else if (opt->arg[strlen(opt->arg)-1] == 'u') Ctrl->S.justify = PSL_TC, opt->arg[strlen(opt->arg)-1] = '\0';
 						txt[0] = txt_b[0] = txt_c[0] = '\0';
 						sscanf (&opt->arg[2], "%[^/]/%[^/]/%s", txt, txt_b, txt_c);
 						if (txt[0]) Ctrl->S.scale = gmt_M_to_inch (GMT, txt);
@@ -633,6 +642,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 								Ctrl->S.n_cols = 4;
 							else
 								Ctrl->S.n_cols = 3;
+						if (p) p[0] = '+';	/* Restore modifier */
 						break;
 					case 't':	/* Draw outline of T axis symbol [set outline attributes] */
 						Ctrl->T2.active = true;
@@ -669,7 +679,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 				break;
 			case 'S':	/* Mechanisms : get format [and size] */
 				Ctrl->S.active = true;
-				if (opt->arg[strlen(opt->arg)-1] == 'u') Ctrl->S.justify = PSL_TC, opt->arg[strlen(opt->arg)-1] = '\0';
+				if ((p = strstr (opt->arg, "+u"))) {	/* Plot label under symbol [over] */
+					Ctrl->S.justify = PSL_TC;
+					p[0] = '\0';	/* Chop off modifier */
+				}
+				else if (opt->arg[strlen(opt->arg)-1] == 'u') Ctrl->S.justify = PSL_TC, opt->arg[strlen(opt->arg)-1] = '\0';
 				txt[0] = txt_b[0] = txt_c[0] = '\0';
 				sscanf (&opt->arg[1], "%[^/]/%[^/]/%s", txt, txt_b, txt_c);
 				if (txt[0]) Ctrl->S.scale = gmt_M_to_inch (GMT, txt);
@@ -721,6 +735,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 						n_errors++;
 						break;
 				}
+				if (p) p[0] = '+';	/* Restore modifier */
 				break;
 
 			case 'T':

--- a/src/meca/psmeca.c
+++ b/src/meca/psmeca.c
@@ -234,9 +234,9 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   z  Anisotropic part of seismic moment tensor (Harvard CMT, with zero trace):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use -Fo option for old (psvelomeca) format (no depth in third column).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally add /fontsize[/offset][u] [Default values are /%g/%fp]\n", DEFAULT_FONTSIZE, DEFAULT_OFFSET);
+	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally add /fontsize[/offset][+u] [Default values are /%g/%fp]\n", DEFAULT_FONTSIZE, DEFAULT_OFFSET);
 	GMT_Message (API, GMT_TIME_NONE, "\t   fontsize < 0 : no label written; offset is from the limit of the beach ball.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   By default label is above the beach ball. Add u to plot it under.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   By default label is above the beach ball. Add +u to plot it under.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Tn[/<pen>] Draw nodal planes and circumference only to provide a transparent\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   beach ball using the default pen (see -W) or sets pen attribute. \n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   n = 1 the only first nodal plane is plotted.\n");
@@ -388,7 +388,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_
 				break;
 			case 'S':	/* Get symbol [and size] */
 				Ctrl->S.active = true;
-				if (opt->arg[strlen(opt->arg)-1] == 'u') Ctrl->S.justify = PSL_TC, opt->arg[strlen(opt->arg)-1] = '\0';
+				if ((p = strstr (opt->arg, "+u"))) {
+					Ctrl->S.justify = PSL_TC;
+					p[0] = '\0';	/* Chop off modifier */
+				}
+				else if (opt->arg[strlen(opt->arg)-1] == 'u') Ctrl->S.justify = PSL_TC, opt->arg[strlen(opt->arg)-1] = '\0';
 				txt[0] = txt_b[0] = txt_c[0] = '\0';
 				sscanf (&opt->arg[1], "%[^/]/%[^/]/%s", txt, txt_b, txt_c);
 				if (txt[0]) Ctrl->S.scale = gmt_M_to_inch (GMT, txt);
@@ -432,6 +436,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_
 						n_errors++;
 						break;
 				}
+				if (p) p[0] = '+';	/* Restore modifier */
 				break;
 			case 'T':
 				Ctrl->T.active = true;

--- a/src/spotter/grdrotater.c
+++ b/src/spotter/grdrotater.c
@@ -121,7 +121,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Option (API, "Rg");
 	GMT_Message (API, GMT_TIME_NONE, "\t-S Do NOT rotate the grid - just produce the rotated outlines (requires -D).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-T Set the time(s) of reconstruction.  Append a single time (-T<time>),\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   an equidistant range of times (-T<min>/<max>/<inc> or -T<min>/<max>/<npoints>+),\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   an equidistant range of times (-T<min>/<max>/<inc> or -T<min>/<max>/<npoints>+n),\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   or the name of a file with a list of times (-T<tfile>).  If no -T is set\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   then the reconstruction times equal the rotation times given in -E.\n");
 	GMT_Option (API, "V,bi2,bo,d,g,h,n,:,.");
@@ -254,7 +254,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDROTATER_CTRL *Ctrl, struct 
 				}
 				/* Not a file */
 				k = sscanf (opt->arg, "%[^/]/%[^/]/%s", txt_a, txt_b, txt_c);
-				if (k == 3) {	/* Gave -Ttstart/tstop/tinc or possibly ancient -Tlon/lat/angle */
+				if (k == 3) {	/* Gave -Ttstart/tstop/tinc[+n] or possibly ancient -Tlon/lat/angle */
 					if (gmt_M_compat_check (GMT, 4) && !gave_e) {	/* No -E|e so likely ancient syntax */
 						GMT_Report (API, GMT_MSG_COMPAT, "-T<lon>/<lat>/<angle> is deprecated; use -E<lon>/<lat>/<angle> instead.\n");
 						Ctrl->E.rot.single = Ctrl->E.active = true;
@@ -267,7 +267,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDROTATER_CTRL *Ctrl, struct 
 					else {	/* Must be Ttstart/tstop/tinc */
 						double min, max, inc;
 						min = atof (txt_a);	max = atof (txt_b);	inc = atof (txt_c);
-						if (opt->arg[strlen(opt->arg)-1] == '+')	/* Gave number of points instead; calculate inc */
+						if (strstr(opt->arg, "+n") || opt->arg[strlen(opt->arg)-1] == '+')	/* Gave number of points instead; calculate inc */
 							inc = (max - min) / (inc - 1.0);
 						if (inc <= 0.0) {
 							GMT_Report (API, GMT_MSG_NORMAL, "Syntax error -T option: Age increment must be positive\n");


### PR DESCRIPTION
Most of this PR is just improving the RST docs but also fixing mistakes as I find them (typos, formatting error etc).  I ran across a few issues that warranted a code update:

1. psmeca and pscoupe had option syntax that ended in optional **f** and **u**.  I changed this to **+f** and **+u** (backwards compatible)
2. mgd77list had **-C** for distance calculations, changed to **-j** as in other modules.
3. talwani3d did not allow users to set a latitude for geoid calculations (lie talwani2d does).
4. grdrotator had a trailing + instead of **+n** in **-T**.

Not sure why but after this only 26 (instead of 27) tests fail for me on OS X.