### PR TITLE
Publish nightly macOS bundle

### DIFF
--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -112,3 +112,13 @@ steps:
     md5sum gmt-*.tar.gz gmt-*.tar.xz gmt-*.dmg
   displayName: Package GMT
   condition: eq(variables['PACKAGE'], true)
+
+# Publish the macOS bundle
+- bash: |
+    cp build/gmt-*.dmg ${BUILD_ARTIFACTSTAGINGDIRECTORY}/gmt-${BUILD_SOURCEBRANCHNAME}-$(date +%Y%m%d)-nightly.dmg
+  displayName: Copy macOS bundle
+  condition: eq(variables['PACKAGE'], true)
+- publish: $(Build.ArtifactStagingDirectory)/
+  artifact: GMT-macOS-bundle
+  displayName: Publish macOS Bundle
+  condition: eq(variables['PACKAGE'], true)


### PR DESCRIPTION
We have created macOS bundles in our nightly scheduled jobs. This PR makes one step further, by publishing the bundle nightly, so that macOS users don't need to wait for next release for bug fixes.

The macOS bundle is published as an artifact of Azure Pipelines, and is available from job status page of scheduled builds. For example:

1. Visit the status page: https://dev.azure.com/GenericMappingTools/GMT/_build/results?buildId=2358&view=results. 
    ![image](https://user-images.githubusercontent.com/3974108/64278216-3661f700-cf1a-11e9-8174-72ebd07dfff5.png)

2. Click **1 published**
    ![image](https://user-images.githubusercontent.com/3974108/64278254-4da0e480-cf1a-11e9-84b9-c80afcd77772.png)

The macOS bundle is named as gmt-branch-YYYYmmdd-nightly.dmg, and we will have gmt-6.0.0-20190904-nightly.dmg and gmt-master-20190904-nightly.dmg if this PR is merged.



