### PR TITLE
Layout of docs under PSL "Justification" improved - whitespaces were not maintained

### DIFF
--- a/doc/rst/source/postscriptlight.rst
+++ b/doc/rst/source/postscriptlight.rst
@@ -99,15 +99,17 @@ corner to which the *x* and *y* coordinates of the subroutine call
 apply. Nine different values are possible, as shown schematically in
 this diagram:
 
-    9------------10----------- 11
+  ::
 
-    \|                         \|
-
-    5             6             7
-
-    \|                          \|
-
-    1------------ 2------------ 3
+    9 ------------ 10 ----------- 11
+    
+    |                             |
+    
+    5              6              7
+    
+    |                             |
+    
+    1 ------------ 2 ------------ 3
 
 The box represents the text or image. E.g., to plot a text string with
 its center at (*x*, *y*), you must use *justify* == 6. *justify* == 0


### PR DESCRIPTION
**Description of proposed changes**

In the documentation for PostScriptLight there is some ASCII Art to visualize the options for justification. However the font used was not monospaced and whitespaces were not maintained. Changed the paragraph to reformatted text and did some cosmetic changes to the text.