### PR TITLE
Change to opaque pixels in postscript

### DIFF
--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -4412,6 +4412,7 @@ int PSL_beginplot (struct PSL_CTRL *PSL, FILE *fp, int orientation, int overlay,
 
 		PSL_command (PSL, "%%%%BeginSetup\n");
 		PSL_command (PSL, "/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def\n");
+		PSL_command (PSL, "PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if\n");
 		if (manual_feed)	/* Manual media feed requested */
 			PSL_command (PSL, "PSLevel 1 gt { << /ManualFeed true >> setpagedevice } if\n");
 		else if (PSL->internal.p_width > 0.0 && PSL->internal.p_height > 0.0)	/* Specific media selected */


### PR DESCRIPTION
See discussion in #1466.  By default, plotting things that are completely white is not seen by ghostscript as marking the page.  By changing the WhiteIsOpaque setting we can detect these changes.
