### PR TITLE
Let gmtselect and GMT_inonout consider holes

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -10556,6 +10556,18 @@ unsigned int gmt_inonout (struct GMT_CTRL *GMT, double x, double y, struct GMT_D
 		if (side_h == GMT_INSIDE) side = GMT_OUTSIDE;	/* Inside one of the holes, hence outside polygon; go to next perimeter polygon */
 		if (side_h == GMT_ONEDGE) side = GMT_ONEDGE;	/* On path of one of the holes, hence on polygon path; update side */
 	}
+	else if ((H = SH->next)) {	/* Must also check non ogr polygones for holes */
+		side_h = GMT_OUTSIDE;	/* We are outside a hole until we are found to be inside it */
+		SHnext = gmt_get_DS_hidden (H);
+		while (side_h == GMT_OUTSIDE && H && SHnext->pol_mode == GMT_IS_HOLE) {	/* Found a hole */
+			/* Must check if point is inside this hole polygon */
+			side_h = support_inonout_sub (GMT, x, y, H);
+			H = SHnext->next;	/* Move to next polygon hole */
+			if (H) SHnext = gmt_get_DS_hidden (H);
+		}
+		if (side_h == GMT_INSIDE) side = GMT_OUTSIDE;	/* Inside one of the holes, hence outside polygon; go to next perimeter polygon */
+		if (side_h == GMT_ONEDGE) side = GMT_ONEDGE;	/* On path of one of the holes, hence on polygon path; update side */
+	}
 
 	/* Here, point is inside or on edge, we return the value */
 	return (side);


### PR DESCRIPTION
The _GMT_inonout_ function did consider holes in polygons but only for OGR polygons.  Regular ASCII files with holes flagged via **-Ph** in the segment header were not checked.  Addresses issue in #896.

