### PR TITLE
Fix a few more path length issues

### DIFF
--- a/src/blockmean.c
+++ b/src/blockmean.c
@@ -563,7 +563,7 @@ int GMT_blockmean (void *V_API, int mode, void *args) {
 			if (strstr (Ctrl->G.file[kk], "%s"))
 				sprintf (file, Ctrl->G.file[kk], code[k]);
 			else
-				strncpy (file, Ctrl->G.file[kk], GMT_LEN128-1);
+				strncpy (file, Ctrl->G.file[kk], PATH_MAX-1);
 			if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, file, GridOut[k]) != GMT_NOERROR) {
 				Return (API->error);
 			}

--- a/src/blockmedian.c
+++ b/src/blockmedian.c
@@ -653,7 +653,7 @@ int GMT_blockmedian (void *V_API, int mode, void *args) {
 			if (strstr (Ctrl->G.file[kk], "%s"))
 				sprintf (file, Ctrl->G.file[kk], code[k]);
 			else
-				strncpy (file, Ctrl->G.file[kk], GMT_LEN128-1);
+				strncpy (file, Ctrl->G.file[kk], PATH_MAX-1);
 			if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, file, GridOut[k]) != GMT_NOERROR) {
 				Return (API->error);
 			}

--- a/src/blockmode.c
+++ b/src/blockmode.c
@@ -859,7 +859,7 @@ int GMT_blockmode (void *V_API, int mode, void *args) {
 			if (strstr (Ctrl->G.file[kk], "%s"))
 				sprintf (file, Ctrl->G.file[kk], code[k]);
 			else
-				strncpy (file, Ctrl->G.file[kk], GMT_LEN128-1);
+				strncpy (file, Ctrl->G.file[kk], PATH_MAX-1);
 			if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, file, GridOut[k]) != GMT_NOERROR) {
 				Return (API->error);
 			}

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -2171,7 +2171,7 @@ GMT_LOCAL int api_next_io_source (struct GMTAPI_CTRL *API, unsigned int directio
 				return (GMT_ERROR_ON_FOPEN);
 			}
 			S_obj->close_file = true;	/* We do want to close files we are opening, but later */
-			strncpy (GMT->current.io.filename[direction], &(S_obj->filename[first]), GMT_BUFSIZ-1);
+			strncpy (GMT->current.io.filename[direction], &(S_obj->filename[first]), PATH_MAX-1);
 			GMT_Report (API, GMT_MSG_LONG_VERBOSE, "%s %s %s file %s\n",
 				operation[direction+first], GMT_family[S_obj->family], dir[direction], &(S_obj->filename[first]));
 			if (gmt_M_binary_header (GMT, direction)) {
@@ -2187,7 +2187,7 @@ GMT_LOCAL int api_next_io_source (struct GMTAPI_CTRL *API, unsigned int directio
 				gmt_setmode (GMT, (int)direction);	/* Windows may need to have its read mode changed from text to binary */
 #endif
 			kind = (S_obj->fp == GMT->session.std[direction]) ? 0 : 1;	/* For message only: 0 if stdin/out, 1 otherwise for user pointer */
-			snprintf (GMT->current.io.filename[direction], GMT_BUFSIZ, "<%s %s>", GMT_stream[kind], GMT_direction[direction]);
+			snprintf (GMT->current.io.filename[direction], PATH_MAX-1, "<%s %s>", GMT_stream[kind], GMT_direction[direction]);
 			GMT_Report (API, GMT_MSG_LONG_VERBOSE, "%s %s %s %s %s stream\n",
 				operation[direction], GMT_family[S_obj->family], dir[direction], GMT_stream[kind], GMT_direction[direction]);
 			if (gmt_M_binary_header (GMT, direction)) {
@@ -2205,7 +2205,7 @@ GMT_LOCAL int api_next_io_source (struct GMTAPI_CTRL *API, unsigned int directio
 			}
 			S_obj->method = S_obj->method - GMT_IS_FDESC + GMT_IS_STREAM;	/* Since fp now holds stream pointer an we have lost the handle */
 			kind = (S_obj->fp == GMT->session.std[direction]) ? 0 : 1;	/* For message only: 0 if stdin/out, 1 otherwise for user pointer */
-			snprintf (GMT->current.io.filename[direction], GMT_BUFSIZ, "<%s %s>", GMT_stream[kind], GMT_direction[direction]);
+			snprintf (GMT->current.io.filename[direction], PATH_MAX-1, "<%s %s>", GMT_stream[kind], GMT_direction[direction]);
 			GMT_Report (API, GMT_MSG_LONG_VERBOSE, "%s %s %s %s %s stream via supplied file descriptor\n",
 				operation[direction], GMT_family[S_obj->family], dir[direction], GMT_stream[kind], GMT_direction[direction]);
 			if (gmt_M_binary_header (GMT, direction)) {
@@ -7041,7 +7041,7 @@ void *GMT_Read_Data (void *V_API, unsigned int family, unsigned int method, unsi
 				if (q) {q[0] = '+'; strncat (CPT_file, q, PATH_MAX-1);}	/* Add back the z-scale modifier */
 			}
 			else	/* Got color list, now a temp CPT instead */
-				strncpy (CPT_file, file, GMT_LEN256-1);
+				strncpy (CPT_file, file, PATH_MAX-1);
 			gmt_M_str_free (file);	/* Free temp CPT name */
 			if ((in_ID = GMT_Register_IO (API, family, method, geometry, GMT_IN, wesn, CPT_file)) == GMT_NOTSET) {
 				gmt_M_str_free (input);
@@ -10016,8 +10016,8 @@ int GMT_Call_Module (void *V_API, const char *module, int mode, void *args) {
 	if (p_func == NULL) {	/* Not in any of the shared libraries */
 		status = GMT_NOT_A_VALID_MODULE;
 		if (strncasecmp (module, "gmt", 3)) {	/* For any module not already starting with "gmt..." */
-			char gmt_module[32] = "gmt";
-			strncat (gmt_module, module, 28);	/* Prepend "gmt" to module and try again */
+			char gmt_module[GMT_LEN32] = "gmt";
+			strncat (gmt_module, module, GMT_LEN32-4);	/* Prepend "gmt" to module and try again */
 			status = GMT_Call_Module (V_API, gmt_module, mode, args);	/* Recursive call to try with the 'gmt' prefix */
 		}
 	}

--- a/src/gmt_contour.h
+++ b/src/gmt_contour.h
@@ -134,10 +134,10 @@ struct GMT_CONTOUR {
 	bool delay;			/* true of we want to delay the actual annotation plotting until later */
 	bool crossect;			/* For SqN2 only: if true we want to add special suffixes to the 2 labels */
 	size_t n_alloc;			/* How many allocated so far */
-	char file[GMT_BUFSIZ];		/* File with crossing lines, if specified */
+	char file[PATH_MAX];		/* File with crossing lines, if specified */
 	char option[GMT_BUFSIZ];	/* Copy of the option string */
 	char label[GMT_BUFSIZ];		/* Fixed label */
-	char label_file[GMT_BUFSIZ];	/* Output files for text dump of label locations */
+	char label_file[PATH_MAX];	/* Output files for text dump of label locations */
 	char unit[GMT_LEN64];		/* Unit for labels */
 	char prefix[GMT_LEN64];		/* prefix for labels */
 	char crossect_tag[2][GMT_LEN64];	/* suffix for crossection beginning and end labels */

--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -101,7 +101,7 @@ GMT_LOCAL int dcw_load_lists (struct GMT_CTRL *GMT, struct GMT_DCW_COUNTRY **C, 
 	/* Open and read list of countries and states and return via two struct and one char arrays plus dimensions in dim */
 	size_t n_alloc = 300;
 	unsigned int k, n;
-	char path[GMT_BUFSIZ] = {""}, line[BUFSIZ] = {""};
+	char path[PATH_MAX] = {""}, line[BUFSIZ] = {""};
 	FILE *fp = NULL;
 	struct GMT_DCW_COUNTRY *Country = NULL;
 	struct GMT_DCW_STATE *State = NULL;
@@ -234,7 +234,7 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 	bool done, new_set, want_state, outline, fill = false;
 	char TAG[GMT_LEN16] = {""}, dim[GMT_LEN16] = {""}, xname[GMT_LEN16] = {""};
 	char yname[GMT_LEN16] = {""}, code[GMT_LEN16] = {""}, state[GMT_LEN16] = {""};
-	char msg[GMT_BUFSIZ] = {""}, segment[GMT_LEN32] = {""}, path[GMT_BUFSIZ] = {""}, list[GMT_BUFSIZ] = {""};
+	char msg[GMT_BUFSIZ] = {""}, segment[GMT_LEN32] = {""}, path[PATH_MAX] = {""}, list[GMT_BUFSIZ] = {""};
 	double west, east, south, north, xscl, yscl, out[2], *lon = NULL, *lat = NULL;
 	struct GMT_RANGE *Z = NULL;
 	struct GMT_DATASET *D = NULL;

--- a/src/gmt_decorate.h
+++ b/src/gmt_decorate.h
@@ -64,7 +64,7 @@ struct GMT_DECORATE {
 	bool fixed;			/* true if we chose fixed positions */
 	bool debug;			/* true of we want to draw helper lines/points */
 	char line_name[16];		/* Name of line: "contour" or "line" */
-	char file[GMT_BUFSIZ];		/* File with crossing lines, if specified */
+	char file[PATH_MAX];		/* File with crossing lines, if specified */
 	char option[GMT_BUFSIZ];	/* Copy of the option string */
 	char size[GMT_LEN64];		/* The symbol size */
 	char fill[GMT_LEN64];		/* The symbol fill */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -285,11 +285,11 @@ GMT_LOCAL bool gmtio_traverse_dir (const char *file, char *path) {
 	struct dirent *F = NULL;
 	int len, d_namlen;
 	bool ok = false;
-	char savedpath[GMT_BUFSIZ];
+	char savedpath[PATH_MAX];
 
  	if ((D = opendir (path)) == NULL) return (false);	/* Unable to open directory listing */
 	len = (int)strlen (file);
-	strncpy (savedpath, path, GMT_BUFSIZ-1);	/* Make copy of current directory path */
+	strncpy (savedpath, path, PATH_MAX-1);	/* Make copy of current directory path */
 
 	while (!ok && (F = readdir (D)) != NULL) {	/* For each directory entry until end or ok becomes true */
 		d_namlen = (int)strlen (F->d_name);
@@ -3774,7 +3774,7 @@ GMT_LOCAL FILE *gmt_nc_fopen (struct GMT_CTRL *GMT, const char *filename, const 
  * Also asigns GMT->current.io.col_type[GMT_IN] based on the variable attributes.
  */
 
-	char file[PATH_MAX] = {""}, path[GMT_BUFSIZ] = {""};
+	char file[PATH_MAX] = {""}, path[PATH_MAX] = {""};
 	int i, j, nvars, dimids[5] = {-1, -1, -1, -1, -1}, ndims, in, id;
 	size_t n, item[2];
 	size_t tmp_pointer; /* To avoid "cast from pointer to integer of different size" */
@@ -4509,7 +4509,7 @@ bool gmt_input_is_bin (struct GMT_CTRL *GMT, const char *filename) {
 
 /*! . */
 FILE * gmt_fopen (struct GMT_CTRL *GMT, const char *filename, const char *mode) {
-	char path[GMT_BUFSIZ], *c = NULL;
+	char path[PATH_MAX], *c = NULL;
 	FILE *fd = NULL;
 	unsigned int first = 0;
 	if (gmt_M_file_is_cache (filename)) {	/* Must be a cache file */
@@ -4793,7 +4793,7 @@ char *gmt_getdatapath (struct GMT_CTRL *GMT, const char *stem, char *path, int m
 	unsigned int d, pos;
 	size_t L;
 	bool found;
-	char *udir[6] = {GMT->session.USERDIR, GMT->session.DATADIR, GMT->session.CACHEDIR, NULL, NULL, NULL}, dir[GMT_BUFSIZ];
+	char *udir[6] = {GMT->session.USERDIR, GMT->session.DATADIR, GMT->session.CACHEDIR, NULL, NULL, NULL}, dir[PATH_MAX];
 	char path_separator[2] = {PATH_SEPARATOR, '\0'}, serverdir[PATH_MAX] = {""}, srtm1dir[PATH_MAX] = {""}, srtm3dir[PATH_MAX] = {""};
 #ifdef HAVE_DIRENT_H_
 	size_t N;
@@ -4936,7 +4936,7 @@ int gmt_access (struct GMT_CTRL *GMT, const char* filename, int mode) {
 	if (mode == W_OK)
 		return (access (file, mode));	/* When writing, only look in current directory */
 	if (mode == R_OK || mode == F_OK) {	/* Look in special directories when reading or just checking for existence */
-		char path[PATH_MAX];
+		char path[PATH_MAX] = {""};
 		if (gmt_M_file_is_remotedata (filename) && !strstr (filename, ".grd"))	/* A remote @earth_relief_xxm|s grid without extension */
 			strcat (file, ".grd");	/* Must supply the .grd */
 		return (gmt_getdatapath (GMT, file, path, mode) ? 0 : -1);
@@ -8409,14 +8409,14 @@ char **gmtlib_get_dir_list (struct GMT_CTRL *GMT, char *path, char *ext) {
 	}
 	(void)closedir (D);
 #elif defined(WIN32)
-	char text[GMT_LEN256] = {""};
+	char text[PATH_MAX] = {""};
 	int left;
 	HANDLE hFind;
 	WIN32_FIND_DATA FindFileData;
 
 	if (access (path, F_OK)) return NULL;	/* Quietly skip non-existent directories */
 	sprintf (text, "%s/*", path);
-	left = GMT_LEN256 - (int)strlen (path) - 2;
+	left = PATH_MAX - (int)strlen (path) - 2;
 	left -= ((ext) ? (int)strlen (ext) : 2);
 	if (ext)
 		strncat (text, ext, left);	/* Look for files with given ending in this dir */
@@ -8541,7 +8541,7 @@ int gmt_mkdir (const char *path)
 {	/* Simulates mkdir -p behavior in a function for Unix and Windows */
 	/* Adapted from http://stackoverflow.com/a/2336245/119527 */
 	const size_t len = strlen (path);
-	char _path[PATH_MAX], sep;
+	char _path[PATH_MAX] = {""}, sep;
 	char *p = NULL; 
 
 	errno = 0;	/* Global var: No error so far */

--- a/src/gmt_io.h
+++ b/src/gmt_io.h
@@ -270,9 +270,9 @@ struct GMT_IO {				/* Used to process input data records */
 	char curr_text[GMT_BUFSIZ];	/* Current ASCII record as it was read */
 	char curr_trailing_text[GMT_BUFSIZ];	/* Current text portion of current record (or NULL) */
 	char segment_header[GMT_BUFSIZ];	/* Current ASCII segment header */
-	char filename[2][GMT_BUFSIZ];	/* Current filenames (or <stdin>/<stdout>) */
+	char filename[2][PATH_MAX];	/* Current filenames (or <stdin>/<stdout>) */
 #ifdef HAVE_GDAL
-	char tempfile[GMT_BUFSIZ];	/* Temporary file used to read - should be removed when closed */
+	char tempfile[PATH_MAX];	/* Temporary file used to read - should be removed when closed */
 #endif
 	char col_set[2][GMT_MAX_COLUMNS];	/* Keeps track of which columns have had their type set */
 	char *o_format[GMT_MAX_COLUMNS];	/* Custom output ASCII format to overrule format_float_out */

--- a/src/gmt_memory.c
+++ b/src/gmt_memory.c
@@ -143,8 +143,8 @@ int gmt_memtrack_init (struct GMT_CTRL *GMT) {
 	else
 	{
 		int pid = getpid();
-		char logfile[32];
-		snprintf (logfile, 32, "gmt_memtrack_%d.log", pid);
+		char logfile[GMT_LEN32];
+		snprintf (logfile, GMT_LEN32, "gmt_memtrack_%d.log", pid);
 		if ((M->fp = fopen (logfile, "w")) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Could not create log file gmt_memtrack_%d.log\n", pid);
 			GMT_exit (GMT, GMT_ERROR_ON_FOPEN); return GMT_ERROR_ON_FOPEN;

--- a/src/gmt_shore.c
+++ b/src/gmt_shore.c
@@ -243,7 +243,7 @@ GMT_LOCAL char *shore_getpathname (struct GMT_CTRL *GMT, char *stem, char *path,
 	 * and returns path if file is readable, NULL otherwise */
 
 	FILE *fp = NULL;
-	char dir[GMT_BUFSIZ];
+	char dir[PATH_MAX];
 	static struct GSHHG_VERSION version = GSHHG_MIN_REQUIRED_VERSION;
 	static bool warn_once = true;
 	bool found = false;
@@ -291,7 +291,7 @@ GMT_LOCAL char *shore_getpathname (struct GMT_CTRL *GMT, char *stem, char *path,
 				GMT_Report (GMT->parent, GMT_MSG_NORMAL, "2. GSHHG: Failed to open %s\n", path);
 				return (NULL);
 			}
-			while (fgets (dir, GMT_BUFSIZ, fp)) {	/* Loop over all input lines until found or done */
+			while (fgets (dir, PATH_MAX, fp)) {	/* Loop over all input lines until found or done */
 				if (dir[0] == '#' || dir[0] == '\n') continue;	/* Comment or blank */
 				gmt_chop (dir);		/* Chop off LF or CR/LF */
 				sprintf (path, "%s/%s%s", dir, stem, ".nc");
@@ -366,7 +366,7 @@ GMT_LOCAL void shore_check (struct GMT_CTRL *GMT, bool ok[5]) {
  * resolution (f, h, i, l, c) */
 
 	int i, j, n_found;
-	char stem[GMT_LEN64] = {""}, path[GMT_BUFSIZ] = {""}, *res = "clihf", *kind[3] = {"GSHHS", "river", "border"};
+	char stem[GMT_LEN64] = {""}, path[PATH_MAX] = {""}, *res = "clihf", *kind[3] = {"GSHHS", "river", "border"};
 
 	for (i = 0; i < 5; i++) {
 		/* For each resolution... */
@@ -530,7 +530,7 @@ int gmt_init_shore (struct GMT_CTRL *GMT, char res, struct GMT_SHORE *c, double 
 	short *stmp = NULL;
 	int *itmp = NULL;
 	size_t start[1], count[1];
-	char stem[GMT_LEN64] = {""}, path[GMT_BUFSIZ] = {""};
+	char stem[GMT_LEN64] = {""}, path[PATH_MAX] = {""};
 
 	snprintf (stem, GMT_LEN64, "binned_GSHHS_%c", res);
 
@@ -928,7 +928,7 @@ int gmt_init_br (struct GMT_CTRL *GMT, char which, char res, struct GMT_BR *c, d
 	short *stmp = NULL;
 	int *itmp = NULL;
 	size_t start[1], count[1];
-	char stem[GMT_LEN64] = {""}, path[GMT_BUFSIZ] = {""};
+	char stem[GMT_LEN64] = {""}, path[PATH_MAX] = {""};
 
 	/* zap structure (nc_get_att_text does not null-terminate strings!) */
 	gmt_M_memset (c, 1, struct GMT_BR);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -378,7 +378,7 @@ GMT_LOCAL char *support_get_userimagename (struct GMT_CTRL *GMT, char *line, cha
 	 */
 
 	int j, err;
-	char *name = NULL, path[GMT_BUFSIZ+GMT_LEN256] = {""};
+	char *name = NULL, path[PATH_MAX+GMT_LEN256] = {""};
 	struct GMT_FILL fill;
 	if (!gmt_M_is_pattern (line)) return NULL;	/* Not an image specification */
 	err = gmtsupport_parse_pattern (GMT, line, &fill);	/* See if this returns an error or not */
@@ -1331,7 +1331,7 @@ bool gmt_consider_current_cpt (struct GMTAPI_CTRL *API, bool *active, char **arg
 	if (arg == NULL) return false;	/* No text pointer to work with */
 	
 	if (gmt_M_cpt_mod (*arg)) {	/* Gave modifiers for a unit change) */
-		char string[GMT_LEN256] = {""};
+		char string[PATH_MAX] = {""};
 		if ((cpt = gmt_get_current_cpt (API->GMT)) == NULL) return false;	/* No current CPT */
 		sprintf (string, "%s%s", cpt, *arg);	/* Append the modifiers to the current CPT name */
 		gmt_M_str_free (*arg);
@@ -9021,7 +9021,7 @@ int gmt_contlabel_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_CONTOUR *G)
 
 			case 't':	/* Save contour label locations to given file [x y angle label] */
 				G->save_labels = 1;
-				if (p[1]) strncpy (G->label_file, &p[1], GMT_BUFSIZ-1);
+				if (p[1]) strncpy (G->label_file, &p[1], PATH_MAX-1);
 				break;
 
 			case 'u':	/* Label Unit specification */
@@ -9143,7 +9143,7 @@ int gmt_contlabel_info (struct GMT_CTRL *GMT, char flag, char *txt, struct GMT_C
 			/* Fall through on purpose to 'x' */
 		case 'x':	/* Crossing line */
 			L->crossing = GMT_CONTOUR_XCURVE;
-			strncpy (L->file, &txt[1], GMT_BUFSIZ-1);
+			strncpy (L->file, &txt[1], PATH_MAX-1);
 			if (!gmt_M_file_is_cache (L->file) && gmt_access (GMT, L->file, R_OK)) {	/* Cannot read/find file */
 				GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error -%c option: Cannot find/read crossing line file %s\n", L->flag, L->file);
 				error++;
@@ -9355,7 +9355,7 @@ int gmtlib_decorate_info (struct GMT_CTRL *GMT, char flag, char *txt, struct GMT
 			/* Fall through on purpose to 'x' */
 		case 'x':	/* Crossing line */
 			L->crossing = GMT_DECORATE_XCURVE;
-			strncpy (L->file, &txt[1], GMT_BUFSIZ-1);
+			strncpy (L->file, &txt[1], PATH_MAX-1);
 			if (!gmt_M_file_is_cache (L->file) && gmt_access (GMT, L->file, R_OK)) {	/* Cannot read/find file */
 				GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error -%c option: Cannot find/read crossing line file %s\n", L->file);
 				error++;

--- a/src/gmtwhich.c
+++ b/src/gmtwhich.c
@@ -144,7 +144,7 @@ int GMT_gmtwhich (void *V_API, int mode, void *args) {
 	int error = 0, fmode;
 	unsigned int first = 0;	/* Real start of filename */
 	
-	char path[GMT_BUFSIZ] = {""}, file[PATH_MAX] = {""}, *Yes = "Y", *No = "N", cwd[GMT_BUFSIZ] = {""}, *p = NULL;
+	char path[PATH_MAX] = {""}, file[PATH_MAX] = {""}, *Yes = "Y", *No = "N", cwd[PATH_MAX] = {""}, *p = NULL;
 	
 	struct GMTWHICH_CTRL *Ctrl = NULL;
 	struct GMT_RECORD *Out = NULL;
@@ -180,7 +180,7 @@ int GMT_gmtwhich (void *V_API, int mode, void *args) {
 		Return (API->error);
 	}
 	
-	if (Ctrl->D.active && (getcwd (cwd, GMT_BUFSIZ) == NULL)) {	/* Get full path, even for current dir */
+	if (Ctrl->D.active && (getcwd (cwd, PATH_MAX) == NULL)) {	/* Get full path, even for current dir */
 		GMT_Report (API, GMT_MSG_VERBOSE, "Unable to determine current working directory!\n");
 	}
 	fmode = (Ctrl->A.active) ? R_OK : F_OK;	/* Either readable or existing files */

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -759,7 +759,7 @@ int GMT_grdblend (void *V_API, int mode, void *args) {
 	gmt_grdfloat *z = NULL, no_data_f;
 	
 	char type;
-	char *outfile = NULL, outtemp[GMT_BUFSIZ];
+	char *outfile = NULL, outtemp[PATH_MAX];
 	
 	struct GRDBLEND_INFO *blend = NULL;
 	struct GMT_GRID *Grid = NULL;

--- a/src/img/img2grd.c
+++ b/src/img/img2grd.c
@@ -407,7 +407,7 @@ int GMT_img2grd (void *V_API, int mode, void *args) {
 	int16_t *row = NULL;
 	uint16_t *u2 = NULL;
 
-	char infile[PATH_MAX] = {""}, cmd[GMT_BUFSIZ] = {""}, input[GMT_STR16] = {""}, output[GMT_LEN256] = {""};
+	char infile[PATH_MAX] = {""}, cmd[GMT_BUFSIZ] = {""}, input[GMT_STR16] = {""}, output[PATH_MAX] = {""};
 	char z_units[GMT_GRID_UNIT_LEN80] = {""}, exact_R[GMT_LEN256] = {""};
 
 	FILE *fp = NULL;
@@ -781,7 +781,7 @@ int GMT_img2grd (void *V_API, int mode, void *args) {
 		}
 	}
 	else	/* The output here is the final result */
-		strncpy (output, Ctrl->G.file, GMT_LEN256-1);
+		strncpy (output, Ctrl->G.file, PATH_MAX-1);
 	sprintf (cmd, "-R%g/%g/%g/%g -Jm1i -I %s -G%s --PROJ_ELLIPSOID=Sphere --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=false", west, east, south2, north2, input, output);
 	GMT_Report (API, GMT_MSG_DEBUG, "Calling grdproject %s.\n", cmd);
 	if (GMT_Call_Module (API, "grdproject", GMT_MODULE_CMD, cmd)!= GMT_NOERROR) {	/* Inverse project the grid or fail */

--- a/src/mgd77/mgd77.c
+++ b/src/mgd77/mgd77.c
@@ -2696,7 +2696,7 @@ int MGD77_Get_Path (struct GMT_CTRL *GMT, char *track_path, char *track, struct 
 	int has_suffix = MGD77_NOT_SET;
 	unsigned int id, fmt, f_start = 0, f_stop = 0;
 	bool append = false, hard_path;
-	char geo_path[GMT_BUFSIZ] = {""};
+	char geo_path[PATH_MAX] = {""};
 
 	for (fmt = 0; fmt < MGD77_FORMAT_ANY; fmt++) {	/* Determine if given track name contains one of the 4 possible extensions */
 		if (strchr (track, '.') && (strlen(track)-strlen(MGD77_suffix[fmt])) > 0 && !strncmp (&track[strlen(track)-strlen(MGD77_suffix[fmt])], MGD77_suffix[fmt], strlen(MGD77_suffix[fmt])))
@@ -2754,7 +2754,7 @@ int MGD77_Get_Path (struct GMT_CTRL *GMT, char *track_path, char *track, struct 
 		if (append)	/* No extension, must append extension */
 			sprintf (geo_path, "%s.%s", track, MGD77_suffix[fmt]);
 		else
-			strncpy (geo_path, track, GMT_BUFSIZ-1);	/* Extension already there */
+			strncpy (geo_path, track, PATH_MAX-1);	/* Extension already there */
 
 		/* Here we have a relative (or absolute, if hard path was given) path.  First look in current directory */
 
@@ -2824,7 +2824,7 @@ int MGD77_Open_File (struct GMT_CTRL *GMT, char *leg, struct MGD77_CONTROL *F, i
 		if (has_suffix == MGD77_NOT_SET)	/* file name given without extension */
 			sprintf (F->path, "%s.%s", leg, MGD77_suffix[F->format]);
 		else
-			strncpy (F->path, leg, GMT_BUFSIZ-1);
+			strncpy (F->path, leg, PATH_MAX-1);
 	}
 	else
 		return (MGD77_UNKNOWN_MODE);
@@ -4041,7 +4041,7 @@ void MGD77_Reset (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F) {
 	F->rec_no = F->n_out_columns = F->bit_pattern[0] = F->bit_pattern[1] = F->n_constraints = F->n_exact = F->n_bit_tests = 0;
 	F->no_checking = false;
 	gmt_M_memset (F->NGDC_id, MGD77_COL_ABBREV_LEN, char);
-	gmt_M_memset (F->path, GMT_BUFSIZ, char);
+	gmt_M_memset (F->path, PATH_MAX, char);
 	F->fp = NULL;
 	F->nc_id = F->nc_recid = MGD77_NOT_SET;
 	F->format = MGD77_FORMAT_ANY;

--- a/src/mgd77/mgd77.h
+++ b/src/mgd77/mgd77.h
@@ -427,7 +427,7 @@ struct MGD77_CONTROL {
 	unsigned int n_MGD77_paths;			/* Number of such directories */
 	char user[MGD77_COL_ABBREV_LEN];		/* Current user id */
 	char NGDC_id[MGD77_COL_ABBREV_LEN];		/* Current NGDC file tag id */
-	char path[GMT_BUFSIZ];				/* Full path to current file */
+	char path[PATH_MAX];				/* Full path to current file */
 	FILE *fp;					/* File pointer to current open file (not used by MGD77+) */
 	unsigned int verbose_level;			/* 0 = none, 1 = warnings, 2 = errors (combined 3 for both) */
 	unsigned int verbose_dest;			/* 1 = to stdout, 2 = to stderr */

--- a/src/mgd77/mgd77list.c
+++ b/src/mgd77/mgd77list.c
@@ -872,7 +872,7 @@ int GMT_mgd77list (void *V_API, int mode, void *args) {
 	if (M.adjust_time) Ctrl->D.start = MGD77_time2utime (GMT, &M, Ctrl->D.start);	/* Convert to Unix time if need be */
 	if (M.adjust_time) Ctrl->D.stop  = MGD77_time2utime (GMT, &M, Ctrl->D.stop);
 	if (Ctrl->L.active) {	/* Scan the ephemeral correction table for needed auxiliary columns */
-		char path[GMT_BUFSIZ] = {""};
+		char path[PATH_MAX] = {""};
 		if (!Ctrl->L.file) {	/* Try default correction table */
 			sprintf (path, "%s/mgd77_corrections.txt", M.MGD77_HOME);
 			if (access (path, R_OK)) {
@@ -1030,7 +1030,7 @@ int GMT_mgd77list (void *V_API, int mode, void *args) {
 	
 
 	if (Ctrl->L.active) {	/* Load an ephemeral correction table */
-		char path[GMT_BUFSIZ] = {""};
+		char path[PATH_MAX] = {""};
 		if (!Ctrl->L.file) {	/* Try default correction table */
 			sprintf (path, "%s/mgd77_corrections.txt", M.MGD77_HOME);
 			if (access (path, R_OK)) {

--- a/src/mgd77/mgd77path.c
+++ b/src/mgd77/mgd77path.c
@@ -145,7 +145,7 @@ int GMT_mgd77path (void *V_API, int mode, void *args) {
 	uint64_t n_cruises = 0, i, n_paths;
 	int error = 0;
 	
-	char path[GMT_BUFSIZ] = {""}, **list = NULL;
+	char path[PATH_MAX] = {""}, **list = NULL;
 	
 	struct MGD77_CONTROL M;
 	struct MGD77PATH_CTRL *Ctrl = NULL;

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -1347,7 +1347,7 @@ GMT_LOCAL int in_mem_PS_convert(struct GMTAPI_CTRL *API, struct PS2RASTER_CTRL *
 		sprintf (t, " -sDEVICE=%s %s -sOutputFile=", device[Ctrl->T.device], device_options[Ctrl->T.device]);
 		strcat (out_file, t);
 		if (API->external && Ctrl->F.active && !gmt_M_file_is_memory (Ctrl->F.file)) {
-			strncpy (t, Ctrl->F.file, GMT_LEN256-1);
+			strncpy (t, Ctrl->F.file, PATH_MAX-1);
 		}
 		else {
 			if (API->tmp_dir)	/* Use the established temp directory */

--- a/src/psimage.c
+++ b/src/psimage.c
@@ -407,7 +407,7 @@ int GMT_psimage (void *V_API, int mode, void *args) {
 
 	unsigned char *picture = NULL, *buffer = NULL;
 
-	char path[GMT_BUFSIZ] = {""}, *file = NULL, *c = NULL;
+	char path[PATH_MAX] = {""}, *file = NULL, *c = NULL;
 
 	struct imageinfo header;
 

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -420,7 +420,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 	char bar_cpt[GMT_LEN256] = {""}, bar_gap[GMT_LEN256] = {""}, bar_height[GMT_LEN256] = {""}, bar_modifiers[GMT_LEN256] = {""};
 	char module_options[GMT_LEN256] = {""}, r_options[GMT_LEN256] = {""}, xy_mode[3] = {""};
 	char txtcolor[GMT_LEN256] = {""}, def_txtcolor[GMT_LEN256] = {""}, buffer[GMT_BUFSIZ] = {""}, A[GMT_LEN32] = {""}, legend_file[PATH_MAX] = {""};
-	char path[GMT_BUFSIZ] = {""}, B[GMT_LEN32] = {""}, C[GMT_LEN32] = {""}, p[GMT_LEN256] = {""};
+	char path[PATH_MAX] = {""}, B[GMT_LEN32] = {""}, C[GMT_LEN32] = {""}, p[GMT_LEN256] = {""};
 	char *line = NULL, string[GMT_STR16] = {""}, *c = NULL, *fill[PSLEGEND_MAX_COLS];
 #ifdef DEBUG
 	char *dname[N_DAT] = {"symbol", "front", "qline", "textline", "partext"};

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -546,18 +546,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctrl, struct GMT
 	n_errors += gmt_M_check_condition (GMT, Ctrl->W.active && Ctrl->W.scale == 0.0, "Syntax error -W option: Scale cannot be zero\n");
 
 	gmt_consider_current_cpt (API, &Ctrl->C.active, &(Ctrl->C.file));
-#if 0
-	if (GMT->current.setting.run_mode == GMT_MODERN && (!Ctrl->C.active || (Ctrl->C.file[0] =='+' && strchr ("uU", Ctrl->C.file[1])))) {
-		sprintf (string, "%s/gmt.cpt", API->gwf_dir);	/* Use this if it exists */
-		if (!access (string, R_OK)) {	/* It does, activate -C<string> */
-			if (Ctrl->C.file) strncat (string, Ctrl->C.file, GMT_LEN256-1);	/* Append the +u|u<unit> instruction */
-			gmt_M_str_free (Ctrl->C.file);
-			Ctrl->C.file = strdup (string);
-			Ctrl->C.active = true;
-			GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Reuse current CPT file %s/gmt.cpt\n", API->gwf_dir);
-		}
-	}
-#endif
+
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
 

--- a/src/seis/pssac.c
+++ b/src/seis/pssac.c
@@ -217,7 +217,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSSAC_CTRL *Ctrl, struct GMT_O
 	int j, k;
 	size_t n_alloc = 0, len;
 	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, p[GMT_BUFSIZ] = {""};
-	char path[GMT_BUFSIZ] = {""};	/* Full path to sac file */
+	char path[PATH_MAX] = {""};	/* Full path to sac file */
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
@@ -518,7 +518,7 @@ GMT_LOCAL void sqr (double *y, int n) {
 GMT_LOCAL int init_sac_list (struct GMT_CTRL *GMT, char **files, unsigned int n_files, struct SAC_LIST **list) {
 	unsigned int n = 0;
 	int nr;
-	char path[GMT_BUFSIZ] = {""};	/* Full path to sac file */
+	char path[PATH_MAX] = {""};	/* Full path to sac file */
 	struct SAC_LIST *L = NULL;
 
 	/* Got a bunch of SAC files or one file in SAC format */

--- a/src/x2sys/x2sys.c
+++ b/src/x2sys/x2sys.c
@@ -127,7 +127,7 @@ static int n_mgg_paths = 0; /* Number of these directories */
 
 GMT_LOCAL int mggpath_func (char *leg_path, char *leg) {
 	int id;
-	char geo_path[GMT_BUFSIZ] = {""};
+	char geo_path[PATH_MAX] = {""};
 
 	/* First look in current directory */
 
@@ -154,7 +154,7 @@ GMT_LOCAL int mggpath_func (char *leg_path, char *leg) {
  */
 
 GMT_LOCAL void mggpath_init (struct GMT_CTRL *GMT) {
-	char line[GMT_BUFSIZ] = {""};
+	char line[PATH_MAX] = {""};
 	FILE *fp = NULL;
 
 	gmt_getsharepath (GMT, "mgg", "gmtfile_paths", "", line, R_OK);
@@ -167,7 +167,7 @@ GMT_LOCAL void mggpath_init (struct GMT_CTRL *GMT) {
 		return;
 	}
 
-	while (fgets (line, GMT_BUFSIZ, fp)) {
+	while (fgets (line, PATH_MAX, fp)) {
 		if (line[0] == '#') continue;	/* Comments */
 		if (line[0] == ' ' || line[0] == '\0') continue;	/* Blank line */
 		mgg_path[n_mgg_paths] = gmt_M_memory (GMT, NULL, strlen (line), char);
@@ -650,7 +650,7 @@ int x2sys_read_file (struct GMT_CTRL *GMT, char *fname, double ***data, struct X
 	size_t n_alloc;
 	FILE *fp = NULL;
 	double **z = NULL, *rec = NULL;
-	char path[GMT_BUFSIZ] = {""};
+	char path[PATH_MAX] = {""};
 
 	if (x2sys_get_data_path (GMT, path, fname, s->suffix)) {
 		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "x2sys_read_file : Cannot find track %s\n", fname);
@@ -711,7 +711,7 @@ int x2sys_read_gmtfile (struct GMT_CTRL *GMT, char *fname, double ***data, struc
 	int i, year, n_records;	/* These must remain 4-byte ints */
 	int64_t rata_day;
 	uint64_t j;
-	char path[GMT_BUFSIZ] = {""};
+	char path[PATH_MAX] = {""};
 	FILE *fp = NULL;
 	double **z = NULL;
 	double NaN = GMT->session.d_NaN, t_off;
@@ -808,7 +808,7 @@ int x2sys_read_mgd77file (struct GMT_CTRL *GMT, char *fname, double ***data, str
 	uint64_t i, j;
 	size_t n_alloc = GMT_CHUNK;
 	int col[MGD77_N_DATA_EXTENDED];
-	char path[GMT_BUFSIZ] = {""}, *tvals[MGD77_N_STRING_FIELDS];
+	char path[PATH_MAX] = {""}, *tvals[MGD77_N_STRING_FIELDS];
 	double **z = NULL, dvals[MGD77_N_DATA_EXTENDED];
 	struct MGD77_HEADER H;
 	struct MGD77_CONTROL MC;
@@ -869,7 +869,7 @@ int x2sys_read_mgd77file (struct GMT_CTRL *GMT, char *fname, double ***data, str
 
 int x2sys_read_mgd77ncfile (struct GMT_CTRL *GMT, char *fname, double ***data, struct X2SYS_INFO *s, struct X2SYS_FILE_INFO *p, struct GMT_IO *G, uint64_t *n_rec) {
 	uint64_t i;
-	char path[GMT_BUFSIZ] = {""};
+	char path[PATH_MAX] = {""};
 	double **z = NULL;
 	struct MGD77_DATASET *S = NULL;
 	struct MGD77_CONTROL MC;
@@ -927,7 +927,7 @@ int x2sys_read_ncfile (struct GMT_CTRL *GMT, char *fname, double ***data, struct
 	int n_fields, ns = s->n_out_columns;
 	uint64_t n_expect = GMT_MAX_COLUMNS;
 	uint64_t i, j;
-	char path[GMT_BUFSIZ] = {""};
+	char path[PATH_MAX] = {""};
 	double **z = NULL, *in = NULL;
 	FILE *fp = NULL;
 	gmt_M_unused(G);
@@ -1540,7 +1540,7 @@ int x2sys_get_data_path (struct GMT_CTRL *GMT, char *track_path, char *track, ch
 	unsigned int id;
 	size_t L_suffix, L_track;
 	bool add_suffix;
-	char geo_path[GMT_BUFSIZ] = {""};
+	char geo_path[PATH_MAX] = {""};
 	gmt_M_unused(GMT);
 
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "x2sys_get_data_path: Given track %s and suffix %s\n", track, suffix);
@@ -1567,7 +1567,7 @@ int x2sys_get_data_path (struct GMT_CTRL *GMT, char *track_path, char *track, ch
 	if (add_suffix)
 		sprintf (geo_path, "%s.%s", track, suffix);
 	else
-		strncpy (geo_path, track, GMT_BUFSIZ-1);
+		strncpy (geo_path, track, PATH_MAX-1);
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "x2sys_get_data_path: Testing path for %s: %s\n", track, geo_path);
 	if (!access(geo_path, R_OK)) {
 		strcpy (track_path, geo_path);
@@ -2011,7 +2011,7 @@ void x2sys_get_corrtable (struct GMT_CTRL *GMT, struct X2SYS_INFO *S, char *ctab
 	/* Pass aux as NULL if the auxiliary columns do not matter (only used by x2sys_datalist) */
 	unsigned int i, n_items, n_aux = 0, n_cols, missing;
 	int ks;
-	char path[GMT_BUFSIZ] = {""}, **item_names = NULL, **col_name = NULL, **aux_name = NULL;
+	char path[PATH_MAX] = {""}, **item_names = NULL, **col_name = NULL, **aux_name = NULL;
 
 	if (!ctable || !strlen(ctable)) {	/* Try default correction table */
 		sprintf (path, "%s/%s/%s_corrections.txt", X2SYS_HOME, S->TAG, S->TAG);

--- a/src/x2sys/x2sys.h
+++ b/src/x2sys/x2sys.h
@@ -129,7 +129,7 @@ struct X2SYS_INFO {
 	char ms_flag;			/* Multi-segment header flag */
 	char suffix[16];		/* Suffix for these data files */
 	char fflags[GMT_BUFSIZ];	/* Text copy of selected columns */
-	char path[GMT_BUFSIZ];		/* Full path to current data file */
+	char path[PATH_MAX];		/* Full path to current data file */
 	char separators[8];		/* List of characters used for column separators */
 	struct X2SYS_DATA_INFO *info;	/* Array of info for each data field */
 };


### PR DESCRIPTION
Standardize on using PATH_MAX for character arrays used for path, file, or dir variables.  Following up on #911.