### PR TITLE
Shorten entry listing for gmt clear

### DIFF
--- a/src/gmt.c
+++ b/src/gmt.c
@@ -235,14 +235,13 @@ int main (int argc, char *argv[]) {
 			fprintf (stderr, "  gmt figure        Set figure format specifics under a GMT modern mode session.\n");
 			fprintf (stderr, "  gmt subplot       Initiate a multi-panel figure.\n");
 			//fprintf (stderr, "  gmt revert        Undo last <n> layers from current figure.\n");
-			fprintf (stderr, "  gmt clear all | cache | cpt | conf | data | history | sessions\n");
-			fprintf (stderr, "                    Delete gmt.history, gmt.conf, session CPT, the user cache or data dir, or all of them.\n\n");
+			fprintf (stderr, "  gmt clear         Delete gmt.history, gmt.conf, current CPT, user cache or data, or all.\n\n");
 			fprintf (stderr, "options:\n");
 			fprintf (stderr, "  --help            List descriptions of available GMT modules.\n");
 			fprintf (stderr, "  --show-bindir     Show directory with GMT executables.\n");
-			fprintf (stderr, "  --show-cores      Print number of available cores.\n");
+			fprintf (stderr, "  --show-cores      Show number of available cores.\n");
 			fprintf (stderr, "  --show-datadir    Show directory/ies with user data.\n");
-			fprintf (stderr, "  --show-modules    List all module names.\n");
+			fprintf (stderr, "  --show-modules    Show all module names.\n");
 			fprintf (stderr, "  --show-library    Show path of the shared GMT library.\n");
 			fprintf (stderr, "  --show-plugindir  Show directory for plug-ins.\n");
 			fprintf (stderr, "  --show-sharedir   Show directory for shared GMT resources.\n");


### PR DESCRIPTION
It went into too much detail, which is covered by the man page,  Also fixed a few action words to "show" to match the option.
