### PR TITLE
Correct parsing of -A for modules using GSHHG data

### DIFF
--- a/doc/rst/source/coast.rst
+++ b/doc/rst/source/coast.rst
@@ -15,7 +15,7 @@ Synopsis
 
 **gmt coast** |-J|\ *parameters*
 |SYN_OPT-R|
-[ |-A|\ *area* ]
+[ |SYN_OPT-A| ]
 [ |SYN_OPT-B| ]
 [ |-C|\ [**l**\ \|\ **r**/]\ *fill* ]
 [ |-D|\ *resolution*\ [**+f**] ]

--- a/doc/rst/source/coast.rst
+++ b/doc/rst/source/coast.rst
@@ -15,7 +15,7 @@ Synopsis
 
 **gmt coast** |-J|\ *parameters*
 |SYN_OPT-R|
-[ |SYN_OPT-A| ]
+[ |SYN_OPT-Area| ]
 [ |SYN_OPT-B| ]
 [ |-C|\ [**l**\ \|\ **r**/]\ *fill* ]
 [ |-D|\ *resolution*\ [**+f**] ]

--- a/doc/rst/source/common_SYN_OPTs.rst_
+++ b/doc/rst/source/common_SYN_OPTs.rst_
@@ -62,7 +62,7 @@
 
 .. |SYN_OPT--| replace:: **--PAR**\ =\ *value*
 
-.. |SYN_OPT-A| replace:: **-A**\ *min\_area*\ [/*min\_level*/*max\_level*][\ **+a**\ [**g**\ \|\ **i**\ ][**s**\ \|\ **S**]][\ **+r**\ \|\ **l**][\ **+p**\ *percent*]
+.. |SYN_OPT-Area| replace:: **-A**\ *min\_area*\ [/*min\_level*/*max\_level*][\ **+a**\ [**g**\ \|\ **i**\ ][**s**\ \|\ **S**]][\ **+r**\ \|\ **l**][\ **+p**\ *percent*]
 
 
 .. |br| raw:: html

--- a/doc/rst/source/common_SYN_OPTs.rst_
+++ b/doc/rst/source/common_SYN_OPTs.rst_
@@ -62,6 +62,9 @@
 
 .. |SYN_OPT--| replace:: **--PAR**\ =\ *value*
 
+.. |SYN_OPT-A| replace:: **-A**\ *min\_area*\ [/*min\_level*/*max\_level*][\ **+a**\ [**g**\ \|\ **i**\ ][**s**\ \|\ **S**]][\ **+r**\ \|\ **l**][\ **+p**\ *percent*]
+
+
 .. |br| raw:: html
 
    <br />

--- a/doc/rst/source/explain_-A.rst_
+++ b/doc/rst/source/explain_-A.rst_
@@ -1,4 +1,4 @@
-|SYN_OPT-A|
+|SYN_OPT-Area|
     Features with an area smaller than *min\_area* in km^2 or of
     hierarchical level that is lower than *min\_level* or higher than
     *max\_level* will not be plotted [Default is 0/0/4 (all features)].

--- a/doc/rst/source/explain_-A.rst_
+++ b/doc/rst/source/explain_-A.rst_
@@ -1,15 +1,16 @@
-**-A**\ *min\_area*\ [/*min\_level*/*max\_level*][\ **+ag**\ \|\ **i**\ \|\ **s**\ \|\ **S**][\ **+r**\ \|\ **l**][\ **+p**\ *percent*]
+|SYN_OPT-A|
     Features with an area smaller than *min\_area* in km^2 or of
     hierarchical level that is lower than *min\_level* or higher than
     *max\_level* will not be plotted [Default is 0/0/4 (all features)].
     Level 2 (lakes) contains regular lakes and wide river bodies which
     we normally include as lakes; append **+r** to just get river-lakes
-    or **+l** to just get regular lakes.  By default (**+ai**) we select the ice shelf
-    boundary as the coastline for Antarctica; append **+ag** to instead
-    select the ice grounding line as coastline.  For expert users who wish to
-    print their own Antarctica coastline and islands via `plot` you can
-    use **+as** to skip all GSHHG features below 60S or **+aS** to instead
-    skip all features north of 60S.  Finally, append
-    **+p**\ *percent* to exclude polygons whose percentage area of the
-    corresponding full-resolution feature is less than *percent*. See
+    or **+l** to just get regular lakes.  Append **+p**\ *percent* to
+    exclude polygons whose percentage area of the corresponding full-resolution
+    feature is less than *percent*.  Use **+a** to control special
+    aspects of the Antarctica coastline: By default (or add **i**) we
+    select the ice shelf boundary as the coastline for Antarctica; alternatively,
+    add **g** to select the ice grounding line instead.  For expert
+    users who wish to utilize their own Antarctica (with islands) coastline
+    you can add **s** to skip all GSHHG features below 60S. In contrast, you
+    can add **S** to instead skip all features *north* of 60S.  See
     GSHHG INFORMATION below for more details. |Add_-A|

--- a/doc/rst/source/gmtselect.rst
+++ b/doc/rst/source/gmtselect.rst
@@ -14,7 +14,7 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt select** [ *table* ]
-[ |SYN_OPT-A| ]
+[ |SYN_OPT-Area| ]
 [ |-C|\ *pointfile*\ **+d**\ *dist*\ [*unit*] ]
 [ |-D|\ *resolution*\ [**+f**] ]
 [ |-E|\ [**fn**] ]

--- a/doc/rst/source/gmtselect.rst
+++ b/doc/rst/source/gmtselect.rst
@@ -14,7 +14,7 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt select** [ *table* ]
-[ |-A|\ *min_area*\ [/*min_level*/*max_level*][\ **+ag**\ \|\ **i**\ \|\ **s**\ \|\ **S**][**+r**\ \|\ **l**][**p**\ *percent*] ]
+[ |SYN_OPT-A| ]
 [ |-C|\ *pointfile*\ **+d**\ *dist*\ [*unit*] ]
 [ |-D|\ *resolution*\ [**+f**] ]
 [ |-E|\ [**fn**] ]

--- a/doc/rst/source/grdlandmask.rst
+++ b/doc/rst/source/grdlandmask.rst
@@ -16,7 +16,7 @@ Synopsis
 **gmt grdlandmask** |-G|\ *mask_grd_file*
 |SYN_OPT-I|
 |SYN_OPT-R|
-[ |-A|\ *min\_area*\ [/*min\_level*/*max\_level*][\ **+ag**\ \|\ **i**\ \|\ **s** \|\ **S**][\ **+r**\ \|\ **l**][\ **p**\ *percent*] ]
+[ |SYN_OPT-A| ]
 [ |-D|\ *resolution*\ [**+f**] ]
 [ |-E|\ [*bordervalues*] ]
 [ |-N|\ *maskvalues* ]

--- a/doc/rst/source/grdlandmask.rst
+++ b/doc/rst/source/grdlandmask.rst
@@ -16,7 +16,7 @@ Synopsis
 **gmt grdlandmask** |-G|\ *mask_grd_file*
 |SYN_OPT-I|
 |SYN_OPT-R|
-[ |SYN_OPT-A| ]
+[ |SYN_OPT-Area| ]
 [ |-D|\ *resolution*\ [**+f**] ]
 [ |-E|\ [*bordervalues*] ]
 [ |-N|\ *maskvalues* ]

--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -14,7 +14,7 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt grdmath**
-[ |SYN_OPT-A| ]
+[ |SYN_OPT-Area| ]
 [ |-D|\ *resolution*\ [**+f**] ]
 [ |SYN_OPT-I| ]
 [ |-M| ] [ |-N| ]

--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -14,7 +14,7 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt grdmath**
-[ |-A|\ *min\_area*\ [/*min\_level*/*max\_level*][\ **+ag**\ \|\ **i**\ \|\ **s** \|\ **S**][\ **+r**\ \|\ **l**][\ **p**\ *percent*] ]
+[ |SYN_OPT-A| ]
 [ |-D|\ *resolution*\ [**+f**] ]
 [ |SYN_OPT-I| ]
 [ |-M| ] [ |-N| ]

--- a/doc/rst/source/pscoast.rst
+++ b/doc/rst/source/pscoast.rst
@@ -15,7 +15,7 @@ Synopsis
 
 **pscoast** |-J|\ *parameters*
 |SYN_OPT-R|
-[ |-A|\ *area* ]
+[ |SYN_OPT-A| ]
 [ |SYN_OPT-B| ]
 [ |-C|\ [**l**\ \|\ **r**/]\ *fill* ]
 [ |-D|\ *resolution*\ [**+f**] ]

--- a/doc/rst/source/pscoast.rst
+++ b/doc/rst/source/pscoast.rst
@@ -15,7 +15,7 @@ Synopsis
 
 **pscoast** |-J|\ *parameters*
 |SYN_OPT-R|
-[ |SYN_OPT-A| ]
+[ |SYN_OPT-Area| ]
 [ |SYN_OPT-B| ]
 [ |-C|\ [**l**\ \|\ **r**/]\ *fill* ]
 [ |-D|\ *resolution*\ [**+f**] ]

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6524,10 +6524,11 @@ void gmt_GSHHG_syntax (struct GMT_CTRL *GMT, char option) {
  	gmt_message (GMT, "\t-%c Place limits on coastline features from the GSHHG data base.\n", option);
 	gmt_message (GMT, "\t   Features smaller than <min_area> (in km^2) or of levels (0-4) outside the min-max levels\n");
 	gmt_message (GMT, "\t   will be skipped [0/4 (4 means lake inside island inside lake)].\n");
-	gmt_message (GMT, "\t   Append +as to skip Antarctica (all data south of %dS) [use all].\n", abs(GSHHS_ANTARCTICA_LIMIT));
-	gmt_message (GMT, "\t   Append +aS to skip anything BUT Antarctica (all data north of %dS) [use all].\n", abs(GSHHS_ANTARCTICA_LIMIT));
-	gmt_message (GMT, "\t   Append +ag to use shelf ice grounding line for Antarctica coastline.\n");
-	gmt_message (GMT, "\t   Append +ai to use ice/water front for Antarctica coastline [Default].\n");
+	gmt_message (GMT, "\t   Select +a and one or two codes to control how Antarctica is handled:\n");
+	gmt_message (GMT, "\t     Add g to use shelf ice grounding line for Antarctica coastline, or\n");
+	gmt_message (GMT, "\t     Add i to use ice/water front for Antarctica coastline [Default].\n");
+	gmt_message (GMT, "\t     Add s to skip Antarctica (all data south of %dS) [use all], or\n", abs(GSHHS_ANTARCTICA_LIMIT));
+	gmt_message (GMT, "\t     Add S to skip anything BUT Antarctica (all data north of %dS) [use all].\n", abs(GSHHS_ANTARCTICA_LIMIT));
 	gmt_message (GMT, "\t   Append +r to only get riverlakes from level 2, or +l to only get lakes [both].\n");
 	gmt_message (GMT, "\t   Append +p<percent> to exclude features whose size is < <percent>%% of the full-resolution feature [use all].\n");
 }

--- a/src/gmt_shore.h
+++ b/src/gmt_shore.h
@@ -51,10 +51,10 @@ enum gmt_enum_gshhs {GSHHS_MAX_DELTA = 65535,	/* Largest value to store in a uns
 	GSHHS_ANTARCTICA_LIMBO		= 7,	/* Level assigned to nodes between ice and grounding lines */
 	GSHHS_ANTARCTICA_ICE_SRC	= 2,	/* Source ID for Antarctica ice line */
 	GSHHS_ANTARCTICA_GROUND_SRC	= 3,	/* Source ID for Antarctica grounding line */
-	GSHHS_ANTARCTICA_ICE		= 0,	/* Use Antarctica ice boundary as coastline */
-	GSHHS_ANTARCTICA_GROUND		= 1,	/* Use Antarctica grounding line as coastline [Default] */
-	GSHHS_ANTARCTICA_SKIP		= 2,	/* Skip Antarctica coastlines */
-	GSHHS_ANTARCTICA_SKIP_INV	= 3,	/* Skip everything BUT Antarctica coastlines */
+	GSHHS_ANTARCTICA_ICE		= 1,	/* Use Antarctica ice boundary as coastline */
+	GSHHS_ANTARCTICA_GROUND		= 2,	/* Use Antarctica grounding line as coastline [Default] */
+	GSHHS_ANTARCTICA_SKIP		= 4,	/* Skip Antarctica coastlines */
+	GSHHS_ANTARCTICA_SKIP_INV	= 8,	/* Skip everything BUT Antarctica coastlines */
 	GSHHS_ANTARCTICA_ICE_ID		= 4,	/* The GSHHG ID of the Antarctica ice-coastline polygon */
 	GSHHS_ANTARCTICA_LIMIT		= -60};	/* Data below 60S is Antarctica */
 

--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -85,7 +85,7 @@
 #define GMT_CONTT	"-T[h|l][+a][+d<gap>[c|i|p][/<length>[c|i|p]]][+l[<labels>]]"
 
 /* Options for coastline extraction  */
-#define GMT_A_OPT       "-A<min_area>[/<min_level>/<max_level>][+ag|i|s|S][+r|l][+p<percent>]"
+#define GMT_A_OPT       "-A<min_area>[/<min_level>/<max_level>][+a[g|i][s|S]][+r|l][+p<percent>]"
 
 /* Used in tools that sets grdheader information via a -D option */
 


### PR DESCRIPTION
For modules that use the GSHHG dataset, the **-A** option offers a special modifier **+a** affecting Antarctica: One can select either the **i**ce front or **g**rounding line as the coastline, and there are expert settings to either **s**kip _all_ of Antarctica or **S**kip everything _but_ Antarctica.  There were several problems:

1. It was not possible to select two **+a** modifier codes simultaneously, such as _both_ **g** and **S**.
2. The flags used internally to know what to do where not powers of 2 and combined poorly.
3. Logical tests involving these flags therefore were subject to unintended consequences.

I have updated the internal flags to be compatible with multiple selections and I have fixed various logical tests to use bit-comparisons instead of plain equality.  The parsing of **-A** now allows one or two codes to be appended and the documentation has been updated accordingly.  I will also port this to the 5.4 branch.  This PR closes issue #763 .
