### PR TITLE
Remove redundant find_program(XZ)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,6 @@ set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/"
 # Find UNIX commands
 include (FindUnixCommands)
 find_package (Git)
-find_program (XZ NAMES xz)
 
 # Include configuration options (default options and options overridden by user).
 include (ConfigCMake)


### PR DESCRIPTION
**Description of proposed changes**

XZ is used in making gmt_release_tar only. There is a `find_program(XZ)` before making tarballs, so it's not needed here.