### PR TITLE
Let psxy -SE -JX/x work even if axes scalings differ

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1420,7 +1420,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 							dim[0] = 90.0 - in[ex1];	/* Cartesian azimuth */
 							gmt_flip_angle_d (GMT, &dim[0]);
 							dim[1] = in[ex2] * GMT->current.proj.scale[GMT_X];
-							dim[2] = in[ex3] * GMT->current.proj.scale[GMT_X];
+							dim[2] = in[ex3] * GMT->current.proj.scale[GMT_Y];
 							PSL_plotsymbol (PSL, xpos[item], plot_y, dim, S.symbol);
 						}
 						else if (S.symbol == PSL_ELLIPSE) {	/* Got axis in km */

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1078,7 +1078,7 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 					else if (gmt_M_is_cartesian (GMT, GMT_IN)) {	/* Got axes in user units, change to inches */
 						data[n].dim[0] = 90.0 - p_in[ex1];	/* Cartesian azimuth */
 						data[n].dim[1] = p_in[ex2] * GMT->current.proj.scale[GMT_X];
-						data[n].dim[2] = p_in[ex3] * GMT->current.proj.scale[GMT_X];
+						data[n].dim[2] = p_in[ex3] * GMT->current.proj.scale[GMT_Y];
 						gmt_flip_angle_d (GMT, &data[n].dim[0]);
 					}
 					else {				/* Got axis in km */


### PR DESCRIPTION
This is a poor-mans geo ellipse where distortion is up to you.  The code incorrectly used the x-scale for both axes.