### PR TITLE
Add support for Itanium

### DIFF
--- a/src/common_sighandler.c
+++ b/src/common_sighandler.c
@@ -106,6 +106,8 @@ void backtrace_symbols_fd(void *const *buffer, int size, int fd) {
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.arm_pc)
 # elif defined(__powerpc__) || defined(__powerpc64__)
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.regs->nip)
+# elif defined(__ia64__)
+#  define UC_IP(uc) ((void *) (uc)->uc_mcontext.sc_ip)
 # else
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.eip)
 # endif


### PR DESCRIPTION
Under Debian/ia64, gmt fails to build from source: https://buildd.debian.org/status/fetch.php?pkg=gmt&arch=ia64&ver=5.4.5%2Bdfsg-2&stamp=1559711160&raw=0

The attached patch fixes the macro used in the signal handler.  Once fixed, the package compiles successfully.