### PR TITLE
Must consider remote earth_relief files without extension

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15217,12 +15217,9 @@ unsigned int gmtlib_get_pos_of_filename (const char *url) {
 GMT_LOCAL bool check_if_we_must_download (struct GMT_CTRL *GMT, const char *file, unsigned int kind) {
 	/* Returns false if file already present unless if it is a remote file */
 	unsigned int pos = gmtlib_get_pos_of_filename (file);	/* Find start of filename */
-	if (pos == 1) return true;  /* Must always check since file on server might have changed and should be refreshed first */
-	else if (kind == GMT_URL_QUERY)
-		return true;	/* A query can never exist locally so must follow the URL */
-	else if (!gmt_access (GMT, &file[pos], F_OK))
-		return false;	/* Regular file exists already so no need to download */
-	return true;	/* File not found */
+	gmt_M_unused (GMT);
+	if (kind == GMT_URL_QUERY) return true;  /* Queries must be run */
+	return (pos == 1) ? true : false;  /* Remote @files must be checked for download update, local files not */
 }
 
 bool gmtlib_file_is_downloadable (struct GMT_CTRL *GMT, const char *file, unsigned int *kind) {

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -457,9 +457,24 @@ unsigned int gmt_download_file_if_not_found (struct GMT_CTRL *GMT, const char* f
 
 	/* Any old files have now been replaced.  Now we can check if the file exists already */
 	
-	if (kind != GMT_URL_QUERY && !gmt_access (GMT, &file[pos], F_OK)) {	/* File found, we are done here */
-		gmt_M_free (GMT, file);
-		return (pos);
+	if (kind != GMT_URL_QUERY) {	/* Regular file, see if we have it already */
+		bool found;
+		if (kind == GMT_DATA_FILE) {	/* Special remote data est @earth_relief_xxm|s request */
+			if (strstr (file, ".grd"))	/* User specified the extension */
+				found = (!gmt_access (GMT, &file[pos], F_OK));
+			else {	/* Must append the extension .grd */
+				char *tmpfile = malloc (strlen (file) + 5);
+				sprintf (tmpfile, "%s.grd", &file[pos]);
+				found = (!gmt_access (GMT, tmpfile, F_OK));
+				gmt_M_str_free (tmpfile);
+			}
+		}
+		else 
+			found = (!gmt_access (GMT, &file[pos], F_OK));
+		if (found) {	/* Got it already */
+			gmt_M_free (GMT, file);
+			return (pos);
+		}
 	}
 	
 	from = (kind == GMT_DATA_FILE) ? GMT_DATA_DIR : GMT_CACHE_DIR;	/* Determine source directory on cache server */


### PR DESCRIPTION
In making the changes for ensuring @files are checked for updates I dropped the check that required us to append ".grd" to earth_relief_xxy files, with the result they cot downloaded again and again.  This PR should restore sanity.  Closes #1639.
