### PR TITLE
ex: set AWK to awk if it's undefined

### DIFF
--- a/doc/examples/ex31/ex31.sh
+++ b/doc/examples/ex31/ex31.sh
@@ -5,6 +5,10 @@
 # GMT modules:	set, coast, plot, text, legend
 # Unix progs:	awk, cat, rm
 #
+
+# set AWK to awk if undefined
+AWK=${AWK:-awk}
+
 gmt begin ex31
 	# create file PSL_custom_fonts.txt in current working directory
 	# and add PostScript font names of Linux Biolinum and Libertine

--- a/doc/examples/ex35/ex35.sh
+++ b/doc/examples/ex35/ex35.sh
@@ -5,6 +5,10 @@
 # GMT modules:  coast, plot, makecpt, grdimage, grdcontour, sphtriangulate, sphdistance
 # Unix progs:   rm
 #
+
+# set AWK to awk if undefined
+AWK=${AWK:-awk}
+
 gmt begin ex35
 	# Get the crude GSHHS data, select GMT format, and decimate to ~20%:
 	# gshhs $GMTHOME/src/coast/gshhs/gshhs_c.b | $AWK '{if ($1 == ">" || NR%5 == 0) print $0}' > gshhs_c.txt

--- a/doc/examples/ex40/ex40.sh
+++ b/doc/examples/ex40/ex40.sh
@@ -5,6 +5,10 @@
 # GMT modules:  basemap, text, plot, gmtsimplify, gmtspatial, subplot
 # Unix progs:   awk, rm
 #
+
+# set AWK to awk if undefined
+AWK=${AWK:-awk}
+
 gmt begin ex40
   gmt spatial @GSHHS_h_Australia.txt -fg -Qk > centroid.txt
   gmt spatial @GSHHS_h_Australia.txt -fg -Qk | $AWK '{printf "Full area = %.0f km@+2@+\n", $3}' > area.txt

--- a/doc/examples/ex43/ex43.sh
+++ b/doc/examples/ex43/ex43.sh
@@ -6,6 +6,9 @@
 # Unix progs:   grep, awk, sed
 #
 
+# set AWK to awk if undefined
+AWK=${AWK:-awk}
+
 # Data from Table 7 in Rousseeuw and Leroy, 1987.
 gmt begin ex43
 
@@ -45,7 +48,7 @@ gmt begin ex43
 	30	-10
 	30	-2.5
 	0	-2.5
-	
+
 	EOF
 	$AWK '{print NR, $6, $7}' A.txt | gmt plot -Sb1ub0 -W0.25p -C
 	gmt basemap -Bafg100 -Bx+l"Animal index number" -By+l"z-zcore" -BWSne


### PR DESCRIPTION
Some examples use variable $AWK, which is usually undefined for users.

I set $AWK to awk if it's undefined, so that users can run these
examples smoothly. awk is chosen because it should work for most users.