### PR TITLE
Clean up psconvert Unix code, comments, and monochrome image option

### DIFF
--- a/doc/rst/source/psconvert.rst
+++ b/doc/rst/source/psconvert.rst
@@ -26,7 +26,7 @@ Synopsis
 [ **-Mb**\ \|\ **f**\ *pslayer* ]
 [ |-Q|\ [**g**\ \|\ **p**\ \|\ **t**][1\|2\|4] ]
 [ |-S| ]
-[ |-T|\ **b**\ \|\ **e**\ \|\ **E**\ \|\ **f**\ \|\ **F**\ \|\ **j**\ \|\ **g**\ \|\ **G**\ \|\ **m**\ \|\ **s**\ \|\ **t** ]
+[ |-T|\ **b**\ \|\ **e**\ \|\ **E**\ \|\ **f**\ \|\ **F**\ \|\ **j**\ \|\ **g**\ \|\ **G**\ \|\ **m**\ \|\ **s**\ \|\ **t**\ [**+m**\ ]\ ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *params* ]
 [ |-Z| ]
@@ -186,13 +186,13 @@ Optional Arguments
 
 .. _-T:
 
-**-Tb**\ \|\ **e**\ \|\ **E**\ \|\ **f**\ \|\ **F**\ \|\ **j**\ \|\ **g**\ \|\ **G**\ \|\ **m**\ \|\ **s**\ \|\ **t**
+**-Tb**\ \|\ **e**\ \|\ **E**\ \|\ **f**\ \|\ **F**\ \|\ **j**\ \|\ **g**\ \|\ **G**\ \|\ **m**\ \|\ **s**\ \|\ **t**\ [**+m**\ ]
     Sets the output format, where **b** means BMP, **e** means EPS,
     **E** means EPS with PageSize command, **f** means PDF, **F** means
     multi-page PDF, **j** means JPEG, **g** means PNG, **G** means
     transparent PNG (untouched regions are transparent), **m** means
     PPM, **s** means SVG, and **t** means TIFF [default is JPEG]. To **bjgt** you can
-    append **-** in order to get a grayscale image. The EPS format can be
+    append **+m** in order to get a monochrome (grayscale) image. The EPS format can be
     combined with any of the other formats. For example, **-Tef**
     creates both an EPS and a PDF file. The **-TF** creates a multi-page
     PDF file from the list of input PS or PDF files. It requires the **-F** option.


### PR DESCRIPTION
Some of the unused Unix piping code needed cleaning.  I added some more comments here and there, and changed the optional trailing - in **-T** for grayscale image to a modifier (**+m** for monochrome, like **+m** for **-Q** in grdview).  Backwards compatible of course, and tested.

