### PR TITLE
Show GMT version after cmake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,9 @@ configure_file (src/config.h.in src/config.h)
 
 # Configuration done
 message(
+	"*\n"
+	"*  GMT Version:               : ${GMT_PACKAGE_VERSION_WITH_GIT_REVISION}\n"
+	"*\n"
 	"*  Options:\n"
 	"*  Found GSHHG database       : ${GSHHG_PATH} (${GSHHG_VERSION})\n"
 	"*  Found DCW-GMT database     : ${DCW_PATH}\n"


### PR DESCRIPTION
**Description of proposed changes**

The cmake configuration result looks like:
```
*
*  GMT Version:               : 6.0.0_bffddd2_2019.06.13
*
*  Options:
*  Found GSHHG database       : /Users/seisman/Gits/gmt/gmt/share/coast (2.3.7)
*  Found DCW-GMT database     : /Users/seisman/Gits/gmt/gmt/share/dcw
*  Found GMT data server      : http://oceania.generic-mapping-tools.org
*  NetCDF library             : /usr/local/opt/netcdf/lib/libnetcdf.dylib
*  NetCDF include dir         : /usr/local/opt/netcdf/include
*  Curl library               :
...
```