### PR TITLE
Add GMT_GRAPHICS_FORMAT [pdf] as new GMT default setting

### DIFF
--- a/doc/rst/source/begin.rst_
+++ b/doc/rst/source/begin.rst_
@@ -47,7 +47,7 @@ Optional Arguments
 
 *formats*
     Give one or more comma-separated graphics extensions from the list of allowable graphics formats
-    :ref:`formats <tbl-formats>` [pdf].
+    :ref:`formats <tbl-formats>` (default is configurable via setting GMT_GRAPHICS_FORMAT [pdf]).
 
 .. _begin-options:
 
@@ -108,7 +108,7 @@ are produced then we do not need to give any further arguments:
     gmt begin
 
 Should we give such a command and still produce a plot then it will automatically
-be called gmtsession.pdf.
+be called gmtsession.pdf (assuming GMT_GRAPHICS_FORMAT is pdf).
 
 To set up proceedings for a jpg figure with 0.5c white margin, we would run
 

--- a/doc/rst/source/figure.rst_
+++ b/doc/rst/source/figure.rst_
@@ -47,7 +47,7 @@ Optional Arguments
 
 *formats*
     Give one or more comma-separated graphics extensions from the list of allowable graphics
-    :ref:`formats <tbl-formats>` [pdf].
+    :ref:`formats <tbl-formats>` (default is configurable via setting GMT_GRAPHICS_FORMAT [pdf]).
 
 .. _figure-options:
 

--- a/src/begin.c
+++ b/src/begin.c
@@ -42,7 +42,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 
 	GMT_Message (API, GMT_TIME_NONE, "\tOPTIONS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t<prefix> is the prefix to use for unnamed figures [%s].\n", GMT_SESSION_NAME);
-	GMT_Message (API, GMT_TIME_NONE, "\t<format(s)> sets the default plot format(s) [%s].\n", gmt_session_format[GMT_SESSION_FORMAT]);
+	GMT_Message (API, GMT_TIME_NONE, "\t<format(s)> sets the default plot format(s) [%s].\n", gmt_session_format[API->GMT->current.setting.graphics_format]);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Choose one or more of these valid extensions separated by commas:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     bmp:	MicroSoft BitMap.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     eps:	Encapsulated PostScript.\n");

--- a/src/figure.c
+++ b/src/figure.c
@@ -43,7 +43,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 
 	GMT_Message (API, GMT_TIME_NONE, "\t<prefix> is the prefix to use for the registered figure\'s name.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t<formats> contains one or more comma-separated formats [%s].\n", gmt_session_format[GMT_SESSION_FORMAT]);
+	GMT_Message (API, GMT_TIME_NONE, "\t<formats> contains one or more comma-separated formats [%s].\n", gmt_session_format[API->GMT->current.setting.graphics_format]);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Choose from these valid extensions:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     bmp:	MicroSoft BitMap.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     eps:	Encapsulated PostScript.\n");

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -104,6 +104,7 @@ struct GMT_DEFAULTS {
 	unsigned int history;     /* mode to pass information via history file gmt.history (GMT_HISTORY_OFF, GMT_HISTORY_READ, GMT_HISTORY_WRITE) */
 	unsigned int history_orig;     /* Copy of history */
 	unsigned int export_type;     /* What data type to export to external APIs [GMT_DOUBLE] */
+	unsigned graphics_format;	/* The default graphics format in modern mode [GMT_SESSION_FORMAT] */
 	/* IO group */
 	uint64_t n_bin_header_cols;		/* Minimum number of columns in a binary file for which the all cols == NaN means segment header [2] */
 	unsigned int io_n_header_items;		/* Number of header records expected when -h is used [1]; else 0 */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -134,7 +134,7 @@ struct GMT5_params {
 	const char *name;
 };
 
-/* These are the active GMT5 keywords, containing no backwards-compatible variants.
+/* These are the active GMT5+ keywords, containing no backwards-compatible variants.
  * Also, some grouped keywords such as FONT and FONT_ANNOT are also not listed since they are not in gmt.conf.
  * If new keywords are added they need to be added here as well as to gmt_keywords.txt. */
 
@@ -184,6 +184,7 @@ static struct GMT5_params GMT5_keywords[]= {
 	{ 0, "GMT_EXPORT_TYPE"},
 	{ 0, "GMT_EXTRAPOLATE_VAL"},
 	{ 0, "GMT_FFT"},
+	{ 0, "GMT_GRAPHICS_FORMAT"},
 	{ 0, "GMT_HISTORY"},
 	{ 0, "GMT_INTERPOLANT"},
 	{ 0, "GMT_LANGUAGE"},
@@ -5475,6 +5476,8 @@ void gmtinit_conf (struct GMT_CTRL *GMT) {
 	GMT->current.setting.extrapolate_val[0] = GMT_EXTRAPOLATE_NONE;
 	/* GMT_FFT */
 	GMT->current.setting.fft = k_fft_auto;
+	/* GMT_GRAPHICS_FORMAT */
+	GMT->current.setting.graphics_format = GMT_SESSION_FORMAT;
 	/* GMT_HISTORY */
 	GMT->current.setting.history = (GMT_HISTORY_READ | GMT_HISTORY_WRITE);
 	/* GMT_INTERPOLANT */
@@ -9728,6 +9731,14 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			else
 				error = true;
 			break;
+		case GMTCASE_GMT_GRAPHICS_FORMAT:
+		 	if ((ival = gmt_get_graphics_id (GMT, value)) == GMT_NOTSET) {
+				GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unrecognized graphics format %s\n", value);
+				error = true;
+			}
+			else
+				GMT->current.setting.graphics_format = ival;
+			break;
 		case GMTCASE_HISTORY:
 			GMT_COMPAT_TRANSLATE ("GMT_HISTORY");
 			break;
@@ -10890,6 +10901,9 @@ char *gmtlib_putparameter (struct GMT_CTRL *GMT, const char *keyword) {
 				default:
 					strcpy (value, "undefined");
 			}
+			break;
+		case GMTCASE_GMT_GRAPHICS_FORMAT:
+			strcpy (value, gmt_session_format[GMT->current.setting.graphics_format]);
 			break;
 		case GMTCASE_HISTORY:
 			if (gmt_M_compat_check (GMT, 4))	/* GMT4: */
@@ -15316,7 +15330,7 @@ GMT_LOCAL void get_session_name_format (struct GMTAPI_CTRL *API, char prefix[GMT
 	sprintf (file, "%s/%s", API->gwf_dir, GMT_SESSION_FILE);
 	if (access (file, F_OK)) {	/* Use default session name and format */
 		strcpy (prefix, GMT_SESSION_NAME);
-		strcpy (formats, gmt_session_format[GMT_SESSION_FORMAT]);
+		strcpy (formats, gmt_session_format[API->GMT->current.setting.graphics_format]);
 		return;
 	}
 	if ((fp = fopen (file, "r")) == NULL) {
@@ -15332,7 +15346,7 @@ GMT_LOCAL void get_session_name_format (struct GMTAPI_CTRL *API, char prefix[GMT
 		return;
 	}
 	if (n == 1)	/* Assign default format */
-		strcpy (formats, gmt_session_format[GMT_SESSION_FORMAT]);
+		strcpy (formats, gmt_session_format[API->GMT->current.setting.graphics_format]);
 	gmt_filename_get (prefix);
 	GMT_Report (API, GMT_MSG_DEBUG, "Got session name as %s and default graphics formats as %s\n", prefix, formats);
 	fclose (fp);
@@ -15666,7 +15680,7 @@ int gmt_add_figure (struct GMTAPI_CTRL *API, char *arg) {
 	else if (!found) {	/* Here we have a new valid entry */
 		this_k = n_figs + 1;	/* This is the ID number of the new figure we are adding */
 		if (n == 1) /* Only got a prefix so must set the default pdf format */
-			strncpy (formats, gmt_session_format[GMT_SESSION_FORMAT], GMT_LEN64-1);
+			strncpy (formats, gmt_session_format[API->GMT->current.setting.graphics_format], GMT_LEN64-1);
 		if ((fp = open_figure_file (API, 1, &err)) == NULL)	/* Failure to open existing or create new file */
 			return GMT_ERROR_ON_FOPEN;
 		/* Append the new entry */

--- a/src/gmt_keywords.txt
+++ b/src/gmt_keywords.txt
@@ -59,9 +59,10 @@ FORMAT_TIME_STAMP		# How to format time for GMT time-stamps
 #-------------------------------------------------------
 GMT_COMPATIBILITY		# Oldest GMT version syntax to parse without error [4 and up]
 GMT_AUTO_DOWNLOAD		# Download GMT-known files or not
-GMT_DATA_URL		# Where to download from [SOEST]
+GMT_DATA_URL			# Where to download from [SOEST]
 GMT_DATA_URL_LIMIT		# Max file size to download remotely
 GMT_FFT				# Which FFT algorithm to use
+GMT_GRAPHICS_FORMAT		# Default graphics format in modern mode
 GMT_HISTORY			# Should we update the command history?
 GMT_INTERPOLANT			# Spline interpolant
 GMT_LANGUAGE			# Language used for annotations


### PR DESCRIPTION
**Description of proposed changes**

This only affects the default graphics format in modern mode.  Rather than always being pdf, it can now be changed to another valid format via gmt set. Closes #803.
