### PR TITLE
Small fixes to documentations

### DIFF
--- a/doc/rst/source/plot_common.rst_
+++ b/doc/rst/source/plot_common.rst_
@@ -226,10 +226,3 @@ If no transparency is appended then we will read it from the last column per dat
 .. _Vec_attributes:
 
 .. include:: explain_vectors.rst_
-
-See Also
---------
-
-:doc:`gmt`, :doc:`gmt.conf`,
-:doc:`gmtcolors`,
-:doc:`basemap`, :doc:`plot3d`

--- a/doc/rst/source/ternary_common.rst_
+++ b/doc/rst/source/ternary_common.rst_
@@ -54,7 +54,7 @@ Optional Arguments
 
 **-L**\ *a*\ /*b*\ /*c*
     Set the labels for the three diagram vertices [none].  These are placed a
-    distance of 3 times the MAP_LABEL_OFFSET :ref:`MAP_LABEL_OFFSET <MAP_LABEL_OFFSET>`
+    distance of 3 times the :ref:`MAP_LABEL_OFFSET <MAP_LABEL_OFFSET>`
     setting from their respective corners.
 
 .. _-M:


### PR DESCRIPTION
Two small fixes: 

1. remove duplicate key in `doc/rst/source/ternary_common.rst_`
2. `See also` is already included at the end of `plot.rst`.