### PR TITLE
Use ctest instead of make check to avoid the stalled build issue on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ script:
     - gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
     - gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -Vd && gmt end
     - if [[ "$TEST" == "true" ]]; then
-        cmake --build . --target check;
+        ctest --force-new-ctest-process -j4;
       fi
     # Upload test coverage even if build fails. Keep separate to make sure this task
     # fails if the tests fail.


### PR DESCRIPTION
Although `cmake --build . --target check` is equivalent to `ctest --force-new-ctest-process -j4`, the former one causes troubles on Travis, as it wont't output anything unless all tests are completed.
