### PR TITLE
Let the openmp.sh test pass if OpenMP is not available

### DIFF
--- a/test/grdfilter/openmp.sh
+++ b/test/grdfilter/openmp.sh
@@ -4,19 +4,22 @@
 ps=openmp.ps
 
 if ! [[ ${HAVE_OPENMP} =~ TRUE|ON ]]; then
-  #echo "[N/A]"
+  # Since a PS-producing test is judge by comparison to original PS
+  # and since no PS is produced without OpenMP, we simply duplicate
+  # the original so they both exist and are identical.
+  echo "OpenMP not availble - just duplicating PS to pass test"
+  cp "${GMT_SRCDIR:-.}"/$ps .
   exit 0
 fi
 FILT=g			# Gaussian filter
 INC=1			# 1x1 degree output
 D=1000			# 1000 km filter width
-DATA=${GMT_SOURCE_DIR}/doc/examples/ex48/etopo10m.nc	# Test on ETOP10 data
 
 # Run gmt grdfilter as specified
-gmt grdfilter -D4 -F${FILT}$D -I$INC $DATA -Gt.nc -fg
+gmt grdfilter -D4 -F${FILT}$D -I$INC @etopo10m_48.nc -Gt.nc -fg
 gmt makecpt -Cglobe > t.cpt
 gmt grdimage t.nc -JQ0/7i -Ba -BWSne+t"$D km Gaussian filter" -Ct.cpt -P -K -Xc -Y1.5i > $ps
 gmt psscale -Ct.cpt -D3.5i/-0.5i+w6i/0.1i+h+jTC -O -K -Bxa -By+l"m" >> $ps
-gmt grdimage $DATA -JQ0/7i -Ba -BWSne+t"Original data" -Ct.cpt -O -K -Y4.75i >> $ps
+gmt grdimage @etopo10m_48.nc -JQ0/7i -Ba -BWSne+t"Original data" -Ct.cpt -O -K -Y4.75i >> $ps
 gmt psxy -Rt.nc -J -O -T >> $ps
 


### PR DESCRIPTION
Better to let it pass since it cannot run, than to fail when OpenMP is not even available.  This way it only counts towards the number of failures if it actually can run.
