### PR TITLE
Use snprintf instead of sprintf when we can

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -655,7 +655,7 @@ GMT_LOCAL void gmtapi_check_for_modern_oneliner (struct GMTAPI_CTRL *API, const 
 		if (opt->option == GMT_OPT_INFILE || opt->option == GMT_OPT_OUTFILE) continue;	/* Skip file names */
 		if (strchr ("bejpPt", opt->option) == NULL) continue;	/* Option not the first letter of a valid graphics format [UPDATE LIST IF ADDING MORE FORMATS IN FUTURE] */
 		if ((len = strlen (opt->arg)) == 0 || len >= GMT_LEN128) continue;	/* No arg or very long args that are filenames can be skipped */
-		sprintf (format, "%c%s", opt->option, opt->arg);	/* Get a local copy so we can mess with it */
+		snprintf (format, GMT_LEN128, "%c%s", opt->option, opt->arg);	/* Get a local copy so we can mess with it */
 		if ((c = strchr (format, ','))) c[0] = 0;	/* Chop off other formats for the initial id test */
 		if (gmt_get_graphics_id (API->GMT, format) != GMT_NOTSET) {	/* Found a valid graphics format option */
 			modern = 1;	/* Seems like it is, but check the rest of the formats, if there are more */
@@ -727,7 +727,7 @@ GMT_LOCAL char * api_get_ppid (struct GMTAPI_CTRL *API) {
 	int ppid = -1;
 	unsigned int k = 0;
 	static char *source[4] = {"GMT_SESSION_NAME", "parent", "app", "hardwired choice"};
-	char *str = NULL, string[8];
+	char *str = NULL, string[GMT_LEN8];
 	if ((str = getenv ("GMT_SESSION_NAME")) != NULL) {	/* GMT_SESSION_NAME was set in the environment */
 		char *tmp = strdup (str);	/* Duplicate the given string */
 		GMT_Report (API, GMT_MSG_DEBUG, "Obtained GMT_SESSION_NAME from the environment: %s\n", str);
@@ -760,7 +760,7 @@ GMT_LOCAL char * api_get_ppid (struct GMTAPI_CTRL *API) {
 		ppid = getppid(), k = 1; /* parent process id */
 #endif
 	GMT_Report (API, GMT_MSG_DEBUG, "Obtained the ppid from %s: %d\n", source[k], ppid);
-	sprintf (string, "%d", ppid);
+	snprintf (string, GMT_LEN8, "%d", ppid);
 	return (strdup (string));
 }
 
@@ -4469,7 +4469,7 @@ GMT_LOCAL int api_export_ppm (struct GMT_CTRL *GMT, char *fname, struct GMT_IMAG
 		return -1;
 	}
 	fwrite (magic, sizeof (char), strlen (magic), fp);	/* Write magic number, linefeed, comment, and another linefeed */
-	sprintf (dim, "%d %d\n255\n", I->header->n_rows, I->header->n_columns);
+	snprintf (dim, GMT_LEN32, "%d %d\n255\n", I->header->n_rows, I->header->n_columns);
 	fwrite (dim, sizeof (char), strlen (dim), fp);	/* Write dimensions and max color value + linefeeds */
 	/* Now dump the image in scaneline order, with each pixel as (R, G, B) */
 	if (strncmp (I->header->mem_layout, "TRP", 3U)) /* Easy street! */
@@ -5627,7 +5627,7 @@ GMT_LOCAL int api_colors2cpt (struct GMTAPI_CTRL *API, char **str, unsigned int 
 		for (k = 0; gray && k < s_length; k++)
 			if (!isdigit ((*str)[k])) gray = false;	/* Not just a bunch of integers */
 		if (gray) {	/* Must also rule out temporary files like 14334.cpt since the ".cpt" is not present */
-			sprintf (tmp_file, "%s.cpt", *str);	/* Try this as a filename */
+			snprintf (tmp_file, GMT_LEN64, "%s.cpt", *str);	/* Try this as a filename */
 			if (!gmt_access (API->GMT, tmp_file, F_OK))
 				return 0;	/* Probably a process id temp file like 13223.cpt */
 		}
@@ -6056,7 +6056,7 @@ void *GMT_Create_Session (const char *session, unsigned int pad, unsigned int mo
 			GMT_Report (API, GMT_MSG_DEBUG, "Must pass a session tag to be used for error log file name\n");
 			return_null (API, GMT_ARG_IS_NULL);
 		}
-		sprintf (file, "%s.log", API->session_tag);
+		snprintf (file, PATH_MAX, "%s.log", API->session_tag);
 		if ((fp = fopen (file, "w")) == NULL) {
 			GMT_Report (API, GMT_MSG_DEBUG, "Unable to open error log file %s\n", file);
 			return_null (API, GMT_ERROR_ON_FOPEN);
@@ -9992,7 +9992,7 @@ const char * gmt_show_name_and_purpose (void *V_API, const char *component, cons
 	API = api_get_api_ptr (V_API);
 	mode_name = gmtlib_get_active_name (API, name);
 	lib = (component) ? component : core;
-	sprintf (full_name, "gmt %s", mode_name);
+	snprintf (full_name, GMT_LEN32, "gmt %s", mode_name);
 	snprintf (message, GMT_LEN256, "%s [%s] %s - %s\n\n", full_name, lib, GMT_version(), purpose);
 	GMT_Message (V_API, GMT_TIME_NONE, message);
 	gmtlib_set_KOP_strings (API);
@@ -10556,7 +10556,7 @@ struct GMT_RESOURCE *GMT_Encode_Options (void *V_API, const char *module_name, i
 	if (gmt_M_is_verbose (API->GMT, GMT_MSG_DEBUG)) {
 		char txt[4] = {""};
 		for (k = 0; k < GMT_N_FAMILIES; k++) if (n_per_family[k] != GMT_NOTSET) {
-			(n_per_family[k] == GMTAPI_UNLIMITED) ? sprintf (txt, ">1") : sprintf (txt, "%d", n_per_family[k]);
+			(n_per_family[k] == GMTAPI_UNLIMITED) ? snprintf (txt, 4, ">1") : snprintf (txt, "%d", 4, n_per_family[k]);
 			GMT_Report (API, GMT_MSG_DEBUG, "GMT_Encode_Options: For %s we expect %s input objects\n", GMT_family[k], txt);
 		}
 	}

--- a/src/gmt_esri_io.c
+++ b/src/gmt_esri_io.c
@@ -36,37 +36,37 @@ GMT_LOCAL int esri_write_info (struct GMT_CTRL *GMT, FILE *fp, struct GMT_GRID_H
 	/* Note: fp is an open file pointer passed in; it will be closed upstream and not here */
 	char record[GMT_BUFSIZ] = {""}, item[GMT_LEN64] = {""};
 
-	sprintf (record, "ncols %d\nnrows %d\n", header->n_columns, header->n_rows);
+	snprintf (record, GMT_BUFSIZ, "ncols %d\nnrows %d\n", header->n_columns, header->n_rows);
 	gmt_M_fputs (record, fp);		/* Write a text record */
 	if (header->registration == GMT_GRID_PIXEL_REG) {	/* Pixel format */
 		sprintf (record, "xllcorner ");
-		sprintf (item, GMT->current.setting.format_float_out, header->wesn[XLO]);
+		snprintf (item, GMT_LEN64, GMT->current.setting.format_float_out, header->wesn[XLO]);
 		strcat  (record, item);	strcat  (record, "\n");
 		gmt_M_fputs (record, fp);		/* Write a text record */
 		sprintf (record, "yllcorner ");
-		sprintf (item, GMT->current.setting.format_float_out, header->wesn[YLO]);
+		snprintf (item, GMT_LEN64, GMT->current.setting.format_float_out, header->wesn[YLO]);
 		strcat  (record, item);	strcat  (record, "\n");
 		gmt_M_fputs (record, fp);		/* Write a text record */
 	}
 	else {	/* Gridline format */
 		sprintf (record, "xllcenter ");
-		sprintf (item, GMT->current.setting.format_float_out, header->wesn[XLO]);
+		snprintf (item, GMT_LEN64, GMT->current.setting.format_float_out, header->wesn[XLO]);
 		strcat  (record, item);	strcat  (record, "\n");
 		gmt_M_fputs (record, fp);		/* Write a text record */
 		sprintf (record, "yllcenter ");
-		sprintf (item, GMT->current.setting.format_float_out, header->wesn[YLO]);
+		snprintf (item, GMT_LEN64, GMT->current.setting.format_float_out, header->wesn[YLO]);
 		strcat  (record, item);	strcat  (record, "\n");
 		gmt_M_fputs (record, fp);		/* Write a text record */
 	}
 	sprintf (record, "cellsize ");
-	sprintf (item, GMT->current.setting.format_float_out, header->inc[GMT_X]);
+	snprintf (item, GMT_LEN64, GMT->current.setting.format_float_out, header->inc[GMT_X]);
 	strcat  (record, item);	strcat  (record, "\n");
 	gmt_M_fputs (record, fp);		/* Write a text record */
 	if (isnan (header->nan_value)) {
 		GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "ESRI Arc/Info ASCII Interchange file must use proxy for NaN; default to -9999\n");
 		header->nan_value = -9999.0f;
 	}
-	sprintf (record, "nodata_value %ld\n", lrintf (header->nan_value));
+	snprintf (record, GMT_BUFSIZ, "nodata_value %ld\n", lrintf (header->nan_value));
 	gmt_M_fputs (record, fp);		/* Write a text record */
 
 	return (GMT_NOERROR);
@@ -699,13 +699,13 @@ int gmt_esri_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gm
 			if (i == last) c[0] = '\n';
 			kk = ij+actual_col[i];
 			if (gmt_M_is_fnan (grid[kk]))
-				sprintf (item, "%ld%c", lrintf (header->nan_value), c[0]);
+				snprintf (item, GMT_LEN64, "%ld%c", lrintf (header->nan_value), c[0]);
 			else if (floating) {
-				sprintf (item, GMT->current.setting.format_float_out, grid[kk]);
+				snprintf (item, GMT_LEN64-1, GMT->current.setting.format_float_out, grid[kk]);
 				strcat (item, c);
 			}
 			else
-				sprintf (item, "%ld%c", lrint ((double)grid[kk]), c[0]);
+				snprintf (item, GMT_LEN64, "%ld%c", lrint ((double)grid[kk]), c[0]);
 			gmt_M_fputs (item, fp);
 		}
 	}

--- a/src/gmt_gdalread.c
+++ b/src/gmt_gdalread.c
@@ -84,7 +84,7 @@ GMT_LOCAL int record_geotransform (char *gdal_filename, GDALDatasetH hDataset, d
 		return (0);
 
 	/* Try again, but try "a.tif.wld" instead. */
-	sprintf (generic_buffer, "%s.xxx", gdal_filename);
+	snprintf (generic_buffer, 5000, "%s.xxx", gdal_filename);
 	status = GDALReadWorldFile (generic_buffer, "wld", adfGeoTransform);
 	if (status == 1)
 		return (0);

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -1225,7 +1225,7 @@ void gmtlib_grd_set_units (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header)
 						strcpy (unit, "seconds"); break;
 				}
 				gmt_format_calendar (GMT, date, clock, &GMT->current.io.date_output, &GMT->current.io.clock_output, false, 1, 0.0);
-				sprintf (string[i], "time [%s since %s %s]", unit, date, clock);
+				snprintf (string[i], GMT_GRID_UNIT_LEN80, "time [%s since %s %s]", unit, date, clock);
 				/* Warning for non-double grids */
 				if (i == 2 && GMT->session.grdformat[header->type][1] != 'd')
 					GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Use double precision output grid to avoid loss of significance of time coordinate.\n");
@@ -1984,12 +1984,12 @@ void gmt_grd_init (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, struct 
 		len = strlen (header->command);
 		for (i = 0; len < GMT_GRID_COMMAND_LEN320 && i < argc; i++) {
 			if (gmtlib_file_is_srtmlist (API, argv[i])) {	/* Want to replace the srtm list with the original @earth_relief_xxx name instead */
-				sprintf (file, "@earth_relief_0%cs", argv[i][strlen(argv[i])-8]);
+				snprintf (file, GMT_LEN64, "@earth_relief_0%cs", argv[i][strlen(argv[i])-8]);
 				txt = file;
 			}
 			else if (gmt_M_file_is_remotedata (argv[i]) && (c = strstr (argv[i], ".grd"))) {
 				c[0] = '\0';
-				sprintf (file, "%s", argv[i]);
+				snprintf (file, GMT_LEN64, "%s", argv[i]);
 				c[0] = '.';
 				txt = file;
 			}

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -507,7 +507,7 @@ GMT_LOCAL void gmtinit_kw_replace (struct GMTAPI_CTRL *API, struct GMT_KW_DICT *
 		opt->option = kw[k].code;		/* Update the option character first */
 		if (e) {
 			e[0] = '=';			/* Put back the = character */
-			sprintf (text, "%s", &e[1]);	/* Get string with the argument */
+			snprintf (text, GMT_LEN256, "%s", &e[1]);	/* Get string with the argument */
 		}
 		else
 			text[0] = '\0';			/* No argument to pass on */
@@ -1505,21 +1505,21 @@ GMT_LOCAL int gmtinit_parse_model1d (struct GMT_CTRL *GMT, char option, char *in
 		char *way[2] = {"last squares", "robust"}, report[GMT_BUFSIZ] = {""}, piece[GMT_LEN64] = {""};
 		if (!M->intercept) GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Warning -%c: No intercept term (p0) given\n", option);
 		GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Solving for %u terms using a %s norm.  The model:\n", n_model, way[M->robust]);
-		sprintf (report, "y(x) = ");
+		strcpy (report, "y(x) = ");
 		for (k =  0; k < n_model; k++) {
 			switch (M->term[k].kind) {
 				case GMT_POLYNOMIAL:
 				case GMT_CHEBYSHEV:
 					if (M->term[k].order[GMT_X] == 0)
-						sprintf (piece, "%c", 'a');
+						snprintf (piece, GMT_LEN64, "%c", 'a');
 					else
-						sprintf (piece, "%c * x^%d", 'a'+ k, M->term[k].order[GMT_X]);
+						snprintf (piece, GMT_LEN64, "%c * x^%d", 'a'+ k, M->term[k].order[GMT_X]);
 					break;
 				case GMT_COSINE:
-					sprintf (piece, "%c * cos (%d*x)", 'a'+k, M->term[k].order[GMT_X]);
+					snprintf (piece, GMT_LEN64, "%c * cos (%d*x)", 'a'+k, M->term[k].order[GMT_X]);
 					break;
 				case GMT_SINE:
-					sprintf (piece, "%c * sin (%d*x)", 'a'+k, M->term[k].order[GMT_X]);
+					snprintf (piece, GMT_LEN64, "%c * sin (%d*x)", 'a'+k, M->term[k].order[GMT_X]);
 					break;
 			}
 			strcat (report, piece);
@@ -2486,13 +2486,13 @@ GMT_LOCAL unsigned int gmtinit_subplot_status (struct GMTAPI_CTRL *API, int fig)
 	bool answer;
 	unsigned int mode = 0;
 	/* Now read subplot information file */
-	sprintf (file, "%s/gmt.subplot.%d", API->gwf_dir, fig);
+	snprintf (file, PATH_MAX, "%s/gmt.subplot.%d", API->gwf_dir, fig);
 	answer = (access (file, F_OK) == 0);	/* true if subplot information file is found */
 	if (answer) {
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Subplot information file found\n");
 		mode |= GMT_SUBPLOT_ACTIVE;
 	}
-	sprintf (file, "%s/gmt.panel.%d", API->gwf_dir, fig);
+	snprintf (file, PATH_MAX, "%s/gmt.panel.%d", API->gwf_dir, fig);
 	answer = (access (file, F_OK) == 0);	/* true if current panel file is found */
 	if (answer)
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Current panel file found\n");
@@ -2509,7 +2509,7 @@ GMT_LOCAL int gmtinit_get_inset_dimensions (struct GMTAPI_CTRL *API, int fig, st
 	FILE *fp = NULL;
 	
 	if (inset) inset->active = false;	/* It is not an inset until we detect that it is */
-	sprintf (file, "%s/gmt.inset.%d", API->gwf_dir, fig);	/* Inset information file */
+	snprintf (file, PATH_MAX, "%s/gmt.inset.%d", API->gwf_dir, fig);	/* Inset information file */
 
 	if (access (file, F_OK)) return (GMT_NOERROR);	/* No inset active */
 
@@ -2534,7 +2534,7 @@ GMT_LOCAL int gmtinit_get_inset_dimensions (struct GMTAPI_CTRL *API, int fig, st
 	}
 	fclose (fp);
 	
-	sprintf (file, "%s/gmt.inset+.%d", API->gwf_dir, fig);	/* Inset continuation file */
+	snprintf (file, PATH_MAX, "%s/gmt.inset+.%d", API->gwf_dir, fig);	/* Inset continuation file */
 	if (access (file, F_OK)) inset->first = true;	/* First time plotting in the inset */
 	if ((fp = fopen (file, "w")) == NULL) {	/* Not good */
 		GMT_Report (API, GMT_MSG_NORMAL, "Cannot create file %s\n", file);
@@ -2596,14 +2596,14 @@ GMT_LOCAL int gmtinit_get_history (struct GMT_CTRL *GMT) {
 	if (GMT->current.setting.run_mode == GMT_MODERN) {	/* Modern mode: Use the workflow directory and one history per figure */
 		char tag[GMT_LEN16] = {""};
 		gmt_history_tag (GMT->parent, tag);
-		sprintf (hfile, "%s/%s.%s", GMT->parent->gwf_dir, GMT_HISTORY_FILE, tag);
+		snprintf (hfile, PATH_MAX, "%s/%s.%s", GMT->parent->gwf_dir, GMT_HISTORY_FILE, tag);
 	}
 	else if (GMT->session.TMPDIR)			/* Isolation mode: Use GMT->session.TMPDIR/gmt.history */
-		sprintf (hfile, "%s/%s", GMT->session.TMPDIR, GMT_HISTORY_FILE);
+		snprintf (hfile, PATH_MAX, "%s/%s", GMT->session.TMPDIR, GMT_HISTORY_FILE);
 	else if (!access (cwd, W_OK))		/* Current directory is writable */
-		sprintf (hfile, "%s", GMT_HISTORY_FILE);
+		snprintf (hfile, PATH_MAX, "%s", GMT_HISTORY_FILE);
 	else if (GMT->session.HOMEDIR)	/* Try home directory instead */
-		sprintf (hfile, "%s/%s", GMT->session.HOMEDIR, GMT_HISTORY_FILE);
+		snprintf (hfile, PATH_MAX, "%s/%s", GMT->session.HOMEDIR, GMT_HISTORY_FILE);
 	else {
 		GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "No writable directory found for gmt history - skipping it.\n");
 		return (GMT_NOERROR);
@@ -2690,14 +2690,14 @@ GMT_LOCAL int gmtinit_put_history (struct GMT_CTRL *GMT) {
 	if (GMT->current.setting.run_mode == GMT_MODERN) {	/* Modern mode: Use the workflow directory */
 		char tag[GMT_LEN16] = {""};
 		gmt_history_tag (GMT->parent, tag);
-		sprintf (hfile, "%s/%s.%s", GMT->parent->gwf_dir, GMT_HISTORY_FILE, tag);
+		snprintf (hfile, PATH_MAX, "%s/%s.%s", GMT->parent->gwf_dir, GMT_HISTORY_FILE, tag);
 	}
 	else if (GMT->session.TMPDIR)			/* Classic isolation mode: Use GMT->session.TMPDIR/gmt.history */
-		sprintf (hfile, "%s/%s", GMT->session.TMPDIR, GMT_HISTORY_FILE);
+		snprintf (hfile, PATH_MAX, "%s/%s", GMT->session.TMPDIR, GMT_HISTORY_FILE);
 	else if (!access (cwd, W_OK))	/* Current directory is writable */
-		sprintf (hfile, "%s", GMT_HISTORY_FILE);
+		snprintf (hfile, PATH_MAX, "%s", GMT_HISTORY_FILE);
 	else if (GMT->session.HOMEDIR)	/* Try home directory instead */
-		sprintf (hfile, "%s/%s", GMT->session.HOMEDIR, GMT_HISTORY_FILE);
+		snprintf (hfile, PATH_MAX, "%s/%s", GMT->session.HOMEDIR, GMT_HISTORY_FILE);
 	else {
 		GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Unable to determine a writeable directory - gmt history not updated.\n");
 		return (GMT_NOERROR);
@@ -2829,7 +2829,7 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 	if ((this_c = getenv ("GMT_USERDIR")) != NULL)		/* GMT_USERDIR was set */
 		GMT->session.USERDIR = strdup (this_c);
 	else if (GMT->session.HOMEDIR) {	/* Use default path for GMT_USERDIR (~/.gmt) */
-		sprintf (path, "%s/%s", GMT->session.HOMEDIR, ".gmt");
+		snprintf (path, PATH_MAX, "%s/%s", GMT->session.HOMEDIR, ".gmt");
 		GMT->session.USERDIR = strdup (path);
 		u = 1;
 	}
@@ -2849,7 +2849,7 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 	if ((this_c = getenv ("GMT_CACHEDIR")) != NULL)		/* GMT_CACHEDIR was set */
 		GMT->session.CACHEDIR = strdup (this_c);
 	else if (GMT->session.USERDIR != NULL) {	/* Use default path for GMT_CACHEDIR as GMT_USERDIR/cache */
-		sprintf (path, "%s/%s", GMT->session.USERDIR, "cache");
+		snprintf (path, PATH_MAX, "%s/%s", GMT->session.USERDIR, "cache");
 		GMT->session.CACHEDIR = strdup (path);
 		c = 1;
 	}
@@ -2870,7 +2870,7 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 	if ((this_c = getenv ("GMT_SESSIONDIR")) != NULL)		/* GMT_SESSIONDIR was set */
 		API->session_dir = strdup (this_c);
 	else if (GMT->session.USERDIR != NULL) {	/* Use GMT_USERDIR/sessions as default path for GMT_SESSIONDIR */
-		sprintf (path, "%s/%s", GMT->session.USERDIR, "sessions");
+		snprintf (path, PATH_MAX, "%s/%s", GMT->session.USERDIR, "sessions");
 		API->session_dir = strdup (path);
 	}
 	else {	/* Use the temp dir as the session dir */
@@ -5224,7 +5224,7 @@ GMT_LOCAL int gmtinit_get_language (struct GMT_CTRL *GMT) {
 
 	gmt_M_memset (months, 12, char *);
 
-	sprintf (line, "gmt_%s", GMT->current.setting.language);
+	snprintf (line, GMT_BUFSIZ, "gmt_%s", GMT->current.setting.language);
 	gmt_getsharepath (GMT, "localization", line, ".locale", file, R_OK);
 	if ((fp = fopen (file, "r")) == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Could not load language %s - revert to us (English)!\n",
@@ -7649,7 +7649,7 @@ int gmt_parse_R_option (struct GMT_CTRL *GMT, char *arg) {
 			  || fabs (G->header->wesn[YLO]) > 90.0 || fabs (G->header->wesn[YHI]) > 90.0) {	/* Yes we probably did, but cannot be sure */
 				inv_project = true;
 				r_unit = 'e';	/* Must specify the "missing" leading e for meter */
-				sprintf (string, "%.16g/%.16g/%.16g/%.16g", G->header->wesn[XLO], G->header->wesn[XHI], G->header->wesn[YLO], G->header->wesn[YHI]);
+				snprintf (string, GMT_BUFSIZ, "%.16g/%.16g/%.16g/%.16g", G->header->wesn[XLO], G->header->wesn[XHI], G->header->wesn[YLO], G->header->wesn[YHI]);
 			}
 		}
 		if (!inv_project) {	/* Got grid with degrees or regular Cartesian */
@@ -10935,13 +10935,13 @@ char *gmtlib_putparameter (struct GMT_CTRL *GMT, const char *keyword) {
 			if (GMT->current.setting.url_size_limit == 0)
 				strcpy (value, "unlimited");
 			else if (GMT->current.setting.url_size_limit < 1024)
-				sprintf (value, "%" PRIu64, (uint64_t)GMT->current.setting.url_size_limit);
+				snprintf (value, GMT_BUFSIZ, "%" PRIu64, (uint64_t)GMT->current.setting.url_size_limit);
 			else if (GMT->current.setting.url_size_limit < 1024*1024)
-				sprintf (value, "%" PRIu64 "Kb", (uint64_t)GMT->current.setting.url_size_limit/1024);
+				snprintf (value, GMT_BUFSIZ, "%" PRIu64 "Kb", (uint64_t)GMT->current.setting.url_size_limit/1024);
 			else if (GMT->current.setting.url_size_limit < 1024*1024*1024)
-				sprintf (value, "%" PRIu64 "Mb", (uint64_t)GMT->current.setting.url_size_limit/(1024*1024));
+				snprintf (value, GMT_BUFSIZ, "%" PRIu64 "Mb", (uint64_t)GMT->current.setting.url_size_limit/(1024*1024));
 			else
-				sprintf (value, "%" PRIu64 "Gb", (uint64_t)GMT->current.setting.url_size_limit/(1024*1024*1024));
+				snprintf (value, GMT_BUFSIZ, "%" PRIu64 "Gb", (uint64_t)GMT->current.setting.url_size_limit/(1024*1024*1024));
 			break;
 
 		case GMTCASE_GMT_CUSTOM_LIBS:
@@ -11201,11 +11201,11 @@ void gmt_putdefaults (struct GMT_CTRL *GMT, char *this_file) {
 	else {	/* Use local dir, tempdir, or workflow dir */
 		char path[PATH_MAX] = {""};
 		if (GMT->current.setting.run_mode == GMT_MODERN)	/* Modern mode: Use the workflow directory */
-			sprintf (path, "%s/gmt.conf", GMT->parent->gwf_dir);
+			snprintf (path, PATH_MAX, "%s/gmt.conf", GMT->parent->gwf_dir);
 		else if (GMT->session.TMPDIR)	/* Write GMT->session.TMPDIR/gmt.conf */
-			sprintf (path, "%s/gmt.conf", GMT->session.TMPDIR);
+			snprintf (path, PATH_MAX, "%s/gmt.conf", GMT->session.TMPDIR);
 		else	/* Write gmt.conf in current directory */
-			sprintf (path, "gmt.conf");
+			strcpy (path, "gmt.conf");
 		gmtinit_savedefaults (GMT, path);
 	}
 }
@@ -11219,7 +11219,7 @@ void gmt_getdefaults (struct GMT_CTRL *GMT, char *this_file) {
 	else {	/* Use local dir, tempdir, or workflow dir (modern mode) */
 		if (GMT->current.setting.run_mode == GMT_MODERN) {	/* Modern mode: Use the workflow directory */
 			char path[PATH_MAX] = {""};
-			sprintf (path, "%s/gmt.conf", GMT->parent->gwf_dir);
+			snprintf (path, PATH_MAX, "%s/gmt.conf", GMT->parent->gwf_dir);
 			gmt_loaddefaults (GMT, path);
 		}
 		else if (gmtlib_getuserpath (GMT, "gmt.conf", file))
@@ -11242,7 +11242,7 @@ char *gmtlib_putfill (struct GMT_CTRL *GMT, struct GMT_FILL *F) {
 			snprintf (text, PATH_MAX+GMT_LEN256, "p%d/%s", F->dpi, F->pattern);
 	}
 	else if (F->rgb[0] < -0.5)
-		sprintf (text, "-");
+		strcpy (text, "-");
 	else if ((i = gmtlib_getrgb_index (GMT, F->rgb)) >= 0)
 		snprintf (text, PATH_MAX+GMT_LEN256, "%s", gmt_M_color_name[i]);
 	else if (gmt_M_is_gray (F->rgb))
@@ -11262,7 +11262,7 @@ char *gmt_putcolor (struct GMT_CTRL *GMT, double *rgb) {
 	int i;
 
 	if (rgb[0] < -0.5)
-		sprintf (text, "-");
+		strcpy (text, "-");
 	else if ((i = gmtlib_getrgb_index (GMT, rgb)) >= 0)
 		snprintf (text, GMT_LEN256, "%s", gmt_M_color_name[i]);
 	else if (gmt_M_is_gray(rgb))
@@ -11280,7 +11280,7 @@ char *gmt_putrgb (struct GMT_CTRL *GMT, double *rgb) {
 	gmt_M_unused(GMT);
 
 	if (rgb[0] < -0.5)
-		sprintf (text, "-");
+		strcpy (text, "-");
 	else
 		snprintf (text, GMT_LEN256, "%.5g/%.5g/%.5g", gmt_M_t255(rgb));
 	gmtinit_append_trans (text, rgb[3]);
@@ -11294,7 +11294,7 @@ char *gmtlib_putcmyk (struct GMT_CTRL *GMT, double *cmyk) {
 	gmt_M_unused(GMT);
 
 	if (cmyk[0] < -0.5)
-		sprintf (text, "-");
+		strcpy (text, "-");
 	else
 		snprintf (text, GMT_LEN256, "%.5g/%.5g/%.5g/%.5g", gmt_M_q(cmyk[0]), gmt_M_q(cmyk[1]), gmt_M_q(cmyk[2]), gmt_M_q(cmyk[3]));
 	gmtinit_append_trans (text, cmyk[4]);
@@ -11308,7 +11308,7 @@ char *gmtlib_puthsv (struct GMT_CTRL *GMT, double *hsv) {
 	gmt_M_unused(GMT);
 
 	if (hsv[0] < -0.5)
-		sprintf (text, "-");
+		strcpy (text, "-");
 	else
 		snprintf (text, GMT_LEN256, "%.5g-%.5g-%.5g", gmt_M_q(hsv[0]), gmt_M_q(hsv[1]), gmt_M_q(hsv[2]));
 	gmtinit_append_trans (text, hsv[3]);
@@ -11692,7 +11692,7 @@ GMT_LOCAL int get_current_panel (struct GMTAPI_CTRL *API, int fig, int *row, int
 	char file[PATH_MAX] = {""};
 	FILE *fp = NULL;
 	int ios;
-	sprintf (file, "%s/gmt.panel.%d", API->gwf_dir, fig);
+	snprintf (file, PATH_MAX, "%s/gmt.panel.%d", API->gwf_dir, fig);
 	if (access (file, F_OK))	{	/* Panel selection file not available so we are not doing subplots */
 		if (gap == NULL) {	/* By default we do the first panel */
 			*row = *col = INT_MAX;
@@ -11740,7 +11740,7 @@ int gmt_set_current_panel (struct GMTAPI_CTRL *API, int fig, int row, int col, d
 	static char *dummy = "@";	/* Signify "use the the auto label" */
 	FILE *fp = NULL;
 	L = (label && label[0]) ? label : dummy;
-	sprintf (file, "%s/gmt.panel.%d", API->gwf_dir, fig);
+	snprintf (file, PATH_MAX, "%s/gmt.panel.%d", API->gwf_dir, fig);
 	if ((fp = fopen (file, "w")) == NULL) {
 		GMT_Report (API, GMT_MSG_NORMAL, "Unable to create file %s!\n", file);
 		API->error = GMT_RUNTIME_ERROR;
@@ -11763,7 +11763,7 @@ int gmt_get_next_panel (struct GMTAPI_CTRL *API, int fig, int *row, int *col) {
 	char file[PATH_MAX] = {""};
 	FILE *fp = NULL;
 	
-	sprintf (file, "%s/gmt.subplotorder.%d", API->gwf_dir, fig);
+	snprintf (file, PATH_MAX, "%s/gmt.subplotorder.%d", API->gwf_dir, fig);
 	if ((fp = fopen (file, "r")) == NULL) {
 		GMT_Report (API, GMT_MSG_NORMAL, "Unable to open file %s!\n", file);
 		API->error = GMT_ERROR_ON_FOPEN;
@@ -11825,7 +11825,7 @@ void gmt_subplot_gaps (struct GMTAPI_CTRL *API, int fig, double *gap) {
 
 	gmt_M_memset (gap, 4, double);
 	/* Now read subplot information file */
-	sprintf (file, "%s/gmt.subplot.%d", API->gwf_dir, fig);
+	snprintf (file, PATH_MAX, "%s/gmt.subplot.%d", API->gwf_dir, fig);
 	if (access (file, F_OK)) {	/* Subplot information file not available */
 		GMT_Report (API, GMT_MSG_NORMAL, "No subplot information file found!\n");
 		return;
@@ -11867,7 +11867,7 @@ struct GMT_SUBPLOT *gmt_subplot_info (struct GMTAPI_CTRL *API, int fig) {
 		return NULL;
 
 	/* Now read subplot information file */
-	sprintf (file, "%s/gmt.subplot.%d", API->gwf_dir, fig);
+	snprintf (file, PATH_MAX, "%s/gmt.subplot.%d", API->gwf_dir, fig);
 	if (access (file, F_OK)) {	/* Subplot information file not available */
 		GMT_Report (API, GMT_MSG_NORMAL, "No subplot information file found!\n");
 		return NULL;
@@ -12074,7 +12074,7 @@ GMT_LOCAL int gmtlib_get_region_from_data (struct GMTAPI_CTRL *API, int family, 
 
 				GMT_Report (API, GMT_MSG_DEBUG, "gmtlib_get_region_from_data: Must save stdin to a temporary file.\n");
 				if (API->tmp_dir)			/* Have a recognized temp directory */
-					sprintf (tmpfile, "%s/", API->tmp_dir);
+					snprintf (tmpfile, PATH_MAX, "%s/", API->tmp_dir);
 				strcat (tmpfile, "gmt_saved_stdin.XXXXXX");	/* The XXXXXX will be replaced by mktemp */
 #ifdef _WIN32
 				if ((file = mktemp (tmpfile)) == NULL) {
@@ -12209,7 +12209,7 @@ GMT_LOCAL int gmtinit_set_missing_R_from_grid (struct GMTAPI_CTRL *API, const ch
 	if ((err = gmtlib_get_region_from_data (API, GMT_IS_GRID, exact, options, wesn)))
 		return err;
 
-	sprintf (region, "%.16g/%.16g/%.16g/%.16g", wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI]);
+	snprintf (region, GMT_LEN256, "%.16g/%.16g/%.16g/%.16g", wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI]);
 	if ((opt = GMT_Make_Option (API, 'R', region)) == NULL)
 		return API->error;	/* Failure to make option */
 	if ((*options = GMT_Append_Option (API, opt, *options)) == NULL)
@@ -12233,7 +12233,7 @@ GMT_LOCAL int gmtinit_set_missing_R_from_datasets (struct GMTAPI_CTRL *API, cons
 	/* Here we know the module is using a grid to get -R implicitly */
 	if ((err = gmtlib_get_region_from_data (API, GMT_IS_DATASET, exact, options, wesn)))
 		return err;
-	sprintf (region, "%.16g/%.16g/%.16g/%.16g", wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI]);
+	snprintf (region, GMT_LEN256, "%.16g/%.16g/%.16g/%.16g", wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI]);
 	if ((opt = GMT_Make_Option (API, 'R', region)) == NULL)
 		return API->error;	/* Failure to make option */
 	if ((*options = GMT_Append_Option (API, opt, *options)) == NULL)
@@ -12392,7 +12392,7 @@ GMT_LOCAL int set_modern_mode_if_oneliner (struct GMTAPI_CTRL *API, struct GMT_O
 			}
 		}
 		if (opt->next && opt->next->option == GMT_OPT_INFILE) {	/* Found a -ext[,ext,ext,...] <prefix> pair */
-			sprintf (session, "%s %s", opt->next->arg, figure);
+			snprintf (session, GMT_LEN128, "%s %s", opt->next->arg, figure);
 			/* Remove the one-liner options before the parser chokes on them */
 			if (GMT_Delete_Option (API, opt->next, options) || GMT_Delete_Option (API, opt, options)) {
 				GMT_Report (API, GMT_MSG_NORMAL, "Unable to remove -ext <prefix> options in set_modern_mode_if_oneliner.\n");
@@ -12423,7 +12423,7 @@ GMT_LOCAL int gmtinit_get_last_dimensions (struct GMTAPI_CTRL *API, int fig) {
 		GMT_Report (API, GMT_MSG_NORMAL, "gmtinit_get_last_dimensions: No workflow directory set\n");
 		return GMT_NOT_A_VALID_DIRECTORY;
 	}
-	sprintf (file, "%s/gmt.canvas.%d", API->gwf_dir, fig);
+	snprintf (file, PATH_MAX, "%s/gmt.canvas.%d", API->gwf_dir, fig);
 	/* See if there is a gmt.canvas file to read for this figure */
 	if (access (file, R_OK))	/* No gmt.canvas file available for current figure so return 0 */
 		return GMT_NOERROR;
@@ -12453,7 +12453,7 @@ GMT_LOCAL int gmtinit_set_last_dimensions (struct GMTAPI_CTRL *API) {
 		return GMT_NOT_A_VALID_DIRECTORY;
 	}
 	fig = gmt_get_current_figure (API);
-	sprintf (file, "%s/gmt.canvas.%d", API->gwf_dir, fig);
+	snprintf (file, PATH_MAX, "%s/gmt.canvas.%d", API->gwf_dir, fig);
 	/* Write current dimensions */
 	if ((fp = fopen (file, "w")) == NULL) {
 		GMT_Report (API, GMT_MSG_NORMAL, "gmtinit_set_last_dimensions: Could not create file %s for figure %d\n", file, fig);
@@ -12478,30 +12478,30 @@ GMT_LOCAL bool build_new_J_option (struct GMTAPI_CTRL *API, struct GMT_OPTION *o
 		slash = strchr (opt_J->arg, '/');	/* slash[0] == '/' means we got separate x and y scale args for linear/log/power axes */
 	if (P) {	/* Subplot mode */
 		if (P->dir[GMT_X] == -1 || P->dir[GMT_Y] == -1) {	/* Nonstandard Cartesian directions set via subplot */
-			sprintf (sclX, "%gi",  P->dir[GMT_X]*P->w);
-			sprintf (sclY, "%gi",  P->dir[GMT_Y]*P->h);
+			snprintf (sclX, GMT_LEN64, "%gi",  P->dir[GMT_X]*P->w);
+			snprintf (sclY, GMT_LEN64, "%gi",  P->dir[GMT_Y]*P->h);
 		}
 		else if (slash) {	/* Found separate x and y scales */
-			sprintf (sclX, "%gi", P->w);
-			sprintf (sclY, "%gi", P->h);
+			snprintf (sclX, GMT_LEN64, "%gi", P->w);
+			snprintf (sclY, GMT_LEN64, "%gi", P->h);
 		}
 		else if (is_psrose)	/* Just append the minimum dimension as the diameter */
-			sprintf (sclX, "%gi", MIN(P->w, P->h));
+			snprintf (sclX, GMT_LEN64, "%gi", MIN(P->w, P->h));
 		else	/* Just append a dummy width */
-			sprintf (sclX, "%gi", P->w);
+			snprintf (sclX, GMT_LEN64, "%gi", P->w);
 	}
 	else if (I) {	/* Inset mode */
 		if (slash) {	/* Found separate x and y scales */
-			sprintf (sclX, "%gi", I->w);
-			sprintf (sclY, "%gi", I->h);
+			snprintf (sclX, GMT_LEN64, "%gi", I->w);
+			snprintf (sclY, GMT_LEN64, "%gi", I->h);
 		}
 		else if (is_psrose)	/* Just append the minimum dimension as the diameter */
-			sprintf (sclX, "%gi", MIN(I->w, I->h));
+			snprintf (sclX, GMT_LEN64, "%gi", MIN(I->w, I->h));
 		else	/* Just append a dummy width */
-			sprintf (sclX, "%gi", I->w);
+			snprintf (sclX, GMT_LEN64, "%gi", I->w);
 	}		
 	arg[0] = c[0] = '\0';	/* Chop off everything from first ? to end */
-	sprintf (arg, "%s%s", opt_J->arg, sclX);	/* Build new -J<arg> from initial J arg, then replace first ? with sclX */
+	snprintf (arg, GMT_LEN128, "%s%s", opt_J->arg, sclX);	/* Build new -J<arg> from initial J arg, then replace first ? with sclX */
 	c[0] = '?';	/* Put back the ? we removed */
 	if (c[1] == 'l')	/* Must add the log character after the scale */
 		strcat (arg, "l");
@@ -12600,7 +12600,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 				S->arg[strlen(S->arg)-1] = '\0';
 			}
 			radius = gmt_M_to_inch (GMT, &S->arg[k]);	/* Get the radius, now in inches */
-			sprintf (j_code, "X%gi", 2 * radius);
+			snprintf (j_code, GMT_LEN256, "X%gi", 2 * radius);
 			if ((opt = GMT_Make_Option (API, 'J', j_code)) == NULL) return NULL;		/* Failed to make -J option */
 			if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failed to append -J option */
 			if (norm) {	/* Need a plain -S for normalization */
@@ -12773,14 +12773,14 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 						frame_set = true;
 					else if (strstr (opt->arg, "+t") || strstr (opt->arg, "+g")) {	/* No axis specs means we have to add default */
 						/* Frame but no sides specified.  Insert the required sides */
-						sprintf (arg, "%s", P->Baxes);
+						snprintf (arg, GMT_LEN256, "%s", P->Baxes);
 						strncat (arg, opt->arg, GMT_LEN256-1);
 						GMT_Update_Option (API, opt, arg);
 						frame_set = true;
 					}
 					else if (opt->arg[0] == 'x') {	/* Gave specific x-setting */
 						if (opt->arg[1] == '+')	{	/* No x-axis annot/tick given, prepend default determined in subplot  */
-							sprintf (arg, "x%s%s", P->Bxannot, &opt->arg[1]);
+							snprintf (arg, GMT_LEN256, "x%s%s", P->Bxannot, &opt->arg[1]);
 							GMT_Update_Option (API, opt, arg);
 						}
 						if (P->Bxlabel[0]) {	/* Provided a label during subplot initialization */
@@ -12799,7 +12799,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 					}
 					else if (opt->arg[0] == 'y') {	/* Gave specific y-setting */
 						if (opt->arg[1] == '+')	{	/* No x-axis annot/tick set, prepend default af */
-							sprintf (arg, "y%s%s", P->Byannot, &opt->arg[1]);
+							snprintf (arg, GMT_LEN256, "y%s%s", P->Byannot, &opt->arg[1]);
 							GMT_Update_Option (API, opt, arg);
 						}
 						if (P->Bylabel[0]) {
@@ -12827,13 +12827,13 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 					if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
 				}
 				if (!x_set) {	/* Did not specify x-axis setting either via -Bx or -B so do that now */
-					sprintf (arg, "x%s", P->Bxannot);	/* Start with the x tick,annot,grid choices */
+					snprintf (arg, GMT_LEN256, "x%s", P->Bxannot);	/* Start with the x tick,annot,grid choices */
 					if (P->Bxlabel[0]) {strcat (arg, "+l"); strcat (arg, P->Bxlabel);}	/* Add label, if active */
 					if ((opt = GMT_Make_Option (API, 'B', arg)) == NULL) return NULL;	/* Failure to make option */
 					if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
 				}
 				if (!y_set) {	/* Did not specify y-axis setting so do that now */
-					sprintf (arg, "y%s", P->Byannot);	/* Start with the x tick,annot,grid choices */
+					snprintf (arg, GMT_LEN256, "y%s", P->Byannot);	/* Start with the x tick,annot,grid choices */
 					if (P->Bylabel[0]) {strcat (arg, "+l"); strcat (arg, P->Bylabel);}	/* Add label, if active */
 					if ((opt = GMT_Make_Option (API, 'B', arg)) == NULL) return NULL;	/* Failure to make option */
 					if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
@@ -12841,10 +12841,10 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 			}
 			if (GMT->hidden.func_level == GMT_CONTROLLER) {	/* Top-level function called by subplot needs to handle positioning and possibly set -J */
 				/* Set -X -Y for absolute positioning */
-				sprintf (arg, "a%gi", P->origin[GMT_X] + P->x);
+				snprintf (arg, GMT_LEN256, "a%gi", P->origin[GMT_X] + P->x);
 				if ((opt = GMT_Make_Option (API, 'X', arg)) == NULL) return NULL;	/* Failure to make option */
 				if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
-				sprintf (arg, "a%gi", P->origin[GMT_Y] + P->y);
+				snprintf (arg, GMT_LEN256, "a%gi", P->origin[GMT_Y] + P->y);
 				if ((opt = GMT_Make_Option (API, 'Y', arg)) == NULL) return NULL;	/* Failure to make option */
 				if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
 				if (build_new_J_option (API, opt_J, P, NULL, is_psrose))	/* Found ?-mark(s) and replaced them */
@@ -12889,9 +12889,9 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 				static char *arg[2] = {"X15c", "Q15c+"};
 				unsigned int geo = is_region_geographic (GMT, *options, mod_name);
 				if (P && (P->dir[GMT_X] == -1 || P->dir[GMT_Y] == -1))	/* Nonstandard Cartesian axes directions */
-					sprintf (scl, "X%gi/%gi",  P->dir[GMT_X]*P->w, P->dir[GMT_Y]*P->h);
+					snprintf (scl, GMT_LEN64, "X%gi/%gi",  P->dir[GMT_X]*P->w, P->dir[GMT_Y]*P->h);
 				else	/* Just append dummy width */
-					sprintf (scl, "%s",  arg[geo]);
+					snprintf (scl, GMT_LEN64, "%s",  arg[geo]);
 				if ((opt = GMT_Make_Option (API, 'J', scl)) == NULL) return NULL;	/* Failure to make option */
 				if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
 				GMT_Report (API, GMT_MSG_DEBUG, "Modern: Adding -J%s to options since there is no history available.\n", scl);
@@ -13008,13 +13008,13 @@ void gmt_end_module (struct GMT_CTRL *GMT, struct GMT_CTRL *Ccopy) {
 		char RG[GMT_LEN256] = {""}, tmp[GMT_LEN64] = {""};
 		int id = gmt_get_option_id (0, "R") + 1;	/* The RG history slot */
 		if (GMT->init.history[id]) gmt_M_str_free (GMT->init.history[id]);
-		sprintf (RG, "%.16g/%.16g/%.16g/%.16g", GMT->common.R.wesn[XLO], GMT->common.R.wesn[XHI], GMT->common.R.wesn[YLO], GMT->common.R.wesn[YHI]);
+		snprintf (RG, GMT_LEN256, "%.16g/%.16g/%.16g/%.16g", GMT->common.R.wesn[XLO], GMT->common.R.wesn[XHI], GMT->common.R.wesn[YLO], GMT->common.R.wesn[YHI]);
 		if (GMT->common.R.active[ISET]) {	/* Also want grid increment saved */
-			sprintf (tmp, "+I%.16g/%.16g", GMT->common.R.inc[GMT_X], GMT->common.R.inc[GMT_Y]);
+			snprintf (tmp, GMT_LEN64, "+I%.16g/%.16g", GMT->common.R.inc[GMT_X], GMT->common.R.inc[GMT_Y]);
 			strcat (RG, tmp);
 		}
 		if (GMT->common.R.active[GSET]) {	/* Also want grid registration saved */
-			sprintf (tmp, "+G%c%c", GMT->common.R.registration == GMT_GRID_PIXEL_REG ? 'P' : 'G', GMT->common.R.row_order == k_nc_start_north ? 'T' : 'B');
+			snprintf (tmp, GMT_LEN64, "+G%c%c", GMT->common.R.registration == GMT_GRID_PIXEL_REG ? 'P' : 'G', GMT->common.R.row_order == k_nc_start_north ? 'T' : 'B');
 			strcat (RG, tmp);
 		}
 		GMT->init.history[id] = strdup (RG);
@@ -14380,7 +14380,7 @@ GMT_LOCAL int parse_proj4 (struct GMT_CTRL *GMT, char *item, char *dest) {
 		else
 			item_t1 = item;
 
-		sprintf(GMT->common.J.proj4string, "%s", item);		/* Copy the proj.4 string */
+		snprintf(GMT->common.J.proj4string, GMT_LEN256, "%s", item);		/* Copy the proj.4 string */
 	}
 	else if (!strncmp(item, "EPSG:", 5) || !strncmp(item, "epsg:", 5))
 		item_t1 = &item[5];		/* Drop the EPSG: part because gmt_impotproj4 is not expecting it */
@@ -14569,7 +14569,7 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 			}
 			else if (item && (item[0] == '+' || isdigit(item[0]) || !strncmp(item, "EPSG:", 5) || !strncmp(item, "epsg:", 5))) {
 #ifdef HAVE_GDAL
-				char   source[1024] = {""}, dest[1024] = {""}, *pch;
+				char   source[GMT_LEN1024] = {""}, dest[GMT_LEN1024] = {""}, *pch;
 				bool two = false;
 
 				/* When reading from gmt.history, those are prefixed with a '+' but we must remove it */
@@ -15113,7 +15113,7 @@ struct GMT_CTRL *gmt_begin (struct GMTAPI_CTRL *API, const char *session, unsign
 	if ((path2 = getenv ("LOCAL_PROJ_LIB")) != NULL)  paths[local_count++] = path2;
 	if (!local_count) {			/* If none of the above was provided, default to share/GDAL_DATA */
 		char dir[PATH_MAX];
-		sprintf (dir, "%s/GDAL_DATA/n%s/proj", API->GMT->session.SHAREDIR, API->GMT->session.SHAREDIR);
+		snprintf (dir, PATH_MAX, "%s/GDAL_DATA/n%s/proj", API->GMT->session.SHAREDIR, API->GMT->session.SHAREDIR);
 		if (access (dir, F_OK) == 0) {		/* ... if it exists */
 			paths[0] = strdup(dir);
 			local_count = -1;
@@ -15125,7 +15125,7 @@ struct GMT_CTRL *gmt_begin (struct GMTAPI_CTRL *API, const char *session, unsign
 	}
 #endif
 
-	sprintf (version, "GMT%d", GMT_MAJOR_VERSION);
+	snprintf (version, GMT_LEN8, "GMT%d", GMT_MAJOR_VERSION);
 	GMT_Report (API, GMT_MSG_DEBUG, "Enter: New_PSL_Ctrl\n");
 	GMT->PSL = New_PSL_Ctrl (version);		/* Allocate a PSL control structure */
 	GMT_Report (API, GMT_MSG_DEBUG, "Exit:  New_PSL_Ctrl\n");
@@ -15395,7 +15395,7 @@ int gmt_remove_dir (struct GMTAPI_CTRL *API, char *dir, bool recreate) {
 GMT_LOCAL FILE *open_figure_file (struct GMTAPI_CTRL *API, unsigned int mode, int *err) {
 	char line[PATH_MAX] = {""}, *opt[2] = {"r", "a"};
 	FILE *fp = NULL;
-	sprintf (line, "%s/gmt.figures", API->gwf_dir);	/* Path to gmt.figures */
+	snprintf (line, PATH_MAX, "%s/gmt.figures", API->gwf_dir);	/* Path to gmt.figures */
 	*err = 0;	/* No error yet */
 	if (mode == 0 && access (line, F_OK)) {
 		GMT_Report (API, GMT_MSG_DEBUG, "No figure file %s - nothing to do\n", line);
@@ -15425,7 +15425,7 @@ GMT_LOCAL void get_session_name_format (struct GMTAPI_CTRL *API, char prefix[GMT
 	int n;
 	char file[PATH_MAX] = {""};
 	FILE *fp = NULL;
-	sprintf (file, "%s/%s", API->gwf_dir, GMT_SESSION_FILE);
+	snprintf (file, PATH_MAX, "%s/%s", API->gwf_dir, GMT_SESSION_FILE);
 	if (access (file, F_OK)) {	/* Use default session name and format */
 		strcpy (prefix, GMT_SESSION_NAME);
 		strcpy (formats, gmt_session_format[API->GMT->current.setting.graphics_format]);
@@ -15533,7 +15533,7 @@ GMT_LOCAL int put_session_name (struct GMTAPI_CTRL *API, char *arg) {
 	if (arg == NULL) return GMT_NOERROR;	/* Nothing to do, which means we accept the defaults */
 	if (arg[0] == '\0') return GMT_NOERROR;	/* Nothing to do, which means we accept the defaults */
 	GMT_Report (API, GMT_MSG_DEBUG, "Set session name to be %s\n", arg);
-	sprintf (file, "%s/%s", API->gwf_dir, GMT_SESSION_FILE);
+	snprintf (file, PATH_MAX, "%s/%s", API->gwf_dir, GMT_SESSION_FILE);
 	if ((fp = fopen (file, "w")) == NULL) {
 		GMT_Report (API, GMT_MSG_NORMAL, "Failed to create session file %s\n", file);
 		return GMT_ERROR_ON_FOPEN;
@@ -15603,10 +15603,10 @@ GMT_LOCAL int process_figures (struct GMTAPI_CTRL *API, char *show) {
 		nf = get_graphics_formats (API->GMT, fig[k].formats, fmt, gcode);
 		for (f = 0; f < nf; f++) {	/* Loop over all desired output formats */
 			mark = '-';	/* This is the last char in extension for a half-baked GMT PostScript file */
-			sprintf (cmd, "%s/gmt_%d.ps%c", API->gwf_dir, fig[k].ID, mark);	/* Check if the file exists */
+			snprintf (cmd, GMT_BUFSIZ, "%s/gmt_%d.ps%c", API->gwf_dir, fig[k].ID, mark);	/* Check if the file exists */
 			if (access (cmd, F_OK)) {	/* No such file, check if the fully baked file is there instead */
 				mark = '+';	/* This is the last char in extension for a fully-baked GMT PostScript file */
-				sprintf (cmd, "%s/gmt_%d.ps%c", API->gwf_dir, fig[k].ID, mark);	/* Check if the file exists */
+				snprintf (cmd, GMT_BUFSIZ, "%s/gmt_%d.ps%c", API->gwf_dir, fig[k].ID, mark);	/* Check if the file exists */
 				if (access (cmd, F_OK)) {	/* No such file ether, give up; warn if a fig set via gmt figure (k > 0) */
 					if (k) GMT_Report (API, GMT_MSG_VERBOSE, "Figure # %d was registered but no matching PostScript-|+ file found - skipping\n", fig[k].ID, cmd);
 					continue;
@@ -15614,7 +15614,7 @@ GMT_LOCAL int process_figures (struct GMTAPI_CTRL *API, char *show) {
 			}
 			/* Here the file exists and we can call psconvert. Note we still pass *.ps- even if *.ps+ was found since psconvert will do the same check */
 			gmt_filename_set (fig[k].prefix);
-			sprintf (cmd, "'%s/gmt_%d.ps-' -T%c -F%s", API->gwf_dir, fig[k].ID, fmt[f], fig[k].prefix);
+			snprintf (cmd, GMT_BUFSIZ, "'%s/gmt_%d.ps-' -T%c -F%s", API->gwf_dir, fig[k].ID, fmt[f], fig[k].prefix);
 			gmt_filename_get (fig[k].prefix);
 			not_PS = (fmt[f] != 'p');	/* Do not add convert options if plain PS */
 			/* Append psconvert optional settings */
@@ -15622,7 +15622,7 @@ GMT_LOCAL int process_figures (struct GMTAPI_CTRL *API, char *show) {
 				pos = 0;	/* Reset position counter */
 				while ((gmt_strtok (fig[k].options, ",", &pos, p))) {
 					if (not_PS || p[0] == 'M') {	/* Only -M is allowed if PS is the format */
-						sprintf (option, " -%s", p);	/* Create proper ps_convert option syntax */
+						snprintf (option, GMT_LEN256, " -%s", p);	/* Create proper ps_convert option syntax */
 						strcat (cmd, option);
 					}
 				}
@@ -15633,7 +15633,7 @@ GMT_LOCAL int process_figures (struct GMTAPI_CTRL *API, char *show) {
 				pos = 0;	/* Reset position counter */
 				while ((gmt_strtok (API->GMT->current.setting.ps_convert, ",", &pos, p))) {
 					if (not_PS || p[0] == 'M') {	/* Only -M is allowed if PS is the formst */
-						sprintf (option, " -%s", p);	/* Create proper ps_convert option syntax */
+						snprintf (option, GMT_LEN256, " -%s", p);	/* Create proper ps_convert option syntax */
 						strcat (cmd, option);
 					}
 				}
@@ -15653,7 +15653,7 @@ GMT_LOCAL int process_figures (struct GMTAPI_CTRL *API, char *show) {
 				char ext[GMT_LEN8] = {""};
 				strcpy (ext, gmt_session_format[gcode[f]]);	/* Set extension */
 				gmt_str_tolower (ext);	/* In case it was PNG */
-				sprintf (cmd, "%s.%s", fig[k].prefix, ext);
+				snprintf (cmd, GMT_BUFSIZ, "%s.%s", fig[k].prefix, ext);
 				gmt_filename_set (cmd);
 				if ((error = GMT_Call_Module (API, "docs", GMT_MODULE_CMD, cmd))) {
 					GMT_Report (API, GMT_MSG_NORMAL, "Failed to call docs\n");
@@ -15676,7 +15676,7 @@ int gmtlib_set_current_figure (struct GMTAPI_CTRL *API, char *prefix, int this_k
 		GMT_Report (API, GMT_MSG_NORMAL, "gmtlib_set_current_figure: No workflow directory set\n");
 		return GMT_NOT_A_VALID_DIRECTORY;
 	}
-	sprintf (file, "%s/gmt.current", API->gwf_dir);
+	snprintf (file, PATH_MAX, "%s/gmt.current", API->gwf_dir);
 	if ((fp = fopen (file, "w")) == NULL) {
 		GMT_Report (API, GMT_MSG_NORMAL, "gmtlib_set_current_figure: Could not create file %s\n", file);
 		return GMT_ERROR_ON_FOPEN;
@@ -15695,7 +15695,7 @@ int gmt_get_current_figure (struct GMTAPI_CTRL *API) {
 		GMT_Report (API, GMT_MSG_NORMAL, "gmt_get_current_figure: No workflow directory set\n");
 		return GMT_NOT_A_VALID_DIRECTORY;
 	}
-	sprintf (file, "%s/gmt.current", API->gwf_dir);
+	snprintf (file, PATH_MAX, "%s/gmt.current", API->gwf_dir);
 	/* See if there is a gmt.current file to read */
 	if (access (file, R_OK))	/* No gmt.current file available so return 0 */
 		return fig_no;
@@ -15823,7 +15823,7 @@ int gmt_add_figure (struct GMTAPI_CTRL *API, char *arg) {
 			return GMT_RUNTIME_ERROR;
 		}
 		GMT_Report (API, GMT_MSG_DEBUG, "New figure: Found special MOVIE_N_LABELS = %s\n", L);
-		sprintf (file, "%s/gmt.movie", API->gwf_dir);
+		snprintf (file, PATH_MAX, "%s/gmt.movie", API->gwf_dir);
 		if ((fp = fopen (file, "w")) == NULL) {	/* Not good */
 			GMT_Report (API, GMT_MSG_NORMAL, "Cannot create file %s\n", file);
 			return GMT_ERROR_ON_FOPEN;
@@ -15831,7 +15831,7 @@ int gmt_add_figure (struct GMTAPI_CTRL *API, char *arg) {
 		fprintf (fp, "# movie label information file\n");
 		n_tags = atoi (L);
 		for (T = 0; T < n_tags; T++) {
-			sprintf (name, "MOVIE_LABEL_ARG%d", T);
+			snprintf (name, GMT_LEN32, "MOVIE_LABEL_ARG%d", T);
 			if ((L = getenv (name)) != NULL) {	/* MOVIE_LABEL_ARG# was set */
 				/* Special processing for gmt movie: If -L is used to set labeling then we
 			 	* need to ensure the label is on top of the frame and unaffected by any
@@ -15925,7 +15925,7 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 	int err = 0, fig, error = GMT_NOERROR;
 	struct stat S;
 
-	sprintf (dir, "%s/gmt%d.%s", API->session_dir, GMT_MAJOR_VERSION, API->session_name);
+	snprintf (dir, PATH_MAX, "%s/gmt%d.%s", API->session_dir, GMT_MAJOR_VERSION, API->session_name);
 	API->gwf_dir = strdup (dir);
 	err = stat (API->gwf_dir, &S);	/* Stat the gwf_dir path (which may not exist) */
 
@@ -15960,7 +15960,7 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 			if (error) return (error);			/* Bail at this point */
 			gmtinit_conf (API->GMT);			/* Get the original system defaults */
 			gmt_getdefaults (API->GMT, NULL);		/* Overload user defaults */
-			sprintf (dir, "%s/gmt.conf", API->gwf_dir);	/* Reuse dir string for saving gmt.conf to this dir */
+			snprintf (dir, PATH_MAX, "%s/gmt.conf", API->gwf_dir);	/* Reuse dir string for saving gmt.conf to this dir */
 			API->GMT->current.setting.run_mode = GMT_MODERN;	/* Enable modern mode here so putdefaults can skip writing PS_MEDIA if not PostScript output */
 			error = put_session_name (API, text);		/* Store session name, possibly setting psconvert options */
 			gmt_putdefaults (API->GMT, dir);		/* Write current GMT defaults to this sessions gmt.conf file in the workflow directory */
@@ -15977,7 +15977,7 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 			/* We only get here when gmt end is called */
 			/* Check if a subplot was left hanging */
 			fig = gmt_get_current_figure (API);	/* Get current figure number */
-			sprintf (file, "%s/gmt.subplot.%d", API->gwf_dir, fig);
+			snprintf (file, PATH_MAX, "%s/gmt.subplot.%d", API->gwf_dir, fig);
 			if (!access (file, R_OK))	/* subplot end was never called */
 				GMT_Report (API, GMT_MSG_NORMAL, "subplot was never completed - plot items in last panel may be missing\n");
 			GMT_Report (API, GMT_MSG_DEBUG, "%s Workflow.  Session ID = %s. Directory %s %s.\n", smode[mode], API->session_name, API->gwf_dir, fstatus[3]);
@@ -16107,7 +16107,7 @@ void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int j
 	}
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Determined colorbar side = %c and axis = %c\n", side, axis);
 
-	sprintf (file, "%s/gmt%d.%s/gmt.frame", GMT->parent->session_dir, GMT_MAJOR_VERSION, GMT->parent->session_name);
+	snprintf (file, PATH_MAX, "%s/gmt%d.%s/gmt.frame", GMT->parent->session_dir, GMT_MAJOR_VERSION, GMT->parent->session_name);
 	if ((fp = fopen (file, "r")) == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "No file %s with frame information - no adjustments made\n", file);
 		return;

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -2746,7 +2746,7 @@ GMT_LOCAL int gmtio_prep_ogr_output (struct GMT_CTRL *GMT, struct GMT_DATASET *D
 	if (GMT_Encode_ID (GMT->parent, out_string, object_ID)) {
 		return (GMT->parent->error);	/* Make filename with embedded object ID */
 	}
-	sprintf (buffer, "-C -fg -<%s ->%s --GMT_HISTORY=false", in_string, out_string);
+	snprintf (buffer, GMT_BUFSIZ, "-C -fg -<%s ->%s --GMT_HISTORY=false", in_string, out_string);
 	GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Calling gmtinfo with args %s\n", buffer);
 	if (GMT_Call_Module (GMT->parent, "gmtinfo", GMT_MODULE_CMD, buffer) != GMT_OK) {	/* Get the extent via gmtinfo */
 		return (GMT->parent->error);
@@ -2768,7 +2768,7 @@ GMT_LOCAL int gmtio_prep_ogr_output (struct GMT_CTRL *GMT, struct GMT_DATASET *D
 	T = D->table[0];
 	TH = gmt_get_DT_hidden (T);
 	TH->ogr = gmt_M_memory (GMT, NULL, 1, struct GMT_OGR);
-	sprintf (buffer, "%.8g/%.8g/%.8g/%.8g", M->table[0]->segment[0]->data[0][0], M->table[0]->segment[0]->data[1][0],
+	snprintf (buffer, GMT_BUFSIZ, "%.8g/%.8g/%.8g/%.8g", M->table[0]->segment[0]->data[0][0], M->table[0]->segment[0]->data[1][0],
 	                                        M->table[0]->segment[0]->data[2][0], M->table[0]->segment[0]->data[3][0]);
 	if (GMT_Destroy_Data (GMT->parent, &M) != GMT_OK) {
 		return (GMT->parent->error);
@@ -2885,7 +2885,7 @@ GMT_LOCAL void gmtio_write_multilines (struct GMT_CTRL *GMT, FILE *fp, char *tex
 	unsigned int pos = 0, k = 0;
 
 	while (gmt_strtok (text, "\\", &pos, p)) {
-		sprintf (line, "# %7s : %s", prefix, &p[k]);
+		snprintf (line, GMT_BUFSIZ, "# %7s : %s", prefix, &p[k]);
 		gmtlib_write_tableheader (GMT, fp, line);
 		k = 1;	/* Need k to skip the n in \n */
 	}
@@ -3672,9 +3672,9 @@ GMT_LOCAL int gmtio_write_table (struct GMT_CTRL *GMT, void *dest, unsigned int 
 			if (SH->file[GMT_OUT])
 				out_file = SH->file[GMT_OUT];
 			else if (io_mode == GMT_WRITE_TABLE_SEGMENT)	/* Build name with table id and seg # */
-				sprintf (tmpfile, file, TH->id, seg);
+				snprintf (tmpfile, PATH_MAX, file, TH->id, seg);
 			else					/* Build name with seg ids */
-				sprintf (tmpfile, file, SH->id);
+				snprintf (tmpfile, PATH_MAX, file, SH->id);
 
 			if (close_file) gmt_fclose (GMT, fp);	/* Close the file since we opened it */
 			if ((fp = gmt_fopen (GMT, out_file, open_mode)) == NULL) {
@@ -4505,7 +4505,7 @@ int gmtlib_write_dataset (struct GMT_CTRL *GMT, void *dest, unsigned int dest_ty
 			if (TH->file[GMT_OUT])
 				out_file = TH->file[GMT_OUT];
 			else
-				sprintf (tmpfile, file, TH->id);
+				snprintf (tmpfile, PATH_MAX, file, TH->id);
 			GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Write Data Table to %s\n", out_file);
 			n_seg = (unsigned int)((GMT->current.io.skip_headers_on_outout) ? 1 : D->table[tbl]->n_segments);
 			if ((error = gmtio_write_table (GMT, out_file, GMT_IS_FILE, D->table[tbl], use_GMT_io, DH->io_mode, n_seg))) {
@@ -4583,14 +4583,14 @@ FILE * gmt_fopen (struct GMT_CTRL *GMT, const char *filename, const char *mode) 
 					char cmd[GMT_BUFSIZ+GMT_LEN256] = {""};
 					int error = 0;
 					if (GMT->parent->tmp_dir)	/* Make unique file in temp dir */
-						sprintf (GMT->current.io.tempfile, "%s/gmt_ogr_%d.gmt", GMT->parent->tmp_dir, (int)getpid());
+						snprintf (GMT->current.io.tempfile, PATH_MAX, "%s/gmt_ogr_%d.gmt", GMT->parent->tmp_dir, (int)getpid());
 					else	/* Make unique file in current dir */
-						sprintf (GMT->current.io.tempfile, "gmt_ogr_%d.gmt", (int)getpid());
+						snprintf (GMT->current.io.tempfile, PATH_MAX, "gmt_ogr_%d.gmt", (int)getpid());
 					GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Convert %s to GMT/OGR file %s\n", c, GMT->current.io.tempfile);
 #if GDAL_VERSION_MAJOR >= 2
-					sprintf (cmd, "ogr2ogr -mapFieldType Integer64=Integer -f \"OGR_GMT\" %s %s", GMT->current.io.tempfile, c);
+					snprintf (cmd, GMT_BUFSIZ+GMT_LEN256, "ogr2ogr -mapFieldType Integer64=Integer -f \"OGR_GMT\" %s %s", GMT->current.io.tempfile, c);
 #else
-					sprintf (cmd, "ogr2ogr -f \"GMT\" %s %s", GMT->current.io.tempfile, c);
+					snprintf (cmd, GMT_BUFSIZ+GMT_LEN256, "ogr2ogr -f \"GMT\" %s %s", GMT->current.io.tempfile, c);
 #endif
 					if ((error = system (cmd))) {
 						GMT_Report (GMT->parent, GMT_MSG_NORMAL, "System call [%s] FAILED with error %d.\n", cmd, error);
@@ -4887,9 +4887,9 @@ char *gmt_getdatapath (struct GMT_CTRL *GMT, const char *stem, char *path, int m
 
 	/* Not found, see if there is a file in the GMT_{USER,DATA}DIR directories [if set] */
 	
-	sprintf (serverdir, "%s/server", GMT->session.USERDIR);	udir[3] = serverdir;
-	sprintf (srtm1dir, "%s/server/srtm1", GMT->session.USERDIR);	udir[4] = srtm1dir;
-	sprintf (srtm3dir, "%s/server/srtm3", GMT->session.USERDIR);	udir[5] = srtm3dir;
+	snprintf (serverdir, PATH_MAX, "%s/server", GMT->session.USERDIR);	udir[3] = serverdir;
+	snprintf (srtm1dir, PATH_MAX, "%s/server/srtm1", GMT->session.USERDIR);	udir[4] = srtm1dir;
+	snprintf (srtm3dir, PATH_MAX, "%s/server/srtm3", GMT->session.USERDIR);	udir[5] = srtm3dir;
 
 	for (d = 0; d < 6; d++) {	/* Loop over USER, DATA and CACHE dirs */
 		if (!udir[d]) continue;	/* This directory was not set */
@@ -5227,15 +5227,15 @@ void gmt_format_duration_output (struct GMT_CTRL *GMT, double dt, char *text) {
 		}
 	}
 	while (k0 < N_T_UNITS) {	/* For remaining units... */
-		sprintf (item, tformat[k0], n[k0]);
+		snprintf (item, GMT_LEN16, tformat[k0], n[k0]);
 		strcat (text, item);
 		k0++;
 	}
 	if (sec > 0.0) {	/* Also add seconds */
 		if (GMT->current.io.clock_output.n_sec_decimals)
-			sprintf (item, "%0*.*fS", GMT->current.io.clock_output.n_sec_decimals+3, GMT->current.io.clock_output.n_sec_decimals, sec);
+			snprintf (item, GMT_LEN16, "%0*.*fS", GMT->current.io.clock_output.n_sec_decimals+3, GMT->current.io.clock_output.n_sec_decimals, sec);
 		else
-			sprintf (item, "%2.2uS", urint (sec));
+			snprintf (item, GMT_LEN16, "%2.2uS", urint (sec));
 		strcat (text, item);
 	}
 }
@@ -6231,20 +6231,20 @@ void gmtlib_clock_C_format (struct GMT_CTRL *GMT, char *form, struct GMT_CLOCK_I
 	if (S->order[0] >= 0) {	/* OK, at least hours is needed */
 		char fmt[GMT_LEN64] = {""};
 		if (S->compact)
-			sprintf (S->format, "%%d");
+			snprintf (S->format, GMT_LEN64, "%%d");
 		else
-			(mode) ? sprintf (S->format, "%%02d") : sprintf (S->format, "%%2d");
+			(mode) ? snprintf (S->format, GMT_LEN64, "%%02d") : snprintf (S->format, GMT_LEN64, "%%2d");
 		if (S->order[1] >= 0) {	/* Need minutes too*/
 			if (S->delimiter[0][0]) strcat (S->format, S->delimiter[0]);
-			(mode) ? sprintf (fmt, "%%02d") : sprintf (fmt, "%%2d");
+			(mode) ? snprintf (fmt, GMT_LEN64, "%%02d") : snprintf (fmt, GMT_LEN64, "%%2d");
 			strcat (S->format, fmt);
 			if (S->order[2] >= 0) {	/* .. and seconds */
 				if (S->delimiter[1][0]) strcat (S->format, S->delimiter[1]);
 				if (mode) {	/* Output format */
-					sprintf (fmt, "%%02d");
+					snprintf (fmt, GMT_LEN64, "%%02d");
 					strcat (S->format, fmt);
 					if (S->n_sec_decimals) {	/* even add format for fractions of second */
-						sprintf (fmt, ".%%%d.%dd", S->n_sec_decimals, S->n_sec_decimals);
+						snprintf (fmt, GMT_LEN64, ".%%%d.%dd", S->n_sec_decimals, S->n_sec_decimals);
 						strcat (S->format, fmt);
 					}
 				}
@@ -6289,11 +6289,11 @@ void gmtlib_date_C_format (struct GMT_CTRL *GMT, char *form, struct GMT_DATE_IO 
 	if (S->item_order[0] >= 0 && S->iso_calendar) {	/* ISO Calendar string: At least one item is needed */
 		k = (S->item_order[0] == 0 && !S->Y2K_year) ? ywidth : 2;
 		if (S->mw_text && S->item_order[0] == 1)	/* Prepare for "Week ##" format */
-			sprintf (S->format, "%%s %%02d");
+			snprintf (S->format, GMT_LEN64, "%%s %%02d");
 		else if (S->compact)			/* Numerical formatting of week or year without leading zeros */
 			sprintf (S->format, "%%d");
 		else					/* Numerical formatting of week or year  */
-			(mode) ? sprintf (S->format, "%%%d.%dd", k, k) : sprintf (S->format, "%%%dd", k);
+			(mode) ? snprintf (S->format, GMT_LEN64, "%%%d.%dd", k, k) : snprintf (S->format, GMT_LEN64, "%%%dd", k);
 		if (S->item_order[1] >= 0) {	/* Need another item */
 			if (S->delimiter[0][0]) strcat (S->format, S->delimiter[0]);
 			if (S->mw_text && S->item_order[0] == 1) {	/* Prepare for "Week ##" format */
@@ -6322,7 +6322,7 @@ void gmtlib_date_C_format (struct GMT_CTRL *GMT, char *form, struct GMT_DATE_IO 
 				if (no_delim)
 					sprintf (S->format, "%%3s");
 				else
-					sprintf (S->format, "%%[^%s]", S->delimiter[0]);
+					snprintf (S->format, GMT_LEN64, "%%[^%s]", S->delimiter[0]);
 			}
 			else
 				sprintf (S->format, "%%s");
@@ -6330,7 +6330,7 @@ void gmtlib_date_C_format (struct GMT_CTRL *GMT, char *form, struct GMT_DATE_IO 
 		else if (S->compact)			/* Numerical formatting of month or year w/o leading zeros */
 			sprintf (S->format, "%%d");
 		else					/* Numerical formatting of month or year */
-			(mode) ? sprintf (S->format, "%%%d.%dd", k, k) : sprintf (S->format, "%%%dd", k);
+			(mode) ? snprintf (S->format, GMT_LEN64, "%%%d.%dd", k, k) : snprintf (S->format, GMT_LEN64, "%%%dd", k);
 		if (S->item_order[1] >= 0) {	/* Need more items */
 			if (S->delimiter[0][0]) strcat (S->format, S->delimiter[0]);
 			k = (S->item_order[1] == 0 && !S->Y2K_year) ? ywidth : 2;
@@ -6340,14 +6340,14 @@ void gmtlib_date_C_format (struct GMT_CTRL *GMT, char *form, struct GMT_DATE_IO 
 					if (no_delim)
 						sprintf (fmt, "%%3s");
 					else
-						sprintf (fmt, "%%[^%s]", S->delimiter[1]);
+						snprintf (fmt, GMT_LEN64, "%%[^%s]", S->delimiter[1]);
 				}
 				else sprintf (fmt, "%%s");
 			}
 			else if (S->compact && !S->Y2K_year)		/* Numerical formatting of month or 4-digit year w/o leading zeros */
 				sprintf (fmt, "%%d");
 			else
-				(mode) ? sprintf (fmt, "%%%d.%dd", k, k) : sprintf (fmt, "%%%dd", k);
+				(mode) ? snprintf (fmt, GMT_LEN64, "%%%d.%dd", k, k) : snprintf (fmt, GMT_LEN64, "%%%dd", k);
 			strcat (S->format, fmt);
 			if (S->item_order[2] >= 0) {	/* .. and even more */
 				if (S->delimiter[1][0]) strcat (S->format, S->delimiter[1]);
@@ -6357,7 +6357,7 @@ void gmtlib_date_C_format (struct GMT_CTRL *GMT, char *form, struct GMT_DATE_IO 
 				else if (S->compact)			/* Numerical formatting of month or year w/o leading zeros */
 					sprintf (fmt, "%%d");
 				else
-					(mode) ? sprintf (fmt, "%%%d.%dd", k, k) : sprintf (fmt, "%%%dd", k);
+					(mode) ? snprintf (fmt, GMT_LEN64, "%%%d.%dd", k, k) : snprintf (fmt, GMT_LEN64, "%%%dd", k);
 				strcat (S->format, fmt);
 			}
 		}
@@ -6400,7 +6400,7 @@ int gmtlib_geo_C_format (struct GMT_CTRL *GMT) {
 			strcat (S->y_format, fmt);
 		}
 		if (S->n_sec_decimals) {	/* even add format for fractions of second (or minutes or degrees) */
-			sprintf (fmt, ".%%%d.%dd", S->n_sec_decimals, S->n_sec_decimals);
+			snprintf (fmt, GMT_LEN64, ".%%%d.%dd", S->n_sec_decimals, S->n_sec_decimals);
 			strcat (S->x_format, fmt);
 			strcat (S->y_format, fmt);
 		}
@@ -6447,12 +6447,12 @@ void gmtlib_plot_C_format (struct GMT_CTRL *GMT) {
 
 		sprintf (GMT->current.plot.format[0][0], "%%d");		/* ddd */
 		if (S->order[1] == -1 && S->n_sec_decimals > 0) /* ddd.xxx format */
-			sprintf (GMT->current.plot.format[0][1], "%%d.%%%d.%dd", S->n_sec_decimals, S->n_sec_decimals);
+			snprintf (GMT->current.plot.format[0][1], GMT_LEN64, "%%d.%%%d.%dd", S->n_sec_decimals, S->n_sec_decimals);
 		else						/* ddd format */
 			sprintf (GMT->current.plot.format[0][1], "%%d");
 		if (GMT->current.setting.map_degree_symbol != gmt_none)
 		{	/* But we want the degree symbol appended */
-			sprintf (fmt, "%c", (int)GMT->current.setting.ps_encoding.code[GMT->current.setting.map_degree_symbol]);
+			snprintf (fmt, GMT_LEN256, "%c", (int)GMT->current.setting.ps_encoding.code[GMT->current.setting.map_degree_symbol]);
 			strcat (GMT->current.plot.format[0][0], fmt);
 			strcat (GMT->current.plot.format[0][1], fmt);
 		}
@@ -6469,7 +6469,7 @@ void gmtlib_plot_C_format (struct GMT_CTRL *GMT) {
 		}
 		strcat (GMT->current.plot.format[1][0], "%02d");
 		if (S->order[2] == -1 && S->n_sec_decimals > 0) /* ddd:mm.xxx format */
-			sprintf (fmt, "%%02d.%%%d.%dd", S->n_sec_decimals, S->n_sec_decimals);
+			snprintf (fmt, GMT_LEN256, "%%02d.%%%d.%dd", S->n_sec_decimals, S->n_sec_decimals);
 		else						/* ddd:mm format */
 			sprintf (fmt, "%%02d");
 		strcat (GMT->current.plot.format[1][1], fmt);
@@ -6506,7 +6506,7 @@ void gmtlib_plot_C_format (struct GMT_CTRL *GMT) {
 		}
 		strcat (GMT->current.plot.format[2][0], "%02d");
 		if (S->n_sec_decimals > 0)			 /* ddd:mm:ss.xxx format */
-			sprintf (fmt, "%%d.%%%d.%dd", S->n_sec_decimals, S->n_sec_decimals);
+			snprintf (fmt, GMT_LEN256, "%%d.%%%d.%dd", S->n_sec_decimals, S->n_sec_decimals);
 		else						/* ddd:mm:ss format */
 			sprintf (fmt, "%%02d");
 		strcat (GMT->current.plot.format[2][1], fmt);
@@ -8480,7 +8480,7 @@ char **gmtlib_get_dir_list (struct GMT_CTRL *GMT, char *path, char *ext) {
 	WIN32_FIND_DATA FindFileData;
 
 	if (access (path, F_OK)) return NULL;	/* Quietly skip non-existent directories */
-	sprintf (text, "%s/*", path);
+	snprintf (text, PATH_MAX, "%s/*", path);
 	left = PATH_MAX - (int)strlen (path) - 2;
 	left -= ((ext) ? (int)strlen (ext) : 2);
 	if (ext)

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -6611,7 +6611,7 @@ void gmt_auto_frame_interval (struct GMT_CTRL *GMT, unsigned int axis, unsigned 
 	T = &A->item[item];
 	if (T->active && T->interval == 0.0) {
 		T->interval = d, T->generated = set_a = true;
-		sprintf (tmp, "a%g", T->interval); strcat (string, tmp);
+		snprintf (tmp, GMT_LEN16, "a%g", T->interval); strcat (string, tmp);
 		if (is_time) T->unit = unit, strcat (string, sunit);
 		if (interval) T->type = 'i', T->flavor = 1;
 	}
@@ -6620,7 +6620,7 @@ void gmt_auto_frame_interval (struct GMT_CTRL *GMT, unsigned int axis, unsigned 
 	T = &A->item[item+2];
 	if (T->active && T->interval == 0.0) {
 		T->interval = (T->type == 'f' || T->type == 'F') ? f : d, T->generated = true;
-		sprintf (tmp, "f%g", T->interval); strcat (string, tmp);
+		snprintf (tmp, GMT_LEN16, "f%g", T->interval); strcat (string, tmp);
 		if (is_time) T->unit = unit, strcat (string, sunit);
 	}
 
@@ -6628,7 +6628,7 @@ void gmt_auto_frame_interval (struct GMT_CTRL *GMT, unsigned int axis, unsigned 
 	T = &A->item[item+4];
 	if (T->active && T->interval == 0.0) {
 		T->interval = set_a ? d : f, T->generated = true;
-		sprintf (tmp, "g%g", T->interval); strcat (string, tmp);
+		snprintf (tmp, GMT_LEN16, "g%g", T->interval); strcat (string, tmp);
 		if (is_time) T->unit = unit, strcat (string, sunit);
 	}
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Auto-frame interval for axis %d item %d: d = %g  f = %g\n", axis, item, d, f);
@@ -9600,7 +9600,7 @@ struct GMT_DATASEGMENT * gmt_get_geo_ellipse (struct GMT_CTRL *GMT, double lon, 
 
 	/* Explicitly close the polygon */
 	px[N] = px[0], py[N] = py[0];
-	sprintf (header, "Ellipse around %g/%g with major/minor axes %g/%g km and major axis azimuth %g approximated by %" PRIu64 " points", lon, lat, major_km, minor_km, azimuth, N);
+	snprintf (header, GMT_LEN256, "Ellipse around %g/%g with major/minor axes %g/%g km and major axis azimuth %g approximated by %" PRIu64 " points", lon, lat, major_km, minor_km, azimuth, N);
 	S->header = strdup (header);
 	return (S);
 }

--- a/src/gmt_mbsystem_module.c
+++ b/src/gmt_mbsystem_module.c
@@ -50,11 +50,11 @@ void gmt_mbsystem_module_show_all (void *V_API) {
 	while (g_mbsystem_module[module_id].name != NULL) {
 		if (module_id == 0 || strcmp (g_mbsystem_module[module_id-1].component, g_mbsystem_module[module_id].component)) {
 			/* Start of new supplemental group */
-			sprintf (message, "\nModule name:     Purpose of %s module:\n", g_mbsystem_module[module_id].component);
+			snprintf (message, 256, "\nModule name:     Purpose of %s module:\n", g_mbsystem_module[module_id].component);
 			GMT_Message (V_API, GMT_TIME_NONE, message);
 			GMT_Message (V_API, GMT_TIME_NONE, "----------------------------------------------------------------\n");
 		}
-	sprintf (message, "%-16s %s\n",
+	snprintf (message, 256, "%-16s %s\n",
 		g_mbsystem_module[module_id].name, g_mbsystem_module[module_id].purpose);
 		GMT_Message (V_API, GMT_TIME_NONE, message);
 		++module_id;

--- a/src/gmt_parse.c
+++ b/src/gmt_parse.c
@@ -281,7 +281,7 @@ GMT_LOCAL int parse_complete_options (struct GMT_CTRL *GMT, struct GMT_OPTION *o
 	if (GMT->current.setting.run_mode == GMT_MODERN && n_B && check_B) {	/* Write gmt.frame file unless module is psscale, overwriting any previous file */
 		char file[PATH_MAX] = {""};
 		FILE *fp = NULL;
-		sprintf (file, "%s/gmt%d.%s/gmt.frame", GMT->parent->session_dir, GMT_MAJOR_VERSION, GMT->parent->session_name);
+		snprintf (file, PATH_MAX, "%s/gmt%d.%s/gmt.frame", GMT->parent->session_dir, GMT_MAJOR_VERSION, GMT->parent->session_name);
 		if ((fp = fopen (file, "w")) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Unable to create file %s\n", file);
 			return (-1);
@@ -581,7 +581,7 @@ struct GMT_OPTION *GMT_Create_Options (void *V_API, int n_args_in, const void *i
 				this_arg = &args[arg][first_char];
 			}
 			else {
-				sprintf (buffer, ">%s", &args[arg][first_char]);
+				snprintf (buffer, GMT_LEN1024, ">%s", &args[arg][first_char]);
 				this_arg = buffer;
 			}
 			append = 0;
@@ -621,7 +621,7 @@ struct GMT_OPTION *GMT_Create_Options (void *V_API, int n_args_in, const void *i
 		struct GMT_OPTION *opt = NULL;
 		for (opt = head; opt; opt = opt->next) {	/* Loop over all options */
 			if (opt->option == 'O' || opt->option == 'K') break;	/* Cannot be a one-liner if -O or -K are involved */
-			sprintf (figure, "%c%s", opt->option, opt->arg);	/* So -png, which would be parse into -p and ng, are reunited to png */
+			snprintf (figure, GMT_LEN512, "%c%s", opt->option, opt->arg);	/* So -png, which would be parse into -p and ng, are reunited to png */
 			if ((c = strchr (figure, ','))) c[0] = 0;	/* Chop of more than one format for the id test */
 			if ((k = gmt_get_graphics_id (API->GMT, figure)) == GMT_NOTSET) continue;	/* Not a quicky one-liner option */
 			if (opt->next && opt->next->option == GMT_OPT_INFILE) 	/* Found a -ext[,ext,ext,...] <prefix> pair */
@@ -724,17 +724,17 @@ char **GMT_Create_Args (void *V_API, int *argc, struct GMT_OPTION *head) {
 		if (opt->option == GMT_OPT_SYNOPSIS)		/* Produce special - option for synopsis */
 			sprintf (buffer, "-");
 		else if (opt->option == '=' && opt->arg[0]) {		/* Start of long list of file args initially given via -=<list> */
-			sprintf (buffer, "=%s", opt->arg);
+			snprintf (buffer, GMT_BUFSIZ, "=%s", opt->arg);
 			skip_infiles = true;
 		}
 		else if (opt->option == GMT_OPT_INFILE)	{	/* Option for input filename [or numbers] */
 			if (skip_infiles) continue;
-			sprintf (buffer, "%s", opt->arg);
+			snprintf (buffer, GMT_BUFSIZ, "%s", opt->arg);
 		}
 		else if (opt->arg && opt->arg[0])			/* Regular -?arg commandline option with argument for some ? */
-			sprintf (buffer, "-%c%s", opt->option, opt->arg);
+			snprintf (buffer, GMT_BUFSIZ, "-%c%s", opt->option, opt->arg);
 		else							/* Regular -? commandline argument without argument */
-			sprintf (buffer, "-%c", opt->option);
+			snprintf (buffer, GMT_BUFSIZ, "-%c", opt->option);
 
 		txt[arg] = gmt_M_memory (G, NULL, strlen (buffer)+1, char);	/* Get memory for this item */
 
@@ -793,29 +793,29 @@ char * GMT_Create_Cmd (void *V_API, struct GMT_OPTION *head) {
 		if (opt->option == GMT_OPT_SYNOPSIS)		/* Produce special - option for synopsis */
 			sprintf (buffer, "-");
 		else if (opt->option == '=' && opt->arg[0]) {		/* Special list file, add it but not the files that follow */
-			sprintf (buffer, "=%s", opt->arg);
+			snprintf (buffer, GMT_BUFSIZ, "=%s", opt->arg);
 			skip_infiles = true;
 		}
 		else if (opt->option == GMT_OPT_INFILE)	{	/* Option for input filename [or numbers] */
 			if (skip_infiles) continue;
 			if (gmtlib_file_is_srtmlist (API, opt->arg))	/* Want to replace the srtm list with the original @earth_relief_xxx name instead */
-				sprintf (buffer, "@earth_relief_0%cs", opt->arg[strlen(opt->arg)-8]);
+				snprintf (buffer, GMT_BUFSIZ, "@earth_relief_0%cs", opt->arg[strlen(opt->arg)-8]);
 			else if (gmt_M_file_is_remotedata (opt->arg) && (c = strstr (opt->arg, ".grd"))) {
 				c[0] = '\0';
-				sprintf (buffer, "%s", opt->arg);
+				snprintf (buffer, GMT_BUFSIZ, "%s", opt->arg);
 				c[0] = '.';
 			}
 			else
-				sprintf (buffer, "%s", opt->arg);
+				snprintf (buffer, GMT_BUFSIZ, "%s", opt->arg);
 		}
 		else if (opt->arg && opt->arg[0]) {			/* Regular -?arg commandline option with argument for some ? */
 			if (strchr (opt->arg, ' '))	/* Has a space in the argument, e.g., a title or similar */
-				sprintf (buffer, "-%c\"%s\"", opt->option, opt->arg);
+				snprintf (buffer, GMT_BUFSIZ, "-%c\"%s\"", opt->option, opt->arg);
 			else
-				sprintf (buffer, "-%c%s", opt->option, opt->arg);
+				snprintf (buffer, GMT_BUFSIZ, "-%c%s", opt->option, opt->arg);
 		}
 		else							/* Regular -? commandline argument without argument */
-			sprintf (buffer, "-%c", opt->option);
+			snprintf (buffer, GMT_BUFSIZ, "-%c", opt->option);
 
 		inc = strlen (buffer);
 		if (!first) inc++;	/* Count the space between args */

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -2901,7 +2901,7 @@ GMT_LOCAL void plot_contlabel_plotlabels (struct GMT_CTRL *GMT, struct PSL_CTRL 
 					char *F = PSL_makecolor (PSL, L->L[k].rgb);
 					char *P = PSL_makepen (PSL, G->font_label.pen.width, G->font_label.pen.rgb, G->font_label.pen.style, G->font_label.pen.offset);
 					font = PSL_makefontsize (PSL, G->font_label.size);
-					sprintf (string, "{%s} FS %s %s", F, P, font);	/* E.g., "{1 0 0 C} FS 4 W 0 A [] 0 B 667 F5" */
+					snprintf (string, GMT_LEN128, "{%s} FS %s %s", F, P, font);	/* E.g., "{1 0 0 C} FS 4 W 0 A [] 0 B 667 F5" */
 					fonts[m] = strdup (string);
 				}
 				else {	/* Regular font fill */
@@ -5195,7 +5195,7 @@ void gmt_draw_map_inset (struct GMT_CTRL *GMT, struct GMT_MAP_INSET *B) {
 	dim[GMT_X] = rect[XHI] - rect[XLO];	dim[GMT_Y] = rect[YHI] - rect[YLO];
 	if (B->refpoint == NULL) {	/* Need to set the BL refpoint since needed in inset to set the temporary origin */
 		char fake[GMT_LEN64] = {""};
-		sprintf (fake, "x%.16lgi/%.16lgi+jBL", rect[XLO], rect[YLO]);
+		snprintf (fake, GMT_LEN64, "x%.16lgi/%.16lgi+jBL", rect[XLO], rect[YLO]);
 		if ((B->refpoint = gmt_get_refpoint (GMT, fake, 'D')) == NULL)
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unable to parse arg %s\n", fake);
 	}
@@ -5427,9 +5427,9 @@ void gmt_draw_vertical_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *ms) {
 	int form, just = PSL_ML;
 
 	if (ms->label[0]) /* Append data unit to the scale length */
-		sprintf (txt, "%g %s", ms->length, ms->label);
+		snprintf (txt, GMT_LEN256, "%g %s", ms->length, ms->label);
 	else
-		sprintf (txt, "%g", ms->length);
+		snprintf (txt, GMT_LEN256, "%g", ms->length);
 
 	if (ms->zdata) /* Append data unit to the scale length */
 		scale = ms->z_scale;
@@ -5481,9 +5481,9 @@ void gmt_draw_vertical_scale_old (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, do
 	}
 
 	if (units) /* Append data unit to the scale length */
-		sprintf (txt, "%g %s", length, units);
+		snprintf (txt, GMT_LEN256, "%g %s", length, units);
 	else
-		sprintf (txt, "%g", length);
+		snprintf (txt, GMT_LEN256, "%g", length);
 	dy = 0.5 * length * zscale;
 	/* Compute the 4 coordinates on the scale line */
 	gmt_xyz_to_xy (GMT, x0 + GMT->current.setting.map_scale_height, y0 - dy, 0.0, &xx[0], &yy[0]);
@@ -5963,7 +5963,7 @@ int gmt_contlabel_save_begin (struct GMT_CTRL *GMT, struct GMT_CONTOUR *G) {
 		return (GMT_MEMORY_ERROR);	/* Establishes data output */
 	}
 	/* Write lon, lat, angle, label record */
-	sprintf (record, "# %s%s%s%sangle%slabel", xname[kind], GMT->current.setting.io_col_separator, yname[kind],
+	snprintf (record, GMT_BUFSIZ, "# %s%s%s%sangle%slabel", xname[kind], GMT->current.setting.io_col_separator, yname[kind],
 		GMT->current.setting.io_col_separator, GMT->current.setting.io_col_separator);
 	GMT_Set_Comment (GMT->parent, GMT_IS_DATASET, GMT_COMMENT_IS_TEXT | GMT_COMMENT_IS_COMMAND, record, G->Out);
 	G->Out->table[0]->segment[0]->n_rows = 0;
@@ -6134,7 +6134,7 @@ char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
 	}
 
 	if (gmt_strtok(szProj4, " \t+", &pos, token)) {
-		sprintf(prjcode, "%s",(token[0] == '+' ? &token[6] : &token[5]));	/* PROJ4 projection code. */
+		snprintf(prjcode, 16, "%s",(token[0] == '+' ? &token[6] : &token[5]));	/* PROJ4 projection code. */
 		//wipe_substr(szProj4, token);	/* Consumed, clear it from list */
 	}
 
@@ -6755,7 +6755,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 		if (!O_active) {	/* See if special movie labeling file exists under modern mode */
 			char file[PATH_MAX] = {""}, record[GMT_LEN128] = {""};
 			FILE *fpl = NULL;
-			sprintf (file, "%s/gmt.movie", GMT->parent->gwf_dir);
+			snprintf (file, PATH_MAX, "%s/gmt.movie", GMT->parent->gwf_dir);
 			if (!access (file, R_OK) && (fpl = fopen (file, "r"))) {	/* File exists and could be opened for reading */
 				while (fgets (record, GMT_LEN128, fpl)) {
 					if (record[0] == '#') continue;	/* Skip header */
@@ -6851,7 +6851,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 	
 	/* Get title */
 
-	sprintf (GMT->current.ps.title, "GMT v%s Document from %s", GMT_VERSION, GMT->init.module_name);
+	snprintf (GMT->current.ps.title, GMT_LEN256, "GMT v%s Document from %s", GMT_VERSION, GMT->init.module_name);
 
 	PSL_beginplot (PSL, fp, GMT->current.setting.ps_orientation|write_to_mem|switch_charset, O_active, GMT->current.setting.ps_color_mode,
 		GMT->current.ps.origin, GMT->current.setting.map_origin, media_size, GMT->current.ps.title, fno);
@@ -7081,11 +7081,11 @@ int gmt_strip_layer (struct GMTAPI_CTRL *API, int nlayers) {
 	
 	fig = gmt_get_current_figure (API);
 	/* Get the name of the corresponding gmt.layers.<fig> file */
-	sprintf (file, "%s/gmt.layers.%d", API->gwf_dir, fig);
+	snprintf (file, PATH_MAX, "%s/gmt.layers.%d", API->gwf_dir, fig);
 	if (nlayers == -1) {	/* Reset to nothing, but still remain at current figure */
 		if (gmt_remove_file (API->GMT, file))	/* Remove the layers file */
 			GMT_Report (API, GMT_MSG_VERBOSE, "Failed to delete file: %s\n", file);
-		sprintf (file, "%s/gmt_%d.ps-", API->gwf_dir, fig);
+		snprintf (file, PATH_MAX, "%s/gmt_%d.ps-", API->gwf_dir, fig);
 		if (gmt_remove_file (API->GMT, file))	/* Wipe the PS file */
 			GMT_Report (API, GMT_MSG_VERBOSE, "Failed to delete file: %s\n", file);
 		return GMT_NOERROR;
@@ -7117,14 +7117,14 @@ int gmt_strip_layer (struct GMTAPI_CTRL *API, int nlayers) {
 		return GMT_RUNTIME_ERROR;
 	}
 	
-	sprintf (file, "%s/gmt_%d.ps-", API->gwf_dir, fig);
+	snprintf (file, PATH_MAX, "%s/gmt_%d.ps-", API->gwf_dir, fig);
 	if (gmt_truncate_file (API, file, layer[k-nlayers-1].size)) {
 		GMT_Report (API, GMT_MSG_NORMAL, "Could not truncate file %s!\n", file);
 		gmt_M_free (API->GMT, layer);
 		return GMT_RUNTIME_ERROR;
 	}
 	/* Finally, rewrite the layers file to skip the reverted layers */
-	sprintf (file, "%s/gmt.layers.%d", API->gwf_dir, fig);
+	snprintf (file, PATH_MAX, "%s/gmt.layers.%d", API->gwf_dir, fig);
 	if ((fp = fopen (file, "w")) == NULL) {
 		GMT_Report (API, GMT_MSG_NORMAL, "Could not create new file %s\n", file);
 		gmt_M_free (API->GMT, layer);
@@ -7191,7 +7191,7 @@ void gmt_plotend (struct GMT_CTRL *GMT) {
 		GMT->current.ps.fp = NULL;
 		GMT->current.ps.filename[0] = '\0';
 		/* Write layer size to gmt.layers.<fig> in case of revert calls */
-		sprintf (file, "%s/gmt.layers.%d", GMT->parent->gwf_dir, GMT->current.ps.figure);
+		snprintf (file, PATH_MAX, "%s/gmt.layers.%d", GMT->parent->gwf_dir, GMT->current.ps.figure);
 		if ((fp = fopen (file, "a")) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Could not open/create file %s\n", file);
 			return;
@@ -8083,7 +8083,7 @@ int gmt_set_psfilename (struct GMT_CTRL *GMT) {
 		return GMT_NOTSET;
 	}
 	else
-		sprintf (GMT->current.ps.filename, "%s/gmt_%d.ps-", GMT->parent->gwf_dir, GMT->current.ps.figure);
+		snprintf (GMT->current.ps.filename, GMT_LEN256, "%s/gmt_%d.ps-", GMT->parent->gwf_dir, GMT->current.ps.figure);
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Use PS filename %s\n", GMT->current.ps.filename);
 	k = 1 + access (GMT->current.ps.filename, W_OK);	/* 1 = File exists (must append) or 0 (must create) */
 	GMT->current.ps.initialize = (k == 0);	/* False means it is an overlay and -R -J may come from history */
@@ -8236,7 +8236,7 @@ struct GMT_POSTSCRIPT * gmtlib_read_ps (struct GMT_CTRL *GMT, void *source, unsi
 
 	P = gmt_get_postscript (GMT);
 	P->header = gmt_M_memory (GMT, NULL, 1, char *);
-	sprintf (buffer, "PostScript read from file: %s", ps_file);
+	snprintf (buffer, GMT_LEN256, "PostScript read from file: %s", ps_file);
 	P->header[0] = strdup (buffer);
 	P->n_headers = 1;
 	if (n_alloc) P->data = gmt_M_memory (GMT, NULL, n_alloc, char);

--- a/src/gmt_shore.c
+++ b/src/gmt_shore.c
@@ -335,7 +335,7 @@ L1:
 		if ( access (path, R_OK) == 0) {	/* File can be read */
 			if ( gshhg_require_min_version (path, version) ) {
 				/* update invalid GMT->session.GSHHGDIR */
-				sprintf (dir, "%s/%s", GMT->session.SHAREDIR, "coast");
+				snprintf (dir, PATH_MAX, "%s/%s", GMT->session.SHAREDIR, "coast");
 				gmt_M_str_free (GMT->session.GSHHGDIR);
 				GMT->session.GSHHGDIR = strdup (dir);
 				GMT_Report (GMT->parent, GMT_MSG_DEBUG, "3. GSHHG: OK, could access %s\n", path);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -1334,7 +1334,7 @@ bool gmt_consider_current_cpt (struct GMTAPI_CTRL *API, bool *active, char **arg
 	if (gmt_M_cpt_mod (*arg)) {	/* Gave modifiers for a unit change) */
 		char string[PATH_MAX] = {""};
 		if ((cpt = gmt_get_current_cpt (API->GMT)) == NULL) return false;	/* No current CPT */
-		sprintf (string, "%s%s", cpt, *arg);	/* Append the modifiers to the current CPT name */
+		snprintf (string, PATH_MAX, "%s%s", cpt, *arg);	/* Append the modifiers to the current CPT name */
 		gmt_M_str_free (cpt);
 		gmt_M_str_free (*arg);
 		*arg = strdup (string);		/* Pass back the name of the current CPT with modifiers */
@@ -3721,11 +3721,11 @@ GMT_LOCAL struct GMT_DATASET * support_voronoi_shewchuk (struct GMT_CTRL *GMT, d
 						else	/* Flag according to which direction we used it */
 							edge_use[j] = (char)next_sign;
 						np++;	/* Increase polygon length counter */
-                        go_j = false;	/* Exit this loop and search for next edge */
+						go_j = false;	/* Exit this loop and search for next edge */
 					}
 				}
 				/* Finalize the polygon */
-				sprintf (header, "Voronoi polygon # %d -L%d", seg, seg);
+				snprintf (header, GMT_LEN64, "Voronoi polygon # %d -L%d", seg, seg);
 				S = P->table[0]->segment[seg] = GMT_Alloc_Segment (GMT->parent, GMT_NO_STRINGS, np, 2U, header, P->table[0]->segment[seg]);
 				gmt_M_memcpy (S->data[GMT_X], xcoord, np, double);
 				gmt_M_memcpy (S->data[GMT_Y], ycoord, np, double);
@@ -3749,7 +3749,7 @@ GMT_LOCAL struct GMT_DATASET * support_voronoi_shewchuk (struct GMT_CTRL *GMT, d
 			j2 = 2 * vorOut.edgelist[k++];
 			S->data[GMT_X][1] = vorOut.pointlist[j2++];
 			S->data[GMT_Y][1] = vorOut.pointlist[j2];
-			sprintf (header, "Voronoi edge # %d -L%d", seg, seg);
+			snprintf (header, GMT_LEN64, "Voronoi edge # %d -L%d", seg, seg);
 			S->header = strdup (header);
 		}
 	}
@@ -4650,7 +4650,7 @@ GMT_LOCAL int support_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name, s
 	else	/* Use as is */
 		strcpy (name, in_name);
 
-	sprintf (file, "%s.def", name);	/* Full name of potential def file */
+	snprintf (file, PATH_MAX, "%s.def", name);	/* Full name of potential def file */
 	/* Deal with downloadable GMT data sets first.  Passing 4 to avoid hearing about missing remote file
 	 * which can happen when we look for *.def but the file is actually a *.eps [Example 46] */
 	pos = gmt_download_file_if_not_found (GMT, file, 4);
@@ -4662,7 +4662,7 @@ GMT_LOCAL int support_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name, s
 		else	/* Use as is */
 			strcpy (name, in_name);
 		/* First check for eps macro */
-		sprintf (file, "%s.eps", name);	/* Full name of eps file */
+		snprintf (file, PATH_MAX, "%s.eps", name);	/* Full name of eps file */
 		pos = gmt_download_file_if_not_found (GMT, file, 0);	/* Deal with downloadable GMT data sets first */
 		if (gmt_getsharepath (GMT, "custom", &name[pos], ".eps", path, R_OK) || gmtlib_getuserpath (GMT, &file[pos], path)) {
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Found EPS macro %s\n", path);
@@ -5211,10 +5211,10 @@ GMT_LOCAL struct GMT_DATASET * support_resample_data_spherical (struct GMT_CTRL 
 			ID[0] = 0;
 			if (Tout->segment[seg]->label) strncpy (ID, Tout->segment[seg]->label, GMT_BUFSIZ-1);	/* Look for label in header */
 			else if (Tout->segment[seg]->header) gmt_parse_segment_item (GMT, Tout->segment[seg]->header, "-L", ID);	/* Look for label in header */
-			if (!ID[0]) sprintf (ID, "%*.*" PRIu64, ndig, ndig, seg_no);	/* Must assign a label from running numbers */
+			if (!ID[0]) snprintf (ID, GMT_BUFSIZ, "%*.*" PRIu64, ndig, ndig, seg_no);	/* Must assign a label from running numbers */
 			if (!Tout->segment[seg]->label) Tout->segment[seg]->label = strdup (ID);
 			gmt_M_str_free (Tout->segment[seg]->header);
-			sprintf (buffer, "Segment label -L%s", ID);
+			snprintf (buffer, GMT_BUFSIZ, "Segment label -L%s", ID);
 			Tout->segment[seg]->header = strdup (buffer);
 		}
 	}
@@ -5269,10 +5269,10 @@ GMT_LOCAL struct GMT_DATASET * support_resample_data_cartesian (struct GMT_CTRL 
 			ID[0] = 0;
 			if (Tout->segment[seg]->label) strncpy (ID, Tout->segment[seg]->label, GMT_BUFSIZ-1);	/* Look for label in header */
 			else if (Tout->segment[seg]->header) gmt_parse_segment_item (GMT, Tout->segment[seg]->header, "-L", ID);	/* Look for label in header */
-			if (!ID[0]) sprintf (ID, "%*.*" PRIu64, ndig, ndig, seg_no);	/* Must assign a label from running numbers */
+			if (!ID[0]) snprintf (ID, GMT_BUFSIZ, "%*.*" PRIu64, ndig, ndig, seg_no);	/* Must assign a label from running numbers */
 			if (!Tout->segment[seg]->label) Tout->segment[seg]->label = strdup (ID);
 			gmt_M_str_free (Tout->segment[seg]->header);
-			sprintf (buffer, "Segment label -L%s", ID);
+			snprintf (buffer, GMT_BUFSIZ, "Segment label -L%s", ID);
 			Tout->segment[seg]->header = strdup (buffer);
 		}
 	}
@@ -5397,25 +5397,25 @@ GMT_LOCAL struct GMT_DATASET * support_crosstracks_spherical (struct GMT_CTRL *G
 				if (orientation > 90.0) orientation -= 180.0;
 				ID[0] = seg_name[0] = 0;
 				if (Tin->segment[seg]->label) {	/* Use old segment label and append crossprofile number */
-					sprintf (ID, "%s-%*.*" PRIu64, Tin->segment[seg]->label, ndig, ndig, row);
+					snprintf (ID, GMT_BUFSIZ, "%s-%*.*" PRIu64, Tin->segment[seg]->label, ndig, ndig, row);
 				}
 				else if (Tin->segment[seg]->header) {	/* Look for label in header */
 					gmt_parse_segment_item (GMT, Tin->segment[seg]->header, "-L", seg_name);
-					if (seg_name[0]) sprintf (ID, "%s-%*.*" PRIu64, seg_name, ndig, ndig, row);
+					if (seg_name[0]) snprintf (ID, GMT_BUFSIZ, "%s-%*.*" PRIu64, seg_name, ndig, ndig, row);
 				}
 				if (!ID[0]) {	/* Must assign a label from running numbers */
 					if (skip_seg_no)	/* Single track, just list cross-profile no */
-						sprintf (ID, "%*.*" PRIu64, ndig, ndig, row);
+						snprintf (ID, GMT_BUFSIZ, "%*.*" PRIu64, ndig, ndig, row);
 					else	/* Segment number and cross-profile no */
-						sprintf (ID, "%*.*" PRIu64 "-%*.*" PRIu64, sdig, sdig, seg_no, ndig, ndig, row);
+						snprintf (ID, GMT_BUFSIZ, "%*.*" PRIu64 "-%*.*" PRIu64, sdig, sdig, seg_no, ndig, ndig, row);
 				}
 				S->label = strdup (ID);
 				if (strchr (ID, ' ')) {	/* Has spaces */
 					char tmp[GMT_BUFSIZ] = {""};
-					sprintf (tmp, "\"%s\"", ID);
+					snprintf (tmp, GMT_BUFSIZ, "\"%s\"", ID);
 					strcpy (ID, tmp);
 				}
-				sprintf (buffer, "Cross profile number -L%s at %8.3f/%07.3f az=%05.1f",
+				snprintf (buffer, GMT_BUFSIZ, "Cross profile number -L%s at %8.3f/%07.3f az=%05.1f",
 					ID, Tin->segment[seg]->data[GMT_X][row], Tin->segment[seg]->data[GMT_Y][row], orientation);
 				S->header = strdup (buffer);
 
@@ -5521,20 +5521,20 @@ GMT_LOCAL struct GMT_DATASET * support_crosstracks_cartesian (struct GMT_CTRL *G
 				if (orientation > 90.0) orientation -= 180.0;
 				ID[0] = seg_name[0] = 0;
 				if (Tin->segment[seg]->label) {	/* Use old segment label and append crossprofile number */
-					sprintf (ID, "%s-%*.*" PRIu64, Tin->segment[seg]->label, ndig, ndig, row);
+					snprintf (ID, GMT_BUFSIZ, "%s-%*.*" PRIu64, Tin->segment[seg]->label, ndig, ndig, row);
 				}
 				else if (Tin->segment[seg]->header) {	/* Look for label in header */
 					gmt_parse_segment_item (GMT, Tin->segment[seg]->header, "-L", seg_name);
-					if (seg_name[0]) sprintf (ID, "%s-%*.*" PRIu64, seg_name, ndig, ndig, row);
+					if (seg_name[0]) snprintf (ID, GMT_BUFSIZ, "%s-%*.*" PRIu64, seg_name, ndig, ndig, row);
 				}
 				if (!ID[0]) {	/* Must assign a label from running numbers */
 					if (Tin->n_segments == 1 && Din->n_tables == 1)	/* Single track, just list cross-profile no */
-						sprintf (ID, "%*.*" PRIu64, ndig, ndig, row);
+						snprintf (ID, GMT_BUFSIZ, "%*.*" PRIu64, ndig, ndig, row);
 					else	/* Segment number and cross-profile no */
-						sprintf (ID, "%*.*" PRIu64 "%*.*" PRIu64, sdig, sdig, seg_no, ndig, ndig, row);
+						snprintf (ID, GMT_BUFSIZ, "%*.*" PRIu64 "%*.*" PRIu64, sdig, sdig, seg_no, ndig, ndig, row);
 				}
 				S->label = strdup (ID);
-				sprintf (buffer, "Cross profile number -L\"%s\" at %g/%g az=%05.1f",
+				snprintf (buffer, GMT_BUFSIZ, "Cross profile number -L\"%s\" at %g/%g az=%05.1f",
 					ID, Tin->segment[seg]->data[GMT_X][row], Tin->segment[seg]->data[GMT_Y][row], orientation);
 				S->header = strdup (buffer);
 
@@ -6438,9 +6438,9 @@ char *gmt_putfont (struct GMT_CTRL *GMT, struct GMT_FONT *F) {
 	static char text[GMT_BUFSIZ];
 
 	if (F->form & 2)
-		sprintf (text, "%gp,%s,%s=%s", F->size, GMT->session.font[F->id].name, gmtlib_putfill (GMT, &F->fill), gmt_putpen (GMT, &F->pen));
+		snprintf (text, GMT_BUFSIZ, "%gp,%s,%s=%s", F->size, GMT->session.font[F->id].name, gmtlib_putfill (GMT, &F->fill), gmt_putpen (GMT, &F->pen));
 	else
-		sprintf (text, "%gp,%s,%s", F->size, GMT->session.font[F->id].name, gmtlib_putfill (GMT, &F->fill));
+		snprintf (text, GMT_BUFSIZ, "%gp,%s,%s", F->size, GMT->session.font[F->id].name, gmtlib_putfill (GMT, &F->fill));
 	return (text);
 }
 
@@ -6642,16 +6642,16 @@ char *gmt_putpen (struct GMT_CTRL *GMT, struct GMT_PEN *P) {
 	k = support_pen2name (P->width);
 	if (P->style[0]) {
 		if (k < 0)
-			sprintf (text, "%.5gp,%s,%s:%.5gp", P->width, gmt_putcolor (GMT, P->rgb), P->style, P->offset);
+			snprintf (text, GMT_BUFSIZ, "%.5gp,%s,%s:%.5gp", P->width, gmt_putcolor (GMT, P->rgb), P->style, P->offset);
 		else
-			sprintf (text, "%s,%s,%s:%.5gp", GMT_penname[k].name, gmt_putcolor (GMT, P->rgb), P->style, P->offset);
+			snprintf (text, GMT_BUFSIZ, "%s,%s,%s:%.5gp", GMT_penname[k].name, gmt_putcolor (GMT, P->rgb), P->style, P->offset);
 		for (i = 0; text[i]; i++) if (text[i] == ' ') text[i] = '_';
 	}
 	else
 		if (k < 0)
-			sprintf (text, "%.5gp,%s", P->width, gmt_putcolor (GMT, P->rgb));
+			snprintf (text, GMT_BUFSIZ, "%.5gp,%s", P->width, gmt_putcolor (GMT, P->rgb));
 		else
-			sprintf (text, "%s,%s", GMT_penname[k].name, gmt_putcolor (GMT, P->rgb));
+			snprintf (text, GMT_BUFSIZ, "%s,%s", GMT_penname[k].name, gmt_putcolor (GMT, P->rgb));
 
 	return (text);
 }
@@ -7669,17 +7669,17 @@ void gmt_save_current_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P) {
 	/* Save this specially scaled CPT for other uses in the modern session */
 	/* Set the correct output file name given the CPT level */
 	if (inset)	/* Only one inset may be active at any given time */
-		sprintf (file, "%s/gmt.inset.cpt", GMT->parent->gwf_dir);
+		snprintf (file, PATH_MAX, "%s/gmt.inset.cpt", GMT->parent->gwf_dir);
 	else if (subplot & GMT_SUBPLOT_ACTIVE) {	/* Either subplot master or a panel-specific CPT */
 		if (subplot & GMT_PANEL_NOTSET)	/* Master for all subplot panels */
-			sprintf (file, "%s/gmt.%d.subplot.cpt", GMT->parent->gwf_dir, fig);
+			snprintf (file, PATH_MAX, "%s/gmt.%d.subplot.cpt", GMT->parent->gwf_dir, fig);
 		else	/* CPT for just this subplot */
-			sprintf (file, "%s/gmt.%d.panel.%s.cpt", GMT->parent->gwf_dir, fig, panel);
+			snprintf (file, PATH_MAX, "%s/gmt.%d.panel.%s.cpt", GMT->parent->gwf_dir, fig, panel);
 	}
 	else if (fig)	/* Limited to one figure only */
-		sprintf (file, "%s/gmt.%d.cpt", GMT->parent->gwf_dir, fig);
+		snprintf (file, PATH_MAX, "%s/gmt.%d.cpt", GMT->parent->gwf_dir, fig);
 	else
-		sprintf (file, "%s/gmt.cpt", GMT->parent->gwf_dir);
+		snprintf (file, PATH_MAX, "%s/gmt.cpt", GMT->parent->gwf_dir);
 		
 	if (gmtlib_write_cpt (GMT, file, GMT_IS_FILE, P->cpt_flags, P) != GMT_NOERROR)
 		GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Unable to save current CPT file to %s !\n", file);
@@ -7689,7 +7689,7 @@ void gmt_save_current_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P) {
 
 char * gmt_get_current_cpt (struct GMT_CTRL *GMT) {
 	/* If modern and a current CPT exists, allocate a string with its name and return, else NULL */
-	char path[GMT_LEN256] = {""}, panel[GMT_LEN16] = {""}, *file = NULL;
+	char path[PATH_MAX] = {""}, panel[GMT_LEN16] = {""}, *file = NULL;
 	int fig, subplot, inset;
 	
 	if (GMT->current.setting.run_mode == GMT_CLASSIC) return NULL;		/* Not available in classic mode */
@@ -7697,25 +7697,25 @@ char * gmt_get_current_cpt (struct GMT_CTRL *GMT) {
 	/* Find the appropriate level CPT for where we are but may have to go up the list */
 	
 	if (inset) {	/* See if an inset CPT exists */
-		sprintf (path, "%s/gmt.inset.cpt", GMT->parent->gwf_dir);
+		snprintf (path, PATH_MAX, "%s/gmt.inset.cpt", GMT->parent->gwf_dir);
 		if (!access (path, R_OK)) file = strdup (path);	/* Yes, found it */
 	}
 	if (!file && (subplot & GMT_SUBPLOT_ACTIVE)) {	/* Nothing yet, see if subplot has one */
 		if ((subplot & GMT_PANEL_NOTSET) == 0) {	/* Panel-specific CPT available? */
-			sprintf (path, "%s/gmt.%d.panel.%s.cpt", GMT->parent->gwf_dir, fig, panel);
+			snprintf (path, PATH_MAX, "%s/gmt.%d.panel.%s.cpt", GMT->parent->gwf_dir, fig, panel);
 			if (!access (path, R_OK)) file = strdup (path);	/* Yes, found it */
 		}
 		if (!file) {	/* No, try subplot master CPT instead? */
-			sprintf (path, "%s/gmt.%d.subplot.cpt", GMT->parent->gwf_dir, fig);
+			snprintf (path, PATH_MAX, "%s/gmt.%d.subplot.cpt", GMT->parent->gwf_dir, fig);
 			if (!access (path, R_OK)) file = strdup (path);	/* Yes, found it */
 		}
 	}
 	if (!file && fig) {	/* Not found a CPT yet, so try one for this specific figure */
-		sprintf (path, "%s/gmt.%d.cpt", GMT->parent->gwf_dir, fig);
+		snprintf (path, PATH_MAX, "%s/gmt.%d.cpt", GMT->parent->gwf_dir, fig);
 		if (!access (path, R_OK)) file = strdup (path);	/* Yes, found it */
 	}
 	if (!file) {	/* Not found a CPT yet, finally try the session master */
-		sprintf (path, "%s/gmt.cpt", GMT->parent->gwf_dir);
+		snprintf (path, PATH_MAX, "%s/gmt.cpt", GMT->parent->gwf_dir);
 		if (!access (path, R_OK)) file = strdup (path);	/* Yes, found it */
 	}
 	if (file)
@@ -8866,7 +8866,7 @@ void gmt_contlabel_init (struct GMT_CTRL *GMT, struct GMT_CONTOUR *G, unsigned i
 		G->line_type = 0;
 		strcpy (G->line_name, "Line");
 	}
-	sprintf (G->label_file, "%s_labels.txt", G->line_name);
+	snprintf (G->label_file, PATH_MAX, "%s_labels.txt", G->line_name);
 	G->must_clip = true;
 	G->draw = true;
 	G->spacing = true;
@@ -10049,7 +10049,7 @@ struct GMT_DATASEGMENT * gmt_prepare_contour (struct GMT_CTRL *GMT, double *x, d
 	n_cols = (gmt_M_is_dnan (z)) ? 2 : 3;	/* psmask only dumps xy */
 	S = GMT_Alloc_Segment (GMT->parent, GMT_NO_STRINGS, n, n_cols, NULL, NULL);
 	if (n_cols == 3)
-		sprintf (header, "%g contour -Z%g", z, z);
+		snprintf (header, GMT_BUFSIZ, "%g contour -Z%g", z, z);
 	else
 		sprintf (header, "clip contour");
 	S->header = strdup (header);
@@ -10080,37 +10080,37 @@ char * gmt_make_filename (struct GMT_CTRL *GMT, char *template, unsigned int fmt
 
 	if (n_fmt == 1) {	/* Just need a single item */
 		if (fmt[0])	/* Just two kinds of files, closed and open */
-			sprintf (file, template, kind[closed]);
+			snprintf (file, PATH_MAX, template, kind[closed]);
 		else if (fmt[1])	/* Just files with a single unique running number */
-			sprintf (file, template, count[0]++);
+			snprintf (file, PATH_MAX, template, count[0]++);
 		else	/* Contour level file */
-			sprintf (file, template, z);
+			snprintf (file, PATH_MAX, template, z);
 	}
 	else if (n_fmt == 2) {	/* Need two items, and f+c is not allowed */
 		if (fmt[0]) {	/* open/close is involved */
 			if (fmt[1] < fmt[0])	/* Files with a single unique running number and open/close */
-				sprintf (file, template, count[closed]++, kind[closed]);
+				snprintf (file, PATH_MAX, template, count[closed]++, kind[closed]);
 			else	/* Same in reverse order */
-				sprintf (file, template, kind[closed], count[closed]++);
+				snprintf (file, PATH_MAX, template, kind[closed], count[closed]++);
 		}
 		else if (fmt[1] < fmt[2])	/* Files with a single unique running number and contour value */
-			sprintf (file, template, count[0]++, z);
+			snprintf (file, PATH_MAX, template, count[0]++, z);
 		else 	/* Same in reverse order */
-			sprintf (file, template, z, count[0]++);
+			snprintf (file, PATH_MAX, template, z, count[0]++);
 	}
 	else {	/* Combinations of three items */
 		if (fmt[0] < fmt[1] && fmt[1] < fmt[2])	/* Files with c, d, and f in that order */
-			sprintf (file, template, kind[closed], count[closed]++, z);
+			snprintf (file, PATH_MAX, template, kind[closed], count[closed]++, z);
 		else if (fmt[0] < fmt[2] && fmt[2] < fmt[1])	/* Files with c, f, and d in that order */
-			sprintf (file, template, kind[closed], z, count[closed]++);
+			snprintf (file, PATH_MAX, template, kind[closed], z, count[closed]++);
 		else if (fmt[1] < fmt[2] && fmt[2] < fmt[0])	/* Files with d, f, c in that order */
-			sprintf (file, template, count[closed]++, z, kind[closed]);
+			snprintf (file, PATH_MAX, template, count[closed]++, z, kind[closed]);
 		else if (fmt[1] < fmt[0] && fmt[0] < fmt[2])	/* Files with d, c, f in that order */
-			sprintf (file, template, count[closed]++, kind[closed], z);
+			snprintf (file, PATH_MAX, template, count[closed]++, kind[closed], z);
 		else if (fmt[2] < fmt[0] && fmt[0] < fmt[1])	/* Files with f, c, d in that order */
-			sprintf (file, template, z, kind[closed], count[closed]++);
+			snprintf (file, PATH_MAX, template, z, kind[closed], count[closed]++);
 		else						/* Files with f, d, c in that order */
-			sprintf (file, template, z, count[closed]++, kind[closed]);
+			snprintf (file, PATH_MAX, template, z, count[closed]++, kind[closed]);
 	}
 	return (strdup (file));
 }
@@ -10155,7 +10155,7 @@ void gmt_sprintf_float (struct GMT_CTRL *GMT, char *string, char *format, double
 		/* Any fraction of pi up to 1/20th allowed.
 		 * substitute_pi becomes true when items with "pi" are used in -R, -I etc. */
 		int k = 1, m, n;
-		char fmt[16] = {""};
+		char fmt[GMT_LEN16] = {""};
 		double f = fabs (x / M_PI);		/* Float multiples of pi */
 		if (fabs (f) < GMT_CONV4_LIMIT) {	/* Deal with special case of zero pi */
 			sprintf (string, "0");
@@ -10165,14 +10165,14 @@ void gmt_sprintf_float (struct GMT_CTRL *GMT, char *string, char *format, double
 		string[0] = (x < 0.0) ? '-' : '+';	/* Place leading sign */
 		string[1] = '\0';			/* Chop off old string */
 		if (n > 1) {	/* Need an integer in front of pi */
-			k += sprintf (fmt, "%d", n);
+			k += snprintf (fmt, GMT_LEN16, "%d", n);
 			strcat (string, fmt);
 			//k += irint (floor (log10 ((double)n))) + 1;	/* Add how many decimals needed for n */
 		}
 		strcat (string, "@~p@~");	/* Place the pi symbol */
 		k += 5;	/* Add number of characters just placed to print pi */
 		if (m > 1) {	/* Add the fractions part */
-			k += sprintf (fmt, "/%d", m);
+			k += snprintf (fmt, GMT_LEN16, "/%d", m);
 			strcat (string, fmt);
 			//k += irint (floor (log10 ((double)m))) + 2;	/* Add how many decimals needed for /m */
 		}
@@ -10293,7 +10293,7 @@ int gmt_get_format (struct GMT_CTRL *GMT, double interval, char *unit, char *pre
 
 		/* Find number of decimals needed in the format statement */
 
-		sprintf (text, GMT->current.setting.format_float_map, interval);
+		snprintf (text, GMT_BUFSIZ, GMT->current.setting.format_float_map, interval);
 		for (i = 0; text[i] && text[i] != '.'; i++);
 		if (text[i]) {	/* Found a decimal point */
 			for (j = i + 1; text[j] && text[j] != 'e'; j++);
@@ -10334,7 +10334,7 @@ int gmt_get_format (struct GMT_CTRL *GMT, double interval, char *unit, char *pre
 		strcpy (format, GMT->current.setting.format_float_map);
 	}
 	if (prefix && prefix[0]) {	/* Must prepend the prefix string */
-		sprintf (text, "%s%s", prefix, format);
+		snprintf (text, GMT_BUFSIZ, "%s%s", prefix, format);
 		strcpy (format, text);
 	}
 	return (ndec);
@@ -16018,7 +16018,7 @@ bool gmt_check_executable (struct GMT_CTRL *GMT, char *program, char *arg, char 
 	/* Turn off any stderr messages coming to the terminal */
 	if (strchr (program, ' ')) {	/* Command has spaces [most likely under Windows] */
 		if (!(program[0] == '\'' || program[0] == '\"'))	/* Not in quotes, place double quotes */
-			sprintf (cmd, "\"%s\"", program);
+			snprintf (cmd, PATH_MAX, "\"%s\"", program);
 		else	/* Already has quotes, but these might be double or single */
 			strncpy (cmd, program, PATH_MAX);
 		if (program[0] == '\'')	/* Replace single quotes with double quotes*/


### PR DESCRIPTION
I did all the gmt_*.c files but there are probably others in the modules.  Related to #960.