### PR TITLE
Update documentation index page

### DIFF
--- a/doc/rst/source/cookbook.rst
+++ b/doc/rst/source/cookbook.rst
@@ -1,6 +1,6 @@
-###########
-Modern Mode
-###########
+##############################
+The GMT Cookbook (Modern Mode)
+##############################
 
 .. toctree::
    :maxdepth: 1

--- a/doc/rst/source/cookbook_classic.rst
+++ b/doc/rst/source/cookbook_classic.rst
@@ -1,0 +1,9 @@
+############
+Classic Mode
+############
+
+.. toctree::
+   :maxdepth: 1
+   :numbered:
+
+   GMT_Docs_classic

--- a/doc/rst/source/cookbook_classic.rst
+++ b/doc/rst/source/cookbook_classic.rst
@@ -1,6 +1,6 @@
-############
-Classic Mode
-############
+###############################
+The GMT Cookbook (Classic Mode)
+###############################
 
 .. toctree::
    :maxdepth: 1

--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -97,35 +97,24 @@ Gallery
 |    Users_contrib_symbols   |
 +----------------------------+
 
-The CookBook (Modern Mode)
-==========================
+Documentations
+==============
 
-+-----------------+
-| .. toctree::    |
-|    :maxdepth: 2 |
-|                 |
-|    cookbook     |
-+-----------------+
+**Modern mode**
 
-The CookBook (Classic Mode)
-===========================
+.. toctree::
+   :maxdepth: 1
 
-+-------------------------+
-| .. toctree::            |
-|    :maxdepth: 2         |
-|                         |
-|    cookbook_classic     |
-+-------------------------+
+   tutorial
+   cookbook
 
-The Tutorial
-============
+**Classic mode**
 
-+--------------------+
-| .. toctree::       |
-|    :maxdepth: 2    |
-|                    |
-|    tutorial        |
-+--------------------+
+.. toctree::
+   :maxdepth: 1
+
+   tutorial_classic
+   cookbook_classic
 
 GMT Data Sets
 =============
@@ -150,32 +139,12 @@ The Software
 API Reference
 =============
 
-+--------------------+
-| .. toctree::       |
-|    :maxdepth: 2    |
-|                    |
-|    api             |
-+--------------------+
+.. toctree::
+   :maxdepth: 1
 
-MATLAB Wrapper
-==============
-
-+--------------------+
-| .. toctree::       |
-|    :maxdepth: 2    |
-|                    |
-|    ml_wrapper      |
-+--------------------+
-
-Julia Wrapper
-=============
-
-+--------------------+
-| .. toctree::       |
-|    :maxdepth: 2    |
-|                    |
-|    jl_wrapper      |
-+--------------------+
+   api
+   ml_wrapper
+   jl_wrapper
 
 .. Include an hidden page with option's examples that can be referenced by individual programs
 

--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -97,8 +97,8 @@ Gallery
 |    Users_contrib_symbols   |
 +----------------------------+
 
-The CookBook
-============
+The CookBook (Modern Mode)
+==========================
 
 +-----------------+
 | .. toctree::    |
@@ -106,6 +106,16 @@ The CookBook
 |                 |
 |    cookbook     |
 +-----------------+
+
+The CookBook (Classic Mode)
+===========================
+
++-------------------------+
+| .. toctree::            |
+|    :maxdepth: 2         |
+|                         |
+|    cookbook_classic     |
++-------------------------+
 
 The Tutorial
 ============

--- a/doc/rst/source/tutorial.rst
+++ b/doc/rst/source/tutorial.rst
@@ -1,6 +1,6 @@
-###########
-Modern Mode
-###########
+######################
+Tutorial (Modern Mode)
+######################
 
 .. toctree::
    :maxdepth: 1

--- a/doc/rst/source/tutorial_classic.rst
+++ b/doc/rst/source/tutorial_classic.rst
@@ -1,0 +1,9 @@
+#######################
+Tutorial (Classic Mode)
+#######################
+
+.. toctree::
+   :maxdepth: 1
+   :numbered:
+
+   GMT_Tutorial_classic


### PR DESCRIPTION
**Description of proposed changes**

1. Add classic tutorial and cookbook
2. Change the index layout to make it less crowded

Fixes #925.

Index page preview (the quick reference and man pages part remain unchanged):

![image](https://user-images.githubusercontent.com/3974108/59556550-3e04a600-8f92-11e9-85eb-b86793f539df.png)

Sidebar preview:

![image](https://user-images.githubusercontent.com/3974108/59556552-4c52c200-8f92-11e9-8c84-0222a6985a69.png)
