### PR TITLE
Make sure internal subplot structure set active to false during subplot end

### DIFF
--- a/src/subplot.c
+++ b/src/subplot.c
@@ -1117,7 +1117,7 @@ int GMT_subplot (void *V_API, int mode, void *args) {
 		}
 		API->GMT->current.map.width  = P->dim[GMT_X];
 		API->GMT->current.map.height = P->dim[GMT_Y];
-		P->active = 0;
+		P->active = 0;	/* Ensure subplot mode is terminated */
 		
 		if ((k = gmt_set_psfilename (GMT)) == GMT_NOTSET) {	/* Get hidden file name for PS */
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "No workflow directory\n");

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -1117,6 +1117,7 @@ int GMT_subplot (void *V_API, int mode, void *args) {
 		}
 		API->GMT->current.map.width  = P->dim[GMT_X];
 		API->GMT->current.map.height = P->dim[GMT_Y];
+		P->active = 0;
 		
 		if ((k = gmt_set_psfilename (GMT)) == GMT_NOTSET) {	/* Get hidden file name for PS */
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "No workflow directory\n");


### PR DESCRIPTION
The debug lines drawn by _subplot end_ suddenly started to change and it was because I had (somewhere) not set P->active to 0 before calling _psxy_, so it auto-scaled the projection to fit the last panel.  This fixes that part but #1320 is still not fixed.  Still working on that part.

