### PR TITLE
Use mergesort in gmtspatial NN so results are stable

### DIFF
--- a/src/gmt_config.h.in
+++ b/src/gmt_config.h.in
@@ -128,6 +128,7 @@
 #cmakedefine HAVE_POPEN
 #cmakedefine HAVE__POPEN
 #cmakedefine HAVE_POSIX_MEMALIGN 1
+#cmakedefine HAVE_MERGESORT
 #cmakedefine HAVE_QSORT_R_GLIBC
 #cmakedefine HAVE_SETLOCALE
 #cmakedefine HAVE__SETMODE

--- a/src/gmtspatial.c
+++ b/src/gmtspatial.c
@@ -146,6 +146,18 @@ struct PAIR {
 	uint64_t pos;
 };
 
+#ifdef __APPLE__
+/* macOX has it built in, so ensure we define this flag */
+#define HAVE_MERGESORT
+#endif
+
+#ifndef _WIN32	/* Not ready to test this on Windows */
+#ifndef HAVE_MERGESORT
+#warning "Include mergesort since not supported by standard library"
+#include "mergesort.c"
+#endif
+#endif
+
 GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
 	struct GMTSPATIAL_CTRL *C;
 	

--- a/src/gmtspatial.c
+++ b/src/gmtspatial.c
@@ -628,14 +628,19 @@ GMT_LOCAL struct NN_DIST *NNA_update_dist (struct GMT_CTRL *GMT, struct NN_DIST 
 		}
 	}
 	gmt_M_free (GMT, distance);
+#ifndef _WIN32
+	/* Prefer mergesort since qsort is not stable for equalities */
+	mergesort (P, np, sizeof (struct NN_DIST), compare_nn_points);	/* Sort on small to large distances */
+#else
 	qsort (P, np, sizeof (struct NN_DIST), compare_nn_points);	/* Sort on small to large distances */
+#endif
 	for (k = np; k > 0 && gmt_M_is_dnan (P[k-1].distance); k--);	/* Skip the NaN distances that were placed at end */
 	*n_points = k;	/* Update point count */
 #ifdef DEBUG
 	if (gmt_M_is_verbose (GMT, GMT_MSG_DEBUG)) {
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "===> Iteration = %d\n", iteration);
 		for (k = 0; k < (int64_t)(*n_points); k++)
-			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "%6d\tID=%6d\tNeighbor=%6d\tDistance = %g\n", (int)k, (int)P[k].ID, P[k].neighbor, P[k].distance);
+			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "%6d\tID=%6d\tNeighbor=%6d\tDistance = %.12g\n", (int)k, (int)P[k].ID, P[k].neighbor, P[k].distance);
 	}
 	iteration++;
 #endif
@@ -685,8 +690,21 @@ GMT_LOCAL struct NN_DIST *NNA_init_dist (struct GMT_CTRL *GMT, struct GMT_DATASE
 		}
 	}
 	gmt_M_free (GMT, distance);
+#ifndef _WIN32
+	/* Prefer mergesort since qsort is not stable for equalities */
+	mergesort (P, np, sizeof (struct NN_DIST), compare_nn_points);
+#else
+	GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Under Windows, sorting is done by qsort (unstable) since mergesort (stable) is not available.\n");
 	qsort (P, np, sizeof (struct NN_DIST), compare_nn_points);
+#endif
 	*n_points = (uint64_t)np;
+#ifdef DEBUG
+	if (gmt_M_is_verbose (GMT, GMT_MSG_DEBUG)) {
+		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "===> Initialization\n");
+		for (k = 0; k < (int64_t)(*n_points); k++)
+			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "%6d\tID=%6d\tNeighbor=%6d\tDistance = %.12g\n", (int)k, (int)P[k].ID, P[k].neighbor, P[k].distance);
+	}
+#endif
 	return (P);
 }
 
@@ -708,7 +726,12 @@ GMT_LOCAL struct NN_INFO *NNA_update_info (struct GMT_CTRL *GMT, struct NN_INFO 
 		info[k].sort_rec = k;
 		info[k].orig_rec = int64_abs (NN_dist[k].ID);
 	}
+#ifndef _WIN32
+	/* Prefer mergesort since qsort is not stable for equalities */
+	mergesort (info, n_points, sizeof (struct NN_INFO), compare_nn_info);
+#else
 	qsort (info, n_points, sizeof (struct NN_INFO), compare_nn_info);
+#endif
 	/* Now, I[k].sort_rec will take the original record # k and return the corresponding record in the sorted array */
 	return (info);
 }
@@ -1137,7 +1160,7 @@ int GMT_gmtspatial (void *V_API, int mode, void *args) {
 	/* OK, with data in hand we can do some damage */
 	
 	if (Ctrl->A.active) {	/* Nearest neighbor analysis. We compute distances between all point pairs and sort on minimum distance */
-		uint64_t n_points, k, a, b, n, col;
+		uint64_t n_points, k, a, b, n, col, n_pairs;
 		double A[3], B[3], w, iw, d_bar, out[7];
 		struct NN_DIST *NN_dist = NULL;
 		struct NN_INFO  *NN_info = NULL;
@@ -1168,15 +1191,15 @@ int GMT_gmtspatial (void *V_API, int mode, void *args) {
 			n = 0;
 			while (n < n_points && NN_dist[n].distance < Ctrl->A.min_dist) n++;	/* Find # of pairs that are too close together */
 			while (n) {	/* Must do more combining since n pairs exceed threshold distance */
-				GMT_Report (API, GMT_MSG_VERBOSE, "NNA Found %" PRIu64 " points, %" PRIu64 " pairs are too close and will be combined by their weighted average\n", n_points, n/2);
 				if (Ctrl->A.mode == 2) {
 					GMT_Report (API, GMT_MSG_VERBOSE, "Slow mode: Replace the single closest pair with its weighted average, then redo NNA\n");
 					n = 1;
 				}
-				for (k = 0; k < n; k++) {	/* Loop over pairs that are too close */
+				for (k = n_pairs = 0; k < n; k++) {	/* Loop over pairs that are too close */
 					if (gmt_M_is_dnan (NN_dist[k].distance)) continue;	/* Already processed */
 					a = k;	/* The current point */
 					b = NN_info[int64_abs(NN_dist[a].neighbor)].sort_rec;	/* a's neighbor location in the sorted NN_dist array */
+					GMT_Report (API, GMT_MSG_DEBUG, "Replace pair %" PRIu64 " and %" PRIu64 " with its weighted average location\n", a, b);
 					w = NN_dist[a].data[GMT_W] + NN_dist[b].data[GMT_W];	/* Weight sum */
 					iw = 1.0 / w;	/* Inverse weight for scaling */
 					/* Compute weighted average z */
@@ -1197,7 +1220,9 @@ int GMT_gmtspatial (void *V_API, int mode, void *args) {
 					NN_dist[a].data[GMT_W] = 0.5 * w;	/* Replace with the average weight */
 					NN_dist[a].ID = -int64_abs (NN_dist[a].ID);	/* Negative means it was averaged with other points */
 					NN_dist[b].distance = GMT->session.d_NaN;	/* Flag this point as used.  NNA_update_dist will sort it and place all NaNs at the end */
+					n_pairs++;
 				}
+				GMT_Report (API, GMT_MSG_VERBOSE, "NNA Found %" PRIu64 " points, %" PRIu64 " pairs were too close and were replaced by their weighted average\n", n_points, n_pairs);
 				NN_dist = NNA_update_dist (GMT, NN_dist, &n_points);		/* Return recomputed array of NN NN_dist sorted on smallest distances */
 				NN_info = NNA_update_info (GMT, NN_info, NN_dist, n_points);	/* Return resorted array of NN ID lookups */
 				n = 0;

--- a/src/mergesort.c
+++ b/src/mergesort.c
@@ -31,7 +31,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-#include "util.h"
+//#include "util.h"
 
 #if defined(LIBC_SCCS) && !defined(lint)
 static char sccsid[] = "@(#)merge.c     8.2 (Berkeley) 2/14/94";

--- a/src/mergesort.c
+++ b/src/mergesort.c
@@ -37,10 +37,6 @@
 static char sccsid[] = "@(#)merge.c     8.2 (Berkeley) 2/14/94";
 #endif /* LIBC_SCCS and not lint */
 
-#ifdef HAVE_MERGESORT
-#undef yasm__mergesort
-#endif
-
 #ifndef HAVE_MERGESORT
 /*
  * Hybrid exponential search/linear search merge sort with hybrid
@@ -98,13 +94,9 @@ static void insertionsort(unsigned char *, size_t, size_t,
 /*
  * Arguments are as for qsort.
  */
-int
-yasm__mergesort(void *base, size_t nmemb, size_t size,
+int mergesort(void *base, size_t nmemb, size_t size,
                 int (*cmp)(const void *, const void *))
 {
-#ifdef HAVE_MERGESORT
-    return mergesort(base, nmemb, size, cmp);
-#else
         size_t i;
         int sense;
         int big, iflag;

--- a/src/mergesort.c
+++ b/src/mergesort.c
@@ -31,13 +31,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-//#include "util.h"
 
-#if defined(LIBC_SCCS) && !defined(lint)
-static char sccsid[] = "@(#)merge.c     8.2 (Berkeley) 2/14/94";
-#endif /* LIBC_SCCS and not lint */
-
-#ifndef HAVE_MERGESORT
 /*
  * Hybrid exponential search/linear search merge sort with hybrid
  * natural/pairwise first pass.  Requires about .3% more comparisons
@@ -89,7 +83,6 @@ static void insertionsort(unsigned char *, size_t, size_t,
 #define EVAL(p) (unsigned char **)                                              \
         ((unsigned char *)0 +                                                   \
             (((unsigned char *)p + PSIZE - 1 - (unsigned char *) 0) & ~(PSIZE - 1)))
-#endif  /*HAVE_MERGESORT*/
 
 /*
  * Arguments are as for qsort.
@@ -230,10 +223,7 @@ COPY:                           b = t;
         }
         free(list2);
         return (0);
-#endif  /*HAVE_MERGESORT*/
 }
-
-#ifndef HAVE_MERGESORT
 
 #define swap(a, b) {                                    \
                 s = b;                                  \
@@ -350,4 +340,3 @@ insertionsort(unsigned char *a, size_t n, size_t size,
                         swap(u, t);
                 }
 }
-#endif  /*HAVE_MERGESORT*/

--- a/src/mergesort.c
+++ b/src/mergesort.c
@@ -1,0 +1,361 @@
+/*
+ * mergesort() implementation for systems that don't have it.
+ *
+ * Copyright (c) 1992, 1993
+ *      The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Peter McIlroy.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include "util.h"
+
+#if defined(LIBC_SCCS) && !defined(lint)
+static char sccsid[] = "@(#)merge.c     8.2 (Berkeley) 2/14/94";
+#endif /* LIBC_SCCS and not lint */
+
+#ifdef HAVE_MERGESORT
+#undef yasm__mergesort
+#endif
+
+#ifndef HAVE_MERGESORT
+/*
+ * Hybrid exponential search/linear search merge sort with hybrid
+ * natural/pairwise first pass.  Requires about .3% more comparisons
+ * for random data than LSMS with pairwise first pass alone.
+ * It works for objects as small as two bytes.
+ */
+
+#define NATURAL
+#define THRESHOLD 16    /* Best choice for natural merge cut-off. */
+
+/* #define NATURAL to get hybrid natural merge.
+ * (The default is pairwise merging.)
+ */
+
+#include <errno.h>
+#include <string.h>
+
+static void setup(unsigned char *, unsigned char *, size_t, size_t,
+                  int (*)(const void *, const void *));
+static void insertionsort(unsigned char *, size_t, size_t,
+                          int (*)(const void *, const void *));
+
+#define ISIZE sizeof(int)
+#define PSIZE sizeof(unsigned char *)
+#define ICOPY_LIST(src, dst, last)                              \
+        do                                                      \
+        *(int*)dst = *(int*)src, src += ISIZE, dst += ISIZE;    \
+        while(src < last)
+#define ICOPY_ELT(src, dst, i)                                  \
+        do                                                      \
+        *(int*) dst = *(int*) src, src += ISIZE, dst += ISIZE;  \
+        while (i -= ISIZE)
+
+#define CCOPY_LIST(src, dst, last)              \
+        do                                      \
+                *dst++ = *src++;                \
+        while (src < last)
+#define CCOPY_ELT(src, dst, i)                  \
+        do                                      \
+                *dst++ = *src++;                \
+        while (i -= 1)
+
+/*
+ * Find the next possible pointer head.  (Trickery for forcing an array
+ * to do double duty as a linked list when objects do not align with word
+ * boundaries.
+ */
+/* Assumption: PSIZE is a power of 2. */
+#define EVAL(p) (unsigned char **)                                              \
+        ((unsigned char *)0 +                                                   \
+            (((unsigned char *)p + PSIZE - 1 - (unsigned char *) 0) & ~(PSIZE - 1)))
+#endif  /*HAVE_MERGESORT*/
+
+/*
+ * Arguments are as for qsort.
+ */
+int
+yasm__mergesort(void *base, size_t nmemb, size_t size,
+                int (*cmp)(const void *, const void *))
+{
+#ifdef HAVE_MERGESORT
+    return mergesort(base, nmemb, size, cmp);
+#else
+        size_t i;
+        int sense;
+        int big, iflag;
+        unsigned char *f1, *f2, *t, *b, *tp2, *q, *l1, *l2;
+        unsigned char *list2, *list1, *p2, *p, *last, **p1;
+
+        if (size < PSIZE / 2) {         /* Pointers must fit into 2 * size. */
+#ifdef EINVAL
+                errno = EINVAL;
+#endif
+                return (-1);
+        }
+
+        if (nmemb == 0)
+                return (0);
+
+        /*
+         * XXX
+         * Stupid subtraction for the Cray.
+         */
+        iflag = 0;
+        if (!(size % ISIZE) && !(((char *)base - (char *)0) % ISIZE))
+                iflag = 1;
+
+        if ((list2 = malloc(nmemb * size + PSIZE)) == NULL)
+                return (-1);
+
+        list1 = base;
+        setup(list1, list2, nmemb, size, cmp);
+        last = list2 + nmemb * size;
+        i = 0;
+        big = 0;
+        while (*EVAL(list2) != last) {
+            l2 = list1;
+            p1 = EVAL(list1);
+            for (tp2 = p2 = list2; p2 != last; p1 = EVAL(l2)) {
+                p2 = *EVAL(p2);
+                f1 = l2;
+                f2 = l1 = list1 + (p2 - list2);
+                if (p2 != last)
+                        p2 = *EVAL(p2);
+                l2 = list1 + (p2 - list2);
+                while (f1 < l1 && f2 < l2) {
+                        if ((*cmp)(f1, f2) <= 0) {
+                                q = f2;
+                                b = f1, t = l1;
+                                sense = -1;
+                        } else {
+                                q = f1;
+                                b = f2, t = l2;
+                                sense = 0;
+                        }
+                        if (!big) {     /* here i = 0 */
+                                while ((b += size) < t && cmp(q, b) >sense)
+                                        if (++i == 6) {
+                                                big = 1;
+                                                goto EXPONENTIAL;
+                                        }
+                        } else {
+EXPONENTIAL:                    for (i = size; ; i <<= 1)
+                                        if ((p = (b + i)) >= t) {
+                                                if ((p = t - size) > b &&
+                                                    (*cmp)(q, p) <= sense)
+                                                        t = p;
+                                                else
+                                                        b = p;
+                                                break;
+                                        } else if ((*cmp)(q, p) <= sense) {
+                                                t = p;
+                                                if (i == size)
+                                                        big = 0;
+                                                goto FASTCASE;
+                                        } else
+                                                b = p;
+                                while (t > b+size) {
+                                        i = (((t - b) / size) >> 1) * size;
+                                        if ((*cmp)(q, p = b + i) <= sense)
+                                                t = p;
+                                        else
+                                                b = p;
+                                }
+                                goto COPY;
+FASTCASE:                       while (i > size)
+                                        if ((*cmp)(q,
+                                                p = b + (i >>= 1)) <= sense)
+                                                t = p;
+                                        else
+                                                b = p;
+COPY:                           b = t;
+                        }
+                        i = size;
+                        if (q == f1) {
+                                if (iflag) {
+                                        ICOPY_LIST(f2, tp2, b);
+                                        ICOPY_ELT(f1, tp2, i);
+                                } else {
+                                        CCOPY_LIST(f2, tp2, b);
+                                        CCOPY_ELT(f1, tp2, i);
+                                }
+                        } else {
+                                if (iflag) {
+                                        ICOPY_LIST(f1, tp2, b);
+                                        ICOPY_ELT(f2, tp2, i);
+                                } else {
+                                        CCOPY_LIST(f1, tp2, b);
+                                        CCOPY_ELT(f2, tp2, i);
+                                }
+                        }
+                }
+                if (f2 < l2) {
+                        if (iflag)
+                                ICOPY_LIST(f2, tp2, l2);
+                        else
+                                CCOPY_LIST(f2, tp2, l2);
+                } else if (f1 < l1) {
+                        if (iflag)
+                                ICOPY_LIST(f1, tp2, l1);
+                        else
+                                CCOPY_LIST(f1, tp2, l1);
+                }
+                *p1 = l2;
+            }
+            tp2 = list1;        /* swap list1, list2 */
+            list1 = list2;
+            list2 = tp2;
+            last = list2 + nmemb*size;
+        }
+        if (base == list2) {
+                memmove(list2, list1, nmemb*size);
+                list2 = list1;
+        }
+        free(list2);
+        return (0);
+#endif  /*HAVE_MERGESORT*/
+}
+
+#ifndef HAVE_MERGESORT
+
+#define swap(a, b) {                                    \
+                s = b;                                  \
+                i = size;                               \
+                do {                                    \
+                        tmp = *a; *a++ = *s; *s++ = tmp; \
+                } while (--i);                          \
+                a -= size;                              \
+        }
+#define reverse(bot, top) {                             \
+        s = top;                                        \
+        do {                                            \
+                i = size;                               \
+                do {                                    \
+                        tmp = *bot; *bot++ = *s; *s++ = tmp; \
+                } while (--i);                          \
+                s -= size2;                             \
+        } while(bot < s);                               \
+}
+
+/*
+ * Optional hybrid natural/pairwise first pass.  Eats up list1 in runs of
+ * increasing order, list2 in a corresponding linked list.  Checks for runs
+ * when THRESHOLD/2 pairs compare with same sense.  (Only used when NATURAL
+ * is defined.  Otherwise simple pairwise merging is used.)
+ */
+void
+setup(unsigned char *list1, unsigned char *list2, size_t n, size_t size,
+      int (*cmp)(const void *, const void *))
+{
+        size_t i;
+        unsigned int tmp;
+        int length, sense;
+        size_t size2;
+        unsigned char *f1, *f2, *s, *l2, *last, *p2;
+
+        size2 = size*2;
+        if (n <= 5) {
+                insertionsort(list1, n, size, cmp);
+                *EVAL(list2) = (unsigned char*) list2 + n*size;
+                return;
+        }
+        /*
+         * Avoid running pointers out of bounds; limit n to evens
+         * for simplicity.
+         */
+        i = 4 + (n & 1);
+        insertionsort(list1 + (n - i) * size, i, size, cmp);
+        last = list1 + size * (n - i);
+        *EVAL(list2 + (last - list1)) = list2 + n * size;
+
+#ifdef NATURAL
+        p2 = list2;
+        f1 = list1;
+        sense = (cmp(f1, f1 + size) > 0);
+        for (; f1 < last; sense = !sense) {
+                length = 2;
+                                        /* Find pairs with same sense. */
+                for (f2 = f1 + size2; f2 < last; f2 += size2) {
+                        if ((cmp(f2, f2+ size) > 0) != sense)
+                                break;
+                        length += 2;
+                }
+                if (length < THRESHOLD) {               /* Pairwise merge */
+                        do {
+                                p2 = *EVAL(p2) = f1 + size2 - list1 + list2;
+                                if (sense > 0)
+                                        swap (f1, f1 + size);
+                        } while ((f1 += size2) < f2);
+                } else {                                /* Natural merge */
+                        l2 = f2;
+                        for (f2 = f1 + size2; f2 < l2; f2 += size2) {
+                                if ((cmp(f2-size, f2) > 0) != sense) {
+                                        p2 = *EVAL(p2) = f2 - list1 + list2;
+                                        if (sense > 0)
+                                                reverse(f1, f2-size);
+                                        f1 = f2;
+                                }
+                        }
+                        if (sense > 0)
+                                reverse (f1, f2-size);
+                        f1 = f2;
+                        if (f2 < last || cmp(f2 - size, f2) > 0)
+                                p2 = *EVAL(p2) = f2 - list1 + list2;
+                        else
+                                p2 = *EVAL(p2) = list2 + n*size;
+                }
+        }
+#else           /* pairwise merge only. */
+        for (f1 = list1, p2 = list2; f1 < last; f1 += size2) {
+                p2 = *EVAL(p2) = p2 + size2;
+                if (cmp (f1, f1 + size) > 0)
+                        swap(f1, f1 + size);
+        }
+#endif /* NATURAL */
+}
+
+/*
+ * This is to avoid out-of-bounds addresses in sorting the
+ * last 4 elements.
+ */
+static void
+insertionsort(unsigned char *a, size_t n, size_t size,
+              int (*cmp)(const void *, const void *))
+{
+        unsigned char *ai, *s, *t, *u, tmp;
+        size_t i;
+
+        for (ai = a+size; --n >= 1; ai += size)
+                for (t = ai; t > a; t -= size) {
+                        u = t - size;
+                        if (cmp(u, t) <= 0)
+                                break;
+                        swap(u, t);
+                }
+}
+#endif  /*HAVE_MERGESORT*/


### PR DESCRIPTION
We found that the nearest neighbor analysis gave slightly different results on macOS and Linux, and traced it to the fact that _qsort_ is an unstable algorithm (if given identical items then the order is undefined).  Thus, we switch to _mergesort_ (which is stable) in this application.  Exception is (for now) Windows which appears not to have a built-in mergesort function.  See #950 for context.
