### PR TITLE
Clarify the margins option and list options alphabetically

### DIFF
--- a/doc/rst/source/subplot.rst_
+++ b/doc/rst/source/subplot.rst_
@@ -120,11 +120,13 @@ Optional Arguments
 .. _subplot_begin-M:
 
 **-M**\ *margins*
-    This is margin space that is added *between* neighboring subplots (i.e., interior margins) in addition
+    This is margin space that is added *between* neighboring subplots (i.e., the interior margins) *in addition*
     to the automatic space added for tick marks, annotations, and labels.  The margins can be specified as
     a single value (for same margin on all sides), a pair of values separated by slashes
     (for setting separate horizontal and vertical margins), or the full set of four slash-separated margins
-    (for setting separate left, right, bottom, and top margins) [0.5c].
+    (for setting separate left, right, bottom, and top margins).  The actual gap created is always a sum of
+    the margins for the two opposing sides (e.g., east plus west or south plus north margins) [Default is
+    half the primary annotation font size, giving the full annotation font size as the default gap].
 
 .. _-R:
 


### PR DESCRIPTION
Since the margin setting must specify the half-width per margin, and the actual gap is always a sum of two such margins, we make this clear in usage and documentation.  Also rearranged the order of options to be alphabetically.  Closes #1401.