### PR TITLE
Make sure ps.active is true at end of plot module

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -7215,6 +7215,7 @@ void gmt_plotend (struct GMT_CTRL *GMT) {
 		/* coverity[leaked_storage] */	/* We can't free P because it was written into a 'memory file' */
 	}
 	GMT->current.ps.title[0] = '\0';	/* Reset title */
+	if (GMT->current.ps.oneliner) GMT->current.ps.active = true;	/* Since we are plotting we reset this here in case other modules have turned it off */
 }
 
 void gmt_geo_line (struct GMT_CTRL *GMT, double *lon, double *lat, uint64_t n) {


### PR DESCRIPTION
For one-liner examples like #1597, grdimage (a PS producing module) sets ps.active to true but then other modules like grdblend and grdsample may be called, so at the end of grdimage I found that ps.active was false.  This then meant that gmt_plotend did not call module end and no plot was produced (and the hidden session dir was left abandoned).  I now set ps.active at end of gmt_plotend since we know we were just plotting.  Closees #1597.
