### PR TITLE
Let do_examples.sh loop over all ex* directories

### DIFF
--- a/doc/examples/do_examples.sh
+++ b/doc/examples/do_examples.sh
@@ -2,6 +2,10 @@
 #
 #	Bash script to run all GMT examples
 #
+
+# Set GMT_END_SHOW to off to disable automatic display of the plots
+#export GMT_END_SHOW=off
+
 echo "Loop over all examples and run each job"
 
 # choose awk
@@ -13,10 +17,10 @@ else
   export AWK=awk
 fi
 
-for n in $(seq -w 1 50); do
-    echo "Running example $n"
-    cd ex$n
-    sh ex$n.sh
+for i in ex*; do
+    echo "Running example ${i}"
+    cd $i
+    bash $i.sh
     cd ..
 done
 


### PR DESCRIPTION
Let do_examples.sh loop over all ex* directories, so that we don't need
to update this script if more examples are added in the future.

Also add `export GMT_END_SHOW=off` (commented by default) to disable
auto-show of plots.