### PR TITLE
Address some linux warnings

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -10973,23 +10973,23 @@ void gmt_getdefaults (struct GMT_CTRL *GMT, char *this_file) {
  */
 char *gmtlib_putfill (struct GMT_CTRL *GMT, struct GMT_FILL *F) {
 
-	static char text[GMT_BUFSIZ+GMT_LEN256] = {""};
+	static char text[PATH_MAX+GMT_LEN256] = {""};
 	int i;
 
 	if (F->use_pattern) {
 		if (F->pattern_no)
-			snprintf (text, GMT_LEN256, "p%d/%d", F->dpi, F->pattern_no);
+			snprintf (text, PATH_MAX+GMT_LEN256, "p%d/%d", F->dpi, F->pattern_no);
 		else
-			snprintf (text, GMT_LEN256, "p%d/%s", F->dpi, F->pattern);
+			snprintf (text, PATH_MAX+GMT_LEN256, "p%d/%s", F->dpi, F->pattern);
 	}
 	else if (F->rgb[0] < -0.5)
 		sprintf (text, "-");
 	else if ((i = gmtlib_getrgb_index (GMT, F->rgb)) >= 0)
-		snprintf (text, GMT_BUFSIZ+GMT_LEN256, "%s", gmt_M_color_name[i]);
+		snprintf (text, PATH_MAX+GMT_LEN256, "%s", gmt_M_color_name[i]);
 	else if (gmt_M_is_gray (F->rgb))
-		snprintf (text, GMT_BUFSIZ+GMT_LEN256, "%.5g", gmt_M_q(gmt_M_s255(F->rgb[0])));
+		snprintf (text, PATH_MAX+GMT_LEN256, "%.5g", gmt_M_q(gmt_M_s255(F->rgb[0])));
 	else
-		snprintf (text, GMT_BUFSIZ+GMT_LEN256, "%.5g/%.5g/%.5g", gmt_M_t255(F->rgb));
+		snprintf (text, PATH_MAX+GMT_LEN256, "%.5g/%.5g/%.5g", gmt_M_t255(F->rgb));
 	gmtinit_append_trans (text, F->rgb[3]);
 	return (text);
 }

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -226,7 +226,7 @@ GMT_LOCAL int gmtsupport_parse_pattern_new (struct GMT_CTRL *GMT, char *line, st
 	if (!gmt_M_file_is_memory (&line[1]) && line[1] == '@') {	/* Must be a cache file */
 		first = gmt_download_file_if_not_found (GMT, &line[1], 0) + 1;	/* Add one since we started at 1 */
 	}
-	strncpy (fill->pattern, &line[first], GMT_BUFSIZ-1);
+	strncpy (fill->pattern, &line[first], PATH_MAX-1);
 	/* Attempt to convert to integer - will be 0 if not an integer and then we set it to -1 for a filename */
 	fill->pattern_no = atoi (fill->pattern);
 	if (fill->pattern_no == 0) {
@@ -7344,7 +7344,7 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 				}
 				X->has_pattern = true;
 				if ((name = support_get_userimagename (GMT, T1, cpt_file))) {	/* Must replace fill->pattern with this full path */
-					strncpy (X->bfn[id].fill->pattern, name, GMT_BUFSIZ-1);
+					strncpy (X->bfn[id].fill->pattern, name, PATH_MAX-1);
 					gmt_M_str_free (name);
 				}
 			}
@@ -7459,7 +7459,7 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 			}
 			X->has_pattern = true;
 			if ((name = support_get_userimagename (GMT, T1, cpt_file))) {	/* Must replace fill->pattern with this full path */
-				strncpy (X->data[n].fill->pattern, name, GMT_BUFSIZ-1);
+				strncpy (X->data[n].fill->pattern, name, PATH_MAX-1);
 				gmt_M_str_free (name);
 			}
 		}

--- a/src/gmt_texture.h
+++ b/src/gmt_texture.h
@@ -66,7 +66,7 @@ struct GMT_FILL {
 	int pattern_no;			/* Number of a predefined pattern, or -1 if not set */
 	unsigned int dpi;		/* Desired dpi of image building-block if use_pattern is true */
 	unsigned int dim[3];		/* width, height, depth of image */
-	char pattern[GMT_BUFSIZ];	/* Full filename of user-defined raster pattern */
+	char pattern[PATH_MAX];		/* Full filename of user-defined raster pattern */
 	unsigned char *image;	/* Pointer to image array */
 	struct GMT_IMAGE *I;	/* The image container */
 };

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -418,7 +418,7 @@ GMT_LOCAL int init_blend_job (struct GMT_CTRL *GMT, char **files, unsigned int n
 					sprintf (buffer, "%s/grdblend_resampled_%d_%d.nc", GMT->parent->tmp_dir, (int)getpid(), n);
 				else	/* Must dump it in current directory */
 					sprintf (buffer, "grdblend_resampled_%d_%d.nc", (int)getpid(), n);
-				sprintf (cmd, "%s %s %s %s -G%s -V%c", B[n].file, h->registration ? "-r" : "",
+				snprintf (cmd, GMT_LEN256, "%s %s %s %s -G%s -V%c", B[n].file, h->registration ? "-r" : "",
 				         Iargs, Rargs, buffer, V_level[GMT->current.setting.verbose]);
 				if (GMT->common.n.active) {	/* User changed BC/method via -n */
 					strcat (cmd, " -n");
@@ -440,7 +440,7 @@ GMT_LOCAL int init_blend_job (struct GMT_CTRL *GMT, char **files, unsigned int n
 					sprintf (buffer, "%s/grdblend_reformatted_%d_%d.nc", GMT->parent->tmp_dir, (int)getpid(), n);
 				else	/* Must dump it in current directory */
 					sprintf (buffer, "grdblend_reformatted_%d_%d.nc", (int)getpid(), n);
-				sprintf (cmd, "%s %s %s -V%c", B[n].file, Rargs, buffer, V_level[GMT->current.setting.verbose]);
+				snprintf (cmd, GMT_LEN256, "%s %s %s -V%c", B[n].file, Rargs, buffer, V_level[GMT->current.setting.verbose]);
 				if (gmt_M_is_geographic (GMT, GMT_IN)) strcat (cmd, " -fg");
 				strcat (cmd, " --GMT_HISTORY=false");
 				GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Reformat %s via grdconvert %s\n", B[n].file, cmd);

--- a/src/testgmt.c
+++ b/src/testgmt.c
@@ -35,7 +35,7 @@ int main () {
 	struct GMTAPI_CTRL *API = NULL;			/* GMT API control structure */
 
 	int in_grdcut_ID, out_grdcut_ID;
-	char *in_grid = "t.nc", *out_grid = "new.nc", string[GMT_STR16];
+	char *in_grid = "t.nc", *out_grid = "new.nc", string[GMT_STR16] = {""}, arg[GMT_LEN256] = {""};
 	double w = 2.0, e = 4.0, s = 1.0, n = 3.0;	/* Hardwired region for test */
 	struct GMT_GRID *Gin = NULL, *Gout = NULL;
 
@@ -56,8 +56,8 @@ int main () {
 	if (GMT_Encode_ID (API, string, in_grdcut_ID) != GMT_NOERROR) exit (EXIT_FAILURE);	/* Make filename with embedded object ID */
 	if ((new_opt = GMT_Make_Option (API, '<', string)) == NULL) exit (EXIT_FAILURE);
 	if ((head = GMT_Append_Option (API, new_opt, NULL)) == NULL) exit (EXIT_FAILURE);
-	sprintf (string, "%g/%g/%g/%g", w, e, s, n);		/* Create argument for -R option */
-	if ((new_opt = GMT_Make_Option (API, 'R', string)) == NULL) exit (EXIT_FAILURE);
+	sprintf (arg, "%g/%g/%g/%g", w, e, s, n);		/* Create argument for -R option */
+	if ((new_opt = GMT_Make_Option (API, 'R', arg)) == NULL) exit (EXIT_FAILURE);
 	if ((head = GMT_Append_Option (API, new_opt, head)) == NULL) exit (EXIT_FAILURE);
 	if (GMT_Encode_ID (API, string, out_grdcut_ID) != GMT_NOERROR) exit (EXIT_FAILURE);	/* Make -Gfilename with embedded object ID */
 	if ((new_opt = GMT_Make_Option (API, 'G', string)) == NULL) exit (EXIT_FAILURE);

--- a/test/README.tests
+++ b/test/README.tests
@@ -13,6 +13,20 @@
 # Scripts that are known to fail can be excluded from the test
 # by adding the comment
 #	# GMT_KNOWN_FAILURE
-# to the script anywhere.
+# to the script anywhere.  Their failures will be listed in the
+# test/fail_count.txt file but not counted by ctest.
+#
+# Under Linux you can have all module calls be run via valgrind
+# in order to track down pesky memory leaks.  To do this, cd
+# into the build directory and do this:
+# 1. Remove old logs with: find . -name '.log' -exec rm -f {} \;
+# 2. export VALGRIND_ARGS="--track-origins=yes --leak-check=full"
+# Afterwards you can find all the *.log files and examine them.
+# On any OS you can activate the full GMT memory tracking by
+# setting
+# 	export GMT_TRACK_MEMORY=2
+# This assumes you configured GMT via with cmake/ConfigUser.cmake
+#	add_definitions(-DDEBUG)
+#	add_definitions(-DMEMDEBUG)
 #
 # P. Wessel, June 2019


### PR DESCRIPTION
Also explain the use of valgrind and memory tracking in README.tests.
