### PR TITLE
Reset subplot row,col|index to start at zero

### DIFF
--- a/doc/rst/source/explain_-c_full.rst_
+++ b/doc/rst/source/explain_-c_full.rst_
@@ -7,4 +7,4 @@
     no **-c** is given and we just entered subplot mode then the first
     panel (top, left) is selected.  Instead of *row, col* you may give
     the one-dimensional *index* which depends on the order you set via **-A**
-    when the subplot was defined.
+    when the subplot was defined. Note: *row*, *col*, and *index* all start at 0.

--- a/doc/rst/source/subplot.rst_
+++ b/doc/rst/source/subplot.rst_
@@ -172,11 +172,11 @@ Optional Arguments
 ------------------
 
 *row,col*
-    Sets the current subplot until further notice.  If not given we go to the next panel by order
+    Sets the current subplot until further notice.  Note: First *row* or *col is 0, not 1. If not given we go to the next panel by order
     specified via **-A**.  As an alternative, you may bypass the **set** mode and
     instead supply the common option **-c**\ [*row,col*] to the first plot command you issue in that subplot.
     GMT maintains information about the current figure and subplot. Also, you may give the one-dimensional
-    *index* instead which starts at 1 and follows the row or column order set via **-A**.
+    *index* instead which starts at 0 and follows the row or column order set via **-A**.
 
 .. _subplot_set-A:
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -11542,7 +11542,7 @@ GMT_LOCAL struct GMT_CTRL *gmt_begin_module_sub (struct GMTAPI_CTRL *API, const 
 
 /* Subplot functions */
 
-GMT_LOCAL int get_current_panel (struct GMTAPI_CTRL *API, int fig, unsigned int *row, unsigned int *col, double gap[], char *tag, unsigned int *first) {
+GMT_LOCAL int get_current_panel (struct GMTAPI_CTRL *API, int fig, int *row, int *col, double gap[], char *tag, unsigned int *first) {
 	/* Gets the current subplot panel, returns 1 if found and 0 otherwise.
 	 * If gap == NULL that means that not finding a panel file is OK since it may be the first; we are just trying to get row,col. */
 	char file[PATH_MAX] = {""};
@@ -11551,7 +11551,7 @@ GMT_LOCAL int get_current_panel (struct GMTAPI_CTRL *API, int fig, unsigned int 
 	sprintf (file, "%s/gmt.panel.%d", API->gwf_dir, fig);
 	if (access (file, F_OK))	{	/* Panel selection file not available so we are not doing subplots */
 		if (gap == NULL) {	/* By default we do the first panel */
-			*row = *col = UINT_MAX;
+			*row = *col = INT_MAX;
 			return GMT_NOERROR;
 		}
 		GMT_Report (API, GMT_MSG_DEBUG, "get_current_panel: No current panel selected so not in subplot mode\n");
@@ -11579,17 +11579,16 @@ GMT_LOCAL int get_current_panel (struct GMTAPI_CTRL *API, int fig, unsigned int 
 		return GMT_RUNTIME_ERROR;
 	}
 	fclose (fp);
-	if (*row == 0 || *col == 0) {
+	if (*row < 0 || *col < 0) {
 		GMT_Report (API, GMT_MSG_NORMAL, "Current panel has row or column outsiden range!\n");
 		API->error = GMT_RUNTIME_ERROR;
 		return GMT_RUNTIME_ERROR;
 	}
 	GMT_Report (API, GMT_MSG_DEBUG, "get_current_panel: Current panel is (%d, %d)\n", *row, *col);
-	(*row)--;	(*col)--;	/* Since they were given on a 1-n,1-m basis */
 	return GMT_NOERROR;
 }
 
-int gmt_set_current_panel (struct GMTAPI_CTRL *API, int fig, unsigned int row, unsigned int col, double gap[], char *label, unsigned first) {
+int gmt_set_current_panel (struct GMTAPI_CTRL *API, int fig, int row, int col, double gap[], char *label, unsigned first) {
 	/* Update gmt.panel with current pane's (row,col) and write first as 0 or 1.
 	 * first should be 1 the first time we visit this panel so that the automatic -B
 	 * and panel tag stuff only happens once. */
@@ -11612,11 +11611,11 @@ int gmt_set_current_panel (struct GMTAPI_CTRL *API, int fig, unsigned int row, u
 	return GMT_NOERROR;
 }
 
-int gmt_get_next_panel (struct GMTAPI_CTRL *API, int fig, unsigned int *row, unsigned int *col) {
+int gmt_get_next_panel (struct GMTAPI_CTRL *API, int fig, int *row, int *col) {
 	/* Auto-advance to next panel, with initialization at first panel.  The order of advancement
 	 * was set by -A's +v modifier and is found by reading the subplotorder file */
 	
-	unsigned int n_rows, n_cols, order;
+	int n_rows, n_cols, order;
 	char file[PATH_MAX] = {""};
 	FILE *fp = NULL;
 	
@@ -11636,24 +11635,24 @@ int gmt_get_next_panel (struct GMTAPI_CTRL *API, int fig, unsigned int *row, uns
 	fclose (fp);
 	
 	/* If the panel file does not exist we initialize to row = col = 0 */
-	if (*col != UINT_MAX && get_current_panel (API, fig, row, col, NULL, NULL, NULL)) {	/* Not good */
+	if (*col != INT_MAX && get_current_panel (API, fig, row, col, NULL, NULL, NULL)) {	/* Not good */
 		API->error = GMT_RUNTIME_ERROR;
 		return GMT_RUNTIME_ERROR;
 	}
 	
-	if (*row == UINT_MAX && *col == UINT_MAX)	/* First panel */
-		*row = *col = 1;
-	else if (*col == UINT_MAX) {	/* row has index which gives (row,col) depending on order */
-		unsigned int index = *row - 1;
+	if (*row == INT_MAX && *col == INT_MAX)	/* First panel */
+		*row = *col = 0;
+	else if (*col == INT_MAX) {	/* row has index which gives (row,col) depending on order */
+		unsigned int index = *row;
 		if (order == GMT_IS_COL_FORMAT) {	/* March down columns */
-			*col = index / n_rows + 1;
-			*row = index % n_rows + 1;
+			*col = index / n_rows;
+			*row = index % n_rows;
 		}
 		else {
-			*col = index % n_cols + 1;
-			*row = index / n_cols + 1;
+			*col = index % n_cols;
+			*row = index / n_cols;
 		}
-		GMT_Report (API, GMT_MSG_NORMAL, "Index %u goes to (%u, %u)\n", index+1, *row, *col);
+		GMT_Report (API, GMT_MSG_NORMAL, "Index %u goes to (%u, %u)\n", index, *row, *col);
 	}
 	else {	/* Auto-advance to next panel */
 		if (order == GMT_IS_COL_FORMAT) {	/* Going down columns */
@@ -11668,7 +11667,6 @@ int gmt_get_next_panel (struct GMTAPI_CTRL *API, int fig, unsigned int *row, uns
 			else	/* Across current row */
 				(*col)++;
 		}
-		(*row)++;	(*col)++;	/* Since they are needed on a 1-n,1-m basis */
 	}
 		
 	API->error = GMT_NOERROR;
@@ -11705,7 +11703,8 @@ struct GMT_SUBPLOT *gmt_subplot_info (struct GMTAPI_CTRL *API, int fig) {
 	/* Only called under modern mode */
 	char file[PATH_MAX] = {""}, line[PATH_MAX] = {""}, tmp[GMT_LEN16] = {""}, *c = NULL;
 	bool found = false;
-	unsigned int row, col, first, k;
+	int row, col;
+	unsigned int first, k;
 	int n;
 	double gap[4] = {0.0, 0.0, 0.0, 0.0};
 	struct GMT_SUBPLOT *P = NULL;
@@ -12316,7 +12315,7 @@ GMT_LOCAL int gmtinit_get_inset_dimensions (struct GMTAPI_CTRL *API, int fig, st
 	double margin[4] = {0.0, 0.0, 0.0, 0.0};
 	FILE *fp = NULL;
 	
-	inset->active = false;	/* It is not an inset until we detect that it is */
+	if (inset) inset->active = false;	/* It is not an inset until we detect that it is */
 	sprintf (file, "%s/gmt.inset.%d", API->gwf_dir, fig);	/* Inset information file */
 
 	if (access (file, F_OK)) return (GMT_NOERROR);	/* No inset active */
@@ -12541,13 +12540,13 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 			}
 
 			if (GMT->hidden.func_level == GMT_CONTROLLER && subplot_status & GMTINIT_SUBPLOT_ACTIVE) {	/* Explore -c setting */
-				unsigned int row = 0, col = 0;
+				int row = 0, col = 0;
 				if ((opt = GMT_Find_Option (API, 'c', *options))) {	/* Got -c<row,col> for subplot so must update current gmt.panel */
 					if (opt->arg[0] && strchr (opt->arg,','))	/* Gave a comma-separate argument so presumably this is our row,col */
 						sscanf (opt->arg, "%d,%d", &row, &col);
 					else if (opt->arg[0] && isdigit (opt->arg[0])) {	/* Probably gave index */
 						row = atoi (opt->arg);
-						col = UINT_MAX;
+						col = INT_MAX;
 						if (gmt_get_next_panel (API, fig, &row, &col)) return NULL;	/* Bad */
 					}
 					else {	/* If there is a previously set panel, we move to the next panel, otherwise set to first */
@@ -15533,7 +15532,7 @@ void gmtlib_get_cpt_level (struct GMTAPI_CTRL *API, int *fig, int *subplot, char
 	panel[0] = '\0';
 	if ((*subplot) & GMTINIT_SUBPLOT_ACTIVE) {	/* subplot active */
 		if (((*subplot) & GMTINIT_PANEL_NOTSET) == 0) {
-			unsigned int row, col;
+			int row, col;
 			if (get_current_panel (API, *fig, &row, &col, NULL, NULL, NULL) == 0)	/* panel set */
 				sprintf (panel, "%u-%u", row, col);
 		}

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12542,10 +12542,19 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 			if (GMT->hidden.func_level == GMT_CONTROLLER && subplot_status & GMTINIT_SUBPLOT_ACTIVE) {	/* Explore -c setting */
 				int row = 0, col = 0;
 				if ((opt = GMT_Find_Option (API, 'c', *options))) {	/* Got -c<row,col> for subplot so must update current gmt.panel */
-					if (opt->arg[0] && strchr (opt->arg,','))	/* Gave a comma-separate argument so presumably this is our row,col */
+					if (opt->arg[0] && strchr (opt->arg,',')) {	/* Gave a comma-separate argument so presumably this is our row,col */
 						sscanf (opt->arg, "%d,%d", &row, &col);
-					else if (opt->arg[0] && isdigit (opt->arg[0])) {	/* Probably gave index */
+						if (row < 0 || col < 0) {
+							GMT_Report (API, GMT_MSG_NORMAL, "Negative row and/or column given to -c!\n");
+							return NULL;
+						}
+					}
+					else if (opt->arg[0] && (strchr ("-+", opt->arg[0]) || isdigit (opt->arg[0]))) {	/* Probably gave index */
 						row = atoi (opt->arg);
+						if (row < 0) {
+							GMT_Report (API, GMT_MSG_NORMAL, "Negative index given to -c!\n");
+							return NULL;
+						}
 						col = INT_MAX;
 						if (gmt_get_next_panel (API, fig, &row, &col)) return NULL;	/* Bad */
 					}

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -11652,7 +11652,7 @@ int gmt_get_next_panel (struct GMTAPI_CTRL *API, int fig, int *row, int *col) {
 			*col = index % n_cols;
 			*row = index / n_cols;
 		}
-		GMT_Report (API, GMT_MSG_NORMAL, "Index %u goes to (%u, %u)\n", index, *row, *col);
+		GMT_Report (API, GMT_MSG_DEBUG, "Index %u goes to (%u, %u)\n", index, *row, *col);
 	}
 	else {	/* Auto-advance to next panel */
 		if (order == GMT_IS_COL_FORMAT) {	/* Going down columns */

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -6980,7 +6980,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 			PSL_command (PSL, "U\n}!\n");
 		}
 		/* Store first = 0 since we are done with -B and the optional tag */
-		if (gmt_set_current_panel (GMT->parent, GMT->current.ps.figure, P->row+1, P->col+1, P->gap, P->tag, 0))	/* +1 since get_current_panel does -1 */
+		if (gmt_set_current_panel (GMT->parent, GMT->current.ps.figure, P->row, P->col, P->gap, P->tag, 0))
 			return NULL;	/* Should never happen */
 	}
 	if (n_movie_labels) {	/* Obtained movie frame labels, implement them via a completion PostScript procedure */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -41,7 +41,7 @@ EXTERN_MSC char *gmt_strdup (struct GMT_CTRL *GMT, const char *s);
 
 /* gmt_init.c: */
 
-EXTERN_MSC int gmt_get_next_panel (struct GMTAPI_CTRL *API, int fig, unsigned int *row, unsigned int *col);
+EXTERN_MSC int gmt_get_next_panel (struct GMTAPI_CTRL *API, int fig, int *row, int *col);
 EXTERN_MSC int gmt_report_usage (struct GMTAPI_CTRL *API, struct GMT_OPTION *options, unsigned int special, int (*usage)(struct GMTAPI_CTRL *, int));
 EXTERN_MSC bool gmt_option_set (struct GMT_CTRL *GMT, bool *active, unsigned int *errors);
 EXTERN_MSC void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int justify);
@@ -52,7 +52,7 @@ EXTERN_MSC char gmt_set_V (int mode);
 EXTERN_MSC void gmtinit_conf_US (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmtinit_conf (struct GMT_CTRL *GMT);
 EXTERN_MSC int gmt_truncate_file (struct GMTAPI_CTRL *API, char *file, size_t size);
-EXTERN_MSC int gmt_set_current_panel (struct GMTAPI_CTRL *API, int fig, unsigned int row, unsigned int col, double gap[], char *label, unsigned int first);
+EXTERN_MSC int gmt_set_current_panel (struct GMTAPI_CTRL *API, int fig, int row, int col, double gap[], char *label, unsigned int first);
 EXTERN_MSC int gmt_get_current_figure (struct GMTAPI_CTRL *API);
 EXTERN_MSC int gmt_add_figure (struct GMTAPI_CTRL *API, char *arg);
 EXTERN_MSC int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *arg);

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -137,13 +137,13 @@ struct GMT_INSET {
 
 /*! For keeping track of GMT subplots under modern mode */
 struct GMT_SUBPLOT {
-	unsigned int active;		/* 1 if subplot is in effect */
-	unsigned int row, col;		/* Current panel position e.g., 0,0 */
-	unsigned int nrows, ncolumns;	/* Panel arrangement for subplot window */
+	unsigned int active;	/* 1 if subplot is in effect */
 	unsigned int first;		/* 1 the first time we reach panel, 0 later */
 	unsigned int candy;		/* 1 when we are plotting a scale, bar, etc and not map */
-	unsigned int parallel;		/* 1 for axis-parallel annotations [0 for standard] */
-	int dir[2];			/* Cartesian axis direction: +1 or -1 [1/1] */
+	unsigned int parallel;	/* 1 for axis-parallel annotations [0 for standard] */
+	int row, col;			/* Current panel position e.g., 0,0 */
+	int nrows, ncolumns;	/* Panel arrangement for subplot window */
+	int dir[2];				/* Cartesian axis direction: +1 or -1 [1/1] */
 	double x, y;			/* LB corner of current panel */
 	double dx, dy;			/* Offset from LB when projection rescaling is required to center */
 	double w, h;			/* Width and height of current panel */

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -61,7 +61,7 @@ struct SUBPLOT_CTRL {
 	struct In {	/* begin | end | set */
 		bool active;
 		unsigned int mode;	/* SUBPLOT_BEGIN|SET|END*/
-		unsigned int row, col;
+		int row, col;
 	} In;
 	struct A {	/* -A[<letter>|<number>][+c<clearance>][+g<fill>][+j|J<pos>][+o<offset>][+p<pen>][+r|R][+v] */
 		bool active;
@@ -123,7 +123,7 @@ GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a n
 	struct SUBPLOT_CTRL *C;
 
 	C = gmt_M_memory (GMT, NULL, 1, struct SUBPLOT_CTRL);
-	C->In.row = C->In.col = UINT_MAX;
+	C->In.row = C->In.col = GMT_NOTSET;
 	sprintf (C->A.placement, "TL");
 	sprintf (C->A.justify, "TL");
 	C->A.off[GMT_X] = C->A.off[GMT_Y] = 0.01 * GMT_TEXT_OFFSET * GMT->current.setting.font_tag.size / PSL_POINTS_PER_INCH; /* 20% */
@@ -154,7 +154,8 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s begin <nrows>x<ncols> -F[f|s]<width(s)>/<height(s)>[+f<wfracs/hfracs>] [-A<autolabelinfo>]\n", name);
 	GMT_Message (API, GMT_TIME_NONE, "\t [-C<side><clearance>[u]] [%s] [-SC<layout>][+<mods>] [-SR<layout>][+<mods>]\n\t[-M<margins>] [%s] [-T<title>] [%s] [%s]\n\n", GMT_J_OPT, GMT_Rgeo_OPT, GMT_V_OPT, GMT_PAR_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s set [<row>,<col>|<index>] [-A<fixedlabel>] [-C<side><clearance>[u]] [%s]\n\n", name, GMT_V_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s set [<row>,<col>|<index>] [-A<fixedlabel>] [-C<side><clearance>[u]] [%s]\n", name, GMT_V_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\tSet <row>,<col> in 0-(nrows-1),0-(ncols-1) range, or <index> in 0 to (nrows*ncols-1) range.\n");
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s end [%s] [%s]\n\n", name, GMT_V_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -242,15 +243,15 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Error set: Unable to parse row,col: %s\n", opt->arg);
 			return GMT_PARSE_ERROR;
 		}
-		if (n == 1) Ctrl->In.col = UINT_MAX;	/* Flag we gave the index instead */
-		if (Ctrl->In.row == 0 || Ctrl->In.col == 0) {
+		if (n == 1) Ctrl->In.col = INT_MAX;	/* Flag we gave the index instead */
+		if (Ctrl->In.row == GMT_NOTSET || Ctrl->In.col == GMT_NOTSET) {
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Error set: Unable to parse row,col: %s\n", opt->arg);
 			return GMT_PARSE_ERROR;
 		}
 		Ctrl->In.mode = SUBPLOT_SET;
 	}
 	else if (strchr (opt->arg, ',')) {	/* Implicitly called set without using the word "set" */
-		if (sscanf (opt->arg, "%d,%d", &Ctrl->In.row, &Ctrl->In.col) < 2 || Ctrl->In.row == 0 || Ctrl->In.col == 0) {
+		if (sscanf (opt->arg, "%d,%d", &Ctrl->In.row, &Ctrl->In.col) < 2 || Ctrl->In.row < 0 || Ctrl->In.col < 0) {
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Not a subplot command: %s\n", opt->arg);
 			return GMT_PARSE_ERROR;
 		}
@@ -1096,7 +1097,7 @@ int GMT_subplot (void *V_API, int mode, void *args) {
 		gmt_M_free (GMT, Ly);
 	}
 	else if (Ctrl->In.mode == SUBPLOT_SET) {	/* SUBPLOT_SET */
-		if (Ctrl->In.col == UINT_MAX) {	/* Auto-set which panel */
+		if (Ctrl->In.col == INT_MAX) {	/* Auto-set which panel */
 			if ((error = gmt_get_next_panel (API, fig, &Ctrl->In.row, &Ctrl->In.col)))	/* Bad */
 				Return (error)
 		}

--- a/test/exmod/ex01.sh
+++ b/test/exmod/ex01.sh
@@ -7,10 +7,10 @@
 gmt begin ex01 ps
   gmt set MAP_GRID_CROSS_SIZE_PRIMARY 0 FONT_ANNOT_PRIMARY 10p PS_MEDIA letter
   gmt subplot begin 2x1 -A -M0.25i -Blrtb -Bafg -T"Low Order Geoid" -Fs6.5i/0 -Rg -JH0/6.5i
-  gmt coast -Glightbrown -Slightblue -c1,1
+  gmt coast -Glightbrown -Slightblue -c0,0
   gmt grdcontour @osu91a1f_16.nc -C10 -A50+f7p -Gd4i -Ln -Wcthinnest,- -Wathin,- -T+d0.1i/0.02i
   gmt grdcontour osu91a1f_16.nc -C10 -A50+f7p -Gd4i -LP -T+d0.1i/0.02i+l
-  gmt coast -Glightbrown -Slightblue -c2,1
+  gmt coast -Glightbrown -Slightblue -c1,0
   gmt grdcontour osu91a1f_16.nc -C10 -A50+f7p -Gd4i -Ln -Wcthinnest,- -Wathin,- -T+d0.1i/0.02i+l
   gmt grdcontour osu91a1f_16.nc -C10 -A50+f7p -Gd4i -LP -T+d0.1i/0.02i+l
   gmt subplot end

--- a/test/exmod/ex02.sh
+++ b/test/exmod/ex02.sh
@@ -10,10 +10,10 @@ gmt begin ex02 ps
   gmt makecpt -Crainbow -T-2/14/2 -H > g.cpt
   gmt grd2cpt @HI_topo_02.nc -Crelief -H -Z > t.cpt
   gmt subplot begin 2x1 -A+JTL+o0.1i/0 -Fs6i/3.5i -M0 -R160/20/220/30+r -JOc190/25.5/292/69/6i -X1.5i -Y1.5i -B10 -T"H@#awaiian@# T@#opo and @#G@#eoid@#"
-    gmt subplot 2,1 -Ce1.1i
+    gmt subplot 1,0 -Ce1.1i
     gmt grdimage @HI_geoid_02.nc -Cg.cpt
     gmt colorbar -Cg.cpt -DJRM+o0.6i/0+e+mc -Bx2+lGEOID -By+lm
-    gmt subplot 1,1 -Ce1.15i
+    gmt subplot 0,0 -Ce1.15i
     gmt grdimage @HI_topo_02.nc -I+a0 -Ct.cpt
     gmt colorbar -Ct.cpt -DJRM+o0.6i/0+mc -I0.3 -Bx2+lTOPO -By+lkm
   gmt subplot end

--- a/test/exmod/ex03.sh
+++ b/test/exmod/ex03.sh
@@ -45,7 +45,7 @@ gmt begin ex03 ps
   # Time to plot spectra
   gmt set FONT_TAG 18p,Helvetica-Bold
   gmt subplot begin 2x1 -M0.1i -SCb+l"Wavelength (km)" -T"Ship and Satellite Gravity" -Fs4i/3.75i -A+jTR+o0.1i -BWeSn+g240/255/240 -X2i -Y1.5i
-    gmt subplot 1,1 -A"Input Power"
+    gmt subplot 0,0 -A"Input Power"
     gmt plot spectrum.xpower -JX-4il/3.75il -Bxa1f3p -Bya1f3p+l"Power (mGal@+2@+km)" \
 	-Gred -ST0.07i -R1/1000/0.1/10000 -Ey+p0.5p
     gmt plot spectrum.ypower -Gblue -Sc0.07i -Ey+p0.5p
@@ -53,7 +53,7 @@ gmt begin ex03 ps
 	S 0.1i T 0.07i red  - 0.3i Ship
 	S 0.1i c 0.07i blue - 0.3i Satellite
 	EOF
-    gmt subplot 2,1 -A"Coherency@+2@+"
+    gmt subplot 1,0 -A"Coherency@+2@+"
     gmt plot spectrum.coh -JX-4il/3.75i -Bxa1f3p -Bya0.25f0.05+l"Coherency@+2@+" -R1/1000/0/1 -Sc0.07i -Gpurple -Ey+p0.5p
   gmt subplot end
 gmt end

--- a/test/exmod/ex06.sh
+++ b/test/exmod/ex06.sh
@@ -7,8 +7,8 @@
 gmt begin ex06 ps
   gmt set PS_MEDIA letter
   gmt subplot begin 2x1 -A+JTL+o0.3i -Fs6i/3.5i -M0.4i -X1.5i -Y1.5i
-    gmt rose @fractures_06.txt -: -A10r -Sn -JX3.6i -Gorange -R0/1/0/360 -Bx0.2g0.2 -By30g30 -B+glightblue -W1p -c2,1
+    gmt rose @fractures_06.txt -: -A10r -Sn -JX3.6i -Gorange -R0/1/0/360 -Bx0.2g0.2 -By30g30 -B+glightblue -W1p -c1,0
     gmt histogram -Bx+l"Topography (m)" -By+l"Frequency"+u" %" -BWSne+t"Histograms"+glightblue @v3206_06.txt \
-	-R-6000/0/0/30 -JX4.8i/2.4i -Gorange -L1p -Z1 -W250 -c1,1
+	-R-6000/0/0/30 -JX4.8i/2.4i -Gorange -L1p -Z1 -W250 -c0,0
   gmt subplot end
 gmt end

--- a/test/exmod/ex12.sh
+++ b/test/exmod/ex12.sh
@@ -9,20 +9,20 @@ gmt begin ex12 ps
   gmt subplot begin 2x2 -M0.05i -Fs3i/0 -SCb -SRl -R0/6.5/-0.2/6.5 -Jx3i -BWSne -T"Delaunay Triangulation"
   # First draw network and label the nodes
   gmt triangulate @Table_5_11.txt -M > net.xy
-  gmt plot net.xy -Wthinner -c1,1
+  gmt plot net.xy -Wthinner -c0,0
   gmt plot @Table_5_11.txt -Sc0.12i -Gwhite -Wthinnest
   gmt text @Table_5_11.txt -F+f6p+r
   # Then draw network and print the node values
-  gmt plot net.xy -Wthinner -c1,2
+  gmt plot net.xy -Wthinner -c0,1
   gmt plot @Table_5_11.txt -Sc0.03i -Gblack
   gmt text @Table_5_11.txt -F+f6p+jLM -Gwhite -W -C0.01i -D0.08i/0i -N
   # Then contour the data and draw triangles using dashed pen; use "gmt gmtinfo" and "gmt makecpt" to make a
   # color palette (.cpt) file
   T=`gmt info -T25+c2 @Table_5_11.txt`
   gmt makecpt -Cjet $T
-  gmt contour @Table_5_11.txt -Wthin -C -Lthinnest,- -Gd1i -c2,1
+  gmt contour @Table_5_11.txt -Wthin -C -Lthinnest,- -Gd1i -c1,0
   # Finally color the topography
-  gmt contour @Table_5_11.txt -C -I -c2,2
+  gmt contour @Table_5_11.txt -C -I -c1,1
   gmt subplot end
 gmt end
 #

--- a/test/exmod/ex13.sh
+++ b/test/exmod/ex13.sh
@@ -11,11 +11,11 @@ gmt begin ex13 ps
   gmt grdmath z.nc DDX = dzdx.nc
   gmt grdmath z.nc DDY = dzdy.nc
   gmt subplot begin 2x2 -M0.05i -Ff6i/6i -BWSne -T"z(x,y) = x@~\327@~exp(-x@+2@+-y@+2@+)"
-    gmt grdcontour z.nc -C0.05 -A0.1 -Gd2i -S4 -T+d0.1i/0.03i -c1,1
-    gmt grdcontour z.nc -C0.05 -Gd2i -S4 -c1,2
+    gmt grdcontour z.nc -C0.05 -A0.1 -Gd2i -S4 -T+d0.1i/0.03i -c0,0
+    gmt grdcontour z.nc -C0.05 -Gd2i -S4 -c0,1
     gmt grdvector dzdx.nc dzdy.nc -I0.2 -Q0.1i+e+n0.25i+h0.5 -Gblack -W1p -S5i
-    gmt grdcontour dzdx.nc -C0.1  -A0.5 -Gd2i -S4 -T+d0.1i/0.03i -c2,1
-    gmt grdcontour dzdy.nc -C0.05 -A0.2 -Gd2i -S4 -T+d0.1i/0.03i -c2,2
+    gmt grdcontour dzdx.nc -C0.1  -A0.5 -Gd2i -S4 -T+d0.1i/0.03i -c1,0
+    gmt grdcontour dzdy.nc -C0.05 -A0.2 -Gd2i -S4 -T+d0.1i/0.03i -c1,1
   gmt subplot end
 gmt end
 rm -f z.nc dzdx.nc dzdy.nc

--- a/test/exmod/ex14.sh
+++ b/test/exmod/ex14.sh
@@ -20,16 +20,16 @@ gmt begin ex14 ps
   gmt plot trend.d -Wthinner,-
   gmt subplot begin 2x2 -M0.05i -Ff6i/6i -BWSne -Yh+0.4i
     # First draw network and label the nodes
-    gmt plot @Table_5_11.txt -R0/7/0/7 -Sc0.05i -Gblack -c1,1
+    gmt plot @Table_5_11.txt -R0/7/0/7 -Sc0.05i -Gblack -c0,0
     gmt text @Table_5_11.txt -D0.1c/0 -F+f6p+jLM -N
     # Then draw gmt blockmean cells and label data values using one decimal
-    gmt plot mean.xyz -Ss0.05i -Gblack -c1,2
+    gmt plot mean.xyz -Ss0.05i -Gblack -c0,1
     gmt text -D0.15c/0 -F+f6p+jLM+z%.1f -Gwhite -W -C0.01i -N mean.xyz
     # Then gmt surface and contour the data
-    gmt grdcontour data.nc -C25 -A50 -Gd3i -S4 -c2,1
+    gmt grdcontour data.nc -C25 -A50 -Gd3i -S4 -c1,0
     gmt plot mean.xyz -Ss0.05i -Gblack
     # Fit bicubic trend to data and compare to gridded gmt surface
-    gmt grdcontour trend.nc -C25 -A50 -Glct/cb -S4 -c2,2
+    gmt grdcontour trend.nc -C25 -A50 -Glct/cb -S4 -c1,1
     gmt plot track -Wthick,.
   gmt subplot end
   gmt plot trend.d -Wthinner,-

--- a/test/exmod/ex15.sh
+++ b/test/exmod/ex15.sh
@@ -12,19 +12,19 @@ gmt begin ex15 ps
   gmt subplot begin 2x2 -M0.1i/0.05i -Fs2.9i/0 $region -JM2.9i -BWSne -T"Gridding with missing data"
 #   Raw nearest neighbor contouring
     gmt nearneighbor $region -I10m -S40k -Gship.nc ship.b -bi
-    gmt grdcontour ship.nc -JM -C250 -A1000 -Gd2i -c2,1
+    gmt grdcontour ship.nc -JM -C250 -A1000 -Gd2i -c1,0
 #   Grid via surface but mask out area with no data using coastlines
     gmt blockmedian ship.b -b3d > ship_10m.b
     gmt surface ship_10m.b -Gship.nc -bi
-    gmt mask -I10m ship.b -T -Glightgray -bi3d -c2,2
+    gmt mask -I10m ship.b -T -Glightgray -bi3d -c1,1
     gmt grdcontour ship.nc -C250 -L-8000/0 -A1000 -Gd2i
 #   Grid via surface but mask out area with no data
-    gmt mask -I10m ship_10m.b -bi3d -c1,1
+    gmt mask -I10m ship_10m.b -bi3d -c0,0
     gmt grdcontour ship.nc -C250 -A1000 -L-8000/0 -Gd2i
     gmt mask -C
 #   Clip data above sealevel then overlay land
     gmt grdclip ship.nc -Sa-1/NaN -Gship_clipped.nc
-    gmt grdcontour ship_clipped.nc -C250 -A1000 -L-8000/0 -Gd2i -c1,2
+    gmt grdcontour ship_clipped.nc -C250 -A1000 -L-8000/0 -Gd2i -c0,1
     gmt coast -Ggray -Wthinnest
     gmt grdinfo -Cn -M ship.nc | gmt psxy -Sa0.15i -Wthick -i10,11
   gmt subplot end

--- a/test/exmod/ex16.sh
+++ b/test/exmod/ex16.sh
@@ -12,17 +12,17 @@ gmt begin ex16 ps
   gmt set FONT_ANNOT_PRIMARY 9p FONT_TITLE 18p,Times-Roman
   gmt colorbar -Dx3.25i/0i+jTC+w5i/0.25i+h -C@ex_16.cpt
   gmt subplot begin 2x2 -M0.05i -Fs3.25i/0 -R0/6.5/-0.2/6.5 -Jx1i -SCb -SRl+t -Bwesn -Yh+0.2i -T"Gridding of Data"
-    gmt contour @Table_5_11.txt -C@ex_16.cpt -I -B+t"contour (triangulate)" -c1,1
+    gmt contour @Table_5_11.txt -C@ex_16.cpt -I -B+t"contour (triangulate)" -c0,0
     # 
     gmt surface @Table_5_11.txt -R0/6.5/-0.2/6.5 -I0.2 -Graws0.nc
-    gmt grdview raws0.nc -C@ex_16.cpt -Qs -B+t"surface (tension = 0)" -c1,2
+    gmt grdview raws0.nc -C@ex_16.cpt -Qs -B+t"surface (tension = 0)" -c0,1
     #
     gmt surface @Table_5_11.txt -Graws5.nc -T0.5
-    gmt grdview raws5.nc -C@ex_16.cpt -Qs -B+t"surface (tension = 0.5)" -c2,1
+    gmt grdview raws5.nc -C@ex_16.cpt -Qs -B+t"surface (tension = 0.5)" -c1,0
     #
     gmt triangulate @Table_5_11.txt -Grawt.nc
     gmt grdfilter rawt.nc -Gfiltered.nc -D0 -Fc1
-    gmt grdview filtered.nc -C@ex_16.cpt -Qs -B+t"triangulate @~\256@~ grdfilter" -c2,2
+    gmt grdview filtered.nc -C@ex_16.cpt -Qs -B+t"triangulate @~\256@~ grdfilter" -c1,1
   gmt subplot end
 gmt end
 rm -f raws0.nc raws5.nc rawt.nc filtered.nc

--- a/test/exmod/ex18.sh
+++ b/test/exmod/ex18.sh
@@ -14,14 +14,14 @@ gmt begin ex18 ps
   echo "-142.65 56.25 400" > pratt.txt
   gmt makecpt -Crainbow -T-60/60
   gmt subplot begin 2x1 -A+JTL+o0.2i -Fs6i/3.5i -M0.2i/0.35i -R@AK_gulf_grav.nc -JM5.5i -B -BWSne
-    gmt subplot 1,1
+    gmt subplot 0,0
     gmt grdimage @AK_gulf_grav.nc -I+d -C
     gmt coast -Di -Ggray -Wthinnest
     gmt colorbar -DJCB+o0/0.35i -C -Bxaf -By+l"mGal"
     gmt text pratt.txt -D0.1i/0.1i -F+f12p,Helvetica-Bold+jLB+tPratt
     gmt plot pratt.txt -SE- -Wthinnest
     # Then draw 10 mGal contours and overlay 50 mGal contour in green
-    gmt subplot 2,1
+    gmt subplot 1,0
     gmt grdcontour @AK_gulf_grav.nc -C20
     # Save 50 mGal contours to individual files, then plot them
     gmt grdcontour @AK_gulf_grav.nc -C10 -L49/51 -Dsm_%d_%c.txt

--- a/test/exmod/ex19.sh
+++ b/test/exmod/ex19.sh
@@ -11,7 +11,7 @@ gmt begin ex19 ps
   gmt makecpt -Crainbow -T-180/180 -H > lon.cpt
   gmt subplot begin 3x1 -Fs6.5i/0 -M0 -Bbltr -Rd -JI0/6.5i
 #   First make a worldmap with graded blue oceans and rainbow continents
-    gmt grdimage lat.nc -Clat.cpt -nl -c1,1
+    gmt grdimage lat.nc -Clat.cpt -nl -c0,0
     gmt coast -Dc -A5000 -Gc
     gmt grdimage lon.nc -Clon.cpt -nl
     gmt coast -Q
@@ -20,12 +20,12 @@ gmt begin ex19 ps
     echo "0 -10 GMT CONFERENCE" | gmt text -F+f32p,Helvetica-Bold,red=thinner
     echo "0 -30 Honolulu, Hawaii, April 1, 2018" | gmt text -F+f18p,Helvetica-Bold,green=thinnest
 #   Then show example of color patterns and placing a PostScript image
-    gmt coast -Dc -A5000 -Gp86+fred+byellow+r100 -Sp@circuit.png+r100 -c2,1
+    gmt coast -Dc -A5000 -Gp86+fred+byellow+r100 -Sp@circuit.png+r100 -c1,0
     echo "0 30 SILLY USES OF" | gmt text -F+f32p,Helvetica-Bold,lightgreen=thinner
     echo "0 -30 COLOR PATTERNS" | gmt text -F+f32p,Helvetica-Bold,magenta=thinner
     gmt image -DjCM+w3i @GMT_covertext.eps
 #   Finally repeat 1st plot but exchange the colors
-    gmt grdimage lon.nc -Clon.cpt -nl -c3,1
+    gmt grdimage lon.nc -Clon.cpt -nl -c2,0
     gmt coast -Dc -A5000 -Gc
     gmt grdimage lat.nc -Clat.cpt -nl
     gmt coast -Q

--- a/test/exmod/ex34.sh
+++ b/test/exmod/ex34.sh
@@ -8,11 +8,11 @@
 gmt begin ex34 ps
   gmt set FORMAT_GEO_MAP dddF FONT_HEADING 24p
   gmt subplot begin 2x1 -Fs4.5i/0 -M0.05i -JM4.5i -R-6/20/35/52 -SRl -SCb -Bwesn -T"Franco-Italian Union, 2042-45"
-  gmt coast -EFR,IT+gP300/8 -Glightgray -c2,1
+  gmt coast -EFR,IT+gP300/8 -Glightgray -c1,0
   # Extract a subset of ETOPO2m for this part of Europe
   # gmt grdcut etopo2m_grd.nc -R -GFR+IT.nc=ns
   gmt makecpt -Cglobe -T-5000/5000
-  gmt grdimage @FR+IT.nc -I+a15+ne0.75 -C -c1,1
+  gmt grdimage @FR+IT.nc -I+a15+ne0.75 -C -c0,0
   gmt coast -EFR,IT+gred@60
   gmt subplot end
 gmt end

--- a/test/exmod/ex47.sh
+++ b/test/exmod/ex47.sh
@@ -24,23 +24,23 @@ gmt begin ex47 ps
   grep '#' $file | sed -e s/#//g > giants.txt
   gmt subplot begin 4x3 -M0p -Fs2i/2i -R2.85/5.25/3.9/6.3 -JX-2i/2i -SRl+l"Log light intensity" -SCb+l"Log temperature"+tc -Bwesn -Bafg
   # L1 regressions
-  plot_one -Ey -N1 -c1,1 +tL@-1@-
-  plot_one -Er -N1 -c2,1
-  plot_one -Eo -N1 -c3,1
-  plot_one -Ex -N1 -c4,1
+  plot_one -Ey -N1 -c0,0 +tL@-1@-
+  plot_one -Er -N1 -c1,0
+  plot_one -Eo -N1 -c2,0
+  plot_one -Ex -N1 -c3,0
   #L2 regressions
-  plot_one -Er -N2 -c1,2 +tL@-2@- 
-  plot_one -Eo -N2 -c2,2
-  plot_one -Ex -N2 -c3,2
-  plot_one -Ey -N2 -c4,2
+  plot_one -Er -N2 -c0,1 +tL@-2@- 
+  plot_one -Eo -N2 -c1,1
+  plot_one -Ex -N2 -c2,1
+  plot_one -Ey -N2 -c3,1
   #LMS regressions - also add labels on right side
-  plot_one -Er -Nr -c1,3 +tLMS
+  plot_one -Er -Nr -c0,2 +tLMS
   gmt text -F+cRM+jTC+a90+t"Y ON X" -N -Dj0.2i
-  plot_one -Eo -Nr -c2,3
+  plot_one -Eo -Nr -c1,2
   gmt text -F+cRM+jTC+a90+t"X ON Y" -N -Dj0.2i
-  plot_one -Ex -Nr -c3,3
+  plot_one -Ex -Nr -c2,2
   gmt text -F+cRM+jTC+a90+tORTHOGONAL -N -Dj0.2i
-  plot_one -Ey -Nr -c4,3
+  plot_one -Ey -Nr -c3,2
   gmt text -F+cRM+jTC+a90+t"REDUCED MAJOR AXIS" -N -Dj0.2i
   gmt subplot end
 gmt end

--- a/test/modern/somepanels.sh
+++ b/test/modern/somepanels.sh
@@ -2,11 +2,11 @@
 # Test only giving a few subplots, Roman labeling, and -A override for one subplot
 gmt begin somepanels ps
   gmt subplot begin 3x3 -F6i/8.5i -M5p -A1+c+r+o0.2i+jBR -SCb+lXLABEL -SRl+lYLABEL -Bwstr -T"FIGURE HEADER"
-    gmt basemap -R0/100/0/10 -c1
-    gmt subplot 2,2 -Apink
+    gmt basemap -R0/100/0/10 -c0
+    gmt subplot 1,1 -Apink
     gmt basemap -B+gpink
-    gmt basemap -c3,3
-    gmt basemap -R300/500/-10/0 -c2,1
-    gmt basemap -Bafg -R300/500/-100/0 -c6
+    gmt basemap -c2,2
+    gmt basemap -R300/500/-10/0 -c1,0
+    gmt basemap -Bafg -R300/500/-100/0 -c5
   gmt subplot end
 gmt end


### PR DESCRIPTION
In order to be consistent with all other places in GMT where rows or columns are given, we will set subplot row,col also follow the same convention.  Thus 0,0 is the top left panel.
Implementation changed some unsigned ints to int and several doc and test scripts needed to be updated.  Only failure (for me right now) was anim_08.sh which seems to have to do with NEIC data changes.
