### PR TITLE
Remove share/VERSION.in

### DIFF
--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -28,12 +28,6 @@ install (DIRECTORY ${_gmt_share_dirs}
 	PATTERN "CMakeLists.txt" EXCLUDE
 	REGEX "[.](cmake|in)$" EXCLUDE)
 
-# install version file (used during runtime to check for correct share dir)
-configure_file (VERSION.in VERSION @ONLY NEWLINE_STYLE LF)
-install (FILES ${CMAKE_CURRENT_BINARY_DIR}/VERSION
-	DESTINATION ${GMT_DATADIR}
-	COMPONENT Runtime)
-
 # only attempt to install shorelines when requested and path is known
 if (GSHHG_PATH AND COPY_GSHHG)
 	install (DIRECTORY ${GSHHG_PATH}/

--- a/share/VERSION.in
+++ b/share/VERSION.in
@@ -1,6 +1,0 @@
-# The version in this file is matched with the hardcoded GMT version at
-# runtime to check if this directory contains the correct run-time support
-# files.  In case of a version mismatch the directory will silently be
-# ignored.
-#
-@GMT_PACKAGE_VERSION_WITH_GIT_REVISION@


### PR DESCRIPTION
In #61, we removed the function `gmt_verify_sharedir_version` and stopped checking the VERSION file in share directory. Thus the share/VERSION is useless now.