### PR TITLE
Fix error in computing space bewteen subplots due to ticks

### DIFF
--- a/src/subplot.c
+++ b/src/subplot.c
@@ -715,20 +715,17 @@ int GMT_subplot (void *V_API, int mode, void *args) {
 		}
 		GMT_Report (API, GMT_MSG_DEBUG, "Subplot: After correcting for inside panel margins: fluff = {%g, %g}\n", fluff[GMT_X], fluff[GMT_Y]);
 
-		/* ROW SETTINGS:  Limit tickmarks to 1 or 2 axes per row or per panel */
+		/* ROW SETTINGS:  Limit tickmarks to 1 or 2 W/E axes per row or per panel */
+		/* Note: Usually, we will tick both the west and east side of a panel.  With -SR in effect
+		 * we will have selected either the left, right, or both end sides (i.e., the two outer panels).
+		 * However, this can be overridden by selecting "l" and/or "r" in the general -B string which controls
+		 * all the axes not implicitly handled by -SR.  Hence, we assume two sides of ticks will need space
+		 * but override if users have turned any of those sides off with l or r */
 
-		nx = 0;
-		if (Ctrl->S[GMT_Y].tick) {	/* Used -SR so must check the settings */
-			if ((Ctrl->S[GMT_Y].tick & SUBPLOT_PLACE_AT_MIN) && !strchr (Ctrl->S[GMT_Y].axes, 'l')) nx++;
-			if ((Ctrl->S[GMT_Y].tick & SUBPLOT_PLACE_AT_MAX) && !strchr (Ctrl->S[GMT_Y].axes, 'r')) nx++;
-		}
-		else {	/* Must see what -B specified instead since that will apply to all panels */
-			if (strchr (Ctrl->S[GMT_Y].axes, 'W') || strchr (Ctrl->S[GMT_Y].axes, 'w')) nx++;	/* All panels need west ticks */
-			if (strchr (Ctrl->S[GMT_Y].axes, 'E') || strchr (Ctrl->S[GMT_Y].axes, 'e')) nx++;	/* All panels need east ticks */
-		}
-		factor = (Ctrl->S[GMT_Y].active) ? 2 : Ctrl->N.dim[GMT_X];	/* Either just one or each row may need separate x-axis ticks */
-		nx *= (factor - 1);
-		fluff[GMT_X] += nx * tick_height;
+		nx = 2;	/* Default is ticks on both W and E */
+		if (strchr (Ctrl->S[GMT_Y].axes, 'l')) nx--;	/* But not on the west (left) side */
+		if (strchr (Ctrl->S[GMT_Y].axes, 'r')) nx--;	/* But not on the east (right) side */
+		fluff[GMT_X] += (Ctrl->N.dim[GMT_X] - 1) * nx * tick_height;
 		GMT_Report (API, GMT_MSG_DEBUG, "Subplot: After %d rows of map ticks: fluff = {%g, %g}\n", nx, fluff[GMT_X], fluff[GMT_Y]);
 		/* Limit annotations/labels to 1 or 2 axes per row or per panel */
 		if (Ctrl->S[GMT_Y].annotate)	/* Used -SR so check settings */
@@ -748,25 +745,17 @@ int GMT_subplot (void *V_API, int mode, void *args) {
 		GMT_Report (API, GMT_MSG_DEBUG, "Subplot: After %d row labels: fluff = {%g, %g}\n", nx, fluff[GMT_X], fluff[GMT_Y]);
 
 		/* COLUMN SETTINGS: Limit annotations/labels to 1 or 2 axes per column or per panel */
+		/* Note: Usually, we will tick both the south and north side of a panel.  With -SC in effect
+		 * we will have selected either the bottom, top, or both end sides (i.e., the two outer panels).
+		 * However, this can be overridden by selecting "b" and/or "t" in the general -B string which controls
+		 * all the axes not implicitly handled by -SC.  Hence, we assume two sides of ticks will need space
+		 * but override if users have turned any of those sides off with b or t */
 
-		ny = 0;
-		if (Ctrl->S[GMT_X].tick) {	/* Gave -SC so check settings */
-			if ((Ctrl->S[GMT_X].tick & SUBPLOT_PLACE_AT_MIN) && !strchr (Ctrl->S[GMT_X].axes, 'b')) ny++;
-			if ((Ctrl->S[GMT_X].tick & SUBPLOT_PLACE_AT_MAX)) {
-				if (!strchr (Ctrl->S[GMT_X].axes, 't')) ny++;
-				y_header_off += tick_height + annot_height;
-			}
-		}
-		else {	/* Must see what -B specified instead since that will apply to all panels */
-			if (strchr (Ctrl->S[GMT_X].axes, 'S') || strchr (Ctrl->S[GMT_X].axes, 's')) ny++;	/* All panels need south ticks */
-			if (strchr (Ctrl->S[GMT_X].axes, 'N') || strchr (Ctrl->S[GMT_X].axes, 'n')) {
-				ny++;	/* All panels need north ticks */
-				y_header_off += tick_height;
-			}
-		}
-		factor = (Ctrl->S[GMT_X].active) ? 2 : Ctrl->N.dim[GMT_Y];	/* Each row may need separate x-axis ticks */
-		ny *= (factor - 1);
-		fluff[GMT_Y] += ny * tick_height;
+		ny = 2;	/* Default is ticks on both S and N */
+		if (strchr (Ctrl->S[GMT_Y].axes, 'b')) ny--;	/* But not on the south (bottom) side */
+		if (strchr (Ctrl->S[GMT_Y].axes, 't')) ny--;	/* But not on the north (top) side */
+		else y_header_off += tick_height;
+		fluff[GMT_Y] += (Ctrl->N.dim[GMT_Y] - 1) * ny * tick_height;
 		GMT_Report (API, GMT_MSG_DEBUG, "Subplot: After %d col ticks: fluff = {%g, %g}\n", ny, fluff[GMT_X], fluff[GMT_Y]);
 		if (Ctrl->S[GMT_X].annotate) {	/* Gave -SC so check settings */
 			ny = 0;	/* For -Sc there are no internal annotations, only ticks */

--- a/test/exmod/ex01.ps
+++ b/test/exmod/ex01.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from pstext
+%%Title: GMT v6.0.0_9cdd6e8-dirty_2019.08.08 [64-bit] Document from pstext
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:51:12 2018
+%%CreationDate: Thu Aug  8 10:52:10 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -336,9 +336,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +592,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +635,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -672,14 +667,14 @@ O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -R0/6.5/0/7 -Jx1i -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
-%@PROJ: xy 0.00000000 6.50000000 0.00000000 7.00000000 0.000 6.500 0.000 7.000 +xy
-%GMTBoundingBox: 72 72 468 504
+%@GMT: gmt pstext -R0/6.5/0/7.13889 -Jx1i -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 6.50000000 0.00000000 7.13889000 0.000 6.500 0.000 7.139 +xy
+%GMTBoundingBox: 72 72 468 514
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-3900 9000 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+3900 9250 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 533 F0
 (Low Order Geoid) bc Z
 %%EndObject
@@ -687,10 +682,10 @@ PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 4500 TM
+0 4667 TM
 
 % PostScript produced by:
-%@GMT: gmt pscoast -Glightbrown -Slightblue -Blrtb -Bxafg -Byafg -Xa0i -Ya3.75i -Rg -JH0/6.5i
+%@GMT: gmt pscoast -Glightbrown -Slightblue -Blrtb -Bxafg -Byafg -Xa0i -Ya3.8889i -Rg -JH0/6.5i
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -698,8 +693,8 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-0 4500 T
-67 3833 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 4667 T
+0 A 67 3833 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (a\)) tl Z
 U
@@ -24753,15 +24748,16 @@ P
 137 -4 D
 167 -2 D
 P S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 %%EndObject
-0 -4500 TM
+0 -4667 TM
 0 A
 FQ
 O0
-0 4500 TM
+0 4667 TM
 
 % PostScript produced by:
-%@GMT: gmt grdcontour @osu91a1f_16.nc -C10 -A50+f7p -Gd4i -Ln -Wcthinnest,- -Wathin,- -T+d0.1i/0.02i -Xa0i -Ya3.75i -Rg -JH0/6.5i
+%@GMT: gmt grdcontour @osu91a1f_16.nc -C10 -A50+f7p -Gd4i -Ln -Wcthinnest,- -Wathin,- -T+d0.1i/0.02i -Xa0i -Ya3.8889i -Rg -JH0/6.5i
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -27543,14 +27539,14 @@ U
 PSL_cliprestore
 %%EndObject
 [] 0 B
-0 -4500 TM
+0 -4667 TM
 0 A
 FQ
 O0
-0 4500 TM
+0 4667 TM
 
 % PostScript produced by:
-%@GMT: gmt grdcontour osu91a1f_16.nc -C10 -A50+f7p -Gd4i -LP -T+d0.1i/0.02i+l -Xa0i -Ya3.75i -Rg -JH0/6.5i
+%@GMT: gmt grdcontour osu91a1f_16.nc -C10 -A50+f7p -Gd4i -LP -T+d0.1i/0.02i+l -Xa0i -Ya3.8889i -Rg -JH0/6.5i
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -30628,15 +30624,15 @@ U
 [] 0 B
 PSL_cliprestore
 %%EndObject
-0 -4500 TM
+0 -4667 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 0 TM
+0 167 TM
 
 % PostScript produced by:
-%@GMT: gmt pscoast -Glightbrown -Slightblue -Blrtb -Bxafg -Byafg -Xa0i -Ya0i -Rg -JH0/6.5i
+%@GMT: gmt pscoast -Glightbrown -Slightblue -Blrtb -Bxafg -Byafg -Xa0i -Ya0.1389i -Rg -JH0/6.5i
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_5
 0 setlinecap
@@ -30644,7 +30640,8 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-67 3833 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 167 T
+0 A 67 3833 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (b\)) tl Z
 U
@@ -54698,15 +54695,16 @@ P
 137 -4 D
 167 -2 D
 P S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 %%EndObject
-0 0 TM
+0 -167 TM
 0 A
 FQ
 O0
-0 0 TM
+0 167 TM
 
 % PostScript produced by:
-%@GMT: gmt grdcontour osu91a1f_16.nc -C10 -A50+f7p -Gd4i -Ln -Wcthinnest,- -Wathin,- -T+d0.1i/0.02i+l -Xa0i -Ya0i -Rg -JH0/6.5i
+%@GMT: gmt grdcontour osu91a1f_16.nc -C10 -A50+f7p -Gd4i -Ln -Wcthinnest,- -Wathin,- -T+d0.1i/0.02i+l -Xa0i -Ya0.1389i -Rg -JH0/6.5i
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_6
 0 setlinecap
@@ -57496,14 +57494,14 @@ U
 PSL_cliprestore
 %%EndObject
 [] 0 B
-0 0 TM
+0 -167 TM
 0 A
 FQ
 O0
-0 0 TM
+0 167 TM
 
 % PostScript produced by:
-%@GMT: gmt grdcontour osu91a1f_16.nc -C10 -A50+f7p -Gd4i -LP -T+d0.1i/0.02i+l -Xa0i -Ya0i -Rg -JH0/6.5i
+%@GMT: gmt grdcontour osu91a1f_16.nc -C10 -A50+f7p -Gd4i -LP -T+d0.1i/0.02i+l -Xa0i -Ya0.1389i -Rg -JH0/6.5i
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_7
 0 setlinecap
@@ -60581,7 +60579,7 @@ U
 [] 0 B
 PSL_cliprestore
 %%EndObject
-0 0 TM
+0 -167 TM
 PSL_completion /PSL_completion {} def
 
 grestore

--- a/test/exmod/ex03.ps
+++ b/test/exmod/ex03.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_831abca_2019.06.27 [64-bit] Document from pstext
+%%Title: GMT v6.0.0_9cdd6e8-dirty_2019.08.08 [64-bit] Document from pstext
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Jun 27 12:16:20 2019
+%%CreationDate: Thu Aug  8 10:52:10 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -667,14 +667,14 @@ O0
 2400 1800 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -R0/4/0/7.76944 -Jx1i -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr2i -Yr1.5i --GMT_HISTORY=false
-%@PROJ: xy 0.00000000 4.00000000 0.00000000 7.76944000 0.000 4.000 0.000 7.769 +xy
-%GMTBoundingBox: 144 108 288 559.4
+%@GMT: gmt pstext -R0/4/0/7.83889 -Jx1i -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr2i -Yr1.5i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 4.00000000 0.00000000 7.83889000 0.000 4.000 0.000 7.839 +xy
+%GMTBoundingBox: 144 108 288 564.4
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-2400 9743 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+2400 9910 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 533 F0
 (Ship and Satellite Gravity) bc Z
 %%EndObject
@@ -682,10 +682,10 @@ PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 4823 TM
+0 4907 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy spectrum.xpower -JX-4il/3.75il -Bxa1f3p '-Bya1f3p+lPower (mGal@+2@+km)' -Gred -ST0.07i -R1/1000/0.1/10000 -Ey+p0.5p -BWens+g240/255/240 -Xa0i -Ya4.0194i
+%@GMT: gmt psxy spectrum.xpower -JX-4il/3.75il -Bxa1f3p '-Bya1f3p+lPower (mGal@+2@+km)' -Gred -ST0.07i -R1/1000/0.1/10000 -Ey+p0.5p -BWens+g240/255/240 -Xa0i -Ya4.0889i
 %@PROJ: xy 1.00000000 1000.00000000 0.10000000 10000.00000000 3.000 -0.000 -1.000 4.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -693,9 +693,9 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-0 4823 T
+0 4907 T
 PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
-4680 4380 M 300 F1
+0 A 4680 4380 M 300 F1
 (Input Power) tr Z
 U
 }!
@@ -1686,14 +1686,14 @@ N 4260 113 M 117 0 D S
 U
 PSL_cliprestore
 %%EndObject
-0 -4823 TM
+0 -4907 TM
 0 A
 FQ
 O0
-0 4823 TM
+0 4907 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy spectrum.ypower -Gblue -Sc0.07i -Ey+p0.5p -Xa0i -Ya4.0194i -R1/1000/0.1/10000 -JX-4il/3.75il
+%@GMT: gmt psxy spectrum.ypower -Gblue -Sc0.07i -Ey+p0.5p -Xa0i -Ya4.0889i -R1/1000/0.1/10000 -JX-4il/3.75il
 %@PROJ: xy 1.00000000 1000.00000000 0.10000000 10000.00000000 3.000 -0.000 -1.000 4.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -1832,14 +1832,14 @@ N 3004 284 M 117 0 D S
 U
 PSL_cliprestore
 %%EndObject
-0 -4823 TM
+0 -4907 TM
 0 A
 FQ
 O0
-0 4823 TM
+0 4907 TM
 
 % PostScript produced by:
-%@GMT: gmt pslegend -DjBL+w1.2i+o0.25i -F+gwhite+pthicker --FONT_ANNOT_PRIMARY=14p,Helvetica-Bold -Xa0i -Ya4.0194i
+%@GMT: gmt pslegend -DjBL+w1.2i+o0.25i -F+gwhite+pthicker --FONT_ANNOT_PRIMARY=14p,Helvetica-Bold -Xa0i -Ya4.0889i
 %@PROJ: xy 1.00000000 1000.00000000 0.10000000 10000.00000000 3.000 -0.000 -1.000 4.000 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -1893,15 +1893,15 @@ PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold P
 0 0 TM
 -300 -300 T
 %%EndObject
-0 -4823 TM
+0 -4907 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 -83 TM
+0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy spectrum.coh -JX-4il/3.75i '-Bxa1f3p+lWavelength (km)' -Bya0.25f0.05+lCoherency@+2@+ -R1/1000/0/1 -Sc0.07i -Gpurple -Ey+p0.5p -BWenS+g240/255/240 -Xa0i -Ya-0.0694i
+%@GMT: gmt psxy spectrum.coh -JX-4il/3.75i '-Bxa1f3p+lWavelength (km)' -Bya0.25f0.05+lCoherency@+2@+ -R1/1000/0/1 -Sc0.07i -Gpurple -Ey+p0.5p -BWenS+g240/255/240 -Xa0i -Ya0i
 %@PROJ: xy 1.00000000 1000.00000000 0.00000000 1.00000000 3.000 -0.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_7
 0 setlinecap
@@ -1909,9 +1909,8 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-0 -83 T
 PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
-4680 4380 M 300 F1
+0 A 4680 4380 M 300 F1
 V MU 0 0 M (Coherency) FP 0 105 G 210 F1 (2) FP 0 -105 G pathbbox N 4 1 roll exch pop add exch U neg exch neg exch G
 (Coherency) Z
 0 105 G 210 F1 (2) Z
@@ -2889,7 +2888,7 @@ N 4260 1891 M 117 0 D S
 U
 PSL_cliprestore
 %%EndObject
-0 83 TM
+0 0 TM
 PSL_completion /PSL_completion {} def
 
 grestore

--- a/test/exmod/ex12.ps
+++ b/test/exmod/ex12.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612 792             
-%%Title: GMT v6.0.0_r19351M [64-bit] Document from pstext
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_9cdd6e8-dirty_2019.08.08 [64-bit] Document from pstext
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Nov 20 17:59:34 2017
+%%CreationDate: Thu Aug  8 10:52:11 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -658,19 +658,23 @@ V 0.06 0.06 scale
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_completion {} def
+/PSL_movie_completion {} def
+%PSL_End_Header
+gsave
 0 A
 FQ
 O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: pstext -R0/6.16944/0/6.35406 -Jx1i -P -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
-%@PROJ: xy 0.00000000 6.16944000 0.00000000 6.35406000 0.000 6.169 0.000 6.354 +xy
+%@GMT: gmt pstext -R0/6.23889/0/6.4235 -Jx1i -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 6.23889000 0.00000000 6.42350000 0.000 6.239 0.000 6.423 +xy
+%GMTBoundingBox: 72 72 449.2 462.492
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-3702 7985 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+3743 8152 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 533 F0
 (Delaunay Triangulation) bc Z
 %%EndObject
@@ -678,430 +682,15 @@ PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 3914 TM
+0 3997 TM
 
 % PostScript produced by:
-%@GMT: psxy net.xy -Wthinner -P -BWens -Bxaf -Byaf -Xa0i -Ya3.2618i -R0/6.5/-0.2/6.5 -Jx3i
+%@GMT: gmt psxy net.xy -Wthinner -BWens -Bxaf -Byaf -Xa0i -Ya3.3312i -R0/6.5/-0.2/6.5 -Jx3i
 %@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-8 W
-166 3489 M
-609 56 D
-S
-166 3489 M
-720 -498 D
-S
-166 3489 M
--55 -997 D
-S
-775 3545 M
-554 -56 D
-S
-775 3545 M
-1219 0 D
-S
-775 3545 M
-111 -554 D
-S
-1329 3489 M
-665 56 D
-S
-1329 3489 M
--443 -498 D
-S
-1329 3489 M
-277 -554 D
-S
-1329 3489 M
-554 -221 D
-S
-1329 3489 M
--55 -720 D
-S
-1994 3545 M
-1163 0 D
-S
-1994 3545 M
--111 -277 D
-S
-1994 3545 M
-664 -333 D
-S
-1994 3545 M
-0 -111 D
-S
-3157 3545 M
--499 -333 D
-S
-3157 3545 M
--222 -665 D
-S
-3157 3545 M
-277 -554 D
-S
-886 2991 M
--775 -499 D
-S
-886 2991 M
--388 -554 D
-S
-886 2991 M
-388 -222 D
-S
-886 2991 M
-56 -776 D
-S
-1606 2935 M
-277 111 D
-S
-1606 2935 M
-277 333 D
-S
-1606 2935 M
--332 -166 D
-S
-1606 2935 M
--221 -332 D
-S
-1606 2935 M
-56 -332 D
-S
-1606 2935 M
-332 -332 D
-S
-1883 3046 M
-0 222 D
-S
-1883 3046 M
-775 166 D
-S
-1883 3046 M
-55 -443 D
-S
-1883 3046 M
-388 -388 D
-S
-1883 3046 M
-111 388 D
-S
-1883 3268 M
-111 166 D
-S
-2658 3212 M
-277 -332 D
-S
-2658 3212 M
--387 -554 D
-S
-2658 3212 M
--664 222 D
-S
-2935 2880 M
-499 111 D
-S
-2935 2880 M
--664 -222 D
-S
-2935 2880 M
--221 -443 D
-S
-2935 2880 M
-554 -388 D
-S
-3434 2991 M
-55 -499 D
-S
-111 2492 M
-387 -55 D
-S
-111 2492 M
-387 -609 D
-S
-111 2492 M
-55 -1052 D
-S
-498 2437 M
-0 -554 D
-S
-498 2437 M
-444 -222 D
-S
-1274 2769 M
-111 -166 D
-S
-1274 2769 M
--332 -554 D
-S
-1385 2603 M
-277 0 D
-S
-1385 2603 M
--443 -388 D
-S
-1385 2603 M
--56 -388 D
-S
-1662 2603 M
-276 0 D
-S
-1662 2603 M
--333 -388 D
-S
-1662 2603 M
-387 -554 D
-S
-1938 2603 M
-333 55 D
-S
-1938 2603 M
-111 -554 D
-S
-2271 2658 M
-443 -221 D
-S
-2271 2658 M
--222 -609 D
-S
-2714 2437 M
-775 55 D
-S
-2714 2437 M
--665 -388 D
-S
-2714 2437 M
--222 -554 D
-S
-2714 2437 M
-166 -554 D
-S
-3489 2492 M
--609 -609 D
-S
-3489 2492 M
-0 -498 D
-S
-498 1883 M
-444 332 D
-S
-498 1883 M
--332 -443 D
-S
-498 1883 M
-610 -277 D
-S
-498 1883 M
-333 -775 D
-S
-942 2215 M
-387 0 D
-S
-942 2215 M
-166 -609 D
-S
-1329 2215 M
-720 -166 D
-S
-1329 2215 M
--221 -609 D
-S
-2049 2049 M
-443 -166 D
-S
-2049 2049 M
--941 -443 D
-S
-2049 2049 M
-56 -664 D
-S
-2492 1883 M
-388 0 D
-S
-2492 1883 M
--387 -498 D
-S
-2492 1883 M
-0 -775 D
-S
-2880 1883 M
-609 111 D
-S
-2880 1883 M
--388 -775 D
-S
-2880 1883 M
-166 -831 D
-S
-2880 1883 M
-277 -111 D
-S
-3489 1994 M
-0 -665 D
-S
-3489 1994 M
--332 -222 D
-S
-166 1440 M
-166 -388 D
-S
-166 1440 M
-665 -332 D
-S
-166 1440 M
-56 -1052 D
-S
-1108 1606 M
-997 -221 D
-S
-1108 1606 M
--277 -498 D
-S
-1108 1606 M
-55 -498 D
-S
-2105 1385 M
--942 -277 D
-S
-2105 1385 M
--388 -665 D
-S
-2105 1385 M
-387 -277 D
-S
-3489 1329 M
--443 -277 D
-S
-3489 1329 M
--55 -664 D
-S
-3489 1329 M
--332 443 D
-S
-332 1052 M
-499 56 D
-S
-332 1052 M
--110 -664 D
-S
-332 1052 M
-443 -609 D
-S
-831 1108 M
-332 0 D
-S
-831 1108 M
-332 -388 D
-S
-831 1108 M
--56 -665 D
-S
-1163 1108 M
-0 -388 D
-S
-1163 1108 M
-554 -388 D
-S
-1163 720 M
-554 0 D
-S
-1163 720 M
--388 -277 D
-S
-1163 720 M
-0 -222 D
-S
-1717 720 M
-775 388 D
-S
-1717 720 M
--554 -222 D
-S
-1717 720 M
--443 -443 D
-S
-1717 720 M
-0 -609 D
-S
-1717 720 M
-554 -166 D
-S
-2492 1108 M
-554 -56 D
-S
-2492 1108 M
-665 -443 D
-S
-2492 1108 M
--221 -554 D
-S
-3046 1052 M
-111 -387 D
-S
-3046 1052 M
-388 -387 D
-S
-3046 1052 M
-111 720 D
-S
-3157 665 M
-277 0 D
-S
-3157 665 M
--886 -111 D
-S
-3157 665 M
--166 -333 D
-S
-3157 665 M
-166 -499 D
-S
-3434 665 M
--111 -499 D
-S
-222 388 M
-553 55 D
-S
-222 388 M
-553 -222 D
-S
-775 443 M
-0 -277 D
-S
-775 443 M
-388 55 D
-S
-775 166 M
-388 332 D
-S
-775 166 M
-499 111 D
-S
-775 166 M
-942 -55 D
-S
-1163 498 M
-111 -221 D
-S
-1274 277 M
-443 -166 D
-S
-1717 111 M
-554 443 D
-S
-1717 111 M
-1274 221 D
-S
-1717 111 M
-1606 55 D
-S
-2271 554 M
-720 -222 D
-S
-2991 332 M
-332 -166 D
-S
 25 W
 2 setlinecap
 N 0 3711 M 0 -3711 D S
@@ -1179,20 +768,6 @@ N 2769 0 M 0 42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 -3711 T
 0 setlinecap
-%%EndObject
-0 -3914 TM
-0 A
-FQ
-O0
-0 3914 TM
-
-% PostScript produced by:
-%@GMT: psxy @Table_5_11.txt -Sc0.12i -Gwhite -Wthinnest -Xa0i -Ya3.2618i -R0/6.5/-0.2/6.5 -Jx3i
-%@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
-%%BeginObject PSL_Layer_3
-0 setlinecap
-0 setlinejoin
-3.32551 setmiterlimit
 clipsave
 0 0 M
 3600 0 D
@@ -1200,156 +775,6 @@ clipsave
 -3600 0 D
 P
 PSL_clip N
-4 W
-V
-{1 A} FS
-O1
-72 166 3489 Sc
-72 775 3545 Sc
-72 1329 3489 Sc
-72 1994 3545 Sc
-72 3157 3545 Sc
-72 886 2991 Sc
-72 1606 2935 Sc
-72 1883 3046 Sc
-72 1883 3268 Sc
-72 2658 3212 Sc
-72 2935 2880 Sc
-72 3434 2991 Sc
-72 111 2492 Sc
-72 498 2437 Sc
-72 1274 2769 Sc
-72 1385 2603 Sc
-72 1662 2603 Sc
-72 1938 2603 Sc
-72 2271 2658 Sc
-72 2714 2437 Sc
-72 3489 2492 Sc
-72 498 1883 Sc
-72 942 2215 Sc
-72 1329 2215 Sc
-72 2049 2049 Sc
-72 2492 1883 Sc
-72 2880 1883 Sc
-72 3489 1994 Sc
-72 166 1440 Sc
-72 1108 1606 Sc
-72 2105 1385 Sc
-72 3489 1329 Sc
-72 332 1052 Sc
-72 831 1108 Sc
-72 1163 1108 Sc
-72 1163 720 Sc
-72 1717 720 Sc
-72 2492 1108 Sc
-72 3046 1052 Sc
-72 3157 665 Sc
-72 3434 665 Sc
-72 222 388 Sc
-72 775 443 Sc
-72 775 166 Sc
-72 1163 498 Sc
-72 1274 277 Sc
-72 1717 111 Sc
-72 2271 554 Sc
-72 2991 332 Sc
-72 3323 166 Sc
-72 3157 1772 Sc
-72 1994 3434 Sc
-U
-PSL_cliprestore
-%%EndObject
-0 -3914 TM
-0 A
-FQ
-O0
-0 3914 TM
-
-% PostScript produced by:
-%@GMT: pstext @Table_5_11.txt -F+f6p+r -Xa0i -Ya3.2618i -R0/6.5/-0.2/6.5 -Jx3i
-%@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
-%%BeginObject PSL_Layer_4
-0 setlinecap
-0 setlinejoin
-3.32551 setmiterlimit
-clipsave
-0 0 M
-3600 0 D
-0 3711 D
--3600 0 D
-P
-PSL_clip N
-166 3489 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-100 F0
-(0) mc Z
-775 3545 M (1) mc Z
-1329 3489 M (2) mc Z
-1994 3545 M (3) mc Z
-3157 3545 M (4) mc Z
-886 2991 M (5) mc Z
-1606 2935 M (6) mc Z
-1883 3046 M (7) mc Z
-1883 3268 M (8) mc Z
-2658 3212 M (9) mc Z
-2935 2880 M (10) mc Z
-3434 2991 M (11) mc Z
-111 2492 M (12) mc Z
-498 2437 M (13) mc Z
-1274 2769 M (14) mc Z
-1385 2603 M (15) mc Z
-1662 2603 M (16) mc Z
-1938 2603 M (17) mc Z
-2271 2658 M (18) mc Z
-2714 2437 M (19) mc Z
-3489 2492 M (20) mc Z
-498 1883 M (21) mc Z
-942 2215 M (22) mc Z
-1329 2215 M (23) mc Z
-2049 2049 M (24) mc Z
-2492 1883 M (25) mc Z
-2880 1883 M (26) mc Z
-3489 1994 M (27) mc Z
-166 1440 M (28) mc Z
-1108 1606 M (29) mc Z
-2105 1385 M (30) mc Z
-3489 1329 M (31) mc Z
-332 1052 M (32) mc Z
-831 1108 M (33) mc Z
-1163 1108 M (34) mc Z
-1163 720 M (35) mc Z
-1717 720 M (36) mc Z
-2492 1108 M (37) mc Z
-3046 1052 M (38) mc Z
-3157 665 M (39) mc Z
-3434 665 M (40) mc Z
-222 388 M (41) mc Z
-775 443 M (42) mc Z
-775 166 M (43) mc Z
-1163 498 M (44) mc Z
-1274 277 M (45) mc Z
-1717 111 M (46) mc Z
-2271 554 M (47) mc Z
-2991 332 M (48) mc Z
-3323 166 M (49) mc Z
-3157 1772 M (50) mc Z
-1994 3434 M (51) mc Z
-PSL_cliprestore
-%%EndObject
-0 -3914 TM
-PSL_completion /PSL_completion {} def
-0 A
-FQ
-O0
-3887 3914 TM
-
-% PostScript produced by:
-%@GMT: psxy net.xy -Wthinner -Bwens -Bxaf -Byaf -Xa3.2389i -Ya3.2618i -R0/6.5/-0.2/6.5 -Jx3i
-%@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
-%%BeginObject PSL_Layer_5
-0 setlinecap
-0 setlinejoin
-3.32551 setmiterlimit
-8 W
 166 3489 M
 609 56 D
 S
@@ -1764,6 +1189,177 @@ S
 2991 332 M
 332 -166 D
 S
+PSL_cliprestore
+%%EndObject
+0 -3997 TM
+0 A
+FQ
+O0
+0 3997 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy @Table_5_11.txt -Sc0.12i -Gwhite -Wthinnest -Xa0i -Ya3.3312i -R0/6.5/-0.2/6.5 -Jx3i
+%@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+3600 0 D
+0 3711 D
+-3600 0 D
+P
+PSL_clip N
+4 W
+V
+{1 A} FS
+O1
+72 166 3489 Sc
+72 775 3545 Sc
+72 1329 3489 Sc
+72 1994 3545 Sc
+72 3157 3545 Sc
+72 886 2991 Sc
+72 1606 2935 Sc
+72 1883 3046 Sc
+72 1883 3268 Sc
+72 2658 3212 Sc
+72 2935 2880 Sc
+72 3434 2991 Sc
+72 111 2492 Sc
+72 498 2437 Sc
+72 1274 2769 Sc
+72 1385 2603 Sc
+72 1662 2603 Sc
+72 1938 2603 Sc
+72 2271 2658 Sc
+72 2714 2437 Sc
+72 3489 2492 Sc
+72 498 1883 Sc
+72 942 2215 Sc
+72 1329 2215 Sc
+72 2049 2049 Sc
+72 2492 1883 Sc
+72 2880 1883 Sc
+72 3489 1994 Sc
+72 166 1440 Sc
+72 1108 1606 Sc
+72 2105 1385 Sc
+72 3489 1329 Sc
+72 332 1052 Sc
+72 831 1108 Sc
+72 1163 1108 Sc
+72 1163 720 Sc
+72 1717 720 Sc
+72 2492 1108 Sc
+72 3046 1052 Sc
+72 3157 665 Sc
+72 3434 665 Sc
+72 222 388 Sc
+72 775 443 Sc
+72 775 166 Sc
+72 1163 498 Sc
+72 1274 277 Sc
+72 1717 111 Sc
+72 2271 554 Sc
+72 2991 332 Sc
+72 3323 166 Sc
+72 3157 1772 Sc
+72 1994 3434 Sc
+U
+PSL_cliprestore
+%%EndObject
+0 -3997 TM
+0 A
+FQ
+O0
+0 3997 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext @Table_5_11.txt -F+f6p+r -Xa0i -Ya3.3312i -R0/6.5/-0.2/6.5 -Jx3i
+%@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+3600 0 D
+0 3711 D
+-3600 0 D
+P
+PSL_clip N
+166 3489 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+100 F0
+(0) mc Z
+775 3545 M (1) mc Z
+1329 3489 M (2) mc Z
+1994 3545 M (3) mc Z
+3157 3545 M (4) mc Z
+886 2991 M (5) mc Z
+1606 2935 M (6) mc Z
+1883 3046 M (7) mc Z
+1883 3268 M (8) mc Z
+2658 3212 M (9) mc Z
+2935 2880 M (10) mc Z
+3434 2991 M (11) mc Z
+111 2492 M (12) mc Z
+498 2437 M (13) mc Z
+1274 2769 M (14) mc Z
+1385 2603 M (15) mc Z
+1662 2603 M (16) mc Z
+1938 2603 M (17) mc Z
+2271 2658 M (18) mc Z
+2714 2437 M (19) mc Z
+3489 2492 M (20) mc Z
+498 1883 M (21) mc Z
+942 2215 M (22) mc Z
+1329 2215 M (23) mc Z
+2049 2049 M (24) mc Z
+2492 1883 M (25) mc Z
+2880 1883 M (26) mc Z
+3489 1994 M (27) mc Z
+166 1440 M (28) mc Z
+1108 1606 M (29) mc Z
+2105 1385 M (30) mc Z
+3489 1329 M (31) mc Z
+332 1052 M (32) mc Z
+831 1108 M (33) mc Z
+1163 1108 M (34) mc Z
+1163 720 M (35) mc Z
+1717 720 M (36) mc Z
+2492 1108 M (37) mc Z
+3046 1052 M (38) mc Z
+3157 665 M (39) mc Z
+3434 665 M (40) mc Z
+222 388 M (41) mc Z
+775 443 M (42) mc Z
+775 166 M (43) mc Z
+1163 498 M (44) mc Z
+1274 277 M (45) mc Z
+1717 111 M (46) mc Z
+2271 554 M (47) mc Z
+2991 332 M (48) mc Z
+3323 166 M (49) mc Z
+3157 1772 M (50) mc Z
+1994 3434 M (51) mc Z
+PSL_cliprestore
+%%EndObject
+0 -3997 TM
+PSL_completion /PSL_completion {} def
+0 A
+FQ
+O0
+3887 3997 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy net.xy -Wthinner -Bwens -Bxaf -Byaf -Xa3.2389i -Ya3.3312i -R0/6.5/-0.2/6.5 -Jx3i
+%@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
 25 W
 2 setlinecap
 N 0 3711 M 0 -3711 D S
@@ -1822,15 +1418,437 @@ N 2769 0 M 0 42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 -3711 T
 0 setlinecap
+clipsave
+0 0 M
+3600 0 D
+0 3711 D
+-3600 0 D
+P
+PSL_clip N
+166 3489 M
+609 56 D
+S
+166 3489 M
+720 -498 D
+S
+166 3489 M
+-55 -997 D
+S
+775 3545 M
+554 -56 D
+S
+775 3545 M
+1219 0 D
+S
+775 3545 M
+111 -554 D
+S
+1329 3489 M
+665 56 D
+S
+1329 3489 M
+-443 -498 D
+S
+1329 3489 M
+277 -554 D
+S
+1329 3489 M
+554 -221 D
+S
+1329 3489 M
+-55 -720 D
+S
+1994 3545 M
+1163 0 D
+S
+1994 3545 M
+-111 -277 D
+S
+1994 3545 M
+664 -333 D
+S
+1994 3545 M
+0 -111 D
+S
+3157 3545 M
+-499 -333 D
+S
+3157 3545 M
+-222 -665 D
+S
+3157 3545 M
+277 -554 D
+S
+886 2991 M
+-775 -499 D
+S
+886 2991 M
+-388 -554 D
+S
+886 2991 M
+388 -222 D
+S
+886 2991 M
+56 -776 D
+S
+1606 2935 M
+277 111 D
+S
+1606 2935 M
+277 333 D
+S
+1606 2935 M
+-332 -166 D
+S
+1606 2935 M
+-221 -332 D
+S
+1606 2935 M
+56 -332 D
+S
+1606 2935 M
+332 -332 D
+S
+1883 3046 M
+0 222 D
+S
+1883 3046 M
+775 166 D
+S
+1883 3046 M
+55 -443 D
+S
+1883 3046 M
+388 -388 D
+S
+1883 3046 M
+111 388 D
+S
+1883 3268 M
+111 166 D
+S
+2658 3212 M
+277 -332 D
+S
+2658 3212 M
+-387 -554 D
+S
+2658 3212 M
+-664 222 D
+S
+2935 2880 M
+499 111 D
+S
+2935 2880 M
+-664 -222 D
+S
+2935 2880 M
+-221 -443 D
+S
+2935 2880 M
+554 -388 D
+S
+3434 2991 M
+55 -499 D
+S
+111 2492 M
+387 -55 D
+S
+111 2492 M
+387 -609 D
+S
+111 2492 M
+55 -1052 D
+S
+498 2437 M
+0 -554 D
+S
+498 2437 M
+444 -222 D
+S
+1274 2769 M
+111 -166 D
+S
+1274 2769 M
+-332 -554 D
+S
+1385 2603 M
+277 0 D
+S
+1385 2603 M
+-443 -388 D
+S
+1385 2603 M
+-56 -388 D
+S
+1662 2603 M
+276 0 D
+S
+1662 2603 M
+-333 -388 D
+S
+1662 2603 M
+387 -554 D
+S
+1938 2603 M
+333 55 D
+S
+1938 2603 M
+111 -554 D
+S
+2271 2658 M
+443 -221 D
+S
+2271 2658 M
+-222 -609 D
+S
+2714 2437 M
+775 55 D
+S
+2714 2437 M
+-665 -388 D
+S
+2714 2437 M
+-222 -554 D
+S
+2714 2437 M
+166 -554 D
+S
+3489 2492 M
+-609 -609 D
+S
+3489 2492 M
+0 -498 D
+S
+498 1883 M
+444 332 D
+S
+498 1883 M
+-332 -443 D
+S
+498 1883 M
+610 -277 D
+S
+498 1883 M
+333 -775 D
+S
+942 2215 M
+387 0 D
+S
+942 2215 M
+166 -609 D
+S
+1329 2215 M
+720 -166 D
+S
+1329 2215 M
+-221 -609 D
+S
+2049 2049 M
+443 -166 D
+S
+2049 2049 M
+-941 -443 D
+S
+2049 2049 M
+56 -664 D
+S
+2492 1883 M
+388 0 D
+S
+2492 1883 M
+-387 -498 D
+S
+2492 1883 M
+0 -775 D
+S
+2880 1883 M
+609 111 D
+S
+2880 1883 M
+-388 -775 D
+S
+2880 1883 M
+166 -831 D
+S
+2880 1883 M
+277 -111 D
+S
+3489 1994 M
+0 -665 D
+S
+3489 1994 M
+-332 -222 D
+S
+166 1440 M
+166 -388 D
+S
+166 1440 M
+665 -332 D
+S
+166 1440 M
+56 -1052 D
+S
+1108 1606 M
+997 -221 D
+S
+1108 1606 M
+-277 -498 D
+S
+1108 1606 M
+55 -498 D
+S
+2105 1385 M
+-942 -277 D
+S
+2105 1385 M
+-388 -665 D
+S
+2105 1385 M
+387 -277 D
+S
+3489 1329 M
+-443 -277 D
+S
+3489 1329 M
+-55 -664 D
+S
+3489 1329 M
+-332 443 D
+S
+332 1052 M
+499 56 D
+S
+332 1052 M
+-110 -664 D
+S
+332 1052 M
+443 -609 D
+S
+831 1108 M
+332 0 D
+S
+831 1108 M
+332 -388 D
+S
+831 1108 M
+-56 -665 D
+S
+1163 1108 M
+0 -388 D
+S
+1163 1108 M
+554 -388 D
+S
+1163 720 M
+554 0 D
+S
+1163 720 M
+-388 -277 D
+S
+1163 720 M
+0 -222 D
+S
+1717 720 M
+775 388 D
+S
+1717 720 M
+-554 -222 D
+S
+1717 720 M
+-443 -443 D
+S
+1717 720 M
+0 -609 D
+S
+1717 720 M
+554 -166 D
+S
+2492 1108 M
+554 -56 D
+S
+2492 1108 M
+665 -443 D
+S
+2492 1108 M
+-221 -554 D
+S
+3046 1052 M
+111 -387 D
+S
+3046 1052 M
+388 -387 D
+S
+3046 1052 M
+111 720 D
+S
+3157 665 M
+277 0 D
+S
+3157 665 M
+-886 -111 D
+S
+3157 665 M
+-166 -333 D
+S
+3157 665 M
+166 -499 D
+S
+3434 665 M
+-111 -499 D
+S
+222 388 M
+553 55 D
+S
+222 388 M
+553 -222 D
+S
+775 443 M
+0 -277 D
+S
+775 443 M
+388 55 D
+S
+775 166 M
+388 332 D
+S
+775 166 M
+499 111 D
+S
+775 166 M
+942 -55 D
+S
+1163 498 M
+111 -221 D
+S
+1274 277 M
+443 -166 D
+S
+1717 111 M
+554 443 D
+S
+1717 111 M
+1274 221 D
+S
+1717 111 M
+1606 55 D
+S
+2271 554 M
+720 -222 D
+S
+2991 332 M
+332 -166 D
+S
+PSL_cliprestore
 %%EndObject
--3887 -3914 TM
+-3887 -3997 TM
 0 A
 FQ
 O0
-3887 3914 TM
+3887 3997 TM
 
 % PostScript produced by:
-%@GMT: psxy @Table_5_11.txt -Sc0.03i -Gblack -Xa3.2389i -Ya3.2618i -R0/6.5/-0.2/6.5 -Jx3i
+%@GMT: gmt psxy @Table_5_11.txt -Sc0.03i -Gblack -Xa3.2389i -Ya3.3312i -R0/6.5/-0.2/6.5 -Jx3i
 %@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
@@ -1901,14 +1919,14 @@ V
 U
 PSL_cliprestore
 %%EndObject
--3887 -3914 TM
+-3887 -3997 TM
 0 A
 FQ
 O0
-3887 3914 TM
+3887 3997 TM
 
 % PostScript produced by:
-%@GMT: pstext @Table_5_11.txt -F+f6p+jLM -Gwhite -W -C0.01i -D0.08i/0i -N -Xa3.2389i -Ya3.2618i -R0/6.5/-0.2/6.5 -Jx3i
+%@GMT: gmt pstext @Table_5_11.txt -F+f6p+jLM -Gwhite -W -C0.01i -D0.08i/0i -N -Xa3.2389i -Ya3.3312i -R0/6.5/-0.2/6.5 -Jx3i
 %@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
 %%BeginObject PSL_Layer_7
 0 setlinecap
@@ -2336,15 +2354,15 @@ PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul 
 U
 2090 3434 M (705) ml Z
 %%EndObject
--3887 -3914 TM
+-3887 -3997 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 -83 TM
+0 0 TM
 
 % PostScript produced by:
-%@GMT: pscontour @Table_5_11.txt -Wthin -Ctopo.cpt -Lthinnest,- -Gd1i -BWenS -Bxaf -Byaf -Xa0i -Ya-0.0694i -R0/6.5/-0.2/6.5 -Jx3i
+%@GMT: gmt pscontour @Table_5_11.txt -Wthin -C -Lthinnest,- -Gd1i -BWenS -Bxaf -Byaf -Xa0i -Ya0i -R0/6.5/-0.2/6.5 -Jx3i
 %@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
 %%BeginObject PSL_Layer_8
 0 setlinecap
@@ -2710,26 +2728,26 @@ P S
 /PSL_setboxpen {4 W 0 A [] 0 B} def
 /PSL_setboxrgb {1 A} def
 /PSL_path_pen [
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
-	(12 W 0 A [] 0 B)
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
+	(12 W 0 A \[\] 0 B)
 ] def
 /PSL_label_justify [ 6 6 6 6 6 6 6 6 6 6 
 	6 6 6 6 6 6 6 6 6 6 
@@ -2807,10 +2825,9 @@ P S
 	(925)
 	(950)
 ] def
-/PSL_label_n [ 0 1 2 3 4 0 4 0 4 0 
-	0 4 1 1 1 0 3 0 2 1 
-	] def
-/PSL_n_paths 20 def
+/PSL_label_n [ 0 1 2 3 4 4 0 4 0 0 
+	4 1 1 1 0 3 0 2 1 ] def
+/PSL_n_paths 19 def
 /PSL_n_labels 31 def
 /PSL_txt_x [ 1698 1894 1391 1295 2172 2729 1015 1807 2837 3018 
 	2770 1777 908 332 2734 1831 997 268 531 1399 
@@ -2904,10 +2921,6 @@ PSL_path_pen 4 get cvx exec
 268 610 D
 S
 PSL_path_pen 5 get cvx exec
-886 2991 M
-0 0 D
-P S
-PSL_path_pen 6 get cvx exec
 3489 2368 M
 -261 -422 D
 -126 -152 D
@@ -2928,12 +2941,12 @@ PSL_path_pen 6 get cvx exec
 389 594 D
 -107 353 D
 S
-PSL_path_pen 7 get cvx exec
+PSL_path_pen 6 get cvx exec
 3283 3293 M
 -142 -367 D
 340 -362 D
 S
-PSL_path_pen 8 get cvx exec
+PSL_path_pen 7 get cvx exec
 3489 1804 M
 -184 -229 D
 -259 -523 D
@@ -2941,7 +2954,8 @@ PSL_path_pen 8 get cvx exec
 -39 61 D
 -194 388 D
 -214 1 D
--412 -154 D
+-253 -95 D
+-159 -59 D
 -244 -295 D
 -191 -130 D
 -74 -114 D
@@ -2953,17 +2967,17 @@ PSL_path_pen 8 get cvx exec
 -77 56 D
 -292 137 D
 S
-PSL_path_pen 9 get cvx exec
-324 3504 M
-48 -157 D
--234 -356 D
+PSL_path_pen 8 get cvx exec
+138 2991 M
+234 356 D
+-48 157 D
 S
-PSL_path_pen 10 get cvx exec
+PSL_path_pen 9 get cvx exec
 3409 3041 M
 -24 -61 D
 57 -60 D
 S
-PSL_path_pen 11 get cvx exec
+PSL_path_pen 10 get cvx exec
 152 1703 M
 157 -73 D
 256 -389 D
@@ -2983,19 +2997,19 @@ PSL_path_pen 11 get cvx exec
 75 142 D
 281 438 D
 S
-PSL_path_pen 12 get cvx exec
+PSL_path_pen 11 get cvx exec
 2118 125 M
 1039 124 D
 53 257 D
 146 -190 D
 S
-PSL_path_pen 13 get cvx exec
+PSL_path_pen 12 get cvx exec
 1332 335 M
 163 -141 D
 -346 55 D
 69 139 D
 P S
-PSL_path_pen 14 get cvx exec
+PSL_path_pen 13 get cvx exec
 665 210 M
 110 67 D
 167 190 D
@@ -3005,13 +3019,13 @@ PSL_path_pen 14 get cvx exec
 -329 123 D
 -111 446 D
 S
-PSL_path_pen 15 get cvx exec
+PSL_path_pen 14 get cvx exec
 3412 565 M
 -77 100 D
 34 64 D
 81 126 D
 S
-PSL_path_pen 16 get cvx exec
+PSL_path_pen 15 get cvx exec
 1559 657 M
 62 63 D
 30 46 D
@@ -3020,24 +3034,26 @@ PSL_path_pen 16 get cvx exec
 563 91 D
 555 -231 D
 -64 -275 D
--1033 -142 D
+-809 -112 D
+-224 -30 D
 -138 324 D
 -93 81 D
 P S
-PSL_path_pen 17 get cvx exec
+PSL_path_pen 16 get cvx exec
 388 321 M
 166 100 D
 -308 115 D
 -41 167 D
 S
-PSL_path_pen 18 get cvx exec
+PSL_path_pen 17 get cvx exec
 2668 604 M
 -37 -161 D
--603 -83 D
+-134 -18 D
+-469 -65 D
 -130 306 D
 447 72 D
 P S
-PSL_path_pen 19 get cvx exec
+PSL_path_pen 18 get cvx exec
 2374 522 M
 -172 -24 D
 -38 88 D
@@ -3059,7 +3075,6 @@ N 0 111 M -83 0 D S
 N 0 1218 M -83 0 D S
 N 0 2326 M -83 0 D S
 N 0 3434 M -83 0 D S
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg exch M} def
 200 F0
@@ -3143,15 +3158,15 @@ N 2769 0 M 0 42 D S
 0 -3711 T
 0 setlinecap
 %%EndObject
-0 83 TM
+0 0 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-3887 -83 TM
+3887 0 TM
 
 % PostScript produced by:
-%@GMT: pscontour @Table_5_11.txt -Ctopo.cpt -I -BwenS -Bxaf -Byaf -Xa3.2389i -Ya-0.0694i -R0/6.5/-0.2/6.5 -Jx3i
+%@GMT: gmt pscontour @Table_5_11.txt -C -I -BwenS -Bxaf -Byaf -Xa3.2389i -Ya0i -R0/6.5/-0.2/6.5 -Jx3i
 %@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
 %%BeginObject PSL_Layer_9
 0 setlinecap
@@ -3319,7 +3334,7 @@ PSL_clip N
 {0 0.667 1 C} FS
 -94 250 -197 -221 2 1329 3489 SP
 {0 1 1 C} FS
-111 -554 -263 27 -94 250 3 1132 3268 SP
+94 -250 263 -27 -111 554 3 886 2991 SP
 {0.333 1 0.667 C} FS
 310 -164 0 -158 -444 222 3 942 2215 SP
 {0.667 1 0.333 C} FS
@@ -3349,8 +3364,7 @@ PSL_clip N
 {0 0.667 1 C} FS
 -9 423 -133 76 -55 -720 3 1329 3489 SP
 {0 1 1 C} FS
--255 146 9 -423 2 1132 3268 SP
-{0.333 1 0.667 C} FS
+9 -423 246 277 2 886 2991 SP
 {0 0.333 1 C} FS
 -13 546 -208 -103 2 1606 2935 SP
 {0 0.667 1 C} FS
@@ -3499,19 +3513,14 @@ PSL_clip N
 {0.333 1 0.667 C} FS
 -148 -280 222 -89 2 2880 1883 SP
 {0.667 1 0.333 C} FS
-111 720 92 -462 -148 -280 3 3102 1794 SP
-{1 1 0 C} FS
-{0.667 1 0.333 C} FS
+-148 -280 -55 22 111 720 3 3046 1052 SP
 259 523 -111 -720 2 3157 1772 SP
 {1 1 0 C} FS
-184 -246 259 523 2 3046 1052 SP
-{1 0.667 0 C} FS
+259 523 -443 -277 2 3489 1329 SP
 {0.667 1 0.333 C} FS
 -184 -229 0 -190 332 222 3 3157 1772 SP
 {1 1 0 C} FS
-184 -246 -184 -229 2 3489 1804 SP
-{1 0.667 0 C} FS
-{1 1 0 C} FS
+-184 -229 0 475 2 3489 1329 SP
 281 438 162 -161 2 3046 1052 SP
 {1 0.667 0 C} FS
 -81 -126 -39 -474 281 438 3 3208 891 SP
@@ -3643,8 +3652,7 @@ PSL_clip N
 {0 0.667 1 C} FS
 271 314 185 -92 -191 -222 3 2628 3545 SP
 {0 1 1 C} FS
-499 333 36 -19 -271 -314 3 2893 3545 SP
-{0.333 1 0.667 C} FS
+271 314 -36 19 -499 -333 3 3157 3545 SP
 {0 0.333 1 C} FS
 -61 -336 328 70 2 1883 3046 SP
 {0 0.667 1 C} FS
@@ -3737,8 +3745,12 @@ N 2769 0 M 0 42 D S
 0 -3711 T
 0 setlinecap
 %%EndObject
--3887 83 TM
+-3887 0 TM
 PSL_completion /PSL_completion {} def
+
+grestore
+PSL_movie_completion /PSL_movie_completion {} def
+%PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage

--- a/test/exmod/ex16.ps
+++ b/test/exmod/ex16.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612 792             
-%%Title: GMT v6.0.0_r19398M [64-bit] Document from psscale
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_9cdd6e8-dirty_2019.08.08 [64-bit] Document from psscale
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Nov 27 09:41:54 2017
+%%CreationDate: Thu Aug  8 10:52:12 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -658,14 +658,18 @@ V 0.06 0.06 scale
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_completion {} def
+/PSL_movie_completion {} def
+%PSL_End_Header
+gsave
 0 A
 FQ
 O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: psscale -Dx3.25i/0i -C@ex_16.cpt -P
+%@GMT: gmt psscale -Dx3.25i/0i+jTC+w5i/0.25i+h -C@ex_16.cpt
 %@PROJ: xy 675.00000000 975.00000000 0.00000000 0.25000000 675.000 975.000 0.000 0.250 +xy
+%GMTBoundingBox: 72 72 360 18
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
@@ -982,23 +986,23 @@ N 6000 0 M 0 -83 D S
 0 setlinecap
 -900 300 T
 %%EndObject
-currentdict /image56 undef
-currentdict /pattern56 undef
-currentdict /image91 undef
-currentdict /pattern91 undef
+currentdict /image57 undef
+currentdict /pattern57 undef
+currentdict /image92 undef
+currentdict /pattern92 undef
 0 A
 FQ
 O0
 0 540 TM
 
 % PostScript produced by:
-%@GMT: pstext -R0/6.66944/0/7.24789 -Jx1i -P -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr0i -Yr0.45i --GMT_HISTORY=false
-%@PROJ: xy 0.00000000 6.66944000 0.00000000 7.24789000 0.000 6.669 0.000 7.248 +xy
+%@GMT: gmt pstext -R0/6.73889/0/7.31733 -Jx1i -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr0i -Yr0.45i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 6.73889000 0.00000000 7.31733000 0.000 6.739 0.000 7.317 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-4002 9512 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+4043 9678 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 533 F0
 (Gridding of Data) bc Z
 %%EndObject
@@ -1006,10 +1010,10 @@ PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 4677 TM
+0 4761 TM
 
 % PostScript produced by:
-%@GMT: pscontour @Table_5_11.txt -C@ex_16.cpt -I '-BWens+tcontour (triangulate)' -Bxaf -Byaf -Xa0i -Ya3.8979i -R0/6.5/-0.2/6.5 -Jx1i
+%@GMT: gmt pscontour @Table_5_11.txt -C@ex_16.cpt -I '-BWens+tcontour (triangulate)' -Bxaf -Byaf -Xa0i -Ya3.9673i -R0/6.5/-0.2/6.5 -Jx1i
 %@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -1810,19 +1814,19 @@ PSL_font_encode 4 get 0 eq {Standard+_Encoding /Times-Roman /Times-Roman PSL_ree
 300 F4
 (contour \(triangulate\)) bc Z
 %%EndObject
-currentdict /image56 undef
-currentdict /pattern56 undef
-currentdict /image91 undef
-currentdict /pattern91 undef
-0 -4677 TM
+currentdict /image57 undef
+currentdict /pattern57 undef
+currentdict /image92 undef
+currentdict /pattern92 undef
+0 -4761 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-4187 4677 TM
+4187 4761 TM
 
 % PostScript produced by:
-%@GMT: grdview raws0.nc -C@ex_16.cpt -Qs '-Bwens+tsurface (tension = 0)' -Bxaf -Byaf -Xa3.4889i -Ya3.8979i -R0/6.5/-0.2/6.5 -Jx1i
+%@GMT: gmt grdview raws0.nc -C@ex_16.cpt -Qs '-Bwens+tsurface (tension = 0)' -Bxaf -Byaf -Xa3.4889i -Ya3.9673i -R0/6.5/-0.2/6.5 -Jx1i
 %@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -4777,19 +4781,19 @@ PSL_font_encode 4 get 0 eq {Standard+_Encoding /Times-Roman /Times-Roman PSL_ree
 300 F4
 (surface \(tension = 0\)) bc Z
 %%EndObject
-currentdict /image56 undef
-currentdict /pattern56 undef
-currentdict /image91 undef
-currentdict /pattern91 undef
--4187 -4677 TM
+currentdict /image57 undef
+currentdict /pattern57 undef
+currentdict /image92 undef
+currentdict /pattern92 undef
+-4187 -4761 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 -83 TM
+0 0 TM
 
 % PostScript produced by:
-%@GMT: grdview raws5.nc -C@ex_16.cpt -Qs '-BWenS+tsurface (tension = 0.5)' -Bxaf -Byaf -Xa0i -Ya-0.0694i -R0/6.5/-0.2/6.5 -Jx1i
+%@GMT: gmt grdview raws5.nc -C@ex_16.cpt -Qs '-BWenS+tsurface (tension = 0.5)' -Bxaf -Byaf -Xa0i -Ya0i -R0/6.5/-0.2/6.5 -Jx1i
 %@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -7527,19 +7531,19 @@ PSL_font_encode 4 get 0 eq {Standard+_Encoding /Times-Roman /Times-Roman PSL_ree
 300 F4
 (surface \(tension = 0.5\)) bc Z
 %%EndObject
-currentdict /image56 undef
-currentdict /pattern56 undef
-currentdict /image91 undef
-currentdict /pattern91 undef
-0 83 TM
+currentdict /image57 undef
+currentdict /pattern57 undef
+currentdict /image92 undef
+currentdict /pattern92 undef
+0 0 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-4187 -83 TM
+4187 0 TM
 
 % PostScript produced by:
-%@GMT: grdview filtered.nc -C@ex_16.cpt -Qs '-BwenS+ttriangulate @~\256@~ grdfilter' -Bxaf -Byaf -Xa3.4889i -Ya-0.0694i -R0/6.5/-0.2/6.5 -Jx1i
+%@GMT: gmt grdview filtered.nc -C@ex_16.cpt -Qs '-BwenS+ttriangulate @~\256@~ grdfilter' -Bxaf -Byaf -Xa3.4889i -Ya0i -R0/6.5/-0.2/6.5 -Jx1i
 %@PROJ: xy 0.00000000 6.50000000 -0.20000000 6.50000000 0.000 6.500 -0.200 6.500 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
@@ -10213,14 +10217,18 @@ V MU 0 0 M (triangulate ) FP 300 F12 (\256) FP 300 F4 ( grdfilter) FP pathbbox N
 300 F12 (\256) Z
 300 F4 ( grdfilter) Z
 %%EndObject
-currentdict /image50 undef
-currentdict /pattern50 undef
-currentdict /image56 undef
-currentdict /pattern56 undef
-currentdict /image91 undef
-currentdict /pattern91 undef
--4187 83 TM
+currentdict /image51 undef
+currentdict /pattern51 undef
+currentdict /image57 undef
+currentdict /pattern57 undef
+currentdict /image92 undef
+currentdict /pattern92 undef
+-4187 0 TM
 PSL_completion /PSL_completion {} def
+
+grestore
+PSL_movie_completion /PSL_movie_completion {} def
+%PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage

--- a/test/exmod/ex19.ps
+++ b/test/exmod/ex19.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612 792             
-%%Title: GMT v6.0.0_r19311 [64-bit] Document from psxy
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_9cdd6e8-dirty_2019.08.08 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sat Nov 11 09:33:08 2017
+%%CreationDate: Thu Aug  8 10:52:13 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -658,14 +658,18 @@ V 0.06 0.06 scale
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_completion {} def
+/PSL_movie_completion {} def
+%PSL_End_Header
+gsave
 0 A
 FQ
 O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: psxy -R-0/6.5/-0/9.75 -Jx1i -P -T -Xr1i -Yr1i --GMT_HISTORY=false
-%@PROJ: xy -0.00000000 6.50000000 -0.00000000 9.75000000 0.000 6.500 0.000 9.750 +xy
+%@GMT: gmt psxy -R0/6.5/0/10.0278 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 6.50000000 0.00000000 10.02780000 0.000 6.500 0.000 10.028 +xy
+%GMTBoundingBox: 72 72 468 722.002
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
@@ -675,11 +679,11 @@ PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 7800 TM
+0 8133 TM
 
 % PostScript produced by:
-%@GMT: grdimage lat.nc -Clat.cpt -nl -Blrtb -Bxaf -Byaf -Xa0i -Ya6.5i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt grdimage lat.nc -Clat.cpt -nl -Blrtb -Bxaf -Byaf -Xa0i -Ya6.7778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
@@ -740,21 +744,104 @@ clipsave
 -337 113 D
 -581 188 D
 -433 138 D
--706 -226 D
--421 -138 D
--371 -125 D
--390 -138 D
--236 -88 D
--257 -100 D
--241 -100 D
--224 -100 D
--155 -75 D
--145 -75 D
--133 -75 D
--83 -50 D
--58 -37 D
--72 -50 D
--83 -63 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-39 -12 D
+-40 -13 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -13 D
+-38 -12 D
+-39 -13 D
+-39 -12 D
+-38 -13 D
+-38 -12 D
+-38 -13 D
+-39 -12 D
+-38 -13 D
+-38 -12 D
+-37 -13 D
+-38 -13 D
+-38 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-36 -12 D
+-36 -13 D
+-37 -13 D
+-36 -12 D
+-35 -13 D
+-36 -12 D
+-35 -13 D
+-36 -12 D
+-35 -13 D
+-35 -12 D
+-35 -13 D
+-34 -12 D
+-34 -13 D
+-35 -12 D
+-33 -13 D
+-34 -12 D
+-34 -13 D
+-33 -13 D
+-33 -12 D
+-33 -13 D
+-33 -12 D
+-32 -13 D
+-32 -12 D
+-32 -13 D
+-32 -12 D
+-32 -13 D
+-31 -12 D
+-31 -13 D
+-31 -12 D
+-30 -13 D
+-30 -12 D
+-30 -13 D
+-30 -12 D
+-30 -13 D
+-29 -12 D
+-29 -13 D
+-29 -12 D
+-28 -13 D
+-28 -12 D
+-28 -13 D
+-27 -12 D
+-28 -13 D
+-27 -12 D
+-26 -13 D
+-27 -12 D
+-26 -13 D
+-26 -12 D
+-50 -25 D
+-50 -25 D
+-48 -25 D
+-47 -25 D
+-46 -25 D
+-44 -25 D
+-43 -25 D
+-42 -25 D
+-41 -25 D
+-39 -25 D
+-56 -37 D
+-52 -38 D
+-66 -50 D
 -60 -49 D
 -53 -50 D
 -37 -38 D
@@ -915,36 +1002,368 @@ P
 -38 13 D
 -568 181 D
 -49 16 D
--646 -206 D
--38 -13 D
--107 -34 D
--38 -13 D
--115 -37 D
--47 -16 D
--105 -34 D
--361 -122 D
--287 -100 D
--26 -10 D
--189 -68 D
--273 -103 D
--135 -53 D
--23 -10 D
--107 -43 D
--37 -16 D
--209 -90 D
--175 -81 D
--19 -10 D
--39 -18 D
--43 -22 D
--120 -62 D
--52 -28 D
--16 -10 D
--33 -18 D
--95 -56 D
--50 -31 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -4 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -4 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -4 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -4 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -4 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-15 -7 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-15 -7 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-15 -7 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-14 -7 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -7 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -7 D
+-13 -6 D
+-13 -6 D
+-12 -6 D
+-13 -7 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -7 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -7 D
+-12 -6 D
+-12 -6 D
+-11 -6 D
+-12 -7 D
+-12 -6 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -7 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-27 -16 D
+-21 -12 D
+-21 -13 D
+-21 -12 D
+-20 -13 D
+-20 -12 D
+-20 -12 D
 -28 -19 D
--99 -68 D
--73 -56 D
+-28 -19 D
+-27 -18 D
+-27 -19 D
+-34 -25 D
+-32 -25 D
+-24 -18 D
 -22 -19 D
 -50 -43 D
 -57 -56 D
@@ -999,15 +1418,15 @@ P
 49 -16 D
 P S
 %%EndObject
-0 -7800 TM
+0 -8133 TM
 0 A
 FQ
 O0
-0 7800 TM
+0 8133 TM
 
 % PostScript produced by:
-%@GMT: pscoast -Dc -A5000 -Gc -Xa0i -Ya6.5i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pscoast -Dc -A5000 -Gc -Xa0i -Ya6.7778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
@@ -1344,13 +1763,17 @@ P
 P
 2737 3475 M
 6 3 D
--51 -13 D
+-31 -7 D
+-20 -6 D
 18 0 D
 P
 2621 3485 M
 38 7 D
 6 7 D
--36 -11 D
+-14 -4 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
 P
 2839 3465 M
 1 2 D
@@ -1366,7 +1789,10 @@ P
 -17 -2 D
 -29 -10 D
 8 3 D
--27 -10 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-6 -2 D
 P
 2933 3465 M
 14 5 D
@@ -1422,7 +1848,8 @@ P
 -13 -9 D
 31 1 D
 3 -8 D
--58 -7 D
+-57 -6 D
+-1 -1 D
 P
 3263 3529 M
 -8 -4 D
@@ -1466,13 +1893,21 @@ P
 52 22 D
 -3 3 D
 -16 -3 D
--25 -11 D
+-18 -7 D
+-15 -8 D
+-8 -3 D
+-15 -8 D
 P
 3098 3511 M
 91 31 D
 16 15 D
 -20 -5 D
 4 4 D
+-18 -9 D
+-18 -9 D
+-10 -5 D
+-18 -9 D
+-18 -9 D
 P
 3249 3573 M
 29 11 D
@@ -1649,7 +2084,9 @@ P
 1 0 D
 -8 -5 D
 2 1 D
--28 -16 D
+-6 -3 D
+-14 -8 D
+-8 -5 D
 13 1 D
 17 8 D
 40 28 D
@@ -1657,7 +2094,11 @@ P
 -3 1 D
 P
 3273 3535 M
--58 -34 D
+-10 -6 D
+-12 -7 D
+-12 -7 D
+-12 -7 D
+-12 -7 D
 -5 -7 D
 10 2 D
 16 10 D
@@ -1751,7 +2192,8 @@ P
 -10 2 D
 -6 -10 D
 8 16 D
--22 -15 D
+-4 -2 D
+-18 -13 D
 -23 -17 D
 -11 -9 D
 -17 -13 D
@@ -1808,7 +2250,10 @@ P
 -23 -12 D
 8 -1 D
 -21 -6 D
--93 -68 D
+-20 -14 D
+-26 -20 D
+-20 -14 D
+-27 -20 D
 2 -3 D
 22 14 D
 10 0 D
@@ -1839,6 +2284,8 @@ P
 14 7 D
 -23 4 D
 -15 -5 D
+-24 -18 D
+-19 -13 D
 P
 3487 3601 M
 14 4 D
@@ -1878,10 +2325,11 @@ P
 -3 9 D
 -11 -9 D
 14 16 D
--22 -7 D
--6 -15 D
+-21 -6 D
+-7 -16 D
 4 12 D
--24 -22 D
+-1 0 D
+-23 -22 D
 -5 -6 D
 -23 -21 D
 -5 -6 D
@@ -2952,18 +3400,124 @@ P
 -49 -20 D
 81 33 D
 46 29 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-7 -2 D
 P
 2834 3454 M
 5 11 D
 -129 0 D
--90 -35 D
--30 -11 D
--183 -72 D
--57 -23 D
--22 -8 D
--35 -15 D
--22 -8 D
--167 -69 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
 -14 -11 D
 42 16 D
 -23 -12 D
@@ -2971,7 +3525,9 @@ P
 -40 -14 D
 -45 -20 D
 -84 -23 D
--32 -14 D
+-11 -5 D
+-10 -4 D
+-11 -5 D
 6 2 D
 -12 -7 D
 158 49 D
@@ -3067,7 +3623,8 @@ P
 1 8 D
 -40 -11 D
 29 15 D
--38 -15 D
+-2 0 D
+-36 -15 D
 20 15 D
 -9 0 D
 -53 -15 D
@@ -3079,12 +3636,51 @@ P
 -35 -11 D
 -22 -13 D
 6 19 D
--99 -44 D
--40 -17 D
--45 -21 D
--33 -14 D
--197 -91 D
--49 -23 D
+-13 -6 D
+-7 -2 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-6 -3 D
+-7 -2 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-6 -3 D
+-7 -2 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-6 -3 D
+-6 -2 D
+-7 -3 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-6 -2 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-6 -2 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
 15 5 D
 -4 -6 D
 -16 -5 D
@@ -3224,22 +3820,55 @@ P
 11 10 D
 -17 0 D
 2 13 D
--69 -35 D
--34 -18 D
+-17 -9 D
+-18 -9 D
+-17 -8 D
+-17 -9 D
+-17 -9 D
+-17 -9 D
 3 1 D
 0 -4 D
--30 -11 D
+-23 -8 D
+-4 -1 D
+-3 -2 D
 11 -1 D
 22 8 D
 -40 -21 D
 -14 1 D
 -18 -10 D
--17 -6 D
--218 -118 D
--155 -88 D
--158 -94 D
--28 -18 D
--15 -8 D
+-11 -3 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-11 -6 D
+-16 -8 D
+-22 -12 D
+-22 -12 D
+-22 -12 D
+-21 -12 D
+-22 -11 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-21 -11 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -11 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -11 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-19 -11 D
+-19 -12 D
+-19 -12 D
+-19 -12 D
+-10 -5 D
+-5 -3 D
 280 0 D
 18 14 D
 26 18 D
@@ -3370,16 +3999,33 @@ P
 10 13 D
 -18 -9 D
 -9 -1 D
--29 -17 D
--212 -136 D
--97 -65 D
--102 -71 D
--33 -23 D
--8 -6 D
+-19 -11 D
+-19 -12 D
+-19 -12 D
+-19 -12 D
+-28 -18 D
+-18 -11 D
+-19 -12 D
+-27 -18 D
+-19 -12 D
+-18 -11 D
+-27 -18 D
+-27 -18 D
+-26 -18 D
+-18 -11 D
+-26 -18 D
+-26 -18 D
+-26 -17 D
+-25 -18 D
+-26 -18 D
+-16 -12 D
+-17 -11 D
+-16 -12 D
 1 -2 D
 -41 -29 D
 27 22 D
--51 -38 D
+-26 -19 D
+-25 -19 D
 -13 -9 D
 -12 -9 D
 279 0 D
@@ -3640,6 +4286,7 @@ P
 3305 3465 M
 6 -3 D
 1 3 D
+-7 0 D
 P
 3288 3421 M
 -6 6 D
@@ -4672,12 +5319,24 @@ P
 114 90 D
 48 37 D
 -280 0 D
--127 -82 D
--94 -64 D
--128 -93 D
--30 -24 D
--15 -11 D
--78 -64 D
+-27 -18 D
+-19 -12 D
+-18 -11 D
+-27 -18 D
+-18 -11 D
+-26 -18 D
+-18 -12 D
+-26 -17 D
+-25 -17 D
+-25 -18 D
+-25 -17 D
+-32 -24 D
+-24 -17 D
+-24 -18 D
+-30 -23 D
+-30 -23 D
+-36 -29 D
+-42 -35 D
 17 -8 D
 0 -17 D
 -45 -70 D
@@ -4772,11 +5431,15 @@ P
 10 11 D
 66 63 D
 -279 0 D
--132 -103 D
--101 -84 D
--67 -60 D
--63 -60 D
--71 -72 D
+-32 -24 D
+-32 -25 D
+-38 -30 D
+-37 -30 D
+-37 -30 D
+-43 -36 D
+-55 -48 D
+-83 -78 D
+-77 -78 D
 -43 -48 D
 -5 -6 D
 P
@@ -6590,10 +7253,12 @@ P
 2186 2135 M
 11 8 D
 -1 2 D
--8 -1 D
+-4 -1 D
+-4 0 D
 P
 2181 2112 M
 1 0 D
+-1 0 D
 P
 3034 1889 M
 -49 -1 D
@@ -6658,7 +7323,8 @@ P
 0 -6 D
 7 1 D
 32 17 D
--29 -17 D
+-22 -13 D
+-7 -4 D
 -19 -2 D
 -8 -25 D
 3 27 D
@@ -6953,6 +7619,7 @@ P
 6460 1733 M
 8 -6 D
 10 7 D
+-17 0 D
 P
 6683 1705 M
 -5 -4 D
@@ -7209,8 +7876,13 @@ P
 47 25 D
 36 22 D
 -250 0 D
--73 -57 D
--78 -58 D
+-29 -23 D
+-29 -23 D
+-30 -23 D
+-31 -23 D
+-24 -17 D
+-25 -17 D
+-24 -17 D
 P
 6206 1014 M
 2 -7 D
@@ -7529,7 +8201,8 @@ P
 -33 -7 D
 -19 -12 D
 -16 -4 D
--45 -34 D
+-28 -22 D
+-17 -12 D
 -11 -9 D
 149 0 D
 133 82 D
@@ -7546,9 +8219,17 @@ P
 5 9 D
 -30 -16 D
 3 10 D
--20 -7 D
--125 -77 D
+-18 -7 D
+-2 0 D
+-17 -11 D
+-16 -10 D
+-17 -10 D
 -25 -16 D
+-16 -10 D
+-17 -10 D
+-17 -10 D
+-17 -11 D
+-8 -5 D
 149 0 D
 18 10 D
 19 9 D
@@ -7564,10 +8245,13 @@ P
 7 7 D
 -28 -9 D
 -7 0 D
--73 -38 D
--28 -15 D
+-18 -10 D
+-18 -9 D
+-19 -10 D
+-18 -9 D
+-19 -10 D
 -19 -9 D
--9 -5 D
+-18 -10 D
 149 0 D
 70 31 D
 P
@@ -7584,13 +8268,33 @@ P
 9 9 D
 -18 -4 D
 -5 7 D
--81 -36 D
--81 -36 D
+-11 -5 D
+-6 -3 D
+-6 -2 D
+-11 -5 D
+-12 -6 D
+-11 -5 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-11 -6 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-11 -5 D
+-12 -6 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-5 -3 D
 148 0 D
 P
 5095 435 M
 16 8 D
--21 -8 D
+-10 -4 D
+-11 -4 D
 P
 3348 435 M
 -12 6 D
@@ -7789,9 +8493,27 @@ P
 195 114 D
 161 97 D
 -149 0 D
--185 -139 D
--141 -103 D
--193 -139 D
+-32 -24 D
+-32 -24 D
+-32 -24 D
+-32 -25 D
+-25 -18 D
+-32 -24 D
+-25 -18 D
+-25 -18 D
+-25 -18 D
+-33 -24 D
+-33 -25 D
+-25 -18 D
+-25 -18 D
+-25 -18 D
+-25 -18 D
+-26 -18 D
+-25 -18 D
+-34 -25 D
+-25 -18 D
+-25 -18 D
+-26 -18 D
 P
 3900 0 M
 133 63 D
@@ -7801,9 +8523,41 @@ P
 253 123 D
 187 94 D
 -149 0 D
--252 -151 D
--135 -78 D
--31 -19 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-21 -13 D
+-20 -12 D
+-20 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -12 D
+-21 -13 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
 P
 3900 0 M
 155 63 D
@@ -7812,11 +8566,87 @@ P
 339 142 D
 218 94 D
 -149 0 D
--309 -154 D
--162 -78 D
--37 -19 D
--246 -117 D
--31 -16 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -7 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-13 -6 D
+-12 -7 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -7 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
 P
 3900 0 M
 194 70 D
@@ -7825,10 +8655,146 @@ P
 321 117 D
 248 94 D
 -148 0 D
--339 -145 D
--225 -94 D
--316 -129 D
--51 -22 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
 P
 4726 265 M
 -20 14 D
@@ -7852,11 +8818,150 @@ P
 -23 6 D
 14 7 D
 -5 0 D
--354 -133 D
--273 -99 D
--58 -22 D
--319 -114 D
--186 -67 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -4 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
 541 173 D
 P
 3181 259 M
@@ -8042,15 +9147,15 @@ P
 P
 PSL_clip N
 %%EndObject
-0 -7800 TM
+0 -8133 TM
 0 A
 FQ
 O0
-0 7800 TM
+0 8133 TM
 
 % PostScript produced by:
-%@GMT: grdimage lon.nc -Clon.cpt -nl -Xa0i -Ya6.5i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt grdimage lon.nc -Clon.cpt -nl -Xa0i -Ya6.7778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
@@ -8111,21 +9216,104 @@ clipsave
 -337 113 D
 -581 188 D
 -433 138 D
--706 -226 D
--421 -138 D
--371 -125 D
--390 -138 D
--236 -88 D
--257 -100 D
--241 -100 D
--224 -100 D
--155 -75 D
--145 -75 D
--133 -75 D
--83 -50 D
--58 -37 D
--72 -50 D
--83 -63 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-39 -12 D
+-40 -13 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -13 D
+-38 -12 D
+-39 -13 D
+-39 -12 D
+-38 -13 D
+-38 -12 D
+-38 -13 D
+-39 -12 D
+-38 -13 D
+-38 -12 D
+-37 -13 D
+-38 -13 D
+-38 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-36 -12 D
+-36 -13 D
+-37 -13 D
+-36 -12 D
+-35 -13 D
+-36 -12 D
+-35 -13 D
+-36 -12 D
+-35 -13 D
+-35 -12 D
+-35 -13 D
+-34 -12 D
+-34 -13 D
+-35 -12 D
+-33 -13 D
+-34 -12 D
+-34 -13 D
+-33 -13 D
+-33 -12 D
+-33 -13 D
+-33 -12 D
+-32 -13 D
+-32 -12 D
+-32 -13 D
+-32 -12 D
+-32 -13 D
+-31 -12 D
+-31 -13 D
+-31 -12 D
+-30 -13 D
+-30 -12 D
+-30 -13 D
+-30 -12 D
+-30 -13 D
+-29 -12 D
+-29 -13 D
+-29 -12 D
+-28 -13 D
+-28 -12 D
+-28 -13 D
+-27 -12 D
+-28 -13 D
+-27 -12 D
+-26 -13 D
+-27 -12 D
+-26 -13 D
+-26 -12 D
+-50 -25 D
+-50 -25 D
+-48 -25 D
+-47 -25 D
+-46 -25 D
+-44 -25 D
+-43 -25 D
+-42 -25 D
+-41 -25 D
+-39 -25 D
+-56 -37 D
+-52 -38 D
+-66 -50 D
 -60 -49 D
 -53 -50 D
 -37 -38 D
@@ -8501,30 +9689,30 @@ o(AnerM(S$.#:@J4%fCrk3L@'r]`><e40~>
 U
 PSL_cliprestore
 %%EndObject
-0 -7800 TM
+0 -8133 TM
 0 A
 FQ
 O0
-0 7800 TM
+0 8133 TM
 
 % PostScript produced by:
-%@GMT: pscoast -Q -Xa0i -Ya6.5i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pscoast -Q -Xa0i -Ya6.7778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 PSL_cliprestore
 %%EndObject
-0 -7800 TM
+0 -8133 TM
 0 A
 FQ
 O0
-0 7800 TM
+0 8133 TM
 
 % PostScript produced by:
-%@GMT: pscoast -Dc -A5000 -Wthinnest -Xa0i -Ya6.5i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pscoast -Dc -A5000 -Wthinnest -Xa0i -Ya6.7778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
@@ -8855,7 +10043,8 @@ S
 S
 2737 3475 M
 6 3 D
--51 -13 D
+-31 -7 D
+-20 -6 D
 S
 2839 3465 M
 1 2 D
@@ -8926,7 +10115,8 @@ S
 -13 -9 D
 31 1 D
 3 -8 D
--58 -7 D
+-57 -6 D
+-1 -1 D
 S
 3249 3573 M
 29 11 D
@@ -13679,7 +14869,8 @@ S
 2186 2135 M
 11 8 D
 -1 2 D
--8 -1 D
+-4 -1 D
+-4 0 D
 S
 2168 1898 M
 3 4 D
@@ -13822,7 +15013,8 @@ P S
 0 -6 D
 7 1 D
 32 17 D
--29 -17 D
+-22 -13 D
+-7 -4 D
 -19 -2 D
 -8 -25 D
 3 27 D
@@ -14591,7 +15783,8 @@ S
 5 9 D
 -30 -16 D
 3 10 D
--20 -7 D
+-18 -7 D
+-2 0 D
 S
 5104 507 M
 -12 15 D
@@ -14910,131 +16103,27 @@ S
 -2 -10 D
 S
 %%EndObject
-0 -7800 TM
+0 -8133 TM
 0 A
 FQ
 O0
-0 7800 TM
+0 8133 TM
 
 % PostScript produced by:
-%@GMT: pstext -F+f32p,Helvetica-Bold,red=thinner -Xa0i -Ya6.5i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pstext -F+f32p,Helvetica-Bold,red=thinner -Xa0i -Ya6.7778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_7
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 clipsave
-3900 0 M
-706 226 D
-421 138 D
-371 125 D
-390 138 D
-236 88 D
-257 100 D
-241 100 D
-224 100 D
-155 75 D
-145 75 D
-133 75 D
-83 50 D
-58 37 D
-72 50 D
-83 63 D
-60 49 D
-53 50 D
-37 38 D
-43 49 D
-29 38 D
-25 37 D
-21 37 D
-19 38 D
-14 37 D
-11 37 D
-8 38 D
-5 50 D
--2 49 D
--5 38 D
--13 49 D
--13 38 D
--17 37 D
--13 25 D
--31 50 D
--28 37 D
--31 38 D
--46 49 D
--52 50 D
--44 38 D
--79 62 D
--69 50 D
--115 75 D
--150 87 D
--141 75 D
--152 75 D
--219 100 D
--237 100 D
--253 100 D
--233 88 D
--279 100 D
--327 113 D
--337 113 D
--581 188 D
--433 138 D
--706 -226 D
--421 -138 D
--371 -125 D
--390 -138 D
--236 -88 D
--257 -100 D
--241 -100 D
--224 -100 D
--155 -75 D
--145 -75 D
--133 -75 D
--83 -50 D
--58 -37 D
--72 -50 D
--83 -63 D
--60 -49 D
--53 -50 D
--37 -38 D
--43 -49 D
--29 -38 D
--25 -37 D
--21 -37 D
--19 -38 D
--14 -37 D
--11 -37 D
--8 -38 D
--5 -50 D
-2 -49 D
-5 -38 D
-13 -49 D
-13 -38 D
-17 -37 D
-13 -25 D
-31 -50 D
-28 -37 D
-31 -38 D
-46 -49 D
-52 -50 D
-44 -38 D
-79 -62 D
-69 -50 D
-115 -75 D
-150 -87 D
-141 -75 D
-152 -75 D
-219 -100 D
-237 -100 D
-253 -100 D
-233 -88 D
-279 -100 D
-327 -113 D
-337 -113 D
-581 -188 D
+0 0 M
+7800 0 D
+0 3900 D
+-7800 0 D
 P
 PSL_clip N
-PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
 8 W
 {1 0 0 C} FS
 O1
@@ -15042,131 +16131,27 @@ O1
 (15TH INTERNATIONAL) mc false charpath fs S
 PSL_cliprestore
 %%EndObject
-0 -7800 TM
+0 -8133 TM
 0 A
 FQ
 O0
-0 7800 TM
+0 8133 TM
 
 % PostScript produced by:
-%@GMT: pstext -F+f32p,Helvetica-Bold,red=thinner -Xa0i -Ya6.5i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pstext -F+f32p,Helvetica-Bold,red=thinner -Xa0i -Ya6.7778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_8
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 clipsave
-3900 0 M
-706 226 D
-421 138 D
-371 125 D
-390 138 D
-236 88 D
-257 100 D
-241 100 D
-224 100 D
-155 75 D
-145 75 D
-133 75 D
-83 50 D
-58 37 D
-72 50 D
-83 63 D
-60 49 D
-53 50 D
-37 38 D
-43 49 D
-29 38 D
-25 37 D
-21 37 D
-19 38 D
-14 37 D
-11 37 D
-8 38 D
-5 50 D
--2 49 D
--5 38 D
--13 49 D
--13 38 D
--17 37 D
--13 25 D
--31 50 D
--28 37 D
--31 38 D
--46 49 D
--52 50 D
--44 38 D
--79 62 D
--69 50 D
--115 75 D
--150 87 D
--141 75 D
--152 75 D
--219 100 D
--237 100 D
--253 100 D
--233 88 D
--279 100 D
--327 113 D
--337 113 D
--581 188 D
--433 138 D
--706 -226 D
--421 -138 D
--371 -125 D
--390 -138 D
--236 -88 D
--257 -100 D
--241 -100 D
--224 -100 D
--155 -75 D
--145 -75 D
--133 -75 D
--83 -50 D
--58 -37 D
--72 -50 D
--83 -63 D
--60 -49 D
--53 -50 D
--37 -38 D
--43 -49 D
--29 -38 D
--25 -37 D
--21 -37 D
--19 -38 D
--14 -37 D
--11 -37 D
--8 -38 D
--5 -50 D
-2 -49 D
-5 -38 D
-13 -49 D
-13 -38 D
-17 -37 D
-13 -25 D
-31 -50 D
-28 -37 D
-31 -38 D
-46 -49 D
-52 -50 D
-44 -38 D
-79 -62 D
-69 -50 D
-115 -75 D
-150 -87 D
-141 -75 D
-152 -75 D
-219 -100 D
-237 -100 D
-253 -100 D
-233 -88 D
-279 -100 D
-327 -113 D
-337 -113 D
-581 -188 D
+0 0 M
+7800 0 D
+0 3900 D
+-7800 0 D
 P
 PSL_clip N
-PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
 8 W
 {1 0 0 C} FS
 O1
@@ -15174,131 +16159,27 @@ O1
 (GMT CONFERENCE) mc false charpath fs S
 PSL_cliprestore
 %%EndObject
-0 -7800 TM
+0 -8133 TM
 0 A
 FQ
 O0
-0 7800 TM
+0 8133 TM
 
 % PostScript produced by:
-%@GMT: pstext -F+f18p,Helvetica-Bold,green=thinnest -Xa0i -Ya6.5i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pstext -F+f18p,Helvetica-Bold,green=thinnest -Xa0i -Ya6.7778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_9
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 clipsave
-3900 0 M
-706 226 D
-421 138 D
-371 125 D
-390 138 D
-236 88 D
-257 100 D
-241 100 D
-224 100 D
-155 75 D
-145 75 D
-133 75 D
-83 50 D
-58 37 D
-72 50 D
-83 63 D
-60 49 D
-53 50 D
-37 38 D
-43 49 D
-29 38 D
-25 37 D
-21 37 D
-19 38 D
-14 37 D
-11 37 D
-8 38 D
-5 50 D
--2 49 D
--5 38 D
--13 49 D
--13 38 D
--17 37 D
--13 25 D
--31 50 D
--28 37 D
--31 38 D
--46 49 D
--52 50 D
--44 38 D
--79 62 D
--69 50 D
--115 75 D
--150 87 D
--141 75 D
--152 75 D
--219 100 D
--237 100 D
--253 100 D
--233 88 D
--279 100 D
--327 113 D
--337 113 D
--581 188 D
--433 138 D
--706 -226 D
--421 -138 D
--371 -125 D
--390 -138 D
--236 -88 D
--257 -100 D
--241 -100 D
--224 -100 D
--155 -75 D
--145 -75 D
--133 -75 D
--83 -50 D
--58 -37 D
--72 -50 D
--83 -63 D
--60 -49 D
--53 -50 D
--37 -38 D
--43 -49 D
--29 -38 D
--25 -37 D
--21 -37 D
--19 -38 D
--14 -37 D
--11 -37 D
--8 -38 D
--5 -50 D
-2 -49 D
-5 -38 D
-13 -49 D
-13 -38 D
-17 -37 D
-13 -25 D
-31 -50 D
-28 -37 D
-31 -38 D
-46 -49 D
-52 -50 D
-44 -38 D
-79 -62 D
-69 -50 D
-115 -75 D
-150 -87 D
-141 -75 D
-152 -75 D
-219 -100 D
-237 -100 D
-253 -100 D
-233 -88 D
-279 -100 D
-327 -113 D
-337 -113 D
-581 -188 D
+0 0 M
+7800 0 D
+0 3900 D
+-7800 0 D
 P
 PSL_clip N
-PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
 4 W
 {0 1 0 C} FS
 O1
@@ -15306,16 +16187,16 @@ O1
 (Honolulu, Hawaii, April 1, 2018) mc false charpath fs S
 PSL_cliprestore
 %%EndObject
-0 -7800 TM
+0 -8133 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 3900 TM
+0 4233 TM
 
 % PostScript produced by:
-%@GMT: pscoast -Dc -A5000 -Gp86+fred+byellow+r100 -Sp@circuit.png+r100 -Blrtb -Bxaf -Byaf -Xa0i -Ya3.25i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pscoast -Dc -A5000 -Gp86+fred+byellow+r100 -Sp@circuit.png+r100 -Blrtb -Bxaf -Byaf -Xa0i -Ya3.5278i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_10
 0 setlinecap
 0 setlinejoin
@@ -15599,21 +16480,104 @@ C$Ku7c]g'?j[?'kIpL!ro*eur5^r1aKnVVQ<>S/_P5lJ/P%&hT<19^iBI#W.C$!.%m<bHj`WIaBpL8cs
 -337 113 D
 -581 188 D
 -433 138 D
--706 -226 D
--421 -138 D
--371 -125 D
--390 -138 D
--236 -88 D
--257 -100 D
--241 -100 D
--224 -100 D
--155 -75 D
--145 -75 D
--133 -75 D
--83 -50 D
--58 -37 D
--72 -50 D
--83 -63 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-39 -12 D
+-40 -13 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -13 D
+-38 -12 D
+-39 -13 D
+-39 -12 D
+-38 -13 D
+-38 -12 D
+-38 -13 D
+-39 -12 D
+-38 -13 D
+-38 -12 D
+-37 -13 D
+-38 -13 D
+-38 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-36 -12 D
+-36 -13 D
+-37 -13 D
+-36 -12 D
+-35 -13 D
+-36 -12 D
+-35 -13 D
+-36 -12 D
+-35 -13 D
+-35 -12 D
+-35 -13 D
+-34 -12 D
+-34 -13 D
+-35 -12 D
+-33 -13 D
+-34 -12 D
+-34 -13 D
+-33 -13 D
+-33 -12 D
+-33 -13 D
+-33 -12 D
+-32 -13 D
+-32 -12 D
+-32 -13 D
+-32 -12 D
+-32 -13 D
+-31 -12 D
+-31 -13 D
+-31 -12 D
+-30 -13 D
+-30 -12 D
+-30 -13 D
+-30 -12 D
+-30 -13 D
+-29 -12 D
+-29 -13 D
+-29 -12 D
+-28 -13 D
+-28 -12 D
+-28 -13 D
+-27 -12 D
+-28 -13 D
+-27 -12 D
+-26 -13 D
+-27 -12 D
+-26 -13 D
+-26 -12 D
+-50 -25 D
+-50 -25 D
+-48 -25 D
+-47 -25 D
+-46 -25 D
+-44 -25 D
+-43 -25 D
+-42 -25 D
+-41 -25 D
+-39 -25 D
+-56 -37 D
+-52 -38 D
+-66 -50 D
 -60 -49 D
 -53 -50 D
 -37 -38 D
@@ -15732,20 +16696,6 @@ QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 3 3 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 5 -1 5 4 1 7 -9 -7 0 3 -8 -2 1 7 3972 3692 SP
 {pattern92 I} FS
 4115 3465 M
@@ -15763,9 +16713,11 @@ rYe!oP<>6Oq#p\GG$Y~>
 -2 18 D
 -10 2 D
 0 -21 D
--17 7 D
+-1 0 D
+-16 7 D
 5 -7 D
--14 0 D
+-5 0 D
+-9 0 D
 -63 186 D
 5 4 D
 -9 9 D
@@ -15786,106 +16738,12 @@ rYe!oP<>6Oq#p\GG$Y~>
 65 -97 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4 -8 6 3 6 -14 -8 -3 -11 13 5 4012 3631 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 5 -7 -16 7 2 4074 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 0 -21 -10 2 -2 18 -2 -20 -5 13 -3 -2 2 -14 -8 3 0 12 -3 -10 -20 10 2 8 13 -3 -4 4 14 4115 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2 -5 2 -5 -12 10 2 -11 -4 8 -5 -5 -12 9 6 16 17 -5 -4 -8 7 1 11 3977 3677 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2 -5 1 -4 -9 9 5 4 4 3986 3651 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4 -8 6 3 6 -14 -8 -3 -11 13 5 4012 3631 SP
 {pattern92 I} FS
 4215 3596 M
@@ -15924,35 +16782,8 @@ fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 79 -76 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 19 -17 9 1 10 -8 1 -17 10 -2 -5 -4 8 -5 -9 -3 -12 3 -3 12 -14 15 -41 26 26 -1 13 4288 3481 SP
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4215 3596 M
 -3 -18 D
 16 -12 D
@@ -15974,19 +16805,6 @@ Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
 -3 8 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 19 -17 9 1 10 -8 1 -17 10 -2 -5 -4 8 -5 -9 -3 -12 3 -3 12 -14 15 -41 26 26 -1 13 4288 3481 SP
 {pattern92 I} FS
 4441 3465 M
@@ -16034,35 +16852,8 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
 14 -13 D
 P
 FO
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 27 -24 0 -10 27 -30 -15 1 -14 5 -25 26 -22 13 -22 19 8 4441 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4437 3509 M
 -21 8 D
 -1 -4 D
@@ -16078,20 +16869,6 @@ UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
 44 0 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 7 -7 7 -7 7 -7 0 -6 -18 -1 -4 -13 -18 16 17 20 -5 11 9 4243 3569 SP
 {pattern92 I} FS
 4517 3465 M
@@ -16139,49 +16916,9 @@ QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 49 -36 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 21 -22 -31 13 -13 10 6 5 4 4254 3682 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6 -4 5 -5 6 -4 6 -5 6 -4 6 -5 6 -4 6 -4 6 -5 5 -4 -19 7 -12 0 -26 25 6 -9 -20 17 -9 4 16 4517 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4409 3606 M
 -6 0 D
 21 -10 D
@@ -16205,34 +16942,7 @@ a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -109 65 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -6 3 -6 3 -5 4 -6 3 -6 3 20 -1 33 -13 3 -13 -12 7 4 -5 -13 5 11 4284 3679 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 21 -22 -31 13 -13 10 6 5 4 4254 3682 SP
 {pattern92 I} FS
 4319 3659 M
@@ -16275,35 +16985,8 @@ QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -83 48 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -23 13 8 -7 -33 14 4 11 4 4354 3639 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4665 3529 M
 -22 6 D
 -10 7 D
@@ -16338,34 +17021,7 @@ pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
 149 0 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6 -3 5 -4 6 -3 6 -3 6 -4 -2 1 -33 19 7 4319 3659 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -23 13 8 -7 -33 14 4 11 4 4354 3639 SP
 {pattern92 I} FS
 17 -10 3 -7 30 -13 -29 13 -3 7 -17 10 6 4832 3465 SP
@@ -16402,20 +17058,6 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
 179 -74 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4832 3465 M
 -17 10 D
@@ -16444,62 +17086,9 @@ q#p\GG$Y~>
 128 -64 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -6 2 -6 3 -5 2 -6 3 -6 2 27 -9 8 -6 7 4831 3513 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 2 4 0 1 -3 3 4822 3517 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 0 2 0 1 -1 3 4768 3540 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -8 3 -8 3 -8 4 -8 3 -7 3 10 1 43 -16 22 -14 -28 9 9 4648 3591 SP
 {pattern92 I} FS
 -1 1 -2 0 5 -2 3 4866 3498 SP
@@ -16542,35 +17131,8 @@ glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
 2 -4 D
 P
 FO
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -50 10 -10 8 24 -6 3 4729 3574 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 5088 3466 M
 -56 18 D
 -33 5 D
@@ -16594,56 +17156,15 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
 148 0 D
 P
 FO
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 8 -3 8 -4 8 -3 8 -3 8 -4 -13 4 26 -12 -58 15 -12 9 41 -15 -50 19 19 0 12 4695 3571 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 -1 11 -10 -32 10 -10 5 28 -4 5 4771 3539 SP
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -50 10 -10 8 24 -6 3 4729 3574 SP
 {pattern92 I} FS
 5176 3465 M
 -14 2 D
 6 -2 D
--80 1 D
--551 205 D
+-77 0 D
+-554 206 D
 -393 142 D
 -244 87 D
 196 -63 D
@@ -16656,49 +17177,9 @@ QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 60 -20 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 2 -1 -3 1 2 5091 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6 -2 -14 2 2 5176 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -7 3 -7 2 -8 3 0 2 30 -12 5 5149 3495 SP
 {pattern92 I} FS
 2621 3485 M
@@ -16710,48 +17191,154 @@ a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 390 125 D
 47 14 D
 159 51 D
--119 -42 D
--50 -19 D
--186 -66 D
--244 -88 D
--66 -25 D
--174 -63 D
--98 -37 D
--226 -85 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -4 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
 6 3 D
--51 -13 D
+-31 -7 D
+-20 -6 D
 -131 0 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 7 3 7 3 6 2 18 0 -20 -6 -31 -7 6 3 7 2737 3475 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -7 -2 -7 -3 -8 -2 -14 -4 6 7 38 7 6 2621 3485 SP
 {pattern92 I} FS
 2839 3465 M
@@ -16774,27 +17361,149 @@ QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 220 78 D
 42 16 D
 85 30 D
--155 -63 D
--44 -19 D
--286 -117 D
--339 -142 D
--218 -94 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 2839 3465 M
 1 2 D
@@ -16810,7 +17519,10 @@ rYe!oP<>6Oq#p\GG$Y~>
 -17 -2 D
 -29 -10 D
 8 3 D
--27 -10 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-6 -2 D
 P
 FO
 {pattern92 I} FS
@@ -16830,14 +17542,70 @@ FO
 316 129 D
 51 22 D
 111 45 D
--56 -27 D
--344 -165 D
--140 -68 D
--48 -23 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-6 -2 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-6 -2 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-6 -3 D
+-6 -2 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-6 -2 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-6 -3 D
+-6 -2 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-6 -3 D
 -60 -23 D
 21 6 D
 -7 -6 D
--77 -38 D
+-8 -4 D
+-15 -7 D
+-15 -8 D
+-8 -3 D
+-15 -8 D
+-16 -8 D
 7 8 D
 -28 -5 D
 -21 -13 D
@@ -16846,67 +17614,17 @@ FO
 -26 -19 D
 35 9 D
 31 14 D
--91 -46 D
+-19 -10 D
+-18 -9 D
+-18 -9 D
+-18 -9 D
+-18 -9 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -19 -5 14 5 2 2933 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -11 -3 -16 -9 18 12 3 2956 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -10 -4 8 4 2 2974 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3189 3556 M
 7 8 D
 -28 -5 D
@@ -16918,19 +17636,6 @@ q#p\GG$Y~>
 58 27 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 8 4 8 3 8 4 7 4 8 4 -7 -6 21 6 -60 -23 8 3312 3617 SP
 {pattern92 I} FS
 3149 3465 M
@@ -16959,8 +17664,8 @@ HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
 -13 -9 D
 31 1 D
 3 -8 D
--58 -7 D
--20 0 D
+-57 -6 D
+-21 -1 D
 91 46 D
 91 31 D
 16 15 D
@@ -16979,10 +17684,27 @@ HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
 257 123 D
 111 53 D
 56 27 D
--175 -101 D
+-21 -12 D
+-20 -12 D
 -21 -11 D
--102 -59 D
--132 -77 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -11 D
+-20 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-20 -12 D
+-21 -11 D
+-20 -12 D
+-20 -12 D
+-21 -12 D
+-20 -12 D
+-20 -11 D
+-20 -12 D
 7 5 D
 -2 11 D
 -19 -12 D
@@ -16990,41 +17712,37 @@ HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
 -23 -10 D
 12 2 D
 -1 -7 D
--59 -35 D
+-15 -9 D
+-15 -9 D
+-14 -8 D
+-15 -9 D
 -3 1 D
--17 -13 D
+-16 -12 D
+-1 -1 D
 10 12 D
 -18 -14 D
 -17 -4 D
 17 1 D
--16 -7 D
+-4 -2 D
+-12 -5 D
 -10 -8 D
--42 -25 D
+-21 -12 D
+-21 -13 D
 -5 0 D
 -13 -9 D
 -4 2 D
 1 -6 D
--18 -10 D
+-10 -6 D
+-8 -4 D
 -2 7 D
 -18 -9 D
 -20 -22 D
--59 -36 D
+-15 -9 D
+-22 -14 D
+-15 -9 D
+-7 -4 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3249 3573 M
 29 11 D
@@ -17052,33 +17770,7 @@ G$Y~>
 -34 -10 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6 -3 -17 -8 -14 0 3 3399 3637 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3149 3465 M
 7 4 D
 5 18 D
@@ -17105,139 +17797,18 @@ glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
 -13 -9 D
 31 1 D
 3 -8 D
--58 -7 D
+-57 -6 D
+-1 -1 D
 P
 FO
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6 4 6 3 6 4 6 3 6 4 6 4 6 3 -20 -22 -18 -9 -2 7 -8 -4 11 3263 3529 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 10 7 1 -6 -4 2 -13 -9 -5 0 5 3294 3548 SP
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 7 4 8 5 -10 -8 -12 -5 4 3358 3586 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4 3 17 1 -17 -4 -18 -14 10 12 5 3370 3593 SP
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 9 5 -16 -12 -3 1 3 3390 3605 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 10 6 -1 -7 12 2 -23 -10 5 -1 -19 -12 -2 11 7 5 8 3470 3652 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -7 -4 -8 -4 -8 -3 -8 -4 -7 -4 -18 -7 -16 -3 -3 3 52 22 -19 -11 52 20 -2 -1 12 3266 3594 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -9 -5 -9 -4 -9 -5 -9 -4 -10 -5 -9 -5 -9 -4 -9 -5 -9 -4 4 4 -20 -5 16 15 91 31 13 3098 3511 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3249 3573 M
 29 11 D
 -17 -9 D
@@ -17264,19 +17835,6 @@ W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
 -34 -10 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6 -3 -17 -8 -14 0 3 3399 3637 SP
 {pattern92 I} FS
 8 -3 2 3 2 3294 3465 SP
@@ -17313,8 +17871,15 @@ QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 21 11 D
 113 65 D
 52 30 D
--100 -72 D
--116 -83 D
+-23 -17 D
+-23 -16 D
+-24 -17 D
+-23 -16 D
+-31 -23 D
+-23 -16 D
+-23 -17 D
+-23 -16 D
+-23 -17 D
 -13 -4 D
 -13 -14 D
 -1 9 D
@@ -17397,7 +17962,8 @@ QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 12 7 D
 -3 -9 D
 19 7 D
--31 -24 D
+-21 -16 D
+-10 -8 D
 -4 2 D
 -18 -17 D
 0 -1 D
@@ -17429,20 +17995,6 @@ FO
 1 0 -2 -1 2 3371 3594 SP
 -5 -4 2 -5 15 11 -6 2 4 3511 3619 SP
 -4 -2 8 4 -1 1 3 3449 3573 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3509 3661 M
 -4 -10 D
@@ -17470,92 +18022,11 @@ rYe!oP<>6Oq#p\GG$Y~>
 18 -1 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 14 -5 -62 -38 -37 -15 -7 3 41 22 21 16 14 15 7 3307 3493 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -28 2 50 26 13 -1 6 7 26 10 5 3261 3508 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2 -4 -27 -17 2 10 22 11 4 3462 3636 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 27 20 6 -7 2 3356 3574 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -27 -15 2 -3 -55 -25 40 39 4 -1 10 5 6 3211 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3289 3465 M
 3 7 D
 -1 -7 D
@@ -17586,33 +18057,7 @@ G$Y~>
 -12 -11 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 7 5 7 6 0 -1 -18 -17 -4 2 5 3412 3545 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3449 3573 M
 -1 1 D
 13 8 D
@@ -17643,20 +18088,6 @@ glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
 22 9 D
 P
 FO
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3511 3619 M
 -6 2 D
 15 11 D
@@ -17700,19 +18131,6 @@ Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
 10 3 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3684 3745 M
 -13 -4 D
 -13 -14 D
@@ -17737,40 +18155,15 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
 20 7 D
 P
 FO
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -11 -6 21 15 0 -3 3 3449 3640 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3371 3594 M
 -2 -1 D
 1 0 D
 -8 -5 D
 2 1 D
--28 -16 D
+-6 -3 D
+-14 -8 D
+-8 -5 D
 13 1 D
 17 8 D
 40 28 D
@@ -17778,22 +18171,12 @@ UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
 -3 1 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3273 3535 M
--58 -34 D
+-10 -6 D
+-12 -7 D
+-12 -7 D
+-12 -7 D
+-12 -7 D
 -5 -7 D
 10 2 D
 16 10 D
@@ -17805,19 +18188,6 @@ QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -16 2 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3509 3661 M
 -4 -10 D
 -9 -2 D
@@ -17844,68 +18214,15 @@ $jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 18 -1 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 14 -5 -62 -38 -37 -15 -7 3 41 22 21 16 14 15 7 3307 3493 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -28 2 50 26 13 -1 6 7 26 10 5 3261 3508 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2 -4 -27 -17 2 10 22 11 4 3462 3636 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 27 20 6 -7 2 3356 3574 SP
 {pattern92 I} FS
 3399 3465 M
 2 7 D
--15 -7 D
+-14 -7 D
+-1 0 D
 8 4 D
 -15 -3 D
 26 10 D
@@ -17983,9 +18300,10 @@ QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 69 50 D
 31 22 D
 -145 -139 D
--37 -35 D
--1 -2 D
--9 -3 D
+-36 -34 D
+-2 -3 D
+-2 -1 D
+-7 -2 D
 -18 -17 D
 -1 5 D
 -10 -11 D
@@ -18027,20 +18345,6 @@ P
 FO
 -12 -15 14 7 6 8 3 3312 3465 SP
 4 3 -21 -6 8 -1 -23 -12 28 13 5 3623 3701 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3312 3465 M
 6 8 D
@@ -18074,40 +18378,14 @@ rYe!oP<>6Oq#p\GG$Y~>
 -10 2 D
 -6 -10 D
 8 16 D
--22 -15 D
+-4 -2 D
+-18 -13 D
 -23 -17 D
 -11 -9 D
 -17 -13 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -14 -7 2 7 2 3399 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3715 3723 M
 -7 -2 D
 -18 -17 D
@@ -18149,40 +18427,16 @@ P<>6Oq#p\GG$Y~>
 5 6 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -1 -1 1 3719 3727 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3623 3701 M
 28 13 D
 -23 -12 D
 8 -1 D
 -21 -6 D
--93 -68 D
+-20 -14 D
+-26 -20 D
+-20 -14 D
+-27 -20 D
 2 -3 D
 22 14 D
 10 0 D
@@ -18213,64 +18467,13 @@ q#p\GG$Y~>
 14 7 D
 -23 4 D
 -15 -5 D
+-24 -18 D
+-19 -13 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -8 -6 -8 -6 -7 2 17 12 14 4 5 3487 3601 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -4 -3 0 1 9 6 3 3456 3578 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -3 -2 -1 2 7 2 3 3443 3569 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -7 -5 -8 -5 -11 3 11 15 24 3 -2 -5 6 3390 3529 SP
 {pattern92 I} FS
 3506 3465 M
@@ -18340,35 +18543,8 @@ FO
 -15 -23 D
 P
 FO
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -4 -5 -11 1 1 4 3 3506 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3790 3743 M
 -3 11 D
 -10 -8 D
@@ -18383,10 +18559,11 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
 -3 9 D
 -11 -9 D
 14 16 D
--22 -7 D
--6 -15 D
+-21 -6 D
+-7 -16 D
 4 12 D
--24 -22 D
+-1 0 D
+-23 -22 D
 -5 -6 D
 -23 -21 D
 -5 -6 D
@@ -18518,20 +18695,6 @@ FO
 -2 -5 -1 -4 14 1 -1 11 -9 1 5 3796 3599 SP
 -2 -3 11 3 -8 4 3 3793 3591 SP
 -1 -4 -2 -5 11 -8 -8 8 11 1 -9 2 5 9 -5 2 8 3784 3564 SP
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3693 3465 M
 -5 2 D
@@ -18634,19 +18797,6 @@ $q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
 -27 -40 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -18 -9 -20 7 3 2 3 3733 3465 SP
 {pattern92 I} FS
 3782 3558 M
@@ -18684,122 +18834,14 @@ UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
 -149 0 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -3 -6 -2 -7 -4 2 -9 -10 -11 4 11 18 20 6 7 3829 3696 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 -5 -13 1 16 8 3 3826 3686 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 -6 -2 -6 -10 -4 16 22 4 3817 3660 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -1 -2 -2 3 4 2 3 3807 3631 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 -5 -1 -5 -7 3 3 11 9 1 5 3800 3612 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -1 0 1 1 2 3796 3598 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 -4 -1 -5 -3 2 5 13 2 -2 5 3789 3578 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -1 -3 -6 2 6 5 2 -1 4 3782 3558 SP
 {pattern92 I} FS
 3900 3048 M
@@ -18976,37 +19018,10 @@ pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
 P
 FO
 0 -2 0 4 -1 -1 3 4054 3450 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 18 -26 -10 -5 -5 7 -1 -11 -7 12 7 13 6 4049 3139 SP
 {pattern92 I} FS
 -3 10 10 -1 -1 13 -16 -8 0 -13 5 4056 3233 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4152 3128 M
 -6 -6 D
@@ -19051,34 +19066,7 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
 -20 75 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 0 3 1 0 1 -6 -1 -1 4 4150 3138 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4054 3450 M
 -1 -1 D
 -2 10 D
@@ -19199,61 +19187,7 @@ HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
 14 16 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -17 -1 -6 10 10 19 10 3 -16 1 0 5 19 8 7 3900 3048 SP
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 18 -26 -10 -5 -5 7 -1 -11 -7 12 7 13 6 4049 3139 SP
 {pattern92 I} FS
 -3 10 10 -1 -1 13 -16 -8 0 -13 5 4056 3233 SP
@@ -19339,19 +19273,6 @@ FO
 7 -3 -10 -10 4 -14 8 -3 -5 10 15 -3 5 -11 -14 9 32 -27 -14 15 0 10 -22 14 5 7 10 -4 -11 12 15 4192 3272 SP
 3 4 12 -12 -9 13 13 -12 -11 16 -23 15 8 2 -13 4 -2 -7 21 -28 17 -9 11 4244 3310 SP
 -30 29 -9 -17 32 -23 3 4219 3285 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4273 3347 M
 -17 5 D
@@ -19440,34 +19361,7 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
 -22 36 D
 P
 FO
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -3 6 7 -8 0 -4 3 4259 3370 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 -3 0 -5 -2 11 3 4053 3453 SP
 {pattern92 I} FS
 7 -3 -10 -10 4 -14 8 -3 -5 10 15 -3 5 -11 -14 9 32 -27 -14 15 0 10 -22 14 5 7 10 -4 -11 12 15 4192 3272 SP
@@ -19507,20 +19401,6 @@ UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
 -7 -19 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -1 -9 -15 9 3 8 3 4287 3437 SP
 {pattern92 I} FS
@@ -19545,19 +19425,6 @@ QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -24 -18 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4374 3437 M
 -1 0 D
@@ -19602,34 +19469,7 @@ $jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -73 78 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6 -8 5 -8 5 -9 -24 20 3 13 5 4247 3389 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -1 -9 -15 9 3 8 3 4287 3437 SP
 {pattern92 I} FS
 4515 3132 M
@@ -19686,20 +19526,6 @@ FO
 12 -4 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4789 3231 M
 -14 6 D
@@ -19803,19 +19629,6 @@ FO
 -3 -3 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4522 3465 M
 9 -6 D
@@ -19872,20 +19685,6 @@ FO
 -4 -3 1 5060 3326 SP
 43 -15 31 -6 -26 32 25 -31 -30 6 -44 16 4 -13 7 5194 3253 SP
 -18 26 -7 18 12 5 -20 5 -7 -6 13 -13 -1 -22 11 -4 7 -13 47 -34 8 -1 11 5240 3155 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 5194 3253 M
 4 -13 D
@@ -19971,19 +19770,6 @@ FO
 P
 FO
 3 1 -15 5 1 0 11 -4 -1 -1 5 5731 3095 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 5809 3031 M
 -17 11 D
@@ -20042,49 +19828,8 @@ pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
 19 -11 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -7 4 -8 4 -8 4 -7 4 -8 4 -7 4 -8 4 44 0 9 -6 -9 2 18 -9 5 -15 -6 -4 13 5794 3063 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -5 3 11 -4 -1 -1 3 5731 3095 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 5060 3326 M
 15 11 D
 23 -5 D
@@ -20096,19 +19841,6 @@ q#p\GG$Y~>
 186 -96 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 5194 3253 M
 -3 9 D
 34 -2 D
@@ -20173,20 +19905,6 @@ FO
 -7 4 -5 -3 10 -1 13 -8 -11 8 22 -15 24 -8 -1 0 -20 7 -17 11 0 1 11 5779 3071 SP
 -4 -3 5 2 2 5730 3096 SP
 6 -3 -13 6 2 5949 3115 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 5861 3031 M
 -29 15 D
@@ -20208,33 +19926,7 @@ G$Y~>
 61 -32 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 46 -24 59 -26 43 -23 1 -7 33 -13 0 -3 -132 63 -75 33 8 5911 3031 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 5949 3115 M
 -37 17 D
 -31 13 D
@@ -20250,34 +19942,7 @@ glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
 16 2 D
 P
 FO
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -7 3 -7 3 -7 3 17 -6 11 -6 5 5560 3280 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 5531 3195 M
 -45 35 D
 25 5 D
@@ -20311,20 +19976,6 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
 19 -8 D
 P
 FO
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6 -3 6 -3 6 -3 7 -4 6 -3 -20 7 -17 11 0 1 8 5779 3071 SP
 {pattern92 I} FS
 5988 3098 M
@@ -20383,19 +20034,6 @@ FO
 -11 5 20 -10 2 1 3 5538 3289 SP
 -56 18 20 -11 -46 5 10 -7 -36 12 -44 10 10 -6 43 -12 22 -9 9 5168 3465 SP
 11 -3 11 -4 10 -4 11 -3 11 -4 63 0 -27 5 -14 -2 -86 19 9 5303 3443 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 5303 3443 M
 -86 19 D
@@ -20460,20 +20098,6 @@ UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
 -67 25 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 7 -3 7 -3 6 -3 7 -3 6 -3 -40 17 1 0 7 5988 3098 SP
 {pattern92 I} FS
 2251 3358 M
@@ -20543,7 +20167,18 @@ QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -31 -10 D
 43 10 D
 -5 -4 D
--127 -54 D
+-10 -4 D
+-11 -5 D
+-11 -4 D
+-10 -5 D
+-11 -4 D
+-11 -5 D
+-10 -4 D
+-11 -5 D
+-10 -4 D
+-11 -5 D
+-10 -4 D
+-11 -5 D
 -11 -3 D
 -25 -11 D
 -13 3 D
@@ -20555,9 +20190,37 @@ QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 30 12 D
 -9 -6 D
 37 9 D
--90 -39 D
--144 -65 D
--45 -21 D
+-6 -2 D
+-12 -6 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-12 -6 D
+-6 -2 D
+-12 -6 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-11 -6 D
+-6 -2 D
+-12 -6 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-11 -6 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-11 -6 D
+-6 -2 D
+-12 -6 D
+-11 -5 D
+-6 -2 D
+-11 -6 D
+-17 -7 D
+-23 -11 D
+-11 -5 D
+-11 -5 D
 -279 0 D
 187 76 D
 96 38 D
@@ -20568,35 +20231,8 @@ QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 74 26 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 10 4 11 5 37 9 -9 -6 30 12 -1 -5 16 8 2 -2 16 5 -74 -24 -13 3 -25 -11 -11 -3 13 1977 3170 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2692 3465 M
 -71 -22 D
 -24 -3 D
@@ -20647,19 +20283,6 @@ pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
 38 14 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2251 3358 M
 34 10 D
 48 17 D
@@ -20685,6 +20308,37 @@ a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -49 -20 D
 81 33 D
 46 29 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-7 -2 D
 P
 FO
 {pattern92 I} FS
@@ -20727,10 +20381,38 @@ FO
 36 3 D
 -8 -10 D
 10 3 D
--152 -73 D
--145 -73 D
--55 -28 D
--74 -39 D
+-12 -6 D
+-6 -2 D
+-12 -6 D
+-12 -6 D
+-11 -5 D
+-12 -6 D
+-12 -6 D
+-6 -2 D
+-11 -6 D
+-12 -6 D
+-6 -2 D
+-11 -6 D
+-12 -6 D
+-11 -5 D
+-11 -6 D
+-6 -3 D
+-6 -2 D
+-11 -6 D
+-11 -6 D
+-6 -2 D
+-11 -6 D
+-12 -6 D
+-22 -11 D
+-22 -11 D
+-22 -11 D
+-22 -12 D
+-22 -11 D
+-22 -11 D
+-21 -11 D
+-21 -12 D
+-21 -11 D
+-11 -5 D
 -279 0 D
 131 60 D
 58 26 D
@@ -20747,46 +20429,94 @@ FO
 P
 FO
 -6 -3 -6 -2 -6 -3 19 0 5 11 5 2834 3454 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -17 -6 4 7 -27 -13 9 5 -21 -8 -3 3 20 9 2 -2 7 5 43 12 -22 -8 12 3 12 2075 3182 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2834 3454 M
 5 11 D
 -129 0 D
--90 -35 D
--30 -11 D
--183 -72 D
--57 -23 D
--22 -8 D
--35 -15 D
--22 -8 D
--167 -69 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
 -14 -11 D
 42 16 D
 -23 -12 D
@@ -20794,7 +20524,9 @@ QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -40 -14 D
 -45 -20 D
 -84 -23 D
--32 -14 D
+-11 -5 D
+-10 -4 D
+-11 -5 D
 6 2 D
 -12 -7 D
 158 49 D
@@ -20841,20 +20573,6 @@ QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 46 21 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -17 -6 4 7 -27 -13 9 5 -21 -8 -3 3 20 9 2 -2 7 5 43 12 -22 -8 12 3 12 2075 3182 SP
 {pattern92 I} FS
 -4 -3 8 3 2 2168 3031 SP
@@ -20950,7 +20668,10 @@ FO
 2861 3389 M
 -11 -3 D
 4 0 D
--50 -26 D
+-13 -7 D
+-12 -6 D
+-13 -7 D
+-12 -6 D
 -26 -8 D
 40 17 D
 -42 -14 D
@@ -20964,78 +20685,11 @@ FO
 73 15 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -17 -20 -38 -24 -4 3 22 10 -36 -13 47 20 -4 3 14 5 8 2169 3093 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -18 -8 6 1 -28 -17 19 20 12 2 -5 2 23 13 -7 -7 8 2249 3139 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 -5 16 8 -30 -18 -8 4 13 6 -1 -5 10 10 7 2325 3194 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -3 -3 13 1 -25 -11 15 4 -8 -8 -25 10 7 7 7 2154 3031 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2168 3031 M
 8 3 D
 -4 -3 D
@@ -21063,7 +20717,8 @@ HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
 1 8 D
 -40 -11 D
 29 15 D
--38 -15 D
+-2 0 D
+-36 -15 D
 20 15 D
 -9 0 D
 -53 -15 D
@@ -21075,12 +20730,51 @@ HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
 -35 -11 D
 -22 -13 D
 6 19 D
--99 -44 D
--40 -17 D
--45 -21 D
--33 -14 D
--197 -91 D
--49 -23 D
+-13 -6 D
+-7 -2 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-6 -3 D
+-7 -2 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-6 -3 D
+-7 -2 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-6 -3 D
+-6 -2 D
+-7 -3 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-6 -2 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-6 -2 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
 15 5 D
 -4 -6 D
 -16 -5 D
@@ -21152,63 +20846,9 @@ HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
 -24 -11 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3 2 4 0 -11 -3 3 2861 3389 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -17 -20 -38 -24 -4 3 22 10 -36 -13 47 20 -4 3 14 5 8 2169 3093 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -18 -8 6 1 -28 -17 19 20 12 2 -5 2 23 13 -7 -7 8 2249 3139 SP
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 -5 16 8 -30 -18 -8 4 13 6 -1 -5 10 10 7 2325 3194 SP
 {pattern92 I} FS
 7 4 6 3 6 3 6 3 7 4 6 3 6 3 -11 -3 -18 -10 -14 1 -40 -21 22 8 11 -1 13 2854 3386 SP
@@ -21229,7 +20869,12 @@ Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
 -6 -5 D
 12 7 D
 7 0 D
--82 -51 D
+-14 -9 D
+-13 -8 D
+-14 -8 D
+-14 -9 D
+-13 -8 D
+-14 -9 D
 -19 0 D
 8 11 D
 -13 0 D
@@ -21259,19 +20904,6 @@ FO
 -79 -30 -19 -4 10 0 -16 -2 7 -1 24 7 -13 -6 -31 -3 14 -3 61 20 -3 -17 22 20 13 2 27 13 13 -3 -12 9 16 2683 3267 SP
 -40 -26 37 16 17 14 17 7 -13 -9 21 13 6 2654 3167 SP
 -41 -15 -41 -3 26 -7 53 20 4 2643 3219 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 2580 3087 M
 6 4 D
@@ -21309,41 +20941,60 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
 11 10 D
 -17 0 D
 2 13 D
--69 -35 D
--34 -18 D
+-17 -9 D
+-18 -9 D
+-17 -8 D
+-17 -9 D
+-17 -9 D
+-17 -9 D
 3 1 D
 0 -4 D
--30 -11 D
+-23 -8 D
+-4 -1 D
+-3 -2 D
 11 -1 D
 22 8 D
 -40 -21 D
 -14 1 D
 -18 -10 D
--17 -6 D
--218 -118 D
--155 -88 D
--158 -94 D
--28 -18 D
--15 -8 D
+-11 -3 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-11 -6 D
+-16 -8 D
+-22 -12 D
+-22 -12 D
+-22 -12 D
+-21 -12 D
+-22 -11 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-21 -11 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -11 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -11 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-19 -11 D
+-19 -12 D
+-19 -12 D
+-19 -12 D
+-10 -5 D
+-5 -3 D
 280 0 D
 18 14 D
 26 18 D
 P
 FO
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 12 7 -6 -5 23 8 1 -3 19 13 -21 -9 14 11 30 2 -11 -13 48 17 44 6 -19 -12 6 -9 -18 -13 14 3027 3465 SP
 {pattern92 I} FS
 -79 -30 -19 -4 10 0 -16 -2 7 -1 24 7 -13 -6 -31 -3 14 -3 61 20 -3 -17 22 20 13 2 27 13 13 -3 -12 9 16 2683 3267 SP
@@ -21381,10 +21032,19 @@ FO
 -1 -6 D
 4 6 D
 11 0 D
--109 -84 D
--165 -133 D
--168 -144 D
--53 -48 D
+-32 -24 D
+-31 -24 D
+-31 -24 D
+-38 -31 D
+-31 -24 D
+-37 -30 D
+-37 -30 D
+-37 -30 D
+-43 -36 D
+-49 -42 D
+-49 -42 D
+-67 -60 D
+-13 -12 D
 -6 2 D
 11 9 D
 7 27 D
@@ -21443,66 +21103,12 @@ FO
 12 7 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -10 -11 52 23 -13 -13 18 3 -24 -11 -59 -40 14 15 -11 -6 2 21 17 12 -14 -3 2 7 18 8 13 3112 3322 SP
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 14 23 25 9 4 -10 3 3125 3441 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 40 17 -7 -7 -21 -9 3 3077 3310 SP
 {pattern92 I} FS
 10 4 15 19 -13 -4 17 15 -12 -3 34 26 -29 -18 -64 -62 -7 -7 20 15 8 -4 20 12 -1 6 13 2614 3097 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 2810 3056 M
 -6 2 D
@@ -21582,16 +21188,33 @@ pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
 10 13 D
 -18 -9 D
 -9 -1 D
--29 -17 D
--212 -136 D
--97 -65 D
--102 -71 D
--33 -23 D
--8 -6 D
+-19 -11 D
+-19 -12 D
+-19 -12 D
+-19 -12 D
+-28 -18 D
+-18 -11 D
+-19 -12 D
+-27 -18 D
+-19 -12 D
+-18 -11 D
+-27 -18 D
+-27 -18 D
+-26 -18 D
+-18 -11 D
+-26 -18 D
+-26 -18 D
+-26 -17 D
+-25 -18 D
+-26 -18 D
+-16 -12 D
+-17 -11 D
+-16 -12 D
 1 -2 D
 -41 -29 D
 27 22 D
--51 -38 D
+-26 -19 D
+-25 -19 D
 -13 -9 D
 -12 -9 D
 279 0 D
@@ -21599,92 +21222,11 @@ pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
 6 7 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 0 1 3304 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4 6 -1 -6 2 3291 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 3 24 -3 2 3264 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -10 -11 52 23 -13 -13 18 3 -24 -11 -59 -40 14 15 -11 -6 2 21 17 12 -14 -3 2 7 18 8 13 3112 3322 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 14 23 25 9 4 -10 3 3125 3441 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 40 17 -7 -7 -21 -9 3 3077 3310 SP
 {pattern92 I} FS
 10 4 15 19 -13 -4 17 15 -12 -3 34 26 -29 -18 -64 -62 -7 -7 20 15 8 -4 20 12 -1 6 13 2614 3097 SP
@@ -21872,37 +21414,10 @@ P
 FO
 16 8 -17 -8 2 3387 3465 SP
 16 7 -15 -6 2 3125 3107 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 18 14 17 2 -30 -22 -6 6 4 3288 3421 SP
 {pattern92 I} FS
 9 0 -5 -11 7 13 8 2 -5 -23 14 18 -7 -8 -1 15 10 9 -5 1 -1 -7 -16 -8 -2 6 -16 -3 7 -2 -5 -15 16 3092 3134 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 2968 3031 M
 9 5 D
@@ -21988,19 +21503,6 @@ q#p\GG$Y~>
 -14 -12 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3387 3465 M
 -17 -8 D
 16 8 D
@@ -22103,40 +21605,14 @@ HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
 0 1 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 3 6 -3 2 3305 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 18 14 17 2 -30 -22 -6 6 4 3288 3421 SP
 {pattern92 I} FS
 9 0 -5 -11 7 13 8 2 -5 -23 14 18 -7 -8 -1 15 10 9 -5 1 -1 -7 -16 -8 -2 6 -16 -3 7 -2 -5 -15 16 3092 3134 SP
 3115 3031 M
 3 3 D
--7 -3 D
+-5 -3 D
+-2 0 D
 29 23 D
 -1 6 D
 8 0 D
@@ -22301,49 +21777,9 @@ fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -53 -95 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -14 -15 -36 -20 -1 6 8 0 -1 6 29 23 6 3111 3031 SP
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -5 -3 3 3 2 3115 3031 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3526 3465 M
 -21 -17 D
 9 -1 D
@@ -22461,34 +21897,7 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
 14 22 D
 P
 FO
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 10 20 6 -10 -7 11 0 -8 -9 5 3492 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3126 3108 M
 32 14 D
 -18 -4 D
@@ -22506,20 +21915,6 @@ UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
 -4 -1 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3067 3036 M
 35 22 D
 26 3 D
@@ -22591,19 +21986,6 @@ FO
 P
 FO
 -3 1 -2 -1 2 3698 3465 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3723 3377 M
 -3 3 D
@@ -22626,20 +22008,6 @@ $jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 8 -5 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3698 3465 M
 -2 -1 D
 -94 1 D
@@ -22739,19 +22107,6 @@ P
 FO
 10 1 -7 1 -3 3 3 3900 3107 SP
 0 14 1 3900 3093 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3793 3071 M
 23 8 D
@@ -22781,20 +22136,6 @@ a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -5 -6 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3900 3093 M
 0 14 D
 -3 3 D
@@ -22845,19 +22186,6 @@ W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
 48 3 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3707 3328 M
 11 -7 D
 41 19 D
@@ -22876,20 +22204,6 @@ QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -3 5 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3793 3071 M
 23 8 D
 2 39 D
@@ -22984,64 +22298,10 @@ FO
 P
 FO
 0 15 -18 -15 2 3918 3031 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -17 -7 -11 16 0 26 19 7 4 4043 2792 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4 -10 -53 -6 6 34 3 4161 2743 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -13 -14 -4 19 8 14 3 4046 2846 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4273 2615 M
 -17 -11 D
 -24 14 D
@@ -23066,19 +22326,6 @@ q#p\GG$Y~>
 376 0 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3918 3031 M
 -18 -15 D
 0 -203 D
@@ -23124,63 +22371,9 @@ HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
 -7 24 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -4 4 4 3 2 3900 2784 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -17 -7 -11 16 0 26 19 7 4 4043 2792 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4 -10 -53 -6 6 34 3 4161 2743 SP
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -13 -14 -4 19 8 14 3 4046 2846 SP
 {pattern92 I} FS
 4511 2598 M
@@ -23317,51 +22510,11 @@ Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
 -35 -3 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 2 -8 -42 11 -8 -5 1 7 25 0 5 4340 2706 SP
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -37 -13 9 10 -5 6 16 9 4 4490 2696 SP
 {pattern92 I} FS
 -68 35 -4 14 16 0 -2 16 12 4 -14 -4 1 -12 -19 -1 13 -26 6 3 10 4400 2998 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4511 2598 M
 -12 26 D
@@ -23380,20 +22533,6 @@ UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
 3 -17 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4556 2834 M
 -26 0 D
 -36 7 D
@@ -23441,19 +22580,6 @@ QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -36 83 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4234 2807 M
 16 -16 D
 6 2 D
@@ -23537,34 +22663,7 @@ $jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 25 -94 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2 -8 -42 11 -8 -5 1 7 25 0 5 4340 2706 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -37 -13 9 10 -5 6 16 9 4 4490 2696 SP
 {pattern92 I} FS
 -68 35 -4 14 16 0 -2 16 12 4 -14 -4 1 -12 -19 -1 13 -26 6 3 10 4400 2998 SP
@@ -23630,20 +22729,6 @@ FO
 3 10 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4801 2598 M
 -1 1 D
@@ -23748,19 +22833,6 @@ P
 FO
 -27 19 19 -22 -5 -15 -52 8 -4 -8 9 4 57 -8 4 9 8 5011 2953 SP
 -25 5 -5 -9 8 -3 3 5144 2873 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4800 2950 M
 -3 9 D
@@ -23794,20 +22866,6 @@ FO
 {pattern92 I} FS
 -27 19 19 -22 -5 -15 -52 8 -4 -8 9 4 57 -8 4 9 8 5011 2953 SP
 -25 5 -5 -9 8 -3 3 5144 2873 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 5403 2598 M
 375 0 D
@@ -23839,19 +22897,6 @@ FO
 P
 FO
 9 -7 8 -7 9 -7 -5 15 -7 7 -22 6 6 6048 2693 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 6048 2693 M
 -22 6 D
@@ -24005,50 +23050,9 @@ FO
 P
 FO
 -2 2 3 2 -12 4 -16 13 -1 29 20 0 -20 0 0 19 -9 -9 6 -14 -5 -19 34 -27 12 5811 3031 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -10 11 15 -5 22 -27 21 -14 2 4 -16 10 8 2 15 -12 -13 6 21 -11 -11 -11 -45 20 -28 34 3 8 14 6330 2619 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 5 23 -15 4 2 6 -17 -10 5 -1 -10 -16 3 -15 8 -6 13 20 -6 -5 12 11 6320 2662 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6190 2598 M
 -20 7 D
 -18 -3 D
@@ -24066,34 +23070,7 @@ q#p\GG$Y~>
 17 -15 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -4 3 -1 1 8 -6 3 6382 2710 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6247 2802 M
 33 -28 D
 8 -30 D
@@ -24129,48 +23106,8 @@ G$Y~>
 -84 57 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -9 5 -9 6 3 2 20 -15 5 -4 5 6200 2831 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -7 4 -7 4 -7 4 -7 4 -6 4 40 -23 1 -2 7 6133 2873 SP
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 5811 3031 M
 34 -27 D
 -5 -19 D
@@ -24245,48 +23182,8 @@ Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
 -60 33 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 10 -8 9 -7 10 -8 5 -4 5 -4 -4 -7 -45 9 -11 11 13 -3 10 9 -13 11 13 -2 -10 5 -1 6 14 6014 2721 SP
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -10 11 15 -5 22 -27 21 -14 2 4 -16 10 8 2 15 -12 -13 6 21 -11 -11 -11 -45 20 -28 34 3 8 14 6330 2619 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 5 23 -15 4 2 6 -17 -10 5 -1 -10 -16 3 -15 8 -6 13 20 -6 -5 12 11 6320 2662 SP
 {pattern92 I} FS
 6389 2705 M
@@ -24349,50 +23246,9 @@ P
 FO
 -6 5 9 -8 3 -1 3 6370 2719 SP
 -9 6 6 -5 12 -7 1 0 4 6228 2814 SP
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -66 30 35 -13 10 2 -48 30 -72 30 -11 8 21 -12 20 -4 -21 17 157 -88 10 5886 3031 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 7 -4 7 -4 8 -4 7 -4 8 -4 8 -5 7 -4 -6 0 -41 23 -13 10 10 5915 2998 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6174 2848 M
 11 5 D
 -30 10 D
@@ -24413,19 +23269,6 @@ pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
 1 -6 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6228 2814 M
 13 -7 D
 53 -36 D
@@ -24471,11 +23314,58 @@ FO
 196 87 D
 121 52 D
 279 0 D
--193 -94 D
--157 -81 D
--145 -81 D
--120 -72 D
--110 -72 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-13 -6 D
+-12 -6 D
+-13 -7 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-16 -9 D
+-22 -12 D
+-22 -12 D
+-21 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-19 -12 D
+-19 -12 D
+-19 -12 D
+-19 -12 D
+-27 -18 D
+-27 -18 D
+-26 -18 D
+-25 -18 D
 P
 FO
 1270 2598 M
@@ -24487,13 +23377,37 @@ FO
 175 87 D
 83 40 D
 279 0 D
--45 -24 D
--16 -10 D
--144 -81 D
--130 -78 D
--112 -72 D
--103 -72 D
--88 -66 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -7 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-19 -12 D
+-19 -12 D
+-20 -12 D
+-28 -18 D
+-27 -18 D
+-19 -12 D
+-26 -18 D
+-27 -18 D
+-26 -18 D
+-25 -18 D
+-25 -18 D
+-32 -24 D
+-31 -24 D
+-38 -30 D
 P
 FO
 2128 3031 M
@@ -24535,7 +23449,8 @@ FO
 -25 -44 D
 -15 -13 D
 8 -3 D
--67 -58 D
+-49 -43 D
+-18 -15 D
 -5 -6 D
 -12 -10 D
 -5 -6 D
@@ -24550,20 +23465,6 @@ FO
 39 21 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 2172 3031 M
 -7 -7 D
@@ -24603,34 +23504,7 @@ W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
 37 24 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 12 6 -2 -6 2 2158 3031 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 30 34 17 -6 -23 -11 21 5 -19 -22 5 2128 3031 SP
 {pattern92 I} FS
 -16 -26 19 -14 34 40 3 1748 2598 SP
@@ -24645,19 +23519,6 @@ rYe!oP<>6Oq#p\GG$Y~>
 5 6 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 1748 2598 M
 34 40 D
@@ -24672,12 +23533,24 @@ pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
 114 90 D
 48 37 D
 -280 0 D
--127 -82 D
--94 -64 D
--128 -93 D
--30 -24 D
--15 -11 D
--78 -64 D
+-27 -18 D
+-19 -12 D
+-18 -11 D
+-27 -18 D
+-18 -11 D
+-26 -18 D
+-18 -12 D
+-26 -17 D
+-25 -17 D
+-25 -18 D
+-25 -17 D
+-32 -24 D
+-24 -17 D
+-24 -18 D
+-30 -23 D
+-30 -23 D
+-36 -29 D
+-42 -35 D
 17 -8 D
 0 -17 D
 -45 -70 D
@@ -24739,20 +23612,6 @@ FO
 P
 FO
 -5 -5 9 2 -4 2 27 1 30 11 -5 -6 -12 -3 -1 -6 32 21 -23 5 -43 -16 11 2614 2862 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 2216 2598 M
 -11 4 D
@@ -24844,11 +23703,15 @@ P<>6Oq#p\GG$Y~>
 10 11 D
 66 63 D
 -279 0 D
--132 -103 D
--101 -84 D
--67 -60 D
--63 -60 D
--71 -72 D
+-32 -24 D
+-32 -25 D
+-38 -30 D
+-37 -30 D
+-37 -30 D
+-43 -36 D
+-55 -48 D
+-83 -78 D
+-77 -78 D
 -43 -48 D
 -5 -6 D
 P
@@ -24963,67 +23826,13 @@ P
 FO
 5 6 -21 -8 -13 -10 24 7 4 2624 2873 SP
 4 5 5 4 -12 -7 -1 -6 4 2675 2926 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -14 -10 10 13 -30 0 22 10 4 2951 2944 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -21 5 -6 7 6 5 3 3018 3011 SP
 {pattern92 I} FS
 -11 0 10 6 31 0 22 12 -44 1 -19 -7 -8 -12 -16 -8 8 2726 2911 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 1 2 26 9 -4 -11 -34 -21 13 16 20 12 -5 0 -18 -13 -1 5 9 2997 2946 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2675 2926 M
 -1 -6 D
 -12 -7 D
@@ -25131,33 +23940,7 @@ G$Y~>
 -5 -6 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -14 -10 10 13 -30 0 22 10 4 2951 2944 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -21 5 -6 7 6 5 3 3018 3011 SP
 {pattern92 I} FS
 -11 0 10 6 31 0 22 12 -44 1 -19 -7 -8 -12 -16 -8 8 2726 2911 SP
@@ -25219,20 +24002,6 @@ glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
 P
 FO
 13 10 -15 -10 2 3113 3031 SP
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3113 3031 M
 -15 -10 D
@@ -25280,19 +24049,6 @@ Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
 1 2 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 -1 0 2 3 1 3 2994 2943 SP
 {pattern92 I} FS
 3524 2598 M
@@ -25363,35 +24119,8 @@ FO
 P
 FO
 3 5 1 13 -4 4 3 3900 2791 SP
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 182 0 -1 -1 1 -29 -12 -25 -47 -32 -19 -38 -8 -3 -13 16 -30 -5 -3 7 -15 1 -18 -14 -17 -3 13 3900 2724 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3900 2791 M
 -4 4 D
 1 13 D
@@ -25434,20 +24163,6 @@ P
 FO
 {pattern92 I} FS
 0 -7 8 3 5 -14 9 3 -18 30 -24 -12 6 4220 2231 SP
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3900 2166 M
 427 0 D
@@ -25490,19 +24205,6 @@ FO
 2 0 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4736 2280 M
 -3 5 D
@@ -25530,20 +24232,6 @@ $jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -14 93 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4511 2598 M
 46 -50 D
 4 39 D
@@ -25634,19 +24322,6 @@ FO
 5 -29 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4986 2166 M
 -1 7 D
@@ -25670,20 +24345,6 @@ a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 4 -31 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4843 2598 M
 42 -45 D
 22 -6 D
@@ -25696,19 +24357,6 @@ W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
 -11 21 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4713 2390 M
 19 -14 D
 54 -65 D
@@ -25789,20 +24437,6 @@ FO
 -20 53 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 5589 2166 M
 2 5 D
@@ -25916,19 +24550,6 @@ FO
 P
 FO
 2 -6 2 -5 1 0 -7 16 4 6015 2221 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 6003 2166 M
 3 7 D
@@ -26120,20 +24741,6 @@ FO
 -109 0 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -4 -13 -33 -3 -7 8 -1 21 11 11 15 -4 6 6142 2346 SP
 {pattern92 I} FS
@@ -26166,19 +24773,6 @@ P<>6Oq#p\GG$Y~>
 -25 5 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 6168 2166 M
 -3 4 D
@@ -26273,63 +24867,9 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
 31 -15 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -6 -10 5 -10 -8 5 6 -15 -13 19 14 11 6 6437 2166 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -4 7 -4 7 -3 7 16 -19 2 -10 -3 1 6 6396 2303 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2 -5 -4 8 0 1 3 6019 2212 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -4 -13 -33 -3 -7 8 -1 21 11 11 15 -4 6 6142 2346 SP
 {pattern92 I} FS
 6158 2166 M
@@ -26365,7 +24905,8 @@ FO
 1 17 D
 -9 4 D
 0 -20 D
--60 -1 D
+-3 -1 D
+-57 0 D
 -13 33 D
 -25 54 D
 -12 22 D
@@ -26430,107 +24971,13 @@ FO
 23 -48 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -16 3 -16 23 7 -1 -4 8 22 -21 5 6546 2187 SP
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 8 -12 3 -36 -14 6 -33 65 4 6330 2425 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 24 -17 -18 -1 -12 9 -16 25 19 -6 5 6556 2194 SP
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -25 11 -4 -4 -4 9 18 16 4 6500 2175 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -30 8 -4 18 5 1 15 -16 4 6450 2230 SP
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -3 -1 0 -20 -9 4 1 17 4 6529 2166 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6225 2526 M
 3 -1 D
 -11 27 D
@@ -26548,20 +24995,6 @@ $jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 42 -41 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6411 2275 M
 5 -6 D
 13 -8 D
@@ -26595,77 +25028,10 @@ pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
 -11 4 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -16 3 -16 23 7 -1 -4 8 22 -21 5 6546 2187 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 8 -12 3 -36 -14 6 -33 65 4 6330 2425 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 24 -17 -18 -1 -12 9 -16 25 19 -6 5 6556 2194 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -25 11 -4 -4 -4 9 18 16 4 6500 2175 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -30 8 -4 18 5 1 15 -16 4 6450 2230 SP
 {pattern92 I} FS
 7314 2166 M
@@ -26721,8 +25087,11 @@ FO
 73 54 D
 99 66 D
 375 0 D
--95 -72 D
--91 -78 D
+-32 -24 D
+-32 -24 D
+-31 -24 D
+-43 -36 D
+-48 -42 D
 -62 -60 D
 -38 -42 D
 -21 -24 D
@@ -26743,8 +25112,9 @@ FO
 64 54 D
 95 72 D
 376 0 D
--77 -66 D
--69 -66 D
+-43 -36 D
+-66 -60 D
+-37 -36 D
 -50 -54 D
 -41 -48 D
 -40 -54 D
@@ -26752,35 +25122,8 @@ FO
 -23 -42 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -6 16 30 11 2 707 2360 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -6 16 30 11 2 707 2360 SP
 {pattern92 I} FS
 1339 2166 M
@@ -26855,20 +25198,6 @@ FO
 31 30 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 1785 2598 M
 -14 -23 D
@@ -26896,19 +25225,6 @@ q#p\GG$Y~>
 50 59 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1724 2598 M
 -3 -6 D
 4 -28 D
@@ -27047,20 +25363,6 @@ FO
 P
 FO
 -19 6 14 -22 2 2083 2211 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 2086 2166 M
 -4 5 D
@@ -27143,48 +25445,8 @@ G$Y~>
 -4 -16 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 5 7 4 8 32 -6 5 -5 -11 -2 2 -4 17 -1 35 17 19 1 -15 -3 -14 -15 -63 -11 -20 6 13 2303 2445 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 24 69 35 40 -3 -4 11 1 -7 -10 9 -7 -9 -23 8 1 -2 -12 -12 -10 9 1 -19 -21 4 -23 2 -2 14 2325 2598 SP
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 21 8 -3 -8 2 2294 2598 SP
 {pattern92 I} FS
 -19 6 14 -22 2 2083 2211 SP
@@ -27248,136 +25510,15 @@ Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
 -3 -18 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 7 -13 40 4 9 -9 -8 -5 -37 3 5 -11 -6 -9 13 -5 -15 -6 -56 6 -1 9 -12 -1 11 5 -22 11 9 8 40 -5 14 10 17 2433 2338 SP
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 8 -11 -30 -1 -11 10 18 2 4 2311 2335 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 -9 -34 -1 11 9 3 2539 2338 SP
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 0 -3 -13 -14 -11 -7 -11 3 -5 -8 -18 1 -41 -25 -9 9 21 11 -4 18 13 15 11 2363 2166 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 5 -17 -35 -17 -7 3 -1 -5 10 1 -8 -12 -4 15 -25 7 -2 15 -41 -4 -23 13 -32 -9 12 -4 -51 -2 24 8 -7 8 16 2566 2166 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -5 -7 -4 -8 -3 1 -41 34 -22 4 5 10 -28 9 21 7 56 2 -18 -11 0 -7 17 -2 3 -19 23 -5 14 2290 2422 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 7 -13 40 4 9 -9 -8 -5 -37 3 5 -11 -6 -9 13 -5 -15 -6 -56 6 -1 9 -12 -1 11 5 -22 11 9 8 40 -5 14 10 17 2433 2338 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 8 -11 -30 -1 -11 10 18 2 4 2311 2335 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 -9 -34 -1 11 9 3 2539 2338 SP
 {pattern92 I} FS
 3046 2166 M
@@ -27457,20 +25598,6 @@ FO
 17 108 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3718 2598 M
 -11 -15 D
@@ -27568,19 +25695,6 @@ P
 FO
 -2 0 0 8 -3 -61 4 25 1 -1 0 6 0 1 -3 5 3 11 9 3900 2096 SP
 0 -3 33 18 15 32 -9 -61 10 62 35 38 -1 18 -2 -20 -48 -46 1 -18 -19 -14 -15 -3 12 4333 1985 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4333 1985 M
 -15 -3 D
@@ -27652,33 +25766,6 @@ pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
 5 126 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -3 5 3 11 2 3900 2096 SP
 {pattern92 I} FS
 4747 1734 M
@@ -27722,20 +25809,6 @@ FO
 -10 -18 18 10 1 9 3 4505 1745 SP
 -18 26 12 -48 2 4681 2050 SP
 -3 -15 20 19 0 11 3 4561 1972 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4625 1734 M
 0 7 D
@@ -27816,19 +25889,6 @@ FO
 8 80 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4765 1883 M
 5 8 D
@@ -27879,49 +25939,9 @@ FO
 -3 12 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -2 9 -2 10 -2 9 -2 10 12 -26 -4 5 2 -27 7 5611 2149 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3 -1 -2 -1 2 5608 2161 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3 11 -8 5 19 5 1 14 11 7 24 -18 13 -24 7 5526 2166 SP
 {pattern92 I} FS
 5621 2101 M
@@ -27967,64 +25987,10 @@ P
 FO
 -1 5 1 -8 -8 2 9 -4 4 5609 2159 SP
 2 -7 2 -7 2 -7 18 0 -6 16 -13 0 -7 12 7 6042 2138 SP
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 0 11 -1 10 0 11 -1 11 0 10 0 11 19 -17 8 -32 24 -12 22 -31 31 -21 9 -19 -50 7 -19 17 2 8 -37 19 -6 7 17 6064 2012 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 8 -2 9 -2 9 -2 8 37 -36 7 4 2 -39 -10 0 -6 16 -13 0 -7 12 11 6042 2138 SP
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 0 -1 1 6003 2166 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -5 -1 -31 29 -17 32 9 17 23 5 8 -22 2 -10 2 -9 2 -10 2 -9 2 -10 1 -8 -8 2 9 -4 14 5609 2159 SP
 {pattern92 I} FS
 6067 1938 M
@@ -28111,20 +26077,6 @@ UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
 8 79 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 6386 1863 M
 30 19 D
@@ -28186,106 +26138,12 @@ QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -1 -18 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 68 -8 36 -13 22 3 30 -8 -5 -9 27 -4 -14 -6 -8 -13 -47 8 -11 13 -31 2 -16 -12 -30 10 -9 19 -27 1 3 21 11 -4 17 6343 1765 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3 -15 14 -1 -5 -9 -16 -1 -4 17 -12 3 4 10 7 6209 1885 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -10 -7 -23 7 10 -9 -6 -4 -24 12 51 10 6 6403 1754 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 15 10 8 -15 -10 0 3 6367 1774 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 5 2 5 2 0 17 -11 -23 -5 -1 1 6 6466 1749 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 2 4 -1 -5 -3 3 6471 1765 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6500 1962 M
 -3 -14 D
 -5 2 D
@@ -28302,78 +26160,10 @@ pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
 4 56 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2 2 9 22 14 12 -23 -36 4 6435 2166 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -5 4 7 -4 2 6170 2166 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -8 10 17 -10 -12 14 16 13 11 -1 1 -26 6 6143 2166 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2 -9 2 -9 2 -8 2 -9 -17 34 -26 6 -40 33 -10 17 -4 37 -20 31 8 -6 9 9 50 -34 19 -32 18 -48 3 -4 16 6052 2095 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6067 1938 M
 6 -6 D
 25 -51 D
@@ -28402,19 +26192,6 @@ G$Y~>
 -22 23 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6386 1863 M
 30 19 D
 -4 6 D
@@ -28475,63 +26252,9 @@ fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -1 -18 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 68 -8 36 -13 22 3 30 -8 -5 -9 27 -4 -14 -6 -8 -13 -47 8 -11 13 -31 2 -16 -12 -30 10 -9 19 -27 1 3 21 11 -4 17 6343 1765 SP
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3 -15 14 -1 -5 -9 -16 -1 -4 17 -12 3 4 10 7 6209 1885 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -10 -7 -23 7 10 -9 -6 -4 -24 12 51 10 6 6403 1754 SP
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 15 10 8 -15 -10 0 3 6367 1774 SP
 {pattern92 I} FS
 6557 1734 M
@@ -28637,19 +26360,6 @@ $q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
 -16 -43 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 6594 2076 M
 5 5 D
@@ -28681,121 +26391,13 @@ UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
 1 -21 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 17 -15 6 -28 -10 -25 -3 20 8 8 -23 -14 0 11 11 6 -16 13 21 -6 -1 17 11 6673 1943 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -27 4 -9 19 19 -11 32 2 5 -8 7 11 -3 -11 7 6669 1884 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -18 -18 -20 0 7 11 23 7 4 6858 1769 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -11 -6 2 18 16 15 -8 -21 4 6794 1821 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -9 11 13 6 13 -12 3 6626 1879 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 -5 -1 -5 -2 -5 -12 15 4 6478 1734 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -5 -8 -38 -21 -49 -6 72 35 4 6557 1734 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6931 1902 M
 -44 16 D
 -18 -7 D
@@ -28841,34 +26443,7 @@ pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
 10 42 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -8 15 5 6 19 -17 -5 -4 4 6518 2166 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6488 1829 M
 10 0 D
 3 57 D
@@ -28901,34 +26476,7 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
 -6 -55 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 0 -2 -12 -7 -20 8 -20 -2 -13 -10 -1 6 33 12 34 -3 8 6470 1761 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6594 2076 M
 5 5 D
 5 -11 D
@@ -28959,77 +26507,10 @@ HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
 1 -21 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 17 -15 6 -28 -10 -25 -3 20 8 8 -23 -14 0 11 11 6 -16 13 21 -6 -1 17 11 6673 1943 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -27 4 -9 19 19 -11 32 2 5 -8 7 11 -3 -11 7 6669 1884 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -18 -18 -20 0 7 11 23 7 4 6858 1769 SP
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -11 -6 2 18 16 15 -8 -21 4 6794 1821 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -9 11 13 6 13 -12 3 6626 1879 SP
 {pattern92 I} FS
 7099 1734 M
@@ -29091,64 +26572,10 @@ FO
 -163 0 D
 P
 FO
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 33 6 23 -16 -33 -1 -8 -11 3 11 -18 -1 -20 -13 2 -14 -15 -2 -5 5 13 14 -1 8 26 13 13 7155 1821 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -19 29 10 2 7 -14 3 7239 1816 SP
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 7 -26 30 -24 -43 33 3 7207 1862 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 7099 1734 M
 -2 4 D
 8 4 D
@@ -29187,63 +26614,9 @@ $jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 17 -41 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 2 8 -3 -5 -5 -5 3 4 7320 1747 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 33 6 23 -16 -33 -1 -8 -11 3 11 -18 -1 -20 -13 2 -14 -15 -2 -5 5 13 14 -1 8 26 13 13 7155 1821 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -19 29 10 2 7 -14 3 7239 1816 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 7 -26 30 -24 -43 33 3 7207 1862 SP
 {pattern92 I} FS
 7318 1742 M
@@ -29274,20 +26647,6 @@ QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -427 0 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -1 -3 -14 10 16 -5 3 7318 1742 SP
 {pattern92 I} FS
@@ -29434,64 +26793,10 @@ FO
 -2 -5 -1 -5 63 0 -10 22 -9 1 1 -5 -16 8 -25 -11 8 2189 2151 SP
 0 -1 2 2 -2 1 3 2188 2144 SP
 -1 -8 -2 -7 12 7 -7 16 4 2181 2112 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -1 10 -1 11 -1 10 -1 11 -2 10 -2 10 28 -16 -6 -7 13 -30 -26 -19 10 2170 1877 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 0 9 0 10 0 9 -1 9 0 9 5 7 14 -9 2 -27 -14 -9 5 -6 -11 -11 11 2167 1953 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 0 5 2 -9 -2 0 3 2167 1967 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2181 2112 M
 -7 16 D
 12 7 D
@@ -29518,19 +26823,6 @@ q#p\GG$Y~>
 10 1 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 4 7 6 10 -8 -1 -2 4 2072 2166 SP
 {pattern92 I} FS
 -2 10 -2 11 -2 10 -2 10 -2 10 -3 10 -38 0 25 -39 27 -31 0 -1 10 2179 1805 SP
@@ -29542,7 +26834,8 @@ HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
 5 23 D
 11 8 D
 -1 2 D
--8 -1 D
+-4 -1 D
+-4 0 D
 0 3 D
 4 4 D
 -1 1 D
@@ -29620,20 +26913,6 @@ FO
 18 -1 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 2602 1879 M
 -38 -15 D
@@ -29737,48 +27016,8 @@ G$Y~>
 -11 67 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 0 -2 -2 -1 -1 1 4 4 4 2188 2147 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -1 -4 -4 0 -4 -1 -1 2 11 8 5 2186 2135 SP
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 0 1 2181 2112 SP
 {pattern92 I} FS
 2602 1881 M
@@ -29793,7 +27032,8 @@ Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
 0 -6 D
 7 1 D
 32 17 D
--29 -17 D
+-22 -13 D
+-7 -4 D
 -19 -2 D
 -8 -25 D
 3 27 D
@@ -29864,35 +27104,8 @@ FO
 -5 -127 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -43 4 10 25 21 8 16 -1 5 -14 -6 -2 6 -5 7 2800 1933 SP
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3034 1889 M
 -49 -1 D
 -25 12 D
@@ -29956,7 +27169,8 @@ $q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
 0 -6 D
 7 1 D
 32 17 D
--29 -17 D
+-22 -13 D
+-7 -4 D
 -19 -2 D
 -8 -25 D
 3 27 D
@@ -29975,34 +27189,7 @@ $q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
 -11 132 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 1 2 0 2 2602 1881 SP
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -43 4 10 25 21 8 16 -1 5 -14 -6 -2 6 -5 7 2800 1933 SP
 {pattern92 I} FS
 3129 1734 M
@@ -30022,19 +27209,6 @@ QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 5 -108 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3129 1734 M
 22 36 D
@@ -30075,20 +27249,6 @@ FO
 24 -28 -2 10 15 1 -17 0 -4 12 -14 7 12 4 -14 0 8 3900 2113 SP
 5 1 -5 0 2 3900 2112 SP
 1 3 15 -5 -16 8 3 3900 2090 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3900 2090 M
 -16 8 D
@@ -30125,19 +27285,6 @@ P
 FO
 {pattern92 I} FS
 0 432 -323 0 32 -80 1 -82 47 -98 -2 -46 -19 -53 -25 -25 -6 -27 9 -21 10 4186 1734 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4186 1734 M
 9 -21 D
@@ -30179,20 +27326,6 @@ P
 FO
 -4 35 9 13 -6 40 -14 7 6 -43 -8 -20 5 -32 7 4637 1734 SP
 -1 -2 7 0 -6 5 3 4753 1729 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4480 1302 M
 11 12 D
@@ -30250,19 +27383,6 @@ FO
 28 107 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4781 1400 M
 45 11 D
@@ -30299,34 +27419,7 @@ QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -2 -58 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -2 -11 -1 -11 -2 -10 -2 -11 -2 -11 -2 -11 -1 -10 -2 -11 -1 -11 -2 -10 -1 -11 -12 9 8 14 -2 31 6 4 -3 41 23 30 17 4733 1600 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4781 1400 M
 45 11 D
 92 147 D
@@ -30432,20 +27525,6 @@ FO
 16 48 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 6348 1523 M
 -21 -4 D
@@ -30474,19 +27553,6 @@ P<>6Oq#p\GG$Y~>
 9 11 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 1 1 -1 2 6459 1734 SP
 {pattern92 I} FS
 6460 1733 M
@@ -30581,35 +27647,8 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
 16 40 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 17 11 5 -17 -6 8 -5 -4 4 6683 1705 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6793 1571 M
 -8 1 D
 -2 13 D
@@ -30704,48 +27743,8 @@ HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
 49 59 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 13 6 12 1 -5 -7 3 6537 1734 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -17 0 10 7 8 -6 3 6460 1733 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 17 11 5 -17 -6 8 -5 -4 4 6683 1705 SP
 {pattern92 I} FS
 6780 1302 M
@@ -30796,24 +27795,13 @@ glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
 -43 -48 D
 -41 -42 D
 -59 -54 D
--64 -54 D
--95 -72 D
+-49 -42 D
+-38 -30 D
+-32 -24 D
+-32 -24 D
+-8 -6 D
 P
 FO
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 6780 1302 M
 45 30 D
@@ -30856,19 +27844,6 @@ Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
 -42 -35 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -1 2 -17 3 19 10 6 -8 41 -5 0 -2 6 7051 1734 SP
 {pattern92 I} FS
 7647 1602 M
@@ -30880,10 +27855,15 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
 -20 -23 D
 -51 -52 D
 -38 -35 D
--84 -69 D
--70 -52 D
--67 -46 D
--36 -23 D
+-41 -34 D
+-43 -35 D
+-30 -23 D
+-24 -17 D
+-24 -17 D
+-25 -18 D
+-26 -17 D
+-26 -17 D
+-18 -12 D
 -375 0 D
 95 72 D
 91 78 D
@@ -30900,79 +27880,11 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
 -25 -33 D
 P
 FO
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 7 -7 -32 -14 4 15 3 7583 1562 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -9 -28 -10 49 2 7249 1468 SP
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -14 -5 6 7 31 1 -44 -15 4 7647 1602 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 7 -7 -32 -14 4 15 3 7583 1562 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -9 -28 -10 49 2 7249 1468 SP
 {pattern92 I} FS
 153 1602 M
@@ -30999,19 +27911,6 @@ pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
 -38 40 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 {pattern92 I} FS
 1270 1302 M
@@ -31119,20 +28018,6 @@ FO
 P
 FO
 -1 12 -19 9 -4 -4 -7 11 -3 -8 26 -18 6 2447 1618 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 2231 1734 M
 19 -28 D
@@ -31187,19 +28072,6 @@ FO
 P
 FO
 6 -12 7 -43 -58 -1 51 -4 8 5 -6 33 1 6 -8 16 8 2780 1302 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 2780 1302 M
 -8 16 D
@@ -31263,20 +28135,6 @@ FO
 -29 103 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3085 1521 M
 2 6 D
@@ -31317,19 +28175,6 @@ FO
 0 433 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 2 10 2 10 2 11 2 10 2 11 2 10 2 11 2 10 2 10 2 11 18 -16 8 5 5 -32 -10 -7 -1 -18 13 -36 16 4223 1302 SP
 {pattern92 I} FS
@@ -31350,20 +28195,6 @@ pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
 38 165 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4256 1198 M
 50 18 D
@@ -31406,35 +28237,8 @@ FO
 -6 -7 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 7 10 -11 -4 9 7 -19 -4 8 7 11 -1 -3 7 9 -5 9 5 9 4869 876 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 7 10 -11 -4 9 7 -19 -4 8 7 11 -1 -3 7 9 -5 9 5 9 4869 876 SP
 {pattern92 I} FS
 5296 869 M
@@ -31451,8 +28255,12 @@ q#p\GG$Y~>
 -57 -60 D
 -73 -72 D
 -73 -66 D
--91 -78 D
--114 -90 D
+-55 -48 D
+-44 -36 D
+-37 -30 D
+-38 -30 D
+-31 -24 D
+-32 -25 D
 P
 FO
 6060 1302 M
@@ -31464,11 +28272,24 @@ FO
 9 -15 D
 22 -2 D
 67 26 D
--72 -60 D
--93 -72 D
--109 -78 D
--153 -102 D
--57 -36 D
+-43 -36 D
+-37 -30 D
+-38 -30 D
+-31 -24 D
+-25 -18 D
+-32 -24 D
+-25 -18 D
+-26 -18 D
+-26 -18 D
+-26 -18 D
+-27 -18 D
+-27 -18 D
+-27 -18 D
+-19 -12 D
+-28 -18 D
+-19 -12 D
+-19 -12 D
+-9 -6 D
 -280 0 D
 132 103 D
 101 84 D
@@ -31479,19 +28300,6 @@ FO
 5 6 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 6060 1302 M
 -10 -11 D
@@ -31536,11 +28344,28 @@ FO
 2 3 D
 -30 -22 D
 -4 -6 D
--109 -71 D
--106 -65 D
--123 -71 D
--54 -29 D
--65 -36 D
+-26 -17 D
+-27 -18 D
+-19 -12 D
+-27 -18 D
+-19 -11 D
+-19 -12 D
+-19 -12 D
+-20 -12 D
+-19 -12 D
+-20 -12 D
+-20 -11 D
+-20 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -12 D
+-21 -11 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-22 -12 D
+-11 -6 D
 -279 0 D
 130 84 D
 106 72 D
@@ -31548,20 +28373,6 @@ FO
 91 72 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 6060 1217 M
 64 0 D
@@ -31623,12 +28434,59 @@ FO
 47 25 D
 36 22 D
 126 0 D
--97 -66 D
--114 -72 D
--134 -78 D
--169 -90 D
--175 -87 D
--83 -40 D
+-26 -18 D
+-26 -18 D
+-26 -18 D
+-19 -12 D
+-27 -18 D
+-19 -12 D
+-19 -12 D
+-19 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-13 -7 D
+-12 -6 D
+-7 -3 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
 -279 0 D
 108 60 D
 32 17 D
@@ -31636,34 +28494,8 @@ FO
 104 65 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -14 -10 0 4 -21 -20 -26 -17 -10 13 -42 -10 48 31 -7 -6 52 28 -7 -11 40 20 2 -7 12 6206 1014 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6312 1141 M
 -9 -12 D
 23 -18 D
@@ -31687,24 +28519,15 @@ glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
 47 25 D
 36 22 D
 -250 0 D
--73 -57 D
--78 -58 D
+-29 -23 D
+-29 -23 D
+-30 -23 D
+-31 -23 D
+-24 -17 D
+-25 -17 D
+-24 -17 D
 P
 FO
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -14 -10 0 4 -21 -20 -26 -17 -10 13 -42 -10 48 31 -7 -6 52 28 -7 -11 40 20 2 -7 12 6206 1014 SP
 {pattern92 I} FS
 6413 869 M
@@ -31716,26 +28539,85 @@ Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
 110 72 D
 47 33 D
 375 0 D
--98 -60 D
--127 -72 D
--157 -81 D
--169 -81 D
--196 -87 D
+-19 -12 D
+-19 -12 D
+-20 -12 D
+-19 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 6766 1064 M
 -18 -6 D
@@ -31772,20 +28654,6 @@ G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
 -6 -15 D
 P
 FO
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6453 951 M
 29 8 D
 94 40 D
@@ -31814,19 +28682,6 @@ $q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
 -3 -11 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6766 1064 M
 -18 -6 D
 -4 -7 D
@@ -31862,20 +28717,6 @@ UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
 -6 -15 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 6453 951 M
 29 8 D
 94 40 D
@@ -32110,49 +28951,9 @@ FO
 P
 FO
 4 17 -21 29 19 -27 -3 -17 4 2786 1277 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 15 -22 7 -10 -9 0 -26 29 4 5 5 2732 1013 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -6 13 19 -14 -10 2 13 -15 -30 25 3 4 6 2855 869 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2943 869 M
 -8 6 D
 9 -6 D
@@ -32254,20 +29055,6 @@ a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 11 -8 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 15 -22 7 -10 -9 0 -26 29 4 5 5 2732 1013 SP
 {pattern92 I} FS
 2885 1112 M
@@ -32307,19 +29094,6 @@ W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
 P
 FO
 -2 -12 7 -13 1 0 -8 16 3 7 5 2785 1279 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 2781 1302 M
 7 -13 D
@@ -32351,20 +29125,6 @@ QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 2 24 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4 -7 4 -8 -7 0 -8 16 3 7 5 2785 1279 SP
 {pattern92 I} FS
 3621 869 M
@@ -32391,9 +29151,12 @@ FO
 3984 435 M
 -21 3 D
 -3 -3 D
--47 0 D
+-17 0 D
+-1 0 D
+-29 0 D
 -6 2 D
--5 -2 D
+-3 -2 D
+-2 0 D
 -2 9 D
 0 425 D
 279 0 D
@@ -32408,78 +29171,11 @@ FO
 -16 -12 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 0 -9 -2 9 2 3902 435 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -3 -2 -6 2 2 3913 435 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -1 0 1 3943 435 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -3 -3 -21 3 2 3984 435 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 1 3 52 0 -16 -12 -4 8 -17 -4 -8 8 -8 -6 -1 0 8 4051 441 SP
 {pattern92 I} FS
 4187 435 M
@@ -32502,49 +29198,9 @@ HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
 -24 -26 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -1 -3 -1 -3 -13 6 3 4064 435 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -69 -29 -14 22 -13 -9 12 10 -6 6 5 4187 435 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4 7 4 6 4 7 9 0 -24 -26 -2 0 6 4215 461 SP
 {pattern92 I} FS
 4400 490 M
@@ -32574,20 +29230,6 @@ glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
 -77 -83 D
 P
 FO
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4400 490 M
 -7 1 D
@@ -32631,26 +29273,18 @@ FO
 48 59 D
 5 6 D
 279 0 D
--98 -89 D
--152 -130 D
--58 -48 D
+-78 -71 D
+-60 -53 D
+-49 -42 D
+-42 -35 D
+-43 -36 D
+-36 -30 D
 -23 -17 D
--105 -84 D
+-37 -30 D
+-37 -30 D
+-31 -24 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4551 478 M
 -16 -5 D
@@ -32693,28 +29327,28 @@ FO
 38 36 D
 13 11 D
 279 0 D
--72 -53 D
--142 -100 D
--87 -59 D
--90 -58 D
--83 -54 D
+-31 -23 D
+-32 -24 D
+-25 -17 D
+-25 -18 D
+-25 -18 D
+-25 -17 D
+-25 -18 D
+-26 -18 D
+-26 -17 D
+-26 -18 D
+-27 -18 D
+-26 -17 D
+-27 -18 D
+-27 -18 D
+-18 -11 D
+-19 -12 D
+-27 -18 D
+-19 -12 D
+-18 -12 D
 -19 -11 D
 P
 FO
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4794 528 M
 -18 0 D
@@ -32730,7 +29364,8 @@ $q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
 -33 -7 D
 -19 -12 D
 -16 -4 D
--45 -34 D
+-28 -22 D
+-17 -12 D
 -11 -9 D
 149 0 D
 133 82 D
@@ -32749,7 +29384,8 @@ FO
 5 9 D
 -30 -16 D
 3 10 D
--20 -7 D
+-18 -7 D
+-2 0 D
 18 12 D
 19 11 D
 74 48 D
@@ -32759,26 +29395,48 @@ FO
 57 41 D
 31 23 D
 280 0 D
--197 -118 D
--83 -48 D
--32 -17 D
--129 -72 D
--178 -94 D
+-19 -11 D
+-20 -12 D
+-19 -12 D
+-19 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -11 D
+-20 -12 D
+-20 -12 D
+-21 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -11 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-22 -11 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-6 -3 D
+-11 -5 D
+-11 -6 D
+-12 -6 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4922 502 M
 -23 -2 D
@@ -32792,9 +29450,17 @@ UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
 5 9 D
 -30 -16 D
 3 10 D
--20 -7 D
--125 -77 D
+-18 -7 D
+-2 0 D
+-17 -11 D
+-16 -10 D
+-17 -10 D
 -25 -16 D
+-16 -10 D
+-17 -10 D
+-17 -10 D
+-17 -11 D
+-8 -5 D
 149 0 D
 18 10 D
 19 9 D
@@ -32819,27 +29485,75 @@ FO
 67 42 D
 15 8 D
 279 0 D
--204 -105 D
--80 -39 D
--55 -28 D
--238 -111 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -7 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
 -13 -7 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -3 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 5104 507 M
 -12 15 D
@@ -32852,10 +29566,13 @@ QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 7 7 D
 -28 -9 D
 -7 0 D
--73 -38 D
--28 -15 D
+-18 -10 D
+-18 -9 D
+-19 -10 D
+-18 -9 D
+-19 -10 D
 -19 -9 D
--9 -5 D
+-18 -10 D
 149 0 D
 70 31 D
 P
@@ -32882,29 +29599,135 @@ FO
 184 93 D
 51 27 D
 279 0 D
--168 -77 D
--54 -23 D
--116 -51 D
--190 -79 D
--183 -75 D
--38 -14 D
--174 -69 D
--54 -20 D
+-12 -6 D
+-7 -2 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-7 -3 D
+-6 -3 D
+-7 -2 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 5111 443 M
 6 3 D
@@ -32919,8 +29742,27 @@ $jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 9 9 D
 -18 -4 D
 -5 7 D
--81 -36 D
--81 -36 D
+-11 -5 D
+-6 -3 D
+-6 -2 D
+-11 -5 D
+-12 -6 D
+-11 -5 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-11 -6 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-11 -5 D
+-12 -6 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-5 -3 D
 148 0 D
 P
 FO
@@ -32938,26 +29780,152 @@ FO
 116 54 D
 19 8 D
 279 0 D
--246 -99 D
--352 -133 D
--347 -123 D
--229 -79 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -11 -4 -10 -4 16 8 3 5095 435 SP
 {pattern92 I} FS
@@ -33126,64 +30094,10 @@ FO
 P
 FO
 6 -6 2 6 -13 6 3 3349 543 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 -8 -7 -7 7 -7 -1 20 -10 -24 10 1 -5 -9 8 0 -5 23 -9 3 -14 16 -1 13 -13 -18 -5 -39 28 -50 17 13 8 16 3068 761 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4 -2 -2 -4 -12 6 3 3348 435 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 12 -12 -14 4 20 -15 -8 -4 -45 27 5 3390 435 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3445 435 M
 -16 13 D
 -43 56 D
@@ -33211,34 +30125,7 @@ rYe!oP<>6Oq#p\GG$Y~>
 17 -13 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 4 2 4 -2 2 2944 869 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2866 869 M
 9 -6 D
 -14 2 D
@@ -33285,33 +30172,6 @@ P<>6Oq#p\GG$Y~>
 -6 3 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 -8 -7 -7 7 -7 -1 20 -10 -24 10 1 -5 -9 8 0 -5 23 -9 3 -14 16 -1 13 -13 -18 -5 -39 28 -50 17 13 8 16 3068 761 SP
 {pattern92 I} FS
 3352 540 M
@@ -33340,63 +30200,10 @@ q#p\GG$Y~>
 -6 5 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 9 -5 -4 -7 9 -13 -17 10 0 -6 -8 6 15 2 -9 5 5 1 9 3112 825 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 5 -5 5 -4 -15 -14 -12 9 12 3 -11 17 11 -5 1 4 8 3338 555 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 2 -1 -10 5 7 -2 3 3352 540 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 9 -5 -4 -7 9 -13 -17 10 0 -6 -8 6 15 2 -9 5 5 1 9 3112 825 SP
 {pattern92 I} FS
 3751 435 M
@@ -33420,20 +30227,6 @@ FO
 279 0 D
 P
 FO
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 12 0 -6 -4 -6 -5 3 3900 444 SP
 {pattern92 I} FS
@@ -33441,19 +30234,6 @@ Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
 -17 6 -12 -6 2 3942 435 SP
 -12 4 -5 -4 2 3960 435 SP
 -11 1 -2 -1 2 3997 435 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&
-(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD
-`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P
--F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3997 435 M
 -2 -1 D
@@ -33475,20 +30255,6 @@ FO
 {pattern92 I} FS
 -16 7 -17 -7 2 4097 435 SP
 -1 1 -1 -1 2 4189 435 SP
-/image86 {<~
-G[=C46#OU`
-$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ
-<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
-9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@
-+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4189 435 M
 -1 -1 D
@@ -33504,19 +30270,6 @@ $q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
 65 97 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`I
-hgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQu
-f^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sb
-UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3900 0 M
 76 73 D
 132 126 D
@@ -33531,20 +30284,6 @@ UA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
 -30 -43 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_
-&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uq
-p^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_
-E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5Sf
-QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3900 0 M
 93 67 D
 193 139 D
@@ -33559,44 +30298,35 @@ QQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -139 -133 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]Q
-gB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-cs
-RM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z
-$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3900 0 M
 347 199 D
 41 25 D
 195 114 D
 161 97 D
 -149 0 D
--185 -139 D
--141 -103 D
--193 -139 D
+-32 -24 D
+-32 -24 D
+-32 -24 D
+-32 -25 D
+-25 -18 D
+-32 -24 D
+-25 -18 D
+-25 -18 D
+-25 -18 D
+-33 -24 D
+-33 -25 D
+-25 -18 D
+-25 -18 D
+-25 -18 D
+-25 -18 D
+-26 -18 D
+-25 -18 D
+-34 -25 D
+-25 -18 D
+-25 -18 D
+-26 -18 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^
-gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K
-86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&G
-pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:
-6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3900 0 M
 133 63 D
 31 16 D
@@ -33605,24 +30335,43 @@ pW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
 253 123 D
 187 94 D
 -149 0 D
--252 -151 D
--135 -78 D
--31 -19 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-21 -13 D
+-20 -12 D
+-20 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -12 D
+-21 -13 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK
-1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2
-@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFV
-a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3900 0 M
 155 63 D
 44 19 D
@@ -33630,27 +30379,89 @@ a:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 339 142 D
 218 94 D
 -149 0 D
--309 -154 D
--162 -78 D
--37 -19 D
--246 -117 D
--31 -16 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -7 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-13 -6 D
+-12 -7 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -7 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU
-(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&R
-W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#
-&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T
-2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 3900 0 M
 194 70 D
 361 129 D
@@ -33658,10 +30469,146 @@ W]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U
 321 117 D
 248 94 D
 -148 0 D
--339 -145 D
--225 -94 D
--316 -129 D
--51 -22 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
 P
 FO
 {pattern92 I} FS
@@ -33687,23 +30634,67 @@ FO
 -23 6 D
 14 7 D
 144 0 D
--168 -57 D
--43 -14 D
+-8 -3 D
+-9 -3 D
+-8 -2 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -2 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -2 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -2 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -2 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -2 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -2 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -2 D
+-9 -3 D
+-9 -3 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l
-!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJH
-U,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"L
-QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 4726 265 M
 -20 14 D
@@ -33727,11 +30718,150 @@ QC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 -23 6 D
 14 7 D
 -5 0 D
--354 -133 D
--273 -99 D
--58 -22 D
--319 -114 D
--186 -67 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -4 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
 541 173 D
 P
 FO
@@ -33747,20 +30877,6 @@ FO
 240 -91 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]
-\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-
-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(
-\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)p
-rYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3181 259 M
 17 -11 D
@@ -33790,19 +30906,6 @@ FO
 254 -109 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-
-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB
-#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd
-7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3131 318 M
 3 -3 D
@@ -33837,20 +30940,6 @@ FO
 149 0 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&
-h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*
-)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W3
-17IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!o
-P<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3172 352 M
 -21 3 D
@@ -33890,19 +30979,6 @@ FO
 149 0 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs
-?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d
->iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=
-03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3223 395 M
 -9 -9 D
@@ -33943,20 +31019,6 @@ FO
 69 -53 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]
-Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@23
-0KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5
-\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6O
-q#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3394 368 M
 -8 3 D
@@ -34002,19 +31064,6 @@ FO
 3 -2 1 3390 435 SP
 8 -8 8 -9 8 -8 8 -8 9 0 -50 41 6 3495 394 SP
 8 -9 9 -8 8 -9 9 -8 8 -8 -33 42 -18 8 7 3567 322 SP
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fL
-HlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]D
-HI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks
-><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3567 322 M
 -18 8 D
@@ -34077,20 +31126,6 @@ FO
 -8 9 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r
-70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52
-\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJ
-P-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\G
-G$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3720 259 M
 -44 7 D
@@ -34110,19 +31145,6 @@ G$Y~>
 -69 100 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJ
-l(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK
-%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>U
-fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 7 -8 7 -7 -14 13 -7 9 4 3516 372 SP
 {pattern92 I} FS
 3774 367 M
@@ -34144,19 +31166,6 @@ fm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
 149 0 D
 P
 FO
-/image86 {<~
-G[=C46#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]
-W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?gT,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u
-'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*
-glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3774 367 M
 -4 -25 D
@@ -34181,20 +31190,6 @@ P
 FO
 {pattern92 I} FS
 -3 10 -4 9 -3 10 -3 10 -3 10 -4 9 -3 10 -2 -10 -37 -14 -2 -16 -22 -17 -38 -1 -12 -10 -1 0 14 3888 435 SP
-/image86 {<~
-G[=C4
-6#OU`$q3A_&m:0^gjgGU(0/J]\u:K&h=jM]Kd1,r70MW]W+m!&(CP`Ihgr]QgB7eK1Mm6l!IS>-pYYQs?n*fLHlMTJl(e?g
-T,IMQ<h+Uqp^E@K86^&RW]V_-72<?*)l@230KW52\Y[.u'sXuD`EIQuf^-csRM`+2@NYJHU,+WB#b#"d>iA]DHI0WK%`\+;
-Sq2=U9ucc_E5Q&GpW7V#&#1c(\!;W317IQ5\T$tJP-IZ*glk4P-F&sbUA4;Z$jaFVa:%"LQC;gd7S=]=03)ks><C>Ufm?/&
-3JhM@+D5SfQQ:u:6l6/T2-c)prYe!oP<>6Oq#p\GG$Y~>
-/FlateDecode filter} def
-/pattern86 {V 768 768 scale
-<< /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
-   {begin [/Indexed /DeviceRGB 1 <FFFF00FF0000>] setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
-   /ImageMatrix [64 0 0 -64 0 64] /DataSource image86
->> image end}
->> matrix makepattern U} def
 {pattern86 I} FS
 3888 435 M
 -13 -10 D
@@ -34296,36 +31291,368 @@ P
 -38 13 D
 -568 181 D
 -49 16 D
--646 -206 D
--38 -13 D
--107 -34 D
--38 -13 D
--115 -37 D
--47 -16 D
--105 -34 D
--361 -122 D
--287 -100 D
--26 -10 D
--189 -68 D
--273 -103 D
--135 -53 D
--23 -10 D
--107 -43 D
--37 -16 D
--209 -90 D
--175 -81 D
--19 -10 D
--39 -18 D
--43 -22 D
--120 -62 D
--52 -28 D
--16 -10 D
--33 -18 D
--95 -56 D
--50 -31 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -4 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -4 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -4 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -4 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -4 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-15 -7 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-15 -7 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-15 -7 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-14 -7 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -7 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -7 D
+-13 -6 D
+-13 -6 D
+-12 -6 D
+-13 -7 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -7 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -7 D
+-12 -6 D
+-12 -6 D
+-11 -6 D
+-12 -7 D
+-12 -6 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -7 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-27 -16 D
+-21 -12 D
+-21 -13 D
+-21 -12 D
+-20 -13 D
+-20 -12 D
+-20 -12 D
 -28 -19 D
--99 -68 D
--73 -56 D
+-28 -19 D
+-27 -18 D
+-27 -19 D
+-34 -25 D
+-32 -25 D
+-24 -18 D
 -22 -19 D
 -50 -43 D
 -57 -56 D
@@ -34380,135 +31707,31 @@ P
 49 -16 D
 P S
 %%EndObject
-currentdict /image85 undef
-currentdict /pattern85 undef
-currentdict /image91 undef
-currentdict /pattern91 undef
-0 -3900 TM
+currentdict /image86 undef
+currentdict /pattern86 undef
+currentdict /image92 undef
+currentdict /pattern92 undef
+0 -4233 TM
 0 A
 FQ
 O0
-0 3900 TM
+0 4233 TM
 
 % PostScript produced by:
-%@GMT: pstext -F+f32p,Helvetica-Bold,lightgreen=thinner -Xa0i -Ya3.25i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pstext -F+f32p,Helvetica-Bold,lightgreen=thinner -Xa0i -Ya3.5278i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_11
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 clipsave
-3900 0 M
-706 226 D
-421 138 D
-371 125 D
-390 138 D
-236 88 D
-257 100 D
-241 100 D
-224 100 D
-155 75 D
-145 75 D
-133 75 D
-83 50 D
-58 37 D
-72 50 D
-83 63 D
-60 49 D
-53 50 D
-37 38 D
-43 49 D
-29 38 D
-25 37 D
-21 37 D
-19 38 D
-14 37 D
-11 37 D
-8 38 D
-5 50 D
--2 49 D
--5 38 D
--13 49 D
--13 38 D
--17 37 D
--13 25 D
--31 50 D
--28 37 D
--31 38 D
--46 49 D
--52 50 D
--44 38 D
--79 62 D
--69 50 D
--115 75 D
--150 87 D
--141 75 D
--152 75 D
--219 100 D
--237 100 D
--253 100 D
--233 88 D
--279 100 D
--327 113 D
--337 113 D
--581 188 D
--433 138 D
--706 -226 D
--421 -138 D
--371 -125 D
--390 -138 D
--236 -88 D
--257 -100 D
--241 -100 D
--224 -100 D
--155 -75 D
--145 -75 D
--133 -75 D
--83 -50 D
--58 -37 D
--72 -50 D
--83 -63 D
--60 -49 D
--53 -50 D
--37 -38 D
--43 -49 D
--29 -38 D
--25 -37 D
--21 -37 D
--19 -38 D
--14 -37 D
--11 -37 D
--8 -38 D
--5 -50 D
-2 -49 D
-5 -38 D
-13 -49 D
-13 -38 D
-17 -37 D
-13 -25 D
-31 -50 D
-28 -37 D
-31 -38 D
-46 -49 D
-52 -50 D
-44 -38 D
-79 -62 D
-69 -50 D
-115 -75 D
-150 -87 D
-141 -75 D
-152 -75 D
-219 -100 D
-237 -100 D
-253 -100 D
-233 -88 D
-279 -100 D
-327 -113 D
-337 -113 D
-581 -188 D
+0 0 M
+7800 0 D
+0 3900 D
+-7800 0 D
 P
 PSL_clip N
-PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
 8 W
 {0.565 0.933 0.565 C} FS
 O1
@@ -34516,131 +31739,27 @@ O1
 (SILLY USES OF) mc false charpath fs S
 PSL_cliprestore
 %%EndObject
-0 -3900 TM
+0 -4233 TM
 0 A
 FQ
 O0
-0 3900 TM
+0 4233 TM
 
 % PostScript produced by:
-%@GMT: pstext -F+f32p,Helvetica-Bold,magenta=thinner -Xa0i -Ya3.25i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pstext -F+f32p,Helvetica-Bold,magenta=thinner -Xa0i -Ya3.5278i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_12
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 clipsave
-3900 0 M
-706 226 D
-421 138 D
-371 125 D
-390 138 D
-236 88 D
-257 100 D
-241 100 D
-224 100 D
-155 75 D
-145 75 D
-133 75 D
-83 50 D
-58 37 D
-72 50 D
-83 63 D
-60 49 D
-53 50 D
-37 38 D
-43 49 D
-29 38 D
-25 37 D
-21 37 D
-19 38 D
-14 37 D
-11 37 D
-8 38 D
-5 50 D
--2 49 D
--5 38 D
--13 49 D
--13 38 D
--17 37 D
--13 25 D
--31 50 D
--28 37 D
--31 38 D
--46 49 D
--52 50 D
--44 38 D
--79 62 D
--69 50 D
--115 75 D
--150 87 D
--141 75 D
--152 75 D
--219 100 D
--237 100 D
--253 100 D
--233 88 D
--279 100 D
--327 113 D
--337 113 D
--581 188 D
--433 138 D
--706 -226 D
--421 -138 D
--371 -125 D
--390 -138 D
--236 -88 D
--257 -100 D
--241 -100 D
--224 -100 D
--155 -75 D
--145 -75 D
--133 -75 D
--83 -50 D
--58 -37 D
--72 -50 D
--83 -63 D
--60 -49 D
--53 -50 D
--37 -38 D
--43 -49 D
--29 -38 D
--25 -37 D
--21 -37 D
--19 -38 D
--14 -37 D
--11 -37 D
--8 -38 D
--5 -50 D
-2 -49 D
-5 -38 D
-13 -49 D
-13 -38 D
-17 -37 D
-13 -25 D
-31 -50 D
-28 -37 D
-31 -38 D
-46 -49 D
-52 -50 D
-44 -38 D
-79 -62 D
-69 -50 D
-115 -75 D
-150 -87 D
-141 -75 D
-152 -75 D
-219 -100 D
-237 -100 D
-253 -100 D
-233 -88 D
-279 -100 D
-327 -113 D
-337 -113 D
-581 -188 D
+0 0 M
+7800 0 D
+0 3900 D
+-7800 0 D
 P
 PSL_clip N
-PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
 8 W
 {1 0 1 C} FS
 O1
@@ -34648,15 +31767,15 @@ O1
 (COLOR PATTERNS) mc false charpath fs S
 PSL_cliprestore
 %%EndObject
-0 -3900 TM
+0 -4233 TM
 0 A
 FQ
 O0
-0 3900 TM
+0 4233 TM
 
 % PostScript produced by:
-%@GMT: psimage -DjCM+w3i @GMT_covertext.eps -Xa0i -Ya3.25i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt psimage -DjCM+w3i @GMT_covertext.eps -Xa0i -Ya3.5278i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_13
 0 setlinecap
 0 setlinejoin
@@ -34983,16 +32102,16 @@ showpage
 %%EndDocument
 PSL_eps_end
 %%EndObject
-0 -3900 TM
+0 -4233 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 0 TM
+0 333 TM
 
 % PostScript produced by:
-%@GMT: grdimage lon.nc -Clon.cpt -nl -Blrtb -Bxaf -Byaf -Xa0i -Ya0i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt grdimage lon.nc -Clon.cpt -nl -Blrtb -Bxaf -Byaf -Xa0i -Ya0.2778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_14
 0 setlinecap
 0 setlinejoin
@@ -35053,21 +32172,104 @@ clipsave
 -337 113 D
 -581 188 D
 -433 138 D
--706 -226 D
--421 -138 D
--371 -125 D
--390 -138 D
--236 -88 D
--257 -100 D
--241 -100 D
--224 -100 D
--155 -75 D
--145 -75 D
--133 -75 D
--83 -50 D
--58 -37 D
--72 -50 D
--83 -63 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-39 -12 D
+-40 -13 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -13 D
+-38 -12 D
+-39 -13 D
+-39 -12 D
+-38 -13 D
+-38 -12 D
+-38 -13 D
+-39 -12 D
+-38 -13 D
+-38 -12 D
+-37 -13 D
+-38 -13 D
+-38 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-36 -12 D
+-36 -13 D
+-37 -13 D
+-36 -12 D
+-35 -13 D
+-36 -12 D
+-35 -13 D
+-36 -12 D
+-35 -13 D
+-35 -12 D
+-35 -13 D
+-34 -12 D
+-34 -13 D
+-35 -12 D
+-33 -13 D
+-34 -12 D
+-34 -13 D
+-33 -13 D
+-33 -12 D
+-33 -13 D
+-33 -12 D
+-32 -13 D
+-32 -12 D
+-32 -13 D
+-32 -12 D
+-32 -13 D
+-31 -12 D
+-31 -13 D
+-31 -12 D
+-30 -13 D
+-30 -12 D
+-30 -13 D
+-30 -12 D
+-30 -13 D
+-29 -12 D
+-29 -13 D
+-29 -12 D
+-28 -13 D
+-28 -12 D
+-28 -13 D
+-27 -12 D
+-28 -13 D
+-27 -12 D
+-26 -13 D
+-27 -12 D
+-26 -13 D
+-26 -12 D
+-50 -25 D
+-50 -25 D
+-48 -25 D
+-47 -25 D
+-46 -25 D
+-44 -25 D
+-43 -25 D
+-42 -25 D
+-41 -25 D
+-39 -25 D
+-56 -37 D
+-52 -38 D
+-66 -50 D
 -60 -49 D
 -53 -50 D
 -37 -38 D
@@ -35529,36 +32731,368 @@ P
 -38 13 D
 -568 181 D
 -49 16 D
--646 -206 D
--38 -13 D
--107 -34 D
--38 -13 D
--115 -37 D
--47 -16 D
--105 -34 D
--361 -122 D
--287 -100 D
--26 -10 D
--189 -68 D
--273 -103 D
--135 -53 D
--23 -10 D
--107 -43 D
--37 -16 D
--209 -90 D
--175 -81 D
--19 -10 D
--39 -18 D
--43 -22 D
--120 -62 D
--52 -28 D
--16 -10 D
--33 -18 D
--95 -56 D
--50 -31 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -4 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -4 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -4 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -4 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -4 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-15 -7 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-15 -7 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-15 -7 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-14 -7 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -7 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -7 D
+-13 -6 D
+-13 -6 D
+-12 -6 D
+-13 -7 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -7 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -7 D
+-12 -6 D
+-12 -6 D
+-11 -6 D
+-12 -7 D
+-12 -6 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -7 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-27 -16 D
+-21 -12 D
+-21 -13 D
+-21 -12 D
+-20 -13 D
+-20 -12 D
+-20 -12 D
 -28 -19 D
--99 -68 D
--73 -56 D
+-28 -19 D
+-27 -18 D
+-27 -19 D
+-34 -25 D
+-32 -25 D
+-24 -18 D
 -22 -19 D
 -50 -43 D
 -57 -56 D
@@ -35613,15 +33147,15 @@ P
 49 -16 D
 P S
 %%EndObject
-0 0 TM
+0 -333 TM
 0 A
 FQ
 O0
-0 0 TM
+0 333 TM
 
 % PostScript produced by:
-%@GMT: pscoast -Dc -A5000 -Gc -Xa0i -Ya0i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pscoast -Dc -A5000 -Gc -Xa0i -Ya0.2778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_15
 0 setlinecap
 0 setlinejoin
@@ -35958,13 +33492,17 @@ P
 P
 2737 3475 M
 6 3 D
--51 -13 D
+-31 -7 D
+-20 -6 D
 18 0 D
 P
 2621 3485 M
 38 7 D
 6 7 D
--36 -11 D
+-14 -4 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
 P
 2839 3465 M
 1 2 D
@@ -35980,7 +33518,10 @@ P
 -17 -2 D
 -29 -10 D
 8 3 D
--27 -10 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-6 -2 D
 P
 2933 3465 M
 14 5 D
@@ -36036,7 +33577,8 @@ P
 -13 -9 D
 31 1 D
 3 -8 D
--58 -7 D
+-57 -6 D
+-1 -1 D
 P
 3263 3529 M
 -8 -4 D
@@ -36080,13 +33622,21 @@ P
 52 22 D
 -3 3 D
 -16 -3 D
--25 -11 D
+-18 -7 D
+-15 -8 D
+-8 -3 D
+-15 -8 D
 P
 3098 3511 M
 91 31 D
 16 15 D
 -20 -5 D
 4 4 D
+-18 -9 D
+-18 -9 D
+-10 -5 D
+-18 -9 D
+-18 -9 D
 P
 3249 3573 M
 29 11 D
@@ -36263,7 +33813,9 @@ P
 1 0 D
 -8 -5 D
 2 1 D
--28 -16 D
+-6 -3 D
+-14 -8 D
+-8 -5 D
 13 1 D
 17 8 D
 40 28 D
@@ -36271,7 +33823,11 @@ P
 -3 1 D
 P
 3273 3535 M
--58 -34 D
+-10 -6 D
+-12 -7 D
+-12 -7 D
+-12 -7 D
+-12 -7 D
 -5 -7 D
 10 2 D
 16 10 D
@@ -36365,7 +33921,8 @@ P
 -10 2 D
 -6 -10 D
 8 16 D
--22 -15 D
+-4 -2 D
+-18 -13 D
 -23 -17 D
 -11 -9 D
 -17 -13 D
@@ -36422,7 +33979,10 @@ P
 -23 -12 D
 8 -1 D
 -21 -6 D
--93 -68 D
+-20 -14 D
+-26 -20 D
+-20 -14 D
+-27 -20 D
 2 -3 D
 22 14 D
 10 0 D
@@ -36453,6 +34013,8 @@ P
 14 7 D
 -23 4 D
 -15 -5 D
+-24 -18 D
+-19 -13 D
 P
 3487 3601 M
 14 4 D
@@ -36492,10 +34054,11 @@ P
 -3 9 D
 -11 -9 D
 14 16 D
--22 -7 D
--6 -15 D
+-21 -6 D
+-7 -16 D
 4 12 D
--24 -22 D
+-1 0 D
+-23 -22 D
 -5 -6 D
 -23 -21 D
 -5 -6 D
@@ -37566,18 +35129,124 @@ P
 -49 -20 D
 81 33 D
 46 29 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-7 -2 D
 P
 2834 3454 M
 5 11 D
 -129 0 D
--90 -35 D
--30 -11 D
--183 -72 D
--57 -23 D
--22 -8 D
--35 -15 D
--22 -8 D
--167 -69 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
 -14 -11 D
 42 16 D
 -23 -12 D
@@ -37585,7 +35254,9 @@ P
 -40 -14 D
 -45 -20 D
 -84 -23 D
--32 -14 D
+-11 -5 D
+-10 -4 D
+-11 -5 D
 6 2 D
 -12 -7 D
 158 49 D
@@ -37681,7 +35352,8 @@ P
 1 8 D
 -40 -11 D
 29 15 D
--38 -15 D
+-2 0 D
+-36 -15 D
 20 15 D
 -9 0 D
 -53 -15 D
@@ -37693,12 +35365,51 @@ P
 -35 -11 D
 -22 -13 D
 6 19 D
--99 -44 D
--40 -17 D
--45 -21 D
--33 -14 D
--197 -91 D
--49 -23 D
+-13 -6 D
+-7 -2 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-6 -3 D
+-7 -2 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-6 -3 D
+-7 -2 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-6 -3 D
+-6 -2 D
+-7 -3 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-6 -2 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-6 -2 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
 15 5 D
 -4 -6 D
 -16 -5 D
@@ -37838,22 +35549,55 @@ P
 11 10 D
 -17 0 D
 2 13 D
--69 -35 D
--34 -18 D
+-17 -9 D
+-18 -9 D
+-17 -8 D
+-17 -9 D
+-17 -9 D
+-17 -9 D
 3 1 D
 0 -4 D
--30 -11 D
+-23 -8 D
+-4 -1 D
+-3 -2 D
 11 -1 D
 22 8 D
 -40 -21 D
 -14 1 D
 -18 -10 D
--17 -6 D
--218 -118 D
--155 -88 D
--158 -94 D
--28 -18 D
--15 -8 D
+-11 -3 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-11 -6 D
+-16 -8 D
+-22 -12 D
+-22 -12 D
+-22 -12 D
+-21 -12 D
+-22 -11 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-21 -11 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -11 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -11 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-19 -11 D
+-19 -12 D
+-19 -12 D
+-19 -12 D
+-10 -5 D
+-5 -3 D
 280 0 D
 18 14 D
 26 18 D
@@ -37984,16 +35728,33 @@ P
 10 13 D
 -18 -9 D
 -9 -1 D
--29 -17 D
--212 -136 D
--97 -65 D
--102 -71 D
--33 -23 D
--8 -6 D
+-19 -11 D
+-19 -12 D
+-19 -12 D
+-19 -12 D
+-28 -18 D
+-18 -11 D
+-19 -12 D
+-27 -18 D
+-19 -12 D
+-18 -11 D
+-27 -18 D
+-27 -18 D
+-26 -18 D
+-18 -11 D
+-26 -18 D
+-26 -18 D
+-26 -17 D
+-25 -18 D
+-26 -18 D
+-16 -12 D
+-17 -11 D
+-16 -12 D
 1 -2 D
 -41 -29 D
 27 22 D
--51 -38 D
+-26 -19 D
+-25 -19 D
 -13 -9 D
 -12 -9 D
 279 0 D
@@ -38254,6 +36015,7 @@ P
 3305 3465 M
 6 -3 D
 1 3 D
+-7 0 D
 P
 3288 3421 M
 -6 6 D
@@ -39286,12 +37048,24 @@ P
 114 90 D
 48 37 D
 -280 0 D
--127 -82 D
--94 -64 D
--128 -93 D
--30 -24 D
--15 -11 D
--78 -64 D
+-27 -18 D
+-19 -12 D
+-18 -11 D
+-27 -18 D
+-18 -11 D
+-26 -18 D
+-18 -12 D
+-26 -17 D
+-25 -17 D
+-25 -18 D
+-25 -17 D
+-32 -24 D
+-24 -17 D
+-24 -18 D
+-30 -23 D
+-30 -23 D
+-36 -29 D
+-42 -35 D
 17 -8 D
 0 -17 D
 -45 -70 D
@@ -39386,11 +37160,15 @@ P
 10 11 D
 66 63 D
 -279 0 D
--132 -103 D
--101 -84 D
--67 -60 D
--63 -60 D
--71 -72 D
+-32 -24 D
+-32 -25 D
+-38 -30 D
+-37 -30 D
+-37 -30 D
+-43 -36 D
+-55 -48 D
+-83 -78 D
+-77 -78 D
 -43 -48 D
 -5 -6 D
 P
@@ -41204,10 +38982,12 @@ P
 2186 2135 M
 11 8 D
 -1 2 D
--8 -1 D
+-4 -1 D
+-4 0 D
 P
 2181 2112 M
 1 0 D
+-1 0 D
 P
 3034 1889 M
 -49 -1 D
@@ -41272,7 +39052,8 @@ P
 0 -6 D
 7 1 D
 32 17 D
--29 -17 D
+-22 -13 D
+-7 -4 D
 -19 -2 D
 -8 -25 D
 3 27 D
@@ -41567,6 +39348,7 @@ P
 6460 1733 M
 8 -6 D
 10 7 D
+-17 0 D
 P
 6683 1705 M
 -5 -4 D
@@ -41823,8 +39605,13 @@ P
 47 25 D
 36 22 D
 -250 0 D
--73 -57 D
--78 -58 D
+-29 -23 D
+-29 -23 D
+-30 -23 D
+-31 -23 D
+-24 -17 D
+-25 -17 D
+-24 -17 D
 P
 6206 1014 M
 2 -7 D
@@ -42143,7 +39930,8 @@ P
 -33 -7 D
 -19 -12 D
 -16 -4 D
--45 -34 D
+-28 -22 D
+-17 -12 D
 -11 -9 D
 149 0 D
 133 82 D
@@ -42160,9 +39948,17 @@ P
 5 9 D
 -30 -16 D
 3 10 D
--20 -7 D
--125 -77 D
+-18 -7 D
+-2 0 D
+-17 -11 D
+-16 -10 D
+-17 -10 D
 -25 -16 D
+-16 -10 D
+-17 -10 D
+-17 -10 D
+-17 -11 D
+-8 -5 D
 149 0 D
 18 10 D
 19 9 D
@@ -42178,10 +39974,13 @@ P
 7 7 D
 -28 -9 D
 -7 0 D
--73 -38 D
--28 -15 D
+-18 -10 D
+-18 -9 D
+-19 -10 D
+-18 -9 D
+-19 -10 D
 -19 -9 D
--9 -5 D
+-18 -10 D
 149 0 D
 70 31 D
 P
@@ -42198,13 +39997,33 @@ P
 9 9 D
 -18 -4 D
 -5 7 D
--81 -36 D
--81 -36 D
+-11 -5 D
+-6 -3 D
+-6 -2 D
+-11 -5 D
+-12 -6 D
+-11 -5 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-11 -6 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-11 -5 D
+-12 -6 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-5 -3 D
 148 0 D
 P
 5095 435 M
 16 8 D
--21 -8 D
+-10 -4 D
+-11 -4 D
 P
 3348 435 M
 -12 6 D
@@ -42403,9 +40222,27 @@ P
 195 114 D
 161 97 D
 -149 0 D
--185 -139 D
--141 -103 D
--193 -139 D
+-32 -24 D
+-32 -24 D
+-32 -24 D
+-32 -25 D
+-25 -18 D
+-32 -24 D
+-25 -18 D
+-25 -18 D
+-25 -18 D
+-33 -24 D
+-33 -25 D
+-25 -18 D
+-25 -18 D
+-25 -18 D
+-25 -18 D
+-26 -18 D
+-25 -18 D
+-34 -25 D
+-25 -18 D
+-25 -18 D
+-26 -18 D
 P
 3900 0 M
 133 63 D
@@ -42415,9 +40252,41 @@ P
 253 123 D
 187 94 D
 -149 0 D
--252 -151 D
--135 -78 D
--31 -19 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-20 -12 D
+-21 -13 D
+-20 -12 D
+-20 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -12 D
+-21 -13 D
+-21 -12 D
+-20 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
 P
 3900 0 M
 155 63 D
@@ -42426,11 +40295,87 @@ P
 339 142 D
 218 94 D
 -149 0 D
--309 -154 D
--162 -78 D
--37 -19 D
--246 -117 D
--31 -16 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -7 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-13 -6 D
+-12 -7 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -7 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
 P
 3900 0 M
 194 70 D
@@ -42439,10 +40384,146 @@ P
 321 117 D
 248 94 D
 -148 0 D
--339 -145 D
--225 -94 D
--316 -129 D
--51 -22 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
 P
 4726 265 M
 -20 14 D
@@ -42466,11 +40547,150 @@ P
 -23 6 D
 14 7 D
 -5 0 D
--354 -133 D
--273 -99 D
--58 -22 D
--319 -114 D
--186 -67 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -4 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
 541 173 D
 P
 3181 259 M
@@ -42656,15 +40876,15 @@ P
 P
 PSL_clip N
 %%EndObject
-0 0 TM
+0 -333 TM
 0 A
 FQ
 O0
-0 0 TM
+0 333 TM
 
 % PostScript produced by:
-%@GMT: grdimage lat.nc -Clat.cpt -nl -Xa0i -Ya0i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt grdimage lat.nc -Clat.cpt -nl -Xa0i -Ya0.2778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_16
 0 setlinecap
 0 setlinejoin
@@ -42725,21 +40945,104 @@ clipsave
 -337 113 D
 -581 188 D
 -433 138 D
--706 -226 D
--421 -138 D
--371 -125 D
--390 -138 D
--236 -88 D
--257 -100 D
--241 -100 D
--224 -100 D
--155 -75 D
--145 -75 D
--133 -75 D
--83 -50 D
--58 -37 D
--72 -50 D
--83 -63 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-40 -12 D
+-39 -13 D
+-39 -12 D
+-40 -13 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -12 D
+-39 -13 D
+-39 -13 D
+-38 -12 D
+-39 -13 D
+-39 -12 D
+-38 -13 D
+-38 -12 D
+-38 -13 D
+-39 -12 D
+-38 -13 D
+-38 -12 D
+-37 -13 D
+-38 -13 D
+-38 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-37 -12 D
+-37 -13 D
+-36 -12 D
+-36 -13 D
+-37 -13 D
+-36 -12 D
+-35 -13 D
+-36 -12 D
+-35 -13 D
+-36 -12 D
+-35 -13 D
+-35 -12 D
+-35 -13 D
+-34 -12 D
+-34 -13 D
+-35 -12 D
+-33 -13 D
+-34 -12 D
+-34 -13 D
+-33 -13 D
+-33 -12 D
+-33 -13 D
+-33 -12 D
+-32 -13 D
+-32 -12 D
+-32 -13 D
+-32 -12 D
+-32 -13 D
+-31 -12 D
+-31 -13 D
+-31 -12 D
+-30 -13 D
+-30 -12 D
+-30 -13 D
+-30 -12 D
+-30 -13 D
+-29 -12 D
+-29 -13 D
+-29 -12 D
+-28 -13 D
+-28 -12 D
+-28 -13 D
+-27 -12 D
+-28 -13 D
+-27 -12 D
+-26 -13 D
+-27 -12 D
+-26 -13 D
+-26 -12 D
+-50 -25 D
+-50 -25 D
+-48 -25 D
+-47 -25 D
+-46 -25 D
+-44 -25 D
+-43 -25 D
+-42 -25 D
+-41 -25 D
+-39 -25 D
+-56 -37 D
+-52 -38 D
+-66 -50 D
 -60 -49 D
 -53 -50 D
 -37 -38 D
@@ -42814,30 +41117,30 @@ Xb#UqBAIJ"H8i;_^+W^8Zam/lAf61qVfSsr@^tA(N=Asf2`/E[/7)W;B!tA"\4c53?(+u*/sj.IIMeOO
 U
 PSL_cliprestore
 %%EndObject
-0 0 TM
+0 -333 TM
 0 A
 FQ
 O0
-0 0 TM
+0 333 TM
 
 % PostScript produced by:
-%@GMT: pscoast -Q -Xa0i -Ya0i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pscoast -Q -Xa0i -Ya0.2778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_17
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 PSL_cliprestore
 %%EndObject
-0 0 TM
+0 -333 TM
 0 A
 FQ
 O0
-0 0 TM
+0 333 TM
 
 % PostScript produced by:
-%@GMT: pscoast -Dc -A5000 -Wthinnest -Xa0i -Ya0i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pscoast -Dc -A5000 -Wthinnest -Xa0i -Ya0.2778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_18
 0 setlinecap
 0 setlinejoin
@@ -43168,7 +41471,8 @@ S
 S
 2737 3475 M
 6 3 D
--51 -13 D
+-31 -7 D
+-20 -6 D
 S
 2839 3465 M
 1 2 D
@@ -43239,7 +41543,8 @@ S
 -13 -9 D
 31 1 D
 3 -8 D
--58 -7 D
+-57 -6 D
+-1 -1 D
 S
 3249 3573 M
 29 11 D
@@ -47992,7 +46297,8 @@ S
 2186 2135 M
 11 8 D
 -1 2 D
--8 -1 D
+-4 -1 D
+-4 0 D
 S
 2168 1898 M
 3 4 D
@@ -48135,7 +46441,8 @@ P S
 0 -6 D
 7 1 D
 32 17 D
--29 -17 D
+-22 -13 D
+-7 -4 D
 -19 -2 D
 -8 -25 D
 3 27 D
@@ -48904,7 +47211,8 @@ S
 5 9 D
 -30 -16 D
 3 10 D
--20 -7 D
+-18 -7 D
+-2 0 D
 S
 5104 507 M
 -12 15 D
@@ -49223,131 +47531,27 @@ S
 -2 -10 D
 S
 %%EndObject
-0 0 TM
+0 -333 TM
 0 A
 FQ
 O0
-0 0 TM
+0 333 TM
 
 % PostScript produced by:
-%@GMT: pstext -F+f32p,Helvetica-Bold,red=thinner -Xa0i -Ya0i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pstext -F+f32p,Helvetica-Bold,red=thinner -Xa0i -Ya0.2778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_19
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 clipsave
-3900 0 M
-706 226 D
-421 138 D
-371 125 D
-390 138 D
-236 88 D
-257 100 D
-241 100 D
-224 100 D
-155 75 D
-145 75 D
-133 75 D
-83 50 D
-58 37 D
-72 50 D
-83 63 D
-60 49 D
-53 50 D
-37 38 D
-43 49 D
-29 38 D
-25 37 D
-21 37 D
-19 38 D
-14 37 D
-11 37 D
-8 38 D
-5 50 D
--2 49 D
--5 38 D
--13 49 D
--13 38 D
--17 37 D
--13 25 D
--31 50 D
--28 37 D
--31 38 D
--46 49 D
--52 50 D
--44 38 D
--79 62 D
--69 50 D
--115 75 D
--150 87 D
--141 75 D
--152 75 D
--219 100 D
--237 100 D
--253 100 D
--233 88 D
--279 100 D
--327 113 D
--337 113 D
--581 188 D
--433 138 D
--706 -226 D
--421 -138 D
--371 -125 D
--390 -138 D
--236 -88 D
--257 -100 D
--241 -100 D
--224 -100 D
--155 -75 D
--145 -75 D
--133 -75 D
--83 -50 D
--58 -37 D
--72 -50 D
--83 -63 D
--60 -49 D
--53 -50 D
--37 -38 D
--43 -49 D
--29 -38 D
--25 -37 D
--21 -37 D
--19 -38 D
--14 -37 D
--11 -37 D
--8 -38 D
--5 -50 D
-2 -49 D
-5 -38 D
-13 -49 D
-13 -38 D
-17 -37 D
-13 -25 D
-31 -50 D
-28 -37 D
-31 -38 D
-46 -49 D
-52 -50 D
-44 -38 D
-79 -62 D
-69 -50 D
-115 -75 D
-150 -87 D
-141 -75 D
-152 -75 D
-219 -100 D
-237 -100 D
-253 -100 D
-233 -88 D
-279 -100 D
-327 -113 D
-337 -113 D
-581 -188 D
+0 0 M
+7800 0 D
+0 3900 D
+-7800 0 D
 P
 PSL_clip N
-PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
 8 W
 {1 0 0 C} FS
 O1
@@ -49355,131 +47559,27 @@ O1
 (15TH INTERNATIONAL) mc false charpath fs S
 PSL_cliprestore
 %%EndObject
-0 0 TM
+0 -333 TM
 0 A
 FQ
 O0
-0 0 TM
+0 333 TM
 
 % PostScript produced by:
-%@GMT: pstext -F+f32p,Helvetica-Bold,red=thinner -Xa0i -Ya0i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pstext -F+f32p,Helvetica-Bold,red=thinner -Xa0i -Ya0.2778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_20
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 clipsave
-3900 0 M
-706 226 D
-421 138 D
-371 125 D
-390 138 D
-236 88 D
-257 100 D
-241 100 D
-224 100 D
-155 75 D
-145 75 D
-133 75 D
-83 50 D
-58 37 D
-72 50 D
-83 63 D
-60 49 D
-53 50 D
-37 38 D
-43 49 D
-29 38 D
-25 37 D
-21 37 D
-19 38 D
-14 37 D
-11 37 D
-8 38 D
-5 50 D
--2 49 D
--5 38 D
--13 49 D
--13 38 D
--17 37 D
--13 25 D
--31 50 D
--28 37 D
--31 38 D
--46 49 D
--52 50 D
--44 38 D
--79 62 D
--69 50 D
--115 75 D
--150 87 D
--141 75 D
--152 75 D
--219 100 D
--237 100 D
--253 100 D
--233 88 D
--279 100 D
--327 113 D
--337 113 D
--581 188 D
--433 138 D
--706 -226 D
--421 -138 D
--371 -125 D
--390 -138 D
--236 -88 D
--257 -100 D
--241 -100 D
--224 -100 D
--155 -75 D
--145 -75 D
--133 -75 D
--83 -50 D
--58 -37 D
--72 -50 D
--83 -63 D
--60 -49 D
--53 -50 D
--37 -38 D
--43 -49 D
--29 -38 D
--25 -37 D
--21 -37 D
--19 -38 D
--14 -37 D
--11 -37 D
--8 -38 D
--5 -50 D
-2 -49 D
-5 -38 D
-13 -49 D
-13 -38 D
-17 -37 D
-13 -25 D
-31 -50 D
-28 -37 D
-31 -38 D
-46 -49 D
-52 -50 D
-44 -38 D
-79 -62 D
-69 -50 D
-115 -75 D
-150 -87 D
-141 -75 D
-152 -75 D
-219 -100 D
-237 -100 D
-253 -100 D
-233 -88 D
-279 -100 D
-327 -113 D
-337 -113 D
-581 -188 D
+0 0 M
+7800 0 D
+0 3900 D
+-7800 0 D
 P
 PSL_clip N
-PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
 8 W
 {1 0 0 C} FS
 O1
@@ -49487,131 +47587,27 @@ O1
 (GMT CONFERENCE) mc false charpath fs S
 PSL_cliprestore
 %%EndObject
-0 0 TM
+0 -333 TM
 0 A
 FQ
 O0
-0 0 TM
+0 333 TM
 
 % PostScript produced by:
-%@GMT: pstext -F+f18p,Helvetica-Bold,green=thinnest -Xa0i -Ya0i -Rd -JI0/6.5i
-%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt pstext -F+f18p,Helvetica-Bold,green=thinnest -Xa0i -Ya0.2778i -Rd -JI0/6.5i
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_21
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 clipsave
-3900 0 M
-706 226 D
-421 138 D
-371 125 D
-390 138 D
-236 88 D
-257 100 D
-241 100 D
-224 100 D
-155 75 D
-145 75 D
-133 75 D
-83 50 D
-58 37 D
-72 50 D
-83 63 D
-60 49 D
-53 50 D
-37 38 D
-43 49 D
-29 38 D
-25 37 D
-21 37 D
-19 38 D
-14 37 D
-11 37 D
-8 38 D
-5 50 D
--2 49 D
--5 38 D
--13 49 D
--13 38 D
--17 37 D
--13 25 D
--31 50 D
--28 37 D
--31 38 D
--46 49 D
--52 50 D
--44 38 D
--79 62 D
--69 50 D
--115 75 D
--150 87 D
--141 75 D
--152 75 D
--219 100 D
--237 100 D
--253 100 D
--233 88 D
--279 100 D
--327 113 D
--337 113 D
--581 188 D
--433 138 D
--706 -226 D
--421 -138 D
--371 -125 D
--390 -138 D
--236 -88 D
--257 -100 D
--241 -100 D
--224 -100 D
--155 -75 D
--145 -75 D
--133 -75 D
--83 -50 D
--58 -37 D
--72 -50 D
--83 -63 D
--60 -49 D
--53 -50 D
--37 -38 D
--43 -49 D
--29 -38 D
--25 -37 D
--21 -37 D
--19 -38 D
--14 -37 D
--11 -37 D
--8 -38 D
--5 -50 D
-2 -49 D
-5 -38 D
-13 -49 D
-13 -38 D
-17 -37 D
-13 -25 D
-31 -50 D
-28 -37 D
-31 -38 D
-46 -49 D
-52 -50 D
-44 -38 D
-79 -62 D
-69 -50 D
-115 -75 D
-150 -87 D
-141 -75 D
-152 -75 D
-219 -100 D
-237 -100 D
-253 -100 D
-233 -88 D
-279 -100 D
-327 -113 D
-337 -113 D
-581 -188 D
+0 0 M
+7800 0 D
+0 3900 D
+-7800 0 D
 P
 PSL_clip N
-PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
 4 W
 {0 1 0 C} FS
 O1
@@ -49619,8 +47615,12 @@ O1
 (Honolulu, Hawaii, April 1, 2018) mc false charpath fs S
 PSL_cliprestore
 %%EndObject
-0 0 TM
+0 -333 TM
 PSL_completion /PSL_completion {} def
+
+grestore
+PSL_movie_completion /PSL_movie_completion {} def
+%PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage

--- a/test/exmod/ex34.ps
+++ b/test/exmod/ex34.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_7121981-dirty_2019.08.07 [64-bit] Document from pstext
+%%Title: GMT v6.0.0_9cdd6e8-dirty_2019.08.08 [64-bit] Document from pstext
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Wed Aug  7 09:19:05 2019
+%%CreationDate: Thu Aug  8 10:52:16 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -667,14 +667,14 @@ O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -R0/4.56944/0/8.33843 -Jx1i -N -F+jBC+f24p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
-%@PROJ: xy 0.00000000 4.56944000 0.00000000 8.33843000 0.000 4.569 0.000 8.338 +xy
-%GMTBoundingBox: 72 72 329 600.367
+%@GMT: gmt pstext -R0/4.5/0/8.40787 -Jx1i -N -F+jBC+f24p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 4.50000000 0.00000000 8.40787000 0.000 4.500 0.000 8.408 +xy
+%GMTBoundingBox: 72 72 324 605.367
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-2742 10366 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+2700 10533 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 (Franco-Italian Union, 2042-45) bc Z
 %%EndObject
@@ -682,10 +682,10 @@ PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 -83 TM
+0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt pscoast -EFR,IT+gP300/8 -Glightgray -BWenS -Bxaf -Byaf -Xa0i -Ya-0.0694i -R-6/20/35/52 -JM4.5i
+%@GMT: gmt pscoast -EFR,IT+gP300/8 -Glightgray -BWenS -Bxaf -Byaf -Xa0i -Ya0i -R-6/20/35/52 -JM4.5i
 %@PROJ: merc -6.00000000 20.00000000 35.00000000 52.00000000 -1447153.380 1447153.380 4139372.762 6766432.491 +proj=merc +lon_0=7 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -18143,15 +18143,15 @@ N -83 4985 M 0 -5068 D S
 %%EndObject
 currentdict /image8 undef
 currentdict /pattern8 undef
-0 83 TM
+0 0 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 5105 TM
+0 5188 TM
 
 % PostScript produced by:
-%@GMT: gmt grdimage @FR+IT.nc -I -BWens -Bxaf -Byaf -Xa0i -Ya4.2539i -R-6/20/35/52 -JM4.5i
+%@GMT: gmt grdimage @FR+IT.nc -I -BWens -Bxaf -Byaf -Xa0i -Ya4.3234i -R-6/20/35/52 -JM4.5i
 %@PROJ: merc -6.00000000 20.00000000 35.00000000 52.00000000 -1447153.380 1447153.380 4139372.762 6766432.491 +proj=merc +lon_0=7 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -31375,14 +31375,14 @@ N -83 4985 M 0 -5068 D S
 -167 2709 M (45èN) mr Z
 -167 4243 M (50èN) mr Z
 %%EndObject
-0 -5105 TM
+0 -5188 TM
 0 A
 FQ
 O0
-0 5105 TM
+0 5188 TM
 
 % PostScript produced by:
-%@GMT: gmt pscoast -EFR,IT+gred@60 -Xa0i -Ya4.2539i -R-6/20/35/52 -JM4.5i
+%@GMT: gmt pscoast -EFR,IT+gred@60 -Xa0i -Ya4.3234i -R-6/20/35/52 -JM4.5i
 %@PROJ: merc -6.00000000 20.00000000 35.00000000 52.00000000 -1447153.380 1447153.380 4139372.762 6766432.491 +proj=merc +lon_0=7 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -40197,7 +40197,7 @@ FO
 /FO {fs os}!
 FO
 %%EndObject
-0 -5105 TM
+0 -5188 TM
 PSL_completion /PSL_completion {} def
 
 grestore

--- a/test/exmod/ex47.ps
+++ b/test/exmod/ex47.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_831abca_2019.06.27 [64-bit] Document from psxy
+%%Title: GMT v6.0.0_9cdd6e8-dirty_2019.08.08 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Jun 27 12:16:20 2019
+%%CreationDate: Thu Aug  8 10:52:18 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -667,9 +667,9 @@ O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -R0/6.06944/0/8.06944 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=false
-%@PROJ: xy 0.00000000 6.06944000 0.00000000 8.06944000 0.000 6.069 0.000 8.069 +xy
-%GMTBoundingBox: 72 72 437 581
+%@GMT: gmt psxy -R0/6.27778/0/8.41667 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 6.27778000 0.00000000 8.41667000 0.000 6.278 0.000 8.417 +xy
+%GMTBoundingBox: 72 72 452 606
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
@@ -679,10 +679,10 @@ PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 7283 TM
+0 7700 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -BWens+ghoneydew+tL@-1@- data.txt -Sc0.05i -Gblue -Bxafg '-Byafg+lLog light intensity' -Xa0i -Ya6.0694i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -BWens+ghoneydew+tL@-1@- data.txt -Sc0.05i -Gblue -Bxafg '-Byafg+lLog light intensity' -Xa0i -Ya6.4167i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -942,14 +942,14 @@ V
 U
 PSL_cliprestore
 %%EndObject
-0 -7283 TM
+0 -7700 TM
 0 A
 FQ
 O0
-0 7283 TM
+0 7700 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa0i -Ya6.0694i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa0i -Ya6.4167i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -964,14 +964,14 @@ V
 30 1760 2390 Sc
 U
 %%EndObject
-0 -7283 TM
+0 -7700 TM
 0 A
 FQ
 O0
-0 7283 TM
+0 7700 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa0i -Ya6.0694i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa0i -Ya6.4167i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -986,14 +986,14 @@ O1
 60 1760 2390 Sc
 U
 %%EndObject
-0 -7283 TM
+0 -7700 TM
 0 A
 FQ
 O0
-0 7283 TM
+0 7700 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -W2p -Xa0i -Ya6.0694i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -W2p -Xa0i -Ya6.4167i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
@@ -1019,15 +1019,15 @@ PSL_clip N
 S
 PSL_cliprestore
 %%EndObject
-0 -7283 TM
+0 -7700 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 4717 TM
+0 5133 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -BWens+ghoneydew data.txt -Sc0.05i -Gblue -Bxafg '-Byafg+lLog light intensity' -Xa0i -Ya3.9306i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -BWens+ghoneydew data.txt -Sc0.05i -Gblue -Bxafg '-Byafg+lLog light intensity' -Xa0i -Ya4.2778i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
@@ -1281,14 +1281,14 @@ V
 U
 PSL_cliprestore
 %%EndObject
-0 -4717 TM
+0 -5133 TM
 0 A
 FQ
 O0
-0 4717 TM
+0 5133 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa0i -Ya3.9306i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa0i -Ya4.2778i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_7
 0 setlinecap
@@ -1303,14 +1303,14 @@ V
 30 1760 2390 Sc
 U
 %%EndObject
-0 -4717 TM
+0 -5133 TM
 0 A
 FQ
 O0
-0 4717 TM
+0 5133 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa0i -Ya3.9306i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa0i -Ya4.2778i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_8
 0 setlinecap
@@ -1325,14 +1325,14 @@ O1
 60 1760 2390 Sc
 U
 %%EndObject
-0 -4717 TM
+0 -5133 TM
 0 A
 FQ
 O0
-0 4717 TM
+0 5133 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -W2p -Xa0i -Ya3.9306i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -W2p -Xa0i -Ya4.2778i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_9
 0 setlinecap
@@ -1352,15 +1352,15 @@ PSL_clip N
 -2 5 D S
 PSL_cliprestore
 %%EndObject
-0 -4717 TM
+0 -5133 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 2150 TM
+0 2567 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -BWens+ghoneydew data.txt -Sc0.05i -Gblue -Bxafg '-Byafg+lLog light intensity' -Xa0i -Ya1.7917i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -BWens+ghoneydew data.txt -Sc0.05i -Gblue -Bxafg '-Byafg+lLog light intensity' -Xa0i -Ya2.1389i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_10
 0 setlinecap
@@ -1614,14 +1614,14 @@ V
 U
 PSL_cliprestore
 %%EndObject
-0 -2150 TM
+0 -2567 TM
 0 A
 FQ
 O0
-0 2150 TM
+0 2567 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa0i -Ya1.7917i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa0i -Ya2.1389i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_11
 0 setlinecap
@@ -1636,14 +1636,14 @@ V
 30 1760 2390 Sc
 U
 %%EndObject
-0 -2150 TM
+0 -2567 TM
 0 A
 FQ
 O0
-0 2150 TM
+0 2567 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa0i -Ya1.7917i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa0i -Ya2.1389i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_12
 0 setlinecap
@@ -1658,14 +1658,14 @@ O1
 60 1760 2390 Sc
 U
 %%EndObject
-0 -2150 TM
+0 -2567 TM
 0 A
 FQ
 O0
-0 2150 TM
+0 2567 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -W2p -Xa0i -Ya1.7917i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -W2p -Xa0i -Ya2.1389i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_13
 0 setlinecap
@@ -1685,15 +1685,15 @@ PSL_clip N
 0 2 D S
 PSL_cliprestore
 %%EndObject
-0 -2150 TM
+0 -2567 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 -417 TM
+0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -BWenS+ghoneydew data.txt -Sc0.05i -Gblue '-Bxafg+lLog temperature' '-Byafg+lLog light intensity' -Xa0i -Ya-0.3472i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -BWenS+ghoneydew data.txt -Sc0.05i -Gblue '-Bxafg+lLog temperature' '-Byafg+lLog light intensity' -Xa0i -Ya0i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_14
 0 setlinecap
@@ -1971,14 +1971,14 @@ V
 U
 PSL_cliprestore
 %%EndObject
-0 417 TM
+0 0 TM
 0 A
 FQ
 O0
-0 -417 TM
+0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa0i -Ya-0.3472i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa0i -Ya0i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_15
 0 setlinecap
@@ -1993,14 +1993,14 @@ V
 30 1760 2390 Sc
 U
 %%EndObject
-0 417 TM
+0 0 TM
 0 A
 FQ
 O0
-0 -417 TM
+0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa0i -Ya-0.3472i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa0i -Ya0i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_16
 0 setlinecap
@@ -2015,14 +2015,14 @@ O1
 60 1760 2390 Sc
 U
 %%EndObject
-0 417 TM
+0 0 TM
 0 A
 FQ
 O0
-0 -417 TM
+0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -W2p -Xa0i -Ya-0.3472i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -W2p -Xa0i -Ya0i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_17
 0 setlinecap
@@ -2042,15 +2042,15 @@ PSL_clip N
 -1 2 D S
 PSL_cliprestore
 %%EndObject
-0 417 TM
+0 0 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-2567 7283 TM
+2567 7700 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -Bwens+ghoneydew+tL@-2@- data.txt -Sc0.05i -Gblue -Bxafg -Byafg -Xa2.1389i -Ya6.0694i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -Bwens+ghoneydew+tL@-2@- data.txt -Sc0.05i -Gblue -Bxafg -Byafg -Xa2.1389i -Ya6.4167i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_18
 0 setlinecap
@@ -2285,14 +2285,14 @@ V
 U
 PSL_cliprestore
 %%EndObject
--2567 -7283 TM
+-2567 -7700 TM
 0 A
 FQ
 O0
-2567 7283 TM
+2567 7700 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa2.1389i -Ya6.0694i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa2.1389i -Ya6.4167i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_19
 0 setlinecap
@@ -2307,14 +2307,14 @@ V
 30 1760 2390 Sc
 U
 %%EndObject
--2567 -7283 TM
+-2567 -7700 TM
 0 A
 FQ
 O0
-2567 7283 TM
+2567 7700 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa2.1389i -Ya6.0694i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa2.1389i -Ya6.4167i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_20
 0 setlinecap
@@ -2329,14 +2329,14 @@ O1
 60 1760 2390 Sc
 U
 %%EndObject
--2567 -7283 TM
+-2567 -7700 TM
 0 A
 FQ
 O0
-2567 7283 TM
+2567 7700 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -W2p -Xa2.1389i -Ya6.0694i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -W2p -Xa2.1389i -Ya6.4167i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_21
 0 setlinecap
@@ -2356,15 +2356,15 @@ PSL_clip N
 -4 8 D S
 PSL_cliprestore
 %%EndObject
--2567 -7283 TM
+-2567 -7700 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-2567 4717 TM
+2567 5133 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -Bwens+ghoneydew data.txt -Sc0.05i -Gblue -Bxafg -Byafg -Xa2.1389i -Ya3.9306i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -Bwens+ghoneydew data.txt -Sc0.05i -Gblue -Bxafg -Byafg -Xa2.1389i -Ya4.2778i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_22
 0 setlinecap
@@ -2592,14 +2592,14 @@ V
 U
 PSL_cliprestore
 %%EndObject
--2567 -4717 TM
+-2567 -5133 TM
 0 A
 FQ
 O0
-2567 4717 TM
+2567 5133 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa2.1389i -Ya3.9306i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa2.1389i -Ya4.2778i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_23
 0 setlinecap
@@ -2614,14 +2614,14 @@ V
 30 1760 2390 Sc
 U
 %%EndObject
--2567 -4717 TM
+-2567 -5133 TM
 0 A
 FQ
 O0
-2567 4717 TM
+2567 5133 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa2.1389i -Ya3.9306i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa2.1389i -Ya4.2778i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_24
 0 setlinecap
@@ -2636,14 +2636,14 @@ O1
 60 1760 2390 Sc
 U
 %%EndObject
--2567 -4717 TM
+-2567 -5133 TM
 0 A
 FQ
 O0
-2567 4717 TM
+2567 5133 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -W2p -Xa2.1389i -Ya3.9306i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -W2p -Xa2.1389i -Ya4.2778i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_25
 0 setlinecap
@@ -2663,15 +2663,15 @@ PSL_clip N
 0 -2 D S
 PSL_cliprestore
 %%EndObject
--2567 -4717 TM
+-2567 -5133 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-2567 2150 TM
+2567 2567 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -Bwens+ghoneydew data.txt -Sc0.05i -Gblue -Bxafg -Byafg -Xa2.1389i -Ya1.7917i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -Bwens+ghoneydew data.txt -Sc0.05i -Gblue -Bxafg -Byafg -Xa2.1389i -Ya2.1389i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_26
 0 setlinecap
@@ -2899,14 +2899,14 @@ V
 U
 PSL_cliprestore
 %%EndObject
--2567 -2150 TM
+-2567 -2567 TM
 0 A
 FQ
 O0
-2567 2150 TM
+2567 2567 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa2.1389i -Ya1.7917i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa2.1389i -Ya2.1389i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_27
 0 setlinecap
@@ -2921,14 +2921,14 @@ V
 30 1760 2390 Sc
 U
 %%EndObject
--2567 -2150 TM
+-2567 -2567 TM
 0 A
 FQ
 O0
-2567 2150 TM
+2567 2567 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa2.1389i -Ya1.7917i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa2.1389i -Ya2.1389i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_28
 0 setlinecap
@@ -2943,14 +2943,14 @@ O1
 60 1760 2390 Sc
 U
 %%EndObject
--2567 -2150 TM
+-2567 -2567 TM
 0 A
 FQ
 O0
-2567 2150 TM
+2567 2567 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -W2p -Xa2.1389i -Ya1.7917i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -W2p -Xa2.1389i -Ya2.1389i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_29
 0 setlinecap
@@ -2970,15 +2970,15 @@ PSL_clip N
 0 -2 D S
 PSL_cliprestore
 %%EndObject
--2567 -2150 TM
+-2567 -2567 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-2567 -417 TM
+2567 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -BwenS+ghoneydew data.txt -Sc0.05i -Gblue '-Bxafg+lLog temperature' -Byafg -Xa2.1389i -Ya-0.3472i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -BwenS+ghoneydew data.txt -Sc0.05i -Gblue '-Bxafg+lLog temperature' -Byafg -Xa2.1389i -Ya0i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_30
 0 setlinecap
@@ -3231,14 +3231,14 @@ V
 U
 PSL_cliprestore
 %%EndObject
--2567 417 TM
+-2567 0 TM
 0 A
 FQ
 O0
-2567 -417 TM
+2567 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa2.1389i -Ya-0.3472i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa2.1389i -Ya0i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_31
 0 setlinecap
@@ -3253,14 +3253,14 @@ V
 30 1760 2390 Sc
 U
 %%EndObject
--2567 417 TM
+-2567 0 TM
 0 A
 FQ
 O0
-2567 -417 TM
+2567 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa2.1389i -Ya-0.3472i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa2.1389i -Ya0i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_32
 0 setlinecap
@@ -3275,14 +3275,14 @@ O1
 60 1760 2390 Sc
 U
 %%EndObject
--2567 417 TM
+-2567 0 TM
 0 A
 FQ
 O0
-2567 -417 TM
+2567 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -W2p -Xa2.1389i -Ya-0.3472i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -W2p -Xa2.1389i -Ya0i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_33
 0 setlinecap
@@ -3324,15 +3324,15 @@ PSL_clip N
 S
 PSL_cliprestore
 %%EndObject
--2567 417 TM
+-2567 0 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-5133 7283 TM
+5133 7700 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -Bwens+ghoneydew+tLMS data.txt -Sc0.05i -Gblue -Bxafg -Byafg -Xa4.2778i -Ya6.0694i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -Bwens+ghoneydew+tLMS data.txt -Sc0.05i -Gblue -Bxafg -Byafg -Xa4.2778i -Ya6.4167i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_34
 0 setlinecap
@@ -3565,14 +3565,14 @@ V
 U
 PSL_cliprestore
 %%EndObject
--5133 -7283 TM
+-5133 -7700 TM
 0 A
 FQ
 O0
-5133 7283 TM
+5133 7700 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa4.2778i -Ya6.0694i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa4.2778i -Ya6.4167i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_35
 0 setlinecap
@@ -3587,14 +3587,14 @@ V
 30 1760 2390 Sc
 U
 %%EndObject
--5133 -7283 TM
+-5133 -7700 TM
 0 A
 FQ
 O0
-5133 7283 TM
+5133 7700 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa4.2778i -Ya6.0694i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa4.2778i -Ya6.4167i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_36
 0 setlinecap
@@ -3609,14 +3609,14 @@ O1
 60 1760 2390 Sc
 U
 %%EndObject
--5133 -7283 TM
+-5133 -7700 TM
 0 A
 FQ
 O0
-5133 7283 TM
+5133 7700 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -W2p -Xa4.2778i -Ya6.0694i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -W2p -Xa4.2778i -Ya6.4167i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_37
 0 setlinecap
@@ -3636,14 +3636,14 @@ PSL_clip N
 -1 3 D S
 PSL_cliprestore
 %%EndObject
--5133 -7283 TM
+-5133 -7700 TM
 0 A
 FQ
 O0
-5133 7283 TM
+5133 7700 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -F+cRM+jTC+a90 -N -Dj0.2i -Xa4.2778i -Ya6.0694i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt pstext '-F+cRM+jTC+a90+tY ON X' -N -Dj0.2i -Xa4.2778i -Ya6.4167i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_38
 0 setlinecap
@@ -3653,15 +3653,15 @@ O0
 200 F0
 V 90 R (Y ON X) tc Z U
 %%EndObject
--5133 -7283 TM
+-5133 -7700 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-5133 4717 TM
+5133 5133 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -Bwens+ghoneydew data.txt -Sc0.05i -Gblue -Bxafg -Byafg -Xa4.2778i -Ya3.9306i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -Bwens+ghoneydew data.txt -Sc0.05i -Gblue -Bxafg -Byafg -Xa4.2778i -Ya4.2778i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_39
 0 setlinecap
@@ -3889,14 +3889,14 @@ V
 U
 PSL_cliprestore
 %%EndObject
--5133 -4717 TM
+-5133 -5133 TM
 0 A
 FQ
 O0
-5133 4717 TM
+5133 5133 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa4.2778i -Ya3.9306i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa4.2778i -Ya4.2778i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_40
 0 setlinecap
@@ -3911,14 +3911,14 @@ V
 30 1760 2390 Sc
 U
 %%EndObject
--5133 -4717 TM
+-5133 -5133 TM
 0 A
 FQ
 O0
-5133 4717 TM
+5133 5133 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa4.2778i -Ya3.9306i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa4.2778i -Ya4.2778i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_41
 0 setlinecap
@@ -3933,14 +3933,14 @@ O1
 60 1760 2390 Sc
 U
 %%EndObject
--5133 -4717 TM
+-5133 -5133 TM
 0 A
 FQ
 O0
-5133 4717 TM
+5133 5133 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -W2p -Xa4.2778i -Ya3.9306i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -W2p -Xa4.2778i -Ya4.2778i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_42
 0 setlinecap
@@ -3960,14 +3960,14 @@ PSL_clip N
 -1 3 D S
 PSL_cliprestore
 %%EndObject
--5133 -4717 TM
+-5133 -5133 TM
 0 A
 FQ
 O0
-5133 4717 TM
+5133 5133 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -F+cRM+jTC+a90 -N -Dj0.2i -Xa4.2778i -Ya3.9306i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt pstext '-F+cRM+jTC+a90+tX ON Y' -N -Dj0.2i -Xa4.2778i -Ya4.2778i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_43
 0 setlinecap
@@ -3977,15 +3977,15 @@ O0
 200 F0
 V 90 R (X ON Y) tc Z U
 %%EndObject
--5133 -4717 TM
+-5133 -5133 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-5133 2150 TM
+5133 2567 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -Bwens+ghoneydew data.txt -Sc0.05i -Gblue -Bxafg -Byafg -Xa4.2778i -Ya1.7917i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -Bwens+ghoneydew data.txt -Sc0.05i -Gblue -Bxafg -Byafg -Xa4.2778i -Ya2.1389i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_44
 0 setlinecap
@@ -4213,14 +4213,14 @@ V
 U
 PSL_cliprestore
 %%EndObject
--5133 -2150 TM
+-5133 -2567 TM
 0 A
 FQ
 O0
-5133 2150 TM
+5133 2567 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa4.2778i -Ya1.7917i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa4.2778i -Ya2.1389i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_45
 0 setlinecap
@@ -4235,14 +4235,14 @@ V
 30 1760 2390 Sc
 U
 %%EndObject
--5133 -2150 TM
+-5133 -2567 TM
 0 A
 FQ
 O0
-5133 2150 TM
+5133 2567 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa4.2778i -Ya1.7917i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa4.2778i -Ya2.1389i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_46
 0 setlinecap
@@ -4257,14 +4257,14 @@ O1
 60 1760 2390 Sc
 U
 %%EndObject
--5133 -2150 TM
+-5133 -2567 TM
 0 A
 FQ
 O0
-5133 2150 TM
+5133 2567 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -W2p -Xa4.2778i -Ya1.7917i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -W2p -Xa4.2778i -Ya2.1389i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_47
 0 setlinecap
@@ -4284,14 +4284,14 @@ PSL_clip N
 -1 3 D S
 PSL_cliprestore
 %%EndObject
--5133 -2150 TM
+-5133 -2567 TM
 0 A
 FQ
 O0
-5133 2150 TM
+5133 2567 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -F+cRM+jTC+a90 -N -Dj0.2i -Xa4.2778i -Ya1.7917i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt pstext -F+cRM+jTC+a90+tORTHOGONAL -N -Dj0.2i -Xa4.2778i -Ya2.1389i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_48
 0 setlinecap
@@ -4301,15 +4301,15 @@ O0
 200 F0
 V 90 R (ORTHOGONAL) tc Z U
 %%EndObject
--5133 -2150 TM
+-5133 -2567 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-5133 -417 TM
+5133 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -BwenS+ghoneydew data.txt -Sc0.05i -Gblue '-Bxafg+lLog temperature' -Byafg -Xa4.2778i -Ya-0.3472i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -BwenS+ghoneydew data.txt -Sc0.05i -Gblue '-Bxafg+lLog temperature' -Byafg -Xa4.2778i -Ya0i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_49
 0 setlinecap
@@ -4562,14 +4562,14 @@ V
 U
 PSL_cliprestore
 %%EndObject
--5133 417 TM
+-5133 0 TM
 0 A
 FQ
 O0
-5133 -417 TM
+5133 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa4.2778i -Ya-0.3472i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.05i -Gred -N -Xa4.2778i -Ya0i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_50
 0 setlinecap
@@ -4584,14 +4584,14 @@ V
 30 1760 2390 Sc
 U
 %%EndObject
--5133 417 TM
+-5133 0 TM
 0 A
 FQ
 O0
-5133 -417 TM
+5133 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa4.2778i -Ya-0.3472i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy giants.txt -Sc0.1i -W0.25p -N -Xa4.2778i -Ya0i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_51
 0 setlinecap
@@ -4606,14 +4606,14 @@ O1
 60 1760 2390 Sc
 U
 %%EndObject
--5133 417 TM
+-5133 0 TM
 0 A
 FQ
 O0
-5133 -417 TM
+5133 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -W2p -Xa4.2778i -Ya-0.3472i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt psxy -W2p -Xa4.2778i -Ya0i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_52
 0 setlinecap
@@ -4633,14 +4633,14 @@ PSL_clip N
 -1 4 D S
 PSL_cliprestore
 %%EndObject
--5133 417 TM
+-5133 0 TM
 0 A
 FQ
 O0
-5133 -417 TM
+5133 0 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -F+cRM+jTC+a90 -N -Dj0.2i -Xa4.2778i -Ya-0.3472i -R2.85/5.25/3.9/6.3 -JX-2i/2i
+%@GMT: gmt pstext '-F+cRM+jTC+a90+tREDUCED MAJOR AXIS' -N -Dj0.2i -Xa4.2778i -Ya0i -R2.85/5.25/3.9/6.3 -JX-2i/2i
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
 %%BeginObject PSL_Layer_53
 0 setlinecap
@@ -4650,7 +4650,7 @@ O0
 200 F0
 V 90 R (REDUCED MAJOR AXIS) tc Z U
 %%EndObject
--5133 417 TM
+-5133 0 TM
 PSL_completion /PSL_completion {} def
 
 grestore

--- a/test/modern/box.ps
+++ b/test/modern/box.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612 792             
-%%Title: GMT v6.0.0_r19359 [64-bit] Document from pstext
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_9cdd6e8-dirty_2019.08.08 [64-bit] Document from pstext
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Tue Nov 21 21:20:03 2017
+%%CreationDate: Thu Aug  8 10:52:57 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -658,19 +658,23 @@ V 0.06 0.06 scale
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_completion {} def
+/PSL_movie_completion {} def
+%PSL_End_Header
+gsave
 0 A
 FQ
 O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: pstext -R0/6.23889/0/6.16944 -Jx1i -P -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
-%@PROJ: xy 0.00000000 6.23889000 0.00000000 6.16944000 0.000 6.239 0.000 6.169 +xy
+%@GMT: gmt pstext -R0/6.23889/0/6.23889 -Jx1i -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 6.23889000 0.00000000 6.23889000 0.000 6.239 0.000 6.239 +xy
+%GMTBoundingBox: 72 72 449.2 449.2
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-3743 8291 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+3743 8458 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 533 F0
 (VERY LONG HEADER STRING) bc Z
 %%EndObject
@@ -678,10 +682,10 @@ PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 3803 TM
+0 3887 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -P '-BWets+ttitle 1' -Bxaf -Byaf -Xa0i -Ya3.1694i -R0/5/0/5 -JX15c
+%@GMT: gmt psbasemap '-BWets+ttitle 1' -Bxaf -Byaf -Xa0i -Ya3.2389i -R0/5/0/5 -JX15c
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 5.00000000 0.000 5.000 0.000 5.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -698,7 +702,7 @@ N 0 1440 M -83 0 D S
 N 0 2880 M -83 0 D S
 /PSL_AH0 0
 /MM {neg exch M} def
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sw mx
 (2) sw mx
@@ -752,15 +756,15 @@ N 0 0 M 3600 0 D S
 400 F0
 (title 1) bc Z
 %%EndObject
-0 -3803 TM
+0 -3887 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-3887 3803 TM
+3887 3887 TM
 
 % PostScript produced by:
-%@GMT: psbasemap '-BwEts+ttitle 2' -Bxaf -Byaf -Xa3.2389i -Ya3.1694i -R0/5/0/5 -JX15c
+%@GMT: gmt psbasemap '-BwEts+ttitle 2' -Bxaf -Byaf -Xa3.2389i -Ya3.2389i -R0/5/0/5 -JX15c
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 5.00000000 0.000 5.000 0.000 5.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -790,7 +794,7 @@ N 0 1440 M 83 0 D S
 N 0 2880 M 83 0 D S
 /PSL_AH0 0
 /MM {exch M} def
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sw mx
 (2) sw mx
@@ -830,15 +834,15 @@ N 0 0 M 3600 0 D S
 400 F0
 (title 2) bc Z
 %%EndObject
--3887 -3803 TM
+-3887 -3887 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 0 TM
+0 83 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -Bafg -BWetS -Xa0i -Ya0i -R0/5/0/5 -JX15c
+%@GMT: gmt psbasemap -Bafg -BWetS -Xa0i -Ya0.0694i -R0/5/0/5 -JX15c
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 5.00000000 0.000 5.000 0.000 5.000 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -875,7 +879,7 @@ N 0 1440 M -83 0 D S
 N 0 2880 M -83 0 D S
 /PSL_AH0 0
 /MM {neg exch M} def
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sw mx
 (2) sw mx
@@ -938,15 +942,15 @@ N 0 0 M 3600 0 D S
 0 -3600 T
 0 setlinecap
 %%EndObject
-0 0 TM
+0 -83 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-3887 0 TM
+3887 83 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -BwEtS -Bxaf -Byaf -Xa3.2389i -Ya0i -R0/5/0/5 -JX15c
+%@GMT: gmt psbasemap -BwEtS -Bxaf -Byaf -Xa3.2389i -Ya0.0694i -R0/5/0/5 -JX15c
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 5.00000000 0.000 5.000 0.000 5.000 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
@@ -976,7 +980,7 @@ N 0 1440 M 83 0 D S
 N 0 2880 M 83 0 D S
 /PSL_AH0 0
 /MM {exch M} def
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sw mx
 (2) sw mx
@@ -1025,8 +1029,12 @@ N 0 0 M 3600 0 D S
 0 -3600 T
 0 setlinecap
 %%EndObject
--3887 0 TM
+-3887 -83 TM
 PSL_completion /PSL_completion {} def
+
+grestore
+PSL_movie_completion /PSL_movie_completion {} def
+%PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage

--- a/test/modern/panels.ps
+++ b/test/modern/panels.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_b7821db-dirty [64-bit] Document from psxy
+%%Title: GMT v6.0.0_9cdd6e8-dirty_2019.08.08 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sat Sep 29 15:54:32 2018
+%%CreationDate: Thu Aug  8 10:52:58 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -336,9 +336,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +592,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +635,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -672,9 +667,9 @@ O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -R0/6.20833/0/6.20833 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=false
-%@PROJ: xy 0.00000000 6.20833000 0.00000000 6.20833000 0.000 6.208 0.000 6.208 +xy
-%GMTBoundingBox: 72 72 447 447
+%@GMT: gmt psxy -R0/6.20833/0/6.27778 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 6.20833000 0.00000000 6.27778000 0.000 6.208 0.000 6.278 +xy
+%GMTBoundingBox: 72 72 447 452
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
@@ -684,10 +679,10 @@ PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 3850 TM
+0 3933 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -R0/80/0/10 -BWrts -Bxaf -Byaf -Xa0i -Ya3.2083i -JX15c
+%@GMT: gmt psbasemap -R0/80/0/10 -BWrts -Bxaf -Byaf -Xa0i -Ya3.2778i -JX15c
 %@PROJ: xy 0.00000000 80.00000000 0.00000000 10.00000000 0.000 80.000 0.000 10.000 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -695,8 +690,8 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-0 3850 T
-67 3533 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 3933 T
+0 A 67 3533 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (a\)) tl Z
 U
@@ -713,6 +708,7 @@ N 0 1440 M -83 0 D S
 N 0 2160 M -83 0 D S
 N 0 2880 M -83 0 D S
 N 0 3600 M -83 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg exch M} def
 200 F0
@@ -767,15 +763,15 @@ N 0 0 M 3600 0 D S
 0 -3600 T
 0 setlinecap
 %%EndObject
-0 -3850 TM
+0 -3933 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-3850 3850 TM
+3850 3933 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Bwrts -Bxaf -Byaf -Xa3.2083i -Ya3.2083i -R0/80/0/10 -JX15c
+%@GMT: gmt psbasemap -Bwrts -Bxaf -Byaf -Xa3.2083i -Ya3.2778i -R0/80/0/10 -JX15c
 %@PROJ: xy 0.00000000 80.00000000 0.00000000 10.00000000 0.000 80.000 0.000 10.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -783,8 +779,8 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-3850 3850 T
-67 3533 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+3850 3933 T
+0 A 67 3533 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (b\)) tl Z
 U
@@ -831,15 +827,15 @@ N 0 0 M 3600 0 D S
 0 -3600 T
 0 setlinecap
 %%EndObject
--3850 -3850 TM
+-3850 -3933 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 0 TM
+0 83 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -BWrtS -Bxaf -Byaf -Xa0i -Ya0i -R0/80/0/10 -JX15c
+%@GMT: gmt psbasemap -BWrtS -Bxaf -Byaf -Xa0i -Ya0.0694i -R0/80/0/10 -JX15c
 %@PROJ: xy 0.00000000 80.00000000 0.00000000 10.00000000 0.000 80.000 0.000 10.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -847,7 +843,8 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-67 3533 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 83 T
+0 A 67 3533 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (c\)) tl Z
 U
@@ -864,6 +861,7 @@ N 0 1440 M -83 0 D S
 N 0 2160 M -83 0 D S
 N 0 2880 M -83 0 D S
 N 0 3600 M -83 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg exch M} def
 200 F0
@@ -937,15 +935,15 @@ N 0 0 M 3600 0 D S
 0 -3600 T
 0 setlinecap
 %%EndObject
-0 0 TM
+0 -83 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-3850 0 TM
+3850 83 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -BwrtS -Bxaf -Byaf -Xa3.2083i -Ya0i -R0/80/0/10 -JX15c
+%@GMT: gmt psbasemap -BwrtS -Bxaf -Byaf -Xa3.2083i -Ya0.0694i -R0/80/0/10 -JX15c
 %@PROJ: xy 0.00000000 80.00000000 0.00000000 10.00000000 0.000 80.000 0.000 10.000 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -953,8 +951,8 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-3850 0 T
-67 3533 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+3850 83 T
+0 A 67 3533 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (d\)) tl Z
 U
@@ -990,6 +988,7 @@ N 900 0 M 0 -83 D S
 N 1800 0 M 0 -83 D S
 N 2700 0 M 0 -83 D S
 N 3600 0 M 0 -83 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg M} def
 200 F0
@@ -1021,7 +1020,7 @@ N 0 0 M 3600 0 D S
 0 -3600 T
 0 setlinecap
 %%EndObject
--3850 0 TM
+-3850 -83 TM
 PSL_completion /PSL_completion {} def
 
 grestore

--- a/test/modern/somepanels.ps
+++ b/test/modern/somepanels.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from pstext
+%%Title: GMT v6.0.0_9cdd6e8-dirty_2019.08.08 [64-bit] Document from pstext
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:53:06 2018
+%%CreationDate: Thu Aug  8 10:52:59 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -336,9 +336,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +592,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +635,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -679,7 +674,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-3600 10583 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+3600 10667 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 533 F0
 (FIGURE HEADER) bc Z
 %%EndObject
@@ -687,10 +682,10 @@ PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 6939 TM
+0 7022 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -R0/100/0/10 -BWrts -Bxaf -Byaf+lYLABEL -Xa0i -Ya5.7824i -JX15c
+%@GMT: gmt psbasemap -R0/100/0/10 -BWrts -Bxaf -Byaf+lYLABEL -Xa0i -Ya5.8519i -JX15c
 %@PROJ: xy 0.00000000 100.00000000 0.00000000 10.00000000 0.000 100.000 0.000 10.000 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -698,24 +693,25 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-0 6939 T
-2021 240 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 7022 T
+0 A 1993 240 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (i) br Z
 U
 }!
 25 W
 2 setlinecap
-N 0 3261 M 0 -3261 D S
+N 0 3178 M 0 -3178 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 652 M -83 0 D S
-N 0 1304 M -83 0 D S
-N 0 1957 M -83 0 D S
-N 0 2609 M -83 0 D S
-N 0 3261 M -83 0 D S
+N 0 636 M -83 0 D S
+N 0 1271 M -83 0 D S
+N 0 1907 M -83 0 D S
+N 0 2542 M -83 0 D S
+N 0 3178 M -83 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg exch M} def
 200 F0
@@ -729,62 +725,62 @@ def
 /PSL_A0_y PSL_A0_y 83 add def
 0 PSL_A0_y MM
 (0) mr Z
-652 PSL_A0_y MM
+636 PSL_A0_y MM
 (2) mr Z
-1304 PSL_A0_y MM
+1271 PSL_A0_y MM
 (4) mr Z
-1957 PSL_A0_y MM
+1907 PSL_A0_y MM
 (6) mr Z
-2609 PSL_A0_y MM
+2542 PSL_A0_y MM
 (8) mr Z
-3261 PSL_A0_y MM
+3178 PSL_A0_y MM
 (10) mr Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 0 326 M -42 0 D S
-N 0 978 M -42 0 D S
-N 0 1631 M -42 0 D S
-N 0 2283 M -42 0 D S
-N 0 2935 M -42 0 D S
+N 0 318 M -42 0 D S
+N 0 953 M -42 0 D S
+N 0 1589 M -42 0 D S
+N 0 2224 M -42 0 D S
+N 0 2860 M -42 0 D S
 /PSL_LH 267 F0
 (M) sh def
 /PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
-1631 PSL_L_y MM
+1589 PSL_L_y MM
 V 90 R (YLABEL) bc Z U
-2261 0 T
+2233 0 T
 25 W
-N 0 3261 M 0 -3261 D S
--2261 0 T
-N 0 0 M 2261 0 D S
+N 0 3178 M 0 -3178 D S
+-2233 0 T
+N 0 0 M 2233 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 -83 D S
-N 452 0 M 0 -83 D S
-N 904 0 M 0 -83 D S
-N 1357 0 M 0 -83 D S
-N 1809 0 M 0 -83 D S
-N 2261 0 M 0 -83 D S
-N 226 0 M 0 -42 D S
-N 678 0 M 0 -42 D S
-N 1131 0 M 0 -42 D S
-N 1583 0 M 0 -42 D S
-N 2035 0 M 0 -42 D S
+N 447 0 M 0 -83 D S
+N 893 0 M 0 -83 D S
+N 1340 0 M 0 -83 D S
+N 1787 0 M 0 -83 D S
+N 2233 0 M 0 -83 D S
+N 223 0 M 0 -42 D S
+N 670 0 M 0 -42 D S
+N 1117 0 M 0 -42 D S
+N 1563 0 M 0 -42 D S
+N 2010 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 3261 T
+0 3178 T
 25 W
-N 0 0 M 2261 0 D S
-0 -3261 T
+N 0 0 M 2233 0 D S
+0 -3178 T
 0 setlinecap
 %%EndObject
-0 -6939 TM
+0 -7022 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-2511 3428 TM
+2483 3594 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Bwrts+gpink -Bxaf -Byaf -Xa2.0926i -Ya2.8565i -R0/100/0/10 -JX15c
+%@GMT: gmt psbasemap -Bwrts+gpink -Bxaf -Byaf -Xa2.0694i -Ya2.9954i -R0/100/0/10 -JX15c
 %@PROJ: xy 0.00000000 100.00000000 0.00000000 10.00000000 0.000 100.000 0.000 10.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -792,67 +788,67 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-2511 3428 T
-2021 240 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+2483 3594 T
+0 A 1993 240 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (pink) br Z
 U
 }!
 {1 0.753 0.796 C} FS
--2261 0 0 3261 2261 0 3 0 0 SP
+-2233 0 0 3178 2233 0 3 0 0 SP
 25 W
 2 setlinecap
-N 0 3261 M 0 -3261 D S
+N 0 3178 M 0 -3178 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 652 M -83 0 D S
-N 0 1304 M -83 0 D S
-N 0 1957 M -83 0 D S
-N 0 2609 M -83 0 D S
-N 0 3261 M -83 0 D S
-N 0 326 M -42 0 D S
-N 0 978 M -42 0 D S
-N 0 1631 M -42 0 D S
-N 0 2283 M -42 0 D S
-N 0 2935 M -42 0 D S
+N 0 636 M -83 0 D S
+N 0 1271 M -83 0 D S
+N 0 1907 M -83 0 D S
+N 0 2542 M -83 0 D S
+N 0 3178 M -83 0 D S
+N 0 318 M -42 0 D S
+N 0 953 M -42 0 D S
+N 0 1589 M -42 0 D S
+N 0 2224 M -42 0 D S
+N 0 2860 M -42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-2261 0 T
+2233 0 T
 25 W
-N 0 3261 M 0 -3261 D S
--2261 0 T
-N 0 0 M 2261 0 D S
+N 0 3178 M 0 -3178 D S
+-2233 0 T
+N 0 0 M 2233 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 -83 D S
-N 452 0 M 0 -83 D S
-N 904 0 M 0 -83 D S
-N 1357 0 M 0 -83 D S
-N 1809 0 M 0 -83 D S
-N 2261 0 M 0 -83 D S
-N 226 0 M 0 -42 D S
-N 678 0 M 0 -42 D S
-N 1131 0 M 0 -42 D S
-N 1583 0 M 0 -42 D S
-N 2035 0 M 0 -42 D S
+N 447 0 M 0 -83 D S
+N 893 0 M 0 -83 D S
+N 1340 0 M 0 -83 D S
+N 1787 0 M 0 -83 D S
+N 2233 0 M 0 -83 D S
+N 223 0 M 0 -42 D S
+N 670 0 M 0 -42 D S
+N 1117 0 M 0 -42 D S
+N 1563 0 M 0 -42 D S
+N 2010 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 3261 T
+0 3178 T
 25 W
-N 0 0 M 2261 0 D S
-0 -3261 T
+N 0 0 M 2233 0 D S
+0 -3178 T
 0 setlinecap
 %%EndObject
--2511 -3428 TM
+-2483 -3594 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-5022 -83 TM
+4967 167 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -BwrtS -Bxaf+lXLABEL -Byaf -Xa4.1852i -Ya-0.0694i -R0/100/0/10 -JX15c
+%@GMT: gmt psbasemap -BwrtS -Bxaf+lXLABEL -Byaf -Xa4.1389i -Ya0.1389i -R0/100/0/10 -JX15c
 %@PROJ: xy 0.00000000 100.00000000 0.00000000 10.00000000 0.000 100.000 0.000 10.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -860,44 +856,45 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-5022 -83 T
-2021 240 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+4967 167 T
+0 A 1993 240 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (ix) br Z
 U
 }!
 25 W
 2 setlinecap
-N 0 3261 M 0 -3261 D S
+N 0 3178 M 0 -3178 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 652 M -83 0 D S
-N 0 1304 M -83 0 D S
-N 0 1957 M -83 0 D S
-N 0 2609 M -83 0 D S
-N 0 3261 M -83 0 D S
-N 0 326 M -42 0 D S
-N 0 978 M -42 0 D S
-N 0 1631 M -42 0 D S
-N 0 2283 M -42 0 D S
-N 0 2935 M -42 0 D S
+N 0 636 M -83 0 D S
+N 0 1271 M -83 0 D S
+N 0 1907 M -83 0 D S
+N 0 2542 M -83 0 D S
+N 0 3178 M -83 0 D S
+N 0 318 M -42 0 D S
+N 0 953 M -42 0 D S
+N 0 1589 M -42 0 D S
+N 0 2224 M -42 0 D S
+N 0 2860 M -42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-2261 0 T
+2233 0 T
 25 W
-N 0 3261 M 0 -3261 D S
--2261 0 T
-N 0 0 M 2261 0 D S
+N 0 3178 M 0 -3178 D S
+-2233 0 T
+N 0 0 M 2233 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 -83 D S
-N 452 0 M 0 -83 D S
-N 904 0 M 0 -83 D S
-N 1357 0 M 0 -83 D S
-N 1809 0 M 0 -83 D S
-N 2261 0 M 0 -83 D S
+N 447 0 M 0 -83 D S
+N 893 0 M 0 -83 D S
+N 1340 0 M 0 -83 D S
+N 1787 0 M 0 -83 D S
+N 2233 0 M 0 -83 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg M} def
 200 F0
@@ -911,41 +908,41 @@ def
 /PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
 0 PSL_A0_y MM
 (0) bc Z
-452 PSL_A0_y MM
+447 PSL_A0_y MM
 (20) bc Z
-904 PSL_A0_y MM
+893 PSL_A0_y MM
 (40) bc Z
-1357 PSL_A0_y MM
+1340 PSL_A0_y MM
 (60) bc Z
-1809 PSL_A0_y MM
+1787 PSL_A0_y MM
 (80) bc Z
-2261 PSL_A0_y MM
+2233 PSL_A0_y MM
 (100) bc Z
-N 226 0 M 0 -42 D S
-N 678 0 M 0 -42 D S
-N 1131 0 M 0 -42 D S
-N 1583 0 M 0 -42 D S
-N 2035 0 M 0 -42 D S
+N 223 0 M 0 -42 D S
+N 670 0 M 0 -42 D S
+N 1117 0 M 0 -42 D S
+N 1563 0 M 0 -42 D S
+N 2010 0 M 0 -42 D S
 /PSL_LH 267 F0
 (M) sh def
 /PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
-1131 PSL_L_y MM
+1117 PSL_L_y MM
 (XLABEL) bc Z
-0 3261 T
+0 3178 T
 25 W
-N 0 0 M 2261 0 D S
-0 -3261 T
+N 0 0 M 2233 0 D S
+0 -3178 T
 0 setlinecap
 %%EndObject
--5022 83 TM
+-4967 -167 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 3428 TM
+0 3594 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -R300/500/-10/0 -BWrts -Bxaf -Byaf+lYLABEL -Xa0i -Ya2.8565i -JX15c
+%@GMT: gmt psbasemap -R300/500/-10/0 -BWrts -Bxaf -Byaf+lYLABEL -Xa0i -Ya2.9954i -JX15c
 %@PROJ: xy 300.00000000 500.00000000 -10.00000000 0.00000000 300.000 500.000 -10.000 0.000 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -953,24 +950,25 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-0 3428 T
-2021 240 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 3594 T
+0 A 1993 240 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (iv) br Z
 U
 }!
 25 W
 2 setlinecap
-N 0 3261 M 0 -3261 D S
+N 0 3178 M 0 -3178 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 652 M -83 0 D S
-N 0 1304 M -83 0 D S
-N 0 1957 M -83 0 D S
-N 0 2609 M -83 0 D S
-N 0 3261 M -83 0 D S
+N 0 636 M -83 0 D S
+N 0 1271 M -83 0 D S
+N 0 1907 M -83 0 D S
+N 0 2542 M -83 0 D S
+N 0 3178 M -83 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg exch M} def
 200 F0
@@ -984,72 +982,72 @@ def
 /PSL_A0_y PSL_A0_y 83 add def
 0 PSL_A0_y MM
 (”10) mr Z
-652 PSL_A0_y MM
+636 PSL_A0_y MM
 (”8) mr Z
-1304 PSL_A0_y MM
+1271 PSL_A0_y MM
 (”6) mr Z
-1957 PSL_A0_y MM
+1907 PSL_A0_y MM
 (”4) mr Z
-2609 PSL_A0_y MM
+2542 PSL_A0_y MM
 (”2) mr Z
-3261 PSL_A0_y MM
+3178 PSL_A0_y MM
 (0) mr Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 0 326 M -42 0 D S
-N 0 978 M -42 0 D S
-N 0 1631 M -42 0 D S
-N 0 2283 M -42 0 D S
-N 0 2935 M -42 0 D S
+N 0 318 M -42 0 D S
+N 0 953 M -42 0 D S
+N 0 1589 M -42 0 D S
+N 0 2224 M -42 0 D S
+N 0 2860 M -42 0 D S
 /PSL_LH 267 F0
 (M) sh def
 /PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
-1631 PSL_L_y MM
+1589 PSL_L_y MM
 V 90 R (YLABEL) bc Z U
-2261 0 T
+2233 0 T
 25 W
-N 0 3261 M 0 -3261 D S
--2261 0 T
-N 0 0 M 2261 0 D S
+N 0 3178 M 0 -3178 D S
+-2233 0 T
+N 0 0 M 2233 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 -83 D S
-N 565 0 M 0 -83 D S
-N 1131 0 M 0 -83 D S
-N 1696 0 M 0 -83 D S
-N 2261 0 M 0 -83 D S
-N 113 0 M 0 -42 D S
-N 226 0 M 0 -42 D S
-N 339 0 M 0 -42 D S
-N 452 0 M 0 -42 D S
-N 678 0 M 0 -42 D S
-N 791 0 M 0 -42 D S
-N 904 0 M 0 -42 D S
-N 1018 0 M 0 -42 D S
-N 1244 0 M 0 -42 D S
-N 1357 0 M 0 -42 D S
-N 1470 0 M 0 -42 D S
-N 1583 0 M 0 -42 D S
-N 1809 0 M 0 -42 D S
-N 1922 0 M 0 -42 D S
-N 2035 0 M 0 -42 D S
-N 2148 0 M 0 -42 D S
+N 558 0 M 0 -83 D S
+N 1117 0 M 0 -83 D S
+N 1675 0 M 0 -83 D S
+N 2233 0 M 0 -83 D S
+N 112 0 M 0 -42 D S
+N 223 0 M 0 -42 D S
+N 335 0 M 0 -42 D S
+N 447 0 M 0 -42 D S
+N 670 0 M 0 -42 D S
+N 782 0 M 0 -42 D S
+N 893 0 M 0 -42 D S
+N 1005 0 M 0 -42 D S
+N 1228 0 M 0 -42 D S
+N 1340 0 M 0 -42 D S
+N 1452 0 M 0 -42 D S
+N 1563 0 M 0 -42 D S
+N 1787 0 M 0 -42 D S
+N 1898 0 M 0 -42 D S
+N 2010 0 M 0 -42 D S
+N 2122 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 3261 T
+0 3178 T
 25 W
-N 0 0 M 2261 0 D S
-0 -3261 T
+N 0 0 M 2233 0 D S
+0 -3178 T
 0 setlinecap
 %%EndObject
-0 -3428 TM
+0 -3594 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-5022 3428 TM
+4967 3594 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Bafg -R300/500/-100/0 -Bwrts -Xa4.1852i -Ya2.8565i -JX15c
+%@GMT: gmt psbasemap -Bafg -R300/500/-100/0 -Bwrts -Xa4.1389i -Ya2.9954i -JX15c
 %@PROJ: xy 300.00000000 500.00000000 -100.00000000 0.00000000 300.000 500.000 -100.000 0.000 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
@@ -1057,8 +1055,8 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-5022 3428 T
-2021 240 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+4967 3594 T
+0 A 1993 240 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (vi) br Z
 U
@@ -1066,93 +1064,93 @@ U
 25 W
 4 W
 0 0 M
-0 3261 D
+0 3178 D
 S
-565 0 M
-0 3261 D
+558 0 M
+0 3178 D
 S
-1131 0 M
-0 3261 D
+1117 0 M
+0 3178 D
 S
-1696 0 M
-0 3261 D
+1675 0 M
+0 3178 D
 S
-2261 0 M
-0 3261 D
+2233 0 M
+0 3178 D
 S
 0 0 M
-2261 0 D
+2233 0 D
 S
-0 652 M
-2261 0 D
+0 636 M
+2233 0 D
 S
-0 1304 M
-2261 0 D
+0 1271 M
+2233 0 D
 S
-0 1957 M
-2261 0 D
+0 1907 M
+2233 0 D
 S
-0 2609 M
-2261 0 D
+0 2542 M
+2233 0 D
 S
-0 3261 M
-2261 0 D
+0 3178 M
+2233 0 D
 S
 2 setlinecap
 25 W
-N 0 3261 M 0 -3261 D S
+N 0 3178 M 0 -3178 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 652 M -83 0 D S
-N 0 1304 M -83 0 D S
-N 0 1957 M -83 0 D S
-N 0 2609 M -83 0 D S
-N 0 3261 M -83 0 D S
-N 0 326 M -42 0 D S
-N 0 978 M -42 0 D S
-N 0 1631 M -42 0 D S
-N 0 2283 M -42 0 D S
-N 0 2935 M -42 0 D S
+N 0 636 M -83 0 D S
+N 0 1271 M -83 0 D S
+N 0 1907 M -83 0 D S
+N 0 2542 M -83 0 D S
+N 0 3178 M -83 0 D S
+N 0 318 M -42 0 D S
+N 0 953 M -42 0 D S
+N 0 1589 M -42 0 D S
+N 0 2224 M -42 0 D S
+N 0 2860 M -42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-2261 0 T
+2233 0 T
 25 W
-N 0 3261 M 0 -3261 D S
--2261 0 T
-N 0 0 M 2261 0 D S
+N 0 3178 M 0 -3178 D S
+-2233 0 T
+N 0 0 M 2233 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 -83 D S
-N 565 0 M 0 -83 D S
-N 1131 0 M 0 -83 D S
-N 1696 0 M 0 -83 D S
-N 2261 0 M 0 -83 D S
-N 113 0 M 0 -42 D S
-N 226 0 M 0 -42 D S
-N 339 0 M 0 -42 D S
-N 452 0 M 0 -42 D S
-N 678 0 M 0 -42 D S
-N 791 0 M 0 -42 D S
-N 904 0 M 0 -42 D S
-N 1018 0 M 0 -42 D S
-N 1244 0 M 0 -42 D S
-N 1357 0 M 0 -42 D S
-N 1470 0 M 0 -42 D S
-N 1583 0 M 0 -42 D S
-N 1809 0 M 0 -42 D S
-N 1922 0 M 0 -42 D S
-N 2035 0 M 0 -42 D S
-N 2148 0 M 0 -42 D S
+N 558 0 M 0 -83 D S
+N 1117 0 M 0 -83 D S
+N 1675 0 M 0 -83 D S
+N 2233 0 M 0 -83 D S
+N 112 0 M 0 -42 D S
+N 223 0 M 0 -42 D S
+N 335 0 M 0 -42 D S
+N 447 0 M 0 -42 D S
+N 670 0 M 0 -42 D S
+N 782 0 M 0 -42 D S
+N 893 0 M 0 -42 D S
+N 1005 0 M 0 -42 D S
+N 1228 0 M 0 -42 D S
+N 1340 0 M 0 -42 D S
+N 1452 0 M 0 -42 D S
+N 1563 0 M 0 -42 D S
+N 1787 0 M 0 -42 D S
+N 1898 0 M 0 -42 D S
+N 2010 0 M 0 -42 D S
+N 2122 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 3261 T
+0 3178 T
 25 W
-N 0 0 M 2261 0 D S
-0 -3261 T
+N 0 0 M 2233 0 D S
+0 -3178 T
 0 setlinecap
 %%EndObject
--5022 -3428 TM
+-4967 -3594 TM
 PSL_completion /PSL_completion {} def
 
 grestore

--- a/test/modern/vardims.ps
+++ b/test/modern/vardims.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612 792             
-%%Title: GMT v6.0.0_r19359 [64-bit] Document from pstext
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_9cdd6e8-dirty_2019.08.08 [64-bit] Document from pstext
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Nov 20 18:12:51 2017
+%%CreationDate: Thu Aug  8 10:52:59 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -658,19 +658,23 @@ V 0.06 0.06 scale
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_completion {} def
+/PSL_movie_completion {} def
+%PSL_End_Header
+gsave
 0 A
 FQ
 O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: pstext -R0/6.06944/0/8.81944 -Jx1i -P -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
-%@PROJ: xy 0.00000000 6.06944000 0.00000000 8.81944000 0.000 6.069 0.000 8.819 +xy
+%@GMT: gmt pstext -R0/6.13889/0/9.02778 -Jx1i -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 6.13889000 0.00000000 9.02778000 0.000 6.139 0.000 9.028 +xy
+%GMTBoundingBox: 72 72 442 650
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-3642 10883 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+3683 11217 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 533 F0
 (Variable dimensions) bc Z
 %%EndObject
@@ -678,10 +682,10 @@ PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 7583 TM
+0 7833 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R0/5/0/5 -BWens+gpink -Bxaf -Byaf -Xa0i -Ya6.3194i -JX15c
+%@GMT: gmt psbasemap -R0/5/0/5 -BWens+gpink -Bxaf -Byaf -Xa0i -Ya6.5278i -JX15c
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 5.00000000 0.000 5.000 0.000 5.000 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -689,13 +693,12 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-0 7583 T
-67 2933 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 7833 T
+0 A 67 2933 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (A) tl Z
 U
 }!
-/PSL_exec_completion 1 def
 {1 0.753 0.796 C} FS
 -2400 0 0 3000 2400 0 3 0 0 SP
 25 W
@@ -707,6 +710,7 @@ N 0 3000 M 0 -3000 D S
 N 0 0 M -83 0 D S
 N 0 1200 M -83 0 D S
 N 0 2400 M -83 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg exch M} def
 200 F0
@@ -768,109 +772,28 @@ N 2400 0 M 0 42 D S
 0 -3000 T
 0 setlinecap
 %%EndObject
-0 -7583 TM
+0 -7833 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-2567 7583 TM
+0 1667 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R10/15/0/5 -Bwens+gyellow -Bxaf -Byaf -Xa2.1389i -Ya6.3194i -JX15c
-%@PROJ: xy 10.00000000 15.00000000 0.00000000 5.00000000 10.000 15.000 0.000 5.000 +xy
+%@GMT: gmt psbasemap -R0/5/10/15 -BWens+gcyan -Bxaf -Byaf -Xa0i -Ya1.3889i -JX15c
+%@PROJ: xy 0.00000000 5.00000000 10.00000000 15.00000000 0.000 5.000 10.000 15.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 /PSL_completion {
 V
-2567 7583 T
-67 2933 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-333 F0
-(D) tl Z
-U
-}!
-/PSL_exec_completion 1 def
-{1 1 0 C} FS
--4800 0 0 3000 4800 0 3 0 0 SP
-25 W
-2 setlinecap
-N 0 3000 M 0 -3000 D S
-/PSL_A0_y 83 def
-/PSL_A1_y 0 def
-8 W
-N 0 0 M -83 0 D S
-N 0 1200 M -83 0 D S
-N 0 2400 M -83 0 D S
-N 0 600 M -42 0 D S
-N 0 1800 M -42 0 D S
-N 0 3000 M -42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-4800 0 T
-25 W
-N 0 3000 M 0 -3000 D S
-/PSL_A0_y 83 def
-/PSL_A1_y 0 def
-8 W
-N 0 0 M 83 0 D S
-N 0 1200 M 83 0 D S
-N 0 2400 M 83 0 D S
-N 0 600 M 42 0 D S
-N 0 1800 M 42 0 D S
-N 0 3000 M 42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--4800 0 T
-25 W
-N 0 0 M 4800 0 D S
-/PSL_A0_y 83 def
-/PSL_A1_y 0 def
-8 W
-N 0 0 M 0 -83 D S
-N 1920 0 M 0 -83 D S
-N 3840 0 M 0 -83 D S
-N 960 0 M 0 -42 D S
-N 2880 0 M 0 -42 D S
-N 4800 0 M 0 -42 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 3000 T
-25 W
-N 0 0 M 4800 0 D S
-/PSL_A0_y 83 def
-/PSL_A1_y 0 def
-8 W
-N 0 0 M 0 83 D S
-N 1920 0 M 0 83 D S
-N 3840 0 M 0 83 D S
-N 960 0 M 0 42 D S
-N 2880 0 M 0 42 D S
-N 4800 0 M 0 42 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -3000 T
-0 setlinecap
-%%EndObject
--2567 -7583 TM
-PSL_completion /PSL_completion {} def
-0 A
-FQ
-O0
-0 1417 TM
-
-% PostScript produced by:
-%@GMT: psbasemap -R0/5/10/15 -BWens+gcyan -Bxaf -Byaf -Xa0i -Ya1.1806i -JX15c
-%@PROJ: xy 0.00000000 5.00000000 10.00000000 15.00000000 0.000 5.000 10.000 15.000 +xy
-%%BeginObject PSL_Layer_3
-0 setlinecap
-0 setlinejoin
-3.32551 setmiterlimit
-/PSL_completion {
-V
-0 1417 T
-67 5933 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 1667 T
+0 A 67 5933 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (B) tl Z
 U
 }!
-/PSL_exec_completion 1 def
 {0 1 1 C} FS
 -2400 0 0 6000 2400 0 3 0 0 SP
 25 W
@@ -885,6 +808,7 @@ N 0 2400 M -83 0 D S
 N 0 3600 M -83 0 D S
 N 0 4800 M -83 0 D S
 N 0 6000 M -83 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg exch M} def
 200 F0
@@ -992,29 +916,214 @@ N 2400 0 M 0 42 D S
 0 -6000 T
 0 setlinecap
 %%EndObject
-0 -1417 TM
+0 -1667 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-2567 1417 TM
+0 0 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R10/15/10/15 -Bwens+gpurple -Bxaf -Byaf -Xa2.1389i -Ya1.1806i -JX15c
-%@PROJ: xy 10.00000000 15.00000000 10.00000000 15.00000000 10.000 15.000 10.000 15.000 +xy
+%@GMT: gmt psbasemap -R0/5/10/15 -BWenS+glightgray -Bxaf -Byaf -Xa0i -Ya0i -JX15c
+%@PROJ: xy 0.00000000 5.00000000 10.00000000 15.00000000 0.000 5.000 10.000 15.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_completion {
+V
+0 A 67 1433 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(C) tl Z
+U
+}!
+{0.827 A} FS
+-2400 0 0 1500 2400 0 3 0 0 SP
+25 W
+2 setlinecap
+N 0 1500 M 0 -1500 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 600 M -83 0 D S
+N 0 1200 M -83 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/PSL_AH0 0
+/MM {neg exch M} def
+200 F0
+(10) sh mx
+(12) sh mx
+(14) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+V 90 R (10) bc Z U
+600 PSL_A0_y MM
+V 90 R (12) bc Z U
+1200 PSL_A0_y MM
+V 90 R (14) bc Z U
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 300 M -42 0 D S
+N 0 900 M -42 0 D S
+N 0 1500 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2400 0 T
+25 W
+N 0 1500 M 0 -1500 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 600 M 83 0 D S
+N 0 1200 M 83 0 D S
+N 0 300 M 42 0 D S
+N 0 900 M 42 0 D S
+N 0 1500 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-2400 0 T
+25 W
+N 0 0 M 2400 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 960 0 M 0 -83 D S
+N 1920 0 M 0 -83 D S
+/PSL_AH0 0
+/MM {neg M} def
+(0) sh mx
+(2) sh mx
+(4) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+960 PSL_A0_y MM
+(2) bc Z
+1920 PSL_A0_y MM
+(4) bc Z
+N 480 0 M 0 -42 D S
+N 1440 0 M 0 -42 D S
+N 2400 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 1500 T
+25 W
+N 0 0 M 2400 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 960 0 M 0 83 D S
+N 1920 0 M 0 83 D S
+N 480 0 M 0 42 D S
+N 1440 0 M 0 42 D S
+N 2400 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -1500 T
+0 setlinecap
+%%EndObject
+0 0 TM
+PSL_completion /PSL_completion {} def
+0 A
+FQ
+O0
+2567 7833 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R10/15/0/5 -Bwens+gyellow -Bxaf -Byaf -Xa2.1389i -Ya6.5278i -JX15c
+%@PROJ: xy 10.00000000 15.00000000 0.00000000 5.00000000 10.000 15.000 0.000 5.000 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 /PSL_completion {
 V
-2567 1417 T
-67 5933 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+2567 7833 T
+0 A 67 2933 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(D) tl Z
+U
+}!
+{1 1 0 C} FS
+-4800 0 0 3000 4800 0 3 0 0 SP
+25 W
+2 setlinecap
+N 0 3000 M 0 -3000 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 1200 M -83 0 D S
+N 0 2400 M -83 0 D S
+N 0 600 M -42 0 D S
+N 0 1800 M -42 0 D S
+N 0 3000 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+4800 0 T
+25 W
+N 0 3000 M 0 -3000 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 1200 M 83 0 D S
+N 0 2400 M 83 0 D S
+N 0 600 M 42 0 D S
+N 0 1800 M 42 0 D S
+N 0 3000 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-4800 0 T
+25 W
+N 0 0 M 4800 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 1920 0 M 0 -83 D S
+N 3840 0 M 0 -83 D S
+N 960 0 M 0 -42 D S
+N 2880 0 M 0 -42 D S
+N 4800 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3000 T
+25 W
+N 0 0 M 4800 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 1920 0 M 0 83 D S
+N 3840 0 M 0 83 D S
+N 960 0 M 0 42 D S
+N 2880 0 M 0 42 D S
+N 4800 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3000 T
+0 setlinecap
+%%EndObject
+-2567 -7833 TM
+PSL_completion /PSL_completion {} def
+0 A
+FQ
+O0
+2567 1667 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R10/15/10/15 -Bwens+gpurple -Bxaf -Byaf -Xa2.1389i -Ya1.3889i -JX15c
+%@PROJ: xy 10.00000000 15.00000000 10.00000000 15.00000000 10.000 15.000 10.000 15.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_completion {
+V
+2567 1667 T
+0 A 67 5933 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (E) tl Z
 U
 }!
-/PSL_exec_completion 1 def
 {0.627 0.125 0.941 C} FS
 -4800 0 0 6000 4800 0 3 0 0 SP
 25 W
@@ -1112,123 +1221,15 @@ N 4800 0 M 0 42 D S
 0 -6000 T
 0 setlinecap
 %%EndObject
--2567 -1417 TM
+-2567 -1667 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 -250 TM
+2567 0 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R0/5/10/15 -BWenS+glightgray -Bxaf -Byaf -Xa0i -Ya-0.2083i -JX15c
-%@PROJ: xy 0.00000000 5.00000000 10.00000000 15.00000000 0.000 5.000 10.000 15.000 +xy
-%%BeginObject PSL_Layer_5
-0 setlinecap
-0 setlinejoin
-3.32551 setmiterlimit
-/PSL_completion {
-V
-0 -250 T
-67 1433 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-333 F0
-(C) tl Z
-U
-}!
-/PSL_exec_completion 1 def
-{0.827 A} FS
--2400 0 0 1500 2400 0 3 0 0 SP
-25 W
-2 setlinecap
-N 0 1500 M 0 -1500 D S
-/PSL_A0_y 83 def
-/PSL_A1_y 0 def
-8 W
-N 0 0 M -83 0 D S
-N 0 600 M -83 0 D S
-N 0 1200 M -83 0 D S
-/PSL_AH0 0
-/MM {neg exch M} def
-200 F0
-(10) sh mx
-(12) sh mx
-(14) sh mx
-def
-/PSL_A0_y PSL_A0_y 83 add def
-0 PSL_A0_y MM
-V 90 R (10) bc Z U
-600 PSL_A0_y MM
-V 90 R (12) bc Z U
-1200 PSL_A0_y MM
-V 90 R (14) bc Z U
-/PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 0 300 M -42 0 D S
-N 0 900 M -42 0 D S
-N 0 1500 M -42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-2400 0 T
-25 W
-N 0 1500 M 0 -1500 D S
-/PSL_A0_y 83 def
-/PSL_A1_y 0 def
-8 W
-N 0 0 M 83 0 D S
-N 0 600 M 83 0 D S
-N 0 1200 M 83 0 D S
-N 0 300 M 42 0 D S
-N 0 900 M 42 0 D S
-N 0 1500 M 42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--2400 0 T
-25 W
-N 0 0 M 2400 0 D S
-/PSL_A0_y 83 def
-/PSL_A1_y 0 def
-8 W
-N 0 0 M 0 -83 D S
-N 960 0 M 0 -83 D S
-N 1920 0 M 0 -83 D S
-/PSL_AH0 0
-/MM {neg M} def
-(0) sh mx
-(2) sh mx
-(4) sh mx
-def
-/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
-0 PSL_A0_y MM
-(0) bc Z
-960 PSL_A0_y MM
-(2) bc Z
-1920 PSL_A0_y MM
-(4) bc Z
-N 480 0 M 0 -42 D S
-N 1440 0 M 0 -42 D S
-N 2400 0 M 0 -42 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 1500 T
-25 W
-N 0 0 M 2400 0 D S
-/PSL_A0_y 83 def
-/PSL_A1_y 0 def
-8 W
-N 0 0 M 0 83 D S
-N 960 0 M 0 83 D S
-N 1920 0 M 0 83 D S
-N 480 0 M 0 42 D S
-N 1440 0 M 0 42 D S
-N 2400 0 M 0 42 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -1500 T
-0 setlinecap
-%%EndObject
-0 250 TM
-PSL_completion /PSL_completion {} def
-0 A
-FQ
-O0
-2567 -250 TM
-
-% PostScript produced by:
-%@GMT: psbasemap -R10/15/10/15 -BwenS+gorange -Bxaf -Byaf -Xa2.1389i -Ya-0.2083i -JX15c
+%@GMT: gmt psbasemap -R10/15/10/15 -BwenS+gorange -Bxaf -Byaf -Xa2.1389i -Ya0i -JX15c
 %@PROJ: xy 10.00000000 15.00000000 10.00000000 15.00000000 10.000 15.000 10.000 15.000 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
@@ -1236,13 +1237,12 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-2567 -250 T
-67 1433 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+2567 0 T
+0 A 67 1433 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (F) tl Z
 U
 }!
-/PSL_exec_completion 1 def
 {1 0.647 0 C} FS
 -4800 0 0 1500 4800 0 3 0 0 SP
 25 W
@@ -1280,6 +1280,7 @@ N 0 0 M 4800 0 D S
 N 0 0 M 0 -83 D S
 N 1920 0 M 0 -83 D S
 N 3840 0 M 0 -83 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg M} def
 200 F0
@@ -1314,8 +1315,12 @@ N 4800 0 M 0 42 D S
 0 -1500 T
 0 setlinecap
 %%EndObject
--2567 250 TM
+-2567 0 TM
 PSL_completion /PSL_completion {} def
+
+grestore
+PSL_movie_completion /PSL_movie_completion {} def
+%PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage

--- a/test/modern/varfracs.ps
+++ b/test/modern/varfracs.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612 792             
-%%Title: GMT v6.0.0_r19359 [64-bit] Document from pstext
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_9cdd6e8-dirty_2019.08.08 [64-bit] Document from pstext
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Nov 20 18:12:52 2017
+%%CreationDate: Thu Aug  8 10:53:00 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -658,19 +658,23 @@ V 0.06 0.06 scale
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_completion {} def
+/PSL_movie_completion {} def
+%PSL_End_Header
+gsave
 0 A
 FQ
 O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: pstext -R0/6.5/0/9 -Jx1i -P -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
+%@GMT: gmt pstext -R0/6.5/0/9 -Jx1i -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 6.50000000 0.00000000 9.00000000 0.000 6.500 0.000 9.000 +xy
+%GMTBoundingBox: 72 72 468 648
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-3900 11100 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+3900 11183 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 533 F0
 (Variable fractions) bc Z
 %%EndObject
@@ -678,10 +682,10 @@ PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 7738 TM
+0 7809 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R0/5/0/5 -BWens+gpink -Bxaf -Byaf -Xa0i -Ya6.4484i -JX15c
+%@GMT: gmt psbasemap -R0/5/0/5 -BWens+gpink -Bxaf -Byaf -Xa0i -Ya6.5079i -JX15c
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 5.00000000 0.000 5.000 0.000 5.000 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -689,24 +693,24 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-0 7738 T
-67 2995 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 7809 T
+0 A 67 2924 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (a\)) tl Z
 U
 }!
-/PSL_exec_completion 1 def
 {1 0.753 0.796 C} FS
--2572 0 0 3062 2572 0 3 0 0 SP
+-2544 0 0 2991 2544 0 3 0 0 SP
 25 W
 2 setlinecap
-N 0 3062 M 0 -3062 D S
+N 0 2991 M 0 -2991 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 1225 M -83 0 D S
-N 0 2450 M -83 0 D S
+N 0 1196 M -83 0 D S
+N 0 2392 M -83 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg exch M} def
 200 F0
@@ -717,66 +721,66 @@ def
 /PSL_A0_y PSL_A0_y 83 add def
 0 PSL_A0_y MM
 V 90 R (0) bc Z U
-1225 PSL_A0_y MM
+1196 PSL_A0_y MM
 V 90 R (2) bc Z U
-2450 PSL_A0_y MM
+2392 PSL_A0_y MM
 V 90 R (4) bc Z U
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 0 612 M -42 0 D S
-N 0 1837 M -42 0 D S
-N 0 3062 M -42 0 D S
+N 0 598 M -42 0 D S
+N 0 1794 M -42 0 D S
+N 0 2991 M -42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-2572 0 T
+2544 0 T
 25 W
-N 0 3062 M 0 -3062 D S
+N 0 2991 M 0 -2991 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 83 0 D S
-N 0 1225 M 83 0 D S
-N 0 2450 M 83 0 D S
-N 0 612 M 42 0 D S
-N 0 1837 M 42 0 D S
-N 0 3062 M 42 0 D S
+N 0 1196 M 83 0 D S
+N 0 2392 M 83 0 D S
+N 0 598 M 42 0 D S
+N 0 1794 M 42 0 D S
+N 0 2991 M 42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--2572 0 T
+-2544 0 T
 25 W
-N 0 0 M 2572 0 D S
+N 0 0 M 2544 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 -83 D S
-N 1029 0 M 0 -83 D S
-N 2058 0 M 0 -83 D S
-N 514 0 M 0 -42 D S
-N 1543 0 M 0 -42 D S
-N 2572 0 M 0 -42 D S
+N 1018 0 M 0 -83 D S
+N 2036 0 M 0 -83 D S
+N 509 0 M 0 -42 D S
+N 1527 0 M 0 -42 D S
+N 2544 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 3062 T
+0 2991 T
 25 W
-N 0 0 M 2572 0 D S
+N 0 0 M 2544 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 83 D S
-N 1029 0 M 0 83 D S
-N 2058 0 M 0 83 D S
-N 514 0 M 0 42 D S
-N 1543 0 M 0 42 D S
-N 2572 0 M 0 42 D S
+N 1018 0 M 0 83 D S
+N 2036 0 M 0 83 D S
+N 509 0 M 0 42 D S
+N 1527 0 M 0 42 D S
+N 2544 0 M 0 42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -3062 T
+0 -2991 T
 0 setlinecap
 %%EndObject
-0 -7738 TM
+0 -7809 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-2739 7738 TM
+2711 7809 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R10/15/0/5 -Bwens+gyellow -Bxaf -Byaf -Xa2.2824i -Ya6.4484i -JX15c
+%@GMT: gmt psbasemap -R10/15/0/5 -Bwens+gyellow -Bxaf -Byaf -Xa2.2593i -Ya6.5079i -JX15c
 %@PROJ: xy 10.00000000 15.00000000 0.00000000 5.00000000 10.000 15.000 0.000 5.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -784,119 +788,118 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-2739 7738 T
-67 2995 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+2711 7809 T
+0 A 67 2924 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (b\)) tl Z
 U
 }!
-/PSL_exec_completion 1 def
 {1 1 0 C} FS
--5144 0 0 3062 5144 0 3 0 0 SP
+-5089 0 0 2991 5089 0 3 0 0 SP
 25 W
 2 setlinecap
-N 0 3062 M 0 -3062 D S
+N 0 2991 M 0 -2991 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 1225 M -83 0 D S
-N 0 2450 M -83 0 D S
-N 0 612 M -42 0 D S
-N 0 1837 M -42 0 D S
-N 0 3062 M -42 0 D S
+N 0 1196 M -83 0 D S
+N 0 2392 M -83 0 D S
+N 0 598 M -42 0 D S
+N 0 1794 M -42 0 D S
+N 0 2991 M -42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-5144 0 T
+5089 0 T
 25 W
-N 0 3062 M 0 -3062 D S
+N 0 2991 M 0 -2991 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 83 0 D S
-N 0 1225 M 83 0 D S
-N 0 2450 M 83 0 D S
-N 0 612 M 42 0 D S
-N 0 1837 M 42 0 D S
-N 0 3062 M 42 0 D S
+N 0 1196 M 83 0 D S
+N 0 2392 M 83 0 D S
+N 0 598 M 42 0 D S
+N 0 1794 M 42 0 D S
+N 0 2991 M 42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--5144 0 T
+-5089 0 T
 25 W
-N 0 0 M 5144 0 D S
+N 0 0 M 5089 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 -83 D S
-N 1029 0 M 0 -83 D S
-N 2058 0 M 0 -83 D S
-N 3087 0 M 0 -83 D S
-N 4116 0 M 0 -83 D S
-N 5144 0 M 0 -83 D S
-N 206 0 M 0 -42 D S
-N 412 0 M 0 -42 D S
-N 617 0 M 0 -42 D S
-N 823 0 M 0 -42 D S
-N 1235 0 M 0 -42 D S
-N 1440 0 M 0 -42 D S
-N 1646 0 M 0 -42 D S
-N 1852 0 M 0 -42 D S
-N 2264 0 M 0 -42 D S
-N 2469 0 M 0 -42 D S
-N 2675 0 M 0 -42 D S
-N 2881 0 M 0 -42 D S
-N 3292 0 M 0 -42 D S
-N 3498 0 M 0 -42 D S
-N 3704 0 M 0 -42 D S
-N 3910 0 M 0 -42 D S
-N 4321 0 M 0 -42 D S
-N 4527 0 M 0 -42 D S
-N 4733 0 M 0 -42 D S
-N 4939 0 M 0 -42 D S
+N 1018 0 M 0 -83 D S
+N 2036 0 M 0 -83 D S
+N 3053 0 M 0 -83 D S
+N 4071 0 M 0 -83 D S
+N 5089 0 M 0 -83 D S
+N 204 0 M 0 -42 D S
+N 407 0 M 0 -42 D S
+N 611 0 M 0 -42 D S
+N 814 0 M 0 -42 D S
+N 1221 0 M 0 -42 D S
+N 1425 0 M 0 -42 D S
+N 1628 0 M 0 -42 D S
+N 1832 0 M 0 -42 D S
+N 2239 0 M 0 -42 D S
+N 2443 0 M 0 -42 D S
+N 2646 0 M 0 -42 D S
+N 2850 0 M 0 -42 D S
+N 3257 0 M 0 -42 D S
+N 3460 0 M 0 -42 D S
+N 3664 0 M 0 -42 D S
+N 3868 0 M 0 -42 D S
+N 4275 0 M 0 -42 D S
+N 4478 0 M 0 -42 D S
+N 4682 0 M 0 -42 D S
+N 4885 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 3062 T
+0 2991 T
 25 W
-N 0 0 M 5144 0 D S
+N 0 0 M 5089 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 83 D S
-N 1029 0 M 0 83 D S
-N 2058 0 M 0 83 D S
-N 3087 0 M 0 83 D S
-N 4116 0 M 0 83 D S
-N 5144 0 M 0 83 D S
-N 206 0 M 0 42 D S
-N 412 0 M 0 42 D S
-N 617 0 M 0 42 D S
-N 823 0 M 0 42 D S
-N 1235 0 M 0 42 D S
-N 1440 0 M 0 42 D S
-N 1646 0 M 0 42 D S
-N 1852 0 M 0 42 D S
-N 2264 0 M 0 42 D S
-N 2469 0 M 0 42 D S
-N 2675 0 M 0 42 D S
-N 2881 0 M 0 42 D S
-N 3292 0 M 0 42 D S
-N 3498 0 M 0 42 D S
-N 3704 0 M 0 42 D S
-N 3910 0 M 0 42 D S
-N 4321 0 M 0 42 D S
-N 4527 0 M 0 42 D S
-N 4733 0 M 0 42 D S
-N 4939 0 M 0 42 D S
+N 1018 0 M 0 83 D S
+N 2036 0 M 0 83 D S
+N 3053 0 M 0 83 D S
+N 4071 0 M 0 83 D S
+N 5089 0 M 0 83 D S
+N 204 0 M 0 42 D S
+N 407 0 M 0 42 D S
+N 611 0 M 0 42 D S
+N 814 0 M 0 42 D S
+N 1221 0 M 0 42 D S
+N 1425 0 M 0 42 D S
+N 1628 0 M 0 42 D S
+N 1832 0 M 0 42 D S
+N 2239 0 M 0 42 D S
+N 2443 0 M 0 42 D S
+N 2646 0 M 0 42 D S
+N 2850 0 M 0 42 D S
+N 3257 0 M 0 42 D S
+N 3460 0 M 0 42 D S
+N 3664 0 M 0 42 D S
+N 3868 0 M 0 42 D S
+N 4275 0 M 0 42 D S
+N 4478 0 M 0 42 D S
+N 4682 0 M 0 42 D S
+N 4885 0 M 0 42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -3062 T
+0 -2991 T
 0 setlinecap
 %%EndObject
--2739 -7738 TM
+-2711 -7809 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 1448 TM
+0 1662 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R0/5/10/15 -BWens+gcyan -Bxaf -Byaf -Xa0i -Ya1.2063i -JX15c
+%@GMT: gmt psbasemap -R0/5/10/15 -BWens+gcyan -Bxaf -Byaf -Xa0i -Ya1.3849i -JX15c
 %@PROJ: xy 0.00000000 5.00000000 10.00000000 15.00000000 0.000 5.000 10.000 15.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -904,27 +907,27 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-0 1448 T
-67 6057 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 1662 T
+0 A 67 5914 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (c\)) tl Z
 U
 }!
-/PSL_exec_completion 1 def
 {0 1 1 C} FS
--2572 0 0 6124 2572 0 3 0 0 SP
+-2544 0 0 5981 2544 0 3 0 0 SP
 25 W
 2 setlinecap
-N 0 6124 M 0 -6124 D S
+N 0 5981 M 0 -5981 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 1225 M -83 0 D S
-N 0 2450 M -83 0 D S
-N 0 3674 M -83 0 D S
-N 0 4899 M -83 0 D S
-N 0 6124 M -83 0 D S
+N 0 1196 M -83 0 D S
+N 0 2392 M -83 0 D S
+N 0 3589 M -83 0 D S
+N 0 4785 M -83 0 D S
+N 0 5981 M -83 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg exch M} def
 200 F0
@@ -938,109 +941,109 @@ def
 /PSL_A0_y PSL_A0_y 83 add def
 0 PSL_A0_y MM
 V 90 R (10) bc Z U
-1225 PSL_A0_y MM
+1196 PSL_A0_y MM
 V 90 R (11) bc Z U
-2450 PSL_A0_y MM
+2392 PSL_A0_y MM
 V 90 R (12) bc Z U
-3674 PSL_A0_y MM
+3589 PSL_A0_y MM
 V 90 R (13) bc Z U
-4899 PSL_A0_y MM
+4785 PSL_A0_y MM
 V 90 R (14) bc Z U
-6124 PSL_A0_y MM
+5981 PSL_A0_y MM
 V 90 R (15) bc Z U
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 0 245 M -42 0 D S
-N 0 490 M -42 0 D S
-N 0 735 M -42 0 D S
-N 0 980 M -42 0 D S
-N 0 1470 M -42 0 D S
-N 0 1715 M -42 0 D S
-N 0 1960 M -42 0 D S
-N 0 2205 M -42 0 D S
-N 0 2694 M -42 0 D S
-N 0 2939 M -42 0 D S
-N 0 3184 M -42 0 D S
-N 0 3429 M -42 0 D S
-N 0 3919 M -42 0 D S
-N 0 4164 M -42 0 D S
-N 0 4409 M -42 0 D S
-N 0 4654 M -42 0 D S
-N 0 5144 M -42 0 D S
-N 0 5389 M -42 0 D S
-N 0 5634 M -42 0 D S
-N 0 5879 M -42 0 D S
+N 0 239 M -42 0 D S
+N 0 478 M -42 0 D S
+N 0 718 M -42 0 D S
+N 0 957 M -42 0 D S
+N 0 1435 M -42 0 D S
+N 0 1675 M -42 0 D S
+N 0 1914 M -42 0 D S
+N 0 2153 M -42 0 D S
+N 0 2632 M -42 0 D S
+N 0 2871 M -42 0 D S
+N 0 3110 M -42 0 D S
+N 0 3349 M -42 0 D S
+N 0 3828 M -42 0 D S
+N 0 4067 M -42 0 D S
+N 0 4306 M -42 0 D S
+N 0 4545 M -42 0 D S
+N 0 5024 M -42 0 D S
+N 0 5263 M -42 0 D S
+N 0 5502 M -42 0 D S
+N 0 5742 M -42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-2572 0 T
+2544 0 T
 25 W
-N 0 6124 M 0 -6124 D S
+N 0 5981 M 0 -5981 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 83 0 D S
-N 0 1225 M 83 0 D S
-N 0 2450 M 83 0 D S
-N 0 3674 M 83 0 D S
-N 0 4899 M 83 0 D S
-N 0 6124 M 83 0 D S
-N 0 245 M 42 0 D S
-N 0 490 M 42 0 D S
-N 0 735 M 42 0 D S
-N 0 980 M 42 0 D S
-N 0 1470 M 42 0 D S
-N 0 1715 M 42 0 D S
-N 0 1960 M 42 0 D S
-N 0 2205 M 42 0 D S
-N 0 2694 M 42 0 D S
-N 0 2939 M 42 0 D S
-N 0 3184 M 42 0 D S
-N 0 3429 M 42 0 D S
-N 0 3919 M 42 0 D S
-N 0 4164 M 42 0 D S
-N 0 4409 M 42 0 D S
-N 0 4654 M 42 0 D S
-N 0 5144 M 42 0 D S
-N 0 5389 M 42 0 D S
-N 0 5634 M 42 0 D S
-N 0 5879 M 42 0 D S
+N 0 1196 M 83 0 D S
+N 0 2392 M 83 0 D S
+N 0 3589 M 83 0 D S
+N 0 4785 M 83 0 D S
+N 0 5981 M 83 0 D S
+N 0 239 M 42 0 D S
+N 0 478 M 42 0 D S
+N 0 718 M 42 0 D S
+N 0 957 M 42 0 D S
+N 0 1435 M 42 0 D S
+N 0 1675 M 42 0 D S
+N 0 1914 M 42 0 D S
+N 0 2153 M 42 0 D S
+N 0 2632 M 42 0 D S
+N 0 2871 M 42 0 D S
+N 0 3110 M 42 0 D S
+N 0 3349 M 42 0 D S
+N 0 3828 M 42 0 D S
+N 0 4067 M 42 0 D S
+N 0 4306 M 42 0 D S
+N 0 4545 M 42 0 D S
+N 0 5024 M 42 0 D S
+N 0 5263 M 42 0 D S
+N 0 5502 M 42 0 D S
+N 0 5742 M 42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--2572 0 T
+-2544 0 T
 25 W
-N 0 0 M 2572 0 D S
+N 0 0 M 2544 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 -83 D S
-N 1029 0 M 0 -83 D S
-N 2058 0 M 0 -83 D S
-N 514 0 M 0 -42 D S
-N 1543 0 M 0 -42 D S
-N 2572 0 M 0 -42 D S
+N 1018 0 M 0 -83 D S
+N 2036 0 M 0 -83 D S
+N 509 0 M 0 -42 D S
+N 1527 0 M 0 -42 D S
+N 2544 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 6124 T
+0 5981 T
 25 W
-N 0 0 M 2572 0 D S
+N 0 0 M 2544 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 83 D S
-N 1029 0 M 0 83 D S
-N 2058 0 M 0 83 D S
-N 514 0 M 0 42 D S
-N 1543 0 M 0 42 D S
-N 2572 0 M 0 42 D S
+N 1018 0 M 0 83 D S
+N 2036 0 M 0 83 D S
+N 509 0 M 0 42 D S
+N 1527 0 M 0 42 D S
+N 2544 0 M 0 42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -6124 T
+0 -5981 T
 0 setlinecap
 %%EndObject
-0 -1448 TM
+0 -1662 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-2739 1448 TM
+2711 1662 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R10/15/10/15 -Bwens+gpurple -Bxaf -Byaf -Xa2.2824i -Ya1.2063i -JX15c
+%@GMT: gmt psbasemap -R10/15/10/15 -Bwens+gpurple -Bxaf -Byaf -Xa2.2593i -Ya1.3849i -JX15c
 %@PROJ: xy 10.00000000 15.00000000 10.00000000 15.00000000 10.000 15.000 10.000 15.000 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -1048,159 +1051,158 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-2739 1448 T
-67 6057 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+2711 1662 T
+0 A 67 5914 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (d\)) tl Z
 U
 }!
-/PSL_exec_completion 1 def
 {0.627 0.125 0.941 C} FS
--5144 0 0 6124 5144 0 3 0 0 SP
+-5089 0 0 5981 5089 0 3 0 0 SP
 25 W
 2 setlinecap
-N 0 6124 M 0 -6124 D S
+N 0 5981 M 0 -5981 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 1225 M -83 0 D S
-N 0 2450 M -83 0 D S
-N 0 3674 M -83 0 D S
-N 0 4899 M -83 0 D S
-N 0 6124 M -83 0 D S
-N 0 245 M -42 0 D S
-N 0 490 M -42 0 D S
-N 0 735 M -42 0 D S
-N 0 980 M -42 0 D S
-N 0 1470 M -42 0 D S
-N 0 1715 M -42 0 D S
-N 0 1960 M -42 0 D S
-N 0 2205 M -42 0 D S
-N 0 2694 M -42 0 D S
-N 0 2939 M -42 0 D S
-N 0 3184 M -42 0 D S
-N 0 3429 M -42 0 D S
-N 0 3919 M -42 0 D S
-N 0 4164 M -42 0 D S
-N 0 4409 M -42 0 D S
-N 0 4654 M -42 0 D S
-N 0 5144 M -42 0 D S
-N 0 5389 M -42 0 D S
-N 0 5634 M -42 0 D S
-N 0 5879 M -42 0 D S
+N 0 1196 M -83 0 D S
+N 0 2392 M -83 0 D S
+N 0 3589 M -83 0 D S
+N 0 4785 M -83 0 D S
+N 0 5981 M -83 0 D S
+N 0 239 M -42 0 D S
+N 0 478 M -42 0 D S
+N 0 718 M -42 0 D S
+N 0 957 M -42 0 D S
+N 0 1435 M -42 0 D S
+N 0 1675 M -42 0 D S
+N 0 1914 M -42 0 D S
+N 0 2153 M -42 0 D S
+N 0 2632 M -42 0 D S
+N 0 2871 M -42 0 D S
+N 0 3110 M -42 0 D S
+N 0 3349 M -42 0 D S
+N 0 3828 M -42 0 D S
+N 0 4067 M -42 0 D S
+N 0 4306 M -42 0 D S
+N 0 4545 M -42 0 D S
+N 0 5024 M -42 0 D S
+N 0 5263 M -42 0 D S
+N 0 5502 M -42 0 D S
+N 0 5742 M -42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-5144 0 T
+5089 0 T
 25 W
-N 0 6124 M 0 -6124 D S
+N 0 5981 M 0 -5981 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 83 0 D S
-N 0 1225 M 83 0 D S
-N 0 2450 M 83 0 D S
-N 0 3674 M 83 0 D S
-N 0 4899 M 83 0 D S
-N 0 6124 M 83 0 D S
-N 0 245 M 42 0 D S
-N 0 490 M 42 0 D S
-N 0 735 M 42 0 D S
-N 0 980 M 42 0 D S
-N 0 1470 M 42 0 D S
-N 0 1715 M 42 0 D S
-N 0 1960 M 42 0 D S
-N 0 2205 M 42 0 D S
-N 0 2694 M 42 0 D S
-N 0 2939 M 42 0 D S
-N 0 3184 M 42 0 D S
-N 0 3429 M 42 0 D S
-N 0 3919 M 42 0 D S
-N 0 4164 M 42 0 D S
-N 0 4409 M 42 0 D S
-N 0 4654 M 42 0 D S
-N 0 5144 M 42 0 D S
-N 0 5389 M 42 0 D S
-N 0 5634 M 42 0 D S
-N 0 5879 M 42 0 D S
+N 0 1196 M 83 0 D S
+N 0 2392 M 83 0 D S
+N 0 3589 M 83 0 D S
+N 0 4785 M 83 0 D S
+N 0 5981 M 83 0 D S
+N 0 239 M 42 0 D S
+N 0 478 M 42 0 D S
+N 0 718 M 42 0 D S
+N 0 957 M 42 0 D S
+N 0 1435 M 42 0 D S
+N 0 1675 M 42 0 D S
+N 0 1914 M 42 0 D S
+N 0 2153 M 42 0 D S
+N 0 2632 M 42 0 D S
+N 0 2871 M 42 0 D S
+N 0 3110 M 42 0 D S
+N 0 3349 M 42 0 D S
+N 0 3828 M 42 0 D S
+N 0 4067 M 42 0 D S
+N 0 4306 M 42 0 D S
+N 0 4545 M 42 0 D S
+N 0 5024 M 42 0 D S
+N 0 5263 M 42 0 D S
+N 0 5502 M 42 0 D S
+N 0 5742 M 42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--5144 0 T
+-5089 0 T
 25 W
-N 0 0 M 5144 0 D S
+N 0 0 M 5089 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 -83 D S
-N 1029 0 M 0 -83 D S
-N 2058 0 M 0 -83 D S
-N 3087 0 M 0 -83 D S
-N 4116 0 M 0 -83 D S
-N 5144 0 M 0 -83 D S
-N 206 0 M 0 -42 D S
-N 412 0 M 0 -42 D S
-N 617 0 M 0 -42 D S
-N 823 0 M 0 -42 D S
-N 1235 0 M 0 -42 D S
-N 1440 0 M 0 -42 D S
-N 1646 0 M 0 -42 D S
-N 1852 0 M 0 -42 D S
-N 2264 0 M 0 -42 D S
-N 2469 0 M 0 -42 D S
-N 2675 0 M 0 -42 D S
-N 2881 0 M 0 -42 D S
-N 3292 0 M 0 -42 D S
-N 3498 0 M 0 -42 D S
-N 3704 0 M 0 -42 D S
-N 3910 0 M 0 -42 D S
-N 4321 0 M 0 -42 D S
-N 4527 0 M 0 -42 D S
-N 4733 0 M 0 -42 D S
-N 4939 0 M 0 -42 D S
+N 1018 0 M 0 -83 D S
+N 2036 0 M 0 -83 D S
+N 3053 0 M 0 -83 D S
+N 4071 0 M 0 -83 D S
+N 5089 0 M 0 -83 D S
+N 204 0 M 0 -42 D S
+N 407 0 M 0 -42 D S
+N 611 0 M 0 -42 D S
+N 814 0 M 0 -42 D S
+N 1221 0 M 0 -42 D S
+N 1425 0 M 0 -42 D S
+N 1628 0 M 0 -42 D S
+N 1832 0 M 0 -42 D S
+N 2239 0 M 0 -42 D S
+N 2443 0 M 0 -42 D S
+N 2646 0 M 0 -42 D S
+N 2850 0 M 0 -42 D S
+N 3257 0 M 0 -42 D S
+N 3460 0 M 0 -42 D S
+N 3664 0 M 0 -42 D S
+N 3868 0 M 0 -42 D S
+N 4275 0 M 0 -42 D S
+N 4478 0 M 0 -42 D S
+N 4682 0 M 0 -42 D S
+N 4885 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 6124 T
+0 5981 T
 25 W
-N 0 0 M 5144 0 D S
+N 0 0 M 5089 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 83 D S
-N 1029 0 M 0 83 D S
-N 2058 0 M 0 83 D S
-N 3087 0 M 0 83 D S
-N 4116 0 M 0 83 D S
-N 5144 0 M 0 83 D S
-N 206 0 M 0 42 D S
-N 412 0 M 0 42 D S
-N 617 0 M 0 42 D S
-N 823 0 M 0 42 D S
-N 1235 0 M 0 42 D S
-N 1440 0 M 0 42 D S
-N 1646 0 M 0 42 D S
-N 1852 0 M 0 42 D S
-N 2264 0 M 0 42 D S
-N 2469 0 M 0 42 D S
-N 2675 0 M 0 42 D S
-N 2881 0 M 0 42 D S
-N 3292 0 M 0 42 D S
-N 3498 0 M 0 42 D S
-N 3704 0 M 0 42 D S
-N 3910 0 M 0 42 D S
-N 4321 0 M 0 42 D S
-N 4527 0 M 0 42 D S
-N 4733 0 M 0 42 D S
-N 4939 0 M 0 42 D S
+N 1018 0 M 0 83 D S
+N 2036 0 M 0 83 D S
+N 3053 0 M 0 83 D S
+N 4071 0 M 0 83 D S
+N 5089 0 M 0 83 D S
+N 204 0 M 0 42 D S
+N 407 0 M 0 42 D S
+N 611 0 M 0 42 D S
+N 814 0 M 0 42 D S
+N 1221 0 M 0 42 D S
+N 1425 0 M 0 42 D S
+N 1628 0 M 0 42 D S
+N 1832 0 M 0 42 D S
+N 2239 0 M 0 42 D S
+N 2443 0 M 0 42 D S
+N 2646 0 M 0 42 D S
+N 2850 0 M 0 42 D S
+N 3257 0 M 0 42 D S
+N 3460 0 M 0 42 D S
+N 3664 0 M 0 42 D S
+N 3868 0 M 0 42 D S
+N 4275 0 M 0 42 D S
+N 4478 0 M 0 42 D S
+N 4682 0 M 0 42 D S
+N 4885 0 M 0 42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -6124 T
+0 -5981 T
 0 setlinecap
 %%EndObject
--2739 -1448 TM
+-2711 -1662 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 -250 TM
+0 0 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R0/5/10/15 -BWenS+glightgray -Bxaf -Byaf -Xa0i -Ya-0.2083i -JX15c
+%@GMT: gmt psbasemap -R0/5/10/15 -BWenS+glightgray -Bxaf -Byaf -Xa0i -Ya0i -JX15c
 %@PROJ: xy 0.00000000 5.00000000 10.00000000 15.00000000 0.000 5.000 10.000 15.000 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
@@ -1208,24 +1210,23 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-0 -250 T
-67 1464 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 A 67 1429 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (e\)) tl Z
 U
 }!
-/PSL_exec_completion 1 def
 {0.827 A} FS
--2572 0 0 1531 2572 0 3 0 0 SP
+-2544 0 0 1495 2544 0 3 0 0 SP
 25 W
 2 setlinecap
-N 0 1531 M 0 -1531 D S
+N 0 1495 M 0 -1495 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 612 M -83 0 D S
-N 0 1225 M -83 0 D S
+N 0 598 M -83 0 D S
+N 0 1196 M -83 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg exch M} def
 200 F0
@@ -1236,37 +1237,37 @@ def
 /PSL_A0_y PSL_A0_y 83 add def
 0 PSL_A0_y MM
 V 90 R (10) bc Z U
-612 PSL_A0_y MM
+598 PSL_A0_y MM
 V 90 R (12) bc Z U
-1225 PSL_A0_y MM
+1196 PSL_A0_y MM
 V 90 R (14) bc Z U
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 0 306 M -42 0 D S
-N 0 919 M -42 0 D S
-N 0 1531 M -42 0 D S
+N 0 299 M -42 0 D S
+N 0 897 M -42 0 D S
+N 0 1495 M -42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-2572 0 T
+2544 0 T
 25 W
-N 0 1531 M 0 -1531 D S
+N 0 1495 M 0 -1495 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 83 0 D S
-N 0 612 M 83 0 D S
-N 0 1225 M 83 0 D S
-N 0 306 M 42 0 D S
-N 0 919 M 42 0 D S
-N 0 1531 M 42 0 D S
+N 0 598 M 83 0 D S
+N 0 1196 M 83 0 D S
+N 0 299 M 42 0 D S
+N 0 897 M 42 0 D S
+N 0 1495 M 42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--2572 0 T
+-2544 0 T
 25 W
-N 0 0 M 2572 0 D S
+N 0 0 M 2544 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 -83 D S
-N 1029 0 M 0 -83 D S
-N 2058 0 M 0 -83 D S
+N 1018 0 M 0 -83 D S
+N 2036 0 M 0 -83 D S
 /PSL_AH0 0
 /MM {neg M} def
 (0) sh mx
@@ -1276,39 +1277,39 @@ def
 /PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
 0 PSL_A0_y MM
 (0) bc Z
-1029 PSL_A0_y MM
+1018 PSL_A0_y MM
 (2) bc Z
-2058 PSL_A0_y MM
+2036 PSL_A0_y MM
 (4) bc Z
-N 514 0 M 0 -42 D S
-N 1543 0 M 0 -42 D S
-N 2572 0 M 0 -42 D S
+N 509 0 M 0 -42 D S
+N 1527 0 M 0 -42 D S
+N 2544 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 1531 T
+0 1495 T
 25 W
-N 0 0 M 2572 0 D S
+N 0 0 M 2544 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 83 D S
-N 1029 0 M 0 83 D S
-N 2058 0 M 0 83 D S
-N 514 0 M 0 42 D S
-N 1543 0 M 0 42 D S
-N 2572 0 M 0 42 D S
+N 1018 0 M 0 83 D S
+N 2036 0 M 0 83 D S
+N 509 0 M 0 42 D S
+N 1527 0 M 0 42 D S
+N 2544 0 M 0 42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -1531 T
+0 -1495 T
 0 setlinecap
 %%EndObject
-0 250 TM
+0 0 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-2739 -250 TM
+2711 0 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R10/15/10/15 -BwenS+gorange -Bxaf -Byaf -Xa2.2824i -Ya-0.2083i -JX15c
+%@GMT: gmt psbasemap -R10/15/10/15 -BwenS+gorange -Bxaf -Byaf -Xa2.2593i -Ya0i -JX15c
 %@PROJ: xy 10.00000000 15.00000000 10.00000000 15.00000000 10.000 15.000 10.000 15.000 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
@@ -1316,53 +1317,53 @@ O0
 3.32551 setmiterlimit
 /PSL_completion {
 V
-2739 -250 T
-67 1464 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+2711 0 T
+0 A 67 1429 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (f\)) tl Z
 U
 }!
-/PSL_exec_completion 1 def
 {1 0.647 0 C} FS
--5144 0 0 1531 5144 0 3 0 0 SP
+-5089 0 0 1495 5089 0 3 0 0 SP
 25 W
 2 setlinecap
-N 0 1531 M 0 -1531 D S
+N 0 1495 M 0 -1495 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 612 M -83 0 D S
-N 0 1225 M -83 0 D S
-N 0 306 M -42 0 D S
-N 0 919 M -42 0 D S
-N 0 1531 M -42 0 D S
+N 0 598 M -83 0 D S
+N 0 1196 M -83 0 D S
+N 0 299 M -42 0 D S
+N 0 897 M -42 0 D S
+N 0 1495 M -42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-5144 0 T
+5089 0 T
 25 W
-N 0 1531 M 0 -1531 D S
+N 0 1495 M 0 -1495 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 83 0 D S
-N 0 612 M 83 0 D S
-N 0 1225 M 83 0 D S
-N 0 306 M 42 0 D S
-N 0 919 M 42 0 D S
-N 0 1531 M 42 0 D S
+N 0 598 M 83 0 D S
+N 0 1196 M 83 0 D S
+N 0 299 M 42 0 D S
+N 0 897 M 42 0 D S
+N 0 1495 M 42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--5144 0 T
+-5089 0 T
 25 W
-N 0 0 M 5144 0 D S
+N 0 0 M 5089 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 -83 D S
-N 1029 0 M 0 -83 D S
-N 2058 0 M 0 -83 D S
-N 3087 0 M 0 -83 D S
-N 4116 0 M 0 -83 D S
-N 5144 0 M 0 -83 D S
+N 1018 0 M 0 -83 D S
+N 2036 0 M 0 -83 D S
+N 3053 0 M 0 -83 D S
+N 4071 0 M 0 -83 D S
+N 5089 0 M 0 -83 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg M} def
 200 F0
@@ -1376,75 +1377,79 @@ def
 /PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
 0 PSL_A0_y MM
 (10) bc Z
-1029 PSL_A0_y MM
+1018 PSL_A0_y MM
 (11) bc Z
-2058 PSL_A0_y MM
+2036 PSL_A0_y MM
 (12) bc Z
-3087 PSL_A0_y MM
+3053 PSL_A0_y MM
 (13) bc Z
-4116 PSL_A0_y MM
+4071 PSL_A0_y MM
 (14) bc Z
-5144 PSL_A0_y MM
+5089 PSL_A0_y MM
 (15) bc Z
-N 206 0 M 0 -42 D S
-N 412 0 M 0 -42 D S
-N 617 0 M 0 -42 D S
-N 823 0 M 0 -42 D S
-N 1235 0 M 0 -42 D S
-N 1440 0 M 0 -42 D S
-N 1646 0 M 0 -42 D S
-N 1852 0 M 0 -42 D S
-N 2264 0 M 0 -42 D S
-N 2469 0 M 0 -42 D S
-N 2675 0 M 0 -42 D S
-N 2881 0 M 0 -42 D S
-N 3292 0 M 0 -42 D S
-N 3498 0 M 0 -42 D S
-N 3704 0 M 0 -42 D S
-N 3910 0 M 0 -42 D S
-N 4321 0 M 0 -42 D S
-N 4527 0 M 0 -42 D S
-N 4733 0 M 0 -42 D S
-N 4939 0 M 0 -42 D S
+N 204 0 M 0 -42 D S
+N 407 0 M 0 -42 D S
+N 611 0 M 0 -42 D S
+N 814 0 M 0 -42 D S
+N 1221 0 M 0 -42 D S
+N 1425 0 M 0 -42 D S
+N 1628 0 M 0 -42 D S
+N 1832 0 M 0 -42 D S
+N 2239 0 M 0 -42 D S
+N 2443 0 M 0 -42 D S
+N 2646 0 M 0 -42 D S
+N 2850 0 M 0 -42 D S
+N 3257 0 M 0 -42 D S
+N 3460 0 M 0 -42 D S
+N 3664 0 M 0 -42 D S
+N 3868 0 M 0 -42 D S
+N 4275 0 M 0 -42 D S
+N 4478 0 M 0 -42 D S
+N 4682 0 M 0 -42 D S
+N 4885 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 1531 T
+0 1495 T
 25 W
-N 0 0 M 5144 0 D S
+N 0 0 M 5089 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 83 D S
-N 1029 0 M 0 83 D S
-N 2058 0 M 0 83 D S
-N 3087 0 M 0 83 D S
-N 4116 0 M 0 83 D S
-N 5144 0 M 0 83 D S
-N 206 0 M 0 42 D S
-N 412 0 M 0 42 D S
-N 617 0 M 0 42 D S
-N 823 0 M 0 42 D S
-N 1235 0 M 0 42 D S
-N 1440 0 M 0 42 D S
-N 1646 0 M 0 42 D S
-N 1852 0 M 0 42 D S
-N 2264 0 M 0 42 D S
-N 2469 0 M 0 42 D S
-N 2675 0 M 0 42 D S
-N 2881 0 M 0 42 D S
-N 3292 0 M 0 42 D S
-N 3498 0 M 0 42 D S
-N 3704 0 M 0 42 D S
-N 3910 0 M 0 42 D S
-N 4321 0 M 0 42 D S
-N 4527 0 M 0 42 D S
-N 4733 0 M 0 42 D S
-N 4939 0 M 0 42 D S
+N 1018 0 M 0 83 D S
+N 2036 0 M 0 83 D S
+N 3053 0 M 0 83 D S
+N 4071 0 M 0 83 D S
+N 5089 0 M 0 83 D S
+N 204 0 M 0 42 D S
+N 407 0 M 0 42 D S
+N 611 0 M 0 42 D S
+N 814 0 M 0 42 D S
+N 1221 0 M 0 42 D S
+N 1425 0 M 0 42 D S
+N 1628 0 M 0 42 D S
+N 1832 0 M 0 42 D S
+N 2239 0 M 0 42 D S
+N 2443 0 M 0 42 D S
+N 2646 0 M 0 42 D S
+N 2850 0 M 0 42 D S
+N 3257 0 M 0 42 D S
+N 3460 0 M 0 42 D S
+N 3664 0 M 0 42 D S
+N 3868 0 M 0 42 D S
+N 4275 0 M 0 42 D S
+N 4478 0 M 0 42 D S
+N 4682 0 M 0 42 D S
+N 4885 0 M 0 42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -1531 T
+0 -1495 T
 0 setlinecap
 %%EndObject
--2739 250 TM
+-2711 0 TM
 PSL_completion /PSL_completion {} def
+
+grestore
+PSL_movie_completion /PSL_movie_completion {} def
+%PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage


### PR DESCRIPTION
The calculation to determine how much space to add between interior subplots was incorrect.  Ticks are always added unless any **-Bblrt** settings override it.  This PR fixes this calculation which means most of the PostScript originals changed as well due to a change in positioning.
There is still some more work to do to prevent the situation in #1320 where -S is not used.

