### PR TITLE
Setup Azure Pipelines for Mac

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
   variables:
     INSTALLDIR: "$HOME/gmt-install-dir"
     COASTLINEDIR: "$HOME/gmt-install-dir/coast"
-    PATH: "$INSTALLDIR/bin:$PATH"
+    #PATH: "$INSTALLDIR/bin:$PATH"
     BUILD_DOCS: false
 
   strategy:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
 
   - bash: |
       set -x -e
-      brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl graphicsmagick glibtool
+      brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl graphicsmagick libtool
     displayName: Install dependencies
 
   - bash: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
 
   - bash: |
       set -x -e
-      brew install ccache cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl graphicsmagick python
+      brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl graphicsmagick
     displayName: Install dependencies
 
   - bash: |
@@ -47,6 +47,9 @@ jobs:
       mkdir "$INSTALLDIR"
       mkdir "$COASTLINEDIR"
     displayName: Create install directories
+
+  - bash: echo "##vso[task.prependpath]$INSTALLDIR/bin"
+    displayName: Add GMT to PATH
 
   - bash: ci/download-coastlines.sh
     displayName: Download coastlines

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -23,6 +23,7 @@ jobs:
     vmImage: 'macOS-10.13'
 
   variables:
+    HOME: "$BUILD_SOURCESDIRECTORY"
     INSTALLDIR: "$HOME/gmt-install-dir"
     COASTLINEDIR: "$HOME/gmt-install-dir/coast"
     #PATH: "$INSTALLDIR/bin:$PATH"

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -7,6 +7,7 @@ trigger:
   branches:
     include:
     - master
+    - azure
     - 5.4
     - refs/tags/*
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
 
   - bash: |
       set -x -e
-      brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl graphicsmagick
+      brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl graphicsmagick glibtool
     displayName: Install dependencies
 
   - bash: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,15 +41,15 @@ jobs:
 
   - bash: |
       set -x -e
-      echo "##vso[task.setvariable variable=INSTALLDIR]gmt-install-dir"
-      echo "##vso[task.setvariable variable=COASTLINEDIR]gmt-install-dir/coast"
+      echo "##vso[task.setvariable variable=INSTALLDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir"
+      echo "##vso[task.setvariable variable=COASTLINEDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir/coast"
       echo "##vso[task.prependpath]$BUILD_SOURCESDIRECTORY/gmt-install-dir/bin"
     displayName: Set environment variables
 
   - bash: |
       set -x -e
-      mkdir "$INSTALLDIR"
-      mkdir "$COASTLINEDIR"
+      mkdir -p "$INSTALLDIR"
+      mkdir -p "$COASTLINEDIR"
     displayName: Create install directories
 
   - bash: ci/download-coastlines.sh

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,81 @@
+# Configuration for Azure Pipelines
+########################################################################################
+
+# Only build the master branch, tags, and PRs (on by default) to avoid building random
+# branches in the repository until a PR is opened.
+trigger:
+  branches:
+    include:
+    - master
+    - 5.4
+    - refs/tags/*
+
+
+jobs:
+
+# Mac
+########################################################################################
+- job:
+  displayName: 'Mac'
+
+  pool:
+    vmImage: 'macOS-10.13'
+
+  variables:
+    INSTALLDIR: "$HOME/gmt-install-dir"
+    COASTLINEDIR: "$HOME/gmt-install-dir/coast"
+    PATH: "$INSTALLDIR/bin:$PATH"
+    BUILD_DOCS: false
+
+  strategy:
+    matrix:
+      CompileOnly:
+        TEST: false
+      Test:
+        TEST: true
+
+  steps:
+
+  - bash: |
+      set -x -e
+      brew install ccache cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl graphicsmagick python
+    displayName: Install dependencies
+
+  - bash: |
+      set -x -e
+      mkdir "$INSTALLDIR"
+      mkdir "$COASTLINEDIR"
+    displayName: Create install directories
+
+  - bash: ci/download-coastlines.sh
+    displayName: Download coastlines
+
+  - bash: ci/build-gmt.sh
+    displayName: Compile GMT
+
+  - bash: |
+      set -x -e
+      gmt defaults -Vd
+      gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
+      gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -Vd && gmt end
+    displayName: Check a few simple commands
+
+  # Run the full tests only if this is a scheduled build
+  - bash: |
+      set -x -e
+      cd build
+      ctest --force-new-ctest-process -j4
+    condition: eq(variables['TEST'], 'true')
+    #condition: and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['TEST'], 'true'))
+    displayName: Full tests
+
+  # Upload test coverage even if build fails. Keep separate to make sure this task fails
+  # if the tests fail.
+  - bash: |
+      set -x -e
+      bash <(curl -s https://codecov.io/bash)
+    env:
+      CODECOV_TOKEN: $(codecov.token)
+    condition: and(succeededOrFailed(), eq(variables['TEST'], 'true'))
+    #condition: and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['TEST'], 'true'))
+    displayName: Upload test coverage

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -7,58 +7,53 @@ trigger:
   branches:
     include:
     - master
-    - azure
     - 5.4
     - refs/tags/*
 
-
 jobs:
 
-# Mac
+# Mac - Compile only
 ########################################################################################
 - job:
-  displayName: 'Mac'
+  displayName: 'Mac | Compile only'
+  condition: not(eq(variables['Build.Reason'], 'Schedule'))
 
   pool:
     vmImage: 'macOS-10.13'
 
   variables:
     BUILD_DOCS: false
-
-  strategy:
-    matrix:
-      CompileOnly:
-        TEST: false
-      Test:
-        TEST: true
+    TEST: false
 
   steps:
 
-  - bash: |
-      set -x -e
-      brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl graphicsmagick || true
-    displayName: Install dependencies
-
-  - bash: echo "##vso[task.setvariable variable=INSTALLDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir"
-    displayName: Set install location
-
-  - bash: echo "##vso[task.setvariable variable=COASTLINEDIR]$INSTALLDIR/coast"
-    displayName: Set coastline location
-
-  - bash: echo "##vso[task.prependpath]$INSTALLDIR/bin"
-    displayName: Set PATH
+  # Setup and compile GMT
+  - template: ci/azure-pipelines-mac.yml
 
   - bash: |
       set -x -e
-      mkdir -p "$INSTALLDIR"
-      mkdir -p "$COASTLINEDIR"
-    displayName: Create install directories
+      gmt defaults -Vd
+      gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
+      gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -Vd && gmt end
+    displayName: Check a few simple commands
 
-  - bash: ci/download-coastlines.sh
-    displayName: Download coastlines
+# Mac - Test
+########################################################################################
+- job:
+  displayName: 'Mac | Test'
+  #condition: eq(variables['Build.Reason'], 'Schedule')
 
-  - bash: ci/build-gmt.sh
-    displayName: Compile GMT
+  pool:
+    vmImage: 'macOS-10.13'
+
+  variables:
+    BUILD_DOCS: false
+    TEST: true
+
+  steps:
+
+  # Setup and compile GMT
+  - template: ci/azure-pipelines-mac.yml
 
   - bash: |
       set -x -e
@@ -72,8 +67,6 @@ jobs:
       set -x -e
       cd build
       ctest --force-new-ctest-process -j4
-    condition: eq(variables['TEST'], 'true')
-    #condition: and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['TEST'], 'true'))
     displayName: Full tests
 
   # Upload test coverage even if build fails. Keep separate to make sure this task fails
@@ -83,6 +76,5 @@ jobs:
       bash <(curl -s https://codecov.io/bash)
     env:
       CODECOV_TOKEN: $(codecov.token)
-    condition: and(succeededOrFailed(), eq(variables['TEST'], 'true'))
-    #condition: and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['TEST'], 'true'))
+    condition: succeededOrFailed()
     displayName: Upload test coverage

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Test'
-  #condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.13'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
 
   - bash: |
       set -x -e
-      brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl
+      brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl graphicsmagick || true
     displayName: Install dependencies
 
   - bash: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -39,12 +39,14 @@ jobs:
       brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl graphicsmagick || true
     displayName: Install dependencies
 
-  - bash: |
-      set -x -e
-      echo "##vso[task.setvariable variable=INSTALLDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir"
-      echo "##vso[task.setvariable variable=COASTLINEDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir/coast"
-      echo "##vso[task.prependpath]$BUILD_SOURCESDIRECTORY/gmt-install-dir/bin"
-    displayName: Set environment variables
+  - bash: echo "##vso[task.setvariable variable=INSTALLDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir"
+    displayName: Set install location
+
+  - bash: echo "##vso[task.setvariable variable=COASTLINEDIR]$INSTALLDIR/coast"
+    displayName: Set coastline location
+
+  - bash: echo "##vso[task.prependpath]$INSTALLDIR/bin"
+    displayName: Set PATH
 
   - bash: |
       set -x -e

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
 
   - bash: |
       set -x -e
-      brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl graphicsmagick libtool
+      brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl
     displayName: Install dependencies
 
   - bash: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -23,10 +23,6 @@ jobs:
     vmImage: 'macOS-10.13'
 
   variables:
-    HOME: "$BUILD_SOURCESDIRECTORY"
-    INSTALLDIR: "$HOME/gmt-install-dir"
-    COASTLINEDIR: "$HOME/gmt-install-dir/coast"
-    #PATH: "$INSTALLDIR/bin:$PATH"
     BUILD_DOCS: false
 
   strategy:
@@ -45,12 +41,16 @@ jobs:
 
   - bash: |
       set -x -e
+      echo "##vso[task.setvariable variable=INSTALLDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir"
+      echo "##vso[task.setvariable variable=COASTLINEDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir/coast"
+      echo "##vso[task.prependpath]$BUILD_SOURCESDIRECTORY/gmt-install-dir/bin"
+    displayName: Set environment variables
+
+  - bash: |
+      set -x -e
       mkdir "$INSTALLDIR"
       mkdir "$COASTLINEDIR"
     displayName: Create install directories
-
-  - bash: echo "##vso[task.prependpath]$INSTALLDIR/bin"
-    displayName: Add GMT to PATH
 
   - bash: ci/download-coastlines.sh
     displayName: Download coastlines

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,8 +41,8 @@ jobs:
 
   - bash: |
       set -x -e
-      echo "##vso[task.setvariable variable=INSTALLDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir"
-      echo "##vso[task.setvariable variable=COASTLINEDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir/coast"
+      echo "##vso[task.setvariable variable=INSTALLDIR]gmt-install-dir"
+      echo "##vso[task.setvariable variable=COASTLINEDIR]gmt-install-dir/coast"
       echo "##vso[task.prependpath]$BUILD_SOURCESDIRECTORY/gmt-install-dir/bin"
     displayName: Set environment variables
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,8 @@ cache:
         - $HOME/.ccache
         - $HOME/cache-gshhg-dcw
         - $HOME/cache-deb
-        - $HOME/Library/Caches/Homebrew
 
 before_cache:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        brew cleanup;
-      fi
     - rm -rf $HOME/.cache/pip/log
 
 # Only build pushes to select branches and tags. This avoids the double
@@ -48,23 +44,6 @@ branches:
 # Set the Ubuntu version for the Linux builds
 dist: xenial
 
-# Dependencies for the Linux and OSX builds
-addons:
-    homebrew:
-        packages:
-            - ccache
-            - cmake
-            - ninja
-            - curl
-            - netcdf
-            - gdal
-            - fftw
-            - pcre2
-            - ghostscript
-            - curl
-            - graphicsmagick
-            - python
-
 # Create the build matrix with different jobs for each platform and cron jobs
 matrix:
     include:
@@ -73,14 +52,6 @@ matrix:
           if: type != cron
         - name: "Linux (cron)"
           os: linux
-          if: type = cron
-          env:
-            - TEST="true"
-        - name: "Mac (compile only)"
-          os: osx
-          if: type != cron
-        - name: "Mac (cron)"
-          os: osx
           if: type = cron
           env:
             - TEST="true"
@@ -113,10 +84,6 @@ before_install:
         rsync -av /var/cache/apt/archives/*.deb ${DEB_CACHE}/
       fi
     - |-
-    # On OSX add ccache to PATH:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        export PATH="/usr/local/opt/ccache/libexec:$PATH";
-      fi
     - mkdir "$INSTALLDIR"
     - mkdir "$COASTLINEDIR"
     - ci/download-coastlines.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Generic Mapping Tools
 
 [![TravisCI](http://img.shields.io/travis/GenericMappingTools/gmt/master.svg?label=TravisCI)](https://travis-ci.org/GenericMappingTools/gmt)
+[![Azure](https://dev.azure.com/GenericMappingTools/GMT/_apis/build/status/GenericMappingTools.gmt?branchName=master)](https://dev.azure.com/GenericMappingTools/GMT/_build/latest?definitionId=2&branchName=master)
 [![CodeCov](https://img.shields.io/codecov/c/github/GenericMappingTools/gmt.svg)](https://codecov.io/gh/GenericMappingTools/gmt/)
 [![Coverity](https://scan.coverity.com/projects/7153/badge.svg)](https://scan.coverity.com/projects/gmt)
 [![Documentation (development version)](https://img.shields.io/badge/docs-development-green.svg)](https://genericmappingtools.github.io/gmt/dev/)

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -4,7 +4,7 @@ steps:
 
 - bash: |
     set -x -e
-    brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl graphicsmagick || true
+    brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript graphicsmagick || true
   displayName: Install dependencies
 
 - bash: echo "##vso[task.setvariable variable=INSTALLDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir"
@@ -12,9 +12,6 @@ steps:
 
 - bash: echo "##vso[task.setvariable variable=COASTLINEDIR]$INSTALLDIR/coast"
   displayName: Set coastline location
-
-- bash: echo "##vso[task.prependpath]$INSTALLDIR/bin"
-  displayName: Set PATH
 
 - bash: echo "##vso[task.prependpath]$INSTALLDIR/bin"
   displayName: Set PATH

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -1,0 +1,32 @@
+# Template for the basic Mac steps in Azure Pipelines
+
+steps:
+
+- bash: |
+    set -x -e
+    brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript curl graphicsmagick || true
+  displayName: Install dependencies
+
+- bash: echo "##vso[task.setvariable variable=INSTALLDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir"
+  displayName: Set install location
+
+- bash: echo "##vso[task.setvariable variable=COASTLINEDIR]$INSTALLDIR/coast"
+  displayName: Set coastline location
+
+- bash: echo "##vso[task.prependpath]$INSTALLDIR/bin"
+  displayName: Set PATH
+
+- bash: echo "##vso[task.prependpath]$INSTALLDIR/bin"
+  displayName: Set PATH
+
+- bash: |
+    set -x -e
+    mkdir -p "$INSTALLDIR"
+    mkdir -p "$COASTLINEDIR"
+  displayName: Create install directories
+
+- bash: ci/download-coastlines.sh
+  displayName: Download coastlines
+
+- bash: ci/build-gmt.sh
+  displayName: Compile GMT


### PR DESCRIPTION
**Description of proposed changes**

Enables the continuous integration services from Azure Pipelines. The configuration is in `.azure-pipelines.yml` and only builds on Mac for now. This can replace the Mac builds on TravisCI to try to speed up the process a bit by having more jobs execute in parallel.

The compilation only job runs in ~7.5 min. Full tests run in ~20 min.


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.

**ToDo**:

- [x] Add badge to the README
- [x] Disable Travis Mac jobs (?)