### PR TITLE
Add "gmt end show" to test scripts

### DIFF
--- a/doc/scripts/gmtest.in
+++ b/doc/scripts/gmtest.in
@@ -24,9 +24,6 @@ fi
 
 shift
 
-# Disable gmt end show from displaying plots
-
-export GMT_END_SHOW=off
 # choose awk
 if type gawk >/dev/null 2>&1 ; then
   export AWK=gawk
@@ -182,6 +179,8 @@ export DCW_DIR="@DCW_PATH@"
 export GMT_BINARY_DIR="@GMT_BINARY_DIR@"
 export GMT_SOURCE_DIR="@GMT_SOURCE_DIR@"
 export GMT_VERSION="@GMT_PACKAGE_VERSION_WITH_GIT_REVISION@"
+# Disable gmt end show from displaying plots
+export GMT_END_SHOW=off
 # Start with proper GMT defaults
 gmt set -Du PS_CHAR_ENCODING ISOLatin1+
 # Tentative PS file name

--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -233,6 +233,8 @@ export GMT_SOURCE_DIR="@GMT_SOURCE_DIR@"
 export HAVE_GMT_DEBUG_SYMBOLS="@HAVE_GMT_DEBUG_SYMBOLS@"
 export HAVE_OPENMP="@HAVE_OPENMP@"
 export HAVE_GLIB_GTHREAD="@HAVE_GLIB_GTHREAD@"
+# Disable gmt end show from displaying plots
+export GMT_END_SHOW=off
 # Start with proper GMT defaults
 gmt set -Du
 # Modern mode needs a stable PPID but ctest messes that up when pipes are used

--- a/test/mapproject/azimuth.sh
+++ b/test/mapproject/azimuth.sh
@@ -25,4 +25,4 @@ ${plon} ${plat}
 EOF
   echo ${lon} ${lat} $az 1000 | gmt plot -S=0.15i+e -W1p,blue -Ggreen
   echo ${lon} ${lat} $az2 1000 | gmt plot -S=0.15i+e -W1p,blue -Ggreen
-gmt end
+gmt end show

--- a/test/modern/box.sh
+++ b/test/modern/box.sh
@@ -6,4 +6,4 @@ gmt begin box ps
     gmt basemap -c -Bafg
     gmt basemap -c
   gmt subplot end
-gmt end
+gmt end show

--- a/test/modern/imagepluscpt.sh
+++ b/test/modern/imagepluscpt.sh
@@ -4,4 +4,4 @@ gmt begin imagepluscpt ps
 	gmt grdimage @earth_relief_01m -RMG+r2 -Cgeo -I+
 	gmt coast -Wthin -N1/thick,red -BWSne -B
 	gmt colorbar -DJTC -B -C
-gmt end
+gmt end show

--- a/test/modern/inset.sh
+++ b/test/modern/inset.sh
@@ -6,4 +6,4 @@ gmt begin inset ps
 		gmt text -F+f12p+cTR+tINSET
 	gmt inset end
 	gmt text -F+f18p+cBL+tMAP -Dj0.2i
-gmt end
+gmt end show

--- a/test/modern/panels.sh
+++ b/test/modern/panels.sh
@@ -7,4 +7,4 @@ gmt begin panels ps
     gmt basemap -c
     gmt basemap -c
   gmt subplot end
-gmt end
+gmt end show

--- a/test/modern/polarpanels.sh
+++ b/test/modern/polarpanels.sh
@@ -6,4 +6,4 @@ gmt begin polarpanels ps
     gmt basemap -JPa?/45 -R0/90/0/1 -Bxa45f -c
     gmt basemap -JPa?/45 -R0/90/0/1 -Bxa45f -c
   gmt subplot end
-gmt end
+gmt end show

--- a/test/modern/powlog.sh
+++ b/test/modern/powlog.sh
@@ -7,4 +7,4 @@ gmt begin powlog ps
     gmt basemap -R0/100/1/100 -JX?p0.5/?l -c
     gmt basemap -c
   gmt subplot end
-gmt end
+gmt end show

--- a/test/modern/shrinkvec1.sh
+++ b/test/modern/shrinkvec1.sh
@@ -7,4 +7,4 @@ gmt begin shrinkvec1 ps
 	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i -W3p -Gred -B -Blstr -X2.25i
 	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i+p- -W3p -Gred -B -Blstr -X2.25i
 	rm -f data.txt
-gmt end
+gmt end show

--- a/test/modern/shrinkvec2.sh
+++ b/test/modern/shrinkvec2.sh
@@ -11,4 +11,4 @@ gmt begin shrinkvec2 ps
 	# Use z and CPT for painting the head and stem
 	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i -W3p+c -C -B -Blstr -X2.25i
 	rm -f data.txt t.cpt
-gmt end
+gmt end show

--- a/test/modern/somepanels.sh
+++ b/test/modern/somepanels.sh
@@ -9,4 +9,4 @@ gmt begin somepanels ps
     gmt basemap -R300/500/-10/0 -c1,0
     gmt basemap -Bafg -R300/500/-100/0 -c5
   gmt subplot end
-gmt end
+gmt end show

--- a/test/modern/vardims.sh
+++ b/test/modern/vardims.sh
@@ -10,4 +10,4 @@ gmt begin vardims ps
     gmt basemap -R10/15/10/15 -B+gpurple -c
     gmt basemap -R10/15/10/15 -B+gorange -c
   gmt subplot end
-gmt end
+gmt end show

--- a/test/modern/varfracs.sh
+++ b/test/modern/varfracs.sh
@@ -10,4 +10,4 @@ gmt begin varfracs ps
     gmt basemap -R0/5/10/15 -B+glightgray -c
     gmt basemap -R10/15/10/15 -B+gorange -c
   gmt subplot end
-gmt end
+gmt end show

--- a/test/modern/vector.sh
+++ b/test/modern/vector.sh
@@ -15,4 +15,4 @@ echo 1 1 4 1 | gmt plot -Sv0.2i+s+b+e+gred -Gblack -Y1c
 
 echo 1 1 4 1 | gmt plot -Sv0.2i+s+b+e -W1p -Gblack -Y1c
 echo 1 1 4 1 | gmt plot -Sv0.2i+s+b+e+p-+gred -W1p -Gblack -Y1c
-gmt end
+gmt end show

--- a/test/modern/viewpluscpt.sh
+++ b/test/modern/viewpluscpt.sh
@@ -4,4 +4,4 @@ gmt begin viewpluscpt ps
 	gmt grdview @earth_relief_01m -RMG+r2 -Cgeo -I+ -Qi
 	gmt coast -Wthin -N1/thick,red -BWSne -B
 	gmt colorbar -DJTC -B -C
-gmt end
+gmt end show

--- a/test/psclip/clip.sh
+++ b/test/psclip/clip.sh
@@ -8,4 +8,4 @@ gmt begin clip ps
 EOF
   gmt plot @tut_data.txt -Gred -Sc2c 
   gmt psclip -C -B
-gmt end
+gmt end show

--- a/test/pslegend/stacklegendmod.sh
+++ b/test/pslegend/stacklegendmod.sh
@@ -10,5 +10,5 @@ gmt begin stacklegendmod ps
   gmt pslegend -DjBL+w1.2i+o0.25i -F+gwhite+pthicker legend.txt -Xa1i -Ya1i
   gmt psbasemap -R2/6/6/10 -Bafg1 -Xa2i -Ya6i
   gmt pslegend -DjBL+w1.2i+o0.25i -F+gwhite+pthicker legend.txt -Xa2i -Ya6i
-gmt end
+gmt end show
 rm -f legend.txt

--- a/test/subplot/tictactoe.sh
+++ b/test/subplot/tictactoe.sh
@@ -7,4 +7,4 @@ gmt begin tictactoe ps
         gmt coast -Rg -JG120/30/? -Gred -Bg -c1,1
         gmt coast -Rg -JG210/30/? -Gred -Bg -c2,2
     gmt subplot end
-gmt end
+gmt end show


### PR DESCRIPTION
- Add "gmt end show" to modern-mode test scripts
- Set **GMT_END_SHOW** to off to disable auto-show when running ctest

I also changed the position of "export GMT_END_SHOW=off" in `doc/scripts/gmtest.in`.