### PR TITLE
Update macOS CI settings

### DIFF
--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -4,6 +4,7 @@ steps:
 
 - bash: |
     set -x -e
+    brew update
     brew install cmake ninja curl netcdf gdal fftw pcre2 ghostscript || true
   displayName: Install dependencies
 
@@ -57,8 +58,10 @@ steps:
     # Download remote files before testing, see #939.
     curl http://www.soest.hawaii.edu/gmt/data/gmt_md5_server.txt | awk 'NF==3 && $1!~/earth/ {print "@"$1}' | xargs gmt which -Gc
     gmt which -Gu @earth_relief_01m @earth_relief_02m @earth_relief_04m @earth_relief_05m @earth_relief_10m @earth_relief_15m
-    ctest --output-on-failure --force-new-ctest-process -j4
+    # run all jobs and rerun if failed
+    ctest ${CTEST_ARGS} || ctest ${CTEST_ARGS} --rerun-failed
   displayName: Full tests
+  env: {"CTEST_ARGS": "--output-on-failure --force-new-ctest-process -j4 --timeout 360"}
   condition: eq(variables['TEST'], true)
 
 # Publish the whole build directory for debugging purpose


### PR DESCRIPTION
Need to run `brew update` to update homebrew formula, so that we can install a "bug-free" ghostscript 9.27_1 via homebrew.