### PR TITLE
Handle session and figure names with spaces

### DIFF
--- a/doc/rst/source/begin.rst_
+++ b/doc/rst/source/begin.rst_
@@ -40,6 +40,8 @@ Optional Arguments
     Name-stem used to construct the single final figure name.  The extension is appended
     automatically from your *formats* selection(s) [gmtsession].  If your script only
     performs calculations or needs to make several figures then you will not use this argument.
+    While not recommended, if your *prefix* has spaces in it then you must enclose your
+    prefix in single quotes.
 
 .. _begin-formats:
 
@@ -112,7 +114,7 @@ To set up proceedings for a jpg figure with 0.5c white margin, we would run
 
    ::
 
-    gmt begin Figure_4 pdf,png A+m1c
+    gmt begin 'My Figure4' pdf,png A+m1c
 
 .. include:: explain_postscript.rst_
 

--- a/doc/rst/source/figure.rst_
+++ b/doc/rst/source/figure.rst_
@@ -37,6 +37,8 @@ Required Arguments
 *prefix*
     Name stem used to construct the figure name.  The extension(s) are appended
     automatically from your *formats* selection(s).
+    While not recommended, if your *prefix* has spaces in it then you must enclose your
+    prefix in single quotes.
 
 Optional Arguments
 ------------------
@@ -81,6 +83,12 @@ around the image, try
    ::
 
     gmt figure GlobalMap jpg A1c
+
+If the same figure were to be called Global Map.jpg you would need quotes:
+
+   ::
+
+    gmt figure 'Global Map' jpg A1c
 
 See Also
 --------

--- a/src/begin.c
+++ b/src/begin.c
@@ -101,19 +101,12 @@ char *get_session_name_and_format (struct GMT_OPTION *opt) {
 	if (opt == NULL) return NULL;	/* Go with the default settings */
 	while (opt && n < 3) {
 		if (opt->option == GMT_OPT_INFILE) {	/* Valid "file" argument */
-			if (strchr (opt->arg, ' ')) {	/* Must be file name with spaces given in quotes */
-				if (space) len++;
-				len += strlen (opt->arg) + 2;
-				strncat (buffer, "'", GMT_LEN256-len);
-				strncat (buffer, opt->arg, GMT_LEN256-len);
-				strncat (buffer, "'", GMT_LEN256-len);
-			}
-			else {
-				if (space) len++, strncat (buffer, " ", GMT_LEN256-len);
-				len += strlen (opt->arg);
-				strncat (buffer, opt->arg, GMT_LEN256-len);
-			}
+			gmt_filename_set (opt->arg);	/* Replace any spaces with ASCII 29 */
+			if (space) len++, strncat (buffer, " ", GMT_LEN256-len);
+			len += strlen (opt->arg);
+			strncat (buffer, opt->arg, GMT_LEN256-len);
 			space = true;
+			gmt_filename_get (opt->arg);	/* Undo ASCII 29 */
 			n++;
 		}
 		opt = opt->next;

--- a/src/docs.c
+++ b/src/docs.c
@@ -106,18 +106,24 @@ int GMT_docs (void *V_API, int mode, void *args) {
 		}
 		
 		if ((ext = gmt_get_ext (opt->arg)) && gmt_get_graphics_id (GMT, ext) != GMT_NOTSET) {	/* Got a graphics file */
+			if (strchr (opt->arg, GMT_ASCII_RS)) {
+				sprintf (name, "\'%s\'", opt->arg);
+				gmt_filename_get (name);
+			}
+			else
+				strcpy (name, opt->arg);
 			if (GMT->hidden.func_level == GMT_TOP_MODULE) {	/* Can only open figs if called via gmt end show */
 				GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Argument %s is not a known module or documentation short-hand\n",
-					opt->arg);
+					name);
 				Return (GMT_RUNTIME_ERROR);
 			}
 			else if (print_url) {
-				GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Reporting local file %s to stdout\n", opt->arg);
+				GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Reporting local file %s to stdout\n", name);
 				printf ("%s\n", opt->arg);
 			}
 			else {	/* Open in viewer */
 				if (!together || !got_file) {	/* Either Windows|Linux, or first time under macOS */
-					snprintf (view, PATH_MAX, "%s %s", file_viewer, opt->arg);
+					snprintf (view, PATH_MAX, "%s %s", file_viewer, name);
 					got_file = true;
 					vlen = PATH_MAX - strlen (view);
 				}

--- a/src/figure.c
+++ b/src/figure.c
@@ -86,12 +86,14 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
 		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Required figure name not specified!\n");
 		return GMT_PARSE_ERROR;
 	}
+	gmt_filename_set (opt->arg);
 	
 	/* Gave a figure prefix so can go on to check optional items */
 	
 	opt = opt->next;	/* Skip the figure prefix since we don't need to check it here */
 	
 	while (opt) {
+		gmt_filename_set (opt->arg);
 		arg_category = GMT_NOTSET;	/* We know noothing */
 		pos = 0;
 		while (gmt_strtok (opt->arg, ",", &pos, p)) {	/* Check args to determine what kind it is */
@@ -138,7 +140,7 @@ int GMT_figure (void *V_API, int mode, void *args) {
 	int error = 0;
 	char *arg = NULL;
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;
-	struct GMT_OPTION *options = NULL;
+	struct GMT_OPTION *options = NULL, *opt = NULL;
 	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);	/* Cast from void to GMTAPI_CTRL pointer */
 
 	/*----------------------- Standard module initialization and parsing ----------------------*/
@@ -169,6 +171,12 @@ int GMT_figure (void *V_API, int mode, void *args) {
 		error = GMT_RUNTIME_ERROR;
 		
 	if (options) GMT_Destroy_Cmd (API, &arg);
+
+	opt = options;
+	while (opt) {
+		gmt_filename_get (opt->arg);
+		opt = opt->next;
+	}
 	
 	reset_history (GMT);	/* Prevent gmt figure from copying previous history to this new fig */
 	

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -76,6 +76,7 @@
 #define GMT_CONV4_LIMIT	 1.0e-4		/* Less tight convergence limit or "close to zero" limit */
 
 #define GMT_ASCII_GS	29	/* ASCII code for group separator (temporarily replacing tabs) */
+#define GMT_ASCII_RS	30	/* ASCII code for record separator (temporarily replacing spaces in filenames) */
 #define GMT_ASCII_US	31	/* ASCII code for unit separator (temporarily replacing spaces in quoted text) */
 
 #define GMT_RENAME_FILE	0

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15241,7 +15241,7 @@ int gmt_get_graphics_id (struct GMT_CTRL *GMT, const char *format) {
 GMT_LOCAL void get_session_name_format (struct GMTAPI_CTRL *API, char prefix[GMT_LEN256], char formats[GMT_LEN256]) {
 	/* Read the session name [and graphics format] from file GMT_SESSION_FILE */
 	int n;
-	char file[PATH_MAX] = {""}, *c = NULL;
+	char file[PATH_MAX] = {""};
 	FILE *fp = NULL;
 	sprintf (file, "%s/%s", API->gwf_dir, GMT_SESSION_FILE);
 	if (access (file, F_OK)) {	/* Use default session name and format */
@@ -15256,20 +15256,14 @@ GMT_LOCAL void get_session_name_format (struct GMTAPI_CTRL *API, char prefix[GMT
 	/* Recycle file as line record */
 	gmt_fgets (API->GMT, file, PATH_MAX, fp);
 	gmt_chop (file);	/* Strip off trailing return */
-	if ((c = strrchr (file, '\''))) {	/* Got file name with spaces */
-		c[0] = '\0';
-		strcpy (prefix, &file[1]);
-		n = 1;
-		if (c[1] && c[2]) strcpy (formats, &c[2]), n = 2;
-		c[0] = '\'';
-	}
-	else if ((n = sscanf (file, "%s %s\n", prefix, formats)) < 1) {
+	if ((n = sscanf (file, "%s %s\n", prefix, formats)) < 1) {
 		GMT_Report (API, GMT_MSG_NORMAL, "Failed to read from session file %s\n", file);
 		fclose (fp);
 		return;
 	}
 	if (n == 1)	/* Assign default format */
 		strcpy (formats, gmt_session_format[GMT_SESSION_FORMAT]);
+	gmt_filename_get (prefix);
 	GMT_Report (API, GMT_MSG_DEBUG, "Got session name as %s and default graphics formats as %s\n", prefix, formats);
 	fclose (fp);
 }
@@ -15427,7 +15421,9 @@ GMT_LOCAL int process_figures (struct GMTAPI_CTRL *API, char *show) {
 				}
 			}
 			/* Here the file exists and we can call psconvert. Note we still pass *.ps- even if *.ps+ was found since psconvert will do the same check */
+			gmt_filename_set (fig[k].prefix);
 			sprintf (cmd, "'%s/gmt_%d.ps-' -T%c -F%s", API->gwf_dir, fig[k].ID, fmt[f], fig[k].prefix);
+			gmt_filename_get (fig[k].prefix);
 			not_PS = (fmt[f] != 'p');	/* Do not add convert options if plain PS */
 			/* Append psconvert optional settings */
 			if (fig[k].options[0]) {	/* Append figure-specific settings */
@@ -15460,6 +15456,7 @@ GMT_LOCAL int process_figures (struct GMTAPI_CTRL *API, char *show) {
 				strcpy (ext, gmt_session_format[gcode[f]]);	/* Set extension */
 				gmt_str_tolower (ext);	/* In case it was PNG */
 				sprintf (cmd, "%s.%s", fig[k].prefix, ext);
+				gmt_filename_set (cmd);
 				if ((error = GMT_Call_Module (API, "docs", GMT_MODULE_CMD, cmd))) {
 					GMT_Report (API, GMT_MSG_NORMAL, "Failed to call docs\n");
 					gmt_M_free (API->GMT, fig);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -329,6 +329,8 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC void gmt_filename_set (char *name);
+EXTERN_MSC void gmt_filename_get (char *name);
 EXTERN_MSC bool gmt_no_pstext_input (struct GMTAPI_CTRL *API, char *arg);
 EXTERN_MSC void gmt_save_current_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P);
 EXTERN_MSC bool gmt_consider_current_cpt (struct GMTAPI_CTRL *API, bool *active, char **arg);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15941,6 +15941,16 @@ bool gmt_no_pstext_input (struct GMTAPI_CTRL *API, char *arg) {
 	return true;
 }
 
+void gmt_filename_set (char *name) {
+	/* Replace spaces with GMT_ASCII_RS */
+	gmt_strrepc (name, ' ', GMT_ASCII_RS);
+}
+
+void gmt_filename_get (char *name) {
+	/* Replace GMT_ASCII_RS with spaces */
+	gmt_strrepc (name, GMT_ASCII_RS, ' ');
+}
+
 #if 0	/* Probably not needed after all */
 char * gmt_add_options (struct GMT_CTRL *GMT, const char *list) {
 	/* Build option string that needs to be passed to GMT_Call_Module */

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -714,6 +714,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PS2RASTER_CTRL *Ctrl, struct G
 						if (gmt_session_format[kk])	/* Did match one of the extensions, remove it */
 							gmt_chop_ext (Ctrl->F.file);
 					}
+					gmt_filename_get (Ctrl->F.file);
 				}
 				else
 					n_errors++;


### PR DESCRIPTION
While discouraged, you can now use session and figure names with spaces, provided they are given in single quotes.  Because we store this names in hidden information files and they become arguments to modules and eventually end up in system calls, all of which seem to have their own rules for dealing with quotes, we replace spaces in such filenames with ASCII 30 and undo the damage just-in-time before use.
