### PR TITLE
Handle internally how img2grd calls grdproject

### DIFF
--- a/src/img/img2grd.c
+++ b/src/img/img2grd.c
@@ -591,9 +591,9 @@ int GMT_img2grd (void *V_API, int mode, void *args) {
 	/* Set navgsq, rnavgsq, for the averaging */
 	navgsq = navg * navg;
 	rnavgsq = 1.0 / navgsq;
-
+	
 	/* Set up header with Mercatorized dimensions assuming -Jm1i  */
-	if (Ctrl->F.active) {	/* Backwards support for old behavior */
+	if (Ctrl->F.active || !Ctrl->M.active) {	/* Backwards support for old behavior in -M, or being internally consistent with central meridian */
 		wesn[XLO] = 0.0;
 		wesn[XHI] = n_columns * inc[GMT_X];
 		wesn[YLO] = 0.0;


### PR DESCRIPTION
To avoid complications with central longitude, we set **-F** under the hood when **-M** is not used to ensure grdproject determines the correct region.  When **-M** _is_ used (to get a Mercator grid) we will by default use (0,0) as projection center but this can be changed via **-F** for those who want to be entirely backwards compatible and are doing their own inverse projections.  This fixes the imgmap.sh test.
