### PR TITLE
Fix CMake CMP0074

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ cmake_minimum_required (VERSION 2.8.5)
 # Use NEW behavior with newer CMake releases
 foreach(p
 		CMP0025 # CMake 3.0: Compiler id for Apple Clang is now AppleClang
+		CMP0074	# CMake 3.12: find_package uses PackageName_ROOT variables
 		)
 	if(POLICY ${p})
 		cmake_policy(SET ${p} NEW)


### PR DESCRIPTION
CMP0074 (https://cmake.org/cmake/help/latest/policy/CMP0074.html).

> In CMake 3.12 and above the find_package(<PackageName>) command now searches prefixes specified by the <PackageName>_ROOT CMake variable and the <PackageName>_ROOT environment variable. 

In our cmake scripts, `<PackageName>_ROOT` variables are only used to specify paths for searching packages, which is consistent with cmake's new behavior. Thus, it's safe to set the policy to `NEW`.

I tested it with cmake 3.14.3 and 3.11.1. both stops showing the CMP0074 warning.

Address #682.