### PR TITLE
Let gmt docs open plot files without prepending file://

### DIFF
--- a/src/docs.c
+++ b/src/docs.c
@@ -132,7 +132,7 @@ int GMT_docs (void *V_API, int mode, void *args) {
 			snprintf (URL, PATH_MAX, "%s", docname);
 	}
 	else {	/* One of the fixed doc files */
-		sbprintf (URL, PATH_MAX, "file:///%s/doc/html/%s", API->GMT->session.SHAREDIR, module);
+		snprintf (URL, PATH_MAX, "file:///%s/doc/html/%s", API->GMT->session.SHAREDIR, module);
 		if (access (&URL[8], R_OK)) 	/* File does not exists, go to GMT documentation site */
 			snprintf (URL, PATH_MAX, "%s/%s", GMT_DOC_URL, module);
 	}

--- a/src/docs.c
+++ b/src/docs.c
@@ -167,9 +167,9 @@ int GMT_docs (void *V_API, int mode, void *args) {
 	}
 	else {
 		sprintf (cmd, "%s %s", can_opener[os], URL);
-		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Opening %s in the default browser via %s\n", URL, can_opener[os]);
+		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Opening %s via %s\n", URL, can_opener[os]);
 		if ((error = system (cmd))) {
-			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Opening %s in the default browser via %s failed with error %d\n",
+			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Opening %s via %s failed with error %d\n",
 				URL, can_opener[os], error);
 			perror ("docs");
 			Return (GMT_RUNTIME_ERROR);

--- a/src/docs.c
+++ b/src/docs.c
@@ -127,19 +127,19 @@ int GMT_docs (void *V_API, int mode, void *args) {
 	/* Get the local URL (which may not exist) */
 	if (other_file) {		/* A local or Web file */
 		if (!strncmp (docname, "http", 4U) || !strncmp (docname, "ftp", 3U))
-			sprintf (URL, "%s", docname);	/* Must assume that the address is correct */
+			snprintf (URL, PATH_MAX, "%s", docname);	/* Must assume that the address is correct */
 		else	/* Must assume this is a local file */
-			sprintf (URL, "file:///%s", docname);
+			snprintf (URL, PATH_MAX, "%s", docname);
 	}
 	else {	/* One of the fixed doc files */
-		sprintf (URL, "file:///%s/doc/html/%s", API->GMT->session.SHAREDIR, module);
+		sbprintf (URL, PATH_MAX, "file:///%s/doc/html/%s", API->GMT->session.SHAREDIR, module);
 		if (access (&URL[8], R_OK)) 	/* File does not exists, go to GMT documentation site */
-			sprintf (URL, "%s/%s", GMT_DOC_URL, module);
+			snprintf (URL, PATH_MAX, "%s/%s", GMT_DOC_URL, module);
 	}
 
 	if (opt->next) {	/* If an option request was made we position the doc there */
 		char t[4] = {""};
-		sprintf (t, "#%c", tolower (opt->next->option));
+		snprintf (t, 4U, "#%c", tolower (opt->next->option));
 		strncat (URL, t, PATH_MAX-1);
 	}
 


### PR DESCRIPTION
Creating URLs starting with file:// should only be done for local documentation (HTML) pages.  This PR closes #1007.
