### PR TITLE
Command line parsing of calendar-time arguments

### DIFF
--- a/doc/rst/source/GMT_Docs.rst
+++ b/doc/rst/source/GMT_Docs.rst
@@ -1003,7 +1003,9 @@ Calendar time coordinates:
     where *date* must be in the *yyyy*\ [*-mm*\ [*-dd*]] (year, month,
     day-of-month) or *yyyy*\ [*-jjj*] (year and day-of-year) for
     Gregorian calendars and *yyyy*\ [*-*\ **W**\ *ww*\ [*-d*]] (year,
-    week, and day-of-week) for the ISO calendar. If no *date* is given
+    week, and day-of-week) for the ISO calendar. Note: this format requirement
+    only applies to command-line arguments and not time coordinates given via
+    data files.  If no *date* is given
     we assume the current day. The **T** flag is required if a *clock* is given.
 
     The optional *clock* string is a 24-hour clock in

--- a/doc/rst/source/GMT_Docs_classic.rst
+++ b/doc/rst/source/GMT_Docs_classic.rst
@@ -1009,7 +1009,9 @@ Calendar time coordinates:
     where *date* must be in the *yyyy*\ [*-mm*\ [*-dd*]] (year, month,
     day-of-month) or *yyyy*\ [*-jjj*] (year and day-of-year) for
     Gregorian calendars and *yyyy*\ [*-*\ **W**\ *ww*\ [*-d*]] (year,
-    week, and day-of-week) for the ISO calendar. If no *date* is given
+    week, and day-of-week) for the ISO calendar. Note: this format requirement
+    only applies to command-line arguments and not time coordinates given via
+    data files.If no *date* is given
     we assume the current day. The **T** flag is required if a *clock* is given.
 
     The optional *clock* string is a 24-hour clock in

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -2503,7 +2503,7 @@ int gmt_scanf_argtime (struct GMT_CTRL *GMT, char *s, double *t) {
 
 	for (i = (negate_year) ? 1 : 0; s[k+i] && s[k+i] != '-'; i++); /* Goes to first - between yyyy and jjj or yyyy and mm */
 	dash = (unsigned int)i++;	/* Position of first character after the first dash (could be end of string if no dash) */
-    if ((dash-negate_year) > 4) return (GMT_IS_NAN);  /* Clearly got some junk or perhaps not using - as delimiter */
+    if (s[dash] && (dash-negate_year) > 4) return (GMT_IS_NAN);  /* Clearly got some junk or perhaps not using - as delimiter */
 	while (s[k+i] && !(s[k+i] == '-' || s[k+i] == 'T')) i++;	/* Goto the ending T character or get stuck on a second - */
 	got_yd = ((i - dash - 1) == 3 && s[k+i] == 'T');		/* Must have a field of 3-characters between - and T to constitute a valid day-of-year format */
 

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -2411,7 +2411,7 @@ GMT_LOCAL int gmtio_scanf_dim (struct GMT_CTRL *GMT, char *s, double *val) {
 }
 
 /*! . */
-GMT_LOCAL int gmtio_scanf_argtime (struct GMT_CTRL *GMT, char *s, double *t) {
+int gmt_scanf_argtime (struct GMT_CTRL *GMT, char *s, double *t) {
 	/* s is a string from a command-line argument.
 	   The argument is known to refer to a time variable.  For example, the argument is
 	   a token from -R<t_min>/<t_max>/a/b[/c/d].  However, we will permit it to be in EITHER
@@ -2503,6 +2503,7 @@ GMT_LOCAL int gmtio_scanf_argtime (struct GMT_CTRL *GMT, char *s, double *t) {
 
 	for (i = (negate_year) ? 1 : 0; s[k+i] && s[k+i] != '-'; i++); /* Goes to first - between yyyy and jjj or yyyy and mm */
 	dash = (unsigned int)i++;	/* Position of first character after the first dash (could be end of string if no dash) */
+    if ((dash-negate_year) > 4) return (GMT_IS_NAN);  /* Clearly got some junk or perhaps not using - as delimiter */
 	while (s[k+i] && !(s[k+i] == '-' || s[k+i] == 'T')) i++;	/* Goto the ending T character or get stuck on a second - */
 	got_yd = ((i - dash - 1) == 3 && s[k+i] == 'T');		/* Must have a field of 3-characters between - and T to constitute a valid day-of-year format */
 
@@ -6587,7 +6588,7 @@ int gmt_scanf (struct GMT_CTRL *GMT, char *s, unsigned int expectation, double *
 			break;
 
 	 	case GMT_IS_ARGTIME:
-			return (gmtio_scanf_argtime (GMT, s, val));
+			return (gmt_scanf_argtime (GMT, s, val));
 			break;
 
 		case  GMT_IS_UNKNOWN:

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -285,6 +285,7 @@ EXTERN_MSC void gmt_add_to_record (struct GMT_CTRL *GMT, char *record, double va
 EXTERN_MSC void gmt_cat_to_record (struct GMT_CTRL *GMT, char *record, char *word, unsigned int way, unsigned int sep);
 EXTERN_MSC int gmt_scanf (struct GMT_CTRL *GMT, char *p, unsigned int expectation, double *val);	/* Convert strings to double, handling special formats [Data records only ] */
 EXTERN_MSC int gmt_scanf_arg (struct GMT_CTRL *GMT, char *p, unsigned int expectation, bool cmd, double *val);	/* Convert strings to double, handling special formats [ command line only ] */
+EXTERN_MSC int gmt_scanf_argtime (struct GMT_CTRL *GMT, char *s, double *t);	/* Strict command-line format parsing of abs time */
 EXTERN_MSC bool gmt_not_numeric (struct GMT_CTRL *GMT, char *text);				/* Rules out _some_ text as possible numerics */
 EXTERN_MSC bool gmt_parse_segment_item (struct GMT_CTRL *GMT, char *in_string, char *pattern, char *out_string);
 EXTERN_MSC int gmt_set_cols (struct GMT_CTRL *GMT, unsigned int direction, uint64_t expected);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15501,6 +15501,8 @@ unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument,
 	 *      9) If +e is given when only an increment is given then we must keep the
 	 *	   increment exact and adjust max to ensure (max-min)/inc is an integer.
 	 *	   The default adjusts inc instead, if flag GMT_ARRAY_ROUND is passed.
+	 *     10) Since -T is a command-line option we enforce ISO calendar string format
+	 *	   only (yyyy-mm-ddT, yyyy-jjjT, yyyy-WwwT).
 	 *
 	 * Note:   The effects in 4) and 5) are only allowed if the corresponding
 	 *	   flags are passed to the parser.
@@ -15689,14 +15691,22 @@ unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument,
 	if (ns >= 1) {
 		if (!strcmp (txt[GMT_X], "-"))	/* Must get this value later */
 			T->delay[GMT_X] = true;
+		else if (T->temporal && gmt_scanf_argtime (GMT, txt[GMT_X], &(T->min)) == GMT_IS_NAN) {
+			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error -%c: Unable to parse min temporal value from %s (ISO datetime format required)\n", option, txt[GMT_X]);
+			return GMT_PARSE_ERROR;
+		}
 		else if (gmt_verify_expectations (GMT, gmt_M_type (GMT, GMT_IN, GMT_X), gmt_scanf_arg (GMT, txt[GMT_X], gmt_M_type (GMT, GMT_IN, GMT_X), false, &(T->min)), txt[GMT_X])) {
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error -%c: Unable to parse min value from %s\n", option, txt[GMT_X]);
 			return GMT_PARSE_ERROR;
 		}
 		if (!strcmp (txt[GMT_Y], "-"))	/* Must get this value later */
 			T->delay[GMT_Y] = true;
+		else if (T->temporal && gmt_scanf_argtime (GMT, txt[GMT_Y], &(T->max)) == GMT_IS_NAN) {
+			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error -%c: Unable to parse max temporal value from %s\n", option, txt[GMT_Y]);
+			return GMT_PARSE_ERROR;
+		}
 		else if (gmt_verify_expectations (GMT, gmt_M_type (GMT, GMT_IN, GMT_X), gmt_scanf_arg (GMT, txt[GMT_Y], gmt_M_type (GMT, GMT_IN, GMT_X), false, &(T->max)), txt[GMT_Y])) {
-			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error -%c: Unable to parse max value from %s\n", option, txt[GMT_Y]);
+			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error -%c: Unable to parse max value from %s (ISO datetime format required)\n", option, txt[GMT_Y]);
 			return GMT_PARSE_ERROR;
 		}
 		if ((T->delay[GMT_X] || T->delay[GMT_Y]) && !(flags & GMT_ARRAY_NOMINMAX)) {
@@ -15710,7 +15720,11 @@ unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument,
 		T->set += 2;
 	}
 	else if (ns == 0 && (flags & GMT_ARRAY_SCALAR)) {
-		if (gmt_verify_expectations (GMT, gmt_M_type (GMT, GMT_IN, GMT_X), gmt_scanf_arg (GMT, txt[GMT_X], gmt_M_type (GMT, GMT_IN, GMT_X), false, &(T->min)), txt[GMT_X])) {
+		if (T->temporal && gmt_scanf_argtime (GMT, txt[GMT_X], &(T->min)) == GMT_IS_NAN) {
+			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error -%c: Unable to parse min temporal value from %s (ISO datetime format required)\n", option, txt[GMT_X]);
+			return GMT_PARSE_ERROR;
+		}
+		else if (gmt_verify_expectations (GMT, gmt_M_type (GMT, GMT_IN, GMT_X), gmt_scanf_arg (GMT, txt[GMT_X], gmt_M_type (GMT, GMT_IN, GMT_X), false, &(T->min)), txt[GMT_X])) {
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error -%c: Unable to parse min value from %s\n", option, txt[GMT_X]);
 			return GMT_PARSE_ERROR;
 		}


### PR DESCRIPTION
Since GMT 4 introduced absolute time parsing we have made a clear distinction between command-line arguments for time and time provided in data files.  The former was required to be in strict ISO format while data files can use whatever format and tell us via **FORMAT_IN_DATE** and **FORMAT_IN_CLOCK**. However, recent changes to how **-T**_min/max/inc_ is parsed incorrectly called the wrong internal converter and other formats were no longer rejected and sometimes even incorrectly parsed.  This PR modifies _gmt_parse_array_ to require ISO calendar formats.
