### PR TITLE
Use find_package to find git

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/"
 
 # Find UNIX commands
 include (FindUnixCommands)
-find_program (GIT git)
+find_package (Git)
 find_program (GS gs gswin64)
 find_program (XZ NAMES xz)
 
@@ -101,10 +101,10 @@ endif (EXISTS ${GMT_SOURCE_DIR}/test/)
 add_subdirectory (cmake/dist) # make distribution bundles (always last)
 
 # Source release target
-if (GIT AND HAVE_GIT_VERSION)
+if (GIT_FOUND AND HAVE_GIT_VERSION)
 	# Export git working tree
 	add_custom_target (git_export_release
-		COMMAND ${GIT} -C ${GMT_SOURCE_DIR} checkout-index -a -f --prefix=${GMT_RELEASE_PREFIX}/)
+		COMMAND ${GIT_EXECUTABLE} -C ${GMT_SOURCE_DIR} checkout-index -a -f --prefix=${GMT_RELEASE_PREFIX}/)
 	# Remove the test dir, so that it is not included in the final release tarball
 	add_custom_target (git_prune_dirs
 		COMMAND ${CMAKE_COMMAND} -E remove_directory ${GMT_RELEASE_PREFIX}/.git
@@ -144,7 +144,7 @@ if (GIT AND HAVE_GIT_VERSION)
 			DEPENDS ${GMT_RELEASE_PREFIX}
 			${_release_dirname}-src.tar.gz ${_release_dirname}-src.tar.xz)
 	endif (GNUTAR AND GZIP AND XZ)
-endif (GIT AND HAVE_GIT_VERSION)
+endif (GIT_FOUND AND HAVE_GIT_VERSION)
 
 get_target_property (_location gmtlib LOCATION)
 get_filename_component (GMT_CORE_LIB_NAME ${_location} NAME)

--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -45,7 +45,7 @@ set (GMT_PACKAGE_VERSION_WITH_GIT_REVISION ${GMT_PACKAGE_VERSION})
 if (NOT GMT_SOURCE_CODE_CONTROL_VERSION_STRING)
 	# Get the location, inside the staging area location, to copy the application bundle to.
 	execute_process (
-		COMMAND ${GIT} describe --abbrev=7 --always --dirty
+		COMMAND ${GIT_EXECUTABLE} describe --abbrev=7 --always --dirty
 		WORKING_DIRECTORY ${GMT_SOURCE_DIR}
 		RESULT_VARIABLE GIT_RETURN_CODE
 		OUTPUT_VARIABLE GIT_COMMIT_HASH
@@ -57,7 +57,7 @@ if (NOT GMT_SOURCE_CODE_CONTROL_VERSION_STRING)
 			if (GIT_COMMIT_HASH)				# Set the updated package version.
 				# get commit date
 				execute_process (
-					COMMAND ${GIT} log -1 --date=short --pretty=format:%cd
+					COMMAND ${GIT_EXECUTABLE} log -1 --date=short --pretty=format:%cd
 					WORKING_DIRECTORY ${GMT_SOURCE_DIR}
 					RESULT_VARIABLE GIT_DATE_RETURN_CODE
 					OUTPUT_VARIABLE GIT_COMMIT_DATE

--- a/doc/rst/CMakeLists.txt
+++ b/doc/rst/CMakeLists.txt
@@ -116,7 +116,7 @@ if (SPHINX_FOUND)
 	endif (GZIP)
 
 	# Install targets for release documentation
-	if (GIT AND HAVE_GIT_VERSION)
+	if (GIT_FOUND AND HAVE_GIT_VERSION)
 		# HTML
 		add_custom_target (_html_release
 			COMMAND ${CMAKE_COMMAND} -E copy_directory
@@ -144,7 +144,7 @@ if (SPHINX_FOUND)
 			${GMT_RELEASE_PREFIX}/man_release
 			DEPENDS docs_man git_export_release)
 		add_depend_to_target (gmt_release _man_release)
-	endif (GIT AND HAVE_GIT_VERSION)
+	endif (GIT_FOUND AND HAVE_GIT_VERSION)
 endif (SPHINX_FOUND)
 
 # Install targets

--- a/doc/scripts/CMakeLists.txt
+++ b/doc/scripts/CMakeLists.txt
@@ -193,7 +193,7 @@ if (NOT EXISTS ${GMT_INSTALL_EXTERNAL_DOC})
 endif (NOT EXISTS ${GMT_INSTALL_EXTERNAL_DOC})
 
 # Install target for release documentation
-if (GIT AND HAVE_GIT_VERSION)
+if (GIT_FOUND AND HAVE_GIT_VERSION)
 	foreach (_fig ${_install_pdf})
 		add_custom_target (_${_fig}_release
 			COMMAND ${CMAKE_COMMAND} -E copy_if_different
@@ -202,6 +202,6 @@ if (GIT AND HAVE_GIT_VERSION)
 			DEPENDS ${RST_BINARY_DIR}/_images/${_fig} git_export_release)
 		add_depend_to_target (gmt_release _${_fig}_release)
 	endforeach (_fig ${_install_pdf})
-endif (GIT AND HAVE_GIT_VERSION)
+endif (GIT_FOUND AND HAVE_GIT_VERSION)
 
 # vim: textwidth=78 noexpandtab tabstop=2 softtabstop=2 shiftwidth=2


### PR DESCRIPTION
CMake provide the FindGit module since 2.8.2, which is better than our own `find_package(git)` solution.

