### PR TITLE
Prevent gmt show end from displaying in tests

### DIFF
--- a/doc/rst/source/cookbook/one-liner.rst
+++ b/doc/rst/source/cookbook/one-liner.rst
@@ -40,3 +40,6 @@ grid, making a JPG plot called France2, try
    ::
 
     gmt grdimage @earth_relief_01m -RFR -JM6i -B -jpg France2
+
+The automatic display of the plot can be deactivated by setting an environmental parameter
+named GMT_END_SHOW to off.

--- a/doc/scripts/gmtest.in
+++ b/doc/scripts/gmtest.in
@@ -24,6 +24,9 @@ fi
 
 shift
 
+# Disable gmt end show from displaying plots
+
+export GMT_END_SHOW=off
 # choose awk
 if type gawk >/dev/null 2>&1 ; then
   export AWK=gawk

--- a/src/end.c
+++ b/src/end.c
@@ -85,7 +85,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options, bool *sho
 int GMT_end (void *V_API, int mode, void *args) {
 	int error = 0;
 	bool show = false;
-	char *display = NULL, *task = "show";
+	char *display = NULL, *task = "show", *setting = NULL;
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;
 	struct GMT_OPTION *options = NULL;
 	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);	/* Cast from void to GMTAPI_CTRL pointer */
@@ -113,7 +113,8 @@ int GMT_end (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the end main code ----------------------------*/
 
-	display = (show) ? task : NULL;
+	if (!((setting = getenv ("GMT_END_SHOW")) && !strcmp (setting, "off")))
+		display = (show) ? task : NULL;
 	
 	if (gmt_manage_workflow (API, GMT_END_WORKFLOW, display))
 		error = GMT_RUNTIME_ERROR;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12972,7 +12972,9 @@ void gmt_end_module (struct GMT_CTRL *GMT, struct GMT_CTRL *Ccopy) {
 
 	if (GMT->hidden.func_level == GMT_TOP_MODULE && GMT->current.ps.oneliner && GMT->current.ps.active) {
 		GMT->current.ps.oneliner = false;
-		if ((i = GMT_Call_Module (GMT->parent, "end", GMT_MODULE_CMD, "show"))) {
+		char *setting = getenv ("GMT_END_SHOW");
+		char *show = (setting && !strcmp (setting, "off")) ? "" : "show";
+		if ((i = GMT_Call_Module (GMT->parent, "end", GMT_MODULE_CMD, show))) {
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unable to call module end for a one-liner plot.\n");
 			return;
 		}


### PR DESCRIPTION
By setting export **GMT_END_SHOW**=off in doc/scripts/gmtest.in we turn off the automatic display of plots.  There are no such examples, animations, or tests.
