### PR TITLE
Let gmt_read_merc understand remote file syntax

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -2327,7 +2327,7 @@ int gmt_read_img (struct GMT_CTRL *GMT, char *imgfile, struct GMT_GRID *Grid, do
 	 */
 
 	int status, first_i;
-	unsigned int min, actual_col, n_cols, row, col;
+	unsigned int min, actual_col, n_cols, row, col, first;
 	uint64_t ij;
 	off_t n_skip;
 	int16_t *i2 = NULL;
@@ -2338,7 +2338,8 @@ int gmt_read_img (struct GMT_CTRL *GMT, char *imgfile, struct GMT_GRID *Grid, do
 	double wesn[4], wesn_all[4];
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (Grid->header);
 
-	if (!gmt_getdatapath (GMT, imgfile, file, R_OK)) return (GMT_GRDIO_FILE_NOT_FOUND);
+	first = gmt_download_file_if_not_found (GMT, imgfile, GMT_CACHE_DIR);
+	if (!gmt_getdatapath (GMT, &imgfile[first], file, R_OK)) return (GMT_GRDIO_FILE_NOT_FOUND);
 	if (stat (file, &buf)) return (GMT_GRDIO_STAT_FAILED);	/* Inquiry about file failed somehow */
 
 	switch (buf.st_size) {	/* Known sizes are 1 or 2 min at lat_max = ~72, ~80, or ~85.  Set exact latitude */
@@ -2384,7 +2385,7 @@ int gmt_read_img (struct GMT_CTRL *GMT, char *imgfile, struct GMT_GRID *Grid, do
 	if ((fp = gmt_fopen (GMT, file, "rb")) == NULL) return (GMT_GRDIO_OPEN_FAILED);
 
 	GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Reading img grid from file %s (scale = %g mode = %d lat = %g)\n",
-	            imgfile, scale, mode, lat);
+	            &imgfile[first], scale, mode, lat);
 	Grid->header->inc[GMT_X] = Grid->header->inc[GMT_Y] = min / 60.0;
 
 	if (init) {

--- a/test/img/imgtrack.ps
+++ b/test/img/imgtrack.ps
@@ -1,0 +1,6010 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_b4968df_2019.05.26 [64-bit] Document from psxy
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun May 26 12:38:51 2019
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_completion {} def
+/PSL_movie_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R180/200/40/50 -JM6i -P -Baf -Sc0.1c -Ct.cpt m.txt -K
+%@PROJ: merc 180.00000000 200.00000000 40.00000000 50.00000000 -1113194.908 1113194.908 4838471.398 6413524.594 +proj=merc +lon_0=190 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%GMTBoundingBox: 72 72 432 305.617
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 5094 D
+-7200 0 D
+P
+PSL_clip N
+4 W
+V
+{0 0.746 1 C} FS
+24 0 0 Sc
+{0 0.783 1 C} FS
+24 6 5 Sc
+{0 0.807 1 C} FS
+24 11 10 Sc
+{0 0.841 1 C} FS
+24 17 15 Sc
+{0 0.815 1 C} FS
+24 23 21 Sc
+{0 0.712 1 C} FS
+24 29 26 Sc
+{0 0.624 1 C} FS
+24 34 31 Sc
+{0 0.579 1 C} FS
+24 40 36 Sc
+{0 0.559 1 C} FS
+24 46 41 Sc
+{0 0.534 1 C} FS
+24 52 46 Sc
+{0 0.493 1 C} FS
+24 57 52 Sc
+{0 0.421 1 C} FS
+24 63 57 Sc
+{0 0.329 1 C} FS
+24 69 62 Sc
+{0 0.244 1 C} FS
+24 75 67 Sc
+{0 0.187 1 C} FS
+24 80 72 Sc
+{0 0.164 1 C} FS
+24 86 77 Sc
+{0 0.233 1 C} FS
+24 92 82 Sc
+{0 0.343 1 C} FS
+24 98 88 Sc
+{0 0.499 1 C} FS
+24 103 93 Sc
+{0 0.71 1 C} FS
+24 109 98 Sc
+{0 0.578 1 C} FS
+24 115 103 Sc
+{0 0.225 1 C} FS
+24 121 108 Sc
+{0 0.0285 1 C} FS
+24 127 113 Sc
+{0.154 0 1 C} FS
+24 132 119 Sc
+{0.0573 0 1 C} FS
+24 138 124 Sc
+{0 0.424 1 C} FS
+24 144 129 Sc
+{0 0.623 1 C} FS
+24 150 134 Sc
+{0 0.663 1 C} FS
+24 155 139 Sc
+{0 0.701 1 C} FS
+24 161 144 Sc
+{0 0.732 1 C} FS
+24 167 149 Sc
+{0 0.749 1 C} FS
+24 173 155 Sc
+{0 0.752 1 C} FS
+24 179 160 Sc
+{0 0.726 1 C} FS
+24 184 165 Sc
+{0 0.676 1 C} FS
+24 190 170 Sc
+{0 0.613 1 C} FS
+24 196 175 Sc
+{0 0.547 1 C} FS
+24 202 180 Sc
+{0 0.495 1 C} FS
+24 208 186 Sc
+{0 0.478 1 C} FS
+24 213 191 Sc
+{0 0.471 1 C} FS
+24 219 196 Sc
+{0 0.451 1 C} FS
+24 225 201 Sc
+{0 0.457 1 C} FS
+24 231 206 Sc
+{0 0.486 1 C} FS
+24 237 211 Sc
+{0 0.517 1 C} FS
+24 243 217 Sc
+{0 0.543 1 C} FS
+24 248 222 Sc
+{0 0.557 1 C} FS
+24 254 227 Sc
+{0 0.564 1 C} FS
+24 260 232 Sc
+{0 0.57 1 C} FS
+24 266 237 Sc
+{0 0.573 1 C} FS
+24 272 242 Sc
+{0 0.577 1 C} FS
+24 278 247 Sc
+{0 0.577 1 C} FS
+24 283 253 Sc
+{0 0.569 1 C} FS
+24 289 258 Sc
+{0 0.553 1 C} FS
+24 295 263 Sc
+{0 0.526 1 C} FS
+24 301 268 Sc
+{0 0.492 1 C} FS
+24 307 273 Sc
+{0 0.451 1 C} FS
+24 313 278 Sc
+{0 0.415 1 C} FS
+24 318 284 Sc
+{0 0.397 1 C} FS
+24 324 289 Sc
+{0 0.383 1 C} FS
+24 330 294 Sc
+{0 0.362 1 C} FS
+24 336 299 Sc
+{0 0.346 1 C} FS
+24 342 304 Sc
+{0 0.341 1 C} FS
+24 348 309 Sc
+{0 0.339 1 C} FS
+24 354 315 Sc
+{0 0.339 1 C} FS
+24 359 320 Sc
+{0 0.34 1 C} FS
+24 365 325 Sc
+{0 0.341 1 C} FS
+24 371 330 Sc
+{0 0.34 1 C} FS
+24 377 335 Sc
+{0 0.338 1 C} FS
+24 383 340 Sc
+{0 0.337 1 C} FS
+24 389 346 Sc
+{0 0.336 1 C} FS
+24 395 351 Sc
+{0 0.338 1 C} FS
+24 401 356 Sc
+{0 0.344 1 C} FS
+24 407 361 Sc
+{0 0.354 1 C} FS
+24 412 366 Sc
+{0 0.365 1 C} FS
+24 418 371 Sc
+{0 0.371 1 C} FS
+24 424 377 Sc
+{0 0.373 1 C} FS
+24 430 382 Sc
+{0 0.373 1 C} FS
+24 436 387 Sc
+{0 0.37 1 C} FS
+24 442 392 Sc
+{0 0.366 1 C} FS
+24 448 397 Sc
+{0 0.361 1 C} FS
+24 454 402 Sc
+{0 0.354 1 C} FS
+24 460 408 Sc
+{0 0.341 1 C} FS
+24 466 413 Sc
+{0 0.327 1 C} FS
+24 471 418 Sc
+{0 0.315 1 C} FS
+24 477 423 Sc
+{0 0.306 1 C} FS
+24 483 428 Sc
+{0 0.302 1 C} FS
+24 489 433 Sc
+{0 0.3 1 C} FS
+24 495 439 Sc
+{0 0.3 1 C} FS
+24 501 444 Sc
+{0 0.308 1 C} FS
+24 507 449 Sc
+{0 0.318 1 C} FS
+24 513 454 Sc
+{0 0.333 1 C} FS
+24 519 459 Sc
+{0 0.344 1 C} FS
+24 525 464 Sc
+{0 0.353 1 C} FS
+24 531 470 Sc
+{0 0.347 1 C} FS
+24 537 475 Sc
+{0 0.333 1 C} FS
+24 543 480 Sc
+{0 0.338 1 C} FS
+24 549 485 Sc
+{0 0.346 1 C} FS
+24 555 490 Sc
+{0 0.341 1 C} FS
+24 560 495 Sc
+{0 0.332 1 C} FS
+24 566 501 Sc
+{0 0.323 1 C} FS
+24 572 506 Sc
+{0 0.319 1 C} FS
+24 578 511 Sc
+{0 0.317 1 C} FS
+24 584 516 Sc
+{0 0.314 1 C} FS
+24 590 521 Sc
+{0 0.31 1 C} FS
+24 596 526 Sc
+{0 0.309 1 C} FS
+24 602 532 Sc
+{0 0.303 1 C} FS
+24 608 537 Sc
+{0 0.296 1 C} FS
+24 614 542 Sc
+{0 0.294 1 C} FS
+24 620 547 Sc
+{0 0.298 1 C} FS
+24 626 552 Sc
+{0 0.299 1 C} FS
+24 632 557 Sc
+{0 0.293 1 C} FS
+24 638 563 Sc
+{0 0.291 1 C} FS
+24 644 568 Sc
+{0 0.3 1 C} FS
+24 650 573 Sc
+{0 0.309 1 C} FS
+24 656 578 Sc
+{0 0.32 1 C} FS
+24 662 583 Sc
+{0 0.33 1 C} FS
+24 668 588 Sc
+{0 0.338 1 C} FS
+24 674 594 Sc
+{0 0.337 1 C} FS
+24 680 599 Sc
+{0 0.328 1 C} FS
+24 686 604 Sc
+{0 0.315 1 C} FS
+24 692 609 Sc
+{0 0.295 1 C} FS
+24 698 614 Sc
+{0 0.284 1 C} FS
+24 704 619 Sc
+{0 0.282 1 C} FS
+24 710 625 Sc
+{0 0.28 1 C} FS
+24 716 630 Sc
+{0 0.282 1 C} FS
+24 722 635 Sc
+{0 0.29 1 C} FS
+24 728 640 Sc
+{0 0.297 1 C} FS
+24 734 645 Sc
+{0 0.309 1 C} FS
+24 740 651 Sc
+{0 0.329 1 C} FS
+24 746 656 Sc
+{0 0.35 1 C} FS
+24 752 661 Sc
+{0 0.369 1 C} FS
+24 758 666 Sc
+{0 0.384 1 C} FS
+24 764 671 Sc
+{0 0.39 1 C} FS
+24 770 676 Sc
+{0 0.389 1 C} FS
+24 776 682 Sc
+{0 0.382 1 C} FS
+24 782 687 Sc
+{0 0.367 1 C} FS
+24 788 692 Sc
+{0 0.35 1 C} FS
+24 794 697 Sc
+{0 0.339 1 C} FS
+24 800 702 Sc
+{0 0.335 1 C} FS
+24 807 707 Sc
+{0 0.334 1 C} FS
+24 813 713 Sc
+{0 0.334 1 C} FS
+24 819 718 Sc
+{0 0.341 1 C} FS
+24 825 723 Sc
+{0 0.348 1 C} FS
+24 831 728 Sc
+{0 0.354 1 C} FS
+24 837 733 Sc
+{0 0.36 1 C} FS
+24 843 738 Sc
+{0 0.361 1 C} FS
+24 849 744 Sc
+{0 0.356 1 C} FS
+24 855 749 Sc
+{0 0.348 1 C} FS
+24 861 754 Sc
+{0 0.339 1 C} FS
+24 867 759 Sc
+{0 0.334 1 C} FS
+24 873 764 Sc
+{0 0.331 1 C} FS
+24 879 769 Sc
+{0 0.329 1 C} FS
+24 885 775 Sc
+{0 0.33 1 C} FS
+24 891 780 Sc
+{0 0.332 1 C} FS
+24 898 785 Sc
+{0 0.331 1 C} FS
+24 904 790 Sc
+{0 0.332 1 C} FS
+24 910 795 Sc
+{0 0.332 1 C} FS
+24 916 800 Sc
+{0 0.33 1 C} FS
+24 922 806 Sc
+{0 0.328 1 C} FS
+24 928 811 Sc
+{0 0.32 1 C} FS
+24 934 816 Sc
+{0 0.318 1 C} FS
+24 940 821 Sc
+{0 0.32 1 C} FS
+24 946 826 Sc
+{0 0.32 1 C} FS
+24 952 832 Sc
+{0 0.325 1 C} FS
+24 959 837 Sc
+{0 0.326 1 C} FS
+24 965 842 Sc
+{0 0.325 1 C} FS
+24 971 847 Sc
+{0 0.316 1 C} FS
+24 977 852 Sc
+{0 0.307 1 C} FS
+24 983 857 Sc
+{0 0.299 1 C} FS
+24 989 863 Sc
+{0 0.311 1 C} FS
+24 995 868 Sc
+{0 0.335 1 C} FS
+24 1001 873 Sc
+{0 0.354 1 C} FS
+24 1007 878 Sc
+{0 0.38 1 C} FS
+24 1014 883 Sc
+{0 0.422 1 C} FS
+24 1020 888 Sc
+{0 0.463 1 C} FS
+24 1026 894 Sc
+{0 0.491 1 C} FS
+24 1032 899 Sc
+{0 0.508 1 C} FS
+24 1038 904 Sc
+{0 0.51 1 C} FS
+24 1044 909 Sc
+{0 0.498 1 C} FS
+24 1050 914 Sc
+{0 0.477 1 C} FS
+24 1057 919 Sc
+{0 0.453 1 C} FS
+24 1063 925 Sc
+{0 0.447 1 C} FS
+24 1069 930 Sc
+{0 0.468 1 C} FS
+24 1075 935 Sc
+{0 0.508 1 C} FS
+24 1081 940 Sc
+{0 0.509 1 C} FS
+24 1087 945 Sc
+{0 0.449 1 C} FS
+24 1094 950 Sc
+{0 0.416 1 C} FS
+24 1100 956 Sc
+{0 0.437 1 C} FS
+24 1106 961 Sc
+{0 0.455 1 C} FS
+24 1112 966 Sc
+{0 0.458 1 C} FS
+24 1118 971 Sc
+{0 0.443 1 C} FS
+24 1124 976 Sc
+{0 0.416 1 C} FS
+24 1131 981 Sc
+{0 0.38 1 C} FS
+24 1137 987 Sc
+{0 0.339 1 C} FS
+24 1143 992 Sc
+{0 0.307 1 C} FS
+24 1149 997 Sc
+{0 0.293 1 C} FS
+24 1155 1002 Sc
+{0 0.295 1 C} FS
+24 1162 1007 Sc
+{0 0.307 1 C} FS
+24 1168 1012 Sc
+{0 0.328 1 C} FS
+24 1174 1018 Sc
+{0 0.35 1 C} FS
+24 1180 1023 Sc
+{0 0.36 1 C} FS
+24 1186 1028 Sc
+{0 0.353 1 C} FS
+24 1192 1033 Sc
+{0 0.325 1 C} FS
+24 1199 1038 Sc
+{0 0.291 1 C} FS
+24 1205 1043 Sc
+{0 0.273 1 C} FS
+24 1211 1049 Sc
+{0 0.248 1 C} FS
+24 1217 1054 Sc
+{0 0.221 1 C} FS
+24 1224 1059 Sc
+{0 0.204 1 C} FS
+24 1230 1064 Sc
+{0 0.197 1 C} FS
+24 1236 1069 Sc
+{0 0.194 1 C} FS
+24 1242 1075 Sc
+{0 0.199 1 C} FS
+24 1248 1080 Sc
+{0 0.218 1 C} FS
+24 1255 1085 Sc
+{0 0.195 1 C} FS
+24 1261 1090 Sc
+{0 0.16 1 C} FS
+24 1267 1095 Sc
+{0 0.141 1 C} FS
+24 1273 1100 Sc
+{0 0.107 1 C} FS
+24 1280 1106 Sc
+{0 0.0738 1 C} FS
+24 1286 1111 Sc
+{0 0.134 1 C} FS
+24 1292 1116 Sc
+{0 0.387 1 C} FS
+24 1298 1121 Sc
+{0 0.502 1 C} FS
+24 1305 1126 Sc
+{0 0.304 1 C} FS
+24 1311 1131 Sc
+{0 0.21 1 C} FS
+24 1317 1137 Sc
+{0 0.196 1 C} FS
+24 1323 1142 Sc
+{0 0.204 1 C} FS
+24 1330 1147 Sc
+{0 0.218 1 C} FS
+24 1336 1152 Sc
+{0 0.225 1 C} FS
+24 1342 1157 Sc
+{0 0.223 1 C} FS
+24 1348 1162 Sc
+{0 0.234 1 C} FS
+24 1355 1168 Sc
+{0 0.243 1 C} FS
+24 1361 1173 Sc
+{0 0.234 1 C} FS
+24 1367 1178 Sc
+{0 0.214 1 C} FS
+24 1373 1183 Sc
+{0 0.198 1 C} FS
+24 1380 1188 Sc
+{0 0.187 1 C} FS
+24 1386 1193 Sc
+{0 0.186 1 C} FS
+24 1392 1199 Sc
+{0 0.199 1 C} FS
+24 1399 1204 Sc
+{0 0.233 1 C} FS
+24 1405 1209 Sc
+{0 0.282 1 C} FS
+24 1411 1214 Sc
+{0 0.332 1 C} FS
+24 1417 1219 Sc
+{0 0.37 1 C} FS
+24 1424 1224 Sc
+{0 0.392 1 C} FS
+24 1430 1230 Sc
+{0 0.396 1 C} FS
+24 1436 1235 Sc
+{0 0.383 1 C} FS
+24 1443 1240 Sc
+{0 0.361 1 C} FS
+24 1449 1245 Sc
+{0 0.333 1 C} FS
+24 1455 1250 Sc
+{0 0.304 1 C} FS
+24 1461 1255 Sc
+{0 0.28 1 C} FS
+24 1468 1260 Sc
+{0 0.263 1 C} FS
+24 1474 1266 Sc
+{0 0.25 1 C} FS
+24 1480 1271 Sc
+{0 0.241 1 C} FS
+24 1487 1276 Sc
+{0 0.235 1 C} FS
+24 1493 1281 Sc
+{0 0.226 1 C} FS
+24 1499 1286 Sc
+{0 0.214 1 C} FS
+24 1506 1291 Sc
+{0 0.192 1 C} FS
+24 1512 1297 Sc
+{0 0.168 1 C} FS
+24 1518 1302 Sc
+{0 0.142 1 C} FS
+24 1525 1307 Sc
+{0 0.113 1 C} FS
+24 1531 1312 Sc
+{0 0.091 1 C} FS
+24 1537 1317 Sc
+{0 0.0616 1 C} FS
+24 1544 1322 Sc
+{0 0.0161 1 C} FS
+24 1550 1328 Sc
+{0.0238 0 1 C} FS
+24 1556 1333 Sc
+{0.053 0 1 C} FS
+24 1563 1338 Sc
+{0.0689 0 1 C} FS
+24 1569 1343 Sc
+{0.0756 0 1 C} FS
+24 1575 1348 Sc
+{0.0705 0 1 C} FS
+24 1582 1353 Sc
+{0.0515 0 1 C} FS
+24 1588 1359 Sc
+{0.0391 0 1 C} FS
+24 1594 1364 Sc
+{0.0295 0 1 C} FS
+24 1601 1369 Sc
+{0.022 0 1 C} FS
+24 1607 1374 Sc
+{0.034 0 1 C} FS
+24 1614 1379 Sc
+{0.0507 0 1 C} FS
+24 1620 1384 Sc
+{0.0768 0 1 C} FS
+24 1626 1390 Sc
+{0.102 0 1 C} FS
+24 1633 1395 Sc
+{0.138 0 1 C} FS
+24 1639 1400 Sc
+{0.161 0 1 C} FS
+24 1645 1405 Sc
+{0.186 0 1 C} FS
+24 1652 1410 Sc
+{0.195 0 1 C} FS
+24 1658 1415 Sc
+{0.191 0 1 C} FS
+24 1665 1420 Sc
+{0.162 0 1 C} FS
+24 1671 1426 Sc
+{0.105 0 1 C} FS
+24 1677 1431 Sc
+{0.0283 0 1 C} FS
+24 1684 1436 Sc
+{0 0.0462 1 C} FS
+24 1690 1441 Sc
+{0 0.118 1 C} FS
+24 1697 1446 Sc
+{0 0.199 1 C} FS
+24 1703 1451 Sc
+{0 0.276 1 C} FS
+24 1709 1457 Sc
+{0 0.334 1 C} FS
+24 1716 1462 Sc
+{0 0.38 1 C} FS
+24 1722 1467 Sc
+{0 0.418 1 C} FS
+24 1729 1472 Sc
+{0 0.451 1 C} FS
+24 1735 1477 Sc
+{0 0.487 1 C} FS
+24 1741 1482 Sc
+{0 0.525 1 C} FS
+24 1748 1487 Sc
+{0 0.567 1 C} FS
+24 1754 1493 Sc
+{0 0.612 1 C} FS
+24 1761 1498 Sc
+{0 0.658 1 C} FS
+24 1767 1503 Sc
+{0 0.701 1 C} FS
+24 1773 1508 Sc
+{0 0.74 1 C} FS
+24 1780 1513 Sc
+{0 0.776 1 C} FS
+24 1786 1518 Sc
+{0 0.809 1 C} FS
+24 1793 1524 Sc
+{0 0.845 1 C} FS
+24 1799 1529 Sc
+{0 0.886 1 C} FS
+24 1806 1534 Sc
+{0 0.933 1 C} FS
+24 1812 1539 Sc
+{0 0.981 1 C} FS
+24 1819 1544 Sc
+{0 1 0.977 C} FS
+24 1825 1549 Sc
+{0 1 0.95 C} FS
+24 1831 1554 Sc
+{0 1 0.951 C} FS
+24 1838 1560 Sc
+{0 1 0.985 C} FS
+24 1844 1565 Sc
+{0 0.944 1 C} FS
+24 1851 1570 Sc
+{0 0.84 1 C} FS
+24 1857 1575 Sc
+{0 0.709 1 C} FS
+24 1864 1580 Sc
+{0 0.558 1 C} FS
+24 1870 1585 Sc
+{0 0.387 1 C} FS
+24 1877 1591 Sc
+{0 0.235 1 C} FS
+24 1883 1596 Sc
+{0 0.0771 1 C} FS
+24 1890 1601 Sc
+{0.0756 0 1 C} FS
+24 1896 1606 Sc
+{0.205 0 1 C} FS
+24 1903 1611 Sc
+{0.306 0 1 C} FS
+24 1909 1616 Sc
+{0.372 0 1 C} FS
+24 1915 1621 Sc
+{0.396 0 1 C} FS
+24 1922 1627 Sc
+{0.377 0 1 C} FS
+24 1928 1632 Sc
+{0.317 0 1 C} FS
+24 1935 1637 Sc
+{0.23 0 1 C} FS
+24 1941 1642 Sc
+{0.117 0 1 C} FS
+24 1948 1647 Sc
+{0 0.00446 1 C} FS
+24 1954 1652 Sc
+{0 0.144 1 C} FS
+24 1961 1657 Sc
+{0 0.304 1 C} FS
+24 1967 1663 Sc
+{0 0.397 1 C} FS
+24 1974 1668 Sc
+{0 0.367 1 C} FS
+24 1980 1673 Sc
+{0 0.339 1 C} FS
+24 1987 1678 Sc
+{0 0.347 1 C} FS
+24 1993 1683 Sc
+{0 0.415 1 C} FS
+24 2000 1688 Sc
+{0 0.5 1 C} FS
+24 2006 1693 Sc
+{0 0.584 1 C} FS
+24 2013 1699 Sc
+{0 0.661 1 C} FS
+24 2020 1704 Sc
+{0 0.719 1 C} FS
+24 2026 1709 Sc
+{0 0.754 1 C} FS
+24 2033 1714 Sc
+{0 0.758 1 C} FS
+24 2039 1719 Sc
+{0 0.731 1 C} FS
+24 2046 1724 Sc
+{0 0.675 1 C} FS
+24 2052 1729 Sc
+{0 0.598 1 C} FS
+24 2059 1735 Sc
+{0 0.513 1 C} FS
+24 2065 1740 Sc
+{0 0.46 1 C} FS
+24 2072 1745 Sc
+{0 0.398 1 C} FS
+24 2078 1750 Sc
+{0 0.35 1 C} FS
+24 2085 1755 Sc
+{0 0.332 1 C} FS
+24 2091 1760 Sc
+{0 0.348 1 C} FS
+24 2098 1765 Sc
+{0 0.384 1 C} FS
+24 2104 1770 Sc
+{0 0.391 1 C} FS
+24 2111 1776 Sc
+{0 0.387 1 C} FS
+24 2118 1781 Sc
+{0 0.388 1 C} FS
+24 2124 1786 Sc
+{0 0.37 1 C} FS
+24 2131 1791 Sc
+{0 0.347 1 C} FS
+24 2137 1796 Sc
+{0 0.391 1 C} FS
+24 2144 1801 Sc
+{0 0.452 1 C} FS
+24 2150 1806 Sc
+{0 0.444 1 C} FS
+24 2157 1812 Sc
+{0 0.413 1 C} FS
+24 2164 1817 Sc
+{0 0.364 1 C} FS
+24 2170 1822 Sc
+{0 0.311 1 C} FS
+24 2177 1827 Sc
+{0 0.273 1 C} FS
+24 2183 1832 Sc
+{0 0.239 1 C} FS
+24 2190 1837 Sc
+{0 0.248 1 C} FS
+24 2196 1842 Sc
+{0 0.291 1 C} FS
+24 2203 1847 Sc
+{0 0.311 1 C} FS
+24 2210 1853 Sc
+{0 0.304 1 C} FS
+24 2216 1858 Sc
+{0 0.29 1 C} FS
+24 2223 1863 Sc
+{0 0.28 1 C} FS
+24 2229 1868 Sc
+{0 0.265 1 C} FS
+24 2236 1873 Sc
+{0 0.23 1 C} FS
+24 2243 1878 Sc
+{0 0.177 1 C} FS
+24 2249 1883 Sc
+{0 0.13 1 C} FS
+24 2256 1888 Sc
+{0 0.0953 1 C} FS
+24 2262 1894 Sc
+{0 0.075 1 C} FS
+24 2269 1899 Sc
+{0 0.0645 1 C} FS
+24 2276 1904 Sc
+{0 0.0648 1 C} FS
+24 2282 1909 Sc
+{0 0.0706 1 C} FS
+24 2289 1914 Sc
+{0 0.0811 1 C} FS
+24 2296 1919 Sc
+{0 0.0996 1 C} FS
+24 2302 1924 Sc
+{0 0.125 1 C} FS
+24 2309 1929 Sc
+{0 0.16 1 C} FS
+24 2315 1935 Sc
+{0 0.19 1 C} FS
+24 2322 1940 Sc
+{0 0.183 1 C} FS
+24 2329 1945 Sc
+{0 0.173 1 C} FS
+24 2335 1950 Sc
+{0 0.228 1 C} FS
+24 2342 1955 Sc
+{0 0.313 1 C} FS
+24 2349 1960 Sc
+{0 0.352 1 C} FS
+24 2355 1965 Sc
+{0 0.366 1 C} FS
+24 2362 1970 Sc
+{0 0.361 1 C} FS
+24 2369 1976 Sc
+{0 0.356 1 C} FS
+24 2375 1981 Sc
+{0 0.368 1 C} FS
+24 2382 1986 Sc
+{0 0.409 1 C} FS
+24 2389 1991 Sc
+{0 0.471 1 C} FS
+24 2395 1996 Sc
+{0 0.53 1 C} FS
+24 2402 2001 Sc
+{0 0.58 1 C} FS
+24 2409 2006 Sc
+{0 0.613 1 C} FS
+24 2415 2011 Sc
+{0 0.529 1 C} FS
+24 2422 2016 Sc
+{0 0.367 1 C} FS
+24 2429 2022 Sc
+{0 0.36 1 C} FS
+24 2435 2027 Sc
+{0 0.361 1 C} FS
+24 2442 2032 Sc
+{0 0.304 1 C} FS
+24 2449 2037 Sc
+{0 0.271 1 C} FS
+24 2455 2042 Sc
+{0 0.248 1 C} FS
+24 2462 2047 Sc
+{0 0.26 1 C} FS
+24 2469 2052 Sc
+{0 0.265 1 C} FS
+24 2475 2057 Sc
+{0 0.268 1 C} FS
+24 2482 2063 Sc
+{0 0.255 1 C} FS
+24 2489 2068 Sc
+{0 0.225 1 C} FS
+24 2495 2073 Sc
+{0 0.191 1 C} FS
+24 2502 2078 Sc
+{0 0.129 1 C} FS
+24 2509 2083 Sc
+{0 0.0566 1 C} FS
+24 2515 2088 Sc
+{0.00719 0 1 C} FS
+24 2522 2093 Sc
+{0.0667 0 1 C} FS
+24 2529 2098 Sc
+{0.12 0 1 C} FS
+24 2536 2103 Sc
+{0.16 0 1 C} FS
+24 2542 2108 Sc
+{0.187 0 1 C} FS
+24 2549 2114 Sc
+{0.201 0 1 C} FS
+24 2556 2119 Sc
+{0.197 0 1 C} FS
+24 2562 2124 Sc
+{0.181 0 1 C} FS
+24 2569 2129 Sc
+{0.155 0 1 C} FS
+24 2576 2134 Sc
+{0.12 0 1 C} FS
+24 2583 2139 Sc
+{0.0812 0 1 C} FS
+24 2589 2144 Sc
+{0.0332 0 1 C} FS
+24 2596 2149 Sc
+{0 0.02 1 C} FS
+24 2603 2154 Sc
+{0 0.0755 1 C} FS
+24 2610 2160 Sc
+{0 0.132 1 C} FS
+24 2616 2165 Sc
+{0 0.178 1 C} FS
+24 2623 2170 Sc
+{0 0.283 1 C} FS
+24 2630 2175 Sc
+{0 0.413 1 C} FS
+24 2637 2180 Sc
+{0 0.533 1 C} FS
+24 2643 2185 Sc
+{0 0.608 1 C} FS
+24 2650 2190 Sc
+{0 0.637 1 C} FS
+24 2657 2195 Sc
+{0 0.633 1 C} FS
+24 2664 2200 Sc
+{0 0.61 1 C} FS
+24 2670 2205 Sc
+{0 0.594 1 C} FS
+24 2677 2210 Sc
+{0 0.571 1 C} FS
+24 2684 2216 Sc
+{0 0.508 1 C} FS
+24 2691 2221 Sc
+{0 0.48 1 C} FS
+24 2697 2226 Sc
+{0 0.468 1 C} FS
+24 2704 2231 Sc
+{0 0.47 1 C} FS
+24 2711 2236 Sc
+{0 0.492 1 C} FS
+24 2718 2241 Sc
+{0 0.536 1 C} FS
+24 2725 2246 Sc
+{0 0.583 1 C} FS
+24 2731 2251 Sc
+{0 0.608 1 C} FS
+24 2738 2256 Sc
+{0 0.593 1 C} FS
+24 2745 2261 Sc
+{0 0.598 1 C} FS
+24 2752 2266 Sc
+{0 0.617 1 C} FS
+24 2758 2272 Sc
+{0 0.53 1 C} FS
+24 2765 2277 Sc
+{0 0.457 1 C} FS
+24 2772 2282 Sc
+{0 0.402 1 C} FS
+24 2779 2287 Sc
+{0 0.372 1 C} FS
+24 2786 2292 Sc
+{0 0.368 1 C} FS
+24 2792 2297 Sc
+{0 0.363 1 C} FS
+24 2799 2302 Sc
+{0 0.366 1 C} FS
+24 2806 2307 Sc
+{0 0.376 1 C} FS
+24 2813 2312 Sc
+{0 0.38 1 C} FS
+24 2820 2317 Sc
+{0 0.387 1 C} FS
+24 2827 2322 Sc
+{0 0.395 1 C} FS
+24 2833 2327 Sc
+{0 0.396 1 C} FS
+24 2840 2333 Sc
+{0 0.402 1 C} FS
+24 2847 2338 Sc
+{0 0.442 1 C} FS
+24 2854 2343 Sc
+{0 0.486 1 C} FS
+24 2861 2348 Sc
+{0 0.497 1 C} FS
+24 2867 2353 Sc
+{0 0.486 1 C} FS
+24 2874 2358 Sc
+{0 0.484 1 C} FS
+24 2881 2363 Sc
+{0 0.484 1 C} FS
+24 2888 2368 Sc
+{0 0.483 1 C} FS
+24 2895 2373 Sc
+{0 0.488 1 C} FS
+24 2902 2378 Sc
+{0 0.502 1 C} FS
+24 2909 2383 Sc
+{0 0.486 1 C} FS
+24 2915 2388 Sc
+{0 0.417 1 C} FS
+24 2922 2393 Sc
+{0 0.382 1 C} FS
+24 2929 2399 Sc
+{0 0.349 1 C} FS
+24 2936 2404 Sc
+{0 0.351 1 C} FS
+24 2943 2409 Sc
+{0 0.377 1 C} FS
+24 2950 2414 Sc
+{0 0.403 1 C} FS
+24 2956 2419 Sc
+{0 0.442 1 C} FS
+24 2963 2424 Sc
+{0 0.485 1 C} FS
+24 2970 2429 Sc
+{0 0.525 1 C} FS
+24 2977 2434 Sc
+{0 0.56 1 C} FS
+24 2984 2439 Sc
+{0 0.555 1 C} FS
+24 2991 2444 Sc
+{0 0.44 1 C} FS
+24 2998 2449 Sc
+{0 0.425 1 C} FS
+24 3005 2454 Sc
+{0 0.479 1 C} FS
+24 3011 2459 Sc
+{0 0.533 1 C} FS
+24 3018 2464 Sc
+{0 0.514 1 C} FS
+24 3025 2469 Sc
+{0 0.479 1 C} FS
+24 3032 2475 Sc
+{0 0.471 1 C} FS
+24 3039 2480 Sc
+{0 0.464 1 C} FS
+24 3046 2485 Sc
+{0 0.454 1 C} FS
+24 3053 2490 Sc
+{0 0.454 1 C} FS
+24 3060 2495 Sc
+{0 0.476 1 C} FS
+24 3067 2500 Sc
+{0 0.526 1 C} FS
+24 3074 2505 Sc
+{0 0.559 1 C} FS
+24 3080 2510 Sc
+{0 0.565 1 C} FS
+24 3087 2515 Sc
+{0 0.557 1 C} FS
+24 3094 2520 Sc
+{0 0.559 1 C} FS
+24 3101 2525 Sc
+{0 0.582 1 C} FS
+24 3108 2530 Sc
+{0 0.622 1 C} FS
+24 3115 2535 Sc
+{0 0.668 1 C} FS
+24 3122 2540 Sc
+{0 0.711 1 C} FS
+24 3129 2545 Sc
+{0 0.744 1 C} FS
+24 3136 2550 Sc
+{0 0.758 1 C} FS
+24 3143 2555 Sc
+{0 0.748 1 C} FS
+24 3150 2560 Sc
+{0 0.721 1 C} FS
+24 3157 2565 Sc
+{0 0.693 1 C} FS
+24 3164 2571 Sc
+{0 0.642 1 C} FS
+24 3170 2576 Sc
+{0 0.532 1 C} FS
+24 3177 2581 Sc
+{0 0.446 1 C} FS
+24 3184 2586 Sc
+{0 0.377 1 C} FS
+24 3191 2591 Sc
+{0 0.345 1 C} FS
+24 3198 2596 Sc
+{0 0.306 1 C} FS
+24 3205 2601 Sc
+{0 0.233 1 C} FS
+24 3212 2606 Sc
+{0 0.167 1 C} FS
+24 3219 2611 Sc
+{0 0.179 1 C} FS
+24 3226 2616 Sc
+{0 0.269 1 C} FS
+24 3233 2621 Sc
+{0 0.422 1 C} FS
+24 3240 2626 Sc
+{0 0.599 1 C} FS
+24 3247 2631 Sc
+{0 0.783 1 C} FS
+24 3254 2636 Sc
+{0 0.934 1 C} FS
+24 3261 2641 Sc
+{0 1 0.981 C} FS
+24 3268 2646 Sc
+{0 0.975 1 C} FS
+24 3275 2651 Sc
+{0 0.892 1 C} FS
+24 3282 2656 Sc
+{0 0.81 1 C} FS
+24 3289 2661 Sc
+{0 0.733 1 C} FS
+24 3296 2666 Sc
+{0 0.652 1 C} FS
+24 3303 2671 Sc
+{0 0.563 1 C} FS
+24 3310 2676 Sc
+{0 0.482 1 C} FS
+24 3317 2681 Sc
+{0 0.411 1 C} FS
+24 3324 2686 Sc
+{0 0.377 1 C} FS
+24 3331 2691 Sc
+{0 0.393 1 C} FS
+24 3338 2696 Sc
+{0 0.416 1 C} FS
+24 3345 2701 Sc
+{0 0.443 1 C} FS
+24 3352 2707 Sc
+{0 0.485 1 C} FS
+24 3359 2712 Sc
+{0 0.533 1 C} FS
+24 3366 2717 Sc
+{0 0.58 1 C} FS
+24 3373 2722 Sc
+{0 0.622 1 C} FS
+24 3380 2727 Sc
+{0 0.65 1 C} FS
+24 3387 2732 Sc
+{0 0.659 1 C} FS
+24 3394 2737 Sc
+{0 0.649 1 C} FS
+24 3401 2742 Sc
+{0 0.622 1 C} FS
+24 3408 2747 Sc
+{0 0.582 1 C} FS
+24 3415 2752 Sc
+{0 0.536 1 C} FS
+24 3422 2757 Sc
+{0 0.505 1 C} FS
+24 3429 2762 Sc
+{0 0.485 1 C} FS
+24 3436 2767 Sc
+{0 0.465 1 C} FS
+24 3443 2772 Sc
+{0 0.451 1 C} FS
+24 3450 2777 Sc
+{0 0.457 1 C} FS
+24 3457 2782 Sc
+{0 0.469 1 C} FS
+24 3464 2787 Sc
+{0 0.479 1 C} FS
+24 3471 2792 Sc
+{0 0.491 1 C} FS
+24 3478 2797 Sc
+{0 0.494 1 C} FS
+24 3485 2802 Sc
+{0 0.483 1 C} FS
+24 3492 2807 Sc
+{0 0.458 1 C} FS
+24 3499 2812 Sc
+{0 0.422 1 C} FS
+24 3506 2817 Sc
+{0 0.377 1 C} FS
+24 3513 2822 Sc
+{0 0.332 1 C} FS
+24 3521 2827 Sc
+{0 0.307 1 C} FS
+24 3528 2832 Sc
+{0 0.332 1 C} FS
+24 3535 2837 Sc
+{0 0.333 1 C} FS
+24 3542 2842 Sc
+{0 0.326 1 C} FS
+24 3549 2847 Sc
+{0 0.37 1 C} FS
+24 3556 2852 Sc
+{0 0.502 1 C} FS
+24 3563 2857 Sc
+{0 0.605 1 C} FS
+24 3570 2862 Sc
+{0 0.644 1 C} FS
+24 3577 2867 Sc
+{0 0.668 1 C} FS
+24 3584 2872 Sc
+{0 0.63 1 C} FS
+24 3591 2877 Sc
+{0 0.554 1 C} FS
+24 3598 2882 Sc
+{0 0.589 1 C} FS
+24 3605 2887 Sc
+{0 0.551 1 C} FS
+24 3613 2892 Sc
+{0 0.516 1 C} FS
+24 3620 2897 Sc
+{0 0.54 1 C} FS
+24 3627 2902 Sc
+{0 0.508 1 C} FS
+24 3634 2907 Sc
+{0 0.489 1 C} FS
+24 3641 2912 Sc
+{0 0.453 1 C} FS
+24 3648 2917 Sc
+{0 0.428 1 C} FS
+24 3655 2922 Sc
+{0 0.421 1 C} FS
+24 3662 2927 Sc
+{0 0.428 1 C} FS
+24 3669 2932 Sc
+{0 0.446 1 C} FS
+24 3676 2937 Sc
+{0 0.464 1 C} FS
+24 3684 2942 Sc
+{0 0.474 1 C} FS
+24 3691 2947 Sc
+{0 0.471 1 C} FS
+24 3698 2952 Sc
+{0 0.467 1 C} FS
+24 3705 2957 Sc
+{0 0.464 1 C} FS
+24 3712 2962 Sc
+{0 0.461 1 C} FS
+24 3719 2967 Sc
+{0 0.46 1 C} FS
+24 3726 2972 Sc
+{0 0.464 1 C} FS
+24 3733 2977 Sc
+{0 0.471 1 C} FS
+24 3741 2982 Sc
+{0 0.476 1 C} FS
+24 3748 2987 Sc
+{0 0.483 1 C} FS
+24 3755 2992 Sc
+{0 0.491 1 C} FS
+24 3762 2997 Sc
+{0 0.495 1 C} FS
+24 3769 3002 Sc
+{0 0.493 1 C} FS
+24 3776 3007 Sc
+{0 0.487 1 C} FS
+24 3783 3011 Sc
+{0 0.481 1 C} FS
+24 3791 3016 Sc
+{0 0.475 1 C} FS
+24 3798 3021 Sc
+{0 0.461 1 C} FS
+24 3805 3026 Sc
+{0 0.45 1 C} FS
+24 3812 3031 Sc
+{0 0.448 1 C} FS
+24 3819 3036 Sc
+{0 0.45 1 C} FS
+24 3826 3041 Sc
+{0 0.457 1 C} FS
+24 3834 3046 Sc
+{0 0.466 1 C} FS
+24 3841 3051 Sc
+{0 0.478 1 C} FS
+24 3848 3056 Sc
+{0 0.489 1 C} FS
+24 3855 3061 Sc
+{0 0.492 1 C} FS
+24 3862 3066 Sc
+{0 0.497 1 C} FS
+24 3869 3071 Sc
+{0 0.505 1 C} FS
+24 3877 3076 Sc
+{0 0.51 1 C} FS
+24 3884 3081 Sc
+{0 0.521 1 C} FS
+24 3891 3086 Sc
+{0 0.539 1 C} FS
+24 3898 3091 Sc
+{0 0.556 1 C} FS
+24 3905 3096 Sc
+{0 0.564 1 C} FS
+24 3913 3101 Sc
+{0 0.562 1 C} FS
+24 3920 3106 Sc
+{0 0.551 1 C} FS
+24 3927 3111 Sc
+{0 0.533 1 C} FS
+24 3934 3116 Sc
+{0 0.513 1 C} FS
+24 3941 3121 Sc
+{0 0.503 1 C} FS
+24 3949 3126 Sc
+{0 0.499 1 C} FS
+24 3956 3130 Sc
+{0 0.498 1 C} FS
+24 3963 3135 Sc
+{0 0.495 1 C} FS
+24 3970 3140 Sc
+{0 0.491 1 C} FS
+24 3977 3145 Sc
+{0 0.489 1 C} FS
+24 3985 3150 Sc
+{0 0.494 1 C} FS
+24 3992 3155 Sc
+{0 0.505 1 C} FS
+24 3999 3160 Sc
+{0 0.512 1 C} FS
+24 4006 3165 Sc
+{0 0.518 1 C} FS
+24 4014 3170 Sc
+{0 0.529 1 C} FS
+24 4021 3175 Sc
+{0 0.538 1 C} FS
+24 4028 3180 Sc
+{0 0.54 1 C} FS
+24 4035 3185 Sc
+{0 0.529 1 C} FS
+24 4042 3190 Sc
+{0 0.516 1 C} FS
+24 4050 3195 Sc
+{0 0.507 1 C} FS
+24 4057 3200 Sc
+{0 0.5 1 C} FS
+24 4064 3205 Sc
+{0 0.492 1 C} FS
+24 4071 3210 Sc
+{0 0.487 1 C} FS
+24 4079 3214 Sc
+{0 0.492 1 C} FS
+24 4086 3219 Sc
+{0 0.502 1 C} FS
+24 4093 3224 Sc
+{0 0.514 1 C} FS
+24 4100 3229 Sc
+{0 0.52 1 C} FS
+24 4108 3234 Sc
+{0 0.528 1 C} FS
+24 4115 3239 Sc
+{0 0.538 1 C} FS
+24 4122 3244 Sc
+{0 0.539 1 C} FS
+24 4129 3249 Sc
+{0 0.533 1 C} FS
+24 4137 3254 Sc
+{0 0.528 1 C} FS
+24 4144 3259 Sc
+{0 0.525 1 C} FS
+24 4151 3264 Sc
+{0 0.526 1 C} FS
+24 4159 3269 Sc
+{0 0.526 1 C} FS
+24 4166 3274 Sc
+{0 0.528 1 C} FS
+24 4173 3278 Sc
+{0 0.531 1 C} FS
+24 4180 3283 Sc
+{0 0.535 1 C} FS
+24 4188 3288 Sc
+{0 0.537 1 C} FS
+24 4195 3293 Sc
+{0 0.538 1 C} FS
+24 4202 3298 Sc
+{0 0.538 1 C} FS
+24 4210 3303 Sc
+{0 0.534 1 C} FS
+24 4217 3308 Sc
+{0 0.524 1 C} FS
+24 4224 3313 Sc
+{0 0.513 1 C} FS
+24 4231 3318 Sc
+{0 0.506 1 C} FS
+24 4239 3323 Sc
+{0 0.504 1 C} FS
+24 4246 3328 Sc
+{0 0.507 1 C} FS
+24 4253 3332 Sc
+{0 0.52 1 C} FS
+24 4261 3337 Sc
+{0 0.537 1 C} FS
+24 4268 3342 Sc
+{0 0.555 1 C} FS
+24 4275 3347 Sc
+{0 0.567 1 C} FS
+24 4283 3352 Sc
+{0 0.577 1 C} FS
+24 4290 3357 Sc
+{0 0.592 1 C} FS
+24 4297 3362 Sc
+{0 0.598 1 C} FS
+24 4305 3367 Sc
+{0 0.592 1 C} FS
+24 4312 3372 Sc
+{0 0.584 1 C} FS
+24 4319 3377 Sc
+{0 0.579 1 C} FS
+24 4327 3381 Sc
+{0 0.568 1 C} FS
+24 4334 3386 Sc
+{0 0.555 1 C} FS
+24 4341 3391 Sc
+{0 0.547 1 C} FS
+24 4349 3396 Sc
+{0 0.555 1 C} FS
+24 4356 3401 Sc
+{0 0.573 1 C} FS
+24 4363 3406 Sc
+{0 0.591 1 C} FS
+24 4371 3411 Sc
+{0 0.603 1 C} FS
+24 4378 3416 Sc
+{0 0.615 1 C} FS
+24 4385 3420 Sc
+{0 0.634 1 C} FS
+24 4393 3425 Sc
+{0 0.652 1 C} FS
+24 4400 3430 Sc
+{0 0.662 1 C} FS
+24 4407 3435 Sc
+{0 0.666 1 C} FS
+24 4415 3440 Sc
+{0 0.664 1 C} FS
+24 4422 3445 Sc
+{0 0.656 1 C} FS
+24 4429 3450 Sc
+{0 0.649 1 C} FS
+24 4437 3455 Sc
+{0 0.638 1 C} FS
+24 4444 3460 Sc
+{0 0.634 1 C} FS
+24 4451 3464 Sc
+{0 0.634 1 C} FS
+24 4459 3469 Sc
+{0 0.63 1 C} FS
+24 4466 3474 Sc
+{0 0.626 1 C} FS
+24 4474 3479 Sc
+{0 0.621 1 C} FS
+24 4481 3484 Sc
+{0 0.614 1 C} FS
+24 4488 3489 Sc
+{0 0.605 1 C} FS
+24 4496 3494 Sc
+{0 0.598 1 C} FS
+24 4503 3498 Sc
+{0 0.595 1 C} FS
+24 4511 3503 Sc
+{0 0.596 1 C} FS
+24 4518 3508 Sc
+{0 0.601 1 C} FS
+24 4525 3513 Sc
+{0 0.608 1 C} FS
+24 4533 3518 Sc
+{0 0.617 1 C} FS
+24 4540 3523 Sc
+{0 0.625 1 C} FS
+24 4548 3528 Sc
+{0 0.632 1 C} FS
+24 4555 3532 Sc
+{0 0.638 1 C} FS
+24 4562 3537 Sc
+{0 0.643 1 C} FS
+24 4570 3542 Sc
+{0 0.646 1 C} FS
+24 4577 3547 Sc
+{0 0.648 1 C} FS
+24 4585 3552 Sc
+{0 0.646 1 C} FS
+24 4592 3557 Sc
+{0 0.639 1 C} FS
+24 4599 3562 Sc
+{0 0.628 1 C} FS
+24 4607 3566 Sc
+{0 0.613 1 C} FS
+24 4614 3571 Sc
+{0 0.601 1 C} FS
+24 4622 3576 Sc
+{0 0.594 1 C} FS
+24 4629 3581 Sc
+{0 0.596 1 C} FS
+24 4636 3586 Sc
+{0 0.604 1 C} FS
+24 4644 3591 Sc
+{0 0.621 1 C} FS
+24 4651 3595 Sc
+{0 0.645 1 C} FS
+24 4659 3600 Sc
+{0 0.661 1 C} FS
+24 4666 3605 Sc
+{0 0.672 1 C} FS
+24 4674 3610 Sc
+{0 0.688 1 C} FS
+24 4681 3615 Sc
+{0 0.701 1 C} FS
+24 4689 3620 Sc
+{0 0.707 1 C} FS
+24 4696 3624 Sc
+{0 0.705 1 C} FS
+24 4703 3629 Sc
+{0 0.7 1 C} FS
+24 4711 3634 Sc
+{0 0.69 1 C} FS
+24 4718 3639 Sc
+{0 0.679 1 C} FS
+24 4726 3644 Sc
+{0 0.669 1 C} FS
+24 4733 3649 Sc
+{0 0.666 1 C} FS
+24 4741 3653 Sc
+{0 0.664 1 C} FS
+24 4748 3658 Sc
+{0 0.66 1 C} FS
+24 4756 3663 Sc
+{0 0.656 1 C} FS
+24 4763 3668 Sc
+{0 0.652 1 C} FS
+24 4771 3673 Sc
+{0 0.65 1 C} FS
+24 4778 3677 Sc
+{0 0.65 1 C} FS
+24 4786 3682 Sc
+{0 0.651 1 C} FS
+24 4793 3687 Sc
+{0 0.656 1 C} FS
+24 4800 3692 Sc
+{0 0.659 1 C} FS
+24 4808 3697 Sc
+{0 0.657 1 C} FS
+24 4815 3702 Sc
+{0 0.658 1 C} FS
+24 4823 3706 Sc
+{0 0.662 1 C} FS
+24 4830 3711 Sc
+{0 0.668 1 C} FS
+24 4838 3716 Sc
+{0 0.671 1 C} FS
+24 4845 3721 Sc
+{0 0.672 1 C} FS
+24 4853 3726 Sc
+{0 0.671 1 C} FS
+24 4860 3730 Sc
+{0 0.668 1 C} FS
+24 4868 3735 Sc
+{0 0.661 1 C} FS
+24 4875 3740 Sc
+{0 0.656 1 C} FS
+24 4883 3745 Sc
+{0 0.66 1 C} FS
+24 4890 3750 Sc
+{0 0.668 1 C} FS
+24 4898 3754 Sc
+{0 0.674 1 C} FS
+24 4905 3759 Sc
+{0 0.688 1 C} FS
+24 4913 3764 Sc
+{0 0.711 1 C} FS
+24 4920 3769 Sc
+{0 0.732 1 C} FS
+24 4928 3774 Sc
+{0 0.748 1 C} FS
+24 4935 3778 Sc
+{0 0.755 1 C} FS
+24 4943 3783 Sc
+{0 0.755 1 C} FS
+24 4951 3788 Sc
+{0 0.75 1 C} FS
+24 4958 3793 Sc
+{0 0.739 1 C} FS
+24 4966 3797 Sc
+{0 0.726 1 C} FS
+24 4973 3802 Sc
+{0 0.715 1 C} FS
+24 4981 3807 Sc
+{0 0.706 1 C} FS
+24 4988 3812 Sc
+{0 0.7 1 C} FS
+24 4996 3817 Sc
+{0 0.701 1 C} FS
+24 5003 3821 Sc
+{0 0.703 1 C} FS
+24 5011 3826 Sc
+{0 0.704 1 C} FS
+24 5018 3831 Sc
+{0 0.704 1 C} FS
+24 5026 3836 Sc
+{0 0.704 1 C} FS
+24 5033 3840 Sc
+{0 0.7 1 C} FS
+24 5041 3845 Sc
+{0 0.694 1 C} FS
+24 5049 3850 Sc
+{0 0.685 1 C} FS
+24 5056 3855 Sc
+{0 0.681 1 C} FS
+24 5064 3860 Sc
+{0 0.684 1 C} FS
+24 5071 3864 Sc
+{0 0.7 1 C} FS
+24 5079 3869 Sc
+{0 0.715 1 C} FS
+24 5086 3874 Sc
+{0 0.732 1 C} FS
+24 5094 3879 Sc
+{0 0.77 1 C} FS
+24 5101 3883 Sc
+{0 0.805 1 C} FS
+24 5109 3888 Sc
+{0 0.824 1 C} FS
+24 5117 3893 Sc
+{0 0.828 1 C} FS
+24 5124 3898 Sc
+{0 0.822 1 C} FS
+24 5132 3902 Sc
+{0 0.805 1 C} FS
+24 5139 3907 Sc
+{0 0.779 1 C} FS
+24 5147 3912 Sc
+{0 0.753 1 C} FS
+24 5155 3917 Sc
+{0 0.744 1 C} FS
+24 5162 3921 Sc
+{0 0.736 1 C} FS
+24 5170 3926 Sc
+{0 0.722 1 C} FS
+24 5177 3931 Sc
+{0 0.711 1 C} FS
+24 5185 3936 Sc
+{0 0.706 1 C} FS
+24 5193 3940 Sc
+{0 0.71 1 C} FS
+24 5200 3945 Sc
+{0 0.728 1 C} FS
+24 5208 3950 Sc
+{0 0.757 1 C} FS
+24 5215 3954 Sc
+{0 0.793 1 C} FS
+24 5223 3959 Sc
+{0 0.841 1 C} FS
+24 5231 3964 Sc
+{0 0.894 1 C} FS
+24 5238 3969 Sc
+{0 0.955 1 C} FS
+24 5246 3973 Sc
+{0 0.905 1 C} FS
+24 5253 3978 Sc
+{0 0.894 1 C} FS
+24 5261 3983 Sc
+{0 0.902 1 C} FS
+24 5269 3988 Sc
+{0 0.897 1 C} FS
+24 5276 3992 Sc
+{0 0.876 1 C} FS
+24 5284 3997 Sc
+{0 0.849 1 C} FS
+24 5291 4002 Sc
+{0 0.818 1 C} FS
+24 5299 4006 Sc
+{0 0.783 1 C} FS
+24 5307 4011 Sc
+{0 0.761 1 C} FS
+24 5314 4016 Sc
+{0 0.752 1 C} FS
+24 5322 4021 Sc
+{0 0.747 1 C} FS
+24 5330 4025 Sc
+{0 0.744 1 C} FS
+24 5337 4030 Sc
+{0 0.744 1 C} FS
+24 5345 4035 Sc
+{0 0.744 1 C} FS
+24 5353 4039 Sc
+{0 0.744 1 C} FS
+24 5360 4044 Sc
+{0 0.742 1 C} FS
+24 5368 4049 Sc
+{0 0.742 1 C} FS
+24 5376 4054 Sc
+{0 0.754 1 C} FS
+24 5383 4058 Sc
+{0 0.794 1 C} FS
+24 5391 4063 Sc
+{0 0.797 1 C} FS
+24 5398 4068 Sc
+{0 0.749 1 C} FS
+24 5406 4072 Sc
+{0 0.742 1 C} FS
+24 5414 4077 Sc
+{0 0.734 1 C} FS
+24 5421 4082 Sc
+{0 0.739 1 C} FS
+24 5429 4086 Sc
+{0 0.741 1 C} FS
+24 5437 4091 Sc
+{0 0.742 1 C} FS
+24 5444 4096 Sc
+{0 0.741 1 C} FS
+24 5452 4101 Sc
+{0 0.743 1 C} FS
+24 5460 4105 Sc
+{0 0.745 1 C} FS
+24 5467 4110 Sc
+{0 0.741 1 C} FS
+24 5475 4115 Sc
+{0 0.739 1 C} FS
+24 5483 4119 Sc
+{0 0.736 1 C} FS
+24 5491 4124 Sc
+{0 0.736 1 C} FS
+24 5498 4129 Sc
+{0 0.739 1 C} FS
+24 5506 4133 Sc
+{0 0.745 1 C} FS
+24 5514 4138 Sc
+{0 0.753 1 C} FS
+24 5521 4143 Sc
+{0 0.766 1 C} FS
+24 5529 4147 Sc
+{0 0.783 1 C} FS
+24 5537 4152 Sc
+{0 0.792 1 C} FS
+24 5544 4157 Sc
+{0 0.798 1 C} FS
+24 5552 4161 Sc
+{0 0.805 1 C} FS
+24 5560 4166 Sc
+{0 0.81 1 C} FS
+24 5568 4171 Sc
+{0 0.809 1 C} FS
+24 5575 4175 Sc
+{0 0.807 1 C} FS
+24 5583 4180 Sc
+{0 0.826 1 C} FS
+24 5591 4185 Sc
+{0 0.865 1 C} FS
+24 5598 4189 Sc
+{0 0.875 1 C} FS
+24 5606 4194 Sc
+{0 0.878 1 C} FS
+24 5614 4199 Sc
+{0 0.875 1 C} FS
+24 5622 4203 Sc
+{0 0.87 1 C} FS
+24 5629 4208 Sc
+{0 0.867 1 C} FS
+24 5637 4213 Sc
+{0 0.866 1 C} FS
+24 5645 4217 Sc
+{0 0.87 1 C} FS
+24 5652 4222 Sc
+{0 0.877 1 C} FS
+24 5660 4226 Sc
+{0 0.889 1 C} FS
+24 5668 4231 Sc
+{0 0.896 1 C} FS
+24 5676 4236 Sc
+{0 0.903 1 C} FS
+24 5683 4240 Sc
+{0 0.92 1 C} FS
+24 5691 4245 Sc
+{0 0.93 1 C} FS
+24 5699 4250 Sc
+{0 0.932 1 C} FS
+24 5707 4254 Sc
+{0 0.925 1 C} FS
+24 5714 4259 Sc
+{0 0.916 1 C} FS
+24 5722 4264 Sc
+{0 0.909 1 C} FS
+24 5730 4268 Sc
+{0 0.904 1 C} FS
+24 5738 4273 Sc
+{0 0.898 1 C} FS
+24 5745 4277 Sc
+{0 0.891 1 C} FS
+24 5753 4282 Sc
+{0 0.887 1 C} FS
+24 5761 4287 Sc
+{0 0.889 1 C} FS
+24 5769 4291 Sc
+{0 0.898 1 C} FS
+24 5776 4296 Sc
+{0 0.917 1 C} FS
+24 5784 4301 Sc
+{0 0.94 1 C} FS
+24 5792 4305 Sc
+{0 0.973 1 C} FS
+24 5800 4310 Sc
+{0 1 1 C} FS
+24 5807 4314 Sc
+{0 1 0.972 C} FS
+24 5815 4319 Sc
+{0 1 0.932 C} FS
+24 5823 4324 Sc
+{0 1 0.897 C} FS
+24 5831 4328 Sc
+{0 1 0.868 C} FS
+24 5839 4333 Sc
+{0 1 0.857 C} FS
+24 5846 4337 Sc
+{0 1 0.886 C} FS
+24 5854 4342 Sc
+{0 1 0.854 C} FS
+24 5862 4347 Sc
+{0 1 0.769 C} FS
+24 5870 4351 Sc
+{0 1 0.818 C} FS
+24 5878 4356 Sc
+{0 1 0.894 C} FS
+24 5885 4360 Sc
+{0 1 0.955 C} FS
+24 5893 4365 Sc
+{0 1 1 C} FS
+24 5901 4370 Sc
+{0 0.968 1 C} FS
+24 5909 4374 Sc
+{0 0.945 1 C} FS
+24 5917 4379 Sc
+{0 0.928 1 C} FS
+24 5924 4383 Sc
+{0 0.916 1 C} FS
+24 5932 4388 Sc
+{0 0.907 1 C} FS
+24 5940 4393 Sc
+{0 0.902 1 C} FS
+24 5948 4397 Sc
+{0 0.906 1 C} FS
+24 5956 4402 Sc
+{0 0.911 1 C} FS
+24 5963 4406 Sc
+{0 0.913 1 C} FS
+24 5971 4411 Sc
+{0 0.912 1 C} FS
+24 5979 4416 Sc
+{0 0.912 1 C} FS
+24 5987 4420 Sc
+{0 0.914 1 C} FS
+24 5995 4425 Sc
+{0 0.914 1 C} FS
+24 6003 4429 Sc
+{0 0.917 1 C} FS
+24 6010 4434 Sc
+{0 0.919 1 C} FS
+24 6018 4438 Sc
+{0 0.922 1 C} FS
+24 6026 4443 Sc
+{0 0.921 1 C} FS
+24 6034 4447 Sc
+{0 0.922 1 C} FS
+24 6042 4452 Sc
+{0 0.924 1 C} FS
+24 6050 4457 Sc
+{0 0.927 1 C} FS
+24 6057 4461 Sc
+{0 0.931 1 C} FS
+24 6065 4466 Sc
+{0 0.931 1 C} FS
+24 6073 4470 Sc
+{0 0.928 1 C} FS
+24 6081 4475 Sc
+{0 0.925 1 C} FS
+24 6089 4479 Sc
+{0 0.924 1 C} FS
+24 6097 4484 Sc
+{0 0.924 1 C} FS
+24 6105 4488 Sc
+{0 0.924 1 C} FS
+24 6112 4493 Sc
+{0 0.93 1 C} FS
+24 6120 4498 Sc
+{0 0.937 1 C} FS
+24 6128 4502 Sc
+{0 0.937 1 C} FS
+24 6136 4507 Sc
+{0 0.927 1 C} FS
+24 6144 4511 Sc
+{0 0.91 1 C} FS
+24 6152 4516 Sc
+{0 0.889 1 C} FS
+24 6160 4520 Sc
+{0 0.869 1 C} FS
+24 6167 4525 Sc
+{0 0.851 1 C} FS
+24 6175 4529 Sc
+{0 0.845 1 C} FS
+24 6183 4534 Sc
+{0 0.849 1 C} FS
+24 6191 4538 Sc
+{0 0.865 1 C} FS
+24 6199 4543 Sc
+{0 0.893 1 C} FS
+24 6207 4547 Sc
+{0 0.926 1 C} FS
+24 6215 4552 Sc
+{0 0.94 1 C} FS
+24 6223 4556 Sc
+{0 0.928 1 C} FS
+24 6230 4561 Sc
+{0 0.916 1 C} FS
+24 6238 4566 Sc
+{0 0.904 1 C} FS
+24 6246 4570 Sc
+{0 0.895 1 C} FS
+24 6254 4575 Sc
+{0 0.884 1 C} FS
+24 6262 4579 Sc
+{0 0.876 1 C} FS
+24 6270 4584 Sc
+{0 0.864 1 C} FS
+24 6278 4588 Sc
+{0 0.855 1 C} FS
+24 6286 4593 Sc
+{0 0.849 1 C} FS
+24 6294 4597 Sc
+{0 0.85 1 C} FS
+24 6302 4602 Sc
+{0 0.868 1 C} FS
+24 6309 4606 Sc
+{0 0.906 1 C} FS
+24 6317 4611 Sc
+{0 0.917 1 C} FS
+24 6325 4615 Sc
+{0 0.903 1 C} FS
+24 6333 4620 Sc
+{0 0.885 1 C} FS
+24 6341 4624 Sc
+{0 0.872 1 C} FS
+24 6349 4629 Sc
+{0 0.861 1 C} FS
+24 6357 4633 Sc
+{0 0.852 1 C} FS
+24 6365 4638 Sc
+{0 0.862 1 C} FS
+24 6373 4642 Sc
+{0 0.886 1 C} FS
+24 6381 4647 Sc
+{0 0.911 1 C} FS
+24 6389 4651 Sc
+{0 0.931 1 C} FS
+24 6397 4655 Sc
+{0 0.94 1 C} FS
+24 6405 4660 Sc
+{0 0.938 1 C} FS
+24 6412 4664 Sc
+{0 0.935 1 C} FS
+24 6420 4669 Sc
+{0 0.932 1 C} FS
+24 6428 4673 Sc
+{0 0.931 1 C} FS
+24 6436 4678 Sc
+{0 0.932 1 C} FS
+24 6444 4682 Sc
+{0 0.933 1 C} FS
+24 6452 4687 Sc
+{0 0.932 1 C} FS
+24 6460 4691 Sc
+{0 0.93 1 C} FS
+24 6468 4696 Sc
+{0 0.931 1 C} FS
+24 6476 4700 Sc
+{0 0.936 1 C} FS
+24 6484 4705 Sc
+{0 0.942 1 C} FS
+24 6492 4709 Sc
+{0 0.944 1 C} FS
+24 6500 4714 Sc
+{0 0.941 1 C} FS
+24 6508 4718 Sc
+{0 0.94 1 C} FS
+24 6516 4722 Sc
+{0 0.94 1 C} FS
+24 6524 4727 Sc
+{0 0.944 1 C} FS
+24 6532 4731 Sc
+{0 0.947 1 C} FS
+24 6540 4736 Sc
+{0 0.949 1 C} FS
+24 6548 4740 Sc
+{0 0.951 1 C} FS
+24 6556 4745 Sc
+{0 0.954 1 C} FS
+24 6564 4749 Sc
+{0 0.955 1 C} FS
+24 6572 4754 Sc
+{0 0.953 1 C} FS
+24 6580 4758 Sc
+{0 0.948 1 C} FS
+24 6588 4762 Sc
+{0 0.938 1 C} FS
+24 6596 4767 Sc
+{0 0.921 1 C} FS
+24 6604 4771 Sc
+{0 0.897 1 C} FS
+24 6612 4776 Sc
+{0 0.862 1 C} FS
+24 6620 4780 Sc
+{0 0.821 1 C} FS
+24 6628 4785 Sc
+{0 0.809 1 C} FS
+24 6636 4789 Sc
+{0 0.818 1 C} FS
+24 6644 4793 Sc
+{0 0.832 1 C} FS
+24 6652 4798 Sc
+{0 0.856 1 C} FS
+24 6660 4802 Sc
+{0 0.881 1 C} FS
+24 6668 4807 Sc
+{0 0.902 1 C} FS
+24 6676 4811 Sc
+{0 0.903 1 C} FS
+24 6684 4816 Sc
+{0 0.874 1 C} FS
+24 6692 4820 Sc
+{0 0.868 1 C} FS
+24 6700 4824 Sc
+{0 0.886 1 C} FS
+24 6708 4829 Sc
+{0 0.902 1 C} FS
+24 6716 4833 Sc
+{0 0.904 1 C} FS
+24 6724 4838 Sc
+{0 0.907 1 C} FS
+24 6732 4842 Sc
+{0 0.909 1 C} FS
+24 6740 4846 Sc
+{0 0.902 1 C} FS
+24 6748 4851 Sc
+{0 0.89 1 C} FS
+24 6756 4855 Sc
+{0 0.881 1 C} FS
+24 6764 4860 Sc
+{0 0.89 1 C} FS
+24 6772 4864 Sc
+{0 0.935 1 C} FS
+24 6780 4868 Sc
+{0 0.964 1 C} FS
+24 6788 4873 Sc
+{0 0.935 1 C} FS
+24 6796 4877 Sc
+{0 0.894 1 C} FS
+24 6804 4881 Sc
+{0 0.872 1 C} FS
+24 6812 4886 Sc
+{0 0.883 1 C} FS
+24 6820 4890 Sc
+{0 0.898 1 C} FS
+24 6828 4895 Sc
+{0 0.917 1 C} FS
+24 6836 4899 Sc
+{0 0.933 1 C} FS
+24 6844 4903 Sc
+{0 0.946 1 C} FS
+24 6852 4908 Sc
+{0 0.95 1 C} FS
+24 6860 4912 Sc
+{0 0.95 1 C} FS
+24 6868 4916 Sc
+{0 0.946 1 C} FS
+24 6876 4921 Sc
+{0 0.944 1 C} FS
+24 6884 4925 Sc
+{0 0.945 1 C} FS
+24 6892 4930 Sc
+{0 0.944 1 C} FS
+24 6900 4934 Sc
+{0 0.942 1 C} FS
+24 6909 4938 Sc
+{0 0.944 1 C} FS
+24 6917 4943 Sc
+{0 0.942 1 C} FS
+24 6925 4947 Sc
+{0 0.934 1 C} FS
+24 6933 4951 Sc
+{0 0.923 1 C} FS
+24 6941 4956 Sc
+{0 0.918 1 C} FS
+24 6949 4960 Sc
+{0 0.92 1 C} FS
+24 6957 4964 Sc
+{0 0.93 1 C} FS
+24 6965 4969 Sc
+{0 0.942 1 C} FS
+24 6973 4973 Sc
+{0 0.947 1 C} FS
+24 6981 4977 Sc
+{0 0.949 1 C} FS
+24 6989 4982 Sc
+{0 0.969 1 C} FS
+24 6997 4986 Sc
+{0 0.986 1 C} FS
+24 7005 4990 Sc
+{0 0.988 1 C} FS
+24 7013 4995 Sc
+{0 0.981 1 C} FS
+24 7022 4999 Sc
+{0 0.969 1 C} FS
+24 7030 5003 Sc
+{0 0.961 1 C} FS
+24 7038 5008 Sc
+{0 0.957 1 C} FS
+24 7046 5012 Sc
+{0 0.953 1 C} FS
+24 7054 5016 Sc
+{0 0.953 1 C} FS
+24 7062 5021 Sc
+{0 0.951 1 C} FS
+24 7070 5025 Sc
+{0 0.955 1 C} FS
+24 7078 5029 Sc
+{0 0.97 1 C} FS
+24 7086 5034 Sc
+{0 0.988 1 C} FS
+24 7094 5038 Sc
+{0 0.994 1 C} FS
+24 7103 5042 Sc
+{0 0.994 1 C} FS
+24 7111 5046 Sc
+{0 0.99 1 C} FS
+24 7119 5051 Sc
+{0 0.984 1 C} FS
+24 7127 5055 Sc
+{0 0.979 1 C} FS
+24 7135 5059 Sc
+{0 0.975 1 C} FS
+24 7143 5064 Sc
+{0 0.971 1 C} FS
+24 7151 5068 Sc
+{0 0.965 1 C} FS
+24 7159 5072 Sc
+{0 0.958 1 C} FS
+24 7167 5076 Sc
+{0 0.954 1 C} FS
+24 7176 5081 Sc
+{0 0.947 1 C} FS
+24 7184 5085 Sc
+{0 0.937 1 C} FS
+24 7192 5089 Sc
+{0 0.922 1 C} FS
+24 7200 5094 Sc
+U
+PSL_cliprestore
+25 W
+8 W
+N 0 0 M 0 -83 D S
+N 0 5094 M 0 83 D S
+N 1800 0 M 0 -83 D S
+N 1800 5094 M 0 83 D S
+N 3600 0 M 0 -83 D S
+N 3600 5094 M 0 83 D S
+N 5400 0 M 0 -83 D S
+N 5400 5094 M 0 83 D S
+N 7200 0 M 0 -83 D S
+N 7200 5094 M 0 83 D S
+N 0 0 M -83 0 D S
+N 7200 0 M 83 0 D S
+N 0 2435 M -83 0 D S
+N 7200 2435 M 83 0 D S
+N 0 5094 M -83 0 D S
+N 7200 5094 M 83 0 D S
+83 W
+N -42 0 M 0 472 D S
+N 7242 0 M 0 472 D S
+1 A
+N -42 472 M 0 478 D S
+N 7242 472 M 0 478 D S
+0 A
+N -42 950 M 0 487 D S
+N 7242 950 M 0 487 D S
+1 A
+N -42 1437 M 0 495 D S
+N 7242 1437 M 0 495 D S
+0 A
+N -42 1932 M 0 503 D S
+N 7242 1932 M 0 503 D S
+1 A
+N -42 2435 M 0 512 D S
+N 7242 2435 M 0 512 D S
+0 A
+N -42 2947 M 0 521 D S
+N 7242 2947 M 0 521 D S
+1 A
+N -42 3468 M 0 531 D S
+N 7242 3468 M 0 531 D S
+0 A
+N -42 3999 M 0 542 D S
+N 7242 3999 M 0 542 D S
+1 A
+N -42 4541 M 0 553 D S
+N 7242 4541 M 0 553 D S
+0 A
+N 0 -42 M 360 0 D S
+N 0 5135 M 360 0 D S
+1 A
+N 360 -42 M 360 0 D S
+N 360 5135 M 360 0 D S
+0 A
+N 720 -42 M 360 0 D S
+N 720 5135 M 360 0 D S
+1 A
+N 1080 -42 M 360 0 D S
+N 1080 5135 M 360 0 D S
+0 A
+N 1440 -42 M 360 0 D S
+N 1440 5135 M 360 0 D S
+1 A
+N 1800 -42 M 360 0 D S
+N 1800 5135 M 360 0 D S
+0 A
+N 2160 -42 M 360 0 D S
+N 2160 5135 M 360 0 D S
+1 A
+N 2520 -42 M 360 0 D S
+N 2520 5135 M 360 0 D S
+0 A
+N 2880 -42 M 360 0 D S
+N 2880 5135 M 360 0 D S
+1 A
+N 3240 -42 M 360 0 D S
+N 3240 5135 M 360 0 D S
+0 A
+N 3600 -42 M 360 0 D S
+N 3600 5135 M 360 0 D S
+1 A
+N 3960 -42 M 360 0 D S
+N 3960 5135 M 360 0 D S
+0 A
+N 4320 -42 M 360 0 D S
+N 4320 5135 M 360 0 D S
+1 A
+N 4680 -42 M 360 0 D S
+N 4680 5135 M 360 0 D S
+0 A
+N 5040 -42 M 360 0 D S
+N 5040 5135 M 360 0 D S
+1 A
+N 5400 -42 M 360 0 D S
+N 5400 5135 M 360 0 D S
+0 A
+N 5760 -42 M 360 0 D S
+N 5760 5135 M 360 0 D S
+1 A
+N 6120 -42 M 360 0 D S
+N 6120 5135 M 360 0 D S
+0 A
+N 6480 -42 M 360 0 D S
+N 6480 5135 M 360 0 D S
+1 A
+N 6840 -42 M 360 0 D S
+N 6840 5135 M 360 0 D S
+0 A
+8 W
+N -83 0 M 7366 0 D S
+N -83 -83 M 7366 0 D S
+N 7200 -83 M 0 5260 D S
+N 7283 -83 M 0 5260 D S
+N 7283 5094 M -7366 0 D S
+N 7283 5177 M -7366 0 D S
+N 0 5177 M 0 -5260 D S
+N -83 5177 M 0 -5260 D S
+0 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(180°) tc Z
+0 5260 M (180°) bc Z
+1800 -167 M (-175°) tc Z
+1800 5260 M (-175°) bc Z
+3600 -167 M (-170°) tc Z
+3600 5260 M (-170°) bc Z
+5400 -167 M (-165°) tc Z
+5400 5260 M (-165°) bc Z
+7200 -167 M (-160°) tc Z
+7200 5260 M (-160°) bc Z
+-167 0 M (40°) mr Z
+7367 0 M (40°) ml Z
+-167 2435 M (45°) mr Z
+7367 2435 M (45°) ml Z
+-167 5094 M (50°) mr Z
+7367 5094 M (50°) ml Z
+%%EndObject
+0 A
+FQ
+O0
+0 6000 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R180/200/39.99118745885167/50.01635757326589 -JM6i -O -Baf -Sc0.1c -Ct.cpt g.txt -Y5i
+%@PROJ: merc 180.00000000 200.00000000 39.99118746 50.01635757 -1113194.908 1113194.908 4837195.911 6416350.055 +proj=merc +lon_0=190 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 5107 D
+-7200 0 D
+P
+PSL_clip N
+4 W
+V
+{0 0.524 1 C} FS
+24 0 0 Sc
+{0 0.705 1 C} FS
+24 4 4 Sc
+{0 0.692 1 C} FS
+24 8 7 Sc
+{0 0.677 1 C} FS
+24 12 11 Sc
+{0 0.671 1 C} FS
+24 16 15 Sc
+{0 0.679 1 C} FS
+24 20 18 Sc
+{0 0.693 1 C} FS
+24 24 22 Sc
+{0 0.699 1 C} FS
+24 28 25 Sc
+{0 0.692 1 C} FS
+24 32 29 Sc
+{0 0.671 1 C} FS
+24 36 33 Sc
+{0 0.644 1 C} FS
+24 40 36 Sc
+{0 0.618 1 C} FS
+24 44 40 Sc
+{0 0.599 1 C} FS
+24 48 44 Sc
+{0 0.584 1 C} FS
+24 52 47 Sc
+{0 0.566 1 C} FS
+24 57 51 Sc
+{0 0.548 1 C} FS
+24 61 55 Sc
+{0 0.53 1 C} FS
+24 65 58 Sc
+{0 0.497 1 C} FS
+24 69 62 Sc
+{0 0.419 1 C} FS
+24 73 65 Sc
+{0 0.326 1 C} FS
+24 77 69 Sc
+{0 0.261 1 C} FS
+24 81 73 Sc
+{0 0.201 1 C} FS
+24 85 76 Sc
+{0 0.151 1 C} FS
+24 89 80 Sc
+{0 0.191 1 C} FS
+24 93 84 Sc
+{0 0.318 1 C} FS
+24 97 87 Sc
+{0 0.428 1 C} FS
+24 101 91 Sc
+{0 0.502 1 C} FS
+24 105 94 Sc
+{0 0.603 1 C} FS
+24 109 98 Sc
+{0 0.696 1 C} FS
+24 113 102 Sc
+{0 0.698 1 C} FS
+24 117 105 Sc
+{0 0.61 1 C} FS
+24 121 109 Sc
+{0 0.452 1 C} FS
+24 125 113 Sc
+{0 0.279 1 C} FS
+24 129 116 Sc
+{0 0.0821 1 C} FS
+24 134 120 Sc
+{0.0767 0 1 C} FS
+24 138 124 Sc
+{0.138 0 1 C} FS
+24 142 127 Sc
+{0.117 0 1 C} FS
+24 146 131 Sc
+{0.0011 0 1 C} FS
+24 150 134 Sc
+{0 0.157 1 C} FS
+24 154 138 Sc
+{0 0.329 1 C} FS
+24 158 142 Sc
+{0 0.465 1 C} FS
+24 162 145 Sc
+{0 0.555 1 C} FS
+24 166 149 Sc
+{0 0.629 1 C} FS
+24 170 153 Sc
+{0 0.685 1 C} FS
+24 174 156 Sc
+{0 0.732 1 C} FS
+24 178 160 Sc
+{0 0.765 1 C} FS
+24 182 164 Sc
+{0 0.788 1 C} FS
+24 187 167 Sc
+{0 0.799 1 C} FS
+24 191 171 Sc
+{0 0.779 1 C} FS
+24 195 175 Sc
+{0 0.712 1 C} FS
+24 199 178 Sc
+{0 0.625 1 C} FS
+24 203 182 Sc
+{0 0.55 1 C} FS
+24 207 185 Sc
+{0 0.493 1 C} FS
+24 211 189 Sc
+{0 0.456 1 C} FS
+24 215 193 Sc
+{0 0.438 1 C} FS
+24 219 196 Sc
+{0 0.435 1 C} FS
+24 223 200 Sc
+{0 0.436 1 C} FS
+24 227 204 Sc
+{0 0.435 1 C} FS
+24 231 207 Sc
+{0 0.437 1 C} FS
+24 236 211 Sc
+{0 0.444 1 C} FS
+24 240 215 Sc
+{0 0.457 1 C} FS
+24 244 218 Sc
+{0 0.475 1 C} FS
+24 248 222 Sc
+{0 0.496 1 C} FS
+24 252 225 Sc
+{0 0.516 1 C} FS
+24 256 229 Sc
+{0 0.533 1 C} FS
+24 260 233 Sc
+{0 0.549 1 C} FS
+24 264 236 Sc
+{0 0.562 1 C} FS
+24 268 240 Sc
+{0 0.572 1 C} FS
+24 272 244 Sc
+{0 0.58 1 C} FS
+24 277 247 Sc
+{0 0.584 1 C} FS
+24 281 251 Sc
+{0 0.585 1 C} FS
+24 285 255 Sc
+{0 0.581 1 C} FS
+24 289 258 Sc
+{0 0.574 1 C} FS
+24 293 262 Sc
+{0 0.564 1 C} FS
+24 297 265 Sc
+{0 0.548 1 C} FS
+24 301 269 Sc
+{0 0.528 1 C} FS
+24 305 273 Sc
+{0 0.504 1 C} FS
+24 309 276 Sc
+{0 0.476 1 C} FS
+24 314 280 Sc
+{0 0.448 1 C} FS
+24 318 284 Sc
+{0 0.425 1 C} FS
+24 322 287 Sc
+{0 0.411 1 C} FS
+24 326 291 Sc
+{0 0.399 1 C} FS
+24 330 295 Sc
+{0 0.38 1 C} FS
+24 334 298 Sc
+{0 0.359 1 C} FS
+24 338 302 Sc
+{0 0.342 1 C} FS
+24 342 306 Sc
+{0 0.331 1 C} FS
+24 347 309 Sc
+{0 0.325 1 C} FS
+24 351 313 Sc
+{0 0.321 1 C} FS
+24 355 316 Sc
+{0 0.319 1 C} FS
+24 359 320 Sc
+{0 0.318 1 C} FS
+24 363 324 Sc
+{0 0.318 1 C} FS
+24 367 327 Sc
+{0 0.319 1 C} FS
+24 371 331 Sc
+{0 0.32 1 C} FS
+24 375 335 Sc
+{0 0.319 1 C} FS
+24 380 338 Sc
+{0 0.318 1 C} FS
+24 384 342 Sc
+{0 0.317 1 C} FS
+24 388 346 Sc
+{0 0.315 1 C} FS
+24 392 349 Sc
+{0 0.313 1 C} FS
+24 396 353 Sc
+{0 0.312 1 C} FS
+24 400 357 Sc
+{0 0.313 1 C} FS
+24 404 360 Sc
+{0 0.315 1 C} FS
+24 409 364 Sc
+{0 0.319 1 C} FS
+24 413 367 Sc
+{0 0.325 1 C} FS
+24 417 371 Sc
+{0 0.333 1 C} FS
+24 421 375 Sc
+{0 0.342 1 C} FS
+24 425 378 Sc
+{0 0.352 1 C} FS
+24 429 382 Sc
+{0 0.361 1 C} FS
+24 434 386 Sc
+{0 0.367 1 C} FS
+24 438 389 Sc
+{0 0.37 1 C} FS
+24 442 393 Sc
+{0 0.37 1 C} FS
+24 446 397 Sc
+{0 0.369 1 C} FS
+24 450 400 Sc
+{0 0.366 1 C} FS
+24 454 404 Sc
+{0 0.363 1 C} FS
+24 458 408 Sc
+{0 0.36 1 C} FS
+24 463 411 Sc
+{0 0.355 1 C} FS
+24 467 415 Sc
+{0 0.35 1 C} FS
+24 471 418 Sc
+{0 0.345 1 C} FS
+24 475 422 Sc
+{0 0.342 1 C} FS
+24 479 426 Sc
+{0 0.34 1 C} FS
+24 483 429 Sc
+{0 0.339 1 C} FS
+24 488 433 Sc
+{0 0.34 1 C} FS
+24 492 437 Sc
+{0 0.341 1 C} FS
+24 496 440 Sc
+{0 0.342 1 C} FS
+24 500 444 Sc
+{0 0.344 1 C} FS
+24 504 448 Sc
+{0 0.346 1 C} FS
+24 508 451 Sc
+{0 0.348 1 C} FS
+24 513 455 Sc
+{0 0.353 1 C} FS
+24 517 459 Sc
+{0 0.359 1 C} FS
+24 521 462 Sc
+{0 0.363 1 C} FS
+24 525 466 Sc
+{0 0.367 1 C} FS
+24 529 470 Sc
+{0 0.372 1 C} FS
+24 533 473 Sc
+{0 0.376 1 C} FS
+24 538 477 Sc
+{0 0.377 1 C} FS
+24 542 480 Sc
+{0 0.371 1 C} FS
+24 546 484 Sc
+{0 0.358 1 C} FS
+24 550 488 Sc
+{0 0.35 1 C} FS
+24 554 491 Sc
+{0 0.347 1 C} FS
+24 559 495 Sc
+{0 0.341 1 C} FS
+24 563 499 Sc
+{0 0.333 1 C} FS
+24 567 502 Sc
+{0 0.325 1 C} FS
+24 571 506 Sc
+{0 0.315 1 C} FS
+24 575 510 Sc
+{0 0.307 1 C} FS
+24 580 513 Sc
+{0 0.304 1 C} FS
+24 584 517 Sc
+{0 0.305 1 C} FS
+24 588 521 Sc
+{0 0.306 1 C} FS
+24 592 524 Sc
+{0 0.304 1 C} FS
+24 596 528 Sc
+{0 0.303 1 C} FS
+24 601 531 Sc
+{0 0.301 1 C} FS
+24 605 535 Sc
+{0 0.297 1 C} FS
+24 609 539 Sc
+{0 0.29 1 C} FS
+24 613 542 Sc
+{0 0.283 1 C} FS
+24 617 546 Sc
+{0 0.278 1 C} FS
+24 622 550 Sc
+{0 0.275 1 C} FS
+24 626 553 Sc
+{0 0.276 1 C} FS
+24 630 557 Sc
+{0 0.278 1 C} FS
+24 634 561 Sc
+{0 0.278 1 C} FS
+24 638 564 Sc
+{0 0.275 1 C} FS
+24 643 568 Sc
+{0 0.273 1 C} FS
+24 647 572 Sc
+{0 0.274 1 C} FS
+24 651 575 Sc
+{0 0.276 1 C} FS
+24 655 579 Sc
+{0 0.276 1 C} FS
+24 659 583 Sc
+{0 0.282 1 C} FS
+24 664 586 Sc
+{0 0.299 1 C} FS
+24 668 590 Sc
+{0 0.316 1 C} FS
+24 672 593 Sc
+{0 0.327 1 C} FS
+24 676 597 Sc
+{0 0.332 1 C} FS
+24 681 601 Sc
+{0 0.332 1 C} FS
+24 685 604 Sc
+{0 0.327 1 C} FS
+24 689 608 Sc
+{0 0.316 1 C} FS
+24 693 612 Sc
+{0 0.302 1 C} FS
+24 697 615 Sc
+{0 0.289 1 C} FS
+24 702 619 Sc
+{0 0.283 1 C} FS
+24 706 623 Sc
+{0 0.279 1 C} FS
+24 710 626 Sc
+{0 0.274 1 C} FS
+24 714 630 Sc
+{0 0.267 1 C} FS
+24 719 634 Sc
+{0 0.264 1 C} FS
+24 723 637 Sc
+{0 0.264 1 C} FS
+24 727 641 Sc
+{0 0.266 1 C} FS
+24 731 645 Sc
+{0 0.273 1 C} FS
+24 736 648 Sc
+{0 0.28 1 C} FS
+24 740 652 Sc
+{0 0.286 1 C} FS
+24 744 655 Sc
+{0 0.294 1 C} FS
+24 748 659 Sc
+{0 0.305 1 C} FS
+24 752 663 Sc
+{0 0.316 1 C} FS
+24 757 666 Sc
+{0 0.326 1 C} FS
+24 761 670 Sc
+{0 0.336 1 C} FS
+24 765 674 Sc
+{0 0.345 1 C} FS
+24 769 677 Sc
+{0 0.352 1 C} FS
+24 774 681 Sc
+{0 0.357 1 C} FS
+24 778 685 Sc
+{0 0.359 1 C} FS
+24 782 688 Sc
+{0 0.359 1 C} FS
+24 786 692 Sc
+{0 0.355 1 C} FS
+24 791 696 Sc
+{0 0.348 1 C} FS
+24 795 699 Sc
+{0 0.341 1 C} FS
+24 799 703 Sc
+{0 0.335 1 C} FS
+24 803 707 Sc
+{0 0.33 1 C} FS
+24 808 710 Sc
+{0 0.327 1 C} FS
+24 812 714 Sc
+{0 0.325 1 C} FS
+24 816 717 Sc
+{0 0.323 1 C} FS
+24 821 721 Sc
+{0 0.321 1 C} FS
+24 825 725 Sc
+{0 0.322 1 C} FS
+24 829 728 Sc
+{0 0.325 1 C} FS
+24 833 732 Sc
+{0 0.33 1 C} FS
+24 838 736 Sc
+{0 0.334 1 C} FS
+24 842 739 Sc
+{0 0.336 1 C} FS
+24 846 743 Sc
+{0 0.337 1 C} FS
+24 850 747 Sc
+{0 0.338 1 C} FS
+24 855 750 Sc
+{0 0.34 1 C} FS
+24 859 754 Sc
+{0 0.34 1 C} FS
+24 863 758 Sc
+{0 0.338 1 C} FS
+24 867 761 Sc
+{0 0.335 1 C} FS
+24 872 765 Sc
+{0 0.334 1 C} FS
+24 876 769 Sc
+{0 0.333 1 C} FS
+24 880 772 Sc
+{0 0.333 1 C} FS
+24 885 776 Sc
+{0 0.334 1 C} FS
+24 889 779 Sc
+{0 0.335 1 C} FS
+24 893 783 Sc
+{0 0.337 1 C} FS
+24 897 787 Sc
+{0 0.339 1 C} FS
+24 902 790 Sc
+{0 0.339 1 C} FS
+24 906 794 Sc
+{0 0.341 1 C} FS
+24 910 798 Sc
+{0 0.342 1 C} FS
+24 915 801 Sc
+{0 0.339 1 C} FS
+24 919 805 Sc
+{0 0.335 1 C} FS
+24 923 809 Sc
+{0 0.332 1 C} FS
+24 927 812 Sc
+{0 0.327 1 C} FS
+24 932 816 Sc
+{0 0.318 1 C} FS
+24 936 820 Sc
+{0 0.306 1 C} FS
+24 940 823 Sc
+{0 0.296 1 C} FS
+24 945 827 Sc
+{0 0.289 1 C} FS
+24 949 831 Sc
+{0 0.288 1 C} FS
+24 953 834 Sc
+{0 0.292 1 C} FS
+24 957 838 Sc
+{0 0.297 1 C} FS
+24 962 842 Sc
+{0 0.303 1 C} FS
+24 966 845 Sc
+{0 0.31 1 C} FS
+24 970 849 Sc
+{0 0.313 1 C} FS
+24 975 852 Sc
+{0 0.316 1 C} FS
+24 979 856 Sc
+{0 0.317 1 C} FS
+24 983 860 Sc
+{0 0.316 1 C} FS
+24 988 863 Sc
+{0 0.317 1 C} FS
+24 992 867 Sc
+{0 0.325 1 C} FS
+24 996 871 Sc
+{0 0.336 1 C} FS
+24 1001 874 Sc
+{0 0.345 1 C} FS
+24 1005 878 Sc
+{0 0.353 1 C} FS
+24 1009 882 Sc
+{0 0.365 1 C} FS
+24 1013 885 Sc
+{0 0.387 1 C} FS
+24 1018 889 Sc
+{0 0.417 1 C} FS
+24 1022 893 Sc
+{0 0.446 1 C} FS
+24 1026 896 Sc
+{0 0.472 1 C} FS
+24 1031 900 Sc
+{0 0.493 1 C} FS
+24 1035 904 Sc
+{0 0.509 1 C} FS
+24 1039 907 Sc
+{0 0.519 1 C} FS
+24 1044 911 Sc
+{0 0.523 1 C} FS
+24 1048 914 Sc
+{0 0.519 1 C} FS
+24 1052 918 Sc
+{0 0.508 1 C} FS
+24 1057 922 Sc
+{0 0.492 1 C} FS
+24 1061 925 Sc
+{0 0.472 1 C} FS
+24 1065 929 Sc
+{0 0.451 1 C} FS
+24 1070 933 Sc
+{0 0.431 1 C} FS
+24 1074 936 Sc
+{0 0.413 1 C} FS
+24 1078 940 Sc
+{0 0.409 1 C} FS
+24 1083 944 Sc
+{0 0.442 1 C} FS
+24 1087 947 Sc
+{0 0.46 1 C} FS
+24 1091 951 Sc
+{0 0.435 1 C} FS
+24 1096 955 Sc
+{0 0.417 1 C} FS
+24 1100 958 Sc
+{0 0.423 1 C} FS
+24 1104 962 Sc
+{0 0.438 1 C} FS
+24 1109 966 Sc
+{0 0.45 1 C} FS
+24 1113 969 Sc
+{0 0.462 1 C} FS
+24 1117 973 Sc
+{0 0.467 1 C} FS
+24 1122 976 Sc
+{0 0.464 1 C} FS
+24 1126 980 Sc
+{0 0.454 1 C} FS
+24 1130 984 Sc
+{0 0.435 1 C} FS
+24 1135 987 Sc
+{0 0.411 1 C} FS
+24 1139 991 Sc
+{0 0.382 1 C} FS
+24 1143 995 Sc
+{0 0.353 1 C} FS
+24 1148 998 Sc
+{0 0.324 1 C} FS
+24 1152 1002 Sc
+{0 0.304 1 C} FS
+24 1157 1006 Sc
+{0 0.295 1 C} FS
+24 1161 1009 Sc
+{0 0.293 1 C} FS
+24 1165 1013 Sc
+{0 0.297 1 C} FS
+24 1170 1017 Sc
+{0 0.307 1 C} FS
+24 1174 1020 Sc
+{0 0.322 1 C} FS
+24 1178 1024 Sc
+{0 0.339 1 C} FS
+24 1183 1028 Sc
+{0 0.353 1 C} FS
+24 1187 1031 Sc
+{0 0.361 1 C} FS
+24 1191 1035 Sc
+{0 0.361 1 C} FS
+24 1196 1038 Sc
+{0 0.351 1 C} FS
+24 1200 1042 Sc
+{0 0.332 1 C} FS
+24 1205 1046 Sc
+{0 0.306 1 C} FS
+24 1209 1049 Sc
+{0 0.287 1 C} FS
+24 1213 1053 Sc
+{0 0.273 1 C} FS
+24 1218 1057 Sc
+{0 0.254 1 C} FS
+24 1222 1060 Sc
+{0 0.232 1 C} FS
+24 1226 1064 Sc
+{0 0.217 1 C} FS
+24 1231 1068 Sc
+{0 0.21 1 C} FS
+24 1235 1071 Sc
+{0 0.207 1 C} FS
+24 1239 1075 Sc
+{0 0.207 1 C} FS
+24 1244 1079 Sc
+{0 0.209 1 C} FS
+24 1248 1082 Sc
+{0 0.205 1 C} FS
+24 1253 1086 Sc
+{0 0.188 1 C} FS
+24 1257 1090 Sc
+{0 0.163 1 C} FS
+24 1261 1093 Sc
+{0 0.149 1 C} FS
+24 1266 1097 Sc
+{0 0.152 1 C} FS
+24 1270 1100 Sc
+{0 0.156 1 C} FS
+24 1275 1104 Sc
+{0 0.15 1 C} FS
+24 1279 1108 Sc
+{0 0.123 1 C} FS
+24 1283 1111 Sc
+{0 0.0918 1 C} FS
+24 1288 1115 Sc
+{0 0.0943 1 C} FS
+24 1292 1119 Sc
+{0 0.154 1 C} FS
+24 1297 1122 Sc
+{0 0.256 1 C} FS
+24 1301 1126 Sc
+{0 0.354 1 C} FS
+24 1305 1130 Sc
+{0 0.379 1 C} FS
+24 1310 1133 Sc
+{0 0.343 1 C} FS
+24 1314 1137 Sc
+{0 0.301 1 C} FS
+24 1318 1141 Sc
+{0 0.261 1 C} FS
+24 1323 1144 Sc
+{0 0.235 1 C} FS
+24 1327 1148 Sc
+{0 0.222 1 C} FS
+24 1332 1151 Sc
+{0 0.221 1 C} FS
+24 1336 1155 Sc
+{0 0.229 1 C} FS
+24 1341 1159 Sc
+{0 0.239 1 C} FS
+24 1345 1162 Sc
+{0 0.246 1 C} FS
+24 1349 1166 Sc
+{0 0.247 1 C} FS
+24 1354 1170 Sc
+{0 0.246 1 C} FS
+24 1358 1173 Sc
+{0 0.246 1 C} FS
+24 1363 1177 Sc
+{0 0.241 1 C} FS
+24 1367 1181 Sc
+{0 0.234 1 C} FS
+24 1371 1184 Sc
+{0 0.225 1 C} FS
+24 1376 1188 Sc
+{0 0.215 1 C} FS
+24 1380 1192 Sc
+{0 0.205 1 C} FS
+24 1385 1195 Sc
+{0 0.196 1 C} FS
+24 1389 1199 Sc
+{0 0.192 1 C} FS
+24 1393 1203 Sc
+{0 0.192 1 C} FS
+24 1398 1206 Sc
+{0 0.193 1 C} FS
+24 1402 1210 Sc
+{0 0.198 1 C} FS
+24 1407 1213 Sc
+{0 0.214 1 C} FS
+24 1411 1217 Sc
+{0 0.241 1 C} FS
+24 1416 1221 Sc
+{0 0.274 1 C} FS
+24 1420 1224 Sc
+{0 0.304 1 C} FS
+24 1424 1228 Sc
+{0 0.329 1 C} FS
+24 1429 1232 Sc
+{0 0.347 1 C} FS
+24 1433 1235 Sc
+{0 0.356 1 C} FS
+24 1438 1239 Sc
+{0 0.356 1 C} FS
+24 1442 1243 Sc
+{0 0.348 1 C} FS
+24 1447 1246 Sc
+{0 0.334 1 C} FS
+24 1451 1250 Sc
+{0 0.315 1 C} FS
+24 1455 1254 Sc
+{0 0.293 1 C} FS
+24 1460 1257 Sc
+{0 0.269 1 C} FS
+24 1464 1261 Sc
+{0 0.248 1 C} FS
+24 1469 1264 Sc
+{0 0.23 1 C} FS
+24 1473 1268 Sc
+{0 0.213 1 C} FS
+24 1478 1272 Sc
+{0 0.201 1 C} FS
+24 1482 1275 Sc
+{0 0.191 1 C} FS
+24 1487 1279 Sc
+{0 0.183 1 C} FS
+24 1491 1283 Sc
+{0 0.177 1 C} FS
+24 1495 1286 Sc
+{0 0.173 1 C} FS
+24 1500 1290 Sc
+{0 0.168 1 C} FS
+24 1504 1294 Sc
+{0 0.162 1 C} FS
+24 1509 1297 Sc
+{0 0.154 1 C} FS
+24 1513 1301 Sc
+{0 0.143 1 C} FS
+24 1518 1305 Sc
+{0 0.135 1 C} FS
+24 1522 1308 Sc
+{0 0.128 1 C} FS
+24 1527 1312 Sc
+{0 0.111 1 C} FS
+24 1531 1315 Sc
+{0 0.0942 1 C} FS
+24 1536 1319 Sc
+{0 0.0787 1 C} FS
+24 1540 1323 Sc
+{0 0.058 1 C} FS
+24 1544 1326 Sc
+{0 0.0297 1 C} FS
+24 1549 1330 Sc
+{8.42e-06 0 1 C} FS
+24 1553 1334 Sc
+{0.026 0 1 C} FS
+24 1558 1337 Sc
+{0.0491 0 1 C} FS
+24 1562 1341 Sc
+{0.0692 0 1 C} FS
+24 1567 1345 Sc
+{0.0859 0 1 C} FS
+24 1571 1348 Sc
+{0.0981 0 1 C} FS
+24 1576 1352 Sc
+{0.106 0 1 C} FS
+24 1580 1355 Sc
+{0.111 0 1 C} FS
+24 1585 1359 Sc
+{0.111 0 1 C} FS
+24 1589 1363 Sc
+{0.107 0 1 C} FS
+24 1594 1366 Sc
+{0.103 0 1 C} FS
+24 1598 1370 Sc
+{0.102 0 1 C} FS
+24 1603 1374 Sc
+{0.101 0 1 C} FS
+24 1607 1377 Sc
+{0.101 0 1 C} FS
+24 1612 1381 Sc
+{0.106 0 1 C} FS
+24 1616 1385 Sc
+{0.113 0 1 C} FS
+24 1620 1388 Sc
+{0.124 0 1 C} FS
+24 1625 1392 Sc
+{0.137 0 1 C} FS
+24 1629 1396 Sc
+{0.15 0 1 C} FS
+24 1634 1399 Sc
+{0.166 0 1 C} FS
+24 1638 1403 Sc
+{0.182 0 1 C} FS
+24 1643 1406 Sc
+{0.197 0 1 C} FS
+24 1647 1410 Sc
+{0.212 0 1 C} FS
+24 1652 1414 Sc
+{0.226 0 1 C} FS
+24 1656 1417 Sc
+{0.236 0 1 C} FS
+24 1661 1421 Sc
+{0.241 0 1 C} FS
+24 1665 1425 Sc
+{0.239 0 1 C} FS
+24 1670 1428 Sc
+{0.226 0 1 C} FS
+24 1674 1432 Sc
+{0.2 0 1 C} FS
+24 1679 1436 Sc
+{0.161 0 1 C} FS
+24 1683 1439 Sc
+{0.111 0 1 C} FS
+24 1688 1443 Sc
+{0.0504 0 1 C} FS
+24 1692 1446 Sc
+{0 0.0156 1 C} FS
+24 1697 1450 Sc
+{0 0.0741 1 C} FS
+24 1701 1454 Sc
+{0 0.123 1 C} FS
+24 1706 1457 Sc
+{0 0.182 1 C} FS
+24 1710 1461 Sc
+{0 0.249 1 C} FS
+24 1715 1465 Sc
+{0 0.303 1 C} FS
+24 1719 1468 Sc
+{0 0.347 1 C} FS
+24 1724 1472 Sc
+{0 0.386 1 C} FS
+24 1728 1476 Sc
+{0 0.42 1 C} FS
+24 1733 1479 Sc
+{0 0.449 1 C} FS
+24 1737 1483 Sc
+{0 0.477 1 C} FS
+24 1742 1486 Sc
+{0 0.504 1 C} FS
+24 1746 1490 Sc
+{0 0.531 1 C} FS
+24 1751 1494 Sc
+{0 0.559 1 C} FS
+24 1755 1497 Sc
+{0 0.586 1 C} FS
+24 1760 1501 Sc
+{0 0.614 1 C} FS
+24 1765 1505 Sc
+{0 0.643 1 C} FS
+24 1769 1508 Sc
+{0 0.67 1 C} FS
+24 1774 1512 Sc
+{0 0.695 1 C} FS
+24 1778 1516 Sc
+{0 0.72 1 C} FS
+24 1783 1519 Sc
+{0 0.742 1 C} FS
+24 1787 1523 Sc
+{0 0.763 1 C} FS
+24 1792 1526 Sc
+{0 0.784 1 C} FS
+24 1796 1530 Sc
+{0 0.807 1 C} FS
+24 1801 1534 Sc
+{0 0.832 1 C} FS
+24 1805 1537 Sc
+{0 0.859 1 C} FS
+24 1810 1541 Sc
+{0 0.892 1 C} FS
+24 1814 1545 Sc
+{0 0.926 1 C} FS
+24 1819 1548 Sc
+{0 0.961 1 C} FS
+24 1823 1552 Sc
+{0 0.997 1 C} FS
+24 1828 1556 Sc
+{0 1 0.972 C} FS
+24 1832 1559 Sc
+{0 1 0.95 C} FS
+24 1837 1563 Sc
+{0 1 0.938 C} FS
+24 1842 1566 Sc
+{0 1 0.939 C} FS
+24 1846 1570 Sc
+{0 1 0.958 C} FS
+24 1851 1574 Sc
+{0 1 0.991 C} FS
+24 1855 1577 Sc
+{0 0.959 1 C} FS
+24 1860 1581 Sc
+{0 0.896 1 C} FS
+24 1864 1585 Sc
+{0 0.818 1 C} FS
+24 1869 1588 Sc
+{0 0.728 1 C} FS
+24 1873 1592 Sc
+{0 0.63 1 C} FS
+24 1878 1595 Sc
+{0 0.525 1 C} FS
+24 1882 1599 Sc
+{0 0.424 1 C} FS
+24 1887 1603 Sc
+{0 0.323 1 C} FS
+24 1892 1606 Sc
+{0 0.211 1 C} FS
+24 1896 1610 Sc
+{0 0.0941 1 C} FS
+24 1901 1614 Sc
+{0.0138 0 1 C} FS
+24 1905 1617 Sc
+{0.108 0 1 C} FS
+24 1910 1621 Sc
+{0.191 0 1 C} FS
+24 1914 1625 Sc
+{0.258 0 1 C} FS
+24 1919 1628 Sc
+{0.306 0 1 C} FS
+24 1923 1632 Sc
+{0.337 0 1 C} FS
+24 1928 1635 Sc
+{0.348 0 1 C} FS
+24 1933 1639 Sc
+{0.34 0 1 C} FS
+24 1937 1643 Sc
+{0.314 0 1 C} FS
+24 1942 1646 Sc
+{0.271 0 1 C} FS
+24 1946 1650 Sc
+{0.22 0 1 C} FS
+24 1951 1654 Sc
+{0.158 0 1 C} FS
+24 1955 1657 Sc
+{0.0837 0 1 C} FS
+24 1960 1661 Sc
+{0.00272 0 1 C} FS
+24 1965 1664 Sc
+{0 0.0964 1 C} FS
+24 1969 1668 Sc
+{0 0.216 1 C} FS
+24 1974 1672 Sc
+{0 0.297 1 C} FS
+24 1978 1675 Sc
+{0 0.319 1 C} FS
+24 1983 1679 Sc
+{0 0.333 1 C} FS
+24 1988 1683 Sc
+{0 0.345 1 C} FS
+24 1992 1686 Sc
+{0 0.362 1 C} FS
+24 1997 1690 Sc
+{0 0.4 1 C} FS
+24 2001 1693 Sc
+{0 0.461 1 C} FS
+24 2006 1697 Sc
+{0 0.53 1 C} FS
+24 2010 1701 Sc
+{0 0.598 1 C} FS
+24 2015 1704 Sc
+{0 0.664 1 C} FS
+24 2020 1708 Sc
+{0 0.724 1 C} FS
+24 2024 1712 Sc
+{0 0.776 1 C} FS
+24 2029 1715 Sc
+{0 0.815 1 C} FS
+24 2033 1719 Sc
+{0 0.839 1 C} FS
+24 2038 1722 Sc
+{0 0.847 1 C} FS
+24 2043 1726 Sc
+{0 0.835 1 C} FS
+24 2047 1730 Sc
+{0 0.806 1 C} FS
+24 2052 1733 Sc
+{0 0.763 1 C} FS
+24 2056 1737 Sc
+{0 0.705 1 C} FS
+24 2061 1741 Sc
+{0 0.634 1 C} FS
+24 2066 1744 Sc
+{0 0.564 1 C} FS
+24 2070 1748 Sc
+{0 0.502 1 C} FS
+24 2075 1752 Sc
+{0 0.446 1 C} FS
+24 2079 1755 Sc
+{0 0.398 1 C} FS
+24 2084 1759 Sc
+{0 0.36 1 C} FS
+24 2089 1762 Sc
+{0 0.33 1 C} FS
+24 2093 1766 Sc
+{0 0.315 1 C} FS
+24 2098 1770 Sc
+{0 0.322 1 C} FS
+24 2102 1773 Sc
+{0 0.343 1 C} FS
+24 2107 1777 Sc
+{0 0.365 1 C} FS
+24 2112 1780 Sc
+{0 0.378 1 C} FS
+24 2116 1784 Sc
+{0 0.386 1 C} FS
+24 2121 1788 Sc
+{0 0.398 1 C} FS
+24 2125 1791 Sc
+{0 0.411 1 C} FS
+24 2130 1795 Sc
+{0 0.413 1 C} FS
+24 2135 1799 Sc
+{0 0.408 1 C} FS
+24 2139 1802 Sc
+{0 0.425 1 C} FS
+24 2144 1806 Sc
+{0 0.476 1 C} FS
+24 2149 1809 Sc
+{0 0.531 1 C} FS
+24 2153 1813 Sc
+{0 0.562 1 C} FS
+24 2158 1817 Sc
+{0 0.553 1 C} FS
+24 2162 1820 Sc
+{0 0.489 1 C} FS
+24 2167 1824 Sc
+{0 0.407 1 C} FS
+24 2172 1828 Sc
+{0 0.35 1 C} FS
+24 2176 1831 Sc
+{0 0.313 1 C} FS
+24 2181 1835 Sc
+{0 0.283 1 C} FS
+24 2186 1838 Sc
+{0 0.254 1 C} FS
+24 2190 1842 Sc
+{0 0.229 1 C} FS
+24 2195 1846 Sc
+{0 0.221 1 C} FS
+24 2200 1849 Sc
+{0 0.231 1 C} FS
+24 2204 1853 Sc
+{0 0.247 1 C} FS
+24 2209 1857 Sc
+{0 0.262 1 C} FS
+24 2213 1860 Sc
+{0 0.27 1 C} FS
+24 2218 1864 Sc
+{0 0.271 1 C} FS
+24 2223 1867 Sc
+{0 0.267 1 C} FS
+24 2227 1871 Sc
+{0 0.262 1 C} FS
+24 2232 1875 Sc
+{0 0.257 1 C} FS
+24 2237 1878 Sc
+{0 0.246 1 C} FS
+24 2241 1882 Sc
+{0 0.226 1 C} FS
+24 2246 1885 Sc
+{0 0.199 1 C} FS
+24 2251 1889 Sc
+{0 0.166 1 C} FS
+24 2255 1893 Sc
+{0 0.134 1 C} FS
+24 2260 1896 Sc
+{0 0.108 1 C} FS
+24 2265 1900 Sc
+{0 0.0889 1 C} FS
+24 2269 1904 Sc
+{0 0.0758 1 C} FS
+24 2274 1907 Sc
+{0 0.0677 1 C} FS
+24 2279 1911 Sc
+{0 0.0639 1 C} FS
+24 2283 1914 Sc
+{0 0.0625 1 C} FS
+24 2288 1918 Sc
+{0 0.0631 1 C} FS
+24 2292 1922 Sc
+{0 0.0654 1 C} FS
+24 2297 1925 Sc
+{0 0.0709 1 C} FS
+24 2302 1929 Sc
+{0 0.0805 1 C} FS
+24 2306 1932 Sc
+{0 0.0943 1 C} FS
+24 2311 1936 Sc
+{0 0.116 1 C} FS
+24 2316 1940 Sc
+{0 0.145 1 C} FS
+24 2320 1943 Sc
+{0 0.176 1 C} FS
+24 2325 1947 Sc
+{0 0.198 1 C} FS
+24 2330 1951 Sc
+{0 0.201 1 C} FS
+24 2334 1954 Sc
+{0 0.195 1 C} FS
+24 2339 1958 Sc
+{0 0.182 1 C} FS
+24 2344 1961 Sc
+{0 0.186 1 C} FS
+24 2348 1965 Sc
+{0 0.226 1 C} FS
+24 2353 1969 Sc
+{0 0.274 1 C} FS
+24 2358 1972 Sc
+{0 0.304 1 C} FS
+24 2363 1976 Sc
+{0 0.321 1 C} FS
+24 2367 1979 Sc
+{0 0.329 1 C} FS
+24 2372 1983 Sc
+{0 0.338 1 C} FS
+24 2377 1987 Sc
+{0 0.349 1 C} FS
+24 2381 1990 Sc
+{0 0.365 1 C} FS
+24 2386 1994 Sc
+{0 0.39 1 C} FS
+24 2391 1998 Sc
+{0 0.42 1 C} FS
+24 2395 2001 Sc
+{0 0.454 1 C} FS
+24 2400 2005 Sc
+{0 0.487 1 C} FS
+24 2405 2008 Sc
+{0 0.516 1 C} FS
+24 2409 2012 Sc
+{0 0.543 1 C} FS
+24 2414 2016 Sc
+{0 0.562 1 C} FS
+24 2419 2019 Sc
+{0 0.537 1 C} FS
+24 2423 2023 Sc
+{0 0.471 1 C} FS
+24 2428 2026 Sc
+{0 0.413 1 C} FS
+24 2433 2030 Sc
+{0 0.4 1 C} FS
+24 2438 2034 Sc
+{0 0.404 1 C} FS
+24 2442 2037 Sc
+{0 0.359 1 C} FS
+24 2447 2041 Sc
+{0 0.287 1 C} FS
+24 2452 2044 Sc
+{0 0.225 1 C} FS
+24 2456 2048 Sc
+{0 0.178 1 C} FS
+24 2461 2052 Sc
+{0 0.149 1 C} FS
+24 2466 2055 Sc
+{0 0.151 1 C} FS
+24 2470 2059 Sc
+{0 0.168 1 C} FS
+24 2475 2062 Sc
+{0 0.164 1 C} FS
+24 2480 2066 Sc
+{0 0.155 1 C} FS
+24 2485 2070 Sc
+{0 0.16 1 C} FS
+24 2489 2073 Sc
+{0 0.151 1 C} FS
+24 2494 2077 Sc
+{0 0.13 1 C} FS
+24 2499 2080 Sc
+{0 0.111 1 C} FS
+24 2503 2084 Sc
+{0 0.0861 1 C} FS
+24 2508 2088 Sc
+{0 0.0508 1 C} FS
+24 2513 2091 Sc
+{0 0.0143 1 C} FS
+24 2518 2095 Sc
+{0.0217 0 1 C} FS
+24 2522 2099 Sc
+{0.0592 0 1 C} FS
+24 2527 2102 Sc
+{0.0969 0 1 C} FS
+24 2532 2106 Sc
+{0.132 0 1 C} FS
+24 2537 2109 Sc
+{0.164 0 1 C} FS
+24 2541 2113 Sc
+{0.19 0 1 C} FS
+24 2546 2117 Sc
+{0.211 0 1 C} FS
+24 2551 2120 Sc
+{0.225 0 1 C} FS
+24 2555 2124 Sc
+{0.233 0 1 C} FS
+24 2560 2127 Sc
+{0.233 0 1 C} FS
+24 2565 2131 Sc
+{0.225 0 1 C} FS
+24 2570 2135 Sc
+{0.209 0 1 C} FS
+24 2574 2138 Sc
+{0.187 0 1 C} FS
+24 2579 2142 Sc
+{0.161 0 1 C} FS
+24 2584 2145 Sc
+{0.132 0 1 C} FS
+24 2589 2149 Sc
+{0.0985 0 1 C} FS
+24 2593 2153 Sc
+{0.0647 0 1 C} FS
+24 2598 2156 Sc
+{0.0264 0 1 C} FS
+24 2603 2160 Sc
+{0 0.0216 1 C} FS
+24 2608 2163 Sc
+{0 0.0807 1 C} FS
+24 2612 2167 Sc
+{0 0.146 1 C} FS
+24 2617 2171 Sc
+{0 0.22 1 C} FS
+24 2622 2174 Sc
+{0 0.32 1 C} FS
+24 2626 2178 Sc
+{0 0.425 1 C} FS
+24 2631 2181 Sc
+{0 0.464 1 C} FS
+24 2636 2185 Sc
+{0 0.476 1 C} FS
+24 2641 2189 Sc
+{0 0.513 1 C} FS
+24 2645 2192 Sc
+{0 0.552 1 C} FS
+24 2650 2196 Sc
+{0 0.579 1 C} FS
+24 2655 2199 Sc
+{0 0.593 1 C} FS
+24 2660 2203 Sc
+{0 0.587 1 C} FS
+24 2665 2206 Sc
+{0 0.565 1 C} FS
+24 2669 2210 Sc
+{0 0.529 1 C} FS
+24 2674 2214 Sc
+{0 0.492 1 C} FS
+24 2679 2217 Sc
+{0 0.488 1 C} FS
+24 2684 2221 Sc
+{0 0.483 1 C} FS
+24 2688 2224 Sc
+{0 0.457 1 C} FS
+24 2693 2228 Sc
+{0 0.44 1 C} FS
+24 2698 2232 Sc
+{0 0.432 1 C} FS
+24 2703 2235 Sc
+{0 0.428 1 C} FS
+24 2707 2239 Sc
+{0 0.433 1 C} FS
+24 2712 2242 Sc
+{0 0.445 1 C} FS
+24 2717 2246 Sc
+{0 0.465 1 C} FS
+24 2722 2250 Sc
+{0 0.498 1 C} FS
+24 2726 2253 Sc
+{0 0.543 1 C} FS
+24 2731 2257 Sc
+{0 0.593 1 C} FS
+24 2736 2260 Sc
+{0 0.636 1 C} FS
+24 2741 2264 Sc
+{0 0.657 1 C} FS
+24 2746 2268 Sc
+{0 0.638 1 C} FS
+24 2750 2271 Sc
+{0 0.611 1 C} FS
+24 2755 2275 Sc
+{0 0.613 1 C} FS
+24 2760 2278 Sc
+{0 0.601 1 C} FS
+24 2765 2282 Sc
+{0 0.569 1 C} FS
+24 2769 2286 Sc
+{0 0.532 1 C} FS
+24 2774 2289 Sc
+{0 0.495 1 C} FS
+24 2779 2293 Sc
+{0 0.46 1 C} FS
+24 2784 2296 Sc
+{0 0.433 1 C} FS
+24 2789 2300 Sc
+{0 0.419 1 C} FS
+24 2793 2303 Sc
+{0 0.41 1 C} FS
+24 2798 2307 Sc
+{0 0.401 1 C} FS
+24 2803 2311 Sc
+{0 0.393 1 C} FS
+24 2808 2314 Sc
+{0 0.392 1 C} FS
+24 2813 2318 Sc
+{0 0.396 1 C} FS
+24 2817 2321 Sc
+{0 0.398 1 C} FS
+24 2822 2325 Sc
+{0 0.404 1 C} FS
+24 2827 2329 Sc
+{0 0.414 1 C} FS
+24 2832 2332 Sc
+{0 0.424 1 C} FS
+24 2837 2336 Sc
+{0 0.432 1 C} FS
+24 2841 2339 Sc
+{0 0.432 1 C} FS
+24 2846 2343 Sc
+{0 0.433 1 C} FS
+24 2851 2346 Sc
+{0 0.447 1 C} FS
+24 2856 2350 Sc
+{0 0.469 1 C} FS
+24 2861 2354 Sc
+{0 0.484 1 C} FS
+24 2865 2357 Sc
+{0 0.491 1 C} FS
+24 2870 2361 Sc
+{0 0.499 1 C} FS
+24 2875 2364 Sc
+{0 0.51 1 C} FS
+24 2880 2368 Sc
+{0 0.518 1 C} FS
+24 2885 2372 Sc
+{0 0.52 1 C} FS
+24 2889 2375 Sc
+{0 0.519 1 C} FS
+24 2894 2379 Sc
+{0 0.515 1 C} FS
+24 2899 2382 Sc
+{0 0.514 1 C} FS
+24 2904 2386 Sc
+{0 0.522 1 C} FS
+24 2909 2389 Sc
+{0 0.546 1 C} FS
+24 2914 2393 Sc
+{0 0.563 1 C} FS
+24 2918 2397 Sc
+{0 0.528 1 C} FS
+24 2923 2400 Sc
+{0 0.463 1 C} FS
+24 2928 2404 Sc
+{0 0.41 1 C} FS
+24 2933 2407 Sc
+{0 0.367 1 C} FS
+24 2938 2411 Sc
+{0 0.339 1 C} FS
+24 2942 2415 Sc
+{0 0.333 1 C} FS
+24 2947 2418 Sc
+{0 0.341 1 C} FS
+24 2952 2422 Sc
+{0 0.356 1 C} FS
+24 2957 2425 Sc
+{0 0.376 1 C} FS
+24 2962 2429 Sc
+{0 0.405 1 C} FS
+24 2967 2432 Sc
+{0 0.438 1 C} FS
+24 2971 2436 Sc
+{0 0.473 1 C} FS
+24 2976 2440 Sc
+{0 0.505 1 C} FS
+24 2981 2443 Sc
+{0 0.544 1 C} FS
+24 2986 2447 Sc
+{0 0.584 1 C} FS
+24 2991 2450 Sc
+{0 0.569 1 C} FS
+24 2996 2454 Sc
+{0 0.485 1 C} FS
+24 3001 2457 Sc
+{0 0.424 1 C} FS
+24 3005 2461 Sc
+{0 0.416 1 C} FS
+24 3010 2465 Sc
+{0 0.438 1 C} FS
+24 3015 2468 Sc
+{0 0.467 1 C} FS
+24 3020 2472 Sc
+{0 0.488 1 C} FS
+24 3025 2475 Sc
+{0 0.491 1 C} FS
+24 3030 2479 Sc
+{0 0.489 1 C} FS
+24 3034 2482 Sc
+{0 0.487 1 C} FS
+24 3039 2486 Sc
+{0 0.483 1 C} FS
+24 3044 2490 Sc
+{0 0.477 1 C} FS
+24 3049 2493 Sc
+{0 0.468 1 C} FS
+24 3054 2497 Sc
+{0 0.459 1 C} FS
+24 3059 2500 Sc
+{0 0.453 1 C} FS
+24 3064 2504 Sc
+{0 0.455 1 C} FS
+24 3068 2507 Sc
+{0 0.47 1 C} FS
+24 3073 2511 Sc
+{0 0.504 1 C} FS
+24 3078 2515 Sc
+{0 0.547 1 C} FS
+24 3083 2518 Sc
+{0 0.566 1 C} FS
+24 3088 2522 Sc
+{0 0.569 1 C} FS
+24 3093 2525 Sc
+{0 0.57 1 C} FS
+24 3098 2529 Sc
+{0 0.564 1 C} FS
+24 3102 2532 Sc
+{0 0.561 1 C} FS
+24 3107 2536 Sc
+{0 0.572 1 C} FS
+24 3112 2540 Sc
+{0 0.593 1 C} FS
+24 3117 2543 Sc
+{0 0.619 1 C} FS
+24 3122 2547 Sc
+{0 0.65 1 C} FS
+24 3127 2550 Sc
+{0 0.681 1 C} FS
+24 3132 2554 Sc
+{0 0.708 1 C} FS
+24 3137 2557 Sc
+{0 0.73 1 C} FS
+24 3141 2561 Sc
+{0 0.742 1 C} FS
+24 3146 2564 Sc
+{0 0.741 1 C} FS
+24 3151 2568 Sc
+{0 0.728 1 C} FS
+24 3156 2572 Sc
+{0 0.702 1 C} FS
+24 3161 2575 Sc
+{0 0.665 1 C} FS
+24 3166 2579 Sc
+{0 0.624 1 C} FS
+24 3171 2582 Sc
+{0 0.583 1 C} FS
+24 3176 2586 Sc
+{0 0.541 1 C} FS
+24 3181 2589 Sc
+{0 0.494 1 C} FS
+24 3185 2593 Sc
+{0 0.439 1 C} FS
+24 3190 2597 Sc
+{0 0.39 1 C} FS
+24 3195 2600 Sc
+{0 0.355 1 C} FS
+24 3200 2604 Sc
+{0 0.33 1 C} FS
+24 3205 2607 Sc
+{0 0.293 1 C} FS
+24 3210 2611 Sc
+{0 0.236 1 C} FS
+24 3215 2614 Sc
+{0 0.176 1 C} FS
+24 3220 2618 Sc
+{0 0.143 1 C} FS
+24 3225 2621 Sc
+{0 0.141 1 C} FS
+24 3229 2625 Sc
+{0 0.188 1 C} FS
+24 3234 2629 Sc
+{0 0.293 1 C} FS
+24 3239 2632 Sc
+{0 0.423 1 C} FS
+24 3244 2636 Sc
+{0 0.557 1 C} FS
+24 3249 2639 Sc
+{0 0.713 1 C} FS
+24 3254 2643 Sc
+{0 0.881 1 C} FS
+24 3259 2646 Sc
+{0 1 0.953 C} FS
+24 3264 2650 Sc
+{0 1 0.875 C} FS
+24 3269 2653 Sc
+{0 1 0.906 C} FS
+24 3274 2657 Sc
+{0 1 0.985 C} FS
+24 3279 2661 Sc
+{0 0.944 1 C} FS
+24 3283 2664 Sc
+{0 0.88 1 C} FS
+24 3288 2668 Sc
+{0 0.819 1 C} FS
+24 3293 2671 Sc
+{0 0.761 1 C} FS
+24 3298 2675 Sc
+{0 0.702 1 C} FS
+24 3303 2678 Sc
+{0 0.644 1 C} FS
+24 3308 2682 Sc
+{0 0.581 1 C} FS
+24 3313 2685 Sc
+{0 0.518 1 C} FS
+24 3318 2689 Sc
+{0 0.455 1 C} FS
+24 3323 2692 Sc
+{0 0.399 1 C} FS
+24 3328 2696 Sc
+{0 0.372 1 C} FS
+24 3333 2700 Sc
+{0 0.375 1 C} FS
+24 3338 2703 Sc
+{0 0.385 1 C} FS
+24 3342 2707 Sc
+{0 0.394 1 C} FS
+24 3347 2710 Sc
+{0 0.409 1 C} FS
+24 3352 2714 Sc
+{0 0.432 1 C} FS
+24 3357 2717 Sc
+{0 0.46 1 C} FS
+24 3362 2721 Sc
+{0 0.489 1 C} FS
+24 3367 2724 Sc
+{0 0.52 1 C} FS
+24 3372 2728 Sc
+{0 0.551 1 C} FS
+24 3377 2731 Sc
+{0 0.582 1 C} FS
+24 3382 2735 Sc
+{0 0.607 1 C} FS
+24 3387 2739 Sc
+{0 0.625 1 C} FS
+24 3392 2742 Sc
+{0 0.635 1 C} FS
+24 3397 2746 Sc
+{0 0.637 1 C} FS
+24 3402 2749 Sc
+{0 0.629 1 C} FS
+24 3407 2753 Sc
+{0 0.612 1 C} FS
+24 3412 2756 Sc
+{0 0.586 1 C} FS
+24 3417 2760 Sc
+{0 0.554 1 C} FS
+24 3421 2763 Sc
+{0 0.526 1 C} FS
+24 3426 2767 Sc
+{0 0.508 1 C} FS
+24 3431 2770 Sc
+{0 0.492 1 C} FS
+24 3436 2774 Sc
+{0 0.473 1 C} FS
+24 3441 2778 Sc
+{0 0.451 1 C} FS
+24 3446 2781 Sc
+{0 0.437 1 C} FS
+24 3451 2785 Sc
+{0 0.433 1 C} FS
+24 3456 2788 Sc
+{0 0.437 1 C} FS
+24 3461 2792 Sc
+{0 0.447 1 C} FS
+24 3466 2795 Sc
+{0 0.457 1 C} FS
+24 3471 2799 Sc
+{0 0.466 1 C} FS
+24 3476 2802 Sc
+{0 0.476 1 C} FS
+24 3481 2806 Sc
+{0 0.482 1 C} FS
+24 3486 2809 Sc
+{0 0.48 1 C} FS
+24 3491 2813 Sc
+{0 0.473 1 C} FS
+24 3496 2816 Sc
+{0 0.461 1 C} FS
+24 3501 2820 Sc
+{0 0.447 1 C} FS
+24 3506 2823 Sc
+{0 0.428 1 C} FS
+24 3511 2827 Sc
+{0 0.408 1 C} FS
+24 3516 2831 Sc
+{0 0.388 1 C} FS
+24 3521 2834 Sc
+{0 0.368 1 C} FS
+24 3526 2838 Sc
+{0 0.356 1 C} FS
+24 3531 2841 Sc
+{0 0.353 1 C} FS
+24 3536 2845 Sc
+{0 0.35 1 C} FS
+24 3541 2848 Sc
+{0 0.346 1 C} FS
+24 3546 2852 Sc
+{0 0.337 1 C} FS
+24 3550 2855 Sc
+{0 0.335 1 C} FS
+24 3555 2859 Sc
+{0 0.385 1 C} FS
+24 3560 2862 Sc
+{0 0.49 1 C} FS
+24 3565 2866 Sc
+{0 0.587 1 C} FS
+24 3570 2869 Sc
+{0 0.644 1 C} FS
+24 3575 2873 Sc
+{0 0.671 1 C} FS
+24 3580 2876 Sc
+{0 0.684 1 C} FS
+24 3585 2880 Sc
+{0 0.698 1 C} FS
+24 3590 2884 Sc
+{0 0.664 1 C} FS
+24 3595 2887 Sc
+{0 0.591 1 C} FS
+24 3600 2891 Sc
+{0 0.568 1 C} FS
+24 3605 2894 Sc
+{0 0.567 1 C} FS
+24 3610 2898 Sc
+{0 0.546 1 C} FS
+24 3615 2901 Sc
+{0 0.528 1 C} FS
+24 3620 2905 Sc
+{0 0.559 1 C} FS
+24 3625 2908 Sc
+{0 0.587 1 C} FS
+24 3630 2912 Sc
+{0 0.571 1 C} FS
+24 3635 2915 Sc
+{0 0.541 1 C} FS
+24 3640 2919 Sc
+{0 0.505 1 C} FS
+24 3645 2922 Sc
+{0 0.466 1 C} FS
+24 3650 2926 Sc
+{0 0.439 1 C} FS
+24 3655 2929 Sc
+{0 0.425 1 C} FS
+24 3660 2933 Sc
+{0 0.421 1 C} FS
+24 3665 2936 Sc
+{0 0.423 1 C} FS
+24 3670 2940 Sc
+{0 0.432 1 C} FS
+24 3675 2943 Sc
+{0 0.444 1 C} FS
+24 3680 2947 Sc
+{0 0.458 1 C} FS
+24 3685 2950 Sc
+{0 0.465 1 C} FS
+24 3690 2954 Sc
+{0 0.464 1 C} FS
+24 3695 2957 Sc
+{0 0.461 1 C} FS
+24 3700 2961 Sc
+{0 0.458 1 C} FS
+24 3705 2964 Sc
+{0 0.456 1 C} FS
+24 3710 2968 Sc
+{0 0.453 1 C} FS
+24 3715 2972 Sc
+{0 0.45 1 C} FS
+24 3720 2975 Sc
+{0 0.447 1 C} FS
+24 3725 2979 Sc
+{0 0.446 1 C} FS
+24 3730 2982 Sc
+{0 0.446 1 C} FS
+24 3736 2986 Sc
+{0 0.452 1 C} FS
+24 3741 2989 Sc
+{0 0.461 1 C} FS
+24 3746 2993 Sc
+{0 0.467 1 C} FS
+24 3751 2996 Sc
+{0 0.472 1 C} FS
+24 3756 3000 Sc
+{0 0.476 1 C} FS
+24 3761 3003 Sc
+{0 0.481 1 C} FS
+24 3766 3007 Sc
+{0 0.485 1 C} FS
+24 3771 3010 Sc
+{0 0.487 1 C} FS
+24 3776 3014 Sc
+{0 0.486 1 C} FS
+24 3781 3017 Sc
+{0 0.483 1 C} FS
+24 3786 3021 Sc
+{0 0.48 1 C} FS
+24 3791 3024 Sc
+{0 0.477 1 C} FS
+24 3796 3028 Sc
+{0 0.471 1 C} FS
+24 3801 3031 Sc
+{0 0.461 1 C} FS
+24 3806 3035 Sc
+{0 0.451 1 C} FS
+24 3811 3038 Sc
+{0 0.446 1 C} FS
+24 3816 3042 Sc
+{0 0.445 1 C} FS
+24 3821 3045 Sc
+{0 0.446 1 C} FS
+24 3826 3049 Sc
+{0 0.45 1 C} FS
+24 3831 3052 Sc
+{0 0.455 1 C} FS
+24 3836 3056 Sc
+{0 0.461 1 C} FS
+24 3841 3059 Sc
+{0 0.468 1 C} FS
+24 3846 3063 Sc
+{0 0.476 1 C} FS
+24 3851 3066 Sc
+{0 0.484 1 C} FS
+24 3856 3070 Sc
+{0 0.489 1 C} FS
+24 3861 3073 Sc
+{0 0.491 1 C} FS
+24 3867 3077 Sc
+{0 0.492 1 C} FS
+24 3872 3080 Sc
+{0 0.496 1 C} FS
+24 3877 3084 Sc
+{0 0.502 1 C} FS
+24 3882 3087 Sc
+{0 0.507 1 C} FS
+24 3887 3091 Sc
+{0 0.511 1 C} FS
+24 3892 3094 Sc
+{0 0.519 1 C} FS
+24 3897 3098 Sc
+{0 0.531 1 C} FS
+24 3902 3101 Sc
+{0 0.542 1 C} FS
+24 3907 3105 Sc
+{0 0.552 1 C} FS
+24 3912 3108 Sc
+{0 0.558 1 C} FS
+24 3917 3112 Sc
+{0 0.558 1 C} FS
+24 3922 3115 Sc
+{0 0.553 1 C} FS
+24 3927 3119 Sc
+{0 0.545 1 C} FS
+24 3932 3122 Sc
+{0 0.534 1 C} FS
+24 3937 3126 Sc
+{0 0.521 1 C} FS
+24 3942 3129 Sc
+{0 0.508 1 C} FS
+24 3948 3133 Sc
+{0 0.5 1 C} FS
+24 3953 3136 Sc
+{0 0.498 1 C} FS
+24 3958 3140 Sc
+{0 0.498 1 C} FS
+24 3963 3143 Sc
+{0 0.496 1 C} FS
+24 3968 3147 Sc
+{0 0.49 1 C} FS
+24 3973 3150 Sc
+{0 0.485 1 C} FS
+24 3978 3154 Sc
+{0 0.484 1 C} FS
+24 3983 3157 Sc
+{0 0.484 1 C} FS
+24 3988 3161 Sc
+{0 0.487 1 C} FS
+24 3993 3164 Sc
+{0 0.494 1 C} FS
+24 3998 3168 Sc
+{0 0.502 1 C} FS
+24 4003 3171 Sc
+{0 0.508 1 C} FS
+24 4008 3175 Sc
+{0 0.512 1 C} FS
+24 4014 3178 Sc
+{0 0.52 1 C} FS
+24 4019 3182 Sc
+{0 0.531 1 C} FS
+24 4024 3185 Sc
+{0 0.541 1 C} FS
+24 4029 3189 Sc
+{0 0.549 1 C} FS
+24 4034 3192 Sc
+{0 0.55 1 C} FS
+24 4039 3195 Sc
+{0 0.546 1 C} FS
+24 4044 3199 Sc
+{0 0.54 1 C} FS
+24 4049 3202 Sc
+{0 0.53 1 C} FS
+24 4054 3206 Sc
+{0 0.518 1 C} FS
+24 4059 3209 Sc
+{0 0.509 1 C} FS
+24 4064 3213 Sc
+{0 0.504 1 C} FS
+24 4070 3216 Sc
+{0 0.502 1 C} FS
+24 4075 3220 Sc
+{0 0.503 1 C} FS
+24 4080 3223 Sc
+{0 0.504 1 C} FS
+24 4085 3227 Sc
+{0 0.505 1 C} FS
+24 4090 3230 Sc
+{0 0.508 1 C} FS
+24 4095 3234 Sc
+{0 0.514 1 C} FS
+24 4100 3237 Sc
+{0 0.518 1 C} FS
+24 4105 3241 Sc
+{0 0.522 1 C} FS
+24 4110 3244 Sc
+{0 0.528 1 C} FS
+24 4116 3248 Sc
+{0 0.535 1 C} FS
+24 4121 3251 Sc
+{0 0.538 1 C} FS
+24 4126 3255 Sc
+{0 0.538 1 C} FS
+24 4131 3258 Sc
+{0 0.536 1 C} FS
+24 4136 3262 Sc
+{0 0.531 1 C} FS
+24 4141 3265 Sc
+{0 0.527 1 C} FS
+24 4146 3269 Sc
+{0 0.524 1 C} FS
+24 4151 3272 Sc
+{0 0.523 1 C} FS
+24 4156 3275 Sc
+{0 0.523 1 C} FS
+24 4162 3279 Sc
+{0 0.525 1 C} FS
+24 4167 3282 Sc
+{0 0.526 1 C} FS
+24 4172 3286 Sc
+{0 0.528 1 C} FS
+24 4177 3289 Sc
+{0 0.53 1 C} FS
+24 4182 3293 Sc
+{0 0.532 1 C} FS
+24 4187 3296 Sc
+{0 0.534 1 C} FS
+24 4192 3300 Sc
+{0 0.536 1 C} FS
+24 4197 3303 Sc
+{0 0.537 1 C} FS
+24 4203 3307 Sc
+{0 0.538 1 C} FS
+24 4208 3310 Sc
+{0 0.538 1 C} FS
+24 4213 3314 Sc
+{0 0.536 1 C} FS
+24 4218 3317 Sc
+{0 0.532 1 C} FS
+24 4223 3321 Sc
+{0 0.526 1 C} FS
+24 4228 3324 Sc
+{0 0.521 1 C} FS
+24 4233 3327 Sc
+{0 0.516 1 C} FS
+24 4239 3331 Sc
+{0 0.513 1 C} FS
+24 4244 3334 Sc
+{0 0.512 1 C} FS
+24 4249 3338 Sc
+{0 0.513 1 C} FS
+24 4254 3341 Sc
+{0 0.519 1 C} FS
+24 4259 3345 Sc
+{0 0.529 1 C} FS
+24 4264 3348 Sc
+{0 0.539 1 C} FS
+24 4269 3352 Sc
+{0 0.55 1 C} FS
+24 4275 3355 Sc
+{0 0.562 1 C} FS
+24 4280 3359 Sc
+{0 0.571 1 C} FS
+24 4285 3362 Sc
+{0 0.579 1 C} FS
+24 4290 3366 Sc
+{0 0.593 1 C} FS
+24 4295 3369 Sc
+{0 0.605 1 C} FS
+24 4300 3372 Sc
+{0 0.61 1 C} FS
+24 4305 3376 Sc
+{0 0.608 1 C} FS
+24 4311 3379 Sc
+{0 0.601 1 C} FS
+24 4316 3383 Sc
+{0 0.592 1 C} FS
+24 4321 3386 Sc
+{0 0.584 1 C} FS
+24 4326 3390 Sc
+{0 0.578 1 C} FS
+24 4331 3393 Sc
+{0 0.569 1 C} FS
+24 4336 3397 Sc
+{0 0.559 1 C} FS
+24 4342 3400 Sc
+{0 0.547 1 C} FS
+24 4347 3403 Sc
+{0 0.541 1 C} FS
+24 4352 3407 Sc
+{0 0.543 1 C} FS
+24 4357 3410 Sc
+{0 0.552 1 C} FS
+24 4362 3414 Sc
+{0 0.565 1 C} FS
+24 4367 3417 Sc
+{0 0.578 1 C} FS
+24 4373 3421 Sc
+{0 0.59 1 C} FS
+24 4378 3424 Sc
+{0 0.599 1 C} FS
+24 4383 3428 Sc
+{0 0.607 1 C} FS
+24 4388 3431 Sc
+{0 0.616 1 C} FS
+24 4393 3435 Sc
+{0 0.627 1 C} FS
+24 4398 3438 Sc
+{0 0.636 1 C} FS
+24 4404 3441 Sc
+{0 0.643 1 C} FS
+24 4409 3445 Sc
+{0 0.645 1 C} FS
+24 4414 3448 Sc
+{0 0.646 1 C} FS
+24 4419 3452 Sc
+{0 0.644 1 C} FS
+24 4424 3455 Sc
+{0 0.64 1 C} FS
+24 4430 3459 Sc
+{0 0.636 1 C} FS
+24 4435 3462 Sc
+{0 0.634 1 C} FS
+24 4440 3465 Sc
+{0 0.63 1 C} FS
+24 4445 3469 Sc
+{0 0.627 1 C} FS
+24 4450 3472 Sc
+{0 0.628 1 C} FS
+24 4455 3476 Sc
+{0 0.627 1 C} FS
+24 4461 3479 Sc
+{0 0.624 1 C} FS
+24 4466 3483 Sc
+{0 0.622 1 C} FS
+24 4471 3486 Sc
+{0 0.619 1 C} FS
+24 4476 3490 Sc
+{0 0.616 1 C} FS
+24 4481 3493 Sc
+{0 0.613 1 C} FS
+24 4487 3496 Sc
+{0 0.609 1 C} FS
+24 4492 3500 Sc
+{0 0.603 1 C} FS
+24 4497 3503 Sc
+{0 0.595 1 C} FS
+24 4502 3507 Sc
+{0 0.59 1 C} FS
+24 4507 3510 Sc
+{0 0.589 1 C} FS
+24 4513 3514 Sc
+{0 0.589 1 C} FS
+24 4518 3517 Sc
+{0 0.59 1 C} FS
+24 4523 3520 Sc
+{0 0.593 1 C} FS
+24 4528 3524 Sc
+{0 0.597 1 C} FS
+24 4533 3527 Sc
+{0 0.603 1 C} FS
+24 4539 3531 Sc
+{0 0.608 1 C} FS
+24 4544 3534 Sc
+{0 0.613 1 C} FS
+24 4549 3538 Sc
+{0 0.619 1 C} FS
+24 4554 3541 Sc
+{0 0.626 1 C} FS
+24 4560 3544 Sc
+{0 0.632 1 C} FS
+24 4565 3548 Sc
+{0 0.637 1 C} FS
+24 4570 3551 Sc
+{0 0.64 1 C} FS
+24 4575 3555 Sc
+{0 0.643 1 C} FS
+24 4580 3558 Sc
+{0 0.646 1 C} FS
+24 4586 3562 Sc
+{0 0.647 1 C} FS
+24 4591 3565 Sc
+{0 0.646 1 C} FS
+24 4596 3568 Sc
+{0 0.643 1 C} FS
+24 4601 3572 Sc
+{0 0.637 1 C} FS
+24 4606 3575 Sc
+{0 0.629 1 C} FS
+24 4612 3579 Sc
+{0 0.62 1 C} FS
+24 4617 3582 Sc
+{0 0.611 1 C} FS
+24 4622 3586 Sc
+{0 0.604 1 C} FS
+24 4627 3589 Sc
+{0 0.598 1 C} FS
+24 4633 3592 Sc
+{0 0.596 1 C} FS
+24 4638 3596 Sc
+{0 0.599 1 C} FS
+24 4643 3599 Sc
+{0 0.606 1 C} FS
+24 4648 3603 Sc
+{0 0.617 1 C} FS
+24 4654 3606 Sc
+{0 0.632 1 C} FS
+24 4659 3609 Sc
+{0 0.648 1 C} FS
+24 4664 3613 Sc
+{0 0.658 1 C} FS
+24 4669 3616 Sc
+{0 0.666 1 C} FS
+24 4674 3620 Sc
+{0 0.678 1 C} FS
+24 4680 3623 Sc
+{0 0.692 1 C} FS
+24 4685 3626 Sc
+{0 0.702 1 C} FS
+24 4690 3630 Sc
+{0 0.709 1 C} FS
+24 4695 3633 Sc
+{0 0.711 1 C} FS
+24 4701 3637 Sc
+{0 0.71 1 C} FS
+24 4706 3640 Sc
+{0 0.706 1 C} FS
+24 4711 3644 Sc
+{0 0.7 1 C} FS
+24 4716 3647 Sc
+{0 0.692 1 C} FS
+24 4722 3650 Sc
+{0 0.682 1 C} FS
+24 4727 3654 Sc
+{0 0.673 1 C} FS
+24 4732 3657 Sc
+{0 0.668 1 C} FS
+24 4737 3661 Sc
+{0 0.665 1 C} FS
+24 4743 3664 Sc
+{0 0.662 1 C} FS
+24 4748 3667 Sc
+{0 0.657 1 C} FS
+24 4753 3671 Sc
+{0 0.653 1 C} FS
+24 4758 3674 Sc
+{0 0.65 1 C} FS
+24 4764 3678 Sc
+{0 0.647 1 C} FS
+24 4769 3681 Sc
+{0 0.646 1 C} FS
+24 4774 3684 Sc
+{0 0.646 1 C} FS
+24 4779 3688 Sc
+{0 0.648 1 C} FS
+24 4785 3691 Sc
+{0 0.65 1 C} FS
+24 4790 3695 Sc
+{0 0.652 1 C} FS
+24 4795 3698 Sc
+{0 0.657 1 C} FS
+24 4801 3701 Sc
+{0 0.66 1 C} FS
+24 4806 3705 Sc
+{0 0.661 1 C} FS
+24 4811 3708 Sc
+{0 0.66 1 C} FS
+24 4816 3712 Sc
+{0 0.66 1 C} FS
+24 4822 3715 Sc
+{0 0.663 1 C} FS
+24 4827 3718 Sc
+{0 0.666 1 C} FS
+24 4832 3722 Sc
+{0 0.67 1 C} FS
+24 4837 3725 Sc
+{0 0.672 1 C} FS
+24 4843 3729 Sc
+{0 0.674 1 C} FS
+24 4848 3732 Sc
+{0 0.674 1 C} FS
+24 4853 3735 Sc
+{0 0.674 1 C} FS
+24 4859 3739 Sc
+{0 0.674 1 C} FS
+24 4864 3742 Sc
+{0 0.673 1 C} FS
+24 4869 3745 Sc
+{0 0.669 1 C} FS
+24 4874 3749 Sc
+{0 0.664 1 C} FS
+24 4880 3752 Sc
+{0 0.66 1 C} FS
+24 4885 3756 Sc
+{0 0.659 1 C} FS
+24 4890 3759 Sc
+{0 0.663 1 C} FS
+24 4895 3762 Sc
+{0 0.668 1 C} FS
+24 4901 3766 Sc
+{0 0.673 1 C} FS
+24 4906 3769 Sc
+{0 0.678 1 C} FS
+24 4911 3773 Sc
+{0 0.69 1 C} FS
+24 4917 3776 Sc
+{0 0.707 1 C} FS
+24 4922 3779 Sc
+{0 0.724 1 C} FS
+24 4927 3783 Sc
+{0 0.738 1 C} FS
+24 4933 3786 Sc
+{0 0.749 1 C} FS
+24 4938 3789 Sc
+{0 0.757 1 C} FS
+24 4943 3793 Sc
+{0 0.76 1 C} FS
+24 4948 3796 Sc
+{0 0.762 1 C} FS
+24 4954 3800 Sc
+{0 0.76 1 C} FS
+24 4959 3803 Sc
+{0 0.755 1 C} FS
+24 4964 3806 Sc
+{0 0.748 1 C} FS
+24 4970 3810 Sc
+{0 0.739 1 C} FS
+24 4975 3813 Sc
+{0 0.73 1 C} FS
+24 4980 3816 Sc
+{0 0.722 1 C} FS
+24 4986 3820 Sc
+{0 0.713 1 C} FS
+24 4991 3823 Sc
+{0 0.706 1 C} FS
+24 4996 3827 Sc
+{0 0.702 1 C} FS
+24 5001 3830 Sc
+{0 0.702 1 C} FS
+24 5007 3833 Sc
+{0 0.703 1 C} FS
+24 5012 3837 Sc
+{0 0.702 1 C} FS
+24 5017 3840 Sc
+{0 0.7 1 C} FS
+24 5023 3843 Sc
+{0 0.699 1 C} FS
+24 5028 3847 Sc
+{0 0.699 1 C} FS
+24 5033 3850 Sc
+{0 0.697 1 C} FS
+24 5039 3854 Sc
+{0 0.694 1 C} FS
+24 5044 3857 Sc
+{0 0.69 1 C} FS
+24 5049 3860 Sc
+{0 0.686 1 C} FS
+24 5055 3864 Sc
+{0 0.683 1 C} FS
+24 5060 3867 Sc
+{0 0.683 1 C} FS
+24 5065 3870 Sc
+{0 0.685 1 C} FS
+24 5071 3874 Sc
+{0 0.694 1 C} FS
+24 5076 3877 Sc
+{0 0.706 1 C} FS
+24 5081 3880 Sc
+{0 0.714 1 C} FS
+24 5087 3884 Sc
+{0 0.723 1 C} FS
+24 5092 3887 Sc
+{0 0.744 1 C} FS
+24 5097 3890 Sc
+{0 0.773 1 C} FS
+24 5103 3894 Sc
+{0 0.798 1 C} FS
+24 5108 3897 Sc
+{0 0.816 1 C} FS
+24 5113 3901 Sc
+{0 0.828 1 C} FS
+24 5119 3904 Sc
+{0 0.832 1 C} FS
+24 5124 3907 Sc
+{0 0.829 1 C} FS
+24 5129 3911 Sc
+{0 0.822 1 C} FS
+24 5135 3914 Sc
+{0 0.81 1 C} FS
+24 5140 3917 Sc
+{0 0.793 1 C} FS
+24 5145 3921 Sc
+{0 0.773 1 C} FS
+24 5151 3924 Sc
+{0 0.756 1 C} FS
+24 5156 3927 Sc
+{0 0.747 1 C} FS
+24 5161 3931 Sc
+{0 0.742 1 C} FS
+24 5167 3934 Sc
+{0 0.736 1 C} FS
+24 5172 3937 Sc
+{0 0.728 1 C} FS
+24 5177 3941 Sc
+{0 0.72 1 C} FS
+24 5183 3944 Sc
+{0 0.715 1 C} FS
+24 5188 3947 Sc
+{0 0.713 1 C} FS
+24 5193 3951 Sc
+{0 0.716 1 C} FS
+24 5199 3954 Sc
+{0 0.724 1 C} FS
+24 5204 3958 Sc
+{0 0.74 1 C} FS
+24 5209 3961 Sc
+{0 0.76 1 C} FS
+24 5215 3964 Sc
+{0 0.784 1 C} FS
+24 5220 3968 Sc
+{0 0.814 1 C} FS
+24 5225 3971 Sc
+{0 0.853 1 C} FS
+24 5231 3974 Sc
+{0 0.901 1 C} FS
+24 5236 3978 Sc
+{0 0.959 1 C} FS
+24 5241 3981 Sc
+{0 1 0.987 C} FS
+24 5247 3984 Sc
+{0 1 0.992 C} FS
+24 5252 3988 Sc
+{0 0.988 1 C} FS
+24 5258 3991 Sc
+{0 0.977 1 C} FS
+24 5263 3994 Sc
+{0 0.958 1 C} FS
+24 5268 3998 Sc
+{0 0.937 1 C} FS
+24 5274 4001 Sc
+{0 0.915 1 C} FS
+24 5279 4004 Sc
+{0 0.891 1 C} FS
+24 5284 4008 Sc
+{0 0.868 1 C} FS
+24 5290 4011 Sc
+{0 0.843 1 C} FS
+24 5295 4014 Sc
+{0 0.819 1 C} FS
+24 5301 4018 Sc
+{0 0.793 1 C} FS
+24 5306 4021 Sc
+{0 0.773 1 C} FS
+24 5311 4024 Sc
+{0 0.762 1 C} FS
+24 5317 4028 Sc
+{0 0.756 1 C} FS
+24 5322 4031 Sc
+{0 0.752 1 C} FS
+24 5327 4034 Sc
+{0 0.749 1 C} FS
+24 5333 4038 Sc
+{0 0.747 1 C} FS
+24 5338 4041 Sc
+{0 0.746 1 C} FS
+24 5344 4044 Sc
+{0 0.746 1 C} FS
+24 5349 4048 Sc
+{0 0.746 1 C} FS
+24 5354 4051 Sc
+{0 0.745 1 C} FS
+24 5360 4054 Sc
+{0 0.744 1 C} FS
+24 5365 4057 Sc
+{0 0.742 1 C} FS
+24 5370 4061 Sc
+{0 0.74 1 C} FS
+24 5376 4064 Sc
+{0 0.738 1 C} FS
+24 5381 4067 Sc
+{0 0.741 1 C} FS
+24 5387 4071 Sc
+{0 0.756 1 C} FS
+24 5392 4074 Sc
+{0 0.773 1 C} FS
+24 5397 4077 Sc
+{0 0.755 1 C} FS
+24 5403 4081 Sc
+{0 0.736 1 C} FS
+24 5408 4084 Sc
+{0 0.739 1 C} FS
+24 5414 4087 Sc
+{0 0.739 1 C} FS
+24 5419 4091 Sc
+{0 0.738 1 C} FS
+24 5424 4094 Sc
+{0 0.741 1 C} FS
+24 5430 4097 Sc
+{0 0.74 1 C} FS
+24 5435 4101 Sc
+{0 0.74 1 C} FS
+24 5441 4104 Sc
+{0 0.741 1 C} FS
+24 5446 4107 Sc
+{0 0.74 1 C} FS
+24 5451 4111 Sc
+{0 0.74 1 C} FS
+24 5457 4114 Sc
+{0 0.743 1 C} FS
+24 5462 4117 Sc
+{0 0.743 1 C} FS
+24 5468 4120 Sc
+{0 0.739 1 C} FS
+24 5473 4124 Sc
+{0 0.736 1 C} FS
+24 5478 4127 Sc
+{0 0.736 1 C} FS
+24 5484 4130 Sc
+{0 0.735 1 C} FS
+24 5489 4134 Sc
+{0 0.736 1 C} FS
+24 5495 4137 Sc
+{0 0.738 1 C} FS
+24 5500 4140 Sc
+{0 0.74 1 C} FS
+24 5505 4144 Sc
+{0 0.743 1 C} FS
+24 5511 4147 Sc
+{0 0.748 1 C} FS
+24 5516 4150 Sc
+{0 0.754 1 C} FS
+24 5522 4153 Sc
+{0 0.762 1 C} FS
+24 5527 4157 Sc
+{0 0.772 1 C} FS
+24 5533 4160 Sc
+{0 0.782 1 C} FS
+24 5538 4163 Sc
+{0 0.791 1 C} FS
+24 5543 4167 Sc
+{0 0.796 1 C} FS
+24 5549 4170 Sc
+{0 0.801 1 C} FS
+24 5554 4173 Sc
+{0 0.806 1 C} FS
+24 5560 4177 Sc
+{0 0.81 1 C} FS
+24 5565 4180 Sc
+{0 0.813 1 C} FS
+24 5571 4183 Sc
+{0 0.815 1 C} FS
+24 5576 4186 Sc
+{0 0.815 1 C} FS
+24 5581 4190 Sc
+{0 0.817 1 C} FS
+24 5587 4193 Sc
+{0 0.824 1 C} FS
+24 5592 4196 Sc
+{0 0.84 1 C} FS
+24 5598 4200 Sc
+{0 0.858 1 C} FS
+24 5603 4203 Sc
+{0 0.87 1 C} FS
+24 5609 4206 Sc
+{0 0.877 1 C} FS
+24 5614 4209 Sc
+{0 0.878 1 C} FS
+24 5619 4213 Sc
+{0 0.876 1 C} FS
+24 5625 4216 Sc
+{0 0.873 1 C} FS
+24 5630 4219 Sc
+{0 0.871 1 C} FS
+24 5636 4223 Sc
+{0 0.87 1 C} FS
+24 5641 4226 Sc
+{0 0.87 1 C} FS
+24 5647 4229 Sc
+{0 0.871 1 C} FS
+24 5652 4232 Sc
+{0 0.875 1 C} FS
+24 5657 4236 Sc
+{0 0.881 1 C} FS
+24 5663 4239 Sc
+{0 0.888 1 C} FS
+24 5668 4242 Sc
+{0 0.894 1 C} FS
+24 5674 4246 Sc
+{0 0.897 1 C} FS
+24 5679 4249 Sc
+{0 0.904 1 C} FS
+24 5685 4252 Sc
+{0 0.916 1 C} FS
+24 5690 4255 Sc
+{0 0.925 1 C} FS
+24 5696 4259 Sc
+{0 0.931 1 C} FS
+24 5701 4262 Sc
+{0 0.933 1 C} FS
+24 5707 4265 Sc
+{0 0.929 1 C} FS
+24 5712 4268 Sc
+{0 0.922 1 C} FS
+24 5717 4272 Sc
+{0 0.915 1 C} FS
+24 5723 4275 Sc
+{0 0.909 1 C} FS
+24 5728 4278 Sc
+{0 0.906 1 C} FS
+24 5734 4282 Sc
+{0 0.902 1 C} FS
+24 5739 4285 Sc
+{0 0.898 1 C} FS
+24 5745 4288 Sc
+{0 0.893 1 C} FS
+24 5750 4291 Sc
+{0 0.889 1 C} FS
+24 5756 4295 Sc
+{0 0.889 1 C} FS
+24 5761 4298 Sc
+{0 0.891 1 C} FS
+24 5767 4301 Sc
+{0 0.896 1 C} FS
+24 5772 4304 Sc
+{0 0.905 1 C} FS
+24 5778 4308 Sc
+{0 0.919 1 C} FS
+24 5783 4311 Sc
+{0 0.936 1 C} FS
+24 5788 4314 Sc
+{0 0.953 1 C} FS
+24 5794 4317 Sc
+{0 0.976 1 C} FS
+24 5799 4321 Sc
+{0 0.997 1 C} FS
+24 5805 4324 Sc
+{0 1 0.986 C} FS
+24 5810 4327 Sc
+{0 1 0.965 C} FS
+24 5816 4330 Sc
+{0 1 0.936 C} FS
+24 5821 4334 Sc
+{0 1 0.909 C} FS
+24 5827 4337 Sc
+{0 1 0.886 C} FS
+24 5832 4340 Sc
+{0 1 0.866 C} FS
+24 5838 4344 Sc
+{0 1 0.852 C} FS
+24 5843 4347 Sc
+{0 1 0.844 C} FS
+24 5849 4350 Sc
+{0 1 0.847 C} FS
+24 5854 4353 Sc
+{0 1 0.863 C} FS
+24 5860 4357 Sc
+{0 1 0.867 C} FS
+24 5865 4360 Sc
+{0 1 0.855 C} FS
+24 5871 4363 Sc
+{0 1 0.853 C} FS
+24 5876 4366 Sc
+{0 1 0.872 C} FS
+24 5882 4369 Sc
+{0 1 0.905 C} FS
+24 5887 4373 Sc
+{0 1 0.943 C} FS
+24 5893 4376 Sc
+{0 1 0.977 C} FS
+24 5898 4379 Sc
+{0 0.995 1 C} FS
+24 5904 4382 Sc
+{0 0.973 1 C} FS
+24 5909 4386 Sc
+{0 0.955 1 C} FS
+24 5915 4389 Sc
+{0 0.941 1 C} FS
+24 5920 4392 Sc
+{0 0.928 1 C} FS
+24 5926 4395 Sc
+{0 0.918 1 C} FS
+24 5931 4399 Sc
+{0 0.911 1 C} FS
+24 5937 4402 Sc
+{0 0.905 1 C} FS
+24 5942 4405 Sc
+{0 0.902 1 C} FS
+24 5948 4408 Sc
+{0 0.905 1 C} FS
+24 5953 4412 Sc
+{0 0.908 1 C} FS
+24 5959 4415 Sc
+{0 0.911 1 C} FS
+24 5964 4418 Sc
+{0 0.913 1 C} FS
+24 5970 4421 Sc
+{0 0.913 1 C} FS
+24 5975 4425 Sc
+{0 0.912 1 C} FS
+24 5981 4428 Sc
+{0 0.913 1 C} FS
+24 5986 4431 Sc
+{0 0.913 1 C} FS
+24 5992 4434 Sc
+{0 0.914 1 C} FS
+24 5997 4437 Sc
+{0 0.913 1 C} FS
+24 6003 4441 Sc
+{0 0.915 1 C} FS
+24 6008 4444 Sc
+{0 0.918 1 C} FS
+24 6014 4447 Sc
+{0 0.92 1 C} FS
+24 6019 4450 Sc
+{0 0.924 1 C} FS
+24 6025 4454 Sc
+{0 0.925 1 C} FS
+24 6030 4457 Sc
+{0 0.923 1 C} FS
+24 6036 4460 Sc
+{0 0.923 1 C} FS
+24 6041 4463 Sc
+{0 0.924 1 C} FS
+24 6047 4466 Sc
+{0 0.924 1 C} FS
+24 6052 4470 Sc
+{0 0.927 1 C} FS
+24 6058 4473 Sc
+{0 0.93 1 C} FS
+24 6063 4476 Sc
+{0 0.932 1 C} FS
+24 6069 4479 Sc
+{0 0.931 1 C} FS
+24 6074 4483 Sc
+{0 0.93 1 C} FS
+24 6080 4486 Sc
+{0 0.927 1 C} FS
+24 6085 4489 Sc
+{0 0.926 1 C} FS
+24 6091 4492 Sc
+{0 0.926 1 C} FS
+24 6097 4495 Sc
+{0 0.927 1 C} FS
+24 6102 4499 Sc
+{0 0.926 1 C} FS
+24 6108 4502 Sc
+{0 0.926 1 C} FS
+24 6113 4505 Sc
+{0 0.928 1 C} FS
+24 6119 4508 Sc
+{0 0.934 1 C} FS
+24 6124 4511 Sc
+{0 0.939 1 C} FS
+24 6130 4515 Sc
+{0 0.942 1 C} FS
+24 6135 4518 Sc
+{0 0.939 1 C} FS
+24 6141 4521 Sc
+{0 0.929 1 C} FS
+24 6146 4524 Sc
+{0 0.917 1 C} FS
+24 6152 4527 Sc
+{0 0.903 1 C} FS
+24 6157 4531 Sc
+{0 0.889 1 C} FS
+24 6163 4534 Sc
+{0 0.874 1 C} FS
+24 6169 4537 Sc
+{0 0.862 1 C} FS
+24 6174 4540 Sc
+{0 0.856 1 C} FS
+24 6180 4543 Sc
+{0 0.852 1 C} FS
+24 6185 4547 Sc
+{0 0.85 1 C} FS
+24 6191 4550 Sc
+{0 0.85 1 C} FS
+24 6196 4553 Sc
+{0 0.855 1 C} FS
+24 6202 4556 Sc
+{0 0.868 1 C} FS
+24 6207 4559 Sc
+{0 0.893 1 C} FS
+24 6213 4563 Sc
+{0 0.927 1 C} FS
+24 6218 4566 Sc
+{0 0.941 1 C} FS
+24 6224 4569 Sc
+{0 0.93 1 C} FS
+24 6230 4572 Sc
+{0 0.919 1 C} FS
+24 6235 4575 Sc
+{0 0.91 1 C} FS
+24 6241 4579 Sc
+{0 0.902 1 C} FS
+24 6246 4582 Sc
+{0 0.895 1 C} FS
+24 6252 4585 Sc
+{0 0.888 1 C} FS
+24 6257 4588 Sc
+{0 0.881 1 C} FS
+24 6263 4591 Sc
+{0 0.875 1 C} FS
+24 6268 4595 Sc
+{0 0.868 1 C} FS
+24 6274 4598 Sc
+{0 0.86 1 C} FS
+24 6280 4601 Sc
+{0 0.854 1 C} FS
+24 6285 4604 Sc
+{0 0.849 1 C} FS
+24 6291 4607 Sc
+{0 0.846 1 C} FS
+24 6296 4610 Sc
+{0 0.847 1 C} FS
+24 6302 4614 Sc
+{0 0.859 1 C} FS
+24 6307 4617 Sc
+{0 0.884 1 C} FS
+24 6313 4620 Sc
+{0 0.905 1 C} FS
+24 6319 4623 Sc
+{0 0.907 1 C} FS
+24 6324 4626 Sc
+{0 0.9 1 C} FS
+24 6330 4630 Sc
+{0 0.895 1 C} FS
+24 6335 4633 Sc
+{0 0.886 1 C} FS
+24 6341 4636 Sc
+{0 0.877 1 C} FS
+24 6346 4639 Sc
+{0 0.87 1 C} FS
+24 6352 4642 Sc
+{0 0.863 1 C} FS
+24 6358 4645 Sc
+{0 0.855 1 C} FS
+24 6363 4649 Sc
+{0 0.852 1 C} FS
+24 6369 4652 Sc
+{0 0.86 1 C} FS
+24 6374 4655 Sc
+{0 0.875 1 C} FS
+24 6380 4658 Sc
+{0 0.894 1 C} FS
+24 6386 4661 Sc
+{0 0.914 1 C} FS
+24 6391 4664 Sc
+{0 0.932 1 C} FS
+24 6397 4668 Sc
+{0 0.939 1 C} FS
+24 6402 4671 Sc
+{0 0.939 1 C} FS
+24 6408 4674 Sc
+{0 0.937 1 C} FS
+24 6413 4677 Sc
+{0 0.934 1 C} FS
+24 6419 4680 Sc
+{0 0.932 1 C} FS
+24 6425 4683 Sc
+{0 0.931 1 C} FS
+24 6430 4687 Sc
+{0 0.93 1 C} FS
+24 6436 4690 Sc
+{0 0.931 1 C} FS
+24 6441 4693 Sc
+{0 0.932 1 C} FS
+24 6447 4696 Sc
+{0 0.933 1 C} FS
+24 6453 4699 Sc
+{0 0.933 1 C} FS
+24 6458 4702 Sc
+{0 0.931 1 C} FS
+24 6464 4705 Sc
+{0 0.929 1 C} FS
+24 6469 4709 Sc
+{0 0.929 1 C} FS
+24 6475 4712 Sc
+{0 0.932 1 C} FS
+24 6481 4715 Sc
+{0 0.936 1 C} FS
+24 6486 4718 Sc
+{0 0.941 1 C} FS
+24 6492 4721 Sc
+{0 0.944 1 C} FS
+24 6497 4724 Sc
+{0 0.943 1 C} FS
+24 6503 4727 Sc
+{0 0.941 1 C} FS
+24 6509 4731 Sc
+{0 0.941 1 C} FS
+24 6514 4734 Sc
+{0 0.941 1 C} FS
+24 6520 4737 Sc
+{0 0.942 1 C} FS
+24 6525 4740 Sc
+{0 0.945 1 C} FS
+24 6531 4743 Sc
+{0 0.947 1 C} FS
+24 6537 4746 Sc
+{0 0.948 1 C} FS
+24 6542 4749 Sc
+{0 0.95 1 C} FS
+24 6548 4753 Sc
+{0 0.951 1 C} FS
+24 6553 4756 Sc
+{0 0.952 1 C} FS
+24 6559 4759 Sc
+{0 0.954 1 C} FS
+24 6565 4762 Sc
+{0 0.955 1 C} FS
+24 6570 4765 Sc
+{0 0.954 1 C} FS
+24 6576 4768 Sc
+{0 0.952 1 C} FS
+24 6582 4771 Sc
+{0 0.947 1 C} FS
+24 6587 4775 Sc
+{0 0.94 1 C} FS
+24 6593 4778 Sc
+{0 0.929 1 C} FS
+24 6598 4781 Sc
+{0 0.917 1 C} FS
+24 6604 4784 Sc
+{0 0.902 1 C} FS
+24 6610 4787 Sc
+{0 0.882 1 C} FS
+24 6615 4790 Sc
+{0 0.858 1 C} FS
+24 6621 4793 Sc
+{0 0.83 1 C} FS
+24 6627 4796 Sc
+{0 0.812 1 C} FS
+24 6632 4800 Sc
+{0 0.813 1 C} FS
+24 6638 4803 Sc
+{0 0.817 1 C} FS
+24 6643 4806 Sc
+{0 0.821 1 C} FS
+24 6649 4809 Sc
+{0 0.836 1 C} FS
+24 6655 4812 Sc
+{0 0.855 1 C} FS
+24 6660 4815 Sc
+{0 0.875 1 C} FS
+24 6666 4818 Sc
+{0 0.894 1 C} FS
+24 6672 4821 Sc
+{0 0.91 1 C} FS
+24 6677 4825 Sc
+{0 0.924 1 C} FS
+24 6683 4828 Sc
+{0 0.918 1 C} FS
+24 6689 4831 Sc
+{0 0.884 1 C} FS
+24 6694 4834 Sc
+{0 0.867 1 C} FS
+24 6700 4837 Sc
+{0 0.874 1 C} FS
+24 6705 4840 Sc
+{0 0.886 1 C} FS
+24 6711 4843 Sc
+{0 0.896 1 C} FS
+24 6717 4846 Sc
+{0 0.9 1 C} FS
+24 6722 4849 Sc
+{0 0.9 1 C} FS
+24 6728 4853 Sc
+{0 0.904 1 C} FS
+24 6734 4856 Sc
+{0 0.906 1 C} FS
+24 6739 4859 Sc
+{0 0.905 1 C} FS
+24 6745 4862 Sc
+{0 0.899 1 C} FS
+24 6751 4865 Sc
+{0 0.891 1 C} FS
+24 6756 4868 Sc
+{0 0.883 1 C} FS
+24 6762 4871 Sc
+{0 0.88 1 C} FS
+24 6768 4874 Sc
+{0 0.888 1 C} FS
+24 6773 4877 Sc
+{0 0.922 1 C} FS
+24 6779 4880 Sc
+{0 0.96 1 C} FS
+24 6785 4884 Sc
+{0 0.963 1 C} FS
+24 6790 4887 Sc
+{0 0.939 1 C} FS
+24 6796 4890 Sc
+{0 0.912 1 C} FS
+24 6802 4893 Sc
+{0 0.887 1 C} FS
+24 6807 4896 Sc
+{0 0.874 1 C} FS
+24 6813 4899 Sc
+{0 0.876 1 C} FS
+24 6819 4902 Sc
+{0 0.882 1 C} FS
+24 6824 4905 Sc
+{0 0.891 1 C} FS
+24 6830 4908 Sc
+{0 0.906 1 C} FS
+24 6835 4911 Sc
+{0 0.922 1 C} FS
+24 6841 4914 Sc
+{0 0.934 1 C} FS
+24 6847 4918 Sc
+{0 0.945 1 C} FS
+24 6852 4921 Sc
+{0 0.95 1 C} FS
+24 6858 4924 Sc
+{0 0.951 1 C} FS
+24 6864 4927 Sc
+{0 0.951 1 C} FS
+24 6869 4930 Sc
+{0 0.948 1 C} FS
+24 6875 4933 Sc
+{0 0.945 1 C} FS
+24 6881 4936 Sc
+{0 0.945 1 C} FS
+24 6887 4939 Sc
+{0 0.945 1 C} FS
+24 6892 4942 Sc
+{0 0.944 1 C} FS
+24 6898 4945 Sc
+{0 0.943 1 C} FS
+24 6904 4948 Sc
+{0 0.942 1 C} FS
+24 6909 4951 Sc
+{0 0.943 1 C} FS
+24 6915 4955 Sc
+{0 0.944 1 C} FS
+24 6921 4958 Sc
+{0 0.943 1 C} FS
+24 6926 4961 Sc
+{0 0.938 1 C} FS
+24 6932 4964 Sc
+{0 0.93 1 C} FS
+24 6938 4967 Sc
+{0 0.924 1 C} FS
+24 6943 4970 Sc
+{0 0.921 1 C} FS
+24 6949 4973 Sc
+{0 0.92 1 C} FS
+24 6955 4976 Sc
+{0 0.924 1 C} FS
+24 6960 4979 Sc
+{0 0.931 1 C} FS
+24 6966 4982 Sc
+{0 0.939 1 C} FS
+24 6972 4985 Sc
+{0 0.946 1 C} FS
+24 6977 4988 Sc
+{0 0.947 1 C} FS
+24 6983 4991 Sc
+{0 0.949 1 C} FS
+24 6989 4994 Sc
+{0 0.96 1 C} FS
+24 6994 4997 Sc
+{0 0.976 1 C} FS
+24 7000 5000 Sc
+{0 0.986 1 C} FS
+24 7006 5004 Sc
+{0 0.99 1 C} FS
+24 7012 5007 Sc
+{0 0.989 1 C} FS
+24 7017 5010 Sc
+{0 0.983 1 C} FS
+24 7023 5013 Sc
+{0 0.974 1 C} FS
+24 7029 5016 Sc
+{0 0.967 1 C} FS
+24 7034 5019 Sc
+{0 0.961 1 C} FS
+24 7040 5022 Sc
+{0 0.958 1 C} FS
+24 7046 5025 Sc
+{0 0.955 1 C} FS
+24 7051 5028 Sc
+{0 0.954 1 C} FS
+24 7057 5031 Sc
+{0 0.953 1 C} FS
+24 7063 5034 Sc
+{0 0.953 1 C} FS
+24 7069 5037 Sc
+{0 0.953 1 C} FS
+24 7074 5040 Sc
+{0 0.957 1 C} FS
+24 7080 5043 Sc
+{0 0.965 1 C} FS
+24 7086 5046 Sc
+{0 0.978 1 C} FS
+24 7091 5049 Sc
+{0 0.99 1 C} FS
+24 7097 5052 Sc
+{0 0.995 1 C} FS
+24 7103 5055 Sc
+{0 0.997 1 C} FS
+24 7109 5058 Sc
+{0 0.995 1 C} FS
+24 7114 5061 Sc
+{0 0.992 1 C} FS
+24 7120 5064 Sc
+{0 0.987 1 C} FS
+24 7126 5068 Sc
+{0 0.983 1 C} FS
+24 7131 5071 Sc
+{0 0.979 1 C} FS
+24 7137 5074 Sc
+{0 0.976 1 C} FS
+24 7143 5077 Sc
+{0 0.972 1 C} FS
+24 7149 5080 Sc
+{0 0.969 1 C} FS
+24 7154 5083 Sc
+{0 0.965 1 C} FS
+24 7160 5086 Sc
+{0 0.96 1 C} FS
+24 7166 5089 Sc
+{0 0.956 1 C} FS
+24 7171 5092 Sc
+{0 0.953 1 C} FS
+24 7177 5095 Sc
+{0 0.949 1 C} FS
+24 7183 5098 Sc
+{0 0.942 1 C} FS
+24 7189 5101 Sc
+{0 0.932 1 C} FS
+24 7194 5104 Sc
+U
+PSL_cliprestore
+25 W
+8 W
+N 0 0 M 0 -83 D S
+N 0 5107 M 0 83 D S
+N 1800 0 M 0 -83 D S
+N 1800 5107 M 0 83 D S
+N 3600 0 M 0 -83 D S
+N 3600 5107 M 0 83 D S
+N 5400 0 M 0 -83 D S
+N 5400 5107 M 0 83 D S
+N 7200 0 M 0 -83 D S
+N 7200 5107 M 0 83 D S
+N 0 4 M -83 0 D S
+N 7200 4 M 83 0 D S
+N 0 2439 M -83 0 D S
+N 7200 2439 M 83 0 D S
+N 0 5098 M -83 0 D S
+N 7200 5098 M 83 0 D S
+83 W
+1 A
+N -42 0 M 0 4 D S
+N 7242 0 M 0 4 D S
+0 A
+N -42 4 M 0 472 D S
+N 7242 4 M 0 472 D S
+1 A
+N -42 476 M 0 479 D S
+N 7242 476 M 0 479 D S
+0 A
+N -42 955 M 0 486 D S
+N 7242 955 M 0 486 D S
+1 A
+N -42 1441 M 0 495 D S
+N 7242 1441 M 0 495 D S
+0 A
+N -42 1936 M 0 503 D S
+N 7242 1936 M 0 503 D S
+1 A
+N -42 2439 M 0 512 D S
+N 7242 2439 M 0 512 D S
+0 A
+N -42 2951 M 0 521 D S
+N 7242 2951 M 0 521 D S
+1 A
+N -42 3472 M 0 531 D S
+N 7242 3472 M 0 531 D S
+0 A
+N -42 4003 M 0 542 D S
+N 7242 4003 M 0 542 D S
+1 A
+N -42 4545 M 0 553 D S
+N 7242 4545 M 0 553 D S
+0 A
+N -42 5098 M 0 9 D S
+N 7242 5098 M 0 9 D S
+N 0 -42 M 360 0 D S
+N 0 5149 M 360 0 D S
+1 A
+N 360 -42 M 360 0 D S
+N 360 5149 M 360 0 D S
+0 A
+N 720 -42 M 360 0 D S
+N 720 5149 M 360 0 D S
+1 A
+N 1080 -42 M 360 0 D S
+N 1080 5149 M 360 0 D S
+0 A
+N 1440 -42 M 360 0 D S
+N 1440 5149 M 360 0 D S
+1 A
+N 1800 -42 M 360 0 D S
+N 1800 5149 M 360 0 D S
+0 A
+N 2160 -42 M 360 0 D S
+N 2160 5149 M 360 0 D S
+1 A
+N 2520 -42 M 360 0 D S
+N 2520 5149 M 360 0 D S
+0 A
+N 2880 -42 M 360 0 D S
+N 2880 5149 M 360 0 D S
+1 A
+N 3240 -42 M 360 0 D S
+N 3240 5149 M 360 0 D S
+0 A
+N 3600 -42 M 360 0 D S
+N 3600 5149 M 360 0 D S
+1 A
+N 3960 -42 M 360 0 D S
+N 3960 5149 M 360 0 D S
+0 A
+N 4320 -42 M 360 0 D S
+N 4320 5149 M 360 0 D S
+1 A
+N 4680 -42 M 360 0 D S
+N 4680 5149 M 360 0 D S
+0 A
+N 5040 -42 M 360 0 D S
+N 5040 5149 M 360 0 D S
+1 A
+N 5400 -42 M 360 0 D S
+N 5400 5149 M 360 0 D S
+0 A
+N 5760 -42 M 360 0 D S
+N 5760 5149 M 360 0 D S
+1 A
+N 6120 -42 M 360 0 D S
+N 6120 5149 M 360 0 D S
+0 A
+N 6480 -42 M 360 0 D S
+N 6480 5149 M 360 0 D S
+1 A
+N 6840 -42 M 360 0 D S
+N 6840 5149 M 360 0 D S
+0 A
+8 W
+N -83 0 M 7366 0 D S
+N -83 -83 M 7366 0 D S
+N 7200 -83 M 0 5273 D S
+N 7283 -83 M 0 5273 D S
+N 7283 5107 M -7366 0 D S
+N 7283 5190 M -7366 0 D S
+N 0 5190 M 0 -5273 D S
+N -83 5190 M 0 -5273 D S
+0 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(180°) tc Z
+0 5274 M (180°) bc Z
+1800 -167 M (-175°) tc Z
+1800 5274 M (-175°) bc Z
+3600 -167 M (-170°) tc Z
+3600 5274 M (-170°) bc Z
+5400 -167 M (-165°) tc Z
+5400 5274 M (-165°) bc Z
+7200 -167 M (-160°) tc Z
+7200 5274 M (-160°) bc Z
+-167 4 M (40°) mr Z
+7367 4 M (40°) ml Z
+-167 2439 M (45°) mr Z
+7367 2439 M (45°) ml Z
+-167 5098 M (50°) mr Z
+7367 5098 M (50°) ml Z
+%%EndObject
+
+grestore
+PSL_movie_completion /PSL_movie_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/img/imgtrack.sh
+++ b/test/img/imgtrack.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Testing various ways of extracting and plotting IMG grids
+
+ps=imgtrack.ps
+IMG=@topo.8.2.img
+# Sample an img file along a track directly
+gmt makecpt -Crainbow -T-8000/0 > t.cpt
+gmt grdtrack -G${IMG},1,1 -R180/200/40/50 -EBL/TR > m.txt
+gmt psxy -R -JM6i -P -Baf -Sc0.1c -Ct.cpt m.txt -K > $ps
+gmt img2grd $IMG -R -T1 -S1 -Gimg_g.nc
+gmt grdtrack -Gimg_g.nc -EBL/TR > g.txt
+gmt psxy -R -J -O -Baf -Sc0.1c -Ct.cpt g.txt -Y5i >> $ps


### PR DESCRIPTION
grdtrack crashed if given **-G**@topo.8.2.img,1,1.  Fixed, also added a simple test to ensure grdtrack works (in prep for redoing the reading code).
