### PR TITLE
Use correct index when checking for b and t axes in subplot

### DIFF
--- a/doc/rst/source/subplot.rst_
+++ b/doc/rst/source/subplot.rst_
@@ -25,6 +25,7 @@ Synopsis (begin mode)
 [ **-S**\ *layout* ]
 [ **-T**\ *title* ]
 [ |SYN_OPT-V| ]
+[ **-W**\ *pen* ]
 [ |SYN_OPT--| ]
 
 |No-spaces|
@@ -157,6 +158,11 @@ Optional Arguments
 
 .. |Add_-V| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-V.rst_
+
+.. _subplot_begin-W:
+
+**-W**\ *pen*
+    Draw horizontal and vertical lines between interior panels using selected pen [no lines].
 
 .. include:: explain_help.rst_
 

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -781,8 +781,8 @@ int GMT_subplot (void *V_API, int mode, void *args) {
 		 * but override if users have turned any of those sides off with b or t */
 
 		ny = 2;	/* Default is ticks on both S and N */
-		if (strchr (Ctrl->S[GMT_Y].axes, 'b')) ny--;	/* But not on the south (bottom) side */
-		if (strchr (Ctrl->S[GMT_Y].axes, 't')) ny--;	/* But not on the north (top) side */
+		if (strchr (Ctrl->S[GMT_X].axes, 'b')) ny--;	/* But not on the south (bottom) side */
+		if (strchr (Ctrl->S[GMT_X].axes, 't')) ny--;	/* But not on the north (top) side */
 		else y_header_off += tick_height;
 		fluff[GMT_Y] += (Ctrl->N.dim[GMT_Y] - 1) * ny * tick_height;
 		GMT_Report (API, GMT_MSG_DEBUG, "Subplot: After %d col ticks: fluff = {%g, %g}\n", ny, fluff[GMT_X], fluff[GMT_Y]);

--- a/test/subplot/tictactoe.ps
+++ b/test/subplot/tictactoe.ps
@@ -1,0 +1,38812 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_84cb819-dirty_2019.08.17 [64-bit] Document from psxy
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sat Aug 17 13:09:00 2019
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_completion {} def
+/PSL_movie_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R0/5.90551/0/5.90551 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 5.90551000 0.00000000 5.90551000 0.000 5.906 0.000 5.906 +xy
+%GMTBoundingBox: 72 72 425.197 425.197
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R0/6.90551/0/6.90551 -Jx1i -W1p,- @GMTAPI@-000000 --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 6.90551000 0.00000000 6.90551000 0.000 6.906 0.000 6.906 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+17 W
+[133 67] 0 B
+clipsave
+0 0 M
+8287 0 D
+0 8287 D
+-8287 0 D
+P
+PSL_clip N
+0 4724 M
+7087 0 D
+S
+0 2362 M
+7087 0 D
+S
+2362 0 M
+0 7087 D
+S
+4724 0 M
+0 7087 D
+S
+PSL_cliprestore
+[] 0 B
+%%EndObject
+PSL_completion /PSL_completion {} def
+0 A
+FQ
+O0
+0 4724 TM
+
+% PostScript produced by:
+%@GMT: gmt pscoast -Rg -JG30/30/1.9685i -Gred -Snavy -Bg -B+n -Xa0i -Ya3.937i
+%@PROJ: ortho 0.00000000 360.00000000 -90.00000000 90.00000000 -6371007.181 6371007.181 -6371007.181 6371007.181 +unavailable +a=6371007.181 +b=6371007.180918 +units=m +no_defs
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+{0 0 0.502 C} FS
+2362 1181 M
+-1 59 D
+-9 97 D
+-13 77 D
+-13 57 D
+-16 56 D
+-25 74 D
+-30 72 D
+-26 53 D
+-38 68 D
+-43 65 D
+-47 63 D
+-51 59 D
+-55 56 D
+-58 52 D
+-62 48 D
+-64 43 D
+-34 21 D
+-68 37 D
+-53 25 D
+-73 29 D
+-93 29 D
+-57 14 D
+-57 11 D
+-59 8 D
+-77 7 D
+-98 1 D
+-19 -1 D
+-20 -1 D
+-19 -2 D
+-20 -2 D
+-19 -2 D
+-20 -2 D
+-19 -3 D
+-19 -3 D
+-20 -3 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-18 -6 D
+-19 -6 D
+-18 -6 D
+-19 -6 D
+-18 -7 D
+-18 -7 D
+-18 -8 D
+-18 -7 D
+-18 -8 D
+-18 -9 D
+-35 -17 D
+-34 -19 D
+-34 -19 D
+-33 -21 D
+-48 -33 D
+-62 -48 D
+-58 -52 D
+-55 -56 D
+-51 -59 D
+-47 -63 D
+-32 -48 D
+-49 -85 D
+-34 -70 D
+-29 -73 D
+-29 -93 D
+-22 -95 D
+-11 -78 D
+-7 -77 D
+-1 -78 D
+3 -59 D
+7 -78 D
+13 -77 D
+23 -95 D
+31 -92 D
+30 -72 D
+35 -70 D
+50 -84 D
+45 -64 D
+49 -61 D
+53 -57 D
+42 -41 D
+59 -51 D
+63 -47 D
+32 -22 D
+101 -59 D
+71 -34 D
+72 -29 D
+93 -29 D
+95 -22 D
+78 -11 D
+78 -7 D
+78 -1 D
+39 1 D
+97 9 D
+77 13 D
+95 23 D
+92 31 D
+72 30 D
+53 26 D
+101 59 D
+80 57 D
+60 50 D
+42 40 D
+41 42 D
+51 59 D
+47 63 D
+22 32 D
+31 50 D
+37 69 D
+25 53 D
+29 72 D
+29 93 D
+14 57 D
+11 58 D
+8 58 D
+7 78 D
+P
+FO
+1147 2093 M
+-1 1 D
+-2 -5 D
+-6 1 D
+2 -6 D
+5 0 D
+-2 -8 D
+-5 7 D
+-3 -3 D
+-2 10 D
+-5 -16 D
+-2 13 D
+-5 -7 D
+-5 5 D
+7 3 D
+-13 -2 D
+1 -19 D
+12 7 D
+-1 -5 D
+5 3 D
+2 -4 D
+-17 -3 D
+0 -5 D
+14 1 D
+-11 -3 D
+4 -3 D
+-9 2 D
+4 -8 D
+5 -6 D
+17 24 D
+4 1 D
+-29 -125 D
+-68 9 D
+-64 15 D
+31 45 D
+36 48 D
+37 45 D
+28 31 D
+14 15 D
+5 4 D
+9 10 D
+5 4 D
+4 5 D
+33 30 D
+-26 -81 D
+P
+FO
+{1 0 0 C} FS
+-2 11 2 -5 2 1105 2072 SP
+1143 2076 M
+-5 7 D
+-3 -3 D
+-2 10 D
+-5 -16 D
+-2 13 D
+-5 -7 D
+-5 5 D
+7 3 D
+-13 -2 D
+1 -19 D
+12 7 D
+-1 -5 D
+5 3 D
+2 -4 D
+-17 -3 D
+0 -5 D
+14 1 D
+-11 -3 D
+4 -3 D
+-9 2 D
+4 -8 D
+5 -6 D
+17 24 D
+4 1 D
+P
+FO
+1 5 5 0 2 -6 -6 1 -2 -5 -1 1 6 1147 2093 SP
+-2 11 2 -5 2 1105 2072 SP
+{0 0 0.502 C} FS
+1173 1940 M
+-2 3 D
+11 -2 D
+6 6 D
+-14 7 D
+-8 -7 D
+5 9 D
+-6 2 D
+-4 -10 D
+-4 -2 D
+2 10 D
+-12 -14 D
+7 13 D
+-9 2 D
+-10 -15 D
+-1 0 D
+-11 6 D
+1 -6 D
+-13 1 D
+25 108 D
+4 17 D
+7 2 D
+-4 6 D
+2 8 D
+6 0 D
+-7 -4 D
+13 -4 D
+13 9 D
+-7 6 D
+-6 -3 D
+0 5 D
+-4 -7 D
+-6 7 D
+23 77 D
+11 34 D
+26 -82 D
+21 -78 D
+23 -101 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-12 0 D
+P
+FO
+{1 0 0 C} FS
+0 -6 8 2 -2 -9 -9 -1 -4 9 5 1155 2054 SP
+-6 -1 4 5 2 1143 2063 SP
+7 1 1 1173 2070 SP
+-4 2 1 1154 1956 SP
+6 2 1 1188 2087 SP
+-4 1 1 1132 1946 SP
+11 3 1 1126 1951 SP
+4 4 1 1133 1947 SP
+-1 0 1 1120 1943 SP
+5 0 1 -6 -11 6 3 1134 1942 SP
+1173 1940 M
+-2 3 D
+11 -2 D
+6 6 D
+-14 7 D
+-8 -7 D
+5 9 D
+-6 2 D
+-4 -10 D
+-4 -2 D
+2 10 D
+-12 -14 D
+7 13 D
+-9 2 D
+-10 -15 D
+P
+FO
+-1 -4 -6 7 -4 -7 0 5 -6 -3 -7 6 13 9 13 -4 -7 -4 6 0 10 1145 2084 SP
+-2 -4 -4 6 7 2 3 1140 2068 SP
+0 -6 8 2 -2 -9 -9 -1 -4 9 5 1155 2054 SP
+-6 -1 4 5 2 1143 2063 SP
+7 1 1 1173 2070 SP
+-4 2 1 1154 1956 SP
+6 2 1 1188 2087 SP
+-4 1 1 1132 1946 SP
+11 3 1 1126 1951 SP
+4 4 1 1133 1947 SP
+{0 0 0.502 C} FS
+1274 2111 M
+2 -2 D
+-1 0 D
+4 -5 D
+1 0 D
+44 -54 D
+-10 -16 D
+9 -6 D
+-6 -8 D
+9 -1 D
+-8 0 D
+-4 -7 D
+12 1 D
+-7 -6 D
+15 1 D
+-6 7 D
+7 0 D
+-7 2 D
+7 0 D
+-5 6 D
+5 -2 D
+-5 7 D
+6 0 D
+0 6 D
+24 -32 D
+11 -17 D
+11 -17 D
+-10 3 D
+3 -6 D
+-10 -3 D
+-11 -2 D
+-11 -3 D
+-11 -2 D
+-11 -2 D
+-12 -2 D
+-11 -2 D
+-12 -2 D
+-11 -1 D
+-12 -2 D
+-12 -1 D
+-20 89 D
+-30 112 D
+-20 60 D
+17 -15 D
+51 -50 D
+P
+FO
+{1 0 0 C} FS
+9 -11 9 3 5 -5 -7 -14 8 1 -5 -4 4 -4 -8 -3 -10 -1 3 10 -6 10 -25 13 22 5 13 1340 1969 SP
+-4 4 11 7 2 1240 2093 SP
+2 4 6 -3 2 1270 2102 SP
+-1 3 1 1260 2096 SP
+-4 0 1 1255 2092 SP
+10 0 1 1260 2107 SP
+1 4 1 1270 2097 SP
+-2 -4 1 1261 2114 SP
+4 1 4 1 3 -6 -10 3 4 1382 1968 SP
+1324 2050 M
+-10 -16 D
+9 -6 D
+-6 -8 D
+9 -1 D
+-8 0 D
+-4 -7 D
+12 1 D
+-7 -6 D
+15 1 D
+-6 7 D
+7 0 D
+-7 2 D
+7 0 D
+-5 6 D
+5 -2 D
+-5 7 D
+6 0 D
+0 6 D
+P
+FO
+-2 3 1 0 4 -5 -1 0 4 1276 2109 SP
+9 -11 9 3 5 -5 -7 -14 8 1 -5 -4 4 -4 -8 -3 -10 -1 3 10 -6 10 -25 13 22 5 13 1340 1969 SP
+-4 4 11 7 2 1240 2093 SP
+2 4 6 -3 2 1270 2102 SP
+-1 3 1 1260 2096 SP
+-4 0 1 1255 2092 SP
+10 0 1 1260 2107 SP
+1 4 1 1270 2097 SP
+-2 -4 1 1261 2114 SP
+{0 0 0.502 C} FS
+1455 1994 M
+-11 12 D
+-13 5 D
+-11 18 D
+-8 0 D
+-11 -4 D
+12 -20 D
+-3 -9 D
+13 -15 D
+-7 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-8 -2 D
+-2 0 D
+-15 23 D
+-23 32 D
+-8 11 D
+1 9 D
+19 21 D
+-9 9 D
+-7 -13 D
+-14 -5 D
+-2 -5 D
+-44 54 D
+1 7 D
+-5 -2 D
+-2 2 D
+3 3 D
+-3 -3 D
+-34 37 D
+-50 49 D
+-9 7 D
+64 -29 D
+91 -51 D
+70 -46 D
+41 -30 D
+13 -11 D
+-11 0 D
+-2 -4 D
+8 -3 D
+-10 -4 D
+26 -6 D
+-15 -3 D
+-29 18 D
+10 -8 D
+1 -14 D
+17 -8 D
+7 -8 D
+P
+FO
+{1 0 0 C} FS
+5 -5 -5 -3 -3 5 3 1406 2030 SP
+0 8 1 1285 2110 SP
+6 -2 1 1442 2046 SP
+3 2 1 1421 2035 SP
+1 -1 -2 0 2 1384 1968 SP
+6 3 7 2 6 3 7 2 13 -15 -3 -9 12 -20 -11 -4 -8 0 -11 18 -13 5 -11 12 12 1455 1994 SP
+1460 2037 M
+-11 0 D
+-2 -4 D
+8 -3 D
+-10 -4 D
+26 -6 D
+-15 -3 D
+-29 18 D
+10 -8 D
+1 -14 D
+17 -8 D
+7 -8 D
+29 15 D
+P
+FO
+3 3 1 1274 2111 SP
+2 -2 -5 -2 1 7 3 1280 2104 SP
+4 -6 4 -5 -2 -5 -14 -5 -7 -13 -9 9 19 21 1 9 8 1336 2034 SP
+5 -5 -5 -3 -3 5 3 1406 2030 SP
+0 8 1 1285 2110 SP
+6 -2 1 1442 2046 SP
+3 2 1 1421 2035 SP
+{0 0 0.502 C} FS
+1 -1 0 1 2 1523 2035 SP
+1503 2020 M
+-4 1 D
+-11 11 D
+3 -7 D
+-13 17 D
+-7 -5 D
+-11 0 D
+-27 21 D
+-55 39 D
+-56 35 D
+-77 43 D
+-64 29 D
+58 -12 D
+81 -21 D
+57 -19 D
+-6 0 D
+3 -4 D
+-6 3 D
+4 -13 D
+15 1 D
+8 7 D
+46 -18 D
+-2 -2 D
+10 -1 D
+-6 -1 D
+2 -11 D
+-5 4 D
+-6 -7 D
+3 -3 D
+3 3 D
+-5 -23 D
+9 -5 D
+-7 0 D
+21 -7 D
+-19 -19 D
+19 -12 D
+23 -2 D
+25 -20 D
+P
+FO
+2 -1 -1 3 -3 -1 3 1481 2111 SP
+-1 3 0 -2 2 1533 2087 SP
+{1 0 0 C} FS
+13 -14 -15 0 -7 5 1 7 4 1365 2143 SP
+8 -2 -8 -4 -2 4 3 1369 2139 SP
+-3 3 1 1424 2123 SP
+-5 4 1 1419 2077 SP
+{0 0 0.502 C} FS
+3 2 1 1516 2092 SP
+{1 0 0 C} FS
+4 3 4 3 8 -7 8 -6 7 -6 8 -6 -11 0 -7 -5 -13 17 3 -7 -11 11 -4 1 12 1503 2020 SP
+1523 2035 M
+0 1 D
+1 -1 D
+29 28 D
+8 10 D
+-28 14 D
+0 -2 D
+-1 3 D
+-38 18 D
+-13 5 D
+-3 -1 D
+-1 3 D
+-36 15 D
+-2 -2 D
+10 -1 D
+-6 -1 D
+2 -11 D
+-5 4 D
+-6 -7 D
+3 -3 D
+3 3 D
+-5 -23 D
+9 -5 D
+-7 0 D
+21 -7 D
+-19 -19 D
+19 -12 D
+23 -2 D
+25 -20 D
+P
+FO
+-9 3 8 7 15 1 4 -13 -6 3 3 -4 -6 0 7 1377 2152 SP
+13 -14 -15 0 -7 5 1 7 4 1365 2143 SP
+8 -2 -8 -4 -2 4 3 1369 2139 SP
+-3 3 1 1424 2123 SP
+-5 4 1 1419 2077 SP
+{0 0 0.502 C} FS
+3 2 1 1516 2092 SP
+3 -10 -9 0 10 0 10 -16 -13 25 5 1532 2088 SP
+-2 1 -2 -1 -9 2 12 -4 -7 -2 4 -4 2 -10 8 2 -6 2 1 9 12 -1 -11 3 0 2 13 1477 2113 SP
+1395 2146 M
+-75 25 D
+-106 27 D
+-33 6 D
+74 -2 D
+83 -7 D
+82 -12 D
+90 -19 D
+17 -5 D
+-5 -3 D
+-6 3 D
+-4 -9 D
+8 -9 D
+-16 3 D
+6 -3 D
+-8 0 D
+0 -5 D
+6 -3 D
+1 4 D
+4 -17 D
+7 -6 D
+-15 11 D
+-24 28 D
+-14 1 D
+7 1 D
+-5 3 D
+-21 -2 D
+1 -12 D
+-7 5 D
+-7 -7 D
+-3 7 D
+-9 -3 D
+8 -10 D
+12 -5 D
+-2 -3 D
+P
+FO
+{1 0 0 C} FS
+-12 4 6 -5 -15 1 -3 14 4 1412 2140 SP
+-6 3 7 1 2 1496 2144 SP
+1527 2159 M
+-5 -3 D
+-6 3 D
+-4 -9 D
+8 -9 D
+-16 3 D
+6 -3 D
+-8 0 D
+0 -5 D
+6 -3 D
+1 4 D
+4 -17 D
+7 -6 D
+-15 11 D
+-24 28 D
+-14 1 D
+7 1 D
+-5 3 D
+-21 -2 D
+1 -12 D
+-7 5 D
+-7 -7 D
+-3 7 D
+-9 -3 D
+8 -10 D
+12 -5 D
+-2 -3 D
+36 -15 D
+0 2 D
+-11 3 D
+12 -1 D
+1 9 D
+-6 2 D
+8 2 D
+2 -10 D
+4 -4 D
+-7 -2 D
+12 -4 D
+-9 2 D
+-2 -1 D
+51 -23 D
+-13 25 D
+10 -16 D
+10 0 D
+-9 0 D
+3 -10 D
+28 -14 D
+16 28 D
+7 24 D
+1 17 D
+-46 14 D
+P
+FO
+9 -3 -1 0 -17 6 3 1395 2146 SP
+-12 4 6 -5 -15 1 -3 14 4 1412 2140 SP
+-6 3 7 1 2 1496 2144 SP
+{0 0 0.502 C} FS
+8 -8 11 -1 -11 1 -8 8 -9 4 5 1583 2161 SP
+1454 2222 M
+-6 -2 D
+14 -5 D
+13 1 D
+-4 5 D
+28 -3 D
+-1 1 D
+19 -2 D
+4 -3 D
+-2 3 D
+8 -3 D
+7 1 D
+2 -5 D
+9 -3 D
+-6 -4 D
+8 -7 D
+-9 -2 D
+26 -10 D
+-23 -3 D
+-4 4 D
+-5 -2 D
+-4 3 D
+-10 0 D
+1 -7 D
+-9 -3 D
+19 -9 D
+-2 -8 D
+-80 19 D
+-73 12 D
+-73 9 D
+-101 5 D
+-10 0 D
+-9 0 D
+86 13 D
+85 6 D
+60 1 D
+P
+FO
+{1 0 0 C} FS
+-8 0 1 1467 2212 SP
+-2 3 1 1539 2206 SP
+{0 0 0.502 C} FS
+-16 -6 -20 9 21 -9 3 1544 2166 SP
+{1 0 0 C} FS
+1583 2161 M
+-9 4 D
+-8 8 D
+-11 1 D
+11 -1 D
+8 -8 D
+9 -4 D
+-4 17 D
+-11 23 D
+-7 10 D
+-27 4 D
+2 -5 D
+9 -3 D
+-6 -4 D
+8 -7 D
+-9 -2 D
+26 -10 D
+-23 -3 D
+-4 4 D
+-5 -2 D
+-4 3 D
+-10 0 D
+1 -7 D
+-9 -3 D
+19 -9 D
+-2 -8 D
+47 -13 D
+11 -4 D
+-1 14 D
+P
+FO
+-6 1 6 1 7 -3 3 1520 2217 SP
+-2 3 4 -3 2 1517 2217 SP
+-1 1 2 -1 2 1497 2219 SP
+-9 1 -4 5 13 1 14 -5 -6 -2 5 1454 2222 SP
+-8 0 1 1467 2212 SP
+-2 3 1 1539 2206 SP
+{0 0 0.502 C} FS
+-16 -6 -20 9 21 -9 3 1544 2166 SP
+24 -9 1 0 -24 9 -6 1 4 1540 2235 SP
+1 0 1 1533 2215 SP
+1 0 1 1519 2217 SP
+1498 2219 M
+-3 8 D
+-6 2 D
+-5 -4 D
+13 -6 D
+-26 2 D
+-8 9 D
+-13 -2 D
+11 2 D
+-13 5 D
+-4 -9 D
+12 -3 D
+-2 -1 D
+-76 2 D
+-9 -1 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-9 -1 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-9 0 D
+-9 -1 D
+-8 -1 D
+-9 -2 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-9 -2 D
+-9 -1 D
+-8 -2 D
+-9 -1 D
+57 22 D
+65 20 D
+63 14 D
+35 6 D
+55 5 D
+34 1 D
+-8 -3 D
+9 -8 D
+17 -9 D
+-2 -10 D
+-8 3 D
+-1 -4 D
+3 -4 D
+19 -6 D
+-13 2 D
+6 1 D
+-11 3 D
+8 -8 D
+-9 8 D
+6 -16 D
+5 0 D
+6 -4 D
+P
+FO
+{1 0 0 C} FS
+3 -11 -12 5 0 4 3 1453 2239 SP
+-3 -2 1 1485 2223 SP
+1540 2235 M
+-6 1 D
+-24 9 D
+30 -10 D
+-29 24 D
+-21 13 D
+-8 -3 D
+9 -8 D
+17 -9 D
+-2 -10 D
+-8 3 D
+-1 -4 D
+3 -4 D
+19 -6 D
+-13 2 D
+6 1 D
+-11 3 D
+8 -8 D
+-9 8 D
+6 -16 D
+5 0 D
+6 -4 D
+44 -6 D
+-17 20 D
+P
+FO
+8 0 -2 -1 12 -3 -4 -9 -13 5 11 2 -13 -2 -8 9 8 1471 2221 SP
+13 -6 -5 -4 -6 2 -3 8 4 1498 2219 SP
+3 -11 -12 5 0 4 3 1453 2239 SP
+-3 -2 1 1485 2223 SP
+{0 0 0.502 C} FS
+1433 2300 M
+36 -16 D
+21 -12 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+27 23 D
+64 44 D
+45 23 D
+35 14 D
+17 6 D
+12 -1 D
+-7 2 D
+9 2 D
+34 -11 D
+P
+FO
+{1 0 0 C} FS
+1 0 1 1490 2272 SP
+-2 1 2 0 3 -2 3 1433 2300 SP
+-2 -1 -7 2 12 -1 3 1369 2314 SP
+{0 0 0.502 C} FS
+1374 2315 M
+-18 3 D
+13 -4 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -4 D
+-9 -4 D
+-18 -9 D
+-18 -9 D
+-18 -11 D
+-27 -18 D
+-28 -20 D
+-27 -23 D
+25 64 D
+22 42 D
+16 23 D
+6 7 D
+0 -1 D
+18 1 D
+64 -10 D
+51 -13 D
+-4 -1 D
+P
+FO
+{1 0 0 C} FS
+-3 0 1 1268 2339 SP
+-6 0 -5 1 -6 0 5 1 13 0 0 -1 6 1250 2340 SP
+3 0 3 0 10 -4 -18 3 4 1374 2315 SP
+-3 0 1 1268 2339 SP
+{0 0 0.502 C} FS
+1129 2343 M
+5 -1 D
+55 1 D
+10 -1 D
+-3 -1 D
+14 0 D
+5 -2 D
+7 1 D
+-4 -1 D
+6 -1 D
+26 2 D
+-19 -25 D
+-15 -27 D
+-19 -42 D
+-16 -42 D
+-19 51 D
+-13 28 D
+-19 34 D
+-16 21 D
+-3 3 D
+P
+FO
+-9 1 4 -1 2 1206 2342 SP
+{1 0 0 C} FS
+1129 2343 M
+5 -1 D
+55 1 D
+10 -1 D
+-3 -1 D
+14 0 D
+5 -2 D
+7 1 D
+-4 -1 D
+6 -1 D
+26 2 D
+1 1 D
+-55 3 D
+-11 0 D
+-11 0 D
+-12 0 D
+-11 0 D
+-11 -1 D
+P
+FO
+{0 0 0.502 C} FS
+-9 1 4 -1 2 1206 2342 SP
+1007 2325 M
+2 -1 D
+0 1 D
+13 3 D
+12 0 D
+-7 0 D
+3 2 D
+13 2 D
+-1 -1 D
+16 4 D
+53 6 D
+9 -10 D
+16 -24 D
+16 -31 D
+16 -37 D
+13 -35 D
+-53 42 D
+-45 29 D
+-35 18 D
+1 8 D
+-5 -4 D
+-18 5 D
+-6 3 D
+11 0 D
+14 5 D
+-10 1 D
+-3 10 D
+-6 -2 D
+-18 0 D
+-11 -5 D
+3 -1 D
+0 -1 D
+-21 5 D
+P
+FO
+{1 0 0 C} FS
+-2 -1 5 2 -1 -1 3 1043 2332 SP
+-4 -1 3 2 -7 0 12 0 4 1022 2328 SP
+0 1 2 -1 2 1007 2325 SP
+5 -2 5 -2 5 -2 0 -1 3 -1 -11 -5 -18 0 -6 -2 -3 10 -10 1 14 5 11 0 12 1020 2305 SP
+4 -2 3 -2 -6 1 -5 -4 1 8 5 1048 2293 SP
+{0 0 0.502 C} FS
+876 2275 M
+31 8 D
+29 -1 D
+13 2 D
+4 4 D
+-23 2 D
+28 1 D
+4 2 D
+-11 -1 D
+6 2 D
+-2 1 D
+5 2 D
+1 -3 D
+11 3 D
+4 4 D
+9 -2 D
+11 9 D
+-5 3 D
+-8 -2 D
+0 2 D
+-16 -6 D
+13 7 D
+-8 0 D
+-21 -8 D
+-18 -4 D
+31 12 D
+-1 0 D
+16 5 D
+21 -5 D
+-9 -12 D
+18 1 D
+5 3 D
+6 1 D
+18 -7 D
+-2 0 D
+2 -7 D
+-9 1 D
+5 -6 D
+7 1 D
+7 3 D
+0 3 D
+35 -18 D
+53 -35 D
+45 -36 D
+-69 26 D
+-48 15 D
+-62 14 D
+26 5 D
+-9 2 D
+-6 -3 D
+-3 4 D
+-3 -3 D
+-13 -4 D
+-25 4 D
+4 2 D
+-12 0 D
+14 2 D
+-13 0 D
+4 4 D
+-9 -6 D
+-1 0 D
+-1 2 D
+-8 -1 D
+-18 2 D
+3 2 D
+-8 0 D
+6 2 D
+-10 -3 D
+-2 0 D
+-2 0 D
+-2 1 D
+13 4 D
+-4 2 D
+-27 -6 D
+-24 1 D
+P
+FO
+{1 0 0 C} FS
+1008 2295 M
+-1 -4 D
+-5 1 D
+-10 -5 D
+8 7 D
+-13 -2 D
+-6 -8 D
+-12 -5 D
+10 -3 D
+7 1 D
+-5 2 D
+6 1 D
+18 -1 D
+-1 3 D
+-18 1 D
+10 4 D
+27 1 D
+1 3 D
+-6 -2 D
+5 4 D
+-8 -2 D
+7 4 D
+-8 -3 D
+6 5 D
+P
+FO
+-9 -3 -5 2 11 4 3 1022 2276 SP
+-15 -3 -1 2 10 4 6 -2 4 937 2281 SP
+8 0 -10 -5 2 1037 2278 SP
+2 4 3 -2 2 1027 2296 SP
+-13 0 8 1 2 999 2270 SP
+-5 -1 1 885 2274 SP
+6 0 1 962 2275 SP
+-2 -3 1 977 2273 SP
+-7 0 1 985 2271 SP
+-5 1 6 -1 2 1033 2282 SP
+6 2 1 992 2263 SP
+1 1 1 1024 2286 SP
+2 3 1 968 2269 SP
+4 2 1 971 2271 SP
+{0 0 0.502 C} FS
+-5 0 1 918 2287 SP
+-5 -2 1 911 2292 SP
+5 2 1 913 2293 SP
+{1 0 0 C} FS
+876 2275 M
+31 8 D
+29 -1 D
+13 2 D
+4 4 D
+-23 2 D
+28 1 D
+4 2 D
+-11 -1 D
+6 2 D
+-2 1 D
+5 2 D
+1 -3 D
+11 3 D
+4 4 D
+9 -2 D
+11 9 D
+-5 3 D
+-8 -2 D
+0 2 D
+-16 -6 D
+13 7 D
+-8 0 D
+-21 -8 D
+-18 -4 D
+31 12 D
+-1 0 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-16 -8 D
+P
+FO
+6 0 7 0 -27 -6 -4 2 13 4 -2 1 6 916 2270 SP
+5 0 -10 -3 6 2 -8 0 3 2 5 929 2269 SP
+4 0 -8 -1 -1 2 3 956 2266 SP
+2 0 -9 -6 4 4 -13 0 14 2 5 961 2266 SP
+4 -1 -12 0 4 2 3 969 2264 SP
+4 0 -13 -4 -3 -3 -3 4 -6 -3 -9 2 21 5 5 0 8 1002 2259 SP
+-4 2 -3 1 0 3 7 3 7 1 5 -6 -9 1 2 -7 -2 0 9 1038 2298 SP
+-5 2 -5 2 -5 1 6 1 5 3 18 1 -9 -12 7 1000 2312 SP
+1008 2295 M
+-1 -4 D
+-5 1 D
+-10 -5 D
+8 7 D
+-13 -2 D
+-6 -8 D
+-12 -5 D
+10 -3 D
+7 1 D
+-5 2 D
+6 1 D
+18 -1 D
+-1 3 D
+-18 1 D
+10 4 D
+27 1 D
+1 3 D
+-6 -2 D
+5 4 D
+-8 -2 D
+7 4 D
+-8 -3 D
+6 5 D
+P
+FO
+-9 -3 -5 2 11 4 3 1022 2276 SP
+-15 -3 -1 2 10 4 6 -2 4 937 2281 SP
+8 0 -10 -5 2 1037 2278 SP
+2 4 3 -2 2 1027 2296 SP
+-13 0 8 1 2 999 2270 SP
+-5 -1 1 885 2274 SP
+6 0 1 962 2275 SP
+-2 -3 1 977 2273 SP
+-7 0 1 985 2271 SP
+-5 1 6 -1 2 1033 2282 SP
+6 2 1 992 2263 SP
+1 1 1 1024 2286 SP
+2 3 1 968 2269 SP
+4 2 1 971 2271 SP
+{0 0 0.502 C} FS
+-5 0 1 918 2287 SP
+-5 -2 1 911 2292 SP
+5 2 1 913 2293 SP
+1 2 -6 -5 3 1 3 805 2216 SP
+-9 -4 8 4 2 807 2218 SP
+820 2232 M
+4 3 D
+-4 -3 D
+16 15 D
+5 4 D
+3 0 D
+-4 -3 D
+40 9 D
+-10 6 D
+-5 -2 D
+-10 0 D
+17 11 D
+24 -1 D
+-8 -1 D
+-3 -3 D
+8 0 D
+-4 0 D
+-3 -3 D
+14 -2 D
+11 5 D
+6 -5 D
+12 7 D
+18 -2 D
+-7 -4 D
+4 -2 D
+24 0 D
+-3 2 D
+4 1 D
+25 -4 D
+-5 -1 D
+20 -1 D
+75 -19 D
+62 -21 D
+35 -14 D
+-69 11 D
+-69 6 D
+-1 3 D
+-14 -1 D
+13 5 D
+-3 3 D
+-9 -3 D
+9 4 D
+-2 6 D
+-5 -3 D
+-3 2 D
+-2 -4 D
+-5 4 D
+-2 -8 D
+0 8 D
+-9 -2 D
+4 -9 D
+-3 5 D
+-4 2 D
+1 -5 D
+-2 -2 D
+-3 2 D
+-1 -3 D
+2 -2 D
+-2 0 D
+-2 0 D
+-1 6 D
+-18 -4 D
+17 5 D
+5 4 D
+-28 -4 D
+2 2 D
+-5 -6 D
+-1 4 D
+-6 -2 D
+11 5 D
+-1 3 D
+-10 2 D
+2 -3 D
+-6 -1 D
+8 -2 D
+-20 1 D
+6 -5 D
+-10 5 D
+17 7 D
+-15 -3 D
+-4 7 D
+-6 -2 D
+6 -1 D
+-9 -1 D
+5 -1 D
+-7 -1 D
+5 -1 D
+-9 -2 D
+5 -3 D
+-7 -2 D
+7 0 D
+-9 -2 D
+9 1 D
+-16 -4 D
+1 -2 D
+-7 -1 D
+-7 0 D
+8 4 D
+2 11 D
+11 5 D
+-4 1 D
+13 2 D
+0 3 D
+1 -3 D
+7 3 D
+-6 -5 D
+9 5 D
+2 -2 D
+2 6 D
+10 0 D
+9 5 D
+-16 -1 D
+-4 -5 D
+-26 -1 D
+-14 -4 D
+3 -4 D
+-10 -2 D
+-8 -10 D
+6 0 D
+-12 -5 D
+3 -4 D
+-7 0 D
+-7 -1 D
+-6 0 D
+2 2 D
+-15 -3 D
+-6 -1 D
+-6 -1 D
+-7 2 D
+14 -1 D
+21 6 D
+1 9 D
+-9 -4 D
+5 5 D
+-9 -5 D
+7 5 D
+-20 -5 D
+8 3 D
+-2 2 D
+-12 -5 D
+-11 0 D
+5 1 D
+12 13 D
+-12 -3 D
+-8 -3 D
+0 -4 D
+-10 -3 D
+-1 -1 D
+1 2 D
+P
+FO
+2 0 -3 1 -1 -1 3 920 2270 SP
+0 1 -1 -1 2 957 2266 SP
+-1 0 1 961 2266 SP
+-3 0 -7 -5 9 1 5 4 4 933 2223 SP
+-2 0 3 0 2 1 3 893 2221 SP
+5 4 1 812 2213 SP
+{1 0 0 C} FS
+995 2249 M
+-13 -4 D
+1 3 D
+-7 -2 D
+-6 -4 D
+9 0 D
+-10 -1 D
+13 -3 D
+-7 0 D
+7 -6 D
+7 1 D
+2 3 D
+16 -1 D
+-5 2 D
+31 4 D
+-5 5 D
+-9 -2 D
+3 5 D
+-10 -3 D
+7 3 D
+-4 1 D
+-7 -3 D
+-7 2 D
+-10 -7 D
+P
+FO
+-14 -9 -27 2 -4 6 6 5 15 -3 13 1 15 4 7 838 2230 SP
+17 12 14 -5 -8 -6 8 2 2 -4 5 882 2259 SP
+-13 2 15 4 5 -3 3 981 2254 SP
+-10 -5 4 4 2 973 2251 SP
+18 1 -15 -6 2 936 2260 SP
+-9 -1 4 2 2 960 2244 SP
+4 4 1 924 2264 SP
+9 0 1 1017 2254 SP
+6 -1 1 942 2245 SP
+4 0 1 941 2255 SP
+1 2 1 942 2258 SP
+{0 0 0.502 C} FS
+-5 -2 1 907 2268 SP
+-4 -3 1 808 2215 SP
+-1 3 1 829 2229 SP
+{1 0 0 C} FS
+-5 -3 -5 -3 -10 0 -5 -2 -10 6 40 9 -4 -3 3 0 8 841 2251 SP
+4 3 1 820 2232 SP
+807 2218 M
+8 4 D
+-9 -4 D
+-1 -2 D
+3 1 D
+-6 -5 D
+0 -1 D
+10 2 D
+5 4 D
+-5 -4 D
+33 4 D
+-7 2 D
+14 -1 D
+21 6 D
+1 9 D
+-9 -4 D
+5 5 D
+-9 -5 D
+7 5 D
+-20 -5 D
+8 3 D
+-2 2 D
+-12 -5 D
+-11 0 D
+5 1 D
+12 13 D
+-12 -3 D
+-8 -3 D
+0 -4 D
+-10 -3 D
+-5 -4 D
+P
+FO
+7 1 -1 -1 -15 -3 2 2 4 870 2220 SP
+893 2221 M
+11 1 D
+8 4 D
+2 11 D
+11 5 D
+-4 1 D
+13 2 D
+0 3 D
+1 -3 D
+7 3 D
+-6 -5 D
+9 5 D
+2 -2 D
+2 6 D
+10 0 D
+9 5 D
+-16 -1 D
+-4 -5 D
+-26 -1 D
+-14 -4 D
+3 -4 D
+-10 -2 D
+-8 -10 D
+6 0 D
+-12 -5 D
+3 -4 D
+P
+FO
+933 2223 M
+5 4 D
+9 1 D
+-7 -5 D
+48 1 D
+12 -1 D
+-1 6 D
+-18 -4 D
+17 5 D
+5 4 D
+-28 -4 D
+2 2 D
+-5 -6 D
+-1 4 D
+-6 -2 D
+11 5 D
+-1 3 D
+-10 2 D
+2 -3 D
+-6 -1 D
+8 -2 D
+-20 1 D
+6 -5 D
+-10 5 D
+17 7 D
+-15 -3 D
+-4 7 D
+-6 -2 D
+6 -1 D
+-9 -1 D
+5 -1 D
+-7 -1 D
+5 -1 D
+-9 -2 D
+5 -3 D
+-7 -2 D
+7 0 D
+-9 -2 D
+9 1 D
+-16 -4 D
+1 -2 D
+P
+FO
+1043 2221 M
+-1 3 D
+-14 -1 D
+13 5 D
+-3 3 D
+-9 -3 D
+9 4 D
+-2 6 D
+-5 -3 D
+-3 2 D
+-2 -4 D
+-5 4 D
+-2 -8 D
+0 8 D
+-9 -2 D
+4 -9 D
+-3 5 D
+-4 2 D
+1 -5 D
+-2 -2 D
+-3 2 D
+-1 -3 D
+2 -2 D
+P
+FO
+-4 1 13 0 -5 -1 3 994 2260 SP
+961 2266 M
+-1 0 D
+1 0 D
+-2 0 D
+-2 0 D
+-1 -1 D
+0 1 D
+-9 1 D
+-7 -4 D
+4 -2 D
+24 0 D
+-3 2 D
+4 1 D
+P
+FO
+920 2270 M
+-1 -1 D
+-16 2 D
+-7 0 D
+-8 -1 D
+-3 -3 D
+8 0 D
+-4 0 D
+-3 -3 D
+14 -2 D
+11 5 D
+6 -5 D
+12 7 D
+P
+FO
+995 2249 M
+-13 -4 D
+1 3 D
+-7 -2 D
+-6 -4 D
+9 0 D
+-10 -1 D
+13 -3 D
+-7 0 D
+7 -6 D
+7 1 D
+2 3 D
+16 -1 D
+-5 2 D
+31 4 D
+-5 5 D
+-9 -2 D
+3 5 D
+-10 -3 D
+7 3 D
+-4 1 D
+-7 -3 D
+-7 2 D
+-10 -7 D
+P
+FO
+-14 -9 -27 2 -4 6 6 5 15 -3 13 1 15 4 7 838 2230 SP
+17 12 14 -5 -8 -6 8 2 2 -4 5 882 2259 SP
+-13 2 15 4 5 -3 3 981 2254 SP
+-10 -5 4 4 2 973 2251 SP
+18 1 -15 -6 2 936 2260 SP
+-9 -1 4 2 2 960 2244 SP
+4 4 1 924 2264 SP
+9 0 1 1017 2254 SP
+6 -1 1 942 2245 SP
+4 0 1 941 2255 SP
+1 2 1 942 2258 SP
+{0 0 0.502 C} FS
+-5 -2 1 907 2268 SP
+-4 -3 1 808 2215 SP
+-1 3 1 829 2229 SP
+780 2168 M
+7 4 D
+-5 2 D
+4 0 D
+-2 4 D
+7 -4 D
+7 5 D
+-5 2 D
+7 0 D
+-14 2 D
+9 1 D
+-1 2 D
+10 -2 D
+-6 5 D
+11 -3 D
+9 6 D
+-9 2 D
+13 2 D
+-9 3 D
+8 0 D
+2 2 D
+5 -2 D
+0 6 D
+10 -2 D
+9 8 D
+-4 2 D
+-8 -5 D
+5 5 D
+-11 -4 D
+18 8 D
+-2 0 D
+11 1 D
+-6 -2 D
+-3 -9 D
+15 5 D
+8 8 D
+20 1 D
+1 -1 D
+7 2 D
+4 -1 D
+16 2 D
+1 -4 D
+9 0 D
+5 4 D
+7 0 D
+-5 -2 D
+12 -1 D
+-3 -5 D
+6 2 D
+0 -3 D
+6 3 D
+-1 -4 D
+14 9 D
+-6 -9 D
+11 7 D
+-2 -9 D
+8 3 D
+-5 -6 D
+6 -1 D
+4 4 D
+-2 -4 D
+8 1 D
+-5 -2 D
+19 -6 D
+-4 8 D
+7 -5 D
+5 4 D
+-3 -5 D
+7 -5 D
+7 -1 D
+10 5 D
+-3 6 D
+6 -3 D
+9 13 D
+-3 4 D
+54 -5 D
+30 -3 D
+54 -9 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-2 0 D
+-1 0 D
+-2 2 D
+-16 -2 D
+5 3 D
+-10 -1 D
+8 2 D
+-14 4 D
+-6 -1 D
+0 -5 D
+-20 1 D
+0 6 D
+-14 7 D
+-17 -10 D
+1 -6 D
+-7 -1 D
+2 6 D
+-5 -6 D
+3 11 D
+-10 -9 D
+-4 4 D
+-8 -4 D
+-5 -6 D
+8 3 D
+-6 -5 D
+6 -4 D
+-4 -6 D
+-7 -4 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+P
+FO
+1 1 -15 -5 5 -1 8 3 4 799 2208 SP
+-3 -2 1 812 2213 SP
+2 0 -1 5 -3 -3 -9 3 9 -5 5 1004 2223 SP
+{1 0 0 C} FS
+2 -2 1 802 2188 SP
+2 2 1 927 2202 SP
+4 0 1 909 2220 SP
+{0 0 0.502 C} FS
+-4 5 1 1018 2207 SP
+-3 3 1 792 2178 SP
+{1 0 0 C} FS
+799 2208 M
+8 3 D
+5 -1 D
+-15 -5 D
+-11 -20 D
+-4 -11 D
+4 0 D
+-2 4 D
+7 -4 D
+7 5 D
+-5 2 D
+7 0 D
+-14 2 D
+9 1 D
+-1 2 D
+10 -2 D
+-6 5 D
+11 -3 D
+9 6 D
+-9 2 D
+13 2 D
+-9 3 D
+8 0 D
+2 2 D
+5 -2 D
+0 6 D
+10 -2 D
+9 8 D
+-4 2 D
+-8 -5 D
+5 5 D
+-11 -4 D
+18 8 D
+-2 0 D
+-11 -1 D
+-11 -2 D
+-11 -1 D
+-3 -2 D
+3 2 D
+-5 -1 D
+-5 -1 D
+-2 -1 D
+P
+FO
+-1 -3 -5 2 7 4 3 780 2168 SP
+1014 2194 M
+-2 2 D
+-16 -2 D
+5 3 D
+-10 -1 D
+8 2 D
+-14 4 D
+-6 -1 D
+0 -5 D
+-20 1 D
+0 6 D
+-14 7 D
+-17 -10 D
+1 -6 D
+-7 -1 D
+2 6 D
+-5 -6 D
+3 11 D
+-10 -9 D
+-4 4 D
+-8 -4 D
+-5 -6 D
+8 3 D
+-6 -5 D
+6 -4 D
+-4 -6 D
+-7 -4 D
+68 13 D
+P
+FO
+1004 2223 M
+9 -5 D
+-9 3 D
+-3 -3 D
+-1 5 D
+-48 1 D
+-12 -1 D
+-5 -2 D
+12 -1 D
+-3 -5 D
+6 2 D
+0 -3 D
+6 3 D
+-1 -4 D
+14 9 D
+-6 -9 D
+11 7 D
+-2 -9 D
+8 3 D
+-5 -6 D
+6 -1 D
+4 4 D
+-2 -4 D
+8 1 D
+-5 -2 D
+19 -6 D
+-4 8 D
+7 -5 D
+5 4 D
+-3 -5 D
+7 -5 D
+7 -1 D
+10 5 D
+-3 6 D
+6 -3 D
+9 13 D
+-3 4 D
+P
+FO
+-8 0 5 4 9 0 1 -4 4 918 2223 SP
+-3 0 2 1 4 -1 3 898 2222 SP
+-2 0 2 1 1 -1 3 890 2221 SP
+-7 -1 8 8 15 5 -3 -9 -6 -2 5 856 2218 SP
+2 -2 1 802 2188 SP
+2 2 1 927 2202 SP
+4 0 1 909 2220 SP
+{0 0 0.502 C} FS
+-4 5 1 1018 2207 SP
+-3 3 1 792 2178 SP
+780 2117 M
+4 3 D
+-1 6 D
+-4 -2 D
+-2 18 D
+72 21 D
+43 10 D
+-25 -17 D
+-9 1 D
+4 -2 D
+-24 -8 D
+-11 -8 D
+-1 4 D
+-1 -4 D
+-9 -1 D
+7 0 D
+-12 1 D
+-4 -8 D
+18 5 D
+-12 -5 D
+2 -5 D
+-7 2 D
+2 -5 D
+-7 1 D
+4 -2 D
+-5 1 D
+0 -5 D
+-1 4 D
+-12 -10 D
+6 11 D
+-3 5 D
+-10 -12 D
+2 -8 D
+-1 0 D
+P
+FO
+1 0 0 1 11 5 -14 -6 4 1017 2194 SP
+1041 2170 M
+7 8 D
+-8 0 D
+-1 -6 D
+-6 -3 D
+4 10 D
+-9 -7 D
+-1 3 D
+-10 -3 D
+12 12 D
+-18 -5 D
+6 6 D
+-8 0 D
+15 3 D
+-7 6 D
+57 6 D
+91 4 D
+16 0 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+P
+FO
+{1 0 0 C} FS
+9 2 -10 -6 2 1033 2180 SP
+-4 -2 1 807 2127 SP
+4 0 1 801 2129 SP
+-4 1 1 825 2140 SP
+2 3 1 1045 2173 SP
+6 4 1 1018 2182 SP
+{0 0 0.502 C} FS
+-4 -2 1 1019 2177 SP
+{1 0 0 C} FS
+1 -2 0 -2 -4 -2 -1 6 4 3 5 780 2117 SP
+1041 2170 M
+7 8 D
+-8 0 D
+-1 -6 D
+-6 -3 D
+4 10 D
+-9 -7 D
+-1 3 D
+-10 -3 D
+12 12 D
+-18 -5 D
+6 6 D
+-8 0 D
+15 3 D
+-7 6 D
+-14 -6 D
+11 5 D
+0 1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-25 -17 D
+-9 1 D
+4 -2 D
+-24 -8 D
+-11 -8 D
+-1 4 D
+-1 -4 D
+-9 -1 D
+7 0 D
+-12 1 D
+-4 -8 D
+18 5 D
+-12 -5 D
+2 -5 D
+-7 2 D
+2 -5 D
+-7 1 D
+4 -2 D
+-5 1 D
+0 -5 D
+-1 4 D
+-12 -10 D
+6 11 D
+-3 5 D
+-10 -12 D
+2 -8 D
+-1 0 D
+9 -20 D
+10 -15 D
+62 31 D
+80 33 D
+73 26 D
+P
+FO
+9 2 -10 -6 2 1033 2180 SP
+-4 -2 1 807 2127 SP
+4 0 1 801 2129 SP
+-4 1 1 825 2140 SP
+2 3 1 1045 2173 SP
+6 4 1 1018 2182 SP
+{0 0 0.502 C} FS
+-4 -2 1 1019 2177 SP
+861 2019 M
+3 0 D
+-8 13 D
+-16 2 D
+-2 4 D
+14 -2 D
+-10 8 D
+16 4 D
+0 -6 D
+11 0 D
+-7 12 D
+7 -2 D
+1 6 D
+3 -17 D
+-9 -14 D
+10 3 D
+-6 -5 D
+5 -2 D
+5 8 D
+9 4 D
+-4 2 D
+7 1 D
+-7 2 D
+7 2 D
+0 11 D
+-8 -1 D
+6 2 D
+-4 3 D
+7 -3 D
+3 5 D
+-9 0 D
+2 6 D
+12 -4 D
+-8 7 D
+6 -2 D
+2 5 D
+0 -6 D
+8 0 D
+4 7 D
+-2 -7 D
+5 2 D
+4 -7 D
+-6 5 D
+-1 -8 D
+11 -2 D
+6 4 D
+-1 5 D
+-7 -4 D
+4 6 D
+10 5 D
+2 -8 D
+-22 -16 D
+-32 -26 D
+-10 -9 D
+P
+FO
+1048 2137 M
+-1 2 D
+-25 -5 D
+29 11 D
+-19 0 D
+12 3 D
+-14 9 D
+8 1 D
+10 -9 D
+14 0 D
+-5 6 D
+7 3 D
+-21 8 D
+11 1 D
+13 -7 D
+-10 13 D
+-16 -3 D
+93 25 D
+47 9 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -7 D
+-7 -3 D
+-13 -7 D
+-13 -7 D
+-14 -7 D
+-13 -7 D
+P
+FO
+-3 -1 1 1039 2132 SP
+4 -1 -3 2 2 1033 2128 SP
+-3 -2 3 0 5 3 -2 0 4 1021 2121 SP
+-5 -4 -6 -3 18 5 7 4 -8 -1 0 3 6 991 2101 SP
+-2 -1 5 -1 -2 3 3 985 2097 SP
+-5 -3 9 -4 5 6 -5 4 4 965 2084 SP
+-2 -2 8 -2 -3 6 3 959 2079 SP
+-5 -4 3 -9 -1 8 7 -4 -5 5 8 4 -2 3 7 940 2066 SP
+{1 0 0 C} FS
+-5 3 7 10 2 -8 3 893 2052 SP
+1 5 5 -5 2 929 2067 SP
+-7 0 -1 8 2 907 2056 SP
+6 6 12 -5 2 847 2040 SP
+2 5 5 -8 2 900 2057 SP
+3 4 1 943 2068 SP
+{0 0 0.502 C} FS
+5 -3 -5 4 2 978 2093 SP
+-2 -4 1 980 2100 SP
+{1 0 0 C} FS
+839 2035 M
+-1 3 D
+14 -2 D
+-10 8 D
+16 4 D
+0 -6 D
+11 0 D
+-7 12 D
+7 -2 D
+1 6 D
+3 -17 D
+-9 -14 D
+10 3 D
+-6 -5 D
+5 -2 D
+5 8 D
+9 4 D
+-4 2 D
+7 1 D
+-7 2 D
+7 2 D
+0 11 D
+-8 -1 D
+6 2 D
+-4 3 D
+7 -3 D
+3 5 D
+-9 0 D
+2 6 D
+12 -4 D
+-8 7 D
+6 -2 D
+2 5 D
+0 -6 D
+8 0 D
+4 7 D
+-2 -7 D
+5 2 D
+4 -7 D
+-6 5 D
+-1 -8 D
+11 -2 D
+6 4 D
+-1 5 D
+-7 -4 D
+4 6 D
+10 5 D
+2 -8 D
+4 3 D
+-2 3 D
+8 4 D
+-5 5 D
+7 -4 D
+-1 8 D
+3 -9 D
+9 6 D
+-3 6 D
+8 -2 D
+1 1 D
+-5 4 D
+5 6 D
+9 -4 D
+11 7 D
+-2 3 D
+5 -1 D
+3 2 D
+0 3 D
+-8 -1 D
+7 4 D
+18 5 D
+13 9 D
+-2 0 D
+5 3 D
+3 0 D
+6 4 D
+-3 2 D
+4 -1 D
+5 3 D
+-3 -1 D
+12 6 D
+-1 2 D
+-25 -5 D
+29 11 D
+-19 0 D
+12 3 D
+-14 9 D
+8 1 D
+10 -9 D
+14 0 D
+-5 6 D
+7 3 D
+-21 8 D
+11 1 D
+13 -7 D
+-10 13 D
+-16 -3 D
+-8 -2 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-16 -8 D
+-15 -7 D
+-16 -8 D
+-15 -8 D
+7 -10 D
+9 -10 D
+P
+FO
+5 -4 5 -3 4 -4 -14 1 -8 13 3 0 6 861 2019 SP
+-5 3 7 10 2 -8 3 893 2052 SP
+1 5 5 -5 2 929 2067 SP
+-7 0 -1 8 2 907 2056 SP
+6 6 12 -5 2 847 2040 SP
+2 5 5 -8 2 900 2057 SP
+3 4 1 943 2068 SP
+{0 0 0.502 C} FS
+5 -3 -5 4 2 978 2093 SP
+-2 -4 1 980 2100 SP
+936 2063 M
+1 -1 D
+6 1 D
+-3 3 D
+10 7 D
+0 -2 D
+10 6 D
+-1 2 D
+6 4 D
+0 1 D
+9 6 D
+6 -3 D
+7 6 D
+-2 4 D
+3 2 D
+3 0 D
+0 2 D
+17 11 D
+22 7 D
+-9 2 D
+6 3 D
+14 -1 D
+-8 5 D
+1 1 D
+15 -4 D
+17 6 D
+-6 6 D
+-10 -3 D
+-2 3 D
+60 33 D
+73 34 D
+-23 -21 D
+-10 -9 D
+-4 -5 D
+-10 -9 D
+-4 -5 D
+-10 -9 D
+-28 -30 D
+-18 -22 D
+-37 -45 D
+-36 -49 D
+-22 -33 D
+-48 17 D
+-36 15 D
+-23 13 D
+26 22 D
+P
+FO
+8 1 1 1039 2132 SP
+{1 0 0 C} FS
+3 6 6 -2 2 951 2068 SP
+-8 -2 1 945 1999 SP
+4 2 1 994 2096 SP
+9 9 1 967 2079 SP
+-5 -3 -2 3 -10 -3 -6 6 17 6 15 -4 -2 -1 -3 -2 -8 -1 8 1 10 1039 2132 SP
+-3 -2 -8 5 14 -1 3 1027 2124 SP
+-7 -5 -9 2 22 7 3 1008 2112 SP
+-2 -1 0 2 3 0 3 988 2099 SP
+-6 -3 -2 4 7 6 6 -3 4 974 2090 SP
+0 1 1 0 2 964 2083 SP
+-5 -3 -1 2 10 6 0 -2 4 950 2073 SP
+-2 -1 -3 3 6 1 1 -1 4 936 2063 SP
+3 6 6 -2 2 951 2068 SP
+-8 -2 1 945 1999 SP
+4 2 1 994 2096 SP
+9 9 1 967 2079 SP
+{0 0 0.502 C} FS
+808 1650 M
+18 3 D
+3 4 D
+-13 5 D
+9 0 D
+16 13 D
+-2 10 D
+-14 3 D
+36 76 D
+42 78 D
+31 55 D
+16 26 D
+13 19 D
+16 25 D
+64 -15 D
+68 -9 D
+-1 -4 D
+-4 -5 D
+2 7 D
+-6 -3 D
+3 -7 D
+-9 5 D
+-6 -12 D
+-10 -2 D
+10 -2 D
+-12 1 D
+-1 -10 D
+-2 8 D
+-6 -2 D
+4 -4 D
+-8 1 D
+6 -6 D
+-13 -3 D
+8 -4 D
+-16 0 D
+3 -3 D
+-11 -9 D
+10 1 D
+-14 -3 D
+3 -4 D
+-3 2 D
+-10 -11 D
+9 1 D
+-17 -5 D
+8 0 D
+-8 -4 D
+2 -4 D
+-6 -1 D
+0 5 D
+-18 -14 D
+7 -3 D
+11 8 D
+-7 -10 D
+-11 -1 D
+1 5 D
+-12 -2 D
+-2 -9 D
+-6 4 D
+4 -7 D
+-12 8 D
+8 -6 D
+-17 1 D
+5 -10 D
+-3 5 D
+-3 -3 D
+-4 3 D
+2 -4 D
+-10 5 D
+-1 -5 D
+14 -4 D
+-14 4 D
+-4 -5 D
+6 -4 D
+-8 1 D
+6 -2 D
+-6 -3 D
+12 -2 D
+4 4 D
+3 -6 D
+5 5 D
+0 -4 D
+-8 -5 D
+-3 6 D
+-15 1 D
+3 -4 D
+-6 0 D
+1 -5 D
+6 2 D
+-8 -5 D
+1 -4 D
+5 3 D
+-6 -8 D
+19 7 D
+-25 -12 D
+2 -6 D
+11 3 D
+-10 -6 D
+7 -2 D
+-5 -3 D
+-5 4 D
+-3 -8 D
+10 -13 D
+13 0 D
+19 15 D
+9 -3 D
+8 15 D
+-5 -29 D
+6 1 D
+-4 -9 D
+6 7 D
+-6 -11 D
+7 -22 D
+-7 -4 D
+0 -18 D
+15 -2 D
+9 14 D
+13 -4 D
+15 24 D
+1 19 D
+6 -1 D
+-8 4 D
+15 1 D
+3 7 D
+1 -7 D
+10 8 D
+-6 3 D
+11 5 D
+-8 16 D
+-7 2 D
+14 40 D
+3 -5 D
+20 11 D
+-10 -54 D
+-17 -99 D
+-1 0 D
+-1 -5 D
+1 0 D
+0 -3 D
+-8 -4 D
+7 7 D
+-14 -4 D
+-8 10 D
+-41 -11 D
+-3 -7 D
+-14 18 D
+-27 -5 D
+5 7 D
+-12 1 D
+-5 11 D
+7 15 D
+19 11 D
+-7 6 D
+11 18 D
+-25 -7 D
+-18 -42 D
+4 1 D
+2 -8 D
+-6 -2 D
+10 -17 D
+-11 9 D
+-5 -9 D
+-4 8 D
+-11 -1 D
+2 -7 D
+-17 7 D
+-8 -5 D
+2 -10 D
+-8 -3 D
+-2 13 D
+-15 -16 D
+6 -7 D
+-16 0 D
+9 -5 D
+-35 -1 D
+-4 -13 D
+-5 -2 D
+-15 4 D
+P
+FO
+1 3 -1 -1 2 1109 1933 SP
+-9 8 1 1104 1912 SP
+{1 0 0 C} FS
+6 -24 -11 -2 -2 6 -5 -8 -1 11 11 9 6 971 1697 SP
+2 11 8 -3 -3 -7 3 953 1710 SP
+1 6 -7 -4 14 7 3 1068 1921 SP
+-7 -8 -3 3 2 1095 1936 SP
+-8 -5 4 7 2 1069 1925 SP
+12 20 -7 -14 2 1034 1726 SP
+-12 -6 13 16 2 1049 1724 SP
+-5 -3 1 1061 1921 SP
+-3 -5 1 959 1699 SP
+-6 -2 1 998 1674 SP
+2 4 1 933 1803 SP
+6 0 1 987 1855 SP
+4 3 1 1035 1887 SP
+0 4 0 -5 2 961 1718 SP
+1 -4 1 1064 1787 SP
+-3 3 4 -3 2 951 1700 SP
+5 1 1 885 1682 SP
+-7 -1 1 993 1853 SP
+-1 6 1 1006 1692 SP
+-6 -3 1 1068 1922 SP
+6 5 1 1075 1931 SP
+2 -5 -3 5 2 949 1698 SP
+-7 -3 1 6 2 988 1680 SP
+-7 -1 1 1109 1944 SP
+{0 0 0.502 C} FS
+-2 5 0 -7 -9 -1 9 -3 9 9 5 943 1732 SP
+2 8 8 -2 4 10 -17 -4 -6 -10 5 1016 1771 SP
+2 -9 1 7 17 -4 3 1036 1772 SP
+0 -6 1 989 1787 SP
+-1 -6 1 1039 1834 SP
+-6 4 1 1105 1918 SP
+7 -2 1 973 1816 SP
+-4 3 1 1087 1885 SP
+1 -4 1 959 1793 SP
+-4 4 1 1075 1874 SP
+0 -5 1 1006 1779 SP
+-2 -5 1 960 1780 SP
+5 -1 1 1071 1896 SP
+-5 0 1 1009 1844 SP
+-1 4 1 1085 1911 SP
+0 -5 1 1009 1781 SP
+-2 3 1 1072 1889 SP
+-3 2 1 1094 1903 SP
+4 -5 1 1019 1813 SP
+0 5 0 -4 2 1009 1786 SP
+6 -1 1 977 1824 SP
+-1 -5 1 1001 1816 SP
+1 -4 1 967 1791 SP
+0 5 -1 -5 2 950 1774 SP
+-2 -4 1 938 1773 SP
+-13 -17 1 1022 1761 SP
+-6 13 1 1081 1876 SP
+-1 -9 1 1037 1840 SP
+9 -1 1 1031 1769 SP
+-18 15 1 1099 1896 SP
+13 -18 1 1040 1863 SP
+3 -13 1 990 1807 SP
+2 -5 1 1029 1799 SP
+6 4 1 1075 1903 SP
+-2 -10 1 994 1777 SP
+-10 -5 1 1054 1788 SP
+-12 6 1 0 2 1094 1890 SP
+5 4 1 1047 1879 SP
+-3 -5 1 1002 1731 SP
+-6 7 1 1070 1866 SP
+-4 -9 1 1012 1828 SP
+-1 -6 1 1031 1848 SP
+2 -4 1 1020 1748 SP
+6 -9 1 1059 1865 SP
+1 -4 1 1009 1724 SP
+4 -8 -4 7 2 1042 1848 SP
+-2 -5 1 1042 1825 SP
+2 -5 0 1 2 1043 1832 SP
+-1 5 0 -5 2 1054 1854 SP
+1 -4 0 4 2 1039 1864 SP
+-2 -10 1 986 1803 SP
+8 3 1 1018 1855 SP
+-3 5 1 1082 1888 SP
+-2 7 1 -6 2 1002 1779 SP
+-2 6 1 1064 1863 SP
+1 -5 1 996 1775 SP
+-2 4 1 1058 1874 SP
+-3 3 1 1057 1883 SP
+{1 0 0 C} FS
+1062 1676 M
+-8 -4 D
+7 7 D
+-14 -4 D
+-8 10 D
+-41 -11 D
+-3 -7 D
+-14 18 D
+-27 -5 D
+5 7 D
+-12 1 D
+-5 11 D
+7 15 D
+19 11 D
+-7 6 D
+11 18 D
+-25 -7 D
+-18 -42 D
+4 1 D
+2 -8 D
+-6 -2 D
+10 -17 D
+-11 9 D
+-5 -9 D
+-4 8 D
+-11 -1 D
+2 -7 D
+-17 7 D
+-8 -5 D
+2 -10 D
+-8 -3 D
+-2 13 D
+-15 -16 D
+6 -7 D
+-16 0 D
+9 -5 D
+-35 -1 D
+-4 -13 D
+-5 -2 D
+50 -13 D
+63 -13 D
+97 -13 D
+22 -2 D
+P
+FO
+1 2 1 0 -1 -5 -1 0 4 1063 1684 SP
+1104 1912 M
+-9 8 D
+9 -8 D
+5 21 D
+-1 -1 D
+2 7 D
+-4 -5 D
+2 7 D
+-6 -3 D
+3 -7 D
+-9 5 D
+-6 -12 D
+-10 -2 D
+10 -2 D
+-12 1 D
+-1 -10 D
+-2 8 D
+-6 -2 D
+4 -4 D
+-8 1 D
+6 -6 D
+-13 -3 D
+8 -4 D
+-16 0 D
+3 -3 D
+-11 -9 D
+10 1 D
+-14 -3 D
+3 -4 D
+-3 2 D
+-10 -11 D
+9 1 D
+-17 -5 D
+8 0 D
+-8 -4 D
+2 -4 D
+-6 -1 D
+0 5 D
+-18 -14 D
+7 -3 D
+11 8 D
+-7 -10 D
+-11 -1 D
+1 5 D
+-12 -2 D
+-2 -9 D
+-6 4 D
+4 -7 D
+-12 8 D
+8 -6 D
+-17 1 D
+5 -10 D
+-3 5 D
+-3 -3 D
+-4 3 D
+2 -4 D
+-10 5 D
+-1 -5 D
+14 -4 D
+-14 4 D
+-4 -5 D
+6 -4 D
+-8 1 D
+6 -2 D
+-6 -3 D
+12 -2 D
+4 4 D
+3 -6 D
+5 5 D
+0 -4 D
+-8 -5 D
+-3 6 D
+-15 1 D
+3 -4 D
+-6 0 D
+1 -5 D
+6 2 D
+-8 -5 D
+1 -4 D
+5 3 D
+-6 -8 D
+19 7 D
+-25 -12 D
+2 -6 D
+11 3 D
+-10 -6 D
+7 -2 D
+-5 -3 D
+-5 4 D
+-3 -8 D
+10 -13 D
+13 0 D
+19 15 D
+9 -3 D
+8 15 D
+-5 -29 D
+6 1 D
+-4 -9 D
+6 7 D
+-6 -11 D
+7 -22 D
+-7 -4 D
+0 -18 D
+15 -2 D
+9 14 D
+13 -4 D
+15 24 D
+1 19 D
+6 -1 D
+-8 4 D
+15 1 D
+3 7 D
+1 -7 D
+10 8 D
+-6 3 D
+11 5 D
+-8 16 D
+-7 2 D
+14 40 D
+3 -5 D
+20 11 D
+P
+FO
+0 1 1 830 1699 SP
+-4 -9 -4 -10 -5 -9 -14 3 -2 10 16 13 9 0 -13 5 3 4 18 3 10 808 1650 SP
+6 -24 -11 -2 -2 6 -5 -8 -1 11 11 9 6 971 1697 SP
+2 11 8 -3 -3 -7 3 953 1710 SP
+1 6 -7 -4 14 7 3 1068 1921 SP
+-7 -8 -3 3 2 1095 1936 SP
+-8 -5 4 7 2 1069 1925 SP
+12 20 -7 -14 2 1034 1726 SP
+-12 -6 13 16 2 1049 1724 SP
+-5 -3 1 1061 1921 SP
+-3 -5 1 959 1699 SP
+-6 -2 1 998 1674 SP
+2 4 1 933 1803 SP
+6 0 1 987 1855 SP
+4 3 1 1035 1887 SP
+0 4 0 -5 2 961 1718 SP
+1 -4 1 1064 1787 SP
+-3 3 4 -3 2 951 1700 SP
+5 1 1 885 1682 SP
+-7 -1 1 993 1853 SP
+-1 6 1 1006 1692 SP
+-6 -3 1 1068 1922 SP
+6 5 1 1075 1931 SP
+2 -5 -3 5 2 949 1698 SP
+-7 -3 1 6 2 988 1680 SP
+-7 -1 1 1109 1944 SP
+{0 0 0.502 C} FS
+-2 5 0 -7 -9 -1 9 -3 9 9 5 943 1732 SP
+2 8 8 -2 4 10 -17 -4 -6 -10 5 1016 1771 SP
+2 -9 1 7 17 -4 3 1036 1772 SP
+0 -6 1 989 1787 SP
+-1 -6 1 1039 1834 SP
+-6 4 1 1105 1918 SP
+7 -2 1 973 1816 SP
+-4 3 1 1087 1885 SP
+1 -4 1 959 1793 SP
+-4 4 1 1075 1874 SP
+0 -5 1 1006 1779 SP
+-2 -5 1 960 1780 SP
+5 -1 1 1071 1896 SP
+-5 0 1 1009 1844 SP
+-1 4 1 1085 1911 SP
+0 -5 1 1009 1781 SP
+-2 3 1 1072 1889 SP
+-3 2 1 1094 1903 SP
+4 -5 1 1019 1813 SP
+0 5 0 -4 2 1009 1786 SP
+6 -1 1 977 1824 SP
+-1 -5 1 1001 1816 SP
+1 -4 1 967 1791 SP
+0 5 -1 -5 2 950 1774 SP
+-2 -4 1 938 1773 SP
+-13 -17 1 1022 1761 SP
+-6 13 1 1081 1876 SP
+-1 -9 1 1037 1840 SP
+9 -1 1 1031 1769 SP
+-18 15 1 1099 1896 SP
+13 -18 1 1040 1863 SP
+3 -13 1 990 1807 SP
+2 -5 1 1029 1799 SP
+6 4 1 1075 1903 SP
+-2 -10 1 994 1777 SP
+-10 -5 1 1054 1788 SP
+-12 6 1 0 2 1094 1890 SP
+5 4 1 1047 1879 SP
+-3 -5 1 1002 1731 SP
+-6 7 1 1070 1866 SP
+-4 -9 1 1012 1828 SP
+-1 -6 1 1031 1848 SP
+2 -4 1 1020 1748 SP
+6 -9 1 1059 1865 SP
+1 -4 1 1009 1724 SP
+4 -8 -4 7 2 1042 1848 SP
+-2 -5 1 1042 1825 SP
+2 -5 0 1 2 1043 1832 SP
+-1 5 0 -5 2 1054 1854 SP
+1 -4 0 4 2 1039 1864 SP
+-2 -10 1 986 1803 SP
+8 3 1 1018 1855 SP
+-3 5 1 1082 1888 SP
+-2 7 1 -6 2 1002 1779 SP
+-2 6 1 1064 1863 SP
+1 -5 1 996 1775 SP
+-2 4 1 1058 1874 SP
+-3 3 1 1057 1883 SP
+0 1 -5 -3 5 0 3 1062 1679 SP
+1090 1837 M
+7 5 D
+10 10 D
+-1 15 D
+4 -3 D
+1 10 D
+5 -4 D
+3 6 D
+17 -2 D
+6 -14 D
+-44 -36 D
+3 -23 D
+-6 -15 D
+10 -8 D
+6 2 D
+-3 -9 D
+60 14 D
+-1 -7 D
+18 -7 D
+-24 -3 D
+-2 -7 D
+-23 6 D
+-23 -7 D
+0 -16 D
+10 -1 D
+-4 -20 D
+-9 -4 D
+-10 15 D
+-10 -3 D
+-11 -18 D
+-1 -30 D
+-9 1 D
+9 14 D
+-8 -12 D
+-7 -2 D
+25 147 D
+P
+FO
+1 0 5 -4 2 1104 1912 SP
+-10 -10 4 0 4 0 1 2 0 2 -3 -4 4 8 7 1109 1935 SP
+2 -1 -5 5 1 -4 3 1124 1942 SP
+-1 1 0 -1 2 1135 1942 SP
+1258 1912 M
+-2 2 D
+-36 15 D
+-13 1 D
+-3 -7 D
+2 8 D
+-9 0 D
+-1 5 D
+7 0 D
+-7 4 D
+-6 -7 D
+-7 5 D
+-6 -3 D
+-4 5 D
+78 3 D
+P
+FO
+1266 1873 M
+-2 -3 D
+4 -10 D
+1 -5 D
+-14 3 D
+-3 -4 D
+2 5 D
+-14 4 D
+-1 -8 D
+14 -6 D
+-5 -9 D
+-25 11 D
+-5 15 D
+4 8 D
+-16 6 D
+6 3 D
+-16 11 D
+61 -14 D
+6 7 D
+P
+FO
+{1 0 0 C} FS
+6 2 4 -4 -5 -1 3 1102 1756 SP
+-16 2 15 8 2 1094 1738 SP
+7 4 1 1103 1775 SP
+{0 0 0.502 C} FS
+6 -3 -14 -8 -3 -11 7 -3 -1 8 14 -2 -1 -8 -9 6 18 -21 -7 12 5 8 -15 11 8 6 8 -3 -6 9 15 1160 1792 SP
+-5 3 1 10 9 15 -9 9 -3 -8 8 2 -2 -12 -16 -14 7 -3 -3 5 4 -4 4 8 0 -12 13 1143 1827 SP
+5 3 7 -9 -4 10 8 -9 -4 12 -15 12 9 2 -11 3 -5 -6 8 -22 12 -7 11 1225 1823 SP
+-7 -3 10 1 -8 12 11 -2 -16 11 -5 -10 11 -7 7 1267 1756 SP
+1 -11 -7 1 11 -7 3 1221 1840 SP
+2 17 -1 -10 -10 -1 -1 -6 4 1131 1812 SP
+11 7 -6 6 3 -4 -8 -8 4 1130 1803 SP
+-6 -3 -6 4 9 -6 3 1189 1862 SP
+12 -8 -1 6 2 1154 1846 SP
+-4 -9 14 8 2 1159 1923 SP
+-17 23 -15 -14 21 -18 3 1190 1802 SP
+8 2 -12 18 6 -9 3 1155 1742 SP
+4 -4 2 5 2 1142 1800 SP
+-6 2 2 -6 2 1190 1880 SP
+-4 -4 14 -2 -10 5 3 1162 1906 SP
+-8 1 5 -5 2 1215 1833 SP
+-10 2 5 -6 2 1195 1744 SP
+-6 -2 1 -13 2 1206 1914 SP
+-1 -6 1 1222 1910 SP
+-2 4 1 1163 1828 SP
+1 -4 1 1153 1809 SP
+7 -2 1 1174 1875 SP
+2 -4 1 1211 1840 SP
+-5 -2 1 1139 1821 SP
+3 3 1 1135 1885 SP
+6 -1 1 1154 1790 SP
+-2 4 1 1157 1875 SP
+-2 -7 1 1125 1822 SP
+-7 -5 1 1194 1919 SP
+-8 -4 1 0 2 1115 1799 SP
+-1 -6 1 1135 1812 SP
+-2 4 1 1139 1831 SP
+2 4 1 1172 1844 SP
+-9 1 1 1202 1902 SP
+-11 12 1 1183 1823 SP
+-8 1 2 -4 2 1261 1780 SP
+7 -9 1 1197 1874 SP
+4 -6 1 1146 1806 SP
+5 -7 1 1196 1890 SP
+0 -12 1 1188 1609 SP
+3 -8 1 1169 1824 SP
+10 2 1 1164 1878 SP
+1 -6 1 1272 1788 SP
+7 -7 1 1275 1773 SP
+0 7 1 1149 1824 SP
+-1 6 1 1178 1819 SP
+-2 -4 1 1269 1800 SP
+0 -5 1 1247 1817 SP
+-1 -4 1 1205 1876 SP
+10 1 1 1166 1842 SP
+0 11 0 -1 2 1148 1792 SP
+1 -6 1 1215 1907 SP
+-1 -5 1 1139 1743 SP
+3 4 1 1186 1821 SP
+-1 9 1 1136 1823 SP
+-1 6 1 1179 1842 SP
+3 -5 1 1189 1840 SP
+-2 -5 1 1129 1798 SP
+5 6 1 1172 1856 SP
+6 2 1 1159 1884 SP
+-1 -4 1 1216 1724 SP
+-4 -2 1 1197 1851 SP
+{1 0 0 C} FS
+3 -5 -7 -1 2 1175 1809 SP
+-2 4 1 1163 1820 SP
+0 -4 1 1232 1809 SP
+1269 1855 M
+-14 3 D
+-3 -4 D
+2 5 D
+-14 4 D
+-1 -8 D
+14 -6 D
+-5 -9 D
+-25 11 D
+-5 15 D
+4 8 D
+-16 6 D
+6 3 D
+-16 11 D
+61 -14 D
+6 7 D
+-5 25 D
+-2 2 D
+-36 15 D
+-13 1 D
+-3 -7 D
+2 8 D
+-9 0 D
+-1 5 D
+7 0 D
+-7 4 D
+-6 -7 D
+-7 5 D
+-6 -3 D
+-4 5 D
+-38 2 D
+0 -1 D
+-11 1 D
+1 -4 D
+-6 5 D
+-10 -10 D
+-5 -21 D
+6 -4 D
+-6 4 D
+-14 -75 D
+7 5 D
+10 10 D
+-1 15 D
+4 -3 D
+1 10 D
+5 -4 D
+3 6 D
+17 -2 D
+6 -14 D
+-44 -36 D
+3 -23 D
+-6 -15 D
+10 -8 D
+6 2 D
+-3 -9 D
+60 14 D
+-1 -7 D
+18 -7 D
+-24 -3 D
+-2 -7 D
+-23 6 D
+-23 -7 D
+0 -16 D
+10 -1 D
+-4 -20 D
+-9 -4 D
+-10 15 D
+-10 -3 D
+-11 -18 D
+-1 -30 D
+-9 1 D
+9 14 D
+-8 -12 D
+-7 -2 D
+-1 -5 D
+5 0 D
+-5 -3 D
+-13 -85 D
+55 -4 D
+77 -2 D
+55 1 D
+77 5 D
+-22 144 D
+P
+FO
+0 4 3 -6 -2 -3 3 1266 1873 SP
+0 -2 -3 -4 4 8 3 1109 1935 SP
+6 2 4 -4 -5 -1 3 1102 1756 SP
+-16 2 15 8 2 1094 1738 SP
+7 4 1 1103 1775 SP
+{0 0 0.502 C} FS
+6 -3 -14 -8 -3 -11 7 -3 -1 8 14 -2 -1 -8 -9 6 18 -21 -7 12 5 8 -15 11 8 6 8 -3 -6 9 15 1160 1792 SP
+-5 3 1 10 9 15 -9 9 -3 -8 8 2 -2 -12 -16 -14 7 -3 -3 5 4 -4 4 8 0 -12 13 1143 1827 SP
+5 3 7 -9 -4 10 8 -9 -4 12 -15 12 9 2 -11 3 -5 -6 8 -22 12 -7 11 1225 1823 SP
+-7 -3 10 1 -8 12 11 -2 -16 11 -5 -10 11 -7 7 1267 1756 SP
+1 -11 -7 1 11 -7 3 1221 1840 SP
+2 17 -1 -10 -10 -1 -1 -6 4 1131 1812 SP
+11 7 -6 6 3 -4 -8 -8 4 1130 1803 SP
+-6 -3 -6 4 9 -6 3 1189 1862 SP
+12 -8 -1 6 2 1154 1846 SP
+-4 -9 14 8 2 1159 1923 SP
+-17 23 -15 -14 21 -18 3 1190 1802 SP
+8 2 -12 18 6 -9 3 1155 1742 SP
+4 -4 2 5 2 1142 1800 SP
+-6 2 2 -6 2 1190 1880 SP
+-4 -4 14 -2 -10 5 3 1162 1906 SP
+-8 1 5 -5 2 1215 1833 SP
+-10 2 5 -6 2 1195 1744 SP
+-6 -2 1 -13 2 1206 1914 SP
+-1 -6 1 1222 1910 SP
+-2 4 1 1163 1828 SP
+1 -4 1 1153 1809 SP
+7 -2 1 1174 1875 SP
+2 -4 1 1211 1840 SP
+-5 -2 1 1139 1821 SP
+3 3 1 1135 1885 SP
+6 -1 1 1154 1790 SP
+-2 4 1 1157 1875 SP
+-2 -7 1 1125 1822 SP
+-7 -5 1 1194 1919 SP
+-8 -4 1 0 2 1115 1799 SP
+-1 -6 1 1135 1812 SP
+-2 4 1 1139 1831 SP
+2 4 1 1172 1844 SP
+-9 1 1 1202 1902 SP
+-11 12 1 1183 1823 SP
+-8 1 2 -4 2 1261 1780 SP
+7 -9 1 1197 1874 SP
+4 -6 1 1146 1806 SP
+5 -7 1 1196 1890 SP
+0 -12 1 1188 1609 SP
+3 -8 1 1169 1824 SP
+10 2 1 1164 1878 SP
+1 -6 1 1272 1788 SP
+7 -7 1 1275 1773 SP
+0 7 1 1149 1824 SP
+-1 6 1 1178 1819 SP
+-2 -4 1 1269 1800 SP
+0 -5 1 1247 1817 SP
+-1 -4 1 1205 1876 SP
+10 1 1 1166 1842 SP
+0 11 0 -1 2 1148 1792 SP
+1 -6 1 1215 1907 SP
+-1 -5 1 1139 1743 SP
+3 4 1 1186 1821 SP
+-1 9 1 1136 1823 SP
+-1 6 1 1179 1842 SP
+3 -5 1 1189 1840 SP
+-2 -5 1 1129 1798 SP
+5 6 1 1172 1856 SP
+6 2 1 1159 1884 SP
+-1 -4 1 1216 1724 SP
+-4 -2 1 1197 1851 SP
+{1 0 0 C} FS
+3 -5 -7 -1 2 1175 1809 SP
+-2 4 1 1163 1820 SP
+0 -4 1 1232 1809 SP
+{0 0 0.502 C} FS
+-9 -4 10 -9 1 -12 -11 -11 13 12 -4 18 1 8 7 1385 1599 SP
+-1 5 -4 0 6 -9 3 1267 1864 SP
+1263 1887 M
+9 11 D
+-14 14 D
+-7 31 D
+58 8 D
+56 11 D
+10 3 D
+11 -2 D
+9 -15 D
+3 -6 D
+-12 9 D
+-7 -10 D
+-13 -3 D
+0 -7 D
+-12 -2 D
+-2 10 D
+5 4 D
+-4 -1 D
+-6 -12 D
+-3 4 D
+-21 -16 D
+5 -4 D
+-9 -2 D
+2 -11 D
+-12 -3 D
+-11 9 D
+11 8 D
+-3 4 D
+-26 6 D
+9 -6 D
+9 -37 D
+-17 7 D
+-15 -16 D
+P
+FO
+{1 0 0 C} FS
+-4 -8 -10 5 6 7 3 1321 1932 SP
+{0 0 0.502 C} FS
+1403 1693 M
+-3 -7 D
+6 -6 D
+10 5 D
+-6 -12 D
+11 -1 D
+-12 -5 D
+4 3 D
+-14 13 D
+5 19 D
+-4 6 D
+3 -4 D
+0 6 D
+6 -3 D
+15 7 D
+0 5 D
+2 -4 D
+4 3 D
+-27 -20 D
+P
+FO
+-7 2 6 5 -8 0 -13 12 6 -7 -5 -2 8 1 5 -6 -4 -5 12 -18 -4 11 11 1448 1790 SP
+7 17 17 4 15 -34 -9 -12 9 12 -15 34 -17 -4 -7 -17 -15 13 9 1405 1892 SP
+8 -11 -1 -9 12 -3 -12 3 2 9 -9 11 -33 15 7 1326 1817 SP
+-20 -9 -15 2 -17 9 16 -10 16 -1 20 8 16 -9 7 1332 1720 SP
+8 -10 -6 8 10 13 3 1445 1742 SP
+-6 -4 8 -6 2 1530 1672 SP
+-3 -22 9 5 2 1322 1735 SP
+-5 -17 5 16 2 1403 1643 SP
+-14 -1 14 0 2 1306 1733 SP
+{1 0 0 C} FS
+1385 1599 M
+1 8 D
+-4 18 D
+13 12 D
+-11 -11 D
+1 -12 D
+10 -9 D
+-9 -4 D
+-1 -2 D
+71 12 D
+77 17 D
+28 8 D
+-48 104 D
+-43 83 D
+-53 92 D
+-22 34 D
+3 -7 D
+-12 9 D
+-7 -10 D
+-13 -3 D
+0 -7 D
+-12 -2 D
+-2 10 D
+5 4 D
+-4 -1 D
+-6 -12 D
+-3 4 D
+-21 -16 D
+5 -4 D
+-9 -2 D
+2 -11 D
+-12 -3 D
+-11 9 D
+11 8 D
+-3 4 D
+-26 6 D
+9 -6 D
+9 -37 D
+-17 7 D
+-15 -16 D
+1 -9 D
+6 -9 D
+-4 0 D
+27 -151 D
+17 -113 D
+45 4 D
+P
+FO
+-4 -1 -1 2 -2 2 11 -2 4 1375 1965 SP
+1 -9 2 -8 -14 14 9 11 4 1263 1887 SP
+-4 -8 -10 5 6 7 3 1321 1932 SP
+{0 0 0.502 C} FS
+1403 1693 M
+-3 -7 D
+6 -6 D
+10 5 D
+-6 -12 D
+11 -1 D
+-12 -5 D
+4 3 D
+-14 13 D
+5 19 D
+-4 6 D
+3 -4 D
+0 6 D
+6 -3 D
+15 7 D
+0 5 D
+2 -4 D
+4 3 D
+-27 -20 D
+P
+FO
+-7 2 6 5 -8 0 -13 12 6 -7 -5 -2 8 1 5 -6 -4 -5 12 -18 -4 11 11 1448 1790 SP
+7 17 17 4 15 -34 -9 -12 9 12 -15 34 -17 -4 -7 -17 -15 13 9 1405 1892 SP
+8 -11 -1 -9 12 -3 -12 3 2 9 -9 11 -33 15 7 1326 1817 SP
+-20 -9 -15 2 -17 9 16 -10 16 -1 20 8 16 -9 7 1332 1720 SP
+8 -10 -6 8 10 13 3 1445 1742 SP
+-6 -4 8 -6 2 1530 1672 SP
+-3 -22 9 5 2 1322 1735 SP
+-5 -17 5 16 2 1403 1643 SP
+-14 -1 14 0 2 1306 1733 SP
+1386 1963 M
+0 4 D
+-2 1 D
+32 10 D
+7 3 D
+5 -7 D
+8 3 D
+14 -6 D
+4 -13 D
+-29 8 D
+5 0 D
+-40 1 D
+-2 -6 D
+14 -9 D
+-7 -3 D
+P
+FO
+4 2 -13 15 -13 4 -9 26 13 11 -24 -2 4 -28 15 -14 -7 -8 -20 14 -13 -1 11 0 4 -8 12 -7 13 0 10 7 10 -12 17 1462 1997 SP
+1644 1866 M
+-9 1 D
+-19 9 D
+-29 -1 D
+-45 -20 D
+10 -4 D
+10 -13 D
+-4 -10 D
+9 -23 D
+-9 23 D
+4 10 D
+-10 12 D
+-63 23 D
+-5 17 D
+-16 15 D
+-8 17 D
+0 10 D
+14 8 D
+-2 -6 D
+-12 -2 D
+0 -9 D
+8 -17 D
+19 -18 D
+3 -15 D
+45 -16 D
+44 18 D
+34 3 D
+23 -10 D
+7 -1 D
+P
+FO
+-1 -1 1 1694 1808 SP
+{1 0 0 C} FS
+1 4 1 1488 1944 SP
+-5 -1 1 1489 1942 SP
+{0 0 0.502 C} FS
+1 6 -8 -2 0 -8 6 4 4 1680 1788 SP
+4 -2 -4 -6 6 9 3 1653 1674 SP
+-1 -10 1 1589 1706 SP
+-1 -4 1 1621 1787 SP
+-8 1 1 1530 1821 SP
+2 5 1 1549 1844 SP
+-5 3 1 1667 1741 SP
+{1 0 0 C} FS
+1694 1808 M
+-1 -1 D
+1 1 D
+-50 58 D
+-9 1 D
+-19 9 D
+-29 -1 D
+-45 -20 D
+10 -4 D
+10 -13 D
+-4 -10 D
+9 -23 D
+-9 23 D
+4 10 D
+-10 12 D
+-63 23 D
+-5 17 D
+-16 15 D
+-8 17 D
+0 10 D
+14 8 D
+-2 -6 D
+-12 -2 D
+0 -9 D
+8 -17 D
+19 -18 D
+3 -15 D
+45 -16 D
+44 18 D
+34 3 D
+23 -10 D
+6 0 D
+-34 36 D
+-6 5 D
+-17 18 D
+-6 5 D
+-11 12 D
+-59 53 D
+-18 15 D
+-11 -6 D
+-12 -6 D
+-6 -3 D
+10 -12 D
+10 7 D
+13 0 D
+12 -7 D
+4 -8 D
+11 0 D
+-13 -1 D
+-20 14 D
+-7 -8 D
+15 -14 D
+4 -28 D
+-24 -2 D
+13 11 D
+-9 26 D
+-13 4 D
+-13 15 D
+-12 -6 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+5 -7 D
+8 3 D
+14 -6 D
+4 -13 D
+-29 8 D
+5 0 D
+-40 1 D
+-2 -6 D
+14 -9 D
+-7 -3 D
+34 -55 D
+41 -71 D
+32 -60 D
+41 -87 D
+18 -40 D
+73 24 D
+52 21 D
+55 27 D
+22 13 D
+-49 63 D
+P
+FO
+1 -2 -1 -1 -2 1 0 4 4 1386 1963 SP
+1 4 1 1488 1944 SP
+-5 -1 1 1489 1942 SP
+{0 0 0.502 C} FS
+1 6 -8 -2 0 -8 6 4 4 1680 1788 SP
+4 -2 -4 -6 6 9 3 1653 1674 SP
+-1 -10 1 1589 1706 SP
+-1 -4 1 1621 1787 SP
+-8 1 1 1530 1821 SP
+2 5 1 1549 1844 SP
+-5 3 1 1667 1741 SP
+9 -3 0 8 -8 4 3 1855 1790 SP
+1 3 1 1694 1808 SP
+-1 1 -35 4 -24 8 -9 15 9 -15 13 -6 36 -9 12 1 8 1642 1868 SP
+2 1 -8 1 5 -3 3 1506 2022 SP
+0 3 -10 3 9 -6 3 1524 2035 SP
+1618 1962 M
+8 -10 D
+25 -6 D
+-25 6 D
+-33 33 D
+-13 6 D
+-9 -2 D
+-46 34 D
+-13 -2 D
+5 4 D
+9 -1 D
+46 -34 D
+8 1 D
+11 -5 D
+2 5 D
+10 0 D
+16 -8 D
+13 1 D
+-13 -2 D
+-16 9 D
+-10 -1 D
+-1 -4 D
+P
+FO
+-18 11 8 -10 10 -7 -2 -11 5 -2 -3 18 6 1777 1851 SP
+11 11 -6 0 2 1561 2021 SP
+4 23 1 1723 1790 SP
+8 8 1 1549 2026 SP
+0 6 -9 -9 2 1547 2039 SP
+-5 14 1 1576 2022 SP
+-14 7 1 1607 2016 SP
+-7 3 1 1804 1784 SP
+4 -3 1 1587 2020 SP
+-9 2 1 1563 2043 SP
+-6 2 1 1605 2022 SP
+0 6 1 1743 1765 SP
+3 2 1 1839 1855 SP
+{1 0 0 C} FS
+1855 1790 M
+-8 4 D
+0 8 D
+9 -3 D
+-1 -9 D
+33 36 D
+7 9 D
+-63 56 D
+-43 36 D
+-76 55 D
+-55 36 D
+-64 38 D
+-33 17 D
+-17 -19 D
+-20 -19 D
+9 -6 D
+-10 3 D
+0 3 D
+-17 -13 D
+5 -3 D
+-8 1 D
+-12 -8 D
+42 -36 D
+41 -38 D
+5 -6 D
+18 -17 D
+5 -6 D
+12 -11 D
+28 -30 D
+12 1 D
+36 -9 D
+13 -6 D
+9 -15 D
+-9 15 D
+-24 8 D
+-35 4 D
+50 -58 D
+1 3 D
+-1 -3 D
+50 -62 D
+19 -25 D
+38 24 D
+49 40 D
+P
+FO
+{0 0 0.502 C} FS
+1618 1962 M
+8 -10 D
+25 -6 D
+-25 6 D
+-33 33 D
+-13 6 D
+-9 -2 D
+-46 34 D
+-13 -2 D
+5 4 D
+9 -1 D
+46 -34 D
+8 1 D
+11 -5 D
+2 5 D
+10 0 D
+16 -8 D
+13 1 D
+-13 -2 D
+-16 9 D
+-10 -1 D
+-1 -4 D
+P
+FO
+-18 11 8 -10 10 -7 -2 -11 5 -2 -3 18 6 1777 1851 SP
+11 11 -6 0 2 1561 2021 SP
+4 23 1 1723 1790 SP
+8 8 1 1549 2026 SP
+0 6 -9 -9 2 1547 2039 SP
+-5 14 1 1576 2022 SP
+-14 7 1 1607 2016 SP
+-7 3 1 1804 1784 SP
+4 -3 1 1587 2020 SP
+-9 2 1 1563 2043 SP
+-6 2 1 1605 2022 SP
+0 6 1 1743 1765 SP
+3 2 1 1839 1855 SP
+3 -5 1 1706 2097 SP
+13 1 6 7 -23 28 23 -28 -7 -6 -13 -1 10 -14 7 1767 2069 SP
+-10 2 -2 3 -7 3 16 -12 -3 -6 -38 27 2 3 -3 -2 -10 7 7 -9 11 -4 3 -3 -5 2 27 -18 9 -6 2 5 16 1807 1931 SP
+-15 25 -9 19 2 12 -7 -3 0 -11 9 -11 9 -28 4 0 8 -13 24 -21 2 2 11 1835 1966 SP
+-15 16 7 -12 8 -5 3 1874 1859 SP
+6 -1 1 1878 1892 SP
+3 3 1 1815 1912 SP
+{1 0 0 C} FS
+1767 2069 M
+10 -14 D
+-13 -1 D
+-7 -6 D
+23 -28 D
+-23 28 D
+6 7 D
+13 1 D
+-9 13 D
+-42 20 D
+-19 8 D
+3 -5 D
+-3 5 D
+-37 16 D
+-61 22 D
+-23 7 D
+-1 -17 D
+-7 -24 D
+-16 -28 D
+57 -31 D
+79 -49 D
+24 -16 D
+75 -56 D
+85 -73 D
+14 -13 D
+19 31 D
+11 22 D
+10 33 D
+5 33 D
+0 11 D
+-48 33 D
+-57 35 D
+-53 29 D
+P
+FO
+{0 0 0.502 C} FS
+-10 2 -2 3 -7 3 16 -12 -3 -6 -38 27 2 3 -3 -2 -10 7 7 -9 11 -4 3 -3 -5 2 27 -18 9 -6 2 5 16 1807 1931 SP
+-15 25 -9 19 2 12 -7 -3 0 -11 9 -11 9 -28 4 0 8 -13 24 -21 2 2 11 1835 1966 SP
+-15 16 7 -12 8 -5 3 1874 1859 SP
+6 -1 1 1878 1892 SP
+3 3 1 1815 1912 SP
+6 -4 0 -1 5 -3 18 -17 7 -7 2 -2 3 -1 -33 30 -8 6 9 1908 2074 SP
+1767 2069 M
+-7 10 D
+0 14 D
+-28 34 D
+-26 11 D
+-17 -6 D
+10 -9 D
+-3 -5 D
+10 -21 D
+-10 21 D
+3 5 D
+-9 7 D
+-14 -2 D
+-44 10 D
+-49 23 D
+44 -20 D
+46 -11 D
+25 6 D
+-2 20 D
+6 -1 D
+2 7 D
+41 -16 D
+0 -2 D
+-1 2 D
+-40 16 D
+-2 -8 D
+-5 2 D
+4 -16 D
+21 -5 D
+20 -14 D
+18 -28 D
+0 -14 D
+4 -5 D
+6 -1 D
+-4 -2 D
+P
+FO
+11 -5 11 -5 11 -4 11 -5 -26 18 -34 28 -4 0 5 -7 -15 7 13 -10 -14 9 12 -11 5 -3 4 -6 -1 0 15 1831 2128 SP
+-2 2 -2 1 0 -1 2 0 2 -1 5 1849 2119 SP
+{1 0 0 C} FS
+8 -6 -4 0 2 1828 2123 SP
+-4 3 1 1830 2117 SP
+{0 0 0.502 C} FS
+6 -4 1 1861 2113 SP
+-2 2 1 1879 2090 SP
+{1 0 0 C} FS
+-4 1 1 1643 2136 SP
+-1 3 1 1743 2118 SP
+1908 2074 M
+-8 6 D
+-33 30 D
+-30 16 D
+-7 2 D
+4 -6 D
+5 -3 D
+12 -11 D
+-14 9 D
+13 -10 D
+-15 7 D
+5 -7 D
+-4 0 D
+-34 28 D
+-26 18 D
+-76 27 D
+-50 14 D
+-82 16 D
+-7 1 D
+10 -16 D
+8 -17 D
+4 -17 D
+44 -20 D
+46 -11 D
+25 6 D
+-2 20 D
+6 -1 D
+2 7 D
+41 -16 D
+0 -2 D
+-1 2 D
+-40 16 D
+-2 -8 D
+-5 2 D
+4 -16 D
+21 -5 D
+20 -14 D
+18 -28 D
+0 -14 D
+4 -5 D
+6 -1 D
+-4 -2 D
+1 -2 D
+53 -27 D
+58 -35 D
+62 -42 D
+-1 22 D
+-7 33 D
+-3 11 D
+-9 22 D
+P
+FO
+-7 4 -8 5 -4 6 -5 7 -4 6 6 -4 0 -1 5 -3 18 -17 7 -7 10 1872 2107 SP
+-2 1 2 0 2 -1 3 1849 2119 SP
+1706 2097 M
+-10 21 D
+3 5 D
+-9 7 D
+-14 -2 D
+-44 10 D
+-49 23 D
+2 -14 D
+0 -5 D
+54 -18 D
+60 -23 D
+P
+FO
+1767 2069 M
+-7 10 D
+0 14 D
+-28 34 D
+-26 11 D
+-17 -6 D
+10 -9 D
+-3 -5 D
+10 -21 D
+37 -16 D
+P
+FO
+8 -6 -4 0 2 1828 2123 SP
+-4 3 1 1830 2117 SP
+{0 0 0.502 C} FS
+6 -4 1 1861 2113 SP
+-2 2 1 1879 2090 SP
+{1 0 0 C} FS
+-4 1 1 1643 2136 SP
+-1 3 1 1743 2118 SP
+{0 0 0.502 C} FS
+1875 2119 M
+-60 27 D
+4 -4 D
+7 -1 D
+9 -8 D
+17 -9 D
+15 -6 D
+17 -10 D
+9 -11 D
+-11 6 D
+-27 19 D
+-11 2 D
+0 3 D
+-6 3 D
+-7 -2 D
+-33 16 D
+-22 9 D
+-36 22 D
+-18 17 D
+3 0 D
+-7 4 D
+-8 10 D
+-11 5 D
+-7 10 D
+8 -6 D
+3 0 D
+-27 19 D
+-4 0 D
+6 -4 D
+-45 18 D
+-26 14 D
+15 -3 D
+-2 1 D
+26 -6 D
+60 -28 D
+73 -29 D
+-54 30 D
+38 -18 D
+50 -34 D
+33 -27 D
+20 -19 D
+P
+FO
+-2 2 5 -6 -1 3 6 -4 -7 5 12 -8 4 -1 0 1 -4 0 -8 5 -2 2 11 1867 2110 SP
+4 -5 -4 4 2 1849 2120 SP
+16 -1 1 1540 2235 SP
+-13 4 -11 4 -4 0 -13 8 13 -8 27 -8 5 -4 7 1511 2272 SP
+2 -1 0 1 -3 1 3 1714 2231 SP
+{1 0 0 C} FS
+16 -9 -5 3 2 1790 2190 SP
+-5 3 1 1785 2193 SP
+1893 2097 M
+-11 6 D
+-27 19 D
+-11 2 D
+0 3 D
+-6 3 D
+-7 -2 D
+18 -8 D
+-4 4 D
+4 -5 D
+8 -2 D
+12 -8 D
+-7 5 D
+6 -4 D
+-1 3 D
+5 -6 D
+23 -13 D
+P
+FO
+-5 6 17 -10 15 -6 17 -9 9 -8 7 -1 4 -4 -42 19 -18 8 9 1875 2119 SP
+1714 2231 M
+-3 1 D
+0 1 D
+-46 16 D
+-19 5 D
+60 -28 D
+73 -29 D
+-54 30 D
+P
+FO
+-3 0 -2 1 4 -1 5 -1 4 1613 2261 SP
+1511 2272 M
+5 -4 D
+27 -8 D
+13 -8 D
+-13 8 D
+-4 0 D
+-24 8 D
+-4 4 D
+-5 0 D
+-5 0 D
+-5 0 D
+-5 0 D
+32 -22 D
+17 -15 D
+16 -1 D
+-16 1 D
+17 -19 D
+4 -5 D
+52 -9 D
+58 -14 D
+57 -17 D
+48 -18 D
+-36 22 D
+-18 17 D
+3 0 D
+-7 4 D
+-8 10 D
+-11 5 D
+-7 10 D
+8 -6 D
+3 0 D
+-27 19 D
+-4 0 D
+6 -4 D
+-45 18 D
+-26 14 D
+-31 5 D
+P
+FO
+7 -3 -4 0 -8 5 -2 2 4 1867 2110 SP
+16 -9 -5 3 2 1790 2190 SP
+-5 3 1 1785 2193 SP
+{0 0 0.502 C} FS
+1725 2227 M
+-14 6 D
+-24 12 D
+-17 6 D
+-11 6 D
+-9 1 D
+-10 4 D
+7 -5 D
+-46 17 D
+2 1 D
+-20 6 D
+9 -1 D
+-33 12 D
+0 2 D
+-104 30 D
+-6 -4 D
+3 1 D
+0 -2 D
+13 -4 D
+-3 0 D
+7 -2 D
+-39 11 D
+24 1 D
+48 -7 D
+67 -21 D
+60 -23 D
+58 -25 D
+22 -12 D
+23 -11 D
+31 -17 D
+P
+FO
+-8 2 -9 2 31 -11 18 -8 22 -5 10 -4 -2 2 -11 5 -11 1 -6 4 -29 11 8 -3 -4 2 13 1620 2260 SP
+-3 1 9 -3 -3 2 3 1607 2262 SP
+-3 2 1 1511 2272 SP
+-1 1 1 1501 2272 SP
+-8 4 -8 3 -7 4 -7 4 -7 4 -7 4 -8 -3 14 -3 20 -12 9 -2 -5 -2 7 -6 7 -1 1 3 7 0 15 1438 2298 SP
+4 1 3 1 -9 2 -8 3 -9 3 -8 3 -8 3 -8 3 7 -4 18 -6 15 -9 11 1393 2319 SP
+{1 0 0 C} FS
+5 -3 -6 1 2 1452 2295 SP
+-1 1 3 -1 2 1648 2264 SP
+8 -4 -17 7 2 1630 2265 SP
+-2 1 1 1642 2268 SP
+{0 0 0.502 C} FS
+-4 2 1 1703 2236 SP
+{1 0 0 C} FS
+1393 2319 M
+15 -9 D
+18 -6 D
+12 -6 D
+7 0 D
+1 3 D
+7 -1 D
+7 -6 D
+-5 -2 D
+9 -2 D
+20 -12 D
+14 -3 D
+-8 -3 D
+11 0 D
+-1 1 D
+11 -1 D
+-3 2 D
+3 -2 D
+75 -6 D
+21 -4 D
+-3 2 D
+16 -4 D
+-4 2 D
+8 -3 D
+-29 11 D
+-6 4 D
+-11 1 D
+-13 7 D
+10 -4 D
+22 -5 D
+18 -8 D
+40 -14 D
+28 -8 D
+28 -10 D
+-24 12 D
+-17 6 D
+-11 6 D
+-9 1 D
+-10 4 D
+7 -5 D
+-46 17 D
+2 1 D
+-20 6 D
+9 -1 D
+-33 12 D
+0 2 D
+-104 30 D
+-6 -4 D
+3 1 D
+0 -2 D
+13 -4 D
+-3 0 D
+7 -2 D
+-39 11 D
+-6 0 D
+-6 -1 D
+-7 -1 D
+-6 0 D
+-6 -1 D
+P
+FO
+5 -2 -10 4 -1 0 3 1725 2227 SP
+5 -3 -6 1 2 1452 2295 SP
+-1 1 3 -1 2 1648 2264 SP
+8 -4 -17 7 2 1630 2265 SP
+-2 1 1 1642 2268 SP
+{0 0 0.502 C} FS
+-4 2 1 1703 2236 SP
+1430 2324 M
+-23 2 D
+8 1 D
+-16 4 D
+-2 3 D
+-15 4 D
+1 0 D
+-9 2 D
+6 -2 D
+-15 1 D
+6 -2 D
+-14 3 D
+1 -1 D
+-6 2 D
+-10 0 D
+23 -7 D
+8 -2 D
+2 3 D
+-2 -5 D
+20 -11 D
+-3 0 D
+-4 -1 D
+-3 -1 D
+-30 8 D
+-31 7 D
+-54 8 D
+15 1 D
+24 -1 D
+-16 5 D
+-1 2 D
+-16 2 D
+1 1 D
+-10 1 D
+11 -1 D
+5 -2 D
+-8 3 D
+22 -2 D
+3 -2 D
+34 -3 D
+-14 4 D
+8 -1 D
+-43 6 D
+-8 1 D
+8 0 D
+-5 1 D
+60 -4 D
+-11 2 D
+4 -1 D
+-16 2 D
+11 -1 D
+-23 3 D
+91 -13 D
+89 -20 D
+26 -7 D
+-23 5 D
+-40 4 D
+-8 0 D
+P
+FO
+-20 1 -1 1 -16 2 -2 1 2 -1 13 -2 3 -1 20 -1 3 0 9 1275 2357 SP
+{1 0 0 C} FS
+3 0 23 -5 -10 1 3 1361 2345 SP
+-10 1 14 -2 3 0 3 1340 2351 SP
+-4 0 9 -1 4 0 3 1323 2353 SP
+-6 1 1 1376 2339 SP
+-7 1 1 1409 2339 SP
+{0 0 0.502 C} FS
+8 -1 1 1316 2354 SP
+5 0 1 1312 2348 SP
+4 0 1 1314 2354 SP
+{1 0 0 C} FS
+1275 2357 M
+26 -2 D
+15 -3 D
+-19 4 D
+-22 1 D
+-3 -1 D
+-5 -3 D
+-8 -5 D
+-8 -7 D
+17 -1 D
+15 1 D
+24 -1 D
+-16 5 D
+-1 2 D
+-16 2 D
+1 1 D
+-10 1 D
+11 -1 D
+5 -2 D
+-8 3 D
+22 -2 D
+3 -2 D
+34 -3 D
+-14 4 D
+8 -1 D
+-43 6 D
+-8 1 D
+8 0 D
+-5 1 D
+60 -4 D
+-11 2 D
+4 -1 D
+-16 2 D
+11 -1 D
+-46 5 D
+-2 -1 D
+P
+FO
+1430 2324 M
+-23 2 D
+8 1 D
+-16 4 D
+-2 3 D
+-15 4 D
+1 0 D
+-9 2 D
+6 -2 D
+-15 1 D
+6 -2 D
+-14 3 D
+1 -1 D
+-6 2 D
+-10 0 D
+23 -7 D
+8 -2 D
+2 3 D
+-2 -5 D
+20 -11 D
+12 3 D
+P
+FO
+3 0 23 -5 -10 1 3 1361 2345 SP
+-10 1 14 -2 3 0 3 1340 2351 SP
+-4 0 9 -1 4 0 3 1323 2353 SP
+-6 1 1 1376 2339 SP
+-7 1 1 1409 2339 SP
+{0 0 0.502 C} FS
+8 -1 1 1316 2354 SP
+5 0 1 1312 2348 SP
+4 0 1 1314 2354 SP
+1213 2362 M
+-26 0 D
+-14 0 D
+9 0 D
+-11 0 D
+28 0 D
+-24 0 D
+-8 0 D
+-3 0 D
+-4 0 D
+8 0 D
+-9 0 D
+1 0 D
+-4 0 D
+-12 -1 D
+4 1 D
+-7 -1 D
+6 1 D
+-6 -1 D
+-1 0 D
+-11 0 D
+-7 0 D
+-29 -2 D
+-12 -1 D
+-3 0 D
+-1 0 D
+68 4 D
+P
+FO
+24 1 -25 -1 2 1275 2357 SP
+-6 -1 -6 0 -6 -1 20 0 4 1109 2343 SP
+{1 0 0 C} FS
+-2 0 5 0 -2 0 3 1154 2362 SP
+2 0 1 0 2 1121 2361 SP
+-6 -1 1 1147 2362 SP
+-2 0 1 1160 2362 SP
+{0 0 0.502 C} FS
+12 -1 1 1218 2362 SP
+-4 0 1 1192 2362 SP
+-10 1 1 1275 2358 SP
+2 0 1 1145 2361 SP
+-1 0 1 1274 2359 SP
+-6 1 1 1275 2358 SP
+{1 0 0 C} FS
+1109 2343 M
+98 1 D
+44 -3 D
+13 11 D
+11 5 D
+-25 -1 D
+35 2 D
+-72 4 D
+-26 0 D
+-14 0 D
+9 0 D
+-11 0 D
+28 0 D
+-24 0 D
+-8 0 D
+-3 0 D
+-4 0 D
+8 0 D
+-9 0 D
+1 0 D
+-4 0 D
+-12 -1 D
+4 1 D
+-7 -1 D
+6 1 D
+-6 -1 D
+-1 0 D
+-11 0 D
+-7 0 D
+-29 -2 D
+-12 -1 D
+-3 0 D
+8 -1 D
+5 -1 D
+16 -11 D
+P
+FO
+-2 0 5 0 -2 0 3 1154 2362 SP
+2 0 1 0 2 1121 2361 SP
+-6 -1 1 1147 2362 SP
+-2 0 1 1160 2362 SP
+{0 0 0.502 C} FS
+12 -1 1 1218 2362 SP
+-4 0 1 1192 2362 SP
+-10 1 1 1275 2358 SP
+2 0 1 1145 2361 SP
+-1 0 1 1274 2359 SP
+-6 1 1 1275 2358 SP
+13 1 13 1 13 2 -3 0 2 0 -16 -2 -16 -2 -16 -1 1 0 4 0 3 0 -7 0 -4 -1 1 0 14 1077 2358 SP
+-10 -1 -11 -2 -10 -1 -11 -1 -11 -1 2 -2 37 1 -8 1 8 3 5 -1 7 2 13 4 12 1047 2333 SP
+-5 -1 -4 -1 -1 -3 14 5 4 1030 2330 SP
+-5 -1 -4 -1 14 0 -1 3 4 1009 2325 SP
+-3 1 -7 -2 -7 -2 -7 -2 -7 -2 6 -1 12 5 15 3 8 974 2318 SP
+946 2323 M
+2 1 D
+-4 -1 D
+-11 1 D
+6 3 D
+1 -2 D
+7 4 D
+13 2 D
+-5 -3 D
+6 1 D
+-10 -3 D
+29 7 D
+-29 -11 D
+P
+FO
+3 0 1 922 2325 SP
+-34 -5 -5 1 -19 0 -26 -4 -10 2 5 -2 13 0 15 3 23 1 4 -1 33 5 7 1 12 964 2334 SP
+-7 -1 8 1 2 0 5 1 -10 -1 5 1025 2351 SP
+-4 0 4 0 22 5 3 913 2327 SP
+8 1 -5 0 2 1071 2356 SP
+-1 -2 1 995 2334 SP
+4 0 1 931 2328 SP
+5 0 1 999 2334 SP
+-16 -2 1 1013 2350 SP
+2 0 1 989 2331 SP
+2 0 1 994 2334 SP
+4 0 1 944 2331 SP
+-4 0 1 1037 2352 SP
+-5 -1 4 1 2 975 2334 SP
+-6 0 1 1059 2355 SP
+-2 0 1 1042 2354 SP
+9 1 1 979 2336 SP
+4 1 1 934 2330 SP
+1 -1 1 1053 2340 SP
+-6 -1 1 988 2333 SP
+{1 0 0 C} FS
+854 2316 M
+36 7 D
+35 2 D
+-3 0 D
+11 -1 D
+6 3 D
+1 -2 D
+7 4 D
+13 2 D
+-5 -3 D
+6 1 D
+-10 -3 D
+29 7 D
+-29 -11 D
+23 -4 D
+15 3 D
+12 5 D
+8 -1 D
+-1 3 D
+18 1 D
+18 6 D
+-1 -3 D
+24 7 D
+5 -1 D
+8 3 D
+-8 1 D
+37 1 D
+-8 7 D
+-10 6 D
+-13 2 D
+-4 -1 D
+-7 0 D
+8 0 D
+-16 -1 D
+-16 -2 D
+-16 -2 D
+2 0 D
+-3 0 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-12 -2 D
+-13 -3 D
+-12 -2 D
+-12 -3 D
+-13 -3 D
+-12 -3 D
+-12 -3 D
+-12 -4 D
+P
+FO
+-4 -1 2 1 2 946 2323 SP
+{0 0 0.502 C} FS
+-34 -5 -5 1 -19 0 -26 -4 -10 2 5 -2 13 0 15 3 23 1 4 -1 33 5 7 1 12 964 2334 SP
+-7 -1 8 1 2 0 5 1 -10 -1 5 1025 2351 SP
+-4 0 4 0 22 5 3 913 2327 SP
+8 1 -5 0 2 1071 2356 SP
+-1 -2 1 995 2334 SP
+4 0 1 931 2328 SP
+5 0 1 999 2334 SP
+-16 -2 1 1013 2350 SP
+2 0 1 989 2331 SP
+2 0 1 994 2334 SP
+4 0 1 944 2331 SP
+-4 0 1 1037 2352 SP
+-5 -1 4 1 2 975 2334 SP
+-6 0 1 1059 2355 SP
+-2 0 1 1042 2354 SP
+9 1 1 979 2336 SP
+4 1 1 934 2330 SP
+1 -1 1 1053 2340 SP
+-6 -1 1 988 2333 SP
+-2 -1 1 922 2325 SP
+4 0 4 0 2 1 -6 0 15 4 -9 1 -3 -2 -10 -3 8 944 2323 SP
+2 0 4 3 -7 -2 -2 0 4 951 2322 SP
+963 2312 M
+-11 0 D
+-22 -6 D
+-9 0 D
+-21 -10 D
+-3 -7 D
+-16 -3 D
+-15 -9 D
+9 1 D
+-1 3 D
+10 1 D
+-7 -3 D
+0 -3 D
+-6 -1 D
+5 0 D
+-4 -3 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 -1 D
+12 7 D
+13 3 D
+8 5 D
+17 3 D
+6 7 D
+-8 -3 D
+-5 -5 D
+2 6 D
+-14 -2 D
+-4 0 D
+6 1 D
+-11 -1 D
+17 4 D
+0 -2 D
+21 5 D
+7 5 D
+22 7 D
+5 0 D
+-6 -3 D
+49 10 D
+5 -1 D
+-5 -1 D
+-6 -2 D
+P
+FO
+-2 0 -9 -5 13 5 3 809 2270 SP
+-5 -3 6 3 2 792 2268 SP
+-2 0 -6 -2 4 0 5 2 4 758 2263 SP
+2 0 1 747 2261 SP
+-3 0 4 0 -1 0 2 1 4 726 2256 SP
+0 1 1 722 2255 SP
+1 0 1 713 2253 SP
+-1 0 -6 -3 8 3 -4 -2 11 5 -2 0 -1 -1 -5 -2 1 0 9 646 2231 SP
+-3 -2 -5 -2 -5 -3 4 1 9 5 3 2 6 631 2224 SP
+{1 0 0 C} FS
+-4 -2 1 875 2286 SP
+-6 -1 1 860 2274 SP
+{0 0 0.502 C} FS
+6 7 7 3 -7 -3 7 3 -6 -2 -5 -3 -1 0 16 8 -15 -6 -9 -7 -29 -8 20 5 -6 -3 3 0 -16 -5 26 8 16 852 2310 SP
+-13 -4 0 -2 12 4 -1 -1 -5 -1 6 1 6 704 2257 SP
+-7 -3 11 4 -5 -1 -11 -4 4 755 2280 SP
+5 3 24 12 -31 -14 -4 -3 4 797 2294 SP
+9 1 -7 -2 7 2 -5 0 4 897 2307 SP
+-3 -2 6 1 5 3 -8 -1 4 730 2263 SP
+-5 -2 8 3 -8 -2 3 736 2273 SP
+-2 -2 -5 -1 10 2 3 762 2274 SP
+-12 -3 1 1 -3 -2 3 811 2288 SP
+-1 -1 9 4 2 856 2301 SP
+-5 1 -1 -3 2 820 2296 SP
+5 2 5 3 2 853 2298 SP
+-6 -2 4 -1 2 784 2281 SP
+-13 -4 20 6 2 878 2318 SP
+-9 0 -2 -4 2 784 2272 SP
+3 1 -5 -2 2 721 2268 SP
+-8 -3 3 0 2 761 2275 SP
+-3 -3 19 8 2 827 2290 SP
+-3 1 -20 -6 2 898 2311 SP
+-3 -1 13 3 2 893 2318 SP
+6 3 -5 -2 2 745 2274 SP
+-11 -4 4 0 7 3 3 742 2265 SP
+6 3 -9 -4 2 680 2244 SP
+1 2 1 887 2312 SP
+6 2 1 800 2296 SP
+-2 0 -22 -5 2 880 2303 SP
+1 1 1 702 2258 SP
+-11 -6 1 859 2304 SP
+17 5 1 793 2297 SP
+-8 -1 1 923 2321 SP
+2 -2 1 750 2266 SP
+0 -1 1 771 2280 SP
+3 0 1 756 2270 SP
+-4 -2 4 1 2 771 2270 SP
+-11 -3 1 841 2280 SP
+6 3 1 846 2309 SP
+9 5 1 885 2284 SP
+1 -2 1 824 2293 SP
+4 1 1 869 2317 SP
+2 2 1 755 2274 SP
+0 -1 1 881 2315 SP
+-9 -2 8 2 2 829 2293 SP
+1 1 1 685 2250 SP
+4 0 1 898 2318 SP
+-1 -1 1 834 2302 SP
+4 1 1 822 2300 SP
+0 2 1 901 2305 SP
+4 0 -3 0 2 852 2297 SP
+-2 -1 1 836 2301 SP
+-9 -4 1 693 2253 SP
+-2 1 1 963 2319 SP
+-1 -1 1 683 2245 SP
+-2 -1 1 675 2245 SP
+2 -1 1 777 2278 SP
+-6 -2 1 794 2290 SP
+1 1 1 742 2277 SP
+4 0 1 775 2274 SP
+4 1 -3 -1 2 700 2259 SP
+4 3 1 656 2235 SP
+8 2 1 869 2318 SP
+-4 0 1 912 2319 SP
+1 0 1 741 2277 SP
+-3 -2 1 808 2285 SP
+-1 1 1 871 2303 SP
+-1 0 1 721 2267 SP
+6 2 1 872 2317 SP
+-1 1 1 675 2243 SP
+-1 -1 1 767 2271 SP
+-2 -2 3 2 2 672 2245 SP
+-5 -2 1 788 2278 SP
+-3 -2 1 769 2268 SP
+-1 0 1 659 2237 SP
+-3 -2 1 637 2228 SP
+4 1 1 812 2286 SP
+-1 1 0 -1 2 816 2296 SP
+-5 -1 1 692 2247 SP
+1 1 1 713 2264 SP
+-10 -5 1 662 2242 SP
+0 1 1 903 2318 SP
+3 1 1 722 2259 SP
+5 2 1 695 2255 SP
+3 2 1 850 2301 SP
+3 2 1 684 2247 SP
+-1 0 1 746 2272 SP
+3 2 1 668 2241 SP
+2 2 1 660 2236 SP
+9 4 1 876 2308 SP
+2 0 -1 0 2 736 2268 SP
+-5 -1 1 765 2286 SP
+4 1 1 779 2273 SP
+-4 -1 1 742 2267 SP
+3 0 1 824 2298 SP
+4 2 1 911 2298 SP
+-3 -2 1 845 2299 SP
+4 2 -3 -2 2 759 2283 SP
+-6 -3 1 711 2264 SP
+-3 -3 1 819 2290 SP
+4 2 1 884 2306 SP
+3 -1 1 770 2274 SP
+6 2 1 895 2321 SP
+1 1 1 708 2261 SP
+-4 -2 1 811 2287 SP
+1 0 1 766 2278 SP
+-2 -1 1 690 2249 SP
+3 2 1 674 2245 SP
+4 2 1 766 2280 SP
+-2 -1 1 713 2260 SP
+-6 -2 1 875 2306 SP
+-1 1 1 895 2315 SP
+7 2 1 911 2295 SP
+-9 -2 1 938 2317 SP
+-1 1 1 873 2304 SP
+3 1 1 815 2296 SP
+4 2 1 915 2299 SP
+0 -1 1 841 2297 SP
+{1 0 0 C} FS
+4 2 1 841 2303 SP
+5 2 1 839 2303 SP
+630 2226 M
+-16 -9 D
+-14 -8 D
+47 23 D
+-5 -3 D
+-5 -2 D
+13 6 D
+-4 -2 D
+8 3 D
+-6 -3 D
+-1 0 D
+56 19 D
+11 3 D
+-1 0 D
+9 2 D
+0 1 D
+0 -1 D
+6 2 D
+-1 0 D
+22 4 D
+-2 0 D
+20 4 D
+-6 -2 D
+31 5 D
+6 3 D
+-5 -3 D
+16 2 D
+13 5 D
+-9 -5 D
+24 1 D
+12 7 D
+13 3 D
+8 5 D
+17 3 D
+6 7 D
+-8 -3 D
+-5 -5 D
+2 6 D
+-14 -2 D
+-4 0 D
+6 1 D
+-11 -1 D
+17 4 D
+0 -2 D
+21 5 D
+7 5 D
+22 7 D
+5 0 D
+-6 -3 D
+49 10 D
+-23 4 D
+-9 -2 D
+4 3 D
+-2 0 D
+-10 -3 D
+-3 -2 D
+-9 1 D
+15 4 D
+-6 0 D
+2 1 D
+-11 1 D
+-2 -1 D
+2 1 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-19 -6 D
+-12 -3 D
+-12 -4 D
+-12 -4 D
+-12 -4 D
+-12 -5 D
+-12 -4 D
+-12 -4 D
+-12 -5 D
+-11 -5 D
+-12 -5 D
+-12 -5 D
+-11 -5 D
+-12 -5 D
+-23 -11 D
+-23 -11 D
+P
+FO
+2 1 -5 -2 1 0 3 646 2231 SP
+963 2312 M
+-11 0 D
+-22 -6 D
+-9 0 D
+-21 -10 D
+-3 -7 D
+-16 -3 D
+-15 -9 D
+9 1 D
+-1 3 D
+10 1 D
+-7 -3 D
+0 -3 D
+-6 -1 D
+5 0 D
+50 24 D
+P
+FO
+-4 -2 1 875 2286 SP
+-6 -1 1 860 2274 SP
+{0 0 0.502 C} FS
+6 7 7 3 -7 -3 7 3 -6 -2 -5 -3 -1 0 16 8 -15 -6 -9 -7 -29 -8 20 5 -6 -3 3 0 -16 -5 26 8 16 852 2310 SP
+-13 -4 0 -2 12 4 -1 -1 -5 -1 6 1 6 704 2257 SP
+-7 -3 11 4 -5 -1 -11 -4 4 755 2280 SP
+5 3 24 12 -31 -14 -4 -3 4 797 2294 SP
+9 1 -7 -2 7 2 -5 0 4 897 2307 SP
+-3 -2 6 1 5 3 -8 -1 4 730 2263 SP
+-5 -2 8 3 -8 -2 3 736 2273 SP
+-2 -2 -5 -1 10 2 3 762 2274 SP
+-12 -3 1 1 -3 -2 3 811 2288 SP
+-1 -1 9 4 2 856 2301 SP
+-5 1 -1 -3 2 820 2296 SP
+5 2 5 3 2 853 2298 SP
+-6 -2 4 -1 2 784 2281 SP
+-13 -4 20 6 2 878 2318 SP
+-9 0 -2 -4 2 784 2272 SP
+3 1 -5 -2 2 721 2268 SP
+-8 -3 3 0 2 761 2275 SP
+-3 -3 19 8 2 827 2290 SP
+-3 1 -20 -6 2 898 2311 SP
+-3 -1 13 3 2 893 2318 SP
+6 3 -5 -2 2 745 2274 SP
+-11 -4 4 0 7 3 3 742 2265 SP
+6 3 -9 -4 2 680 2244 SP
+1 2 1 887 2312 SP
+6 2 1 800 2296 SP
+-2 0 -22 -5 2 880 2303 SP
+1 1 1 702 2258 SP
+-11 -6 1 859 2304 SP
+17 5 1 793 2297 SP
+-8 -1 1 923 2321 SP
+2 -2 1 750 2266 SP
+0 -1 1 771 2280 SP
+3 0 1 756 2270 SP
+-4 -2 4 1 2 771 2270 SP
+-11 -3 1 841 2280 SP
+6 3 1 846 2309 SP
+9 5 1 885 2284 SP
+1 -2 1 824 2293 SP
+4 1 1 869 2317 SP
+2 2 1 755 2274 SP
+0 -1 1 881 2315 SP
+-9 -2 8 2 2 829 2293 SP
+1 1 1 685 2250 SP
+4 0 1 898 2318 SP
+-1 -1 1 834 2302 SP
+4 1 1 822 2300 SP
+0 2 1 901 2305 SP
+4 0 -3 0 2 852 2297 SP
+-2 -1 1 836 2301 SP
+-9 -4 1 693 2253 SP
+-2 1 1 963 2319 SP
+-1 -1 1 683 2245 SP
+-2 -1 1 675 2245 SP
+2 -1 1 777 2278 SP
+-6 -2 1 794 2290 SP
+1 1 1 742 2277 SP
+4 0 1 775 2274 SP
+4 1 -3 -1 2 700 2259 SP
+4 3 1 656 2235 SP
+8 2 1 869 2318 SP
+-4 0 1 912 2319 SP
+1 0 1 741 2277 SP
+-3 -2 1 808 2285 SP
+-1 1 1 871 2303 SP
+-1 0 1 721 2267 SP
+6 2 1 872 2317 SP
+-1 1 1 675 2243 SP
+-1 -1 1 767 2271 SP
+-2 -2 3 2 2 672 2245 SP
+-5 -2 1 788 2278 SP
+-3 -2 1 769 2268 SP
+-1 0 1 659 2237 SP
+-3 -2 1 637 2228 SP
+4 1 1 812 2286 SP
+-1 1 0 -1 2 816 2296 SP
+-5 -1 1 692 2247 SP
+1 1 1 713 2264 SP
+-10 -5 1 662 2242 SP
+0 1 1 903 2318 SP
+3 1 1 722 2259 SP
+5 2 1 695 2255 SP
+3 2 1 850 2301 SP
+3 2 1 684 2247 SP
+-1 0 1 746 2272 SP
+3 2 1 668 2241 SP
+2 2 1 660 2236 SP
+9 4 1 876 2308 SP
+2 0 -1 0 2 736 2268 SP
+-5 -1 1 765 2286 SP
+4 1 1 779 2273 SP
+-4 -1 1 742 2267 SP
+3 0 1 824 2298 SP
+4 2 1 911 2298 SP
+-3 -2 1 845 2299 SP
+4 2 -3 -2 2 759 2283 SP
+-6 -3 1 711 2264 SP
+-3 -3 1 819 2290 SP
+4 2 1 884 2306 SP
+3 -1 1 770 2274 SP
+6 2 1 895 2321 SP
+1 1 1 708 2261 SP
+-4 -2 1 811 2287 SP
+1 0 1 766 2278 SP
+-2 -1 1 690 2249 SP
+3 2 1 674 2245 SP
+4 2 1 766 2280 SP
+-2 -1 1 713 2260 SP
+-6 -2 1 875 2306 SP
+-1 1 1 895 2315 SP
+7 2 1 911 2295 SP
+-9 -2 1 938 2317 SP
+-1 1 1 873 2304 SP
+3 1 1 815 2296 SP
+4 2 1 915 2299 SP
+0 -1 1 841 2297 SP
+{1 0 0 C} FS
+4 2 1 841 2303 SP
+5 2 1 839 2303 SP
+{0 0 0.502 C} FS
+2 2 -6 -4 1 0 3 516 2147 SP
+3 1 14 7 -16 -7 -4 -3 4 637 2227 SP
+2 0 6 4 -9 -5 3 642 2229 SP
+0 1 -1 -1 2 647 2231 SP
+-3 -2 1 713 2253 SP
+-1 -1 1 722 2255 SP
+2 1 6 3 -10 -3 6 2 -6 -2 -2 2 -4 -4 5 1 8 731 2257 SP
+-3 -1 1 747 2261 SP
+1 0 1 1 -4 -1 3 761 2263 SP
+11 6 2 4 -14 -10 3 793 2268 SP
+2 0 1 1 2 4 -7 -5 4 813 2270 SP
+855 2261 M
+-21 -8 D
+2 2 D
+-7 1 D
+1 -2 D
+-9 -2 D
+1 6 D
+-15 -2 D
+10 4 D
+10 -1 D
+-1 3 D
+4 -1 D
+7 3 D
+5 4 D
+-10 -2 D
+-4 -3 D
+-6 0 D
+15 4 D
+-5 1 D
+5 3 D
+35 1 D
+-9 -5 D
+P
+FO
+820 2232 M
+-1 0 D
+1 0 D
+-2 -1 D
+-1 -2 D
+-13 -12 D
+3 1 D
+-1 0 D
+-7 -4 D
+6 2 D
+-4 -5 D
+-2 0 D
+-2 0 D
+1 2 D
+-4 -3 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-8 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-1 0 D
+-6 -3 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -3 D
+-7 -2 D
+-6 -2 D
+-7 -3 D
+-6 -2 D
+-7 -3 D
+-6 -3 D
+-7 -2 D
+-12 -6 D
+-3 -1 D
+-2 -1 D
+-6 -2 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -7 D
+-12 -6 D
+11 7 D
+27 21 D
+34 16 D
+15 16 D
+61 40 D
+6 8 D
+4 0 D
+25 10 D
+7 5 D
+-5 -1 D
+13 5 D
+21 5 D
+9 -2 D
+6 3 D
+0 -5 D
+7 3 D
+-6 -5 D
+2 -1 D
+14 6 D
+1 2 D
+2 0 D
+11 7 D
+4 0 D
+-27 -14 D
+8 -1 D
+-8 -7 D
+11 -1 D
+30 17 D
+-4 -4 D
+-21 -11 D
+9 -3 D
+9 4 D
+-17 -12 D
+18 8 D
+-4 -5 D
+-12 -4 D
+13 -4 D
+22 8 D
+-1 -4 D
+7 3 D
+3 -1 D
+12 7 D
+1 -2 D
+11 10 D
+-22 -5 D
+3 3 D
+-21 0 D
+0 2 D
+33 7 D
+9 4 D
+-14 1 D
+24 6 D
+-3 -3 D
+14 8 D
+4 -1 D
+-17 -15 D
+P
+FO
+{1 0 0 C} FS
+-11 -4 10 -5 -12 -5 -3 -5 -5 2 -28 -4 14 5 -3 1 25 14 9 2 1 4 9 4 3 -2 13 688 2191 SP
+28 8 0 -4 -18 -7 3 851 2269 SP
+6 -4 -6 -3 -3 2 3 685 2197 SP
+12 6 -4 -3 2 738 2212 SP
+10 7 -11 -10 2 522 2131 SP
+10 1 -5 -1 2 786 2229 SP
+-5 -1 1 850 2262 SP
+-8 -3 1 745 2217 SP
+{0 0 0.502 C} FS
+18 9 2 2 11 5 2 2 16 8 -7 -3 -49 -25 -7 -3 11 5 -10 -6 4 1 10 6 12 625 2219 SP
+-11 -7 12 8 4 3 -5 -2 4 543 2168 SP
+9 5 18 10 -27 -14 3 614 2215 SP
+6 4 -8 -5 2 610 2206 SP
+6 3 -1 0 2 768 2257 SP
+3 3 -7 -2 2 808 2262 SP
+5 1 3 3 2 727 2235 SP
+6 5 -7 -2 4 -1 3 680 2241 SP
+-9 -3 1 -2 2 755 2258 SP
+4 1 2 4 2 614 2205 SP
+3 3 1 634 2218 SP
+-13 -8 14 8 2 754 2246 SP
+15 5 1 725 2249 SP
+5 5 1 637 2221 SP
+5 5 1 574 2178 SP
+-3 1 2 -1 2 767 2264 SP
+4 4 1 541 2165 SP
+2 -2 1 729 2245 SP
+-6 -1 1 776 2261 SP
+8 1 1 740 2248 SP
+-6 -3 1 616 2217 SP
+-2 -1 1 562 2181 SP
+2 -1 1 774 2263 SP
+2 0 1 782 2266 SP
+1 2 1 645 2225 SP
+-2 1 1 784 2215 SP
+4 2 1 555 2179 SP
+4 3 1 530 2152 SP
+2 2 1 514 2143 SP
+-3 0 1 843 2254 SP
+-4 1 1 800 2260 SP
+-3 -1 1 556 2156 SP
+5 4 1 626 2216 SP
+3 3 1 627 2214 SP
+11 4 1 716 2240 SP
+5 4 1 583 2190 SP
+2 2 1 650 2224 SP
+2 2 1 559 2170 SP
+-7 0 1 834 2252 SP
+0 1 1 673 2236 SP
+6 3 1 644 2220 SP
+2 2 1 566 2177 SP
+-1 0 1 607 2210 SP
+4 2 1 763 2254 SP
+-3 0 1 698 2248 SP
+4 3 1 539 2157 SP
+1 1 1 657 2228 SP
+2 3 1 636 2218 SP
+-3 0 1 742 2244 SP
+1 -1 0 1 2 624 2211 SP
+4 0 1 758 2256 SP
+-5 -2 1 731 2247 SP
+-1 0 1 640 2225 SP
+-5 -2 1 624 2220 SP
+-1 0 1 558 2176 SP
+4 3 1 588 2190 SP
+4 2 1 547 2160 SP
+1 -1 0 1 2 638 2219 SP
+6 4 1 756 2251 SP
+-1 0 1 555 2175 SP
+4 3 1 604 2201 SP
+-1 0 1 533 2160 SP
+5 2 1 714 2246 SP
+-4 -2 1 475 2099 SP
+-1 0 1 649 2231 SP
+-5 -2 1 645 2229 SP
+-1 1 1 783 2264 SP
+2 1 1 641 2226 SP
+-4 -1 1 685 2238 SP
+1 0 1 557 2179 SP
+1 1 1 653 2229 SP
+3 2 1 607 2202 SP
+5 3 1 767 2230 SP
+2 2 1 528 2155 SP
+1 1 1 650 2227 SP
+-2 1 1 653 2230 SP
+-1 0 1 524 2152 SP
+-3 -2 1 700 2245 SP
+2 2 1 652 2225 SP
+2 2 1 541 2160 SP
+5 2 1 765 2227 SP
+5 4 1 644 2224 SP
+0 1 1 651 2228 SP
+{1 0 0 C} FS
+-3 -1 1 615 2214 SP
+516 2147 M
+1 0 D
+-6 -4 D
+-23 -24 D
+-14 -16 D
+-6 -9 D
+28 18 D
+27 21 D
+34 16 D
+15 16 D
+61 40 D
+6 8 D
+4 0 D
+25 10 D
+7 5 D
+-5 -1 D
+13 5 D
+21 5 D
+9 -2 D
+6 3 D
+0 -5 D
+7 3 D
+-6 -5 D
+2 -1 D
+14 6 D
+1 2 D
+2 0 D
+11 7 D
+4 0 D
+-27 -14 D
+8 -1 D
+-8 -7 D
+11 -1 D
+30 17 D
+-4 -4 D
+-21 -11 D
+9 -3 D
+9 4 D
+-17 -12 D
+18 8 D
+-4 -5 D
+-12 -4 D
+13 -4 D
+22 8 D
+-1 -4 D
+7 3 D
+3 -1 D
+12 7 D
+1 -2 D
+11 10 D
+-22 -5 D
+3 3 D
+-21 0 D
+0 2 D
+33 7 D
+9 4 D
+-14 1 D
+24 6 D
+-3 -3 D
+14 8 D
+4 -1 D
+9 7 D
+5 3 D
+-21 -8 D
+2 2 D
+-7 1 D
+1 -2 D
+-9 -2 D
+1 6 D
+-15 -2 D
+10 4 D
+10 -1 D
+-1 3 D
+4 -1 D
+7 3 D
+5 4 D
+-10 -2 D
+-4 -3 D
+-6 0 D
+15 4 D
+-5 1 D
+5 3 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-7 -5 D
+3 5 D
+-5 -1 D
+-5 0 D
+-6 -1 D
+-14 -10 D
+2 4 D
+11 6 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-4 -1 D
+1 1 D
+-5 -1 D
+-6 -1 D
+-3 -1 D
+3 1 D
+-5 -1 D
+-6 -2 D
+-5 -1 D
+5 1 D
+-4 -4 D
+-2 2 D
+-6 -2 D
+6 2 D
+-10 -3 D
+6 3 D
+-2 0 D
+-2 -1 D
+-1 -1 D
+1 1 D
+-5 -1 D
+-4 -1 D
+-3 -2 D
+3 2 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-1 -1 D
+0 1 D
+-4 -2 D
+-9 -5 D
+6 4 D
+-2 -1 D
+-4 -3 D
+-16 -7 D
+14 7 D
+-8 -3 D
+-16 -8 D
+-7 -4 D
+-14 -9 D
+-13 -8 D
+-18 -13 D
+-18 -13 D
+P
+FO
+-1 0 1 656 2178 SP
+2 0 -4 -3 1 2 3 797 2211 SP
+1 0 -1 -1 2 802 2212 SP
+6 2 -7 -4 2 806 2218 SP
+3 4 3 4 3 1 -13 -12 4 817 2229 SP
+-1 0 1 820 2232 SP
+-11 -4 10 -5 -12 -5 -3 -5 -5 2 -28 -4 14 5 -3 1 25 14 9 2 1 4 9 4 3 -2 13 688 2191 SP
+28 8 0 -4 -18 -7 3 851 2269 SP
+6 -4 -6 -3 -3 2 3 685 2197 SP
+12 6 -4 -3 2 738 2212 SP
+10 7 -11 -10 2 522 2131 SP
+10 1 -5 -1 2 786 2229 SP
+-5 -1 1 850 2262 SP
+-8 -3 1 745 2217 SP
+{0 0 0.502 C} FS
+18 9 2 2 11 5 2 2 16 8 -7 -3 -49 -25 -7 -3 11 5 -10 -6 4 1 10 6 12 625 2219 SP
+-11 -7 12 8 4 3 -5 -2 4 543 2168 SP
+9 5 18 10 -27 -14 3 614 2215 SP
+6 4 -8 -5 2 610 2206 SP
+6 3 -1 0 2 768 2257 SP
+3 3 -7 -2 2 808 2262 SP
+5 1 3 3 2 727 2235 SP
+6 5 -7 -2 4 -1 3 680 2241 SP
+-9 -3 1 -2 2 755 2258 SP
+4 1 2 4 2 614 2205 SP
+3 3 1 634 2218 SP
+-13 -8 14 8 2 754 2246 SP
+15 5 1 725 2249 SP
+5 5 1 637 2221 SP
+5 5 1 574 2178 SP
+-3 1 2 -1 2 767 2264 SP
+4 4 1 541 2165 SP
+2 -2 1 729 2245 SP
+-6 -1 1 776 2261 SP
+8 1 1 740 2248 SP
+-6 -3 1 616 2217 SP
+-2 -1 1 562 2181 SP
+2 -1 1 774 2263 SP
+2 0 1 782 2266 SP
+1 2 1 645 2225 SP
+-2 1 1 784 2215 SP
+4 2 1 555 2179 SP
+4 3 1 530 2152 SP
+2 2 1 514 2143 SP
+-3 0 1 843 2254 SP
+-4 1 1 800 2260 SP
+-3 -1 1 556 2156 SP
+5 4 1 626 2216 SP
+3 3 1 627 2214 SP
+11 4 1 716 2240 SP
+5 4 1 583 2190 SP
+2 2 1 650 2224 SP
+2 2 1 559 2170 SP
+-7 0 1 834 2252 SP
+0 1 1 673 2236 SP
+6 3 1 644 2220 SP
+2 2 1 566 2177 SP
+-1 0 1 607 2210 SP
+4 2 1 763 2254 SP
+-3 0 1 698 2248 SP
+4 3 1 539 2157 SP
+1 1 1 657 2228 SP
+2 3 1 636 2218 SP
+-3 0 1 742 2244 SP
+1 -1 0 1 2 624 2211 SP
+4 0 1 758 2256 SP
+-5 -2 1 731 2247 SP
+-1 0 1 640 2225 SP
+-5 -2 1 624 2220 SP
+-1 0 1 558 2176 SP
+4 3 1 588 2190 SP
+4 2 1 547 2160 SP
+1 -1 0 1 2 638 2219 SP
+6 4 1 756 2251 SP
+-1 0 1 555 2175 SP
+4 3 1 604 2201 SP
+-1 0 1 533 2160 SP
+5 2 1 714 2246 SP
+-4 -2 1 475 2099 SP
+-1 0 1 649 2231 SP
+-5 -2 1 645 2229 SP
+-1 1 1 783 2264 SP
+2 1 1 641 2226 SP
+-4 -1 1 685 2238 SP
+1 0 1 557 2179 SP
+1 1 1 653 2229 SP
+3 2 1 607 2202 SP
+5 3 1 767 2230 SP
+2 2 1 528 2155 SP
+1 1 1 650 2227 SP
+-2 1 1 653 2230 SP
+-1 0 1 524 2152 SP
+-3 -2 1 700 2245 SP
+2 2 1 652 2225 SP
+2 2 1 541 2160 SP
+5 2 1 765 2227 SP
+5 4 1 644 2224 SP
+0 1 1 651 2228 SP
+{1 0 0 C} FS
+-3 -1 1 615 2214 SP
+{0 0 0.502 C} FS
+1 9 1 9 1 8 0 9 -2 -1 -2 -2 -5 -42 4 1 8 427 2009 SP
+-12 -8 0 -1 8 4 3 3 4 432 2026 SP
+-1 0 4 2 2 437 2039 SP
+1 2 -6 -4 4 1 3 458 2080 SP
+559 2141 M
+-1 -3 D
+-3 -1 D
+8 2 D
+-5 -1 D
+10 4 D
+-9 -1 D
+8 2 D
+-3 0 D
+45 19 D
+46 16 D
+3 -2 D
+8 3 D
+-10 -1 D
+61 17 D
+70 14 D
+7 1 D
+3 -1 D
+0 2 D
+4 0 D
+-4 -4 D
+2 1 D
+-2 -3 D
+-6 -2 D
+4 -2 D
+-6 0 D
+-2 -4 D
+-9 -3 D
+-8 2 D
+4 -3 D
+-12 -7 D
+2 -1 D
+-29 -12 D
+-8 0 D
+-3 -4 D
+2 4 D
+-7 3 D
+-15 -7 D
+1 8 D
+8 8 D
+-17 -2 D
+-9 -16 D
+9 4 D
+-13 -8 D
+6 1 D
+-16 -8 D
+-7 -8 D
+-1 3 D
+-7 -4 D
+-29 -34 D
+36 26 D
+-9 -8 D
+8 4 D
+-24 -22 D
+22 10 D
+-11 -8 D
+14 6 D
+6 7 D
+2 -2 D
+9 6 D
+-4 1 D
+8 4 D
+-6 -1 D
+18 8 D
+-3 3 D
+12 4 D
+-2 -6 D
+12 7 D
+-2 -5 D
+-10 -6 D
+5 0 D
+-8 -1 D
+7 -4 D
+-11 1 D
+-17 -14 D
+19 7 D
+-7 -6 D
+11 5 D
+-3 -5 D
+7 6 D
+-1 -6 D
+6 5 D
+0 -3 D
+8 5 D
+-7 0 D
+6 3 D
+-3 3 D
+10 0 D
+-8 0 D
+6 1 D
+-4 4 D
+5 -2 D
+2 4 D
+-1 -3 D
+9 5 D
+-2 2 D
+6 0 D
+-7 0 D
+7 4 D
+-7 -2 D
+9 3 D
+-5 0 D
+7 2 D
+-4 0 D
+8 3 D
+0 3 D
+2 -3 D
+10 12 D
+-2 -6 D
+7 3 D
+-2 2 D
+3 -2 D
+4 4 D
+-6 -9 D
+6 3 D
+5 11 D
+0 -10 D
+5 2 D
+-3 -26 D
+-8 -2 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-15 -8 D
+-16 -8 D
+-15 -8 D
+-15 -8 D
+-15 -8 D
+-15 -9 D
+-15 -8 D
+-5 1 D
+14 6 D
+-4 -1 D
+4 3 D
+3 8 D
+5 0 D
+0 4 D
+1 -2 D
+3 5 D
+1 -2 D
+4 7 D
+-2 -6 D
+8 3 D
+7 10 D
+2 -3 D
+6 8 D
+4 0 D
+-3 4 D
+8 0 D
+-2 4 D
+6 -1 D
+7 5 D
+0 5 D
+2 -3 D
+16 14 D
+4 0 D
+2 4 D
+-10 -2 D
+-7 -5 D
+-1 3 D
+-5 -5 D
+-3 3 D
+-10 -6 D
+11 7 D
+-13 0 D
+10 7 D
+-9 -1 D
+13 4 D
+4 10 D
+4 0 D
+-5 -3 D
+8 2 D
+1 3 D
+11 5 D
+4 6 D
+-2 -6 D
+18 6 D
+-5 0 D
+10 11 D
+8 3 D
+1 3 D
+19 13 D
+-5 1 D
+16 17 D
+-3 1 D
+-15 -7 D
+-10 -1 D
+-2 -3 D
+-14 -7 D
+-19 -1 D
+-16 -13 D
+-29 -14 D
+-14 -2 D
+-2 7 D
+-11 -8 D
+-32 -19 D
+-5 0 D
+-10 -6 D
+10 7 D
+-6 -2 D
+1 2 D
+61 31 D
+P
+FO
+-6 2 1 782 2174 SP
+6 -1 -5 1 2 479 2004 SP
+{1 0 0 C} FS
+-1 -6 -18 -3 8 7 3 754 2187 SP
+2 4 5 0 2 673 2176 SP
+-7 -6 2 4 2 751 2182 SP
+1 4 4 0 2 618 2104 SP
+-7 -3 1 766 2190 SP
+-1 -3 1 541 2132 SP
+4 -2 1 782 2206 SP
+5 4 1 602 2110 SP
+5 3 1 676 2173 SP
+-6 -1 1 784 2199 SP
+-1 -3 1 529 2043 SP
+-3 2 1 792 2204 SP
+0 -3 1 637 2112 SP
+-3 0 1 561 2137 SP
+-3 -4 1 600 2096 SP
+-7 -5 1 658 2118 SP
+2 3 1 655 2155 SP
+{0 0 0.502 C} FS
+-1 -5 -9 -7 11 9 1 -3 -20 -18 14 9 -6 -3 13 13 7 4 1 3 -6 -5 -5 0 5 6 -2 5 -2 -5 -12 -11 16 502 2043 SP
+3 6 -4 -3 -2 1 3 566 2122 SP
+-6 -5 5 4 6 2 3 486 2058 SP
+6 5 -4 -2 2 462 2049 SP
+4 5 -5 -3 2 524 2054 SP
+3 4 -5 -3 2 524 2061 SP
+4 5 -7 -5 2 547 2114 SP
+19 15 -17 -8 2 458 2037 SP
+14 4 4 6 2 682 2151 SP
+3 4 -8 -6 2 556 2126 SP
+-4 -1 -3 -4 2 457 2070 SP
+13 7 -16 -3 2 462 2061 SP
+7 8 -8 -7 2 602 2137 SP
+-8 -3 6 -1 2 483 2056 SP
+-7 -8 6 4 2 465 2022 SP
+0 3 -5 -3 4 0 3 505 2075 SP
+-4 -5 1 486 2036 SP
+-6 -2 1 571 2099 SP
+-4 -3 1 521 2070 SP
+-4 -2 1 471 2072 SP
+0 -6 1 484 2026 SP
+-3 -3 1 595 2147 SP
+-4 0 1 633 2156 SP
+-5 -3 1 492 2016 SP
+1 2 1 512 2110 SP
+-6 -5 1 501 2055 SP
+-4 -4 1 491 2045 SP
+-4 -2 1 589 2140 SP
+-4 -2 1 547 2089 SP
+1 3 1 474 2085 SP
+-5 -3 1 572 2102 SP
+0 2 1 595 2120 SP
+5 4 -5 -3 2 472 2036 SP
+-4 -3 1 567 2104 SP
+0 1 1 493 2022 SP
+-2 0 1 465 2071 SP
+-5 -3 1 529 2060 SP
+3 3 1 723 2149 SP
+-2 -3 1 768 2188 SP
+-1 2 1 588 2114 SP
+5 7 1 459 1995 SP
+1 -6 1 523 2099 SP
+-3 1 -3 -5 2 472 2087 SP
+-9 -7 1 484 2065 SP
+-2 -7 8 10 2 614 2138 SP
+-12 -8 1 549 2088 SP
+0 -4 1 0 2 548 2114 SP
+9 6 1 466 2031 SP
+-5 -3 1 537 2099 SP
+7 6 -6 -6 2 450 2046 SP
+-7 -5 1 535 2081 SP
+-8 -3 1 584 2133 SP
+-8 -7 1 592 2140 SP
+-2 1 1 487 2067 SP
+-5 -1 1 540 2105 SP
+6 2 -5 -2 2 615 2146 SP
+1 -2 1 480 2051 SP
+1 2 1 609 2137 SP
+-7 -4 1 591 2123 SP
+5 3 1 457 2013 SP
+-5 -6 1 628 2148 SP
+-5 -4 1 460 2036 SP
+-4 -4 1 577 2126 SP
+-3 -3 1 536 2125 SP
+-7 -3 1 633 2155 SP
+6 5 1 474 2028 SP
+-9 -6 1 534 2071 SP
+-2 1 1 493 2031 SP
+-7 -5 1 533 2077 SP
+-4 -1 1 605 2135 SP
+1 -2 1 508 2072 SP
+-6 -1 1 598 2125 SP
+-4 -1 1 528 2056 SP
+-4 -1 1 620 2148 SP
+-4 -1 1 460 2077 SP
+-11 -7 1 540 2087 SP
+-3 0 1 460 2068 SP
+-5 -3 1 490 2047 SP
+-7 -6 1 494 2068 SP
+-10 -8 1 445 2010 SP
+-5 0 1 786 2195 SP
+0 2 1 581 2116 SP
+{1 0 0 C} FS
+-5 -5 -2 1 2 456 2038 SP
+458 2080 M
+4 1 D
+-6 -4 D
+-13 -23 D
+-6 -15 D
+4 2 D
+-4 -2 D
+-5 -13 D
+3 3 D
+8 4 D
+0 -1 D
+-12 -8 D
+-4 -15 D
+4 1 D
+-5 -42 D
+42 29 D
+11 7 D
+-5 1 D
+6 -1 D
+28 18 D
+-5 1 D
+14 6 D
+-4 -1 D
+4 3 D
+3 8 D
+5 0 D
+0 4 D
+1 -2 D
+3 5 D
+1 -2 D
+4 7 D
+-2 -6 D
+8 3 D
+7 10 D
+2 -3 D
+6 8 D
+4 0 D
+-3 4 D
+8 0 D
+-2 4 D
+6 -1 D
+7 5 D
+0 5 D
+2 -3 D
+16 14 D
+4 0 D
+2 4 D
+-10 -2 D
+-7 -5 D
+-1 3 D
+-5 -5 D
+-3 3 D
+-10 -6 D
+11 7 D
+-13 0 D
+10 7 D
+-9 -1 D
+13 4 D
+4 10 D
+4 0 D
+-5 -3 D
+8 2 D
+1 3 D
+11 5 D
+4 6 D
+-2 -6 D
+18 6 D
+-5 0 D
+10 11 D
+8 3 D
+1 3 D
+19 13 D
+-5 1 D
+16 17 D
+-3 1 D
+-15 -7 D
+-10 -1 D
+-2 -3 D
+-14 -7 D
+-19 -1 D
+-16 -13 D
+-29 -14 D
+-14 -2 D
+-2 7 D
+-11 -8 D
+-32 -19 D
+-5 0 D
+-10 -6 D
+10 7 D
+-6 -2 D
+1 2 D
+-12 -7 D
+-5 -4 D
+-7 -9 D
+P
+FO
+782 2174 M
+-6 2 D
+6 -2 D
+9 21 D
+6 10 D
+-6 -2 D
+4 -2 D
+-6 0 D
+-2 -4 D
+-9 -3 D
+-8 2 D
+4 -3 D
+-12 -7 D
+2 -1 D
+-29 -12 D
+-8 0 D
+-3 -4 D
+2 4 D
+-7 3 D
+-15 -7 D
+1 8 D
+8 8 D
+-17 -2 D
+-9 -16 D
+9 4 D
+-13 -8 D
+6 1 D
+-16 -8 D
+-7 -8 D
+-1 3 D
+-7 -4 D
+-29 -34 D
+36 26 D
+-9 -8 D
+8 4 D
+-24 -22 D
+22 10 D
+-11 -8 D
+14 6 D
+6 7 D
+2 -2 D
+9 6 D
+-4 1 D
+8 4 D
+-6 -1 D
+18 8 D
+-3 3 D
+12 4 D
+-2 -6 D
+12 7 D
+-2 -5 D
+-10 -6 D
+5 0 D
+-8 -1 D
+7 -4 D
+-11 1 D
+-17 -14 D
+19 7 D
+-7 -6 D
+11 5 D
+-3 -5 D
+7 6 D
+-1 -6 D
+6 5 D
+0 -3 D
+8 5 D
+-7 0 D
+6 3 D
+-3 3 D
+10 0 D
+-8 0 D
+6 1 D
+-4 4 D
+5 -2 D
+2 4 D
+-1 -3 D
+9 5 D
+-2 2 D
+6 0 D
+-7 0 D
+7 4 D
+-7 -2 D
+9 3 D
+-5 0 D
+7 2 D
+-4 0 D
+8 3 D
+0 3 D
+2 -3 D
+10 12 D
+-2 -6 D
+7 3 D
+-2 2 D
+3 -2 D
+4 4 D
+-6 -9 D
+6 3 D
+5 11 D
+0 -10 D
+5 2 D
+P
+FO
+2 1 1 2 2 1 -4 -4 4 801 2211 SP
+-1 -1 0 2 3 -1 3 794 2210 SP
+-10 -1 8 3 3 -2 3 655 2178 SP
+3 0 1 564 2143 SP
+10 4 -5 -1 8 2 -3 -1 -1 -3 5 559 2141 SP
+-1 -6 -18 -3 8 7 3 754 2187 SP
+2 4 5 0 2 673 2176 SP
+-7 -6 2 4 2 751 2182 SP
+1 4 4 0 2 618 2104 SP
+-7 -3 1 766 2190 SP
+-1 -3 1 541 2132 SP
+4 -2 1 782 2206 SP
+5 4 1 602 2110 SP
+5 3 1 676 2173 SP
+-6 -1 1 784 2199 SP
+-1 -3 1 529 2043 SP
+-3 2 1 792 2204 SP
+0 -3 1 637 2112 SP
+-3 0 1 561 2137 SP
+-3 -4 1 600 2096 SP
+-7 -5 1 658 2118 SP
+2 3 1 655 2155 SP
+{0 0 0.502 C} FS
+-1 -5 -9 -7 11 9 1 -3 -20 -18 14 9 -6 -3 13 13 7 4 1 3 -6 -5 -5 0 5 6 -2 5 -2 -5 -12 -11 16 502 2043 SP
+3 6 -4 -3 -2 1 3 566 2122 SP
+-6 -5 5 4 6 2 3 486 2058 SP
+6 5 -4 -2 2 462 2049 SP
+4 5 -5 -3 2 524 2054 SP
+3 4 -5 -3 2 524 2061 SP
+4 5 -7 -5 2 547 2114 SP
+19 15 -17 -8 2 458 2037 SP
+14 4 4 6 2 682 2151 SP
+3 4 -8 -6 2 556 2126 SP
+-4 -1 -3 -4 2 457 2070 SP
+13 7 -16 -3 2 462 2061 SP
+7 8 -8 -7 2 602 2137 SP
+-8 -3 6 -1 2 483 2056 SP
+-7 -8 6 4 2 465 2022 SP
+0 3 -5 -3 4 0 3 505 2075 SP
+-4 -5 1 486 2036 SP
+-6 -2 1 571 2099 SP
+-4 -3 1 521 2070 SP
+-4 -2 1 471 2072 SP
+0 -6 1 484 2026 SP
+-3 -3 1 595 2147 SP
+-4 0 1 633 2156 SP
+-5 -3 1 492 2016 SP
+1 2 1 512 2110 SP
+-6 -5 1 501 2055 SP
+-4 -4 1 491 2045 SP
+-4 -2 1 589 2140 SP
+-4 -2 1 547 2089 SP
+1 3 1 474 2085 SP
+-5 -3 1 572 2102 SP
+0 2 1 595 2120 SP
+5 4 -5 -3 2 472 2036 SP
+-4 -3 1 567 2104 SP
+0 1 1 493 2022 SP
+-2 0 1 465 2071 SP
+-5 -3 1 529 2060 SP
+3 3 1 723 2149 SP
+-2 -3 1 768 2188 SP
+-1 2 1 588 2114 SP
+5 7 1 459 1995 SP
+1 -6 1 523 2099 SP
+-3 1 -3 -5 2 472 2087 SP
+-9 -7 1 484 2065 SP
+-2 -7 8 10 2 614 2138 SP
+-12 -8 1 549 2088 SP
+0 -4 1 0 2 548 2114 SP
+9 6 1 466 2031 SP
+-5 -3 1 537 2099 SP
+7 6 -6 -6 2 450 2046 SP
+-7 -5 1 535 2081 SP
+-8 -3 1 584 2133 SP
+-8 -7 1 592 2140 SP
+-2 1 1 487 2067 SP
+-5 -1 1 540 2105 SP
+6 2 -5 -2 2 615 2146 SP
+1 -2 1 480 2051 SP
+1 2 1 609 2137 SP
+-7 -4 1 591 2123 SP
+5 3 1 457 2013 SP
+-5 -6 1 628 2148 SP
+-5 -4 1 460 2036 SP
+-4 -4 1 577 2126 SP
+-3 -3 1 536 2125 SP
+-7 -3 1 633 2155 SP
+6 5 1 474 2028 SP
+-9 -6 1 534 2071 SP
+-2 1 1 493 2031 SP
+-7 -5 1 533 2077 SP
+-4 -1 1 605 2135 SP
+1 -2 1 508 2072 SP
+-6 -1 1 598 2125 SP
+-4 -1 1 528 2056 SP
+-4 -1 1 620 2148 SP
+-4 -1 1 460 2077 SP
+-11 -7 1 540 2087 SP
+-3 0 1 460 2068 SP
+-5 -3 1 490 2047 SP
+-7 -6 1 494 2068 SP
+-10 -8 1 445 2010 SP
+-5 0 1 786 2195 SP
+0 2 1 581 2116 SP
+{1 0 0 C} FS
+-5 -5 -2 1 2 456 2038 SP
+{0 0 0.502 C} FS
+424 1939 M
+2 2 D
+-3 -1 D
+0 2 D
+18 7 D
+4 6 D
+1 -4 D
+4 6 D
+-16 -1 D
+-11 -7 D
+-1 16 D
+4 3 D
+0 -1 D
+16 3 D
+4 -9 D
+11 0 D
+6 8 D
+0 -4 D
+2 7 D
+1 -5 D
+3 5 D
+9 4 D
+7 9 D
+-7 1 D
+9 5 D
+4 9 D
+-12 4 D
+12 -3 D
+-3 6 D
+9 -8 D
+3 7 D
+3 0 D
+-2 5 D
+5 4 D
+-3 0 D
+5 2 D
+-9 -1 D
+7 1 D
+-1 3 D
+4 1 D
+-1 1 D
+60 33 D
+46 24 D
+80 34 D
+83 29 D
+2 -18 D
+-8 -3 D
+1 -5 D
+-7 -1 D
+8 -4 D
+7 6 D
+3 -9 D
+-16 -3 D
+1 -4 D
+-6 -1 D
+4 4 D
+-12 -6 D
+1 7 D
+-8 2 D
+7 -9 D
+-7 0 D
+-4 -6 D
+2 13 D
+-3 -6 D
+0 5 D
+-11 -3 D
+12 -4 D
+-4 1 D
+3 -7 D
+-12 10 D
+1 -10 D
+-6 8 D
+-4 -9 D
+-5 4 D
+-1 -6 D
+-2 5 D
+-3 -4 D
+-4 1 D
+19 -4 D
+-2 -3 D
+-19 6 D
+3 -7 D
+-8 3 D
+-6 -6 D
+10 -2 D
+-2 -4 D
+-9 6 D
+1 -3 D
+-10 -3 D
+5 -3 D
+-7 1 D
+-9 -5 D
+12 -1 D
+8 6 D
+-14 -14 D
+3 8 D
+-2 -5 D
+-7 5 D
+1 -8 D
+-4 6 D
+-1 -4 D
+-5 0 D
+1 -5 D
+-5 2 D
+1 -6 D
+-3 4 D
+0 -6 D
+-9 -3 D
+6 0 D
+-11 -3 D
+-2 -7 D
+-6 -1 D
+3 -3 D
+-6 1 D
+5 -2 D
+-6 -1 D
+0 -3 D
+-3 2 D
+2 -5 D
+-4 2 D
+1 -6 D
+-9 -7 D
+13 -7 D
+-11 0 D
+7 -1 D
+-9 -2 D
+5 -2 D
+-6 -4 D
+7 1 D
+-12 -4 D
+9 1 D
+-10 -5 D
+8 1 D
+-2 -8 D
+5 11 D
+4 -7 D
+3 6 D
+6 -1 D
+-1 5 D
+2 -5 D
+2 6 D
+6 -2 D
+-1 4 D
+5 -3 D
+-1 4 D
+6 -1 D
+7 10 D
+0 -6 D
+3 9 D
+6 -5 D
+6 6 D
+-1 -6 D
+5 7 D
+0 -5 D
+2 4 D
+4 -3 D
+3 7 D
+0 -6 D
+7 5 D
+-1 5 D
+6 -4 D
+11 12 D
+0 -6 D
+9 4 D
+-16 -9 D
+-22 -14 D
+-22 -15 D
+-22 -15 D
+-21 -15 D
+-22 -16 D
+-28 -21 D
+-41 -34 D
+-52 -47 D
+-6 -6 D
+-14 20 D
+-16 31 D
+-13 43 D
+P
+FO
+{1 0 0 C} FS
+-7 -8 1 708 2025 SP
+7 4 1 773 2107 SP
+1 5 1 615 1983 SP
+3 -2 1 753 2107 SP
+4 1 1 612 1994 SP
+-4 1 4 0 2 620 2007 SP
+1 -2 1 745 2099 SP
+-2 -6 1 679 2014 SP
+{0 0 0.502 C} FS
+2 -2 1 670 2058 SP
+1 -2 1 496 2014 SP
+3 -1 1 736 2102 SP
+{1 0 0 C} FS
+0 -4 -11 -7 -16 -1 4 6 1 -4 4 6 18 7 7 423 1942 SP
+-3 -1 2 2 2 424 1939 SP
+783 2108 M
+-16 -3 D
+1 -4 D
+-6 -1 D
+4 4 D
+-12 -6 D
+1 7 D
+-8 2 D
+7 -9 D
+-7 0 D
+-4 -6 D
+2 13 D
+-3 -6 D
+0 5 D
+-11 -3 D
+12 -4 D
+-4 1 D
+3 -7 D
+-12 10 D
+1 -10 D
+-6 8 D
+-4 -9 D
+-5 4 D
+-1 -6 D
+-2 5 D
+-3 -4 D
+-4 1 D
+19 -4 D
+-2 -3 D
+-19 6 D
+3 -7 D
+-8 3 D
+-6 -6 D
+10 -2 D
+-2 -4 D
+-9 6 D
+1 -3 D
+-10 -3 D
+5 -3 D
+-7 1 D
+-9 -5 D
+12 -1 D
+8 6 D
+-14 -14 D
+3 8 D
+-2 -5 D
+-7 5 D
+1 -8 D
+-4 6 D
+-1 -4 D
+-5 0 D
+1 -5 D
+-5 2 D
+1 -6 D
+-3 4 D
+0 -6 D
+-9 -3 D
+6 0 D
+-11 -3 D
+-2 -7 D
+-6 -1 D
+3 -3 D
+-6 1 D
+5 -2 D
+-6 -1 D
+0 -3 D
+-3 2 D
+2 -5 D
+-4 2 D
+1 -6 D
+-9 -7 D
+13 -7 D
+-11 0 D
+7 -1 D
+-9 -2 D
+5 -2 D
+-6 -4 D
+7 1 D
+-12 -4 D
+9 1 D
+-10 -5 D
+8 1 D
+-2 -8 D
+5 11 D
+4 -7 D
+3 6 D
+6 -1 D
+-1 5 D
+2 -5 D
+2 6 D
+6 -2 D
+-1 4 D
+5 -3 D
+-1 4 D
+6 -1 D
+7 10 D
+0 -6 D
+3 9 D
+6 -5 D
+6 6 D
+-1 -6 D
+5 7 D
+0 -5 D
+2 4 D
+4 -3 D
+3 7 D
+0 -6 D
+7 5 D
+-1 5 D
+6 -4 D
+11 12 D
+0 -6 D
+29 16 D
+55 31 D
+7 3 D
+-13 20 D
+P
+FO
+-1 2 0 3 7 6 1 0 7 -4 -7 -1 1 -5 -8 -3 8 779 2124 SP
+-9 -6 -10 -6 -1 1 4 1 -1 3 7 1 -9 -1 5 2 -3 0 5 4 -2 5 3 0 3 7 9 -8 -3 6 11 -3 16 480 2004 SP
+426 1968 M
+0 -1 D
+16 3 D
+4 -9 D
+11 0 D
+6 8 D
+0 -4 D
+2 7 D
+1 -5 D
+3 5 D
+9 4 D
+7 9 D
+-7 1 D
+9 5 D
+4 9 D
+-12 4 D
+-16 -11 D
+-16 -11 D
+-16 -11 D
+P
+FO
+-7 -8 1 708 2025 SP
+7 4 1 773 2107 SP
+1 5 1 615 1983 SP
+3 -2 1 753 2107 SP
+4 1 1 612 1994 SP
+-4 1 4 0 2 620 2007 SP
+1 -2 1 745 2099 SP
+-2 -6 1 679 2014 SP
+{0 0 0.502 C} FS
+2 -2 1 670 2058 SP
+1 -2 1 496 2014 SP
+3 -1 1 736 2102 SP
+720 2027 M
+2 2 D
+6 -7 D
+15 8 D
+1 -4 D
+-10 -3 D
+0 -3 D
+6 4 D
+-4 -4 D
+10 -2 D
+4 4 D
+2 -5 D
+29 9 D
+8 -1 D
+10 10 D
+-6 -10 D
+7 -4 D
+5 3 D
+-1 -5 D
+19 -4 D
+38 4 D
+11 -7 D
+-30 -25 D
+-30 -27 D
+0 4 D
+-17 -11 D
+11 13 D
+-3 11 D
+-5 -10 D
+0 8 D
+-7 -7 D
+-2 4 D
+-2 -4 D
+-5 2 D
+14 -11 D
+-9 0 D
+2 -5 D
+-14 6 D
+7 -16 D
+-16 -3 D
+12 -4 D
+2 -7 D
+-48 -49 D
+-46 -51 D
+-39 -47 D
+-10 -14 D
+-17 -20 D
+-20 -28 D
+-34 21 D
+-37 28 D
+-41 39 D
+-20 26 D
+39 36 D
+60 51 D
+42 32 D
+81 55 D
+P
+FO
+1 -1 -1 2 -2 0 3 842 2033 SP
+{1 0 0 C} FS
+4 -1 1 729 2021 SP
+812 1960 M
+0 4 D
+-17 -11 D
+11 13 D
+-3 11 D
+-5 -10 D
+0 8 D
+-7 -7 D
+-2 4 D
+-2 -4 D
+-5 2 D
+14 -11 D
+-9 0 D
+2 -5 D
+-14 6 D
+7 -16 D
+-16 -3 D
+12 -4 D
+2 -7 D
+P
+FO
+842 2033 M
+-2 0 D
+-1 2 D
+-21 18 D
+-13 15 D
+-3 5 D
+-14 -7 D
+-14 -7 D
+-14 -8 D
+-13 -8 D
+-14 -8 D
+-13 -8 D
+2 2 D
+6 -7 D
+15 8 D
+1 -4 D
+-10 -3 D
+0 -3 D
+6 4 D
+-4 -4 D
+10 -2 D
+4 4 D
+2 -5 D
+29 9 D
+8 -1 D
+10 10 D
+-6 -10 D
+7 -4 D
+5 3 D
+-1 -5 D
+19 -4 D
+38 4 D
+-15 10 D
+P
+FO
+4 -1 1 729 2021 SP
+{0 0 0.502 C} FS
+780 1930 M
+3 -9 D
+35 0 D
+17 5 D
+-2 4 D
+6 -2 D
+3 20 D
+7 2 D
+-8 -1 D
+1 8 D
+-9 -5 D
+-8 6 D
+-6 -8 D
+3 10 D
+-10 -5 D
+0 5 D
+50 44 D
+10 8 D
+32 -17 D
+45 -18 D
+30 -10 D
+-24 -38 D
+-13 -19 D
+-24 -40 D
+-50 -92 D
+-36 -74 D
+2 6 D
+-8 12 D
+3 26 D
+-15 9 D
+14 -2 D
+-7 5 D
+10 0 D
+17 16 D
+-26 6 D
+24 15 D
+-18 6 D
+-8 -14 D
+-7 3 D
+-3 -13 D
+-12 -4 D
+11 -4 D
+-21 -22 D
+10 8 D
+9 4 D
+0 -6 D
+-4 2 D
+-13 -17 D
+0 -5 D
+3 4 D
+18 -4 D
+-10 -7 D
+1 -9 D
+5 2 D
+-9 -11 D
+2 -5 D
+-16 3 D
+-10 -6 D
+8 0 D
+-2 -7 D
+-21 -7 D
+16 -15 D
+15 3 D
+-13 -8 D
+-12 4 D
+-27 -14 D
+24 -5 D
+6 7 D
+40 -10 D
+-6 -14 D
+-92 31 D
+-42 18 D
+-47 23 D
+-21 13 D
+31 42 D
+11 13 D
+16 21 D
+57 65 D
+53 56 D
+P
+FO
+-1 -2 9 -1 -6 3 -1 2 4 830 1700 SP
+-3 -5 5 11 2 825 1688 SP
+{1 0 0 C} FS
+732 1698 M
+21 0 D
+16 31 D
+14 5 D
+1 15 D
+-14 1 D
+7 2 D
+-3 4 D
+-7 -6 D
+0 6 D
+-14 -6 D
+6 -3 D
+-8 -6 D
+-15 6 D
+1 -9 D
+-10 -5 D
+10 -8 D
+-17 -7 D
+13 -3 D
+-20 -1 D
+5 -4 D
+-10 -2 D
+9 -3 D
+-9 -2 D
+8 -1 D
+-6 -4 D
+P
+FO
+8 9 6 2 -2 -4 3 804 1798 SP
+-1 -12 -2 8 2 806 1783 SP
+7 -1 -6 -4 2 799 1772 SP
+-7 -4 8 4 2 785 1725 SP
+-1 4 1 -3 2 795 1753 SP
+6 -1 1 789 1653 SP
+5 -1 1 795 1794 SP
+-1 -5 1 851 1868 SP
+-3 -3 1 883 1825 SP
+6 -1 1 780 1710 SP
+6 2 1 785 1759 SP
+-1 -5 1 849 1803 SP
+{0 0 0.502 C} FS
+-6 -2 1 778 1741 SP
+-6 -4 1 743 1720 SP
+-7 -3 1 837 1935 SP
+-6 -3 1 822 1780 SP
+{1 0 0 C} FS
+825 1688 M
+5 12 D
+-1 2 D
+-6 3 D
+9 -1 D
+2 6 D
+-8 12 D
+3 26 D
+-15 9 D
+14 -2 D
+-7 5 D
+10 0 D
+17 16 D
+-26 6 D
+24 15 D
+-18 6 D
+-8 -14 D
+-7 3 D
+-3 -13 D
+-12 -4 D
+11 -4 D
+-21 -22 D
+10 8 D
+9 4 D
+0 -6 D
+-4 2 D
+-13 -17 D
+0 -5 D
+3 4 D
+18 -4 D
+-10 -7 D
+1 -9 D
+5 2 D
+-9 -11 D
+2 -5 D
+-16 3 D
+-10 -6 D
+8 0 D
+-2 -7 D
+-21 -7 D
+16 -15 D
+15 3 D
+-13 -8 D
+-12 4 D
+-27 -14 D
+24 -5 D
+6 7 D
+40 -10 D
+P
+FO
+780 1930 M
+3 -9 D
+35 0 D
+17 5 D
+-2 4 D
+6 -2 D
+3 20 D
+7 2 D
+-8 -1 D
+1 8 D
+-9 -5 D
+-8 6 D
+-6 -8 D
+3 10 D
+-10 -5 D
+0 5 D
+P
+FO
+732 1698 M
+21 0 D
+16 31 D
+14 5 D
+1 15 D
+-14 1 D
+7 2 D
+-3 4 D
+-7 -6 D
+0 6 D
+-14 -6 D
+6 -3 D
+-8 -6 D
+-15 6 D
+1 -9 D
+-10 -5 D
+10 -8 D
+-17 -7 D
+13 -3 D
+-20 -1 D
+5 -4 D
+-10 -2 D
+9 -3 D
+-9 -2 D
+8 -1 D
+-6 -4 D
+P
+FO
+8 9 6 2 -2 -4 3 804 1798 SP
+-1 -12 -2 8 2 806 1783 SP
+7 -1 -6 -4 2 799 1772 SP
+-7 -4 8 4 2 785 1725 SP
+-1 4 1 -3 2 795 1753 SP
+6 -1 1 789 1653 SP
+5 -1 1 795 1794 SP
+-1 -5 1 851 1868 SP
+-3 -3 1 883 1825 SP
+6 -1 1 780 1710 SP
+6 2 1 785 1759 SP
+-1 -5 1 849 1803 SP
+{0 0 0.502 C} FS
+-6 -2 1 778 1741 SP
+-6 -4 1 743 1720 SP
+-7 -3 1 837 1935 SP
+-6 -3 1 822 1780 SP
+720 1420 M
+4 1 D
+-2 5 D
+6 20 D
+21 17 D
+36 9 D
+2 19 D
+8 7 D
+12 3 D
+25 -17 D
+43 20 D
+18 -13 D
+5 -33 D
+59 -57 D
+5 -25 D
+-12 -16 D
+7 -2 D
+11 17 D
+10 3 D
+-9 16 D
+8 13 D
+15 -5 D
+6 -11 D
+3 7 D
+-35 31 D
+5 9 D
+-20 5 D
+-11 32 D
+-15 16 D
+2 23 D
+21 5 D
+1 -20 D
+11 9 D
+13 -38 D
+13 -4 D
+11 -13 D
+-10 5 D
+24 -13 D
+11 -15 D
+-8 -27 D
+9 -16 D
+-18 -181 D
+-19 -10 D
+-18 16 D
+-35 13 D
+-7 22 D
+-28 15 D
+-19 1 D
+-30 25 D
+-2 9 D
+23 17 D
+-8 21 D
+13 17 D
+-11 -5 D
+-8 14 D
+-31 -4 D
+-21 9 D
+-18 -5 D
+-20 11 D
+-44 2 D
+-20 -9 D
+P
+FO
+1 0 3 0 2 738 1473 SP
+7 -2 3 6 3 6 -21 -8 4 817 1632 SP
+{1 0 0 C} FS
+-17 -4 -6 17 9 24 19 2 4 844 1398 SP
+-14 -4 -2 6 9 6 3 766 1422 SP
+1 -9 -50 2 15 30 3 936 1335 SP
+-16 -11 3 18 11 12 3 864 1445 SP
+5 -9 -3 4 2 963 1492 SP
+-5 -2 1 862 1287 SP
+-1 -8 1 957 1502 SP
+7 -1 1 979 1465 SP
+3 -4 1 923 1322 SP
+5 1 1 886 1468 SP
+2 -4 1 954 1496 SP
+{0 0 0.502 C} FS
+11 2 1 851 1546 SP
+-4 8 0 -1 2 901 1562 SP
+5 -6 1 1016 1441 SP
+-6 -3 1 867 1558 SP
+6 8 1 880 1530 SP
+3 4 1 998 1551 SP
+6 5 1 887 1531 SP
+14 4 1 1002 1531 SP
+-3 4 1 887 1552 SP
+{1 0 0 C} FS
+1005 1206 M
+-19 -10 D
+-18 16 D
+-35 13 D
+-7 22 D
+-28 15 D
+-19 1 D
+-30 25 D
+-2 9 D
+23 17 D
+-8 21 D
+13 17 D
+-11 -5 D
+-8 14 D
+-31 -4 D
+-21 9 D
+-18 -5 D
+-20 11 D
+-44 2 D
+-20 -9 D
+-29 -101 D
+-3 -14 D
+65 -18 D
+75 -16 D
+64 -11 D
+115 -15 D
+14 -1 D
+P
+FO
+817 1632 M
+-21 -8 D
+-39 -97 D
+-19 -54 D
+4 0 D
+-4 0 D
+-10 -27 D
+21 17 D
+36 9 D
+2 19 D
+8 7 D
+12 3 D
+25 -17 D
+43 20 D
+18 -13 D
+5 -33 D
+59 -57 D
+5 -25 D
+-12 -16 D
+7 -2 D
+11 17 D
+10 3 D
+-9 16 D
+8 13 D
+15 -5 D
+6 -11 D
+3 7 D
+-35 31 D
+5 9 D
+-20 5 D
+-11 32 D
+-15 16 D
+2 23 D
+21 5 D
+1 -20 D
+11 9 D
+13 -38 D
+13 -4 D
+11 -13 D
+-10 5 D
+24 -13 D
+11 -15 D
+-8 -27 D
+9 -16 D
+26 204 D
+-66 7 D
+-85 14 D
+-71 17 D
+P
+FO
+-1 -3 -2 5 4 1 3 720 1420 SP
+-17 -4 -6 17 9 24 19 2 4 844 1398 SP
+-14 -4 -2 6 9 6 3 766 1422 SP
+1 -9 -50 2 15 30 3 936 1335 SP
+-16 -11 3 18 11 12 3 864 1445 SP
+5 -9 -3 4 2 963 1492 SP
+-5 -2 1 862 1287 SP
+-1 -8 1 957 1502 SP
+7 -1 1 979 1465 SP
+3 -4 1 923 1322 SP
+5 1 1 886 1468 SP
+2 -4 1 954 1496 SP
+{0 0 0.502 C} FS
+11 2 1 851 1546 SP
+-4 8 0 -1 2 901 1562 SP
+5 -6 1 1016 1441 SP
+-6 -3 1 867 1558 SP
+6 8 1 880 1530 SP
+3 4 1 998 1551 SP
+6 5 1 887 1531 SP
+14 4 1 1002 1531 SP
+-3 4 1 887 1552 SP
+1227 1182 M
+-6 25 D
+-6 6 D
+-16 1 D
+-34 -16 D
+-37 14 D
+-31 2 D
+-4 10 D
+-28 5 D
+-3 10 D
+-24 8 D
+-29 -13 D
+-3 -28 D
+-1 0 D
+14 140 D
+4 41 D
+10 -16 D
+6 1 D
+-6 -4 D
+5 -10 D
+34 -6 D
+-6 -4 D
+-24 7 D
+-5 -7 D
+8 -22 D
+7 4 D
+5 -13 D
+3 8 D
+9 -8 D
+-7 23 D
+13 -3 D
+-8 9 D
+9 3 D
+8 -8 D
+1 10 D
+-24 16 D
+9 3 D
+-1 7 D
+6 -4 D
+-10 26 D
+6 4 D
+15 -16 D
+-3 9 D
+10 -4 D
+-10 12 D
+23 4 D
+25 -8 D
+-10 -12 D
+21 18 D
+23 1 D
+-19 28 D
+-6 0 D
+20 22 D
+5 29 D
+1 -5 D
+9 3 D
+1 19 D
+1 -4 D
+6 6 D
+-6 -7 D
+11 10 D
+-5 6 D
+5 -6 D
+4 10 D
+17 6 D
+7 -7 D
+-14 1 D
+8 -2 D
+-3 -4 D
+25 -1 D
+2 -7 D
+-17 -9 D
+10 1 D
+4 -17 D
+9 -3 D
+37 21 D
+-17 -2 D
+-10 16 D
+10 -17 D
+-7 2 D
+-8 10 D
+10 13 D
+-3 -9 D
+13 12 D
+45 15 D
+-8 -13 D
+-12 0 D
+14 -12 D
+-5 4 D
+-9 -18 D
+-13 -5 D
+53 -30 D
+6 -51 D
+-25 -3 D
+-31 5 D
+-22 16 D
+-26 -2 D
+-32 -19 D
+-32 2 D
+1 -9 D
+11 -1 D
+-15 -2 D
+0 -6 D
+-35 2 D
+-10 -10 D
+-1 -8 D
+14 1 D
+-5 -19 D
+7 -4 D
+-8 -2 D
+-4 7 D
+-3 -8 D
+17 -6 D
+-5 -7 D
+11 -9 D
+-7 -5 D
+18 1 D
+-16 -7 D
+18 4 D
+20 -16 D
+12 2 D
+4 13 D
+8 0 D
+28 -16 D
+19 4 D
+11 12 D
+12 -4 D
+12 6 D
+-5 -26 D
+6 -21 D
+-27 -67 D
+-34 -4 D
+P
+FO
+8 3 -8 -2 2 1320 1536 SP
+{1 0 0 C} FS
+-1 -8 -36 12 -9 -4 3 7 24 -1 5 1092 1286 SP
+-38 -13 11 10 -3 6 18 8 4 1232 1276 SP
+-8 -2 -4 7 5 0 3 1122 1367 SP
+-7 -3 -13 9 -3 13 3 1090 1348 SP
+-9 -6 6 9 2 1146 1305 SP
+-4 7 8 -2 2 1025 1356 SP
+5 2 1 1132 1321 SP
+-5 0 1 1118 1390 SP
+6 3 1 1116 1337 SP
+-4 -2 1 1115 1324 SP
+-6 1 1 1224 1507 SP
+-7 4 1 1210 1510 SP
+-1 5 1 1065 1311 SP
+1 9 1 1116 1350 SP
+-6 -3 1 1109 1388 SP
+-7 1 1 1132 1340 SP
+6 -4 1 1029 1349 SP
+5 -5 -5 4 2 1100 1343 SP
+6 -2 1 1077 1389 SP
+3 5 1 1132 1297 SP
+4 6 1 1029 1363 SP
+{0 0 0.502 C} FS
+-52 30 1 13 15 1 5 14 13 4 -15 -4 -4 -12 -18 -1 2 -23 7 3 10 1246 1557 SP
+3 9 -7 5 2 1238 1356 SP
+2 -8 1 1204 1345 SP
+-1 -9 1 1196 1351 SP
+-1 -6 1 1038 1416 SP
+-3 -3 1 1206 1358 SP
+1 -8 1 1161 1500 SP
+5 5 -5 -4 2 1187 1342 SP
+1 -6 1 1256 1522 SP
+-6 4 1 1243 1368 SP
+2 -5 1 1189 1522 SP
+3 -3 1 1044 1371 SP
+-2 -5 1 1042 1412 SP
+-2 -14 1 1279 1220 SP
+{1 0 0 C} FS
+1227 1182 M
+-6 25 D
+-6 6 D
+-16 1 D
+-34 -16 D
+-37 14 D
+-31 2 D
+-4 10 D
+-28 5 D
+-3 10 D
+-24 8 D
+-29 -13 D
+-3 -28 D
+-1 0 D
+-2 -17 D
+91 -6 D
+91 -2 D
+P
+FO
+1336 1412 M
+-25 -3 D
+-31 5 D
+-22 16 D
+-26 -2 D
+-32 -19 D
+-32 2 D
+1 -9 D
+11 -1 D
+-15 -2 D
+0 -6 D
+-35 2 D
+-10 -10 D
+-1 -8 D
+14 1 D
+-5 -19 D
+7 -4 D
+-8 -2 D
+-4 7 D
+-3 -8 D
+17 -6 D
+-5 -7 D
+11 -9 D
+-7 -5 D
+18 1 D
+-16 -7 D
+18 4 D
+20 -16 D
+12 2 D
+4 13 D
+8 0 D
+28 -16 D
+19 4 D
+11 12 D
+12 -4 D
+12 6 D
+-5 -26 D
+6 -21 D
+-27 -67 D
+-34 -4 D
+5 -24 D
+66 2 D
+66 5 D
+-21 206 D
+P
+FO
+1320 1536 M
+-8 -2 D
+8 3 D
+-7 54 D
+-11 -1 D
+-11 -1 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-99 5 D
+-11 1 D
+-26 -204 D
+10 -16 D
+6 1 D
+-6 -4 D
+5 -10 D
+34 -6 D
+-6 -4 D
+-24 7 D
+-5 -7 D
+8 -22 D
+7 4 D
+5 -13 D
+3 8 D
+9 -8 D
+-7 23 D
+13 -3 D
+-8 9 D
+9 3 D
+8 -8 D
+1 10 D
+-24 16 D
+9 3 D
+-1 7 D
+6 -4 D
+-10 26 D
+6 4 D
+15 -16 D
+-3 9 D
+10 -4 D
+-10 12 D
+23 4 D
+25 -8 D
+-10 -12 D
+21 18 D
+23 1 D
+-19 28 D
+-6 0 D
+20 22 D
+5 29 D
+1 -5 D
+9 3 D
+1 19 D
+1 -4 D
+6 6 D
+-6 -7 D
+11 10 D
+-5 6 D
+5 -6 D
+4 10 D
+17 6 D
+7 -7 D
+-14 1 D
+8 -2 D
+-3 -4 D
+25 -1 D
+2 -7 D
+-17 -9 D
+10 1 D
+4 -17 D
+9 -3 D
+37 21 D
+-17 -2 D
+-10 16 D
+10 -17 D
+-7 2 D
+-8 10 D
+10 13 D
+-3 -9 D
+13 12 D
+45 15 D
+-8 -13 D
+-12 0 D
+14 -12 D
+-5 4 D
+-9 -18 D
+-13 -5 D
+53 -30 D
+P
+FO
+-1 -8 -36 12 -9 -4 3 7 24 -1 5 1092 1286 SP
+-38 -13 11 10 -3 6 18 8 4 1232 1276 SP
+-8 -2 -4 7 5 0 3 1122 1367 SP
+-7 -3 -13 9 -3 13 3 1090 1348 SP
+-9 -6 6 9 2 1146 1305 SP
+-4 7 8 -2 2 1025 1356 SP
+5 2 1 1132 1321 SP
+-5 0 1 1118 1390 SP
+6 3 1 1116 1337 SP
+-4 -2 1 1115 1324 SP
+-6 1 1 1224 1507 SP
+-7 4 1 1210 1510 SP
+-1 5 1 1065 1311 SP
+1 9 1 1116 1350 SP
+-6 -3 1 1109 1388 SP
+-7 1 1 1132 1340 SP
+6 -4 1 1029 1349 SP
+5 -5 -5 4 2 1100 1343 SP
+6 -2 1 1077 1389 SP
+3 5 1 1132 1297 SP
+4 6 1 1029 1363 SP
+{0 0 0.502 C} FS
+-52 30 1 13 15 1 5 14 13 4 -15 -4 -4 -12 -18 -1 2 -23 7 3 10 1246 1557 SP
+3 9 -7 5 2 1238 1356 SP
+2 -8 1 1204 1345 SP
+-1 -9 1 1196 1351 SP
+-1 -6 1 1038 1416 SP
+-3 -3 1 1206 1358 SP
+1 -8 1 1161 1500 SP
+5 5 -5 -4 2 1187 1342 SP
+1 -6 1 1256 1522 SP
+-6 4 1 1243 1368 SP
+2 -5 1 1189 1522 SP
+3 -3 1 1044 1371 SP
+-2 -5 1 1042 1412 SP
+-2 -14 1 1279 1220 SP
+-6 -1 -7 -1 -6 -1 -6 -1 -6 -2 2 -3 9 5 11 -6 0 8 16 2 -1 1 11 1497 1206 SP
+-1 6 0 6 -1 7 -1 6 -1 7 0 6 -1 6 -3 0 -17 -11 -5 -10 8 -17 23 -13 12 1330 1463 SP
+-4 -2 4 1 2 1320 1537 SP
+-7 -30 1 1385 1599 SP
+1594 1555 M
+-2 -2 D
+2 2 D
+16 -42 D
+-3 -2 D
+-6 7 D
+-15 -5 D
+-9 20 D
+-1 21 D
+10 2 D
+-4 9 D
+7 -2 D
+0 4 D
+P
+FO
+1484 1398 M
+-2 17 D
+12 7 D
+-13 3 D
+-35 35 D
+-6 24 D
+-3 -8 D
+-14 22 D
+4 22 D
+19 5 D
+3 16 D
+23 15 D
+23 1 D
+6 -5 D
+0 -22 D
+8 -3 D
+-25 -4 D
+-4 -11 D
+11 -5 D
+-18 -1 D
+0 -6 D
+9 -2 D
+12 -19 D
+23 -4 D
+-2 -13 D
+12 -19 D
+-4 18 D
+10 5 D
+21 -18 D
+-12 -11 D
+-14 6 D
+1 -16 D
+8 -10 D
+-4 5 D
+10 1 D
+5 -8 D
+-8 1 D
+1 -10 D
+5 5 D
+9 -7 D
+11 -42 D
+-32 -11 D
+-45 12 D
+-11 25 D
+P
+FO
+-5 18 -23 10 -14 -3 -5 9 5 -9 19 0 18 -7 4 -18 8 -2 9 1418 1280 SP
+5 11 6 -1 0 14 8 -2 -1 9 -12 -4 -6 -20 -1 -10 7 -6 9 1361 1586 SP
+-11 20 -6 -7 11 -16 3 1427 1367 SP
+-13 0 9 -4 2 1436 1426 SP
+-6 -14 20 12 2 1378 1366 SP
+5 -12 1 1413 1259 SP
+12 -7 1 1413 1414 SP
+-20 8 19 -8 2 1351 1527 SP
+-8 12 7 -12 2 1403 1283 SP
+4 -4 1 1409 1265 SP
+-4 -2 1 1592 1509 SP
+-13 7 1 1344 1529 SP
+-5 -3 1 1533 1269 SP
+1 -5 1 1427 1325 SP
+-2 -3 1 1445 1308 SP
+11 -12 1 1422 1545 SP
+{1 0 0 C} FS
+2 -5 1 1468 1514 SP
+1497 1206 M
+-1 1 D
+16 2 D
+0 8 D
+11 -6 D
+9 5 D
+2 -3 D
+58 11 D
+101 26 D
+-33 116 D
+-44 131 D
+-6 16 D
+-3 -2 D
+-6 7 D
+-15 -5 D
+-9 20 D
+-1 21 D
+10 2 D
+-4 9 D
+7 -2 D
+0 4 D
+-28 69 D
+-10 -3 D
+-9 -2 D
+-9 -3 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -2 D
+-10 -2 D
+-10 -2 D
+-10 -1 D
+-10 -2 D
+-10 -1 D
+-11 -2 D
+-7 -30 D
+7 30 D
+-9 -1 D
+-9 -1 D
+-9 -2 D
+-9 -1 D
+-9 -1 D
+-9 0 D
+-9 -1 D
+-9 -1 D
+7 -54 D
+4 1 D
+-4 -2 D
+10 -73 D
+23 -13 D
+8 -17 D
+-5 -10 D
+-17 -11 D
+-3 0 D
+16 -146 D
+7 -77 D
+92 10 D
+P
+FO
+-2 -2 1 1594 1555 SP
+{0 0 0.502 C} FS
+1484 1398 M
+-2 17 D
+12 7 D
+-13 3 D
+-35 35 D
+-6 24 D
+-3 -8 D
+-14 22 D
+4 22 D
+19 5 D
+3 16 D
+23 15 D
+23 1 D
+6 -5 D
+0 -22 D
+8 -3 D
+-25 -4 D
+-4 -11 D
+11 -5 D
+-18 -1 D
+0 -6 D
+9 -2 D
+12 -19 D
+23 -4 D
+-2 -13 D
+12 -19 D
+-4 18 D
+10 5 D
+21 -18 D
+-12 -11 D
+-14 6 D
+1 -16 D
+8 -10 D
+-4 5 D
+10 1 D
+5 -8 D
+-8 1 D
+1 -10 D
+5 5 D
+9 -7 D
+11 -42 D
+-32 -11 D
+-45 12 D
+-11 25 D
+P
+FO
+-5 18 -23 10 -14 -3 -5 9 5 -9 19 0 18 -7 4 -18 8 -2 9 1418 1280 SP
+5 11 6 -1 0 14 8 -2 -1 9 -12 -4 -6 -20 -1 -10 7 -6 9 1361 1586 SP
+-11 20 -6 -7 11 -16 3 1427 1367 SP
+-13 0 9 -4 2 1436 1426 SP
+-6 -14 20 12 2 1378 1366 SP
+5 -12 1 1413 1259 SP
+12 -7 1 1413 1414 SP
+-20 8 19 -8 2 1351 1527 SP
+-8 12 7 -12 2 1403 1283 SP
+4 -4 1 1409 1265 SP
+-4 -2 1 1592 1509 SP
+-13 7 1 1344 1529 SP
+-5 -3 1 1533 1269 SP
+1 -5 1 1427 1325 SP
+-2 -3 1 1445 1308 SP
+11 -12 1 1422 1545 SP
+{1 0 0 C} FS
+2 -5 1 1468 1514 SP
+{0 0 0.502 C} FS
+1594 1555 M
+1 1 D
+-1 -1 D
+-5 12 D
+0 9 D
+12 -1 D
+6 7 D
+-5 -15 D
+4 -9 D
+17 -7 D
+-4 -8 D
+-4 -16 D
+7 -6 D
+-12 -8 D
+P
+FO
+-16 11 9 -19 -5 -18 -33 -8 -3 -12 6 9 36 10 4 12 8 1749 1630 SP
+-16 -3 -4 -12 5 -1 3 1826 1585 SP
+-6 -6 1 1764 1502 SP
+-11 -3 11 2 2 1923 1428 SP
+-6 5 1 1915 1365 SP
+3 2 1 1610 1571 SP
+3 3 1 1722 1694 SP
+2 -4 1 1921 1409 SP
+-3 -3 1 1611 1632 SP
+-4 0 1 1716 1423 SP
+0 -6 1 1812 1494 SP
+-11 -6 1 1816 1606 SP
+-4 -1 1 1731 1506 SP
+{1 0 0 C} FS
+1589 1567 M
+0 9 D
+12 -1 D
+6 7 D
+-5 -15 D
+4 -9 D
+17 -7 D
+-4 -8 D
+-4 -16 D
+7 -6 D
+-12 -8 D
+26 -73 D
+36 -115 D
+21 -75 D
+69 21 D
+54 20 D
+83 37 D
+66 36 D
+-55 118 D
+-45 82 D
+-54 88 D
+-11 15 D
+-10 16 D
+-11 15 D
+-16 23 D
+-15 -9 D
+-15 -8 D
+-15 -8 D
+-8 -4 D
+-8 -3 D
+-16 -8 D
+-8 -4 D
+-9 -3 D
+-8 -4 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+P
+FO
+1 1 1 1594 1555 SP
+{0 0 0.502 C} FS
+-16 11 9 -19 -5 -18 -33 -8 -3 -12 6 9 36 10 4 12 8 1749 1630 SP
+-16 -3 -4 -12 5 -1 3 1826 1585 SP
+-6 -6 1 1764 1502 SP
+-11 -3 11 2 2 1923 1428 SP
+-6 5 1 1915 1365 SP
+3 2 1 1610 1571 SP
+3 3 1 1722 1694 SP
+2 -4 1 1921 1409 SP
+-3 -3 1 1611 1632 SP
+-4 0 1 1716 1423 SP
+0 -6 1 1812 1494 SP
+-11 -6 1 1816 1606 SP
+-4 -1 1 1731 1506 SP
+2 -2 1 5 -4 -1 3 2070 1632 SP
+13 1 -2 -5 6 -3 0 -13 10 -1 0 -5 4 5 -13 3 -1 22 -17 1 10 1826 1706 SP
+10 -9 1 8 2 1821 1662 SP
+-2 -3 5 -2 2 2075 1585 SP
+1 -11 5 -1 2 1877 1764 SP
+-1 -5 8 2 2 1867 1782 SP
+-7 -4 4 -3 2 1919 1629 SP
+6 3 1 1808 1667 SP
+9 -10 1 1957 1628 SP
+-1 -4 1 2038 1640 SP
+-3 4 1 2016 1400 SP
+-3 -12 6 6 2 2062 1455 SP
+5 6 1 2039 1458 SP
+10 -9 1 1884 1767 SP
+-2 13 1 2026 1424 SP
+4 -5 1 1854 1717 SP
+-3 -2 1 2036 1546 SP
+2 1 1 1900 1818 SP
+-4 -4 1 1988 1568 SP
+6 2 1 1984 1412 SP
+3 4 1 1999 1412 SP
+0 4 1 1826 1729 SP
+0 5 1 1976 1384 SP
+4 2 1 2023 1527 SP
+3 7 1 2032 1450 SP
+-1 5 1 2034 1494 SP
+-1 -4 1 1984 1553 SP
+-2 -4 1 2020 1534 SP
+4 -1 1 1947 1451 SP
+0 -6 1 1863 1686 SP
+3 2 -4 -2 2 2024 1546 SP
+-1 5 1 2042 1453 SP
+-3 -2 1 2034 1561 SP
+3 1 1 2014 1511 SP
+-1 5 1 1973 1383 SP
+-3 -3 1 1935 1466 SP
+-1 5 1 1997 1415 SP
+-3 -2 1 2014 1542 SP
+{1 0 0 C} FS
+2070 1632 M
+-4 -1 D
+1 5 D
+-47 63 D
+-52 60 D
+-61 64 D
+-12 12 D
+-31 -36 D
+-29 -27 D
+-28 -22 D
+-18 -13 D
+-13 -8 D
+-13 -8 D
+21 -31 D
+11 -15 D
+10 -16 D
+11 -15 D
+54 -88 D
+31 -58 D
+21 -41 D
+43 -93 D
+37 23 D
+34 24 D
+52 45 D
+26 27 D
+23 28 D
+5 7 D
+-30 51 D
+P
+FO
+{0 0 0.502 C} FS
+13 1 -2 -5 6 -3 0 -13 10 -1 0 -5 4 5 -13 3 -1 22 -17 1 10 1826 1706 SP
+10 -9 1 8 2 1821 1662 SP
+-2 -3 5 -2 2 2075 1585 SP
+1 -11 5 -1 2 1877 1764 SP
+-1 -5 8 2 2 1867 1782 SP
+-7 -4 4 -3 2 1919 1629 SP
+6 3 1 1808 1667 SP
+9 -10 1 1957 1628 SP
+-1 -4 1 2038 1640 SP
+-3 4 1 2016 1400 SP
+-3 -12 6 6 2 2062 1455 SP
+5 6 1 2039 1458 SP
+10 -9 1 1884 1767 SP
+-2 13 1 2026 1424 SP
+4 -5 1 1854 1717 SP
+-3 -2 1 2036 1546 SP
+2 1 1 1900 1818 SP
+-4 -4 1 1988 1568 SP
+6 2 1 1984 1412 SP
+3 4 1 1999 1412 SP
+0 4 1 1826 1729 SP
+0 5 1 1976 1384 SP
+4 2 1 2023 1527 SP
+3 7 1 2032 1450 SP
+-1 5 1 2034 1494 SP
+-1 -4 1 1984 1553 SP
+-2 -4 1 2020 1534 SP
+4 -1 1 1947 1451 SP
+0 -6 1 1863 1686 SP
+3 2 -4 -2 2 2024 1546 SP
+-1 5 1 2042 1453 SP
+-3 -2 1 2034 1561 SP
+3 1 1 2014 1511 SP
+-1 5 1 1973 1383 SP
+-3 -3 1 1935 1466 SP
+-1 5 1 1997 1415 SP
+-3 -2 1 2014 1542 SP
+9 -17 0 -9 1 8 -10 17 -12 36 5 2202 1662 SP
+-2 7 1 2202 1658 SP
+1 0 7 -3 0 6 -8 -2 4 2201 1653 SP
+-2 3 1 2199 1641 SP
+-1 2 -7 -1 10 -7 0 4 4 2067 1636 SP
+8 -9 8 -8 8 -9 -10 19 -1 12 -9 10 -3 -6 -14 12 5 -12 9 2118 1804 SP
+6 -7 5 -6 -8 17 -4 5 -4 -3 5 2156 1759 SP
+1 -1 -1 2 -1 1 3 2192 1710 SP
+6 -7 -3 4 0 3 -4 4 2 2 -2 0 -1 4 7 2172 1719 SP
+5 -5 -1 5 0 -4 -4 7 4 2174 1727 SP
+4 -4 -3 6 2 2198 1644 SP
+2 3 -2 2 2 2187 1693 SP
+7 -12 4 -1 2 1951 1941 SP
+3 -4 1 2151 1740 SP
+-4 2 1 2179 1725 SP
+-5 6 4 -5 2 1972 1925 SP
+0 3 1 2199 1649 SP
+-3 5 0 -1 2 2178 1700 SP
+1 2 1 2199 1667 SP
+2 1 1 1968 1767 SP
+-1 4 1 2198 1670 SP
+{1 0 0 C} FS
+2199 1641 M
+-2 3 D
+2 -3 D
+2 12 D
+-8 -2 D
+0 6 D
+8 -3 D
+1 4 D
+-2 7 D
+2 -5 D
+-12 38 D
+-10 17 D
+1 8 D
+0 -9 D
+9 -17 D
+12 -35 D
+2 31 D
+-48 66 D
+-4 -3 D
+-4 5 D
+-8 17 D
+-22 26 D
+5 -12 D
+-14 12 D
+-3 -6 D
+-9 10 D
+-1 12 D
+-10 19 D
+-12 11 D
+-5 6 D
+-59 54 D
+-70 55 D
+-1 -22 D
+-7 -33 D
+-7 -22 D
+-23 -43 D
+-7 -10 D
+49 -50 D
+53 -59 D
+28 -34 D
+42 -56 D
+0 4 D
+10 -7 D
+-7 -1 D
+46 -69 D
+26 -45 D
+14 20 D
+19 33 D
+14 35 D
+5 14 D
+P
+FO
+{0 0 0.502 C} FS
+6 -7 -3 4 0 3 -4 4 2 2 -2 0 -1 4 7 2172 1719 SP
+5 -5 -1 5 0 -4 -4 7 4 2174 1727 SP
+4 -4 -3 6 2 2198 1644 SP
+2 3 -2 2 2 2187 1693 SP
+7 -12 4 -1 2 1951 1941 SP
+3 -4 1 2151 1740 SP
+-4 2 1 2179 1725 SP
+-5 6 4 -5 2 1972 1925 SP
+0 3 1 2199 1649 SP
+-3 5 0 -1 2 2178 1700 SP
+1 2 1 2199 1667 SP
+2 1 1 1968 1767 SP
+-1 4 1 2198 1670 SP
+2203 1711 M
+0 3 D
+0 -4 D
+-3 -1 D
+2 -12 D
+-8 27 D
+-10 4 D
+-1 -5 D
+2 13 D
+-9 4 D
+-19 20 D
+-1 -1 D
+-16 19 D
+-3 6 D
+-3 2 D
+1 4 D
+-6 8 D
+-5 15 D
+1 3 D
+-7 9 D
+-4 -10 D
+4 -11 D
+-32 35 D
+-11 18 D
+-4 10 D
+8 -4 D
+15 -23 D
+-1 6 D
+9 -16 D
+-17 36 D
+1 12 D
+11 -14 D
+2 1 D
+2 -6 D
+6 -9 D
+0 5 D
+2 -5 D
+0 4 D
+-2 3 D
+2 4 D
+11 -11 D
+-2 1 D
+4 -7 D
+4 -3 D
+-4 5 D
+7 -8 D
+-1 4 D
+14 -20 D
+5 -4 D
+1 -3 D
+3 -2 D
+-8 13 D
+4 -4 D
+-5 8 D
+2 -2 D
+-4 5 D
+1 2 D
+-6 8 D
+1 2 D
+-13 17 D
+-12 13 D
+-18 12 D
+-4 0 D
+-7 7 D
+-20 31 D
+-13 12 D
+-9 14 D
+-6 4 D
+1 2 D
+-13 14 D
+5 1 D
+-19 25 D
+-50 50 D
+-42 34 D
+61 -42 D
+39 -32 D
+18 -17 D
+-3 3 D
+7 -6 D
+19 -20 D
+27 -33 D
+-1 0 D
+-8 10 D
+28 -34 D
+13 -25 D
+23 -36 D
+5 -4 D
+-4 9 D
+-7 9 D
+3 -3 D
+-19 32 D
+11 -13 D
+2 0 D
+-23 29 D
+3 -3 D
+-3 4 D
+4 -5 D
+-6 10 D
+-9 11 D
+5 -6 D
+-18 22 D
+9 -10 D
+-2 2 D
+31 -37 D
+31 -42 D
+17 -28 D
+19 -43 D
+7 -21 D
+7 -36 D
+P
+FO
+-1 2 -2 2 1 -6 5 -4 -2 5 5 2190 1713 SP
+-1 1 -4 4 -2 0 -10 9 -32 36 -3 9 3 -9 -19 24 10 -15 14 -16 22 -25 22 -19 12 1908 2075 SP
+{1 0 0 C} FS
+-7 10 2 0 14 -22 7 -7 -3 5 -4 4 -3 7 6 -7 -2 1 4 -3 10 -19 -6 3 -20 28 -6 11 14 2176 1802 SP
+7 -8 -3 5 12 -19 -2 2 9 -13 1 -4 -4 4 -9 13 1 1 -8 13 10 2146 1849 SP
+6 -9 -4 5 2 2180 1798 SP
+-4 9 1 2163 1796 SP
+-5 6 1 2065 1957 SP
+6 -8 1 2120 1888 SP
+-1 3 1 2183 1790 SP
+-4 6 1 2143 1837 SP
+3 -5 1 2138 1841 SP
+-3 4 1 2165 1807 SP
+2 -2 1 2109 1860 SP
+-3 4 1 2147 1833 SP
+3 -5 -4 5 2 2157 1821 SP
+{0 0 0.502 C} FS
+4 -2 1 2028 1939 SP
+4 -5 1 2020 1958 SP
+4 -3 1 2037 1920 SP
+1 2 1 1991 1998 SP
+-2 5 -9 6 2 2004 1988 SP
+7 -9 1 2105 1909 SP
+-1 -1 1 2011 1939 SP
+{1 0 0 C} FS
+2203 1710 M
+-3 -1 D
+2 -12 D
+-8 27 D
+-10 4 D
+-1 -5 D
+2 13 D
+-9 4 D
+-19 20 D
+-1 -1 D
+34 -46 D
+-2 5 D
+5 -4 D
+1 -6 D
+-2 2 D
+12 -17 D
+P
+FO
+0 3 1 2203 1711 SP
+-1 1 -2 2 4 -5 3 2088 1936 SP
+2038 1987 M
+19 -20 D
+27 -33 D
+-1 0 D
+-8 10 D
+28 -34 D
+13 -25 D
+23 -36 D
+5 -4 D
+-4 9 D
+-7 9 D
+3 -3 D
+-19 32 D
+11 -13 D
+2 0 D
+-23 29 D
+3 -3 D
+-3 4 D
+4 -5 D
+-6 10 D
+-9 11 D
+5 -6 D
+-32 38 D
+-8 7 D
+-15 16 D
+P
+FO
+-5 5 -3 3 10 -9 3 -3 4 2021 2002 SP
+-5 4 -5 4 13 -10 2 -2 4 1997 2023 SP
+1908 2075 M
+22 -19 D
+36 -41 D
+10 -15 D
+-19 24 D
+3 -9 D
+-3 9 D
+-32 36 D
+-10 9 D
+-2 0 D
+-5 5 D
+12 -21 D
+9 -22 D
+8 -33 D
+3 -22 D
+0 -11 D
+70 -55 D
+47 -43 D
+12 -11 D
+5 -6 D
+12 -11 D
+-11 18 D
+-4 10 D
+8 -4 D
+15 -23 D
+-1 6 D
+9 -16 D
+-17 36 D
+1 12 D
+11 -14 D
+2 1 D
+2 -6 D
+6 -9 D
+0 5 D
+2 -5 D
+0 4 D
+-2 3 D
+2 4 D
+11 -11 D
+-2 1 D
+4 -7 D
+4 -3 D
+-4 5 D
+7 -8 D
+-1 4 D
+14 -20 D
+5 -4 D
+1 -3 D
+3 -2 D
+-8 13 D
+4 -4 D
+-5 8 D
+2 -2 D
+-4 5 D
+1 2 D
+-6 8 D
+1 2 D
+-13 17 D
+-12 13 D
+-18 12 D
+-4 0 D
+-7 7 D
+-20 31 D
+-13 12 D
+-9 14 D
+-6 4 D
+1 2 D
+-13 14 D
+5 1 D
+-19 25 D
+-50 50 D
+-49 39 D
+-14 8 D
+P
+FO
+7 -8 8 -9 4 -11 -4 -10 -7 9 1 3 -5 15 -6 8 1 4 -3 2 -3 6 11 2140 1778 SP
+-7 10 2 0 14 -22 7 -7 -3 5 -4 4 -3 7 6 -7 -2 1 4 -3 10 -19 -6 3 -20 28 -6 11 14 2176 1802 SP
+7 -8 -3 5 12 -19 -2 2 9 -13 1 -4 -4 4 -9 13 1 1 -8 13 10 2146 1849 SP
+6 -9 -4 5 2 2180 1798 SP
+-4 9 1 2163 1796 SP
+-5 6 1 2065 1957 SP
+6 -8 1 2120 1888 SP
+-1 3 1 2183 1790 SP
+-4 6 1 2143 1837 SP
+3 -5 1 2138 1841 SP
+-3 4 1 2165 1807 SP
+2 -2 1 2109 1860 SP
+-3 4 1 2147 1833 SP
+3 -5 -4 5 2 2157 1821 SP
+{0 0 0.502 C} FS
+4 -2 1 2028 1939 SP
+4 -5 1 2020 1958 SP
+4 -3 1 2037 1920 SP
+1 2 1 1991 1998 SP
+-2 5 -9 6 2 2004 1988 SP
+7 -9 1 2105 1909 SP
+-1 -1 1 2011 1939 SP
+2090 1933 M
+-17 21 D
+-25 25 D
+-4 6 D
+-39 35 D
+4 -5 D
+5 -4 D
+7 -9 D
+-19 20 D
+-1 -2 D
+-5 5 D
+1 1 D
+-9 8 D
+0 5 D
+-17 15 D
+-17 17 D
+4 -5 D
+-13 11 D
+12 -13 D
+-8 1 D
+32 -25 D
+6 -8 D
+10 -9 D
+-39 30 D
+-42 28 D
+-8 7 D
+-15 9 D
+-9 11 D
+58 -38 D
+-13 11 D
+-2 4 D
+7 -5 D
+-6 5 D
+-14 6 D
+-22 15 D
+-7 7 D
+5 -1 D
+-15 7 D
+-14 15 D
+-25 23 D
+-47 35 D
+-26 17 D
+55 -33 D
+52 -35 D
+60 -46 D
+65 -58 D
+62 -63 D
+49 -58 D
+30 -40 D
+-38 48 D
+P
+FO
+-2 2 5 -5 2 2083 1941 SP
+-3 3 3 -3 4 -4 0 1 4 2031 1993 SP
+{1 0 0 C} FS
+2 -2 -17 15 5 -5 3 1947 2076 SP
+8 -7 -26 22 2 1932 2089 SP
+16 -13 -9 8 2 1894 2120 SP
+-2 2 1 1943 2080 SP
+-5 3 1 1814 2176 SP
+4 -5 -15 7 5 -1 -7 7 -22 15 -14 6 -6 5 7 -5 -2 4 -13 11 58 -38 11 1884 2108 SP
+7 -4 7 -4 1 -2 1 -1 -15 9 -8 7 6 1916 2081 SP
+2012 2011 M
+-10 11 D
+-1 -2 D
+-5 5 D
+1 1 D
+-9 8 D
+0 5 D
+-17 15 D
+-17 17 D
+4 -5 D
+-13 11 D
+12 -13 D
+-8 1 D
+32 -25 D
+6 -8 D
+P
+FO
+2031 1993 M
+0 1 D
+23 -22 D
+7 -8 D
+8 -7 D
+21 -24 D
+-17 21 D
+-25 25 D
+-4 6 D
+-39 35 D
+4 -5 D
+5 -4 D
+7 -9 D
+P
+FO
+2 -2 -17 15 5 -5 3 1947 2076 SP
+8 -7 -26 22 2 1932 2089 SP
+16 -13 -9 8 2 1894 2120 SP
+-2 2 1 1943 2080 SP
+-5 3 1 1814 2176 SP
+{0 0 0.502 C} FS
+13 -7 13 -8 14 -7 -1 1 -8 4 -7 4 -8 4 -7 4 -11 6 -10 6 -2 1 11 1786 2196 SP
+{1 0 0 C} FS
+-13 -7 -14 -8 -13 -7 1 1 7 4 8 4 7 4 7 4 8 5 8 4 7 4 11 577 2196 SP
+{0 0 0.502 C} FS
+9 12 -1 -1 -7 -9 -7 -9 -7 -9 2 1 -4 -5 4 5 1 2 9 245 1901 SP
+-3 -2 2 0 9 7 -5 -3 -1 0 5 511 2143 SP
+1 0 1 451 2085 SP
+-1 -3 2 3 2 414 2060 SP
+390 2043 M
+0 -1 D
+6 7 D
+13 12 D
+-26 -19 D
+0 2 D
+15 12 D
+3 5 D
+17 12 D
+16 15 D
+-10 -6 D
+7 5 D
+-3 -1 D
+-22 -16 D
+-11 -9 D
+2 3 D
+43 34 D
+9 4 D
+-7 -5 D
+0 -2 D
+-11 -12 D
+13 12 D
+4 2 D
+11 13 D
+18 14 D
+4 6 D
+15 11 D
+1 -3 D
+-4 -4 D
+5 3 D
+-5 -3 D
+0 -1 D
+6 3 D
+-36 -29 D
+-22 -15 D
+-28 -30 D
+-14 -13 D
+P
+FO
+-3 -3 -1 -2 3 4 -7 -11 -1 -3 -5 -4 2 3 -5 -5 8 5 13 14 0 5 11 359 2018 SP
+5 3 4 2 6 5 -8 -6 7 5 -13 -8 6 555 2180 SP
+2 3 -4 -5 2 275 1939 SP
+5 6 -3 -4 2 285 1951 SP
+11 7 -15 -9 2 533 2165 SP
+7 5 1 511 2150 SP
+2 2 1 535 2164 SP
+4 3 1 539 2168 SP
+4 3 1 536 2166 SP
+-4 -5 1 259 1919 SP
+2 1 1 518 2154 SP
+-5 -3 1 427 2069 SP
+0 1 1 524 2158 SP
+1 1 1 528 2159 SP
+-4 -3 1 447 2105 SP
+1 1 1 534 2168 SP
+5 4 -4 -4 2 436 2096 SP
+2 2 -2 -1 2 502 2146 SP
+1 1 1 511 2148 SP
+-5 -5 1 472 2126 SP
+-3 -3 1 446 2106 SP
+-4 -3 1 441 2085 SP
+0 1 1 463 2103 SP
+-6 -3 1 0 2 435 2079 SP
+{1 0 0 C} FS
+-13 -13 9 11 2 417 2067 SP
+0 1 1 493 2132 SP
+0 2 1 489 2131 SP
+245 1901 M
+5 7 D
+-4 -5 D
+2 1 D
+28 34 D
+24 26 D
+48 45 D
+11 9 D
+0 5 D
+13 14 D
+8 5 D
+-5 -5 D
+2 3 D
+-5 -4 D
+-8 -14 D
+3 4 D
+-1 -2 D
+24 19 D
+0 -1 D
+6 7 D
+13 12 D
+-26 -19 D
+0 2 D
+15 12 D
+3 5 D
+17 12 D
+16 15 D
+-10 -6 D
+7 5 D
+-3 -1 D
+-22 -16 D
+-11 -9 D
+2 3 D
+43 34 D
+9 4 D
+-7 -5 D
+0 -2 D
+-11 -12 D
+13 12 D
+4 2 D
+11 13 D
+18 14 D
+4 6 D
+15 11 D
+1 -3 D
+-4 -4 D
+5 3 D
+-5 -3 D
+0 -1 D
+6 3 D
+-36 -29 D
+-22 -15 D
+-28 -30 D
+-14 -13 D
+15 11 D
+2 3 D
+-1 -3 D
+37 25 D
+-1 0 D
+17 9 D
+13 17 D
+22 24 D
+8 8 D
+-6 -3 D
+9 7 D
+2 0 D
+10 10 D
+47 35 D
+27 17 D
+-16 -9 D
+-29 -18 D
+-22 -13 D
+-31 -22 D
+-31 -22 D
+-41 -32 D
+-48 -42 D
+-46 -44 D
+-68 -76 D
+P
+FO
+{0 0 0.502 C} FS
+5 3 4 2 6 5 -8 -6 7 5 -13 -8 6 555 2180 SP
+2 3 -4 -5 2 275 1939 SP
+5 6 -3 -4 2 285 1951 SP
+11 7 -15 -9 2 533 2165 SP
+7 5 1 511 2150 SP
+2 2 1 535 2164 SP
+4 3 1 539 2168 SP
+4 3 1 536 2166 SP
+-4 -5 1 259 1919 SP
+2 1 1 518 2154 SP
+-5 -3 1 427 2069 SP
+0 1 1 524 2158 SP
+1 1 1 528 2159 SP
+-4 -3 1 447 2105 SP
+1 1 1 534 2168 SP
+5 4 -4 -4 2 436 2096 SP
+2 2 -2 -1 2 502 2146 SP
+1 1 1 511 2148 SP
+-5 -5 1 472 2126 SP
+-3 -3 1 446 2106 SP
+-4 -3 1 441 2085 SP
+0 1 1 463 2103 SP
+-6 -3 1 0 2 435 2079 SP
+{1 0 0 C} FS
+-13 -13 9 11 2 417 2067 SP
+0 1 1 493 2132 SP
+0 2 1 489 2131 SP
+{0 0 0.502 C} FS
+248 1904 M
+3 4 D
+0 -6 D
+5 7 D
+0 -1 D
+5 7 D
+-5 -8 D
+6 5 D
+-3 -2 D
+4 4 D
+2 5 D
+2 1 D
+-5 -7 D
+9 10 D
+-13 -16 D
+24 30 D
+-5 -6 D
+7 9 D
+-4 -6 D
+11 12 D
+-8 -9 D
+17 20 D
+-12 -15 D
+17 17 D
+0 -2 D
+-6 -5 D
+-14 -16 D
+-9 -8 D
+11 9 D
+19 20 D
+-13 -15 D
+8 4 D
+10 10 D
+4 1 D
+-3 -12 D
+6 5 D
+-5 -6 D
+-1 -7 D
+5 6 D
+-3 -2 D
+11 13 D
+16 10 D
+-1 -3 D
+5 4 D
+-4 -6 D
+10 6 D
+-5 -5 D
+3 -1 D
+-4 -4 D
+4 -2 D
+7 6 D
+-4 -7 D
+9 -5 D
+-7 -3 D
+-1 -11 D
+-5 1 D
+5 7 D
+-10 2 D
+-9 -8 D
+-6 -10 D
+14 5 D
+-3 -6 D
+5 4 D
+5 -12 D
+2 -1 D
+8 14 D
+-1 8 D
+10 17 D
+12 10 D
+0 4 D
+11 4 D
+-2 4 D
+5 4 D
+2 8 D
+-2 -11 D
+5 -1 D
+11 9 D
+4 12 D
+-5 7 D
+-21 1 D
+11 2 D
+8 6 D
+11 -7 D
+9 3 D
+-5 -35 D
+0 -9 D
+-20 -15 D
+-25 -20 D
+-15 -12 D
+4 5 D
+-9 -4 D
+0 3 D
+8 1 D
+11 10 D
+-14 -4 D
+-8 -8 D
+6 -5 D
+-26 -22 D
+-37 -35 D
+-41 -42 D
+-23 -25 D
+-61 -79 D
+-14 -20 D
+3 37 D
+8 37 D
+13 36 D
+19 36 D
+33 47 D
+P
+FO
+4 3 0 2 -5 -3 -2 -5 4 366 2024 SP
+5 3 -3 -1 -6 -5 3 399 2049 SP
+4 5 -4 -4 -1 -1 3 415 2060 SP
+-10 -9 1 451 2085 SP
+-1 -1 4 1 -1 3 -1 -1 4 456 2077 SP
+-2 -1 1 437 2039 SP
+6 6 -5 -4 2 431 2024 SP
+{1 0 0 C} FS
+-6 -2 8 7 2 15 6 -2 4 362 1938 SP
+5 14 5 10 4 2 3 408 1967 SP
+3 2 -3 -9 2 312 1956 SP
+0 -2 1 309 1952 SP
+0 2 1 309 1948 SP
+5 0 1 380 1946 SP
+-6 -5 1 258 1907 SP
+4 2 1 283 1934 SP
+2 1 1 249 1901 SP
+{0 0 0.502 C} FS
+3 5 3 1 -9 -14 4 1 14 21 -1 2 -9 -8 -3 0 8 371 2013 SP
+10 -6 -8 -16 -16 -16 16 16 9 17 7 -2 -17 7 7 387 2005 SP
+-1 1 4 2 -4 -2 6 8 -8 -8 5 428 2049 SP
+7 2 -3 1 7 7 -10 -10 4 432 2032 SP
+4 2 6 6 -10 -7 3 419 2050 SP
+5 5 -6 -5 2 420 2032 SP
+0 1 -4 -4 2 421 2055 SP
+3 1 -2 -1 2 360 1982 SP
+-18 -13 1 369 2000 SP
+-6 -5 1 422 2062 SP
+-3 0 1 453 2072 SP
+-5 -5 1 370 1984 SP
+-12 -9 1 430 2069 SP
+-3 0 1 406 2038 SP
+-2 0 1 444 2057 SP
+-4 -2 1 352 1988 SP
+-1 0 1 377 2026 SP
+-3 -4 1 376 1987 SP
+-2 -1 1 350 2001 SP
+-6 -7 1 285 1945 SP
+2 3 1 381 2030 SP
+-6 -4 1 426 2017 SP
+-4 -2 1 407 2033 SP
+-4 -2 1 424 2057 SP
+-3 -3 1 344 1972 SP
+-3 -5 1 365 1970 SP
+-3 0 1 366 1960 SP
+-4 -5 1 280 1938 SP
+-4 -1 1 436 2063 SP
+-5 -5 1 374 1986 SP
+-3 -1 1 377 2019 SP
+-7 -6 1 353 2002 SP
+-7 -6 1 353 2003 SP
+3 2 -2 -2 2 330 1965 SP
+-4 -3 1 368 1995 SP
+-5 -3 1 0 2 394 2030 SP
+{1 0 0 C} FS
+1 1 6 -5 -8 -8 -14 -4 11 10 8 1 0 3 -9 -4 4 5 9 362 1918 SP
+431 2024 M
+-5 -4 D
+6 6 D
+5 13 D
+-2 -1 D
+2 1 D
+10 23 D
+9 15 D
+-1 -1 D
+-1 3 D
+4 1 D
+6 10 D
+4 4 D
+-11 -6 D
+-6 -3 D
+-10 -9 D
+10 9 D
+-27 -18 D
+-9 -7 D
+-5 -5 D
+4 5 D
+-15 -11 D
+-6 -5 D
+-3 -1 D
+-24 -19 D
+-2 -5 D
+-5 -3 D
+0 2 D
+-43 -39 D
+-21 -20 D
+-29 -32 D
+-18 -23 D
+3 4 D
+0 -6 D
+5 7 D
+0 -1 D
+5 7 D
+-5 -8 D
+6 5 D
+-3 -2 D
+4 4 D
+2 5 D
+2 1 D
+-5 -7 D
+9 10 D
+-13 -16 D
+24 30 D
+-5 -6 D
+7 9 D
+-4 -6 D
+11 12 D
+-8 -9 D
+17 20 D
+-12 -15 D
+17 17 D
+0 -2 D
+-6 -5 D
+-14 -16 D
+-9 -8 D
+11 9 D
+19 20 D
+-13 -15 D
+8 4 D
+10 10 D
+4 1 D
+-3 -12 D
+6 5 D
+-5 -6 D
+-1 -7 D
+5 6 D
+-3 -2 D
+11 13 D
+16 10 D
+-1 -3 D
+5 4 D
+-4 -6 D
+10 6 D
+-5 -5 D
+3 -1 D
+-4 -4 D
+4 -2 D
+7 6 D
+-4 -7 D
+9 -5 D
+-7 -3 D
+-1 -11 D
+-5 1 D
+5 7 D
+-10 2 D
+-9 -8 D
+-6 -10 D
+14 5 D
+-3 -6 D
+5 4 D
+5 -12 D
+2 -1 D
+8 14 D
+-1 8 D
+10 17 D
+12 10 D
+0 4 D
+11 4 D
+-2 4 D
+5 4 D
+2 8 D
+-2 -11 D
+5 -1 D
+11 9 D
+4 12 D
+-5 7 D
+-21 1 D
+11 2 D
+8 6 D
+11 -7 D
+9 3 D
+P
+FO
+-6 -2 8 7 2 15 6 -2 4 362 1938 SP
+5 14 5 10 4 2 3 408 1967 SP
+3 2 -3 -9 2 312 1956 SP
+0 -2 1 309 1952 SP
+0 2 1 309 1948 SP
+5 0 1 380 1946 SP
+-6 -5 1 258 1907 SP
+4 2 1 283 1934 SP
+2 1 1 249 1901 SP
+{0 0 0.502 C} FS
+3 5 3 1 -9 -14 4 1 14 21 -1 2 -9 -8 -3 0 8 371 2013 SP
+10 -6 -8 -16 -16 -16 16 16 9 17 7 -2 -17 7 7 387 2005 SP
+-1 1 4 2 -4 -2 6 8 -8 -8 5 428 2049 SP
+7 2 -3 1 7 7 -10 -10 4 432 2032 SP
+4 2 6 6 -10 -7 3 419 2050 SP
+5 5 -6 -5 2 420 2032 SP
+0 1 -4 -4 2 421 2055 SP
+3 1 -2 -1 2 360 1982 SP
+-18 -13 1 369 2000 SP
+-6 -5 1 422 2062 SP
+-3 0 1 453 2072 SP
+-5 -5 1 370 1984 SP
+-12 -9 1 430 2069 SP
+-3 0 1 406 2038 SP
+-2 0 1 444 2057 SP
+-4 -2 1 352 1988 SP
+-1 0 1 377 2026 SP
+-3 -4 1 376 1987 SP
+-2 -1 1 350 2001 SP
+-6 -7 1 285 1945 SP
+2 3 1 381 2030 SP
+-6 -4 1 426 2017 SP
+-4 -2 1 407 2033 SP
+-4 -2 1 424 2057 SP
+-3 -3 1 344 1972 SP
+-3 -5 1 365 1970 SP
+-3 0 1 366 1960 SP
+-4 -5 1 280 1938 SP
+-4 -1 1 436 2063 SP
+-5 -5 1 374 1986 SP
+-3 -1 1 377 2019 SP
+-7 -6 1 353 2002 SP
+-7 -6 1 353 2003 SP
+3 2 -2 -2 2 330 1965 SP
+-4 -3 1 368 1995 SP
+-5 -3 1 0 2 394 2030 SP
+360 1916 M
+1 0 D
+1 2 D
+60 47 D
+1 -16 D
+-9 -6 D
+-1 3 D
+-7 -8 D
+3 6 D
+-11 -2 D
+1 -6 D
+-10 0 D
+-5 -6 D
+4 -3 D
+-3 -13 D
+7 -2 D
+-8 -4 D
+5 -7 D
+-12 -1 D
+1 -5 D
+15 4 D
+-6 -8 D
+-10 -5 D
+7 1 D
+-9 -7 D
+1 -4 D
+14 8 D
+4 5 D
+-5 0 D
+10 6 D
+-11 -4 D
+5 7 D
+4 0 D
+2 5 D
+6 -3 D
+-4 6 D
+15 7 D
+-2 6 D
+5 4 D
+-10 -1 D
+8 5 D
+-2 5 D
+9 2 D
+-2 5 D
+2 0 D
+4 -21 D
+10 -32 D
+16 -31 D
+14 -20 D
+-14 -13 D
+-6 -7 D
+-7 -6 D
+-38 -41 D
+-7 -6 D
+-54 -64 D
+-17 -21 D
+-48 -67 D
+-30 -46 D
+-27 -46 D
+-23 35 D
+-8 14 D
+-13 29 D
+-11 37 D
+-6 37 D
+-1 23 D
+44 60 D
+31 39 D
+40 43 D
+48 47 D
+19 18 D
+P
+FO
+7 4 -7 -2 2 423 1940 SP
+{1 0 0 C} FS
+-3 -1 1 389 1896 SP
+2 -2 1 418 1926 SP
+{0 0 0.502 C} FS
+12 1 -12 0 2 413 1936 SP
+-5 2 1 405 1927 SP
+1 -5 1 407 1918 SP
+-2 0 1 397 1921 SP
+{1 0 0 C} FS
+423 1940 M
+-7 -2 D
+7 4 D
+0 7 D
+-9 -6 D
+-1 3 D
+-7 -8 D
+3 6 D
+-11 -2 D
+1 -6 D
+-10 0 D
+-5 -6 D
+4 -3 D
+-3 -13 D
+7 -2 D
+-8 -4 D
+5 -7 D
+-12 -1 D
+1 -5 D
+15 4 D
+-6 -8 D
+-10 -5 D
+7 1 D
+-9 -7 D
+1 -4 D
+14 8 D
+4 5 D
+-5 0 D
+10 6 D
+-11 -4 D
+5 7 D
+4 0 D
+2 5 D
+6 -3 D
+-4 6 D
+15 7 D
+-2 6 D
+5 4 D
+-10 -1 D
+8 5 D
+-2 5 D
+9 2 D
+-2 5 D
+2 0 D
+P
+FO
+-1 -1 1 2 1 0 3 360 1916 SP
+-3 -1 1 389 1896 SP
+2 -2 1 418 1926 SP
+{0 0 0.502 C} FS
+12 1 -12 0 2 413 1936 SP
+-5 2 1 405 1927 SP
+1 -5 1 407 1918 SP
+-2 0 1 397 1921 SP
+398 1364 M
+-46 29 D
+-49 37 D
+-43 40 D
+-35 41 D
+-5 7 D
+37 62 D
+30 45 D
+44 59 D
+47 57 D
+18 21 D
+7 6 D
+25 27 D
+13 14 D
+7 6 D
+6 7 D
+14 13 D
+25 -31 D
+36 -34 D
+37 -28 D
+34 -21 D
+-33 -46 D
+-51 -79 D
+-33 -56 D
+-43 -83 D
+-28 -59 D
+P
+FO
+{1 0 0 C} FS
+6 -6 1 409 1547 SP
+3 -5 1 393 1577 SP
+3 -3 1 405 1573 SP
+-2 4 1 399 1576 SP
+6 -6 1 409 1547 SP
+3 -5 1 393 1577 SP
+3 -3 1 405 1573 SP
+-2 4 1 399 1576 SP
+{0 0 0.502 C} FS
+796 1624 M
+-19 14 D
+-2 -23 D
+-17 3 D
+-1 8 D
+-22 0 D
+5 -7 D
+-6 2 D
+-1 -10 D
+21 -13 D
+-2 -21 D
+8 -5 D
+-7 -12 D
+1 -3 D
+-22 -38 D
+-67 24 D
+-5 9 D
+-26 -7 D
+2 -16 D
+-21 -41 D
+-20 -21 D
+9 1 D
+-8 -10 D
+7 -3 D
+-3 1 D
+-12 -25 D
+29 -6 D
+8 -31 D
+21 8 D
+32 -10 D
+14 12 D
+11 -1 D
+8 13 D
+9 4 D
+-18 -55 D
+-14 2 D
+-19 -8 D
+-12 4 D
+0 8 D
+-25 3 D
+-6 18 D
+-7 -1 D
+-24 -29 D
+-44 -16 D
+-16 -19 D
+-7 -28 D
+-59 26 D
+-46 24 D
+-25 15 D
+26 59 D
+24 51 D
+40 74 D
+53 88 D
+31 47 D
+28 38 D
+29 -17 D
+56 -27 D
+61 -23 D
+56 -18 D
+P
+FO
+-5 0 1 738 1473 SP
+-2 -6 -2 -7 3 4 5 11 -2 5 5 722 1426 SP
+{1 0 0 C} FS
+0 -5 1 754 1567 SP
+3 -3 1 754 1572 SP
+{0 0 0.502 C} FS
+-4 -3 1 699 1471 SP
+-3 -5 1 667 1540 SP
+10 -5 -1 0 2 649 1470 SP
+5 4 -6 -4 2 659 1457 SP
+-4 -4 1 666 1506 SP
+-4 3 4 -4 2 660 1504 SP
+{1 0 0 C} FS
+702 1365 M
+-14 2 D
+-19 -8 D
+-12 4 D
+0 8 D
+-25 3 D
+-6 18 D
+-7 -1 D
+-24 -29 D
+-44 -16 D
+-16 -19 D
+-7 -28 D
+79 -30 D
+63 -19 D
+17 65 D
+P
+FO
+722 1426 M
+-2 5 D
+8 15 D
+10 27 D
+-5 0 D
+5 0 D
+31 84 D
+27 67 D
+-19 14 D
+-2 -23 D
+-17 3 D
+-1 8 D
+-22 0 D
+5 -7 D
+-6 2 D
+-1 -10 D
+21 -13 D
+-2 -21 D
+8 -5 D
+-7 -12 D
+1 -3 D
+-22 -38 D
+-67 24 D
+-5 9 D
+-26 -7 D
+2 -16 D
+-21 -41 D
+-20 -21 D
+9 1 D
+-8 -10 D
+7 -3 D
+-3 1 D
+-12 -25 D
+29 -6 D
+8 -31 D
+21 8 D
+32 -10 D
+14 12 D
+11 -1 D
+8 13 D
+9 4 D
+P
+FO
+0 -5 1 754 1567 SP
+3 -3 1 754 1572 SP
+{0 0 0.502 C} FS
+-4 -3 1 699 1471 SP
+-3 -5 1 667 1540 SP
+10 -5 -1 0 2 649 1470 SP
+5 4 -6 -4 2 659 1457 SP
+-4 -4 1 666 1506 SP
+-4 3 4 -4 2 660 1504 SP
+-3 -17 10 -12 -10 12 8 8 -3 8 5 681 834 SP
+4 -9 1 614 975 SP
+0 -6 7 2 4 -14 8 2 -13 29 -24 -8 6 887 856 SP
+3 -6 1 625 943 SP
+5 -5 1 666 872 SP
+-3 -5 1 625 955 SP
+{1 0 0 C} FS
+681 834 M
+-3 8 D
+8 8 D
+-10 12 D
+10 -12 D
+-3 -17 D
+86 -18 D
+89 -15 D
+106 -13 D
+15 -1 D
+7 162 D
+16 222 D
+1 19 D
+-65 7 D
+-114 17 D
+-75 16 D
+-66 17 D
+-13 4 D
+-29 -121 D
+-19 -103 D
+-8 -51 D
+4 -9 D
+-4 9 D
+-14 -113 D
+0 -7 D
+70 -19 D
+P
+FO
+{0 0 0.502 C} FS
+0 -6 7 2 4 -14 8 2 -13 29 -24 -8 6 887 856 SP
+3 -6 1 625 943 SP
+5 -5 1 666 872 SP
+-3 -5 1 625 955 SP
+1227 1182 M
+0 -2 D
+31 -44 D
+13 37 D
+-7 -30 D
+12 0 D
+40 -57 D
+4 -16 D
+20 -11 D
+15 -27 D
+2 -27 D
+16 -12 D
+5 -92 D
+-1 1 D
+2 -9 D
+0 -3 D
+-3 4 D
+-3 -9 D
+-25 58 D
+-23 15 D
+-8 47 D
+5 -3 D
+-9 20 D
+-24 17 D
+-5 20 D
+6 0 D
+-13 11 D
+-31 68 D
+-18 23 D
+-3 19 D
+2 0 D
+P
+FO
+{1 0 0 C} FS
+6 -2 1 1305 1093 SP
+{0 0 0.502 C} FS
+16 4 12 23 -19 -24 -19 -5 4 -22 5 1235 1058 SP
+9 3 -7 10 2 1329 814 SP
+-6 8 1 1275 806 SP
+{1 0 0 C} FS
+1379 890 M
+-3 4 D
+-3 -9 D
+-25 58 D
+-23 15 D
+-8 47 D
+5 -3 D
+-9 20 D
+-24 17 D
+-5 20 D
+6 0 D
+-13 11 D
+-31 68 D
+-18 23 D
+-3 19 D
+2 0 D
+0 2 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-98 4 D
+-49 4 D
+-16 -223 D
+-8 -180 D
+109 -7 D
+110 -2 D
+101 3 D
+84 6 D
+P
+FO
+0 3 2 -6 -1 1 3 1378 901 SP
+1227 1182 M
+0 -2 D
+31 -44 D
+13 37 D
+-7 -30 D
+12 0 D
+40 -57 D
+4 -16 D
+20 -11 D
+15 -27 D
+2 -27 D
+16 -12 D
+-7 106 D
+-7 90 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 0 D
+P
+FO
+6 -2 1 1305 1093 SP
+{0 0 0.502 C} FS
+16 4 12 23 -19 -24 -19 -5 4 -22 5 1235 1058 SP
+9 3 -7 10 2 1329 814 SP
+-6 8 1 1275 806 SP
+1596 815 M
+0 6 D
+9 5 D
+-7 -2 D
+3 28 D
+-10 1 D
+-25 -17 D
+-38 -9 D
+-18 -13 D
+-13 2 D
+-24 -13 D
+-29 21 D
+-12 -3 D
+16 11 D
+-1 9 D
+-44 38 D
+-20 4 D
+-4 7 D
+0 6 D
+8 0 D
+-9 5 D
+-5 92 D
+16 -13 D
+41 -56 D
+0 -30 D
+19 -49 D
+31 6 D
+11 13 D
+57 23 D
+12 13 D
+51 30 D
+3 17 D
+45 21 D
+5 18 D
+16 6 D
+5 19 D
+18 9 D
+-4 25 D
+4 9 D
+7 -3 D
+15 43 D
+-23 21 D
+-28 1 D
+-11 9 D
+-11 21 D
+1 16 D
+-32 -55 D
+-26 -4 D
+-7 -8 D
+-16 5 D
+0 34 D
+-11 0 D
+1 -27 D
+-18 23 D
+1 14 D
+-26 16 D
+-18 33 D
+-7 0 D
+8 4 D
+-5 9 D
+37 7 D
+28 -39 D
+18 -2 D
+26 -14 D
+18 0 D
+29 21 D
+16 -25 D
+46 2 D
+22 -110 D
+15 -100 D
+6 -42 D
+5 -49 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-8 -2 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+P
+FO
+{1 0 0 C} FS
+-23 -5 10 7 2 1650 872 SP
+-15 -12 4 6 2 1643 1167 SP
+6 2 1 1613 1106 SP
+6 1 1 1615 863 SP
+3 10 1 1712 1049 SP
+-4 4 1 1555 1133 SP
+-5 3 1 1416 922 SP
+1596 815 M
+0 6 D
+9 5 D
+-7 -2 D
+3 28 D
+-10 1 D
+-25 -17 D
+-38 -9 D
+-18 -13 D
+-13 2 D
+-24 -13 D
+-29 21 D
+-12 -3 D
+16 11 D
+-1 9 D
+-44 38 D
+-20 4 D
+-4 7 D
+4 -104 D
+100 11 D
+90 14 D
+P
+FO
+1534 1213 M
+28 -39 D
+18 -2 D
+26 -14 D
+18 0 D
+29 21 D
+16 -25 D
+46 2 D
+-22 94 D
+-11 -3 D
+-11 -3 D
+-11 -3 D
+-11 -3 D
+-12 -3 D
+-11 -3 D
+-11 -3 D
+-11 -2 D
+-12 -3 D
+-11 -2 D
+-12 -3 D
+-11 -2 D
+-12 -2 D
+P
+FO
+1373 993 M
+16 -13 D
+41 -56 D
+0 -30 D
+19 -49 D
+31 6 D
+11 13 D
+57 23 D
+12 13 D
+51 30 D
+3 17 D
+45 21 D
+5 18 D
+16 6 D
+5 19 D
+18 9 D
+-4 25 D
+4 9 D
+7 -3 D
+15 43 D
+-23 21 D
+-28 1 D
+-11 9 D
+-11 21 D
+1 16 D
+-32 -55 D
+-26 -4 D
+-7 -8 D
+-16 5 D
+0 34 D
+-11 0 D
+1 -27 D
+-18 23 D
+1 14 D
+-26 16 D
+-18 33 D
+-7 0 D
+8 4 D
+-5 9 D
+-11 -2 D
+-12 -1 D
+-11 -2 D
+-12 -2 D
+-11 -1 D
+-12 -2 D
+-11 -1 D
+-12 -1 D
+-11 -2 D
+-12 -1 D
+-12 -1 D
+-11 -1 D
+14 -188 D
+P
+FO
+1 -2 -9 5 8 0 3 1379 896 SP
+-23 -5 10 7 2 1650 872 SP
+-15 -12 4 6 2 1643 1167 SP
+6 2 1 1613 1106 SP
+6 1 1 1615 863 SP
+3 10 1 1712 1049 SP
+-4 4 1 1555 1133 SP
+-5 3 1 1416 922 SP
+{0 0 0.502 C} FS
+-5 -3 2 -11 1 -11 2 -11 2 -11 1 15 -6 24 8 6 1 6 9 2061 978 SP
+1715 1156 M
+29 2 D
+70 37 D
+7 -14 D
+10 2 D
+7 -16 D
+13 6 D
+1 -8 D
+6 9 D
+-4 -9 D
+15 -9 D
+18 10 D
+-2 -10 D
+-17 -12 D
+35 -20 D
+17 19 D
+-3 22 D
+8 3 D
+-4 -8 D
+2 -6 D
+6 3 D
+-3 -9 D
+7 -9 D
+1 -19 D
+28 -68 D
+51 -77 D
+8 -19 D
+-12 -6 D
+-11 -5 D
+-12 -6 D
+-12 -6 D
+-6 -3 D
+-6 -2 D
+-12 -6 D
+-7 -3 D
+-6 -2 D
+-12 -6 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+-7 -3 D
+-6 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-6 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-8 74 D
+-21 134 D
+P
+FO
+2 14 -15 23 2 38 -5 -2 4 -2 -1 -34 15 -22 -2 -15 -14 -21 9 1844 1265 SP
+1 6 1 1948 1226 SP
+-3 -1 4 1 2 2035 1004 SP
+3 -4 1 1989 1026 SP
+0 -4 1 2001 1022 SP
+-1 -4 1 1842 1193 SP
+-4 -6 1 2004 1057 SP
+{1 0 0 C} FS
+2061 978 M
+1 6 D
+8 6 D
+-6 24 D
+1 15 D
+-14 67 D
+-21 84 D
+-30 92 D
+-28 75 D
+-7 17 D
+-20 -11 D
+-20 -11 D
+-21 -11 D
+-21 -10 D
+-22 -11 D
+-11 -4 D
+-11 -5 D
+-12 -5 D
+-6 -2 D
+-11 -5 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -1 D
+22 -94 D
+29 2 D
+70 37 D
+7 -14 D
+10 2 D
+7 -16 D
+13 6 D
+1 -8 D
+6 9 D
+-4 -9 D
+15 -9 D
+18 10 D
+-2 -10 D
+-17 -12 D
+35 -20 D
+17 19 D
+-3 22 D
+8 3 D
+-4 -8 D
+2 -6 D
+6 3 D
+-3 -9 D
+7 -9 D
+1 -19 D
+28 -68 D
+51 -77 D
+8 -19 D
+P
+FO
+{0 0 0.502 C} FS
+2 14 -15 23 2 38 -5 -2 4 -2 -1 -34 15 -22 -2 -15 -14 -21 9 1844 1265 SP
+1 6 1 1948 1226 SP
+-3 -1 4 1 2 2035 1004 SP
+3 -4 1 1989 1026 SP
+0 -4 1 2001 1022 SP
+-1 -4 1 1842 1193 SP
+-4 -6 1 2004 1057 SP
+-3 -4 2 -10 2 -9 2 -10 2 -10 -1 41 -1 6 7 2268 1152 SP
+1 -7 0 8 2 2264 1146 SP
+2065 1029 M
+1 20 D
+-11 32 D
+1 13 D
+8 6 D
+1 13 D
+12 13 D
+-2 10 D
+15 38 D
+4 28 D
+12 21 D
+2 20 D
+-5 10 D
+7 14 D
+-1 11 D
+6 -10 D
+1 13 D
+7 -6 D
+-3 9 D
+4 -5 D
+0 9 D
+5 -3 D
+-3 12 D
+7 -9 D
+-3 18 D
+5 -10 D
+1 4 D
+-5 10 D
+7 7 D
+29 -36 D
+0 9 D
+2 -9 D
+8 3 D
+6 -8 D
+-5 -5 D
+7 -5 D
+-2 11 D
+15 -29 D
+6 -33 D
+2 9 D
+0 -9 D
+1 7 D
+4 -4 D
+0 8 D
+4 -4 D
+0 12 D
+4 9 D
+-4 5 D
+4 -3 D
+2 10 D
+-4 13 D
+9 -14 D
+3 4 D
+9 -30 D
+9 -21 D
+-2 8 D
+9 -16 D
+3 -19 D
+3 0 D
+1 -22 D
+3 -12 D
+-27 -31 D
+-23 -24 D
+-42 -37 D
+-37 -28 D
+-31 -21 D
+-16 -10 D
+-16 -10 D
+P
+FO
+2 -7 -3 14 2 2264 1206 SP
+{1 0 0 C} FS
+-2 12 3 -4 2 2205 1140 SP
+3 -14 -1 4 2 2208 1129 SP
+0 5 1 2208 1131 SP
+3 -4 1 2209 1104 SP
+3 -1 1 2181 1262 SP
+2 -3 1 2256 1177 SP
+2 -4 1 2227 1254 SP
+-1 7 1 2138 1301 SP
+-1 8 1 2256 1169 SP
+3 -2 1 2170 1279 SP
+2 -2 1 2257 1158 SP
+2 -3 1 2174 1282 SP
+{0 0 0.502 C} FS
+12 -31 -3 -17 4 16 -12 32 4 2112 1325 SP
+-6 7 -16 3 22 -11 3 2087 1330 SP
+-2 -4 1 2064 1122 SP
+-3 -2 1 2086 1294 SP
+3 8 1 2039 1269 SP
+-2 -7 6 0 2 2079 1426 SP
+2 -6 1 2146 1329 SP
+4 -10 1 2143 1328 SP
+-2 6 1 2035 1380 SP
+{1 0 0 C} FS
+2264 1146 M
+0 8 D
+1 -7 D
+3 5 D
+-3 51 D
+-19 73 D
+-27 79 D
+-33 78 D
+-39 77 D
+-5 8 D
+-16 -21 D
+-24 -27 D
+-43 -40 D
+-23 -19 D
+-26 -18 D
+-27 -18 D
+-18 -11 D
+29 -75 D
+26 -76 D
+19 -67 D
+23 -101 D
+3 -16 D
+1 20 D
+-11 32 D
+1 13 D
+8 6 D
+1 13 D
+12 13 D
+-2 10 D
+15 38 D
+4 28 D
+12 21 D
+2 20 D
+-5 10 D
+7 14 D
+-1 11 D
+6 -10 D
+1 13 D
+7 -6 D
+-3 9 D
+4 -5 D
+0 9 D
+5 -3 D
+-3 12 D
+7 -9 D
+-3 18 D
+5 -10 D
+1 4 D
+-5 10 D
+7 7 D
+29 -36 D
+0 9 D
+2 -9 D
+8 3 D
+6 -8 D
+-5 -5 D
+7 -5 D
+-2 11 D
+15 -29 D
+6 -33 D
+2 9 D
+0 -9 D
+1 7 D
+4 -4 D
+0 8 D
+4 -4 D
+0 12 D
+4 9 D
+-4 5 D
+4 -3 D
+2 10 D
+-4 13 D
+9 -14 D
+3 4 D
+9 -30 D
+9 -21 D
+-2 8 D
+9 -16 D
+3 -19 D
+3 0 D
+1 -22 D
+P
+FO
+-2 12 3 -4 2 2205 1140 SP
+3 -14 -1 4 2 2208 1129 SP
+0 5 1 2208 1131 SP
+3 -4 1 2209 1104 SP
+3 -1 1 2181 1262 SP
+2 -3 1 2256 1177 SP
+2 -4 1 2227 1254 SP
+-1 7 1 2138 1301 SP
+-1 8 1 2256 1169 SP
+3 -2 1 2170 1279 SP
+2 -2 1 2257 1158 SP
+2 -3 1 2174 1282 SP
+{0 0 0.502 C} FS
+12 -31 -3 -17 4 16 -12 32 4 2112 1325 SP
+-6 7 -16 3 22 -11 3 2087 1330 SP
+-2 -4 1 2064 1122 SP
+-3 -2 1 2086 1294 SP
+3 8 1 2039 1269 SP
+-2 -7 6 0 2 2079 1426 SP
+2 -6 1 2146 1329 SP
+4 -10 1 2143 1328 SP
+-2 6 1 2035 1380 SP
+2344 1347 M
+-5 32 D
+3 -13 D
+-1 2 D
+3 -29 D
+-7 -47 D
+-12 -39 D
+-13 -30 D
+-1 2 D
+2 2 D
+-2 1 D
+1 3 D
+-1 5 D
+3 1 D
+4 35 D
+-5 25 D
+1 3 D
+-15 41 D
+-7 10 D
+-9 1 D
+-19 22 D
+-6 20 D
+1 13 D
+-4 8 D
+2 1 D
+-4 5 D
+4 6 D
+-2 13 D
+2 7 D
+-2 7 D
+6 -3 D
+-1 10 D
+3 -1 D
+3 -12 D
+6 -10 D
+1 3 D
+-8 22 D
+2 -4 D
+1 17 D
+-2 6 D
+3 4 D
+-2 5 D
+2 3 D
+-5 12 D
+4 -6 D
+-2 6 D
+2 0 D
+-8 14 D
+9 -6 D
+-3 4 D
+-1 11 D
+3 -4 D
+-3 10 D
+3 -2 D
+-1 14 D
+-2 7 D
+-2 1 D
+-1 10 D
+-3 6 D
+3 -1 D
+-5 14 D
+-2 1 D
+0 9 D
+-3 4 D
+0 4 D
+-3 5 D
+1 2 D
+-4 8 D
+2 -1 D
+-6 10 D
+-3 9 D
+0 -3 D
+0 3 D
+-4 3 D
+2 2 D
+26 -48 D
+26 -57 D
+23 -59 D
+19 -60 D
+7 -29 D
+-1 5 D
+7 -33 D
+P
+FO
+2 -1 -1 2 2 2311 1221 SP
+2266 1199 M
+-5 21 D
+6 13 D
+3 -17 D
+6 10 D
+7 -1 D
+8 -19 D
+1 9 D
+3 -11 D
+1 6 D
+9 -1 D
+-22 -37 D
+-9 -12 D
+P
+FO
+0 -2 1 2199 1641 SP
+-3 -1 -5 11 -5 1 3 -7 2 3 4 -8 3 -8 -2 6 3 2 9 2201 1654 SP
+1 -3 1 2202 1658 SP
+{1 0 0 C} FS
+2 -17 -5 -18 -3 6 -4 23 -1 17 4 2 6 2281 1396 SP
+0 -4 1 2342 1369 SP
+1 2 1 2311 1228 SP
+-1 5 1 2262 1565 SP
+-1 8 1 2299 1199 SP
+-1 1 1 2282 1219 SP
+{0 0 0.502 C} FS
+2309 1216 M
+-6 6 D
+-11 28 D
+6 -14 D
+2 24 D
+-12 44 D
+-5 1 D
+-1 10 D
+-8 8 D
+-5 16 D
+-10 9 D
+-4 -12 D
+-1 7 D
+5 5 D
+10 -8 D
+5 -17 D
+6 -3 D
+8 -13 D
+4 -16 D
+4 -6 D
+0 -5 D
+5 -19 D
+-2 -24 D
+6 -14 D
+6 5 D
+-7 -6 D
+P
+FO
+-2 -11 -6 6 6 -6 2 10 4 -3 3 14 -3 -13 7 2252 1507 SP
+3 -4 -4 11 2 2210 1671 SP
+1 -10 2 9 2 2204 1604 SP
+-1 5 1 2204 1616 SP
+4 -6 1 2180 1449 SP
+2 -5 1 2207 1449 SP
+2 -4 1 2261 1471 SP
+3 -6 1 2203 1454 SP
+-3 7 2 -7 2 2255 1547 SP
+-12 7 1 2258 1407 SP
+-1 7 1 2311 1238 SP
+{1 0 0 C} FS
+2 -4 1 2291 1293 SP
+-5 14 1 2304 1222 SP
+2311 1221 M
+-1 2 D
+2 -1 D
+-1 3 D
+2 2 D
+-2 1 D
+1 3 D
+-1 5 D
+3 1 D
+4 35 D
+-5 25 D
+1 3 D
+-15 41 D
+-7 10 D
+-9 1 D
+-19 22 D
+-6 20 D
+1 13 D
+-4 8 D
+2 1 D
+-4 5 D
+4 6 D
+-2 13 D
+2 7 D
+-2 7 D
+6 -3 D
+-1 10 D
+3 -1 D
+3 -12 D
+6 -10 D
+1 3 D
+-8 22 D
+2 -4 D
+1 17 D
+-2 6 D
+3 4 D
+-2 5 D
+2 3 D
+-5 12 D
+4 -6 D
+-2 6 D
+2 0 D
+-8 14 D
+9 -6 D
+-3 4 D
+-1 11 D
+3 -4 D
+-3 10 D
+3 -2 D
+-1 14 D
+-2 7 D
+-2 1 D
+-1 10 D
+-3 6 D
+3 -1 D
+-5 14 D
+-2 1 D
+0 9 D
+-3 4 D
+0 4 D
+-3 5 D
+1 2 D
+-4 8 D
+2 -1 D
+-6 10 D
+-3 9 D
+0 -3 D
+0 3 D
+-4 3 D
+2 2 D
+-33 53 D
+-2 -31 D
+7 -16 D
+2 3 D
+3 -7 D
+-5 1 D
+-5 11 D
+-3 -1 D
+-4 -19 D
+-3 -14 D
+-13 -35 D
+-6 -14 D
+-23 -40 D
+-10 -13 D
+29 -54 D
+32 -70 D
+25 -63 D
+27 -87 D
+6 -24 D
+6 13 D
+3 -17 D
+6 10 D
+7 -1 D
+8 -19 D
+1 9 D
+3 -11 D
+1 6 D
+9 -1 D
+P
+FO
+2 -14 1 -8 -1 2 3 -13 -3 14 -2 18 6 2344 1347 SP
+1 -5 1 2337 1392 SP
+-2 8 -3 7 5 -13 3 -9 4 2314 1469 SP
+0 -2 -2 6 3 2 0 -2 -1 -2 -1 3 1 -3 7 2202 1658 SP
+1 -3 -2 6 0 1 3 2266 1199 SP
+2 -17 -5 -18 -3 6 -4 23 -1 17 4 2 6 2281 1396 SP
+0 -4 1 2342 1369 SP
+1 2 1 2311 1228 SP
+-1 5 1 2262 1565 SP
+-1 8 1 2299 1199 SP
+-1 1 1 2282 1219 SP
+{0 0 0.502 C} FS
+2309 1216 M
+-6 6 D
+-11 28 D
+6 -14 D
+2 24 D
+-12 44 D
+-5 1 D
+-1 10 D
+-8 8 D
+-5 16 D
+-10 9 D
+-4 -12 D
+-1 7 D
+5 5 D
+10 -8 D
+5 -17 D
+6 -3 D
+8 -13 D
+4 -16 D
+4 -6 D
+0 -5 D
+5 -19 D
+-2 -24 D
+6 -14 D
+6 5 D
+-7 -6 D
+P
+FO
+-2 -11 -6 6 6 -6 2 10 4 -3 3 14 -3 -13 7 2252 1507 SP
+3 -4 -4 11 2 2210 1671 SP
+1 -10 2 9 2 2204 1604 SP
+-1 5 1 2204 1616 SP
+4 -6 1 2180 1449 SP
+2 -5 1 2207 1449 SP
+2 -4 1 2261 1471 SP
+3 -6 1 2203 1454 SP
+-3 7 2 -7 2 2255 1547 SP
+-12 7 1 2258 1407 SP
+-1 7 1 2311 1238 SP
+{1 0 0 C} FS
+2 -4 1 2291 1293 SP
+-5 14 1 2304 1222 SP
+{0 0 0.502 C} FS
+2338 1418 M
+1 -2 D
+-2 8 D
+4 -19 D
+-1 1 D
+2 -11 D
+-6 27 D
+6 -31 D
+-3 18 D
+5 -32 D
+0 -18 D
+-9 39 D
+1 -2 D
+-14 51 D
+3 -7 D
+-2 8 D
+1 1 D
+4 -17 D
+1 2 D
+-2 12 D
+3 -6 D
+-4 13 D
+4 -8 D
+-1 6 D
+2 -7 D
+-2 10 D
+0 -4 D
+-4 15 D
+2 -11 D
+-3 8 D
+3 -13 D
+-7 16 D
+-10 38 D
+-9 23 D
+0 -13 D
+14 -43 D
+-1 -1 D
+-13 37 D
+-31 71 D
+-22 43 D
+-11 20 D
+-12 27 D
+-2 1 D
+-2 12 D
+-4 5 D
+-3 7 D
+-2 0 D
+-1 6 D
+-3 6 D
+1 -7 D
+-5 13 D
+-1 0 D
+-3 30 D
+-5 22 D
+-19 50 D
+-15 28 D
+-16 23 D
+29 -41 D
+38 -65 D
+29 -55 D
+41 -92 D
+25 -71 D
+23 -84 D
+P
+FO
+{1 0 0 C} FS
+0 -4 -3 16 -1 2 -1 6 3 -11 5 2337 1421 SP
+5 -10 14 -41 -2 1 -25 59 4 2276 1573 SP
+2 -7 2 -9 -1 3 -5 18 0 3 5 2335 1432 SP
+-1 -2 1 -6 -2 8 -4 24 4 2342 1387 SP
+-1 -6 -4 16 0 4 3 -10 4 2332 1419 SP
+-2 9 3 -13 -2 6 3 2334 1431 SP
+-5 9 1 0 2 2208 1748 SP
+8 -18 -4 8 2 2228 1711 SP
+1 -3 1 2330 1443 SP
+-1 5 1 2330 1435 SP
+1 -1 1 2328 1427 SP
+0 -1 1 2326 1452 SP
+-2 11 1 2335 1416 SP
+-2 5 1 2323 1460 SP
+-1 7 1 2341 1392 SP
+1 1 1 2333 1426 SP
+1 -3 1 2331 1441 SP
+0 4 1 2255 1636 SP
+-2 6 1 2254 1642 SP
+{0 0 0.502 C} FS
+-2 4 1 -5 2 2325 1449 SP
+{1 0 0 C} FS
+0 3 0 -3 4 -20 -3 18 4 2342 1391 SP
+-4 16 -2 11 2 2342 1395 SP
+0 3 0 -4 1 -3 -1 1 4 2341 1405 SP
+-2 8 1 2339 1416 SP
+2237 1640 M
+-12 27 D
+-2 1 D
+-2 12 D
+-4 5 D
+-3 7 D
+-2 0 D
+-1 6 D
+-3 6 D
+1 -7 D
+-5 13 D
+-1 0 D
+1 -17 D
+P
+FO
+2322 1447 M
+3 -7 D
+-2 8 D
+1 1 D
+4 -17 D
+1 2 D
+-2 12 D
+3 -6 D
+-4 13 D
+4 -8 D
+-1 6 D
+2 -7 D
+-2 10 D
+0 -4 D
+-4 15 D
+2 -11 D
+-3 8 D
+3 -13 D
+-7 16 D
+-10 38 D
+-9 23 D
+0 -13 D
+14 -43 D
+-1 -1 D
+P
+FO
+1 -2 1 2335 1398 SP
+0 -4 -3 16 -1 2 -1 6 3 -11 5 2337 1421 SP
+5 -10 14 -41 -2 1 -25 59 4 2276 1573 SP
+2 -7 2 -9 -1 3 -5 18 0 3 5 2335 1432 SP
+-1 -2 1 -6 -2 8 -4 24 4 2342 1387 SP
+-1 -6 -4 16 0 4 3 -10 4 2332 1419 SP
+-2 9 3 -13 -2 6 3 2334 1431 SP
+-5 9 1 0 2 2208 1748 SP
+8 -18 -4 8 2 2228 1711 SP
+1 -3 1 2330 1443 SP
+-1 5 1 2330 1435 SP
+1 -1 1 2328 1427 SP
+0 -1 1 2326 1452 SP
+-2 11 1 2335 1416 SP
+-2 5 1 2323 1460 SP
+-1 7 1 2341 1392 SP
+1 1 1 2333 1426 SP
+1 -3 1 2331 1441 SP
+0 4 1 2255 1636 SP
+-2 6 1 2254 1642 SP
+{0 0 0.502 C} FS
+-2 4 1 -5 2 2325 1449 SP
+19 1384 M
+2 11 D
+0 -4 D
+3 23 D
+-2 -10 D
+11 54 D
+24 86 D
+26 72 D
+36 82 D
+42 79 D
+48 76 D
+8 10 D
+-24 -38 D
+-17 -36 D
+-11 -37 D
+-6 -37 D
+-1 -22 D
+-9 -15 D
+-22 -35 D
+-32 -59 D
+-24 -53 D
+-26 -70 D
+-20 -70 D
+-7 -32 D
+P
+FO
+{1 0 0 C} FS
+-6 -12 -5 -13 9 23 4 9 1 5 0 -1 7 20 2 4 -8 -23 1 1 10 79 1607 SP
+-2 -9 0 5 2 12 3 19 1371 SP
+-1 0 2 7 1 0 3 46 1479 SP
+-3 -8 3 15 2 3 3 64 1556 SP
+1 1 1 123 1706 SP
+-1 -6 0 3 2 25 1417 SP
+-1 -5 1 55 1515 SP
+1 3 -1 -2 2 64 1553 SP
+2 7 1 38 1448 SP
+-2 -7 1 44 1470 SP
+2 6 1 34 1434 SP
+1 2 1 26 1412 SP
+-1 1 1 23 1386 SP
+-2 -4 1 117 1694 SP
+0 -2 1 60 1540 SP
+-1 -7 -1 -7 -1 -7 -1 -5 -3 -15 4 22 1 7 -2 -10 3 23 0 -4 2 11 11 19 1384 SP
+-6 -12 -5 -13 9 23 4 9 1 5 0 -1 7 20 2 4 -8 -23 1 1 10 79 1607 SP
+-2 -9 0 5 2 12 3 19 1371 SP
+-1 0 2 7 1 0 3 46 1479 SP
+-3 -8 3 15 2 3 3 64 1556 SP
+1 1 1 123 1706 SP
+-1 -6 0 3 2 25 1417 SP
+-1 -5 1 55 1515 SP
+1 3 -1 -2 2 64 1553 SP
+2 7 1 38 1448 SP
+-2 -7 1 44 1470 SP
+2 6 1 34 1434 SP
+1 2 1 26 1412 SP
+-1 1 1 23 1386 SP
+-2 -4 1 117 1694 SP
+0 -2 1 60 1540 SP
+{0 0 0.502 C} FS
+88 1160 M
+-26 40 D
+-13 25 D
+-19 49 D
+-9 42 D
+-3 34 D
+0 9 D
+15 63 D
+23 71 D
+18 46 D
+29 60 D
+28 51 D
+23 35 D
+4 8 D
+3 -38 D
+8 -37 D
+13 -36 D
+19 -36 D
+19 -28 D
+-45 -88 D
+-28 -64 D
+-18 -49 D
+-22 -75 D
+-9 -33 D
+P
+FO
+{1 0 0 C} FS
+1 6 1 31 1407 SP
+1 6 1 31 1407 SP
+{0 0 0.502 C} FS
+290 985 M
+-52 33 D
+-47 35 D
+-42 37 D
+-7 8 D
+-8 7 D
+-34 39 D
+-12 16 D
+12 58 D
+21 74 D
+26 74 D
+32 72 D
+41 80 D
+28 -35 D
+26 -27 D
+44 -38 D
+43 -31 D
+37 -23 D
+-11 -26 D
+-29 -77 D
+-25 -78 D
+-20 -78 D
+-13 -60 D
+P
+FO
+{1 0 0 C} FS
+-3 9 4 -2 2 261 1108 SP
+5 -1 1 252 1159 SP
+4 2 1 275 1121 SP
+-4 5 5 -5 2 260 1145 SP
+0 -5 1 278 1137 SP
+-3 9 4 -2 2 261 1108 SP
+5 -1 1 252 1159 SP
+4 2 1 275 1121 SP
+-4 5 5 -5 2 260 1145 SP
+0 -5 1 278 1137 SP
+{0 0 0.502 C} FS
+528 1299 M
+-12 -10 D
+-24 -12 D
+-21 2 D
+-19 -21 D
+-13 -4 D
+-15 -26 D
+-19 -10 D
+4 2 D
+-30 -33 D
+-7 -18 D
+5 5 D
+4 -23 D
+-9 -14 D
+-1 -35 D
+-16 -35 D
+-16 -11 D
+10 -24 D
+-2 -10 D
+14 -4 D
+-12 1 D
+-4 6 D
+-4 -16 D
+8 -3 D
+-8 0 D
+10 -7 D
+-6 -2 D
+7 -6 D
+-2 -4 D
+15 -2 D
+-9 0 D
+7 -6 D
+-8 -3 D
+3 -8 D
+4 2 D
+-2 -5 D
+6 1 D
+1 -18 D
+6 -8 D
+-17 9 D
+-42 22 D
+-24 14 D
+17 94 D
+14 61 D
+23 78 D
+26 77 D
+24 60 D
+4 9 D
+43 -25 D
+57 -27 D
+P
+FO
+-1 2 1 614 975 SP
+{1 0 0 C} FS
+-11 1 11 7 2 422 1304 SP
+-12 -9 5 10 2 458 1290 SP
+-4 -4 -3 5 2 439 1295 SP
+-8 -5 2 5 2 470 1302 SP
+-1 -7 1 412 1327 SP
+{0 0 0.502 C} FS
+10 -15 25 -11 5 3 -5 -3 -25 11 -17 39 6 407 1030 SP
+-1 9 -4 1 4 -10 3 540 988 SP
+19 15 1 457 936 SP
+11 3 1 550 993 SP
+9 -5 1 598 998 SP
+3 -12 1 610 992 SP
+6 5 1 447 929 SP
+6 6 1 539 967 SP
+-11 -2 11 1 2 542 1007 SP
+-6 0 1 565 984 SP
+-4 -8 1 555 1007 SP
+-3 -2 1 369 1073 SP
+-5 -1 1 380 1080 SP
+49 6 1 484 955 SP
+33 -1 1 563 999 SP
+{1 0 0 C} FS
+614 975 M
+-1 2 D
+1 -2 D
+14 86 D
+21 103 D
+21 86 D
+-84 26 D
+-58 23 D
+-12 -10 D
+-24 -12 D
+-21 2 D
+-19 -21 D
+-13 -4 D
+-15 -26 D
+-19 -10 D
+4 2 D
+-30 -33 D
+-7 -18 D
+5 5 D
+4 -23 D
+-9 -14 D
+-1 -35 D
+-16 -35 D
+-16 -11 D
+10 -24 D
+-2 -10 D
+14 -4 D
+-12 1 D
+-4 6 D
+-4 -16 D
+8 -3 D
+-8 0 D
+10 -7 D
+-6 -2 D
+7 -6 D
+-2 -4 D
+15 -2 D
+-9 0 D
+7 -6 D
+-8 -3 D
+3 -8 D
+4 2 D
+-2 -5 D
+6 1 D
+1 -18 D
+6 -8 D
+77 -34 D
+83 -30 D
+60 -19 D
+7 -2 D
+8 75 D
+P
+FO
+-11 1 11 7 2 422 1304 SP
+-12 -9 5 10 2 458 1290 SP
+-4 -4 -3 5 2 439 1295 SP
+-8 -5 2 5 2 470 1302 SP
+-1 -7 1 412 1327 SP
+{0 0 0.502 C} FS
+10 -15 25 -11 5 3 -5 -3 -25 11 -17 39 6 407 1030 SP
+-1 9 -4 1 4 -10 3 540 988 SP
+19 15 1 457 936 SP
+11 3 1 550 993 SP
+9 -5 1 598 998 SP
+3 -12 1 610 992 SP
+6 5 1 447 929 SP
+6 6 1 539 967 SP
+-11 -2 11 1 2 542 1007 SP
+-6 0 1 565 984 SP
+-4 -8 1 555 1007 SP
+-3 -2 1 369 1073 SP
+-5 -1 1 380 1080 SP
+49 6 1 484 955 SP
+33 -1 1 563 999 SP
+593 772 M
+25 4 D
+46 -3 D
+-8 -3 D
+18 -5 D
+12 -14 D
+5 3 D
+-5 -4 D
+8 -4 D
+-6 1 D
+3 -4 D
+6 1 D
+-6 -5 D
+11 -19 D
+13 -2 D
+1 5 D
+2 -6 D
+-1 6 D
+4 -6 D
+2 7 D
+4 -7 D
+18 -2 D
+0 8 D
+6 -10 D
+5 4 D
+7 -16 D
+10 1 D
+2 -6 D
+-6 1 D
+8 -15 D
+-12 -32 D
+6 -3 D
+0 -12 D
+-7 3 D
+13 -9 D
+-9 0 D
+-3 6 D
+-5 -18 D
+-8 2 D
+18 -34 D
+42 -42 D
+9 -23 D
+10 -7 D
+-7 -1 D
+23 -40 D
+-7 -10 D
+9 -16 D
+-93 16 D
+-69 15 D
+-81 21 D
+-6 2 D
+-6 57 D
+-3 81 D
+1 110 D
+P
+FO
+595 794 M
+3 8 D
+-2 9 D
+0 3 D
+1 -2 D
+5 22 D
+-6 -46 D
+-2 1 D
+P
+FO
+-1 4 -1 -3 2 683 833 SP
+0 -3 31 13 14 25 -9 -51 10 51 32 27 -2 15 0 -16 -45 -32 1 -16 -18 -10 -14 -1 12 976 629 SP
+{1 0 0 C} FS
+4 4 2 -4 2 709 644 SP
+5 9 5 -4 2 747 693 SP
+{0 0 0.502 C} FS
+7 44 -8 -43 -42 7 42 -7 7 -18 5 713 800 SP
+7 -3 -5 -6 9 1 -3 17 4 940 556 SP
+26 -18 1 682 821 SP
+-6 7 1 938 585 SP
+-5 -1 1 887 536 SP
+5 -5 1 833 737 SP
+0 6 -5 -3 2 782 609 SP
+-5 4 1 800 557 SP
+-5 -1 1 837 515 SP
+{1 0 0 C} FS
+976 629 M
+-14 -1 D
+-18 -10 D
+1 -16 D
+-45 -32 D
+0 -16 D
+-2 15 D
+32 27 D
+10 51 D
+-9 -51 D
+14 25 D
+31 13 D
+3 152 D
+-99 11 D
+-75 11 D
+-108 22 D
+-14 3 D
+-1 -3 D
+-1 4 D
+-72 18 D
+-9 3 D
+-4 -41 D
+1 -2 D
+5 22 D
+-6 -46 D
+-2 1 D
+-1 -17 D
+25 4 D
+46 -3 D
+-8 -3 D
+18 -5 D
+12 -14 D
+5 3 D
+-5 -4 D
+8 -4 D
+-6 1 D
+3 -4 D
+6 1 D
+-6 -5 D
+11 -19 D
+13 -2 D
+1 5 D
+2 -6 D
+-1 6 D
+4 -6 D
+2 7 D
+4 -7 D
+18 -2 D
+0 8 D
+6 -10 D
+5 4 D
+7 -16 D
+10 1 D
+2 -6 D
+-6 1 D
+8 -15 D
+-12 -32 D
+6 -3 D
+0 -12 D
+-7 3 D
+13 -9 D
+-9 0 D
+-3 6 D
+-5 -18 D
+-8 2 D
+18 -34 D
+42 -42 D
+9 -23 D
+10 -7 D
+-7 -1 D
+23 -40 D
+-7 -10 D
+9 -16 D
+84 -11 D
+46 -4 D
+-3 153 D
+P
+FO
+-1 -7 -2 6 3 8 3 595 794 SP
+4 4 2 -4 2 709 644 SP
+5 9 5 -4 2 747 693 SP
+{0 0 0.502 C} FS
+7 44 -8 -43 -42 7 42 -7 7 -18 5 713 800 SP
+7 -3 -5 -6 9 1 -3 17 4 940 556 SP
+26 -18 1 682 821 SP
+-6 7 1 938 585 SP
+-5 -1 1 887 536 SP
+5 -5 1 833 737 SP
+0 6 -5 -3 2 782 609 SP
+-5 4 1 800 557 SP
+-5 -1 1 837 515 SP
+1377 430 M
+-8 27 D
+4 8 D
+-4 -1 D
+7 14 D
+-16 15 D
+9 24 D
+17 28 D
+-3 -114 D
+-3 -1 D
+P
+FO
+-6 0 1 0 9 -8 2 4 -1 5 5 1262 423 SP
+0 2 -49 -6 -45 30 43 -30 47 0 4 1 6 976 634 SP
+{1 0 0 C} FS
+7 -5 -3 -7 -2 4 3 1373 495 SP
+7 6 1 1376 463 SP
+{0 0 0.502 C} FS
+1214 555 M
+9 35 D
+13 6 D
+6 -3 D
+8 7 D
+3 -5 D
+10 2 D
+6 -12 D
+10 6 D
+2 -4 D
+-16 -5 D
+-2 -17 D
+-16 -10 D
+13 -2 D
+-8 -6 D
+-11 2 D
+2 -8 D
+-5 -3 D
+1 9 D
+-12 4 D
+-9 -10 D
+P
+FO
+0 34 -19 20 -7 20 -14 4 12 -29 18 -12 -5 -7 13 -42 6 17 9 1161 515 SP
+-8 -13 16 7 0 7 3 1147 430 SP
+3 -6 -8 -2 19 4 3 1234 617 SP
+-16 22 9 -41 2 1308 679 SP
+5 7 -13 -6 2 1183 445 SP
+6 -8 5 16 2 1157 547 SP
+-3 -13 20 16 -1 9 3 1192 609 SP
+6 -1 1 1260 622 SP
+0 5 1 1310 559 SP
+3 -3 1 1181 549 SP
+5 -4 1 1234 452 SP
+-11 -9 8 0 2 1171 588 SP
+-1 7 -12 1 2 1233 453 SP
+-9 -12 1 1347 718 SP
+-10 -8 11 8 2 1279 526 SP
+1 9 1 1304 548 SP
+15 5 1 1228 621 SP
+-4 -3 1 1109 447 SP
+3 6 1 1299 528 SP
+-3 -4 1 1363 747 SP
+-2 -5 1 1338 705 SP
+6 0 1 1182 591 SP
+5 3 1 1334 579 SP
+{1 0 0 C} FS
+11 1 1 993 634 SP
+-1 6 1 1225 581 SP
+-2 4 1 1250 593 SP
+0 5 0 -4 2 1219 551 SP
+1262 423 M
+-1 5 D
+2 4 D
+10 -8 D
+78 4 D
+26 2 D
+-8 27 D
+4 8 D
+-4 -1 D
+7 14 D
+-16 15 D
+9 24 D
+17 28 D
+-1 182 D
+-2 59 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 -1 D
+-9 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-93 3 D
+-84 6 D
+-3 -152 D
+51 1 D
+43 -30 D
+-45 30 D
+-49 -6 D
+1 -144 D
+2 -54 D
+102 -7 D
+102 -2 D
+P
+FO
+7 -5 -3 -7 -2 4 3 1373 495 SP
+7 6 1 1376 463 SP
+{0 0 0.502 C} FS
+1214 555 M
+9 35 D
+13 6 D
+6 -3 D
+8 7 D
+3 -5 D
+10 2 D
+6 -12 D
+10 6 D
+2 -4 D
+-16 -5 D
+-2 -17 D
+-16 -10 D
+13 -2 D
+-8 -6 D
+-11 2 D
+2 -8 D
+-5 -3 D
+1 9 D
+-12 4 D
+-9 -10 D
+P
+FO
+0 34 -19 20 -7 20 -14 4 12 -29 18 -12 -5 -7 13 -42 6 17 9 1161 515 SP
+-8 -13 16 7 0 7 3 1147 430 SP
+3 -6 -8 -2 19 4 3 1234 617 SP
+-16 22 9 -41 2 1308 679 SP
+5 7 -13 -6 2 1183 445 SP
+6 -8 5 16 2 1157 547 SP
+-3 -13 20 16 -1 9 3 1192 609 SP
+6 -1 1 1260 622 SP
+0 5 1 1310 559 SP
+3 -3 1 1181 549 SP
+5 -4 1 1234 452 SP
+-11 -9 8 0 2 1171 588 SP
+-1 7 -12 1 2 1233 453 SP
+-9 -12 1 1347 718 SP
+-10 -8 11 8 2 1279 526 SP
+1 9 1 1304 548 SP
+15 5 1 1228 621 SP
+-4 -3 1 1109 447 SP
+3 6 1 1299 528 SP
+-3 -4 1 1363 747 SP
+-2 -5 1 1338 705 SP
+6 0 1 1182 591 SP
+5 3 1 1334 579 SP
+{1 0 0 C} FS
+11 1 1 993 634 SP
+-1 6 1 1225 581 SP
+-2 4 1 1250 593 SP
+0 5 0 -4 2 1219 551 SP
+{0 0 0.502 C} FS
+1386 545 M
+4 7 D
+16 9 D
+-4 6 D
+11 0 D
+45 53 D
+49 37 D
+37 44 D
+51 103 D
+1 11 D
+99 22 D
+68 18 D
+6 -86 D
+3 -115 D
+-4 -95 D
+-5 -59 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-9 -1 D
+-8 0 D
+P
+FO
+{1 0 0 C} FS
+4 -1 1 1685 566 SP
+6 1 1 1506 454 SP
+1386 545 M
+4 7 D
+16 9 D
+-4 6 D
+11 0 D
+45 53 D
+49 37 D
+37 44 D
+51 103 D
+1 11 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+3 -156 D
+P
+FO
+4 -1 1 1685 566 SP
+6 1 1 1506 454 SP
+{0 0 0.502 C} FS
+2021 956 M
+7 -18 D
+16 -8 D
+6 10 D
+2 13 D
+11 12 D
+-4 2 D
+2 11 D
+11 7 D
+1 -4 D
+-1 -1 D
+2 -5 D
+1 -29 D
+-2 3 D
+6 -20 D
+6 -74 D
+1 -80 D
+-6 -86 D
+-4 -37 D
+-4 -22 D
+-11 -7 D
+-11 -6 D
+-11 -6 D
+-12 -7 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-7 -3 D
+-6 -3 D
+-6 -2 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -2 D
+-13 -6 D
+-6 -2 D
+-7 -3 D
+-6 -3 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-13 -6 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+6 75 D
+3 111 D
+-4 100 D
+-5 69 D
+76 24 D
+92 35 D
+61 28 D
+P
+FO
+{1 0 0 C} FS
+3 0 1 2064 965 SP
+-1 10 -1 11 -1 10 6 -20 -2 3 1 -24 6 2074 970 SP
+1 -1 -1 -1 2 2073 981 SP
+-6 -4 -7 -3 -7 -4 -7 -4 -6 -3 2 11 -4 2 11 12 2 13 6 10 16 -8 7 -18 12 2021 956 SP
+3 0 1 2064 965 SP
+{0 0 0.502 C} FS
+2079 929 M
+5 -17 D
+14 13 D
+5 19 D
+-10 23 D
+-18 16 D
+-2 -2 D
+-1 4 D
+43 27 D
+57 42 D
+42 37 D
+37 39 D
+14 17 D
+2 -36 D
+3 7 D
+13 -18 D
+7 -69 D
+-2 3 D
+-13 1 D
+0 7 D
+-7 8 D
+-20 -16 D
+5 -14 D
+12 -5 D
+8 -17 D
+9 1 D
+3 -24 D
+6 -6 D
+-3 -68 D
+-7 -60 D
+-7 -36 D
+-25 -32 D
+-28 -31 D
+-50 -44 D
+-37 -28 D
+-30 -21 D
+-21 -13 D
+-11 -6 D
+7 44 D
+6 85 D
+1 72 D
+-6 90 D
+P
+FO
+0 5 0 -8 -5 0 6 -1 4 2073 979 SP
+1 -8 2 -8 3 4 3 4 -3 13 -4 -6 -3 8 7 2278 1137 SP
+{1 0 0 C} FS
+-3 -5 -4 3 0 9 4 -3 4 2271 972 SP
+7 0 -3 -3 2 2259 991 SP
+4 -4 -2 -7 2 2283 951 SP
+3 -6 -3 1 2 2234 1048 SP
+3 2 1 2280 967 SP
+0 4 1 2228 1063 SP
+2 -1 1 2268 991 SP
+2 -1 1 2287 936 SP
+1 -4 1 2268 1107 SP
+2 7 1 2278 953 SP
+-3 0 3 1 2 2281 1091 SP
+1 -6 1 2279 964 SP
+{0 0 0.502 C} FS
+-3 7 -2 -4 2 2284 1014 SP
+{1 0 0 C} FS
+-1 13 0 12 0 12 0 13 6 -6 3 -24 9 1 8 -17 12 -5 5 -14 -20 -16 -7 8 0 7 -13 1 -2 3 15 2290 1031 SP
+-1 9 -1 9 -1 9 13 -18 3 7 2 -36 -2 -3 -1 -2 -3 13 -4 -6 -3 8 11 2278 1137 SP
+-2 -2 -18 16 -10 23 5 19 14 13 0 -1 5 -16 1 -10 1 -11 1 -10 2 -10 0 -8 -5 0 6 -1 14 2073 979 SP
+-3 -5 -4 3 0 9 4 -3 4 2271 972 SP
+7 0 -3 -3 2 2259 991 SP
+4 -4 -2 -7 2 2283 951 SP
+3 -6 -3 1 2 2234 1048 SP
+3 2 1 2280 967 SP
+0 4 1 2228 1063 SP
+2 -1 1 2268 991 SP
+2 -1 1 2287 936 SP
+1 -4 1 2268 1107 SP
+2 7 1 2278 953 SP
+-3 0 3 1 2 2281 1091 SP
+1 -6 1 2279 964 SP
+{0 0 0.502 C} FS
+-3 7 -2 -4 2 2284 1014 SP
+2291 969 M
+2 -2 D
+7 -29 D
+12 -14 D
+2 -5 D
+0 7 D
+3 1 D
+1 8 D
+2 -4 D
+6 51 D
+-2 10 D
+-4 -6 D
+-1 -7 D
+2 11 D
+-3 -2 D
+0 16 D
+-6 -5 D
+3 22 D
+-3 0 D
+-3 -12 D
+2 9 D
+-1 2 D
+-3 -3 D
+-10 14 D
+0 -10 D
+-7 10 D
+-7 69 D
+2 -2 D
+7 -36 D
+6 -19 D
+15 -7 D
+3 11 D
+2 -1 D
+-6 18 D
+-2 31 D
+-3 11 D
+-13 12 D
+-9 -6 D
+-8 32 D
+-3 16 D
+17 24 D
+14 25 D
+2 -24 D
+3 3 D
+3 21 D
+-4 7 D
+5 -1 D
+-3 6 D
+1 1 D
+1 -1 D
+-1 2 D
+13 30 D
+12 39 D
+7 47 D
+0 7 D
+4 -45 D
+-4 58 D
+9 -48 D
+5 -42 D
+-1 4 D
+4 -48 D
+1 -80 D
+-6 -88 D
+-15 -100 D
+-12 -47 D
+-16 -41 D
+-28 -49 D
+-11 -15 D
+10 59 D
+6 67 D
+P
+FO
+{1 0 0 C} FS
+2355 1058 M
+5 70 D
+0 -2 D
+1 53 D
+1 0 D
+-1 13 D
+-1 5 D
+1 6 D
+-3 12 D
+1 8 D
+-2 46 D
+-1 -8 D
+-1 8 D
+0 -8 D
+-1 11 D
+-2 5 D
+1 -12 D
+-2 8 D
+3 -35 D
+-1 -8 D
+1 -9 D
+-2 -20 D
+0 -35 D
+-4 -24 D
+0 -27 D
+-5 -7 D
+-1 4 D
+-2 -39 D
+2 -2 D
+-1 -11 D
+2 1 D
+-2 -2 D
+2 -2 D
+-1 -7 D
+2 8 D
+0 -30 D
+4 18 D
+0 -12 D
+5 25 D
+0 -5 D
+2 11 D
+-1 -14 D
+P
+FO
+5 8 5 13 5 8 -1 -8 6 9 -4 -11 -2 -13 -10 -16 -1 4 -5 -13 -3 -15 -4 -8 1 10 -3 -13 3 16 0 3 16 2343 967 SP
+0 -10 3 6 -1 -10 -4 -8 -1 12 -2 -3 1 9 7 2329 992 SP
+-2 -6 -1 7 1 -2 3 2319 1041 SP
+2 -5 -1 -7 -1 3 3 2335 1134 SP
+4 3 0 -6 -2 0 3 2309 1024 SP
+2 10 -1 -5 -1 -4 3 2346 985 SP
+-1 -12 -2 -3 1 12 3 2335 1000 SP
+1 -7 -1 1 2 2292 930 SP
+2 11 1 3 2 2344 983 SP
+0 -3 -2 -2 2 2302 1032 SP
+-2 0 1 7 2 2306 1019 SP
+0 -5 -3 0 2 2322 1023 SP
+2 8 -1 -6 2 2309 1186 SP
+0 -5 1 2358 1263 SP
+0 2 1 2358 1247 SP
+1 -1 1 2319 1027 SP
+1 17 1 2357 1069 SP
+-2 3 2 -2 2 2311 1214 SP
+2 4 1 2318 1012 SP
+-2 -4 1 2316 1043 SP
+1 4 1 2349 1008 SP
+0 5 1 2351 1279 SP
+2 4 1 2313 1006 SP
+1 5 1 2316 1036 SP
+2 0 1 2300 905 SP
+0 -3 0 4 2 2359 1215 SP
+-1 6 1 2350 1289 SP
+1 -2 1 2287 1079 SP
+{0 0 0.502 C} FS
+0 3 1 2360 1138 SP
+-1 -6 1 2351 1057 SP
+{1 0 0 C} FS
+0 3 0 10 0 -6 0 -1 0 -13 5 2362 1191 SP
+-1 4 1 -5 2 2357 1274 SP
+0 2 -3 26 -1 18 4 -45 4 2344 1346 SP
+-1 2 1 -1 2 2312 1222 SP
+-3 -6 -3 6 5 -1 -4 7 3 21 3 3 2 -24 7 2305 1209 SP
+1 -9 1 -9 2 -10 -7 25 -9 -6 -13 12 -3 11 -2 31 -6 18 2 -1 3 11 15 -7 6 -19 7 -36 2 -2 15 2283 1100 SP
+2291 969 M
+2 -2 D
+7 -29 D
+12 -14 D
+2 -5 D
+0 7 D
+3 1 D
+1 8 D
+2 -4 D
+6 51 D
+-2 10 D
+-4 -6 D
+-1 -7 D
+2 11 D
+-3 -2 D
+0 16 D
+-6 -5 D
+3 22 D
+-3 0 D
+-3 -12 D
+2 9 D
+-1 2 D
+-3 -3 D
+-10 14 D
+0 -10 D
+-7 10 D
+P
+FO
+2355 1058 M
+5 70 D
+0 -2 D
+1 53 D
+1 0 D
+-1 13 D
+-1 5 D
+1 6 D
+-3 12 D
+1 8 D
+-2 46 D
+-1 -8 D
+-1 8 D
+0 -8 D
+-1 11 D
+-2 5 D
+1 -12 D
+-2 8 D
+3 -35 D
+-1 -8 D
+1 -9 D
+-2 -20 D
+0 -35 D
+-4 -24 D
+0 -27 D
+-5 -7 D
+-1 4 D
+-2 -39 D
+2 -2 D
+-1 -11 D
+2 1 D
+-2 -2 D
+2 -2 D
+-1 -7 D
+2 8 D
+0 -30 D
+4 18 D
+0 -12 D
+5 25 D
+0 -5 D
+2 11 D
+-1 -14 D
+P
+FO
+5 8 5 13 5 8 -1 -8 6 9 -4 -11 -2 -13 -10 -16 -1 4 -5 -13 -3 -15 -4 -8 1 10 -3 -13 3 16 0 3 16 2343 967 SP
+0 -10 3 6 -1 -10 -4 -8 -1 12 -2 -3 1 9 7 2329 992 SP
+-2 -6 -1 7 1 -2 3 2319 1041 SP
+2 -5 -1 -7 -1 3 3 2335 1134 SP
+4 3 0 -6 -2 0 3 2309 1024 SP
+2 10 -1 -5 -1 -4 3 2346 985 SP
+-1 -12 -2 -3 1 12 3 2335 1000 SP
+1 -7 -1 1 2 2292 930 SP
+2 11 1 3 2 2344 983 SP
+0 -3 -2 -2 2 2302 1032 SP
+-2 0 1 7 2 2306 1019 SP
+0 -5 -3 0 2 2322 1023 SP
+2 8 -1 -6 2 2309 1186 SP
+0 -5 1 2358 1263 SP
+0 2 1 2358 1247 SP
+1 -1 1 2319 1027 SP
+1 17 1 2357 1069 SP
+-2 3 2 -2 2 2311 1214 SP
+2 4 1 2318 1012 SP
+-2 -4 1 2316 1043 SP
+1 4 1 2349 1008 SP
+0 5 1 2351 1279 SP
+2 4 1 2313 1006 SP
+1 5 1 2316 1036 SP
+2 0 1 2300 905 SP
+0 -3 0 4 2 2359 1215 SP
+-1 6 1 2350 1289 SP
+1 -2 1 2287 1079 SP
+{0 0 0.502 C} FS
+0 3 1 2360 1138 SP
+-1 -6 1 2351 1057 SP
+2362 1201 M
+0 1 D
+0 -4 D
+-3 61 D
+-2 19 D
+0 -4 D
+-8 61 D
+-5 24 D
+-1 27 D
+3 -14 D
+-4 23 D
+2 -13 D
+-3 17 D
+2 -7 D
+-5 26 D
+15 -89 D
+8 -89 D
+P
+FO
+{1 0 0 C} FS
+2340 1410 M
+0 1 D
+8 -51 D
+-2 11 D
+7 -45 D
+-4 32 D
+0 -3 D
+P
+FO
+-1 8 1 -7 2 2353 1322 SP
+0 1 1 2345 1380 SP
+0 -3 0 5 -2 8 1 -2 1 -5 5 2341 1399 SP
+2 -13 1 2342 1395 SP
+1 -2 -3 11 -1 8 2 -8 1 -6 5 2343 1386 SP
+0 -4 0 5 2 2357 1273 SP
+0 -3 0 -7 0 -3 0 -8 0 1 5 2362 1201 SP
+2340 1410 M
+0 1 D
+8 -51 D
+-2 11 D
+7 -45 D
+-4 32 D
+0 -3 D
+P
+FO
+-1 8 1 -7 2 2353 1322 SP
+0 1 1 2345 1380 SP
+{0 0 0.502 C} FS
+-1 -9 -2 -9 0 -8 0 -9 -1 -8 1 5 0 5 2 16 3 15 0 6 0 5 11 13 1332 SP
+0 1 0 13 0 -7 -4 -20 3 16 1 5 -1 -9 7 15 1366 SP
+2 16 -2 -15 2 12 1347 SP
+0 -1 1 14 1347 SP
+0 1 1 13 1344 SP
+{1 0 0 C} FS
+0 3 1 14 1353 SP
+0 1181 M
+2 63 D
+7 66 D
+4 27 D
+11 81 D
+-13 -74 D
+-9 -88 D
+P
+FO
+{0 0 0.502 C} FS
+0 1 0 13 0 -7 -4 -20 3 16 1 5 -1 -9 7 15 1366 SP
+2 16 -2 -15 2 12 1347 SP
+0 -1 1 14 1347 SP
+0 1 1 13 1344 SP
+{1 0 0 C} FS
+0 3 1 14 1353 SP
+{0 0 0.502 C} FS
+2 1109 M
+0 4 D
+5 -33 D
+3 -2 D
+-2 0 D
+-1 0 D
+-1 7 D
+0 -16 D
+-1 21 D
+1 -6 D
+-2 12 D
+1 -5 D
+-1 10 D
+-1 -1 D
+-1 13 D
+P
+FO
+73 929 M
+-1 0 D
+-14 21 D
+-8 21 D
+-7 -4 D
+0 12 D
+2 1 D
+-4 5 D
+3 2 D
+-3 14 D
+-1 -3 D
+-1 10 D
+-1 -1 D
+-3 12 D
+0 -3 D
+-1 8 D
+0 -2 D
+-5 19 D
+0 -4 D
+-3 10 D
+-2 -10 D
+2 -6 D
+-2 1 D
+-1 8 D
+-3 -12 D
+1 12 D
+-4 10 D
+-2 21 D
+-4 0 D
+-1 7 D
+2 -4 D
+2 16 D
+5 9 D
+-1 3 D
+1 6 D
+-3 16 D
+1 44 D
+-1 6 D
+-1 -6 D
+0 22 D
+-7 66 D
+1 31 D
+-1 -6 D
+8 69 D
+2 9 D
+1 -26 D
+5 -33 D
+9 -34 D
+16 -41 D
+18 -33 D
+21 -32 D
+-13 -93 D
+-3 -55 D
+-1 -53 D
+P
+FO
+{1 0 0 C} FS
+-7 23 1 16 4 -3 2 -9 2 -14 -1 2 1 -7 7 15 1072 SP
+0 4 1 7 1 0 -1 -6 4 13 1078 SP
+-2 6 1 4 2 18 1077 SP
+2 -2 1 45 976 SP
+1 -4 1 15 1087 SP
+0 -4 1 17 1091 SP
+1 2 1 13 1085 SP
+-1 -3 1 15 1083 SP
+0 2 1 15 1078 SP
+0 5 1 44 970 SP
+0 -2 1 15 1088 SP
+0 4 1 37 1011 SP
+{0 0 0.502 C} FS
+-2 17 1 -7 -1 -4 3 -10 -1 12 5 14 1051 SP
+-1 4 -1 -8 2 9 1218 SP
+0 -4 1 21 1060 SP
+0 1 1 3 1099 SP
+0 3 1 3 1096 SP
+1 -7 1 -10 2 2 1124 SP
+-2 28 2 -27 2 11 1071 SP
+2 -20 1 20 1028 SP
+{1 0 0 C} FS
+0 6 1 6 1084 SP
+1 -6 1 15 1057 SP
+73 929 M
+-1 0 D
+-14 21 D
+-8 21 D
+-7 -4 D
+0 12 D
+2 1 D
+-4 5 D
+3 2 D
+-3 14 D
+-1 -3 D
+-1 10 D
+-1 -1 D
+-3 12 D
+0 -3 D
+-1 8 D
+0 -2 D
+-5 19 D
+0 -4 D
+-3 10 D
+-2 -10 D
+2 -6 D
+-2 1 D
+-1 8 D
+-3 -12 D
+1 12 D
+-4 10 D
+-2 21 D
+-4 0 D
+-1 7 D
+2 -4 D
+2 16 D
+5 9 D
+-1 3 D
+1 6 D
+-3 16 D
+1 44 D
+-1 6 D
+-1 -6 D
+0 22 D
+-7 66 D
+1 31 D
+-1 -6 D
+5 51 D
+-7 -44 D
+-5 -67 D
+-1 -69 D
+3 -46 D
+4 -26 D
+3 -2 D
+-2 0 D
+-1 0 D
+-1 7 D
+0 -16 D
+-1 21 D
+1 -6 D
+-2 12 D
+1 -5 D
+-1 10 D
+-1 -1 D
+-1 13 D
+7 -80 D
+15 -89 D
+9 -33 D
+16 -42 D
+23 -40 D
+16 -24 D
+-11 68 D
+-4 49 D
+P
+FO
+-7 23 1 16 4 -3 2 -9 2 -14 -1 2 1 -7 7 15 1072 SP
+0 4 1 7 1 0 -1 -6 4 13 1078 SP
+-2 6 1 4 2 18 1077 SP
+2 -2 1 45 976 SP
+1 -4 1 15 1087 SP
+0 -4 1 17 1091 SP
+1 2 1 13 1085 SP
+-1 -3 1 15 1083 SP
+0 2 1 15 1078 SP
+0 5 1 44 970 SP
+0 -2 1 15 1088 SP
+0 4 1 37 1011 SP
+{0 0 0.502 C} FS
+-2 17 1 -7 -1 -4 3 -10 -1 12 5 14 1051 SP
+-1 4 -1 -8 2 9 1218 SP
+0 -4 1 21 1060 SP
+0 1 1 3 1099 SP
+0 3 1 3 1096 SP
+1 -7 1 -10 2 2 1124 SP
+-2 28 2 -27 2 11 1071 SP
+2 -20 1 20 1028 SP
+{1 0 0 C} FS
+0 6 1 6 1084 SP
+1 -6 1 15 1057 SP
+{0 0 0.502 C} FS
+117 768 M
+6 17 D
+-2 19 D
+-11 43 D
+-13 17 D
+-24 65 D
+-2 53 D
+2 61 D
+12 101 D
+3 16 D
+25 -32 D
+21 -23 D
+8 -7 D
+7 -8 D
+42 -37 D
+57 -42 D
+42 -26 D
+-11 -101 D
+-3 -91 D
+3 -71 D
+11 -92 D
+-41 25 D
+-55 41 D
+-41 35 D
+-7 8 D
+-15 14 D
+P
+FO
+-2 2 1 85 859 SP
+-1 2 1 95 834 SP
+{1 0 0 C} FS
+117 768 M
+6 17 D
+-2 19 D
+-11 43 D
+-13 17 D
+-24 65 D
+1 -21 D
+7 -63 D
+7 -40 D
+P
+FO
+{0 0 0.502 C} FS
+-2 2 1 85 859 SP
+-1 2 1 95 834 SP
+373 940 M
+6 -7 D
+-3 -4 D
+6 -6 D
+0 -16 D
+5 -2 D
+-7 1 D
+11 -18 D
+-2 -7 D
+19 -20 D
+37 -53 D
+19 -16 D
+23 3 D
+36 -8 D
+35 -20 D
+35 5 D
+-2 -95 D
+1 -84 D
+6 -79 D
+2 -14 D
+-51 15 D
+-62 22 D
+-73 29 D
+-85 41 D
+-11 7 D
+-28 16 D
+-11 92 D
+-3 88 D
+3 74 D
+11 101 D
+57 -32 D
+18 -8 D
+P
+FO
+0 -3 18 -30 -1 9 12 -3 -14 4 -2 11 -12 10 11 1 -12 3 9 596 809 SP
+5 0 -5 1 2 596 808 SP
+0 -3 1 3 12 -8 -12 10 4 594 789 SP
+-7 10 -2 -9 4 3 2 -5 -4 -11 5 502 849 SP
+1 -7 1 537 795 SP
+{1 0 0 C} FS
+594 789 M
+-12 10 D
+12 -8 D
+2 17 D
+-5 1 D
+5 0 D
+-12 3 D
+11 1 D
+-12 10 D
+-2 11 D
+-14 4 D
+12 -3 D
+-1 9 D
+18 -30 D
+4 41 D
+-48 14 D
+-102 37 D
+-60 26 D
+-17 8 D
+6 -7 D
+-3 -4 D
+6 -6 D
+0 -16 D
+5 -2 D
+-7 1 D
+11 -18 D
+-2 -7 D
+19 -20 D
+37 -53 D
+19 -16 D
+23 3 D
+36 -8 D
+35 -20 D
+35 5 D
+P
+FO
+{0 0 0.502 C} FS
+-7 10 -2 -9 4 3 2 -5 -4 -11 5 502 849 SP
+1 -7 1 537 795 SP
+849 446 M
+10 -17 D
+-3 -18 D
+-20 -15 D
+-11 -34 D
+5 -30 D
+60 -69 D
+16 -47 D
+48 -45 D
+-114 16 D
+-96 20 D
+-74 20 D
+-18 42 D
+-16 45 D
+-13 49 D
+-11 53 D
+-12 77 D
+0 7 D
+73 -20 D
+104 -22 D
+P
+FO
+{1 0 0 C} FS
+2 -4 1 825 352 SP
+849 446 M
+10 -17 D
+-3 -18 D
+-20 -15 D
+-11 -34 D
+5 -30 D
+60 -69 D
+16 -47 D
+48 -45 D
+49 -5 D
+-12 95 D
+-8 94 D
+-4 76 D
+-85 9 D
+P
+FO
+2 -4 1 825 352 SP
+{0 0 0.502 C} FS
+1197 158 M
+7 6 D
+20 10 D
+12 28 D
+-3 -3 D
+-6 4 D
+57 24 D
+3 24 D
+-16 20 D
+0 12 D
+5 -3 D
+28 15 D
+11 14 D
+60 25 D
+3 3 D
+-9 -103 D
+-10 -68 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+P
+FO
+-1 1 1 1088 160 SP
+5 1 -6 25 6 10 -10 27 -14 4 11 -29 -6 -15 8 -23 8 1273 424 SP
+0 -2 3 1 3 0 -6 3 4 1383 427 SP
+-8 2 6 -2 -8 1 -4 -4 4 1115 187 SP
+-13 13 13 -14 14 -4 3 1263 324 SP
+-17 -3 23 3 15 16 3 1123 304 SP
+-5 3 2 -2 -5 0 3 1154 191 SP
+6 8 -7 -2 0 -6 3 1180 408 SP
+1 -4 1 1120 410 SP
+0 -4 1 1286 356 SP
+4 2 1 1040 274 SP
+-2 2 1 1218 186 SP
+-1 -4 1 1176 398 SP
+0 5 1 1295 342 SP
+38 1 1 1196 337 SP
+{1 0 0 C} FS
+1088 160 M
+-1 1 D
+44 -2 D
+66 -1 D
+7 6 D
+20 10 D
+12 28 D
+-3 -3 D
+-6 4 D
+57 24 D
+3 24 D
+-16 20 D
+0 12 D
+5 -3 D
+28 15 D
+11 14 D
+60 25 D
+3 3 D
+5 90 D
+-6 3 D
+-6 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 0 D
+8 -23 D
+-6 -15 D
+11 -29 D
+-14 4 D
+-10 27 D
+6 10 D
+-6 25 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-7 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-87 3 D
+-78 6 D
+6 -109 D
+12 -116 D
+6 -40 D
+P
+FO
+{0 0 0.502 C} FS
+-8 2 6 -2 -8 1 -4 -4 4 1115 187 SP
+-13 13 13 -14 14 -4 3 1263 324 SP
+-17 -3 23 3 15 16 3 1123 304 SP
+-5 3 2 -2 -5 0 3 1154 191 SP
+6 8 -7 -2 0 -6 3 1180 408 SP
+1 -4 1 1120 410 SP
+0 -4 1 1286 356 SP
+4 2 1 1040 274 SP
+-2 2 1 1218 186 SP
+-1 -4 1 1176 398 SP
+0 5 1 1295 342 SP
+38 1 1 1196 337 SP
+1378 337 M
+18 22 D
+-7 27 D
+5 3 D
+-5 22 D
+6 10 D
+-12 6 D
+0 4 D
+132 15 D
+96 17 D
+85 19 D
+67 18 D
+-11 -78 D
+-16 -71 D
+-14 -49 D
+-20 -55 D
+-9 -20 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -1 D
+-6 -2 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 0 D
+-7 -1 D
+12 90 D
+P
+FO
+{1 0 0 C} FS
+1457 226 M
+39 11 D
+58 96 D
+3 13 D
+8 7 D
+-2 18 D
+6 3 D
+3 -8 D
+7 9 D
+-6 34 D
+-13 9 D
+2 6 D
+-11 -9 D
+1 -14 D
+-11 -9 D
+-7 2 D
+2 -9 D
+-6 -1 D
+-6 -13 D
+0 6 D
+-9 -9 D
+3 -3 D
+-6 -3 D
+2 6 D
+-10 -6 D
+0 -7 D
+-6 3 D
+-34 -11 D
+-12 -20 D
+7 -33 D
+-21 -20 D
+-7 -13 D
+10 -31 D
+P
+FO
+7 4 -4 -7 2 1694 339 SP
+-2 8 5 -2 2 1446 410 SP
+0 5 6 -3 2 1464 406 SP
+-1 5 8 -2 2 1652 316 SP
+3 -4 1 1480 400 SP
+3 -1 1 1540 400 SP
+5 -1 1 1453 403 SP
+3 5 1 1565 351 SP
+{0 0 0.502 C} FS
+3 5 1 1538 337 SP
+{1 0 0 C} FS
+0 -11 -1 -11 -1 -11 0 -11 -1 -12 0 -11 -1 -12 -12 6 6 10 -5 22 5 3 -7 27 18 22 13 1378 337 SP
+1457 226 M
+39 11 D
+58 96 D
+3 13 D
+8 7 D
+-2 18 D
+6 3 D
+3 -8 D
+7 9 D
+-6 34 D
+-13 9 D
+2 6 D
+-11 -9 D
+1 -14 D
+-11 -9 D
+-7 2 D
+2 -9 D
+-6 -1 D
+-6 -13 D
+0 6 D
+-9 -9 D
+3 -3 D
+-6 -3 D
+2 6 D
+-10 -6 D
+0 -7 D
+-6 3 D
+-34 -11 D
+-12 -20 D
+7 -33 D
+-21 -20 D
+-7 -13 D
+10 -31 D
+P
+FO
+7 4 -4 -7 2 1694 339 SP
+-2 8 5 -2 2 1446 410 SP
+0 5 6 -3 2 1464 406 SP
+-1 5 8 -2 2 1652 316 SP
+3 -4 1 1480 400 SP
+3 -1 1 1540 400 SP
+5 -1 1 1453 403 SP
+3 5 1 1565 351 SP
+{0 0 0.502 C} FS
+3 5 1 1538 337 SP
+1965 341 M
+-20 -11 D
+-20 -11 D
+-21 -11 D
+-21 -10 D
+-11 -5 D
+-11 -5 D
+-11 -5 D
+-11 -5 D
+-12 -5 D
+-6 -2 D
+-11 -5 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -3 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-7 -1 D
+-6 -2 D
+-6 -2 D
+17 42 D
+16 45 D
+18 69 D
+11 60 D
+8 57 D
+50 15 D
+63 22 D
+72 29 D
+62 29 D
+57 31 D
+5 4 D
+-10 -52 D
+-21 -77 D
+-25 -65 D
+-37 -73 D
+P
+FO
+2142 495 M
+-16 -21 D
+-31 -34 D
+-28 -26 D
+-31 -25 D
+-26 -19 D
+-27 -18 D
+-18 -11 D
+17 28 D
+34 67 D
+20 52 D
+17 55 D
+14 57 D
+5 30 D
+42 26 D
+48 35 D
+18 14 D
+41 37 D
+41 47 D
+12 16 D
+-14 -61 D
+-24 -74 D
+-25 -57 D
+-24 -47 D
+-23 -40 D
+P
+FO
+2145 499 M
+-3 -4 D
+30 44 D
+26 47 D
+26 55 D
+17 44 D
+21 66 D
+12 54 D
+16 23 D
+27 49 D
+17 50 D
+4 17 D
+-17 -73 D
+-26 -84 D
+-23 -58 D
+-36 -80 D
+-36 -66 D
+-47 -74 D
+P
+FO
+135 632 M
+-2 4 D
+6 -10 D
+-1 2 D
+9 -14 D
+-3 6 D
+2 -1 D
+-9 24 D
+34 -70 D
+29 -49 D
+20 -29 D
+-39 58 D
+-33 56 D
+P
+FO
+{1 0 0 C} FS
+2 -2 1 135 632 SP
+{0 0 0.502 C} FS
+-1 0 -6 13 5 -9 1 -3 3 -5 -6 11 -1 2 1 -1 -4 9 9 117 668 SP
+6 -14 -1 5 -1 1 -2 5 -2 4 5 102 704 SP
+-3 6 1 123 658 SP
+-5 10 1 106 693 SP
+{1 0 0 C} FS
+135 632 M
+-2 4 D
+6 -10 D
+-1 2 D
+9 -14 D
+-3 6 D
+2 -1 D
+-31 83 D
+-21 75 D
+-6 28 D
+-26 40 D
+-13 24 D
+-19 50 D
+-6 25 D
+14 -62 D
+26 -86 D
+18 -47 D
+30 -71 D
+P
+FO
+2 -2 1 135 632 SP
+{0 0 0.502 C} FS
+-1 0 -6 13 5 -9 1 -3 3 -5 -6 11 -1 2 1 -1 -4 9 9 117 668 SP
+6 -14 -1 5 -1 1 -2 5 -2 4 5 102 704 SP
+-3 6 1 123 658 SP
+-5 10 1 106 693 SP
+137 643 M
+0 3 D
+-7 18 D
+0 6 D
+-23 79 D
+4 -9 D
+6 28 D
+21 -22 D
+8 -7 D
+7 -8 D
+41 -35 D
+36 -27 D
+39 -27 D
+21 -12 D
+12 -59 D
+19 -70 D
+23 -59 D
+26 -55 D
+24 -41 D
+4 -5 D
+-46 29 D
+-41 31 D
+-30 26 D
+-21 20 D
+-35 41 D
+-29 42 D
+-28 49 D
+P
+FO
+{1 0 0 C} FS
+137 643 M
+0 3 D
+-7 18 D
+0 6 D
+-23 79 D
+4 -9 D
+6 28 D
+-29 37 D
+13 -56 D
+16 -54 D
+P
+FO
+{0 0 0.502 C} FS
+670 227 M
+-57 17 D
+-66 24 D
+-84 37 D
+-61 33 D
+-4 3 D
+-11 17 D
+-26 47 D
+-25 56 D
+-19 54 D
+-17 63 D
+-10 52 D
+34 -19 D
+11 -7 D
+60 -29 D
+65 -28 D
+40 -15 D
+85 -28 D
+15 -4 D
+9 -71 D
+14 -66 D
+17 -61 D
+25 -65 D
+P
+FO
+954 171 M
+22 -19 D
+4 -9 D
+-8 -1 D
+13 -15 D
+6 1 D
+22 -8 D
+9 -37 D
+18 -44 D
+9 -15 D
+-75 8 D
+-104 19 D
+-68 18 D
+-15 9 D
+-27 21 D
+-13 12 D
+-30 36 D
+-17 24 D
+-26 46 D
+-4 10 D
+74 -20 D
+57 -12 D
+72 -13 D
+P
+FO
+{1 0 0 C} FS
+954 171 M
+22 -19 D
+4 -9 D
+-8 -1 D
+13 -15 D
+6 1 D
+22 -8 D
+-10 46 D
+P
+FO
+{0 0 0.502 C} FS
+1013 120 M
+0 -1 D
+41 5 D
+39 -4 D
+37 4 D
+51 21 D
+16 13 D
+75 2 D
+87 6 D
+-13 -60 D
+-16 -52 D
+-12 -23 D
+-5 -7 D
+-11 -1 D
+-11 -1 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 -1 D
+-11 0 D
+-11 0 D
+-11 -1 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-55 2 D
+-55 4 D
+-12 20 D
+-15 39 D
+P
+FO
+4 -2 1 1088 160 SP
+{1 0 0 C} FS
+4 1 1 1288 34 SP
+{0 0 0.502 C} FS
+6 -1 1 1102 154 SP
+{1 0 0 C} FS
+1088 160 M
+4 -2 D
+-4 2 D
+-85 6 D
+10 -47 D
+41 5 D
+39 -4 D
+37 4 D
+51 21 D
+16 13 D
+-11 0 D
+-11 0 D
+-11 0 D
+P
+FO
+4 1 1 1288 34 SP
+{0 0 0.502 C} FS
+6 -1 1 1102 154 SP
+1561 69 M
+-10 -3 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-10 -2 D
+-10 -2 D
+-10 -3 D
+-10 -2 D
+-10 -2 D
+-11 -2 D
+-10 -2 D
+-10 -2 D
+-11 -2 D
+-10 -2 D
+-11 -1 D
+-10 -2 D
+-11 -2 D
+-10 -1 D
+-11 -2 D
+-11 -1 D
+-11 -1 D
+-10 -1 D
+-11 -1 D
+-11 -1 D
+10 15 D
+11 27 D
+18 64 D
+7 36 D
+87 10 D
+92 14 D
+96 21 D
+59 16 D
+-25 -47 D
+-23 -33 D
+-36 -42 D
+-27 -22 D
+P
+FO
+1732 136 M
+-14 -7 D
+-16 -8 D
+-8 -3 D
+-16 -8 D
+-9 -3 D
+-8 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-10 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -2 D
+-9 -3 D
+34 24 D
+20 18 D
+30 36 D
+23 33 D
+25 47 D
+56 17 D
+67 24 D
+83 37 D
+66 36 D
+-23 -32 D
+-32 -40 D
+-22 -23 D
+-5 -4 D
+-4 -5 D
+-33 -29 D
+-30 -22 D
+-21 -14 D
+-23 -13 D
+-26 -15 D
+P
+FO
+{1 0 0 C} FS
+4 2 -8 -3 6 3 -14 -6 5 2 8 4 -3 -1 7 2 5 3 9 1662 104 SP
+4 2 -8 -3 6 3 -14 -6 5 2 8 4 -3 -1 7 2 5 3 9 1662 104 SP
+{0 0 0.502 C} FS
+1786 166 M
+40 27 D
+39 31 D
+14 13 D
+4 5 D
+14 13 D
+37 43 D
+31 43 D
+37 23 D
+50 37 D
+29 26 D
+21 20 D
+35 41 D
+5 7 D
+-21 -29 D
+-39 -49 D
+-51 -56 D
+-63 -61 D
+-48 -41 D
+-40 -30 D
+-31 -22 D
+-31 -21 D
+-22 -13 D
+P
+FO
+3 4 4 6 2 3 3 2136 486 SP
+2 -3 4 -6 3 -4 3 217 499 SP
+226 486 M
+-6 9 D
+28 -35 D
+19 -20 D
+28 -26 D
+23 -19 D
+43 -31 D
+37 -23 D
+7 -11 D
+15 -21 D
+28 -35 D
+26 -28 D
+5 -4 D
+4 -5 D
+10 -8 D
+4 -5 D
+39 -31 D
+41 -27 D
+-54 34 D
+-61 44 D
+-39 31 D
+-47 42 D
+-54 53 D
+-50 57 D
+P
+FO
+802 69 M
+-47 14 D
+-70 27 D
+-55 26 D
+-63 36 D
+-51 36 D
+-19 16 D
+-4 5 D
+-10 8 D
+-4 5 D
+-14 13 D
+-37 43 D
+-16 21 D
+-7 11 D
+-7 11 D
+49 -28 D
+100 -45 D
+103 -36 D
+20 -5 D
+14 -29 D
+27 -43 D
+30 -37 D
+6 -7 D
+27 -23 D
+20 -15 D
+P
+FO
+854 46 M
+-24 8 D
+-28 15 D
+48 -13 D
+92 -19 D
+75 -10 D
+32 -3 D
+10 -11 D
+11 -7 D
+7 -1 D
+-63 7 D
+-74 13 D
+-50 11 D
+P
+FO
+1077 5 M
+-2 0 D
+-8 2 D
+-13 11 D
+-5 6 D
+77 -5 D
+88 -1 D
+88 5 D
+11 1 D
+-10 -11 D
+-8 -6 D
+-3 -1 D
+-2 -1 D
+-3 0 D
+-15 -2 D
+-13 0 D
+-13 -1 D
+-13 -1 D
+-13 0 D
+-13 -1 D
+-13 0 D
+-13 0 D
+-13 0 D
+-78 3 D
+P
+FO
+1285 5 M
+7 1 D
+11 7 D
+10 11 D
+75 8 D
+104 19 D
+69 18 D
+-14 -8 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -2 D
+-14 -4 D
+-12 -3 D
+-12 -4 D
+-12 -3 D
+-13 -3 D
+-12 -2 D
+-12 -3 D
+-13 -3 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-13 -2 D
+-12 -1 D
+-13 -2 D
+-13 -1 D
+P
+FO
+1509 46 M
+38 15 D
+14 8 D
+46 14 D
+71 27 D
+54 26 D
+-23 -11 D
+-22 -11 D
+-12 -6 D
+-11 -5 D
+-12 -5 D
+-12 -5 D
+-11 -5 D
+-12 -5 D
+-12 -4 D
+-12 -5 D
+-12 -4 D
+-12 -4 D
+-12 -5 D
+-12 -4 D
+-12 -3 D
+-12 -4 D
+P
+FO
+630 136 M
+55 -26 D
+52 -20 D
+46 -16 D
+19 -5 D
+28 -15 D
+24 -8 D
+-49 15 D
+-71 27 D
+-47 20 D
+P
+FO
+25 W
+4 W
+854 46 M
+-45 18 D
+-36 24 D
+-21 18 D
+-38 44 D
+-28 45 D
+-25 50 D
+-29 82 D
+-17 73 D
+-12 71 D
+-9 84 D
+-3 90 D
+1 102 D
+5 79 D
+10 100 D
+17 112 D
+16 84 D
+21 94 D
+28 104 D
+34 111 D
+36 100 D
+21 54 D
+41 95 D
+27 58 D
+50 96 D
+35 61 D
+45 71 D
+37 53 D
+19 25 D
+38 48 D
+38 43 D
+15 16 D
+5 4 D
+S
+1181 0 M
+0 2149 D
+S
+1509 46 M
+44 18 D
+29 19 D
+28 23 D
+38 44 D
+23 35 D
+30 60 D
+29 82 D
+19 80 D
+15 102 D
+6 86 D
+2 92 D
+-4 104 D
+-11 117 D
+-11 83 D
+-13 75 D
+-25 122 D
+-32 122 D
+-31 103 D
+-45 127 D
+-47 114 D
+-39 84 D
+-42 81 D
+-25 46 D
+-58 94 D
+-51 73 D
+-57 71 D
+-15 16 D
+-9 11 D
+-24 25 D
+S
+1954 288 M
+41 38 D
+25 27 D
+32 40 D
+37 55 D
+26 46 D
+28 62 D
+14 36 D
+18 60 D
+14 62 D
+11 80 D
+4 83 D
+-1 60 D
+-7 77 D
+-12 79 D
+-15 70 D
+-23 79 D
+-24 70 D
+-29 69 D
+-41 85 D
+-37 67 D
+-41 66 D
+-33 48 D
+-59 77 D
+-57 66 D
+-40 43 D
+-70 67 D
+-66 56 D
+-69 52 D
+-24 16 D
+-15 11 D
+-88 54 D
+-91 47 D
+-75 32 D
+-17 6 D
+S
+2362 1181 M
+-1 51 D
+-10 92 D
+-12 58 D
+-15 58 D
+-25 72 D
+-28 63 D
+-32 62 D
+-23 37 D
+-19 29 D
+-31 43 D
+-34 42 D
+-29 33 D
+-25 26 D
+-7 6 D
+-6 7 D
+-47 43 D
+-56 46 D
+-68 48 D
+-64 39 D
+-83 43 D
+-61 27 D
+-90 33 D
+-83 24 D
+-75 17 D
+-86 13 D
+-39 5 D
+-29 2 D
+S
+1954 2074 M
+-7 7 D
+-47 35 D
+-49 32 D
+-46 24 D
+-69 29 D
+-58 18 D
+-60 13 D
+-69 10 D
+-72 4 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-9 -2 D
+-8 -1 D
+-9 -1 D
+-8 -2 D
+-8 -2 D
+-9 -1 D
+S
+1509 2316 M
+-28 6 D
+-43 3 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-10 -4 D
+-9 -4 D
+-10 -4 D
+-19 -10 D
+-19 -11 D
+-29 -19 D
+-9 -6 D
+S
+1181 2362 M
+0 -110 D
+S
+854 2316 M
+27 6 D
+43 3 D
+45 -6 D
+37 -9 D
+47 -19 D
+48 -27 D
+29 -19 D
+S
+408 2074 M
+42 34 D
+62 40 D
+45 24 D
+69 29 D
+58 18 D
+60 13 D
+70 10 D
+71 4 D
+57 -1 D
+83 -8 D
+50 -8 D
+17 -3 D
+S
+0 1181 M
+2 59 D
+8 76 D
+13 66 D
+15 58 D
+22 64 D
+24 56 D
+35 69 D
+27 45 D
+35 51 D
+32 42 D
+35 41 D
+36 39 D
+7 6 D
+6 7 D
+27 24 D
+6 7 D
+63 52 D
+60 44 D
+79 49 D
+75 39 D
+69 31 D
+99 36 D
+83 23 D
+66 15 D
+86 13 D
+39 5 D
+29 2 D
+S
+408 288 M
+-35 33 D
+-21 21 D
+-14 17 D
+-28 34 D
+-37 55 D
+-29 53 D
+-19 41 D
+-20 50 D
+-22 75 D
+-16 87 D
+-7 65 D
+-2 84 D
+3 59 D
+8 78 D
+18 96 D
+21 79 D
+29 88 D
+32 78 D
+28 60 D
+41 76 D
+24 41 D
+37 57 D
+28 39 D
+41 55 D
+37 45 D
+59 65 D
+20 21 D
+56 53 D
+37 32 D
+29 25 D
+38 30 D
+54 39 D
+55 36 D
+40 25 D
+58 31 D
+49 25 D
+75 32 D
+17 6 D
+S
+1130 2155 M
+14 15 D
+37 34 D
+S
+1270 2174 M
+-44 16 D
+-45 14 D
+S
+1233 2245 M
+-30 -23 D
+-22 -18 D
+S
+1092 2226 M
+83 -20 D
+6 -2 D
+S
+1130 2155 M
+28 -5 D
+41 -1 D
+29 5 D
+29 11 D
+11 7 D
+1 2 D
+8 7 D
+5 8 D
+2 12 D
+-2 10 D
+-4 7 D
+-2 1 D
+-2 4 D
+-2 1 D
+-1 2 D
+-12 8 D
+-18 8 D
+-21 6 D
+-26 3 D
+-3 0 D
+-14 1 D
+-3 -1 D
+-4 0 D
+-3 0 D
+-3 0 D
+-4 -1 D
+-3 0 D
+-3 0 D
+-4 -1 D
+-3 0 D
+-3 -1 D
+-3 -1 D
+-3 0 D
+-3 -1 D
+-3 -1 D
+-3 -1 D
+-3 -1 D
+-3 0 D
+-3 -1 D
+-5 -3 D
+-3 -1 D
+-5 -2 D
+-6 -4 D
+-3 -1 D
+-1 -2 D
+-6 -4 D
+-4 -5 D
+-2 -1 D
+-5 -8 D
+-2 -12 D
+2 -9 D
+4 -8 D
+2 -1 D
+4 -5 D
+2 -1 D
+1 -2 D
+13 -8 D
+18 -8 D
+P S
+217 499 M
+20 -26 D
+20 -23 D
+8 -7 D
+15 -16 D
+34 -29 D
+48 -35 D
+42 -26 D
+52 -28 D
+36 -18 D
+79 -32 D
+77 -26 D
+104 -28 D
+102 -20 D
+106 -15 D
+92 -8 D
+84 -3 D
+76 -1 D
+93 4 D
+83 7 D
+123 16 D
+102 21 D
+82 21 D
+71 23 D
+80 31 D
+50 23 D
+41 21 D
+50 29 D
+67 49 D
+33 29 D
+15 16 D
+8 7 D
+32 39 D
+3 5 D
+S
+0 1181 M
+2 -37 D
+3 -20 D
+14 -48 D
+12 -29 D
+14 -28 D
+31 -46 D
+22 -28 D
+47 -48 D
+67 -54 D
+59 -39 D
+13 -7 D
+53 -29 D
+56 -27 D
+91 -37 D
+81 -27 D
+112 -30 D
+99 -21 D
+84 -13 D
+85 -11 D
+106 -8 D
+98 -3 D
+126 1 D
+78 5 D
+124 12 D
+85 13 D
+91 18 D
+96 23 D
+92 28 D
+86 32 D
+87 39 D
+73 40 D
+65 43 D
+42 32 D
+20 17 D
+4 5 D
+35 34 D
+31 36 D
+31 47 D
+15 28 D
+19 48 D
+9 39 D
+3 19 D
+1 31 D
+S
+217 1863 M
+-18 -27 D
+-20 -41 D
+-14 -42 D
+-7 -51 D
+2 -42 D
+9 -42 D
+16 -41 D
+17 -33 D
+28 -40 D
+27 -31 D
+31 -30 D
+35 -29 D
+49 -34 D
+32 -20 D
+40 -22 D
+48 -24 D
+26 -11 D
+53 -21 D
+55 -19 D
+88 -26 D
+85 -19 D
+88 -15 D
+90 -12 D
+108 -8 D
+110 -2 D
+101 3 D
+125 11 D
+106 16 D
+86 18 D
+89 23 D
+92 31 D
+59 24 D
+37 17 D
+53 27 D
+44 26 D
+67 49 D
+33 29 D
+30 31 D
+25 31 D
+26 40 D
+19 42 D
+12 41 D
+4 26 D
+1 34 D
+-5 42 D
+-11 42 D
+-23 49 D
+-20 30 D
+S
+886 1811 M
+88 -21 D
+84 -12 D
+68 -5 D
+97 -1 D
+68 5 D
+66 8 D
+82 16 D
+60 17 D
+70 26 D
+35 17 D
+33 18 D
+40 28 D
+16 12 D
+4 5 D
+22 21 D
+22 28 D
+16 28 D
+10 29 D
+4 19 D
+1 20 D
+-4 29 D
+-9 29 D
+-14 28 D
+-13 19 D
+-28 31 D
+-41 33 D
+-43 27 D
+-56 27 D
+-54 20 D
+-42 13 D
+-71 17 D
+-84 13 D
+-77 6 D
+-87 1 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-9 -2 D
+-10 -1 D
+-9 -1 D
+-9 -2 D
+-10 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -3 D
+-8 -2 D
+-9 -2 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-8 -2 D
+-9 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-13 -7 D
+-13 -7 D
+-18 -12 D
+-17 -12 D
+-30 -25 D
+-25 -26 D
+-14 -19 D
+-11 -18 D
+-15 -39 D
+-4 -29 D
+1 -29 D
+7 -29 D
+13 -29 D
+5 -9 D
+13 -19 D
+33 -35 D
+31 -25 D
+35 -23 D
+40 -22 D
+60 -25 D
+P S
+8 W
+%%EndObject
+0 -4724 TM
+PSL_completion /PSL_completion {} def
+0 A
+FQ
+O0
+2362 2362 TM
+
+% PostScript produced by:
+%@GMT: gmt pscoast -Rg -JG120/30/1.9685i -Gred -Snavy -Bg -B+n -Xa1.9685i -Ya1.9685i
+%@PROJ: ortho 0.00000000 360.00000000 -90.00000000 90.00000000 -6371007.181 6371007.181 -6371007.181 6371007.181 +unavailable +a=6371007.181 +b=6371007.180918 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+{0 0 0.502 C} FS
+2362 1181 M
+-1 59 D
+-9 97 D
+-13 77 D
+-13 57 D
+-16 56 D
+-25 74 D
+-30 72 D
+-26 53 D
+-38 68 D
+-43 65 D
+-47 63 D
+-51 59 D
+-55 56 D
+-58 52 D
+-62 48 D
+-64 43 D
+-34 21 D
+-68 37 D
+-53 25 D
+-73 29 D
+-93 29 D
+-57 14 D
+-57 11 D
+-59 8 D
+-77 7 D
+-98 1 D
+-19 -1 D
+-20 -1 D
+-19 -2 D
+-20 -2 D
+-19 -2 D
+-20 -2 D
+-19 -3 D
+-19 -3 D
+-20 -3 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-18 -6 D
+-19 -6 D
+-18 -6 D
+-19 -6 D
+-18 -7 D
+-18 -7 D
+-18 -8 D
+-18 -7 D
+-18 -8 D
+-18 -9 D
+-35 -17 D
+-34 -19 D
+-34 -19 D
+-33 -21 D
+-48 -33 D
+-62 -48 D
+-58 -52 D
+-55 -56 D
+-51 -59 D
+-47 -63 D
+-32 -48 D
+-49 -85 D
+-34 -70 D
+-29 -73 D
+-29 -93 D
+-22 -95 D
+-11 -78 D
+-7 -77 D
+-1 -78 D
+3 -59 D
+7 -78 D
+13 -77 D
+23 -95 D
+31 -92 D
+30 -72 D
+35 -70 D
+50 -84 D
+45 -64 D
+49 -61 D
+53 -57 D
+42 -41 D
+59 -51 D
+63 -47 D
+32 -22 D
+101 -59 D
+71 -34 D
+72 -29 D
+93 -29 D
+95 -22 D
+78 -11 D
+78 -7 D
+78 -1 D
+39 1 D
+97 9 D
+77 13 D
+95 23 D
+92 31 D
+72 30 D
+53 26 D
+101 59 D
+80 57 D
+60 50 D
+42 40 D
+41 42 D
+51 59 D
+47 63 D
+22 32 D
+31 50 D
+37 69 D
+25 53 D
+29 72 D
+29 93 D
+14 57 D
+11 58 D
+8 58 D
+7 78 D
+P
+FO
+988 2207 M
+1 0 D
+-7 0 D
+1 3 D
+-9 -2 D
+0 -2 D
+-6 -1 D
+-6 0 D
+11 4 D
+-5 1 D
+15 3 D
+-23 -2 D
+19 4 D
+-9 1 D
+8 3 D
+4 -2 D
+-3 5 D
+-29 -4 D
+10 -4 D
+-8 -1 D
+4 -2 D
+-6 -2 D
+-3 7 D
+-7 -1 D
+0 -6 D
+-3 5 D
+-5 -4 D
+4 5 D
+-12 -4 D
+-10 -4 D
+34 -1 D
+2 -2 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-9 -1 D
+-8 -2 D
+-8 -1 D
+-9 -1 D
+-8 -2 D
+-8 -1 D
+-9 -2 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+11 23 D
+21 28 D
+16 15 D
+62 3 D
+79 -3 D
+64 -7 D
+88 -17 D
+57 -15 D
+-89 5 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-8 -1 D
+P
+FO
+{1 0 0 C} FS
+16 4 -8 -3 2 959 2222 SP
+962 2205 M
+11 4 D
+-5 1 D
+15 3 D
+-23 -2 D
+19 4 D
+-9 1 D
+8 3 D
+4 -2 D
+-3 5 D
+-29 -4 D
+10 -4 D
+-8 -1 D
+4 -2 D
+-6 -2 D
+-3 7 D
+-7 -1 D
+0 -6 D
+-3 5 D
+-5 -4 D
+4 5 D
+-12 -4 D
+-10 -4 D
+34 -1 D
+2 -2 D
+P
+FO
+7 0 0 -2 -9 -2 1 3 -7 0 1 0 6 988 2207 SP
+16 4 -8 -3 2 959 2222 SP
+{0 0 0.502 C} FS
+777 2146 M
+4 2 D
+-3 -6 D
+7 -1 D
+9 10 D
+-8 1 D
+10 1 D
+3 4 D
+-12 -2 D
+-2 2 D
+12 2 D
+-17 1 D
+15 1 D
+3 5 D
+-18 -1 D
+0 1 D
+8 7 D
+-7 -2 D
+2 6 D
+66 14 D
+101 13 D
+3 -3 D
+9 4 D
+12 1 D
+0 -3 D
+-6 2 D
+-7 -7 D
+14 -4 D
+9 4 D
+-4 3 D
+8 1 D
+-11 0 D
+11 5 D
+72 2 D
+64 -1 D
+57 -4 D
+-9 -1 D
+-9 -1 D
+-10 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-10 -2 D
+-9 -1 D
+-9 -1 D
+-9 -2 D
+-9 -1 D
+-10 -2 D
+-9 -2 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -4 D
+-9 -3 D
+-9 -4 D
+-6 28 D
+P
+FO
+{1 0 0 C} FS
+-8 -2 3 -3 -14 -1 -2 4 14 4 5 929 2193 SP
+-1 3 7 0 2 943 2201 SP
+1 -4 1 953 2189 SP
+3 3 1 797 2162 SP
+3 -2 1 978 2185 SP
+2 3 1 785 2168 SP
+3 -4 1 792 2173 SP
+5 -1 1 787 2169 SP
+-1 -3 -7 -2 8 7 3 780 2166 SP
+777 2146 M
+4 2 D
+-3 -6 D
+7 -1 D
+9 10 D
+-8 1 D
+10 1 D
+3 4 D
+-12 -2 D
+-2 2 D
+12 2 D
+-17 1 D
+15 1 D
+3 5 D
+-18 -1 D
+P
+FO
+-7 -1 11 5 -11 0 8 1 -4 3 9 4 14 -4 -7 -7 -6 2 0 -3 10 974 2206 SP
+-6 -1 9 4 3 -3 3 950 2204 SP
+-8 -2 3 -3 -14 -1 -2 4 14 4 5 929 2193 SP
+-1 3 7 0 2 943 2201 SP
+1 -4 1 953 2189 SP
+3 3 1 797 2162 SP
+3 -2 1 978 2185 SP
+2 3 1 785 2168 SP
+3 -4 1 792 2173 SP
+5 -1 1 787 2169 SP
+{0 0 0.502 C} FS
+1021 2145 M
+-2 -1 D
+-1 0 D
+-8 -4 D
+1 0 D
+-7 -3 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -7 D
+-13 -6 D
+-24 1 D
+-7 -7 D
+-13 0 D
+0 -5 D
+-1 5 D
+-10 0 D
+3 -7 D
+-10 2 D
+5 -8 D
+8 6 D
+1 -5 D
+2 5 D
+1 -4 D
+7 5 D
+-2 -4 D
+10 6 D
+0 -4 D
+8 1 D
+-13 -7 D
+-14 -8 D
+-13 -8 D
+-13 -8 D
+-20 -13 D
+-7 -4 D
+2 8 D
+-7 -5 D
+-21 22 D
+-15 23 D
+-8 17 D
+44 17 D
+53 19 D
+81 23 D
+82 19 D
+83 13 D
+55 6 D
+-7 -2 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-7 -3 D
+P
+FO
+{1 0 0 C} FS
+-13 -9 5 -4 -5 -5 -20 -1 1 -4 -6 2 -3 -4 -6 4 -3 5 14 2 12 7 14 19 10 -11 13 825 2067 SP
+8 3 12 -5 2 988 2160 SP
+7 0 -5 -4 2 1006 2145 SP
+5 2 1 995 2149 SP
+-1 3 1 988 2151 SP
+1 -6 -1 0 2 1013 2152 SP
+7 1 1 998 2144 SP
+-5 1 1 1023 2152 SP
+2 -2 2 -2 -7 -5 2 8 4 832 2042 SP
+934 2103 M
+-24 1 D
+-7 -7 D
+-13 0 D
+0 -5 D
+-1 5 D
+-10 0 D
+3 -7 D
+-10 2 D
+5 -8 D
+8 6 D
+1 -5 D
+2 5 D
+1 -4 D
+7 5 D
+-2 -4 D
+10 6 D
+0 -4 D
+8 1 D
+P
+FO
+3 2 1 0 -7 -4 -1 0 4 1018 2144 SP
+-13 -9 5 -4 -5 -5 -20 -1 1 -4 -6 2 -3 -4 -6 4 -3 5 14 2 12 7 14 19 10 -11 13 825 2067 SP
+8 3 12 -5 2 988 2160 SP
+7 0 -5 -4 2 1006 2145 SP
+5 2 1 995 2149 SP
+-1 3 1 988 2151 SP
+1 -6 -1 0 2 1013 2152 SP
+7 1 1 998 2144 SP
+-5 1 1 1023 2152 SP
+{0 0 0.502 C} FS
+884 2005 M
+13 11 D
+4 10 D
+23 12 D
+-2 5 D
+-9 6 D
+-25 -13 D
+-13 -2 D
+-17 -13 D
+-26 20 D
+0 1 D
+74 45 D
+6 3 D
+13 3 D
+36 -6 D
+12 7 D
+-21 1 D
+-11 7 D
+-7 1 D
+77 37 D
+11 1 D
+-4 3 D
+3 1 D
+4 -1 D
+-4 1 D
+43 19 D
+22 8 D
+66 23 D
+29 9 D
+-12 -7 D
+-18 -12 D
+-12 -7 D
+-23 -17 D
+-18 -13 D
+-24 -18 D
+-35 -29 D
+-46 -41 D
+-35 -34 D
+-5 -6 D
+-6 -5 D
+-3 7 D
+-7 0 D
+-2 -6 D
+-9 5 D
+-1 -18 D
+-8 9 D
+17 23 D
+-8 -8 D
+-20 -5 D
+-6 -13 D
+-9 -7 D
+P
+FO
+{1 0 0 C} FS
+-6 -5 -5 3 6 3 3 922 2047 SP
+12 2 1 1021 2138 SP
+2 5 -1 -5 2 954 2029 SP
+4 -1 1 933 2039 SP
+-1 -1 0 1 2 832 2041 SP
+6 -4 5 -3 5 -3 5 -3 -17 -13 -13 -2 -25 -13 -9 6 -2 5 23 12 4 10 13 11 12 884 2005 SP
+947 2015 M
+-3 7 D
+-7 0 D
+-2 -6 D
+-9 5 D
+-1 -18 D
+-8 9 D
+17 23 D
+-8 -8 D
+-20 -5 D
+-6 -13 D
+-9 -7 D
+30 -14 D
+7 6 D
+P
+FO
+4 -1 1 1021 2145 SP
+-4 -2 -4 3 11 1 3 1011 2140 SP
+-7 -4 -7 -4 -7 1 -11 7 -21 1 12 7 36 -6 13 3 8 912 2090 SP
+-6 -5 -5 3 6 3 3 922 2047 SP
+12 2 1 1021 2138 SP
+2 5 -1 -5 2 954 2029 SP
+4 -1 1 933 2039 SP
+{0 0 0.502 C} FS
+-1 -1 2 1 2 966 1971 SP
+937 1981 M
+0 4 D
+11 9 D
+-9 -3 D
+21 13 D
+-10 3 D
+-3 8 D
+6 5 D
+28 29 D
+52 47 D
+47 39 D
+65 47 D
+36 22 D
+-42 -63 D
+-29 -51 D
+-3 4 D
+-5 -2 D
+2 4 D
+-21 -4 D
+6 -10 D
+14 -4 D
+-16 -32 D
+-5 1 D
+1 -7 D
+-3 4 D
+-18 -3 D
+4 4 D
+-12 2 D
+-4 -2 D
+6 -1 D
+-40 -1 D
+-6 -7 D
+-2 5 D
+-5 -16 D
+-35 8 D
+-12 -15 D
+5 -16 D
+-19 -22 D
+P
+FO
+0 -2 5 1 -4 2 3 1072 2016 SP
+3 1 -3 0 2 1053 1975 SP
+{1 0 0 C} FS
+-21 -10 -3 10 6 4 14 1 4 1090 2096 SP
+-3 -5 -8 5 5 2 3 1085 2093 SP
+5 2 1 1072 2056 SP
+5 4 1 995 2051 SP
+{0 0 0.502 C} FS
+5 -2 1 1053 1988 SP
+{1 0 0 C} FS
+5 -2 6 -3 -7 -6 -6 -7 -7 -7 -6 -7 -3 8 -10 3 21 13 -9 -3 11 9 0 4 12 937 1981 SP
+966 1971 M
+2 1 D
+-1 -1 D
+66 -17 D
+10 -2 D
+10 23 D
+-3 0 D
+3 1 D
+19 40 D
+-4 2 D
+5 1 D
+14 27 D
+-5 1 D
+1 -7 D
+-3 4 D
+-18 -3 D
+4 4 D
+-12 2 D
+-4 -2 D
+6 -1 D
+-40 -1 D
+-6 -7 D
+-2 5 D
+-5 -16 D
+-35 8 D
+-12 -15 D
+5 -16 D
+-19 -22 D
+12 -5 D
+P
+FO
+4 6 14 -4 6 -10 -21 -4 2 4 -5 -2 -3 4 7 1110 2090 SP
+-21 -10 -3 10 6 4 14 1 4 1090 2096 SP
+-3 -5 -8 5 5 2 3 1085 2093 SP
+5 2 1 1072 2056 SP
+5 4 1 995 2051 SP
+{0 0 0.502 C} FS
+5 -2 1 1053 1988 SP
+-15 -4 -4 7 3 -7 -22 -10 38 13 5 1053 1976 SP
+1 1 -3 2 1 6 -2 -9 -6 4 -6 -3 -17 -3 6 -5 2 5 16 0 3 -9 1 9 4 0 13 1073 2019 SP
+1103 2078 M
+42 73 D
+36 53 D
+0 -218 D
+-9 4 D
+3 5 D
+-19 3 D
+-13 -7 D
+-2 12 D
+-4 -5 D
+-3 6 D
+-9 0 D
+-3 -5 D
+7 0 D
+-29 -5 D
+-7 -6 D
+13 12 D
+41 20 D
+-4 10 D
+5 -5 D
+3 4 D
+-12 14 D
+-22 -1 D
+6 5 D
+-14 4 D
+11 3 D
+-8 6 D
+-15 -7 D
+-5 -8 D
+-5 1 D
+P
+FO
+{1 0 0 C} FS
+4 8 -8 -4 -2 10 24 3 4 1098 2066 SP
+4 4 4 -4 2 1137 2008 SP
+1181 1986 M
+-9 4 D
+3 5 D
+-19 3 D
+-13 -7 D
+-2 12 D
+-4 -5 D
+-3 6 D
+-9 0 D
+-3 -5 D
+7 0 D
+-29 -5 D
+-7 -6 D
+13 12 D
+41 20 D
+-4 10 D
+5 -5 D
+3 4 D
+-12 14 D
+-22 -1 D
+6 5 D
+-14 4 D
+11 3 D
+-8 6 D
+-15 -7 D
+-5 -8 D
+-5 1 D
+-14 -27 D
+4 0 D
+1 9 D
+3 -9 D
+16 0 D
+2 5 D
+6 -5 D
+-17 -3 D
+-6 -3 D
+-6 4 D
+-2 -9 D
+1 6 D
+-3 2 D
+-19 -40 D
+38 13 D
+-22 -10 D
+3 -7 D
+-4 7 D
+-15 -4 D
+-10 -23 D
+68 -9 D
+70 -3 D
+P
+FO
+-3 -6 0 1 7 11 3 1103 2078 SP
+4 8 -8 -4 -2 10 24 3 4 1098 2066 SP
+4 4 4 -4 2 1137 2008 SP
+{0 0 0.502 C} FS
+-2 -7 -12 -7 4 -9 -3 9 11 6 3 8 6 1218 1941 SP
+1280 2036 M
+-8 5 D
+-5 -10 D
+9 -9 D
+11 2 D
+9 -20 D
+-1 -1 D
+2 0 D
+6 -15 D
+-4 -3 D
+5 1 D
+1 -1 D
+-3 -4 D
+8 -7 D
+-13 0 D
+1 -7 D
+-14 6 D
+-13 -5 D
+-9 7 D
+-6 -20 D
+-22 20 D
+7 2 D
+-8 4 D
+6 3 D
+-6 8 D
+-15 0 D
+-11 7 D
+-9 -14 D
+-17 1 D
+0 218 D
+38 -56 D
+24 -42 D
+7 -11 D
+P
+FO
+{1 0 0 C} FS
+-3 6 1 1263 2028 SP
+6 1 1 1291 1972 SP
+{0 0 0.502 C} FS
+-19 13 6 15 -7 -16 3 1205 1973 SP
+{1 0 0 C} FS
+1218 1941 M
+3 8 D
+11 6 D
+-3 9 D
+4 -9 D
+-12 -7 D
+-2 -7 D
+79 8 D
+21 3 D
+-9 22 D
+-13 0 D
+1 -7 D
+-14 6 D
+-13 -5 D
+-9 7 D
+-6 -20 D
+-22 20 D
+7 2 D
+-8 4 D
+6 3 D
+-6 8 D
+-15 0 D
+-11 7 D
+-9 -14 D
+-17 1 D
+0 -46 D
+P
+FO
+-2 5 7 -6 -3 -4 3 1305 1985 SP
+5 1 -4 -3 2 1303 1988 SP
+2 0 -1 -1 2 1296 2004 SP
+-4 6 11 2 9 -9 -5 -10 -8 5 5 1280 2036 SP
+-3 6 1 1263 2028 SP
+6 1 1 1291 1972 SP
+{0 0 0.502 C} FS
+-19 13 6 15 -7 -16 3 1205 1973 SP
+-6 -18 7 17 -3 5 3 1367 1963 SP
+1 -1 1 1309 1975 SP
+0 -2 1 1 2 1304 1986 SP
+1297 2003 M
+17 0 D
+1 5 D
+-11 4 D
+-8 -8 D
+-9 20 D
+17 4 D
+-12 10 D
+10 -9 D
+6 9 D
+-24 5 D
+0 -9 D
+-4 2 D
+-33 65 D
+-16 26 D
+-25 41 D
+-25 36 D
+66 -43 D
+54 -41 D
+65 -57 D
+52 -51 D
+22 -24 D
+-16 9 D
+-18 -3 D
+-16 -10 D
+-30 6 D
+5 5 D
+-14 3 D
+-6 -2 D
+-4 -13 D
+-5 10 D
+6 -5 D
+2 8 D
+-15 -5 D
+14 5 D
+-38 0 D
+5 -4 D
+-7 -4 D
+P
+FO
+{1 0 0 C} FS
+-25 0 5 8 11 -1 3 1321 2033 SP
+-6 3 1 1298 2012 SP
+1367 1963 M
+-3 5 D
+7 17 D
+-6 -18 D
+2 -4 D
+48 14 D
+26 11 D
+-1 0 D
+-16 9 D
+-18 -3 D
+-16 -10 D
+-30 6 D
+5 5 D
+-14 3 D
+-6 -2 D
+-4 -13 D
+-5 10 D
+6 -5 D
+2 8 D
+-15 -5 D
+14 5 D
+-38 0 D
+5 -4 D
+-7 -4 D
+1 -2 D
+1 1 D
+14 -35 D
+P
+FO
+3 -6 -4 2 0 -9 -24 5 6 9 10 -9 -12 10 17 4 8 1287 2024 SP
+-8 -8 -11 4 1 5 17 0 4 1297 2003 SP
+-25 0 5 8 11 -1 3 1321 2033 SP
+-6 3 1 1298 2012 SP
+{0 0 0.502 C} FS
+1497 2016 M
+-6 -1 D
+2 -1 D
+-14 -8 D
+-15 -8 D
+-15 -7 D
+-8 -3 D
+-1 0 D
+-45 47 D
+-41 39 D
+-59 51 D
+-54 40 D
+-60 39 D
+48 -15 D
+78 -29 D
+71 -32 D
+54 -27 D
+22 -13 D
+53 -32 D
+7 -9 D
+1 4 D
+16 -10 D
+-22 -17 D
+P
+FO
+{1 0 0 C} FS
+-1 0 1 1441 1988 SP
+2 1 2 -1 -6 -1 3 1497 2016 SP
+-4 3 1 4 7 -9 3 1507 2056 SP
+{0 0 0.502 C} FS
+1515 2051 M
+3 11 D
+-13 -3 D
+2 -3 D
+-53 32 D
+-38 21 D
+-70 34 D
+-70 29 D
+-71 25 D
+-24 7 D
+99 -12 D
+89 -18 D
+62 -16 D
+62 -19 D
+60 -21 D
+17 -7 D
+-3 0 D
+4 -8 D
+5 -4 D
+-12 -22 D
+-22 -26 D
+-11 -10 D
+P
+FO
+{1 0 0 C} FS
+-3 3 1 1574 2099 SP
+-5 2 1 3 1 2 1 3 5 -4 4 -8 -3 0 7 1570 2111 SP
+4 -2 2 -3 -13 -3 3 11 4 1515 2051 SP
+-3 3 1 1574 2099 SP
+{0 0 0.502 C} FS
+1582 2168 M
+-2 -1 D
+-2 -27 D
+-4 -3 D
+-6 3 D
+1 -7 D
+-7 -1 D
+6 -6 D
+-7 5 D
+-5 -2 D
+9 -8 D
+-1 -7 D
+9 -4 D
+-107 38 D
+-88 24 D
+-71 15 D
+-72 11 D
+-54 6 D
+65 4 D
+82 1 D
+82 -5 D
+90 -11 D
+62 -12 D
+17 -4 D
+P
+FO
+2 4 -4 -1 2 1575 2133 SP
+{1 0 0 C} FS
+1582 2168 M
+-2 -1 D
+-2 -27 D
+-4 -3 D
+-6 3 D
+1 -7 D
+-7 -1 D
+6 -6 D
+-7 5 D
+-5 -2 D
+9 -8 D
+-1 -7 D
+9 -4 D
+-3 1 D
+9 -4 D
+6 28 D
+-1 22 D
+P
+FO
+{0 0 0.502 C} FS
+2 4 -4 -1 2 1575 2133 SP
+1546 2229 M
+-4 1 D
+9 -6 D
+2 -2 D
+-8 -3 D
+7 1 D
+4 -2 D
+5 -7 D
+-6 2 D
+7 -4 D
+13 -21 D
+4 -11 D
+-61 13 D
+-63 9 D
+-81 8 D
+-82 2 D
+-10 0 D
+-9 0 D
+-9 0 D
+-9 -1 D
+-9 0 D
+-10 0 D
+-9 -1 D
+-9 0 D
+-9 -1 D
+-9 -1 D
+-10 0 D
+-9 -1 D
+93 23 D
+84 13 D
+53 4 D
+25 -5 D
+-9 4 D
+2 2 D
+30 1 D
+-2 -4 D
+12 -8 D
+8 2 D
+38 -8 D
+-3 3 D
+11 4 D
+-15 8 D
+-13 2 D
+36 -2 D
+P
+FO
+{1 0 0 C} FS
+-1 1 7 -4 -6 2 3 1561 2211 SP
+-2 2 4 -2 7 1 -8 -3 4 1553 2222 SP
+4 -2 -4 1 2 1546 2229 SP
+-9 0 -9 1 -8 0 -3 1 -10 1 -15 8 11 4 -3 3 38 -8 8 2 12 -8 -2 -4 12 1459 2246 SP
+-6 0 -6 0 2 2 -9 4 25 -5 5 1411 2244 SP
+{0 0 0.502 C} FS
+1446 2295 M
+-2 0 D
+6 -10 D
+-21 -4 D
+-1 -4 D
+8 -3 D
+21 3 D
+-11 -6 D
+3 -2 D
+4 2 D
+2 -2 D
+5 0 D
+5 -3 D
+-11 2 D
+2 -4 D
+13 -4 D
+-13 -1 D
+28 -10 D
+14 -2 D
+-3 4 D
+6 -1 D
+-13 8 D
+20 -9 D
+4 2 D
+-16 11 D
+-4 6 D
+36 -22 D
+3 -3 D
+-36 2 D
+-39 12 D
+-4 -6 D
+9 -3 D
+-2 -2 D
+-10 0 D
+-10 -1 D
+-10 0 D
+1 1 D
+-21 3 D
+7 2 D
+-22 2 D
+3 -4 D
+7 -4 D
+7 -1 D
+-7 0 D
+-8 -1 D
+-7 0 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-8 -2 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+52 29 D
+41 19 D
+57 21 D
+-2 -1 D
+8 -9 D
+6 3 D
+-4 2 D
+10 0 D
+-7 2 D
+-4 6 D
+21 5 D
+3 -1 D
+4 3 D
+0 -5 D
+5 4 D
+10 -3 D
+-12 5 D
+7 0 D
+2 2 D
+15 4 D
+3 -2 D
+4 2 D
+4 -3 D
+-4 4 D
+7 1 D
+5 -5 D
+7 0 D
+1 7 D
+21 3 D
+P
+FO
+{1 0 0 C} FS
+1433 2256 M
+-12 2 D
+6 1 D
+-13 6 D
+21 -7 D
+-3 5 D
+-22 7 D
+-10 5 D
+-13 -1 D
+1 -2 D
+7 0 D
+2 -2 D
+-12 -5 D
+11 -1 D
+8 5 D
+7 -5 D
+-5 -9 D
+7 -2 D
+-2 3 D
+11 -4 D
+-6 4 D
+12 -5 D
+-8 5 D
+15 -5 D
+P
+FO
+-10 0 -4 5 6 1 9 -6 4 1370 2261 SP
+5 -1 7 -4 -11 0 3 1426 2281 SP
+-1 -3 -13 5 2 1373 2255 SP
+14 -3 -8 0 2 1428 2250 SP
+5 4 -2 -2 2 1363 2270 SP
+1 1 1 1435 2295 SP
+-5 -2 1 1393 2279 SP
+-8 2 1 1379 2276 SP
+4 2 1 1370 2274 SP
+-5 -1 1 1384 2254 SP
+4 -2 1 1345 2275 SP
+4 -1 1 1398 2256 SP
+8 -2 1 1373 2280 SP
+3 -1 1 1377 2278 SP
+{0 0 0.502 C} FS
+-4 0 3 0 2 1458 2281 SP
+-3 2 1 1479 2278 SP
+3 -3 1 1482 2277 SP
+{1 0 0 C} FS
+1446 2295 M
+-2 0 D
+6 -10 D
+-21 -4 D
+-1 -4 D
+8 -3 D
+21 3 D
+-11 -6 D
+3 -2 D
+4 2 D
+2 -2 D
+5 0 D
+5 -3 D
+-11 2 D
+2 -4 D
+13 -4 D
+-13 -1 D
+28 -10 D
+14 -2 D
+-3 4 D
+6 -1 D
+-13 8 D
+20 -9 D
+4 2 D
+-16 11 D
+-4 6 D
+29 -17 D
+-27 19 D
+-39 21 D
+P
+FO
+-6 -1 -5 0 1 7 7 0 5 -5 4 0 6 1403 2292 SP
+-4 -1 -4 4 4 -3 4 2 3 -2 5 1393 2290 SP
+-4 -1 2 2 6 0 3 1370 2284 SP
+-2 0 -12 5 10 -3 5 4 0 -5 5 1366 2283 SP
+-4 -1 4 3 3 -1 3 1359 2281 SP
+-3 -2 -4 6 -7 2 10 0 -4 2 6 3 8 -9 -2 -1 8 1331 2273 SP
+6 0 6 1 7 -1 7 -4 3 -4 -22 2 7 2 -21 3 1 1 9 1429 2245 SP
+9 -1 9 0 10 0 -2 -2 9 -3 -4 -6 -39 12 7 1495 2245 SP
+1433 2256 M
+-12 2 D
+6 1 D
+-13 6 D
+21 -7 D
+-3 5 D
+-22 7 D
+-10 5 D
+-13 -1 D
+1 -2 D
+7 0 D
+2 -2 D
+-12 -5 D
+11 -1 D
+8 5 D
+7 -5 D
+-5 -9 D
+7 -2 D
+-2 3 D
+11 -4 D
+-6 4 D
+12 -5 D
+-8 5 D
+15 -5 D
+P
+FO
+-10 0 -4 5 6 1 9 -6 4 1370 2261 SP
+5 -1 7 -4 -11 0 3 1426 2281 SP
+-1 -3 -13 5 2 1373 2255 SP
+14 -3 -8 0 2 1428 2250 SP
+5 4 -2 -2 2 1363 2270 SP
+1 1 1 1435 2295 SP
+-5 -2 1 1393 2279 SP
+-8 2 1 1379 2276 SP
+4 2 1 1370 2274 SP
+-5 -1 1 1384 2254 SP
+4 -2 1 1345 2275 SP
+4 -1 1 1398 2256 SP
+8 -2 1 1373 2280 SP
+3 -1 1 1377 2278 SP
+{0 0 0.502 C} FS
+-4 0 3 0 2 1458 2281 SP
+-3 2 1 1479 2278 SP
+3 -3 1 1482 2277 SP
+4 -1 -10 3 1 -1 3 1329 2330 SP
+-5 3 4 -2 2 1333 2329 SP
+1361 2323 M
+5 -2 D
+-5 2 D
+38 -11 D
+-9 2 D
+-2 -10 D
+24 -1 D
+-3 2 D
+10 0 D
+22 -8 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+0 3 D
+-6 2 D
+-6 -2 D
+3 1 D
+-7 2 D
+-15 -1 D
+7 -5 D
+-16 1 D
+13 -5 D
+-5 -2 D
+-5 -1 D
+-5 -1 D
+-9 4 D
+-8 -1 D
+-11 -6 D
+6 0 D
+3 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-1 1 D
+-6 -4 D
+-11 -4 D
+-12 -4 D
+-11 -4 D
+-12 -5 D
+-5 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-11 -6 D
+-6 -3 D
+-6 -2 D
+-11 -6 D
+-12 -6 D
+-12 -7 D
+-11 -6 D
+-12 -7 D
+28 36 D
+22 25 D
+7 0 D
+0 6 D
+9 -6 D
+7 1 D
+-4 4 D
+7 -4 D
+15 0 D
+-6 2 D
+5 1 D
+-10 1 D
+12 2 D
+-17 1 D
+17 -1 D
+-3 4 D
+-20 0 D
+16 1 D
+-15 1 D
+6 1 D
+-7 1 D
+-5 -1 D
+2 2 D
+12 0 D
+-3 6 D
+6 -6 D
+8 -3 D
+0 10 D
+5 -1 D
+-12 3 D
+8 0 D
+-1 2 D
+7 -4 D
+8 -1 D
+8 3 D
+-8 0 D
+1 2 D
+-8 -2 D
+10 6 D
+-14 -1 D
+15 2 D
+10 -6 D
+0 5 D
+18 -1 D
+-3 2 D
+-4 -1 D
+0 3 D
+-3 -2 D
+-1 3 D
+-3 -2 D
+-2 3 D
+-8 0 D
+-3 2 D
+-1 -2 D
+-3 3 D
+-1 -3 D
+-2 5 D
+-6 0 D
+5 4 D
+6 -3 D
+27 -3 D
+7 -4 D
+3 1 D
+-1 -4 D
+7 0 D
+-7 0 D
+4 -3 D
+-10 3 D
+8 -4 D
+-5 0 D
+14 -2 D
+-6 -2 D
+11 -5 D
+4 5 D
+-11 3 D
+11 6 D
+0 1 D
+-5 4 D
+-11 1 D
+0 3 D
+-21 4 D
+-3 -1 D
+-6 3 D
+-11 1 D
+5 3 D
+2 2 D
+4 -1 D
+3 5 D
+11 2 D
+-10 -3 D
+1 -5 D
+21 -3 D
+-4 3 D
+10 -2 D
+-7 3 D
+9 -3 D
+-2 5 D
+4 -2 D
+7 0 D
+-6 3 D
+8 2 D
+-1 -1 D
+28 -7 D
+1 3 D
+-3 2 D
+-12 2 D
+1 2 D
+-2 1 D
+P
+FO
+-1 -1 4 1 -1 0 3 1400 2291 SP
+3 -1 -2 1 2 1369 2284 SP
+0 1 1 1366 2283 SP
+1 1 -6 3 -3 -3 7 -2 4 1271 2302 SP
+-3 0 1 -1 2 1286 2313 SP
+5 -1 1 1316 2330 SP
+{1 0 0 C} FS
+1308 2278 M
+-4 5 D
+6 -1 D
+-1 3 D
+-9 3 D
+-2 -3 D
+0 3 D
+-10 -3 D
+1 2 D
+-15 -1 D
+-1 -3 D
+7 -1 D
+-8 -5 D
+6 1 D
+1 -12 D
+12 2 D
+-2 3 D
+10 -2 D
+-2 4 D
+5 -3 D
+3 1 D
+-6 3 D
+9 2 D
+-16 5 D
+P
+FO
+-15 5 21 5 20 -2 8 -2 -17 -2 -5 -3 1 -4 7 1341 2322 SP
+23 -8 -21 -1 -11 3 0 -2 -13 2 5 1391 2303 SP
+8 3 6 -6 -10 0 3 1327 2281 SP
+-8 4 10 -3 2 1321 2285 SP
+-6 -5 -10 6 2 1363 2292 SP
+0 2 5 -1 2 1308 2290 SP
+-8 3 9 -3 2 1380 2293 SP
+-4 -2 1 1314 2269 SP
+-3 -1 1 1319 2295 SP
+-3 -1 1 1346 2292 SP
+5 -1 1 1355 2291 SP
+{0 0 0.502 C} FS
+-2 2 1 1402 2294 SP
+-4 1 1 1324 2330 SP
+8 -1 1 1345 2323 SP
+{1 0 0 C} FS
+-6 2 -7 3 10 0 -3 2 24 -1 -2 -10 -5 2 -4 0 8 1399 2312 SP
+5 -2 1 1361 2323 SP
+1333 2329 M
+4 -2 D
+-7 3 D
+-1 0 D
+1 -1 D
+-11 3 D
+-3 -2 D
+5 -1 D
+-5 1 D
+-9 -4 D
+-4 -2 D
+9 1 D
+-10 -3 D
+1 -5 D
+21 -3 D
+-4 3 D
+10 -2 D
+-7 3 D
+9 -3 D
+-2 5 D
+4 -2 D
+7 0 D
+-6 3 D
+8 2 D
+-1 -1 D
+28 -7 D
+1 3 D
+-3 2 D
+-12 2 D
+1 2 D
+P
+FO
+-3 -2 0 1 2 3 4 -1 4 1294 2319 SP
+1286 2313 M
+1 -1 D
+-3 0 D
+-2 -2 D
+6 -3 D
+27 -3 D
+7 -4 D
+3 1 D
+-1 -4 D
+7 0 D
+-7 0 D
+4 -3 D
+-10 3 D
+8 -4 D
+-5 0 D
+14 -2 D
+-6 -2 D
+11 -5 D
+4 5 D
+-11 3 D
+11 6 D
+0 1 D
+-5 4 D
+-11 1 D
+0 3 D
+-21 4 D
+-3 -1 D
+-6 3 D
+-11 1 D
+P
+FO
+1271 2302 M
+7 -2 D
+-3 -3 D
+-6 3 D
+-22 -19 D
+12 0 D
+-3 6 D
+6 -6 D
+8 -3 D
+0 10 D
+5 -1 D
+-12 3 D
+8 0 D
+-1 2 D
+7 -4 D
+8 -1 D
+8 3 D
+-8 0 D
+1 2 D
+-8 -2 D
+10 6 D
+-14 -1 D
+15 2 D
+10 -6 D
+0 5 D
+18 -1 D
+-3 2 D
+-4 -1 D
+0 3 D
+-3 -2 D
+-1 3 D
+-3 -2 D
+-2 3 D
+-8 0 D
+-3 2 D
+-1 -2 D
+-3 3 D
+-1 -3 D
+-2 5 D
+-6 0 D
+P
+FO
+1231 2265 M
+7 0 D
+0 6 D
+9 -6 D
+7 1 D
+-4 4 D
+7 -4 D
+15 0 D
+-6 2 D
+5 1 D
+-10 1 D
+12 2 D
+-17 1 D
+17 -1 D
+-3 4 D
+-20 0 D
+16 1 D
+-15 1 D
+6 1 D
+-7 1 D
+-5 -1 D
+P
+FO
+4 1 -6 -4 -1 1 3 1338 2276 SP
+1366 2283 M
+0 1 D
+0 -1 D
+3 1 D
+-2 1 D
+3 -1 D
+8 2 D
+-9 4 D
+-8 -1 D
+-11 -6 D
+6 0 D
+3 -2 D
+P
+FO
+1400 2291 M
+-1 0 D
+21 3 D
+0 3 D
+-6 2 D
+-6 -2 D
+3 1 D
+-7 2 D
+-15 -1 D
+7 -5 D
+-16 1 D
+16 -5 D
+P
+FO
+1308 2278 M
+-4 5 D
+6 -1 D
+-1 3 D
+-9 3 D
+-2 -3 D
+0 3 D
+-10 -3 D
+1 2 D
+-15 -1 D
+-1 -3 D
+7 -1 D
+-8 -5 D
+6 1 D
+1 -12 D
+12 2 D
+-2 3 D
+10 -2 D
+-2 4 D
+5 -3 D
+3 1 D
+-6 3 D
+9 2 D
+-16 5 D
+P
+FO
+-15 5 21 5 20 -2 8 -2 -17 -2 -5 -3 1 -4 7 1341 2322 SP
+23 -8 -21 -1 -11 3 0 -2 -13 2 5 1391 2303 SP
+8 3 6 -6 -10 0 3 1327 2281 SP
+-8 4 10 -3 2 1321 2285 SP
+-6 -5 -10 6 2 1363 2292 SP
+0 2 5 -1 2 1308 2290 SP
+-8 3 9 -3 2 1380 2293 SP
+-4 -2 1 1314 2269 SP
+-3 -1 1 1319 2295 SP
+-3 -1 1 1346 2292 SP
+5 -1 1 1355 2291 SP
+{0 0 0.502 C} FS
+-2 2 1 1402 2294 SP
+-4 1 1 1324 2330 SP
+8 -1 1 1345 2323 SP
+1233 2343 M
+5 -2 D
+7 1 D
+-4 -1 D
+11 0 D
+-14 -1 D
+16 -1 D
+-7 -1 D
+15 2 D
+-5 -1 D
+6 -1 D
+-11 -1 D
+14 0 D
+-12 -1 D
+8 -3 D
+11 2 D
+-5 -3 D
+12 1 D
+-5 -1 D
+4 -1 D
+-9 0 D
+15 -1 D
+-11 -2 D
+13 -3 D
+7 0 D
+-7 3 D
+11 -2 D
+-4 3 D
+7 -5 D
+2 0 D
+-3 -2 D
+-23 4 D
+4 -4 D
+13 -3 D
+-4 -4 D
+-3 -1 D
+-4 0 D
+3 -1 D
+-2 -1 D
+-4 -1 D
+2 -1 D
+-5 -4 D
+-9 1 D
+-5 -3 D
+8 -2 D
+-2 -2 D
+-5 2 D
+-6 -4 D
+-10 2 D
+3 -2 D
+-8 0 D
+5 -2 D
+-8 1 D
+14 -6 D
+-17 3 D
+12 -4 D
+-19 2 D
+2 -3 D
+-9 2 D
+-5 -2 D
+6 -2 D
+-8 1 D
+1 -3 D
+-3 2 D
+-19 -7 D
+18 2 D
+-12 -3 D
+8 -2 D
+-10 2 D
+-11 -3 D
+-4 -3 D
+6 -3 D
+14 0 D
+-7 -2 D
+26 -4 D
+8 1 D
+-39 -46 D
+-11 -15 D
+0 73 D
+5 1 D
+1 6 D
+5 -2 D
+-1 4 D
+3 -3 D
+13 5 D
+-1 2 D
+-11 0 D
+9 6 D
+12 0 D
+20 4 D
+-13 6 D
+-15 0 D
+1 2 D
+13 -1 D
+-12 2 D
+23 -1 D
+-14 3 D
+8 1 D
+-13 4 D
+2 -2 D
+-8 2 D
+-10 -2 D
+-12 1 D
+-5 2 D
+0 27 D
+P
+FO
+3 0 -2 3 -6 0 2 -2 4 1312 2333 SP
+-3 1 1 1316 2330 SP
+13 0 -8 1 10 3 -13 -2 4 1245 2279 SP
+{1 0 0 C} FS
+-5 0 1 1262 2337 SP
+5 -1 1 1226 2306 SP
+-2 -1 1 1275 2309 SP
+{0 0 0.502 C} FS
+12 1 1 1207 2276 SP
+8 0 1 1247 2340 SP
+{1 0 0 C} FS
+1312 2333 M
+2 -2 D
+-6 0 D
+-2 3 D
+-50 7 D
+-11 1 D
+-4 -1 D
+11 0 D
+-14 -1 D
+16 -1 D
+-7 -1 D
+15 2 D
+-5 -1 D
+6 -1 D
+-11 -1 D
+14 0 D
+-12 -1 D
+8 -3 D
+11 2 D
+-5 -3 D
+12 1 D
+-5 -1 D
+4 -1 D
+-9 0 D
+15 -1 D
+-11 -2 D
+13 -3 D
+7 0 D
+-7 3 D
+11 -2 D
+-4 3 D
+7 -5 D
+15 6 D
+-3 1 D
+3 -1 D
+3 2 D
+P
+FO
+-5 0 6 1 5 -2 3 1233 2343 SP
+1181 2277 M
+5 1 D
+1 6 D
+5 -2 D
+-1 4 D
+3 -3 D
+13 5 D
+-1 2 D
+-11 0 D
+9 6 D
+12 0 D
+20 4 D
+-13 6 D
+-15 0 D
+1 2 D
+13 -1 D
+-12 2 D
+23 -1 D
+-14 3 D
+8 1 D
+-13 4 D
+2 -2 D
+-8 2 D
+-10 -2 D
+-12 1 D
+-5 2 D
+P
+FO
+1245 2279 M
+-13 -2 D
+10 3 D
+-8 1 D
+13 0 D
+13 12 D
+9 7 D
+-5 2 D
+-6 -4 D
+-10 2 D
+3 -2 D
+-8 0 D
+5 -2 D
+-8 1 D
+14 -6 D
+-17 3 D
+12 -4 D
+-19 2 D
+2 -3 D
+-9 2 D
+-5 -2 D
+6 -2 D
+-8 1 D
+1 -3 D
+-3 2 D
+-19 -7 D
+18 2 D
+-12 -3 D
+8 -2 D
+-10 2 D
+-11 -3 D
+-4 -3 D
+6 -3 D
+14 0 D
+-7 -2 D
+26 -4 D
+8 1 D
+P
+FO
+3 2 8 -2 -5 -3 -9 1 4 1277 2306 SP
+1 1 2 -1 -4 -1 3 1284 2312 SP
+3 -1 -4 0 2 1287 2314 SP
+3 1 13 -3 4 -4 -20 3 -3 1 5 1300 2322 SP
+-5 0 1 1262 2337 SP
+5 -1 1 1226 2306 SP
+-2 -1 1 1275 2309 SP
+{0 0 0.502 C} FS
+12 1 1 1207 2276 SP
+8 0 1 1247 2340 SP
+1131 2343 M
+4 -1 D
+37 2 D
+9 0 D
+0 -27 D
+-21 7 D
+6 2 D
+-7 -1 D
+-4 6 D
+-9 2 D
+8 1 D
+-6 0 D
+3 2 D
+-5 -2 D
+8 3 D
+-13 1 D
+0 -4 D
+-3 2 D
+-10 0 D
+7 1 D
+-10 -1 D
+7 2 D
+-7 -1 D
+4 1 D
+-8 0 D
+6 1 D
+-11 1 D
+28 1 D
+-17 1 D
+-14 -1 D
+P
+FO
+1 0 8 -4 -9 5 3 1181 2276 SP
+1130 2266 M
+14 -3 D
+2 4 D
+-13 0 D
+-3 2 D
+17 -1 D
+-12 3 D
+7 1 D
+-4 3 D
+21 -4 D
+-7 7 D
+11 -2 D
+2 3 D
+3 -6 D
+13 3 D
+0 -72 D
+-39 49 D
+P
+FO
+{1 0 0 C} FS
+2 -3 -10 3 2 1151 2270 SP
+-3 0 1 1135 2338 SP
+-2 -1 1 1141 2339 SP
+4 1 1 1150 2334 SP
+4 -1 1 1135 2265 SP
+6 -3 1 1158 2276 SP
+{0 0 0.502 C} FS
+-3 1 1 1148 2275 SP
+{1 0 0 C} FS
+-4 0 -5 0 10 1 4 -1 4 1131 2343 SP
+1130 2266 M
+14 -3 D
+2 4 D
+-13 0 D
+-3 2 D
+17 -1 D
+-12 3 D
+7 1 D
+-4 3 D
+21 -4 D
+-7 7 D
+11 -2 D
+2 3 D
+3 -6 D
+13 3 D
+-9 5 D
+9 -4 D
+0 40 D
+-21 7 D
+6 2 D
+-7 -1 D
+-4 6 D
+-9 2 D
+8 1 D
+-6 0 D
+3 2 D
+-5 -2 D
+8 3 D
+-13 1 D
+0 -4 D
+-3 2 D
+-10 0 D
+7 1 D
+-10 -1 D
+7 2 D
+-7 -1 D
+4 1 D
+-8 0 D
+6 1 D
+-11 1 D
+28 1 D
+-17 1 D
+-14 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-10 -2 D
+-10 -1 D
+-10 -2 D
+29 -16 D
+29 -22 D
+6 -5 D
+5 -6 D
+P
+FO
+2 -3 -10 3 2 1151 2270 SP
+-3 0 1 1135 2338 SP
+-2 -1 1 1141 2339 SP
+4 1 1 1150 2334 SP
+4 -1 1 1135 2265 SP
+6 -3 1 1158 2276 SP
+{0 0 0.502 C} FS
+-3 1 1 1148 2275 SP
+935 2302 M
+-1 0 D
+22 5 D
+8 6 D
+8 1 D
+-9 -4 D
+16 5 D
+0 -4 D
+-9 -2 D
+-4 -3 D
+20 5 D
+-5 -3 D
+9 1 D
+-27 -5 D
+-18 0 D
+0 -3 D
+-5 1 D
+-4 -2 D
+11 0 D
+2 -2 D
+4 2 D
+0 -2 D
+5 3 D
+0 -2 D
+17 3 D
+1 2 D
+2 -1 D
+5 2 D
+-8 -4 D
+7 1 D
+4 3 D
+8 0 D
+-10 -4 D
+14 4 D
+-6 -3 D
+8 1 D
+-9 -1 D
+-4 -3 D
+10 0 D
+-10 -1 D
+1 -1 D
+-11 -3 D
+9 3 D
+-13 -2 D
+-6 -4 D
+4 -1 D
+9 2 D
+-4 1 D
+8 0 D
+5 -2 D
+-13 -3 D
+-55 9 D
+P
+FO
+1069 2259 M
+4 1 D
+-4 9 D
+14 -10 D
+4 8 D
+2 -5 D
+19 7 D
+0 -3 D
+-17 -5 D
+-3 -6 D
+12 3 D
+3 -3 D
+19 10 D
+-1 -5 D
+-15 -6 D
+27 6 D
+-4 6 D
+7 -6 D
+39 -48 D
+6 -8 D
+-50 28 D
+-56 25 D
+P
+FO
+0 2 1 1062 2262 SP
+-2 -2 3 2 2 1057 2264 SP
+-2 1 -1 -1 5 -2 0 1 4 1047 2268 SP
+-5 2 -5 1 5 -6 5 -2 0 3 4 1 6 1022 2276 SP
+-2 0 -2 -2 5 1 3 1016 2278 SP
+-3 1 -10 -5 10 0 7 3 4 1000 2282 SP
+-2 0 -5 -3 9 2 3 995 2284 SP
+-4 1 -15 -3 13 2 -8 -3 9 3 3 -2 6 2 7 979 2287 SP
+{1 0 0 C} FS
+7 2 13 0 -13 -2 3 972 2300 SP
+7 1 -9 -3 2 984 2292 SP
+3 2 12 2 2 974 2297 SP
+8 0 -13 -5 2 971 2312 SP
+7 0 -13 -3 2 977 2299 SP
+6 0 1 981 2287 SP
+{0 0 0.502 C} FS
+7 2 1 1012 2280 SP
+7 0 -6 0 2 1021 2280 SP
+{1 0 0 C} FS
+966 2313 M
+6 1 D
+-9 -4 D
+16 5 D
+0 -4 D
+-9 -2 D
+-4 -3 D
+20 5 D
+-5 -3 D
+9 1 D
+-27 -5 D
+-18 0 D
+0 -3 D
+-5 1 D
+-4 -2 D
+11 0 D
+2 -2 D
+4 2 D
+0 -2 D
+5 3 D
+0 -2 D
+17 3 D
+1 2 D
+2 -1 D
+5 2 D
+-8 -4 D
+7 1 D
+4 3 D
+8 0 D
+-10 -4 D
+14 4 D
+-6 -3 D
+8 1 D
+-9 -1 D
+-4 -3 D
+10 0 D
+-10 -1 D
+1 -1 D
+-11 -3 D
+9 3 D
+-13 -2 D
+-6 -4 D
+4 -1 D
+9 2 D
+-4 1 D
+8 0 D
+5 -2 D
+-13 -3 D
+3 -1 D
+6 2 D
+3 -2 D
+9 3 D
+-8 -3 D
+13 2 D
+-15 -3 D
+8 -2 D
+9 2 D
+-5 -3 D
+1 -1 D
+7 3 D
+10 0 D
+-10 -5 D
+9 -2 D
+5 1 D
+-2 -2 D
+3 -1 D
+4 1 D
+0 3 D
+5 -2 D
+5 -6 D
+11 -4 D
+0 1 D
+5 -2 D
+-1 -1 D
+6 -2 D
+3 2 D
+-2 -2 D
+4 -2 D
+0 2 D
+0 -2 D
+7 -3 D
+4 1 D
+-4 9 D
+14 -10 D
+4 8 D
+2 -5 D
+19 7 D
+0 -3 D
+-17 -5 D
+-3 -6 D
+12 3 D
+3 -3 D
+19 10 D
+-1 -5 D
+-15 -6 D
+27 6 D
+-4 6 D
+1 0 D
+-18 17 D
+-5 6 D
+-24 19 D
+-23 15 D
+-17 9 D
+-10 -2 D
+-10 -2 D
+-10 -2 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-9 -3 D
+P
+FO
+-7 -2 -7 -3 -7 -2 6 5 22 5 -1 0 6 935 2302 SP
+7 2 13 0 -13 -2 3 972 2300 SP
+7 1 -9 -3 2 984 2292 SP
+3 2 12 2 2 974 2297 SP
+8 0 -13 -5 2 971 2312 SP
+7 0 -13 -3 2 977 2299 SP
+6 0 1 981 2287 SP
+{0 0 0.502 C} FS
+7 2 1 1012 2280 SP
+7 0 -6 0 2 1021 2280 SP
+976 2288 M
+-3 0 D
+1 -2 D
+9 1 D
+4 -1 D
+-2 -1 D
+6 -2 D
+4 1 D
+4 -1 D
+0 -1 D
+8 -2 D
+-5 -2 D
+7 -2 D
+7 2 D
+3 -1 D
+-2 -1 D
+9 -1 D
+10 -3 D
+7 -8 D
+4 4 D
+4 -2 D
+-5 -6 D
+12 4 D
+-10 -7 D
+9 -6 D
+11 3 D
+-4 4 D
+5 1 D
+56 -24 D
+45 -24 D
+11 -7 D
+-65 17 D
+-88 16 D
+-72 7 D
+-79 2 D
+-7 -1 D
+-8 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+33 25 D
+31 17 D
+26 12 D
+P
+FO
+0 -3 1 1062 2262 SP
+{1 0 0 C} FS
+9 1 -6 -3 2 980 2284 SP
+-1 2 1 881 2267 SP
+3 -1 1 1012 2274 SP
+12 -2 1 992 2281 SP
+-3 2 5 1 -4 4 11 3 9 -6 -10 -7 -2 1 -2 1 0 3 0 -3 10 1062 2262 SP
+-3 1 11 4 -5 -6 3 1051 2266 SP
+-6 2 4 4 7 -8 3 1036 2272 SP
+-2 1 5 0 -2 -1 3 1019 2277 SP
+-4 1 7 2 7 -2 -5 -2 4 1007 2280 SP
+1 0 0 -1 2 999 2283 SP
+-4 1 4 1 6 -2 -2 -1 4 987 2286 SP
+-2 1 5 1 1 -2 -3 0 4 976 2288 SP
+9 1 -6 -3 2 980 2284 SP
+-1 2 1 881 2267 SP
+3 -1 1 1012 2274 SP
+12 -2 1 992 2281 SP
+{0 0 0.502 C} FS
+534 2160 M
+-3 -5 D
+11 9 D
+-2 -3 D
+17 7 D
+7 7 D
+50 21 D
+78 25 D
+62 13 D
+70 9 D
+7 0 D
+-16 -15 D
+-21 -28 D
+-11 -23 D
+-2 0 D
+-3 -1 D
+-5 0 D
+7 1 D
+-2 2 D
+-9 -4 D
+7 7 D
+-15 -2 D
+-1 4 D
+-4 -6 D
+2 6 D
+-11 -4 D
+10 4 D
+-3 2 D
+-4 -3 D
+2 4 D
+-8 -5 D
+-2 4 D
+-6 -5 D
+2 7 D
+-4 -3 D
+-9 1 D
+0 -3 D
+-1 4 D
+-6 -3 D
+3 3 D
+-11 -1 D
+-1 -3 D
+-3 5 D
+-1 -4 D
+-2 2 D
+-6 -3 D
+-1 2 D
+6 3 D
+-12 1 D
+-4 -4 D
+6 -1 D
+-10 -2 D
+1 4 D
+6 3 D
+0 3 D
+-11 -3 D
+6 4 D
+-8 -4 D
+11 8 D
+-9 -6 D
+5 8 D
+-11 -7 D
+6 4 D
+-4 -1 D
+5 3 D
+-5 -2 D
+7 6 D
+-5 -2 D
+-7 -7 D
+7 7 D
+-4 -1 D
+-6 -4 D
+3 4 D
+-4 -4 D
+-2 1 D
+-4 -5 D
+3 0 D
+-7 -4 D
+5 0 D
+-5 -1 D
+-4 0 D
+7 4 D
+5 7 D
+-5 -4 D
+1 3 D
+-6 -3 D
+1 -1 D
+-3 1 D
+-5 -3 D
+3 0 D
+-7 -1 D
+3 -5 D
+-8 4 D
+-6 -3 D
+1 -3 D
+-5 1 D
+-5 -4 D
+6 5 D
+-8 -3 D
+-16 -11 D
+-2 -5 D
+11 0 D
+-4 -5 D
+13 4 D
+-28 -12 D
+0 -2 D
+-8 -3 D
+6 1 D
+-10 -3 D
+-23 -15 D
+-3 1 D
+-16 -9 D
+-5 -8 D
+12 4 D
+-5 -8 D
+20 6 D
+19 10 D
+-1 -3 D
+4 5 D
+-1 -6 D
+7 2 D
+-7 -4 D
+6 -1 D
+4 5 D
+4 -3 D
+17 12 D
+3 4 D
+40 13 D
+-5 -4 D
+11 -4 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-13 -7 D
+-13 -7 D
+-5 -2 D
+-2 -2 D
+-4 2 D
+6 0 D
+-2 4 D
+10 9 D
+-4 12 D
+-7 -2 D
+19 15 D
+0 9 D
+6 2 D
+3 5 D
+11 8 D
+14 5 D
+6 -2 D
+7 6 D
+15 4 D
+-2 7 D
+-36 -14 D
+0 -1 D
+-7 -5 D
+-1 1 D
+-18 -13 D
+11 9 D
+-8 -3 D
+8 6 D
+2 4 D
+-7 -5 D
+10 10 D
+-2 1 D
+-10 -7 D
+-1 2 D
+13 7 D
+-11 -3 D
+-7 -5 D
+4 5 D
+-7 -6 D
+9 12 D
+-11 -6 D
+4 5 D
+P
+FO
+3 1 1 770 2174 SP
+10 8 1 746 2168 SP
+{1 0 0 C} FS
+-23 -15 0 3 6 4 -7 -2 10 6 7 0 6 537 2124 SP
+9 5 -4 -5 -6 -3 3 553 2139 SP
+7 2 -3 2 7 -4 3 759 2188 SP
+-9 1 3 2 2 776 2182 SP
+-4 2 7 1 2 765 2189 SP
+18 5 -13 -4 2 555 2112 SP
+-4 1 14 3 2 551 2105 SP
+-3 1 1 761 2192 SP
+-4 -1 1 541 2130 SP
+0 1 1 511 2100 SP
+4 1 1 649 2193 SP
+-1 -2 1 695 2195 SP
+3 -1 1 724 2189 SP
+-4 -2 1 558 2139 SP
+-4 -3 1 611 2130 SP
+-3 -2 1 543 2133 SP
+-1 -2 1 542 2150 SP
+-1 2 1 692 2192 SP
+5 3 1 527 2107 SP
+-2 2 1 761 2188 SP
+5 -1 1 771 2189 SP
+5 3 1 542 2134 SP
+-2 1 5 3 2 519 2108 SP
+1 -4 -1 3 2 784 2179 SP
+{0 0 0.502 C} FS
+-2 2 6 3 -7 -4 0 3 -4 -5 6 1 6 576 2154 SP
+-3 -5 8 3 -3 -4 9 3 -1 5 -9 -2 6 601 2143 SP
+-9 -5 7 3 -5 -9 3 599 2135 SP
+-6 -2 1 622 2162 SP
+-6 -2 1 664 2163 SP
+7 5 1 752 2170 SP
+-3 -4 1 655 2183 SP
+4 3 1 716 2165 SP
+-4 -3 1 633 2178 SP
+6 4 1 704 2165 SP
+5 3 -5 -2 2 611 2151 SP
+6 2 -5 -2 2 620 2171 SP
+-1 -3 1 730 2177 SP
+1 2 1 679 2181 SP
+-5 -3 4 3 2 747 2176 SP
+-6 -2 1 613 2151 SP
+4 2 1 722 2173 SP
+3 2 1 736 2169 SP
+-5 -4 1 644 2162 SP
+-4 -2 1 618 2154 SP
+-2 -3 1 663 2185 SP
+6 2 -5 -2 2 650 2172 SP
+-5 -3 1 630 2174 SP
+5 2 -4 -2 2 615 2172 SP
+-4 -1 1 617 2176 SP
+-16 -4 1 591 2136 SP
+15 8 1 706 2164 SP
+-10 -4 1 671 2167 SP
+-3 -5 1 0 2 597 2136 SP
+19 14 1 727 2164 SP
+-21 -14 1 695 2176 SP
+-14 -8 1 643 2172 SP
+-5 -3 1 628 2151 SP
+4 -1 1 738 2178 SP
+-10 -4 1 611 2156 SP
+4 -2 -3 2 2 613 2135 SP
+8 7 1 721 2164 SP
+4 0 1 713 2180 SP
+-4 -1 1 564 2129 SP
+8 6 1 696 2164 SP
+-8 -2 1 661 2172 SP
+-6 -3 1 680 2174 SP
+-4 -3 1 578 2130 SP
+-10 -6 1 696 2168 SP
+-4 -2 1 557 2122 SP
+9 5 1 678 2168 SP
+-5 -1 1 654 2158 SP
+-5 -3 1 662 2161 SP
+-5 -2 1 684 2166 SP
+4 2 1 697 2177 SP
+10 5 -10 -4 2 639 2171 SP
+1 -2 1 691 2182 SP
+6 4 1 720 2168 SP
+-6 -4 1 612 2154 SP
+7 3 -1 0 2 694 2166 SP
+-5 -3 1 608 2154 SP
+4 2 1 706 2173 SP
+3 3 0 -1 2 717 2178 SP
+{1 0 0 C} FS
+506 2073 M
+-4 2 D
+6 0 D
+-2 4 D
+10 9 D
+-4 12 D
+-7 -2 D
+19 15 D
+0 9 D
+6 2 D
+3 5 D
+11 8 D
+14 5 D
+6 -2 D
+7 6 D
+15 4 D
+-2 7 D
+-36 -14 D
+0 -1 D
+-7 -5 D
+-1 1 D
+-18 -13 D
+11 9 D
+-8 -3 D
+8 6 D
+2 4 D
+-7 -5 D
+10 10 D
+-2 1 D
+-10 -7 D
+-1 2 D
+13 7 D
+-11 -3 D
+-7 -5 D
+4 5 D
+-7 -6 D
+9 12 D
+-11 -6 D
+0 1 D
+-30 -30 D
+-31 -43 D
+-11 -21 D
+-10 -22 D
+66 39 D
+P
+FO
+2 1 -5 -2 2 513 2077 SP
+746 2168 M
+10 8 D
+-10 -8 D
+32 8 D
+-5 0 D
+7 1 D
+-2 2 D
+-9 -4 D
+7 7 D
+-15 -2 D
+-1 4 D
+-4 -6 D
+2 6 D
+-11 -4 D
+10 4 D
+-3 2 D
+-4 -3 D
+2 4 D
+-8 -5 D
+-2 4 D
+-6 -5 D
+2 7 D
+-4 -3 D
+-9 1 D
+0 -3 D
+-1 4 D
+-6 -3 D
+3 3 D
+-11 -1 D
+-1 -3 D
+-3 5 D
+-1 -4 D
+-2 2 D
+-6 -3 D
+-1 2 D
+6 3 D
+-12 1 D
+-4 -4 D
+6 -1 D
+-10 -2 D
+1 4 D
+6 3 D
+0 3 D
+-11 -3 D
+6 4 D
+-8 -4 D
+11 8 D
+-9 -6 D
+5 8 D
+-11 -7 D
+6 4 D
+-4 -1 D
+5 3 D
+-5 -2 D
+7 6 D
+-5 -2 D
+-7 -7 D
+7 7 D
+-4 -1 D
+-6 -4 D
+3 4 D
+-4 -4 D
+-2 1 D
+-4 -5 D
+3 0 D
+-7 -4 D
+5 0 D
+-5 -1 D
+-4 0 D
+7 4 D
+5 7 D
+-5 -4 D
+1 3 D
+-6 -3 D
+1 -1 D
+-3 1 D
+-5 -3 D
+3 0 D
+-7 -1 D
+3 -5 D
+-8 4 D
+-6 -3 D
+1 -3 D
+-5 1 D
+-5 -4 D
+6 5 D
+-8 -3 D
+-16 -11 D
+-2 -5 D
+11 0 D
+-4 -5 D
+13 4 D
+-28 -12 D
+0 -2 D
+-8 -3 D
+6 1 D
+-10 -3 D
+-23 -15 D
+-3 1 D
+-16 -9 D
+-5 -8 D
+12 4 D
+-5 -8 D
+20 6 D
+19 10 D
+-1 -3 D
+4 5 D
+-1 -6 D
+7 2 D
+-7 -4 D
+6 -1 D
+4 5 D
+4 -3 D
+17 12 D
+3 4 D
+40 13 D
+-5 -4 D
+11 -4 D
+41 14 D
+P
+FO
+-7 -4 -7 -3 -8 -4 7 7 10 5 7 2 -2 -3 8 7 3 2 -3 -5 10 534 2160 SP
+-23 -15 0 3 6 4 -7 -2 10 6 7 0 6 537 2124 SP
+9 5 -4 -5 -6 -3 3 553 2139 SP
+7 2 -3 2 7 -4 3 759 2188 SP
+-9 1 3 2 2 776 2182 SP
+-4 2 7 1 2 765 2189 SP
+18 5 -13 -4 2 555 2112 SP
+-4 1 14 3 2 551 2105 SP
+-3 1 1 761 2192 SP
+-4 -1 1 541 2130 SP
+0 1 1 511 2100 SP
+4 1 1 649 2193 SP
+-1 -2 1 695 2195 SP
+3 -1 1 724 2189 SP
+-4 -2 1 558 2139 SP
+-4 -3 1 611 2130 SP
+-3 -2 1 543 2133 SP
+-1 -2 1 542 2150 SP
+-1 2 1 692 2192 SP
+5 3 1 527 2107 SP
+-2 2 1 761 2188 SP
+5 -1 1 771 2189 SP
+5 3 1 542 2134 SP
+-2 1 5 3 2 519 2108 SP
+1 -4 -1 3 2 784 2179 SP
+{0 0 0.502 C} FS
+-2 2 6 3 -7 -4 0 3 -4 -5 6 1 6 576 2154 SP
+-3 -5 8 3 -3 -4 9 3 -1 5 -9 -2 6 601 2143 SP
+-9 -5 7 3 -5 -9 3 599 2135 SP
+-6 -2 1 622 2162 SP
+-6 -2 1 664 2163 SP
+7 5 1 752 2170 SP
+-3 -4 1 655 2183 SP
+4 3 1 716 2165 SP
+-4 -3 1 633 2178 SP
+6 4 1 704 2165 SP
+5 3 -5 -2 2 611 2151 SP
+6 2 -5 -2 2 620 2171 SP
+-1 -3 1 730 2177 SP
+1 2 1 679 2181 SP
+-5 -3 4 3 2 747 2176 SP
+-6 -2 1 613 2151 SP
+4 2 1 722 2173 SP
+3 2 1 736 2169 SP
+-5 -4 1 644 2162 SP
+-4 -2 1 618 2154 SP
+-2 -3 1 663 2185 SP
+6 2 -5 -2 2 650 2172 SP
+-5 -3 1 630 2174 SP
+5 2 -4 -2 2 615 2172 SP
+-4 -1 1 617 2176 SP
+-16 -4 1 591 2136 SP
+15 8 1 706 2164 SP
+-10 -4 1 671 2167 SP
+-3 -5 1 0 2 597 2136 SP
+19 14 1 727 2164 SP
+-21 -14 1 695 2176 SP
+-14 -8 1 643 2172 SP
+-5 -3 1 628 2151 SP
+4 -1 1 738 2178 SP
+-10 -4 1 611 2156 SP
+4 -2 -3 2 2 613 2135 SP
+8 7 1 721 2164 SP
+4 0 1 713 2180 SP
+-4 -1 1 564 2129 SP
+8 6 1 696 2164 SP
+-8 -2 1 661 2172 SP
+-6 -3 1 680 2174 SP
+-4 -3 1 578 2130 SP
+-10 -6 1 696 2168 SP
+-4 -2 1 557 2122 SP
+9 5 1 678 2168 SP
+-5 -1 1 654 2158 SP
+-5 -3 1 662 2161 SP
+-5 -2 1 684 2166 SP
+4 2 1 697 2177 SP
+10 5 -10 -4 2 639 2171 SP
+1 -2 1 691 2182 SP
+6 4 1 720 2168 SP
+-6 -4 1 612 2154 SP
+7 3 -1 0 2 694 2166 SP
+-5 -3 1 608 2154 SP
+4 2 1 706 2173 SP
+3 3 0 -1 2 717 2178 SP
+1 1 -2 0 0 -2 3 508 2075 SP
+663 2142 M
+14 -1 D
+17 7 D
+-3 -3 D
+10 4 D
+-5 -5 D
+7 2 D
+-3 -9 D
+-16 -9 D
+-36 4 D
+-25 -12 D
+-15 -5 D
+-9 -8 D
+2 -2 D
+-9 -3 D
+12 -22 D
+-7 -3 D
+-7 -12 D
+-3 10 D
+-7 -3 D
+6 14 D
+-5 8 D
+-16 -8 D
+-1 -5 D
+-19 -9 D
+-4 2 D
+15 13 D
+-2 3 D
+-16 -5 D
+-27 -15 D
+1 4 D
+12 4 D
+-10 -3 D
+-1 2 D
+39 20 D
+89 38 D
+P
+FO
+-1 0 -5 -4 2 746 2168 SP
+-12 1 -1 -2 0 -2 2 0 3 1 -5 0 10 1 7 773 2175 SP
+6 4 -5 -2 2 781 2171 SP
+1 1 -1 0 2 780 2165 SP
+745 2091 M
+3 2 D
+16 25 D
+0 7 D
+-8 -1 D
+10 2 D
+0 5 D
+6 2 D
+0 -4 D
+4 6 D
+-7 0 D
+6 5 D
+-4 2 D
+6 4 D
+1 -17 D
+5 -22 D
+-9 -4 D
+-10 -4 D
+-9 -4 D
+P
+FO
+701 2070 M
+-3 0 D
+-7 -4 D
+-9 -5 D
+2 9 D
+-5 0 D
+5 0 D
+4 10 D
+-8 -3 D
+-6 -10 D
+-10 -2 D
+11 18 D
+15 10 D
+10 1 D
+6 11 D
+3 -2 D
+13 13 D
+-13 -38 D
+8 0 D
+P
+FO
+{1 0 0 C} FS
+1 -2 -4 -4 -1 1 3 578 2098 SP
+2 8 8 -3 2 560 2092 SP
+3 -2 1 597 2107 SP
+{0 0 0.502 C} FS
+-2 5 -2 -4 -8 3 -12 -4 -3 -5 9 4 -3 -7 -9 -4 7 8 -23 -19 14 9 7 1 13 13 6 -1 -4 -6 9 7 16 612 2088 SP
+3 4 10 5 15 3 10 8 -8 -2 2 -3 -13 -5 -14 1 -3 -5 6 4 -5 -4 9 2 -13 -5 13 648 2112 SP
+4 -1 -9 -8 10 6 -9 -8 13 8 11 13 3 -3 2 7 -6 0 -22 -15 -7 -10 11 644 2070 SP
+-3 3 2 -5 10 10 -1 -7 10 14 -10 -2 -6 -9 7 578 2014 SP
+-11 -5 1 4 -7 -9 3 662 2079 SP
+18 7 -10 -4 -1 4 -6 -2 4 633 2111 SP
+6 -1 6 5 -4 -3 -8 0 4 624 2107 SP
+6 1 -4 2 4 4 -6 -6 4 686 2105 SP
+-9 -10 7 3 2 668 2116 SP
+-11 -2 9 -3 2 757 2146 SP
+23 20 -14 1 -19 -19 3 622 2077 SP
+2 -3 17 15 -9 -8 3 562 2065 SP
+-4 -3 5 1 2 620 2100 SP
+3 4 -7 -4 2 706 2113 SP
+-3 -8 7 7 2 736 2138 SP
+1 4 -6 -5 2 655 2080 SP
+1 5 -6 -5 2 564 2046 SP
+-3 2 -15 -6 2 746 2119 SP
+-7 -2 1 742 2110 SP
+4 3 1 649 2103 SP
+-4 -3 1 629 2099 SP
+-2 -4 1 700 2119 SP
+-4 -2 1 662 2084 SP
+-2 1 1 642 2112 SP
+3 0 1 713 2142 SP
+0 -3 1 609 2089 SP
+4 3 1 701 2127 SP
+-7 -2 1 644 2119 SP
+-6 2 1 751 2127 SP
+-3 2 1 620 2112 SP
+6 3 -6 -2 2 633 2109 SP
+-5 -3 4 3 2 653 2116 SP
+-5 -1 4 1 2 667 2106 SP
+1 4 1 732 2117 SP
+13 11 1 643 2091 SP
+0 5 -4 -4 2 602 2030 SP
+-10 -8 1 699 2107 SP
+-7 -5 1 626 2101 SP
+-9 -5 1 718 2114 SP
+-10 -7 1 441 1975 SP
+-9 -5 1 0 2 644 2098 SP
+2 -4 1 704 2125 SP
+-6 -4 1 611 2028 SP
+-6 -8 1 1 2 595 2018 SP
+8 4 1 645 2108 SP
+7 3 1 639 2092 SP
+-5 -2 1 623 2036 SP
+-5 -2 1 639 2055 SP
+-5 -2 1 702 2104 SP
+2 -4 1 663 2108 SP
+11 5 1 611 2093 SP
+-7 -3 1 738 2112 SP
+-5 -2 1 563 2073 SP
+5 1 1 641 2088 SP
+9 4 1 645 2114 SP
+7 3 1 664 2102 SP
+-6 -4 1 662 2096 SP
+-5 -1 1 618 2105 SP
+6 0 1 680 2112 SP
+2 -2 1 711 2130 SP
+-4 -2 1 545 2025 SP
+-2 1 1 674 2097 SP
+{1 0 0 C} FS
+-5 -4 -1 3 2 629 2088 SP
+5 2 1 640 2100 SP
+-4 -2 1 630 2059 SP
+682 2061 M
+2 9 D
+-5 0 D
+5 0 D
+4 10 D
+-8 -3 D
+-6 -10 D
+-10 -2 D
+11 18 D
+15 10 D
+10 1 D
+6 11 D
+3 -2 D
+13 13 D
+-13 -38 D
+8 0 D
+31 15 D
+16 25 D
+0 7 D
+-8 -1 D
+10 2 D
+0 5 D
+6 2 D
+0 -4 D
+4 6 D
+-7 0 D
+6 5 D
+-4 2 D
+6 4 D
+3 19 D
+-1 0 D
+2 6 D
+-5 -2 D
+6 4 D
+-12 1 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-5 -4 D
+-1 0 D
+6 4 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-6 -3 D
+14 -1 D
+17 7 D
+-3 -3 D
+10 4 D
+-5 -5 D
+7 2 D
+-3 -9 D
+-16 -9 D
+-36 4 D
+-25 -12 D
+-15 -5 D
+-9 -8 D
+2 -2 D
+-9 -3 D
+12 -22 D
+-7 -3 D
+-7 -12 D
+-3 10 D
+-7 -3 D
+6 14 D
+-5 8 D
+-16 -8 D
+-1 -5 D
+-19 -9 D
+-4 2 D
+15 13 D
+-2 3 D
+-16 -5 D
+-27 -15 D
+1 4 D
+12 4 D
+-10 -3 D
+-1 2 D
+-3 -1 D
+-2 -1 D
+0 -2 D
+-2 0 D
+-7 -3 D
+-12 -7 D
+-12 -7 D
+-12 -7 D
+-12 -7 D
+-12 -8 D
+-6 -3 D
+-8 -33 D
+-3 -22 D
+1 -33 D
+7 -33 D
+3 -11 D
+48 37 D
+64 46 D
+15 9 D
+67 41 D
+P
+FO
+5 2 -7 -4 -3 0 3 701 2070 SP
+-3 -1 -5 0 10 1 3 773 2175 SP
+1 -2 -4 -4 -1 1 3 578 2098 SP
+2 8 8 -3 2 560 2092 SP
+3 -2 1 597 2107 SP
+{0 0 0.502 C} FS
+-2 5 -2 -4 -8 3 -12 -4 -3 -5 9 4 -3 -7 -9 -4 7 8 -23 -19 14 9 7 1 13 13 6 -1 -4 -6 9 7 16 612 2088 SP
+3 4 10 5 15 3 10 8 -8 -2 2 -3 -13 -5 -14 1 -3 -5 6 4 -5 -4 9 2 -13 -5 13 648 2112 SP
+4 -1 -9 -8 10 6 -9 -8 13 8 11 13 3 -3 2 7 -6 0 -22 -15 -7 -10 11 644 2070 SP
+-3 3 2 -5 10 10 -1 -7 10 14 -10 -2 -6 -9 7 578 2014 SP
+-11 -5 1 4 -7 -9 3 662 2079 SP
+18 7 -10 -4 -1 4 -6 -2 4 633 2111 SP
+6 -1 6 5 -4 -3 -8 0 4 624 2107 SP
+6 1 -4 2 4 4 -6 -6 4 686 2105 SP
+-9 -10 7 3 2 668 2116 SP
+-11 -2 9 -3 2 757 2146 SP
+23 20 -14 1 -19 -19 3 622 2077 SP
+2 -3 17 15 -9 -8 3 562 2065 SP
+-4 -3 5 1 2 620 2100 SP
+3 4 -7 -4 2 706 2113 SP
+-3 -8 7 7 2 736 2138 SP
+1 4 -6 -5 2 655 2080 SP
+1 5 -6 -5 2 564 2046 SP
+-3 2 -15 -6 2 746 2119 SP
+-7 -2 1 742 2110 SP
+4 3 1 649 2103 SP
+-4 -3 1 629 2099 SP
+-2 -4 1 700 2119 SP
+-4 -2 1 662 2084 SP
+-2 1 1 642 2112 SP
+3 0 1 713 2142 SP
+0 -3 1 609 2089 SP
+4 3 1 701 2127 SP
+-7 -2 1 644 2119 SP
+-6 2 1 751 2127 SP
+-3 2 1 620 2112 SP
+6 3 -6 -2 2 633 2109 SP
+-5 -3 4 3 2 653 2116 SP
+-5 -1 4 1 2 667 2106 SP
+1 4 1 732 2117 SP
+13 11 1 643 2091 SP
+0 5 -4 -4 2 602 2030 SP
+-10 -8 1 699 2107 SP
+-7 -5 1 626 2101 SP
+-9 -5 1 718 2114 SP
+-10 -7 1 441 1975 SP
+-9 -5 1 0 2 644 2098 SP
+2 -4 1 704 2125 SP
+-6 -4 1 611 2028 SP
+-6 -8 1 1 2 595 2018 SP
+8 4 1 645 2108 SP
+7 3 1 639 2092 SP
+-5 -2 1 623 2036 SP
+-5 -2 1 639 2055 SP
+-5 -2 1 702 2104 SP
+2 -4 1 663 2108 SP
+11 5 1 611 2093 SP
+-7 -3 1 738 2112 SP
+-5 -2 1 563 2073 SP
+5 1 1 641 2088 SP
+9 4 1 645 2114 SP
+7 3 1 664 2102 SP
+-6 -4 1 662 2096 SP
+-5 -1 1 618 2105 SP
+6 0 1 680 2112 SP
+2 -2 1 711 2130 SP
+-4 -2 1 545 2025 SP
+-2 1 1 674 2097 SP
+{1 0 0 C} FS
+-5 -4 -1 3 2 629 2088 SP
+5 2 1 640 2100 SP
+-4 -2 1 630 2059 SP
+{0 0 0.502 C} FS
+-5 3 -6 -11 -11 -8 -11 0 13 0 14 12 7 4 7 450 1863 SP
+5 2 1 3 -10 -8 3 691 2066 SP
+717 2078 M
+14 0 D
+14 13 D
+38 16 D
+11 -23 D
+17 -23 D
+16 -16 D
+0 -7 D
+-12 -7 D
+-5 -4 D
+-7 -3 D
+8 9 D
+-14 1 D
+-6 7 D
+-9 -3 D
+-4 6 D
+12 5 D
+6 -1 D
+-3 2 D
+-16 -1 D
+5 3 D
+-22 6 D
+-4 -5 D
+-4 5 D
+-13 -6 D
+-5 5 D
+9 10 D
+11 -3 D
+5 4 D
+4 17 D
+-6 -7 D
+-43 -21 D
+7 13 D
+-12 1 D
+-8 -1 D
+P
+FO
+{1 0 0 C} FS
+-10 0 5 7 10 -1 3 776 2065 SP
+{0 0 0.502 C} FS
+535 1905 M
+-6 -2 D
+-5 -7 D
+6 -3 D
+-12 -4 D
+2 -6 D
+-7 4 D
+3 -1 D
+9 16 D
+19 7 D
+4 6 D
+-2 -5 D
+5 4 D
+-1 -6 D
+9 -5 D
+5 3 D
+-4 -3 D
+4 -1 D
+-24 5 D
+P
+FO
+0 5 8 -1 -3 5 9 14 -6 -7 -3 2 3 -5 -4 -6 -7 0 -16 -16 11 8 11 640 1927 SP
+22 2 7 -8 -37 -23 -16 1 16 -1 38 23 -8 8 -21 -2 12 14 9 743 1999 SP
+-10 -10 -10 -3 -3 -8 3 8 10 3 11 9 12 26 7 646 2012 SP
+-11 7 0 10 5 14 -6 -14 1 -11 11 -6 -7 -14 7 550 1960 SP
+-9 -10 7 8 15 0 3 591 1905 SP
+-5 2 -4 -9 2 547 1815 SP
+-20 -9 5 -3 2 563 1974 SP
+15 6 1 490 1877 SP
+-2 7 1 -7 2 559 1981 SP
+{1 0 0 C} FS
+450 1863 M
+7 4 D
+14 12 D
+13 0 D
+-11 0 D
+-11 -8 D
+-6 -11 D
+-6 3 D
+12 -21 D
+23 -29 D
+18 -20 D
+15 -14 D
+6 -4 D
+43 47 D
+19 20 D
+27 25 D
+6 7 D
+61 55 D
+28 23 D
+15 11 D
+43 33 D
+36 26 D
+8 5 D
+-7 -3 D
+8 9 D
+-14 1 D
+-6 7 D
+-9 -3 D
+-4 6 D
+12 5 D
+6 -1 D
+-3 2 D
+-16 -1 D
+5 3 D
+-22 6 D
+-4 -5 D
+-4 5 D
+-13 -6 D
+-5 5 D
+9 10 D
+11 -3 D
+5 4 D
+4 17 D
+-6 -7 D
+-43 -21 D
+7 13 D
+-12 1 D
+-8 -1 D
+-5 -2 D
+-5 -2 D
+-10 -8 D
+1 3 D
+-16 -8 D
+-15 -8 D
+-16 -9 D
+-15 -8 D
+-15 -9 D
+-15 -9 D
+-15 -10 D
+-15 -9 D
+-15 -9 D
+-21 -15 D
+-22 -15 D
+-28 -21 D
+-34 -27 D
+-7 -5 D
+P
+FO
+-2 2 2 1 2 2 0 -7 4 827 2045 SP
+-9 -4 -9 -4 14 13 14 0 4 717 2078 SP
+-10 0 5 7 10 -1 3 776 2065 SP
+{0 0 0.502 C} FS
+535 1905 M
+-6 -2 D
+-5 -7 D
+6 -3 D
+-12 -4 D
+2 -6 D
+-7 4 D
+3 -1 D
+9 16 D
+19 7 D
+4 6 D
+-2 -5 D
+5 4 D
+-1 -6 D
+9 -5 D
+5 3 D
+-4 -3 D
+4 -1 D
+-24 5 D
+P
+FO
+0 5 8 -1 -3 5 9 14 -6 -7 -3 2 3 -5 -4 -6 -7 0 -16 -16 11 8 11 640 1927 SP
+22 2 7 -8 -37 -23 -16 1 16 -1 38 23 -8 8 -21 -2 12 14 9 743 1999 SP
+-10 -10 -10 -3 -3 -8 3 8 10 3 11 9 12 26 7 646 2012 SP
+-11 7 0 10 5 14 -6 -14 1 -11 11 -6 -7 -14 7 550 1960 SP
+-9 -10 7 8 15 0 3 591 1905 SP
+-5 2 -4 -9 2 547 1815 SP
+-20 -9 5 -3 2 563 1974 SP
+15 6 1 490 1877 SP
+-2 7 1 -7 2 559 1981 SP
+827 2038 M
+5 1 D
+0 2 D
+26 -20 D
+-7 -5 D
+5 -4 D
+-4 -11 D
+-16 -7 D
+3 21 D
+2 -3 D
+-9 25 D
+-7 -1 D
+-9 -12 D
+-6 3 D
+P
+FO
+4 -1 15 13 2 10 32 14 18 -4 -11 15 -35 -13 -14 -14 -13 2 13 18 -6 8 4 -7 -10 -5 -6 -10 5 -9 12 -5 -13 -10 17 891 2002 SP
+793 1829 M
+-3 6 D
+3 18 D
+-15 20 D
+-39 23 D
+-2 -9 D
+-11 -12 D
+-12 -2 D
+-22 -16 D
+22 17 D
+12 1 D
+11 12 D
+5 52 D
+18 9 D
+14 17 D
+19 12 D
+12 4 D
+14 -6 D
+-9 -1 D
+-6 6 D
+-10 -3 D
+-19 -12 D
+-16 -19 D
+-17 -8 D
+-4 -36 D
+37 -23 D
+19 -23 D
+-3 -21 D
+3 -5 D
+P
+FO
+-3 0 1 751 1767 SP
+{1 0 0 C} FS
+5 1 1 828 1967 SP
+-2 3 1 826 1965 SP
+{0 0 0.502 C} FS
+-7 5 -8 -4 7 -3 3 721 1769 SP
+-1 -4 -7 -1 11 1 3 593 1732 SP
+-10 -4 1 598 1793 SP
+-5 -1 1 693 1811 SP
+-2 5 1 696 1889 SP
+7 1 1 728 1887 SP
+1 6 1 665 1756 SP
+{1 0 0 C} FS
+751 1767 M
+-3 0 D
+3 0 D
+42 62 D
+-3 6 D
+3 18 D
+-15 20 D
+-39 23 D
+-2 -9 D
+-11 -12 D
+-12 -2 D
+-22 -16 D
+22 17 D
+12 1 D
+11 12 D
+5 52 D
+18 9 D
+14 17 D
+19 12 D
+12 4 D
+14 -6 D
+-9 -1 D
+-6 6 D
+-10 -3 D
+-19 -12 D
+-16 -19 D
+-17 -8 D
+-4 -36 D
+37 -23 D
+19 -23 D
+-3 -21 D
+3 -4 D
+15 19 D
+9 13 D
+29 37 D
+59 71 D
+15 17 D
+-30 14 D
+-13 -10 D
+12 -5 D
+5 -9 D
+-6 -10 D
+-10 -5 D
+4 -7 D
+-6 8 D
+13 18 D
+-13 2 D
+-14 -14 D
+-35 -13 D
+-11 15 D
+18 -4 D
+32 14 D
+2 10 D
+15 13 D
+-26 16 D
+-7 -5 D
+5 -4 D
+-4 -11 D
+-16 -7 D
+3 21 D
+2 -3 D
+-9 25 D
+-7 -1 D
+-9 -12 D
+-6 3 D
+-22 -15 D
+-22 -16 D
+-29 -22 D
+-21 -17 D
+-15 -11 D
+-48 -41 D
+-34 -31 D
+-6 -7 D
+-27 -25 D
+-62 -67 D
+29 -24 D
+39 -26 D
+52 -29 D
+49 -22 D
+32 54 D
+9 13 D
+12 20 D
+P
+FO
+-2 -1 -1 0 0 2 5 1 4 827 2038 SP
+5 1 1 828 1967 SP
+-2 3 1 826 1965 SP
+{0 0 0.502 C} FS
+-7 5 -8 -4 7 -3 3 721 1769 SP
+-1 -4 -7 -1 11 1 3 593 1732 SP
+-10 -4 1 598 1793 SP
+-5 -1 1 693 1811 SP
+-2 5 1 696 1889 SP
+7 1 1 728 1887 SP
+1 6 1 665 1756 SP
+3 -9 9 2 -1 9 3 832 1628 SP
+4 0 1 751 1767 SP
+1 1 -12 28 -3 22 12 12 -13 -12 0 -12 7 -32 8 -8 8 794 1831 SP
+2 -1 -1 5 -4 -4 3 942 1980 SP
+4 1 0 7 -5 -8 3 967 1971 SP
+904 1882 M
+-9 -9 D
+4 -21 D
+-4 21 D
+28 34 D
+4 12 D
+-7 6 D
+29 42 D
+-8 8 D
+9 -2 D
+0 -6 D
+-29 -43 D
+6 -5 D
+-3 -10 D
+9 0 D
+5 -7 D
+-5 -14 D
+9 -10 D
+-10 10 D
+5 14 D
+-5 7 D
+-8 -1 D
+P
+FO
+-7 -10 -1 -12 -16 -2 1 -5 21 10 5 850 1718 SP
+21 -5 -3 4 2 962 1941 SP
+27 6 1 746 1737 SP
+15 -4 1 964 1951 SP
+9 1 -18 4 2 983 1956 SP
+20 7 1 969 1930 SP
+4 11 1 975 1906 SP
+-1 8 1 788 1669 SP
+-3 -3 1 972 1921 SP
+-1 7 1 996 1945 SP
+1 5 1 984 1909 SP
+7 3 1 728 1710 SP
+4 -2 1 901 1666 SP
+{1 0 0 C} FS
+832 1628 M
+-1 9 D
+9 2 D
+3 -9 D
+-11 -2 D
+71 -17 D
+18 -3 D
+31 101 D
+30 88 D
+37 99 D
+24 56 D
+-48 11 D
+-28 8 D
+-5 -8 D
+0 7 D
+4 1 D
+-19 6 D
+-5 3 D
+-4 -4 D
+-1 5 D
+-16 7 D
+-60 -70 D
+-33 -42 D
+-15 -19 D
+-14 -20 D
+-5 -6 D
+8 -8 D
+7 -32 D
+0 -12 D
+-13 -12 D
+12 12 D
+-3 22 D
+-12 28 D
+-42 -62 D
+4 0 D
+-4 0 D
+-13 -19 D
+-8 -14 D
+-9 -13 D
+-28 -47 D
+58 -22 D
+53 -17 D
+P
+FO
+{0 0 0.502 C} FS
+904 1882 M
+-9 -9 D
+4 -21 D
+-4 21 D
+28 34 D
+4 12 D
+-7 6 D
+29 42 D
+-8 8 D
+9 -2 D
+0 -6 D
+-29 -43 D
+6 -5 D
+-3 -10 D
+9 0 D
+5 -7 D
+-5 -14 D
+9 -10 D
+-10 10 D
+5 14 D
+-5 7 D
+-8 -1 D
+P
+FO
+-7 -10 -1 -12 -16 -2 1 -5 21 10 5 850 1718 SP
+21 -5 -3 4 2 962 1941 SP
+27 6 1 746 1737 SP
+15 -4 1 964 1951 SP
+9 1 -18 4 2 983 1956 SP
+20 7 1 969 1930 SP
+4 11 1 975 1906 SP
+-1 8 1 788 1669 SP
+-3 -3 1 972 1921 SP
+-1 7 1 996 1945 SP
+1 5 1 984 1909 SP
+7 3 1 728 1710 SP
+4 -2 1 901 1666 SP
+-9 -2 1 1181 1835 SP
+17 10 15 -13 19 -5 29 24 -29 -24 -19 6 -14 13 -18 -10 8 1181 1776 SP
+-6 10 3 2 -2 8 -4 -18 -11 1 8 42 5 -1 -6 3 3 11 -7 -9 3 -12 -1 -3 -2 5 -4 -29 -1 -10 9 -1 16 981 1718 SP
+24 20 20 13 19 2 -12 6 -15 -3 -8 -11 -35 -16 5 -3 -15 -11 -9 -28 5 -1 11 1060 1699 SP
+-10 -10 1 -9 2 935 1635 SP
+3 -6 1 987 1641 SP
+5 -2 1 961 1706 SP
+{1 0 0 C} FS
+1181 1776 M
+-18 -10 D
+-14 13 D
+-19 6 D
+-29 -24 D
+29 24 D
+19 -5 D
+15 -13 D
+17 10 D
+0 58 D
+-9 -2 D
+9 2 D
+0 105 D
+-82 4 D
+-56 8 D
+-36 -86 D
+-42 -116 D
+-44 -142 D
+64 -10 D
+97 -10 D
+88 -3 D
+11 0 D
+P
+FO
+{0 0 0.502 C} FS
+-6 10 3 2 -2 8 -4 -18 -11 1 8 42 5 -1 -6 3 3 11 -7 -9 3 -12 -1 -3 -2 5 -4 -29 -1 -10 9 -1 16 981 1718 SP
+24 20 20 13 19 2 -12 6 -15 -3 -8 -11 -35 -16 5 -3 -15 -11 -9 -28 5 -1 11 1060 1699 SP
+-10 -10 1 -9 2 935 1635 SP
+3 -6 1 987 1641 SP
+5 -2 1 961 1706 SP
+-2 -7 -5 2 4 -8 -18 -17 -11 -5 1 -3 1 -3 31 31 0 10 9 1400 1601 SP
+1181 1777 M
+12 7 D
+30 -1 D
+48 24 D
+-2 25 D
+-31 18 D
+-9 -10 D
+-15 4 D
+-33 -9 D
+33 9 D
+15 -3 D
+7 7 D
+-17 14 D
+-15 39 D
+14 40 D
+1 0 D
+-12 -36 D
+12 -40 D
+38 -25 D
+45 -2 D
+2 -5 D
+22 -4 D
+7 -41 D
+-6 1 D
+5 0 D
+-6 39 D
+-22 4 D
+-2 6 D
+-34 -2 D
+9 -20 D
+-10 -19 D
+-44 -14 D
+-29 0 D
+-6 -4 D
+5 -6 D
+-10 5 D
+-2 -2 D
+P
+FO
+1418 1685 M
+-4 2 D
+-12 -2 D
+0 -5 D
+-12 -11 D
+1 15 D
+-8 -12 D
+-4 16 D
+-12 -3 D
+-8 5 D
+26 33 D
+13 24 D
+P
+FO
+-5 4 4 -4 -2 -1 3 1424 1664 SP
+{1 0 0 C} FS
+-2 -9 -6 6 2 1391 1694 SP
+1 3 1 1380 1694 SP
+{0 0 0.502 C} FS
+-1 -6 1 1428 1649 SP
+4 1 1 0 2 1386 1638 SP
+{1 0 0 C} FS
+-1 4 1 1209 1891 SP
+4 0 1 1262 1797 SP
+1400 1601 M
+0 10 D
+31 31 D
+-5 17 D
+-5 4 D
+3 1 D
+-6 21 D
+-4 2 D
+-12 -2 D
+0 -5 D
+-12 -11 D
+1 15 D
+-8 -12 D
+-4 16 D
+-12 -3 D
+-8 5 D
+26 33 D
+13 24 D
+-36 100 D
+-32 80 D
+-11 25 D
+-11 -1 D
+-10 -2 D
+-11 -2 D
+-11 -1 D
+-12 -1 D
+-11 -1 D
+-11 -1 D
+-11 -1 D
+-12 -1 D
+-12 -36 D
+12 -40 D
+38 -25 D
+45 -2 D
+2 -5 D
+22 -4 D
+7 -41 D
+-6 1 D
+5 0 D
+-6 39 D
+-22 4 D
+-2 6 D
+-34 -2 D
+9 -20 D
+-10 -19 D
+-44 -14 D
+-29 0 D
+-6 -4 D
+5 -6 D
+-10 5 D
+-2 -2 D
+0 -191 D
+78 2 D
+98 8 D
+P
+FO
+-3 10 -3 9 7 1 6 1 7 1 7 2 6 1 7 1 -2 -7 -5 2 4 -8 -18 -17 -11 -5 13 1433 1636 SP
+-1 3 4 -4 -2 -1 3 1424 1664 SP
+-9 0 -10 -1 -9 0 -9 0 14 40 -15 39 -17 14 7 7 15 -3 33 9 10 1181 1835 SP
+-33 -9 -15 4 -9 -10 -31 18 -2 25 48 24 30 -1 12 7 8 1181 1777 SP
+-2 -9 -6 6 2 1391 1694 SP
+1 3 1 1380 1694 SP
+{0 0 0.502 C} FS
+-1 -6 1 1428 1649 SP
+4 1 1 0 2 1386 1638 SP
+{1 0 0 C} FS
+-1 4 1 1209 1891 SP
+4 0 1 1262 1797 SP
+{0 0 0.502 C} FS
+1490 1618 M
+-19 26 D
+-25 52 D
+-4 -3 D
+10 -10 D
+-10 -8 D
+5 -20 D
+15 -21 D
+6 -21 D
+-11 -2 D
+-11 -2 D
+-4 13 D
+5 30 D
+-16 16 D
+7 -1 D
+1 6 D
+-21 12 D
+-20 62 D
+14 33 D
+30 11 D
+5 -4 D
+2 7 D
+24 2 D
+0 10 D
+31 -1 D
+-10 -6 D
+5 -4 D
+31 17 D
+-5 5 D
+-7 -3 D
+-3 7 D
+3 33 D
+21 16 D
+9 -15 D
+2 1 D
+21 -29 D
+-2 -24 D
+-10 -8 D
+3 -22 D
+11 -27 D
+53 -71 D
+5 33 D
+-8 12 D
+14 7 D
+13 -21 D
+19 -32 D
+-8 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -4 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-10 -3 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+P
+FO
+-1 3 -8 -4 7 0 0 -7 2 8 -2 -14 8 -6 -6 5 0 10 1 2 10 1431 1642 SP
+7 3 1 1424 1664 SP
+9 -15 1 1367 1963 SP
+11 1 0 10 5 8 -4 4 13 8 -14 -8 -1 -21 -10 -1 8 1458 1968 SP
+1 -2 -2 4 2 1628 1741 SP
+{1 0 0 C} FS
+-2 -16 -3 7 2 1624 1664 SP
+1 4 1 1623 1671 SP
+1446 1609 M
+-4 13 D
+5 30 D
+-16 16 D
+7 -1 D
+1 6 D
+-21 12 D
+6 -21 D
+7 3 D
+-7 -3 D
+2 -5 D
+8 -6 D
+-2 -14 D
+2 8 D
+0 -7 D
+7 0 D
+-8 -4 D
+8 -28 D
+P
+FO
+11 3 6 -21 15 -21 5 -20 -10 -8 10 -10 -4 -3 -25 52 -19 26 9 1490 1618 SP
+1628 1741 M
+-37 57 D
+-20 29 D
+-2 -24 D
+-10 -8 D
+3 -22 D
+11 -27 D
+53 -71 D
+5 33 D
+-8 12 D
+14 7 D
+P
+FO
+-4 4 2 1 3 -4 2 -5 4 1543 1864 SP
+1458 1968 M
+-10 -1 D
+-1 -21 D
+-14 -8 D
+13 8 D
+-4 4 D
+5 8 D
+0 10 D
+11 1 D
+-17 19 D
+-9 -4 D
+-9 -3 D
+-8 -4 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -2 D
+-10 -3 D
+9 -15 D
+-9 15 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-10 -2 D
+33 -78 D
+36 -98 D
+10 -29 D
+14 33 D
+30 11 D
+5 -4 D
+2 7 D
+24 2 D
+0 10 D
+31 -1 D
+-10 -6 D
+5 -4 D
+31 17 D
+-5 5 D
+-7 -3 D
+-3 7 D
+3 33 D
+21 16 D
+-18 23 D
+-49 60 D
+P
+FO
+2 -8 -6 5 0 10 1 2 4 1431 1642 SP
+-2 -16 -3 7 2 1624 1664 SP
+1 4 1 1623 1671 SP
+{0 0 0.502 C} FS
+1637 1727 M
+1 0 D
+-12 18 D
+13 19 D
+-16 22 D
+9 6 D
+-19 16 D
+1 9 D
+-15 -2 D
+-10 38 D
+5 5 D
+6 -4 D
+2 16 D
+8 -10 D
+-2 12 D
+12 11 D
+17 -6 D
+-6 9 D
+0 30 D
+7 25 D
+15 5 D
+-5 7 D
+-34 17 D
+5 -4 D
+-13 5 D
+-2 -9 D
+-4 3 D
+-5 -3 D
+20 17 D
+-3 5 D
+43 -33 D
+62 -53 D
+20 -18 D
+6 -7 D
+14 -12 D
+6 -7 D
+7 -6 D
+31 -33 D
+7 -6 D
+24 -27 D
+7 -7 D
+-30 -24 D
+-19 -13 D
+-20 -13 D
+-14 -9 D
+-15 -8 D
+-15 -8 D
+-16 -8 D
+-8 -3 D
+-16 -8 D
+-8 -4 D
+-9 -3 D
+P
+FO
+-7 10 -7 9 0 -27 -9 -12 16 -23 -5 -7 7 -1 7 7 -11 13 7 3 3 23 4 -7 2 2 13 1550 1856 SP
+-2 3 2 -8 2 2 3 1539 1870 SP
+-5 -1 0 -1 5 1 3 1458 1969 SP
+4 0 1 1449 1978 SP
+7 4 7 4 8 4 7 3 8 4 8 3 -16 9 0 -10 -27 -8 0 -7 -10 6 -17 0 1 -6 13 -4 4 -6 15 1493 2014 SP
+5 -4 6 -3 5 4 6 4 5 4 6 5 6 4 6 4 -11 -3 -10 -9 -30 -2 11 1548 2030 SP
+{1 0 0 C} FS
+-8 -2 -2 5 2 1492 2004 SP
+-9 -1 5 1 2 1811 1792 SP
+15 -5 -9 2 2 1672 1785 SP
+-7 -4 3 13 2 1606 1829 SP
+7 1 1 1747 1783 SP
+-1 -4 1 1795 1792 SP
+9 -2 1 1681 1787 SP
+2 4 1 1759 1776 SP
+{0 0 0.502 C} FS
+0 4 1 1620 1755 SP
+{1 0 0 C} FS
+1548 2030 M
+-30 -2 D
+-10 -9 D
+-11 -3 D
+-4 -2 D
+4 -6 D
+13 -4 D
+1 -6 D
+-17 0 D
+-10 6 D
+0 -7 D
+-27 -8 D
+0 -10 D
+-16 9 D
+8 -10 D
+4 0 D
+-4 0 D
+9 -9 D
+5 1 D
+0 -1 D
+-5 -1 D
+32 -36 D
+31 -39 D
+18 -23 D
+2 2 D
+2 -8 D
+7 -8 D
+2 2 D
+4 -7 D
+3 23 D
+7 3 D
+-11 13 D
+7 7 D
+7 -1 D
+-5 -7 D
+16 -23 D
+-9 -12 D
+0 -27 D
+32 -46 D
+23 -36 D
+13 19 D
+-16 22 D
+9 6 D
+-19 16 D
+1 9 D
+-15 -2 D
+-10 38 D
+5 5 D
+6 -4 D
+2 16 D
+8 -10 D
+-2 12 D
+12 11 D
+17 -6 D
+-6 9 D
+0 30 D
+7 25 D
+15 5 D
+-5 7 D
+-34 17 D
+5 -4 D
+-13 5 D
+-2 -9 D
+-4 3 D
+-5 -3 D
+20 17 D
+-3 5 D
+-37 28 D
+-11 7 D
+P
+FO
+5 -7 -10 14 1 0 3 1637 1727 SP
+-8 -2 -2 5 2 1492 2004 SP
+-9 -1 5 1 2 1811 1792 SP
+15 -5 -9 2 2 1672 1785 SP
+-7 -4 3 13 2 1606 1829 SP
+7 1 1 1747 1783 SP
+-1 -4 1 1795 1792 SP
+9 -2 1 1681 1787 SP
+2 4 1 1759 1776 SP
+{0 0 0.502 C} FS
+0 4 1 1620 1755 SP
+1612 1984 M
+-4 8 D
+-14 9 D
+3 4 D
+15 -10 D
+7 8 D
+17 -5 D
+14 2 D
+-4 5 D
+7 -4 D
+0 6 D
+-9 0 D
+-1 8 D
+-8 5 D
+-7 -2 D
+11 6 D
+-8 2 D
+7 1 D
+-7 9 D
+-20 1 D
+-9 -6 D
+-2 -4 D
+18 -7 D
+-31 11 D
+-39 -1 D
+-17 11 D
+16 15 D
+17 21 D
+12 22 D
+16 -14 D
+-2 -9 D
+8 -7 D
+19 3 D
+11 -3 D
+5 7 D
+9 -4 D
+3 5 D
+-1 -6 D
+-11 1 D
+17 -2 D
+-3 -11 D
+-11 2 D
+7 -23 D
+13 4 D
+0 -5 D
+12 -3 D
+10 11 D
+-4 3 D
+6 -2 D
+-7 10 D
+4 3 D
+4 -6 D
+11 -2 D
+6 -5 D
+-3 -5 D
+8 -10 D
+-6 -3 D
+26 -26 D
+8 -2 D
+1 4 D
+3 -4 D
+8 6 D
+0 -7 D
+14 -6 D
+-1 13 D
+19 -8 D
+7 -8 D
+-4 14 D
+4 0 D
+42 -27 D
+2 -4 D
+9 -5 D
+-6 -8 D
+14 -22 D
+-2 5 D
+2 2 D
+-6 3 D
+5 2 D
+-8 8 D
+6 -1 D
+-5 12 D
+11 -7 D
+2 -3 D
+-2 3 D
+54 -40 D
+29 -23 D
+-9 -22 D
+-18 -32 D
+-19 -26 D
+-28 -30 D
+-11 -9 D
+-5 -5 D
+-25 27 D
+-6 7 D
+-7 6 D
+-31 33 D
+-7 6 D
+-6 7 D
+-14 12 D
+-6 7 D
+-68 60 D
+P
+FO
+2 -1 -4 3 -8 4 -8 15 7 -2 8 6 11 -4 -13 4 -5 -5 -8 2 3 -13 13 -8 12 1715 2043 SP
+{1 0 0 C} FS
+1 -11 6 -3 -2 -4 -5 11 4 1853 1900 SP
+7 -5 -18 -8 -3 7 3 1687 2003 SP
+5 -13 -8 1 2 6 3 1844 1932 SP
+12 1 0 -9 -9 3 3 1750 1987 SP
+4 0 3 -7 -4 0 3 1742 2002 SP
+1 3 1 1647 2009 SP
+-5 -2 1 4 2 1827 1812 SP
+-5 16 1 1855 1880 SP
+0 10 1 1840 1834 SP
+4 -9 1 1831 1825 SP
+5 6 1 1844 1841 SP
+4 0 1 1841 1959 SP
+1 6 1 1829 1814 SP
+6 2 1 1717 1957 SP
+{0 0 0.502 C} FS
+1 -5 1 1748 2003 SP
+-1 -3 1 1659 2044 SP
+2 -3 1 1734 2011 SP
+{1 0 0 C} FS
+2 -3 1 1846 1962 SP
+-5 4 -5 12 6 -1 -8 8 5 2 -6 3 2 2 -2 5 14 -22 -6 -8 9 -5 2 -4 12 1824 1977 SP
+1715 2043 M
+13 -8 D
+3 -13 D
+-8 2 D
+-5 -5 D
+-13 4 D
+11 -4 D
+8 6 D
+7 -2 D
+-8 15 D
+-62 33 D
+-67 30 D
+-15 6 D
+-3 -8 D
+16 -14 D
+-2 -9 D
+8 -7 D
+19 3 D
+11 -3 D
+5 7 D
+9 -4 D
+3 5 D
+-1 -6 D
+-11 1 D
+17 -2 D
+-3 -11 D
+-11 2 D
+7 -23 D
+13 4 D
+0 -5 D
+12 -3 D
+10 11 D
+-4 3 D
+6 -2 D
+-7 10 D
+4 3 D
+4 -6 D
+11 -2 D
+6 -5 D
+-3 -5 D
+8 -10 D
+-6 -3 D
+26 -26 D
+8 -2 D
+1 4 D
+3 -4 D
+8 6 D
+0 -7 D
+14 -6 D
+-1 13 D
+19 -8 D
+7 -8 D
+-4 14 D
+4 0 D
+P
+FO
+1612 1984 M
+-4 8 D
+-14 9 D
+3 4 D
+15 -10 D
+7 8 D
+17 -5 D
+14 2 D
+-4 5 D
+7 -4 D
+0 6 D
+-9 0 D
+-1 8 D
+-8 5 D
+-7 -2 D
+11 6 D
+-8 2 D
+7 1 D
+-7 9 D
+-20 1 D
+-9 -6 D
+-2 -4 D
+18 -7 D
+-31 11 D
+-39 -1 D
+21 -15 D
+11 -7 D
+P
+FO
+1 -11 6 -3 -2 -4 -5 11 4 1853 1900 SP
+7 -5 -18 -8 -3 7 3 1687 2003 SP
+5 -13 -8 1 2 6 3 1844 1932 SP
+12 1 0 -9 -9 3 3 1750 1987 SP
+4 0 3 -7 -4 0 3 1742 2002 SP
+1 3 1 1647 2009 SP
+-5 -2 1 4 2 1827 1812 SP
+-5 16 1 1855 1880 SP
+0 10 1 1840 1834 SP
+4 -9 1 1831 1825 SP
+5 6 1 1844 1841 SP
+4 0 1 1841 1959 SP
+1 6 1 1829 1814 SP
+6 2 1 1717 1957 SP
+{0 0 0.502 C} FS
+1 -5 1 1748 2003 SP
+-1 -3 1 1659 2044 SP
+2 -3 1 1734 2011 SP
+1846 1962 M
+-2 2 D
+2 -2 D
+-11 7 D
+-1 2 D
+6 -2 D
+-32 47 D
+-5 11 D
+-12 12 D
+-3 -3 D
+-7 4 D
+-34 36 D
+-2 8 D
+6 -7 D
+6 2 D
+-4 -5 D
+6 -8 D
+17 -11 D
+-1 5 D
+11 -10 D
+-8 15 D
+-6 3 D
+5 -1 D
+-8 4 D
+3 4 D
+-9 6 D
+-6 -1 D
+-9 9 D
+8 -4 D
+-6 4 D
+5 -1 D
+-5 7 D
+4 -4 D
+1 3 D
+3 -4 D
+-2 4 D
+6 -2 D
+-1 5 D
+7 0 D
+-5 15 D
+6 2 D
+-3 3 D
+63 -29 D
+74 -41 D
+26 -16 D
+8 -33 D
+3 -22 D
+-1 -33 D
+-7 -33 D
+-3 -11 D
+-59 46 D
+P
+FO
+-5 4 -6 3 -5 3 -5 4 -6 3 -5 4 -5 3 13 -26 16 -9 11 -10 -6 12 10 -4 -13 10 11 0 14 1782 2004 SP
+-2 1 4 -2 33 -27 -33 27 4 1711 2045 SP
+5 -1 -1 3 -1 3 -1 3 -6 -7 5 1588 2175 SP
+{1 0 0 C} FS
+5 -5 -6 -1 10 -5 -4 0 6 -5 -3 -3 -7 4 2 2 -4 1 -9 13 6 -5 -2 3 12 1823 2016 SP
+11 -9 -7 5 2 1771 2080 SP
+-1 -4 -6 8 2 1806 2033 SP
+4 -4 1 1769 2097 SP
+-1 3 1 1764 2087 SP
+-5 3 1 1767 2080 SP
+{0 0 0.502 C} FS
+6 -15 1 1774 2045 SP
+4 2 1 1791 2023 SP
+6 -5 1 1807 2010 SP
+6 -9 1 1763 2052 SP
+5 0 1 1766 2064 SP
+2 4 1 1765 2020 SP
+5 0 1 1770 2017 SP
+5 -3 1 1734 2102 SP
+1 1 1 1786 2029 SP
+4 1 1 1790 2026 SP
+3 1 1 1769 2018 SP
+4 0 1 1774 2015 SP
+0 4 1 1764 2020 SP
+8 -3 1 1802 2014 SP
+{1 0 0 C} FS
+1588 2175 M
+-6 -7 D
+3 -22 D
+-1 -17 D
+-5 -22 D
+52 -22 D
+59 -29 D
+21 -11 D
+-33 27 D
+33 -27 D
+51 -29 D
+20 -12 D
+11 0 D
+-13 10 D
+10 -4 D
+-6 12 D
+11 -10 D
+16 -9 D
+13 -26 D
+11 -8 D
+-1 2 D
+6 -2 D
+-32 47 D
+-5 11 D
+-12 12 D
+-3 -3 D
+-7 4 D
+-34 36 D
+-2 8 D
+6 -7 D
+6 2 D
+-4 -5 D
+6 -8 D
+17 -11 D
+-1 5 D
+11 -10 D
+-8 15 D
+-6 3 D
+5 -1 D
+-8 4 D
+3 4 D
+-9 6 D
+-6 -1 D
+-9 9 D
+8 -4 D
+-6 4 D
+5 -1 D
+-5 7 D
+4 -4 D
+1 3 D
+3 -4 D
+-2 4 D
+6 -2 D
+-1 5 D
+7 0 D
+-5 15 D
+6 2 D
+-3 3 D
+-51 20 D
+-44 15 D
+P
+FO
+-2 2 1 1846 1962 SP
+5 -5 -6 -1 10 -5 -4 0 6 -5 -3 -3 -7 4 2 2 -4 1 -9 13 6 -5 -2 3 12 1823 2016 SP
+11 -9 -7 5 2 1771 2080 SP
+-1 -4 -6 8 2 1806 2033 SP
+4 -4 1 1769 2097 SP
+-1 3 1 1764 2087 SP
+-5 3 1 1767 2080 SP
+{0 0 0.502 C} FS
+6 -15 1 1774 2045 SP
+4 2 1 1791 2023 SP
+6 -5 1 1807 2010 SP
+6 -9 1 1763 2052 SP
+5 0 1 1766 2064 SP
+2 4 1 1765 2020 SP
+5 0 1 1770 2017 SP
+5 -3 1 1734 2102 SP
+1 1 1 1786 2029 SP
+4 1 1 1790 2026 SP
+3 1 1 1769 2018 SP
+4 0 1 1774 2015 SP
+0 4 1 1764 2020 SP
+8 -3 1 1802 2014 SP
+2 0 -4 2 2 1864 2131 SP
+1869 2125 M
+-2 0 D
+9 -14 D
+3 -1 D
+-6 5 D
+10 -7 D
+-5 6 D
+6 -5 D
+25 -36 D
+16 -32 D
+4 -10 D
+-39 24 D
+-61 33 D
+-63 29 D
+-5 4 D
+3 1 D
+5 -3 D
+-7 2 D
+9 -6 D
+16 7 D
+-5 5 D
+-9 0 D
+3 1 D
+-5 3 D
+11 -4 D
+0 4 D
+-21 7 D
+17 -5 D
+2 2 D
+-7 5 D
+9 -5 D
+0 3 D
+3 -3 D
+3 2 D
+-1 -2 D
+4 0 D
+4 -4 D
+9 5 D
+13 -9 D
+-13 10 D
+21 -9 D
+-23 14 D
+15 -8 D
+0 3 D
+8 -7 D
+4 0 D
+-4 0 D
+5 -3 D
+-2 5 D
+7 -6 D
+5 0 D
+-12 9 D
+7 -4 D
+-2 3 D
+3 -4 D
+7 0 D
+10 -7 D
+-6 4 D
+5 -1 D
+-12 8 D
+18 -12 D
+4 -1 D
+-6 4 D
+8 -6 D
+-4 5 D
+7 -6 D
+-6 7 D
+7 -7 D
+-6 8 D
+3 -4 D
+1 1 D
+-8 7 D
+9 -8 D
+0 2 D
+-6 4 D
+5 -3 D
+-2 3 D
+-9 6 D
+10 -7 D
+-7 6 D
+P
+FO
+-1 1 1 1872 2122 SP
+-3 5 -3 6 -3 5 -2 5 -2 6 -5 1 -4 1 -9 -13 9 0 12 -7 -8 0 5 -4 17 -10 13 1562 2209 SP
+-2 2 -2 3 -14 5 19 -12 4 1556 2218 SP
+-2 2 -2 2 -8 -3 15 -3 4 1546 2228 SP
+5 0 -4 3 -4 4 -3 3 -4 4 -11 1 17 -9 0 -6 8 1540 2243 SP
+1589 2237 M
+4 -2 D
+-2 2 D
+20 -4 D
+11 -5 D
+-16 5 D
+17 -8 D
+2 -5 D
+-16 7 D
+0 -2 D
+-8 6 D
+4 -6 D
+12 -7 D
+-6 0 D
+-31 20 D
+P
+FO
+0 -1 1 1629 2230 SP
+{1 0 0 C} FS
+8 2 16 -6 0 -4 -8 5 13 -9 -18 11 1 -3 -5 4 8 1859 2107 SP
+6 -4 -1 3 11 -5 -9 -1 -4 4 1 -4 -9 5 3 0 8 1827 2121 SP
+-6 2 12 -3 1 -6 -5 2 2 3 -5 -1 6 1793 2126 SP
+-4 3 6 -3 -4 2 -1 2 8 -4 5 1810 2132 SP
+-11 4 5 -1 -3 2 3 1849 2123 SP
+22 -9 -2 -2 -12 4 3 1793 2131 SP
+-8 4 -2 3 9 -3 3 1799 2128 SP
+15 -7 -4 1 2 1805 2125 SP
+-7 2 1 0 2 1832 2117 SP
+-21 6 8 -2 2 1807 2120 SP
+3 -1 1 1846 2127 SP
+4 -3 1 1855 2124 SP
+3 -1 1 1819 2127 SP
+5 -3 1 1818 2134 SP
+-3 3 1 1870 2119 SP
+-8 1 5 -1 2 1839 2125 SP
+-4 1 1 1810 2130 SP
+-3 0 1 1806 2133 SP
+-3 0 2 0 2 1800 2132 SP
+-1 2 1 1836 2124 SP
+1 1 1 1806 2129 SP
+-4 1 1 1853 2121 SP
+-6 3 1 1805 2118 SP
+{0 0 0.502 C} FS
+2 11 12 -2 12 3 -5 11 21 -2 -19 4 -6 -4 8 -8 -13 -4 -11 3 -2 -11 -5 0 12 1642 2212 SP
+-8 6 11 -8 -3 -2 7 -5 -3 6 -8 8 6 1827 2139 SP
+-4 5 4 -5 -13 6 6 -5 14 -3 5 1740 2150 SP
+-16 1 10 -2 8 -9 -9 10 6 0 5 1768 2174 SP
+11 -3 -11 3 3 -7 3 1669 2217 SP
+-6 0 11 -3 2 1731 2136 SP
+-1 3 1 1801 2159 SP
+-6 3 1 1602 2216 SP
+9 -9 1 1823 2147 SP
+-3 0 1 1638 2224 SP
+-4 0 0 -1 2 1599 2216 SP
+7 0 1 1790 2160 SP
+11 0 1 1739 2155 SP
+7 -8 1 1811 2155 SP
+7 -7 1 1805 2171 SP
+-4 1 1 1593 2221 SP
+-5 0 1 1608 2215 SP
+6 2 1 1798 2156 SP
+-6 1 1 1645 2218 SP
+8 -2 1 1728 2151 SP
+6 -3 1 1842 2142 SP
+3 0 -2 0 2 1627 2214 SP
+7 -1 1 1729 2142 SP
+9 -4 1 1744 2142 SP
+-3 -2 1 1632 2211 SP
+-4 4 4 -3 2 1797 2161 SP
+3 -3 1 1653 2218 SP
+6 -4 1 1821 2142 SP
+-5 2 1 1596 2196 SP
+1 2 1 1604 2218 SP
+{1 0 0 C} FS
+-3 4 1 0 -5 6 10 -7 -6 5 3 -1 9 -14 -2 0 -2 1 -1 2 1 -1 -1 1 12 1872 2122 SP
+1864 2131 M
+-4 2 D
+2 0 D
+-23 21 D
+-43 22 D
+-32 14 D
+-66 23 D
+-41 11 D
+-28 6 D
+0 -1 D
+0 1 D
+-18 3 D
+11 -5 D
+-16 5 D
+17 -8 D
+2 -5 D
+-16 7 D
+0 -2 D
+-8 6 D
+4 -6 D
+12 -7 D
+-6 0 D
+-31 20 D
+-40 5 D
+0 -6 D
+17 -9 D
+-11 1 D
+0 -1 D
+15 -3 D
+-8 -3 D
+3 -4 D
+19 -12 D
+-14 5 D
+1 -2 D
+22 -14 D
+-8 0 D
+12 -7 D
+9 0 D
+-9 -13 D
+91 -25 D
+72 -27 D
+15 -6 D
+-5 4 D
+3 1 D
+5 -3 D
+-7 2 D
+9 -6 D
+16 7 D
+-5 5 D
+-9 0 D
+3 1 D
+-5 3 D
+11 -4 D
+0 4 D
+-21 7 D
+17 -5 D
+2 2 D
+-7 5 D
+9 -5 D
+0 3 D
+3 -3 D
+3 2 D
+-1 -2 D
+4 0 D
+4 -4 D
+9 5 D
+13 -9 D
+-13 10 D
+21 -9 D
+-23 14 D
+15 -8 D
+0 3 D
+8 -7 D
+4 0 D
+-4 0 D
+5 -3 D
+-2 5 D
+7 -6 D
+5 0 D
+-12 9 D
+7 -4 D
+-2 3 D
+3 -4 D
+7 0 D
+10 -7 D
+-6 4 D
+5 -1 D
+-12 8 D
+18 -12 D
+4 -1 D
+-6 4 D
+8 -6 D
+-4 5 D
+7 -6 D
+-6 7 D
+7 -7 D
+-6 8 D
+3 -4 D
+1 1 D
+-8 7 D
+9 -8 D
+0 2 D
+-6 4 D
+5 -3 D
+-2 3 D
+-9 6 D
+10 -7 D
+-7 6 D
+10 -7 D
+P
+FO
+-1 0 -2 2 4 -2 3 1589 2237 SP
+8 2 16 -6 0 -4 -8 5 13 -9 -18 11 1 -3 -5 4 8 1859 2107 SP
+6 -4 -1 3 11 -5 -9 -1 -4 4 1 -4 -9 5 3 0 8 1827 2121 SP
+-6 2 12 -3 1 -6 -5 2 2 3 -5 -1 6 1793 2126 SP
+-4 3 6 -3 -4 2 -1 2 8 -4 5 1810 2132 SP
+-11 4 5 -1 -3 2 3 1849 2123 SP
+22 -9 -2 -2 -12 4 3 1793 2131 SP
+-8 4 -2 3 9 -3 3 1799 2128 SP
+15 -7 -4 1 2 1805 2125 SP
+-7 2 1 0 2 1832 2117 SP
+-21 6 8 -2 2 1807 2120 SP
+3 -1 1 1846 2127 SP
+4 -3 1 1855 2124 SP
+3 -1 1 1819 2127 SP
+5 -3 1 1818 2134 SP
+-3 3 1 1870 2119 SP
+-8 1 5 -1 2 1839 2125 SP
+-4 1 1 1810 2130 SP
+-3 0 1 1806 2133 SP
+-3 0 2 0 2 1800 2132 SP
+-1 2 1 1836 2124 SP
+1 1 1 1806 2129 SP
+-4 1 1 1853 2121 SP
+-6 3 1 1805 2118 SP
+{0 0 0.502 C} FS
+2 11 12 -2 12 3 -5 11 21 -2 -19 4 -6 -4 8 -8 -13 -4 -11 3 -2 -11 -5 0 12 1642 2212 SP
+-8 6 11 -8 -3 -2 7 -5 -3 6 -8 8 6 1827 2139 SP
+-4 5 4 -5 -13 6 6 -5 14 -3 5 1740 2150 SP
+-16 1 10 -2 8 -9 -9 10 6 0 5 1768 2174 SP
+11 -3 -11 3 3 -7 3 1669 2217 SP
+-6 0 11 -3 2 1731 2136 SP
+-1 3 1 1801 2159 SP
+-6 3 1 1602 2216 SP
+9 -9 1 1823 2147 SP
+-3 0 1 1638 2224 SP
+-4 0 0 -1 2 1599 2216 SP
+7 0 1 1790 2160 SP
+11 0 1 1739 2155 SP
+7 -8 1 1811 2155 SP
+7 -7 1 1805 2171 SP
+-4 1 1 1593 2221 SP
+-5 0 1 1608 2215 SP
+6 2 1 1798 2156 SP
+-6 1 1 1645 2218 SP
+8 -2 1 1728 2151 SP
+6 -3 1 1842 2142 SP
+3 0 -2 0 2 1627 2214 SP
+7 -1 1 1729 2142 SP
+9 -4 1 1744 2142 SP
+-3 -2 1 1632 2211 SP
+-4 4 4 -3 2 1797 2161 SP
+3 -3 1 1653 2218 SP
+6 -4 1 1821 2142 SP
+-5 2 1 1596 2196 SP
+1 2 1 1604 2218 SP
+-2 1 1 1817 2172 SP
+-1 0 1 1821 2169 SP
+-5 3 1 1835 2158 SP
+1 0 1 1629 2230 SP
+-6 2 -7 1 5 -3 7 0 7 -7 16 -3 -10 4 -5 5 8 1591 2237 SP
+-5 1 10 -4 0 2 -1 1 4 1580 2238 SP
+1521 2251 M
+7 2 D
+-6 9 D
+6 0 D
+-23 13 D
+-23 6 D
+0 4 D
+-19 9 D
+-4 -2 D
+10 -2 D
+-6 -1 D
+-14 5 D
+1 1 D
+-4 0 D
+-5 2 D
+28 2 D
+14 -6 D
+0 -3 D
+9 -4 D
+-5 -3 D
+23 -8 D
+-5 4 D
+-15 5 D
+23 -7 D
+4 3 D
+4 0 D
+2 -2 D
+6 1 D
+-3 -4 D
+-6 2 D
+0 -5 D
+14 -6 D
+13 -10 D
+-5 0 D
+-10 4 D
+-2 -3 D
+8 -6 D
+2 -8 D
+-4 0 D
+-5 0 D
+P
+FO
+1 0 -12 5 9 -5 3 1493 2300 SP
+-6 2 4 -2 2 1508 2299 SP
+3 0 -7 2 2 -2 3 1536 2297 SP
+0 -1 1 1545 2296 SP
+2 0 -4 1 0 -1 3 1563 2293 SP
+1 -1 1 1567 2292 SP
+1 0 1 1574 2290 SP
+-2 1 5 -2 -8 3 -8 4 6 -3 1 -1 2 0 -1 0 4 -2 9 1630 2274 SP
+-2 1 -1 0 -5 2 -3 1 5 -2 5 1644 2268 SP
+{1 0 0 C} FS
+-3 1 1 1487 2286 SP
+2 1 1 1457 2297 SP
+{0 0 0.502 C} FS
+36 -14 10 -5 -6 3 8 -4 -4 2 -12 6 6 -2 17 -9 -9 6 -29 12 -3 8 -6 -2 -7 4 -11 3 -7 7 8 -9 16 1652 2239 SP
+15 -4 -18 6 -5 1 -8 3 5 -1 -9 2 6 1631 2271 SP
+-7 3 -1 2 -3 0 16 -7 0 2 5 1667 2250 SP
+20 -9 25 -13 -21 13 -24 10 4 1660 2247 SP
+-4 -1 -1 2 0 -2 9 -1 4 1556 2261 SP
+-12 6 18 -9 2 1720 2232 SP
+-10 3 6 -3 11 -3 3 1601 2279 SP
+-1 1 -2 1 9 -4 3 1671 2251 SP
+-6 3 3 -1 -8 2 3 1589 2279 SP
+0 2 5 -2 -7 3 3 1580 2274 SP
+-6 3 7 -5 2 1581 2264 SP
+-1 -1 17 -5 -15 6 3 1609 2262 SP
+-10 5 -1 -1 10 -4 3 1567 2269 SP
+1 1 -14 4 2 1588 2276 SP
+-13 9 12 -10 2 1660 2230 SP
+13 -2 -16 5 2 1540 2291 SP
+5 -3 0 1 2 1680 2248 SP
+3 0 -9 2 2 1600 2276 SP
+-12 5 14 -9 2 1561 2277 SP
+5 -1 -5 7 2 1577 2255 SP
+-5 2 2 -4 2 1630 2238 SP
+10 -4 3 -1 2 1637 2264 SP
+-8 2 1 -1 2 1578 2286 SP
+5 -3 2 0 2 1608 2281 SP
+6 -2 1 1600 2250 SP
+-7 2 1 1670 2242 SP
+6 -2 1 5 2 1557 2266 SP
+10 -5 1 1653 2262 SP
+-19 8 1 1593 2260 SP
+6 -6 1 1730 2216 SP
+7 -1 1 1602 2240 SP
+-13 3 1 1566 2289 SP
+-11 4 1 1611 2270 SP
+-11 3 1 1581 2283 SP
+-4 2 -5 1 2 1551 2290 SP
+0 3 1 1499 2291 SP
+7 -4 1 1660 2237 SP
+11 -5 1 1471 2287 SP
+-14 4 1 0 2 1583 2270 SP
+6 -4 1 1669 2229 SP
+10 -4 1 1609 2273 SP
+-9 3 1 1630 2241 SP
+1 -2 1 1575 2272 SP
+9 -4 1 1645 2266 SP
+-6 1 1 1621 2240 SP
+-5 2 1 1626 2253 SP
+-3 1 1 1638 2251 SP
+5 -2 1 1545 2264 SP
+3 -1 1 1563 2271 SP
+-5 2 1 1613 2258 SP
+2 0 1 1639 2268 SP
+8 -2 1 1552 2243 SP
+-9 4 1 1609 2280 SP
+5 -2 1 1638 2269 SP
+-9 2 1 1581 2280 SP
+-1 2 1 1630 2259 SP
+6 -4 1 1697 2239 SP
+-7 2 1 1562 2286 SP
+7 -3 1 1671 2254 SP
+5 -2 1 1630 2273 SP
+2 -3 1 1690 2220 SP
+10 -6 1 1815 2169 SP
+5 -1 1 1608 2241 SP
+4 -2 1 1704 2235 SP
+-6 3 1 1565 2279 SP
+5 -1 1 1570 2264 SP
+5 -2 1 1665 2255 SP
+2 1 1 1795 2179 SP
+1 -2 1 1666 2229 SP
+5 -2 1 1624 2275 SP
+-6 1 1 1565 2287 SP
+6 -3 1 1662 2259 SP
+-2 2 1 1564 2283 SP
+-5 2 1 1544 2293 SP
+4 -1 1 1634 2271 SP
+10 -6 1 1813 2173 SP
+-2 0 1 1567 2278 SP
+-9 3 1 1623 2258 SP
+4 -1 1 1594 2285 SP
+5 -2 1 1677 2250 SP
+4 -2 1 1704 2240 SP
+6 -2 1 1611 2242 SP
+-4 1 1 1591 2284 SP
+5 -3 1 1654 2262 SP
+8 -3 1 1585 2264 SP
+6 -2 1 1622 2275 SP
+5 -2 1 1619 2271 SP
+4 -2 1 1634 2271 SP
+4 -2 1 1623 2276 SP
+11 -6 1 1590 2256 SP
+3 -1 1 1616 2273 SP
+0 1 1 1717 2226 SP
+-4 0 1 1552 2289 SP
+3 -1 1 1593 2281 SP
+-6 1 1 1619 2258 SP
+3 -2 1 1505 2272 SP
+-5 2 1 1584 2266 SP
+2 0 1 1677 2245 SP
+2 -1 1 1688 2246 SP
+-7 3 1 1573 2275 SP
+-3 2 2 -2 2 1570 2261 SP
+-6 2 1 1570 2284 SP
+1 -2 1 1653 2229 SP
+5 -2 1 1657 2259 SP
+-3 1 1 1572 2277 SP
+-5 2 1 1607 2272 SP
+5 -1 1 1613 2278 SP
+4 -2 1 1646 2266 SP
+3 -1 1 1623 2266 SP
+4 -2 1 1623 2273 SP
+1 2 1 1578 2260 SP
+5 -1 1 1605 2246 SP
+3 -2 1 1489 2275 SP
+1 2 1 1562 2248 SP
+5 -2 1 1572 2263 SP
+-4 1 1 1626 2257 SP
+-5 3 5 -2 2 1504 2270 SP
+-5 2 1 1579 2268 SP
+{1 0 0 C} FS
+6 -3 1 1618 2255 SP
+9 -4 1 1618 2255 SP
+1835 2158 M
+-5 3 D
+5 -3 D
+-15 11 D
+1 0 D
+-6 4 D
+2 -1 D
+-46 32 D
+-39 22 D
+-63 31 D
+-25 11 D
+5 -2 D
+-13 5 D
+6 -3 D
+-16 7 D
+5 -2 D
+-49 16 D
+-8 1 D
+1 0 D
+-1 0 D
+-7 2 D
+1 -1 D
+-5 2 D
+0 -1 D
+-18 4 D
+0 -1 D
+0 1 D
+-9 1 D
+2 -2 D
+-7 2 D
+3 0 D
+-26 2 D
+4 -2 D
+-10 2 D
+-9 1 D
+9 -5 D
+-12 5 D
+-7 0 D
+-7 -1 D
+-7 0 D
+14 -6 D
+0 -3 D
+9 -4 D
+-5 -3 D
+23 -8 D
+-5 4 D
+-15 5 D
+23 -7 D
+4 3 D
+4 0 D
+2 -2 D
+6 1 D
+-3 -4 D
+-6 2 D
+0 -5 D
+14 -6 D
+13 -10 D
+-5 0 D
+-10 4 D
+-2 -3 D
+8 -6 D
+2 -8 D
+40 -5 D
+-1 3 D
+12 -4 D
+-5 5 D
+-10 4 D
+16 -3 D
+7 -7 D
+7 0 D
+5 -3 D
+19 -3 D
+-1 0 D
+62 -15 D
+47 -15 D
+45 -18 D
+50 -24 D
+6 -4 D
+P
+FO
+-1 1 -1 0 4 -2 3 1630 2274 SP
+1521 2251 M
+7 2 D
+-6 9 D
+6 0 D
+-23 13 D
+-23 6 D
+0 4 D
+-19 9 D
+-4 -2 D
+10 -2 D
+-6 -1 D
+-14 5 D
+1 1 D
+-4 0 D
+41 -21 D
+28 -18 D
+P
+FO
+-3 1 1 1487 2286 SP
+2 1 1 1457 2297 SP
+{0 0 0.502 C} FS
+36 -14 10 -5 -6 3 8 -4 -4 2 -12 6 6 -2 17 -9 -9 6 -29 12 -3 8 -6 -2 -7 4 -11 3 -7 7 8 -9 16 1652 2239 SP
+15 -4 -18 6 -5 1 -8 3 5 -1 -9 2 6 1631 2271 SP
+-7 3 -1 2 -3 0 16 -7 0 2 5 1667 2250 SP
+20 -9 25 -13 -21 13 -24 10 4 1660 2247 SP
+-4 -1 -1 2 0 -2 9 -1 4 1556 2261 SP
+-12 6 18 -9 2 1720 2232 SP
+-10 3 6 -3 11 -3 3 1601 2279 SP
+-1 1 -2 1 9 -4 3 1671 2251 SP
+-6 3 3 -1 -8 2 3 1589 2279 SP
+0 2 5 -2 -7 3 3 1580 2274 SP
+-6 3 7 -5 2 1581 2264 SP
+-1 -1 17 -5 -15 6 3 1609 2262 SP
+-10 5 -1 -1 10 -4 3 1567 2269 SP
+1 1 -14 4 2 1588 2276 SP
+-13 9 12 -10 2 1660 2230 SP
+13 -2 -16 5 2 1540 2291 SP
+5 -3 0 1 2 1680 2248 SP
+3 0 -9 2 2 1600 2276 SP
+-12 5 14 -9 2 1561 2277 SP
+5 -1 -5 7 2 1577 2255 SP
+-5 2 2 -4 2 1630 2238 SP
+10 -4 3 -1 2 1637 2264 SP
+-8 2 1 -1 2 1578 2286 SP
+5 -3 2 0 2 1608 2281 SP
+6 -2 1 1600 2250 SP
+-7 2 1 1670 2242 SP
+6 -2 1 5 2 1557 2266 SP
+10 -5 1 1653 2262 SP
+-19 8 1 1593 2260 SP
+6 -6 1 1730 2216 SP
+7 -1 1 1602 2240 SP
+-13 3 1 1566 2289 SP
+-11 4 1 1611 2270 SP
+-11 3 1 1581 2283 SP
+-4 2 -5 1 2 1551 2290 SP
+0 3 1 1499 2291 SP
+7 -4 1 1660 2237 SP
+11 -5 1 1471 2287 SP
+-14 4 1 0 2 1583 2270 SP
+6 -4 1 1669 2229 SP
+10 -4 1 1609 2273 SP
+-9 3 1 1630 2241 SP
+1 -2 1 1575 2272 SP
+9 -4 1 1645 2266 SP
+-6 1 1 1621 2240 SP
+-5 2 1 1626 2253 SP
+-3 1 1 1638 2251 SP
+5 -2 1 1545 2264 SP
+3 -1 1 1563 2271 SP
+-5 2 1 1613 2258 SP
+2 0 1 1639 2268 SP
+8 -2 1 1552 2243 SP
+-9 4 1 1609 2280 SP
+5 -2 1 1638 2269 SP
+-9 2 1 1581 2280 SP
+-1 2 1 1630 2259 SP
+6 -4 1 1697 2239 SP
+-7 2 1 1562 2286 SP
+7 -3 1 1671 2254 SP
+5 -2 1 1630 2273 SP
+2 -3 1 1690 2220 SP
+10 -6 1 1815 2169 SP
+5 -1 1 1608 2241 SP
+4 -2 1 1704 2235 SP
+-6 3 1 1565 2279 SP
+5 -1 1 1570 2264 SP
+5 -2 1 1665 2255 SP
+2 1 1 1795 2179 SP
+1 -2 1 1666 2229 SP
+5 -2 1 1624 2275 SP
+-6 1 1 1565 2287 SP
+6 -3 1 1662 2259 SP
+-2 2 1 1564 2283 SP
+-5 2 1 1544 2293 SP
+4 -1 1 1634 2271 SP
+10 -6 1 1813 2173 SP
+-2 0 1 1567 2278 SP
+-9 3 1 1623 2258 SP
+4 -1 1 1594 2285 SP
+5 -2 1 1677 2250 SP
+4 -2 1 1704 2240 SP
+6 -2 1 1611 2242 SP
+-4 1 1 1591 2284 SP
+5 -3 1 1654 2262 SP
+8 -3 1 1585 2264 SP
+6 -2 1 1622 2275 SP
+5 -2 1 1619 2271 SP
+4 -2 1 1634 2271 SP
+4 -2 1 1623 2276 SP
+11 -6 1 1590 2256 SP
+3 -1 1 1616 2273 SP
+0 1 1 1717 2226 SP
+-4 0 1 1552 2289 SP
+3 -1 1 1593 2281 SP
+-6 1 1 1619 2258 SP
+3 -2 1 1505 2272 SP
+-5 2 1 1584 2266 SP
+2 0 1 1677 2245 SP
+2 -1 1 1688 2246 SP
+-7 3 1 1573 2275 SP
+-3 2 2 -2 2 1570 2261 SP
+-6 2 1 1570 2284 SP
+1 -2 1 1653 2229 SP
+5 -2 1 1657 2259 SP
+-3 1 1 1572 2277 SP
+-5 2 1 1607 2272 SP
+5 -1 1 1613 2278 SP
+4 -2 1 1646 2266 SP
+3 -1 1 1623 2266 SP
+4 -2 1 1623 2273 SP
+1 2 1 1578 2260 SP
+5 -1 1 1605 2246 SP
+3 -2 1 1489 2275 SP
+1 2 1 1562 2248 SP
+5 -2 1 1572 2263 SP
+-4 1 1 1626 2257 SP
+-5 3 5 -2 2 1504 2270 SP
+-5 2 1 1579 2268 SP
+{1 0 0 C} FS
+6 -3 1 1618 2255 SP
+9 -4 1 1618 2255 SP
+{0 0 0.502 C} FS
+-1 1 2 -1 2 -1 -1 1 4 1633 2272 SP
+7 -2 -6 2 2 1629 2274 SP
+-3 2 1 1574 2290 SP
+-3 1 1 1567 2292 SP
+-2 0 2 -1 5 -1 4 -1 -2 1 13 -4 -11 4 -7 2 8 1559 2293 SP
+1 0 1 0 2 1534 2297 SP
+9 -4 14 -4 -21 8 3 1506 2299 SP
+-2 0 1 0 12 -3 -10 3 4 1490 2300 SP
+1419 2305 M
+2 1 D
+-11 6 D
+6 -2 D
+8 1 D
+-7 1 D
+2 1 D
+18 -3 D
+9 1 D
+4 -3 D
+-13 0 D
+8 -1 D
+-5 0 D
+13 -5 D
+2 2 D
+-6 2 D
+6 0 D
+1 -4 D
+7 0 D
+6 -3 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+P
+FO
+1361 2323 M
+-29 7 D
+1 -1 D
+-6 3 D
+2 -2 D
+-10 2 D
+2 1 D
+6 -1 D
+-5 1 D
+26 9 D
+29 3 D
+41 -7 D
+39 -8 D
+73 -21 D
+-13 3 D
+12 -4 D
+0 -1 D
+-41 9 D
+1 -1 D
+-21 5 D
+2 -1 D
+-17 4 D
+11 -4 D
+-4 0 D
+11 -4 D
+-21 8 D
+-26 6 D
+-18 2 D
+23 -9 D
+-9 2 D
+-12 6 D
+-19 1 D
+4 -2 D
+-19 6 D
+4 -3 D
+-9 2 D
+0 2 D
+-24 1 D
+3 -4 D
+-11 1 D
+4 -2 D
+-7 1 D
+10 -4 D
+-6 1 D
+18 -5 D
+4 4 D
+6 -2 D
+18 2 D
+9 -2 D
+-11 -4 D
+4 -3 D
+16 0 D
+-4 -4 D
+-8 2 D
+14 -5 D
+-5 -1 D
+P
+FO
+{1 0 0 C} FS
+0 1 -27 4 1 1 -13 3 12 -2 20 1 -1 -2 6 -1 14 -5 -5 -1 10 -1 4 -2 -9 1 13 1370 2343 SP
+5 -7 -13 2 -10 6 3 1449 2301 SP
+-22 3 11 -1 2 1392 2339 SP
+7 -3 -6 2 2 1378 2335 SP
+-4 -1 0 1 2 1381 2327 SP
+0 2 1 1427 2305 SP
+3 1 1 1383 2333 SP
+{0 0 0.502 C} FS
+1 0 1 -1 -6 2 -2 1 -6 3 -9 3 6 1627 2275 SP
+1 -2 5 -1 2 1494 2307 SP
+6 -2 2 1 2 1465 2306 SP
+-6 3 -1 -1 6 -2 3 1466 2320 SP
+17 -6 7 -2 -13 4 3 1584 2290 SP
+6 -2 3 0 -8 2 3 1517 2303 SP
+6 -2 1 1576 2294 SP
+14 -6 1 1471 2315 SP
+-2 -1 1 1525 2304 SP
+17 -6 1 1587 2290 SP
+-8 2 1 1526 2298 SP
+-8 2 1 1501 2310 SP
+4 0 1 1500 2304 SP
+-7 1 1 1498 2310 SP
+-6 1 1 1513 2301 SP
+-6 1 1 1515 2299 SP
+9 -3 1 1589 2289 SP
+5 -1 1 1342 2333 SP
+3 0 1 1407 2311 SP
+4 0 1 1469 2307 SP
+4 -2 1 1594 2288 SP
+9 -3 1 1573 2295 SP
+-2 -1 1 1505 2311 SP
+9 -3 0 1 2 1565 2297 SP
+4 1 1 1408 2312 SP
+6 -2 1 1573 2294 SP
+-5 1 4 -1 2 1555 2301 SP
+2 -1 1 1489 2309 SP
+8 -3 1 1580 2290 SP
+5 -2 1 1566 2297 SP
+7 -2 1 1573 2295 SP
+-2 0 3 0 2 1481 2314 SP
+7 -2 1 1561 2299 SP
+-5 1 1 1505 2305 SP
+-1 1 1 1507 2309 SP
+7 -2 -1 0 2 1606 2283 SP
+5 -1 1 1569 2296 SP
+-8 3 7 -3 2 1489 2310 SP
+0 -1 1 1535 2303 SP
+4 -2 1 1624 2276 SP
+2 -1 1 1622 2277 SP
+5 -2 1 1504 2302 SP
+4 -2 1 1609 2282 SP
+5 -1 1 1555 2299 SP
+-5 2 5 -1 2 1591 2288 SP
+2 -1 1 1402 2327 SP
+6 -2 1 1582 2292 SP
+7 -3 1 1601 2285 SP
+-5 2 1 1559 2297 SP
+-7 2 6 -2 2 1568 2297 SP
+2 -1 1 1393 2329 SP
+6 -3 1 1586 2291 SP
+5 -2 1 1589 2289 SP
+{1 0 0 C} FS
+1495 2320 M
+35 -11 D
+-13 3 D
+12 -4 D
+0 -1 D
+-41 9 D
+1 -1 D
+-21 5 D
+2 -1 D
+-17 4 D
+11 -4 D
+-4 0 D
+11 -4 D
+-21 8 D
+-26 6 D
+-18 2 D
+23 -9 D
+-9 2 D
+-12 6 D
+-19 1 D
+4 -2 D
+-19 6 D
+4 -3 D
+-9 2 D
+0 2 D
+-24 1 D
+3 -4 D
+-11 1 D
+4 -2 D
+-7 1 D
+10 -4 D
+-6 1 D
+18 -5 D
+4 4 D
+6 -2 D
+18 2 D
+9 -2 D
+-11 -4 D
+4 -3 D
+16 0 D
+-4 -4 D
+-8 2 D
+14 -5 D
+-5 -1 D
+20 -7 D
+2 1 D
+-11 6 D
+6 -2 D
+8 1 D
+-7 1 D
+2 1 D
+18 -3 D
+9 1 D
+4 -3 D
+-13 0 D
+8 -1 D
+-5 0 D
+13 -5 D
+2 2 D
+-6 2 D
+6 0 D
+1 -4 D
+7 0 D
+6 -3 D
+21 1 D
+-10 3 D
+22 -4 D
+4 0 D
+-21 8 D
+23 -8 D
+42 -4 D
+9 -2 D
+-18 6 D
+13 -4 D
+-2 1 D
+15 -4 D
+-3 1 D
+10 -3 D
+-3 2 D
+3 -2 D
+16 -3 D
+39 -13 D
+-6 2 D
+10 -4 D
+-1 1 D
+6 -3 D
+-59 23 D
+P
+FO
+-5 1 6 -1 2 1321 2333 SP
+-1 0 1 1320 2332 SP
+1 0 2 -2 -5 2 3 1332 2330 SP
+7 -2 8 -1 1 -1 -23 5 4 1355 2325 SP
+0 1 -27 4 1 1 -13 3 12 -2 20 1 -1 -2 6 -1 14 -5 -5 -1 10 -1 4 -2 -9 1 13 1370 2343 SP
+5 -7 -13 2 -10 6 3 1449 2301 SP
+-22 3 11 -1 2 1392 2339 SP
+7 -3 -6 2 2 1378 2335 SP
+-4 -1 0 1 2 1381 2327 SP
+0 2 1 1427 2305 SP
+3 1 1 1383 2333 SP
+{0 0 0.502 C} FS
+1 0 1 -1 -6 2 -2 1 -6 3 -9 3 6 1627 2275 SP
+1 -2 5 -1 2 1494 2307 SP
+6 -2 2 1 2 1465 2306 SP
+-6 3 -1 -1 6 -2 3 1466 2320 SP
+17 -6 7 -2 -13 4 3 1584 2290 SP
+6 -2 3 0 -8 2 3 1517 2303 SP
+6 -2 1 1576 2294 SP
+14 -6 1 1471 2315 SP
+-2 -1 1 1525 2304 SP
+17 -6 1 1587 2290 SP
+-8 2 1 1526 2298 SP
+-8 2 1 1501 2310 SP
+4 0 1 1500 2304 SP
+-7 1 1 1498 2310 SP
+-6 1 1 1513 2301 SP
+-6 1 1 1515 2299 SP
+9 -3 1 1589 2289 SP
+5 -1 1 1342 2333 SP
+3 0 1 1407 2311 SP
+4 0 1 1469 2307 SP
+4 -2 1 1594 2288 SP
+9 -3 1 1573 2295 SP
+-2 -1 1 1505 2311 SP
+9 -3 0 1 2 1565 2297 SP
+4 1 1 1408 2312 SP
+6 -2 1 1573 2294 SP
+-5 1 4 -1 2 1555 2301 SP
+2 -1 1 1489 2309 SP
+8 -3 1 1580 2290 SP
+5 -2 1 1566 2297 SP
+7 -2 1 1573 2295 SP
+-2 0 3 0 2 1481 2314 SP
+7 -2 1 1561 2299 SP
+-5 1 1 1505 2305 SP
+-1 1 1 1507 2309 SP
+7 -2 -1 0 2 1606 2283 SP
+5 -1 1 1569 2296 SP
+-8 3 7 -3 2 1489 2310 SP
+0 -1 1 1535 2303 SP
+4 -2 1 1624 2276 SP
+2 -1 1 1622 2277 SP
+5 -2 1 1504 2302 SP
+4 -2 1 1609 2282 SP
+5 -1 1 1555 2299 SP
+-5 2 5 -1 2 1591 2288 SP
+2 -1 1 1402 2327 SP
+6 -2 1 1582 2292 SP
+7 -3 1 1601 2285 SP
+-5 2 1 1559 2297 SP
+-7 2 6 -2 2 1568 2297 SP
+2 -1 1 1393 2329 SP
+6 -3 1 1586 2291 SP
+5 -2 1 1589 2289 SP
+1393 2343 M
+-29 3 D
+8 -1 D
+-4 0 D
+-5 -1 D
+-5 0 D
+-5 -1 D
+-5 -1 D
+-5 -1 D
+-6 -2 D
+-5 -2 D
+-5 -2 D
+-5 -2 D
+-5 0 D
+4 0 D
+-2 -1 D
+-7 2 D
+0 -1 D
+-6 1 D
+-1 2 D
+-6 -1 D
+4 1 D
+-7 1 D
+-2 2 D
+10 1 D
+-10 0 D
+-7 3 D
+-4 0 D
+-6 5 D
+9 0 D
+-7 1 D
+21 -1 D
+-5 2 D
+33 -4 D
+11 0 D
+-30 5 D
+-2 -1 D
+-24 5 D
+9 -1 D
+-53 6 D
+24 -4 D
+-11 2 D
+1 -1 D
+-26 3 D
+2 -2 D
+-6 1 D
+9 -1 D
+-6 0 D
+14 -2 D
+3 -2 D
+8 0 D
+0 -1 D
+-10 1 D
+5 -2 D
+-20 2 D
+4 1 D
+-13 -1 D
+11 1 D
+-16 2 D
+-1 -2 D
+-7 1 D
+2 -1 D
+-9 1 D
+8 -1 D
+-11 0 D
+5 -1 D
+-7 0 D
+5 -1 D
+6 1 D
+9 -1 D
+-6 -1 D
+6 1 D
+-3 -1 D
+10 1 D
+-6 -1 D
+6 0 D
+-7 0 D
+10 -1 D
+-4 -1 D
+5 1 D
+3 -1 D
+2 1 D
+-1 -2 D
+4 1 D
+-1 -1 D
+11 -1 D
+-9 0 D
+19 -3 D
+-12 1 D
+8 -1 D
+-7 0 D
+7 -1 D
+-17 2 D
+3 -2 D
+20 -1 D
+-21 1 D
+0 -1 D
+1 0 D
+-52 1 D
+0 18 D
+48 -1 D
+-3 0 D
+56 -3 D
+-1 0 D
+11 -1 D
+-17 1 D
+21 -2 D
+-2 0 D
+16 -3 D
+10 0 D
+33 -5 D
+-3 1 D
+11 -1 D
+-7 1 D
+P
+FO
+-8 0 9 0 2 1244 2342 SP
+{1 0 0 C} FS
+-13 1 8 2 10 -2 3 1297 2343 SP
+8 -2 -5 1 2 1346 2347 SP
+-9 2 7 -1 2 1287 2344 SP
+7 -1 -3 0 2 1230 2361 SP
+1 1 1 1292 2341 SP
+-9 0 1 1321 2336 SP
+1 0 1 1263 2359 SP
+1 -1 1 1336 2349 SP
+1 1 1 1302 2337 SP
+7 0 1 1308 2335 SP
+-6 0 1 1228 2360 SP
+-5 0 1 1231 2361 SP
+-3 1 1 1222 2359 SP
+6 -1 1 1312 2353 SP
+{0 0 0.502 C} FS
+-4 -1 13 -1 2 1272 2354 SP
+12 -2 1 0 -8 1 3 1329 2353 SP
+3 -1 1 1341 2351 SP
+4 -1 1 1293 2357 SP
+4 -1 1 1233 2352 SP
+-5 0 1 1287 2342 SP
+16 -2 1 1316 2354 SP
+6 -1 1 1318 2354 SP
+-9 1 1 1324 2353 SP
+2 0 1 1336 2351 SP
+1 0 1 1320 2354 SP
+4 0 -1 0 2 1303 2356 SP
+2 0 1 1334 2352 SP
+4 0 1 1290 2338 SP
+{1 0 0 C} FS
+1228 2361 M
+1 0 D
+-3 0 D
+56 -3 D
+-1 0 D
+11 -1 D
+-17 1 D
+21 -2 D
+-2 0 D
+16 -3 D
+10 0 D
+33 -5 D
+-3 1 D
+11 -1 D
+-7 1 D
+23 -3 D
+-81 11 D
+P
+FO
+1244 2342 M
+9 0 D
+-8 0 D
+51 -6 D
+10 -2 D
+-1 2 D
+-6 -1 D
+4 1 D
+-7 1 D
+-2 2 D
+10 1 D
+-10 0 D
+-7 3 D
+-4 0 D
+-6 5 D
+9 0 D
+-7 1 D
+21 -1 D
+-5 2 D
+33 -4 D
+11 0 D
+-30 5 D
+-2 -1 D
+-24 5 D
+9 -1 D
+-53 6 D
+24 -4 D
+-11 2 D
+1 -1 D
+-26 3 D
+2 -2 D
+-6 1 D
+9 -1 D
+-6 0 D
+14 -2 D
+3 -2 D
+8 0 D
+0 -1 D
+-10 1 D
+5 -2 D
+-20 2 D
+4 1 D
+-13 -1 D
+11 1 D
+-16 2 D
+-1 -2 D
+-7 1 D
+2 -1 D
+-9 1 D
+8 -1 D
+-11 0 D
+5 -1 D
+-7 0 D
+5 -1 D
+6 1 D
+9 -1 D
+-6 -1 D
+6 1 D
+-3 -1 D
+10 1 D
+-6 -1 D
+6 0 D
+-7 0 D
+10 -1 D
+-4 -1 D
+5 1 D
+3 -1 D
+2 1 D
+-1 -2 D
+4 1 D
+-1 -1 D
+11 -1 D
+-9 0 D
+19 -3 D
+-12 1 D
+8 -1 D
+-7 0 D
+7 -1 D
+-17 2 D
+3 -2 D
+20 -1 D
+-21 1 D
+0 -1 D
+P
+FO
+4 0 0 -1 -7 2 3 1319 2332 SP
+4 0 -5 0 2 1322 2333 SP
+1 -1 -8 1 2 1372 2345 SP
+-13 1 8 2 10 -2 3 1297 2343 SP
+8 -2 -5 1 2 1346 2347 SP
+-9 2 7 -1 2 1287 2344 SP
+7 -1 -3 0 2 1230 2361 SP
+1 1 1 1292 2341 SP
+-9 0 1 1321 2336 SP
+1 0 1 1263 2359 SP
+1 -1 1 1336 2349 SP
+1 1 1 1302 2337 SP
+7 0 1 1308 2335 SP
+-6 0 1 1228 2360 SP
+-5 0 1 1231 2361 SP
+-3 1 1 1222 2359 SP
+6 -1 1 1312 2353 SP
+{0 0 0.502 C} FS
+-4 -1 13 -1 2 1272 2354 SP
+12 -2 1 0 -8 1 3 1329 2353 SP
+3 -1 1 1341 2351 SP
+4 -1 1 1293 2357 SP
+4 -1 1 1233 2352 SP
+-5 0 1 1287 2342 SP
+16 -2 1 1316 2354 SP
+6 -1 1 1318 2354 SP
+-9 1 1 1324 2353 SP
+2 0 1 1336 2351 SP
+1 0 1 1320 2354 SP
+4 0 -1 0 2 1303 2356 SP
+2 0 1 1334 2352 SP
+4 0 1 1290 2338 SP
+1181 2362 M
+0 -18 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 -1 D
+-1 2 D
+-11 -1 D
+3 2 D
+-12 -2 D
+7 -1 D
+-6 -1 D
+-6 0 D
+-6 -1 D
+4 3 D
+-9 0 D
+8 1 D
+-5 1 D
+20 2 D
+-19 -2 D
+4 2 D
+-9 0 D
+23 1 D
+-10 0 D
+9 0 D
+2 2 D
+-15 -3 D
+5 1 D
+-15 -1 D
+26 3 D
+-19 -1 D
+19 2 D
+-14 0 D
+10 1 D
+-9 -1 D
+10 1 D
+-5 0 D
+4 1 D
+-19 -3 D
+-6 0 D
+24 3 D
+-15 -1 D
+12 2 D
+-7 0 D
+-10 -2 D
+-7 0 D
+17 2 D
+-5 0 D
+1 1 D
+-8 -1 D
+7 1 D
+-2 1 D
+-11 -2 D
+5 -1 D
+-15 1 D
+12 0 D
+-7 0 D
+13 1 D
+-15 -1 D
+14 2 D
+-7 -1 D
+5 1 D
+-9 -1 D
+6 1 D
+-10 -1 D
+8 1 D
+-10 -1 D
+2 1 D
+-6 -1 D
+4 1 D
+-10 -1 D
+3 1 D
+-8 -1 D
+5 1 D
+-5 -1 D
+2 1 D
+-6 -1 D
+6 1 D
+-9 -1 D
+7 1 D
+-12 -1 D
+-4 -1 D
+-22 -2 D
+8 1 D
+-7 -1 D
+4 1 D
+-7 -1 D
+-2 0 D
+-4 -1 D
+3 0 D
+-5 0 D
+-5 -1 D
+-11 -1 D
+13 1 D
+-13 -2 D
+8 1 D
+-7 -1 D
+9 1 D
+-9 -1 D
+7 1 D
+-7 -1 D
+7 1 D
+-8 -2 D
+7 1 D
+-6 -1 D
+11 1 D
+-9 -1 D
+11 1 D
+-12 -2 D
+6 0 D
+-8 -1 D
+7 1 D
+-7 -1 D
+5 1 D
+-7 -2 D
+8 1 D
+-10 -1 D
+13 1 D
+-10 -2 D
+12 0 D
+-9 -1 D
+1 -1 D
+-32 3 D
+-5 -1 D
+-6 -1 D
+86 13 D
+88 6 D
+P
+FO
+{1 0 0 C} FS
+-9 0 1 1017 2344 SP
+2 -1 1 1117 2343 SP
+6 1 1 1014 2350 SP
+-7 0 1 1129 2347 SP
+-2 -1 1 1033 2353 SP
+-4 0 1 1048 2354 SP
+-6 0 1 1120 2348 SP
+-8 -1 1 1017 2347 SP
+{0 0 0.502 C} FS
+-5 -1 1 1097 2356 SP
+-4 -1 1 1130 2350 SP
+{1 0 0 C} FS
+1113 2341 M
+4 3 D
+-9 0 D
+8 1 D
+-5 1 D
+20 2 D
+-19 -2 D
+4 2 D
+-9 0 D
+23 1 D
+-10 0 D
+9 0 D
+2 2 D
+-15 -3 D
+5 1 D
+-15 -1 D
+26 3 D
+-19 -1 D
+19 2 D
+-14 0 D
+10 1 D
+-9 -1 D
+10 1 D
+-5 0 D
+4 1 D
+-19 -3 D
+-6 0 D
+24 3 D
+-15 -1 D
+12 2 D
+-7 0 D
+-10 -2 D
+-7 0 D
+17 2 D
+-5 0 D
+1 1 D
+-8 -1 D
+7 1 D
+-2 1 D
+-11 -2 D
+5 -1 D
+-15 1 D
+12 0 D
+-7 0 D
+13 1 D
+-15 -1 D
+14 2 D
+-7 -1 D
+5 1 D
+-9 -1 D
+6 1 D
+-10 -1 D
+8 1 D
+-10 -1 D
+2 1 D
+-6 -1 D
+4 1 D
+-10 -1 D
+3 1 D
+-8 -1 D
+5 1 D
+-5 -1 D
+2 1 D
+-6 -1 D
+6 1 D
+-9 -1 D
+7 1 D
+-12 -1 D
+-4 -1 D
+-22 -2 D
+8 1 D
+-7 -1 D
+4 1 D
+-7 -1 D
+-2 0 D
+-4 -1 D
+3 0 D
+-5 0 D
+-5 -1 D
+-11 -1 D
+13 1 D
+-13 -2 D
+8 1 D
+-7 -1 D
+9 1 D
+-9 -1 D
+7 1 D
+-7 -1 D
+7 1 D
+-8 -2 D
+7 1 D
+-6 -1 D
+11 1 D
+-9 -1 D
+11 1 D
+-12 -2 D
+6 0 D
+-8 -1 D
+7 1 D
+-7 -1 D
+5 1 D
+-7 -2 D
+8 1 D
+-10 -1 D
+13 1 D
+-10 -2 D
+12 0 D
+-9 -1 D
+31 -11 D
+50 7 D
+P
+FO
+4 0 5 0 7 -1 -12 -2 3 2 -11 -1 -1 2 7 1145 2343 SP
+-9 0 1 1017 2344 SP
+2 -1 1 1117 2343 SP
+6 1 1 1014 2350 SP
+-7 0 1 1129 2347 SP
+-2 -1 1 1033 2353 SP
+-4 0 1 1048 2354 SP
+-6 0 1 1120 2348 SP
+-8 -1 1 1017 2347 SP
+{0 0 0.502 C} FS
+-5 -1 1 1097 2356 SP
+-4 -1 1 1130 2350 SP
+1013 2342 M
+-13 -3 D
+3 -2 D
+-6 -1 D
+2 2 D
+-6 -1 D
+3 0 D
+-4 0 D
+-9 -3 D
+5 0 D
+-9 -2 D
+0 -4 D
+-6 -3 D
+10 0 D
+-11 -1 D
+-10 -3 D
+2 -1 D
+-6 0 D
+-15 -7 D
+-8 -11 D
+-5 -1 D
+-9 -4 D
+-49 3 D
+4 1 D
+-7 1 D
+12 1 D
+17 5 D
+-12 -2 D
+11 2 D
+-7 0 D
+7 2 D
+-5 -1 D
+5 2 D
+-20 -7 D
+3 2 D
+-7 -2 D
+14 6 D
+-25 -7 D
+3 3 D
+-10 -4 D
+-10 -3 D
+-11 -1 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-10 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-5 -2 D
+48 19 D
+61 21 D
+86 23 D
+62 12 D
+P
+FO
+-2 0 3 0 1 1 3 962 2312 SP
+{1 0 0 C} FS
+-5 -2 1 998 2339 SP
+872 2300 M
+4 1 D
+-7 1 D
+12 1 D
+17 5 D
+-12 -2 D
+11 2 D
+-7 0 D
+7 2 D
+-5 -1 D
+5 2 D
+-20 -7 D
+3 2 D
+-7 -2 D
+14 6 D
+-25 -7 D
+3 3 D
+-10 -4 D
+-10 -3 D
+P
+FO
+962 2312 M
+51 14 D
+30 6 D
+-25 9 D
+-5 1 D
+-13 -3 D
+3 -2 D
+-6 -1 D
+2 2 D
+-6 -1 D
+3 0 D
+-4 0 D
+-9 -3 D
+5 0 D
+-9 -2 D
+0 -4 D
+-6 -3 D
+10 0 D
+-11 -1 D
+-10 -3 D
+2 -1 D
+-6 0 D
+-15 -7 D
+-8 -11 D
+P
+FO
+-5 -2 1 998 2339 SP
+{0 0 0.502 C} FS
+845 2299 M
+-13 -5 D
+-7 -4 D
+-7 -6 D
+1 -4 D
+5 2 D
+-4 -2 D
+24 6 D
+0 -2 D
+2 3 D
+10 2 D
+-4 1 D
+12 5 D
+-8 -1 D
+11 2 D
+-2 2 D
+7 2 D
+49 -3 D
+-17 -8 D
+-9 -4 D
+-16 -8 D
+-15 -9 D
+-27 -20 D
+-6 -5 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -2 D
+-7 -1 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-7 -3 D
+-6 -2 D
+-6 -2 D
+-7 -3 D
+-6 -2 D
+-12 -6 D
+-7 -2 D
+6 2 D
+14 9 D
+25 12 D
+13 10 D
+-5 -6 D
+6 5 D
+-2 -3 D
+11 2 D
+14 11 D
+8 -1 D
+11 9 D
+-11 -3 D
+6 3 D
+-14 -5 D
+0 2 D
+-8 -6 D
+-14 -3 D
+5 -1 D
+-6 -3 D
+4 3 D
+-14 -5 D
+-5 -2 D
+3 1 D
+-10 -8 D
+-3 0 D
+-9 -5 D
+0 -1 D
+-8 -3 D
+-5 -3 D
+8 7 D
+-11 -5 D
+1 2 D
+-20 -13 D
+-2 -3 D
+-3 0 D
+8 6 D
+-4 1 D
+-13 -10 D
+5 2 D
+-23 -19 D
+-10 -6 D
+29 24 D
+47 31 D
+53 29 D
+59 27 D
+44 17 D
+49 12 D
+P
+FO
+-1 -1 -4 -3 4 3 3 2 4 573 2179 SP
+-5 -2 9 4 2 564 2175 SP
+{1 0 0 C} FS
+606 2210 M
+-8 -6 D
+24 11 D
+0 -2 D
+15 7 D
+11 7 D
+-4 -1 D
+6 3 D
+-1 1 D
+-6 -4 D
+-2 0 D
+12 7 D
+-10 -4 D
+0 1 D
+-13 -8 D
+1 2 D
+-9 -6 D
+8 6 D
+-6 -3 D
+1 1 D
+-6 -4 D
+2 1 D
+-5 -2 D
+P
+FO
+7 2 0 -2 -4 -1 3 681 2237 SP
+-12 -6 8 5 2 665 2229 SP
+-3 -2 -2 0 2 655 2226 SP
+2 0 1 612 2207 SP
+5 2 -4 -2 2 637 2218 SP
+-3 -2 1 543 2168 SP
+-2 -2 1 679 2238 SP
+-6 -2 1 743 2252 SP
+-3 0 1 686 2222 SP
+-4 -2 1 600 2201 SP
+1 -1 1 646 2224 SP
+-4 -2 1 671 2224 SP
+{0 0 0.502 C} FS
+-1 0 1 623 2218 SP
+-1 1 1 829 2283 SP
+-1 1 1 655 2222 SP
+{1 0 0 C} FS
+564 2175 M
+12 6 D
+4 3 D
+-4 -3 D
+6 2 D
+14 9 D
+25 12 D
+13 10 D
+-5 -6 D
+6 5 D
+-2 -3 D
+11 2 D
+14 11 D
+8 -1 D
+11 9 D
+-11 -3 D
+6 3 D
+-14 -5 D
+0 2 D
+-8 -6 D
+-14 -3 D
+5 -1 D
+-6 -3 D
+4 3 D
+-14 -5 D
+-5 -2 D
+3 1 D
+-10 -8 D
+-3 0 D
+-9 -5 D
+0 -1 D
+-8 -3 D
+-5 -3 D
+8 7 D
+-11 -5 D
+1 2 D
+-20 -13 D
+-2 -3 D
+-3 0 D
+8 6 D
+-4 1 D
+-13 -10 D
+5 2 D
+-23 -19 D
+P
+FO
+845 2299 M
+-13 -5 D
+-7 -4 D
+-7 -6 D
+1 -4 D
+5 2 D
+-4 -2 D
+24 6 D
+0 -2 D
+2 3 D
+10 2 D
+-4 1 D
+12 5 D
+-8 -1 D
+11 2 D
+-2 2 D
+7 2 D
+-7 -1 D
+-7 0 D
+-7 0 D
+P
+FO
+606 2210 M
+-8 -6 D
+24 11 D
+0 -2 D
+15 7 D
+11 7 D
+-4 -1 D
+6 3 D
+-1 1 D
+-6 -4 D
+-2 0 D
+12 7 D
+-10 -4 D
+0 1 D
+-13 -8 D
+1 2 D
+-9 -6 D
+8 6 D
+-6 -3 D
+1 1 D
+-6 -4 D
+2 1 D
+-5 -2 D
+P
+FO
+7 2 0 -2 -4 -1 3 681 2237 SP
+-12 -6 8 5 2 665 2229 SP
+-3 -2 -2 0 2 655 2226 SP
+2 0 1 612 2207 SP
+5 2 -4 -2 2 637 2218 SP
+-3 -2 1 543 2168 SP
+-2 -2 1 679 2238 SP
+-6 -2 1 743 2252 SP
+-3 0 1 686 2222 SP
+-4 -2 1 600 2201 SP
+1 -1 1 646 2224 SP
+-4 -2 1 671 2224 SP
+{0 0 0.502 C} FS
+-1 0 1 623 2218 SP
+-1 1 1 829 2283 SP
+-1 1 1 655 2222 SP
+399 2066 M
+3 3 D
+-6 -7 D
+17 13 D
+-22 -21 D
+4 -4 D
+-14 -15 D
+-25 -23 D
+-68 -80 D
+-8 -5 D
+-3 -5 D
+9 7 D
+0 -2 D
+12 14 D
+7 5 D
+-5 -9 D
+-8 -10 D
+4 3 D
+26 36 D
+6 4 D
+7 11 D
+39 41 D
+18 14 D
+-1 -5 D
+-16 -13 D
+5 1 D
+-30 -30 D
+-15 -21 D
+4 8 D
+-12 -19 D
+-12 -14 D
+-17 -15 D
+-17 -20 D
+-35 -36 D
+-29 -33 D
+-35 -46 D
+-2 1 D
+24 44 D
+27 40 D
+5 9 D
+27 36 D
+5 4 D
+14 17 D
+8 7 D
+-1 0 D
+11 13 D
+5 8 D
+43 47 D
+P
+FO
+-1 -1 1 413 2079 SP
+-5 -3 5 2 5 3 -1 2 4 515 2147 SP
+{1 0 0 C} FS
+2 4 13 12 14 13 -3 -5 4 327 1993 SP
+2 2 5 4 1 1 3 367 2037 SP
+-7 -7 11 21 17 15 3 266 1915 SP
+-4 -1 13 11 5 3 3 355 2017 SP
+-7 -8 3 4 2 368 2007 SP
+0 1 1 254 1910 SP
+-6 -5 1 377 2017 SP
+-2 -4 1 346 1984 SP
+-3 -4 1 261 1911 SP
+-1 -1 1 366 2023 SP
+-4 -4 1 373 2014 SP
+{0 0 0.502 C} FS
+-2 -3 1 434 2085 SP
+6 6 1 434 2075 SP
+-4 -6 1 323 1952 SP
+0 1 1 439 2086 SP
+4 3 1 414 2064 SP
+2 1 1 408 2029 SP
+-4 -1 3 1 2 413 2062 SP
+2 -3 1 391 2015 SP
+3 3 1 430 2075 SP
+{1 0 0 C} FS
+182 1793 M
+-2 1 D
+24 44 D
+27 40 D
+5 9 D
+27 36 D
+5 4 D
+14 17 D
+8 7 D
+-1 0 D
+11 13 D
+5 8 D
+24 27 D
+-51 -56 D
+-54 -70 D
+-27 -41 D
+-8 -14 D
+-13 -29 D
+-2 -8 D
+P
+FO
+515 2147 M
+-1 2 D
+-21 -12 D
+-31 -21 D
+-20 -14 D
+-29 -23 D
+-1 -1 D
+1 1 D
+-14 -13 D
+3 3 D
+-6 -7 D
+17 13 D
+-22 -21 D
+4 -4 D
+-14 -15 D
+-25 -23 D
+-68 -80 D
+-8 -5 D
+-3 -5 D
+9 7 D
+0 -2 D
+12 14 D
+7 5 D
+-5 -9 D
+-8 -10 D
+4 3 D
+26 36 D
+6 4 D
+7 11 D
+39 41 D
+18 14 D
+-1 -5 D
+-16 -13 D
+5 1 D
+-30 -30 D
+-15 -21 D
+4 8 D
+-12 -19 D
+-12 -14 D
+-17 -15 D
+-12 -15 D
+40 37 D
+49 40 D
+58 41 D
+15 33 D
+21 32 D
+21 26 D
+P
+FO
+2 4 13 12 14 13 -3 -5 4 327 1993 SP
+2 2 5 4 1 1 3 367 2037 SP
+-7 -7 11 21 17 15 3 266 1915 SP
+-4 -1 13 11 5 3 3 355 2017 SP
+-7 -8 3 4 2 368 2007 SP
+0 1 1 254 1910 SP
+-6 -5 1 377 2017 SP
+-2 -4 1 346 1984 SP
+-3 -4 1 261 1911 SP
+-1 -1 1 366 2023 SP
+-4 -4 1 373 2014 SP
+{0 0 0.502 C} FS
+-2 -3 1 434 2085 SP
+6 6 1 434 2075 SP
+-4 -6 1 323 1952 SP
+0 1 1 439 2086 SP
+4 3 1 414 2064 SP
+2 1 1 408 2029 SP
+-4 -1 3 1 2 413 2062 SP
+2 -3 1 391 2015 SP
+3 3 1 430 2075 SP
+159 1670 M
+13 21 D
+3 8 D
+0 9 D
+-8 5 D
+8 28 D
+3 17 D
+5 9 D
+5 17 D
+6 8 D
+6 17 D
+-4 3 D
+-14 -19 D
+26 35 D
+43 49 D
+35 36 D
+-11 -15 D
+0 -2 D
+-2 0 D
+-7 -9 D
+-7 -19 D
+-2 0 D
+7 16 D
+-4 -3 D
+-15 -19 D
+2 0 D
+-9 -12 D
+5 5 D
+-5 -10 D
+14 19 D
+-3 -8 D
+7 10 D
+1 -2 D
+-6 -10 D
+6 7 D
+12 22 D
+1 -3 D
+5 6 D
+-3 -6 D
+18 23 D
+2 -1 D
+-11 -17 D
+5 8 D
+-3 -8 D
+9 13 D
+1 -8 D
+-7 -18 D
+-7 -3 D
+11 2 D
+0 -11 D
+20 28 D
+0 3 D
+14 5 D
+21 16 D
+-4 -4 D
+3 -3 D
+14 12 D
+-3 -3 D
+4 1 D
+-5 -1 D
+8 0 D
+4 7 D
+-4 -7 D
+7 4 D
+5 -4 D
+-5 -8 D
+1 7 D
+-2 -5 D
+-3 -1 D
+0 -14 D
+-5 -5 D
+-8 3 D
+2 -4 D
+-13 -13 D
+-2 -7 D
+18 -6 D
+-3 8 D
+12 15 D
+-12 -16 D
+0 5 D
+8 11 D
+10 3 D
+-7 -5 D
+10 1 D
+15 -15 D
+-10 -4 D
+-2 7 D
+-8 -15 D
+3 5 D
+-14 -6 D
+-5 4 D
+-17 -49 D
+-5 -4 D
+-30 -32 D
+-4 12 D
+1 20 D
+9 23 D
+-3 11 D
+-14 4 D
+2 18 D
+-6 -7 D
+-1 -6 D
+-1 6 D
+-4 -4 D
+2 19 D
+-6 -2 D
+-6 -5 D
+1 -6 D
+-12 -11 D
+-3 -6 D
+-1 2 D
+5 7 D
+-5 -4 D
+-5 -12 D
+-4 -3 D
+-5 -11 D
+-4 0 D
+1 -8 D
+-4 2 D
+2 -5 D
+-10 -21 D
+1 -5 D
+8 7 D
+0 -4 D
+-9 -26 D
+4 -6 D
+7 3 D
+-2 -10 D
+5 -2 D
+-16 -15 D
+-12 -19 D
+-38 -34 D
+-3 15 D
+P
+FO
+-3 3 1 391 1862 SP
+{1 0 0 C} FS
+-5 -5 10 25 -2 2 3 3 -2 -12 5 218 1812 SP
+-9 10 6 1 3 6 6 -3 4 210 1736 SP
+-1 2 5 7 0 -3 3 265 1855 SP
+-1 1 6 12 9 11 3 255 1856 SP
+-4 0 6 4 2 226 1800 SP
+5 7 -2 -5 2 266 1891 SP
+1 -1 1 236 1818 SP
+0 2 1 281 1872 SP
+1 -1 1 247 1837 SP
+-1 1 1 239 1828 SP
+0 3 1 362 1896 SP
+2 6 1 364 1905 SP
+3 3 1 234 1843 SP
+5 6 1 255 1845 SP
+-1 0 1 279 1875 SP
+1 4 1 248 1831 SP
+-3 -5 1 261 1885 SP
+3 5 1 251 1848 SP
+-1 -4 1 282 1891 SP
+3 2 1 222 1801 SP
+3 2 1 270 1895 SP
+{0 0 0.502 C} FS
+21 44 11 8 1 -8 11 7 4 -4 -4 5 -9 -5 -2 8 -18 -15 3 -2 10 401 1915 SP
+6 4 3 7 2 258 1789 SP
+-5 -6 1 250 1799 SP
+-5 -5 1 254 1807 SP
+-4 -3 1 304 1926 SP
+-2 -1 1 258 1807 SP
+-6 -6 1 356 1923 SP
+3 0 -2 0 2 248 1806 SP
+-4 -3 1 374 1887 SP
+2 6 1 266 1794 SP
+-3 -4 1 372 1923 SP
+-3 -4 1 274 1894 SP
+-3 -2 1 301 1922 SP
+-8 -9 1 182 1671 SP
+{1 0 0 C} FS
+159 1670 M
+13 21 D
+3 8 D
+0 9 D
+-8 5 D
+8 28 D
+3 17 D
+5 9 D
+5 17 D
+6 8 D
+6 17 D
+-4 3 D
+-22 -31 D
+-7 -20 D
+-7 -35 D
+-2 -42 D
+P
+FO
+302 1774 M
+-4 12 D
+1 20 D
+9 23 D
+-3 11 D
+-14 4 D
+2 18 D
+-6 -7 D
+-1 -6 D
+-1 6 D
+-4 -4 D
+2 19 D
+-6 -2 D
+-6 -5 D
+1 -6 D
+-12 -11 D
+-3 -6 D
+-1 2 D
+5 7 D
+-5 -4 D
+-5 -12 D
+-4 -3 D
+-5 -11 D
+-4 0 D
+1 -8 D
+-4 2 D
+2 -5 D
+-10 -21 D
+1 -5 D
+8 7 D
+0 -4 D
+-9 -26 D
+4 -6 D
+7 3 D
+-2 -10 D
+5 -2 D
+-16 -15 D
+-12 -19 D
+-38 -34 D
+-3 15 D
+-13 -21 D
+7 -40 D
+6 -20 D
+2 -6 D
+26 41 D
+34 46 D
+30 39 D
+33 37 D
+P
+FO
+391 1862 M
+-3 3 D
+3 -3 D
+42 37 D
+-8 33 D
+-3 22 D
+1 33 D
+7 33 D
+3 11 D
+-19 -14 D
+-20 -13 D
+-25 -19 D
+-31 -25 D
+-41 -36 D
+-11 -11 D
+-11 -15 D
+0 -2 D
+-2 0 D
+-7 -9 D
+-7 -19 D
+-2 0 D
+7 16 D
+-4 -3 D
+-15 -19 D
+2 0 D
+-9 -12 D
+5 5 D
+-5 -10 D
+14 19 D
+-3 -8 D
+7 10 D
+1 -2 D
+-6 -10 D
+6 7 D
+12 22 D
+1 -3 D
+5 6 D
+-3 -6 D
+18 23 D
+2 -1 D
+-11 -17 D
+5 8 D
+-3 -8 D
+9 13 D
+1 -8 D
+-7 -18 D
+-7 -3 D
+11 2 D
+0 -11 D
+20 28 D
+0 3 D
+14 5 D
+21 16 D
+-4 -4 D
+3 -3 D
+14 12 D
+-3 -3 D
+4 1 D
+-5 -1 D
+8 0 D
+4 7 D
+-4 -7 D
+7 4 D
+5 -4 D
+-5 -8 D
+1 7 D
+-2 -5 D
+-3 -1 D
+0 -14 D
+-5 -5 D
+-8 3 D
+2 -4 D
+-13 -13 D
+-2 -7 D
+18 -6 D
+-3 8 D
+12 15 D
+-12 -16 D
+0 5 D
+8 11 D
+10 3 D
+-7 -5 D
+10 1 D
+15 -15 D
+-10 -4 D
+-2 7 D
+-8 -15 D
+3 5 D
+-14 -6 D
+-5 4 D
+-17 -49 D
+10 11 D
+P
+FO
+-5 -5 10 25 -2 2 3 3 -2 -12 5 218 1812 SP
+-9 10 6 1 3 6 6 -3 4 210 1736 SP
+-1 2 5 7 0 -3 3 265 1855 SP
+-1 1 6 12 9 11 3 255 1856 SP
+-4 0 6 4 2 226 1800 SP
+5 7 -2 -5 2 266 1891 SP
+1 -1 1 236 1818 SP
+0 2 1 281 1872 SP
+1 -1 1 247 1837 SP
+-1 1 1 239 1828 SP
+0 3 1 362 1896 SP
+2 6 1 364 1905 SP
+3 3 1 234 1843 SP
+5 6 1 255 1845 SP
+-1 0 1 279 1875 SP
+1 4 1 248 1831 SP
+-3 -5 1 261 1885 SP
+3 5 1 251 1848 SP
+-1 -4 1 282 1891 SP
+3 2 1 222 1801 SP
+3 2 1 270 1895 SP
+{0 0 0.502 C} FS
+21 44 11 8 1 -8 11 7 4 -4 -4 5 -9 -5 -2 8 -18 -15 3 -2 10 401 1915 SP
+6 4 3 7 2 258 1789 SP
+-5 -6 1 250 1799 SP
+-5 -5 1 254 1807 SP
+-4 -3 1 304 1926 SP
+-2 -1 1 258 1807 SP
+-6 -6 1 356 1923 SP
+3 0 -2 0 2 248 1806 SP
+-4 -3 1 374 1887 SP
+2 6 1 266 1794 SP
+-3 -4 1 372 1923 SP
+-3 -4 1 274 1894 SP
+-3 -2 1 301 1922 SP
+-8 -9 1 182 1671 SP
+-5 6 -4 6 -1 -4 5 -1 0 -12 4 6 4 -9 1 1 8 208 1535 SP
+4 5 4 4 5 5 4 4 4 5 5 5 4 4 -1 2 -9 2 -8 -4 -11 -15 -6 -21 12 337 1810 SP
+1 -1 1 391 1862 SP
+-26 -14 1 450 1863 SP
+466 1706 M
+-2 0 D
+2 0 D
+-28 -36 D
+-2 1 D
+3 8 D
+-9 7 D
+13 19 D
+16 12 D
+6 -5 D
+6 8 D
+0 -6 D
+3 3 D
+P
+FO
+319 1678 M
+11 12 D
+7 -3 D
+0 11 D
+16 44 D
+17 19 D
+-6 -4 D
+12 22 D
+18 12 D
+8 -9 D
+13 8 D
+17 -5 D
+7 -13 D
+-3 -7 D
+-18 -14 D
+0 -6 D
+-9 13 D
+-10 -5 D
+-1 -10 D
+-5 11 D
+-4 -4 D
+1 -7 D
+-12 -19 D
+3 -17 D
+-10 -7 D
+-11 -20 D
+12 14 D
+7 -2 D
+-7 -26 D
+-12 0 D
+1 14 D
+-11 -12 D
+-5 -11 D
+3 6 D
+3 -6 D
+-4 -8 D
+-1 5 D
+-7 -7 D
+5 0 D
+-3 -10 D
+-23 -35 D
+-17 12 D
+-4 37 D
+14 23 D
+P
+FO
+0 5 9 15 1 21 -5 6 4 10 -4 -10 4 -11 0 -16 -9 -15 0 -6 10 232 1636 SP
+10 4 0 -4 10 8 0 -6 7 7 -5 3 -17 -8 -8 -5 -3 -8 9 435 1869 SP
+11 20 -6 0 -8 -18 3 287 1691 SP
+-2 8 -2 -8 2 328 1725 SP
+-9 -6 10 -3 2 278 1719 SP
+-5 -12 1 219 1624 SP
+-3 -12 1 315 1731 SP
+-3 -16 1 387 1839 SP
+-6 -13 1 231 1647 SP
+-2 -5 1 222 1631 SP
+-3 1 1 429 1680 SP
+4 12 1 388 1844 SP
+-3 1 1 252 1558 SP
+-2 -4 1 260 1662 SP
+-3 -1 1 254 1640 SP
+-7 -14 1 413 1809 SP
+{1 0 0 C} FS
+-4 -4 1 398 1762 SP
+208 1535 M
+1 1 D
+4 -9 D
+4 6 D
+0 -12 D
+5 -1 D
+-1 -4 D
+23 -29 D
+33 -34 D
+18 -16 D
+53 97 D
+36 58 D
+34 50 D
+20 28 D
+-2 1 D
+3 8 D
+-9 7 D
+13 19 D
+16 12 D
+6 -5 D
+6 8 D
+0 -6 D
+23 26 D
+30 35 D
+-11 9 D
+-10 9 D
+-30 34 D
+-20 30 D
+-3 6 D
+-26 -14 D
+26 14 D
+-17 36 D
+-42 -37 D
+1 -1 D
+-1 1 D
+-33 -31 D
+-16 -15 D
+-5 -6 D
+-6 -21 D
+-11 -15 D
+-8 -4 D
+-9 2 D
+-1 2 D
+-16 -19 D
+-32 -38 D
+-40 -52 D
+-40 -61 D
+12 -29 D
+P
+FO
+-2 0 1 466 1706 SP
+{0 0 0.502 C} FS
+319 1678 M
+11 12 D
+7 -3 D
+0 11 D
+16 44 D
+17 19 D
+-6 -4 D
+12 22 D
+18 12 D
+8 -9 D
+13 8 D
+17 -5 D
+7 -13 D
+-3 -7 D
+-18 -14 D
+0 -6 D
+-9 13 D
+-10 -5 D
+-1 -10 D
+-5 11 D
+-4 -4 D
+1 -7 D
+-12 -19 D
+3 -17 D
+-10 -7 D
+-11 -20 D
+12 14 D
+7 -2 D
+-7 -26 D
+-12 0 D
+1 14 D
+-11 -12 D
+-5 -11 D
+3 6 D
+3 -6 D
+-4 -8 D
+-1 5 D
+-7 -7 D
+5 0 D
+-3 -10 D
+-23 -35 D
+-17 12 D
+-4 37 D
+14 23 D
+P
+FO
+0 5 9 15 1 21 -5 6 4 10 -4 -10 4 -11 0 -16 -9 -15 0 -6 10 232 1636 SP
+10 4 0 -4 10 8 0 -6 7 7 -5 3 -17 -8 -8 -5 -3 -8 9 435 1869 SP
+11 20 -6 0 -8 -18 3 287 1691 SP
+-2 8 -2 -8 2 328 1725 SP
+-9 -6 10 -3 2 278 1719 SP
+-5 -12 1 219 1624 SP
+-3 -12 1 315 1731 SP
+-3 -16 1 387 1839 SP
+-6 -13 1 231 1647 SP
+-2 -5 1 222 1631 SP
+-3 1 1 429 1680 SP
+4 12 1 388 1844 SP
+-3 1 1 252 1558 SP
+-2 -4 1 260 1662 SP
+-3 -1 1 254 1640 SP
+-7 -14 1 413 1809 SP
+{1 0 0 C} FS
+-4 -4 1 398 1762 SP
+{0 0 0.502 C} FS
+466 1706 M
+1 0 D
+-1 0 D
+8 11 D
+7 5 D
+4 -9 D
+8 0 D
+-15 -5 D
+-5 -8 D
+0 -16 D
+-8 -2 D
+-14 -7 D
+-3 -8 D
+-10 3 D
+P
+FO
+2 18 -12 -17 -20 -6 -26 21 -13 -3 12 -1 29 -22 14 3 8 597 1638 SP
+-13 11 -13 -3 3 -4 3 600 1552 SP
+-7 0 1 496 1553 SP
+11 -9 1 537 1379 SP
+-1 8 1 488 1345 SP
+3 0 1 485 1704 SP
+5 -1 1 644 1692 SP
+-1 -4 0 -1 2 522 1369 SP
+-4 0 1 538 1739 SP
+-2 3 1 415 1539 SP
+-4 -3 1 516 1511 SP
+-11 5 1 613 1573 SP
+-3 2 1 483 1580 SP
+{1 0 0 C} FS
+474 1717 M
+7 5 D
+4 -9 D
+8 0 D
+-15 -5 D
+-5 -8 D
+0 -16 D
+-8 -2 D
+-14 -7 D
+-3 -8 D
+-10 3 D
+-44 -63 D
+-24 -36 D
+-43 -74 D
+-32 -60 D
+48 -38 D
+45 -29 D
+39 -23 D
+41 -21 D
+33 -16 D
+23 -9 D
+18 53 D
+35 87 D
+38 85 D
+55 108 D
+23 40 D
+-49 22 D
+-37 20 D
+-54 35 D
+-29 24 D
+P
+FO
+1 0 1 466 1706 SP
+{0 0 0.502 C} FS
+2 18 -12 -17 -20 -6 -26 21 -13 -3 12 -1 29 -22 14 3 8 597 1638 SP
+-13 11 -13 -3 3 -4 3 600 1552 SP
+-7 0 1 496 1553 SP
+11 -9 1 537 1379 SP
+-1 8 1 488 1345 SP
+3 0 1 485 1704 SP
+5 -1 1 644 1692 SP
+-1 -4 0 -1 2 522 1369 SP
+-4 0 1 538 1739 SP
+-2 3 1 415 1539 SP
+-4 -3 1 516 1511 SP
+-11 5 1 613 1573 SP
+-3 2 1 483 1580 SP
+0 -1 1 832 1628 SP
+-1 -2 7 1 -6 4 3 858 1349 SP
+9 -10 -7 -1 2 -6 -14 -6 5 -9 -5 -3 7 -1 -4 12 21 12 -9 14 10 717 1616 SP
+-3 -14 8 4 2 670 1598 SP
+-5 1 2 -6 2 814 1322 SP
+-12 -5 3 -5 2 818 1598 SP
+-7 -1 9 -7 2 831 1614 SP
+-9 4 1 -5 2 706 1497 SP
+6 -4 1 667 1611 SP
+-3 -13 1 738 1462 SP
+-4 -1 1 829 1387 SP
+0 6 1 592 1276 SP
+-13 -4 11 -3 2 679 1266 SP
+11 -1 1 658 1290 SP
+-2 -12 1 827 1592 SP
+7 10 1 620 1282 SP
+-3 -6 1 749 1597 SP
+-5 2 1 732 1343 SP
+4 -2 1 904 1597 SP
+-7 1 1 707 1402 SP
+6 -4 1 574 1314 SP
+6 0 1 586 1300 SP
+4 1 1 742 1627 SP
+3 2 1 547 1304 SP
+4 -2 1 703 1345 SP
+9 2 1 645 1292 SP
+4 4 1 684 1316 SP
+-5 -1 1 690 1397 SP
+-5 1 1 705 1352 SP
+3 -4 1 573 1372 SP
+-6 -2 1 722 1574 SP
+-5 2 1 720 1355 SP
+4 4 1 657 1284 SP
+-4 3 1 744 1352 SP
+3 -3 1 680 1346 SP
+2 4 1 544 1306 SP
+-5 1 1 576 1391 SP
+3 4 1 587 1304 SP
+-4 2 1 707 1362 SP
+{1 0 0 C} FS
+858 1349 M
+-6 4 D
+7 1 D
+23 104 D
+30 117 D
+9 33 D
+-80 17 D
+-9 3 D
+0 -1 D
+0 1 D
+-64 18 D
+-59 21 D
+-16 7 D
+-27 -48 D
+-55 -108 D
+-38 -86 D
+-37 -96 D
+-12 -35 D
+58 -23 D
+81 -27 D
+72 -19 D
+75 -16 D
+21 -4 D
+25 129 D
+P
+FO
+{0 0 0.502 C} FS
+9 -10 -7 -1 2 -6 -14 -6 5 -9 -5 -3 7 -1 -4 12 21 12 -9 14 10 717 1616 SP
+-3 -14 8 4 2 670 1598 SP
+-5 1 2 -6 2 814 1322 SP
+-12 -5 3 -5 2 818 1598 SP
+-7 -1 9 -7 2 831 1614 SP
+-9 4 1 -5 2 706 1497 SP
+6 -4 1 667 1611 SP
+-3 -13 1 738 1462 SP
+-4 -1 1 829 1387 SP
+0 6 1 592 1276 SP
+-13 -4 11 -3 2 679 1266 SP
+11 -1 1 658 1290 SP
+-2 -12 1 827 1592 SP
+7 10 1 620 1282 SP
+-3 -6 1 749 1597 SP
+-5 2 1 732 1343 SP
+4 -2 1 904 1597 SP
+-7 1 1 707 1402 SP
+6 -4 1 574 1314 SP
+6 0 1 586 1300 SP
+4 1 1 742 1627 SP
+3 2 1 547 1304 SP
+4 -2 1 703 1345 SP
+9 2 1 645 1292 SP
+4 4 1 684 1316 SP
+-5 -1 1 690 1397 SP
+-5 1 1 705 1352 SP
+3 -4 1 573 1372 SP
+-6 -2 1 722 1574 SP
+-5 2 1 720 1355 SP
+4 4 1 657 1284 SP
+-4 3 1 744 1352 SP
+3 -3 1 680 1346 SP
+2 4 1 544 1306 SP
+-5 1 1 576 1391 SP
+3 4 1 587 1304 SP
+-4 2 1 707 1362 SP
+-31 -26 -8 -17 -15 -1 15 -1 8 19 32 26 6 1119 1182 SP
+7 5 1 1113 1182 SP
+3 -1 11 -12 10 0 -23 13 4 1103 1183 SP
+2 3 1 1077 1184 SP
+0 3 -9 7 3 -14 5 2 4 859 1354 SP
+16 17 20 2 1 14 -18 4 -6 22 -13 -7 6 1181 1335 SP
+13 15 1 6 -14 6 3 1181 1272 SP
+2 2 -2 2 2 1181 1205 SP
+3 -12 -1 7 7 -1 -3 7 8 -3 -6 4 5 2 7 1146 1241 SP
+3 -10 7 3 -8 0 3 7 4 1166 1238 SP
+2 -7 3 5 2 1081 1186 SP
+11 -5 -2 5 2 1136 1212 SP
+-14 -10 5 -4 2 1150 1571 SP
+1 -5 1 1133 1279 SP
+-5 6 0 1 2 1174 1229 SP
+4 6 -4 -5 2 1151 1545 SP
+5 0 1 1091 1185 SP
+1 6 1 1126 1228 SP
+5 -1 1 1120 1189 SP
+4 -2 1 904 1512 SP
+5 1 1 1123 1191 SP
+{1 0 0 C} FS
+1077 1184 M
+2 3 D
+-2 -3 D
+26 -1 D
+-23 13 D
+10 0 D
+11 -12 D
+12 -2 D
+7 5 D
+-7 -5 D
+6 0 D
+32 26 D
+8 19 D
+15 -1 D
+-15 -1 D
+-8 -17 D
+-31 -26 D
+61 -1 D
+0 24 D
+-2 2 D
+2 2 D
+0 63 D
+-14 6 D
+1 6 D
+13 15 D
+0 36 D
+-13 -7 D
+-6 22 D
+-18 4 D
+1 14 D
+20 2 D
+16 17 D
+0 198 D
+-11 0 D
+-11 0 D
+-99 5 D
+-86 9 D
+-53 9 D
+-39 -150 D
+-23 -104 D
+5 2 D
+3 -14 D
+-9 7 D
+-20 -99 D
+-7 -38 D
+101 -16 D
+104 -10 D
+P
+FO
+{0 0 0.502 C} FS
+3 -12 -1 7 7 -1 -3 7 8 -3 -6 4 5 2 7 1146 1241 SP
+3 -10 7 3 -8 0 3 7 4 1166 1238 SP
+2 -7 3 5 2 1081 1186 SP
+11 -5 -2 5 2 1136 1212 SP
+-14 -10 5 -4 2 1150 1571 SP
+1 -5 1 1133 1279 SP
+-5 6 0 1 2 1174 1229 SP
+4 6 -4 -5 2 1151 1545 SP
+5 0 1 1091 1185 SP
+1 6 1 1126 1228 SP
+5 -1 1 1120 1189 SP
+4 -2 1 904 1512 SP
+5 1 1 1123 1191 SP
+1218 1181 M
+5 1 D
+-5 -1 D
+-3 0 D
+-11 7 D
+-20 -3 D
+31 16 D
+-20 18 D
+-13 3 D
+33 -5 D
+-19 18 D
+-10 35 D
+-5 2 D
+0 27 D
+5 5 D
+-3 5 D
+10 -2 D
+1 10 D
+19 9 D
+10 -3 D
+2 11 D
+-32 8 D
+-12 -7 D
+0 52 D
+15 16 D
+14 5 D
+7 -12 D
+-16 -22 D
+11 0 D
+-13 -14 D
+39 26 D
+31 -4 D
+-6 -17 D
+8 -4 D
+-10 -2 D
+-5 -9 D
+10 -1 D
+-4 -3 D
+9 -1 D
+1 4 D
+15 -5 D
+7 -20 D
+-6 5 D
+-6 -6 D
+5 -7 D
+2 5 D
+0 -11 D
+7 1 D
+-10 -22 D
+7 -9 D
+-6 -1 D
+5 -6 D
+11 10 D
+3 -6 D
+2 9 D
+5 -6 D
+-2 8 D
+12 -4 D
+2 10 D
+9 -3 D
+6 21 D
+-4 21 D
+-21 31 D
+-16 10 D
+1 11 D
+32 25 D
+-2 18 D
+13 12 D
+-1 8 D
+8 -2 D
+6 17 D
+21 -12 D
+28 21 D
+30 60 D
+14 48 D
+24 -92 D
+5 -21 D
+-2 -2 D
+11 -36 D
+-1 -18 D
+5 2 D
+2 -11 D
+-3 -27 D
+-27 -33 D
+-9 5 D
+6 10 D
+-8 -5 D
+-5 -36 D
+-48 -7 D
+-34 -31 D
+2 -7 D
+20 0 D
+3 12 D
+4 -6 D
+25 17 D
+19 2 D
+-2 -18 D
+13 -8 D
+3 7 D
+13 13 D
+-8 7 D
+2 9 D
+4 -7 D
+1 5 D
+7 -2 D
+-5 -5 D
+19 3 D
+6 12 D
+4 -10 D
+3 14 D
+8 -1 D
+0 11 D
+4 -1 D
+1 -14 D
+1 2 D
+19 -101 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-8 0 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-8 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-8 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-8 -1 D
+-7 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+P
+FO
+-3 5 -8 -3 7 -10 4 4 4 1181 1209 SP
+0 1 7 3 -5 3 4 13 40 31 18 2 -17 -1 27 19 -22 -10 -15 -15 -30 -21 -8 -25 12 1401 1601 SP
+{1 0 0 C} FS
+2 11 9 -4 -7 -26 5 -13 5 4 -5 9 11 3 2 -11 -7 5 9 -10 -23 -12 -21 17 9 33 11 9 14 1369 1210 SP
+5 -14 6 3 -13 -18 -4 5 -11 -12 -12 2 -4 8 8 13 11 -5 8 13 10 1404 1255 SP
+-3 -11 1 6 2 1375 1202 SP
+13 4 1 1287 1252 SP
+1 7 1 1474 1369 SP
+-3 -10 1 1433 1293 SP
+5 1 1 1365 1197 SP
+4 8 1 1337 1277 SP
+-1 -7 1 1327 1290 SP
+3 4 1 1330 1241 SP
+3 -4 1 1284 1344 SP
+3 4 1 1337 1272 SP
+3 5 1 1342 1253 SP
+{0 0 0.502 C} FS
+1 -5 1 1283 1465 SP
+-5 -5 1 1315 1472 SP
+0 -5 1 1255 1455 SP
+6 -1 1 1359 1504 SP
+12 0 -6 14 2 1360 1487 SP
+-3 -10 1 1449 1312 SP
+-5 2 1 1245 1492 SP
+{1 0 0 C} FS
+1215 1181 M
+-11 7 D
+-20 -3 D
+31 16 D
+-20 18 D
+-13 3 D
+33 -5 D
+-19 18 D
+-10 35 D
+-5 2 D
+0 -63 D
+4 4 D
+7 -10 D
+-8 -3 D
+-3 5 D
+0 -24 D
+P
+FO
+5 1 1 1218 1181 SP
+0 2 1 2 0 -6 3 1511 1317 SP
+1493 1402 M
+-3 -27 D
+-27 -33 D
+-9 5 D
+6 10 D
+-8 -5 D
+-5 -36 D
+-48 -7 D
+-34 -31 D
+2 -7 D
+20 0 D
+3 12 D
+4 -6 D
+25 17 D
+19 2 D
+-2 -18 D
+13 -8 D
+3 7 D
+13 13 D
+-8 7 D
+2 9 D
+4 -7 D
+1 5 D
+7 -2 D
+-5 -5 D
+19 3 D
+6 12 D
+4 -10 D
+3 14 D
+8 -1 D
+0 11 D
+4 -1 D
+P
+FO
+-2 8 5 2 0 -14 -1 -4 4 1487 1429 SP
+-2 8 -1 8 7 -21 -2 -2 4 1478 1467 SP
+1401 1601 M
+-8 -25 D
+-30 -21 D
+-15 -15 D
+-22 -10 D
+27 19 D
+-17 -1 D
+18 2 D
+40 31 D
+4 13 D
+-5 3 D
+7 3 D
+0 1 D
+-11 -1 D
+-11 -2 D
+-10 -1 D
+-11 -2 D
+-11 -1 D
+-11 -1 D
+-11 -1 D
+-11 -1 D
+-10 -1 D
+-11 -1 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 0 D
+-12 -1 D
+-11 0 D
+-11 -1 D
+-11 0 D
+-11 0 D
+-11 0 D
+0 -198 D
+15 16 D
+14 5 D
+7 -12 D
+-16 -22 D
+11 0 D
+-13 -14 D
+39 26 D
+31 -4 D
+-6 -17 D
+8 -4 D
+-10 -2 D
+-5 -9 D
+10 -1 D
+-4 -3 D
+9 -1 D
+1 4 D
+15 -5 D
+7 -20 D
+-6 5 D
+-6 -6 D
+5 -7 D
+2 5 D
+0 -11 D
+7 1 D
+-10 -22 D
+7 -9 D
+-6 -1 D
+5 -6 D
+11 10 D
+3 -6 D
+2 9 D
+5 -6 D
+-2 8 D
+12 -4 D
+2 10 D
+9 -3 D
+6 21 D
+-4 21 D
+-21 31 D
+-16 10 D
+1 11 D
+32 25 D
+-2 18 D
+13 12 D
+-1 8 D
+8 -2 D
+6 17 D
+21 -12 D
+28 21 D
+30 60 D
+14 48 D
+-8 28 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+P
+FO
+-12 -7 -32 8 2 11 10 -3 19 9 1 10 10 -2 -3 5 5 5 9 1181 1299 SP
+2 11 9 -4 -7 -26 5 -13 5 4 -5 9 11 3 2 -11 -7 5 9 -10 -23 -12 -21 17 9 33 11 9 14 1369 1210 SP
+5 -14 6 3 -13 -18 -4 5 -11 -12 -12 2 -4 8 8 13 11 -5 8 13 10 1404 1255 SP
+-3 -11 1 6 2 1375 1202 SP
+13 4 1 1287 1252 SP
+1 7 1 1474 1369 SP
+-3 -10 1 1433 1293 SP
+5 1 1 1365 1197 SP
+4 8 1 1337 1277 SP
+-1 -7 1 1327 1290 SP
+3 4 1 1330 1241 SP
+3 -4 1 1284 1344 SP
+3 4 1 1337 1272 SP
+3 5 1 1342 1253 SP
+{0 0 0.502 C} FS
+1 -5 1 1283 1465 SP
+-5 -5 1 1315 1472 SP
+0 -5 1 1255 1455 SP
+6 -1 1 1359 1504 SP
+12 0 -6 14 2 1360 1487 SP
+-3 -10 1 1449 1312 SP
+-5 2 1 1245 1492 SP
+1512 1313 M
+11 17 D
+-8 11 D
+4 15 D
+-6 24 D
+8 3 D
+2 27 D
+-18 36 D
+-9 -2 D
+7 -10 D
+-13 5 D
+-3 -10 D
+-4 15 D
+16 8 D
+-15 7 D
+1 7 D
+9 -4 D
+8 8 D
+26 -8 D
+5 21 D
+22 14 D
+-8 -2 D
+-4 19 D
+-5 -9 D
+-16 0 D
+-32 22 D
+5 -44 D
+-15 -3 D
+4 -6 D
+-6 -7 D
+-22 85 D
+-7 28 D
+2 9 D
+-5 20 D
+22 4 D
+21 -77 D
+2 16 D
+12 -1 D
+4 -10 D
+1 7 D
+-23 24 D
+-2 27 D
+12 5 D
+13 -9 D
+-18 23 D
+85 22 D
+44 14 D
+50 20 D
+36 -65 D
+34 -66 D
+28 -59 D
+43 -104 D
+22 -62 D
+7 -17 D
+-12 -5 D
+-6 -2 D
+-11 -5 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+P
+FO
+-1 4 -1 -8 2 0 3 1510 1325 SP
+-1 6 -1 -5 2 -7 1 1 4 1491 1413 SP
+{1 0 0 C} FS
+-6 -1 9 19 0 -7 3 1549 1509 SP
+-12 -5 17 27 2 1564 1522 SP
+-10 -17 4 10 2 1593 1558 SP
+4 2 1 1563 1508 SP
+1 5 1 1618 1641 SP
+-11 -2 -18 23 13 -9 12 5 -2 27 -23 24 1 7 4 -10 12 -1 2 16 21 -77 11 1468 1613 SP
+3 -10 2 -9 -2 0 -3 -1 -5 20 2 9 6 1449 1580 SP
+1483 1444 M
+16 8 D
+-15 7 D
+1 7 D
+9 -4 D
+8 8 D
+26 -8 D
+5 21 D
+22 14 D
+-8 -2 D
+-4 19 D
+-5 -9 D
+-16 0 D
+-32 22 D
+5 -44 D
+-15 -3 D
+4 -6 D
+-6 -7 D
+P
+FO
+1491 1413 M
+1 1 D
+2 -7 D
+-1 -5 D
+17 -77 D
+2 0 D
+-1 -8 D
+1 -4 D
+11 17 D
+-8 11 D
+4 15 D
+-6 24 D
+8 3 D
+2 27 D
+-18 36 D
+-9 -2 D
+7 -10 D
+-13 5 D
+-3 -10 D
+P
+FO
+-6 -1 9 19 0 -7 3 1549 1509 SP
+-12 -5 17 27 2 1564 1522 SP
+-10 -17 4 10 2 1593 1558 SP
+4 2 1 1563 1508 SP
+1 5 1 1618 1641 SP
+{0 0 0.502 C} FS
+2067 1437 M
+-31 -26 D
+-26 -18 D
+-27 -18 D
+-18 -11 D
+-20 -11 D
+-20 -11 D
+-21 -11 D
+-21 -10 D
+-22 -11 D
+-11 -4 D
+-11 -5 D
+-39 105 D
+-41 95 D
+-28 59 D
+-48 90 D
+-14 24 D
+25 11 D
+47 23 D
+36 21 D
+13 9 D
+19 13 D
+30 24 D
+60 -72 D
+55 -75 D
+51 -78 D
+41 -72 D
+P
+FO
+2188 1604 M
+-8 -22 D
+-19 -36 D
+-29 -42 D
+-30 -34 D
+-35 -33 D
+-34 65 D
+-38 64 D
+-30 46 D
+-38 54 D
+-46 59 D
+-42 50 D
+10 10 D
+11 9 D
+23 25 D
+19 26 D
+23 43 D
+4 11 D
+55 -48 D
+6 -7 D
+27 -25 D
+12 -13 D
+7 -6 D
+54 -60 D
+49 -63 D
+26 -36 D
+9 -15 D
+P
+FO
+2188 1781 M
+11 -36 D
+5 -45 D
+-1 -30 D
+-6 -37 D
+-9 -29 D
+-33 51 D
+-37 50 D
+-28 35 D
+-54 60 D
+-7 6 D
+-25 26 D
+-14 12 D
+-6 7 D
+-55 48 D
+8 33 D
+3 22 D
+-1 33 D
+-7 33 D
+-3 11 D
+55 -39 D
+39 -31 D
+31 -27 D
+36 -34 D
+49 -54 D
+26 -32 D
+P
+FO
+1879 2114 M
+8 -1 D
+-8 7 D
+9 -6 D
+-7 9 D
+-13 3 D
+1 1 D
+-7 6 D
+3 -1 D
+5 -5 D
+-7 7 D
+9 -6 D
+0 2 D
+26 -17 D
+-14 10 D
+11 -9 D
+-13 9 D
+8 -10 D
+17 -9 D
+-3 3 D
+11 -8 D
+-3 4 D
+65 -51 D
+33 -30 D
+19 -18 D
+61 -68 D
+48 -62 D
+23 -35 D
+12 -21 D
+13 -29 D
+2 -8 D
+-23 33 D
+-47 56 D
+-34 36 D
+-42 39 D
+-45 37 D
+-47 35 D
+-21 14 D
+-14 31 D
+-13 21 D
+-18 26 D
+P
+FO
+6 -4 1 1872 2122 SP
+{1 0 0 C} FS
+2 0 1 1882 2112 SP
+0 1 1 1875 2125 SP
+0 1 1 1871 2125 SP
+2 -1 1 1876 2125 SP
+{0 0 0.502 C} FS
+-4 3 1 1863 2138 SP
+5 -3 1 1943 2083 SP
+4 -3 1 1948 2078 SP
+4 -1 1 1856 2140 SP
+-2 1 1 1868 2137 SP
+1 -1 1 1996 2036 SP
+4 -3 1 1971 2059 SP
+{1 0 0 C} FS
+1954 2074 M
+-12 11 D
+-37 28 D
+-55 35 D
+-11 6 D
+23 -21 D
+3 -1 D
+5 -5 D
+-7 7 D
+9 -6 D
+0 2 D
+26 -17 D
+-14 10 D
+11 -9 D
+-13 9 D
+8 -10 D
+17 -9 D
+-3 3 D
+11 -8 D
+-3 4 D
+65 -51 D
+33 -30 D
+-27 27 D
+P
+FO
+2 -2 -5 4 1 1 3 1868 2126 SP
+2 -1 -12 2 -7 9 9 -6 -8 7 8 -1 3 -4 4 -4 -6 4 6 -4 10 1872 2122 SP
+2 0 1 1882 2112 SP
+0 1 1 1875 2125 SP
+0 1 1 1871 2125 SP
+2 -1 1 1876 2125 SP
+{0 0 0.502 C} FS
+-4 3 1 1863 2138 SP
+5 -3 1 1943 2083 SP
+4 -3 1 1948 2078 SP
+4 -1 1 1856 2140 SP
+-2 1 1 1868 2137 SP
+1 -1 1 1996 2036 SP
+4 -3 1 1971 2059 SP
+8 -5 1 1835 2158 SP
+4 -2 1 1821 2169 SP
+9 -4 1 1817 2172 SP
+-4 3 1 1840 2159 SP
+-4 2 1 1825 2171 SP
+4 -3 1 1829 2164 SP
+-8 6 9 -6 2 1848 2155 SP
+7 -4 1 1843 2155 SP
+3 -2 1 1846 2155 SP
+{1 0 0 C} FS
+1732 2226 M
+53 -31 D
+32 -23 D
+9 -4 D
+-9 4 D
+8 -5 D
+-4 2 D
+14 -11 D
+8 -5 D
+-8 5 D
+9 -7 D
+12 -6 D
+55 -36 D
+41 -33 D
+2 -2 D
+-39 33 D
+-41 31 D
+-64 43 D
+-67 39 D
+P
+FO
+{0 0 0.502 C} FS
+-4 3 1 1840 2159 SP
+-4 2 1 1825 2171 SP
+4 -3 1 1829 2164 SP
+-8 6 9 -6 2 1848 2155 SP
+7 -4 1 1843 2155 SP
+3 -2 1 1846 2155 SP
+514 2149 M
+19 14 D
+-18 -11 D
+23 18 D
+-8 -5 D
+4 3 D
+-44 -31 D
+-7 -6 D
+-7 -4 D
+-25 -18 D
+44 34 D
+66 44 D
+23 13 D
+46 26 D
+-16 -9 D
+-14 -8 D
+-14 -9 D
+-14 -9 D
+-19 -13 D
+-29 -24 D
+P
+FO
+2 1 1 413 2079 SP
+{1 0 0 C} FS
+-4 -3 1 481 2131 SP
+-3 -3 1 485 2134 SP
+408 2074 M
+7 6 D
+-2 -1 D
+39 30 D
+41 28 D
+21 12 D
+19 14 D
+-18 -11 D
+23 18 D
+-8 -5 D
+4 3 D
+-44 -31 D
+-7 -6 D
+-7 -4 D
+-25 -18 D
+12 10 D
+P
+FO
+-4 -3 1 481 2131 SP
+-3 -3 1 485 2134 SP
+67 1574 M
+24 61 D
+21 43 D
+35 63 D
+27 40 D
+8 22 D
+19 36 D
+16 24 D
+-22 -31 D
+-39 -64 D
+-30 -56 D
+-36 -79 D
+P
+FO
+{0 0 0.502 C} FS
+159 1670 M
+-21 -52 D
+19 22 D
+-15 -19 D
+1 -6 D
+-22 -66 D
+-7 -15 D
+-2 -20 D
+-9 -30 D
+-10 -23 D
+-2 -19 D
+-22 -60 D
+-10 -30 D
+1 5 D
+-3 -6 D
+14 64 D
+2 25 D
+16 43 D
+-1 -4 D
+6 21 D
+5 26 D
+7 19 D
+1 -4 D
+4 16 D
+38 96 D
+P
+FO
+{1 0 0 C} FS
+-1 -5 1 123 1560 SP
+{0 0 0.502 C} FS
+1 -5 10 13 -10 -10 -3 6 -8 -20 5 103 1570 SP
+2 -2 1 12 2 34 1314 SP
+1 10 1 27 1336 SP
+{1 0 0 C} FS
+59 1352 M
+1 5 D
+-3 -6 D
+14 64 D
+2 25 D
+16 43 D
+-1 -4 D
+6 21 D
+5 26 D
+7 19 D
+1 -4 D
+4 16 D
+38 96 D
+10 17 D
+-1 28 D
+3 35 D
+10 41 D
+3 7 D
+-18 -26 D
+-37 -63 D
+-31 -65 D
+-18 -44 D
+-20 -60 D
+-17 -66 D
+-12 -56 D
+-3 -34 D
+1 -34 D
+5 -33 D
+9 -34 D
+3 -8 D
+7 34 D
+P
+FO
+0 3 -1 -6 0 1 3 62 1362 SP
+159 1670 M
+-21 -52 D
+19 22 D
+-15 -19 D
+1 -6 D
+-22 -66 D
+-7 -15 D
+-2 -20 D
+-9 -30 D
+-10 -23 D
+-2 -19 D
+24 55 D
+7 13 D
+21 41 D
+31 53 D
+-6 19 D
+-6 27 D
+P
+FO
+-1 -5 1 123 1560 SP
+{0 0 0.502 C} FS
+1 -5 10 13 -10 -10 -3 6 -8 -20 5 103 1570 SP
+2 -2 1 12 2 34 1314 SP
+1 10 1 27 1336 SP
+94 1151 M
+2 6 D
+4 -3 D
+-3 4 D
+7 23 D
+-3 7 D
+-12 2 D
+-13 16 D
+-8 0 D
+-3 10 D
+-8 3 D
+-2 36 D
+-4 5 D
+6 0 D
+2 9 D
+1 59 D
+-2 16 D
+3 13 D
+1 -4 D
+0 9 D
+21 60 D
+8 20 D
+-13 -91 D
+-9 -25 D
+-9 -55 D
+9 -14 D
+6 5 D
+21 -16 D
+7 4 D
+25 -9 D
+6 13 D
+24 -13 D
+8 12 D
+8 -7 D
+9 12 D
+11 -5 D
+7 23 D
+6 4 D
+1 -6 D
+24 22 D
+0 33 D
+-11 20 D
+-1 15 D
+6 24 D
+8 11 D
+-37 -20 D
+-11 14 D
+-5 -1 D
+-3 14 D
+15 27 D
+-3 6 D
+-12 -21 D
+5 30 D
+7 10 D
+1 28 D
+12 37 D
+-2 3 D
+4 -1 D
+3 10 D
+13 -19 D
+-12 -46 D
+5 -14 D
+1 -28 D
+7 -12 D
+20 -3 D
+-6 -31 D
+20 -30 D
+-35 -95 D
+-19 -63 D
+-23 -95 D
+-5 -31 D
+-30 27 D
+-32 35 D
+P
+FO
+{1 0 0 C} FS
+-10 11 5 -1 2 127 1165 SP
+-11 1 4 2 2 233 1410 SP
+3 -3 1 194 1384 SP
+3 -4 1 111 1181 SP
+-5 -5 6 5 2 208 1270 SP
+1 6 1 187 1442 SP
+1 6 1 74 1357 SP
+94 1151 M
+2 6 D
+4 -3 D
+-3 4 D
+7 23 D
+-3 7 D
+-12 2 D
+-13 16 D
+-8 0 D
+-3 10 D
+-8 3 D
+-2 36 D
+-4 5 D
+6 0 D
+2 9 D
+1 59 D
+-2 16 D
+1 8 D
+-13 -47 D
+-10 -47 D
+2 -8 D
+18 -38 D
+8 -16 D
+19 -30 D
+P
+FO
+221 1516 M
+-12 -46 D
+5 -14 D
+1 -28 D
+7 -12 D
+20 -3 D
+-6 -31 D
+20 -30 D
+39 85 D
+-35 33 D
+-16 17 D
+P
+FO
+91 1442 M
+-13 -91 D
+-9 -25 D
+-9 -55 D
+9 -14 D
+6 5 D
+21 -16 D
+7 4 D
+25 -9 D
+6 13 D
+24 -13 D
+8 12 D
+8 -7 D
+9 12 D
+11 -5 D
+7 23 D
+6 4 D
+1 -6 D
+24 22 D
+0 33 D
+-11 20 D
+-1 15 D
+6 24 D
+8 11 D
+-37 -20 D
+-11 14 D
+-5 -1 D
+-3 14 D
+15 27 D
+-3 6 D
+-12 -21 D
+5 30 D
+7 10 D
+1 28 D
+12 37 D
+-2 3 D
+4 -1 D
+3 10 D
+-25 45 D
+-9 24 D
+-24 -40 D
+-28 -54 D
+-19 -41 D
+P
+FO
+-1 -2 0 9 1 -4 3 61 1357 SP
+-10 11 5 -1 2 127 1165 SP
+-11 1 4 2 2 233 1410 SP
+3 -3 1 194 1384 SP
+3 -4 1 111 1181 SP
+-5 -5 6 5 2 208 1270 SP
+1 6 1 187 1442 SP
+1 6 1 74 1357 SP
+{0 0 0.502 C} FS
+-6 3 -2 -11 -1 -11 -2 -11 -1 -12 5 11 2 27 9 -3 3 4 9 420 919 SP
+256 1352 M
+15 -20 D
+54 -25 D
+-4 -16 D
+7 -6 D
+-4 -18 D
+11 -5 D
+-4 -7 D
+8 2 D
+-6 -4 D
+5 -19 D
+16 -6 D
+-6 -7 D
+-17 5 D
+14 -45 D
+19 1 D
+9 19 D
+8 -4 D
+-7 -3 D
+-2 -6 D
+5 -3 D
+-6 -5 D
+1 -12 D
+-8 -16 D
+-7 -78 D
+17 -111 D
+2 -24 D
+-63 32 D
+-26 16 D
+-41 26 D
+-47 34 D
+-25 21 D
+12 63 D
+25 95 D
+27 79 D
+P
+FO
+20 4 9 8 3 29 21 27 -5 2 2 -5 -18 -24 -4 -28 -8 -9 -21 -4 10 380 1334 SP
+4 4 1 426 1220 SP
+3 -3 1 403 966 SP
+1 -6 1 369 1028 SP
+-1 -4 1 378 1014 SP
+3 3 -2 -3 2 339 1284 SP
+-6 -2 1 393 1040 SP
+{1 0 0 C} FS
+420 919 M
+3 4 D
+9 -3 D
+2 27 D
+7 19 D
+13 77 D
+23 103 D
+27 95 D
+20 60 D
+-34 14 D
+-63 32 D
+-57 34 D
+-43 30 D
+-32 26 D
+-39 -85 D
+15 -20 D
+54 -25 D
+-4 -16 D
+7 -6 D
+-4 -18 D
+11 -5 D
+-4 -7 D
+8 2 D
+-6 -4 D
+5 -19 D
+16 -6 D
+-6 -7 D
+-17 5 D
+14 -45 D
+19 1 D
+9 19 D
+8 -4 D
+-7 -3 D
+-2 -6 D
+5 -3 D
+-6 -5 D
+1 -12 D
+-8 -16 D
+-7 -78 D
+17 -111 D
+2 -24 D
+P
+FO
+{0 0 0.502 C} FS
+20 4 9 8 3 29 21 27 -5 2 2 -5 -18 -24 -4 -28 -8 -9 -21 -4 10 380 1334 SP
+4 4 1 426 1220 SP
+3 -3 1 403 966 SP
+1 -6 1 369 1028 SP
+-1 -4 1 378 1014 SP
+3 3 -2 -3 2 339 1284 SP
+-6 -2 1 393 1040 SP
+-8 2 -1 -11 -1 -10 0 -10 -1 -11 18 32 0 7 7 768 815 SP
+-2 -6 4 6 2 756 817 SP
+439 958 M
+9 16 D
+1 36 D
+5 10 D
+11 -3 D
+7 9 D
+17 -1 D
+2 9 D
+33 14 D
+19 16 D
+23 4 D
+15 11 D
+0 13 D
+15 3 D
+6 9 D
+1 -14 D
+8 8 D
+5 -11 D
+2 9 D
+2 -7 D
+6 5 D
+3 -6 D
+4 10 D
+3 -13 D
+9 15 D
+-1 -13 D
+4 2 D
+0 13 D
+13 -3 D
+13 -58 D
+7 7 D
+-3 -9 D
+12 -7 D
+3 -12 D
+-10 2 D
+7 -13 D
+4 10 D
+4 -38 D
+-10 -30 D
+7 4 D
+-5 -7 D
+5 4 D
+5 -8 D
+4 6 D
+5 -9 D
+6 9 D
+11 1 D
+-3 9 D
+6 -8 D
+8 5 D
+2 14 D
+6 -22 D
+7 0 D
+-2 -34 D
+3 -27 D
+3 8 D
+7 -25 D
+-5 -17 D
+6 -5 D
+-9 -18 D
+1 -14 D
+-102 23 D
+-89 25 D
+-78 27 D
+-54 21 D
+P
+FO
+-1 -8 1 0 0 15 3 787 862 SP
+{1 0 0 C} FS
+2 11 3 -6 2 652 892 SP
+1 10 -1 -15 -1 5 3 653 880 SP
+3 3 1 652 882 SP
+3 -6 1 643 858 SP
+4 -5 1 682 1012 SP
+3 -5 1 755 852 SP
+1 -5 1 747 948 SP
+3 7 1 651 1087 SP
+4 6 1 750 847 SP
+2 -4 1 678 1036 SP
+4 -4 1 748 836 SP
+1 -5 1 684 1034 SP
+{0 0 0.502 C} FS
+-8 -34 -16 -7 17 6 8 34 4 636 1132 SP
+-15 18 16 -29 2 612 1161 SP
+4 3 -4 -2 2 474 1034 SP
+-4 2 1 587 1138 SP
+7 2 1 526 1168 SP
+-8 -1 6 -7 2 674 1231 SP
+-1 -7 1 679 1098 SP
+-1 -11 1 674 1101 SP
+3 4 1 595 1247 SP
+{1 0 0 C} FS
+756 817 M
+4 6 D
+-2 -6 D
+10 -2 D
+0 7 D
+18 32 D
+1 23 D
+1 0 D
+15 148 D
+15 107 D
+13 80 D
+-82 17 D
+-66 17 D
+-64 19 D
+-72 26 D
+-23 10 D
+-23 -69 D
+-30 -112 D
+-22 -103 D
+-10 -59 D
+9 16 D
+1 36 D
+5 10 D
+11 -3 D
+7 9 D
+17 -1 D
+2 9 D
+33 14 D
+19 16 D
+23 4 D
+15 11 D
+0 13 D
+15 3 D
+6 9 D
+1 -14 D
+8 8 D
+5 -11 D
+2 9 D
+2 -7 D
+6 5 D
+3 -6 D
+4 10 D
+3 -13 D
+9 15 D
+-1 -13 D
+4 2 D
+0 13 D
+13 -3 D
+13 -58 D
+7 7 D
+-3 -9 D
+12 -7 D
+3 -12 D
+-10 2 D
+7 -13 D
+4 10 D
+4 -38 D
+-10 -30 D
+7 4 D
+-5 -7 D
+5 4 D
+5 -8 D
+4 6 D
+5 -9 D
+6 9 D
+11 1 D
+-3 9 D
+6 -8 D
+8 5 D
+2 14 D
+6 -22 D
+7 0 D
+-2 -34 D
+3 -27 D
+3 8 D
+7 -25 D
+-5 -17 D
+6 -5 D
+-9 -18 D
+P
+FO
+2 11 3 -6 2 652 892 SP
+1 10 -1 -15 -1 5 3 653 880 SP
+3 3 1 652 882 SP
+3 -6 1 643 858 SP
+4 -5 1 682 1012 SP
+3 -5 1 755 852 SP
+1 -5 1 747 948 SP
+3 7 1 651 1087 SP
+4 6 1 750 847 SP
+2 -4 1 678 1036 SP
+4 -4 1 748 836 SP
+1 -5 1 684 1034 SP
+{0 0 0.502 C} FS
+-8 -34 -16 -7 17 6 8 34 4 636 1132 SP
+-15 18 16 -29 2 612 1161 SP
+4 3 -4 -2 2 474 1034 SP
+-4 2 1 587 1138 SP
+7 2 1 526 1168 SP
+-8 -1 6 -7 2 674 1231 SP
+-1 -7 1 679 1098 SP
+-1 -11 1 674 1101 SP
+3 4 1 595 1247 SP
+1158 777 M
+17 10 D
+-4 18 D
+-1 -14 D
+-5 5 D
+1 -9 D
+-10 -10 D
+-7 0 D
+-86 3 D
+-108 8 D
+-46 5 D
+-2 4 D
+8 -3 D
+-6 5 D
+6 -1 D
+0 6 D
+10 -5 D
+36 15 D
+4 25 D
+5 0 D
+-7 52 D
+-11 19 D
+-23 17 D
+-25 44 D
+7 19 D
+13 7 D
+0 10 D
+5 -3 D
+-3 8 D
+14 -2 D
+9 9 D
+13 0 D
+2 7 D
+10 -12 D
+9 7 D
+7 -6 D
+-7 -11 D
+4 -15 D
+7 0 D
+3 23 D
+1 -4 D
+23 5 D
+1 5 D
+13 -2 D
+1 6 D
+10 -4 D
+1 13 D
+3 -9 D
+3 6 D
+5 -4 D
+-2 19 D
+16 -18 D
+-1 5 D
+11 6 D
+2 -6 D
+8 7 D
+5 -5 D
+18 5 D
+4 6 D
+-5 4 D
+15 3 D
+2 7 D
+5 -5 D
+10 11 D
+-7 5 D
+17 1 D
+-2 7 D
+8 0 D
+-2 7 D
+8 -1 D
+1 9 D
+6 -6 D
+-3 15 D
+8 6 D
+-7 1 D
+5 1 D
+-5 7 D
+8 -2 D
+0 -211 D
+-2 1 D
+-3 -8 D
+5 -18 D
+0 -56 D
+-2 2 D
+2 -2 D
+-1 -12 D
+1 5 D
+0 -37 D
+-11 0 D
+P
+FO
+4 -4 -2 3 2 905 794 SP
+786 854 M
+2 23 D
+19 0 D
+-4 -16 D
+18 -2 D
+16 -13 D
+7 -27 D
+9 4 D
+0 -13 D
+6 4 D
+23 -17 D
+-99 15 D
+P
+FO
+0 -2 1 1077 1184 SP
+-10 6 5 11 -10 9 -4 -7 11 -3 -2 -10 -7 -5 1 0 5 4 10 -5 10 1104 1183 SP
+-3 -2 1 1113 1182 SP
+{1 0 0 C} FS
+-13 -12 -32 1 -2 8 13 18 17 9 11 -5 6 967 953 SP
+-5 -1 1 1181 788 SP
+6 -2 1 909 799 SP
+-5 -3 5 4 2 1130 1049 SP
+-1 -7 0 7 2 861 801 SP
+-3 4 1 832 843 SP
+{0 0 0.502 C} FS
+896 795 M
+-13 15 D
+-9 38 D
+6 -20 D
+14 12 D
+8 0 D
+-1 51 D
+-10 8 D
+6 8 D
+-14 19 D
+2 17 D
+-13 21 D
+-17 -1 D
+4 5 D
+13 -4 D
+13 -20 D
+-2 -18 D
+12 -12 D
+8 -22 D
+-1 -16 D
+6 -12 D
+-5 -2 D
+0 -22 D
+-21 -12 D
+7 -21 D
+20 -8 D
+-22 8 D
+P
+FO
+-22 1 -6 13 6 -13 22 -1 4 -7 25 0 -25 0 7 1019 1053 SP
+1 -6 9 8 2 1157 1169 SP
+-12 -5 17 0 2 1037 1165 SP
+5 3 1 1052 1169 SP
+0 -7 1 821 1129 SP
+-1 -5 1 865 1094 SP
+1 -4 1 996 1023 SP
+-1 -7 1 862 1103 SP
+-3 -7 1 1079 1062 SP
+-18 23 1 922 997 SP
+-1 -7 2 7 2 915 806 SP
+{1 0 0 C} FS
+1 -5 1 901 878 SP
+-6 20 1 887 807 SP
+905 794 M
+-2 3 D
+4 -4 D
+2 0 D
+-2 4 D
+8 -3 D
+-6 5 D
+6 -1 D
+0 6 D
+10 -5 D
+36 15 D
+4 25 D
+5 0 D
+-7 52 D
+-11 19 D
+-23 17 D
+-25 44 D
+7 19 D
+13 7 D
+0 10 D
+5 -3 D
+-3 8 D
+14 -2 D
+9 9 D
+13 0 D
+2 7 D
+10 -12 D
+9 7 D
+7 -6 D
+-7 -11 D
+4 -15 D
+7 0 D
+3 23 D
+1 -4 D
+23 5 D
+1 5 D
+13 -2 D
+1 6 D
+10 -4 D
+1 13 D
+3 -9 D
+3 6 D
+5 -4 D
+-2 19 D
+16 -18 D
+-1 5 D
+11 6 D
+2 -6 D
+8 7 D
+5 -5 D
+18 5 D
+4 6 D
+-5 4 D
+15 3 D
+2 7 D
+5 -5 D
+10 11 D
+-7 5 D
+17 1 D
+-2 7 D
+8 0 D
+-2 7 D
+8 -1 D
+1 9 D
+6 -6 D
+-3 15 D
+8 6 D
+-7 1 D
+5 1 D
+-5 7 D
+8 -2 D
+0 68 D
+-10 0 D
+-10 0 D
+-41 1 D
+-7 -5 D
+-2 -10 D
+11 -3 D
+-4 -7 D
+-10 9 D
+5 11 D
+-10 6 D
+-7 0 D
+-6 0 D
+-13 1 D
+0 -2 D
+0 2 D
+-7 0 D
+-90 7 D
+-89 11 D
+-60 10 D
+-18 -116 D
+-18 -141 D
+-7 -78 D
+19 0 D
+-4 -16 D
+18 -2 D
+16 -13 D
+7 -27 D
+9 4 D
+0 -13 D
+6 4 D
+23 -17 D
+P
+FO
+-10 -10 1 -9 -5 5 -1 -14 -4 18 17 10 6 1158 777 SP
+-1 -5 1 1181 814 SP
+-2 2 1 1181 821 SP
+5 -18 -3 -8 -2 1 3 1181 902 SP
+-3 0 5 4 10 -5 -5 1 -4 0 3 2 -3 -2 7 1113 1182 SP
+-1 -4 0 7 1 1 3 786 854 SP
+-13 -12 -32 1 -2 8 13 18 17 9 11 -5 6 967 953 SP
+-5 -1 1 1181 788 SP
+6 -2 1 909 799 SP
+-5 -3 5 4 2 1130 1049 SP
+-1 -7 0 7 2 861 801 SP
+-3 4 1 832 843 SP
+{0 0 0.502 C} FS
+896 795 M
+-13 15 D
+-9 38 D
+6 -20 D
+14 12 D
+8 0 D
+-1 51 D
+-10 8 D
+6 8 D
+-14 19 D
+2 17 D
+-13 21 D
+-17 -1 D
+4 5 D
+13 -4 D
+13 -20 D
+-2 -18 D
+12 -12 D
+8 -22 D
+-1 -16 D
+6 -12 D
+-5 -2 D
+0 -22 D
+-21 -12 D
+7 -21 D
+20 -8 D
+-22 8 D
+P
+FO
+-22 1 -6 13 6 -13 22 -1 4 -7 25 0 -25 0 7 1019 1053 SP
+1 -6 9 8 2 1157 1169 SP
+-12 -5 17 0 2 1037 1165 SP
+5 3 1 1052 1169 SP
+0 -7 1 821 1129 SP
+-1 -5 1 865 1094 SP
+1 -4 1 996 1023 SP
+-1 -7 1 862 1103 SP
+-3 -7 1 1079 1062 SP
+-18 23 1 922 997 SP
+-1 -7 2 7 2 915 806 SP
+{1 0 0 C} FS
+1 -5 1 901 878 SP
+-6 20 1 887 807 SP
+{0 0 0.502 C} FS
+1304 780 M
+0 2 D
+0 -2 D
+-4 0 D
+-4 0 D
+-1 9 D
+1 -9 D
+-11 -1 D
+-12 0 D
+0 1 D
+-8 2 D
+-3 -3 D
+-4 -1 D
+-4 0 D
+9 8 D
+0 18 D
+-10 -26 D
+-3 0 D
+-4 0 D
+7 16 D
+-7 4 D
+-7 -19 D
+-3 -1 D
+-9 0 D
+-9 -1 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+0 44 D
+6 -5 D
+-6 5 D
+0 56 D
+2 -6 D
+8 -7 D
+1 8 D
+8 -4 D
+-6 -16 D
+13 -4 D
+9 7 D
+17 -15 D
+-1 15 D
+16 -18 D
+13 0 D
+2 -9 D
+2 11 D
+-8 -1 D
+-5 10 D
+9 3 D
+-6 5 D
+-9 2 D
+-3 -8 D
+-7 13 D
+-10 -2 D
+0 -7 D
+-12 10 D
+-6 18 D
+22 32 D
+-7 18 D
+3 12 D
+-33 3 D
+-4 -48 D
+-8 3 D
+0 211 D
+2 -1 D
+14 26 D
+-5 4 D
+19 4 D
+-6 9 D
+7 5 D
+-5 4 D
+10 1 D
+0 8 D
+-10 -3 D
+12 9 D
+-4 2 D
+112 5 D
+107 11 D
+97 15 D
+20 -129 D
+15 -119 D
+10 -108 D
+3 -44 D
+-7 -1 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 0 D
+-7 -1 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-7 0 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-8 0 D
+P
+FO
+{1 0 0 C} FS
+-14 2 -6 21 6 -1 -1 8 13 -19 5 1270 798 SP
+-2 -11 -26 -35 -8 6 20 62 4 1198 1017 SP
+16 -16 -17 -1 -8 7 -5 23 15 -5 5 1282 805 SP
+-20 9 -6 -3 1 8 22 15 4 1222 786 SP
+-24 8 3 16 6 1 7 -15 4 1196 836 SP
+7 6 -1 -14 -16 15 3 1262 814 SP
+5 9 5 -3 2 1346 1152 SP
+-10 -17 5 8 2 1328 1114 SP
+9 -8 -4 2 2 1244 837 SP
+-3 7 1 1221 840 SP
+4 -4 1 1183 853 SP
+4 -3 1 1221 859 SP
+3 11 1 1221 819 SP
+-3 8 1 1221 869 SP
+5 5 1 1231 787 SP
+5 -2 1 1230 825 SP
+4 -6 1 1253 830 SP
+5 1 1 1250 1065 SP
+5 4 1 1257 1068 SP
+{0 0 0.502 C} FS
+-3 7 -3 -5 2 1208 864 SP
+{1 0 0 C} FS
+5 0 -3 -1 -7 -19 -7 4 7 16 5 1246 778 SP
+-10 -26 0 18 9 8 3 1254 778 SP
+6 0 -3 -3 -8 2 0 1 4 1273 779 SP
+-1 9 1 1296 780 SP
+0 2 1 1304 780 SP
+-12 0 -11 0 -11 0 -4 2 12 9 -10 -3 0 8 10 1 -5 4 7 5 -6 9 19 4 -5 4 14 26 2 -1 15 1181 1113 SP
+1181 877 M
+2 -6 D
+8 -7 D
+1 8 D
+8 -4 D
+-6 -16 D
+13 -4 D
+9 7 D
+17 -15 D
+-1 15 D
+16 -18 D
+13 0 D
+2 -9 D
+2 11 D
+-8 -1 D
+-5 10 D
+9 3 D
+-6 5 D
+-9 2 D
+-3 -8 D
+-7 13 D
+-10 -2 D
+0 -7 D
+-12 10 D
+-6 18 D
+22 32 D
+-7 18 D
+3 12 D
+-33 3 D
+-4 -48 D
+-8 3 D
+P
+FO
+6 -5 1 1181 821 SP
+-14 2 -6 21 6 -1 -1 8 13 -19 5 1270 798 SP
+-2 -11 -26 -35 -8 6 20 62 4 1198 1017 SP
+16 -16 -17 -1 -8 7 -5 23 15 -5 5 1282 805 SP
+-20 9 -6 -3 1 8 22 15 4 1222 786 SP
+-24 8 3 16 6 1 7 -15 4 1196 836 SP
+7 6 -1 -14 -16 15 3 1262 814 SP
+5 9 5 -3 2 1346 1152 SP
+-10 -17 5 8 2 1328 1114 SP
+9 -8 -4 2 2 1244 837 SP
+-3 7 1 1221 840 SP
+4 -4 1 1183 853 SP
+4 -3 1 1221 859 SP
+3 11 1 1221 819 SP
+-3 8 1 1221 869 SP
+5 5 1 1231 787 SP
+5 -2 1 1230 825 SP
+4 -6 1 1253 830 SP
+5 1 1 1250 1065 SP
+5 4 1 1257 1068 SP
+{0 0 0.502 C} FS
+-3 7 -3 -5 2 1208 864 SP
+1929 913 M
+-7 -3 D
+-6 -2 D
+-7 -3 D
+-6 -2 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-8 -2 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-12 143 D
+-13 109 D
+-23 148 D
+82 17 D
+67 17 D
+82 25 D
+54 20 D
+23 10 D
+28 -89 D
+23 -88 D
+9 -36 D
+17 -88 D
+P
+FO
+2188 1068 M
+-35 -29 D
+-29 -21 D
+-31 -20 D
+-15 -10 D
+-11 -6 D
+-11 -7 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-11 -7 D
+-6 -3 D
+-6 -2 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-6 -3 D
+-6 -2 D
+-7 -3 D
+-6 -3 D
+-10 70 D
+-15 79 D
+-14 62 D
+-18 71 D
+-33 106 D
+33 14 D
+63 32 D
+67 40 D
+34 24 D
+31 26 D
+20 -41 D
+31 -75 D
+19 -51 D
+21 -67 D
+23 -93 D
+P
+FO
+2327 1258 M
+-18 -42 D
+-29 -48 D
+-31 -40 D
+-36 -38 D
+-25 -22 D
+-11 59 D
+-19 76 D
+-30 93 D
+-34 83 D
+-27 58 D
+41 39 D
+29 35 D
+24 35 D
+12 21 D
+13 29 D
+2 8 D
+14 -23 D
+29 -53 D
+23 -46 D
+29 -71 D
+17 -48 D
+20 -73 D
+P
+FO
+{1 0 0 C} FS
+1 -5 1 2259 1468 SP
+1 -5 1 2259 1468 SP
+{0 0 0.502 C} FS
+2338 1418 M
+6 -42 D
+-1 -43 D
+-5 -33 D
+-11 -42 D
+-13 57 D
+-22 72 D
+-31 79 D
+-26 54 D
+-29 54 D
+-13 22 D
+-5 8 D
+11 37 D
+5 44 D
+-1 30 D
+-6 37 D
+-9 29 D
+14 -20 D
+21 -34 D
+31 -56 D
+23 -51 D
+18 -46 D
+21 -64 D
+P
+FO
+{1 0 0 C} FS
+0 -5 -4 3 1 4 3 2271 1476 SP
+-7 3 -2 18 2 2292 1458 SP
+4 -4 -4 -2 2 2280 1485 SP
+-1 -7 0 4 2 2275 1482 SP
+1 7 1 2260 1471 SP
+0 -5 -4 3 1 4 3 2271 1476 SP
+-7 3 -2 18 2 2292 1458 SP
+4 -4 -4 -2 2 2280 1485 SP
+-1 -7 0 4 2 2275 1482 SP
+1 7 1 2260 1471 SP
+{0 0 0.502 C} FS
+2295 1574 M
+-27 68 D
+-29 57 D
+-33 56 D
+-13 20 D
+-5 6 D
+-8 22 D
+-19 36 D
+-16 24 D
+22 -31 D
+39 -64 D
+41 -78 D
+26 -57 D
+P
+FO
+35 906 M
+-9 42 D
+-6 36 D
+-1 20 D
+1 19 D
+4 -47 D
+4 -34 D
+8 -40 D
+P
+FO
+{1 0 0 C} FS
+2 -9 1 -6 -1 6 3 22 978 SP
+0 2 1 28 942 SP
+{0 0 0.502 C} FS
+1 1128 M
+0 31 D
+2 -14 D
+0 -15 D
+1 1 D
+0 -5 D
+-1 3 D
+1 -27 D
+-1 -2 D
+0 8 D
+0 -1 D
+-1 11 D
+0 -6 D
+P
+FO
+0 -7 -1 1 1 -5 3 2 1180 SP
+-1 30 -2 -45 2 11 1201 SP
+0 -11 1 6 0 9 3 0 1194 SP
+1 -4 1 3 1172 SP
+0 5 1 8 1081 SP
+-3 -5 1 20 1215 SP
+0 -3 0 2 2 7 1065 SP
+-1 8 1 8 1074 SP
+1 -3 1 1 1187 SP
+0 5 1 8 1055 SP
+-1 -3 1 26 1234 SP
+-1 -4 1 17 1209 SP
+0 -2 1 0 1181 SP
+1 0 1 10 1088 SP
+{1 0 0 C} FS
+0 7 1 1 1149 SP
+0 5 1 2 1148 SP
+0 -4 1 2 1122 SP
+24 944 M
+8 -32 D
+3 -6 D
+-9 42 D
+-6 36 D
+-1 20 D
+1 19 D
+-2 55 D
+1 47 D
+7 78 D
+10 55 D
+-8 25 D
+-7 33 D
+-3 34 D
+1 34 D
+5 34 D
+-13 -74 D
+-9 -88 D
+-2 -87 D
+4 -88 D
+11 -87 D
+P
+FO
+2 -9 1 -6 -1 6 3 22 978 SP
+0 2 1 28 942 SP
+{0 0 0.502 C} FS
+1 1128 M
+0 31 D
+2 -14 D
+0 -15 D
+1 1 D
+0 -5 D
+-1 3 D
+1 -27 D
+-1 -2 D
+0 8 D
+0 -1 D
+-1 11 D
+0 -6 D
+P
+FO
+0 -7 -1 1 1 -5 3 2 1180 SP
+-1 30 -2 -45 2 11 1201 SP
+0 -11 1 6 0 9 3 0 1194 SP
+1 -4 1 3 1172 SP
+0 5 1 8 1081 SP
+-3 -5 1 20 1215 SP
+0 -3 0 2 2 7 1065 SP
+-1 8 1 8 1074 SP
+1 -3 1 1 1187 SP
+0 5 1 8 1055 SP
+-1 -3 1 26 1234 SP
+-1 -4 1 17 1209 SP
+0 -2 1 0 1181 SP
+1 0 1 10 1088 SP
+{1 0 0 C} FS
+0 7 1 1 1149 SP
+0 5 1 2 1148 SP
+0 -4 1 2 1122 SP
+{0 0 0.502 C} FS
+20 1023 M
+0 5 D
+3 0 D
+-2 8 D
+3 -6 D
+9 25 D
+14 7 D
+14 17 D
+31 62 D
+2 10 D
+43 -49 D
+29 -27 D
+8 -7 D
+-9 -59 D
+-6 -74 D
+-1 -65 D
+4 -72 D
+4 -39 D
+8 -46 D
+-25 22 D
+-43 46 D
+-29 40 D
+-24 40 D
+-17 41 D
+-10 54 D
+-6 61 D
+P
+FO
+{1 0 0 C} FS
+2 -4 1 117 846 SP
+2 -3 1 62 851 SP
+20 1023 M
+0 5 D
+3 0 D
+-2 8 D
+3 -6 D
+9 25 D
+14 7 D
+14 17 D
+31 62 D
+2 10 D
+-21 30 D
+-25 46 D
+-10 23 D
+-2 8 D
+-12 -71 D
+-6 -86 D
+1 -70 D
+P
+FO
+2 -4 1 117 846 SP
+2 -3 1 62 851 SP
+{0 0 0.502 C} FS
+376 939 M
+3 -23 D
+13 -23 D
+8 2 D
+5 11 D
+14 -1 D
+-4 6 D
+5 8 D
+13 -6 D
+0 -4 D
+-2 0 D
+2 -1 D
+-6 -32 D
+-2 5 D
+3 -24 D
+-5 -75 D
+-1 -88 D
+4 -69 D
+7 -67 D
+-74 34 D
+-30 15 D
+-11 7 D
+-39 22 D
+-41 27 D
+-56 42 D
+-8 8 D
+-9 53 D
+-6 79 D
+-1 57 D
+4 74 D
+4 42 D
+8 50 D
+43 -35 D
+59 -40 D
+32 -18 D
+16 -10 D
+P
+FO
+{1 0 0 C} FS
+4 -4 1 419 905 SP
+2 10 1 11 0 10 3 -24 -2 5 -5 -22 6 432 898 SP
+2 -1 -2 0 2 433 909 SP
+-8 3 -7 3 -7 4 -8 3 -7 3 5 8 -4 6 14 -1 5 11 8 2 13 -23 3 -23 12 376 939 SP
+4 -4 1 419 905 SP
+{0 0 0.502 C} FS
+428 857 M
+2 -21 D
+17 -3 D
+10 12 D
+-5 31 D
+-16 33 D
+-3 0 D
+0 4 D
+82 -31 D
+64 -21 D
+91 -25 D
+88 -19 D
+-9 -33 D
+7 2 D
+24 -37 D
+-2 -70 D
+-5 6 D
+-30 22 D
+2 6 D
+-14 18 D
+-42 16 D
+5 -19 D
+24 -23 D
+16 -29 D
+20 -14 D
+6 -28 D
+17 -18 D
+3 -110 D
+3 -49 D
+-78 16 D
+-113 29 D
+-43 13 D
+-62 22 D
+-54 21 D
+-9 90 D
+-2 86 D
+2 73 D
+P
+FO
+0 5 -1 -7 -6 4 6 -7 4 433 908 SP
+-1 -8 0 -8 8 -2 7 -1 0 14 -12 2 -2 11 7 782 788 SP
+{1 0 0 C} FS
+-5 -1 -11 12 1 7 9 -9 4 727 654 SP
+15 -11 -6 1 2 701 692 SP
+13 -13 -7 -2 2 757 612 SP
+2 -9 -4 5 2 666 779 SP
+6 -2 1 749 634 SP
+1 4 1 659 800 SP
+4 -4 1 722 677 SP
+7 -6 1 768 590 SP
+0 -5 1 749 780 SP
+3 4 1 744 623 SP
+-5 3 5 -2 2 773 745 SP
+2 -8 1 747 632 SP
+{0 0 0.502 C} FS
+-6 11 -6 1 2 761 672 SP
+{1 0 0 C} FS
+1 6 0 6 0 7 0 12 0 12 0 13 17 -18 6 -28 20 -14 16 -29 24 -23 5 -19 -42 16 -14 18 2 6 -30 22 -5 6 17 778 679 SP
+0 10 1 9 0 10 24 -37 7 2 -9 -33 -5 1 -5 1 0 14 -12 2 -2 11 11 782 788 SP
+-3 0 -16 33 -5 31 10 12 17 -3 2 -21 0 -10 -1 -11 -2 -10 -1 -10 -1 -7 -6 4 6 -7 13 433 908 SP
+-5 -1 -11 12 1 7 9 -9 4 727 654 SP
+15 -11 -6 1 2 701 692 SP
+13 -13 -7 -2 2 757 612 SP
+2 -9 -4 5 2 666 779 SP
+6 -2 1 749 634 SP
+1 4 1 659 800 SP
+4 -4 1 722 677 SP
+7 -6 1 768 590 SP
+0 -5 1 749 780 SP
+3 4 1 744 623 SP
+-5 3 5 -2 2 773 745 SP
+2 -8 1 747 632 SP
+{0 0 0.502 C} FS
+-6 11 -6 1 2 761 672 SP
+777 616 M
+6 -6 D
+26 -45 D
+60 -56 D
+-1 7 D
+12 -6 D
+2 5 D
+9 -8 D
+7 44 D
+-10 16 D
+-15 4 D
+-3 -5 D
+3 8 D
+-8 3 D
+-2 17 D
+-22 9 D
+9 16 D
+-8 6 D
+-12 -4 D
+8 3 D
+-4 5 D
+-10 4 D
+-26 31 D
+-3 -8 D
+-17 23 D
+2 70 D
+2 -3 D
+7 -43 D
+14 -30 D
+43 -35 D
+9 6 D
+6 -7 D
+-16 29 D
+1 32 D
+-6 16 D
+-30 33 D
+-22 10 D
+-6 31 D
+1 24 D
+86 -14 D
+13 -1 D
+-7 -23 D
+9 -2 D
+19 10 D
+-7 13 D
+13 -10 D
+-4 9 D
+7 -5 D
+-3 4 D
+92 -9 D
+116 -6 D
+39 -1 D
+-33 -31 D
+17 10 D
+16 20 D
+25 1 D
+0 -91 D
+-4 -3 D
+4 2 D
+0 -85 D
+-3 -11 D
+-5 1 D
+6 -15 D
+-3 4 D
+-9 -9 D
+1 -13 D
+-13 -15 D
+4 -14 D
+12 0 D
+-1 -34 D
+11 -1 D
+0 -48 D
+-4 -3 D
+4 0 D
+0 -9 D
+-21 -3 D
+19 -8 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-109 5 D
+-91 8 D
+-122 16 D
+-32 6 D
+-4 77 D
+P
+FO
+{1 0 0 C} FS
+1078 523 M
+27 14 D
+-4 5 D
+4 -2 D
+6 13 D
+-9 7 D
+11 12 D
+4 -3 D
+15 8 D
+-3 16 D
+12 12 D
+-3 6 D
+9 -6 D
+13 3 D
+-23 17 D
+-3 6 D
+8 2 D
+-22 24 D
+15 0 D
+-8 10 D
+24 3 D
+-8 10 D
+23 9 D
+-19 9 D
+-8 -3 D
+1 7 D
+-9 -3 D
+4 10 D
+-12 11 D
+-7 -8 D
+-1 9 D
+-19 -27 D
+-10 -2 D
+5 -4 D
+-5 -6 D
+-29 -4 D
+-19 -26 D
+-33 -6 D
+-5 -24 D
+-26 8 D
+-5 8 D
+-15 -16 D
+0 -15 D
+7 -6 D
+-3 -9 D
+10 -5 D
+-7 2 D
+8 -6 D
+-4 -5 D
+10 2 D
+7 -33 D
+29 0 D
+4 -13 D
+23 9 D
+12 -4 D
+0 -6 D
+19 1 D
+1 -14 D
+P
+FO
+37 -13 20 0 29 -9 -2 -7 26 -7 -11 -3 -5 -9 -45 11 -13 11 -30 5 -12 -8 -31 9 -13 16 -26 2 -3 16 12 -4 16 1059 448 SP
+4 -12 13 -2 -4 -8 -14 1 -5 15 -12 4 3 7 7 910 554 SP
+-7 -5 -24 5 12 -7 -5 -2 -26 9 45 7 6 1120 437 SP
+-7 -2 0 8 3 -4 3 864 630 SP
+4 -8 -6 -3 -2 5 3 943 675 SP
+12 -5 -2 -4 -5 3 3 831 635 SP
+12 7 12 -12 -9 1 3 1079 453 SP
+-1 -11 -12 5 5 8 3 936 546 SP
+6 -10 -5 4 2 786 572 SP
+-9 2 3 9 11 -3 3 1100 443 SP
+-27 1 12 4 16 -5 3 1033 475 SP
+1 -4 -7 2 2 812 656 SP
+2 -7 -6 4 4 4 3 822 636 SP
+-1 -4 -10 7 2 875 605 SP
+10 1 -6 -2 2 879 773 SP
+0 -5 1 1170 680 SP
+5 -1 1 1147 676 SP
+4 -4 1 865 616 SP
+5 13 1 1100 522 SP
+4 -5 1 901 790 SP
+7 -1 1 860 604 SP
+-8 0 1 856 638 SP
+6 1 1 1085 472 SP
+4 3 1 1121 724 SP
+6 -1 1 845 609 SP
+3 3 1 855 631 SP
+5 -3 1 820 526 SP
+9 -2 1 1123 656 SP
+4 3 1 1130 449 SP
+1 5 1 1120 736 SP
+2 -5 1 782 726 SP
+4 2 1 1173 442 SP
+{0 0 0.502 C} FS
+5 0 1 1105 587 SP
+-2 -4 1 1025 550 SP
+{1 0 0 C} FS
+2 0 19 -8 -20 -3 -1 0 4 1181 433 SP
+4 0 -4 -3 2 1181 445 SP
+11 -1 0 -10 -1 -24 12 0 4 -14 -13 -15 1 -13 -9 -9 -3 4 6 -15 -5 1 -3 -11 12 1181 600 SP
+4 2 -4 -3 2 1181 686 SP
+2 1 16 20 17 10 -33 -31 4 1156 777 SP
+-3 4 5 -4 2 907 793 SP
+-12 1 -4 9 13 -10 -7 13 19 10 9 -2 -7 -23 7 882 797 SP
+-1 -9 0 -10 -1 -10 -6 31 -22 10 -30 33 -6 16 1 32 -16 29 6 -7 9 6 43 -35 14 -30 7 -43 2 -3 15 780 749 SP
+777 616 M
+6 -6 D
+26 -45 D
+60 -56 D
+-1 7 D
+12 -6 D
+2 5 D
+9 -8 D
+7 44 D
+-10 16 D
+-15 4 D
+-3 -5 D
+3 8 D
+-8 3 D
+-2 17 D
+-22 9 D
+9 16 D
+-8 6 D
+-12 -4 D
+8 3 D
+-4 5 D
+-10 4 D
+-26 31 D
+-3 -8 D
+-17 23 D
+P
+FO
+1078 523 M
+27 14 D
+-4 5 D
+4 -2 D
+6 13 D
+-9 7 D
+11 12 D
+4 -3 D
+15 8 D
+-3 16 D
+12 12 D
+-3 6 D
+9 -6 D
+13 3 D
+-23 17 D
+-3 6 D
+8 2 D
+-22 24 D
+15 0 D
+-8 10 D
+24 3 D
+-8 10 D
+23 9 D
+-19 9 D
+-8 -3 D
+1 7 D
+-9 -3 D
+4 10 D
+-12 11 D
+-7 -8 D
+-1 9 D
+-19 -27 D
+-10 -2 D
+5 -4 D
+-5 -6 D
+-29 -4 D
+-19 -26 D
+-33 -6 D
+-5 -24 D
+-26 8 D
+-5 8 D
+-15 -16 D
+0 -15 D
+7 -6 D
+-3 -9 D
+10 -5 D
+-7 2 D
+8 -6 D
+-4 -5 D
+10 2 D
+7 -33 D
+29 0 D
+4 -13 D
+23 9 D
+12 -4 D
+0 -6 D
+19 1 D
+1 -14 D
+P
+FO
+37 -13 20 0 29 -9 -2 -7 26 -7 -11 -3 -5 -9 -45 11 -13 11 -30 5 -12 -8 -31 9 -13 16 -26 2 -3 16 12 -4 16 1059 448 SP
+4 -12 13 -2 -4 -8 -14 1 -5 15 -12 4 3 7 7 910 554 SP
+-7 -5 -24 5 12 -7 -5 -2 -26 9 45 7 6 1120 437 SP
+-7 -2 0 8 3 -4 3 864 630 SP
+4 -8 -6 -3 -2 5 3 943 675 SP
+12 -5 -2 -4 -5 3 3 831 635 SP
+12 7 12 -12 -9 1 3 1079 453 SP
+-1 -11 -12 5 5 8 3 936 546 SP
+6 -10 -5 4 2 786 572 SP
+-9 2 3 9 11 -3 3 1100 443 SP
+-27 1 12 4 16 -5 3 1033 475 SP
+1 -4 -7 2 2 812 656 SP
+2 -7 -6 4 4 4 3 822 636 SP
+-1 -4 -10 7 2 875 605 SP
+10 1 -6 -2 2 879 773 SP
+0 -5 1 1170 680 SP
+5 -1 1 1147 676 SP
+4 -4 1 865 616 SP
+5 13 1 1100 522 SP
+4 -5 1 901 790 SP
+7 -1 1 860 604 SP
+-8 0 1 856 638 SP
+6 1 1 1085 472 SP
+4 3 1 1121 724 SP
+6 -1 1 845 609 SP
+3 3 1 855 631 SP
+5 -3 1 820 526 SP
+9 -2 1 1123 656 SP
+4 3 1 1130 449 SP
+1 5 1 1120 736 SP
+2 -5 1 782 726 SP
+4 2 1 1173 442 SP
+{0 0 0.502 C} FS
+5 0 1 1105 587 SP
+-2 -4 1 1025 550 SP
+1272 424 M
+58 28 D
+-45 -6 D
+-29 -17 D
+-3 -6 D
+-9 0 D
+-9 0 D
+-10 -1 D
+-9 0 D
+-9 0 D
+-10 0 D
+-16 11 D
+0 9 D
+34 -3 D
+27 10 D
+-2 5 D
+-9 -8 D
+-19 -2 D
+-22 6 D
+-9 -5 D
+0 48 D
+10 0 D
+-6 45 D
+12 6 D
+7 -1 D
+-4 -15 D
+14 -8 D
+-1 -12 D
+9 -2 D
+2 7 D
+16 1 D
+-14 14 D
+6 7 D
+-24 23 D
+7 -2 D
+37 22 D
+-37 -1 D
+-11 -12 D
+-9 1 D
+-13 13 D
+5 19 D
+83 1 D
+18 24 D
+-26 -16 D
+-62 8 D
+-7 -11 D
+-6 4 D
+-5 -5 D
+-1 -3 D
+0 85 D
+5 2 D
+-5 -1 D
+0 91 D
+55 1 D
+-7 -3 D
+13 -16 D
+6 6 D
+-2 13 D
+7 0 D
+-5 -11 D
+6 11 D
+8 1 D
+-4 -5 D
+4 -3 D
+12 3 D
+-1 5 D
+31 1 D
+-1 -4 D
+1 4 D
+108 9 D
+115 14 D
+52 9 D
+5 -123 D
+1 -102 D
+-41 6 D
+-16 -8 D
+2 -5 D
+-16 -5 D
+-12 -17 D
+-14 -6 D
+-9 14 D
+-3 -7 D
+-6 8 D
+-4 28 D
+-31 3 D
+-24 -11 D
+-6 -11 D
+21 1 D
+7 -13 D
+32 7 D
+-5 -12 D
+-9 5 D
+-10 -8 D
+-16 -1 D
+18 -8 D
+1 -13 D
+11 5 D
+8 17 D
+-4 -10 D
+7 -6 D
+19 2 D
+-7 -4 D
+12 -5 D
+57 -7 D
+-2 -6 D
+6 2 D
+1 -11 D
+9 -6 D
+-7 -4 D
+13 0 D
+-11 -3 D
+9 -5 D
+-4 -12 D
+20 8 D
+-2 -32 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 0 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-7 -1 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-7 0 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-7 0 D
+-8 -1 D
+-8 0 D
+P
+FO
+{1 0 0 C} FS
+1284 700 M
+5 5 D
+2 -10 D
+6 8 D
+-6 14 D
+6 11 D
+11 -19 D
+-1 12 D
+9 8 D
+-5 23 D
+-6 2 D
+2 13 D
+-16 9 D
+3 -16 D
+-15 0 D
+-1 -10 D
+-8 2 D
+-14 -13 D
+3 9 D
+-9 6 D
+-24 -16 D
+-6 -16 D
+5 -4 D
+10 17 D
+16 -8 D
+5 9 D
+12 -8 D
+-4 -19 D
+P
+FO
+17 -11 5 -22 -11 -22 -2 16 8 8 -22 -14 0 10 11 5 -15 10 20 -3 -1 13 11 1345 591 SP
+-27 1 -10 14 19 -7 30 5 5 -7 6 9 -2 -8 7 1345 542 SP
+-11 -16 -18 -2 3 8 19 9 4 1542 476 SP
+6 0 -2 -12 -7 -1 0 6 4 1237 504 SP
+-9 -6 -2 14 12 13 -3 -16 4 1471 505 SP
+3 13 -6 2 11 8 -2 -12 4 1238 504 SP
+-6 8 8 1 4 -6 3 1331 587 SP
+-4 -5 -12 0 2 4 3 1283 450 SP
+15 0 -5 -5 -7 2 3 1345 570 SP
+-9 9 12 5 14 -9 3 1304 536 SP
+-22 -3 6 4 2 1406 595 SP
+-18 1 21 5 2 1300 457 SP
+-20 5 7 2 2 1507 593 SP
+-13 1 11 5 2 1243 564 SP
+-29 -1 18 3 2 1506 581 SP
+0 10 6 2 2 1351 633 SP
+-13 -5 1 6 2 1392 565 SP
+-8 -1 1 6 2 1406 579 SP
+8 4 -1 -6 2 1222 715 SP
+21 2 -13 -2 2 1304 562 SP
+4 6 2 -3 2 1263 450 SP
+0 12 1 -8 2 1190 487 SP
+-1 4 3 -9 -1 5 3 1304 554 SP
+3 -3 1 1227 587 SP
+7 2 1 1345 533 SP
+4 -3 1 1373 598 SP
+15 5 1 1246 446 SP
+5 1 1 1488 584 SP
+-1 -5 1 1222 501 SP
+7 1 1 1554 479 SP
+-4 3 1 1380 462 SP
+-7 -12 7 13 2 1442 501 SP
+5 -5 1 1292 660 SP
+-7 -3 1 1222 584 SP
+7 3 1 1242 448 SP
+4 3 1 1327 587 SP
+11 3 1 1394 584 SP
+3 -6 1 1438 508 SP
+3 5 1 1474 747 SP
+-5 2 1 1344 455 SP
+5 -1 1 1251 763 SP
+6 0 1 1419 480 SP
+5 2 1 1395 591 SP
+5 1 1 1334 573 SP
+6 -3 1 1452 535 SP
+-17 3 20 4 2 1271 557 SP
+5 1 1 1381 578 SP
+12 15 1 1407 465 SP
+{0 0 0.502 C} FS
+-6 -4 5 -1 2 1211 544 SP
+4 -2 1 1207 548 SP
+1 -5 1 1194 559 SP
+{1 0 0 C} FS
+8 0 0 -11 -16 11 3 1197 422 SP
+10 0 -3 -6 -29 -17 -45 -6 58 28 5 1272 424 SP
+1585 587 M
+-41 6 D
+-16 -8 D
+2 -5 D
+-16 -5 D
+-12 -17 D
+-14 -6 D
+-9 14 D
+-3 -7 D
+-6 8 D
+-4 28 D
+-31 3 D
+-24 -11 D
+-6 -11 D
+21 1 D
+7 -13 D
+32 7 D
+-5 -12 D
+-9 5 D
+-10 -8 D
+-16 -1 D
+18 -8 D
+1 -13 D
+11 5 D
+8 17 D
+-4 -10 D
+7 -6 D
+19 2 D
+-7 -4 D
+12 -5 D
+57 -7 D
+-2 -6 D
+6 2 D
+1 -11 D
+9 -6 D
+-7 -4 D
+13 0 D
+-11 -3 D
+9 -5 D
+-4 -12 D
+20 8 D
+P
+FO
+-1 -4 1 1304 780 SP
+-5 0 -1 5 12 3 4 -3 -4 -5 5 1262 779 SP
+6 11 -5 -11 2 1253 778 SP
+-5 0 -2 13 6 6 13 -16 -7 -3 5 1236 778 SP
+-5 -1 5 2 2 1181 685 SP
+1181 493 M
+10 0 D
+-6 45 D
+12 6 D
+7 -1 D
+-4 -15 D
+14 -8 D
+-1 -12 D
+9 -2 D
+2 7 D
+16 1 D
+-14 14 D
+6 7 D
+-24 23 D
+7 -2 D
+37 22 D
+-37 -1 D
+-11 -12 D
+-9 1 D
+-13 13 D
+5 19 D
+83 1 D
+18 24 D
+-26 -16 D
+-62 8 D
+-7 -11 D
+-6 4 D
+-5 -5 D
+P
+FO
+-9 -5 -22 6 -19 -2 -9 -8 -2 5 27 10 34 -3 7 1181 442 SP
+1284 700 M
+5 5 D
+2 -10 D
+6 8 D
+-6 14 D
+6 11 D
+11 -19 D
+-1 12 D
+9 8 D
+-5 23 D
+-6 2 D
+2 13 D
+-16 9 D
+3 -16 D
+-15 0 D
+-1 -10 D
+-8 2 D
+-14 -13 D
+3 9 D
+-9 6 D
+-24 -16 D
+-6 -16 D
+5 -4 D
+10 17 D
+16 -8 D
+5 9 D
+12 -8 D
+-4 -19 D
+P
+FO
+17 -11 5 -22 -11 -22 -2 16 8 8 -22 -14 0 10 11 5 -15 10 20 -3 -1 13 11 1345 591 SP
+-27 1 -10 14 19 -7 30 5 5 -7 6 9 -2 -8 7 1345 542 SP
+-11 -16 -18 -2 3 8 19 9 4 1542 476 SP
+6 0 -2 -12 -7 -1 0 6 4 1237 504 SP
+-9 -6 -2 14 12 13 -3 -16 4 1471 505 SP
+3 13 -6 2 11 8 -2 -12 4 1238 504 SP
+-6 8 8 1 4 -6 3 1331 587 SP
+-4 -5 -12 0 2 4 3 1283 450 SP
+15 0 -5 -5 -7 2 3 1345 570 SP
+-9 9 12 5 14 -9 3 1304 536 SP
+-22 -3 6 4 2 1406 595 SP
+-18 1 21 5 2 1300 457 SP
+-20 5 7 2 2 1507 593 SP
+-13 1 11 5 2 1243 564 SP
+-29 -1 18 3 2 1506 581 SP
+0 10 6 2 2 1351 633 SP
+-13 -5 1 6 2 1392 565 SP
+-8 -1 1 6 2 1406 579 SP
+8 4 -1 -6 2 1222 715 SP
+21 2 -13 -2 2 1304 562 SP
+4 6 2 -3 2 1263 450 SP
+0 12 1 -8 2 1190 487 SP
+-1 4 3 -9 -1 5 3 1304 554 SP
+3 -3 1 1227 587 SP
+7 2 1 1345 533 SP
+4 -3 1 1373 598 SP
+15 5 1 1246 446 SP
+5 1 1 1488 584 SP
+-1 -5 1 1222 501 SP
+7 1 1 1554 479 SP
+-4 3 1 1380 462 SP
+-7 -12 7 13 2 1442 501 SP
+5 -5 1 1292 660 SP
+-7 -3 1 1222 584 SP
+7 3 1 1242 448 SP
+4 3 1 1327 587 SP
+11 3 1 1394 584 SP
+3 -6 1 1438 508 SP
+3 5 1 1474 747 SP
+-5 2 1 1344 455 SP
+5 -1 1 1251 763 SP
+6 0 1 1419 480 SP
+5 2 1 1395 591 SP
+5 1 1 1334 573 SP
+6 -3 1 1452 535 SP
+-17 3 20 4 2 1271 557 SP
+5 1 1 1381 578 SP
+12 15 1 1407 465 SP
+{0 0 0.502 C} FS
+-6 -4 5 -1 2 1211 544 SP
+4 -2 1 1207 548 SP
+1 -5 1 1194 559 SP
+1781 505 M
+-5 3 D
+5 -3 D
+-10 -3 D
+-10 -3 D
+-3 2 D
+6 5 D
+-14 -2 D
+1 8 D
+-12 -4 D
+-7 14 D
+-16 5 D
+-3 11 D
+16 6 D
+-3 8 D
+-34 2 D
+1 11 D
+-23 12 D
+-85 10 D
+-1 126 D
+-5 99 D
+86 18 D
+105 27 D
+92 30 D
+67 26 D
+9 -99 D
+2 -72 D
+-1 -78 D
+-7 -82 D
+-2 -15 D
+-4 1 D
+-3 -5 D
+7 1 D
+-1 -6 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -3 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+P
+FO
+1581 489 M
+20 -16 D
+21 7 D
+8 -3 D
+15 13 D
+-22 4 D
+28 5 D
+-5 4 D
+10 1 D
+-5 8 D
+15 -2 D
+-2 5 D
+3 -3 D
+5 5 D
+1 -5 D
+22 0 D
+26 -24 D
+-12 -3 D
+-11 -3 D
+-12 -2 D
+-12 -3 D
+-11 -3 D
+-12 -3 D
+-12 -2 D
+-12 -3 D
+-12 -2 D
+-12 -2 D
+-12 -3 D
+-12 -2 D
+P
+FO
+{1 0 0 C} FS
+22 -5 -28 -9 -4 -10 0 9 -14 -5 -14 -15 3 -10 -12 -5 -4 2 8 14 -2 6 19 16 12 1787 571 SP
+-19 15 8 4 7 -7 3 1855 589 SP
+8 -18 27 -11 -38 15 3 1823 614 SP
+9 -2 -3 -6 2 1891 574 SP
+-17 -6 8 5 2 1717 616 SP
+-21 8 13 -2 2 1917 583 SP
+5 -5 -5 0 2 1733 563 SP
+0 5 3 -2 2 1887 564 SP
+-17 6 9 2 2 1886 584 SP
+2 5 1 1885 570 SP
+9 -2 1 1771 512 SP
+8 0 1 1771 625 SP
+-9 -2 1 1816 530 SP
+4 -2 1 1766 511 SP
+3 -3 1 1877 574 SP
+1 -5 1 1848 605 SP
+0 -4 1 1900 569 SP
+4 0 1 1715 562 SP
+6 0 1 1643 496 SP
+3 0 1 1891 563 SP
+-5 -2 1 1789 623 SP
+-1 -4 1 1697 571 SP
+3 0 1 1905 843 SP
+4 -1 1 1763 642 SP
+8 -2 1 1641 494 SP
+1 -4 1 1783 529 SP
+{0 0 0.502 C} FS
+3 -6 1 1608 514 SP
+-5 0 1 1597 582 SP
+{1 0 0 C} FS
+1761 499 M
+-3 2 D
+6 5 D
+-14 -2 D
+1 8 D
+-12 -4 D
+-7 14 D
+-16 5 D
+-3 11 D
+16 6 D
+-3 8 D
+-34 2 D
+1 11 D
+-23 12 D
+-85 10 D
+-4 -98 D
+20 -16 D
+21 7 D
+8 -3 D
+15 13 D
+-22 4 D
+28 5 D
+-5 4 D
+10 1 D
+-5 8 D
+15 -2 D
+-2 5 D
+3 -3 D
+5 5 D
+1 -5 D
+22 0 D
+26 -24 D
+P
+FO
+-5 3 1 1781 505 SP
+0 2 7 1 -3 -5 -4 1 4 1930 567 SP
+22 -5 -28 -9 -4 -10 0 9 -14 -5 -14 -15 3 -10 -12 -5 -4 2 8 14 -2 6 19 16 12 1787 571 SP
+-19 15 8 4 7 -7 3 1855 589 SP
+8 -18 27 -11 -38 15 3 1823 614 SP
+9 -2 -3 -6 2 1891 574 SP
+-17 -6 8 5 2 1717 616 SP
+-21 8 13 -2 2 1917 583 SP
+5 -5 -5 0 2 1733 563 SP
+0 5 3 -2 2 1887 564 SP
+-17 6 9 2 2 1886 584 SP
+2 5 1 1885 570 SP
+9 -2 1 1771 512 SP
+8 0 1 1771 625 SP
+-9 -2 1 1816 530 SP
+4 -2 1 1766 511 SP
+3 -3 1 1877 574 SP
+1 -5 1 1848 605 SP
+0 -4 1 1900 569 SP
+4 0 1 1715 562 SP
+6 0 1 1643 496 SP
+3 0 1 1891 563 SP
+-5 -2 1 1789 623 SP
+-1 -4 1 1697 571 SP
+3 0 1 1905 843 SP
+4 -1 1 1763 642 SP
+8 -2 1 1641 494 SP
+1 -4 1 1783 529 SP
+{0 0 0.502 C} FS
+3 -6 1 1608 514 SP
+-5 0 1 1597 582 SP
+1930 564 M
+12 2 D
+-12 1 D
+6 52 D
+4 83 D
+-1 96 D
+-10 115 D
+81 37 D
+11 7 D
+40 21 D
+63 40 D
+47 35 D
+17 15 D
+10 -67 D
+5 -74 D
+1 -65 D
+-6 -88 D
+-8 -54 D
+-2 -7 D
+-17 -15 D
+-37 -28 D
+-30 -21 D
+-21 -13 D
+-11 -6 D
+-11 -7 D
+-11 -6 D
+-11 -6 D
+-12 -7 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-7 -3 D
+-6 -3 D
+-6 -2 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -2 D
+-6 -3 D
+P
+FO
+{1 0 0 C} FS
+-10 16 5 -4 2 1946 577 SP
+2 -5 1 1951 577 SP
+4 0 1 1933 575 SP
+-1 4 1 2124 856 SP
+5 1 1 2092 940 SP
+0 -1 -12 1 12 2 3 1930 564 SP
+-10 16 5 -4 2 1946 577 SP
+2 -5 1 1951 577 SP
+4 0 1 1933 575 SP
+-1 4 1 2124 856 SP
+5 1 1 2092 940 SP
+{0 0 0.502 C} FS
+2327 902 M
+-22 -49 D
+-31 -48 D
+-25 -32 D
+-28 -31 D
+-33 -29 D
+9 53 D
+6 79 D
+1 65 D
+-6 91 D
+-10 67 D
+25 22 D
+43 46 D
+29 40 D
+24 40 D
+18 42 D
+11 -74 D
+4 -40 D
+2 -65 D
+-1 -49 D
+-5 -56 D
+-8 -56 D
+P
+FO
+2338 944 M
+-11 -42 D
+11 72 D
+4 40 D
+2 56 D
+-1 57 D
+-5 57 D
+-8 57 D
+-3 17 D
+13 50 D
+4 42 D
+-1 34 D
+-5 34 D
+15 -87 D
+8 -87 D
+1 -101 D
+-6 -87 D
+-15 -99 D
+P
+FO
+{1 0 0 C} FS
+1 1 -1 -4 2 2352 1141 SP
+1 1 -1 -4 2 2352 1141 SP
+{0 0 0.502 C} FS
+0 -2 3 -7 -1 2 3 65 795 SP
+0 -2 1 -2 0 -2 0 1 -1 7 5 36 898 SP
+{1 0 0 C} FS
+65 795 M
+-20 65 D
+-10 46 D
+-5 13 D
+-6 25 D
+11 -50 D
+26 -87 D
+P
+FO
+{0 0 0.502 C} FS
+64 797 M
+-28 101 D
+0 4 D
+17 -41 D
+29 -48 D
+31 -40 D
+36 -38 D
+25 -22 D
+13 -60 D
+17 -58 D
+25 -62 D
+18 -39 D
+25 -44 D
+23 -36 D
+-35 33 D
+-35 41 D
+-30 42 D
+-45 75 D
+-35 67 D
+-35 81 D
+P
+FO
+{1 0 0 C} FS
+154 598 M
+4 -6 D
+-41 99 D
+1 2 D
+-9 23 D
+2 -1 D
+4 -11 D
+0 6 D
+-24 63 D
+-1 6 D
+-1 -3 D
+4 -17 D
+-1 -2 D
+-3 7 D
+4 -12 D
+-2 3 D
+2 -12 D
+-2 8 D
+0 -5 D
+3 -6 D
+-3 7 D
+-1 -1 D
+3 -8 D
+-4 8 D
+-6 8 D
+5 -16 D
+32 -77 D
+P
+FO
+2 0 2 -7 2 197 575 SP
+-2 11 2 -6 2 55 841 SP
+-1 6 2 -7 2 62 824 SP
+-4 8 7 -10 2 184 579 SP
+2 -6 1 68 806 SP
+2 -4 1 89 767 SP
+2 -5 1 59 828 SP
+-1 4 1 119 690 SP
+{0 0 0.502 C} FS
+-2 4 1 114 693 SP
+{1 0 0 C} FS
+64 797 M
+-28 101 D
+13 -51 D
+P
+FO
+154 598 M
+4 -6 D
+-41 99 D
+1 2 D
+-9 23 D
+2 -1 D
+4 -11 D
+0 6 D
+-24 63 D
+-1 6 D
+-1 -3 D
+4 -17 D
+-1 -2 D
+-3 7 D
+4 -12 D
+-2 3 D
+2 -12 D
+-2 8 D
+0 -5 D
+3 -6 D
+-3 7 D
+-1 -1 D
+3 -8 D
+-4 8 D
+-6 8 D
+5 -16 D
+32 -77 D
+P
+FO
+2 0 2 -7 2 197 575 SP
+-2 11 2 -6 2 55 841 SP
+-1 6 2 -7 2 62 824 SP
+-4 8 7 -10 2 184 579 SP
+2 -6 1 68 806 SP
+2 -4 1 89 767 SP
+2 -5 1 59 828 SP
+-1 4 1 119 690 SP
+{0 0 0.502 C} FS
+-2 4 1 114 693 SP
+524 278 M
+-77 35 D
+-49 28 D
+-46 29 D
+-41 31 D
+-16 13 D
+-27 42 D
+-27 51 D
+-32 74 D
+-20 65 D
+-14 59 D
+-1 8 D
+17 -15 D
+67 -49 D
+60 -35 D
+29 -16 D
+74 -35 D
+12 -5 D
+13 -72 D
+14 -54 D
+16 -51 D
+30 -71 D
+P
+FO
+831 189 M
+-96 20 D
+-110 31 D
+-78 28 D
+-23 10 D
+-18 32 D
+-32 77 D
+-20 65 D
+-15 70 D
+-6 36 D
+67 -26 D
+85 -28 D
+112 -29 D
+39 -9 D
+47 -9 D
+9 -83 D
+8 -58 D
+15 -70 D
+P
+FO
+1179 422 M
+2 -1 D
+0 -142 D
+-17 -2 D
+-33 -10 D
+-12 3 D
+-40 -15 D
+-6 -9 D
+-7 9 D
+-9 -31 D
+18 -23 D
+-7 5 D
+-3 -3 D
+-4 8 D
+7 -13 D
+-13 6 D
+34 -34 D
+3 -10 D
+-111 8 D
+-129 17 D
+-21 4 D
+-15 51 D
+-20 101 D
+-12 102 D
+-1 14 D
+88 -14 D
+124 -14 D
+108 -6 D
+P
+FO
+{1 0 0 C} FS
+-5 6 1 1055 206 SP
+3 2 1 1091 267 SP
+-1 -3 1 1053 217 SP
+0 2 1 1053 218 SP
+1181 279 M
+-17 -2 D
+-33 -10 D
+-12 3 D
+-40 -15 D
+-6 -9 D
+-7 9 D
+-9 -31 D
+18 -23 D
+-7 5 D
+-3 -3 D
+-4 8 D
+7 -13 D
+-13 6 D
+34 -34 D
+3 -10 D
+89 -2 D
+P
+FO
+0 1 2 -1 2 1179 422 SP
+-5 6 1 1055 206 SP
+3 2 1 1091 267 SP
+-1 -3 1 1053 217 SP
+0 2 1 1053 218 SP
+{0 0 0.502 C} FS
+1181 421 M
+9 -4 D
+8 5 D
+-1 0 D
+56 1 D
+-2 -6 D
+11 2 D
+10 5 D
+63 3 D
+100 9 D
+129 18 D
+15 3 D
+-10 -96 D
+-3 -18 D
+-7 -1 D
+-9 7 D
+-43 7 D
+-23 11 D
+15 21 D
+-3 5 D
+11 2 D
+1 8 D
+10 8 D
+-7 6 D
+-12 -11 D
+1 6 D
+-7 -3 D
+5 5 D
+-14 -8 D
+-9 5 D
+-12 -5 D
+-4 6 D
+-8 -3 D
+-29 8 D
+-5 -4 D
+19 -2 D
+0 -8 D
+-26 -5 D
+-3 3 D
+-10 -6 D
+3 -4 D
+-7 3 D
+3 -4 D
+-8 0 D
+-1 -11 D
+-10 -3 D
+-10 -13 D
+12 -4 D
+-8 -8 D
+-6 4 D
+-3 -6 D
+-1 5 D
+-10 2 D
+-7 -5 D
+3 -6 D
+-5 4 D
+-2 -5 D
+5 12 D
+-16 10 D
+-11 3 D
+-5 -8 D
+-1 4 D
+-7 -5 D
+-4 5 D
+-2 -11 D
+-6 6 D
+-10 -8 D
+7 -6 D
+-13 0 D
+8 -6 D
+-11 4 D
+-6 -6 D
+2 -5 D
+5 3 D
+-7 -8 D
+11 0 D
+-11 -3 D
+-17 5 D
+-1 -7 D
+9 -2 D
+-1 -6 D
+-7 3 D
+0 -8 D
+-12 17 D
+-15 -13 D
+4 -12 D
+-25 -19 D
+-22 -4 D
+P
+FO
+{1 0 0 C} FS
+12 9 11 -11 -8 5 -4 -3 4 1402 411 SP
+-4 9 12 1 -2 -4 3 1505 384 SP
+-6 7 13 1 2 1382 403 SP
+4 3 1 1503 418 SP
+11 3 1 1552 354 SP
+8 7 1 1242 409 SP
+7 2 1 1215 413 SP
+-1 -5 1 1434 420 SP
+4 5 1 1494 412 SP
+6 8 1 1509 423 SP
+{0 0 0.502 C} FS
+8 2 -2 8 2 1353 327 SP
+1 5 1 1443 319 SP
+{1 0 0 C} FS
+1566 343 M
+-7 -1 D
+-9 7 D
+-43 7 D
+-23 11 D
+15 21 D
+-3 5 D
+11 2 D
+1 8 D
+10 8 D
+-7 6 D
+-12 -11 D
+1 6 D
+-7 -3 D
+5 5 D
+-14 -8 D
+-9 5 D
+-12 -5 D
+-4 6 D
+-8 -3 D
+-29 8 D
+-5 -4 D
+19 -2 D
+0 -8 D
+-26 -5 D
+-3 3 D
+-10 -6 D
+3 -4 D
+-7 3 D
+3 -4 D
+-8 0 D
+-1 -11 D
+-10 -3 D
+-10 -13 D
+12 -4 D
+-8 -8 D
+-6 4 D
+-3 -6 D
+-1 5 D
+-10 2 D
+-7 -5 D
+3 -6 D
+-5 4 D
+-2 -5 D
+5 12 D
+-16 10 D
+-11 3 D
+-5 -8 D
+-1 4 D
+-7 -5 D
+-4 5 D
+-2 -11 D
+-6 6 D
+-10 -8 D
+7 -6 D
+-13 0 D
+8 -6 D
+-11 4 D
+-6 -6 D
+2 -5 D
+5 3 D
+-7 -8 D
+11 0 D
+-11 -3 D
+-17 5 D
+-1 -7 D
+9 -2 D
+-1 -6 D
+-7 3 D
+0 -8 D
+-12 17 D
+-15 -13 D
+4 -12 D
+-25 -19 D
+-22 -4 D
+0 -121 D
+89 2 D
+111 8 D
+129 17 D
+21 4 D
+19 67 D
+13 64 D
+P
+FO
+-9 -1 10 5 11 2 -2 -6 4 1253 423 SP
+-8 0 -8 0 -1 0 8 5 9 -4 5 1181 421 SP
+12 9 11 -11 -8 5 -4 -3 4 1402 411 SP
+-4 9 12 1 -2 -4 3 1505 384 SP
+-6 7 13 1 2 1382 403 SP
+4 3 1 1503 418 SP
+11 3 1 1552 354 SP
+8 7 1 1242 409 SP
+7 2 1 1215 413 SP
+-1 -5 1 1434 420 SP
+4 5 1 1494 412 SP
+6 8 1 1509 423 SP
+{0 0 0.502 C} FS
+8 2 -2 8 2 1353 327 SP
+1 5 1 1443 319 SP
+1743 242 M
+12 17 D
+-2 13 D
+10 17 D
+-14 17 D
+-13 2 D
+2 14 D
+-1 -4 D
+-8 4 D
+-2 -7 D
+-3 3 D
+-4 -4 D
+-5 28 D
+-39 7 D
+0 27 D
+-9 4 D
+3 22 D
+-14 8 D
+-14 -7 D
+-1 23 D
+-15 29 D
+-8 -5 D
+-3 -17 D
+-10 -10 D
+7 1 D
+-11 -21 D
+1 -17 D
+-25 -41 D
+-11 -2 D
+9 68 D
+4 46 D
+84 17 D
+58 14 D
+1 -1 D
+36 6 D
+7 -3 D
+13 11 D
+-15 -3 D
+-2 1 D
+20 6 D
+3 -2 D
+-3 2 D
+45 14 D
+91 34 D
+12 5 D
+-10 -58 D
+-13 -55 D
+-11 -39 D
+-23 -61 D
+-27 -57 D
+-6 -10 D
+-10 -4 D
+-9 -4 D
+-9 -3 D
+-10 -4 D
+-9 -4 D
+-10 -3 D
+-10 -4 D
+-9 -3 D
+-10 -3 D
+P
+FO
+{1 0 0 C} FS
+8 14 0 -4 2 1762 295 SP
+-1 -4 1 1760 277 SP
+9 -1 1 1815 495 SP
+2 4 1 1757 269 SP
+6 1 1 1805 503 SP
+1743 242 M
+12 17 D
+-2 13 D
+10 17 D
+-14 17 D
+-13 2 D
+2 14 D
+-1 -4 D
+-8 4 D
+-2 -7 D
+-3 3 D
+-4 -4 D
+-5 28 D
+-39 7 D
+0 27 D
+-9 4 D
+3 22 D
+-14 8 D
+-14 -7 D
+-1 23 D
+-15 29 D
+-8 -5 D
+-3 -17 D
+-10 -10 D
+7 1 D
+-11 -21 D
+1 -17 D
+-25 -41 D
+-11 -2 D
+-7 -45 D
+-17 -72 D
+-11 -37 D
+96 20 D
+110 31 D
+P
+FO
+3 -2 1 1781 505 SP
+-7 -2 -7 -2 -7 -2 -6 -1 -7 -2 -2 1 -15 -3 13 11 7 -3 36 6 1 -1 11 1721 488 SP
+8 14 0 -4 2 1762 295 SP
+-1 -4 1 1760 277 SP
+9 -1 1 1815 495 SP
+2 4 1 1757 269 SP
+6 1 1 1805 503 SP
+{0 0 0.502 C} FS
+2164 613 M
+-19 -23 D
+15 13 D
+1 4 D
+-5 -7 D
+8 13 D
+-4 -12 D
+-2 -2 D
+2 2 D
+-20 -53 D
+-17 -39 D
+-23 -43 D
+-29 -46 D
+-4 -6 D
+-31 -25 D
+-26 -19 D
+-27 -18 D
+-18 -11 D
+-20 -11 D
+-20 -11 D
+-21 -11 D
+-21 -10 D
+-11 -5 D
+-11 -5 D
+-11 -5 D
+-11 -5 D
+17 32 D
+21 47 D
+22 62 D
+14 54 D
+11 56 D
+5 29 D
+81 37 D
+57 31 D
+47 30 D
+48 35 D
+18 14 D
+8 8 D
+-6 -32 D
+-15 -56 D
+P
+FO
+{1 0 0 C} FS
+4 2 2 -5 -3 -3 3 2016 515 SP
+5 0 -13 -18 -1 7 3 2140 573 SP
+-5 9 7 6 0 -9 3 2010 524 SP
+-15 3 6 2 2 1957 558 SP
+-1 3 4 2 2 2024 483 SP
+6 -12 -28 11 2 1980 420 SP
+1 8 1 2028 521 SP
+4 0 1 2023 510 SP
+5 5 1 0 2 2127 551 SP
+-5 -5 1 2028 530 SP
+3 3 1 2024 541 SP
+4 5 1 1982 439 SP
+2 -2 -3 2 2 1993 441 SP
+-6 -3 6 4 2 2019 494 SP
+4 1 1 2024 516 SP
+-1 3 1 1997 436 SP
+2 -2 1 2024 477 SP
+-5 -3 1 2016 587 SP
+-2 -2 1 2160 601 SP
+-5 -7 1 4 15 13 -19 -23 4 2164 613 SP
+4 2 2 -5 -3 -3 3 2016 515 SP
+5 0 -13 -18 -1 7 3 2140 573 SP
+-5 9 7 6 0 -9 3 2010 524 SP
+-15 3 6 2 2 1957 558 SP
+-1 3 4 2 2 2024 483 SP
+6 -12 -28 11 2 1980 420 SP
+1 8 1 2028 521 SP
+4 0 1 2023 510 SP
+5 5 1 0 2 2127 551 SP
+-5 -5 1 2028 530 SP
+3 3 1 2024 541 SP
+4 5 1 1982 439 SP
+2 -2 -3 2 2 1993 441 SP
+-6 -3 6 4 2 2019 494 SP
+4 1 1 2024 516 SP
+-1 3 1 1997 436 SP
+2 -2 1 2024 477 SP
+-5 -3 1 2016 587 SP
+{0 0 0.502 C} FS
+2160 601 M
+2 5 D
+-2 -5 D
+16 55 D
+11 50 D
+1 7 D
+33 29 D
+41 47 D
+23 32 D
+24 40 D
+18 41 D
+-13 -54 D
+-23 -72 D
+-33 -81 D
+-22 -45 D
+-36 -66 D
+-47 -75 D
+-27 -35 D
+-31 -34 D
+-28 -26 D
+19 29 D
+21 35 D
+22 44 D
+11 26 D
+P
+FO
+{1 0 0 C} FS
+-4 -4 3 4 2 2245 720 SP
+5 4 1 2239 719 SP
+2 2 1 2177 577 SP
+3 4 1 2250 724 SP
+2 5 1 2160 601 SP
+-4 -4 3 4 2 2245 720 SP
+5 4 1 2239 719 SP
+2 2 1 2177 577 SP
+3 4 1 2250 724 SP
+{0 0 0.502 C} FS
+2295 788 M
+14 45 D
+11 38 D
+9 40 D
+9 33 D
+-22 -91 D
+P
+FO
+217 499 M
+31 -39 D
+19 -20 D
+28 -26 D
+21 -29 D
+41 -48 D
+41 -40 D
+10 -9 D
+-39 35 D
+-63 65 D
+-34 39 D
+-48 62 D
+P
+FO
+693 107 M
+-49 22 D
+-70 39 D
+-54 34 D
+-42 30 D
+-20 16 D
+-11 7 D
+-60 52 D
+-39 40 D
+-23 27 D
+-30 40 D
+23 -19 D
+43 -31 D
+46 -29 D
+51 -27 D
+66 -30 D
+18 -30 D
+28 -38 D
+22 -25 D
+15 -16 D
+33 -28 D
+44 -29 D
+P
+FO
+921 41 M
+-81 17 D
+-85 25 D
+-62 24 D
+-27 16 D
+-26 18 D
+-33 28 D
+-23 24 D
+-35 45 D
+-19 30 D
+-6 10 D
+58 -23 D
+68 -23 D
+85 -23 D
+96 -20 D
+17 -45 D
+24 -45 D
+12 -20 D
+23 -26 D
+P
+FO
+1092 160 M
+1 -5 D
+16 -15 D
+-2 -13 D
+-12 -1 D
+3 -8 D
+26 -7 D
+23 -1 D
+34 10 D
+0 -102 D
+-11 0 D
+-11 0 D
+-55 2 D
+-109 9 D
+-74 12 D
+-19 17 D
+-18 21 D
+-24 41 D
+-19 41 D
+-10 28 D
+129 -19 D
+95 -8 D
+P
+FO
+{1 0 0 C} FS
+-11 1 -11 0 -11 0 -12 0 -11 1 -11 0 -11 0 0 38 2 0 32 10 23 -1 26 -7 3 -8 -12 -1 -2 -13 16 -15 1 -5 17 1092 160 SP
+{0 0 0.502 C} FS
+1181 120 M
+60 1 D
+13 9 D
+31 8 D
+91 15 D
+49 -4 D
+-3 -5 D
+10 -1 D
+9 -11 D
+-6 -1 D
+12 -2 D
+1 4 D
+36 19 D
+1 6 D
+0 -10 D
+-11 -7 D
+-2 -7 D
+-7 -1 D
+-4 -4 D
+15 4 D
+9 9 D
+5 -5 D
+-11 -8 D
+13 3 D
+8 -2 D
+2 -2 D
+-1 0 D
+-2 -8 D
+3 -1 D
+-11 -20 D
+-20 -28 D
+-17 -19 D
+-13 -11 D
+-11 -2 D
+-10 -2 D
+-11 -1 D
+-10 -2 D
+-11 -2 D
+-10 -1 D
+-11 -2 D
+-11 -1 D
+-11 -1 D
+-10 -1 D
+-11 -1 D
+-11 -1 D
+-11 -1 D
+-11 -1 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 -1 D
+-11 0 D
+-11 0 D
+-11 -1 D
+-11 0 D
+-11 0 D
+-11 0 D
+P
+FO
+{1 0 0 C} FS
+-24 -4 19 5 2 1460 123 SP
+1181 120 M
+60 1 D
+13 9 D
+31 8 D
+91 15 D
+49 -4 D
+-3 -5 D
+10 -1 D
+9 -11 D
+-6 -1 D
+12 -2 D
+1 4 D
+36 19 D
+1 6 D
+0 -10 D
+-11 -7 D
+-2 -7 D
+-7 -1 D
+-4 -4 D
+15 4 D
+9 9 D
+5 -5 D
+-11 -8 D
+13 3 D
+8 -2 D
+2 -2 D
+-1 0 D
+-2 -8 D
+3 -1 D
+23 53 D
+6 17 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 0 D
+-7 -1 D
+-8 -1 D
+-7 0 D
+-7 -1 D
+-8 0 D
+-7 -1 D
+-7 0 D
+-8 -1 D
+-7 0 D
+-8 -1 D
+-7 0 D
+-7 0 D
+-8 -1 D
+-7 0 D
+-8 0 D
+-7 -1 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+P
+FO
+-24 -4 19 5 2 1460 123 SP
+{0 0 0.502 C} FS
+1502 119 M
+6 -4 D
+41 3 D
+25 13 D
+1 -2 D
+-7 -3 D
+12 3 D
+-3 -3 D
+10 0 D
+2 2 D
+29 13 D
+-8 -3 D
+39 15 D
+14 17 D
+14 8 D
+-3 1 D
+17 16 D
+26 17 D
+-1 2 D
+17 15 D
+10 13 D
+58 21 D
+38 15 D
+-39 -59 D
+-37 -42 D
+-41 -36 D
+-26 -18 D
+-18 -11 D
+-9 -5 D
+-8 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-10 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -2 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-10 -2 D
+-10 -2 D
+-10 -3 D
+-10 -2 D
+-10 -2 D
+-11 -2 D
+-10 -2 D
+-10 -2 D
+17 15 D
+25 31 D
+12 18 D
+P
+FO
+{1 0 0 C} FS
+-1 -3 -5 0 6 -4 -3 -6 -24 -2 -23 -9 5 10 1 -1 11 9 7 0 11 7 9 1 12 1558 93 SP
+-2 2 4 1 2 1605 123 SP
+6 3 1 1572 96 SP
+0 2 1 1551 111 SP
+{0 0 0.502 C} FS
+-2 1 1 1563 96 SP
+2 2 1 1549 122 SP
+3 4 1 1665 193 SP
+1 3 1 1615 152 SP
+{1 0 0 C} FS
+1502 119 M
+6 -4 D
+41 3 D
+25 13 D
+1 -2 D
+-7 -3 D
+12 3 D
+-3 -3 D
+10 0 D
+2 2 D
+29 13 D
+-8 -3 D
+39 15 D
+14 17 D
+14 8 D
+-3 1 D
+17 16 D
+26 17 D
+-1 2 D
+17 15 D
+10 13 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-22 -56 D
+P
+FO
+-1 -3 -5 0 6 -4 -3 -6 -24 -2 -23 -9 5 10 1 -1 11 9 7 0 11 7 9 1 12 1558 93 SP
+-2 2 4 1 2 1605 123 SP
+6 3 1 1572 96 SP
+0 2 1 1551 111 SP
+{0 0 0.502 C} FS
+-2 1 1 1563 96 SP
+2 2 1 1549 122 SP
+3 4 1 1665 193 SP
+1 3 1 1615 152 SP
+1732 136 M
+-14 -7 D
+-16 -8 D
+-8 -3 D
+-16 -8 D
+-9 -3 D
+27 16 D
+35 25 D
+32 29 D
+37 42 D
+26 38 D
+13 21 D
+76 35 D
+50 28 D
+37 23 D
+50 37 D
+15 13 D
+-25 -34 D
+-37 -43 D
+-40 -40 D
+-11 -9 D
+-39 -33 D
+-41 -31 D
+-32 -22 D
+-32 -21 D
+-22 -13 D
+-22 -13 D
+-23 -13 D
+P
+FO
+{1 0 0 C} FS
+1911 254 M
+-6 -5 D
+12 9 D
+41 35 D
+20 19 D
+-15 -14 D
+-7 -3 D
+7 9 D
+-6 -8 D
+-5 -2 D
+7 7 D
+0 2 D
+6 7 D
+-3 -3 D
+-2 1 D
+-4 -3 D
+4 5 D
+-4 -3 D
+-5 -12 D
+2 3 D
+4 2 D
+-6 -5 D
+-3 -4 D
+5 3 D
+-4 -3 D
+-4 -5 D
+-14 -13 D
+-13 -10 D
+5 2 D
+P
+FO
+1807 180 M
+47 31 D
+-1 0 D
+9 6 D
+-1 -1 D
+42 32 D
+-5 -3 D
+7 5 D
+-14 -10 D
+2 3 D
+5 3 D
+-12 -8 D
+-37 -29 D
+-24 -16 D
+-35 -21 D
+-1 -2 D
+-2 0 D
+-11 -8 D
+P
+FO
+-10 -6 3 2 2 1778 163 SP
+4 4 1 1901 247 SP
+{0 0 0.502 C} FS
+-5 -4 1 1821 191 SP
+-4 -3 1 1823 192 SP
+-1 -1 1 1785 168 SP
+6 4 1 1940 280 SP
+-2 -2 1 1808 182 SP
+-13 -9 1 1842 204 SP
+-5 -4 1 1837 201 SP
+0 -1 1 1846 207 SP
+{1 0 0 C} FS
+1911 254 M
+-6 -5 D
+12 9 D
+41 35 D
+20 19 D
+-15 -14 D
+-7 -3 D
+7 9 D
+-6 -8 D
+-5 -2 D
+7 7 D
+0 2 D
+6 7 D
+-3 -3 D
+-2 1 D
+-4 -3 D
+4 5 D
+-4 -3 D
+-5 -12 D
+2 3 D
+4 2 D
+-6 -5 D
+-3 -4 D
+5 3 D
+-4 -3 D
+-4 -5 D
+-14 -13 D
+-13 -10 D
+5 2 D
+P
+FO
+1807 180 M
+47 31 D
+-1 0 D
+9 6 D
+-1 -1 D
+42 32 D
+-5 -3 D
+7 5 D
+-14 -10 D
+2 3 D
+5 3 D
+-12 -8 D
+-37 -29 D
+-24 -16 D
+-35 -21 D
+-1 -2 D
+-2 0 D
+-11 -8 D
+P
+FO
+-10 -6 3 2 2 1778 163 SP
+4 4 1 1901 247 SP
+{0 0 0.502 C} FS
+-5 -4 1 1821 191 SP
+-4 -3 1 1823 192 SP
+-1 -1 1 1785 168 SP
+6 4 1 1940 280 SP
+-2 -2 1 1808 182 SP
+-13 -9 1 1842 204 SP
+-5 -4 1 1837 201 SP
+0 -1 1 1846 207 SP
+1954 288 M
+21 19 D
+39 40 D
+32 38 D
+21 29 D
+35 33 D
+35 41 D
+8 11 D
+-38 -52 D
+-59 -69 D
+-27 -28 D
+-47 -45 D
+P
+FO
+630 136 M
+55 -26 D
+39 -18 D
+-71 32 D
+P
+FO
+724 92 M
+-31 15 D
+44 -17 D
+46 -16 D
+67 -18 D
+71 -15 D
+15 -10 D
+15 -7 D
+19 -5 D
+-76 16 D
+-86 25 D
+P
+FO
+970 19 M
+-24 7 D
+-20 11 D
+-5 4 D
+85 -13 D
+109 -9 D
+66 -1 D
+0 -18 D
+-12 0 D
+-88 4 D
+-87 11 D
+P
+FO
+1181 0 M
+0 18 D
+77 2 D
+109 9 D
+74 12 D
+-15 -10 D
+-10 -5 D
+-5 -2 D
+-5 -2 D
+-5 -1 D
+-5 -1 D
+-16 -3 D
+-12 -2 D
+-12 -2 D
+-13 -2 D
+-12 -1 D
+-13 -2 D
+-12 -1 D
+-13 -2 D
+-12 -1 D
+-12 -1 D
+-13 -1 D
+-12 0 D
+-13 -1 D
+-12 0 D
+-13 -1 D
+-12 0 D
+P
+FO
+1393 19 M
+23 7 D
+20 11 D
+5 4 D
+81 17 D
+76 22 D
+63 23 D
+8 4 D
+-18 -9 D
+-10 -5 D
+-15 -6 D
+-12 -5 D
+-12 -4 D
+-12 -5 D
+-12 -4 D
+-12 -4 D
+-12 -5 D
+-12 -4 D
+-12 -3 D
+-13 -4 D
+-12 -4 D
+-12 -3 D
+-13 -3 D
+-12 -4 D
+-13 -3 D
+-12 -3 D
+-13 -2 D
+-12 -3 D
+-13 -3 D
+P
+FO
+1638 92 M
+31 15 D
+41 18 D
+22 11 D
+-23 -12 D
+-12 -5 D
+-23 -11 D
+-12 -6 D
+-12 -5 D
+P
+FO
+25 W
+4 W
+408 2074 M
+42 34 D
+62 40 D
+45 24 D
+69 29 D
+58 18 D
+60 13 D
+70 10 D
+71 4 D
+57 -1 D
+83 -8 D
+50 -8 D
+17 -3 D
+S
+0 1181 M
+2 59 D
+8 76 D
+13 66 D
+15 58 D
+22 64 D
+24 56 D
+35 69 D
+27 45 D
+35 51 D
+32 42 D
+35 41 D
+36 39 D
+7 6 D
+6 7 D
+27 24 D
+6 7 D
+63 52 D
+60 44 D
+79 49 D
+75 39 D
+69 31 D
+99 36 D
+83 23 D
+66 15 D
+86 13 D
+39 5 D
+29 2 D
+S
+408 288 M
+-35 33 D
+-21 21 D
+-14 17 D
+-28 34 D
+-37 55 D
+-29 53 D
+-19 41 D
+-20 50 D
+-22 75 D
+-16 87 D
+-7 65 D
+-2 84 D
+3 59 D
+8 78 D
+18 96 D
+21 79 D
+29 88 D
+32 78 D
+28 60 D
+41 76 D
+24 41 D
+37 57 D
+28 39 D
+41 55 D
+37 45 D
+59 65 D
+20 21 D
+56 53 D
+37 32 D
+29 25 D
+38 30 D
+54 39 D
+55 36 D
+40 25 D
+58 31 D
+49 25 D
+75 32 D
+17 6 D
+S
+854 46 M
+-45 18 D
+-36 24 D
+-21 18 D
+-38 44 D
+-28 45 D
+-25 50 D
+-29 82 D
+-17 73 D
+-12 71 D
+-9 84 D
+-3 90 D
+1 102 D
+5 79 D
+10 100 D
+17 112 D
+16 84 D
+21 94 D
+28 104 D
+34 111 D
+36 100 D
+21 54 D
+41 95 D
+27 58 D
+50 96 D
+35 61 D
+45 71 D
+37 53 D
+19 25 D
+38 48 D
+38 43 D
+15 16 D
+5 4 D
+S
+1181 0 M
+0 2149 D
+S
+1509 46 M
+44 18 D
+29 19 D
+28 23 D
+38 44 D
+23 35 D
+30 60 D
+29 82 D
+19 80 D
+15 102 D
+6 86 D
+2 92 D
+-4 104 D
+-11 117 D
+-11 83 D
+-13 75 D
+-25 122 D
+-32 122 D
+-31 103 D
+-45 127 D
+-47 114 D
+-39 84 D
+-42 81 D
+-25 46 D
+-58 94 D
+-51 73 D
+-57 71 D
+-15 16 D
+-9 11 D
+-24 25 D
+S
+1954 288 M
+41 38 D
+25 27 D
+32 40 D
+37 55 D
+26 46 D
+28 62 D
+14 36 D
+18 60 D
+14 62 D
+11 80 D
+4 83 D
+-1 60 D
+-7 77 D
+-12 79 D
+-15 70 D
+-23 79 D
+-24 70 D
+-29 69 D
+-41 85 D
+-37 67 D
+-41 66 D
+-33 48 D
+-59 77 D
+-57 66 D
+-40 43 D
+-70 67 D
+-66 56 D
+-69 52 D
+-24 16 D
+-15 11 D
+-88 54 D
+-91 47 D
+-75 32 D
+-17 6 D
+S
+2362 1181 M
+-1 51 D
+-10 92 D
+-12 58 D
+-15 58 D
+-25 72 D
+-28 63 D
+-32 62 D
+-23 37 D
+-19 29 D
+-31 43 D
+-34 42 D
+-29 33 D
+-25 26 D
+-7 6 D
+-6 7 D
+-47 43 D
+-56 46 D
+-68 48 D
+-64 39 D
+-83 43 D
+-61 27 D
+-90 33 D
+-83 24 D
+-75 17 D
+-86 13 D
+-39 5 D
+-29 2 D
+S
+1954 2074 M
+-7 7 D
+-47 35 D
+-49 32 D
+-46 24 D
+-69 29 D
+-58 18 D
+-60 13 D
+-69 10 D
+-72 4 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-9 -2 D
+-8 -1 D
+-9 -1 D
+-8 -2 D
+-8 -2 D
+-9 -1 D
+S
+1509 2316 M
+-28 6 D
+-43 3 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-10 -4 D
+-9 -4 D
+-10 -4 D
+-19 -10 D
+-19 -11 D
+-29 -19 D
+-9 -6 D
+S
+1181 2362 M
+0 -110 D
+S
+854 2316 M
+27 6 D
+43 3 D
+45 -6 D
+37 -9 D
+47 -19 D
+48 -27 D
+29 -19 D
+S
+1092 2226 M
+83 -20 D
+6 -2 D
+S
+1130 2155 M
+14 15 D
+37 34 D
+S
+1270 2174 M
+-44 16 D
+-45 14 D
+S
+1233 2245 M
+-30 -23 D
+-22 -18 D
+S
+1092 2226 M
+-8 -9 D
+-5 -10 D
+-1 -11 D
+7 -15 D
+8 -7 D
+1 -2 D
+20 -11 D
+29 -9 D
+27 -3 D
+37 1 D
+31 7 D
+23 10 D
+6 4 D
+1 2 D
+10 9 D
+6 13 D
+-1 14 D
+-9 13 D
+-10 9 D
+-11 6 D
+-37 12 D
+-37 3 D
+-4 -1 D
+-3 0 D
+-3 0 D
+-4 0 D
+-3 0 D
+-3 -1 D
+-4 0 D
+-3 -1 D
+-3 0 D
+-3 -1 D
+-4 0 D
+-3 -1 D
+-3 -1 D
+-3 0 D
+-3 -1 D
+-3 -1 D
+-3 -1 D
+-5 -2 D
+-3 -1 D
+-3 -1 D
+-7 -4 D
+-6 -4 D
+-3 -1 D
+P S
+217 499 M
+23 -30 D
+36 -38 D
+25 -22 D
+46 -35 D
+30 -21 D
+61 -35 D
+54 -27 D
+79 -32 D
+77 -26 D
+104 -28 D
+102 -20 D
+106 -15 D
+92 -8 D
+84 -3 D
+76 -1 D
+93 4 D
+83 7 D
+123 16 D
+102 21 D
+82 21 D
+71 23 D
+80 31 D
+50 23 D
+41 21 D
+50 29 D
+67 49 D
+33 29 D
+15 16 D
+8 7 D
+32 39 D
+3 5 D
+S
+0 1181 M
+2 -37 D
+3 -20 D
+14 -48 D
+12 -29 D
+14 -28 D
+31 -46 D
+22 -28 D
+47 -48 D
+67 -54 D
+59 -39 D
+13 -7 D
+53 -29 D
+56 -27 D
+91 -37 D
+81 -27 D
+112 -30 D
+99 -21 D
+84 -13 D
+85 -11 D
+106 -8 D
+98 -3 D
+126 1 D
+78 5 D
+124 12 D
+85 13 D
+91 18 D
+96 23 D
+92 28 D
+86 32 D
+87 39 D
+73 40 D
+65 43 D
+42 32 D
+20 17 D
+4 5 D
+35 34 D
+31 36 D
+31 47 D
+15 28 D
+19 48 D
+9 39 D
+3 19 D
+1 31 D
+S
+217 1863 M
+-25 -39 D
+-18 -42 D
+-10 -33 D
+-5 -34 D
+-1 -34 D
+6 -42 D
+9 -33 D
+10 -25 D
+17 -33 D
+27 -40 D
+34 -39 D
+31 -30 D
+55 -43 D
+52 -33 D
+39 -22 D
+54 -27 D
+26 -11 D
+53 -21 D
+55 -19 D
+88 -26 D
+85 -19 D
+88 -15 D
+90 -12 D
+108 -8 D
+110 -2 D
+101 3 D
+125 11 D
+106 16 D
+86 18 D
+89 23 D
+92 31 D
+59 24 D
+37 17 D
+53 27 D
+44 26 D
+67 49 D
+33 29 D
+30 31 D
+25 31 D
+26 40 D
+19 42 D
+12 41 D
+4 26 D
+1 34 D
+-5 42 D
+-11 42 D
+-23 49 D
+-20 30 D
+S
+670 2215 M
+-27 -26 D
+-22 -28 D
+-11 -18 D
+-15 -39 D
+-4 -29 D
+1 -29 D
+7 -29 D
+13 -29 D
+5 -9 D
+13 -19 D
+33 -35 D
+31 -25 D
+35 -23 D
+40 -22 D
+60 -25 D
+57 -19 D
+88 -21 D
+84 -12 D
+68 -5 D
+97 -1 D
+68 5 D
+66 8 D
+82 16 D
+60 17 D
+70 26 D
+35 17 D
+33 18 D
+40 28 D
+16 12 D
+4 5 D
+22 21 D
+22 28 D
+16 28 D
+10 29 D
+4 19 D
+1 20 D
+-4 29 D
+-9 29 D
+-14 28 D
+-13 19 D
+-28 31 D
+-41 33 D
+-43 27 D
+-56 27 D
+-54 20 D
+-42 13 D
+-71 17 D
+-84 13 D
+-77 6 D
+-87 1 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-9 -2 D
+-10 -1 D
+-9 -1 D
+-9 -2 D
+-10 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -3 D
+-8 -2 D
+-9 -2 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-8 -2 D
+-9 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-13 -7 D
+-13 -7 D
+-18 -12 D
+-17 -12 D
+P S
+8 W
+%%EndObject
+-2362 -2362 TM
+PSL_completion /PSL_completion {} def
+0 A
+FQ
+O0
+4724 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pscoast -Rg -JG210/30/1.9685i -Gred -Snavy -Bg -B+n -Xa3.937i -Ya0i
+%@PROJ: ortho 0.00000000 360.00000000 -90.00000000 90.00000000 -6371007.181 6371007.181 -6371007.181 6371007.181 +unavailable +a=6371007.181 +b=6371007.180918 +units=m +no_defs
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+{0 0 0.502 C} FS
+2362 1181 M
+-1 59 D
+-9 97 D
+-13 77 D
+-13 57 D
+-16 56 D
+-25 74 D
+-30 72 D
+-26 53 D
+-38 68 D
+-43 65 D
+-47 63 D
+-51 59 D
+-55 56 D
+-58 52 D
+-62 48 D
+-64 43 D
+-34 21 D
+-68 37 D
+-53 25 D
+-73 29 D
+-93 29 D
+-57 14 D
+-57 11 D
+-59 8 D
+-77 7 D
+-98 1 D
+-19 -1 D
+-20 -1 D
+-19 -2 D
+-20 -2 D
+-19 -2 D
+-20 -2 D
+-19 -3 D
+-19 -3 D
+-20 -3 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-18 -6 D
+-19 -6 D
+-18 -6 D
+-19 -6 D
+-18 -7 D
+-18 -7 D
+-18 -8 D
+-18 -7 D
+-18 -8 D
+-18 -9 D
+-35 -17 D
+-34 -19 D
+-34 -19 D
+-33 -21 D
+-48 -33 D
+-62 -48 D
+-58 -52 D
+-55 -56 D
+-51 -59 D
+-47 -63 D
+-32 -48 D
+-49 -85 D
+-34 -70 D
+-29 -73 D
+-29 -93 D
+-22 -95 D
+-11 -78 D
+-7 -77 D
+-1 -78 D
+3 -59 D
+7 -78 D
+13 -77 D
+23 -95 D
+31 -92 D
+30 -72 D
+35 -70 D
+50 -84 D
+45 -64 D
+49 -61 D
+53 -57 D
+42 -41 D
+59 -51 D
+63 -47 D
+32 -22 D
+101 -59 D
+71 -34 D
+72 -29 D
+93 -29 D
+95 -22 D
+78 -11 D
+78 -7 D
+78 -1 D
+39 1 D
+97 9 D
+77 13 D
+95 23 D
+92 31 D
+72 30 D
+53 26 D
+101 59 D
+80 57 D
+60 50 D
+42 40 D
+41 42 D
+51 59 D
+47 63 D
+22 32 D
+31 50 D
+37 69 D
+25 53 D
+29 72 D
+29 93 D
+14 57 D
+11 58 D
+8 58 D
+7 78 D
+P
+FO
+1215 2286 M
+3 2 D
+6 0 D
+-2 3 D
+-4 0 D
+2 4 D
+4 -4 D
+4 2 D
+1 -5 D
+5 7 D
+2 -6 D
+6 3 D
+4 -3 D
+-7 -1 D
+13 0 D
+0 10 D
+-13 -3 D
+2 3 D
+-6 -1 D
+-2 2 D
+17 0 D
+1 2 D
+-14 1 D
+11 0 D
+-5 2 D
+9 -2 D
+-9 7 D
+-17 -9 D
+-4 -1 D
+15 24 D
+11 15 D
+3 3 D
+57 -7 D
+54 -11 D
+21 -6 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-18 -9 D
+-18 -10 D
+-19 -11 D
+-28 -18 D
+-37 -28 D
+-19 -16 D
+20 52 D
+P
+FO
+{1 0 0 C} FS
+2 -5 -3 2 2 1258 2295 SP
+1220 2295 M
+4 -4 D
+4 2 D
+1 -5 D
+5 7 D
+2 -6 D
+6 3 D
+4 -3 D
+-7 -1 D
+13 0 D
+0 10 D
+-13 -3 D
+2 3 D
+-6 -1 D
+-2 2 D
+17 0 D
+1 2 D
+-14 1 D
+11 0 D
+-5 2 D
+9 -2 D
+-9 7 D
+-17 -9 D
+-4 -1 D
+P
+FO
+-2 -2 -4 0 -2 3 6 0 2 2 1 0 6 1215 2286 SP
+2 -5 -3 2 2 1258 2295 SP
+{0 0 0.502 C} FS
+1189 2344 M
+2 0 D
+-11 0 D
+-6 -1 D
+14 -2 D
+8 2 D
+-5 -2 D
+6 -1 D
+8 3 D
+-1 -3 D
+11 3 D
+-6 -2 D
+8 -1 D
+11 3 D
+11 -2 D
+-1 1 D
+13 -1 D
+-6 -6 D
+-20 -31 D
+-3 -5 D
+-7 -1 D
+5 -3 D
+-2 -4 D
+-7 0 D
+7 2 D
+-12 3 D
+-14 -5 D
+7 -3 D
+7 1 D
+0 -2 D
+3 3 D
+6 -4 D
+-20 -44 D
+-14 -38 D
+-19 51 D
+-13 28 D
+-19 34 D
+-16 21 D
+-3 3 D
+56 3 D
+P
+FO
+{1 0 0 C} FS
+0 2 -8 0 2 4 9 0 3 -4 5 1208 2306 SP
+6 1 -4 -3 2 1219 2302 SP
+-7 -1 1 1189 2299 SP
+5 -1 1 1208 2340 SP
+-6 -1 1 1174 2290 SP
+4 -1 1 1230 2342 SP
+-11 0 1 1236 2340 SP
+-5 -1 1 1230 2342 SP
+1 0 1 1242 2342 SP
+-5 1 -1 1 11 -2 3 1228 2343 SP
+1189 2344 M
+2 0 D
+-11 0 D
+-6 -1 D
+14 -2 D
+8 2 D
+-5 -2 D
+6 -1 D
+8 3 D
+-1 -3 D
+11 3 D
+-6 -2 D
+8 -1 D
+10 3 D
+P
+FO
+1 3 6 -4 3 3 0 -2 7 1 7 -3 -14 -5 -12 3 7 2 -7 0 10 1218 2291 SP
+1 2 5 -3 -7 -1 3 1222 2299 SP
+0 2 -8 0 2 4 9 0 3 -4 5 1208 2306 SP
+6 1 -4 -3 2 1219 2302 SP
+-7 -1 1 1189 2299 SP
+5 -1 1 1208 2340 SP
+-6 -1 1 1174 2290 SP
+4 -1 1 1230 2342 SP
+-11 0 1 1236 2340 SP
+-5 -1 1 1230 2342 SP
+{0 0 0.502 C} FS
+1089 2272 M
+-1 0 D
+-1 1 D
+1 0 D
+-49 24 D
+10 9 D
+-9 1 D
+5 4 D
+-9 -1 D
+9 1 D
+4 3 D
+-13 -2 D
+7 4 D
+-15 -3 D
+6 -2 D
+-7 -1 D
+7 0 D
+-7 -1 D
+6 -1 D
+-6 0 D
+5 -2 D
+-5 -1 D
+-1 -3 D
+-31 11 D
+-15 4 D
+11 1 D
+-4 1 D
+43 11 D
+57 9 D
+24 2 D
+9 -10 D
+16 -24 D
+16 -31 D
+16 -37 D
+13 -35 D
+-42 34 D
+-25 18 D
+P
+FO
+{1 0 0 C} FS
+-9 -2 -6 1 7 5 -8 -1 6 2 -4 1 8 2 10 2 -3 -4 6 -2 25 0 -23 -6 12 1023 2325 SP
+3 -3 -10 -4 2 1122 2285 SP
+-2 -3 -6 2 2 1092 2277 SP
+1 -2 1 1102 2282 SP
+5 0 1 1107 2285 SP
+-10 -1 0 1 2 1103 2275 SP
+-1 -2 1 1092 2280 SP
+2 2 1 1101 2271 SP
+-4 -1 -4 -1 -4 1 11 1 4 980 2317 SP
+1039 2297 M
+10 9 D
+-9 1 D
+5 4 D
+-9 -1 D
+9 1 D
+4 3 D
+-13 -2 D
+7 4 D
+-15 -3 D
+6 -2 D
+-7 -1 D
+7 0 D
+-7 -1 D
+6 -1 D
+-6 0 D
+5 -2 D
+-5 -1 D
+-1 -3 D
+P
+FO
+2 -1 -5 2 1 0 3 1087 2273 SP
+-1 0 1 1089 2272 SP
+-9 -2 -6 1 7 5 -8 -1 6 2 -4 1 8 2 10 2 -3 -4 6 -2 25 0 -23 -6 12 1023 2325 SP
+3 -3 -10 -4 2 1122 2285 SP
+-2 -3 -6 2 2 1092 2277 SP
+1 -2 1 1102 2282 SP
+5 0 1 1107 2285 SP
+-10 -1 0 1 2 1103 2275 SP
+-1 -2 1 1092 2280 SP
+2 2 1 1101 2271 SP
+{0 0 0.502 C} FS
+907 2291 M
+11 -2 D
+13 2 D
+11 -5 D
+19 7 D
+-11 5 D
+2 4 D
+-13 2 D
+41 13 D
+30 -9 D
+16 -6 D
+-1 -4 D
+-19 -13 D
+9 -3 D
+7 8 D
+17 7 D
+29 -14 D
+15 -8 D
+-1 -4 D
+5 2 D
+1 -1 D
+-3 -3 D
+4 3 D
+33 -22 D
+34 -25 D
+25 -21 D
+-42 17 D
+-64 20 D
+-49 13 D
+-49 9 D
+-55 7 D
+-20 1 D
+12 4 D
+1 2 D
+-8 -1 D
+10 5 D
+-25 -5 D
+14 5 D
+29 1 D
+-9 1 D
+-2 5 D
+-17 -2 D
+-7 1 D
+P
+FO
+{1 0 0 C} FS
+-5 1 5 3 3 -1 3 956 2289 SP
+0 -5 1 1077 2271 SP
+-6 -1 1 920 2273 SP
+-3 -2 1 941 2283 SP
+-1 0 2 0 2 978 2317 SP
+-7 -2 -6 -3 -7 -3 -6 -2 -13 2 2 4 -11 5 11 4 8 3 11 -5 13 2 11 -2 12 907 2291 SP
+902 2271 M
+12 4 D
+1 2 D
+-8 -1 D
+10 5 D
+-25 -5 D
+14 5 D
+29 1 D
+-9 1 D
+-2 5 D
+-17 -2 D
+-7 1 D
+-12 -6 D
+-11 -6 D
+-5 -3 D
+P
+FO
+4 3 -3 -3 2 1088 2272 SP
+-2 1 5 2 -1 -4 3 1083 2275 SP
+-4 2 -5 2 3 2 14 5 7 8 9 -3 -19 -13 -1 -4 8 1026 2302 SP
+-5 1 5 3 3 -1 3 956 2289 SP
+0 -5 1 1077 2271 SP
+-6 -1 1 920 2273 SP
+-3 -2 1 941 2283 SP
+{0 0 0.502 C} FS
+-1 0 0 -1 2 839 2250 SP
+859 2264 M
+5 1 D
+10 -1 D
+-3 3 D
+13 -4 D
+7 5 D
+11 3 D
+48 -4 D
+62 -10 D
+49 -12 D
+63 -19 D
+57 -22 D
+-74 11 D
+-57 6 D
+-65 3 D
+6 2 D
+-3 2 D
+6 -1 D
+-3 9 D
+-16 -5 D
+-7 -7 D
+-12 0 D
+-11 0 D
+-12 -1 D
+-11 0 D
+2 2 D
+-10 -2 D
+5 2 D
+-1 7 D
+4 -1 D
+6 7 D
+-3 1 D
+-2 -3 D
+4 16 D
+-9 1 D
+7 2 D
+-20 -3 D
+18 16 D
+-18 1 D
+-24 -7 D
+-25 0 D
+P
+FO
+-2 0 0 -2 4 3 3 881 2220 SP
+1 -1 0 1 2 829 2215 SP
+{1 0 0 C} FS
+-12 8 15 3 7 -2 -1 -6 4 997 2234 SP
+-7 0 7 4 3 -1 3 993 2235 SP
+2 -1 1 939 2232 SP
+5 -1 1 943 2263 SP
+{0 0 0.502 C} FS
+-3 -3 1 846 2220 SP
+{1 0 0 C} FS
+-4 -3 -5 -2 -7 0 -8 0 -7 0 -8 1 11 3 7 5 13 -4 -3 3 10 -1 5 1 12 859 2264 SP
+839 2250 M
+0 -1 D
+-1 0 D
+-25 -23 D
+-11 -15 D
+27 4 D
+0 1 D
+1 -1 D
+32 4 D
+19 1 D
+4 3 D
+0 -2 D
+37 2 D
+2 2 D
+-10 -2 D
+5 2 D
+-1 7 D
+4 -1 D
+6 7 D
+-3 1 D
+-2 -3 D
+4 16 D
+-9 1 D
+7 2 D
+-20 -3 D
+18 16 D
+-18 1 D
+-24 -7 D
+-25 0 D
+-13 -9 D
+P
+FO
+8 0 -7 -7 -16 -5 -3 9 6 -1 -3 2 6 2 7 985 2224 SP
+-12 8 15 3 7 -2 -1 -6 4 997 2234 SP
+-7 0 7 4 3 -1 3 993 2235 SP
+2 -1 1 939 2232 SP
+5 -1 1 943 2263 SP
+{0 0 0.502 C} FS
+-3 -3 1 846 2220 SP
+-3 5 9 4 -10 -4 -10 7 13 -12 5 830 2215 SP
+2 1 2 1 9 2 -12 -2 7 4 -4 2 -3 7 -7 -5 6 1 -1 -7 -13 -4 12 2 0 -2 13 885 2221 SP
+968 2224 M
+16 -1 D
+1 1 D
+73 -4 D
+82 -9 D
+41 -7 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 -1 D
+-9 0 D
+-9 0 D
+-10 -1 D
+-9 0 D
+-9 -1 D
+-9 0 D
+-10 -1 D
+-9 -1 D
+-9 0 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-10 -1 D
+-9 -1 D
+-9 -1 D
+-9 -2 D
+-9 -1 D
+-9 -1 D
+-9 -2 D
+-10 -1 D
+-9 -2 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-8 -2 D
+-9 -3 D
+-9 -2 D
+5 6 D
+6 0 D
+5 10 D
+-9 5 D
+16 5 D
+-6 0 D
+8 3 D
+1 5 D
+-7 -1 D
+-1 -3 D
+-4 12 D
+-7 1 D
+15 -2 D
+25 -13 D
+13 5 D
+-7 -4 D
+6 0 D
+20 10 D
+-1 10 D
+7 -2 D
+7 8 D
+3 -4 D
+9 5 D
+-8 5 D
+-11 0 D
+2 3 D
+P
+FO
+{1 0 0 C} FS
+11 0 -5 2 15 4 3 -10 4 950 2223 SP
+5 -1 -6 -3 2 866 2188 SP
+835 2159 M
+5 6 D
+6 0 D
+5 10 D
+-9 5 D
+16 5 D
+-6 0 D
+8 3 D
+1 5 D
+-7 -1 D
+-1 -3 D
+-4 12 D
+-7 1 D
+15 -2 D
+25 -13 D
+13 5 D
+-7 -4 D
+6 0 D
+20 10 D
+-1 10 D
+7 -2 D
+7 8 D
+3 -4 D
+9 5 D
+-8 5 D
+-11 0 D
+2 3 D
+-10 -1 D
+-9 0 D
+-9 -1 D
+-9 0 D
+0 -2 D
+12 2 D
+-13 -4 D
+-1 -7 D
+6 1 D
+-7 -5 D
+-3 7 D
+-4 2 D
+7 4 D
+-12 -2 D
+11 3 D
+-6 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-6 0 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+13 -12 D
+-10 7 D
+-10 -4 D
+9 4 D
+-3 5 D
+-9 -1 D
+-9 -1 D
+-9 -2 D
+-11 -16 D
+-10 -23 D
+-4 -30 D
+P
+FO
+-9 0 1 1 16 -1 3 968 2224 SP
+11 0 -5 2 15 4 3 -10 4 950 2223 SP
+5 -1 -6 -3 2 866 2188 SP
+{0 0 0.502 C} FS
+-9 -2 -8 4 -11 -6 11 5 8 -3 9 1 6 779 2124 SP
+909 2123 M
+5 6 D
+-14 0 D
+-13 -8 D
+4 -5 D
+-9 -4 D
+-17 -8 D
+-1 0 D
+-13 -6 D
+-6 -3 D
+-4 1 D
+2 -2 D
+-7 -1 D
+-7 -6 D
+-1 -1 D
+-2 7 D
+-9 -3 D
+6 10 D
+-7 6 D
+8 7 D
+-26 -4 D
+24 19 D
+3 -3 D
+5 6 D
+4 -2 D
+10 5 D
+-1 8 D
+10 9 D
+-20 -1 D
+2 9 D
+80 19 D
+100 16 D
+74 7 D
+92 3 D
+-9 -2 D
+-8 -1 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-9 -1 D
+-9 -3 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-9 -3 D
+-8 -2 D
+-9 -2 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-9 -3 D
+-8 -2 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+P
+FO
+{1 0 0 C} FS
+8 4 1 895 2130 SP
+2 -3 1 823 2096 SP
+{0 0 0.502 C} FS
+16 15 19 2 -20 -2 3 818 2142 SP
+{1 0 0 C} FS
+779 2124 M
+9 1 D
+8 -3 D
+11 5 D
+-11 -6 D
+-8 4 D
+-9 -2 D
+9 -28 D
+10 -16 D
+4 -6 D
+17 9 D
+9 4 D
+-2 7 D
+-9 -3 D
+6 10 D
+-7 6 D
+8 7 D
+-26 -4 D
+24 19 D
+3 -3 D
+5 6 D
+4 -2 D
+10 5 D
+-1 8 D
+10 9 D
+-20 -1 D
+2 9 D
+-12 -3 D
+-11 -3 D
+-12 -4 D
+-11 -3 D
+-12 -4 D
+P
+FO
+6 3 -7 -6 -6 0 3 842 2093 SP
+2 -2 -4 1 2 845 2095 SP
+-1 0 1 865 2104 SP
+9 3 4 -5 -13 -8 -14 0 5 6 5 909 2123 SP
+8 4 1 895 2130 SP
+2 -3 1 823 2096 SP
+{0 0 0.502 C} FS
+16 15 19 2 -20 -2 3 818 2142 SP
+-25 -2 24 1 5 4 3 823 2049 SP
+-1 -1 1 829 2087 SP
+-2 0 1 -1 2 843 2094 SP
+864 2104 M
+3 -10 D
+6 1 D
+5 7 D
+-13 2 D
+26 12 D
+8 -9 D
+13 10 D
+-11 -8 D
+13 -1 D
+4 15 D
+-12 -3 D
+3 3 D
+75 29 D
+68 22 D
+69 18 D
+60 12 D
+-7 -3 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-14 -7 D
+-14 -7 D
+-15 -7 D
+-14 -7 D
+-14 -8 D
+-14 -8 D
+-14 -8 D
+-15 -9 D
+-14 -9 D
+-14 -9 D
+-21 -14 D
+-21 -14 D
+-21 -15 D
+-27 -20 D
+-27 -22 D
+-14 -11 D
+8 13 D
+-9 10 D
+-17 7 D
+2 20 D
+8 -1 D
+2 9 D
+-4 3 D
+-19 -3 D
+13 7 D
+-5 -5 D
+10 1 D
+-8 7 D
+9 -6 D
+-6 22 D
+-4 -4 D
+-7 2 D
+P
+FO
+{1 0 0 C} FS
+-3 14 12 0 0 -7 3 909 2099 SP
+3 4 1 877 2106 SP
+823 2049 M
+5 4 D
+24 1 D
+-25 -2 D
+-4 -3 D
+10 -10 D
+39 -27 D
+8 14 D
+-9 10 D
+-17 7 D
+2 20 D
+8 -1 D
+2 9 D
+-4 3 D
+-19 -3 D
+13 7 D
+-5 -5 D
+10 1 D
+-8 7 D
+9 -6 D
+-6 22 D
+-4 -4 D
+-7 2 D
+-2 -1 D
+1 -1 D
+-2 0 D
+-7 -3 D
+-6 -3 D
+-10 -5 D
+-17 -9 D
+11 -14 D
+P
+FO
+-9 -4 3 3 -12 -3 4 15 13 -1 -11 -8 13 10 8 -9 8 891 2116 SP
+-13 2 5 7 6 1 3 -10 4 864 2104 SP
+-3 14 12 0 0 -7 3 909 2099 SP
+3 4 1 877 2106 SP
+{0 0 0.502 C} FS
+929 1984 M
+-3 4 D
+-2 -1 D
+-24 10 D
+-28 15 D
+0 1 D
+21 16 D
+20 17 D
+83 59 D
+64 39 D
+50 27 D
+71 33 D
+-32 -29 D
+-4 -5 D
+-19 -18 D
+-4 -5 D
+-5 -4 D
+-36 -40 D
+-49 -61 D
+-35 -48 D
+-4 -7 D
+-12 -6 D
+7 0 D
+-9 -14 D
+P
+FO
+{1 0 0 C} FS
+0 1 1 872 2012 SP
+3 -2 -2 -1 -3 4 3 929 1984 SP
+2 3 7 0 -12 -6 3 993 1987 SP
+{0 0 0.502 C} FS
+988 1981 M
+18 0 D
+-10 8 D
+-3 -2 D
+21 31 D
+49 63 D
+27 32 D
+27 30 D
+5 4 D
+18 19 D
+5 4 D
+4 5 D
+32 29 D
+-22 -69 D
+-24 -86 D
+-22 -98 D
+-1 2 D
+-13 -4 D
+-5 -4 D
+-54 8 D
+-61 14 D
+P
+FO
+{1 0 0 C} FS
+4 2 1 1094 1947 SP
+1 4 6 -1 5 0 6 -1 -5 -4 -13 -4 -1 2 7 1113 1951 SP
+-3 -3 -3 -2 -10 8 18 0 4 988 1981 SP
+4 2 1 1094 1947 SP
+{0 0 0.502 C} FS
+1233 1942 M
+-5 2 D
+-55 2 D
+-10 3 D
+3 5 D
+-13 -1 D
+-6 6 D
+-7 -6 D
+4 6 D
+-5 4 D
+-11 -7 D
+-12 0 D
+-3 -8 D
+4 23 D
+29 120 D
+26 85 D
+9 28 D
+26 -82 D
+21 -78 D
+23 -101 D
+-6 0 D
+-6 -1 D
+P
+FO
+9 -2 -5 4 2 1157 1948 SP
+{1 0 0 C} FS
+1233 1942 M
+-5 2 D
+-55 2 D
+-10 3 D
+3 5 D
+-13 -1 D
+-6 6 D
+-7 -6 D
+4 6 D
+-5 4 D
+-11 -7 D
+-12 0 D
+-3 -8 D
+0 3 D
+-2 -8 D
+78 -3 D
+P
+FO
+{0 0 0.502 C} FS
+9 -2 -5 4 2 1157 1948 SP
+1355 1960 M
+-2 3 D
+0 -3 D
+-4 -1 D
+-5 -1 D
+-4 -1 D
+-12 7 D
+7 -6 D
+-3 -3 D
+-4 -1 D
+-4 -1 D
+-5 -1 D
+1 5 D
+-5 -5 D
+-10 -2 D
+-11 -2 D
+-10 -1 D
+-11 -1 D
+-11 -2 D
+-11 -1 D
+-20 89 D
+-30 112 D
+-20 60 D
+40 -37 D
+36 -37 D
+44 -51 D
+13 -16 D
+-1 -17 D
+5 6 D
+6 -3 D
+18 -23 D
+-11 3 D
+-14 -7 D
+10 -7 D
+3 -28 D
+6 1 D
+18 -10 D
+11 10 D
+-3 7 D
+1 2 D
+20 -30 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+P
+FO
+{1 0 0 C} FS
+2 0 -5 -5 1 5 3 1319 1952 SP
+4 1 -3 -3 7 -6 -12 7 4 1340 1957 SP
+0 -3 -2 3 2 1355 1960 SP
+-5 7 -5 7 -6 8 1 2 -3 7 11 10 18 -10 6 1 3 -28 10 -7 -14 -7 -11 3 12 1342 2026 SP
+-3 4 -3 5 6 -3 5 6 -1 -17 5 1314 2063 SP
+{0 0 0.502 C} FS
+1486 2010 M
+-3 2 D
+-28 2 D
+-29 20 D
+-12 3 D
+-5 -4 D
+23 -19 D
+-28 13 D
+-4 -2 D
+12 -5 D
+-7 0 D
+2 -4 D
+-5 -2 D
+-1 7 D
+-11 1 D
+-4 -9 D
+-9 11 D
+-10 -19 D
+4 -11 D
+8 1 D
+0 -5 D
+16 8 D
+-12 -13 D
+7 -4 D
+21 8 D
+18 0 D
+-30 -16 D
+0 -1 D
+-5 -1 D
+-5 -2 D
+-6 -2 D
+-20 30 D
+8 27 D
+-18 6 D
+-5 -5 D
+-6 1 D
+-18 23 D
+2 0 D
+-2 14 D
+9 -5 D
+-4 14 D
+-8 0 D
+-7 -4 D
+0 -5 D
+-39 47 D
+-45 48 D
+-44 42 D
+-5 4 D
+56 -25 D
+62 -33 D
+41 -24 D
+13 -9 D
+7 -4 D
+-5 2 D
+-21 -3 D
+9 -5 D
+6 2 D
+4 -6 D
+2 3 D
+14 1 D
+24 -16 D
+-4 -2 D
+13 -4 D
+-15 2 D
+13 -5 D
+-4 -6 D
+9 6 D
+2 -5 D
+8 -2 D
+18 -13 D
+-3 -2 D
+8 -4 D
+-6 -2 D
+10 1 D
+4 -3 D
+2 -3 D
+-13 -1 D
+4 -5 D
+27 -6 D
+25 -21 D
+-3 -1 D
+P
+FO
+{1 0 0 C} FS
+1354 2043 M
+1 8 D
+6 -5 D
+9 8 D
+-8 -13 D
+13 0 D
+6 14 D
+12 5 D
+-9 10 D
+-7 1 D
+4 -6 D
+-6 0 D
+-18 10 D
+2 -7 D
+17 -8 D
+-10 -4 D
+-27 7 D
+-1 -4 D
+7 0 D
+-6 -6 D
+8 3 D
+-7 -8 D
+8 5 D
+-6 -10 D
+P
+FO
+10 1 5 -4 -11 -5 3 1340 2087 SP
+1 -4 -10 -2 -6 8 3 1425 2037 SP
+-8 1 10 7 2 1325 2087 SP
+-3 -9 -2 6 2 1335 2049 SP
+13 -5 -8 3 2 1363 2088 SP
+5 -1 1 1477 2019 SP
+6 -5 -6 4 2 1400 2064 SP
+1 5 1 1386 2075 SP
+7 -3 1 1377 2082 SP
+-6 4 1 1329 2079 SP
+-6 -2 1 1370 2099 SP
+-1 -3 1 1338 2069 SP
+-2 -4 1 1394 2077 SP
+-3 -2 1 1391 2076 SP
+{0 0 0.502 C} FS
+6 -4 1 1444 2011 SP
+5 1 1 1451 1994 SP
+5 1 -6 -1 2 1450 1992 SP
+{1 0 0 C} FS
+1486 2010 M
+-3 2 D
+-28 2 D
+-29 20 D
+-12 3 D
+-5 -4 D
+23 -19 D
+-28 13 D
+-4 -2 D
+12 -5 D
+-7 0 D
+2 -4 D
+-5 -2 D
+-1 7 D
+-11 1 D
+-4 -9 D
+-9 11 D
+-10 -19 D
+4 -11 D
+8 1 D
+0 -5 D
+16 8 D
+-12 -13 D
+7 -4 D
+21 8 D
+18 0 D
+-30 -16 D
+0 -1 D
+38 14 D
+34 15 D
+P
+FO
+-6 5 -7 5 27 -6 4 -5 -13 -1 2 -3 6 1446 2048 SP
+-4 3 10 1 -6 -2 8 -4 -3 -2 5 1433 2058 SP
+-4 3 8 -2 1 -4 3 1406 2077 SP
+-2 1 9 6 -4 -6 13 -5 -15 2 5 1402 2081 SP
+-4 3 12 -4 -4 -2 3 1393 2087 SP
+-5 3 14 1 2 3 4 -6 6 2 9 -5 -21 -3 -5 2 8 1360 2109 SP
+3 -4 4 -5 0 -5 -7 -4 -8 0 -4 14 9 -5 -2 14 2 0 9 1324 2049 SP
+5 -7 5 -7 5 -7 -6 1 -5 -5 -18 6 8 27 7 1363 1997 SP
+1354 2043 M
+1 8 D
+6 -5 D
+9 8 D
+-8 -13 D
+13 0 D
+6 14 D
+12 5 D
+-9 10 D
+-7 1 D
+4 -6 D
+-6 0 D
+-18 10 D
+2 -7 D
+17 -8 D
+-10 -4 D
+-27 7 D
+-1 -4 D
+7 0 D
+-6 -6 D
+8 3 D
+-7 -8 D
+8 5 D
+-6 -10 D
+P
+FO
+10 1 5 -4 -11 -5 3 1340 2087 SP
+1 -4 -10 -2 -6 8 3 1425 2037 SP
+-8 1 10 7 2 1325 2087 SP
+-3 -9 -2 6 2 1335 2049 SP
+13 -5 -8 3 2 1363 2088 SP
+5 -1 1 1477 2019 SP
+6 -5 -6 4 2 1400 2064 SP
+1 5 1 1386 2075 SP
+7 -3 1 1377 2082 SP
+-6 4 1 1329 2079 SP
+-6 -2 1 1370 2099 SP
+-1 -3 1 1338 2069 SP
+-2 -4 1 1394 2077 SP
+-3 -2 1 1391 2076 SP
+{0 0 0.502 C} FS
+6 -4 1 1444 2011 SP
+5 1 1 1451 1994 SP
+5 1 -6 -1 2 1450 1992 SP
+-2 -2 7 4 -3 1 3 1557 2068 SP
+9 1 -8 0 2 1555 2066 SP
+1543 2052 M
+-5 -2 D
+5 2 D
+-22 -19 D
+-3 4 D
+4 2 D
+-40 12 D
+11 -19 D
+5 1 D
+9 -10 D
+-12 -8 D
+-4 -3 D
+-25 21 D
+8 -2 D
+3 3 D
+-8 6 D
+4 -3 D
+4 4 D
+-15 13 D
+-11 -2 D
+-6 12 D
+-12 -6 D
+-18 13 D
+7 4 D
+-4 6 D
+-24 11 D
+3 -4 D
+-4 -1 D
+-24 16 D
+4 0 D
+-27 14 D
+-13 9 D
+-69 39 D
+-62 30 D
+-21 9 D
+61 -13 D
+54 -13 D
+23 -7 D
+1 -4 D
+14 -1 D
+-13 -4 D
+3 -4 D
+9 1 D
+-9 -3 D
+3 -8 D
+4 3 D
+3 -4 D
+3 6 D
+4 -7 D
+3 9 D
+0 -10 D
+8 1 D
+-3 11 D
+2 -7 D
+5 -3 D
+-2 7 D
+2 2 D
+4 -4 D
+0 4 D
+-2 3 D
+5 -2 D
+1 -7 D
+17 -1 D
+-17 0 D
+-5 -4 D
+28 -4 D
+-2 -3 D
+5 6 D
+1 -4 D
+7 -1 D
+-11 -2 D
+0 -5 D
+10 -6 D
+-2 5 D
+6 -1 D
+-8 5 D
+20 -9 D
+-6 10 D
+11 -11 D
+-18 -3 D
+15 -2 D
+4 -12 D
+6 1 D
+-6 3 D
+9 -2 D
+-5 3 D
+7 -1 D
+-5 3 D
+9 0 D
+-4 5 D
+6 1 D
+-7 2 D
+9 0 D
+-9 2 D
+16 -2 D
+0 4 D
+13 -6 D
+-8 -2 D
+-2 -15 D
+-11 -2 D
+4 -3 D
+-12 3 D
+0 -4 D
+-2 4 D
+-7 -1 D
+6 5 D
+-9 -3 D
+-2 3 D
+-2 -8 D
+-9 5 D
+-10 -5 D
+16 -5 D
+4 6 D
+26 -11 D
+14 0 D
+-3 7 D
+10 -2 D
+9 11 D
+-7 3 D
+12 1 D
+-2 7 D
+19 -9 D
+-2 -2 D
+16 -4 D
+11 -5 D
+7 -7 D
+-14 9 D
+-21 5 D
+-1 -12 D
+9 0 D
+-5 -5 D
+9 2 D
+-7 -4 D
+20 -4 D
+-7 0 D
+2 -5 D
+11 1 D
+11 -8 D
+-5 2 D
+-12 -15 D
+13 -4 D
+7 0 D
+0 8 D
+11 -4 D
+1 1 D
+-2 -1 D
+P
+FO
+-2 2 3 -3 1 0 3 1442 2051 SP
+0 -2 1 1 2 1405 2078 SP
+1 0 1 1401 2081 SP
+4 -2 7 3 -10 3 -4 -3 4 1429 2133 SP
+3 -1 -3 3 -2 -1 3 1469 2117 SP
+-6 -1 1 1551 2078 SP
+{1 0 0 C} FS
+1368 2122 M
+12 0 D
+-1 -3 D
+7 -1 D
+6 4 D
+-9 4 D
+11 -2 D
+-14 8 D
+7 -2 D
+-6 10 D
+-8 1 D
+-1 -3 D
+-16 6 D
+4 -4 D
+-31 4 D
+6 -8 D
+8 0 D
+-3 -6 D
+11 0 D
+-8 -1 D
+5 -3 D
+6 3 D
+7 -6 D
+10 7 D
+P
+FO
+14 6 26 -20 5 -13 -6 -4 -15 14 -13 7 -16 3 7 1525 2070 SP
+-17 -12 -14 17 8 5 -8 2 -2 9 5 1480 2049 SP
+14 -7 -15 -1 -6 7 3 1382 2108 SP
+10 4 -4 -6 2 1389 2111 SP
+-18 8 15 3 2 1426 2078 SP
+9 -2 -4 -2 2 1402 2116 SP
+-5 -5 1 1439 2065 SP
+-9 3 1 1345 2121 SP
+-6 4 1 1420 2106 SP
+-4 3 1 1421 2090 SP
+-1 -4 1 1420 2085 SP
+{0 0 0.502 C} FS
+5 0 1 1455 2047 SP
+4 1 -1 0 2 1555 2072 SP
+1 -5 1 1533 2065 SP
+{1 0 0 C} FS
+5 3 5 4 9 -10 5 1 11 -19 -40 12 4 2 -3 4 8 1521 2033 SP
+-5 -2 1 1543 2052 SP
+1555 2066 M
+-8 0 D
+10 2 D
+-3 1 D
+7 4 D
+-10 5 D
+-6 -1 D
+6 1 D
+-34 17 D
+7 -7 D
+-14 9 D
+-21 5 D
+-1 -12 D
+9 0 D
+-5 -5 D
+9 2 D
+-7 -4 D
+20 -4 D
+-7 0 D
+2 -5 D
+11 1 D
+11 -8 D
+-5 2 D
+-12 -15 D
+13 -4 D
+7 0 D
+0 8 D
+11 -4 D
+P
+FO
+-7 3 1 0 15 -4 -2 -2 4 1492 2106 SP
+1469 2117 M
+-2 -1 D
+-3 3 D
+-6 2 D
+-8 -2 D
+-2 -15 D
+-11 -2 D
+4 -3 D
+-12 3 D
+0 -4 D
+-2 4 D
+-7 -1 D
+6 5 D
+-9 -3 D
+-2 3 D
+-2 -8 D
+-9 5 D
+-10 -5 D
+16 -5 D
+4 6 D
+26 -11 D
+14 0 D
+-3 7 D
+10 -2 D
+9 11 D
+-7 3 D
+12 1 D
+-2 7 D
+P
+FO
+1429 2133 M
+-4 -3 D
+-10 3 D
+7 3 D
+-59 21 D
+1 -7 D
+17 -1 D
+-17 0 D
+-5 -4 D
+28 -4 D
+-2 -3 D
+5 6 D
+1 -4 D
+7 -1 D
+-11 -2 D
+0 -5 D
+10 -6 D
+-2 5 D
+6 -1 D
+-8 5 D
+20 -9 D
+-6 10 D
+11 -11 D
+-18 -3 D
+15 -2 D
+4 -12 D
+6 1 D
+-6 3 D
+9 -2 D
+-5 3 D
+7 -1 D
+-5 3 D
+9 0 D
+-4 5 D
+6 1 D
+-7 2 D
+9 0 D
+-9 2 D
+16 -2 D
+0 4 D
+P
+FO
+1319 2171 M
+1 -4 D
+14 -1 D
+-13 -4 D
+3 -4 D
+9 1 D
+-9 -3 D
+3 -8 D
+4 3 D
+3 -4 D
+3 6 D
+4 -7 D
+3 9 D
+0 -10 D
+8 1 D
+-3 11 D
+2 -7 D
+5 -3 D
+-2 7 D
+2 2 D
+4 -4 D
+0 4 D
+-2 3 D
+P
+FO
+4 -3 -13 6 4 0 3 1369 2103 SP
+1401 2081 M
+1 0 D
+1 -2 D
+2 -1 D
+1 1 D
+0 -2 D
+9 -6 D
+7 4 D
+-4 6 D
+-24 11 D
+3 -4 D
+-4 -1 D
+P
+FO
+1442 2051 M
+24 -18 D
+8 -2 D
+3 3 D
+-8 6 D
+4 -3 D
+4 4 D
+-15 13 D
+-11 -2 D
+-6 12 D
+-12 -6 D
+P
+FO
+1368 2122 M
+12 0 D
+-1 -3 D
+7 -1 D
+6 4 D
+-9 4 D
+11 -2 D
+-14 8 D
+7 -2 D
+-6 10 D
+-8 1 D
+-1 -3 D
+-16 6 D
+4 -4 D
+-31 4 D
+6 -8 D
+8 0 D
+-3 -6 D
+11 0 D
+-8 -1 D
+5 -3 D
+6 3 D
+7 -6 D
+10 7 D
+P
+FO
+14 6 26 -20 5 -13 -6 -4 -15 14 -13 7 -16 3 7 1525 2070 SP
+-17 -12 -14 17 8 5 -8 2 -2 9 5 1480 2049 SP
+14 -7 -15 -1 -6 7 3 1382 2108 SP
+10 4 -4 -6 2 1389 2111 SP
+-18 8 15 3 2 1426 2078 SP
+9 -2 -4 -2 2 1402 2116 SP
+-5 -5 1 1439 2065 SP
+-9 3 1 1345 2121 SP
+-6 4 1 1420 2106 SP
+-4 3 1 1421 2090 SP
+-1 -4 1 1420 2085 SP
+{0 0 0.502 C} FS
+5 0 1 1455 2047 SP
+4 1 -1 0 2 1555 2072 SP
+1 -5 1 1533 2065 SP
+1582 2117 M
+-7 -1 D
+5 -6 D
+-4 3 D
+2 -6 D
+-7 10 D
+-7 -2 D
+5 -6 D
+-7 5 D
+14 -12 D
+-9 5 D
+1 -3 D
+-10 9 D
+6 -10 D
+-11 10 D
+-9 -1 D
+10 -9 D
+-14 6 D
+9 -9 D
+-8 5 D
+-2 -2 D
+-5 7 D
+0 -9 D
+-10 9 D
+-9 -5 D
+4 -5 D
+9 2 D
+-6 -5 D
+11 -1 D
+-18 1 D
+2 -2 D
+-11 5 D
+6 0 D
+4 10 D
+-16 2 D
+-8 -6 D
+-19 9 D
+-1 3 D
+-3 -1 D
+-5 2 D
+-3 3 D
+-3 -1 D
+-13 6 D
+-1 5 D
+-10 5 D
+-5 -4 D
+-7 3 D
+5 1 D
+-12 6 D
+3 5 D
+-6 -1 D
+0 5 D
+-6 -2 D
+1 4 D
+-14 -5 D
+6 8 D
+-10 -4 D
+1 9 D
+-8 1 D
+6 4 D
+-7 3 D
+-4 -2 D
+2 3 D
+-8 1 D
+5 1 D
+-19 12 D
+4 -9 D
+-7 7 D
+-5 -3 D
+3 4 D
+-7 7 D
+-7 2 D
+-10 -2 D
+3 -7 D
+-6 4 D
+-9 -12 D
+3 -5 D
+-61 17 D
+-77 16 D
+58 -1 D
+90 -7 D
+20 -2 D
+1 -3 D
+16 -3 D
+-5 -2 D
+10 -1 D
+-8 0 D
+14 -8 D
+7 -1 D
+-1 6 D
+20 -8 D
+0 -6 D
+14 -13 D
+17 4 D
+-1 7 D
+7 -1 D
+-2 -7 D
+5 6 D
+-3 -12 D
+11 6 D
+4 -6 D
+7 1 D
+5 4 D
+-7 0 D
+5 3 D
+-6 7 D
+5 5 D
+6 1 D
+87 -22 D
+28 -9 D
+-1 -15 D
+P
+FO
+-1 -2 15 -3 -5 5 -8 1 4 1563 2077 SP
+2 1 1 1551 2078 SP
+-3 1 2 -7 3 3 9 -6 -9 8 5 1358 2159 SP
+{1 0 0 C} FS
+-3 3 1 1561 2107 SP
+-2 -2 1 1435 2157 SP
+-4 2 1 1453 2126 SP
+{0 0 0.502 C} FS
+4 -7 1 1344 2181 SP
+3 -5 1 1570 2112 SP
+{1 0 0 C} FS
+1563 2077 M
+-8 1 D
+-5 5 D
+15 -3 D
+11 20 D
+4 10 D
+-4 3 D
+2 -6 D
+-7 10 D
+-7 -2 D
+5 -6 D
+-7 5 D
+14 -12 D
+-9 5 D
+1 -3 D
+-10 9 D
+6 -10 D
+-11 10 D
+-9 -1 D
+10 -9 D
+-14 6 D
+9 -9 D
+-8 5 D
+-2 -2 D
+-5 7 D
+0 -9 D
+-10 9 D
+-9 -5 D
+4 -5 D
+9 2 D
+-6 -5 D
+11 -1 D
+-18 1 D
+7 -5 D
+29 -14 D
+2 1 D
+-2 -1 D
+10 -5 D
+P
+FO
+1 3 5 -5 -7 -1 3 1582 2117 SP
+1349 2194 M
+1 -3 D
+16 -3 D
+-5 -2 D
+10 -1 D
+-8 0 D
+14 -8 D
+7 -1 D
+-1 6 D
+20 -8 D
+0 -6 D
+14 -13 D
+17 4 D
+-1 7 D
+7 -1 D
+-2 -7 D
+5 6 D
+-3 -12 D
+11 6 D
+4 -6 D
+7 1 D
+5 4 D
+-7 0 D
+5 3 D
+-6 7 D
+5 5 D
+6 1 D
+-68 13 D
+P
+FO
+1 0 1 1345 2194 SP
+1358 2159 M
+-9 8 D
+9 -6 D
+3 3 D
+2 -7 D
+59 -21 D
+5 1 D
+-12 6 D
+3 5 D
+-6 -1 D
+0 5 D
+-6 -2 D
+1 4 D
+-14 -5 D
+6 8 D
+-10 -4 D
+1 9 D
+-8 1 D
+6 4 D
+-7 3 D
+-4 -2 D
+2 3 D
+-8 1 D
+5 1 D
+-19 12 D
+4 -9 D
+-7 7 D
+-5 -3 D
+3 4 D
+-7 7 D
+-7 2 D
+-10 -2 D
+3 -7 D
+-6 4 D
+-9 -12 D
+3 -5 D
+P
+FO
+8 -3 -5 -4 -10 5 -1 5 4 1445 2127 SP
+3 -1 -3 -1 -3 3 3 1464 2119 SP
+2 -1 -3 -1 -1 3 3 1473 2115 SP
+7 -3 -8 -6 -16 2 4 10 6 0 5 1506 2100 SP
+-3 3 1 1561 2107 SP
+-2 -2 1 1435 2157 SP
+-4 2 1 1453 2126 SP
+{0 0 0.502 C} FS
+4 -7 1 1344 2181 SP
+3 -5 1 1570 2112 SP
+1582 2167 M
+-4 0 D
+1 -5 D
+4 -1 D
+2 -19 D
+-72 21 D
+-43 10 D
+25 5 D
+9 -6 D
+-4 5 D
+24 -5 D
+11 2 D
+1 -4 D
+1 2 D
+9 -3 D
+-6 4 D
+11 -7 D
+4 5 D
+-18 5 D
+12 -2 D
+-2 5 D
+8 -5 D
+-3 5 D
+7 -5 D
+-3 4 D
+4 -3 D
+0 4 D
+1 -4 D
+12 2 D
+-6 -6 D
+4 -6 D
+10 4 D
+-3 8 D
+P
+FO
+-2 0 1 0 -11 -3 13 3 4 1346 2194 SP
+1321 2221 M
+-7 -5 D
+8 -2 D
+1 6 D
+6 1 D
+-4 -8 D
+9 5 D
+1 -4 D
+10 1 D
+-12 -9 D
+18 1 D
+-6 -4 D
+8 -2 D
+-15 0 D
+7 -7 D
+-74 7 D
+-82 3 D
+-8 0 D
+78 12 D
+P
+FO
+{1 0 0 C} FS
+-9 0 10 3 2 1329 2211 SP
+4 1 1 1555 2173 SP
+-4 2 1 1561 2169 SP
+5 -4 1 1537 2172 SP
+3 1 -3 -2 2 1318 2220 SP
+-6 -2 1 1345 2205 SP
+{0 0 0.502 C} FS
+4 0 1 1343 2211 SP
+{1 0 0 C} FS
+-1 2 0 2 4 -1 1 -5 -4 0 5 1582 2167 SP
+1321 2221 M
+-7 -5 D
+8 -2 D
+1 6 D
+6 1 D
+-4 -8 D
+9 5 D
+1 -4 D
+10 1 D
+-12 -9 D
+18 1 D
+-6 -4 D
+8 -2 D
+-15 0 D
+8 -7 D
+13 3 D
+-11 -3 D
+99 -16 D
+23 -5 D
+25 5 D
+9 -6 D
+-4 5 D
+24 -5 D
+11 2 D
+1 -4 D
+1 2 D
+9 -3 D
+-6 4 D
+11 -7 D
+4 5 D
+-18 5 D
+12 -2 D
+-2 5 D
+8 -5 D
+-3 5 D
+7 -5 D
+-3 4 D
+4 -3 D
+0 4 D
+1 -4 D
+12 2 D
+-6 -6 D
+4 -6 D
+10 4 D
+-3 8 D
+1 -1 D
+-9 21 D
+-9 14 D
+-39 6 D
+-64 5 D
+-80 2 D
+-8 -1 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 -1 D
+-8 0 D
+P
+FO
+-9 0 10 3 2 1329 2211 SP
+4 1 1 1555 2173 SP
+-4 2 1 1561 2169 SP
+5 -4 1 1537 2172 SP
+3 1 -3 -2 2 1318 2220 SP
+-6 -2 1 1345 2205 SP
+{0 0 0.502 C} FS
+4 0 1 1343 2211 SP
+1501 2266 M
+-3 0 D
+8 -8 D
+16 -7 D
+2 -3 D
+-14 6 D
+11 -8 D
+-17 4 D
+0 3 D
+-11 4 D
+7 -8 D
+-7 3 D
+-1 -2 D
+-3 10 D
+9 3 D
+-10 2 D
+6 1 D
+-5 2 D
+-4 -2 D
+-9 1 D
+3 -2 D
+-7 2 D
+7 -4 D
+-7 2 D
+0 -6 D
+8 -2 D
+-5 1 D
+4 -3 D
+-8 5 D
+-3 -2 D
+9 -4 D
+-2 -2 D
+-12 6 D
+8 -7 D
+-6 4 D
+-1 -3 D
+0 4 D
+-9 3 D
+-4 -3 D
+3 3 D
+-6 1 D
+-4 4 D
+6 -4 D
+1 4 D
+-11 5 D
+-6 0 D
+2 -4 D
+7 0 D
+-5 -2 D
+-9 1 D
+-3 5 D
+54 3 D
+11 0 D
+P
+FO
+1314 2249 M
+1 -2 D
+25 -1 D
+-29 -3 D
+20 -3 D
+-13 0 D
+15 -10 D
+-9 1 D
+-10 9 D
+-14 2 D
+6 -6 D
+-8 0 D
+21 -11 D
+-11 2 D
+-12 8 D
+9 -14 D
+16 1 D
+0 -1 D
+-8 0 D
+-8 -1 D
+-7 0 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-8 -1 D
+60 23 D
+47 15 D
+P
+FO
+4 -1 1 1323 2251 SP
+-4 1 2 -1 2 1330 2252 SP
+2 0 -2 1 -5 -2 2 0 4 1341 2255 SP
+6 1 6 1 -18 1 -8 -1 9 -1 0 -2 6 1371 2261 SP
+1 1 -4 1 1 -2 3 1378 2262 SP
+5 0 -9 5 -5 -2 5 -4 4 1397 2265 SP
+3 0 -8 3 3 -4 3 1403 2266 SP
+5 1 -3 6 1 -5 -7 4 4 -4 -7 0 2 -2 7 1422 2268 SP
+{1 0 0 C} FS
+5 -3 -7 -3 -2 5 3 1469 2261 SP
+0 -2 -6 4 2 1434 2264 SP
+7 -3 1 -4 2 1455 2263 SP
+-6 -1 -12 8 2 1515 2250 SP
+-2 -2 -5 5 2 1462 2261 SP
+-3 -2 1 1419 2268 SP
+{0 0 0.502 C} FS
+5 -4 1 1384 2263 SP
+2 2 1 1382 2259 SP
+{1 0 0 C} FS
+1523 2250 M
+1 -2 D
+-14 6 D
+11 -8 D
+-17 4 D
+0 3 D
+-11 4 D
+7 -8 D
+-7 3 D
+-1 -2 D
+-3 10 D
+9 3 D
+-10 2 D
+6 1 D
+-5 2 D
+-4 -2 D
+-9 1 D
+3 -2 D
+-7 2 D
+7 -4 D
+-7 2 D
+0 -6 D
+8 -2 D
+-5 1 D
+4 -3 D
+-8 5 D
+-3 -2 D
+9 -4 D
+-2 -2 D
+-12 6 D
+8 -7 D
+-6 4 D
+-1 -3 D
+0 4 D
+-9 3 D
+-4 -3 D
+3 3 D
+-6 1 D
+-4 4 D
+6 -4 D
+1 4 D
+-11 5 D
+-6 0 D
+2 -4 D
+7 0 D
+-5 -2 D
+-9 1 D
+-3 5 D
+-2 -1 D
+-2 0 D
+2 -2 D
+-7 0 D
+4 -4 D
+-7 4 D
+1 -5 D
+-3 6 D
+-4 -1 D
+-5 0 D
+3 -4 D
+-9 3 D
+5 -4 D
+-5 -2 D
+-9 5 D
+-5 -1 D
+-5 -1 D
+1 -2 D
+-8 1 D
+0 -2 D
+9 -1 D
+-8 -1 D
+-18 1 D
+-6 -2 D
+-7 -1 D
+2 0 D
+-5 -2 D
+-2 1 D
+-3 -1 D
+-3 -1 D
+2 -1 D
+-4 1 D
+-2 -1 D
+-3 0 D
+4 -1 D
+-4 1 D
+-4 -1 D
+-5 -1 D
+1 -2 D
+25 -1 D
+-29 -3 D
+20 -3 D
+-13 0 D
+15 -10 D
+-9 1 D
+-10 9 D
+-14 2 D
+6 -6 D
+-8 0 D
+21 -11 D
+-11 2 D
+-12 8 D
+9 -14 D
+16 1 D
+0 -1 D
+41 2 D
+48 1 D
+64 -3 D
+79 -8 D
+8 -2 D
+-22 25 D
+P
+FO
+-5 3 -5 4 -5 3 15 -6 8 -8 -3 0 6 1501 2266 SP
+5 -3 -7 -3 -2 5 3 1469 2261 SP
+0 -2 -6 4 2 1434 2264 SP
+7 -3 1 -4 2 1455 2263 SP
+-6 -1 -12 8 2 1515 2250 SP
+-2 -2 -5 5 2 1462 2261 SP
+-3 -2 1 1419 2268 SP
+{0 0 0.502 C} FS
+5 -4 1 1384 2263 SP
+2 2 1 1382 2259 SP
+1426 2269 M
+-7 1 D
+3 -2 D
+-5 0 D
+-5 -1 D
+0 1 D
+-10 -1 D
+1 -1 D
+-2 -1 D
+-3 0 D
+-1 0 D
+-4 -1 D
+-5 0 D
+-6 3 D
+-7 -2 D
+3 -3 D
+-2 0 D
+-1 -1 D
+-4 2 D
+0 -2 D
+-5 -1 D
+-6 -1 D
+-6 -1 D
+-21 0 D
+8 -3 D
+-3 -1 D
+-2 0 D
+-15 3 D
+9 -5 D
+-2 0 D
+-15 5 D
+-17 -1 D
+6 -5 D
+11 0 D
+1 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -3 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-6 -2 D
+-7 -3 D
+28 23 D
+28 21 D
+37 24 D
+46 24 D
+36 14 D
+27 7 D
+30 -9 D
+37 -15 D
+41 -21 D
+-11 0 D
+-11 0 D
+-10 -1 D
+-11 -1 D
+-11 0 D
+P
+FO
+-8 1 1 1323 2251 SP
+{1 0 0 C} FS
+-4 -3 -5 3 2 1411 2270 SP
+8 -1 1 1417 2299 SP
+-5 -1 1 1369 2265 SP
+-9 -3 1 1395 2268 SP
+5 1 1 -2 11 0 6 -5 -17 -1 -15 5 2 1 3 0 8 -1 -8 1 10 1323 2251 SP
+3 1 9 -5 -15 3 3 1336 2254 SP
+7 1 8 -3 -21 0 3 1354 2258 SP
+2 0 0 -2 -4 2 3 1375 2261 SP
+5 1 3 -3 -7 -2 -6 3 4 1388 2264 SP
+-1 0 1 1398 2265 SP
+5 0 1 -1 -10 -1 0 1 4 1412 2267 SP
+2 0 3 -2 -7 1 3 1426 2269 SP
+-4 -3 -5 3 2 1411 2270 SP
+8 -1 1 1417 2299 SP
+-5 -1 1 1369 2265 SP
+-9 -3 1 1395 2268 SP
+{0 0 0.502 C} FS
+1509 2316 M
+-23 5 D
+-38 4 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-9 -2 D
+-8 -2 D
+-53 13 D
+-56 9 D
+-23 2 D
+5 2 D
+-2 -1 D
+6 0 D
+-3 1 D
+9 -1 D
+7 2 D
+9 -1 D
+-10 2 D
+12 -2 D
+1 2 D
+2 -2 D
+6 0 D
+-3 1 D
+7 -1 D
+-6 2 D
+14 -1 D
+-9 2 D
+17 -2 D
+-4 1 D
+11 0 D
+-10 1 D
+14 -1 D
+-3 1 D
+13 -1 D
+-8 1 D
+16 -1 D
+-8 1 D
+8 -1 D
+-2 1 D
+25 -3 D
+-19 3 D
+37 -5 D
+-3 1 D
+11 -3 D
+-8 2 D
+17 -3 D
+-5 2 D
+11 -3 D
+-3 1 D
+12 -2 D
+-15 3 D
+19 -4 D
+-7 2 D
+8 -2 D
+-6 2 D
+6 -1 D
+-24 5 D
+27 -6 D
+-4 1 D
+6 -1 D
+-7 2 D
+8 -2 D
+0 1 D
+-5 0 D
+5 0 D
+-19 3 D
+25 -4 D
+-13 3 D
+10 -2 D
+-7 1 D
+13 -3 D
+-42 9 D
+-17 3 D
+4 -1 D
+-86 12 D
+15 -2 D
+-14 -1 D
+-22 2 D
+12 2 D
+88 -11 D
+87 -18 D
+P
+FO
+-1 -1 0 1 2 1254 2343 SP
+9 -2 1 1258 2347 SP
+{1 0 0 C} FS
+-1 -1 7 0 -14 0 3 1294 2342 SP
+8 1 3 -1 2 1267 2342 SP
+8 0 -4 -1 2 1293 2342 SP
+4 0 1 1302 2341 SP
+-2 0 1 1429 2335 SP
+-6 1 1 1375 2341 SP
+-3 0 1 1327 2344 SP
+-1 0 1 1298 2356 SP
+8 -1 1 1369 2342 SP
+7 0 1 1294 2342 SP
+-6 0 1 1287 2341 SP
+7 0 1 1254 2341 SP
+{0 0 0.502 C} FS
+-9 2 -2 0 -8 1 -1 0 17 -2 2 -1 6 1347 2351 SP
+5 0 -2 0 -17 2 3 1326 2353 SP
+1 0 1 1323 2351 SP
+6 -1 1 1257 2346 SP
+-7 2 1 1389 2342 SP
+4 0 1 1275 2350 SP
+-1 0 1 1403 2341 SP
+4 -1 1 1287 2351 SP
+1 0 1 1356 2349 SP
+2 0 1 1402 2341 SP
+-5 1 1 1291 2347 SP
+5 -1 1 1353 2346 SP
+2 -1 1 1277 2346 SP
+0 1 1 1353 2349 SP
+2 0 1 1290 2348 SP
+3 -1 1 1268 2348 SP
+-3 1 1 1343 2350 SP
+-5 1 1 1385 2342 SP
+1 0 1 1361 2347 SP
+-1 0 1 1395 2342 SP
+1 0 1 1413 2339 SP
+2 -1 1 1424 2337 SP
+5 -2 1 1282 2351 SP
+0 1 1 1326 2350 SP
+-8 1 1 1331 2353 SP
+18 -4 1 1263 2350 SP
+-13 4 1 1322 2348 SP
+-3 1 1 1372 2346 SP
+-2 0 1 1333 2352 SP
+-6 0 1 1287 2346 SP
+2 0 1 1368 2347 SP
+10 -1 1 1308 2355 SP
+11 -2 1 1268 2350 SP
+-4 0 1 1315 2347 SP
+-6 1 5 -1 2 1293 2351 SP
+3 0 1 1351 2348 SP
+1 0 1 1332 2349 SP
+-5 2 1 1303 2350 SP
+4 -1 1 1320 2350 SP
+2 0 1 1320 2352 SP
+-2 0 1 1319 2352 SP
+-1 0 1 1309 2351 SP
+0 -1 1 1323 2348 SP
+2 0 1 1376 2345 SP
+-8 1 1 1345 2346 SP
+3 -1 1 1280 2349 SP
+-2 1 1 1361 2348 SP
+2 -1 1 1298 2351 SP
+-1 0 1 1366 2348 SP
+2 -1 1 1304 2349 SP
+3 -1 1 1305 2348 SP
+{1 0 0 C} FS
+1258 2347 M
+9 -2 D
+-9 2 D
+-3 -2 D
+-1 -2 D
+0 1 D
+-2 -2 D
+4 1 D
+-2 -1 D
+6 0 D
+-3 1 D
+9 -1 D
+7 2 D
+9 -1 D
+-10 2 D
+12 -2 D
+1 2 D
+2 -2 D
+6 0 D
+-3 1 D
+7 -1 D
+-6 2 D
+14 -1 D
+-9 2 D
+17 -2 D
+-4 1 D
+11 0 D
+-10 1 D
+14 -1 D
+-3 1 D
+13 -1 D
+-8 1 D
+16 -1 D
+-8 1 D
+8 -1 D
+-2 1 D
+25 -3 D
+-19 3 D
+37 -5 D
+-3 1 D
+11 -3 D
+-8 2 D
+17 -3 D
+-5 2 D
+11 -3 D
+-3 1 D
+12 -2 D
+-15 3 D
+19 -4 D
+-7 2 D
+8 -2 D
+-6 2 D
+6 -1 D
+-24 5 D
+27 -6 D
+-4 1 D
+6 -1 D
+-7 2 D
+8 -2 D
+0 1 D
+-5 0 D
+5 0 D
+-19 3 D
+25 -4 D
+-13 3 D
+10 -2 D
+-7 1 D
+13 -3 D
+-42 9 D
+-17 3 D
+4 -1 D
+-86 12 D
+15 -2 D
+-14 -1 D
+-22 2 D
+-3 -1 D
+-5 -2 D
+P
+FO
+-1 -1 7 0 -14 0 3 1294 2342 SP
+8 1 3 -1 2 1267 2342 SP
+8 0 -4 -1 2 1293 2342 SP
+4 0 1 1302 2341 SP
+-2 0 1 1429 2335 SP
+-6 1 1 1375 2341 SP
+-3 0 1 1327 2344 SP
+-1 0 1 1298 2356 SP
+8 -1 1 1369 2342 SP
+7 0 1 1294 2342 SP
+-6 0 1 1287 2341 SP
+7 0 1 1254 2341 SP
+{0 0 0.502 C} FS
+-9 2 -2 0 -8 1 -1 0 17 -2 2 -1 6 1347 2351 SP
+5 0 -2 0 -17 2 3 1326 2353 SP
+1 0 1 1323 2351 SP
+6 -1 1 1257 2346 SP
+-7 2 1 1389 2342 SP
+4 0 1 1275 2350 SP
+-1 0 1 1403 2341 SP
+4 -1 1 1287 2351 SP
+1 0 1 1356 2349 SP
+2 0 1 1402 2341 SP
+-5 1 1 1291 2347 SP
+5 -1 1 1353 2346 SP
+2 -1 1 1277 2346 SP
+0 1 1 1353 2349 SP
+2 0 1 1290 2348 SP
+3 -1 1 1268 2348 SP
+-3 1 1 1343 2350 SP
+-5 1 1 1385 2342 SP
+1 0 1 1361 2347 SP
+-1 0 1 1395 2342 SP
+1 0 1 1413 2339 SP
+2 -1 1 1424 2337 SP
+5 -2 1 1282 2351 SP
+0 1 1 1326 2350 SP
+-8 1 1 1331 2353 SP
+18 -4 1 1263 2350 SP
+-13 4 1 1322 2348 SP
+-3 1 1 1372 2346 SP
+-2 0 1 1333 2352 SP
+-6 0 1 1287 2346 SP
+2 0 1 1368 2347 SP
+10 -1 1 1308 2355 SP
+11 -2 1 1268 2350 SP
+-4 0 1 1315 2347 SP
+-6 1 5 -1 2 1293 2351 SP
+3 0 1 1351 2348 SP
+1 0 1 1332 2349 SP
+-5 2 1 1303 2350 SP
+4 -1 1 1320 2350 SP
+2 0 1 1320 2352 SP
+-2 0 1 1319 2352 SP
+-1 0 1 1309 2351 SP
+0 -1 1 1323 2348 SP
+2 0 1 1376 2345 SP
+-8 1 1 1345 2346 SP
+3 -1 1 1280 2349 SP
+-2 1 1 1361 2348 SP
+2 -1 1 1298 2351 SP
+-1 0 1 1366 2348 SP
+2 -1 1 1304 2349 SP
+3 -1 1 1305 2348 SP
+1273 2356 M
+-7 0 D
+-11 0 D
+1 -2 D
+-4 1 D
+-1 -1 D
+-5 1 D
+-3 -1 D
+-16 1 D
+-7 2 D
+44 1 D
+-2 1 D
+6 0 D
+-17 1 D
+4 0 D
+-75 2 D
+52 -1 D
+53 -3 D
+-3 0 D
+-2 0 D
+-2 -1 D
+-3 0 D
+P
+FO
+-5 1 1 1258 2347 SP
+11 1 -4 0 -4 1 -1 -1 3 1 -4 -2 6 1253 2343 SP
+-2 0 5 -1 -1 1 3 1238 2342 SP
+1 0 1 1227 2343 SP
+1104 2347 M
+51 -1 D
+4 2 D
+-3 -2 D
+10 -1 D
+-7 0 D
+7 -1 D
+6 2 D
+17 -2 D
+-11 0 D
+-11 0 D
+-12 0 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 -1 D
+P
+FO
+1096 2353 M
+2 0 D
+-5 2 D
+18 1 D
+-3 -1 D
+16 2 D
+-15 -1 D
+30 2 D
+6 -2 D
+-5 -1 D
+16 0 D
+-6 -1 D
+16 -1 D
+-61 -1 D
+-6 -1 D
+P
+FO
+{1 0 0 C} FS
+-6 0 1 1259 2360 SP
+{0 0 0.502 C} FS
+10 0 -6 0 14 0 2 1 -6 0 -13 0 1 0 9 0 -19 2 7 -1 -4 -1 15 -1 -8 0 -8 1 5 -1 15 1203 2362 SP
+6 0 -1 -1 -9 0 9 0 3 0 -8 0 2 0 15 1 -6 0 2 -1 -4 1 -3 -1 0 1 13 1219 2360 SP
+-4 0 -7 0 4 -1 -8 1 4 -1 14 0 -8 0 11 0 5 1 -9 0 -12 0 11 1138 2360 SP
+-1 1 7 0 -11 0 3 1141 2359 SP
+-1 0 1 0 10 0 1 0 4 1231 2360 SP
+6 -1 -4 1 9 0 3 1232 2360 SP
+7 0 6 0 -9 1 3 1173 2357 SP
+-12 1 1 -1 2 1208 2359 SP
+3 2 -13 -2 2 1203 2348 SP
+15 0 3 0 14 0 -21 0 4 1172 2362 SP
+-3 0 -2 0 2 1220 2361 SP
+6 0 -2 1 2 1172 2355 SP
+-14 0 10 -1 2 1200 2351 SP
+7 0 -5 1 2 1148 2359 SP
+6 0 -1 3 2 1156 2349 SP
+1 1 1 1140 2350 SP
+2 0 1 1199 2360 SP
+-1 0 1 1209 2361 SP
+-7 0 1 1188 2356 SP
+-2 0 1 1151 2359 SP
+5 0 1 1223 2360 SP
+-3 0 1 1227 2353 SP
+-6 0 1 1208 2362 SP
+2 0 1 1205 2355 SP
+3 1 -1 0 2 1238 2359 SP
+8 1 -1 0 2 1169 2349 SP
+8 0 1 1247 2360 SP
+0 -1 1 1 2 1227 2360 SP
+2 0 1 1223 2359 SP
+-2 0 1 1190 2359 SP
+-8 0 9 0 2 1160 2352 SP
+11 -1 1 1179 2361 SP
+8 1 -2 0 2 1101 2359 SP
+-7 1 1 1165 2356 SP
+-5 0 1 1217 2361 SP
+-5 1 1 1166 2354 SP
+-3 0 1 1193 2361 SP
+-10 0 1 1198 2355 SP
+-1 -1 1 1090 2359 SP
+-4 0 1 1087 2358 SP
+1 0 1 1213 2360 SP
+2 0 1 1184 2361 SP
+1 1 1 1094 2358 SP
+1 1 1 1157 2355 SP
+-10 0 1 1196 2359 SP
+0 -1 1 1214 2362 SP
+-1 1 1 1147 2350 SP
+-3 -1 1 1176 2361 SP
+0 -1 1 1227 2360 SP
+1 0 1 1183 2359 SP
+-4 1 1 1174 2359 SP
+3 0 1 1233 2361 SP
+-6 -1 1 1191 2358 SP
+5 0 -6 0 2 1204 2354 SP
+4 1 1 1165 2358 SP
+{1 0 0 C} FS
+-3 1 7 0 2 1187 2361 SP
+1 -1 1 1200 2361 SP
+1093 2355 M
+18 1 D
+-3 -1 D
+16 2 D
+-15 -1 D
+30 2 D
+6 -2 D
+-5 -1 D
+16 0 D
+-6 -1 D
+16 -1 D
+-61 -1 D
+-6 -1 D
+4 -2 D
+1 -2 D
+51 -1 D
+4 2 D
+-3 -2 D
+10 -1 D
+-7 0 D
+7 -1 D
+6 2 D
+27 -2 D
+39 -2 D
+-1 1 D
+6 -1 D
+11 1 D
+2 3 D
+2 1 D
+-5 1 D
+5 -1 D
+7 6 D
+8 3 D
+-7 0 D
+-11 0 D
+1 -2 D
+-4 1 D
+-1 -1 D
+-5 1 D
+-3 -1 D
+-16 1 D
+-7 2 D
+44 1 D
+-2 1 D
+6 0 D
+-17 1 D
+4 0 D
+-114 2 D
+-13 -1 D
+-12 -1 D
+-13 0 D
+-13 -1 D
+-13 -1 D
+13 -2 D
+P
+FO
+-3 1 2 0 2 1096 2353 SP
+3 1 -4 -2 2 1253 2343 SP
+-6 0 1 1259 2360 SP
+{0 0 0.502 C} FS
+10 0 -6 0 14 0 2 1 -6 0 -13 0 1 0 9 0 -19 2 7 -1 -4 -1 15 -1 -8 0 -8 1 5 -1 15 1203 2362 SP
+6 0 -1 -1 -9 0 9 0 3 0 -8 0 2 0 15 1 -6 0 2 -1 -4 1 -3 -1 0 1 13 1219 2360 SP
+-4 0 -7 0 4 -1 -8 1 4 -1 14 0 -8 0 11 0 5 1 -9 0 -12 0 11 1138 2360 SP
+-1 1 7 0 -11 0 3 1141 2359 SP
+-1 0 1 0 10 0 1 0 4 1231 2360 SP
+6 -1 -4 1 9 0 3 1232 2360 SP
+7 0 6 0 -9 1 3 1173 2357 SP
+-12 1 1 -1 2 1208 2359 SP
+3 2 -13 -2 2 1203 2348 SP
+15 0 3 0 14 0 -21 0 4 1172 2362 SP
+-3 0 -2 0 2 1220 2361 SP
+6 0 -2 1 2 1172 2355 SP
+-14 0 10 -1 2 1200 2351 SP
+7 0 -5 1 2 1148 2359 SP
+6 0 -1 3 2 1156 2349 SP
+1 1 1 1140 2350 SP
+2 0 1 1199 2360 SP
+-1 0 1 1209 2361 SP
+-7 0 1 1188 2356 SP
+-2 0 1 1151 2359 SP
+5 0 1 1223 2360 SP
+-3 0 1 1227 2353 SP
+-6 0 1 1208 2362 SP
+2 0 1 1205 2355 SP
+3 1 -1 0 2 1238 2359 SP
+8 1 -1 0 2 1169 2349 SP
+8 0 1 1247 2360 SP
+0 -1 1 1 2 1227 2360 SP
+2 0 1 1223 2359 SP
+-2 0 1 1190 2359 SP
+-8 0 9 0 2 1160 2352 SP
+11 -1 1 1179 2361 SP
+8 1 -2 0 2 1101 2359 SP
+-7 1 1 1165 2356 SP
+-5 0 1 1217 2361 SP
+-5 1 1 1166 2354 SP
+-3 0 1 1193 2361 SP
+-10 0 1 1198 2355 SP
+-1 -1 1 1090 2359 SP
+-4 0 1 1087 2358 SP
+1 0 1 1213 2360 SP
+2 0 1 1184 2361 SP
+1 1 1 1094 2358 SP
+1 1 1 1157 2355 SP
+-10 0 1 1196 2359 SP
+0 -1 1 1214 2362 SP
+-1 1 1 1147 2350 SP
+-3 -1 1 1176 2361 SP
+0 -1 1 1227 2360 SP
+1 0 1 1183 2359 SP
+-4 1 1 1174 2359 SP
+3 0 1 1233 2361 SP
+-6 -1 1 1191 2358 SP
+5 0 -6 0 2 1204 2354 SP
+4 1 1 1165 2358 SP
+{1 0 0 C} FS
+-3 1 7 0 2 1187 2361 SP
+1 -1 1 1200 2361 SP
+{0 0 0.502 C} FS
+4 1 -6 0 2 1095 2354 SP
+1099 2351 M
+-9 -2 D
+16 -3 D
+5 -5 D
+-12 -1 D
+-12 -1 D
+-11 -2 D
+-12 -1 D
+-11 -2 D
+-11 -2 D
+-12 -2 D
+-11 -3 D
+-11 -2 D
+-10 -3 D
+-11 -3 D
+-11 -1 D
+-11 3 D
+11 0 D
+7 4 D
+13 3 D
+0 2 D
+12 2 D
+2 -2 D
+-5 -1 D
+13 4 D
+22 6 D
+-6 0 D
+9 2 D
+-2 2 D
+23 2 D
+-11 -3 D
+3 -1 D
+26 2 D
+-8 0 D
+-10 6 D
+18 0 D
+14 4 D
+P
+FO
+{1 0 0 C} FS
+4 3 10 0 -7 -3 3 1042 2337 SP
+{0 0 0.502 C} FS
+7 2 -6 -2 8 2 13 3 -6 -2 5 2 -8 -2 -5 -1 4 1 -12 -2 4 0 11 914 2331 SP
+-7 -4 -17 -4 -15 4 9 4 -10 -4 16 -4 17 4 7 4 14 1 9 958 2330 SP
+-32 -3 -9 1 2 1 -12 -1 12 1 -2 -2 8 0 34 3 8 1036 2352 SP
+6 1 1 907 2330 SP
+{1 0 0 C} FS
+854 2316 M
+22 5 D
+40 4 D
+34 -2 D
+17 -3 D
+-2 1 D
+11 0 D
+7 4 D
+13 3 D
+0 2 D
+12 2 D
+2 -2 D
+-5 -1 D
+13 4 D
+22 6 D
+-6 0 D
+9 2 D
+-2 2 D
+23 2 D
+-11 -3 D
+3 -1 D
+26 2 D
+-8 0 D
+-10 6 D
+18 0 D
+14 4 D
+-7 1 D
+4 1 D
+-14 3 D
+-14 -2 D
+-13 -1 D
+-12 -1 D
+-13 -2 D
+-13 -2 D
+-12 -1 D
+-13 -2 D
+-12 -3 D
+-13 -2 D
+-12 -2 D
+-12 -3 D
+-13 -2 D
+-12 -3 D
+-12 -3 D
+-13 -3 D
+-12 -3 D
+-12 -4 D
+P
+FO
+4 1 1 -1 2 0 -11 -1 4 987 2319 SP
+-2 1 -1 2 14 -2 -9 -2 4 1099 2351 SP
+4 3 10 0 -7 -3 3 1042 2337 SP
+{0 0 0.502 C} FS
+7 2 -6 -2 8 2 13 3 -6 -2 5 2 -8 -2 -5 -1 4 1 -12 -2 4 0 11 914 2331 SP
+-7 -4 -17 -4 -15 4 9 4 -10 -4 16 -4 17 4 7 4 14 1 9 958 2330 SP
+-32 -3 -9 1 2 1 -12 -1 12 1 -2 -2 8 0 34 3 8 1036 2352 SP
+6 1 1 907 2330 SP
+976 2318 M
+0 -1 D
+2 0 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-5 1 D
+-8 -3 D
+-14 -2 D
+-3 3 D
+28 5 D
+-5 -1 D
+41 9 D
+1 2 D
+-14 -1 D
+7 3 D
+P
+FO
+-3 -2 13 -1 13 3 8 -6 -12 -7 24 8 -4 7 -15 0 7 6 19 1 13 5 -10 -4 -4 2 -12 -2 -13 -4 -10 -6 -10 2 17 900 2287 SP
+718 2254 M
+57 24 D
+45 20 D
+-10 -3 D
+-10 -2 D
+4 3 D
+-8 -1 D
+8 1 D
+-4 -3 D
+73 19 D
+5 -1 D
+16 1 D
+9 -1 D
+0 -3 D
+-14 -6 D
+2 3 D
+11 3 D
+0 2 D
+-8 2 D
+-19 -2 D
+-2 2 D
+-45 -12 D
+-45 -19 D
+-34 -15 D
+-22 -8 D
+-7 -3 D
+P
+FO
+1 0 1 668 2239 SP
+{1 0 0 C} FS
+-1 -2 1 874 2297 SP
+5 2 1 873 2297 SP
+{0 0 0.502 C} FS
+8 4 0 1 -7 -4 3 683 2249 SP
+0 -1 1 1 2 741 2275 SP
+8 2 -1 0 2 833 2306 SP
+-2 -1 1 814 2297 SP
+6 3 1 695 2257 SP
+{1 0 0 C} FS
+668 2239 M
+1 0 D
+-1 0 D
+40 13 D
+10 2 D
+57 24 D
+45 20 D
+-10 -3 D
+-10 -2 D
+4 3 D
+-8 -1 D
+8 1 D
+-4 -3 D
+73 19 D
+5 -1 D
+16 1 D
+9 -1 D
+0 -3 D
+-14 -6 D
+2 3 D
+11 3 D
+0 2 D
+-8 2 D
+-19 -2 D
+-2 2 D
+-45 -12 D
+-45 -19 D
+-34 -15 D
+-22 -8 D
+-7 -3 D
+57 11 D
+47 5 D
+48 1 D
+28 15 D
+-10 2 D
+-10 -6 D
+-13 -4 D
+-12 -2 D
+-4 2 D
+-10 -4 D
+13 5 D
+19 1 D
+7 6 D
+-15 0 D
+-4 7 D
+24 8 D
+-12 -7 D
+8 -6 D
+13 3 D
+13 -1 D
+32 13 D
+-5 1 D
+-8 -3 D
+-14 -2 D
+-3 3 D
+28 5 D
+-5 -1 D
+41 9 D
+1 2 D
+-14 -1 D
+7 3 D
+-26 4 D
+-33 1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-7 -2 D
+-7 -2 D
+-13 -4 D
+-12 -3 D
+-12 -4 D
+-12 -4 D
+-12 -4 D
+-12 -5 D
+-12 -4 D
+-12 -4 D
+-12 -5 D
+-11 -5 D
+-12 -5 D
+-12 -5 D
+-11 -5 D
+-12 -5 D
+-23 -11 D
+-23 -11 D
+-11 -6 D
+-16 -9 D
+-14 -8 D
+38 18 D
+P
+FO
+-1 1 1 0 2 0 0 -1 4 976 2318 SP
+-1 -2 1 874 2297 SP
+5 2 1 873 2297 SP
+{0 0 0.502 C} FS
+8 4 0 1 -7 -4 3 683 2249 SP
+0 -1 1 1 2 741 2275 SP
+8 2 -1 0 2 833 2306 SP
+-2 -1 1 814 2297 SP
+6 3 1 695 2257 SP
+-9 -6 0 -2 8 6 3 507 2139 SP
+-1 -1 1 668 2239 SP
+35 17 24 10 8 2 -8 -1 -13 -6 -36 -17 -12 -6 7 720 2255 SP
+-2 -1 8 2 -5 0 3 856 2262 SP
+0 -1 10 2 -9 0 3 838 2249 SP
+744 2239 M
+-8 0 D
+-25 -11 D
+25 11 D
+33 3 D
+13 3 D
+9 5 D
+46 5 D
+13 6 D
+-5 -4 D
+-8 -3 D
+-47 -4 D
+-8 -5 D
+-11 -2 D
+-2 -4 D
+-9 -4 D
+-16 -4 D
+-14 -8 D
+13 8 D
+16 4 D
+10 5 D
+1 2 D
+P
+FO
+-8 -3 -11 -6 2 5 -4 -3 3 -3 5 585 2182 SP
+-11 -10 6 3 2 801 2240 SP
+-4 -6 1 639 2226 SP
+-7 -7 1 813 2243 SP
+1 -3 9 9 2 815 2237 SP
+4 -5 1 787 2233 SP
+14 3 1 755 2221 SP
+7 4 1 558 2177 SP
+-4 0 1 775 2229 SP
+8 3 1 800 2228 SP
+6 2 -1 0 2 758 2219 SP
+1 0 1 619 2217 SP
+-3 -2 1 523 2135 SP
+{1 0 0 C} FS
+507 2139 M
+8 6 D
+0 -2 D
+-9 -6 D
+1 2 D
+-25 -26 D
+-14 -19 D
+55 31 D
+65 29 D
+61 22 D
+103 27 D
+50 8 D
+11 15 D
+25 23 D
+-9 0 D
+10 2 D
+0 -1 D
+17 12 D
+-5 0 D
+8 2 D
+8 6 D
+5 2 D
+-12 0 D
+-12 0 D
+-12 -1 D
+-12 0 D
+-12 -1 D
+-12 -1 D
+-11 -2 D
+-12 -1 D
+-12 -2 D
+-11 -2 D
+-11 -2 D
+-12 -3 D
+-11 -2 D
+-48 -23 D
+-13 -6 D
+-8 -1 D
+8 2 D
+59 27 D
+-10 -2 D
+-10 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-1 -1 D
+1 1 D
+-10 -4 D
+-10 -4 D
+-10 -4 D
+-10 -4 D
+-19 -9 D
+-9 -5 D
+-14 -8 D
+-19 -13 D
+-12 -8 D
+-11 -9 D
+-27 -22 D
+P
+FO
+{0 0 0.502 C} FS
+744 2239 M
+-8 0 D
+-25 -11 D
+25 11 D
+33 3 D
+13 3 D
+9 5 D
+46 5 D
+13 6 D
+-5 -4 D
+-8 -3 D
+-47 -4 D
+-8 -5 D
+-11 -2 D
+-2 -4 D
+-9 -4 D
+-16 -4 D
+-14 -8 D
+13 8 D
+16 4 D
+10 5 D
+1 2 D
+P
+FO
+-8 -3 -11 -6 2 5 -4 -3 3 -3 5 585 2182 SP
+-11 -10 6 3 2 801 2240 SP
+-4 -6 1 639 2226 SP
+-7 -7 1 813 2243 SP
+1 -3 9 9 2 815 2237 SP
+4 -5 1 787 2233 SP
+14 3 1 755 2221 SP
+7 4 1 558 2177 SP
+-4 0 1 775 2229 SP
+8 3 1 800 2228 SP
+6 2 -1 0 2 758 2219 SP
+1 0 1 619 2217 SP
+-3 -2 1 523 2135 SP
+-2 4 1 656 2097 SP
+-13 -14 -6 -11 23 -2 -23 2 6 11 14 14 -10 4 7 595 2069 SP
+10 8 2 0 7 5 -16 -9 3 6 37 19 -1 -2 3 3 9 5 -7 -2 -11 -7 -2 -2 4 4 -26 -14 -9 -5 -2 -4 16 555 2131 SP
+15 1 8 -1 -1 -7 7 8 -1 5 -8 -3 -9 7 -4 -4 -8 0 -24 -11 -2 -3 11 527 2087 SP
+-6 -2 -8 -6 2 488 2105 SP
+-6 -5 1 484 2087 SP
+-2 -3 1 547 2133 SP
+{1 0 0 C} FS
+595 2069 M
+-10 4 D
+14 14 D
+6 11 D
+-23 2 D
+23 -2 D
+-6 -11 D
+-13 -14 D
+9 -4 D
+55 26 D
+6 2 D
+-2 4 D
+2 -4 D
+37 16 D
+61 22 D
+23 7 D
+4 30 D
+10 23 D
+11 16 D
+-9 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-9 -2 D
+-8 -1 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -3 D
+-8 -2 D
+-8 -2 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-15 -7 D
+-7 -3 D
+-14 -7 D
+-14 -7 D
+-14 -8 D
+-14 -8 D
+-6 -4 D
+-8 -10 D
+-18 -32 D
+-9 -21 D
+-8 -33 D
+-3 -22 D
+0 -11 D
+48 33 D
+50 31 D
+60 33 D
+P
+FO
+{0 0 0.502 C} FS
+10 8 2 0 7 5 -16 -9 3 6 37 19 -1 -2 3 3 9 5 -7 -2 -11 -7 -2 -2 4 4 -26 -14 -9 -5 -2 -4 16 555 2131 SP
+15 1 8 -1 -1 -7 7 8 -1 5 -8 -3 -9 7 -4 -4 -8 0 -24 -11 -2 -3 11 527 2087 SP
+-6 -2 -8 -6 2 488 2105 SP
+-6 -5 1 484 2087 SP
+-2 -3 1 547 2133 SP
+-5 -2 0 3 -6 -6 -17 1 -7 3 -3 -2 -2 -3 32 0 9 6 9 454 1855 SP
+595 2069 M
+8 -2 D
+0 -16 D
+27 -13 D
+27 12 D
+16 25 D
+-10 0 D
+3 10 D
+-10 12 D
+10 -12 D
+-2 -9 D
+8 -1 D
+14 15 D
+44 25 D
+49 9 D
+0 -1 D
+-44 -8 D
+-46 -24 D
+-24 -30 D
+1 -26 D
+-5 -3 D
+-2 -15 D
+-42 -23 D
+0 4 D
+1 -3 D
+40 22 D
+2 15 D
+6 3 D
+-5 18 D
+-21 -14 D
+-20 -4 D
+-18 16 D
+0 15 D
+-4 1 D
+-6 -5 D
+5 7 D
+-2 0 D
+P
+FO
+531 1892 M
+1 3 D
+-4 6 D
+-5 -3 D
+-12 1 D
+14 8 D
+-12 -2 D
+14 11 D
+-5 6 D
+4 7 D
+35 2 D
+25 5 D
+-28 -22 D
+P
+FO
+1 -1 3 5 -2 -4 -2 1 4 513 1876 SP
+{1 0 0 C} FS
+-9 -3 5 7 2 534 1912 SP
+4 1 1 532 1919 SP
+{0 0 0.502 C} FS
+-6 -3 1 501 1866 SP
+1 -2 1 0 2 483 1884 SP
+{1 0 0 C} FS
+4 2 1 719 2108 SP
+1 -3 1 619 2038 SP
+454 1855 M
+9 6 D
+32 0 D
+14 12 D
+3 5 D
+1 -1 D
+18 15 D
+1 3 D
+-4 6 D
+-5 -3 D
+-12 1 D
+14 8 D
+-12 -2 D
+14 11 D
+-5 6 D
+4 7 D
+35 2 D
+25 5 D
+55 41 D
+28 19 D
+15 9 D
+43 27 D
+75 41 D
+-11 17 D
+-9 22 D
+-3 11 D
+-44 -8 D
+-46 -24 D
+-24 -30 D
+1 -26 D
+-5 -3 D
+-2 -15 D
+-42 -23 D
+0 4 D
+1 -3 D
+40 22 D
+2 15 D
+6 3 D
+-5 18 D
+-21 -14 D
+-20 -4 D
+-18 16 D
+0 15 D
+-4 1 D
+-6 -5 D
+5 7 D
+-2 0 D
+-8 -4 D
+-15 -7 D
+-15 -8 D
+-15 -8 D
+-14 -9 D
+-15 -8 D
+-22 -14 D
+-14 -9 D
+-14 -9 D
+-21 -14 D
+-20 -14 D
+1 -23 D
+7 -33 D
+18 -43 D
+P
+FO
+8 7 7 7 5 -6 4 -7 4 -7 -5 -2 0 3 -6 -6 -17 1 -7 3 10 490 1856 SP
+2 2 -2 -4 -2 1 3 513 1876 SP
+656 2097 M
+10 -12 D
+-2 -9 D
+8 -1 D
+14 15 D
+44 25 D
+49 9 D
+-2 18 D
+-8 -2 D
+-7 -3 D
+-8 -2 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+P
+FO
+595 2069 M
+8 -2 D
+0 -16 D
+27 -13 D
+27 12 D
+16 25 D
+-10 0 D
+3 10 D
+-10 12 D
+-6 -2 D
+-12 -6 D
+-6 -2 D
+-13 -6 D
+-12 -6 D
+P
+FO
+-9 -3 5 7 2 534 1912 SP
+4 1 1 532 1919 SP
+{0 0 0.502 C} FS
+-6 -3 1 501 1866 SP
+1 -2 1 0 2 483 1884 SP
+{1 0 0 C} FS
+4 2 1 719 2108 SP
+1 -3 1 619 2038 SP
+{0 0 0.502 C} FS
+488 1810 M
+18 27 D
+41 43 D
+-4 1 D
+-6 -11 D
+-10 1 D
+-17 -13 D
+-15 -21 D
+-17 -16 D
+-8 11 D
+10 10 D
+27 14 D
+11 19 D
+0 -6 D
+6 3 D
+7 20 D
+55 44 D
+36 8 D
+18 -12 D
+-3 -6 D
+7 2 D
+8 -14 D
+11 5 D
+7 -21 D
+-8 4 D
+-3 -5 D
+27 -12 D
+4 5 D
+-6 4 D
+7 5 D
+38 13 D
+26 -7 D
+-6 -6 D
+-5 -3 D
+-4 -5 D
+2 0 D
+-25 -27 D
+-27 -10 D
+-13 4 D
+-21 -13 D
+-24 -20 D
+-49 -73 D
+33 13 D
+8 12 D
+14 -6 D
+-35 -45 D
+-3 -5 D
+-27 16 D
+-36 26 D
+-36 33 D
+-4 5 D
+-5 4 D
+P
+FO
+3 2 -5 3 1 -4 -6 -4 7 3 -12 -7 -4 -8 3 7 9 5 2 0 10 495 1861 SP
+-5 2 5 -3 2 513 1877 SP
+-17 -10 1 823 2049 SP
+5 -7 12 4 12 -1 4 4 13 -5 -13 6 -27 -7 -5 6 8 851 1995 SP
+-1 -2 3 4 2 648 1784 SP
+{1 0 0 C} FS
+-15 -7 5 6 2 572 1748 SP
+5 1 1 577 1752 SP
+470 1832 M
+10 10 D
+27 14 D
+11 19 D
+0 -6 D
+6 3 D
+7 20 D
+-18 -15 D
+5 -3 D
+-5 2 D
+-4 -3 D
+-4 -8 D
+-12 -7 D
+7 3 D
+-6 -4 D
+1 -4 D
+-5 3 D
+-22 -21 D
+P
+FO
+5 -5 -17 -16 -15 -21 -17 -13 -10 1 -6 -11 -4 1 41 43 18 27 9 488 1810 SP
+648 1784 M
+40 48 D
+29 32 D
+-27 -10 D
+-13 4 D
+-21 -13 D
+-24 -20 D
+-49 -73 D
+33 13 D
+8 12 D
+14 -6 D
+P
+FO
+4 4 2 0 -4 -5 -5 -3 4 749 1899 SP
+851 1995 M
+-5 6 D
+-27 -7 D
+-13 6 D
+13 -5 D
+4 4 D
+12 -1 D
+12 4 D
+5 -7 D
+9 9 D
+11 8 D
+-39 27 D
+-10 10 D
+-17 -10 D
+17 10 D
+-18 19 D
+-3 5 D
+-16 -8 D
+-14 -8 D
+-15 -8 D
+-15 -8 D
+-15 -9 D
+-14 -9 D
+-15 -9 D
+-21 -14 D
+-15 -9 D
+-21 -14 D
+-21 -15 D
+-27 -21 D
+-7 -5 D
+36 8 D
+18 -12 D
+-3 -6 D
+7 2 D
+8 -14 D
+11 5 D
+7 -21 D
+-8 4 D
+-3 -5 D
+27 -12 D
+4 5 D
+-6 4 D
+7 5 D
+38 13 D
+26 -7 D
+16 15 D
+15 16 D
+54 50 D
+P
+FO
+-7 -6 3 7 9 5 2 0 4 495 1861 SP
+-15 -7 5 6 2 572 1748 SP
+5 1 1 577 1752 SP
+{0 0 0.502 C} FS
+638 1771 M
+13 17 D
+25 0 D
+16 21 D
+11 -4 D
+9 21 D
+10 4 D
+-7 9 D
+39 24 D
+7 -1 D
+-1 -7 D
+19 6 D
+-8 -10 D
+12 6 D
+20 -4 D
+0 -14 D
+8 7 D
+38 11 D
+36 3 D
+14 -9 D
+8 6 D
+6 30 D
+-3 -4 D
+0 11 D
+-13 -1 D
+3 3 D
+-7 3 D
+33 -9 D
+6 3 D
+-60 -108 D
+-42 -85 D
+-28 -64 D
+-92 31 D
+-42 18 D
+-47 23 D
+-21 13 D
+34 45 D
+P
+FO
+8 9 8 9 -30 -12 -18 1 -22 -20 -10 1 2 -6 11 -2 11 13 6 -3 29 7 -8 -5 4 -1 13 742 1891 SP
+3 3 -9 -5 3 -1 3 755 1905 SP
+-3 3 2 -3 2 852 1995 SP
+1 -3 1 861 2004 SP
+8 -3 8 -4 7 -4 7 -3 7 -4 7 -4 7 13 -13 -3 -20 14 -9 -1 5 8 -7 12 -7 -3 -1 -10 -7 -5 15 924 1987 SP
+-3 -4 -3 -5 9 -3 8 -3 8 -2 9 -3 8 -3 8 -3 -8 7 -17 4 -15 20 11 969 1953 SP
+{1 0 0 C} FS
+-6 5 6 3 2 911 1984 SP
+-8 7 5 -4 2 802 1667 SP
+1 -13 -2 7 2 714 1774 SP
+-8 4 16 4 2 733 1840 SP
+5 -5 1 751 1715 SP
+-5 -1 1 791 1680 SP
+2 -8 1 721 1768 SP
+5 1 1 751 1702 SP
+{0 0 0.502 C} FS
+5 1 1 659 1797 SP
+{1 0 0 C} FS
+969 1953 M
+-15 20 D
+-17 4 D
+-13 10 D
+-7 -5 D
+-1 -10 D
+-7 -3 D
+-7 12 D
+5 8 D
+-9 -1 D
+-20 14 D
+-13 -3 D
+7 13 D
+-11 -8 D
+1 -3 D
+-1 3 D
+-9 -9 D
+2 -3 D
+-3 3 D
+-54 -49 D
+-21 -20 D
+-5 -6 D
+-16 -15 D
+3 -1 D
+-9 -5 D
+-7 -8 D
+4 -1 D
+-8 -5 D
+29 7 D
+6 -3 D
+11 13 D
+11 -2 D
+2 -6 D
+-10 1 D
+-22 -20 D
+-18 1 D
+-30 -12 D
+-34 -37 D
+-32 -39 D
+25 0 D
+16 21 D
+11 -4 D
+9 21 D
+10 4 D
+-7 9 D
+39 24 D
+7 -1 D
+-1 -7 D
+19 6 D
+-8 -10 D
+12 6 D
+20 -4 D
+0 -14 D
+8 7 D
+38 11 D
+36 3 D
+14 -9 D
+8 6 D
+6 30 D
+-3 -4 D
+0 11 D
+-13 -1 D
+3 3 D
+-7 3 D
+33 -9 D
+6 3 D
+P
+FO
+-5 -7 10 13 2 638 1771 SP
+-6 5 6 3 2 911 1984 SP
+-8 7 5 -4 2 802 1667 SP
+1 -13 -2 7 2 714 1774 SP
+-8 4 16 4 2 733 1840 SP
+5 -5 1 751 1715 SP
+-5 -1 1 791 1680 SP
+2 -8 1 721 1768 SP
+5 1 1 751 1702 SP
+{0 0 0.502 C} FS
+5 1 1 659 1797 SP
+932 1893 M
+10 6 D
+6 12 D
+7 -1 D
+-7 -14 D
+15 -3 D
+2 -14 D
+11 -10 D
+5 4 D
+-2 -7 D
+9 1 D
+-5 8 D
+10 3 D
+4 7 D
+-6 5 D
+14 -7 D
+-1 6 D
+6 -5 D
+10 8 D
+-10 15 D
+-13 6 D
+-8 1 D
+-2 -16 D
+3 26 D
+-21 29 D
+10 14 D
+61 -14 D
+54 -8 D
+-15 -15 D
+-17 1 D
+-7 -8 D
+16 -14 D
+1 -9 D
+16 -3 D
+-1 -8 D
+10 -2 D
+-11 0 D
+-5 10 D
+8 -15 D
+-22 1 D
+-3 9 D
+-34 -10 D
+14 -10 D
+-8 0 D
+4 -10 D
+25 -7 D
+1 4 D
+2 -6 D
+11 8 D
+8 -3 D
+-8 -4 D
+5 -10 D
+-5 -6 D
+-10 2 D
+-11 -8 D
+-10 4 D
+-23 -27 D
+3 -8 D
+8 0 D
+-5 -3 D
+16 -6 D
+-11 -1 D
+0 -13 D
+21 3 D
+3 -19 D
+-8 -8 D
+20 6 D
+3 -3 D
+-7 -45 D
+-4 -2 D
+-1 -10 D
+-17 4 D
+-22 -18 D
+5 3 D
+5 -1 D
+0 6 D
+7 -4 D
+6 9 D
+3 -6 D
+16 7 D
+-2 -12 D
+-2 -2 D
+2 2 D
+-15 -97 D
+-75 8 D
+-104 19 D
+-68 18 D
+32 72 D
+38 77 D
+P
+FO
+-1 -2 3 4 0 8 20 9 1 -7 16 -5 2 -11 -2 12 -13 4 -3 8 -20 -5 -3 -13 12 1087 1823 SP
+{1 0 0 C} FS
+-14 -4 1 -7 -9 1 11 8 4 976 1667 SP
+-3 -7 -23 12 9 4 3 1002 1840 SP
+-15 -8 -7 8 10 0 3 1016 1683 SP
+10 -10 -14 -2 -3 8 3 1022 1783 SP
+3 -3 -8 -4 -4 3 3 1039 1793 SP
+5 0 1 987 1873 SP
+-6 3 5 1 2 838 1661 SP
+18 10 1 949 1659 SP
+14 4 1 874 1658 SP
+-8 -6 1 856 1662 SP
+12 -3 1 886 1657 SP
+4 -4 1 1054 1692 SP
+9 2 1 841 1660 SP
+6 -4 1 954 1803 SP
+{0 0 0.502 C} FS
+-8 -1 1 1046 1787 SP
+-5 0 1 1050 1871 SP
+-4 -2 1 1048 1801 SP
+{1 0 0 C} FS
+-2 -2 1 1064 1688 SP
+1 6 16 7 3 -6 6 9 7 -4 0 6 5 -1 5 3 -22 -18 -17 4 -1 -10 -4 -2 12 1068 1712 SP
+1087 1823 M
+-3 -13 D
+-20 -5 D
+-3 8 D
+-13 4 D
+-2 12 D
+2 -11 D
+16 -5 D
+1 -7 D
+20 9 D
+0 8 D
+3 4 D
+16 85 D
+7 31 D
+-17 2 D
+-15 -15 D
+-17 1 D
+-7 -8 D
+16 -14 D
+1 -9 D
+16 -3 D
+-1 -8 D
+10 -2 D
+-11 0 D
+-5 10 D
+8 -15 D
+-22 1 D
+-3 9 D
+-34 -10 D
+14 -10 D
+-8 0 D
+4 -10 D
+25 -7 D
+1 4 D
+2 -6 D
+11 8 D
+8 -3 D
+-8 -4 D
+5 -10 D
+-5 -6 D
+-10 2 D
+-11 -8 D
+-10 4 D
+-23 -27 D
+3 -8 D
+8 0 D
+-5 -3 D
+16 -6 D
+-11 -1 D
+0 -13 D
+21 3 D
+3 -19 D
+-8 -8 D
+20 6 D
+3 -3 D
+P
+FO
+932 1893 M
+10 6 D
+6 12 D
+7 -1 D
+-7 -14 D
+15 -3 D
+2 -14 D
+11 -10 D
+5 4 D
+-2 -7 D
+9 1 D
+-5 8 D
+10 3 D
+4 7 D
+-6 5 D
+14 -7 D
+-1 6 D
+6 -5 D
+10 8 D
+-10 15 D
+-13 6 D
+-8 1 D
+-2 -16 D
+3 26 D
+-21 29 D
+P
+FO
+-14 -4 1 -7 -9 1 11 8 4 976 1667 SP
+-3 -7 -23 12 9 4 3 1002 1840 SP
+-15 -8 -7 8 10 0 3 1016 1683 SP
+10 -10 -14 -2 -3 8 3 1022 1783 SP
+3 -3 -8 -4 -4 3 3 1039 1793 SP
+5 0 1 987 1873 SP
+-6 3 5 1 2 838 1661 SP
+18 10 1 949 1659 SP
+14 4 1 874 1658 SP
+-8 -6 1 856 1662 SP
+12 -3 1 886 1657 SP
+4 -4 1 1054 1692 SP
+9 2 1 841 1660 SP
+6 -4 1 954 1803 SP
+{0 0 0.502 C} FS
+-8 -1 1 1046 1787 SP
+-5 0 1 1050 1871 SP
+-4 -2 1 1048 1801 SP
+1064 1688 M
+2 3 D
+-2 -3 D
+2 12 D
+2 1 D
+2 -6 D
+50 38 D
+15 6 D
+11 13 D
+-9 3 D
+1 6 D
+37 35 D
+14 2 D
+-9 -6 D
+11 -6 D
+-14 4 D
+-10 -5 D
+-5 -17 D
+9 0 D
+-8 -11 D
+21 8 D
+0 6 D
+2 -5 D
+1 8 D
+10 -3 D
+5 9 D
+-8 6 D
+10 9 D
+-2 -8 D
+4 5 D
+1 -5 D
+11 5 D
+-4 -4 D
+7 -1 D
+-6 -3 D
+6 2 D
+1 -6 D
+11 1 D
+7 -7 D
+29 3 D
+12 -7 D
+3 3 D
+22 -135 D
+7 -47 D
+-11 -1 D
+-11 -1 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-99 5 D
+-11 1 D
+P
+FO
+2 12 1 11 2 11 -31 -17 -1 -17 -9 -11 16 7 2 -10 6 14 10 -11 10 1075 1757 SP
+0 2 -1 -3 -24 -32 24 31 4 1088 1827 SP
+1 -3 6 0 6 1 6 0 -20 6 5 1253 1936 SP
+{1 0 0 C} FS
+-3 -5 -10 6 2 -11 -3 5 -3 -7 -11 3 1 8 7 -2 -4 4 16 10 -3 -8 4 3 12 1135 1718 SP
+-8 -11 3 7 2 1208 1772 SP
+-10 1 10 6 2 1150 1736 SP
+-4 -4 1 1241 1773 SP
+5 1 1 1216 1779 SP
+2 5 1 1202 1776 SP
+{0 0 0.502 C} FS
+-22 -6 1 1141 1768 SP
+9 -4 1 1115 1751 SP
+-4 -7 1 1109 1734 SP
+-12 -7 1 1144 1780 SP
+4 -5 1 1170 1777 SP
+10 -1 1 1087 1775 SP
+6 -6 0 1 2 1086 1769 SP
+-2 -5 1 1217 1808 SP
+5 -2 1 1122 1756 SP
+7 -4 -1 0 2 1121 1752 SP
+5 -3 1 1088 1771 SP
+3 -4 0 1 2 1088 1765 SP
+6 0 1 1087 1776 SP
+3 -9 1 1110 1739 SP
+{1 0 0 C} FS
+1253 1936 M
+-20 6 D
+-11 -1 D
+-11 0 D
+-11 0 D
+-11 -1 D
+-12 0 D
+-66 3 D
+-13 -63 D
+-10 -53 D
+24 31 D
+-24 -32 D
+-13 -69 D
+10 -11 D
+6 14 D
+2 -10 D
+16 7 D
+-9 -11 D
+-1 -17 D
+-31 -17 D
+-2 -12 D
+2 1 D
+2 -6 D
+50 38 D
+15 6 D
+11 13 D
+-9 3 D
+1 6 D
+37 35 D
+14 2 D
+-9 -6 D
+11 -6 D
+-14 4 D
+-10 -5 D
+-5 -17 D
+9 0 D
+-8 -11 D
+21 8 D
+0 6 D
+2 -5 D
+1 8 D
+10 -3 D
+5 9 D
+-8 6 D
+10 9 D
+-2 -8 D
+4 5 D
+1 -5 D
+11 5 D
+-4 -4 D
+7 -1 D
+-6 -3 D
+6 2 D
+1 -6 D
+11 1 D
+7 -7 D
+29 3 D
+12 -7 D
+3 3 D
+-20 111 D
+P
+FO
+2 3 1 1064 1688 SP
+-3 -5 -10 6 2 -11 -3 5 -3 -7 -11 3 1 8 7 -2 -4 4 16 10 -3 -8 4 3 12 1135 1718 SP
+-8 -11 3 7 2 1208 1772 SP
+-10 1 10 6 2 1150 1736 SP
+-4 -4 1 1241 1773 SP
+5 1 1 1216 1779 SP
+2 5 1 1202 1776 SP
+{0 0 0.502 C} FS
+-22 -6 1 1141 1768 SP
+9 -4 1 1115 1751 SP
+-4 -7 1 1109 1734 SP
+-12 -7 1 1144 1780 SP
+4 -5 1 1170 1777 SP
+10 -1 1 1087 1775 SP
+6 -6 0 1 2 1086 1769 SP
+-2 -5 1 1217 1808 SP
+5 -2 1 1122 1756 SP
+7 -4 -1 0 2 1121 1752 SP
+5 -3 1 1088 1771 SP
+3 -4 0 1 2 1088 1765 SP
+6 0 1 1087 1776 SP
+3 -9 1 1110 1739 SP
+-2 0 2 -3 1 4 3 1514 1623 SP
+1501 1620 M
+-7 6 D
+-38 0 D
+6 -5 D
+7 5 D
+-3 -11 D
+10 3 D
+3 -3 D
+-10 -2 D
+-10 -2 D
+-10 -2 D
+-11 -1 D
+-10 -2 D
+-10 -2 D
+-10 -2 D
+-11 -1 D
+-10 -2 D
+-11 -1 D
+-10 -2 D
+-11 -1 D
+-10 -1 D
+-11 -1 D
+-10 -1 D
+-11 -1 D
+-21 138 D
+-8 44 D
+4 5 D
+8 -4 D
+-4 -5 D
+-3 7 D
+-3 -8 D
+38 -20 D
+6 4 D
+-13 11 D
+10 -5 D
+-1 6 D
+6 -12 D
+9 -2 D
+-8 22 D
+11 -18 D
+7 -3 D
+3 7 D
+-1 -9 D
+10 -2 D
+-4 -3 D
+9 -4 D
+-9 3 D
+8 -5 D
+-5 -4 D
+27 -14 D
+-4 -13 D
+10 12 D
+6 -6 D
+3 -18 D
+5 11 D
+-1 12 D
+2 -16 D
+7 -1 D
+-7 -8 D
+7 -5 D
+-7 5 D
+1 -5 D
+11 -1 D
+-4 -6 D
+12 -9 D
+3 13 D
+2 -8 D
+8 0 D
+-10 -1 D
+18 -12 D
+-4 -10 D
+3 6 D
+4 -6 D
+7 11 D
+-5 -18 D
+5 -6 D
+3 5 D
+-4 -8 D
+9 2 D
+-8 -5 D
+13 3 D
+-9 -5 D
+16 2 D
+-4 -3 D
+6 -2 D
+6 8 D
+-7 -9 D
+9 -2 D
+1 6 D
+0 -6 D
+6 1 D
+0 10 D
+1 -12 D
+7 6 D
+-2 -11 D
+1 0 D
+-2 0 D
+P
+FO
+0 1 1 1497 1619 SP
+11 2 10 1 11 1 11 2 11 1 -1 3 -1 4 -37 10 7 -8 -8 -9 -4 7 -8 -3 -12 -13 13 1315 1952 SP
+4 1 5 1 1 11 -14 -14 4 1332 1955 SP
+5 1 4 1 -14 9 1 -12 4 1353 1960 SP
+3 -4 7 2 7 1 7 2 7 2 -6 10 -12 -11 -15 2 8 1388 1959 SP
+1416 1916 M
+-2 -4 D
+4 1 D
+11 -18 D
+-6 -9 D
+-1 14 D
+-6 -13 D
+-13 0 D
+4 13 D
+-6 1 D
+11 5 D
+-15 -1 D
+-11 -8 D
+-4 6 D
+30 20 D
+P
+FO
+-3 1 1 1440 1877 SP
+{1 0 0 C} FS
+23 -14 11 -20 -11 2 1 8 -7 -12 3 18 -8 1 3 5 8 1401 1658 SP
+-2 -7 5 1 6 -13 -20 14 6 3 -9 0 -3 11 6 -5 8 1386 1696 SP
+-2 7 9 -14 -15 1 0 5 9 -3 -11 7 6 1345 1738 SP
+5 3 1 -7 0 5 4 0 -1 -8 5 1391 1713 SP
+-11 15 6 -7 1 3 3 1438 1661 SP
+10 -25 -9 4 -5 13 3 1356 1737 SP
+-1 9 5 1 6 -10 3 1359 1730 SP
+6 -17 -4 5 2 1360 1723 SP
+-7 8 4 -2 2 1380 1692 SP
+-15 24 6 -10 2 1349 1724 SP
+3 -4 1 1444 1663 SP
+0 -4 1 1454 1650 SP
+3 -4 1 1390 1704 SP
+-2 -4 1 1411 1700 SP
+6 2 1 1478 1626 SP
+-12 11 8 -7 2 1421 1676 SP
+-5 5 1 1383 1715 SP
+-6 5 1 1384 1718 SP
+6 -3 1 1370 1728 SP
+5 0 1 1411 1681 SP
+5 -2 1 1372 1721 SP
+-5 6 1 1439 1656 SP
+-1 6 1 1339 1727 SP
+{0 0 0.502 C} FS
+34 -7 4 -11 20 -12 26 1 10 -19 -5 17 -13 6 -15 -5 -23 14 -4 10 -33 7 -7 6 12 1398 1873 SP
+3 8 -6 -10 -13 6 -7 -6 19 -1 13 6 6 1448 1682 SP
+8 4 -8 -3 -2 13 -5 -5 10 -15 5 1337 1792 SP
+-29 23 13 -13 -16 -5 18 5 13 -10 5 1458 1743 SP
+5 -11 -4 11 -23 2 3 1450 1839 SP
+-8 7 4 -11 2 1292 1806 SP
+13 -2 1 1467 1706 SP
+1 4 1 1367 1913 SP
+-16 -6 1 1472 1681 SP
+-4 3 1 1431 1871 SP
+-5 4 0 -1 2 1363 1916 SP
+13 -9 1 1449 1721 SP
+16 -13 -1 0 2 1350 1792 SP
+-17 -4 1 1475 1694 SP
+-13 -4 1 1536 1682 SP
+3 -4 -2 4 2 1373 1919 SP
+3 -5 -2 5 2 1368 1907 SP
+21 -11 1 1448 1713 SP
+-4 6 1 1418 1867 SP
+4 -7 -1 0 2 1326 1805 SP
+5 -9 1 1501 1652 SP
+-5 3 1 1388 1888 SP
+6 -7 1 1303 1807 SP
+-2 8 1 -8 2 1321 1790 SP
+-9 4 1 1383 1885 SP
+5 3 -5 -2 2 1469 1709 SP
+-3 -2 1 1428 1858 SP
+-3 -5 1 1447 1689 SP
+-1 4 1 1309 1925 SP
+6 -1 1 1374 1910 SP
+{1 0 0 C} FS
+9 2 3 -3 10 3 -3 -11 7 5 6 -5 -38 0 -7 6 2 0 2 1 0 -1 0 1 12 1497 1619 SP
+1514 1623 M
+1 4 D
+2 -3 D
+44 12 D
+-25 55 D
+-41 85 D
+-8 14 D
+-7 15 D
+-40 72 D
+-3 1 D
+3 -1 D
+-11 18 D
+-6 -9 D
+-1 14 D
+-6 -13 D
+-13 0 D
+4 13 D
+-6 1 D
+11 5 D
+-15 -1 D
+-11 -8 D
+-4 6 D
+30 20 D
+-24 36 D
+-15 2 D
+-12 -11 D
+-6 10 D
+-2 0 D
+1 -12 D
+-14 9 D
+-4 -1 D
+-4 -1 D
+-14 -14 D
+1 11 D
+-2 0 D
+-2 0 D
+-12 -13 D
+-8 -3 D
+-4 7 D
+-8 -9 D
+7 -8 D
+-37 10 D
+17 -86 D
+14 -77 D
+4 5 D
+8 -4 D
+-4 -5 D
+-3 7 D
+-3 -8 D
+38 -20 D
+6 4 D
+-13 11 D
+10 -5 D
+-1 6 D
+6 -12 D
+9 -2 D
+-8 22 D
+11 -18 D
+7 -3 D
+3 7 D
+-1 -9 D
+10 -2 D
+-4 -3 D
+9 -4 D
+-9 3 D
+8 -5 D
+-5 -4 D
+27 -14 D
+-4 -13 D
+10 12 D
+6 -6 D
+3 -18 D
+5 11 D
+-1 12 D
+2 -16 D
+7 -1 D
+-7 -8 D
+7 -5 D
+-7 5 D
+1 -5 D
+11 -1 D
+-4 -6 D
+12 -9 D
+3 13 D
+2 -8 D
+8 0 D
+-10 -1 D
+18 -12 D
+-4 -10 D
+3 6 D
+4 -6 D
+7 11 D
+-5 -18 D
+5 -6 D
+3 5 D
+-4 -8 D
+9 2 D
+-8 -5 D
+13 3 D
+-9 -5 D
+16 2 D
+-4 -3 D
+6 -2 D
+6 8 D
+-7 -9 D
+9 -2 D
+1 6 D
+0 -6 D
+6 1 D
+0 10 D
+1 -12 D
+7 6 D
+-2 -11 D
+P
+FO
+-1 1 4 1 -2 -4 3 1416 1916 SP
+23 -14 11 -20 -11 2 1 8 -7 -12 3 18 -8 1 3 5 8 1401 1658 SP
+-2 -7 5 1 6 -13 -20 14 6 3 -9 0 -3 11 6 -5 8 1386 1696 SP
+-2 7 9 -14 -15 1 0 5 9 -3 -11 7 6 1345 1738 SP
+5 3 1 -7 0 5 4 0 -1 -8 5 1391 1713 SP
+-11 15 6 -7 1 3 3 1438 1661 SP
+10 -25 -9 4 -5 13 3 1356 1737 SP
+-1 9 5 1 6 -10 3 1359 1730 SP
+6 -17 -4 5 2 1360 1723 SP
+-7 8 4 -2 2 1380 1692 SP
+-15 24 6 -10 2 1349 1724 SP
+3 -4 1 1444 1663 SP
+0 -4 1 1454 1650 SP
+3 -4 1 1390 1704 SP
+-2 -4 1 1411 1700 SP
+6 2 1 1478 1626 SP
+-12 11 8 -7 2 1421 1676 SP
+-5 5 1 1383 1715 SP
+-6 5 1 1384 1718 SP
+6 -3 1 1370 1728 SP
+5 0 1 1411 1681 SP
+5 -2 1 1372 1721 SP
+-5 6 1 1439 1656 SP
+-1 6 1 1339 1727 SP
+{0 0 0.502 C} FS
+34 -7 4 -11 20 -12 26 1 10 -19 -5 17 -13 6 -15 -5 -23 14 -4 10 -33 7 -7 6 12 1398 1873 SP
+3 8 -6 -10 -13 6 -7 -6 19 -1 13 6 6 1448 1682 SP
+8 4 -8 -3 -2 13 -5 -5 10 -15 5 1337 1792 SP
+-29 23 13 -13 -16 -5 18 5 13 -10 5 1458 1743 SP
+5 -11 -4 11 -23 2 3 1450 1839 SP
+-8 7 4 -11 2 1292 1806 SP
+13 -2 1 1467 1706 SP
+1 4 1 1367 1913 SP
+-16 -6 1 1472 1681 SP
+-4 3 1 1431 1871 SP
+-5 4 0 -1 2 1363 1916 SP
+13 -9 1 1449 1721 SP
+16 -13 -1 0 2 1350 1792 SP
+-17 -4 1 1475 1694 SP
+-13 -4 1 1536 1682 SP
+3 -4 -2 4 2 1373 1919 SP
+3 -5 -2 5 2 1368 1907 SP
+21 -11 1 1448 1713 SP
+-4 6 1 1418 1867 SP
+4 -7 -1 0 2 1326 1805 SP
+5 -9 1 1501 1652 SP
+-5 3 1 1388 1888 SP
+6 -7 1 1303 1807 SP
+-2 8 1 -8 2 1321 1790 SP
+-9 4 1 1383 1885 SP
+5 3 -5 -2 2 1469 1709 SP
+-3 -2 1 1428 1858 SP
+-3 -5 1 1447 1689 SP
+-1 4 1 1309 1925 SP
+6 -1 1 1374 1910 SP
+-2 2 1 1596 1647 SP
+-1 1 1 1590 1645 SP
+-1 6 1 1567 1638 SP
+2 -1 1 1440 1877 SP
+-3 6 -4 6 -3 -3 7 -7 -15 -3 8 -15 4 7 10 3 8 1418 1913 SP
+-2 3 -4 -7 7 -1 1 1 4 1412 1923 SP
+1399 1972 M
+11 -7 D
+23 1 D
+8 -7 D
+21 14 D
+3 16 D
+16 -4 D
+16 10 D
+-10 5 D
+1 -7 D
+-10 6 D
+7 1 D
+0 8 D
+6 -2 D
+-5 4 D
+5 2 D
+34 -29 D
+-11 -7 D
+-14 4 D
+-8 -5 D
+-17 8 D
+-6 -16 D
+9 2 D
+4 10 D
+-2 -17 D
+14 -6 D
+4 -5 D
+-6 0 D
+11 -7 D
+-17 7 D
+1 4 D
+-22 5 D
+-7 -9 D
+-22 -6 D
+-5 5 D
+6 6 D
+-12 5 D
+-13 -4 D
+-24 2 D
+-5 8 D
+P
+FO
+2 -2 9 6 -13 -3 3 1553 1958 SP
+4 3 -5 -1 2 1570 1941 SP
+2 -2 6 -4 -5 8 -4 -1 4 1604 1908 SP
+-2 0 1 1615 1897 SP
+2 -2 -3 4 -1 1 3 1636 1874 SP
+-1 -1 1 1641 1869 SP
+-1 -1 1 1649 1860 SP
+0 1 6 -7 -7 11 3 6 -10 -1 1 -2 2 -2 4 -1 0 -4 9 1716 1782 SP
+3 -4 5 0 5 3 -4 4 -9 -3 -3 3 6 1731 1763 SP
+{1 0 0 C} FS
+4 1 1 1487 1980 SP
+5 -3 1 1503 1998 SP
+{0 0 0.502 C} FS
+-5 -29 -7 -7 6 3 -6 -5 5 2 6 9 1 -5 -16 -10 14 3 10 22 29 -5 -21 11 7 4 -3 11 16 2 -27 0 16 1511 1839 SP
+14 -18 0 15 -12 9 1 7 5 -6 -6 10 6 1658 1807 SP
+-12 9 -1 6 8 -1 -11 7 5 -17 10 -4 6 1608 1794 SP
+-5 -16 -24 -14 31 7 4 20 4 1565 1816 SP
+-8 5 7 0 -8 1 6 -8 4 1465 1932 SP
+-2 8 7 8 -12 -12 7 -3 4 1687 1709 SP
+4 5 -6 11 -5 -3 7 -12 4 1633 1843 SP
+5 -1 -8 6 8 -12 3 1626 1783 SP
+2 4 5 -4 -10 10 3 1600 1866 SP
+11 -3 0 -5 2 5 3 1552 1890 SP
+1 5 -10 -3 2 1507 1901 SP
+5 -16 1 13 2 1542 1867 SP
+-5 2 -5 -8 2 1509 1913 SP
+6 -3 -4 12 2 1578 1875 SP
+13 9 -20 -6 2 1484 1839 SP
+9 -14 2 13 2 1578 1913 SP
+-2 -4 5 -1 2 1641 1768 SP
+-5 -3 8 -6 -3 8 3 1601 1857 SP
+3 9 -19 -6 2 1535 1910 SP
+2 -4 21 -1 2 1464 1915 SP
+3 3 -14 2 2 1470 1869 SP
+-5 -7 5 -4 2 1617 1818 SP
+12 -10 -4 8 -7 2 3 1620 1868 SP
+-6 -1 9 -6 2 1682 1817 SP
+-2 -5 1 0 2 1475 1894 SP
+-6 8 1 1562 1807 SP
+2 -6 22 -6 2 1482 1927 SP
+-1 -9 1 1660 1786 SP
+-10 -12 11 12 2 1503 1893 SP
+-17 0 0 -1 2 1569 1748 SP
+8 -7 1 1439 1900 SP
+2 -12 -2 11 2 1612 1881 SP
+0 9 1 1591 1850 SP
+-4 11 1 1607 1870 SP
+4 1 -5 6 2 1592 1900 SP
+11 -3 1 1521 1962 SP
+-6 -5 1 1516 1830 SP
+-9 -6 1 1477 1994 SP
+0 11 0 -1 2 1538 1891 SP
+-3 -5 1 1493 1829 SP
+-1 -9 1 1607 1847 SP
+1 7 1 1481 1867 SP
+-9 2 1 1534 1899 SP
+-1 -7 1 1677 1786 SP
+-3 6 1 1464 1878 SP
+0 -4 1 4 2 1528 1857 SP
+-4 4 1 1540 1843 SP
+0 -4 1 1461 1942 SP
+3 -3 1 1510 1915 SP
+3 3 1 1526 1869 SP
+9 -6 1 1670 1795 SP
+-2 7 1 -6 2 1400 1948 SP
+1 7 1 1679 1817 SP
+2 -5 1 1688 1787 SP
+-1 8 1 1585 1878 SP
+6 -1 1 1568 1842 SP
+-1 -6 1 1620 1761 SP
+-5 8 1 1588 1892 SP
+3 -7 1 1662 1768 SP
+-4 -3 1 1706 1787 SP
+-7 1 1 1493 1809 SP
+0 -11 1 1563 1662 SP
+4 -6 1 1450 1893 SP
+0 -4 1 1621 1754 SP
+3 4 1 1554 1901 SP
+-2 4 1 -4 2 1492 1914 SP
+1 -5 1 1641 1783 SP
+-15 7 14 -7 2 1549 1688 SP
+-7 1 1 1491 1832 SP
+-1 6 1 -5 2 1687 1800 SP
+1 4 1 1595 1888 SP
+-2 -5 1 1690 1764 SP
+6 0 1 1574 1895 SP
+3 2 1 1593 1906 SP
+-1 4 0 -4 2 1704 1784 SP
+3 -4 1 1725 1760 SP
+3 -12 1 0 2 1580 1657 SP
+-4 4 0 -1 2 1550 1901 SP
+-1 7 1 1547 1855 SP
+5 -5 1 1670 1834 SP
+0 -4 1 1649 1768 SP
+10 -9 1 1700 1719 SP
+0 -5 1 1459 1888 SP
+-3 5 1 1640 1849 SP
+-4 -3 1 1667 1782 SP
+-3 -6 1 1512 1897 SP
+-2 -4 1 1678 1806 SP
+0 -4 1 1617 1834 SP
+3 3 -3 -2 2 1694 1788 SP
+2 3 -2 -2 2 1702 1794 SP
+-9 -7 1 1486 1899 SP
+1 -4 1 1626 1834 SP
+-5 1 4 -1 2 1598 1750 SP
+-4 5 1 1583 1902 SP
+3 -4 1 1621 1855 SP
+-3 6 1 1538 1860 SP
+4 1 -5 -1 2 1452 1974 SP
+3 3 1 1517 1896 SP
+3 -3 1 1603 1787 SP
+-7 5 7 -4 2 1651 1757 SP
+3 4 1 1543 1898 SP
+-4 -1 1 1478 1918 SP
+-3 6 1 1592 1884 SP
+-5 0 1 1467 1850 SP
+-1 -4 1 1654 1785 SP
+3 1 1 1552 1896 SP
+2 -5 -1 5 2 1596 1851 SP
+2 -6 1 1673 1817 SP
+-3 -2 1 1688 1780 SP
+-4 -1 1 1596 1838 SP
+2 -4 1 1649 1818 SP
+5 -3 1 1570 1677 SP
+6 -2 -1 0 2 1488 1909 SP
+1 -4 1 1467 1891 SP
+-7 0 1 1451 1986 SP
+9 -3 1 1424 1936 SP
+1 -4 1 1489 1913 SP
+-2 5 1 1547 1851 SP
+-4 -3 1 1447 1976 SP
+0 -4 0 3 2 1521 1900 SP
+{1 0 0 C} FS
+-4 -4 1 1521 1866 SP
+-5 -6 1 1523 1865 SP
+1567 1638 M
+-1 6 D
+1 -6 D
+23 7 D
+-1 1 D
+1 -1 D
+6 2 D
+-2 2 D
+2 -2 D
+54 19 D
+59 26 D
+46 24 D
+8 5 D
+-35 45 D
+-9 -3 D
+-4 4 D
+5 3 D
+5 0 D
+-2 3 D
+-10 -1 D
+3 6 D
+-7 11 D
+6 -7 D
+-42 51 D
+-24 27 D
+-1 -1 D
+1 1 D
+-8 9 D
+-1 -1 D
+1 1 D
+-26 28 D
+-2 0 D
+2 0 D
+-11 11 D
+-4 -1 D
+-5 8 D
+6 -4 D
+-31 30 D
+-5 -1 D
+4 3 D
+-16 15 D
+-13 -3 D
+9 6 D
+-24 22 D
+-11 -7 D
+-14 4 D
+-8 -5 D
+-17 8 D
+-6 -16 D
+9 2 D
+4 10 D
+-2 -17 D
+14 -6 D
+4 -5 D
+-6 0 D
+11 -7 D
+-17 7 D
+1 4 D
+-22 5 D
+-7 -9 D
+-22 -6 D
+-5 5 D
+6 6 D
+-12 5 D
+-13 -4 D
+-24 2 D
+24 -36 D
+1 1 D
+7 -1 D
+-4 -7 D
+2 -3 D
+10 3 D
+4 7 D
+8 -15 D
+-15 -3 D
+7 -7 D
+-3 -3 D
+11 -18 D
+2 -1 D
+-2 1 D
+44 -79 D
+7 -15 D
+12 -22 D
+44 -93 D
+14 -32 D
+P
+FO
+-2 2 4 -1 0 -4 3 1716 1782 SP
+1399 1972 M
+11 -7 D
+23 1 D
+8 -7 D
+21 14 D
+3 16 D
+16 -4 D
+16 10 D
+-10 5 D
+1 -7 D
+-10 6 D
+7 1 D
+0 8 D
+6 -2 D
+-5 4 D
+-15 -9 D
+-9 -4 D
+-8 -4 D
+-9 -3 D
+-17 -8 D
+-10 -3 D
+-9 -4 D
+P
+FO
+4 1 1 1487 1980 SP
+5 -3 1 1503 1998 SP
+{0 0 0.502 C} FS
+-5 -29 -7 -7 6 3 -6 -5 5 2 6 9 1 -5 -16 -10 14 3 10 22 29 -5 -21 11 7 4 -3 11 16 2 -27 0 16 1511 1839 SP
+14 -18 0 15 -12 9 1 7 5 -6 -6 10 6 1658 1807 SP
+-12 9 -1 6 8 -1 -11 7 5 -17 10 -4 6 1608 1794 SP
+-5 -16 -24 -14 31 7 4 20 4 1565 1816 SP
+-8 5 7 0 -8 1 6 -8 4 1465 1932 SP
+-2 8 7 8 -12 -12 7 -3 4 1687 1709 SP
+4 5 -6 11 -5 -3 7 -12 4 1633 1843 SP
+5 -1 -8 6 8 -12 3 1626 1783 SP
+2 4 5 -4 -10 10 3 1600 1866 SP
+11 -3 0 -5 2 5 3 1552 1890 SP
+1 5 -10 -3 2 1507 1901 SP
+5 -16 1 13 2 1542 1867 SP
+-5 2 -5 -8 2 1509 1913 SP
+6 -3 -4 12 2 1578 1875 SP
+13 9 -20 -6 2 1484 1839 SP
+9 -14 2 13 2 1578 1913 SP
+-2 -4 5 -1 2 1641 1768 SP
+-5 -3 8 -6 -3 8 3 1601 1857 SP
+3 9 -19 -6 2 1535 1910 SP
+2 -4 21 -1 2 1464 1915 SP
+3 3 -14 2 2 1470 1869 SP
+-5 -7 5 -4 2 1617 1818 SP
+12 -10 -4 8 -7 2 3 1620 1868 SP
+-6 -1 9 -6 2 1682 1817 SP
+-2 -5 1 0 2 1475 1894 SP
+-6 8 1 1562 1807 SP
+2 -6 22 -6 2 1482 1927 SP
+-1 -9 1 1660 1786 SP
+-10 -12 11 12 2 1503 1893 SP
+-17 0 0 -1 2 1569 1748 SP
+8 -7 1 1439 1900 SP
+2 -12 -2 11 2 1612 1881 SP
+0 9 1 1591 1850 SP
+-4 11 1 1607 1870 SP
+4 1 -5 6 2 1592 1900 SP
+11 -3 1 1521 1962 SP
+-6 -5 1 1516 1830 SP
+-9 -6 1 1477 1994 SP
+0 11 0 -1 2 1538 1891 SP
+-3 -5 1 1493 1829 SP
+-1 -9 1 1607 1847 SP
+1 7 1 1481 1867 SP
+-9 2 1 1534 1899 SP
+-1 -7 1 1677 1786 SP
+-3 6 1 1464 1878 SP
+0 -4 1 4 2 1528 1857 SP
+-4 4 1 1540 1843 SP
+0 -4 1 1461 1942 SP
+3 -3 1 1510 1915 SP
+3 3 1 1526 1869 SP
+9 -6 1 1670 1795 SP
+-2 7 1 -6 2 1400 1948 SP
+1 7 1 1679 1817 SP
+2 -5 1 1688 1787 SP
+-1 8 1 1585 1878 SP
+6 -1 1 1568 1842 SP
+-1 -6 1 1620 1761 SP
+-5 8 1 1588 1892 SP
+3 -7 1 1662 1768 SP
+-4 -3 1 1706 1787 SP
+-7 1 1 1493 1809 SP
+0 -11 1 1563 1662 SP
+4 -6 1 1450 1893 SP
+0 -4 1 1621 1754 SP
+3 4 1 1554 1901 SP
+-2 4 1 -4 2 1492 1914 SP
+1 -5 1 1641 1783 SP
+-15 7 14 -7 2 1549 1688 SP
+-7 1 1 1491 1832 SP
+-1 6 1 -5 2 1687 1800 SP
+1 4 1 1595 1888 SP
+-2 -5 1 1690 1764 SP
+6 0 1 1574 1895 SP
+3 2 1 1593 1906 SP
+-1 4 0 -4 2 1704 1784 SP
+3 -4 1 1725 1760 SP
+3 -12 1 0 2 1580 1657 SP
+-4 4 0 -1 2 1550 1901 SP
+-1 7 1 1547 1855 SP
+5 -5 1 1670 1834 SP
+0 -4 1 1649 1768 SP
+10 -9 1 1700 1719 SP
+0 -5 1 1459 1888 SP
+-3 5 1 1640 1849 SP
+-4 -3 1 1667 1782 SP
+-3 -6 1 1512 1897 SP
+-2 -4 1 1678 1806 SP
+0 -4 1 1617 1834 SP
+3 3 -3 -2 2 1694 1788 SP
+2 3 -2 -2 2 1702 1794 SP
+-9 -7 1 1486 1899 SP
+1 -4 1 1626 1834 SP
+-5 1 4 -1 2 1598 1750 SP
+-4 5 1 1583 1902 SP
+3 -4 1 1621 1855 SP
+-3 6 1 1538 1860 SP
+4 1 -5 -1 2 1452 1974 SP
+3 3 1 1517 1896 SP
+3 -3 1 1603 1787 SP
+-7 5 7 -4 2 1651 1757 SP
+3 4 1 1543 1898 SP
+-4 -1 1 1478 1918 SP
+-3 6 1 1592 1884 SP
+-5 0 1 1467 1850 SP
+-1 -4 1 1654 1785 SP
+3 1 1 1552 1896 SP
+2 -5 -1 5 2 1596 1851 SP
+2 -6 1 1673 1817 SP
+-3 -2 1 1688 1780 SP
+-4 -1 1 1596 1838 SP
+2 -4 1 1649 1818 SP
+5 -3 1 1570 1677 SP
+6 -2 -1 0 2 1488 1909 SP
+1 -4 1 1467 1891 SP
+-7 0 1 1451 1986 SP
+9 -3 1 1424 1936 SP
+1 -4 1 1489 1913 SP
+-2 5 1 1547 1851 SP
+-4 -3 1 1447 1976 SP
+0 -4 0 3 2 1521 1900 SP
+{1 0 0 C} FS
+-4 -4 1 1521 1866 SP
+-5 -6 1 1523 1865 SP
+{0 0 0.502 C} FS
+-2 -2 6 -3 -2 7 3 1847 1782 SP
+-3 3 -14 15 15 -22 5 0 4 1725 1770 SP
+-1 2 -7 0 10 -4 3 1720 1777 SP
+0 -5 1 4 2 1715 1783 SP
+3 1 1 1649 1860 SP
+1 2 1 1641 1869 SP
+-2 3 -6 1 10 -9 -6 0 6 -1 2 -12 4 8 -6 8 8 1632 1879 SP
+3 -1 1 1615 1897 SP
+-1 1 -2 0 5 -3 3 1601 1911 SP
+-11 -3 -2 -10 14 11 3 1569 1943 SP
+-2 1 -1 0 -2 -8 7 5 4 1549 1961 SP
+1507 2023 M
+2 -2 D
+20 3 D
+-3 -3 D
+7 -8 D
+0 5 D
+8 -4 D
+-1 -12 D
+15 -11 D
+-10 0 D
+-10 13 D
+1 -7 D
+-4 5 D
+-7 0 D
+-4 -6 D
+10 -4 D
+3 3 D
+6 -6 D
+-15 4 D
+5 -6 D
+-5 -4 D
+-34 29 D
+P
+FO
+1543 2052 M
+1 2 D
+15 12 D
+-4 0 D
+8 1 D
+-6 1 D
+4 5 D
+4 -2 D
+-1 -3 D
+4 1 D
+36 -19 D
+42 -24 D
+13 -9 D
+28 -17 D
+20 -14 D
+40 -28 D
+69 -53 D
+55 -48 D
+6 -6 D
+-4 -2 D
+-7 6 D
+-27 7 D
+-34 30 D
+-15 -14 D
+-61 1 D
+-6 -16 D
+-4 8 D
+-25 17 D
+-7 -4 D
+6 -6 D
+-14 6 D
+-20 22 D
+-10 23 D
+-6 1 D
+0 15 D
+-7 2 D
+6 3 D
+-2 8 D
+-14 2 D
+-1 -5 D
+-2 4 D
+-11 -4 D
+-4 4 D
+27 2 D
+-8 12 D
+8 7 D
+-11 17 D
+-30 -6 D
+4 5 D
+21 1 D
+-8 16 D
+-10 1 D
+17 6 D
+-18 3 D
+4 5 D
+12 -4 D
+-13 20 D
+-21 5 D
+0 7 D
+-6 -1 D
+-4 6 D
+-12 -3 D
+0 4 D
+-12 -8 D
+22 -9 D
+-3 -3 D
+21 -19 D
+1 -6 D
+-34 18 D
+-9 0 D
+14 -15 D
+-24 10 D
+3 4 D
+-14 -5 D
+-4 4 D
+P
+FO
+{1 0 0 C} FS
+10 -4 -9 21 11 -5 4 8 5 -10 28 -24 -14 6 3 -5 -25 0 -10 7 -1 -6 -8 0 -3 8 13 1674 2001 SP
+-28 4 -1 10 19 1 3 1511 2002 SP
+-6 18 6 -3 3 -9 3 1677 1986 SP
+-12 0 4 3 2 1624 2015 SP
+-10 5 11 3 2 1840 1865 SP
+-11 6 6 -2 2 1576 2030 SP
+6 -1 1 1512 2017 SP
+8 -4 1 1617 2014 SP
+{0 0 0.502 C} FS
+1 5 -19 10 -1 -6 -11 10 -2 -5 -16 19 7 -16 49 -38 6 -3 -10 10 10 2 -5 10 -9 1 13 1737 1778 SP
+10 0 -11 3 -4 -5 5 -8 4 1819 1777 SP
+-9 1 -18 14 27 -21 3 1748 1754 SP
+-5 -5 7 0 2 1753 1811 SP
+-7 1 2 -4 2 1594 1944 SP
+-3 -4 7 -3 2 1554 1978 SP
+-5 3 -3 -4 2 1635 1951 SP
+-6 -12 7 -8 -4 12 3 1682 1838 SP
+10 -5 -1 7 2 1607 1921 SP
+-4 8 -2 -12 2 1748 1828 SP
+-4 -4 1 1729 1823 SP
+-13 -6 1 1608 1956 SP
+-15 8 1 1637 1904 SP
+5 13 -5 -12 2 1725 1815 SP
+-5 -4 1 1788 1834 SP
+3 -8 -3 7 2 1596 1919 SP
+-4 -8 1 1821 1789 SP
+-2 8 1 1633 1924 SP
+6 -5 1 1586 1942 SP
+-7 8 1 1622 1931 SP
+6 -4 1 1746 1745 SP
+3 -4 1 1800 1777 SP
+-2 5 1 1588 1932 SP
+1 -5 -1 4 2 1580 1933 SP
+-1 -7 1 1717 1817 SP
+2 -4 1 1578 2054 SP
+-4 0 1 1807 1754 SP
+-4 0 1 1833 1811 SP
+-1 -2 1 1848 1799 SP
+4 -4 1 1519 2029 SP
+3 -4 1 1563 1973 SP
+3 -4 1 1806 1869 SP
+5 3 -5 -2 2 1736 1805 SP
+-3 -6 1 1735 1822 SP
+-11 5 1 1646 1917 SP
+-5 -5 1 1779 1808 SP
+-2 -7 1 1713 1840 SP
+-2 -5 1 1803 1826 SP
+7 -4 1 1528 2025 SP
+0 -5 1 1689 1844 SP
+-6 -1 1 1718 1846 SP
+-2 -3 1 1796 1814 SP
+0 -6 1 1756 1759 SP
+-4 0 1 1599 1946 SP
+3 -9 1 1664 1849 SP
+-5 0 1 1824 1821 SP
+-1 -4 1 1705 1843 SP
+-2 -5 1 1726 1827 SP
+-4 3 3 -3 2 1621 1944 SP
+0 -6 1 1738 1831 SP
+-4 5 1 1604 1932 SP
+5 -1 1 1631 1921 SP
+0 -6 1 1723 1800 SP
+4 -6 1 1739 1760 SP
+1 -6 1 1804 1793 SP
+-4 -1 1 1774 1822 SP
+-4 3 1 1815 1833 SP
+0 -5 1 1724 1831 SP
+-6 -4 1 1606 1944 SP
+1 -4 1 1807 1787 SP
+-3 -2 1 1758 1819 SP
+1 -4 1 1829 1782 SP
+-5 3 1 1648 1892 SP
+4 -4 1 1887 1840 SP
+1 -5 1 1713 1789 SP
+4 -4 1 1718 1788 SP
+0 -4 1 0 2 1579 1941 SP
+-2 -3 1 1721 1798 SP
+4 -6 1 1677 1864 SP
+-1 -4 1 1805 1769 SP
+1 5 -1 -4 2 1709 1819 SP
+3 4 -3 -3 2 1755 1824 SP
+-5 0 1 1595 2009 SP
+-2 -3 1 1834 1793 SP
+-1 -4 1 1712 1826 SP
+1 -7 0 1 2 1710 1810 SP
+1 -5 0 1 2 1838 1789 SP
+2 3 1 1663 1867 SP
+-1 -5 1 1710 1839 SP
+-2 -4 1 1821 1815 SP
+-5 0 1 1597 2015 SP
+-5 -4 1 1718 1820 SP
+-1 -4 1 1712 1820 SP
+{1 0 0 C} FS
+3 -4 1 1748 1772 SP
+1847 1782 M
+-2 7 D
+6 -3 D
+31 32 D
+13 17 D
+-18 16 D
+-4 -2 D
+-7 6 D
+-27 7 D
+-34 30 D
+-15 -14 D
+-61 1 D
+-6 -16 D
+-4 8 D
+-25 17 D
+-7 -4 D
+6 -6 D
+-14 6 D
+-20 22 D
+-10 23 D
+-6 1 D
+0 15 D
+-7 2 D
+6 3 D
+-2 8 D
+-14 2 D
+-1 -5 D
+-2 4 D
+-11 -4 D
+-4 4 D
+27 2 D
+-8 12 D
+8 7 D
+-11 17 D
+-30 -6 D
+4 5 D
+21 1 D
+-8 16 D
+-10 1 D
+17 6 D
+-18 3 D
+4 5 D
+12 -4 D
+-13 20 D
+-21 5 D
+0 7 D
+-6 -1 D
+-4 6 D
+-12 -3 D
+0 4 D
+-12 -8 D
+22 -9 D
+-3 -3 D
+21 -19 D
+1 -6 D
+-34 18 D
+-9 0 D
+14 -15 D
+-24 10 D
+3 4 D
+-14 -5 D
+-4 4 D
+-14 -10 D
+2 -2 D
+20 3 D
+-3 -3 D
+7 -8 D
+0 5 D
+8 -4 D
+-1 -12 D
+15 -11 D
+-10 0 D
+-10 13 D
+1 -7 D
+-4 5 D
+-7 0 D
+-4 -6 D
+10 -4 D
+3 3 D
+6 -6 D
+-15 4 D
+5 -6 D
+-5 -4 D
+24 -22 D
+7 5 D
+-2 -8 D
+-1 0 D
+16 -15 D
+14 11 D
+-2 -10 D
+-11 -3 D
+31 -30 D
+5 -3 D
+-2 0 D
+11 -11 D
+3 -1 D
+-3 1 D
+17 -18 D
+-6 8 D
+4 8 D
+2 -12 D
+6 -1 D
+-6 0 D
+10 -9 D
+-6 1 D
+5 -5 D
+1 2 D
+-1 -2 D
+8 -9 D
+3 1 D
+-3 -1 D
+15 -16 D
+9 -11 D
+42 -50 D
+1 4 D
+0 -5 D
+4 -5 D
+10 -4 D
+-7 0 D
+2 -3 D
+5 0 D
+15 -22 D
+-14 15 D
+32 -42 D
+26 16 D
+30 22 D
+P
+FO
+-1 1 4 1 -1 -3 3 1565 2071 SP
+-6 1 7 0 2 1556 2067 SP
+-3 -4 -3 -3 -4 0 13 11 4 1546 2055 SP
+10 -4 -9 21 11 -5 4 8 5 -10 28 -24 -14 6 3 -5 -25 0 -10 7 -1 -6 -8 0 -3 8 13 1674 2001 SP
+-28 4 -1 10 19 1 3 1511 2002 SP
+-6 18 6 -3 3 -9 3 1677 1986 SP
+-12 0 4 3 2 1624 2015 SP
+-10 5 11 3 2 1840 1865 SP
+-11 6 6 -2 2 1576 2030 SP
+6 -1 1 1512 2017 SP
+8 -4 1 1617 2014 SP
+{0 0 0.502 C} FS
+1 5 -19 10 -1 -6 -11 10 -2 -5 -16 19 7 -16 49 -38 6 -3 -10 10 10 2 -5 10 -9 1 13 1737 1778 SP
+10 0 -11 3 -4 -5 5 -8 4 1819 1777 SP
+-9 1 -18 14 27 -21 3 1748 1754 SP
+-5 -5 7 0 2 1753 1811 SP
+-7 1 2 -4 2 1594 1944 SP
+-3 -4 7 -3 2 1554 1978 SP
+-5 3 -3 -4 2 1635 1951 SP
+-6 -12 7 -8 -4 12 3 1682 1838 SP
+10 -5 -1 7 2 1607 1921 SP
+-4 8 -2 -12 2 1748 1828 SP
+-4 -4 1 1729 1823 SP
+-13 -6 1 1608 1956 SP
+-15 8 1 1637 1904 SP
+5 13 -5 -12 2 1725 1815 SP
+-5 -4 1 1788 1834 SP
+3 -8 -3 7 2 1596 1919 SP
+-4 -8 1 1821 1789 SP
+-2 8 1 1633 1924 SP
+6 -5 1 1586 1942 SP
+-7 8 1 1622 1931 SP
+6 -4 1 1746 1745 SP
+3 -4 1 1800 1777 SP
+-2 5 1 1588 1932 SP
+1 -5 -1 4 2 1580 1933 SP
+-1 -7 1 1717 1817 SP
+2 -4 1 1578 2054 SP
+-4 0 1 1807 1754 SP
+-4 0 1 1833 1811 SP
+-1 -2 1 1848 1799 SP
+4 -4 1 1519 2029 SP
+3 -4 1 1563 1973 SP
+3 -4 1 1806 1869 SP
+5 3 -5 -2 2 1736 1805 SP
+-3 -6 1 1735 1822 SP
+-11 5 1 1646 1917 SP
+-5 -5 1 1779 1808 SP
+-2 -7 1 1713 1840 SP
+-2 -5 1 1803 1826 SP
+7 -4 1 1528 2025 SP
+0 -5 1 1689 1844 SP
+-6 -1 1 1718 1846 SP
+-2 -3 1 1796 1814 SP
+0 -6 1 1756 1759 SP
+-4 0 1 1599 1946 SP
+3 -9 1 1664 1849 SP
+-5 0 1 1824 1821 SP
+-1 -4 1 1705 1843 SP
+-2 -5 1 1726 1827 SP
+-4 3 3 -3 2 1621 1944 SP
+0 -6 1 1738 1831 SP
+-4 5 1 1604 1932 SP
+5 -1 1 1631 1921 SP
+0 -6 1 1723 1800 SP
+4 -6 1 1739 1760 SP
+1 -6 1 1804 1793 SP
+-4 -1 1 1774 1822 SP
+-4 3 1 1815 1833 SP
+0 -5 1 1724 1831 SP
+-6 -4 1 1606 1944 SP
+1 -4 1 1807 1787 SP
+-3 -2 1 1758 1819 SP
+1 -4 1 1829 1782 SP
+-5 3 1 1648 1892 SP
+4 -4 1 1887 1840 SP
+1 -5 1 1713 1789 SP
+4 -4 1 1718 1788 SP
+0 -4 1 0 2 1579 1941 SP
+-2 -3 1 1721 1798 SP
+4 -6 1 1677 1864 SP
+-1 -4 1 1805 1769 SP
+1 5 -1 -4 2 1709 1819 SP
+3 4 -3 -3 2 1755 1824 SP
+-5 0 1 1595 2009 SP
+-2 -3 1 1834 1793 SP
+-1 -4 1 1712 1826 SP
+1 -7 0 1 2 1710 1810 SP
+1 -5 0 1 2 1838 1789 SP
+2 3 1 1663 1867 SP
+-1 -5 1 1710 1839 SP
+-2 -4 1 1821 1815 SP
+-5 0 1 1597 2015 SP
+-5 -4 1 1718 1820 SP
+-1 -4 1 1712 1820 SP
+{1 0 0 C} FS
+3 -4 1 1748 1772 SP
+{0 0 0.502 C} FS
+-1 -9 -1 -9 -1 -9 0 -9 2 -1 2 -2 5 43 -4 5 8 1935 1920 SP
+12 -8 -8 8 -3 1 3 1930 1904 SP
+-4 3 1 1926 1891 SP
+-1 -1 6 -4 0 1 -4 6 4 1904 1849 SP
+1803 1915 M
+1 6 D
+3 -3 D
+-8 9 D
+5 -6 D
+-10 7 D
+9 -13 D
+-4 4 D
+-4 7 D
+4 -7 D
+-39 30 D
+-20 14 D
+-33 23 D
+-3 7 D
+-8 3 D
+11 -10 D
+-41 27 D
+-14 8 D
+-13 9 D
+-63 35 D
+-8 4 D
+-3 4 D
+0 -2 D
+-4 2 D
+5 3 D
+-3 1 D
+2 3 D
+6 -1 D
+-3 4 D
+6 -4 D
+1 4 D
+9 -2 D
+8 -8 D
+-3 7 D
+11 0 D
+-1 3 D
+28 -7 D
+8 -7 D
+4 3 D
+-3 -4 D
+7 -11 D
+15 -3 D
+-1 -11 D
+-8 -5 D
+17 -13 D
+10 15 D
+-10 4 D
+13 -1 D
+-6 4 D
+16 -5 D
+7 4 D
+1 -5 D
+7 -1 D
+29 15 D
+-36 3 D
+9 2 D
+-8 3 D
+24 3 D
+-22 9 D
+11 -2 D
+-13 6 D
+-7 -2 D
+-2 4 D
+-8 1 D
+3 -5 D
+-8 2 D
+6 -3 D
+-18 6 D
+3 -6 D
+-12 5 D
+2 5 D
+-12 2 D
+2 4 D
+10 -1 D
+-5 5 D
+8 -6 D
+-7 10 D
+11 -10 D
+18 2 D
+-20 8 D
+7 1 D
+-11 3 D
+3 3 D
+-6 -1 D
+0 5 D
+-5 0 D
+-1 4 D
+-8 0 D
+8 -6 D
+-6 2 D
+2 -5 D
+-9 7 D
+7 -6 D
+-6 3 D
+4 -6 D
+-5 5 D
+-2 -3 D
+1 3 D
+-9 2 D
+3 -4 D
+-7 4 D
+7 -5 D
+-7 1 D
+7 -4 D
+-8 4 D
+4 -4 D
+-7 3 D
+4 -3 D
+-8 2 D
+0 -4 D
+-2 6 D
+-10 -7 D
+3 6 D
+-8 1 D
+3 -4 D
+-4 5 D
+-4 -2 D
+6 7 D
+-6 0 D
+-4 -10 D
+-1 12 D
+-5 2 D
+3 20 D
+0 5 D
+91 -32 D
+80 -35 D
+84 -45 D
+14 -8 D
+5 -7 D
+-14 10 D
+4 -4 D
+-4 3 D
+-3 -5 D
+-4 5 D
+-1 -4 D
+-1 3 D
+-3 -2 D
+-1 4 D
+-4 -3 D
+3 4 D
+-9 6 D
+-7 -2 D
+-2 5 D
+-5 -2 D
+-5 4 D
+3 -7 D
+-8 9 D
+3 -7 D
+-7 8 D
+-6 2 D
+0 -5 D
+-3 5 D
+-16 1 D
+-3 4 D
+-3 -1 D
+10 -10 D
+7 -1 D
+2 -5 D
+4 0 D
+3 -6 D
+10 -5 D
+-11 4 D
+13 -16 D
+-10 4 D
+9 -10 D
+-13 10 D
+-3 -10 D
+-5 5 D
+5 -1 D
+-8 7 D
+-1 -2 D
+-11 7 D
+-4 -5 D
+2 6 D
+-17 11 D
+4 -5 D
+-10 -4 D
+-8 5 D
+-1 -4 D
+-19 3 D
+5 -8 D
+-16 -8 D
+3 -7 D
+15 -5 D
+11 -12 D
+1 4 D
+15 -8 D
+18 -23 D
+16 0 D
+29 -17 D
+14 -20 D
+2 -20 D
+11 -2 D
+32 -23 D
+5 -10 D
+10 -7 D
+-10 4 D
+7 -10 D
+-2 -1 D
+-42 38 D
+P
+FO
+-6 6 6 -7 2 1580 2111 SP
+5 -8 1 1883 2004 SP
+{1 0 0 C} FS
+-11 7 2 7 18 -10 -8 -4 4 1608 2072 SP
+-3 -4 -4 5 2 1689 2011 SP
+7 3 -2 -4 2 1611 2077 SP
+0 -3 -4 3 2 1744 2055 SP
+7 -2 1 1596 2078 SP
+1 5 1 1822 1903 SP
+-5 7 1 1581 2066 SP
+-6 2 1 1761 2029 SP
+-6 1 1 1687 2019 SP
+6 -2 1 1578 2078 SP
+1 2 1 1833 2025 SP
+2 -5 1 1571 2077 SP
+0 3 1 1725 2065 SP
+3 -5 1 1801 1928 SP
+3 1 1 1762 2046 SP
+6 -1 1 1705 2077 SP
+-2 -2 1 1707 2024 SP
+{0 0 0.502 C} FS
+1 4 9 -3 -11 4 -1 4 20 -4 -14 8 6 -4 -13 1 -7 5 -1 -2 6 -2 5 -7 -5 -1 2 -8 1 3 13 -3 16 1860 1990 SP
+-3 -6 3 0 3 -6 3 1796 1966 SP
+5 0 -4 0 -6 7 3 1876 1947 SP
+-7 3 5 -5 2 1900 1922 SP
+-4 0 5 -4 2 1838 2007 SP
+-3 -2 5 -3 2 1838 1998 SP
+-5 -3 8 -2 2 1815 1951 SP
+2 8 -19 9 16 -17 3 1905 1933 SP
+-14 7 -4 -5 2 1680 2059 SP
+-2 -3 8 -3 2 1806 1943 SP
+4 -7 3 1 2 1905 1873 SP
+-13 14 15 -26 2 1901 1898 SP
+-7 -5 8 2 2 1760 1989 SP
+-1 -3 8 -8 -6 11 3 1879 1945 SP
+8 -2 -6 4 2 1897 1964 SP
+5 -2 -5 7 2 1858 1950 SP
+4 2 1 1876 1976 SP
+7 -6 1 1791 2008 SP
+4 -1 1 1841 1982 SP
+-5 6 5 -5 2 1891 1897 SP
+0 5 1 1878 1987 SP
+4 1 1 1767 1963 SP
+3 -3 1 1730 1996 SP
+4 -4 0 1 2 1871 2007 SP
+-1 -2 1 1850 1896 SP
+6 -2 1 1861 1974 SP
+4 -1 1 1871 1973 SP
+5 -2 1 1773 1967 SP
+4 -3 1 1815 1990 SP
+-1 -2 1 1888 1874 SP
+6 -3 1 1790 2006 SP
+0 -3 1 1767 2008 SP
+5 -3 1 1891 1955 SP
+4 -1 1 1795 1997 SP
+1 -3 1 1869 2003 SP
+2 -5 1 1897 1886 SP
+5 -4 1 1833 2006 SP
+-2 -1 1 1639 2097 SP
+2 2 1 1594 2082 SP
+1 -4 1 1774 2008 SP
+-5 0 1 1903 1986 SP
+0 -11 0 10 2 1839 1941 SP
+2 -8 4 4 2 1890 1866 SP
+8 -4 1 1879 1932 SP
+1 9 -7 -6 2 1748 2003 SP
+13 -6 1 1813 1995 SP
+-1 8 1 1814 1954 SP
+-8 6 1 1896 1954 SP
+5 -2 1 1825 1961 SP
+6 -2 1 1912 1905 SP
+7 -3 -1 0 2 1828 1985 SP
+8 -5 -1 0 2 1779 1972 SP
+7 2 1 1771 1971 SP
+1 -3 1 1876 1933 SP
+5 -6 1 1822 1956 SP
+5 -3 1 1747 1992 SP
+-1 4 1 1882 1948 SP
+0 -4 1 1753 2000 SP
+-8 4 7 -4 2 1772 1998 SP
+-4 2 1 1905 1964 SP
+5 4 -1 0 2 1735 2005 SP
+5 -2 1 1902 1938 SP
+4 3 1 1785 1974 SP
+4 2 1 1826 1909 SP
+6 -4 1 1730 1999 SP
+-6 3 1 1888 1970 SP
+9 -5 1 1828 1998 SP
+3 -4 1 1869 1992 SP
+8 -2 1 1829 1988 SP
+4 -2 1 1757 1996 SP
+0 4 1 1854 1960 SP
+6 -6 1 1764 2004 SP
+4 -4 1 1834 2009 SP
+4 -3 1 1742 1995 SP
+-4 7 3 -7 2 1903 1861 SP
+10 -5 1 1823 1984 SP
+3 -6 1 1902 1882 SP
+-4 2 4 -3 2 1873 1969 SP
+7 -1 1 1868 1944 SP
+9 -5 1 1918 1948 SP
+5 -4 1 1576 2086 SP
+1 -4 1 1781 1996 SP
+{1 0 0 C} FS
+5 -1 2 -6 2 1906 1928 SP
+1904 1849 M
+-4 7 D
+6 -4 D
+13 23 D
+7 16 D
+-4 3 D
+4 -3 D
+4 13 D
+-3 1 D
+-8 8 D
+12 -8 D
+4 15 D
+-4 5 D
+5 43 D
+-31 22 D
+-22 14 D
+5 -8 D
+-5 8 D
+-29 18 D
+5 -7 D
+-14 10 D
+4 -4 D
+-4 3 D
+-3 -5 D
+-4 5 D
+-1 -4 D
+-1 3 D
+-3 -2 D
+-1 4 D
+-4 -3 D
+3 4 D
+-9 6 D
+-7 -2 D
+-2 5 D
+-5 -2 D
+-5 4 D
+3 -7 D
+-8 9 D
+3 -7 D
+-7 8 D
+-6 2 D
+0 -5 D
+-3 5 D
+-16 1 D
+-3 4 D
+-3 -1 D
+10 -10 D
+7 -1 D
+2 -5 D
+4 0 D
+3 -6 D
+10 -5 D
+-11 4 D
+13 -16 D
+-10 4 D
+9 -10 D
+-13 10 D
+-3 -10 D
+-5 5 D
+5 -1 D
+-8 7 D
+-1 -2 D
+-11 7 D
+-4 -5 D
+2 6 D
+-17 11 D
+4 -5 D
+-10 -4 D
+-8 5 D
+-1 -4 D
+-19 3 D
+5 -8 D
+-16 -8 D
+3 -7 D
+15 -5 D
+11 -12 D
+1 4 D
+15 -8 D
+18 -23 D
+16 0 D
+29 -17 D
+14 -20 D
+2 -20 D
+11 -2 D
+32 -23 D
+5 -10 D
+10 -7 D
+-10 4 D
+7 -10 D
+-2 -1 D
+18 -16 D
+P
+FO
+1580 2111 M
+6 -7 D
+-6 6 D
+-9 -20 D
+-6 -10 D
+6 -1 D
+-3 4 D
+6 -4 D
+1 4 D
+9 -2 D
+8 -8 D
+-3 7 D
+11 0 D
+-1 3 D
+28 -7 D
+8 -7 D
+4 3 D
+-3 -4 D
+7 -11 D
+15 -3 D
+-1 -11 D
+-8 -5 D
+17 -13 D
+10 15 D
+-10 4 D
+13 -1 D
+-6 4 D
+16 -5 D
+7 4 D
+1 -5 D
+7 -1 D
+29 15 D
+-36 3 D
+9 2 D
+-8 3 D
+24 3 D
+-22 9 D
+11 -2 D
+-13 6 D
+-7 -2 D
+-2 4 D
+-8 1 D
+3 -5 D
+-8 2 D
+6 -3 D
+-18 6 D
+3 -6 D
+-12 5 D
+2 5 D
+-12 2 D
+2 4 D
+10 -1 D
+-5 5 D
+8 -6 D
+-7 10 D
+11 -10 D
+18 2 D
+-20 8 D
+7 1 D
+-11 3 D
+3 3 D
+-6 -1 D
+0 5 D
+-5 0 D
+-1 4 D
+-8 0 D
+8 -6 D
+-6 2 D
+2 -5 D
+-9 7 D
+7 -6 D
+-6 3 D
+4 -6 D
+-5 5 D
+-2 -3 D
+1 3 D
+-9 2 D
+3 -4 D
+-7 4 D
+7 -5 D
+-7 1 D
+7 -4 D
+-8 4 D
+4 -4 D
+-7 3 D
+4 -3 D
+-8 2 D
+0 -4 D
+-2 6 D
+-10 -7 D
+3 6 D
+-8 1 D
+3 -4 D
+-4 5 D
+-4 -2 D
+6 7 D
+-6 0 D
+-4 -10 D
+-1 12 D
+-5 2 D
+P
+FO
+-1 -2 -3 1 5 3 3 1561 2073 SP
+2 -1 0 -2 -3 4 3 1568 2069 SP
+-8 3 -3 7 2 1707 1986 SP
+-4 7 1 1799 1919 SP
+-10 7 5 -6 -8 9 3 -3 1 6 5 1803 1915 SP
+-11 7 2 7 18 -10 -8 -4 4 1608 2072 SP
+-3 -4 -4 5 2 1689 2011 SP
+7 3 -2 -4 2 1611 2077 SP
+0 -3 -4 3 2 1744 2055 SP
+7 -2 1 1596 2078 SP
+1 5 1 1822 1903 SP
+-5 7 1 1581 2066 SP
+-6 2 1 1761 2029 SP
+-6 1 1 1687 2019 SP
+6 -2 1 1578 2078 SP
+1 2 1 1833 2025 SP
+2 -5 1 1571 2077 SP
+0 3 1 1725 2065 SP
+3 -5 1 1801 1928 SP
+3 1 1 1762 2046 SP
+6 -1 1 1705 2077 SP
+-2 -2 1 1707 2024 SP
+{0 0 0.502 C} FS
+1 4 9 -3 -11 4 -1 4 20 -4 -14 8 6 -4 -13 1 -7 5 -1 -2 6 -2 5 -7 -5 -1 2 -8 1 3 13 -3 16 1860 1990 SP
+-3 -6 3 0 3 -6 3 1796 1966 SP
+5 0 -4 0 -6 7 3 1876 1947 SP
+-7 3 5 -5 2 1900 1922 SP
+-4 0 5 -4 2 1838 2007 SP
+-3 -2 5 -3 2 1838 1998 SP
+-5 -3 8 -2 2 1815 1951 SP
+2 8 -19 9 16 -17 3 1905 1933 SP
+-14 7 -4 -5 2 1680 2059 SP
+-2 -3 8 -3 2 1806 1943 SP
+4 -7 3 1 2 1905 1873 SP
+-13 14 15 -26 2 1901 1898 SP
+-7 -5 8 2 2 1760 1989 SP
+-1 -3 8 -8 -6 11 3 1879 1945 SP
+8 -2 -6 4 2 1897 1964 SP
+5 -2 -5 7 2 1858 1950 SP
+4 2 1 1876 1976 SP
+7 -6 1 1791 2008 SP
+4 -1 1 1841 1982 SP
+-5 6 5 -5 2 1891 1897 SP
+0 5 1 1878 1987 SP
+4 1 1 1767 1963 SP
+3 -3 1 1730 1996 SP
+4 -4 0 1 2 1871 2007 SP
+-1 -2 1 1850 1896 SP
+6 -2 1 1861 1974 SP
+4 -1 1 1871 1973 SP
+5 -2 1 1773 1967 SP
+4 -3 1 1815 1990 SP
+-1 -2 1 1888 1874 SP
+6 -3 1 1790 2006 SP
+0 -3 1 1767 2008 SP
+5 -3 1 1891 1955 SP
+4 -1 1 1795 1997 SP
+1 -3 1 1869 2003 SP
+2 -5 1 1897 1886 SP
+5 -4 1 1833 2006 SP
+-2 -1 1 1639 2097 SP
+2 2 1 1594 2082 SP
+1 -4 1 1774 2008 SP
+-5 0 1 1903 1986 SP
+0 -11 0 10 2 1839 1941 SP
+2 -8 4 4 2 1890 1866 SP
+8 -4 1 1879 1932 SP
+1 9 -7 -6 2 1748 2003 SP
+13 -6 1 1813 1995 SP
+-1 8 1 1814 1954 SP
+-8 6 1 1896 1954 SP
+5 -2 1 1825 1961 SP
+6 -2 1 1912 1905 SP
+7 -3 -1 0 2 1828 1985 SP
+8 -5 -1 0 2 1779 1972 SP
+7 2 1 1771 1971 SP
+1 -3 1 1876 1933 SP
+5 -6 1 1822 1956 SP
+5 -3 1 1747 1992 SP
+-1 4 1 1882 1948 SP
+0 -4 1 1753 2000 SP
+-8 4 7 -4 2 1772 1998 SP
+-4 2 1 1905 1964 SP
+5 4 -1 0 2 1735 2005 SP
+5 -2 1 1902 1938 SP
+4 3 1 1785 1974 SP
+4 2 1 1826 1909 SP
+6 -4 1 1730 1999 SP
+-6 3 1 1888 1970 SP
+9 -5 1 1828 1998 SP
+3 -4 1 1869 1992 SP
+8 -2 1 1829 1988 SP
+4 -2 1 1757 1996 SP
+0 4 1 1854 1960 SP
+6 -6 1 1764 2004 SP
+4 -4 1 1834 2009 SP
+4 -3 1 1742 1995 SP
+-4 7 3 -7 2 1903 1861 SP
+10 -5 1 1823 1984 SP
+3 -6 1 1902 1882 SP
+-4 2 4 -3 2 1873 1969 SP
+7 -1 1 1868 1944 SP
+9 -5 1 1918 1948 SP
+5 -4 1 1576 2086 SP
+1 -4 1 1781 1996 SP
+{1 0 0 C} FS
+5 -1 2 -6 2 1906 1928 SP
+{0 0 0.502 C} FS
+1939 1990 M
+-3 2 D
+3 -4 D
+-18 17 D
+-4 0 D
+-1 4 D
+-4 0 D
+16 -19 D
+12 -9 D
+0 -16 D
+-4 3 D
+-16 19 D
+-3 13 D
+-12 15 D
+-6 1 D
+0 3 D
+-2 -4 D
+0 5 D
+-4 0 D
+-9 7 D
+-6 1 D
+6 -9 D
+-9 6 D
+-4 -3 D
+12 -18 D
+-12 17 D
+4 -10 D
+-10 20 D
+-3 -4 D
+-3 3 D
+2 -7 D
+-5 3 D
+3 -4 D
+-5 4 D
+9 -9 D
+-7 7 D
+1 -4 D
+-4 4 D
+1 -2 D
+-52 29 D
+-54 28 D
+-80 34 D
+-83 29 D
+-2 19 D
+8 -3 D
+-1 6 D
+7 -4 D
+-7 8 D
+-8 -1 D
+-3 9 D
+16 -6 D
+-1 4 D
+6 -3 D
+-3 -2 D
+11 -1 D
+-1 -5 D
+8 -7 D
+-7 11 D
+7 -4 D
+4 3 D
+-2 -10 D
+3 4 D
+0 -4 D
+11 -5 D
+-12 11 D
+4 -4 D
+-3 8 D
+12 -16 D
+-1 9 D
+6 -11 D
+4 5 D
+5 -6 D
+2 3 D
+1 -4 D
+3 1 D
+5 -4 D
+-20 16 D
+2 1 D
+19 -17 D
+-3 7 D
+8 -8 D
+6 1 D
+-10 8 D
+2 2 D
+9 -11 D
+0 3 D
+9 -4 D
+-4 5 D
+6 -6 D
+9 -2 D
+-11 9 D
+-9 2 D
+14 0 D
+-3 -4 D
+2 2 D
+7 -8 D
+-1 7 D
+4 -8 D
+1 3 D
+5 -5 D
+-1 5 D
+5 -5 D
+0 5 D
+2 -5 D
+0 4 D
+9 -4 D
+-6 5 D
+11 -7 D
+2 4 D
+6 -5 D
+-3 5 D
+6 -5 D
+-5 5 D
+6 -4 D
+0 3 D
+3 -4 D
+-2 5 D
+5 -5 D
+-2 5 D
+9 -2 D
+-13 14 D
+11 -8 D
+-7 6 D
+9 -6 D
+-5 5 D
+6 -2 D
+-7 5 D
+12 -7 D
+-9 6 D
+10 -4 D
+-8 5 D
+2 3 D
+-5 -2 D
+-4 6 D
+-3 -1 D
+-6 5 D
+1 -4 D
+-2 5 D
+-2 -2 D
+-5 5 D
+0 -2 D
+-5 4 D
+1 -2 D
+-6 4 D
+-7 -1 D
+0 3 D
+-3 -2 D
+-5 6 D
+-7 1 D
+1 3 D
+-5 -1 D
+0 3 D
+-2 -1 D
+-4 4 D
+-2 -2 D
+0 3 D
+-7 2 D
+0 -3 D
+-5 5 D
+-12 0 D
+0 4 D
+-8 2 D
+37 -9 D
+58 -19 D
+57 -22 D
+67 -32 D
+33 -19 D
+19 -30 D
+14 -32 D
+7 -21 D
+P
+FO
+{1 0 0 C} FS
+7 1 1 1654 2189 SP
+-7 1 1 1589 2172 SP
+-1 -2 1 1747 2151 SP
+-3 3 1 1609 2160 SP
+-4 3 1 1750 2142 SP
+-4 4 1 1742 2140 SP
+-2 3 1 1618 2161 SP
+2 2 1 1683 2178 SP
+{0 0 0.502 C} FS
+-1 3 1 1692 2142 SP
+-2 3 1 1867 2014 SP
+4 -3 -3 3 2 1626 2153 SP
+{1 0 0 C} FS
+-1 3 12 -9 16 -19 -4 0 -1 4 -4 0 -18 17 7 1939 1988 SP
+3 -3 -3 2 2 1939 1990 SP
+1579 2176 M
+16 -6 D
+-1 4 D
+6 -3 D
+-3 -2 D
+11 -1 D
+-1 -5 D
+8 -7 D
+-7 11 D
+7 -4 D
+4 3 D
+-2 -10 D
+3 4 D
+0 -4 D
+11 -5 D
+-12 11 D
+4 -4 D
+-3 8 D
+12 -16 D
+-1 9 D
+6 -11 D
+4 5 D
+5 -6 D
+2 3 D
+1 -4 D
+3 1 D
+5 -4 D
+-20 16 D
+2 1 D
+19 -17 D
+-3 7 D
+8 -8 D
+6 1 D
+-10 8 D
+2 2 D
+9 -11 D
+0 3 D
+9 -4 D
+-4 5 D
+6 -6 D
+9 -2 D
+-11 9 D
+-9 2 D
+14 0 D
+-3 -4 D
+2 2 D
+7 -8 D
+-1 7 D
+4 -8 D
+1 3 D
+5 -5 D
+-1 5 D
+5 -5 D
+0 5 D
+2 -5 D
+0 4 D
+9 -4 D
+-6 5 D
+11 -7 D
+2 4 D
+6 -5 D
+-3 5 D
+6 -5 D
+-5 5 D
+6 -4 D
+0 3 D
+3 -4 D
+-2 5 D
+5 -5 D
+-2 5 D
+9 -2 D
+-13 14 D
+11 -8 D
+-7 6 D
+9 -6 D
+-5 5 D
+6 -2 D
+-7 5 D
+12 -7 D
+-9 6 D
+10 -4 D
+-8 5 D
+2 3 D
+-5 -2 D
+-4 6 D
+-3 -1 D
+-6 5 D
+1 -4 D
+-2 5 D
+-2 -2 D
+-5 5 D
+0 -2 D
+-5 4 D
+1 -2 D
+-6 4 D
+-7 -1 D
+0 3 D
+-3 -2 D
+-5 6 D
+-7 1 D
+1 3 D
+-5 -1 D
+0 3 D
+-2 -1 D
+-4 4 D
+-2 -2 D
+0 3 D
+-7 2 D
+0 -3 D
+-5 5 D
+-12 0 D
+0 4 D
+-49 11 D
+-41 7 D
+12 -19 D
+P
+FO
+1 -2 0 -2 -8 -1 -7 8 7 -4 -1 6 8 -3 7 1583 2161 SP
+9 -6 10 -6 1 -2 -4 4 1 -4 -7 7 9 -9 -5 4 3 -4 -5 3 2 -7 -3 3 -3 -4 -10 20 4 -10 -12 17 16 1883 2004 SP
+1936 1968 M
+-16 19 D
+-3 13 D
+-12 15 D
+-6 1 D
+0 3 D
+-2 -4 D
+0 5 D
+-4 0 D
+-9 7 D
+-6 1 D
+6 -9 D
+-9 6 D
+-4 -3 D
+12 -18 D
+27 -18 D
+P
+FO
+7 1 1 1654 2189 SP
+-7 1 1 1589 2172 SP
+-1 -2 1 1747 2151 SP
+-3 3 1 1609 2160 SP
+-4 3 1 1750 2142 SP
+-4 4 1 1742 2140 SP
+-2 3 1 1618 2161 SP
+2 2 1 1683 2178 SP
+{0 0 0.502 C} FS
+-1 3 1 1692 2142 SP
+-2 3 1 1867 2014 SP
+4 -3 -3 3 2 1626 2153 SP
+1643 2195 M
+-3 1 D
+-6 7 D
+-15 5 D
+-1 2 D
+10 -4 D
+0 2 D
+-6 1 D
+4 0 D
+-9 6 D
+-5 0 D
+-2 4 D
+-28 9 D
+-9 5 D
+-10 0 D
+6 2 D
+-7 5 D
+-5 1 D
+1 1 D
+-19 11 D
+-41 15 D
+-7 4 D
+49 -1 D
+10 -1 D
+0 -1 D
+17 -4 D
+-11 1 D
+3 -6 D
+5 2 D
+0 -3 D
+7 0 D
+2 -3 D
+3 1 D
+4 -3 D
+-14 10 D
+9 -4 D
+-2 3 D
+14 -9 D
+-7 9 D
+16 -6 D
+-11 6 D
+-3 3 D
+59 -11 D
+35 -10 D
+55 -21 D
+32 -15 D
+46 -31 D
+46 -38 D
+32 -35 D
+8 -11 D
+-46 26 D
+-75 34 D
+-64 23 D
+-52 15 D
+P
+FO
+-1 1 1 -1 1 -1 3 1521 2252 SP
+{1 0 0 C} FS
+-4 4 1 1633 2204 SP
+1550 2270 M
+0 -1 D
+17 -4 D
+-11 1 D
+3 -6 D
+5 2 D
+0 -3 D
+7 0 D
+2 -3 D
+3 1 D
+4 -3 D
+-14 10 D
+9 -4 D
+-2 3 D
+14 -9 D
+-7 9 D
+16 -6 D
+-11 6 D
+-3 3 D
+P
+FO
+1521 2252 M
+7 -7 D
+11 -9 D
+22 -25 D
+61 -11 D
+21 -5 D
+-3 1 D
+-6 7 D
+-15 5 D
+-1 2 D
+10 -4 D
+0 2 D
+-6 1 D
+4 0 D
+-9 6 D
+-5 0 D
+-2 4 D
+-28 9 D
+-9 5 D
+-10 0 D
+6 2 D
+-7 5 D
+-5 1 D
+1 1 D
+-19 11 D
+-38 13 D
+P
+FO
+-4 4 1 1633 2204 SP
+{0 0 0.502 C} FS
+1582 2266 M
+-3 4 D
+-35 14 D
+-17 5 D
+2 -2 D
+-5 2 D
+-4 -4 D
+-7 2 D
+8 -3 D
+-1 -2 D
+9 -1 D
+8 -5 D
+6 0 D
+-3 -2 D
+10 -3 D
+0 -1 D
+-49 2 D
+-10 0 D
+-41 21 D
+-37 15 D
+-30 9 D
+33 6 D
+32 2 D
+46 -5 D
+40 -12 D
+-1 0 D
+15 -4 D
+-14 4 D
+7 -2 D
+-26 8 D
+25 -9 D
+-24 7 D
+48 -14 D
+-11 4 D
+21 -7 D
+-19 6 D
+17 -6 D
+0 1 D
+63 -24 D
+73 -34 D
+55 -29 D
+-54 24 D
+-44 16 D
+-47 11 D
+P
+FO
+{1 0 0 C} FS
+-13 5 -12 5 -12 5 -7 3 10 -4 -1 0 15 -6 8 -3 -6 2 13 -5 1 0 6 -2 3 -2 -6 3 14 -5 -1 0 16 1579 2293 SP
+-8 2 -6 2 2 0 3 1558 2298 SP
+3 -1 1 1556 2300 SP
+-8 3 7 -2 2 1563 2298 SP
+1 -1 -2 1 2 1568 2297 SP
+-5 1 1 1567 2296 SP
+1 1 1 1511 2306 SP
+3 -1 1 1479 2321 SP
+6 -2 -6 3 2 1577 2293 SP
+1 0 1 1513 2313 SP
+{0 0 0.502 C} FS
+5 -2 1 1585 2291 SP
+6 -2 1 1526 2287 SP
+6 -1 1 1540 2305 SP
+{1 0 0 C} FS
+1534 2308 M
+-1 0 D
+15 -4 D
+-14 4 D
+7 -2 D
+-26 8 D
+25 -9 D
+-24 7 D
+48 -14 D
+-11 4 D
+21 -7 D
+-19 6 D
+17 -6 D
+0 1 D
+P
+FO
+1582 2266 M
+-3 4 D
+-35 14 D
+-17 5 D
+2 -2 D
+-5 2 D
+-4 -4 D
+-7 2 D
+8 -3 D
+-1 -2 D
+9 -1 D
+8 -5 D
+6 0 D
+-3 -2 D
+10 -3 D
+0 -1 D
+P
+FO
+-13 5 -12 5 -12 5 -7 3 10 -4 -1 0 15 -6 8 -3 -6 2 13 -5 1 0 6 -2 3 -2 -6 3 14 -5 -1 0 16 1579 2293 SP
+-8 2 -6 2 2 0 3 1558 2298 SP
+3 -1 1 1556 2300 SP
+-8 3 7 -2 2 1563 2298 SP
+1 -1 -2 1 2 1568 2297 SP
+-5 1 1 1567 2296 SP
+1 1 1 1511 2306 SP
+3 -1 1 1479 2321 SP
+6 -2 -6 3 2 1577 2293 SP
+1 0 1 1513 2313 SP
+{0 0 0.502 C} FS
+5 -2 1 1585 2291 SP
+6 -2 1 1526 2287 SP
+6 -1 1 1540 2305 SP
+{1 0 0 C} FS
+-13 -7 -14 -8 -13 -7 1 1 8 4 7 4 7 4 7 4 11 6 11 6 1 1 11 577 2196 SP
+{0 0 0.502 C} FS
+-1 -2 -1 -1 4 5 3 292 1955 SP
+-13 -8 2 1 -6 -4 0 2 -10 -7 -1 0 -3 -3 12 8 2 0 16 11 10 537 2170 SP
+2 2 -4 -4 2 287 1952 SP
+-1 1 -4 -4 2 485 2127 SP
+1 1 -9 -7 2 496 2132 SP
+-2 -2 1 405 2072 SP
+1 1 1 324 1992 SP
+-10 -7 1 478 2121 SP
+-4 -3 1 508 2150 SP
+-2 -3 1 462 2095 SP
+-1 -1 1 537 2169 SP
+1 0 1 499 2145 SP
+{1 0 0 C} FS
+292 1955 M
+4 5 D
+-1 -1 D
+53 50 D
+40 32 D
+54 38 D
+19 12 D
+7 3 D
+22 28 D
+37 36 D
+23 17 D
+11 9 D
+39 25 D
+-22 -12 D
+-23 -14 D
+-32 -21 D
+-31 -21 D
+-40 -30 D
+-39 -32 D
+-55 -51 D
+-53 -54 D
+-24 -29 D
+-9 -9 D
+-46 -60 D
+28 37 D
+P
+FO
+{0 0 0.502 C} FS
+-13 -8 2 1 -6 -4 0 2 -10 -7 -1 0 -3 -3 12 8 2 0 16 11 10 537 2170 SP
+2 2 -4 -4 2 287 1952 SP
+-1 1 -4 -4 2 485 2127 SP
+1 1 -9 -7 2 496 2132 SP
+-2 -2 1 405 2072 SP
+1 1 1 324 1992 SP
+-10 -7 1 478 2121 SP
+-4 -3 1 508 2150 SP
+-2 -3 1 462 2095 SP
+-1 -1 1 537 2169 SP
+1 0 1 499 2145 SP
+-9 -9 -1 7 0 -1 0 -7 10 9 12 5 6 160 1723 SP
+1 0 1 161 1727 SP
+-1 -3 -7 -13 0 -5 8 20 4 161 1732 SP
+1 2 1 164 1744 SP
+2 2 6 8 -9 -11 0 -1 4 295 1959 SP
+-8 -9 -8 -8 -9 -9 11 4 1 -10 9 10 3 12 13 18 -4 1 9 244 1804 SP
+-5 -7 -5 -6 8 3 4 5 3 11 5 207 1759 SP
+-1 -1 2 3 2 170 1710 SP
+-6 -10 3 5 -1 -5 5 8 -2 -7 2 6 1 -1 7 190 1754 SP
+-5 -8 1 -2 0 4 4 4 4 188 1742 SP
+1 3 -4 -6 3 2 3 164 1745 SP
+-3 -8 3 4 2 175 1738 SP
+-7 1 -4 -5 2 411 1972 SP
+-3 -4 1 212 1788 SP
+4 7 1 183 1732 SP
+-5 -2 1 391 1956 SP
+0 -2 1 163 1739 SP
+3 4 0 -1 2 184 1755 SP
+0 -3 1 163 1728 SP
+-3 -3 1 395 2044 SP
+1 -1 1 164 1728 SP
+{1 0 0 C} FS
+164 1744 M
+1 2 D
+-4 -14 D
+8 20 D
+0 -5 D
+-8 -16 D
+0 -4 D
+1 0 D
+-1 0 D
+-1 -4 D
+12 5 D
+10 9 D
+0 -8 D
+-1 7 D
+-9 -9 D
+-12 -4 D
+-2 -30 D
+49 66 D
+3 11 D
+4 5 D
+8 3 D
+22 26 D
+-4 1 D
+13 18 D
+3 12 D
+9 10 D
+1 -10 D
+11 4 D
+5 6 D
+6 5 D
+5 6 D
+18 16 D
+5 6 D
+48 42 D
+58 45 D
+1 22 D
+7 33 D
+3 11 D
+15 32 D
+16 26 D
+4 5 D
+-13 -7 D
+-13 -8 D
+-18 -12 D
+-18 -13 D
+-24 -18 D
+-28 -23 D
+-17 -14 D
+-42 -40 D
+-9 -12 D
+6 8 D
+-42 -47 D
+-24 -32 D
+-24 -35 D
+-18 -34 D
+-13 -35 D
+P
+FO
+{0 0 0.502 C} FS
+-6 -10 3 5 -1 -5 5 8 -2 -7 2 6 1 -1 7 190 1754 SP
+-5 -8 1 -2 0 4 4 4 4 188 1742 SP
+1 3 -4 -6 3 2 3 164 1745 SP
+-3 -8 3 4 2 175 1738 SP
+-7 1 -4 -5 2 411 1972 SP
+-3 -4 1 212 1788 SP
+4 7 1 183 1732 SP
+-5 -2 1 391 1956 SP
+0 -2 1 163 1739 SP
+3 4 0 -1 2 184 1755 SP
+0 -3 1 163 1728 SP
+-3 -3 1 395 2044 SP
+1 -1 1 164 1728 SP
+159 1674 M
+0 -2 D
+3 14 D
+-2 8 D
+9 -4 D
+9 24 D
+1 8 D
+-2 -20 D
+9 23 D
+21 34 D
+15 19 D
+3 1 D
+3 5 D
+-1 -6 D
+6 7 D
+6 -4 D
+-2 -7 D
+7 6 D
+4 22 D
+-4 2 D
+33 35 D
+11 3 D
+3 -4 D
+-8 -11 D
+-15 -7 D
+1 -5 D
+-9 -3 D
+17 -3 D
+-1 -19 D
+-11 -8 D
+-2 -7 D
+-2 4 D
+-6 -4 D
+0 -6 D
+-2 0 D
+0 -4 D
+2 1 D
+-2 -11 D
+-11 -18 D
+3 7 D
+-5 -1 D
+-4 -8 D
+4 3 D
+-7 -8 D
+1 -3 D
+-13 -10 D
+-5 -11 D
+-1 3 D
+-3 -7 D
+7 1 D
+-4 -6 D
+6 6 D
+-3 -7 D
+4 7 D
+-1 -10 D
+6 6 D
+-1 -7 D
+13 11 D
+12 17 D
+18 33 D
+5 16 D
+7 7 D
+19 -1 D
+13 13 D
+10 0 D
+5 6 D
+0 -6 D
+12 8 D
+-5 -20 D
+19 -3 D
+51 20 D
+41 20 D
+-16 -15 D
+-60 -66 D
+-4 -6 D
+-3 0 D
+-13 -17 D
+1 0 D
+-10 -12 D
+-13 -12 D
+3 -1 D
+-7 -9 D
+-19 -17 D
+-27 -6 D
+1 9 D
+8 3 D
+-5 3 D
+-23 -22 D
+-13 23 D
+-23 -3 D
+-4 -6 D
+3 -12 D
+7 7 D
+-3 -6 D
+14 -3 D
+5 -10 D
+-11 -11 D
+-2 -13 D
+15 4 D
+3 10 D
+5 5 D
+-3 -7 D
+3 3 D
+0 -6 D
+-4 -1 D
+7 -9 D
+8 5 D
+-5 -10 D
+9 8 D
+2 -6 D
+6 8 D
+1 -3 D
+-9 -10 D
+2 0 D
+-31 -48 D
+-21 -36 D
+-14 20 D
+-9 14 D
+-14 28 D
+-11 29 D
+-11 43 D
+P
+FO
+1 2 2 5 -2 1 -4 -10 2 1 5 172 1713 SP
+1 0 3 -2 3 5 10 5 31 -5 4 -9 -3 9 19 -3 -11 6 -13 0 -22 5 -23 -11 12 455 1855 SP
+{1 0 0 C} FS
+6 7 -1 -9 -15 -15 -6 -12 3 0 4 9 3 -4 -6 -8 2 6 -4 -11 -10 4 6 24 20 19 6 0 14 186 1614 SP
+4 0 -7 -13 3 -2 -12 -5 1 6 -8 -2 -1 8 4 8 9 5 -1 -10 8 4 11 216 1627 SP
+-6 -6 3 4 2 183 1604 SP
+3 -5 1 200 1690 SP
+-5 -3 6 3 2 297 1665 SP
+-6 -4 1 242 1636 SP
+1 -3 1 179 1607 SP
+4 4 1 219 1680 SP
+-4 -4 1 225 1695 SP
+3 1 1 197 1658 SP
+-2 -4 1 253 1756 SP
+2 1 1 216 1677 SP
+3 1 1 206 1661 SP
+{0 0 0.502 C} FS
+-3 -3 1 334 1837 SP
+-4 -1 1 342 1825 SP
+-3 -3 1 325 1846 SP
+0 -4 1 371 1820 SP
+1 -7 9 12 2 359 1809 SP
+-7 -5 1 257 1640 SP
+2 4 -1 0 2 352 1875 SP
+{1 0 0 C} FS
+159 1675 M
+3 11 D
+-2 8 D
+9 -4 D
+9 24 D
+1 8 D
+-2 -20 D
+9 23 D
+21 34 D
+-35 -46 D
+2 1 D
+-4 -10 D
+-2 1 D
+2 5 D
+-12 -17 D
+P
+FO
+0 -2 1 159 1674 SP
+1 2 2 0 -4 -4 3 274 1606 SP
+324 1675 M
+-19 -17 D
+-27 -6 D
+1 9 D
+8 3 D
+-5 3 D
+-23 -22 D
+-13 23 D
+-23 -3 D
+-4 -6 D
+3 -12 D
+7 7 D
+-3 -6 D
+14 -3 D
+5 -10 D
+-11 -11 D
+-2 -13 D
+15 4 D
+3 10 D
+5 5 D
+-3 -7 D
+3 3 D
+0 -6 D
+-4 -1 D
+7 -9 D
+8 5 D
+-5 -10 D
+9 8 D
+2 -6 D
+6 8 D
+1 -3 D
+7 11 D
+15 21 D
+P
+FO
+5 6 3 -1 -10 -10 -3 -2 4 341 1697 SP
+5 6 5 6 1 0 -13 -17 -3 0 5 366 1726 SP
+455 1855 M
+-23 -11 D
+-22 5 D
+-13 0 D
+-11 6 D
+19 -3 D
+-3 9 D
+4 -9 D
+31 -5 D
+10 5 D
+3 5 D
+4 -2 D
+-20 43 D
+-7 22 D
+-5 34 D
+0 11 D
+-26 -20 D
+-32 -25 D
+-48 -42 D
+-5 -6 D
+-18 -16 D
+-5 -6 D
+-6 -5 D
+-5 -6 D
+11 3 D
+3 -4 D
+-8 -11 D
+-15 -7 D
+1 -5 D
+-9 -3 D
+17 -3 D
+-1 -19 D
+-11 -8 D
+-2 -7 D
+-2 4 D
+-6 -4 D
+0 -6 D
+-2 0 D
+0 -4 D
+2 1 D
+-2 -11 D
+-11 -18 D
+3 7 D
+-5 -1 D
+-4 -8 D
+4 3 D
+-7 -8 D
+1 -3 D
+-13 -10 D
+-5 -11 D
+-1 3 D
+-3 -7 D
+7 1 D
+-4 -6 D
+6 6 D
+-3 -7 D
+4 7 D
+-1 -10 D
+6 6 D
+-1 -7 D
+13 11 D
+12 17 D
+18 33 D
+5 16 D
+7 7 D
+19 -1 D
+13 13 D
+10 0 D
+5 6 D
+0 -6 D
+12 8 D
+-5 -20 D
+19 -3 D
+51 20 D
+41 20 D
+14 15 D
+8 7 D
+-9 13 D
+P
+FO
+-8 -8 -7 -9 -4 2 4 22 7 6 -2 -7 6 -4 6 7 -1 -6 3 5 3 1 11 222 1778 SP
+6 7 -1 -9 -15 -15 -6 -12 3 0 4 9 3 -4 -6 -8 2 6 -4 -11 -10 4 6 24 20 19 6 0 14 186 1614 SP
+4 0 -7 -13 3 -2 -12 -5 1 6 -8 -2 -1 8 4 8 9 5 -1 -10 8 4 11 216 1627 SP
+-6 -6 3 4 2 183 1604 SP
+3 -5 1 200 1690 SP
+-5 -3 6 3 2 297 1665 SP
+-6 -4 1 242 1636 SP
+1 -3 1 179 1607 SP
+4 4 1 219 1680 SP
+-4 -4 1 225 1695 SP
+3 1 1 197 1658 SP
+-2 -4 1 253 1756 SP
+2 1 1 216 1677 SP
+3 1 1 206 1661 SP
+{0 0 0.502 C} FS
+-3 -3 1 334 1837 SP
+-4 -1 1 342 1825 SP
+-3 -3 1 325 1846 SP
+0 -4 1 371 1820 SP
+1 -7 9 12 2 359 1809 SP
+-7 -5 1 257 1640 SP
+2 4 -1 0 2 352 1875 SP
+272 1602 M
+13 5 D
+5 12 D
+10 9 D
+14 20 D
+5 -3 D
+18 16 D
+20 35 D
+-4 4 D
+-5 -11 D
+1 12 D
+-8 -4 D
+10 12 D
+9 -5 D
+1 13 D
+5 4 D
+0 -8 D
+8 1 D
+1 -22 D
+16 10 D
+17 -5 D
+-4 3 D
+14 15 D
+-9 -3 D
+-4 10 D
+8 34 D
+-32 -30 D
+-5 8 D
+-4 -7 D
+-6 -1 D
+19 23 D
+50 54 D
+11 10 D
+8 5 D
+16 14 D
+8 -11 D
+-58 -58 D
+13 8 D
+2 -9 D
+-6 -8 D
+5 4 D
+14 29 D
+22 17 D
+7 -5 D
+-5 -13 D
+16 24 D
+4 -5 D
+5 -4 D
+14 -15 D
+26 -23 D
+43 -30 D
+20 -12 D
+-33 -46 D
+-51 -79 D
+-33 -56 D
+-43 -83 D
+-28 -59 D
+-14 -34 D
+-46 29 D
+-49 37 D
+-43 40 D
+-35 41 D
+-5 7 D
+40 66 D
+P
+FO
+3 3 -5 -5 0 -1 3 279 1612 SP
+3 4 -3 -3 -4 -5 0 -1 4 331 1684 SP
+{1 0 0 C} FS
+-2 4 17 6 -5 -5 3 415 1708 SP
+-8 5 27 5 2 430 1706 SP
+-17 -3 10 3 2 468 1709 SP
+2 -1 1 419 1698 SP
+6 2 1 548 1739 SP
+-5 6 16 24 -5 -13 7 -5 22 17 14 29 5 4 -6 -8 2 -9 13 8 -58 -58 11 478 1821 SP
+-7 -7 -8 -7 -1 1 -1 2 16 14 8 5 6 446 1813 SP
+351 1709 M
+9 -5 D
+1 13 D
+5 4 D
+0 -8 D
+8 1 D
+1 -22 D
+16 10 D
+17 -5 D
+-4 3 D
+14 15 D
+-9 -3 D
+-4 10 D
+8 34 D
+-32 -30 D
+-5 8 D
+-4 -7 D
+-6 -1 D
+P
+FO
+331 1684 M
+-23 -30 D
+-15 -20 D
+-7 -11 D
+-7 -11 D
+-7 -10 D
+13 5 D
+5 12 D
+10 9 D
+14 20 D
+5 -3 D
+18 16 D
+20 35 D
+-4 4 D
+-5 -11 D
+1 12 D
+-8 -4 D
+P
+FO
+-2 4 17 6 -5 -5 3 415 1708 SP
+-8 5 27 5 2 430 1706 SP
+-17 -3 10 3 2 468 1709 SP
+2 -1 1 419 1698 SP
+6 2 1 548 1739 SP
+{0 0 0.502 C} FS
+670 1250 M
+-32 9 D
+-68 23 D
+-63 26 D
+-44 20 D
+-61 33 D
+-4 3 D
+26 59 D
+24 51 D
+40 74 D
+53 88 D
+31 47 D
+28 38 D
+29 -17 D
+56 -27 D
+61 -23 D
+56 -18 D
+-25 -59 D
+-36 -95 D
+-44 -133 D
+P
+FO
+1003 1189 M
+-65 7 D
+-114 17 D
+-75 16 D
+-66 17 D
+-13 4 D
+22 81 D
+28 89 D
+34 97 D
+40 102 D
+8 17 D
+48 -13 D
+92 -19 D
+86 -11 D
+21 -2 D
+-25 -198 D
+P
+FO
+1359 1189 M
+-8 -1 D
+-7 0 D
+-7 -1 D
+-8 -1 D
+-7 0 D
+-7 -1 D
+-8 0 D
+-7 0 D
+-8 -1 D
+-7 0 D
+-7 -1 D
+-8 0 D
+-7 0 D
+-8 -1 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 -1 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-118 5 D
+-30 3 D
+27 259 D
+19 143 D
+55 -4 D
+77 -2 D
+55 1 D
+77 5 D
+22 -170 D
+20 -185 D
+P
+FO
+1479 1615 M
+21 -15 D
+9 7 D
+0 -11 D
+24 1 D
+-32 23 D
+4 1 D
+8 -3 D
+2 6 D
+2 0 D
+5 -5 D
+-4 -5 D
+8 6 D
+5 -12 D
+10 -3 D
+12 -23 D
+-5 -11 D
+2 11 D
+-5 7 D
+-3 -13 D
+0 17 D
+-26 -2 D
+16 -26 D
+5 2 D
+1 -14 D
+8 2 D
+-7 -3 D
+14 -66 D
+15 -26 D
+1 -21 D
+19 -27 D
+15 -16 D
+11 4 D
+7 -11 D
+-9 5 D
+5 -11 D
+38 -34 D
+3 -12 D
+10 0 D
+25 -87 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-8 -1 D
+-7 0 D
+-7 -1 D
+-29 277 D
+-17 125 D
+74 8 D
+P
+FO
+1 -8 1 1497 1619 SP
+0 -2 1 1640 1428 SP
+{1 0 0 C} FS
+5 -4 1 1480 1613 SP
+4 -2 1 1526 1606 SP
+8 -3 1 1508 1617 SP
+3 -4 1 1526 1605 SP
+{0 0 0.502 C} FS
+-2 5 1 1558 1609 SP
+1 -7 1 1614 1486 SP
+4 -7 1 1590 1490 SP
+7 -7 1 1538 1624 SP
+-10 7 1 1576 1596 SP
+4 -3 1 1600 1419 SP
+-2 -4 1 1597 1456 SP
+{1 0 0 C} FS
+1640 1428 M
+0 -2 D
+-20 59 D
+-49 128 D
+-10 23 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+5 -5 D
+-4 -5 D
+8 6 D
+5 -12 D
+10 -3 D
+12 -23 D
+-5 -11 D
+2 11 D
+-5 7 D
+-3 -13 D
+0 17 D
+-26 -2 D
+16 -26 D
+5 2 D
+1 -14 D
+8 2 D
+-7 -3 D
+14 -66 D
+15 -26 D
+1 -21 D
+19 -27 D
+15 -16 D
+11 4 D
+7 -11 D
+-9 5 D
+5 -11 D
+38 -34 D
+3 -12 D
+10 0 D
+-18 61 D
+P
+FO
+-5 -1 1 5 8 -3 3 1505 1621 SP
+-2 0 -32 23 24 1 0 -11 9 7 21 -15 -9 -2 -9 -2 -1 8 1 -8 10 1497 1619 SP
+5 -4 1 1480 1613 SP
+4 -2 1 1526 1606 SP
+8 -3 1 1508 1617 SP
+3 -4 1 1526 1605 SP
+{0 0 0.502 C} FS
+-2 5 1 1558 1609 SP
+1 -7 1 1614 1486 SP
+4 -7 1 1590 1490 SP
+7 -7 1 1538 1624 SP
+-10 7 1 1576 1596 SP
+4 -3 1 1600 1419 SP
+-2 -4 1 1597 1456 SP
+-9 -4 -9 -3 14 -21 31 -4 -17 35 5 1774 1276 SP
+1668 1337 M
+24 -1 D
+21 -10 D
+43 -57 D
+-8 -2 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-8 -2 D
+-8 -2 D
+P
+FO
+0 4 1 1640 1428 SP
+2 -10 1 1567 1638 SP
+2 -5 1 1590 1645 SP
+10 -14 1 1596 1647 SP
+-2 -2 1 1801 1666 SP
+{1 0 0 C} FS
+-6 0 1 1677 1331 SP
+6 -2 1 1694 1325 SP
+{0 0 0.502 C} FS
+-9 -4 -10 6 -12 -7 11 5 5 -6 1 4 8 -4 7 1757 1675 SP
+-10 -7 -8 6 8 -7 3 3 4 -7 5 1734 1405 SP
+-5 4 -11 -15 -4 4 2 -6 17 13 5 1713 1640 SP
+-20 28 3 9 -11 0 27 -37 4 1796 1661 SP
+-9 -10 2 -14 2 1776 1450 SP
+2 -8 -5 1 16 -10 3 1715 1510 SP
+-2 6 1 1617 1612 SP
+7 -7 1 1732 1338 SP
+-3 7 1 1646 1616 SP
+-1 -6 1 1899 1460 SP
+4 -1 1 1796 1367 SP
+2 -5 0 1 2 1737 1384 SP
+6 -2 1 1748 1365 SP
+3 -6 1 1639 1452 SP
+2 -5 1 1719 1575 SP
+0 -5 1 1704 1536 SP
+6 -7 1 1584 1638 SP
+-3 -9 1 1635 1594 SP
+2 -4 1 1659 1429 SP
+2 -8 1 1757 1519 SP
+5 -5 1 1684 1607 SP
+1 -4 1 1780 1548 SP
+3 -8 1 1593 1618 SP
+2 -5 1 1617 1605 SP
+{1 0 0 C} FS
+1774 1276 M
+-17 35 D
+31 -4 D
+14 -21 D
+76 32 D
+78 40 D
+9 6 D
+-49 106 D
+-52 96 D
+-43 70 D
+-20 30 D
+-2 -2 D
+2 2 D
+-23 33 D
+-15 22 D
+-15 -9 D
+-15 -8 D
+-16 -8 D
+-16 -8 D
+-8 -4 D
+-8 -3 D
+-9 -4 D
+-8 -4 D
+-9 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+10 -14 D
+-10 14 D
+-3 -1 D
+-3 -1 D
+2 -5 D
+-2 5 D
+-8 -3 D
+-7 -2 D
+-8 -2 D
+2 -10 D
+-2 10 D
+-3 -1 D
+-3 -1 D
+35 -87 D
+36 -97 D
+8 -24 D
+0 4 D
+2 -12 D
+15 -45 D
+11 -38 D
+24 -1 D
+21 -10 D
+43 -57 D
+P
+FO
+-6 0 1 1677 1331 SP
+6 -2 1 1694 1325 SP
+{0 0 0.502 C} FS
+-9 -4 -10 6 -12 -7 11 5 5 -6 1 4 8 -4 7 1757 1675 SP
+-10 -7 -8 6 8 -7 3 3 4 -7 5 1734 1405 SP
+-5 4 -11 -15 -4 4 2 -6 17 13 5 1713 1640 SP
+-20 28 3 9 -11 0 27 -37 4 1796 1661 SP
+-9 -10 2 -14 2 1776 1450 SP
+2 -8 -5 1 16 -10 3 1715 1510 SP
+-2 6 1 1617 1612 SP
+7 -7 1 1732 1338 SP
+-3 7 1 1646 1616 SP
+-1 -6 1 1899 1460 SP
+4 -1 1 1796 1367 SP
+2 -5 0 1 2 1737 1384 SP
+6 -2 1 1748 1365 SP
+3 -6 1 1639 1452 SP
+2 -5 1 1719 1575 SP
+0 -5 1 1704 1536 SP
+6 -7 1 1584 1638 SP
+-3 -9 1 1635 1594 SP
+2 -4 1 1659 1429 SP
+2 -8 1 1757 1519 SP
+5 -5 1 1684 1607 SP
+1 -4 1 1780 1548 SP
+3 -8 1 1593 1618 SP
+2 -5 1 1617 1605 SP
+-3 -5 3 -6 3 -5 4 -6 3 -6 4 -6 3 -6 4 -6 4 -6 -2 14 4 -3 -4 4 -4 25 -15 17 14 2135 1508 SP
+-3 6 1 2132 1505 SP
+-3 -3 4 1 1 5 3 2112 1480 SP
+-9 -8 -8 -8 -9 -9 4 -4 8 6 -1 -4 6 10 1 -6 5 15 -1 -5 6 -5 -3 9 19 19 -9 -2 14 2070 1440 SP
+-1 1 1 2036 1412 SP
+2 2 -1 6 -10 2 6 -12 1 0 5 1851 1786 SP
+-1 0 1 1911 1819 SP
+1 4 -3 -2 2 1949 1780 SP
+1972 1755 M
+1 -2 D
+-6 -4 D
+-13 5 D
+10 -7 D
+15 -23 D
+0 -10 D
+-15 13 D
+-3 -12 D
+-4 14 D
+-13 14 D
+-16 -3 D
+10 -19 D
+-6 7 D
+2 -13 D
+22 -27 D
+11 -21 D
+-2 -9 D
+-23 22 D
+-16 29 D
+-4 -5 D
+-9 26 D
+7 -3 D
+0 15 D
+12 8 D
+-9 5 D
+-5 -4 D
+-4 5 D
+-11 -20 D
+-8 4 D
+-3 -7 D
+-7 7 D
+-4 -22 D
+-4 -2 D
+-4 6 D
+-7 -11 D
+-1 45 D
+4 1 D
+-5 9 D
+5 -7 D
+0 5 D
+-5 6 D
+14 7 D
+14 -8 D
+7 5 D
+22 -20 D
+28 16 D
+14 -6 D
+5 -4 D
+P
+FO
+4 -4 1 5 -3 -1 7 12 1 17 4 -4 -2 -6 6 -3 -8 21 -13 -9 0 -24 11 2003 1719 SP
+{1 0 0 C} FS
+6 7 -2 -3 2 2089 1467 SP
+{0 0 0.502 C} FS
+-4 -3 -4 15 -6 -11 8 2 -7 -3 13 -9 6 1807 1749 SP
+-2 -4 4 -3 2 2087 1566 SP
+-5 1 3 -4 2 2077 1573 SP
+-4 5 -11 0 14 -5 3 1830 1739 SP
+-5 -1 2 -5 2 1967 1463 SP
+7 -1 1 2041 1542 SP
+-7 -2 1 1851 1737 SP
+-2 -4 1 1827 1764 SP
+1 -7 1 2072 1563 SP
+-5 -1 1 1824 1752 SP
+-4 0 1 1826 1755 SP
+4 0 1 2103 1574 SP
+-1 -3 1 1844 1751 SP
+4 -5 1 1936 1793 SP
+0 4 -1 -4 2 1839 1751 SP
+-1 -4 1 1834 1770 SP
+4 -7 1 1915 1684 SP
+0 8 0 -9 2 1828 1720 SP
+11 -12 1 2012 1443 SP
+5 -7 1 1926 1693 SP
+-3 5 2 -5 2 1861 1696 SP
+13 -16 1 2013 1573 SP
+1 -6 1 1843 1707 SP
+-5 9 -12 2 2 1856 1611 SP
+-1 -4 1 1851 1757 SP
+6 -7 1 2013 1576 SP
+6 0 1 1890 1673 SP
+3 -4 1 1916 1661 SP
+0 -5 1 1842 1669 SP
+4 -3 1 1921 1782 SP
+0 -6 1 1899 1791 SP
+5 -6 1 1927 1785 SP
+{1 0 0 C} FS
+13 3 -9 -10 2 1945 1764 SP
+0 -4 1 1869 1770 SP
+-1 -9 1 1874 1755 SP
+2036 1412 M
+-1 1 D
+1 -1 D
+29 23 D
+5 5 D
+-9 -2 D
+19 19 D
+-3 9 D
+6 -5 D
+-1 -5 D
+5 15 D
+1 -6 D
+6 10 D
+-1 -4 D
+8 6 D
+4 -4 D
+7 7 D
+1 5 D
+4 1 D
+15 19 D
+-3 6 D
+3 -6 D
+2 1 D
+1 2 D
+-15 17 D
+-4 25 D
+-4 4 D
+4 -3 D
+-2 14 D
+-37 57 D
+-41 56 D
+-16 21 D
+-17 20 D
+0 -24 D
+-13 -9 D
+-8 21 D
+6 -3 D
+-2 -6 D
+4 -4 D
+1 17 D
+7 12 D
+-3 -1 D
+1 5 D
+-24 28 D
+1 -2 D
+-6 -4 D
+-13 5 D
+10 -7 D
+15 -23 D
+0 -10 D
+-15 13 D
+-3 -12 D
+-4 14 D
+-13 14 D
+-16 -3 D
+10 -19 D
+-6 7 D
+2 -13 D
+22 -27 D
+11 -21 D
+-2 -9 D
+-23 22 D
+-16 29 D
+-4 -5 D
+-9 26 D
+7 -3 D
+0 15 D
+12 8 D
+-9 5 D
+-5 -4 D
+-4 5 D
+-11 -20 D
+-8 4 D
+-3 -7 D
+-7 7 D
+-4 -22 D
+-4 -2 D
+-4 6 D
+-7 -11 D
+-1 45 D
+4 1 D
+-5 9 D
+5 -7 D
+0 5 D
+-5 6 D
+14 7 D
+14 -8 D
+7 5 D
+22 -20 D
+28 16 D
+14 -6 D
+-9 11 D
+-5 5 D
+-3 -2 D
+1 4 D
+-13 14 D
+-5 4 D
+-18 19 D
+-1 0 D
+1 0 D
+-6 5 D
+-10 11 D
+-20 -25 D
+-24 -24 D
+1 0 D
+6 -12 D
+-10 2 D
+-1 6 D
+-28 -23 D
+-17 -13 D
+-19 -13 D
+-14 -8 D
+-6 -4 D
+23 -33 D
+50 -75 D
+37 -63 D
+55 -104 D
+37 -82 D
+51 33 D
+P
+FO
+6 7 -2 -3 2 2089 1467 SP
+{0 0 0.502 C} FS
+-4 -3 -4 15 -6 -11 8 2 -7 -3 13 -9 6 1807 1749 SP
+-2 -4 4 -3 2 2087 1566 SP
+-5 1 3 -4 2 2077 1573 SP
+-4 5 -11 0 14 -5 3 1830 1739 SP
+-5 -1 2 -5 2 1967 1463 SP
+7 -1 1 2041 1542 SP
+-7 -2 1 1851 1737 SP
+-2 -4 1 1827 1764 SP
+1 -7 1 2072 1563 SP
+-5 -1 1 1824 1752 SP
+-4 0 1 1826 1755 SP
+4 0 1 2103 1574 SP
+-1 -3 1 1844 1751 SP
+4 -5 1 1936 1793 SP
+0 4 -1 -4 2 1839 1751 SP
+-1 -4 1 1834 1770 SP
+4 -7 1 1915 1684 SP
+0 8 0 -9 2 1828 1720 SP
+11 -12 1 2012 1443 SP
+5 -7 1 1926 1693 SP
+-3 5 2 -5 2 1861 1696 SP
+13 -16 1 2013 1573 SP
+1 -6 1 1843 1707 SP
+-5 9 -12 2 2 1856 1611 SP
+-1 -4 1 1851 1757 SP
+6 -7 1 2013 1576 SP
+6 0 1 1890 1673 SP
+3 -4 1 1916 1661 SP
+0 -5 1 1842 1669 SP
+4 -3 1 1921 1782 SP
+0 -6 1 1899 1791 SP
+5 -6 1 1927 1785 SP
+{1 0 0 C} FS
+13 3 -9 -10 2 1945 1764 SP
+0 -4 1 1869 1770 SP
+-1 -9 1 1874 1755 SP
+{0 0 0.502 C} FS
+2114 1565 M
+-3 27 D
+0 38 D
+-5 -3 D
+0 8 D
+-5 -1 D
+6 5 D
+-2 8 D
+-4 4 D
+3 -6 D
+-5 5 D
+-2 -6 D
+-2 10 D
+5 -1 D
+-9 10 D
+13 -12 D
+-15 14 D
+-9 -2 D
+5 2 D
+-7 4 D
+5 -2 D
+-3 6 D
+-8 2 D
+7 -1 D
+-3 5 D
+-11 -1 D
+-3 5 D
+12 -2 D
+-17 17 D
+0 10 D
+7 -15 D
+14 -8 D
+9 -16 D
+-12 27 D
+-19 17 D
+13 -7 D
+-7 19 D
+-11 10 D
+-4 13 D
+3 21 D
+-6 7 D
+5 -4 D
+1 13 D
+-5 4 D
+4 -6 D
+-12 4 D
+-16 25 D
+1 4 D
+-5 5 D
+4 2 D
+-10 13 D
+5 -5 D
+-2 8 D
+4 -2 D
+-5 14 D
+-7 4 D
+4 3 D
+-9 26 D
+7 -11 D
+2 11 D
+4 -9 D
+-5 1 D
+10 -23 D
+10 -10 D
+6 1 D
+-15 23 D
+3 3 D
+-4 4 D
+-8 27 D
+-8 1 D
+2 -12 D
+-11 -3 D
+-11 9 D
+-1 -4 D
+-10 14 D
+2 -9 D
+-5 3 D
+-3 -6 D
+2 11 D
+-5 12 D
+-11 6 D
+-4 -9 D
+6 -21 D
+20 -45 D
+-11 22 D
+-7 6 D
+-11 31 D
+-10 13 D
+5 36 D
+0 9 D
+31 -23 D
+29 -24 D
+-4 1 D
+10 -11 D
+0 -3 D
+-9 13 D
+-11 9 D
+15 -21 D
+7 -4 D
+-6 14 D
+33 -28 D
+72 -71 D
+16 -19 D
+27 -32 D
+21 -26 D
+33 -47 D
+-1 -23 D
+-6 -37 D
+-11 -37 D
+-17 -36 D
+-17 -28 D
+-10 -14 D
+P
+FO
+-3 4 0 -11 5 -10 2 13 4 1996 1727 SP
+-4 5 3 -7 6 -2 3 1963 1764 SP
+-3 -4 4 0 1 2 3 1947 1782 SP
+10 -2 1 1911 1819 SP
+1 2 -4 5 1 -7 1 -1 4 1906 1852 SP
+1 -2 1 1926 1891 SP
+-6 2 5 -3 2 1931 1905 SP
+{1 0 0 C} FS
+6 -9 -9 7 -1 -13 -7 12 4 2001 1896 SP
+-5 -10 -6 -1 -3 4 3 1954 1940 SP
+-4 8 4 12 2 2050 1740 SP
+0 4 1 2053 1741 SP
+0 -6 1 2054 1750 SP
+-5 9 1 1982 1918 SP
+6 -11 1 2104 1651 SP
+-3 7 1 2079 1688 SP
+-2 6 1 2113 1624 SP
+{0 0 0.502 C} FS
+-3 -5 -2 6 9 14 -4 13 -14 -20 1 -10 8 -7 3 -9 8 1992 1783 SP
+9 16 16 -1 -16 2 -9 -17 -7 27 17 -64 6 1975 1847 SP
+1 -5 -4 5 4 -5 -7 -3 9 -3 5 1934 1853 SP
+3 -9 -6 1 10 -3 3 1930 1895 SP
+-6 2 10 -9 2 1943 1825 SP
+-5 -2 6 -2 2 1942 1869 SP
+1 -4 4 -1 2 1941 1819 SP
+3 -4 1 2002 1826 SP
+17 -21 1 1994 1811 SP
+6 -5 1 1940 1800 SP
+3 -7 1 1909 1856 SP
+6 -5 1 1992 1846 SP
+-13 9 12 -9 2 1933 1803 SP
+3 -6 1 1956 1820 SP
+3 -6 1 1918 1872 SP
+4 -7 1 2010 1790 SP
+1 -4 1 1985 1764 SP
+3 0 1 1986 1854 SP
+2 -4 1 2012 1746 SP
+6 -3 1 2077 1642 SP
+1 5 -1 -4 2 1981 1765 SP
+6 -5 1 1937 1906 SP
+4 -5 1 1955 1837 SP
+5 -8 1 1938 1821 SP
+4 -3 1 2018 1804 SP
+4 0 1 1997 1858 SP
+3 -5 1 1996 1876 SP
+3 1 1 2083 1644 SP
+4 -5 1 1926 1836 SP
+5 -4 1 1988 1852 SP
+3 -6 1 1985 1787 SP
+7 -5 1 2009 1753 SP
+7 -7 1 2009 1751 SP
+3 -4 1 2032 1780 SP
+5 -5 1 1994 1820 SP
+4 -6 1 1968 1810 SP
+{1 0 0 C} FS
+-1 1 -6 14 7 -4 15 -21 -11 9 -9 13 0 -3 10 -11 -4 1 9 2000 1918 SP
+1931 1905 M
+5 -3 D
+-6 2 D
+-4 -13 D
+1 -2 D
+-1 2 D
+-15 -31 D
+-5 -8 D
+2 -8 D
+-4 5 D
+-9 -14 D
+10 -11 D
+6 -5 D
+10 -2 D
+-10 2 D
+18 -19 D
+5 -4 D
+13 -14 D
+1 2 D
+4 0 D
+-3 -4 D
+10 -10 D
+4 -6 D
+6 -2 D
+3 -7 D
+24 -28 D
+2 13 D
+5 -10 D
+0 -11 D
+22 -27 D
+47 -63 D
+38 -57 D
+4 -7 D
+-3 27 D
+0 38 D
+-5 -3 D
+0 8 D
+-5 -1 D
+6 5 D
+-2 8 D
+-4 4 D
+3 -6 D
+-5 5 D
+-2 -6 D
+-2 10 D
+5 -1 D
+-9 10 D
+13 -12 D
+-15 14 D
+-9 -2 D
+5 2 D
+-7 4 D
+5 -2 D
+-3 6 D
+-8 2 D
+7 -1 D
+-3 5 D
+-11 -1 D
+-3 5 D
+12 -2 D
+-17 17 D
+0 10 D
+7 -15 D
+14 -8 D
+9 -16 D
+-12 27 D
+-19 17 D
+13 -7 D
+-7 19 D
+-11 10 D
+-4 13 D
+3 21 D
+-6 7 D
+5 -4 D
+1 13 D
+-5 4 D
+4 -6 D
+-12 4 D
+-16 25 D
+1 4 D
+-5 5 D
+4 2 D
+-10 13 D
+5 -5 D
+-2 8 D
+4 -2 D
+-5 14 D
+-7 4 D
+4 3 D
+-9 26 D
+7 -11 D
+2 11 D
+4 -9 D
+-5 1 D
+10 -23 D
+10 -10 D
+6 1 D
+-15 23 D
+3 3 D
+-4 4 D
+-8 27 D
+-8 1 D
+2 -12 D
+-11 -3 D
+-11 9 D
+-1 -4 D
+-10 14 D
+2 -9 D
+-5 3 D
+-3 -6 D
+2 11 D
+-5 12 D
+-11 6 D
+-4 -9 D
+6 -21 D
+20 -45 D
+-11 22 D
+-7 6 D
+-11 31 D
+-10 13 D
+P
+FO
+6 -9 -9 7 -1 -13 -7 12 4 2001 1896 SP
+-5 -10 -6 -1 -3 4 3 1954 1940 SP
+-4 8 4 12 2 2050 1740 SP
+0 4 1 2053 1741 SP
+0 -6 1 2054 1750 SP
+-5 9 1 1982 1918 SP
+6 -11 1 2104 1651 SP
+-3 7 1 2079 1688 SP
+-2 6 1 2113 1624 SP
+{0 0 0.502 C} FS
+-3 -5 -2 6 9 14 -4 13 -14 -20 1 -10 8 -7 3 -9 8 1992 1783 SP
+9 16 16 -1 -16 2 -9 -17 -7 27 17 -64 6 1975 1847 SP
+1 -5 -4 5 4 -5 -7 -3 9 -3 5 1934 1853 SP
+3 -9 -6 1 10 -3 3 1930 1895 SP
+-6 2 10 -9 2 1943 1825 SP
+-5 -2 6 -2 2 1942 1869 SP
+1 -4 4 -1 2 1941 1819 SP
+3 -4 1 2002 1826 SP
+17 -21 1 1994 1811 SP
+6 -5 1 1940 1800 SP
+3 -7 1 1909 1856 SP
+6 -5 1 1992 1846 SP
+-13 9 12 -9 2 1933 1803 SP
+3 -6 1 1956 1820 SP
+3 -6 1 1918 1872 SP
+4 -7 1 2010 1790 SP
+1 -4 1 1985 1764 SP
+3 0 1 1986 1854 SP
+2 -4 1 2012 1746 SP
+6 -3 1 2077 1642 SP
+1 5 -1 -4 2 1981 1765 SP
+6 -5 1 1937 1906 SP
+4 -5 1 1955 1837 SP
+5 -8 1 1938 1821 SP
+4 -3 1 2018 1804 SP
+4 0 1 1997 1858 SP
+3 -5 1 1996 1876 SP
+3 1 1 2083 1644 SP
+4 -5 1 1926 1836 SP
+5 -4 1 1988 1852 SP
+3 -6 1 1985 1787 SP
+7 -5 1 2009 1753 SP
+7 -7 1 2009 1751 SP
+3 -4 1 2032 1780 SP
+5 -5 1 1994 1820 SP
+4 -6 1 1968 1810 SP
+2002 1916 M
+0 2 D
+-2 0 D
+-44 35 D
+-16 12 D
+0 16 D
+8 -7 D
+1 -5 D
+7 -2 D
+-2 -2 D
+10 -13 D
+-1 7 D
+10 -15 D
+5 -2 D
+-4 8 D
+3 7 D
+-7 13 D
+8 -8 D
+-5 12 D
+12 -17 D
+-1 6 D
+-15 18 D
+6 -3 D
+10 -10 D
+-7 9 D
+9 -7 D
+-1 3 D
+-14 14 D
+-4 2 D
+5 -7 D
+-10 10 D
+11 -12 D
+-5 1 D
+-3 5 D
+-3 -1 D
+-6 10 D
+4 -10 D
+-14 15 D
+1 -7 D
+-4 4 D
+9 -12 D
+-8 7 D
+3 -8 D
+-10 10 D
+2 -5 D
+-8 33 D
+-13 31 D
+-11 21 D
+-13 20 D
+52 -33 D
+37 -28 D
+36 -29 D
+39 -37 D
+5 -6 D
+6 -5 D
+50 -58 D
+41 -59 D
+12 -21 D
+13 -29 D
+13 -44 D
+5 -45 D
+0 -7 D
+-38 53 D
+-26 33 D
+-28 31 D
+-11 13 D
+-66 65 D
+P
+FO
+-7 8 7 -9 2 1939 1989 SP
+{1 0 0 C} FS
+3 -4 1 1974 1977 SP
+-2 3 1 1944 1994 SP
+{0 0 0.502 C} FS
+11 -15 1 1950 1977 SP
+-5 7 4 -7 2 1958 1974 SP
+-1 5 1 1955 1985 SP
+3 -4 1 1965 1969 SP
+{1 0 0 C} FS
+1939 1989 M
+7 -9 D
+-7 8 D
+1 -7 D
+8 -7 D
+1 -5 D
+7 -2 D
+-2 -2 D
+10 -13 D
+-1 7 D
+10 -15 D
+5 -2 D
+-4 8 D
+3 7 D
+-7 13 D
+8 -8 D
+-5 12 D
+12 -17 D
+-1 6 D
+-15 18 D
+6 -3 D
+10 -10 D
+-7 9 D
+9 -7 D
+-1 3 D
+-14 14 D
+-4 2 D
+5 -7 D
+-10 10 D
+11 -12 D
+-5 1 D
+-3 5 D
+-3 -1 D
+-6 10 D
+4 -10 D
+-14 15 D
+1 -7 D
+-4 4 D
+9 -12 D
+-8 7 D
+3 -8 D
+-10 10 D
+2 -5 D
+-1 1 D
+P
+FO
+1 -1 -2 0 0 2 3 2002 1916 SP
+3 -4 1 1974 1977 SP
+-2 3 1 1944 1994 SP
+{0 0 0.502 C} FS
+11 -15 1 1950 1977 SP
+-5 7 4 -7 2 1958 1974 SP
+-1 5 1 1955 1985 SP
+3 -4 1 1965 1969 SP
+2136 1876 M
+-26 34 D
+-40 46 D
+-6 5 D
+-21 22 D
+-41 36 D
+-42 33 D
+-45 30 D
+-20 12 D
+-21 26 D
+-19 20 D
+-46 38 D
+-32 22 D
+-14 9 D
+55 -33 D
+52 -35 D
+60 -46 D
+65 -58 D
+62 -63 D
+49 -58 D
+P
+FO
+13 -7 13 -8 14 -7 -1 1 -8 4 -7 4 -8 4 -7 4 -11 6 -10 6 -2 1 11 1786 2196 SP
+18 1370 M
+2 1 D
+3 18 D
+-2 -12 D
+1 6 D
+-4 -12 D
+4 39 D
+16 70 D
+18 60 D
+25 72 D
+25 58 D
+-1 -2 D
+2 5 D
+-2 -6 D
+2 5 D
+-6 -14 D
+1 1 D
+-13 -31 D
+8 18 D
+-3 -10 D
+2 4 D
+-2 -7 D
+2 4 D
+-3 -8 D
+5 11 D
+-4 -9 D
+2 3 D
+-2 -5 D
+8 16 D
+-9 -22 D
+3 5 D
+1 0 D
+-2 -6 D
+2 2 D
+-3 -7 D
+1 -4 D
+3 3 D
+2 6 D
+0 -5 D
+3 4 D
+-2 -6 D
+4 4 D
+2 7 D
+0 -7 D
+3 6 D
+0 -4 D
+3 7 D
+-1 -5 D
+4 7 D
+-2 -8 D
+6 13 D
+3 1 D
+0 4 D
+1 -2 D
+3 9 D
+-1 -7 D
+-27 -48 D
+-29 -65 D
+-20 -51 D
+-22 -72 D
+-1 -6 D
+0 3 D
+-3 -13 D
+1 4 D
+-7 -33 D
+P
+FO
+-1 0 1 164 1744 SP
+3 9 5 6 5 12 -3 -4 -2 -7 -5 -6 -2 -1 2 0 -3 -8 9 161 1731 SP
+-1 0 1 161 1727 SP
+{1 0 0 C} FS
+-2 -4 5 14 3 8 4 9 1 1 -4 -9 6 81 1610 SP
+0 2 1 20 1369 SP
+1 0 1 100 1616 SP
+{0 0 0.502 C} FS
+3 11 6 13 -6 -14 -3 -10 -3 -8 -3 -11 3 11 7 110 1670 SP
+-1 3 -3 -5 3 1 3 153 1696 SP
+-1 2 -2 -8 2 158 1749 SP
+1 0 1 159 1745 SP
+-2 -4 1 101 1656 SP
+-3 -5 1 108 1650 SP
+{1 0 0 C} FS
+106 1670 M
+-1 -2 D
+2 5 D
+-2 -6 D
+2 5 D
+-6 -14 D
+1 1 D
+-13 -31 D
+8 18 D
+-3 -10 D
+2 4 D
+-2 -7 D
+2 4 D
+-3 -8 D
+5 11 D
+-4 -9 D
+2 3 D
+-2 -5 D
+8 16 D
+-9 -22 D
+3 5 D
+1 0 D
+-2 -6 D
+2 2 D
+-3 -7 D
+1 -4 D
+3 3 D
+2 6 D
+0 -5 D
+3 4 D
+-2 -6 D
+4 4 D
+2 7 D
+0 -7 D
+3 6 D
+0 -4 D
+3 7 D
+-1 -5 D
+4 7 D
+-2 -8 D
+6 13 D
+3 1 D
+0 4 D
+1 -2 D
+3 9 D
+-1 -7 D
+32 53 D
+2 30 D
+-2 -1 D
+-5 -6 D
+-2 -7 D
+-3 -4 D
+5 12 D
+5 6 D
+6 21 D
+-1 0 D
+1 0 D
+9 35 D
+14 35 D
+19 33 D
+11 16 D
+-30 -43 D
+-40 -68 D
+-36 -70 D
+P
+FO
+-2 -4 -2 -8 1 6 -2 -12 3 18 2 1 6 18 1370 SP
+-1 -4 1 25 1392 SP
+0 3 1 27 1398 SP
+2 8 2 7 -5 -18 -2 -6 0 2 5 48 1469 SP
+0 2 2 0 -3 -8 0 2 0 2 1 0 -1 0 7 161 1727 SP
+-2 -4 5 14 3 8 4 9 1 1 -4 -9 6 81 1610 SP
+0 2 1 20 1369 SP
+1 0 1 100 1616 SP
+{0 0 0.502 C} FS
+3 11 6 13 -6 -14 -3 -10 -3 -8 -3 -11 3 11 7 110 1670 SP
+-1 3 -3 -5 3 1 3 153 1696 SP
+-1 2 -2 -8 2 158 1749 SP
+1 0 1 159 1745 SP
+-2 -4 1 101 1656 SP
+-3 -5 1 108 1650 SP
+24 1297 M
+1 1 D
+-1 -1 D
+1 13 D
+-1 -9 D
+-2 18 D
+-1 -1 D
+-1 4 D
+2 3 D
+4 15 D
+-6 -16 D
+4 20 D
+-4 -13 D
+-1 0 D
+-1 28 D
+9 39 D
+-1 -7 D
+4 19 D
+11 37 D
+-4 -16 D
+2 6 D
+0 -7 D
+-5 -11 D
+-1 -10 D
+2 2 D
+-3 -23 D
+4 15 D
+-4 -25 D
+1 -7 D
+-2 -9 D
+3 8 D
+-1 5 D
+2 11 D
+1 -2 D
+1 13 D
+-2 -5 D
+3 14 D
+-1 4 D
+-2 -6 D
+7 34 D
+10 16 D
+5 19 D
+4 8 D
+0 19 D
+-14 -38 D
+6 22 D
+29 72 D
+21 43 D
+23 41 D
+-1 -1 D
+12 13 D
+2 6 D
+2 -7 D
+4 9 D
+3 0 D
+2 7 D
+1 -4 D
+4 5 D
+-2 4 D
+5 0 D
+1 3 D
+2 -23 D
+13 -50 D
+16 -36 D
+7 -14 D
+18 -28 D
+5 -6 D
+-45 -88 D
+-28 -64 D
+-18 -49 D
+-22 -75 D
+-9 -33 D
+-10 -49 D
+-29 45 D
+-18 38 D
+-11 31 D
+P
+FO
+{1 0 0 C} FS
+-1 10 4 22 0 -4 2 7 -3 -24 5 25 1332 SP
+-4 -8 -15 -14 3 9 25 39 4 86 1556 SP
+-3 -22 -1 9 1 10 4 24 1 -13 5 27 1331 SP
+1 18 -1 0 2 7 4 2 4 20 1346 SP
+-3 -13 2 19 4 13 0 -2 -3 -16 5 30 1403 SP
+2 2 -3 -12 2 22 3 28 1350 SP
+5 4 -1 -5 2 154 1583 SP
+-9 -8 5 4 2 134 1564 SP
+-1 -12 0 4 2 32 1380 SP
+2 7 1 32 1395 SP
+0 -5 1 34 1425 SP
+-1 -5 1 37 1412 SP
+3 8 1 27 1376 SP
+2 8 1 39 1420 SP
+1 2 1 21 1342 SP
+0 -4 1 29 1377 SP
+-1 -7 1 31 1369 SP
+1 -2 1 107 1568 SP
+2 0 1 108 1566 SP
+{0 0 0.502 C} FS
+2 7 -1 -2 2 37 1422 SP
+{1 0 0 C} FS
+0 -2 -1 0 -4 -13 1 7 3 11 5 20 1326 SP
+-6 -17 4 15 2 3 3 20 1322 SP
+0 -3 -1 -1 0 6 3 22 1313 SP
+1 9 1 24 1301 SP
+1 1 1 24 1297 SP
+126 1640 M
+-1 -1 D
+12 13 D
+2 6 D
+2 -7 D
+4 9 D
+3 0 D
+2 7 D
+1 -4 D
+4 5 D
+-2 4 D
+5 0 D
+1 3 D
+-1 18 D
+P
+FO
+41 1447 M
+-4 -16 D
+2 6 D
+0 -7 D
+-5 -11 D
+-1 -10 D
+2 2 D
+-3 -23 D
+4 15 D
+-4 -25 D
+1 -7 D
+-2 -9 D
+3 8 D
+-1 5 D
+2 11 D
+1 -2 D
+1 13 D
+-2 -5 D
+3 14 D
+-1 4 D
+-2 -6 D
+7 34 D
+10 16 D
+5 19 D
+4 8 D
+0 19 D
+-14 -38 D
+1 7 D
+P
+FO
+-1 -7 1 27 1398 SP
+-1 10 4 22 0 -4 2 7 -3 -24 5 25 1332 SP
+-4 -8 -15 -14 3 9 25 39 4 86 1556 SP
+-3 -22 -1 9 1 10 4 24 1 -13 5 27 1331 SP
+1 18 -1 0 2 7 4 2 4 20 1346 SP
+-3 -13 2 19 4 13 0 -2 -3 -16 5 30 1403 SP
+2 2 -3 -12 2 22 3 28 1350 SP
+5 4 -1 -5 2 154 1583 SP
+-9 -8 5 4 2 134 1564 SP
+-1 -12 0 4 2 32 1380 SP
+2 7 1 32 1395 SP
+0 -5 1 34 1425 SP
+-1 -5 1 37 1412 SP
+3 8 1 27 1376 SP
+2 8 1 39 1420 SP
+1 2 1 21 1342 SP
+0 -4 1 29 1377 SP
+-1 -7 1 31 1369 SP
+1 -2 1 107 1568 SP
+2 0 1 108 1566 SP
+{0 0 0.502 C} FS
+2 7 -1 -2 2 37 1422 SP
+290 985 M
+-52 33 D
+-47 35 D
+-42 37 D
+-7 8 D
+-8 7 D
+-34 39 D
+-12 16 D
+12 58 D
+21 74 D
+26 74 D
+32 72 D
+41 80 D
+28 -35 D
+26 -27 D
+44 -38 D
+43 -31 D
+37 -23 D
+-11 -26 D
+-29 -77 D
+-25 -78 D
+-20 -78 D
+-13 -60 D
+P
+FO
+600 855 M
+-65 20 D
+-69 25 D
+-71 30 D
+-42 20 D
+-52 28 D
+-11 7 D
+17 94 D
+14 61 D
+23 78 D
+26 77 D
+24 60 D
+4 9 D
+49 -28 D
+54 -26 D
+81 -32 D
+81 -27 D
+7 -1 D
+-24 -100 D
+-17 -82 D
+-17 -107 D
+-12 -97 D
+P
+FO
+979 786 M
+-123 14 D
+-89 15 D
+-100 22 D
+-67 18 D
+9 88 D
+22 134 D
+27 127 D
+12 46 D
+65 -18 D
+75 -16 D
+64 -11 D
+115 -15 D
+14 -1 D
+-16 -223 D
+P
+FO
+{1 0 0 C} FS
+4 4 -3 -4 2 989 1025 SP
+4 4 -3 -4 2 989 1025 SP
+{0 0 0.502 C} FS
+1383 786 M
+-8 -1 D
+-9 0 D
+-8 -1 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 -1 D
+-9 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-93 3 D
+-84 6 D
+7 162 D
+16 222 D
+1 19 D
+89 -6 D
+97 -2 D
+89 2 D
+81 6 D
+15 -205 D
+8 -172 D
+P
+FO
+{1 0 0 C} FS
+-6 -2 -6 8 7 0 3 1028 1008 SP
+-20 16 20 9 2 1068 959 SP
+5 -9 -13 7 2 1066 993 SP
+-11 0 5 1 2 1047 1002 SP
+9 2 1 995 1025 SP
+-6 -2 -6 8 7 0 3 1028 1008 SP
+-20 16 20 9 2 1068 959 SP
+5 -9 -13 7 2 1066 993 SP
+-11 0 5 1 2 1047 1002 SP
+9 2 1 995 1025 SP
+{0 0 0.502 C} FS
+1763 855 M
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-8 -2 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 0 D
+-9 -1 D
+-8 -1 D
+-6 143 D
+-10 157 D
+-8 103 D
+65 7 D
+114 17 D
+75 16 D
+67 17 D
+13 4 D
+35 -154 D
+21 -126 D
+P
+FO
+1756 1269 M
+3 -4 D
+32 -17 D
+0 -12 D
+6 -3 D
+-17 -4 D
+27 -13 D
+5 8 D
+19 -12 D
+8 -25 D
+33 -14 D
+8 -11 D
+7 10 D
+-10 14 D
+-14 1 D
+-23 38 D
+-26 17 D
+-6 12 D
+-34 22 D
+28 10 D
+13 -18 D
+21 -14 D
+9 2 D
+3 -11 D
+27 -11 D
+-1 -14 D
+22 -3 D
+3 -8 D
+38 -21 D
+19 -23 D
+-1 -15 D
+5 -2 D
+-6 -6 D
+5 -6 D
+35 -20 D
+23 5 D
+14 -7 D
+16 1 D
+14 -65 D
+11 -65 D
+-11 -7 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-12 -6 D
+-11 -7 D
+-6 -2 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-7 -3 D
+-6 -3 D
+-6 -2 D
+-7 -3 D
+-13 -6 D
+-6 -2 D
+-7 -3 D
+-6 -2 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-7 -2 D
+-15 124 D
+-17 98 D
+-21 100 D
+-17 73 D
+P
+FO
+{1 0 0 C} FS
+-3 8 5 -3 2 1810 1267 SP
+4 0 1 1874 1219 SP
+10 -7 1 1791 1271 SP
+5 -2 1 1843 1182 SP
+-3 4 1 1877 1188 SP
+{0 0 0.502 C} FS
+-7 10 2 -6 -7 -3 3 2022 1136 SP
+-10 -4 4 -1 2 1992 1159 SP
+-5 8 -2 -7 2 1853 1289 SP
+7 -11 1 1942 1186 SP
+2 5 1 1955 1346 SP
+3 -6 1 1852 1265 SP
+4 -3 1 1866 1255 SP
+-3 -3 1 1916 1282 SP
+4 0 1 1980 1125 SP
+{1 0 0 C} FS
+1802 1286 M
+13 -18 D
+21 -14 D
+9 2 D
+3 -11 D
+27 -11 D
+-1 -14 D
+22 -3 D
+3 -8 D
+38 -21 D
+19 -23 D
+-1 -15 D
+5 -2 D
+-6 -6 D
+5 -6 D
+35 -20 D
+23 5 D
+14 -7 D
+16 1 D
+-20 75 D
+-33 100 D
+-29 74 D
+-19 -11 D
+-19 -10 D
+-19 -10 D
+-20 -10 D
+-21 -10 D
+-10 -4 D
+-11 -5 D
+-11 -5 D
+-11 -4 D
+-11 -4 D
+P
+FO
+1756 1269 M
+3 -4 D
+32 -17 D
+0 -12 D
+6 -3 D
+-17 -4 D
+27 -13 D
+5 8 D
+19 -12 D
+8 -25 D
+33 -14 D
+8 -11 D
+7 10 D
+-10 14 D
+-14 1 D
+-23 38 D
+-26 17 D
+-6 12 D
+-34 22 D
+-9 -3 D
+P
+FO
+-3 8 5 -3 2 1810 1267 SP
+4 0 1 1874 1219 SP
+10 -7 1 1791 1271 SP
+5 -2 1 1843 1182 SP
+-3 4 1 1877 1188 SP
+{0 0 0.502 C} FS
+-7 10 2 -6 -7 -3 3 2022 1136 SP
+-10 -4 4 -1 2 1992 1159 SP
+-5 8 -2 -7 2 1853 1289 SP
+7 -11 1 1942 1186 SP
+2 5 1 1955 1346 SP
+3 -6 1 1852 1265 SP
+4 -3 1 1866 1255 SP
+-3 -3 1 1916 1282 SP
+4 0 1 1980 1125 SP
+2252 1132 M
+-12 15 D
+-7 62 D
+-6 15 D
+-17 -1 D
+-26 -34 D
+-9 -3 D
+2 26 D
+-7 27 D
+-3 -2 D
+1 12 D
+5 -11 D
+-4 30 D
+-4 -1 D
+-2 38 D
+-14 -6 D
+-16 -28 D
+6 -35 D
+-3 -25 D
+-10 -2 D
+-19 -28 D
+-12 6 D
+-7 -5 D
+-42 48 D
+-21 60 D
+3 6 D
+2 -8 D
+-2 20 D
+-13 23 D
+-4 -3 D
+4 4 D
+-4 17 D
+6 11 D
+-5 3 D
+8 4 D
+-1 -5 D
+6 19 D
+-4 13 D
+7 1 D
+-1 -6 D
+6 13 D
+-2 5 D
+2 -5 D
+17 9 D
+2 9 D
+15 -6 D
+2 8 D
+4 -2 D
+-4 8 D
+5 1 D
+8 -7 D
+1 8 D
+-10 1 D
+2 10 D
+-5 -1 D
+35 33 D
+4 -5 D
+3 12 D
+5 6 D
+2 0 D
+17 -10 D
+7 -20 D
+3 6 D
+2 -11 D
+7 -7 D
+2 4 D
+11 -17 D
+8 0 D
+3 -8 D
+3 5 D
+2 -3 D
+-12 37 D
+-37 46 D
+7 10 D
+26 -48 D
+26 -55 D
+9 -21 D
+-9 -6 D
+-18 -34 D
+3 -15 D
+-4 -8 D
+7 9 D
+4 25 D
+7 8 D
+2 -2 D
+-3 -6 D
+5 -1 D
+14 10 D
+23 -60 D
+23 -77 D
+16 -69 D
+1 -8 D
+P
+FO
+-1 -1 5 0 -3 2 3 2235 1113 SP
+2047 1115 M
+48 3 D
+23 28 D
+42 -16 D
+32 10 D
+-3 0 D
+12 14 D
+3 -8 D
+-4 -4 D
+26 -16 D
+-2 -5 D
+3 0 D
+2 -14 D
+-21 -22 D
+-41 -35 D
+-36 -27 D
+-28 -19 D
+-21 -13 D
+-10 -6 D
+-8 50 D
+P
+FO
+1 -4 1 2036 1412 SP
+4 -8 1 2132 1505 SP
+{1 0 0 C} FS
+-2 -2 -4 4 3 6 3 2193 1341 SP
+0 5 1 2015 1346 SP
+2 5 1 2167 1287 SP
+3 2 1 2052 1414 SP
+3 2 1 2218 1317 SP
+2 9 1 2015 1350 SP
+3 0 1 2060 1414 SP
+-2 -5 1 2196 1218 SP
+-1 14 1 2016 1330 SP
+0 6 1 2173 1232 SP
+1 5 1 2026 1384 SP
+2 4 1 2157 1303 SP
+0 7 1 2177 1220 SP
+-2 10 1 2032 1277 SP
+{0 0 0.502 C} FS
+-8 -3 10 -4 2 2134 1163 SP
+-9 -4 12 -10 2 2221 1145 SP
+-5 2 4 -9 2 2164 1462 SP
+-5 -1 3 -4 2 2215 1147 SP
+0 -5 1 2005 1301 SP
+2 2 1 2160 1198 SP
+3 12 1 2174 1173 SP
+3 -3 1 2082 1169 SP
+-7 7 1 2000 1305 SP
+4 -4 1 2136 1495 SP
+3 -3 1 2055 1425 SP
+{1 0 0 C} FS
+2235 1113 M
+-3 2 D
+5 0 D
+15 17 D
+-12 15 D
+-7 62 D
+-6 15 D
+-17 -1 D
+-26 -34 D
+-9 -3 D
+2 26 D
+-7 27 D
+-3 -2 D
+1 12 D
+5 -11 D
+-4 30 D
+-4 -1 D
+-2 38 D
+-14 -6 D
+-16 -28 D
+6 -35 D
+-3 -25 D
+-10 -2 D
+-19 -28 D
+-12 6 D
+-7 -5 D
+-42 48 D
+-21 60 D
+3 6 D
+2 -8 D
+-2 20 D
+-13 23 D
+-4 -3 D
+4 4 D
+-4 17 D
+6 11 D
+-5 3 D
+8 4 D
+-1 -5 D
+6 19 D
+-4 13 D
+7 1 D
+-1 -6 D
+6 13 D
+-2 5 D
+2 -5 D
+17 9 D
+2 9 D
+15 -6 D
+2 8 D
+4 -2 D
+-4 8 D
+5 1 D
+8 -7 D
+1 8 D
+-10 1 D
+2 10 D
+-5 -1 D
+-28 -24 D
+-6 -4 D
+1 -4 D
+-1 4 D
+-27 -20 D
+-15 -10 D
+-22 -14 D
+-7 -4 D
+38 -99 D
+24 -75 D
+20 -75 D
+48 3 D
+23 28 D
+42 -16 D
+32 10 D
+-3 0 D
+12 14 D
+3 -8 D
+-4 -4 D
+26 -16 D
+-2 -5 D
+3 0 D
+2 -14 D
+P
+FO
+-3 6 -2 7 14 10 5 -1 -3 -6 2 -2 7 8 4 25 7 9 -4 -8 3 -15 -18 -34 -9 -6 13 2203 1394 SP
+2132 1505 M
+4 -8 D
+-4 8 D
+-15 -19 D
+2 0 D
+17 -10 D
+7 -20 D
+3 6 D
+2 -11 D
+7 -7 D
+2 4 D
+11 -17 D
+8 0 D
+3 -8 D
+3 5 D
+2 -3 D
+-12 37 D
+-37 46 D
+-1 -2 D
+P
+FO
+-4 -4 3 12 4 -5 3 2105 1473 SP
+-2 -2 -4 4 3 6 3 2193 1341 SP
+0 5 1 2015 1346 SP
+2 5 1 2167 1287 SP
+3 2 1 2052 1414 SP
+3 2 1 2218 1317 SP
+2 9 1 2015 1350 SP
+3 0 1 2060 1414 SP
+-2 -5 1 2196 1218 SP
+-1 14 1 2016 1330 SP
+0 6 1 2173 1232 SP
+1 5 1 2026 1384 SP
+2 4 1 2157 1303 SP
+0 7 1 2177 1220 SP
+-2 10 1 2032 1277 SP
+{0 0 0.502 C} FS
+-8 -3 10 -4 2 2134 1163 SP
+-9 -4 12 -10 2 2221 1145 SP
+-5 2 4 -9 2 2164 1462 SP
+-5 -1 3 -4 2 2215 1147 SP
+0 -5 1 2005 1301 SP
+2 2 1 2160 1198 SP
+3 12 1 2174 1173 SP
+3 -3 1 2082 1169 SP
+-7 7 1 2000 1305 SP
+4 -4 1 2136 1495 SP
+3 -3 1 2055 1425 SP
+2343 1333 M
+-2 3 D
+0 17 D
+-2 -26 D
+1 3 D
+0 -21 D
+-5 -2 D
+-4 -22 D
+-4 10 D
+-5 -7 D
+-4 9 D
+2 -12 D
+1 5 D
+1 -5 D
+-2 -1 D
+-2 -28 D
+4 -10 D
+-3 -8 D
+-1 17 D
+-5 11 D
+2 17 D
+-4 2 D
+-3 -37 D
+-4 -7 D
+1 -8 D
+-4 -3 D
+-1 -26 D
+1 -3 D
+-27 -41 D
+-8 38 D
+-15 62 D
+-20 61 D
+-20 53 D
+10 8 D
+10 -10 D
+6 6 D
+2 -4 D
+0 -15 D
+15 27 D
+2 14 D
+-11 -7 D
+-3 8 D
+-8 -8 D
+-29 2 D
+-2 -1 D
+-22 49 D
+-24 48 D
+-15 27 D
+19 28 D
+12 21 D
+13 29 D
+13 45 D
+5 44 D
+0 8 D
+31 -50 D
+17 -30 D
+29 -59 D
+31 -77 D
+19 -63 D
+13 -55 D
+P
+FO
+{1 0 0 C} FS
+7 -5 7 21 5 -1 0 -7 -9 -15 5 -5 2 -8 5 3 -1 -11 -12 -22 -4 4 -2 -6 0 9 -7 -4 -1 10 8 15 -1 12 17 2283 1389 SP
+4 -4 0 -5 -1 7 -2 -3 4 2210 1435 SP
+0 -9 2 -5 0 -10 -3 13 4 2344 1351 SP
+6 -2 -6 1 -6 14 3 -1 4 2194 1471 SP
+7 -4 -8 -14 -7 2 4 9 4 2256 1330 SP
+1 -6 -2 1 -1 9 3 2316 1447 SP
+3 -6 -4 -17 -1 11 3 2298 1438 SP
+8 -4 -7 2 -5 9 4 -6 4 2209 1464 SP
+4 -13 -7 5 -2 9 3 2205 1436 SP
+-1 -12 -2 7 2 2255 1422 SP
+2 -14 -1 6 2 2240 1440 SP
+4 1 -2 -3 2 2270 1387 SP
+-3 2 2 0 2 2321 1307 SP
+0 -2 1 7 -1 -4 3 2338 1335 SP
+1 0 1 2307 1458 SP
+1 4 1 2298 1444 SP
+-8 8 1 2232 1441 SP
+-2 3 1 2324 1428 SP
+-2 -10 1 2184 1478 SP
+1 -3 1 2319 1440 SP
+4 -4 -3 4 2 2223 1396 SP
+-2 7 1 2328 1414 SP
+7 -5 1 2214 1462 SP
+4 2 1 2214 1398 SP
+-1 5 1 2336 1376 SP
+1 -5 1 2339 1375 SP
+2 2 1 2245 1448 SP
+1 -2 1 2323 1314 SP
+2 0 1 2218 1399 SP
+2 1 1 2236 1443 SP
+0 4 1 2302 1444 SP
+-2 -3 1 2264 1410 SP
+4 0 1 2221 1442 SP
+{0 0 0.502 C} FS
+0 3 1 2333 1282 SP
+2 1 1 2277 1392 SP
+1 -3 1 2314 1262 SP
+{1 0 0 C} FS
+3 6 3 7 3 6 3 6 3 6 1 -3 0 -16 -1 -10 -4 -3 1 -8 -4 -7 -3 -37 -4 2 2 17 -5 11 -1 17 16 2319 1238 SP
+2343 1333 M
+-2 3 D
+0 17 D
+-2 -26 D
+1 3 D
+0 -21 D
+-5 -2 D
+-4 -22 D
+-4 10 D
+-5 -7 D
+-4 9 D
+2 -12 D
+1 5 D
+1 -5 D
+-2 -1 D
+-2 -28 D
+4 -10 D
+8 22 D
+9 36 D
+P
+FO
+3 -6 3 -7 -2 -1 -29 2 -8 -8 -3 8 -11 -7 2 14 15 27 0 -15 2 -4 6 6 10 -10 10 8 14 2211 1374 SP
+7 -5 7 21 5 -1 0 -7 -9 -15 5 -5 2 -8 5 3 -1 -11 -12 -22 -4 4 -2 -6 0 9 -7 -4 -1 10 8 15 -1 12 17 2283 1389 SP
+4 -4 0 -5 -1 7 -2 -3 4 2210 1435 SP
+0 -9 2 -5 0 -10 -3 13 4 2344 1351 SP
+6 -2 -6 1 -6 14 3 -1 4 2194 1471 SP
+7 -4 -8 -14 -7 2 4 9 4 2256 1330 SP
+1 -6 -2 1 -1 9 3 2316 1447 SP
+3 -6 -4 -17 -1 11 3 2298 1438 SP
+8 -4 -7 2 -5 9 4 -6 4 2209 1464 SP
+4 -13 -7 5 -2 9 3 2205 1436 SP
+-1 -12 -2 7 2 2255 1422 SP
+2 -14 -1 6 2 2240 1440 SP
+4 1 -2 -3 2 2270 1387 SP
+-3 2 2 0 2 2321 1307 SP
+0 -2 1 7 -1 -4 3 2338 1335 SP
+1 0 1 2307 1458 SP
+1 4 1 2298 1444 SP
+-8 8 1 2232 1441 SP
+-2 3 1 2324 1428 SP
+-2 -10 1 2184 1478 SP
+1 -3 1 2319 1440 SP
+4 -4 -3 4 2 2223 1396 SP
+-2 7 1 2328 1414 SP
+7 -5 1 2214 1462 SP
+4 2 1 2214 1398 SP
+-1 5 1 2336 1376 SP
+1 -5 1 2339 1375 SP
+2 2 1 2245 1448 SP
+1 -2 1 2323 1314 SP
+2 0 1 2218 1399 SP
+2 1 1 2236 1443 SP
+0 4 1 2302 1444 SP
+-2 -3 1 2264 1410 SP
+4 0 1 2221 1442 SP
+{0 0 0.502 C} FS
+0 3 1 2333 1282 SP
+2 1 1 2277 1392 SP
+1 -3 1 2314 1262 SP
+2338 1418 M
+6 -42 D
+0 -17 D
+-17 71 D
+-21 63 D
+-18 46 D
+-29 60 D
+-11 22 D
+-30 50 D
+-14 22 D
+-2 29 D
+-5 30 D
+-11 37 D
+-17 36 D
+-17 28 D
+-7 10 D
+29 -41 D
+38 -65 D
+29 -55 D
+41 -92 D
+25 -71 D
+23 -84 D
+P
+FO
+{1 0 0 C} FS
+-1 3 1 2331 1418 SP
+-1 3 1 2331 1418 SP
+{0 0 0.502 C} FS
+24 1418 M
+-5 -31 D
+-1 -16 D
+-4 -13 D
+4 12 D
+-2 -23 D
+-5 -24 D
+-9 -77 D
+-2 -48 D
+3 65 D
+6 65 D
+P
+FO
+{1 0 0 C} FS
+-2 -12 -1 -13 -2 -13 -1 -8 1 10 0 -5 2 16 1 8 0 1 0 7 0 1 2 18 0 -3 1 13 0 -7 15 4 1281 SP
+0 -5 1 4 1274 SP
+0 -3 1 4 1281 SP
+0 1 1 11 1339 SP
+0 4 1 13 1351 SP
+0 3 0 -4 0 -6 3 0 1191 SP
+0 -1 1 5 1274 SP
+3 11 1 1 -4 -13 3 18 1371 SP
+-2 -12 -1 -13 -2 -13 -1 -8 1 10 0 -5 2 16 1 8 0 1 0 7 0 1 2 18 0 -3 1 13 0 -7 15 4 1281 SP
+0 -5 1 4 1274 SP
+0 -3 1 4 1281 SP
+0 1 1 11 1339 SP
+0 4 1 13 1351 SP
+{0 0 0.502 C} FS
+21 958 M
+1 -1 D
+-12 68 D
+-5 50 D
+0 -2 D
+-4 62 D
+0 -6 D
+1 3 D
+-1 18 D
+0 -6 D
+-1 41 D
+3 -41 D
+2 14 D
+-2 -3 D
+-3 41 D
+0 -7 D
+0 7 D
+0 -5 D
+2 55 D
+6 53 D
+5 36 D
+5 24 D
+1 -28 D
+-1 1 D
+-2 -21 D
+4 15 D
+-2 -11 D
+2 7 D
+1 -4 D
+-2 -7 D
+2 -3 D
+1 5 D
+2 -16 D
+11 -39 D
+13 -30 D
+11 -23 D
+29 -45 D
+-11 -71 D
+-5 -79 D
+-1 -47 D
+1 -23 D
+-15 34 D
+-4 1 D
+0 -6 D
+-4 6 D
+-3 -10 D
+-3 2 D
+-4 21 D
+0 -5 D
+-4 43 D
+-7 22 D
+-5 3 D
+-1 -7 D
+4 -12 D
+2 -17 D
+8 -13 D
+-1 -9 D
+-3 10 D
+-2 -2 D
+-3 8 D
+6 -32 D
+2 -2 D
+1 13 D
+-1 -8 D
+8 -21 D
+-2 0 D
+23 -62 D
+2 -2 D
+1 -12 D
+5 -14 D
+-2 2 D
+5 -10 D
+-4 4 D
+4 -11 D
+1 -10 D
+6 -6 D
+6 -33 D
+-20 29 D
+-20 38 D
+-13 31 D
+-11 41 D
+P
+FO
+{1 0 0 C} FS
+11 1234 M
+1 2 D
+-1 -11 D
+2 21 D
+2 7 D
+-1 -23 D
+1 11 D
+2 2 D
+6 58 D
+-3 -17 D
+-1 8 D
+-2 -8 D
+0 5 D
+-3 -4 D
+2 17 D
+-4 -2 D
+-3 -18 D
+3 11 D
+0 -16 D
+1 6 D
+0 -14 D
+-3 -16 D
+P
+FO
+-1 15 2 -20 1 -26 -2 -15 0 17 1 3 -3 -1 0 9 2 0 -2 18 3 -15 -1 14 12 12 1094 SP
+-5 17 -3 21 4 -19 5 -13 1 -10 0 7 1 -8 7 13 1044 SP
+-2 -9 -6 9 0 7 5 -3 4 70 851 SP
+0 1 1 5 1069 SP
+-1 -1 -3 16 2 6 1 -15 4 43 929 SP
+1 -7 -1 12 -1 3 0 3 0 1 5 7 1053 SP
+1 -3 0 -9 2 10 1098 SP
+0 -1 1 -5 -1 4 0 3 4 17 981 SP
+2 -9 -1 -3 -1 7 3 12 1072 SP
+-2 14 1 -1 3 -17 3 8 1061 SP
+-4 11 1 0 2 22 1062 SP
+-2 10 1 -6 2 18 980 SP
+-6 18 2 -3 2 46 998 SP
+-1 8 1 -1 2 2 1123 SP
+-9 18 6 -8 2 46 986 SP
+0 9 1 -1 2 13 1132 SP
+-2 3 0 5 2 20 1040 SP
+-2 3 0 7 2 22 1045 SP
+1 0 -1 -6 2 9 1281 SP
+2 -10 -1 6 2 7 1087 SP
+1 -11 0 6 2 7 1079 SP
+0 -4 1 1 1154 SP
+1 -2 1 14 1035 SP
+0 -6 1 16 1085 SP
+1 -2 1 41 1001 SP
+3 -3 1 73 846 SP
+-2 5 1 29 939 SP
+0 9 1 36 944 SP
+0 -7 1 8 1191 SP
+0 1 1 1 1153 SP
+1 0 1 9 1101 SP
+2 -3 1 20 1058 SP
+1 -8 1 34 953 SP
+2 4 1 47 1167 SP
+-1 5 1 24 953 SP
+0 -3 1 17 1309 SP
+1 -4 1 34 935 SP
+1 -1 1 20 1065 SP
+1 -2 1 10 1082 SP
+1 -6 1 35 972 SP
+-2 11 2 -6 2 4 1100 SP
+1 -2 1 17 1060 SP
+-1 -9 0 9 2 34 926 SP
+{0 0 0.502 C} FS
+0 -1 0 -2 2 2 1118 SP
+{1 0 0 C} FS
+-4 18 1 -1 2 21 958 SP
+72 940 M
+-15 34 D
+-4 1 D
+0 -6 D
+-4 6 D
+-3 -10 D
+-3 2 D
+-4 21 D
+0 -5 D
+-4 43 D
+-7 22 D
+-5 3 D
+-1 -7 D
+4 -12 D
+2 -17 D
+8 -13 D
+-1 -9 D
+-3 10 D
+-2 -2 D
+-3 8 D
+6 -32 D
+2 -2 D
+1 13 D
+-1 -8 D
+8 -21 D
+-2 0 D
+23 -62 D
+2 -2 D
+1 -12 D
+5 -14 D
+-2 2 D
+5 -10 D
+-4 4 D
+4 -11 D
+1 -10 D
+6 -6 D
+-9 76 D
+P
+FO
+0 -3 1 24 1297 SP
+-1 2 1 5 2 -3 -1 -6 -1 -1 5 21 1318 SP
+2 7 -2 -8 2 20 1323 SP
+-1 3 3 13 1 2 -2 -21 -1 1 5 19 1331 SP
+0 1 1 5 1273 SP
+5 1075 M
+0 -2 D
+-4 62 D
+0 -6 D
+1 3 D
+-1 18 D
+0 -6 D
+-1 41 D
+3 -41 D
+2 14 D
+-2 -3 D
+-3 41 D
+0 -7 D
+0 7 D
+1 -68 D
+P
+FO
+11 1234 M
+1 2 D
+-1 -11 D
+2 21 D
+2 7 D
+-1 -23 D
+1 11 D
+2 2 D
+6 58 D
+-3 -17 D
+-1 8 D
+-2 -8 D
+0 5 D
+-3 -4 D
+2 17 D
+-4 -2 D
+-3 -18 D
+3 11 D
+0 -16 D
+1 6 D
+0 -14 D
+-3 -16 D
+P
+FO
+-1 15 2 -20 1 -26 -2 -15 0 17 1 3 -3 -1 0 9 2 0 -2 18 3 -15 -1 14 12 12 1094 SP
+-5 17 -3 21 4 -19 5 -13 1 -10 0 7 1 -8 7 13 1044 SP
+-2 -9 -6 9 0 7 5 -3 4 70 851 SP
+0 1 1 5 1069 SP
+-1 -1 -3 16 2 6 1 -15 4 43 929 SP
+1 -7 -1 12 -1 3 0 3 0 1 5 7 1053 SP
+1 -3 0 -9 2 10 1098 SP
+0 -1 1 -5 -1 4 0 3 4 17 981 SP
+2 -9 -1 -3 -1 7 3 12 1072 SP
+-2 14 1 -1 3 -17 3 8 1061 SP
+-4 11 1 0 2 22 1062 SP
+-2 10 1 -6 2 18 980 SP
+-6 18 2 -3 2 46 998 SP
+-1 8 1 -1 2 2 1123 SP
+-9 18 6 -8 2 46 986 SP
+0 9 1 -1 2 13 1132 SP
+-2 3 0 5 2 20 1040 SP
+-2 3 0 7 2 22 1045 SP
+1 0 -1 -6 2 9 1281 SP
+2 -10 -1 6 2 7 1087 SP
+1 -11 0 6 2 7 1079 SP
+0 -4 1 1 1154 SP
+1 -2 1 14 1035 SP
+0 -6 1 16 1085 SP
+1 -2 1 41 1001 SP
+3 -3 1 73 846 SP
+-2 5 1 29 939 SP
+0 9 1 36 944 SP
+0 -7 1 8 1191 SP
+0 1 1 1 1153 SP
+1 0 1 9 1101 SP
+2 -3 1 20 1058 SP
+1 -8 1 34 953 SP
+2 4 1 47 1167 SP
+-1 5 1 24 953 SP
+0 -3 1 17 1309 SP
+1 -4 1 34 935 SP
+1 -1 1 20 1065 SP
+1 -2 1 10 1082 SP
+1 -6 1 35 972 SP
+-2 11 2 -6 2 4 1100 SP
+1 -2 1 17 1060 SP
+-1 -9 0 9 2 34 926 SP
+{0 0 0.502 C} FS
+0 -1 0 -2 2 2 1118 SP
+185 704 M
+-4 7 D
+3 -7 D
+-11 10 D
+-3 4 D
+3 1 D
+-8 9 D
+-2 8 D
+-6 4 D
+-7 22 D
+-11 19 D
+-3 14 D
+8 -6 D
+-3 11 D
+-19 28 D
+0 10 D
+-13 31 D
+-37 71 D
+-1 54 D
+5 79 D
+4 39 D
+8 48 D
+25 -32 D
+21 -23 D
+8 -7 D
+7 -8 D
+42 -37 D
+57 -42 D
+42 -26 D
+-11 -98 D
+-3 -104 D
+5 -85 D
+6 -52 D
+2 -7 D
+-1 0 D
+-4 5 D
+-1 -3 D
+6 -5 D
+1 -6 D
+-19 11 D
+-37 25 D
+-42 31 D
+P
+FO
+82 838 M
+12 -31 D
+7 -8 D
+4 -8 D
+5 3 D
+-11 21 D
+12 -15 D
+-4 8 D
+5 -6 D
+-4 12 D
+8 -15 D
+-2 8 D
+2 -6 D
+1 3 D
+2 -7 D
+12 -17 D
+20 -46 D
+-18 17 D
+-36 41 D
+-9 13 D
+P
+FO
+{1 0 0 C} FS
+14 -24 -16 13 -1 -7 -1 9 -8 7 -8 -4 3 -13 -7 4 -3 6 4 7 -2 9 10 1 12 175 771 SP
+-18 34 5 -3 8 -15 3 219 734 SP
+8 -26 17 -32 -25 46 3 193 787 SP
+8 -10 -2 -4 2 252 684 SP
+4 -5 -8 6 3 -1 3 130 874 SP
+-21 29 13 -16 2 272 670 SP
+3 -8 -2 3 2 143 806 SP
+-1 6 3 -5 2 251 676 SP
+-16 22 8 -6 2 245 699 SP
+1 3 1 247 685 SP
+6 -9 1 176 719 SP
+5 -6 1 159 841 SP
+-6 6 1 203 701 SP
+3 -5 1 173 723 SP
+3 -7 1 240 697 SP
+2 -6 1 212 756 SP
+1 -4 1 261 670 SP
+2 -3 1 133 819 SP
+3 -4 1 108 801 SP
+3 -3 1 254 671 SP
+-3 2 1 170 824 SP
+0 -3 1 123 842 SP
+2 -4 1 259 943 SP
+3 -4 1 153 865 SP
+5 -9 1 107 801 SP
+2 -6 1 180 729 SP
+{0 0 0.502 C} FS
+2 -7 1 89 846 SP
+-2 2 1 77 927 SP
+{1 0 0 C} FS
+173 714 M
+-3 4 D
+3 1 D
+-8 9 D
+-2 8 D
+-6 4 D
+-7 22 D
+-11 19 D
+-3 14 D
+8 -6 D
+-3 11 D
+-19 28 D
+0 10 D
+-13 31 D
+-37 71 D
+3 -45 D
+7 -57 D
+12 -31 D
+7 -8 D
+4 -8 D
+5 3 D
+-11 21 D
+12 -15 D
+-4 8 D
+5 -6 D
+-4 12 D
+8 -15 D
+-2 8 D
+2 -6 D
+1 3 D
+2 -7 D
+12 -17 D
+20 -46 D
+14 -14 D
+P
+FO
+3 -7 -4 7 2 185 704 SP
+0 1 6 -5 -1 -3 -4 5 -1 0 5 289 639 SP
+14 -24 -16 13 -1 -7 -1 9 -8 7 -8 -4 3 -13 -7 4 -3 6 4 7 -2 9 10 1 12 175 771 SP
+-18 34 5 -3 8 -15 3 219 734 SP
+8 -26 17 -32 -25 46 3 193 787 SP
+8 -10 -2 -4 2 252 684 SP
+4 -5 -8 6 3 -1 3 130 874 SP
+-21 29 13 -16 2 272 670 SP
+3 -8 -2 3 2 143 806 SP
+-1 6 3 -5 2 251 676 SP
+-16 22 8 -6 2 245 699 SP
+1 3 1 247 685 SP
+6 -9 1 176 719 SP
+5 -6 1 159 841 SP
+-6 6 1 203 701 SP
+3 -5 1 173 723 SP
+3 -7 1 240 697 SP
+2 -6 1 212 756 SP
+1 -4 1 261 670 SP
+2 -3 1 133 819 SP
+3 -4 1 108 801 SP
+3 -3 1 254 671 SP
+-3 2 1 170 824 SP
+0 -3 1 123 842 SP
+2 -4 1 259 943 SP
+3 -4 1 153 865 SP
+5 -9 1 107 801 SP
+2 -6 1 180 729 SP
+{0 0 0.502 C} FS
+2 -7 1 89 846 SP
+-2 2 1 77 927 SP
+289 636 M
+12 -10 D
+-12 13 D
+-5 30 D
+-6 67 D
+-2 79 D
+4 80 D
+10 90 D
+51 -28 D
+18 -10 D
+55 -26 D
+86 -34 D
+70 -23 D
+30 -9 D
+-7 -86 D
+-2 -83 D
+1 -96 D
+7 -83 D
+1 -7 D
+-51 15 D
+-62 22 D
+-73 29 D
+-85 41 D
+-11 7 D
+-28 16 D
+P
+FO
+{1 0 0 C} FS
+-14 28 6 -9 2 301 634 SP
+4 -9 1 306 630 SP
+4 -4 1 289 645 SP
+-2 5 1 471 740 SP
+5 -3 1 444 853 SP
+0 -2 -12 13 12 -10 3 289 636 SP
+-14 28 6 -9 2 301 634 SP
+4 -9 1 306 630 SP
+4 -4 1 289 645 SP
+-2 5 1 471 740 SP
+5 -3 1 444 853 SP
+{0 0 0.502 C} FS
+979 431 M
+-131 15 D
+-96 17 D
+-78 17 D
+-74 20 D
+-6 59 D
+-3 78 D
+1 115 D
+8 103 D
+82 -22 D
+101 -21 D
+105 -16 D
+91 -10 D
+-3 -178 D
+1 -126 D
+P
+FO
+1383 431 M
+-8 -1 D
+-9 -1 D
+-8 0 D
+-8 -1 D
+-9 -1 D
+-8 0 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-9 0 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-8 -1 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 -1 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-118 5 D
+-42 4 D
+-3 152 D
+1 142 D
+2 61 D
+109 -7 D
+110 -2 D
+101 3 D
+84 6 D
+3 -154 D
+-1 -157 D
+P
+FO
+{1 0 0 C} FS
+8 -3 -4 -2 2 1030 631 SP
+5 -1 1 1379 449 SP
+8 -3 -4 -2 2 1030 631 SP
+5 -1 1 1379 449 SP
+{0 0 0.502 C} FS
+1763 500 M
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-9 -1 D
+-8 0 D
+3 128 D
+-1 175 D
+-2 52 D
+124 14 D
+104 18 D
+100 23 D
+52 14 D
+6 -86 D
+3 -115 D
+-4 -95 D
+P
+FO
+2072 630 M
+-11 -7 D
+-11 -6 D
+-11 -6 D
+-12 -7 D
+-12 -6 D
+-11 -6 D
+-12 -6 D
+-7 -3 D
+-6 -3 D
+-6 -2 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-7 -2 D
+-13 -6 D
+-6 -2 D
+-7 -3 D
+-6 -3 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-13 -6 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+6 75 D
+3 111 D
+-4 100 D
+-5 69 D
+85 27 D
+81 31 D
+81 37 D
+11 7 D
+40 21 D
+11 7 D
+7 -59 D
+5 -59 D
+2 -74 D
+-3 -71 D
+-8 -77 D
+P
+FO
+2229 1107 M
+1 -2 D
+6 -1 D
+1 7 D
+-2 2 D
+3 2 D
+12 -7 D
+2 -10 D
+2 1 D
+-1 6 D
+5 -8 D
+1 7 D
+8 7 D
+3 -7 D
+3 8 D
+3 -12 D
+3 5 D
+2 10 D
+7 -55 D
+3 -67 D
+-1 -1 D
+1 -11 D
+-4 -14 D
+2 -2 D
+-5 -13 D
+0 -23 D
+4 -1 D
+2 9 D
+0 -6 D
+-2 -3 D
+1 -3 D
+1 3 D
+-1 -9 D
+-10 -28 D
+0 -20 D
+-2 -8 D
+6 -3 D
+-9 -55 D
+-25 -32 D
+-28 -31 D
+-50 -44 D
+-37 -28 D
+-30 -21 D
+-21 -13 D
+-11 -6 D
+7 45 D
+5 62 D
+2 73 D
+-3 74 D
+-8 84 D
+-3 17 D
+31 19 D
+55 39 D
+34 28 D
+23 21 D
+P
+FO
+1 -6 7 10 7 9 8 9 -9 12 -3 -4 1 -3 -7 -1 -6 -19 9 2276 1147 SP
+0 3 0 -1 2 2277 1142 SP
+0 -7 1 -6 3 11 -5 8 4 2281 1115 SP
+{1 0 0 C} FS
+-5 -9 6 -7 -3 -5 -6 12 3 6 5 2193 859 SP
+4 7 1 2208 873 SP
+1 -3 1 2269 1099 SP
+4 4 1 2198 870 SP
+-1 -4 2 4 2 2287 918 SP
+-3 1 3 0 2 2186 865 SP
+3 2 1 2195 873 SP
+1 12 1 12 1 12 2 12 6 -3 -2 -8 0 -20 -10 -28 8 2289 919 SP
+1 3 1 -3 -2 -3 3 2290 931 SP
+0 11 1 11 0 11 2 9 4 -1 0 -23 -5 -13 2 -2 -4 -14 9 2291 981 SP
+0 4 1 -6 -1 -1 3 2291 993 SP
+2281 1115 M
+-5 8 D
+3 11 D
+-2 8 D
+0 -1 D
+-1 6 D
+-6 -19 D
+-7 -1 D
+1 -3 D
+-3 -4 D
+-9 12 D
+-15 -17 D
+13 -7 D
+2 -10 D
+2 1 D
+-1 6 D
+5 -8 D
+1 7 D
+8 7 D
+3 -7 D
+3 8 D
+3 -12 D
+3 5 D
+P
+FO
+-3 -3 -2 2 1 7 6 -1 1 -2 5 2229 1107 SP
+-5 -9 6 -7 -3 -5 -6 12 3 6 5 2193 859 SP
+4 7 1 2208 873 SP
+1 -3 1 2269 1099 SP
+4 4 1 2198 870 SP
+-1 -4 2 4 2 2287 918 SP
+-3 1 3 0 2 2186 865 SP
+3 2 1 2195 873 SP
+{0 0 0.502 C} FS
+2 11 2 11 2 11 2 11 -6 -8 -6 -9 -1 -23 4 -15 8 2283 860 SP
+0 5 -3 -17 1 -5 1 4 0 3 0 3 0 3 7 2290 928 SP
+0 3 0 -2 0 -3 3 2291 986 SP
+2281 1115 M
+-2 19 D
+2 11 D
+-1 1 D
+-3 -4 D
+0 7 D
+-1 -2 D
+-2 13 D
+27 41 D
+2 -9 D
+-5 -29 D
+3 -10 D
+-10 11 D
+-8 -2 D
+-5 -6 D
+-1 -7 D
+4 -4 D
+2 6 D
+7 -6 D
+2 5 D
+-1 -13 D
+10 -13 D
+3 -45 D
+4 0 D
+-3 -30 D
+-5 -12 D
+0 -12 D
+-3 -7 D
+1 -9 D
+-7 -16 D
+-4 74 D
+P
+FO
+2 4 0 5 -4 9 -2 -11 1 -7 2 -4 6 2322 1246 SP
+2 -9 2 -9 0 9 0 8 1 9 -1 1 0 -8 -2 0 -3 15 0 -8 0 1 11 2349 1332 SP
+0 -4 1 1 4 21 1 8 -5 -27 -1 -2 0 7 7 2361 1131 SP
+2359 1091 M
+-3 -26 D
+1 10 D
+-1 -7 D
+0 10 D
+-5 -18 D
+-3 -25 D
+-5 -22 D
+1 0 D
+-3 -11 D
+0 5 D
+-5 -10 D
+-1 6 D
+-5 -16 D
+2 6 D
+-1 0 D
+2 2 D
+2 9 D
+1 -6 D
+5 10 D
+1 -5 D
+9 58 D
+5 22 D
+1 -9 D
+P
+FO
+0 -11 -3 -4 0 -12 0 -38 0 3 4 -15 -3 13 -1 6 1 42 2 3 1 13 0 17 -1 21 13 2345 1215 SP
+-2 12 2 -18 2 2350 1291 SP
+0 4 1 2348 1323 SP
+0 -4 1 2349 1324 SP
+0 2 1 2358 1083 SP
+{1 0 0 C} FS
+0 -3 1 2348 1315 SP
+2359 1091 M
+-3 -26 D
+1 10 D
+-1 -7 D
+0 10 D
+-5 -18 D
+-3 -25 D
+-5 -22 D
+1 0 D
+-3 -11 D
+0 5 D
+-5 -10 D
+-1 6 D
+-5 -16 D
+2 6 D
+-1 0 D
+2 2 D
+2 9 D
+1 -6 D
+5 10 D
+1 -5 D
+9 58 D
+5 22 D
+1 -9 D
+4 57 D
+0 7 D
+-6 -29 D
+6 30 D
+0 -4 D
+1 79 D
+-7 82 D
+-6 37 D
+0 -8 D
+-3 15 D
+-2 0 D
+0 -8 D
+-1 1 D
+-7 -44 D
+-11 -36 D
+-3 -7 D
+3 -11 D
+-2 -11 D
+-4 9 D
+0 5 D
+-18 -37 D
+2 -9 D
+-5 -29 D
+3 -10 D
+-10 11 D
+-8 -2 D
+-5 -6 D
+-1 -7 D
+4 -4 D
+2 6 D
+7 -6 D
+2 5 D
+-1 -13 D
+10 -13 D
+3 -45 D
+4 0 D
+-3 -30 D
+-5 -12 D
+0 -12 D
+-3 -7 D
+1 -9 D
+-7 -16 D
+-1 -56 D
+1 4 D
+1 -5 D
+-5 -40 D
+-4 -36 D
+4 -15 D
+-1 -23 D
+19 32 D
+19 41 D
+8 25 D
+9 37 D
+11 67 D
+P
+FO
+1 -1 -1 -2 0 5 3 2277 1144 SP
+1 -4 -2 -2 -1 -2 -1 1 2 11 5 2279 1134 SP
+0 3 1 2290 928 SP
+{0 0 0.502 C} FS
+0 -11 -3 -4 0 -12 0 -38 0 3 4 -15 -3 13 -1 6 1 42 2 3 1 13 0 17 -1 21 13 2345 1215 SP
+-2 12 2 -18 2 2350 1291 SP
+0 4 1 2348 1323 SP
+0 -4 1 2349 1324 SP
+0 2 1 2358 1083 SP
+{1 0 0 C} FS
+0 -3 1 2348 1315 SP
+{0 0 0.502 C} FS
+2354 1320 M
+1 -6 D
+-2 7 D
+2 -13 D
+-4 24 D
+-2 0 D
+-5 27 D
+-1 25 D
+-5 34 D
+8 -42 D
+P
+FO
+{1 0 0 C} FS
+2354 1320 M
+1 -6 D
+-2 7 D
+2 -13 D
+-4 24 D
+-2 0 D
+8 -51 D
+5 -82 D
+0 -5 D
+-3 76 D
+P
+FO
+{0 0 0.502 C} FS
+24 944 M
+11 -41 D
+16 -38 D
+22 -38 D
+15 -22 D
+17 -71 D
+18 -54 D
+-30 57 D
+-12 29 D
+-5 23 D
+3 -5 D
+-3 8 D
+2 2 D
+-5 12 D
+0 -5 D
+-3 10 D
+-2 1 D
+-4 10 D
+-2 2 D
+-3 10 D
+-2 2 D
+-10 27 D
+6 -15 D
+2 -10 D
+-7 17 D
+2 -8 D
+-3 8 D
+2 -7 D
+-1 5 D
+3 -11 D
+-2 2 D
+8 -26 D
+-3 9 D
+2 -6 D
+-24 86 D
+P
+FO
+{1 0 0 C} FS
+0 2 6 -19 -4 11 1 -1 4 44 869 SP
+-4 13 4 -6 0 -4 3 82 772 SP
+-3 11 3 -6 2 42 872 SP
+1 0 1 70 813 SP
+3 -4 1 112 703 SP
+1 -7 1 50 860 SP
+0 2 1 69 812 SP
+0 4 1 71 814 SP
+{0 0 0.502 C} FS
+-1 5 1 88 735 SP
+{1 0 0 C} FS
+123 680 M
+-30 57 D
+-12 29 D
+-5 23 D
+3 -5 D
+-3 8 D
+2 2 D
+-5 12 D
+0 -5 D
+-3 10 D
+-2 1 D
+-4 10 D
+-2 2 D
+-3 10 D
+-2 2 D
+-10 27 D
+6 -15 D
+2 -10 D
+-7 17 D
+2 -8 D
+-3 8 D
+2 -7 D
+-1 5 D
+3 -11 D
+-2 2 D
+8 -26 D
+-3 9 D
+2 -6 D
+-3 11 D
+25 -73 D
+24 -59 D
+28 -58 D
+31 -56 D
+48 -76 D
+11 -15 D
+-31 46 D
+-17 30 D
+-31 63 D
+P
+FO
+0 2 6 -19 -4 11 1 -1 4 44 869 SP
+-4 13 4 -6 0 -4 3 82 772 SP
+-3 11 3 -6 2 42 872 SP
+1 0 1 70 813 SP
+3 -4 1 112 703 SP
+1 -7 1 50 860 SP
+0 2 1 69 812 SP
+0 4 1 71 814 SP
+{0 0 0.502 C} FS
+-1 5 1 88 735 SP
+326 389 M
+-8 15 D
+-17 22 D
+-9 17 D
+-28 38 D
+-13 15 D
+-10 18 D
+2 -5 D
+-9 13 D
+4 -8 D
+-4 6 D
+-1 -1 D
+-23 42 D
+-31 42 D
+-14 33 D
+-7 13 D
+-8 24 D
+-11 20 D
+-5 3 D
+-25 73 D
+-2 -1 D
+3 -16 D
+-1 -5 D
+3 -5 D
+2 -16 D
+7 -21 D
+6 -32 D
+-4 7 D
+-20 61 D
+-15 64 D
+19 -25 D
+38 -41 D
+6 -5 D
+1 -3 D
+20 -22 D
+6 -10 D
+6 2 D
+-10 10 D
+-1 3 D
+11 -10 D
+3 -5 D
+-2 5 D
+7 -7 D
+60 -44 D
+28 -18 D
+10 -5 D
+12 -59 D
+19 -70 D
+23 -59 D
+26 -55 D
+24 -41 D
+4 -5 D
+-23 14 D
+-28 19 D
+P
+FO
+{1 0 0 C} FS
+-6 12 3 -4 2 287 451 SP
+3 -5 1 303 427 SP
+7 -10 1 212 663 SP
+-2 3 1 308 418 SP
+4 -3 1 202 680 SP
+326 389 M
+-8 15 D
+-17 22 D
+-9 17 D
+-28 38 D
+-13 15 D
+-10 18 D
+2 -5 D
+-9 13 D
+4 -8 D
+-4 6 D
+-1 -1 D
+-23 42 D
+-31 42 D
+-14 33 D
+-7 13 D
+-8 24 D
+-11 20 D
+-5 3 D
+-25 73 D
+-2 -1 D
+3 -16 D
+-1 -5 D
+3 -5 D
+2 -16 D
+7 -21 D
+6 -32 D
+-4 7 D
+24 -59 D
+28 -56 D
+33 -53 D
+28 -38 D
+31 -34 D
+28 -26 D
+P
+FO
+-2 5 3 -5 2 184 704 SP
+-7 7 -8 6 -1 3 -10 10 6 2 6 -10 20 -22 1 -3 8 151 734 SP
+-6 12 3 -4 2 287 451 SP
+3 -5 1 303 427 SP
+7 -10 1 212 663 SP
+-2 3 1 308 418 SP
+4 -3 1 202 680 SP
+{0 0 0.502 C} FS
+614 405 M
+-24 -2 D
+25 -6 D
+-1 4 D
+-7 -1 D
+7 5 D
+2 -10 D
+-1 -2 D
+1 1 D
+16 -66 D
+19 -56 D
+16 -40 D
+3 -5 D
+-57 17 D
+-66 24 D
+-84 37 D
+-61 33 D
+-4 3 D
+-11 17 D
+-26 47 D
+-25 56 D
+-19 54 D
+-17 63 D
+-10 52 D
+34 -19 D
+11 -7 D
+60 -29 D
+65 -28 D
+40 -15 D
+85 -28 D
+15 -4 D
+4 -37 D
+P
+FO
+{1 0 0 C} FS
+-8 10 5 -2 6 -9 -3 0 4 412 482 SP
+12 -8 -14 -5 -10 13 3 597 385 SP
+-13 18 7 -2 5 -11 3 397 502 SP
+-17 19 5 -3 2 319 601 SP
+-5 6 5 -3 2 448 428 SP
+20 -25 -53 52 2 436 393 SP
+-3 8 1 425 476 SP
+6 -4 1 426 466 SP
+8 -1 1 590 373 SP
+-4 -1 1 419 488 SP
+2 1 1 407 507 SP
+1 4 1 420 419 SP
+-7 6 1 435 409 SP
+7 -3 1 430 451 SP
+5 -3 1 422 474 SP
+-5 5 1 447 396 SP
+5 -4 1 453 419 SP
+-4 2 1 375 572 SP
+1 1 -1 -2 2 616 395 SP
+-7 -1 -1 4 25 -6 -24 -2 4 614 405 SP
+-8 10 5 -2 6 -9 -3 0 4 412 482 SP
+12 -8 -14 -5 -10 13 3 597 385 SP
+-13 18 7 -2 5 -11 3 397 502 SP
+-17 19 5 -3 2 319 601 SP
+-5 6 5 -3 2 448 428 SP
+20 -25 -53 52 2 436 393 SP
+-3 8 1 425 476 SP
+6 -4 1 426 466 SP
+8 -1 1 590 373 SP
+-4 -1 1 419 488 SP
+2 1 1 407 507 SP
+1 4 1 420 419 SP
+-7 6 1 435 409 SP
+7 -3 1 430 451 SP
+5 -3 1 422 474 SP
+-5 5 1 447 396 SP
+5 -4 1 453 419 SP
+-4 2 1 375 572 SP
+{0 0 0.502 C} FS
+616 394 M
+2 3 D
+-2 -2 D
+-14 80 D
+-2 25 D
+105 -27 D
+78 -16 D
+89 -14 D
+107 -12 D
+6 -109 D
+12 -116 D
+6 -40 D
+-87 10 D
+-92 14 D
+-95 21 D
+-59 16 D
+-9 19 D
+-20 53 D
+-18 64 D
+P
+FO
+{1 0 0 C} FS
+-12 5 7 -2 2 755 402 SP
+13 -5 1 735 413 SP
+6 -2 1 709 315 SP
+6 0 1 773 393 SP
+-2 -2 2 3 2 616 394 SP
+-12 5 7 -2 2 755 402 SP
+13 -5 1 735 413 SP
+6 -2 1 709 315 SP
+6 0 1 773 393 SP
+{0 0 0.502 C} FS
+1359 166 M
+-8 -1 D
+-7 0 D
+-7 -1 D
+-8 0 D
+-7 -1 D
+-7 0 D
+-8 -1 D
+-7 0 D
+-8 -1 D
+-7 0 D
+-7 0 D
+-8 -1 D
+-7 0 D
+-8 0 D
+-7 -1 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-104 4 D
+-52 4 D
+-12 95 D
+-8 94 D
+-4 76 D
+75 -6 D
+110 -3 D
+102 1 D
+109 7 D
+8 1 D
+-4 -83 D
+-11 -121 D
+P
+FO
+{1 0 0 C} FS
+9 -4 1 1189 309 SP
+4 -3 1 1266 332 SP
+3 -1 1 1357 309 SP
+9 -4 1 1189 309 SP
+4 -3 1 1266 332 SP
+3 -1 1 1357 309 SP
+{0 0 0.502 C} FS
+1693 227 M
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -1 D
+-6 -2 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 0 D
+-7 -1 D
+10 72 D
+10 110 D
+4 83 D
+132 15 D
+96 17 D
+85 19 D
+67 18 D
+-11 -78 D
+-16 -71 D
+-14 -49 D
+-20 -55 D
+P
+FO
+1965 341 M
+-20 -11 D
+-20 -11 D
+-21 -11 D
+-21 -10 D
+-11 -5 D
+-11 -5 D
+-11 -5 D
+-11 -5 D
+-12 -5 D
+-6 -2 D
+-11 -5 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -3 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-7 -1 D
+-6 -2 D
+-6 -2 D
+17 42 D
+16 45 D
+18 69 D
+11 60 D
+8 57 D
+50 15 D
+63 22 D
+72 29 D
+62 29 D
+57 31 D
+5 4 D
+-10 -52 D
+-21 -77 D
+-25 -65 D
+-37 -73 D
+P
+FO
+2142 495 M
+-16 -21 D
+-31 -34 D
+-28 -26 D
+-31 -25 D
+-26 -19 D
+-27 -18 D
+-18 -11 D
+17 28 D
+34 67 D
+20 52 D
+17 55 D
+14 57 D
+5 30 D
+42 26 D
+48 35 D
+18 14 D
+41 37 D
+41 47 D
+12 16 D
+-14 -61 D
+-24 -74 D
+-25 -57 D
+-24 -47 D
+-23 -40 D
+P
+FO
+2286 822 M
+-2 -38 D
+-4 -18 D
+0 -5 D
+6 4 D
+-16 -41 D
+-26 -58 D
+-36 -69 D
+-55 -87 D
+-11 -15 D
+30 44 D
+26 47 D
+26 55 D
+17 44 D
+21 66 D
+12 54 D
+P
+FO
+3 10 -4 -11 0 -1 3 2304 815 SP
+{1 0 0 C} FS
+2286 822 M
+-2 -38 D
+-4 -18 D
+0 -5 D
+6 4 D
+-1 -5 D
+25 73 D
+23 86 D
+5 25 D
+-11 -41 D
+-14 -33 D
+-17 -32 D
+P
+FO
+{0 0 0.502 C} FS
+3 10 -4 -11 0 -1 3 2304 815 SP
+{1 0 0 C} FS
+-3 4 -4 6 -2 3 3 226 486 SP
+{0 0 0.502 C} FS
+356 336 M
+2 -2 D
+-3 3 D
+14 -13 D
+-17 19 D
+-1 3 D
+-12 15 D
+2 3 D
+-8 13 D
+-7 12 D
+35 -25 D
+37 -23 D
+7 -11 D
+15 -21 D
+28 -35 D
+26 -28 D
+5 -4 D
+4 -5 D
+10 -8 D
+4 -5 D
+39 -31 D
+41 -27 D
+-65 41 D
+-81 61 D
+-47 42 D
+P
+FO
+3 -5 -3 4 2 316 384 SP
+3 -4 -3 3 2 333 360 SP
+{1 0 0 C} FS
+356 336 M
+2 -2 D
+-3 3 D
+14 -13 D
+-17 19 D
+-1 3 D
+-12 15 D
+2 3 D
+-8 13 D
+-7 12 D
+-16 12 D
+-50 46 D
+-35 41 D
+-5 7 D
+38 -51 D
+43 -51 D
+P
+FO
+{0 0 0.502 C} FS
+3 -5 -3 4 2 316 384 SP
+3 -4 -3 3 2 333 360 SP
+802 69 M
+-47 14 D
+-70 27 D
+-55 26 D
+-63 36 D
+-51 36 D
+-19 16 D
+-4 5 D
+-10 8 D
+-4 5 D
+-14 13 D
+-37 43 D
+-16 21 D
+-7 11 D
+-7 11 D
+49 -28 D
+100 -45 D
+103 -36 D
+20 -5 D
+14 -29 D
+27 -43 D
+30 -37 D
+6 -7 D
+27 -23 D
+20 -15 D
+P
+FO
+{1 0 0 C} FS
+669 145 M
+-2 -1 D
+11 -5 D
+6 0 D
+-1 12 D
+13 -4 D
+-3 10 D
+-8 4 D
+-8 -1 D
+-18 8 D
+-16 13 D
+7 -7 D
+-15 8 D
+-1 4 D
+-11 7 D
+-5 7 D
+-2 -1 D
+-13 9 D
+-1 -1 D
+-7 7 D
+-5 1 D
+33 -26 D
+-5 5 D
+10 -6 D
+2 -3 D
+-5 3 D
+9 -7 D
+6 -2 D
+-6 2 D
+11 -9 D
+3 -7 D
+-7 0 D
+21 -12 D
+P
+FO
+656 129 M
+5 -1 D
+-11 11 D
+10 -3 D
+-10 5 D
+20 -9 D
+-7 3 D
+-3 4 D
+7 3 D
+-4 4 D
+-5 2 D
+3 0 D
+-11 3 D
+-12 7 D
+3 0 D
+-8 1 D
+2 -11 D
+-9 1 D
+-9 4 D
+-4 -1 D
+5 -4 D
+-5 3 D
+7 -6 D
+P
+FO
+2 -3 -6 4 2 643 133 SP
+4 -2 1 639 185 SP
+0 1 1 654 151 SP
+{0 0 0.502 C} FS
+-5 3 3 -3 2 629 147 SP
+1 -1 1 632 145 SP
+3 -2 1 623 145 SP
+3 0 1 664 159 SP
+9 -6 1 625 147 SP
+5 -5 1 637 146 SP
+4 -3 1 635 146 SP
+7 -5 1 639 146 SP
+{1 0 0 C} FS
+669 145 M
+-2 -1 D
+11 -5 D
+6 0 D
+-1 12 D
+13 -4 D
+-3 10 D
+-8 4 D
+-8 -1 D
+-18 8 D
+-16 13 D
+7 -7 D
+-15 8 D
+-1 4 D
+-11 7 D
+-5 7 D
+-2 -1 D
+-13 9 D
+-1 -1 D
+-7 7 D
+-5 1 D
+33 -26 D
+-5 5 D
+10 -6 D
+2 -3 D
+-5 3 D
+9 -7 D
+6 -2 D
+-6 2 D
+11 -9 D
+3 -7 D
+-7 0 D
+21 -12 D
+P
+FO
+656 129 M
+5 -1 D
+-11 11 D
+10 -3 D
+-10 5 D
+20 -9 D
+-7 3 D
+-3 4 D
+7 3 D
+-4 4 D
+-5 2 D
+3 0 D
+-11 3 D
+-12 7 D
+3 0 D
+-8 1 D
+2 -11 D
+-9 1 D
+-9 4 D
+-4 -1 D
+5 -4 D
+-5 3 D
+7 -6 D
+P
+FO
+2 -3 -6 4 2 643 133 SP
+4 -2 1 639 185 SP
+0 1 1 654 151 SP
+{0 0 0.502 C} FS
+-5 3 3 -3 2 629 147 SP
+1 -1 1 632 145 SP
+3 -2 1 623 145 SP
+3 0 1 664 159 SP
+9 -6 1 625 147 SP
+5 -5 1 637 146 SP
+4 -3 1 635 146 SP
+7 -5 1 639 146 SP
+1049 24 M
+-75 8 D
+-104 19 D
+-68 18 D
+-15 9 D
+-27 21 D
+-13 12 D
+-30 36 D
+-17 24 D
+-26 46 D
+-4 10 D
+65 -18 D
+96 -20 D
+129 -19 D
+43 -4 D
+13 -60 D
+14 -46 D
+14 -29 D
+P
+FO
+{1 0 0 C} FS
+-8 2 4 0 2 800 91 SP
+-8 2 4 0 2 800 91 SP
+{0 0 0.502 C} FS
+1313 24 M
+-11 -1 D
+-11 -1 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 -1 D
+-11 0 D
+-11 0 D
+-11 -1 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-55 2 D
+-55 4 D
+-12 20 D
+-13 34 D
+-14 52 D
+-7 36 D
+96 -6 D
+97 -2 D
+96 3 D
+67 5 D
+-13 -60 D
+-16 -52 D
+-12 -23 D
+P
+FO
+1561 69 M
+-10 -3 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-10 -2 D
+-10 -2 D
+-10 -3 D
+-10 -2 D
+-10 -2 D
+-11 -2 D
+-10 -2 D
+-10 -2 D
+-11 -2 D
+-10 -2 D
+-11 -1 D
+-10 -2 D
+-11 -2 D
+-10 -1 D
+-11 -2 D
+-11 -1 D
+-11 -1 D
+-10 -1 D
+-11 -1 D
+-11 -1 D
+10 15 D
+11 27 D
+18 64 D
+7 36 D
+87 10 D
+92 14 D
+96 21 D
+59 16 D
+-25 -47 D
+-23 -33 D
+-36 -42 D
+-27 -22 D
+P
+FO
+1732 136 M
+-14 -7 D
+-16 -8 D
+-8 -3 D
+-16 -8 D
+-9 -3 D
+-8 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-10 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -2 D
+-9 -3 D
+34 24 D
+20 18 D
+30 36 D
+23 33 D
+25 47 D
+56 17 D
+67 24 D
+83 37 D
+66 36 D
+-23 -32 D
+-32 -40 D
+-22 -23 D
+-5 -4 D
+-4 -5 D
+-33 -29 D
+-30 -22 D
+-21 -14 D
+-23 -13 D
+-26 -15 D
+P
+FO
+1786 166 M
+40 27 D
+39 31 D
+14 13 D
+4 5 D
+14 13 D
+37 43 D
+31 43 D
+37 23 D
+50 37 D
+29 26 D
+21 20 D
+35 41 D
+5 7 D
+-21 -29 D
+-39 -49 D
+-51 -56 D
+-63 -61 D
+-48 -41 D
+-40 -30 D
+-31 -22 D
+-31 -21 D
+-22 -13 D
+P
+FO
+3 4 4 6 2 3 3 2136 486 SP
+630 136 M
+55 -26 D
+52 -20 D
+46 -16 D
+19 -5 D
+21 -12 D
+31 -11 D
+-49 15 D
+-71 27 D
+-47 20 D
+P
+FO
+{1 0 0 C} FS
+-1 0 1 663 120 SP
+-1 0 1 663 120 SP
+{0 0 0.502 C} FS
+854 46 M
+-31 11 D
+-21 12 D
+48 -13 D
+92 -19 D
+75 -10 D
+32 -3 D
+10 -11 D
+11 -7 D
+7 -1 D
+-63 7 D
+-74 13 D
+-50 11 D
+P
+FO
+1077 5 M
+-1 0 D
+-9 2 D
+-15 13 D
+-3 4 D
+77 -5 D
+88 -1 D
+88 5 D
+11 1 D
+-10 -11 D
+-8 -6 D
+-3 -1 D
+-3 -1 D
+-3 0 D
+-14 -2 D
+-13 0 D
+-13 -1 D
+-13 -1 D
+-13 0 D
+-13 -1 D
+-13 0 D
+-13 0 D
+-13 0 D
+-78 3 D
+P
+FO
+1285 5 M
+10 2 D
+15 13 D
+3 4 D
+75 8 D
+104 19 D
+69 18 D
+-15 -8 D
+-15 -7 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-13 -3 D
+-12 -3 D
+-12 -4 D
+-12 -3 D
+-13 -3 D
+-12 -2 D
+-12 -3 D
+-13 -3 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-13 -2 D
+-12 -1 D
+-13 -2 D
+-13 -1 D
+P
+FO
+1509 46 M
+30 11 D
+22 12 D
+46 14 D
+71 27 D
+54 26 D
+-23 -11 D
+-22 -11 D
+-12 -6 D
+-11 -5 D
+-12 -5 D
+-12 -5 D
+-11 -5 D
+-12 -5 D
+-12 -4 D
+-12 -5 D
+-12 -4 D
+-12 -4 D
+-12 -5 D
+-12 -4 D
+-12 -3 D
+-12 -4 D
+P
+FO
+25 W
+4 W
+1509 2316 M
+-28 6 D
+-43 3 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-10 -4 D
+-9 -4 D
+-10 -4 D
+-19 -10 D
+-19 -11 D
+-29 -19 D
+-9 -6 D
+S
+1181 2362 M
+0 -110 D
+S
+854 2316 M
+27 6 D
+43 3 D
+45 -6 D
+37 -9 D
+47 -19 D
+48 -27 D
+29 -19 D
+S
+408 2074 M
+42 34 D
+62 40 D
+45 24 D
+69 29 D
+58 18 D
+60 13 D
+70 10 D
+71 4 D
+57 -1 D
+83 -8 D
+50 -8 D
+17 -3 D
+S
+0 1181 M
+2 59 D
+8 76 D
+13 66 D
+15 58 D
+22 64 D
+24 56 D
+35 69 D
+27 45 D
+35 51 D
+32 42 D
+35 41 D
+36 39 D
+7 6 D
+6 7 D
+27 24 D
+6 7 D
+63 52 D
+60 44 D
+79 49 D
+75 39 D
+69 31 D
+99 36 D
+83 23 D
+66 15 D
+86 13 D
+39 5 D
+29 2 D
+S
+408 288 M
+-35 33 D
+-21 21 D
+-14 17 D
+-28 34 D
+-37 55 D
+-29 53 D
+-19 41 D
+-20 50 D
+-22 75 D
+-16 87 D
+-7 65 D
+-2 84 D
+3 59 D
+8 78 D
+18 96 D
+21 79 D
+29 88 D
+32 78 D
+28 60 D
+41 76 D
+24 41 D
+37 57 D
+28 39 D
+41 55 D
+37 45 D
+59 65 D
+20 21 D
+56 53 D
+37 32 D
+29 25 D
+38 30 D
+54 39 D
+55 36 D
+40 25 D
+58 31 D
+49 25 D
+75 32 D
+17 6 D
+S
+854 46 M
+-45 18 D
+-36 24 D
+-21 18 D
+-38 44 D
+-28 45 D
+-25 50 D
+-29 82 D
+-17 73 D
+-12 71 D
+-9 84 D
+-3 90 D
+1 102 D
+5 79 D
+10 100 D
+17 112 D
+16 84 D
+21 94 D
+28 104 D
+34 111 D
+36 100 D
+21 54 D
+41 95 D
+27 58 D
+50 96 D
+35 61 D
+45 71 D
+37 53 D
+19 25 D
+38 48 D
+38 43 D
+15 16 D
+5 4 D
+S
+1181 0 M
+0 2149 D
+S
+1509 46 M
+44 18 D
+29 19 D
+28 23 D
+38 44 D
+23 35 D
+30 60 D
+29 82 D
+19 80 D
+15 102 D
+6 86 D
+2 92 D
+-4 104 D
+-11 117 D
+-11 83 D
+-13 75 D
+-25 122 D
+-32 122 D
+-31 103 D
+-45 127 D
+-47 114 D
+-39 84 D
+-42 81 D
+-25 46 D
+-58 94 D
+-51 73 D
+-57 71 D
+-15 16 D
+-9 11 D
+-24 25 D
+S
+1954 288 M
+41 38 D
+25 27 D
+32 40 D
+37 55 D
+26 46 D
+28 62 D
+14 36 D
+18 60 D
+14 62 D
+11 80 D
+4 83 D
+-1 60 D
+-7 77 D
+-12 79 D
+-15 70 D
+-23 79 D
+-24 70 D
+-29 69 D
+-41 85 D
+-37 67 D
+-41 66 D
+-33 48 D
+-59 77 D
+-57 66 D
+-40 43 D
+-70 67 D
+-66 56 D
+-69 52 D
+-24 16 D
+-15 11 D
+-88 54 D
+-91 47 D
+-75 32 D
+-17 6 D
+S
+2362 1181 M
+-1 51 D
+-10 92 D
+-12 58 D
+-15 58 D
+-25 72 D
+-28 63 D
+-32 62 D
+-23 37 D
+-19 29 D
+-31 43 D
+-34 42 D
+-29 33 D
+-25 26 D
+-7 6 D
+-6 7 D
+-47 43 D
+-56 46 D
+-68 48 D
+-64 39 D
+-83 43 D
+-61 27 D
+-90 33 D
+-83 24 D
+-75 17 D
+-86 13 D
+-39 5 D
+-29 2 D
+S
+1954 2074 M
+-7 7 D
+-47 35 D
+-49 32 D
+-46 24 D
+-69 29 D
+-58 18 D
+-60 13 D
+-69 10 D
+-72 4 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-9 -2 D
+-8 -1 D
+-9 -1 D
+-8 -2 D
+-8 -2 D
+-9 -1 D
+S
+1233 2245 M
+-30 -23 D
+-22 -18 D
+S
+1092 2226 M
+83 -20 D
+6 -2 D
+S
+1130 2155 M
+14 15 D
+37 34 D
+S
+1270 2174 M
+-44 16 D
+-45 14 D
+S
+1233 2245 M
+-36 6 D
+-3 0 D
+-3 0 D
+-14 1 D
+-3 -1 D
+-4 0 D
+-3 0 D
+-3 0 D
+-4 -1 D
+-3 0 D
+-3 0 D
+-4 -1 D
+-3 0 D
+-3 -1 D
+-3 -1 D
+-3 0 D
+-3 -1 D
+-3 -1 D
+-3 -1 D
+-3 -1 D
+-3 0 D
+-3 -1 D
+-5 -3 D
+-3 -1 D
+-5 -2 D
+-6 -4 D
+-3 -1 D
+-1 -2 D
+-6 -4 D
+-4 -5 D
+-2 -1 D
+-5 -8 D
+-2 -12 D
+2 -9 D
+4 -8 D
+2 -1 D
+4 -5 D
+2 -1 D
+1 -2 D
+13 -8 D
+18 -8 D
+24 -6 D
+30 -2 D
+31 1 D
+25 6 D
+23 9 D
+11 7 D
+1 2 D
+8 7 D
+5 8 D
+2 12 D
+-2 10 D
+-4 7 D
+-2 1 D
+-2 4 D
+-2 1 D
+-1 2 D
+-12 8 D
+-18 8 D
+P S
+217 499 M
+20 -26 D
+20 -23 D
+8 -7 D
+15 -16 D
+34 -29 D
+48 -35 D
+42 -26 D
+52 -28 D
+36 -18 D
+79 -32 D
+77 -26 D
+104 -28 D
+102 -20 D
+106 -15 D
+92 -8 D
+84 -3 D
+76 -1 D
+93 4 D
+83 7 D
+123 16 D
+102 21 D
+82 21 D
+71 23 D
+80 31 D
+50 23 D
+41 21 D
+50 29 D
+67 49 D
+33 29 D
+15 16 D
+8 7 D
+32 39 D
+3 5 D
+S
+0 1181 M
+2 -37 D
+3 -20 D
+14 -48 D
+12 -29 D
+14 -28 D
+31 -46 D
+22 -28 D
+47 -48 D
+67 -54 D
+59 -39 D
+13 -7 D
+53 -29 D
+56 -27 D
+91 -37 D
+81 -27 D
+112 -30 D
+99 -21 D
+84 -13 D
+85 -11 D
+106 -8 D
+98 -3 D
+126 1 D
+78 5 D
+124 12 D
+85 13 D
+91 18 D
+96 23 D
+92 28 D
+86 32 D
+87 39 D
+73 40 D
+65 43 D
+42 32 D
+20 17 D
+4 5 D
+35 34 D
+31 36 D
+31 47 D
+15 28 D
+19 48 D
+9 39 D
+3 19 D
+1 31 D
+S
+217 1863 M
+-18 -27 D
+-20 -41 D
+-14 -42 D
+-7 -51 D
+2 -42 D
+9 -42 D
+16 -41 D
+17 -33 D
+28 -40 D
+27 -31 D
+31 -30 D
+35 -29 D
+49 -34 D
+32 -20 D
+40 -22 D
+48 -24 D
+26 -11 D
+53 -21 D
+55 -19 D
+88 -26 D
+85 -19 D
+88 -15 D
+90 -12 D
+108 -8 D
+110 -2 D
+101 3 D
+125 11 D
+106 16 D
+86 18 D
+89 23 D
+92 31 D
+59 24 D
+37 17 D
+53 27 D
+44 26 D
+67 49 D
+33 29 D
+30 31 D
+25 31 D
+26 40 D
+19 42 D
+12 41 D
+4 26 D
+1 34 D
+-5 42 D
+-11 42 D
+-23 49 D
+-20 30 D
+S
+1476 2323 M
+-79 19 D
+-84 13 D
+-77 6 D
+-87 1 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-9 -2 D
+-10 -1 D
+-9 -1 D
+-9 -2 D
+-10 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -3 D
+-8 -2 D
+-9 -2 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-8 -2 D
+-9 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-13 -7 D
+-13 -7 D
+-18 -12 D
+-17 -12 D
+-30 -25 D
+-25 -26 D
+-14 -19 D
+-11 -18 D
+-15 -39 D
+-4 -29 D
+1 -29 D
+7 -29 D
+13 -29 D
+5 -9 D
+13 -19 D
+33 -35 D
+31 -25 D
+35 -23 D
+40 -22 D
+60 -25 D
+57 -19 D
+88 -21 D
+84 -12 D
+68 -5 D
+97 -1 D
+68 5 D
+66 8 D
+82 16 D
+60 17 D
+70 26 D
+35 17 D
+33 18 D
+40 28 D
+16 12 D
+4 5 D
+22 21 D
+22 28 D
+16 28 D
+10 29 D
+4 19 D
+1 20 D
+-4 29 D
+-9 29 D
+-14 28 D
+-13 19 D
+-28 31 D
+-41 33 D
+-43 27 D
+-56 27 D
+-54 20 D
+P S
+8 W
+%%EndObject
+-4724 0 TM
+PSL_completion /PSL_completion {} def
+
+grestore
+PSL_movie_completion /PSL_movie_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/subplot/tictactoe.sh
+++ b/test/subplot/tictactoe.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Test lines between subplot with -W
+gmt begin tictactoe ps
+    gmt set FONT_ANNOT_PRIMARY 12p
+    gmt subplot begin 3x3 -Fs5c -M0 -W1p,- -B+n
+        gmt coast -Rg -JG30/30/?  -Gred -Snavy -Bg -c0,0
+        gmt coast -Rg -JG120/30/? -Gred -Snavy -Bg -c1,1
+        gmt coast -Rg -JG210/30/? -Gred -Snavy -Bg -c2,2
+    gmt subplot end
+gmt end


### PR DESCRIPTION
We used GMT_Y when we need to use GMT_X as index into the axes variables, causing extra space for nonexistent ticks to be added.