### PR TITLE
Set scheduled daily and monthly builds

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -11,6 +11,22 @@ trigger:
     - 5.4
     - refs/tags/*
 
+# Scheduled build
+schedules:
+- cron: "0 0 * * *"
+  displayName: Scheduled daily build
+  branches:
+    include:
+    - master
+    - 6.0
+  always: true
+- cron: "0 0 1 * *"
+  displayName: Scheduled monthly build
+  branches:
+    include:
+    - 5.4
+  always: true
+
 jobs:
 
 # Mac - Compile only


### PR DESCRIPTION
- Daily build for master and 6.0 branches
- Monthly build for 5.4 branch

Azure pipelines now only allow define scheduled build in YAML file.

Documentations:

- https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?tabs=yaml&view=azure-devops#scheduled-triggers
- https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#scheduled-trigger

Closed #1028 

This PR also need to be picked into master and 5.4 branches.
