### PR TITLE
Ensure grd2kml -I uses the same usage and parsing as grdimage

### DIFF
--- a/doc/rst/source/grd2kml.rst
+++ b/doc/rst/source/grd2kml.rst
@@ -94,13 +94,14 @@ Optional Arguments
 
 **-I**\ [*intensfile*\ \|\ *intensity*\ \|\ *modifiers*]
     Gives the name of a grid file with intensities in the (-1,+1) range,
-    or a constant intensity to apply everywhere; this simply affects the
-    ambient light.  If just **+** is given then we derive an intensity
-    grid from the input data grid *grd_z* via a call to :doc:`grdgradient`
-    using the arguments **-A**\ -45 and **-Nt**\ 1 for that module. You can
-    append **+a**\ *azimuth* and **+n**\ *args* to override those values.  If you want
-    more specific intensities then run :doc:`grdgradient` separately first.
+    or a constant intensity to apply everywhere (affects the ambient light).
+    Alternatively, derive an intensity grid from the input data grid *grid*
+    via a call to :doc:`grdgradient`; append **+a**\ *azimuth* and **+n**\ *args*
+    to specify azimuth and intensity arguments for that module or just give **+d**
+    to select the default arguments (**+a**\ -45\ **+nt**\ 1). If you want a more
+    specific intensity scenario then run :doc:`grdgradient` separately first.
     [Default is no illumination].
+
 
 .. _-L:
 

--- a/src/grd2kml.c
+++ b/src/grd2kml.c
@@ -159,8 +159,8 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-H Tell psconvert to do sub-pixel smoothing using factor <factor> [no sub-pixel smoothing].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Apply directional illumination. Append name of intensity grid file.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   For a constant intensity (i.e., change the ambient light), append a single value.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   To derive intensities from <grid> instead, append +a<azim> [-45] and +n<method> [t1].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Use -I+ to accept the default values (see grdgradient for details).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   To derive intensities from <grid> instead, append +a<azim> [-45] and +n<method> [t1]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   or use -I+d to accept the default values (see grdgradient for details).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-L Set tile size as a power of 2 [256].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Q Use PS Level 3 colormasking to make nodes with z = NaN transparent.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-T Set title (document description) for the top-level KML.\n");
@@ -235,7 +235,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRD2KML_CTRL *Ctrl, struct GMT
 				break;
 			case 'I':	/* Here, intensity must be a grid file since we need to filter it */
 				Ctrl->I.active = true;
-				if ((c = gmt_first_modifier (GMT, opt->arg, "an"))) {	/* Want to control how grdgradient is run */
+				if (!strcmp (opt->arg, "+d"))	/* Gave +d only, so derive intensities from input grid using default settings */
+					Ctrl->I.derive = true;
+				else if ((c = gmt_first_modifier (GMT, opt->arg, "an"))) {	/* Want to control how grdgradient is run */
 					unsigned int pos = 0;
 					char p[GMT_BUFSIZ] = {""};
 					Ctrl->I.derive = true;


### PR DESCRIPTION
When **-I+d** was introduced for grdimage we forgot to do the same to grd2kml.  This PR completes that implementation.
