### PR TITLE
coupe: Improve -S option while keeping backwards-compatibility

### DIFF
--- a/doc/rst/source/supplements/seis/coupe.rst
+++ b/doc/rst/source/supplements/seis/coupe.rst
@@ -15,7 +15,7 @@ Synopsis
 
 **gmt coupe** [ *files* ] |-J|\ *parameters*
 |SYN_OPT-R| |-A|\ *parameters*
-|-S|\ *<format><scale>*\ [/*fontsize*\ [/*offset*]][**+u**\ ]
+|-S|\ *<format><scale>*\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
 [ |SYN_OPT-B| ]
 [ |-E|\ *color* ]
 [ |-F|\ *mode*\ [*args*] ]

--- a/doc/rst/source/supplements/seis/coupe_common.rst_
+++ b/doc/rst/source/supplements/seis/coupe_common.rst_
@@ -84,7 +84,7 @@ Optional Arguments
 **-F**\ *mode*\ [*args*]
     Sets one or more attributes; repeatable. The various combinations are
 
-**-Fs**\ *symbol[size[/fontsize[/offset*\ [**+u**]]]
+**-Fs**\ *symbol[size][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
    selects a symbol instead of mechanism. Choose from the following:
    (**c**) circle, (**d**) diamond, (**i**) itriangle, (**s**) square,
    (**t**) triangle, (**x**) cross. *size* is the symbol size in

--- a/doc/rst/source/supplements/seis/pscoupe.rst
+++ b/doc/rst/source/supplements/seis/pscoupe.rst
@@ -15,7 +15,7 @@ Synopsis
 
 **pscoupe** [ *files* ] |-J|\ *parameters*
 |SYN_OPT-R| |-A|\ *parameters*
-|-S|\ *<format><scale>*\ [/*fontsize*\ [/*offset*]][**+u**\ ]
+|-S|\ *<format><scale>*\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
 [ |SYN_OPT-B| ]
 [ |-E|\ *color* ]
 [ |-F|\ *mode*\ [*args*] ]

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -82,7 +82,7 @@ struct PSCOUPE_CTRL {
 	struct Q {	/* -Q */
 		bool active;
 	} Q;
-	struct S {	/* -S<format><scale>[+f<font>][+j<justification>][+o<dx>[/<dy>]] and -Fs */
+	struct S {	/* -S<format><scale>[+f<font>][+j<justify>][+o<dx>[/<dy>]] and -Fs */
 		bool active;
 		bool zerotrace;
 		bool no_label;
@@ -426,9 +426,9 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] -A<params> %s %s -S<format><scale>[+f<font>][+j<justification>][+o<dx>[/<dy>]]\n", name, GMT_J_OPT, GMT_Rgeo_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] -A<params> %s %s -S<format><scale>[+f<font>][+j<justify>][+o<dx>[/<dy>]]\n", name, GMT_J_OPT, GMT_Rgeo_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-E<fill>] [-Fa[<size>][/<Psymbol>[<Tsymbol>]] [-Fe<fill>] [-Fg<fill>] [-Fr<fill>] [-Fp[<pen>]] [-Ft[<pen>]]\n", GMT_B_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-Fs<symbol><size>+f<font>+o<dx>/<dy>+j<justfication>]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t[-Fs<symbol><size>+f<font>+o<dx>/<dy>+j<justify>]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t[-G<fill>] %s[-L<pen>] [-M] [-N] %s%s\n", API->K_OPT, API->O_OPT, API->P_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-T<nplane>[/<pen>]] [%s] [%s] [-W<pen>] \n", GMT_U_OPT, GMT_V_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [-Z<cpt>]\n", GMT_X_OPT, GMT_Y_OPT);
@@ -626,7 +626,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 						Ctrl->S.active = true;
 						Ctrl->S.symbol = opt->arg[1];
 						if ((strstr (opt->arg, "+f")) || strstr (opt->arg, "+o") || strstr (opt->arg, "+j")) { 
-							/* New syntax: -Fs<symbol><size>+f<font>+o<dx>/<dy>+j<justfication> */
+							/* New syntax: -Fs<symbol><size>+f<font>+o<dx>/<dy>+j<justify> */
 							char word[GMT_LEN256] = {""}, *c = NULL;
 
 							/* parse beachball size */
@@ -751,7 +751,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 				}
 
 				if ((strstr (opt->arg, "+f")) || strstr (opt->arg, "+o") || strstr (opt->arg, "+j")) { 
-					/* New syntax: -S<format><scale>+f<font>+o<dx>/<dy>+j<justfication> */
+					/* New syntax: -S<format><scale>+f<font>+o<dx>/<dy>+j<justify> */
 					char word[GMT_LEN256] = {""}, *c = NULL;
 
 					/* parse beachball size */

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -8,11 +8,9 @@
  *--------------------------------------------------------------------*/
 /*
 
-pscoupe will read <x,y> pairs (or <lon,lat>) from inputfile and
-plot symbols on a cross-section. Focal mechanisms may be specified
-(double couple or moment tensor) and require additional columns of data.
+pscoupe will read focal mechanisms from input file and plot beachballs on a cross-section. 
+Focal mechanisms are specified in double couple, moment tensor, or principal axis.
 PostScript code is written to stdout.
-
 
  Author:	Genevieve Patau
  Date:		9 September 1992
@@ -30,11 +28,11 @@ PostScript code is written to stdout.
 #define THIS_MODULE_PURPOSE	"Plot cross-sections of focal mechanisms"
 #define THIS_MODULE_KEYS	"<D{,>X}"
 #define THIS_MODULE_NEEDS	"Jd"
-#define THIS_MODULE_OPTIONS "-:>BHJKOPRUVXYdehipt" GMT_OPT("c")
+#define THIS_MODULE_OPTIONS "-:>BJKOPRUVXYdehipt" GMT_OPT("Hc")
 
-#define DEFAULT_FONTSIZE	9.0	/* In points */
-#define DEFAULT_OFFSET		3.0	/* In points */
-#define DEFAULT_SIZE		6.0 /* In points */
+#define DEFAULT_FONTSIZE		9.0	/* In points */
+#define DEFAULT_OFFSET			3.0	/* In points */
+#define DEFAULT_SYMBOL_SIZE		6.0	/* In points */
 
 #define READ_CMT	0
 #define READ_AKI	1
@@ -84,19 +82,20 @@ struct PSCOUPE_CTRL {
 	struct Q {	/* -Q */
 		bool active;
 	} Q;
-	struct S {	/* -S and -Fs */
+	struct S {	/* -S<format><scale>[+f<font>][+j<justification>][+o<dx>[/<dy>]] and -Fs */
 		bool active;
 		bool zerotrace;
 		bool no_label;
 		unsigned int readmode;
 		unsigned int plotmode;
-		unsigned int justify;
 		unsigned int n_cols;
+		int justify;
 		int symbol;
 		char P_symbol, T_symbol;
 		double scale;
-		double fontsize, offset;
+		double offset[2];
 		struct GMT_FILL fill;
+		struct GMT_FONT font;
 	} S;
 	struct T {	/* -Tnplane[/<pen>] */
 		bool active;
@@ -111,28 +110,28 @@ struct PSCOUPE_CTRL {
 		bool active;
 		char *file;
 	} Z;
-	struct A2 {	/* -a[size][/Psymbol[Tsymbol]] */
+	struct A2 {	/* -Fa[size][/Psymbol[Tsymbol]] */
 		bool active;
 		char P_symbol, T_symbol;
 		double size;
 	} A2;
-	struct E2 {	/* -e<fill> */
+	struct E2 {	/* -Fe<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} E2;
- 	struct G2 {	/* -g<fill> */
+ 	struct G2 {	/* -Fg<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} G2;
- 	struct P2 {	/* -p[<pen>] */
+ 	struct P2 {	/* -Fp[<pen>] */
 		bool active;
 		struct GMT_PEN pen;
 	} P2;
-	struct R2 {	/* -r[<fill>] */
+	struct R2 {	/* -Fr[<fill>] */
 		bool active;
 		struct GMT_FILL fill;
 	} R2;
- 	struct T2 {	/* -t[<pen>] */
+ 	struct T2 {	/* -Ft[<pen>] */
 		bool active;
 		struct GMT_PEN pen;
 	} T2;
@@ -151,10 +150,10 @@ GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a n
 	C->L.active = true;
 	gmt_init_fill (GMT, &C->E.fill, 1.0, 1.0, 1.0);
 	gmt_init_fill (GMT, &C->G.fill, 0.0, 0.0, 0.0);
-	C->S.fontsize = DEFAULT_FONTSIZE;
-	C->S.offset = DEFAULT_OFFSET * GMT->session.u2u[GMT_PT][GMT_INCH];
-	C->S.justify = PSL_BC;
-	C->A2.size = DEFAULT_SIZE * GMT->session.u2u[GMT_PT][GMT_INCH];
+	C->S.font = GMT->current.setting.font_annot[GMT_PRIMARY];
+	C->S.font.size = DEFAULT_FONTSIZE;
+	C->S.justify = PSL_TC;
+	C->A2.size = DEFAULT_SYMBOL_SIZE * GMT->session.u2u[GMT_PT][GMT_INCH];
 	C->A2.P_symbol = C->A2.T_symbol = PSL_CIRCLE;
 	return (C);
 }
@@ -427,9 +426,9 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] -A<params> %s %s -S<format><scale>[/<fontsize>[/<offset>]][+u]\n", name, GMT_J_OPT, GMT_Rgeo_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] -A<params> %s %s -S<format><scale>[+f<font>][+j<justification>][+o<dx>[/<dy>]]\n", name, GMT_J_OPT, GMT_Rgeo_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-E<fill>] [-Fa[<size>][/<Psymbol>[<Tsymbol>]] [-Fe<fill>] [-Fg<fill>] [-Fr<fill>] [-Fp[<pen>]] [-Ft[<pen>]]\n", GMT_B_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-Fs<symbol><scale>[/<fontsize>[/<justify>/<offset>/<angle>/<form>]]]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t[-Fs<symbol><size>+f<font>+o<dx>/<dy>+j<justfication>]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t[-G<fill>] %s[-L<pen>] [-M] [-N] %s%s\n", API->K_OPT, API->O_OPT, API->P_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-T<nplane>[/<pen>]] [%s] [%s] [-W<pen>] \n", GMT_U_OPT, GMT_V_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [-Z<cpt>]\n", GMT_X_OPT, GMT_Y_OPT);
@@ -443,27 +442,6 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   -Ac<x1/y1/x2/y2/dip/p_width/dmin/dmax>[+f]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   -Ad<x1/y1/strike/p_length/dip/p_width/dmin/max>[+f]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Add +f to get the frame from the cross-section parameters.\n");
-	GMT_Option (API, "J-,R");
-	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
-	GMT_Option (API, "<,B-");
-	gmt_fill_syntax (API->GMT, 'E', "Set color used for extensive parts [Default is white]");
-	GMT_Message (API, GMT_TIME_NONE, "\t-F Sets various attributes of symbols depending on <mode>:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   a Plot axis. Default symbols are circles.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   e Set color used for T_symbol [default as set by -E].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   g Set color used for P_symbol [default as set by -G].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   p Draw P_symbol outline using the current pen (see -W) or sets pen attribute for outline.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   r Draw box behind labels.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   s Select symbol type and symbol size (in %s). Choose between:\n",
-		API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit]);
-	GMT_Message (API, GMT_TIME_NONE, "\t     st(a)r, (c)ircle, (d)iamond, (h)exagon, (i)nvtriangle, (s)quare, (t)riangle.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   t Draw T_symbol outline using the current pen (see -W) or sets pen attribute for outline.\n");
-	gmt_fill_syntax (API->GMT, 'G', "Set color used for compressive parts [Default is black]");
-	GMT_Option (API, "K");
-	GMT_Message (API, GMT_TIME_NONE, "\t-L Draw line or symbol outline using the current pen (see -W) or sets pen attribute for outline.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-M Set same size for any magnitude. Size is given with -S.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-N Do Not skip/clip symbols that fall outside map border [Default will ignore those outside].\n");
-	GMT_Option (API, "O,P");
-	GMT_Message (API, GMT_TIME_NONE, "\t-Q Do not print cross-section information to files\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-S Select format type and symbol size (in measure_unit).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append the format code for your input file:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   a  Focal mechanism in Aki & Richard's convention:\n");
@@ -489,9 +467,30 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t        P_value P_azim P_plunge exp newX newY [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   z  Anisotropic part of seismic moment tensor (Global CMT, with zero trace):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp [event_title]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally add /fontsize[/offset][+u] [Default values are /%g/%f].\n", DEFAULT_FONTSIZE, DEFAULT_OFFSET);
+	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally add +f<font>+j<justify>+o<dx>[/<dy>] to change the label font, location and offset.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   fontsize < 0 : no label written; offset is from the limit of the beach ball.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   By default label is above the beach ball. Append +u to plot it under.\n");
+	GMT_Option (API, "J-,R");
+	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
+	GMT_Option (API, "<,B-");
+	gmt_fill_syntax (API->GMT, 'E', "Set color used for extensive parts [Default is white]");
+	GMT_Message (API, GMT_TIME_NONE, "\t-F Sets various attributes of symbols depending on <mode>:\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   a Plot axis. Default symbols are circles.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   e Set color used for T_symbol [default as set by -E].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   g Set color used for P_symbol [default as set by -G].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   p Draw P_symbol outline using the current pen (see -W) or sets pen attribute for outline.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   r Draw box behind labels.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   s Select symbol type and symbol size (in %s). Choose between:\n",
+		API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit]);
+	GMT_Message (API, GMT_TIME_NONE, "\t     st(a)r, (c)ircle, (d)iamond, (h)exagon, (i)nvtriangle, (s)quare, (t)riangle.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   t Draw T_symbol outline using the current pen (see -W) or sets pen attribute for outline.\n");
+	gmt_fill_syntax (API->GMT, 'G', "Set color used for compressive parts [Default is black]");
+	GMT_Option (API, "K");
+	GMT_Message (API, GMT_TIME_NONE, "\t-L Draw line or symbol outline using the current pen (see -W) or sets pen attribute for outline.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-M Set same size for any magnitude. Size is given with -S.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-N Do Not skip/clip symbols that fall outside map border [Default will ignore those outside].\n");
+	GMT_Option (API, "O,P");
+	GMT_Message (API, GMT_TIME_NONE, "\t-Q Do not print cross-section information to files\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Tn[/<pen>] draw nodal planes and circumference only to provide a transparent beach ball\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   using the current pen (see -W) or sets pen attribute.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   n = 1 the only first nodal plane is plotted.\n");
@@ -570,7 +569,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 			case 'E':	/* Set color for extensive parts  */
 				Ctrl->E.active = true;
 				if (!opt->arg[0] || (opt->arg[0] && gmt_getfill (GMT, opt->arg, &Ctrl->E.fill))) {
-					gmt_fill_syntax (GMT, 'G', " ");
+					gmt_fill_syntax (GMT, 'E', " ");
 					n_errors++;
 				}
 				Ctrl->A.polygon = true;
@@ -626,22 +625,50 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 					case 's':	/* Only points : get symbol [and size] */
 						Ctrl->S.active = true;
 						Ctrl->S.symbol = opt->arg[1];
-						if ((p = strstr (opt->arg, "+u"))) {	/* Plot label under symbol [over] */
-							Ctrl->S.justify = PSL_TC;
-							p[0] = '\0';	/* Chop off modifier */
+						if ((strstr (opt->arg, "+f")) || strstr (opt->arg, "+o") || strstr (opt->arg, "+j")) { 
+							/* New syntax: -Fs<symbol><size>+f<font>+o<dx>/<dy>+j<justfication> */
+							char word[GMT_LEN256] = {""}, *c = NULL;
+
+							/* parse beachball size */
+							if ((c = strchr (opt->arg, '+'))) c[0] = '\0';	/* Chop off modifiers for now */
+							Ctrl->S.scale = gmt_M_to_inch (GMT, &opt->arg[2]);
+							if (c) c[0] = '+';	/* Restore modifiers */
+
+							if (gmt_get_modifier (opt->arg, 'j', word) && strchr ("LCRBMT", word[0]) && strchr ("LCRBMT", word[1]))
+								Ctrl->S.justify = gmt_just_decode (GMT, word, Ctrl->S.justify);
+							if (gmt_get_modifier (opt->arg, 'f', word)) 
+								n_errors += gmt_getfont (GMT, word, &(Ctrl->S.font));
+							if (gmt_get_modifier (opt->arg, 'o', word)) {
+								if (gmt_get_pair (GMT, word, GMT_PAIR_DIM_DUP, Ctrl->S.offset) < 0) n_errors++;
+							} else {	/* Set default offset */
+								if (Ctrl->S.justify%4 != 2) /* Not center aligned */
+									Ctrl->S.offset[0] = DEFAULT_OFFSET * GMT->session.u2u[GMT_PT][GMT_INCH];
+								if (Ctrl->S.justify/4 != 1) /* Not middle aligned */
+									Ctrl->S.offset[1] = DEFAULT_OFFSET * GMT->session.u2u[GMT_PT][GMT_INCH];
+							}
+							if (Ctrl->S.font.size <= 0.0) Ctrl->S.no_label = true;
+						} else {	/* Old syntax: -Fs<symbol>[<size>[/fontsize[/offset[+u]]]] */	
+							Ctrl->S.offset[1] = DEFAULT_OFFSET * GMT->session.u2u[GMT_PT][GMT_INCH];	/* Set default offset */
+							if ((p = strstr (opt->arg, "+u"))) {	/* Plot label under symbol [over] */
+								Ctrl->S.justify = PSL_BC;
+								p[0] = '\0';	/* Chop off modifier */
+							}
+							else if (opt->arg[strlen(opt->arg)-1] == 'u') {
+								Ctrl->S.justify = PSL_BC; 
+								opt->arg[strlen(opt->arg)-1] = '\0';
+							}
+							txt[0] = txt_b[0] = txt_c[0] = '\0';
+							sscanf (&opt->arg[2], "%[^/]/%[^/]/%s", txt, txt_b, txt_c);
+							if (txt[0]) Ctrl->S.scale = gmt_M_to_inch (GMT, txt);
+							if (txt_b[0]) Ctrl->S.font.size = gmt_convert_units (GMT, txt_b, GMT_PT, GMT_PT);
+							if (txt_c[0]) Ctrl->S.offset[1] = gmt_convert_units (GMT, txt_c, GMT_PT, GMT_INCH);
+							if (Ctrl->S.font.size < 0.0) Ctrl->S.no_label = true;
+							if (p) p[0] = '+';	/* Restore modifier */
 						}
-						else if (opt->arg[strlen(opt->arg)-1] == 'u') Ctrl->S.justify = PSL_TC, opt->arg[strlen(opt->arg)-1] = '\0';
-						txt[0] = txt_b[0] = txt_c[0] = '\0';
-						sscanf (&opt->arg[2], "%[^/]/%[^/]/%s", txt, txt_b, txt_c);
-						if (txt[0]) Ctrl->S.scale = gmt_M_to_inch (GMT, txt);
-						if (txt_b[0]) Ctrl->S.fontsize = gmt_convert_units (GMT, txt_b, GMT_PT, GMT_PT);
-						if (txt_c[0]) Ctrl->S.offset = gmt_convert_units (GMT, txt_c, GMT_PT, GMT_INCH);
-						if (Ctrl->S.fontsize < 0.0) Ctrl->S.no_label = true;
 						if (gmt_M_is_zero (Ctrl->S.scale))
-								Ctrl->S.n_cols = 4;
-							else
-								Ctrl->S.n_cols = 3;
-						if (p) p[0] = '+';	/* Restore modifier */
+							Ctrl->S.n_cols = 4;
+						else
+							Ctrl->S.n_cols = 3;
 						break;
 					case 't':	/* Draw outline of T axis symbol [set outline attributes] */
 						Ctrl->T2.active = true;
@@ -678,19 +705,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 				break;
 			case 'S':	/* Mechanisms : get format [and size] */
 				Ctrl->S.active = true;
-				if ((p = strstr (opt->arg, "+u"))) {	/* Plot label under symbol [over] */
-					Ctrl->S.justify = PSL_TC;
-					p[0] = '\0';	/* Chop off modifier */
-				}
-				else if (opt->arg[strlen(opt->arg)-1] == 'u') Ctrl->S.justify = PSL_TC, opt->arg[strlen(opt->arg)-1] = '\0';
-				txt[0] = txt_b[0] = txt_c[0] = '\0';
-				sscanf (&opt->arg[1], "%[^/]/%[^/]/%s", txt, txt_b, txt_c);
-				if (txt[0]) Ctrl->S.scale = gmt_M_to_inch (GMT, txt);
-				if (txt_b[0]) Ctrl->S.fontsize = gmt_convert_units (GMT, txt_b, GMT_PT, GMT_PT);
-				if (txt_c[0]) Ctrl->S.offset = gmt_convert_units (GMT, txt_c, GMT_PT, GMT_INCH);
-				if (Ctrl->S.fontsize < 0.0) Ctrl->S.no_label = true;
-
-				switch (opt->arg[0]) {
+				switch (opt->arg[0]) {	/* parse format */
 					case 'c':
 						Ctrl->S.readmode = READ_CMT;	Ctrl->S.n_cols = 13;
 						Ctrl->S.plotmode = PLOT_DC;
@@ -734,7 +749,47 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 						n_errors++;
 						break;
 				}
-				if (p) p[0] = '+';	/* Restore modifier */
+
+				if ((strstr (opt->arg, "+f")) || strstr (opt->arg, "+o") || strstr (opt->arg, "+j")) { 
+					/* New syntax: -S<format><scale>+f<font>+o<dx>/<dy>+j<justfication> */
+					char word[GMT_LEN256] = {""}, *c = NULL;
+
+					/* parse beachball size */
+					if ((c = strchr (opt->arg, '+'))) c[0] = '\0';	/* Chop off modifiers for now */
+					Ctrl->S.scale = gmt_M_to_inch (GMT, &opt->arg[1]);
+					if (c) c[0] = '+';	/* Restore modifiers */
+
+					if (gmt_get_modifier (opt->arg, 'j', word) && strchr ("LCRBMT", word[0]) && strchr ("LCRBMT", word[1]))
+						Ctrl->S.justify = gmt_just_decode (GMT, word, Ctrl->S.justify);
+					if (gmt_get_modifier (opt->arg, 'f', word)) 
+						n_errors += gmt_getfont (GMT, word, &(Ctrl->S.font));
+					if (gmt_get_modifier (opt->arg, 'o', word)) {
+						if (gmt_get_pair (GMT, word, GMT_PAIR_DIM_DUP, Ctrl->S.offset) < 0) n_errors++;
+					} else {	/* Set default offset */
+						if (Ctrl->S.justify%4 != 2) /* Not center aligned */
+							Ctrl->S.offset[0] = DEFAULT_OFFSET * GMT->session.u2u[GMT_PT][GMT_INCH];
+						if (Ctrl->S.justify/4 != 1) /* Not middle aligned */
+							Ctrl->S.offset[1] = DEFAULT_OFFSET * GMT->session.u2u[GMT_PT][GMT_INCH];
+					}
+					if (Ctrl->S.font.size <= 0.0) Ctrl->S.no_label = true;
+				} else {	/* Old syntax: -S<format><scale>[/fontsize[/offset]][+u] */
+					Ctrl->S.offset[1] = DEFAULT_OFFSET * GMT->session.u2u[GMT_PT][GMT_INCH];	/* Set default offset */
+					if ((p = strstr (opt->arg, "+u"))) {	/* Plot label under symbol [over] */
+						Ctrl->S.justify = PSL_BC;
+						p[0] = '\0';	/* Chop off modifier */
+					}
+					else if (opt->arg[strlen(opt->arg)-1] == 'u') {
+						Ctrl->S.justify = PSL_BC;
+						opt->arg[strlen(opt->arg)-1] = '\0';
+					}
+					txt[0] = txt_b[0] = txt_c[0] = '\0';
+					sscanf (&opt->arg[1], "%[^/]/%[^/]/%s", txt, txt_b, txt_c);
+					if (txt[0]) Ctrl->S.scale = gmt_M_to_inch (GMT, txt);
+					if (txt_b[0]) Ctrl->S.font.size = gmt_convert_units (GMT, txt_b, GMT_PT, GMT_PT);
+					if (txt_c[0]) Ctrl->S.offset[1] = gmt_convert_units (GMT, txt_c, GMT_PT, GMT_INCH);
+					if (Ctrl->S.font.size < 0.0) Ctrl->S.no_label = true;
+					if (p) p[0] = '+';	/* Restore modifier */
+				}
 				break;
 
 			case 'T':
@@ -771,7 +826,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 	//n_errors += gmt_M_check_condition (GMT, Ctrl->F.active && Ctrl->S.active, "Syntax error: Cannot specify both -F and -S\n");
 	n_errors += gmt_M_check_condition (GMT, !GMT->common.R.active[RSET], "Syntax error: Must specify -R option\n");
 	n_errors += gmt_M_check_condition (GMT, !Ctrl->S.active, "Syntax error: Must specify -S option\n");
-	n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && Ctrl->S.scale <= 0.0, "Syntax error: -S must specify scale\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && Ctrl->S.scale < 0.0, "Syntax error: -S must specify scale\n");
 
 	/* Set to default pen where needed */
 
@@ -1114,12 +1169,29 @@ Definition of scalar moment.
 		}
 
 		if (!Ctrl->S.no_label) {
+			int label_justify = 0;
+			double label_x = plot_x; 
+			double label_y = plot_y;
+			
+			label_justify = gmt_flip_justify(GMT, Ctrl->S.justify);
+			label_x += 0.5 * (Ctrl->S.justify%4 - label_justify%4) * size * 0.5;
+			label_y += 0.5 * (Ctrl->S.justify/4 - label_justify/4) * size * 0.5;
+
+			/* Also deal with any justified offsets if given */
+			if (Ctrl->S.justify%4 == 1) /* Left aligned */
+				label_x -= Ctrl->S.offset[0];
+			else /* Right or center aligned */
+				label_x += Ctrl->S.offset[0];
+			if (Ctrl->S.justify/4 == 0) /* Bottom aligned */
+				label_y -= Ctrl->S.offset[1];
+			else /* Top or middle aligned */
+				label_y += Ctrl->S.offset[1];
+
 			gmt_setpen (GMT, &Ctrl->W.pen);
-			i = (Ctrl->S.justify == PSL_BC ? 1 : -1);
 			PSL_setfill (PSL, Ctrl->R2.fill.rgb, false);
-			if (Ctrl->R2.active) PSL_plotbox (PSL, plot_x - size * 0.5, plot_y + i * (size * 0.5 + Ctrl->S.offset + Ctrl->S.fontsize / PSL_POINTS_PER_INCH), plot_x + size * 0.5, plot_y + i * (size * 0.5 + Ctrl->S.offset));
-			PSL_plottext (PSL, plot_x, plot_y + i * (size * 0.5 + Ctrl->S.offset), Ctrl->S.fontsize, event_title, angle,
-				Ctrl->S.justify, form);
+			// if (Ctrl->R2.active) PSL_plotbox (PSL, label_x, label_y, label_x + Ctrl->S.font.size / PSL_POINTS_PER_INCH, label_y + Ctrl->S.font.size / PSL_POINTS_PER_INCH);
+			form = gmt_setfont(GMT, &Ctrl->S.font);
+			PSL_plottext (PSL, label_x, label_y, Ctrl->S.font.size, event_title, angle, label_justify, form);
 		}
 	} while (true);
 

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -75,7 +75,7 @@ struct PSMECA_CTRL {
 	struct N {	/* -N */
 		bool active;
 	} N;
-	struct S {	/* -S<format><scale>[+f<font>][+j<justification>][+o<dx>[/<dy>]] */
+	struct S {	/* -S<format><scale>[+f<font>][+j<justify>][+o<dx>[/<dy>]] */
 		bool active;
 		bool no_label;
 		unsigned int readmode;
@@ -169,7 +169,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] %s %s\n", name, GMT_J_OPT, GMT_Rgeo_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t-S<format><scale>[+f<font>][+j<justification>][+o<dx>[/<dy>]] [%s]\n", GMT_B_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t-S<format><scale>[+f<font>][+j<justify>][+o<dx>[/<dy>]] [%s]\n", GMT_B_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-C[<pen>][+s<pointsize>]] [-D<depmin>/<depmax>] [-E<fill>] [-G<fill>] %s[-L<pen>] [-M]\n", API->K_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-Fa[<size>[/<Psymbol>[<Tsymbol>]]] [-Fe<fill>] [-Fg<fill>] [-Fo] [-Fr<fill>] [-Fp[<pen>]] [-Ft[<pen>]] [-Fz[<pen>]]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t[-N] %s%s[-T<nplane>[/<pen>]] [%s] [%s] [-W<pen>]\n", API->O_OPT, API->P_OPT, GMT_U_OPT, GMT_V_OPT);
@@ -418,7 +418,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_
 				}
 
 				if ((strstr (opt->arg, "+f")) || strstr (opt->arg, "+o") || strstr (opt->arg, "+j")) { 
-					/* New syntax: -S<format><scale>+f<font>+o<dx>/<dy>+j<justfication> */
+					/* New syntax: -S<format><scale>+f<font>+o<dx>/<dy>+j<justify> */
 					char word[GMT_LEN256] = {""}, *c = NULL;
 
 					/* parse beachball size */


### PR DESCRIPTION
This PR update the -S option of coupe, similar to #1298.

Address #1207.