### PR TITLE
Improve parsing of modifier text with plus-symbols

### DIFF
--- a/doc/scripts/func_F_iso+.sh
+++ b/doc/scripts/func_F_iso+.sh
@@ -71,7 +71,7 @@ $AWK -f tt.awk tt.txt > tt.d
 gmt set PS_CHAR_ENCODING ISOLatin1+
 
 # First the uncoded ones
-gmt psxy -R0/9/2/32 -Jx0.345i/-0.21i -BN+tISOLatin1++ -P -K -Glightred -Y0.0 << EOF
+gmt psxy -R0/9/2/32 -Jx0.345i/-0.21i -BN+tISOLatin1+ -P -K -Glightred -Y0.0 << EOF
 >
 1	4
 2	4

--- a/doc/scripts/func_F_stand+.sh
+++ b/doc/scripts/func_F_stand+.sh
@@ -71,7 +71,7 @@ $AWK -f tt.awk tt.txt > tt.d
 gmt set PS_CHAR_ENCODING Standard+
 
 # First mark uncoded entries
-gmt psxy -R0/9/2/32 -Jx0.345i/-0.21i -BN+tStandard++ -P -K -Glightred -Y0.0 << EOF
+gmt psxy -R0/9/2/32 -Jx0.345i/-0.21i -BN+tStandard+ -P -K -Glightred -Y0.0 << EOF
 >
 1	4
 2	4

--- a/test/psimage/transparent_gif.sh
+++ b/test/psimage/transparent_gif.sh
@@ -10,14 +10,14 @@ ps=transparent_gif.ps
 gmt psbasemap -R0/1/0/1 -JX7c -Y19c -B+glightblue+t"no option" -K -P > $ps
 gmt psimage @warning.gif -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -Y-9c -R -J -B+glightblue+t"-Gblack\053t" -O -K >> $ps
+gmt psbasemap -Y-9c -R -J -B+glightblue+t"-Gblack+t" -O -K >> $ps
 gmt psimage @warning.gif -Gblack+t -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -X8c -R -J -B+glightblue+t"-Gwhite\053t" -O -K >> $ps
+gmt psbasemap -X8c -R -J -B+glightblue+t"-Gwhite+t" -O -K >> $ps
 gmt psimage @warning.gif -Gwhite+t -D0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -X-8c -Y-9c -R -J -B+glightblue+t"-Gred\053t" -O -K >> $ps
+gmt psbasemap -X-8c -Y-9c -R -J -B+glightblue+t"-Gred+t" -O -K >> $ps
 gmt psimage @warning.gif -Gred+t -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -X8c -R -J -B+glightblue+t"-Gblue\053t" -O -K >> $ps
+gmt psbasemap -X8c -R -J -B+glightblue+t"-Gblue+t" -O -K >> $ps
 gmt psimage @warning.gif -Gblue+t -Dx0.5c/0.5c+jBL+w6c -O >> $ps

--- a/test/psimage/transparent_png.sh
+++ b/test/psimage/transparent_png.sh
@@ -9,14 +9,14 @@ ps=transparent_png.ps
 gmt psbasemap -R0/1/0/1 -JX7c -Y19c -B+glightblue+t"no option" -K -P > $ps
 gmt psimage @warning.png -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -Y-9c -R -J -B+glightblue+t"-Gblack\053t" -O -K >> $ps
+gmt psbasemap -Y-9c -R -J -B+glightblue+t"-Gblack+t" -O -K >> $ps
 gmt psimage @warning.png -Gblack+t -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -X8c -R -J -B+glightblue+t"-Gwhite\053t" -O -K >> $ps
+gmt psbasemap -X8c -R -J -B+glightblue+t"-Gwhite+t" -O -K >> $ps
 gmt psimage @warning.png -Gwhite+t -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -X-8c -Y-9c -R -J -B+glightblue+t"-Gred\053t" -O -K >> $ps
+gmt psbasemap -X-8c -Y-9c -R -J -B+glightblue+t"-Gred+t" -O -K >> $ps
 gmt psimage @warning.png -Gred+t -Dx0.5c/0.5c+jBL+w6c -O -K >> $ps
 
-gmt psbasemap -X8c -R -J -B+glightblue+t"-Gblue\053t" -O -K >> $ps
+gmt psbasemap -X8c -R -J -B+glightblue+t"-Gblue+t" -O -K >> $ps
 gmt psimage @warning.png -Gblue+t -Dx0.5c/0.5c+jBL+w6c -O >> $ps

--- a/test/pstext/utf8.ps
+++ b/test/pstext/utf8.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from pstext
+%%Title: GMT v6.0.0_0f5f308_2019.03.24 [64-bit] Document from pstext
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:52:59 2018
+%%CreationDate: Mon Mar 25 09:37:28 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -336,9 +336,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +592,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +635,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -723,7 +718,7 @@ N 0 0 M 7560 0 D S
 0 setlinecap
 /PSL_H_y PSL_L_y PSL_LH add 233 add def
 3780 9720 PSL_H_y add M
-(UTF­8 via ISOLatin1) bc Z
+(UTF­8 via ISOLatin1+) bc Z
 %%EndObject
 
 grestore


### PR DESCRIPTION
Since quotes are not passed into GMT, it can be difficult to know if any combination of **+**_letter_ is a modifier or not.  To eliminate as many cases as we can, we run this check before parsing:

1. For argument to an option that takes modifiers, replace any + symbol that is _not_ followed by one of the allowed modifier letters with ASCII 1.
2. New: The second time we find a + followed by a valid modifier we know it cannot be a modifer since a modifier can only be given once.  So **+t**Title+test will now handle the second **+t** sequence as plain text.
3. Bug: If a string ended in a plus then it got removed.

With these improvements we are less vulnerable to this problem and a few tests could be simplified and a few actually had text ending in double-pus-symbols to compensate for the loss of the last plus.  Ultimately, the only foolproof way to not have a +letter be interpreted as a modifier is to use the octal code for the plus: \053.

Closes #576.