### PR TITLE
Names with spaces not quote ready in modern mode

### DIFF
--- a/doc/rst/source/subplot.rst_
+++ b/doc/rst/source/subplot.rst_
@@ -104,7 +104,9 @@ Optional Arguments
     Reserve a space of dimension *clearance* between the margin and the subplot on the specified
     side, using *side* values from **w**, **e**, **s**, or **n**.  The option is repeatable to set aside space
     on more than one side.  Such space will be left untouched by the main map plotting but can
-    be accessed by modules that plot scales, bars, text, etc.  Settings specified under **begin** directive apply to all panels.
+    be accessed by modules that plot scales, bars, text, etc.  Settings specified under **begin** directive apply
+    to all panels, while settings under **set** only apply to the selected panel.  Note: Common options **-X**
+    and **-Y** are not available during subplots; use **-C** instead.
 
 .. _-J:
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15427,7 +15427,7 @@ GMT_LOCAL int process_figures (struct GMTAPI_CTRL *API, char *show) {
 				}
 			}
 			/* Here the file exists and we can call psconvert. Note we still pass *.ps- even if *.ps+ was found since psconvert will do the same check */
-			sprintf (cmd, "'%s/gmt_%d.ps-' -T%c -F'%s'", API->gwf_dir, fig[k].ID, fmt[f], fig[k].prefix);
+			sprintf (cmd, "'%s/gmt_%d.ps-' -T%c -F%s", API->gwf_dir, fig[k].ID, fmt[f], fig[k].prefix);
 			not_PS = (fmt[f] != 'p');	/* Do not add convert options if plain PS */
 			/* Append psconvert optional settings */
 			if (fig[k].options[0]) {	/* Append figure-specific settings */


### PR DESCRIPTION
Quoting filenames with spaces to -F does not work yet in gmt end so we are reverting that change for now.