### PR TITLE
Return full name in gmt_show_name_and_purpose()

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -9996,7 +9996,7 @@ const char * gmt_show_name_and_purpose (void *V_API, const char *component, cons
 	snprintf (message, GMT_LEN256, "%s [%s] %s - %s\n\n", full_name, lib, GMT_version(), purpose);
 	GMT_Message (V_API, GMT_TIME_NONE, message);
 	gmtlib_set_KOP_strings (API);
-	return mode_name;
+	return full_name;
 }
 
 /* Module Extension: Allow listing and calling modules by name */


### PR DESCRIPTION
Fixes #1357 