### PR TITLE
Overriding subplot label needs more space

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -11853,7 +11853,7 @@ void gmt_subplot_gaps (struct GMTAPI_CTRL *API, int fig, double *gap) {
 /*! Return information about current panel */
 struct GMT_SUBPLOT *gmt_subplot_info (struct GMTAPI_CTRL *API, int fig) {
 	/* Only called under modern mode */
-	char file[PATH_MAX] = {""}, line[PATH_MAX] = {""}, tmp[GMT_LEN16] = {""}, *c = NULL;
+	char file[PATH_MAX] = {""}, line[PATH_MAX] = {""}, tmp[GMT_LEN128] = {""}, *c = NULL;
 	bool found = false;
 	int row, col;
 	unsigned int first, k;
@@ -11919,7 +11919,7 @@ struct GMT_SUBPLOT *gmt_subplot_info (struct GMTAPI_CTRL *API, int fig) {
 			if (P->pen[0] == '-') P->pen[0] = '\0';		/* - means no pen */
 			P->first = first;
 			gmt_M_memcpy (P->gap, gap, 4, double);
-			if (strcmp (tmp, "@")) strncpy (P->tag, tmp, GMT_LEN16-1);	/* Replace auto-tag with manually added tag */
+			if (strcmp (tmp, "@")) strncpy (P->tag, tmp, GMT_LEN128-1);	/* Replace auto-tag with manually added tag */
 			if ((c = strchr (line, GMT_ASCII_GS)) == NULL) {	/* Get the position before frame setting */
 				GMT_Report (API, GMT_MSG_NORMAL, "Error decoding subplot information file %s.  Bad format? [%s] (n=%d)\n", file, line, n);
 				fclose (fp);

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -154,9 +154,9 @@ struct GMT_SUBPLOT {
 	double gap[4];			/* Shrink plottable region to make space for enhancements */
 	char refpoint[3];		/* Reference point for panel tag */
 	char justify[3];		/* Justification relative to refpoint */
-	char tag[GMT_LEN16];		/* Panel tag, e.g., a) */
-	char fill[GMT_LEN64];		/* Panel tag, e.g., a) */
-	char pen[GMT_LEN64];		/* Panel tag, e.g., a) */
+	char tag[GMT_LEN128];		/* Panel tag, e.g., a) */
+	char fill[GMT_LEN64];		/* Panel fill color */
+	char pen[GMT_LEN64];		/* Panel tag pen outline */
 	char Baxes[GMT_LEN128];		/* The -B setting for selected axes, including +color, tec */
 	char Btitle[GMT_LEN128];	/* The -B setting for any title */
 	char Bxlabel[GMT_LEN128];	/* The -Bx setting for x labels */

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -76,7 +76,7 @@ struct SUBPLOT_CTRL {
 	} In;
 	struct A {	/* -A[<letter>|<number>][+c<clearance>][+g<fill>][+j|J<pos>][+o<offset>][+p<pen>][+r|R][+v] */
 		bool active;			/* Want to plot subplot tags */
-		char format[GMT_LEN16];		/* Format for plotting tag (or constant string when done via subplot set) */
+		char format[GMT_LEN128];	/* Format for plotting tag (or constant string when done via subplot set) */
 		char fill[GMT_LEN64];		/* Color fill for optional rectangle behind the tag [none] */
 		char pen[GMT_LEN64];		/* Outline pen for optional rectangle behind the tag [none] */
 		unsigned int mode;		/* Either letter (0) of number (1) tag */
@@ -308,7 +308,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT
 			case 'A':	/* Enable subplot tags and get attributes */
 				Ctrl->A.active = true;
 				if (Ctrl->In.mode == SUBPLOT_SET) {	/* Override the auto-annotation for this subplot only */
-					strncpy (Ctrl->A.format, opt->arg, GMT_LEN16);
+					strncpy (Ctrl->A.format, opt->arg, GMT_LEN128);
 				}
 				else {	/* The full enchilada for begin */
 					if ((c = strchr (opt->arg, '+'))) c[0] = '\0';	/* Chop off modifiers for now */


### PR DESCRIPTION
We only had 16 characters for overriding the label since it was borne as a format.  Closes #1653.
