### PR TITLE
Lay groundwork for having multiple hidden, current CPTs in modern mode

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12321,6 +12321,8 @@ GMT_LOCAL int gmtinit_get_inset_dimensions (struct GMTAPI_CTRL *API, int fig, st
 
 	if (access (file, F_OK)) return (GMT_NOERROR);	/* No inset active */
 
+	if (inset == NULL) return 1;	/* Just wanted to know if there is an inset active */
+	
 	/* Extract dimensions from the inset information file */
 	if ((fp = fopen (file, "r")) == NULL) {	/* Not good */
 		GMT_Report (API, GMT_MSG_NORMAL, "Cannot read file %s\n", file);
@@ -15522,6 +15524,22 @@ int gmt_get_current_figure (struct GMTAPI_CTRL *API) {
 	}
 	fclose (fp);
 	return (fig_no);
+}
+
+void gmtlib_get_cpt_level (struct GMTAPI_CTRL *API, int *fig, int *subplot, char *panel, int *inset) {
+	/* Determine figure number, subplot panel, inset */
+	*fig = gmt_get_current_figure (API);	/* Return figure number 1-? or 0 if a session plot */
+	*subplot = gmtinit_subplot_status (API, *fig);	/* Get information about subplot, if active */
+	panel[0] = '\0';
+	if ((*subplot) & GMTINIT_SUBPLOT_ACTIVE) {	/* subplot active */
+		if (((*subplot) & GMTINIT_PANEL_NOTSET) == 0) {
+			unsigned int row, col;
+			if (get_current_panel (API, *fig, &row, &col, NULL, NULL, NULL) == 0)	/* panel set */
+				sprintf (panel, "%u-%u", row, col);
+		}
+	}
+	*inset = gmtinit_get_inset_dimensions (API, *fig, NULL);	/* True if inset is active */
+	GMT_Report (API, GMT_MSG_DEBUG, "gmtlib_get_cpt_level: Fig: %d Subplot: %d Panel: (%s) Inset: %d\n", *fig, *subplot, panel, *inset);
 }
 
 GMT_LOCAL bool is_integer (char *L) {

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -50,6 +50,7 @@ struct GMT_XINGS {
 
 EXTERN_MSC char *opt (struct GMTAPI_CTRL *API,char code);
 
+EXTERN_MSC void gmtlib_get_cpt_level (struct GMTAPI_CTRL *API, int *fig, int *subplot, char *panel, int *inset);
 EXTERN_MSC unsigned int gmtlib_char_count (char *txt, char c);
 EXTERN_MSC void gmt_check_modern_oneliner (struct GMTAPI_CTRL *API, const char *module, struct GMT_OPTION *head);
 EXTERN_MSC void gmtlib_set_KOP_strings (struct GMTAPI_CTRL *API);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7659,8 +7659,11 @@ bool gmt_is_cpt_master (struct GMT_CTRL *GMT, char *cpt) {
 }
 
 void gmt_save_current_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P) {
-	char file[PATH_MAX] = {""};
+	char file[PATH_MAX] = {""}, panel[GMT_LEN16] = {""};
+	int fig, subplot, inset;
+
 	if (GMT->current.setting.run_mode == GMT_CLASSIC) return;
+	gmtlib_get_cpt_level (GMT->parent, &fig, &subplot, panel, &inset);	/* Determine the cpt level */
 	/* Save cpt for use by session */
 	sprintf (file, "%s/gmt.cpt", GMT->parent->gwf_dir);	/* Save this specially stretched CPT for other uses in the modern session, such as colorbor */
 	if (gmtlib_write_cpt (GMT, file, GMT_IS_FILE, P->cpt_flags, P) != GMT_NOERROR)
@@ -7671,8 +7674,11 @@ void gmt_save_current_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P) {
 
 char * gmt_get_current_cpt (struct GMT_CTRL *GMT) {
 	/* If modern and a current CPT exists, allocate a string with its name and return, else NULL */
-	char path[GMT_LEN256] = {""}, *file = NULL;
+	char path[GMT_LEN256] = {""}, panel[GMT_LEN16] = {""}, *file = NULL;
+	int fig, subplot, inset;
+	
 	if (GMT->current.setting.run_mode == GMT_CLASSIC) return NULL;	/* Not available in classic mode */
+	gmtlib_get_cpt_level (GMT->parent, &fig, &subplot, panel, &inset);	/* Determine the cpt level */
 	sprintf (path, "%s/gmt.cpt", GMT->parent->gwf_dir);	/* Save this specially stretched CPT for other uses in the modern session, such as colorbor */
 	if (!access (path, R_OK)) {
 		file = strdup (path);


### PR DESCRIPTION
See #1294 for context.  I am adding a new function _gmtlib_get_cpt_level_ that will let us determine which current CPT should be written or read in modern mode.  The information it gathers is not being used yet thought, so no change in behavior yet.
