### PR TITLE
Always build branch 6.0

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -7,6 +7,7 @@ trigger:
   branches:
     include:
     - master
+    - 6.0
     - 5.4
     - refs/tags/*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_cache:
 branches:
     only:
         - master
+        - 6.0
         - 5.4
         # Regex to build tagged commits with version numbers
         - /\d+\.\d+(\.\d+)?(\S*)?$/


### PR DESCRIPTION
Branch 6.0 should always be built.