### PR TITLE
Properly extract session and graphics format for begin

### DIFF
--- a/src/begin.c
+++ b/src/begin.c
@@ -19,7 +19,7 @@
  * Version:	6 API
  *
  * Brief synopsis: gmt begin starts a modern mode session.
- *	gmt begin [<prefix>] [<format>]
+ *	gmt begin [<prefix>] [<format>] [-V<level>]
  */
 
 #include "gmt_dev.h"
@@ -66,9 +66,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
 	char p[GMT_LEN64] = {""};
 	struct GMT_OPTION *opt = NULL;
 
-	GMT->current.ps.crop_to_fit = true;	/* Default is to make a tight PDF plot */
-	if ((opt = options))	/* Gave a replacement session name */
-		opt = opt->next;
+	GMT->current.ps.crop_to_fit = true;	/* Default is to make a tight PDF plot, unless PS */
+	if ((opt = options))	/* Gave a replacement session name and possibly more */
+		opt = opt->next;	/* Skip session name */
 	if (opt && opt->option == 'V')	/* Skip any -V already processed by GMT_Parse_Common */
 		opt = opt->next;
 	if (opt) {	/* Also gave replacement primary format(s) */
@@ -86,16 +86,18 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
 
-char *get_the_options (struct GMT_OPTION *opt) {
-	/* Extract file arguments (including graphics format) from options */
+char *get_session_name_and_format (struct GMT_OPTION *opt) {
+	/* Extract session arguments (including optional graphics format) from options */
 	char buffer[GMT_LEN256] = {""};
 	bool space = false;
-	if (opt == NULL) return NULL;
-	while (opt) {
+	unsigned int n = 0;
+	if (opt == NULL) return NULL;	/* Go with the default settings */
+	while (opt && n < 2) {
 		if (opt->option == GMT_OPT_INFILE) {	/* Valid file argument */
 			if (space) strcat (buffer, " ");
 			strcat (buffer, opt->arg);
 			space = true;
+			n++;
 		}
 		opt = opt->next;
 	}
@@ -131,7 +133,7 @@ int GMT_begin (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the begin main code ----------------------------*/
 
-	arg = get_the_options (options);
+	arg = get_session_name_and_format (options);
 	if (gmt_manage_workflow (API, GMT_BEGIN_WORKFLOW, arg))
 		error = GMT_RUNTIME_ERROR;
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15202,7 +15202,7 @@ bool gmtlib_fig_is_ps (struct GMT_CTRL *GMT) {
 }
 
 GMT_LOCAL int put_session_name (struct GMTAPI_CTRL *API, char *arg) {
-	/* Write the session name to file GMT_SESSION_FILE unless default */
+	/* Write the session name to file GMT_SESSION_FILE unless default. */
 	FILE *fp = NULL;
 	char file[PATH_MAX] = {""};
 	if (arg == NULL) return GMT_NOERROR;	/* Nothing to do, which means we accept the defaults */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15571,7 +15571,7 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 			error = put_session_name (API, text);		/* Store session name */
 			API->GMT->current.setting.history_orig = API->GMT->current.setting.history;	/* Temporarily turn off history so nothing is copied into the workflow dir */
 			API->GMT->current.setting.history = GMT_HISTORY_OFF;	/* Turn off so that no history is copied into the workflow directory */
-			GMT_Report (API, GMT_MSG_DEBUG, "%s Workflow.  Session Name = %s. Directory %s %s.\n", smode[mode], API->session_name, API->gwf_dir, fstatus[2]);
+			GMT_Report (API, GMT_MSG_DEBUG, "%s Workflow.  Session ID = %s. Directory %s %s.\n", smode[mode], API->session_name, API->gwf_dir, fstatus[2]);
 			break;
 		case GMT_USE_WORKFLOW:
 			/* We always get here except when gmt begin | end are called. */
@@ -15585,7 +15585,7 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 			sprintf (file, "%s/gmt.subplot.%d", API->gwf_dir, fig);
 			if (!access (file, R_OK))	/* subplot end was never called */
 				GMT_Report (API, GMT_MSG_NORMAL, "subplot was never completed - plot items in last panel may be missing\n");
-			GMT_Report (API, GMT_MSG_DEBUG, "%s Workflow.  Session Name = %s. Directory %s %s.\n", smode[mode], API->session_name, API->gwf_dir, fstatus[3]);
+			GMT_Report (API, GMT_MSG_DEBUG, "%s Workflow.  Session ID = %s. Directory %s %s.\n", smode[mode], API->session_name, API->gwf_dir, fstatus[3]);
 			if ((error = process_figures (API)))
 				GMT_Report (API, GMT_MSG_NORMAL, "process_figures returned error %d\n", error);
 			GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Destroying the current workflow directory %s\n", API->gwf_dir);
@@ -15598,7 +15598,7 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 			break;
 	}
 	if (API->GMT->current.setting.run_mode == GMT_MODERN) {
-		GMT_Report (API, GMT_MSG_DEBUG, "GMT now running in %s mode [Session Name = %s]\n", type[API->GMT->current.setting.run_mode], API->session_name);
+		GMT_Report (API, GMT_MSG_DEBUG, "GMT now running in %s mode [Session ID = %s]\n", type[API->GMT->current.setting.run_mode], API->session_name);
 		API->GMT->current.setting.use_modern_name = true;
 	}
 	return error;


### PR DESCRIPTION
The session name and graphics format could get confused if **-Vd** was given.  Closes issue #995.
