### PR TITLE
Make sure psconvert -A is used in modern mode if not PostScript

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15554,6 +15554,8 @@ GMT_LOCAL int process_figures (struct GMTAPI_CTRL *API, char *show) {
 						strcat (cmd, option);
 					}
 				}
+				if (not_PS && strchr (fig[k].options, 'A') == NULL)	/* Must always add -A if not PostScript */
+					strcat (cmd, " -A");
 			}
 			else if (API->GMT->current.setting.ps_convert[0]) {	/* Supply chosen session settings for psconvert */
 				pos = 0;	/* Reset position counter */
@@ -15563,7 +15565,11 @@ GMT_LOCAL int process_figures (struct GMTAPI_CTRL *API, char *show) {
 						strcat (cmd, option);
 					}
 				}
+				if (not_PS && strchr (API->GMT->current.setting.ps_convert, 'A') == NULL)	/* Must always add -A if not PostScript */
+					strcat (cmd, " -A");
 			}
+			else if (not_PS)
+				strcat (cmd, " -A");
 			GMT_Report (API, GMT_MSG_DEBUG, "psconvert: %s\n", cmd);
 			if ((error = GMT_Call_Module (API, "psconvert", GMT_MODULE_CMD, cmd))) {
 				GMT_Report (API, GMT_MSG_NORMAL, "Failed to call psconvert\n");


### PR DESCRIPTION
Users may select special settings and forget to add A.  See #1416.
