### PR TITLE
docs: literalinclude more scripts to the cookbook

### DIFF
--- a/doc/rst/source/cookbook/coordinate_transformations.rst
+++ b/doc/rst/source/cookbook/coordinate_transformations.rst
@@ -135,11 +135,7 @@ appending a **g** or **d** to the end of the **-Jx** (or **-JX**)
 option. As an example, we want to plot a crude world map centered on
 125ºE. Our command will be
 
-  ::
-
-    gmt set MAP_GRID_CROSS_SIZE_PRIMARY 0.1i MAP_FRAME_TYPE FANCY FORMAT_GEO_MAP ddd:mm:ssF
-    gmt coast -Rg-55/305/-90/90 -Jx0.014i -Bagf -BWSen -Dc -A1000 -Glightbrown -Wthinnest \
-        -Slightblue -pdf GMT_linear_d
+.. literalinclude:: /_verbatim/GMT_linear_d.txt
 
 with the result reproduced in
 Figure :ref:`Linear transformation of map coordinates <GMT_Linear_d>`.
@@ -179,12 +175,8 @@ projection type given by **-JX** (including the optional **d**, **g**,
 **t** or **T**) conflict, GMT will warn the users about it. In
 general, the options provided with **-JX** will prevail.
 
-   ::
+.. literalinclude:: /_verbatim/GMT_linear_cal.txt
 
-    gmt set FORMAT_DATE_MAP o TIME_WEEK_START Sunday FORMAT_CLOCK_MAP=-hham
-            FORMAT_TIME_PRIMARY_MAP full
-    gmt basemap -R2001-9-24T/2001-9-29T/T07:0/T15:0 -JX4i/-2i -Bxa1Kf1kg1d
-            -Bya1Hg1h -BWsNe+glightyellow -pdf GMT_linear_cal
 
 Cartesian logarithmic projection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -288,10 +280,7 @@ polar coordinates :math:`z(\theta, r) = r^2 \cdot \cos{4\theta}` using
 :doc:`/grdmath`, a RPN calculator that
 operates on or creates grid files.
 
-   ::
-
-    gmt grdmath -R0/360/2/4 -I6/0.1 X 4 MUL PI MUL 180 DIV COS Y 2 POW MUL = tt.nc
-    gmt grdcontour tt.nc -JP3i -B30 -BNs+ghoneydew -C2 -S4 --FORMAT_GEO_MAP=+ddd -pdf GMT_polar
+.. literalinclude:: /_verbatim/GMT_polar.txt
 
 We used :doc:`/grdcontour` to make a
 contour map of this data. Because the data file only contains values

--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -872,10 +872,7 @@ annotations are supported for all axes.
 Our first example shows a time period of almost two months in Spring
 2000. We want to annotate the month intervals as well as the date at the start of each week:
 
-   ::
-
-     gmt set FORMAT_DATE_MAP=-o FONT_ANNOT_PRIMARY +9p
-     gmt basemap -R2000-4-1T/2000-5-25T/0/1 -JX5i/0.2i -Bpa7Rf1d -Bsa1O -BS -pdf GMT_-B_time1
+.. literalinclude:: /_verbatim/GMT_-B_time1.txt
 
 These commands result in Figure :ref:`Cartesian time axis <cartesian_axis1>`.
 Note the leading hyphen in the :ref:`FORMAT_DATE_MAP <FORMAT_DATE_MAP>`
@@ -910,10 +907,7 @@ followed by one space and a two-digit day-of-month number.
 The third example (Figure :ref:`cartesian_axis3`) presents two years, annotating
 both the years and every 3rd month.
 
-   ::
-
-     gmt set FORMAT_DATE_MAP o FORMAT_TIME_PRIMARY_MAP Character FONT_ANNOT_PRIMARY +9p
-     gmt basemap -R1997T/1999T/0/1 -JX5i/0.2i -Bpa3Of1o -Bsa1Y -BS -pdf GMT_-B_time3
+.. literalinclude:: /_verbatim/GMT_-B_time3.txt
 
 Note that while the year annotation is centered on the 1-year interval,
 the month annotations must be centered on the corresponding month and
@@ -935,10 +929,7 @@ relative time by specifying **t** in the **-R** option while the
 :ref:`TIME_UNIT <TIME_UNIT>` is **d** (for days). We select both primary and secondary
 annotations, ask for a 12-hour clock, and let time go from right to left:
 
-   ::
-
-     gmt set FORMAT_CLOCK_MAP=-hham FONT_ANNOT_PRIMARY +9p TIME_UNIT d
-     gmt basemap -R0.2t/0.35t/0/1 -JX-5i/0.2i -Bpa15mf5m -Bsa1H -BS -pdf GMT_-B_time4
+.. literalinclude:: /_verbatim/GMT_-B_time4.txt
 
 .. _cartesian_axis4:
 
@@ -967,10 +958,7 @@ Our sixth example (Figure :ref:`cartesian_axis6`) shows the first five months of
 1996, and we have annotated each month with an abbreviated, upper case name and
 2-digit year. Only the primary axes information is specified.
 
-   ::
-
-    gmt set FORMAT_DATE_MAP "o yy" FORMAT_TIME_PRIMARY_MAP Abbreviated
-    gmt basemap -R1996T/1996-6T/0/1 -JX5i/0.2i -Ba1Of1d -BS -pdf GMT_-B_time6
+.. literalinclude:: /_verbatim/GMT_-B_time6.txt
 
 .. _cartesian_axis6:
 
@@ -987,10 +975,7 @@ in order to have the two years annotated we need to allow for the annotation of
 small fractional intervals; normally such truncated interval must be at
 least half of a full interval.
 
-   ::
-
-    gmt set FORMAT_DATE_MAP jjj TIME_INTERVAL_FRACTION 0.05 FONT_ANNOT_PRIMARY +9p
-    gmt basemap -R2000-12-15T/2001-1-15T/0/1 -JX5i/0.2i -Bpa5Df1d -Bsa1Y -BS -pdf GMT_-B_time7
+.. literalinclude:: /_verbatim/GMT_-B_time7.txt
 
 .. _cartesian_axis7:
 

--- a/doc/rst/source/cookbook/map_projections.rst
+++ b/doc/rst/source/cookbook/map_projections.rst
@@ -239,8 +239,7 @@ rectangular by defining the corners of a rectangular map boundary. Using
    ::
 
     gmt set FORMAT_GEO_MAP ddd:mm:ssF MAP_GRID_CROSS_SIZE_PRIMARY 0
-    gmt coast -R0/-40/60/-10r -JA30/-30/4.5i -Bag -Dl -A500 -Gp300/10
-              -Wthinnest -pdf GMT_lambert_az_rect
+    gmt coast -R0/-40/60/-10r -JA30/-30/4.5i -Bag -Dl -A500 -Gp300/10 -Wthinnest -pdf GMT_lambert_az_rect
 
 .. figure:: /_images/GMT_lambert_az_rect.*
    :width: 500 px

--- a/doc/rst/source/nearneighbor.rst
+++ b/doc/rst/source/nearneighbor.rst
@@ -1,8 +1,8 @@
 .. index:: ! nearneighbor
 
-**************
+************
 nearneighbor
-**************
+************
 
 .. only:: not man
 
@@ -45,7 +45,7 @@ is computed as a weighted mean of the nearest point from each sector
 inside the search radius. The weighting function used is w(r) = 1 / (1 +
 d ^ 2), where d = 3 \* r / search_radius and r is distance from the
 node. This weight is modulated by the weights of the observation points [if
-supplied]. 
+supplied].
 
 Required Arguments
 ------------------
@@ -53,7 +53,7 @@ Required Arguments
 .. _-G:
 
 **-G**\ *out_grdfile*
-    Give the name of the output grid file. 
+    Give the name of the output grid file.
 
 .. _-I:
 
@@ -70,7 +70,7 @@ Required Arguments
     of *sectors* (i.e., rounded up to next integer) [Default is a quadrant
     search with 100% coverage, i.e., *sectors* = *min_sectors* = 4]. Note
     that only the nearest value per sector enters into the averaging; the
-    more distant points are ignored. 
+    more distant points are ignored.
 
 .. _-R:
 
@@ -94,7 +94,7 @@ Optional Arguments
 .. _-E:
 
 **-E**\ *empty*
-    Set the value assigned to empty nodes [NaN]. 
+    Set the value assigned to empty nodes [NaN].
 
 .. _-V:
 
@@ -106,9 +106,9 @@ Optional Arguments
 **-W**
    Input data have a 4th column containing observation point weights.
    These are multiplied with the geometrical weight factor to determine
-   the actual weights used in the calculations. 
+   the actual weights used in the calculations.
 
-.. |Add_-bi| replace:: [Default is 3 (or 4 if **-W** is set) columns]. 
+.. |Add_-bi| replace:: [Default is 3 (or 4 if **-W** is set) columns].
 .. include:: explain_-bi.rst_
 
 .. |Add_-di| unicode:: 0x20 .. just an invisible code
@@ -130,7 +130,7 @@ Optional Arguments
    adding **g** for geographic, **p** for periodic, or **n** for
    natural boundary conditions. For the latter two you may append **x**
    or **y** to specify just one direction, otherwise both are assumed.
-   [Default is geographic if grid is geographic]. 
+   [Default is geographic if grid is geographic].
 
 .. |Add_nodereg| unicode:: 0x20 .. just an invisible code
 .. include:: explain_nodereg.rst_
@@ -150,7 +150,7 @@ Examples
 
 To grid the data in the remote file @ship_15.txt at 5x5 arc minutes using
 a search radius of 15 arch minutes, and plot the resulting grid using
-default projection and colors, try:
+default projection and colors, try::
 
     gmt begin map
       gmt nearneighbor @ship_15.txt -R245/255/20/30 -I5m -Ggrid.nc -S15m
@@ -159,9 +159,7 @@ default projection and colors, try:
 
 To create a gridded data set from the file seaMARCII_bathy.lon_lat_z
 using a 0.5 min grid, a 5 km search radius, using an octant search with
-100% sector coverage, and set empty nodes to -9999:
-
-   ::
+100% sector coverage, and set empty nodes to -9999::
 
     gmt nearneighbor seaMARCII_bathy.lon_lat_z -R242/244/-22/-20 -I0.5m \
                      -E-9999 -Gbathymetry.nc -S5k -N8+m8
@@ -169,9 +167,7 @@ using a 0.5 min grid, a 5 km search radius, using an octant search with
 To make a global grid file from the data in geoid.xyz using a 1 degree
 grid, a 200 km search radius, spherical distances, using an quadrant
 search, and set nodes to NaN only when fewer than two quadrants contain
-at least one value:
-
-   ::
+at least one value::
 
     gmt nearneighbor geoid.xyz -R0/360/-90/90 -I1 -Lg -Ggeoid.nc -S200k -N4
 

--- a/doc/scripts/GMT_-B_time1.sh
+++ b/doc/scripts/GMT_-B_time1.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+gmt begin GMT_-B_time1
 gmt set FORMAT_DATE_MAP=-o FONT_ANNOT_PRIMARY +9p
-gmt basemap -R2000-4-1T/2000-5-25T/0/1 -JX5i/0.2i -Bpa7Rf1d -Bsa1O -BS -ps GMT_-B_time1
+gmt basemap -R2000-4-1T/2000-5-25T/0/1 -JX5i/0.2i -Bpa7Rf1d -Bsa1O -BS
+gmt end show

--- a/doc/scripts/GMT_-B_time3.sh
+++ b/doc/scripts/GMT_-B_time3.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+gmt begin GMT_-B_time3
 gmt set FORMAT_DATE_MAP o FORMAT_TIME_PRIMARY_MAP Character FONT_ANNOT_PRIMARY +9p
-gmt basemap -R1997T/1999T/0/1 -JX5i/0.2i -Bpa3Of1o -Bsa1Y -BS -ps GMT_-B_time3
+gmt basemap -R1997T/1999T/0/1 -JX5i/0.2i -Bpa3Of1o -Bsa1Y -BS
+gmt end show

--- a/doc/scripts/GMT_-B_time4.sh
+++ b/doc/scripts/GMT_-B_time4.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+gmt begin GMT_-B_time4
 gmt set FORMAT_CLOCK_MAP=-hham FONT_ANNOT_PRIMARY +9p TIME_UNIT d
-gmt basemap -R0.2t/0.35t/0/1 -JX-5i/0.2i -Bpa15mf5m -Bsa1H -BS -ps GMT_-B_time4
+gmt basemap -R0.2t/0.35t/0/1 -JX-5i/0.2i -Bpa15mf5m -Bsa1H -BS
+gmt end show

--- a/doc/scripts/GMT_-B_time6.sh
+++ b/doc/scripts/GMT_-B_time6.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+gmt begin GMT_-B_time6
 gmt set FORMAT_DATE_MAP "o yy" FORMAT_TIME_PRIMARY_MAP Abbreviated
-gmt basemap -R1996T/1996-6T/0/1 -JX5i/0.2i -Ba1Of1d -BS -ps GMT_-B_time6
+gmt basemap -R1996T/1996-6T/0/1 -JX5i/0.2i -Ba1Of1d -BS
+gmt end show

--- a/doc/scripts/GMT_-B_time7.sh
+++ b/doc/scripts/GMT_-B_time7.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+gmt begin GMT_-B_time7
 gmt set FORMAT_DATE_MAP jjj TIME_INTERVAL_FRACTION 0.05 FONT_ANNOT_PRIMARY +9p
-gmt basemap -R2000-12-15T/2001-1-15T/0/1 -JX5i/0.2i -Bpa5Df1d -Bsa1Y -BS -ps GMT_-B_time7
+gmt basemap -R2000-12-15T/2001-1-15T/0/1 -JX5i/0.2i -Bpa5Df1d -Bsa1Y -BS
+gmt end show

--- a/doc/scripts/GMT_linear_cal.sh
+++ b/doc/scripts/GMT_linear_cal.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+gmt begin GMT_linear_cal
 gmt set FORMAT_DATE_MAP o TIME_WEEK_START Sunday FORMAT_CLOCK_MAP=-hham FORMAT_TIME_PRIMARY_MAP full
-gmt basemap -R2001-9-24T/2001-9-29T/T07:0/T15:0 -JX4i/-2i -Bxa1Kf1kg1d -Bya1Hg1h -BWsNe+glightyellow -ps GMT_linear_cal
+gmt basemap -R2001-9-24T/2001-9-29T/T07:0/T15:0 -JX4i/-2i -Bxa1Kf1kg1d -Bya1Hg1h -BWsNe+glightyellow
+gmt end show

--- a/doc/scripts/GMT_linear_d.sh
+++ b/doc/scripts/GMT_linear_d.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+gmt begin GMT_linear_d
 gmt set MAP_GRID_CROSS_SIZE_PRIMARY 0.1i MAP_FRAME_TYPE FANCY FORMAT_GEO_MAP ddd:mm:ssF
-gmt coast -Rg-55/305/-90/90 -Jx0.014i -Bagf -BWSen -Dc -A1000 -Glightbrown -Wthinnest -Slightblue -ps GMT_linear_d
+gmt coast -Rg-55/305/-90/90 -Jx0.014i -Bagf -BWSen -Dc -A1000 -Glightbrown -Wthinnest -Slightblue
+gmt end show


### PR DESCRIPTION
Some "one-liner" scripts actually have two commands, `gmt set` and `gmt basesmap`.
I change these scripts to the "normal" modern mode, and use
literalinclude to include them to the cookbook.