### PR TITLE
Synchronize cmake settings with admin/ConfigReleaseBuild.cmake

### DIFF
--- a/admin/ConfigReleaseBuild.cmake
+++ b/admin/ConfigReleaseBuild.cmake
@@ -4,7 +4,7 @@
 # your environment and pointing to the latest releases.
 #
 #-------------------------------------------------------------
-set (CMAKE_BUILD_TYPE relwithdebinfo)
+set (CMAKE_BUILD_TYPE Release)
 set (CMAKE_INSTALL_PREFIX "gmt-${GMT_PACKAGE_VERSION}")
 set (GSHHG_ROOT "$ENV{GMT_GSHHG_SOURCE}")
 set (DCW_ROOT "$ENV{GMT_DCW_SOURCE}")

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -90,7 +90,7 @@ steps:
     mkdir build
     cd build
     call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-    cmake .. -G "Ninja" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_C_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Release
+    cmake .. -G "Ninja" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_C_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=RelWithDebInfo
     cmake --build .
     cmake --build . --target install
   displayName: Compile GMT

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -90,7 +90,7 @@ steps:
     mkdir build
     cd build
     call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-    cmake .. -G "Ninja" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_C_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    cmake .. -G "Ninja" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_C_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Release
     cmake --build .
     cmake --build . --target install
   displayName: Compile GMT

--- a/ci/build-gmt.sh
+++ b/ci/build-gmt.sh
@@ -5,7 +5,7 @@
 set -e
 
 cat > cmake/ConfigUser.cmake << 'EOF'
-set (CMAKE_BUILD_TYPE relwithdebinfo)
+set (CMAKE_BUILD_TYPE Release)
 set (CMAKE_INSTALL_PREFIX "$ENV{INSTALLDIR}")
 set (GSHHG_ROOT "$ENV{COASTLINEDIR}/gshhg")
 set (DCW_ROOT "$ENV{COASTLINEDIR}/dcw")

--- a/ci/build-gmt.sh
+++ b/ci/build-gmt.sh
@@ -5,14 +5,21 @@
 set -e
 
 cat > cmake/ConfigUser.cmake << 'EOF'
+set (CMAKE_BUILD_TYPE relwithdebinfo)
 set (CMAKE_INSTALL_PREFIX "$ENV{INSTALLDIR}")
 set (GSHHG_ROOT "$ENV{COASTLINEDIR}/gshhg")
 set (DCW_ROOT "$ENV{COASTLINEDIR}/dcw")
 set (COPY_GSHHG TRUE)
 set (COPY_DCW TRUE)
+
+set (GMT_INSTALL_MODULE_LINKS FALSE)
 set (GMT_USE_THREADS TRUE)
 set (GMT_ENABLE_OPENMP TRUE)
+
+# recommended even for release build
 set (CMAKE_C_FLAGS "-Wall -Wdeclaration-after-statement ${CMAKE_C_FLAGS}")
+# extra warnings
+set (CMAKE_C_FLAGS "-Wextra ${CMAKE_C_FLAGS}")
 EOF
 
 if [[ "$TEST" == "true" ]]; then
@@ -23,7 +30,7 @@ set (DO_TESTS TRUE)
 set (DO_API_TESTS ON)
 set (N_TEST_JOBS 2)
 set (SUPPORT_EXEC_IN_BINARY_DIR TRUE)
-set (CMAKE_C_FLAGS "-Wextra -coverage -O0 ${CMAKE_C_FLAGS}")
+set (CMAKE_C_FLAGS "-coverage -O0 ${CMAKE_C_FLAGS}")
 EOF
 fi
 


### PR DESCRIPTION
In anticipation to the possible nightly dev releases (macOS and Windows), I synchronized the settings in admin/ConfigReleaseBuild.cmake to the CI cmake settings. I also changed the CMAKE_BUILD_TYPE to _RelWithDebInfo_, as it's said to be better than _Release_.