### PR TITLE
Add admin dir with files needed for building a rc or final release

### DIFF
--- a/admin/ConfigReleaseBuild.cmake
+++ b/admin/ConfigReleaseBuild.cmake
@@ -1,0 +1,21 @@
+#
+# Use this file as ConfigUser.cmake when building the release
+# Make sure GMT_GSHHG_SOURCE and GMT_DCW_SOURCE are defined in
+# your environment and pointing to the latest releases.
+#
+#-------------------------------------------------------------
+set (CMAKE_BUILD_TYPE relwithdebinfo)
+set (CMAKE_INSTALL_PREFIX "gmt-${GMT_PACKAGE_VERSION}")
+set (GSHHG_ROOT "$ENV{GMT_GSHHG_SOURCE}")
+set (DCW_ROOT "$ENV{GMT_DCW_SOURCE}")
+set (COPY_GSHHG TRUE)
+set (COPY_DCW TRUE)
+
+set (GMT_INSTALL_MODULE_LINKS FALSE)
+set (GMT_USE_THREADS TRUE)
+set (GMT_ENABLE_OPENMP TRUE)
+
+# recommended even for release build
+set (CMAKE_C_FLAGS "-Wall -Wdeclaration-after-statement ${CMAKE_C_FLAGS}")
+# extra warnings
+set (CMAKE_C_FLAGS "-Wextra ${CMAKE_C_FLAGS}")

--- a/admin/RELEASE.md
+++ b/admin/RELEASE.md
@@ -1,0 +1,16 @@
+# Releasing GMT
+
+**The admin directory is just for the GMT developers to store configuration
+files and scripts useful for building the actual releases.**
+
+## Contents
+
+- build-release.sh
+- ConfigReleaseBuild.cmake
+
+## Do the release
+
+Make sure you are in the top gmt directory and then
+run
+
+    admin/build-release.sh [tag]

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -25,7 +25,7 @@ cp -f admin/ConfigReleaseBuild.cmake cmake/ConfigUser.cmake
 rm -rf build
 mkdir build
 cd build
-cmake -G Ninja -DGMT_PACKAGE_VERSION_SUFFIX=${tag} -DGMT_PUBLIC_RELEASE=TRUE ..
+cmake -G Ninja ..
 # 3. Build the release and the tar balls
 cmake --build . --target gmt_release
 cmake --build . --target gmt_release_tar

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -35,11 +35,9 @@ rm -f gmt-${Version}${tag}-src.tar
 cmake --build . --target install
 # 6. Build the macOS Bundle
 cpack -G Bundle
-# 7. Rename bundle to match standard package prefix
-mv GMT-${Version}${tag}-Darwin.dmg gmt-${Version}${tag}-darwin-x86_64.dmg
-# 8. Report m5d hash
+# 7. Report m5d hash
 md5 gmt-${Version}${tag}-*
-# 9. Replace temporary ConfigReleaseBuild.cmake file with the original file
+# 8. Replace temporary ConfigReleaseBuild.cmake file with the original file
 rm -f ../cmake/ConfigUser.cmake
 if [ -f ../cmake/ConfigUser.cmake.orig ]; then
 	mv ../cmake/ConfigUser.cmake.orig cmake/ConfigUser.cmake

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Script that builds a GMT release and makes the compressed tarballs and macOS Bundle
+Version=6.0.0
+if [ $# -eq 0 ]; then
+	echo "Usage: build-release.sh tag"
+	echo "e.g., build-release.sh rc3"
+	echo "If no tag (i.e., a final 6.x.y version) then give - as tag"
+	echo "build-release.sh must be run from top-level gmt directory"
+	exit 1
+fi
+if [ ! -d cmake ]; then
+	echo "Must be run from top-level gmt directory"
+	exit 1
+fi
+if [ ! "X$1" = "X-" ]; then
+	tag=$1
+fi
+
+# 1. Set basic ConfigUser.cmake file for a release build
+if [ -f cmake/ConfigUser.cmake ]; then
+	cp cmake/ConfigUser.cmake cmake/ConfigUser.cmake.orig
+fi
+cp -f admin/ConfigReleaseBuild.cmake cmake/ConfigUser.cmake
+# 2. Make build dir and configure it
+rm -rf build
+mkdir build
+cd build
+cmake -G Ninja -DGMT_PACKAGE_VERSION_SUFFIX=${tag} -DGMT_PUBLIC_RELEASE=TRUE ..
+# 3. Build the release and the tar balls
+cmake --build . --target gmt_release
+cmake --build . --target gmt_release_tar
+# 4. Remove the uncompressed tar ball
+rm -f gmt-${Version}${tag}-src.tar
+# 5. Install executables before building macOS Bundle
+cmake --build . --target install
+# 6. Build the macOS Bundle
+cpack -G Bundle
+# 7. Rename bundle to match standard package prefix
+mv GMT-${Version}${tag}-Darwin.dmg gmt-${Version}${tag}-darwin-x86_64.dmg
+# 8. Report m5d hash
+md5 gmt-${Version}${tag}-*
+# 9. Replace temporary ConfigReleaseBuild.cmake file with the original file
+rm -f ../cmake/ConfigUser.cmake
+if [ -f ../cmake/ConfigUser.cmake.orig ]; then
+	mv ../cmake/ConfigUser.cmake.orig cmake/ConfigUser.cmake
+fi
+# 10. Put the products on my ftp site
+#scp gmt-${Version}${tag}-darwin-x86_64.dmg gmt-${Version}${tag}-src.tar.* ftp:/export/ftp1/ftp/pub/pwessel/release


### PR DESCRIPTION
We place convenience scripts and CMake settings in the new admin dir.  They are not part of the tar distribution but used by the developers when building the tar balls and macOS bundle for the releases.

