### PR TITLE
Simplify README and update install/build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,5 +1,23 @@
 # Building GMT
 
+## Contents
+
+- [Build and runtime dependencies](#build-and-runtime-dependencies)
+- [Install dependencies](#install-dependencies)
+  * [Ubuntu/Debian](#ubuntudebian)
+  * [RHEL/CentOS/Fedora](#rhelcentosfedora)
+  * [macOS with homebrew](#macos-with-homebrew)
+- [Get GMT source codes](#get-gmt-source-codes)
+- [Configuring](#configuring)
+- [Building GMT source codes](#building-gmt-source-codes)
+- [Building documentation](#building-documentation)
+- [Install](#install)
+- [Set path](#set-path)
+- [Tests](#tests)
+- [Updating the development source codes](#updating-the-development-source-codes)
+- [Packaging](#packaging)
+- [Creating a source package](#creating-a-source-package)
+
 ## Build and runtime dependencies
 
 To build GMT, you must install:
@@ -13,7 +31,7 @@ Optionally install for more capabilities within GMT:
 
 - [GDAL](https://www.gdal.org/) (Ability to read and write numerous grid and image formats)
 - [PCRE](https://www.pcre.org/) or PCRE2 (Regular expression support)
-- [FFTW](http://www.fftw.org/) single-precision (Fast FFTs [not needed under macOS])
+- [FFTW](http://www.fftw.org/) single-precision (Fast FFTs, >=3.3 [not needed under macOS])
 - LAPACK (Fast matrix inversion [not needed under macOS])
 - BLAS (Fast matrix multiplications [not needed underr macOS])
 
@@ -32,7 +50,7 @@ You also need download support data:
 
 ### Ubuntu/Debian
 
-For Ubuntu/Debian, there are prepackaged development binaries available. 
+For Ubuntu/Debian, there are prepackaged development binaries available.
 Install the GMT dependencies with:
 
     # Install required dependencies
@@ -40,13 +58,13 @@ Install the GMT dependencies with:
 
     # Install optional dependencies
     sudo apt-get install libgdal1-dev libfftw3-dev libpcre3-dev liblapack-dev libblas-dev
-    
+
     # to enable testing
     sudo apt-get install graphicsmagick
-    
+
     # to build the documentation
     sudo apt-get install python-sphinx
-    
+
     # to build the documentation in PDF format
     sudo apt-get install texlive texlive-latex-extra
 
@@ -113,7 +131,7 @@ If you want to build/use the latest developing/unstable GMT, you can get the sou
 
 ## Configuring
 
-GMT can be build on any platform supported by CMake. CMake is a cross-platform, open-source system for managing the build process. The building process is
+GMT can be built on any platform supported by CMake. CMake is a cross-platform, open-source system for managing the build process. The building process is
 controlled by two configuration files in the `cmake` directory:
 
 - "ConfigDefault.cmake": is version controlled and used to add new default
@@ -154,11 +172,11 @@ make -j
 
 which will compile all the programs.
 
-You can add an argument *x* to *-j* (e.g. *-j4*) which means make will 
-use *x* cores in the build; this depends on the number of cores in your CPU 
-and if hyperthreading is available or not. By using *-j* without any argument, 
-make will not limit the number of jobs that can run simultaneously. 
-cmake will build out-of-source in the the directory build. 
+You can add an argument *x* to *-j* (e.g. *-j4*) which means make will
+use *x* cores in the build; this depends on the number of cores in your CPU
+and if hyperthreading is available or not. By using *-j* without any argument,
+make will not limit the number of jobs that can run simultaneously.
+cmake will build out-of-source in the the directory build.
 
 ## Building documentation
 
@@ -184,10 +202,16 @@ and/or LaTeX are not available. Set *GMT_INSTALL_EXTERNAL_DOC* in
 make -j install
 ```
 
-will install gmt executable, library, development headers and built-in data 
-to the specified GMT install location. 
-Optionally it will also install the GSHHG shorelines (if found), DCW (if found), 
+will install gmt executable, library, development headers and built-in data
+to the specified GMT install location.
+Optionally it will also install the GSHHG shorelines (if found), DCW (if found),
 UNIX manpages, and HTML and PDF documentation.
+
+## Set path
+
+Make sure you set the PATH to include the directory containing the GMT executables (BINDIR)
+if this is not a standard directory like /usr/local/bin. Then, you should now be able to
+run GMT programs.
 
 ## Tests
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -43,7 +43,7 @@ Optionally install for building GMT documentations and running tests:
 
 You also need download support data:
 
-- gshhg: A Global Self-consistent, Hierarchical, High-resolution Geography Database (>=2.2.2)
+- gshhg: A Global Self-consistent, Hierarchical, High-resolution Geography Database (>=2.2.0)
 - dcw-gmt: The Digital Chart of the World (optional, >=1.0.5)
 
 ## Install dependencies

--- a/README.md
+++ b/README.md
@@ -53,10 +53,7 @@ will benefit from the availability of GMT:
 > Generic Mapping Tools: Improved version released, Eos Trans. AGU, 94(45),
 > 409-410, doi:[10.1002/2013EO450001](https://doi.org/10.1002/2013EO450001)
 
-## Introduction
-
-You do not need to read these instructions unless you plan to build and
-install the programs manually.
+## Install GMT
 
 GMT has been installed successfully under UNIX/Linux/OS X on workstations.  It
 also installs under Windows and in UNIX emulators such as Cygwin or on virtual
@@ -69,79 +66,10 @@ Note there are three GMT tar archives available (#3 is optional):
 2. gshhg-gmt-2.x.x.tar.gz:     All five resolutions of GSHHG coastline data
 3. dcw-gmt-1.x.x.tar.bz2:      Digital Chart of the World polygon data
 
-The archives are available in bzip2 (\*.bz2) and gzip (\*.gz) formats.
-If you do not have bzip2 installed you can obtain source or executables
-from http://www.bzip.org.
-
-For Windows users there are separate Windows installers available; this
-discussion only considers UNIX/Linux/OS X installations. Windows users who
-which to build GMT from the sources refer to README.WIN32.
-
-## Note to package maintainers
-
-Package maintainers note packaging recommendations at
-http://gmt.soest.hawaii.edu/projects/gmt/wiki/PackagingGMT
-
-## Build and runtime prerequisites
-
-- Software:
-  You need Ghostscript, CMake (>=2.8.5), netCDF (>=4.0, netCDF-4/HDF5
-  support mandatory) and Curl.  Optionally install Sphinx, PCRE1 or PCRE2, GDAL, LAPACK,
-  BLAS and FFTW (single precision version).
-- Data:
-  You need gshhg (>=2.2.2); optionally install dcw-gmt (>=1.0.5)
-
-### CMake
-
-Install CMake (>=2.8.5) from http://www.cmake.org/cmake/resources/software.html
-
-### Install netCDF library
-
-For all major Linux distributions there are prepackaged development binaries
-available. netCDF is also available on MacOSX trough the macports and fink
-package managers.
-
-Otherwise, get netCDF from http://www.unidata.ucar.edu/downloads/netcdf/.
-You need at least version 4.0 with netCDF-4/HDF5 data model support (do not
-disable HDF5/ZLIB in netCDF with --disable-netcdf-4).
-
-### Install CURL library
-
-To handle URLs we depend on libcurl so install via your favorite package
-manager if it is not intrinsic to your Unix installation.  Otherwise, get
-it from https://curl.haxx.se.
-
-### GDAL (optional)
-
-To use the GDAL interface (ability to provide grids or images to be imported
-via gdal) you must have the GDAL library and include files installed.  Like
-netCDF, GDAL is available through your favorite package manager on many *NIX
-systems.
-
-### PCRE (optional)
-
-To use the PCRE interface (ability to specify regular expressions in some
-search options, e.g., gmtconvert) you must have the PCRE library and include
-files installed.  PCRE is available through your favorite package manager
-on many *NIX systems.
-
-Because GDAL already links with PCRE1 it is most practical to use that version.
-But if you insist, GMT can also be compiled with PCRE2.
-
-### LAPACK (optional)
-
-To greatly speed up some linear algebra calculations (greenspline in
-particular) you must have the LAPACK library and include files installed.
-LAPACK is available through your favorite package manager on many *NIX
-systems or in the case of OS X is built in.  Normally this also installs
-BLAS but if not you need to do that separately as we are using some
-cblas_* functions to do linear algebra calculations.
-
-### Install support data
-
-You can obtain GMT from http://gmt.soest.hawaii.edu/. Alternatively you may
-get GMT from any of the following FTP sites. Try the site that is closest to
-you to minimize transmission times:
+For macOS and Windows users there are separate installers available.
+You can obtain GMT and support data from http://gmt.soest.hawaii.edu/.
+Alternatively you may get GMT from any of the following FTP sites.
+Try the site that is closest to you to minimize transmission times:
 
 | Site                                                        | FTP address             |
 |:------------------------------------------------------------|:------------------------|
@@ -153,53 +81,9 @@ you to minimize transmission times:
 | GDS, Vienna U. of Technology, AUSTRIA                       | gd.tuwien.ac.at         |
 | TENET, Tertiary Education & Research Networks, SOUTH AFRICA | gmt.mirror.ac.za        |
 
-The development sources are available from GitHub at
-https://github.com/GenericMappingTools/gmt.
 
-Extract the files and put them in a separate directory (need not be
-where you eventually want to install GMT).
-
-## Building GMT (quick start)
-
-This is just a quick start description. For a more thorough description read more on [Building GMT](BUILDING.md)
-
-Checkout GMT from its GitHub repository:
-
-```
-git clone https://github.com/GenericMappingTools/gmt
-cd gmt
-cp cmake/ConfigUserTemplate.cmake cmake/ConfigUser.cmake
-```
-
-Edit *cmake/ConfigUser.cmake* [see comments in the file]. Then:
-
-```
-mkdir build
-cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-make -j
-```
-You can add an argument *x* to *-j* (e.g. *-j4*) which means make will use *x*
-cores in the build; this depends on the number of cores in your CPU and if
-hyperthreading is available or not. By using *-j* without any argument, *make*
-will not limit the number of jobs that can run simultaneously.
-cmake will build out-of-source in the the directory _build_. 'CMAKE_BUILD_TYPE'
-can be one of: empty, Debug, Release, RelWithDebInfo or MinSizeRel
-
-```
-make -j install
-```
-
-installs a basic gmt in _build/gmt_.
-
-NOTE: All cmake command line options such as _-DCMAKE\_INSTALL\_PREFIX_ can be
-configured in *cmake/ConfigUser.cmake*.
-
-### Set path
-
-Make sure users set their PATH to include the directory containing
-the GMT executables (BINDIR) if this is not a standard directory
-like /usr/local/bin.  You should now be able to run GMT programs.
+Refere to the [install instructions](INSTALL.md) to install GMT,
+and [build instructions](BUILDING.md) to build GMT from the sources.
 
 ## GMT supplemental Code
 
@@ -207,25 +91,24 @@ GMT users elsewhere have developed programs that utilize the GMT libraries and
 produce PostScript code compatible with the rest of GMT or simply perform data
 manipulation. Currently, the supplemental archive include the directories:
 
-  gshhg     - Data extractor for GSHHG shoreline polygons and rivers, borders.
-  img       - Data extractor for Smith/Sandwell altimetry grids.
-  meca      - Plotting of focal mechanisms, velocity arrows,
-              and error ellipses on maps.
-  mgd77     - Programs for handling of native MGD77 files.
-  potential - geopotential manipulations
-  segyprogs - Plotting SEGY seismic data sets.
-  spotter   - Plate tectonic & kinematics applications.
-  x2sys     - Track intersection (crossover) tools.
+-  gshhg: Data extractor for GSHHG shoreline polygons and rivers, borders.
+-  img: Data extractor for Smith/Sandwell altimetry grids.
+-  meca: Plotting of focal mechanisms, velocity arrows, and error ellipses on maps.
+-  mgd77: Programs for handling of native MGD77 files.
+-  potential: geopotential manipulations
+-  segyprogs: Plotting SEGY seismic data sets.
+-  spotter: Plate tectonic & kinematics applications.
+-  x2sys: Track intersection (crossover) tools.
 
 ## Misc
 
 Before running programs, there are a few things you should do/know:
 
-  - Read carefully the documentation for the gmt system.  This can be
+    Read carefully the documentation for the gmt system. This can be
     found as both PDF and HTML files in the doc/pdf|html directories.
     The successful operation of gmt-programs depends directly on your
     understanding of how gmt "works", its option lists, I/O, and composite
-    plot mechanisms.  Then, before running individual gmt programs, read
+    plot mechanisms. Then, before running individual gmt programs, read
     the associated man page.
 
 ## Software support
@@ -246,7 +129,3 @@ Should you or someone you know without net-access need to obtain GMT:
 Geoware makes and distributes CD/DVD-Rs with the GMT package and many
 useful data sets.  For more details and a full description of the data
 sets (up to 60 Gb of data!) visit http://www.geoware-online.com/.
-
-Good luck!
-
-The GMT Team.


### PR DESCRIPTION
Remove the build instructions in README and link to INSTALL.md and BUILDING.md.

Close #472 