### PR TITLE
Eliminate use of bc in scripts

### DIFF
--- a/doc/scripts/GMT_App_E.sh
+++ b/doc/scripts/GMT_App_E.sh
@@ -26,7 +26,7 @@ for iy in 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0
 do
 	for ix in 1 2 3 4 5 6
 	do
-		p=`echo "$iy * 6 + $ix" | bc`
+		let p=iy*6+ix
 		gmt plot -R0/$xwidth/0/$ywidth -Jx1i -Gp$p+r300 tt.App_E.d -X${x}i -Y${y}i
 		gmt plot -Wthinner -L tt.App_E.d 
 		gmt plot -GP$p+r300 tt.App_E.d -X${xwidth}i 

--- a/doc/scripts/GMT_App_G.sh
+++ b/doc/scripts/GMT_App_G.sh
@@ -32,13 +32,13 @@ gmt plot <<EOF
 5.4	0
 EOF
 
-i=1
+let i=1
 while [ $i -le 17 ]
 do
-	i1=`echo "$i - 1" | bc`
-	i2=`echo "$i1 + 17" | bc`
+	i1=$(( i-1 ))
+	i2=$(( i1+17 ))
 	k1=$i
-	k2=`echo "$i + 17" | bc`
+	k2=$(( i+17 ))
 
 	f1=`sed -n ${k1}p tt.d`
 	f2=`sed -n ${k2}p tt.d`
@@ -53,7 +53,7 @@ do
 2.85	0.03	10p,$fn2	BC	$i2
 3.1	0.03	10p,$i2		BL	$f2
 EOF
-	i=`echo "$i + 1" | bc`
+	let i=i+1
 done
 
 gmt text -Y${dy}i -F+f+j <<EOF

--- a/doc/scripts/GMT_App_M_1a.sh
+++ b/doc/scripts/GMT_App_M_1a.sh
@@ -42,7 +42,7 @@ n=`cat tt.lis | wc -l`
 let n2=n/2
 # dy is line spacing and y0 is total box height
 dy=0.75
-y0=`echo "$n2 * $dy * 0.5" | bc`
+y0=`gmt math -Q $n2 $dy MUL 0.5 MUL =`
 
 gmt begin GMT_App_M_1a ps
 gmt set MAP_FRAME_PEN thinner FONT_ANNOT_PRIMARY 8p MAP_TICK_LENGTH_PRIMARY 0.1i MAP_ANNOT_OFFSET_PRIMARY 0.04i

--- a/doc/scripts/GMT_App_M_1b.sh
+++ b/doc/scripts/GMT_App_M_1b.sh
@@ -41,7 +41,7 @@ n=`cat tt.lis | wc -l`
 let n2=n/2
 # dy is line spacing and y0 is total box height
 dy=0.75
-y0=`echo "$n2 * $dy * 0.5" | bc`
+y0=`gmt math -Q $n2 $dy MUL 0.5 MUL =`
 
 gmt begin GMT_App_M_1b ps
 gmt set MAP_FRAME_PEN thinner FONT_ANNOT_PRIMARY 8p MAP_TICK_LENGTH_PRIMARY 0.1i MAP_ANNOT_OFFSET_PRIMARY 0.04i

--- a/doc/scripts/GMT_App_M_1c.sh
+++ b/doc/scripts/GMT_App_M_1c.sh
@@ -38,7 +38,7 @@ let n2=n/2
 let n2=n
 # dy is line spacing and y0 is total box height
 dy=0.75
-y0=`echo "$n2 * $dy * 0.5" | bc`
+y0=`gmt math -Q $n2 $dy MUL 0.5 MUL =`
 
 gmt begin GMT_App_M_1c ps
 gmt set MAP_FRAME_PEN thinner FONT_ANNOT_PRIMARY 8p MAP_TICK_LENGTH_PRIMARY 0.1i MAP_ANNOT_OFFSET_PRIMARY 0.04i


### PR DESCRIPTION
For integer calculations we can use bash arithmetic and for floating point we can ust gmt math. We found bc is not available under Windows bash.
