### PR TITLE
Fixing a few tests plus a bad test in gmtspatial

### DIFF
--- a/src/gmtspatial.c
+++ b/src/gmtspatial.c
@@ -924,7 +924,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMTSPATIAL_CTRL *Ctrl, struct 
 			case 'Q':	/* Measure area/length and handedness of polygons */
 				Ctrl->Q.active = true;
 				s = opt->arg;
-				if (strchr ("-+", s[0]) && strchr (GMT_LEN_UNITS, s[1])) {	/* Since [-|+] is deprecated as of GMT 6 */
+				if (s[0] && strchr ("-+", s[0]) && strchr (GMT_LEN_UNITS, s[1])) {	/* Since [-|+] is deprecated as of GMT 6 */
 					if (gmt_M_compat_check (GMT, 6))
 						GMT_Report (API, GMT_MSG_COMPAT, "Leading -|+ with unit to set flat Earth or ellipsoidal mode is deprecated; use -j<mode> instead\n");
 					else {

--- a/test/pscoast/placement.sh
+++ b/test/pscoast/placement.sh
@@ -4,7 +4,6 @@
 # Create triplicate plots of each.
 
 ps=placement.ps
-gmt defaults > save.conf
 
 coast () {
 gmt pscoast -B+glightblue -Dc -Gblack -O -K -Ya0c $*

--- a/test/psscale/cyclecpt.sh
+++ b/test/psscale/cyclecpt.sh
@@ -3,8 +3,8 @@
 ps=cyclecpt.ps
 gmt makecpt -Ccyclic -T0/180 -Ww > temp_cpt.cpt
 # Vertical
-gmt psscale -P -K -Ctemp_cpt.cpt -Dx3c/5c+w10c/0.618c+n+e -By+l"m" -Bxa+l"Cyclic CPT with NaN and unit" -X1i > $ps
+gmt psscale -P -K -Ctemp_cpt.cpt -Dx3c/5c+w10c/0.618c+n -By+l"m" -Bxa+l"Cyclic CPT with NaN and unit" -X1i > $ps
 gmt psscale -O -K -Ctemp_cpt.cpt -Dx3c/5c+w10c/0.618c+n -Bxa+l"Cyclic CPT with NaN" -X4i >> $ps
 # Horizontal
-gmt psscale -O -K -Ctemp_cpt.cpt -Dx5c/5c+w10c/0.618c+n+e+h -By+l"m" -Bxa+l"Cyclic CPT with NaN and unit" -X-4i -Y5i >> $ps
+gmt psscale -O -K -Ctemp_cpt.cpt -Dx5c/5c+w10c/0.618c+n+h -By+l"m" -Bxa+l"Cyclic CPT with NaN and unit" -X-4i -Y5i >> $ps
 gmt psscale -O -Ctemp_cpt.cpt -Dx5c/5c+w10c/0.618c+n+h -Bxa+l"Cyclic CPT with NaN" -Y1i >> $ps


### PR DESCRIPTION
A stray call to gmt defaults made placement.sh fail, and cyclecpt.sh used modifier **+e** which cannot be used with cyclic cpts.  Finally, gmtspatial performed a string search on a blank string and gave misleading warnings. These fixes dropped failed tests from 26 to 25.
