### PR TITLE
Print usage with modern names

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -645,10 +645,7 @@ GMT_LOCAL void gmtapi_check_for_modern_oneliner (struct GMTAPI_CTRL *API, const 
 			return;
 		}
 		if (head->next == NULL) {	/* Gave a single argument */
-			if (head->arg[0] == '+' && head->arg[1] == '\0')	/* Gave + */
-				modern = 1;
-			else if (head->arg[0] == '-' && (head->arg[1] == '\0' || head->arg[1] == GMT_OPT_USAGE || head->arg[1] == GMT_OPT_SYNOPSIS))	/* Gave a single argument */
-				modern = 1;
+			if (head->option == GMT_OPT_USAGE || head->option == GMT_OPT_SYNOPSIS) modern = 1;
 			if (modern) usage = true;
 		}
 	}


### PR DESCRIPTION
See #1314 for context. This PR fixes #1314, but I'm not sure if it's correct.

If I understand it correctly, function `GMT_Create_Options` converts input arguments to a list of GMT_OPTION. If the argument is `-`, `+`, `-+` or `-^`, then `head->option` is set to be `GMT_OPT_USAGE` or `GMT_OPT_USAGE`. So we can check `head->option` to determine if we need to print module usage.