### PR TITLE
Make macOS bundle on macOS CI

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
 # Mac - Build docs
 ########################################################################################
 - job:
-  displayName: 'Mac | Build docs'
+  displayName: 'Mac | Build docs + Package'
   condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
@@ -69,6 +69,13 @@ jobs:
       cmake --build . --target docs_html
       cmake --build . --target docs_man
     displayName: Build documentations
+
+  - bash: |
+      cmake --build . --target gmt_release
+      cmake --build . --target gmt_release_tar
+      cpack -G Bundle
+      md5sum GMT-*.dmg
+    displayName: Package GMT
 
 # Mac - Test
 ########################################################################################

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Build docs + Package'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.13'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -23,6 +23,7 @@ jobs:
 
   variables:
     BUILD_DOCS: false
+    PACKAGE: false
     TEST: false
 
   steps:
@@ -48,6 +49,7 @@ jobs:
 
   variables:
     BUILD_DOCS: true
+    PACKAGE: true
     TEST: false
 
   steps:
@@ -89,6 +91,7 @@ jobs:
 
   variables:
     BUILD_DOCS: false
+    PACKAGE: false
     TEST: true
 
   steps:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -75,7 +75,7 @@ jobs:
       cmake --build . --target gmt_release
       cmake --build . --target gmt_release_tar
       cpack -G Bundle
-      md5sum GMT-*.dmg
+      md5sum gmt-*.tar gmt-*.tar.gz gmt-*.tar.xz GMT-*.dmg
     displayName: Package GMT
 
 # Mac - Test

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
       gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -Vd && gmt end
     displayName: Check a few simple commands
 
-# Mac - Build docs
+# Mac - Build docs + Package
 ########################################################################################
 - job:
   displayName: 'Mac | Build docs + Package'
@@ -71,6 +71,7 @@ jobs:
     displayName: Build documentations
 
   - bash: |
+      cd build
       cmake --build . --target gmt_release
       cmake --build . --target gmt_release_tar
       cpack -G Bundle

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -42,7 +42,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Build docs + Package'
-  condition: ne(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.13'

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -20,6 +20,12 @@ steps:
   displayName: Install dependencies required by building docs
   condition: eq(variables['BUILD_DOCS'], true)
 
+- bash: |
+    set -x -e
+    brew install gnu-tar md5sha1sum
+  displayName: Install dependencies required by packaging
+  condition: eq(variables['PACKAGE'], true)
+
 - bash: echo "##vso[task.setvariable variable=INSTALLDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir"
   displayName: Set install location
 


### PR DESCRIPTION
Let macOS CI build source tarballs and macOS bundle (dmg file) nightly, to avoid any changes breaking the packaging process.

Now we have a nightly macOS bundle. After confirming that the bundle works for everyone, we can upload it somewhere.
