### PR TITLE
Delete incomplete/corrupted files due to Ctrl-C

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -57,7 +57,6 @@
 #if !(defined(WIN32) || defined(NO_SIGHANDLER))
 #define GMT_CATCH_CTRL_C
 #include <signal.h>
-#include "common_sighandler.h"
 struct sigaction new_action, old_action;
 char *file_to_delete_if_ctrl_C;
 #endif

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -56,6 +56,8 @@
 
 #if !(defined(WIN32) || defined(NO_SIGHANDLER))
 #define GMT_CATCH_CTRL_C
+#include <signal.h>
+#include "common_sighandler.h"
 struct sigaction new_action, old_action;
 char *file_to_delete_if_ctrl_C;
 #endif


### PR DESCRIPTION
When remote grid files are copied from the server via Curl, and the user interrupts this download via Ctlr-C, we end up with a corrupted file.  Then, if the user tries to access this file (the same day, since we only updated the Md5 hash and check file sizes once a day) it will give an error.  This PR responds to #549 by activating a custom signal handler during the download so that if Ctrl-C happens it is caught and deletes the partial file before exiting.  The signal handler is restored to the default once Curl finishes successfully.  This PR excludes Windows for now.  I tested it on macOS this way:

1. Make sure ~/.gmt/server/earth_relief_01m.grd is removed first.
2. Run grdinfo @earth_relief_01m.grd
3. Type Ctrl-C after 5 seconds.

There should not be any partial earth_relief_01m.grd in the server directory.  If you have compiled with -DDEBUG then you also get a fprintf message informing you of the removal of the file.