### PR TITLE
Fix segyprogs to segy

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -20,7 +20,7 @@ GMT 6 has benefitted from the contributions of two new team members
 # Supplement Contributions
 
 [Tim Henstock](https://www.southampton.ac.uk/oes/research/staff/then.page)
-contributed the segyprogs supplement, while
+contributed the segy supplement, while
 [Kurt Feigl](http://geoscience.wisc.edu/geoscience/people/faculty/feigl/) and
 Genevieve Patau wrote the seis supplement.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ manipulation. Currently, the supplemental archive include the directories:
 -  meca: Plotting of focal mechanisms, velocity arrows, and error ellipses on maps.
 -  mgd77: Programs for handling of native MGD77 files.
 -  potential: geopotential manipulations
--  segyprogs: Plotting SEGY seismic data sets.
+-  segy: Plotting SEGY seismic data sets.
 -  spotter: Plate tectonic & kinematics applications.
 -  x2sys: Track intersection (crossover) tools.
 

--- a/doc/rst/source/GMT_Docs.rst
+++ b/doc/rst/source/GMT_Docs.rst
@@ -6034,8 +6034,8 @@ which uses the methods of Talwani to compute various geopotential components
 from 2-D [26]_ or 3-D [27]_ bodies.
 The package is maintained by Joaquim Luis and Paul Wessel.
 
-segyprogs: plotting SEGY seismic data
--------------------------------------
+segy: plotting SEGY seismic data
+--------------------------------
 
 This package contains programs to plot SEGY seismic data files using the
 GMT mapping transformations and postscript library.

--- a/doc/rst/source/GMT_Docs_classic.rst
+++ b/doc/rst/source/GMT_Docs_classic.rst
@@ -6072,8 +6072,8 @@ which uses the methods of Talwani to compute various geopotential components
 from 2-D [26]_ or 3-D [27]_ bodies.
 The package is maintained by Joaquim Luis and Paul Wessel.
 
-segyprogs: plotting SEGY seismic data
--------------------------------------
+segy: plotting SEGY seismic data
+--------------------------------
 
 This package contains programs to plot SEGY seismic data files using the
 GMT mapping transformations and postscript library.

--- a/src/segy/CMakeLists.txt
+++ b/src/segy/CMakeLists.txt
@@ -23,7 +23,7 @@ set (SUPPL_LIB_SRCS segy_io.h segy.h segyreel.h segy_io.c)
 set (SUPPL_PROGS_SRCS segy2grd.c pssegy.c pssegyz.c)
 
 # example files
-set (SUPPL_EXAMPLE_FILES README.segyprogs
+set (SUPPL_EXAMPLE_FILES README.segy
 	test.list wa1_mig13.segy)
 set (SUPPL_EXAMPLE_PROGS segyprogs_1.sh segyprogs_2.sh segyprogs_3.sh
 	segyprogs_4.sh segyprogs_5.sh)

--- a/src/segy/README.segy
+++ b/src/segy/README.segy
@@ -43,7 +43,7 @@ GMT 5 Released made these into modules.  Note: Some options conflicted with the 
 common options.  For instance, pssegy used -X -Y -B -U for various settings but that
 cannot be allowed in GMT 5.  I simply moved these to modifiers under a new option
 -Q, i.e., now use -Qx, -Qy, -Qu, and -Qb to set these parameters.
-This obviously makes GMT 4 scripts using segyprogs NOT backwards compatible but it
+This obviously makes GMT 4 scripts using segy NOT backwards compatible but it
 cannot be helped.
 
 pssegy: program to plot segy files in postscript.
@@ -61,9 +61,9 @@ throughout.  No current bugs are known.
 pssegyz: program to ploy segy files in 3-D in postscript.
 This is just an extension of pssegy which rather than plotting the seismic
 data in (x,y) space uses the GMT transformation routines to plot the
-data in (x,y,z) space, with z being the depth/time axis. 
-The code was generalized to allow plotting location to be based on any 
-(int*4) location in the SEGY trace header in both the x and y dimensions. 
+data in (x,y,z) space, with z being the depth/time axis.
+The code was generalized to allow plotting location to be based on any
+(int*4) location in the SEGY trace header in both the x and y dimensions.
 Note that as you increase the projection elevation there are an increasing
 number of pathological cases for variable area plotting and the code
 may well leave regions unshaded, or shade regions which should be transparent


### PR DESCRIPTION
**Description of proposed changes**

The official name of segy supplement is `segy`. Sometimes we use segyprogs. This PR fixes segyprogs to segy.