### PR TITLE
Add --output-on-failure option to ctest

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -66,7 +66,7 @@ jobs:
   - bash: |
       set -x -e
       cd build
-      ctest --force-new-ctest-process -j4
+      ctest --output-on-failure --force-new-ctest-process -j4
     displayName: Full tests
 
   # Upload test coverage even if build fails. Keep separate to make sure this task fails

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ script:
     - gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
     - gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -Vd && gmt end
     - if [[ "$TEST" == "true" ]]; then
-        ctest --force-new-ctest-process -j4;
+        ctest --output-on-failure --force-new-ctest-process -j4;
       fi
     # Upload test coverage even if build fails. Keep separate to make sure this task
     # fails if the tests fail.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -420,7 +420,7 @@ Optionally set *N_TEST_JOBS* to the number of ctest jobs to run simultaneously.
 You can also select individual tests using regexp with ctest, e.g.:
 
 ```
-ctest -R ex2[3-6]
+ctest --output-on-failure -R ex2[3-6]
 ```
 
 ## Creating source packages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ include (ConfigCMake)
 # Global test target
 add_custom_target (check
 	COMMAND ${CMAKE_CTEST_COMMAND}
-	--force-new-ctest-process -j${N_TEST_JOBS})
+	--output-on-failure --force-new-ctest-process -j${N_TEST_JOBS})
 
 # Find test dependencies
 find_program (GRAPHICSMAGICK gm)


### PR DESCRIPTION
**Description of proposed changes**

ctest --output-on-failure can output more information when a test failure, like

```
235/839 Test #237: exmod/ex03.sh ...........................***Failed    5.30 sec
Set GMT_SESSION_NAME = 24621
/usr/bin/gm compare: image difference exceeds limit (0.4492 > 0.003).
exmod/ex03.ps: RMS Error = 0.4492 [FAIL]
memtrack errors: 0
exit status: 1
```
No need to check the ctest logfile anymore.