### PR TITLE
Handle no arguments in mapproejct -G

### DIFF
--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -149,7 +149,7 @@ Optional Arguments
     **c** (Cartesian distance using input coordinates) or **C**
     (Cartesian distance using projected coordinates). The **C** unit
     requires **-R** and **-J** to be set. When no fixed point is given
-    we calculate accumulative distances [or by adding **+a**] along the
+    we calculate accumulated distances [or by adding **+a**] along the
     track defined by the input points. Append **+i** to obtain *incremental*
     distances between successive points, or append both modifiers to get
     both distance measurements. Alternatively, append **+v** to obtain a

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -481,7 +481,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct 
 			case 'G':	/* Syntax. Old: -G[<lon0/lat0>][/[+|-]unit][+|-]  New: -G[<lon0/lat0>][+i][+a][+u<unit>][+v] */
 				Ctrl->G.active = true;
 				for (n_slash = k = 0; opt->arg[k]; k++) if (opt->arg[k] == '/') n_slash++;
-				if (n_slash == 2 || !(strstr (opt->arg, "+a") || strstr (opt->arg, "+i") || strstr (opt->arg, "+u") || strstr (opt->arg, "+v")))
+				if (opt->arg[0] && (n_slash == 2 || !(strstr (opt->arg, "+a") || strstr (opt->arg, "+i") || strstr (opt->arg, "+u") || strstr (opt->arg, "+v"))))
 					n_errors += old_G_parse (GMT, opt->arg, Ctrl);		/* -G[<lon0/lat0>][/[+|-]unit][+|-] */
 				else {	/* -G[<lon0/lat0>][+i][+a][+u[+|-]<unit>][+v] */
 					/* Note [+|-] is now deprecated in GMT 6; use -je instead */
@@ -490,9 +490,10 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct 
 					 * to avoid parsing problems. */
 					if ((q = strstr (opt->arg, "+u")) && q[2] == '+') q[2] = '*';
 					if (gmt_validate_modifiers (GMT, opt->arg, 'G', "aiuv")) n_errors++;
-					if ((p = gmt_first_modifier (GMT, opt->arg, "aiuv")) == NULL) {	/* This cannot happen given the strstr checks, but Coverity prefers it */
-						GMT_Report (API, GMT_MSG_NORMAL, "Syntax error -G: No modifiers?\n");
-						n_errors++;
+					if ((p = gmt_first_modifier (GMT, opt->arg, "aiuv")) == NULL) {	/* If just -G given then we get here; default to cumulate distances in meters */
+						Ctrl->G.mode |= GMT_MP_VAR_POINT;
+						Ctrl->G.mode |= GMT_MP_CUMUL_DIST;
+						Ctrl->used[MP_COL_DS] = true;	/* Output incremental distances */
 						break;
 					}
 					pos = 0;	txt_a[0] = 0;


### PR DESCRIPTION
This should default to accumulated distances in meters from input points, i.e., the same as **-G+ue**.  Closes  #1492.
