### PR TITLE
Update modern mode script given -H option to makecpt/grd2cpt

### DIFF
--- a/doc/examples/anim02/anim_02.sh
+++ b/doc/examples/anim02/anim_02.sh
@@ -14,16 +14,14 @@ else	# Make animated GIF
 fi	
 # 1. Create files needed in the loop
 cat << EOF > pre.sh
-gmt begin
-	gmt math -T0/360/10 T 180 ADD = angles.txt
-	gmt makecpt -Crainbow -T500/4500
-gmt end
+gmt math -T0/360/10 T 180 ADD = angles.txt
+gmt makecpt -Crainbow -T500/4500 > main.cpt
 EOF
 # 2. Set up the main frame script
 cat << EOF > main.sh
 gmt begin
 	width=\`gmt math -Q \${MOVIE_WIDTH} 0.5i SUB =\`
-	gmt grdimage @tut_relief.nc -I+a\${MOVIE_COL0}+nt2 -JM\${width} -C \
+	gmt grdimage @tut_relief.nc -I+a\${MOVIE_COL0}+nt2 -JM\${width} -Cmain.cpt \
 		-BWSne -B1 -X0.35i -Y0.3i --FONT_ANNOT_PRIMARY=9p
 	gmt plot -Sc0.8i -Gwhite -Wthin <<< "256.25 35.6" 
 	gmt plot -Sv0.1i+e -Gred -Wthick <<< "256.25 35.6 \${MOVIE_COL1} 0.37i" 

--- a/doc/examples/anim02/anim_02.sh
+++ b/doc/examples/anim02/anim_02.sh
@@ -14,8 +14,10 @@ else	# Make animated GIF
 fi	
 # 1. Create files needed in the loop
 cat << EOF > pre.sh
-gmt math -T0/360/10 T 180 ADD = angles.txt
-gmt makecpt -Crainbow -T500/4500 > main.cpt
+gmt begin
+	gmt math -T0/360/10 T 180 ADD = angles.txt
+	gmt makecpt -Crainbow -T500/4500 -H > main.cpt
+gmt end
 EOF
 # 2. Set up the main frame script
 cat << EOF > main.sh

--- a/doc/examples/anim02/anim_02.sh
+++ b/doc/examples/anim02/anim_02.sh
@@ -14,14 +14,16 @@ else	# Make animated GIF
 fi	
 # 1. Create files needed in the loop
 cat << EOF > pre.sh
+gmt begin
 	gmt math -T0/360/10 T 180 ADD = angles.txt
-	gmt makecpt -Crainbow -T500/4500 > main.cpt
+	gmt makecpt -Crainbow -T500/4500
+gmt end
 EOF
 # 2. Set up the main frame script
 cat << EOF > main.sh
 gmt begin
 	width=\`gmt math -Q \${MOVIE_WIDTH} 0.5i SUB =\`
-	gmt grdimage @tut_relief.nc -I+a\${MOVIE_COL0}+nt2 -JM\${width} -Cmain.cpt \
+	gmt grdimage @tut_relief.nc -I+a\${MOVIE_COL0}+nt2 -JM\${width} -C \
 		-BWSne -B1 -X0.35i -Y0.3i --FONT_ANNOT_PRIMARY=9p
 	gmt plot -Sc0.8i -Gwhite -Wthin <<< "256.25 35.6" 
 	gmt plot -Sv0.1i+e -Gred -Wthick <<< "256.25 35.6 \${MOVIE_COL1} 0.37i" 

--- a/doc/examples/anim03/anim_03.sh
+++ b/doc/examples/anim03/anim_03.sh
@@ -14,9 +14,11 @@ else	# Make animated GIF, infinitely looping
 fi	
 # 1. Create files needed in the loop
 cat << EOF > pre.sh
-gmt math -T0/355/5 -o1 T = angles.txt
-gmt makecpt -Crelief -T-2000/2000/20 > iceland.cpt
-gmt grdclip -Sb0/-1 -Gabove.nc @Iceland.nc
+gmt begin
+	gmt math -T0/355/5 -o1 T = angles.txt
+	gmt makecpt -Crelief -T-2000/2000/20 -H > iceland.cpt
+	gmt grdclip -Sb0/-1 -Gabove.nc @Iceland.nc
+gmt end
 EOF
 # 2. Set up the main frame script
 cat << EOF > main.sh

--- a/doc/examples/anim03/anim_03.sh
+++ b/doc/examples/anim03/anim_03.sh
@@ -14,16 +14,14 @@ else	# Make animated GIF, infinitely looping
 fi	
 # 1. Create files needed in the loop
 cat << EOF > pre.sh
-gmt begin
-	gmt math -T0/355/5 -o1 T = angles.txt
-	gmt makecpt -Crelief -T-2000/2000/20
-	gmt grdclip -Sb0/-1 -Gabove.nc @Iceland.nc
-gmt end
+gmt math -T0/355/5 -o1 T = angles.txt
+gmt makecpt -Crelief -T-2000/2000/20 > iceland.cpt
+gmt grdclip -Sb0/-1 -Gabove.nc @Iceland.nc
 EOF
 # 2. Set up the main frame script
 cat << EOF > main.sh
 gmt begin
-	gmt grdview above.nc -R-26/-12/63/67 -JM2.5i -C -Qi100 -Bafg \
+	gmt grdview above.nc -R-26/-12/63/67 -JM2.5i -Ciceland.cpt -Qi100 -Bafg \
 		-X0.5i -Y0.5i -p\${MOVIE_COL0}/35+w20W/65N+v1.5i/0.75i
 gmt end
 EOF

--- a/doc/examples/anim03/anim_03.sh
+++ b/doc/examples/anim03/anim_03.sh
@@ -14,14 +14,16 @@ else	# Make animated GIF, infinitely looping
 fi	
 # 1. Create files needed in the loop
 cat << EOF > pre.sh
+gmt begin
 	gmt math -T0/355/5 -o1 T = angles.txt
-	gmt makecpt -Crelief -T-2000/2000/20 > iceland.cpt
+	gmt makecpt -Crelief -T-2000/2000/20
 	gmt grdclip -Sb0/-1 -Gabove.nc @Iceland.nc
+gmt end
 EOF
 # 2. Set up the main frame script
 cat << EOF > main.sh
 gmt begin
-	gmt grdview above.nc -R-26/-12/63/67 -JM2.5i -Ciceland.cpt -Qi100 -Bafg \
+	gmt grdview above.nc -R-26/-12/63/67 -JM2.5i -C -Qi100 -Bafg \
 		-X0.5i -Y0.5i -p\${MOVIE_COL0}/35+w20W/65N+v1.5i/0.75i
 gmt end
 EOF

--- a/doc/examples/anim04/anim_04.sh
+++ b/doc/examples/anim04/anim_04.sh
@@ -15,9 +15,11 @@ fi
 # 1. Create files needed in the loop
 cat << EOF > pre.sh
 # Set up flight path
-gmt project -C-73.8333/40.75 -E-80.133/25.75 -G10 -Q > flight_path.txt
-gmt grdgradient @USEast_Coast.nc -A90 -Nt1 -Gint_US.nc
-gmt makecpt -Cglobe > globe_US.cpt
+gmt begin
+	gmt project -C-73.8333/40.75 -E-80.133/25.75 -G10 -Q > flight_path.txt
+	gmt grdgradient @USEast_Coast.nc -A90 -Nt1 -Gint_US.nc
+	gmt makecpt -Cglobe -H > globe_US.cpt
+gmt end
 EOF
 # 2. Set up the main frame script
 cat << EOF > main.sh

--- a/doc/examples/anim04/anim_04.sh
+++ b/doc/examples/anim04/anim_04.sh
@@ -15,16 +15,18 @@ fi
 # 1. Create files needed in the loop
 cat << EOF > pre.sh
 # Set up flight path
-gmt project -C-73.8333/40.75 -E-80.133/25.75 -G10 -Q > flight_path.txt
-gmt grdgradient @USEast_Coast.nc -A90 -Nt1 -Gint_US.nc
-gmt makecpt -Cglobe > globe_US.cpt
+gmt begin
+	gmt project -C-73.8333/40.75 -E-80.133/25.75 -G10 -Q > flight_path.txt
+	gmt grdgradient @USEast_Coast.nc -A90 -Nt1 -Gint_US.nc
+	gmt makecpt -Cglobe
+gmt end
 EOF
 # 2. Set up the main frame script
 cat << EOF > main.sh
 gmt begin
 	gmt set FONT_TAG 14p,Helvetica-Bold
 	gmt grdimage -JG\${MOVIE_COL0}/\${MOVIE_COL1}/160/210/55/0/36/34/\${MOVIE_WIDTH}+ \
-		-Rg @USEast_Coast.nc -Iint_US.nc -Cglobe_US.cpt -X0 -Y0
+		-Rg @USEast_Coast.nc -Iint_US.nc -C -X0 -Y0
 	gmt plot -W1p flight_path.txt
 gmt end
 EOF

--- a/doc/examples/anim04/anim_04.sh
+++ b/doc/examples/anim04/anim_04.sh
@@ -15,18 +15,16 @@ fi
 # 1. Create files needed in the loop
 cat << EOF > pre.sh
 # Set up flight path
-gmt begin
-	gmt project -C-73.8333/40.75 -E-80.133/25.75 -G10 -Q > flight_path.txt
-	gmt grdgradient @USEast_Coast.nc -A90 -Nt1 -Gint_US.nc
-	gmt makecpt -Cglobe
-gmt end
+gmt project -C-73.8333/40.75 -E-80.133/25.75 -G10 -Q > flight_path.txt
+gmt grdgradient @USEast_Coast.nc -A90 -Nt1 -Gint_US.nc
+gmt makecpt -Cglobe > globe_US.cpt
 EOF
 # 2. Set up the main frame script
 cat << EOF > main.sh
 gmt begin
 	gmt set FONT_TAG 14p,Helvetica-Bold
 	gmt grdimage -JG\${MOVIE_COL0}/\${MOVIE_COL1}/160/210/55/0/36/34/\${MOVIE_WIDTH}+ \
-		-Rg @USEast_Coast.nc -Iint_US.nc -C -X0 -Y0
+		-Rg @USEast_Coast.nc -Iint_US.nc -Cglobe_US.cpt -X0 -Y0
 	gmt plot -W1p flight_path.txt
 gmt end
 EOF

--- a/doc/examples/anim05/anim_05.sh
+++ b/doc/examples/anim05/anim_05.sh
@@ -14,7 +14,9 @@ else	# Make animated GIF, infinitely looping
 fi	
 # 1. Create files needed in the loop
 cat << EOF > pre.sh
-	gmt makecpt -Cpolar -T-25/25 > t.cpt
+gmt begin
+	gmt makecpt -Cpolar -T-25/25
+gmt end
 EOF
 # 2. Set up the main frame script
 cat << EOF > main.sh
@@ -22,9 +24,9 @@ gmt begin
 	let k=\${MOVIE_FRAME}+1
 	gmt greenspline @Table_5_11.txt -R0/6.5/0/6.5 -I0.05 -Sc -Gt.nc -D1 -Cn\${k} -Emisfit.txt
 	gmt grdcontour t.nc -C25 -A50 -Baf -BWsNE -JX4i -Gl3.6/6.5/4.05/0.75 -X0.25i -Y0.4i
-	gmt plot misfit.txt -Ct.cpt -Sc0.15c -Wfaint -i0,1,4
+	gmt plot misfit.txt -C -Sc0.15c -Wfaint -i0,1,4
 	printf "%2.2d" \$k | gmt text -F+cTR+jTR+f18p -Dj0.1i -Gwhite -W0.25p
-	gmt psscale -Ct.cpt -DJBC+e -Bxaf -By+l"misfit"
+	gmt psscale -C -DJBC+e -Bxaf -By+l"misfit"
 gmt end
 EOF
 # 3. Run the movie

--- a/doc/examples/anim05/anim_05.sh
+++ b/doc/examples/anim05/anim_05.sh
@@ -14,9 +14,7 @@ else	# Make animated GIF, infinitely looping
 fi	
 # 1. Create files needed in the loop
 cat << EOF > pre.sh
-gmt begin
-	gmt makecpt -Cpolar -T-25/25
-gmt end
+gmt makecpt -Cpolar -T-25/25 > t.cpt
 EOF
 # 2. Set up the main frame script
 cat << EOF > main.sh
@@ -24,9 +22,9 @@ gmt begin
 	let k=\${MOVIE_FRAME}+1
 	gmt greenspline @Table_5_11.txt -R0/6.5/0/6.5 -I0.05 -Sc -Gt.nc -D1 -Cn\${k} -Emisfit.txt
 	gmt grdcontour t.nc -C25 -A50 -Baf -BWsNE -JX4i -Gl3.6/6.5/4.05/0.75 -X0.25i -Y0.4i
-	gmt plot misfit.txt -C -Sc0.15c -Wfaint -i0,1,4
+	gmt plot misfit.txt -Ct.cpt -Sc0.15c -Wfaint -i0,1,4
 	printf "%2.2d" \$k | gmt text -F+cTR+jTR+f18p -Dj0.1i -Gwhite -W0.25p
-	gmt psscale -C -DJBC+e -Bxaf -By+l"misfit"
+	gmt psscale -Ct.cpt -DJBC+e -Bxaf -By+l"misfit"
 gmt end
 EOF
 # 3. Run the movie

--- a/doc/examples/anim05/anim_05.sh
+++ b/doc/examples/anim05/anim_05.sh
@@ -14,7 +14,9 @@ else	# Make animated GIF, infinitely looping
 fi	
 # 1. Create files needed in the loop
 cat << EOF > pre.sh
-gmt makecpt -Cpolar -T-25/25 > t.cpt
+gmt begin
+	gmt makecpt -Cpolar -T-25/25 -H > t.cpt
+gmt end
 EOF
 # 2. Set up the main frame script
 cat << EOF > main.sh

--- a/doc/examples/anim07/anim_07.sh
+++ b/doc/examples/anim07/anim_07.sh
@@ -18,7 +18,7 @@ gmt begin
 	# Set view and sun longitudes
 	gmt math -T0/360/5 -I T 5 SUB = longitudes.txt
 	# Extract a topography CPT
-	gmt makecpt -Cdem2 -T0/6000
+	gmt makecpt -Cdem2 -T0/6000 -H > t.cpt
 	# Get gradients of the relief from N45E
 	gmt grdgradient @earth_relief_20m -Nt1.25 -A45 -Gintens.nc
 gmt end
@@ -35,7 +35,7 @@ gmt begin
 	# Clip to expose land areas only
 	gmt coast -Gc
 	# Overlay relief over land only using dem cpt
-	gmt grdimage @earth_relief_20m -Is.nc -C
+	gmt grdimage @earth_relief_20m -Is.nc -Ct.cpt
 	# Undo clipping and overlay gridlines
 	gmt coast -Q -B30g30
 gmt end

--- a/doc/examples/anim07/anim_07.sh
+++ b/doc/examples/anim07/anim_07.sh
@@ -14,12 +14,14 @@ else	# Make movie in MP4 format and a thumbnail animated GIF using every 10th fr
 fi
 # 1. Create background plot and data files needed in the loop
 cat << EOF > pre.sh
-# Set view and sun longitudes
-gmt math -T0/360/5 -I T 5 SUB = longitudes.txt
-# Extract a topography CPT
-gmt makecpt -Cdem2 -T0/6000 > movie_dem.cpt
-# Get gradients of the relief from N45E
-gmt grdgradient @earth_relief_20m -Nt1.25 -A45 -Gintens.nc
+gmt begin
+	# Set view and sun longitudes
+	gmt math -T0/360/5 -I T 5 SUB = longitudes.txt
+	# Extract a topography CPT
+	gmt makecpt -Cdem2 -T0/6000
+	# Get gradients of the relief from N45E
+	gmt grdgradient @earth_relief_20m -Nt1.25 -A45 -Gintens.nc
+gmt end
 EOF
 # 2. Set up main script
 cat << EOF > main.sh
@@ -33,7 +35,7 @@ gmt begin
 	# Clip to expose land areas only
 	gmt coast -Gc
 	# Overlay relief over land only using dem cpt
-	gmt grdimage @earth_relief_20m -Is.nc -Cmovie_dem.cpt
+	gmt grdimage @earth_relief_20m -Is.nc -C
 	# Undo clipping and overlay gridlines
 	gmt coast -Q -B30g30
 gmt end

--- a/doc/examples/anim08/anim_08.sh
+++ b/doc/examples/anim08/anim_08.sh
@@ -21,9 +21,11 @@ TIME="starttime=2018-01-01%2000:00:00&endtime=2018-12-31%2000:00:00"
 MAG="minmagnitude=5"
 ORDER="orderby=time-asc"
 URL="\${SITE}?\${TIME}&\${MAG}&\${ORDER}"
-gmt convert \$URL -i2,1,3,4+s50,0 -hi1 > q.txt
-gmt makecpt -Cred,green,blue -T0,70,300,10000 > movie_dem.cpt
-gmt math -T2018-01-01T/2018-12-31T/2 --TIME_UNIT=d TNORM 40 MUL 200 ADD = times.txt
+gmt begin
+	gmt convert \$URL -i2,1,3,4+s50,0 -hi1 > q.txt
+	gmt makecpt -Cred,green,blue -T0,70,300,10000 -H > movie_dem.cpt
+	gmt math -T2018-01-01T/2018-12-31T/2 --TIME_UNIT=d TNORM 40 MUL 200 ADD = times.txt
+gmt end
 EOF
 # 2. Set up main script
 cat << EOF > main.sh

--- a/doc/examples/anim08/anim_08.sh
+++ b/doc/examples/anim08/anim_08.sh
@@ -16,23 +16,21 @@ fi
 # Note: The URL tends to change every few years...
 # 1. Extract 2018 data from URL and prepare inputs and frame times
 cat << EOF > pre.sh
-gmt begin
-	SITE="https://earthquake.usgs.gov/fdsnws/event/1/query.csv"
-	TIME="starttime=2018-01-01%2000:00:00&endtime=2018-12-31%2000:00:00"
-	MAG="minmagnitude=5"
-	ORDER="orderby=time-asc"
-	URL="\${SITE}?\${TIME}&\${MAG}&\${ORDER}"
-	gmt convert \$URL -i2,1,3,4+s50,0 -hi1 > q.txt
-	gmt makecpt -Cred,green,blue -T0,70,300,10000
-	gmt math -T2018-01-01T/2018-12-31T/2 --TIME_UNIT=d TNORM 40 MUL 200 ADD = times.txt
-gmt end
+SITE="https://earthquake.usgs.gov/fdsnws/event/1/query.csv"
+TIME="starttime=2018-01-01%2000:00:00&endtime=2018-12-31%2000:00:00"
+MAG="minmagnitude=5"
+ORDER="orderby=time-asc"
+URL="\${SITE}?\${TIME}&\${MAG}&\${ORDER}"
+gmt convert \$URL -i2,1,3,4+s50,0 -hi1 > q.txt
+gmt makecpt -Cred,green,blue -T0,70,300,10000 > movie_dem.cpt
+gmt math -T2018-01-01T/2018-12-31T/2 --TIME_UNIT=d TNORM 40 MUL 200 ADD = times.txt
 EOF
 # 2. Set up main script
 cat << EOF > main.sh
 gmt begin
 	gmt coast -Rg -JG\${MOVIE_COL1}/5/6i -G128 -S32 -X0 -Y0 -A500
 	gmt plot @ridge.txt -W0.5p,darkyellow
-	gmt events q.txt -SE- -C --TIME_UNIT=d -T\${MOVIE_COL0} -Es+r2+d6 -Ms5+c0.5 -Mi1+c-0.6 -Mt+c0
+	gmt events q.txt -SE- -Cmovie_dem.cpt --TIME_UNIT=d -T\${MOVIE_COL0} -Es+r2+d6 -Ms5+c0.5 -Mi1+c-0.6 -Mt+c0
 gmt end
 EOF
 # 3. Run the movie

--- a/doc/examples/anim08/anim_08.sh
+++ b/doc/examples/anim08/anim_08.sh
@@ -16,21 +16,23 @@ fi
 # Note: The URL tends to change every few years...
 # 1. Extract 2018 data from URL and prepare inputs and frame times
 cat << EOF > pre.sh
-SITE="https://earthquake.usgs.gov/fdsnws/event/1/query.csv"
-TIME="starttime=2018-01-01%2000:00:00&endtime=2018-12-31%2000:00:00"
-MAG="minmagnitude=5"
-ORDER="orderby=time-asc"
-URL="\${SITE}?\${TIME}&\${MAG}&\${ORDER}"
-gmt convert \$URL -i2,1,3,4+s50,0 -hi1 > q.txt
-gmt makecpt -Cred,green,blue -T0,70,300,10000 > q.cpt
-gmt math -T2018-01-01T/2018-12-31T/2 --TIME_UNIT=d TNORM 40 MUL 200 ADD = times.txt
+gmt begin
+	SITE="https://earthquake.usgs.gov/fdsnws/event/1/query.csv"
+	TIME="starttime=2018-01-01%2000:00:00&endtime=2018-12-31%2000:00:00"
+	MAG="minmagnitude=5"
+	ORDER="orderby=time-asc"
+	URL="\${SITE}?\${TIME}&\${MAG}&\${ORDER}"
+	gmt convert \$URL -i2,1,3,4+s50,0 -hi1 > q.txt
+	gmt makecpt -Cred,green,blue -T0,70,300,10000
+	gmt math -T2018-01-01T/2018-12-31T/2 --TIME_UNIT=d TNORM 40 MUL 200 ADD = times.txt
+gmt end
 EOF
 # 2. Set up main script
 cat << EOF > main.sh
 gmt begin
 	gmt coast -Rg -JG\${MOVIE_COL1}/5/6i -G128 -S32 -X0 -Y0 -A500
 	gmt plot @ridge.txt -W0.5p,darkyellow
-	gmt events q.txt -SE- -Cq.cpt --TIME_UNIT=d -T\${MOVIE_COL0} -Es+r2+d6 -Ms5+c0.5 -Mi1+c-0.6 -Mt+c0
+	gmt events q.txt -SE- -C --TIME_UNIT=d -T\${MOVIE_COL0} -Es+r2+d6 -Ms5+c0.5 -Mi1+c-0.6 -Mt+c0
 gmt end
 EOF
 # 3. Run the movie

--- a/doc/rst/source/grd2cpt.rst
+++ b/doc/rst/source/grd2cpt.rst
@@ -17,9 +17,12 @@ Synopsis
 [ |-C|\ *cpt* ] [ |-D|\ [**i**] ]
 [ |-E|\ [*nlevels*] ]
 [ |-F|\ [**R**\ \|\ **r**\ \|\ **h**\ \|\ **c**\ ][**+c**\ ]]
-[ |-G|\ *zlo*\ /\ *zhi* ] [ |-I|\ [**c**][**z**] ]
+[ |-G|\ *zlo*\ /\ *zhi* ]
+[ |-H| ]
+[ |-I|\ [**c**][**z**] ]
 [ |-L|\ *minlimit/maxlimit* ]
-[ |-M| ] [ |-N| ]
+[ |-M| ]
+[ |-N| ]
 [ |-Q|\ [**i**\ \|\ **o**] ]
 [ |SYN_OPT-R| ]
 [ |-S|\ **h**\ \|\ **l**\ \|\ **m**\ \|\ **u** ]
@@ -35,7 +38,9 @@ Description
 -----------
 
 **grd2cpt** reads one or more grid files and writes a static color palette
-(CPT) file to standard output. The CPT is based on an existing dynamic
+(CPT) file. In classic mode we write the CMT to standard output, while under
+modern mode we simply save the CPT as the current session CPT (but see **-H**).
+The CPT is based on an existing dynamic
 master CPT of your choice, and the mapping from data value to
 colors is through the data's cumulative distribution function (CDF), so
 that the colors are histogram equalized. Thus if the grid(s) and the
@@ -128,6 +133,12 @@ Optional Arguments
     are to *zlo* and *zhi*.  If one of these equal NaN then
     we leave that end of the CPT alone.  The truncation takes place
     before any resampling. See also :ref:`manipulating_CPTs`
+
+.. _-H:
+
+**-H**\
+    Modern mode only: Write the CPT to standard output as well [Default saves
+    the CPT as the session current CPT].
 
 .. _-I:
 

--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -19,8 +19,11 @@ Synopsis
 [ |-E|\ [*nlevels*] ]
 [ |-F|\ [**R**\ \|\ **r**\ \|\ **h**\ \|\ **c**\ ][**+c**\ ]]
 [ |-G|\ *zlo*\ /\ *zhi* ]
-[ |-I|\ [**c**][**z**] ] [ |-M| ]
-[ |-N| ] [ |-Q| ]
+[ |-H| ]
+[ |-I|\ [**c**][**z**] ]
+[ |-M| ]
+[ |-N| ]
+[ |-Q| ]
 [ |-S|\ *mode* ]
 [ |-T|\ [*min*/*max*/*inc*\ [**+n**\ ]\|\ *file*\ \|\ *list*\ ] ]
 [ |-V|\ [*level*\ ] ]
@@ -37,7 +40,9 @@ Description
 -----------
 
 **makecpt** is a module that will help you make static color palette tables
-(CPTs). You define an equidistant set of contour intervals or pass
+(CPTs). In classic mode we write the CMT to standard output, while under
+modern mode we simply save the CPT as the current session CPT (but see **-H**).
+You define an equidistant set of contour intervals or pass
 your own z-table or list, and create a new CPT based on an existing master (dynamic)
 CPT. The resulting CPT can be reversed relative to the master
 cpt, and can be made continuous or discrete.  For color tables beyond the
@@ -125,6 +130,12 @@ Optional Arguments
     are to *zlo* and *zhi*.  If one of these equal NaN then
     we leave that end of the CPT alone.  The truncation takes place
     before any resampling. See also :ref:`manipulating_CPTs`
+
+.. _-H:
+
+**-H**\
+    Modern mode only: Write the CPT to standard output as well [Default saves
+    the CPT as the session current CPT].
 
 .. _-I:
 

--- a/doc/scripts/GMT_App_M_1a.sh
+++ b/doc/scripts/GMT_App_M_1a.sh
@@ -49,10 +49,10 @@ do
 	j=`expr $i + 1`
 	left=`sed -n ${j}p tt.lis`
 	right=`sed -n ${i}p tt.lis`
-	gmt makecpt -C$left > tt.left.cpt
-	gmt makecpt -C$left -T-1/1/0.25 > tt.left2.cpt
-	gmt makecpt -C$right > tt.right.cpt
-	gmt makecpt -C$right -T-1/1/0.25 > tt.right2.cpt
+	gmt makecpt -H -C$left > tt.left.cpt
+	gmt makecpt -H -C$left -T-1/1/0.25 > tt.left2.cpt
+	gmt makecpt -H -C$right > tt.right.cpt
+	gmt makecpt -H -C$right -T-1/1/0.25 > tt.right2.cpt
 	gmt colorbar -D1.55i/${y}i+w2.70i/0.125i+h+jTC -Ctt.left.cpt -B0 
 	gmt colorbar -D4.50i/${y}i+w2.70i/0.125i+h+jTC -Ctt.right.cpt -B0 
 	gmt colorbar -D1.55i/${y2}i+w2.70i/0.125i+h+jTC -Ctt.left2.cpt -Bf0.25

--- a/doc/scripts/GMT_App_M_1b.sh
+++ b/doc/scripts/GMT_App_M_1b.sh
@@ -48,10 +48,10 @@ do
 	j=`expr $i + 1`
 	left=`sed -n ${j}p tt.lis`
 	right=`sed -n ${i}p tt.lis`
-	gmt makecpt -C$left > tt.left.cpt
-	gmt makecpt -C$left -T-1/1/0.25 > tt.left2.cpt
-	gmt makecpt -C$right > tt.right.cpt
-	gmt makecpt -C$right -T-1/1/0.25 > tt.right2.cpt
+	gmt makecpt -H -C$left > tt.left.cpt
+	gmt makecpt -H -C$left -T-1/1/0.25 > tt.left2.cpt
+	gmt makecpt -H -C$right > tt.right.cpt
+	gmt makecpt -H -C$right -T-1/1/0.25 > tt.right2.cpt
 	gmt colorbar -D1.55i/${y}i+w2.70i/0.125i+h+jTC -Ctt.left.cpt -B0 
 	gmt colorbar -D4.50i/${y}i+w2.70i/0.125i+h+jTC -Ctt.right.cpt -B0
 	gmt colorbar -D1.55i/${y2}i+w2.70i/0.125i+h+jTC -Ctt.left2.cpt -Bf0.25 

--- a/doc/scripts/GMT_App_M_1c.sh
+++ b/doc/scripts/GMT_App_M_1c.sh
@@ -46,10 +46,10 @@ do
 	j=`expr $i + 1`
 	left=`sed -n ${j}p tt.lis`
 	right=`sed -n ${i}p tt.lis`
-	gmt makecpt -C$left > tt.left.cpt
-	gmt makecpt -C$left -T-1/1/0.25 > tt.left2.cpt
-	gmt makecpt -C$right > tt.right.cpt
-	gmt makecpt -C$right -T-1/1/0.25 > tt.right2.cpt
+	gmt makecpt -H -C$left > tt.left.cpt
+	gmt makecpt -H -C$left -T-1/1/0.25 > tt.left2.cpt
+	gmt makecpt -H -C$right > tt.right.cpt
+	gmt makecpt -H -C$right -T-1/1/0.25 > tt.right2.cpt
 	gmt colorbar -D1.55i/${y}i+w2.70i/0.125i+h+jTC -Ctt.left.cpt -B0 
 	gmt colorbar -D4.50i/${y}i+w2.70i/0.125i+h+jTC -Ctt.right.cpt -B0 
 	gmt colorbar -D1.55i/${y2}i+w2.70i/0.125i+h+jTC -Ctt.left2.cpt -Bf0.25 

--- a/doc/scripts/GMT_App_O_9.sh
+++ b/doc/scripts/GMT_App_O_9.sh
@@ -9,8 +9,8 @@ gmt set FORMAT_GEO_MAP ddd:mm:ssF FONT_ANNOT_PRIMARY +9p FONT_TITLE 22p
 gmt project -E-74/41 -C-17/28 -G10 -Q > great_NY_Canaries.txt
 gmt project -E-74/41 -C2.33/48.87 -G100 -Q > great_NY_Paris.txt
 km=`echo -17 28 | gmt mapproject -G-74/41+uk -fg --FORMAT_FLOAT_OUT=%.0f -o2`
-gmt makecpt -Clightred,lightyellow,lightgreen -T0,3,6,100 -N > ttt.cpt
-gmt grdimage @App_O_ttt.nc -Itopo5_int.nc -Cttt.cpt $R -JM5.3i -nc+t1 
+gmt makecpt -Clightred,lightyellow,lightgreen -T0,3,6,100 -N
+gmt grdimage @App_O_ttt.nc -Itopo5_int.nc -C $R -JM5.3i -nc+t1 
 gmt grdcontour @App_O_ttt.nc -C0.5 -A1+u" hour"+v+f8p,Bookman-Demi \
 	-GL80W/31N/17W/26N,17W/28N/17W/50N -S2
 gmt plot -Wfatter,white great_NY_Canaries.txt

--- a/doc/scripts/GMT_CPTscale.sh
+++ b/doc/scripts/GMT_CPTscale.sh
@@ -21,10 +21,10 @@ gmt plot -R0/6/0/6 -Jx1i -W0.25p << EOF
 5	0.785
 EOF
 gmt colorbar -Cglobe -Baf -Dx3i/1.5i+w2.8i/0.15i+jCM -W0.001 
-gmt makecpt -Cglobe -T-500/3000 > t.cpt
-gmt colorbar -Ct.cpt -Baf -Dx5i/1.5i+w2.0i/0.15i+jLM -W0.001 
-gmt makecpt -Cglobe -G-3000/5000 -T-500/3000 > t.cpt
-gmt colorbar -Ct.cpt -Baf -Dx1i/1.5i+w2.0i/0.15i+jRM+ma -W0.001 
+gmt makecpt -Cglobe -T-500/3000
+gmt colorbar -C -Baf -Dx5i/1.5i+w2.0i/0.15i+jLM -W0.001 
+gmt makecpt -Cglobe -G-3000/5000 -T-500/3000
+gmt colorbar -C -Baf -Dx1i/1.5i+w2.0i/0.15i+jRM+ma -W0.001 
 gmt text -N -F+f14p+j << EOF 
 0	0	LB	Scale a subset (via @%1%-G@%%)
 6	0	RB	Scale entire range

--- a/doc/scripts/GMT_color_interpolate.sh
+++ b/doc/scripts/GMT_color_interpolate.sh
@@ -3,14 +3,14 @@ gmt begin GMT_color_interpolate ps
 gmt basemap -Jx1i -R0/6.8/0/2.0 -B0 
 
 # Plot polar color map in the left; right (top) and wrong (bottom)
-gmt makecpt -Cpolar -T-1/1 > tmp.cpt
-gmt colorbar -D1.7/1.6+w3i/0.3i+h+jTC -Ctmp.cpt -B0.5f0.1 
-gmt colorbar -D1.7/0.7+w3i/0.3i+h+jTC -Ctmp.cpt -B0.5f0.1 --COLOR_MODEL=hsv 
+gmt makecpt -Cpolar -T-1/1
+gmt colorbar -D1.7/1.6+w3i/0.3i+h+jTC -C -B0.5f0.1 
+gmt colorbar -D1.7/0.7+w3i/0.3i+h+jTC -C -B0.5f0.1 --COLOR_MODEL=hsv 
 
 # Plot rainbow color map in the left; right (top) and wrong (bottom)
-gmt makecpt -Crainbow -T-1/1 > tmp.cpt
-gmt colorbar -D5.1/1.6+w3i/0.3i+h+jTC -Ctmp.cpt -B0.5f0.1 
-gmt colorbar -D5.1/0.7+w3i/0.3i+h+jTC -Ctmp.cpt -B0.5f0.1 --COLOR_MODEL=rgb 
+gmt makecpt -Crainbow -T-1/1
+gmt colorbar -D5.1/1.6+w3i/0.3i+h+jTC -C -B0.5f0.1 
+gmt colorbar -D5.1/0.7+w3i/0.3i+h+jTC -C -B0.5f0.1 --COLOR_MODEL=rgb 
 
 gmt plot -Sd0.1i -Wblack -Gwhite << END
 0.2 1.6

--- a/doc/scripts/GMT_colorbar.sh
+++ b/doc/scripts/GMT_colorbar.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 gmt begin GMT_colorbar ps
-gmt makecpt -T-15/15 -Cpolar > t.cpt
-gmt basemap -R0/20/0/1 -JM5i -BWse -Baf 
-gmt colorbar -Ct.cpt -Baf -Bx+u"\\232" -By+l@~D@~T -DJBC+e
+	gmt makecpt -T-15/15 -Cpolar
+	gmt basemap -R0/20/0/1 -JM5i -BWse -Baf 
+	gmt colorbar -C -Baf -Bx+u"\\232" -By+l@~D@~T -DJBC+e
 gmt end

--- a/doc/scripts/GMT_cyclic.sh
+++ b/doc/scripts/GMT_cyclic.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 gmt begin GMT_cyclic ps
-gmt makecpt -T0/100 -Cjet -Ww > t.cpt
-gmt basemap -R0/20/0/1 -JM5i -BWse -Baf
-gmt colorbar -Ct.cpt -Baf -DJBC 
+	gmt makecpt -T0/100 -Cjet -Ww
+	gmt basemap -R0/20/0/1 -JM5i -BWse -Baf
+	gmt colorbar -C -Baf -DJBC 
 gmt end

--- a/doc/scripts/GMT_hinge.sh
+++ b/doc/scripts/GMT_hinge.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 gmt begin GMT_hinge ps
-gmt makecpt -Cglobe -T-8000/3000 > t.cpt
-gmt colorbar -Ct.cpt  -Baf -Dx0/0+w4.5i/0.1i+h -W0.001 
-gmt colorbar -Cglobe  -Baf -Dx0/0+w4.5i/0.1i+h -W0.001 -Y0.5i 
-echo 2.25 0.1 90 0.2i | gmt plot -R0/4.5/0/1 -Jx1i -Sv0.1i+a80+b -W1p -Gblack 
-gmt text -F+f12p+jCB << EOF 
-2.25	0.35	HINGE
-EOF
+	gmt makecpt -Cglobe -T-8000/3000
+	gmt colorbar -C  -Baf -Dx0/0+w4.5i/0.1i+h -W0.001 
+	gmt colorbar -Cglobe  -Baf -Dx0/0+w4.5i/0.1i+h -W0.001 -Y0.5i 
+	echo 2.25 0.1 90 0.2i | gmt plot -R0/4.5/0/1 -Jx1i -Sv0.1i+a80+b -W1p -Gblack 
+	gmt text -F+f12p+jCB <<- EOF 
+	2.25	0.35	HINGE
+	EOF
 gmt end

--- a/doc/scripts/GMT_tut_14.sh
+++ b/doc/scripts/GMT_tut_14.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 gmt begin GMT_tut_14 ps
-gmt makecpt -Crainbow -T-20/60/10 > disc.cpt
-gmt makecpt -Crainbow -T-20/60 > cont.cpt
-gmt basemap -R0/6/0/9 -Jx1i -B0 -Xc 
-gmt colorbar -Dx1i/1i+w4i/0.5i+h -Cdisc.cpt -Ba -B+tdiscrete 
-gmt colorbar -Dx1i/3i+w4i/0.5i+h -Ccont.cpt -Ba -B+tcontinuous 
-gmt colorbar -Dx1i/5i+w4i/0.5i+h -Cdisc.cpt -Ba -B+tdiscrete -I0.5 
-gmt colorbar -Dx1i/7i+w4i/0.5i+h -Ccont.cpt -Ba -B+tcontinuous -I0.5 
+	gmt makecpt -H -Crainbow -T-20/60/10 > disc.cpt
+	gmt makecpt -H -Crainbow -T-20/60 > cont.cpt
+	gmt basemap -R0/6/0/9 -Jx1i -B0 -Xc 
+	gmt colorbar -Dx1i/1i+w4i/0.5i+h -Cdisc.cpt -Ba -B+tdiscrete 
+	gmt colorbar -Dx1i/3i+w4i/0.5i+h -Ccont.cpt -Ba -B+tcontinuous 
+	gmt colorbar -Dx1i/5i+w4i/0.5i+h -Cdisc.cpt -Ba -B+tdiscrete -I0.5 
+	gmt colorbar -Dx1i/7i+w4i/0.5i+h -Ccont.cpt -Ba -B+tcontinuous -I0.5 
 gmt end

--- a/doc/scripts/GMT_tut_15.sh
+++ b/doc/scripts/GMT_tut_15.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 gmt begin GMT_tut_15 ps
-gmt makecpt -Crainbow -T1000/5000 > topo.cpt
-gmt grdimage @tut_relief.nc -JM6i -Ba -BWSnE -Ctopo.cpt 
-gmt colorbar -DJTC -Rtut_relief.nc -Ctopo.cpt -I0.4 -Bxa -By+lm 
+	gmt makecpt -Crainbow -T1000/5000
+	gmt grdimage @tut_relief.nc -JM6i -Ba -BWSnE -C 
+	gmt colorbar -DJTC -Rtut_relief.nc -C -I0.4 -Bxa -By+lm 
 gmt end

--- a/doc/scripts/GMT_tut_16.sh
+++ b/doc/scripts/GMT_tut_16.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 gmt begin GMT_tut_16 ps
-gmt makecpt -Crainbow -T1000/5000 > topo.cpt
-gmt grdgradient @tut_relief.nc -Ne0.8 -A100 -fg -Gus_i.nc
-gmt grdimage tut_relief.nc -Ius_i.nc -JM6i -Ba -BWSnE -Ctopo.cpt 
-gmt colorbar -DJTC -Rtut_relief.nc -Ctopo.cpt -I0.4 -Bxa -By+lm 
+	gmt makecpt -Crainbow -T1000/5000
+	gmt grdgradient @tut_relief.nc -Ne0.8 -A100 -fg -Gus_i.nc
+	gmt grdimage tut_relief.nc -Ius_i.nc -JM6i -Ba -BWSnE -C
+	gmt colorbar -DJTC -Rtut_relief.nc -C -I0.4 -Bxa -By+lm 
 gmt end

--- a/doc/scripts/GMT_tut_19.sh
+++ b/doc/scripts/GMT_tut_19.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 gmt begin GMT_tut_19 ps
-  gmt makecpt -Ctopo -T1000/5000 > t.cpt
+  gmt makecpt -Ctopo -T1000/5000
   gmt grdgradient @tut_relief.nc -Ne0.8 -A100 -fg -Gus_i.nc
-  gmt grdview tut_relief.nc -JM4i -p135/35 -Qi50 -Ius_i.nc -Ct.cpt -Ba -JZ0.5i
+  gmt grdview tut_relief.nc -JM4i -p135/35 -Qi50 -Ius_i.nc -C -Ba -JZ0.5i
 gmt end
 

--- a/doc/scripts/GMT_tut_9.sh
+++ b/doc/scripts/GMT_tut_9.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 gmt begin GMT_tut_9 ps
-gmt makecpt -Cred,green,blue -T0,100,300,10000 > quakes.cpt
-gmt coast -R130/150/35/50 -JM6i -B5 -Ggray 
-gmt plot @tut_quakes.ngdc -Wfaint -i4,3,5,6+s0.1 -h3 -Scc -Cquakes.cpt
+	gmt makecpt -Cred,green,blue -T0,100,300,10000
+	gmt coast -R130/150/35/50 -JM6i -B5 -Ggray 
+	gmt plot @tut_quakes.ngdc -Wfaint -i4,3,5,6+s0.1 -h3 -Scc -C -Vl
 gmt end

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -1338,7 +1338,7 @@ bool gmt_consider_current_cpt (struct GMTAPI_CTRL *API, bool *active, char **arg
 		gmt_M_str_free (*arg);
 		*arg = strdup (string);		/* Pass back the name of the current CPT with modifers */
 	}
-	else if ((*arg)[0] == '\0') {	/* Noting given */
+	else if (*arg == NULL) {	/* Noting given */
 		if ((cpt = gmt_get_current_cpt (API->GMT)) == NULL) return false;	/* No current CPT */
 		*arg = strdup (cpt);		/* Pass back the name of the current CPT */
 	}

--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -37,9 +37,9 @@
 #define THIS_MODULE_NAME	"grd2cpt"
 #define THIS_MODULE_LIB		"core"
 #define THIS_MODULE_PURPOSE	"Make linear or histogram-equalized color palette table from grid"
-#define THIS_MODULE_KEYS	"<G{+,>C}"
+#define THIS_MODULE_KEYS	"<G{+,>C},H->"
 #define THIS_MODULE_NEEDS	""
-#define THIS_MODULE_OPTIONS "->RVh"
+#define THIS_MODULE_OPTIONS	"->RVh"
 
 #define GRD2CPT_N_LEVELS	11	/* The default number of levels if nothing is specified */
 
@@ -77,6 +77,9 @@ struct GRD2CPT_CTRL {
 		bool active;
 		double z_low, z_high;
 	} G;
+	struct H {	/* -H */
+		bool active;
+	} H;
 	struct I {	/* -I[z][c] */
 		bool active;
 		unsigned int mode;
@@ -135,9 +138,10 @@ GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct GRD2CPT_CTRL *C) {	/* Dea
 
 GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
+	const char *H_OPT = (API->GMT->current.setting.run_mode == GMT_MODERN) ? " [-H]" : "";
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s <grid> [-A<transparency>[+a]] [-C<cpt>] [-D[i]] [-E[<nlevels>]] [-F[R|r|h|c][+c]]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-G<zlo>/<zhi>] [-I[c][z]] [-L<min_limit>/<max_limit>] [-M] [-N] [-Q[i|o]]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t[-G<zlo>/<zhi>]%s [-I[c][z]] [-L<min_limit>/<max_limit>] [-M] [-N] [-Q[i|o]]\n", H_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-T<start>/<stop>/<inc> or -T<n>]\n\t[-Sh|l|m|u] [%s] [-W[w]] [-Z] [%s]\n\n", GMT_Rgeo_OPT, GMT_V_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -156,6 +160,8 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +c to output a discrete CPT in categorical CPT format.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Truncate incoming CPT to be limited to the z-range <zlo>/<zhi>.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   To accept one of the incoming limits, set that limit to NaN.\n");
+	if (API->GMT->current.setting.run_mode == GMT_MODERN)
+		GMT_Message (API, GMT_TIME_NONE, "\t-H Also write CPT to stdout [Default just saves as current CPT].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Reverse sense of CPT in one or two ways:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   -Ic Reverse sense of color table as well as back- and foreground color [Default].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   -Iz Reverse sign of z-values in the color table (takes affect before -G, T are consulted).\n");
@@ -265,6 +271,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRD2CPT_CTRL *Ctrl, struct GMT
 				if (!(txt_b[0] == 'N' || txt_b[0] == 'n') || !strcmp (txt_b, "-")) Ctrl->G.z_high = atof (txt_b);
 				n_errors += gmt_M_check_condition (GMT, gmt_M_is_dnan (Ctrl->G.z_low) && gmt_M_is_dnan (Ctrl->G.z_high),
 								"Syntax error -G option: Both of z_low/z_high cannot be NaN\n");
+				break;
+			case 'H':	/* Modern mode only: write CPT to stdout */
+				Ctrl->H.active = true;
 				break;
 			case 'I':	/* Invert table */
 				Ctrl->I.active = true;
@@ -380,6 +389,10 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRD2CPT_CTRL *Ctrl, struct GMT
 		}
 	}
 	
+	if (Ctrl->H.active && GMT->current.setting.run_mode == GMT_CLASSIC) {
+		n_errors++;
+		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unrecognized option -H\n");
+	}
 	n_errors += gmt_M_check_condition (GMT, n_files[GMT_IN] < 1, "Error: No grid name(s) specified.\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->W.active && Ctrl->Z.active,
 					"Syntax error: -W and -Z cannot be used simultaneously\n");
@@ -419,6 +432,7 @@ int GMT_grd2cpt (void *V_API, int mode, void *args) {
 	unsigned int row, col, j, cpt_flags = 0;
 	int signed_levels, error = 0;
 	size_t n_alloc = GMT_TINY_CHUNK;
+	bool write = false;
 
 	char format[GMT_BUFSIZ] = {""}, *l = NULL, **grdfile = NULL;
 
@@ -711,7 +725,9 @@ int GMT_grd2cpt (void *V_API, int mode, void *args) {
 
 	if (Ctrl->A.active) gmt_cpt_transparency (GMT, Pout, Ctrl->A.value, Ctrl->A.mode);	/* Set transparency */
 
-	if (GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, cpt_flags, NULL, Ctrl->Out.file, Pout) != GMT_NOERROR)
+	write = (GMT->current.setting.run_mode == GMT_CLASSIC || Ctrl->H.active);	/* Only output to stdout in classic mode and with -H in modern mode */
+
+	if (write && GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, cpt_flags, NULL, Ctrl->Out.file, Pout) != GMT_NOERROR)
 		error = API->error;
 
 	gmt_save_current_cpt (GMT, Pout);	/* Save for use by session, if modern */

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -299,7 +299,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDIMAGE_CTRL *Ctrl, struct GM
 					c[0] = '\0';	/* Temporarily chop off the modifier */
 				}
 				gmt_M_str_free (Ctrl->C.file);
-				Ctrl->C.file = strdup (opt->arg);
+				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
 				if (c) c[0] = '+';	/* Restore */
 				break;
 #ifdef HAVE_GDAL

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -195,7 +195,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDVECTOR_CTRL *Ctrl, struct G
 					c[0] = '\0';	/* Temporarily chop off the modifier */
 				}
 				gmt_M_str_free (Ctrl->C.file);
-				Ctrl->C.file = strdup (opt->arg);
+				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
 				if (c) c[0] = '+';	/* Restore */
 				break;
 			case 'E':	/* Center vectors [OBSOLETE; use modifier +jc in -Q ] */

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -508,7 +508,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT
 					c[0] = '\0';	/* Temporarily chop off the modifier */
 				}
 				gmt_M_str_free (Ctrl->C.file);
-				Ctrl->C.file = strdup (opt->arg);
+				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
 				if (c) c[0] = '+';	/* Restore */
 				break;
 			case 'G':	/* One grid or image or three separate r,g,b grids */

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -32,9 +32,9 @@
 #define THIS_MODULE_NAME	"makecpt"
 #define THIS_MODULE_LIB		"core"
 #define THIS_MODULE_PURPOSE	"Make GMT color palette tables"
-#define THIS_MODULE_KEYS	">C},ED(,SD(,TD(,<D("
+#define THIS_MODULE_KEYS	">C},ED(,SD(,TD(,<D(,H->"
 #define THIS_MODULE_NEEDS	""
-#define THIS_MODULE_OPTIONS "->Vbdhi"
+#define THIS_MODULE_OPTIONS	"->Vbdhi"
 
 EXTERN_MSC unsigned int gmtlib_log_array (struct GMT_CTRL *GMT, double min, double max, double delta, double **array);
 
@@ -79,6 +79,9 @@ struct MAKECPT_CTRL {
 		bool active;
 		double z_low, z_high;
 	} G;
+	struct H {	/* -H */
+		bool active;
+	} H;
 	struct I {	/* -I[z][c] */
 		bool active;
 		unsigned int mode;
@@ -134,8 +137,9 @@ GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct MAKECPT_CTRL *C) {	/* Dea
 
 GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
+	const char *H_OPT = (API->GMT->current.setting.run_mode == GMT_MODERN) ? " [-H]" : "";
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [-A<transparency>[+a]] [-C<cpt>|colors] [-D[i|o]] [-E<nlevels>] [-F[R|r|h|c][+c]] [-G<zlo>/<zhi>]\n", name);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s [-A<transparency>[+a]] [-C<cpt>|colors] [-D[i|o]] [-E<nlevels>] [-F[R|r|h|c][+c]] [-G<zlo>/<zhi>]%s\n", name, H_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "	[-I[c][z]] [-M] [-N] [-Q] [-S<mode>] [-T<min>/<max>[/<inc>[+b|l|n]] | -T<table> | -T<z1,z2,...zn>] [%s] [-W[w]]\n\t[-Z] [%s] [%s] [%s]\n\t[%s] [%s]\n\n",
 		GMT_V_OPT, GMT_bi_OPT, GMT_di_OPT, GMT_i_OPT, GMT_ho_OPT, GMT_PAR_OPT);
 
@@ -156,6 +160,8 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +c to output a discrete CPT in categorical CPT format.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Truncate incoming CPT to be limited to the z-range <zlo>/<zhi>.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   To accept one of the incoming limits, set that limit to NaN.\n");
+	if (API->GMT->current.setting.run_mode == GMT_MODERN)
+		GMT_Message (API, GMT_TIME_NONE, "\t-H Also write CPT to stdout [Default just saves as current CPT].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Reverse sense of CPT in one or two ways:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   -Ic Reverse sense of color table as well as back- and foreground color [Default].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   -Iz Reverse sign of z-values in the color table (takes affect before -G, T are consulted).\n");
@@ -261,6 +267,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MAKECPT_CTRL *Ctrl, struct GMT
 				n_errors += gmt_M_check_condition (GMT, gmt_M_is_dnan (Ctrl->G.z_low) && gmt_M_is_dnan (Ctrl->G.z_high),
 				                                   "Syntax error -G option: Both of z_low/z_high cannot be NaN\n");
 				break;
+			case 'H':	/* Modern mode only: write CPT to stdout */
+				Ctrl->H.active = true;
+				break;
 			case 'I':	/* Invert table */
 				Ctrl->I.active = true;
 				if ((Ctrl->I.mode = gmt_parse_inv_cpt (GMT, opt->arg)) == UINT_MAX)
@@ -333,6 +342,10 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MAKECPT_CTRL *Ctrl, struct GMT
 
 	if (Ctrl->Q.active && Ctrl->Q.mode == 2) Ctrl->T.T.logarithmic = true;
 	
+	if (Ctrl->H.active && GMT->current.setting.run_mode == GMT_CLASSIC) {
+		n_errors++;
+		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unrecognized option -H\n");
+	}
 	n_errors += gmt_M_check_condition (GMT, n_files[GMT_IN] > 0 && !(Ctrl->E.active || Ctrl->S.active),
 	                                   "Syntax error: No input files expected unless -E or -S are used\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->W.active && Ctrl->Z.active,
@@ -359,6 +372,8 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MAKECPT_CTRL *Ctrl, struct GMT
 int GMT_makecpt (void *V_API, int mode, void *args) {
 	int i, nz = 0, error = 0;
 	unsigned int cpt_flags = 0;
+	
+	bool write = false;
 
 	double *z = NULL;
 
@@ -565,8 +580,10 @@ int GMT_makecpt (void *V_API, int mode, void *args) {
 	if (Ctrl->D.mode == 1) cpt_flags |= GMT_CPT_EXTEND_BNF;	/* bit 1 controls if BF will be set to equal bottom/top rgb value */
 	if (Ctrl->F.active) Pout->model = Ctrl->F.model;
 	if (Ctrl->F.cat) Pout->categorical = 1;
+	
+	write = (GMT->current.setting.run_mode == GMT_CLASSIC || Ctrl->H.active);	/* Only output to stdout in classic mode and with -H in modern mode */
 
-	if (GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, cpt_flags, NULL, Ctrl->Out.file, Pout) != GMT_NOERROR) {
+	if (write && GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, cpt_flags, NULL, Ctrl->Out.file, Pout) != GMT_NOERROR) {
 		Return (API->error);
 	}
 

--- a/src/meca/pscoupe.c
+++ b/src/meca/pscoupe.c
@@ -755,7 +755,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 				break;
 			case 'Z':	/* Vary symbol color with z */
 				Ctrl->Z.active = true;
-				Ctrl->Z.file = strdup (opt->arg);
+				if (opt->arg[0]) Ctrl->Z.file = strdup (opt->arg);
 				break;
 
 			default:	/* Report bad options */

--- a/src/meca/psmeca.c
+++ b/src/meca/psmeca.c
@@ -455,7 +455,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_
 				break;
 			case 'Z':	/* Vary symbol color with z */
 				Ctrl->Z.active = true;
-				Ctrl->Z.file = strdup (opt->arg);
+				if (opt->arg[0]) Ctrl->Z.file = strdup (opt->arg);
 				break;
 
 			default:	/* Report bad options */

--- a/src/movie.c
+++ b/src/movie.c
@@ -341,14 +341,22 @@ GMT_LOCAL unsigned int check_language (struct GMT_CTRL *GMT, unsigned int mode, 
 
 GMT_LOCAL bool script_is_classic (struct GMT_CTRL *GMT, FILE *fp) {
 	/* Read script to determine if it is in GMT classic mode or not, then rewind */
-	bool classic = true;
+	bool modern = false;
 	char line[PATH_MAX] = {""};
-	while (classic && gmt_fgets (GMT, line, PATH_MAX, fp)) {
+	while (!modern && gmt_fgets (GMT, line, PATH_MAX, fp)) {
 		if (strstr (line, "gmt begin"))	/* A modern mode script */
-			classic = false;
+			modern = true;
+		else if (strstr (line, "gmt figure"))	/* A modern mode script */
+			modern = true;
+		else if (strstr (line, "gmt subplot"))	/* A modern mode script */
+			modern = true;
+		else if (strstr (line, "gmt inset"))	/* A modern mode script */
+			modern = true;
+		else if (strstr (line, "gmt end"))	/* A modern mode script */
+			modern = true;
 	}
 	rewind (fp);	/* Go back to beginning of file */
-	return (classic);
+	return (!modern);
 }
 
 GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {

--- a/src/movie.c
+++ b/src/movie.c
@@ -433,7 +433,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-Q Debugging: Leave all intermediate files and directories behind for inspection.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append s to only create the work scripts but none will be executed (except for background script).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-S Given names for the optional background and foreground GMT scripts [none]:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   -Sb Append the name of a background script that may pre-compute\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   -Sb Append name of background GMT modern script that may pre-compute\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t       files needed by <mainscript> and/or build a static background plot layer.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t       If a plot is generated then the script must be in GMT modern mode.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   -Sf Append name of foreground GMT modern mode script which will\n");
@@ -1075,10 +1075,15 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	fclose (fp);	/* Done writing the init script */
 	
 	if (Ctrl->S[MOVIE_PREFLIGHT].active) {	/* Create the preflight script from the user's background script */
-		/* The background script is allowed to be classic if no plot is generated */
+		/* The background script must be modern mode */
 		unsigned int rec = 0;
-		is_classic = script_is_classic (GMT, Ctrl->S[MOVIE_PREFLIGHT].fp);
 		sprintf (pre_file, "movie_preflight.%s", extension[Ctrl->In.mode]);
+		is_classic = script_is_classic (GMT, Ctrl->S[MOVIE_PREFLIGHT].fp);
+		if (is_classic) {
+			GMT_Report (API, GMT_MSG_NORMAL, "Your preflight file %s is not in GMT modern node - exiting\n", pre_file);
+			fclose (Ctrl->In.fp);
+			Return (GMT_RUNTIME_ERROR);
+		}
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Create preflight script %s and execute it\n", pre_file);
 		if ((fp = fopen (pre_file, "w")) == NULL) {
 			GMT_Report (API, GMT_MSG_NORMAL, "Unable to create preflight script %s - exiting\n", pre_file);
@@ -1094,22 +1099,18 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			set_tvalue (fp, Ctrl->In.mode, "GMT_SESSION_NAME", "$$");
 		fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 		while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->S[MOVIE_PREFLIGHT].fp)) {	/* Read the background script and copy to preflight script with some exceptions */
-			if ((is_classic && rec == 0) || strstr (line, "gmt begin")) {	/* Need to insert gmt figure after this line (or as first line) in case a background plot will be made */
+			if (strstr (line, "gmt begin")) {	/* Need to insert gmt figure after this line (or as first line) in case a background plot will be made */
 				fprintf (fp, "gmt begin\n");	/* To ensure there are no args here since we are using gmt figure instead */
 				set_comment (fp, Ctrl->In.mode, "\tSet fixed background output ps name");
 				fprintf (fp, "\tgmt figure movie_background ps\n");
 				fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
 				fprintf (fp, "\tgmt set DIR_DATA %s\n", datadir);
-				if (is_classic)	/* Also write the current line since it was not a gmt begin line */
-					fprintf (fp, "%s", line);
 			}
 			else if (!strstr (line, "#!/"))	/* Skip any leading shell incantation since already placed by set_script */
 				fprintf (fp, "%s", line);	/* Just copy the line as is */
 			rec++;
 		}
 		fclose (Ctrl->S[MOVIE_PREFLIGHT].fp);	/* Done reading the foreground script */
-		if (is_classic)	/* Must close modern session explicitly */
-			fprintf (fp, "gmt end\n");
 		fclose (fp);	/* Done writing the preflight script */
 #ifndef WIN32
 		/* Set executable bit if not on Windows */
@@ -1165,13 +1166,13 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		precision = irint (ceil (log10 ((double)(Ctrl->T.start_frame+n_frames))));	/* Width needed to hold largest frame number */
 	
 	if (Ctrl->S[MOVIE_POSTFLIGHT].active) {	/* Prepare the postflight script */
+		sprintf (post_file, "movie_postflight.%s", extension[Ctrl->In.mode]);
 		is_classic = script_is_classic (GMT, Ctrl->S[MOVIE_POSTFLIGHT].fp);
 		if (is_classic) {
 			GMT_Report (API, GMT_MSG_NORMAL, "Your postflight file %s is not in GMT modern node - exiting\n", post_file);
 			fclose (Ctrl->In.fp);
 			Return (GMT_RUNTIME_ERROR);
 		}
-		sprintf (post_file, "movie_postflight.%s", extension[Ctrl->In.mode]);
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Create postflight script %s\n", post_file);
 		if ((fp = fopen (post_file, "w")) == NULL) {
 			GMT_Report (API, GMT_MSG_NORMAL, "Unable to create postflight file %s - exiting\n", post_file);

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -348,6 +348,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *Ctrl, struct GM
 				break;
 		}
 	}
+
+	gmt_consider_current_cpt (GMT->parent, &Ctrl->C.active, &(Ctrl->C.cpt));
+
 	if (Ctrl->C.active) n_col++;	/* Need to read one more column for z */
 	if (Ctrl->S.mode) n_col++;	/* Must allow for size in input before time and length */
 	if (t_string) {	/* Do a special check for absolute time since auto-detection based on input file has not happened yet and user may have forgotten about -f */

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -58,7 +58,7 @@ enum Psevent {	/* Misc. named array indices */
 struct PSEVENTS_CTRL {
 	struct PSEVENTS_C {	/* 	-C<cpt> */
 		bool active;
-		char *cpt;
+		char *file;
 	} C;
 	struct PSEVENTS_D {	/*	-D[j]<dx>[/<dy>][v[<pen>]] */
 		bool active;
@@ -116,7 +116,7 @@ GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a n
 
 GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *C) {	/* Deallocate control structure */
 	if (!C) return;
-	gmt_M_str_free (C->C.cpt);	
+	gmt_M_str_free (C->C.file);	
 	gmt_M_str_free (C->D.string);	
 	gmt_M_str_free (C->F.string);	
 	gmt_M_str_free (C->G.color);	
@@ -202,7 +202,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *Ctrl, struct GM
 			
 			case 'C':	/* Set a cpt for converting z column to color */
 				Ctrl->C.active = true;
-				Ctrl->C.cpt = strdup (opt->arg);
+				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
 				break;
 
 			case 'D':
@@ -349,7 +349,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *Ctrl, struct GM
 		}
 	}
 
-	gmt_consider_current_cpt (GMT->parent, &Ctrl->C.active, &(Ctrl->C.cpt));
+	gmt_consider_current_cpt (GMT->parent, &Ctrl->C.active, &(Ctrl->C.file));
 
 	if (Ctrl->C.active) n_col++;	/* Need to read one more column for z */
 	if (Ctrl->S.mode) n_col++;	/* Must allow for size in input before time and length */
@@ -613,7 +613,7 @@ Do_text:	if (Ctrl->E.active[PSEVENTS_TEXT] && In->text) {	/* Also plot trailing 
 		/* Build psxy command with fixed options and those that depend on -C -G -W.
 		 * We must set symbol unit as inch since we are passing sizes in inches directly (dimensions are in inches internally in GMT).  */
 		sprintf (cmd, "%s -R -J -O -K -I -t -S%s --GMT_HISTORY=false --PROJ_LENGTH_UNIT=inch", tmp_file_symbols, Ctrl->S.symbol);
-		if (Ctrl->C.active) {strcat (cmd, " -C"); strcat (cmd, Ctrl->C.cpt);}
+		if (Ctrl->C.active) {strcat (cmd, " -C"); strcat (cmd, Ctrl->C.file);}
 		if (Ctrl->G.active) {strcat (cmd, " -G"); strcat (cmd, Ctrl->G.color);}
 		if (Ctrl->W.pen) {strcat (cmd, " -W"); strcat (cmd, Ctrl->W.pen);}
 		GMT_Report (API, GMT_MSG_DEBUG, "cmd: gmt psxy %s\n", cmd);

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -556,9 +556,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSHISTOGRAM_CTRL *Ctrl, struct
 				Ctrl->A.active = true;
 				break;
 			case 'C':
-				gmt_M_str_free (Ctrl->C.file);
-				Ctrl->C.file = strdup (opt->arg);
 				Ctrl->C.active = true;
+				gmt_M_str_free (Ctrl->C.file);
+				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
 				break;
 			case 'D':
 				Ctrl->D.active = true;

--- a/src/psrose.c
+++ b/src/psrose.c
@@ -271,9 +271,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSROSE_CTRL *Ctrl, struct GMT_
 						break;
 					}
 				}
-				gmt_M_str_free (Ctrl->C.file);
-				Ctrl->C.file = strdup (opt->arg);
 				Ctrl->C.active = true;
+				gmt_M_str_free (Ctrl->C.file);
+				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
 				break;
 			case 'D':	/* Center the bins */
 				Ctrl->D.active = true;

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -254,7 +254,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctrl, struct GMT
 			case 'C':
 				Ctrl->C.active = true;
 				gmt_M_str_free (Ctrl->C.file);
-				Ctrl->C.file = strdup (opt->arg);
+				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
 				break;
 			case 'D':
 				Ctrl->D.active = true;

--- a/src/psternary.c
+++ b/src/psternary.c
@@ -159,7 +159,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSTERNARY_CTRL *Ctrl, struct G
 			case 'C':	/* Use CPT for coloring symbols */
 				Ctrl->C.active = true;
 				gmt_M_str_free (Ctrl->C.string);
-				Ctrl->C.string = strdup (opt->arg);
+				if (opt->arg[0]) Ctrl->C.string = strdup (opt->arg);
 				break;
 			case 'G':	/* Fill */
 				Ctrl->G.active = true;

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -624,11 +624,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OP
 				}
 				break;
 			case 'C':	/* Vary symbol color with z */
-				if (opt->arg[0]) {
-					gmt_M_str_free (Ctrl->C.file);
-					Ctrl->C.file = strdup (opt->arg);
-					Ctrl->C.active = true;
-				}
+				Ctrl->C.active = true;
+				gmt_M_str_free (Ctrl->C.file);
+				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
 				break;
 			case 'D':
 				if ((j = sscanf (opt->arg, "%[^/]/%s", txt_a, txt_b)) < 1) {

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -326,11 +326,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSXYZ_CTRL *Ctrl, struct GMT_O
 			/* Processes program-specific parameters */
 
 			case 'C':	/* Vary symbol color with z */
-				if (opt->arg[0]) {
-					gmt_M_str_free (Ctrl->C.file);
-					Ctrl->C.file = strdup (opt->arg);
-					Ctrl->C.active = true;
-				}
+				Ctrl->C.active = true;
+				gmt_M_str_free (Ctrl->C.file);
+				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
 				break;
 			case 'D':
 				if ((n = sscanf (opt->arg, "%[^/]/%[^/]/%s", txt_a, txt_b, txt_c)) < 2) {

--- a/test/exmod/ex02.sh
+++ b/test/exmod/ex02.sh
@@ -7,8 +7,8 @@
 #
 gmt begin ex02 ps
   gmt set MAP_ANNOT_OBLIQUE 0 PS_MEDIA letter
-  gmt makecpt -Crainbow -T-2/14/2 > g.cpt
-  gmt grd2cpt @HI_topo_02.nc -Crelief -Z > t.cpt
+  gmt makecpt -Crainbow -T-2/14/2 -H > g.cpt
+  gmt grd2cpt @HI_topo_02.nc -Crelief -H -Z > t.cpt
   gmt subplot begin 2x1 -A+JTL+o0.1i/0 -Fs6i/3.5i -M0 -R160/20/220/30+r -JOc190/25.5/292/69/6i -X1.5i -Y1.5i -B10 -T"H@#awaiian@# T@#opo and @#G@#eoid@#"
     gmt subplot 2,1 -Ce1.1i
     gmt grdimage @HI_geoid_02.nc -Cg.cpt

--- a/test/exmod/ex12.sh
+++ b/test/exmod/ex12.sh
@@ -19,11 +19,11 @@ gmt begin ex12 ps
   # Then contour the data and draw triangles using dashed pen; use "gmt gmtinfo" and "gmt makecpt" to make a
   # color palette (.cpt) file
   T=`gmt info -T25+c2 @Table_5_11.txt`
-  gmt makecpt -Cjet $T > topo.cpt
-  gmt contour @Table_5_11.txt -Wthin -Ctopo.cpt -Lthinnest,- -Gd1i -c2,1
+  gmt makecpt -Cjet $T
+  gmt contour @Table_5_11.txt -Wthin -C -Lthinnest,- -Gd1i -c2,1
   # Finally color the topography
-  gmt contour @Table_5_11.txt -Ctopo.cpt -I -c2,2
+  gmt contour @Table_5_11.txt -C -I -c2,2
   gmt subplot end
 gmt end
 #
-rm -f net.xy topo.cpt
+rm -f net.xy

--- a/test/exmod/ex18.sh
+++ b/test/exmod/ex18.sh
@@ -12,12 +12,12 @@ gmt begin ex18 ps
   gmt set PROJ_ELLIPSOID Sphere FORMAT_FLOAT_OUT %g
   # Define location of Pratt seamount and the 400 km diameter
   echo "-142.65 56.25 400" > pratt.txt
-  gmt makecpt -Crainbow -T-60/60 > grav.cpt
+  gmt makecpt -Crainbow -T-60/60
   gmt subplot begin 2x1 -A+JTL+o0.2i -Fs6i/3.5i -M0.2i/0.35i -R@AK_gulf_grav.nc -JM5.5i -B -BWSne
     gmt subplot 1,1
-    gmt grdimage @AK_gulf_grav.nc -I+d -Cgrav.cpt
+    gmt grdimage @AK_gulf_grav.nc -I+d -C
     gmt coast -Di -Ggray -Wthinnest
-    gmt colorbar -DJCB+o0/0.35i -Cgrav.cpt -Bxaf -By+l"mGal"
+    gmt colorbar -DJCB+o0/0.35i -C -Bxaf -By+l"mGal"
     gmt text pratt.txt -D0.1i/0.1i -F+f12p,Helvetica-Bold+jLB+tPratt
     gmt plot pratt.txt -SE- -Wthinnest
     # Then draw 10 mGal contours and overlay 50 mGal contour in green
@@ -53,4 +53,4 @@ Areas: $area km@+2@+
 END
   gmt subplot end
 gmt end
-rm -f grav.cpt sm_*.txt tmp.nc mask.nc pratt.txt center* gmt.conf
+rm -f sm_*.txt tmp.nc mask.nc pratt.txt center* gmt.conf

--- a/test/exmod/ex19.sh
+++ b/test/exmod/ex19.sh
@@ -7,8 +7,8 @@
 gmt begin ex19 ps
   gmt grdmath -Rd -I1 -r Y COSD 2 POW = lat.nc
   gmt grdmath X = lon.nc
-  gmt makecpt -Cwhite,blue -T0,1 -Z -N > lat.cpt
-  gmt makecpt -Crainbow -T-180/180 > lon.cpt
+  gmt makecpt -Cwhite,blue -T0,1 -Z -N -H > lat.cpt
+  gmt makecpt -Crainbow -T-180/180 -H > lon.cpt
   gmt subplot begin 3x1 -Fs6.5i/0 -M0 -Bbltr -Rd -JI0/6.5i
 #   First make a worldmap with graded blue oceans and rainbow continents
     gmt grdimage lat.nc -Clat.cpt -nl -c1,1

--- a/test/exmod/ex34.sh
+++ b/test/exmod/ex34.sh
@@ -11,9 +11,8 @@ gmt begin ex34 ps
   gmt coast -EFR,IT+gP300/8 -Glightgray -c2,1
   # Extract a subset of ETOPO2m for this part of Europe
   # gmt grdcut etopo2m_grd.nc -R -GFR+IT.nc=ns
-  gmt makecpt -Cglobe -T-5000/5000 > z.cpt
-  gmt grdimage @FR+IT.nc -I+a15+ne0.75 -Cz.cpt -c1,1
+  gmt makecpt -Cglobe -T-5000/5000
+  gmt grdimage @FR+IT.nc -I+a15+ne0.75 -C -c1,1
   gmt coast -EFR,IT+gred@60
   gmt subplot end
 gmt end
-rm -f z.cpt

--- a/test/modern/shrinkvec2.sh
+++ b/test/modern/shrinkvec2.sh
@@ -3,12 +3,12 @@
 # Get fill and/or pen color via CPT on z values
 gmt begin shrinkvec2 ps
 	gmt math -T0/2/0.1 -o1,0 0 = | awk '{printf "%s\t%s\t%s\t0\t%si\n", $1, $2, $2, $2}' > data.txt
-	gmt makecpt -Cjet -T0/2 > t.cpt
+	gmt makecpt -Cjet -T0/2
 	# Use z and CPT for painting the head only
-	gmt plot data.txt -R0/1/0/2.1 -JX2i/9i -Sv0.5i+ea+h0.4+jb+n2i -W3p+cf -Ct.cpt -B -BWStr
+	gmt plot data.txt -R0/1/0/2.1 -JX2i/9i -Sv0.5i+ea+h0.4+jb+n2i -W3p+cf -C -B -BWStr
 	# Use z and CPT for painting the head and turn off head outline
-	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i+p- -W3p+cf -Ct.cpt -B -Blstr -X2.25i
+	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i+p- -W3p+cf -C -B -Blstr -X2.25i
 	# Use z and CPT for painting the head and stem
-	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i -W3p+c -Ct.cpt -B -Blstr -X2.25i
+	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i -W3p+c -C -B -Blstr -X2.25i
 	rm -f data.txt t.cpt
 gmt end


### PR DESCRIPTION
Most modern mode scripts needed to use the current CPT mechanism.  However, a few that were written as classic scripts (multiple CPTs) or animation scripts (each frame is its own session so cannot use current cpt from another session) we now add -H to write that CPT to stdout.  Back to my 19 test failures.