### PR TITLE
Let movie use same column numbering as rest of GMT

### DIFF
--- a/doc/examples/anim01/anim_01.sh
+++ b/doc/examples/anim01/anim_01.sh
@@ -29,8 +29,8 @@ gmt begin
 	gmt convert sin_curve.txt -Z0:\${last} | gmt plot -W1p,blue -R0/360/-1.2/1.6 -JX3.5i/1.65i -X0.35i -Y0.25i
 	gmt convert sin_point.txt -Z0:\${MOVIE_FRAME} | gmt plot -Sc0.1i -Gdarkred
 #	Plot bright red dot at current angle and annotate
-	gmt plot -Sc0.1i -Gred <<< "\${MOVIE_COL1} \${MOVIE_COL2}"
-	printf "0 1.6 a = %3.3d" \${MOVIE_COL1} | gmt text -F+f14p,Helvetica-Bold+jTL -N -Dj0.1i/0.05i
+	gmt plot -Sc0.1i -Gred <<< "\${MOVIE_COL0} \${MOVIE_COL1}"
+	printf "0 1.6 a = %3.3d" \${MOVIE_COL0} | gmt text -F+f14p,Helvetica-Bold+jTL -N -Dj0.1i/0.05i
 gmt end
 EOF
 # 3. Run the movie

--- a/doc/examples/anim02/anim_02.sh
+++ b/doc/examples/anim02/anim_02.sh
@@ -21,10 +21,10 @@ EOF
 cat << EOF > main.sh
 gmt begin
 	width=\`gmt math -Q \${MOVIE_WIDTH} 0.5i SUB =\`
-	gmt grdimage @tut_relief.nc -I+a\${MOVIE_COL1}+nt2 -JM\${width} -Cmain.cpt \
+	gmt grdimage @tut_relief.nc -I+a\${MOVIE_COL0}+nt2 -JM\${width} -Cmain.cpt \
 		-BWSne -B1 -X0.35i -Y0.3i --FONT_ANNOT_PRIMARY=9p
 	gmt plot -Sc0.8i -Gwhite -Wthin <<< "256.25 35.6" 
-	gmt plot -Sv0.1i+e -Gred -Wthick <<< "256.25 35.6 \${MOVIE_COL2} 0.37i" 
+	gmt plot -Sv0.1i+e -Gred -Wthick <<< "256.25 35.6 \${MOVIE_COL1} 0.37i" 
 gmt end
 EOF
 # 3. Run the movie

--- a/doc/examples/anim03/anim_03.sh
+++ b/doc/examples/anim03/anim_03.sh
@@ -22,7 +22,7 @@ EOF
 cat << EOF > main.sh
 gmt begin
 	gmt grdview above.nc -R-26/-12/63/67 -JM2.5i -Ciceland.cpt -Qi100 -Bafg \
-		-X0.5i -Y0.5i -p\${MOVIE_COL1}/35+w20W/65N+v1.5i/0.75i
+		-X0.5i -Y0.5i -p\${MOVIE_COL0}/35+w20W/65N+v1.5i/0.75i
 gmt end
 EOF
 # 3. Run the movie

--- a/doc/examples/anim04/anim_04.sh
+++ b/doc/examples/anim04/anim_04.sh
@@ -23,7 +23,7 @@ EOF
 cat << EOF > main.sh
 gmt begin
 	gmt set FONT_TAG 14p,Helvetica-Bold
-	gmt grdimage -JG\${MOVIE_COL1}/\${MOVIE_COL2}/160/210/55/0/36/34/\${MOVIE_WIDTH}+ \
+	gmt grdimage -JG\${MOVIE_COL0}/\${MOVIE_COL1}/160/210/55/0/36/34/\${MOVIE_WIDTH}+ \
 		-Rg @USEast_Coast.nc -Iint_US.nc -Cglobe_US.cpt -X0 -Y0
 	gmt plot -W1p flight_path.txt
 gmt end

--- a/doc/examples/anim06/anim_06.sh
+++ b/doc/examples/anim06/anim_06.sh
@@ -42,7 +42,7 @@ EOF
 cat << EOF > main.sh
 gmt begin
 	# Shift the chirp in time to simulate paper movement
-	gmt math chirp.txt -C0 \${MOVIE_COL2} SUB = chirp_shifted.txt
+	gmt math chirp.txt -C0 \${MOVIE_COL1} SUB = chirp_shifted.txt
 	# Plot the shifted chirp
 	gmt plot \$R \$J chirp_shifted.txt -W1p,red -X0.2i -Y0.3i
 	# Compute index of most recent sample number
@@ -50,7 +50,7 @@ gmt begin
 	# Extract all the old samples before the present
 	gmt convert chirp_samples.txt -Z:\$last_sample > tmp.txt
 	if [ -s tmp.txt ]; then
-		gmt math tmp.txt -C0 \${MOVIE_COL2} SUB = samples.txt
+		gmt math tmp.txt -C0 \${MOVIE_COL1} SUB = samples.txt
 		gmt plot -Sc0.3c -Gblue samples.txt
 	fi
 	# Take a new sample every 12 frames = 0.5 seconds
@@ -60,13 +60,13 @@ gmt begin
 		gmt plot -W2.5p,blue resampled.txt
 	fi
 	if [ \$take_sample -eq 1 ]; then	# Take and plot sample at zero time
-		y=\`gmt math -Q \${MOVIE_COL2} 2 POW 2 DIV 60 DIV \$f MUL 2 MUL PI MUL COS =\`
+		y=\`gmt math -Q \${MOVIE_COL1} 2 POW 2 DIV 60 DIV \$f MUL 2 MUL PI MUL COS =\`
 		echo 0 \$y | gmt plot -Sc0.5c -Gred
 	fi
 	# Add time counter in upper left corner
-	printf "%4.1f 2 t = %6.3f s\n" -7.5 \${MOVIE_COL2} | gmt text -F+f18p,Helvetica-Bold+jTL -Dj0.1i/0.1i
+	printf "%4.1f 2 t = %6.3f s\n" -7.5 \${MOVIE_COL1} | gmt text -F+f18p,Helvetica-Bold+jTL -Dj0.1i/0.1i
 	# Add cycles counter in upper right corner
-	fnow=\`gmt math -Q \${MOVIE_COL2} 60 DIV \$f MUL =\`
+	fnow=\`gmt math -Q \${MOVIE_COL1} 60 DIV \$f MUL =\`
 	printf "2.5 2 f = %6.4f Hz\n" \$fnow | gmt text -F+f16p,Helvetica-Bold+jTR -Dj0.1i/0.1i
 	# Add frame counter in lower right corner
 	printf "2.5 -1.5 %04d\n" \${MOVIE_FRAME} | gmt text -F+f14p,Helvetica-Bold+jBR -Dj0.1i/0.1i

--- a/doc/examples/anim07/anim_07.sh
+++ b/doc/examples/anim07/anim_07.sh
@@ -27,9 +27,9 @@ gmt begin
 	# Let HSV minimum value go to zero
 	gmt set COLOR_HSV_MIN_V 0
 	# Fake simulation of sun illumination from east combined with relief slopes
-	gmt grdmath intens.nc X \${MOVIE_COL2} SUB DUP -180 LE 360 MUL ADD 90 DIV ERF ADD 0.25 SUB = s.nc
+	gmt grdmath intens.nc X \${MOVIE_COL1} SUB DUP -180 LE 360 MUL ADD 90 DIV ERF ADD 0.25 SUB = s.nc
 	# Plot age grid first using age cpt
-	gmt grdimage @age.3.20.nc -Is.nc -C@crustal_age.cpt -JG\${MOVIE_COL1}/0/6i -X0 -Y0
+	gmt grdimage @age.3.20.nc -Is.nc -C@crustal_age.cpt -JG\${MOVIE_COL0}/0/6i -X0 -Y0
 	# Clip to expose land areas only
 	gmt coast -Gc
 	# Overlay relief over land only using dem cpt

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -90,9 +90,9 @@ Required Arguments
 **-T**\ *frames*\ \|\ *timefile*\ [**+p**\ *width*]\ [**+s**\ *first*]\ [**+w**]
     Either specify how many image frames to make or supply a file with a set of parameters,
     one record per frame (i.e., row).  The values in the columns will be available to the
-    *mainscript* as named variables **MOVIE_COL1**, **MOVIE_COL2**, etc., while any trailing text
+    *mainscript* as named variables **MOVIE_COL0**, **MOVIE_COL1**, etc., while any trailing text
     can be accessed via the variable **MOVIE_TEXT**.  Append **+w** to also split the trailing
-    string into individual words that can be accessed via **MOVIE_WORD1**, **MOVIE_WORD2**, etc. The number of records equals
+    string into individual words that can be accessed via **MOVIE_WORD0**, **MOVIE_WORD1**, etc. The number of records equals
     the number of frames. Note that the *background* script is allowed to create the *timefile*,
     hence we check of its existence both before and after the background script has run.  Normally,
     the frame numbering starts at 0; you can change this by appending a different starting frame
@@ -162,8 +162,8 @@ Optional Arguments
     **e** selects the elapsed time in seconds as the label; append **+s**\ *scale* to set the length
     in seconds of each frame [Default is 1/*framerate*],
     **f** selects the running frame number as the label, **c**\ *col* uses the value in column
-    number *col* of *timefile* as label (first column is 1), while **t**\ *col* uses word number
-    *col* from the trailing text in *timefile* (requires **-T**\ ...\ **+w**).
+    number *col* of *timefile* as label (first column is 0), while **t**\ *col* uses word number
+    *col* from the trailing text in *timefile* (requires **-T**\ ...\ **+w**; first word is 0).
     The label font is controlled via :ref:`FONT_TAG <FONT_TAG>`.
     Append **+c**\ *dx*\ [/*dy*] for the clearance between label and bounding box; only
     used if **+g** or **+p** are set.  Append units **c**\ \|\ **i**\ \|\ **p** or % of the font size [15%].
@@ -251,10 +251,10 @@ In addition, the *mainscript* also has access to parameters that vary with the f
 **MOVIE_FRAME**\ : The current frame number (an integer),
 **MOVIE_TAG**\ : The formatted frame number (a string, e.g., 000136), and
 **MOVIE_NAME**\ : The name prefix for the current frame (i.e., *prefix*\ _\ **MOVIE_TAG**),
-Furthermore, if a *timefile* was given then variables **MOVIE_COL1**\ , **MOVIE_COL2**\ , etc. are
+Furthermore, if a *timefile* was given then variables **MOVIE_COL0**\ , **MOVIE_COL1**\ , etc. are
 also set, yielding one variable per column in *timefile*.  If *timefile* has trailing text then that text can
 be accessed via the variable **MOVIE_TEXT**, and if word-splitting was requested in **-T** with the **+w** modifier then
-the trailing text is also split into individual word parameters **MOVIE_WORD1**\ , **MOVIE_WORD2**\ , etc.
+the trailing text is also split into individual word parameters **MOVIE_WORD0**\ , **MOVIE_WORD1**\ , etc.
 
 Data Files
 ----------

--- a/src/movie.c
+++ b/src/movie.c
@@ -396,8 +396,8 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-L Automatic labeling of frames.  Repeatable.  Places chosen label at the frame perimeter:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     e selects elapsed time as the label. Use +s<scl> to set time in sec per frame [1/<framerate>].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     f selects the running frame number as the label.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     c<col> uses the value in column <col> of <timefile> (first column is 1).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     t<col> uses word number <col> from the trailing text in <timefile> (requires -T...+w).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     c<col> uses the value in column <col> of <timefile> (first column is 0).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     t<col> uses word number <col> (first is 0) from the trailing text in <timefile> (requires -T...+w).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +c<dx>[/<dy>] for the clearance between label and surrounding box.  Only\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     used if +g or +p are set.  Append units {%s} or %% of fontsize [%d%%].\n", GMT_DIM_UNITS_DISPLAY, GMT_TEXT_CLEARANCE);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +f[<fontinfo>] to set the size, font, and optionally the label color [%s].\n",
@@ -1260,7 +1260,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		set_tvalue (fp, Ctrl->In.mode, "MOVIE_TAG", state_tag);		/* Current frame tag (formatted frame number) */
 		set_tvalue (fp, Ctrl->In.mode, "MOVIE_NAME", state_prefix);	/* Current frame name prefix */
 		for (col = 0; col < n_values; col++) {	/* Derive frame variables from <timefile> in each parameter file */
-			sprintf (string, "MOVIE_COL%u", col+1);
+			sprintf (string, "MOVIE_COL%u", col);
 			set_dvalue (fp, Ctrl->In.mode, string, D->table[0]->segment[0]->data[col][frame], 0);
 		}
 		if (has_text) {	/* Also place any string parameter as a single string variable */
@@ -1271,7 +1271,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 				trail = orig;
 				while ((word = strsep (&trail, " \t")) != NULL) {
 					if (*word != '\0') {	/* Skip empty strings */
-						sprintf (string, "MOVIE_WORD%u", ++col);
+						sprintf (string, "MOVIE_WORD%u", col++);
 						set_tvalue (fp, Ctrl->In.mode, string, word);
 					}
 				}


### PR DESCRIPTION
Meaning, we now set **MOVIE_COL0**, **MOVIE_COL1**, ... and **MOVIE_WORD0**, **MOVIE_WORD1**, etc, as well as **-L+c**_col_ starting at 0.  Without this change we are using a different numbering system than common GMT options like **i-**, **-o**, and others.