### PR TITLE
Let +t be last modifier in pstext -F

### DIFF
--- a/doc/rst/source/text_common.rst_
+++ b/doc/rst/source/text_common.rst_
@@ -121,7 +121,8 @@ Optional Arguments
     comes from the data record.  Instead, use **+h** or **+l** to select the
     text as the most recent segment header or segment label, respectively in
     a multisegment input file, **+r** to use the record number (counting up from *first*),
-    **+t**\ *text* to set a fixed text string, or **+z** to format incoming *z* values
+    **+t**\ *text* to set a fixed text string (if *text* contains plus characters then the
+    **+t** modifier must be the last modifier in **-F**), or **+z** to format incoming *z* values
     to a string using the supplied *format* [use FORMAT_FLOAT_MAP].  Note: If **-Z** is
     in effect then the *z* value used for formatting is in the 4th, not 3rd column.
     If you only want a specific word from the trailing text and not the whole line,

--- a/test/pstext/labeler.sh
+++ b/test/pstext/labeler.sh
@@ -6,5 +6,5 @@ gmt convert points.txt -o0,1 > p.txt
 gmt psxy -R0/7/-0.5/6.5 -JX6i -P -Baf -Sc0.25i -Gred -Wfaint points.txt -K > $ps
 gmt pstext -R -J -O -K -F+r+f10p,Helvetica-Bold,white p.txt >> $ps
 gmt pstext -R -J -O -K -F+z"z = %.1f@."+f9p,Times-Italic+jTC -Dj0/0.2i points.txt >> $ps
-gmt pstext -R -J -O -K -F+t"Some text label"+f24p,Courier-Bold t.txt >> $ps
+gmt pstext -R -J -O -K -F+f24p,Courier-Bold+t"Some text label" t.txt >> $ps
 gmt psxy -R -J -O -T >> $ps


### PR DESCRIPTION
Since no quotes are let into GMT, we cannot tell if a **+x** string following **+t** is part of the string or some other modifier.  Hence, if your string contains plus characters then **+t** must be the last modifier given in **-F**.
