### PR TITLE
Align classic mapping modules with modern

### DIFF
--- a/doc/rst/source/PS_classic.rst
+++ b/doc/rst/source/PS_classic.rst
@@ -8,9 +8,9 @@ Classic Mode Mapping
    psbasemap
    psclip
    pscoast
-   psevents
    psscale
    pscontour
+   psevents
    grdimage_classic
    grdcontour_classic
    grdvector_classic


### PR DESCRIPTION
The order of classic modules should follow that of the modern modules so that each row is the same module.
