### PR TITLE
Add sanity check on IO_COL_SEPARATOR

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9261,6 +9261,11 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				strncpy (GMT->current.setting.io_col_separator, ",", 8U);
 			else if (!strcmp (lower_value, "none"))
 				GMT->current.setting.io_col_separator[0] = 0;
+#ifdef WIN32
+			/* Fix crazy MinGW obsession of replacing / with C:/somepath... [https://github.com/GenericMappingTools/gmt/issues/1054] */
+			else if (strlen (lower_value) > 1 && lower_value[1] == ':')
+				strncpy (GMT->current.setting.io_col_separator, "/", 8U);
+#endif
 			else
 				strncpy (GMT->current.setting.io_col_separator, value, 8U);
 			GMT->current.setting.io_col_separator[7] = 0;	/* Just a precaution */


### PR DESCRIPTION
**Description of proposed changes**

Apparently, a single slash in minGW is repalced with a full path C:/MinGW/msys/1.0 or similar.  This is nuts of course, hence this PR to look for such cases and correct then back to a single slash.  This PR closes #1054.
