### PR TITLE
Document the modern mode one-liner

### DIFF
--- a/doc/rst/source/GMT_Docs.rst
+++ b/doc/rst/source/GMT_Docs.rst
@@ -9330,6 +9330,48 @@ Finally we show an example of a polygon file:
     # @P
     ...
 
+GMT Modern Mode One-line Commands
+=================================
+
+Background
+----------
+
+Modern mode simplifies GMT by placing all commands between gmt :doc:`begin` and gmt :doc:`end`.
+However, for very simply plots, such as a simple coastline map that only requires a call to
+a single module, having to place that command between **begin** and **end** makes the documentation
+longer and more tedious to maintain.  Because of this, we have implemented a special way
+to begin and end GMT modern mode within a single call to a plotting module.
+
+One-liner Syntax
+----------------
+
+The syntax for this special mechanism involves a few simple rules:
+
+#. The command must be a plotting command and modern mode syntax (e.g., :doc:`coast` instead
+   of :doc:`pscoast`, no **-O**, **-K**, **-P** options, etc.) is required.
+#. The plot file and type must be specified with the special option **-format** *prefix*,
+   where **format** is one or more comma-separated graphics extensions from the list of
+   allowable graphics formats :ref:`formats <tbl-formats>`, and *prefix* is the prefix of
+   the illustration (the extension is automatically set by the chosen format). Note the
+   leading hyphen for the format option.
+
+Examples
+--------
+
+To make a Mercator coastline plot of France, painting land blue, adding map frame and
+requesting both PDF and png graphics output with prefix France1, try
+
+   ::
+
+    gmt coast -RFR -JM6i -Gblue -B -pdf,png France1
+
+To make a DEM map of France using the default DEM color table and data from the 1m global
+grid, making a JPG plot called France2, try
+
+   ::
+
+    gmt grdimage @earth_relief_01m -RFR -JM6i -B -jpg France2
+
 .. [1]
    Version 1.0 was then informally released at the Lamont-Doherty Earth Observatory.
 


### PR DESCRIPTION
I have added a short Appendix that explains the rationale for this special mechanism and documents the syntax, plus shows a few examples.  It looks like adding **-I+d** to grdimage does not work in this example, which I will look into.
