### PR TITLE
Link docs to specific version

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -67,7 +67,7 @@ set (GMT_LIB_SOVERSION 6)
 set (GMT_LIB_VERSION "${GMT_LIB_SOVERSION}.${GMT_PACKAGE_VERSION_MINOR}.${GMT_PACKAGE_VERSION_PATCH}")
 
 # The GMT documentation URL
-set (GMT_DOC_URL "https://docs.generic-mapping-tools.org/dev")
+set (GMT_DOC_URL "https://docs.generic-mapping-tools.org/${GMT_PACKAGE_VERSION_MAJOR}.${GMT_PACKAGE_VERSION_MINOR}")
 
 # Use SI units per default
 if (NOT UNITS)


### PR DESCRIPTION
**Description of proposed changes**

After #1337 was merged, we now have three versions documentations hosted, dev from master branch, 6.0 from 6.0 branch and 5.4 from 5.4 branch. This PR changes GMT_DOC_URL, so that GMT 6.0 users will open the documentations for 6.0.

Closes #871.

