### PR TITLE
Let first plot under subplot default to first panel if not set via -c

### DIFF
--- a/doc/rst/source/explain_-c_full.rst_
+++ b/doc/rst/source/explain_-c_full.rst_
@@ -3,4 +3,6 @@
 **-c**\ [*row*\ ,\ *col*]
     Used to advance to the selected subplot panel.  Only allowed when in
     subplot mode.  Available to all plot modules.  If no arguments are
-    given then we advance to the next panel in the selected order.
+    given then we advance to the next panel in the selected order. If
+    no **-c** is given and we just entered subplot mode then the first
+    panel is selected.

--- a/doc/rst/source/explain_-c_full.rst_
+++ b/doc/rst/source/explain_-c_full.rst_
@@ -5,4 +5,4 @@
     subplot mode.  Available to all plot modules.  If no arguments are
     given then we advance to the next panel in the selected order. If
     no **-c** is given and we just entered subplot mode then the first
-    panel is selected.
+    panel (top, left) is selected.

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -11623,7 +11623,7 @@ GMT_LOCAL unsigned int gmtinit_subplot_status (struct GMTAPI_CTRL *API, int fig)
 		mode |= GMTINIT_SUBPLOT_ACTIVE;
 	}
 	sprintf (file, "%s/gmt.panel.%d", API->gwf_dir, fig);
-	answer = (access (file, F_OK) == 0);	/* true if curent panel file is found */
+	answer = (access (file, F_OK) == 0);	/* true if current panel file is found */
 	if (answer)
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Current panel file found\n");
 	else


### PR DESCRIPTION
When a subplot is started, it is convenient to have a default for which panel to first plot in.  That default will be the first panel, of course, and now we select that if the first plot command in a subplot does not set **-c** explicitly.
