### PR TITLE
Let grdfilter -Vl report which row it is working on

### DIFF
--- a/src/grdfilter.c
+++ b/src/grdfilter.c
@@ -1354,7 +1354,7 @@ GMT_LOCAL void threaded_function (struct THREAD_STRUCT *t) {
 
 	for (row_out = r_start; row_out < r_stop; row_out++) {
 
-		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Processing output line %d\n", row_out);
+		GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Processing output line %d\n", row_out);
 #ifdef DEBUG
 		if (Ctrl->A.active && row_out != Ctrl->A.ROW) continue;		/* Not at our selected row for testing */
 #endif
@@ -1511,7 +1511,7 @@ GMT_LOCAL void threaded_function (struct THREAD_STRUCT *t) {
 		}
 	}
 
-	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Processing output line %d\n", row_out);
+	GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Processing output line %d\n", row_out);
 
 	if (slow) {
 		if (slower) gmt_M_free (GMT, work_data);


### PR DESCRIPTION
Without **-Vl** reporting current row it is hard to know if a large median or mode filter calculation is actually working since it may take hours with no progress output.  The user may not expect to have to use **-Vd** to learn this.

