### PR TITLE
Help gmt which when -G not given and file starts with at-symbol

### DIFF
--- a/doc/rst/source/gmtwhich.rst
+++ b/doc/rst/source/gmtwhich.rst
@@ -26,7 +26,7 @@ line. We look for the file in (1) the current directory,
 (4) in $GMT_CACHEDIR (if defined). If
 found we print the full path name to the file, just the directory (see
 **-D**), or a confirmation (see **-C**). The $GMT_USERDIR and
-$GMT_DATADIR environment variables can be colon-separated list of
+$GMT_DATADIR environment variables can be comma-separated list of
 directories, and we search recursively down any directory that ends with
 / (i.e., /export/data is a single directory whereas /export/data/ will
 be searched recursively.) 

--- a/src/gmtwhich.c
+++ b/src/gmtwhich.c
@@ -192,7 +192,8 @@ int GMT_gmtwhich (void *V_API, int mode, void *args) {
 
 		if (Ctrl->G.active)
 			first = gmt_download_file_if_not_found (GMT, opt->arg, Ctrl->G.mode);
-
+		else if (opt->arg[0] == '@') /* Giave @ without -G is likely a user mistake; remove it */
+			first = 1;
 		if (gmt_M_file_is_remotedata (opt->arg) && !strstr (opt->arg, ".grd"))
 			sprintf (file, "%s.grd", opt->arg);	/* Append the implicit .grd for remote earth_relief grids */
 		else


### PR DESCRIPTION
This is likely a common user error and we strip off the unneeded at-character.  Closes #1278.
