### PR TITLE
Add --new-script option to gmt

### DIFF
--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -77,11 +77,14 @@ several other options are available:
 **--help**
     List and description of GMT modules.
 
-**--show-cores**
-    Show number of available cores.
+**--new-script**
+    Write a GMT modern mode script template to stdout.
 
 **--show-bindir**
     Show directory of executables and exit.
+
+**--show-cores**
+    Show number of available cores.
 
 **--show-datadir**
     Show data directory/ies and exit.
@@ -91,6 +94,9 @@ several other options are available:
 
 **--show-modules**
     List module names on stdout and exit.
+
+**--show-library**
+    Show the path of the shared GMT library.
 
 **--show-plugindir**
     Show plugin directory and exit.

--- a/src/gmt.c
+++ b/src/gmt.c
@@ -200,12 +200,14 @@ int main (int argc, char *argv[]) {
 			/* print new shell template */
 			else if (!strncmp (argv[arg_n], "--new-script", 12U)) {
 				unsigned int type = 0;
-				char *txt = getenv ("shell"), *shell[2] = {"bash", "csh"};
+				time_t right_now = time (NULL);
+				char *txt = getenv ("shell"), *shell[2] = {"bash", "csh"}, stamp[GMT_LEN32] = {""};
+				strftime (stamp, GMT_LEN32, "%FT%R", localtime (&right_now));
 				if (((txt = getenv ("shell")) || (txt = getenv ("SHELL"))) && (txt && strstr (txt, "csh")))	/* Got csh or tcsh */
 					type = 1;
-				printf ("#/usr/bin/env %s\n", shell[type]);
+				printf ("#!/usr/bin/env %s\n", shell[type]);
 				printf ("# GMT standard %s template\n", shell[type]);
-				printf ("# Date:\n# Purpose:\n");
+				printf ("# Date: %s\n# Purpose:\n", stamp);
 				if (type)
 					printf ("setenv GMT_SESSION_NAME $$    # Set a unique session name\n");
 				else

--- a/src/gmt.c
+++ b/src/gmt.c
@@ -206,8 +206,8 @@ int main (int argc, char *argv[]) {
 				if (((txt = getenv ("shell")) || (txt = getenv ("SHELL"))) && (txt && strstr (txt, "csh")))	/* Got csh or tcsh */
 					type = 1;
 				printf ("#!/usr/bin/env %s\n", shell[type]);
-				printf ("# GMT standard %s template\n", shell[type]);
-				printf ("# Date: %s\n# Purpose:\n", stamp);
+				printf ("# GMT modern mode %s template\n", shell[type]);
+				printf ("# Date: %s\n# User: %s\n# Purpose:\n", stamp, gmt_putusername(NULL));
 				if (type)
 					printf ("setenv GMT_SESSION_NAME $$    # Set a unique session name\n");
 				else

--- a/src/gmt.c
+++ b/src/gmt.c
@@ -197,6 +197,23 @@ int main (int argc, char *argv[]) {
 				status = GMT_NOERROR;
 			}
 
+			/* print new shell template */
+			else if (!strncmp (argv[arg_n], "--new-script", 12U)) {
+				unsigned int type = 0;
+				char *txt = getenv ("shell"), *shell[2] = {"bash", "csh"};
+				if (((txt = getenv ("shell")) || (txt = getenv ("SHELL"))) && (txt && strstr (txt, "csh")))	/* Got csh or tcsh */
+					type = 1;
+				printf ("#/usr/bin/env %s\n", shell[type]);
+				printf ("# GMT standard %s template\n", shell[type]);
+				printf ("# Date:\n# Purpose:\n");
+				if (type)
+					printf ("setenv GMT_SESSION_NAME $$    # Set a unique session name\n");
+				else
+					printf ("export GMT_SESSION_NAME=$$    # Set a unique session name\n");
+				printf ("gmt begin\n\t#<place modern session commands here>\ngmt end show\n");
+				status = GMT_NOERROR;
+			}
+
 		} /* for (arg_n = 1; arg_n < argc; ++arg_n) */
 	} /* status == GMT_NOERROR */
 
@@ -231,6 +248,7 @@ int main (int argc, char *argv[]) {
 			fprintf (stderr, "       %s <module name> [<module-options>]\n\n", PROGRAM_NAME);
 			fprintf (stderr, "options:\n");
 			fprintf (stderr, "  --help            List descriptions of available GMT modules.\n");
+			fprintf (stderr, "  --new-script      Write GMT modern mode script template to stdout.\n");
 			fprintf (stderr, "  --show-bindir     Show directory with GMT executables.\n");
 			fprintf (stderr, "  --show-cores      Show number of available cores.\n");
 			fprintf (stderr, "  --show-datadir    Show directory/ies with user data.\n");

--- a/src/gmt.c
+++ b/src/gmt.c
@@ -206,7 +206,7 @@ int main (int argc, char *argv[]) {
 				strftime (stamp, GMT_LEN32, "%FT%T", localtime (&right_now));
 				if ((txt = getenv ("shell")) == NULL) txt = getenv ("SHELL");	/* Here txt is either a shell path or NULL */
 #ifdef WIN32
-				if (txt == NULL)	/* Assume batch then */
+				if (txt == NULL)	/* Assume batch if no shell setting exist udner Windows */
 					type = 2;
 #endif
 				if (type == 0 && txt && strstr (txt, "csh"))	/* Got csh or tcsh */
@@ -218,8 +218,8 @@ int main (int argc, char *argv[]) {
 				switch (type) {
 					case 0: printf ("export GMT_SESSION_NAME=$$	# Set a unique session name\n"); break;
 					case 1: printf ("setenv GMT_SESSION_NAME $$	# Set a unique session name\n"); break;
-					case 2: printf ("REM Set a unique session name:\n");
-						printf ("set GMT_SESSION_NAME $$\n");
+					case 2: printf ("REM Set a unique session name:\n");	/* Can't use $$ so output the PPID of this process */
+						printf ("set GMT_SESSION_NAME %s\n", api_ctrl->session_name);
 						break;
 				}
 				printf ("gmt begin figurename\n\t%sPlace modern session commands here\ngmt end show\n", comment[type]);

--- a/src/gmt.c
+++ b/src/gmt.c
@@ -222,7 +222,7 @@ int main (int argc, char *argv[]) {
 						printf ("set GMT_SESSION_NAME=%s\n", api_ctrl->session_name);
 						break;
 				}
-				printf ("gmt begin figurename\n\t%sPlace modern session commands here\ngmt end show\n", comment[type]);
+				printf ("gmt begin figurename\n\t%s Place modern session commands here\ngmt end show\n", comment[type]);
 				status = GMT_NOERROR;
 			}
 

--- a/src/gmt.c
+++ b/src/gmt.c
@@ -219,7 +219,7 @@ int main (int argc, char *argv[]) {
 					case 0: printf ("export GMT_SESSION_NAME=$$	# Set a unique session name\n"); break;
 					case 1: printf ("setenv GMT_SESSION_NAME $$	# Set a unique session name\n"); break;
 					case 2: printf ("REM Set a unique session name:\n");	/* Can't use $$ so output the PPID of this process */
-						printf ("set GMT_SESSION_NAME %s\n", api_ctrl->session_name);
+						printf ("set GMT_SESSION_NAME=%s\n", api_ctrl->session_name);
 						break;
 				}
 				printf ("gmt begin figurename\n\t%sPlace modern session commands here\ngmt end show\n", comment[type]);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14592,7 +14592,7 @@ char *gmt_putusername (struct GMT_CTRL *GMT) {
 		DWORD Size = _tcslen (name);
 		if (GetUserName (name, &Size)) /* Got a user name, return it */
 			return (name);
-		if ((U = getenv ("USERNAME"))	/* Got a name from the environment instead */
+		if (U = getenv ("USERNAME"))	/* Got a name from the environment instead */
 			return (U);
 	}
 #endif

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -85,6 +85,8 @@
 #include <locale.h>
 #ifndef WIN32
 #include <glob.h>
+#else
+#include <Windows.h>
 #endif
 
 /*! . */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14588,10 +14588,12 @@ char *gmt_putusername (struct GMT_CTRL *GMT) {
 #endif
 #ifdef WIN32
 	{
-		char name[GMT_LEN256] = {""};
+		char name[GMT_LEN256] = {""}, *U = NULL;
 		DWORD Size = _tcslen (name);
-		if (GetUserName (name, &Size))
+		if (GetUserName (name, &Size)) /* Got a user name, return it */
 			return (name);
+		if ((U = getenv ("USERNAME"))	/* Got a name from the environment instead */
+			return (U);
 	}
 #endif
 	return (unknown);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14584,6 +14584,14 @@ char *gmt_putusername (struct GMT_CTRL *GMT) {
 	pw = getpwuid (getuid ());
 	if (pw) return (pw->pw_name);
 #endif
+#ifdef WIN32
+	{
+		char name[GMT_LEN256] = {""};
+		DWORD Size = _tcslen (name);
+		if (GetUserName (name, &Size))
+			return (name);
+	}
+#endif
 	return (unknown);
 }
 


### PR DESCRIPTION
This option will write a modern mode script template to stdout in either bash or csh format.  We could extend this to DOS batch if we can detect the Windows command window (?). Not tested by a user whose default shell is csh or tcsh.
