### PR TITLE
Update pslegend text syntax to GMT5

### DIFF
--- a/doc/examples/ex22/example_22.sh
+++ b/doc/examples/ex22/example_22.sh
@@ -43,7 +43,7 @@ gmt psxy -R -J -O -K -Cneis.cpt -Sci -Wfaint -hi1 -i2,1,3,4+s0.015 $file >> $ps
 # Create legend input file for NEIS quake plot
 
 cat > neis.legend << END
-H 16 1 $n events during $first to $last
+H 16p,Helvetica-Bold $n events during $first to $last
 D 0 1p
 N 3
 V 0 1p
@@ -80,7 +80,7 @@ G 0.4i
 # Add USGS logo
 I @USGS.png 1i RT
 G -0.3i
-L 12 6 LB $me
+L 12p,Times-Italic LB $me
 END
 
 # OK, now we can actually run gmt pslegend.  We center the legend below the map.

--- a/doc/examples/ex31/example_31.sh
+++ b/doc/examples/ex31/example_31.sh
@@ -55,14 +55,14 @@ gmt pstext -R -J -F+f7p,LinBiolinumOI+jBL -Dj0.1c -Gwhite -C5%+tO -Qu -O -K >> $
 # construct legend
 cat << EOF > legend.txt
 G -0.1c
-H 10 LinBiolinumOB Population of the European Union capital cities
+H 10p,LinBiolinumOB Population of the European Union capital cities
 G 0.15c
 N 2
 S 0.15c c 0.15c 196/80/80 0.25p 0.5c < 1 Million inhabitants
 S 0.15c c 0.15c 196/80/80 1.25p 0.5c > 1 Million inhabitants
 N 1
 G 0.15c
-L 8 LinBiolinumOB L Population in Millions 
+L 8p,LinBiolinumOB L Population in Millions 
 N 6
 EOF
 

--- a/doc/examples/ex42/example_42.sh
+++ b/doc/examples/ex42/example_42.sh
@@ -20,7 +20,7 @@ gmt psscale -Cz.cpt -DJRM+w2.5i/0.2i+o0.5i/0+mc -R -J -O -K -F+p+i -Bxa1000+lELE
 gmt pscoast -R -J -Di -Glightblue -Sroyalblue2 -O -K -X2i -Y4.75i >> $ps
 gmt pscoast -R -J -Di -Glightbrown -O -K -A+ag -Bafg >> $ps
 gmt pslegend -DjLM+w1.7i+jRM+o0.5i/0 -R -J -O -K -F+p+i << EOF >> $ps
-H 18 Times-Roman Legend
+H 18p,Times-Roman Legend
 D 0.1i 1p
 S 0.15i s 0.2i blue  0.25p 0.3i Ocean
 S 0.15i s 0.2i lightblue  0.25p 0.3i Ice front

--- a/doc/examples/ex43/example_43.sh
+++ b/doc/examples/ex43/example_43.sh
@@ -27,7 +27,7 @@ gmt psxy -R -J -O -K -Sc0.15i -Ct.cpt -Wfaint -i0,1,6 model.txt >> $ps
 gmt pstext A.txt -R -J -O -K -F+f8p+jCM+r1 -B0 >> $ps
 # Build legend
 cat << EOF > legend.txt
-H 18 Times-Roman Index of Animals
+H 18p,Times-Roman Index of Animals
 D 1p
 N 7 43 7 43
 EOF

--- a/doc/rst/source/legend.rst
+++ b/doc/rst/source/legend.rst
@@ -45,7 +45,7 @@ specifications, use
      # H is header, L is label, S is symbol, T is paragraph text, M is map scale.
      #
      G -0.1i
-     H 24 Times-Roman My Map Legend
+     H 24p,Times-Roman My Map Legend
      D 0.2i 1p
      N 2
      V 0 1p
@@ -64,7 +64,8 @@ specifications, use
      I SOEST_logo.ras 3i CT
      G 0.05i
      B colors.cpt 0.2i 0.2i
-     G 0.05i L 9 4 R Smith et al., @%5%J. Geophys. Res., 99@%%, 2000
+     G 0.05i
+     L 9p,Times-Roman R Smith et al., @%5%J. Geophys. Res., 99@%%, 2000
      G 0.1i
      P
      T Let us just try some simple text that can go on a few lines.

--- a/doc/rst/source/legend_common.rst_
+++ b/doc/rst/source/legend_common.rst_
@@ -120,8 +120,9 @@ Legend Codes
     See :doc:`colorbar` for details on all modifiers and options.
 **C** *textcolor*
     The **C** record specifies the color with which the remaining text
-    is to be printed. *textcolor* can be in the form *r/g/b*, *c/m/y/k*,
-    a named color, or an indirect color via z=\ *value* (requires a prior **A** code as well).
+    is to be printed via z=\ *value* (requires a prior **A** code as well).
+    When **C** is used in a legend then your font specifications cannot also
+    contain a color specification since we will append ,*textcolor* to the font.
     Use **-** to reset to default color.
 **D** [*offset*] *pen* [**-**\ \|\ **+**\ \|\ **=**]
     The **D** record results in a horizontal line with specified *pen*
@@ -145,16 +146,16 @@ Legend Codes
     The **G** record specifies a vertical gap of the given length. In
     addition to the standard units (**i**, **c**, **p**) you may use
     **l** for lines. A negative *gap* will move the current line upwards (thus closing a gap).
-**H** *fontsize*\ \|\ **-** *font*\ \|\ **-** *header*
+**H** *font*\ \|\ **-** *header*
     The **H** record plots a centered text string using the specified
-    font parameters. Use **-** to default to size and type of **FONT\_TITLE**.
+    font parameters. Use **-** to default to size and fonttype of **FONT\_TITLE**.
 **I** *imagefile width justification*
     Place an EPS or raster image in the legend justified relative to
     the current point. The image *width* determines the size of the image on the page.
-**L** *fontsize*\ \|\ **-** *font*\ \|\ **-** *justification label*
+**L** *font*\ \|\ **-** *justification label*
     The **L** record plots a (L)eft, (C)entered, or (R)ight-justified
     text string within a column using the specified font parameters. Use
-    **-** to default to the size and type of **FONT\_LABEL**.
+    **-** to default to the size and font type of **FONT\_LABEL**.
 **M** *slon*\ \|\ **-** *slat length* [**+f**\ ][**+l**\ [*label*]][**+u**\ ] [**-F**\ *param*] [ **-R**\ *w/e/s/n* **-J**\ *param* ]
     Place a map scale in the legend. Specify *slon slat*, the point on
     the map where the scale applies (*slon* is only meaningful for

--- a/doc/rst/source/pslegend.rst
+++ b/doc/rst/source/pslegend.rst
@@ -49,7 +49,7 @@ specifications, use
      # H is header, L is label, S is symbol, T is paragraph text, M is map scale.
      #
      G -0.1i
-     H 24 Times-Roman My Map Legend
+     H 24p,Times-Roman My Map Legend
      D 0.2i 1p
      N 2
      V 0 1p
@@ -68,7 +68,8 @@ specifications, use
      I SOEST_logo.ras 3i CT
      G 0.05i
      B colors.cpt 0.2i 0.2i
-     G 0.05i L 9 4 R Smith et al., @%5%J. Geophys. Res., 99@%%, 2000
+     G 0.05i
+     L 9p,Times-Roman R Smith et al., @%5%J. Geophys. Res., 99@%%, 2000
      G 0.1i
      P
      T Let us just try some simple text that can go on a few lines.

--- a/doc/scripts/GMT_RGBchart.sh
+++ b/doc/scripts/GMT_RGBchart.sh
@@ -66,8 +66,8 @@ gmt logo -R -J -O -K -Dg0.5/1+jMC+w$W >> $ps
 
 height=`gmt math -Q $HEIGHT $ROW DIV =`
 gmt pslegend -O -R -J -DjBR+w$WIDTH >> $ps <<END
-L $fontsizeL 1 R Values are R/G/B. Names are case-insensitive.
-L $fontsizeL 1 R Optionally, use GREY instead of GRAY.
+L ${fontsizeL}p,Helvetica-Bold R Values are R/G/B. Names are case-insensitive.
+L ${fontsizeL}p,Helvetica-Bold R Optionally, use GREY instead of GRAY.
 END
 
 gmt_remove_tmpdir

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -325,6 +325,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC int gmt_getfonttype (struct GMT_CTRL *GMT, char *name);
 EXTERN_MSC int gmt_legend_file (struct GMTAPI_CTRL *API, char *file);
 EXTERN_MSC int gmt_add_legend_item (struct GMTAPI_CTRL *API, char *symbol, char *size, struct GMT_FILL *fill, struct GMT_PEN *pen, char *label);
 EXTERN_MSC unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument, struct GMT_ARRAY *T, unsigned int flags, unsigned int tcol);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -944,7 +944,7 @@ bool gmtlib_is_color (struct GMT_CTRL *GMT, char *word) {
 }
 
 /*! . */
-GMT_LOCAL int support_getfonttype (struct GMT_CTRL *GMT, char *name) {
+int gmt_getfonttype (struct GMT_CTRL *GMT, char *name) {
 	unsigned int i;
 
 	if (!name[0]) return (-1);
@@ -6331,7 +6331,7 @@ int gmt_getfont (struct GMT_CTRL *GMT, char *buffer, struct GMT_FONT *F) {
 	/* Processes font settings given as [size][,name][,fill][=pen] */
 
 	F->form = 1;	/* Default is to fill the text with a solid color */
-    F->set = 0;     /* Start from no settings */
+	F->set = 0;     /* Start from no settings */
 	if ((s = strchr (line, '='))) {	/* Specified an outline pen */
 		s[0] = 0, i = 1;	/* Chop of this modifier */
 		if (s[1] == '~') F->form |= 8, i = 2;	/* Want to have an outline that does not obscure the text */
@@ -6389,7 +6389,7 @@ int gmt_getfont (struct GMT_CTRL *GMT, char *buffer, struct GMT_FONT *F) {
 	else
 		F->size = pointsize;
 	if (!name[0] || name[0] == '-') { /* Skip */ }
-	else if ((k = support_getfonttype (GMT, name)) >= 0)
+	else if ((k = gmt_getfonttype (GMT, name)) >= 0)
 		F->id = k;
 	else
 		GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Representation of font type not recognized. Using default.\n");
@@ -6437,6 +6437,7 @@ bool gmt_getpen (struct GMT_CTRL *GMT, char *buffer, struct GMT_PEN *P) {
 	char width[GMT_LEN256] = {""}, color[GMT_LEN256] = {""}, style[GMT_LEN256] = {""}, line[GMT_BUFSIZ] = {""}, *c = NULL;
 
 	if (!buffer || !buffer[0]) return (false);		/* Nothing given: return silently, leaving P in tact */
+	if (!P) return (false);		/* Nothing given: return silently, leaving P in tact */
 
 	strncpy (line, buffer, GMT_BUFSIZ-1);	/* Work on a copy of the arguments */
 	gmt_chop (line);	/* Remove trailing CR, LF and properly NULL-terminate the string */

--- a/test/pslegend/fancy.sh
+++ b/test/pslegend/fancy.sh
@@ -12,7 +12,7 @@ cat << EOF > tt.txt
 # H is ps=fancy.ps
 #
 G -0.1i
-H 24 Times-Roman Map Legend
+H 24p,Times-Roman Map Legend
 D 0.2i 1p
 V 0 1p
 S 0.1i c 0.15i p300/12 0.25p 0.3i This circle is hachured

--- a/test/pslegend/fill_frame.sh
+++ b/test/pslegend/fill_frame.sh
@@ -6,10 +6,10 @@ ps=fill_frame.ps
 color=yellow
 
 gmt psbasemap -R0/15/0/25 -Jx1c -P -B0 -K -Y1c > $ps
-gmt pslegend -R -J -O -K -Dx1c/24c+w8c/1c+jTL -F+g$color >> $ps <<< "L - - C $color fill, no frame"
-gmt pslegend -R -J -O -K -Dx1c/22c+w8c/1c+jTL -F+p+g$color >> $ps <<< "L - - C $color fill, black frame"
-gmt pslegend -R -J -O -K -Dx1c/20c+w8c/1c+jTL -F+p2p,blue+g${color}@50 >> $ps <<< "L - - C $color@@50 fill, blue frame"
-gmt pslegend -R -J -O -K -Dx1c/18c+w8c/1c+jTL -F+p2p,blue@50+g$color >> $ps <<< "L - - C $color fill, blue@@50 frame"
+gmt pslegend -R -J -O -K -Dx1c/24c+w8c/1c+jTL -F+g$color >> $ps <<< "L - C $color fill, no frame"
+gmt pslegend -R -J -O -K -Dx1c/22c+w8c/1c+jTL -F+p+g$color >> $ps <<< "L - C $color fill, black frame"
+gmt pslegend -R -J -O -K -Dx1c/20c+w8c/1c+jTL -F+p2p,blue+g${color}@50 >> $ps <<< "L - C $color@@50 fill, blue frame"
+gmt pslegend -R -J -O -K -Dx1c/18c+w8c/1c+jTL -F+p2p,blue@50+g$color >> $ps <<< "L - C $color fill, blue@@50 frame"
 gmt pslegend -R -J -O -K -Dx1c/15c+w8c+jTL -F+p+g$color >> $ps <<%
 P
 T This text wraps to the next line. It uses all standard paragraph modes. But what if you want to use left alignment?

--- a/test/pslegend/leg3D.sh
+++ b/test/pslegend/leg3D.sh
@@ -5,17 +5,17 @@
 ps=leg3D.ps
 gmt pslegend -R-85/-33/-58/15 -JM15c -p210/40 -P -DjLB+o0.2i+w2.2i/0+jBL -F+glightgrey+pthinner+s-4p/-6p/grey20@40 << EOF > $ps
 # Modified legend from example 10
-H 10 Times-Roman My Title 
+H 10p,Times-Roman My Title 
 C red
-L - - L dying
+L - L dying
 C yellow
-L - - L in trouble
+L - L in trouble
 C darkgreen
-L - - L vigorous
+L - L vigorous
 C blue
-L - - L developing
+L - L developing
 C purple
-L - - L institutional
+L - L institutional
 N 1 
 S 0.1i c 0.15i p300/12 0.25p 0.3i This circle is hachured
 S 0.1i e 0.15i yellow 0.25p 0.3i This ellipse is yellow

--- a/test/pslegend/legcpt.sh
+++ b/test/pslegend/legcpt.sh
@@ -9,7 +9,7 @@
 ps=legcpt.ps
 gmt makecpt -Cabyss > col.cpt
 cat << EOF > leg
-H 16 1 10 events during Monday to Friday
+H 16p,Helvetica-Bold 10 events during Monday to Friday
 D 0 1p
 B col.cpt 1c 1c -Ba1000f100g500+lm
 G 0.7c

--- a/test/pslegend/legend.sh
+++ b/test/pslegend/legend.sh
@@ -13,7 +13,7 @@ gmt pslegend -R0/10/0/10 -JM6i -Dx0.5i/0.5i+w5i+jBL+l1.2 -C0.1i/0.1i -F+p+gazure
 # H is ps=legend.ps
 #
 G -0.1i
-H 24 Times-Roman My Map Legend
+H 24p,Times-Roman My Map Legend
 D 0.2i 1p
 N 2
 V 0 1p
@@ -33,7 +33,7 @@ I @SOEST_block4.png 3i CT
 G 0.05i
 B tt.cpt 0.2i 0.2i -B0
 G 0.05i
-L 9 4 R Smith et al., @%5%J. Geophys. Res., 99@%%, 2000
+L 9p,Times-Roman R Smith et al., @%5%J. Geophys. Res., 99@%%, 2000
 G 0.1i
 T Let us just try some simple text that can go on a few lines.
 T There is no easy way to predetermine how many lines may be required

--- a/test/pslegend/legend3D.sh
+++ b/test/pslegend/legend3D.sh
@@ -13,7 +13,7 @@ gmt pslegend -R0/10/0/9 -JM6i -Dx0.5i/0.5i+w5i+jBL+l1.2 -C0.1i/0.1i -F+p+gazure1
 # H is ps=legend.ps
 #
 G -0.1i
-H 24 Times-Roman My Map Legend
+H 24p,Times-Roman My Map Legend
 D 0.2i 1p
 N 2
 V 0 1p
@@ -33,7 +33,7 @@ I @SOEST_block4.png 3i CT
 G 0.05i
 B tt.cpt 0.2i 0.2i -B0
 G 0.05i
-L 9 4 R Smith et al., @%5%J. Geophys. Res., 99@%%, 2000
+L 9p,Times-Roman R Smith et al., @%5%J. Geophys. Res., 99@%%, 2000
 G 0.1i
 T Let us just try some simple text that can go on a few lines.
 T There is no easy way to predetermine how many lines may be required

--- a/test/pslegend/table.sh
+++ b/test/pslegend/table.sh
@@ -11,85 +11,85 @@ cat <<EOF > table.txt
 # G is vertical gap, V is vertical line, N sets # of columns, D draws horizontal line,
 #
 G 0.04i
-H 24 Times-Roman Eight Largest Cities in North America
+H 24p,Times-Roman Eight Largest Cities in North America
 D 1p
 N 6 22 16 20 20 8 8
 V 0.25p
 S 0.15i c 0.1i snow1 -
-L - - C City Name
-L - - C Country
-L - - C Population
-L - - C Climate
-L - - C WC?
-L - - C OL?
+L - C City Name
+L - C Country
+L - C Population
+L - C Climate
+L - C WC?
+L - C OL?
 D 0 1p
 F lightgreen
 S 0.15i c 0.1i red 0.25p
-L - - R Mexico City
-L - - R Mexico
-L - - R 8,851,080
-L - - R Tropical
-L - - C Y
-L - - C Y
+L - R Mexico City
+L - R Mexico
+L - R 8,851,080
+L - R Tropical
+L - C Y
+L - C Y
 F -
 S 0.15i c 0.1i orange 0.25p
-L - - R New York City
-L - - R USA
-L - - R 8,405,837
-L - - R Tempered
-L - - C Y
-L - - C N
+L - R New York City
+L - R USA
+L - R 8,405,837
+L - R Tempered
+L - C Y
+L - C N
 S 0.15i c 0.1i yellow 0.25p
-L - - R Los Angeles
-L - - R USA
-L - - R 3,904,657
-L - - R Subtropical
-L - - C Y
-L - - C Y
+L - R Los Angeles
+L - R USA
+L - R 3,904,657
+L - R Subtropical
+L - C Y
+L - C Y
 F lightblue
 S 0.15i c 0.1i green 0.25p
-L - - R Toronto
-L - - R Canada
-L - - R 2,795,060
-L - - R Tempered
-L - - C N
-L - - C N
+L - R Toronto
+L - R Canada
+L - R 2,795,060
+L - R Tempered
+L - C N
+L - C N
 F -
 S 0.15i c 0.1i blue 0.25p
-L - - R Chicago
-L - - R USA
-L - - R 2,714,856
-L - - R Tempered
-L - - C Y
-L - - C N
+L - R Chicago
+L - R USA
+L - R 2,714,856
+L - R Tempered
+L - C Y
+L - C N
 S 0.15i c 0.1i cyan 0.25p
-L - - R Houston
-L - - R USA
-L - - R 2,714,856
-L - - R subtropical
-L - - C N
-L - - C N
+L - R Houston
+L - R USA
+L - R 2,714,856
+L - R subtropical
+L - C N
+L - C N
 F lightred
 S 0.15i c 0.1i magenta 0.25p
-L - - R Havana
-L - - R Cuba
-L - - R 2,106,146
-L - - R Tropical
-L - - C N
-L - - C N
+L - R Havana
+L - R Cuba
+L - R 2,106,146
+L - R Tropical
+L - C N
+L - C N
 F lightblue
 S 0.15i c 0.1i white 0.25p
-L - - R Montreal
-L - - R Canada
-L - - R 1,649,519
-L - - R Tempered
-L - - C N
-L - - C Y
+L - R Montreal
+L - R Canada
+L - R 1,649,519
+L - R Tempered
+L - C N
+L - C Y
 D 1p
 V 1p
 F -
 N 1
-L 9 4 R Information from Wikipedia
+L 9p,Times-Roman R Information from Wikipedia
 G 0.05i
 T Many of these cities have hosted World Cup Soccer (WC) and some
 T have hosted the Olympics (OL).  The rest is just some basic information

--- a/test/pslegend/zlegend.sh
+++ b/test/pslegend/zlegend.sh
@@ -13,7 +13,7 @@ gmt pslegend -R -J -DjMC+w4i+jMC+l1.25 -C0.1i/0.1i -F+p+i+gwhite -O >> $ps <<EOF
 # Legend test for gmt pslegend
 # G is vertical gap, V is vertical line, N sets # of columns, D draws horizontal line,
 #
-H 18p Times-Roman Intensity of Coffee Stains
+H 18p,Times-Roman Intensity of Coffee Stains
 A a.cpt
 D 0.2i 1p
 S 0.1i c 0.15i z=0 0.25p 0.3i Symbol color given via z=0 and CPT look-up
@@ -29,9 +29,9 @@ S 0.1i c 0.15i z=9 0.25p 0.3i Symbol color given via z=9 and CPT look-up
 S 0.1i c 0.15i z=10 0.25p 0.3i Symbol color given via z=10 and CPT look-up
 D 0.2i 1p
 G 0.05i
-L 9 4 R The CPT file was made via gmt makecpt -Ccopper -T0/10/1
+L 9p,Times-Roman R The CPT file was made via gmt makecpt -Ccopper -T0/10/1
 D 0 2p
-H 18p Times-Roman Intensity of Political Partisanship
+H 18p,Times-Roman Intensity of Political Partisanship
 D 0.2i 1p
 A b.cpt
 S 0.1i s 0.15i z=-5 0.25p 0.3i Symbol color given via z=-5 and CPT look-up
@@ -47,5 +47,5 @@ S 0.1i s 0.15i z=4 0.25p 0.3i Symbol color given via z=4 and CPT look-up
 S 0.1i s 0.15i z=5 0.25p 0.3i Symbol color given via z=5 and CPT look-up
 D 0.2i 1p
 G 0.05i
-L 9 4 R The CPT file was made via gmt makecpt -Cpolar  -T-5/5/1
+L 9p,Times-Roman R The CPT file was made via gmt makecpt -Cpolar  -T-5/5/1
 EOF


### PR DESCRIPTION
The _specfile_ that pslegend reads had two formats involving text (**H** and **L** directives) and both only considered GMT4-style specification of text (size font).  This parsing has been updated to handle GMT5-style font specifications (but is still backwards compatible with GMT4 format) and the documentation and examples scripts now use the modern format.  All but 25 test pass, as before.
