### PR TITLE
fix typo of -D full in GMT_Tutorial*.rst

### DIFF
--- a/doc/rst/source/GMT_Tutorial.rst
+++ b/doc/rst/source/GMT_Tutorial.rst
@@ -423,7 +423,7 @@ to the common switches we may need to use some of several coast-specific options
   +========+================================================================================================+
   | **-A** | Exclude small features or those of high hierarchical levels (see Appendix K)                   |
   +--------+------------------------------------------------------------------------------------------------+
-  | **-D** | Select data resolution (**b**\ ull, **h**\ igh, **i**\ ntermediate, **l**\ ow, or **c**\ rude) |
+  | **-D** | Select data resolution (**f**\ ull, **h**\ igh, **i**\ ntermediate, **l**\ ow, or **c**\ rude) |
   +--------+------------------------------------------------------------------------------------------------+
   | **-G** | Set color of dry areas (default does not paint)                                                |
   +--------+------------------------------------------------------------------------------------------------+

--- a/doc/rst/source/GMT_Tutorial_classic.rst
+++ b/doc/rst/source/GMT_Tutorial_classic.rst
@@ -423,7 +423,7 @@ to the common switches we may need to use some of several pscoast-specific optio
   +========+================================================================================================+
   | **-A** | Exclude small features or those of high hierarchical levels (see Appendix K)                   |
   +--------+------------------------------------------------------------------------------------------------+
-  | **-D** | Select data resolution (**b**\ ull, **h**\ igh, **i**\ ntermediate, **l**\ ow, or **c**\ rude) |
+  | **-D** | Select data resolution (**f**\ ull, **h**\ igh, **i**\ ntermediate, **l**\ ow, or **c**\ rude) |
   +--------+------------------------------------------------------------------------------------------------+
   | **-G** | Set color of dry areas (default does not paint)                                                |
   +--------+------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->

Fixes typo of -D **f**ull, which was **b**ull, in `GMT_Tutorial.rst` and `GMT_Tutorial_classic.rst`.

**Reminders**

- [x] Correct base branch selected? `master` for new features, `6.0` for bug fixes
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
