### PR TITLE
Do not try to delete files when they are not present

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -295,7 +295,7 @@ unsigned int gmt_download_file_if_not_found (struct GMT_CTRL *GMT, const char* f
 				fclose (ftpfile.fp);
 				ftpfile.fp = NULL;
 			}
-			if (gmt_remove_file (GMT, local_path))
+			if (!access (local_path, F_OK) && gmt_remove_file (GMT, local_path))	/* Failed to clean up as well */
 				GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Could not even remove file %s\n", local_path);
 		}
 	}


### PR DESCRIPTION
If getting a remote file via the Curl library fails, we try to clean up the unfinished downloaded file.  But if the cause of the failure is _server is down_ or similar there won't be any downloaded file and we get annyoung messages like

> grdimage [DEBUG]: Delete /home/kristof/.gmt/server/earth_relief_15s.grd
> grdimage [ERROR]: Failed to remove /home/kristof/.gmt/server/earth_relief_15s.grd! [remove error: No such file or directory]
> grdimage [ERROR]: Could not even remove file /home/kristof/.gmt/server/earth_relief_15s.grd
> 

We now only try to delete the file if actually found.  See #492 for context.