### PR TITLE
let build-release.sh detect version and if macOS bundle is needed

### DIFF
--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -1,19 +1,16 @@
 #!/bin/bash
-# Script that builds a GMT release and makes the compressed tarballs and macOS Bundle
-Version=6.0.0
-if [ $# -eq 0 ]; then
-	echo "Usage: build-release.sh tag"
-	echo "e.g., build-release.sh rc3"
-	echo "If no tag (i.e., a final 6.x.y version) then give - as tag"
+# Script that builds a GMT release and makes the compressed tarballs.
+# If run under macOS it also builds the macOS Bundle
+if [ $# -gt 0 ]; then
+	echo "Usage: build-release.sh"
 	echo "build-release.sh must be run from top-level gmt directory"
+	echo "Will create the release compressed tarballs and (under macOS) the bundle"
+	echo "Requires you have set GMT_PACKAGE_VERSION_* and GMT_PUBLIC_RELEASE in cmake/ConfigDefaults.cmake"
 	exit 1
 fi
 if [ ! -d cmake ]; then
 	echo "Must be run from top-level gmt directory"
 	exit 1
-fi
-if [ ! "X$1" = "X-" ]; then
-	tag=$1
 fi
 
 # 1. Set basic ConfigUser.cmake file for a release build
@@ -25,22 +22,29 @@ cp -f admin/ConfigReleaseBuild.cmake cmake/ConfigUser.cmake
 rm -rf build
 mkdir build
 cd build
+echo "build-release.sh: Configure and build tar balls"
 cmake -G Ninja ..
 # 3. Build the release and the tar balls
 cmake --build . --target gmt_release
 cmake --build . --target gmt_release_tar
-# 4. Remove the uncompressed tar ball
-rm -f gmt-${Version}${tag}-src.tar
-# 5. Install executables before building macOS Bundle
+# 4. get the version string
+Version=`src/gmt --version`
+# 5. Remove the uncompressed tar ball
+rm -f gmt-${Version}-src.tar
+# 6. Install executables before building macOS Bundle
 cmake --build . --target install
-# 6. Build the macOS Bundle
-cpack -G Bundle
-# 7. Report m5d hash
-md5 gmt-${Version}${tag}-*
-# 8. Replace temporary ConfigReleaseBuild.cmake file with the original file
+if [ `uname` = "Darwin" ]; then
+	echo "build-release.sh: Build macOS bundle"
+	# 7. Build the macOS Bundle
+	cpack -G Bundle
+fi
+# 8. Report m5d hash
+echo "build-release.sh: Report m5d hash per file"
+md5 gmt-${Version}-*
+# 9. Replace temporary ConfigReleaseBuild.cmake file with the original file
 rm -f ../cmake/ConfigUser.cmake
 if [ -f ../cmake/ConfigUser.cmake.orig ]; then
 	mv ../cmake/ConfigUser.cmake.orig cmake/ConfigUser.cmake
 fi
 # 10. Put the products on my ftp site
-#scp gmt-${Version}${tag}-darwin-x86_64.dmg gmt-${Version}${tag}-src.tar.* ftp:/export/ftp1/ftp/pub/pwessel/release
+#scp gmt-${Version}-darwin-x86_64.dmg gmt-${Version}-src.tar.* ftp:/export/ftp1/ftp/pub/pwessel/release

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -44,7 +44,7 @@ md5 gmt-${Version}-*
 # 9. Replace temporary ConfigReleaseBuild.cmake file with the original file
 rm -f ../cmake/ConfigUser.cmake
 if [ -f ../cmake/ConfigUser.cmake.orig ]; then
-	mv ../cmake/ConfigUser.cmake.orig cmake/ConfigUser.cmake
+	mv ../cmake/ConfigUser.cmake.orig ../cmake/ConfigUser.cmake
 fi
 # 10. Put the products on my ftp site
 #scp gmt-${Version}-darwin-x86_64.dmg gmt-${Version}-src.tar.* ftp:/export/ftp1/ftp/pub/pwessel/release


### PR DESCRIPTION
Since we are building the executables we can use them to get the version string, and we can check if we are running macOS before making the bundle.  Thus, on LInux this script will only make the tarballs.
