### PR TITLE
Add modifier +s to -Sr to specify a rectangle via opposite diagonal corners

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -321,7 +321,8 @@
 
     **-Sr**
         **r**\ ectangle. No size needs to be specified, but the x- and
-        y-dimensions must be found in columns 3 and 4.
+        y-dimensions must be found in columns 3 and 4.  Alternatively, append **+s**
+        and then the diagonal corner coordinates are expected in columns 3 and 4.
 
     **-SR**
         **R**\ ounded rectangle. No size needs to be specified, but the x-

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13777,6 +13777,8 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 			break;
 		case 'r':
 			p->symbol = PSL_RECT;
+			if (strstr (text, "+s"))	/* Make a rectangle from two corners of a diagonal */
+				p->diagonal = true;
 			p->n_required = 2;
 			check = false;
 			break;

--- a/src/gmt_plot.h
+++ b/src/gmt_plot.h
@@ -139,6 +139,7 @@ struct GMT_SYMBOL {
 	bool shade3D;		/* true when we should simulate shading of 3D symbols cube and column */
 	bool fq_parse;		/* true -Sf or -Sq were given with no args on command line and must be parsed via segment headers */
 	bool accumulate;	/* true if -So takes many band z and they are increments, not total z values */
+	bool diagonal;		/* true if -SJ+s is given */
 	struct GMT_FONT font;	/* Font to use for the -Sl symbol */
 	unsigned int convert_angles;	/* If 2, convert azimuth to angle on map, 1 special case for -JX, 0 plain case */
 	unsigned int n_nondim;	/* Number of columns that has angles or km (and not dimensions with units) */

--- a/src/gmt_plot.h
+++ b/src/gmt_plot.h
@@ -139,7 +139,7 @@ struct GMT_SYMBOL {
 	bool shade3D;		/* true when we should simulate shading of 3D symbols cube and column */
 	bool fq_parse;		/* true -Sf or -Sq were given with no args on command line and must be parsed via segment headers */
 	bool accumulate;	/* true if -So takes many band z and they are increments, not total z values */
-	bool diagonal;		/* true if -SJ+s is given */
+	bool diagonal;		/* true if -Sr+s is given */
 	struct GMT_FONT font;	/* Font to use for the -Sl symbol */
 	unsigned int convert_angles;	/* If 2, convert azimuth to angle on map, 1 special case for -JX, 0 plain case */
 	unsigned int n_nondim;	/* Number of columns that has angles or km (and not dimensions with units) */

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1472,7 +1472,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 							S_Diag->data[GMT_Y][0] = S_Diag->data[GMT_Y][1] = S_Diag->data[GMT_Y][4] = in[GMT_Y];
 							S_Diag->data[GMT_Y][2] = S_Diag->data[GMT_Y][3] = in[pos2y];
 							S_Diag->n_rows = 5;
-							if (gmt_M_is_geographic (GMT, GMT_IN))	/* May need to resample */
+							if (gmt_M_is_geographic (GMT, GMT_IN) && !Ctrl->A.active)	/* May need to resample */
 								S_Diag->n_rows = gmt_fix_up_path (GMT, &S_Diag->data[GMT_X], &S_Diag->data[GMT_Y], S_Diag->n_rows, Ctrl->A.step, Ctrl->A.mode);
 							/* Plot it */
 							gmt_setfill (GMT, &current_fill, outline_active);

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -506,6 +506,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     <labelinfo> controls the label attributes.  Choose from\n");
 	gmt_label_syntax (API->GMT, 7, 1);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Rectangles: x- and y-dimensions must be in columns 3-4.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     Append +s if instead the diagonal corner coordinates are given in columns 3-4.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Rounded rectangles: x- and y-dimensions and corner radius must be in columns 3-5.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Vectors: Direction and length must be in columns 3-4.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     If -SV rather than -Sv is selected, psxy will expect azimuth and\n");
@@ -1063,6 +1064,11 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 		gmt_set_column (GMT, GMT_IN, pos2x, gmt_M_type (GMT, GMT_IN, GMT_X));
 		gmt_set_column (GMT, GMT_IN, pos2y, gmt_M_type (GMT, GMT_IN, GMT_Y));
 	}
+	if (S.symbol == PSL_RECT && S.diagonal) {	/* Getting lon1,lat1,lon2,lat2 of a diagonal and will draw the rectangle subject to -A */
+		/* Reading 2nd coordinate so must set column types */
+		gmt_set_column (GMT, GMT_IN, pos2x, gmt_M_type (GMT, GMT_IN, GMT_X));
+		gmt_set_column (GMT, GMT_IN, pos2y, gmt_M_type (GMT, GMT_IN, GMT_Y));
+	}
 	if (S.symbol == PSL_VECTOR && S.v.status & PSL_VEC_COMPONENTS)
 		gmt_set_column (GMT, GMT_IN, pos2y, GMT_IS_FLOAT);	/* Just the users dy component, not length */
 	if (S.symbol == PSL_VECTOR || S.symbol == GMT_SYMBOL_GEOVECTOR || S.symbol == PSL_MARC ) {	/* One of the vector symbols */
@@ -1137,6 +1143,8 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 		unsigned int n_warn[3] = {0, 0, 0}, warn, item, n_times;
 		double xpos[2], width = 0.0, dim[PSL_MAX_DIMS];
 		struct GMT_RECORD *In = NULL;
+		struct GMT_DATASET *Diag = NULL;
+		struct GMT_DATASEGMENT *S_Diag = NULL;
 
 		if (S.read_symbol_cmd)	/* Must prepare for a rough ride */
 			GMT_Set_Columns (API, GMT_IN, 0, GMT_COL_VAR);
@@ -1173,6 +1181,11 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 				PSL_command (PSL, "/QR_outline false def\n");
 		}
 		
+		if (S.diagonal) {
+			uint64_t dim[GMT_DIM_SIZE] = {1, 1, 5, 2};	/* Put everything in one table */
+			if ((Diag = GMT_Create_Data (API, GMT_IS_DATASET, GMT_IS_POLYGON, GMT_NO_STRINGS, dim, NULL, NULL, 0, 0, NULL)) == NULL) Return (API->error);
+			S_Diag = Diag->table[0]->segment[0];
+		}
 		do {	/* Keep returning records until we reach EOF */
 			if ((In = GMT_Get_Record (API, GMT_READ_DATA, NULL)) == NULL) {	/* Read next record, get NULL if special case */
 				if (gmt_M_rec_is_error (GMT)) {		/* Bail if there are any read errors */
@@ -1362,7 +1375,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 				gmt_setpen (GMT, &current_pen);
 			}
 
-			if (S.symbol == PSL_ELLIPSE || S.symbol == PSL_ROTRECT) {	/* Ellipses and rectangles */
+			if ((S.symbol == PSL_ELLIPSE || S.symbol == PSL_ROTRECT)) {	/* Ellipses and rectangles */
 				if (S.n_required == 0)	/* Degenerate ellipse or rectangle, got diameter via S.size_x */
 					in[ex2] = in[ex3] = S.size_x;	/* Duplicate diameter as major and minor axes */
 				else if (S.n_required == 1)	/* Degenerate ellipse or rectangle, expect single diameter via input */
@@ -1445,6 +1458,27 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 						}
 						/* Fall through on purpose to pick up the other parameters */
 					case PSL_RECT:
+						if (S.diagonal) {	/* Special rectangle give by opposing corners on a diagonal */
+							if (gmt_M_is_dnan (in[pos2x])) {
+								GMT_Report (API, GMT_MSG_VERBOSE, "Diagonal longitude = NaN near line %d\n", n_total_read);
+								continue;
+							}
+							if (gmt_M_is_dnan (in[pos2y])) {
+								GMT_Report (API, GMT_MSG_VERBOSE, "Diagonal latitude = NaN near line %d\n", n_total_read);
+								continue;
+							}
+							S_Diag->data[GMT_X][0] = S_Diag->data[GMT_X][3] = S_Diag->data[GMT_X][4] = in[GMT_X];
+							S_Diag->data[GMT_X][1] = S_Diag->data[GMT_X][2] = in[pos2x];
+							S_Diag->data[GMT_Y][0] = S_Diag->data[GMT_Y][1] = S_Diag->data[GMT_Y][4] = in[GMT_Y];
+							S_Diag->data[GMT_Y][2] = S_Diag->data[GMT_Y][3] = in[pos2y];
+							S_Diag->n_rows = 5;
+							if (gmt_M_is_geographic (GMT, GMT_IN))	/* May need to resample */
+								S_Diag->n_rows = gmt_fix_up_path (GMT, &S_Diag->data[GMT_X], &S_Diag->data[GMT_Y], S_Diag->n_rows, Ctrl->A.step, Ctrl->A.mode);
+							/* Plot it */
+							gmt_setfill (GMT, &current_fill, outline_active);
+							gmt_geo_polygons (GMT, S_Diag);
+							break;
+						}
 						dim[0] = in[ex1];
 						if (gmt_M_is_dnan (dim[0])) {
 							GMT_Report (API, GMT_MSG_VERBOSE, "Rounded rectangle width = NaN near line %d\n", n_total_read);
@@ -1711,6 +1745,9 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 		if (n_warn[2]) GMT_Report (API, GMT_MSG_VERBOSE, "%d vector heads had to be scaled more than implied by +n<norm> since they were still too long. Consider changing the +n<norm> modifier to -S\n", n_warn[2]);
 
 		if (GMT_End_IO (API, GMT_IN, 0) != GMT_NOERROR) {	/* Disables further data input */
+			Return (API->error);
+		}
+		if (GMT_Destroy_Data (API, &Diag) != GMT_NOERROR) {	/* Be gone with the diagonal */
 			Return (API->error);
 		}
 	}

--- a/test/psxy/diagonal.ps
+++ b/test/psxy/diagonal.ps
@@ -1,0 +1,1454 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_bf6dcee-dirty_2019.08.06 [64-bit] Document from psxy
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Tue Aug  6 12:42:37 2019
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_completion {} def
+/PSL_movie_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+-3600 PSL_xorig sub PSL_page_xsize 2 div add 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R0/90/0/70 -JM6i -Wthick,green -Gcyan -Baf '-BWSne+tRectangle via diagonal' -SJ+s -A -P -K -Xc
+%@PROJ: merc 0.00000000 90.00000000 0.00000000 70.00000000 -5009377.086 5009377.086 -0.000 11028513.631 +proj=merc +lon_0=45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%GMTBoundingBox: -216 72 432 475.54
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+8 W
+N 0 0 M 0 -83 D S
+N 0 7926 M 0 83 D S
+N 1200 0 M 0 -83 D S
+N 1200 7926 M 0 83 D S
+N 2400 0 M 0 -83 D S
+N 2400 7926 M 0 83 D S
+N 3600 0 M 0 -83 D S
+N 3600 7926 M 0 83 D S
+N 4800 0 M 0 -83 D S
+N 4800 7926 M 0 83 D S
+N 6000 0 M 0 -83 D S
+N 6000 7926 M 0 83 D S
+N 7200 0 M 0 -83 D S
+N 7200 7926 M 0 83 D S
+N 0 0 M -83 0 D S
+N 7200 0 M 83 0 D S
+N 0 1206 M -83 0 D S
+N 7200 1206 M 83 0 D S
+N 0 2502 M -83 0 D S
+N 7200 2502 M 83 0 D S
+N 0 4018 M -83 0 D S
+N 7200 4018 M 83 0 D S
+N 0 6010 M -83 0 D S
+N 7200 6010 M 83 0 D S
+83 W
+N -42 0 M 0 398 D S
+N 7242 0 M 0 398 D S
+1 A
+N -42 398 M 0 401 D S
+N 7242 398 M 0 401 D S
+0 A
+N -42 799 M 0 407 D S
+N 7242 799 M 0 407 D S
+1 A
+N -42 1206 M 0 417 D S
+N 7242 1206 M 0 417 D S
+0 A
+N -42 1623 M 0 431 D S
+N 7242 1623 M 0 431 D S
+1 A
+N -42 2054 M 0 448 D S
+N 7242 2054 M 0 448 D S
+0 A
+N -42 2502 M 0 473 D S
+N 7242 2502 M 0 473 D S
+1 A
+N -42 2975 M 0 502 D S
+N 7242 2975 M 0 502 D S
+0 A
+N -42 3477 M 0 541 D S
+N 7242 3477 M 0 541 D S
+1 A
+N -42 4018 M 0 591 D S
+N 7242 4018 M 0 591 D S
+0 A
+N -42 4609 M 0 656 D S
+N 7242 4609 M 0 656 D S
+1 A
+N -42 5265 M 0 745 D S
+N 7242 5265 M 0 745 D S
+0 A
+N -42 6010 M 0 867 D S
+N 7242 6010 M 0 867 D S
+1 A
+N -42 6877 M 0 1049 D S
+N 7242 6877 M 0 1049 D S
+0 A
+N 0 -42 M 400 0 D S
+N 0 7967 M 400 0 D S
+1 A
+N 400 -42 M 400 0 D S
+N 400 7967 M 400 0 D S
+0 A
+N 800 -42 M 400 0 D S
+N 800 7967 M 400 0 D S
+1 A
+N 1200 -42 M 400 0 D S
+N 1200 7967 M 400 0 D S
+0 A
+N 1600 -42 M 400 0 D S
+N 1600 7967 M 400 0 D S
+1 A
+N 2000 -42 M 400 0 D S
+N 2000 7967 M 400 0 D S
+0 A
+N 2400 -42 M 400 0 D S
+N 2400 7967 M 400 0 D S
+1 A
+N 2800 -42 M 400 0 D S
+N 2800 7967 M 400 0 D S
+0 A
+N 3200 -42 M 400 0 D S
+N 3200 7967 M 400 0 D S
+1 A
+N 3600 -42 M 400 0 D S
+N 3600 7967 M 400 0 D S
+0 A
+N 4000 -42 M 400 0 D S
+N 4000 7967 M 400 0 D S
+1 A
+N 4400 -42 M 400 0 D S
+N 4400 7967 M 400 0 D S
+0 A
+N 4800 -42 M 400 0 D S
+N 4800 7967 M 400 0 D S
+1 A
+N 5200 -42 M 400 0 D S
+N 5200 7967 M 400 0 D S
+0 A
+N 5600 -42 M 400 0 D S
+N 5600 7967 M 400 0 D S
+1 A
+N 6000 -42 M 400 0 D S
+N 6000 7967 M 400 0 D S
+0 A
+N 6400 -42 M 400 0 D S
+N 6400 7967 M 400 0 D S
+1 A
+N 6800 -42 M 400 0 D S
+N 6800 7967 M 400 0 D S
+0 A
+8 W
+N -83 0 M 7366 0 D S
+N -83 -83 M 7366 0 D S
+N 7200 -83 M 0 8092 D S
+N 7283 -83 M 0 8092 D S
+N 7283 7926 M -7366 0 D S
+N 7283 8009 M -7366 0 D S
+N 0 8009 M 0 -8092 D S
+N -83 8009 M 0 -8092 D S
+/PSL_H_y 400 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(100°) sh add def
+3600 7926 PSL_H_y add M
+400 F0
+(Rectangle via diagonal) bc Z
+0 -167 M 200 F0
+(0°) tc Z
+1200 -167 M (15°) tc Z
+2400 -167 M (30°) tc Z
+3600 -167 M (45°) tc Z
+4800 -167 M (60°) tc Z
+6000 -167 M (75°) tc Z
+7200 -167 M (90°) tc Z
+-167 0 M (0°) mr Z
+-167 1206 M (15°) mr Z
+-167 2502 M (30°) mr Z
+-167 4018 M (45°) mr Z
+-167 6010 M (60°) mr Z
+clipsave
+0 0 M
+7200 0 D
+0 7926 D
+-7200 0 D
+P
+PSL_clip N
+17 W
+0 1 0 C
+V
+{0 1 1 C} FS
+O1
+/FO {P}!
+1200 398 M
+688 1 D
+112 -1 D
+0 2577 D
+-230 8 D
+-201 2 D
+-15 0 D
+-16 0 D
+-15 -1 D
+-16 0 D
+-15 0 D
+-15 0 D
+-16 0 D
+-15 -1 D
+-16 0 D
+-15 0 D
+-15 -1 D
+-16 0 D
+-15 -1 D
+-16 0 D
+-15 -1 D
+-15 0 D
+-16 -1 D
+-15 0 D
+-15 -1 D
+-16 0 D
+-15 -1 D
+-15 -1 D
+-16 0 D
+-15 -1 D
+P
+FO
+/FO {fs os}!
+FO
+/FO {P}!
+160 2502 M
+174 5 D
+233 1 D
+218 -5 D
+15 -1 D
+0 2107 D
+-136 6 D
+-213 3 D
+-20 -1 D
+-19 0 D
+-19 0 D
+-20 0 D
+-19 -1 D
+-20 0 D
+-19 -1 D
+-19 0 D
+-20 -1 D
+-19 -1 D
+-20 0 D
+-19 -1 D
+-19 -1 D
+-20 -1 D
+-19 -1 D
+P
+FO
+/FO {fs os}!
+FO
+{1 0 0 C} FS
+/FO {P}!
+1200 3906 M
+120 16 D
+191 21 D
+193 15 D
+176 9 D
+213 4 D
+160 -1 D
+195 -7 D
+176 -11 D
+192 -18 D
+207 -25 D
+17 -3 D
+0 703 D
+-153 22 D
+-175 20 D
+-176 15 D
+-178 10 D
+-178 4 D
+-20 0 D
+-20 0 D
+-20 0 D
+-20 0 D
+-20 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-20 -1 D
+-20 0 D
+-20 -1 D
+-19 0 D
+-20 -1 D
+-20 -1 D
+-20 0 D
+-20 -1 D
+-19 -1 D
+-20 -1 D
+-20 -1 D
+-20 -1 D
+-19 -1 D
+-20 -1 D
+-20 -2 D
+-20 -1 D
+-19 -2 D
+-20 -1 D
+-19 -2 D
+-20 -1 D
+-20 -2 D
+-19 -2 D
+-20 -1 D
+-19 -2 D
+-20 -2 D
+-19 -2 D
+-20 -2 D
+-19 -2 D
+-20 -2 D
+-19 -3 D
+-20 -2 D
+-19 -2 D
+-19 -3 D
+-20 -2 D
+-19 -3 D
+-19 -2 D
+-19 -3 D
+-20 -3 D
+-19 -2 D
+-19 -3 D
+-19 -3 D
+-19 -3 D
+P
+FO
+/FO {fs os}!
+FO
+FQ
+83 W
+0 A
+2000 5265 M
+107 19 D
+217 31 D
+153 16 D
+177 14 D
+134 7 D
+223 4 D
+201 -4 D
+156 -8 D
+221 -19 D
+153 -19 D
+151 -22 D
+107 -19 D
+0 1612 D
+-87 17 D
+-176 29 D
+-179 23 D
+-180 17 D
+-151 9 D
+-182 5 D
+-30 0 D
+-30 0 D
+-30 0 D
+-31 -1 D
+-30 0 D
+-30 -1 D
+-31 -1 D
+-30 -1 D
+-30 -1 D
+-31 -2 D
+-30 -1 D
+-30 -2 D
+-30 -2 D
+-30 -2 D
+-30 -3 D
+-30 -2 D
+-31 -3 D
+-30 -3 D
+-29 -3 D
+-30 -3 D
+-30 -3 D
+-30 -4 D
+-30 -4 D
+-30 -4 D
+-29 -4 D
+-30 -4 D
+-29 -4 D
+-30 -5 D
+-29 -5 D
+-29 -5 D
+-30 -5 D
+-29 -5 D
+-29 -5 D
+-29 -6 D
+-29 -6 D
+P S
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R0/90/0/70 -JM6i -O -Ap -Wthin -Glightbrown -SJ+s
+%@PROJ: merc 0.00000000 90.00000000 0.00000000 70.00000000 -5009377.086 5009377.086 -0.000 11028513.631 +proj=merc +lon_0=45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 7926 D
+-7200 0 D
+P
+PSL_clip N
+12 W
+V
+{0.922 0.745 0.333 C} FS
+O1
+/FO {P}!
+4000 2975 M
+2000 0 D
+0 -2577 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+P
+FO
+/FO {fs os}!
+FO
+/FO {P}!
+3360 4609 M
+1440 0 D
+0 -2107 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+-15 0 D
+-14 0 D
+P
+FO
+/FO {fs os}!
+FO
+{1 0 0 C} FS
+/FO {P}!
+7040 4609 M
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+-19 0 D
+-20 0 D
+0 2268 D
+1840 0 D
+P
+FO
+/FO {fs os}!
+FO
+U
+PSL_cliprestore
+%%EndObject
+
+grestore
+PSL_movie_completion /PSL_movie_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/psxy/diagonal.sh
+++ b/test/psxy/diagonal.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+ps=diagonal.ps
+gmt psxy -R0/90/0/70 -JM6i -Wthick,green -Gcyan -Baf -BWSne+t"Rectangle via diagonal" -Sr+s -A -P -K -Xc << EOF > $ps
+15	5	25	35
+2	30	10	50
+> -Gred
+15	44	38	50
+> -G- -W5p,black
+25	55	50	65
+EOF
+gmt psxy -R -J -O -Ap -Wthin -Glightbrown -Sr+s << EOF >> $ps
+50	35	75	5
+42	50	60	30
+> -Gred
+88	50	65	65
+EOF

--- a/test/psxy/diagonal.sh
+++ b/test/psxy/diagonal.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ps=diagonal.ps
-gmt psxy -R0/90/0/70 -JM6i -Wthick,green -Gcyan -Baf -BWSne+t"Rectangle via diagonal" -Sr+s -A -P -K -Xc << EOF > $ps
+gmt psxy -R0/90/0/70 -JM6i -Wthick,green -Gcyan -Baf -BWSne+t"Rectangle via diagonal" -Sr+s -P -K -Xc << EOF > $ps
 15	5	25	35
 2	30	10	50
 > -Gred
@@ -8,7 +8,7 @@ gmt psxy -R0/90/0/70 -JM6i -Wthick,green -Gcyan -Baf -BWSne+t"Rectangle via diag
 > -G- -W5p,black
 25	55	50	65
 EOF
-gmt psxy -R -J -O -Ap -Wthin -Glightbrown -Sr+s << EOF >> $ps
+gmt psxy -R -J -O -A -Wthin -Glightbrown -Sr+s << EOF >> $ps
 50	35	75	5
 42	50	60	30
 > -Gred


### PR DESCRIPTION
It is often desirable to draw a rectangle based on the coordinates of one of the diagonals. Thus, **-Sr+s** will do this and expects

`lon1 lat1 lon2 lat2
`

for points on any diagonal.  It creates a polygon and is thus subject to **-A** as well as **-W -G**.

