### PR TITLE
Note that -o counts columns after -i has reduced input

### DIFF
--- a/doc/rst/source/explain_-ocols_full.rst_
+++ b/doc/rst/source/explain_-ocols_full.rst_
@@ -9,4 +9,6 @@
     Normally, any trailing text in the internal records will be written but
     when **-o** is used you must explicitly add the column *t*. To only output a single word from the
     trailing text, append the word number (first word is 0).  Finally, **-on** will
-    simply write the numerical output only and skip any trailing text.
+    simply write the numerical output only and skip any trailing text.  Note: If **-i** is
+    also used then columns given to **-o** correspond to the order *after* the **-i** selection
+    and not the columns in the original record.


### PR DESCRIPTION
When -i is used then -o refers to the remaining columns, not the original columns.  Addresses http://gmt.soest.hawaii.edu/boards/1/topics/8340?r=8344.
