### PR TITLE
Allow GMT5-style -G option in pswiggle

### DIFF
--- a/src/pswiggle.c
+++ b/src/pswiggle.c
@@ -335,7 +335,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSWIGGLE_CTRL *Ctrl, struct GM
 					}
 					c[0] = '\0';	/* Chop off all modifiers */
 				}
-				else if (gmt_M_compat_check (GMT, 5)) {	/* Allow old syntax -G+|-|=<fill> */
+				else if (strchr ("-+=", opt->arg[0])) {	/* Allow old syntax -G+|-|=<fill> */
 					switch (opt->arg[0]) {
 						case '=': j = 1, pos = neg = true; break;
 						case '+': j = 1, pos = true; 	   break;


### PR DESCRIPTION
A bit too harsh to not check for old syntax unless compatibility mode was set properly. Closes #1104.
