### PR TITLE
Fix old inset syntax and classic psbasemap -D syntax

### DIFF
--- a/doc/rst/source/inset.rst_
+++ b/doc/rst/source/inset.rst_
@@ -40,12 +40,12 @@ Required Arguments
 
 .. _-D:
 
-**-D**\ [*unit*]\ *xmin/xmax/ymin/ymax*\ [**r**] \| **-D**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ **+w**\ *width*\ [/*height*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
-    Define the map inset box on the map.  Specify the box in one of three ways:
+**-D**\ *xmin/xmax/ymin/ymax*\ [**+r**][**+u**\ *unit*]] \| **-D**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ **+w**\ *width*\ [/*height*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
+    Define the map inset rectangle on the map.  Specify the rectangle in one of three ways:
     (a) Give *west/east/south/north* of geographic rectangle bounded by parallels
-    and meridians; append **r** if the coordinates instead are the lower left and
-    upper right corners of the desired rectangle. (b) Give **u**\ *xmin/xmax/ymin/ymax*
-    of bounding rectangle in projected coordinates (here, **u** is the coordinate unit).
+    and meridians; append **+r** if the coordinates instead are the lower left and
+    upper right corners of the desired rectangle. (b) Give *xmin/xmax/ymin/ymax*
+    of bounding rectangle in projected coordinates and optionally append **+u**\ *unit* [Default coordinate unit is meter (e)].
     (c) Give the reference point on the map for the inset using one of four coordinate systems:
     (1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
     a 2-char justification code that refers to the (invisible) map domain rectangle,
@@ -124,13 +124,12 @@ To make a simple basemap plot called inset.pdf that demonstrates the inset modul
 
     gmt begin inset pdf
       gmt basemap -R0/40/20/60 -JM6.5i -Bafg -B+glightgreen
-        gmt inset begin -DjTR+w2.5i+o0.2i -F+gpink+p0.5p -M0.25i
-          gmt basemap -Rg -JA20/20/2i -Bafg
-          echo INSET | gmt text -F+f18p+cTR -Dj-0.15i
-        gmt inset end
-      echo MAP | gmt text -F+f18p+cBL -Dj0.2i
+      gmt inset begin -DjTR+w2.5i+o0.2i -F+gpink+p0.5p -M0.25i
+        gmt basemap -Rg -JA20/20/2i -Bafg
+        gmt text -F+f18p+cTR+tINSET -Dj-0.15i -N
+      gmt inset end
+      gmt text -F+f18p+cBL+tMAP -Dj0.2i
     gmt end
-
 
 See Also
 --------

--- a/doc/rst/source/psbasemap.rst
+++ b/doc/rst/source/psbasemap.rst
@@ -40,12 +40,12 @@ Synopsis
 
 .. _-D:
 
-**-D**\ [*unit*]\ *xmin/xmax/ymin/ymax*\ [**r**][**+s**\ *file*][**+t**] \| **-D**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ **+w**\ *width*\ [/*height*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]][**+s**\ *file*][**+t**]
+**-D**\ *xmin/xmax/ymin/ymax*\ [**+r**][**+s**\ *file*][**+t**][**+u**\ *unit*]\  \| **-D**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ **+w**\ *width*\ [/*height*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]][**+s**\ *file*][**+t**]
     Draw a simple map inset box on the map.  Requires **-F**.  Specify the box in one of three ways:
     (a) Give *west/east/south/north* of geographic rectangle bounded by parallels
     and meridians; append **r** if the coordinates instead are the lower left and
-    upper right corners of the desired rectangle. (b) Give **u**\ *xmin/xmax/ymin/ymax*
-    of bounding rectangle in projected coordinates (here, **u** is the coordinate unit).
+    upper right corners of the desired rectangle. (b) Give *xmin/xmax/ymin/ymax*
+    of bounding rectangle in projected coordinates and optionally append **+u**\ *unit* [Default coordinate unit is meter (e)].
     (c) Give the reference point on the map for the inset using one of four coordinate systems:
     (1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
     a 2-char justification code that refers to the (invisible) map domain rectangle,

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6875,14 +6875,15 @@ void gmt_mapinset_syntax (struct GMT_CTRL *GMT, char option, char *string) {
 	gmt_message (GMT, "\t     Specify the map inset region using one of three specifications:\n");
 	gmt_message (GMT, "\t     a) Give <west>/<east>/<south>/<north> of geographic rectangle bounded by meridians and parallels.\n");
 	gmt_message (GMT, "\t        Append +r if coordinates are the lower left and upper right corners of a rectangular area.\n");
-	gmt_message (GMT, "\t     b) Give <xmin>/<xmax>/<ymin>/<ymax>+u<unit> of bounding rectangle in projected coordinates.\n");
+	gmt_message (GMT, "\t     b) Give <xmin>/<xmax>/<ymin>/<ymax>[+u<unit>] of bounding rectangle in projected coordinates [meters].\n");
 	gmt_message (GMT, "\t     c) Set reference point and dimensions of the inset:\n");
 	gmt_refpoint_syntax (GMT, "D", NULL, GMT_ANCHOR_INSET, 1);
-	gmt_message (GMT, "\t        Append +w<width>[<u>]/<height>[<u>] of bounding rectangle (<u> is unit).\n");
+	gmt_message (GMT, "\t        Append +w<width>[<u>]/<height>[<u>] of bounding rectangle (<u> is a unit from %s).\n", GMT_DIM_UNITS_DISPLAY);
 	gmt_refpoint_syntax (GMT, "D", NULL, GMT_ANCHOR_INSET, 2);
-	if (GMT->current.setting.run_mode == GMT_CLASSIC)
+	if (GMT->current.setting.run_mode == GMT_CLASSIC) {
 		gmt_message (GMT, "\t     Append +s<file> to save inset lower left corner and dimensions to <file>.\n");
-	gmt_message (GMT, "\t     Append +t to translate plot origin to the lower left corner of the inset.\n");
+		gmt_message (GMT, "\t     Append +t to translate plot origin to the lower left corner of the inset.\n");
+	}
 	gmt_message (GMT, "\t   Set panel attributes separately via the -F option.\n");
 }
 

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -11823,7 +11823,10 @@ int gmt_getinset (struct GMT_CTRL *GMT, char option, char *in_text, struct GMT_M
 	/* Parse the map inset option, which comes in two flavors:
 	 * 1) -D<xmin/xmax/ymin/ymax>[+r][+s<file>][+u<unit>]
 	 * 2) -Dg|j|J|n|x<refpoint>+w<width>[<u>][/<height>[<u>]][+j<justify>][+o<dx>[/<dy>]][+s<file>]
-	 * Note: the [+s<file>] is only valid in classic mode (via psbasemap)
+	 *    Note: the [+s<file>] is only valid in classic mode (via psbasemap)
+	 *
+	 * For backwards compatibility we also check the deprecated form of (1):
+	 *    [<unit>]<xmin/xmax/ymin/ymax>
 	 */
 	unsigned int col_type[2], k = 0, error = 0;
 	int n;
@@ -11843,7 +11846,7 @@ int gmt_getinset (struct GMT_CTRL *GMT, char option, char *in_text, struct GMT_M
 	/* Determine if we got an reference point or a region */
 
 	if (strchr ("gjJnx", text[0])) {	/* Did the reference point thing. */
-		/* Syntax is -Dg|j|J|n|x<refpoint>+w<width>[u][/<height>[u]][+j<justify>][+o<dx>[/<dy>]][+s<file>] */
+		/* Syntax is -Dg|j|J|n|x<refpoint>+w<width>[u][/<height>[u]][+j<justify>][+o<dx>[/<dy>]][+s<file>], with +s<file> only in classic mode */
 		unsigned int last;
 		char *q[2] = {NULL, NULL};
 		size_t len;
@@ -11937,7 +11940,7 @@ int gmt_getinset (struct GMT_CTRL *GMT, char option, char *in_text, struct GMT_M
 			}
 			c[0] = '\0';	/* Chop off all modifiers so other items can be determined */
 		}
-		else if (strchr (GMT_LEN_UNITS2, text[0])) {	/* Got a rectangular region given in these units */
+		else if (strchr (GMT_LEN_UNITS2, text[0])) {	/* Deprecated args: Got a rectangular region given in these units */
 			/* -D<unit>]<xmin/xmax/ymin/ymax> */
 			B->unit = text[0];
 			k = 1;

--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -72,8 +72,8 @@
 #define GMT_TROSE_DIR	GMT_XYANCHOR "+w<width>[+f[<level>]]" GMT_JUSTIFY "[+l<w,e,s,n>]" GMT_OFFSET
 #define GMT_TROSE_MAG	GMT_XYANCHOR "+w<width>[+d[<dec>[/<dlabel>]]][+i<pen>]" GMT_JUSTIFY "[+l<w,e,s,n>][+p<pen>][+t<ints>]" GMT_OFFSET
 #define GMT_SCALE	GMT_XYANCHOR "+c[<slon>/]<slat>+w<length>[e|f|M|n|k|u][+a<align>][+f]" GMT_JUSTIFY "[+l[<label>]]" GMT_OFFSET "[+u]"
-#define GMT_INSET_A	GMT_XYANCHOR "+w<width>[<unit>][/<height>[<unit>]]" GMT_JUSTIFY GMT_OFFSET "[+t]"
-#define GMT_INSET_B	"<xmin>/<xmax>/<ymin>/<ymax>[+r][+t][+u<unit>]"
+#define GMT_INSET_A	GMT_XYANCHOR "+w<width>[<unit>][/<height>[<unit>]]" GMT_JUSTIFY GMT_OFFSET
+#define GMT_INSET_B	"<xmin>/<xmax>/<ymin>/<ymax>[+r][+u<unit>]"
 #define GMT_INSET_A_CL	GMT_XYANCHOR "+w<width>[<unit>][/<height>[<unit>]]" GMT_JUSTIFY GMT_OFFSET "[+s<file>][+t]"
 #define GMT_INSET_B_CL	"<xmin>/<xmax>/<ymin>/<ymax>[+r][+s<file>][+t][+u<unit>]"
 

--- a/src/inset.c
+++ b/src/inset.c
@@ -48,7 +48,7 @@ struct INSET_CTRL {
 		bool active;
 		unsigned int mode;	/* INSET_BEGIN|END*/
 	} In;
-	struct D {	/* -D[g|j|n|x]<refpoint>+w<width>[<unit>][/<height>[<unit>]][+j<justify>[+o<dx>[/<dy>]][+t] or [<unit>]<xmin>/<xmax>/<ymin>/<ymax>[r][+t] */
+	struct D {	/* -D[g|j|n|x]<refpoint>+w<width>[<unit>][/<height>[<unit>]][+j<justify>[+o<dx>[/<dy>]][+t] or <xmin>/<xmax>/<ymin>/<ymax>[+r][+t][+u] */
 		bool active;
 		struct GMT_MAP_INSET inset;
 	} D;

--- a/src/psbasemap.c
+++ b/src/psbasemap.c
@@ -41,7 +41,7 @@ struct PSBASEMAP_CTRL {
 		bool active;
 		char *file;
 	} A;
-	struct D {	/* -D[g|j|n|x]<refpoint>+w<width>[<unit>][/<height>[<unit>]][+j<justify>[+o<dx>[/<dy>]][+s<file>][+t] or [<unit>]<xmin>/<xmax>/<ymin>/<ymax>[r][+s<file>][+t] */
+	struct D {	/* -D[g|j|n|x]<refpoint>+w<width>[<unit>][/<height>[<unit>]][+j<justify>[+o<dx>[/<dy>]][+s<file>][+t] or <xmin>/<xmax>/<ymin>/<ymax>[+r][+s<file>][+t][+u<unit>] */
 		bool active;
 		struct GMT_MAP_INSET inset;
 	} D;


### PR DESCRIPTION
There was a mix of deprecated syntax and modern syntax in the comments in the sources as well as in the usage and RST docs. This closes #1383.
