### PR TITLE
docs: Use literalinclude directive to include scripts into the cookbook

### DIFF
--- a/doc/rst/source/cookbook/contour_annotations.rst
+++ b/doc/rst/source/cookbook/contour_annotations.rst
@@ -307,12 +307,8 @@ Our first example uses the default placement algorithm. Because of the
 size of the map we request contour labels every 1.5 inches along the
 lines:
 
-    ::
 
-     gmt begin GMT_App_O_1
-       gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500
-       gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+f8p -Gd1.5i -S10 -T+lLH
-     gmt end show
+.. literalinclude:: /_verbatim/GMT_App_O_1.txt
 
 As seen in Figure :ref:`Contour label 1 <Contour_label_1>`, the contours are
 placed rather arbitrary. The string of contours for -40 to
@@ -335,12 +331,7 @@ Fixed number of labels
 We now exercise the option for specifying exactly how many labels each
 contour line should have:
 
-    ::
-
-     gmt begin GMT_App_O_2
-       gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500
-       gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+f8p -Gn1/1i -S10 -T+lLH
-     gmt end show
+.. literalinclude:: /_verbatim/GMT_App_O_2.txt
 
 By selecting only one label per contour and requiring that labels only
 be placed on contour lines whose length exceed 1 inch, we achieve the
@@ -364,18 +355,7 @@ nonzero "slop" to be used in the distance calculations: The point on the
 contour closest to our fixed points and within the given maximum
 distance will host the label.
 
-    ::
-
-     cat << EOF > fix.txt
-     80      -8.5
-     55      -7.5
-     102     0
-     130     10.5
-     EOF
-     gmt begin GMT_App_O_3
-       gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500
-       gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+f8p -Gffix.txt/0.1i -S10 -T+lLH
-     gmt end show
+.. literalinclude:: /_verbatim/GMT_App_O_3.txt
 
 The angle of the label is evaluated from the contour line geometry, and
 the final result is shown in Figure :ref:`Contour label 3 <Contour_label_3>`.
@@ -399,12 +379,7 @@ Often, it will suffice to place contours at the imaginary intersections
 between the contour lines and a well-placed straight line segment. The
 **-Gl** or **-GL** algorithms work well in those cases:
 
-    ::
-
-     gmt begin GMT_App_O_4
-       gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500
-       gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+f8p -GLZ-/Z+ -S10 -T+lLH
-     gmt end show
+.. literalinclude:: /_verbatim/GMT_App_O_4.txt
 
 The obvious choice in this example is to specify a great circle between
 the high and the low, thus placing all labels between these extrema.
@@ -432,12 +407,7 @@ on the command line, or (2) we have another data set or lines whose
 intersections we wish to use, the general crossing algorithm makes more
 sense:
 
-    ::
-
-     gmt begin GMT_App_O_5
-       gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500
-       gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+f8p -GX@App_O_cross.txt -S10 -T+lLH
-     gmt end show
+.. literalinclude:: /_verbatim/GMT_App_O_5.txt
 
 .. _Contour_label_5:
 
@@ -471,13 +441,7 @@ so that the label is more readable. We choose the place the labels every
 1000 km along the line and use that distance as the label. The labels
 are placed normal to the line:
 
-    ::
-
-     gmt begin GMT_App_O_6
-       gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500
-       gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+f8p -Gl50/10S/160/10S -S10 -T+l
-       gmt plot -SqD1000k:+g+LD+an+p -Wthick @App_O_transect.txt
-     gmt end show
+.. literalinclude:: /_verbatim/GMT_App_O_6.txt
 
 .. _Contour_label_6:
 
@@ -502,13 +466,7 @@ line, use spherical degrees for placement, append the degree symbol as a
 unit for the labels, choose a rounded rectangular text box, and
 inverse-video the label:
 
-    ::
-
-     gmt begin GMT_App_O_7
-       gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500
-       gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+u" m"+f8p -Gl50/10S/160/10S -S10 -T+l
-       gmt plot -SqD15d:+gblack+fwhite+Ld+o+u@. -Wthick @App_O_transect.txt
-     gmt end show
+.. literalinclude:: /_verbatim/GMT_App_O_7.txt
 
 The output is presented as Figure :ref:`Contour label 7 <Contour_label_7>`.
 
@@ -531,14 +489,7 @@ those records whose distances are multiples of 1500 km and create a
 "fixed points" file that can be used to place labels and specify the
 labels. This is done with **awk**.
 
-    ::
-
-     gmt begin GMT_App_O_8
-       gmt convert -i0,1,4 -Em150 @App_O_transect.txt | $AWK '{print $1,$2,int($3)}' > fix2.txt
-       gmt coast -R50/160/-15/15 -JM5.3i -Gburlywood -Sazure -A500
-       gmt grdcontour @App_O_geoid.nc -B20f10 -BWSne -C10 -A20+d+u" m"+f8p -Gl50/10S/160/10S -S10 -T+l
-     gmt plot -Sqffix2.txt:+g+an+p+Lf+u" m"+f8p -Wthick @App_O_transect.txt
-     gmt end show
+.. literalinclude:: /_verbatim/GMT_App_O_8.txt
 
 The output is presented as Figure :ref:`Contour label 8 <Contour_label_8>`.
 
@@ -562,33 +513,7 @@ Islands [37]_. We lay down a color map based on the travel times and the
 shape of the seafloor, and travel time contours with curved labels as
 well as a few quoted lines. The final script is
 
-    ::
-
-     gmt begin GMT_App_O_9
-       R=-R-85/5/10/55
-       gmt grdgradient @App_O_topo5.nc -Nt1 -A45 -Gtopo5_int.nc
-       gmt set FORMAT_GEO_MAP ddd:mm:ssF FONT_ANNOT_PRIMARY +9p FONT_TITLE 22p
-       gmt project -E-74/41 -C-17/28 -G10 -Q > great_NY_Canaries.txt
-       gmt project -E-74/41 -C2.33/48.87 -G100 -Q > great_NY_Paris.txt
-       km=`echo -17 28 | gmt mapproject -G-74/41+uk -fg --FORMAT_FLOAT_OUT=%.0f -o2`
-       gmt makecpt -Clightred,lightyellow,lightgreen -T0,3,6,100 -N > ttt.cpt
-       gmt grdimage @App_O_ttt.nc -Itopo5_int.nc -Cttt.cpt $R -JM5.3i -nc+t1
-       gmt grdcontour @App_O_ttt.nc -C0.5 -A1+u" hour"+v+f8p,Bookman-Demi \
-       	  -GL80W/31N/17W/26N,17W/28N/17W/50N -S2
-       gmt plot -Wfatter,white great_NY_Canaries.txt
-       gmt coast -B20f5 -BWSne+t"Tsunami travel times from the Canaries" -N1/thick \
-       	  -Glightgray -Wfaint -A500
-       gmt convert great_NY_*.txt -E | gmt plot $R -Sa0.15i -Gred -Wthin
-       gmt plot -Wthick great_NY_Canaries.txt \
-       	-Sqn1:+f8p,Times-Italic+l"Distance Canaries to New York = $km km"+ap+v
-       gmt plot great_NY_Paris.txt -Sc0.08c -Gblack
-       gmt plot -Wthinner great_NY_Paris.txt -SqD1000k:+an+o+gblue+LDk+f7p,Helvetica-Bold,white
-       cat << EOF | gmt text -Gwhite -Wthin -Dj0.1i -F+f8p,Bookman-Demi+j
-       74W	41N	RT	New York
-       2.33E	48.87N	CT	Paris
-       17W	28N	CT	Canaries
-       EOF
-     gmt end show
+.. literalinclude:: /_verbatim/GMT_App_O_9.txt
 
 with the complete illustration presented as Figure
 :ref:`Contour label 9 <Contour_label_9>`.

--- a/doc/rst/source/cookbook/coordinate_transformations.rst
+++ b/doc/rst/source/cookbook/coordinate_transformations.rst
@@ -99,12 +99,7 @@ Figure :ref:`Linear transformation of Cartesian coordinates <GMT_linear>`.
 
 The complete commands given to produce this plot were
 
-   ::
-
-    gmt begin GMT_linear
-      gmt plot -R0/100/0/10 -JX3i/1.5i -Bag -BWSne+gsnow -Wthick,blue,- sqrt.txt
-      gmt plot -St0.1i -N -Gred -Wfaint sqrt10.txt
-    gmt end show
+.. literalinclude:: /_verbatim/GMT_linear.txt
 
 Normally, the user's *x*-values will increase to the right and the
 *y*-values will increase upwards. It should be noted that in many
@@ -210,13 +205,7 @@ Hence, to produce a plot in which the *x*-axis is logarithmic (the
 *y*-axis remains linear, i.e., a semi-log plot), try (Figure :ref:`Logarithmic
 transformation <GMT_log>`)
 
-   ::
-
-    gmt begin GMT_log
-      gmt plot -R1/100/0/10 -Jx1.5il/0.15i -Bx2g3 -Bya2f1g2 -BWSne+gbisque
-          -Wthick,blue,- -h sqrt.txt
-      gmt plot -Ss0.1i -N -Gred -W -h sqrt10.txt
-    gmt end show
+.. literalinclude:: /_verbatim/GMT_log.txt
 
 Note that if *x*- and *y*-scaling are different and a
 :math:`\log_{10}-\log_{10}` plot is desired, the **l** must be
@@ -245,12 +234,7 @@ case P) followed by the desired exponent, in our case 0.5. Since
 to the linear transformation. Thus our command becomes (Figure :ref:`Power
 transformation <GMT_pow>`)
 
-   ::
-
-    gmt begin GMT_pow
-      gmt plot -R0/100/0/10 -Jx0.3ip0.5/0.15i -Bxa1p -Bya2f1 -BWSne+givory -Wthick sqrt.txt
-      gmt plot -Sc0.075i -Ggreen -W sqrt10.txt
-    gmt end show
+.. literalinclude:: /_verbatim/GMT_pow.txt
 
 Linear projection with polar coordinates (**-Jp** **-JP**) :ref:`... <-Jp_full>`
 --------------------------------------------------------------------------------

--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -891,13 +891,7 @@ removes leading zeros from calendar items (e.g., 02 becomes 2).
 
 The next example shows two different ways to annotate an axis portraying 2 days in July 1969:
 
-   ::
-
-     gmt set FORMAT_DATE_MAP "o dd" FORMAT_CLOCK_MAP hh:mm FONT_ANNOT_PRIMARY +9p
-     gmt begin B_time2
-       gmt basemap -R1969-7-21T/1969-7-23T/0/1 -JX5i/0.2i -Bpa6Hf1h -Bsa1K -BS
-       gmt basemap -Bpa6Hf1h -Bsa1D -BS -Y0.65i
-    gmt end show
+.. literalinclude:: /_verbatim/GMT_-B_time2.txt
 
 The lower example (Figure :ref:`cartesian_axis2`) chooses to annotate the weekdays (by
 specifying **a**\ 1\ **K**) while the upper example choses dates (by
@@ -959,15 +953,7 @@ shows ISO weeks with week numbers and abbreviated names of the weekdays.
 The upper uses Gregorian weeks (which start at the day chosen by
 :ref:`TIME_WEEK_START <TIME_WEEK_START>`); they do not have numbers.
 
-   ::
-
-    gmt begin GMT_-B_time5
-      gmt set FORMAT_DATE_MAP u FORMAT_TIME_PRIMARY_MAP Character \
-           FORMAT_TIME_SECONDARY_MAP full FONT_ANNOT_PRIMARY +9p
-      gmt basemap -R1969-7-21T/1969-8-9T/0/1 -JX5i/0.2i -Bpa1K -Bsa1U -BS
-      gmt set FORMAT_DATE_MAP o TIME_WEEK_START Sunday FORMAT_TIME_SECONDARY_MAP Character
-      gmt basemap -Bpa3Kf1k -Bsa1r -BS -Y0.65i
-    gmt end show
+.. literalinclude:: /_verbatim/GMT_-B_time5.txt
 
 .. _cartesian_axis5:
 
@@ -1039,32 +1025,7 @@ value. Our last example (Figure :ref:`Custom and irregular annotations
 <Custom_annotations>`) shows such a custom basemap with an interval
 annotations on the *x*-axis and irregular annotations on the *y*-axis.
 
-   ::
-
-    cat << EOF > xannots.txt
-    416.0 ig Devonian
-    443.7 ig Silurian
-    488.3 ig Ordovician
-    542 ig Cambrian
-    EOF
-    cat << EOF > yannots.txt
-    0 a
-    1 a
-    2 f
-    2.71828 ag e
-    3 f
-    3.1415926 ag @~p@~
-    4 f
-    5 f
-    6 f
-    6.2831852 ag 2@~p@~
-    EOF
-    gmt begin GMT_-B_custom
-    gmt basemap -R416/542/0/6.2831852 -JX-5i/2.5i -Bpx25f5g25+u" Ma" -Bpycyannots.txt -BWS+glightblue
-    gmt basemap -R416/542/0/6.2831852 -JX-5i/2.5i -Bsxcxannots.txt -Bsy0 -BWS \
-        --MAP_ANNOT_OFFSET_SECONDARY=10p --MAP_GRID_PEN_SECONDARY=2p
-    gmt end show
-    rm -f [xy]annots.txt
+.. literalinclude:: /_verbatim/GMT_-B_custom.txt
 
 .. _Custom_annotations:
 


### PR DESCRIPTION
Most of the code blocks in the cookbook are copied from the bash scripts in the `doc/scripts` directory.
Using `literalincldue` directive to avoid maintain two duplicate scripts at different
places.