### PR TITLE
Documentation update on psconvert control in begin and figure.

### DIFF
--- a/doc/rst/source/begin.rst_
+++ b/doc/rst/source/begin.rst_
@@ -20,8 +20,9 @@ Description
 
 The **begin** module instructs GMT to begin a new modern session.  If your script only makes
 a single plot then this is the most opportune time to specify the name
-and format(s) of your plot.  However, if multiple illustrations will be made
-then you will instead use :doc:`figure` for each figure you wish to make.  The session
+and format(s) of your plot.  However, if you want to create multiple illustrations within this
+session or need more control over the conversion from the internal PostScript to the output format,
+you will instead use :doc:`figure` for the figure(s) you wish to make.  The session
 keeps track of all default and history settings and isolates them from any other session
 that may run concurrently.  Thus unlike in classic mode you can run multiple modern sessions
 simultaneously without having destructive interference in updating the history of common
@@ -63,9 +64,9 @@ Optional Arguments
     +--------+-----------------------------------------+
     |  pdf   | Portable Document Format [Default]      |
     +--------+-----------------------------------------+
-    |  png   | Portable Network Graphics (opaque)      | 
+    |  png   | Portable Network Graphics (opaque)      |
     +--------+-----------------------------------------+
-    |  PNG   | Portable Network Graphics (transparent) | 
+    |  PNG   | Portable Network Graphics (transparent) |
     +--------+-----------------------------------------+
     |  ppm   | Portable Pixel Map                      |
     +--------+-----------------------------------------+

--- a/doc/rst/source/figure.rst_
+++ b/doc/rst/source/figure.rst_
@@ -19,14 +19,15 @@ Description
 -----------
 
 A GMT modern session can make any number of illustrations (including none).
-In situations when many illustrations will be made during a single session,
+In situations when multiple illustrations will be made during a single session or when you need
+specific control over the conversion from PostScript to the output format,
 the **figure** module is used to specify the name and format(s) to use for the next plot.
 It must be issued before you start plotting to the intended figure, and each
 new **figure** call changes plotting focus to the next figure.  You may go back and forth between
 different figures but the optional arguments (*formats* and *options*) can only
 be given the first time you specify a new figure.
 In addition to *prefix* and *formats*, you can supply a comma-separated series of
-:doc:`psconvert` options that will override the default settings provided via
+:doc:`psconvert` *options* that will override the default settings provided via
 :ref:`PS_CONVERT <PS_CONVERT>` [**A**]. The only other available options control verbosity
 and default parameter settings.
 

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -1103,7 +1103,7 @@ fonts can be found in the :doc:`gmt` man page.
 
 **PS_CONVERT**
     Comma-separated list of optional module arguments that we should
-    supply when :doc:`psconvert` is called implicitly under modern mode [A,P].
+    supply when :doc:`psconvert` is called implicitly under modern mode [**A**].
     Ignored when psconvert is called on the command line explicitly.
     The option arguments must be listed without their leading option hyphen.
 


### PR DESCRIPTION
Some additional information in begin and figure on the ability to control the PostScript conversion with `figure [options]`.
Corrected PS_CONVERT default to be `A`, not `A,P`.
