### PR TITLE
Move the prototype to a core header.

### DIFF
--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -120,6 +120,7 @@ EXTERN_MSC void gmt_setmode (struct GMT_CTRL *GMT, int direction);
 /* gmt_bcr.c: */
 EXTERN_MSC double gmt_bcr_get_z (struct GMT_CTRL *GMT, struct GMT_GRID *G, double xx, double yy);		/* Compute z(x,y) from bcr structure and grid */
 EXTERN_MSC double gmt_bcr_get_z_fast (struct GMT_CTRL *GMT, struct GMT_GRID *G, double xx, double yy);		/* Same but without region and nan checks */
+EXTERN_MSC int gmt_parse_j_option (struct GMT_CTRL *GMT, char *arg);
 
 /* gmt_customio.c: */
 

--- a/src/mgd77/mgd77list.c
+++ b/src/mgd77/mgd77list.c
@@ -347,8 +347,6 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
-EXTERN_MSC int gmt_parse_j_option (struct GMT_CTRL *GMT, char *arg);
-
 GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77LIST_CTRL *Ctrl, struct GMT_OPTION *options) {
 	/* This parses the options provided to mgd77list and sets parameters in CTRL.
 	 * Any GMT common options will override values set previously by other commands.


### PR DESCRIPTION
Was causing a ``unresolved external symbol gmt_parse_j_option`` link error on Windows
