### PR TITLE
Let modern mode one-liner use gmt show to display plot(s)

### DIFF
--- a/doc/rst/source/cookbook/one-liner.rst
+++ b/doc/rst/source/cookbook/one-liner.rst
@@ -7,8 +7,9 @@ Background
 Modern mode simplifies GMT by placing all commands between gmt :doc:`/begin` and gmt :doc:`/end`.
 However, for very simply plots, such as a simple coastline map that only requires a call to
 a single module, having to place that command between **begin** and **end** makes the documentation
-longer and more tedious to maintain.  Because of this, we have implemented a special way
-to begin and end GMT modern mode within a single call to a plotting module.
+longer and more tedious to maintain.  Because of this, we have implemented a special and quick way
+to begin and end GMT modern mode within a single call to a plotting module. When the plot finishes
+we automatically call gmt :doc:`/end` with the show command to display the plot(s).
 
 One-liner Syntax
 ----------------

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12965,7 +12965,7 @@ void gmt_end_module (struct GMT_CTRL *GMT, struct GMT_CTRL *Ccopy) {
 
 	if (GMT->hidden.func_level == GMT_TOP_MODULE && GMT->current.ps.oneliner && GMT->current.ps.active) {
 		GMT->current.ps.oneliner = false;
-		if ((i = GMT_Call_Module (GMT->parent, "end", GMT_MODULE_CMD, ""))) {
+		if ((i = GMT_Call_Module (GMT->parent, "end", GMT_MODULE_CMD, "show"))) {
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unable to call module end for a one-liner plot.\n");
 			return;
 		}


### PR DESCRIPTION
The point of one-liners is for making simple illustrations or showing how GMT works in the documentation, hence we now let the implicit gmt end use the _show_ instruction to display the result.
