### PR TITLE
Update descriptions in top-level CMakeLists.txt and ConfigUserTemplate.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,9 @@
 #	Contact info: gmt.soest.hawaii.edu
 #-------------------------------------------------------------------------------
 #
-# To modify the cmake process: Edit your cmake/ConfigUser.cmake file
+# To configure the cmake process, first copy the configuration template
+# 'cmake/ConfigUserTemplate.cmake' to 'cmake/ConfigUser.cmake',
+# then edit 'cmake/ConfigUser.cmake'.
 #
 # To build out-of-source do (example):
 #
@@ -23,9 +25,6 @@
 #	cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 #
 # CMAKE_BUILD_TYPE can be: empty, Debug, Release, RelWithDebInfo or MinSizeRel
-#
-# cmake creates a new file cmake/ConfigUser.cmake if it does not already
-# exist. You can configure additional options there.
 #
 
 # Make sure the user doesn't play dirty with symlinks
@@ -94,7 +93,7 @@ endif (DO_EXAMPLES OR DO_TESTS AND NOT GRAPHICSMAGICK)
 #set(_manfiles_ps "" CACHE INTERNAL "Global list of PS manpages")
 add_subdirectory (src)
 add_subdirectory (share)      # share must be processed *after* src (GSHHG_PATH)
-add_subdirectory (doc)        # share must be processed *after* src (PDF manpages)
+add_subdirectory (doc)        # doc must be processed *after* src (PDF manpages)
 if (EXISTS ${GMT_SOURCE_DIR}/test/)
 	add_subdirectory (test)
 endif (EXISTS ${GMT_SOURCE_DIR}/test/)

--- a/cmake/ConfigUserTemplate.cmake
+++ b/cmake/ConfigUserTemplate.cmake
@@ -110,13 +110,13 @@
 # Set path to GSHHG Shoreline Database [auto]:
 #set (GSHHG_ROOT "gshhg_path")
 
-# Copy GSHHG files to $/coast [FALSE]:
+# Copy GSHHG files to ${GMT_DATADIR}/coast [FALSE]:
 #set (COPY_GSHHG TRUE)
 
 # Set path to DCW Digital Chart of the World for GMT [auto]:
 #set (DCW_ROOT "dcw-gmt_path")
 
-# Copy DCW files to $/dcw [FALSE]:
+# Copy DCW files to ${GMT_DATADIR}/dcw [FALSE]:
 #set (COPY_DCW TRUE)
 
 # FOR WINDOWS ONLY
@@ -183,7 +183,7 @@
 #set (BUILD_SHARED_LIBS FALSE)
 
 # Create position independent code on all targets [auto] (needed for static
-# build on non-x86:
+# build on non-x86):
 #set (CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
 # Build GMT shared lib with supplemental modules [TRUE]:

--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -17,7 +17,7 @@
 #
 include ("${CMAKE_SOURCE_DIR}/cmake/ConfigDefault.cmake")
 
-# If "ConfigUser.cmake" doesn't exist then create one for convenience.
+# A "ConfigUser.cmake" in the soruce tree overrides the defaults.
 if (EXISTS "${CMAKE_SOURCE_DIR}/cmake/ConfigUser.cmake")
 	include ("${CMAKE_SOURCE_DIR}/cmake/ConfigUser.cmake")
 endif (EXISTS "${CMAKE_SOURCE_DIR}/cmake/ConfigUser.cmake")

--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -17,7 +17,7 @@
 #
 include ("${CMAKE_SOURCE_DIR}/cmake/ConfigDefault.cmake")
 
-# A "ConfigUser.cmake" in the soruce tree overrides the defaults.
+# A "ConfigUser.cmake" in the source tree overrides the defaults.
 if (EXISTS "${CMAKE_SOURCE_DIR}/cmake/ConfigUser.cmake")
 	include ("${CMAKE_SOURCE_DIR}/cmake/ConfigUser.cmake")
 endif (EXISTS "${CMAKE_SOURCE_DIR}/cmake/ConfigUser.cmake")


### PR DESCRIPTION
1. cmake/ConfigUser.cmake won't be created if it doesn't exist
2. Fix some typos