### PR TITLE
Special handling of psrose in modern mode subplot/inset

### DIFF
--- a/doc/examples/ex06/example_06.bat
+++ b/doc/examples/ex06/example_06.bat
@@ -7,6 +7,6 @@ REM DOS calls:	del
 REM
 echo GMT EXAMPLE 06
 set ps=example_06.ps
-gmt psrose @fractures_06.txt -: -A10r -S1.8in -P -Gorange -R0/1/0/360 -X2.5i -K -Bx0.2g0.2 -By30g30 -B+glightblue -W1p > %ps%
+gmt psrose @fractures_06.txt -: -A10r -S -JX3.6i -P -Gorange -R0/1/0/360 -X2.5i -K -Bx0.2g0.2 -By30g30 -B+glightblue -W1p > %ps%
 gmt pshistogram -Bxa2000f1000+l"Topography (m)" -Bya10f5+l"Frequency"+u" %%" -BWSne+t"Histograms"+glightblue @v3206_06.txt -R-6000/0/0/30 -JX4.8i/2.4i -Gorange -O -Y5.0i -X-0.5i -L1p -Z1 -W250 >> %ps%
 del .gmt*

--- a/doc/examples/ex06/example_06.sh
+++ b/doc/examples/ex06/example_06.sh
@@ -5,7 +5,7 @@
 # GMT modules:	pshistogram, psrose
 #
 ps=example_06.ps
-gmt psrose @fractures_06.txt -: -A10r -Sn -JX3.6i -P -Gorange -R0/1/0/360 -X2.5i -K -Bx0.2g0.2 \
+gmt psrose @fractures_06.txt -: -A10r -S -JX3.6i -P -Gorange -R0/1/0/360 -X2.5i -K -Bx0.2g0.2 \
 	-By30g30 -B+glightblue -W1p > $ps
 gmt pshistogram -Bxa2000f1000+l"Topography (m)" -Bya10f5+l"Frequency"+u" %" \
 	-BWSne+t"Histograms"+glightblue @v3206_06.txt -R-6000/0/0/30 -JX4.8i/2.4i -Gorange -O \

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12485,7 +12485,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 	else if (options && gmt_M_compat_check (GMT, 6) && !strncmp (mod_name, "psrose", 6U) && (opt = GMT_Find_Option (API, 'J', *options)) == NULL) {
 		/* Running psrose with old -S[n]<radius syntax.  Need to replace with new -J [-S] syntax */
 		struct GMT_OPTION *S = GMT_Find_Option (API, 'S', *options);
-		if (S) {	/* Gave -S option */
+        if (S && S->arg[0]) {	/* Gave -S option with some arguments */
 			char j_code[GMT_LEN256] = {""};
 			unsigned int k, norm = (S->arg[0] == 'n') ? 1 : 0;
 			double radius;
@@ -12506,7 +12506,12 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 			}
 		}
 		else {	/* No -S option given either, so user expects default radius and no normalization */
-			if ((opt = GMT_Make_Option (API, 'J', "X6i")) == NULL) return NULL;		/* Failure to make -J option */
+			if (GMT->current.setting.run_mode == GMT_MODERN) {
+				if ((opt = GMT_Make_Option (API, 'J', "X?")) == NULL) return NULL;		/* Failure to make -J option */
+			}
+			else {
+				if ((opt = GMT_Make_Option (API, 'J', "X6i")) == NULL) return NULL;		/* Failure to make -J option */
+			}
 			if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append -J option */
 		}
 	}

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12508,7 +12508,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 		else {	/* No old-style -S option given either, so user expects default radius and no normalization */
 			if (GMT->current.setting.run_mode == GMT_MODERN) {
 				is_psrose = true;	/* Since psrose does not really parse -J properly we need to flag this */
-				if ((opt = GMT_Make_Option (API, 'J', "x?")) == NULL) return NULL;	/* Failure to make -J option */
+				if ((opt = GMT_Make_Option (API, 'J', "X?")) == NULL) return NULL;	/* Failure to make -J option */
 			}
 			else {
 				if ((opt = GMT_Make_Option (API, 'J', "X6i")) == NULL) return NULL;	/* Failure to make -J option */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12448,7 +12448,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 	 * Modules like psxy has "d" so we can make a quick map without specifying -R.
 	 */
 
-	bool is_PS;
+	bool is_PS, is_psrose = false;
 	unsigned int srtm_res = 0;
 	char *required = (char *)in_required;
 	struct GMT_OPTION *E = NULL, *opt = NULL, *opt_R = NULL;
@@ -12485,7 +12485,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 	else if (options && gmt_M_compat_check (GMT, 6) && !strncmp (mod_name, "psrose", 6U) && (opt = GMT_Find_Option (API, 'J', *options)) == NULL) {
 		/* Running psrose with old -S[n]<radius syntax.  Need to replace with new -J [-S] syntax */
 		struct GMT_OPTION *S = GMT_Find_Option (API, 'S', *options);
-        if (S && S->arg[0]) {	/* Gave -S option with some arguments */
+		if (S && S->arg[0]) {	/* Gave -S option with some arguments */
 			char j_code[GMT_LEN256] = {""};
 			unsigned int k, norm = (S->arg[0] == 'n') ? 1 : 0;
 			double radius;
@@ -12505,12 +12505,13 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 				if (GMT_Delete_Option (API, S, options)) return NULL;		/* Failed to remove -S */
 			}
 		}
-		else {	/* No -S option given either, so user expects default radius and no normalization */
+		else {	/* No old-style -S option given either, so user expects default radius and no normalization */
 			if (GMT->current.setting.run_mode == GMT_MODERN) {
-				if ((opt = GMT_Make_Option (API, 'J', "X?")) == NULL) return NULL;		/* Failure to make -J option */
+				is_psrose = true;	/* Since psrose does not really parse -J properly we need to flag this */
+				if ((opt = GMT_Make_Option (API, 'J', "x?")) == NULL) return NULL;	/* Failure to make -J option */
 			}
 			else {
-				if ((opt = GMT_Make_Option (API, 'J', "X6i")) == NULL) return NULL;		/* Failure to make -J option */
+				if ((opt = GMT_Make_Option (API, 'J', "X6i")) == NULL) return NULL;	/* Failure to make -J option */
 			}
 			if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append -J option */
 		}
@@ -12528,6 +12529,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 		unsigned int n_errors = 0, subplot_status = 0, inset_status = 0;
 		int id, fig;
 		bool got_R = false, got_J = false, exceptionb, exceptionp;
+		;
 		char arg[GMT_LEN256] = {""}, scl[GMT_LEN64] = {""}, *c = NULL;
 		struct GMT_OPTION *opt_J = NULL;
 		struct GMT_SUBPLOT *P = NULL;
@@ -12744,8 +12746,10 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 					/* Gave -J that passed the log/power/special check, must subplot width dummy scale/width; these get changed in map_setxy in gmt_map.c */
 					if (P->dir[GMT_X] == -1 || P->dir[GMT_Y] == -1)	/* Nonstandard Cartesian directions */
 						sprintf (scl, "%gi/%gi",  P->dir[GMT_X]*P->w, P->dir[GMT_Y]*P->h);
+					else if (is_psrose)	/* Just append minimum dimension */
+						sprintf (scl, "%gi", MIN(P->w, P->h));
 					else	/* Just append dummy width */
-						sprintf (scl, "%gi",  P->w);
+						sprintf (scl, "%gi", P->w);
 					arg[0] = c[0] = '\0';
 					sprintf (arg, "%s%s%s", opt_J->arg, scl, &c[1]);
 					c[0] = '?';

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -2169,7 +2169,6 @@ GMT_LOCAL void map_setxy (struct GMT_CTRL *GMT, double xmin, double xmax, double
 	/* Set x/y parameters */
 	struct GMT_SUBPLOT *P = &(GMT->current.plot.panel);	/* P->active == 1 if a subplot */
 	struct GMT_INSET *I = &(GMT->current.plot.inset);	/* I->active == 1 if an inset */
-	bool is_psrose = !strncmp (GMT->init.module_name, "psrose", 6U);
 	
 	/* Set up the original min/max values, the rectangular map dimensionsm and the projection offset */
 	GMT->current.proj.rect_m[XLO] = xmin;	GMT->current.proj.rect_m[XHI] = xmax;	/* This is in original meters */
@@ -2196,7 +2195,6 @@ GMT_LOCAL void map_setxy (struct GMT_CTRL *GMT, double xmin, double xmax, double
 		else {	/* Cartesian is scaled independently to fit the subplot fully */
 			fx = 1.0 / fw;	fy = 1.0 / fh;	P->dx = P->dy = 0.0;
 		}
-		if (is_psrose) fx *= 0.5, fy *= 0.5;	/* Not sure about this yet but we are off by a factor of 2 */
 		/* Update all projection parameters given the reduction factors fx, fy */
 		GMT->current.proj.scale[GMT_X] *= fx;
 		GMT->current.proj.scale[GMT_Y] *= fy;
@@ -2227,7 +2225,6 @@ GMT_LOCAL void map_setxy (struct GMT_CTRL *GMT, double xmin, double xmax, double
 		else {	/* Cartesian is scaled independently to fit the panel */
 			fx = 1.0 / fw;	fy = 1.0 / fh;	I->dx = I->dy = 0.0;
 		}
-		if (is_psrose) fx *= 0.5, fy *= 0.5;	/* Not sure about this yet but we are off by a factor of 2 */
 		/* Update all projection parameters given the reduction factors fx, fy */
 		GMT->current.proj.scale[GMT_X] *= fx;
 		GMT->current.proj.scale[GMT_Y] *= fy;

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -2169,7 +2169,9 @@ GMT_LOCAL void map_setxy (struct GMT_CTRL *GMT, double xmin, double xmax, double
 	/* Set x/y parameters */
 	struct GMT_SUBPLOT *P = &(GMT->current.plot.panel);	/* P->active == 1 if a subplot */
 	struct GMT_INSET *I = &(GMT->current.plot.inset);	/* I->active == 1 if an inset */
-
+	bool is_psrose = !strncmp (GMT->init.module_name, "psrose", 6U);
+	
+	/* Set up the original min/max values, the rectangular map dimensionsm and the projection offset */
 	GMT->current.proj.rect_m[XLO] = xmin;	GMT->current.proj.rect_m[XHI] = xmax;	/* This is in original meters */
 	GMT->current.proj.rect_m[YLO] = ymin;	GMT->current.proj.rect_m[YHI] = ymax;
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Projected values in meters: %g %g %g %g\n", xmin, xmax, ymin, ymax);
@@ -2178,10 +2180,10 @@ GMT_LOCAL void map_setxy (struct GMT_CTRL *GMT, double xmin, double xmax, double
 	GMT->current.proj.origin[GMT_X] = -xmin * GMT->current.proj.scale[GMT_X];
 	GMT->current.proj.origin[GMT_Y] = -ymin * GMT->current.proj.scale[GMT_Y];
 
-	if (P->active && P->no_scaling == 0)	{	/* Must rescale to fit subplot panel dimensions and set dy for centering */
+	if (P->active && P->no_scaling == 0)	{	/* Must rescale to fit inside subplot dimensions and set dx,dy for centering */
 		double fw, fh, fx, fy, w, h;
 		w = GMT->current.proj.rect[XHI];	h = GMT->current.proj.rect[YHI];
-		adjust_panel_for_gaps (GMT, P);	/* Deal with any gaps: shrink w/h and adjust origin */
+		adjust_panel_for_gaps (GMT, P);	/* Deal with any gaps requested via subplot -C: shrink w/h and adjust origin */
 		fw = w / P->w;	fh = h / P->h;
 		if (gmt_M_is_geographic (GMT, GMT_IN) || GMT->current.proj.projection == GMT_POLAR || GMT->current.proj.gave_map_width == 0) {	/* Giving -Jx will end up here with map projections */
 			if (fw > fh) {	/* Wider than taller given panel dims; adjust width to fit exactly */
@@ -2191,9 +2193,11 @@ GMT_LOCAL void map_setxy (struct GMT_CTRL *GMT, double xmin, double xmax, double
 				fx = fy = 1.0 / fh;	P->dy = 0.0;	P->dx = 0.5 * (P->w - w * fx);
 			}
 		}
-		else {	/* Cartesian is scaled independently to fit the panel */
+		else {	/* Cartesian is scaled independently to fit the subplot fully */
 			fx = 1.0 / fw;	fy = 1.0 / fh;	P->dx = P->dy = 0.0;
 		}
+		if (is_psrose) fx *= 0.5, fy *= 0.5;	/* Not sure about this yet but we are off by a factor of 2 */
+		/* Update all projection parameters given the reduction factors fx, fy */
 		GMT->current.proj.scale[GMT_X] *= fx;
 		GMT->current.proj.scale[GMT_Y] *= fy;
 		GMT->current.proj.w_r *= fx;	/* Only matter for geographic where fx = fy anyway */
@@ -2208,7 +2212,7 @@ GMT_LOCAL void map_setxy (struct GMT_CTRL *GMT, double xmin, double xmax, double
 			GMT->current.setting.map_annot_oblique |= GMT_OBL_ANNOT_LAT_PARALLEL;	/* Plot latitude parallel to frame for geo maps */
 		}
 	}
-	else if (I->active && P->no_scaling == 0) {
+	else if (I->active && P->no_scaling == 0) {	/* Must rescale to fit inside inset dimensions and set dx,dy for centering */
 		double fw, fh, fx, fy, w, h;
 		w = GMT->current.proj.rect[XHI];	h = GMT->current.proj.rect[YHI];
 		fw = w / I->w;	fh = h / I->h;
@@ -2223,6 +2227,8 @@ GMT_LOCAL void map_setxy (struct GMT_CTRL *GMT, double xmin, double xmax, double
 		else {	/* Cartesian is scaled independently to fit the panel */
 			fx = 1.0 / fw;	fy = 1.0 / fh;	I->dx = I->dy = 0.0;
 		}
+		if (is_psrose) fx *= 0.5, fy *= 0.5;	/* Not sure about this yet but we are off by a factor of 2 */
+		/* Update all projection parameters given the reduction factors fx, fy */
 		GMT->current.proj.scale[GMT_X] *= fx;
 		GMT->current.proj.scale[GMT_Y] *= fy;
 		GMT->current.proj.w_r *= fx;	/* Only matter for geographic where fx = fy anyway */
@@ -2246,7 +2252,7 @@ GMT_LOCAL void map_setinfo (struct GMT_CTRL *GMT, double xmin, double xmax, doub
 	w = (xmax - xmin) * GMT->current.proj.scale[GMT_X];
 	h = (ymax - ymin) * GMT->current.proj.scale[GMT_Y];
 
-	if (GMT->current.proj.gave_map_width == 1)		/* Must rescale to given width */
+	if (GMT->current.proj.gave_map_width == 1)	/* Must rescale to given width */
 		factor = scl / w;
 	else if (GMT->current.proj.gave_map_width == 2)	/* Must rescale to given height */
 		factor = scl / h;

--- a/test/exmod/ex06.ps
+++ b/test/exmod/ex06.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from psxy
+%%Title: GMT v6.0.0_010caf5-dirty_2019.08.09 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:53:09 2018
+%%CreationDate: Fri Aug  9 19:52:40 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -336,9 +336,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +592,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +635,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -669,12 +664,12 @@ gsave
 0 A
 FQ
 O0
-1800 1800 TM
+1500 1200 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -R0/6/0/8.32311 -Jx1i -T -Xr1.5i -Yr1.5i --GMT_HISTORY=false
+%@GMT: gmt psxy -R0/6/0/8.32311 -Jx1i -T -Xr1.25i -Yr1i --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 6.00000000 0.00000000 8.32311000 0.000 6.000 0.000 8.323 +xy
-%GMTBoundingBox: 108 108 432 599.264
+%GMTBoundingBox: 90 72 432 599.264
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
@@ -684,121 +679,19 @@ PSL_completion /PSL_completion {} def
 0 A
 FQ
 O0
-1500 0 TM
+0 5788 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @fractures_06.txt -: -A10r -Sn -JX3.6i6i -Gorange -R0/1/0/360 -Bx0.2g0.2 -By30g30 -BWENS+glightblue -W1p -Xa0i -Ya0i
-%@PROJ: xy -1.80000000 1.80000000 -1.80000000 1.80000000 -1.800 1.800 -1.800 1.800 +xy
+%@GMT: gmt pshistogram '-Bxaf+lTopography (m)' '-Byaf+lFrequency+u %' -BWSne+tHistograms+glightblue @v3206_06.txt -R-6000/0/0/30 -Gorange -L1p -Z1 -W250 -Xa0i -Ya4.8231i -JX15c
+%@PROJ: xy -6000.00000000 0.00000000 0.00000000 30.00000000 -6000.000 0.000 0.000 30.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 /PSL_completion {
 V
-1500 0 T
--1860 4560 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-333 F0
-(b\)) br Z
-U
-}!
-2160 2160 T
-{0.678 0.847 0.902 C} FS
-2160 0 0 Sc
-25 W
-FQ
-O1
-2160 0 0 Sc
-17 W
-{1 0.647 0 C} FS
-60 688 M
-163 145 D
-326 344 D
-414 198 D
-406 -6 D
-400 -130 D
-185 -328 D
--121 -420 D
--388 -365 D
--464 -212 D
--259 -107 D
--200 -51 D
--277 72 D
--45 -28 D
-31 -130 D
--27 -107 D
--79 -28 D
--50 -390 D
--167 -195 D
--182 28 D
--191 24 D
--107 180 D
--110 136 D
--30 183 D
--50 144 D
-153 192 D
-212 128 D
--20 71 D
-57 61 D
-150 1 D
--83 107 D
--187 275 D
-31 161 D
-153 -6 D
-107 69 D
-139 -135 D
-FO
-4 W
-N 0 0 M 2160 0 D S
-N 0 0 M 1871 1080 D S
-N 0 0 M 1080 1871 D S
-N 0 0 M 0 2160 D S
-N 0 0 M -1080 1871 D S
-N 0 0 M -1871 1080 D S
-N 0 0 M -2160 0 D S
-N 0 0 M -1871 -1080 D S
-N 0 0 M -1080 -1871 D S
-N 0 0 M 0 -2160 D S
-N 0 0 M 1080 -1871 D S
-N 0 0 M 1871 -1080 D S
-N 0 0 M 2160 0 D S
-N 0 0 432 0 360 arc S
-N 0 0 864 0 360 arc S
-N 0 0 1296 0 360 arc S
-N 0 0 1728 0 360 arc S
-N 0 0 2160 0 360 arc S
-0 2860 M 400 F0
-() bc Z
-0 -2327 M 267 F0
-(South) tc Z
-N 2160 -2160 M -432 0 D S
-N 2160 -2160 M 0 83 D S
-N 1728 -2160 M 0 83 D S
-1944 -2243 M 200 F0
-(0.2) tc Z
-2327 0 M 267 F0
-(East) ml Z
--2327 0 M (West) mr Z
-0 2327 M (North) bc Z
--2160 -2160 T
-%%EndObject
--1500 0 TM
-PSL_completion /PSL_completion {} def
-0 A
-FQ
-O0
-0 5788 TM
-
-% PostScript produced by:
-%@GMT: gmt pshistogram '-Bxaf+lTopography (m)' '-Byaf+lFrequency+u %' -BWSne+tHistograms+glightblue @v3206_06.txt -R-6000/0/0/30 -JX4.8i/2.4i -Gorange -L1p -Z1 -W250 -Xa0i -Ya4.8231i
-%@PROJ: xy -6000.00000000 0.00000000 0.00000000 30.00000000 -6000.000 0.000 0.000 30.000 +xy
-%%BeginObject PSL_Layer_3
-0 setlinecap
-0 setlinejoin
-3.32551 setmiterlimit
-/PSL_completion {
-V
 0 5788 T
--360 4560 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 A -360 4560 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (a\)) br Z
 U
@@ -850,6 +743,7 @@ N 0 0 M -83 0 D S
 N 0 1400 M -83 0 D S
 N 0 2800 M -83 0 D S
 N 0 4200 M -83 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg exch M} def
 200 F0
@@ -1022,6 +916,109 @@ N 6960 0 M 0 42 D S
 (Histograms) bc Z
 %%EndObject
 0 -5788 TM
+PSL_completion /PSL_completion {} def
+0 A
+FQ
+O0
+1500 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psrose @fractures_06.txt -: -A10r -S -Gorange -R0/1/0/360 -Bx0.2g0.2 -By30g30 -BWENS+glightblue -W1p -Jx3.5i -Xa0i -Ya0i
+%@PROJ: xy -1.75000000 1.75000000 -1.75000000 1.75000000 -1.750 1.750 -1.750 1.750 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_completion {
+V
+1500 0 T
+0 A -1860 4560 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(b\)) br Z
+U
+}!
+2100 2100 T
+{0.678 0.847 0.902 C} FS
+2100 0 0 Sc
+25 W
+FQ
+O1
+2100 0 0 Sc
+17 W
+{1 0.647 0 C} FS
+59 669 M
+158 140 D
+317 336 D
+402 192 D
+395 -6 D
+389 -126 D
+179 -319 D
+-117 -409 D
+-377 -354 D
+-452 -206 D
+-251 -105 D
+-194 -49 D
+-270 70 D
+-44 -27 D
+31 -127 D
+-27 -104 D
+-77 -27 D
+-48 -380 D
+-162 -189 D
+-177 27 D
+-186 24 D
+-105 175 D
+-106 132 D
+-29 178 D
+-49 140 D
+149 186 D
+206 125 D
+-19 69 D
+55 59 D
+146 1 D
+-81 104 D
+-182 268 D
+31 156 D
+148 -6 D
+105 67 D
+135 -131 D
+FO
+4 W
+N 0 0 M 2100 0 D S
+N 0 0 M 1819 1050 D S
+N 0 0 M 1050 1819 D S
+N 0 0 M 0 2100 D S
+N 0 0 M -1050 1819 D S
+N 0 0 M -1819 1050 D S
+N 0 0 M -2100 0 D S
+N 0 0 M -1819 -1050 D S
+N 0 0 M -1050 -1819 D S
+N 0 0 M 0 -2100 D S
+N 0 0 M 1050 -1819 D S
+N 0 0 M 1819 -1050 D S
+N 0 0 M 2100 0 D S
+N 0 0 420 0 360 arc S
+N 0 0 840 0 360 arc S
+N 0 0 1260 0 360 arc S
+N 0 0 1680 0 360 arc S
+N 0 0 2100 0 360 arc S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 2800 M 400 F0
+() bc Z
+0 -2267 M 267 F0
+(South) tc Z
+N 2100 -2100 M -420 0 D S
+N 2100 -2100 M 0 83 D S
+N 1680 -2100 M 0 83 D S
+1890 -2183 M 200 F0
+(0.2) tc Z
+2267 0 M 267 F0
+(East) ml Z
+-2267 0 M (West) mr Z
+0 2267 M (North) bc Z
+-2100 -2100 T
+%%EndObject
+-1500 0 TM
 PSL_completion /PSL_completion {} def
 
 grestore

--- a/test/exmod/ex06.sh
+++ b/test/exmod/ex06.sh
@@ -5,9 +5,9 @@
 # GMT modules:	histogram, rose
 #
 gmt begin ex06 ps
-  gmt subplot begin 2x1 -A+JTL+o0.3i -Fs6i/3.5i -M0.4i
-    gmt rose @fractures_06.txt -: -A10r -S -Gorange -R0/1/0/360 -Bx0.2g0.2 -By30g30 -B+glightblue -W1p -c1
+  gmt subplot begin 2x1 -A+JTL+o0.3i -Fs6i/3.5i -M0.4i -X1.25i
     gmt histogram -Bx+l"Topography (m)" -By+l"Frequency"+u" %" -BWSne+t"Histograms"+glightblue @v3206_06.txt \
 	-R-6000/0/0/30 -Gorange -L1p -Z1 -W250 -c0
+    gmt rose @fractures_06.txt -: -A10r -S -Gorange -R0/1/0/360 -Bx0.2g0.2 -By30g30 -B+glightblue -W1p -c1
   gmt subplot end
 gmt end

--- a/test/exmod/ex06.sh
+++ b/test/exmod/ex06.sh
@@ -5,10 +5,9 @@
 # GMT modules:	histogram, rose
 #
 gmt begin ex06 ps
-  gmt set PS_MEDIA letter
-  gmt subplot begin 2x1 -A+JTL+o0.3i -Fs6i/3.5i -M0.4i -X1.5i -Y1.5i
-    gmt rose @fractures_06.txt -: -A10r -Sn -JX3.6i -Gorange -R0/1/0/360 -Bx0.2g0.2 -By30g30 -B+glightblue -W1p -c1,0
+  gmt subplot begin 2x1 -A+JTL+o0.3i -Fs6i/3.5i -M0.4i
+    gmt rose @fractures_06.txt -: -A10r -S -Gorange -R0/1/0/360 -Bx0.2g0.2 -By30g30 -B+glightblue -W1p -c1
     gmt histogram -Bx+l"Topography (m)" -By+l"Frequency"+u" %" -BWSne+t"Histograms"+glightblue @v3206_06.txt \
-	-R-6000/0/0/30 -JX4.8i/2.4i -Gorange -L1p -Z1 -W250 -c0,0
+	-R-6000/0/0/30 -Gorange -L1p -Z1 -W250 -c0
   gmt subplot end
 gmt end

--- a/test/exmod/ex06.sh
+++ b/test/exmod/ex06.sh
@@ -6,8 +6,8 @@
 #
 gmt begin ex06 ps
   gmt subplot begin 2x1 -A+JTL+o0.3i -Fs6i/3.5i -M0.4i -X1.25i
+    gmt rose @fractures_06.txt -: -A10r -S -Gorange -R0/1/0/360 -Bx0.2g0.2 -By30g30 -B+glightblue -W1p -c1
     gmt histogram -Bx+l"Topography (m)" -By+l"Frequency"+u" %" -BWSne+t"Histograms"+glightblue @v3206_06.txt \
 	-R-6000/0/0/30 -Gorange -L1p -Z1 -W250 -c0
-    gmt rose @fractures_06.txt -: -A10r -S -Gorange -R0/1/0/360 -Bx0.2g0.2 -By30g30 -B+glightblue -W1p -c1
   gmt subplot end
 gmt end


### PR DESCRIPTION
The rose module is very old and does not really use the **-J** machinery.  it always took a radius from -S.  Now it fishes out the width from **-J** but this is flawed.  However, when rose is called in a subplot we can take advantage of the fact that it is a square domain (a circle) and hence we create a scale that equals the shortest dimension of the subplot.  This works since rose fishes that dimension and uses it as diameter.  In a future revision we should rewrite rose to use **-J** like all other modules.  I updated ex06.sh which now works.