### PR TITLE
docs: Enable MP4 movies in animation examples

### DIFF
--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -53,7 +53,7 @@ html_context = {
 }
 # favicon of the docs
 html_favicon = "_static/favicon.png"
-html_static_path = ['_static']
+html_static_path = ['_static', '_source/_static']
 html_last_updated_fmt = '%b %d, %Y'
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = True


### PR DESCRIPTION
Currently, the animation examples don't show the MP4 movies correctly
(e.g. https://docs.generic-mapping-tools.org/latest/gallery/anim08.html),
because sphinx doesn't copy these MP4 files to _static directory.

This PR adds `_source/_static` to `html_static_path` so that the MP4 files in
`_source/_static` are copied as expected.