### PR TITLE
Fix string length to PATH_MAX for very-long paths

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15093,7 +15093,7 @@ struct GMT_CTRL *gmt_begin (struct GMTAPI_CTRL *API, const char *session, unsign
 	if ((path1 = getenv ("LOCAL_GDAL_DATA")) != NULL) paths[local_count++] = path1;
 	if ((path2 = getenv ("LOCAL_PROJ_LIB")) != NULL)  paths[local_count++] = path2;
 	if (!local_count) {			/* If none of the above was provided, default to share/GDAL_DATA */
-		char dir[GMT_LEN256];
+		char dir[PATH_MAX];
 		sprintf (dir, "%s/GDAL_DATA/n%s/proj", API->GMT->session.SHAREDIR, API->GMT->session.SHAREDIR);
 		if (access (dir, F_OK) == 0) {		/* ... if it exists */
 			paths[0] = strdup(dir);


### PR DESCRIPTION
The conda-forge builds fails because they use a very-long path (>256 characters), e.g. `/home/conda/feedstock_root/build_artifacts/gmt_1567804993613/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl`. 

Changing the string length from GMT_LEN256 to PATH_MAX can fix the issue, and I have applied the patch to the conda-forge builds, and it works.