### PR TITLE
docs: Cleanup the messy explain_-bi_full.rst_

### DIFF
--- a/doc/rst/source/explain_-bi_full.rst_
+++ b/doc/rst/source/explain_-bi_full.rst_
@@ -20,21 +20,4 @@
     that *type* applies to all columns and that *ncols* is implied by
     the expectation of the program. If the input file is netCDF, no
     **-b** is needed; simply append **?**\ *var1*\ **/**\ *var2*\ **/**\ *...*
-    to the filename to specify the variables to be read. |example_-bio|
-
-
-.. |example_-bio| raw:: html
-
-   <a href="#openModal">(Example)</a>
-   <div id="openModal" class="modalDialog">
-    <div>
-        <a href="#close" title="Close" class="close">X</a>
-        <h2>-bio example</h2>
-        <p>
-        # Write a binary file, and read it back, with 3 columns in which the first</br>
-        # is a 4 bytes float, second a 8 bytes long int and third a 8 bytes double.</br>
-        echo 1.5 2 2.5 | gmt convert -bo1f,1l,1d > lixo.bin</br>
-        gmt convert lixo.bin -bi1f,1l,1d</br>
-        </p>
-    </div>
-   </div>
+    to the filename to specify the variables to be read.


### PR DESCRIPTION
Remove the -bi example written in raw HTML codes.
![image](https://user-images.githubusercontent.com/3974108/65843160-20b7d580-e2fe-11e9-80af-81a0dbfcaf5d.png)
