### PR TITLE
Exclude gmt.history when install examples

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -61,4 +61,5 @@ install (DIRECTORY examples
 	USE_SOURCE_PERMISSIONS
 	PATTERN "${_exclude_bat}" EXCLUDE
 	PATTERN "CMakeLists.txt" EXCLUDE
+	PATTERN "gmt.history" EXCLUDE
 	REGEX "[.](cmake|in|ps)$" EXCLUDE)


### PR DESCRIPTION
Sometimes, we may run examples in the example directory and forget to cleanup the generated `gmt.history` files, because these files are invisible to git (ignored in .gitignore).

When installing GMT or making tarballs, these `gmt.history` files are also copied to the installation directory or included in the tarballs.

This PR excludes gmt.history files when installing examples.