### PR TITLE
Ensure -SE-, -SJ- and -SW all handle geographic units

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -68,7 +68,7 @@
         For degenerate ellipses (circles) with just the diameter given, use **-SE-**.
         The diameter is excepted to be given in column 3.  Alternatively, append
         the desired diameter to **-SE-** and this fixed diameter is used instead.
-	For allowable geographical units, see UNITS.
+	For allowable geographical units, see UNITS [Default is k for km].
 
     **-Sf**\ *gap*\ [/*size*][**+l**\ \|\ **+r**][**+b+c+f+s+t**][\ **+o**\ *offset*][**+p**\ [*pen*]].
         Draw a **f**\ ront. Supply distance *gap* between symbols and symbol *size*. If *gap* is
@@ -114,7 +114,7 @@
 	the dimension diameter to **-SJ-** and this fixed dimension is used instead.
 	An exception occurs for a linear projection in
         which we assume the dimensions are given in the same units as **-R**.
-	For allowable geographical units, see UNITS.
+	For allowable geographical units, see UNITS [Default is k for km].
 
     **-Sk**
         **k**\ ustom symbol. Append *name*\ /\ *size*, and we will look for a
@@ -362,8 +362,9 @@
         Same as **-Sw**, except azimuths (in degrees east of north) should
         be given instead of the two directions. The azimuths will be mapped
         into angles based on the chosen map projection (**-Sw** leaves the
-        directions unchanged.) For geo-wedges, specify *size* as a radial
-        geographical distance. For allowable geographical units, see UNITS.
+        directions unchanged). Specify *size* as a geographical diameter.
+        For allowable geographical units, see UNITS [Default is k for km]. To instead
+        specify a diameter in plot units, you must append the desired unit.
         Append **+a** to just draw the arc or **+r** to just draw the radial lines.
 
     **-Sx**

--- a/doc/rst/source/explain_symbols2.rst_
+++ b/doc/rst/source/explain_symbols2.rst_
@@ -68,7 +68,7 @@
 	For degenerate ellipses (circles) with just the diameter given, use **-SE-**.
 	The diameter is excepted to be given in column 4.  Alternatively, append
 	the desired diameter to **-SE-** and this fixed diameter is used instead.
-	For allowable geographical units, see UNITS.
+	For allowable geographical units, see UNITS [Default is k for km].
 
     **-Sf**\ *gap*\ [/*size*\ ][**+l**\ \|\ **+r**][**+b+c+f+s+t**][\ **+o**\ *offset*][**+p**\ [*pen*]].
         Draw a **f**\ ront.  Supply distance gap between symbols and symbol size. If *gap* is
@@ -113,7 +113,7 @@
 	the dimension diameter to **-SJ-** and this fixed dimension is used instead.
 	An exception occurs for a linear projection in
         which we assume the dimensions are given in the same units as **-R**.
-	For allowable geographical units, see UNITS.
+	For allowable geographical units, see UNITS [Default is k for km].
 
     **-Sk**
         **k**\ ustom symbol. Append <name>/*size*, and we will look for a
@@ -374,8 +374,9 @@
         Same as **-Sw**, except azimuths (in degrees east of north) should
         be given instead of the two directions. The azimuths will be mapped
         into angles based on the chosen map projection (**-Sw** leaves the
-        directions unchanged.) For geo-wedges, specify *size* as a radial
-        geographical distance. For allowable geographical units, see UNITS.
+        directions unchanged). Specify *size* as a geographical diameter.
+        For allowable geographical units, see UNITS [Default is k for km]. To instead
+        specify a diameter in plot units, you must append the desired unit.
         Append **+a** to just draw the arc or **+r** to just draw the radial lines.
 
     **-Sx**

--- a/doc/rst/source/explain_symbols_only.rst_
+++ b/doc/rst/source/explain_symbols_only.rst_
@@ -1,0 +1,114 @@
+**-S**\ [*symbol*][\ *size*\ [**u**]]
+    Plot individual symbols.
+    If present, *size* is symbol size in the unit set in
+    :doc:`gmt.conf` (unless **c**, **i**, or **p** is appended). If the symbol
+    code (see below) is not given it will be read from the last column in
+    the input data; this cannot be used in conjunction with binary input.
+    Optionally, append **c**, **i**, or
+    **p** to indicate that the size information in the input data is in
+    units of cm, inch, or point, respectively [Default is
+    :ref:`PROJ_LENGTH_UNIT <PROJ_LENGTH_UNIT>`]. Note: if you provide *both* size and symbol via the
+    input file you must use :ref:`PROJ_LENGTH_UNIT <PROJ_LENGTH_UNIT>` to indicate the unit
+    used for the symbol size or append the units to the sizes in the file.
+    If symbol sizes are expected via the third data column then you may convert
+    those values to suitable symbol sizes via the **-i** mechanism.
+
+    The uppercase symbols **A**, **C**, **D**, **G**, **H**, **I**, **N**,
+    **S**, **T** are normalized to have the same area as a circle with
+    diameter *size*, while the size of the corresponding lowercase symbols
+    refers to the diameter of a circumscribed circle.
+
+    You can change symbols by adding the required **-S** option to any of
+    your multisegment headers.
+
+    Choose between these symbol codes:
+
+    **-S-**
+        x-dash (-). *size* is the length of a short horizontal (x-dir) line segment.
+
+    **-S+**
+        plus (+). *size* is diameter of circumscribing circle.
+
+    **-Sa**
+        st\ **a**\ r. *size* is diameter of circumscribing circle.
+
+    **-Sb**\ [*size*\ [**c**\ \|\ **i**\ \|\ **p**\ \|\ **u**]][**+b**\ [*base*]]
+        Vertical **b**\ ar extending from *base* to y. The *size* is bar width.
+        Append **u** if *size* is in x-units [Default is plot-distance units].
+        By default, *base* = 0. Append **+b**\ [*base*\ ] to change this
+        value. If *base* is not appended then we read it from the last input
+        data column.  Use **+B**\ [*base*\ ] if the bar height is measured relative
+        to *base* [Relative to origin].
+
+    **-SB**\ [*size*\ [**c**\ \|\ **i**\ \|\ **p**\ \|\ **u**]][**+b**\ [*base*]]
+        Horizontal **b**\ ar extending from *base* to x. The *size* is bar width.
+        Append **u** if *size* is in y-units [Default is plot-distance units].
+        By default, *base* = 0. Append **+b**\ [*base*\ ] to change this
+        value. If *base* is not appended then we read it from the last input
+        data column.  Use **+B**\ [*base*\ ] if the bar length is measured relative
+        to *base* [Relative to origin].
+
+    **-Sc**
+        **c**\ ircle. *size* is diameter of circle.
+
+    **-Sd**
+        **d**\ iamond. *size* is diameter of circumscribing circle.
+
+    **-Se**
+        **e**\ llipse. Direction (in degrees counter-clockwise from horizontal),
+        major_axis, and minor_axis must be found in columns 3, 4, and 5.
+
+    **-Sg**
+        octa\ **g**\ on. *size* is diameter of circumscribing circle.
+
+    **-Sh**
+        **h**\ exagon. *size* is diameter of circumscribing circle.
+
+    **-Si**
+        **i**\ nverted triangle. *size* is diameter of circumscribing circle.
+
+    **-Sj**
+        Rotated rectangle. Direction (in degrees counter-clockwise from
+        horizontal), x-dimension, and y-dimension must be found in columns 3, 4, and 5.
+
+    **-Sk**
+        **k**\ ustom symbol. Append *name*\ /\ *size*, and we will look for a
+        definition file called *name*\ .def in (1) the current
+        directory or (2) in ~/.gmt or (3) in
+        **$GMT_SHAREDIR**/custom. The symbol as defined in that file is of size
+        1.0 by default; the appended *size* will scale symbol accordingly. Users
+        may add their own custom \*.def files; see CUSTOM SYMBOLS below.
+
+    **-Sl**
+        **l**\ etter or text string (less than 256 characters). Give size, and
+        append **+t**\ *string* after the size. Note that the size is only approximate;
+        no individual scaling is done for different characters. Remember to
+        escape special characters like \*. Optionally, you may append **+f**\ *font*
+        to select a particular font [Default is :ref:`FONT_ANNOT_PRIMARY <FONT_ANNOT_PRIMARY>`] and
+        **+j**\ *justify* to change justification [CM].
+
+    **-Sn**
+        pe\ **n**\ tagon. *size* is diameter of circumscribing circle.
+
+    **-Sp**
+        **p**\ oint. No size needs to be specified (1 pixel is used).
+
+    **-Sr**
+        **r**\ ectangle. No size needs to be specified, but the x- and
+        y-dimensions must be found in columns 3 and 4.
+
+    **-SR**
+        **R**\ ounded rectangle. No size needs to be specified, but the x-
+        and y-dimensions and corner radius must be found in columns 3, 4, and 5.
+
+    **-Ss**
+        **s**\ quare. *size* is diameter of circumscribing circle.
+
+    **-St**
+        **t**\ riangle. *size* is diameter of circumscribing circle.
+
+    **-Sx**
+        cross (x). *size* is diameter of circumscribing circle.
+
+    **-Sy**
+        y-dash (\|). *size* is the length of a short vertical (y-dir) line segment.

--- a/doc/rst/source/solar_common.rst_
+++ b/doc/rst/source/solar_common.rst_
@@ -9,7 +9,7 @@ Description
 Required Arguments
 ------------------
 
-There are no required arguments but either **-I** or **-T** must be selected.
+None.
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/ternary_common.rst_
+++ b/doc/rst/source/ternary_common.rst_
@@ -11,6 +11,11 @@ as symbol size. Symbols whose *size* is <= 0 are skipped. If no symbols
 are specified then the symbol code (see **-S** below) must be present as
 last column in the input.
 
+Required Arguments
+------------------
+
+Either **-M** (for dumping data) or **-R** and **-J** must be selected.
+
 Optional Arguments
 ------------------
 
@@ -62,7 +67,7 @@ Optional Arguments
 **-M**
     Do no plotting.  Instead, convert the input (*a*,\ *b*,\ *c*\ [,\ *z*]) records
     to Cartesian (*x*,\ *y*,\ [,\ *z*]) records, where *x, y* are normalized coordinates
-    on the triangle (i.e., 0-1 in *x*\ and 0-sqrt(3)/2 in *y*\ ).
+    on the triangle (i.e., 0–1 in *x* and 0–sqrt(3)/2 in *y*\ ).
 
 .. _-N:
 
@@ -77,7 +82,7 @@ Optional Arguments
 
 .. _-S:
 
-.. include:: explain_symbols.rst_
+.. include:: explain_symbols_only.rst_
 
 .. _-U:
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13220,6 +13220,17 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 				check = false;
 				p->w_active = true;
 			}
+			else if (symbol_type == 'W') {	/* Can take either plot diameter or geo diameter */
+				if (strchr (GMT_DIM_UNITS, txt_a[len-1]))	/* Gave a plot unit diameter */
+					p->size_x = p->given_size_x = gmt_M_to_inch (GMT, txt_a);
+				else {	/* Add the implicit k for km */
+					strcat (txt_a, "k");
+					p->w_mode = gmt_get_distance (GMT, txt_a, &(p->w_radius), &(p->w_unit));
+					p->size_y = p->given_size_y = 0.0;
+					check = false;
+					p->w_active = true;
+				}
+			}
 			else
 				p->size_x = p->given_size_x = gmt_M_to_inch (GMT, txt_a);
 		}
@@ -13425,7 +13436,8 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 			p->convert_angles = 1;
 			if (degenerate) {	/* Degenerate rectangle = square with zero angle */
 				if (diameter[0]) {	/* Gave a fixed diameter as symbol size */
-					p->size_x = p->size_y = atof (diameter);	/* In km */
+					(void)gmtlib_scanf_geodim (GMT, diameter, &p->size_y);
+					p->size_x = p->size_y;
 				}
 				else {	/* Must read diameter from data file */
 					p->n_required = 1;	/* Only expect diameter */

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -462,14 +462,14 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     axes [in km], and convert azimuths based on map projection.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Use -SE- for a degenerate ellipse (circle) with only its diameter given\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     in column 3, or append a fixed diameter to -SE- instead.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     Append any of the units in %s to the axes [k].\n", GMT_LEN_UNITS_DISPLAY);
+	GMT_Message (API, GMT_TIME_NONE, "\t     Append any of the units in %s to the axes [Default is k].\n", GMT_LEN_UNITS_DISPLAY);
 	GMT_Message (API, GMT_TIME_NONE, "\t     For linear projection we scale the axes by the map scale.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Rotatable Rectangle: Direction, x- and y-dimensions in columns 3-5.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     If -SJ rather than -Sj is selected, psxy will expect azimuth, and\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     dimensions [in km] and convert azimuths based on map projection.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Use -SJ- for a degenerate rectangle (square w/no rotation) with one dimension given\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     in column 3, or append a fixed dimension to -SJ- instead.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     Append any of the units in %s to the dimensions [k].\n", GMT_LEN_UNITS_DISPLAY);
+	GMT_Message (API, GMT_TIME_NONE, "\t     Append any of the units in %s to the dimensions [Default is k].\n", GMT_LEN_UNITS_DISPLAY);
 	GMT_Message (API, GMT_TIME_NONE, "\t     For linear projection we scale dimensions by the map scale.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Fronts: Give <tickgap>[/<ticklen>][+l|+r][+<type>][+o<offset>][+p[<pen>]].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     If <tickgap> is negative it means the number of gaps instead.\n");
@@ -507,7 +507,9 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	gmt_vector_syntax (API->GMT, 19);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Wedges: Start and stop directions of wedge must be in columns 3-4.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     If -SW rather than -Sw is selected, specify two azimuths instead.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     For geo-wedges, specify <size><unit> with units from %s.\n", GMT_LEN_UNITS_DISPLAY);
+	GMT_Message (API, GMT_TIME_NONE, "\t     -SW: Specify <size><unit> with units either from %s or %s [Default is k].\n", GMT_LEN_UNITS_DISPLAY, GMT_DIM_UNITS_DISPLAY);
+	GMT_Message (API, GMT_TIME_NONE, "\t     -Sw: Specify <size><unit> with units from %s [Default is %s].\n", GMT_DIM_UNITS_DISPLAY,
+		API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit]);
 	GMT_Message (API, GMT_TIME_NONE, "\t     Append +a to just draw arc or +r to just draw radial lines [wedge].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Geovectors: Azimuth and length must be in columns 3-4.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Append any of the units in %s to length [k].\n", GMT_LEN_UNITS_DISPLAY);

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -209,14 +209,14 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     axes [in km], and convert azimuths based on map projection.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Use -SE- for a degenerate ellipse (circle) with only diameter in km given.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     in column 4, or append a fixed diameter in km to -SE- instead.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     Append any of the units in %s to the axes [k].\n", GMT_LEN_UNITS_DISPLAY);
+	GMT_Message (API, GMT_TIME_NONE, "\t     Append any of the units in %s to the axes [Default is k].\n", GMT_LEN_UNITS_DISPLAY);
 	GMT_Message (API, GMT_TIME_NONE, "\t     For a linear projection we scale the axes by the map scale.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Rotatable Rectangle: Direction, x- and y-dimensions in columns 4-6.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     If -SJ rather than -Sj is selected, psxy will expect azimuth, and\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     dimensions [in km] and convert azimuths based on map projection.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Use -SJ- for a degenerate rectangle (square w/no rotation) with only one dimension given\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     in column 4, or append a fixed dimension to -SJ- instead.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     Append any of the units in %s to the dimensions [k].\n", GMT_LEN_UNITS_DISPLAY);
+	GMT_Message (API, GMT_TIME_NONE, "\t     Append any of the units in %s to the dimensions [Default is k].\n", GMT_LEN_UNITS_DISPLAY);
 	GMT_Message (API, GMT_TIME_NONE, "\t     For a linear projection we scale dimensions by the map scale.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Fronts: Give <tickgap>[/<ticklen>][+l|+r][+<type>][+o<offset>][+p[<pen>]].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     If <tickgap> is negative it means the number of gaps instead.\n");
@@ -254,7 +254,9 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	gmt_vector_syntax (API->GMT, 19);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Wedges: Start and stop directions of wedge must be in columns 3-4.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     If -SW rather than -Sw is selected, specify two azimuths instead.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     For geo-wedges, specify <size><unit> with units from %s.\n", GMT_LEN_UNITS_DISPLAY);
+	GMT_Message (API, GMT_TIME_NONE, "\t     -SW: Specify <size><unit> with units either from %s or %s [Default is k].\n", GMT_LEN_UNITS_DISPLAY, GMT_DIM_UNITS_DISPLAY);
+	GMT_Message (API, GMT_TIME_NONE, "\t     -Sw: Specify <size><unit> with units from %s [Default is %s].\n", GMT_DIM_UNITS_DISPLAY,
+		API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit]);
 	GMT_Message (API, GMT_TIME_NONE, "\t     Append +a to just draw arc or +r to just draw radial lines [wedge].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Geovectors: Azimuth and length must be in columns 3-4.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Append any of the units in %s to length [k].\n", GMT_LEN_UNITS_DISPLAY);


### PR DESCRIPTION
While **-SE-** worked correctly, **-SJ-** did not process the units (hardwired for km instead) and **-SW**_diameter_ needed to handle either geographic units (with km as the default) or plot units (unit is required when geo-wedge **-SW** is used; not so for Cartesian **-Sw**).