### PR TITLE
Fix spelling errors.

### DIFF
--- a/src/PSL_prologue.ps
+++ b/src/PSL_prologue.ps
@@ -113,7 +113,7 @@
 % Translate and memorize advance
 /PSL_xorig 0 def /PSL_yorig 0 def
 /TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
-% To reencode one font with the provided encoding vector
+% To re-encode one font with the provided encoding vector
 /PSL_reencode {findfont dup length dict begin
   {1 index /FID ne {def}{pop pop} ifelse} forall
   exch /Encoding edef currentdict end definefont pop

--- a/src/PSL_strings.h
+++ b/src/PSL_strings.h
@@ -1032,7 +1032,7 @@ static char *PSL_prologue_str =
 "% Translate and memorize advance\n"
 "/PSL_xorig 0 def /PSL_yorig 0 def\n"
 "/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!\n"
-"% To reencode one font with the provided encoding vector\n"
+"% To re-encode one font with the provided encoding vector\n"
 "/PSL_reencode {findfont dup length dict begin\n"
 "  {1 index /FID ne {def}{pop pop} ifelse} forall\n"
 "  exch /Encoding edef currentdict end definefont pop\n"

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -75,7 +75,7 @@
  * PSL_setdefaults	   : Change several PSL session default values
  * PSL_setdash		   : Specify pattern for dashed line
  * PSL_setfill		   : Sets the fill color or pattern
- * PSL_setfont		   : Changes current font and possibly reencodes it to current encoding
+ * PSL_setfont		   : Changes current font and possibly re-encodes it to current encoding
  * PSL_setformat	   : Changes # of decimals used in color and gray specs [3]
  * PSL_setlinecap	   : Changes the line cap setting
  * PSL_setlinejoin	   : Changes the line join setting
@@ -1465,7 +1465,7 @@ static int psl_putfont (struct PSL_CTRL *PSL, double fontsize) {
 
 static int psl_encodefont (struct PSL_CTRL *PSL, int font_no) {
 	if (PSL->init.encoding == NULL) return (PSL_NO_ERROR);		/* Already have StandardEncoding by default */
-	if (PSL->internal.font[font_no].encoded) return (PSL_NO_ERROR);	/* Already reencoded or should not be reencoded ever */
+	if (PSL->internal.font[font_no].encoded) return (PSL_NO_ERROR);	/* Already re-encoded or should not be re-encoded ever */
 
 	/* Re-encode fonts with Standard+ or ISOLatin1[+] encodings */
 	PSL_command (PSL, "PSL_font_encode %d get 0 eq {%s_Encoding /%s /%s PSL_reencode PSL_font_encode %d 1 put} if", font_no, PSL->init.encoding, PSL->internal.font[font_no].name, PSL->internal.font[font_no].name, font_no);

--- a/src/postscriptlight_f77.c
+++ b/src/postscriptlight_f77.c
@@ -64,7 +64,7 @@
  * PSL_setdefaults	: Change several PSL session default values
  * PSL_setdash		: Specify pattern for dashed line
  * PSL_setfill		: Sets the fill color or pattern
- * PSL_setfont		: Changes current font and possibly reencodes it to current encoding
+ * PSL_setfont		: Changes current font and possibly re-encodes it to current encoding
  * PSL_setformat	: Changes # of decimals used in color and gray specs [3]
  * PSL_setlinecap	: Changes the line cap setting
  * PSL_setlinejoin	: Changes the line join setting


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the Debian package build of GMT 6.0.0rc1:

 * reencode -> re-encode
