### PR TITLE
Publish the build directory if failed for debugging purpose

### DIFF
--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -61,6 +61,19 @@ steps:
   displayName: Full tests
   condition: eq(variables['TEST'], true)
 
+# Publish the whole build directory for debugging purpose
+- task: CopyFiles@2
+  inputs:
+    contents: 'build/**/*'
+    targetFolder: $(Build.ArtifactStagingDirectory)
+  condition: failed()
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathToPublish: $(Build.ArtifactStagingDirectory)
+    artifactName: BuildDirectory
+  displayName: Publish build directory
+  condition: failed()
+
 # Upload test coverage even if build fails. Keep separate to make sure this task fails
 # if the tests fail.
 - bash: |


### PR DESCRIPTION
If a build fails, this PR will publish/upload the whole build directory as Azure Pipeline artifacts. We can download this zipped file from the build status page and check the generated PS files.
![image](https://user-images.githubusercontent.com/3974108/60850493-a7588d00-a1bd-11e9-9ea2-a9dd8679d7df.png)
