### PR TITLE
Prevent movie label overflow and increase to 32

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -44,9 +44,10 @@ that is repeated for all frames, with some variation using specific frame variab
 module simplifies (and hides) most of the steps normally needed to set up a full-blown
 animation job.  Instead, the user can focus on composing the main frame plot and let the
 parallel execution of frames and assembly of images into a movie take place in the background.
-Individual frames are converted from PostScript plots to lossless PNG images and optionally
-assembled into an animation (this step requires external tools that must be present in
-your path; see Technical Details below).
+Individual frames are converted from PostScript plots to lossless, transparent PNG images and optionally
+assembled into an animation (this last step requires external tools that must be present in
+your path; see Technical Details below).  For opaque PNG images, simply specify a background
+color via **-G**.
 
 Required Arguments
 ------------------
@@ -73,7 +74,7 @@ Required Arguments
     and are (with pixel dimensions given in parenthesis):
     **uxga** (1600 x 1200), **sxga+** (1400 x 1050), **xga** (1024 x 768),
     **svga** (800 x 600), and **dvd** (640 x 480).
-    Note: Your :ref:`PROJ_LENGTH_UNIT <PROJ_LENGTH_UNIT>` setting determines if movie sets
+    Note: Your :ref:`PROJ_LENGTH_UNIT <PROJ_LENGTH_UNIT>` setting determines if **movie** sets
     you up to work with the SI or US canvas dimensions.  Instead of a named format you can
     request a custom format directly by giving *width*\ [*unit*]\ x\ *height*\ [*unit*]\ x\ *dpu*,
     where *dpu* is the dots-per-unit pixel density.
@@ -158,7 +159,7 @@ Optional Arguments
 
 **-L**\ *labelinfo*
 
-    Automatic labeling of individual frames.  Repeatable.  Places the chosen label at the frame perimeter:
+    Automatic labeling of individual frames.  Repeatable up to 32 labels.  Places the chosen label at the frame perimeter:
     **e** selects the elapsed time in seconds as the label; append **+s**\ *scale* to set the length
     in seconds of each frame [Default is 1/*framerate*],
     **f** selects the running frame number as the label, **c**\ *col* uses the value in column
@@ -275,7 +276,7 @@ As you can see from **-C**, unless you specified a custom format you are given a
 or 24 x 18 cm (4:3).  If your :ref:`PROJ_LENGTH_UNIT <PROJ_LENGTH_UNIT>` setting is inch then the custom canvas sizes are just
 slightly (1.6%) larger than the corresponding SI sizes (9.6 x 5.4" or 9.6 x 7.2"); this has no effect on the size of the movie
 frames but allow us to use good sizes that work well with the dpu chosen.  You should compose your plots using
-the given canvas size, and movie will make proper conversions of the canvas to image pixel dimensions. It is your responsibility
+the given canvas size, and **movie** will make proper conversions of the canvas to image pixel dimensions. It is your responsibility
 to use **-X -Y** to allow for suitable margins and any positioning of items on the canvas.  To minimize processing time it is
 recommended that any static part of the movie be considered either a static background (to be made once by *backgroundscript*) and/or
 a static foreground (to be made once by *foregroundscript*); **movie** will then assemble these layers per frame.  Also, any computation of
@@ -298,8 +299,8 @@ access to the information in *movie_init* while the frame script in addition has
 specific parameter file.  Using the **-Q** option will just produce these scripts which you can then examine.
 
 The conversion of PNG frames to an animated GIF (**-F**\ gif) relies on GraphicsMagick (http://www.graphicsmagick.org). 
-Thus, "gm" must be accessible via your standard search path. Likewise, the conversion of
-PNG frames to an MP4 movie (**-F**\ mp4) or WebM movie (**-F**\ webm) relies on ffmpeg (https://www.ffmpeg.org). 
+Thus, **gm** must be accessible via your standard search path. Likewise, the conversion of
+PNG frames to an MP4 (**-F**\ mp4) or WebM (**-F**\ webm) movie relies on ffmpeg (https://www.ffmpeg.org). 
 
 Hints for Movie Makers
 ----------------------
@@ -316,18 +317,18 @@ To test your movie, start by using options **-Q -M** to ensure your cover page l
 This page shows you one frame of your movie (you can select which frame via the **-M** arguments).  Fix any
 issues with your use of variables and options until this works.  You can then try to remove **-Q**.
 We recommend you make a very short (i.e., **-T**) and small (i.e., **-C**) movie so you don't have to wait very
-long to see the result.  Once things are working you can beef up number of frames and movie
-quality.
+long to see the result.  Once things are working you can beef up number of frames and movie quality.
 
 Examples
 --------
 
 To make an animated GIF movie based on the script globe.sh, which simply spins a globe using the
-frame number to serve as the view longitude, using a custom square 600x600 pixel canvas and 360 frames, try
+frame number to serve as the view longitude, using a custom square 600x600 pixel canvas and 360 frames,
+and place a frame counter in the top left corner, try
 
    ::
 
-    gmt movie globe.sh -Nglobe -T360 -Agif -C6ix6ix100
+    gmt movie globe.sh -Nglobe -T360 -Agif -C6ix6ix100 -Lf
 
 Here, the globe.sh bash script simply plots a map with :doc:`coast` but uses the frame number variable
 as the center longitude:
@@ -343,7 +344,7 @@ longitudes.  The equivalent DOS batch script setup would be
 
   ::
 
-    gmt movie globe.bat -Nglobe -T360 -Agif -C6ix6ix100
+    gmt movie globe.bat -Nglobe -T360 -Agif -C6ix6ix100 -Lf
 
 Now, the globe.bat DOS script is simply
 
@@ -369,9 +370,9 @@ To explore more elaborate movies, see the Animations examples under our Gallery.
 Other Movie Formats
 -------------------
 
-As configured, movie only offers the MP4 and WebM formats for movies.  The conversion is performed by the
+As configured, **movie** only offers the MP4 and WebM formats for movies.  The conversion is performed by the
 tool ffmpeg (https://www.ffmpeg.org), which has more codecs and processing options than there are children in China.
-If you wish to run ffmpeg with other options, select mp4 and run movie with long verbose (**-Vl**).
+If you wish to run ffmpeg with other options, select mp4 and run **movie** with long verbose (**-Vl**).
 At the end it will print the ffmpeg command used.  You can copy, paste, and modify this command to
 select other codecs, bit-rates, and arguments.  You can also use the PNG sequence as input to tools such
 as QuickTime Pro, iMovie, MovieMaker, and similar commercial programs to make a movie that way.

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -6415,7 +6415,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 	int k, id, fno[PSL_MAX_EPS_FONTS], n_fonts, last, form, justify;
 	bool O_active = GMT->common.O.active;
 	unsigned int this_proj, write_to_mem = 0, switch_charset = 0, n_movie_labels = 0;
-	char *mode[2] = {"w","a"}, *movie_label_arg[GMT_LEN16];
+	char *mode[2] = {"w","a"}, *movie_label_arg[GMT_LEN32];
 	static char *ps_mode[2] = {"classic", "modern"};
 	double media_size[2], plot_x, plot_y;
 	FILE *fp = NULL;	/* Default which means stdout in PSL */
@@ -6473,6 +6473,10 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 			if (!access (file, R_OK) && (fpl = fopen (file, "r"))) {	/* File exists and could be opened for reading */
 				while (fgets (record, GMT_LEN128, fpl)) {
 					if (record[0] == '#') continue;	/* Skip header */
+					if (n_movie_labels == GMT_LEN32) {
+						GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Number of movie labels exceed capacity [%d] - skipped.\n", n_movie_labels);
+						continue;
+					}
 					gmt_chop (record);		/* Chop off LF or CR/LF */
 					GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Found MOVIE_LABEL_ARG%d = %s.\n", n_movie_labels, record);
 					movie_label_arg[n_movie_labels++] = strdup (record);
@@ -6693,7 +6697,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 		if (gmt_set_current_panel (GMT->parent, GMT->current.ps.figure, P->row+1, P->col+1, P->gap, P->tag, 0))	/* +1 since get_current_panel does -1 */
 			return NULL;	/* Should never happen */
 	}
-	else if (n_movie_labels) {	/* Obtained movie frame label, implement it via a completion PostScript procedure */
+	else if (n_movie_labels) {	/* Obtained movie frame labels, implement them via a completion PostScript procedure */
 		/* Decode x/y/just/clearance_x/clearance_Y/pen/fill/txt in MOVIE_LABEL_ARG */
 		double off[2] = {0.0, 0.0};
 		char just[4] = {""}, x[GMT_LEN32] = {""}, y[GMT_LEN32] = {""}, FF[GMT_LEN64] = {""}, PP[GMT_LEN64] = {""}, font[GMT_LEN64] = {""}, label[GMT_LEN64] = {""};
@@ -6703,7 +6707,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 		
 		/* Create special PSL_movie_completion PostScript procedure and define it here in the output PS.
 		 * It will be called at the end of everything else in PSL_endplot. It always exist but is NULL by default.
-		 * If not NULL then it will plot 1-16 labels set via movie.c's -L option */
+		 * If not NULL then it will plot 1-32 labels set via movie.c's -L option */
 		
 		PSL_command (PSL, "/PSL_movie_completion {\nV\n");
 		PSL_comment (PSL, "Start of movie labels\n");

--- a/src/movie.c
+++ b/src/movie.c
@@ -126,7 +126,7 @@ struct MOVIE_CTRL {
 			double x, y;
 			double off[2];
 			double clearance[2];
-		} tag[GMT_LEN16];
+		} tag[GMT_LEN32];
 	} L;
 	struct MOVIE_M {	/* -M[<frame>][,format] */
 		bool active;
@@ -406,7 +406,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Stabilizes sub-pixel changes between frames, such as moving text and lines.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Include a script file to be inserted into the movie_init.sh script [none].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Used to add constant variables needed by all movie scripts.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-L Automatic labeling of frames; repeatable.  Places chosen label at the frame perimeter:\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-L Automatic labeling of frames; repeatable (max 32).  Places chosen label at the frame perimeter:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     e selects elapsed time as the label. Use +s<scl> to set time in sec per frame [1/<framerate>].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     f selects the running frame number as the label.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     c<col> uses the value in column <col> of <timefile> (first column is 0).\n");
@@ -625,8 +625,8 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_O
 
 			case 'L':	/* Label frame and get attributes */
 				Ctrl->L.active = true;
-				if ((T = Ctrl->L.n_tags) == GMT_LEN16) {
-					GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error option -L: Cannot handle more than %d tags\n", GMT_LEN16);
+				if ((T = Ctrl->L.n_tags) == GMT_LEN32) {
+					GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error option -L: Cannot handle more than %d tags\n", GMT_LEN32);
 					n_errors++;
 					break;
 				}

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -1574,7 +1574,7 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
    	   will be the default in a future release. Since it was introduced in 9.21 we start using it
    	   right now and remove this conditional once it becomes the default */
 
-	/* INitial assignment of gs_params. NOte: If we detect transparency then we must select the PDF settings since we must convert to PDF first */
+	/* INitial assignment of gs_params. Note: If we detect transparency then we must select the PDF settings since we must convert to PDF first */
 	if (Ctrl->T.device == GS_DEV_PDF)	/* For PDF (and PNG via PDF) we want a bunch of prepress and other settings to maximize quality */
 		gs_params = (gsVersion.major >= 9 && gsVersion.minor >= 21) ? gs_params_pdfnew : gs_params_pdfold;
 	else	/* For rasters */


### PR DESCRIPTION
The repeatable movie **-L** option can now handle up to 32 labels, and this is now documented better.  Other changes are spelling and typos.
