### PR TITLE
test: rerun failed tests twice and increase timeout

### DIFF
--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -64,10 +64,10 @@ steps:
     curl http://www.soest.hawaii.edu/gmt/data/gmt_md5_server.txt | awk 'NF==3 && $1!~/earth/ {print "@"$1}' | xargs gmt which -Gc
     gmt which -Gu @earth_relief_01m @earth_relief_02m @earth_relief_04m @earth_relief_05m @earth_relief_10m @earth_relief_15m
     # run all jobs, and rerun failed jobs
-    ctest ${CTEST_ARGS} || ctest ${CTEST_ARGS} --rerun-failed
+    ctest ${CTEST_ARGS} || ctest ${CTEST_ARGS} --rerun-failed || ctest ${CTEST_ARGS} --rerun-failed
   displayName: Full tests
   env:
-    CTEST_ARGS: "--output-on-failure --force-new-ctest-process -j4 --timeout 360"
+    CTEST_ARGS: "--output-on-failure --force-new-ctest-process -j4 --timeout 480"
   condition: eq(variables['TEST'], true)
 
 # Publish the whole build directory for debugging purpose

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -111,10 +111,10 @@ steps:
     # disable MinGW's path conversion, see #1035.
     export MSYS_NO_PATHCONV=1
     # run all jobs and rerun if failed
-    ctest ${CTEST_ARGS} || ctest ${CTEST_ARGS} --rerun-failed
+    ctest ${CTEST_ARGS} || ctest ${CTEST_ARGS} --rerun-failed || ctest ${CTEST_ARGS} --rerun-failed
   displayName: Full tests
   env:
-    CTEST_ARGS: "--output-on-failure --force-new-ctest-process -j4 --timeout 360"
+    CTEST_ARGS: "--output-on-failure --force-new-ctest-process -j4 --timeout 480"
   condition: eq(variables['TEST'], true)
 
 # Publish the whole build directory for debugging purpose


### PR DESCRIPTION
**Description of proposed changes**

- Re-run failed tests twice to fix occasional failures caused by `Found no history for option -R`.
- Sometimes, tests on Windows take more time than expected, resulting in timeout failures.