### PR TITLE
Split how the trailing help usage is handled

### DIFF
--- a/doc/rst/source/begin.rst_
+++ b/doc/rst/source/begin.rst_
@@ -48,7 +48,7 @@ Optional Arguments
 .. |Add_-V| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-V.rst_
 
-.. include:: explain_help.rst_
+.. include:: explain_help_nopar.rst_
 
 .. _tbl-formats:
 

--- a/doc/rst/source/clear.rst_
+++ b/doc/rst/source/clear.rst_
@@ -63,7 +63,7 @@ Optional Arguments
 .. |Add_-V| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-V.rst_
 
-.. include:: explain_help.rst_
+.. include:: explain_help_nopar.rst_
 
 Examples
 --------

--- a/doc/rst/source/end.rst_
+++ b/doc/rst/source/end.rst_
@@ -33,7 +33,7 @@ Optional Arguments
 .. |Add_-V| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-V.rst_
 
-.. include:: explain_help.rst_
+.. include:: explain_help_nopar.rst_
 
 Examples
 --------

--- a/doc/rst/source/explain_help_nopar.rst_
+++ b/doc/rst/source/explain_help_nopar.rst_
@@ -1,0 +1,7 @@
+**-^** or just **-**
+    Print a short message about the syntax of the command, then exits (NOTE: on Windows just use **-**).
+**-+** or just **+**
+    Print an extensive usage (help) message, including the explanation of
+    any module-specific option (but not the GMT common options), then exits.
+**-?** or no arguments
+    Print a complete usage (help) message, including the explanation of all options, then exits.

--- a/doc/rst/source/figure.rst_
+++ b/doc/rst/source/figure.rst_
@@ -61,7 +61,7 @@ Optional Arguments
 .. |Add_-V| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-V.rst_
 
-.. include:: explain_help.rst_
+.. include:: explain_help_nopar.rst_
 
 .. include:: explain_postscript.rst_
 

--- a/doc/rst/source/inset.rst_
+++ b/doc/rst/source/inset.rst_
@@ -95,7 +95,7 @@ Optional Arguments
 .. |Add_-V| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-V.rst_
 
-.. include:: explain_help.rst_
+.. include:: explain_help_nopar.rst_
 
 Synopsis (end mode)
 -------------------
@@ -112,7 +112,7 @@ Optional Arguments
 .. _inset_end-V:
 
 .. include:: explain_-V.rst_
-.. include:: explain_help.rst_
+.. include:: explain_help_nopar.rst_
 
 
 Examples

--- a/src/begin.c
+++ b/src/begin.c
@@ -53,7 +53,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     ppm:	Portable Pixel Map.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     ps:	PostScript.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     tif:	Tagged Image Format File.\n");
-	GMT_Option (API, "V,.");
+	GMT_Option (API, "V,;");
 	
 	return (GMT_MODULE_USAGE);
 }

--- a/src/clear.c
+++ b/src/clear.c
@@ -51,7 +51,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   sessions  Deletes the user\'s sessions directory [%s].\n", API->session_dir);
 	GMT_Message (API, GMT_TIME_NONE, "\t   all       All of the above.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
-	GMT_Option (API, "V,.");
+	GMT_Option (API, "V,;");
 	
 	return (GMT_MODULE_USAGE);
 }

--- a/src/end.c
+++ b/src/end.c
@@ -41,7 +41,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 
 	GMT_Message (API, GMT_TIME_NONE, "\tOPTIONS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\tshow Display each figure in the default viewer.\n");
-	GMT_Option (API, "V,.");
+	GMT_Option (API, "V,;");
 	
 	return (GMT_MODULE_USAGE);
 }

--- a/src/figure.c
+++ b/src/figure.c
@@ -59,7 +59,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   The valid subset of psconvert options are\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     A[<args>],C<args>,D<dir>,E<dpi>,H<factor>,Mb|f<file>,Q<args>,S\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   See the psconvert documentation for details.\n");
-	GMT_Option (API, "V,.");
+	GMT_Option (API, "V,;");
 	
 	return (GMT_MODULE_USAGE);
 }

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6560,6 +6560,13 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 			gmt_message (GMT, "\t(See gmt.conf man page for GMT default parameters).\n");
 			break;
 
+		case ';':	/* Trailer message without --PAR=value etc */
+
+			gmt_message (GMT, "\t-^ (or -) Print short synopsis message.\n");
+			gmt_message (GMT, "\t-+ (or +) Print longer synopsis message.\n");
+			gmt_message (GMT, "\t-? (or no arguments) Print this usage message.\n");
+			break;
+
 		case '<':	/* Table input */
 
 			gmt_message (GMT, "\t<table> is one or more data files (in ASCII, binary, netCDF).\n");

--- a/src/inset.c
+++ b/src/inset.c
@@ -35,7 +35,7 @@
 #define THIS_MODULE_PURPOSE	"Manage figure inset setup and completion"
 #define THIS_MODULE_KEYS	">X}"
 #define THIS_MODULE_NEEDS	"JR"
-#define THIS_MODULE_OPTIONS	"-JRV"
+#define THIS_MODULE_OPTIONS	"JRV"
 
 /* Control structure for inset */
 
@@ -92,7 +92,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	gmt_mappanel_syntax (API->GMT, 'F', "Specify a rectangular panel behind the map inset.", 3);
 	GMT_Message (API, GMT_TIME_NONE, "\t-M Allows for padding around the inset. Append a uniform <margin>, separate <xmargin>/<ymargin>,\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   or individual <wmargin>/<emargin>/<smargin>/<nmargin> for each side [0.5c].\n");
-	GMT_Option (API, "V,.");
+	GMT_Option (API, "V,;");
 	
 	return (GMT_MODULE_USAGE);
 }


### PR DESCRIPTION
Some modern mode commands (begin, end, figure, clear, inset) do not take **--PAR**=_value_ but the _GMT_Option_ arg "." would print that out.  I added a new shorthand ";" that excludes the par argument and mention of gmt.conf.  Likewise, for the documentation I added a new explain_help_nopar.rst_ that excludes that information.  This PR completes what #1267 started.
