### PR TITLE
Fix building instructions for fedora/centos/rhel

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -92,8 +92,8 @@ You then can install the GMT's dependencies with:
     sudo yum install gdal-devel pcre-devel fftw3-devel lapack-devel openblas-devel
 
     # to enable movie-making
-    Fedora: sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
-    CentOS/RHEL: sudo yum localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm https://download1.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-7.noarch.rpm
+    # Fedora:       sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
+    # CentOS/RHEL:  sudo yum localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm
 
     sudo apt-get install GraphicsMagick ffmpeg
 


### PR DESCRIPTION
FFmpeg is available in the rpmfusion free repo. The non-free repo is not needed.