### PR TITLE
Improve -B docs for colorbar/psscale

### DIFF
--- a/doc/rst/source/colorbar_common.rst_
+++ b/doc/rst/source/colorbar_common.rst_
@@ -67,13 +67,14 @@ Optional Arguments
     x-axis label will plot beneath a horizontal bar (or vertically to
     the right of a vertical bar), except when using the **+m** modifier of the **-D** option. As an
     option, use the y-axis label to plot the data unit to the right of a
-    horizontal bar (and above a vertical bar). When using **-Ba** or
-    **-Baf** annotation and/or minor tick intervals are chosen
-    automatically. If **-B** is omitted, or no annotation intervals are
+    horizontal bar (and above a vertical bar). If **-B** is omitted, or no annotation intervals are
     provided, the default is to annotate every color level based on the
     numerical entries in the CPT (which may be overridden by ULB
     flags in the CPT). To specify custom text annotations for
     intervals, you must append ;\ *annotation* to each z-slice in the CPT.
+    For standard **-B** operations, see below.
+
+.. include:: explain_-B.rst_
 
 .. _-C:
 


### PR DESCRIPTION
Since colorbar/psscale can do its own default annotation by using the information in the CPT, it did not fully discuss the general **-B** option as used elsewhere.  I now added that information link as well.
