### PR TITLE
Include one-liner.rst as an appendix of cookbook

### DIFF
--- a/doc/rst/source/cookbook.rst
+++ b/doc/rst/source/cookbook.rst
@@ -59,3 +59,4 @@ The GMT Cookbook
    cookbook/custom_symbols
    cookbook/contour_annotations
    cookbook/ogrgmt_format.rst
+   cookbook/one-liner


### PR DESCRIPTION
I forgot to include one-liner.rst into the cookbook before.