### PR TITLE
List file to add extra exe's to the Win installer

### DIFF
--- a/cmake/dist/add_exes_cpack.txt
+++ b/cmake/dist/add_exes_cpack.txt
@@ -1,0 +1,44 @@
+# List of extra  files to include in the installer
+# This file is prepared to use JL's installation paths.
+
+SET (PATO_GDAL_BIN  "C:/programs/compa_libs/gdal_GIT/compileds/${VC}_${BITAGE}/bin")
+SET (PATO_PROJ_BIN  "C:/programs/compa_libs/proj5_GIT/compileds/${VC}_${BITAGE}/bin")
+
+install (PROGRAMS 
+	${PATO_GDAL_BIN}/gdaladdo.exe
+	${PATO_GDAL_BIN}/gdalbuildvrt.exe
+	${PATO_GDAL_BIN}/gdaldem.exe
+	${PATO_GDAL_BIN}/gdalenhance.exe
+	${PATO_GDAL_BIN}/gdalinfo.exe
+	${PATO_GDAL_BIN}/gdallocationinfo.exe
+	${PATO_GDAL_BIN}/gdalmanage.exe
+	${PATO_GDAL_BIN}/gdalserver.exe
+	${PATO_GDAL_BIN}/gdalsrsinfo.exe
+	${PATO_GDAL_BIN}/gdaltindex.exe
+	${PATO_GDAL_BIN}/gdaltransform.exe
+	${PATO_GDAL_BIN}/gdalwarp.exe
+	${PATO_GDAL_BIN}/gdal_contour.exe
+	${PATO_GDAL_BIN}/gdal_grid.exe
+	${PATO_GDAL_BIN}/gdal_rasterize.exe
+	${PATO_GDAL_BIN}/gdal_translate.exe
+	${PATO_GDAL_BIN}/gnmanalyse.exe
+	${PATO_GDAL_BIN}/gnmmanage.exe
+	${PATO_GDAL_BIN}/nearblack.exe
+	${PATO_GDAL_BIN}/ogr2ogr.exe
+	${PATO_GDAL_BIN}/ogrinfo.exe
+	${PATO_GDAL_BIN}/ogrlineref.exe
+	${PATO_GDAL_BIN}/ogrtindex.exe
+	${PATO_GDAL_BIN}/testepsg.exe
+	DESTINATION ${GMT_BINDIR}
+	COMPONENT Runtime)
+
+install (PROGRAMS 
+	${PATO_PROJ_BIN}/cct.exe
+	${PATO_PROJ_BIN}/cs2cs.exe
+	${PATO_PROJ_BIN}/geod.exe
+	${PATO_PROJ_BIN}/gie.exe
+	${PATO_PROJ_BIN}/nad2bin.exe
+	${PATO_PROJ_BIN}/proj.exe
+	${PATO_PROJ_BIN}/projinfo.exe
+	DESTINATION ${GMT_BINDIR}
+	COMPONENT Runtime)

--- a/cmake/modules/FindFFTW3.cmake
+++ b/cmake/modules/FindFFTW3.cmake
@@ -70,6 +70,11 @@ if (FFTW3F_LIBRARY)
 	check_symbol_exists (fftwf_import_wisdom_from_filename fftw3.h FFTW3F_VERSION_RECENT)
 	cmake_pop_check_state() # restore state of CMAKE_REQUIRED_*
 
+	# For some reason in my machine check_symbol_exists() call above is not able to its job
+	if (WIN32 AND NOT FFTW3F_VERSION_RECENT)
+		set (FFTW3F_VERSION_RECENT TRUE)
+	endif ()
+
 	# old version warning
 	if (NOT FFTW3F_VERSION_RECENT)
 		message (WARNING "FFTW library found, but it is either too old (<3.3) or statically-linked.")


### PR DESCRIPTION
On Windows the installer ships with a complete GDAL + PROJ4 (V6). But for that I need to provide the list of the exe's to include in the installer. This file has that, but for my own paths.