### PR TITLE
Improve CI tests on Linux and macOS

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Test'
-  condition: ne(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.13'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Compile only'
-  condition: not(eq(variables['Build.Reason'], 'Schedule'))
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.13'
@@ -66,6 +66,9 @@ jobs:
   - bash: |
       set -x -e
       cd build
+      # Download remote files before testing, see #939.
+      curl http://www.soest.hawaii.edu/gmt/data/gmt_md5_server.txt | awk 'NF==3 && $1!~/earth/ {print "@"$1}' | xargs gmt which -Gc
+      gmt which -Gu @earth_relief_02m @earth_relief_05m
       ctest --output-on-failure --force-new-ctest-process -j4
     displayName: Full tests
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Test'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.13'

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,13 +52,13 @@ matrix:
           if: type != cron
         - name: "Linux (cron)"
           os: linux
-          if: type != cron
+          if: type = cron
           env:
             - TEST="true"
         # Only build the docs on Linux cron jobs
         - name: "Linux (cron - build docs)"
           os: linux
-          if: type != cron
+          if: type = cron
           env:
             - BUILD_DOCS=true
             - DEPLOY_DOCS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,10 @@ script:
     - gmt defaults -Vd
     - gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
     - gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -Vd && gmt end
+    # Download remote files before testing, see #939.
     - if [[ "$TEST" == "true" ]]; then
+        curl http://www.soest.hawaii.edu/gmt/data/gmt_md5_server.txt | awk 'NF==3 && $1!~/earth/ {print "@"$1}' | xargs gmt which -Gc;
+        gmt which -Gu @earth_relief_02m @earth_relief_05m;
         ctest --output-on-failure --force-new-ctest-process -j4;
       fi
     # Upload test coverage even if build fails. Keep separate to make sure this task

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,13 +52,13 @@ matrix:
           if: type != cron
         - name: "Linux (cron)"
           os: linux
-          if: type = cron
+          if: type != cron
           env:
             - TEST="true"
         # Only build the docs on Linux cron jobs
         - name: "Linux (cron - build docs)"
           os: linux
-          if: type = cron
+          if: type != cron
           env:
             - BUILD_DOCS=true
             - DEPLOY_DOCS=true

--- a/test/geodesy/run_GPS_case_sub
+++ b/test/geodesy/run_GPS_case_sub
@@ -13,7 +13,7 @@ W=$6
 #
 # Reformat the data and set the minimum sigma at 0.6 mm/yr
 #
-gmt select ${src:-.}/$D $R -fg | awk '{su = ($5 < .6 ? .6 : $5);sv = ($6 < .6 ? .6 : $6);print($1,$2,$3,$4,su,sv) }' > data.lluv
+gmt select $D $R -fg | awk '{su = ($5 < .6 ? .6 : $5);sv = ($6 < .6 ? .6 : $6);print($1,$2,$3,$4,su,sv) }' > data.lluv
 
 #
 # Use blockmean to avoid aliasing and combine u,v into one file


### PR DESCRIPTION
Download remote files before running tests, to avoid corrupted files due to parallel testing.