### PR TITLE
Ensure that -p resets any rotation at the end of the layer

### DIFF
--- a/test/psbasemap/zrotation.ps
+++ b/test/psbasemap/zrotation.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_r20181M [64-bit] Document from psxy
+%%Title: GMT v6.0.0_13fea00-dirty_2019.06.14 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun May 27 16:15:55 2018
+%%CreationDate: Fri Jun 14 18:11:40 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -592,9 +592,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -637,8 +635,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath fs S} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -670,7 +667,7 @@ O0
 120 1620 TM
 
 % PostScript produced by:
-%@GMT: psxy -R0/8.3/0/8.3 -Jx1i -P -K -W1p -X0.1i -Y1.35i -B0 '-B+tRotation about S pole axis'
+%@GMT: gmt psxy -R0/8.3/0/8.3 -Jx1i -P -K -W1p -X0.1i -Y1.35i -B0 '-B+tRotation about S pole axis'
 %@PROJ: xy 0.00000000 8.30000000 0.00000000 8.30000000 0.000 8.300 0.000 8.300 +xy
 %GMTBoundingBox: 7.2 97.2 597.6 597.6
 %%BeginObject PSL_Layer_1
@@ -678,12 +675,20 @@ O0
 0 setlinejoin
 3.32551 setmiterlimit
 17 W
+clipsave
+0 0 M
+9960 0 D
+0 9960 D
+-9960 0 D
+P
+PSL_clip N
 4980 0 M
 0 9960 D
 S
 0 4980 M
 9960 0 D
 S
+PSL_cliprestore
 25 W
 2 setlinecap
 N 0 9960 M 0 -9960 D S
@@ -709,7 +714,7 @@ N 0 0 M 9960 0 D S
 0 setlinecap
 /PSL_H_y PSL_L_y PSL_LH add 233 add def
 4980 9960 PSL_H_y add M
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 (Rotation about S pole axis) bc Z
 %%EndObject
@@ -719,7 +724,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: pstext -R0/8.3/0/8.3 -Jx1i -O -K -F+jTL -Dj0.2i
+%@GMT: gmt pstext -R0/8.3/0/8.3 -Jx1i -O -K -F+jTL -Dj0.2i
 %@PROJ: xy 0.00000000 8.30000000 0.00000000 8.30000000 0.000 8.300 0.000 8.300 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -732,7 +737,7 @@ clipsave
 -9960 0 D
 P
 PSL_clip N
-240 4740 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+240 4740 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (rot = 0) tl Z
 5220 4740 M (rot = 45) tl Z
@@ -746,7 +751,7 @@ O0
 540 540 TM
 
 % PostScript produced by:
-%@GMT: pscoast -R0/360/-90/0 -JA0/-90/3.25i -Bg90a360f360 -O -K -Gred -Dc -X0.45i -Y0.45i
+%@GMT: gmt pscoast -R0/360/-90/0 -JA0/-90/3.25i -Bg90a360f360 -O -K -Gred -Dc -X0.45i -Y0.45i
 %@PROJ: laea 0.00000000 360.00000000 -90.00000000 0.00000000 -9009964.761 9009964.761 -9009964.761 9009964.761 +proj=laea +lat_0=-90 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -1439,6 +1444,7 @@ P
 FO
 3372 839 M
 7 4 D
+-6 -4 D
 P
 FO
 3312 736 M
@@ -1503,17 +1509,20 @@ FO
 -7 4 D
 -35 -18 D
 -60 3 D
--40 -25 D
+-20 -12 D
+-20 -13 D
 P
 3093 520 M
 -7 2 D
 P
 3158 477 M
 7 5 D
+-6 -5 D
 P
 FO
 2809 398 M
 10 0 D
+-10 0 D
 P
 FO
 2560 274 M
@@ -1682,6 +1691,7 @@ FO
 -1 -7 D
 5 3 D
 -2 4 D
+-1 0 D
 P
 FO
 29 2285 M
@@ -2159,6 +2169,7 @@ FO
 3142 3219 M
 5 -8 D
 4 10 D
+-8 -2 D
 P
 FO
 3158 3193 M
@@ -2317,7 +2328,8 @@ FO
 -4 -5 D
 -19 -17 D
 -4 -5 D
--57 -50 D
+-43 -38 D
+-14 -12 D
 P
 3234 920 M
 11 -5 D
@@ -2380,6 +2392,7 @@ P
 FO
 3162 706 M
 -1 -6 D
+1 7 D
 P
 FO
 3153 684 M
@@ -2416,9 +2429,15 @@ FO
 -8 57 D
 14 11 D
 -160 191 D
--58 -46 D
--81 -57 D
--53 -32 D
+-48 -39 D
+-30 -22 D
+-30 -21 D
+-31 -21 D
+-21 -13 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
 P
 FO
 2809 398 M
@@ -2466,6 +2485,7 @@ FO
 -41 -1 D
 0 -6 D
 13 5 D
+-15 -11 D
 P
 FO
 2313 329 M
@@ -2669,8 +2689,8 @@ FO
 2 44 D
 -92 108 D
 -29 36 D
--61 -54 D
--36 -34 D
+-55 -49 D
+-42 -39 D
 -5 -6 D
 -18 -17 D
 -5 -6 D
@@ -2744,8 +2764,9 @@ FO
 10 -2 D
 6 12 D
 17 75 D
--38 -28 D
--56 -45 D
+-29 -21 D
+-47 -37 D
+-18 -15 D
 59 -71 D
 P
 FO
@@ -3246,6 +3267,7 @@ P
 FO
 1015 2200 M
 6 1 D
+-5 -1 D
 P
 FO
 948 2241 M
@@ -3429,7 +3451,8 @@ FO
 -8 20 D
 19 14 D
 -33 84 D
--52 -30 D
+-26 -15 D
+-26 -15 D
 9 -15 D
 19 -40 D
 15 -41 D
@@ -3455,7 +3478,10 @@ FO
 -11 26 D
 -13 2 D
 -7 11 D
--45 -9 D
+-11 -2 D
+-12 -2 D
+-11 -2 D
+-11 -3 D
 7 -70 D
 -2 -53 D
 -5 -43 D
@@ -3515,16 +3541,22 @@ FO
 6 10 D
 23 9 D
 -50 60 D
--35 -27 D
+-28 -22 D
 -22 -15 D
--39 -21 D
--24 -11 D
--25 -10 D
+-15 -9 D
+-15 -9 D
+-16 -8 D
+-16 -8 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-9 -3 D
 P
 FO
 2110 1497 M
 7 -7 D
 -3 8 D
+-2 -1 D
 P
 FO
 2174 1051 M
@@ -3553,7 +3585,8 @@ FO
 -21 -8 D
 -2 12 D
 10 10 D
--3 1 D
+-1 0 D
+-2 1 D
 -10 -3 D
 -1 10 D
 -14 7 D
@@ -3856,7 +3889,8 @@ FO
 -13 6 D
 -14 -5 D
 -19 8 D
--10 0 D
+-5 0 D
+-5 0 D
 -3 -3 D
 0 3 D
 -2 0 D
@@ -3893,6 +3927,7 @@ FO
 -20 58 D
 -23 48 D
 -5 7 D
+-311 -180 D
 P
 FO
 1950 1950 M
@@ -3900,6 +3935,8 @@ FO
 7 70 D
 -2 53 D
 -5 43 D
+-236 -41 D
+-119 -21 D
 P
 FO
 1950 1950 M
@@ -3979,6 +4016,7 @@ FO
 36 -31 D
 34 -5 D
 227 270 D
+-254 -146 D
 P
 FO
 1520 1874 M
@@ -3997,6 +4035,7 @@ FO
 8 -3 D
 8 -32 D
 338 195 D
+-108 -19 D
 P
 FO
 1549 2021 M
@@ -4077,6 +4116,8 @@ FO
 -2 -12 D
 139 -382 D
 0 481 D
+-5 0 D
+-4 0 D
 P
 FO
 25 W
@@ -4124,11 +4165,33 @@ S
 -10 -14 D
 -4 -3 D
 -8 -9 D
--20 -14 D
--17 -9 D
--23 -6 D
--25 -2 D
--26 4 D
+-8 -6 D
+-8 -6 D
+-4 -2 D
+-6 -4 D
+-4 -2 D
+-3 -1 D
+-4 -2 D
+-2 0 D
+-3 -1 D
+-4 -2 D
+-3 0 D
+-4 -2 D
+-3 0 D
+-2 -1 D
+-2 0 D
+-3 0 D
+-2 -1 D
+-3 0 D
+-2 0 D
+-3 -1 D
+-2 0 D
+-2 0 D
+-3 0 D
+-2 0 D
+-3 0 D
+-2 0 D
+-24 4 D
 -23 8 D
 -16 10 D
 -17 14 D
@@ -4149,9 +4212,6 @@ S
 27 11 D
 19 3 D
 P S
-1950 1950 M
-0 0 D
-P S
 1950 3900 M
 68 -1 D
 108 -7 D
@@ -4210,26 +4270,120 @@ P S
 -59 -65 D
 -76 -77 D
 -57 -53 D
--60 -50 D
--46 -37 D
--79 -57 D
--66 -43 D
--50 -31 D
--68 -38 D
--35 -18 D
--79 -38 D
--81 -35 D
--83 -31 D
--102 -32 D
--85 -23 D
--86 -19 D
--107 -17 D
--107 -12 D
--68 -4 D
--88 -2 D
--68 1 D
--108 7 D
--97 11 D
+-45 -38 D
+-38 -31 D
+-31 -23 D
+-31 -24 D
+-24 -17 D
+-24 -16 D
+-25 -17 D
+-24 -16 D
+-17 -10 D
+-17 -10 D
+-25 -16 D
+-17 -9 D
+-17 -10 D
+-17 -10 D
+-17 -9 D
+-17 -9 D
+-18 -9 D
+-17 -9 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-17 -8 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-10 -1 D
+-9 0 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-79 3 D
+-97 8 D
+-68 8 D
 -77 13 D
 -77 15 D
 -104 27 D
@@ -4306,26 +4460,118 @@ N 1950 3900 M 0 83 D S
 N 1950 3900 M 0 83 D S
 25 W
 1950 3900 M
--68 -1 D
--108 -7 D
--97 -11 D
--77 -13 D
--77 -15 D
--104 -27 D
--94 -29 D
--55 -19 D
--100 -41 D
--89 -41 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 0 D
+-10 -1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-9 -3 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-10 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-17 -8 D
+-18 -9 D
 -17 -9 D
--69 -37 D
--51 -29 D
--33 -21 D
--82 -54 D
--86 -64 D
--61 -50 D
--65 -59 D
--77 -76 D
--53 -57 D
+-9 -4 D
+-18 -9 D
+-17 -9 D
+-17 -9 D
+-17 -10 D
+-17 -10 D
+-17 -9 D
+-17 -10 D
+-17 -11 D
+-16 -10 D
+-17 -11 D
+-24 -16 D
+-17 -11 D
+-24 -16 D
+-24 -17 D
+-31 -24 D
+-31 -23 D
+-46 -38 D
+-59 -51 D
+-63 -61 D
+-55 -56 D
+-33 -36 D
 -50 -60 D
 -37 -46 D
 -57 -79 D
@@ -4454,9 +4700,9 @@ N 1950 3900 M 0 83 D S
 -107 12 D
 -68 4 D
 P S
-1950 4067 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+1950 4067 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(0ö) bc Z
+(0è) bc Z
 %%EndObject
 0 A
 FQ
@@ -4464,7010 +4710,3391 @@ O0
 4980 0 TM
 
 % PostScript produced by:
-%@GMT: pscoast -R0/360/-90/0 -JA45/-90/3.25i -Bg90a360f360 -Gred -Dc -X4.15i -O -K -p0
+%@GMT: gmt pscoast -R0/360/-90/0 -JA0/-90/3.25i -Bg90a360f360 -Gred -Dc -X4.15i -O -K -p45
 1950 1950 T
+45 R
 -1950 -1950 T
-%@PROJ: laea 0.00000000 360.00000000 -90.00000000 0.00000000 -9009786.912 9009786.912 -9009786.912 9009786.912 +proj=laea +lat_0=-90 +lon_0=45 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@PROJ: laea 0.00000000 360.00000000 -90.00000000 0.00000000 -9009964.761 9009964.761 -9009964.761 9009964.761 +proj=laea +lat_0=-90 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-1078 3694 M
--49 -67 D
-7 -14 D
--10 11 D
-33 52 D
--1 8 D
-2 1 D
-2 -7 D
-2 9 D
--51 -27 D
--85 -49 D
--69 -45 D
--48 -33 D
-4 -13 D
--13 -8 D
-43 -6 D
-77 10 D
-25 -11 D
-16 5 D
--10 -9 D
-52 -16 D
--4 -17 D
-20 -7 D
-88 51 D
-91 45 D
--74 160 D
+2567 3800 M
+-82 -13 D
+-6 -15 D
+2 15 D
+60 13 D
+5 7 D
+2 -1 D
+-4 -6 D
+8 5 D
+-103 30 D
+-104 25 D
+-81 14 D
+-6 -11 D
+-15 3 D
+26 -34 D
+62 -48 D
+9 -25 D
+15 -8 D
+-13 0 D
+26 -47 D
+-15 -10 D
+8 -19 D
+85 -22 D
+90 -29 D
+21 -8 D
+60 166 D
 P
-1091 3649 M
--11 13 D
-12 9 D
--4 -9 D
-11 2 D
+2544 3759 M
+1 17 D
+16 -2 D
+-10 -4 D
+9 -6 D
 P
-1076 3674 M
--12 1 D
+2552 3787 M
+-9 9 D
 P
-1027 3585 M
--7 -6 D
+2453 3759 M
+-9 1 D
 P
-848 3539 M
--6 -8 D
--3 5 D
+2295 3853 M
+-11 -1 D
+2 5 D
 P
-899 3516 M
--9 -3 D
+2314 3800 M
+-8 5 D
 P
-970 3517 M
--6 -5 D
+2365 3751 M
+-8 0 D
 P
 {1 0 0 C} FS
 FO
-1611 3691 M
--3 5 D
-3 4 D
-16 -6 D
-86 14 D
-73 8 D
--17 30 D
-6 9 D
--8 -2 D
-9 16 D
--26 15 D
-11 26 D
-24 30 D
--5 53 D
--124 -15 D
--89 -16 D
--87 -19 D
--86 -24 D
--77 -25 D
--76 -27 D
--99 -42 D
--16 -8 D
-74 -160 D
-114 49 D
-95 33 D
-74 22 D
-75 19 D
+2941 3421 M
+2 5 D
+5 1 D
+7 -16 D
+65 -47 D
+37 -28 D
+26 -21 D
+9 32 D
+10 3 D
+-6 4 D
+18 5 D
+-9 29 D
+26 10 D
+38 5 D
+34 41 D
+-27 23 D
+-42 33 D
+-29 21 D
+-29 21 D
+-52 36 D
+-68 43 D
+-86 48 D
+-80 41 D
+-106 47 D
+-67 25 D
+-60 -166 D
+43 -16 D
+113 -49 D
+69 -35 D
+68 -38 D
+72 -45 D
 P
-1507 3813 M
-5 36 D
-3 2 D
-66 14 D
-7 -6 D
-15 8 D
-4 -3 D
--25 -9 D
--1 -17 D
--22 -13 D
-21 1 D
--12 -9 D
--18 -1 D
-6 -7 D
--9 -4 D
-1 9 D
--21 0 D
--11 -13 D
-P
-1518 3842 M
--3 5 D
-P
-1515 3812 M
-1 -4 D
-P
-1434 3753 M
-4 19 D
-32 -36 D
--5 -10 D
-29 -5 D
-27 -27 D
--23 -1 D
--15 19 D
--35 13 D
--9 34 D
-P
-1438 3657 M
--1 8 D
-20 15 D
--7 -18 D
-P
-1487 3690 M
--18 -13 D
-6 10 D
-P
-1419 3782 M
-3 17 D
-12 -4 D
-P
-1659 3844 M
-0 4 D
-P
-1456 3795 M
-5 -2 D
-P
-1563 3715 M
-8 -3 D
-P
-1430 3826 M
-13 4 D
--15 -13 D
-P
-1560 3715 M
--19 -2 D
--2 8 D
-P
-1615 3805 M
-16 11 D
--14 -11 D
-P
-1651 3832 M
-0 9 D
-P
-1378 3658 M
--5 -6 D
-P
-1647 3811 M
-3 7 D
-P
-1695 3867 M
-8 4 D
-P
-FO
-1769 3787 M
--3 5 D
--3 -9 D
-11 -4 D
-P
-FO
-1779 3753 M
-10 6 D
-P
-FO
-1785 3840 M
-5 6 D
-26 11 D
--7 5 D
-18 1 D
-54 36 D
--101 -6 D
-P
-FO
-2286 3789 M
-6 -3 D
-P
-FO
-1987 3734 M
-10 0 D
-P
-FO
-3536 3085 M
-4 -22 D
-7 5 D
-P
-FO
-3513 3088 M
--10 7 D
-5 -23 D
-P
-FO
-3508 3060 M
-3 -11 D
-P
-FO
-3506 3110 M
-7 -1 D
-P
-FO
-3516 3112 M
--3 -8 D
-P
-FO
-3675 2412 M
--12 31 D
--1 -31 D
-1 -3 D
-P
-FO
-3688 2416 M
--4 5 D
-1 -6 D
-2 0 D
-0 1 D
-P
-FO
-3832 2459 M
--1 0 D
--1 9 D
--12 -13 D
-3 6 D
--13 10 D
--11 -4 D
--21 15 D
--11 -9 D
-5 -19 D
--35 -7 D
-5 -18 D
-26 8 D
-68 18 D
-P
-FO
-3540 3063 M
-2 -12 D
--10 -57 D
-10 -87 D
-1 -22 D
-5 5 D
-6 -20 D
-8 0 D
--1 -17 D
-47 13 D
-6 21 D
--12 23 D
--7 1 D
-11 0 D
--5 12 D
-12 12 D
--15 34 D
-16 -3 D
--19 31 D
--27 41 D
--21 30 D
-P
-FO
-3717 2593 M
-29 -34 D
-2 7 D
-1 -7 D
-16 -5 D
-1 16 D
-18 -14 D
--1 -7 D
-15 -20 D
-12 8 D
--20 59 D
--36 94 D
--40 92 D
--7 14 D
--11 2 D
-4 -17 D
--4 11 D
-1 -14 D
--8 4 D
-11 -14 D
--25 -23 D
-22 -43 D
--10 -11 D
-25 -30 D
-3 -20 D
--4 -2 D
-12 -27 D
--13 -7 D
-P
-3792 2574 M
-4 -8 D
-P
-3709 2682 M
--5 2 D
-P
-FO
-3630 2595 M
-4 -19 D
-14 11 D
--14 38 D
-8 24 D
--12 48 D
--17 14 D
--18 43 D
-0 23 D
--28 68 D
--13 1 D
--14 14 D
-17 -38 D
--8 0 D
-16 -44 D
-16 -28 D
-15 -57 D
-P
-FO
-3621 2850 M
-9 -1 D
--6 18 D
-8 14 D
--12 20 D
--10 2 D
-10 -18 D
--7 -11 D
-P
-FO
-3652 2503 M
-29 -63 D
--2 41 D
--5 6 D
--2 -20 D
--6 37 D
--8 9 D
-P
-FO
-3648 2568 M
--5 14 D
--6 -21 D
-14 -16 D
-P
-FO
-3638 2810 M
-11 -4 D
--6 20 D
--11 -4 D
-P
-FO
-3513 3027 M
--2 9 D
--2 -13 D
-P
-FO
-3649 2535 M
-3 -18 D
-11 -1 D
--3 14 D
-P
-FO
-3642 2642 M
-5 -24 D
-11 -17 D
-P
-FO
-3634 2922 M
--4 18 D
--4 0 D
-P
-FO
-3729 2561 M
-16 -3 D
-P
-FO
-3619 2943 M
-6 -10 D
-P
-FO
-3671 2566 M
-4 -8 D
-P
-FO
-3607 2967 M
-6 -9 D
-P
-FO
-3510 2959 M
+2954 3581 M
+29 22 D
+4 -1 D
+56 -37 D
 2 -9 D
-P
-FO
-3670 2493 M
-5 -5 D
-P
-FO
-3682 2427 M
-4 -6 D
-P
-FO
-3669 2385 M
-6 27 D
--12 -3 D
-P
-FO
-3694 2274 M
-42 -83 D
--14 67 D
--26 42 D
--8 2 D
-P
-FO
-3855 1783 M
-18 70 D
--5 26 D
--5 -1 D
--1 26 D
--16 21 D
--4 21 D
-16 16 D
--7 6 D
-9 10 D
-27 6 D
-5 54 D
--10 40 D
--11 9 D
-1 -35 D
--13 -12 D
-5 -55 D
--11 9 D
-5 15 D
--8 17 D
-0 25 D
--8 -30 D
--14 -2 D
-5 -18 D
-17 -11 D
--10 6 D
--7 -12 D
-0 -32 D
--4 11 D
--6 -19 D
--19 -95 D
--6 2 D
-0 -10 D
--11 0 D
--10 -16 D
--2 12 D
--5 -22 D
-0 18 D
--7 -14 D
--12 6 D
-2 -33 D
-P
-FO
-3740 2429 M
-3 -14 D
-43 21 D
-11 -17 D
-1 -11 D
--16 2 D
--3 -25 D
--13 0 D
-2 -16 D
-7 -1 D
-7 -25 D
-9 25 D
-9 -7 D
-14 44 D
-1 -13 D
-33 -54 D
--14 60 D
--15 15 D
--3 14 D
-8 23 D
-11 -2 D
--1 7 D
-P
-3802 2396 M
-1 -8 D
--7 9 D
-P
-3804 2403 M
-0 -7 D
-P
-3809 2426 M
--4 -2 D
-4 3 D
-P
-FO
-3685 2415 M
-10 -51 D
-19 -39 D
-4 5 D
--11 12 D
--8 28 D
--1 34 D
--10 12 D
--1 0 D
-0 -1 D
-P
-FO
-3880 2187 M
-5 2 D
--1 12 D
--4 -2 D
--8 -28 D
-P
-FO
-3833 2181 M
+15 -5 D
+1 -5 D
+-24 12 D
+-12 -12 D
+-26 6 D
+16 -14 D
+-15 3 D
+-13 11 D
+-1 -8 D
 -9 2 D
-10 -8 D
--6 -9 D
-7 -48 D
--6 -32 D
-14 18 D
--1 43 D
+7 6 D
+-15 15 D
+-17 -1 D
 P
-FO
-3750 1856 M
-5 -31 D
-8 -5 D
-3 30 D
--15 18 D
-P
-FO
-3771 2347 M
-6 0 D
--4 11 D
--12 1 D
-1 -10 D
-P
-FO
-3796 1973 M
--17 3 D
-12 -18 D
-15 5 D
--5 13 D
-P
-FO
-3771 2344 M
--13 2 D
-11 -17 D
-0 10 D
-15 -2 D
-P
-FO
-3874 2211 M
--5 -7 D
-3 -15 D
-6 13 D
--3 9 D
-P
-FO
-3726 2263 M
-4 -2 D
--2 18 D
--7 4 D
-P
-FO
-3860 2185 M
-2 12 D
--7 8 D
-3 -26 D
-P
-FO
-3820 2246 M
--6 -23 D
-7 -18 D
-7 16 D
-P
-FO
-3889 2086 M
-4 -10 D
--3 37 D
-P
-FO
-3737 2239 M
-9 -32 D
--2 28 D
-P
-FO
-3880 1916 M
-1 -13 D
-8 35 D
-P
-FO
-3832 2350 M
-8 -17 D
--3 21 D
-P
-FO
-3869 1917 M
--1 -31 D
-5 50 D
-P
-FO
-3859 2107 M
-6 -1 D
--5 21 D
-P
-FO
-3873 2085 M
-7 -1 D
--2 13 D
-P
-FO
-3846 2250 M
--5 22 D
-6 -33 D
-P
-FO
-3721 2294 M
--3 -5 D
-7 -4 D
-P
-FO
-3736 2414 M
--8 -4 D
-13 3 D
-P
-FO
-3838 2249 M
-4 4 D
--8 -6 D
-P
-FO
-3848 2380 M
+2983 3593 M
+0 6 D
 -1 -6 D
 P
-FO
-3824 2180 M
-3 -11 D
+2959 3574 M
+-2 -4 D
+P
+2861 3590 M
+15 10 D
+-3 -48 D
+-10 -3 D
+17 -25 D
+0 -37 D
+-17 15 D
+2 24 D
+-16 34 D
+19 31 D
+P
+2795 3519 M
+5 7 D
+25 -4 D
+-18 -8 D
+P
+2853 3508 M
+-22 3 D
+11 3 D
+P
+2870 3621 M
+14 10 D
+5 -12 D
+P
+3083 3495 M
+4 3 D
+P
+2905 3604 M
+3 -5 D
+P
+2924 3472 M
+4 -8 D
+P
+2909 3645 M
+12 -7 D
+-20 2 D
+P
+2922 3474 M
+-15 12 D
+4 7 D
+P
+3024 3499 M
+20 -4 D
+-18 2 D
+P
+3070 3492 M
+6 6 D
+P
+2753 3562 M
+-8 -1 D
+P
+3051 3480 M
+7 3 D
+P
+3125 3486 M
+9 -3 D
 P
 FO
-3891 2142 M
--3 -8 D
+3121 3377 M
+1 5 D
+-8 -4 D
+5 -11 D
 P
 FO
-3712 2318 M
-10 -21 D
+3104 3346 M
+11 -3 D
 P
 FO
-3874 1947 M
-1 -8 D
+3169 3403 M
+9 1 D
+26 -11 D
+-2 9 D
+13 -13 D
+64 -12 D
+-5 4 D
+-4 5 D
+-47 41 D
+-20 17 D
 P
 FO
-3763 2369 M
--6 0 D
+3488 3013 M
+1 -7 D
 P
 FO
-3750 1837 M
--1 -12 D
+3238 3185 M
+7 -7 D
 P
 FO
-3752 2114 M
-3 7 D
+3874 1631 M
+-13 -18 D
+9 -2 D
 P
 FO
-3794 2020 M
-14 -10 D
+3859 1650 M
+-2 12 D
+-13 -20 D
 P
 FO
-3843 2387 M
--5 11 D
+3837 1634 M
+-6 -11 D
 P
 FO
-3713 2325 M
-5 -10 D
-P
-FO
-3874 2217 M
+3871 1670 M
 4 -6 D
 P
 FO
-3878 2105 M
-4 -17 D
-P
-FO
-3801 2027 M
--6 -5 D
-P
-FO
-3742 2170 M
-1 8 D
-P
-FO
-3772 2055 M
--1 -9 D
-P
-FO
-3885 2104 M
-2 -8 D
-P
-FO
-3862 2203 M
-1 -8 D
-P
-FO
-3828 2006 M
--3 -10 D
-4 10 D
-P
-FO
-3833 2303 M
-9 -30 D
--2 26 D
-P
-FO
-3871 2127 M
-2 -8 D
-P
-FO
-3756 2072 M
-16 -17 D
-P
-FO
-3664 1494 M
-5 5 D
-0 -10 D
-9 23 D
-9 -3 D
-3 20 D
-21 10 D
-18 27 D
-14 5 D
--5 -29 D
-11 5 D
-23 57 D
-11 -4 D
-25 38 D
-47 145 D
--102 9 D
--26 -33 D
--1 -34 D
--6 -12 D
-7 -25 D
-15 35 D
--7 -46 D
-7 9 D
--4 -17 D
-12 8 D
--12 -26 D
-8 3 D
--6 -5 D
-4 -7 D
--7 -3 D
--13 -37 D
--43 -40 D
-P
-3770 1747 M
+3879 1665 M
 -7 -4 D
 P
-3846 1763 M
-1 8 D
+FO
+3497 1057 M
+13 30 D
+-23 -21 D
+-1 -3 D
 P
 FO
-3654 1460 M
-8 7 D
+3508 1050 M
+1 7 D
+-4 -5 D
+3 -1 D
 P
 FO
-3567 1196 M
-7 8 D
+3641 979 M
+-1 2 D
+5 6 D
+-17 -1 D
+6 2 D
+-1 16 D
+-12 6 D
+-3 25 D
+-15 1 D
+-9 -16 D
+-30 19 D
+-10 -15 D
+85 -49 D
+P
+FO
+3861 1613 M
+-7 -10 D
+-48 -33 D
+-53 -69 D
+-16 -16 D
+8 0 D
+-10 -19 D
+5 -5 D
+-12 -12 D
+42 -24 D
+19 11 D
+8 24 D
+-4 6 D
+7 -8 D
+5 13 D
+17 -1 D
+14 35 D
+9 -14 D
+14 60 D
+11 60 D
+P
+FO
+3655 1155 M
+-5 -45 D
+7 4 D
+-5 -6 D
+8 -14 D
+13 10 D
+3 -22 D
+-6 -4 D
+-4 -26 D
+14 -2 D
+31 63 D
+35 77 D
+29 72 D
+16 44 D
+-7 8 D
+-9 -14 D
+5 11 D
+-9 -11 D
+-3 9 D
+-3 -18 D
+-33 1 D
+-15 -45 D
+-15 -2 D
+-4 -38 D
+-11 -16 D
+-5 1 D
+-10 -28 D
+-14 4 D
+P
+3694 1089 M
+-3 -9 D
+P
+3712 1224 M
 -3 5 D
--8 -11 D
 P
 FO
-3724 1440 M
-0 -36 D
-8 3 D
-7 -18 D
-6 6 D
-5 22 D
+3594 1218 M
+-11 -16 D
+18 -2 D
+17 37 D
+23 11 D
+25 42 D
+-2 22 D
+18 44 D
+16 16 D
+28 67 D
+-8 11 D
+0 19 D
+-15 -38 D
+-6 5 D
+-20 -42 D
+-8 -31 D
+-29 -52 D
+P
+FO
+3769 1405 M
+5 -7 D
+8 17 D
+16 4 D
+5 23 D
+-5 8 D
+-6 -20 D
 -13 -3 D
--3 28 D
-6 25 D
-9 -2 D
--7 9 D
-12 49 D
--23 -37 D
+-11 -22 D
 P
 FO
-3681 1320 M
--16 -12 D
--4 -13 D
-37 29 D
+3545 1137 M
+-25 -64 D
+28 30 D
+1 8 D
+-16 -13 D
+22 30 D
+1 13 D
 P
 FO
-3737 1369 M
-47 62 D
--33 -44 D
--25 -10 D
+3587 1186 M
+7 14 D
+-19 -11 D
+-1 -21 D
 P
 FO
-3623 1260 M
--3 8 D
--12 -15 D
+3752 1365 M
+5 -11 D
+9 18 D
+-10 5 D
+-5 -12 D
 P
 FO
-3821 1552 M
-0 -15 D
-4 31 D
+3817 1606 M
+5 8 D
+-11 -7 D
 P
 FO
-3602 1214 M
--20 -22 D
-37 35 D
+3565 1163 M
+-11 -15 D
+7 -9 D
+8 12 D
 P
 FO
-3756 1533 M
-3 8 D
--8 -7 D
+3635 1243 M
+-13 -20 D
+-3 -20 D
 P
 FO
-3616 1270 M
--5 -5 D
-6 -1 D
-P
-FO
-3640 1267 M
--8 -16 D
-26 28 D
-P
-FO
-3626 1273 M
-3 -5 D
-P
-FO
-3671 1475 M
--10 -14 D
-P
-FO
-3792 1456 M
--6 -13 D
-P
-FO
-3652 1397 M
-6 15 D
-P
-FO
-3674 1485 M
--5 -7 D
-P
-FO
-3640 1284 M
--8 -4 D
-P
-FO
-3704 1328 M
--6 -1 D
-P
-FO
-3607 1247 M
--4 1 D
-P
-FO
-3767 1564 M
--3 -7 D
-P
-FO
-3734 1689 M
--2 -9 D
-P
-FO
-3611 1264 M
--4 -6 D
-P
-FO
-3776 1427 M
-2 8 D
-P
-FO
-3787 1593 M
+3829 1447 M
+9 15 D
 -3 3 D
 P
 FO
-3814 1468 M
--3 -8 D
+3640 1124 M
+9 -13 D
 P
 FO
-3734 1694 M
--7 -14 D
+3832 1472 M
+-3 -11 D
 P
 FO
-3681 1454 M
+3603 1169 M
+-3 -9 D
+P
+FO
+3841 1498 M
+-3 -11 D
+P
+FO
+3766 1561 M
+-4 -9 D
+P
+FO
+3550 1118 M
+0 -8 D
+P
+FO
+3512 1063 M
+-1 -7 D
+P
+FO
+3473 1042 M
+24 15 D
+-11 6 D
+P
+FO
+3412 946 M
+-28 -88 D
+37 57 D
+11 48 D
+-4 7 D
+P
+FO
+3179 485 M
+62 37 D
+15 22 D
+-5 2 D
+18 20 D
+4 25 D
+12 19 D
+23 0 D
+-1 9 D
+13 0 D
+24 -15 D
+41 35 D
+21 35 D
+-1 15 D
+-24 -26 D
+-18 1 D
+-35 -42 D
+-1 14 D
+14 7 D
+6 17 D
+18 18 D
+-27 -15 D
+-11 8 D
+-10 -16 D
+4 -20 D
+-3 11 D
+-12 -4 D
+-23 -22 D
+5 10 D
+-18 -9 D
+-80 -53 D
+-3 6 D
+-7 -8 D
+-8 8 D
+-19 -4 D
+8 9 D
+-19 -12 D
+13 13 D
+-16 -5 D
+-4 14 D
+-22 -25 D
+P
+FO
+3554 1024 M
+-7 -13 D
+45 -16 D
+-5 -19 D
+-7 -9 D
+-9 13 D
+-20 -15 D
+-9 8 D
+-10 -12 D
+4 -6 D
+-12 -22 D
+24 11 D
+1 -12 D
+41 22 D
+-9 -10 D
+-15 -62 D
+33 53 D
+0 21 D
+7 11 D
+22 12 D
+7 -10 D
+4 6 D
+P
+3575 956 M
+-5 -6 D
+2 10 D
+P
+3581 959 M
+-5 -4 D
+5 5 D
+P
+3602 972 M
+-5 2 D
+P
+FO
+3505 1052 M
+-28 -43 D
+-14 -41 D
+6 1 D
+0 16 D
+14 25 D
+24 26 D
+1 15 D
+P
+FO
+3483 753 M
+4 -3 D
+8 10 D
+-4 1 D
+-26 -14 D
+P
+FO
+3445 782 M
+-5 8 D
+2 -13 D
+-11 -3 D
+-29 -38 D
+-27 -18 D
+23 3 D
+29 31 D
+P
+FO
+3156 610 M
+-18 -24 D
+2 -10 D
+23 19 D
+2 23 D
+P
+FO
+3518 943 M
+5 -4 D
+5 11 D
+-8 9 D
+-7 -9 D
+P
+FO
+3271 661 M
+-9 14 D
+-4 -21 D
+13 -7 D
+6 13 D
+P
+FO
+3517 941 M
+-9 10 D
+-3 -19 D
+7 7 D
+9 -12 D
+P
+FO
+3495 774 M
+-9 -2 D
+-8 -12 D
+13 4 D
+P
+FO
+3427 916 M
+2 -5 D
+10 15 D
+-1 7 D
+P
+FO
+3466 765 M
+10 8 D
+2 10 D
+-17 -20 D
+P
+FO
+3482 837 M
+-21 -12 D
+-8 -18 D
+16 7 D
+P
+FO
+3417 675 M
+-4 -10 D
+23 28 D
+P
+FO
+3418 891 M
+-16 -29 D
+18 21 D
+P
+FO
+3291 562 M
+-9 -10 D
+31 18 D
+P
+FO
+3564 902 M
+-7 -18 D
+13 18 D
+P
+FO
+3283 570 M
+-21 -22 D
+38 33 D
+P
+FO
+3411 711 M
+3 -5 D
+11 19 D
+P
+FO
+3405 685 M
+4 -5 D
+8 11 D
+P
+FO
+3503 822 M
+12 19 D
+-19 -28 D
+P
+FO
+3445 941 M
+-5 -1 D
+2 -8 D
+P
+FO
+3541 1015 M
+-8 3 D
+11 -7 D
+P
+FO
+3496 827 M
+6 -1 D
+-10 1 D
+P
+FO
+3597 912 M
 -6 -3 D
 P
 FO
-3563 1198 M
--14 -22 D
+3438 788 M
+-6 -10 D
+P
+FO
+3458 714 M
+-8 -4 D
+P
+FO
+3456 964 M
+-8 -22 D
+P
+FO
+3309 587 M
+-6 -6 D
+P
+FO
+3528 964 M
+-4 4 D
+P
+FO
+3143 597 M
+-9 -7 D
+P
+FO
+3340 791 M
+7 3 D
+P
+FO
+3303 695 M
+3 -16 D
+P
+FO
+3598 920 M
+4 12 D
+P
+FO
+3462 968 M
+-4 -10 D
+P
+FO
+3500 778 M
+-3 -7 D
+P
+FO
+3423 697 M
+-10 -16 D
+P
+FO
+3314 696 M
+-8 0 D
+P
+FO
+3372 839 M
+7 4 D
+-6 -4 D
+P
+FO
+3312 736 M
+-6 -6 D
+6 5 D
+P
+FO
+3427 691 M
+-4 -7 D
+P
+FO
+3481 777 M
+-5 -6 D
+P
+FO
+3318 661 M
+-10 -5 D
+P
+FO
+3531 868 M
+-15 -28 D
 18 20 D
 P
 FO
-3556 1167 M
--11 -8 D
-32 13 D
+3434 717 M
+-5 -7 D
 P
 FO
-3550 1158 M
--10 -2 D
+3313 760 M
+0 -1 D
 P
 FO
-3572 1189 M
--6 -7 D
-P
-FO
-2114 163 M
--7 1 D
-P
-FO
-400 865 M
-37 -25 D
-12 25 D
-10 -4 D
--10 38 D
-P
-FO
-391 858 M
-4 -6 D
-2 6 D
--4 2 D
--2 -1 D
-P
-FO
-355 828 M
-13 -7 D
--1 9 D
-18 -13 D
-18 13 D
--7 22 D
--10 3 D
--18 -12 D
--8 -7 D
--7 -4 D
-P
-FO
-609 558 M
--10 4 D
-3 -21 D
-8 -7 D
--6 19 D
-15 -7 D
-P
-FO
-573 591 M
--11 7 D
-P
-FO
-592 566 M
--10 8 D
-P
-FO
-404 858 M
--6 4 D
-P
-FO
-615 536 M
--5 8 D
-P
-FO
-595 553 M
--7 9 D
-P
-FO
-121 1460 M
-28 -54 D
-1 -20 D
-24 -31 D
--5 -5 D
--5 9 D
-4 -46 D
-5 -2 D
--8 -20 D
-4 -24 D
-18 -42 D
-25 -18 D
-14 -34 D
-12 -6 D
-0 8 D
-12 -14 D
--3 -15 D
-15 -36 D
--4 -15 D
-23 -33 D
--8 9 D
-2 -8 D
--6 15 D
--11 17 D
-3 15 D
--15 35 D
-2 18 D
--10 11 D
-1 -9 D
--13 7 D
--17 36 D
--22 16 D
--26 61 D
-6 39 D
--4 43 D
--14 19 D
-0 16 D
--14 29 D
--9 2 D
--7 26 D
-3 -19 D
--17 -41 D
-4 -70 D
-31 -86 D
--9 14 D
--23 70 D
--4 73 D
-15 59 D
--53 -14 D
-23 -77 D
-41 -119 D
-45 -107 D
-47 -96 D
-48 -86 D
-38 -62 D
-34 -52 D
-11 -14 D
-7 4 D
-8 7 D
-18 12 D
--5 2 D
-3 8 D
-16 0 D
-49 34 D
-3 41 D
-14 39 D
--22 34 D
--38 65 D
--35 65 D
--33 68 D
--36 83 D
--29 78 D
--27 87 D
--9 32 D
-P
-128 1418 M
-4 -11 D
-P
-148 1375 M
-0 -11 D
-P
-157 1362 M
--1 -12 D
-P
-FO
-393 860 M
--4 1 D
-2 -3 D
-0 1 D
-P
-FO
-56 2116 M
--5 -75 D
--10 -38 D
-17 -47 D
--13 2 D
--5 13 D
-2 -21 D
--7 17 D
--11 -11 D
-8 -14 D
--10 -3 D
-4 -7 D
--4 4 D
-2 -9 D
--6 -10 D
-5 -6 D
--8 -1 D
-4 -5 D
--7 -33 D
-4 -2 D
--2 -23 D
-14 -14 D
-1 14 D
-4 -12 D
--5 -8 D
-24 -33 D
--17 13 D
-7 -42 D
--16 -12 D
-18 -44 D
-1 -17 D
--7 23 D
--8 9 D
--17 12 D
--2 3 D
-12 -91 D
-20 -106 D
-23 -97 D
-53 14 D
--13 51 D
--19 24 D
--4 30 D
--14 19 D
--7 38 D
-1 12 D
-5 0 D
--2 10 D
--22 49 D
-21 -44 D
-6 -29 D
-22 -10 D
--22 2 D
--3 17 D
-3 -31 D
--3 18 D
--2 -18 D
-18 -33 D
-3 -28 D
-24 -32 D
-6 -35 D
-4 -9 D
-116 31 D
--23 95 D
--16 88 D
--12 89 D
--8 106 D
--1 138 D
-6 98 D
-P
-52 1738 M
--9 -9 D
--3 31 D
-8 -10 D
-5 6 D
--11 -16 D
-P
-42 1745 M
-2 10 D
-P
-94 1550 M
--5 7 D
-P
-91 1561 M
--5 2 D
-P
-62 1559 M
--2 24 D
-5 5 D
-P
-44 1707 M
-22 16 D
-P
-52 1794 M
-20 2 D
-P
-65 1639 M
--2 7 D
-P
-FO
-119 1459 M
-0 3 D
-P
-FO
-23 1755 M
-4 10 D
-2 -10 D
-10 9 D
--1 25 D
--9 32 D
--21 14 D
-2 -66 D
-P
-14 1811 M
-5 -1 D
-P
-FO
-30 1725 M
-9 -7 D
--7 16 D
--10 8 D
--1 -6 D
-P
-FO
-8 1780 M
--1 2 D
-1 -5 D
-P
-FO
-44 1971 M
--1 11 D
-P
-FO
-12 1746 M
--1 14 D
-P
-FO
-20 1733 M
--6 9 D
-P
-FO
-16 1747 M
-4 -5 D
-P
-FO
-20 1747 M
--4 5 D
-P
-FO
-52 1965 M
--5 2 D
-P
-FO
-10 1748 M
-0 1 D
-P
-FO
-23 1926 M
--4 3 D
-P
-FO
--5 -3 1 68 1629 SP
-198 2223 M
--24 42 D
--20 8 D
--32 -9 D
--9 -10 D
--10 -49 D
--27 -41 D
--20 -48 D
-127 -11 D
-13 107 D
-P
-119 2145 M
-0 -12 D
-P
-139 2176 M
--2 -7 D
-1 7 D
-P
-FO
-1021 3461 M
-22 -9 D
-6 -23 D
--17 -36 D
-5 -51 D
-24 -34 D
-111 -37 D
-48 -60 D
-85 -39 D
-31 15 D
-30 15 D
--166 355 D
--52 -25 D
--71 -38 D
-P
-FO
-1043 3329 M
-5 -3 D
-P
-FO
-1472 3246 M
-80 27 D
-62 17 D
-6 13 D
-22 24 D
-3 53 D
--2 -5 D
--10 5 D
-69 51 D
--5 39 D
--29 27 D
--4 17 D
-7 -2 D
-37 25 D
-12 21 D
-82 38 D
-4 5 D
--10 111 D
--10 3 D
-0 1 D
--106 -13 D
--53 -9 D
-19 -25 D
--5 -18 D
-22 -34 D
--20 2 D
--24 31 D
-8 13 D
--16 28 D
--68 -15 D
--90 -23 D
--95 -31 D
--65 -25 D
--93 -40 D
-166 -355 D
-62 27 D
-P
-1491 3310 M
--1 -10 D
--12 -1 D
-9 -2 D
--11 0 D
-P
-1640 3569 M
-21 -2 D
-22 -16 D
--22 15 D
-P
-1449 3494 M
-15 28 D
-31 13 D
--23 -11 D
-P
-1540 3334 M
--6 -1 D
-4 -4 D
--8 4 D
-P
-1493 3647 M
-2 -7 D
--9 -5 D
-6 12 D
-P
-1406 3623 M
-3 -4 D
-P
-1664 3615 M
-1 -5 D
-P
-1353 3405 M
-4 5 D
-P
-1628 3347 M
--3 4 D
-P
-1491 3634 M
--1 -6 D
-P
-1681 3599 M
--1 6 D
-P
-1540 3567 M
-54 13 D
-P
-FO
-1806 3601 M
-22 28 D
--16 35 D
-7 4 D
--11 25 D
-8 13 D
--20 6 D
-P
-FO
-1950 3424 M
-54 9 D
-71 131 D
-2 19 D
-12 6 D
--4 25 D
-8 2 D
-6 -12 D
-10 10 D
--11 47 D
--22 15 D
-3 7 D
--17 -8 D
-2 -18 D
--17 -7 D
--11 4 D
-4 -12 D
--8 0 D
--9 -15 D
--1 8 D
--12 -9 D
-4 -6 D
--9 -2 D
-2 7 D
--14 -5 D
-1 -10 D
--10 6 D
--50 -9 D
--14 -25 D
-16 -48 D
--27 -27 D
--6 -20 D
-22 -53 D
-P
-2049 3576 M
-3 7 D
-P
-FO
-2294 3496 M
--6 -9 D
-11 2 D
-P
-FO
-1896 3691 M
-9 -3 D
--5 10 D
-P
-FO
-1926 3683 M
-10 -4 D
--2 6 D
-P
-FO
-2229 3489 M
-13 -10 D
--2 9 D
-P
-FO
-1951 3673 M
-5 -5 D
-P
-FO
-2045 3660 M
-5 -3 D
-P
-FO
-1908 3681 M
-8 -2 D
-P
-FO
-2090 3586 M
-4 5 D
-P
-FO
-3484 2361 M
--10 23 D
--29 41 D
--1 16 D
--43 47 D
--16 3 D
-9 13 D
--53 -3 D
--29 -34 D
-4 11 D
--6 2 D
-11 10 D
--17 -16 D
-2 19 D
--42 -61 D
--16 -9 D
-31 -96 D
-5 -20 D
-P
-FO
-3662 2412 M
-0 -3 D
-1 0 D
-P
-FO
-3309 2494 M
-7 9 D
-P
-FO
-3425 2478 M
-5 -3 D
-P
-FO
-3327 2503 M
--6 -1 D
-P
-FO
-3327 2503 M
-5 1 D
-P
-FO
-3575 1808 M
-1 11 D
-13 15 D
-23 67 D
-19 37 D
-24 -20 D
-7 5 D
-0 -17 D
-9 0 D
-8 -16 D
-9 13 D
--11 16 D
-8 -1 D
--2 12 D
-4 -8 D
--6 21 D
-6 15 D
--4 18 D
-8 7 D
--3 12 D
-12 48 D
--4 6 D
--4 -30 D
--10 -1 D
--4 39 D
-4 5 D
--8 14 D
--4 -5 D
-4 12 D
--6 -5 D
-0 12 D
--13 0 D
--4 14 D
--17 12 D
--5 -19 D
--10 11 D
-5 9 D
--8 4 D
-7 2 D
-1 16 D
--7 10 D
--8 -6 D
-5 8 D
--6 2 D
-16 -4 D
-11 25 D
-2 17 D
--11 6 D
-6 3 D
--8 8 D
-6 8 D
--15 0 D
-7 10 D
--12 13 D
--6 -12 D
--3 19 D
--6 -13 D
-3 17 D
--9 8 D
--6 -5 D
-5 -7 D
--12 9 D
-2 -17 D
--6 16 D
-3 25 D
--10 -1 D
-0 -13 D
--9 -1 D
-2 11 D
--11 -2 D
-20 23 D
--21 17 D
--15 -9 D
--35 28 D
--12 29 D
--200 -54 D
-19 -80 D
-18 -106 D
-8 -95 D
-2 -70 D
--1 -69 D
--4 -57 D
-P
-3586 2130 M
-11 4 D
-3 -12 D
-P
-3573 1994 M
-6 -2 D
-P
-FO
-3688 2302 M
--7 2 D
-5 -17 D
-8 -13 D
-P
-FO
-3662 2409 M
--1 -15 D
-8 -9 D
--6 24 D
-P
-FO
-3694 2072 M
--4 5 D
-6 14 D
--13 -19 D
-10 -17 D
-P
-FO
-3648 1908 M
--4 3 D
--2 -19 D
-13 7 D
-P
-FO
-3684 2101 M
-2 -19 D
-7 10 D
-P
-FO
-3692 1915 M
-2 -7 D
-P
-FO
-3594 1831 M
-1 -17 D
-0 17 D
-P
-FO
-3669 2315 M
-10 -9 D
-P
-FO
-3666 2356 M
-4 -9 D
-P
-FO
-3703 2024 M
--6 0 D
-P
-FO
-3686 1928 M
-5 -6 D
-P
-FO
-3696 1905 M
-8 -9 D
-P
-FO
-3261 1516 M
-24 -16 D
-32 5 D
-25 -12 D
-48 23 D
-17 22 D
-23 -3 D
--6 2 D
-15 13 D
--11 2 D
-7 5 D
--2 6 D
-50 11 D
-42 62 D
-39 2 D
-11 14 D
-29 -4 D
-19 22 D
--1 22 D
-30 2 D
-44 25 D
--4 13 D
--18 4 D
--9 16 D
--2 -12 D
--22 18 D
--23 -3 D
--46 36 D
-3 17 D
--249 22 D
--10 -86 D
--16 -85 D
--17 -72 D
-P
-FO
-3654 1460 M
--5 -4 D
-P
-FO
-3681 1562 M
--3 -2 D
--19 -60 D
--10 -12 D
-3 -22 D
-9 25 D
-3 3 D
-P
-FO
-3353 1494 M
--7 0 D
-19 -11 D
-P
-FO
-3318 1496 M
--6 0 D
-P
-FO
-3611 1405 M
--10 -16 D
-P
-FO
-3306 1499 M
-5 -3 D
-P
-FO
-3630 1420 M
--4 -11 D
-P
-FO
-3112 788 M
-1 3 D
-P
-FO
-3122 778 M
-22 39 D
--29 -30 D
-5 -4 D
-5 13 D
-P
-FO
-3353 1061 M
-2 6 D
--11 -2 D
+2839 416 M
+7 0 D
 -6 -8 D
-P
-FO
-3124 830 M
-19 1 D
-9 28 D
--17 -10 D
-P
-FO
-3381 1070 M
--13 2 D
--6 -13 D
-25 7 D
-P
-FO
-3517 1152 M
--6 -11 D
-26 26 D
-P
-FO
-3281 1053 M
--6 -7 D
-8 1 D
-P
-FO
-3254 1135 M
-80 48 D
--35 -10 D
--45 -37 D
-P
-FO
-3340 1040 M
-9 -5 D
-P
-FO
-3330 1050 M
--8 -7 D
-P
-FO
-3121 858 M
--8 -11 D
-P
-FO
-3354 1038 M
-2 9 D
-P
-FO
-3379 1043 M
--1 -6 D
-P
-FO
-3289 1130 M
-3 -6 D
-P
-FO
-3271 1113 M
-9 4 D
--10 -4 D
-P
-FO
-3313 1060 M
--7 -11 D
-P
-FO
-3340 1047 M
--7 -6 D
-P
-FO
-3251 1105 M
-7 2 D
-P
-FO
-3269 1054 M
--7 -3 D
-P
-FO
-3458 1044 M
-4 8 D
-P
-FO
-3122 778 M
-0 -1 D
-P
-FO
-3112 788 M
-0 -6 D
-P
-FO
-2969 590 M
--10 -6 D
-17 9 D
-P
-FO
-2998 601 M
--17 -10 D
-P
-FO
-2961 760 M
--7 -5 D
-P
-FO
-2942 578 M
--6 -6 D
-P
-FO
-2362 372 M
--15 2 D
-P
-FO
-2258 319 M
--6 4 D
-P
-FO
-2119 338 M
--5 2 D
-P
-FO
-466 979 M
-11 27 D
-10 58 D
-11 0 D
-5 19 D
-1 27 D
--19 111 D
-6 39 D
-26 18 D
-24 13 D
-44 4 D
-32 21 D
-77 7 D
-16 15 D
-2 -1 D
--41 91 D
--30 81 D
--25 84 D
--379 -102 D
-23 -80 D
-36 -101 D
-25 -62 D
-42 -90 D
-55 -102 D
-26 -43 D
-P
-428 1256 M
-4 32 D
-9 -5 D
--6 -9 D
-6 -5 D
-1 -23 D
--11 0 D
-P
-466 1353 M
--6 -13 D
--13 0 D
-P
-337 1395 M
-3 3 D
-P
-366 1314 M
-6 1 D
-P
-342 1347 M
--4 -4 D
-P
-349 1336 M
-0 -1 D
--4 0 D
-P
-FO
-614 1601 M
--15 -3 D
--7 3 D
--34 5 D
--7 12 D
--10 64 D
-17 -75 D
-44 -7 D
-11 3 D
--13 55 D
--15 78 D
--11 91 D
--15 9 D
--17 21 D
--29 6 D
--17 -10 D
--16 11 D
--3 -10 D
-1 13 D
--17 16 D
--17 31 D
--1 25 D
--18 27 D
-3 22 D
--8 13 D
-7 1 D
-1 27 D
--9 2 D
--9 27 D
--10 -2 D
--29 32 D
--188 17 D
--6 -106 D
-1 -130 D
-7 -90 D
-9 -81 D
-17 -96 D
-16 -72 D
-10 -39 D
-379 102 D
-P
-397 1935 M
--5 -11 D
-3 -6 D
--5 6 D
--10 -10 D
--2 21 D
-4 -1 D
-7 10 D
--9 -17 D
-3 -9 D
-P
-348 1947 M
--1 -9 D
--9 6 D
-2 -9 D
--9 7 D
-13 12 D
-P
-423 1866 M
-1 0 D
--5 -11 D
-P
-570 1651 M
--4 6 D
-P
-435 1837 M
--1 17 D
-6 0 D
-P
-397 1965 M
--5 -4 D
-P
-566 1829 M
--5 5 D
-5 -4 D
-P
-379 1906 M
--6 -13 D
-P
-FO
-525 1861 M
--8 3 D
-P
-FO
-444 1938 M
--2 6 D
-P
-FO
-430 1966 M
-0 8 D
-P
-FO
-371 2088 M
--6 6 D
--23 5 D
--12 17 D
--91 18 D
--4 6 D
-9 5 D
--5 13 D
--41 65 D
--11 -83 D
--4 -35 D
-P
-FO
-1305 3172 M
-38 -21 D
-11 -14 D
--7 -11 D
-25 -22 D
-6 8 D
-31 -2 D
--43 92 D
-P
-FO
-1472 3246 M
-6 -3 D
--6 3 D
--62 -25 D
--44 -19 D
-43 -92 D
-46 39 D
-49 15 D
-43 29 D
-53 65 D
-14 32 D
--82 -23 D
-P
-1494 3241 M
-7 1 D
-P
-FO
-1819 2956 M
-6 2 D
--6 -1 D
-P
-FO
-2337 2820 M
-7 3 D
-12 -11 D
--6 11 D
-12 -7 D
-4 6 D
--18 4 D
-6 5 D
--10 1 D
-2 10 D
-P
-FO
-3248 2423 M
--10 -5 D
--22 -29 D
--28 -5 D
--10 13 D
--15 -9 D
--3 -36 D
-7 -29 D
-37 -35 D
-0 -2 D
-80 21 D
--29 97 D
-P
-FO
-3204 2286 M
-19 -78 D
-22 -12 D
-22 -36 D
-31 -119 D
--19 -72 D
--9 3 D
--5 -15 D
--31 -19 D
-1 9 D
--9 -18 D
-10 0 D
-31 -43 D
-11 0 D
--23 -4 D
--12 13 D
--16 0 D
-0 10 D
--8 4 D
-3 -20 D
-20 -9 D
--15 -10 D
--16 12 D
-1 -18 D
--10 -13 D
--8 -4 D
-3 2 D
--22 -1 D
--6 -5 D
-157 -13 D
-4 69 D
-1 89 D
--6 95 D
--9 69 D
--14 81 D
--18 74 D
-P
-FO
-3203 1906 M
-4 -25 D
-2 34 D
-P
-FO
-3169 1843 M
--14 -11 D
--25 -60 D
-17 -31 D
--7 -3 D
--2 10 D
--2 -18 D
--6 4 D
--13 -17 D
-7 0 D
-9 -39 D
--2 11 D
-4 -5 D
--4 -50 D
-36 -14 D
-9 -18 D
-6 4 D
-24 -21 D
-12 -36 D
-7 3 D
-17 -23 D
-19 -13 D
-22 71 D
-20 84 D
-15 85 D
-8 74 D
-P
-3142 1774 M
-5 -2 D
-P
-3230 1626 M
-7 -4 D
-P
-3172 1688 M
-6 0 D
-P
-FO
-3025 1741 M
--10 -15 D
-18 -10 D
--14 -13 D
-27 -10 D
--6 -2 D
-32 -2 D
--5 32 D
-20 35 D
--16 2 D
--23 -13 D
-5 7 D
--10 0 D
-P
-3031 1735 M
-6 4 D
-P
-FO
-3086 1688 M
--4 -6 D
-13 5 D
-P
-FO
-3019 1721 M
-7 -7 D
-P
-FO
-3103 1765 M
-10 2 D
-P
-FO
-2829 1214 M
--1 9 D
--13 -5 D
--3 -16 D
-18 -46 D
--12 -16 D
-15 -29 D
-11 6 D
-4 21 D
-21 12 D
-27 -8 D
--13 9 D
-18 10 D
-6 -10 D
-16 2 D
-11 -9 D
-0 6 D
-20 5 D
--2 5 D
-13 -4 D
-5 7 D
--52 2 D
-8 -3 D
--12 -7 D
--6 7 D
-7 2 D
--14 2 D
--6 -7 D
-5 7 D
--18 3 D
--12 20 D
-3 20 D
--28 -12 D
-P
-2852 1172 M
-0 -8 D
-P
-FO
-2794 1359 M
--1 -16 D
-27 -33 D
--8 -15 D
-13 4 D
--13 -4 D
--9 -13 D
-9 3 D
-7 -9 D
-6 -41 D
-8 -8 D
-4 7 D
-0 -10 D
-8 22 D
-19 -1 D
--2 -7 D
-5 18 D
--24 51 D
-1 35 D
-8 14 D
--7 35 D
--8 1 D
-6 4 D
--15 12 D
--9 -15 D
--23 -14 D
-P
-2838 1346 M
--7 6 D
-8 2 D
-P
-2834 1343 M
--3 6 D
-P
-2829 1396 M
--5 1 D
-P
-2837 1364 M
--14 2 D
-P
-2838 1316 M
--14 17 D
-P
-2838 1324 M
--8 6 D
-P
-2837 1310 M
--11 -1 D
-P
-FO
-2798 1399 M
-10 -2 D
--8 12 D
-P
-FO
-2903 1141 M
--5 -2 D
-P
-FO
-2845 1231 M
-2 -6 D
-P
-FO
-2668 1143 M
--2 -10 D
-8 8 D
-P
-FO
-1130 1479 M
--7 5 D
--21 -18 D
-16 6 D
-3 -10 D
-8 13 D
--15 1 D
-P
-FO
-1117 1502 M
--35 71 D
--3 -6 D
-3 6 D
--3 9 D
--23 -3 D
--35 19 D
--15 -5 D
-3 -19 D
--14 -22 D
--21 5 D
--16 22 D
--28 -7 D
--21 13 D
--2 -14 D
--7 9 D
-6 9 D
--9 7 D
--10 -7 D
-12 -11 D
--4 -13 D
--28 -9 D
-1 26 D
--14 25 D
--34 -9 D
-0 6 D
--11 -10 D
--2 26 D
--10 21 D
--158 -42 D
-21 -11 D
-23 12 D
--25 -14 D
--20 12 D
--22 -5 D
-25 -84 D
-21 -58 D
-34 -80 D
-16 -34 D
-15 -2 D
-56 30 D
-82 4 D
-9 -7 D
-36 30 D
-37 3 D
-6 14 D
-6 -3 D
--13 12 D
--1 7 D
--6 3 D
-15 -5 D
-1 12 D
-7 1 D
-0 -8 D
-3 9 D
-1 -7 D
-20 5 D
-5 11 D
-11 -6 D
-0 16 D
-22 -9 D
--2 14 D
-7 -11 D
-7 2 D
--6 6 D
-21 1 D
--5 -8 D
-6 -8 D
--5 7 D
-2 -6 D
--8 0 D
-8 -3 D
--2 -7 D
-4 -5 D
--1 10 D
-9 -1 D
-14 -7 D
-1 7 D
--3 -6 D
--11 7 D
-7 4 D
--6 10 D
-6 9 D
-10 -6 D
--4 9 D
-11 -10 D
--11 15 D
-4 11 D
-2 -8 D
-5 9 D
-5 -22 D
-1 16 D
-8 -6 D
-0 7 D
-16 2 D
--7 3 D
-7 11 D
-4 -10 D
-5 7 D
-P
-1094 1494 M
--11 -5 D
-6 9 D
--8 -3 D
-11 13 D
-P
-1055 1476 M
--13 -3 D
--12 26 D
-10 -18 D
-P
-653 1535 M
--3 -8 D
--7 17 D
-P
-921 1432 M
-2 13 D
-6 -9 D
-P
-943 1416 M
--7 -2 D
-2 8 D
-P
-995 1530 M
--7 -7 D
-P
-1002 1474 M
-2 -6 D
-P
-1082 1522 M
--6 -2 D
-P
-915 1416 M
-5 -3 D
-P
-997 1520 M
--8 -1 D
-P
-1054 1442 M
--2 7 D
-9 -2 D
-P
-1053 1491 M
-2 -6 D
-P
-933 1429 M
-1 -6 D
-P
-983 1468 M
-1 -7 D
-P
-904 1412 M
-3 4 D
-P
-978 1449 M
--2 -6 D
-P
-849 1405 M
-5 4 D
-P
-915 1433 M
-1 6 D
-P
-898 1430 M
-4 -5 D
-P
-909 1409 M
-0 7 D
-P
-1105 1515 M
-0 -15 D
-P
-FO
-993 1420 M
--9 6 D
--26 -16 D
-5 -8 D
-11 2 D
-21 7 D
-P
-FO
-1012 1451 M
--9 -4 D
-10 -5 D
-P
-FO
-1103 1461 M
--3 9 D
--8 -10 D
-P
-FO
-1129 1465 M
-1 9 D
-P
-FO
-1116 1458 M
--3 6 D
-P
-FO
-1112 1466 M
-4 5 D
-P
-FO
-1035 1447 M
--5 2 D
-P
-FO
-1016 1434 M
--1 7 D
-P
-FO
-1043 1450 M
-3 4 D
-P
-FO
-1020 1422 M
--4 6 D
-P
-FO
-1091 1462 M
-3 4 D
-P
-FO
-1112 1464 M
--3 -5 D
-P
-FO
-1090 1446 M
--2 6 D
-P
-FO
-1029 1439 M
--6 1 D
-P
-FO
-1094 1456 M
-7 4 D
-P
-FO
-1019 1434 M
-2 -8 D
-P
-FO
-1107 1450 M
--1 7 D
-P
-FO
-1043 1437 M
--6 -1 D
-P
-FO
-613 1603 M
-13 3 D
-13 -7 D
-158 42 D
--14 29 D
--13 17 D
--30 13 D
--11 -4 D
--5 -15 D
--15 1 D
--11 -34 D
--29 -4 D
-18 4 D
-8 16 D
-2 39 D
--14 43 D
--39 30 D
--27 4 D
--33 24 D
--7 -6 D
-8 19 D
-39 -32 D
--24 28 D
--26 14 D
-13 -102 D
-15 -78 D
-P
-659 1756 M
--11 -3 D
--22 19 D
-14 0 D
-1 -9 D
-P
-657 1680 M
--16 28 D
-11 -14 D
-3 4 D
-P
-656 1765 M
--17 11 D
-P
-FO
-638 1598 M
--9 6 D
--15 -3 D
-2 -8 D
-P
-FO
-5 3 1 621 1602 SP
-1611 2291 M
--8 6 D
-7 -7 D
-P
-FO
-1620 2300 M
--7 -3 D
-1 -3 D
-P
-FO
-1646 2322 M
--1 0 D
-P
-FO
-1683 2350 M
--21 -11 D
--1 -5 D
-P
-FO
-1744 2392 M
--4 -10 D
--14 3 D
--14 -13 D
--10 5 D
--7 -19 D
-32 18 D
-20 10 D
-P
-FO
-1762 2393 M
--18 -1 D
-3 -6 D
-P
-FO
-1896 2428 M
--12 5 D
-6 11 D
--7 -10 D
--34 19 D
--52 -47 D
-41 12 D
-P
-FO
-1906 2457 M
--2 0 D
--5 -29 D
-9 1 D
-P
-FO
-2090 2473 M
--8 2 D
--18 14 D
-5 11 D
--13 15 D
--18 8 D
--34 -8 D
-2 -21 D
--15 11 D
--9 -5 D
-8 -8 D
--8 -5 D
--18 8 D
--2 -9 D
--56 -29 D
-2 -28 D
-53 2 D
-53 -4 D
-52 -10 D
-8 -3 D
-P
-FO
-2252 2382 M
--11 2 D
--18 -11 D
--33 0 D
--6 4 D
-9 6 D
--4 21 D
--20 8 D
-3 24 D
--82 37 D
--16 -59 D
-26 -7 D
-49 -19 D
-40 -20 D
-37 -24 D
-P
-FO
-2365 2723 M
-7 -6 D
-P
-FO
-2427 2284 M
--12 16 D
-4 24 D
--11 3 D
--17 -14 D
--16 2 D
--13 20 D
--22 11 D
--17 33 D
--20 6 D
--1 -8 D
--26 10 D
--11 -8 D
--13 3 D
--26 -38 D
-35 -27 D
-38 -36 D
-29 -34 D
-16 -21 D
-P
-FO
-2485 2093 M
--8 22 D
-2 33 D
-11 18 D
--15 18 D
--11 -2 D
--18 12 D
--3 54 D
-10 4 D
-2 15 D
--17 -7 D
-1 21 D
--11 1 D
--1 2 D
--83 -58 D
-28 -45 D
-23 -48 D
-17 -50 D
-2 -9 D
-P
-FO
-2507 1901 M
-19 52 D
--5 43 D
--23 14 D
-15 26 D
--13 12 D
-4 6 D
--11 16 D
-6 6 D
--12 11 D
--2 6 D
--71 -19 D
-7 -25 D
-8 -53 D
-2 -61 D
--2 -27 D
-P
-FO
-2394 1743 M
-3 1 D
-27 30 D
-20 7 D
--2 24 D
-8 2 D
-8 28 D
-23 19 D
-18 -13 D
--10 17 D
-11 10 D
--3 10 D
-10 23 D
--78 7 D
--6 -44 D
--7 -34 D
--16 -51 D
--14 -32 D
-P
-FO
-2384 1742 M
-10 1 D
--8 4 D
-P
-FO
-2744 1473 M
-5 -7 D
-P
-FO
-1530 1716 M
--3 -8 D
-8 -5 D
-1 2 D
-P
-FO
-1509 1758 M
--19 -27 D
-9 -11 D
-14 10 D
-0 -11 D
-14 3 D
--7 12 D
-P
-FO
-1488 1816 M
--13 -7 D
--62 -3 D
--19 -10 D
--9 -21 D
--10 8 D
-0 13 D
--3 -1 D
--4 -9 D
--8 6 D
--16 -4 D
-8 -9 D
-32 -14 D
-0 -8 D
-12 5 D
-19 -14 D
-12 4 D
-2 -8 D
-15 7 D
--3 -12 D
-23 18 D
-24 5 D
-9 -12 D
-12 8 D
--14 36 D
-P
-FO
-1066 1713 M
-2 -10 D
-6 12 D
-1 -10 D
-0 8 D
-11 -11 D
--6 15 D
-P
-FO
-1082 1573 M
-2 3 D
--5 6 D
-P
-FO
-1117 1502 M
--7 20 D
-12 -13 D
-6 4 D
--11 -11 D
-6 -12 D
-4 7 D
-5 -13 D
--2 12 D
-10 4 D
--13 2 D
-4 6 D
-12 -10 D
--1 10 D
-12 2 D
-4 12 D
--8 -4 D
-7 7 D
--8 -8 D
--2 13 D
-0 -15 D
--10 4 D
-9 1 D
-1 12 D
-17 1 D
--12 -3 D
-10 1 D
--6 -3 D
-5 -11 D
-15 9 D
--12 8 D
-14 -1 D
--2 6 D
--11 -5 D
--9 19 D
-10 9 D
-13 -4 D
--7 -2 D
-7 -7 D
-2 21 D
--26 -6 D
--22 18 D
--3 14 D
--11 -15 D
-4 -9 D
--5 8 D
--7 -11 D
--26 7 D
--3 -3 D
-P
-FO
-1130 1479 M
-P
-FO
-1177 1642 M
--16 19 D
--3 -43 D
--21 -26 D
-16 -21 D
-12 6 D
--6 16 D
-18 -5 D
-2 19 D
-7 -3 D
--7 -5 D
-7 -2 D
--3 -20 D
-5 16 D
-5 -8 D
--6 -4 D
-14 -12 D
-P
-1168 1603 M
-5 -2 D
-P
-1170 1630 M
-8 -21 D
-P
-FO
-1198 1599 M
-5 12 D
--5 -4 D
--4 8 D
-6 2 D
--2 14 D
--6 -20 D
--7 7 D
-P
-FO
-1197 1550 M
--12 8 D
--2 -17 D
-10 -5 D
-4 12 D
--7 4 D
-P
-FO
-1179 1540 M
-2 10 D
--5 -5 D
--16 10 D
-7 -16 D
-P
-FO
-1181 1577 M
-0 11 D
--12 -10 D
-P
-FO
-1188 1578 M
--4 -12 D
-7 3 D
-P
-FO
-1133 1478 M
-2 -6 D
-7 5 D
-P
-FO
-1148 1492 M
--1 6 D
--5 -8 D
-P
-FO
-1185 1526 M
--2 15 D
-0 -29 D
-P
-FO
-1171 1500 M
--10 -3 D
-P
-FO
-1185 1622 M
--3 17 D
-P
-FO
-1193 1564 M
--9 -2 D
-P
-FO
-1138 1487 M
-3 12 D
-P
-FO
-1202 1585 M
--2 11 D
-P
-FO
-1196 1599 M
--6 10 D
-5 -10 D
-P
-FO
-1148 1477 M
--7 5 D
-P
-FO
-1157 1677 M
-6 -9 D
-P
-FO
-1158 1493 M
-0 -1 D
-7 0 D
-P
-FO
-1161 1503 M
-2 9 D
--3 -9 D
-P
-FO
-1166 1515 M
-3 7 D
--4 -7 D
-P
-FO
-1201 1584 M
-2 -6 D
-P
-FO
-1179 1526 M
--3 7 D
-P
-FO
-1198 1587 M
--3 5 D
-P
-FO
-1168 1509 M
--1 6 D
-P
-FO
-1370 1763 M
--6 -7 D
-14 -6 D
-P
-FO
-1315 1780 M
-5 -13 D
-1 11 D
-P
-FO
-1080 1717 M
--16 9 D
-2 -13 D
-P
-FO
-1360 1792 M
--6 4 D
-4 8 D
--20 2 D
--7 15 D
--8 -8 D
-21 -25 D
-P
-FO
-1375 1796 M
-0 6 D
--3 -7 D
-P
-FO
-1077 1732 M
--2 7 D
--4 -7 D
--7 18 D
--6 -4 D
-8 -5 D
--7 -13 D
-13 3 D
-10 -9 D
-3 7 D
-P
-FO
-1063 1715 M
-0 7 D
-P
-FO
-1341 1807 M
-12 3 D
--3 9 D
--7 0 D
-P
-FO
-1320 1826 M
-7 -2 D
--6 14 D
-P
-FO
-1124 2081 M
--17 -7 D
--5 -20 D
-P
-FO
-1603 2297 M
--3 -17 D
-4 3 D
-6 7 D
-P
-FO
-1695 2358 M
-0 -3 D
--12 -5 D
--22 -16 D
--1 -7 D
--15 -5 D
--6 -14 D
--19 -8 D
--6 -6 D
-0 -4 D
--3 1 D
--1 -1 D
-340 -340 D
--203 436 D
--33 -17 D
-P
-FO
-1899 2428 M
--1 -1 D
--2 1 D
--42 -7 D
--49 -12 D
--8 -3 D
--12 -13 D
--23 0 D
--15 -7 D
-203 -436 D
--42 479 D
-P
-FO
-1950 1950 M
-124 464 D
--25 7 D
--53 8 D
--61 2 D
--27 -2 D
-P
-FO
-1950 1950 M
-276 394 D
--45 28 D
--48 23 D
--50 17 D
--9 2 D
-P
-FO
-1950 1950 M
-394 276 D
--27 35 D
--36 38 D
--34 29 D
--21 16 D
-P
-FO
-1950 1950 M
-464 124 D
--7 26 D
--19 49 D
--20 40 D
--24 37 D
-P
-FO
-1950 1950 M
-479 -42 D
-2 53 D
--4 53 D
--10 52 D
--3 8 D
-P
-FO
-1950 1950 M
-436 -203 D
-17 41 D
-17 59 D
-7 44 D
-2 17 D
-P
-FO
-2158 1742 M
-55 45 D
--15 9 D
-2 13 D
-30 -3 D
-30 -18 D
--9 -18 D
-15 15 D
-8 -15 D
--5 -7 D
-14 -4 D
--5 -8 D
-9 -8 D
--7 -17 D
-22 -20 D
-2 -13 D
-13 -3 D
--7 6 D
-37 9 D
-28 37 D
-9 0 D
-2 5 D
--436 203 D
-P
-FO
-2071 1689 M
-9 19 D
-57 30 D
-17 2 D
-4 2 D
--208 208 D
-P
-FO
-1981 1599 M
-5 4 D
-29 0 D
-15 13 D
-8 43 D
-35 4 D
--6 19 D
-4 7 D
--121 261 D
-P
-FO
-1849 1573 M
-15 -7 D
-12 2 D
-19 -17 D
-10 24 D
-48 3 D
-28 21 D
--31 351 D
-P
-FO
-1700 1592 M
-26 -6 D
-11 19 D
--5 17 D
-8 -7 D
--1 18 D
-10 2 D
--4 9 D
-8 5 D
-22 -23 D
-16 6 D
-2 -28 D
-19 -17 D
-9 3 D
-28 -17 D
-101 377 D
-P
-FO
-1616 1716 M
-0 -5 D
-24 4 D
-11 -63 D
-9 1 D
-15 -21 D
-1 -23 D
-14 -14 D
-10 -3 D
-250 358 D
-P
-FO
-1606 1858 M
--6 -13 D
--54 -3 D
--17 -5 D
--41 -21 D
-18 -51 D
-3 -7 D
-2 2 D
--2 -2 D
-14 -30 D
-4 -6 D
-7 2 D
--4 -8 D
-6 -11 D
-4 18 D
-22 -11 D
--18 19 D
-10 6 D
-19 -8 D
--1 23 D
+22 10 D
+4 -8 D
 17 12 D
-7 -52 D
-15 7 D
--7 12 D
-6 3 D
-8 -6 D
--2 -12 D
-334 234 D
-P
-FO
-1664 1975 M
--8 -44 D
--18 -10 D
--2 -14 D
--30 -49 D
-344 92 D
-P
-FO
-1552 1843 M
--10 0 D
--13 -6 D
-P
-FO
-1582 2122 M
-19 -24 D
--14 -8 D
-1 -13 D
-25 -6 D
-6 -18 D
-13 3 D
-18 -46 D
-20 -16 D
--6 -19 D
-286 -25 D
-P
-FO
-1600 2280 M
--2 -18 D
--26 -35 D
-0 -34 D
-11 -13 D
--8 -48 D
-7 -10 D
-368 -172 D
--340 340 D
--6 -7 D
-P
-FO
-25 W
-4 W
-1865 2035 M
--1294 1294 D
-S
-2035 2035 M
-1294 1294 D
-S
-2035 1865 M
-1294 -1294 D
-S
-1865 1865 M
--1294 -1294 D
-S
-1950 1950 M
--85 85 D
-S
-1950 1950 M
-85 85 D
-S
-1950 1950 M
-85 -85 D
-S
-1950 1950 M
--85 -85 D
-S
-1865 2035 M
-3 4 D
-11 9 D
-13 8 D
-20 9 D
-26 5 D
-19 1 D
-26 -5 D
-23 -9 D
-16 -10 D
-8 -6 D
-1 -2 D
-6 -5 D
-1 -2 D
-4 -3 D
-16 -24 D
-8 -21 D
-4 -21 D
-1 -22 D
--5 -26 D
--7 -18 D
--13 -21 D
--15 -16 D
--19 -14 D
--16 -8 D
--25 -7 D
--22 -2 D
--22 2 D
--25 8 D
--17 9 D
--16 12 D
--1 2 D
--6 5 D
--1 2 D
--2 1 D
--15 22 D
--9 22 D
--5 22 D
--1 22 D
-5 26 D
-11 27 D
-11 15 D
-7 8 D
-P S
-1950 1950 M
-0 0 D
-P S
-571 3329 M
-49 47 D
-29 27 D
-67 57 D
-54 43 D
-79 57 D
-91 58 D
-85 49 D
-87 44 D
-89 40 D
-101 38 D
-74 25 D
-66 19 D
-105 25 D
-96 18 D
-126 16 D
-88 6 D
-88 2 D
-78 -1 D
-79 -5 D
-68 -6 D
-116 -17 D
-96 -19 D
-104 -27 D
-94 -29 D
-100 -38 D
-55 -23 D
-71 -33 D
-78 -40 D
-101 -59 D
-82 -54 D
-94 -70 D
-38 -31 D
-66 -58 D
-64 -61 D
-47 -49 D
-27 -29 D
-57 -67 D
-43 -54 D
-57 -79 D
-58 -91 D
-49 -85 D
-44 -87 D
-40 -89 D
-38 -101 D
-25 -74 D
-19 -66 D
-25 -105 D
-18 -96 D
-16 -126 D
-6 -88 D
-2 -88 D
--1 -78 D
--5 -79 D
--6 -68 D
--17 -116 D
--19 -96 D
--27 -104 D
--29 -94 D
--38 -100 D
--23 -55 D
--33 -71 D
--40 -78 D
--59 -101 D
--54 -82 D
--70 -94 D
--31 -38 D
--58 -66 D
--61 -64 D
--49 -47 D
--29 -27 D
--67 -57 D
--54 -43 D
--79 -57 D
--91 -58 D
--85 -49 D
--87 -44 D
--89 -40 D
--101 -38 D
--74 -25 D
--66 -19 D
--105 -25 D
--96 -18 D
--126 -16 D
--88 -6 D
--88 -2 D
--78 1 D
--79 5 D
--68 6 D
--116 17 D
--96 19 D
--104 27 D
--94 29 D
--100 38 D
--55 23 D
--71 33 D
--78 40 D
--101 59 D
--82 54 D
--94 70 D
--38 31 D
--66 58 D
--64 61 D
--47 49 D
--27 29 D
--57 67 D
--43 54 D
--57 79 D
--58 91 D
--49 85 D
--44 87 D
--40 89 D
--38 101 D
--25 74 D
--19 66 D
--25 105 D
--18 96 D
--16 126 D
--6 88 D
--2 88 D
-1 78 D
-5 79 D
-6 68 D
-17 116 D
-19 96 D
-27 104 D
-29 94 D
-38 100 D
-23 55 D
-33 71 D
-40 78 D
-59 101 D
-54 82 D
-70 94 D
-31 38 D
-58 66 D
-P S
-8 W
-N 571 3329 M -59 59 D S
-N 571 3329 M -59 59 D S
-25 W
-571 3329 M
--47 -49 D
--27 -29 D
--57 -67 D
--43 -54 D
--57 -79 D
--58 -91 D
--49 -85 D
--44 -87 D
--40 -89 D
--38 -101 D
--25 -74 D
--19 -66 D
--25 -105 D
--18 -96 D
--16 -126 D
--6 -88 D
--2 -88 D
-1 -78 D
-5 -79 D
-6 -68 D
-17 -116 D
-19 -96 D
-27 -104 D
-29 -94 D
-38 -100 D
-23 -55 D
-33 -71 D
-40 -78 D
-59 -101 D
-54 -82 D
-70 -94 D
-31 -38 D
-58 -66 D
-61 -64 D
-49 -47 D
-29 -27 D
-67 -57 D
-54 -43 D
-79 -57 D
-91 -58 D
-85 -49 D
-87 -44 D
-89 -40 D
-101 -38 D
-74 -25 D
-66 -19 D
-105 -25 D
-96 -18 D
-126 -16 D
-88 -6 D
-88 -2 D
-78 1 D
-79 5 D
-68 6 D
-116 17 D
-96 19 D
-104 27 D
-94 29 D
-100 38 D
-55 23 D
-71 33 D
-78 40 D
-101 59 D
-82 54 D
-94 70 D
-38 31 D
-66 58 D
-64 61 D
-47 49 D
-27 29 D
-57 67 D
-43 54 D
-57 79 D
-58 91 D
-49 85 D
-44 87 D
-40 89 D
-38 101 D
-25 74 D
-19 66 D
-25 105 D
-18 96 D
-16 126 D
-6 88 D
-2 88 D
--1 78 D
--5 79 D
--6 68 D
--17 116 D
--19 96 D
--27 104 D
--29 94 D
--38 100 D
--23 55 D
--33 71 D
--40 78 D
--59 101 D
--54 82 D
--70 94 D
--31 38 D
--58 66 D
--61 64 D
--49 47 D
--29 27 D
--67 57 D
--54 43 D
--79 57 D
--91 58 D
--85 49 D
--87 44 D
--89 40 D
--101 38 D
--74 25 D
--66 19 D
--105 25 D
--96 18 D
--126 16 D
--88 6 D
--88 2 D
--78 -1 D
--79 -5 D
--68 -6 D
--116 -17 D
--96 -19 D
--104 -27 D
--94 -29 D
--100 -38 D
--55 -23 D
--71 -33 D
--78 -40 D
--101 -59 D
--82 -54 D
--94 -70 D
--38 -31 D
--66 -58 D
-P S
-453 3447 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V 45 R (0ö) bc Z U
-%%EndObject
-0 A
-FQ
-O0
--4980 4980 TM
-
-% PostScript produced by:
-%@GMT: pscoast -R0/360/-90/0 -JA180/-90/3.25i -Bg90a360f360 -Gred -Dc -X-4.15i -Y4.15i -O -K -p0
-1950 1950 T
--1950 -1950 T
-%@PROJ: laea 0.00000000 360.00000000 -90.00000000 0.00000000 -9009964.761 9009964.761 -9009964.761 9009964.761 +proj=laea +lat_0=-90 +lon_0=180 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
-%%BeginObject PSL_Layer_5
-0 setlinecap
-0 setlinejoin
-3.32551 setmiterlimit
-1333 100 M
-82 13 D
-6 15 D
--2 -15 D
--60 -13 D
--5 -7 D
--2 1 D
-4 6 D
--8 -5 D
-103 -30 D
-104 -25 D
-81 -14 D
-6 11 D
-15 -3 D
--26 34 D
--62 48 D
--9 25 D
--15 8 D
-13 0 D
--26 47 D
-15 10 D
--8 19 D
--85 22 D
--90 29 D
--21 8 D
--60 -166 D
-P
-1356 141 M
--1 -17 D
--16 2 D
-10 4 D
--9 6 D
-P
-1348 113 M
-9 -9 D
-P
-1447 141 M
-9 -1 D
-P
-1605 47 M
+22 -8 D
+31 7 D
+13 -7 D
+-23 -17 D
+11 -4 D
+57 24 D
+5 -11 D
+45 9 D
+135 70 D
+-66 79 D
+-41 -6 D
+-25 -23 D
+-13 -4 D
+-13 -23 D
+36 14 D
+-38 -27 D
 11 1 D
--2 -5 D
-P
-1586 100 M
-8 -5 D
-P
-1535 149 M
-8 0 D
-P
-{1 0 0 C} FS
-FO
-959 479 M
--2 -5 D
--5 -1 D
--7 16 D
--65 47 D
--37 28 D
--26 21 D
--9 -32 D
--10 -3 D
-6 -4 D
--18 -5 D
-9 -29 D
+-14 -9 D
+13 -3 D
 -26 -10 D
--38 -5 D
--34 -41 D
-27 -23 D
-42 -33 D
-29 -21 D
-29 -21 D
-52 -36 D
-68 -43 D
-86 -48 D
-80 -41 D
-106 -47 D
-67 -25 D
-60 166 D
--43 16 D
--113 49 D
--69 35 D
--68 38 D
--72 45 D
+7 -3 D
+-7 0 D
+-2 -8 D
+-7 4 D
+-35 -18 D
+-60 3 D
+-20 -12 D
+-20 -13 D
 P
-946 319 M
--29 -22 D
--4 1 D
--56 37 D
--2 9 D
--15 5 D
--1 5 D
-24 -12 D
-12 12 D
-26 -6 D
--16 14 D
-15 -3 D
-13 -11 D
-1 8 D
-9 -2 D
--7 -6 D
-15 -15 D
-17 1 D
+3093 520 M
+-7 2 D
 P
-917 307 M
-0 -6 D
-1 6 D
+3158 477 M
+7 5 D
+-6 -5 D
 P
-941 326 M
-2 4 D
+FO
+2809 398 M
+10 0 D
+-10 0 D
 P
-1039 310 M
--15 -10 D
-3 48 D
-10 3 D
--17 25 D
-0 37 D
-17 -15 D
--2 -24 D
-16 -34 D
--19 -31 D
+FO
+2560 274 M
+10 0 D
+2 6 D
+-13 -3 D
+0 -2 D
+1 0 D
 P
-1105 381 M
--5 -7 D
--25 4 D
-18 8 D
-P
-1047 392 M
-22 -3 D
--11 -3 D
-P
-1030 279 M
--14 -10 D
--5 12 D
-P
-817 405 M
--4 -3 D
-P
-995 296 M
--3 5 D
-P
-976 428 M
--4 8 D
-P
-991 255 M
--12 7 D
-20 -2 D
-P
-978 426 M
-15 -12 D
--4 -7 D
-P
-876 401 M
--20 4 D
-18 -2 D
-P
-830 408 M
--6 -6 D
-P
-1147 338 M
+FO
+2843 335 M
+-25 -26 D
+8 -3 D
+-7 -18 D
 8 1 D
-P
-849 420 M
--7 -3 D
-P
-775 414 M
--9 3 D
+19 11 D
+-11 7 D
+17 22 D
+23 14 D
+4 -8 D
+2 11 D
+42 27 D
+-42 -11 D
 P
 FO
-779 523 M
--1 -5 D
+2728 281 M
+-19 3 D
+-12 -7 D
+46 -5 D
+P
+FO
+2803 275 M
+77 11 D
+-54 -8 D
+-25 11 D
+P
+FO
+2646 279 M
+3 8 D
+-20 -2 D
+P
+FO
+2992 346 M
+-11 -10 D
+25 19 D
+P
+FO
+2598 262 M
+-30 -2 D
+51 -1 D
+P
+FO
+2932 378 M
 8 4 D
--5 11 D
+-10 0 D
 P
 FO
-796 554 M
--11 3 D
-P
-FO
-731 497 M
--9 -1 D
--26 11 D
-2 -9 D
--13 13 D
--64 12 D
-5 -4 D
-4 -5 D
-47 -41 D
-20 -17 D
-P
-FO
-412 887 M
--1 7 D
-P
-FO
-662 715 M
--7 7 D
-P
-FO
-26 2269 M
-13 18 D
--9 2 D
-P
-FO
-41 2250 M
-2 -12 D
-13 20 D
-P
-FO
-63 2266 M
-6 11 D
-P
-FO
-29 2230 M
--4 6 D
-P
-FO
-21 2235 M
-7 4 D
-P
-FO
-403 2843 M
--13 -30 D
-23 21 D
-1 3 D
-P
-FO
-392 2850 M
--1 -7 D
-4 5 D
--3 1 D
-P
-FO
-259 2921 M
-1 -2 D
--5 -6 D
-17 1 D
--6 -2 D
-1 -16 D
-12 -6 D
-3 -25 D
-15 -1 D
-9 16 D
-30 -19 D
-10 15 D
--85 49 D
-P
-FO
-39 2287 M
-7 10 D
-48 33 D
-53 69 D
-16 16 D
+2648 291 M
 -8 0 D
-10 19 D
--5 5 D
-12 12 D
--42 24 D
--19 -11 D
--8 -24 D
-4 -6 D
--7 8 D
--5 -13 D
--17 1 D
--14 -35 D
--9 14 D
--14 -60 D
--11 -60 D
-P
-FO
-245 2745 M
-5 45 D
--7 -4 D
-5 6 D
--8 14 D
--13 -10 D
--3 22 D
-6 4 D
-4 26 D
--14 2 D
--31 -63 D
--35 -77 D
--29 -72 D
--16 -44 D
-7 -8 D
-9 14 D
--5 -11 D
-9 11 D
-3 -9 D
-3 18 D
-33 -1 D
-15 45 D
-15 2 D
-4 38 D
-11 16 D
-5 -1 D
-10 28 D
-14 -4 D
-P
-206 2811 M
-3 9 D
-P
-188 2676 M
 3 -5 D
 P
 FO
-306 2682 M
-11 16 D
--18 2 D
--17 -37 D
--23 -11 D
--25 -42 D
-2 -22 D
--18 -44 D
--16 -16 D
--28 -67 D
-8 -11 D
-0 -19 D
-15 38 D
-6 -5 D
-20 42 D
-8 31 D
-29 52 D
+2662 272 M
+-17 -5 D
+39 1 D
 P
 FO
-131 2495 M
--5 7 D
--8 -17 D
--16 -4 D
--5 -23 D
-5 -8 D
-6 20 D
-13 3 D
-11 22 D
+2656 286 M
+-1 -6 D
+2 6 D
 P
 FO
-355 2763 M
-25 64 D
--28 -30 D
--1 -8 D
-16 13 D
--22 -30 D
--1 -13 D
+2831 398 M
+-17 -3 D
 P
 FO
-313 2714 M
--7 -14 D
-19 11 D
-1 21 D
+2903 298 M
+1 1 D
+-15 -6 D
 P
 FO
-148 2535 M
--5 11 D
--9 -18 D
-10 -5 D
-5 12 D
+2762 356 M
+16 6 D
 P
 FO
-83 2294 M
--5 -8 D
-11 7 D
-P
-FO
-335 2737 M
-11 15 D
--7 9 D
--8 -12 D
-P
-FO
-265 2657 M
-13 20 D
-3 20 D
-P
-FO
-71 2453 M
--9 -15 D
-3 -3 D
-P
-FO
-260 2776 M
--9 13 D
-P
-FO
-68 2428 M
-3 11 D
-P
-FO
-297 2731 M
-3 9 D
-P
-FO
-59 2402 M
-3 11 D
-P
-FO
-134 2339 M
-4 9 D
-P
-FO
-350 2782 M
-0 8 D
-P
-FO
-388 2837 M
-1 7 D
-P
-FO
-427 2858 M
--24 -15 D
-11 -6 D
-P
-FO
-488 2954 M
-28 88 D
--37 -57 D
--11 -48 D
-4 -7 D
-P
-FO
-721 3415 M
--62 -37 D
--15 -22 D
-5 -2 D
--18 -20 D
--4 -25 D
--12 -19 D
--23 0 D
-1 -9 D
--13 0 D
--24 15 D
--41 -35 D
--21 -35 D
-1 -15 D
-24 26 D
-18 -1 D
-35 42 D
-1 -14 D
--14 -7 D
--6 -17 D
--18 -18 D
-27 15 D
-11 -8 D
-10 16 D
--4 20 D
-3 -11 D
-12 4 D
-23 22 D
--5 -10 D
-18 9 D
-80 53 D
-3 -6 D
-7 8 D
-8 -8 D
-19 4 D
--8 -9 D
-19 12 D
--13 -13 D
-16 5 D
-4 -14 D
-22 25 D
-P
-FO
-346 2876 M
-7 13 D
--45 16 D
-5 19 D
-7 9 D
-9 -13 D
-20 15 D
-9 -8 D
-10 12 D
--4 6 D
-12 22 D
--24 -11 D
--1 12 D
--41 -22 D
-9 10 D
-15 62 D
--33 -53 D
-0 -21 D
--7 -11 D
--22 -12 D
--7 10 D
--4 -6 D
-P
-325 2944 M
-5 6 D
--2 -10 D
-P
-319 2941 M
-5 4 D
--5 -5 D
-P
-298 2928 M
-5 -2 D
-P
-FO
-395 2848 M
-28 43 D
-14 41 D
--6 -1 D
-0 -16 D
--14 -25 D
--24 -26 D
--1 -15 D
-P
-FO
-417 3147 M
--4 3 D
--8 -10 D
-4 -1 D
-26 14 D
-P
-FO
-455 3118 M
-5 -8 D
--2 13 D
-11 3 D
-29 38 D
-27 18 D
--23 -3 D
--29 -31 D
-P
-FO
-744 3290 M
-18 24 D
--2 10 D
--23 -19 D
--2 -23 D
-P
-FO
-382 2957 M
--5 4 D
--5 -11 D
-8 -9 D
-7 9 D
-P
-FO
-629 3239 M
-9 -14 D
-4 21 D
--13 7 D
--6 -13 D
-P
-FO
-383 2959 M
-9 -10 D
-3 19 D
--7 -7 D
--9 12 D
-P
-FO
-405 3126 M
-9 2 D
-8 12 D
--13 -4 D
-P
-FO
-473 2984 M
--2 5 D
--10 -15 D
-1 -7 D
-P
-FO
-434 3135 M
--10 -8 D
--2 -10 D
-17 20 D
-P
-FO
-418 3063 M
-21 12 D
-8 18 D
--16 -7 D
-P
-FO
-483 3225 M
-4 10 D
--23 -28 D
-P
-FO
-482 3009 M
-16 29 D
--18 -21 D
-P
-FO
-609 3338 M
-9 10 D
--31 -18 D
-P
-FO
-336 2998 M
-7 18 D
--13 -18 D
-P
-FO
-617 3330 M
-21 22 D
--38 -33 D
-P
-FO
-489 3189 M
--3 5 D
--11 -19 D
-P
-FO
-495 3215 M
--4 5 D
--8 -11 D
-P
-FO
-397 3078 M
--12 -19 D
-19 28 D
-P
-FO
-455 2959 M
-5 1 D
--2 8 D
-P
-FO
-359 2885 M
-8 -3 D
--11 7 D
-P
-FO
-404 3073 M
--6 1 D
-10 -1 D
-P
-FO
-303 2988 M
-6 3 D
-P
-FO
-462 3112 M
-6 10 D
-P
-FO
-442 3186 M
-8 4 D
-P
-FO
-444 2936 M
-8 22 D
-P
-FO
-591 3313 M
-6 6 D
-P
-FO
-372 2936 M
-4 -4 D
-P
-FO
-757 3303 M
-9 7 D
-P
-FO
-560 3109 M
--7 -3 D
-P
-FO
-597 3205 M
--3 16 D
-P
-FO
-302 2980 M
--4 -12 D
-P
-FO
-438 2932 M
-4 10 D
-P
-FO
-400 3122 M
-3 7 D
-P
-FO
-477 3203 M
-10 16 D
-P
-FO
-586 3204 M
-8 0 D
-P
-FO
-528 3061 M
--7 -4 D
-P
-FO
-588 3164 M
-6 6 D
--6 -5 D
-P
-FO
-473 3209 M
-4 7 D
-P
-FO
-419 3123 M
-5 6 D
-P
-FO
-582 3239 M
-10 5 D
-P
-FO
-369 3032 M
-15 28 D
--18 -20 D
-P
-FO
-466 3183 M
-5 7 D
-P
-FO
-587 3140 M
-0 1 D
-P
-FO
-1061 3484 M
--7 0 D
-6 8 D
--22 -10 D
--4 8 D
--17 -12 D
--22 8 D
--31 -7 D
--13 7 D
-23 17 D
--11 4 D
--57 -24 D
--5 11 D
--45 -9 D
--135 -70 D
-66 -79 D
-41 6 D
-25 23 D
-13 4 D
-13 23 D
--36 -14 D
-38 27 D
--11 -1 D
-14 9 D
--13 3 D
-26 10 D
--7 3 D
-7 0 D
-2 8 D
-7 -4 D
-35 18 D
-60 -3 D
-40 25 D
-P
-807 3380 M
-7 -2 D
-P
-742 3423 M
--7 -5 D
-P
-FO
-1091 3502 M
--10 0 D
-P
-FO
-1340 3626 M
--10 0 D
--2 -6 D
-13 3 D
-0 2 D
--1 0 D
-P
-FO
-1057 3565 M
-25 26 D
--8 3 D
-7 18 D
+2840 402 M
 -8 -1 D
--19 -11 D
-11 -7 D
--17 -22 D
--23 -14 D
--4 8 D
--2 -11 D
--42 -27 D
-42 11 D
 P
 FO
-1172 3619 M
-19 -3 D
-12 7 D
--46 5 D
+2674 285 M
+-8 2 D
 P
 FO
-1097 3625 M
--77 -11 D
-54 8 D
-25 -11 D
+2751 270 M
+-6 4 D
 P
 FO
-1254 3621 M
--3 -8 D
-20 2 D
-P
-FO
-908 3554 M
-11 10 D
--25 -19 D
-P
-FO
-1302 3638 M
-30 2 D
--51 1 D
-P
-FO
-968 3522 M
--8 -4 D
-10 0 D
-P
-FO
-1252 3609 M
-8 0 D
--3 5 D
-P
-FO
-1238 3628 M
-17 5 D
--39 -1 D
-P
-FO
-1244 3614 M
-1 6 D
--2 -6 D
-P
-FO
-1069 3502 M
-17 3 D
-P
-FO
-997 3602 M
--1 -1 D
-15 6 D
-P
-FO
-1138 3544 M
--16 -6 D
-P
-FO
-1060 3498 M
-8 1 D
-P
-FO
-1226 3615 M
-8 -2 D
-P
-FO
-1149 3630 M
-6 -4 D
-P
-FO
-1276 3619 M
-2 -4 D
-P
-FO
-938 3508 M
-7 3 D
-P
-FO
-873 3396 M
-8 5 D
-P
-FO
-1260 3609 M
-7 2 D
-P
-FO
-1029 3611 M
--7 -4 D
-P
-FO
-903 3502 M
-1 -5 D
-P
-FO
-973 3609 M
-8 3 D
-P
-FO
-870 3393 M
-14 4 D
-P
-FO
-1077 3525 M
-6 -3 D
-P
-FO
-1341 3623 M
-26 4 D
--27 -1 D
-0 -1 D
-1 0 D
-P
-FO
-1368 3640 M
-14 -3 D
--32 14 D
-P
-FO
-1379 3642 M
-8 -6 D
-P
-FO
-1341 3635 M
-9 1 D
-P
-FO
-3097 3330 M
-5 -6 D
-P
-FO
-3813 1621 M
--9 44 D
--26 -9 D
--4 10 D
--19 -34 D
-P
-FO
-3824 1620 M
-1 7 D
--5 -3 D
-2 -4 D
-P
-FO
-3871 1615 M
--4 14 D
--6 -6 D
--3 22 D
--22 3 D
--10 -20 D
-4 -10 D
-40 -7 D
-P
-FO
-3883 1986 M
-4 -10 D
-13 17 D
--1 11 D
--10 -18 D
--5 15 D
-P
-FO
-3884 1937 M
-4 -13 D
-P
-FO
-3889 1969 M
-1 -13 D
-P
-FO
-3815 1629 M
-1 -7 D
-P
-FO
-3894 2006 M
--2 -9 D
-P
-FO
-3895 1980 M
-0 -11 D
-P
-FO
-3590 1003 M
-18 58 D
-14 15 D
-4 39 D
-8 0 D
--3 -9 D
-30 35 D
--2 5 D
-19 8 D
-14 20 D
-18 42 D
--6 30 D
-14 34 D
--4 14 D
--5 -6 D
-1 18 D
-13 9 D
-15 35 D
-12 8 D
-8 40 D
--1 -12 D
-4 6 D
--6 -14 D
--4 -19 D
--13 -9 D
--14 -36 D
--14 -11 D
--1 -14 D
-5 6 D
-5 -14 D
--13 -37 D
-4 -28 D
--25 -61 D
--32 -24 D
--27 -32 D
--4 -24 D
--11 -11 D
--10 -30 D
-4 -8 D
--14 -24 D
-1 0 D
-11 16 D
-41 17 D
-47 52 D
-39 83 D
--4 -16 D
--32 -66 D
--50 -54 D
--52 -32 D
-47 -27 D
-47 87 D
-39 80 D
-35 83 D
-25 66 D
-29 85 D
-24 87 D
-19 78 D
-13 70 D
--40 7 D
-2 -4 D
--7 -4 D
--12 11 D
--58 11 D
--32 -27 D
--37 -17 D
--27 -113 D
--27 -87 D
--31 -86 D
--22 -54 D
--46 -97 D
--35 -66 D
--12 -22 D
-P
-3615 1038 M
-5 11 D
-P
-3631 1082 M
-8 8 D
-P
-3634 1098 M
-9 8 D
-P
-FO
-3822 1620 M
-2 -4 D
-0 4 D
-P
-FO
-3172 494 M
-56 49 D
-35 20 D
-21 45 D
-7 -11 D
--6 -13 D
-14 16 D
--7 -16 D
-16 0 D
-4 15 D
-9 -4 D
-2 7 D
-0 -5 D
-5 8 D
-12 2 D
-0 7 D
-6 -3 D
-1 6 D
-28 17 D
--1 5 D
-18 15 D
-0 20 D
--11 -9 D
-6 11 D
-9 1 D
-6 41 D
-3 -21 D
-25 34 D
-20 -2 D
-18 44 D
-12 12 D
--12 -21 D
--1 -12 D
-4 -20 D
--1 -3 D
-31 39 D
-30 40 D
-47 68 D
-44 70 D
-17 29 D
--47 27 D
--27 -45 D
--4 -31 D
--18 -23 D
--3 -24 D
--23 -31 D
--8 -9 D
--4 5 D
--5 -9 D
--20 -50 D
-16 45 D
-16 25 D
--8 23 D
-14 -17 D
--10 -13 D
-20 23 D
--10 -15 D
-13 12 D
-11 35 D
-18 22 D
-5 40 D
-22 29 D
-3 9 D
--104 60 D
--34 -56 D
--26 -41 D
--52 -73 D
--65 -83 D
--54 -61 D
--34 -36 D
--6 -5 D
--17 -18 D
--6 -5 D
--11 -12 D
--72 -66 D
--19 -16 D
-P
-3442 758 M
-12 0 D
--19 -24 D
-1 12 D
--7 0 D
-18 3 D
-P
-3444 746 M
--9 -6 D
-P
-3545 920 M
--1 -9 D
-P
-3540 911 M
-2 -5 D
-P
-3561 892 M
--15 -19 D
--7 0 D
-P
-3469 774 M
--26 4 D
-27 -4 D
-P
-3402 718 M
--15 13 D
-P
-3502 837 M
--3 -7 D
-P
-FO
-3591 1002 M
--1 -2 D
-2 2 D
-P
-FO
-3450 725 M
--9 -5 D
-5 9 D
--13 1 D
--17 -19 D
--17 -28 D
-5 -25 D
-46 48 D
-P
-3417 679 M
+2624 281 M
 -2 4 D
 P
 FO
-3466 752 M
--1 11 D
--6 -17 D
-1 -12 D
+2962 392 M
+-7 -3 D
+P
+FO
+3027 504 M
+-8 -5 D
+P
+FO
+2640 291 M
+-7 -2 D
+P
+FO
+2871 289 M
+7 4 D
+P
+FO
+2997 398 M
+-1 5 D
+P
+FO
+2927 291 M
+-8 -3 D
+P
+FO
+3030 507 M
+-14 -4 D
+P
+FO
+2823 375 M
+-6 3 D
+P
+FO
+2559 277 M
+-26 -4 D
+27 1 D
+0 1 D
+-1 0 D
+P
+FO
+2532 260 M
+-14 3 D
+32 -14 D
+P
+FO
+2521 258 M
+-8 6 D
+P
+FO
+2559 265 M
+-9 -1 D
+P
+FO
+803 570 M
+-5 6 D
+P
+FO
+87 2279 M
+9 -44 D
+26 9 D
+4 -10 D
+19 34 D
+P
+FO
+76 2280 M
+-1 -7 D
 5 3 D
+-2 4 D
+-1 0 D
 P
 FO
-3443 697 M
-0 -2 D
-3 4 D
+29 2285 M
+4 -14 D
+6 6 D
+3 -22 D
+22 -3 D
+10 20 D
+-4 10 D
+-40 7 D
 P
 FO
-3283 588 M
--8 -9 D
+17 1914 M
+-4 10 D
+-13 -17 D
+1 -11 D
+10 18 D
+5 -15 D
 P
 FO
-3464 724 M
--8 -10 D
+16 1963 M
+-4 13 D
 P
 FO
-3468 739 M
--2 -11 D
+11 1931 M
+-1 13 D
 P
 FO
-3461 726 M
-0 6 D
+85 2271 M
+-1 7 D
 P
 FO
-3458 729 M
+6 1894 M
+2 9 D
+P
+FO
+5 1920 M
+0 11 D
+P
+FO
+310 2897 M
+-18 -58 D
+-14 -15 D
+-4 -39 D
+-8 0 D
+3 9 D
+-30 -35 D
+2 -5 D
+-19 -8 D
+-14 -20 D
+-18 -42 D
+6 -30 D
+-14 -34 D
+4 -14 D
+5 6 D
+-1 -18 D
+-13 -9 D
+-15 -35 D
+-12 -8 D
+-8 -40 D
+1 12 D
+-4 -6 D
+6 14 D
+4 19 D
+13 9 D
+14 36 D
+14 11 D
+1 14 D
+-5 -6 D
+-5 14 D
+13 37 D
+-4 28 D
+25 61 D
+32 24 D
+27 32 D
+4 24 D
+11 11 D
+10 30 D
+-4 8 D
+14 24 D
+-1 0 D
+-11 -16 D
+-41 -17 D
+-47 -52 D
+-39 -83 D
+4 16 D
+32 66 D
+50 54 D
+52 32 D
+-47 27 D
+-47 -87 D
+-39 -80 D
+-35 -83 D
+-25 -66 D
+-29 -85 D
+-24 -87 D
+-19 -78 D
+-13 -70 D
+40 -7 D
+-2 4 D
+7 4 D
+12 -11 D
+58 -11 D
+32 27 D
+37 17 D
+27 113 D
+27 87 D
+31 86 D
+22 54 D
+46 97 D
+35 66 D
+12 22 D
+P
+285 2862 M
+-5 -11 D
+P
+269 2818 M
+-8 -8 D
+P
+266 2802 M
+-9 -8 D
+P
+FO
+78 2280 M
+-2 4 D
+0 -4 D
+P
+FO
+728 3406 M
+-56 -49 D
+-35 -20 D
+-21 -45 D
+-7 11 D
+6 13 D
+-14 -16 D
+7 16 D
+-16 0 D
+-4 -15 D
+-9 4 D
+-2 -7 D
+0 5 D
+-5 -8 D
+-12 -2 D
+0 -7 D
+-6 3 D
 -1 -6 D
+-28 -17 D
+1 -5 D
+-18 -15 D
+0 -20 D
+11 9 D
+-6 -11 D
+-9 -1 D
+-6 -41 D
+-3 21 D
+-25 -34 D
+-20 2 D
+-18 -44 D
+-12 -12 D
+12 21 D
+1 12 D
+-4 20 D
+1 3 D
+-31 -39 D
+-30 -40 D
+-47 -68 D
+-44 -70 D
+-17 -29 D
+47 -27 D
+27 45 D
+4 31 D
+18 23 D
+3 24 D
+23 31 D
+8 9 D
+4 -5 D
+5 9 D
+20 50 D
+-16 -45 D
+-16 -25 D
+8 -23 D
+-14 17 D
+10 13 D
+-20 -23 D
+10 15 D
+-13 -12 D
+-11 -35 D
+-18 -22 D
+-5 -40 D
+-22 -29 D
+-3 -9 D
+104 -60 D
+34 56 D
+26 41 D
+52 73 D
+65 83 D
+54 61 D
+34 36 D
+6 5 D
+17 18 D
+6 5 D
+11 12 D
+72 66 D
+19 16 D
+P
+458 3142 M
+-12 0 D
+19 24 D
+-1 -12 D
+7 0 D
+-18 -3 D
+P
+456 3154 M
+9 6 D
+P
+355 2980 M
+1 9 D
+P
+360 2989 M
+-2 5 D
+P
+339 3008 M
+15 19 D
+7 0 D
+P
+431 3126 M
+26 -4 D
+-27 4 D
+P
+498 3182 M
+15 -13 D
+P
+398 3063 M
+3 7 D
 P
 FO
-3282 597 M
+309 2898 M
+1 2 D
+-2 -2 D
+P
+FO
+450 3175 M
+9 5 D
+-5 -9 D
+13 -1 D
+17 19 D
+17 28 D
+-5 25 D
+-46 -48 D
+P
+483 3221 M
 2 -4 D
 P
 FO
-3464 721 M
+434 3148 M
+1 -11 D
+6 17 D
+-1 12 D
+-5 -3 D
 P
 FO
-3329 604 M
-1 -5 D
+457 3203 M
+0 2 D
+-3 -4 D
 P
 FO
-5 -1 1 3508 846 SP
-2996 518 M
--13 -46 D
-8 -21 D
-30 -16 D
-13 2 D
-42 27 D
-48 9 D
-48 21 D
--82 97 D
--75 -59 D
-P
-3107 517 M
+617 3312 M
 8 9 D
 P
-3071 509 M
-6 4 D
+FO
+436 3176 M
+8 10 D
 P
 FO
-1539 225 M
--9 21 D
-11 21 D
-38 14 D
-32 40 D
-7 40 D
--52 105 D
-8 76 D
--32 88 D
--64 22 D
--135 -368 D
-69 -24 D
-77 -23 D
+432 3161 M
+2 11 D
 P
 FO
-1616 334 M
+439 3174 M
+0 -6 D
+P
+FO
+442 3171 M
+1 6 D
+P
+FO
+618 3303 M
+-2 4 D
+P
+FO
+436 3179 M
+P
+FO
+571 3296 M
 -1 5 D
 P
 FO
-1371 696 M
-1 -1 D
--67 34 D
--64 36 D
--14 -5 D
--33 -2 D
--39 -34 D
-5 1 D
-3 -10 D
--85 12 D
--24 -30 D
-2 -40 D
--10 -15 D
--3 7 D
--44 7 D
--24 -6 D
--84 31 D
--6 0 D
--72 -86 D
-4 -10 D
-47 -37 D
-76 -56 D
-5 -3 D
-5 30 D
-16 10 D
-8 40 D
-13 -16 D
--5 -39 D
--15 -3 D
--8 -32 D
-78 -49 D
-40 -24 D
-75 -40 D
-77 -36 D
-85 -36 D
-29 -10 D
+-5 1 1 392 3054 SP
+904 3382 M
+13 46 D
+-8 21 D
+-30 16 D
+-13 -2 D
+-42 -27 D
+-48 -9 D
+-48 -21 D
+82 -97 D
+75 59 D
+P
+793 3383 M
+-8 -9 D
+P
+829 3391 M
+-6 -4 D
+P
+FO
+2361 3675 M
+9 -21 D
+-11 -21 D
+-38 -14 D
+-32 -40 D
+-7 -40 D
+52 -105 D
+-8 -76 D
+32 -88 D
+64 -22 D
 135 368 D
--72 28 D
-P
-1313 664 M
-8 6 D
-8 -7 D
--4 7 D
-8 -8 D
-P
-1025 586 M
--14 16 D
--4 28 D
-5 -27 D
-P
-1213 504 M
--30 -9 D
--33 13 D
-25 -9 D
-P
-1261 681 M
-5 -3 D
-0 6 D
-4 -9 D
-P
-1073 427 M
-4 7 D
-10 -3 D
--13 -5 D
-P
-1152 383 M
-0 5 D
-P
-975 570 M
-2 5 D
-P
-1344 499 M
--7 -1 D
-P
-1189 735 M
-1 -6 D
-P
-1084 435 M
-4 3 D
-P
-975 594 M
--4 -6 D
-P
-1097 517 M
--48 28 D
+-69 24 D
+-77 23 D
 P
 FO
-885 681 M
--36 -4 D
--13 -36 D
--8 2 D
--10 -26 D
--15 -3 D
-10 -19 D
+2284 3566 M
+1 -5 D
 P
 FO
-908 908 M
--45 32 D
--143 -43 D
--14 -12 D
--13 4 D
--15 -21 D
--7 5 D
-4 13 D
--14 0 D
--25 -41 D
-4 -26 D
--7 -3 D
-18 -6 D
-12 13 D
-17 -6 D
-4 -11 D
-6 11 D
-6 -6 D
-17 5 D
--6 -6 D
-16 -2 D
-1 7 D
-8 -5 D
--7 -4 D
-14 -6 D
-6 7 D
-3 -11 D
-42 -29 D
-28 8 D
-22 45 D
-38 0 D
-19 10 D
-22 53 D
-P
-730 870 M
--7 -2 D
-P
-FO
-614 1100 M
-11 2 D
--10 7 D
-P
-FO
-758 681 M
--5 8 D
--4 -10 D
-P
-FO
-742 707 M
--5 10 D
--3 -5 D
-P
-FO
-665 1059 M
--3 16 D
--5 -8 D
-P
-FO
-731 732 M
-0 7 D
-P
-FO
-674 808 M
--2 6 D
-P
-FO
-756 697 M
--4 6 D
-P
-FO
-695 892 M
--7 -1 D
-P
-FO
-575 2744 M
--9 -24 D
--8 -49 D
--12 -12 D
--2 -64 D
-9 -13 D
--16 -3 D
-40 -35 D
-44 4 D
--10 -5 D
-3 -6 D
--15 1 D
-23 -1 D
--15 -13 D
-73 15 D
-18 -6 D
-31 64 D
-25 44 D
-P
-FO
-413 2834 M
-2 2 D
+2529 3204 M
 -1 1 D
-P
-FO
-605 2526 M
--12 -1 D
-P
-FO
-534 2619 M
--2 6 D
-P
-FO
-585 2533 M
-5 -4 D
-P
-FO
-585 2533 M
--4 2 D
-P
-FO
-902 3199 M
--9 -7 D
--20 -1 D
--64 -32 D
--39 -12 D
--3 31 D
--8 2 D
-11 12 D
--6 6 D
-6 17 D
--15 -2 D
--4 -20 D
--5 6 D
--7 -10 D
-2 9 D
--10 -20 D
--15 -5 D
--10 -16 D
--10 1 D
--7 -11 D
--42 -25 D
--1 -7 D
-23 18 D
-8 -6 D
--24 -31 D
--7 -1 D
--4 -15 D
-6 0 D
--11 -5 D
-7 -1 D
--8 -8 D
-10 -9 D
--8 -13 D
-3 -20 D
-18 9 D
-0 -14 D
--11 -3 D
-3 -9 D
--6 4 D
--12 -11 D
--2 -12 D
-9 -1 D
--9 -2 D
-3 -6 D
--8 14 D
--26 -10 D
--13 -11 D
-3 -12 D
--6 2 D
--1 -11 D
--9 -1 D
-10 -11 D
--12 -2 D
-0 -17 D
-13 4 D
--12 -16 D
-14 5 D
--15 -10 D
-2 -12 D
-7 0 D
-1 8 D
-3 -15 D
-10 14 D
--7 -16 D
--19 -16 D
-7 -6 D
-10 9 D
-6 -5 D
--9 -7 D
-9 -6 D
--30 -2 D
-3 -28 D
-17 -4 D
-5 -44 D
--12 -29 D
-179 -103 D
-36 59 D
-25 37 D
-26 36 D
-67 84 D
-34 38 D
-5 4 D
-17 19 D
-5 4 D
-4 5 D
-5 4 D
-4 5 D
-19 17 D
-4 5 D
-57 50 D
-P
-666 2980 M
--11 5 D
-7 10 D
-P
-772 3067 M
--4 6 D
-P
-FO
-472 2930 M
-4 -6 D
-8 15 D
-4 15 D
-P
-FO
-415 2836 M
-11 10 D
-2 12 D
--1 0 D
--13 -21 D
-P
-FO
-630 3097 M
-0 -6 D
--15 -6 D
-23 4 D
-5 19 D
-P
-FO
-779 3181 M
-1 -6 D
-14 12 D
--13 5 D
-P
-FO
-617 3069 M
-12 15 D
--12 -2 D
-P
-FO
-743 3207 M
-3 6 D
-P
-FO
-871 3197 M
-11 12 D
-P
-FO
-476 2907 M
-0 14 D
-P
-FO
-450 2876 M
-3 9 D
-P
-FO
-658 3137 M
-5 -4 D
-P
-FO
-738 3194 M
-1 6 D
-P
-FO
-747 3216 M
-1 12 D
-P
-FO
-1330 3184 M
--6 29 D
--26 18 D
--9 26 D
--50 18 D
--28 -4 D
--14 19 D
-2 -6 D
--19 1 D
-6 -9 D
--8 2 D
--3 -6 D
--43 28 D
--74 -15 D
--28 27 D
--18 -2 D
--18 23 D
--28 -2 D
--16 -17 D
--22 20 D
--49 14 D
--7 -12 D
-11 -16 D
--5 -18 D
-9 7 D
-3 -28 D
-18 -14 D
-8 -57 D
--14 -11 D
-160 -191 D
-58 46 D
-81 57 D
-53 32 D
-P
-FO
-1091 3502 M
-7 -1 D
-P
-FO
-1001 3448 M
-3 0 D
-56 28 D
-15 2 D
-14 18 D
--25 -11 D
-0 -1 D
--3 0 D
--20 -11 D
-P
-FO
-1280 3264 M
-5 -4 D
--5 21 D
-P
-FO
-1304 3239 M
-4 -5 D
-P
-FO
-1161 3510 M
-18 4 D
-P
-FO
-1310 3227 M
--1 7 D
-P
-FO
-1137 3513 M
-10 4 D
-P
-FO
-1950 3594 M
--2 -2 D
-P
-FO
-1950 3608 M
--43 -13 D
-41 1 D
-0 6 D
--13 -5 D
-P
-FO
-1587 3571 M
--6 -3 D
-9 -7 D
-10 2 D
-P
-FO
-1912 3572 M
--14 13 D
--26 -14 D
-19 -5 D
-P
-FO
-1560 3584 M
-8 -11 D
-13 6 D
--22 12 D
-P
-FO
-1407 3623 M
-11 3 D
--36 0 D
-P
-FO
-1644 3525 M
-9 1 D
--8 5 D
-P
-FO
-1604 3448 M
--90 23 D
-32 -18 D
-P
-FO
-1611 3576 M
--3 10 D
-P
-FO
-1610 3562 M
-11 0 D
-P
-FO
-1894 3550 M
-14 2 D
-P
-FO
-1602 3588 M
--8 -5 D
-P
-FO
-1581 3602 M
-5 4 D
-P
-FO
-1583 3476 M
-2 7 D
-P
-FO
-1608 3476 M
--10 3 D
-P
-FO
-1616 3543 M
-12 3 D
-P
-FO
-1605 3571 M
-10 0 D
-P
-FO
-1628 3467 M
--7 4 D
-P
-FO
-1651 3516 M
-7 -3 D
-P
-FO
-1524 3657 M
--9 -3 D
-P
-FO
-1950 3608 M
-P
-FO
-1950 3594 M
-4 4 D
-P
-FO
-2191 3632 M
-12 -2 D
--19 5 D
-P
-FO
-2163 3645 M
-19 -6 D
-P
-FO
-2076 3507 M
-9 -2 D
-P
-FO
-2219 3621 M
-8 0 D
-P
-FO
-2775 3357 M
-9 -12 D
-P
-FO
-2885 3321 M
-2 -7 D
-P
-FO
-2970 3210 M
-2 -6 D
-P
-FO
-3686 1588 M
--27 -12 D
--48 -34 D
--8 8 D
--17 -10 D
--20 -19 D
--65 -91 D
--32 -24 D
--30 6 D
--27 8 D
--34 28 D
--37 8 D
--60 49 D
--21 1 D
--1 2 D
--31 -81 D
--14 -35 D
--38 -78 D
--30 -55 D
-340 -196 D
-43 80 D
-40 83 D
-35 84 D
-31 86 D
-30 103 D
-P
-3517 1365 M
--25 -20 D
--4 10 D
-11 1 D
--1 8 D
-16 18 D
-8 -8 D
-P
-3422 1323 M
-13 5 D
-9 -9 D
-P
-3483 1202 M
--5 0 D
-P
-3520 1280 M
--5 3 D
-P
-3513 1240 M
-6 0 D
-P
-3516 1253 M
-4 -3 D
-P
-FO
-3142 1252 M
-13 -8 D
-2 -7 D
-20 -28 D
--3 -14 D
--38 -51 D
-41 64 D
--26 37 D
--10 5 D
--36 -58 D
--39 -56 D
--56 -72 D
-4 -17 D
--3 -27 D
-17 -25 D
-19 -5 D
-3 -18 D
-10 5 D
--11 -9 D
-1 -23 D
--10 -34 D
--16 -19 D
--7 -31 D
--18 -14 D
--4 -15 D
--4 4 D
--21 -18 D
-5 -8 D
--12 -25 D
-8 -6 D
--2 -44 D
-92 -108 D
-29 -36 D
-61 54 D
-36 34 D
-5 6 D
-18 17 D
-5 6 D
-12 11 D
-66 72 D
-51 63 D
-49 65 D
-42 61 D
-34 55 D
-17 28 D
--340 196 D
-P
-3058 863 M
-12 3 D
-2 8 D
-0 -9 D
-14 1 D
--14 -17 D
--2 4 D
--12 -3 D
-18 6 D
-4 9 D
-P
-3085 819 M
-7 6 D
-2 -11 D
-5 8 D
-1 -11 D
--17 1 D
-P
-3089 930 M
-10 5 D
-P
-3138 1186 M
--2 -7 D
-1 7 D
-P
-3101 958 M
--11 -12 D
--4 4 D
-P
-3038 841 M
-6 -1 D
--7 1 D
-P
-3014 1057 M
-1 -7 D
-P
-3092 870 M
-14 5 D
-P
-FO
-3020 1006 M
-4 -9 D
-P
-FO
-3024 894 M
--3 -6 D
-P
-FO
-3013 863 M
--5 -5 D
-P
-FO
-2969 735 M
-0 -7 D
-13 -21 D
--4 -20 D
-51 -77 D
-0 -7 D
--10 2 D
--6 -12 D
--17 -75 D
-38 28 D
-56 45 D
--59 71 D
-P
-FO
-1542 630 M
--12 41 D
-2 18 D
-13 2 D
--2 34 D
--10 -1 D
--21 23 D
--34 -95 D
-P
-FO
-1371 696 M
--2 6 D
-2 -6 D
-62 -27 D
-45 -17 D
-34 96 D
--60 4 D
--45 25 D
--50 9 D
--84 -9 D
--32 -12 D
+67 -34 D
 64 -36 D
-57 -29 D
-P
-1360 715 M
--7 4 D
-P
-FO
-1331 1146 M
+14 5 D
+33 2 D
+39 34 D
+-5 -1 D
+-3 10 D
+85 -12 D
+24 30 D
+-2 40 D
+10 15 D
+3 -7 D
+44 -7 D
+24 6 D
+84 -31 D
+6 0 D
+72 86 D
+-4 10 D
+-47 37 D
+-76 56 D
 -5 3 D
+-5 -30 D
+-16 -10 D
+-8 -40 D
+-13 16 D
+5 39 D
+15 3 D
+8 32 D
+-78 49 D
+-40 24 D
+-75 40 D
+-77 36 D
+-85 36 D
+-29 10 D
+-135 -368 D
+72 -28 D
 P
-FO
-1061 1609 M
--7 2 D
--1 17 D
--3 -12 D
--3 13 D
--8 -1 D
-10 -17 D
--8 2 D
-7 -8 D
--9 -6 D
-P
-FO
-698 2533 M
-10 -3 D
-36 5 D
-24 -16 D
--3 -17 D
-18 -5 D
-27 24 D
-15 26 D
--1 50 D
-1 2 D
--71 42 D
--34 -62 D
-P
-FO
-825 2599 M
-43 68 D
--8 24 D
-11 42 D
-62 106 D
-64 37 D
-4 -8 D
-15 7 D
-34 -9 D
--7 -6 D
-20 7 D
--7 7 D
-8 52 D
+2587 3236 M
+-8 -6 D
+-8 7 D
+4 -7 D
 -8 8 D
-19 -13 D
-0 -18 D
-11 -12 D
--7 -6 D
-3 -9 D
-12 17 D
--8 20 D
-17 -4 D
-4 -19 D
-12 13 D
-16 2 D
-8 -3 D
--4 1 D
-17 -15 D
-8 -1 D
--102 121 D
--57 -50 D
--4 -5 D
--19 -17 D
--4 -5 D
--5 -4 D
--4 -5 D
--5 -4 D
--17 -19 D
--5 -4 D
--54 -62 D
--55 -70 D
--36 -52 D
--43 -70 D
 P
-FO
-1095 2867 M
-15 20 D
--26 -22 D
+2875 3314 M
+14 -16 D
+4 -28 D
+-5 27 D
 P
-FO
-1164 2887 M
-17 -2 D
-60 25 D
-11 34 D
-7 -3 D
--6 -8 D
-13 11 D
-2 -7 D
-21 3 D
--4 5 D
-21 34 D
--7 -9 D
-1 6 D
-38 32 D
--16 36 D
-7 19 D
--7 1 D
--2 32 D
-17 34 D
--7 3 D
-4 29 D
--4 22 D
--87 -47 D
--52 -33 D
--81 -57 D
--48 -39 D
+2687 3396 M
+30 9 D
+33 -13 D
+-25 9 D
 P
-1232 2917 M
--2 5 D
+2639 3219 M
+-5 3 D
+0 -6 D
+-4 9 D
 P
-1274 3085 M
--2 7 D
+2827 3473 M
+-4 -7 D
+-10 3 D
+13 5 D
 P
-1271 2999 M
--3 5 D
+2748 3517 M
+0 -5 D
 P
-FO
-1338 2858 M
-17 3 D
--6 21 D
-20 -1 D
--12 26 D
-5 -3 D
--21 23 D
--19 -25 D
--39 -11 D
-11 -12 D
-24 -8 D
--8 -2 D
-7 -6 D
+2925 3330 M
+-2 -5 D
 P
-1338 2866 M
--8 2 D
-P
-FO
-1332 2939 M
+2556 3401 M
 7 1 D
--12 5 D
 P
-FO
-1356 2868 M
-0 9 D
+2711 3165 M
+-1 6 D
 P
-FO
-1266 2897 M
--9 5 D
+2816 3465 M
+-4 -3 D
 P
-FO
-1849 3092 M
--6 -7 D
-13 -6 D
-14 9 D
-19 46 D
-20 3 D
-10 31 D
--12 3 D
--17 -12 D
--24 7 D
--14 24 D
-3 -16 D
--20 6 D
-3 12 D
--13 10 D
--1 14 D
--4 -4 D
--17 10 D
--3 -5 D
--6 12 D
--8 -1 D
-35 -39 D
--4 8 D
-13 -4 D
-0 -8 D
--7 3 D
-9 -12 D
-9 1 D
--8 -1 D
-10 -15 D
--5 -22 D
--17 -12 D
-28 -12 D
-P
-1862 3138 M
-6 5 D
-P
-FO
-1771 2965 M
-12 10 D
-4 43 D
-16 5 D
--11 6 D
-11 -6 D
-16 3 D
--8 3 D
-1 12 D
-25 34 D
-0 11 D
--8 -2 D
-7 7 D
--21 -10 D
--13 13 D
-7 4 D
--16 -9 D
--20 -53 D
--25 -24 D
--16 -4 D
--20 -30 D
-5 -6 D
--7 1 D
-2 -20 D
-17 5 D
-26 -6 D
-P
-1749 3005 M
-1 -9 D
--7 4 D
-P
-1754 3004 M
--2 -6 D
-P
-1720 2964 M
-3 -5 D
-P
-1737 2991 M
-8 -10 D
-P
-1770 3026 M
-1 0 D
--3 -21 D
-P
-1765 3020 M
-1 -10 D
-P
-1776 3030 M
-8 -7 D
-P
-FO
-1740 2939 M
--6 9 D
--3 -15 D
-P
-FO
-1848 3196 M
-5 -3 D
-P
-FO
-1825 3091 M
+2925 3306 M
 4 6 D
 P
-FO
-2013 3029 M
-9 5 D
--12 0 D
+2803 3383 M
+48 -28 D
 P
 FO
-2863 1703 M
-1 -9 D
-28 -1 D
--15 6 D
-4 10 D
--15 -3 D
-11 -12 D
+3015 3219 M
+36 4 D
+13 36 D
+8 -2 D
+10 26 D
+15 3 D
+-10 19 D
 P
 FO
-2856 1678 M
--23 -69 D
--3 -6 D
-7 2 D
--7 -2 D
--3 -9 D
-17 -13 D
-11 -39 D
-15 -7 D
-12 16 D
-25 5 D
-11 -18 D
--4 -27 D
-25 -15 D
-5 -24 D
-12 8 D
--2 -11 D
--10 -2 D
-1 -11 D
-12 -2 D
--1 16 D
-12 6 D
-27 -13 D
--20 -18 D
--8 -27 D
-31 -18 D
--5 -5 D
-15 0 D
--16 -20 D
--8 -22 D
-107 -61 D
-34 -21 D
--6 23 D
--26 8 D
-28 -8 D
-5 -23 D
-20 -12 D
-47 88 D
-26 57 D
-27 69 D
-13 35 D
--9 13 D
--61 17 D
--61 55 D
--1 13 D
--47 3 D
--28 24 D
--15 -5 D
--2 6 D
-1 -17 D
--4 -6 D
-2 -7 D
--8 15 D
--8 -9 D
--6 5 D
-6 5 D
--9 -4 D
-4 5 D
--18 12 D
--10 -5 D
--4 12 D
--12 -10 D
--9 21 D
--8 -12 D
-3 13 D
--7 4 D
-1 -9 D
--17 15 D
-10 1 D
-2 11 D
--2 -9 D
-3 6 D
-5 -6 D
--3 7 D
-6 4 D
-1 7 D
--6 -8 D
--6 7 D
--4 15 D
--6 -5 D
-6 3 D
-3 -13 D
--9 2 D
--1 -11 D
--12 -2 D
--2 11 D
--4 -10 D
--1 15 D
--2 -17 D
--11 -6 D
-4 7 D
--9 -3 D
-12 20 D
--13 -11 D
--1 10 D
--5 -5 D
--13 10 D
-3 -7 D
--13 -3 D
-5 10 D
--9 -2 D
-P
-2878 1668 M
-11 -5 D
--10 -2 D
-7 -4 D
--17 -1 D
-P
-2919 1652 M
-10 -7 D
--10 -26 D
-6 19 D
-P
-3160 1326 M
-8 4 D
--7 -17 D
-P
-3044 1589 M
--11 -8 D
-2 10 D
-P
-3039 1615 M
-7 -3 D
--7 -4 D
-P
-2922 1571 M
-10 1 D
-P
-2957 1616 M
-3 5 D
-P
-2867 1639 M
-5 -3 D
--5 2 D
-P
-3060 1596 M
--2 6 D
-P
-2928 1580 M
-6 -5 D
-P
-2943 1675 M
--4 -5 D
--5 6 D
-P
-2909 1640 M
-2 6 D
-P
-3038 1599 M
-3 5 D
-P
-2975 1607 M
-4 5 D
-P
-3070 1591 M
--5 -1 D
-P
-2991 1617 M
-6 2 D
-P
-3114 1556 M
--6 1 D
-P
-3047 1584 M
-1 0 D
--5 -4 D
-P
-3062 1574 M
-0 6 D
-P
-3069 1596 M
--5 -4 D
-P
-2856 1660 M
-10 10 D
-P
-FO
-3002 1648 M
-2 -10 D
-29 -8 D
-2 10 D
--9 6 D
--20 10 D
-P
-FO
-2966 1639 M
-9 -3 D
+2992 2992 M
+45 -32 D
+143 43 D
+14 12 D
+13 -4 D
+15 21 D
+7 -5 D
+-4 -13 D
+14 0 D
+25 41 D
+-4 26 D
+7 3 D
+-18 6 D
+-12 -13 D
+-17 6 D
+-4 11 D
+-6 -11 D
+-6 6 D
+-17 -5 D
+6 6 D
+-16 2 D
+-1 -7 D
+-8 5 D
+7 4 D
+-14 6 D
+-6 -7 D
 -3 11 D
+-42 29 D
+-28 -8 D
+-22 -45 D
+-38 0 D
+-19 -10 D
+-22 -53 D
+P
+3170 3030 M
+7 2 D
 P
 FO
-2895 1697 M
--4 -8 D
+3286 2800 M
+-11 -2 D
+10 -7 D
+P
+FO
+3142 3219 M
+5 -8 D
+4 10 D
+-8 -2 D
+P
+FO
+3158 3193 M
+5 -10 D
+3 5 D
+P
+FO
+3235 2841 M
+3 -16 D
+5 8 D
+P
+FO
+3169 3168 M
+0 -7 D
+P
+FO
+3226 3092 M
+2 -6 D
+P
+FO
+3144 3203 M
+4 -6 D
+P
+FO
+3205 3008 M
+7 1 D
+P
+FO
+3325 1156 M
+9 24 D
+8 49 D
+12 12 D
+2 64 D
+-9 13 D
+16 3 D
+-40 35 D
+-44 -4 D
+10 5 D
+-3 6 D
+15 -1 D
+-23 1 D
+15 13 D
+-73 -15 D
+-18 6 D
+-31 -64 D
+-25 -44 D
+P
+FO
+3487 1066 M
+-2 -2 D
+1 -1 D
+P
+FO
+3295 1374 M
 12 1 D
 P
 FO
-2874 1713 M
--7 -6 D
+3366 1281 M
+2 -6 D
 P
 FO
-2888 1708 M
--2 -6 D
+3315 1367 M
+-5 4 D
 P
 FO
-2885 1700 M
--6 -1 D
+3315 1367 M
+4 -2 D
 P
 FO
-2952 1659 M
-3 -6 D
-P
-FO
-2975 1654 M
--4 -5 D
-P
-FO
-2945 1662 M
--5 -1 D
-P
-FO
-2981 1665 M
--1 -6 D
-P
-FO
-2903 1688 M
--6 -1 D
-P
-FO
-2886 1702 M
-5 1 D
-P
-FO
-2915 1699 M
--3 -6 D
-P
-FO
-2962 1660 M
-5 -5 D
-P
-FO
-2905 1694 M
--8 2 D
-P
-FO
-2973 1657 M
-4 6 D
-P
-FO
-2900 1707 M
--5 -5 D
-P
-FO
-2954 1672 M
-6 -4 D
-P
-FO
-3141 1250 M
--12 7 D
--4 14 D
--34 21 D
--107 61 D
--11 -30 D
--3 -22 D
-12 -30 D
-11 -5 D
-14 7 D
-10 -11 D
-32 16 D
-23 -17 D
--15 9 D
--17 -5 D
--29 -26 D
--21 -40 D
-6 -49 D
-17 -22 D
-6 -41 D
-9 0 D
--19 -8 D
--5 50 D
--2 -37 D
-8 -28 D
-63 81 D
-44 66 D
-P
-3000 1174 M
-11 -5 D
-1 -29 D
--10 10 D
-6 6 D
-P
-3055 1227 M
--9 -31 D
-3 17 D
--5 -1 D
-P
-2996 1165 M
-4 -19 D
-P
-FO
-3126 1271 M
-2 -10 D
-14 -9 D
-4 7 D
-P
-FO
--5 2 1 3135 1256 SP
-1948 1469 M
-2 -10 D
-0 10 D
-P
-FO
-1935 1469 M
-8 -2 D
-2 2 D
-P
-FO
-1902 1472 M
-0 -1 D
-P
-FO
-1856 1478 M
-23 -7 D
-4 3 D
-P
-FO
-1783 1492 M
-10 3 D
-8 -11 D
-19 -1 D
-4 -10 D
-18 9 D
--29 7 D
--27 9 D
-P
-FO
-1770 1504 M
-13 -12 D
-3 6 D
-P
-FO
-1650 1574 M
-5 -12 D
--12 -4 D
-13 2 D
-10 -37 D
-70 -3 D
--23 11 D
--43 28 D
-P
-FO
-1623 1560 M
-1 -1 D
-24 17 D
--7 6 D
-P
-FO
-1482 1680 M
-3 -8 D
-3 -23 D
--11 -4 D
--2 -20 D
-8 -17 D
-29 -20 D
-14 17 D
-3 -18 D
-9 -4 D
-0 12 D
-9 -2 D
-8 -19 D
-7 5 D
-61 -19 D
-18 22 D
--20 17 D
--31 32 D
--22 27 D
--21 29 D
--13 23 D
-P
-FO
-1431 1858 M
-6 -10 D
-21 -4 D
-23 -24 D
-2 -7 D
--11 2 D
--12 -17 D
-8 -20 D
--19 -14 D
-33 -84 D
-52 30 D
--9 15 D
--19 40 D
--15 41 D
--15 61 D
-P
-FO
-1110 1697 M
--1 10 D
-0 -10 D
-P
-FO
-1377 2051 M
--3 -20 D
--20 -14 D
-6 -10 D
-21 -2 D
-10 -13 D
--4 -23 D
-7 -23 D
--11 -35 D
-10 -19 D
-7 5 D
-11 -26 D
-13 -2 D
-7 -11 D
-45 9 D
--7 70 D
-2 53 D
-5 43 D
-P
-FO
-1471 2227 M
--10 -21 D
--25 -22 D
--20 -5 D
--3 -24 D
-9 -5 D
-4 -22 D
--35 -40 D
--10 4 D
--12 -9 D
-16 -7 D
--14 -14 D
-6 -9 D
-0 -2 D
-99 -18 D
-10 44 D
-20 58 D
-23 48 D
-5 7 D
-P
-FO
-1591 2378 M
--51 -23 D
--26 -34 D
-6 -26 D
--29 -8 D
-1 -18 D
--7 -1 D
--4 -18 D
--8 -1 D
-1 -16 D
--3 -6 D
-63 -37 D
-23 38 D
-22 28 D
-23 26 D
-32 31 D
-7 5 D
-P
-FO
-1783 2410 M
--3 2 D
--40 -2 D
--20 8 D
--15 -17 D
--8 4 D
--25 -15 D
--30 4 D
--3 21 D
--5 -19 D
--14 1 D
--6 -10 D
--23 -9 D
-50 -60 D
-35 27 D
-22 15 D
-39 21 D
-24 11 D
-25 10 D
-P
-FO
-1790 2403 M
--7 7 D
-3 -8 D
-P
-FO
-1726 2849 M
-2 8 D
-P
-FO
-2413 1819 M
-7 3 D
--2 10 D
--2 -2 D
-P
-FO
-2398 1774 M
-32 5 D
-1 15 D
--16 3 D
-7 7 D
--12 8 D
--3 -13 D
-P
-FO
-2371 1718 M
-14 -4 D
-47 -42 D
-20 -6 D
-21 8 D
-2 -12 D
--10 -10 D
-3 -1 D
-10 3 D
-1 -10 D
-14 -7 D
-1 11 D
--13 33 D
-6 5 D
--12 6 D
--3 23 D
--12 5 D
-4 7 D
--15 6 D
-10 6 D
--29 4 D
--21 13 D
-3 15 D
--15 3 D
--15 -36 D
-P
-FO
-2742 1492 M
-6 9 D
--13 -4 D
-7 8 D
--6 -6 D
-1 16 D
--7 -15 D
-P
-FO
-2830 1603 M
--3 -1 D
--1 -8 D
-1 0 D
-P
-FO
-2856 1677 M
--10 -18 D
-2 17 D
--7 1 D
-15 1 D
-4 12 D
--8 -1 D
-6 13 D
--7 -11 D
--10 4 D
-8 -10 D
--8 -2 D
--1 16 D
--6 -8 D
--10 7 D
--12 -5 D
-9 -3 D
--10 -1 D
-12 0 D
--9 -10 D
-11 11 D
-4 -10 D
--7 6 D
--9 -9 D
--12 12 D
-10 -6 D
--8 6 D
-6 -2 D
-5 11 D
--17 4 D
-3 -14 D
--9 11 D
--3 -5 D
-11 -5 D
--7 -20 D
--13 1 D
--7 12 D
-7 -4 D
-0 11 D
--17 -14 D
-23 -14 D
-3 -29 D
--8 -11 D
-19 3 D
-3 9 D
--2 -10 D
-13 3 D
-13 -23 D
-4 0 D
-18 49 D
-P
-FO
-2863 1703 M
-P
-FO
-2714 1621 M
--2 -25 D
-33 29 D
-33 3 D
-4 26 D
--13 5 D
--7 -15 D
--10 15 D
--14 -12 D
--3 7 D
-8 -1 D
--3 6 D
-15 13 D
--13 -8 D
-2 9 D
-6 -1 D
--1 18 D
-P
-2748 1642 M
--2 5 D
-3 -4 D
-P
-2727 1624 M
-10 21 D
-P
-FO
-2729 1666 M
--11 -5 D
-6 0 D
--3 -9 D
--5 3 D
--9 -11 D
-19 9 D
--1 -9 D
-P
-FO
-2766 1701 M
-2 -15 D
-13 10 D
--4 12 D
--10 -6 D
-2 -8 D
-P
-FO
-2786 1695 M
--9 -6 D
-7 0 D
-4 -19 D
-6 17 D
-P
-FO
-2758 1670 M
--9 -8 D
-16 -1 D
-P
-FO
-2752 1674 M
-11 6 D
--6 3 D
-P
-FO
-2862 1706 M
-3 6 D
--9 1 D
-P
-FO
-2841 1707 M
--4 -5 D
-10 1 D
-P
-FO
-2791 1709 M
--9 -12 D
-20 20 D
-P
-FO
-2819 1717 M
-9 -5 D
-P
-FO
-2722 1641 M
--9 -14 D
-P
-FO
-2758 1687 M
-8 -4 D
-P
-FO
-2852 1703 M
--10 -6 D
-P
-FO
-2737 1679 M
--1 0 D
--5 -9 D
-P
-FO
-2731 1665 M
--3 -12 D
-4 12 D
-P
-FO
-2851 1717 M
-2 -8 D
-P
-FO
-2704 1582 M
-2 11 D
-P
-FO
-2834 1713 M
--5 6 D
-P
-FO
-2824 1708 M
--7 -5 D
-P
-FO
-2812 1703 M
--7 -3 D
-P
-FO
-2738 1679 M
-4 6 D
-P
-FO
-2795 1705 M
--3 -7 D
-P
-FO
-2738 1675 M
--1 -6 D
-P
-FO
-2815 1709 M
--4 -5 D
-P
-FO
-2492 1672 M
-10 1 D
--6 14 D
-P
-FO
-2520 1621 M
-5 13 D
--9 -7 D
-P
-FO
-2730 1500 M
-5 -18 D
-7 10 D
-P
-FO
-2479 1644 M
-1 -7 D
--8 -3 D
-13 -15 D
--6 -15 D
-11 0 D
-3 33 D
-P
-FO
-2465 1652 M
--4 -4 D
-7 3 D
-P
-FO
-2721 1487 M
--3 -6 D
-8 2 D
--9 -18 D
-8 -1 D
--2 8 D
-14 5 D
--11 6 D
--1 15 D
--7 -3 D
-P
-FO
-2743 1489 M
--5 -5 D
-P
-FO
-2481 1621 M
--9 6 D
--5 -8 D
-5 -6 D
-P
-FO
-2483 1592 M
--3 6 D
--7 -14 D
-P
-FO
-2442 1273 M
-16 -7 D
-18 11 D
-P
-FO
-1950 1459 M
-7 6 D
-7 4 D
--14 0 D
-P
-FO
-1842 1482 M
-2 1 D
-12 -5 D
-27 -4 D
-6 4 D
-13 -6 D
-14 5 D
-19 -8 D
-10 0 D
-3 3 D
-0 -3 D
-2 0 D
-0 481 D
--164 -452 D
-48 -15 D
-P
-FO
-1648 1576 M
-1 0 D
-1 -2 D
-34 -25 D
-44 -26 D
-8 -3 D
-17 0 D
-17 -16 D
-16 -6 D
-164 452 D
--309 -368 D
-P
-FO
-1950 1950 M
--416 -240 D
-23 -38 D
-22 -28 D
-23 -26 D
-32 -31 D
-7 -5 D
-P
-FO
-1950 1950 M
--474 -83 D
-10 -44 D
-20 -58 D
-23 -48 D
-5 -7 D
-P
-FO
-1950 1950 M
--474 83 D
--7 -70 D
-2 -53 D
-5 -43 D
-P
-FO
-1950 1950 M
--416 240 D
--9 -15 D
--19 -40 D
--15 -41 D
--15 -61 D
-P
-FO
-1950 1950 M
--309 368 D
--20 -17 D
--31 -32 D
--22 -27 D
--21 -29 D
--13 -23 D
-P
-FO
-1950 1950 M
--164 452 D
--41 -17 D
--32 -16 D
--44 -29 D
--28 -22 D
-P
-FO
-1950 2244 M
--71 7 D
-5 -16 D
--11 -8 D
--19 23 D
--9 33 D
-19 7 D
--21 0 D
-5 16 D
-9 2 D
--7 12 D
-9 2 D
--1 12 D
-17 7 D
--1 30 D
-7 11 D
--7 12 D
-1 -10 D
--32 20 D
--47 -6 D
--6 5 D
--4 -1 D
-164 -452 D
-P
-FO
-2048 2220 M
--19 -7 D
--62 19 D
--12 11 D
--5 1 D
-0 -294 D
-P
-FO
-2177 2220 M
--7 1 D
--20 20 D
--20 2 D
--37 -25 D
--27 22 D
--9 -18 D
--9 -2 D
--98 -270 D
-P
-FO
-2288 2145 M
--6 16 D
--10 7 D
--1 25 D
--24 -9 D
--36 31 D
--34 5 D
--227 -270 D
-P
-FO
-2380 2026 M
--14 23 D
--21 -6 D
--9 -15 D
--1 11 D
--12 -14 D
--9 6 D
--3 -10 D
--9 2 D
-1 32 D
--16 7 D
-18 21 D
--1 27 D
--8 3 D
--8 32 D
--338 -195 D
-P
-FO
-2351 1879 M
-4 4 D
--19 14 D
-36 52 D
--7 6 D
-5 26 D
-14 16 D
-1 20 D
--5 9 D
--430 -76 D
-P
-FO
-2259 1772 M
-12 5 D
-36 -33 D
-20 -12 D
-44 -14 D
-14 27 D
-12 29 D
--2 0 D
-3 0 D
-11 31 D
-1 7 D
--6 3 D
-9 4 D
-3 11 D
--16 -10 D
--7 24 D
--2 -26 D
--10 3 D
--8 19 D
--16 -17 D
--20 3 D
-31 42 D
--15 6 D
--3 -14 D
--7 2 D
--1 10 D
+2998 701 M
 9 7 D
--401 71 D
+20 1 D
+64 32 D
+39 12 D
+3 -31 D
+8 -2 D
+-11 -12 D
+6 -6 D
+-6 -17 D
+15 2 D
+4 20 D
+5 -6 D
+7 10 D
+-2 -9 D
+10 20 D
+15 5 D
+10 16 D
+10 -1 D
+7 11 D
+42 25 D
+1 7 D
+-23 -18 D
+-8 6 D
+24 31 D
+7 1 D
+4 15 D
+-6 0 D
+11 5 D
+-7 1 D
+8 8 D
+-10 9 D
+8 13 D
+-3 20 D
+-18 -9 D
+0 14 D
+11 3 D
+-3 9 D
+6 -4 D
+12 11 D
+2 12 D
+-9 1 D
+9 2 D
+-3 6 D
+8 -14 D
+26 10 D
+13 11 D
+-3 12 D
+6 -2 D
+1 11 D
+9 1 D
+-10 11 D
+12 2 D
+0 17 D
+-13 -4 D
+12 16 D
+-14 -5 D
+15 10 D
+-2 12 D
+-7 0 D
+-1 -8 D
+-3 15 D
+-10 -14 D
+7 16 D
+19 16 D
+-7 6 D
+-10 -9 D
+-6 5 D
+9 7 D
+-9 6 D
+30 2 D
+-3 28 D
+-17 4 D
+-5 44 D
+12 29 D
+-179 103 D
+-36 -59 D
+-25 -37 D
+-26 -36 D
+-67 -84 D
+-34 -38 D
+-5 -4 D
+-17 -19 D
+-5 -4 D
+-4 -5 D
+-5 -4 D
+-4 -5 D
+-19 -17 D
+-4 -5 D
+-43 -38 D
+-14 -12 D
+P
+3234 920 M
+11 -5 D
+-7 -10 D
+P
+3128 833 M
+4 -6 D
 P
 FO
-2135 1730 M
-37 25 D
-20 -5 D
-11 8 D
-56 14 D
--309 178 D
+3428 970 M
+-4 6 D
+-8 -15 D
+-4 -15 D
 P
 FO
-2307 1744 M
-7 -7 D
+3485 1064 M
+-11 -10 D
+-2 -12 D
+1 0 D
+13 21 D
+P
+FO
+3270 803 M
+0 6 D
+15 6 D
+-23 -4 D
+-5 -19 D
+P
+FO
+3121 719 M
+-1 6 D
+-14 -12 D
 13 -5 D
 P
 FO
-2089 1568 M
-3 31 D
-15 -5 D
-9 11 D
--13 21 D
-8 17 D
--11 7 D
-20 45 D
--3 26 D
-18 9 D
--185 220 D
+3283 831 M
+-12 -15 D
+12 2 D
 P
 FO
-1964 1469 M
-0 1 D
+3157 693 M
+-3 -6 D
+P
+FO
+3029 703 M
+-11 -12 D
+P
+FO
+3424 993 M
+0 -14 D
+P
+FO
+3450 1024 M
+-3 -9 D
+P
+FO
+3242 763 M
+-5 4 D
+P
+FO
+3162 706 M
+-1 -6 D
+1 7 D
+P
+FO
+3153 684 M
+-1 -12 D
+P
+FO
+2570 716 M
+6 -29 D
+26 -18 D
+9 -26 D
+50 -18 D
+28 4 D
+14 -19 D
+-2 6 D
+19 -1 D
+-6 9 D
+8 -2 D
+3 6 D
+43 -28 D
+74 15 D
+28 -27 D
+18 2 D
+18 -23 D
+28 2 D
+16 17 D
+22 -20 D
+49 -14 D
+7 12 D
+-11 16 D
+5 18 D
+-9 -7 D
+-3 28 D
+-18 14 D
+-8 57 D
 14 11 D
-43 6 D
-24 24 D
+-160 191 D
+-48 -39 D
+-30 -22 D
+-30 -21 D
+-31 -21 D
+-21 -13 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+P
+FO
+2809 398 M
+-7 1 D
+P
+FO
+2899 452 M
+-3 0 D
+-56 -28 D
+-15 -2 D
+-14 -18 D
+25 11 D
+0 1 D
+3 0 D
+20 11 D
+P
+FO
+2620 636 M
+-5 4 D
+5 -21 D
+P
+FO
+2596 661 M
+-4 5 D
+P
+FO
+2739 390 M
+-18 -4 D
+P
+FO
+2590 673 M
+1 -7 D
+P
+FO
+2763 387 M
+-10 -4 D
+P
+FO
+1950 306 M
+2 2 D
+P
+FO
+1950 292 M
+43 13 D
+-41 -1 D
+0 -6 D
+13 5 D
+-15 -11 D
+P
+FO
+2313 329 M
+6 3 D
+-9 7 D
+-10 -2 D
+P
+FO
+1988 328 M
+14 -13 D
+26 14 D
+-19 5 D
+P
+FO
+2340 316 M
+-8 11 D
+-13 -6 D
+22 -12 D
+P
+FO
+2493 277 M
+-11 -3 D
+36 0 D
+P
+FO
+2256 375 M
+-9 -1 D
+8 -5 D
+P
+FO
+2296 452 M
+90 -23 D
+-32 18 D
+P
+FO
+2289 324 M
+3 -10 D
+P
+FO
+2290 338 M
+-11 0 D
+P
+FO
+2006 350 M
+-14 -2 D
+P
+FO
+2298 312 M
+8 5 D
+P
+FO
+2319 298 M
+-5 -4 D
+P
+FO
+2317 424 M
+-2 -7 D
+P
+FO
+2292 424 M
+10 -3 D
+P
+FO
+2284 357 M
+-12 -3 D
+P
+FO
+2295 329 M
+-10 0 D
+P
+FO
+2272 433 M
+7 -4 D
+P
+FO
+2249 384 M
+-7 3 D
+P
+FO
+2376 243 M
+9 3 D
+P
+FO
+1950 292 M
+P
+FO
+1950 306 M
+-4 -4 D
+P
+FO
+1709 268 M
+-12 2 D
+19 -5 D
+P
+FO
+1737 255 M
+-19 6 D
+P
+FO
+1824 393 M
+-9 2 D
+P
+FO
+1681 279 M
+-8 0 D
+P
+FO
+1125 543 M
+-9 12 D
+P
+FO
+1015 579 M
+-2 7 D
+P
+FO
+930 690 M
+-2 6 D
+P
+FO
+214 2312 M
+27 12 D
+48 34 D
+8 -8 D
+17 10 D
+20 19 D
+65 91 D
+32 24 D
+30 -6 D
+27 -8 D
+34 -28 D
+37 -8 D
+60 -49 D
+21 -1 D
+1 -2 D
+31 81 D
+14 35 D
+38 78 D
+30 55 D
+-340 196 D
+-43 -80 D
+-40 -83 D
+-35 -84 D
+-31 -86 D
+-30 -103 D
+P
+383 2535 M
+25 20 D
+4 -10 D
+-11 -1 D
+1 -8 D
+-16 -18 D
+-8 8 D
+P
+478 2577 M
+-13 -5 D
+-9 9 D
+P
+417 2698 M
+5 0 D
+P
+380 2620 M
+5 -3 D
+P
+387 2660 M
+-6 0 D
+P
+384 2647 M
+-4 3 D
+P
+FO
+758 2648 M
+-13 8 D
+-2 7 D
+-20 28 D
+3 14 D
+38 51 D
+-41 -64 D
+26 -37 D
+10 -5 D
+36 58 D
+39 56 D
+56 72 D
+-4 17 D
+3 27 D
+-17 25 D
+-19 5 D
+-3 18 D
+-10 -5 D
+11 9 D
+-1 23 D
+10 34 D
+16 19 D
+7 31 D
+18 14 D
+4 15 D
+4 -4 D
+21 18 D
+-5 8 D
+12 25 D
+-8 6 D
+2 44 D
+-92 108 D
+-29 36 D
+-55 -49 D
+-42 -39 D
+-5 -6 D
+-18 -17 D
+-5 -6 D
+-12 -11 D
+-66 -72 D
+-51 -63 D
+-49 -65 D
+-42 -61 D
+-34 -55 D
+-17 -28 D
+340 -196 D
+P
+842 3037 M
+-12 -3 D
+-2 -8 D
+0 9 D
+-14 -1 D
+14 17 D
+2 -4 D
+12 3 D
+-18 -6 D
+-4 -9 D
+P
+815 3081 M
+-7 -6 D
+-2 11 D
+-5 -8 D
+-1 11 D
+17 -1 D
+P
+811 2970 M
+-10 -5 D
+P
+762 2714 M
+2 7 D
+-1 -7 D
+P
+799 2942 M
+11 12 D
+4 -4 D
+P
+862 3059 M
+-6 1 D
+7 -1 D
+P
+886 2843 M
+-1 7 D
+P
+808 3030 M
+-14 -5 D
+P
+FO
+880 2894 M
+-4 9 D
+P
+FO
+876 3006 M
+3 6 D
+P
+FO
+887 3037 M
+5 5 D
+P
+FO
+931 3165 M
+0 7 D
+-13 21 D
+4 20 D
+-51 77 D
+0 7 D
+10 -2 D
+6 12 D
+17 75 D
+-29 -21 D
+-47 -37 D
+-18 -15 D
+59 -71 D
+P
+FO
+2358 3270 M
+12 -41 D
+-2 -18 D
+-13 -2 D
+2 -34 D
+10 1 D
+21 -23 D
+34 95 D
+P
+FO
+2529 3204 M
+2 -6 D
+-2 6 D
+-62 27 D
+-45 17 D
+-34 -96 D
+60 -4 D
+45 -25 D
+50 -9 D
+84 9 D
+32 12 D
+-64 36 D
+-57 29 D
+P
+2540 3185 M
+7 -4 D
+P
+FO
+2569 2754 M
+5 -3 D
+P
+FO
+2839 2291 M
+7 -2 D
+1 -17 D
+3 12 D
+3 -13 D
+8 1 D
+-10 17 D
+8 -2 D
+-7 8 D
+9 6 D
+P
+FO
+3202 1367 M
+-10 3 D
+-36 -5 D
+-24 16 D
+3 17 D
+-18 5 D
+-27 -24 D
+-15 -26 D
+1 -50 D
+-1 -2 D
+71 -42 D
+34 62 D
+P
+FO
+3075 1301 M
+-43 -68 D
+8 -24 D
+-11 -42 D
+-62 -106 D
+-64 -37 D
+-4 8 D
+-15 -7 D
+-34 9 D
+7 6 D
+-20 -7 D
+7 -7 D
+-8 -52 D
+8 -8 D
+-19 13 D
+0 18 D
+-11 12 D
+7 6 D
+-3 9 D
+-12 -17 D
+8 -20 D
+-17 4 D
+-4 19 D
+-12 -13 D
+-16 -2 D
+-8 3 D
+4 -1 D
+-17 15 D
+-8 1 D
+102 -121 D
+57 50 D
+4 5 D
+19 17 D
+4 5 D
+5 4 D
+4 5 D
+5 4 D
+17 19 D
+5 4 D
+54 62 D
+55 70 D
+36 52 D
+43 70 D
+P
+FO
+2805 1033 M
+-15 -20 D
+26 22 D
+P
+FO
+2736 1013 M
+-17 2 D
+-60 -25 D
+-11 -34 D
+-7 3 D
+6 8 D
+-13 -11 D
+-2 7 D
+-21 -3 D
+4 -5 D
+-21 -34 D
+7 9 D
+-1 -6 D
+-38 -32 D
+16 -36 D
+-7 -19 D
+7 -1 D
+2 -32 D
+-17 -34 D
+7 -3 D
+-4 -29 D
+4 -22 D
+87 47 D
+52 33 D
+81 57 D
+48 39 D
+P
+2668 983 M
+2 -5 D
+P
+2626 815 M
+2 -7 D
+P
+2629 901 M
+3 -5 D
+P
+FO
+2562 1042 M
+-17 -3 D
+6 -21 D
+-20 1 D
+12 -26 D
+-5 3 D
+21 -23 D
+19 25 D
+39 11 D
+-11 12 D
+-24 8 D
+8 2 D
+-7 6 D
+P
+2562 1034 M
+8 -2 D
+P
+FO
+2568 961 M
+-7 -1 D
+12 -5 D
+P
+FO
+2544 1032 M
+0 -9 D
+P
+FO
+2634 1003 M
+9 -5 D
+P
+FO
+2051 808 M
+6 7 D
+-13 6 D
+-14 -9 D
+-19 -46 D
+-20 -3 D
+-10 -31 D
+12 -3 D
+17 12 D
+24 -7 D
+14 -24 D
+-3 16 D
+20 -6 D
+-3 -12 D
+13 -10 D
+1 -14 D
+4 4 D
+17 -10 D
+3 5 D
+6 -12 D
+8 1 D
+-35 39 D
+4 -8 D
+-13 4 D
+0 8 D
+7 -3 D
+-9 12 D
+-9 -1 D
+8 1 D
+-10 15 D
+5 22 D
+17 12 D
+-28 12 D
+P
+2038 762 M
+-6 -5 D
+P
+FO
+2129 935 M
+-12 -10 D
+-4 -43 D
+-16 -5 D
+11 -6 D
+-11 6 D
+-16 -3 D
+8 -3 D
+-1 -12 D
+-25 -34 D
+0 -11 D
+8 2 D
+-7 -7 D
+21 10 D
+13 -13 D
+-7 -4 D
+16 9 D
+20 53 D
+25 24 D
+16 4 D
+20 30 D
+-5 6 D
+7 -1 D
+-2 20 D
+-17 -5 D
+-26 6 D
+P
+2151 895 M
+-1 9 D
+7 -4 D
+P
+2146 896 M
+2 6 D
+P
+2180 936 M
+-3 5 D
+P
+2163 909 M
+-8 10 D
+P
+2130 874 M
+-1 0 D
+3 21 D
+P
+2135 880 M
+-1 10 D
+P
+2124 870 M
+-8 7 D
+P
+FO
+2160 961 M
+6 -9 D
+3 15 D
+P
+FO
+2052 704 M
+-5 3 D
+P
+FO
+2075 809 M
+-4 -6 D
+P
+FO
+1887 871 M
+-9 -5 D
+12 0 D
+P
+FO
+1037 2197 M
+-1 9 D
+-28 1 D
+15 -6 D
+-4 -10 D
+15 3 D
+-11 12 D
+P
+FO
+1044 2222 M
+23 69 D
+3 6 D
+-7 -2 D
+7 2 D
+3 9 D
+-17 13 D
+-11 39 D
+-15 7 D
+-12 -16 D
+-25 -5 D
+-11 18 D
+4 27 D
+-25 15 D
+-5 24 D
+-12 -8 D
+2 11 D
+10 2 D
+-1 11 D
+-12 2 D
+1 -16 D
+-12 -6 D
+-27 13 D
+20 18 D
+8 27 D
+-31 18 D
+5 5 D
+-15 0 D
+16 20 D
+8 22 D
+-107 61 D
+-34 21 D
+6 -23 D
+26 -8 D
+-28 8 D
+-5 23 D
+-20 12 D
+-47 -88 D
+-26 -57 D
+-27 -69 D
+-13 -35 D
+9 -13 D
+61 -17 D
+61 -55 D
+1 -13 D
+47 -3 D
+28 -24 D
+15 5 D
+2 -6 D
+-1 17 D
+4 6 D
+-2 7 D
+8 -15 D
+8 9 D
+6 -5 D
+-6 -5 D
+9 4 D
+-4 -5 D
+18 -12 D
+10 5 D
+4 -12 D
+12 10 D
+9 -21 D
+8 12 D
+-3 -13 D
+7 -4 D
+-1 9 D
+17 -15 D
+-10 -1 D
+-2 -11 D
+2 9 D
+-3 -6 D
+-5 6 D
+3 -7 D
+-6 -4 D
+-1 -7 D
+6 8 D
+6 -7 D
+4 -15 D
+6 5 D
+-6 -3 D
+-3 13 D
+9 -2 D
+1 11 D
+12 2 D
+2 -11 D
+4 10 D
+1 -15 D
 2 17 D
-40 28 D
-2 12 D
--139 382 D
+11 6 D
+-4 -7 D
+9 3 D
+-12 -20 D
+13 11 D
+1 -10 D
+5 5 D
+13 -10 D
+-3 7 D
+13 3 D
+-5 -10 D
+9 2 D
+P
+1022 2232 M
+-11 5 D
+10 2 D
+-7 4 D
+17 1 D
+P
+981 2248 M
+-10 7 D
+10 26 D
+-6 -19 D
+P
+740 2574 M
+-8 -4 D
+7 17 D
+P
+856 2311 M
+11 8 D
+-2 -10 D
+P
+861 2285 M
+-7 3 D
+7 4 D
+P
+978 2329 M
+-10 -1 D
+P
+943 2284 M
+-3 -5 D
+P
+1033 2261 M
+-5 3 D
+5 -2 D
+P
+840 2304 M
+2 -6 D
+P
+972 2320 M
+-6 5 D
+P
+957 2225 M
+4 5 D
+5 -6 D
+P
+991 2260 M
+-2 -6 D
+P
+862 2301 M
+-3 -5 D
+P
+925 2293 M
+-4 -5 D
+P
+830 2309 M
+5 1 D
+P
+909 2283 M
+-6 -2 D
+P
+786 2344 M
+6 -1 D
+P
+853 2316 M
+-1 0 D
+5 4 D
+P
+838 2326 M
+0 -6 D
+P
+831 2304 M
+5 4 D
+P
+1044 2240 M
+-10 -10 D
+P
+FO
+898 2252 M
+-2 10 D
+-29 8 D
+-2 -10 D
+9 -6 D
+20 -10 D
+P
+FO
+934 2261 M
+-9 3 D
+3 -11 D
+P
+FO
+1005 2203 M
+4 8 D
+-12 -1 D
+P
+FO
+1026 2187 M
+7 6 D
+P
+FO
+1012 2192 M
+2 6 D
+P
+FO
+1015 2200 M
+6 1 D
+-5 -1 D
+P
+FO
+948 2241 M
+-3 6 D
+P
+FO
+925 2246 M
+4 5 D
+P
+FO
+955 2238 M
+5 1 D
+P
+FO
+919 2235 M
+1 6 D
+P
+FO
+997 2212 M
+6 1 D
+P
+FO
+1014 2198 M
+-5 -1 D
+P
+FO
+985 2201 M
+3 6 D
+P
+FO
+938 2240 M
+-5 5 D
+P
+FO
+995 2206 M
+8 -2 D
+P
+FO
+927 2243 M
+-4 -6 D
+P
+FO
+1000 2193 M
+5 5 D
+P
+FO
+946 2228 M
+-6 4 D
+P
+FO
+759 2650 M
+12 -7 D
+4 -14 D
+34 -21 D
+107 -61 D
+11 30 D
+3 22 D
+-12 30 D
+-11 5 D
+-14 -7 D
+-10 11 D
+-32 -16 D
+-23 17 D
+15 -9 D
+17 5 D
+29 26 D
+21 40 D
+-6 49 D
+-17 22 D
+-6 41 D
+-9 0 D
+19 8 D
+5 -50 D
+2 37 D
+-8 28 D
+-63 -81 D
+-44 -66 D
+P
+900 2726 M
+-11 5 D
+-1 29 D
+10 -10 D
+-6 -6 D
+P
+845 2673 M
+9 31 D
+-3 -17 D
+5 1 D
+P
+904 2735 M
+-4 19 D
+P
+FO
+774 2629 M
+-2 10 D
+-14 9 D
+-4 -7 D
+P
+FO
+5 -2 1 765 2644 SP
+1952 2431 M
+-2 10 D
+0 -10 D
+P
+FO
+1965 2431 M
+-8 2 D
+-2 -2 D
+P
+FO
+1998 2428 M
+0 1 D
+P
+FO
+2044 2422 M
+-23 7 D
+-4 -3 D
+P
+FO
+2117 2408 M
+-10 -3 D
+-8 11 D
+-19 1 D
+-4 10 D
+-18 -9 D
+29 -7 D
+27 -9 D
+P
+FO
+2130 2396 M
+-13 12 D
+-3 -6 D
+P
+FO
+2250 2326 M
+-5 12 D
+12 4 D
+-13 -2 D
+-10 37 D
+-70 3 D
+23 -11 D
+43 -28 D
+P
+FO
+2277 2340 M
+-1 1 D
+-24 -17 D
+7 -6 D
+P
+FO
+2418 2220 M
+-3 8 D
+-3 23 D
+11 4 D
+2 20 D
+-8 17 D
+-29 20 D
+-14 -17 D
+-3 18 D
+-9 4 D
+0 -12 D
+-9 2 D
+-8 19 D
+-7 -5 D
+-61 19 D
+-18 -22 D
+20 -17 D
+31 -32 D
+22 -27 D
+21 -29 D
+13 -23 D
+P
+FO
+2469 2042 M
+-6 10 D
+-21 4 D
+-23 24 D
+-2 7 D
+11 -2 D
+12 17 D
+-8 20 D
+19 14 D
+-33 84 D
+-26 -15 D
+-26 -15 D
+9 -15 D
+19 -40 D
+15 -41 D
+15 -61 D
+P
+FO
+2790 2203 M
+1 -10 D
+0 10 D
+P
+FO
+2523 1849 M
+3 20 D
+20 14 D
+-6 10 D
+-21 2 D
+-10 13 D
+4 23 D
+-7 23 D
+11 35 D
+-10 19 D
+-7 -5 D
+-11 26 D
+-13 2 D
+-7 11 D
+-11 -2 D
+-12 -2 D
+-11 -2 D
+-11 -3 D
+7 -70 D
+-2 -53 D
+-5 -43 D
+P
+FO
+2429 1673 M
+10 21 D
+25 22 D
+20 5 D
+3 24 D
+-9 5 D
+-4 22 D
+35 40 D
+10 -4 D
+12 9 D
+-16 7 D
+14 14 D
+-6 9 D
+0 2 D
+-99 18 D
+-10 -44 D
+-20 -58 D
+-23 -48 D
+-5 -7 D
+P
+FO
+2309 1522 M
+51 23 D
+26 34 D
+-6 26 D
+29 8 D
+-1 18 D
+7 1 D
+4 18 D
+8 1 D
+-1 16 D
+3 6 D
+-63 37 D
+-23 -38 D
+-22 -28 D
+-23 -26 D
+-32 -31 D
+-7 -5 D
+P
+FO
+2117 1490 M
+3 -2 D
+40 2 D
+20 -8 D
+15 17 D
+8 -4 D
+25 15 D
+30 -4 D
+3 -21 D
+5 19 D
+14 -1 D
+6 10 D
+23 9 D
+-50 60 D
+-28 -22 D
+-22 -15 D
+-15 -9 D
+-15 -9 D
+-16 -8 D
+-16 -8 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-9 -3 D
+P
+FO
+2110 1497 M
+7 -7 D
+-3 8 D
+-2 -1 D
+P
+FO
+2174 1051 M
+-2 -8 D
+P
+FO
+1487 2081 M
+-7 -3 D
+2 -10 D
+2 2 D
+P
+FO
+1502 2126 M
+-32 -5 D
+-1 -15 D
+16 -3 D
+-7 -7 D
+12 -8 D
+3 13 D
+P
+FO
+1529 2182 M
+-14 4 D
+-47 42 D
+-20 6 D
+-21 -8 D
+-2 12 D
+10 10 D
+-1 0 D
+-2 1 D
+-10 -3 D
+-1 10 D
+-14 7 D
+-1 -11 D
+13 -33 D
+-6 -5 D
+12 -6 D
+3 -23 D
+12 -5 D
+-4 -7 D
+15 -6 D
+-10 -6 D
+29 -4 D
+21 -13 D
+-3 -15 D
+15 -3 D
+15 36 D
+P
+FO
+1158 2408 M
+-6 -9 D
+13 4 D
+-7 -8 D
+6 6 D
+-1 -16 D
+7 15 D
+P
+FO
+1070 2297 M
+3 1 D
+1 8 D
+-1 0 D
+P
+FO
+1044 2223 M
+10 18 D
+-2 -17 D
+7 -1 D
+-15 -1 D
+-4 -12 D
+8 1 D
+-6 -13 D
+7 11 D
+10 -4 D
+-8 10 D
+8 2 D
+1 -16 D
+6 8 D
+10 -7 D
+12 5 D
+-9 3 D
+10 1 D
+-12 0 D
+9 10 D
+-11 -11 D
+-4 10 D
+7 -6 D
+9 9 D
+12 -12 D
+-10 6 D
+8 -6 D
+-6 2 D
+-5 -11 D
+17 -4 D
+-3 14 D
+9 -11 D
+3 5 D
+-11 5 D
+7 20 D
+13 -1 D
+7 -12 D
+-7 4 D
+0 -11 D
+17 14 D
+-23 14 D
+-3 29 D
+8 11 D
+-19 -3 D
+-3 -9 D
+2 10 D
+-13 -3 D
+-13 23 D
+-4 0 D
+-18 -49 D
+P
+FO
+1037 2197 M
+P
+FO
+1186 2279 M
+2 25 D
+-33 -29 D
+-33 -3 D
+-4 -26 D
+13 -5 D
+7 15 D
+10 -15 D
+14 12 D
+3 -7 D
+-8 1 D
+3 -6 D
+-15 -13 D
+13 8 D
+-2 -9 D
+-6 1 D
+1 -18 D
+P
+1152 2258 M
+2 -5 D
+-3 4 D
+P
+1173 2276 M
+-10 -21 D
+P
+FO
+1171 2234 M
+11 5 D
+-6 0 D
+3 9 D
+5 -3 D
+9 11 D
+-19 -9 D
+1 9 D
+P
+FO
+1134 2199 M
+-2 15 D
+-13 -10 D
+4 -12 D
+10 6 D
+-2 8 D
+P
+FO
+1114 2205 M
+9 6 D
+-7 0 D
+-4 19 D
+-6 -17 D
+P
+FO
+1142 2230 M
+9 8 D
+-16 1 D
+P
+FO
+1148 2226 M
+-11 -6 D
+6 -3 D
+P
+FO
+1038 2194 M
+-3 -6 D
+9 -1 D
+P
+FO
+1059 2193 M
+4 5 D
+-10 -1 D
+P
+FO
+1109 2191 M
+9 12 D
+-20 -20 D
+P
+FO
+1081 2183 M
+-9 5 D
+P
+FO
+1178 2259 M
+9 14 D
+P
+FO
+1142 2213 M
+-8 4 D
+P
+FO
+1048 2197 M
+10 6 D
+P
+FO
+1163 2221 M
+1 0 D
+5 9 D
+P
+FO
+1169 2235 M
+3 12 D
+-4 -12 D
+P
+FO
+1049 2183 M
+-2 8 D
+P
+FO
+1196 2318 M
+-2 -11 D
+P
+FO
+1066 2187 M
+5 -6 D
+P
+FO
+1076 2192 M
+7 5 D
+P
+FO
+1088 2197 M
+7 3 D
+P
+FO
+1162 2221 M
+-4 -6 D
+P
+FO
+1105 2195 M
+3 7 D
+P
+FO
+1162 2225 M
+1 6 D
+P
+FO
+1085 2191 M
+4 5 D
+P
+FO
+1408 2228 M
+-10 -1 D
+6 -14 D
+P
+FO
+1380 2279 M
+-5 -13 D
+9 7 D
+P
+FO
+1170 2400 M
+-5 18 D
+-7 -10 D
+P
+FO
+1421 2256 M
+-1 7 D
+8 3 D
+-13 15 D
+6 15 D
+-11 0 D
+-3 -33 D
+P
+FO
+1435 2248 M
+4 4 D
+-7 -3 D
+P
+FO
+1179 2413 M
+3 6 D
+-8 -2 D
+9 18 D
+-8 1 D
+2 -8 D
+-14 -5 D
+11 -6 D
+1 -15 D
+7 3 D
+P
+FO
+1157 2411 M
+5 5 D
+P
+FO
+1419 2279 M
+9 -6 D
+5 8 D
+-5 6 D
+P
+FO
+1417 2308 M
+3 -6 D
+7 14 D
+P
+FO
+1458 2627 M
+-16 7 D
+-18 -11 D
+P
+FO
+1950 2441 M
+-7 -6 D
+-7 -4 D
+14 0 D
+P
+FO
+2058 2418 M
+-2 -1 D
+-12 5 D
+-27 4 D
+-6 -4 D
+-13 6 D
+-14 -5 D
+-19 8 D
+-5 0 D
+-5 0 D
+-3 -3 D
+0 3 D
+-2 0 D
 0 -481 D
+164 452 D
+-48 15 D
+P
+FO
+2252 2324 M
+-1 0 D
+-1 2 D
+-34 25 D
+-44 26 D
+-8 3 D
+-17 0 D
+-17 16 D
+-16 6 D
+-164 -452 D
+309 368 D
+P
+FO
+1950 1950 M
+416 240 D
+-23 38 D
+-22 28 D
+-23 26 D
+-32 31 D
+-7 5 D
+P
+FO
+1950 1950 M
+474 83 D
+-10 44 D
+-20 58 D
+-23 48 D
+-5 7 D
+-311 -180 D
+P
+FO
+1950 1950 M
+474 -83 D
+7 70 D
+-2 53 D
+-5 43 D
+-236 -41 D
+-119 -21 D
+P
+FO
+1950 1950 M
+416 -240 D
+9 15 D
+19 40 D
+15 41 D
+15 61 D
+P
+FO
+1950 1950 M
+309 -368 D
+20 17 D
+31 32 D
+22 27 D
+21 29 D
+13 23 D
+P
+FO
+1950 1950 M
+164 -452 D
+41 17 D
+32 16 D
+44 29 D
+28 22 D
+P
+FO
+1950 1656 M
+71 -7 D
+-5 16 D
+11 8 D
+19 -23 D
+9 -33 D
+-19 -7 D
+21 0 D
+-5 -16 D
+-9 -2 D
+7 -12 D
+-9 -2 D
+1 -12 D
+-17 -7 D
+1 -30 D
+-7 -11 D
+7 -12 D
+-1 10 D
+32 -20 D
+47 6 D
+6 -5 D
+4 1 D
+-164 452 D
+P
+FO
+1852 1680 M
+19 7 D
+62 -19 D
+12 -11 D
+5 -1 D
+0 294 D
+P
+FO
+1723 1680 M
+7 -1 D
+20 -20 D
+20 -2 D
+37 25 D
+27 -22 D
+9 18 D
+9 2 D
+98 270 D
+P
+FO
+1612 1755 M
+6 -16 D
+10 -7 D
+1 -25 D
+24 9 D
+36 -31 D
+34 -5 D
+227 270 D
+-254 -146 D
+P
+FO
+1520 1874 M
+14 -23 D
+21 6 D
+9 15 D
+1 -11 D
+12 14 D
+9 -6 D
+3 10 D
+9 -2 D
+-1 -32 D
+16 -7 D
+-18 -21 D
+1 -27 D
+8 -3 D
+8 -32 D
+338 195 D
+-108 -19 D
+P
+FO
+1549 2021 M
+-4 -4 D
+19 -14 D
+-36 -52 D
+7 -6 D
+-5 -26 D
+-14 -16 D
+-1 -20 D
+5 -9 D
+430 76 D
+P
+FO
+1641 2128 M
+-12 -5 D
+-36 33 D
+-20 12 D
+-44 14 D
+-14 -27 D
+-12 -29 D
+2 0 D
+-3 0 D
+-11 -31 D
+-1 -7 D
+6 -3 D
+-9 -4 D
+-3 -11 D
+16 10 D
+7 -24 D
+2 26 D
+10 -3 D
+8 -19 D
+16 17 D
+20 -3 D
+-31 -42 D
+15 -6 D
+3 14 D
+7 -2 D
+1 -10 D
+-9 -7 D
+401 -71 D
+P
+FO
+1765 2170 M
+-37 -25 D
+-20 5 D
+-11 -8 D
+-56 -14 D
+309 -178 D
+P
+FO
+1593 2156 M
+-7 7 D
+-13 5 D
+P
+FO
+1811 2332 M
+-3 -31 D
+-15 5 D
+-9 -11 D
+13 -21 D
+-8 -17 D
+11 -7 D
+-20 -45 D
+3 -26 D
+-18 -9 D
+185 -220 D
+P
+FO
+1936 2431 M
+0 -1 D
+-14 -11 D
+-43 -6 D
+-24 -24 D
+-2 -17 D
+-40 -28 D
+-2 -12 D
+139 -382 D
+0 481 D
+-5 0 D
+-4 0 D
 P
 FO
 25 W
 4 W
-1950 1829 M
-0 -1829 D
-S
-1829 1950 M
--1829 0 D
-S
 1950 2071 M
 0 1829 D
 S
 2071 1950 M
 1829 0 D
 S
-1950 1950 M
-0 -121 D
+1950 1829 M
+0 -1829 D
 S
-1950 1950 M
--121 0 D
+1829 1950 M
+-1829 0 D
 S
 1950 1950 M
 0 121 D
@@ -11475,3773 +8102,17 @@ S
 1950 1950 M
 121 0 D
 S
-1950 1829 M
--22 2 D
--23 7 D
--23 12 D
--14 11 D
--1 2 D
--6 5 D
--1 2 D
--2 1 D
--11 16 D
--9 17 D
--6 19 D
--3 26 D
-3 27 D
-5 16 D
-10 22 D
-10 14 D
-4 3 D
-8 9 D
-20 14 D
-17 9 D
-23 6 D
-25 2 D
-26 -4 D
-23 -8 D
-16 -10 D
-17 -14 D
-5 -6 D
-2 -1 D
-13 -20 D
-10 -23 D
-4 -23 D
-1 -20 D
--5 -26 D
--10 -25 D
--14 -20 D
--2 -1 D
--5 -6 D
--2 -1 D
--3 -4 D
--22 -15 D
--27 -11 D
--19 -3 D
-P S
 1950 1950 M
-0 0 D
-P S
-1950 0 M
--68 1 D
--108 7 D
--97 11 D
--77 13 D
--77 15 D
--104 27 D
--94 29 D
--55 19 D
--100 41 D
--89 41 D
--17 9 D
--69 37 D
--51 29 D
--33 21 D
--82 54 D
--86 64 D
--61 50 D
--65 59 D
--77 76 D
--53 57 D
--50 60 D
--37 46 D
--57 79 D
--43 66 D
--31 50 D
--38 68 D
--18 35 D
--38 79 D
--35 81 D
--31 83 D
--32 102 D
--23 85 D
--19 86 D
--17 107 D
--12 107 D
--4 68 D
--2 88 D
-1 68 D
-7 108 D
-11 97 D
-13 77 D
-15 77 D
-27 104 D
-29 94 D
-19 55 D
-41 100 D
-41 89 D
-9 17 D
-37 69 D
-29 51 D
-21 33 D
-54 82 D
-64 86 D
-50 61 D
-59 65 D
-76 77 D
-57 53 D
-60 50 D
-46 37 D
-79 57 D
-66 43 D
-50 31 D
-68 38 D
-35 18 D
-79 38 D
-81 35 D
-83 31 D
-102 32 D
-85 23 D
-86 19 D
-107 17 D
-107 12 D
-68 4 D
-88 2 D
-68 -1 D
-108 -7 D
-97 -11 D
-77 -13 D
-77 -15 D
-104 -27 D
-94 -29 D
-55 -19 D
-100 -41 D
-89 -41 D
-17 -9 D
-69 -37 D
-51 -29 D
-33 -21 D
-82 -54 D
-86 -64 D
-61 -50 D
-65 -59 D
-77 -76 D
-53 -57 D
-50 -60 D
-37 -46 D
-57 -79 D
-43 -66 D
-31 -50 D
-38 -68 D
-18 -35 D
-38 -79 D
-35 -81 D
-31 -83 D
-32 -102 D
-23 -85 D
-19 -86 D
-17 -107 D
-12 -107 D
-4 -68 D
-2 -88 D
--1 -68 D
--7 -108 D
--11 -97 D
--13 -77 D
--15 -77 D
--27 -104 D
--29 -94 D
--19 -55 D
--41 -100 D
--41 -89 D
--9 -17 D
--37 -69 D
--29 -51 D
--21 -33 D
--54 -82 D
--64 -86 D
--50 -61 D
--59 -65 D
--76 -77 D
--57 -53 D
--60 -50 D
--46 -37 D
--79 -57 D
--66 -43 D
--50 -31 D
--68 -38 D
--35 -18 D
--79 -38 D
--81 -35 D
--83 -31 D
--102 -32 D
--85 -23 D
--86 -19 D
--107 -17 D
--107 -12 D
--68 -4 D
-P S
-8 W
-N 1950 0 M 0 -83 D S
-N 1950 0 M 0 -83 D S
-25 W
-1950 0 M
-68 1 D
-108 7 D
-97 11 D
-77 13 D
-77 15 D
-104 27 D
-94 29 D
-55 19 D
-100 41 D
-89 41 D
-17 9 D
-69 37 D
-51 29 D
-33 21 D
-82 54 D
-86 64 D
-61 50 D
-65 59 D
-77 76 D
-53 57 D
-50 60 D
-37 46 D
-57 79 D
-43 66 D
-31 50 D
-38 68 D
-18 35 D
-38 79 D
-35 81 D
-31 83 D
-32 102 D
-23 85 D
-19 86 D
-17 107 D
-12 107 D
-4 68 D
-2 88 D
--1 68 D
--7 108 D
--11 97 D
--13 77 D
--15 77 D
--27 104 D
--29 94 D
--19 55 D
--41 100 D
--41 89 D
--9 17 D
--37 69 D
--29 51 D
--21 33 D
--54 82 D
--64 86 D
--50 61 D
--59 65 D
--76 77 D
--57 53 D
--60 50 D
--46 37 D
--79 57 D
--66 43 D
--50 31 D
--68 38 D
--35 18 D
--79 38 D
--81 35 D
--83 31 D
--102 32 D
--85 23 D
--86 19 D
--107 17 D
--107 12 D
--68 4 D
--88 2 D
--68 -1 D
--108 -7 D
--97 -11 D
--77 -13 D
--77 -15 D
--104 -27 D
--94 -29 D
--55 -19 D
--100 -41 D
--89 -41 D
--17 -9 D
--69 -37 D
--51 -29 D
--33 -21 D
--82 -54 D
--86 -64 D
--61 -50 D
--65 -59 D
--77 -76 D
--53 -57 D
--50 -60 D
--37 -46 D
--57 -79 D
--43 -66 D
--31 -50 D
--38 -68 D
--18 -35 D
--38 -79 D
--35 -81 D
--31 -83 D
--32 -102 D
--23 -85 D
--19 -86 D
--17 -107 D
--12 -107 D
--4 -68 D
--2 -88 D
-1 -68 D
-7 -108 D
-11 -97 D
-13 -77 D
-15 -77 D
-27 -104 D
-29 -94 D
-19 -55 D
-41 -100 D
-41 -89 D
-9 -17 D
-37 -69 D
-29 -51 D
-21 -33 D
-54 -82 D
-64 -86 D
-50 -61 D
-59 -65 D
-76 -77 D
-57 -53 D
-60 -50 D
-46 -37 D
-79 -57 D
-66 -43 D
-50 -31 D
-68 -38 D
-35 -18 D
-79 -38 D
-81 -35 D
-83 -31 D
-102 -32 D
-85 -23 D
-86 -19 D
-107 -17 D
-107 -12 D
-68 -4 D
-P S
-1950 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-(0ö) tc Z
-%%EndObject
-0 A
-FQ
-O0
-4980 0 TM
-
-% PostScript produced by:
-%@GMT: pscoast -R0/360/-90/0 -JA245/-90/3.25i -Bg90a360f360 -Gred -Dc -X4.15i -O -p0
-1950 1950 T
--1950 -1950 T
-%@PROJ: laea 0.00000000 360.00000000 -90.00000000 0.00000000 -9009909.869 9009909.869 -9009909.869 9009909.869 +proj=laea +lat_0=-90 +lon_0=245 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
-%%BeginObject PSL_Layer_6
-0 setlinecap
-0 setlinejoin
-3.32551 setmiterlimit
-3366 609 M
-23 80 D
--11 11 D
-13 -8 D
--14 -59 D
-4 -7 D
--1 -2 D
--4 6 D
-1 -9 D
-44 48 D
-47 57 D
-46 59 D
-47 67 D
--7 11 D
-9 11 D
--42 -8 D
--70 -36 D
--26 2 D
--14 -10 D
-6 12 D
--54 -4 D
--2 18 D
--21 0 D
--47 -56 D
--39 -43 D
--9 -11 D
--15 -16 D
--11 -10 D
--15 -16 D
-125 -125 D
-18 19 D
-7 6 D
-P
-3338 647 M
-15 -8 D
--8 -13 D
-0 10 D
--9 -6 D
-P
-3361 628 M
-12 5 D
-P
-3377 729 M
-4 8 D
-P
-3529 833 M
-3 10 D
-5 -3 D
-P
-3473 838 M
-8 5 D
-P
-3407 813 M
-3 7 D
-P
-{1 0 0 C} FS
-FO
-2864 430 M
-4 -4 D
--1 -5 D
--17 0 D
-0 1 D
--35 -20 D
--77 -41 D
--30 -14 D
-26 -22 D
--2 -11 D
-6 4 D
--3 -18 D
-30 -5 D
--2 -28 D
--11 -36 D
-22 -48 D
-80 39 D
-86 48 D
-62 38 D
-52 34 D
-36 26 D
-29 21 D
-78 61 D
-54 47 D
-59 55 D
-6 7 D
-13 12 D
--125 125 D
--50 -48 D
--52 -46 D
--72 -59 D
--37 -28 D
--83 -56 D
-P
-3004 351 M
-7 -36 D
--40 -27 D
--20 -11 D
--8 2 D
--11 -12 D
--5 2 D
-21 17 D
--6 16 D
-17 20 D
--20 -8 D
-9 12 D
-16 7 D
--8 5 D
-7 6 D
-2 -8 D
-20 7 D
-6 16 D
-P
-3003 320 M
-5 -3 D
-P
-2996 349 M
--3 4 D
-P
-3051 432 M
-3 -19 D
--42 23 D
-2 11 D
--30 -5 D
--34 16 D
-21 9 D
-21 -13 D
-37 0 D
-20 -30 D
-P
-3015 521 M
-4 -7 D
--14 -21 D
-0 19 D
-P
-2980 474 M
-12 18 D
--1 -12 D
--11 -7 D
-P
-3076 410 M
-2 -17 D
--12 0 D
-P
-2871 270 M
-2 -4 D
-P
-3046 385 M
--6 0 D
-P
-2918 424 M
--9 0 D
-P
-3081 365 M
--11 -9 D
-9 18 D
-P
-2920 425 M
-17 8 D
-5 -6 D
-P
-2899 322 M
--11 -16 D
-P
-2875 283 M
-2 -7 D
--3 7 D
-P
-3071 541 M
-3 7 D
-P
-2871 305 M
-0 -7 D
-P
-2845 236 M
--6 -7 D
-P
-FO
-2748 286 M
-5 -3 D
-0 8 D
--12 1 D
-P
-FO
-2727 314 M
--7 -9 D
-P
-FO
-2752 231 M
--3 -8 D
--21 -19 D
-9 -2 D
--17 -7 D
--38 -53 D
-86 38 D
-6 3 D
-P
-FO
-2263 107 M
--6 1 D
-P
-FO
-2525 261 M
--9 -3 D
-P
-FO
-848 341 M
--11 19 D
--5 -7 D
-P
-FO
-871 346 M
-11 -3 D
--12 20 D
-P
-FO
-866 374 M
--7 10 D
-P
-FO
-885 327 M
--7 -1 D
-P
-FO
-876 322 M
-0 9 D
-P
-FO
-487 926 M
-0 -2 D
-22 -23 D
--12 32 D
--7 -6 D
-P
-FO
-476 918 M
-6 -4 D
--3 6 D
--2 -1 D
-0 -1 D
-P
-FO
-355 828 M
-2 0 D
-3 -7 D
-7 15 D
-0 -6 D
-15 -5 D
-10 8 D
-24 -8 D
-7 13 D
--11 15 D
-21 14 D
-10 5 D
--11 15 D
--79 -55 D
-P
-FO
-837 360 M
--6 11 D
--10 57 D
--40 78 D
--8 21 D
--3 -7 D
--13 17 D
--7 -3 D
--5 16 D
--40 -28 D
-2 -21 D
-19 -18 D
-7 1 D
--10 -3 D
-9 -10 D
--8 -15 D
-25 -27 D
--16 -3 D
-39 -30 D
-60 -43 D
-P
-FO
-509 741 M
--38 23 D
-0 -8 D
--3 7 D
--17 -1 D
-4 -15 D
--21 6 D
--1 7 D
--22 14 D
--8 -12 D
-94 -113 D
-53 -57 D
-6 -5 D
-5 -6 D
-6 -5 D
-5 -6 D
-6 -5 D
-5 -6 D
-6 -5 D
-10 2 D
--9 14 D
-7 -9 D
--5 13 D
-8 -1 D
--14 10 D
-15 30 D
--35 33 D
-5 14 D
--33 19 D
--10 18 D
-3 4 D
--21 21 D
-10 11 D
-P
-432 733 M
--6 7 D
-P
-547 660 M
-6 1 D
-P
-FO
-592 770 M
--10 16 D
--10 -15 D
-26 -31 D
-1 -26 D
-28 -40 D
-21 -8 D
-32 -34 D
-7 -22 D
-50 -54 D
-13 3 D
-17 -8 D
--29 30 D
-8 3 D
--30 36 D
--25 20 D
--34 49 D
-P
-FO
-687 532 M
--8 -2 D
-11 -14 D
--3 -16 D
-19 -15 D
-10 1 D
--15 15 D
-3 13 D
-P
-FO
-539 848 M
--48 50 D
-16 -38 D
-7 -4 D
--5 19 D
-18 -32 D
-11 -6 D
-P
-FO
-566 789 M
-9 -12 D
--2 22 D
--18 10 D
-P
-FO
-658 565 M
--12 0 D
-12 -17 D
-10 7 D
-P
-FO
-850 403 M
-4 -8 D
--2 13 D
-P
-FO
-554 820 M
--9 15 D
--11 -2 D
-8 -13 D
-P
-FO
-597 721 M
--13 21 D
--16 12 D
-P
-FO
-700 460 M
-10 -15 D
-4 2 D
-P
-FO
-487 767 M
--15 -2 D
-P
-FO
-722 446 M
--10 8 D
-P
-FO
-544 782 M
--7 6 D
-P
-FO
-741 428 M
--9 6 D
-P
-FO
-830 468 M
--6 8 D
-5 -8 D
-P
-FO
-520 852 M
--7 3 D
-P
-FO
-486 910 M
--6 3 D
-P
-FO
-483 953 M
-4 -27 D
-5 3 D
-5 4 D
-P
-FO
-422 1050 M
--68 62 D
-37 -58 D
-38 -30 D
-8 1 D
-P
-FO
-103 1455 M
-7 -71 D
-13 -24 D
-5 4 D
-10 -24 D
-21 -15 D
-12 -19 D
--9 -20 D
-8 -3 D
--5 -12 D
--24 -16 D
-14 -52 D
-23 -34 D
-14 -4 D
--13 32 D
-8 16 D
--23 49 D
-13 -4 D
-0 -16 D
-13 -13 D
-9 -24 D
--2 31 D
-12 7 D
--11 15 D
--20 5 D
-12 -2 D
-2 13 D
--10 30 D
-7 -8 D
--1 19 D
--15 96 D
-7 0 D
--4 9 D
-11 4 D
-4 19 D
-5 -11 D
--3 22 D
-7 -17 D
-2 16 D
-13 -2 D
--13 31 D
-P
-FO
-432 887 M
--8 13 D
--33 -34 D
--16 12 D
--5 10 D
-16 3 D
--6 24 D
-12 5 D
--6 14 D
--8 -1 D
--15 21 D
-0 -27 D
--11 4 D
-2 -46 D
--5 12 D
--50 40 D
-34 -52 D
-19 -9 D
-7 -12 D
-1 -25 D
--11 -2 D
-4 -5 D
-P
-362 898 M
--3 6 D
-9 -6 D
-P
-363 890 M
--2 7 D
-P
-366 866 M
-3 4 D
-P
-FO
-479 920 M
--27 44 D
--32 30 D
--2 -6 D
-15 -7 D
-17 -24 D
-13 -32 D
-14 -7 D
-0 1 D
-P
-FO
-217 1067 M
--4 -3 D
-6 -11 D
-2 3 D
--1 29 D
-P
-FO
-260 1089 M
-9 1 D
--12 4 D
-2 11 D
--23 42 D
--5 32 D
--7 -21 D
-16 -41 D
-19 -28 D
-P
-FO
-226 1423 M
--14 27 D
--10 2 D
-8 -29 D
-20 -12 D
-P
-FO
-375 954 M
--6 -2 D
-8 -9 D
-11 3 D
--5 10 D
--8 -1 D
-P
-FO
-223 1298 M
-17 2 D
--17 12 D
--13 -9 D
-10 -11 D
-P
-FO
-373 956 M
-13 4 D
--16 11 D
-4 -9 D
--15 -3 D
-P
-FO
-231 1047 M
-2 8 D
--7 13 D
--2 -14 D
-P
-FO
-388 1048 M
--4 1 D
-8 -16 D
-8 -2 D
-P
-FO
-235 1076 M
-3 -12 D
-9 -5 D
--11 23 D
-P
-FO
-294 1032 M
--2 24 D
--13 15 D
--1 -18 D
-P
-FO
-174 1159 M
--7 8 D
-16 -33 D
-P
-FO
-370 1067 M
--20 27 D
-12 -25 D
-P
-FO
-125 1322 M
--5 11 D
-4 -35 D
-P
-FO
-318 930 M
--13 14 D
-10 -19 D
-P
-FO
-136 1325 M
--11 29 D
-14 -49 D
-P
-FO
-210 1149 M
--6 0 D
-12 -18 D
-P
-FO
-189 1166 M
--7 -2 D
-7 -12 D
-P
-FO
-271 1019 M
-12 -19 D
--17 30 D
-P
-FO
-404 1021 M
-1 6 D
--9 1 D
-P
-FO
-430 903 M
-7 6 D
--11 -7 D
-P
-FO
-278 1023 M
--3 -5 D
-6 9 D
-P
-FO
-313 896 M
-0 7 D
-P
-FO
-268 1093 M
--7 9 D
-P
-FO
-192 1106 M
-0 8 D
-P
-FO
-420 1002 M
--16 16 D
-P
-FO
-141 1295 M
--4 7 D
-P
-FO
-390 937 M
-5 2 D
-P
-FO
-220 1440 M
--3 12 D
-P
-FO
-312 1180 M
-0 -8 D
-P
-FO
-241 1254 M
--16 4 D
-P
-FO
-320 892 M
-9 -9 D
-P
-FO
-421 995 M
--7 8 D
-P
-FO
-233 1041 M
--5 5 D
-P
-FO
-192 1145 M
--10 15 D
-P
-FO
-237 1244 M
-4 7 D
-P
-FO
-342 1130 M
-1 -7 D
-P
-FO
-274 1229 M
--3 8 D
-2 -8 D
-P
-FO
-184 1144 M
--4 6 D
-P
-FO
-240 1058 M
--4 7 D
-P
-FO
-204 1255 M
-0 11 D
-P
-FO
-301 975 M
--19 25 D
-11 -25 D
-P
-FO
-205 1126 M
--4 8 D
-P
-FO
-295 1218 M
--22 10 D
-P
-FO
-184 1793 M
--3 -7 D
--4 9 D
--1 -24 D
--9 0 D
-4 -20 D
--17 -17 D
--7 -32 D
--12 -9 D
--5 29 D
--9 -9 D
--2 -61 D
--11 0 D
--11 -45 D
-6 -152 D
-99 27 D
-13 39 D
--11 33 D
-2 14 D
--15 21 D
--3 -39 D
--9 46 D
--3 -10 D
--2 16 D
--8 -11 D
-1 29 D
--6 -6 D
-4 6 D
--7 6 D
-6 5 D
-0 39 D
-27 53 D
-P
-170 1518 M
-6 6 D
-P
-104 1477 M
-2 -7 D
-P
-FO
-181 1828 M
--5 -10 D
-P
-FO
-173 2105 M
--4 -9 D
-5 -4 D
-3 13 D
-P
-FO
-109 1823 M
--13 34 D
--7 -6 D
--12 14 D
--3 -8 D
-2 -22 D
-11 7 D
-13 -25 D
-2 -26 D
--9 0 D
-10 -7 D
-6 -50 D
-9 43 D
-P
-FO
-108 1950 M
-11 17 D
--1 13 D
--24 -39 D
-P
-FO
-72 1884 M
--23 -74 D
-16 53 D
-20 18 D
--13 4 D
-P
-FO
-142 2026 M
-5 -6 D
-7 18 D
-P
-FO
-56 1684 M
--5 14 D
-7 -31 D
-P
-FO
-146 2076 M
-11 28 D
--22 -46 D
-P
-FO
-110 1724 M
-0 -8 D
-5 9 D
-P
-FO
-152 2019 M
-3 7 D
--6 -1 D
-P
-FO
-128 2014 M
-3 17 D
--16 -35 D
-P
-FO
-143 2013 M
--4 4 D
-P
-FO
-171 1808 M
-4 16 D
-P
-FO
-50 1784 M
-1 15 D
-P
-FO
-162 1888 M
--1 -17 D
-P
-FO
-171 1797 M
-3 8 D
--4 -8 D
-P
-FO
-135 1998 M
-5 6 D
-P
-FO
-89 1934 M
-6 4 D
-P
-FO
-152 2044 M
-5 1 D
-P
-FO
-110 1691 M
-1 8 D
-P
-FO
-184 1585 M
--1 9 D
-P
-FO
-155 2026 M
-2 7 D
-P
-FO
-55 1818 M
-2 -9 D
-P
-FO
-101 1657 M
-5 -2 D
-P
-FO
-33 1766 M
-1 8 D
-P
-FO
-186 1581 M
-2 15 D
-P
-FO
-154 1824 M
-5 5 D
-P
-FO
-177 2105 M
-6 25 D
--10 -25 D
-P
-FO
-173 2137 M
-8 11 D
--26 -23 D
-P
-FO
-175 2147 M
-9 6 D
-P
-FO
-166 2110 M
-3 9 D
--4 -9 D
-P
-FO
-1184 3573 M
-8 2 D
-P
-FO
-3035 3500 M
--43 10 D
--2 -27 D
--12 0 D
-23 -32 D
-P
-FO
-3042 3509 M
--6 4 D
-0 -6 D
-5 1 D
-0 1 D
-P
-FO
-3065 3550 M
--14 2 D
-3 -9 D
--21 7 D
--12 -18 D
-14 -18 D
-10 0 D
-12 18 D
-7 8 D
-4 7 D
-P
-FO
-2734 3717 M
-11 0 D
--10 18 D
--10 4 D
-12 -16 D
--16 1 D
-P
-FO
-2779 3698 M
-13 -3 D
-P
-FO
-2753 3715 M
-12 -4 D
-P
-FO
-3029 3504 M
-7 -1 D
-P
-FO
-2720 3735 M
-8 -5 D
--8 6 D
-P
-FO
-2745 3726 M
-10 -6 D
-P
-FO
-3501 3036 M
--45 41 D
--7 18 D
--34 21 D
-4 7 D
-7 -7 D
--20 42 D
--5 0 D
-1 22 D
--12 21 D
--31 34 D
--30 8 D
--25 26 D
--14 2 D
-4 -7 D
--17 9 D
--2 15 D
--26 29 D
--2 15 D
--32 23 D
-10 -5 D
--4 6 D
-10 -12 D
-16 -12 D
-2 -15 D
-27 -28 D
-4 -17 D
-13 -7 D
--4 7 D
-15 -2 D
-28 -27 D
-27 -8 D
-45 -48 D
-8 -39 D
-18 -39 D
-19 -13 D
-6 -15 D
-23 -22 D
-9 1 D
-15 -23 D
-1 0 D
--9 17 D
-1 44 D
--27 65 D
--59 71 D
-13 -11 D
-46 -57 D
-28 -68 D
-7 -61 D
-44 31 D
--20 30 D
--22 28 D
--16 22 D
--39 49 D
--47 54 D
--55 59 D
--7 6 D
--18 19 D
--7 6 D
--6 7 D
--66 61 D
--68 58 D
--42 33 D
--29 21 D
--29 21 D
--8 5 D
--4 -7 D
--13 -17 D
--6 -9 D
-5 0 D
-1 -9 D
--16 -5 D
--34 -49 D
-11 -40 D
-0 -41 D
-59 -46 D
-32 -26 D
-37 -33 D
-66 -63 D
-63 -66 D
-69 -82 D
-41 -53 D
-24 -34 D
-P
-3480 3073 M
--7 9 D
-P
-3447 3107 M
--4 10 D
-P
-3434 3116 M
--4 12 D
-P
-FO
-3040 3507 M
-4 0 D
--3 2 D
-P
-FO
-3786 2442 M
--21 72 D
--3 40 D
--32 38 D
-13 2 D
-9 -11 D
--9 19 D
-12 -13 D
-7 14 D
--12 11 D
-8 6 D
--6 5 D
-5 -2 D
--6 7 D
-3 12 D
--6 3 D
-6 5 D
--5 3 D
--4 33 D
--5 1 D
--6 22 D
--19 8 D
-5 -13 D
--8 10 D
-2 9 D
--26 18 D
--8 4 D
-21 -5 D
--21 36 D
-11 18 D
--32 34 D
--7 16 D
-14 -20 D
-11 -5 D
-20 -5 D
-2 -2 D
--30 59 D
--32 58 D
--48 78 D
--14 20 D
--23 35 D
--5 6 D
--44 -31 D
-29 -43 D
-27 -16 D
-13 -27 D
-20 -13 D
-19 -33 D
-4 -12 D
--5 -1 D
-6 -9 D
-37 -39 D
--35 34 D
--16 25 D
--24 2 D
-22 6 D
-8 -14 D
--13 27 D
-9 -15 D
--5 17 D
--27 24 D
--13 26 D
--34 22 D
--17 31 D
--7 7 D
--98 -69 D
-32 -47 D
-34 -55 D
-45 -78 D
-40 -80 D
-36 -82 D
-35 -91 D
-27 -86 D
-11 -39 D
-P
-3661 2799 M
-5 11 D
-14 -28 D
--11 6 D
--3 -7 D
-5 18 D
-P
-3673 2795 M
-1 -10 D
-P
-3558 2961 M
-7 -5 D
-P
-3564 2951 M
-5 0 D
-P
-3590 2963 M
-11 -21 D
--3 -7 D
-P
-3658 2830 M
--15 -22 D
-P
-3680 2745 M
--18 -8 D
-P
-3615 2887 M
-5 -6 D
-P
-FO
-3502 3037 M
-2 -2 D
--1 2 D
-P
-FO
-3694 2792 M
-0 -11 D
--5 9 D
--7 -11 D
-10 -24 D
-19 -27 D
-24 -6 D
--24 62 D
-P
-3722 2742 M
--5 0 D
-P
-FO
-3677 2818 M
--11 3 D
-13 -12 D
-12 -4 D
--1 6 D
-P
-FO
-3716 2774 M
-2 -1 D
--2 4 D
-P
-FO
-3748 2582 M
-5 -10 D
-P
-FO
-3701 2804 M
-6 -12 D
-P
-FO
-3690 2814 M
-9 -7 D
-P
-FO
-3698 2803 M
--6 2 D
-P
-FO
-3694 2800 M
-5 -3 D
--5 4 D
-P
-FO
-3739 2585 M
-5 0 D
-P
-FO
-3703 2803 M
-1 0 D
-P
-FO
-3752 2631 M
-5 -1 D
-P
-FO
--3 -4 3 5 2 3609 2895 SP
-3690 2292 M
-36 -31 D
-23 -1 D
-26 20 D
-5 13 D
--8 49 D
-12 48 D
-2 52 D
--123 -33 D
-20 -81 D
-P
-3737 2393 M
--4 11 D
-P
-3730 2357 M
--1 7 D
-P
-FO
-3340 848 M
--24 1 D
--13 19 D
-3 40 D
--23 46 D
--34 24 D
--116 -3 D
--66 40 D
--93 8 D
--47 -50 D
-277 -277 D
-20 21 D
-11 10 D
-15 16 D
-9 11 D
-25 27 D
-14 17 D
-P
-FO
-3273 964 M
--5 1 D
-6 -1 D
-P
-FO
-2842 896 M
-1 0 D
--25 -21 D
--85 -63 D
--9 -6 D
--1 -14 D
--12 -31 D
-14 -50 D
-1 5 D
-11 -1 D
--48 -72 D
-18 -34 D
-37 -16 D
-10 -15 D
--8 0 D
--25 -36 D
--5 -25 D
--64 -63 D
--2 -6 D
-48 -101 D
-10 0 D
-60 29 D
-59 32 D
-11 7 D
-12 7 D
--26 17 D
--2 19 D
--33 24 D
-21 5 D
-32 -21 D
--3 -15 D
-25 -21 D
-33 20 D
-19 13 D
-77 52 D
-73 57 D
-71 60 D
-67 64 D
--277 277 D
--70 -65 D
-P
-2846 829 M
--2 10 D
-11 4 D
--9 -1 D
-10 4 D
-P
-2795 535 M
--20 -5 D
--27 7 D
-26 -7 D
-P
-2949 671 M
--5 -31 D
--25 -24 D
-18 19 D
-P
-2809 789 M
-5 4 D
--6 2 D
-10 0 D
-P
-2960 512 M
--5 6 D
-7 8 D
--1 -14 D
-P
-3033 564 M
--4 3 D
-P
-2788 483 M
--3 4 D
-P
-3009 787 M
--3 -6 D
-P
-2730 747 M
-5 -2 D
-P
-2957 524 M
--1 6 D
-P
-2767 493 M
-3 -6 D
-P
-2888 571 M
--46 -31 D
-P
-FO
-2650 448 M
--11 -34 D
-27 -27 D
--6 -6 D
-20 -21 D
--4 -14 D
-22 1 D
-P
-FO
-2454 565 M
--48 -27 D
--21 -148 D
-4 -18 D
--9 -10 D
-13 -22 D
--7 -4 D
--11 8 D
--6 -12 D
-27 -40 D
-26 -7 D
--1 -7 D
-13 13 D
--7 16 D
-13 13 D
-12 -1 D
--8 11 D
-8 2 D
-3 17 D
-3 -7 D
-9 13 D
--6 4 D
-8 5 D
-0 -8 D
-12 10 D
--4 9 D
-11 -2 D
-44 25 D
-5 29 D
--32 40 D
-16 34 D
--1 21 D
--39 43 D
-P
-2413 388 M
--1 -7 D
-P
-FO
-2156 380 M
-2 11 D
--10 -6 D
-P
-FO
-2596 333 M
--9 -1 D
-7 -7 D
-P
-FO
-2565 330 M
--10 0 D
-3 -5 D
-P
-FO
-2214 409 M
--15 4 D
-5 -8 D
-P
-FO
-2538 331 M
--6 3 D
-P
-FO
-2446 310 M
--6 1 D
-P
-FO
-2581 338 M
--8 -1 D
-P
-FO
-2378 365 M
--2 -6 D
-P
-FO
-649 1039 M
-18 -18 D
-41 -28 D
-6 -16 D
-57 -29 D
-16 3 D
--4 -16 D
-49 22 D
-15 42 D
-0 -12 D
-6 0 D
--7 -13 D
-11 21 D
-5 -19 D
-18 72 D
-12 14 D
--25 31 D
--43 57 D
--5 8 D
-P
-FO
-499 930 M
--1 3 D
--1 0 D
-P
-FO
-859 975 M
--4 -12 D
-P
-FO
-745 949 M
--6 1 D
-P
-FO
-845 960 M
-5 2 D
-P
-FO
-845 959 M
--4 -2 D
-P
-FO
-375 1528 M
-2 -11 D
--7 -19 D
-2 -71 D
--6 -41 D
--29 11 D
--5 -7 D
--6 15 D
--9 -2 D
--12 12 D
--4 -15 D
-16 -12 D
--8 -2 D
-6 -10 D
--7 6 D
-13 -18 D
--1 -15 D
-10 -16 D
--5 -9 D
-7 -11 D
-5 -49 D
-6 -4 D
--6 29 D
-8 5 D
-18 -35 D
--2 -7 D
-12 -10 D
-3 6 D
-0 -13 D
-3 7 D
-4 -11 D
-13 5 D
-8 -13 D
-20 -5 D
--2 20 D
-14 -7 D
--2 -11 D
-9 -1 D
--6 -4 D
-5 -15 D
-10 -7 D
-5 8 D
--2 -9 D
-7 0 D
--17 -1 D
--2 -28 D
-4 -16 D
-12 -2 D
--4 -5 D
-10 -5 D
--2 -9 D
-13 4 D
--3 -12 D
-16 -7 D
-2 13 D
-9 -17 D
-1 15 D
-3 -18 D
-12 -4 D
-3 7 D
--7 4 D
-14 -3 D
--8 15 D
-12 -13 D
-6 -25 D
-9 4 D
--5 13 D
-8 3 D
-2 -11 D
-10 6 D
--11 -28 D
-26 -9 D
-11 13 D
-42 -14 D
-21 -23 D
-170 119 D
--15 21 D
--47 75 D
--34 61 D
--11 23 D
--27 57 D
--24 59 D
--37 108 D
--8 31 D
-P
-474 1221 M
--9 -8 D
--6 11 D
-P
-440 1354 M
--7 -1 D
-P
-FO
-437 1025 M
-7 1 D
--10 13 D
--12 11 D
-P
-FO
-498 933 M
--4 15 D
--11 6 D
-14 -21 D
-P
-FO
-353 1239 M
-5 -4 D
--1 -15 D
-6 22 D
--15 13 D
-P
-FO
-340 1408 M
-5 -1 D
--5 18 D
--10 -10 D
-P
-FO
-372 1215 M
--8 17 D
--4 -12 D
-P
-FO
-301 1387 M
--4 6 D
-P
-FO
-364 1500 M
--6 15 D
-P
-FO
-459 1019 M
--12 5 D
-P
-FO
-477 982 M
--7 7 D
-P
-FO
-328 1281 M
-6 2 D
-P
-FO
-311 1377 M
--6 4 D
-P
-FO
-294 1395 M
--11 6 D
-P
-FO
-569 1909 M
--28 8 D
--27 -17 D
--28 4 D
--37 -39 D
--9 -26 D
--23 -5 D
-7 0 D
--10 -17 D
-11 1 D
--5 -7 D
-4 -4 D
--43 -28 D
--18 -73 D
--36 -14 D
--6 -18 D
--28 -6 D
--11 -27 D
-9 -20 D
--27 -13 D
--33 -38 D
-7 -11 D
-19 3 D
-14 -12 D
--2 11 D
-27 -9 D
-20 11 D
-55 -18 D
-4 -17 D
-241 65 D
--15 59 D
--16 85 D
--10 86 D
-P
-FO
-181 1827 M
-3 6 D
-P
-FO
-191 1723 M
-2 3 D
--3 62 D
-6 15 D
--11 20 D
--1 -30 D
-P
-FO
-476 1899 M
-6 2 D
--21 4 D
-P
-FO
-509 1909 M
-6 2 D
-P
-FO
-203 1894 M
-4 19 D
-P
-FO
-522 1910 M
--7 1 D
-P
-FO
-190 1874 M
-0 11 D
-P
-FO
-460 2645 M
-1 -3 D
-P
-FO
-447 2651 M
--6 -45 D
-16 38 D
--5 2 D
--1 -13 D
-P
-FO
-328 2306 M
-0 -7 D
-10 6 D
-2 9 D
-P
-FO
-464 2601 M
--18 -7 D
-2 -29 D
-12 14 D
-P
-FO
-304 2288 M
-14 2 D
-0 14 D
--20 -15 D
-P
-FO
-204 2164 M
-3 12 D
--16 -33 D
-P
-FO
-393 2338 M
-3 9 D
--8 -5 D
-P
-FO
-447 2270 M
--59 -73 D
-29 22 D
-P
-FO
-333 2330 M
--10 1 D
-P
-FO
-345 2324 M
-5 9 D
-P
-FO
-476 2575 M
-4 14 D
-P
-FO
-318 2327 M
-2 -10 D
-P
-FO
-297 2314 M
--2 6 D
-P
-FO
-412 2262 M
--6 5 D
-P
-FO
-423 2285 M
--8 -8 D
-P
-FO
-365 2320 M
-2 13 D
-P
-FO
-335 2323 M
-4 8 D
-P
-FO
-439 2299 M
--6 -4 D
-P
-FO
-405 2341 M
-5 5 D
--6 -5 D
-P
-FO
-223 2286 M
--1 -10 D
-P
-FO
-447 2651 M
-P
-FO
-460 2645 M
--1 5 D
-P
-FO
-528 2879 M
-7 10 D
--14 -15 D
-P
-FO
-504 2859 M
-13 15 D
-P
-FO
-593 2722 M
-5 8 D
-P
-FO
-549 2900 M
-3 8 D
-P
-FO
-1024 3292 M
-14 3 D
-P
-FO
-1103 3377 M
-7 -1 D
-P
-FO
-1239 3407 M
-6 0 D
-P
-FO
-3012 3370 M
--1 -29 D
-11 -58 D
--11 -4 D
-2 -20 D
-9 -25 D
-55 -98 D
-8 -39 D
--18 -25 D
--19 -21 D
--39 -19 D
--23 -30 D
--70 -33 D
--10 -19 D
--2 -1 D
-9 -8 D
-60 -63 D
-41 -47 D
-46 -59 D
-21 -30 D
-322 225 D
--39 54 D
--15 20 D
--21 25 D
--59 70 D
--75 78 D
--66 62 D
--51 43 D
--45 36 D
-P
-3142 3123 M
-8 -31 D
--11 1 D
-4 10 D
--8 3 D
--9 21 D
-10 4 D
-P
-3141 3019 M
-1 14 D
-11 4 D
-P
-3276 3023 M
--2 -4 D
-P
-3221 3090 M
--5 -3 D
-P
-3254 3066 M
-3 6 D
-P
-3244 3075 M
-4 2 D
-P
-FO
-3086 2735 M
-13 8 D
-7 -1 D
-34 7 D
-11 -8 D
-31 -57 D
--41 64 D
--44 -8 D
--10 -6 D
-32 -48 D
-35 -59 D
-42 -80 D
-5 -11 D
-17 -3 D
-24 -14 D
-29 4 D
-12 15 D
-19 -5 D
--1 11 D
-4 -13 D
-21 -9 D
-26 -23 D
-11 -23 D
-25 -19 D
-5 -22 D
-12 -10 D
--6 -3 D
-8 -26 D
-10 1 D
-17 -22 D
-9 5 D
-38 -20 D
-182 49 D
--20 70 D
--24 70 D
--38 98 D
--41 89 D
--38 72 D
--45 78 D
--31 48 D
--23 33 D
--322 -225 D
-P
-3404 2495 M
-2 12 D
--6 5 D
-7 -4 D
-6 13 D
-9 -19 D
--4 0 D
--3 -13 D
-2 20 D
--6 7 D
-P
-3454 2501 M
--2 9 D
-11 -3 D
--5 8 D
-10 -4 D
--8 -15 D
-P
-3356 2551 M
-0 11 D
-P
-3144 2703 M
-6 -4 D
-P
-3335 2574 M
-7 -16 D
--6 -1 D
-P
-3415 2467 M
-3 5 D
-P
-3210 2537 M
-6 -2 D
-P
-3411 2528 M
-2 15 D
-P
-FO
-3258 2521 M
-9 -1 D
-P
-FO
-3361 2477 M
-4 -5 D
-P
-FO
-3384 2455 M
-3 -8 D
-P
-FO
-3481 2360 M
-7 -3 D
-24 3 D
-17 -12 D
-92 14 D
-6 -4 D
--7 -8 D
-9 -10 D
-61 -48 D
--18 82 D
--9 35 D
-P
-FO
-2974 1023 M
--43 6 D
--15 10 D
-3 12 D
--31 12 D
--3 -10 D
--30 -8 D
-72 -72 D
-P
-FO
-2842 896 M
--7 0 D
-7 0 D
-36 31 D
-49 46 D
--73 72 D
--28 -53 D
--42 -30 D
--30 -42 D
--27 -79 D
--3 -35 D
-60 43 D
-42 33 D
-P
-2820 893 M
--6 -4 D
-P
-FO
-2417 1049 M
--4 -3 D
-P
-FO
-1884 1000 M
--6 -5 D
--15 6 D
-10 -8 D
--14 3 D
--2 -8 D
-19 2 D
--4 -6 D
-10 3 D
-1 -11 D
-P
-FO
-892 1062 M
-7 8 D
-11 34 D
-25 15 D
-14 -9 D
-11 13 D
--9 36 D
--17 24 D
--46 20 D
--2 2 D
--67 -47 D
-23 -33 D
-37 -48 D
-P
-FO
-886 1205 M
--43 67 D
--25 4 D
--34 27 D
--69 101 D
--7 74 D
-9 0 D
-0 16 D
-22 28 D
-3 -9 D
-2 21 D
--9 -4 D
--44 30 D
--11 -4 D
-21 11 D
-15 -7 D
-16 5 D
-2 -10 D
-9 -1 D
--9 19 D
--22 1 D
-11 14 D
-19 -5 D
--7 16 D
-5 16 D
-6 6 D
--2 -3 D
-20 8 D
-4 7 D
--152 -40 D
-14 -49 D
-33 -96 D
-30 -70 D
-25 -52 D
-26 -50 D
-46 -76 D
-25 -37 D
-4 -5 D
-P
-FO
-757 1562 M
--12 23 D
-10 -33 D
-P
-FO
-768 1633 M
-9 15 D
-4 65 D
--27 25 D
-6 5 D
-5 -9 D
--5 17 D
-7 -2 D
-7 21 D
--7 -2 D
--22 33 D
-6 -10 D
--6 4 D
--13 48 D
--38 0 D
--15 15 D
--4 -6 D
--30 11 D
--24 30 D
--5 -5 D
--24 16 D
--23 5 D
-8 -110 D
-12 -86 D
-18 -85 D
-9 -35 D
-P
-770 1708 M
--6 0 D
-P
-636 1817 M
--8 1 D
-P
-712 1778 M
--5 -1 D
-P
-FO
-868 1779 M
-5 17 D
--21 4 D
-9 16 D
--29 1 D
-5 4 D
--30 -10 D
-15 -28 D
--7 -40 D
-16 5 D
-18 19 D
--3 -8 D
-9 3 D
-P
-861 1783 M
--5 -7 D
-P
-FO
-793 1808 M
-1 7 D
--9 -9 D
-P
-FO
-867 1800 M
--8 4 D
-P
-FO
-803 1730 M
--9 -6 D
-P
-FO
-872 2341 M
-4 -8 D
-11 9 D
--2 16 D
--34 37 D
-6 19 D
--24 23 D
--8 -10 D
-4 -21 D
--16 -19 D
--28 -2 D
-15 -3 D
--14 -16 D
--9 8 D
--14 -8 D
--13 5 D
-1 -6 D
--16 -11 D
-3 -5 D
--13 0 D
--2 -8 D
-49 16 D
--9 0 D
-10 10 D
-7 -4 D
--6 -5 D
-14 3 D
-4 9 D
--3 -8 D
-18 3 D
-18 -15 D
-4 -19 D
-22 20 D
-P
-836 2372 M
--2 8 D
-P
-FO
-955 2217 M
--5 15 D
--37 22 D
-3 16 D
--11 -7 D
-11 7 D
-4 16 D
--7 -6 D
--10 6 D
--20 37 D
--10 5 D
--2 -9 D
--3 10 D
-0 -23 D
--17 -6 D
--1 7 D
-1 -18 D
-40 -40 D
-11 -33 D
--3 -16 D
-19 -31 D
-8 2 D
--5 -6 D
-19 -6 D
-3 17 D
-17 21 D
-P
-909 2214 M
-9 -3 D
--7 -5 D
-P
-912 2218 M
-4 -4 D
-P
-934 2170 M
-6 1 D
-P
-917 2197 M
-12 3 D
--13 -3 D
-P
-899 2242 M
-18 -11 D
-P
-902 2235 M
-9 -3 D
-P
-898 2248 M
-9 5 D
-P
-FO
-965 2177 M
--10 -1 D
-11 -9 D
-P
-FO
-777 2384 M
-5 3 D
-P
-FO
-863 2319 M
--4 6 D
-P
-FO
-999 2463 M
--1 10 D
--5 -10 D
-P
-FO
-2560 2673 M
-8 -2 D
-13 24 D
--12 -11 D
--7 8 D
--3 -15 D
-15 5 D
-P
-FO
-2580 2656 M
-47 -45 D
-9 -10 D
-2 7 D
--1 -7 D
-6 -7 D
-20 11 D
-39 -7 D
-13 11 D
--9 17 D
-5 25 D
-22 2 D
-23 -14 D
-23 15 D
-24 -5 D
--2 14 D
-9 -7 D
--2 -9 D
-10 -4 D
-7 10 D
--14 6 D
--1 14 D
-23 18 D
-8 -25 D
-21 -19 D
-29 20 D
-3 -6 D
-6 14 D
-11 -24 D
-17 -16 D
-134 93 D
--23 4 D
--18 -20 D
-18 22 D
-24 -5 D
-18 13 D
--36 50 D
--47 58 D
--50 55 D
--35 36 D
--9 8 D
--16 -3 D
--42 -47 D
--75 -32 D
--12 4 D
--22 -41 D
--34 -15 D
--1 -16 D
--7 1 D
-16 -6 D
-4 -7 D
-7 -1 D
--17 0 D
-4 -12 D
--7 -3 D
--2 8 D
-1 -10 D
--4 6 D
--18 -12 D
-0 -11 D
--13 2 D
-5 -15 D
--23 0 D
-7 -12 D
--10 8 D
--6 -5 D
-7 -3 D
--19 -9 D
-2 10 D
--9 6 D
-7 -5 D
--4 5 D
-8 2 D
--8 0 D
--1 8 D
--6 3 D
-5 -9 D
--8 -2 D
--16 2 D
-1 -7 D
-0 6 D
-13 -2 D
--5 -7 D
-10 -6 D
--3 -11 D
--12 2 D
-8 -8 D
--14 6 D
-14 -10 D
-1 -12 D
--4 7 D
--2 -10 D
--12 19 D
-4 -16 D
--10 3 D
-3 -6 D
--15 -7 D
-8 -1 D
--3 -13 D
--7 9 D
--2 -9 D
-P
-2598 2671 M
-9 9 D
--3 -11 D
-7 6 D
--6 -16 D
-P
-2629 2702 M
-12 7 D
-19 -20 D
--15 13 D
-P
-3027 2783 M
-0 9 D
-12 -14 D
-P
-2740 2789 M
-2 -13 D
--8 6 D
-P
-2714 2796 M
-6 5 D
-0 -8 D
-P
-2704 2671 M
-4 10 D
-P
-2678 2722 M
--3 4 D
-P
-2620 2649 M
-4 4 D
-P
-2740 2806 M
--6 1 D
-P
-2698 2680 M
-7 4 D
-P
-2619 2734 M
-3 -6 D
--8 -2 D
-P
-2636 2688 M
--5 5 D
-P
-2728 2787 M
--4 6 D
-P
-2694 2734 M
--3 6 D
-P
-2749 2813 M
--2 -4 D
-P
-2692 2753 M
-0 6 D
-P
-2799 2838 M
--4 -5 D
-P
-2746 2790 M
-1 -6 D
-P
-2761 2799 M
--6 3 D
-P
-2744 2814 M
-2 -6 D
-P
-2595 2648 M
--5 14 D
-P
-FO
-2668 2776 M
-11 -3 D
-18 23 D
--7 7 D
--27 -20 D
-P
-FO
-2661 2739 M
-7 8 D
--11 1 D
-P
-FO
-2579 2699 M
-6 -7 D
-4 12 D
-P
-FO
-2555 2687 M
-3 -9 D
-P
-FO
-2566 2698 M
-4 -5 D
-P
-FO
-2572 2691 M
--2 -5 D
-P
-FO
-2637 2735 M
-6 1 D
-P
-FO
-2652 2754 M
-2 -6 D
-P
-FO
-2631 2730 M
--1 -5 D
-P
-FO
-2644 2764 M
-5 -4 D
-P
-FO
-2590 2703 M
--2 -5 D
-P
-FO
-2571 2694 M
-1 5 D
-P
-FO
-2586 2718 M
-4 -5 D
-P
-FO
-2641 2745 M
-6 2 D
-P
-FO
-2585 2707 M
--5 -6 D
-P
-FO
-2648 2753 M
--4 7 D
-P
-FO
-2571 2708 M
-4 -6 D
-P
-FO
-2627 2742 M
-5 4 D
-P
-FO
-3087 2734 M
--11 -8 D
--14 2 D
--134 -93 D
-22 -23 D
-19 -11 D
-33 -2 D
-9 7 D
--1 16 D
-14 4 D
--1 36 D
-26 14 D
--15 -10 D
--3 -18 D
-12 -37 D
-27 -36 D
-47 -15 D
-28 6 D
-38 -12 D
-5 8 D
--1 -20 D
--48 16 D
-33 -17 D
-29 -5 D
--36 71 D
--40 69 D
--12 20 D
-P
-3097 2574 M
-9 7 D
-27 -11 D
--13 -5 D
--4 8 D
-P
-3073 2646 M
-24 -21 D
--14 10 D
--2 -6 D
-P
-3103 2567 M
-19 -5 D
--19 4 D
-P
-FO
-3063 2729 M
-10 -2 D
-13 8 D
--5 7 D
-P
-FO
--4 -4 1 3080 2731 SP
-2385 1745 M
-10 -2 D
--9 4 D
-P
-FO
-2379 1734 M
-6 5 D
--1 3 D
-P
-FO
-2363 1704 M
-0 1 D
-P
-FO
-2338 1666 M
-16 17 D
--1 5 D
-P
-FO
-2295 1605 M
-1 11 D
-13 2 D
-9 17 D
-11 -1 D
-0 20 D
--19 -23 D
--20 -21 D
-P
-FO
-2278 1598 M
-17 7 D
--5 5 D
-P
-FO
-2164 1519 M
-13 -1 D
--1 -12 D
-3 13 D
-38 -7 D
-33 62 D
--49 -34 D
-P
-FO
-2165 1488 M
-1 2 D
--4 28 D
--9 -4 D
-P
-FO
-1997 1411 M
-9 0 D
-21 -6 D
--1 -13 D
-18 -9 D
-19 -1 D
-30 19 D
--10 19 D
-18 -5 D
-7 7 D
--11 5 D
-6 7 D
-21 -1 D
--2 9 D
-43 46 D
--12 26 D
--41 -17 D
--59 -17 D
--44 -7 D
--17 -2 D
-P
-FO
-1814 1441 M
-12 2 D
-12 17 D
-31 10 D
-7 -1 D
--6 -9 D
-11 -18 D
-21 -1 D
-5 -24 D
-90 -6 D
--5 60 D
--53 -2 D
--53 4 D
--52 10 D
--8 3 D
-P
-FO
-1824 1081 M
--9 4 D
-P
-FO
-1616 1473 M
-17 -11 D
-5 -24 D
-11 1 D
-10 19 D
-16 4 D
-19 -14 D
-25 -3 D
-27 -26 D
-21 2 D
--2 8 D
-28 -1 D
-8 11 D
-13 2 D
-12 45 D
--26 7 D
--49 19 D
--40 20 D
--37 24 D
-P
-FO
-1497 1633 M
-15 -18 D
-9 -32 D
--4 -20 D
-20 -13 D
-9 6 D
-21 -5 D
-21 -50 D
--7 -7 D
-3 -14 D
-14 11 D
-6 -19 D
-10 3 D
-2 -2 D
-58 83 D
--35 27 D
--38 36 D
--29 34 D
--16 21 D
-P
-FO
-1410 1805 M
-0 -55 D
-19 -39 D
-27 -4 D
--6 -31 D
-17 -6 D
--2 -7 D
-15 -11 D
--2 -8 D
-14 -6 D
-5 -5 D
-59 41 D
--28 45 D
--23 48 D
--17 50 D
--2 9 D
-P
-FO
-1462 1993 M
--3 -2 D
--15 -37 D
--16 -14 D
-10 -22 D
--7 -5 D
-3 -29 D
--16 -25 D
--21 6 D
-15 -13 D
--7 -12 D
-7 -9 D
--2 -26 D
-76 21 D
--7 25 D
--8 53 D
--2 61 D
-2 27 D
-P
-FO
-1471 1997 M
--9 -4 D
-9 -1 D
-P
-FO
-1040 2127 M
--6 5 D
-P
-FO
-2264 2314 M
-0 8 D
--9 2 D
-0 -3 D
-P
-FO
-2298 2281 M
-10 32 D
--13 7 D
--10 -14 D
--3 11 D
--12 -8 D
-10 -9 D
-4 -5 D
-10 -9 D
-P
-FO
-2338 2234 M
-10 11 D
-57 24 D
-14 16 D
-2 23 D
-12 -4 D
-5 -12 D
-2 1 D
-1 11 D
-10 -3 D
-13 9 D
--11 5 D
--35 2 D
--2 8 D
--10 -9 D
--22 7 D
--10 -8 D
--5 7 D
--11 -12 D
--2 12 D
--15 -25 D
--21 -13 D
--13 9 D
--8 -12 D
-P
-FO
-2700 2475 M
--6 9 D
--1 -14 D
--5 9 D
-3 -7 D
--14 7 D
-11 -12 D
-P
-FO
-2637 2601 M
--1 -4 D
-7 -3 D
-P
-FO
-2580 2656 M
-13 -17 D
--15 9 D
--5 -6 D
-7 14 D
--10 9 D
--2 -8 D
--9 11 D
-7 -11 D
--8 -7 D
-12 3 D
--2 -8 D
--14 6 D
-4 -10 D
--11 -6 D
-0 -12 D
-6 7 D
--3 -9 D
-5 10 D
-6 -12 D
--5 14 D
-10 0 D
--8 -4 D
-4 -12 D
--16 -7 D
-10 7 D
--9 -4 D
-4 5 D
--8 8 D
--11 -13 D
-14 -3 D
--13 -4 D
-3 -5 D
-9 8 D
-16 -15 D
--7 -11 D
--14 -1 D
-7 5 D
--10 3 D
-5 -20 D
-23 15 D
-27 -10 D
-7 -12 D
-5 18 D
--6 8 D
-7 -7 D
-3 13 D
-27 2 D
-1 4 D
--32 33 D
-P
-FO
-2560 2673 M
-P
-FO
-2571 2504 M
-22 -13 D
--13 42 D
-11 31 D
--21 15 D
--10 -10 D
-11 -13 D
--18 -2 D
-5 -18 D
--8 0 D
-5 7 D
--7 0 D
--5 19 D
-1 -15 D
--7 5 D
-4 6 D
--17 6 D
-P
-2566 2544 M
--5 -1 D
-P
-2574 2517 M
--15 17 D
-P
-FO
-2536 2537 M
-0 -13 D
-3 5 D
-7 -6 D
--5 -4 D
-6 -12 D
-0 21 D
-8 -5 D
-P
-FO
-2521 2584 M
-14 -4 D
--4 16 D
--12 1 D
-1 -11 D
-8 -2 D
-P
-FO
-2535 2599 M
-1 -10 D
-3 6 D
-19 -4 D
--13 13 D
-P
-FO
-2545 2564 M
-4 -11 D
-8 13 D
-P
-FO
-2539 2560 M
--1 12 D
--5 -4 D
-P
-FO
-2557 2673 M
--4 5 D
--5 -7 D
-P
-FO
-2547 2655 M
-3 -6 D
-3 9 D
-P
-FO
-2524 2610 M
-7 -13 D
--10 27 D
-P
-FO
-2528 2639 M
-8 6 D
-P
-FO
-2557 2519 M
-8 -14 D
-P
-FO
-2530 2572 M
-7 5 D
-P
-FO
-2555 2663 M
-1 -12 D
-P
-FO
-2528 2548 M
-6 -9 D
-P
-FO
-2539 2538 M
-9 -8 D
-P
-FO
-2542 2668 M
-8 -2 D
--8 3 D
-P
-FO
-2602 2478 M
--9 6 D
-P
-FO
-2538 2651 M
--7 -2 D
-P
-FO
-2539 2640 M
-1 -9 D
-P
-FO
-2538 2627 M
-0 -7 D
-P
-FO
-2529 2550 M
--4 5 D
-P
-FO
-2529 2612 M
-5 -5 D
-P
-FO
-2533 2548 M
-4 -4 D
-P
-FO
-2534 2632 M
-3 -6 D
-P
-FO
-2431 2324 M
-3 9 D
--15 1 D
-P
-FO
-2489 2327 M
--10 10 D
-3 -11 D
-P
-FO
-2688 2467 M
-0 -1 D
-18 -2 D
--6 11 D
-P
-FO
-2451 2301 M
-6 -3 D
-0 -9 D
-19 6 D
-11 -12 D
-5 10 D
--28 17 D
-P
-FO
-2438 2291 M
-1 -5 D
-1 7 D
--2 -1 D
-P
-FO
-2696 2453 M
-4 -5 D
-1 8 D
-13 -15 D
-4 6 D
--9 1 D
-2 15 D
--10 -7 D
--13 6 D
--1 -8 D
-P
-FO
-2703 2474 M
-2 -6 D
-P
-FO
-2473 2292 M
--10 -6 D
-6 -8 D
-7 3 D
-P
-FO
-2499 2282 M
--6 0 D
-10 -12 D
-P
-FO
-2771 2110 M
-14 12 D
--2 21 D
-P
-FO
-2395 1743 M
--4 16 D
--5 -12 D
-P
-FO
-2329 1654 M
-0 2 D
-17 21 D
-7 11 D
--1 7 D
-11 9 D
-1 16 D
-15 14 D
-5 8 D
--2 4 D
-3 -1 D
-1 2 D
--436 203 D
-340 -340 D
-30 32 D
-P
-FO
-2162 1518 M
--1 2 D
-3 -1 D
-51 30 D
-35 25 D
-6 16 D
-22 8 D
-12 12 D
--340 340 D
-203 -436 D
-P
-FO
+0 -121 D
+S
 1950 1950 M
-42 -479 D
-44 6 D
-34 7 D
-51 16 D
-32 14 D
-P
-FO
-1950 1950 M
--124 -464 D
-25 -7 D
-53 -8 D
-61 -2 D
-27 2 D
-P
-FO
-1950 1950 M
--276 -394 D
-45 -28 D
-48 -23 D
-50 -17 D
-9 -2 D
-P
-FO
-1950 1950 M
--394 -276 D
-27 -35 D
-36 -38 D
-34 -29 D
-21 -16 D
-P
-FO
-1950 1950 M
--464 -124 D
-7 -26 D
-19 -49 D
-20 -40 D
-24 -37 D
-P
-FO
-1950 1950 M
--479 42 D
--2 -53 D
-4 -53 D
-10 -52 D
-3 -8 D
-P
-FO
-1684 2074 M
--37 -61 D
-17 -3 D
-2 -13 D
--28 -7 D
--35 6 D
-3 20 D
--9 -19 D
--13 11 D
-2 9 D
--14 -2 D
-2 10 D
--11 4 D
-1 19 D
--28 11 D
--6 11 D
--14 -1 D
-8 -3 D
--31 -21 D
--14 -45 D
--8 -3 D
-0 -5 D
-479 -42 D
-P
-FO
-1747 2153 M
--2 -20 D
--43 -48 D
--15 -7 D
--3 -4 D
-266 -124 D
-P
-FO
-1801 2269 M
--3 -5 D
--27 -10 D
--10 -17 D
-7 -44 D
--32 -16 D
-12 -15 D
--1 -9 D
-203 -203 D
-P
-FO
-1916 2338 M
--16 2 D
--11 -6 D
--24 10 D
--1 -26 D
--44 -19 D
--19 -30 D
-149 -319 D
-P
-FO
-2063 2372 M
--27 -4 D
--4 -21 D
-11 -14 D
--11 3 D
-8 -16 D
--9 -6 D
-7 -6 D
--6 -8 D
--28 14 D
--13 -11 D
--12 25 D
--24 11 D
--7 -6 D
--32 5 D
-34 -388 D
-P
-FO
-2184 2284 M
--2 4 D
--21 -11 D
--31 55 D
--9 -4 D
--21 15 D
--9 21 D
--18 8 D
--10 0 D
--113 -422 D
-P
-FO
-2242 2154 M
-1 14 D
-45 18 D
-9 7 D
-10 7 D
-31 34 D
--39 47 D
--1 -2 D
-0 2 D
--9 10 D
--5 4 D
--4 5 D
--10 9 D
--6 -4 D
-0 9 D
--9 7 D
-3 -18 D
--24 3 D
+-121 0 D
+S
+1950 2071 M
+22 -2 D
+23 -7 D
 23 -12 D
--8 -8 D
--21 1 D
-10 -22 D
--12 -17 D
--25 47 D
--12 -12 D
-11 -9 D
--4 -5 D
--9 3 D
--3 12 D
--234 -334 D
-219 154 D
-P
-FO
-2227 2024 M
--7 45 D
-13 15 D
--2 14 D
-11 56 D
--73 -50 D
--219 -154 D
-P
-FO
-2288 2186 M
-9 4 D
-10 10 D
--15 -10 D
-P
-FO
-2355 1915 M
--27 16 D
-11 11 D
--6 12 D
--25 -2 D
--11 14 D
--12 -6 D
--32 36 D
--25 8 D
--1 20 D
--277 -74 D
-P
-FO
-2391 1759 M
--4 18 D
-13 42 D
--11 32 D
--16 8 D
--8 48 D
--10 8 D
--405 35 D
-436 -203 D
-P
-FO
-25 W
-4 W
-2060 1899 M
-1657 -773 D
-S
-1899 1840 M
--773 -1657 D
-S
-1840 2001 M
--1657 773 D
-S
-2001 2060 M
-773 1657 D
-S
-1950 1950 M
-110 -51 D
-S
-1950 1950 M
--51 -110 D
-S
-1950 1950 M
--110 51 D
-S
-1950 1950 M
-51 110 D
-S
-2060 1899 M
--11 -19 D
--6 -8 D
--4 -3 D
--3 -4 D
--2 -1 D
--3 -4 D
--20 -14 D
--17 -9 D
--23 -6 D
--22 -2 D
--27 3 D
--27 10 D
--22 15 D
--11 10 D
--3 4 D
--2 1 D
--13 20 D
--10 23 D
--4 21 D
--1 22 D
-5 26 D
-10 25 D
-14 20 D
-2 1 D
-10 11 D
-16 11 D
-21 11 D
-21 6 D
-29 2 D
-26 -5 D
-23 -9 D
-16 -10 D
-10 -8 D
+14 -11 D
 1 -2 D
 6 -5 D
 1 -2 D
@@ -15252,314 +8123,8482 @@ S
 3 -26 D
 -3 -27 D
 -5 -16 D
+-10 -22 D
+-10 -14 D
+-4 -3 D
+-8 -9 D
+-8 -6 D
+-8 -6 D
+-4 -2 D
+-6 -4 D
+-4 -2 D
+-3 -1 D
+-4 -2 D
+-2 0 D
+-3 -1 D
+-4 -2 D
+-3 0 D
+-4 -2 D
+-3 0 D
+-2 -1 D
+-2 0 D
+-3 0 D
+-2 -1 D
+-3 0 D
+-2 0 D
+-3 -1 D
+-2 0 D
+-2 0 D
+-3 0 D
+-2 0 D
+-3 0 D
+-2 0 D
+-24 4 D
+-23 8 D
+-16 10 D
+-17 14 D
+-5 6 D
+-2 1 D
+-13 20 D
+-10 23 D
+-4 23 D
+-1 20 D
+5 26 D
+10 25 D
+14 20 D
+2 1 D
+5 6 D
+2 1 D
+3 4 D
+22 15 D
+27 11 D
+19 3 D
 P S
-1950 1950 M
-0 0 D
-P S
-3717 1126 M
--12 -27 D
--9 -17 D
--36 -70 D
--49 -84 D
--48 -74 D
--57 -80 D
--42 -54 D
--19 -22 D
--45 -52 D
--47 -50 D
--41 -42 D
--28 -27 D
--15 -13 D
--36 -33 D
--68 -56 D
--62 -48 D
--80 -56 D
--100 -61 D
--69 -38 D
--88 -43 D
--62 -28 D
--92 -35 D
--92 -31 D
--66 -19 D
--105 -25 D
--87 -16 D
--87 -12 D
--97 -9 D
--108 -4 D
--88 1 D
--88 5 D
--117 13 D
--106 18 D
--86 19 D
--85 23 D
--56 17 D
--92 33 D
--82 34 D
--71 32 D
--17 9 D
--70 36 D
--84 49 D
--74 48 D
--80 57 D
--54 42 D
--22 19 D
--52 45 D
--50 47 D
--42 41 D
--27 28 D
--13 15 D
--33 36 D
--56 68 D
--48 62 D
--56 80 D
--61 100 D
--38 69 D
--43 88 D
--28 62 D
--35 92 D
--31 92 D
--19 66 D
--25 105 D
--16 87 D
--12 87 D
--9 97 D
--4 108 D
-1 88 D
-5 88 D
-13 117 D
-18 106 D
-19 86 D
-23 85 D
-17 56 D
-33 92 D
-34 82 D
-32 71 D
-9 17 D
-36 70 D
-49 84 D
-48 74 D
-57 80 D
-42 54 D
-19 22 D
-45 52 D
-47 50 D
-41 42 D
-28 27 D
-15 13 D
-36 33 D
-68 56 D
-62 48 D
-80 56 D
-100 61 D
-69 38 D
-88 43 D
-62 28 D
-92 35 D
-92 31 D
-66 19 D
-105 25 D
-87 16 D
-87 12 D
-97 9 D
-108 4 D
-88 -1 D
-88 -5 D
-117 -13 D
-106 -18 D
-86 -19 D
-85 -23 D
-56 -17 D
-92 -33 D
-82 -34 D
-71 -32 D
+1950 3900 M
+68 -1 D
+108 -7 D
+97 -11 D
+77 -13 D
+77 -15 D
+104 -27 D
+94 -29 D
+55 -19 D
+100 -41 D
+89 -41 D
 17 -9 D
-70 -36 D
-84 -49 D
-74 -48 D
-80 -57 D
-54 -42 D
-22 -19 D
-52 -45 D
-50 -47 D
-42 -41 D
-27 -28 D
-13 -15 D
-33 -36 D
-56 -68 D
-48 -62 D
-56 -80 D
-61 -100 D
-38 -69 D
-43 -88 D
-28 -62 D
-35 -92 D
-31 -92 D
-19 -66 D
-25 -105 D
-16 -87 D
-12 -87 D
-9 -97 D
-4 -108 D
--1 -88 D
--5 -88 D
--13 -117 D
--18 -106 D
--19 -86 D
--23 -85 D
--17 -56 D
--33 -92 D
--34 -82 D
+69 -37 D
+51 -29 D
+33 -21 D
+82 -54 D
+86 -64 D
+61 -50 D
+65 -59 D
+77 -76 D
+53 -57 D
+50 -60 D
+37 -46 D
+57 -79 D
+43 -66 D
+31 -50 D
+38 -68 D
+18 -35 D
+38 -79 D
+35 -81 D
+31 -83 D
+32 -102 D
+23 -85 D
+19 -86 D
+17 -107 D
+12 -107 D
+4 -68 D
+2 -88 D
+-1 -68 D
+-7 -108 D
+-11 -97 D
+-13 -77 D
+-15 -77 D
+-27 -104 D
+-29 -94 D
+-19 -55 D
+-41 -100 D
+-41 -89 D
+-9 -17 D
+-37 -69 D
+-29 -51 D
+-21 -33 D
+-54 -82 D
+-64 -86 D
+-50 -61 D
+-59 -65 D
+-76 -77 D
+-57 -53 D
+-45 -38 D
+-38 -31 D
+-31 -23 D
+-31 -24 D
+-24 -17 D
+-24 -16 D
+-25 -17 D
+-24 -16 D
+-17 -10 D
+-17 -10 D
+-25 -16 D
+-17 -9 D
+-17 -10 D
+-17 -10 D
+-17 -9 D
+-17 -9 D
+-18 -9 D
+-17 -9 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-17 -8 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-10 -1 D
+-9 0 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-79 3 D
+-97 8 D
+-68 8 D
+-77 13 D
+-77 15 D
+-104 27 D
+-94 29 D
+-55 19 D
+-100 41 D
+-89 41 D
+-17 9 D
+-69 37 D
+-51 29 D
+-33 21 D
+-82 54 D
+-86 64 D
+-61 50 D
+-65 59 D
+-77 76 D
+-53 57 D
+-50 60 D
+-37 46 D
+-57 79 D
+-43 66 D
+-31 50 D
+-38 68 D
+-18 35 D
+-38 79 D
+-35 81 D
+-31 83 D
+-32 102 D
+-23 85 D
+-19 86 D
+-17 107 D
+-12 107 D
+-4 68 D
+-2 88 D
+1 68 D
+7 108 D
+11 97 D
+13 77 D
+15 77 D
+27 104 D
+29 94 D
+19 55 D
+41 100 D
+41 89 D
+9 17 D
+37 69 D
+29 51 D
+21 33 D
+54 82 D
+64 86 D
+50 61 D
+59 65 D
+76 77 D
+57 53 D
+60 50 D
+46 37 D
+79 57 D
+66 43 D
+50 31 D
+68 38 D
+35 18 D
+79 38 D
+81 35 D
+83 31 D
+102 32 D
+85 23 D
+86 19 D
+107 17 D
+107 12 D
+68 4 D
 P S
 8 W
-N 3717 1126 M 76 -35 D S
-N 3717 1126 M 76 -35 D S
+N 1950 3900 M 0 83 D S
+N 1950 3900 M 0 83 D S
 25 W
-3717 1126 M
-13 27 D
-41 99 D
-39 111 D
-29 103 D
-20 86 D
-18 96 D
-12 97 D
-8 88 D
-3 108 D
--1 78 D
--7 107 D
--11 98 D
--13 77 D
--15 77 D
--27 104 D
--35 112 D
--46 119 D
--49 106 D
--51 95 D
--45 76 D
--32 49 D
--57 80 D
--61 77 D
--57 66 D
--14 14 D
--13 15 D
--48 49 D
--71 66 D
--52 45 D
--46 37 D
--63 47 D
--81 55 D
--83 51 D
--78 42 D
--61 30 D
--36 17 D
--99 41 D
--111 39 D
--103 29 D
--86 20 D
--96 18 D
--97 12 D
--88 8 D
--108 3 D
--78 -1 D
--107 -7 D
--98 -11 D
--77 -13 D
--77 -15 D
--104 -27 D
--112 -35 D
--119 -46 D
--106 -49 D
--95 -51 D
--76 -45 D
--49 -32 D
--80 -57 D
--77 -61 D
--66 -57 D
--14 -14 D
--15 -13 D
--49 -48 D
--66 -71 D
--45 -52 D
+1950 3900 M
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 0 D
+-10 -1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-9 -3 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-10 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-17 -8 D
+-18 -9 D
+-17 -9 D
+-9 -4 D
+-18 -9 D
+-17 -9 D
+-17 -9 D
+-17 -10 D
+-17 -10 D
+-17 -9 D
+-17 -10 D
+-17 -11 D
+-16 -10 D
+-17 -11 D
+-24 -16 D
+-17 -11 D
+-24 -16 D
+-24 -17 D
+-31 -24 D
+-31 -23 D
+-46 -38 D
+-59 -51 D
+-63 -61 D
+-55 -56 D
+-33 -36 D
+-50 -60 D
 -37 -46 D
--47 -63 D
--55 -81 D
--51 -83 D
--42 -78 D
--30 -61 D
--17 -36 D
--41 -99 D
--39 -111 D
--29 -103 D
--20 -86 D
--18 -96 D
--12 -97 D
--8 -88 D
--3 -108 D
-1 -78 D
-7 -107 D
-11 -98 D
+-57 -79 D
+-43 -66 D
+-31 -50 D
+-38 -68 D
+-18 -35 D
+-38 -79 D
+-35 -81 D
+-31 -83 D
+-32 -102 D
+-23 -85 D
+-19 -86 D
+-17 -107 D
+-12 -107 D
+-4 -68 D
+-2 -88 D
+1 -68 D
+7 -108 D
+11 -97 D
 13 -77 D
 15 -77 D
 27 -104 D
-35 -112 D
-46 -119 D
-49 -106 D
-51 -95 D
-45 -76 D
-32 -49 D
-57 -80 D
-61 -77 D
-57 -66 D
-14 -14 D
-13 -15 D
-48 -49 D
-71 -66 D
-52 -45 D
+29 -94 D
+19 -55 D
+41 -100 D
+41 -89 D
+9 -17 D
+37 -69 D
+29 -51 D
+21 -33 D
+54 -82 D
+64 -86 D
+50 -61 D
+59 -65 D
+76 -77 D
+57 -53 D
+60 -50 D
 46 -37 D
-63 -47 D
-81 -55 D
-83 -51 D
-78 -42 D
-61 -30 D
-36 -17 D
-99 -41 D
-111 -39 D
-103 -29 D
-86 -20 D
-96 -18 D
-97 -12 D
-88 -8 D
-108 -3 D
-78 1 D
-107 7 D
-98 11 D
+79 -57 D
+66 -43 D
+50 -31 D
+68 -38 D
+35 -18 D
+79 -38 D
+81 -35 D
+83 -31 D
+102 -32 D
+85 -23 D
+86 -19 D
+107 -17 D
+107 -12 D
+68 -4 D
+88 -2 D
+68 1 D
+108 7 D
+97 11 D
 77 13 D
 77 15 D
 104 27 D
-112 35 D
-119 46 D
-106 49 D
-95 51 D
-76 45 D
-49 32 D
-80 57 D
-77 61 D
-66 57 D
-14 14 D
-15 13 D
-49 48 D
-66 71 D
-45 52 D
+94 29 D
+55 19 D
+100 41 D
+89 41 D
+17 9 D
+69 37 D
+51 29 D
+33 21 D
+82 54 D
+86 64 D
+61 50 D
+65 59 D
+77 76 D
+53 57 D
+50 60 D
 37 46 D
-47 63 D
-55 81 D
-51 83 D
-42 78 D
-30 61 D
+57 79 D
+43 66 D
+31 50 D
+38 68 D
+18 35 D
+38 79 D
+35 81 D
+31 83 D
+32 102 D
+23 85 D
+19 86 D
+17 107 D
+12 107 D
+4 68 D
+2 88 D
+-1 68 D
+-7 108 D
+-11 97 D
+-13 77 D
+-15 77 D
+-27 104 D
+-29 94 D
+-19 55 D
+-41 100 D
+-41 89 D
+-9 17 D
+-37 69 D
+-29 51 D
+-21 33 D
+-54 82 D
+-64 86 D
+-50 61 D
+-59 65 D
+-76 77 D
+-57 53 D
+-60 50 D
+-46 37 D
+-79 57 D
+-66 43 D
+-50 31 D
+-68 38 D
+-35 18 D
+-79 38 D
+-81 35 D
+-83 31 D
+-102 32 D
+-85 23 D
+-86 19 D
+-107 17 D
+-107 12 D
+-68 4 D
 P S
-3868 1055 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+1950 4067 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-V 65 R (0ö) tc Z U
+(0è) bc Z
 %%EndObject
+1950 1950 T
+-45 R
+-1950 -1950 T
+0 A
+FQ
+O0
+-4980 4980 TM
+
+% PostScript produced by:
+%@GMT: gmt pscoast -R0/360/-90/0 -JA0/-90/3.25i -Bg90a360f360 -Gred -Dc -X-4.15i -Y4.15i -O -K -p180
+1950 1950 T
+180 R
+-1950 -1950 T
+%@PROJ: laea 0.00000000 360.00000000 -90.00000000 0.00000000 -9009964.761 9009964.761 -9009964.761 9009964.761 +proj=laea +lat_0=-90 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+2567 3800 M
+-82 -13 D
+-6 -15 D
+2 15 D
+60 13 D
+5 7 D
+2 -1 D
+-4 -6 D
+8 5 D
+-103 30 D
+-104 25 D
+-81 14 D
+-6 -11 D
+-15 3 D
+26 -34 D
+62 -48 D
+9 -25 D
+15 -8 D
+-13 0 D
+26 -47 D
+-15 -10 D
+8 -19 D
+85 -22 D
+90 -29 D
+21 -8 D
+60 166 D
+P
+2544 3759 M
+1 17 D
+16 -2 D
+-10 -4 D
+9 -6 D
+P
+2552 3787 M
+-9 9 D
+P
+2453 3759 M
+-9 1 D
+P
+2295 3853 M
+-11 -1 D
+2 5 D
+P
+2314 3800 M
+-8 5 D
+P
+2365 3751 M
+-8 0 D
+P
+{1 0 0 C} FS
+FO
+2941 3421 M
+2 5 D
+5 1 D
+7 -16 D
+65 -47 D
+37 -28 D
+26 -21 D
+9 32 D
+10 3 D
+-6 4 D
+18 5 D
+-9 29 D
+26 10 D
+38 5 D
+34 41 D
+-27 23 D
+-42 33 D
+-29 21 D
+-29 21 D
+-52 36 D
+-68 43 D
+-86 48 D
+-80 41 D
+-106 47 D
+-67 25 D
+-60 -166 D
+43 -16 D
+113 -49 D
+69 -35 D
+68 -38 D
+72 -45 D
+P
+2954 3581 M
+29 22 D
+4 -1 D
+56 -37 D
+2 -9 D
+15 -5 D
+1 -5 D
+-24 12 D
+-12 -12 D
+-26 6 D
+16 -14 D
+-15 3 D
+-13 11 D
+-1 -8 D
+-9 2 D
+7 6 D
+-15 15 D
+-17 -1 D
+P
+2983 3593 M
+0 6 D
+-1 -6 D
+P
+2959 3574 M
+-2 -4 D
+P
+2861 3590 M
+15 10 D
+-3 -48 D
+-10 -3 D
+17 -25 D
+0 -37 D
+-17 15 D
+2 24 D
+-16 34 D
+19 31 D
+P
+2795 3519 M
+5 7 D
+25 -4 D
+-18 -8 D
+P
+2853 3508 M
+-22 3 D
+11 3 D
+P
+2870 3621 M
+14 10 D
+5 -12 D
+P
+3083 3495 M
+4 3 D
+P
+2905 3604 M
+3 -5 D
+P
+2924 3472 M
+4 -8 D
+P
+2909 3645 M
+12 -7 D
+-20 2 D
+P
+2922 3474 M
+-15 12 D
+4 7 D
+P
+3024 3499 M
+20 -4 D
+-18 2 D
+P
+3070 3492 M
+6 6 D
+P
+2753 3562 M
+-8 -1 D
+P
+3051 3480 M
+7 3 D
+P
+3125 3486 M
+9 -3 D
+P
+FO
+3121 3377 M
+1 5 D
+-8 -4 D
+5 -11 D
+P
+FO
+3104 3346 M
+11 -3 D
+P
+FO
+3169 3403 M
+9 1 D
+26 -11 D
+-2 9 D
+13 -13 D
+64 -12 D
+-5 4 D
+-4 5 D
+-47 41 D
+-20 17 D
+P
+FO
+3488 3013 M
+1 -7 D
+P
+FO
+3238 3185 M
+7 -7 D
+P
+FO
+3874 1631 M
+-13 -18 D
+9 -2 D
+P
+FO
+3859 1650 M
+-2 12 D
+-13 -20 D
+P
+FO
+3837 1634 M
+-6 -11 D
+P
+FO
+3871 1670 M
+4 -6 D
+P
+FO
+3879 1665 M
+-7 -4 D
+P
+FO
+3497 1057 M
+13 30 D
+-23 -21 D
+-1 -3 D
+P
+FO
+3508 1050 M
+1 7 D
+-4 -5 D
+3 -1 D
+P
+FO
+3641 979 M
+-1 2 D
+5 6 D
+-17 -1 D
+6 2 D
+-1 16 D
+-12 6 D
+-3 25 D
+-15 1 D
+-9 -16 D
+-30 19 D
+-10 -15 D
+85 -49 D
+P
+FO
+3861 1613 M
+-7 -10 D
+-48 -33 D
+-53 -69 D
+-16 -16 D
+8 0 D
+-10 -19 D
+5 -5 D
+-12 -12 D
+42 -24 D
+19 11 D
+8 24 D
+-4 6 D
+7 -8 D
+5 13 D
+17 -1 D
+14 35 D
+9 -14 D
+14 60 D
+11 60 D
+P
+FO
+3655 1155 M
+-5 -45 D
+7 4 D
+-5 -6 D
+8 -14 D
+13 10 D
+3 -22 D
+-6 -4 D
+-4 -26 D
+14 -2 D
+31 63 D
+35 77 D
+29 72 D
+16 44 D
+-7 8 D
+-9 -14 D
+5 11 D
+-9 -11 D
+-3 9 D
+-3 -18 D
+-33 1 D
+-15 -45 D
+-15 -2 D
+-4 -38 D
+-11 -16 D
+-5 1 D
+-10 -28 D
+-14 4 D
+P
+3694 1089 M
+-3 -9 D
+P
+3712 1224 M
+-3 5 D
+P
+FO
+3594 1218 M
+-11 -16 D
+18 -2 D
+17 37 D
+23 11 D
+25 42 D
+-2 22 D
+18 44 D
+16 16 D
+28 67 D
+-8 11 D
+0 19 D
+-15 -38 D
+-6 5 D
+-20 -42 D
+-8 -31 D
+-29 -52 D
+P
+FO
+3769 1405 M
+5 -7 D
+8 17 D
+16 4 D
+5 23 D
+-5 8 D
+-6 -20 D
+-13 -3 D
+-11 -22 D
+P
+FO
+3545 1137 M
+-25 -64 D
+28 30 D
+1 8 D
+-16 -13 D
+22 30 D
+1 13 D
+P
+FO
+3587 1186 M
+7 14 D
+-19 -11 D
+-1 -21 D
+P
+FO
+3752 1365 M
+5 -11 D
+9 18 D
+-10 5 D
+-5 -12 D
+P
+FO
+3817 1606 M
+5 8 D
+-11 -7 D
+P
+FO
+3565 1163 M
+-11 -15 D
+7 -9 D
+8 12 D
+P
+FO
+3635 1243 M
+-13 -20 D
+-3 -20 D
+P
+FO
+3829 1447 M
+9 15 D
+-3 3 D
+P
+FO
+3640 1124 M
+9 -13 D
+P
+FO
+3832 1472 M
+-3 -11 D
+P
+FO
+3603 1169 M
+-3 -9 D
+P
+FO
+3841 1498 M
+-3 -11 D
+P
+FO
+3766 1561 M
+-4 -9 D
+P
+FO
+3550 1118 M
+0 -8 D
+P
+FO
+3512 1063 M
+-1 -7 D
+P
+FO
+3473 1042 M
+24 15 D
+-11 6 D
+P
+FO
+3412 946 M
+-28 -88 D
+37 57 D
+11 48 D
+-4 7 D
+P
+FO
+3179 485 M
+62 37 D
+15 22 D
+-5 2 D
+18 20 D
+4 25 D
+12 19 D
+23 0 D
+-1 9 D
+13 0 D
+24 -15 D
+41 35 D
+21 35 D
+-1 15 D
+-24 -26 D
+-18 1 D
+-35 -42 D
+-1 14 D
+14 7 D
+6 17 D
+18 18 D
+-27 -15 D
+-11 8 D
+-10 -16 D
+4 -20 D
+-3 11 D
+-12 -4 D
+-23 -22 D
+5 10 D
+-18 -9 D
+-80 -53 D
+-3 6 D
+-7 -8 D
+-8 8 D
+-19 -4 D
+8 9 D
+-19 -12 D
+13 13 D
+-16 -5 D
+-4 14 D
+-22 -25 D
+P
+FO
+3554 1024 M
+-7 -13 D
+45 -16 D
+-5 -19 D
+-7 -9 D
+-9 13 D
+-20 -15 D
+-9 8 D
+-10 -12 D
+4 -6 D
+-12 -22 D
+24 11 D
+1 -12 D
+41 22 D
+-9 -10 D
+-15 -62 D
+33 53 D
+0 21 D
+7 11 D
+22 12 D
+7 -10 D
+4 6 D
+P
+3575 956 M
+-5 -6 D
+2 10 D
+P
+3581 959 M
+-5 -4 D
+5 5 D
+P
+3602 972 M
+-5 2 D
+P
+FO
+3505 1052 M
+-28 -43 D
+-14 -41 D
+6 1 D
+0 16 D
+14 25 D
+24 26 D
+1 15 D
+P
+FO
+3483 753 M
+4 -3 D
+8 10 D
+-4 1 D
+-26 -14 D
+P
+FO
+3445 782 M
+-5 8 D
+2 -13 D
+-11 -3 D
+-29 -38 D
+-27 -18 D
+23 3 D
+29 31 D
+P
+FO
+3156 610 M
+-18 -24 D
+2 -10 D
+23 19 D
+2 23 D
+P
+FO
+3518 943 M
+5 -4 D
+5 11 D
+-8 9 D
+-7 -9 D
+P
+FO
+3271 661 M
+-9 14 D
+-4 -21 D
+13 -7 D
+6 13 D
+P
+FO
+3517 941 M
+-9 10 D
+-3 -19 D
+7 7 D
+9 -12 D
+P
+FO
+3495 774 M
+-9 -2 D
+-8 -12 D
+13 4 D
+P
+FO
+3427 916 M
+2 -5 D
+10 15 D
+-1 7 D
+P
+FO
+3466 765 M
+10 8 D
+2 10 D
+-17 -20 D
+P
+FO
+3482 837 M
+-21 -12 D
+-8 -18 D
+16 7 D
+P
+FO
+3417 675 M
+-4 -10 D
+23 28 D
+P
+FO
+3418 891 M
+-16 -29 D
+18 21 D
+P
+FO
+3291 562 M
+-9 -10 D
+31 18 D
+P
+FO
+3564 902 M
+-7 -18 D
+13 18 D
+P
+FO
+3283 570 M
+-21 -22 D
+38 33 D
+P
+FO
+3411 711 M
+3 -5 D
+11 19 D
+P
+FO
+3405 685 M
+4 -5 D
+8 11 D
+P
+FO
+3503 822 M
+12 19 D
+-19 -28 D
+P
+FO
+3445 941 M
+-5 -1 D
+2 -8 D
+P
+FO
+3541 1015 M
+-8 3 D
+11 -7 D
+P
+FO
+3496 827 M
+6 -1 D
+-10 1 D
+P
+FO
+3597 912 M
+-6 -3 D
+P
+FO
+3438 788 M
+-6 -10 D
+P
+FO
+3458 714 M
+-8 -4 D
+P
+FO
+3456 964 M
+-8 -22 D
+P
+FO
+3309 587 M
+-6 -6 D
+P
+FO
+3528 964 M
+-4 4 D
+P
+FO
+3143 597 M
+-9 -7 D
+P
+FO
+3340 791 M
+7 3 D
+P
+FO
+3303 695 M
+3 -16 D
+P
+FO
+3598 920 M
+4 12 D
+P
+FO
+3462 968 M
+-4 -10 D
+P
+FO
+3500 778 M
+-3 -7 D
+P
+FO
+3423 697 M
+-10 -16 D
+P
+FO
+3314 696 M
+-8 0 D
+P
+FO
+3372 839 M
+7 4 D
+-6 -4 D
+P
+FO
+3312 736 M
+-6 -6 D
+6 5 D
+P
+FO
+3427 691 M
+-4 -7 D
+P
+FO
+3481 777 M
+-5 -6 D
+P
+FO
+3318 661 M
+-10 -5 D
+P
+FO
+3531 868 M
+-15 -28 D
+18 20 D
+P
+FO
+3434 717 M
+-5 -7 D
+P
+FO
+3313 760 M
+0 -1 D
+P
+FO
+2839 416 M
+7 0 D
+-6 -8 D
+22 10 D
+4 -8 D
+17 12 D
+22 -8 D
+31 7 D
+13 -7 D
+-23 -17 D
+11 -4 D
+57 24 D
+5 -11 D
+45 9 D
+135 70 D
+-66 79 D
+-41 -6 D
+-25 -23 D
+-13 -4 D
+-13 -23 D
+36 14 D
+-38 -27 D
+11 1 D
+-14 -9 D
+13 -3 D
+-26 -10 D
+7 -3 D
+-7 0 D
+-2 -8 D
+-7 4 D
+-35 -18 D
+-60 3 D
+-20 -12 D
+-20 -13 D
+P
+3093 520 M
+-7 2 D
+P
+3158 477 M
+7 5 D
+-6 -5 D
+P
+FO
+2809 398 M
+10 0 D
+-10 0 D
+P
+FO
+2560 274 M
+10 0 D
+2 6 D
+-13 -3 D
+0 -2 D
+1 0 D
+P
+FO
+2843 335 M
+-25 -26 D
+8 -3 D
+-7 -18 D
+8 1 D
+19 11 D
+-11 7 D
+17 22 D
+23 14 D
+4 -8 D
+2 11 D
+42 27 D
+-42 -11 D
+P
+FO
+2728 281 M
+-19 3 D
+-12 -7 D
+46 -5 D
+P
+FO
+2803 275 M
+77 11 D
+-54 -8 D
+-25 11 D
+P
+FO
+2646 279 M
+3 8 D
+-20 -2 D
+P
+FO
+2992 346 M
+-11 -10 D
+25 19 D
+P
+FO
+2598 262 M
+-30 -2 D
+51 -1 D
+P
+FO
+2932 378 M
+8 4 D
+-10 0 D
+P
+FO
+2648 291 M
+-8 0 D
+3 -5 D
+P
+FO
+2662 272 M
+-17 -5 D
+39 1 D
+P
+FO
+2656 286 M
+-1 -6 D
+2 6 D
+P
+FO
+2831 398 M
+-17 -3 D
+P
+FO
+2903 298 M
+1 1 D
+-15 -6 D
+P
+FO
+2762 356 M
+16 6 D
+P
+FO
+2840 402 M
+-8 -1 D
+P
+FO
+2674 285 M
+-8 2 D
+P
+FO
+2751 270 M
+-6 4 D
+P
+FO
+2624 281 M
+-2 4 D
+P
+FO
+2962 392 M
+-7 -3 D
+P
+FO
+3027 504 M
+-8 -5 D
+P
+FO
+2640 291 M
+-7 -2 D
+P
+FO
+2871 289 M
+7 4 D
+P
+FO
+2997 398 M
+-1 5 D
+P
+FO
+2927 291 M
+-8 -3 D
+P
+FO
+3030 507 M
+-14 -4 D
+P
+FO
+2823 375 M
+-6 3 D
+P
+FO
+2559 277 M
+-26 -4 D
+27 1 D
+0 1 D
+-1 0 D
+P
+FO
+2532 260 M
+-14 3 D
+32 -14 D
+P
+FO
+2521 258 M
+-8 6 D
+P
+FO
+2559 265 M
+-9 -1 D
+P
+FO
+803 570 M
+-5 6 D
+P
+FO
+87 2279 M
+9 -44 D
+26 9 D
+4 -10 D
+19 34 D
+P
+FO
+76 2280 M
+-1 -7 D
+5 3 D
+-2 4 D
+-1 0 D
+P
+FO
+29 2285 M
+4 -14 D
+6 6 D
+3 -22 D
+22 -3 D
+10 20 D
+-4 10 D
+-40 7 D
+P
+FO
+17 1914 M
+-4 10 D
+-13 -17 D
+1 -11 D
+10 18 D
+5 -15 D
+P
+FO
+16 1963 M
+-4 13 D
+P
+FO
+11 1931 M
+-1 13 D
+P
+FO
+85 2271 M
+-1 7 D
+P
+FO
+6 1894 M
+2 9 D
+P
+FO
+5 1920 M
+0 11 D
+P
+FO
+310 2897 M
+-18 -58 D
+-14 -15 D
+-4 -39 D
+-8 0 D
+3 9 D
+-30 -35 D
+2 -5 D
+-19 -8 D
+-14 -20 D
+-18 -42 D
+6 -30 D
+-14 -34 D
+4 -14 D
+5 6 D
+-1 -18 D
+-13 -9 D
+-15 -35 D
+-12 -8 D
+-8 -40 D
+1 12 D
+-4 -6 D
+6 14 D
+4 19 D
+13 9 D
+14 36 D
+14 11 D
+1 14 D
+-5 -6 D
+-5 14 D
+13 37 D
+-4 28 D
+25 61 D
+32 24 D
+27 32 D
+4 24 D
+11 11 D
+10 30 D
+-4 8 D
+14 24 D
+-1 0 D
+-11 -16 D
+-41 -17 D
+-47 -52 D
+-39 -83 D
+4 16 D
+32 66 D
+50 54 D
+52 32 D
+-47 27 D
+-47 -87 D
+-39 -80 D
+-35 -83 D
+-25 -66 D
+-29 -85 D
+-24 -87 D
+-19 -78 D
+-13 -70 D
+40 -7 D
+-2 4 D
+7 4 D
+12 -11 D
+58 -11 D
+32 27 D
+37 17 D
+27 113 D
+27 87 D
+31 86 D
+22 54 D
+46 97 D
+35 66 D
+12 22 D
+P
+285 2862 M
+-5 -11 D
+P
+269 2818 M
+-8 -8 D
+P
+266 2802 M
+-9 -8 D
+P
+FO
+78 2280 M
+-2 4 D
+0 -4 D
+P
+FO
+728 3406 M
+-56 -49 D
+-35 -20 D
+-21 -45 D
+-7 11 D
+6 13 D
+-14 -16 D
+7 16 D
+-16 0 D
+-4 -15 D
+-9 4 D
+-2 -7 D
+0 5 D
+-5 -8 D
+-12 -2 D
+0 -7 D
+-6 3 D
+-1 -6 D
+-28 -17 D
+1 -5 D
+-18 -15 D
+0 -20 D
+11 9 D
+-6 -11 D
+-9 -1 D
+-6 -41 D
+-3 21 D
+-25 -34 D
+-20 2 D
+-18 -44 D
+-12 -12 D
+12 21 D
+1 12 D
+-4 20 D
+1 3 D
+-31 -39 D
+-30 -40 D
+-47 -68 D
+-44 -70 D
+-17 -29 D
+47 -27 D
+27 45 D
+4 31 D
+18 23 D
+3 24 D
+23 31 D
+8 9 D
+4 -5 D
+5 9 D
+20 50 D
+-16 -45 D
+-16 -25 D
+8 -23 D
+-14 17 D
+10 13 D
+-20 -23 D
+10 15 D
+-13 -12 D
+-11 -35 D
+-18 -22 D
+-5 -40 D
+-22 -29 D
+-3 -9 D
+104 -60 D
+34 56 D
+26 41 D
+52 73 D
+65 83 D
+54 61 D
+34 36 D
+6 5 D
+17 18 D
+6 5 D
+11 12 D
+72 66 D
+19 16 D
+P
+458 3142 M
+-12 0 D
+19 24 D
+-1 -12 D
+7 0 D
+-18 -3 D
+P
+456 3154 M
+9 6 D
+P
+355 2980 M
+1 9 D
+P
+360 2989 M
+-2 5 D
+P
+339 3008 M
+15 19 D
+7 0 D
+P
+431 3126 M
+26 -4 D
+-27 4 D
+P
+498 3182 M
+15 -13 D
+P
+398 3063 M
+3 7 D
+P
+FO
+309 2898 M
+1 2 D
+-2 -2 D
+P
+FO
+450 3175 M
+9 5 D
+-5 -9 D
+13 -1 D
+17 19 D
+17 28 D
+-5 25 D
+-46 -48 D
+P
+483 3221 M
+2 -4 D
+P
+FO
+434 3148 M
+1 -11 D
+6 17 D
+-1 12 D
+-5 -3 D
+P
+FO
+457 3203 M
+0 2 D
+-3 -4 D
+P
+FO
+617 3312 M
+8 9 D
+P
+FO
+436 3176 M
+8 10 D
+P
+FO
+432 3161 M
+2 11 D
+P
+FO
+439 3174 M
+0 -6 D
+P
+FO
+442 3171 M
+1 6 D
+P
+FO
+618 3303 M
+-2 4 D
+P
+FO
+436 3179 M
+P
+FO
+571 3296 M
+-1 5 D
+P
+FO
+-5 1 1 392 3054 SP
+904 3382 M
+13 46 D
+-8 21 D
+-30 16 D
+-13 -2 D
+-42 -27 D
+-48 -9 D
+-48 -21 D
+82 -97 D
+75 59 D
+P
+793 3383 M
+-8 -9 D
+P
+829 3391 M
+-6 -4 D
+P
+FO
+2361 3675 M
+9 -21 D
+-11 -21 D
+-38 -14 D
+-32 -40 D
+-7 -40 D
+52 -105 D
+-8 -76 D
+32 -88 D
+64 -22 D
+135 368 D
+-69 24 D
+-77 23 D
+P
+FO
+2284 3566 M
+1 -5 D
+P
+FO
+2529 3204 M
+-1 1 D
+67 -34 D
+64 -36 D
+14 5 D
+33 2 D
+39 34 D
+-5 -1 D
+-3 10 D
+85 -12 D
+24 30 D
+-2 40 D
+10 15 D
+3 -7 D
+44 -7 D
+24 6 D
+84 -31 D
+6 0 D
+72 86 D
+-4 10 D
+-47 37 D
+-76 56 D
+-5 3 D
+-5 -30 D
+-16 -10 D
+-8 -40 D
+-13 16 D
+5 39 D
+15 3 D
+8 32 D
+-78 49 D
+-40 24 D
+-75 40 D
+-77 36 D
+-85 36 D
+-29 10 D
+-135 -368 D
+72 -28 D
+P
+2587 3236 M
+-8 -6 D
+-8 7 D
+4 -7 D
+-8 8 D
+P
+2875 3314 M
+14 -16 D
+4 -28 D
+-5 27 D
+P
+2687 3396 M
+30 9 D
+33 -13 D
+-25 9 D
+P
+2639 3219 M
+-5 3 D
+0 -6 D
+-4 9 D
+P
+2827 3473 M
+-4 -7 D
+-10 3 D
+13 5 D
+P
+2748 3517 M
+0 -5 D
+P
+2925 3330 M
+-2 -5 D
+P
+2556 3401 M
+7 1 D
+P
+2711 3165 M
+-1 6 D
+P
+2816 3465 M
+-4 -3 D
+P
+2925 3306 M
+4 6 D
+P
+2803 3383 M
+48 -28 D
+P
+FO
+3015 3219 M
+36 4 D
+13 36 D
+8 -2 D
+10 26 D
+15 3 D
+-10 19 D
+P
+FO
+2992 2992 M
+45 -32 D
+143 43 D
+14 12 D
+13 -4 D
+15 21 D
+7 -5 D
+-4 -13 D
+14 0 D
+25 41 D
+-4 26 D
+7 3 D
+-18 6 D
+-12 -13 D
+-17 6 D
+-4 11 D
+-6 -11 D
+-6 6 D
+-17 -5 D
+6 6 D
+-16 2 D
+-1 -7 D
+-8 5 D
+7 4 D
+-14 6 D
+-6 -7 D
+-3 11 D
+-42 29 D
+-28 -8 D
+-22 -45 D
+-38 0 D
+-19 -10 D
+-22 -53 D
+P
+3170 3030 M
+7 2 D
+P
+FO
+3286 2800 M
+-11 -2 D
+10 -7 D
+P
+FO
+3142 3219 M
+5 -8 D
+4 10 D
+-8 -2 D
+P
+FO
+3158 3193 M
+5 -10 D
+3 5 D
+P
+FO
+3235 2841 M
+3 -16 D
+5 8 D
+P
+FO
+3169 3168 M
+0 -7 D
+P
+FO
+3226 3092 M
+2 -6 D
+P
+FO
+3144 3203 M
+4 -6 D
+P
+FO
+3205 3008 M
+7 1 D
+P
+FO
+3325 1156 M
+9 24 D
+8 49 D
+12 12 D
+2 64 D
+-9 13 D
+16 3 D
+-40 35 D
+-44 -4 D
+10 5 D
+-3 6 D
+15 -1 D
+-23 1 D
+15 13 D
+-73 -15 D
+-18 6 D
+-31 -64 D
+-25 -44 D
+P
+FO
+3487 1066 M
+-2 -2 D
+1 -1 D
+P
+FO
+3295 1374 M
+12 1 D
+P
+FO
+3366 1281 M
+2 -6 D
+P
+FO
+3315 1367 M
+-5 4 D
+P
+FO
+3315 1367 M
+4 -2 D
+P
+FO
+2998 701 M
+9 7 D
+20 1 D
+64 32 D
+39 12 D
+3 -31 D
+8 -2 D
+-11 -12 D
+6 -6 D
+-6 -17 D
+15 2 D
+4 20 D
+5 -6 D
+7 10 D
+-2 -9 D
+10 20 D
+15 5 D
+10 16 D
+10 -1 D
+7 11 D
+42 25 D
+1 7 D
+-23 -18 D
+-8 6 D
+24 31 D
+7 1 D
+4 15 D
+-6 0 D
+11 5 D
+-7 1 D
+8 8 D
+-10 9 D
+8 13 D
+-3 20 D
+-18 -9 D
+0 14 D
+11 3 D
+-3 9 D
+6 -4 D
+12 11 D
+2 12 D
+-9 1 D
+9 2 D
+-3 6 D
+8 -14 D
+26 10 D
+13 11 D
+-3 12 D
+6 -2 D
+1 11 D
+9 1 D
+-10 11 D
+12 2 D
+0 17 D
+-13 -4 D
+12 16 D
+-14 -5 D
+15 10 D
+-2 12 D
+-7 0 D
+-1 -8 D
+-3 15 D
+-10 -14 D
+7 16 D
+19 16 D
+-7 6 D
+-10 -9 D
+-6 5 D
+9 7 D
+-9 6 D
+30 2 D
+-3 28 D
+-17 4 D
+-5 44 D
+12 29 D
+-179 103 D
+-36 -59 D
+-25 -37 D
+-26 -36 D
+-67 -84 D
+-34 -38 D
+-5 -4 D
+-17 -19 D
+-5 -4 D
+-4 -5 D
+-5 -4 D
+-4 -5 D
+-19 -17 D
+-4 -5 D
+-43 -38 D
+-14 -12 D
+P
+3234 920 M
+11 -5 D
+-7 -10 D
+P
+3128 833 M
+4 -6 D
+P
+FO
+3428 970 M
+-4 6 D
+-8 -15 D
+-4 -15 D
+P
+FO
+3485 1064 M
+-11 -10 D
+-2 -12 D
+1 0 D
+13 21 D
+P
+FO
+3270 803 M
+0 6 D
+15 6 D
+-23 -4 D
+-5 -19 D
+P
+FO
+3121 719 M
+-1 6 D
+-14 -12 D
+13 -5 D
+P
+FO
+3283 831 M
+-12 -15 D
+12 2 D
+P
+FO
+3157 693 M
+-3 -6 D
+P
+FO
+3029 703 M
+-11 -12 D
+P
+FO
+3424 993 M
+0 -14 D
+P
+FO
+3450 1024 M
+-3 -9 D
+P
+FO
+3242 763 M
+-5 4 D
+P
+FO
+3162 706 M
+-1 -6 D
+1 7 D
+P
+FO
+3153 684 M
+-1 -12 D
+P
+FO
+2570 716 M
+6 -29 D
+26 -18 D
+9 -26 D
+50 -18 D
+28 4 D
+14 -19 D
+-2 6 D
+19 -1 D
+-6 9 D
+8 -2 D
+3 6 D
+43 -28 D
+74 15 D
+28 -27 D
+18 2 D
+18 -23 D
+28 2 D
+16 17 D
+22 -20 D
+49 -14 D
+7 12 D
+-11 16 D
+5 18 D
+-9 -7 D
+-3 28 D
+-18 14 D
+-8 57 D
+14 11 D
+-160 191 D
+-48 -39 D
+-30 -22 D
+-30 -21 D
+-31 -21 D
+-21 -13 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+P
+FO
+2809 398 M
+-7 1 D
+P
+FO
+2899 452 M
+-3 0 D
+-56 -28 D
+-15 -2 D
+-14 -18 D
+25 11 D
+0 1 D
+3 0 D
+20 11 D
+P
+FO
+2620 636 M
+-5 4 D
+5 -21 D
+P
+FO
+2596 661 M
+-4 5 D
+P
+FO
+2739 390 M
+-18 -4 D
+P
+FO
+2590 673 M
+1 -7 D
+P
+FO
+2763 387 M
+-10 -4 D
+P
+FO
+1950 306 M
+2 2 D
+P
+FO
+1950 292 M
+43 13 D
+-41 -1 D
+0 -6 D
+13 5 D
+-15 -11 D
+P
+FO
+2313 329 M
+6 3 D
+-9 7 D
+-10 -2 D
+P
+FO
+1988 328 M
+14 -13 D
+26 14 D
+-19 5 D
+P
+FO
+2340 316 M
+-8 11 D
+-13 -6 D
+22 -12 D
+P
+FO
+2493 277 M
+-11 -3 D
+36 0 D
+P
+FO
+2256 375 M
+-9 -1 D
+8 -5 D
+P
+FO
+2296 452 M
+90 -23 D
+-32 18 D
+P
+FO
+2289 324 M
+3 -10 D
+P
+FO
+2290 338 M
+-11 0 D
+P
+FO
+2006 350 M
+-14 -2 D
+P
+FO
+2298 312 M
+8 5 D
+P
+FO
+2319 298 M
+-5 -4 D
+P
+FO
+2317 424 M
+-2 -7 D
+P
+FO
+2292 424 M
+10 -3 D
+P
+FO
+2284 357 M
+-12 -3 D
+P
+FO
+2295 329 M
+-10 0 D
+P
+FO
+2272 433 M
+7 -4 D
+P
+FO
+2249 384 M
+-7 3 D
+P
+FO
+2376 243 M
+9 3 D
+P
+FO
+1950 292 M
+P
+FO
+1950 306 M
+-4 -4 D
+P
+FO
+1709 268 M
+-12 2 D
+19 -5 D
+P
+FO
+1737 255 M
+-19 6 D
+P
+FO
+1824 393 M
+-9 2 D
+P
+FO
+1681 279 M
+-8 0 D
+P
+FO
+1125 543 M
+-9 12 D
+P
+FO
+1015 579 M
+-2 7 D
+P
+FO
+930 690 M
+-2 6 D
+P
+FO
+214 2312 M
+27 12 D
+48 34 D
+8 -8 D
+17 10 D
+20 19 D
+65 91 D
+32 24 D
+30 -6 D
+27 -8 D
+34 -28 D
+37 -8 D
+60 -49 D
+21 -1 D
+1 -2 D
+31 81 D
+14 35 D
+38 78 D
+30 55 D
+-340 196 D
+-43 -80 D
+-40 -83 D
+-35 -84 D
+-31 -86 D
+-30 -103 D
+P
+383 2535 M
+25 20 D
+4 -10 D
+-11 -1 D
+1 -8 D
+-16 -18 D
+-8 8 D
+P
+478 2577 M
+-13 -5 D
+-9 9 D
+P
+417 2698 M
+5 0 D
+P
+380 2620 M
+5 -3 D
+P
+387 2660 M
+-6 0 D
+P
+384 2647 M
+-4 3 D
+P
+FO
+758 2648 M
+-13 8 D
+-2 7 D
+-20 28 D
+3 14 D
+38 51 D
+-41 -64 D
+26 -37 D
+10 -5 D
+36 58 D
+39 56 D
+56 72 D
+-4 17 D
+3 27 D
+-17 25 D
+-19 5 D
+-3 18 D
+-10 -5 D
+11 9 D
+-1 23 D
+10 34 D
+16 19 D
+7 31 D
+18 14 D
+4 15 D
+4 -4 D
+21 18 D
+-5 8 D
+12 25 D
+-8 6 D
+2 44 D
+-92 108 D
+-29 36 D
+-55 -49 D
+-42 -39 D
+-5 -6 D
+-18 -17 D
+-5 -6 D
+-12 -11 D
+-66 -72 D
+-51 -63 D
+-49 -65 D
+-42 -61 D
+-34 -55 D
+-17 -28 D
+340 -196 D
+P
+842 3037 M
+-12 -3 D
+-2 -8 D
+0 9 D
+-14 -1 D
+14 17 D
+2 -4 D
+12 3 D
+-18 -6 D
+-4 -9 D
+P
+815 3081 M
+-7 -6 D
+-2 11 D
+-5 -8 D
+-1 11 D
+17 -1 D
+P
+811 2970 M
+-10 -5 D
+P
+762 2714 M
+2 7 D
+-1 -7 D
+P
+799 2942 M
+11 12 D
+4 -4 D
+P
+862 3059 M
+-6 1 D
+7 -1 D
+P
+886 2843 M
+-1 7 D
+P
+808 3030 M
+-14 -5 D
+P
+FO
+880 2894 M
+-4 9 D
+P
+FO
+876 3006 M
+3 6 D
+P
+FO
+887 3037 M
+5 5 D
+P
+FO
+931 3165 M
+0 7 D
+-13 21 D
+4 20 D
+-51 77 D
+0 7 D
+10 -2 D
+6 12 D
+17 75 D
+-29 -21 D
+-47 -37 D
+-18 -15 D
+59 -71 D
+P
+FO
+2358 3270 M
+12 -41 D
+-2 -18 D
+-13 -2 D
+2 -34 D
+10 1 D
+21 -23 D
+34 95 D
+P
+FO
+2529 3204 M
+2 -6 D
+-2 6 D
+-62 27 D
+-45 17 D
+-34 -96 D
+60 -4 D
+45 -25 D
+50 -9 D
+84 9 D
+32 12 D
+-64 36 D
+-57 29 D
+P
+2540 3185 M
+7 -4 D
+P
+FO
+2569 2754 M
+5 -3 D
+P
+FO
+2839 2291 M
+7 -2 D
+1 -17 D
+3 12 D
+3 -13 D
+8 1 D
+-10 17 D
+8 -2 D
+-7 8 D
+9 6 D
+P
+FO
+3202 1367 M
+-10 3 D
+-36 -5 D
+-24 16 D
+3 17 D
+-18 5 D
+-27 -24 D
+-15 -26 D
+1 -50 D
+-1 -2 D
+71 -42 D
+34 62 D
+P
+FO
+3075 1301 M
+-43 -68 D
+8 -24 D
+-11 -42 D
+-62 -106 D
+-64 -37 D
+-4 8 D
+-15 -7 D
+-34 9 D
+7 6 D
+-20 -7 D
+7 -7 D
+-8 -52 D
+8 -8 D
+-19 13 D
+0 18 D
+-11 12 D
+7 6 D
+-3 9 D
+-12 -17 D
+8 -20 D
+-17 4 D
+-4 19 D
+-12 -13 D
+-16 -2 D
+-8 3 D
+4 -1 D
+-17 15 D
+-8 1 D
+102 -121 D
+57 50 D
+4 5 D
+19 17 D
+4 5 D
+5 4 D
+4 5 D
+5 4 D
+17 19 D
+5 4 D
+54 62 D
+55 70 D
+36 52 D
+43 70 D
+P
+FO
+2805 1033 M
+-15 -20 D
+26 22 D
+P
+FO
+2736 1013 M
+-17 2 D
+-60 -25 D
+-11 -34 D
+-7 3 D
+6 8 D
+-13 -11 D
+-2 7 D
+-21 -3 D
+4 -5 D
+-21 -34 D
+7 9 D
+-1 -6 D
+-38 -32 D
+16 -36 D
+-7 -19 D
+7 -1 D
+2 -32 D
+-17 -34 D
+7 -3 D
+-4 -29 D
+4 -22 D
+87 47 D
+52 33 D
+81 57 D
+48 39 D
+P
+2668 983 M
+2 -5 D
+P
+2626 815 M
+2 -7 D
+P
+2629 901 M
+3 -5 D
+P
+FO
+2562 1042 M
+-17 -3 D
+6 -21 D
+-20 1 D
+12 -26 D
+-5 3 D
+21 -23 D
+19 25 D
+39 11 D
+-11 12 D
+-24 8 D
+8 2 D
+-7 6 D
+P
+2562 1034 M
+8 -2 D
+P
+FO
+2568 961 M
+-7 -1 D
+12 -5 D
+P
+FO
+2544 1032 M
+0 -9 D
+P
+FO
+2634 1003 M
+9 -5 D
+P
+FO
+2051 808 M
+6 7 D
+-13 6 D
+-14 -9 D
+-19 -46 D
+-20 -3 D
+-10 -31 D
+12 -3 D
+17 12 D
+24 -7 D
+14 -24 D
+-3 16 D
+20 -6 D
+-3 -12 D
+13 -10 D
+1 -14 D
+4 4 D
+17 -10 D
+3 5 D
+6 -12 D
+8 1 D
+-35 39 D
+4 -8 D
+-13 4 D
+0 8 D
+7 -3 D
+-9 12 D
+-9 -1 D
+8 1 D
+-10 15 D
+5 22 D
+17 12 D
+-28 12 D
+P
+2038 762 M
+-6 -5 D
+P
+FO
+2129 935 M
+-12 -10 D
+-4 -43 D
+-16 -5 D
+11 -6 D
+-11 6 D
+-16 -3 D
+8 -3 D
+-1 -12 D
+-25 -34 D
+0 -11 D
+8 2 D
+-7 -7 D
+21 10 D
+13 -13 D
+-7 -4 D
+16 9 D
+20 53 D
+25 24 D
+16 4 D
+20 30 D
+-5 6 D
+7 -1 D
+-2 20 D
+-17 -5 D
+-26 6 D
+P
+2151 895 M
+-1 9 D
+7 -4 D
+P
+2146 896 M
+2 6 D
+P
+2180 936 M
+-3 5 D
+P
+2163 909 M
+-8 10 D
+P
+2130 874 M
+-1 0 D
+3 21 D
+P
+2135 880 M
+-1 10 D
+P
+2124 870 M
+-8 7 D
+P
+FO
+2160 961 M
+6 -9 D
+3 15 D
+P
+FO
+2052 704 M
+-5 3 D
+P
+FO
+2075 809 M
+-4 -6 D
+P
+FO
+1887 871 M
+-9 -5 D
+12 0 D
+P
+FO
+1037 2197 M
+-1 9 D
+-28 1 D
+15 -6 D
+-4 -10 D
+15 3 D
+-11 12 D
+P
+FO
+1044 2222 M
+23 69 D
+3 6 D
+-7 -2 D
+7 2 D
+3 9 D
+-17 13 D
+-11 39 D
+-15 7 D
+-12 -16 D
+-25 -5 D
+-11 18 D
+4 27 D
+-25 15 D
+-5 24 D
+-12 -8 D
+2 11 D
+10 2 D
+-1 11 D
+-12 2 D
+1 -16 D
+-12 -6 D
+-27 13 D
+20 18 D
+8 27 D
+-31 18 D
+5 5 D
+-15 0 D
+16 20 D
+8 22 D
+-107 61 D
+-34 21 D
+6 -23 D
+26 -8 D
+-28 8 D
+-5 23 D
+-20 12 D
+-47 -88 D
+-26 -57 D
+-27 -69 D
+-13 -35 D
+9 -13 D
+61 -17 D
+61 -55 D
+1 -13 D
+47 -3 D
+28 -24 D
+15 5 D
+2 -6 D
+-1 17 D
+4 6 D
+-2 7 D
+8 -15 D
+8 9 D
+6 -5 D
+-6 -5 D
+9 4 D
+-4 -5 D
+18 -12 D
+10 5 D
+4 -12 D
+12 10 D
+9 -21 D
+8 12 D
+-3 -13 D
+7 -4 D
+-1 9 D
+17 -15 D
+-10 -1 D
+-2 -11 D
+2 9 D
+-3 -6 D
+-5 6 D
+3 -7 D
+-6 -4 D
+-1 -7 D
+6 8 D
+6 -7 D
+4 -15 D
+6 5 D
+-6 -3 D
+-3 13 D
+9 -2 D
+1 11 D
+12 2 D
+2 -11 D
+4 10 D
+1 -15 D
+2 17 D
+11 6 D
+-4 -7 D
+9 3 D
+-12 -20 D
+13 11 D
+1 -10 D
+5 5 D
+13 -10 D
+-3 7 D
+13 3 D
+-5 -10 D
+9 2 D
+P
+1022 2232 M
+-11 5 D
+10 2 D
+-7 4 D
+17 1 D
+P
+981 2248 M
+-10 7 D
+10 26 D
+-6 -19 D
+P
+740 2574 M
+-8 -4 D
+7 17 D
+P
+856 2311 M
+11 8 D
+-2 -10 D
+P
+861 2285 M
+-7 3 D
+7 4 D
+P
+978 2329 M
+-10 -1 D
+P
+943 2284 M
+-3 -5 D
+P
+1033 2261 M
+-5 3 D
+5 -2 D
+P
+840 2304 M
+2 -6 D
+P
+972 2320 M
+-6 5 D
+P
+957 2225 M
+4 5 D
+5 -6 D
+P
+991 2260 M
+-2 -6 D
+P
+862 2301 M
+-3 -5 D
+P
+925 2293 M
+-4 -5 D
+P
+830 2309 M
+5 1 D
+P
+909 2283 M
+-6 -2 D
+P
+786 2344 M
+6 -1 D
+P
+853 2316 M
+-1 0 D
+5 4 D
+P
+838 2326 M
+0 -6 D
+P
+831 2304 M
+5 4 D
+P
+1044 2240 M
+-10 -10 D
+P
+FO
+898 2252 M
+-2 10 D
+-29 8 D
+-2 -10 D
+9 -6 D
+20 -10 D
+P
+FO
+934 2261 M
+-9 3 D
+3 -11 D
+P
+FO
+1005 2203 M
+4 8 D
+-12 -1 D
+P
+FO
+1026 2187 M
+7 6 D
+P
+FO
+1012 2192 M
+2 6 D
+P
+FO
+1015 2200 M
+6 1 D
+-5 -1 D
+P
+FO
+948 2241 M
+-3 6 D
+P
+FO
+925 2246 M
+4 5 D
+P
+FO
+955 2238 M
+5 1 D
+P
+FO
+919 2235 M
+1 6 D
+P
+FO
+997 2212 M
+6 1 D
+P
+FO
+1014 2198 M
+-5 -1 D
+P
+FO
+985 2201 M
+3 6 D
+P
+FO
+938 2240 M
+-5 5 D
+P
+FO
+995 2206 M
+8 -2 D
+P
+FO
+927 2243 M
+-4 -6 D
+P
+FO
+1000 2193 M
+5 5 D
+P
+FO
+946 2228 M
+-6 4 D
+P
+FO
+759 2650 M
+12 -7 D
+4 -14 D
+34 -21 D
+107 -61 D
+11 30 D
+3 22 D
+-12 30 D
+-11 5 D
+-14 -7 D
+-10 11 D
+-32 -16 D
+-23 17 D
+15 -9 D
+17 5 D
+29 26 D
+21 40 D
+-6 49 D
+-17 22 D
+-6 41 D
+-9 0 D
+19 8 D
+5 -50 D
+2 37 D
+-8 28 D
+-63 -81 D
+-44 -66 D
+P
+900 2726 M
+-11 5 D
+-1 29 D
+10 -10 D
+-6 -6 D
+P
+845 2673 M
+9 31 D
+-3 -17 D
+5 1 D
+P
+904 2735 M
+-4 19 D
+P
+FO
+774 2629 M
+-2 10 D
+-14 9 D
+-4 -7 D
+P
+FO
+5 -2 1 765 2644 SP
+1952 2431 M
+-2 10 D
+0 -10 D
+P
+FO
+1965 2431 M
+-8 2 D
+-2 -2 D
+P
+FO
+1998 2428 M
+0 1 D
+P
+FO
+2044 2422 M
+-23 7 D
+-4 -3 D
+P
+FO
+2117 2408 M
+-10 -3 D
+-8 11 D
+-19 1 D
+-4 10 D
+-18 -9 D
+29 -7 D
+27 -9 D
+P
+FO
+2130 2396 M
+-13 12 D
+-3 -6 D
+P
+FO
+2250 2326 M
+-5 12 D
+12 4 D
+-13 -2 D
+-10 37 D
+-70 3 D
+23 -11 D
+43 -28 D
+P
+FO
+2277 2340 M
+-1 1 D
+-24 -17 D
+7 -6 D
+P
+FO
+2418 2220 M
+-3 8 D
+-3 23 D
+11 4 D
+2 20 D
+-8 17 D
+-29 20 D
+-14 -17 D
+-3 18 D
+-9 4 D
+0 -12 D
+-9 2 D
+-8 19 D
+-7 -5 D
+-61 19 D
+-18 -22 D
+20 -17 D
+31 -32 D
+22 -27 D
+21 -29 D
+13 -23 D
+P
+FO
+2469 2042 M
+-6 10 D
+-21 4 D
+-23 24 D
+-2 7 D
+11 -2 D
+12 17 D
+-8 20 D
+19 14 D
+-33 84 D
+-26 -15 D
+-26 -15 D
+9 -15 D
+19 -40 D
+15 -41 D
+15 -61 D
+P
+FO
+2790 2203 M
+1 -10 D
+0 10 D
+P
+FO
+2523 1849 M
+3 20 D
+20 14 D
+-6 10 D
+-21 2 D
+-10 13 D
+4 23 D
+-7 23 D
+11 35 D
+-10 19 D
+-7 -5 D
+-11 26 D
+-13 2 D
+-7 11 D
+-11 -2 D
+-12 -2 D
+-11 -2 D
+-11 -3 D
+7 -70 D
+-2 -53 D
+-5 -43 D
+P
+FO
+2429 1673 M
+10 21 D
+25 22 D
+20 5 D
+3 24 D
+-9 5 D
+-4 22 D
+35 40 D
+10 -4 D
+12 9 D
+-16 7 D
+14 14 D
+-6 9 D
+0 2 D
+-99 18 D
+-10 -44 D
+-20 -58 D
+-23 -48 D
+-5 -7 D
+P
+FO
+2309 1522 M
+51 23 D
+26 34 D
+-6 26 D
+29 8 D
+-1 18 D
+7 1 D
+4 18 D
+8 1 D
+-1 16 D
+3 6 D
+-63 37 D
+-23 -38 D
+-22 -28 D
+-23 -26 D
+-32 -31 D
+-7 -5 D
+P
+FO
+2117 1490 M
+3 -2 D
+40 2 D
+20 -8 D
+15 17 D
+8 -4 D
+25 15 D
+30 -4 D
+3 -21 D
+5 19 D
+14 -1 D
+6 10 D
+23 9 D
+-50 60 D
+-28 -22 D
+-22 -15 D
+-15 -9 D
+-15 -9 D
+-16 -8 D
+-16 -8 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-9 -3 D
+P
+FO
+2110 1497 M
+7 -7 D
+-3 8 D
+-2 -1 D
+P
+FO
+2174 1051 M
+-2 -8 D
+P
+FO
+1487 2081 M
+-7 -3 D
+2 -10 D
+2 2 D
+P
+FO
+1502 2126 M
+-32 -5 D
+-1 -15 D
+16 -3 D
+-7 -7 D
+12 -8 D
+3 13 D
+P
+FO
+1529 2182 M
+-14 4 D
+-47 42 D
+-20 6 D
+-21 -8 D
+-2 12 D
+10 10 D
+-1 0 D
+-2 1 D
+-10 -3 D
+-1 10 D
+-14 7 D
+-1 -11 D
+13 -33 D
+-6 -5 D
+12 -6 D
+3 -23 D
+12 -5 D
+-4 -7 D
+15 -6 D
+-10 -6 D
+29 -4 D
+21 -13 D
+-3 -15 D
+15 -3 D
+15 36 D
+P
+FO
+1158 2408 M
+-6 -9 D
+13 4 D
+-7 -8 D
+6 6 D
+-1 -16 D
+7 15 D
+P
+FO
+1070 2297 M
+3 1 D
+1 8 D
+-1 0 D
+P
+FO
+1044 2223 M
+10 18 D
+-2 -17 D
+7 -1 D
+-15 -1 D
+-4 -12 D
+8 1 D
+-6 -13 D
+7 11 D
+10 -4 D
+-8 10 D
+8 2 D
+1 -16 D
+6 8 D
+10 -7 D
+12 5 D
+-9 3 D
+10 1 D
+-12 0 D
+9 10 D
+-11 -11 D
+-4 10 D
+7 -6 D
+9 9 D
+12 -12 D
+-10 6 D
+8 -6 D
+-6 2 D
+-5 -11 D
+17 -4 D
+-3 14 D
+9 -11 D
+3 5 D
+-11 5 D
+7 20 D
+13 -1 D
+7 -12 D
+-7 4 D
+0 -11 D
+17 14 D
+-23 14 D
+-3 29 D
+8 11 D
+-19 -3 D
+-3 -9 D
+2 10 D
+-13 -3 D
+-13 23 D
+-4 0 D
+-18 -49 D
+P
+FO
+1037 2197 M
+P
+FO
+1186 2279 M
+2 25 D
+-33 -29 D
+-33 -3 D
+-4 -26 D
+13 -5 D
+7 15 D
+10 -15 D
+14 12 D
+3 -7 D
+-8 1 D
+3 -6 D
+-15 -13 D
+13 8 D
+-2 -9 D
+-6 1 D
+1 -18 D
+P
+1152 2258 M
+2 -5 D
+-3 4 D
+P
+1173 2276 M
+-10 -21 D
+P
+FO
+1171 2234 M
+11 5 D
+-6 0 D
+3 9 D
+5 -3 D
+9 11 D
+-19 -9 D
+1 9 D
+P
+FO
+1134 2199 M
+-2 15 D
+-13 -10 D
+4 -12 D
+10 6 D
+-2 8 D
+P
+FO
+1114 2205 M
+9 6 D
+-7 0 D
+-4 19 D
+-6 -17 D
+P
+FO
+1142 2230 M
+9 8 D
+-16 1 D
+P
+FO
+1148 2226 M
+-11 -6 D
+6 -3 D
+P
+FO
+1038 2194 M
+-3 -6 D
+9 -1 D
+P
+FO
+1059 2193 M
+4 5 D
+-10 -1 D
+P
+FO
+1109 2191 M
+9 12 D
+-20 -20 D
+P
+FO
+1081 2183 M
+-9 5 D
+P
+FO
+1178 2259 M
+9 14 D
+P
+FO
+1142 2213 M
+-8 4 D
+P
+FO
+1048 2197 M
+10 6 D
+P
+FO
+1163 2221 M
+1 0 D
+5 9 D
+P
+FO
+1169 2235 M
+3 12 D
+-4 -12 D
+P
+FO
+1049 2183 M
+-2 8 D
+P
+FO
+1196 2318 M
+-2 -11 D
+P
+FO
+1066 2187 M
+5 -6 D
+P
+FO
+1076 2192 M
+7 5 D
+P
+FO
+1088 2197 M
+7 3 D
+P
+FO
+1162 2221 M
+-4 -6 D
+P
+FO
+1105 2195 M
+3 7 D
+P
+FO
+1162 2225 M
+1 6 D
+P
+FO
+1085 2191 M
+4 5 D
+P
+FO
+1408 2228 M
+-10 -1 D
+6 -14 D
+P
+FO
+1380 2279 M
+-5 -13 D
+9 7 D
+P
+FO
+1170 2400 M
+-5 18 D
+-7 -10 D
+P
+FO
+1421 2256 M
+-1 7 D
+8 3 D
+-13 15 D
+6 15 D
+-11 0 D
+-3 -33 D
+P
+FO
+1435 2248 M
+4 4 D
+-7 -3 D
+P
+FO
+1179 2413 M
+3 6 D
+-8 -2 D
+9 18 D
+-8 1 D
+2 -8 D
+-14 -5 D
+11 -6 D
+1 -15 D
+7 3 D
+P
+FO
+1157 2411 M
+5 5 D
+P
+FO
+1419 2279 M
+9 -6 D
+5 8 D
+-5 6 D
+P
+FO
+1417 2308 M
+3 -6 D
+7 14 D
+P
+FO
+1458 2627 M
+-16 7 D
+-18 -11 D
+P
+FO
+1950 2441 M
+-7 -6 D
+-7 -4 D
+14 0 D
+P
+FO
+2058 2418 M
+-2 -1 D
+-12 5 D
+-27 4 D
+-6 -4 D
+-13 6 D
+-14 -5 D
+-19 8 D
+-5 0 D
+-5 0 D
+-3 -3 D
+0 3 D
+-2 0 D
+0 -481 D
+164 452 D
+-48 15 D
+P
+FO
+2252 2324 M
+-1 0 D
+-1 2 D
+-34 25 D
+-44 26 D
+-8 3 D
+-17 0 D
+-17 16 D
+-16 6 D
+-164 -452 D
+309 368 D
+P
+FO
+1950 1950 M
+416 240 D
+-23 38 D
+-22 28 D
+-23 26 D
+-32 31 D
+-7 5 D
+P
+FO
+1950 1950 M
+474 83 D
+-10 44 D
+-20 58 D
+-23 48 D
+-5 7 D
+-311 -180 D
+P
+FO
+1950 1950 M
+474 -83 D
+7 70 D
+-2 53 D
+-5 43 D
+-236 -41 D
+-119 -21 D
+P
+FO
+1950 1950 M
+416 -240 D
+9 15 D
+19 40 D
+15 41 D
+15 61 D
+P
+FO
+1950 1950 M
+309 -368 D
+20 17 D
+31 32 D
+22 27 D
+21 29 D
+13 23 D
+P
+FO
+1950 1950 M
+164 -452 D
+41 17 D
+32 16 D
+44 29 D
+28 22 D
+P
+FO
+1950 1656 M
+71 -7 D
+-5 16 D
+11 8 D
+19 -23 D
+9 -33 D
+-19 -7 D
+21 0 D
+-5 -16 D
+-9 -2 D
+7 -12 D
+-9 -2 D
+1 -12 D
+-17 -7 D
+1 -30 D
+-7 -11 D
+7 -12 D
+-1 10 D
+32 -20 D
+47 6 D
+6 -5 D
+4 1 D
+-164 452 D
+P
+FO
+1852 1680 M
+19 7 D
+62 -19 D
+12 -11 D
+5 -1 D
+0 294 D
+P
+FO
+1723 1680 M
+7 -1 D
+20 -20 D
+20 -2 D
+37 25 D
+27 -22 D
+9 18 D
+9 2 D
+98 270 D
+P
+FO
+1612 1755 M
+6 -16 D
+10 -7 D
+1 -25 D
+24 9 D
+36 -31 D
+34 -5 D
+227 270 D
+-254 -146 D
+P
+FO
+1520 1874 M
+14 -23 D
+21 6 D
+9 15 D
+1 -11 D
+12 14 D
+9 -6 D
+3 10 D
+9 -2 D
+-1 -32 D
+16 -7 D
+-18 -21 D
+1 -27 D
+8 -3 D
+8 -32 D
+338 195 D
+-108 -19 D
+P
+FO
+1549 2021 M
+-4 -4 D
+19 -14 D
+-36 -52 D
+7 -6 D
+-5 -26 D
+-14 -16 D
+-1 -20 D
+5 -9 D
+430 76 D
+P
+FO
+1641 2128 M
+-12 -5 D
+-36 33 D
+-20 12 D
+-44 14 D
+-14 -27 D
+-12 -29 D
+2 0 D
+-3 0 D
+-11 -31 D
+-1 -7 D
+6 -3 D
+-9 -4 D
+-3 -11 D
+16 10 D
+7 -24 D
+2 26 D
+10 -3 D
+8 -19 D
+16 17 D
+20 -3 D
+-31 -42 D
+15 -6 D
+3 14 D
+7 -2 D
+1 -10 D
+-9 -7 D
+401 -71 D
+P
+FO
+1765 2170 M
+-37 -25 D
+-20 5 D
+-11 -8 D
+-56 -14 D
+309 -178 D
+P
+FO
+1593 2156 M
+-7 7 D
+-13 5 D
+P
+FO
+1811 2332 M
+-3 -31 D
+-15 5 D
+-9 -11 D
+13 -21 D
+-8 -17 D
+11 -7 D
+-20 -45 D
+3 -26 D
+-18 -9 D
+185 -220 D
+P
+FO
+1936 2431 M
+0 -1 D
+-14 -11 D
+-43 -6 D
+-24 -24 D
+-2 -17 D
+-40 -28 D
+-2 -12 D
+139 -382 D
+0 481 D
+-5 0 D
+-4 0 D
+P
+FO
+25 W
+4 W
+1950 2071 M
+0 1829 D
+S
+2071 1950 M
+1829 0 D
+S
+1950 1829 M
+0 -1829 D
+S
+1829 1950 M
+-1829 0 D
+S
+1950 1950 M
+0 121 D
+S
+1950 1950 M
+121 0 D
+S
+1950 1950 M
+0 -121 D
+S
+1950 1950 M
+-121 0 D
+S
+1950 2071 M
+22 -2 D
+23 -7 D
+23 -12 D
+14 -11 D
+1 -2 D
+6 -5 D
+1 -2 D
+2 -1 D
+11 -16 D
+9 -17 D
+6 -19 D
+3 -26 D
+-3 -27 D
+-5 -16 D
+-10 -22 D
+-10 -14 D
+-4 -3 D
+-8 -9 D
+-8 -6 D
+-8 -6 D
+-4 -2 D
+-6 -4 D
+-4 -2 D
+-3 -1 D
+-4 -2 D
+-2 0 D
+-3 -1 D
+-4 -2 D
+-3 0 D
+-4 -2 D
+-3 0 D
+-2 -1 D
+-2 0 D
+-3 0 D
+-2 -1 D
+-3 0 D
+-2 0 D
+-3 -1 D
+-2 0 D
+-2 0 D
+-3 0 D
+-2 0 D
+-3 0 D
+-2 0 D
+-24 4 D
+-23 8 D
+-16 10 D
+-17 14 D
+-5 6 D
+-2 1 D
+-13 20 D
+-10 23 D
+-4 23 D
+-1 20 D
+5 26 D
+10 25 D
+14 20 D
+2 1 D
+5 6 D
+2 1 D
+3 4 D
+22 15 D
+27 11 D
+19 3 D
+P S
+1950 3900 M
+68 -1 D
+108 -7 D
+97 -11 D
+77 -13 D
+77 -15 D
+104 -27 D
+94 -29 D
+55 -19 D
+100 -41 D
+89 -41 D
+17 -9 D
+69 -37 D
+51 -29 D
+33 -21 D
+82 -54 D
+86 -64 D
+61 -50 D
+65 -59 D
+77 -76 D
+53 -57 D
+50 -60 D
+37 -46 D
+57 -79 D
+43 -66 D
+31 -50 D
+38 -68 D
+18 -35 D
+38 -79 D
+35 -81 D
+31 -83 D
+32 -102 D
+23 -85 D
+19 -86 D
+17 -107 D
+12 -107 D
+4 -68 D
+2 -88 D
+-1 -68 D
+-7 -108 D
+-11 -97 D
+-13 -77 D
+-15 -77 D
+-27 -104 D
+-29 -94 D
+-19 -55 D
+-41 -100 D
+-41 -89 D
+-9 -17 D
+-37 -69 D
+-29 -51 D
+-21 -33 D
+-54 -82 D
+-64 -86 D
+-50 -61 D
+-59 -65 D
+-76 -77 D
+-57 -53 D
+-45 -38 D
+-38 -31 D
+-31 -23 D
+-31 -24 D
+-24 -17 D
+-24 -16 D
+-25 -17 D
+-24 -16 D
+-17 -10 D
+-17 -10 D
+-25 -16 D
+-17 -9 D
+-17 -10 D
+-17 -10 D
+-17 -9 D
+-17 -9 D
+-18 -9 D
+-17 -9 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-17 -8 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-10 -1 D
+-9 0 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-79 3 D
+-97 8 D
+-68 8 D
+-77 13 D
+-77 15 D
+-104 27 D
+-94 29 D
+-55 19 D
+-100 41 D
+-89 41 D
+-17 9 D
+-69 37 D
+-51 29 D
+-33 21 D
+-82 54 D
+-86 64 D
+-61 50 D
+-65 59 D
+-77 76 D
+-53 57 D
+-50 60 D
+-37 46 D
+-57 79 D
+-43 66 D
+-31 50 D
+-38 68 D
+-18 35 D
+-38 79 D
+-35 81 D
+-31 83 D
+-32 102 D
+-23 85 D
+-19 86 D
+-17 107 D
+-12 107 D
+-4 68 D
+-2 88 D
+1 68 D
+7 108 D
+11 97 D
+13 77 D
+15 77 D
+27 104 D
+29 94 D
+19 55 D
+41 100 D
+41 89 D
+9 17 D
+37 69 D
+29 51 D
+21 33 D
+54 82 D
+64 86 D
+50 61 D
+59 65 D
+76 77 D
+57 53 D
+60 50 D
+46 37 D
+79 57 D
+66 43 D
+50 31 D
+68 38 D
+35 18 D
+79 38 D
+81 35 D
+83 31 D
+102 32 D
+85 23 D
+86 19 D
+107 17 D
+107 12 D
+68 4 D
+P S
+8 W
+N 1950 3900 M 0 83 D S
+N 1950 3900 M 0 83 D S
+25 W
+1950 3900 M
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 0 D
+-10 -1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-9 -3 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-10 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-17 -8 D
+-18 -9 D
+-17 -9 D
+-9 -4 D
+-18 -9 D
+-17 -9 D
+-17 -9 D
+-17 -10 D
+-17 -10 D
+-17 -9 D
+-17 -10 D
+-17 -11 D
+-16 -10 D
+-17 -11 D
+-24 -16 D
+-17 -11 D
+-24 -16 D
+-24 -17 D
+-31 -24 D
+-31 -23 D
+-46 -38 D
+-59 -51 D
+-63 -61 D
+-55 -56 D
+-33 -36 D
+-50 -60 D
+-37 -46 D
+-57 -79 D
+-43 -66 D
+-31 -50 D
+-38 -68 D
+-18 -35 D
+-38 -79 D
+-35 -81 D
+-31 -83 D
+-32 -102 D
+-23 -85 D
+-19 -86 D
+-17 -107 D
+-12 -107 D
+-4 -68 D
+-2 -88 D
+1 -68 D
+7 -108 D
+11 -97 D
+13 -77 D
+15 -77 D
+27 -104 D
+29 -94 D
+19 -55 D
+41 -100 D
+41 -89 D
+9 -17 D
+37 -69 D
+29 -51 D
+21 -33 D
+54 -82 D
+64 -86 D
+50 -61 D
+59 -65 D
+76 -77 D
+57 -53 D
+60 -50 D
+46 -37 D
+79 -57 D
+66 -43 D
+50 -31 D
+68 -38 D
+35 -18 D
+79 -38 D
+81 -35 D
+83 -31 D
+102 -32 D
+85 -23 D
+86 -19 D
+107 -17 D
+107 -12 D
+68 -4 D
+88 -2 D
+68 1 D
+108 7 D
+97 11 D
+77 13 D
+77 15 D
+104 27 D
+94 29 D
+55 19 D
+100 41 D
+89 41 D
+17 9 D
+69 37 D
+51 29 D
+33 21 D
+82 54 D
+86 64 D
+61 50 D
+65 59 D
+77 76 D
+53 57 D
+50 60 D
+37 46 D
+57 79 D
+43 66 D
+31 50 D
+38 68 D
+18 35 D
+38 79 D
+35 81 D
+31 83 D
+32 102 D
+23 85 D
+19 86 D
+17 107 D
+12 107 D
+4 68 D
+2 88 D
+-1 68 D
+-7 108 D
+-11 97 D
+-13 77 D
+-15 77 D
+-27 104 D
+-29 94 D
+-19 55 D
+-41 100 D
+-41 89 D
+-9 17 D
+-37 69 D
+-29 51 D
+-21 33 D
+-54 82 D
+-64 86 D
+-50 61 D
+-59 65 D
+-76 77 D
+-57 53 D
+-60 50 D
+-46 37 D
+-79 57 D
+-66 43 D
+-50 31 D
+-68 38 D
+-35 18 D
+-79 38 D
+-81 35 D
+-83 31 D
+-102 32 D
+-85 23 D
+-86 19 D
+-107 17 D
+-107 12 D
+-68 4 D
+P S
+1950 4067 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0è) bc Z
+%%EndObject
+1950 1950 T
+-180 R
+-1950 -1950 T
+0 A
+FQ
+O0
+4980 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pscoast -R0/360/-90/0 -JA0/-90/3.25i -Bg90a360f360 -Gred -Dc -X4.15i -O -p245
+1950 1950 T
+245 R
+-1950 -1950 T
+%@PROJ: laea 0.00000000 360.00000000 -90.00000000 0.00000000 -9009964.761 9009964.761 -9009964.761 9009964.761 +proj=laea +lat_0=-90 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+2567 3800 M
+-82 -13 D
+-6 -15 D
+2 15 D
+60 13 D
+5 7 D
+2 -1 D
+-4 -6 D
+8 5 D
+-103 30 D
+-104 25 D
+-81 14 D
+-6 -11 D
+-15 3 D
+26 -34 D
+62 -48 D
+9 -25 D
+15 -8 D
+-13 0 D
+26 -47 D
+-15 -10 D
+8 -19 D
+85 -22 D
+90 -29 D
+21 -8 D
+60 166 D
+P
+2544 3759 M
+1 17 D
+16 -2 D
+-10 -4 D
+9 -6 D
+P
+2552 3787 M
+-9 9 D
+P
+2453 3759 M
+-9 1 D
+P
+2295 3853 M
+-11 -1 D
+2 5 D
+P
+2314 3800 M
+-8 5 D
+P
+2365 3751 M
+-8 0 D
+P
+{1 0 0 C} FS
+FO
+2941 3421 M
+2 5 D
+5 1 D
+7 -16 D
+65 -47 D
+37 -28 D
+26 -21 D
+9 32 D
+10 3 D
+-6 4 D
+18 5 D
+-9 29 D
+26 10 D
+38 5 D
+34 41 D
+-27 23 D
+-42 33 D
+-29 21 D
+-29 21 D
+-52 36 D
+-68 43 D
+-86 48 D
+-80 41 D
+-106 47 D
+-67 25 D
+-60 -166 D
+43 -16 D
+113 -49 D
+69 -35 D
+68 -38 D
+72 -45 D
+P
+2954 3581 M
+29 22 D
+4 -1 D
+56 -37 D
+2 -9 D
+15 -5 D
+1 -5 D
+-24 12 D
+-12 -12 D
+-26 6 D
+16 -14 D
+-15 3 D
+-13 11 D
+-1 -8 D
+-9 2 D
+7 6 D
+-15 15 D
+-17 -1 D
+P
+2983 3593 M
+0 6 D
+-1 -6 D
+P
+2959 3574 M
+-2 -4 D
+P
+2861 3590 M
+15 10 D
+-3 -48 D
+-10 -3 D
+17 -25 D
+0 -37 D
+-17 15 D
+2 24 D
+-16 34 D
+19 31 D
+P
+2795 3519 M
+5 7 D
+25 -4 D
+-18 -8 D
+P
+2853 3508 M
+-22 3 D
+11 3 D
+P
+2870 3621 M
+14 10 D
+5 -12 D
+P
+3083 3495 M
+4 3 D
+P
+2905 3604 M
+3 -5 D
+P
+2924 3472 M
+4 -8 D
+P
+2909 3645 M
+12 -7 D
+-20 2 D
+P
+2922 3474 M
+-15 12 D
+4 7 D
+P
+3024 3499 M
+20 -4 D
+-18 2 D
+P
+3070 3492 M
+6 6 D
+P
+2753 3562 M
+-8 -1 D
+P
+3051 3480 M
+7 3 D
+P
+3125 3486 M
+9 -3 D
+P
+FO
+3121 3377 M
+1 5 D
+-8 -4 D
+5 -11 D
+P
+FO
+3104 3346 M
+11 -3 D
+P
+FO
+3169 3403 M
+9 1 D
+26 -11 D
+-2 9 D
+13 -13 D
+64 -12 D
+-5 4 D
+-4 5 D
+-47 41 D
+-20 17 D
+P
+FO
+3488 3013 M
+1 -7 D
+P
+FO
+3238 3185 M
+7 -7 D
+P
+FO
+3874 1631 M
+-13 -18 D
+9 -2 D
+P
+FO
+3859 1650 M
+-2 12 D
+-13 -20 D
+P
+FO
+3837 1634 M
+-6 -11 D
+P
+FO
+3871 1670 M
+4 -6 D
+P
+FO
+3879 1665 M
+-7 -4 D
+P
+FO
+3497 1057 M
+13 30 D
+-23 -21 D
+-1 -3 D
+P
+FO
+3508 1050 M
+1 7 D
+-4 -5 D
+3 -1 D
+P
+FO
+3641 979 M
+-1 2 D
+5 6 D
+-17 -1 D
+6 2 D
+-1 16 D
+-12 6 D
+-3 25 D
+-15 1 D
+-9 -16 D
+-30 19 D
+-10 -15 D
+85 -49 D
+P
+FO
+3861 1613 M
+-7 -10 D
+-48 -33 D
+-53 -69 D
+-16 -16 D
+8 0 D
+-10 -19 D
+5 -5 D
+-12 -12 D
+42 -24 D
+19 11 D
+8 24 D
+-4 6 D
+7 -8 D
+5 13 D
+17 -1 D
+14 35 D
+9 -14 D
+14 60 D
+11 60 D
+P
+FO
+3655 1155 M
+-5 -45 D
+7 4 D
+-5 -6 D
+8 -14 D
+13 10 D
+3 -22 D
+-6 -4 D
+-4 -26 D
+14 -2 D
+31 63 D
+35 77 D
+29 72 D
+16 44 D
+-7 8 D
+-9 -14 D
+5 11 D
+-9 -11 D
+-3 9 D
+-3 -18 D
+-33 1 D
+-15 -45 D
+-15 -2 D
+-4 -38 D
+-11 -16 D
+-5 1 D
+-10 -28 D
+-14 4 D
+P
+3694 1089 M
+-3 -9 D
+P
+3712 1224 M
+-3 5 D
+P
+FO
+3594 1218 M
+-11 -16 D
+18 -2 D
+17 37 D
+23 11 D
+25 42 D
+-2 22 D
+18 44 D
+16 16 D
+28 67 D
+-8 11 D
+0 19 D
+-15 -38 D
+-6 5 D
+-20 -42 D
+-8 -31 D
+-29 -52 D
+P
+FO
+3769 1405 M
+5 -7 D
+8 17 D
+16 4 D
+5 23 D
+-5 8 D
+-6 -20 D
+-13 -3 D
+-11 -22 D
+P
+FO
+3545 1137 M
+-25 -64 D
+28 30 D
+1 8 D
+-16 -13 D
+22 30 D
+1 13 D
+P
+FO
+3587 1186 M
+7 14 D
+-19 -11 D
+-1 -21 D
+P
+FO
+3752 1365 M
+5 -11 D
+9 18 D
+-10 5 D
+-5 -12 D
+P
+FO
+3817 1606 M
+5 8 D
+-11 -7 D
+P
+FO
+3565 1163 M
+-11 -15 D
+7 -9 D
+8 12 D
+P
+FO
+3635 1243 M
+-13 -20 D
+-3 -20 D
+P
+FO
+3829 1447 M
+9 15 D
+-3 3 D
+P
+FO
+3640 1124 M
+9 -13 D
+P
+FO
+3832 1472 M
+-3 -11 D
+P
+FO
+3603 1169 M
+-3 -9 D
+P
+FO
+3841 1498 M
+-3 -11 D
+P
+FO
+3766 1561 M
+-4 -9 D
+P
+FO
+3550 1118 M
+0 -8 D
+P
+FO
+3512 1063 M
+-1 -7 D
+P
+FO
+3473 1042 M
+24 15 D
+-11 6 D
+P
+FO
+3412 946 M
+-28 -88 D
+37 57 D
+11 48 D
+-4 7 D
+P
+FO
+3179 485 M
+62 37 D
+15 22 D
+-5 2 D
+18 20 D
+4 25 D
+12 19 D
+23 0 D
+-1 9 D
+13 0 D
+24 -15 D
+41 35 D
+21 35 D
+-1 15 D
+-24 -26 D
+-18 1 D
+-35 -42 D
+-1 14 D
+14 7 D
+6 17 D
+18 18 D
+-27 -15 D
+-11 8 D
+-10 -16 D
+4 -20 D
+-3 11 D
+-12 -4 D
+-23 -22 D
+5 10 D
+-18 -9 D
+-80 -53 D
+-3 6 D
+-7 -8 D
+-8 8 D
+-19 -4 D
+8 9 D
+-19 -12 D
+13 13 D
+-16 -5 D
+-4 14 D
+-22 -25 D
+P
+FO
+3554 1024 M
+-7 -13 D
+45 -16 D
+-5 -19 D
+-7 -9 D
+-9 13 D
+-20 -15 D
+-9 8 D
+-10 -12 D
+4 -6 D
+-12 -22 D
+24 11 D
+1 -12 D
+41 22 D
+-9 -10 D
+-15 -62 D
+33 53 D
+0 21 D
+7 11 D
+22 12 D
+7 -10 D
+4 6 D
+P
+3575 956 M
+-5 -6 D
+2 10 D
+P
+3581 959 M
+-5 -4 D
+5 5 D
+P
+3602 972 M
+-5 2 D
+P
+FO
+3505 1052 M
+-28 -43 D
+-14 -41 D
+6 1 D
+0 16 D
+14 25 D
+24 26 D
+1 15 D
+P
+FO
+3483 753 M
+4 -3 D
+8 10 D
+-4 1 D
+-26 -14 D
+P
+FO
+3445 782 M
+-5 8 D
+2 -13 D
+-11 -3 D
+-29 -38 D
+-27 -18 D
+23 3 D
+29 31 D
+P
+FO
+3156 610 M
+-18 -24 D
+2 -10 D
+23 19 D
+2 23 D
+P
+FO
+3518 943 M
+5 -4 D
+5 11 D
+-8 9 D
+-7 -9 D
+P
+FO
+3271 661 M
+-9 14 D
+-4 -21 D
+13 -7 D
+6 13 D
+P
+FO
+3517 941 M
+-9 10 D
+-3 -19 D
+7 7 D
+9 -12 D
+P
+FO
+3495 774 M
+-9 -2 D
+-8 -12 D
+13 4 D
+P
+FO
+3427 916 M
+2 -5 D
+10 15 D
+-1 7 D
+P
+FO
+3466 765 M
+10 8 D
+2 10 D
+-17 -20 D
+P
+FO
+3482 837 M
+-21 -12 D
+-8 -18 D
+16 7 D
+P
+FO
+3417 675 M
+-4 -10 D
+23 28 D
+P
+FO
+3418 891 M
+-16 -29 D
+18 21 D
+P
+FO
+3291 562 M
+-9 -10 D
+31 18 D
+P
+FO
+3564 902 M
+-7 -18 D
+13 18 D
+P
+FO
+3283 570 M
+-21 -22 D
+38 33 D
+P
+FO
+3411 711 M
+3 -5 D
+11 19 D
+P
+FO
+3405 685 M
+4 -5 D
+8 11 D
+P
+FO
+3503 822 M
+12 19 D
+-19 -28 D
+P
+FO
+3445 941 M
+-5 -1 D
+2 -8 D
+P
+FO
+3541 1015 M
+-8 3 D
+11 -7 D
+P
+FO
+3496 827 M
+6 -1 D
+-10 1 D
+P
+FO
+3597 912 M
+-6 -3 D
+P
+FO
+3438 788 M
+-6 -10 D
+P
+FO
+3458 714 M
+-8 -4 D
+P
+FO
+3456 964 M
+-8 -22 D
+P
+FO
+3309 587 M
+-6 -6 D
+P
+FO
+3528 964 M
+-4 4 D
+P
+FO
+3143 597 M
+-9 -7 D
+P
+FO
+3340 791 M
+7 3 D
+P
+FO
+3303 695 M
+3 -16 D
+P
+FO
+3598 920 M
+4 12 D
+P
+FO
+3462 968 M
+-4 -10 D
+P
+FO
+3500 778 M
+-3 -7 D
+P
+FO
+3423 697 M
+-10 -16 D
+P
+FO
+3314 696 M
+-8 0 D
+P
+FO
+3372 839 M
+7 4 D
+-6 -4 D
+P
+FO
+3312 736 M
+-6 -6 D
+6 5 D
+P
+FO
+3427 691 M
+-4 -7 D
+P
+FO
+3481 777 M
+-5 -6 D
+P
+FO
+3318 661 M
+-10 -5 D
+P
+FO
+3531 868 M
+-15 -28 D
+18 20 D
+P
+FO
+3434 717 M
+-5 -7 D
+P
+FO
+3313 760 M
+0 -1 D
+P
+FO
+2839 416 M
+7 0 D
+-6 -8 D
+22 10 D
+4 -8 D
+17 12 D
+22 -8 D
+31 7 D
+13 -7 D
+-23 -17 D
+11 -4 D
+57 24 D
+5 -11 D
+45 9 D
+135 70 D
+-66 79 D
+-41 -6 D
+-25 -23 D
+-13 -4 D
+-13 -23 D
+36 14 D
+-38 -27 D
+11 1 D
+-14 -9 D
+13 -3 D
+-26 -10 D
+7 -3 D
+-7 0 D
+-2 -8 D
+-7 4 D
+-35 -18 D
+-60 3 D
+-20 -12 D
+-20 -13 D
+P
+3093 520 M
+-7 2 D
+P
+3158 477 M
+7 5 D
+-6 -5 D
+P
+FO
+2809 398 M
+10 0 D
+-10 0 D
+P
+FO
+2560 274 M
+10 0 D
+2 6 D
+-13 -3 D
+0 -2 D
+1 0 D
+P
+FO
+2843 335 M
+-25 -26 D
+8 -3 D
+-7 -18 D
+8 1 D
+19 11 D
+-11 7 D
+17 22 D
+23 14 D
+4 -8 D
+2 11 D
+42 27 D
+-42 -11 D
+P
+FO
+2728 281 M
+-19 3 D
+-12 -7 D
+46 -5 D
+P
+FO
+2803 275 M
+77 11 D
+-54 -8 D
+-25 11 D
+P
+FO
+2646 279 M
+3 8 D
+-20 -2 D
+P
+FO
+2992 346 M
+-11 -10 D
+25 19 D
+P
+FO
+2598 262 M
+-30 -2 D
+51 -1 D
+P
+FO
+2932 378 M
+8 4 D
+-10 0 D
+P
+FO
+2648 291 M
+-8 0 D
+3 -5 D
+P
+FO
+2662 272 M
+-17 -5 D
+39 1 D
+P
+FO
+2656 286 M
+-1 -6 D
+2 6 D
+P
+FO
+2831 398 M
+-17 -3 D
+P
+FO
+2903 298 M
+1 1 D
+-15 -6 D
+P
+FO
+2762 356 M
+16 6 D
+P
+FO
+2840 402 M
+-8 -1 D
+P
+FO
+2674 285 M
+-8 2 D
+P
+FO
+2751 270 M
+-6 4 D
+P
+FO
+2624 281 M
+-2 4 D
+P
+FO
+2962 392 M
+-7 -3 D
+P
+FO
+3027 504 M
+-8 -5 D
+P
+FO
+2640 291 M
+-7 -2 D
+P
+FO
+2871 289 M
+7 4 D
+P
+FO
+2997 398 M
+-1 5 D
+P
+FO
+2927 291 M
+-8 -3 D
+P
+FO
+3030 507 M
+-14 -4 D
+P
+FO
+2823 375 M
+-6 3 D
+P
+FO
+2559 277 M
+-26 -4 D
+27 1 D
+0 1 D
+-1 0 D
+P
+FO
+2532 260 M
+-14 3 D
+32 -14 D
+P
+FO
+2521 258 M
+-8 6 D
+P
+FO
+2559 265 M
+-9 -1 D
+P
+FO
+803 570 M
+-5 6 D
+P
+FO
+87 2279 M
+9 -44 D
+26 9 D
+4 -10 D
+19 34 D
+P
+FO
+76 2280 M
+-1 -7 D
+5 3 D
+-2 4 D
+-1 0 D
+P
+FO
+29 2285 M
+4 -14 D
+6 6 D
+3 -22 D
+22 -3 D
+10 20 D
+-4 10 D
+-40 7 D
+P
+FO
+17 1914 M
+-4 10 D
+-13 -17 D
+1 -11 D
+10 18 D
+5 -15 D
+P
+FO
+16 1963 M
+-4 13 D
+P
+FO
+11 1931 M
+-1 13 D
+P
+FO
+85 2271 M
+-1 7 D
+P
+FO
+6 1894 M
+2 9 D
+P
+FO
+5 1920 M
+0 11 D
+P
+FO
+310 2897 M
+-18 -58 D
+-14 -15 D
+-4 -39 D
+-8 0 D
+3 9 D
+-30 -35 D
+2 -5 D
+-19 -8 D
+-14 -20 D
+-18 -42 D
+6 -30 D
+-14 -34 D
+4 -14 D
+5 6 D
+-1 -18 D
+-13 -9 D
+-15 -35 D
+-12 -8 D
+-8 -40 D
+1 12 D
+-4 -6 D
+6 14 D
+4 19 D
+13 9 D
+14 36 D
+14 11 D
+1 14 D
+-5 -6 D
+-5 14 D
+13 37 D
+-4 28 D
+25 61 D
+32 24 D
+27 32 D
+4 24 D
+11 11 D
+10 30 D
+-4 8 D
+14 24 D
+-1 0 D
+-11 -16 D
+-41 -17 D
+-47 -52 D
+-39 -83 D
+4 16 D
+32 66 D
+50 54 D
+52 32 D
+-47 27 D
+-47 -87 D
+-39 -80 D
+-35 -83 D
+-25 -66 D
+-29 -85 D
+-24 -87 D
+-19 -78 D
+-13 -70 D
+40 -7 D
+-2 4 D
+7 4 D
+12 -11 D
+58 -11 D
+32 27 D
+37 17 D
+27 113 D
+27 87 D
+31 86 D
+22 54 D
+46 97 D
+35 66 D
+12 22 D
+P
+285 2862 M
+-5 -11 D
+P
+269 2818 M
+-8 -8 D
+P
+266 2802 M
+-9 -8 D
+P
+FO
+78 2280 M
+-2 4 D
+0 -4 D
+P
+FO
+728 3406 M
+-56 -49 D
+-35 -20 D
+-21 -45 D
+-7 11 D
+6 13 D
+-14 -16 D
+7 16 D
+-16 0 D
+-4 -15 D
+-9 4 D
+-2 -7 D
+0 5 D
+-5 -8 D
+-12 -2 D
+0 -7 D
+-6 3 D
+-1 -6 D
+-28 -17 D
+1 -5 D
+-18 -15 D
+0 -20 D
+11 9 D
+-6 -11 D
+-9 -1 D
+-6 -41 D
+-3 21 D
+-25 -34 D
+-20 2 D
+-18 -44 D
+-12 -12 D
+12 21 D
+1 12 D
+-4 20 D
+1 3 D
+-31 -39 D
+-30 -40 D
+-47 -68 D
+-44 -70 D
+-17 -29 D
+47 -27 D
+27 45 D
+4 31 D
+18 23 D
+3 24 D
+23 31 D
+8 9 D
+4 -5 D
+5 9 D
+20 50 D
+-16 -45 D
+-16 -25 D
+8 -23 D
+-14 17 D
+10 13 D
+-20 -23 D
+10 15 D
+-13 -12 D
+-11 -35 D
+-18 -22 D
+-5 -40 D
+-22 -29 D
+-3 -9 D
+104 -60 D
+34 56 D
+26 41 D
+52 73 D
+65 83 D
+54 61 D
+34 36 D
+6 5 D
+17 18 D
+6 5 D
+11 12 D
+72 66 D
+19 16 D
+P
+458 3142 M
+-12 0 D
+19 24 D
+-1 -12 D
+7 0 D
+-18 -3 D
+P
+456 3154 M
+9 6 D
+P
+355 2980 M
+1 9 D
+P
+360 2989 M
+-2 5 D
+P
+339 3008 M
+15 19 D
+7 0 D
+P
+431 3126 M
+26 -4 D
+-27 4 D
+P
+498 3182 M
+15 -13 D
+P
+398 3063 M
+3 7 D
+P
+FO
+309 2898 M
+1 2 D
+-2 -2 D
+P
+FO
+450 3175 M
+9 5 D
+-5 -9 D
+13 -1 D
+17 19 D
+17 28 D
+-5 25 D
+-46 -48 D
+P
+483 3221 M
+2 -4 D
+P
+FO
+434 3148 M
+1 -11 D
+6 17 D
+-1 12 D
+-5 -3 D
+P
+FO
+457 3203 M
+0 2 D
+-3 -4 D
+P
+FO
+617 3312 M
+8 9 D
+P
+FO
+436 3176 M
+8 10 D
+P
+FO
+432 3161 M
+2 11 D
+P
+FO
+439 3174 M
+0 -6 D
+P
+FO
+442 3171 M
+1 6 D
+P
+FO
+618 3303 M
+-2 4 D
+P
+FO
+436 3179 M
+P
+FO
+571 3296 M
+-1 5 D
+P
+FO
+-5 1 1 392 3054 SP
+904 3382 M
+13 46 D
+-8 21 D
+-30 16 D
+-13 -2 D
+-42 -27 D
+-48 -9 D
+-48 -21 D
+82 -97 D
+75 59 D
+P
+793 3383 M
+-8 -9 D
+P
+829 3391 M
+-6 -4 D
+P
+FO
+2361 3675 M
+9 -21 D
+-11 -21 D
+-38 -14 D
+-32 -40 D
+-7 -40 D
+52 -105 D
+-8 -76 D
+32 -88 D
+64 -22 D
+135 368 D
+-69 24 D
+-77 23 D
+P
+FO
+2284 3566 M
+1 -5 D
+P
+FO
+2529 3204 M
+-1 1 D
+67 -34 D
+64 -36 D
+14 5 D
+33 2 D
+39 34 D
+-5 -1 D
+-3 10 D
+85 -12 D
+24 30 D
+-2 40 D
+10 15 D
+3 -7 D
+44 -7 D
+24 6 D
+84 -31 D
+6 0 D
+72 86 D
+-4 10 D
+-47 37 D
+-76 56 D
+-5 3 D
+-5 -30 D
+-16 -10 D
+-8 -40 D
+-13 16 D
+5 39 D
+15 3 D
+8 32 D
+-78 49 D
+-40 24 D
+-75 40 D
+-77 36 D
+-85 36 D
+-29 10 D
+-135 -368 D
+72 -28 D
+P
+2587 3236 M
+-8 -6 D
+-8 7 D
+4 -7 D
+-8 8 D
+P
+2875 3314 M
+14 -16 D
+4 -28 D
+-5 27 D
+P
+2687 3396 M
+30 9 D
+33 -13 D
+-25 9 D
+P
+2639 3219 M
+-5 3 D
+0 -6 D
+-4 9 D
+P
+2827 3473 M
+-4 -7 D
+-10 3 D
+13 5 D
+P
+2748 3517 M
+0 -5 D
+P
+2925 3330 M
+-2 -5 D
+P
+2556 3401 M
+7 1 D
+P
+2711 3165 M
+-1 6 D
+P
+2816 3465 M
+-4 -3 D
+P
+2925 3306 M
+4 6 D
+P
+2803 3383 M
+48 -28 D
+P
+FO
+3015 3219 M
+36 4 D
+13 36 D
+8 -2 D
+10 26 D
+15 3 D
+-10 19 D
+P
+FO
+2992 2992 M
+45 -32 D
+143 43 D
+14 12 D
+13 -4 D
+15 21 D
+7 -5 D
+-4 -13 D
+14 0 D
+25 41 D
+-4 26 D
+7 3 D
+-18 6 D
+-12 -13 D
+-17 6 D
+-4 11 D
+-6 -11 D
+-6 6 D
+-17 -5 D
+6 6 D
+-16 2 D
+-1 -7 D
+-8 5 D
+7 4 D
+-14 6 D
+-6 -7 D
+-3 11 D
+-42 29 D
+-28 -8 D
+-22 -45 D
+-38 0 D
+-19 -10 D
+-22 -53 D
+P
+3170 3030 M
+7 2 D
+P
+FO
+3286 2800 M
+-11 -2 D
+10 -7 D
+P
+FO
+3142 3219 M
+5 -8 D
+4 10 D
+-8 -2 D
+P
+FO
+3158 3193 M
+5 -10 D
+3 5 D
+P
+FO
+3235 2841 M
+3 -16 D
+5 8 D
+P
+FO
+3169 3168 M
+0 -7 D
+P
+FO
+3226 3092 M
+2 -6 D
+P
+FO
+3144 3203 M
+4 -6 D
+P
+FO
+3205 3008 M
+7 1 D
+P
+FO
+3325 1156 M
+9 24 D
+8 49 D
+12 12 D
+2 64 D
+-9 13 D
+16 3 D
+-40 35 D
+-44 -4 D
+10 5 D
+-3 6 D
+15 -1 D
+-23 1 D
+15 13 D
+-73 -15 D
+-18 6 D
+-31 -64 D
+-25 -44 D
+P
+FO
+3487 1066 M
+-2 -2 D
+1 -1 D
+P
+FO
+3295 1374 M
+12 1 D
+P
+FO
+3366 1281 M
+2 -6 D
+P
+FO
+3315 1367 M
+-5 4 D
+P
+FO
+3315 1367 M
+4 -2 D
+P
+FO
+2998 701 M
+9 7 D
+20 1 D
+64 32 D
+39 12 D
+3 -31 D
+8 -2 D
+-11 -12 D
+6 -6 D
+-6 -17 D
+15 2 D
+4 20 D
+5 -6 D
+7 10 D
+-2 -9 D
+10 20 D
+15 5 D
+10 16 D
+10 -1 D
+7 11 D
+42 25 D
+1 7 D
+-23 -18 D
+-8 6 D
+24 31 D
+7 1 D
+4 15 D
+-6 0 D
+11 5 D
+-7 1 D
+8 8 D
+-10 9 D
+8 13 D
+-3 20 D
+-18 -9 D
+0 14 D
+11 3 D
+-3 9 D
+6 -4 D
+12 11 D
+2 12 D
+-9 1 D
+9 2 D
+-3 6 D
+8 -14 D
+26 10 D
+13 11 D
+-3 12 D
+6 -2 D
+1 11 D
+9 1 D
+-10 11 D
+12 2 D
+0 17 D
+-13 -4 D
+12 16 D
+-14 -5 D
+15 10 D
+-2 12 D
+-7 0 D
+-1 -8 D
+-3 15 D
+-10 -14 D
+7 16 D
+19 16 D
+-7 6 D
+-10 -9 D
+-6 5 D
+9 7 D
+-9 6 D
+30 2 D
+-3 28 D
+-17 4 D
+-5 44 D
+12 29 D
+-179 103 D
+-36 -59 D
+-25 -37 D
+-26 -36 D
+-67 -84 D
+-34 -38 D
+-5 -4 D
+-17 -19 D
+-5 -4 D
+-4 -5 D
+-5 -4 D
+-4 -5 D
+-19 -17 D
+-4 -5 D
+-43 -38 D
+-14 -12 D
+P
+3234 920 M
+11 -5 D
+-7 -10 D
+P
+3128 833 M
+4 -6 D
+P
+FO
+3428 970 M
+-4 6 D
+-8 -15 D
+-4 -15 D
+P
+FO
+3485 1064 M
+-11 -10 D
+-2 -12 D
+1 0 D
+13 21 D
+P
+FO
+3270 803 M
+0 6 D
+15 6 D
+-23 -4 D
+-5 -19 D
+P
+FO
+3121 719 M
+-1 6 D
+-14 -12 D
+13 -5 D
+P
+FO
+3283 831 M
+-12 -15 D
+12 2 D
+P
+FO
+3157 693 M
+-3 -6 D
+P
+FO
+3029 703 M
+-11 -12 D
+P
+FO
+3424 993 M
+0 -14 D
+P
+FO
+3450 1024 M
+-3 -9 D
+P
+FO
+3242 763 M
+-5 4 D
+P
+FO
+3162 706 M
+-1 -6 D
+1 7 D
+P
+FO
+3153 684 M
+-1 -12 D
+P
+FO
+2570 716 M
+6 -29 D
+26 -18 D
+9 -26 D
+50 -18 D
+28 4 D
+14 -19 D
+-2 6 D
+19 -1 D
+-6 9 D
+8 -2 D
+3 6 D
+43 -28 D
+74 15 D
+28 -27 D
+18 2 D
+18 -23 D
+28 2 D
+16 17 D
+22 -20 D
+49 -14 D
+7 12 D
+-11 16 D
+5 18 D
+-9 -7 D
+-3 28 D
+-18 14 D
+-8 57 D
+14 11 D
+-160 191 D
+-48 -39 D
+-30 -22 D
+-30 -21 D
+-31 -21 D
+-21 -13 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+P
+FO
+2809 398 M
+-7 1 D
+P
+FO
+2899 452 M
+-3 0 D
+-56 -28 D
+-15 -2 D
+-14 -18 D
+25 11 D
+0 1 D
+3 0 D
+20 11 D
+P
+FO
+2620 636 M
+-5 4 D
+5 -21 D
+P
+FO
+2596 661 M
+-4 5 D
+P
+FO
+2739 390 M
+-18 -4 D
+P
+FO
+2590 673 M
+1 -7 D
+P
+FO
+2763 387 M
+-10 -4 D
+P
+FO
+1950 306 M
+2 2 D
+P
+FO
+1950 292 M
+43 13 D
+-41 -1 D
+0 -6 D
+13 5 D
+-15 -11 D
+P
+FO
+2313 329 M
+6 3 D
+-9 7 D
+-10 -2 D
+P
+FO
+1988 328 M
+14 -13 D
+26 14 D
+-19 5 D
+P
+FO
+2340 316 M
+-8 11 D
+-13 -6 D
+22 -12 D
+P
+FO
+2493 277 M
+-11 -3 D
+36 0 D
+P
+FO
+2256 375 M
+-9 -1 D
+8 -5 D
+P
+FO
+2296 452 M
+90 -23 D
+-32 18 D
+P
+FO
+2289 324 M
+3 -10 D
+P
+FO
+2290 338 M
+-11 0 D
+P
+FO
+2006 350 M
+-14 -2 D
+P
+FO
+2298 312 M
+8 5 D
+P
+FO
+2319 298 M
+-5 -4 D
+P
+FO
+2317 424 M
+-2 -7 D
+P
+FO
+2292 424 M
+10 -3 D
+P
+FO
+2284 357 M
+-12 -3 D
+P
+FO
+2295 329 M
+-10 0 D
+P
+FO
+2272 433 M
+7 -4 D
+P
+FO
+2249 384 M
+-7 3 D
+P
+FO
+2376 243 M
+9 3 D
+P
+FO
+1950 292 M
+P
+FO
+1950 306 M
+-4 -4 D
+P
+FO
+1709 268 M
+-12 2 D
+19 -5 D
+P
+FO
+1737 255 M
+-19 6 D
+P
+FO
+1824 393 M
+-9 2 D
+P
+FO
+1681 279 M
+-8 0 D
+P
+FO
+1125 543 M
+-9 12 D
+P
+FO
+1015 579 M
+-2 7 D
+P
+FO
+930 690 M
+-2 6 D
+P
+FO
+214 2312 M
+27 12 D
+48 34 D
+8 -8 D
+17 10 D
+20 19 D
+65 91 D
+32 24 D
+30 -6 D
+27 -8 D
+34 -28 D
+37 -8 D
+60 -49 D
+21 -1 D
+1 -2 D
+31 81 D
+14 35 D
+38 78 D
+30 55 D
+-340 196 D
+-43 -80 D
+-40 -83 D
+-35 -84 D
+-31 -86 D
+-30 -103 D
+P
+383 2535 M
+25 20 D
+4 -10 D
+-11 -1 D
+1 -8 D
+-16 -18 D
+-8 8 D
+P
+478 2577 M
+-13 -5 D
+-9 9 D
+P
+417 2698 M
+5 0 D
+P
+380 2620 M
+5 -3 D
+P
+387 2660 M
+-6 0 D
+P
+384 2647 M
+-4 3 D
+P
+FO
+758 2648 M
+-13 8 D
+-2 7 D
+-20 28 D
+3 14 D
+38 51 D
+-41 -64 D
+26 -37 D
+10 -5 D
+36 58 D
+39 56 D
+56 72 D
+-4 17 D
+3 27 D
+-17 25 D
+-19 5 D
+-3 18 D
+-10 -5 D
+11 9 D
+-1 23 D
+10 34 D
+16 19 D
+7 31 D
+18 14 D
+4 15 D
+4 -4 D
+21 18 D
+-5 8 D
+12 25 D
+-8 6 D
+2 44 D
+-92 108 D
+-29 36 D
+-55 -49 D
+-42 -39 D
+-5 -6 D
+-18 -17 D
+-5 -6 D
+-12 -11 D
+-66 -72 D
+-51 -63 D
+-49 -65 D
+-42 -61 D
+-34 -55 D
+-17 -28 D
+340 -196 D
+P
+842 3037 M
+-12 -3 D
+-2 -8 D
+0 9 D
+-14 -1 D
+14 17 D
+2 -4 D
+12 3 D
+-18 -6 D
+-4 -9 D
+P
+815 3081 M
+-7 -6 D
+-2 11 D
+-5 -8 D
+-1 11 D
+17 -1 D
+P
+811 2970 M
+-10 -5 D
+P
+762 2714 M
+2 7 D
+-1 -7 D
+P
+799 2942 M
+11 12 D
+4 -4 D
+P
+862 3059 M
+-6 1 D
+7 -1 D
+P
+886 2843 M
+-1 7 D
+P
+808 3030 M
+-14 -5 D
+P
+FO
+880 2894 M
+-4 9 D
+P
+FO
+876 3006 M
+3 6 D
+P
+FO
+887 3037 M
+5 5 D
+P
+FO
+931 3165 M
+0 7 D
+-13 21 D
+4 20 D
+-51 77 D
+0 7 D
+10 -2 D
+6 12 D
+17 75 D
+-29 -21 D
+-47 -37 D
+-18 -15 D
+59 -71 D
+P
+FO
+2358 3270 M
+12 -41 D
+-2 -18 D
+-13 -2 D
+2 -34 D
+10 1 D
+21 -23 D
+34 95 D
+P
+FO
+2529 3204 M
+2 -6 D
+-2 6 D
+-62 27 D
+-45 17 D
+-34 -96 D
+60 -4 D
+45 -25 D
+50 -9 D
+84 9 D
+32 12 D
+-64 36 D
+-57 29 D
+P
+2540 3185 M
+7 -4 D
+P
+FO
+2569 2754 M
+5 -3 D
+P
+FO
+2839 2291 M
+7 -2 D
+1 -17 D
+3 12 D
+3 -13 D
+8 1 D
+-10 17 D
+8 -2 D
+-7 8 D
+9 6 D
+P
+FO
+3202 1367 M
+-10 3 D
+-36 -5 D
+-24 16 D
+3 17 D
+-18 5 D
+-27 -24 D
+-15 -26 D
+1 -50 D
+-1 -2 D
+71 -42 D
+34 62 D
+P
+FO
+3075 1301 M
+-43 -68 D
+8 -24 D
+-11 -42 D
+-62 -106 D
+-64 -37 D
+-4 8 D
+-15 -7 D
+-34 9 D
+7 6 D
+-20 -7 D
+7 -7 D
+-8 -52 D
+8 -8 D
+-19 13 D
+0 18 D
+-11 12 D
+7 6 D
+-3 9 D
+-12 -17 D
+8 -20 D
+-17 4 D
+-4 19 D
+-12 -13 D
+-16 -2 D
+-8 3 D
+4 -1 D
+-17 15 D
+-8 1 D
+102 -121 D
+57 50 D
+4 5 D
+19 17 D
+4 5 D
+5 4 D
+4 5 D
+5 4 D
+17 19 D
+5 4 D
+54 62 D
+55 70 D
+36 52 D
+43 70 D
+P
+FO
+2805 1033 M
+-15 -20 D
+26 22 D
+P
+FO
+2736 1013 M
+-17 2 D
+-60 -25 D
+-11 -34 D
+-7 3 D
+6 8 D
+-13 -11 D
+-2 7 D
+-21 -3 D
+4 -5 D
+-21 -34 D
+7 9 D
+-1 -6 D
+-38 -32 D
+16 -36 D
+-7 -19 D
+7 -1 D
+2 -32 D
+-17 -34 D
+7 -3 D
+-4 -29 D
+4 -22 D
+87 47 D
+52 33 D
+81 57 D
+48 39 D
+P
+2668 983 M
+2 -5 D
+P
+2626 815 M
+2 -7 D
+P
+2629 901 M
+3 -5 D
+P
+FO
+2562 1042 M
+-17 -3 D
+6 -21 D
+-20 1 D
+12 -26 D
+-5 3 D
+21 -23 D
+19 25 D
+39 11 D
+-11 12 D
+-24 8 D
+8 2 D
+-7 6 D
+P
+2562 1034 M
+8 -2 D
+P
+FO
+2568 961 M
+-7 -1 D
+12 -5 D
+P
+FO
+2544 1032 M
+0 -9 D
+P
+FO
+2634 1003 M
+9 -5 D
+P
+FO
+2051 808 M
+6 7 D
+-13 6 D
+-14 -9 D
+-19 -46 D
+-20 -3 D
+-10 -31 D
+12 -3 D
+17 12 D
+24 -7 D
+14 -24 D
+-3 16 D
+20 -6 D
+-3 -12 D
+13 -10 D
+1 -14 D
+4 4 D
+17 -10 D
+3 5 D
+6 -12 D
+8 1 D
+-35 39 D
+4 -8 D
+-13 4 D
+0 8 D
+7 -3 D
+-9 12 D
+-9 -1 D
+8 1 D
+-10 15 D
+5 22 D
+17 12 D
+-28 12 D
+P
+2038 762 M
+-6 -5 D
+P
+FO
+2129 935 M
+-12 -10 D
+-4 -43 D
+-16 -5 D
+11 -6 D
+-11 6 D
+-16 -3 D
+8 -3 D
+-1 -12 D
+-25 -34 D
+0 -11 D
+8 2 D
+-7 -7 D
+21 10 D
+13 -13 D
+-7 -4 D
+16 9 D
+20 53 D
+25 24 D
+16 4 D
+20 30 D
+-5 6 D
+7 -1 D
+-2 20 D
+-17 -5 D
+-26 6 D
+P
+2151 895 M
+-1 9 D
+7 -4 D
+P
+2146 896 M
+2 6 D
+P
+2180 936 M
+-3 5 D
+P
+2163 909 M
+-8 10 D
+P
+2130 874 M
+-1 0 D
+3 21 D
+P
+2135 880 M
+-1 10 D
+P
+2124 870 M
+-8 7 D
+P
+FO
+2160 961 M
+6 -9 D
+3 15 D
+P
+FO
+2052 704 M
+-5 3 D
+P
+FO
+2075 809 M
+-4 -6 D
+P
+FO
+1887 871 M
+-9 -5 D
+12 0 D
+P
+FO
+1037 2197 M
+-1 9 D
+-28 1 D
+15 -6 D
+-4 -10 D
+15 3 D
+-11 12 D
+P
+FO
+1044 2222 M
+23 69 D
+3 6 D
+-7 -2 D
+7 2 D
+3 9 D
+-17 13 D
+-11 39 D
+-15 7 D
+-12 -16 D
+-25 -5 D
+-11 18 D
+4 27 D
+-25 15 D
+-5 24 D
+-12 -8 D
+2 11 D
+10 2 D
+-1 11 D
+-12 2 D
+1 -16 D
+-12 -6 D
+-27 13 D
+20 18 D
+8 27 D
+-31 18 D
+5 5 D
+-15 0 D
+16 20 D
+8 22 D
+-107 61 D
+-34 21 D
+6 -23 D
+26 -8 D
+-28 8 D
+-5 23 D
+-20 12 D
+-47 -88 D
+-26 -57 D
+-27 -69 D
+-13 -35 D
+9 -13 D
+61 -17 D
+61 -55 D
+1 -13 D
+47 -3 D
+28 -24 D
+15 5 D
+2 -6 D
+-1 17 D
+4 6 D
+-2 7 D
+8 -15 D
+8 9 D
+6 -5 D
+-6 -5 D
+9 4 D
+-4 -5 D
+18 -12 D
+10 5 D
+4 -12 D
+12 10 D
+9 -21 D
+8 12 D
+-3 -13 D
+7 -4 D
+-1 9 D
+17 -15 D
+-10 -1 D
+-2 -11 D
+2 9 D
+-3 -6 D
+-5 6 D
+3 -7 D
+-6 -4 D
+-1 -7 D
+6 8 D
+6 -7 D
+4 -15 D
+6 5 D
+-6 -3 D
+-3 13 D
+9 -2 D
+1 11 D
+12 2 D
+2 -11 D
+4 10 D
+1 -15 D
+2 17 D
+11 6 D
+-4 -7 D
+9 3 D
+-12 -20 D
+13 11 D
+1 -10 D
+5 5 D
+13 -10 D
+-3 7 D
+13 3 D
+-5 -10 D
+9 2 D
+P
+1022 2232 M
+-11 5 D
+10 2 D
+-7 4 D
+17 1 D
+P
+981 2248 M
+-10 7 D
+10 26 D
+-6 -19 D
+P
+740 2574 M
+-8 -4 D
+7 17 D
+P
+856 2311 M
+11 8 D
+-2 -10 D
+P
+861 2285 M
+-7 3 D
+7 4 D
+P
+978 2329 M
+-10 -1 D
+P
+943 2284 M
+-3 -5 D
+P
+1033 2261 M
+-5 3 D
+5 -2 D
+P
+840 2304 M
+2 -6 D
+P
+972 2320 M
+-6 5 D
+P
+957 2225 M
+4 5 D
+5 -6 D
+P
+991 2260 M
+-2 -6 D
+P
+862 2301 M
+-3 -5 D
+P
+925 2293 M
+-4 -5 D
+P
+830 2309 M
+5 1 D
+P
+909 2283 M
+-6 -2 D
+P
+786 2344 M
+6 -1 D
+P
+853 2316 M
+-1 0 D
+5 4 D
+P
+838 2326 M
+0 -6 D
+P
+831 2304 M
+5 4 D
+P
+1044 2240 M
+-10 -10 D
+P
+FO
+898 2252 M
+-2 10 D
+-29 8 D
+-2 -10 D
+9 -6 D
+20 -10 D
+P
+FO
+934 2261 M
+-9 3 D
+3 -11 D
+P
+FO
+1005 2203 M
+4 8 D
+-12 -1 D
+P
+FO
+1026 2187 M
+7 6 D
+P
+FO
+1012 2192 M
+2 6 D
+P
+FO
+1015 2200 M
+6 1 D
+-5 -1 D
+P
+FO
+948 2241 M
+-3 6 D
+P
+FO
+925 2246 M
+4 5 D
+P
+FO
+955 2238 M
+5 1 D
+P
+FO
+919 2235 M
+1 6 D
+P
+FO
+997 2212 M
+6 1 D
+P
+FO
+1014 2198 M
+-5 -1 D
+P
+FO
+985 2201 M
+3 6 D
+P
+FO
+938 2240 M
+-5 5 D
+P
+FO
+995 2206 M
+8 -2 D
+P
+FO
+927 2243 M
+-4 -6 D
+P
+FO
+1000 2193 M
+5 5 D
+P
+FO
+946 2228 M
+-6 4 D
+P
+FO
+759 2650 M
+12 -7 D
+4 -14 D
+34 -21 D
+107 -61 D
+11 30 D
+3 22 D
+-12 30 D
+-11 5 D
+-14 -7 D
+-10 11 D
+-32 -16 D
+-23 17 D
+15 -9 D
+17 5 D
+29 26 D
+21 40 D
+-6 49 D
+-17 22 D
+-6 41 D
+-9 0 D
+19 8 D
+5 -50 D
+2 37 D
+-8 28 D
+-63 -81 D
+-44 -66 D
+P
+900 2726 M
+-11 5 D
+-1 29 D
+10 -10 D
+-6 -6 D
+P
+845 2673 M
+9 31 D
+-3 -17 D
+5 1 D
+P
+904 2735 M
+-4 19 D
+P
+FO
+774 2629 M
+-2 10 D
+-14 9 D
+-4 -7 D
+P
+FO
+5 -2 1 765 2644 SP
+1952 2431 M
+-2 10 D
+0 -10 D
+P
+FO
+1965 2431 M
+-8 2 D
+-2 -2 D
+P
+FO
+1998 2428 M
+0 1 D
+P
+FO
+2044 2422 M
+-23 7 D
+-4 -3 D
+P
+FO
+2117 2408 M
+-10 -3 D
+-8 11 D
+-19 1 D
+-4 10 D
+-18 -9 D
+29 -7 D
+27 -9 D
+P
+FO
+2130 2396 M
+-13 12 D
+-3 -6 D
+P
+FO
+2250 2326 M
+-5 12 D
+12 4 D
+-13 -2 D
+-10 37 D
+-70 3 D
+23 -11 D
+43 -28 D
+P
+FO
+2277 2340 M
+-1 1 D
+-24 -17 D
+7 -6 D
+P
+FO
+2418 2220 M
+-3 8 D
+-3 23 D
+11 4 D
+2 20 D
+-8 17 D
+-29 20 D
+-14 -17 D
+-3 18 D
+-9 4 D
+0 -12 D
+-9 2 D
+-8 19 D
+-7 -5 D
+-61 19 D
+-18 -22 D
+20 -17 D
+31 -32 D
+22 -27 D
+21 -29 D
+13 -23 D
+P
+FO
+2469 2042 M
+-6 10 D
+-21 4 D
+-23 24 D
+-2 7 D
+11 -2 D
+12 17 D
+-8 20 D
+19 14 D
+-33 84 D
+-26 -15 D
+-26 -15 D
+9 -15 D
+19 -40 D
+15 -41 D
+15 -61 D
+P
+FO
+2790 2203 M
+1 -10 D
+0 10 D
+P
+FO
+2523 1849 M
+3 20 D
+20 14 D
+-6 10 D
+-21 2 D
+-10 13 D
+4 23 D
+-7 23 D
+11 35 D
+-10 19 D
+-7 -5 D
+-11 26 D
+-13 2 D
+-7 11 D
+-11 -2 D
+-12 -2 D
+-11 -2 D
+-11 -3 D
+7 -70 D
+-2 -53 D
+-5 -43 D
+P
+FO
+2429 1673 M
+10 21 D
+25 22 D
+20 5 D
+3 24 D
+-9 5 D
+-4 22 D
+35 40 D
+10 -4 D
+12 9 D
+-16 7 D
+14 14 D
+-6 9 D
+0 2 D
+-99 18 D
+-10 -44 D
+-20 -58 D
+-23 -48 D
+-5 -7 D
+P
+FO
+2309 1522 M
+51 23 D
+26 34 D
+-6 26 D
+29 8 D
+-1 18 D
+7 1 D
+4 18 D
+8 1 D
+-1 16 D
+3 6 D
+-63 37 D
+-23 -38 D
+-22 -28 D
+-23 -26 D
+-32 -31 D
+-7 -5 D
+P
+FO
+2117 1490 M
+3 -2 D
+40 2 D
+20 -8 D
+15 17 D
+8 -4 D
+25 15 D
+30 -4 D
+3 -21 D
+5 19 D
+14 -1 D
+6 10 D
+23 9 D
+-50 60 D
+-28 -22 D
+-22 -15 D
+-15 -9 D
+-15 -9 D
+-16 -8 D
+-16 -8 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-9 -3 D
+P
+FO
+2110 1497 M
+7 -7 D
+-3 8 D
+-2 -1 D
+P
+FO
+2174 1051 M
+-2 -8 D
+P
+FO
+1487 2081 M
+-7 -3 D
+2 -10 D
+2 2 D
+P
+FO
+1502 2126 M
+-32 -5 D
+-1 -15 D
+16 -3 D
+-7 -7 D
+12 -8 D
+3 13 D
+P
+FO
+1529 2182 M
+-14 4 D
+-47 42 D
+-20 6 D
+-21 -8 D
+-2 12 D
+10 10 D
+-1 0 D
+-2 1 D
+-10 -3 D
+-1 10 D
+-14 7 D
+-1 -11 D
+13 -33 D
+-6 -5 D
+12 -6 D
+3 -23 D
+12 -5 D
+-4 -7 D
+15 -6 D
+-10 -6 D
+29 -4 D
+21 -13 D
+-3 -15 D
+15 -3 D
+15 36 D
+P
+FO
+1158 2408 M
+-6 -9 D
+13 4 D
+-7 -8 D
+6 6 D
+-1 -16 D
+7 15 D
+P
+FO
+1070 2297 M
+3 1 D
+1 8 D
+-1 0 D
+P
+FO
+1044 2223 M
+10 18 D
+-2 -17 D
+7 -1 D
+-15 -1 D
+-4 -12 D
+8 1 D
+-6 -13 D
+7 11 D
+10 -4 D
+-8 10 D
+8 2 D
+1 -16 D
+6 8 D
+10 -7 D
+12 5 D
+-9 3 D
+10 1 D
+-12 0 D
+9 10 D
+-11 -11 D
+-4 10 D
+7 -6 D
+9 9 D
+12 -12 D
+-10 6 D
+8 -6 D
+-6 2 D
+-5 -11 D
+17 -4 D
+-3 14 D
+9 -11 D
+3 5 D
+-11 5 D
+7 20 D
+13 -1 D
+7 -12 D
+-7 4 D
+0 -11 D
+17 14 D
+-23 14 D
+-3 29 D
+8 11 D
+-19 -3 D
+-3 -9 D
+2 10 D
+-13 -3 D
+-13 23 D
+-4 0 D
+-18 -49 D
+P
+FO
+1037 2197 M
+P
+FO
+1186 2279 M
+2 25 D
+-33 -29 D
+-33 -3 D
+-4 -26 D
+13 -5 D
+7 15 D
+10 -15 D
+14 12 D
+3 -7 D
+-8 1 D
+3 -6 D
+-15 -13 D
+13 8 D
+-2 -9 D
+-6 1 D
+1 -18 D
+P
+1152 2258 M
+2 -5 D
+-3 4 D
+P
+1173 2276 M
+-10 -21 D
+P
+FO
+1171 2234 M
+11 5 D
+-6 0 D
+3 9 D
+5 -3 D
+9 11 D
+-19 -9 D
+1 9 D
+P
+FO
+1134 2199 M
+-2 15 D
+-13 -10 D
+4 -12 D
+10 6 D
+-2 8 D
+P
+FO
+1114 2205 M
+9 6 D
+-7 0 D
+-4 19 D
+-6 -17 D
+P
+FO
+1142 2230 M
+9 8 D
+-16 1 D
+P
+FO
+1148 2226 M
+-11 -6 D
+6 -3 D
+P
+FO
+1038 2194 M
+-3 -6 D
+9 -1 D
+P
+FO
+1059 2193 M
+4 5 D
+-10 -1 D
+P
+FO
+1109 2191 M
+9 12 D
+-20 -20 D
+P
+FO
+1081 2183 M
+-9 5 D
+P
+FO
+1178 2259 M
+9 14 D
+P
+FO
+1142 2213 M
+-8 4 D
+P
+FO
+1048 2197 M
+10 6 D
+P
+FO
+1163 2221 M
+1 0 D
+5 9 D
+P
+FO
+1169 2235 M
+3 12 D
+-4 -12 D
+P
+FO
+1049 2183 M
+-2 8 D
+P
+FO
+1196 2318 M
+-2 -11 D
+P
+FO
+1066 2187 M
+5 -6 D
+P
+FO
+1076 2192 M
+7 5 D
+P
+FO
+1088 2197 M
+7 3 D
+P
+FO
+1162 2221 M
+-4 -6 D
+P
+FO
+1105 2195 M
+3 7 D
+P
+FO
+1162 2225 M
+1 6 D
+P
+FO
+1085 2191 M
+4 5 D
+P
+FO
+1408 2228 M
+-10 -1 D
+6 -14 D
+P
+FO
+1380 2279 M
+-5 -13 D
+9 7 D
+P
+FO
+1170 2400 M
+-5 18 D
+-7 -10 D
+P
+FO
+1421 2256 M
+-1 7 D
+8 3 D
+-13 15 D
+6 15 D
+-11 0 D
+-3 -33 D
+P
+FO
+1435 2248 M
+4 4 D
+-7 -3 D
+P
+FO
+1179 2413 M
+3 6 D
+-8 -2 D
+9 18 D
+-8 1 D
+2 -8 D
+-14 -5 D
+11 -6 D
+1 -15 D
+7 3 D
+P
+FO
+1157 2411 M
+5 5 D
+P
+FO
+1419 2279 M
+9 -6 D
+5 8 D
+-5 6 D
+P
+FO
+1417 2308 M
+3 -6 D
+7 14 D
+P
+FO
+1458 2627 M
+-16 7 D
+-18 -11 D
+P
+FO
+1950 2441 M
+-7 -6 D
+-7 -4 D
+14 0 D
+P
+FO
+2058 2418 M
+-2 -1 D
+-12 5 D
+-27 4 D
+-6 -4 D
+-13 6 D
+-14 -5 D
+-19 8 D
+-5 0 D
+-5 0 D
+-3 -3 D
+0 3 D
+-2 0 D
+0 -481 D
+164 452 D
+-48 15 D
+P
+FO
+2252 2324 M
+-1 0 D
+-1 2 D
+-34 25 D
+-44 26 D
+-8 3 D
+-17 0 D
+-17 16 D
+-16 6 D
+-164 -452 D
+309 368 D
+P
+FO
+1950 1950 M
+416 240 D
+-23 38 D
+-22 28 D
+-23 26 D
+-32 31 D
+-7 5 D
+P
+FO
+1950 1950 M
+474 83 D
+-10 44 D
+-20 58 D
+-23 48 D
+-5 7 D
+-311 -180 D
+P
+FO
+1950 1950 M
+474 -83 D
+7 70 D
+-2 53 D
+-5 43 D
+-236 -41 D
+-119 -21 D
+P
+FO
+1950 1950 M
+416 -240 D
+9 15 D
+19 40 D
+15 41 D
+15 61 D
+P
+FO
+1950 1950 M
+309 -368 D
+20 17 D
+31 32 D
+22 27 D
+21 29 D
+13 23 D
+P
+FO
+1950 1950 M
+164 -452 D
+41 17 D
+32 16 D
+44 29 D
+28 22 D
+P
+FO
+1950 1656 M
+71 -7 D
+-5 16 D
+11 8 D
+19 -23 D
+9 -33 D
+-19 -7 D
+21 0 D
+-5 -16 D
+-9 -2 D
+7 -12 D
+-9 -2 D
+1 -12 D
+-17 -7 D
+1 -30 D
+-7 -11 D
+7 -12 D
+-1 10 D
+32 -20 D
+47 6 D
+6 -5 D
+4 1 D
+-164 452 D
+P
+FO
+1852 1680 M
+19 7 D
+62 -19 D
+12 -11 D
+5 -1 D
+0 294 D
+P
+FO
+1723 1680 M
+7 -1 D
+20 -20 D
+20 -2 D
+37 25 D
+27 -22 D
+9 18 D
+9 2 D
+98 270 D
+P
+FO
+1612 1755 M
+6 -16 D
+10 -7 D
+1 -25 D
+24 9 D
+36 -31 D
+34 -5 D
+227 270 D
+-254 -146 D
+P
+FO
+1520 1874 M
+14 -23 D
+21 6 D
+9 15 D
+1 -11 D
+12 14 D
+9 -6 D
+3 10 D
+9 -2 D
+-1 -32 D
+16 -7 D
+-18 -21 D
+1 -27 D
+8 -3 D
+8 -32 D
+338 195 D
+-108 -19 D
+P
+FO
+1549 2021 M
+-4 -4 D
+19 -14 D
+-36 -52 D
+7 -6 D
+-5 -26 D
+-14 -16 D
+-1 -20 D
+5 -9 D
+430 76 D
+P
+FO
+1641 2128 M
+-12 -5 D
+-36 33 D
+-20 12 D
+-44 14 D
+-14 -27 D
+-12 -29 D
+2 0 D
+-3 0 D
+-11 -31 D
+-1 -7 D
+6 -3 D
+-9 -4 D
+-3 -11 D
+16 10 D
+7 -24 D
+2 26 D
+10 -3 D
+8 -19 D
+16 17 D
+20 -3 D
+-31 -42 D
+15 -6 D
+3 14 D
+7 -2 D
+1 -10 D
+-9 -7 D
+401 -71 D
+P
+FO
+1765 2170 M
+-37 -25 D
+-20 5 D
+-11 -8 D
+-56 -14 D
+309 -178 D
+P
+FO
+1593 2156 M
+-7 7 D
+-13 5 D
+P
+FO
+1811 2332 M
+-3 -31 D
+-15 5 D
+-9 -11 D
+13 -21 D
+-8 -17 D
+11 -7 D
+-20 -45 D
+3 -26 D
+-18 -9 D
+185 -220 D
+P
+FO
+1936 2431 M
+0 -1 D
+-14 -11 D
+-43 -6 D
+-24 -24 D
+-2 -17 D
+-40 -28 D
+-2 -12 D
+139 -382 D
+0 481 D
+-5 0 D
+-4 0 D
+P
+FO
+25 W
+4 W
+1950 2071 M
+0 1829 D
+S
+2071 1950 M
+1829 0 D
+S
+1950 1829 M
+0 -1829 D
+S
+1829 1950 M
+-1829 0 D
+S
+1950 1950 M
+0 121 D
+S
+1950 1950 M
+121 0 D
+S
+1950 1950 M
+0 -121 D
+S
+1950 1950 M
+-121 0 D
+S
+1950 2071 M
+22 -2 D
+23 -7 D
+23 -12 D
+14 -11 D
+1 -2 D
+6 -5 D
+1 -2 D
+2 -1 D
+11 -16 D
+9 -17 D
+6 -19 D
+3 -26 D
+-3 -27 D
+-5 -16 D
+-10 -22 D
+-10 -14 D
+-4 -3 D
+-8 -9 D
+-8 -6 D
+-8 -6 D
+-4 -2 D
+-6 -4 D
+-4 -2 D
+-3 -1 D
+-4 -2 D
+-2 0 D
+-3 -1 D
+-4 -2 D
+-3 0 D
+-4 -2 D
+-3 0 D
+-2 -1 D
+-2 0 D
+-3 0 D
+-2 -1 D
+-3 0 D
+-2 0 D
+-3 -1 D
+-2 0 D
+-2 0 D
+-3 0 D
+-2 0 D
+-3 0 D
+-2 0 D
+-24 4 D
+-23 8 D
+-16 10 D
+-17 14 D
+-5 6 D
+-2 1 D
+-13 20 D
+-10 23 D
+-4 23 D
+-1 20 D
+5 26 D
+10 25 D
+14 20 D
+2 1 D
+5 6 D
+2 1 D
+3 4 D
+22 15 D
+27 11 D
+19 3 D
+P S
+1950 3900 M
+68 -1 D
+108 -7 D
+97 -11 D
+77 -13 D
+77 -15 D
+104 -27 D
+94 -29 D
+55 -19 D
+100 -41 D
+89 -41 D
+17 -9 D
+69 -37 D
+51 -29 D
+33 -21 D
+82 -54 D
+86 -64 D
+61 -50 D
+65 -59 D
+77 -76 D
+53 -57 D
+50 -60 D
+37 -46 D
+57 -79 D
+43 -66 D
+31 -50 D
+38 -68 D
+18 -35 D
+38 -79 D
+35 -81 D
+31 -83 D
+32 -102 D
+23 -85 D
+19 -86 D
+17 -107 D
+12 -107 D
+4 -68 D
+2 -88 D
+-1 -68 D
+-7 -108 D
+-11 -97 D
+-13 -77 D
+-15 -77 D
+-27 -104 D
+-29 -94 D
+-19 -55 D
+-41 -100 D
+-41 -89 D
+-9 -17 D
+-37 -69 D
+-29 -51 D
+-21 -33 D
+-54 -82 D
+-64 -86 D
+-50 -61 D
+-59 -65 D
+-76 -77 D
+-57 -53 D
+-45 -38 D
+-38 -31 D
+-31 -23 D
+-31 -24 D
+-24 -17 D
+-24 -16 D
+-25 -17 D
+-24 -16 D
+-17 -10 D
+-17 -10 D
+-25 -16 D
+-17 -9 D
+-17 -10 D
+-17 -10 D
+-17 -9 D
+-17 -9 D
+-18 -9 D
+-17 -9 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-17 -8 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-10 -1 D
+-9 0 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-79 3 D
+-97 8 D
+-68 8 D
+-77 13 D
+-77 15 D
+-104 27 D
+-94 29 D
+-55 19 D
+-100 41 D
+-89 41 D
+-17 9 D
+-69 37 D
+-51 29 D
+-33 21 D
+-82 54 D
+-86 64 D
+-61 50 D
+-65 59 D
+-77 76 D
+-53 57 D
+-50 60 D
+-37 46 D
+-57 79 D
+-43 66 D
+-31 50 D
+-38 68 D
+-18 35 D
+-38 79 D
+-35 81 D
+-31 83 D
+-32 102 D
+-23 85 D
+-19 86 D
+-17 107 D
+-12 107 D
+-4 68 D
+-2 88 D
+1 68 D
+7 108 D
+11 97 D
+13 77 D
+15 77 D
+27 104 D
+29 94 D
+19 55 D
+41 100 D
+41 89 D
+9 17 D
+37 69 D
+29 51 D
+21 33 D
+54 82 D
+64 86 D
+50 61 D
+59 65 D
+76 77 D
+57 53 D
+60 50 D
+46 37 D
+79 57 D
+66 43 D
+50 31 D
+68 38 D
+35 18 D
+79 38 D
+81 35 D
+83 31 D
+102 32 D
+85 23 D
+86 19 D
+107 17 D
+107 12 D
+68 4 D
+P S
+8 W
+N 1950 3900 M 0 83 D S
+N 1950 3900 M 0 83 D S
+25 W
+1950 3900 M
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 0 D
+-10 -1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-9 -3 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-10 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-17 -8 D
+-18 -9 D
+-17 -9 D
+-9 -4 D
+-18 -9 D
+-17 -9 D
+-17 -9 D
+-17 -10 D
+-17 -10 D
+-17 -9 D
+-17 -10 D
+-17 -11 D
+-16 -10 D
+-17 -11 D
+-24 -16 D
+-17 -11 D
+-24 -16 D
+-24 -17 D
+-31 -24 D
+-31 -23 D
+-46 -38 D
+-59 -51 D
+-63 -61 D
+-55 -56 D
+-33 -36 D
+-50 -60 D
+-37 -46 D
+-57 -79 D
+-43 -66 D
+-31 -50 D
+-38 -68 D
+-18 -35 D
+-38 -79 D
+-35 -81 D
+-31 -83 D
+-32 -102 D
+-23 -85 D
+-19 -86 D
+-17 -107 D
+-12 -107 D
+-4 -68 D
+-2 -88 D
+1 -68 D
+7 -108 D
+11 -97 D
+13 -77 D
+15 -77 D
+27 -104 D
+29 -94 D
+19 -55 D
+41 -100 D
+41 -89 D
+9 -17 D
+37 -69 D
+29 -51 D
+21 -33 D
+54 -82 D
+64 -86 D
+50 -61 D
+59 -65 D
+76 -77 D
+57 -53 D
+60 -50 D
+46 -37 D
+79 -57 D
+66 -43 D
+50 -31 D
+68 -38 D
+35 -18 D
+79 -38 D
+81 -35 D
+83 -31 D
+102 -32 D
+85 -23 D
+86 -19 D
+107 -17 D
+107 -12 D
+68 -4 D
+88 -2 D
+68 1 D
+108 7 D
+97 11 D
+77 13 D
+77 15 D
+104 27 D
+94 29 D
+55 19 D
+100 41 D
+89 41 D
+17 9 D
+69 37 D
+51 29 D
+33 21 D
+82 54 D
+86 64 D
+61 50 D
+65 59 D
+77 76 D
+53 57 D
+50 60 D
+37 46 D
+57 79 D
+43 66 D
+31 50 D
+38 68 D
+18 35 D
+38 79 D
+35 81 D
+31 83 D
+32 102 D
+23 85 D
+19 86 D
+17 107 D
+12 107 D
+4 68 D
+2 88 D
+-1 68 D
+-7 108 D
+-11 97 D
+-13 77 D
+-15 77 D
+-27 104 D
+-29 94 D
+-19 55 D
+-41 100 D
+-41 89 D
+-9 17 D
+-37 69 D
+-29 51 D
+-21 33 D
+-54 82 D
+-64 86 D
+-50 61 D
+-59 65 D
+-76 77 D
+-57 53 D
+-60 50 D
+-46 37 D
+-79 57 D
+-66 43 D
+-50 31 D
+-68 38 D
+-35 18 D
+-79 38 D
+-81 35 D
+-83 31 D
+-102 32 D
+-85 23 D
+-86 19 D
+-107 17 D
+-107 12 D
+-68 4 D
+P S
+1950 4067 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0è) bc Z
+%%EndObject
+1950 1950 T
+-245 R
+-1950 -1950 T
 
 grestore
 PSL_movie_completion /PSL_movie_completion {} def

--- a/test/psbasemap/zrotation.sh
+++ b/test/psbasemap/zrotation.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-# GMT_KNOWN_FAILURE
 # Test script for plain -p<rot> about map center.
 # This should place 4 plots that differ by a rotation about the S pole
-# Currently fails.  Faked the orig by using -JA<rot>... instead [in brackets]
 
 ps=zrotation.ps
 gmt set MAP_FRAME_TYPE plain
@@ -22,9 +20,9 @@ gmt pstext -R -J -O -K -F+jTL -Dj0.2i << EOF >> $ps
 EOF
 # LL corner is standard, no rotation
 gmt pscoast -R0/360/-90/0 -JA0/-90/3.25i -Bg90a360f360 -O -K -Gred -Dc -X0.45i -Y0.45i >> $ps
-# LR corner is 45 degrees rotation [-JA45/-90/3.25i -p0+w0/-90]
+# LR corner is 45 degrees rotation
 gmt pscoast -R -J -Bg90a360f360 -Gred -Dc -X4.15i -O -K -p45+w0/-90 >> $ps
-# UL corner is 180 degrees rotation [-JA180/-90/3.25i -p0+w0/-90]
+# UL corner is 180 degrees rotation
 gmt pscoast -R -J -Bg90a360f360 -Gred -Dc -X-4.15i -Y4.15i -O -K -p180+w0/-90 >> $ps
-# UR corner is 245 degrees rotation [-JA245/-90/3.25i -p0+w0/-90]
+# UR corner is 245 degrees rotation
 gmt pscoast -R -J -Bg90a360f360 -Gred -Dc -X4.15i -O -p245+w0/-90 >> $ps


### PR DESCRIPTION
The test script _zrotation.sh_ failed because we never undid the rotation and reset the origin at the end of the layer when **-p**_angle_**+w**_lon0_/_lat0_, hence rotations and offsets were accumulating off the page.  Adding the reset fixes the problem that the script was designed to test.