### PR TITLE
Use a functinon to check if an executable exists via popen

### DIFF
--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -333,7 +333,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
-EXTERN_MSC bool gmt_check_executable (struct GMT_CTRL *GMT, char *in_cmd, char *pattern, char *text);
+EXTERN_MSC bool gmt_check_executable (struct GMT_CTRL *GMT, char *program, char *arg, char *pattern, char *text);
 EXTERN_MSC void gmt_filename_set (char *name);
 EXTERN_MSC void gmt_filename_get (char *name);
 EXTERN_MSC bool gmt_no_pstext_input (struct GMTAPI_CTRL *API, char *arg);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -333,6 +333,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC bool gmt_check_executable (struct GMT_CTRL *GMT, char *in_cmd, char *pattern, char *text);
 EXTERN_MSC void gmt_filename_set (char *name);
 EXTERN_MSC void gmt_filename_get (char *name);
 EXTERN_MSC bool gmt_no_pstext_input (struct GMTAPI_CTRL *API, char *arg);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16032,7 +16032,7 @@ bool gmt_check_executable (struct GMT_CTRL *GMT, char *program, char *arg, char 
 	}
 	/* Finally, append redirection of errors */
 #ifdef WIN32
-	strcat (cmd, " > NUL");
+	strcat (cmd, " 2> NUL");
 #else
 	strcat (cmd, " 2> /dev/null");
 #endif

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16016,7 +16016,7 @@ bool gmt_check_executable (struct GMT_CTRL *GMT, char *program, char *arg, char 
 	bool answer = false;
 	
 	/* Turn off any stderr messages coming to the terminal */
-	if (strchr (program, ' '))	/* Command has spaces, place in quotes */
+	if (strchr (program, ' ') && !(program[0] == '\'' || program[0] == '\"'))	/* Command has spaces and not already in quotes, place in quotes */
 		sprintf (cmd, "'%s'", program);
 	else
 		strncpy (cmd, program, PATH_MAX);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16017,14 +16017,14 @@ bool gmt_check_executable (struct GMT_CTRL *GMT, char *program, char *arg, char 
 	
 	/* Turn off any stderr messages coming to the terminal */
 	if (strchr (program, ' ')) {	/* Command has spaces [most likely under Windows] */
-		if (!(program[0] == '\'' || program[0] == '\"'))	/* Not in quotes, place single quotes */
-			sprintf (cmd, "'%s'", program);
-		else
+		if (!(program[0] == '\'' || program[0] == '\"'))	/* Not in quotes, place double quotes */
+			sprintf (cmd, "\"%s\"", program);
+		else	/* Already has quotes, but these might be double or single */
 			strncpy (cmd, program, PATH_MAX);
-		if (program[0] == '\"')	/* Replace double quotes with single quotes*/
-			gmt_strrepc (cmd, '\"', '\'');
+		if (program[0] == '\'')	/* Replace single quotes with double quotes*/
+			gmt_strrepc (cmd, '\'', '\"');
 	}
-	else
+	else	/* No spaces, just copy */
 		strncpy (cmd, program, PATH_MAX);
 	if (arg) {	/* Append the command argument */
 		strcat (cmd, " ");

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16036,7 +16036,7 @@ bool gmt_check_executable (struct GMT_CTRL *GMT, char *program, char *arg, char 
 #else
 	strcat (cmd, " 2> /dev/null");
 #endif
-	GMT_Report (GMT->parent, GMT_MSG_NORMAL, "gmt_check_executable: Pass to popen: [%s]\n", cmd);
+	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "gmt_check_executable: Pass to popen: [%s]\n", cmd);
 
 	if ((fp = popen (cmd, "r")))	/* There was such a command */
 		gmt_fgets (GMT, line, PATH_MAX, fp);	/* Read first line */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16030,6 +16030,7 @@ bool gmt_check_executable (struct GMT_CTRL *GMT, char *program, char *arg, char 
 #else
 	strcat (cmd, " 2> /dev/null");
 #endif
+	GMT_Report (GMT->parent, GMT_MSG_NORMAL, "gmt_check_executable: Pass to popen: [%s]\n", cmd);
 
 	if ((fp = popen (cmd, "r")))	/* There was such a command */
 		gmt_fgets (GMT, line, PATH_MAX, fp);	/* Read first line */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16016,8 +16016,14 @@ bool gmt_check_executable (struct GMT_CTRL *GMT, char *program, char *arg, char 
 	bool answer = false;
 	
 	/* Turn off any stderr messages coming to the terminal */
-	if (strchr (program, ' ') && !(program[0] == '\'' || program[0] == '\"'))	/* Command has spaces and not already in quotes, place in quotes */
-		sprintf (cmd, "'%s'", program);
+	if (strchr (program, ' ')) {	/* Command has spaces [most likely under Windows] */
+		if (!(program[0] == '\'' || program[0] == '\"'))	/* Not in quotes, place single quotes */
+			sprintf (cmd, "'%s'", program);
+		else
+			strncpy (cmd, program, PATH_MAX);
+		if (program[0] == '\"')	/* Replace double quotes with single quotes*/
+			gmt_strrepc (cmd, '\"', '\'');
+	}
 	else
 		strncpy (cmd, program, PATH_MAX);
 	if (arg) {	/* Append the command argument */

--- a/src/movie.c
+++ b/src/movie.c
@@ -984,34 +984,28 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		run_script = system;	/* The standard system function will be used */
 	
 		if (Ctrl->A.active) {	/* Ensure we have the GraphicsMagick executable "gm" installed in the path */
-			sprintf (cmd, "gm version");
-			if ((fp = popen (cmd, "r"))) gmt_fgets (GMT, line, PATH_MAX, fp);	/* Read first line */
-			if (fp == NULL || line[0] == '\0' || strstr (line, "www.GraphicsMagick.org") == NULL) {
+			if (gmt_check_executable (GMT, "gm version", "www.GraphicsMagick.org", line)) {
+				sscanf (line, "%*s %s %*s", version);
+				GMT_Report (API, GMT_MSG_LONG_VERBOSE, "GraphicsMagick %s found.\n", version);
+			}
+			else {
 				GMT_Report (API, GMT_MSG_NORMAL, "GraphicsMagick is not installed or not in your executable path - cannot build animated GIF.\n");
 				close_files (Ctrl);
 				Return (GMT_RUNTIME_ERROR);
 			}
-			else {	/* Get here if we read a line that has www.GraphicsMagick.org in it - get version */
-				sscanf (line, "%*s %s %*s", version);
-				GMT_Report (API, GMT_MSG_LONG_VERBOSE, "GraphicsMagick %s found.\n", version);
-			}
-			pclose (fp);
 		}
 		else if (Ctrl->F.active[MOVIE_MP4] || Ctrl->F.active[MOVIE_WEBM]) {	/* Ensure we have ffmpeg installed */
-			sprintf (cmd, "ffmpeg -version");
-			if ((fp = popen (cmd, "r"))) gmt_fgets (GMT, line, PATH_MAX, fp);	/* Read first line */
-			if (fp == NULL || line[0] == '\0' || strstr (line, "FFmpeg developers") == NULL) {
-				GMT_Report (API, GMT_MSG_NORMAL, "ffmpeg is not installed - cannot build MP4 or WEbM movies.\n");
-				close_files (Ctrl);
-				Return (GMT_RUNTIME_ERROR);
-			}
-			else {	/* OK, but check if width is odd or even */
+			if (gmt_check_executable (GMT, "ffmpeg -version", "FFmpeg developers", line)) {
 				sscanf (line, "%*s %*s %s %*s", version);
 				GMT_Report (API, GMT_MSG_LONG_VERBOSE, "FFmpeg %s found.\n", version);
 				if (p_width % 2)	/* Don't like odd pixel widths */
 					GMT_Report (API, GMT_MSG_NORMAL, "Your frame width is an odd number of pixels (%u). This may not work with ffmpeg...\n", p_width);
 			}
-			pclose (fp);
+			else {
+				GMT_Report (API, GMT_MSG_NORMAL, "ffmpeg is not installed - cannot build MP4 or WEbM movies.\n");
+				close_files (Ctrl);
+				Return (GMT_RUNTIME_ERROR);
+			}
 		}
 	}
 	

--- a/src/movie.c
+++ b/src/movie.c
@@ -984,7 +984,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		run_script = system;	/* The standard system function will be used */
 	
 		if (Ctrl->A.active) {	/* Ensure we have the GraphicsMagick executable "gm" installed in the path */
-			if (gmt_check_executable (GMT, "gm version", "www.GraphicsMagick.org", line)) {
+			if (gmt_check_executable (GMT, "gm", "version", "www.GraphicsMagick.org", line)) {
 				sscanf (line, "%*s %s %*s", version);
 				GMT_Report (API, GMT_MSG_LONG_VERBOSE, "GraphicsMagick %s found.\n", version);
 			}
@@ -995,7 +995,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			}
 		}
 		else if (Ctrl->F.active[MOVIE_MP4] || Ctrl->F.active[MOVIE_WEBM]) {	/* Ensure we have ffmpeg installed */
-			if (gmt_check_executable (GMT, "ffmpeg -version", "FFmpeg developers", line)) {
+			if (gmt_check_executable (GMT, "ffmpeg", "-version", "FFmpeg developers", line)) {
 				sscanf (line, "%*s %*s %s %*s", version);
 				GMT_Report (API, GMT_MSG_LONG_VERBOSE, "FFmpeg %s found.\n", version);
 				if (p_width % 2)	/* Don't like odd pixel widths */

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -1538,8 +1538,7 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 	}
 
 	/* Test if GhostScript can be executed (version query) */
-	sprintf (cmd, "%s --version", Ctrl->G.file);
-	if (gmt_check_executable (GMT, cmd, NULL, cmd)) {	/* Found GhostScript */
+	if (gmt_check_executable (GMT, Ctrl->G.file, "--version", NULL, cmd)) {	/* Found GhostScript */
 		int n = sscanf (cmd, "%d.%d", &gsVersion.major, &gsVersion.minor);
 		if (n != 2) {
 			/* command execution failed or cannot parse response */

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -1505,7 +1505,7 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 	struct GMT_GDALREAD_OUT_CTRL *from_gdalread = NULL;
 #endif
 
-	FILE *fp = NULL, *fpo = NULL, *fpb = NULL, *fp2 = NULL, *fpw = NULL, *fpp = NULL;
+	FILE *fp = NULL, *fpo = NULL, *fpb = NULL, *fp2 = NULL, *fpw = NULL;
 
 	struct GMT_OPTION *opt = NULL;
 	struct PS2RASTER_CTRL *Ctrl = NULL;
@@ -1538,12 +1538,9 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 	}
 
 	/* Test if GhostScript can be executed (version query) */
-	sprintf(cmd, "%s --version", Ctrl->G.file);
-	if ((fpp = popen(cmd, "r")) != NULL) {
-		int n;
-		n = fscanf(fpp, "%d.%d", &gsVersion.major, &gsVersion.minor);
-		if (pclose(fpp) == -1)
-			GMT_Report (API, GMT_MSG_NORMAL, "Error closing GhostScript version query.\n");
+	sprintf (cmd, "%s --version", Ctrl->G.file);
+	if (gmt_check_executable (GMT, cmd, NULL, cmd)) {	/* Found GhostScript */
+		int n = sscanf (cmd, "%d.%d", &gsVersion.major, &gsVersion.minor);
 		if (n != 2) {
 			/* command execution failed or cannot parse response */
 			GMT_Report (API, GMT_MSG_NORMAL, "Failed to parse response to GhostScript version query [n = %d %d %d].\n",
@@ -1551,7 +1548,7 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 			Return (GMT_RUNTIME_ERROR);
 		}
 	}
-	else { /* failed to open pipe */
+	else {	/* Failure to open GhostScript */
 		GMT_Report (API, GMT_MSG_NORMAL, "Cannot execute GhostScript (%s).\n", Ctrl->G.file);
 		Return (GMT_RUNTIME_ERROR);
 	}


### PR DESCRIPTION
We had several places where we did a special popen check, but I have consolidated those actions in a new gmt_check_executable () function that handles the common tasks.  It is being called by psconvert.c and movie.c
