### PR TITLE
Allow PS_ORIENTATION parsing under mdoern mode

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9175,14 +9175,12 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			GMT_COMPAT_TRANSLATE ("PS_PAGE_ORIENTATION");
 			break;
 		case GMTCASE_PS_PAGE_ORIENTATION:
-			if (GMT->current.setting.run_mode == GMT_CLASSIC) {	/* Ignore under modern mode */
-				if (!strcmp (lower_value, "landscape"))
-					GMT->current.setting.ps_orientation = PSL_LANDSCAPE;
-				else if (!strcmp (lower_value, "portrait"))
-					GMT->current.setting.ps_orientation = PSL_PORTRAIT;
-				else
-					error = true;
-			}
+			if (!strcmp (lower_value, "landscape"))
+				GMT->current.setting.ps_orientation = PSL_LANDSCAPE;
+			else if (!strcmp (lower_value, "portrait"))
+				GMT->current.setting.ps_orientation = PSL_PORTRAIT;
+			else
+				error = true;
 			break;
 		case GMTCASE_PAPER_MEDIA:
 			GMT_COMPAT_TRANSLATE ("PS_MEDIA");


### PR DESCRIPTION
We had turned this off, but as long as we allow users to select the ps format then they needto be able to control orientation of the paper.  Closes #1141.

