### PR TITLE
Build documentations on Windows CI

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -130,7 +130,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Windows | Compile + Build Docs + Package'
-  #condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
   timeoutInMinutes: 120
 
   pool:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -130,7 +130,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Windows | Compile + Build Docs + Package'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  #condition: eq(variables['Build.Reason'], 'Schedule')
   timeoutInMinutes: 120
 
   pool:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -126,10 +126,10 @@ jobs:
     condition: succeededOrFailed()
     displayName: Upload test coverage
 
-# Windows - Compile + Package
+# Windows - Compile + Build Docs + Package
 ########################################################################################
 - job:
-  displayName: 'Windows | Compile + Package'
+  displayName: 'Windows | Compile + Build Docs + Package'
   condition: eq(variables['Build.Reason'], 'Schedule')
   timeoutInMinutes: 120
 
@@ -137,7 +137,8 @@ jobs:
     vmImage: 'vs2017-win2016'
 
   variables:
-    BUILD_DOCS: false
+    BUILD_DOCS: true
+    PACKAGE: true
     TEST: false
 
   steps:

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -28,6 +28,7 @@ steps:
 - bash: |
     set -x -e
     pip install --user sphinx
+    echo "##vso[task.prependpath]C:\\Users\\VssAdministrator\\AppData\\Roaming\\Python\\Python36\\Scripts"
   displayName: Install dependencies for building documentations
   condition: eq(variables['BUILD_DOCS'], true)
 

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -25,6 +25,12 @@ steps:
     choco install ghostscript ninja
   displayName: Install dependencies via chocolatey
 
+- bash: |
+    set -x -e
+    pip install --user sphinx
+  displayName: Install dependencies for building documentations
+  condition: eq(variables["BUILD_DOCS"], true)
+
 - bash: echo "##vso[task.setvariable variable=INSTALLDIR]D:/a/1/s/gmt-install-dir"
   displayName: Set install location
 
@@ -62,5 +68,16 @@ steps:
 - bash: |
     set -x -e
     cd build
+    cmake --build . --target docs_html_depends
+    cmake --build . --target docs_man_depends
+    cmake --build . --target docs_html
+    cmake --build . --target docs_man
+  displayName: Build documentations
+  condition: eq(variables["BUILD_DOCS", true])
+
+- bash: |
+    set -x -e
+    cd build
     cmake --build . --target package
   displayName: Package GMT
+  condition: eq(variable["PACKAGE", true])

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -29,7 +29,7 @@ steps:
     set -x -e
     pip install --user sphinx
   displayName: Install dependencies for building documentations
-  condition: eq(variables["BUILD_DOCS"], true)
+  condition: eq(variables['BUILD_DOCS'], true)
 
 - bash: echo "##vso[task.setvariable variable=INSTALLDIR]D:/a/1/s/gmt-install-dir"
   displayName: Set install location

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -73,11 +73,11 @@ steps:
     cmake --build . --target docs_html
     cmake --build . --target docs_man
   displayName: Build documentations
-  condition: eq(variables["BUILD_DOCS", true])
+  condition: eq(variables['BUILD_DOCS', true])
 
 - bash: |
     set -x -e
     cd build
     cmake --build . --target package
   displayName: Package GMT
-  condition: eq(variable["PACKAGE", true])
+  condition: eq(variables['PACKAGE', true])

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -73,11 +73,11 @@ steps:
     cmake --build . --target docs_html
     cmake --build . --target docs_man
   displayName: Build documentations
-  condition: eq(variables['BUILD_DOCS', true])
+  condition: eq(variables['BUILD_DOCS'], true)
 
 - bash: |
     set -x -e
     cd build
     cmake --build . --target package
   displayName: Package GMT
-  condition: eq(variables['PACKAGE', true])
+  condition: eq(variables['PACKAGE'], true)


### PR DESCRIPTION
Build documentations on Windows CI nightly.

What we do with Windows CI now:

- compile source codes
- build documentations
- make windows installer

After checking if the installer work (I believe there must be some problems with the installer), we can upload it somewhere in the future.