### PR TITLE
Keep documentation inside the macOS bundle

### DIFF
--- a/cmake/dist/CMakeLists.txt
+++ b/cmake/dist/CMakeLists.txt
@@ -213,15 +213,6 @@ if (APPLE)
 		fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/${GMT_BINDIR}/gmt${CMAKE_EXECUTABLE_SUFFIX}\" \"\${CMAKE_INSTALL_PREFIX}/${GMT_LIBDIR}/gmt${CMAKE_EXECUTABLE_SUFFIX}/plugins/supplements.so\" \"\")
 	endif ()
 	" COMPONENT Runtime)
-
-	# Workaround: move documentation:
-	install (CODE "
-	if (CMAKE_INSTALL_PREFIX MATCHES \"_CPack_Packages.+[.]app/Contents/Resources\")
-		execute_process (COMMAND ${CMAKE_COMMAND} -E rename
-			\${CMAKE_INSTALL_PREFIX}/${GMT_DOCDIR}
-			\${CMAKE_INSTALL_PREFIX}/../../../Documentation)
-	endif ()
-	" COMPONENT Documentation)
 endif (APPLE)
 
 # Linux, Cygwin & Co:


### PR DESCRIPTION
The whole doc directory was moved outside of the macOS bundle due to some unknown reasons. 
This PR changes the install script and keeps the doc directory in its original location (i.e. `share/doc`). 

After applying the change, the bundle still works, and running `gmt docs coast` can open the local HTML documentation. 

The only downside I can see is that users have to right click the bundle and then click "Show Package Contents" to view the examples, or RGB tables in the bundle.