### PR TITLE
Display gmt in front of classic modules as well

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -9992,11 +9992,8 @@ const char * gmt_show_name_and_purpose (void *V_API, const char *component, cons
 	API = api_get_api_ptr (V_API);
 	mode_name = gmtlib_get_active_name (API, name);
 	lib = (component) ? component : core;
-	if (API->GMT->current.setting.use_modern_name || API->GMT->current.setting.run_mode == GMT_MODERN) {	/* Must include the required "gmt " prefix */
-		sprintf (full_name, "gmt %s", mode_name);
-		mode_name = full_name;
-	}
-	snprintf (message, GMT_LEN256, "%s [%s] %s - %s\n\n", mode_name, lib, GMT_version(), purpose);
+	sprintf (full_name, "gmt %s", mode_name);
+	snprintf (message, GMT_LEN256, "%s [%s] %s - %s\n\n", full_name, lib, GMT_version(), purpose);
 	GMT_Message (V_API, GMT_TIME_NONE, message);
 	gmtlib_set_KOP_strings (API);
 	return mode_name;


### PR DESCRIPTION
The usage messages will now say

> gmt pscoast


instead of just

> pscoast.


Closes #1357 