### PR TITLE
Add single quotes around filenames, in case there are spaces in the full path

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15328,7 +15328,7 @@ GMT_LOCAL int process_figures (struct GMTAPI_CTRL *API, char *show) {
 				}
 			}
 			/* Here the file exists and we can call psconvert. Note we still pass *.ps- even if *.ps+ was found since psconvert will do the same check */
-			sprintf (cmd, "%s/gmt_%d.ps- -T%c -F%s", API->gwf_dir, fig[k].ID, fmt[f], fig[k].prefix);
+			sprintf (cmd, "'%s/gmt_%d.ps-' -T%c -F%s", API->gwf_dir, fig[k].ID, fmt[f], fig[k].prefix);
 			not_PS = (fmt[f] != 'p');	/* Do not add convert options if plain PS */
 			/* Append psconvert optional settings */
 			if (fig[k].options[0]) {	/* Append figure-specific settings */


### PR DESCRIPTION
See the attached screenshot for a bug report.

![image](https://user-images.githubusercontent.com/3974108/62007343-37c12800-b101-11e9-87c2-7c8d287ad2e5.png)

Although it's really a bad idea to have a username with spaces, we can easily fix the issue by adding single quotes around the filenames.