### PR TITLE
Improve the rotation to landscape for PostSript plots

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -6718,22 +6718,24 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 		O_active = (k) ? true : false;	/* -O is determined by presence or absence of hidden PS file */
 		/* Determine paper size */
 		wants_PS = gmtlib_fig_is_ps (GMT);	/* True if we have requested a PostScript output format */
-		if (wants_PS && media_size[GMT_X] > (GMT_PAPER_DIM-0.1)) {	/* Cannot use "auto" if requesting a PostScript file */
-			GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Must specify a paper size when requesting a PostScript file\n");
-			if (GMT->current.setting.proj_length_unit == GMT_INCH) {	/* Use US settings */
-				GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Changing paper size to US Letter, but we cannot know if this is adequate for your plot; use PS_MEDIA.\n");
-				media_size[GMT_X] = 612.0; media_size[GMT_Y] = 792.0;
+		if (wants_PS) {	/* Requesting a PostScript file in modern mode */
+			if (media_size[GMT_X] > (GMT_PAPER_DIM-0.1)) {	/* Cannot use "auto" if requesting a PostScript file */
+				GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Must specify a paper size when requesting a PostScript file\n");
+				if (GMT->current.setting.proj_length_unit == GMT_INCH) {	/* Use US settings */
+					GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Changing paper size to US Letter, but we cannot know if this is adequate for your plot; use PS_MEDIA.\n");
+					media_size[GMT_X] = 612.0; media_size[GMT_Y] = 792.0;
+				}
+				else {	/* Use SI settings */
+					GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Changing paper size to A4, but we cannot know if this is adequate for your plot.\n");
+					media_size[GMT_X] = 595.0; media_size[GMT_Y] = 842.0;
+				}
 			}
-			else {	/* Use SI settings */
-				GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Changing paper size to A4, but we cannot know if this is adequate for your plot.\n");
-				media_size[GMT_X] = 595.0; media_size[GMT_Y] = 842.0;
-			}
-			if ((((GMT->current.map.width + GMT->current.setting.map_origin[GMT_X]) * 72) > media_size[GMT_X]) && GMT->current.setting.ps_orientation == PSL_PORTRAIT) {
+			if ((GMT->current.map.width > GMT->current.map.height) && (((GMT->current.map.width + GMT->current.setting.map_origin[GMT_X]) * 72) > media_size[GMT_X]) && GMT->current.setting.ps_orientation == PSL_PORTRAIT) {
 				GMT->current.setting.ps_orientation = PSL_LANDSCAPE;
-				GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Also changing to landscape orientation based on plot dimensions but again not sure.\n");
+				GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Changing to PostScript landscape orientation based on plot and paper dimensions but cannot not sure.  Use PS_PAGE_ORIENTATION to correct any error\n");
 			}
 		}
-		if (!wants_PS && !O_active) {	/* Not desiring PS output so we can add safety margin of GMT_PAPER_MARGIN inches for initial layer */
+		else if (!O_active) {	/* Not desiring PS output so we can add safety margin of GMT_PAPER_MARGIN inches for initial layer */
 			if (!(GMT->common.X.active || GMT->common.Y.active))
 				GMT->current.setting.map_origin[GMT_X] = GMT->current.setting.map_origin[GMT_Y] = GMT_PAPER_MARGIN;
 		}

--- a/test/exmod/ex22.ps
+++ b/test/exmod/ex22.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
-%%BoundingBox: 0 0 595 842
-%%HiResBoundingBox: 0 0 595.0000 842.0000             
-%%Title: GMT v6.0.0_6e2c408_2019.07.26 [64-bit] Document from pscoast
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_f72d373_2019.07.26 [64-bit] Document from pscoast
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Fri Jul 26 13:05:48 2019
+%%CreationDate: Fri Jul 26 20:18:30 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Landscape
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -646,17 +646,17 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
-PSLevel 1 gt { << /PageSize [595 842] /ImagingBBox null >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
 %%Page: 1 1
 
 %%BeginPageSetup
-V 595 0 T 90 R 0.06 0.06 scale
+V 612 0 T 90 R 0.06 0.06 scale
 %%EndPageSetup
 
-/PSL_page_xsize 14033 def
-/PSL_page_ysize 9917 def
+/PSL_page_xsize 13200 def
+/PSL_page_ysize 10200 def
 /PSL_completion {} def
 /PSL_movie_completion {} def
 %PSL_End_Header
@@ -16439,41 +16439,41 @@ N 2700 5400 M -83 0 D S
 6 -5 D
 12 -7 D
 P S
-/PSL_H_y 400 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/PSL_H_y 400 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 167 F0
-(100°) sh add def
+(100) sh add def
 5400 5400 PSL_H_y add M
 300 F0
-(World­wide earthquake activity) bc Z
+(World-wide earthquake activity) bc Z
 2770 -128 M 167 F0
-(0°) tc Z
-2770 5528 M (0°) bc Z
-3439 -137 M (45°E) tc Z
-3439 5537 M (45°E) bc Z
-4101 -149 M (90°E) tc Z
-4101 5549 M (90°E) bc Z
-4755 -161 M (135°E) tc Z
-4755 5561 M (135°E) bc Z
-5400 -167 M (180°) tc Z
-5400 5567 M (180°) bc Z
-6045 -161 M (135°W) tc Z
-6045 5561 M (135°W) bc Z
-6699 -149 M (90°W) tc Z
-6699 5549 M (90°W) bc Z
-7361 -137 M (45°W) tc Z
-7361 5537 M (45°W) bc Z
-8030 -128 M (0°) tc Z
-8030 5528 M (0°) bc Z
-2533 0 M (90°S) mr Z
-8267 0 M (90°S) ml Z
-1034 1012 M (45°S) mr Z
-9766 1012 M (45°S) ml Z
--167 2700 M (0°) mr Z
-10967 2700 M (0°) ml Z
-1034 4388 M (45°N) mr Z
-9766 4388 M (45°N) ml Z
-2533 5400 M (90°N) mr Z
-8267 5400 M (90°N) ml Z
+(0) tc Z
+2770 5528 M (0) bc Z
+3439 -137 M (45E) tc Z
+3439 5537 M (45E) bc Z
+4101 -149 M (90E) tc Z
+4101 5549 M (90E) bc Z
+4755 -161 M (135E) tc Z
+4755 5561 M (135E) bc Z
+5400 -167 M (180) tc Z
+5400 5567 M (180) bc Z
+6045 -161 M (135W) tc Z
+6045 5561 M (135W) bc Z
+6699 -149 M (90W) tc Z
+6699 5549 M (90W) bc Z
+7361 -137 M (45W) tc Z
+7361 5537 M (45W) bc Z
+8030 -128 M (0) tc Z
+8030 5528 M (0) bc Z
+2533 0 M (90S) mr Z
+8267 0 M (90S) ml Z
+1034 1012 M (45S) mr Z
+9766 1012 M (45S) ml Z
+-167 2700 M (0) mr Z
+10967 2700 M (0) ml Z
+1034 4388 M (45N) mr Z
+9766 4388 M (45N) ml Z
+2533 5400 M (90N) mr Z
+8267 5400 M (90N) ml Z
 %%EndObject
 0 A
 FQ
@@ -19640,13 +19640,13 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
 4200 1732 M 267 F1
-(1197 events during 2017­09­01 to 2017­10­01) bc Z
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+(1197 events during 2017-09-01 to 2017-10-01) bc Z
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 307 1438 M 167 F0
-(Shallow depth \(0­100 km\)) bl Z
-3107 1438 M (Intermediate depth \(100­300 km\)) bl Z
+(Shallow depth \(0-100 km\)) bl Z
+3107 1438 M (Intermediate depth \(100-300 km\)) bl Z
 5907 1438 M (Very deep \(\> 300 km\)) bl Z
 427 1163 M (M 3) bl Z
 1627 1163 M (M 4) bl Z
@@ -19655,7 +19655,7 @@ PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reenco
 5227 1163 M (M 7) bl Z
 6427 1163 M (M 8) bl Z
 7627 1163 M (M 9) bl Z
-PSL_font_encode 6 get 0 eq {ISOLatin1+_Encoding /Times-Italic /Times-Italic PSL_reencode PSL_font_encode 6 1 put} if
+PSL_font_encode 6 get 0 eq {Standard+_Encoding /Times-Italic /Times-Italic PSL_reencode PSL_font_encode 6 1 put} if
 67 256 M 200 F6
 (GMT guru \100 GMTbox) bl Z
 %%EndObject

--- a/test/exmod/ex23.ps
+++ b/test/exmod/ex23.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
-%%BoundingBox: 0 0 595 842
-%%HiResBoundingBox: 0 0 595.0000 842.0000             
-%%Title: GMT v6.0.0_6e2c408_2019.07.26 [64-bit] Document from pscoast
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_f72d373_2019.07.26 [64-bit] Document from pscoast
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Fri Jul 26 13:05:52 2019
+%%CreationDate: Fri Jul 26 20:22:59 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Landscape
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -646,17 +646,17 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
-PSLevel 1 gt { << /PageSize [595 842] /ImagingBBox null >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
 %%Page: 1 1
 
 %%BeginPageSetup
-V 595 0 T 90 R 0.06 0.06 scale
+V 612 0 T 90 R 0.06 0.06 scale
 %%EndPageSetup
 
-/PSL_page_xsize 14033 def
-/PSL_page_ysize 9917 def
+/PSL_page_xsize 13200 def
+/PSL_page_ysize 10200 def
 /PSL_completion {} def
 /PSL_movie_completion {} def
 %PSL_End_Header
@@ -35237,9 +35237,9 @@ P
 157 -3 D
 128 -1 D
 P S
-/PSL_H_y 400 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/PSL_H_y 400 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(100∞) sh add def
+(100è) sh add def
 5400 5400 PSL_H_y add M
 400 F0
 (Distances from Rome to the World) bc Z
@@ -35531,7 +35531,7 @@ PSL_clip N
 /PSL_setboxpen {4 W 0 A [] 0 B} def
 /PSL_setboxrgb {1 A} def
 /PSL_path_pen [
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 	(4 W 1 A \[33 17\] 0 B)
 	(12 W 1 A \[\] 0 B)
 	(4 W 1 A \[33 17\] 0 B)
@@ -61842,16 +61842,16 @@ PSL_clip N
 V
 {1 0 0 C} FS
 O1
-47 5902 3395 Ss
-47 -4534 3395 Ss
-47 420 2165 Ss
-47 11006 2165 Ss
-47 8161 2055 Ss
-47 -2326 2055 Ss
-47 8617 4525 Ss
-47 657 4525 Ss
-47 3523 1822 Ss
-47 13736 1822 Ss
+120 5902 3395 Ss
+120 -4534 3395 Ss
+120 420 2165 Ss
+120 11006 2165 Ss
+120 8161 2055 Ss
+120 -2326 2055 Ss
+120 8617 4525 Ss
+120 657 4525 Ss
+120 3523 1822 Ss
+120 13736 1822 Ss
 U
 PSL_cliprestore
 %%EndObject
@@ -61867,14 +61867,14 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-PSL_font_encode 9 get 0 eq {ISOLatin1+_Encoding /Courier-Bold /Courier-Bold PSL_reencode PSL_font_encode 9 1 put} if
+PSL_font_encode 9 get 0 eq {Standard+_Encoding /Courier-Bold /Courier-Bold PSL_reencode PSL_font_encode 9 1 put} if
 1 0 0 C
-5973 3395 M 200 F9
+6082 3395 M 200 F9
 (HANOI) ml Z
-491 2165 M (LIMA) ml Z
-8232 2055 M (SUVA) ml Z
-8546 4525 M (SEATTLE) mr Z
-3594 1822 M (PRETORIA) ml Z
+600 2165 M (LIMA) ml Z
+8341 2055 M (SUVA) ml Z
+8437 4525 M (SEATTLE) mr Z
+3703 1822 M (PRETORIA) ml Z
 %%EndObject
 0 A
 FQ
@@ -62180,7 +62180,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
 4 W
 {1 A} FS
 O1

--- a/test/exmod/ex23.sh
+++ b/test/exmod/ex23.sh
@@ -26,7 +26,6 @@ gmt begin ex23 ps
 	237.67	47.58	RM	SEATTLE
 	28.20	-25.75	LM	PRETORIA
 	END
-	
 	gmt coast -Rg -JH90/9i -Glightgreen -Sblue -A1000 -Bg30 \
 		-B+t"Distances from $name to the World" -Wthinnest
 	

--- a/test/exmod/ex24.ps
+++ b/test/exmod/ex24.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
-%%BoundingBox: 0 0 595 842
-%%HiResBoundingBox: 0 0 595.0000 842.0000             
-%%Title: GMT v6.0.0_6e2c408_2019.07.26 [64-bit] Document from pscoast
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_f72d373_2019.07.26 [64-bit] Document from pscoast
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Fri Jul 26 13:06:00 2019
+%%CreationDate: Fri Jul 26 20:24:09 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Landscape
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -646,17 +646,17 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
-PSLevel 1 gt { << /PageSize [595 842] /ImagingBBox null >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
 %%Page: 1 1
 
 %%BeginPageSetup
-V 595 0 T 90 R 0.06 0.06 scale
+V 612 0 T 90 R 0.06 0.06 scale
 %%EndPageSetup
 
-/PSL_page_xsize 14033 def
-/PSL_page_ysize 9917 def
+/PSL_page_xsize 13200 def
+/PSL_page_ysize 10200 def
 /PSL_completion {} def
 /PSL_movie_completion {} def
 %PSL_End_Header
@@ -12526,18 +12526,18 @@ N 10883 8113 M -10966 0 D S
 N 10883 8197 M -10966 0 D S
 N 0 8197 M 0 -8280 D S
 N -83 8197 M 0 -8280 D S
-0 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 -167 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(100∞) tc Z
-2160 -167 M (120∞) tc Z
-4320 -167 M (140∞) tc Z
-6480 -167 M (160∞) tc Z
-8640 -167 M (180∞) tc Z
-10800 -167 M (-160∞) tc Z
--167 0 M (-60∞) mr Z
--167 3419 M (-40∞) mr Z
--167 5922 M (-20∞) mr Z
--167 8113 M (0∞) mr Z
+(100è) tc Z
+2160 -167 M (120è) tc Z
+4320 -167 M (140è) tc Z
+6480 -167 M (160è) tc Z
+8640 -167 M (180è) tc Z
+10800 -167 M (î160è) tc Z
+-167 0 M (î60è) mr Z
+-167 3419 M (î40è) mr Z
+-167 5922 M (î20è) mr Z
+-167 8113 M (0è) mr Z
 %%EndObject
 0 A
 FQ
@@ -25521,7 +25521,7 @@ clipsave
 -10800 0 D
 P
 PSL_clip N
-PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
 1 A
 5219 2897 M 233 F1
 (Hobart) tl Z

--- a/test/exmod/ex25.ps
+++ b/test/exmod/ex25.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
-%%BoundingBox: 0 0 595 842
-%%HiResBoundingBox: 0 0 595.0000 842.0000             
-%%Title: GMT v6.0.0_6e2c408_2019.07.26 [64-bit] Document from grdimage
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_f72d373_2019.07.26 [64-bit] Document from grdimage
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Fri Jul 26 13:06:06 2019
+%%CreationDate: Fri Jul 26 20:25:00 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Landscape
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -646,17 +646,17 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
-PSLevel 1 gt { << /PageSize [595 842] /ImagingBBox null >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
 %%Page: 1 1
 
 %%BeginPageSetup
-V 595 0 T 90 R 0.06 0.06 scale
+V 612 0 T 90 R 0.06 0.06 scale
 %%EndPageSetup
 
-/PSL_page_xsize 14033 def
-/PSL_page_ysize 9917 def
+/PSL_page_xsize 13200 def
+/PSL_page_ysize 10200 def
 /PSL_completion {} def
 /PSL_movie_completion {} def
 %PSL_End_Header
@@ -1250,34 +1250,34 @@ N 2700 5400 M -69 0 D S
 6 -5 D
 12 -7 D
 P S
-/PSL_H_y 333 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/PSL_H_y 333 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 167 F0
-(100∞) sh add def
+(100è) sh add def
 5400 5400 PSL_H_y add M
 333 F0
 (Antipodal comparisons) bc Z
 2759 5507 M 167 F0
-(0∞) bc Z
-3650 5517 M (60∞E) bc Z
-4532 5531 M (120∞E) bc Z
-5400 5539 M (180∞) bc Z
-6268 5531 M (120∞W) bc Z
-7150 5517 M (60∞W) bc Z
-8041 5507 M (0∞) bc Z
-2561 0 M (90∞S) mr Z
-8239 0 M (90∞S) ml Z
-1759 519 M (60∞S) mr Z
-9041 519 M (60∞S) ml Z
-436 1558 M (30∞S) mr Z
-10364 1558 M (30∞S) ml Z
--139 2700 M (0∞) mr Z
-10939 2700 M (0∞) ml Z
-436 3842 M (30∞N) mr Z
-10364 3842 M (30∞N) ml Z
-1759 4881 M (60∞N) mr Z
-9041 4881 M (60∞N) ml Z
-2561 5400 M (90∞N) mr Z
-8239 5400 M (90∞N) ml Z
+(0è) bc Z
+3650 5517 M (60èE) bc Z
+4532 5531 M (120èE) bc Z
+5400 5539 M (180è) bc Z
+6268 5531 M (120èW) bc Z
+7150 5517 M (60èW) bc Z
+8041 5507 M (0è) bc Z
+2561 0 M (90èS) mr Z
+8239 0 M (90èS) ml Z
+1759 519 M (60èS) mr Z
+9041 519 M (60èS) ml Z
+436 1558 M (30èS) mr Z
+10364 1558 M (30èS) ml Z
+-139 2700 M (0è) mr Z
+10939 2700 M (0è) ml Z
+436 3842 M (30èN) mr Z
+10364 3842 M (30èN) ml Z
+1759 4881 M (60èN) mr Z
+9041 4881 M (60èN) ml Z
+2561 5400 M (90èN) mr Z
+8239 5400 M (90èN) ml Z
 %%EndObject
 0 A
 FQ
@@ -10560,7 +10560,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-427 100 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+427 100 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 167 F0
 (Terrestrial Antipodes \[4 %\]) bl Z
 2827 100 M (Oceanic Antipodes \[46 %\]) bl Z


### PR DESCRIPTION
We had an issue here as we would not always switch to landscape when the plot clearly was landscape and exceeding the paper width.,  Now we chech that width > height and that width+margin exceed paperwidth before we switch to landscape.  Updating several PS files (22,23,24,25) to new versions.
