### PR TITLE
Simplify test scripts gmtest.in and their CMakeLists.txt files

### DIFF
--- a/cmake/ConfigUserTemplate.cmake
+++ b/cmake/ConfigUserTemplate.cmake
@@ -216,8 +216,6 @@
 #set (DO_EXAMPLES TRUE)
 #set (DO_TESTS TRUE)
 #set (DO_ANIMATIONS TRUE)
-# Auto-convert classic scripts to modern during testing:
-#set (MODERNIZE_TESTS TRUE)
 # Number of parallel test jobs with "make check":
 #set (N_TEST_JOBS 4)
 

--- a/doc/examples/CMakeLists.txt
+++ b/doc/examples/CMakeLists.txt
@@ -153,12 +153,6 @@ if (UNIX AND DO_ANIMATIONS)
 endif (UNIX AND DO_ANIMATIONS)
 
 # run examples (test)
-if (MODERNIZE_TESTS)
-	set (SCRIPT_MODE "M")
-else (MODERNIZE_TESTS)
-#set (SCRIPT_MODE "C")
-	set (SCRIPT_MODE "")
-endif (MODERNIZE_TESTS)
 
 if (DO_EXAMPLES) # AND UNIX)
 	# this file takes care of setting up the test environment
@@ -177,7 +171,7 @@ if (DO_EXAMPLES) # AND UNIX)
 		string (REPLACE "//" "/" _job ${_job})	# GLOB creates double slashes we do not want
 		add_test (NAME ${_job}
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-			COMMAND ${BASH} gmtest ${_job} ${SCRIPT_MODE})
+			COMMAND ${BASH} gmtest ${_job})
 	endforeach (_job ${_examples})
 elseif (DO_EXAMPLES_WIN_BATCH_DISABLED) # (DO_EXAMPLES AND WIN32)
 	# only supporting examples with installed GMT in %path%
@@ -187,7 +181,7 @@ elseif (DO_EXAMPLES_WIN_BATCH_DISABLED) # (DO_EXAMPLES AND WIN32)
 			${CMAKE_CURRENT_BINARY_DIR}/${_job} PATH)
 		add_test (NAME ${_job}
 			WORKING_DIRECTORY ${_job_path}
-			COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${_job} ${SCRIPT_MODE})
+			COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${_job})
 	endforeach (_job ${_examples_win})
 endif (DO_EXAMPLES) # AND UNIX)
 

--- a/doc/examples/animate.in
+++ b/doc/examples/animate.in
@@ -8,11 +8,9 @@ test -z "$1" && exit 1
 
 # Where the current script resides (need absolute path)
 script_name="$1"
-script_mode="$2"
 script_dir=$(dirname "${script_name}")
 local_script=$(basename "${script_name}")
 script="@GMT_SOURCE_DIR@/doc/examples/${script_name}"
-classic=$(grep "GMT CLASSIC" "$script" -c)
 if ! [ -x "${script}" ]; then
   echo "error: cannot execute script ${script}." >&2
   exit 1
@@ -82,21 +80,7 @@ unset GLOBIGNORE
 # Start with proper GMT defaults
 gmt set -Du FORMAT_TIME_STAMP "Version 6"
 
-if [ "X$script_mode" = "XM" ]; then
-	# Test a modernized version of the script instead
-	if [ $classic -eq 0 ]; then
-		echo "Modernizing $script to $local_script before testing"
-		gmtmodernize "$script" > ./${local_script}
-		export GMT_SESSION_NAME=$$
-		echo "Set GMT_SESSION_NAME = $GMT_SESSION_NAME"
-		. "${local_script}" animate
-	else
-		echo "Cannot modernize classic GMT script ${script}. Run in classic mode" >&2
-		. "${script}" animate
-	fi
-else
-	# Now run the original script
-	. "${script}" animate
-fi
+# Now run the original script
+. "${script}" animate
 
 # vim: ft=sh

--- a/doc/examples/gmtest.in
+++ b/doc/examples/gmtest.in
@@ -8,12 +8,14 @@ test -z "$1" && exit 1
 
 # Where the current script resides (need absolute path)
 script_name="$1"
-script_mode="$2"
 script_dir=$(dirname "${script_name}")
 local_script=$(basename "${script_name}")
 script="@GMT_SOURCE_DIR@/doc/examples/${script_name}"
 src="@GMT_SOURCE_DIR@/doc/examples/${script_dir}"
-classic=$(grep "GMT CLASSIC" "$script" -c)
+# Is it a modern mode script?
+modern=$(grep "gmt begin" "$script" -c)
+# Is it a script that is known to fail?
+known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
 if ! [ -x "${script}" ]; then
   echo "error: cannot execute script ${script}." >&2
   exit 1
@@ -73,23 +75,27 @@ if ! [ -x "$GRAPHICSMAGICK" ]; then
   return
 fi
 for ps in *.ps ; do
-  # syntax: gm compare [ options ... ] reference-image [ options ... ] compare-image [ options ... ]
-  rms=$("${GRAPHICSMAGICK}" compare -density 200 -maximum-error $GRAPHICSMAGICK_RMS -highlight-color magenta -highlight-style assign -metric rmse -file "${ps%.ps}.png" "$ps" "${src}/${ps}") || pscmpfailed="yes"
-  rms=$(perl -ne 'print $1 if /Total: ([0-9.]+)/' <<< "$rms")
-  if [ -z "$rms" ]; then
-    rms="NA"
+  if [ ${known2fail} -eq 1 ]; then	# No point running the comparison since we know it fails
+      echo "${ps}: RMS Error = NA [FAIL] (known failure)"
   else
-    rms=$(printf "%.3f\n" $rms)
-  fi
-  if [ "$pscmpfailed" ]; then
-    now=$(date "+%F %T")
-    echo "${ps}: RMS Error = $rms [FAIL]"
-    echo "$now ${ps}: RMS Error = $rms" >> "@CMAKE_CURRENT_BINARY_DIR@/fail_count.d"
-    make_pdf "$ps" # try to make pdf file
-    ((++ERROR))
-  else
-    test -z "$rms" && rms=NA
-    echo "${ps}: RMS Error = $rms [PASS]"
+    # syntax: gm compare [ options ... ] reference-image [ options ... ] compare-image [ options ... ]
+    rms=$("${GRAPHICSMAGICK}" compare -density 200 -maximum-error $GRAPHICSMAGICK_RMS -highlight-color magenta -highlight-style assign -metric rmse -file "${ps%.ps}.png" "$ps" "${src}/${ps}") || pscmpfailed="yes"
+    rms=$(perl -ne 'print $1 if /Total: ([0-9.]+)/' <<< "$rms")
+    if [ -z "$rms" ]; then
+      rms="NA"
+    else
+      rms=$(printf "%.3f\n" $rms)
+    fi
+    if [ "$pscmpfailed" ]; then
+      now=$(date "+%F %T")
+      echo "${ps}: RMS Error = $rms [FAIL]"
+      echo "$now ${ps}: RMS Error = $rms" >> "@CMAKE_CURRENT_BINARY_DIR@/fail_count.d"
+      make_pdf "$ps" # try to make pdf file
+      ((++ERROR))
+    else
+      test -z "$rms" && rms=NA
+      echo "${ps}: RMS Error = $rms [PASS]"
+    fi
   fi
 done
 }
@@ -158,19 +164,8 @@ for file in "$src"/* ; do
 done
 unset GLOBIGNORE
 
-if [ "X$script_mode" = "XM" ]; then
-	# Test a modernized version of the script instead
-	if [ $classic -eq 0 ]; then
-		echo "Modernizing $script to $local_script before testing"
-		gmtmodernize "$script" > ./${local_script}
-	else
-		echo "Cannot modernize classic GMT script ${script}. Run in classic mode" >&2
-		ln -sf "$script" .
-	fi
-else
-	# Run the original classic script via link from current directory
-	ln -sf "$script" .
-fi
+# Run the original script via link from current directory
+ln -sf "$script" .
 
 # Make a script to capture everything that can be run again
 cat > gmtest.sh << EOF
@@ -191,9 +186,10 @@ export GS_FONTPATH="@CMAKE_CURRENT_SOURCE_DIR@/ex31/fonts"
 # Start with proper GMT defaults
 gmt set -Du FORMAT_TIME_STAMP "Version 6"
 # Modern mode needs a stable PPID but ctest messes that up when pipes are used
-if [ "X$script_mode" = "XM" ]; then
+if [ ${modern} -gt 0 ]; then
 	export GMT_SESSION_NAME=\$\$
 	echo "Set GMT_SESSION_NAME = \$GMT_SESSION_NAME"
+	script_mode=M
 fi
 # Now run the script
 . "${local_script}"

--- a/doc/scripts/CMakeLists.txt
+++ b/doc/scripts/CMakeLists.txt
@@ -161,12 +161,6 @@ add_depend_to_target (docs_pdf_depends _docs_pdf_scripts_fig _docs_scripts_verba
 # run tests
 if (DO_TESTS)
 	# this file takes care of setting up the test environment
-	if (MODERNIZE_TESTS)
-		set (SCRIPT_MODE "M")
-	else (MODERNIZE_TESTS)
-		set (SCRIPT_MODE "C")
-	endif (MODERNIZE_TESTS)
-
 	configure_file (gmtest.in gmtest @ONLY)
 
 	# Workaround cmake bug 3957: CRLF line ending
@@ -180,7 +174,7 @@ if (DO_TESTS)
 	foreach (_job ${_scripts_tests})
 		add_test (NAME ${_job}
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-			COMMAND ${BASH} gmtest ${_job} ${SCRIPT_MODE})
+			COMMAND ${BASH} gmtest ${_job})
 	endforeach (_job)
 endif (DO_TESTS)
 

--- a/doc/scripts/gmtest.in
+++ b/doc/scripts/gmtest.in
@@ -7,12 +7,14 @@ test -z "$1" && exit 1
 
 # Where the current script resides (need absolute path)
 script_name="$1"
-script_mode="$2"
 script="@GMT_SOURCE_DIR@/doc/scripts/${script_name}"
 local_script=$(basename "${script_name}")
 src="@GMT_SOURCE_DIR@/doc/scripts"
 tut="@GMT_SOURCE_DIR@/doc/tutorial"
-classic=$(grep "GMT CLASSIC" "$script" -c)
+# Is it a modern mode script?
+modern=$(grep "gmt begin" "$script" -c)
+# Is it a script that is known to fail?
+known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
 if ! [ -x "${script}" ]; then
   echo "error: cannot execute script ${script}." >&2
   exit 1
@@ -72,25 +74,29 @@ pscmp () {
     echo "[PASS] (without comparison)"
     return
   fi
-  # syntax: gm compare [ options ... ] reference-image [ options ... ] compare-image [ options ... ]
-  rms=$("${GRAPHICSMAGICK}" compare -density 200 -maximum-error $GRAPHICSMAGICK_RMS -highlight-color magenta -highlight-style assign -metric rmse -file "${ps%.ps}.png" "$ps" "${src}/${ps}") || pscmpfailed="yes"
-  rms=$(perl -ne 'print $1 if /Total: ([0-9.]+)/' <<< "$rms")
-  if [ -z "$rms" ]; then
-    rms="NA"
+  if [ ${known2fail} -eq 1 ]; then	# No point running the comparison since we know it fails
+      echo "${ps}: RMS Error = NA [FAIL] (known failure)"
   else
-    rms=$(printf "%.3f\n" $rms)
+    # syntax: gm compare [ options ... ] reference-image [ options ... ] compare-image [ options ... ]
+    rms=$("${GRAPHICSMAGICK}" compare -density 200 -maximum-error $GRAPHICSMAGICK_RMS -highlight-color magenta -highlight-style assign -metric rmse -file "${ps%.ps}.png" "$ps" "${src}/${ps}") || pscmpfailed="yes"
+    rms=$(perl -ne 'print $1 if /Total: ([0-9.]+)/' <<< "$rms")
+    if [ -z "$rms" ]; then
+      rms="NA"
+    else
+      rms=$(printf "%.3f\n" $rms)
+    fi
+    if [ "$pscmpfailed" ]; then
+      now=$(date "+%F %T")
+      echo "${ps}: RMS Error = $rms [FAIL]"
+      echo "$now ${ps}: RMS Error = $rms" >> "@CMAKE_CURRENT_BINARY_DIR@/fail_count.d"
+      make_pdf "$ps" # try to make pdf file
+      ((++ERROR))
+    else
+      test -z "$rms" && rms=NA
+      echo "${ps}: RMS Error = $rms [PASS]"
+    fi
   fi
-  if [ "$pscmpfailed" ]; then
-    now=$(date "+%F %T")
-    echo "${ps}: RMS Error = $rms [FAIL]"
-    echo "$now ${ps}: RMS Error = $rms" >> "@CMAKE_CURRENT_BINARY_DIR@/fail_count.d"
-    make_pdf "$ps" # try to make pdf file
-    ((++ERROR))
-  else
-    test -z "$rms" && rms=NA
-    echo "${ps}: RMS Error = $rms [PASS]"
-  fi
-}
+  }
 
 # Make sure to cleanup at end
 function cleanup()
@@ -149,19 +155,8 @@ exec_dir="@CMAKE_CURRENT_BINARY_DIR@/${script_name%.sh}"
 rm -rf "$exec_dir"
 mkdir -p "$exec_dir"
 cd "$exec_dir"
-if [ "X$script_mode" = "XM" ]; then
-	# Test a modernized version of the script instead
-	if [ $classic -eq 0 ]; then
-		echo "Modernizing $script to $local_script before testing"
-		gmtmodernize "$script" > ./${local_script}
-	else
-		echo "Cannot modernize classic GMT script ${script}. Run in classic mode" >&2
-		ln -sf "$script" .
-	fi
-else
-	# Run the original classic script via link from current directory
-	ln -sf "$script" .
-fi
+# Run the original script via link from current directory
+ln -sf "$script" .
 
 # Make a script to capture everything that can be run again
 cat > gmtest.sh << EOF
@@ -182,10 +177,11 @@ gmt set -Du PS_CHAR_ENCODING ISOLatin1+
 # Tentative PS file name
 ps="${script_name%.sh}.ps"
 # Modern mode needs a stable PPID but ctest messes that up when pipes are used
-#if [ "X$script_mode" = "XM" ]; then
+if [ ${modern} -gt 0 ]; then
 	export GMT_SESSION_NAME=\$\$
 	echo "Set GMT_SESSION_NAME = \$GMT_SESSION_NAME"
-#fi
+	script_mode=M
+fi
 # Now run the script
 . "${local_script}"
 EOF

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,12 +17,6 @@
 
 # run tests
 if (DO_TESTS)
-	if (MODERNIZE_TESTS)
-		set (SCRIPT_MODE "M")
-	else (MODERNIZE_TESTS)
-		set (SCRIPT_MODE "C")
-	endif (MODERNIZE_TESTS)
-
 	# list of test dirs {Note: You must add new test sub-directories here}
 	set (GMT_TEST_DIRS byteswap blockmean blockmedian blockmode filter1d fitcircle gdal
 		genper gmt_core gmtconvert gmtlogo gmtinfo gmtmath gmtregress gmtselect gmtsimplify
@@ -33,13 +27,11 @@ if (DO_TESTS)
 		ogr postscriptlight project psbasemap psclip pscoast pscontour psevents pshistogram
 		psimage pslegend psmask psrose pssac psscale pssolar psternary pstext pswiggle psxy
 		psxyz sample1d segy spectrum1d sph sph2grd splitxyz surface time trend1d trend2d
-		triangulate img meca mgd77 potential spotter x2sys)
+		triangulate img meca mgd77 potential spotter x2sys modern exmod)
 
 	if (DO_API_TESTS)
 		list (APPEND GMT_TEST_DIRS api)
 	endif (DO_API_TESTS)
-
-	set (GMT_TEST_DIRS_MODERN modern exmod)
 
 	# export HAVE_GMT_DEBUG_SYMBOLS
 	get_directory_property (_dir_defs COMPILE_DEFINITIONS)
@@ -69,18 +61,7 @@ if (DO_TESTS)
 		foreach (_test ${_test_scripts})
 			add_test (NAME ${_test}
 				WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-				COMMAND ${BASH} gmtest ${_test} ${SCRIPT_MODE})
-		endforeach (_test ${_test_scripts})
-	endforeach (_test_dir ${GMT_TEST_DIRS})
-	# add modern tests
-	foreach (_test_dir ${GMT_TEST_DIRS_MODERN})
-		# find files RELATIVE so that test NAMEs are not absolute paths
-		file (GLOB _test_scripts RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
-			"${CMAKE_CURRENT_SOURCE_DIR}/${_test_dir}/*.sh")
-		foreach (_test ${_test_scripts})
-			add_test (NAME ${_test}
-				WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-				COMMAND ${BASH} gmtest ${_test} m)
+				COMMAND ${BASH} gmtest ${_test})
 		endforeach (_test ${_test_scripts})
 	endforeach (_test_dir ${GMT_TEST_DIRS})
 endif (DO_TESTS)

--- a/test/genper/gridlines2.sh
+++ b/test/genper/gridlines2.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# GMT_KNOWN_FAILURE
 # More testing of issue #667, item #5
 ps=gridlines2.ps
 lon0=225.989251068

--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -4,18 +4,20 @@
 # Functions to be used with test scripts
 
 # Print the shell script name and purpose and fill out to 72 characters
-# and make sure to use US system defaults
+# and make sure to use US GMT system defaults
 
 test -z "$1" && exit 1
 
 # Name of the script and the directory portion of it
 script_name="$1"
-script_mode="$2"
 script_dir=$(dirname "${script_name}")
 local_script=$(basename "${script_name}")
 script="@GMT_SOURCE_DIR@/test/${script_name}"
 src="@GMT_SOURCE_DIR@/test/${script_dir}"
-classic=$(grep "GMT CLASSIC" "$script" -c)
+# Is it a modern mode script?
+modern=$(grep "gmt begin" "$script" -c)
+# Is it a script that is known to fail?
+known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
 if ! [ -x "${script}" ]; then
   echo "error: cannot execute script ${script}." >&2
   exit 1
@@ -120,24 +122,28 @@ if ! [ -x "$GRAPHICSMAGICK" ]; then
   return
 fi
 for ps in *.ps ; do
-  # syntax: gm compare [ options ... ] reference-image [ options ... ] compare-image [ options ... ]
-  rms=$("${GRAPHICSMAGICK}" compare -density 200 -maximum-error $GRAPHICSMAGICK_RMS -highlight-color magenta -highlight-style assign -metric rmse -file "${ps%.ps}.png" "$ps" "$src/${psref:-$ps}") || pscmpfailed="yes"
-  rms=$(perl -ne 'print $1 if /Total: ([0-9.]+)/' <<< "$rms")
-  if [ -z "$rms" ]; then
-    rms="NA"
+  if [ ${known2fail} -eq 1 ]; then	# No point running the comparison since we know it fails
+      echo "${script_dir}/${ps}: RMS Error = NA [FAIL] (known failure)"
   else
-    rms=$(printf "%.3f\n" $rms)
-  fi
-  if [ "$pscmpfailed" ]; then
-    now=$(date "+%F %T")
-    echo "${script_dir}/${ps}: RMS Error = $rms [FAIL]"
-    echo "$now ${script_dir}/${ps}: RMS Error = $rms" >> "@CMAKE_CURRENT_BINARY_DIR@/fail_count.d"
-    make_pdf "$ps" # try to make pdf file
-    ((++ERROR))
-  else
-    test -z "$rms" && rms=NA
-    echo "${script_dir}/${ps}: RMS Error = $rms [PASS]"
-  fi
+    # syntax: gm compare [ options ... ] reference-image [ options ... ] compare-image [ options ... ]
+    rms=$("${GRAPHICSMAGICK}" compare -density 200 -maximum-error $GRAPHICSMAGICK_RMS -highlight-color magenta -highlight-style assign -metric rmse -file "${ps%.ps}.png" "$ps" "$src/${psref:-$ps}") || pscmpfailed="yes"
+    rms=$(perl -ne 'print $1 if /Total: ([0-9.]+)/' <<< "$rms")
+    if [ -z "$rms" ]; then
+      rms="NA"
+    else
+      rms=$(printf "%.3f\n" $rms)
+    fi
+    if [ "$pscmpfailed" ]; then
+      now=$(date "+%F %T")
+      echo "${script_dir}/${ps}: RMS Error = $rms [FAIL]"
+      echo "$now ${script_dir}/${ps}: RMS Error = $rms" >> "@CMAKE_CURRENT_BINARY_DIR@/fail_count.d"
+      make_pdf "$ps" # try to make pdf file
+      ((++ERROR))
+    else
+      test -z "$rms" && rms=NA
+      echo "${script_dir}/${ps}: RMS Error = $rms [PASS]"
+    fi
+  fi	
 done
 }
 
@@ -210,19 +216,8 @@ exec_dir="@CMAKE_CURRENT_BINARY_DIR@/${script_name%.sh}"
 rm -rf "$exec_dir"
 mkdir -p "$exec_dir"
 cd "$exec_dir"
-if [ "X$script_mode" = "XM" ]; then
-	# Test a modernized version of the script instead
-	if [ $classic -eq 0 ]; then
-		echo "Modernizing $script to $local_script before testing"
-		gmtmodernize "$script" > ./${local_script}
-	else
-		echo "Cannot modernize classic GMT script ${script}. Run in classic mode" >&2
-		ln -sf "$script" .
-	fi
-else
-	# Run the original classic script via link from current directory
-	ln -sf "$script" .
-fi
+# Run the original script via link from current directory
+ln -sf "$script" .
 
 # Make a script to capture everything that can be run again
 cat > gmtest.sh << EOF
@@ -244,7 +239,7 @@ export HAVE_GLIB_GTHREAD="@HAVE_GLIB_GTHREAD@"
 # Start with proper GMT defaults
 gmt set -Du
 # Modern mode needs a stable PPID but ctest messes that up when pipes are used
-if [ "X$script_mode" = "XM" ] || [ "X$script_mode" = "Xm" ]; then
+if [ ${modern} -gt 0 ]; then
 	export GMT_SESSION_NAME=\$\$
 	echo "Set GMT_SESSION_NAME = \$GMT_SESSION_NAME"
 	script_mode=M

--- a/test/grdcontour/periodic.sh
+++ b/test/grdcontour/periodic.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# GMT_KNOWN_FAILURE
 # Demonstrate issue #536 with labeling of periodic contours
 # Turns out non-issue due to different contour lengths and -Gd
 # Using -Gl shows annotation machinery works fine.

--- a/test/grdfilter/openmp.sh
+++ b/test/grdfilter/openmp.sh
@@ -4,7 +4,7 @@
 ps=openmp.ps
 
 if ! [[ ${HAVE_OPENMP} =~ TRUE|ON ]]; then
-  echo "[N/A]"
+  #echo "[N/A]"
   exit 0
 fi
 FILT=g			# Gaussian filter

--- a/test/grdimage/grdimage.sh
+++ b/test/grdimage/grdimage.sh
@@ -2,7 +2,6 @@
 #
 
 ps=grdimage.ps
-# GMT CLASSIC
 image="gmt grdimage t.nc -Ct.cpt -JX1i -B1 -BWeSn --FONT_ANNOT_PRIMARY=10p"
 contour="gmt grdcontour t.nc -Ct.cpt -J -R -O"
 

--- a/test/grdimage/mask.sh
+++ b/test/grdimage/mask.sh
@@ -2,7 +2,6 @@
 #
 # Test colorizing 1-bit images in grdimage
 ps=mask.ps
-# GMT CLASSIC
 
 # Created mask.nc this way, now in git
 # gmt grdmath -R0/20/0/20 -I1 -r 0 1 RAND RINT = mask.nc=nb

--- a/test/grdimage/oneincshift.sh
+++ b/test/grdimage/oneincshift.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+# GMT_KNOWN_FAILURE
 # Global pixel grids offset by half a grid increment fails
 # The same for gridline-registered grids work.
 # Here, q0.nc is fine but q.nc is shifted by 1/2 dx.

--- a/test/grdview/wrap.sh
+++ b/test/grdview/wrap.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# GMT_KNOWN_FAILURE
 # grdview does not close gap across periodic boundary that is not split, such as for azimuthal projections
 # There are three troubles here:
 # 1) The gap, which is seen in the output of this script (no orig present to ensure test will fail)

--- a/test/ogr/select.sh
+++ b/test/ogr/select.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# GMT_KNOWN_FAILURE
 # Test that gmtselect can apply a -Z test to data with OGR records,
 # where the z comes from the metadata header, and that output it
 # will pass the metadata as well by writing an OGR file

--- a/test/potential/case_largeR_noW.sh
+++ b/test/potential/case_largeR_noW.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #	Testing gpsgridder for large region without weights
 #	Work is being done by run_GPS_case.sh
-# GMT CLASSIC mode
 ps=case_largeR_noW.ps
 # Use real GPS data with uncertainties
 data=`gmt which -G @wus_gps_final_crowell.txt`

--- a/test/potential/case_largeR_withW.sh
+++ b/test/potential/case_largeR_withW.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #	Testing gpsgridder for large region with weights
 #	Work is being done by run_GPS_case.sh
-# GMT CLASSIC mode
 ps=case_largeR_withW.ps
 # Use real GPS data with uncertainties
 data=`gmt which -G @wus_gps_final_crowell.txt`

--- a/test/potential/case_smallR_noW.sh
+++ b/test/potential/case_smallR_noW.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #	Testing gpsgridder for small region without weights
 #	Work is being done by run_GPS_case.sh
-# GMT CLASSIC mode
 ps=case_smallR_noW.ps
 # Use real GPS data with uncertainties
 data=`gmt which -G @wus_gps_final_crowell.txt`

--- a/test/potential/case_smallR_withW.sh
+++ b/test/potential/case_smallR_withW.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #	Testing gpsgridder for small region with weights
 #	Work is being done by run_GPS_case.sh
-# GMT CLASSIC mode
 ps=case_smallR_withW.ps
 # Use real GPS data with uncertainties
 data=`gmt which -G @wus_gps_final_crowell.txt`

--- a/test/psbasemap/poption.sh
+++ b/test/psbasemap/poption.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# GMT_KNOWN_FAILURE
 # Test script for -p perspective. Ancient #131 issue.
 # The p<az>/90 is wrongly positioned while th p180/90 is always correct.
 

--- a/test/psbasemap/rotalign.sh
+++ b/test/psbasemap/rotalign.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+# GMT_KNOWN_FAILURE
 # The failure pointed out in http://gmt.soest.hawaii.edu/boards/1/topics/7776
 # The axes labels and annotations are 180 out of phase.
 #
-
 ps=rotalign.ps
 
 gmt set MAP_ANNOT_ORTHO ""

--- a/test/psbasemap/zrotation.sh
+++ b/test/psbasemap/zrotation.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# GMT_KNOWN_FAILURE
 # Test script for plain -p<rot> about map center.
 # This should place 4 plots that differ by a rotation about the S pole
 # Currently fails.  Faked the orig by using -JA<rot>... instead [in brackets]

--- a/test/psxy/clipping4.sh
+++ b/test/psxy/clipping4.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+# GMT_KNOWN_FAILURE
 # Check ellipse clipping and filling/outline
 
 ps=clipping4.ps

--- a/test/psxy/clipping5.sh
+++ b/test/psxy/clipping5.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-#
+# GMT_KNOWN_FAILURE
 # Check ellipse clipping and filling/outline
-# Note: This will pass the test since the original is the same as the output
-# The issues have been posted to gmt-dev forum
+# Middle plot polygons have odd stray line along boundaries
+# Annotation mismatch will go away once bug is fixed and we rebuild orig
 ps=clipping5.ps
 
 cat << EOF > t.txt

--- a/test/psxy/clipping6.sh
+++ b/test/psxy/clipping6.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# GMT_KNOWN_FAILURE
 ps=clipping6.ps
 cat << EOF > badpol.txt
 -70	-55

--- a/test/psxy/nearpole.sh
+++ b/test/psxy/nearpole.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# GMT_KNOWN_FAILURE
 # This is a follow up on topic http://gmt.soest.hawaii.edu/boards/1/topics/7166?r=7203#message-7203
 # submitted by Sabin.  The problem polygon (Amundsen Terrane) is not polar but is very very close to the
 # S pole and elongated almost 180 degrees way from the map center.  Hence it ends up very

--- a/test/psxy/nojump.sh
+++ b/test/psxy/nojump.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
+# GMT_KNOWN_FAILURE
 # Added after issue #672 which exposed a map jump that should not happen
 # Fixed in r14052 but we keep this test in case it resurfaces
+# Well, bottom panel plots the wrong closed polygon
 ps=nojump.ps
 cat << EOF > t.txt
 115 -20

--- a/test/psxy/outline.sh
+++ b/test/psxy/outline.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
+# GMT_KNOWN_FAILURE
 # Test issue #1204
+# Text should be red with blue outline but the quoted text is blue.
 ps=outline.ps
 cat << EOF > t.txt
 0 0.25

--- a/test/psxy/wrapper.sh
+++ b/test/psxy/wrapper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# GMT_KNOWN_FAILURE
 # Examples of how large polygons (> 180 degree range) clipped by near-global regions
 # sometimes fails the inside/outside area tests.
 # There is not yet a orig to compare but it fails.


### PR DESCRIPTION
I have cleaned up the testing schemes (CMakeLists.txt (3), gmtest.sh (3), and animate.in):

- Eliminate special provisions for classic versus modernize checks in the three gmtest.in scripts. We no longer plan (or have been doing) a conversion from classic to modern on the fly.
- Use a simple grep-command to detect if a script is modern mode (look for "gmt begin") and use that to handle the setting of the session PPID.
-  Flag all known failure scripts with the keyword **GMT_KNOWN_FAILURE**.  Any script with that text in it will not be compared with an original PostScript file (which often is missing) and instead will FAIL (known failure) and not be added to the failure count.
- Eliminate **MODERNIZE_TESTS** from the make/Config*.cmake files.

The only desired modification would be a report of the count of known failures at the end, so we are at least reminded when running the tests.  However, the log file lists all the information
