### PR TITLE
Use points  for units in default -X -Y settings

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -848,13 +848,13 @@ fonts can be found in the :doc:`gmt` man page.
 
 **MAP_ORIGIN_X**
     (**-X**) Sets the x-coordinate of the origin on the paper for a
-    new plot [1i]. For an overlay, the default offset is 0.
+    new plot [72p]. For an overlay, the default offset is 0.
 
 .. _MAP_ORIGIN_Y:
 
 **MAP_ORIGIN_Y**
     (**-Y**) Sets the y-coordinate of the origin on the paper for a
-    new plot [1i]. For an overlay, the default offset is 0.
+    new plot [72p]. For an overlay, the default offset is 0.
 
 .. _MAP_POLAR_CAP:
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -5323,9 +5323,9 @@ void gmtinit_conf (struct GMT_CTRL *GMT) {
 	GMT->current.setting.map_logo_pos[GMT_X] = GMT->current.setting.map_logo_pos[GMT_Y] = -54 * pt;	/* -54p */
 	GMT->current.setting.given_unit[GMTCASE_MAP_LOGO_POS] = 'p';
 	/* MAP_ORIGIN_X, MAP_ORIGIN_Y */
-	GMT->current.setting.map_origin[GMT_X] = GMT->current.setting.map_origin[GMT_Y] = 1;	/* 1i */
-	GMT->current.setting.given_unit[GMTCASE_MAP_ORIGIN_X] = 'i';
-	GMT->current.setting.given_unit[GMTCASE_MAP_ORIGIN_Y] = 'i';
+	GMT->current.setting.map_origin[GMT_X] = GMT->current.setting.map_origin[GMT_Y] = 72 * pt;	/* 72p = 1i */
+	GMT->current.setting.given_unit[GMTCASE_MAP_ORIGIN_X] = 'p';
+	GMT->current.setting.given_unit[GMTCASE_MAP_ORIGIN_Y] = 'p';
 	/* MAP_POLAR_CAP */
 	GMT->current.setting.map_polar_cap[0] = 85;
 	GMT->current.setting.map_polar_cap[1] = 90;


### PR DESCRIPTION
It used to say 1 inch but all otther distance settings are given in points.  Now use 72p.
