### PR TITLE
Check if feature/pen syntax is wrong

### DIFF
--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -363,6 +363,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOAST_CTRL *Ctrl, struct GMT
 					n_errors++;
 					continue;
 				}
+				if (strchr (opt->arg, '/') == NULL && strchr (opt->arg, ',')) {
+					GMT_Report (API, GMT_MSG_NORMAL, "Syntax error: usage is -I<feature>[/<pen>]\n");
+					n_errors++;
+					continue;
+				}
 				pen = GMT->current.setting.map_default_pen;	/* Set default pen */
 				if ((string = strchr (opt->arg, '/')) != NULL) {	/* Get specified pen */
 					if (gmt_getpen (GMT, ++string, &pen)) {	/* Error decoding pen */
@@ -423,6 +428,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOAST_CTRL *Ctrl, struct GMT
 					n_errors++;
 					continue;
 				}
+				if (strchr (opt->arg, '/') == NULL && strchr (opt->arg, ',')) {
+					GMT_Report (API, GMT_MSG_NORMAL, "Syntax error: usage is -N<feature>[/<pen>]\n");
+					n_errors++;
+					continue;
+				}
 				pen = GMT->current.setting.map_default_pen;	/* Set default pen */
 				if ((string = strchr (opt->arg, '/')) != NULL) {	/* Get specified pen */
 					if (gmt_getpen (GMT, ++string, &pen)) {	/* Error decoding pen */
@@ -463,6 +473,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCOAST_CTRL *Ctrl, struct GMT
 				break;
 			case 'W':
 				Ctrl->W.active = true;	/* Want to draw shorelines */
+				if (strchr (opt->arg, '/') == NULL && strchr (opt->arg, ',')) {
+					GMT_Report (API, GMT_MSG_NORMAL, "Syntax error: usage is -W<feature>[/<pen>]\n");
+					n_errors++;
+					continue;
+				}
 				if ((opt->arg[0] >= '1' && opt->arg[0] <= '4') && opt->arg[1] == '/') {	/* Specific pen for this feature */
 					k = (int)(opt->arg[0] - '1');
 					if (opt->arg[2] && gmt_getpen (GMT, &opt->arg[2], &Ctrl->W.pen[k])) {


### PR DESCRIPTION
pscoast has several options like **-N**_feature_[/_pen_] but it would not detect and process wrong syntax like -N1,1p (the pen is simplly ignored).  This PR adds checks for such incorrect syntax which yields an error message.  One of the examples in the G-cubed paper made that mistake. I have asked Wiley to fix it before publication.

