### PR TITLE
Let gmt_mkdir call perror upon failing

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8548,6 +8548,7 @@ int gmt_mkdir (const char *path)
 
 	if (len >= PATH_MAX) {	/* Make sure we don't exceed limits */
 		errno = ENAMETOOLONG;
+		perror ("gmt_mkdir error");
 		return -1; 
 	}   
 	strcpy (_path, path);	/* Copy string so its mutable */
@@ -8564,8 +8565,10 @@ int gmt_mkdir (const char *path)
 			if (mkdir (_path) != 0)
 #endif
 			{
-				if (errno != EEXIST)	/* Failed to make or visit intermediate directory */
+				if (errno != EEXIST) {	/* Failed to make or visit intermediate directory */
+					perror ("gmt_mkdir error");
 					return -1; 
+				}
 			}
 			*p = sep;	/* Reset the separator */
 		}
@@ -8578,8 +8581,10 @@ int gmt_mkdir (const char *path)
 	if (mkdir (_path) != 0)
 #endif
 	{
-		if (errno != EEXIST)
+		if (errno != EEXIST) {
+			perror ("gmt_mkdir error");
 			return -1; 
+		}
 	}   
 
 	return 0;


### PR DESCRIPTION
To better track down isues with permissions and more we let gmt_mkdir set errno and call perror.  See #994 for context.