### PR TITLE
meca & coupe: Fix -Fa option

### DIFF
--- a/doc/rst/source/supplements/seis/coupe.rst
+++ b/doc/rst/source/supplements/seis/coupe.rst
@@ -23,7 +23,7 @@ Synopsis
 [ |-L|\ *[pen]* ]
 [ |-M| ] [ |-N| ]
 [ |-Q| ]
-[ |-T|\ *n* ]
+[ |-T|\ *nplane*\ [/*pen*\ ] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]

--- a/doc/rst/source/supplements/seis/coupe_common.rst_
+++ b/doc/rst/source/supplements/seis/coupe_common.rst_
@@ -151,13 +151,18 @@ Optional Arguments
 
 .. _-T:
 
-**-T**\ [*num_of_planes*]
+**-T**\ [*nplane*\ ][\ **/**\ *pen*]
     Plots the nodal planes and outlines the bubble which is transparent.
-    If *num_of_planes* is
+    If *nplane* is
+
     *0*: both nodal planes are plotted;
+
     *1*: only the first nodal plane is plotted;
-    *2*: only the second nodal plane is plotted
-    [Default: 0].
+
+    *2*: only the second nodal plane is plotted.
+
+    Append **/**\ *pen* to set the pen attributes for this feature.
+    Default pen is as set by **-W**. [Default: 0].
 
 .. _-U:
 

--- a/doc/rst/source/supplements/seis/coupe_common.rst_
+++ b/doc/rst/source/supplements/seis/coupe_common.rst_
@@ -101,23 +101,23 @@ Optional Arguments
     **4**:
       Text string to appear above the beach ball (default) or under (add **+u**).
 
-**-Fa**\ [*size*][/\ *P\_symbol*\ [/\ *T\_symbol*]]
+**-Fa**\ [*size*\ [/*Psymbol*\ [*Tsymbol*\ ]]]
     Computes and plots P and T axes with symbols. Optionally specify
     *size* and (separate) P and T axis symbols from the following:
     (**c**) circle, (**d**) diamond, (**h**) hexagon, (**i**) inverse
     triangle, (**p**) point, (**s**) square, (**t**) triangle, (**x**)
     cross. [Default: 6\ **p**/**cc**]
 
-**-Fe**\ *color*
+**-Fe**\ *fill*
     Sets the color or fill pattern for the T axis symbol. [Default as set by |-E|]
 
-**-Fg**\ *color*
+**-Fg**\ *fill*
     Sets the color or fill pattern for the P axis symbol. [Default as set by |-G|]
 
 **-Fp**\ [*pen*]
     Draws the P axis outline using current pen (see |-W|), or sets pen attributes.
 
-**-Fr**\ [*color*]
+**-Fr**\ [*fill*]
     Draw a box behind the label (if any). [Default fill is white]
 
 **-Ft**\ [*pen*]
@@ -125,7 +125,7 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *color*
+**-G**\ *fill*
     Sets color or fill pattern for compressional quadrants [Default is black].
 
 .. _-L:

--- a/doc/rst/source/supplements/seis/meca.rst
+++ b/doc/rst/source/supplements/seis/meca.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-F|\ *mode*\ [*args*] ] [ |-G|\ *fill*] [ |-L|\ [*pen*\ ] ]
 [ |-M| ]
 [ |-N| ]
-[ |-T|\ *num\_of\_plane*\ [/*pen*\ ] ]
+[ |-T|\ *nplane*\ [/*pen*\ ] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]

--- a/doc/rst/source/supplements/seis/meca_common.rst_
+++ b/doc/rst/source/supplements/seis/meca_common.rst_
@@ -59,7 +59,7 @@ Optional Arguments
 
 **-F**\ *mode*\ [*args*]
     Sets one or more attributes; repeatable. The various combinations are
-**-Fa**\ [*size*\ ][/\ *P\_axis\_symbol*\ [*T\_axis\_symbol*\ ]]
+**-Fa**\ [*size*\ [/*Psymbol*\ [*Tsymbol*\ ]]]
     Computes and plots P and T axes with symbols. Optionally specify
     *size* and (separate) P and T axis symbols from the following:
     (**c**) circle, (**d**) diamond, (**h**) hexagon, (**i**) inverse

--- a/doc/rst/source/supplements/seis/meca_common.rst_
+++ b/doc/rst/source/supplements/seis/meca_common.rst_
@@ -110,9 +110,9 @@ Optional Arguments
 
 .. _-T:
 
-**-T**\ [*num\_of\_planes*\ ][\ **/**\ *pen*]
+**-T**\ [*nplane*\ ][\ **/**\ *pen*]
     Plots the nodal planes and outlines the bubble which is transparent.
-    If *num\_of\_planes* is
+    If *nplane* is
 
     *0*: both nodal planes are plotted;
 
@@ -121,7 +121,7 @@ Optional Arguments
     *2*: only the second nodal plane is plotted.
 
     Append **/**\ *pen* to set the pen attributes for this feature.
-    Default pen is as set by **-W**.
+    Default pen is as set by **-W**. [Default: 0].
 
 .. _-U:
 

--- a/doc/rst/source/supplements/seis/pscoupe.rst
+++ b/doc/rst/source/supplements/seis/pscoupe.rst
@@ -25,7 +25,7 @@ Synopsis
 [ |-M| ] [ |-N| ]
 [ |-O| ]
 [ |-Q| ]
-[ |-T|\ *n* ]
+[ |-T|\ *nplane*\ [/*pen*\ ] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]

--- a/doc/rst/source/supplements/seis/psmeca.rst
+++ b/doc/rst/source/supplements/seis/psmeca.rst
@@ -21,7 +21,7 @@ psmeca [ *table* ] |-J|\ *parameters* |SYN_OPT-R|
 [ |-F|\ *mode*\ [*args*] ] [ |-G|\ *fill*] [ |-K| ] [ |-L|\ [*pen*\ ] ]
 [ |-M| ]
 [ |-N| ] [ |-O| ] [ |-P| ]
-[ |-T|\ *num\_of\_plane*\ [*pen*\ ] ]
+[ |-T|\ *nplane*\ [*pen*\ ] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -110,7 +110,7 @@ struct PSCOUPE_CTRL {
 		bool active;
 		char *file;
 	} Z;
-	struct A2 {	/* -Fa[size][/Psymbol[Tsymbol]] */
+	struct A2 {	/* -Fa[size[/Psymbol[Tsymbol]]] */
 		bool active;
 		char P_symbol, T_symbol;
 		double size;
@@ -579,7 +579,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 				switch (opt->arg[0]) {
 					case 'a':	/* plot axis */
 						Ctrl->A2.active = true;
-						strncpy (txt, &opt->arg[2], GMT_LEN256-1);
+						strncpy (txt, &opt->arg[1], GMT_LEN256-1);
 						if ((p = strchr (txt, '/')) != NULL) p[0] = '\0';
 						if (txt[0]) Ctrl->A2.size = gmt_M_to_inch (GMT, txt);
 						if (p) {

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -99,7 +99,7 @@ struct PSMECA_CTRL {
 		bool active;
 		char *file;
 	} Z;
-	struct A2 {	/* -Fa[size][/Psymbol[/Tsymbol]] */
+	struct A2 {	/* -Fa[size[/Psymbol[Tsymbol]]] */
 		bool active;
 		char P_symbol, T_symbol;
 		double size;
@@ -296,7 +296,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_
 				switch (opt->arg[0]) {
 					case 'a':	/* plot axis */
 						Ctrl->A2.active = true;
-						strncpy (txt, &opt->arg[2], GMT_LEN256-1);
+						strncpy (txt, &opt->arg[1], GMT_LEN256-1);
 						if ((p = strchr (txt, '/')) != NULL) p[0] = '\0';
 						if (txt[0]) Ctrl->A2.size = gmt_M_to_inch (GMT, txt);
 						if (p) {	/* Also specified symbols */


### PR DESCRIPTION
-Fa option doesn't work due to a typo.

https://github.com/GenericMappingTools/gmt/blob/e8253389d7689c3f210bb087200c4553339485e4/src/seis/psmeca.c#L299

should be ` strncpy (txt, &opt->arg[1], GMT_LEN256-1); `.

This PR fixes the bug and also improve the manpages.