### PR TITLE
Add share/proj to the list of custom dirs that GDAL may consult

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15094,7 +15094,7 @@ struct GMT_CTRL *gmt_begin (struct GMTAPI_CTRL *API, const char *session, unsign
 	if ((path2 = getenv ("LOCAL_PROJ_LIB")) != NULL)  paths[local_count++] = path2;
 	if (!local_count) {			/* If none of the above was provided, default to share/GDAL_DATA */
 		char dir[GMT_LEN256];
-		sprintf (dir, "%s/GDAL_DATA", API->GMT->session.SHAREDIR);
+		sprintf (dir, "%s/GDAL_DATA/n%s/proj", API->GMT->session.SHAREDIR, API->GMT->session.SHAREDIR);
 		if (access (dir, F_OK) == 0) {		/* ... if it exists */
 			paths[0] = strdup(dir);
 			local_count = -1;


### PR DESCRIPTION
I used this to make the Win installers but we can merge this after RC4.