### PR TITLE
Ensure terminals opened via the macOS GMT app has unique GMT_SESSION_NAME

### DIFF
--- a/cmake/dist/startup_macosx.sh.in
+++ b/cmake/dist/startup_macosx.sh.in
@@ -29,6 +29,8 @@ if [ "$1" = "GMT_PROMPT" ]; then
     test -f ~/.bashrc && source ~/.bashrc
     source "${BUNDLE_RESOURCES}/share/tools/gmt_completion.bash"
     unset DYLD_LIBRARY_PATH
+    # Assist modern mode scripts by setting a unique session name
+    export GMT_SESSION_NAME=$$
 EOF
   exec /bin/bash --rcfile "${_temp_bashrc}" -i
 fi


### PR DESCRIPTION
To minimize sub-shell troubles for users of the macos Application bundle, we assign GMT_SESSION_NAME to equal the terminal's process ID when we launch the GMT app. See #1299 for context.

