### PR TITLE
Allow gmt docs to open classic modules

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -61,7 +61,7 @@ set (GMT_LIB_SOVERSION 6)
 set (GMT_LIB_VERSION "${GMT_LIB_SOVERSION}.${GMT_PACKAGE_VERSION_MINOR}.${GMT_PACKAGE_VERSION_PATCH}")
 
 # The GMT documentation URL
-set (GMT_DOC_URL "http://docs.generic-mapping-tools.org/latest")
+set (GMT_DOC_URL "http://docs.generic-mapping-tools.org/dev")
 
 # Use SI units per default
 if (NOT UNITS)

--- a/src/docs.c
+++ b/src/docs.c
@@ -138,9 +138,7 @@ int GMT_docs (void *V_API, int mode, void *args) {
 			docname = gmt_current_name (opt->arg, name);
 	
 			if (strcmp (opt->arg, docname))
-				GMT_Report (GMT->parent, GMT_MSG_NORMAL,
-				            "For now, HTML documentation only uses GMT modern mode names, hence %s will display as %s\n",
-				            opt->arg, docname);
+				docname = opt->arg;
 
 			t = strdup (docname);	/* Make a copy because gmt_str_tolower changes the input that may be a const char */
 			gmt_str_tolower (t);

--- a/src/docs.c
+++ b/src/docs.c
@@ -135,9 +135,9 @@ int GMT_docs (void *V_API, int mode, void *args) {
 		}
 		else {	/* Documentation references */
 
-			docname = gmt_current_name (opt->arg, name);
+			docname = gmt_current_name (opt->arg, name);	/* Get modern mode name */
 	
-			if (strcmp (opt->arg, docname))
+			if (strcmp (opt->arg, docname))	/* Gave classic name so change to what was given */
 				docname = opt->arg;
 
 			t = strdup (docname);	/* Make a copy because gmt_str_tolower changes the input that may be a const char */


### PR DESCRIPTION
We were too harsh on this earlier.  Asking for pscoast is not deprecated.
