### PR TITLE
Add golden ratio to g*math and NODE, NODEP to grdmath

### DIFF
--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -184,7 +184,7 @@ Optional Arguments
 Operators
 ---------
 
-Choose among the following 185 operators. "args" are the number of input
+Choose among the following 185 operators. Here, "args" are the number of input
 and output arguments.
 
 +-----------------+--------+--------------------------------------------------------------------------------------------+
@@ -556,6 +556,8 @@ The following symbols have special meaning:
 | **E**       | 2.7182818...                            |
 +-------------+-----------------------------------------+
 | **EULER**   | 0.5772156...                            |
++-------------+-----------------------------------------+
+| **PHI**     | 1.6180339... (golden ratio)             |
 +-------------+-----------------------------------------+
 | **EPS_F**   | 1.192092896e-07 (sgl. prec. eps)        |
 +-------------+-----------------------------------------+

--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -572,6 +572,8 @@ The following symbols have special meaning:
 +-------------+-------------------------------------------------+
 | **EULER**   | 0.5772156...                                    |
 +-------------+-------------------------------------------------+
+| **PHI**     | 1.6180339... (golden ratio)                     |
++-------------+-------------------------------------------------+
 | **EPS_F**   | 1.192092896e-07 (single precision epsilon       |
 +-------------+-------------------------------------------------+
 | **XMIN**    | Minimum x value                                 |
@@ -608,6 +610,8 @@ The following symbols have special meaning:
 +-------------+-------------------------------------------------+
 | **NODE**    | Grid with node numbers 0, 1, ..., (NX*NY)-1     |
 +-------------+-------------------------------------------------+
+| **NODEP**   | Grid with node numbers in presence of pad       |
++-------------+-------------------------------------------------+
 
 Notes On Operators
 ------------------
@@ -625,7 +629,7 @@ Notes On Operators
    azimuth and back-azimuths in degrees, respectively. The operators
    **LDIST** and **PDIST** compute spherical distances in km if **-fg** is
    set or implied, else they return Cartesian distances. Note: If the current
-   :ref:`PROJ_ELLIPSOID <Projection Parameters>` is ellipsoidal then
+   :ref:`PROJ_ELLIPSOID <PROJ_ELLIPSOID>` is ellipsoidal then
    geodesics are used in calculations of distances, which can be slow.
    You can trade speed with accuracy by changing the algorithm used to
    compute the geodesic (see :ref:`PROJ_GEODESIC <Projection Parameters>`).
@@ -686,6 +690,9 @@ Notes On Operators
    of the ability to spread the load onto several cores.  At present, the
    list of such operators is: **LDIST**, **LDIST2**, **PDIST**, **PDIST2**,
    **SAZ**, **SBAZ**, **SDIST**, **YLM**, and **grd_YLMg**.
+
+#. Operators **DEG2KM** and **KM2DEG** are only exact when a spherical Earth
+   is selected with :ref:`PROJ_ELLIPSOID <PROJ_ELLIPSOID>`.
 
 .. include:: explain_float.rst_
 

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -64,6 +64,9 @@
 #ifndef M_EULER
 #define M_EULER		0.577215664901532860606512	/* Euler's constant (gamma) */
 #endif
+#ifndef M_PHI
+#define M_PHI		1.618033988749894848204587	/* Golden ratio (phi) */
+#endif
 #define MAD_NORMALIZE	1.4826	/*  1/N^{-1}(0.75), where z = \N^{-1}(p) is the inverse cumulative normal distribution */
 
 #define GMT_CONV15_LIMIT 1.0e-15	/* Very tight convergence limit or "close to zero" limit */

--- a/src/gmtmath.c
+++ b/src/gmtmath.c
@@ -50,14 +50,15 @@ EXTERN_MSC struct GMT_OPTION * gmt_substitute_macros (struct GMT_CTRL *GMT, stru
 #define GMTMATH_ARG_IS_F_EPS	-5
 #define GMTMATH_ARG_IS_D_EPS	-6
 #define GMTMATH_ARG_IS_EULER	-7
-#define GMTMATH_ARG_IS_TMIN	-8
-#define GMTMATH_ARG_IS_TMAX	-9
-#define GMTMATH_ARG_IS_TRANGE	-10
-#define GMTMATH_ARG_IS_TINC	-11
-#define GMTMATH_ARG_IS_N	-12
-#define GMTMATH_ARG_IS_J_MATRIX	-13
-#define GMTMATH_ARG_IS_T_MATRIX	-14
-#define GMTMATH_ARG_IS_t_MATRIX	-15
+#define GMTMATH_ARG_IS_PHI	-8
+#define GMTMATH_ARG_IS_TMIN	-9
+#define GMTMATH_ARG_IS_TMAX	-10
+#define GMTMATH_ARG_IS_TRANGE	-11
+#define GMTMATH_ARG_IS_TINC	-12
+#define GMTMATH_ARG_IS_N	-13
+#define GMTMATH_ARG_IS_J_MATRIX	-14
+#define GMTMATH_ARG_IS_T_MATRIX	-15
+#define GMTMATH_ARG_IS_t_MATRIX	-16
 #define GMTMATH_ARG_IS_STORE	-50
 #define GMTMATH_ARG_IS_RECALL	-51
 #define GMTMATH_ARG_IS_CLEAR	-52
@@ -676,8 +677,9 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 		"\tPI                  = 3.1415926...\n"
 		"\tE                   = 2.7182818...\n"
 		"\tEULER               = 0.5772156...\n"
-		"\tF_EPS (single eps)   = 1.192092896e-07\n"
-		"\tD_EPS (double eps)   = 2.2204460492503131e-16\n"
+		"\tPHI (golden ratio)  = 1.6180339...\n"
+		"\tF_EPS (single eps)  = 1.192092896e-07\n"
+		"\tD_EPS (double eps)  = 2.2204460492503131e-16\n"
 		"\tTMIN, TMAX, TRANGE, or TINC = the corresponding constant.\n"
 		"\tN                   = number of records.\n"
 		"\tT                   = table with t-coordinates.\n"
@@ -5261,6 +5263,7 @@ GMT_LOCAL int decode_gmt_argument (struct GMT_CTRL *GMT, char *txt, double *valu
 	if (!strcmp (txt, "F_EPS")) return GMTMATH_ARG_IS_F_EPS;
 	if (!strcmp (txt, "D_EPS")) return GMTMATH_ARG_IS_D_EPS;
 	if (!strcmp (txt, "EULER")) return GMTMATH_ARG_IS_EULER;
+	if (!strcmp (txt, "PHI")) return GMTMATH_ARG_IS_PHI;
 	if (!strcmp (txt, "TMIN")) return GMTMATH_ARG_IS_TMIN;
 	if (!strcmp (txt, "TMAX")) return GMTMATH_ARG_IS_TMAX;
 	if (!strcmp (txt, "TRANGE")) return GMTMATH_ARG_IS_TRANGE;
@@ -5793,9 +5796,10 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 
 	special_symbol[GMTMATH_ARG_IS_PI-GMTMATH_ARG_IS_PI]     = M_PI;
 	special_symbol[GMTMATH_ARG_IS_PI-GMTMATH_ARG_IS_E]      = M_E;
-	special_symbol[GMTMATH_ARG_IS_PI-GMTMATH_ARG_IS_F_EPS]   = FLT_EPSILON;
-	special_symbol[GMTMATH_ARG_IS_PI-GMTMATH_ARG_IS_D_EPS]   = DBL_EPSILON;
+	special_symbol[GMTMATH_ARG_IS_PI-GMTMATH_ARG_IS_F_EPS]  = FLT_EPSILON;
+	special_symbol[GMTMATH_ARG_IS_PI-GMTMATH_ARG_IS_D_EPS]  = DBL_EPSILON;
 	special_symbol[GMTMATH_ARG_IS_PI-GMTMATH_ARG_IS_EULER]  = M_EULER;
+	special_symbol[GMTMATH_ARG_IS_PI-GMTMATH_ARG_IS_PHI]    = M_PHI;
 	special_symbol[GMTMATH_ARG_IS_PI-GMTMATH_ARG_IS_TMIN]   = Ctrl->T.T.min;
 	special_symbol[GMTMATH_ARG_IS_PI-GMTMATH_ARG_IS_TMAX]   = Ctrl->T.T.max;
 	special_symbol[GMTMATH_ARG_IS_PI-GMTMATH_ARG_IS_TRANGE] = Ctrl->T.T.max - Ctrl->T.T.min;

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -54,25 +54,27 @@ EXTERN_MSC struct GMT_OPTION * gmt_substitute_macros (struct GMT_CTRL *GMT, stru
 #define GRDMATH_ARG_IS_E		-4
 #define GRDMATH_ARG_IS_F_EPS		-5
 #define GRDMATH_ARG_IS_EULER		-6
-#define GRDMATH_ARG_IS_XMIN		-7
-#define GRDMATH_ARG_IS_XMAX		-8
-#define GRDMATH_ARG_IS_XRANGE		-9
-#define GRDMATH_ARG_IS_XINC		-10
-#define GRDMATH_ARG_IS_NX		-11
-#define GRDMATH_ARG_IS_YMIN		-12
-#define GRDMATH_ARG_IS_YMAX		-13
-#define GRDMATH_ARG_IS_YRANGE		-14
-#define GRDMATH_ARG_IS_YINC		-15
-#define GRDMATH_ARG_IS_NY		-16
-#define GRDMATH_ARG_IS_X_MATRIX		-17
-#define GRDMATH_ARG_IS_x_MATRIX		-18
-#define GRDMATH_ARG_IS_Y_MATRIX		-19
-#define GRDMATH_ARG_IS_y_MATRIX		-20
-#define GRDMATH_ARG_IS_XCOL_MATRIX	-21
-#define GRDMATH_ARG_IS_YROW_MATRIX	-22
-#define GRDMATH_ARG_IS_NODE_MATRIX	-23
-#define GRDMATH_ARG_IS_ASCIIFILE	-24
-#define GRDMATH_ARG_IS_SAVE		-25
+#define GRDMATH_ARG_IS_PHI		-7
+#define GRDMATH_ARG_IS_XMIN		-8
+#define GRDMATH_ARG_IS_XMAX		-9
+#define GRDMATH_ARG_IS_XRANGE		-10
+#define GRDMATH_ARG_IS_XINC		-11
+#define GRDMATH_ARG_IS_NX		-12
+#define GRDMATH_ARG_IS_YMIN		-13
+#define GRDMATH_ARG_IS_YMAX		-14
+#define GRDMATH_ARG_IS_YRANGE		-15
+#define GRDMATH_ARG_IS_YINC		-16
+#define GRDMATH_ARG_IS_NY		-17
+#define GRDMATH_ARG_IS_X_MATRIX		-18
+#define GRDMATH_ARG_IS_x_MATRIX		-19
+#define GRDMATH_ARG_IS_Y_MATRIX		-20
+#define GRDMATH_ARG_IS_y_MATRIX		-21
+#define GRDMATH_ARG_IS_XCOL_MATRIX	-22
+#define GRDMATH_ARG_IS_YROW_MATRIX	-23
+#define GRDMATH_ARG_IS_NODE_MATRIX	-24
+#define GRDMATH_ARG_IS_NODEP_MATRIX	-25
+#define GRDMATH_ARG_IS_ASCIIFILE	-26
+#define GRDMATH_ARG_IS_SAVE		-27
 #define GRDMATH_ARG_IS_STORE		-50
 #define GRDMATH_ARG_IS_RECALL		-51
 #define GRDMATH_ARG_IS_CLEAR		-52
@@ -391,8 +393,11 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 		"\tE                      = 2.7182818...\n"
 		"\tF_EPS (single eps)     = 1.192092896e-07\n"
 		"\tEULER                  = 0.5772156...\n"
+		"\tPHI (golden ratio)     = 1.6180339...\n"
 		"\tXMIN, XMAX, XRANGE, XINC or NX = the corresponding constants.\n"
 		"\tYMIN, YMAX, YRANGE, YINC or NY = the corresponding constants.\n"
+		"\tNODE                   = grid with continuous node indices (0-(NX*NY-1)).\n"
+		"\tNODEP                  = grid with discontinuous node indices due to padding.\n"
 		"\tX                      = grid with x-coordinates.\n"
 		"\tY                      = grid with y-coordinates.\n"
 		"\tXNORM                  = grid with normalized [-1|+1] x-coordinates.\n"
@@ -5211,6 +5216,7 @@ GMT_LOCAL int decode_grd_argument (struct GMT_CTRL *GMT, struct GMT_OPTION *opt,
 	if (!(strcmp (opt->arg, "E") && strcmp (opt->arg, "e"))) return GRDMATH_ARG_IS_E;
 	if (!(strcmp (opt->arg, "F_EPS") && strcmp (opt->arg, "EPS"))) return GRDMATH_ARG_IS_F_EPS;
 	if (!strcmp (opt->arg, "EULER"))  return GRDMATH_ARG_IS_EULER;
+	if (!strcmp (opt->arg, "PHI"))    return GRDMATH_ARG_IS_PHI;
 	if (!strcmp (opt->arg, "XMIN"))   return GRDMATH_ARG_IS_XMIN;
 	if (!strcmp (opt->arg, "XMAX"))   return GRDMATH_ARG_IS_XMAX;
 	if (!strcmp (opt->arg, "XRANGE")) return GRDMATH_ARG_IS_XRANGE;
@@ -5228,6 +5234,7 @@ GMT_LOCAL int decode_grd_argument (struct GMT_CTRL *GMT, struct GMT_OPTION *opt,
 	if (!strcmp (opt->arg, "XCOL"))   return GRDMATH_ARG_IS_XCOL_MATRIX;
 	if (!strcmp (opt->arg, "YROW"))   return GRDMATH_ARG_IS_YROW_MATRIX;
 	if (!strcmp (opt->arg, "NODE"))   return GRDMATH_ARG_IS_NODE_MATRIX;
+	if (!strcmp (opt->arg, "NODEP"))  return GRDMATH_ARG_IS_NODEP_MATRIX;
 	if (!strcmp (opt->arg, "NaN")) {*value = GMT->session.d_NaN; return GRDMATH_ARG_IS_NUMBER;}
 
 	/* Preliminary test-conversion to a number */
@@ -5732,6 +5739,7 @@ int GMT_grdmath (void *V_API, int mode, void *args) {
 	special_symbol[GRDMATH_ARG_IS_PI-GRDMATH_ARG_IS_PI]    = M_PI;
 	special_symbol[GRDMATH_ARG_IS_PI-GRDMATH_ARG_IS_E]     = M_E;
 	special_symbol[GRDMATH_ARG_IS_PI-GRDMATH_ARG_IS_EULER] = M_EULER;
+	special_symbol[GRDMATH_ARG_IS_PI-GRDMATH_ARG_IS_PHI]   = M_PHI;
 	special_symbol[GRDMATH_ARG_IS_PI-GRDMATH_ARG_IS_F_EPS] = FLT_EPSILON;
 	special_symbol[GRDMATH_ARG_IS_PI-GRDMATH_ARG_IS_XMIN]  = info.G->header->wesn[XLO];
 	special_symbol[GRDMATH_ARG_IS_PI-GRDMATH_ARG_IS_XMAX]  = info.G->header->wesn[XHI];
@@ -5928,10 +5936,15 @@ int GMT_grdmath (void *V_API, int mode, void *args) {
 				if (!stack[nstack]->G) stack[nstack]->G = alloc_stack_grid (GMT, info.G);
 				grdmath_grd_padloop (GMT, info.G, row, col, node) stack[nstack]->G->data[node] = (float)(row - stack[nstack]->G->header->pad[YHI]);
 			}
-			else if (op == GRDMATH_ARG_IS_NODE_MATRIX) {		/* Need to set up matrix of node numbers (pad will be zero)*/
+			else if (op == GRDMATH_ARG_IS_NODE_MATRIX) {		/* Need to set up matrix of continuous node numbers (pad not considered) */
 				if (gmt_M_is_verbose (GMT, GMT_MSG_VERBOSE)) GMT_Message (API, GMT_TIME_NONE, "NODE ");
 				if (!stack[nstack]->G) stack[nstack]->G = alloc_stack_grid (GMT, info.G);
 				gmt_M_grd_loop (GMT, info.G, row, col, node) stack[nstack]->G->data[node] = (float)gmt_M_ij0(stack[nstack]->G->header,row,col);
+			}
+			else if (op == GRDMATH_ARG_IS_NODEP_MATRIX) {		/* Need to set up matrix of node numbers (in presence of pad) */
+				if (gmt_M_is_verbose (GMT, GMT_MSG_VERBOSE)) GMT_Message (API, GMT_TIME_NONE, "NODEP ");
+				if (!stack[nstack]->G) stack[nstack]->G = alloc_stack_grid (GMT, info.G);
+				gmt_M_grd_loop (GMT, info.G, row, col, node) stack[nstack]->G->data[node] = (float)gmt_M_ijp(stack[nstack]->G->header,row,col);
 			}
 			else if (op == GRDMATH_ARG_IS_ASCIIFILE) {
 				gmt_M_str_free (info.ASCII_file);


### PR DESCRIPTION
Added **PHI** (the Golden ratio 1.6180340051...) as new constant symbol to grdmath and gmtmath.  Also added **NODE** (continuous) and **NODEP** (node number in presence of the pad) to grdmath.  Turns out **NODE** was already implemented but not fully documented.