### PR TITLE
Fix problem with -E under modern mode

### DIFF
--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -495,6 +495,8 @@ int GMT_grd2cpt (void *V_API, int mode, void *args) {
 	}
 	if (Ctrl->W.wrap) Pin->is_wrapping = true;	/* A cyclic CPT has been requested */
 
+	write = (GMT->current.setting.run_mode == GMT_CLASSIC || Ctrl->H.active);	/* Only output to stdout in classic mode and with -H in modern mode */
+
 	GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Processing input grid(s)\n");
 
 	gmt_M_memset (wesn, 4, double);
@@ -594,9 +596,10 @@ int GMT_grd2cpt (void *V_API, int mode, void *args) {
 		if (Ctrl->D.mode == 1) cpt_flags |= GMT_CPT_EXTEND_BNF;	/* bit 1 controls if BF will be set to equal bottom/top rgb value */
 		if (Ctrl->F.active) Pout->model = Ctrl->F.model;
 		if (Ctrl->F.cat) Pout->categorical = 1;
-		if (GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, cpt_flags, NULL, Ctrl->Out.file, Pout) != GMT_NOERROR) {
+		if (write && GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, cpt_flags, NULL, Ctrl->Out.file, Pout) != GMT_NOERROR) {
 			Return (API->error);
 		}
+		if (!write) gmt_save_current_cpt (GMT, Pout);	/* Save for use by session, if modern */
 		free_them_grids (API, G, grdfile, ngrd);
 		gmt_M_free (GMT, G);
 		gmt_M_free (GMT, grdfile);
@@ -724,8 +727,6 @@ int GMT_grd2cpt (void *V_API, int mode, void *args) {
 	if (Ctrl->F.cat) Pout->categorical = 1;
 
 	if (Ctrl->A.active) gmt_cpt_transparency (GMT, Pout, Ctrl->A.value, Ctrl->A.mode);	/* Set transparency */
-
-	write = (GMT->current.setting.run_mode == GMT_CLASSIC || Ctrl->H.active);	/* Only output to stdout in classic mode and with -H in modern mode */
 
 	if (write && GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, cpt_flags, NULL, Ctrl->Out.file, Pout) != GMT_NOERROR)
 		error = API->error;


### PR DESCRIPTION
It would write the CPT to stdout even under modern mode since the handling of -E was separate from the rest of the cases.
