### PR TITLE
Let grdgradient -N support ambient light, like -E

### DIFF
--- a/doc/rst/source/grdgradient.rst
+++ b/doc/rst/source/grdgradient.rst
@@ -16,7 +16,7 @@ Synopsis
 **gmt grdgradient** *in_grdfile* |-G|\ *out_grdfile*
 [ |-A|\ *azim*\ [/*azim2*] ] [ |-D|\ [**a**][**c**][**o**][**n**] ]
 [ |-E|\ [**m**\ \|\ **s**\ \|\ **p**\ ]\ *azim/elev*\ [**+a**\ *ambient*\ ][**+d**\ *diffuse*\ ][**+p**\ *specular*\ ][**+s**\ *shine*\ ] ] 
-[ |-N|\ [**e**\ \|\ **t**][*amp*][**+s**\ *sigma*\ ][**+o**\ *offset*\ ] ]
+[ |-N|\ [**e**\ \|\ **t**][*amp*][**+a**\ *ambient*\ ][**+s**\ *sigma*\ ][**+o**\ *offset*\ ] ]
 [ |-Q|\ **c**\ \|\ **r**\ \|\ **R**
 [ |SYN_OPT-R| ] [ |-S|\ *slopefile* ]
 [ |SYN_OPT-V| ] [ |SYN_OPT-f| ]
@@ -103,7 +103,7 @@ Optional Arguments
 
 .. _-N:
 
-**-N**\ [**e**\ \|\ **t**][*amp*][**+s**\ *sigma*\ ][**+o**\ *offset*\ ]
+**-N**\ [**e**\ \|\ **t**][*amp*][**+a**\ *ambient*\ ][**+s**\ *sigma*\ ][**+o**\ *offset*\ ]
     Normalization. [Default is no normalization.] The actual gradients *g*
     are offset and scaled to produce normalized gradients *gn* with a
     maximum output magnitude of *amp*. If *amp* is not given, default
@@ -118,7 +118,8 @@ Optional Arguments
     *sigma*) where *sigma* is estimated using the L2 norm of (*g* -
     *offset*) if it is not given. To use *offset* and/or *sigma* from a
     previous calculation, leave out the argument to the modifier(s) and
-    see **-Q** for usage.
+    see **-Q** for usage.  As a final option, you may add **+a**\ *ambient*
+    to add *ambient* to all nodes after gradient calculations are completed.
 
 .. _-Q:
 
@@ -202,6 +203,14 @@ with the resulting *offset* and *sigma*.  Then, for each of your grid tile calcu
 **+o** and/or **+s** without arguments to **-N** and specify **-Qr**.  This option will read
 the values from the hidden statistics file and use them in the normalization.
 If you use **-QR** for the final tile then the statistics file is removed after use.
+
+Ambient
+-------
+
+The *ambient* light offset is used to darken or brighten all intensities.  This
+modifier is typically used to darken an entire image by subtracting a constant from
+all the intensities.  E.g., if you use **+a**\ -0.5 then you subtract 0.5 from all
+intensities, making them more negative and hence darken the image.
 
 Examples
 --------

--- a/doc/rst/source/grdimage_common.rst_
+++ b/doc/rst/source/grdimage_common.rst_
@@ -114,9 +114,10 @@ Optional Arguments
     Gives the name of a grid file with intensities in the (-1,+1) range,
     or a constant intensity to apply everywhere (affects the ambient light).
     Alternatively, derive an intensity grid from the input data grid *grd_z*
-    via a call to :doc:`grdgradient`; append **+a**\ *azimuth* and **+n**\ *args*
-    to specify azimuth and intensity arguments for that module or just give **+d**
-    to select the default arguments (**+a**\ -45\ **+nt**\ 1). If you want a more
+    via a call to :doc:`grdgradient`; append **+a**\ *azimuth*, **+n**\ *args*,
+    and **+m**\ *ambient* to specify azimuth, intensity, and ambient arguments
+    for that module, or just give **+d** to select the
+    default arguments (**+a**\ -45\ **+nt**\ 1\ **+m**\ 0). If you want a more
     specific intensity scenario then run :doc:`grdgradient` separately first.
     [Default is no illumination].
 

--- a/src/grdgradient.c
+++ b/src/grdgradient.c
@@ -68,11 +68,11 @@ struct GRDGRADIENT_CTRL {
 		bool active;
 		char *file;
 	} G;
-	struct N {	/* -N[t_or_e][<amp>][+o<offset>][+s<sigma>] */
+	struct N {	/* -N[t_or_e][<amp>][+<ambient>][+o<offset>][+s<sigma>] */
 		bool active;
 		unsigned int set[3];	/* 1 if values are specified for amp, offset and sigma, 2 means we want last-run values */
 		unsigned int mode;	/* 1 = atan, 2 = exp */
-		double norm, sigma, offset;
+		double norm, sigma, offset, ambient;
 	} N;
 	struct Q {	/* -Qc|r|R */
 		/* Note: If -Qc is set with -N then -G is not required. GMT_Encode_Options turns off the primary output */
@@ -131,7 +131,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s <ingrid> -G<outgrid> [-A<azim>[/<azim2>]] [-D[a][c][o][n]]\n", name);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-E[s|p|m]<azim>/<elev>[+a<ambient>][+d<diffuse>][+p<specular>][+s<shine>]]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t[-N[t|e][<amp>][+s<sigma>][+o<offset>]] [-Qc|r|R] [%s]\n\t[-S<slopegrid>] [%s] [-fg] [%s] [%s]\n\n", GMT_Rgeo_OPT, GMT_V_OPT, GMT_n_OPT, GMT_PAR_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-N[t|e][<amp>][+a<ambient>][+s<sigma>][+o<offset>]] [-Qc|r|R] [%s]\n\t[-S<slopegrid>] [%s] [-fg] [%s] [%s]\n\n", GMT_Rgeo_OPT, GMT_V_OPT, GMT_n_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -160,6 +160,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Normalize gradients so that max |grad| = <amp> [1.0].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t  -Nt will make atan transform, then scale to <amp> [1.0].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t  -Ne will make exp  transform, then scale to <amp> [1.0].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t    Append +a<ambient> to add <ambient> to the result [0].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t    For -Nt|e, optionally append +s<sigma> and/or +o<offset> to set\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t    sigma and offset for the transform [Default estimates from the data].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t    See -Q to use the same offset, sigma for multiple grid calculations.\n");
@@ -330,10 +331,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDGRADIENT_CTRL *Ctrl, struct
 					Ctrl->N.mode = (opt->arg[0] == 't') ? 1 : 2;
 					j = 1;
 				}
-				if ((c = gmt_first_modifier (GMT, opt->arg, "os"))) {	/* Process any modifiers */
+				if ((c = gmt_first_modifier (GMT, opt->arg, "aos"))) {	/* Process any modifiers */
 					pos = 0;	/* Reset to start of new word */
-					while (gmt_getmodopt (GMT, 'N', c, "os", &pos, p, &n_errors) && n_errors == 0) {
+					while (gmt_getmodopt (GMT, 'N', c, "aos", &pos, p, &n_errors) && n_errors == 0) {
 						switch (p[0]) {
+							case 'a': Ctrl->N.ambient = atof (&p[1]); break;
 							case 'o': Ctrl->N.set[1] = 1; if (p[1]) Ctrl->N.offset = atof (&p[1]); else Ctrl->N.set[1] = 2; break;
 							case 's': Ctrl->N.set[2] = 1; if (p[1]) Ctrl->N.sigma  = atof (&p[1]); else Ctrl->N.set[2] = 2; break;
 							default: break;	/* These are caught in gmt_getmodopt so break is just for Coverity */
@@ -743,10 +745,10 @@ int GMT_grdgradient (void *V_API, int mode, void *args) {
 				}
 				rpi = 2.0 * Ctrl->N.norm / M_PI;
 				gmt_M_grd_loop (GMT, Out, row, col, ij) {
-					if (!gmt_M_is_fnan (Out->data[ij])) Out->data[ij] = (gmt_grdfloat)(rpi * atan ((Out->data[ij] - ave_gradient) * denom));
+					if (!gmt_M_is_fnan (Out->data[ij])) Out->data[ij] = (gmt_grdfloat)(rpi * atan ((Out->data[ij] - ave_gradient) * denom) + Ctrl->N.ambient);
 				}
-				Out->header->z_max = rpi * atan ((max_gradient - ave_gradient) * denom);
-				Out->header->z_min = rpi * atan ((min_gradient - ave_gradient) * denom);
+				Out->header->z_max = rpi * atan ((max_gradient - ave_gradient) * denom) + Ctrl->N.ambient;
+				Out->header->z_min = rpi * atan ((min_gradient - ave_gradient) * denom) + Ctrl->N.ambient;
 			}
 			else if (Ctrl->N.mode == 2) {	/* Exp transformation */
 				if (!Ctrl->N.set[2]) {
@@ -764,14 +766,14 @@ int GMT_grdgradient (void *V_API, int mode, void *args) {
 				gmt_M_grd_loop (GMT, Out, row, col, ij) {
 					if (gmt_M_is_fnan (Out->data[ij])) continue;
 					if (Out->data[ij] < ave_gradient) {
-						Out->data[ij] = (gmt_grdfloat)(-Ctrl->N.norm * (1.0 - exp ( (Out->data[ij] - ave_gradient) * denom)));
+						Out->data[ij] = (gmt_grdfloat)(-Ctrl->N.norm * (1.0 - exp ( (Out->data[ij] - ave_gradient) * denom)) + Ctrl->N.ambient);
 					}
 					else {
-						Out->data[ij] = (gmt_grdfloat)( Ctrl->N.norm * (1.0 - exp (-(Out->data[ij] - ave_gradient) * denom)));
+						Out->data[ij] = (gmt_grdfloat)( Ctrl->N.norm * (1.0 - exp (-(Out->data[ij] - ave_gradient) * denom)) + Ctrl->N.ambient);
 					}
 				}
-				Out->header->z_max =  Ctrl->N.norm * (1.0 - exp (-(max_gradient - ave_gradient) * denom));
-				Out->header->z_min = -Ctrl->N.norm * (1.0 - exp ( (min_gradient - ave_gradient) * denom));
+				Out->header->z_max =  Ctrl->N.norm * (1.0 - exp (-(max_gradient - ave_gradient) * denom)) + Ctrl->N.ambient;
+				Out->header->z_min = -Ctrl->N.norm * (1.0 - exp ( (min_gradient - ave_gradient) * denom)) + Ctrl->N.ambient;
 			}
 			else {	/* Linear transformation */
 				if ((max_gradient - ave_gradient) > (ave_gradient - min_gradient))
@@ -779,10 +781,10 @@ int GMT_grdgradient (void *V_API, int mode, void *args) {
 				else
 					denom = Ctrl->N.norm / (ave_gradient - min_gradient);
 				gmt_M_grd_loop (GMT, Out, row, col, ij) {
-					if (!gmt_M_is_fnan (Out->data[ij])) Out->data[ij] = (gmt_grdfloat)((Out->data[ij] - ave_gradient) * denom);
+					if (!gmt_M_is_fnan (Out->data[ij])) Out->data[ij] = (gmt_grdfloat)((Out->data[ij] - ave_gradient) * denom) + Ctrl->N.ambient;
 				}
-				Out->header->z_max = (max_gradient - ave_gradient) * denom;
-				Out->header->z_min = (min_gradient - ave_gradient) * denom;
+				Out->header->z_max = (max_gradient - ave_gradient) * denom + Ctrl->N.ambient;
+				Out->header->z_min = (min_gradient - ave_gradient) * denom + Ctrl->N.ambient;
 			}
 		}
 	}
@@ -846,7 +848,6 @@ int GMT_grdgradient (void *V_API, int mode, void *args) {
 		}
 		fclose (fp);
 	}
-	
 
 	Return (GMT_NOERROR);
 }


### PR DESCRIPTION
Thus, **-N** now has a new modifier **+a**_ambient_.  This feature also allows grdimage **-I** to pass in **+m**_ambient_ which simplifies operations where we just want to adjust for ambient light in the intensities.  E.g.,

`gmt grdimage @earth_relief_10m -JM6i -R0/30/0/30 -P -I+a45+nt1+m-1 -Baf > t.ps
`

auto-computes intensities from directional gradients, then subtracts 1 from all intensities to really darken the resulting image.