### PR TITLE
Fix test/psxy/categorical.sh in Windows CI builds

### DIFF
--- a/test/psxy/categorical.sh
+++ b/test/psxy/categorical.sh
@@ -3,8 +3,8 @@
 # the aspatial field NAME via the CPT to yield pen color 
 ps=categorical.ps
 # Get an OGR file from test cache and convert to shapefile
-gmt which -Gl @RidgeTest.gmt
-ogr2ogr -f "ESRI Shapefile" RidgeTest.shp RidgeTest.gmt
+test_data=`gmt which -Gl @RidgeTest.gmt`
+ogr2ogr -f "ESRI Shapefile" RidgeTest.shp $test_data
 # Make a text-based categorical cpt file
 cat << EOF > ridge.cpt
 Reykjanes	red


### PR DESCRIPTION
In CI builds, we download all test data to the cache directory before running the tests. This works for all tests but breaks `test/psxy/categorical.sh`.

In `test/psxy/categorical.sh`, ogr2ogr tries to read the data `RidgeTest.gmt` from current directory. However, as the data has been downloaded in the cache directory, `gmt which -Gl @RidgeTest.gmt` won't download it to current directory.

I expect to see the test fails on all platforms, but it passes on Linux and macOS, and only fails on Windows. I don't know why but this PR may help avoid the possible problem on all platforms.