### PR TITLE
subplot internal structure did not have space for frame modifiers

### DIFF
--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -150,7 +150,7 @@ struct GMT_SUBPLOT {
 	char tag[GMT_LEN16];		/* Panel tag, e.g., a) */
 	char fill[GMT_LEN64];		/* Panel tag, e.g., a) */
 	char pen[GMT_LEN64];		/* Panel tag, e.g., a) */
-	char Baxes[GMT_LEN8];		/* The -B setting for selected axes */
+	char Baxes[GMT_LEN128];		/* The -B setting for selected axes, including +color, tec */
 	char Btitle[GMT_LEN128];	/* The -B setting for any title */
 	char Bxlabel[GMT_LEN128];	/* The -Bx setting for x labels */
 	char Bylabel[GMT_LEN128];	/* The -By setting for x labels */


### PR DESCRIPTION
When the frame settings were read back in form the file that subplot set up, we only allowed 8 characters for the frame, just thinking about WESN etc, but there are modifiers like **+g**_fill_ to consider as well.  Closes issue #940.
