### PR TITLE
Allow pscontour and grdcontour to take comma-separated lists

### DIFF
--- a/doc/rst/source/contour.rst
+++ b/doc/rst/source/contour.rst
@@ -16,9 +16,9 @@ Synopsis
 
 **gmt contour** [ *table* ] |-J|\ *parameters*
 |SYN_OPT-Rz|
-[ |-A|\ [**-**\ \|\ [+]\ *annot\_int*][*labelinfo*] ]
+[ |-A|\ [**-**\ \|\ *contours*][*labelinfo*] ]
 [ |SYN_OPT-B| ]
-[ |-C|\ [**+**\ ]\ *cont_int* ]
+[ |-C|\ *contours* ]
 [ |-D|\ [*template*] ] [ |-E|\ *indexfile* ]
 [ |-G|\ [**d**\ \|\ **f**\ \|\ **n**\ \|\ **l**\ \|\ **L**\ \|\ **x**\ \|\ **X**]\ *params* ]
 [ |-I| ] [ |-J|\ **z**\ \|\ **Z**\ *parameters* ]
@@ -53,6 +53,12 @@ map at 0.5 inch/degree along the standard parallels 18 and 24, use
    ::
 
     gmt contour topo.xyz -R320/330/20/30 -Jl18/24/0.5i -Ctopo.cpt -W0.5p -pdf topo
+
+To use the same data but only contour the values 250 and 700, use
+
+   ::
+
+    gmt contour topo.xyz -R320/330/20/30 -Jl18/24/0.5i -C250,700 -W0.5p -pdf topo
 
 To create a color plot of the numerical temperature
 solution obtained on a triangular mesh whose node coordinates and

--- a/doc/rst/source/contour_common.rst_
+++ b/doc/rst/source/contour_common.rst_
@@ -38,11 +38,12 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ [**-**\ \|\ [**+**\]\ *annot_int*][*labelinfo*]
-    *annot_int* is annotation interval in data units; it is ignored if
-    contour levels are given in a file. [Default is no annotations]. Prepend
-    **-** to disable all annotations implied by **-C**. Alternatively prepend
-    **+** to the annotation interval to plot that as a single contour. The optional
+**-A**\ [**-**\ \|\*contours*][*labelinfo*]
+    *contours* is annotation interval in data units; it is ignored if
+    contour levels are given in a file vua **-C**. [Default is no annotations]. Prepend
+    **-** to disable all annotations implied by **-C**. To just select a few specific
+    contours give them as a comma-separated string; if only a single contour please add
+    a trailing comma so it is seen as a list and not a contour interval. The optional
     *labelinfo* controls the specifics of the label formatting and consists
     of a concatenated string made up of any of the following control arguments:
 
@@ -54,17 +55,17 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ [**+**\ ]\ *cont_int*
-    The contours to be drawn may be specified in one of three possible ways:
+**-C**\ *contours*
+    The contours to be drawn may be specified in one of four possible ways:
 
-    (1) If *cont_int* has the suffix ".cpt" and can be opened as a
+    (1) If *contours* is a string with suffix ".cpt" and can be opened as a
         file, it is assumed to be a CPT. The color
         boundaries are then used as contour levels. If the CPT has
         annotation flags in the last column then those contours will be
         annotated. By default all contours are labeled; use **-A-** to
         disable all annotations.
 
-    (2) If *cont_int* is a file but not a CPT, it is expected to
+    (2) If *contours* is a file but not a CPT, it is expected to
         contain contour levels in column 1 and a
         C(ontour) OR A(nnotate) in
         col 2. The levels marked C (or c) are contoured, the levels marked A
@@ -72,20 +73,19 @@ Optional Arguments
         be present and contain the fixed annotation angle for this contour
         level.
 
-    (3) If no file is found, then *cont_int* is interpreted as a
-        constant contour interval. However, if prepended with the **+** sign the
-        *cont_int* is taken as meaning draw that single contour. The **-A**
-        option offers the same possibility so they may be used together to
-        plot only one annotated and one non-annotated contour.
-        If **-A** is set and **-C** is not, then the contour interval is set
-        equal to the specified annotation interval. Note to specify a negative
-        value you must still prepend the +, as in '... -C+-10'.
+    (3) If *contours* is a string with comma-separated values it is interpreted
+        as those specific contours only.  To indicate a single specific contour
+        you must append a trailing comma to separate it from a contour interval.
+        The **-A** option offers the same list choice so they may be used together
+        to plot only specific annotated and non-annotated contours.
+
+    (4) Otherwise, *contours* is interpreted as a constant contour interval.
 
     If a file is given and **-T** is set, then only contours marked with
     upper case C or A will have tick-marks. In all cases the contour
     values have the same units as the file.  Finally, if neither **-C**
     nor **-A** are set then we auto-compute suitable contour and annotation
-    intervals from the data range, yielding 10-20 contours.
+    intervals from the data range, yielding approximately 10-20 contours.
 
 .. _-D:
 

--- a/doc/rst/source/grdcontour.rst
+++ b/doc/rst/source/grdcontour.rst
@@ -14,9 +14,9 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt grdcontour** *grid*
-|-J|\ *parameters* [ |-A|\ [**-**\ \|\ [+]\ *annot_int*][*labelinfo*] ]
+|-J|\ *parameters* [ |-A|\ [**-**\ *contours*][*labelinfo*] ]
 [ |SYN_OPT-B| ]
-[ |-C|\ [+]\ *cont_int*\ \|\ *cpt* ]
+[ |-C|\ *contours*\ \|\ *cpt* ]
 [ |-D|\ *template* ]
 [ |-F|\ [**l**\ \|\ **r**] ]
 [ |-G|\ [**d**\ \|\ **f**\ \|\ **n**\ \|\ **l**\ \|\ **L**\ \|\ **x**\ \|\ **X**]\ *params* ]
@@ -56,6 +56,12 @@ degree tickmarks, and draw 30 minute gridlines:
    ::
 
     gmt grdcontour hawaii_grav.nc -Jm0.5i -C25 -A50+f10p -B1g30m -pdf hawaii_grav
+
+To do the same map but only draw the 50 and 150 and annotate the 100 contour:
+
+   ::
+
+    gmt grdcontour hawaii_grav.nc -Jm0.5i -C50.150 -A100,+f10p -B1g30m -pdf hawaii_grav
 
 To contour the file image.nc using the levels in the file cont.txt on a
 linear projection at 0.1 cm/x-unit and 50 cm/y-unit, using 20 (x) and

--- a/doc/rst/source/grdcontour_classic.rst
+++ b/doc/rst/source/grdcontour_classic.rst
@@ -14,9 +14,10 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **grdcontour** *grid*
-|-J|\ *parameters* [ |-A|\ [**-**\ \|\ [+]\ *annot_int*][*labelinfo*] ]
+|-J|\ *parameters*
+[ |-A|\ [**-**\ *contours*][*labelinfo*] ]
 [ |SYN_OPT-B| ]
-[ |-C|\ [+]\ *cont_int*\ \|\ *cpt* ]
+[ |-C|\ *contours* ]
 [ |-D|\ *template* ]
 [ |-F|\ [**l**\ \|\ **r**] ]
 [ |-G|\ [**d**\ \|\ **f**\ \|\ **n**\ \|\ **l**\ \|\ **L**\ \|\ **x**\ \|\ **X**]\ *params* ]
@@ -59,6 +60,12 @@ degree tickmarks, and draw 30 minute gridlines:
    ::
 
     gmt grdcontour hawaii_grav.nc -Jm0.5i -C25 -A50+f10p -B1g30m > hawaii_grav.ps
+
+To do the same map but only draw the 50 and 150 and annotate the 100 contour:
+
+   ::
+
+    gmt grdcontour hawaii_grav.nc -Jm0.5i -C50.150 -A100,+f10p -B1g30m > hawaii_grav.ps
 
 To contour the file image.nc using the levels in the file cont.txt on a
 linear projection at 0.1 cm/x-unit and 50 cm/y-unit, using 20 (x) and

--- a/doc/rst/source/grdcontour_common.rst_
+++ b/doc/rst/source/grdcontour_common.rst_
@@ -24,11 +24,12 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ [**-**\ \|\ [+]\ *annot_int*][*labelinfo*]
-    *annot_int* is annotation interval in data units; it is ignored if
-    contour levels are given in a file. [Default is no annotations]. Append
-    **-** to disable all annotations implied by **-C**. Alternatively prepend
-    + to the annotation interval to plot that as a single contour. The optional
+**-A**\ [**-**\ \|\*contours*][*labelinfo*]
+    *contours* is annotation interval in data units; it is ignored if
+    contour levels are given in a file viua **-C**. [Default is no annotations]. Prepend
+    **-** to disable all annotations implied by **-C**. To just select a few specific
+    contours give them as a comma-separated string; if only a single contour please add
+    a trailing comma so it is seen as a list and not a contour interval. The optional
     *labelinfo* controls the specifics of the label formatting and consists
     of a concatenated string made up of any of the following control arguments:
 
@@ -40,39 +41,36 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ [+]\ *cont_int*
-    The contours to be drawn may be specified in one of three possible ways:
+**-C**\ *contours*
+    The contours to be drawn may be specified in one of four possible ways:
 
-    (1) If *cont_int* has the suffix ".cpt" and can be opened as a
+    (1) If *contours* is a string with suffix ".cpt" and can be opened as a
         file, it is assumed to be a CPT. The color
         boundaries are then used as contour levels. If the CPT has
         annotation flags in the last column then those contours will be
         annotated. By default all contours are labeled; use **-A-** to
         disable all annotations.
 
-    (2) If *cont_int* is a file but not a CPT, it is expected to
-        contain contour levels in column 1 and a
-        C(ontour) OR A(nnotate) in
+    (2) If *contours* is a file but not a CPT, it is expected to
+        contain contour levels in column 1 and a C(ontour) OR A(nnotate) in
         col 2. The levels marked C (or c) are contoured, the levels marked A
         (or a) are contoured and annotated. Optionally, a third column may
         be present and contain the fixed annotation angle for this contour
         level.
 
-    (3) If no file is found, then *cont_int* is interpreted as a
-        constant contour interval. However, if prepended with the + sign the
-        *cont_int* is taken as meaning draw that single contour. The **-A**
-        option offers the same possibility so they may be used together to
-        plot a single annotated contour and another single non-annotated contour,
-        as in '... -A+10 -C+5' that plots an annotated 10 contour and an non-annotated 5 contour.
-        If **-A** is set and **-C** is not, then the contour interval is set
-        equal to the specified annotation interval. Note to specify a negative
-        value you must still prepend the +, as in '... -C+-10'.
+    (3) If *contours* is a string with comma-separated values it is interpreted
+        as those specific contours only.  To indicate a single specific contour
+        you must append a trailing comma to separate it from a contour interval.
+        The **-A** option offers the same list choice so they may be used together
+        to plot only specific annotated and non-annotated contours.
+
+    (4) Otherwise, *contours* is interpreted as a constant contour interval.
 
     If a file is given and **-T** is set, then only contours marked with
     upper case C or A will have tick-marks. In all cases the contour
     values have the same units as the grid.  Finally, if neither **-C**
     nor **-A** are set then we auto-compute suitable contour and annotation
-    intervals from the data range, yielding 10-20 contours.
+    intervals from the data range, yielding approximately 10-20 contours.
 
 .. _-D:
 

--- a/doc/rst/source/pscontour.rst
+++ b/doc/rst/source/pscontour.rst
@@ -16,9 +16,9 @@ Synopsis
 
 **pscontour** [ *table* ] |-J|\ *parameters*
 |SYN_OPT-Rz|
-[ |-A|\ [**-**\ \|\ [**+**\ ]\ *annot\_int*][*labelinfo*] ]
+[ |-A|\ [**-**\ *contours*][*labelinfo*] ]
 [ |SYN_OPT-B| ]
-[ |-C|\ [**+**\ ]\ *cont_int* ]
+[ |-C|\ *contours* ]
 [ |-D|\ [*template*] ] [ |-E|\ *indexfile* ]
 [ |-G|\ [**d**\ \|\ **f**\ \|\ **n**\ \|\ **l**\ \|\ **L**\ \|\ **x**\ \|\ **X**]\ *params* ]
 [ |-I| ] [ |-J|\ **z**\ \|\ **Z**\ *parameters* ]
@@ -58,6 +58,13 @@ map at 0.5 inch/degree along the standard parallels 18 and 24, use
    ::
 
     gmt pscontour topo.xyz -R320/330/20/30 -Jl18/24/0.5i -Ctopo.cpt -W0.5p > topo.ps
+
+
+To use the same data but only contour the values 250 and 700, use
+
+   ::
+
+    gmt pscontour topo.xyz -R320/330/20/30 -Jl18/24/0.5i -C250,700 -W0.5p > topo.ps
 
 To create a color plot of the numerical temperature
 solution obtained on a triangular mesh whose node coordinates and

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -325,6 +325,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC double *gmt_list_to_array (struct GMT_CTRL *GMT, char *list, unsigned int type, uint64_t *n);
 EXTERN_MSC int gmt_getfonttype (struct GMT_CTRL *GMT, char *name);
 EXTERN_MSC int gmt_legend_file (struct GMTAPI_CTRL *API, char *file);
 EXTERN_MSC int gmt_add_legend_item (struct GMTAPI_CTRL *API, char *symbol, char *size, struct GMT_FILL *fill, struct GMT_PEN *pen, char *label);


### PR DESCRIPTION
This PR lets both contour and grdcontour accept a comma-separated list of specific contours.  The special case of a single contour needs to be given a trailing comma to not be confused with a contour interval.  This buries the old scheme of giving a single contour by using a leading +, which always looked odd for negative contours (e.g., **-C**+-10).  It is now **-C**-10, with its trailing comma, or **-C**10, for the positive 10 contour.  The old scheme is still supported of course but no longer documented.  The list mechanism allows both **-A** and **-C** to be used at the same time, provided they are both lists.  Closes #461.