### PR TITLE
Fix gmtest script for examples

### DIFF
--- a/doc/examples/gmtest.in
+++ b/doc/examples/gmtest.in
@@ -166,7 +166,7 @@ rm -rf "$exec_dir"
 mkdir -p "$exec_dir"
 cd "$exec_dir"
 shopt -s extglob
-GLOBIGNORE="!(*.bat|*.ps|*.sh)"
+GLOBIGNORE="!(*.bat|*.sh)"
 for file in "$src"/* ; do
   test -f "$file" && ln -s "$file" .
 done


### PR DESCRIPTION
No need to make symbolic links for PS files, as the gmtest script tries to compare the PS in local dir to the orig PS. Creating symbolic links to the orig PS means that the orig PS is also updated when running the test script, thus the example tests always pass.