### PR TITLE
Use SHA256 hash for remote files and rename variables

### DIFF
--- a/src/gmt_io.h
+++ b/src/gmt_io.h
@@ -244,7 +244,7 @@ struct GMT_IO {				/* Used to process input data records */
 	bool warn_geo_as_cartesion;	/* true if we should warn if we read a record with geographic data while the expected format has not been set (i.e., no -J or -fg) */
 	bool first_rec;			/* true when reading very first data record in a dataset */
 	bool trailing_text[2];	/* Default is to process training text unless turned off via -i, -o */
-	bool md5_refreshed;		/* true after calling the md5_refresh function the first time */
+	bool hash_refreshed;		/* true after calling the hash_refresh function the first time */
 	uint64_t seg_no;		/* Number of current multi-segment in entire data set */
 	uint64_t seg_in_tbl_no;		/* Number of current multi-segment in current table */
 	uint64_t n_clean_rec;		/* Number of clean records read (not including skipped records or comments or blanks) */

--- a/src/gmt_remote.h
+++ b/src/gmt_remote.h
@@ -32,9 +32,9 @@ struct GMT_DATA_INFO {
 	char remark[GMT_LEN128];	/* What it is */
 };
 
-struct GMT_MD5 {
+struct GMT_DATA_HASH {	/* Holds file hashes (probably SHA256) */
 	char name[GMT_LEN64];	/* File name */
-	char md5[GMT_LEN64];	/* The MD5 hash */
+	char hash[GMT_LEN64];	/* The file hash */
 	size_t size;		/* File size in bytes */
 };
 


### PR DESCRIPTION
The hash codes on the server are now SHA256 instead of MD5.  This PR renames local variables in gmt_remote.? that used md5 or MD5 in their names to more general names using "hash".  Also, the file with the hash codes are now called gmt_hash_server.txt instead of gmt_md5_server.txt, but I added a symbolic link so the old name will still find the hash table (helping people on rc? releases and un-updated git builds).
The new codes will force a re-download of all files...