### PR TITLE
Add CMake variable to simply beta or similar releases

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -41,14 +41,16 @@ set (GMT_VERSION_YEAR "2019")
 set (GMT_PACKAGE_VERSION_MAJOR 6)
 set (GMT_PACKAGE_VERSION_MINOR 0)
 set (GMT_PACKAGE_VERSION_PATCH 0)
+# If this is a beta version or similar, add a string suffix
+# set (GMT_PACKAGE_VERSION_SUFFIX "b1")
 
 # Whether to make a public release.
-# When making internal releases or just an ordinary developer build, set it to FALSE.
-# When making *public* release, set it to TRUE.
-set (GMT_PUBLIC_RELEASE FALSE)
+# When making internal releases or just an ordinary developer build, it is set to FALSE.
+# When making *public* release, uncomment to set it to TRUE.
+# set (GMT_PUBLIC_RELEASE TRUE)
 
 # The GMT package version.
-set (GMT_PACKAGE_VERSION "${GMT_PACKAGE_VERSION_MAJOR}.${GMT_PACKAGE_VERSION_MINOR}.${GMT_PACKAGE_VERSION_PATCH}")
+set (GMT_PACKAGE_VERSION "${GMT_PACKAGE_VERSION_MAJOR}.${GMT_PACKAGE_VERSION_MINOR}.${GMT_PACKAGE_VERSION_PATCH}${GMT_PACKAGE_VERSION_SUFFIX}")
 
 # The API version (SOVERSION) of the GMT libraries.
 # Increment this when more or fewer functions are included in the


### PR DESCRIPTION
Since CMake variables not explicity set to TRUE are by default FALSE, just let **GMT_PUBLIC_RELEASE** be set to TRUE but commented out.  Same with the new **GMT_PACKAGE_VERSION_SUFFIX** used for "beta".  Thus by default neither are set, but can be uncommented when needed for releases.
