### PR TITLE
Fix some typos in polar

### DIFF
--- a/doc/rst/source/supplements/seis/polar.rst
+++ b/doc/rst/source/supplements/seis/polar.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-E|\ *color* ]
 [ |-F|\ *color* ]
 [ |-G|\ *color* ]
-[ |-L| ] [ |-N| ]
+[ |-N| ]
 [ |-Q|\ *mode*\ [*args*] ]
 [ |-T|\ *angle*/*form*/*justify*/*fontsize* ]
 [ |SYN_OPT-U| ]

--- a/doc/rst/source/supplements/seis/polar_common.rst_
+++ b/doc/rst/source/supplements/seis/polar_common.rst_
@@ -121,7 +121,7 @@ Optional Arguments
     **-Qt**\ *pen*
         Set pen color to write station code. Default uses the default pen (see |-W|).
 
-.. _-Y:
+.. _-T:
 
 **-T**\ *angle*/*form*/*justify*/*fontsize*
     To write station code; *fontsize* must be given in points [Default is 0.0/0/5/12].

--- a/doc/rst/source/supplements/seis/pspolar.rst
+++ b/doc/rst/source/supplements/seis/pspolar.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-E|\ *color* ]
 [ |-F|\ *color* ]
 [ |-G|\ *color* ]
-[ |-K| ] [ |-L| ] [ |-N| ]
+[ |-K| ] [ |-N| ]
 [ |-O| ]
 [ |-Q|\ *mode*\ [*args*] ]
 [ |-T|\ *angle*/*form*/*justify*/*fontsize* ]

--- a/src/seis/pspolar.c
+++ b/src/seis/pspolar.c
@@ -163,10 +163,9 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-F Specify background color of beach ball. It can be\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   <r/g/b> (each 0-255) for color or <gray> (0-255) for gray-shade [0].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   [Default is no fill].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-G Specify color symbol for station in compressive part. Fill can be either\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-G Specify color symbol for station in compressive part.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Fill can be either <r/g/b> (each 0-255) for color\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   or <gray> (0-255) for gray-shade [0].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Add L[<pen>] to outline [Default is black].\n");
 	GMT_Option (API, "K");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Do Not skip/clip symbols that fall outside map border\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   [Default will ignore those outside].\n");


### PR DESCRIPTION
I don't see any -L<pen> option in the polar source code.