### PR TITLE
Clarify that modern and classic have different defaults for colorbars

### DIFF
--- a/doc/rst/source/colorbar_common.rst_
+++ b/doc/rst/source/colorbar_common.rst_
@@ -41,8 +41,9 @@ Optional Arguments
 .. _-C:
 
 **-C**\ [*cpt*]
-    *cpt* is the CPT to be used. If no *cpt* is appended then we use the
-    current CPT.  If no **-C** is given the we read stdin.  By default all
+    *cpt* is the CPT to be used. If no *cpt* is appended or no **-C** is given
+    then we use the current CPT (modern mode only).  In classic mode, if no **-C**
+    is given the we read stdin.  By default all
     color changes are annotated. To use a subset, add an extra column to
     the CPT with a L, U, or B to annotate Lower, Upper, or Both
     color segment boundaries (but see **-B**). If not given, the module

--- a/doc/rst/source/colorbar_common.rst_
+++ b/doc/rst/source/colorbar_common.rst_
@@ -43,7 +43,7 @@ Optional Arguments
 **-C**\ [*cpt*]
     *cpt* is the CPT to be used. If no *cpt* is appended or no **-C** is given
     then we use the current CPT (modern mode only).  In classic mode, if no **-C**
-    is given the we read stdin.  By default all
+    is given then we read stdin.  By default all
     color changes are annotated. To use a subset, add an extra column to
     the CPT with a L, U, or B to annotate Lower, Upper, or Both
     color segment boundaries (but see **-B**). If not given, the module

--- a/doc/rst/source/colorbar_notes.rst_
+++ b/doc/rst/source/colorbar_notes.rst_
@@ -5,9 +5,9 @@ Notes
    color bar will be painted using polygons. For all other cases we must
    paint with an image. Some color printers may give slightly different
    colors for the two methods given identical RGB values.  See option **-N**
-   for affecting these decisions.  Also not that for years now, Apple's
-   Preview insists on smoothing CPT color images to a blur.  Use another
-   PDF viewer if this bothers you.
+   for affecting these decisions.  Also note that for years now, Apple's
+   Preview insists on smoothing deliberately course CPT color images to a blur.
+   Use another PDF viewer if this bothers you.
 #. For cyclic (wrapping) color tables the cyclic symbol is plotted to the right
    of the color bar.  If annotations are specified there then we place the cyclic
    symbol at the left, unless **+n** was used in which case we center of the color bar instead.

--- a/doc/rst/source/colorbar_notes.rst_
+++ b/doc/rst/source/colorbar_notes.rst_
@@ -4,7 +4,10 @@ Notes
 #. When the CPT is discrete and no illumination is specified, the
    color bar will be painted using polygons. For all other cases we must
    paint with an image. Some color printers may give slightly different
-   colors for the two methods given identical RGB values.
+   colors for the two methods given identical RGB values.  See option **-N**
+   for affecting these decisions.  Also not that for years now, Apple's
+   Preview insists on smoothing CPT color images to a blur.  Use another
+   PDF viewer if this bothers you.
 #. For cyclic (wrapping) color tables the cyclic symbol is plotted to the right
    of the color bar.  If annotations are specified there then we place the cyclic
    symbol at the left, unless **+n** was used in which case we center of the color bar instead.


### PR DESCRIPTION
In classic mode, psscale expects **-C**_cpt_ or it will read stdin.  In modern mode, colorbar will use the current CPT unless a **-C**_cpt_ is given to override that choice.  I also added a note about macOS Preview lameness regarding course PDF images.
