### PR TITLE
Introduce -Zvalue and -Ccpt as an alternative to -Gcolor in plot and plot3d

### DIFF
--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -31,6 +31,7 @@ Synopsis
 [ |-W|\ [*pen*][*attr*] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
+[ |-Z|\ *value* ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-bi| ]
 [ |SYN_OPT-di| ]
@@ -71,6 +72,12 @@ sides 0.25 inch on the left side of the line, spaced every 0.8 inch, use
    ::
 
     gmt plot trench.txt -R150/200/20/50 -Jm0.15i -Sf0.8i/0.1i+l+t -Gwhite -W -B10 -pdf map
+
+To plot a point with color dictated by the *t.cpt* file for the *z*-value 65, try
+
+   ::
+
+    echo 175 30 | gmt plot -R150/200/20/50 -J15c -Sc0.5c -Z65 -Ct.cpt > map.ps
 
 To plot the data in the file misc.txt as symbols determined by the code in
 the last column, and with size given by the magnitude in the 4th column,

--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -31,7 +31,7 @@ Synopsis
 [ |-W|\ [*pen*][*attr*] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
-[ |-Z|\ *value* ]
+[ |-Z|\ [**l**\ \|\ **f**] *value* ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-bi| ]
 [ |SYN_OPT-di| ]
@@ -77,7 +77,7 @@ To plot a point with color dictated by the *t.cpt* file for the *z*-value 65, tr
 
    ::
 
-    echo 175 30 | gmt plot -R150/200/20/50 -J15c -Sc0.5c -Z65 -Ct.cpt > map.ps
+    echo 175 30 | gmt plot -R150/200/20/50 -J15c -Sc0.5c -Zf65 -Ct.cpt > map.ps
 
 To plot the data in the file misc.txt as symbols determined by the code in
 the last column, and with size given by the magnitude in the 4th column,

--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -77,7 +77,7 @@ To plot a point with color dictated by the *t.cpt* file for the *z*-value 65, tr
 
    ::
 
-    echo 175 30 | gmt plot -R150/200/20/50 -J15c -Sc0.5c -Zf65 -Ct.cpt -pdf map
+    echo 175 30 | gmt plot -R150/200/20/50 -JM15c -Sc0.5c -Zf65 -Ct.cpt -pdf map
 
 To plot the data in the file misc.txt as symbols determined by the code in
 the last column, and with size given by the magnitude in the 4th column,

--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -77,7 +77,7 @@ To plot a point with color dictated by the *t.cpt* file for the *z*-value 65, tr
 
    ::
 
-    echo 175 30 | gmt plot -R150/200/20/50 -J15c -Sc0.5c -Zf65 -Ct.cpt > map.ps
+    echo 175 30 | gmt plot -R150/200/20/50 -J15c -Sc0.5c -Zf65 -Ct.cpt -pdf map
 
 To plot the data in the file misc.txt as symbols determined by the code in
 the last column, and with size given by the magnitude in the 4th column,

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -30,7 +30,7 @@ Synopsis
 [ |-W|\ [*pen*][*attr*] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
-[ |-Z|\ *value* ]
+[ |-Z|\ [**l**\ \|\ **f**] *value* ]
 [ |SYN_OPT-a| ] 
 [ |SYN_OPT-bi| ]
 [ |SYN_OPT-di| ]
@@ -60,7 +60,7 @@ southeast at 30 degree elevation, use:
               -Gblue -Bx2+lXLABEL -By2+lYLABEL -Bz10+lZLABEL -B+t"3-D PLOT" -p135/30
               -U+c -W -pdf heights
 
-To plot a point with color dictated by the *t.cpt* file for the *level*-value 65, try
+To plot a point with color and outline dictated by the *t.cpt* file for the *level*-value 65, try
 
    ::
 

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -64,7 +64,7 @@ To plot a point with color and outline dictated by the *t.cpt* file for the *lev
 
    ::
 
-    echo 175 30 0 | gmt plot3d -R150/200/20/50 -J15c -Sc0.5c -Z65 -Ct.cpt -pdf map
+    echo 175 30 0 | gmt plot3d -R150/200/20/50 -JM15c -Sc0.5c -Z65 -Ct.cpt -pdf map
 
 .. include:: plot3d_notes.rst_
 

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -30,6 +30,7 @@ Synopsis
 [ |-W|\ [*pen*][*attr*] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
+[ |-Z|\ *value* ]
 [ |SYN_OPT-a| ] 
 [ |SYN_OPT-bi| ]
 [ |SYN_OPT-di| ]
@@ -58,6 +59,12 @@ southeast at 30 degree elevation, use:
     gmt plot3d heights.xyz -R0/10/0/10/0/100 -Jx1.25c -Jz0.125c -So1.25c
               -Gblue -Bx2+lXLABEL -By2+lYLABEL -Bz10+lZLABEL -B+t"3-D PLOT" -p135/30
               -U+c -W -pdf heights
+
+To plot a point with color dictated by the *t.cpt* file for the *level*-value 65, try
+
+   ::
+
+    echo 175 30 0 | gmt plot3d -R150/200/20/50 -J15c -Sc0.5c -Z65 -Ct.cpt > map.ps
 
 .. include:: plot3d_notes.rst_
 

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -64,7 +64,7 @@ To plot a point with color and outline dictated by the *t.cpt* file for the *lev
 
    ::
 
-    echo 175 30 0 | gmt plot3d -R150/200/20/50 -J15c -Sc0.5c -Z65 -Ct.cpt > map.ps
+    echo 175 30 0 | gmt plot3d -R150/200/20/50 -J15c -Sc0.5c -Z65 -Ct.cpt -pdf map
 
 .. include:: plot3d_notes.rst_
 

--- a/doc/rst/source/plot3d_common.rst_
+++ b/doc/rst/source/plot3d_common.rst_
@@ -139,6 +139,12 @@ Optional Arguments
 
 .. include:: explain_-XY.rst_
 
+.. _-Z:
+
+**-Z**\ *value*
+    Instead of specifying a symbol or polygon fill color via **-G**, give both
+    a *level* value via **-Z** and a color lookup table via **-C**.
+
 .. include:: explain_-aspatial.rst_
 
 .. |Add_-bi| replace:: [Default is the required number of columns given the chosen settings]. 

--- a/doc/rst/source/plot3d_common.rst_
+++ b/doc/rst/source/plot3d_common.rst_
@@ -141,9 +141,10 @@ Optional Arguments
 
 .. _-Z:
 
-**-Z**\ *value*
-    Instead of specifying a symbol or polygon fill color via **-G**, give both
-    a *level* value via **-Z** and a color lookup table via **-C**.
+**-Z**\ [**l**\ \|\ **f**] *value*
+    Instead of specifying a symbol or polygon fill and outline color via **-G** and **-W**,
+    give both a *level* value via **-Z** and a color lookup table via **-C**.  To just set the
+    fill or outline, use **-Zf** or **-Zl**, respectively.
 
 .. include:: explain_-aspatial.rst_
 

--- a/doc/rst/source/plot_common.rst_
+++ b/doc/rst/source/plot_common.rst_
@@ -192,9 +192,10 @@ Optional Arguments
 
 .. _-Z:
 
-**-Z**\ *value*
-    Instead of specifying a symbol or polygon fill color via **-G**, give both
-    a *level* value via **-Z** and a color lookup table via **-C**.
+**-Z**\ [**l**\ \|\ **f**] *value*
+    Instead of specifying a symbol or polygon fill and outline color via **-G** and **-W**,
+    give both a *level* value via **-Z** and a color lookup table via **-C**.  To just set the
+    fill or outline, use **-Zf** or **-Zl**, respectively.
 
 .. |Add_-bi| replace:: [Default is the required number of columns given the chosen settings].
 .. include:: explain_-bi.rst_

--- a/doc/rst/source/plot_common.rst_
+++ b/doc/rst/source/plot_common.rst_
@@ -190,6 +190,12 @@ Optional Arguments
 
 .. include:: explain_-XY.rst_
 
+.. _-Z:
+
+**-Z**\ *value*
+    Instead of specifying a symbol or polygon fill color via **-G**, give both
+    a *level* value via **-Z** and a color lookup table via **-C**.
+
 .. |Add_-bi| replace:: [Default is the required number of columns given the chosen settings].
 .. include:: explain_-bi.rst_
 

--- a/doc/rst/source/psxy.rst
+++ b/doc/rst/source/psxy.rst
@@ -34,6 +34,7 @@ Synopsis
 [ |-W|\ [*pen*][*attr*] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
+[ |-Z|\ *value* ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-bi| ]
 [ |SYN_OPT-di| ]
@@ -75,7 +76,13 @@ sides 0.25 inch on the left side of the line, spaced every 0.8 inch, use
 
    ::
 
-    gmt psxy trench.txt -R150/200/20/50 -Jm0.15i -Sf0.8i/0.1i+l+t -Gwhite -W -B10 > map.ps
+    gmt psxy trench.txt -R150/200/20/50 -Jm0.15i -Sf0.8i/0.1i+l+t -Gwhite -W -Baf > map.ps
+
+To plot a point with color dictated by the *t.cpt* file for the *z*-value 65, try
+
+   ::
+
+    echo 175 30 | gmt psxy -R150/200/20/50 -JX15c -Sc0.5c -Z65 -Ct.cpt > map.ps
 
 To plot the data in the file misc.txt as symbols determined by the code in
 the last column, and with size given by the magnitude in the 4th column,

--- a/doc/rst/source/psxy.rst
+++ b/doc/rst/source/psxy.rst
@@ -34,7 +34,7 @@ Synopsis
 [ |-W|\ [*pen*][*attr*] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
-[ |-Z|\ *value* ]
+[ |-Z|\ [**l**\ \|\ **f**] *value* ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-bi| ]
 [ |SYN_OPT-di| ]
@@ -82,7 +82,7 @@ To plot a point with color dictated by the *t.cpt* file for the *z*-value 65, tr
 
    ::
 
-    echo 175 30 | gmt psxy -R150/200/20/50 -JX15c -Sc0.5c -Z65 -Ct.cpt > map.ps
+    echo 175 30 | gmt psxy -R150/200/20/50 -JX15c -Sc0.5c -Zf65 -Ct.cpt > map.ps
 
 To plot the data in the file misc.txt as symbols determined by the code in
 the last column, and with size given by the magnitude in the 4th column,

--- a/doc/rst/source/psxyz.rst
+++ b/doc/rst/source/psxyz.rst
@@ -31,6 +31,7 @@ Synopsis
 [ |-W|\ [*pen*][*attr*] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
+[ |-Z|\ *value* ]
 [ |SYN_OPT-a| ] 
 [ |SYN_OPT-bi| ]
 [ |SYN_OPT-di| ]
@@ -61,6 +62,12 @@ southeast at 30 degree elevation, use:
     gmt psxyz heights.xyz -R0/10/0/10/0/100 -Jx1.25c -Jz0.125c -So1.25c \
               -Gblue -Bx2+lXLABEL -By2+lYLABEL -Bz10+lZLABEL -B+t"3-D PLOT" -p135/30 \
               -U+c -W -P > heights.ps
+
+To plot a point with color dictated by the *t.cpt* file for the *level*-value 65, try
+
+   ::
+
+    echo 175 30 0 | gmt psxyz -R150/200/20/50 -JX15c -Sc0.5c -Z65 -Ct.cpt > map.ps
 
 .. include:: plot3d_notes.rst_
 

--- a/doc/rst/source/psxyz.rst
+++ b/doc/rst/source/psxyz.rst
@@ -31,7 +31,7 @@ Synopsis
 [ |-W|\ [*pen*][*attr*] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
-[ |-Z|\ *value* ]
+[ |-Z|\ [**l**\ \|\ **f**] *value* ]
 [ |SYN_OPT-a| ] 
 [ |SYN_OPT-bi| ]
 [ |SYN_OPT-di| ]
@@ -63,7 +63,7 @@ southeast at 30 degree elevation, use:
               -Gblue -Bx2+lXLABEL -By2+lYLABEL -Bz10+lZLABEL -B+t"3-D PLOT" -p135/30 \
               -U+c -W -P > heights.ps
 
-To plot a point with color dictated by the *t.cpt* file for the *level*-value 65, try
+To plot a point with color and outline dictated by the *t.cpt* file for the *level*-value 65, try
 
    ::
 

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -93,6 +93,10 @@ struct PSXY_CTRL {
 		bool cpt_effect;
 		struct GMT_PEN pen;
 	} W;
+	struct PSXY_Z {	/* -Z<value> */
+		bool active;
+		double value;
+	} Z;
 };
 
 #define EBAR_CAP_WIDTH		7.0	/* Error bar cap width */
@@ -386,7 +390,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	if (API->GMT->current.setting.run_mode == GMT_CLASSIC)	/* -T has no purpose in modern mode */
 		GMT_Message (API, GMT_TIME_NONE, "\t[-S[<symbol>][<size>[unit]]] [-T] [%s] [%s] [-W[<pen>][<attr>]]\n\t[%s] [%s] [%s]\n", GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, GMT_a_OPT);
 	else
-		GMT_Message (API, GMT_TIME_NONE, "\t[-S[<symbol>][<size>[unit]]] [%s] [%s] [-W[<pen>][<attr>]]\n\t[%s] [%s] [%s]\n", GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, GMT_a_OPT);
+		GMT_Message (API, GMT_TIME_NONE, "\t[-S[<symbol>][<size>[unit]]] [%s] [%s] [-W[<pen>][<attr>]]\n\t[%s] [%s] [%s] [-Z<val>]\n", GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, GMT_a_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] %s[%s] [%s]\n\t[%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s]\n\n", GMT_bi_OPT, API->c_OPT, GMT_di_OPT, GMT_e_OPT, \
 		GMT_f_OPT, GMT_g_OPT, GMT_h_OPT, GMT_i_OPT, GMT_p_OPT, GMT_tv_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
@@ -519,7 +523,9 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 		GMT_Message (API, GMT_TIME_NONE, "\t-T Ignore all input files.\n");
 	GMT_Option (API, "U,V");
 	gmt_pen_syntax (API->GMT, 'W', "Set pen attributes [Default pen is %s]:", 15);
-	GMT_Option (API, "X,a,bi");
+	GMT_Option (API, "X");
+	GMT_Message (API, GMT_TIME_NONE, "\t-Z Use <value> with -C <cpt> to determine <color> instead of via -G<color>.\n");
+	GMT_Option (API, "a,bi");
 	if (gmt_M_showusage (API)) GMT_Message (API, GMT_TIME_NONE, "\t   Default is the required number of columns.\n");
 	GMT_Option (API, "c,di,e,f,g,h,i,p,t");
 	GMT_Message (API, GMT_TIME_NONE, "\t   For plotting symbols with variable transparency read from file, give no value.\n");
@@ -596,7 +602,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OP
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int n_errors = 0;
+	unsigned int n_errors = 0, ztype;
 	int j;
 	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, *c = NULL;
 	struct GMT_OPTION *opt = NULL;
@@ -782,6 +788,12 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OP
 				if (Ctrl->W.pen.cptmode) Ctrl->W.cpt_effect = true;
 				break;
 
+			case 'Z':		/* Get value for CPT lookup */
+				Ctrl->Z.active = true;
+				ztype = (strchr (opt->arg, 'T')) ? GMT_IS_ABSTIME : gmt_M_type (GMT, GMT_IN, GMT_Z);
+				n_errors += gmt_verify_expectations (GMT, ztype, gmt_scanf_arg (GMT, opt->arg, ztype, false, &Ctrl->Z.value), opt->arg);
+				break;
+
 			default:	/* Report bad options */
 				n_errors += gmt_default_error (GMT, opt->option);
 				break;
@@ -792,6 +804,8 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OP
 
 	/* Check that the options selected are mutually consistent */
 
+	n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active && !Ctrl->C.active, "Syntax error -Z option: No CPT given via -C\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active && Ctrl->G.active, "Syntax error -Z option: Not compatible with -G\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && Ctrl->C.file[0] == '\0', "Syntax error -C option: No CPT given\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && gmt_parse_symbol_option (GMT, Ctrl->S.arg, S, 0, true), "Syntax error -S option\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->E.active && (S->symbol == PSL_VECTOR || S->symbol == GMT_SYMBOL_GEOVECTOR || S->symbol == PSL_MARC \
@@ -803,7 +817,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OP
 	n_errors += gmt_M_check_condition (GMT, Ctrl->E.active && Ctrl->E.mode && !Ctrl->C.active, "Syntax error: -E option +|-<pen> requires the -C option\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->W.active && Ctrl->W.pen.cptmode && !Ctrl->C.active, "Syntax error: -W modifier +c requires the -C option\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->E.active && (Ctrl->W.pen.cptmode + Ctrl->E.mode) == 3, "Syntax error: Conflicting -E and -W options regarding -C option application\n");
-	n_errors += gmt_M_check_condition (GMT, Ctrl->L.anchor && !Ctrl->G.active && !Ctrl->L.outline, "Syntax error: -L<modifiers> must include +p<pen> if -G not given\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->L.anchor && (!Ctrl->G.active && !Ctrl->Z.active) && !Ctrl->L.outline, "Syntax error: -L<modifiers> must include +p<pen> if -G not given\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->I.mode == 1 && !Ctrl->S.active, "Syntax error: -I with no argument is only applicable for symbols\n");
 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
@@ -903,8 +917,29 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 		}
 	}
 
+	if (Ctrl->C.active) {
+		if ((P = GMT_Read_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, Ctrl->C.file, NULL)) == NULL) {
+			Return (API->error);
+		}
+		get_rgb = not_line;	/* Need to assign color from either z or text from input data file */
+		PH = gmt_get_C_hidden (P);
+		if (Ctrl->Z.active) {	/* Get color from cpt -Z and store in -G */
+			(void)gmt_get_rgb_from_z (GMT, P, Ctrl->Z.value, Ctrl->G.fill.rgb);
+			Ctrl->G.active = true;	/* -C plus -Z = -G */
+			get_rgb = false;
+		}
+		else if ((P->categorical & 2))	/* Get rgb from trailing text, so read no extra z columns */
+			rgb_from_z = false;
+		else {	/* Read extra z column for symbols only */
+			rgb_from_z = not_line;
+			if (rgb_from_z && (P->categorical & 2) == 0) n_cols_start++;
+		}
+	}
+
 	polygon = (S.symbol == GMT_SYMBOL_LINE && (Ctrl->G.active || Ctrl->L.polygon) && !Ctrl->L.anchor);
 	if (S.symbol == PSL_DOT) penset_OK = false;	/* Dots have no outline */
+
+	Ctrl->E.size *= 0.5;	/* Since we draw half-way in either direction */
 
 	current_pen = default_pen = Ctrl->W.pen;
 	current_fill = default_fill = (S.symbol == PSL_DOT && !Ctrl->G.active) ? black : Ctrl->G.fill;
@@ -914,21 +949,6 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 		gmt_illuminate (GMT, Ctrl->I.value, default_fill.rgb);
 	}
 
-	Ctrl->E.size *= 0.5;	/* Since we draw half-way in either direction */
-
-	if (Ctrl->C.active) {
-		if ((P = GMT_Read_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, Ctrl->C.file, NULL)) == NULL) {
-			Return (API->error);
-		}
-		get_rgb = not_line;	/* Need to assign color from either z or text from input data file */
-		PH = gmt_get_C_hidden (P);
-		if ((P->categorical & 2))	/* Get rgb from trailing text, so read no extra z columns */
-			rgb_from_z = false;
-		else {	/* Read extra z column for symbols only */
-			rgb_from_z = not_line;
-			if (rgb_from_z && (P->categorical & 2) == 0) n_cols_start++;
-		}
-	}
 	if (Ctrl->L.anchor == PSXY_POL_SYMM_DEV) n_cols_start += 1;
 	if (Ctrl->L.anchor == PSXY_POL_ASYMM_DEV || Ctrl->L.anchor == PSXY_POL_ASYMM_ENV) n_cols_start += 2;
 	


### PR DESCRIPTION
For plot and plot3 there are times when one has a data value and a color lookup table and would like to specify the fill and outline color of a symbol or polygon via the data value and color table.  This PR adds this capability via the new option **-Z**_value_ and existing way of setting a color lookup table via **-C**.  Append **l** or **f** to only have the color apply to pen or fill, respectively,
