### PR TITLE
WIP: Address cmake warnings in CI builds

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Test'
-  condition: ne(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.13'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Test'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.13'

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
           if: type != cron
         - name: "Linux (cron)"
           os: linux
-          if: type != cron
+          if: type = cron
           env:
             - TEST="true"
         # Only build the docs on Linux cron jobs

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_install:
         DEB_CACHE=$HOME/cache-deb
         DEB_PACKAGES="cmake ninja-build libcurl4-gnutls-dev libnetcdf-dev libgdal-dev libfftw3-dev libpcre3-dev liblapack-dev ghostscript curl"
         if [[ "$TEST" == "true" || "$BUILD_DOCS" == "true" ]]; then
-          DEB_PACKAGES="$DEB_PACKAGES graphicsmagick ffmpeg python python-pip texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk"
+          DEB_PACKAGES="$DEB_PACKAGES gdal-bin graphicsmagick ffmpeg python python-pip texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk"
         fi
         test -d $DEB_CACHE || mkdir $DEB_CACHE
         echo "Copy cached deb packages"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
           if: type != cron
         - name: "Linux (cron)"
           os: linux
-          if: type = cron
+          if: type != cron
           env:
             - TEST="true"
         # Only build the docs on Linux cron jobs

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -4,7 +4,7 @@ steps:
 
 - bash: |
     set -x -e
-    brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript graphicsmagick || true
+    brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript graphicsmagick ffmpeg || true
   displayName: Install dependencies
 
 - bash: echo "##vso[task.setvariable variable=INSTALLDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir"

--- a/ci/build-gmt.sh
+++ b/ci/build-gmt.sh
@@ -16,8 +16,9 @@ if [[ "$TEST" == "true" ]]; then
 enable_testing()
 set (DO_EXAMPLES TRUE)
 set (DO_TESTS TRUE)
-set (N_TEST_JOBS 2)
 set (DO_API_TESTS ON)
+set (N_TEST_JOBS 2)
+set (SUPPORT_EXEC_IN_BINARY_DIR TRUE)
 set (CMAKE_C_FLAGS "-Wextra -coverage -O0 ${CMAKE_C_FLAGS}")
 EOF
 fi


### PR DESCRIPTION
1. Set SUPPORT_EXEC_IN_BINARY_DIR to TRUE
2. Install gdal-bin (gdal_translate, ogr2ogr) on Linux
3. Install ffmpeg on macOS