### PR TITLE
Use named enums instead of integers for MAP_ANNOT_OBLIQUE

### DIFF
--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -267,6 +267,17 @@ enum GMT_enum_download {
 	GMT_NO_DOWNLOAD = 0, GMT_YES_DOWNLOAD = 1};
 
 /*! Various mode for axes */
+enum GMT_enum_oblique {
+	GMT_OBL_ANNOT_LON_X_LAT_Y    =  0,
+	GMT_OBL_ANNOT_ANYWHERE       =  1,
+	GMT_OBL_ANNOT_LON_HORIZONTAL =  2,
+	GMT_OBL_ANNOT_LAT_HORIZONTAL =  4,
+	GMT_OBL_ANNOT_EXTEND_TICKS   =  8,
+	GMT_OBL_ANNOT_NORMAL_TICKS   = 16,
+	GMT_OBL_ANNOT_LAT_PARALLEL   = 32,
+	GMT_OBL_ANNOT_FLAG_LIMIT     = 64};
+
+/*! Various mode for axes */
 enum GMT_enum_axes {
 	GMT_AXIS_NONE  = 0,
 	GMT_AXIS_DRAW  = 1,

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -138,7 +138,7 @@ struct GMT_DEFAULTS {
 	double map_tick_length[4];		/* Length of primary and secondary major and minor tickmarks [5p/2.5p/15p/3.75p] */
 	double map_title_offset;		/* Distance between lowermost annotation (or label) and base of plot title [14p] */
 	double map_vector_shape;		/* 0.0 = straight vectorhead, 1.0 = arrowshape, with continuous range in between */
-	unsigned int map_annot_oblique;	/* Controls annotations and tick angles etc. [0] */
+	unsigned int map_annot_oblique;	/* Controls annotations and tick angles etc. [GMT_OBL_ANNOT_ANYWHERE] */
 	unsigned int map_logo_justify;		/* Justification of the GMT timestamp box [1 (BL)] */
 	unsigned int map_frame_type;		/* Fancy (0), plain (1), or graph (2) [0] */
 	bool map_logo;			/* Plot time and map projection on map [false] */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -5228,7 +5228,7 @@ void gmtinit_conf (struct GMT_CTRL *GMT) {
 	GMT->current.setting.given_unit[GMTCASE_MAP_ANNOT_OFFSET_PRIMARY] = 'p';
 	GMT->current.setting.given_unit[GMTCASE_MAP_ANNOT_OFFSET_SECONDARY] = 'p';
 	/* MAP_ANNOT_OBLIQUE */
-	GMT->current.setting.map_annot_oblique = 1;
+	GMT->current.setting.map_annot_oblique = GMT_OBL_ANNOT_ANYWHERE;
 	/* MAP_ANNOT_MIN_ANGLE */
 	GMT->current.setting.map_annot_min_angle = 20;
 	/* MAP_ANNOT_MIN_SPACING */
@@ -8601,7 +8601,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 		case GMTCASE_MAP_ANNOT_OBLIQUE:
 			ival = atoi (value);
-			if (ival >= 0 && ival < 64)
+			if (ival >= GMT_OBL_ANNOT_LON_X_LAT_Y && ival < GMT_OBL_ANNOT_FLAG_LIMIT)
 				GMT->current.setting.map_annot_oblique = ival;
 			else
 				error = true;

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -2204,7 +2204,7 @@ GMT_LOCAL void map_setxy (struct GMT_CTRL *GMT, double xmin, double xmax, double
 		//GMT->current.setting.map_frame_type = GMT_IS_PLAIN;	/* Reset to plain frame for panel maps */
 		if (gmt_M_is_rect_graticule (GMT) && P->parallel) {
 			strcpy (GMT->current.setting.map_annot_ortho, "");	/* All annotations will be parallel to axes */
-			GMT->current.setting.map_annot_oblique |= 32;		/* Plot latitude parallel to frame for geo maps */
+			GMT->current.setting.map_annot_oblique |= GMT_OBL_ANNOT_LAT_PARALLEL;	/* Plot latitude parallel to frame for geo maps */
 		}
 	}
 }
@@ -3079,7 +3079,7 @@ GMT_LOCAL bool map_init_stereo (struct GMT_CTRL *GMT) {
 		GMT->current.map.clip = &map_rect_clip;
 		GMT->current.map.left_edge = &map_left_rect;
 		GMT->current.map.right_edge = &map_right_rect;
-		GMT->current.map.frame.check_side = !(GMT->current.setting.map_annot_oblique & 1);
+		GMT->current.map.frame.check_side = !(GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_ANYWHERE);
 		GMT->current.map.frame.horizontal = (fabs (GMT->current.proj.pars[1]) < 30.0 && fabs (GMT->common.R.wesn[YHI] - GMT->common.R.wesn[YLO]) < 30.0) ? 1 : 0;
 	}
 	else {
@@ -3364,7 +3364,7 @@ GMT_LOCAL bool map_init_oblique (struct GMT_CTRL *GMT) {
 	}
 #endif
 	if (GMT->current.setting.map_frame_type & GMT_IS_FANCY) GMT->current.setting.map_frame_type = GMT_IS_PLAIN;
-	GMT->current.map.frame.check_side = !(GMT->current.setting.map_annot_oblique & 1);
+	GMT->current.map.frame.check_side = !(GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_ANYWHERE);
 	return (true);
 }
 
@@ -3759,7 +3759,7 @@ GMT_LOCAL bool map_init_lambeq (struct GMT_CTRL *GMT) {
 		GMT->current.map.clip = &map_rect_clip;
 		GMT->current.map.left_edge = &map_left_rect;
 		GMT->current.map.right_edge = &map_right_rect;
-		GMT->current.map.frame.check_side = !(GMT->current.setting.map_annot_oblique & 1);
+		GMT->current.map.frame.check_side = !(GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_ANYWHERE);
 		GMT->current.map.frame.horizontal = (fabs (GMT->current.proj.pars[1]) < 30.0 && fabs (GMT->common.R.wesn[YHI] - GMT->common.R.wesn[YLO]) < 30.0) ? 1 : 0;
 	}
 	else {
@@ -3853,7 +3853,7 @@ GMT_LOCAL bool map_init_ortho (struct GMT_CTRL *GMT) {
 		GMT->current.map.clip = &map_rect_clip;
 		GMT->current.map.left_edge = &map_left_rect;
 		GMT->current.map.right_edge = &map_right_rect;
-		GMT->current.map.frame.check_side = !(GMT->current.setting.map_annot_oblique & 1);
+		GMT->current.map.frame.check_side = !(GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_ANYWHERE);
 		GMT->current.map.frame.horizontal = (fabs (GMT->current.proj.pars[1]) < 30.0 && fabs (GMT->common.R.wesn[YHI] - GMT->common.R.wesn[YLO]) < 30.0) ? 1 : 0;
 	}
 	else {
@@ -3991,7 +3991,7 @@ GMT_LOCAL bool map_init_genper (struct GMT_CTRL *GMT) {
 		GMT->current.map.clip = &map_rect_clip_old;
 		GMT->current.map.left_edge = &gmt_left_genper;
 		GMT->current.map.right_edge = &gmt_right_genper;
-		GMT->current.map.frame.check_side = !(GMT->current.setting.map_annot_oblique & 1);
+		GMT->current.map.frame.check_side = !(GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_ANYWHERE);
 		GMT->current.map.frame.horizontal = (fabs (GMT->current.proj.pars[1]) < 30.0 && fabs (GMT->common.R.wesn[YHI] - GMT->common.R.wesn[YLO]) < 30.0) ? 1 : 0;
 		GMT->current.map.jump = &map_jump_not;
 		search = true;
@@ -4079,7 +4079,7 @@ GMT_LOCAL bool map_init_gnomonic (struct GMT_CTRL *GMT) {
 		GMT->current.map.clip = &map_rect_clip;
 		GMT->current.map.left_edge = &map_left_rect;
 		GMT->current.map.right_edge = &map_right_rect;
-		GMT->current.map.frame.check_side = !(GMT->current.setting.map_annot_oblique & 1);
+		GMT->current.map.frame.check_side = !(GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_ANYWHERE);
 		GMT->current.map.frame.horizontal = (fabs (GMT->current.proj.pars[1]) < 30.0 && fabs (GMT->common.R.wesn[YHI] - GMT->common.R.wesn[YLO]) < 30.0) ? 1 : 0;
 	}
 	else {
@@ -4163,7 +4163,7 @@ GMT_LOCAL bool map_init_azeqdist (struct GMT_CTRL *GMT) {
 		GMT->current.map.clip = &map_rect_clip;
 		GMT->current.map.left_edge = &map_left_rect;
 		GMT->current.map.right_edge = &map_right_rect;
-		GMT->current.map.frame.check_side = !(GMT->current.setting.map_annot_oblique & 1);
+		GMT->current.map.frame.check_side = !(GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_ANYWHERE);
 		GMT->current.map.frame.horizontal = (fabs (GMT->current.proj.pars[1]) < 60.0 && fabs (GMT->common.R.wesn[YHI] - GMT->common.R.wesn[YLO]) < 30.0) ? 1 : 0;
 	}
 	else {

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -1394,8 +1394,8 @@ GMT_LOCAL void plot_map_tick (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double
 	for (i = 0; i < nx; i++) {
 		if (!GMT->current.proj.edge[sides[i]]) continue;
 		if ((GMT->current.map.frame.side[sides[i]] & GMT_AXIS_TICK) == 0) continue;
-		if (!(GMT->current.setting.map_annot_oblique & 1) && ((type == 0 && (sides[i] % 2)) || (type == 1 && !(sides[i] % 2)))) continue;
-		angle = ((GMT->current.setting.map_annot_oblique & 16) ? (sides[i] - 1) * 90.0 : angles[i]);
+		if (!(GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_ANYWHERE) && ((type == 0 && (sides[i] % 2)) || (type == 1 && !(sides[i] % 2)))) continue;
+		angle = ((GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_NORMAL_TICKS) ? (sides[i] - 1) * 90.0 : angles[i]);
 		if (set_angle) {	/* Adjust angle to fit the range of angles relative to each side */
 			if (sides[i] == 0 && angle < 180.0) angle -= 180.0;
 			if (sides[i] == 1 && (angle > 90.0 && angle < 270.0)) angle -= 180.0;
@@ -1404,7 +1404,7 @@ GMT_LOCAL void plot_map_tick (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double
 		}
 		sincosd (angle, &s, &c);
 		tick_length = len;
-		if (GMT->current.setting.map_annot_oblique & 8) {
+		if (GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_EXTEND_TICKS) {
 			if (sides[i] % 2) {
 				/* if (fabs (c) > cosd (GMT->current.setting.map_annot_min_angle)) continue; */
 				if (fabs (c) < sind (GMT->current.setting.map_annot_min_angle)) continue;
@@ -1472,7 +1472,7 @@ GMT_LOCAL void plot_map_symbol (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, doub
 	annot_type = 2 << type;		/* 2 = NS, 4 = EW */
 
 	for (i = 0; i < nx; i++) {
-		if (!(GMT->current.setting.map_annot_oblique & 1) && ((type == 0 && (sides[i] % 2)) || (type == 1 && !(sides[i] % 2)))) continue;
+		if (!(GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_ANYWHERE) && ((type == 0 && (sides[i] % 2)) || (type == 1 && !(sides[i] % 2)))) continue;
 
 		if (gmtlib_prepare_label (GMT, line_angles[i], sides[i], xx[i], yy[i], type, &line_angle, &text_angle, &justify)) continue;
 
@@ -1480,7 +1480,7 @@ GMT_LOCAL void plot_map_symbol (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, doub
 		tick_length = GMT->current.setting.map_tick_length[GMT_PRIMARY];
 		o_len = len;
 		if (GMT->current.setting.map_annot_oblique & annot_type) o_len = tick_length;
-		if (GMT->current.setting.map_annot_oblique & 8) {
+		if (GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_EXTEND_TICKS) {
 			div = ((sides[i] % 2) ? fabs (ca) : fabs (sa));
 			o_len /= div;
 		}
@@ -4647,8 +4647,8 @@ void gmt_map_basemap (struct GMT_CTRL *GMT) {
 
 	w = GMT->common.R.wesn[XLO], e = GMT->common.R.wesn[XHI], s = GMT->common.R.wesn[YLO], n = GMT->common.R.wesn[YHI];
 
-	if (GMT->current.setting.map_annot_oblique & 2) GMT->current.map.frame.horizontal = 2;
-	if (GMT->current.map.frame.horizontal == 2) GMT->current.setting.map_annot_oblique |= 2;
+	if (GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_LON_HORIZONTAL) GMT->current.map.frame.horizontal = 2;
+	if (GMT->current.map.frame.horizontal == 2) GMT->current.setting.map_annot_oblique |= GMT_OBL_ANNOT_LON_HORIZONTAL;
 	if (GMT->current.setting.map_frame_type & GMT_IS_GRAPH && gmt_M_is_geographic (GMT, GMT_IN)) GMT->current.setting.map_frame_type = GMT_IS_PLAIN;
 	if (GMT->current.setting.map_frame_type & GMT_IS_FANCY && !plot_is_fancy_boundary(GMT)) GMT->current.setting.map_frame_type = GMT_IS_PLAIN;
 

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4503,8 +4503,8 @@ GMT_LOCAL bool support_get_label_parameters (struct GMT_CTRL *GMT, int side, dou
 	else if ( (*text_angle - 90.0) > GMT_CONV8_LIMIT) *text_angle -= 180.0;
 #endif
 
-	if (type == 0 && GMT->current.setting.map_annot_oblique & 2) *text_angle = 0.0;	/* Force horizontal lon annotation */
-	if (type == 1 && GMT->current.setting.map_annot_oblique & 4) *text_angle = 0.0;	/* Force horizontal lat annotation */
+	if (type == 0 && GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_LON_HORIZONTAL) *text_angle = 0.0;	/* Force horizontal lon annotation */
+	if (type == 1 && GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_LAT_HORIZONTAL) *text_angle = 0.0;	/* Force horizontal lat annotation */
 
 	switch (side) {
 		case 0:		/* S */
@@ -4514,7 +4514,7 @@ GMT_LOCAL bool support_get_label_parameters (struct GMT_CTRL *GMT, int side, dou
 				*justify = ((*text_angle) < 0.0) ? 5 : 7;
 			break;
 		case 1:		/* E */
-			if (type == 1 && GMT->current.setting.map_annot_oblique & 32) {
+			if (type == 1 && GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_LAT_PARALLEL) {
 				*text_angle = 90.0;	/* Force parallel lat annotation */
 				*justify = 10;
 			}
@@ -4528,7 +4528,7 @@ GMT_LOCAL bool support_get_label_parameters (struct GMT_CTRL *GMT, int side, dou
 				*justify = ((*text_angle) < 0.0) ? 7 : 5;
 			break;
 		default:	/* W */
-			if (type == 1 && GMT->current.setting.map_annot_oblique & 32) {
+			if (type == 1 && GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_LAT_PARALLEL) {
 				*text_angle = 90.0;	/* Force parallel lat annotation */
 				*justify = 2;
 			}
@@ -13656,7 +13656,7 @@ int gmtlib_prepare_label (struct GMT_CTRL *GMT, double angle, unsigned int side,
 
 	if (GMT->current.map.frame.check_side == true && type != side%2) return -1;
 
-	if (GMT->current.setting.map_annot_oblique & 16 && !(side%2)) angle = -90.0;	/* support_get_label_parameters will make this 0 */
+	if (GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_NORMAL_TICKS && !(side%2)) angle = -90.0;	/* support_get_label_parameters will make this 0 */
 
 	if (angle < 0.0) angle += 360.0;
 
@@ -13671,7 +13671,7 @@ int gmtlib_prepare_label (struct GMT_CTRL *GMT, double angle, unsigned int side,
 
 	if (!support_get_label_parameters (GMT, side, angle, type, text_angle, justify)) return -1;
 	*line_angle = angle;
-	if (GMT->current.setting.map_annot_oblique & 16) *line_angle = (side - 1) * 90.0;
+	if (GMT->current.setting.map_annot_oblique & GMT_OBL_ANNOT_NORMAL_TICKS) *line_angle = (side - 1) * 90.0;
 
 	if (!set_angle) *justify = support_polar_adjust (GMT, side, angle, x, y);
 	if (set_angle && !GMT->common.R.oblique && GMT->current.proj.projection_GMT == GMT_GNOMONIC) {

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -551,9 +551,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT
 			for (j = 0; j < Ctrl->N.dim[GMT_Y]; j++) Ctrl->F.h[j] = GMT->current.map.height;
 		}
 		if (B_args) {	/* Got common -B settings that applies to all axes not controlled by -SR, -SC */
-			if (!noB || ((Bxy && (Bx || By)) || (!Bxy && ((Bx && !By) || (By && !Bx)))) ) {
-				GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Error -B: Must either set -Bx and -By or -B that applies to both axes.\n");
-				n_errors++;
+			if (!noB) {
+				if ((Bxy && (Bx || By)) || (!Bxy && ((Bx && !By) || (By && !Bx)))) {
+					GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Error -B: Must either set -Bx and -By or -B that applies to both axes.\n");
+					n_errors++;
+				}
 			}
 			if (Bxy || Bx)	/* Did get axis annotation settings */
 				Ctrl->S[GMT_X].b = (Bx) ? strdup (Bx->arg) : strdup (Bxy->arg);


### PR DESCRIPTION
It was getting too hard to remember what map_annot_oblique &16 actually meant.  This is groundwork in preparation to solve #499.  Sorry, it also fixed a minor issues in subplot related to the fix yesterday.
