### PR TITLE
Update links to GMT documentations

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -61,8 +61,8 @@ set (GMT_LIB_SOVERSION 6)
 # The build version (VERSION) of the GMT libraries.
 set (GMT_LIB_VERSION "${GMT_LIB_SOVERSION}.${GMT_PACKAGE_VERSION_MINOR}.${GMT_PACKAGE_VERSION_PATCH}")
 
-# The GMT wiki location
-set (GMT_TRAC_WIKI "http://gmt.soest.hawaii.edu/")
+# The GMT documentation URL
+set (GMT_DOC_URL "http://docs.generic-mapping-tools.org/latest")
 
 # Use SI units per default
 if (NOT UNITS)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -31,7 +31,7 @@
 #define GMT_VERSION_STRING "@GMT_VERSION_STRING@"
 #define GMT_LONG_VERSION_STRING "@GMT_LONG_VERSION_STRING@"
 
-#define GMT_TRAC_WIKI "@GMT_TRAC_WIKI@"
+#define GMT_DOC_URL "@GMT_DOC_URL@"
 
 /* path to executables/libs */
 #define GMT_BINDIR_RELATIVE "@GMT_BINDIR@"

--- a/src/docs.c
+++ b/src/docs.c
@@ -133,8 +133,8 @@ int GMT_docs (void *V_API, int mode, void *args) {
 	}
 	else {	/* One of the fixed doc files */
 		sprintf (URL, "file:///%s/doc/html/%s", API->GMT->session.SHAREDIR, module);
-		if (access (&URL[8], R_OK)) 	/* File does not exists, go to SOEST site */
-			sprintf (URL, "http://gmt.soest.hawaii.edu/doc/latest/%s", module);
+		if (access (&URL[8], R_OK)) 	/* File does not exists, go to GMT documentation site */
+			sprintf (URL, "%s/%s", GMT_DOC_URL, module);
 	}
 
 	if (opt->next) {	/* If an option request was made we position the doc there */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -108,7 +108,7 @@
 
 #define GMT_more_than_once(GMT,active) (gmt_M_check_condition (GMT, active, "Option -%c given more than once\n", option))
 
-#define GMT_COMPAT_INFO "Please see " GMT_TRAC_WIKI "doc/" GMT_PACKAGE_VERSION "/GMT_Docs.html#new-features-in-gmt-5 for more information.\n"
+#define GMT_COMPAT_INFO "Please see " GMT_DOC_URL "/changes.html#new-features-in-gmt-5 for more information.\n"
 #define GMT_COMPAT_WARN GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Parameter %s is deprecated.\n" GMT_COMPAT_INFO, GMT_keywords[case_val])
 #define GMT_COMPAT_CHANGE(new_P) GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Parameter %s is deprecated. Use %s instead.\n" GMT_COMPAT_INFO, GMT_keywords[case_val], new_P)
 #define GMT_COMPAT_TRANSLATE(new_P) error = (gmt_M_compat_check (GMT, 4) ? GMT_COMPAT_CHANGE (new_P) + gmtlib_setparameter (GMT, new_P, value, core) : gmtinit_badvalreport (GMT, keyword))


### PR DESCRIPTION
Fix old http://gmt.soest.hawaii.edu/doc/ links to http://docs.generic-mapping-tools.org/latest/.