### PR TITLE
Fix a bug in subplot set index

### DIFF
--- a/src/subplot.c
+++ b/src/subplot.c
@@ -241,7 +241,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT
 	else if (!strncmp (opt->arg, "set", 3U)) {	/* Explicitly called set row,col or set index */
 		opt = opt->next;	/* The row,col part */
 		if (opt) {	/* There is an argument */
-			if (isdigit (opt->arg[0]) && (n = sscanf (opt->arg, "%d,%d", &Ctrl->In.row, &Ctrl->In.col) < 1)) {
+			if (isdigit (opt->arg[0]) && (n = sscanf (opt->arg, "%d,%d", &Ctrl->In.row, &Ctrl->In.col)) < 1) {
 				GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Error set: Unable to parse row,col: %s\n", opt->arg);
 				return GMT_PARSE_ERROR;
 			}


### PR DESCRIPTION
`gmt subplot set <index>` fails due to a typo.

To reproduce the bug, run:
```
gmt begin panels
  gmt subplot begin 2x2 -Fs3i+d -M5p -A -SCt -SR -Bwsne
    gmt subplot set 0
    gmt basemap -R0/80/0/10
    gmt subplot set 1
    gmt basemap
    gmt subplot set 2
    gmt basemap
    gmt subplot set 3
    gmt basemap
  gmt subplot end
gmt end show
```