### PR TITLE
Do not compile codes and run tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,10 @@ env:
         - PATH="$INSTALLDIR/bin:$PATH"
         - BUILD_DOCS=false
         - DEPLOY_DOCS=false
-        - PACKAGE=false
-        - TEST=false
         - CCACHE_MAXSIZE=200M
         - CCACHE_COMPRESS=true
         # Encrypted Github token (GH_TOKEN)
         - secure: "cwHlTNa+b2lPiCbN5Ja9alj6EkKwJsuR5QcNPORrp3uCOQF9+cJUFEyMIGVGzrzZQnpjn05XYDr6eGFUYkbaR1QVUQdNH+2rCiScFHe94fRPJlJabxXexCfvZCNV8VRi6NSyFPuZKkCVs10bQ7Lk5dPS/V4Dalz1xyURcvI8H8XQFTmDYb/7QFw73l0WzNf+Y1rzNpRZEQ4ERhmnir489njCv1w7oJ0C+BrRvPqTmNmfXbrY6Bcana6BJvvumSY1xRaw60f/UNKYTlTVlYTVSWK1kq9mTfkhiJhe5oNoWchKloiOg3fA2XtAuucuXSdCjqo9aWHMxKJy+jQ7/BeId9hacvB9pVclYoOLARBcPoWDb21eKJZ8A70yKlUM3ryhVXM4drHzM4ITitPA1sEJWNJ2BQO8Cils0FfcOLvBR3NdbLi8RdHZItmU/Oe8o1srUTnnkdPRiEWbmAEs4pVrsHY9sD0660PXTFBSQ7sDXeyTl2etG/YSQKvE3ysOnZwhEuTXqf8cpo+tSbjindvWSyyN0HSuJ0bd7Ei+qWUQ3nJNEtHpiq8Ms6KUPHjPpWO2BEl+FQHWFpmRtwBg/REk36VWIl1UHSKuKkqxUT4qiZeL5zlrHGso+7QGhVjkYj5un3XoVObopFNVUB8y56xeW21gI51HK48cPd5rMnX95KE="
-        # Encrypted codecov token (CODECOV_TOKEN)
-        - secure: "LYeFC3IeHdb8ff5+AfnACUUMIc9KRNIDlbQnRIIx+VPT4AT5XGiwN8PT9VhIFWsU1pJOw8DUdtggQ2kbkal3voF6RDhbYOCn5xzTjJ6D5UOC2JeIBkhx+Cb8lx9qZtVAippVOVsEPxCIGGxhCMy5+Dczib+4pA/zyKuU3l9DqSdsBlgZWJ2o+qyAltSa6JX3kvMCDl7ahR/d/IZqDxKvsyljuYq/WqhflTa1JjTfNYXyvE2w/Ml74ui6RdqX1ign3wWzO3P4nmdE+i3m6x9jlG6KIqTRd3pK2871zERNpeSTRXoQL7GpDbF9LWXPig3vLwWbeW09CEt4ZaoaP/J0JbXHN/mC5668RrVphZdVQmwQ+RCjGBXK/0zQ5/hpF4XmcCcef4sQGIm03v58KqQ0MDNhBwr+PkA1OGKTM82xEL5dzdo5+sPxm9W/rPwWnB8/FwKcheBfacGbhJ2Vv75XlqrZdIdslS4hLGHFy5jBddSMWCokDDd8KtJyWBlI/FKVjAjk7X/YFGFzyQCw3e/p6A511Yk5QF0sm5qnbhVB6b5BoW1R2D5FhLdIXZuCOJD5sfQ2BLcq7UpXRIW/KkV0XUQjv8YoM/K6Kljh2uDBT9CRfWf4Nko5ClhD0pk+uMTZ9S/tS8blL9BZJrH3Atolq+oeoEMI2eJuWepav9GcqYk="
 
 # We need sudo privileges for copying cached deb packages
 sudo: required
@@ -49,23 +45,13 @@ dist: xenial
 # Create the build matrix with different jobs for each platform and cron jobs
 matrix:
     include:
-        - name: "Linux (compile only)"
-          os: linux
-          if: type != cron
-        - name: "Linux (cron - test)"
-          os: linux
-          if: type = cron
-          env:
-            - TEST="true"
-        # Only build the docs on Linux cron jobs
-        - name: "Linux (cron - build docs + package)"
+        - name: "Linux (cron - build docs)"
           os: linux
           if: type = cron
           env:
             - BUILD_DOCS=true
             - DEPLOY_DOCS=true
             - HTML_BUILDDIR="build/doc/rst/html"
-            - PACKAGE=true
 
 # Setup the build environment
 before_install:
@@ -74,8 +60,8 @@ before_install:
         # Download dependencies if not cached (https://stackoverflow.com/a/52446551)
         DEB_CACHE=$HOME/cache-deb
         DEB_PACKAGES="cmake ninja-build libcurl4-gnutls-dev libnetcdf-dev libgdal-dev libfftw3-dev libpcre3-dev liblapack-dev ghostscript curl"
-        if [[ "$TEST" == "true" || "$BUILD_DOCS" == "true" ]]; then
-          DEB_PACKAGES="$DEB_PACKAGES gdal-bin graphicsmagick ffmpeg python python-pip"
+        if [[ "$BUILD_DOCS" == "true" ]]; then
+          DEB_PACKAGES="$DEB_PACKAGES graphicsmagick ffmpeg python python-pip"
         fi
         test -d $DEB_CACHE || mkdir $DEB_CACHE
         echo "Copy cached deb packages"
@@ -107,17 +93,6 @@ script:
     - gmt defaults -Vd
     - gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
     - gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
-    # Download remote files before testing, see #939.
-    - if [[ "$TEST" == "true" ]]; then
-        curl http://www.soest.hawaii.edu/gmt/data/gmt_md5_server.txt | awk 'NF==3 && $1!~/earth/ {print "@"$1}' | xargs gmt which -Gc;
-        gmt which -Gu @earth_relief_01m @earth_relief_02m @earth_relief_04m @earth_relief_05m @earth_relief_10m @earth_relief_15m;
-        ctest --output-on-failure --force-new-ctest-process -j4;
-      fi
-    # Upload test coverage even if build fails. Keep separate to make sure this task
-    # fails if the tests fail.
-    - if [[ "$TEST" == "true" ]]; then
-        bash <(curl -s https://codecov.io/bash);
-      fi
     # Use set -e so that the build fails when a command fails.
     # The default action for Travis-CI is to continue running even if a command fails.
     - set -e
@@ -131,11 +106,6 @@ script:
         cmake --build . --target docs_man;
       fi
     # Make source tarballs
-    - if [[ "$PACKAGE" == "true" ]]; then
-        cmake --build . --target gmt_release;
-        cmake --build . --target gmt_release_tar;
-        md5sum gmt-*.tar gmt-*.tar.gz gmt-*.tar.xz;
-      fi
     - set +e
     - cd ..
 


### PR DESCRIPTION
We now run Linux CI builds in Azure Pipelines, thus no need to have the same CI builds in Travis CI. The only job in Travis CI is to build and deploy documentations nightly.