### PR TITLE
Correct how trailing text words are accessed in custom symbols

### DIFF
--- a/doc/rst/source/GMT_Docs.rst
+++ b/doc/rst/source/GMT_Docs.rst
@@ -8165,7 +8165,7 @@ Normally, the **l** macro code will place a hard-wired text string.  However,
 you can also obtain the entire string from your input file via a single symbol
 variable **$t** that must be declared with type **s** (string).  The string will be taken
 as all trialing text in your data record.  To select a single word from the trailing text
-you just use $k, where k starts at 1 for the first word, regardless of how many numerical
+you just use **$t**\ *k*, where *k* starts at 0 for the first word, regardless of how many numerical
 columns that precede it.  For each word you plan to use you must add a type **s** above.
 Words must be separated by one tab or space only.  To place the dollar sign $ itself you must
 use octal \\044 so as to not confuse the parser with a symbol variable.

--- a/doc/rst/source/GMT_Docs_classic.rst
+++ b/doc/rst/source/GMT_Docs_classic.rst
@@ -8202,7 +8202,7 @@ Normally, the **l** macro code will place a hard-wired text string.  However,
 you can also obtain the entire string from your input file via a single symbol
 variable **$t** that must be declared with type **s** (string).  The string will be taken
 as all trialing text in your data record.  To select a single word from the trailing text
-you just use $k, where k starts at 1 for the first word, regardless of how many numerical
+you just use **$t**\ *k*, where *k* starts at 0 for the first word, regardless of how many numerical
 columns that precede it.  For each word you plan to use you must add a type **s** above.
 Words must be separated by one tab or space only.  To place the dollar sign $ itself you must
 use octal \\044 so as to not confuse the parser with a symbol variable.

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -2689,6 +2689,8 @@ GMT_LOCAL void plot_format_symbol_string (struct GMT_CTRL *GMT, struct GMT_CUSTO
  	 * These are the things that can happen:
 	 * 1. Action is GMT_SYMBOL_TEXT means we have a static fixed text string; just copy
 	 * 2. s->text is $t.  Then we use the trialing text from the input as the text.
+	 *    Optionally, a single word of the trailing text can be selected by appending
+	 *    a word integer, $t0 is the first word, $t1 the second, etc.
 	 * 3. We have a format statement that contains free-form text with interspersed
 	 *    special formatting commands.  These have the syntax
 	 *    %X  Add longitude or x using chosen default format.
@@ -2703,7 +2705,7 @@ GMT_LOCAL void plot_format_symbol_string (struct GMT_CTRL *GMT, struct GMT_CUSTO
 		strcpy (text, s->string);
 	else if (!strcmp (s->string, "$t"))	/* Get entire string from trailing text in the input */
 		strcpy (text, GMT->current.io.curr_trailing_text);
-	else if (!strncmp (s->string, "$t:", 3U)) {	/* Get word number n from trailing text in the input */
+	else if (!strncmp (s->string, "$t", 2U) && isdigit (s->string[2])) {	/* Get word number n from trailing text in the input */
 		char *word = NULL, *trail = NULL, *orig = strdup (GMT->current.io.curr_trailing_text);
 		int col = 0;
 		trail = orig;
@@ -2711,8 +2713,10 @@ GMT_LOCAL void plot_format_symbol_string (struct GMT_CTRL *GMT, struct GMT_CUSTO
 			col++;	/* Advance to the right word */
 		if (word && *word != '\0')	/* Skip empty strings */
 			strcpy (text, word);
-		else
+		else {	/* Default to the whole trailing text if word does not exist */
+			GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "No word # %d in the trailing text (%d words) - return all text\n", s->var[0], col);
 			strcpy (text, GMT->current.io.curr_trailing_text);
+		}
 		gmt_M_str_free (orig);
 	}
 	else {	/* Must replace special items within a template string */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4915,7 +4915,7 @@ GMT_LOCAL int support_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name, s
 				if ((c = strchr (s->string, '$'))) {	/* Got a text string variable */
 					s->action = GMT_SYMBOL_VARTEXT;
 					if (c[1] == 't' && isdigit (c[2]))	/* Select this word from trailing text */
-						s->var[0] = atoi (&c[3]) + 1;	/* We add the 1 here so 0-(n-1) becomes 1-n */
+						s->var[0] = atoi (&c[2]) + 1;	/* We add the 1 here so 0-(n-1) becomes 1-n */
 				}
 				s->font = GMT->current.setting.font_annot[GMT_PRIMARY];	/* Default font for symbols */
 				s->justify = PSL_MC;				/* Default justification of text */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4914,8 +4914,8 @@ GMT_LOCAL int support_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name, s
 				strcpy (s->string, col[3]);
 				if ((c = strchr (s->string, '$'))) {	/* Got a text string variable */
 					s->action = GMT_SYMBOL_VARTEXT;
-					if (c[1] == 't' && c[2] == ':' && isdigit (c[3]))	/* Select this word from trailing text */
-						s->var[0] = atoi (&c[3]);
+					if (c[1] == 't' && isdigit (c[2]))	/* Select this word from trailing text */
+						s->var[0] = atoi (&c[3]) + 1;	/* We add the 1 here so 0-(n-1) becomes 1-n */
 				}
 				s->font = GMT->current.setting.font_annot[GMT_PRIMARY];	/* Default font for symbols */
 				s->justify = PSL_MC;				/* Default justification of text */

--- a/test/psxy/custom_textsymbol.sh
+++ b/test/psxy/custom_textsymbol.sh
@@ -16,8 +16,8 @@ EOF
 
 cat << EOF > text_subst_symbol.def
 N: 2 ss
-0 0 1 \$t:1 l -Gred
-0 0 1 \$t:2 l -Gblue
+0 0 1 \$t0 l -Gred
+0 0 1 \$t1 l -Gblue
 EOF
 gmt pscoast -R117/-1.5/122.5/3r -JM15c -Bag -Di -Ggrey -Wthinnest -A250 -P -K -Xc > $ps
 gmt psxy -R -J t.txt -Sktext_subst_symbol -O >> $ps


### PR DESCRIPTION
**Description of proposed changes**

See #1062 for context.  This PR reinstates the rule that 0 is the first item in a list (here, the words in the trailing text).  It also eliminates the colon between **$t** and the _word_ number since this syntax clashes with how **-i** and **-o** specify single words.  The only place we use colon is in ranges, e.g., **-i**1:5 (or **-i**1-5).