### PR TITLE
Improved handling of minus and hyphen in text

### DIFF
--- a/doc/rst/source/postscriptlight.rst
+++ b/doc/rst/source/postscriptlight.rst
@@ -439,6 +439,14 @@ affect the current state of parameters such as line and fill attributes.
     are interpreted as the cutoff acute angle (in degrees) when mitering
     becomes active.
 
+**long PSL_settextmode** (**struct PSL_CTRL** *\*P*, **long** *mode*)
+
+    Changes between the two modes PSL_TXTMODE_MINUS and PSL_TXTMODE_HYPHEN.
+    When the minus mode is active we assume we are plotting annotation
+    strings with numbers and all hyphens are translated to minus codes
+    which differs based on char sets.  Likewise, in hyphen mode any
+    minus character is typeset as a hyphen in the current char set.
+
 **long PSL_settransparency** (**struct PSL_CTRL** *\*P*, **double**
 *\*transparency*)
 

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -4454,11 +4454,11 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		/* Then do annotations too - here just set text height/width parameters in PostScript */
 
 		if (do_annot) {
-			annot_pos = (T->type == 'A' || T->type == 'I') ? 1 : 0;					/* 1 means lower annotation, 0 means upper (close to axis) */
-			font = GMT->current.setting.font_annot[annot_pos];			/* Set the font to use */
+			annot_pos = (T->type == 'A' || T->type == 'I') ? 1 : 0;	/* 1 means lower annotation, 0 means upper (close to axis) */
+			font = GMT->current.setting.font_annot[annot_pos];	/* Set the font to use */
 			form = gmt_setfont (GMT, &font);
 			PSL_command (PSL, "/PSL_AH%d 0\n", annot_pos);
-			PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus */
+			if (A->type != GMT_TIME) PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus */
 			if (first) {
 				/* Change up/down (neg) and/or flip coordinates (exch) */
 				PSL_command (PSL, "/MM {%s%sM} def\n", neg ? "neg " : "", (axis != GMT_X) ? "exch " : "");

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -2327,6 +2327,8 @@ GMT_LOCAL void plot_draw_mag_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, s
 	scale[GMT_ROSE_SECONDARY] = 1.0;
 	GMT->current.plot.r_theta_annot = false;	/* Just in case it was turned on in gmt_map.c */
 
+	PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus signs */
+
 	for (level = 0; level < 2; level++) {	/* Inner (0) and outer (1) angles */
 		if (level == GMT_ROSE_PRIMARY && mr->kind != 2) continue;	/* Sorry, not magnetic directions */
 		if (mr->draw_circle[level]) {
@@ -2449,6 +2451,8 @@ GMT_LOCAL void plot_draw_mag_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, s
 		PSL_plotsymbol (PSL, mr->refpoint->x, mr->refpoint->y, &s, PSL_CIRCLE);
 		PSL_plotsegment (PSL, xp[2], yp[2], xp[3], yp[3]);
 	}
+	
+	PSL_settextmode (PSL, PSL_TXTMODE_HYPHEN);	/* Back to leave as is */
 }
 
 /* These are used to scale the plain arrow given rose size */

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -1896,6 +1896,7 @@ GMT_LOCAL void plot_map_annotate (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, do
 	check_edges = (!GMT->common.R.oblique && (GMT->current.setting.map_frame_type & GMT_IS_INSIDE));
 
 	PSL_comment (PSL, "Map annotations\n");
+	PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus signs */
 
 	form = gmt_setfont (GMT, &GMT->current.setting.font_annot[GMT_PRIMARY]);
 
@@ -2022,6 +2023,7 @@ GMT_LOCAL void plot_map_annotate (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, do
 	GMT->current.map.on_border_is_outside = false;	/* Reset back to default */
 	GMT->current.map.is_world = is_world_save;
 	GMT->current.map.lon_wrap = lon_wrap_save;
+	PSL_settextmode (PSL, PSL_TXTMODE_HYPHEN);	/* Back to leave as is */
 }
 
 GMT_LOCAL void plot_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double w, double e, double s, double n) {
@@ -4452,6 +4454,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 			font = GMT->current.setting.font_annot[annot_pos];			/* Set the font to use */
 			form = gmt_setfont (GMT, &font);
 			PSL_command (PSL, "/PSL_AH%d 0\n", annot_pos);
+			PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus */
 			if (first) {
 				/* Change up/down (neg) and/or flip coordinates (exch) */
 				PSL_command (PSL, "/MM {%s%sM} def\n", neg ? "neg " : "", (axis != GMT_X) ? "exch " : "");
@@ -4507,6 +4510,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 			for (i = 0; i < nx; i++) gmt_M_str_free (label_c[i]);
 			gmt_M_free (GMT, label_c);
 		}
+		PSL_settextmode (PSL, PSL_TXTMODE_HYPHEN);	/* Replace hyphens with minus */
 	}
 	if (np) gmt_M_free (GMT, knots_p);
 
@@ -6005,6 +6009,7 @@ void gmt_contlabel_plot (struct GMT_CTRL *GMT, struct GMT_CONTOUR *G) {
 		return;
 	}
 
+	PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus signs */
 	gmt_setfont (GMT, &G->font_label);
 
 	if (G->must_clip) {		/* Transparent boxes means we must set up plot text, then set up clip paths, then draw lines, then deactivate clipping */
@@ -6023,6 +6028,7 @@ void gmt_contlabel_plot (struct GMT_CTRL *GMT, struct GMT_CONTOUR *G) {
 		plot_contlabel_plotlabels (GMT, PSL, G, mode);	/* Plot labels and possibly turn on clipping if delay */
 	}
 	PSL_command (GMT->PSL, "[] 0 B\n");	/* Ensure no pen textures remain in effect */
+	PSL_settextmode (PSL, PSL_TXTMODE_HYPHEN);	/* Back to leave as is */
 }
 
 #if 0        	// We have no current need for this anymore

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -833,6 +833,8 @@ GMT_LOCAL void grd_sort_and_plot_ticks (struct GMT_CTRL *GMT, struct PSL_CTRL *P
 	 * One idea would be to add help points to include the pole and used this polygon to compute where to
 	 * plot the label but then skip those points when drawing the line. */
 
+	PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus signs */
+
 	for (pol = 0; tick_label && pol < n; pol++) {	/* Finally, do labels */
 		if (!save[pol].do_it) continue;
 		if (abs (save[pol].kind) == 2 && gmt_M_is_azimuthal (GMT)) {	/* Only plot once at mean location */
@@ -859,6 +861,8 @@ GMT_LOCAL void grd_sort_and_plot_ticks (struct GMT_CTRL *GMT, struct PSL_CTRL *P
 			if (mode & 2) gmt_add_label_record (GMT, T, save[pol].xlabel, save[pol].ylabel, 0.0, lbl[save[pol].high]);
 		}
 	}
+	
+	PSL_settextmode (PSL, PSL_TXTMODE_HYPHEN);	/* Back to leave as is */
 	PSL_comment (PSL, "End Embellishment of innermost contours\n");
 }
 

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -616,10 +616,8 @@ static void *psl_memory (struct PSL_CTRL *PSL, void *prev_addr, size_t nelem, si
  *   We also handle the differences between hyphens and minus symbol.
  * In ISOLatin1 the hyphen key on the keyboard results in a minus sign while
  * in Standard it gives a hyphen.  In GMT we want minus signs in annotations
- * contours and other numerical negative values.  We assume that if a string
- * begins with a hyphen then a minus sign is implied.  Likewise, if a hyphen
- * is found later on in the string we assume it is a hyphen and under ISOLatin1
- * we must insert the octal code for the hyphen (0255). */
+ * contours and other numerical negative values. This behavior is controlled
+ * by the setting in PSL_settextmode. */
 
 
 static unsigned int psl_ut8_code_to_ISOLatin (char code) {
@@ -648,8 +646,8 @@ static void psl_fix_utf8 (struct PSL_CTRL *PSL, char *in_string) {
 		if ((unsigned char)(in_string[k]) == 0303 || (unsigned char)(in_string[k]) == 0305)
 			utf8_codes++;	/* Count them up */
 		//else if (in_string[k] == 0055 && k && !(in_string[k-1] == '@' || in_string[k-1] == ' '))	/* A hyphen needs a non-blank before it (k > 0) unlike a negative number (but watch out for @- for subscript) */
-		else if (in_string[k] == 0055 && do_minus)	/* A hyphen needs a non-blank before it (k > 0) unlike a negative number (but watch out for @- for subscript) */
-			in_string[k] = 0255;	/* Hyphen is octal 255 in ISOLatin1 */
+		else if ((unsigned char)in_string[k] == 0255 && do_minus)
+			in_string[k] = 0055;	/* Minus is octal 0055 in ISOLatin1 */
 	}
 	if (utf8_codes == 0) return;	/* Nothing to do */
 

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -635,7 +635,7 @@ static void psl_fix_utf8 (struct PSL_CTRL *PSL, char *in_string) {
 
 	if (!strncmp (PSL->init.encoding, "Standard+", 9U) && do_minus) {	/* For Standard+ encoding we may need to swap leading minus values encoded as hyphen with the actual minus symbol */
 		for (k = 0; in_string[k]; k++) {
-			if (in_string[k] == 0055)	/* Found leading hyphen which we interpret to be a minus sign */
+			if ((k == 0 || in_string[k-1] != '@') && in_string[k] == 0055)	/* Found a hyphen which we interpret to be a minus sign */
 				in_string[k] = 0224;	/* Minus is octal 224 in Standard+ but not present in just Standard */
 		}
 	}
@@ -645,9 +645,12 @@ static void psl_fix_utf8 (struct PSL_CTRL *PSL, char *in_string) {
 	for (k = 0; in_string[k]; k++) {
 		if ((unsigned char)(in_string[k]) == 0303 || (unsigned char)(in_string[k]) == 0305)
 			utf8_codes++;	/* Count them up */
-		//else if (in_string[k] == 0055 && k && !(in_string[k-1] == '@' || in_string[k-1] == ' '))	/* A hyphen needs a non-blank before it (k > 0) unlike a negative number (but watch out for @- for subscript) */
-		else if ((unsigned char)in_string[k] == 0255 && do_minus)
-			in_string[k] = 0055;	/* Minus is octal 0055 in ISOLatin1 */
+		else if (k == 0 || in_string[k-1] != '@') {
+			if ((unsigned char)in_string[k] == 0255 && do_minus)
+				in_string[k] = 0055;	/* Minus symbol is octal 0055 in ISOLatin1 */
+			else if ((unsigned char)in_string[k] == 0055 && !do_minus)
+				in_string[k] = 0255;	/* Hyphen symbol is octal 0255 in ISOLatin1 */
+		}
 	}
 	if (utf8_codes == 0) return;	/* Nothing to do */
 

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -206,6 +206,11 @@ enum PSL_enum_txt {PSL_TXT_INIT	= 1,
 	PSL_TXT_FILLBOX		= 128,
 	PSL_TXT_DRAWBOX		= 256};
 
+/* PSL codes for text hyphen substitution (PSL_settextmode) */
+
+enum PSL_enum_txtmode {PSL_TXTMODE_HYPHEN	= 0,
+	PSL_TXTMODE_MINUS			= 1};
+	
 /* Verbosity levels */
 
 enum PSL_enum_verbose {PSL_MSG_QUIET = 0,	/* No messages whatsoever */
@@ -291,6 +296,7 @@ struct PSL_CTRL {
 		int font_no;			/* Current font number				*/
 		int outline;			/* Current outline				*/
 		int complete;			/* true for executing a custom PSL_plot_completion procedure once */
+		int use_minus;			/* true for replacing hyphen code with minus codes */
 	} current;
 	struct INTERNAL {	/* Variables used internally only */
 		char *SHAREDIR;			/* Pointer to path of directory with postscriptlight subdirectory */
@@ -419,6 +425,7 @@ EXTERN_MSC int PSL_setmiterlimit (struct PSL_CTRL *PSL, int limit);
 EXTERN_MSC int PSL_setorigin (struct PSL_CTRL *PSL, double x, double y, double angle, int mode);
 EXTERN_MSC int PSL_setparagraph (struct PSL_CTRL *PSL, double line_space, double par_width, int par_just);
 EXTERN_MSC int PSL_setpattern (struct PSL_CTRL *PSL, int image_no, char *imagefile, int image_dpi, double f_rgb[], double b_rgb[]);
+EXTERN_MSC int PSL_settextmode (struct PSL_CTRL *PSL, int mode);
 EXTERN_MSC int PSL_settransparency (struct PSL_CTRL *PSL, double transparency);
 EXTERN_MSC int PSL_settransparencymode (struct PSL_CTRL *PSL, const char *mode);
 EXTERN_MSC int PSL_definteger (struct PSL_CTRL *PSL, const char *param, int value);

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -314,6 +314,8 @@ GMT_LOCAL void sort_and_plot_ticks (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, 
 
 	/* Here, only the polygons that are innermost (containing the local max/min, will have do_it = true */
 
+	PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus signs */
+
 	for (pol = 0; pol < n; pol++) {
 		if (!save[pol].do_it) continue;
 		np = save[pol].n;
@@ -381,6 +383,8 @@ GMT_LOCAL void sort_and_plot_ticks (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, 
 			}
 		}
 	}
+	
+	PSL_settextmode (PSL, PSL_TXTMODE_HYPHEN);	/* Back to leave as is */
 }
 
 GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -1125,6 +1125,8 @@ GMT_LOCAL void gmt_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctr
 			}
 
 			/* Now we place annotations */
+
+			PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus signs */
 			form = gmt_setfont (GMT, &GMT->current.setting.font_annot[GMT_PRIMARY]);
 			x1 = xleft;
 			if (center) x1 += 0.5 * z_width[0];	/* Can use z_width[0] since -L forces all widths to be equal */
@@ -1170,6 +1172,7 @@ GMT_LOCAL void gmt_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctr
 					if (do_annot) PSL_plottext (PSL, xpos[P->n_colors], y_annot, GMT->current.setting.font_annot[GMT_PRIMARY].size, text, 0.0, -this_just, form);
 				}
 			}
+			PSL_settextmode (PSL, PSL_TXTMODE_HYPHEN);	/* Back to leave as is */
 		}
 
 		if (label[0]) {	/* Add label */
@@ -1391,6 +1394,7 @@ GMT_LOCAL void gmt_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctr
 
 			/* Finally plot annotations */
 
+			PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus signs */
 			form = gmt_setfont (GMT, &GMT->current.setting.font_annot[GMT_PRIMARY]);
 			x1 = xleft;
 			if (center) x1 += 0.5 * z_width[0];	/* Can use z_width[0] since -L forces all widths to be equal */
@@ -1440,6 +1444,7 @@ GMT_LOCAL void gmt_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctr
 					if (do_annot) PSL_plottext (PSL, xpos[P->n_colors], y_annot, GMT->current.setting.font_annot[GMT_PRIMARY].size, text, -90.0, -this_just, form);
 				}
 			}
+			PSL_settextmode (PSL, PSL_TXTMODE_HYPHEN);	/* Back to leave as is */
 		}
 
 		if (label[0]) {	/* Add label */

--- a/src/pstext.c
+++ b/src/pstext.c
@@ -939,6 +939,7 @@ int GMT_pstext (void *V_API, int mode, void *args) {
 			geometry = (Ctrl->F.mixed) ? GMT_IS_NONE : GMT_IS_POINT;
 			if (!Ctrl->F.mixed) cmode =  GMT_COL_FIX_NO_TEXT;
 			code = 1;
+			PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus signs */
 		}
 		else if (Ctrl->F.get_text == GET_REC_NUMBER) {	/* Format record number into text */
 			rec_mode = (ncol) ? GMT_READ_MIXED : GMT_READ_DATA;
@@ -1315,6 +1316,8 @@ int GMT_pstext (void *V_API, int mode, void *args) {
 	if (GMT_End_IO (API, GMT_IN, 0) != GMT_NOERROR) {	/* Disables further data input */
 		Return (API->error);
 	}
+
+	PSL_settextmode (PSL, PSL_TXTMODE_HYPHEN);	/* Back to leave as is */
 
 	if (GMT->common.t.variable)	/* Reset the transparency */
 		PSL_settransparency (PSL, 0.0);

--- a/test/grdblend/center_bf_g.sh
+++ b/test/grdblend/center_bf_g.sh
@@ -11,7 +11,7 @@ gmt grdblend -R-1/1/-1/1 -I1 LL.grd=bf LR.grd=bf UL.grd=bf UR.grd=bf -GCM.nc
 gmt grdblend -R-2/2/-2/2 -I1 LL.grd=bf LR.grd=bf UL.grd=bf UR.grd=bf -Gall.nc
 gmt makecpt -Cjet -T-4/4 > t.cpt
 gmt grdimage CM.nc -Ct.cpt -JX4i -P -Bafg2 -K -Xc > $ps
-gmt grd2xyz CM.nc | gmt pstext -RCM.nc -JX4i -O -K -F+f16p+jCM -N -Gwhite >> $ps
+gmt grd2xyz CM.nc | gmt pstext -RCM.nc -JX4i -O -K -F+f16p+jCM+z%g -N -Gwhite >> $ps
 gmt grdimage all.nc -Ct.cpt -JX4i -P -Bafg2 -BWsNE+t"Gridline Native binary bf" -O -K -Y4.5i >> $ps
 gmt grdinfo CM.nc -Ib | gmt psxy -Rall.nc -JX4i -W4p -O -K -A >> $ps
-gmt grd2xyz all.nc | gmt pstext -Rall.nc -JX4i -O -F+f16p+jCM -N -Gwhite >> $ps
+gmt grd2xyz all.nc | gmt pstext -Rall.nc -JX4i -O -F+f16p+jCM+z%g -N -Gwhite >> $ps

--- a/test/grdblend/center_bf_p.sh
+++ b/test/grdblend/center_bf_p.sh
@@ -11,7 +11,7 @@ gmt grdblend -R-1/1/-1/1 -I1 -r LL.grd=bf LR.grd=bf UL.grd=bf UR.grd=bf -GCM.nc
 gmt grdblend -R-2/2/-2/2 -I1 -r LL.grd=bf LR.grd=bf UL.grd=bf UR.grd=bf -Gall.nc
 gmt makecpt -Cjet -T-4/4 > t.cpt
 gmt grdimage CM.nc -Ct.cpt -JX4i -P -Bafg2 -K -Xc > $ps
-gmt grd2xyz CM.nc | gmt pstext -RCM.nc -JX4i -O -K -F+f16p+jCM >> $ps
+gmt grd2xyz CM.nc | gmt pstext -RCM.nc -JX4i -O -K -F+f16p+jCM+z%g >> $ps
 gmt grdimage all.nc -Ct.cpt -JX4i -P -Bafg2 -BWsNE+t"Pixel native binary bf" -O -K -Y4.5i >> $ps
 gmt grdinfo CM.nc -Ib | gmt psxy -Rall.nc -JX4i -W4p -O -K -A >> $ps
-gmt grd2xyz all.nc | gmt pstext -Rall.nc -JX4i -O -F+f16p+jCM  >> $ps
+gmt grd2xyz all.nc | gmt pstext -Rall.nc -JX4i -O -F+f16p+jCM+z%g  >> $ps

--- a/test/grdblend/center_cf_g.sh
+++ b/test/grdblend/center_cf_g.sh
@@ -11,7 +11,7 @@ gmt grdblend -R-1/1/-1/1 -I1 LL.cdf=cf LR.cdf=cf UL.cdf=cf UR.cdf=cf -GCM.nc
 gmt grdblend -R-2/2/-2/2 -I1 LL.cdf=cf LR.cdf=cf UL.cdf=cf UR.cdf=cf -Gall.nc
 gmt makecpt -Cjet -T-4/4 > t.cpt
 gmt grdimage CM.nc -Ct.cpt -JX4i -P -Bafg2 -K -Xc > $ps
-gmt grd2xyz CM.nc | gmt pstext -RCM.nc -JX4i -O -K -F+f16p+jCM -N -Gwhite >> $ps
+gmt grd2xyz CM.nc | gmt pstext -RCM.nc -JX4i -O -K -F+f16p+jCM+z%g -N -Gwhite >> $ps
 gmt grdimage all.nc -Ct.cpt -JX4i -P -Bafg2 -BWsNE+t"Gridline old netCDF cf" -O -K -Y4.5i >> $ps
 gmt grdinfo CM.nc -Ib | gmt psxy -Rall.nc -JX4i -W4p -O -K -A >> $ps
-gmt grd2xyz all.nc | gmt pstext -Rall.nc -JX4i -O -F+f16p+jCM -N -Gwhite >> $ps
+gmt grd2xyz all.nc | gmt pstext -Rall.nc -JX4i -O -F+f16p+jCM+z%g -N -Gwhite >> $ps

--- a/test/grdblend/center_cf_p.sh
+++ b/test/grdblend/center_cf_p.sh
@@ -11,7 +11,7 @@ gmt grdblend -R-1/1/-1/1 -I1 -r LL.cdf=cf LR.cdf=cf UL.cdf=cf UR.cdf=cf -GCM.nc
 gmt grdblend -R-2/2/-2/2 -I1 -r LL.cdf=cf LR.cdf=cf UL.cdf=cf UR.cdf=cf -Gall.nc
 gmt makecpt -Cjet -T-4/4 > t.cpt
 gmt grdimage CM.nc -Ct.cpt -JX4i -P -Bafg2 -K -Xc > $ps
-gmt grd2xyz CM.nc | gmt pstext -RCM.nc -JX4i -O -K -F+f16p+jCM >> $ps
+gmt grd2xyz CM.nc | gmt pstext -RCM.nc -JX4i -O -K -F+f16p+jCM+z%g >> $ps
 gmt grdimage all.nc -Ct.cpt -JX4i -P -Bafg2 -BWsNE+t"Pixel old netCDF cf" -O -K -Y4.5i >> $ps
 gmt grdinfo CM.nc -Ib | gmt psxy -Rall.nc -JX4i -W4p -O -K -A >> $ps
-gmt grd2xyz all.nc | gmt pstext -Rall.nc -JX4i -O -F+f16p+jCM  >> $ps
+gmt grd2xyz all.nc | gmt pstext -Rall.nc -JX4i -O -F+f16p+jCM+z%g  >> $ps

--- a/test/grdblend/center_nf_g.sh
+++ b/test/grdblend/center_nf_g.sh
@@ -11,7 +11,7 @@ gmt grdblend -R-1/1/-1/1 -I1 LL.nc LR.nc UL.nc UR.nc -GCM.nc
 gmt grdblend -R-2/2/-2/2 -I1 LL.nc LR.nc UL.nc UR.nc -Gall.nc
 gmt makecpt -Cjet -T-4/4 > t.cpt
 gmt grdimage CM.nc -Ct.cpt -JX4i -P -Bafg2 -K -Xc > $ps
-gmt grd2xyz CM.nc | gmt pstext -RCM.nc -JX4i -O -K -F+f16p+jCM -N -Gwhite >> $ps
+gmt grd2xyz CM.nc | gmt pstext -RCM.nc -JX4i -O -K -F+f16p+jCM+z%g -N -Gwhite >> $ps
 gmt grdimage all.nc -Ct.cpt -JX4i -P -Bafg2 -BWsNE+t"Gridline new netCDF nf" -O -K -Y4.5i >> $ps
 gmt grdinfo CM.nc -Ib | gmt psxy -Rall.nc -JX4i -W4p -O -K -A >> $ps
-gmt grd2xyz all.nc | gmt pstext -Rall.nc -JX4i -O -F+f16p+jCM -N -Gwhite >> $ps
+gmt grd2xyz all.nc | gmt pstext -Rall.nc -JX4i -O -F+f16p+jCM+z%g -N -Gwhite >> $ps

--- a/test/grdblend/center_nf_p.sh
+++ b/test/grdblend/center_nf_p.sh
@@ -11,7 +11,7 @@ gmt grdblend -R-1/1/-1/1 -I1 -r LL.nc LR.nc UL.nc UR.nc -GCM.nc
 gmt grdblend -R-2/2/-2/2 -I1 -r LL.nc LR.nc UL.nc UR.nc -Gall.nc
 gmt makecpt -Cjet -T-4/4 > t.cpt
 gmt grdimage CM.nc -Ct.cpt -JX4i -P -Bafg2 -K -Xc > $ps
-gmt grd2xyz CM.nc | gmt pstext -RCM.nc -JX4i -O -K -F+f16p+jCM >> $ps
+gmt grd2xyz CM.nc | gmt pstext -RCM.nc -JX4i -O -K -F+f16p+jCM+z%g >> $ps
 gmt grdimage all.nc -Ct.cpt -JX4i -P -Bafg2 -BWsNE+t"Pixel new netCDF nf" -O -K -Y4.5i >> $ps
 gmt grdinfo CM.nc -Ib | gmt psxy -Rall.nc -JX4i -W4p -O -K -A >> $ps
-gmt grd2xyz all.nc | gmt pstext -Rall.nc -JX4i -O -F+f16p+jCM  >> $ps
+gmt grd2xyz all.nc | gmt pstext -Rall.nc -JX4i -O -F+f16p+jCM+z%g  >> $ps


### PR DESCRIPTION
**Description of proposed changes**

See #1421 for background.  This PR addresses this by replacing hyphens with minus sign _only_ during axes annotations.  For the example in #1421 , we now get this:
![isolatin](https://user-images.githubusercontent.com/26473567/64082394-ebda4380-cca9-11e9-8906-9f5847e04045.png)

The implementation is a new PSL function _PSL_settextmode_ that can be used to switch the text machine from replacing hyphens with minus sings (for annotations) or the other way around (for text).  The changes brings 52 test "failures" and I wanted to confirm with you what you thing (please build this PR and run tests).  What I see are these types of failures:

1. Powers of ten (10^-3) now uses the minus symbols whereas in the past those remained hyphens.  This is an improvement; e.g. ex03.sh
2. Lots of basic text and labels that contained hyphens were typeset as minus before (e.g., new_gaps.sh printing GMT option settings and the leading hyphen would become a minus.  This is good. Most of the failures seems to be text with hyphens incorrectly changed to minus.
3. Plotting negative numbers with pstext (e.g., center_bf_g.sh, reduce.sh) now have hyphens. Do we rely on octal codes here (awkward when plotting data tables) or do we check for a single word that is a number and then switch automatically?  Other than -F+z we cannot really know.
4. Sometimes we set an equation and it may contain minus sign, with pstext. We could scan for @~ (switching to symbol font) as an indication of math and use minus.  Thoughts on that one?  Other places we cannot know, e.g., -6x4 labels in geodesy_01.sh.  In some doc scripts we actually use the octal code for a long-dash or minus to force the issue (GMT_-OK.sh).
5. Embedded negative numbers in magnetic rose direction now has minus sign (e.g. rose_map1.sh).
6. Lastly, time axis with primary and secondary annotations (e.g., time_testing_6.sh).  Right now, the labels January-04 uses a minus instead of a hyphen.  This may be a good effect, but it is also easy to turn off minus here since all those numbers are positive, hence we can be reasonably assured that a hyphen is a hyphen.  Shall I force these to be hyphens?

Let me know what you are willing to consider good failures and what you think we need to do further with this PR.

