### PR TITLE
docs: Add the new grdinterpolate to the modules list

### DIFF
--- a/doc/rst/source/modules.rst
+++ b/doc/rst/source/modules.rst
@@ -64,6 +64,7 @@ This is a list of all GMT core and supplemental modules and their uses.
    grdhisteq
    grdimage
    grdinfo
+   grdinterpolate
    grdlandmask
    grdmask
    grdmath
@@ -217,6 +218,7 @@ Core Modules
     - :doc:`grdhisteq`
     - :doc:`grdimage`
     - :doc:`grdinfo`
+    - :doc:`grdinterpolate`
     - :doc:`grdlandmask`
     - :doc:`grdmask`
     - :doc:`grdmath`

--- a/doc/rst/source/modules_classic.rst
+++ b/doc/rst/source/modules_classic.rst
@@ -54,6 +54,7 @@ These modules are fully compatible with GMT 4 and 5.
     grdhisteq
     grdimage_classic
     grdinfo
+    grdinterpolate
     grdlandmask
     grdmask
     grdmath
@@ -199,6 +200,7 @@ Core Modules
     - :doc:`grdhisteq`
     - :doc:`grdimage_classic`
     - :doc:`grdinfo`
+    - :doc:`grdinterpolate`
     - :doc:`grdlandmask`
     - :doc:`grdmask`
     - :doc:`grdmath`


### PR DESCRIPTION
In **master branch**, we added a new module `grdinterpolate`. This PR adds `grdinterpolate` to the modules list.