### PR TITLE
WIP: Add nightly packaging to CI

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -161,7 +161,7 @@ jobs:
 
   variables:
     BUILD_DOCS: false
-    TEST: false
+    TEST: true
 
   steps:
 
@@ -192,7 +192,7 @@ jobs:
   - bash: |
       set -x -e
       cd build
-      cmake --build . --target gmt_release
-      cmake --build . --target gmt_release_tar
+      #cmake --build . --target gmt_release
+      #cmake --build . --target gmt_release_tar
       cmake --build . --target package
     displayName: Package GMT

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -115,6 +115,40 @@ jobs:
     condition: succeededOrFailed()
     displayName: Upload test coverage
 
+# Mac - Pacakge
+########################################################################################
+- job:
+  displayName: 'Mac | Package'
+  condition: eq(variables['Build.Reason'], 'Schedule')
+
+  pool:
+    vmImage: 'macOS-10.13'
+
+  variables:
+    BUILD_DOCS: true
+    PACKAGING: true
+
+  steps:
+
+  # Setup and compile GMT
+  - template: ci/azure-pipelines-mac.yml
+
+  - bash: |
+      set -x -e
+      gmt defaults -Vd
+      gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
+      gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -Vd && gmt end
+    displayName: Check a few simple commands
+
+  # Run the full tests only if this is a scheduled build
+  - bash: |
+      set -x -e
+      cd build
+      cmake --build . --target gmt_release
+      cmake --build . --target gmt_release_tar
+      cmake --build . --target package
+    displayName: Packaing
+
 # Windows - Compile + Package
 ########################################################################################
 - job:
@@ -143,3 +177,11 @@ jobs:
       gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
       gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -Vd && gmt end
     displayName: Check a few simple commands
+
+  - bash: |
+      set -x -e
+      cd build
+      cmake --build . --target gmt_release
+      cmake --build . --target gmt_release_tar
+      cmake --build . --target package
+    displayName: Package GMT

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -74,7 +74,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Test'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.13'
@@ -119,7 +119,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Package'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.13'
@@ -153,7 +153,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Windows | Compile + Package'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: ne(variables['Build.Reason'], 'Schedule')
   timeoutInMinutes: 120
 
   pool:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -152,7 +152,7 @@ jobs:
 # Windows - Compile + Package
 ########################################################################################
 - job:
-  displayName: 'Windows | Compile + Package'
+  displayName: 'Windows | Compile + Tests + Package'
   condition: ne(variables['Build.Reason'], 'Schedule')
   timeoutInMinutes: 120
 
@@ -177,6 +177,17 @@ jobs:
       gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
       gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -Vd && gmt end
     displayName: Check a few simple commands
+
+  # Run the full tests only if this is a scheduled build
+  - bash: |
+      set -x -e
+      cd build
+      # Download remote files before testing, see #939.
+      gmt which -Gu @tut_ship.xyz @App_O_geoid.nc @sat_03.txt @ship_03.txt @wus_gps_final.txt
+      gmt which -Gu @CA_fault_data.txt @nn_polar.txt @white_noise.nc @topo.8.2.img @App_O_transect.txt
+      gmt which -Gu @earth_relief_02m @earth_relief_05m
+      ctest --output-on-failure --force-new-ctest-process -j4
+    displayName: Full tests
 
   - bash: |
       set -x -e

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -125,6 +125,7 @@ jobs:
     vmImage: 'macOS-10.13'
 
   variables:
+    TEST: false
     BUILD_DOCS: true
     PACKAGING: true
 
@@ -183,8 +184,7 @@ jobs:
       set -x -e
       cd build
       # Download remote files before testing, see #939.
-      gmt which -Gu @tut_ship.xyz @App_O_geoid.nc @sat_03.txt @ship_03.txt @wus_gps_final.txt
-      gmt which -Gu @CA_fault_data.txt @nn_polar.txt @white_noise.nc @topo.8.2.img @App_O_transect.txt
+      curl http://www.soest.hawaii.edu/gmt/data/gmt_md5_server.txt | awk 'NF==3 && $1!~/earth/ {print "@"$1}' | xargs gmt which -Gc
       gmt which -Gu @earth_relief_02m @earth_relief_05m
       ctest --output-on-failure --force-new-ctest-process -j4
     displayName: Full tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,13 +54,13 @@ matrix:
         # cron jobs to run full tests
         - name: "Linux (cron - run tests)"
           os: linux
-          if: type = cron
+          if: type != cron
           env:
             - TEST="true"
         # cron jobs to build and deploy docs, make tarballs
         - name: "Linux (cron - build and deploy docs + make tarballs)"
           os: linux
-          if: type = cron
+          if: type != cron
           env:
             - BUILD_DOCS=true
             - DEPLOY_DOCS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
         - BUILD_DOCS=false
         - DEPLOY_DOCS=false
         - TEST=false
+        - PACKAGING=false
         - CCACHE_MAXSIZE=200M
         - CCACHE_COMPRESS=true
         # Encrypted Github token (GH_TOKEN)
@@ -50,19 +51,21 @@ matrix:
         - name: "Linux (compile only)"
           os: linux
           if: type != cron
-        - name: "Linux (cron)"
+        # cron jobs to run full tests
+        - name: "Linux (cron - run tests)"
           os: linux
           if: type = cron
           env:
             - TEST="true"
-        # Only build the docs on Linux cron jobs
-        - name: "Linux (cron - build docs)"
+        # cron jobs to build and deploy docs, make tarballs
+        - name: "Linux (cron - build and deploy docs + make tarballs)"
           os: linux
           if: type = cron
           env:
             - BUILD_DOCS=true
             - DEPLOY_DOCS=true
             - HTML_BUILDDIR="build/doc/rst/html"
+            - PACKAGING=true
 
 # Setup the build environment
 before_install:
@@ -133,6 +136,12 @@ script:
         cmake --build . --target docs_pdf_shrink;
       fi
     - set +e
+    # Create source pacakges for Linux
+    - if [[ "$PACKAGING" == "true" ]]; then
+        cmake --build . --target gmt_release;
+        cmake --build . --target gmt_release_tar;
+        md5sum gmt-*.tar.gz gmt-*.tar.xz;
+      fi
     - cd ..
 
 # Things to do if the build is successful

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -5,7 +5,7 @@ steps:
 - bash: |
     set -x -e
     brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript || true
-  displayName: Install dependencies
+  displayName: Install build dependencies
 
 - bash: |
     set -x -e

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -22,7 +22,7 @@ steps:
 
 - bash: |
     set -x -e
-    choco install ghostscript ninja
+    choco install ghostscript ninja graphicsmagick
   displayName: Install dependencies via chocolatey
 
 - bash: echo "##vso[task.setvariable variable=INSTALLDIR]D:/a/1/s/gmt-install-dir"

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -58,9 +58,3 @@ steps:
     cmake --build .
     cmake --build . --target install
   displayName: Compile GMT
-
-- bash: |
-    set -x -e
-    cd build
-    cmake --build . --target package
-  displayName: Package GMT

--- a/ci/build-gmt-windows.sh
+++ b/ci/build-gmt-windows.sh
@@ -20,7 +20,8 @@ if [[ "$TEST" == "true" ]]; then
 enable_testing()
 set (DO_EXAMPLES TRUE)
 set (DO_TESTS TRUE)
-set (N_TEST_JOBS 2)
+set (DO_API_TESTS ON)
+set (SUPPORT_EXEC_IN_BINARY_DIR TRUE)
 EOF
 fi
 


### PR DESCRIPTION
**Description of proposed changes**

This PR makes source packages and installer nightly, to test if changing CMakeLists.txt breaks packaging.

- Linux: Make source packages only
- macOS: Make both source packages and Bundles
- Windows: Make both source packages and binary installers 

This also make it possible to distribute nightly built installers for macOS and Windows.