### PR TITLE
Fix wrong -N syntax in ex26

### DIFF
--- a/doc/examples/ex26/ex26.bat
+++ b/doc/examples/ex26/ex26.bat
@@ -22,7 +22,7 @@ set Height=0.0
 
 set PROJ=-JG%longitude%/%latitude%/%altitude%/%azimuth%/%tilt%/%twist%/%Width%/%Height%/4i
 
-gmt pscoast -Rg %PROJ% -X1i -B5g5 -Glightbrown -Slightblue -W -Dl -N1/1p,red -N2,0.5p -P -K -Y5i > %ps%
+gmt pscoast -Rg %PROJ% -X1i -B5g5 -Glightbrown -Slightblue -W -Dl -N1/1p,red -N2/0.5p -P -K -Y5i > %ps%
 
 REM now point from an altitude of 160 km with a specific tilt and azimuth and with
 REM a wider restricted view and a boresight twist of 45 degrees

--- a/doc/examples/ex26/ex26.ps
+++ b/doc/examples/ex26/ex26.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_6e2c408_2019.07.26 [64-bit] Document from pscoast
+%%Title: GMT v6.0.0_77d96ee-dirty_2019.09.25 [64-bit] Document from pscoast
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Fri Jul 26 11:54:49 2019
+%%CreationDate: Wed Sep 25 20:21:50 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -646,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -657,7 +658,7 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
+/PSL_plot_completion {} def
 /PSL_movie_completion {} def
 %PSL_End_Header
 gsave
@@ -667,7 +668,7 @@ O0
 1200 6000 TM
 
 % PostScript produced by:
-%@GMT: gmt pscoast -Rg -JG-74.0/41.5/160.0/0/0/0/0.0/0.0/4i -X1i -B5g5 -Glightbrown -Slightblue -W -Dl -N1/1p,red -N2,0.5p -Y5i
+%@GMT: gmt pscoast -Rg -JG-74.0/41.5/160.0/0/0/0/0.0/0.0/4i -X1i -B5g5 -Glightbrown -Slightblue -W -Dl -N1/1p,red -N2/0.5p -Y5i
 %@PROJ: nsper 0.00000000 360.00000000 -90.00000000 90.00000000 -709478.641 709478.641 -709478.641 709478.641 +unavailable +a=6371007.181 +b=6371007.180918 +units=m +no_defs
 %GMTBoundingBox: 72 360 288 288
 %%BeginObject PSL_Layer_1
@@ -10220,6 +10221,7 @@ FO
 -13 -4 D
 P
 FO
+8 W
 1612 4616 M
 -89 -102 D
 S
@@ -10328,7 +10330,7 @@ S
 210 48 D
 20 12 D
 S
-4 W
+8 W
 0 A
 787 2181 M
 -29 -12 D
@@ -10358,7 +10360,7 @@ S
 -74 -466 D
 -73 -167 D
 S
-4 W
+8 W
 0 A
 283 3530 M
 23 -4 D
@@ -10430,7 +10432,7 @@ S
 -32 -116 D
 -20 -19 D
 S
-4 W
+8 W
 0 A
 135 2890 M
 -20 -106 D
@@ -10505,7 +10507,7 @@ S
 23 47 D
 -10 54 D
 S
-4 W
+8 W
 0 A
 1343 4023 M
 15 -61 D
@@ -10651,7 +10653,7 @@ S
 -7 59 D
 1 2 D
 S
-4 W
+8 W
 0 A
 2545 2609 M
 458 -6 D
@@ -10709,7 +10711,7 @@ S
 109 -312 D
 70 -37 D
 S
-4 W
+8 W
 0 A
 3385 4130 M
 73 10 D
@@ -10748,7 +10750,7 @@ S
 28 -35 D
 20 5 D
 S
-4 W
+8 W
 0 A
 3860 3583 M
 75 -117 D

--- a/doc/examples/ex26/ex26.sh
+++ b/doc/examples/ex26/ex26.sh
@@ -17,7 +17,7 @@ gmt begin ex26
 	Height=0.0
 
 	PROJ=-JG${longitude}/${latitude}/${altitude}/${azimuth}/${tilt}/${twist}/${Width}/${Height}/4i
-	gmt coast -Rg $PROJ -X1i -B5g5 -Glightbrown -Slightblue -W -Dl -N1/1p,red -N2,0.5p -Y5i
+	gmt coast -Rg $PROJ -X1i -B5g5 -Glightbrown -Slightblue -W -Dl -N1/1p,red -N2/0.5p -Y5i
 
 	# now point from an altitude of 160 km with a specific tilt and azimuth and with a wider restricted
 	# view and a boresight twist of 45 degrees


### PR DESCRIPTION
Change `-N2,0.5p` to `-N2/0.5p` and update original PS.