### PR TITLE
Cleanup documentation settings for epub and htmlhelp formats

### DIFF
--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -177,9 +177,6 @@ html_show_sourcelink = True
 # This is the file name suffix for HTML files (e.g. ".xhtml").
 #html_file_suffix = None
 
-# Output file base name for HTML help builder.
-htmlhelp_basename = 'GMT_Docs'
-
 # Redefine supported_image_types for the HTML builder
 from sphinx.builders.html import StandaloneHTMLBuilder
 StandaloneHTMLBuilder.supported_image_types = [
@@ -382,44 +379,3 @@ man_pages = [
 ('supplements/x2sys/x2sys_report', 'x2sys_report', 'Report statistics from crossover data base', '', 1),
 ('supplements/x2sys/x2sys_solve', 'x2sys_solve', 'Determine least-squares systematic correction from crossovers', '', 1)
 ]
-
-
-# -- Options for Epub output ---------------------------------------------------
-
-# Bibliographic Dublin Core info.
-epub_title = u'GMT'
-epub_author = gmt_team
-epub_publisher = gmt_team
-epub_copyright = copyright
-
-# The language of the text. It defaults to the language option
-# or en if the language is not set.
-#epub_language = ''
-
-# The scheme of the identifier. Typical schemes are ISBN or URL.
-#epub_scheme = ''
-
-# The unique identifier of the text. This can be a ISBN number
-# or the project homepage.
-#epub_identifier = ''
-
-# A unique identification for the text.
-#epub_uid = ''
-
-# HTML files that should be inserted before the pages created by sphinx.
-# The format is a list of tuples containing the path and title.
-#epub_pre_files = []
-
-# HTML files shat should be inserted after the pages created by sphinx.
-# The format is a list of tuples containing the path and title.
-#epub_post_files = []
-
-# A list of files that should not be packed into the epub file.
-#epub_exclude_files = []
-
-# The depth of the table of contents in toc.ncx.
-#epub_tocdepth = 3
-
-# Allow duplicate toc entries.
-#epub_tocdup = True
-


### PR DESCRIPTION
We don't want epub and htmlhelp documentations.