### PR TITLE
Fix Windows CI builds due to vcpkg clapack and openblas issues

### DIFF
--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -9,7 +9,8 @@ steps:
     echo 'set(VCPKG_BUILD_TYPE release)' >> ${VCPKG_INSTALLATION_ROOT}/triplets/x64-windows.cmake
     cat ${VCPKG_INSTALLATION_ROOT}/triplets/x64-windows.cmake
     # install libraries
-    vcpkg install netcdf-c gdal pcre fftw3 clapack openblas --triplet x64-windows
+    #vcpkg install netcdf-c gdal pcre fftw3 clapack openblas --triplet x64-windows
+    vcpkg install netcdf-c gdal pcre fftw3 --triplet x64-windows
     # hook up user-wide integration
     vcpkg integrate install
     # list installed libraries


### PR DESCRIPTION
vcpkg recently builds problematic clacpak and openblas libraries, making our Windows CI builds fail.

In this PR, I remove clapack and openblas from library building list to fix the issue temporarily.