### PR TITLE
Build manpages and PDF documentations in nightly cron jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
         # Only build the docs on Linux cron jobs
         - name: "Linux (cron - build docs)"
           os: linux
-          if: type = cron
+          if: type != cron
           env:
             - BUILD_DOCS=true
             - DEPLOY_DOCS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_install:
         DEB_CACHE=$HOME/cache-deb
         DEB_PACKAGES="cmake ninja-build libcurl4-gnutls-dev libnetcdf-dev libgdal-dev libfftw3-dev libpcre3-dev liblapack-dev ghostscript curl"
         if [[ "$TEST" == "true" || "$BUILD_DOCS" == "true" ]]; then
-          DEB_PACKAGES="$DEB_PACKAGES graphicsmagick ffmpeg python python-pip texlive-latex-extra"
+          DEB_PACKAGES="$DEB_PACKAGES graphicsmagick ffmpeg python python-pip texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk"
         fi
         test -d $DEB_CACHE || mkdir $DEB_CACHE
         echo "Copy cached deb packages"
@@ -123,6 +123,8 @@ script:
         cmake --build . --target animation;
         kill %1;
         cmake --build . --target docs_html;
+        cmake --build . --target docs_man;
+        cmake --build . --target docs_pdf;
       fi
     - set +e
     - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
         # Only build the docs on Linux cron jobs
         - name: "Linux (cron - build docs)"
           os: linux
-          if: type != cron
+          if: type = cron
           env:
             - BUILD_DOCS=true
             - DEPLOY_DOCS=true


### PR DESCRIPTION
This PR build manpages and PDF documentations in nightly cron jobs. 

To enable building PDF documentations, [some extra packages](http://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.latex.LaTeXBuilder) are installed. 