### PR TITLE
Descrive the hierarchy of current CPTs in moderm mode

### DIFF
--- a/doc/rst/source/explain_cpt.rst_
+++ b/doc/rst/source/explain_cpt.rst_
@@ -1,0 +1,27 @@
+Note on CPTs in Modern Mode
+---------------------------
+
+In modern mode, CPTs are rarely needed to be named explicitly.  Instead, when
+a module that may create a CPT, such as :doc:`grd2cpt` and :doc:`makecpt` (or even
+:doc:`grdimage` when no color table is available), the behavior under modern mode
+is to write that CPT to a hidden file in the session directory.  When a module
+requires a CPT (e.g., **grdimage** not given **-C** or **plot** given **-C** with no name)
+then we read this hidden CPT (if it exists).  This file is called the *current* CPT.
+In fact, there are several levels of current CPTs that may all be different, and
+some may not be present.  If you create a CPT within an **inset** operation then
+that CPT is only accessible during the inset plotting; it thus only has the inset
+as its *scope*.  If you create a CPT while positioned into a specific subplot, then
+that CPT is likewise only accessible to that subplot.  If, on the other hand, you
+make a CPT after **subplot begin** but before any plotting then that CPT is
+available to all the subplots (but can be locally overridden by a subplot-specific
+CPT mention above).  Finally, each call to **figure** means you may have a figure-specific
+CPT, should you create them.  If none exists then the session CPT is used.  The
+rule gmt follows is to always get the CPT with the most restricted scope that is visible from
+where you are in the plotting hierarchy.  If not found we go up the hierarchy to CPTs
+with broader scope, and if none is ultimately found (and the module, unlike **grdimage**, cannot
+create a CPT by itself), then you have likely made a scripting error.
+There are cases in modern mode when you must explicitly create a named CPT using the
+**-H** option.  One such case is when making movies with :doc:`movie` since you
+will want to create the CPT once and have **movie** access it again and again.  Since
+each movie frame is a *separate session* there is no cross-session sharing of current
+CPTs.

--- a/doc/rst/source/grd2cpt.rst
+++ b/doc/rst/source/grd2cpt.rst
@@ -259,6 +259,7 @@ file relief, run
 
     gmt grd2cpt mydata.nc -Crelief -L0/10000 -T0/200/20 > mydata.cpt
 
+.. include:: explain_cpt.rst_
 
 See Also
 --------

--- a/doc/rst/source/grdimage.rst
+++ b/doc/rst/source/grdimage.rst
@@ -82,6 +82,8 @@ remotely located Jessica Rabbit
         http://larryfire.files.wordpress.com/2009/07/untooned_jessicarabbit.jpg
         -pdf jess
 
+.. include:: explain_cpt.rst_
+
 See Also
 --------
 

--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -320,6 +320,8 @@ we always get a color regardless of the *z* value, try
 
     gmt makecpt -Cjet -T0/500 -Ww > wrapped.cpt
 
+.. include:: explain_cpt.rst_
+
 Bugs
 ----
 

--- a/doc/rst/source/subplot.rst_
+++ b/doc/rst/source/subplot.rst_
@@ -216,8 +216,9 @@ Synopsis (end mode)
 **gmt subplot end** [ |SYN_OPT-V| ]
 
 This command finalizes the current subplot, including any placement of tags, and updates the
-dimensions of the last plot to that of the entire subplot. This allows **-X** and **-Y** to
-use the codes *w* and *h* in setting the current point relative to the entire subplot.  We also reset
+gmt.history to reflect the dimensions and linear projection required to draw the entire figure
+outline. This allows subsequent commands, such as colorbar, to use **-DJ** to place bars with
+reference to the complete figure dimensions. We also reset
 the current plot location to where it was prior to the subplot.
 
 Optional Arguments


### PR DESCRIPTION
Added a new explain_cpt.rst_ file included by grd2cpt, makecpt, and grdimage that explains the concept of the hidden current CPT, the hierarchy of such files, and how gmt navigates to find the right one.  No coding changes, just RST.
