### PR TITLE
Allow colorbar to just get the current CPT if it exists

### DIFF
--- a/doc/scripts/GMT_hinge.sh
+++ b/doc/scripts/GMT_hinge.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 gmt begin GMT_hinge ps
 	gmt makecpt -Cglobe -T-8000/3000
-	gmt colorbar -C  -Baf -Dx0/0+w4.5i/0.1i+h -W0.001 
+	gmt colorbar -Baf -Dx0/0+w4.5i/0.1i+h -W0.001 
 	gmt colorbar -Cglobe  -Baf -Dx0/0+w4.5i/0.1i+h -W0.001 -Y0.5i 
 	echo 2.25 0.1 90 0.2i | gmt plot -R0/4.5/0/1 -Jx1i -Sv0.1i+a80+b -W1p -Gblack 
 	gmt text -F+f12p+jCB <<- EOF 

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -545,6 +545,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctrl, struct GMT
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active && Ctrl->Z.file && gmt_access (GMT, Ctrl->Z.file, R_OK), "Syntax error -Z option: Cannot access file %s\n", Ctrl->Z.file);
 	n_errors += gmt_M_check_condition (GMT, Ctrl->W.active && Ctrl->W.scale == 0.0, "Syntax error -W option: Scale cannot be zero\n");
 
+	if (!Ctrl->C.active && (c = gmt_get_current_cpt (API->GMT))) {
+		Ctrl->C.active = true;	/* Select current CPT */
+		gmt_M_str_free (c);
+	}
+
 	gmt_consider_current_cpt (API, &Ctrl->C.active, &(Ctrl->C.file));
 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);


### PR DESCRIPTION
No longer must give a blank **-C** for this step.  This only happens under modern mode.
