### PR TITLE
mapproject erroneously complaied about leading sign in unit

### DIFF
--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -267,7 +267,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 GMT_LOCAL char set_unit_and_mode (struct GMTAPI_CTRL *API, char *arg, unsigned int *mode) {
 	unsigned int k = 0;
 	*mode = GMT_GREATCIRCLE;	/* Default is great circle distances */
-	if (arg[0]) {
+	if (strchr ("-+", arg[0])) {
 		if (gmt_M_compat_check (API->GMT, 6))
 			GMT_Report (API, GMT_MSG_COMPAT, "Leading -|+ with unit to set flat Earth or ellipsoidal mode is deprecated; use -j<mode> instead\n");
 		else {


### PR DESCRIPTION
When gmt mapproject **-Gk** was run it acted as if **-G**±**k** had been given and gave a compatibility message about using **-j** instead.  Now we do a better job of checking the argument.

