### PR TITLE
Anchor tabs is only supported by URLs, not files

### DIFF
--- a/doc/rst/source/docs.rst_
+++ b/doc/rst/source/docs.rst_
@@ -46,7 +46,9 @@ Optional Module Arguments
 
 *-option*
     Where *-option* is the one-letter option of the module in question (e.g, **-R**).
-    We then display the *module* documentation positioned at that specific option.
+    We then display the *module* documentation positioned at that specific option.  Note
+    that this operation is only valid for an actual URL, hence we implicitly set
+    **-S** when an option anchor is specified.
 
 Examples
 --------

--- a/src/docs.c
+++ b/src/docs.c
@@ -213,6 +213,8 @@ int GMT_docs (void *V_API, int mode, void *args) {
 			else if (!other_file)		/* A supplemental module */
 				snprintf (module, GMT_LEN64, "supplements/%s/%s.html", group, docname);
 
+			if (opt->next && opt->next->option != GMT_OPT_INFILE) remote = true;	/* Can only use anchors on actual URLs not local files */
+			
 			/* Get the local URL (which may not exist) */
 			if (other_file) {	/* A local or Web file */
 				if (!strncmp (docname, "file:", 5U) || !strncmp (docname, "http", 4U) || !strncmp (docname, "ftp", 3U))	/* Looks like an URL already */


### PR DESCRIPTION
This means gmt docs module option must be sent to the server, even if **-S** is not set.
