### PR TITLE
Dont let clear recreate cache after removing it

### DIFF
--- a/src/clear.c
+++ b/src/clear.c
@@ -75,7 +75,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
 }
 
 GMT_LOCAL int clear_cache (struct GMTAPI_CTRL *API) {
-	if (gmt_remove_dir (API, API->GMT->session.CACHEDIR, true))
+	if (gmt_remove_dir (API, API->GMT->session.CACHEDIR, false))
 		return GMT_RUNTIME_ERROR;
 	return GMT_NOERROR;
 }


### PR DESCRIPTION
For some reason I had clear cache remove cache and its content, then create an empty cache dir.  But that dir will be created when needed, so makes more sense to remove it like everything else.  Addresses #582.
