### PR TITLE
The column in -Lc starts at 0 so no adjusting later

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -925,7 +925,6 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			Ctrl->L.tag[T].y = 0.5 * Ctrl->C.dim[GMT_Y] * row;
 			if (col != 1) Ctrl->L.tag[T].x += (1-col) * Ctrl->L.tag[T].off[GMT_X];
 			if (row != 1) Ctrl->L.tag[T].y += (1-row) * Ctrl->L.tag[T].off[GMT_Y];
-			Ctrl->L.tag[T].col--;	/* So 0 becomes -1 (INTMAX, actually, since unsigned), 1 becomes 0, etc */
 			if (Ctrl->L.tag[T].mode == MOVIE_LABEL_IS_COL_T && !strchr (Ctrl->L.tag[T].format, 's')) {
 				GMT_Report (API, GMT_MSG_NORMAL, "Syntax error -L: Using +f<format> with word variables requires a \'%%s\'-style format.\n");
 				close_files (Ctrl);


### PR DESCRIPTION
An earier version of **-Lc**_col_ started at _col_ = 1 and then we subtracted 1 to get internal values starting at 0, but after realigning these columns to match other column specifications in GMT we don't want to subtract 1 no more.
