### PR TITLE
Watch for remote CPT files in arguments

### DIFF
--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -455,7 +455,7 @@ int GMT_grd2cpt (void *V_API, int mode, void *args) {
 	/*---------------------------- This is the grd2cpt main code ----------------------------*/
 
 	if (Ctrl->C.active) {
-		if ((l = strstr (Ctrl->C.file, ".cpt")) != NULL) *l = 0;	/* Strip off .cpt if used */
+		if (Ctrl->C.file[0] != '@' && (l = strstr (Ctrl->C.file, ".cpt")) != NULL) *l = 0;	/* Strip off .cpt if used */
 	}
 	else {	/* No table specified; set default rainbow table */
 		Ctrl->C.active = true;

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -388,7 +388,7 @@ int GMT_makecpt (void *V_API, int mode, void *args) {
 	/*---------------------------- This is the makecpt main code ----------------------------*/
 
 	if (Ctrl->C.active) {
-		if ((l = strstr (Ctrl->C.file, ".cpt"))) *l = 0;	/* Strip off .cpt if used */
+		if (Ctrl->C.file[0] != '@' && (l = strstr (Ctrl->C.file, ".cpt"))) *l = 0;	/* Strip off .cpt if used */
 	}
 	else {	/* No table specified; set default rainbow table */
 		Ctrl->C.active = true;


### PR DESCRIPTION
Both makecpt and grd2cpt would strip off the trailing ".cpt" from a file name but this should not be done if file starts with '@', i.e., a remote CPT file.  Closes issue #685.
