### PR TITLE
Bump version to 6.1.0 in master branch

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -39,7 +39,7 @@ set (GMT_VERSION_YEAR "2019")
 
 # The GMT package version.
 set (GMT_PACKAGE_VERSION_MAJOR 6)
-set (GMT_PACKAGE_VERSION_MINOR 0)
+set (GMT_PACKAGE_VERSION_MINOR 1)
 set (GMT_PACKAGE_VERSION_PATCH 0)
 # If this is a beta version or similar, add a string suffix
 #set (GMT_PACKAGE_VERSION_SUFFIX "rc2")


### PR DESCRIPTION
This PR bumps the version to 6.1.x in the master branch, as this branch is for next minor release (i.e. 6.1.x)