### PR TITLE
Update macOS CI settings

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,16 +27,7 @@ jobs:
     TEST: false
 
   steps:
-
-  # Setup and compile GMT
   - template: ci/azure-pipelines-mac.yml
-
-  - bash: |
-      set -x -e
-      gmt defaults -Vd
-      gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
-      gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -Vd && gmt end
-    displayName: Check a few simple commands
 
 # Mac - Build docs + Package
 ########################################################################################
@@ -53,32 +44,7 @@ jobs:
     TEST: false
 
   steps:
-
-  # Setup and compile GMT
   - template: ci/azure-pipelines-mac.yml
-
-  - bash: |
-      set -x -e
-      gmt defaults -Vd
-      gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
-      gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -Vd && gmt end
-    displayName: Check a few simple commands
-
-  - bash: |
-      cd build
-      cmake --build . --target docs_html_depends
-      cmake --build . --target docs_man_depends
-      cmake --build . --target docs_html
-      cmake --build . --target docs_man
-    displayName: Build documentations
-
-  - bash: |
-      cd build
-      cmake --build . --target gmt_release
-      cmake --build . --target gmt_release_tar
-      cpack -G Bundle
-      md5sum gmt-*.tar gmt-*.tar.gz gmt-*.tar.xz GMT-*.dmg
-    displayName: Package GMT
 
 # Mac - Test
 ########################################################################################
@@ -95,36 +61,7 @@ jobs:
     TEST: true
 
   steps:
-
-  # Setup and compile GMT
   - template: ci/azure-pipelines-mac.yml
-
-  - bash: |
-      set -x -e
-      gmt defaults -Vd
-      gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
-      gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -Vd && gmt end
-    displayName: Check a few simple commands
-
-  # Run the full tests only if this is a scheduled build
-  - bash: |
-      set -x -e
-      cd build
-      # Download remote files before testing, see #939.
-      curl http://www.soest.hawaii.edu/gmt/data/gmt_md5_server.txt | awk 'NF==3 && $1!~/earth/ {print "@"$1}' | xargs gmt which -Gc
-      gmt which -Gu @earth_relief_02m @earth_relief_05m
-      ctest --output-on-failure --force-new-ctest-process -j4
-    displayName: Full tests
-
-  # Upload test coverage even if build fails. Keep separate to make sure this task fails
-  # if the tests fail.
-  - bash: |
-      set -x -e
-      bash <(curl -s https://codecov.io/bash)
-    env:
-      CODECOV_TOKEN: $(codecov.token)
-    condition: succeededOrFailed()
-    displayName: Upload test coverage
 
 # Windows - Compile + Build Docs + Package
 ########################################################################################

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Build docs + Package'
-  #condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.14'
@@ -50,7 +50,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Test'
-  #condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.14'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
   condition: ne(variables['Build.Reason'], 'Schedule')
 
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
 
   variables:
     BUILD_DOCS: false
@@ -45,7 +45,7 @@ jobs:
   condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
 
   variables:
     BUILD_DOCS: true
@@ -87,7 +87,7 @@ jobs:
   condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
 
   variables:
     BUILD_DOCS: false

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Build docs + Package'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  #condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.14'
@@ -50,7 +50,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Test'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  #condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.14'

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -91,6 +91,7 @@ steps:
     cmake --build . --target gmt_release
     cmake --build . --target gmt_release_tar
     cpack -G Bundle
-    md5sum gmt-*.tar gmt-*.tar.gz gmt-*.tar.xz GMT-*.dmg
+    ls -l gmt-*.tar.gz gmt-*.tar.xz GMT-*.dmg
+    md5sum gmt-*.tar.gz gmt-*.tar.xz GMT-*.dmg
   displayName: Package GMT
   condition: eq(variables['PACKAGE'], true)

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -62,7 +62,7 @@ steps:
     cd build
     # Download remote files before testing, see #939.
     curl http://www.soest.hawaii.edu/gmt/data/gmt_md5_server.txt | awk 'NF==3 && $1!~/earth/ {print "@"$1}' | xargs gmt which -Gc
-    gmt which -Gu @earth_relief_02m @earth_relief_05m
+    gmt which -Gu @earth_relief_01m @earth_relief_02m @earth_relief_04m @earth_relief_05m @earth_relief_10m @earth_relief_15m
     ctest --output-on-failure --force-new-ctest-process -j4
   displayName: Full tests
   condition: eq(variables['TEST'], true)

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -1,4 +1,4 @@
-# Template for the basic Mac steps in Azure Pipelines
+# Template for macOS steps in Azure Pipelines
 
 steps:
 
@@ -10,20 +10,21 @@ steps:
 - bash: |
     set -x -e
     brew install graphicsmagick || true
-  displayName: Install dependencies required by testing
+  displayName: Install dependencies for runing tests
   condition: eq(variables['TEST'], true)
 
 - bash: |
     set -x -e
     pip3 install --user sphinx
     echo "##vso[task.prependpath]$HOME/Library/Python/3.7/bin"
-  displayName: Install dependencies required by building docs
+  displayName: Install dependencies for building documentation
   condition: eq(variables['BUILD_DOCS'], true)
 
 - bash: |
     set -x -e
+    # we need the GNU tar
     brew install gnu-tar md5sha1sum
-  displayName: Install dependencies required by packaging
+  displayName: Install dependencies for packaging
   condition: eq(variables['PACKAGE'], true)
 
 - bash: echo "##vso[task.setvariable variable=INSTALLDIR]$BUILD_SOURCESDIRECTORY/gmt-install-dir"
@@ -46,3 +47,50 @@ steps:
 
 - bash: ci/build-gmt.sh
   displayName: Compile GMT
+
+- bash: |
+    set -x -e
+    gmt --version
+    gmt defaults -Vd
+    gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -P -Vd > test.ps
+    gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -Vd && gmt end
+  displayName: Check a few simple commands
+
+# Run the full tests
+- bash: |
+    set -x -e
+    cd build
+    # Download remote files before testing, see #939.
+    curl http://www.soest.hawaii.edu/gmt/data/gmt_md5_server.txt | awk 'NF==3 && $1!~/earth/ {print "@"$1}' | xargs gmt which -Gc
+    gmt which -Gu @earth_relief_02m @earth_relief_05m
+    ctest --output-on-failure --force-new-ctest-process -j4
+  displayName: Full tests
+  condition: eq(variables['TEST'], true)
+
+# Upload test coverage even if build fails. Keep separate to make sure this task fails
+# if the tests fail.
+- bash: |
+    set -x -e
+    bash <(curl -s https://codecov.io/bash)
+  env:
+    CODECOV_TOKEN: $(codecov.token)
+  condition: and(eq(variables['TEST'], true), succeededOrFailed())
+  displayName: Upload test coverage
+
+- bash: |
+    cd build
+    cmake --build . --target docs_html_depends
+    cmake --build . --target docs_man_depends
+    cmake --build . --target docs_html
+    cmake --build . --target docs_man
+  displayName: Build documentations
+  condition: eq(variables['BUILD_DOCS'], true)
+
+- bash: |
+    cd build
+    cmake --build . --target gmt_release
+    cmake --build . --target gmt_release_tar
+    cpack -G Bundle
+    md5sum gmt-*.tar gmt-*.tar.gz gmt-*.tar.xz GMT-*.dmg
+  displayName: Package GMT
+  condition: eq(variables['PACKAGE'], true)


### PR DESCRIPTION
This PR changes macOS CI settings to avoid duplicate steps:

- Update macOS image from macOS-10.13 to macOS-10.14
- Move steps to template `ci/azure-pipelines-mac.yml`
- Download remote files before tests
- Check file size of GMT packages 