### PR TITLE
Cleanup doc/fig/CMakeLists.txt

### DIFF
--- a/doc/fig/CMakeLists.txt
+++ b/doc/fig/CMakeLists.txt
@@ -21,9 +21,9 @@ set (_fig_fig GMT4_mode.png GMT5_Summit_2016.jpg GMT5_mode.png GMT5_external.png
 	formatpicture.png rendering.png)
 
 # Copy figures without converting
+FILE(MAKE_DIRECTORY ${RST_BINARY_DIR}/_images)
 set (_fig_fig_out)
 foreach (_fig ${_fig_fig})
-	FILE(MAKE_DIRECTORY ${RST_BINARY_DIR}/_images)
 	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_fig}
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different
 		${CMAKE_CURRENT_SOURCE_DIR}/${_fig} ${RST_BINARY_DIR}/_images/${_fig}

--- a/doc/fig/CMakeLists.txt
+++ b/doc/fig/CMakeLists.txt
@@ -18,8 +18,7 @@
 # Figure files
 set (_fig_fig GMT4_mode.png GMT5_Summit_2016.jpg GMT5_mode.png GMT5_external.png
 	GMT_Environment.png GMT_record.png gimp-sliders+panel.png hsv-cone.png
-	formatpicture.png formatting.png highres.png
-	noantialias.png rendering.png withantialias.png)
+	formatpicture.png rendering.png)
 
 # Copy figures without converting
 set (_fig_fig_out)


### PR DESCRIPTION
**Description of proposed changes**

This PR makes two changes to `doc/fig/CMakeLists.txt`:

1. Four figures (formatting.png, highres.png, noantialias.png and withantialias.png) aren't directly included in the rST documentations, thus no need to copy them
2. Move `MAKE_DIRECTORY` out of for loop to avoid trying to create the same directory multiple times.