### PR TITLE
Fix how psxy and psxyz handles reading symbol size when -i is also usd

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1108,7 +1108,12 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 		
 		if (S.read_size && GMT->current.io.col[GMT_IN][ex1].convert) {	/* Doing math on the size column, must delay unit conversion unless inch */
 			gmt_set_column (GMT, GMT_IN, ex1, GMT_IS_FLOAT);
-			delayed_unit_scaling = (S.u_set && S.u != GMT_INCH);
+			if (S.u_set)	/* Specified a particular unit, so scale values unless we chose inches */
+				delayed_unit_scaling = (S.u != GMT_INCH);
+			else if (GMT->current.setting.proj_length_unit != GMT_INCH) {	/* Gave no unit but default unit is not inch so we must scale */
+				delayed_unit_scaling = true;
+				S.u = GMT->current.setting.proj_length_unit;
+			}
 		}
 		if (QR_symbol) {
 			if (!Ctrl->G.active)	/* Default to black */

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -813,11 +813,16 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 		}
 		if (S.read_size && GMT->current.io.col[GMT_IN][ex1].convert) {	/* Doing math on the size column, must delay unit conversion unless inch */
 			gmt_set_column (GMT, GMT_IN, ex1, GMT_IS_FLOAT);
-			delayed_unit_scaling[GMT_X] = (S.u_set && S.u != GMT_INCH);
+			if (S.u_set)
+				delayed_unit_scaling[GMT_X] = (S.u != GMT_INCH);
+			else if (GMT->current.setting.proj_length_unit != GMT_INCH) {
+				delayed_unit_scaling[GMT_X] = true;
+				S.u = GMT->current.setting.proj_length_unit;
+			}
 		}
 		if (S.read_size && GMT->current.io.col[GMT_IN][ex2].convert) {	/* Doing math on the size column, must delay unit conversion unless inch */
 			gmt_set_column (GMT, GMT_IN, ex2, GMT_IS_FLOAT);
-			delayed_unit_scaling[GMT_Y] = (S.u_set && S.u != GMT_INCH);
+			delayed_unit_scaling[GMT_Y] = (S.u_set && S.u != GMT_INCH);	/* Since S.u will be set under GMT_X if that else branch kicked in */
 		}
 		
 		if (!read_symbol) API->object[API->current_item[GMT_IN]]->n_expected_fields = n_needed;


### PR DESCRIPTION
@joa-quim  pointed out that example_22.sh did not seem to care if **-Sci** or just **-Sc** was given (the **i** tells psxy that input sizes are in inches).  This was because of a bug that did not detect that when **-Sc** (no unit) is given the _default_ unit should be used, and if that is unchanged by gmt.conf it is CM, hence a scaling should actually occur.  Now fixed, and in psxyz as well.
