### PR TITLE
Allow setting GDAL_DATA and PROJ_LIB via environment variables.

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14715,11 +14715,13 @@ struct GMT_CTRL *gmt_begin (struct GMTAPI_CTRL *API, const char *session, unsign
 		sprintf (dir, "%s/GDAL_DATA", API->GMT->session.SHAREDIR);
 		if (access (dir, F_OK) == 0) {		/* ... if it exists */
 			paths[0] = strdup(dir);
-			local_count++;
+			local_count = -1;
 		}
 	}
-	if (local_count)		/* Means we have a request to use custom GDAL/PROJ4 data dirs */
+	if (local_count) {		/* Means we have a request to use custom GDAL/PROJ4 data dirs */
 		OSRSetPROJSearchPaths(paths);
+		if (local_count < 0)  free (paths[0]);		/* This case was strdup allocated, so it can be freed */
+	}
 #endif
 
 	sprintf (version, "GMT%d", GMT_MAJOR_VERSION);


### PR DESCRIPTION
With the advent of GDAL3+PROJ4 V4 there might be conflicts between the different versions of files that PROJ4 needs to find out, for example, what a EPSG number is (@seisman  felt it already). On the other hand, in Windows I want to ship a full working GDAL+PROJ4 and for that we need a collection of auxiliary files pointed by GDAL's GDAL_DATA and PROJ's PROJ_LIB environmental variables.

This PR lets GMT users set them via the ``LOCAL_GDAL_DATA`` and ``LOCAL_PROJ_LIB`` (better names may be proposed) env variables. Furthermore, if all those files are copied into GMT's ``share/GDAL_DATA`` directory (like the Windows installer will do) then that dir will take preference to the GDAL's & PROJ's pointed ones.

Well, this is the intention. Only tested on Windows (Winbuntu is several years away of having a GDAL3) and it worked.

Reminder, this is a GDAL3 only thing (#ifdefed with GDAL_VERSION_MAJOR >= 3)