### PR TITLE
Fix pstext bug and update example scripts

### DIFF
--- a/doc/examples/ex03/example_03.sh
+++ b/doc/examples/ex03/example_03.sh
@@ -4,7 +4,7 @@
 # Purpose:	Resample track data, do spectral analysis, and plot
 # GMT modules:	filter1d, fitcircle, gmtconvert, gmtinfo, project, sample1d
 # GMT modules:	spectrum1d, trend1d, pshistogram, psxy, pstext
-# Unix progs:	echo, rm
+# Unix progs:	rm
 #
 # This example begins with data files "ship_03.txt" and "sat_03.txt" which
 # are measurements of a quantity "g" (a "gravity anomaly" which is an
@@ -106,13 +106,12 @@ gmt convert -A samp_ship.pg samp_sat.pg -o1,3 | gmt spectrum1d -S256 -D1 -W -C -
 gmt psxy spectrum.coh -Bxa1f3p+l"Wavelength (km)" -Bya0.25f0.05+l"Coherency@+2@+" \
 	-BWeSn+g240/255/240 -JX-4il/3.75i -R1/1000/0/1 -P -K -X2.5i -Sc0.07i -Gpurple \
 	-Ey+p0.5p -Y1.5i > $ps
-echo "Coherency@+2@+" | gmt pstext -R -J -F+cTR+f18p,Helvetica-Bold -Dj0.1i \
-	-O -K >> $ps
+gmt pstext -R -J -F+cTR+f18p,Helvetica-Bold+tCoherency@+2@+ -Dj0.1i -O -K >> $ps
 gmt psxy spectrum.xpower -Bxa1f3p -Bya1f3p+l"Power (mGal@+2@+km)" \
 	-BWeSn+t"Ship and Satellite Gravity"+g240/255/240 \
 	-Gred -ST0.07i -O -R1/1000/0.1/10000 -JX-4il/3.75il -Y4.2i -K -Ey+p0.5p >> $ps
 gmt psxy spectrum.ypower -R -JX -O -K -Gblue -Sc0.07i -Ey+p0.5p >> $ps
-echo "Input Power" | gmt pstext -R0/4/0/3.75 -Jx1i -F+cTR+f18p,Helvetica-Bold -Dj0.1i -O -K >> $ps
+gmt pstext -R0/4/0/3.75 -Jx1i -F+cTR+f18p,Helvetica-Bold+t"Input Power" -Dj0.1i -O -K >> $ps
 gmt pslegend -R -J -O -DjBL+w1.2i+o0.25i -F+gwhite+pthicker --FONT_ANNOT_PRIMARY=14p,Helvetica-Bold << EOF >> $ps
 S 0.1i T 0.07i red - 0.3i Ship
 S 0.1i c 0.07i blue - 0.3i Satellite
@@ -158,14 +157,12 @@ gmt convert -A samp2_ship.pg samp2_sat.pg -o1,3 | gmt spectrum1d -S256 -D1 -W -C
 gmt psxy spectrum.coh -Bxa1f3p+l"Wavelength (km)" -Bya0.25f0.05+l"Coherency@+2@+" -BWeSn \
 	-JX-4il/3.75i -R1/1000/0/1 -U"Example 3f in Cookbook"+o-2.25i/-1.25i -P -K -X2.5i \
 	-Sc0.07i -Gblack -Ey+p0.5p -Y1.5i > example_03f.ps
-echo "Coherency@+2@+" | gmt pstext -R -J -F+cTR+f18p,Helvetica-Bold -Dj0.1i \
-	-O -K -Wthicker -C0.1i >> example_03f.ps
+gmt pstext -R -J -F+cTR+f18p,Helvetica-Bold+t"Coherency@+2@+" -Dj0.1i -O -K -Wthicker -C0.1i >> example_03f.ps
 gmt psxy -Bxa1f3p -Bya1f3p+l"Power (mGal@+2@+km)" -BWeSn+t"Ship and Satellite Gravity" \
 	spectrum.xpower -ST0.07i -O -R1/1000/0.1/10000 -JX-4il/3.75il -Y4.2i -K -Ey+p0.5p \
 	>> example_03f.ps
 gmt psxy spectrum.ypower -R -J -O -K -Gblack -Sc0.07i -Ey+p0.5p >> example_03f.ps
-echo "Input Power" | gmt pstext -R -J -F+cTR+f18p,Helvetica-Bold -Dj0.1i \
-	-O -K -Wthicker -C0.1i >> example_03f.ps
+gmt pstext -R -J -F+cTR+f18p,Helvetica-Bold+t"Input Power" -Dj0.1i -O -K -Wthicker -C0.1i >> example_03f.ps
 gmt pslegend -R0/4/0/3.75 -Jx -O -DjBL+w1.2i+o0.25i -F+glightgray+pthicker \
 	--FONT_ANNOT_PRIMARY=14p,Helvetica-Bold << EOF >> example_03f.ps
 S 0.1i T 0.07i black - 0.3i Ship

--- a/doc/examples/ex40/example_40.sh
+++ b/doc/examples/ex40/example_40.sh
@@ -16,7 +16,7 @@ gmt spatial @GSHHS_h_Australia.txt -fg -Qk | $AWK '{printf "Full area = %.0f km@
 gmt spatial T500k.txt -fg -Qk | $AWK '{printf "Reduced area = %.0f km@+2@+\n", $3}' > area_T500k.txt
 gmt psxy -R -J -O -K -W1p,blue T500k.txt >> $ps
 gmt psxy -R -J -O -K -Sx0.3i -W3p centroid.txt >> $ps
-echo T = 500 km | gmt pstext -R -J -O -K -Dj0.1i/0.1i -F+cLT+jTL+f18p >> $ps
+gmt pstext -R -J -O -K -Dj0.1i/0.1i -F+cLT+jTL+f18p+t"T = 500 km" >> $ps
 gmt pstext -R -J -O -K area.txt -F+f14p+cCM >> $ps
 gmt pstext -R -J -O -K area_T500k.txt -F+f14p+cLB -Dj0.2i >> $ps
 gmt psbasemap -R -J -O -K -B20+lightgray -BWsne+g240/255/240 -Y4.7i >> $ps
@@ -26,7 +26,7 @@ gmt simplify @GSHHS_h_Australia.txt -T100k > T100k.txt
 gmt spatial T100k.txt -fg -Qk | $AWK '{printf "Reduced area = %.0f km@+2@+\n", $3}' > area_T100k.txt
 gmt psxy -R -J -O -K -W1p,blue T100k.txt >> $ps
 gmt psxy -R -J -O -K -Sx0.3i -W3p centroid.txt >> $ps
-echo T = 100 km | gmt pstext -R -J -O -K -Dj0.1i/0.1i -F+cLT+jTL+f18p >> $ps
+gmt pstext -R -J -O -K -Dj0.1i/0.1i -F+cLT+jTL+f18p+t"T = 100 km" >> $ps
 gmt pstext -R -J -O -K area.txt -F+f14p+cCM >> $ps
 gmt pstext -R -J -O -K area_T100k.txt -F+f14p+cLB -Dj0.2i >> $ps
 gmt psxy -R -J -O -T >> $ps

--- a/doc/examples/ex45/example_45.sh
+++ b/doc/examples/ex45/example_45.sh
@@ -3,7 +3,7 @@
 #
 # Purpose:      Illustrate use of trend1d mixed models
 # GMT modules:  pstext, psxy, trend1d
-# Unix progs:   echo, rm
+# Unix progs:   rm
 #
 
 ps=example_45.ps
@@ -11,18 +11,18 @@ ps=example_45.ps
 gmt trend1d -Fxm @MaunaLoa_CO2.txt -Np1 > model.txt
 gmt psxy -R1958/2016/310/410 -JX6i/1.9i -P -Bxaf -Byaf+u" ppm" -BWSne+gazure1 -Sc0.05c -Gred -K @MaunaLoa_CO2.txt -X1.5i > $ps
 gmt psxy -R -J -O -K -W0.5p,blue model.txt >> $ps
-echo "m@-2@-(t) = a + b\264t" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i -Glightyellow >> $ps
+gmt pstext -R -J -O -K -F+f12p+cTL+t"m@-2@-(t) = a + b\264t" -Dj0.1i -Glightyellow >> $ps
 # Basic LS line y = a + bx + cx^2
 gmt trend1d -Fxm @MaunaLoa_CO2.txt -Np2 > model.txt
 gmt psxy -R -J -O -Bxaf -Byaf+u" ppm" -BWSne+gazure1 -Sc0.05c -Gred -K @MaunaLoa_CO2.txt -Y2.3i >> $ps
 gmt psxy -R -J -O -K -W0.5p,blue model.txt >> $ps
-echo "m@-3@-(t) = a + b\264t + c\264t@+2@+" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i -Glightyellow >> $ps
+gmt pstext -R -J -O -K -F+f12p+cTL+t"m@-3@-(t) = a + b\264t + c\264t@+2@+" -Dj0.1i -Glightyellow >> $ps
 # Basic LS line y = a + bx + cx^2 + seasonal change
 gmt trend1d -Fxmr @MaunaLoa_CO2.txt -Np2,f1+o1958+l1 > model.txt
 gmt psxy -R -J -O -Bxaf -Byaf+u" ppm" -BWSne+gazure1 -Sc0.05c -Gred -K @MaunaLoa_CO2.txt -Y2.3i >> $ps
 gmt psxy -R -J -O -K -W0.25p,blue model.txt >> $ps
-echo "m@-5@-(t) = a + b\264t + c\264t@+2@+ + d\264cos(2@~p@~t) + e\264sin(2@~p@~t)" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i -Glightyellow >> $ps
+gmt pstext -R -J -O -K -F+f12p+cTL+t"m@-5@-(t) = a + b\264t + c\264t@+2@+ + d\264cos(2@~p@~t) + e\264sin(2@~p@~t)" -Dj0.1i -Glightyellow >> $ps
 # Plot residuals of last model
 gmt psxy -R1958/2016/-4/4 -J -O -Bxaf -Byafg10+u" ppm" -BWSne+t"The Keeling Curve [CO@-2@- at Mauna Loa]"+gazure1 -Sc0.05c -Gred -K model.txt -i0,2 -Y2.3i >> $ps
-echo "@~e@~(t) = y(t) - m@-5@-(t)" | gmt pstext -R -J -O -F+f12p+cTL -Dj0.1i -Glightyellow >> $ps
+gmt pstext -R -J -O -F+f12p+cTL+t"@~e@~(t) = y(t) - m@-5@-(t)" -Dj0.1i -Glightyellow >> $ps
 rm -f model.txt

--- a/doc/examples/ex47/example_47.sh
+++ b/doc/examples/ex47/example_47.sh
@@ -38,9 +38,9 @@ plot_one -Eo -Nr wesn -Xa5.4i -Ya3.2i >> $ps
 plot_one -Ex -Nr wesn -Xa5.4i -Ya5.4i >> $ps
 plot_one -Ey -Nr wesn+tLMS -Xa5.4i -Ya7.6i >> $ps
 # Labels
-echo REDUCED MAJOR AXIS | gmt pstext -R -J -O -K -F+cRM+jTC+a90 -N -Dj0.2i -Xa5.4i -Ya1i >> $ps
-echo ORTHOGONAL | gmt pstext -R -J -O -K -F+cRM+jTC+a90 -N -Dj0.2i -Xa5.4i -Ya3.2i >> $ps
-echo X ON Y | gmt pstext -R -J -O -K -F+cRM+jTC+a90 -N -Dj0.2i -Xa5.4i -Ya5.4i >> $ps
-echo Y ON X | gmt pstext -R -J -O -K -F+cRM+jTC+a90 -N -Dj0.2i -Xa5.4i -Ya7.6i >> $ps
+gmt pstext -R -J -O -K -F+cRM+jTC+a90+t"REDUCED MAJOR AXIS" -N -Dj0.2i -Xa5.4i -Ya1i >> $ps
+gmt pstext -R -J -O -K -F+cRM+jTC+a90+tORTHOGONAL -N -Dj0.2i -Xa5.4i -Ya3.2i >> $ps
+gmt pstext -R -J -O -K -F+cRM+jTC+a90+t"X ON Y" -N -Dj0.2i -Xa5.4i -Ya5.4i >> $ps
+gmt pstext -R -J -O -K -F+cRM+jTC+a90+t"Y ON X" -N -Dj0.2i -Xa5.4i -Ya7.6i >> $ps
 gmt psxy -R -J -O -T >> $ps
 rm -f tmp data giants

--- a/doc/examples/ex50/example_50.sh
+++ b/doc/examples/ex50/example_50.sh
@@ -71,7 +71,7 @@ gmt psxy -R0/6/0/1.02 -J -O -K p.txt -L+yb -Glightred -W1p -BES -Bxa1 -Byaf -Y0.
 # Plot Chi-squared cumulative distribution
 gmt math -T0/12/0.1 T 4 CHI2CDF = p.txt
 gmt psxy -R0/12/0/1.02 -J -O -K p.txt -L+yb -Glightred -W1p -BES -Bxa1 -Byaf -Y0.9i >> $ps
-echo "Probability @;lightgreen;Density@;; and @;lightred;Cumulative@;; Distribution Functions" | gmt pstext -R0/6.5/0/1.25 -Jx1i -N -X-3.5i -O -K -F+f18p+cTC >> $ps
+gmt pstext -R0/6.5/0/1.25 -Jx1i -N -X-3.5i -O -K -F+f18p+cTC+t"Probability @;lightgreen;Density@;; and @;lightred;Cumulative@;; Distribution Functions" >> $ps
 gmt pstext -R0/6.5/0/10 -J -O -F+f14p,Times-Italic+jTC -Dj0.35i -N -Y-8.1i << EOF >> $ps
 3.25 0.9 Binomial P@-8,0.25@-
 3.25 1.8 Poisson P(@~l=2@~)


### PR DESCRIPTION
Following #1160, we upgrade 5 scripts to not use the echo command to send a static string into pstext.  In the process I fixed a bug related to the static string given since it needs to be copied into a larger buffer so that substitutions for color can happen (which will make the string longer and not suitable for a string allocated by strdup).

