### PR TITLE
Give more control regarding MAP_FRAME_TYPE=graph

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -763,7 +763,15 @@ fonts can be found in the :doc:`gmt` man page.
     ticks and annotations must be inside the maps (e.g., for preparing
     geotiffs), chose **inside**.  Finally, for Cartesian plots you can
     also choose **graph**\ , which adds a vector to the end of each axis.
-    This works best when you reduce the number of axes plotted.
+    This works best when you reduce the number of axes plotted to one
+    per dimension.  By default, the vector tip extends the length of each
+    axis by 7.5%. Alternatively, append ,\ *length*\ [**u**], where **u**
+    can be % (then *length* is the alternate extension in percent) or one
+    of **c**, **i**, or **p** (then *length* is the absolute extension
+    of the axis to the start of the vector base instead).  The vector stem
+    is set to match :ref:`MAP_FRAME_WIDTH <MAP_FRAME_WIDTH>`, while the vector
+    head length and width are 10 and 5 times this width, respectively.  You
+    may control its shape via :ref:`MAP_VECTOR_SHAPE <MAP_VECTOR_SHAPE>`.
 
 .. _MAP_FRAME_WIDTH:
 

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -217,6 +217,10 @@ enum GMT_swap_direction {
 #define GMT_IS_ROMAN_LCASE	1	/* For converting arabic numerals to Roman */
 #define GMT_IS_ROMAN_UCASE	2
 
+/* Settings for the MAP_FRAME_TYPE = graph */
+#define GMT_GRAPH_EXTENSION		7.5	/* In percent */
+#define GMT_GRAPH_EXTENSION_UNIT	'%'	/* In percent */
+
 /*! Codes for grdtrack */
 enum GMT_enum_tracklayout {
 	GMT_LEFT_RIGHT = 1,

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -138,9 +138,11 @@ struct GMT_DEFAULTS {
 	double map_tick_length[4];		/* Length of primary and secondary major and minor tickmarks [5p/2.5p/15p/3.75p] */
 	double map_title_offset;		/* Distance between lowermost annotation (or label) and base of plot title [14p] */
 	double map_vector_shape;		/* 0.0 = straight vectorhead, 1.0 = arrowshape, with continuous range in between */
+	double map_graph_extension;		/* If mapframetype is graph, how must longer to make axis length. [7.5%] */
 	unsigned int map_annot_oblique;	/* Controls annotations and tick angles etc. [GMT_OBL_ANNOT_ANYWHERE] */
 	unsigned int map_logo_justify;		/* Justification of the GMT timestamp box [1 (BL)] */
 	unsigned int map_frame_type;		/* Fancy (0), plain (1), or graph (2) [0] */
+	unsigned int map_graph_extension_unit;	/* If mapframetype is graph, the unit is GMT_CM, GMT_INCH, GMT_PT [%] */
 	bool map_logo;			/* Plot time and map projection on map [false] */
 	struct GMT_PEN map_default_pen;		/* Default pen for most pens [0.25p] */
 	struct GMT_PEN map_frame_pen;		/* Pen attributes for map boundary [1.25p] */

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -4353,9 +4353,9 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		PSL_plotsegment (PSL, 0.0, 0.0, length, 0.0);
 	else
 		PSL_plotsegment (PSL, 0.0, length, 0.0, 0.0);
-	if (GMT->current.setting.map_frame_type & GMT_IS_GRAPH) {	/* Extend axis 7.5% with an arrow */
+	if (GMT->current.setting.map_frame_type & GMT_IS_GRAPH) {	/* Extend axis with an arrow */
 		struct GMT_FILL arrow;
-		double vector_width, dim[PSL_MAX_DIMS];
+		double vector_width, dim[PSL_MAX_DIMS], g_scale_begin = 0.0, g_scale_end = 0.0, g_ext = 0.0;
 		gmt_init_fill (GMT, &arrow, GMT->current.setting.map_frame_pen.rgb[0], GMT->current.setting.map_frame_pen.rgb[1], GMT->current.setting.map_frame_pen.rgb[2]);
 		gmt_setfill (GMT, &arrow, false);
 		gmt_M_memset (dim, PSL_MAX_DIMS, double);
@@ -4364,24 +4364,39 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		dim[5] = GMT->current.setting.map_vector_shape; dim[6] = PSL_VEC_END | PSL_VEC_FILL;
 		dim[11] = 0.5 * GMT->current.setting.map_frame_pen.width;
 		PSL_defpen (PSL, "PSL_vecheadpen", GMT->current.setting.map_frame_pen.width, GMT->current.setting.map_frame_pen.style, GMT->current.setting.map_frame_pen.offset, GMT->current.setting.map_frame_pen.rgb);
+
+		/* The start of the vector at the end of a positive axis is computed as x = g_scale_end * length + g_ext;
+		 * The start of the vector at the start of a negative axis is computed as x = g_scale_begin * length - g_ext;
+		 * The required constants are set below */
+		if (GMT->current.setting.map_graph_extension_unit == GMT_GRAPH_EXTENSION_UNIT) {	/* Gave scaling in percent */
+			/* Here, the computed length is to the tip of the vector */
+			g_scale_end = 1.0 + 0.01 * GMT->current.setting.map_graph_extension;
+			g_scale_begin = -0.01 * GMT->current.setting.map_graph_extension;
+		}
+		else {	/* Gave actual length extension (now in inches) */
+			/* Here, the computed length is to the base of the vector */
+			g_scale_end = 1.0;
+			g_ext = GMT->current.setting.map_graph_extension + dim[3];
+		}
+		
 		if (horizontal) {
 			double x = 0.0;
 			if (GMT->current.proj.xyz_pos[axis]) {
 				x = length;
-				dim[0] = 1.075 * length;
+				dim[0] = g_scale_end * length + g_ext;
 			}
 			else
-				dim[0] = -0.075 * length;
+				dim[0] = g_scale_begin * length - g_ext;
 			PSL_plotsymbol (PSL, x, 0.0, dim, PSL_VECTOR);
 		}
 		else {
 			double y = 0.0;
 			if (GMT->current.proj.xyz_pos[axis]) {
 				y = length;
-				dim[1] = 1.075 * length;
+				dim[1] = g_scale_end * length + g_ext;
 			}
 			else
-				dim[1] = -0.075 * length;
+				dim[1] = g_scale_begin * length - g_ext;
 			PSL_plotsymbol (PSL, 0.0, y, dim, PSL_VECTOR);
 		}
 	}


### PR DESCRIPTION
This PR allows users to change the default parameters for the length of the extension needed to add a vector at the end of the axis under **MAP_FRAME_TYPE**=_graph_ mode [7.5%].  You can append ,_length_[_unit_], where _unit_ may be **%** (extension to tip of vector is this fraction of the axis length) or give an absolute length (with units **c**, **i**, **p**).  Then we extend the axis by that amount before adding the vector head.