### PR TITLE
Cleanup PS settings from examples

### DIFF
--- a/doc/examples/ex01/ex01.sh
+++ b/doc/examples/ex01/ex01.sh
@@ -4,8 +4,8 @@
 # Purpose:	Make two contour maps based on the data in the file osu91a1f_16.nc
 # GMT modules:	set, subplot, grdcontour, coast
 #
-gmt begin ex01 ps
-  gmt set MAP_GRID_CROSS_SIZE_PRIMARY 0 FONT_ANNOT_PRIMARY 10p PS_MEDIA letter
+gmt begin ex01
+  gmt set MAP_GRID_CROSS_SIZE_PRIMARY 0 FONT_ANNOT_PRIMARY 10p
   gmt subplot begin 2x1 -A -M0.25i -Blrtb -Bafg -T"Low Order Geoid" -Fs6.5i/0 -Rg -JH6.5i
     gmt coast -JH? -Glightbrown -Slightblue -c0,0
     gmt grdcontour @osu91a1f_16.nc -C10 -A50+f7p -Gd4i -Ln -Wcthinnest,- -Wathin,- -T+d0.1i/0.02i+l

--- a/doc/examples/ex02/ex02.sh
+++ b/doc/examples/ex02/ex02.sh
@@ -4,8 +4,8 @@
 # Purpose:	Make two color images based gridded data
 # GMT modules:	set, grd2cpt, grdimage, makecpt, colorbar, subplot
 #
-gmt begin ex02 ps
-  gmt set MAP_ANNOT_OBLIQUE 0 PS_MEDIA letter
+gmt begin ex02
+  gmt set MAP_ANNOT_OBLIQUE 0
   gmt subplot begin 2x1 -A+JTL+o0.1i/0 -Fs6i/3.5i -M0 -R160/20/220/30+r -JOc190/25.5/292/69/6i -X1.5i -Y1.5i -B10 -T"H@#awaiian@# T@#opo and @#G@#eoid@#"
     gmt subplot set 0,0 -Ce1.1i
     gmt grd2cpt @HI_topo_02.nc -Crelief -Z

--- a/doc/examples/ex03/ex03.sh
+++ b/doc/examples/ex03/ex03.sh
@@ -18,7 +18,7 @@
 # and we use various GMT tools to facilitate their comparison.
 #
 
-gmt begin ex03 ps
+gmt begin ex03
   gmt set GMT_FFT kiss
   # First, we use "gmt fitcircle" to find the parameters of a great circle
   # most closely fitting the x,y points in "sat_03.txt":

--- a/doc/examples/ex04/ex04.sh
+++ b/doc/examples/ex04/ex04.sh
@@ -6,7 +6,7 @@
 # Unix progs:	echo, rm
 #
 gmt begin
-	gmt figure ex04 ps
+	gmt figure ex04
 	gmt makecpt -C255,100 -T-10/10/10 -N
 	gmt grdcontour @HI_geoid_04.nc -R195/210/18/25 -Jm0.45i -p60/30 -C1 -A5+o -Gd4i -X1.25i -Y1.25i
 	gmt coast -p -B2 -BNEsw -Gblack -TdjBR+o0.1i+w1i+l
@@ -15,7 +15,7 @@ gmt begin
 	echo '3.25 5.75 H@#awaiian@# R@#idge@#' | gmt text -R0/10/0/10 -Jx1i \
 	-F+f60p,ZapfChancery-MediumItalic+jCB
 
-	gmt figure ex04c ps
+	gmt figure ex04c
 	gmt grdimage @HI_geoid_04.nc -I+a0+nt0.75 -R195/210/18/25 -JM6.75i -p60/30 -C@geoid_04.cpt -X1.25i -Y1.25i
 	gmt coast -p -B2 -BNEsw -Gblack
 	gmt basemap -p -TdjBR+o0.1i+w1i+l --COLOR_BACKGROUND=red --FONT=red --MAP_TICK_PEN_PRIMARY=thinner,red

--- a/doc/examples/ex05/ex05.sh
+++ b/doc/examples/ex05/ex05.sh
@@ -5,7 +5,7 @@
 # GMT modules:	grdmath, grdview, text, makecpt
 # Unix progs:	echo, rm
 #
-gmt begin ex05 ps
+gmt begin ex05
 	gmt grdmath -R-15/15/-15/15 -I0.3 X Y HYPOT DUP 2 MUL PI MUL 8 DIV COS EXCH NEG 10 DIV \
 	EXP MUL = sombrero.nc
 	gmt makecpt -C128 -T-5,5 -N

--- a/doc/examples/ex06/ex06.sh
+++ b/doc/examples/ex06/ex06.sh
@@ -4,7 +4,7 @@
 # Purpose:	Make standard and polar histograms
 # GMT modules:	histogram, rose
 #
-gmt begin ex06 ps
+gmt begin ex06
   gmt subplot begin 2x1 -A+JTL+o0.3i -Fs6i/3.5i -M0.4i -X1.25i
     gmt histogram -Bx+l"Topography (m)" -By+l"Frequency"+u" %" -BWSne+t"Histograms"+glightblue @v3206_06.txt \
 	-R-6000/0/0/30 -Gorange -L1p -Z1 -W250 -c0

--- a/doc/examples/ex07/ex07.sh
+++ b/doc/examples/ex07/ex07.sh
@@ -4,7 +4,7 @@
 # Purpose:	Make a basemap with earthquakes and isochrons etc
 # GMT modules:	coast, legend, text, plot
 #
-gmt begin ex07 ps
+gmt begin ex07
 	gmt coast -R-50/0/-10/20 -JM9i -Slightblue -GP26+r300+ftan+bdarkbrown -Dl -Wthinnest -B --FORMAT_GEO_MAP=dddF
 	gmt plot @fz_07.txt -Wthinner,-
 	gmt plot @quakes_07.txt -h1 -Sci -i0,1,2+s0.01 -Gred -Wthinnest

--- a/doc/examples/ex08/ex08.sh
+++ b/doc/examples/ex08/ex08.sh
@@ -5,7 +5,7 @@
 # GMT modules:	grd2xyz, makecpt, text, plot3d
 # Unix progs:	echo
 #
-gmt begin ex08 ps
+gmt begin ex08
 	gmt makecpt -Ccubhelix -T-5000/0
 	gmt grd2xyz @guinea_bay.nc | gmt plot3d -B -Bz1000+l"Topography (m)" -BWSneZ+b+tETOPO5 \
 	-R-0.1/5.1/-0.1/5.1/-5000/0 -JM5i -JZ6i -p200/30 -So0.0833333ub-5000 -Wthinnest -C -i0-2,2

--- a/doc/examples/ex09/ex09.sh
+++ b/doc/examples/ex09/ex09.sh
@@ -4,7 +4,7 @@
 # Purpose:	Make wiggle plot along track from geoid deflections
 # GMT modules:	convert, wiggle, text, plot
 #
-gmt begin ex09 ps
+gmt begin ex09
 	gmt wiggle @tracks_09.txt -R185/250/-68/-42 -Jm0.13i -B -BWSne+g240/255/240 -Gred+p \
 	-Gblue+n -Z2000 -Wthinnest -DjBR+w500+l@~m@~rad+o0.2i --FORMAT_GEO_MAP=dddF
 	gmt plot @ridge_09.txt -Wthicker

--- a/doc/examples/ex10/ex10.sh
+++ b/doc/examples/ex10/ex10.sh
@@ -4,7 +4,7 @@
 # Purpose:	Make 3-D bar graph on top of perspective map
 # GMT modules:	coast, text, plot3d, legend, makecpt, math
 #
-gmt begin ex10 ps
+gmt begin ex10
 	gmt coast -Rd -JQ0/37.5/8i -Sazure2 -Gwheat -Wfaint -A5000 -p200/40
 	gmt makecpt -Cpurple,blue,darkgreen,yellow,red -T0,1,2,3,4,5
 	gmt math -T @languages_10.txt -o0-2 -C2 3 COL ADD 4 COL ADD 5 COL ADD 6 COL ADD = \

--- a/doc/examples/ex11/ex11.sh
+++ b/doc/examples/ex11/ex11.sh
@@ -4,7 +4,7 @@
 # Purpose:	Create a 3-D RGB Cube
 # GMT modules:	set, grdimage, grdmath, text, plot
 # Unix progs:	rm
-gmt begin ex11 ps
+gmt begin ex11
 # Use gmt plot to plot "cut-along-the-dotted" lines.
 	gmt set MAP_TICK_LENGTH_PRIMARY 0
 

--- a/doc/examples/ex12/ex12.sh
+++ b/doc/examples/ex12/ex12.sh
@@ -5,7 +5,7 @@
 # GMT modules:	makecpt, gmtinfo, contour, text, plot, triangulate, subplot
 # Unix progs:	rm
 #
-gmt begin ex12 ps
+gmt begin ex12
   # Contour the data and draw triangles using dashed pen; use "gmt gmtinfo" and "gmt makecpt" to make a
   # color palette (.cpt) file
   T=`gmt info -T25+c2 @Table_5_11.txt`

--- a/doc/examples/ex13/ex13.sh
+++ b/doc/examples/ex13/ex13.sh
@@ -5,7 +5,7 @@
 # GMT modules:	set, grdmath, grdcontour, grdvector, subplot
 # Unix progs:	rm
 #
-gmt begin ex13 ps
+gmt begin ex13
   gmt set FONT_HEADING 40p,Times-Italic
   gmt grdmath -R-2/2/-2/2 -I0.1 X Y R2 NEG EXP X MUL = z.nc
   gmt grdmath z.nc DDX = dzdx.nc

--- a/doc/examples/ex14/ex14.sh
+++ b/doc/examples/ex14/ex14.sh
@@ -6,7 +6,7 @@
 # GMT modules:	set, plot, surface, subplot
 # Unix progs:	rm
 #
-gmt begin ex14 ps
+gmt begin ex14
   gmt set MAP_GRID_PEN_PRIMARY thinnest,-
   # calculate mean data and grids
   gmt blockmean @Table_5_11.txt -R0/7/0/7 -I1 > mean.xyz

--- a/doc/examples/ex15/ex15.sh
+++ b/doc/examples/ex15/ex15.sh
@@ -6,7 +6,7 @@
 # GMT modules:	info, nearneighbor, coast, mask, surface, plot
 # Unix progs:	rm
 #
-gmt begin ex15 ps
+gmt begin ex15
   gmt convert @ship_15.txt -bo > ship.b
   region=`gmt info ship.b -I1 -bi3d`
   gmt subplot begin 2x2 -M0.1i/0.05i -Fs2.9i/0 $region -JM2.9i -BWSne -T"Gridding with missing data"

--- a/doc/examples/ex16/ex16.sh
+++ b/doc/examples/ex16/ex16.sh
@@ -5,7 +5,7 @@
 # GMT modules:	gmtset, grdview, grdfilter, contour, colorbar, surface, triangulate
 # Unix progs:	rm
 #
-gmt begin ex16 ps
+gmt begin ex16
   gmt set FONT_ANNOT_PRIMARY 9p FONT_TITLE 18p,Times-Roman
   gmt subplot begin 2x2 -M0.05i -Fs3.25i/0 -R0/6.5/-0.2/6.5 -Jx1i -SCb -SRl+t -Bwesn -Y2i -T"Gridding of Data"
     gmt contour @Table_5_11.txt -C@ex_16.cpt -I -B+t"contour (triangulate)" -c0,0

--- a/doc/examples/ex17/ex17.sh
+++ b/doc/examples/ex17/ex17.sh
@@ -5,7 +5,7 @@
 # GMT modules:	grd2cpt, grdimage, coast, text, makecpt
 # Unix progs:	rm
 #
-gmt begin ex17 ps
+gmt begin ex17
 
 	# First generate geoid image w/ shading
 	gmt grd2cpt @india_geoid.nc -Crainbow -H > geoid.cpt

--- a/doc/examples/ex18/ex18.sh
+++ b/doc/examples/ex18/ex18.sh
@@ -7,7 +7,7 @@
 # GMT modules:	grdmath, grdvolume, makecpt, coast, colorbar, text, plot
 # Unix progs:	rm
 #
-gmt begin ex18 ps
+gmt begin ex18
   # Use spherical gmt projection since SS data define on sphere
   gmt set PROJ_ELLIPSOID Sphere FORMAT_FLOAT_OUT %g
   # Define location of Pratt seamount and the 400 km diameter

--- a/doc/examples/ex19/ex19.sh
+++ b/doc/examples/ex19/ex19.sh
@@ -4,7 +4,7 @@
 # Purpose:	Illustrates various color pattern effects for maps
 # GMT modules:	grdimage, grdmath, makecpt, coast, text, image, makecpt
 # Unix progs:	echo, rm
-gmt begin ex19 ps
+gmt begin ex19
   gmt grdmath -Rd -I1 -r Y COSD 2 POW = lat.nc
   gmt grdmath X = lon.nc
   gmt makecpt -Cwhite,blue -T0,1 -Z -N -H > lat.cpt

--- a/doc/examples/ex20/ex20.sh
+++ b/doc/examples/ex20/ex20.sh
@@ -7,7 +7,7 @@
 #
 # Plot a world-map with volcano symbols of different sizes at hotspot locations
 # using table from Muller et al., 1993, Geology.
-gmt begin ex20 ps
+gmt begin ex20
 	gmt set PROJ_LENGTH_UNIT inch
 	gmt coast -Rg -JR9i -B -B+t"Hotspot Islands and Hot Cities" -Gdarkgreen -Slightblue -A5000
 	gmt plot @hotspots.txt -Skvolcano -Wthinnest -Gred

--- a/doc/examples/ex21/ex21.sh
+++ b/doc/examples/ex21/ex21.sh
@@ -5,7 +5,7 @@
 # GMT modules:	set, convert, info, basemap, plot
 # Unix progs:	echo, rm
 #
-gmt begin ex21 ps
+gmt begin ex21
 	# File has time stored as dd-Mon-yy so set input format to match it
 	gmt set FORMAT_DATE_IN dd-o-yy FORMAT_DATE_MAP o FONT_ANNOT_PRIMARY +10p
 	gmt set FORMAT_TIME_PRIMARY_MAP abbreviated PS_CHAR_ENCODING ISOLatin1+

--- a/doc/examples/ex22/ex22.sh
+++ b/doc/examples/ex22/ex22.sh
@@ -5,7 +5,7 @@
 # GMT modules:	set, coast, plot, legend
 # Unix progs:	cat, sed, awk, wget|curl
 #
-gmt begin ex22 ps
+gmt begin ex22
 	gmt set FONT_ANNOT_PRIMARY 10p FONT_TITLE 18p FORMAT_GEO_MAP ddd:mm:ssF
 
 	# Get the data (-s silently) from USGS using the curl

--- a/doc/examples/ex23/ex23.sh
+++ b/doc/examples/ex23/ex23.sh
@@ -5,7 +5,7 @@
 # GMT modules:	grdmath, grdcontour, coast, plot, text, grdtrack
 # Unix progs:	echo, cat
 #
-gmt begin ex23 ps
+gmt begin ex23
 	# Position and name of central point:
 	lon=12.50
 	lat=41.99

--- a/doc/examples/ex24/ex24.sh
+++ b/doc/examples/ex24/ex24.sh
@@ -6,7 +6,7 @@
 # Unix progs:	echo, cat, rm
 #
 # Highlight oceanic earthquakes within 3000 km of Hobart and > 1000 km from dateline
-gmt begin ex24 ps
+gmt begin ex24
 	echo "147:13 -42:48 6000" > point.txt
 	cat <<- END > dateline.txt
 	> Our proxy for the dateline

--- a/doc/examples/ex25/ex25.sh
+++ b/doc/examples/ex25/ex25.sh
@@ -6,7 +6,7 @@
 # Unix progs:	cat
 #
 # Create D minutes global grid with -1 over oceans and +1 over land
-gmt begin ex25 ps
+gmt begin ex25
 	D=30
 	gmt grdlandmask -Rg -I${D}m -Dc -A500 -N-1/1/1/1/1 -r -Gwetdry.nc
 	# Manipulate so -1 means ocean/ocean antipode, +1 = land/land, and 0 elsewhere

--- a/doc/examples/ex26/ex26.sh
+++ b/doc/examples/ex26/ex26.sh
@@ -4,7 +4,7 @@
 # Purpose:	Demonstrate general vertical perspective projection
 # GMT modules:	coast
 #
-gmt begin ex26 ps
+gmt begin ex26
 
 	# first do an overhead of the east coast from 160 km altitude point straight down
 	latitude=41.5

--- a/doc/examples/ex27/ex27.sh
+++ b/doc/examples/ex27/ex27.sh
@@ -4,7 +4,7 @@
 # Purpose:	Illustrates how to plot Mercator img grids
 # GMT modules:	makecpt, grdimage, grdinfo, coast, colorbar
 #
-gmt begin ex27 ps
+gmt begin ex27
 	# Gravity in tasman_grav.nc is in 0.1 mGal increments and the grid
 	# is already in projected Mercator x/y units.
 

--- a/doc/examples/ex28/ex28.sh
+++ b/doc/examples/ex28/ex28.sh
@@ -4,7 +4,7 @@
 # Purpose:	Illustrates how to mix UTM data and UTM gmt projection
 # GMT modules:	makecpt, grdimage, coast, text, basemap
 #
-gmt begin ex28 ps
+gmt begin ex28
 	# Set up a color table
 	gmt makecpt -Ccopper -T0/1500
 	# Lay down the UTM topo grid using a 1:160,000 scale

--- a/doc/examples/ex29/ex29.sh
+++ b/doc/examples/ex29/ex29.sh
@@ -5,7 +5,7 @@
 # GMT modules:  makecpt, grdcontour, grdimage, grdmath greenspline, colorbar, text
 # Unix progs:   echo, rm
 #
-gmt begin ex29 ps
+gmt begin ex29
   # This example uses 370 radio occultation data for Mars to grid the topography.
   # Data and information from Smith, D. E., and M. T. Zuber (1996), The shape of
   # Mars and the topographic signature of the hemispheric dichotomy, Science, 271, 184-187.

--- a/doc/examples/ex30/ex30.sh
+++ b/doc/examples/ex30/ex30.sh
@@ -6,7 +6,7 @@
 # Unix progs:	echo, rm
 #
 # Draw generic x-y axes with arrows
-gmt begin ex30 ps
+gmt begin ex30
 	gmt basemap -R0/360/-1.25/1.75 -JX8i/6i -Bx90f30+u@. -By1g10 -BWS+t"Two Trigonometric Functions" \
 		--MAP_FRAME_TYPE=graph --MAP_VECTOR_SHAPE=0.5
 

--- a/doc/examples/ex31/ex31.sh
+++ b/doc/examples/ex31/ex31.sh
@@ -5,7 +5,7 @@
 # GMT modules:	set, coast, plot, text, legend
 # Unix progs:	awk, cat, rm
 #
-gmt begin ex31 ps
+gmt begin ex31
 	# create file PSL_custom_fonts.txt in current working directory
 	# and add PostScript font names of Linux Biolinum and Libertine
 	$AWK '{print $1, 0.700, 0}' <<- EOF > PSL_custom_fonts.txt

--- a/doc/examples/ex32/ex32.sh
+++ b/doc/examples/ex32/ex32.sh
@@ -7,7 +7,7 @@
 # Unix progs:	cat, rm
 # Credits:	Original by Stephan Eickschen
 #
-gmt begin ex32 ps
+gmt begin ex32
 	# Here we get and convert the flag of Europe directly from the web through grdconvert using
 	# GDAL support. We take into account the dimension of the flag (1000x667 pixels)
 	# for a ratio of 3x2.

--- a/doc/examples/ex33/ex33.sh
+++ b/doc/examples/ex33/ex33.sh
@@ -5,7 +5,7 @@
 # GMT modules:  makecpt, convert, grdimage, grdtrack, text, plot
 # Unix progs:   cat, rm
 #
-gmt begin ex33 ps
+gmt begin ex33
 
 	# Extract a subset of ETOPO1m for the East Pacific Rise
 	# gmt grdcut etopo1m_grd.nc -R118W/107W/49S/42S -Gspac_33.nc

--- a/doc/examples/ex34/ex34.sh
+++ b/doc/examples/ex34/ex34.sh
@@ -4,7 +4,7 @@
 # Purpose:      Illustrate coast with DCW country polygons
 # GMT modules:  set, coast, makecpt, grdimage
 #
-gmt begin ex34 ps
+gmt begin ex34
   gmt set FORMAT_GEO_MAP dddF FONT_HEADING 24p
   gmt makecpt -Cglobe -T-5000/5000
   gmt subplot begin 2x1 -Fs4.5i/0 -M0.05i -JM4.5i -R-6/20/35/52 -SRl -SCb -Bwesn -T"Franco-Italian Union, 2042-45"

--- a/doc/examples/ex35/ex35.sh
+++ b/doc/examples/ex35/ex35.sh
@@ -5,7 +5,7 @@
 # GMT modules:  coast, plot, makecpt, grdimage, grdcontour, sphtriangulate, sphdistance
 # Unix progs:   rm
 #
-gmt begin ex35 ps
+gmt begin ex35
 	# Get the crude GSHHS data, select GMT format, and decimate to ~20%:
 	# gshhs $GMTHOME/src/coast/gshhs/gshhs_c.b | $AWK '{if ($1 == ">" || NR%5 == 0) print $0}' > gshhs_c.txt
 	# Get Voronoi polygons

--- a/doc/examples/ex36/ex36.sh
+++ b/doc/examples/ex36/ex36.sh
@@ -5,7 +5,7 @@
 # GMT modules:  plot, makecpt, grdimage, sphinterpolate
 # Unix progs:   rm
 #
-gmt begin ex36 ps
+gmt begin ex36
   # Interpolate data of Mars radius from Mariner9 and Viking Orbiter spacecrafts
   gmt subplot begin 3x1 -Fs5.5i/0 -JH0/5.5i -Rg -M0
     gmt makecpt -Crainbow -T-7000/15000

--- a/doc/examples/ex37/ex37.sh
+++ b/doc/examples/ex37/ex37.sh
@@ -6,7 +6,7 @@
 # Unix progs:   rm
 #
 
-gmt begin ex37 ps
+gmt begin ex37
     # Testing gmt grdfft coherence calculation with Karen Marks example data
     # Prefix of two .nc files
     G=@grav.V18.par.surf.1km.sq

--- a/doc/examples/ex38/ex38.sh
+++ b/doc/examples/ex38/ex38.sh
@@ -5,8 +5,8 @@
 # GMT modules:  colorbar, text, makecpt, grdhisteq, grdimage
 # Unix progs:   rm
 #
-gmt begin ex38 ps
-  gmt set FONT_TAG 14p PS_MEDIA letter
+gmt begin ex38
+  gmt set FONT_TAG 14p
 
   gmt makecpt -Crainbow -T0/1700 -H > t.cpt
   gmt makecpt -Crainbow -T0/15/1 -H > c.cpt

--- a/doc/examples/ex39/ex39.sh
+++ b/doc/examples/ex39/ex39.sh
@@ -5,7 +5,7 @@
 # GMT modules:  colorbar, text, makecpt, grdimage, sph2grd
 # Unix progs:   rm
 #
-gmt begin ex39 ps
+gmt begin ex39
 	# Evaluate the first 180, 90, and 30 order/degrees of Venus spherical
 	# harmonics topography model, skipping the L = 0 term (radial mean).
 	# File truncated from http://www.ipgp.fr/~wieczor/SH/VenusTopo180.txt.zip

--- a/doc/examples/ex40/ex40.sh
+++ b/doc/examples/ex40/ex40.sh
@@ -5,7 +5,7 @@
 # GMT modules:  basemap, text, plot, gmtsimplify, gmtspatial, subplot
 # Unix progs:   awk, rm
 #
-gmt begin ex40 ps
+gmt begin ex40
   gmt spatial @GSHHS_h_Australia.txt -fg -Qk > centroid.txt
   gmt spatial @GSHHS_h_Australia.txt -fg -Qk | $AWK '{printf "Full area = %.0f km@+2@+\n", $3}' > area.txt
 

--- a/doc/examples/ex41/ex41.sh
+++ b/doc/examples/ex41/ex41.sh
@@ -4,7 +4,7 @@
 # Purpose:      Illustrate typesetting of legend with table
 # GMT modules:  set, coast, legend, plot, makecpt
 #
-gmt begin ex41 ps
+gmt begin ex41
 	gmt set FONT_ANNOT_PRIMARY 12p FONT_LABEL 12p
 	gmt makecpt -Cred,orange,yellow,green,bisque,cyan,magenta,white,gray -T1/10/1 -N
 	gmt coast -R130W/50W/8N/56N -JM5.6i -B0 -Glightgray -Sazure1 -A1000 -Wfaint -Xc -Y1.2i --MAP_FRAME_TYPE=plain

--- a/doc/examples/ex42/ex42.sh
+++ b/doc/examples/ex42/ex42.sh
@@ -5,7 +5,7 @@
 # GMT modules:  makecpt, grdimage, coast, legend, colorbar, text, plot
 # Unix progs:   [curl grdconvert]
 #
-gmt begin ex42 ps
+gmt begin ex42
 	gmt set FONT_ANNOT_PRIMARY 12p FONT_LABEL 12p PROJ_ELLIPSOID WGS-84 FORMAT_GEO_MAP dddF
 	# Data obtained via website and converted to netCDF thus:
 	# curl http://www.antarctica.ac.uk//bas_research/data/access/bedmap/download/bedelev.asc.gz

--- a/doc/examples/ex43/ex43.sh
+++ b/doc/examples/ex43/ex43.sh
@@ -7,7 +7,7 @@
 #
 
 # Data from Table 7 in Rousseeuw and Leroy, 1987.
-gmt begin ex43 ps
+gmt begin ex43
 
 	file=`gmt which -G @bb_weights.txt`
 	gmt regress -Ey -Nw -i0:1+l $file > model.txt

--- a/doc/examples/ex44/ex44.sh
+++ b/doc/examples/ex44/ex44.sh
@@ -5,7 +5,7 @@
 # GMT modules:  coast, basemap, mapproject
 #
 
-gmt begin ex44 ps
+gmt begin ex44
   gmt subplot begin 2x1 -Fs6i/4i -B -BWSne
     gmt coast -R10W/5E/35N/44N -JM6i -EES+gbisque -Gbrown -Wfaint -N1/1p -Sazure1 -Df --FORMAT_GEO_MAP=dddF -c0
     gmt inset begin -DjTR+w2i/0.93i+o0.15i/0.1i -F+gwhite+p1p+c0.1c+s

--- a/doc/examples/ex45/ex45.sh
+++ b/doc/examples/ex45/ex45.sh
@@ -6,8 +6,8 @@
 # Unix progs:   rm
 #
 
-gmt begin ex45 ps
-  gmt set FONT_HEADING 24p PS_MEDIA letter
+gmt begin ex45
+  gmt set FONT_HEADING 24p
   gmt subplot begin 4x1 -Fs6i/1.9i -R1958/2016/310/410 -Bxaf -Byaf+u" ppm" -BWSne+gazure1 -T"The Keeling Curve [CO@-2@- at Mauna Loa]"
 
     # Basic LS line y = a + bx

--- a/doc/examples/ex46/ex46.sh
+++ b/doc/examples/ex46/ex46.sh
@@ -5,7 +5,7 @@
 # GMT modules:  solar, coast, plot
 #
 
-gmt begin ex46 ps
+gmt begin ex46
 	gmt coast -Rd -JKs0/10i -A5000 -W0.5p -N1/0.5p,gray -S175/210/255 -Bafg --MAP_FRAME_TYPE=plain -Xc
 	gmt solar -Td+d2016-02-09T16:00:00 -Gnavy@95
 	gmt solar -Tc+d2016-02-09T16:00:00 -Gnavy@85

--- a/doc/examples/ex47/ex47.sh
+++ b/doc/examples/ex47/ex47.sh
@@ -16,7 +16,7 @@ function plot_one { # First 3-4 args are: -E -N -c [-Barg]
   gmt regress data.txt -Fxm $1 $2 -T2.85/5.25/0.1 | gmt plot -W2p	
 }
 
-gmt begin ex47 ps
+gmt begin ex47
   file=`gmt which -G @hertzsprung-russell.txt`
   # Allow outliers (commented out by #) to be included in the analysis:
   sed -e s/#//g $file > data.txt

--- a/doc/examples/ex48/ex48.sh
+++ b/doc/examples/ex48/ex48.sh
@@ -5,7 +5,7 @@
 # GMT modules:  makecpt, coast, plot, sphtriangulate, grdimate, gmtmath, text
 #
 
-gmt begin ex48 ps
+gmt begin ex48
 	cat <<- EOF > airports.txt
 	157.8583W	21.3069N	61	300	HNL	BC	0.6i
 	149.5585W	17.5516S	-120	120	PPT	TC	0.6i

--- a/doc/examples/ex49/ex49.sh
+++ b/doc/examples/ex49/ex49.sh
@@ -6,7 +6,7 @@
 #		basemap, legend, colorbar, plot, xyz2grd
 #
 
-gmt begin ex49 ps
+gmt begin ex49
 	# Convert coarser age grid to pixel registration to match bathymetry grid
 	gmt grdsample @age_gridline.nc -T -Gage_pixel.nc
 	# Image depths with color-coded age contours

--- a/doc/examples/ex50/ex50.sh
+++ b/doc/examples/ex50/ex50.sh
@@ -5,7 +5,7 @@
 # GMT modules:  math, set, plot, text
 #
 
-gmt begin ex50 ps
+gmt begin ex50
 	# Left column have all the PDFs
 	gmt set FONT_ANNOT_PRIMARY 10p,Helvetica,black
 	# Binomial distribution

--- a/doc/examples/gmtest.in
+++ b/doc/examples/gmtest.in
@@ -192,7 +192,7 @@ export GMT_SOURCE_DIR="@GMT_SOURCE_DIR@"
 # Font lookup path for Ghostscript (invoked from gm compare and psconvert)
 export GS_FONTPATH="@CMAKE_CURRENT_SOURCE_DIR@/ex31/fonts"
 # Start with proper GMT defaults
-gmt set -Du FORMAT_TIME_STAMP "Version 6"
+gmt set -Du FORMAT_TIME_STAMP "Version 6" GMT_GRAPHICS_FORMAT ps
 # Modern mode needs a stable PPID but ctest messes that up when pipes are used
 if [ ${modern} -gt 0 ]; then
 	export GMT_SESSION_NAME=\$\$


### PR DESCRIPTION
Currently, all modern examples generate images in PS format, since we need PS files for testing purpose. GMT users may be confused why the examples use PS, instead of the default PDF.

In this PR, I removed **ps** from the **gmt begin** command, thus the output figure format is controlled by **GMT_GRAPHICS_FORMAT** (PDF by default).

For most users, they can run the example scripts and generate figures in PDF format. 
For developers, I modified the **gmtest.in**  script and set **GMT_GRAPHICS_FORMAT** to **ps**, so we still have PS files for testing.