### PR TITLE
Usage and explanation for -p were partly incorrect

### DIFF
--- a/doc/rst/source/explain_perspective_full.rst_
+++ b/doc/rst/source/explain_perspective_full.rst_
@@ -8,11 +8,11 @@
     perspective). [Default is at the bottom of the z-axis]. Use **-px**
     or **-py** to plot against the "wall" x = level or y = level
     (default is on the horizontal plane, which is the same as using
-    **-pz**). For frames used for animation, you may want to append
-    **+** to fix the center of your data domain (or specify a particular
-    world coordinate point with **+w**\ *lon0*/*lat*\ [/*z*]) which will
-    project to the center of your page size (or specify the coordinates
-    of the projected view point with **+v**\ *x0*/*y0*. When **-p** is
+    **-pz**). For frames used for animation, note we fix the center of your
+    data domain.  Specify another center using a particular
+    world coordinate point with **+w**\ *lon0*/*lat0*\ [/*z0*]) which will
+    project to the center of your page size, or specify the coordinates
+    of the projected 2-D view point with **+v**\ *x0*/*y0*. When **-p** is
     used without any further arguments, the values from the last use of
     **-p** in a previous GMT command will be used.  Alternatively, you
     can perform a simple rotation about the z-axis by just giving the

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6480,11 +6480,11 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 		case 'E':	/* GMT4: For backward compatibility */
 			if (gmt_M_compat_check (GMT, 4) || options[k] == 'p') {
 				gmt_message (GMT, "\t-%c Select a 3-D pseudo perspective view.  Append the\n", options[k]);
-				gmt_message (GMT, "\t   azimuth and elevation of the viewpoint [180/90].\n");
-				gmt_message (GMT, "\t   When used with -Jz|Z, optionally add zlevel for frame, etc. [bottom of z-axis]\n");
-				gmt_message (GMT, "\t   Optionally, append +w<lon/lat[/z] to specify a fixed point\n");
-				gmt_message (GMT, "\t   and +vx/y for its justification.  Just append + by itself\n");
-				gmt_message (GMT, "\t   to select default values [region center and page center].\n");
+				gmt_message (GMT, "\t   <azimuth>/<elevation> of the viewpoint [180/90].\n");
+				gmt_message (GMT, "\t   When used with -Jz|Z, optionally add /<zlevel> for frame level [bottom of z-axis].\n");
+				gmt_message (GMT, "\t   Prepend x or y to plot against the “wall” x = level or y = level [z].\n");
+				gmt_message (GMT, "\t   Optionally, append +w<lon0>/<lat0>[/<z0>] to specify a fixed coordinate point\n");
+				gmt_message (GMT, "\t   or +v<x0>/<y0> for a fixed projected point [region center and page center].\n");
 				gmt_message (GMT, "\t   For a plain rotation about the z-axis, give rotation angle only\n");
 				gmt_message (GMT, "\t   and optionally use +w or +v to select location of axis [plot origin].\n");
 			}


### PR DESCRIPTION
The usage message for **-p** was badly formatted, had no mention of the leading (optional) **x**, **y**, **z** directives, and both the usage and docs mention appending a lonely **+** (with no arguments) to fix the center, but that is just the default behavior (no **+** required).  FYI, we do now want any lonely **+** as this will cause trouble with modifier parsing, especially after long-options are implemented.
