### PR TITLE
Fix missing gmt.conf in supplemental man pages

### DIFF
--- a/doc/rst/source/explain_help.rst_
+++ b/doc/rst/source/explain_help.rst_
@@ -6,4 +6,4 @@
 **-?** or no arguments
     Print a complete usage (help) message, including the explanation of all options, then exits.
 **--PAR**\ =\ *value*
-    Temporarily override a GMT default setting; repeatable. See :doc:`gmt.conf` for parameters.
+    Temporarily override a GMT default setting; repeatable. See :doc:`/gmt.conf` for parameters.


### PR DESCRIPTION
```
:doc:`gmt.conf` will creates a link to the file `gmt.conf.rst` in the same directory 
as the RST source file. 
For supplemental man pages, it doesn't work.

:doc:`/gmt.conf` always searches the file `gmt.conf.rst` 
in the root directory of the whole documentation.
```