### PR TITLE
Allow for round-off in comparing two regions in grdimage

### DIFF
--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -676,8 +676,9 @@ int GMT_grdimage (void *V_API, int mode, void *args) {
 	if (Ctrl->D.active) {	/* Main input is a single image and not a grid */
 
 		if (use_intensity_grid && GMT->common.R.active[RSET]) {
-			if (GMT->common.R.wesn[XLO] < Intens_orig->header->wesn[XLO] || GMT->common.R.wesn[XHI] > Intens_orig->header->wesn[XHI] || 
-			    GMT->common.R.wesn[YLO] < Intens_orig->header->wesn[YLO] || GMT->common.R.wesn[YHI] > Intens_orig->header->wesn[YHI]) {
+            double xnoise = Intens_orig->header->inc[GMT_X]*GMT_CONV4_LIMIT, ynoise = Intens_orig->header->inc[GMT_Y]*GMT_CONV4_LIMIT;
+			if (GMT->common.R.wesn[XLO] < (Intens_orig->header->wesn[XLO]-xnoise) || GMT->common.R.wesn[XHI] > (Intens_orig->header->wesn[XHI]+xnoise) ||
+			    GMT->common.R.wesn[YLO] < (Intens_orig->header->wesn[YLO]-ynoise) || GMT->common.R.wesn[YHI] > (Intens_orig->header->wesn[YHI]+ynoise)) {
 				GMT_Report (API, GMT_MSG_NORMAL, "Requested region exceeds illumination extent\n");
 				Return (GMT_RUNTIME_ERROR);
 			}


### PR DESCRIPTION
The check to see if the **-R** used in grdimage exceeds the intensity grid was subject to round-off abuse, as evidenced in #621.  This PR should fix the error encountered by allowing 10^-4 times grid increment slop in w/e/s/n values.
