### PR TITLE
Count number of graphics formats and build argument

### DIFF
--- a/src/gmt_gsformats.h
+++ b/src/gmt_gsformats.h
@@ -28,7 +28,8 @@
 #ifndef GMT_GSFORMATS_H
 #define GMT_GSFORMATS_H
 
-/* List ps at end since it causes a renaming of ps- to ps only.  Also allow jalternative peg and tiff spellings */
+/* List ps at end since it causes a renaming of ps- to ps only.  Also allow alternative jpeg and tiff spellings */
 static char *gmt_session_format[] = {"pdf", "jpg", "jpeg", "png", "PNG", "ppm", "tif", "tiff", "bmp", "eps", "ps", NULL};
+static char gmt_session_code[] =    { 'f',   'j',    'j',   'g',   'G',   'm',   't',    't',   'b',   'e',  'p',    0};
 
 #endif  /* GMT_GSFORMATS_H */


### PR DESCRIPTION
Improve how we compute the option string for **-T** in psconvert from the comma-separated format list fed to begin or figure.  Closes #1384.
