### PR TITLE
Remove scheduled builds from the YAML configure file

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -11,22 +11,6 @@ trigger:
     - 5.4
     - refs/tags/*
 
-# Scheduled build
-schedules:
-- cron: "0 0 * * *"
-  displayName: Scheduled daily build
-  branches:
-    include:
-    - master
-    - 6.0
-  always: true
-- cron: "0 0 1 * *"
-  displayName: Scheduled monthly build
-  branches:
-    include:
-    - 5.4
-  always: true
-
 jobs:
 
 # Linux - Compile only


### PR DESCRIPTION
According to the [Azure Pipeline documentations](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#scheduled-triggers), we can setup scheduled triggers in the YAML file and/or the pipeline settings UI, and the UI defined scheduled triggers take precedence over YAML scheduled triggers.

But, there may be some bugs from their side. Our scheduled triggers don't work in that way. The YAML scheduled triggers are never run. This PR removes the scheduled triggers from the YAML file.