### PR TITLE
Ensure that if none of -W -C -G set the we set a default outline for spidermen

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1072,7 +1072,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 			PSL_defpen (PSL, "PSL_spiderpen", S.v.pen.width, S.v.pen.style, S.v.pen.offset, S.v.pen.rgb);
 			last_spiderpen = S.v.pen;
 		}
-		else if (Ctrl->W.active || !(Ctrl->G.active || Ctrl->C.active)) {	/* Use -W as wedge pen as well as outline, and default to this pen if neither -C, -W or -G given */
+		else if (Ctrl->W.active || S.w_type || !(Ctrl->G.active || Ctrl->C.active)) {	/* Use -W as wedge pen as well as outline, and default to this pen if neither -C, -W or -G given */
 			current_pen = default_pen, Ctrl->W.active = true;	/* Return to default pen */
 			if (Ctrl->W.active) {	/* Vector head outline pen default is half that of stem pen */
 				PSL_defpen (PSL, "PSL_spiderpen", current_pen.width, current_pen.style, current_pen.offset, current_pen.rgb);

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1068,11 +1068,11 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 		}
 	}
 	if (S.symbol == PSL_WEDGE) {
-		if (S.v.status == PSL_VEC_OUTLINE2) {	/* Wedge splider pen specified separately */
+		if (S.v.status == PSL_VEC_OUTLINE2) {	/* Wedge spider pen specified separately */
 			PSL_defpen (PSL, "PSL_spiderpen", S.v.pen.width, S.v.pen.style, S.v.pen.offset, S.v.pen.rgb);
 			last_spiderpen = S.v.pen;
 		}
-		else if (Ctrl->W.active) {	/* use -W as wedge pen as well as outline */
+		else if (Ctrl->W.active || !(Ctrl->G.active || Ctrl->C.active)) {	/* Use -W as wedge pen as well as outline, and default to this pen if neither -C, -W or -G given */
 			current_pen = default_pen, Ctrl->W.active = true;	/* Return to default pen */
 			if (Ctrl->W.active) {	/* Vector head outline pen default is half that of stem pen */
 				PSL_defpen (PSL, "PSL_spiderpen", current_pen.width, current_pen.style, current_pen.offset, current_pen.rgb);
@@ -1211,7 +1211,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 					}
 				}
 				else if (S.symbol == PSL_WEDGE) {
-					if (S.v.status == PSL_VEC_OUTLINE2) {	/* Wedge splider pen specified separately */
+					if (S.v.status == PSL_VEC_OUTLINE2) {	/* Wedge spider pen specified separately */
 						PSL_defpen (PSL, "PSL_spiderpen", S.v.pen.width, S.v.pen.style, S.v.pen.offset, S.v.pen.rgb);
 						last_spiderpen = S.v.pen;
 					}

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -809,7 +809,7 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 				PSL_defpen (PSL, "PSL_spiderpen", S.v.pen.width, S.v.pen.style, S.v.pen.offset, S.v.pen.rgb);
 				last_spiderpen = S.v.pen;
 			}
-			else if (Ctrl->W.active || !(Ctrl->G.active || Ctrl->C.active)) {	/* Use -W as wedge pen as well as outline, and default to this pen if neither -C, -W or -G given */
+			else if (Ctrl->W.active || S.w_type || !(Ctrl->G.active || Ctrl->C.active)) {	/* Use -W as wedge pen as well as outline, and default to this pen if neither -C, -W or -G given */
 				current_pen = default_pen, Ctrl->W.active = true;	/* Return to default pen */
 				if (Ctrl->W.active) {	/* Vector head outline pen default is half that of stem pen */
 					PSL_defpen (PSL, "PSL_spiderpen", current_pen.width, current_pen.style, current_pen.offset, current_pen.rgb);

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -805,11 +805,11 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 			}
 		}
 		else if (S.symbol == PSL_WEDGE) {
-			if (S.v.status == PSL_VEC_OUTLINE2) {	/* Wedge splider pen specified separately */
+			if (S.v.status == PSL_VEC_OUTLINE2) {	/* Wedge spider pen specified separately */
 				PSL_defpen (PSL, "PSL_spiderpen", S.v.pen.width, S.v.pen.style, S.v.pen.offset, S.v.pen.rgb);
 				last_spiderpen = S.v.pen;
 			}
-			else if (Ctrl->W.active) {	/* use -W as wedge pen as well as outline */
+			else if (Ctrl->W.active || !(Ctrl->G.active || Ctrl->C.active)) {	/* Use -W as wedge pen as well as outline, and default to this pen if neither -C, -W or -G given */
 				current_pen = default_pen, Ctrl->W.active = true;	/* Return to default pen */
 				if (Ctrl->W.active) {	/* Vector head outline pen default is half that of stem pen */
 					PSL_defpen (PSL, "PSL_spiderpen", current_pen.width, current_pen.style, current_pen.offset, current_pen.rgb);
@@ -823,6 +823,7 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 			if (!Ctrl->W.active)	/* No outline of QR code */
 				PSL_command (PSL, "/QR_outline false def\n");
 		}
+		outline_active =  Ctrl->W.active;
 		if (S.read_size && GMT->current.io.col[GMT_IN][ex1].convert) {	/* Doing math on the size column, must delay unit conversion unless inch */
 			gmt_set_column (GMT, GMT_IN, ex1, GMT_IS_FLOAT);
 			if (S.u_set)
@@ -917,7 +918,7 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 					}
 				}
 				else if (S.symbol == PSL_WEDGE) {
-					if (S.v.status == PSL_VEC_OUTLINE2) {	/* Wedge splider pen specified separately */
+					if (S.v.status == PSL_VEC_OUTLINE2) {	/* Wedge spider pen specified separately */
 						PSL_defpen (PSL, "PSL_spiderpen", S.v.pen.width, S.v.pen.style, S.v.pen.offset, S.v.pen.rgb);
 						last_spiderpen = S.v.pen;
 					}


### PR DESCRIPTION
Also, if users set any of the modifiers **+a**_dr_ or **+r**_da_ then a default _PSL_spiderpen_ must be set.