### PR TITLE
Clarify subplot usage in -SC|R and fix documentatino

### DIFF
--- a/doc/rst/source/subplot.rst_
+++ b/doc/rst/source/subplot.rst_
@@ -64,8 +64,8 @@ Required Arguments
     Specify the dimensions of each **s**\ ubplot directly.  Then, the figure dimensions are computed from the
     subplot dimensions after adding the space that optional tick marks, annotations, labels, and margins occupy between panels.
     The annotations, ticks, and labels along the outside perimeter are not counted as part of the figure dimensions.
-    To specify different subplot dimensions for each row (or column),  append a colon followed by a comma-separated list of widths,
-    a slash, and then the list of heights.  A single number means constant widths (or heights) [Default].
+    To specify different subplot dimensions for each row (or column),  append a comma-separated list of widths,
+    a slash, and then the comma-separated list of heights.  A single number means constant widths (or heights) [Default].
     For example **–Fs**\ 5c,8c/8c will make the first column 5 cm wide and the second column 8 cm wide, with
     all having a constant height of 8 cm. The number of values must either be one (constant across the rows or columns)
     or exactly match the number of rows (or columns). For geographic maps, the height of each panel depends on

--- a/doc/rst/source/subplot.rst_
+++ b/doc/rst/source/subplot.rst_
@@ -132,14 +132,14 @@ Optional Arguments
     (i.e., **b**\ ottom) rows will have *x* annotations; append **t** or **b** to select only one of those two rows [both].
     Append **+l** if annotated *x*-axes should have a label [none]; optionally append the label if it is the same
     for the entire subplot.
+    Append **+t** to make space for subplot titles for each row; use **+tc** for top row titles only [no subplot titles].
+    Labels and titles that depends on which row or column are specified as usual via a panel's **-B** setting.
     Considerations for **-SR**: Use when all subplots in a **R**\ ow share a common *y*-range. The first (i.e., **l**\ eft) and the last
     (i.e., **r**\ ight) columns will have *y*-annotations; append **l** or **r** to select only one of those two columns [both].
     Append **+l** if annotated *y*-axes will have a label [none]; optionally, append the label if it is the same
     for the entire subplot.
     Append **+p** to make all annotations axis-parallel [horizontal]; if not used you may have to set **-C** to secure
     extra space for long horizontal annotations.
-    Append **+t** to make space for subplot titles for each row; use **+tc** for top row titles only [no subplot titles].
-    Labels and titles that depends on which row or column are specified as usual via a panel's **-B** setting.
 
 .. _subplot_begin-T:
 
@@ -234,7 +234,7 @@ To make a minimalistic 2x2 basemap layout called panels.pdf, try
 
     gmt begin panels pdf
       gmt subplot begin 2x2 -Fs8c -M5p -A -SCb -SRl -Bwstr
-        gmt basemap -R0/80/0/10 -c
+        gmt basemap -R0/80/0/10
         gmt basemap -c
         gmt basemap -c
         gmt basemap -c

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -497,17 +497,13 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT
 					Ctrl->S[k].has_label = true;
 					if (string[0]) Ctrl->S[k].label[GMT_SECONDARY] = strdup (string);
 				}
-				if (k == GMT_Y) {	/* Modifier for y-axis only */
+				if (gmt_get_modifier (opt->arg, 't', string))	/* Want space for panel titles, this could go with either -SR or -SC so do it outside but save in -SC */
+					Ctrl->S[GMT_X].ptitle = (string[0] == 'c') ? SUBPLOT_PANEL_COL_TITLE : SUBPLOT_PANEL_TITLE;
+				if (k == GMT_Y) {	/* Modifiers for y-axis only */
 					if (gmt_get_modifier (opt->arg, 'p', string))	/* Want axis-parallel annotations [horizontal] */
 						Ctrl->S[k].parallel = 1;
-					if (gmt_get_modifier (opt->arg, 't', string)) {	/* Only for SC */
-						GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Modifier +t only allowed for -SC\n");
-						n_errors++;
-					}
 				}
 				else {	/* Modifier for x-axis only */
-					if (gmt_get_modifier (opt->arg, 't', string))	/* Want space for panel titles */
-						Ctrl->S[k].ptitle = (string[0] == 'c') ? SUBPLOT_PANEL_COL_TITLE : SUBPLOT_PANEL_TITLE;
 					if (gmt_get_modifier (opt->arg, 'p', string)) {	/* Only for SR */
 						GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Modifier +p only allowed for -SR\n");
 						n_errors++;

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -188,7 +188,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-SC Each subplot Column shares a common x-range. First row (top axis) and last row (bottom axis) are annotated;\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t    Append t or b to select only one of those two axes annotations instead [both].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t    Append +l if annotated x-axes should have a label [none]; optionally append the label if it is fixed.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t    Alternatively, you can also use +s.  If no label is given then you msut set it when the panel is plotted via -B.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t    Alternatively, you can also use +s.  If no label is given then you must set it when the panel is plotted via -B.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t    Append +t to make space for individual titles for all subplots; use +tc for top row titles only [no subplot titles].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-SR Each subplot Row shares a common y-range. First column (left axis) and last column (right axis) are annotated;\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t    Append l or r to select only one of those two axes annotations instead [both].\n");
@@ -500,10 +500,18 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT
 				if (k == GMT_Y) {	/* Modifier for y-axis only */
 					if (gmt_get_modifier (opt->arg, 'p', string))	/* Want axis-parallel annotations [horizontal] */
 						Ctrl->S[k].parallel = 1;
-					/* Panel title is a common modifier */
+					if (gmt_get_modifier (opt->arg, 't', string)) {	/* Only for SC */
+						GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Modifier +t only allowed for -SC\n");
+						n_errors++;
+					}
+				}
+				else {	/* Modifier for x-axis only */
 					if (gmt_get_modifier (opt->arg, 't', string))	/* Want space for panel titles */
 						Ctrl->S[k].ptitle = (string[0] == 'c') ? SUBPLOT_PANEL_COL_TITLE : SUBPLOT_PANEL_TITLE;
-					
+					if (gmt_get_modifier (opt->arg, 'p', string)) {	/* Only for SR */
+						GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Modifier +p only allowed for -SR\n");
+						n_errors++;
+					}
 				}
 				break;
 	
@@ -768,11 +776,11 @@ int GMT_subplot (void *V_API, int mode, void *args) {
 			if (ny == 2 || Ctrl->S[GMT_X].annotate & SUBPLOT_PLACE_AT_MAX) y_header_off += label_height;
 		}
 		GMT_Report (API, GMT_MSG_DEBUG, "Subplot: After %d col labels: fluff = {%g, %g}\n", ny, fluff[GMT_X], fluff[GMT_Y]);
-		if (Ctrl->S[GMT_Y].ptitle == SUBPLOT_PANEL_TITLE) {
+		if (Ctrl->S[GMT_X].ptitle == SUBPLOT_PANEL_TITLE) {
 			fluff[GMT_Y] += (Ctrl->N.dim[GMT_Y]-1) * title_height;
 			y_header_off += title_height;
 		}
-		else if (Ctrl->S[GMT_Y].ptitle == SUBPLOT_PANEL_COL_TITLE) {
+		else if (Ctrl->S[GMT_X].ptitle == SUBPLOT_PANEL_COL_TITLE) {
 			y_header_off += title_height;
 		}
 		GMT_Report (API, GMT_MSG_DEBUG, "Subplot: After %d panel titles: fluff = {%g, %g}\n", factor, fluff[GMT_X], fluff[GMT_Y]);
@@ -846,7 +854,7 @@ int GMT_subplot (void *V_API, int mode, void *args) {
 					D->table[0]->segment[seg]->n_rows = 4;
 				}
 			}
-			if ((row == 0 && Ctrl->S[GMT_Y].ptitle == SUBPLOT_PANEL_COL_TITLE) || (Ctrl->S[GMT_Y].ptitle == SUBPLOT_PANEL_TITLE)) {
+			if ((row == 0 && Ctrl->S[GMT_X].ptitle == SUBPLOT_PANEL_COL_TITLE) || (Ctrl->S[GMT_X].ptitle == SUBPLOT_PANEL_TITLE)) {
 				if (row) y -= title_height;	/* Make space for panel title */
 			}
 			if (Ctrl->S[GMT_X].active)	/* May need shared annotation at top N */

--- a/test/modern/somepanels.sh
+++ b/test/modern/somepanels.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Test only giving a few subplots, Roman labeling, and -A override for one subplot
 gmt begin somepanels ps
-  gmt subplot begin 3x3 -F6i/8.5i -M5p -A1+c+r+o0.2i+jBR -SCb+lXLABEL+tc -SRl+lYLABEL -Bwstr -T"FIGURE HEADER"
+  gmt subplot begin 3x3 -F6i/8.5i -M5p -A1+c+r+o0.2i+jBR -SCb+lXLABEL -SRl+lYLABEL -Bwstr -T"FIGURE HEADER"
     gmt basemap -R0/100/0/10 -c1,1
     gmt subplot 2,2 -Apink
     gmt basemap -B+gpink


### PR DESCRIPTION
There was references to a colon separator for **-Fs** which is not true, and there were confusions regarding where **+t** goes (with -SC but allow -Sr as well).
