### PR TITLE
Need check git commit hash for both public and non-public release

### DIFF
--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -42,7 +42,7 @@ set (GMT_PACKAGE_VERSION_WITH_GIT_REVISION ${GMT_PACKAGE_VERSION})
 # Add the last git commit hash and date to the package version if this is a non-public release.
 # A non-public release has a FALSE 'GMT_PUBLIC_RELEASE' variable in 'ConfigDefault.cmake'.
 #set (HAVE_GIT_VERSION)
-if (NOT GMT_PUBLIC_RELEASE)
+if (GIT_FOUND)
 	# Get the location, inside the staging area location, to copy the application bundle to.
 	execute_process (
 		COMMAND ${GIT_EXECUTABLE} describe --abbrev=7 --always --dirty
@@ -54,21 +54,22 @@ if (NOT GMT_PUBLIC_RELEASE)
 	if (GIT_RETURN_CODE)
 		message (STATUS "Unable to determine git commit hash for non-public release - ignoring.")
 	else (GIT_RETURN_CODE)
-		if (GIT_COMMIT_HASH)				# Set the updated package version.
-			# get commit date
-			execute_process (
-				COMMAND ${GIT_EXECUTABLE} log -1 --date=short --pretty=format:%cd
-				WORKING_DIRECTORY ${GMT_SOURCE_DIR}
-				RESULT_VARIABLE GIT_DATE_RETURN_CODE
-				OUTPUT_VARIABLE GIT_COMMIT_DATE
-				OUTPUT_STRIP_TRAILING_WHITESPACE)
-			string(REPLACE "-" "." GIT_COMMIT_DATE "${GIT_COMMIT_DATE}")
-
-			set (GMT_PACKAGE_VERSION_WITH_GIT_REVISION "${GMT_PACKAGE_VERSION}_${GIT_COMMIT_HASH}_${GIT_COMMIT_DATE}")
+		if (GIT_COMMIT_HASH)				
 			set (HAVE_GIT_VERSION TRUE)
+			# For non-public release, add the last git commit hash and date
+			if (NOT GMT_PUBLIC_RELEASE)
+				execute_process (
+					COMMAND ${GIT_EXECUTABLE} log -1 --date=short --pretty=format:%cd
+					WORKING_DIRECTORY ${GMT_SOURCE_DIR}
+					RESULT_VARIABLE GIT_DATE_RETURN_CODE
+					OUTPUT_VARIABLE GIT_COMMIT_DATE
+					OUTPUT_STRIP_TRAILING_WHITESPACE)
+				string(REPLACE "-" "." GIT_COMMIT_DATE "${GIT_COMMIT_DATE}")
+				set (GMT_PACKAGE_VERSION_WITH_GIT_REVISION "${GMT_PACKAGE_VERSION}_${GIT_COMMIT_HASH}_${GIT_COMMIT_DATE}")
+			endif (NOT GMT_PUBLIC_RELEASE)
 		endif (GIT_COMMIT_HASH)
 	endif (GIT_RETURN_CODE)
-endif (NOT GMT_PUBLIC_RELEASE)
+endif (GIT_FOUND)
 
 # The current GMT version.
 set (GMT_VERSION_STRING "${GMT_PACKAGE_NAME} ${GMT_PACKAGE_VERSION_WITH_GIT_REVISION}")


### PR DESCRIPTION
**Description of proposed changes**

We always need check last commit hash:

- for non-public release (GMT_PUBLIC_REALSE=FALSE), we need add the last commit hash to GMT version.
- for public release (GMT_PUBLIC_REALSE=TRUE), when making source codes tarballs, we need to know we're operating on a git repository.