### PR TITLE
See if using ; under Windows work better for dirs

### DIFF
--- a/doc/rst/source/GMT_Docs.rst
+++ b/doc/rst/source/GMT_Docs.rst
@@ -4286,7 +4286,7 @@ Variable $GMT_DATADIR and parameter DIR_DATA
     the current directory. This allows maintainers to consolidate large
     data files and to simplify scripting that use these files since the
     absolute path need not be specified. Separate multiple directories
-    with colons (:) – under Windows use semi-colons (;). Any directory
+    with commas. Any directory
     name that ends in a trailing slash (/) will be searched recursively
     (not under Windows).
 

--- a/doc/rst/source/GMT_Docs_classic.rst
+++ b/doc/rst/source/GMT_Docs_classic.rst
@@ -4335,7 +4335,7 @@ Variable $GMT_DATADIR and parameter DIR_DATA
     the current directory. This allows maintainers to consolidate large
     data files and to simplify scripting that use these files since the
     absolute path need not be specified. Separate multiple directories
-    with colons (:) – under Windows use semi-colons (;). Any directory
+    with commas. Any directory
     name that ends in a trailing slash (/) will be searched recursively
     (not under Windows).
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -2830,6 +2830,7 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 			gmt_dos_path_fix (GMT->session.DATADIR);
 		}
 #endif
+		gmt_replace_backslash_in_path (GMT->session.DATADIR);
 		gmt_strrepc (GMT->session.DATADIR, PATH_SEPARATOR, ',');	/* Use comma for OS-independent separator */
 	}
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -2819,7 +2819,7 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 	/* Determine GMT_DATADIR (data directories) */
 
 	if ((this_c = getenv ("GMT_DATADIR")) != NULL) {		/* GMT_DATADIR was set */
-		if (strchr (this_c, PATH_SEPARATOR) || access (this_c, R_OK) == 0) {
+		if (strchr (this_c, ',') || strchr (this_c, PATH_SEPARATOR) || access (this_c, R_OK) == 0) {
 			/* A list of directories or a single directory that is accessible */
 			GMT->session.DATADIR = strdup (this_c);
 			gmt_dos_path_fix (GMT->session.DATADIR);
@@ -2827,9 +2827,10 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 #ifdef WIN32
 		else if (strchr(this_c, ':')) {		/* May happen to have ':' as a path separator when running a MSYS bash shell*/
 			GMT->session.DATADIR = strdup(this_c);
-			gmt_dos_path_fix(GMT->session.DATADIR);
+			gmt_dos_path_fix (GMT->session.DATADIR);
 		}
 #endif
+		gmt_strrepc (GMT->session.DATADIR, PATH_SEPARATOR, ',');	/* Use comma for OS-independent separator */
 	}
 
 	/* Determine GMT_TMPDIR (for isolation mode). Needs to exist use it. */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -4831,7 +4831,7 @@ char *gmt_getdatapath (struct GMT_CTRL *GMT, const char *stem, char *path, int m
 	size_t L;
 	bool found;
 	char *udir[6] = {GMT->session.USERDIR, GMT->session.DATADIR, GMT->session.CACHEDIR, NULL, NULL, NULL}, dir[PATH_MAX];
-	char path_separator[2] = {PATH_SEPARATOR, '\0'}, serverdir[PATH_MAX] = {""}, srtm1dir[PATH_MAX] = {""}, srtm3dir[PATH_MAX] = {""};
+	char path_separator[2] = {',', '\0'}, serverdir[PATH_MAX] = {""}, srtm1dir[PATH_MAX] = {""}, srtm3dir[PATH_MAX] = {""};
 #ifdef HAVE_DIRENT_H_
 	size_t N;
 #endif /* HAVE_DIRENT_H_ */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8566,8 +8566,10 @@ int gmt_rename_file (struct GMT_CTRL *GMT, const char *oldfile, const char *newf
 
 void gmt_replace_backslash_in_path (char *dir) {
 	size_t k = 0;
-	while (dir[k])
+	while (dir[k]) {
 		if (dir[k] == '\\') dir[k] = '/';
+		k++;
+	}
 }
 
 /*! . */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8564,6 +8564,12 @@ int gmt_rename_file (struct GMT_CTRL *GMT, const char *oldfile, const char *newf
 	return errno;
 }
 
+void gmt_replace_backslash_in_path (char *dir) {
+	size_t k = 0;
+	while (dir[k])
+		if (dir[k] == '\\') dir[k] = '/';
+}
+
 /*! . */
 void gmt_set_column (struct GMT_CTRL *GMT, unsigned int direction, unsigned int col, enum gmt_col_enum type) {
 	/* Sets the column type for this input or output column or both (dir == GMT_IO) */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -233,6 +233,7 @@ EXTERN_MSC int gmt_set_psfilename (struct GMT_CTRL *GMT);
 
 /* gmt_io.c: */
 
+EXTERN_MSC void gmt_replace_backslash_in_path (char *dir);
 EXTERN_MSC void gmt_disable_bhi_opts (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmt_reenable_bhi_opts (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmt_insert_tableheader (struct GMT_CTRL *GMT, struct GMT_DATATABLE *T, char *txt);

--- a/src/movie.c
+++ b/src/movie.c
@@ -1045,7 +1045,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 #endif
 
 	if (GMT->session.DATADIR)	/* Prepend initial and subdir as new datadirs to the existing search list */
-		sprintf (datadir, "%s%c%s%c%s", topdir, path_sep[path_id], cwd, path_sep[path_id, GMT->session.DATADIR);
+		sprintf (datadir, "%s%c%s%c%s", topdir, path_sep[path_id], cwd, path_sep[path_id], GMT->session.DATADIR);
 	else	/* Set the initial and prefix subdirectory as data dirs */
 		sprintf (datadir, "%s%c%s", topdir, path_sep[path_id], cwd);
 	if (Ctrl->W.active && strlen (Ctrl->W.dir) > 2) {	/* Also append a specific work directory with data files that we should search */

--- a/src/movie.c
+++ b/src/movie.c
@@ -867,14 +867,14 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	
 	unsigned int n_values = 0, n_frames = 0, frame, i_frame, col, p_width, p_height, k, T;
 	unsigned int n_frames_not_started = 0, n_frames_completed = 0, first_frame = 0, n_cores_unused;
-	unsigned int dd, hh, mm, ss, flavor = 0, path_id = 0;
+	unsigned int dd, hh, mm, ss, flavor = 0;
 	
 	bool done = false, layers = false, one_frame = false, has_text = false, is_classic = false, upper_case = false;
 	
 	char *extension[3] = {"sh", "csh", "bat"}, *load[3] = {"source", "source", "call"}, *rmfile[3] = {"rm -f", "rm -f", "del"};
 	char *rmdir[3] = {"rm -rf", "rm -rf", "rd /s /q"}, *export[3] = {"export ", "export ", ""};
 	char *mvfile[3] = {"mv -f", "mv -rf", "move"}, *sc_call[3] = {"bash ", "csh ", "start /B"};
-	char var_token[4] = "$$%", path_sep[4] = "::;";
+	char var_token[4] = "$$%";
 	char init_file[PATH_MAX] = {""}, state_tag[GMT_LEN16] = {""}, state_prefix[GMT_LEN64] = {""}, param_file[PATH_MAX] = {""}, cwd[PATH_MAX] = {""};
 	char pre_file[PATH_MAX] = {""}, post_file[PATH_MAX] = {""}, main_file[PATH_MAX] = {""}, line[PATH_MAX] = {""}, version[GMT_LEN32] = {""};
 	char string[GMT_LEN128] = {""}, extra[GMT_LEN256] = {""}, cmd[GMT_LEN256] = {""}, cleanup_file[PATH_MAX] = {""}, L_txt[GMT_LEN128] = {""};
@@ -1038,16 +1038,11 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	}
 
 	/* We use DATADIR to include the top and working directory so any files we supply or create can be found while inside frame directory */
-#ifdef WIN32
-	path_id = DOS_MODE;
-#else
-	path_id = Ctrl->In.mode;
-#endif
 
 	if (GMT->session.DATADIR)	/* Prepend initial and subdir as new datadirs to the existing search list */
-		sprintf (datadir, "%s%c%s%c%s", topdir, path_sep[path_id], cwd, path_sep[path_id], GMT->session.DATADIR);
+		sprintf (datadir, "%s,%s,%s", topdir, cwd, GMT->session.DATADIR);	/* Start with topdir */
 	else	/* Set the initial and prefix subdirectory as data dirs */
-		sprintf (datadir, "%s%c%s", topdir, path_sep[path_id], cwd);
+		sprintf (datadir, "%s,%s", topdir, cwd);
 	if (Ctrl->W.active && strlen (Ctrl->W.dir) > 2) {	/* Also append a specific work directory with data files that we should search */
 		char work_dir[PATH_MAX] = {""};
 #ifdef WIN32
@@ -1056,9 +1051,9 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		if (Ctrl->W.dir[0] != '/') /* Not hard path */
 #endif
 			/* Prepend cwd to the given relative path and update Ctrl->D.dir */
-			sprintf (work_dir, "%c%s%c%s", path_sep[path_id], topdir, dir_sep, Ctrl->W.dir);
+			sprintf (work_dir, ",%s,%s", topdir, Ctrl->W.dir);
 		else
-			sprintf (work_dir, "%c%s", path_sep[path_id], Ctrl->W.dir);
+			sprintf (work_dir, ",%s", Ctrl->W.dir);
 		strcat (datadir, work_dir);
 	}
 		

--- a/src/movie.c
+++ b/src/movie.c
@@ -867,7 +867,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	
 	unsigned int n_values = 0, n_frames = 0, frame, i_frame, col, p_width, p_height, k, T;
 	unsigned int n_frames_not_started = 0, n_frames_completed = 0, first_frame = 0, n_cores_unused;
-	unsigned int dd, hh, mm, ss, flavor = 0;
+	unsigned int dd, hh, mm, ss, flavor = 0, path_id = 0;
 	
 	bool done = false, layers = false, one_frame = false, has_text = false, is_classic = false, upper_case = false;
 	
@@ -1038,10 +1038,16 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	}
 
 	/* We use DATADIR to include the top and working directory so any files we supply or create can be found while inside frame directory */
+#ifdef WIN32
+	path_id = DOS_MODE;
+#else
+	path_id = Ctrl->In.mode;
+#endif
+
 	if (GMT->session.DATADIR)	/* Prepend initial and subdir as new datadirs to the existing search list */
-		sprintf (datadir, "%s%c%s%c%s", topdir, path_sep[Ctrl->In.mode], cwd, path_sep[Ctrl->In.mode], GMT->session.DATADIR);
+		sprintf (datadir, "%s%c%s%c%s", topdir, path_sep[path_id], cwd, path_sep[path_id, GMT->session.DATADIR);
 	else	/* Set the initial and prefix subdirectory as data dirs */
-		sprintf (datadir, "%s%c%s", topdir, path_sep[Ctrl->In.mode], cwd);
+		sprintf (datadir, "%s%c%s", topdir, path_sep[path_id], cwd);
 	if (Ctrl->W.active && strlen (Ctrl->W.dir) > 2) {	/* Also append a specific work directory with data files that we should search */
 		char work_dir[PATH_MAX] = {""};
 #ifdef WIN32
@@ -1050,9 +1056,9 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		if (Ctrl->W.dir[0] != '/') /* Not hard path */
 #endif
 			/* Prepend cwd to the given relative path and update Ctrl->D.dir */
-			sprintf (work_dir, "%c%s%c%s", path_sep[Ctrl->In.mode], topdir, dir_sep, Ctrl->W.dir);
+			sprintf (work_dir, "%c%s%c%s", path_sep[path_id], topdir, dir_sep, Ctrl->W.dir);
 		else
-			sprintf (work_dir, "%c%s", path_sep[Ctrl->In.mode], Ctrl->W.dir);
+			sprintf (work_dir, "%c%s", path_sep[path_id], Ctrl->W.dir);
 		strcat (datadir, work_dir);
 	}
 		

--- a/src/movie.c
+++ b/src/movie.c
@@ -858,6 +858,18 @@ void close_files (struct MOVIE_CTRL *Ctrl) {
 	if (Ctrl->I.active) fclose (Ctrl->I.fp);
 }
 
+void double_backslahes_if_dos (char *dir) {
+	char tmp[PATH_MAX] = {""};
+	size_t k = 0, j = 0;
+	if (strchr (dir, '\\') == NULL) return;	/* No backslashes */
+	while (dir[k]) {
+		if (dir[k] == '\\') tmp[j++] = '\\';
+		tmp[j++] = dir[k++];
+	}
+	tmp[j] = '\0';
+	strncpy (dir, tmp, j);
+}
+
 #define bailout(code) {gmt_M_free_options (mode); return (code);}
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
@@ -1056,7 +1068,8 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			sprintf (work_dir, ",%s", Ctrl->W.dir);
 		strcat (datadir, work_dir);
 	}
-		
+	double_backslahes_if_dos (datadir);	/* Since we will be fprintf the path we must use // for a slash */
+	
 	/* Create the initialization file with settings common to all frames */
 	
 	sprintf (init_file, "movie_init.%s", extension[Ctrl->In.mode]);


### PR DESCRIPTION
In movie, we select the directory path separator based on the scripting language, but since this fails on Windows perhaps we should always select ; there.  Give it a try on the animation tests, @seisman.
