### PR TITLE
Strengthen contouring checks

### DIFF
--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -947,7 +947,7 @@ int GMT_grdcontour (void *V_API, int mode, void *args) {
 
 	enum grdcontour_contour_type closed;
 
-	unsigned int id, n_contours, n_edges, tbl_scl = 1, io_mode = 0, uc, tbl, label_mode = 0;
+	unsigned int id, n_contours, n_edges, tbl_scl = 1, io_mode = 0, uc, tbl, label_mode = 0, n_cont_attempts = 0;
 	unsigned int cont_counts[2] = {0, 0}, i, n, nn, *edge = NULL, n_tables = 1, fmt[3] = {0, 0, 0};
 
 	uint64_t ij, *n_seg = NULL;
@@ -1615,8 +1615,11 @@ int GMT_grdcontour (void *V_API, int mode, void *args) {
 			gmt_M_free (GMT, x);
 			gmt_M_free (GMT, y);
 		}
+		n_cont_attempts++;
 	}
 
+	if (n_cont_attempts == 0) GMT_Report (API, GMT_MSG_VERBOSE, "No contours drawn, check your -A, -C, -L settings?\n");
+	
 	if (Ctrl->D.active) {	/* Write the contour line output file(s) */
 		gmt_set_segmentheader (GMT, GMT_OUT, true);	/* Turn on segment headers on output */
 		if ((error = GMT_Set_Columns (API, GMT_OUT, 3, GMT_COL_FIX_NO_TEXT)) != GMT_NOERROR) {

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -401,8 +401,13 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDCONTOUR_CTRL *Ctrl, struct 
 				}
 				else if (opt->arg[0] == '+' && (isdigit(opt->arg[1]) || strchr ("-+.", opt->arg[1])))
 					Ctrl->C.single_cont = atof (&opt->arg[1]);
-				else if (opt->arg[0] != '-')
+				else if (opt->arg[0] != '-') {
 					Ctrl->C.interval = atof (opt->arg);
+					if (gmt_M_is_zero (Ctrl->C.interval)) {
+						GMT_Report (API, GMT_MSG_NORMAL, "Syntax error -C: Contour interval cannot be zero\n");
+						n_errors++;
+					}
+				}
 				else {
 					GMT_Report (API, GMT_MSG_NORMAL, "Syntax error -C: Contour interval cannot be negative (%s)\n", opt->arg);
 					n_errors++;
@@ -1216,6 +1221,14 @@ int GMT_grdcontour (void *V_API, int mode, void *args) {
 		GMT_Report (API, GMT_MSG_VERBOSE, "No contours within specified -L range\n");
 		if (GMT_Destroy_Data (API, &G) != GMT_NOERROR) {
 			Return (API->error);
+		}
+		if (make_plot) {
+			if ((PSL = gmt_plotinit (GMT, options)) == NULL) Return (GMT_RUNTIME_ERROR);
+			gmt_plane_perspective (GMT, GMT->current.proj.z_project.view_plane, GMT->current.proj.z_level);
+			gmt_plotcanvas (GMT);	/* Fill canvas if requested */
+			gmt_map_basemap (GMT);
+			gmt_plane_perspective (GMT, -1, 0.0);
+			gmt_plotend (GMT);
 		}
 		Return (GMT_NOERROR);
 	}

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -559,8 +559,13 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCONTOUR_CTRL *Ctrl, struct G
 				}
 				else if (opt->arg[0] == '+' && (isdigit(opt->arg[1]) || strchr ("-+.", opt->arg[1])))
 					Ctrl->C.single_cont = atof (&opt->arg[1]);
-				else if (opt->arg[0] != '-')
+				else if (opt->arg[0] != '-') {
 					Ctrl->C.interval = atof (opt->arg);
+					if (gmt_M_is_zero (Ctrl->C.interval)) {
+						GMT_Report (API, GMT_MSG_NORMAL, "Syntax error -C: Contour interval cannot be zero\n");
+						n_errors++;
+					}
+				}
 				else {
 					GMT_Report (API, GMT_MSG_NORMAL, "Syntax error -C: Contour interval cannot be negative (%s)\n", opt->arg);
 					n_errors++;


### PR DESCRIPTION
Neither grdcontour nor pscontour should allow a zero contour interval.  grdcontour should make a plot even if no contours are drawn.  This addresses most of #597.  The case of -C1 with earth_relief_30m is particular since the data are integer and that means contours need to go through every node.  This probably hits some crazy logic.  However, we dont want to add a special check for the earth_relief grids.  I will see if there is a way to avoid those odd messages.