### PR TITLE
Let grd2cpt and makecpt set current CPT

### DIFF
--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -329,6 +329,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC void gmt_save_current_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P);
 EXTERN_MSC bool gmt_consider_current_cpt (struct GMTAPI_CTRL *API, bool *active, char **arg);
 EXTERN_MSC double *gmt_list_to_array (struct GMT_CTRL *GMT, char *list, unsigned int type, uint64_t *n);
 EXTERN_MSC int gmt_getfonttype (struct GMT_CTRL *GMT, char *name);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7661,12 +7661,12 @@ bool gmt_is_cpt_master (struct GMT_CTRL *GMT, char *cpt) {
 	return true;	/* Acting as if it is a master table */
 }
 
-GMT_LOCAL void support_save_current_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P) {
+void gmt_save_current_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P) {
 	char file[GMT_LEN256] = {""};
 	if (GMT->current.setting.run_mode == GMT_CLASSIC) return;
 	/* Save cpt for use by session */
 	sprintf (file, "%s/gmt.cpt", GMT->parent->gwf_dir);	/* Save this specially stretched CPT for other uses in the modern session, such as colorbor */
-	if (GMT_Write_Data (GMT->parent, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, 0, NULL, file, P) != GMT_NOERROR)
+	if (GMT_Write_Data (GMT->parent, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_IO_RESET, NULL, file, P) != GMT_NOERROR)
 		GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Unable to save current CPT file to %s !\n", file);
 	else
 		GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Save current CPT file to %s !\n", file);
@@ -7747,7 +7747,7 @@ struct GMT_PALETTE *gmt_get_palette (struct GMT_CTRL *GMT, char *file, enum GMT_
 			GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Auto-stretching CPT file %s to fit rounded data range %g to %g\n", master, zmin, zmax);
 		}
 		gmt_stretch_cpt (GMT, P, zmin, zmax);
-		support_save_current_cpt (GMT, P);	/* Save for use by session, if modern */
+		gmt_save_current_cpt (GMT, P);	/* Save for use by session, if modern */
 	}
 	else if (file) {	/* Gave a CPT file */
 		P = GMT_Read_Data (GMT->parent, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, &file[first], NULL);

--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -714,6 +714,8 @@ int GMT_grd2cpt (void *V_API, int mode, void *args) {
 	if (GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, cpt_flags, NULL, Ctrl->Out.file, Pout) != GMT_NOERROR)
 		error = API->error;
 
+	gmt_save_current_cpt (GMT, Pout);	/* Save for use by session, if modern */
+
 	gmt_M_free (GMT, cdf_cpt);
 	gmt_M_free (GMT, z);
 	if (error == GMT_NOERROR)

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -570,5 +570,7 @@ int GMT_makecpt (void *V_API, int mode, void *args) {
 		Return (API->error);
 	}
 
+	gmt_save_current_cpt (GMT, Pout);	/* Save for use by session, if modern */
+
 	Return (GMT_NOERROR);
 }


### PR DESCRIPTION
These creators of CPTs now set the output as the current CPT in modern mode.
This brings up the issue if makecpt and grd2cpt should even write their result to stdout since all modules needing a cpt can get the current one via -C with no arguments.  It looks a bit silly to say

`  gmt makecpt -Cterra -T-3000/1500 > /dev/null
`

when

`  gmt makecpt -Cterra -T-3000/1500
`

should be all you need? See #823 for more details.