### PR TITLE
subplot: Raise error message if row=nrow or col=ncol

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -11822,8 +11822,8 @@ struct GMT_SUBPLOT *gmt_subplot_info (struct GMTAPI_CTRL *API, int fig) {
 			fclose (fp);
 			return NULL;
 		}
-		if (row > P->nrows || col > P->ncolumns) {
-			GMT_Report (API, GMT_MSG_NORMAL, "Selected current panel (%d,%d) exceeds dimension of current subplot (%dx%d)]\n", row, col, P->nrows, P->ncolumns);
+		if (row >= P->nrows || col >= P->ncolumns) {
+			GMT_Report (API, GMT_MSG_NORMAL, "Selected current panel (%d,%d) exceeds dimension of current subplot (%dx%d)\n", row, col, P->nrows, P->ncolumns);
 			fclose (fp);
 			return NULL;
 		}


### PR DESCRIPTION
The old codes didn't raise an error message if we use `gmt subplot set 2,2` in a 2x2 layout.

Fixes #1039.
