### PR TITLE
Remove unused variable in cmake/ConfigDefault.cmake

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -142,11 +142,8 @@ endif (NOT DEFINED GMT_DATA_URL)
 #
 if (NOT DEFINED CMAKE_CONFIGURATION_TYPES)
 	if (NOT DEFINED CMAKE_BUILD_TYPE)
-		# Should we set build type to RelWithDebInfo for developers and
-		# to release for general public (ie when GPLATES_SOURCE_RELEASE is true) ?
-		# Currently it's Release for both.
 		set (CMAKE_BUILD_TYPE Release CACHE STRING
-		"Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel ${extra_build_configurations}."
+		"Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
 		FORCE)
 	endif (NOT DEFINED CMAKE_BUILD_TYPE)
 endif (NOT DEFINED CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
Variable `extra_build_configurations` is neither defined or used anywhere.