### PR TITLE
Fix bugs in gmt_get_modifier()

### DIFF
--- a/src/common_string.c
+++ b/src/common_string.c
@@ -231,19 +231,17 @@ unsigned int gmt_get_modifier (const char *string, char modifier, char *token) {
 	if (!string || string[0] == 0) return 0;	/* No hope */
 	len = strlen (string);
 	for (k = 0; start == 0 && k < (len-1); k++) {
-		if (string[k] == '\"') quoted = !quoted;	/* Initially false, becomes true at start of quote, then false when exit quote */
+		if (string[k] == '\"' || string[k] == '\'') quoted = !quoted;	/* Initially false, becomes true at start of quote, then false when exit quote */
 		if (quoted) continue;		/* Not look inside quoted strings */
 		if (string[k] == '+' && string[k+1] == modifier)	/* Found the start */
 			start = k+2;
 	}
 	if (start == 0) return 0;	/* Not found */
-	k = start;
-	while (k < len) {
-		if (string[k] == '\"') quoted = !quoted;	/* Initially false, becomes true at start of quote, then false when exit quote */
+	for (k = start; k < len; k++) {
+		if (string[k] == '\"' || string[k] == '\'') quoted = !quoted;	/* Initially false, becomes true at start of quote, then false when exit quote */
 		if (quoted) continue;	/* Not look inside quoted strings */
 		if (string[k] == '+')	/* Found the end */
 			break;
-		k++;
 	}
 	len = k - start;
 	if (token) {	/* Only pass back when token is not NULL */


### PR DESCRIPTION
There are two bugs in gmt_get_modifier():

1. Does not check if a modifier is inside single quotes
2. In the while loop, doesn't increase `k` if a quote is found

A small C function to reproduce the bugs:
```c
int main () {
    char string[160], token[80];
    strcpy (string, "+gblue+o5p/5p+jTL+t'text with space'+l\"text with +ered modifier\"+h'text +byellow modifier'");

    gmt_get_modifier (string, 'l', token);
    fprintf(stderr, "%s\n", token);

    gmt_get_modifier (string, 'h', token);
    fprintf(stderr, "%s\n", token);
}
```

Output with the old code:
```
"text with
'text
```

Output after apply the patch:
```
"text with +ered modifier"
'text +byellow modifier'
```