### PR TITLE
Fix some deprecated syntax in examples

### DIFF
--- a/doc/examples/ex03/example_03.bat
+++ b/doc/examples/ex03/example_03.bat
@@ -22,13 +22,13 @@ gmt math -T-1167/1169/1 -N1/0 = samp.x
 REM
 REM Now we can resample the gmt projected satellite data:
 REM
-gmt sample1d sat.pg -Nsamp.x > samp_sat.pg
+gmt sample1d sat.pg -Tsamp.x > samp_sat.pg
 REM
 REM For reasons above, we use gmt filter1d to pre-treat the ship data.  We also need to sample it
 REM because of the gaps over 1 km we found.  So we use gmt filter1d and gmt sample1d.  We also use the -E
 REM on gmt filter1d to use the data all the way out to sampr1/sampr2 :
 REM
-gmt filter1d ship.pg -Fm1 -T-1167/1169/1 -E | gmt sample1d -Nsamp.x > samp_ship.pg
+gmt filter1d ship.pg -Fm1 -T-1167/1169/1 -E | gmt sample1d -Tsamp.x > samp_ship.pg
 REM Now to do the cross-spectra, assuming that the ship is the input and the sat is the output 
 REM data, we do this:
 REM 

--- a/doc/examples/ex03/example_03.sh
+++ b/doc/examples/ex03/example_03.sh
@@ -78,13 +78,13 @@ gmt math -T$bounds/1 -N1/0 T = samp.x
 #
 # Now we can resample the gmt projected satellite data:
 #
-gmt sample1d sat.pg -Nsamp.x > samp_sat.pg
+gmt sample1d sat.pg -Tsamp.x > samp_sat.pg
 #
 # For reasons above, we use gmt filter1d to pre-treat the ship data.  We also need to sample
 # it because of the gaps > 1 km we found.  So we use gmt filter1d | gmt sample1d.  We also
 # use the -E on gmt filter1d to use the data all the way out to bounds :
 #
-gmt filter1d ship.pg -Fm1 -T$bounds/1 -E | gmt sample1d -Nsamp.x > samp_ship.pg
+gmt filter1d ship.pg -Fm1 -T$bounds/1 -E | gmt sample1d -Tsamp.x > samp_ship.pg
 #
 # Now we plot them again to see if we have done the right thing:
 #
@@ -137,9 +137,9 @@ gmt psxy $R -JX8i/1.1i -O -Y4.25i -Bxf100 -Bya0.5f0.1+l"Weight" -BWesn -Sp0.03i 
 # and this time we also use gmt trend1d to return the residual from the model fit (the 
 # de-trended data):
 gmt trend1d -Fxrw -Np1+r samp_ship.pg | gmt select -Z0/0.6 -o0,1 -Iz \
-	| gmt sample1d -Nsamp.x > samp2_ship.pg
+	| gmt sample1d -Tsamp.x > samp2_ship.pg
 gmt trend1d -Fxrw -Np1+r samp_sat.pg  | gmt select -Z0/0.6 -o0,1 -Iz \
-	| gmt sample1d -Nsamp.x > samp2_sat.pg
+	| gmt sample1d -Tsamp.x > samp2_sat.pg
 #
 # We plot these to see how they look:
 #

--- a/doc/examples/ex31/example_31.bat
+++ b/doc/examples/ex31/example_31.bat
@@ -47,7 +47,7 @@ echo L 8 LinBiolinumOB L Population in Millions >> legend.txt
 echo N 6 >> legend.txt
 
 REM append city names and population to legend
-gawk "BEGIN {FS=\",\"; f=\"L 8 LinBiolinumO L\"} ($4 > 1000000) {printf \"%%s %%s:\n%%s %%.2f\n\", f, $3, f, $4/1e6}" europe-capitals.csv >> legend.txt
+gawk "BEGIN {FS=\",\"; f=\"L 8p,LinBiolinumO L\"} ($4 > 1000000) {printf \"%%s %%s:\n%%s %%.2f\n\", f, $3, f, $4/1e6}" europe-capitals.csv >> legend.txt
 
 REM reduce annotation font size for legend
 gmt set FONT_ANNOT_PRIMARY 8p

--- a/doc/examples/ex31/example_31.sh
+++ b/doc/examples/ex31/example_31.sh
@@ -62,12 +62,12 @@ S 0.15c c 0.15c 196/80/80 0.25p 0.5c < 1 Million inhabitants
 S 0.15c c 0.15c 196/80/80 1.25p 0.5c > 1 Million inhabitants
 N 1
 G 0.15c
-L 8p,LinBiolinumOB L Population in Millions 
+L 8p,LinBiolinumOB L Population in Millions
 N 6
 EOF
 
 # append city names and population to legend
-$AWK 'BEGIN {FS=","; f="L 8 LinBiolinumO L"}
+$AWK 'BEGIN {FS=","; f="L 8p,LinBiolinumO L"}
   $4 > 1000000 {printf "%s %s:\n%s %.2f\n", f, $3, f, $4/1e6}' \
   $capitals >> legend.txt
 

--- a/doc/examples/ex38/example_38.bat
+++ b/doc/examples/ex38/example_38.bat
@@ -13,16 +13,16 @@ gmt makecpt -Crainbow -T0/15/1 > c.cpt
 gmt grdhisteq @topo_38.nc -Gout.nc -C16
 gmt grdimage @topo_38.nc -I+a45+nt1 -Ct.cpt -JM3i -Y6i -K -P -B5 -BWSne > %ps%
 echo 315 -10 Original | gmt pstext -R@topo_38.nc -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> %ps%
-gmt grdimage out.nc -Cc.cpt -J -X3.5i -K -O -B5 -BWSne >> %ps%
+gmt grdimage out.nc -Cc.cpt -J -X3.8i -K -O -B5 -BWSne >> %ps%
 echo 315 -10 Equalized | gmt pstext -R -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> %ps%
 gmt psscale -Dx0i/-0.4i+jTC+w5i/0.15i+h+e+n -O -K -Ct.cpt -Ba500 -By+lm >> %ps%
 gmt grdhisteq @topo_38.nc -Gout.nc -N
 gmt makecpt -Crainbow -T-3/3 > c.cpt
-gmt grdimage out.nc -Cc.cpt -J -X-3.5i -Y-3.3i -K -O -B5 -BWSne >> %ps%
+gmt grdimage out.nc -Cc.cpt -J -X-3.8i -Y-3.3i -K -O -B5 -BWSne >> %ps%
 echo 315 -10 Normalized | gmt pstext -R -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> %ps%
 gmt grdhisteq @topo_38.nc -Gout.nc -Q
 gmt makecpt -Crainbow -T0/15 > q.cpt
-gmt grdimage out.nc -Cq.cpt -J -X3.5i -K -O -B5 -BWSne >> %ps%
+gmt grdimage out.nc -Cq.cpt -J -X3.8i -K -O -B5 -BWSne >> %ps%
 echo 315 -10 Quadratic | gmt pstext -R -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> %ps%
 gmt psscale -Dx0i/-0.4i+w5i/0.15i+h+jTC+e+n -O -K -Cc.cpt -Bx1 -By+l"z@-n@-" >> %ps%
 gmt psscale -Dx0i/-1.0i+w5i/0.15i+h+jTC+e+n -O -Cq.cpt -Bx1 -By+l"z@-q@-" >> %ps%

--- a/doc/examples/ex38/example_38.bat
+++ b/doc/examples/ex38/example_38.bat
@@ -12,18 +12,18 @@ gmt makecpt -Crainbow -T0/1700 > t.cpt
 gmt makecpt -Crainbow -T0/15/1 > c.cpt
 gmt grdhisteq @topo_38.nc -Gout.nc -C16
 gmt grdimage @topo_38.nc -I+a45+nt1 -Ct.cpt -JM3i -Y6i -K -P -B5 -BWSne > %ps%
-echo 315 -10 Original | gmt pstext -R@topo_38.nc -J -O -K -F+jTR+f14p -T -Gwhite -W1p -Dj0.1i >> %ps%
+echo 315 -10 Original | gmt pstext -R@topo_38.nc -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> %ps%
 gmt grdimage out.nc -Cc.cpt -J -X3.5i -K -O -B5 -BWSne >> %ps%
-echo 315 -10 Equalized | gmt pstext -R -J -O -K -F+jTR+f14p -T -Gwhite -W1p -Dj0.1i >> %ps%
+echo 315 -10 Equalized | gmt pstext -R -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> %ps%
 gmt psscale -Dx0i/-0.4i+jTC+w5i/0.15i+h+e+n -O -K -Ct.cpt -Ba500 -By+lm >> %ps%
 gmt grdhisteq @topo_38.nc -Gout.nc -N
 gmt makecpt -Crainbow -T-3/3 > c.cpt
 gmt grdimage out.nc -Cc.cpt -J -X-3.5i -Y-3.3i -K -O -B5 -BWSne >> %ps%
-echo 315 -10 Normalized | gmt pstext -R -J -O -K -F+jTR+f14p -T -Gwhite -W1p -Dj0.1i >> %ps%
+echo 315 -10 Normalized | gmt pstext -R -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> %ps%
 gmt grdhisteq @topo_38.nc -Gout.nc -Q
 gmt makecpt -Crainbow -T0/15 > q.cpt
 gmt grdimage out.nc -Cq.cpt -J -X3.5i -K -O -B5 -BWSne >> %ps%
-echo 315 -10 Quadratic | gmt pstext -R -J -O -K -F+jTR+f14p -T -Gwhite -W1p -Dj0.1i >> %ps%
+echo 315 -10 Quadratic | gmt pstext -R -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> %ps%
 gmt psscale -Dx0i/-0.4i+w5i/0.15i+h+jTC+e+n -O -K -Cc.cpt -Bx1 -By+l"z@-n@-" >> %ps%
 gmt psscale -Dx0i/-1.0i+w5i/0.15i+h+jTC+e+n -O -Cq.cpt -Bx1 -By+l"z@-q@-" >> %ps%
 REM Clean up

--- a/doc/examples/ex38/example_38.sh
+++ b/doc/examples/ex38/example_38.sh
@@ -11,18 +11,18 @@ gmt makecpt -Crainbow -T0/1700 > t.cpt
 gmt makecpt -Crainbow -T0/15/1 > c.cpt
 gmt grdhisteq @topo_38.nc -Gout.nc -C16
 gmt grdimage @topo_38.nc -I+d -Ct.cpt -JM3i -Y6i -K -P -B5 -BWSne > $ps
-echo "315 -10 Original" | gmt pstext -R@topo_38.nc -J -O -K -F+jTR+f14p -T -Gwhite -W1p -Dj0.1i >> $ps
+echo "315 -10 Original" | gmt pstext -R@topo_38.nc -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> $ps
 gmt grdimage out.nc -Cc.cpt -J -X3.5i -K -O -B5 -BWSne >> $ps
-echo "315 -10 Equalized" | gmt pstext -R -J -O -K -F+jTR+f14p -T -Gwhite -W1p -Dj0.1i >> $ps
+echo "315 -10 Equalized" | gmt pstext -R -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> $ps
 gmt psscale -Dx0i/-0.4i+jTC+w5i/0.15i+h+e+n -O -K -Ct.cpt -Ba500 -By+lm >> $ps
 gmt grdhisteq @topo_38.nc -Gout.nc -N
 gmt makecpt -Crainbow -T-3/3 > c.cpt
 gmt grdimage out.nc -Cc.cpt -J -X-3.5i -Y-3.3i -K -O -B5 -BWSne >> $ps
-echo "315 -10 Normalized" | gmt pstext -R -J -O -K -F+jTR+f14p -T -Gwhite -W1p -Dj0.1i >> $ps
+echo "315 -10 Normalized" | gmt pstext -R -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> $ps
 gmt grdhisteq @topo_38.nc -Gout.nc -Q
 gmt makecpt -Crainbow -T0/15 > q.cpt
 gmt grdimage out.nc -Cq.cpt -J -X3.5i -K -O -B5 -BWSne >> $ps
-echo "315 -10 Quadratic" | gmt pstext -R -J -O -K -F+jTR+f14p -T -Gwhite -W1p -Dj0.1i >> $ps
+echo "315 -10 Quadratic" | gmt pstext -R -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> $ps
 gmt psscale -Dx0i/-0.4i+w5i/0.15i+h+jTC+e+n -O -K -Cc.cpt -Bx1 -By+l"z@-n@-" >> $ps
 gmt psscale -Dx0i/-1.0i+w5i/0.15i+h+jTC+e+n -O -Cq.cpt -Bx1 -By+l"z@-q@-" >> $ps
 rm -f out.nc ?.cpt

--- a/doc/examples/ex38/example_38.sh
+++ b/doc/examples/ex38/example_38.sh
@@ -12,16 +12,16 @@ gmt makecpt -Crainbow -T0/15/1 > c.cpt
 gmt grdhisteq @topo_38.nc -Gout.nc -C16
 gmt grdimage @topo_38.nc -I+d -Ct.cpt -JM3i -Y6i -K -P -B5 -BWSne > $ps
 echo "315 -10 Original" | gmt pstext -R@topo_38.nc -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> $ps
-gmt grdimage out.nc -Cc.cpt -J -X3.5i -K -O -B5 -BWSne >> $ps
+gmt grdimage out.nc -Cc.cpt -J -X3.8i -K -O -B5 -BWSne >> $ps
 echo "315 -10 Equalized" | gmt pstext -R -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> $ps
 gmt psscale -Dx0i/-0.4i+jTC+w5i/0.15i+h+e+n -O -K -Ct.cpt -Ba500 -By+lm >> $ps
 gmt grdhisteq @topo_38.nc -Gout.nc -N
 gmt makecpt -Crainbow -T-3/3 > c.cpt
-gmt grdimage out.nc -Cc.cpt -J -X-3.5i -Y-3.3i -K -O -B5 -BWSne >> $ps
+gmt grdimage out.nc -Cc.cpt -J -X-3.8i -Y-3.3i -K -O -B5 -BWSne >> $ps
 echo "315 -10 Normalized" | gmt pstext -R -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> $ps
 gmt grdhisteq @topo_38.nc -Gout.nc -Q
 gmt makecpt -Crainbow -T0/15 > q.cpt
-gmt grdimage out.nc -Cq.cpt -J -X3.5i -K -O -B5 -BWSne >> $ps
+gmt grdimage out.nc -Cq.cpt -J -X3.8i -K -O -B5 -BWSne >> $ps
 echo "315 -10 Quadratic" | gmt pstext -R -J -O -K -F+jTR+f14p -Gwhite -W1p -Dj0.1i >> $ps
 gmt psscale -Dx0i/-0.4i+w5i/0.15i+h+jTC+e+n -O -K -Cc.cpt -Bx1 -By+l"z@-n@-" >> $ps
 gmt psscale -Dx0i/-1.0i+w5i/0.15i+h+jTC+e+n -O -Cq.cpt -Bx1 -By+l"z@-q@-" >> $ps

--- a/doc/examples/ex43/example_43.bat
+++ b/doc/examples/ex43/example_43.bat
@@ -28,7 +28,7 @@ REM Build legend
 echo H 18 Times-Roman Index of Animals > legend.txt
 echo D 1p >> legend.txt
 echo N 7 43 7 43 >> legend.txt
-gawk -F'\t' "{printf "L - - C %d.\nL - - L %s\n", NR, $NF}" B.txt >> legend.txt
+gawk -F'\t' "{printf "L - C %d.\nL - L %s\n", NR, $NF}" B.txt >> legend.txt
 gmt pslegend -DjBR+w2.5i+o0.4c -R -J -O -K -F+p1p+gwhite+s+c3p+r legend.txt --FONT_LABEL=8p >> %ps%
 gmt psbasemap -R0.5/28.5/-10/4 -JX6i/2i -O -K -Y-2.9i -B+glightgoldenrod >> %ps%
 gmt psxy -R -J -O -K -Gcornsilk1 -W0.25p,- << EOF >> %ps%

--- a/doc/examples/ex43/example_43.sh
+++ b/doc/examples/ex43/example_43.sh
@@ -31,7 +31,7 @@ H 18p,Times-Roman Index of Animals
 D 1p
 N 7 43 7 43
 EOF
-$AWK -F'\t' '{printf "L - - C %d.\nL - - L %s\n", NR, $NF}' B.txt >> legend.txt
+$AWK -F'\t' '{printf "L - C %d.\nL - L %s\n", NR, $NF}' B.txt >> legend.txt
 gmt pslegend -DjBR+w2.5i+o0.4c -R -J -O -K -F+p1p+gwhite+s+c3p+r legend.txt --FONT_LABEL=8p >> $ps
 gmt psbasemap -R0.5/28.5/-10/4 -JX6i/2i -O -K -Y-2.9i -B+glightgoldenrod >> $ps
 gmt psxy -R -J -O -K -Gcornsilk1 -W0.25p,- << EOF >> $ps


### PR DESCRIPTION
Please see the commit messages for deprecation warnings of old scripts.

The PS files in these examples need to be re-generated. Someone using US defaults please help with it.