### PR TITLE
Let the :offset part of pen style be optional, width default 0

### DIFF
--- a/doc/examples/ex30/example_30.sh
+++ b/doc/examples/ex30/example_30.sh
@@ -14,7 +14,7 @@ gmt psbasemap -R0/360/-1.25/1.75 -JX8i/6i -Bx90f30+u@. -By1g10 -BWS+t"Two Trigon
 # Draw sine an cosine curves
 
 gmt math -T0/360/0.1 T COSD = | gmt psxy -R -J -O -K -W3p >> $ps
-gmt math -T0/360/0.1 T SIND = | gmt psxy -R -J -O -K -W3p,0_6:0 --PS_LINE_CAP=round >> $ps
+gmt math -T0/360/0.1 T SIND = | gmt psxy -R -J -O -K -W3p,0_6 --PS_LINE_CAP=round >> $ps
 
 # Indicate the x-angle = 120 degrees
 gmt psxy -R -J -O -K -W0.5p,- << EOF >> $ps

--- a/doc/rst/source/GMT_Docs.rst
+++ b/doc/rst/source/GMT_Docs.rst
@@ -2450,11 +2450,11 @@ option argument, with commas separating the given attributes, e.g.,
     relative to the pen width (dots has a length that equals the pen
     width while dashes are 8 times as long; gaps between segments are 4
     times the pen width). For more detailed attributes including exact
-    dimensions you may specify *string*:*offset*, where *string* is a
+    dimensions you may specify *string*\ [:*offset*\ ], where *string* is a
     series of numbers separated by underscores. These numbers represent
     a pattern by indicating the length of line segments and the gap
-    between segments. The *offset* phase-shifts the pattern from the
-    beginning the line. For example, if you want a yellow line of width
+    between segments. The optional *offset* phase-shifts the pattern from the
+    beginning the line [0]. For example, if you want a yellow line of width
     0.1 cm that alternates between long dashes (4 points), an 8 point
     gap, then a 5 point dash, then another 8 point gap, with pattern
     offset by 2 points from the origin, specify

--- a/doc/rst/source/GMT_Docs_classic.rst
+++ b/doc/rst/source/GMT_Docs_classic.rst
@@ -2511,11 +2511,11 @@ option argument, with commas separating the given attributes, e.g.,
     relative to the pen width (dots has a length that equals the pen
     width while dashes are 8 times as long; gaps between segments are 4
     times the pen width). For more detailed attributes including exact
-    dimensions you may specify *string*:*offset*, where *string* is a
+    dimensions you may specify *string*\ [:*offset*\ ], where *string* is a
     series of numbers separated by underscores. These numbers represent
     a pattern by indicating the length of line segments and the gap
-    between segments. The *offset* phase-shifts the pattern from the
-    beginning the line. For example, if you want a yellow line of width
+    between segments. The optional *offset* phase-shifts the pattern from the
+    beginning the line [0]. For example, if you want a yellow line of width
     0.1 cm that alternates between long dashes (4 points), an 8 point
     gap, then a 5 point dash, then another 8 point gap, with pattern
     offset by 2 points from the origin, specify

--- a/doc/scripts/GMT_linecap.sh
+++ b/doc/scripts/GMT_linecap.sh
@@ -9,7 +9,7 @@ gmt plot lines.txt -R-0.25/5.25/-0.2/1.4 -Jx1i -W4p
 gmt plot lines.txt -Y0.2i -W4p,orange,. 
 gmt plot lines.txt -Y0.2i -W4p,red,9_4_2_4:2p 
 gmt plot lines.txt -Y0.2i -W4p,-  --PS_LINE_CAP=round
-gmt plot lines.txt -Y0.2i -W4p,orange,0_8:0p --PS_LINE_CAP=round 
-gmt plot lines.txt -Y0.2i -W4p,red,0_16:0p  --PS_LINE_CAP=round 
+gmt plot lines.txt -Y0.2i -W4p,orange,0_8 --PS_LINE_CAP=round 
+gmt plot lines.txt -Y0.2i -W4p,red,0_16  --PS_LINE_CAP=round 
 gmt plot lines.txt -W2p,green,0_16:8p  --PS_LINE_CAP=round
 gmt end

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6753,9 +6753,9 @@ void gmt_pen_syntax (struct GMT_CTRL *GMT, char option, char *string, unsigned i
 	gmt_message (GMT, "\t             (4) any valid color name.\n");
 	gmt_message (GMT, "\t   <style> = (1) pattern of dashes (-) and dots (.), scaled by <width>.\n");
 	gmt_message (GMT, "\t             (2) \"dashed\", \"dotted\", \"dashdot\", \"dotdash\", or \"solid\".\n");
-	gmt_message (GMT, "\t             (3) <pattern>:<offset>; <pattern> holds lengths (default unit points)\n");
+	gmt_message (GMT, "\t             (3) <pattern>[:<offset>]; <pattern> holds lengths (default unit points)\n");
 	gmt_message (GMT, "\t                 of any number of lines and gaps separated by underscores.\n");
-	gmt_message (GMT, "\t                 <offset> shifts elements from start of the line [0].\n");
+	gmt_message (GMT, "\t                The optional <offset> shifts elements from start of the line [0].\n");
 	gmt_message (GMT, "\t   For PDF stroke transparency, append @<transparency> in the range 0-100%% [0 = opaque].\n");
 	if (mode)
 		gmt_message (GMT, "\t   Additional line attribute modifiers are also available.  Choose from:\n");

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -1058,8 +1058,9 @@ GMT_LOCAL int support_getpenstyle (struct GMT_CTRL *GMT, char *line, struct GMT_
 
 		for (i = 1, c_pos = 0; line[i] && c_pos == 0; i++) if (line[i] == ':') c_pos = i;
 		if (c_pos == 0) {
-			GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Pen style %s do not follow format <pattern>:<phase>. <phase> set to 0\n", line);
+			GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Pen style %s does not contain :<phase>. <phase> set to 0\n", line);
 			P->offset = 0.0;
+			sscanf (line, "%s", P->style);
 		}
 		else {
 			line[c_pos] = ' ';
@@ -1117,7 +1118,7 @@ GMT_LOCAL bool support_is_penstyle (char *word) {
 	int n;
 
 	/* Returns true if we are sure the word is a style string - else false.
-	 * style syntax is a|o|<pattern>:<phase>|<string made up of -|. only>[<unit>]
+	 * style syntax is a|o|<pattern>[:<phase>]|<string made up of -|. only>[<unit>]
 	 * Also recognized "dashed" for -, "dotted" for . as well as "solid" */
 
 	n = (int)strlen (word);
@@ -1136,6 +1137,10 @@ GMT_LOCAL bool support_is_penstyle (char *word) {
 	}
 	if (strchr(word,'t')) return (false);	/* Got a t somewhere */
 	if (strchr(word,':')) return (true);	/* Got <pattern>:<phase> */
+	if (strchr(word,'_')) {	/* Got <pattern> without optional :<phase>, add :0 */
+		strcat (word, ":0");
+		return (true);
+	}
 	while (n >= 0 && (word[n] == '-' || word[n] == '.')) n--;	/* Wind down as long as we find - or . */
 	return ((n == -1));	/* true if we only found -/., false otherwise */
 }
@@ -6629,7 +6634,7 @@ bool gmt_getpen (struct GMT_CTRL *GMT, char *buffer, struct GMT_PEN *P) {
 		}
 		/* Unstated else branch means we got width stored correctly */
 	}
-	/* Unstated else branch means we got all 3: width,color,style */
+	/* Unstated else branch means we got width stored correctly */
 
 	/* Assign width, color, style if given */
 	if (support_getpenwidth (GMT, width, P)) GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Representation of pen width (%s) not recognized. Using default.\n", width);


### PR DESCRIPTION
If the phase shift in a pen pattern is zero, we should not have to add "colon 0" to indicate that - a zero phase should be the default.  We even have a check in _gmt_getpen_ for this and it warns that phase is zero but then it also failed to parse the pattern.  Updated the parsing, checking, docs and two scripts specifying zero phase.
