### PR TITLE
Warn if user uses classic mode name module in modern mode command

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12734,7 +12734,7 @@ void gmt_check_if_modern_mode_oneliner (struct GMTAPI_CTRL *API, int argc, char 
 	if (API->GMT->current.setting.run_mode == GMT_MODERN && !strncmp (argv[k], "ps", 2U)) {	/* Gave classic ps* name in modern mode */
 		char not_used[GMT_LEN32] = {""};
 		const char *mod_name = gmt_current_name (argv[k], not_used);
-		GMT_Report (API, GMT_MSG_VERBOSE, "Detected a classic module name (%s) in modern mode - please use the modern mode name %s instead\n", argv[k], mod_name);
+		GMT_Report (API, GMT_MSG_VERBOSE, "Detected a classic module name (%s) in modern mode - please use the modern mode name %s instead.\n", argv[k], mod_name);
 	}
 	if (API->GMT->current.setting.use_modern_name) {
 		if (n_args == 0) {	/* Gave none or a single argument */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12731,8 +12731,10 @@ void gmt_check_if_modern_mode_oneliner (struct GMTAPI_CTRL *API, int argc, char 
 	}
 	API->GMT->current.setting.use_modern_name = gmtlib_is_modern_name (API, argv[k]);
 	
-	if (API->GMT->current.setting.run_mode == GMT_MODERN && !strncmp (argv[k], "ps", 2U)) {
-		GMT_Report (API, GMT_MSG_VERBOSE, "Module name %s is a classic mode name - please use modern mode names instead\n", argv[k]);
+	if (API->GMT->current.setting.run_mode == GMT_MODERN && !strncmp (argv[k], "ps", 2U)) {	/* Gave classic ps* name in modern mode */
+		char not_used[GMT_LEN32] = {""};
+		const char *mod_name = gmt_current_name (argv[k], not_used);
+		GMT_Report (API, GMT_MSG_VERBOSE, "Detected a classic module name (%s) in modern mode - please use the modern mode name %s instead\n", argv[k], mod_name);
 	}
 	if (API->GMT->current.setting.use_modern_name) {
 		if (n_args == 0) {	/* Gave none or a single argument */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12731,6 +12731,9 @@ void gmt_check_if_modern_mode_oneliner (struct GMTAPI_CTRL *API, int argc, char 
 	}
 	API->GMT->current.setting.use_modern_name = gmtlib_is_modern_name (API, argv[k]);
 	
+	if (API->GMT->current.setting.run_mode == GMT_MODERN && !strncmp (argv[k], "ps", 2U)) {
+		GMT_Report (API, GMT_MSG_VERBOSE, "Module name %s is a classic mode name - please use modern mode names instead\n", argv[k]);
+	}
 	if (API->GMT->current.setting.use_modern_name) {
 		if (n_args == 0) {	/* Gave none or a single argument */
 			if (API->GMT->current.setting.run_mode == GMT_CLASSIC)


### PR DESCRIPTION
We issue a warning if a classic mode module name is used in a modern mode workflow, but we continue execution.  The warning requires _-V_ to be visible.  For instance

```
gmt begin
   gmt pscoast -Rg -JH0/6i -Gred -B -V
gmt end
```

will print

> gmt [WARNING]: Detected a classic module name (pscoast) in modern mode - please use the modern mode name coast instead
