### PR TITLE
Set subplot frame -R -J as the current history when subplot ends

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12423,7 +12423,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 		unsigned int E_flags;
 		E_flags = strip_R_from_E_in_pscoast (GMT, *options, r_code);
 		if (GMT->current.setting.run_mode == GMT_MODERN && !(E_flags & 1)) {	/* Just country codes and plot settings, no region specs */
-			int id = gmtlib_get_option_id (0, "R");		/* The -RP history item */
+			int id = gmt_get_option_id (0, "R");		/* The -RP history item */
 			if (!GMT->init.history[id]) id++;		/* No history for -RP, increment to -RG as fallback */
 			if (GMT->init.history[id]) add_R = false;	/* There is history for -R so -R will be added below */
 		}
@@ -12700,7 +12700,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 
 		if (got_R == false && (strchr (required, 'R') || strchr (required, 'g') || strchr (required, 'd'))) {	/* Need a region but no -R was set */
 			/* First consult the history */
-			id = gmtlib_get_option_id (0, "R");	/* The -RP history item */
+			id = gmt_get_option_id (0, "R");	/* The -RP history item */
 			if (GMT->current.ps.active || !strncmp (mod_name, "pscoast", 7U)) {	/* A plotting module (or pscoast which may run -M); first check -RP history */
 				if (!GMT->init.history[id]) id++;	/* No history for -RP, increment to -RG as fallback */
 			}
@@ -12717,12 +12717,12 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 			}
 		}
 		if (got_J == false && strchr (required, 'J')) {	/* Need a projection but no -J was set */
-			if ((id = gmtlib_get_option_id (0, "J")) >= 0 && GMT->init.history[id]) {	/* There is history for -J */
+			if ((id = gmt_get_option_id (0, "J")) >= 0 && GMT->init.history[id]) {	/* There is history for -J */
 				/* Must now search for actual option since -J only has the code (e.g., -JM) */
 				/* Continue looking for -J<code> */
 				char str[3] = {"J"};
 				str[1] = GMT->init.history[id][0];
-				if ((id = gmtlib_get_option_id (id + 1, str)) >= 0 && GMT->init.history[id]) {	/* There is history for this -J */
+				if ((id = gmt_get_option_id (id + 1, str)) >= 0 && GMT->init.history[id]) {	/* There is history for this -J */
 					if ((opt = GMT_Make_Option (API, 'J', "")) == NULL) return NULL;	/* Failure to make option */
 					if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
 					GMT_Report (API, GMT_MSG_DEBUG, "Modern: Adding -J to options since there is history available.\n");
@@ -12848,7 +12848,7 @@ void gmt_end_module (struct GMT_CTRL *GMT, struct GMT_CTRL *Ccopy) {
 	if (GMT->current.setting.run_mode == GMT_MODERN && !GMT->current.ps.active && GMT->common.R.active[RSET]) {	/* Modern mode: Add enhanced RG history, if possible */
 		/* For grid regions we add history under RG in the form <region>[+I<incs>][+GP|G] */
 		char RG[GMT_LEN256] = {""}, tmp[GMT_LEN64] = {""};
-		int id = gmtlib_get_option_id (0, "R") + 1;	/* The RG history slot */
+		int id = gmt_get_option_id (0, "R") + 1;	/* The RG history slot */
 		if (GMT->init.history[id]) gmt_M_str_free (GMT->init.history[id]);
 		sprintf (RG, "%.16g/%.16g/%.16g/%.16g", GMT->common.R.wesn[XLO], GMT->common.R.wesn[XHI], GMT->common.R.wesn[YLO], GMT->common.R.wesn[YHI]);
 		if (GMT->common.R.active[ISET]) {	/* Also want grid increment saved */
@@ -14808,7 +14808,7 @@ int gmt_init_time_system_structure (struct GMT_CTRL *GMT, struct GMT_TIME_SYSTEM
 	return (error);
 }
 
-int gmtlib_get_option_id (int start, char *this_option) {
+int gmt_get_option_id (int start, char *this_option) {
 	/* Search the GMT_unique_option list starting at given position for this_option */
 	int k, id = -1;
 	for (k = start; k < GMT_N_UNIQUE && id == -1; k++)
@@ -14840,13 +14840,13 @@ int gmt_set_missing_options (struct GMT_CTRL *GMT, char *options) {
 		/* Must dig around in the history array */
 		gmt_M_memset (str, 3, char);
 		str[0] = options[j];
-		if ((id = gmtlib_get_option_id (0, str)) == -1) continue;	/* Not an option we have history for yet */
+		if ((id = gmt_get_option_id (0, str)) == -1) continue;	/* Not an option we have history for yet */
 		if (options[j] == 'R' && !GMT->current.ps.active) id++;		/* Examine -RG history if not a plotter */
 		if (GMT->init.history[id] == NULL) continue;	/* No history for this option */
 		if (options[j] == 'J') {	/* Must now search for actual option since -J only has the code (e.g., -JM) */
 			/* Continue looking for -J<code> */
 			str[1] = GMT->init.history[id][0];
-			if ((id = gmtlib_get_option_id (id + 1, str)) == -1) continue;	/* Not an option we have history for yet */
+			if ((id = gmt_get_option_id (id + 1, str)) == -1) continue;	/* Not an option we have history for yet */
 			if (GMT->init.history[id] == NULL) continue;	/* No history for this option */
 		}
 		/* Here we should have a parsable command option */

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -229,7 +229,6 @@ EXTERN_MSC void gmtlib_contract_headerpad (struct GMT_CTRL *GMT, struct GMT_GRID
 EXTERN_MSC void gmtlib_contract_pad (struct GMT_CTRL *GMT, void *object, int family, unsigned int *orig_pad, double *orig_wesn);
 EXTERN_MSC uint64_t gmtlib_glob_list (struct GMT_CTRL *GMT, const char *pattern, char ***list);
 EXTERN_MSC void gmtlib_change_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET *D);
-EXTERN_MSC int gmtlib_get_option_id (int start, char *this_option);
 
 #ifdef HAVE_GDAL
 EXTERN_MSC int gmtlib_read_image (struct GMT_CTRL *GMT, char *file, struct GMT_IMAGE *I, double *wesn,

--- a/src/gmt_parse.c
+++ b/src/gmt_parse.c
@@ -304,7 +304,7 @@ GMT_LOCAL int parse_complete_options (struct GMT_CTRL *GMT, struct GMT_OPTION *o
 		if (opt->option == 'J') {               /* -J is special since it can be -J or -J<code> */
 
 			/* Always look up "J" first. It comes before "J?" and tells what the last -J was */
-			if ((id = gmtlib_get_option_id (0, str)) == GMT_NOTSET) Return;	/* No -J found at all - nothing more to do */
+			if ((id = gmt_get_option_id (0, str)) == GMT_NOTSET) Return;	/* No -J found at all - nothing more to do */
 			if (opt->arg && opt->arg[0]) {      /* Gave -J<code>[<args>] so we either use or update history and continue */
 				str[1] = opt->arg[0];
 				/* Remember this last -J<code> for later use as -J, but do not remember it when -Jz|Z */
@@ -319,7 +319,7 @@ GMT_LOCAL int parse_complete_options (struct GMT_CTRL *GMT, struct GMT_OPTION *o
 				str[1] = GMT->init.history[id][0];
 			}
 			/* Continue looking for -J<code> */
-			if ((id = gmtlib_get_option_id (id + 1, str)) == GMT_NOTSET) Return;	/* No -J<code> found */
+			if ((id = gmt_get_option_id (id + 1, str)) == GMT_NOTSET) Return;	/* No -J<code> found */
 			update_id = id;
 		}
 		else if (opt->option == 'B') {          /* -B is also special since there may be many of these, or just -B */
@@ -345,7 +345,7 @@ GMT_LOCAL int parse_complete_options (struct GMT_CTRL *GMT, struct GMT_OPTION *o
 			}
 		}
 		else {	/* Gave -R[<args>], -V[<args>] etc., so we either use or update the history and continue */
-			update_id = id = gmtlib_get_option_id (0, str);	/* If -R then we get id for RP */
+			update_id = id = gmt_get_option_id (0, str);	/* If -R then we get id for RP */
 			if (id == GMT_NOTSET) Return;	/* Error: user gave shorthand option but there is no record in the history */
 			if (GMT->current.setting.run_mode == GMT_MODERN && opt->option == 'R') {	/* Must deal with both RP and RG under modern mode */
 				if (GMT->current.ps.active || !strncmp (GMT->init.module_name, "pscoast", 7U)) {	/* Plotting module: First check RP if it exists */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -41,6 +41,7 @@ EXTERN_MSC char *gmt_strdup (struct GMT_CTRL *GMT, const char *s);
 
 /* gmt_init.c: */
 
+EXTERN_MSC int gmt_get_option_id (int start, char *this_option);
 EXTERN_MSC bool gmt_is_integer (char *L);
 EXTERN_MSC int gmt_get_next_panel (struct GMTAPI_CTRL *API, int fig, int *row, int *col);
 EXTERN_MSC int gmt_report_usage (struct GMTAPI_CTRL *API, struct GMT_OPTION *options, unsigned int special, int (*usage)(struct GMTAPI_CTRL *, int));

--- a/src/img/img2grd.c
+++ b/src/img/img2grd.c
@@ -56,8 +56,6 @@
 #include "gmt_dev.h"
 #include "common_byteswap.h"
 
-EXTERN_MSC int gmtlib_get_option_id (int start, char *this_option);
-
 #define THIS_MODULE_NAME	"img2grd"
 #define THIS_MODULE_LIB		"img"
 #define THIS_MODULE_PURPOSE	"Extract a subset from an img file in Mercator or Geographic format"
@@ -746,7 +744,7 @@ int GMT_img2grd (void *V_API, int mode, void *args) {
 		 * south and north boundaries in the specified -R setting.  Because this is only an issue in this program we replace
 		 * the given -R with the exact -R in the gmt.history file so that any subsequent module call using -R shorthand will
 		 * get the actual (exect) region and not the requested (initial, approximate) region. */
-		int id = gmtlib_get_option_id (0, "R");			/* The -R[P] item in the history array */
+		int id = gmt_get_option_id (0, "R");			/* The -R[P] item in the history array */
 		if (GMT->current.setting.run_mode == GMT_MODERN) id++;	/* Instead pick the -RG item under modern mode since this is not a plotting tool */
 		gmt_M_str_free (GMT->init.history[id]);			/* Free the previous history string set during parsing */
 		GMT->init.history[id] = strdup (exact_R);		/* Replace it with the exact region */

--- a/src/inset.c
+++ b/src/inset.c
@@ -197,8 +197,6 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct INSET_CTRL *Ctrl, struct GMT_O
 #define bailout(code) {gmt_M_free_options (mode); return (code);}
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
-EXTERN_MSC int gmtlib_get_option_id (int start, char *this_option);
-
 int GMT_inset (void *V_API, int mode, void *args) {
 	int error = 0, fig, k;
 	bool exist;
@@ -302,7 +300,7 @@ int GMT_inset (void *V_API, int mode, void *args) {
 		}
 		/* For now, skip the first 5 comments and get the 6th record which holds the REGION line */
 		for (k = 0; k < 6; k++) gmt_fgets (GMT, line, GMT_LEN128, fp);
-		id = gmtlib_get_option_id (0, "R");	/* Get index for the -RP history item */
+		id = gmt_get_option_id (0, "R");	/* Get index for the -RP history item */
 		if (!GMT->init.history[id]) id++;	/* No history for -RP, increment to -RG as fallback */
 		if (GMT->init.history[id]) gmt_M_str_free (GMT->init.history[id]);	/* Free what it was */
 		gmt_chop (line);
@@ -310,13 +308,13 @@ int GMT_inset (void *V_API, int mode, void *args) {
 		gmt_fgets (GMT, line, GMT_LEN128, fp);		/* Read the PROJ line */
 		fclose (fp);
 		gmt_chop (line);
-		j_id = gmtlib_get_option_id (0, "J");	/* Get the -J index */
+		j_id = gmt_get_option_id (0, "J");	/* Get the -J index */
 		if (GMT->init.history[j_id])	/* There is prior history for this -J (it should be) */
 			gmt_M_str_free (GMT->init.history[j_id]);	/* Remove it */
 		/* Must now search for actual option since -J only has the code (e.g., -JM) */
 		/* Continue looking for -J<code> */
 		str[1] = line[8];	/* This is the -J code */
-		id = gmtlib_get_option_id (j_id + 1, str);	/* Get the actual -J? code id */
+		id = gmt_get_option_id (j_id + 1, str);	/* Get the actual -J? code id */
 		if (GMT->init.history[id])	/* There is prior history for this -J (it should be) */
 			gmt_M_str_free (GMT->init.history[id]);	/* Remove it */
 		GMT->init.history[id] = strdup (&line[8]);	/* Insert the original code */

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -64,8 +64,6 @@
 
 #define NOT_REALLY_AN_ERROR -999
 
-EXTERN_MSC int gmtlib_get_option_id (int start, char *this_option);
-
 /* Control structure for pscoast */
 
 struct PSCOAST_CTRL {

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -846,8 +846,6 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT
 #define bailout(code) {gmt_M_free_options (mode); return (code);}
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
-EXTERN_MSC int gmtlib_get_option_id (int start, char *this_option);
-
 int GMT_coupe (void *V_API, int mode, void *args) {
 	/* This is the GMT6 modern mode name */
 	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);	/* Cast from void to GMTAPI_CTRL pointer */
@@ -1216,7 +1214,7 @@ Definition of scalar moment.
 
 	if (GMT->current.setting.run_mode == GMT_MODERN) {	/* Deal with the fact that -R was set implicitly via -A */
 		char r_code[GMT_LEN256] = {""};
-		int id = gmtlib_get_option_id (0, "R");		/* The -RP history item */
+		int id = gmt_get_option_id (0, "R");		/* The -RP history item */
 		if (GMT->init.history[id]) gmt_M_str_free (GMT->init.history[id]);	/*  Free previous -R */
 		sprintf (r_code, "%.16g/%.16g/%.16g/%.16g", GMT->common.R.wesn[XLO], GMT->common.R.wesn[XHI], GMT->common.R.wesn[YLO], GMT->common.R.wesn[YHI]);
 		GMT->init.history[id] = strdup (r_code);

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -1114,8 +1114,8 @@ int GMT_subplot (void *V_API, int mode, void *args) {
 			Return (error)
 	}
 	else {	/* SUBPLOT_END */
-		int k;
-		char *wmode[2] = {"w","a"}, vfile[GMT_STR16] = {""};
+		int k, id;
+		char *wmode[2] = {"w","a"}, vfile[GMT_STR16] = {""}, Rtxt[GMT_LEN64] = {""};
 		FILE *fp = NULL;
 		struct GMT_SUBPLOT *P = NULL;
 		
@@ -1168,6 +1168,21 @@ int GMT_subplot (void *V_API, int mode, void *args) {
 			gmt_remove_file (GMT, file);
 		}
 		GMT_Report (API, GMT_MSG_DEBUG, "Subplot: Removed panel and subplot files\n");
+		
+		/* Set -R and J to match subplot frame so later calls, e.g., colorbar, can use -DJ */
+		/* First set R (i.e., RP for plotting) */
+		id = gmt_get_option_id (0, "R");		/* The -RP history item */
+		if (GMT->init.history[id]) gmt_M_str_free (GMT->init.history[id]);	/* Remove what this was */
+		sprintf (Rtxt, "0/%.16g/0/%.16g", P->dim[GMT_X], P->dim[GMT_Y]);
+		GMT->init.history[id] = strdup (Rtxt);
+		/* Now set -Jx1i */
+		id = gmt_get_option_id (0, "J");	/* Top level -J history */
+		if (GMT->init.history[id]) gmt_M_str_free (GMT->init.history[id]);	/* Remove what this was */
+		GMT->init.history[id] = strdup ("x");	/* Just the flavor */
+		id = gmt_get_option_id (id, "Jx");	/* Find Jx history, if any */
+		if (GMT->init.history[id]) gmt_M_str_free (GMT->init.history[id]);	/* Remove what this was */
+		GMT->init.history[id] = strdup ("x1i");
+		
 		gmt_M_memset (&GMT->current.plot.panel, 1, struct GMT_SUBPLOT);	/* Wipe that smile off your face */
 	}
 		


### PR DESCRIPTION
That way, subsequent commands, especially _colorbar_, and _legend_, can use **-DJ** without having to specify a **-R -J** combination that covers the completed figure (which we may not know if **-Fs** was used) to place items around that frame.

The change is really just in subplot for the **END** case but I needed to promote an internal gmtlib function to the next level since it is being used in too many modules to not be defined in gmt_prototypes.h.
