### PR TITLE
docs: Allow scripts to generate other figure formats

### DIFF
--- a/doc/scripts/GMT_-B_custom.sh
+++ b/doc/scripts/GMT_-B_custom.sh
@@ -22,4 +22,4 @@ gmt begin GMT_-B_custom
 gmt basemap -R416/542/0/6.2831852 -JX-5i/2.5i -Bpx25f5g25+u" Ma" -Bpycyannots.txt -BWS+glightblue
 gmt basemap -R416/542/0/6.2831852 -JX-5i/2.5i -Bsxcxannots.txt -Bsy0 -BWS \
 	--MAP_ANNOT_OFFSET_SECONDARY=10p --MAP_GRID_PEN_SECONDARY=2p
-gmt end
+gmt end show

--- a/doc/scripts/GMT_-B_custom.sh
+++ b/doc/scripts/GMT_-B_custom.sh
@@ -18,7 +18,7 @@ cat << EOF >| yannots.txt
 6.2831852	ag	2@~p@~
 EOF
 
-gmt begin GMT_-B_custom ps
+gmt begin GMT_-B_custom
 gmt basemap -R416/542/0/6.2831852 -JX-5i/2.5i -Bpx25f5g25+u" Ma" -Bpycyannots.txt -BWS+glightblue
 gmt basemap -R416/542/0/6.2831852 -JX-5i/2.5i -Bsxcxannots.txt -Bsy0 -BWS \
 	--MAP_ANNOT_OFFSET_SECONDARY=10p --MAP_GRID_PEN_SECONDARY=2p

--- a/doc/scripts/GMT_-B_geo_1.sh
+++ b/doc/scripts/GMT_-B_geo_1.sh
@@ -15,4 +15,4 @@ gmt text -F+f9p+jCB << EOF
 0.375 0.05 frame
 1.29166666 0.05 grid
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_-B_geo_1.sh
+++ b/doc/scripts/GMT_-B_geo_1.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_-B_geo_1 ps
+gmt begin GMT_-B_geo_1
 gmt set FORMAT_GEO_MAP ddd:mm:ssF
 gmt basemap -R-1/2/0/0.4 -JM3i -Ba1f15mg5m -BS
 gmt plot -Sv2p+e+a60 -W0.5p -Gblack -Y-0.35i -N << EOF 

--- a/doc/scripts/GMT_-B_geo_2.sh
+++ b/doc/scripts/GMT_-B_geo_2.sh
@@ -26,4 +26,4 @@ gmt text -N -F+f+j << EOF
 -0.25 0.05 9p CB frame
 0.625 0.05 9p CB grid
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_-B_geo_2.sh
+++ b/doc/scripts/GMT_-B_geo_2.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_-B_geo_2 ps
+gmt begin GMT_-B_geo_2
 gmt set FORMAT_GEO_MAP ddd:mm:ssF FONT_ANNOT_PRIMARY +9p
 gmt basemap -R-2/1/0/0.35 -JM4i -Bpa15mf5mg5m -BwSe -Bs1f30mg15m --MAP_FRAME_TYPE=fancy+ \
 	--MAP_GRID_PEN_PRIMARY=thinnest,black,. --MAP_GRID_CROSS_SIZE_SECONDARY=0.1i \

--- a/doc/scripts/GMT_-B_linear.sh
+++ b/doc/scripts/GMT_-B_linear.sh
@@ -14,4 +14,4 @@ gmt text -Gwhite -C0.01i/0.01i -F+f9p+jCB << EOF
 7 0.2 frame
 9.5 0.2 grid
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_-B_linear.sh
+++ b/doc/scripts/GMT_-B_linear.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_-B_linear ps
+gmt begin GMT_-B_linear
 gmt basemap -R0/12/0/0.95 -JX3i/0.3i -Ba4f2g1+lFrequency+u" %" -BS
 gmt plot -Sv2p+e+a60 -W0.5p -Gblack -Y0.1i -N << EOF
 2 0 0 0.5

--- a/doc/scripts/GMT_-B_log.sh
+++ b/doc/scripts/GMT_-B_log.sh
@@ -4,4 +4,4 @@ gmt set MAP_GRID_PEN_PRIMARY thinnest,.
 gmt basemap -R1/1000/0/1 -JX3il/0.25i -B1f2g3p+l"Axis Label" -BS
 gmt basemap -B1f2g3l+l"Axis Label" -BS -Y0.85i
 gmt basemap -B1f2g3+l"Axis Label" -BS -Y0.85i
-gmt end
+gmt end show

--- a/doc/scripts/GMT_-B_log.sh
+++ b/doc/scripts/GMT_-B_log.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_-B_log ps
+gmt begin GMT_-B_log
 gmt set MAP_GRID_PEN_PRIMARY thinnest,.
 gmt basemap -R1/1000/0/1 -JX3il/0.25i -B1f2g3p+l"Axis Label" -BS
 gmt basemap -B1f2g3l+l"Axis Label" -BS -Y0.85i

--- a/doc/scripts/GMT_-B_pow.sh
+++ b/doc/scripts/GMT_-B_pow.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_-B_pow ps
+gmt begin GMT_-B_pow
 gmt set MAP_GRID_PEN_PRIMARY thinnest,.
 gmt basemap -R0/100/0/0.9 -JX3ip0.5/0.25i -Ba3f2g1p+l"Axis Label" -BS
 gmt basemap -Ba20f10g5+l"Axis Label" -BS -Y0.85i

--- a/doc/scripts/GMT_-B_pow.sh
+++ b/doc/scripts/GMT_-B_pow.sh
@@ -3,4 +3,4 @@ gmt begin GMT_-B_pow
 gmt set MAP_GRID_PEN_PRIMARY thinnest,.
 gmt basemap -R0/100/0/0.9 -JX3ip0.5/0.25i -Ba3f2g1p+l"Axis Label" -BS
 gmt basemap -Ba20f10g5+l"Axis Label" -BS -Y0.85i
-gmt end
+gmt end show

--- a/doc/scripts/GMT_-B_time2.sh
+++ b/doc/scripts/GMT_-B_time2.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_-B_time2 ps
+gmt begin GMT_-B_time2
   gmt set FORMAT_DATE_MAP "o dd" FORMAT_CLOCK_MAP hh:mm FONT_ANNOT_PRIMARY +9p
   gmt basemap -R1969-7-21T/1969-7-23T/0/1 -JX5i/0.2i -Bpa6Hf1h -Bsa1K -BS
   gmt basemap -Bpa6Hf1h -Bsa1D -BS -Y0.65i

--- a/doc/scripts/GMT_-B_time2.sh
+++ b/doc/scripts/GMT_-B_time2.sh
@@ -3,4 +3,4 @@ gmt begin GMT_-B_time2
   gmt set FORMAT_DATE_MAP "o dd" FORMAT_CLOCK_MAP hh:mm FONT_ANNOT_PRIMARY +9p
   gmt basemap -R1969-7-21T/1969-7-23T/0/1 -JX5i/0.2i -Bpa6Hf1h -Bsa1K -BS
   gmt basemap -Bpa6Hf1h -Bsa1D -BS -Y0.65i
-gmt end
+gmt end show

--- a/doc/scripts/GMT_-B_time5.sh
+++ b/doc/scripts/GMT_-B_time5.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_-B_time5 ps
+gmt begin GMT_-B_time5
   gmt set FORMAT_DATE_MAP u FORMAT_TIME_PRIMARY_MAP Character FORMAT_TIME_SECONDARY_MAP full FONT_ANNOT_PRIMARY +9p
   gmt basemap -R1969-7-21T/1969-8-9T/0/1 -JX5i/0.2i -Bpa1K -Bsa1U -BS
   gmt set FORMAT_DATE_MAP o TIME_WEEK_START Sunday FORMAT_TIME_SECONDARY_MAP Character

--- a/doc/scripts/GMT_-B_time5.sh
+++ b/doc/scripts/GMT_-B_time5.sh
@@ -4,4 +4,4 @@ gmt begin GMT_-B_time5
   gmt basemap -R1969-7-21T/1969-8-9T/0/1 -JX5i/0.2i -Bpa1K -Bsa1U -BS
   gmt set FORMAT_DATE_MAP o TIME_WEEK_START Sunday FORMAT_TIME_SECONDARY_MAP Character
   gmt basemap -Bpa3Kf1k -Bsa1r -BS -Y0.65i
-gmt end 
+gmt end show 

--- a/doc/scripts/GMT_-J.sh
+++ b/doc/scripts/GMT_-J.sh
@@ -92,4 +92,4 @@ gmt plot -Wthinner << EOF
 0.025	2.87
 0.025	2.55
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_-J.sh
+++ b/doc/scripts/GMT_-J.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_-J ps
+gmt begin GMT_-J
 gmt text -R0/5/0/3 -Jx1i -F+f+j << EOF
 2.5	2.8	16p,Helvetica-Bold	BC	GMT PROJECTIONS
 2	2.25	12p,Helvetica-Bold	BC	GEOGRAPHIC PROJECTIONS

--- a/doc/scripts/GMT_-R.sh
+++ b/doc/scripts/GMT_-R.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_-R ps
+gmt begin GMT_-R
 gmt set MAP_FRAME_TYPE PLAIN FONT_ANNOT_PRIMARY 8p,Helvetica MAP_TICK_LENGTH_PRIMARY 0.05i \
 	PS_CHAR_ENCODING ISOLatin1+
 gmt coast -R-90/-70/18/35.819 -JM2i -Dl -Glightbrown -Wthinnest -Ba10g5 -BWsEN 

--- a/doc/scripts/GMT_-R.sh
+++ b/doc/scripts/GMT_-R.sh
@@ -49,4 +49,4 @@ gmt plot -N -Wthinner << EOF
 2	2
 1.63	-0.35
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_-XY.sh
+++ b/doc/scripts/GMT_-XY.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_-XY ps
+gmt begin GMT_-XY
 gmt basemap -R0/1.5/0/1.7 -Jx1i -B0 -B+glightyellow
 gmt plot -Sv5p+e -W0.5p -Gblack << EOF
 0.2	0.2	0	1.1

--- a/doc/scripts/GMT_-XY.sh
+++ b/doc/scripts/GMT_-XY.sh
@@ -19,4 +19,4 @@ gmt text -N --FONT=Helvetica-Bold -F+f+j << EOF
 1.3	0.25	9p	BL	x
 0.25	1.6	9p	ML	y
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_API_flow.sh
+++ b/doc/scripts/GMT_API_flow.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_API_flow ps
+gmt begin GMT_API_flow
 gmt text -R-2/3/-1/1 -Jx1i -F+f14p,Helvetica-Bold -Gwhite -W0.5p -N -C50% -X2i << EOF
 -2	0	EXTERNAL INTERFACE
 0	0	gmt

--- a/doc/scripts/GMT_API_flow.sh
+++ b/doc/scripts/GMT_API_flow.sh
@@ -21,4 +21,4 @@ gmt text -F+f48p,Helvetica,gray -N << EOF
 0.60	0.06	[
 1.97	0.06	]
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_API_use.sh
+++ b/doc/scripts/GMT_API_use.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_API_use ps
+gmt begin GMT_API_use
 gmt plot -R-4.5/4.5/-2/2 -Jx0.8i -W2p+ve0.2i+gblack+h0.5 -Xc << EOF 
 >
 -2	0.75

--- a/doc/scripts/GMT_API_use.sh
+++ b/doc/scripts/GMT_API_use.sh
@@ -44,4 +44,4 @@ gmt text -F+f12p+jCM -Glightorange -W0.25p -C50% << EOF
 -2.8 -0.75 GMT CONTAINERS
 +2.8 -0.75 GMT CONTAINERS
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_E.sh
+++ b/doc/scripts/GMT_App_E.sh
@@ -20,7 +20,7 @@ $xwidth	$ywidth
 0	$ywidth
 END
 
-gmt begin GMT_App_E ps
+gmt begin GMT_App_E
 gmt basemap -R0/5.75/0/7.55 -Jx1i -B0
 gmt set MAP_FRAME_PEN thinner
 for iy in 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0

--- a/doc/scripts/GMT_App_E.sh
+++ b/doc/scripts/GMT_App_E.sh
@@ -38,4 +38,4 @@ do
 	y=$dy
 	x=$back
 done
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_G.sh
+++ b/doc/scripts/GMT_App_G.sh
@@ -8,7 +8,7 @@ dy=-0.2222
 y0=4.3
 yy=4.0778
 tr '",' '  ' < "${GMT_SOURCE_DIR}"/src/standard_adobe_fonts.h | awk '{print $2}' > tt.d
-gmt begin GMT_App_G ps
+gmt begin GMT_App_G
 gmt set MAP_FRAME_PEN thinner
 gmt plot -R0/5.4/0/$y0 -Jx1i -B0 <<EOF
 >

--- a/doc/scripts/GMT_App_G.sh
+++ b/doc/scripts/GMT_App_G.sh
@@ -61,4 +61,4 @@ gmt text -Y${dy}i -F+f+j <<EOF
 3.1	0.03	10p,ZapfDingbats	BL	ZapfDingbats @%0%(ZapfDingbats)@%%
 EOF
 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_J_1.sh
+++ b/doc/scripts/GMT_App_J_1.sh
@@ -90,4 +90,4 @@ gmt text -F+f9p,Times-Roman+j << END
 0.2	0.2	RM	Gaussian
 0.2	0.1	RM	Cosine
 END
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_J_1.sh
+++ b/doc/scripts/GMT_App_J_1.sh
@@ -72,7 +72,7 @@
 #
 #---------------------------------------------------
 
-gmt begin GMT_App_J_1 ps
+gmt begin GMT_App_J_1
 RJ="-R-0.6/0.6/-0.1/1.1 -JX4i/2i"
 echo "-0.5	0" > tt.tmp
 gmt math -T-0.5/0.5/0.01 1 = >> tt.tmp

--- a/doc/scripts/GMT_App_J_2.sh
+++ b/doc/scripts/GMT_App_J_2.sh
@@ -72,7 +72,7 @@
 # graphs of h(x) can be interpreted as also = the graphs of h(r).
 #
 #---------------------------------------------------
-gmt begin GMT_App_J_2 ps
+gmt begin GMT_App_J_2
 gmt set FONT_ANNOT_PRIMARY 10p,Times-Roman FONT_TITLE 14p,Times-Roman FONT_LABEL 12p,Times-Roman
 gmt math -T0/5/0.01 T SINC = | gmt plot -R0/5/-0.3/1 -JX4i/2i -Bxa1f0.2+l"Frequency (cycles per filter width)" -Bya0.2f0.1g1+l"Gain" -BWeSn -Wthick
 gmt math -T0/5/0.01 T SINC 1 T T MUL SUB DIV = | grep -v '^>' | $AWK '{ if ($1 == 1) print 1, 0.5; else print $0}' | gmt plot -Wthick,-

--- a/doc/scripts/GMT_App_J_2.sh
+++ b/doc/scripts/GMT_App_J_2.sh
@@ -85,4 +85,4 @@ gmt text -F+f9p,Times-Roman+j << END
 3.8	0.5	RM	Gaussian
 3.8	0.4	RM	Cosine
 END
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_J_3.sh
+++ b/doc/scripts/GMT_App_J_3.sh
@@ -584,7 +584,7 @@ EOF
 # These were pre-computed because of the need to do a numerical Hankel transform.
 # Also, I found that j0(x) and j1(x) are not reliable on some machines....
 #
-gmt begin GMT_App_J_3 ps
+gmt begin GMT_App_J_3
 gmt set FONT_ANNOT_PRIMARY 10p,Times-Roman FONT_TITLE 14p,Times-Roman FONT_LABEL 12p,Times-Roman
 cut -f1,2 tt.r_tr_fns | gmt plot -R0/5/-0.3/1 -JX4i/2i -Bxa1f0.2+l"Frequency (cycles per filter width)" -Bya0.2f0.1g1+l"Gain" -BWeSn -Wthick
 cut -f1,3 tt.r_tr_fns | gmt plot -Wthick,- 

--- a/doc/scripts/GMT_App_J_3.sh
+++ b/doc/scripts/GMT_App_J_3.sh
@@ -597,4 +597,4 @@ gmt text -F+f9p,Times-Roman+j << END
 3.8	0.5	RM	Gaussian
 3.8	0.4	RM	Cosine
 END
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_K_1.sh
+++ b/doc/scripts/GMT_App_K_1.sh
@@ -4,4 +4,4 @@ gmt begin GMT_App_K_1
 	gmt coast -Rk-9000/9000/-9000/9000 -JE130.35/-0.2/3.5i -Dc \
 	  -A500 -Gburlywood -Sazure -Wthinnest -N1/thinnest,- -B20g20 -BWSne 
 	echo 130.35 -0.2 | gmt psxy -SJ-4000 -Wthicker
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_K_1.sh
+++ b/doc/scripts/GMT_App_K_1.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_App_K_1 ps
+gmt begin GMT_App_K_1
 	gmt set MAP_GRID_CROSS_SIZE_PRIMARY 0 MAP_ANNOT_OBLIQUE 22 MAP_ANNOT_MIN_SPACING 0.3i
 	gmt coast -Rk-9000/9000/-9000/9000 -JE130.35/-0.2/3.5i -Dc \
 	  -A500 -Gburlywood -Sazure -Wthinnest -N1/thinnest,- -B20g20 -BWSne 

--- a/doc/scripts/GMT_App_K_2.sh
+++ b/doc/scripts/GMT_App_K_2.sh
@@ -3,4 +3,4 @@ gmt begin GMT_App_K_2
 	gmt coast -Rk-2000/2000/-2000/2000 -JE130.35/-0.2/3.5i -Dl -A100 \
 	-Gburlywood -Sazure -Wthinnest -N1/thinnest,- -B10g5 -BWSne 
 	echo 130.35 -0.2 | gmt psxy -SJ-1000 -Wthicker
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_K_2.sh
+++ b/doc/scripts/GMT_App_K_2.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_App_K_2 ps
+gmt begin GMT_App_K_2
 	gmt coast -Rk-2000/2000/-2000/2000 -JE130.35/-0.2/3.5i -Dl -A100 \
 	-Gburlywood -Sazure -Wthinnest -N1/thinnest,- -B10g5 -BWSne 
 	echo 130.35 -0.2 | gmt psxy -SJ-1000 -Wthicker

--- a/doc/scripts/GMT_App_K_3.sh
+++ b/doc/scripts/GMT_App_K_3.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_App_K_3 ps
+gmt begin GMT_App_K_3
 	gmt coast -Rk-500/500/-500/500 -JE130.35/-0.2/3.5i -Di -A20 \
 	  -Gburlywood -Sazure -Wthinnest -N1/thinnest,- -B2g1 -BWSne
 	echo 133 2 | gmt plot -Sc1.4i -Gwhite 

--- a/doc/scripts/GMT_App_K_3.sh
+++ b/doc/scripts/GMT_App_K_3.sh
@@ -6,4 +6,4 @@ gmt begin GMT_App_K_3
 	gmt basemap -Tm133/2+w1i+t45/10/5+jCM --FONT_TITLE=12p --MAP_TICK_LENGTH_PRIMARY=0.05i \
 	  --FONT_ANNOT_SECONDARY=8p 
 	echo 130.35 -0.2 | gmt psxy -SJ-200 -Wthicker
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_K_4.sh
+++ b/doc/scripts/GMT_App_K_4.sh
@@ -3,4 +3,4 @@ gmt begin GMT_App_K_4
 	gmt coast -Rk-100/100/-100/100 -JE130.35/-0.2/3.5i -Dh -A1 \
 	  -Gburlywood -Sazure -Wthinnest -N1/thinnest,- -B30mg10m -BWSne 
 	echo 130.35 -0.2 | gmt psxy -SJ-40 -Wthicker
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_K_4.sh
+++ b/doc/scripts/GMT_App_K_4.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_App_K_4 ps
+gmt begin GMT_App_K_4
 	gmt coast -Rk-100/100/-100/100 -JE130.35/-0.2/3.5i -Dh -A1 \
 	  -Gburlywood -Sazure -Wthinnest -N1/thinnest,- -B30mg10m -BWSne 
 	echo 130.35 -0.2 | gmt psxy -SJ-40 -Wthicker

--- a/doc/scripts/GMT_App_K_5.sh
+++ b/doc/scripts/GMT_App_K_5.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_App_K_5 ps
+gmt begin GMT_App_K_5
 gmt coast -Rk-20/20/-20/20 -JE130.35/-0.2/3.5i -Df -Gburlywood \
 	-Sazure -Wthinnest -N1/thinnest,- -B10mg2m -BWSne 
 gmt end

--- a/doc/scripts/GMT_App_K_5.sh
+++ b/doc/scripts/GMT_App_K_5.sh
@@ -2,4 +2,4 @@
 gmt begin GMT_App_K_5
 gmt coast -Rk-20/20/-20/20 -JE130.35/-0.2/3.5i -Df -Gburlywood \
 	-Sazure -Wthinnest -N1/thinnest,- -B10mg2m -BWSne 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_M_1a.sh
+++ b/doc/scripts/GMT_App_M_1a.sh
@@ -74,4 +74,4 @@ do
 	y2=`gmt math -Q $y2 $dy ADD =`
 done
 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_M_1a.sh
+++ b/doc/scripts/GMT_App_M_1a.sh
@@ -45,7 +45,7 @@ let n2=22
 dy=0.75
 y0=`gmt math -Q $n2 2 ADD $dy MUL 0.5 MUL =`
 
-gmt begin GMT_App_M_1a ps
+gmt begin GMT_App_M_1a
 gmt set MAP_FRAME_PEN thinner FONT_ANNOT_PRIMARY 8p MAP_TICK_LENGTH_PRIMARY 0.1i MAP_ANNOT_OFFSET_PRIMARY 0.04i
 gmt basemap -R0/6.1/0/$y0 -Jx1i -B0
 

--- a/doc/scripts/GMT_App_M_1b.sh
+++ b/doc/scripts/GMT_App_M_1b.sh
@@ -45,7 +45,7 @@ let n2=22
 dy=0.75
 y0=`gmt math -Q $n2 $dy MUL 0.5 MUL =`
 
-gmt begin GMT_App_M_1b ps
+gmt begin GMT_App_M_1b
 gmt set MAP_FRAME_PEN thinner FONT_ANNOT_PRIMARY 8p MAP_TICK_LENGTH_PRIMARY 0.1i MAP_ANNOT_OFFSET_PRIMARY 0.04i
 gmt basemap -R0/6.1/0/$y0 -Jx1i -B0
 i=1

--- a/doc/scripts/GMT_App_M_1b.sh
+++ b/doc/scripts/GMT_App_M_1b.sh
@@ -72,4 +72,4 @@ do
 	y=`gmt math -Q $y $dy ADD =`
 	y2=`gmt math -Q $y2 $dy ADD =`
 done
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_M_1c.sh
+++ b/doc/scripts/GMT_App_M_1c.sh
@@ -41,7 +41,7 @@ let n2=n
 dy=0.75
 y0=`gmt math -Q $n2 $dy MUL 0.5 MUL =`
 
-gmt begin GMT_App_M_1c ps
+gmt begin GMT_App_M_1c
 gmt set MAP_FRAME_PEN thinner FONT_ANNOT_PRIMARY 8p MAP_TICK_LENGTH_PRIMARY 0.1i MAP_ANNOT_OFFSET_PRIMARY 0.04i
 gmt basemap -R0/6.1/0/$y0 -Jx1i -B0 
 

--- a/doc/scripts/GMT_App_M_1c.sh
+++ b/doc/scripts/GMT_App_M_1c.sh
@@ -69,4 +69,4 @@ do
 	y=`gmt math -Q $y $dy ADD =`
 	y2=`gmt math -Q $y2 $dy ADD =`
 done
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_M_2.sh
+++ b/doc/scripts/GMT_App_M_2.sh
@@ -38,4 +38,4 @@ gmt colorbar -Cyears.cpt -D08/04+w-8/0.5+jML+ef -L0.0
 gmt colorbar -Cyears.cpt -D12/04+w-8/0.5+jML+ef -L0.1  
 gmt colorbar -Cyears.cpt -D16/04+w-8/0.5+jML+ef -Li    
 gmt colorbar -Cyears.cpt -D20/04+w-8/0.5+jML+ef -Li0.1
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_M_2.sh
+++ b/doc/scripts/GMT_App_M_2.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_App_M_2 ps
+gmt begin GMT_App_M_2
 gmt set FONT_ANNOT_PRIMARY 10p PROJ_LENGTH_UNIT cm PS_MEDIA 11ix8.5i
 
 # Set up color palette with named annotations

--- a/doc/scripts/GMT_App_N_1.sh
+++ b/doc/scripts/GMT_App_N_1.sh
@@ -73,5 +73,5 @@ EOF
 	gmt plot -Sri -Gblack tt.bars
 	# Shorten the spelling of QR_TRANSPARENT to QR_TRANSP to fit the figure
 	sed -e 's/TRANSPARENT/TRANSP/' < tt.text | gmt text -F+f${fs}p,white
-	gmt end
+	gmt end show
 done

--- a/doc/scripts/GMT_App_N_1.sh
+++ b/doc/scripts/GMT_App_N_1.sh
@@ -67,7 +67,7 @@ EOF
 			echo "$x $yt $width $dy" >> tt.bars
 		done
 	done
-	gmt begin GMT_App_N_$p ps
+	gmt begin GMT_App_N_$p
 	gmt plot -R0/$n_cols/0/$H -Jx${width}i tt.lines -Wthick -B0
 	gmt plot -S${width}i -W0.5p tt.symbols  -Ggray
 	gmt plot -Sri -Gblack tt.bars

--- a/doc/scripts/GMT_App_O_1.sh
+++ b/doc/scripts/GMT_App_O_1.sh
@@ -5,4 +5,4 @@
 gmt begin GMT_App_O_1
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+f8p -Gd1.5i -S10 -T+lLH 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_O_1.sh
+++ b/doc/scripts/GMT_App_O_1.sh
@@ -2,7 +2,7 @@
 #
 #	Makes Fig 1 for Appendix O (labeled lines)
 #
-gmt begin GMT_App_O_1 ps
+gmt begin GMT_App_O_1
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+f8p -Gd1.5i -S10 -T+lLH 
 gmt end

--- a/doc/scripts/GMT_App_O_2.sh
+++ b/doc/scripts/GMT_App_O_2.sh
@@ -5,4 +5,4 @@
 gmt begin GMT_App_O_2
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+f8p -Gn1/1i -S10 -T+lLH
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_O_2.sh
+++ b/doc/scripts/GMT_App_O_2.sh
@@ -2,7 +2,7 @@
 #
 #	Makes Fig 2 for Appendix O (labeled lines)
 #
-gmt begin GMT_App_O_2 ps
+gmt begin GMT_App_O_2
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+f8p -Gn1/1i -S10 -T+lLH
 gmt end

--- a/doc/scripts/GMT_App_O_3.sh
+++ b/doc/scripts/GMT_App_O_3.sh
@@ -11,4 +11,4 @@ EOF
 gmt begin GMT_App_O_3
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+f8p -Gffix.txt/0.1i -S10 -T+lLH 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_O_3.sh
+++ b/doc/scripts/GMT_App_O_3.sh
@@ -8,7 +8,7 @@ cat << EOF > fix.txt
 102     0
 130     10.5
 EOF
-gmt begin GMT_App_O_3 ps
+gmt begin GMT_App_O_3
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+f8p -Gffix.txt/0.1i -S10 -T+lLH 
 gmt end

--- a/doc/scripts/GMT_App_O_4.sh
+++ b/doc/scripts/GMT_App_O_4.sh
@@ -5,4 +5,4 @@
 gmt begin GMT_App_O_4
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+f8p -GLZ-/Z+ -S10 -T+lLH 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_O_4.sh
+++ b/doc/scripts/GMT_App_O_4.sh
@@ -2,7 +2,7 @@
 #
 #	Makes Fig 4 for Appendix O (labeled lines)
 #
-gmt begin GMT_App_O_4 ps
+gmt begin GMT_App_O_4
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+f8p -GLZ-/Z+ -S10 -T+lLH 
 gmt end

--- a/doc/scripts/GMT_App_O_5.sh
+++ b/doc/scripts/GMT_App_O_5.sh
@@ -2,7 +2,7 @@
 #
 #	Makes Fig 5 for Appendix O (labeled lines)
 #
-gmt begin GMT_App_O_5 ps
+gmt begin GMT_App_O_5
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+f8p -GX@App_O_cross.txt -S10 -T+lLH 
 gmt end

--- a/doc/scripts/GMT_App_O_5.sh
+++ b/doc/scripts/GMT_App_O_5.sh
@@ -5,4 +5,4 @@
 gmt begin GMT_App_O_5
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+f8p -GX@App_O_cross.txt -S10 -T+lLH 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_O_6.sh
+++ b/doc/scripts/GMT_App_O_6.sh
@@ -2,7 +2,7 @@
 #
 #	Makes Fig 6 for Appendix O (labeled lines)
 #
-gmt begin GMT_App_O_6 ps
+gmt begin GMT_App_O_6
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+f8p -Gl50/10S/160/10S -S10 -T+l 
 gmt plot -SqD1000k:+g+LD+an+p -Wthick @App_O_transect.txt

--- a/doc/scripts/GMT_App_O_6.sh
+++ b/doc/scripts/GMT_App_O_6.sh
@@ -6,4 +6,4 @@ gmt begin GMT_App_O_6
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+f8p -Gl50/10S/160/10S -S10 -T+l 
 gmt plot -SqD1000k:+g+LD+an+p -Wthick @App_O_transect.txt
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_O_7.sh
+++ b/doc/scripts/GMT_App_O_7.sh
@@ -2,7 +2,7 @@
 #
 #	Makes Fig 7 for Appendix O (labeled lines)
 #
-gmt begin GMT_App_O_7 ps
+gmt begin GMT_App_O_7
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+u" m"+f8p -Gl50/10S/160/10S -S10 -T+l
 gmt plot -SqD15d:+gblack+fwhite+Ld+o+u@. -Wthick @App_O_transect.txt

--- a/doc/scripts/GMT_App_O_7.sh
+++ b/doc/scripts/GMT_App_O_7.sh
@@ -6,4 +6,4 @@ gmt begin GMT_App_O_7
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+u" m"+f8p -Gl50/10S/160/10S -S10 -T+l
 gmt plot -SqD15d:+gblack+fwhite+Ld+o+u@. -Wthick @App_O_transect.txt
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_O_8.sh
+++ b/doc/scripts/GMT_App_O_8.sh
@@ -7,4 +7,4 @@ gmt convert -i0,1,4 -Em150 @App_O_transect.txt | $AWK '{print $1,$2,int($3)}' > 
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+u" m"+f8p -Gl50/10S/160/10S -S10 -T+l 
 gmt plot -Sqffix2.txt:+g+an+p+Lf+u" m"+f8p -Wthick @App_O_transect.txt
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_O_8.sh
+++ b/doc/scripts/GMT_App_O_8.sh
@@ -2,7 +2,7 @@
 #
 #	Makes Fig 8 for Appendix O (labeled lines)
 #
-gmt begin GMT_App_O_8 ps
+gmt begin GMT_App_O_8
 gmt convert -i0,1,4 -Em150 @App_O_transect.txt | $AWK '{print $1,$2,int($3)}' > fix2.txt
 gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500 
 gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+u" m"+f8p -Gl50/10S/160/10S -S10 -T+l 

--- a/doc/scripts/GMT_App_O_9.sh
+++ b/doc/scripts/GMT_App_O_9.sh
@@ -26,4 +26,4 @@ cat << EOF | gmt text -Gwhite -Wthin -Dj0.1i -F+f8p,Bookman-Demi+j
 2.33E	48.87N	CT	Paris
 17W	28N	CT	Canaries
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_App_O_9.sh
+++ b/doc/scripts/GMT_App_O_9.sh
@@ -2,7 +2,7 @@
 #
 #	Makes Fig 9 for Appendix O (labeled lines)
 #
-gmt begin GMT_App_O_9 ps
+gmt begin GMT_App_O_9
 R=-R-85/5/10/55
 gmt grdgradient @App_O_topo5.nc -Nt1 -A45 -Gtopo5_int.nc
 gmt set FORMAT_GEO_MAP ddd:mm:ssF FONT_ANNOT_PRIMARY +9p FONT_TITLE 22p

--- a/doc/scripts/GMT_CPTscale.sh
+++ b/doc/scripts/GMT_CPTscale.sh
@@ -32,4 +32,4 @@ gmt text -N -F+f14p+j << EOF
 1	3.1	CB	New CPT v1
 5	3.1	CB	New CPT v2
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_CPTscale.sh
+++ b/doc/scripts/GMT_CPTscale.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_CPTscale ps
+gmt begin GMT_CPTscale
 gmt plot -R0/6/0/6 -Jx1i -W0.25p << EOF
 > Normal scaling of whole CPT
 3	2.9

--- a/doc/scripts/GMT_Defaults_1a.sh
+++ b/doc/scripts/GMT_Defaults_1a.sh
@@ -26,4 +26,4 @@ gmt plot -Sv0.06i+s+e -W0.5p,blue -N -Gblue << EOF
 -62 -14 -60 -13
 -28.3 -8 -30 -11.5
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_Defaults_1a.sh
+++ b/doc/scripts/GMT_Defaults_1a.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_Defaults_1a ps
+gmt begin GMT_Defaults_1a
 gmt set MAP_FRAME_TYPE fancy FORMAT_GEO_MAP ddd:mm:ssF MAP_GRID_CROSS_SIZE_PRIMARY 0.1i FONT_ANNOT_PRIMARY +8p
 gmt basemap -X2i -R-60/-30/-10/10 -JM2.25i -Ba10f5g5 -BWSne+t"Plot Title" 
 gmt text -N -F+f7p,Helvetica-Bold,blue+j << EOF 

--- a/doc/scripts/GMT_Defaults_1b.sh
+++ b/doc/scripts/GMT_Defaults_1b.sh
@@ -39,4 +39,4 @@ gmt plot -Wthinnest,- -X-0.5i -Y-0.5i << EOF
 0.1	0.1
 0.75	0.1
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_Defaults_1b.sh
+++ b/doc/scripts/GMT_Defaults_1b.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_Defaults_1b ps
+gmt begin GMT_Defaults_1b
 gmt set MAP_FRAME_TYPE plain FORMAT_GEO_MAP ddd:mm:ssF MAP_GRID_CROSS_SIZE_PRIMARY 0i \
 	FONT_ANNOT_PRIMARY +8p MAP_ANNOT_OBLIQUE 1
 gmt basemap -X1.5i -R-90/20/-55/25r -JOc-80/25.5/2/69/2.25i -Ba10f5g5 

--- a/doc/scripts/GMT_Defaults_1c.sh
+++ b/doc/scripts/GMT_Defaults_1c.sh
@@ -28,4 +28,4 @@ gmt plot -Sv0.06i+s+e -N -W0.5p,blue -Gblue << EOF
 2.3 0.3 1.8 -0.2
 2.35 -0.27 2.1 -0.27
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_Defaults_1c.sh
+++ b/doc/scripts/GMT_Defaults_1c.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_Defaults_1c ps
+gmt begin GMT_Defaults_1c
 gmt set MAP_FRAME_TYPE plain FORMAT_DATE_MAP "o dd" FORMAT_CLOCK_MAP hh FONT_ANNOT_PRIMARY +8p
 gmt basemap -R2001-9-11T/2001-9-13T/0.01/100 -JX2.25iT/2.25il -Bpxa6Hf1hg6h+l"x-axis label" -Bpya1g3p+l"y-axis label" -BWSne \
 	-X2i -Bsxa1D -U"Dazed and Confused"+o-0.75i/-0.85i --GMT_LANGUAGE=pt \

--- a/doc/scripts/GMT_SRTM.sh
+++ b/doc/scripts/GMT_SRTM.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #	Show distribution of SRTM tiles
-gmt begin GMT_SRTM ps
+gmt begin GMT_SRTM
 gmt set MAP_FRAME_TYPE plain
 gmt coast -R-180/180/-60/60 -JQ0/6i -Baf -BWStr -Dc -A5000 -Glightgray --FORMAT_GEO_MAP=dddF
 echo "1	red" > t.cpt

--- a/doc/scripts/GMT_SRTM.sh
+++ b/doc/scripts/GMT_SRTM.sh
@@ -7,4 +7,4 @@ echo "1	red" > t.cpt
 gmt grdmath @srtm_tiles.nc 0 NAN = t.nc
 gmt grdimage t.nc -Ct.cpt
 gmt coast -Dc -A5000 -W0.25p
-gmt end
+gmt end show

--- a/doc/scripts/GMT_albers.sh
+++ b/doc/scripts/GMT_albers.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_albers ps
+gmt begin GMT_albers
 gmt set MAP_GRID_CROSS_SIZE_PRIMARY 0
 gmt coast -R110/140/20/35 -JB125/20/25/45/5i -Bag -Dl -Ggreen -Wthinnest -A250
 gmt end

--- a/doc/scripts/GMT_albers.sh
+++ b/doc/scripts/GMT_albers.sh
@@ -2,4 +2,4 @@
 gmt begin GMT_albers
 gmt set MAP_GRID_CROSS_SIZE_PRIMARY 0
 gmt coast -R110/140/20/35 -JB125/20/25/45/5i -Bag -Dl -Ggreen -Wthinnest -A250
-gmt end
+gmt end show

--- a/doc/scripts/GMT_anchor.sh
+++ b/doc/scripts/GMT_anchor.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_anchor ps
+gmt begin GMT_anchor
 gmt basemap -R0/1/0/1 -JX5i/2i -Ba1f0.5 -BwSnE+gbisque
 gmt inset begin -DjTL+o0.7i/0.5i+w1.5i/0.75i -F+glightgreen+p1p
 gmt inset end 

--- a/doc/scripts/GMT_anchor.sh
+++ b/doc/scripts/GMT_anchor.sh
@@ -51,4 +51,4 @@ echo 0 0.75 0 1 | gmt plot -N -Sv0.2i+bt+et+s -W1p -D-0.2i/0
 echo 0 1 0.14 1 | gmt plot -N -Sv0.2i+bt+et+s -W1p -D0/0.2i 
 echo 0.07 1 dx  | gmt text -N -F+f12p,Times-Italic+jCM -Gwhite -D0/0.2i 
 echo 0 0.875 dy | gmt text -N -F+f12p,Times-Italic+jCM -Gwhite -D-0.2i/0 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_arrows.sh
+++ b/doc/scripts/GMT_arrows.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Demonstrate how arrows look like
-gmt begin GMT_arrows ps
+gmt begin GMT_arrows
 # Cartesian straight arrows
 gmt plot -R0/5/0/5 -JX1.75i -S -W1.5p -Gred -B0 --MAP_VECTOR_SHAPE=0.5 << EOF 
 0.5	0.5	4.5	0.5	v0.2i+s

--- a/doc/scripts/GMT_arrows.sh
+++ b/doc/scripts/GMT_arrows.sh
@@ -29,4 +29,4 @@ gmt plot -R0/90/-41.17/41.17 -JM1.75i -S -W1.5p -Gred -B0 --MAP_VECTOR_SHAPE=0.5
 10	35	90	8000	=0.2i+r+b
 10	-35	90	8000	=0.2i+bl
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_arrows_types.sh
+++ b/doc/scripts/GMT_arrows_types.sh
@@ -27,4 +27,4 @@ gmt plot -S -W1.5p -Gred --MAP_VECTOR_SHAPE=0.5 << EOF
 0.5	5.5	4.5	5.5	v0.25i+s+b+ei
 0.5	6.5	4.5	6.5	v0.25i+s+bA+eA
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_arrows_types.sh
+++ b/doc/scripts/GMT_arrows_types.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Demonstrate how arrows heads can look like (just doing Cartesian arrows here)
-gmt begin GMT_arrows_types ps
+gmt begin GMT_arrows_types
 # Cartesian straight arrows
 gmt plot -R0/10/0/7 -JX5.75i/1.75i -S -W1.5p -Gred -B0 --MAP_VECTOR_SHAPE=0 << EOF 
 0.5	0.5	4.5	0.5	v0.25i+s+e+a40

--- a/doc/scripts/GMT_atan.sh
+++ b/doc/scripts/GMT_atan.sh
@@ -29,4 +29,4 @@ gmt text -F+f9p+jLB << EOF
 -0.7	4.3	tan@+-1@+ 
 -0.7	3.7	transformed
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_atan.sh
+++ b/doc/scripts/GMT_atan.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_atan ps
+gmt begin GMT_atan
 gmt grdgradient -A45 @tut_relief.nc -N -fg -Gtt.t.nc
 gmt grd2xyz -Z tt.t.nc > tt.d
 gmt histogram tt.d -R-0.75/0.75/0/20 -JX1.5i/1i -Bx0.5 -By5f5 -BWSne -W0.01 -Gblack -Z1

--- a/doc/scripts/GMT_bezier.sh
+++ b/doc/scripts/GMT_bezier.sh
@@ -7,7 +7,7 @@ cat << EOF > line.txt
 2	1.5
 EOF
 
-gmt begin GMT_bezier ps
+gmt begin GMT_bezier
 gmt plot line.txt -R-0.25/4.25/-0.2/2.2 -JX3i/1.25i -W2p
 gmt plot line.txt -Sc0.1i -Gred -Wfaint 
 gmt plot line.txt -W2p+s -X3i 

--- a/doc/scripts/GMT_bezier.sh
+++ b/doc/scripts/GMT_bezier.sh
@@ -12,4 +12,4 @@ gmt plot line.txt -R-0.25/4.25/-0.2/2.2 -JX3i/1.25i -W2p
 gmt plot line.txt -Sc0.1i -Gred -Wfaint 
 gmt plot line.txt -W2p+s -X3i 
 gmt plot line.txt -Sc0.1i -Gred -Wfaint 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_chunking.sh
+++ b/doc/scripts/GMT_chunking.sh
@@ -3,7 +3,7 @@
 # Make an illustration of grid chunking
 #
 
-gmt begin GMT_chunking ps
+gmt begin GMT_chunking
 gmt set MAP_FRAME_PEN thick FONT_ANNOT_PRIMARY 9p
 
 n=1 # current cell number

--- a/doc/scripts/GMT_chunking.sh
+++ b/doc/scripts/GMT_chunking.sh
@@ -34,4 +34,4 @@ for ((x=0;x<12;++x)); do
 done
 
 rm -f chunk.tmp
-gmt end
+gmt end show

--- a/doc/scripts/GMT_color_interpolate.sh
+++ b/doc/scripts/GMT_color_interpolate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_color_interpolate ps
+gmt begin GMT_color_interpolate
 gmt basemap -Jx1i -R0/6.8/0/2.0 -B0 
 
 # Plot polar color map in the left; right (top) and wrong (bottom)

--- a/doc/scripts/GMT_color_interpolate.sh
+++ b/doc/scripts/GMT_color_interpolate.sh
@@ -31,4 +31,4 @@ gmt text -F+f14p,Helvetica-Bold+jBC << END
 5.1 1.7 rainbow (HSV)
 5.1 0.8 rainbow (RGB)
 END
-gmt end
+gmt end show

--- a/doc/scripts/GMT_colorbar.sh
+++ b/doc/scripts/GMT_colorbar.sh
@@ -3,4 +3,4 @@ gmt begin GMT_colorbar
 	gmt makecpt -T-15/15 -Cpolar
 	gmt basemap -R0/20/0/1 -JM5i -BWse -Baf 
 	gmt colorbar -C -Baf -Bx+u"\\232" -By+l@~D@~T -DJBC+e
-gmt end
+gmt end show

--- a/doc/scripts/GMT_colorbar.sh
+++ b/doc/scripts/GMT_colorbar.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_colorbar ps
+gmt begin GMT_colorbar
 	gmt makecpt -T-15/15 -Cpolar
 	gmt basemap -R0/20/0/1 -JM5i -BWse -Baf 
 	gmt colorbar -C -Baf -Bx+u"\\232" -By+l@~D@~T -DJBC+e

--- a/doc/scripts/GMT_cyclic.sh
+++ b/doc/scripts/GMT_cyclic.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_cyclic ps
+gmt begin GMT_cyclic
 	gmt makecpt -T0/100 -Cjet -Ww
 	gmt basemap -R0/20/0/1 -JM5i -BWse -Baf
 	gmt colorbar -C -Baf -DJBC 

--- a/doc/scripts/GMT_cyclic.sh
+++ b/doc/scripts/GMT_cyclic.sh
@@ -3,4 +3,4 @@ gmt begin GMT_cyclic
 	gmt makecpt -T0/100 -Cjet -Ww
 	gmt basemap -R0/20/0/1 -JM5i -BWse -Baf
 	gmt colorbar -C -Baf -DJBC 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_dir_rose.sh
+++ b/doc/scripts/GMT_dir_rose.sh
@@ -9,4 +9,4 @@ gmt basemap -R-5/5/-5/5 -Jm0.15i -Ba5f -BWSne+gazure1 -Tdg0/0+w1i+jCM -X1i
 gmt basemap -Ba5f -BwSne+gazure1 -Tdg0/0+w1i+f1+jCM+l,,,N -X1.75i
 # right: Plain kind
 gmt basemap -R-7/7/-5/5 -Ba5f -BwSnE+gazure1 -Tdg0/0+w1i+f3+l+jCM -X1.75i
-gmt end
+gmt end show

--- a/doc/scripts/GMT_dir_rose.sh
+++ b/doc/scripts/GMT_dir_rose.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Showing map directional roses
-gmt begin GMT_dir_rose ps
+gmt begin GMT_dir_rose
 gmt set FONT_LABEL 10p FONT_TITLE 12p MAP_ANNOT_OBLIQUE 34 MAP_TITLE_OFFSET 5p \
 	MAP_FRAME_WIDTH 3p FORMAT_GEO_MAP dddF FONT_ANNOT_PRIMARY 10p
 # left: Fancy kind = 1

--- a/doc/scripts/GMT_eckert4.sh
+++ b/doc/scripts/GMT_eckert4.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-gmt begin GMT_eckert4 ps
+gmt begin GMT_eckert4
 gmt coast -Rg -JKf4.5i -Bg -Dc -A10000 -Wthinnest -Givory -Sbisque3 
 gmt end

--- a/doc/scripts/GMT_eckert4.sh
+++ b/doc/scripts/GMT_eckert4.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 gmt begin GMT_eckert4
 gmt coast -Rg -JKf4.5i -Bg -Dc -A10000 -Wthinnest -Givory -Sbisque3 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_eckert6.sh
+++ b/doc/scripts/GMT_eckert6.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-gmt begin GMT_eckert6 ps
+gmt begin GMT_eckert6
 gmt coast -Rg -JKs4.5i -Bg -Dc -A10000 -Wthinnest -Givory -Sbisque3 
 gmt end

--- a/doc/scripts/GMT_eckert6.sh
+++ b/doc/scripts/GMT_eckert6.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 gmt begin GMT_eckert6
 gmt coast -Rg -JKs4.5i -Bg -Dc -A10000 -Wthinnest -Givory -Sbisque3 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_encoding.sh
+++ b/doc/scripts/GMT_encoding.sh
@@ -66,4 +66,4 @@ gmt plot -Wthick << EOF
 1	0
 1	32
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_encoding.sh
+++ b/doc/scripts/GMT_encoding.sh
@@ -54,7 +54,7 @@ BEGIN {
 }
 EOF
 
-gmt begin GMT_encoding ps
+gmt begin GMT_encoding
 gmt set PS_CHAR_ENCODING $1
 gmt plot -R0/9/-1/32 -Jx0.345i/-0.21i -Bg1 -B+t"Octal codes for $1" -Ggray -X3i -Sri tt.empty
 $AWK -f tt.awk tt.chart | gmt text -F+f10p,Times-Roman

--- a/doc/scripts/GMT_equidistant_conic.sh
+++ b/doc/scripts/GMT_equidistant_conic.sh
@@ -2,4 +2,4 @@
 gmt begin GMT_equidistant_conic
 gmt set FORMAT_GEO_MAP ddd:mm:ssF MAP_GRID_CROSS_SIZE_PRIMARY 0.05i
 gmt coast -R-88/-70/18/24 -JD-79/21/19/23/4.5i -Bag -Di -N1/thick,red -Glightgreen -Wthinnest 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_equidistant_conic.sh
+++ b/doc/scripts/GMT_equidistant_conic.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_equidistant_conic ps
+gmt begin GMT_equidistant_conic
 gmt set FORMAT_GEO_MAP ddd:mm:ssF MAP_GRID_CROSS_SIZE_PRIMARY 0.05i
 gmt coast -R-88/-70/18/24 -JD-79/21/19/23/4.5i -Bag -Di -N1/thick,red -Glightgreen -Wthinnest 
 gmt end

--- a/doc/scripts/GMT_fatline.sh
+++ b/doc/scripts/GMT_fatline.sh
@@ -11,4 +11,4 @@ gmt begin GMT_fatline
 	gmt psxy -W1p,red gc.d
 	gmt psxy -X3.25i -W30p gc.d --PS_LINE_CAP=round --PS_LINE_JOIN=round
 	gmt psxy -W1p,red gc.d
-gmt end
+gmt end show

--- a/doc/scripts/GMT_fatline.sh
+++ b/doc/scripts/GMT_fatline.sh
@@ -6,7 +6,7 @@ cat > gc.d << END
 -82 85
 -8  85
 END
-gmt begin GMT_fatline ps
+gmt begin GMT_fatline
 	gmt psxy -R-90/82/0/87+r -JM-45/84.5/2.5i -W30p gc.d
 	gmt psxy -W1p,red gc.d
 	gmt psxy -X3.25i -W30p gc.d --PS_LINE_CAP=round --PS_LINE_JOIN=round

--- a/doc/scripts/GMT_hinge.sh
+++ b/doc/scripts/GMT_hinge.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_hinge ps
+gmt begin GMT_hinge
 	gmt makecpt -Cglobe -T-8000/3000
 	gmt colorbar -Baf -Dx0/0+w4.5i/0.1i+h -W0.001 
 	gmt colorbar -Cglobe  -Baf -Dx0/0+w4.5i/0.1i+h -W0.001 -Y0.5i 

--- a/doc/scripts/GMT_hinge.sh
+++ b/doc/scripts/GMT_hinge.sh
@@ -7,4 +7,4 @@ gmt begin GMT_hinge
 	gmt text -F+f12p+jCB <<- EOF 
 	2.25	0.35	HINGE
 	EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_images.sh
+++ b/doc/scripts/GMT_images.sh
@@ -2,4 +2,4 @@
 gmt begin GMT_images
 gmt image @nsf1.jpg -R0/2/0/1 -JX5i/1.6i -B0 -DjML+w1.5i+o0.1i/0i 
 gmt image @soest.eps -DjMR+o0.1i/0i+w2i 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_images.sh
+++ b/doc/scripts/GMT_images.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_images ps
+gmt begin GMT_images
 gmt image @nsf1.jpg -R0/2/0/1 -JX5i/1.6i -B0 -DjML+w1.5i+o0.1i/0i 
 gmt image @soest.eps -DjMR+o0.1i/0i+w2i 
 gmt end

--- a/doc/scripts/GMT_inset.sh
+++ b/doc/scripts/GMT_inset.sh
@@ -8,4 +8,4 @@ gmt coast -R110E/170E/44S/9S -JM6i -Baf -BWSne -Wfaint -N2/1p  -EAU+gbisque -Gbr
 gmt inset begin -DjTR+w1.5i+o0.15i -F+gwhite+p1p+s -M0.05i
   gmt coast -Rg -JG120/30S/1.4i -Da -Gbrown -A5000 -Bg -Wfaint -EAU+gbisque 
 gmt inset end 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_inset.sh
+++ b/doc/scripts/GMT_inset.sh
@@ -2,7 +2,7 @@
 #
 # Testing gmt legend capabilities for tables with colors
 
-gmt begin GMT_inset ps
+gmt begin GMT_inset
 # Bottom map of Australia
 gmt coast -R110E/170E/44S/9S -JM6i -Baf -BWSne -Wfaint -N2/1p  -EAU+gbisque -Gbrown -Sazure1 -Da -Xc --FORMAT_GEO_MAP=dddF
 gmt inset begin -DjTR+w1.5i+o0.15i -F+gwhite+p1p+s -M0.05i

--- a/doc/scripts/GMT_legend.sh
+++ b/doc/scripts/GMT_legend.sh
@@ -105,4 +105,4 @@ cat << EOF > t.cpt
 EOF
 gmt legend -Dx0/0+w5.6i+jBL+l1.2 -C0.05i -F+p+gsnow1 -B0 table.txt --FONT_ANNOT_PRIMARY=12p  --FONT_LABEL=12p
 rm -f table.txt t.cpt
-gmt end
+gmt end show

--- a/doc/scripts/GMT_legend.sh
+++ b/doc/scripts/GMT_legend.sh
@@ -2,7 +2,7 @@
 #
 # Testing gmt legend capabilities for tables with colors
 
-gmt begin GMT_legend ps
+gmt begin GMT_legend
 gmt set FONT_ANNOT_PRIMARY 12p  FONT_LABEL 12p
 
 cat <<EOF > table.txt

--- a/doc/scripts/GMT_linear.sh
+++ b/doc/scripts/GMT_linear.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_linear ps
+gmt begin GMT_linear
 gmt plot -R0/100/0/10 -JX3i/1.5i -Bag -BWSne+gsnow -Wthick,blue,- sqrt.txt
 gmt plot -St0.1i -N -Gred -Wfaint sqrt10.txt
 gmt end

--- a/doc/scripts/GMT_linear.sh
+++ b/doc/scripts/GMT_linear.sh
@@ -2,4 +2,4 @@
 gmt begin GMT_linear
 gmt plot -R0/100/0/10 -JX3i/1.5i -Bag -BWSne+gsnow -Wthick,blue,- sqrt.txt
 gmt plot -St0.1i -N -Gred -Wfaint sqrt10.txt
-gmt end
+gmt end show

--- a/doc/scripts/GMT_linearrow.sh
+++ b/doc/scripts/GMT_linearrow.sh
@@ -4,4 +4,4 @@ gmt math -T10/30/1 T 20 SUB 10 DIV 2 POW 41.5 ADD = line.txt
 gmt begin GMT_linearrow
 gmt plot line.txt -R8/32/40/44 -JM5i -Wfaint,red -Bxaf -Bya2f1 -BWSne --MAP_FRAME_TYPE=plain 
 gmt plot line.txt -W2p+o1c/500k+vb0.2i+gred+pfaint+bc+ve0.3i+gblue+h0.5 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_linearrow.sh
+++ b/doc/scripts/GMT_linearrow.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 gmt math -T10/30/1 T 20 SUB 10 DIV 2 POW 41.5 ADD = line.txt
 
-gmt begin GMT_linearrow ps
+gmt begin GMT_linearrow
 gmt plot line.txt -R8/32/40/44 -JM5i -Wfaint,red -Bxaf -Bya2f1 -BWSne --MAP_FRAME_TYPE=plain 
 gmt plot line.txt -W2p+o1c/500k+vb0.2i+gred+pfaint+bc+ve0.3i+gblue+h0.5 
 gmt end

--- a/doc/scripts/GMT_linecap.sh
+++ b/doc/scripts/GMT_linecap.sh
@@ -4,7 +4,7 @@ cat << EOF > lines.txt
 5       0
 EOF
 
-gmt begin GMT_linecap ps
+gmt begin GMT_linecap
 gmt plot lines.txt -R-0.25/5.25/-0.2/1.4 -Jx1i -W4p 
 gmt plot lines.txt -Y0.2i -W4p,orange,. 
 gmt plot lines.txt -Y0.2i -W4p,red,9_4_2_4:2p 

--- a/doc/scripts/GMT_linecap.sh
+++ b/doc/scripts/GMT_linecap.sh
@@ -12,4 +12,4 @@ gmt plot lines.txt -Y0.2i -W4p,-  --PS_LINE_CAP=round
 gmt plot lines.txt -Y0.2i -W4p,orange,0_8 --PS_LINE_CAP=round 
 gmt plot lines.txt -Y0.2i -W4p,red,0_16  --PS_LINE_CAP=round 
 gmt plot lines.txt -W2p,green,0_16:8p  --PS_LINE_CAP=round
-gmt end
+gmt end show

--- a/doc/scripts/GMT_lineoffset.sh
+++ b/doc/scripts/GMT_lineoffset.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 gmt math -T10/30/1 T 20 SUB 10 DIV 2 POW 41.5 ADD = line.txt
 
-gmt begin GMT_lineoffset ps
+gmt begin GMT_lineoffset
 gmt plot line.txt -R8/32/40/44 -JM5i -Wfaint,red -Bxaf -Bya2f1 -BWSne --MAP_FRAME_TYPE=plain 
 gmt plot line.txt -W2p+o1c/500k 
 gmt text -F+f10p+jCM+a << EOF 

--- a/doc/scripts/GMT_lineoffset.sh
+++ b/doc/scripts/GMT_lineoffset.sh
@@ -8,4 +8,4 @@ gmt text -F+f10p+jCM+a << EOF
 11.0 42.6 -11.5 1 cm
 27.1 42.3 +9.5 500 km
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_log.sh
+++ b/doc/scripts/GMT_log.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_log ps
+gmt begin GMT_log
 gmt plot -R1/100/0/10 -Jx1.5il/0.15i -Bx2g3 -Bya2f1g2 -BWSne+gbisque -Wthick,blue,- -h sqrt.txt
 gmt plot -Ss0.1i -N -Gred -W -h sqrt10.txt
 gmt end

--- a/doc/scripts/GMT_log.sh
+++ b/doc/scripts/GMT_log.sh
@@ -2,4 +2,4 @@
 gmt begin GMT_log
 gmt plot -R1/100/0/10 -Jx1.5il/0.15i -Bx2g3 -Bya2f1g2 -BWSne+gbisque -Wthick,blue,- -h sqrt.txt
 gmt plot -Ss0.1i -N -Gred -W -h sqrt10.txt
-gmt end
+gmt end show

--- a/doc/scripts/GMT_mag_rose.sh
+++ b/doc/scripts/GMT_mag_rose.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_mag_rose ps
+gmt begin GMT_mag_rose
 # Magnetic rose with a specified declination
 gmt basemap -R-10/-2/12.8812380332/0.661018975345+r -JOc0/0/50/60/7i -Baf -BWSne -X1.25i --MAP_ANNOT_OBLIQUE=34 --FONT_ANNOT_PRIMARY=12p 
 gmt basemap -Tmg-2/0.5+w2.5i+d-14.5+t45/10/5+i0.25p,blue+p0.25p,red+l+jCM \

--- a/doc/scripts/GMT_mag_rose.sh
+++ b/doc/scripts/GMT_mag_rose.sh
@@ -25,4 +25,4 @@ gmt text -F+f11.5p+jLM << EOF
 4.1 0.50 @;darkgreen;MAP_DEFAULT_PEN@;;
 4.1 0.25 @;darkgreen;COLOR_BACKGROUND@;;
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_mapscale.sh
+++ b/doc/scripts/GMT_mapscale.sh
@@ -13,4 +13,4 @@ gmt plot -Wfaint -A -N << EOF
 0	50
 40	50
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_mapscale.sh
+++ b/doc/scripts/GMT_mapscale.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_mapscale ps
+gmt begin GMT_mapscale
 gmt basemap -R0/40/50/56 -JM5i -Baf -LjML+c53+w1000k+f+l"Scale at 53\\232N" -F+glightcyan+c0+p 
 gmt basemap -LjBR+c53+w1000k+l+f -F+p1p+i+gwhite+c0.1i 
 h=`gmt mapproject -Wh -Di`

--- a/doc/scripts/GMT_nearneighbor.sh
+++ b/doc/scripts/GMT_nearneighbor.sh
@@ -56,4 +56,4 @@ gmt text -F+f8p,Helvetica-Oblique+jBL << EOF
 1	1.4	R
 1.0	1	r@-i@-
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_nearneighbor.sh
+++ b/doc/scripts/GMT_nearneighbor.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_nearneighbor ps
+gmt begin GMT_nearneighbor
 gmt plot -R0/2/0/2 -Jx1i -Sc1i -Wthick -Glightgreen@70 -Bg0.25 << EOF 
 0.75	1.25
 EOF

--- a/doc/scripts/GMT_obl_nz.sh
+++ b/doc/scripts/GMT_obl_nz.sh
@@ -53,4 +53,4 @@ gmt text -F+f12p,Times-Italic+j -Dj0.1i -Gwhite << EOF
 1.5	1.5	TR	y
 EOF
 echo $plon $plat | gmt mapproject -JoA$lon/$lat/$az/1:1 -Fk -C
-gmt end
+gmt end show

--- a/doc/scripts/GMT_obl_nz.sh
+++ b/doc/scripts/GMT_obl_nz.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Oblique Mercator map for NZ using complementary poles
-gmt begin GMT_obl_nz ps
+gmt begin GMT_obl_nz
 lon=173:17:02E
 lat=41:16:15S
 az=35

--- a/doc/scripts/GMT_panel.sh
+++ b/doc/scripts/GMT_panel.sh
@@ -7,4 +7,4 @@ gmt inset begin -DjBR+o0.3i+w1.75i/0.75i -F+p1p+i+s+gwhite+c0.1i
 gmt inset end
 gmt inset begin -DjBR+o0.3i+w1.75i/0.75i -F+p0.25p,-+c0 
 gmt inset end
-gmt end
+gmt end show

--- a/doc/scripts/GMT_panel.sh
+++ b/doc/scripts/GMT_panel.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_panel ps
+gmt begin GMT_panel
 gmt basemap -R0/2/0/1 -JX5i/2i -B0 
 gmt inset begin -DjTL+o0.2i+w1.75i/0.75i -F+glightgreen+r
 gmt inset end

--- a/doc/scripts/GMT_polar.sh
+++ b/doc/scripts/GMT_polar.sh
@@ -2,4 +2,4 @@
 gmt begin GMT_polar
 gmt grdmath -R0/360/2/4 -I6/0.1 X 4 MUL PI MUL 180 DIV COS Y 2 POW MUL = tt.nc
 gmt grdcontour tt.nc -JP3i -B30 -BNs+ghoneydew -C2 -S4 --FORMAT_GEO_MAP=+ddd 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_polar.sh
+++ b/doc/scripts/GMT_polar.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_polar ps
+gmt begin GMT_polar
 gmt grdmath -R0/360/2/4 -I6/0.1 X 4 MUL PI MUL 180 DIV COS Y 2 POW MUL = tt.nc
 gmt grdcontour tt.nc -JP3i -B30 -BNs+ghoneydew -C2 -S4 --FORMAT_GEO_MAP=+ddd 
 gmt end

--- a/doc/scripts/GMT_pow.sh
+++ b/doc/scripts/GMT_pow.sh
@@ -2,4 +2,4 @@
 gmt begin GMT_pow
 gmt plot -R0/100/0/10 -Jx0.3ip0.5/0.15i -Bxa1p -Bya2f1 -BWSne+givory -Wthick sqrt.txt 
 gmt plot -Sc0.075i -Ggreen -W sqrt10.txt
-gmt end
+gmt end show

--- a/doc/scripts/GMT_pow.sh
+++ b/doc/scripts/GMT_pow.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_pow ps
+gmt begin GMT_pow
 gmt plot -R0/100/0/10 -Jx0.3ip0.5/0.15i -Bxa1p -Bya2f1 -BWSne+givory -Wthick sqrt.txt 
 gmt plot -Sc0.075i -Ggreen -W sqrt10.txt
 gmt end

--- a/doc/scripts/GMT_pstext_clearance.sh
+++ b/doc/scripts/GMT_pstext_clearance.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_pstext_clearance ps
+gmt begin GMT_pstext_clearance
 gmt text -R0/3/-0.1/1.5 -Jx1i -C0.2i+tO -Wthick -F+f36p,Helvetica-Bold << EOF 
 1.5	0.5	My Text
 EOF

--- a/doc/scripts/GMT_pstext_clearance.sh
+++ b/doc/scripts/GMT_pstext_clearance.sh
@@ -22,4 +22,4 @@ gmt plot << EOF
 0.59	0.69
 0.46	0.82
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_pstext_justify.sh
+++ b/doc/scripts/GMT_pstext_justify.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_pstext_justify ps
+gmt begin GMT_pstext_justify
 B=0.2
 M=0.38
 T=0.56

--- a/doc/scripts/GMT_pstext_justify.sh
+++ b/doc/scripts/GMT_pstext_justify.sh
@@ -58,4 +58,4 @@ $R	$B
 $R	$M
 $R	$T
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_registration.sh
+++ b/doc/scripts/GMT_registration.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_registration ps
+gmt begin GMT_registration
 # Gridline registration
 gmt plot -R0/3/0/3 -JX2.5i/1.25i -B1g1 -Bwesn -Wthinner -L -Glightred << EOF 
 0.5	1.5

--- a/doc/scripts/GMT_registration.sh
+++ b/doc/scripts/GMT_registration.sh
@@ -19,4 +19,4 @@ gmt plot -R0/3/0/3 -JX2.5i/1.25i -B1g1 -Bwesn -W0p -L -Glightred -X2.75i << EOF
 EOF
 gmt grdmath -R0/3/0/3 -I1 -r 0 = tt.nc
 gmt grd2xyz tt.nc | gmt plot -R0/3/0/3 -JX2.5i/1.25i -Sc0.12i -Gblack 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_sinus_int.sh
+++ b/doc/scripts/GMT_sinus_int.sh
@@ -3,4 +3,4 @@ gmt begin GMT_sinus_int
 gmt coast -R200/340/-90/90 -Ji0.014i -Bg -A10000 -Dc -Gdarkred -Sazure 
 gmt coast -R-20/60/-90/90 -Bg -Dc -A10000 -Gdarkgreen -Sazure -X1.96i 
 gmt coast -R60/200/-90/90 -Bg -Dc -A10000 -Gdarkblue -Sazure -X1.12i
-gmt end
+gmt end show

--- a/doc/scripts/GMT_sinus_int.sh
+++ b/doc/scripts/GMT_sinus_int.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_sinus_int ps
+gmt begin GMT_sinus_int
 gmt coast -R200/340/-90/90 -Ji0.014i -Bg -A10000 -Dc -Gdarkred -Sazure 
 gmt coast -R-20/60/-90/90 -Bg -Dc -A10000 -Gdarkgreen -Sazure -X1.96i 
 gmt coast -R60/200/-90/90 -Bg -Dc -A10000 -Gdarkblue -Sazure -X1.12i

--- a/doc/scripts/GMT_stereonets.sh
+++ b/doc/scripts/GMT_stereonets.sh
@@ -4,4 +4,4 @@ gmt basemap -R0/360/-90/90 -JA0/0/1.75i -Bg15
 echo "180 -90 SCHMIDT" | gmt text -N -D0/-0.2c -F+f12p,Helvetica-Bold+jTC 
 gmt basemap -JS0/0/1.75i -Bg15 -X2.75i 
 echo "180 -90 WULFF" | gmt text -N -D0/-0.2c -F+f12p,Helvetica-Bold+jTC 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_stereonets.sh
+++ b/doc/scripts/GMT_stereonets.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_stereonets ps
+gmt begin GMT_stereonets
 gmt basemap -R0/360/-90/90 -JA0/0/1.75i -Bg15 
 echo "180 -90 SCHMIDT" | gmt text -N -D0/-0.2c -F+f12p,Helvetica-Bold+jTC 
 gmt basemap -JS0/0/1.75i -Bg15 -X2.75i 

--- a/doc/scripts/GMT_tut_1.sh
+++ b/doc/scripts/GMT_tut_1.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 gmt begin GMT_tut_1
   gmt basemap -R10/70/-3/8 -JX4i/3i -Ba -B+glightred+t"My first plot"
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_1.sh
+++ b/doc/scripts/GMT_tut_1.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_1 ps
+gmt begin GMT_tut_1
   gmt basemap -R10/70/-3/8 -JX4i/3i -Ba -B+glightred+t"My first plot"
 gmt end

--- a/doc/scripts/GMT_tut_10.sh
+++ b/doc/scripts/GMT_tut_10.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_10 ps
+gmt begin GMT_tut_10
   gmt text -R0/7/0/5 -Jx1i -Ba -F+f30p,Times-Roman,DarkOrange+jBL << EOF
 1  1  It's P@al, not Pal!
 1  2  Try @%33%ZapfChancery@%% today

--- a/doc/scripts/GMT_tut_10.sh
+++ b/doc/scripts/GMT_tut_10.sh
@@ -6,4 +6,4 @@ gmt begin GMT_tut_10
 1  3  @~D@~g@-b@- = 2@~pr@~G@~D@~h.
 1  4  University of Hawaii at M@!a\225noa
 EOF
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_11.sh
+++ b/doc/scripts/GMT_tut_11.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_11 ps
+gmt begin GMT_tut_11
   gmt grdcontour @tut_bathy.nc -JM6i -C250 -A1000 -Ba
 gmt end

--- a/doc/scripts/GMT_tut_11.sh
+++ b/doc/scripts/GMT_tut_11.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 gmt begin GMT_tut_11
   gmt grdcontour @tut_bathy.nc -JM6i -C250 -A1000 -Ba
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_12.sh
+++ b/doc/scripts/GMT_tut_12.sh
@@ -2,4 +2,4 @@
 gmt begin GMT_tut_12
   gmt nearneighbor -R245/255/20/30 -I5m -S40k -Gship.nc @tut_ship.xyz
   gmt grdcontour ship.nc -JM6i -Ba -C250 -A1000
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_12.sh
+++ b/doc/scripts/GMT_tut_12.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_12 ps
+gmt begin GMT_tut_12
   gmt nearneighbor -R245/255/20/30 -I5m -S40k -Gship.nc @tut_ship.xyz
   gmt grdcontour ship.nc -JM6i -Ba -C250 -A1000
 gmt end

--- a/doc/scripts/GMT_tut_13.sh
+++ b/doc/scripts/GMT_tut_13.sh
@@ -5,4 +5,4 @@ gmt begin GMT_tut_13
   gmt mask -R245/255/20/30 -I5m ship_5m.xyz -JM6i -Ba
   gmt grdcontour ship.nc -C250 -A1000 
   gmt mask -C 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_13.sh
+++ b/doc/scripts/GMT_tut_13.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 gmt blockmedian -R245/255/20/30 -I5m -V @tut_ship.xyz > ship_5m.xyz
 gmt surface ship_5m.xyz -R245/255/20/30 -I5m -Gship.nc
-gmt begin GMT_tut_13 ps
+gmt begin GMT_tut_13
   gmt mask -R245/255/20/30 -I5m ship_5m.xyz -JM6i -Ba
   gmt grdcontour ship.nc -C250 -A1000 
   gmt mask -C 

--- a/doc/scripts/GMT_tut_14.sh
+++ b/doc/scripts/GMT_tut_14.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_14 ps
+gmt begin GMT_tut_14
   gmt makecpt -H -Crainbow -T-20/60/10 > disc.cpt
   gmt makecpt -H -Crainbow -T-20/60 > cont.cpt
   gmt basemap -R0/6/0/9 -Jx1i -B0 -Xc 

--- a/doc/scripts/GMT_tut_14.sh
+++ b/doc/scripts/GMT_tut_14.sh
@@ -7,4 +7,4 @@ gmt begin GMT_tut_14
   gmt colorbar -Dx1i/3i+w4i/0.5i+h -Ccont.cpt -Ba -B+tcontinuous 
   gmt colorbar -Dx1i/5i+w4i/0.5i+h -Cdisc.cpt -Ba -B+tdiscrete -I0.5 
   gmt colorbar -Dx1i/7i+w4i/0.5i+h -Ccont.cpt -Ba -B+tcontinuous -I0.5 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_15.sh
+++ b/doc/scripts/GMT_tut_15.sh
@@ -3,4 +3,4 @@ gmt begin GMT_tut_15
   gmt makecpt -Crainbow -T1000/5000
   gmt grdimage @tut_relief.nc -JM6i -Ba -BWSnE
   gmt colorbar -DJTC -I0.4 -Bxa -By+lm 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_15.sh
+++ b/doc/scripts/GMT_tut_15.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_15 ps
+gmt begin GMT_tut_15
   gmt makecpt -Crainbow -T1000/5000
   gmt grdimage @tut_relief.nc -JM6i -Ba -BWSnE
   gmt colorbar -DJTC -I0.4 -Bxa -By+lm 

--- a/doc/scripts/GMT_tut_16.sh
+++ b/doc/scripts/GMT_tut_16.sh
@@ -4,4 +4,4 @@ gmt begin GMT_tut_16
   gmt grdgradient @tut_relief.nc -Ne0.8 -A100 -fg -Gus_i.nc
   gmt grdimage tut_relief.nc -Ius_i.nc -JM6i -Ba -BWSnE
   gmt colorbar -DJTC -I0.4 -Bxa -By+lm 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_16.sh
+++ b/doc/scripts/GMT_tut_16.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_16 ps
+gmt begin GMT_tut_16
   gmt makecpt -Crainbow -T1000/5000
   gmt grdgradient @tut_relief.nc -Ne0.8 -A100 -fg -Gus_i.nc
   gmt grdimage tut_relief.nc -Ius_i.nc -JM6i -Ba -BWSnE

--- a/doc/scripts/GMT_tut_17.sh
+++ b/doc/scripts/GMT_tut_17.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_17 ps
+gmt begin GMT_tut_17
   gmt makecpt -Cno_green -T-2/30/2
   gmt grdimage -Rg -JW180/9i "@otemp.anal1deg.nc?otemp[2,0]" -Bag
 gmt end

--- a/doc/scripts/GMT_tut_17.sh
+++ b/doc/scripts/GMT_tut_17.sh
@@ -2,4 +2,4 @@
 gmt begin GMT_tut_17
   gmt makecpt -Cno_green -T-2/30/2
   gmt grdimage -Rg -JW180/9i "@otemp.anal1deg.nc?otemp[2,0]" -Bag
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_18.sh
+++ b/doc/scripts/GMT_tut_18.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_18 ps
+gmt begin GMT_tut_18
   gmt grd2cpt @tut_bathy.nc -Cocean
   gmt grdview tut_bathy.nc -JM5i -JZ2i -p135/30 -Ba
 gmt end

--- a/doc/scripts/GMT_tut_18.sh
+++ b/doc/scripts/GMT_tut_18.sh
@@ -2,4 +2,4 @@
 gmt begin GMT_tut_18
   gmt grd2cpt @tut_bathy.nc -Cocean
   gmt grdview tut_bathy.nc -JM5i -JZ2i -p135/30 -Ba
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_19.sh
+++ b/doc/scripts/GMT_tut_19.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_19 ps
+gmt begin GMT_tut_19
   gmt makecpt -Ctopo -T1000/5000
   gmt grdgradient @tut_relief.nc -Ne0.8 -A100 -fg -Gus_i.nc
   gmt grdview tut_relief.nc -JM4i -p135/35 -Qi50 -Ius_i.nc -Ba -JZ0.5i -C

--- a/doc/scripts/GMT_tut_19.sh
+++ b/doc/scripts/GMT_tut_19.sh
@@ -3,4 +3,4 @@ gmt begin GMT_tut_19
   gmt makecpt -Ctopo -T1000/5000
   gmt grdgradient @tut_relief.nc -Ne0.8 -A100 -fg -Gus_i.nc
   gmt grdview tut_relief.nc -JM4i -p135/35 -Qi50 -Ius_i.nc -Ba -JZ0.5i -C
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_2.sh
+++ b/doc/scripts/GMT_tut_2.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 gmt begin GMT_tut_2
   gmt basemap -R1/10000/1e20/1e25 -JX9il/6il -Bxa2+l"Wavelength (m)" -Bya1pf3+l"Power (W)" -BWS
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_2.sh
+++ b/doc/scripts/GMT_tut_2.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_2 ps
+gmt begin GMT_tut_2
   gmt basemap -R1/10000/1e20/1e25 -JX9il/6il -Bxa2+l"Wavelength (m)" -Bya1pf3+l"Power (W)" -BWS
 gmt end

--- a/doc/scripts/GMT_tut_3.sh
+++ b/doc/scripts/GMT_tut_3.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 gmt begin GMT_tut_3
   gmt coast -R-90/-70/0/20 -JM6i -Ba -Gchocolate
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_3.sh
+++ b/doc/scripts/GMT_tut_3.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_3 ps
+gmt begin GMT_tut_3
   gmt coast -R-90/-70/0/20 -JM6i -Ba -Gchocolate
 gmt end

--- a/doc/scripts/GMT_tut_4.sh
+++ b/doc/scripts/GMT_tut_4.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_4 ps
+gmt begin GMT_tut_4
   gmt coast -R-130/-70/24/52 -JB-100/35/33/45/6i -Ba -B+t"Conic Projection" -N1/thickest -N2/thinnest -A500 -Ggray -Wthinnest
 gmt end

--- a/doc/scripts/GMT_tut_4.sh
+++ b/doc/scripts/GMT_tut_4.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 gmt begin GMT_tut_4
   gmt coast -R-130/-70/24/52 -JB-100/35/33/45/6i -Ba -B+t"Conic Projection" -N1/thickest -N2/thinnest -A500 -Ggray -Wthinnest
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_5.sh
+++ b/doc/scripts/GMT_tut_5.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 gmt begin GMT_tut_5
   gmt coast -Rg -JG280/30/6i -Bag -Dc -A5000 -Gwhite -SDarkTurquoise
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_5.sh
+++ b/doc/scripts/GMT_tut_5.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_5 ps
+gmt begin GMT_tut_5
   gmt coast -Rg -JG280/30/6i -Bag -Dc -A5000 -Gwhite -SDarkTurquoise
 gmt end

--- a/doc/scripts/GMT_tut_6.sh
+++ b/doc/scripts/GMT_tut_6.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_6 ps
+gmt begin GMT_tut_6
   gmt coast -Rg -JKs180/9i -Bag -Dc -A5000 -Gchocolate -SDarkTurquoise -Wthinnest
 gmt end

--- a/doc/scripts/GMT_tut_6.sh
+++ b/doc/scripts/GMT_tut_6.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 gmt begin GMT_tut_6
   gmt coast -Rg -JKs180/9i -Bag -Dc -A5000 -Gchocolate -SDarkTurquoise -Wthinnest
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_7.sh
+++ b/doc/scripts/GMT_tut_7.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 gmt begin GMT_tut_7
   gmt plot @tut_data.txt -R0/6/0/6 -Jx1i -B -Wthinner
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_7.sh
+++ b/doc/scripts/GMT_tut_7.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_7 ps
+gmt begin GMT_tut_7
   gmt plot @tut_data.txt -R0/6/0/6 -Jx1i -B -Wthinner
 gmt end

--- a/doc/scripts/GMT_tut_8.sh
+++ b/doc/scripts/GMT_tut_8.sh
@@ -2,4 +2,4 @@
 gmt begin GMT_tut_8
   gmt plot @tut_data.txt -R0/6/0/6 -Jx1i -Baf -Wthinner 
   gmt plot tut_data.txt -W -Si0.2i 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_8.sh
+++ b/doc/scripts/GMT_tut_8.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_8 ps
+gmt begin GMT_tut_8
   gmt plot @tut_data.txt -R0/6/0/6 -Jx1i -Baf -Wthinner 
   gmt plot tut_data.txt -W -Si0.2i 
 gmt end

--- a/doc/scripts/GMT_tut_9.sh
+++ b/doc/scripts/GMT_tut_9.sh
@@ -3,4 +3,4 @@ gmt begin GMT_tut_9
   gmt makecpt -Cred,green,blue -T0,100,300,10000
   gmt coast -R130/150/35/50 -JM6i -B5 -Ggray 
   gmt plot @tut_quakes.ngdc -Wfaint -i4,3,5,6+s0.1 -h3 -Scc -C -Vl
-gmt end
+gmt end show

--- a/doc/scripts/GMT_tut_9.sh
+++ b/doc/scripts/GMT_tut_9.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_tut_9 ps
+gmt begin GMT_tut_9
   gmt makecpt -Cred,green,blue -T0,100,300,10000
   gmt coast -R130/150/35/50 -JM6i -B5 -Ggray 
   gmt plot @tut_quakes.ngdc -Wfaint -i4,3,5,6+s0.1 -h3 -Scc -C -Vl

--- a/doc/scripts/GMT_utm_zones.sh
+++ b/doc/scripts/GMT_utm_zones.sh
@@ -103,4 +103,4 @@ EOF
 $AWK '{if ($1 < 0) printf "-180 %s %s\\232S\n", $1, -$1}' tt.L.d | gmt text -N -D-0.05i/0 -F+f10p+jRM 
 $AWK '{if ($1 > 0) printf "-180 %s %s\\232N\n", $1,  $1}' tt.L.d | gmt text -N -D-0.05i/0 -F+f10p+jRM
 echo "-180 0 0\\232" | gmt text -N -D-0.05i/0 -F+f10p+jRM
-gmt end
+gmt end show

--- a/doc/scripts/GMT_utm_zones.sh
+++ b/doc/scripts/GMT_utm_zones.sh
@@ -2,7 +2,7 @@
 #
 # Makes a plot of the global UTM zone grid including the exceptions near Norway/Spitsbergen
 #
-gmt begin GMT_utm_zones ps
+gmt begin GMT_utm_zones
 gmt set MAP_FRAME_TYPE plain FORMAT_GEO_MAP dddF MAP_TITLE_OFFSET 0.25i MAP_ANNOT_OFFSET_PRIMARY 0.15i FONT_TITLE 24p FONT_ANNOT_PRIMARY 10p PS_MEDIA 11ix8.5i
 
 gmt coast -Rd -JQ9i -Groyalblue -Sazure -Dl -A2000 -Bx60f6 -By0 -BwsNe

--- a/doc/scripts/GMT_vertscale.sh
+++ b/doc/scripts/GMT_vertscale.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_vertscale ps
+gmt begin GMT_vertscale
 gmt math -T-8/6/0.01 -N3/0 -C2 T 3 DIV 2 POW NEG EXP T PI 2 MUL MUL COS MUL 50 MUL = t.txt
 gmt wiggle -R-10/10/-3/3 -JM6i -Baf -Z100i -DjRM+w100+lnT t.txt -Tfaint -W1p -BWSne --MAP_FRAME_TYPE=plain 
 gmt end

--- a/doc/scripts/GMT_vertscale.sh
+++ b/doc/scripts/GMT_vertscale.sh
@@ -2,4 +2,4 @@
 gmt begin GMT_vertscale
 gmt math -T-8/6/0.01 -N3/0 -C2 T 3 DIV 2 POW NEG EXP T PI 2 MUL MUL COS MUL 50 MUL = t.txt
 gmt wiggle -R-10/10/-3/3 -JM6i -Baf -Z100i -DjRM+w100+lnT t.txt -Tfaint -W1p -BWSne --MAP_FRAME_TYPE=plain 
-gmt end
+gmt end show

--- a/doc/scripts/GMT_volcano.sh
+++ b/doc/scripts/GMT_volcano.sh
@@ -15,4 +15,4 @@ cat <<END > bullseye.def
 0	0	0.1	c	-Gwhite -W0.25p
 END
 echo "0 0" | gmt plot -N -Ba0.25g0.05 -BwSnE -Wthick -Skbullseye/2i -X2.5i
-gmt end
+gmt end show

--- a/doc/scripts/GMT_volcano.sh
+++ b/doc/scripts/GMT_volcano.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_volcano ps
+gmt begin GMT_volcano
 echo "0 0" | gmt plot -R-0.5/0.5/-0.5/0.5 -JX2i -Ba0.25g0.05 -BWSne -Wthick -Skvolcano/2i 
 cat <<END > bullseye.def
 0	-0.7	M	-W0.5p,red

--- a/doc/scripts/gmtest.in
+++ b/doc/scripts/gmtest.in
@@ -182,7 +182,7 @@ export GMT_VERSION="@GMT_PACKAGE_VERSION_WITH_GIT_REVISION@"
 # Disable gmt end show from displaying plots
 export GMT_END_SHOW=off
 # Start with proper GMT defaults
-gmt set -Du PS_CHAR_ENCODING ISOLatin1+
+gmt set -Du PS_CHAR_ENCODING ISOLatin1+ GMT_GRAPHICS_FORMAT ps
 # Tentative PS file name
 ps="${script_name%.sh}.ps"
 # Modern mode needs a stable PPID but ctest messes that up when pipes are used

--- a/doc/scripts/psevents_intensity.sh
+++ b/doc/scripts/psevents_intensity.sh
@@ -48,5 +48,5 @@ gmt begin psevents_intensity
 	1.5 6 DURATION OF EVENT
 	EOF
 	rm -f B.txt t.txt
-gmt end
+gmt end show
 	

--- a/doc/scripts/psevents_intensity.sh
+++ b/doc/scripts/psevents_intensity.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Make a figure illustration intensity curve for an event across time in psevents
-gmt begin psevents_intensity ps
+gmt begin psevents_intensity
 	cat <<- EOF > B.txt
 	-0.5	afg	t@-r@-
 	0	afg	t@-b@-

--- a/doc/scripts/psevents_size.sh
+++ b/doc/scripts/psevents_size.sh
@@ -48,5 +48,5 @@ gmt begin psevents_size
 	1.5 6 DURATION OF EVENT
 	EOF
 	rm -f B.txt t.txt
-gmt end
+gmt end show
 	

--- a/doc/scripts/psevents_size.sh
+++ b/doc/scripts/psevents_size.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Make a figure illustration size curve for an event across time in psevents
-gmt begin psevents_size ps
+gmt begin psevents_size
 	cat <<- EOF > B.txt
 	-0.5	afg	t@-r@-
 	0	afg	t@-b@-

--- a/doc/scripts/psevents_transparency.sh
+++ b/doc/scripts/psevents_transparency.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Make a figure illustrating transparency curve for an event across time in psevents
-gmt begin psevents_transparency ps
+gmt begin psevents_transparency
 	cat <<- EOF > B.txt
 	-0.5	afg	t@-r@-
 	0	afg	t@-b@-

--- a/doc/scripts/psevents_transparency.sh
+++ b/doc/scripts/psevents_transparency.sh
@@ -44,5 +44,5 @@ gmt begin psevents_transparency
 	1.5 120 DURATION OF EVENT
 	EOF
 	rm -f B.txt t.txt
-gmt end
+gmt end show
 	


### PR DESCRIPTION
Like what we did to the examples, I make some changes to the scripts in `doc/scripts` directory.

- remove `ps` from `gmt begin` command. Then we can include these scripts directly into the cookbook, and users can copy&paste the commands and get PDF files
- Set `GMT_GRAPHICS_FORMAT` to `ps` in `gmtest` so that these scripts still generate PS files for tests

All tests still pass.