### PR TITLE
Fix do_view.sh and do_view.bat

### DIFF
--- a/doc/examples/do_view.bat
+++ b/doc/examples/do_view.bat
@@ -7,7 +7,7 @@ REM all examples have been run with do_examples
 
 echo Loop over all examples and view each plot
 
-for %%d in (01 02 03 03a 03b 03c 03d 03e 03f 04 04c 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50) do gsview32 example_%%d.ps
+for /r %%i in (*.ps) do gsview32 %%i
 
 echo "Completed viewing all examples"
 echo ON

--- a/doc/examples/do_view.sh
+++ b/doc/examples/do_view.sh
@@ -4,7 +4,7 @@
 #	Simple driver to view all examples using ghostview
 #
 viewer=${1:-gv}
-for f in example_*.ps
+for f in ex*/example_*.ps
 do
 	$viewer $f
 done


### PR DESCRIPTION
1. Fixes do_view.sh
2. Simplify do_view.bat by wildcard. The new script can view any *.ps file in the example directory.