### PR TITLE
Document subplot -F modifiers +g, +p, and new +c

### DIFF
--- a/doc/rst/source/subplot.rst_
+++ b/doc/rst/source/subplot.rst_
@@ -74,7 +74,7 @@ Required Arguments
     a zero *height*, or (2) you can select *height* based on trial and error to suit your plot layout.
 
     Optionally, you may draw or paint the figure rectangle behind the subplots, and even expand it via **+c**.  This
-    is most useful if you supply **-B=n** to subplot begin, meaning no ticks or annotations will take place in the
+    is most useful if you supply **-B+n** to subplot begin, meaning no ticks or annotations will take place in the
     subplots.
 
 Optional Arguments

--- a/doc/rst/source/subplot.rst_
+++ b/doc/rst/source/subplot.rst_
@@ -15,7 +15,7 @@ Synopsis (begin mode)
 .. include:: common_SYN_OPTs.rst_
 
 **gmt subplot begin** *nrows*\ **x**\ *ncols*
-**-F**\ [**f**\ \|\ **s**\ ]\ *width*\ /*height*\ [**+f**\ *wfracs*\ /*hfracs*\ ]
+**-F**\ [**f**\ \|\ **s**\ ]\ *width*\ /*height*\ [**+f**\ *wfracs*\ /*hfracs*\ ][**+c**\ *dx/dy*\ ][**+g**\ *fill*\ ][**+p**\ *pen*\ ]
 [ **-A**\ *autolabel* ]
 [ **-C**\ *side*\ /*clearance*\ [**u**]
 [ |SYN_OPT-B| ]
@@ -46,7 +46,7 @@ Required Arguments
 
 .. _subplot_begin-F:
 
-**-F**\ [**f**\ \|\ **s**\ ]\ *width(s)*\ /*height(s)*\ \ [**+f**\ *wfracs*\ /*hfracs*\ ]
+**-F**\ [**f**\ \|\ **s**\ ]\ *width(s)*\ /*height(s)*\ \ [**+f**\ *wfracs*\ /*hfracs*\ ][**+c**\ *dx/dy*\ ][**+g**\ *fill*\ ][**+p**\ *pen*\ ]
     Specify the dimensions of the figure.  There are two different ways to do this:
     (**f**) Specify overall figure dimensions or (**s**) specify the dimensions of
     a single subplot.
@@ -72,6 +72,10 @@ Required Arguments
     your map region and projection.  There are two options: (1) Specify both **-R** and **-J** and we use these
     to compute the height of each subplot.  All subplots must share the same region and projection and you specify
     a zero *height*, or (2) you can select *height* based on trial and error to suit your plot layout.
+
+    Optionally, you may draw or paint the figure rectangle behind the subplots. and even expand it via **+c**.  This
+    is most useful if you supply **-B=n** to subplot begin, meaning no ticks or annotations will take place in the
+    subplots.
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/subplot.rst_
+++ b/doc/rst/source/subplot.rst_
@@ -73,7 +73,7 @@ Required Arguments
     to compute the height of each subplot.  All subplots must share the same region and projection and you specify
     a zero *height*, or (2) you can select *height* based on trial and error to suit your plot layout.
 
-    Optionally, you may draw or paint the figure rectangle behind the subplots. and even expand it via **+c**.  This
+    Optionally, you may draw or paint the figure rectangle behind the subplots, and even expand it via **+c**.  This
     is most useful if you supply **-B=n** to subplot begin, meaning no ticks or annotations will take place in the
     subplots.
 

--- a/test/modern/polarpanels.ps
+++ b/test/modern/polarpanels.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_bdab28f-dirty [64-bit] Document from psxy
+%%Title: GMT v6.0.0_9c40f06-dirty_2019.08.09 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Feb 14 12:38:36 2019
+%%CreationDate: Fri Aug  9 10:54:16 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -336,9 +336,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +592,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +635,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -672,9 +667,9 @@ O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -R0/4.46012/0/4.46012 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=false
-%@PROJ: xy 0.00000000 4.46012000 0.00000000 4.46012000 0.000 4.460 0.000 4.460 +xy
-%GMTBoundingBox: 72 72 321.129 321.129
+%@GMT: gmt psxy -R0/4.85382/0/4.85382 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 4.85382000 0.00000000 4.85382000 0.000 4.854 0.000 4.854 +xy
+%GMTBoundingBox: 72 72 349.475 349.475
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
@@ -684,10 +679,10 @@ PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 3336 TM
+0 3808 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -JPa1.9685i/45 -R0/90/0/1 -Bxa45f -BWENS -Byaf -Xa0i -Ya2.4916i
+%@GMT: gmt psbasemap -JPa1.9685i/45 -R0/90/0/1 -Bxa45f -BWENS -Byaf -Xa0i -Ya2.8853i
 %@PROJ: polar 0.00000000 90.00000000 0.00000000 1.00000000 -0.707 0.707 0.000 1.000 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -782,11 +777,11 @@ S
 1181 0 M
 -1181 1181 D
 S
--118 1299 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-118 1299 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-V 45 R (0∞) bc Z U
-1181 1837 M (45∞) bc Z
-2480 1299 M V -45 R (90∞) bc Z U
+V 45 R (0è) bc Z U
+1181 1837 M (45è) bc Z
+2480 1299 M V -45 R (90è) bc Z U
 1299 -118 M V -45 R (0) mr Z U
 1063 -118 M V 45 R (0) ml Z U
 827 119 M V 44.8 R (0.2) mr Z U
@@ -800,15 +795,15 @@ V 45 R (0∞) bc Z U
 -118 1064 M V 44.8 R (1) mr Z U
 2481 1064 M V -44.8 R (1) ml Z U
 %%EndObject
-0 -3336 TM
+0 -3808 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-3462 3336 TM
+3462 3808 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -JPa1.9685i/45 -R0/90/0/1 -Bxa45f -BWENS -Byaf -Xa2.8853i -Ya2.4916i
+%@GMT: gmt psbasemap -JPa1.9685i/45 -R0/90/0/1 -Bxa45f -BWENS -Byaf -Xa2.8853i -Ya2.8853i
 %@PROJ: polar 0.00000000 90.00000000 0.00000000 1.00000000 -0.707 0.707 0.000 1.000 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -903,11 +898,11 @@ S
 1181 0 M
 -1181 1181 D
 S
--118 1299 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-118 1299 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-V 45 R (0∞) bc Z U
-1181 1837 M (45∞) bc Z
-2480 1299 M V -45 R (90∞) bc Z U
+V 45 R (0è) bc Z U
+1181 1837 M (45è) bc Z
+2480 1299 M V -45 R (90è) bc Z U
 1299 -118 M V -45 R (0) mr Z U
 1063 -118 M V 45 R (0) ml Z U
 827 119 M V 44.8 R (0.2) mr Z U
@@ -921,15 +916,15 @@ V 45 R (0∞) bc Z U
 -118 1064 M V 44.8 R (1) mr Z U
 2481 1064 M V -44.8 R (1) ml Z U
 %%EndObject
--3462 -3336 TM
+-3462 -3808 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-0 -127 TM
+0 346 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -JPa1.9685i/45 -R0/90/0/1 -Bxa45f -BWENS -Byaf -Xa0i -Ya-0.3937i
+%@GMT: gmt psbasemap -JPa1.9685i/45 -R0/90/0/1 -Bxa45f -BWENS -Byaf -Xa0i -Ya0i
 %@PROJ: polar 0.00000000 90.00000000 0.00000000 1.00000000 -0.707 0.707 0.000 1.000 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -1024,11 +1019,11 @@ S
 1181 0 M
 -1181 1181 D
 S
--118 1299 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-118 1299 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-V 45 R (0∞) bc Z U
-1181 1837 M (45∞) bc Z
-2480 1299 M V -45 R (90∞) bc Z U
+V 45 R (0è) bc Z U
+1181 1837 M (45è) bc Z
+2480 1299 M V -45 R (90è) bc Z U
 1299 -118 M V -45 R (0) mr Z U
 1063 -118 M V 45 R (0) ml Z U
 827 119 M V 44.8 R (0.2) mr Z U
@@ -1042,15 +1037,15 @@ V 45 R (0∞) bc Z U
 -118 1064 M V 44.8 R (1) mr Z U
 2481 1064 M V -44.8 R (1) ml Z U
 %%EndObject
-0 127 TM
+0 -346 TM
 PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-3462 -127 TM
+3462 346 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -JPa1.9685i/45 -R0/90/0/1 -Bxa45f -BWENS -Byaf -Xa2.8853i -Ya-0.3937i
+%@GMT: gmt psbasemap -JPa1.9685i/45 -R0/90/0/1 -Bxa45f -BWENS -Byaf -Xa2.8853i -Ya0i
 %@PROJ: polar 0.00000000 90.00000000 0.00000000 1.00000000 -0.707 0.707 0.000 1.000 +unavailable +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -1145,11 +1140,11 @@ S
 1181 0 M
 -1181 1181 D
 S
--118 1299 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-118 1299 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-V 45 R (0∞) bc Z U
-1181 1837 M (45∞) bc Z
-2480 1299 M V -45 R (90∞) bc Z U
+V 45 R (0è) bc Z U
+1181 1837 M (45è) bc Z
+2480 1299 M V -45 R (90è) bc Z U
 1299 -118 M V -45 R (0) mr Z U
 1063 -118 M V 45 R (0) ml Z U
 827 119 M V 44.8 R (0.2) mr Z U
@@ -1163,7 +1158,7 @@ V 45 R (0∞) bc Z U
 -118 1064 M V 44.8 R (1) mr Z U
 2481 1064 M V -44.8 R (1) ml Z U
 %%EndObject
--3462 127 TM
+-3462 -346 TM
 PSL_completion /PSL_completion {} def
 
 grestore


### PR DESCRIPTION
These were not documented but where there all along, except **+c**.  This lets you draw the background figure canvas, possibly expanded by **+c**_clearance_, and specify fill and outline.  Makes most sense if **-B+n** was used to set up the subplot.  See #1342 for discussion.
