### PR TITLE
Add the DOI for the source code release on zenodo

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -38,7 +38,7 @@ set (GMT_PACKAGE_DESCRIPTION_SUMMARY "The Generic Mapping Tools")
 set (GMT_VERSION_YEAR "2019")
 
 # The GMT release DOI
-set (GMT_VERSION_DOI "10.5281/zenodo.3407866")
+set (GMT_VERSION_DOI "https://doi.org/10.5281/zenodo.3407866")
 
 # The GMT release citation
 set (GMT_VERSION_CITATION "Wessel, P., Luis, J., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2019). The Generic Mapping Tools Version 6. Geochemistry, Geophysics, Geosystems, 20. https://doi.org/10.1029/2019GC008515")

--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -38,7 +38,7 @@ set (GMT_PACKAGE_DESCRIPTION_SUMMARY "The Generic Mapping Tools")
 set (GMT_VERSION_YEAR "2019")
 
 # The GMT release DOI
-set (GMT_VERSION_DOI "TBD")
+set (GMT_VERSION_DOI "10.5281/zenodo.3407866")
 
 # The GMT release citation
 set (GMT_VERSION_CITATION "Wessel, P., Luis, J., Uieda, L., Scharroo, R., Wobbe, F., Smith, W. H. F., & Tian, D. (2019). The Generic Mapping Tools Version 6. Geochemistry, Geophysics, Geosystems, 20. https://doi.org/10.1029/2019GC008515")


### PR DESCRIPTION
We have reserved this DOI and will publish it when we release 6.0.0.  It is displayed when the user runs

`gmt --show-doi
`
