### PR TITLE
meca: -S option is required

### DIFF
--- a/doc/rst/source/supplements/seis/meca.rst
+++ b/doc/rst/source/supplements/seis/meca.rst
@@ -14,13 +14,13 @@ Synopsis
 .. include:: ../../common_SYN_OPTs.rst_
 
 **gmt meca** [ *table* ] |-J|\ *parameters* |SYN_OPT-R|
+|-S|\ *<format><scale>*\ [/*fontsize*\ [/*offset*]][**+u**\ ]
 [ |SYN_OPT-B| ]
 [ |-C|\ [*pen*\ ][\ **+s**\ *pointsize*] ] [ |-D|\ *depmin*/*depmax* ]
 [ |-E|\ *fill*]
 [ |-F|\ *mode*\ [*args*] ] [ |-G|\ *fill*] [ |-L|\ [*pen*\ ] ]
 [ |-M| ]
 [ |-N| ]
-[ |-S|\ *<format><scale>*\ [/*fontsize*\ [/*offset*]][**+u**\ ]
 [ |-T|\ *num\_of\_plane*\ [/*pen*\ ] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]

--- a/doc/rst/source/supplements/seis/psmeca.rst
+++ b/doc/rst/source/supplements/seis/psmeca.rst
@@ -14,13 +14,13 @@ Synopsis
 .. include:: ../../common_SYN_OPTs.rst_
 
 psmeca [ *table* ] |-J|\ *parameters* |SYN_OPT-R|
+|-S|\ *<format><scale>*\ [/*fontsize*\ [/*offset*]][**+u**\ ]
 [ |SYN_OPT-B| ]
 [ |-C|\ [*pen*\ ][\ **+s**\ *pointsize*] ] [ |-D|\ *depmin*/*depmax* ]
 [ |-E|\ *fill*]
 [ |-F|\ *mode*\ [*args*] ] [ |-G|\ *fill*] [ |-K| ] [ |-L|\ [*pen*\ ] ]
 [ |-M| ]
 [ |-N| ] [ |-O| ] [ |-P| ]
-[ |-S|\ *<format><scale>*\ [/*fontsize*\ [/*offset*]][**+u**\ ]]
 [ |-T|\ *num\_of\_plane*\ [*pen*\ ] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -465,6 +465,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_
 	gmt_consider_current_cpt (GMT->parent, &Ctrl->Z.active, &(Ctrl->Z.file));
 
 	/* Check that the options selected are mutually consistent */
+	n_errors += gmt_M_check_condition(GMT, !Ctrl->S.active, "Syntax error: Must specify -S option\n");
 
 	no_size_needed = (Ctrl->S.readmode == READ_CMT || Ctrl->S.readmode == READ_PLANES || Ctrl->S.readmode == READ_AKI ||
 	                  Ctrl->S.readmode == READ_TENSOR || Ctrl->S.readmode == READ_AXIS);


### PR DESCRIPTION
If `-S` option is not specified, the beachball *scale* = 0, which doesn't make sense. It ain any format. 

In this PR, `-S` option becomes a required option.