### PR TITLE
Replace apt-get with apt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,8 +81,8 @@ before_install:
         echo "Copy cached deb packages"
         sudo rsync -av ${DEB_CACHE}/ /var/cache/apt/archives/
         echo "Start to install software"
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends --no-install-suggests $DEB_PACKAGES
+        sudo apt update
+        sudo apt install -y --no-install-recommends --no-install-suggests $DEB_PACKAGES
         echo "Update the cache"
         rsync -av /var/cache/apt/archives/*.deb ${DEB_CACHE}/
       fi

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -71,22 +71,22 @@ For Ubuntu and Debian, there are prepackaged development binaries available.
 Install the GMT dependencies with:
 
     # Install required dependencies
-    sudo apt-get install build-essential cmake libcurl4-gnutls-dev libnetcdf-dev ghostscript
+    sudo apt install build-essential cmake libcurl4-gnutls-dev libnetcdf-dev ghostscript
 
     # Install optional dependencies
-    sudo apt-get install libgdal1-dev libfftw3-dev libpcre3-dev liblapack-dev libblas-dev
+    sudo apt install libgdal1-dev libfftw3-dev libpcre3-dev liblapack-dev libblas-dev
 
     # to enable movie-making
-    sudo apt-get install graphicsmagick ffmpeg
+    sudo apt install graphicsmagick ffmpeg
 
     # to enable testing
-    sudo apt-get install graphicsmagick
+    sudo apt install graphicsmagick
 
     # to build the documentation
-    sudo apt-get install python-sphinx
+    sudo apt install python-sphinx
 
     # to build the documentation in PDF format
-    sudo apt-get install texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk
+    sudo apt install texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk
 
 ### RHEL/CentOS
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,7 +41,7 @@ Otherwise, installing from the distros goes like this:
 
 Install GMT5 via
 
-    sudo apt-get install gmt gmt-dcw gmt-gshhg
+    sudo apt install gmt gmt-dcw gmt-gshhg
 
 **Note:** The Ubuntu package under 16.04 LTS for mysterious reasons does not
 include the supplements. If you need them you will need to


### PR DESCRIPTION
Apt is recommended since Ubuntu 16.04.