### PR TITLE
Deal with duplicates input points in sphinterpolate

### DIFF
--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -1564,7 +1564,7 @@ int GMT_greenspline (void *V_API, int mode, void *args) {
 			else if (in[GMT_X] > Ctrl->R3.range[XHI] && (in[GMT_X] - 360.0) > Ctrl->R3.range[XLO]) in[GMT_X] -= 360.0;
 		}
 
-		X[n] = gmt_M_memory (GMT, NULL, n_cols, double);	/* Allocate space for this constraint */
+		if (X[n] == NULL) X[n] = gmt_M_memory (GMT, NULL, n_cols, double);	/* Allocate space for this constraint */
 		for (k = 0; k < dimension; k++) X[n][k] = in[k];	/* Get coordinates + optional weights (if -W) */
 		/* Check for duplicates */
 		skip = false;
@@ -1572,7 +1572,7 @@ int GMT_greenspline (void *V_API, int mode, void *args) {
 			r = get_radius (GMT, X[i], X[n], dimension);
 			if (gmt_M_is_zero (r)) {	/* Duplicates will give zero point separation */
 				if (doubleAlmostEqualZero (in[dimension], obs[i])) {
-					GMT_Report (API, GMT_MSG_NORMAL,
+					GMT_Report (API, GMT_MSG_VERBOSE,
 					            "Data constraint %" PRIu64 " is identical to %" PRIu64 " and will be skipped\n", n_read, i);
 					skip = true;
 					n_skip++;
@@ -1755,7 +1755,7 @@ int GMT_greenspline (void *V_API, int mode, void *args) {
 							n_skip++;
 						}
 						else {
-							GMT_Report (API, GMT_MSG_VERBOSE, "Slope constraint %" PRIu64 " and %" PRIu64
+							GMT_Report (API, GMT_MSG_NORMAL, "Slope constraint %" PRIu64 " and %" PRIu64
 							            " occupy the same location but differ in observation (%.12g vs %.12g)\n", n_read, i-n, obs[p], obs[i]);
 							n_duplicates++;
 						}


### PR DESCRIPTION
See issue #634 for context.  The problem was that the particular input file had lots of duplicate points along the two poles (same latitude, different longitudes are still the same point).  Unlike greenspline, sphinterpolate had no check for this and garbage grids were produced, if at all. I have ported the same checks from greenspline so that exact duplicates (e.g., [5 90 44.5] and [154 90 44.5]) are resolved by skipping the duplicate, whereas near-duplicates (same physical location but different observations) will result in an error that the user must resolve.