### PR TITLE
Fix missing longitude annotation for frame-type inside

### DIFF
--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -116,7 +116,6 @@ EXTERN_MSC void gmtlib_encode (struct GMT_CTRL *GMT, void *vptr, uint64_t k, gmt
 EXTERN_MSC struct GMT_CUSTOM_SYMBOL * gmtlib_get_custom_symbol (struct GMT_CTRL *GMT, char *name);
 EXTERN_MSC void gmtlib_free_custom_symbols (struct GMT_CTRL *GMT);
 EXTERN_MSC bool gmtlib_geo_to_dms (double val, int n_items, double fact, int *d, int *m,  int *s,  int *ix);
-EXTERN_MSC double gmtlib_get_annot_offset (struct GMT_CTRL *GMT, bool *flip, unsigned int level);
 EXTERN_MSC int gmtlib_get_coordinate_label (struct GMT_CTRL *GMT, char *string, struct GMT_PLOT_CALCLOCK *P, char *format, struct GMT_PLOT_AXIS_ITEM *T, double coord);
 EXTERN_MSC void gmtlib_get_time_label (struct GMT_CTRL *GMT, char *string, struct GMT_PLOT_CALCLOCK *P, struct GMT_PLOT_AXIS_ITEM *T, double t);
 EXTERN_MSC int gmtlib_getrgb_index (struct GMT_CTRL *GMT, double *rgb);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -41,7 +41,6 @@
  *  support_csplint             Natural cubic 1-D spline evaluator
  *  gmt_delaunay            Performs a Delaunay triangulation
  *  gmtlib_get_annot_label     Construct degree/minute label
- *  gmtlib_get_annot_offset    Return offset in inches for text annotation
  *  gmt_get_index           Return color table entry for given z
  *  gmt_get_fill_from_z     Return fill type for given z
  *  gmt_get_format          Find # of decimals and create format string
@@ -13833,32 +13832,6 @@ double gmt_get_angle (struct GMT_CTRL *GMT, double lon1, double lat1, double lon
 	if (direction < 0.0) direction += 360.0;
 	if (direction >= 360.0) direction -= 360.0;
 	return (direction);
-}
-
-/*! . */
-double gmtlib_get_annot_offset (struct GMT_CTRL *GMT, bool *flip, unsigned int level) {
-	/* Return offset in inches for text annotation.  If annotation
-	 * is to be placed 'inside' the map, set flip to true */
-
-	double a = GMT->current.setting.map_annot_offset[level];
-	if (GMT->current.setting.map_frame_type & GMT_IS_INSIDE) {	/* Inside annotation */
-		a = -fabs (a);
-		a -= fabs (GMT->current.setting.map_tick_length[0]);
-		*flip = true;
-	}
-	else if (a >= 0.0) {	/* Outside annotation */
-		double dist = GMT->current.setting.map_tick_length[0];	/* Length of tickmark (could be negative) */
-		/* For fancy frame we must consider that the frame width might exceed the ticklength */
-		if (GMT->current.setting.map_frame_type & GMT_IS_FANCY && GMT->current.setting.map_frame_width > dist) dist = GMT->current.setting.map_frame_width;
-		if (dist > 0.0) a += dist;
-		*flip = false;
-	}
-	else {		/* Inside annotation via negative tick length */
-		if (GMT->current.setting.map_tick_length[0] < 0.0) a += GMT->current.setting.map_tick_length[0];
-		*flip = true;
-	}
-
-	return (a);
 }
 
 /*! . */


### PR DESCRIPTION
The labels were there in the PostScript but due to a bug they got placed outside the frame and clipped.  See #499 for context. I hope @KristofKoch can give this a test before we merge.
