### PR TITLE
Add option -E to deal with altitudes stored in the Extended data property

### DIFF
--- a/doc/rst/source/kml2gmt.rst
+++ b/doc/rst/source/kml2gmt.rst
@@ -14,6 +14,7 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt kml2gmt** [ *kmlfiles* ]
+[ |-E| ]
 [ |-F|\ **s**\ \|\ **l**\ \|\ **p** ]
 [ |SYN_OPT-V| ]
 [ |-Z| ]
@@ -47,6 +48,13 @@ Optional Arguments
 *kmlfiles*
     Name of one or more KML files to work on. If not are given, then
     standard input is read.
+
+.. _-E:
+
+**-E**
+    Get the altitude from the *ExtendData* property; *z* coordinates are then ignored. KML provides
+    more than one mechanism to store information via *ExtendData* but here we only implemented the
+    *<SimpleData name="string">* variation. Implicitly sets **-Z**
 
 .. _-F:
 

--- a/src/kml2gmt.c
+++ b/src/kml2gmt.c
@@ -37,16 +37,19 @@
 #define POLYGON			2
 
 struct KML2GMT_CTRL {
-	struct In {	/* in file */
+	struct KML2GMT_In {	/* in file */
 		bool active;
 		char *file;
 	} In;
-	struct F {	/* -F */
+	struct KML2GMT_E {	/* -E */
+		bool active;
+	} E;
+	struct KML2GMT_F {	/* -F */
 		bool active;
 		unsigned int mode;
 		unsigned int geometry;
 	} F;
-	struct Z {	/* -Z */
+	struct KML2GMT_Z {	/* -Z */
 		bool active;
 	} Z;
 };
@@ -70,7 +73,7 @@ GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct KML2GMT_CTRL *C) {	/* Dea
 GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<kmlfiles>] [-Fs|l|p] [%s] [-Z] [%s] [%s]\n\t[%s] [%s] [%s]\n\n",
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<kmlfiles>] [-E] [-Fs|l|p] [%s] [-Z] [%s] [%s]\n\t[%s] [%s] [%s]\n\n",
 		name, GMT_V_OPT, GMT_bo_OPT, GMT_do_OPT, GMT_ho_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -80,6 +83,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t<kmlfiles> is one or more KML files from Google Earth or similar.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If no files are given, standard input is read.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-E Get Z from the ExtendData property (only single <SimpleData name=\"string\"> implemented so far).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-F Restrict feature type; choose from (s)symbol, (l)ine, or (p)olygon.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use to only output data for the selected feature type [all].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Z Output the z-column from the KML file [Only lon,lat is output].\n");
@@ -113,6 +117,10 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct KML2GMT_CTRL *Ctrl, struct GMT
 
 			/* Processes program-specific parameters */
 
+			case 'E':	/* Feature type */
+		 		Ctrl->E.active = true;
+ 				Ctrl->Z.active = true;	/* Needs this too */
+				break;
 			case 'F':	/* Feature type */
 		 		Ctrl->F.active = true;
 				switch (opt->arg[0]) {
@@ -156,13 +164,13 @@ int GMT_kml2gmt (void *V_API, int mode, void *args) {
 	unsigned int i, start, fmode = POINT, n_features = 0, pos;
 	int error = 0, n_scan;
 	size_t length;
-	bool scan = true, first = true, skip, single = false;
+	bool scan = true, first = true, skip, single = false, extended = false;
 	
 	char line[GMT_BUFSIZ] = {""}, buffer[GMT_BUFSIZ] = {""}, name[GMT_BUFSIZ] = {""};
 	char word[GMT_LEN128] = {""}, description[GMT_BUFSIZ] = {""};
 	char *gm[3] = {"Point", "Line", "Polygon"};
 
-	double out[3];
+	double out[3], elev;
 	
 	FILE *fp = NULL;
 
@@ -286,6 +294,24 @@ int GMT_kml2gmt (void *V_API, int mode, void *args) {
 			if (description[0]) { strcat (GMT->current.io.segment_header, "-D\""); strcat (GMT->current.io.segment_header, description); strcat (GMT->current.io.segment_header, "\""); }
 		}
 		
+		if (Ctrl->E.active && strstr (line, "<ExtendedData>")) {
+			/* https://developers.google.com/kml/documentation/kmlreference#extendeddata
+			   But only a single <SimpleData name="string" is implemented here. */
+			fgets (line, GMT_BUFSIZ, fp);
+			if (strstr (line, "<SchemaData")) {
+				fgets (line, GMT_BUFSIZ, fp);
+				if (strstr (line, "<SimpleData")) {
+					char *p1, *p2;
+					p1 = strchr(line, '>');		p1++;           /* Find end of <SimpleData */
+					p2 = strchr (&p1[0], '<');	p2[0] = '\0';   /* Find begin of </SimpleData>*/
+					elev = atof(p1);
+					extended = true;
+				}
+				else
+					extended = false;
+			}
+		}
+
 		if (!strstr (line, "<coordinates>")) continue;
 		/* We get here when the line says coordinates */
 		
@@ -302,6 +328,7 @@ int GMT_kml2gmt (void *V_API, int mode, void *args) {
 		if (fmode == POINT && single) {	/* Process the single point from current record */
 			for (i = 0; i < length && line[i] != '>'; i++);		/* Find end of <coordinates> */
 			sscanf (&line[i+1], "%lg,%lg,%lg", &out[GMT_X], &out[GMT_Y], &out[GMT_Z]);
+			if (extended) out[GMT_Z] = elev;
 			GMT_Put_Record (API, GMT_WRITE_DATA, Out);	/* Write this to output */
 		}
 		else if (single) {	/* Process multiple points from current single record */
@@ -309,6 +336,7 @@ int GMT_kml2gmt (void *V_API, int mode, void *args) {
 			pos = i + 1;
 			while (gmt_strtok (line, " \t", &pos, word)) {	/* Look for clusters of x,y,z separated by whitespace */
 				n_scan = sscanf (word, "%lg,%lg,%lg", &out[GMT_X], &out[GMT_Y], &out[GMT_Z]);
+				if (extended) out[GMT_Z] = elev;
 				if (n_scan == 2 || n_scan == 3)
 					GMT_Put_Record (API, GMT_WRITE_DATA, Out);	/* Write this to output */
 				else
@@ -317,6 +345,7 @@ int GMT_kml2gmt (void *V_API, int mode, void *args) {
 		}
 		else {	/* Processes points from separate lines */
 			while (fscanf (fp, "%lg,%lg,%lg", &out[GMT_X], &out[GMT_Y], &out[GMT_Z])) {
+				if (extended) out[GMT_Z] = elev;	/* Replave Z by the extended data value */
 				GMT_Put_Record (API, GMT_WRITE_DATA, Out);	/* Write this to output */
 			}
 		}


### PR DESCRIPTION
I have one file that stores the altitude in the ``<ExtendedData>`` instead of the regular place (that have zeros only!!!!!). Apparently [this is legal](https://developers.google.com/kml/documentation/kmlreference#extendeddata) and there are even more than one way to store this info. The new **-E** option allows to retrieve that altitude info but only for the ``<SimpleData name="string">`` case.
```
			<Placemark>
				<name>200100</name>
				<Snippet maxLines="0"></Snippet>
				<styleUrl>#200100</styleUrl>
				<ExtendedData>
					<SchemaData schemaUrl="#BATIMETRIA_SIMP_schema">
						<SimpleData name="Elevation">-32</SimpleData>
					</SchemaData>
				</ExtendedData>
				<LineString>
					<tessellate>1</tessellate>
					<coordinates>
						-6.205370240543999,36.1351560248308,0 -6.20530461341698,36.1351591913437,0 
```