### PR TITLE
Add inset to the list reported by gmt

### DIFF
--- a/src/gmt.c
+++ b/src/gmt.c
@@ -228,8 +228,8 @@ int main (int argc, char *argv[]) {
 			fprintf (stderr, "  gmt end           Terminate the current GMT modern mode session.\n");
 			fprintf (stderr, "  gmt docs          Display the HTML documentation for selected module.\n");
 			fprintf (stderr, "  gmt figure        Set figure format specifics under a GMT modern mode session.\n");
+			fprintf (stderr, "  gmt inset         Manage figure inset setup and completion.\n");
 			fprintf (stderr, "  gmt subplot       Initiate a multi-panel figure.\n");
-			//fprintf (stderr, "  gmt revert        Undo last <n> layers from current figure.\n");
 			fprintf (stderr, "  gmt clear         Delete gmt.history, gmt.conf, current CPT, user cache or data, or all.\n\n");
 			fprintf (stderr, "options:\n");
 			fprintf (stderr, "  --help            List descriptions of available GMT modules.\n");


### PR DESCRIPTION
We had forgotten to add inset to the list of gmt sessions commands reported by the gmt.c driver.
