### PR TITLE
Let grdcontour/pscontour be able to have unique pen per contour

### DIFF
--- a/doc/rst/source/contour_common.rst_
+++ b/doc/rst/source/contour_common.rst_
@@ -71,7 +71,8 @@ Optional Arguments
         col 2. The levels marked C (or c) are contoured, the levels marked A
         (or a) are contoured and annotated. Optionally, a third column may
         be present and contain the fixed annotation angle for this contour
-        level.
+        level. If so, an optional fourth column may be present and hold a
+	contour-specific pen.
 
     (3) If *contours* is a string with comma-separated values it is interpreted
         as those specific contours only.  To indicate a single specific contour

--- a/doc/rst/source/grdcontour_common.rst_
+++ b/doc/rst/source/grdcontour_common.rst_
@@ -56,7 +56,8 @@ Optional Arguments
         col 2. The levels marked C (or c) are contoured, the levels marked A
         (or a) are contoured and annotated. Optionally, a third column may
         be present and contain the fixed annotation angle for this contour
-        level.
+        level. If so, an optional fourth column may be present and hold a
+	contour-specific pen.
 
     (3) If *contours* is a string with comma-separated values it is interpreted
         as those specific contours only.  To indicate a single specific contour

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -1395,8 +1395,8 @@ int GMT_grdcontour (void *V_API, int mode, void *args) {
 			cont[n_contours].do_tick = (Ctrl->T.active && (cont[n_contours].type == 'C' || cont[n_contours].type == 'A')) ? 1 : 0;
 			cont[n_contours].angle = (got == 3) ? tmp : GMT->session.d_NaN;
 			if (got >= 3) Ctrl->contour.angle_type = 2;	/* Must set this directly if angles are provided */
-			if (got == 4) {
-				if (gmt_getpen (GMT, pen, &cont[n_contours].pen)) {
+			if (got == 4) {	/* Also got a pen specification for this contour */
+				if (gmt_getpen (GMT, pen, &cont[n_contours].pen)) {	/* Bad pen syntax */
 					gmt_pen_syntax (GMT, 'C', " ", 0);
 					Return (GMT_RUNTIME_ERROR);
 				}

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -974,7 +974,7 @@ int GMT_grdcontour (void *V_API, int mode, void *args) {
 	/* High-level function that implements the grdcontour task */
 	int error, c;
 	bool need_proj, make_plot, two_only = false, begin, is_closed, data_is_time = false;
-	bool use_contour = true, use_t_offset = false, mem_G = false, individual_pens = false;
+	bool use_contour = true, use_t_offset = false, mem_G = false;
 
 	enum grdcontour_contour_type closed;
 
@@ -1400,7 +1400,7 @@ int GMT_grdcontour (void *V_API, int mode, void *args) {
 					gmt_pen_syntax (GMT, 'C', " ", 0);
 					Return (GMT_RUNTIME_ERROR);
 				}
-				individual_pens = cont[n_contours].penset = true;
+				cont[n_contours].penset = true;
 			}
 			
 			n_contours++;
@@ -1581,7 +1581,7 @@ int GMT_grdcontour (void *V_API, int mode, void *args) {
 
 		id = (cont[c].type == 'A' || cont[c].type == 'a') ? 1 : 0;
 
-		if (individual_pens && cont[c].penset)
+		if (cont[c].penset)
 			Ctrl->contour.line_pen = cont[c].pen;	/* Load contour-specific pen into contour structure */
 		else
 			Ctrl->contour.line_pen = Ctrl->W.pen[id];	/* Load current pen into contour structure */

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -205,7 +205,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   1. Fixed contour interval.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   2. Comma-separated contours (for single contour append comma to be seen as list).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   3. File with contour levels in col 1 and C(ont) or A(nnot) in col 2\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      [and optionally an individual annotation angle in col 3 and optionally a pen on col 4].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t      [and optionally an individual annotation angle in col 3 and optionally a pen in col 4].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   4. Name of a CPT.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If -T is used, only contours with upper case C or A is ticked\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     [CPT contours are set to C unless the CPT flags are set;\n");

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -803,7 +803,7 @@ int GMT_contour (void *V_API, int mode, void *args) {
 int GMT_pscontour (void *V_API, int mode, void *args) {
 	int add, error = 0;
 	bool two_only = false, make_plot, skip = false, convert, get_contours, is_closed;
-	bool use_contour = true, skip_points, skip_triangles, individual_pens = false;
+	bool use_contour = true, skip_points, skip_triangles;
 	
 	unsigned int pscontour_sum, m, n, nx, k2, k3, node1, node2, c, cont_counts[2] = {0, 0};
 	unsigned int label_mode = 0, last_entry, last_exit, fmt[3] = {0, 0, 0}, n_skipped, n_out;
@@ -1147,7 +1147,7 @@ int GMT_pscontour (void *V_API, int mode, void *args) {
 					gmt_pen_syntax (GMT, 'C', " ", 0);
 					Return (GMT_RUNTIME_ERROR);
 				}
-				individual_pens = cont[c].penset = true;
+				cont[c].penset = true;
 			}
 			cont[c].do_tick = Ctrl->T.active;
 			c++;
@@ -1477,7 +1477,7 @@ int GMT_pscontour (void *V_API, int mode, void *args) {
 
 			id = (cont[c].type == 'A' || cont[c].type == 'a') ? 1 : 0;
 
-			if (individual_pens && cont[c].penset)
+			if (cont[c].penset)
 				Ctrl->contour.line_pen = cont[c].pen;		/* Load contour-specific pen into contour structure */
 			else
 				Ctrl->contour.line_pen = Ctrl->W.pen[id];	/* Load current pen into contour structure */

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -413,7 +413,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   1. Fixed contour interval.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   2. Comma-separated contours (for single contour append comma to be seen as list).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   3. File with contour levels in col 1 and C(ont) or A(nnot) in col 2\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      [and optionally an individual annotation angle in col 3 and optionally a pen on col 4].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t      [and optionally an individual annotation angle in col 3 and optionally a pen in col 4].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   4. Name of a CPT.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If -T is used, only contours with upper case C or A is ticked\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     [CPT contours are set to C unless the CPT flags are set;\n");

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -1142,8 +1142,8 @@ int GMT_pscontour (void *V_API, int mode, void *args) {
 			cont[c].do_tick = (Ctrl->T.active && ((cont[c].type == 'C') || (cont[c].type == 'A'))) ? true : false;
 			cont[c].angle = (got == 3) ? tmp : GMT->session.d_NaN;
 			if (got >= 3) Ctrl->contour.angle_type = 2;	/* Must set this directly if angles are provided */
-			if (got == 4) {
-				if (gmt_getpen (GMT, pen, &cont[c].pen)) {
+			if (got == 4) {	/* Also got a pen specification for this contour */
+				if (gmt_getpen (GMT, pen, &cont[c].pen)) {	/* Bad pen syntax */
 					gmt_pen_syntax (GMT, 'C', " ", 0);
 					Return (GMT_RUNTIME_ERROR);
 				}

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -126,9 +126,10 @@ struct PSCONTOUR {
 	double angle;
 	size_t n_alloc;
 	unsigned int nl;
-	bool do_tick;
+	bool do_tick, penset;
 	struct PSCONTOUR_LINE *L;
 	char type;
+	struct GMT_PEN pen;
 };
 
 struct PSCONTOUR_PT {
@@ -412,7 +413,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   1. Fixed contour interval.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   2. Comma-separated contours (for single contour append comma to be seen as list).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   3. File with contour levels in col 1 and C(ont) or A(nnot) in col 2\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      [and optionally an individual annotation angle in col 3].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t      [and optionally an individual annotation angle in col 3 and optionally a pen on col 4].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   4. Name of a CPT.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If -T is used, only contours with upper case C or A is ticked\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     [CPT contours are set to C unless the CPT flags are set;\n");
@@ -802,7 +803,7 @@ int GMT_contour (void *V_API, int mode, void *args) {
 int GMT_pscontour (void *V_API, int mode, void *args) {
 	int add, error = 0;
 	bool two_only = false, make_plot, skip = false, convert, get_contours, is_closed;
-	bool use_contour = true, skip_points, skip_triangles;
+	bool use_contour = true, skip_points, skip_triangles, individual_pens = false;
 	
 	unsigned int pscontour_sum, m, n, nx, k2, k3, node1, node2, c, cont_counts[2] = {0, 0};
 	unsigned int label_mode = 0, last_entry, last_exit, fmt[3] = {0, 0, 0}, n_skipped, n_out;
@@ -1105,9 +1106,10 @@ int GMT_pscontour (void *V_API, int mode, void *args) {
 		if (za) gmt_M_free (GMT, za);
 		if (zc) gmt_M_free (GMT, zc);
 	}
-	else if (Ctrl->C.file) {	/* read contour info from file with cval C|A [angle] records */
+	else if (Ctrl->C.file) {	/* Read contour info from file with cval C|A [angle [pen]] records */
 		struct GMT_RECORD *Rec = NULL;
 		int got, in_ID, NL;
+		char pen[GMT_LEN64] = {""};
 		double tmp;
 
 		/* Must register Ctrl->C.file first since we are going to read rec-by-rec from all available source */
@@ -1139,7 +1141,14 @@ int GMT_pscontour (void *V_API, int mode, void *args) {
 			if (cont[c].type == '\0') cont[c].type = 'C';
 			cont[c].do_tick = (Ctrl->T.active && ((cont[c].type == 'C') || (cont[c].type == 'A'))) ? true : false;
 			cont[c].angle = (got == 3) ? tmp : GMT->session.d_NaN;
-			if (got == 3) Ctrl->contour.angle_type = 2;	/* Must set this directly if angles are provided */
+			if (got >= 3) Ctrl->contour.angle_type = 2;	/* Must set this directly if angles are provided */
+			if (got == 4) {
+				if (gmt_getpen (GMT, pen, &cont[c].pen)) {
+					gmt_pen_syntax (GMT, 'C', " ", 0);
+					Return (GMT_RUNTIME_ERROR);
+				}
+				individual_pens = cont[c].penset = true;
+			}
 			cont[c].do_tick = Ctrl->T.active;
 			c++;
 		} while (true);
@@ -1468,7 +1477,10 @@ int GMT_pscontour (void *V_API, int mode, void *args) {
 
 			id = (cont[c].type == 'A' || cont[c].type == 'a') ? 1 : 0;
 
-			Ctrl->contour.line_pen = Ctrl->W.pen[id];	/* Load current pen into contour structure */
+			if (individual_pens && cont[c].penset)
+				Ctrl->contour.line_pen = cont[c].pen;		/* Load contour-specific pen into contour structure */
+			else
+				Ctrl->contour.line_pen = Ctrl->W.pen[id];	/* Load current pen into contour structure */
 
 			if (Ctrl->W.cpt_effect) {
 				gmt_get_rgb_from_z (GMT, P, cont[c].val, rgb);


### PR DESCRIPTION
The **-C**_file_ option allows these modules to read specific contours, flag them as **C** or **A**, and optionally get a fixed annotation angle.  This PR adds an optional 4th item, a _pen_, that may be read from the file.  This allows each contour to be drawn with a unique pen.  If the pen is not present then we default the the one set via **-W**.  This enhancement is in support of #322.
