### PR TITLE
Try to defeat minGW insanity on path replacements

### DIFF
--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -50,6 +50,7 @@ struct GMT_XINGS {
 
 EXTERN_MSC char *opt (struct GMTAPI_CTRL *API,char code);
 
+EXTERN_MSC unsigned int gmtlib_char_count (char *txt, char c);
 EXTERN_MSC void gmtlib_set_KOP_strings (struct GMTAPI_CTRL *API);
 EXTERN_MSC bool gmtlib_is_modern_name (struct GMTAPI_CTRL *API, char *module);
 EXTERN_MSC const char *gmtlib_get_active_name (struct GMTAPI_CTRL *API, const char *module);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -4775,6 +4775,8 @@ GMT_LOCAL void mingw_undo_path_substitution (char *path) {
 		char c = tolower (path[2]);
 		path[2] = '/';
 		path[3] = c;
+		if (!strncmp (path, &path[2], 2U))	/* Got X:X:/path, left-shift by 2 */
+			gmt_strlshift (path, 2U);
 	}
 }
 #endif

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -4771,7 +4771,7 @@ int gmt_set_cols (struct GMT_CTRL *GMT, unsigned int direction, uint64_t expecte
  * that back as indicated above.  It cannot be any worse that it is. */
 
 GMT_LOCAL void mingw_undo_path_substitution (char *path) {
-	if (support_char_count (path, ':') == 2 && strlen (path) > 3) {
+	if (gmtlib_char_count (path, ':') == 2 && strlen (path) > 3) {
 		char c = tolower (path[2]);
 		path[2] = '/';
 		path[3] = c;

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -767,7 +767,7 @@ GMT_LOCAL bool support_check_cmyk (double cmyk[]) {
 }
 
 /*! . */
-GMT_LOCAL unsigned int support_char_count (char *txt, char c) {
+unsigned int gmtlib_char_count (char *txt, char c) {
 	unsigned int i = 0, n = 0;
 	while (txt[i]) if (txt[i++] == c) n++;
 	return (n);
@@ -823,7 +823,7 @@ GMT_LOCAL bool support_gethsv (struct GMT_CTRL *GMT, char *line, double hsv[]) {
 	c = buffer[strlen(buffer)-1];
 	if (!(isdigit (c) || c == '.')) return (true);
 
-	count = (int)support_char_count (buffer, '/');
+	count = (int)gmtlib_char_count (buffer, '/');
 
 	if (count == 3) {	/* c/m/y/k */
 		n = sscanf (buffer, "%lf/%lf/%lf/%lf", &cmyk[0], &cmyk[1], &cmyk[2], &cmyk[3]);
@@ -845,7 +845,7 @@ GMT_LOCAL bool support_gethsv (struct GMT_CTRL *GMT, char *line, double hsv[]) {
 		}
 	}
 
-	if (support_char_count (buffer, '-')  == 2) {		/* h-s-v */
+	if (gmtlib_char_count (buffer, '-')  == 2) {		/* h-s-v */
 		n = sscanf (buffer, "%lf-%lf-%lf", &hsv[0], &hsv[1], &hsv[2]);
 		return (n != 3 || support_check_hsv (hsv));
 	}
@@ -6252,7 +6252,7 @@ bool gmt_getrgb (struct GMT_CTRL *GMT, char *line, double rgb[]) {
 	c = buffer[strlen(buffer)-1];
 	if (c <= 0 || !(isdigit (c) || c == '.')) return (true);
 
-	count = (int)support_char_count (buffer, '/');
+	count = (int)gmtlib_char_count (buffer, '/');
 
 	if (count == 3) {	/* c/m/y/k */
 		n = sscanf (buffer, "%lf/%lf/%lf/%lf", &cmyk[0], &cmyk[1], &cmyk[2], &cmyk[3]);
@@ -6275,7 +6275,7 @@ bool gmt_getrgb (struct GMT_CTRL *GMT, char *line, double rgb[]) {
 		}
 	}
 
-	if (support_char_count (buffer, '-') == 2) {		/* h-s-v despite pretending to be r/g/b */
+	if (gmtlib_char_count (buffer, '-') == 2) {		/* h-s-v despite pretending to be r/g/b */
 		n = sscanf (buffer, "%lf-%lf-%lf", &hsv[0], &hsv[1], &hsv[2]);
 		if (n != 3 || support_check_hsv (hsv)) return (true);
 		support_hsv_to_rgb (rgb, hsv);


### PR DESCRIPTION
With minGW replacing /a with A: we must undo this craziness before trying to open files.  See #1035 for context.
