### PR TITLE
Allow header comments in share/mgd77 files

### DIFF
--- a/share/mgd77/Dst_all.wdc
+++ b/share/mgd77/Dst_all.wdc
@@ -1,3 +1,14 @@
+# World Data Center for Geomagnetism, Kyoto, M. Nose, T. Iyemori, M. Sugiura, T. Kamei (2015), Geomagnetic Dst index,
+# doi:10.17593/14515-74000. Combination of files from
+# Final DST indices: http://wdc.kugi.kyoto-u.ac.jp/dst_final/index.html
+# Provisional DST indices: http://wdc.kugi.kyoto-u.ac.jp/dst_provisional/index.html
+# Last update by Mike Hamilton, May 2019.  Notes on getting the data (other than selecting time window):
+# Set Output Type beneath that to Dst Output and WDC-like format. Give email address got get data. The output data is
+# almost right for use with mgd77magref. I ran this awk/sed command to get it just right:
+#
+#awk '{printf "%.10s %+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d%+04d\n",$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27}' ~/Downloads/WWW_dstae00025601.dat | sed -e 's/+/ /g' -e 's/*/P/'
+#
+#-----------------------------------------------------------------------------------------------------------------------
 DST5701*01  X219 000 011 013 012 012 009 007 007 006 002-001-007-007-008-001 009 008 004 000 001 003 002 004 009 009 004
 DST5701*02  X219 000 011 003 006 009 010 012 007 005 008 032 007-007-007-002-001 001 002 005 005-014-041-065-065-059-006
 DST5701*03  X219 000-050-044-042-046-043-042-041-039-040-040-036-031-033-028-027-030-032-031-029-026-028-025-024-021-035

--- a/share/mgd77/F107_mon.plt
+++ b/share/mgd77/F107_mon.plt
@@ -1,3 +1,6 @@
+# http://umbra.nascom.nasa.gov/sdb/yohkoh/ys_dbase/indices_flux_raw/Penticton_Absolute/monthly/MONTHPLT.ABS
+# Last updated by Mike Hamilton, May 2019
+#-----------
 1947 01  ---
 1947 02 1784
 1947 03 2101

--- a/src/mgd77/cm4_functions.c
+++ b/src/mgd77/cm4_functions.c
@@ -191,6 +191,9 @@ int MGD77_cm4field (struct GMT_CTRL *GMT, struct MGD77_CM4 *Ctrl, double *p_lon,
 
 	/* coverity[tainted_data_argument] */	/* Try to shut up Coverity about Tainted variables */
 	c_unused = fgets(line, GMT_BUFSIZ, fp);
+	while (line[0] == '#')	/* Skip comments */
+		c_unused = fgets(line, GMT_BUFSIZ, fp);
+
 	if ((n = sscanf (line, "%d %d %d", &lsmf, &lpos, &lcmf)) != 3) {
 		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Failed to parse line in MGD77_cm4field\n");
 		gmt_M_str_free (bkpo);	gmt_M_str_free (gamf);	gmt_M_str_free (f107x);
@@ -331,6 +334,7 @@ int MGD77_cm4field (struct GMT_CTRL *GMT, struct MGD77_CM4 *Ctrl, double *p_lon,
 			/* One improvement would be to compute year_min/year_max and retain only the needed data in dstx */
 
 			while (fgets (line, GMT_BUFSIZ, fp)) {
+				if (line[0] == '#') continue;	/* Comment line only */
 				sscanf (&line[3], "%2d %2d", &jyr, &jmon);
 				sscanf (&line[8], "%2d", &jdom);
 				for (i = 0; i < 24; ++i)
@@ -393,6 +397,7 @@ int MGD77_cm4field (struct GMT_CTRL *GMT, struct MGD77_CM4 *Ctrl, double *p_lon,
 			}
 			jaft = 0;
 			while (fgets (line, GMT_BUFSIZ, fp)) {
+				if (line[0] == '#') continue;	/* Comment line only */
 				if (line[9] != '-') {
 					sscanf (line, "%d %d %d", &jyr, &jmon, &jf107);
 					if (jaft == 0) {


### PR DESCRIPTION
This allows us to add some comments about how we can update these files with magnetic indices when the time comes.  Ideally, these files should be remote files so the users can benefit when we update rather than waiting for a new GMT release.