### PR TITLE
Fix Harvard CMT to Global CMT

### DIFF
--- a/doc/rst/source/supplements/seis/coupe_common.rst_
+++ b/doc/rst/source/supplements/seis/coupe_common.rst_
@@ -100,7 +100,7 @@ Required Arguments
       text string to appear above the beach ball [Default] or under (add **+u**).
 
   **-Sc**\ *scale[/fontsize[/offset*\ [**+u**]]]
-     Focal mechanisms in Harvard CMT convention. *scale* adjusts the scaling
+     Focal mechanisms in Global CMT convention. *scale* adjusts the scaling
      of the radius of the "beach ball", which will be proportional to the
      magnitude. The *scale* is the size for magnitude = 5 (that is M0 = 4E+23
      dynes-cm.) in **PROJ_LENGTH_UNIT** (unless **c**, **i**, or
@@ -170,7 +170,7 @@ Required Arguments
       text string to appear above the beach ball (default) or under (add **+u**).
 
   **-Sm\|d\|z**\ *scale[/fontsize[/offset*\ [**+u**]]]
-     Seismic moment tensor (Harvard CMT, with zero trace). *scale* adjusts
+     Seismic moment tensor (Global CMT, with zero trace). *scale* adjusts
      the scaling of the radius of the "beach ball", which will be
      proportional to the magnitude. The *scale* is the size for magnitude = 5
      (that is seismic scalar moment = 4E+23 dynes-cm) in

--- a/doc/rst/source/supplements/seis/meca_common.rst_
+++ b/doc/rst/source/supplements/seis/meca_common.rst_
@@ -69,7 +69,7 @@ Required Arguments
 
 **-Sc**\ *scale[/fontsize[/offset*]][**+u**\ ]
 
-    Focal mechanisms in Harvard CMT convention. *scale* adjusts the scaling
+    Focal mechanisms in Global CMT convention. *scale* adjusts the scaling
     of the radius of the "beach ball", which will be proportional to the
     magnitude. Scale is the size for magnitude = 5 (that is M0 = 4.0E23
     dynes-cm) in inch (unless **c**, **i**, or **p** is appended).
@@ -108,12 +108,12 @@ Required Arguments
 
 **-Sm\|d\|z**\ *scale[/fontsize[/offset*]][**+u**\ ]
 
-    Seismic moment tensor (Harvard CMT, with zero trace). *scale* adjusts
+    Seismic moment tensor (Global CMT, with zero trace). *scale* adjusts
     the scaling of the radius of the "beach ball", which will be
     proportional to the magnitude. Scale is the size for magnitude = 5 (that
     is scalar seismic moment = 4.0E23 dynes-cm) in inch (unless **c**,
     **i**, **m**, or **p** is appended). (**-T**\ *0* option overlays best
-    double couple transparently.) Use **-Sm** to plot the Harvard CMT
+    double couple transparently.) Use **-Sm** to plot the Global CMT
     seismic moment tensor with zero trace. Use **-Sd** to plot only the
     double couple part of moment tensor. Use **-Sz** to plot the anisotropic
     part of moment tensor (zero trace). The color or shade of the
@@ -192,7 +192,7 @@ Required Arguments
     for magnitude = 5 (that is seismic scalar moment = 4\*10e+23 dynes-cm)
     in inch (unless **c**, **i**, or **p** is appended). (**-T**\ *0*
     option overlays best double couple transparently.) Use **-Sx** to plot
-    standard Harvard CMT. Use **-Sy** to plot only the double couple part of
+    standard Global CMT. Use **-Sy** to plot only the double couple part of
     moment tensor. Use **-St** to plot zero trace moment tensor. The color
     or shade of the compressive quadrants can be specified with the **-G**
     option. The color or shade of the extensive quadrants can be specified

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -468,15 +468,15 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append the format code for your input file:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   a  Focal mechanism in Aki & Richard's convention:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth strike dip rake mag newX newY [event_title]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   c  Focal mechanisms in Harvard CMT convention\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   c  Focal mechanisms in Global CMT convention\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth strike1 dip1 rake1 strike2 dip2 rake2 moment newX newY [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      with moment in 2 columns : mantissa and exponent corresponding to seismic moment in dynes-cm\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   d  Best double couple defined from seismic moment tensor (Harvard CMT, with zero trace):\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   d  Best double couple defined from seismic moment tensor (Global CMT, with zero trace):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp newX newY [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   p  Focal mechanism defined with:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth strike1 dip1 strike2 fault mag newX newY [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      fault = -1/+1 for a normal/inverse fault\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   m  Seismic moment tensor (Harvard CMT, with zero trace):\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   m  Seismic moment tensor (Global CMT, with zero trace):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp newX newY [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   t  Zero trace moment tensor defined from principal axis:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth T_value T_azim T_plunge N_value N_azim N_plunge\n");
@@ -487,7 +487,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   y  Best double couple defined from principal axis:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth T_value T_azim T_plunge N_value N_azim N_plunge\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        P_value P_azim P_plunge exp newX newY [event_title]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   z  Anisotropic part of seismic moment tensor (Harvard CMT, with zero trace):\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   z  Anisotropic part of seismic moment tensor (Global CMT, with zero trace):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally add /fontsize[/offset][+u] [Default values are /%g/%f].\n", DEFAULT_FONTSIZE, DEFAULT_OFFSET);
 	GMT_Message (API, GMT_TIME_NONE, "\t   fontsize < 0 : no label written; offset is from the limit of the beach ball.\n");

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -210,15 +210,15 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append the format code for your input file:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   a  Focal mechanism in Aki & Richard's convention:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth strike dip rake mag newX newY [event_title]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   c  Focal mechanisms in Harvard CMT convention\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   c  Focal mechanisms in Global CMT convention\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth strike1 dip1 rake1 strike2 dip2 rake2 moment newX newY [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      with moment in 2 columns : mantissa and exponent corresponding to seismic moment in dynes-cm\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   d  Best double couple defined from seismic moment tensor (Harvard CMT, with zero trace):\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   d  Best double couple defined from seismic moment tensor (Global CMT, with zero trace):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp newX newY [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   p  Focal mechanism defined with:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth strike1 dip1 strike2 fault mag newX newY [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      fault = -1/+1 for a normal/inverse fault\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   m  Seismic moment tensor (Harvard CMT, with zero trace):\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   m  Seismic moment tensor (Global CMT, with zero trace):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp newX newY [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   t  Zero trace moment tensor defined from principal axis:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth T_value T_azim T_plunge N_value N_azim N_plunge\n");
@@ -229,7 +229,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   y  Best double couple defined from principal axis:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth T_value T_azim T_plunge N_value N_azim N_plunge\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        P_value P_azim P_plunge exp newX newY [event_title]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   z  Anisotropic part of seismic moment tensor (Harvard CMT, with zero trace):\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   z  Anisotropic part of seismic moment tensor (Global CMT, with zero trace):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use -Fo option for old (psvelomeca) format (no depth in third column).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally add /fontsize[/offset][+u] [Default values are /%g/%fp]\n", DEFAULT_FONTSIZE, DEFAULT_OFFSET);

--- a/test/seis/seis_06.sh
+++ b/test/seis/seis_06.sh
@@ -4,7 +4,7 @@ ps=seis_06.ps
 
 gmt set PROJ_LENGTH_UNIT inch MAP_TICK_LENGTH_PRIMARY 0.075i MAP_FRAME_WIDTH 0.1i MAP_ORIGIN_X 2.5c MAP_ORIGIN_Y 1.3i FONT_TITLE 18p
 
-# this is Harvard CMT for tibethan earthquake (1997)
+# this is Global CMT for tibethan earthquake (1997)
 gmt psmeca -Fo -R85/89/25/50 -JX7i -P -M -Sm4i -N  -L -K -G150 -T0 << EOF > $ps
 # lon  lat  mrr   mtt  mff   mrt   mrf  mtf ex nlon nlat
  87  35 -0.26 -0.71 0.97 -0.20 -0.61 2.60 27  0    0


### PR DESCRIPTION
Harvard CMT was renamed to Global CMT since 2006.