### PR TITLE
Discuss need for makecpt or grd2cpt -H when making movies

### DIFF
--- a/doc/rst/source/grd2cpt.rst
+++ b/doc/rst/source/grd2cpt.rst
@@ -138,7 +138,8 @@ Optional Arguments
 
 **-H**\
     Modern mode only: Write the CPT to standard output as well [Default saves
-    the CPT as the session current CPT].
+    the CPT as the session current CPT].  Required for scripts used to make
+    animations via :doc:`movie` where we must pass named CPT files.
 
 .. _-I:
 

--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -135,7 +135,8 @@ Optional Arguments
 
 **-H**\
     Modern mode only: Write the CPT to standard output as well [Default saves
-    the CPT as the session current CPT].
+    the CPT as the session current CPT]. Required for scripts used to make
+    animations via :doc:`movie` where we must pass named CPT files.
 
 .. _-I:
 

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -319,6 +319,16 @@ issues with your use of variables and options until this works.  You can then tr
 We recommend you make a very short (i.e., **-T**) and small (i.e., **-C**) movie so you don't have to wait very
 long to see the result.  Once things are working you can beef up number of frames and movie quality.
 
+Color table usage
+-----------------
+
+Because **movie** launches individual frame plots as separate sessions running in parallel, we cannot
+utilize the current CPT (i.e., the last CPT created directly by :doc:`makecpt` or :doc:`grd2cpt`, or
+indirectly by :doc:`grdimage` or  :doc:`grdview`).  Instead, you must create CPTs using explicit
+files and pass those names to the modules that require CPT information.  In modern mode, this means
+you need to use the **-H** option in :doc:`makecpt` or :doc:`grd2cpt` in order to redirect their output
+to named files.
+
 Examples
 --------
 


### PR DESCRIPTION
Since movie frames run as separate sessions we cannot use the "current CPT" mechanism and instead must name the CPT files; this requires **-H** in modern mode.