### PR TITLE
Fix modern example 17

### DIFF
--- a/test/exmod/ex17.ps
+++ b/test/exmod/ex17.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_914aec3_2019.07.26 [64-bit] Document from grdimage
+%%Title: GMT v6.0.0_b754c1f-dirty_2019.08.26 [64-bit] Document from grdimage
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Fri Jul 26 10:28:57 2019
+%%CreationDate: Mon Aug 26 21:57:35 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -6517,7 +6517,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt pscoast -Q '-B+tClipping of Images' -R@india_geoid.nc -JM6.5i
+%@GMT: gmt pscoast -Q '-B+tClipping of Images' -Ba10f5 -R@india_geoid.nc -JM6.5i
 %@PROJ: merc 60.00000000 90.00000000 -10.00000000 25.00000000 -1669792.362 1669792.362 -1111475.103 2857692.611 +proj=merc +lon_0=75 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -6526,12 +6526,93 @@ O0
 PSL_cliprestore
 25 W
 8 W
+N 0 0 M 0 -83 D S
+N 0 9270 M 0 84 D S
+N 2600 0 M 0 -83 D S
+N 2600 9270 M 0 84 D S
+N 5200 0 M 0 -83 D S
+N 5200 9270 M 0 84 D S
+N 7800 0 M 0 -83 D S
+N 7800 9270 M 0 84 D S
+N 0 0 M -83 0 D S
+N 7800 0 M 83 0 D S
+N 0 2596 M -83 0 D S
+N 7800 2596 M 83 0 D S
+N 0 5192 M -83 0 D S
+N 7800 5192 M 83 0 D S
+N 0 7871 M -83 0 D S
+N 7800 7871 M 83 0 D S
+83 W
+N -42 0 M 0 1303 D S
+N 7842 0 M 0 1303 D S
+1 A
+N -42 1303 M 0 1293 D S
+N 7842 1303 M 0 1293 D S
+0 A
+N -42 2596 M 0 1293 D S
+N 7842 2596 M 0 1293 D S
+1 A
+N -42 3889 M 0 1303 D S
+N 7842 3889 M 0 1303 D S
+0 A
+N -42 5192 M 0 1323 D S
+N 7842 5192 M 0 1323 D S
+1 A
+N -42 6515 M 0 1356 D S
+N 7842 6515 M 0 1356 D S
+0 A
+N -42 7871 M 0 1399 D S
+N 7842 7871 M 0 1399 D S
+N 0 -42 M 1300 0 D S
+N 0 9312 M 1300 0 D S
+1 A
+N 1300 -42 M 1300 0 D S
+N 1300 9312 M 1300 0 D S
+0 A
+N 2600 -42 M 1300 0 D S
+N 2600 9312 M 1300 0 D S
+1 A
+N 3900 -42 M 1300 0 D S
+N 3900 9312 M 1300 0 D S
+0 A
+N 5200 -42 M 1300 0 D S
+N 5200 9312 M 1300 0 D S
+1 A
+N 6500 -42 M 1300 0 D S
+N 6500 9312 M 1300 0 D S
+0 A
+8 W
+N -83 0 M 7966 0 D S
+N -83 -83 M 7966 0 D S
+N 7800 -83 M 0 9437 D S
+N 7883 -83 M 0 9437 D S
+N 7883 9270 M -7966 0 D S
+N 7883 9354 M -7966 0 D S
+N 0 9354 M 0 -9437 D S
+N -83 9354 M 0 -9437 D S
 /PSL_H_y 400 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (100è) sh add def
 3900 9270 PSL_H_y add M
 400 F0
 (Clipping of Images) bc Z
+0 -167 M 200 F0
+(60è) tc Z
+0 9437 M (60è) bc Z
+2600 -167 M (70è) tc Z
+2600 9437 M (70è) bc Z
+5200 -167 M (80è) tc Z
+5200 9437 M (80è) bc Z
+7800 -167 M (90è) tc Z
+7800 9437 M (90è) bc Z
+-167 0 M (î10è) mr Z
+7967 0 M (î10è) ml Z
+-167 2596 M (0è) mr Z
+7967 2596 M (0è) ml Z
+-167 5192 M (10è) mr Z
+7967 5192 M (10è) ml Z
+-167 7871 M (20è) mr Z
+7967 7871 M (20è) ml Z
 %%EndObject
 0 A
 FQ

--- a/test/exmod/ex17.sh
+++ b/test/exmod/ex17.sh
@@ -8,37 +8,30 @@
 gmt begin ex17 ps
 
 	# First generate geoid image w/ shading
-	
 	gmt grd2cpt @india_geoid.nc -Crainbow -H > geoid.cpt
 	gmt grdimage @india_geoid.nc -I+d -JM6.5i -Cgeoid.cpt
-	
-	# Then use gmt pscoast to initiate clip path for land
-	
-	gmt pscoast -R@india_geoid.nc -Dl -Gc
-	
+
+	# Then use gmt coast to initiate clip path for land
+	gmt coast -R@india_geoid.nc -Dl -Gc
+
 	# Now generate topography image w/shading
-	
 	gmt makecpt -C150 -T-10000,10000 -N
 	gmt grdimage @india_topo.nc -I+d
-	
+
 	# Finally undo clipping and overlay basemap
-	
-	gmt pscoast -Q -B+t"Clipping of Images"
-	
-	# Put a color legend on top of the land mask
-	
+	gmt coast -Q -B+t"Clipping of Images" -Ba10f5
+
+	# Put a colorbar on top of the land mask
 	gmt colorbar -DjTR+o0.3i/0.1i+w4i/0.2i+h -Cgeoid.cpt -Bx5f1 -By+lm -I
-	
+
 	# Add a text paragraph
-	
 	gmt text -M -Gwhite -Wthinner -C+tO -D-0.1i/0.1i -F+f12,Times-Roman+jRB <<- END
 	> 90 -10 12p 3i j
 	@_@%5%Example 17.@%%@_  We first plot the color geoid image
 	for the entire region, followed by a gray-shaded @#etopo5@#
 	image that is clipped so it is only visible inside the coastlines.
 	END
-	
+
 	# Clean up
-	
 	rm -f geoid.cpt
 gmt end


### PR DESCRIPTION
The original PS file doesn't have a frame. This PR adds `-Ba10f5` to add the frame and also fixes pscoast to coast.