### PR TITLE
Increase GRAPHICSMAGICK_RMS to allow snyder_map.sh pass

### DIFF
--- a/test/genper/snyder_map.sh
+++ b/test/genper/snyder_map.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Due to hairline differences in many gridlines between Linux and macOS we need a
 # higher rms threshold for this test to pass
-# GRAPHICSMAGICK_RMS = 0.0052
+# GRAPHICSMAGICK_RMS = 0.0055
 
 ps=snyder_map.ps
 


### PR DESCRIPTION
synder_map.sh fails on Linux, with a RMS=0.0053. The only tiny differences are the gridlines.
