### PR TITLE
Disallow map projections when plotting Mercator IMG subsets

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -3267,6 +3267,16 @@ int gmt_raster_type (struct GMT_CTRL *GMT, char *file) {
 	return code;
 }
 
+int gmt_img_sanitycheck (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h) {
+	/* Make sure that img Mercator grids are not used with map projections for plotting */
+	
+	if (strncmp (h->remark, "Spherical Mercator Projected with -Jm1 -R", 41U)) return GMT_NOERROR;	/* Not a Mercator img grid since missing the critical remark format */
+	if (h->registration == GMT_GRID_NODE_REG) return GMT_NOERROR;		/* Cannot be a Mercator img grid since they are pixel registered */
+	if (GMT->current.proj.projection == GMT_LINEAR) return GMT_NOERROR;	/* Only linear projection is allowed with this projected grid */
+	GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Cannot use a map projection with an already projected grid (spherical Mercator img grid).  Use -Jx or -JX.\n");
+	return GMT_PROJECTION_ERROR;
+}
+
 #ifdef HAVE_GDAL
 GMT_LOCAL void gdal_free_from (struct GMT_CTRL *GMT, struct GMT_GDALREAD_OUT_CTRL *from_gdalread) {
 	int i;

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -152,6 +152,7 @@ EXTERN_MSC bool gmt_file_is_srtmtile (struct GMTAPI_CTRL *API, const char *file,
 
 /* gmt_grdio.c: */
 
+EXTERN_MSC int gmt_img_sanitycheck (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h);
 EXTERN_MSC void gmt_grd_flip_vertical (void *gridp, const unsigned n_cols, const unsigned n_rows, const unsigned n_stride, size_t cell_size);
 EXTERN_MSC int gmt_raster_type (struct GMT_CTRL *GMT, char *file);
 EXTERN_MSC void gmt_copy_gridheader (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *to, struct GMT_GRID_HEADER *from);

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -1158,6 +1158,9 @@ int GMT_grdcontour (void *V_API, int mode, void *args) {
 	if ((G = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, Ctrl->In.file, NULL)) == NULL) {	/* Get header only */
 		Return (API->error);
 	}
+	if ((API->error = gmt_img_sanitycheck (GMT, G->header))) {	/* Used map projection on a Mercator (cartesian) grid */
+		Return (API->error);
+	}
 
 	make_plot = !Ctrl->D.active;	/* Turn off plotting if -D was used */
 	need_proj = !Ctrl->D.active || Ctrl->contour.save_labels;	/* Turn off mapping if -D was used, unless +t was set */

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -736,6 +736,9 @@ int GMT_grdimage (void *V_API, int mode, void *args) {
 			if ((Grid_orig[k] = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, Ctrl->In.file[k], NULL)) == NULL) {	/* Get header only */
 				Return (API->error);
 			}
+			if ((API->error = gmt_img_sanitycheck (GMT, Grid_orig[k]->header))) {	/* Used map projection on a Mercator (cartesian) grid */
+				Return (API->error);
+			}
 		}
 		if (!Ctrl->C.active)
 			Ctrl->C.active = true;	/* Use default CPT (rainbow) and autostretch or under modern reuse current CPT */

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -379,6 +379,9 @@ int GMT_grdvector (void *V_API, int mode, void *args) {
 		if ((Grid[k] = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, Ctrl->In.file[k], NULL)) == NULL) {	/* Get header only */
 			Return (API->error);
 		}
+		if ((API->error = gmt_img_sanitycheck (GMT, Grid[k]->header))) {	/* Used map projection on a Mercator (cartesian) grid */
+			Return (API->error);
+		}
 		gmt_grd_init (GMT, Grid[k]->header, options, true);
 	}
 

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -821,6 +821,9 @@ int GMT_grdview (void *V_API, int mode, void *args) {
 	if ((Topo = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, Ctrl->In.file, NULL)) == NULL) {	/* Get header only */
 		Return (API->error);
 	}
+	if ((API->error = gmt_img_sanitycheck (GMT, Topo->header))) {	/* Used map projection on a Mercator (cartesian) grid */
+		Return (API->error);
+	}
 
 	if (use_intensity_grid && !Ctrl->I.derive) {
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Read intensity grid header from file %s\n", Ctrl->I.file);


### PR DESCRIPTION
See #674 for context.  If users extract a subset from an IMG grid and requests it to remain in the spherical Mercator format, then one cannot plot this grid with anything but a Cartesian projection.  This PR adds a new check to prevent such a mix of projections and projected data in the 4 modules that plot grids (grdimage, grdcontour, grdview, grdvector).

