### PR TITLE
Update stale bot settings

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,17 +1,20 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 30
+daysUntilStale: 90
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
+  - bug
   - discussion
+  - enhancement
   - longterm
+  - "Feature request"
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had activity in
-  the last 30 days. It will be closed if no further activity occurs within 7 days. Thank
+  the last 90 days. It will be closed if no further activity occurs within 7 days. Thank
   you for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
**Description of proposed changes**

- Increase `daysUntilStale` to 90 days
- Exempt more labels

Fixes #652.