### PR TITLE
GMT_Create_Options must always allocate memory

### DIFF
--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -595,7 +595,7 @@ EXTERN_MSC void gmt_cart_to_polar (struct GMT_CTRL *GMT, double *r, double *thet
 
 /* From gmt_parse.c */
 /* This macro is called via each modules Return macro so API and options are set */
-#define gmt_M_free_options(mode) {if (mode >= 0 && GMT_Destroy_Options (API, &options) != GMT_OK) exit (GMT_MEMORY_ERROR);}
+#define gmt_M_free_options(mode) {if (GMT_Destroy_Options (API, &options) != GMT_OK) exit (GMT_MEMORY_ERROR);}
 
 /* From gmt_api.c */
 EXTERN_MSC struct GMTAPI_CTRL *gmt_get_api_ptr (struct GMTAPI_CTRL *ptr);


### PR DESCRIPTION
When users of the API passes a linked list of GMT_OPTION struct pointers to _GMT_Create_Option_ it cannot just return that pointer but must duplicate the list first and return the head of that duplicate.  That way, _gmt_M_free_options_ can always free the options link so that we honor the "const" modifier for the input argument to _GMT_Create_Options_. See #1132 for context.  Closes #1132.
