### PR TITLE
Make nightly source tarballs on Linux CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,7 +138,7 @@ script:
     - if [[ "$PACKAGE" == "true" ]]; then
         cmake --build . --target gmt_release;
         cmake --build . --target gmt_release_tar;
-        md5sum gmt-*.tar gmt-*.tar.gz gmt-*.tar.xz
+        md5sum gmt-*.tar gmt-*.tar.gz gmt-*.tar.xz;
       fi
     - set +e
     - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
         # Only build the docs on Linux cron jobs
         - name: "Linux (cron - build docs + package)"
           os: linux
-          if: type != cron
+          if: type = cron
           env:
             - BUILD_DOCS=true
             - DEPLOY_DOCS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
         # Only build the docs on Linux cron jobs
         - name: "Linux (cron - build docs + package)"
           os: linux
-          if: type = cron
+          if: type != cron
           env:
             - BUILD_DOCS=true
             - DEPLOY_DOCS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
         - PATH="$INSTALLDIR/bin:$PATH"
         - BUILD_DOCS=false
         - DEPLOY_DOCS=false
+        - PACKAGE=false
         - TEST=false
         - CCACHE_MAXSIZE=200M
         - CCACHE_COMPRESS=true
@@ -50,19 +51,20 @@ matrix:
         - name: "Linux (compile only)"
           os: linux
           if: type != cron
-        - name: "Linux (cron)"
+        - name: "Linux (cron - test)"
           os: linux
           if: type = cron
           env:
             - TEST="true"
         # Only build the docs on Linux cron jobs
-        - name: "Linux (cron - build docs)"
+        - name: "Linux (cron - build docs + package)"
           os: linux
           if: type = cron
           env:
             - BUILD_DOCS=true
             - DEPLOY_DOCS=true
             - HTML_BUILDDIR="build/doc/rst/html"
+            - PACKAGE=true
 
 # Setup the build environment
 before_install:
@@ -132,13 +134,19 @@ script:
         cmake --build . --target docs_pdf;
         cmake --build . --target docs_pdf_shrink;
       fi
+    # Make source tarballs
+    - if [[ "$PACKAGE" == "true" ]]; then
+        cmake --build . --target gmt_release;
+        cmake --build . --target gmt_release_tar;
+        md5sum gmt-*.tar gmt-*.tar.gz gmt-*.tar.xz
+      fi
     - set +e
     - cd ..
 
 # Things to do if the build is successful
 after_success:
     - if [ "$DEPLOY_DOCS" == "true" ]; then
-        git clone --branch=1.0.0 --depth=1 https://github.com/fatiando/continuous-integration.git;
+        git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git;
       fi
 
 # Deploy build artifacts to external services


### PR DESCRIPTION
The PR makes source packages tarballs on Linux CI nightly, to test if changing CMakeLists.txt breaks packaging.