### PR TITLE
Always check remote files for updates

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15219,39 +15219,11 @@ GMT_LOCAL bool check_if_we_must_download (struct GMT_CTRL *GMT, const char *file
 	unsigned int pos = gmtlib_get_pos_of_filename (file);	/* Find start of filename */
 	if (pos == 1) return true;  /* Must always check since file on server might have changed and should be refreshed first */
 	else if (kind == GMT_URL_QUERY)
-		return true;	/* A query can never exist locally */
+		return true;	/* A query can never exist locally so must follow the URL */
 	else if (!gmt_access (GMT, &file[pos], F_OK))
-		return false;	/* File exists already so no need to download */
+		return false;	/* Regular file exists already so no need to download */
 	return true;	/* File not found */
 }
-
-#if 0
-GMT_LOCAL bool check_if_we_must_download (struct GMT_CTRL *GMT, const char *file, unsigned int kind) {
-	/* Returns false if file already present */
-	unsigned int pos = gmtlib_get_pos_of_filename (file);	/* Find start of filename */
-    if (pos == 1) return true;  /* Must always check since file on server might have changed */
-	if (kind == GMT_URL_QUERY)
-		return true;	/* A query can never exist locally */
-	else if (kind == GMT_REGULAR_FILE)
-		return false;	/* A query must exist locally */
-	else if (kind == GMT_DATA_FILE) {	/* Special remote data set @earth_relief_xxm|s grid request */
-		bool found;
-		if (strstr (file, ".grd")) {	/* User already gave the extension */
-			found = (!gmt_access (GMT, &file[1], F_OK));    /* Not found so need to download */
-		}
-		else {	/* Must append the extension .grd */
-			char *tmpfile = malloc (strlen(file)+5);
-			sprintf (tmpfile, "%s.grd", &file[1]);
-			found = (!gmt_access (GMT, tmpfile, F_OK));	/* Not found so need to download */
-			gmt_M_str_free (tmpfile);
-		}
-		return !found;
-	}
-	else if (!gmt_access (GMT, &file[pos], F_OK))
-		return false;	/* File exists already so no need to download */
-	return true;
-}
-#endif
 
 bool gmtlib_file_is_downloadable (struct GMT_CTRL *GMT, const char *file, unsigned int *kind) {
 	/* Returns true if file is a known GMT-distributable file and download is enabled */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15285,7 +15285,9 @@ bool gmt_check_filearg (struct GMT_CTRL *GMT, char option, char *file, unsigned 
 	if (direction == GMT_OUT) return true;		/* Cannot check any further */
 	if (file[0] == '=') pos = 1;	/* Gave a list of files with =<filelist> mechanism in x2sys */
 	not_url = !gmtlib_file_is_downloadable (GMT, file, &kind);	/* not_url may become false if this could potentially be obtained from GMT ftp site */
-	if (kind == GMT_CACHE_FILE || kind == GMT_DATA_FILE) pos = 1;	/* Has leading '@' in name so must skip that letter when checking if it exists locally */
+	if (kind == GMT_CACHE_FILE || kind == GMT_DATA_FILE) {
+		pos = gmt_download_file_if_not_found (GMT, file, 0);	/* Has leading '@' in name so must skip that letter when checking if it exists locally */
+	}
 	else if (kind == GMT_URL_FILE) pos = gmtlib_get_pos_of_filename (file);	/* Find start of filename */
 	if (!not_url && kind == 0 && (family == GMT_IS_GRID || family == GMT_IS_IMAGE))	/* Only grid and images can be URLs so far */
 		not_url = !gmtlib_check_url_name (&file[pos]);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -455,6 +455,13 @@ unsigned int gmt_download_file_if_not_found (struct GMT_CTRL *GMT, const char* f
 
 	hash_refresh (GMT);	/* Watch out for changes on the server once a day */
 
+	/* Any old files have now been replaced.  Now we can check if the file exists already */
+	
+	if (kind != GMT_URL_QUERY && !gmt_access (GMT, &file[pos], F_OK)) {	/* File found, we are done here */
+		gmt_M_free (GMT, file);
+		return (pos);
+	}
+	
 	from = (kind == GMT_DATA_FILE) ? GMT_DATA_DIR : GMT_CACHE_DIR;	/* Determine source directory on cache server */
 	to = (mode == GMT_LOCAL_DIR) ? GMT_LOCAL_DIR : from;
 	snprintf (serverdir, PATH_MAX, "%s/server", user_dir[GMT_DATA_DIR]);


### PR DESCRIPTION
When remote files (starting with the @ character) is given on the command line we must always check if the file has changed on the server.  This only happens once in a 24-hour period, but when 24+ hours have lapsed we must refresh our hash list and see if the entry has changed for the remote file at hand.  If it has the local file is removed and the updated file is obtained.

This PR fixed the problem that we prematurely checked to see if the local file existed before we had a chance to update the file.