### PR TITLE
Dont count figure formats that are not recognized

### DIFF
--- a/doc/rst/source/figure.rst
+++ b/doc/rst/source/figure.rst
@@ -118,6 +118,12 @@ To make two figures in one session and go back and forth between different figur
 
     gmt end show
 
+Technical Note
+--------------
+
+If you are calling **figure** from an external environment and you do not want the plot to
+be converted automatically when the session ends, perhaps because you wish to do this yourself,
+you can specify the file name or figure format as - (i.e., just a hyphen).
 
 See Also
 --------

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15578,9 +15578,10 @@ GMT_LOCAL int get_graphics_formats (struct GMT_CTRL *GMT, char *formats, char fm
 	unsigned int pos = 0;
 	char p[GMT_LEN32] = {""};
 	while ((gmt_strtok (formats, ",", &pos, p))) {
-		k = gmt_get_graphics_id (GMT, p);
-		gcode[n] = k;
-		fmt[n++] = gmt_session_code[k];
+		if ((k = gmt_get_graphics_id (GMT, p)) != GMT_NOTSET) {	/* Valid code */
+			gcode[n] = k;
+			fmt[n++] = gmt_session_code[k];
+		}
 	}
 	return (n);
 }


### PR DESCRIPTION
See issue #1636.  Here, a format instead of file name was set to - and it was passed to _gmt_get_graphics_id_ that determines the graphics format.  It returned -1 (not found) but it was still counted as a format and hence we said ONE output format was selected (instead of zero).  Closes #1636.

