### PR TITLE
Improve mapproject documentation

### DIFF
--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -101,6 +101,7 @@ Optional Arguments
     is given then we compute the azimuth (or back-azimuth) from the
     previous point.  Alternatively, append **+v** to obtain a
     *variable* 2nd point (*lon0*/*lat0*) via columns 3-4 in the input file.
+    See :ref:`Output Order` for how **-A** affects the output record.
 
 .. _-C:
 
@@ -153,6 +154,7 @@ Optional Arguments
     distances between successive points, or append both modifiers to get
     both distance measurements. Alternatively, append **+v** to obtain a
     *variable* 2nd point (*lon0*/*lat0*) via columns 3-4 in the input file.
+    See :ref:`Output Order` for how **-G** affects the output record.
 
 .. _-I:
 
@@ -172,6 +174,7 @@ Optional Arguments
     unit requires **-R** and **-J** to be set. Finally, append **+p** to
     report the line segment id and the fractional point number instead
     of lon/lat of the nearest point.
+    See :ref:`Output Order` for how **-L** affects the output record.
 
 .. _-N:
 
@@ -245,6 +248,7 @@ Optional Arguments
     times (ETA) for successive points.  Finally, because of the
     need for incremental distances the **-G** option with the
     **+i** modifier is required.
+    See :ref:`Output Order` for how **-Z** affects the output record.
 
 .. |Add_-bi| replace:: [Default is 2 input columns]. 
 .. include:: explain_-bi.rst_


### PR DESCRIPTION
Now added an internal lin from the descriptions of **-A**, **-G**, **-L**, **-Z** to explicitly mention how these options affect the output record column order.