### PR TITLE
docs: New design of example gallery

### DIFF
--- a/doc/rst/CMakeLists.txt
+++ b/doc/rst/CMakeLists.txt
@@ -47,6 +47,10 @@ if (SPHINX_FOUND)
 		${CMAKE_CURRENT_BINARY_DIR}/_templates)
 	add_depend_to_target (docs_html_depends _docs_copy_rst_tree_templates)
 	add_depend_to_target (docs_man_depends _docs_copy_rst_tree_templates)
+	copy_dir_if_different (_docs_copy_rst_tree_extensions
+		${CMAKE_CURRENT_SOURCE_DIR}/_extensions/
+		${CMAKE_CURRENT_BINARY_DIR}/_extensions)
+	add_depend_to_target (docs_html_depends _docs_copy_rst_tree_extensions)
 	add_custom_target (_docs_rst_mkdir_verbatim
 		COMMAND ${CMAKE_COMMAND} -E make_directory
 		${CMAKE_CURRENT_BINARY_DIR}/_source/_verbatim

--- a/doc/rst/_extensions/jinja.py
+++ b/doc/rst/_extensions/jinja.py
@@ -1,0 +1,111 @@
+#
+# The sphinx-jinja extension is available from https://github.com/tardyp/sphinx-jinja,
+# licensed under the MIT License.
+#
+#
+# The MIT License
+#
+# Copyright (c) 2016-2019 Pierre Tardy
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+import codecs
+import os
+import sys
+import urllib
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives
+from docutils.statemachine import StringList
+from jinja2 import FileSystemLoader, Environment
+import sphinx.util
+
+
+class JinjaDirective(Directive):
+    has_content = True
+    optional_arguments = 1
+    option_spec = {
+        "file": directives.path,
+        "header_char": directives.unchanged,
+        "debug": directives.unchanged,
+    }
+    app = None
+
+    def run(self):
+        node = nodes.Element()
+        node.document = self.state.document
+        env = self.state.document.settings.env
+        docname = env.docname
+        template_filename = self.options.get("file")
+        debug_template = self.options.get("debug")
+        cxt = (self.app.config.jinja_contexts[self.arguments[0]].copy()
+               if self.arguments else {})
+        cxt["options"] = {
+            "header_char": self.options.get("header_char")
+        }
+        if template_filename:
+            if debug_template is not None:
+                print('')
+                print('********** Begin Jinja Debug Output: Template Before Processing **********')
+                print('********** From {} **********'.format(docname))
+                reference_uri = directives.uri(os.path.join('source', template_filename))
+                template_path = urllib.url2pathname(reference_uri)
+                encoded_path = template_path.encode(sys.getfilesystemencoding())
+                imagerealpath = os.path.abspath(encoded_path)
+                with codecs.open(imagerealpath, encoding='utf-8') as f:
+                    print(f.read())
+                print('********** End Jinja Debug Output: Template Before Processing **********')
+                print('')
+            tpl = Environment(
+                          loader=FileSystemLoader(
+                              self.app.config.jinja_base, followlinks=True)
+                      ).get_template(template_filename)
+        else:
+            if debug_template is not None:
+                print('')
+                print('********** Begin Jinja Debug Output: Template Before Processing **********')
+                print('********** From {} **********'.format(docname))
+                print('\n'.join(self.content))
+                print('********** End Jinja Debug Output: Template Before Processing **********')
+                print('')
+            tpl = Environment(
+                      loader=FileSystemLoader(
+                          self.app.config.jinja_base, followlinks=True)
+                  ).from_string('\n'.join(self.content))
+        new_content = tpl.render(**cxt)
+        if debug_template is not None:
+            print('')
+            print('********** Begin Jinja Debug Output: Template After Processing **********')
+            print(new_content)
+            print('********** End Jinja Debug Output: Template After Processing **********')
+            print('')
+        new_content = StringList(new_content.splitlines(), source='')
+        sphinx.util.nested_parse_with_titles(
+            self.state, new_content, node)
+        return node.children
+
+
+def setup(app):
+    JinjaDirective.app = app
+    app.add_directive('jinja', JinjaDirective)
+    app.add_config_value('jinja_contexts', {}, 'env')
+    app.add_config_value('jinja_base', os.path.abspath('.'), 'env')
+    return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/doc/rst/_static/style.css
+++ b/doc/rst/_static/style.css
@@ -17,3 +17,10 @@
 .hlist {
     width: 100%;
 }
+
+#example-gallery ul li {
+    list-style: none;
+    width: 180px;
+    display: inline-grid;
+    margin-right: 15px;
+}

--- a/doc/rst/_static/style.css
+++ b/doc/rst/_static/style.css
@@ -18,6 +18,7 @@
     width: 100%;
 }
 
+/* style for example gallery */
 #example-gallery ul li {
     list-style: none;
     width: 180px;

--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -3,10 +3,12 @@
 # GMT documentation build configuration file.
 # Refer to http://www.sphinx-doc.org/en/master/usage/configuration.html for details.
 #
+import sys, os
+sys.path.append(os.path.abspath('_extensions'))
 
 # -- General configuration -----------------------------------------------------
 needs_sphinx = '1.8'
-extensions = ['sphinx.ext.mathjax']
+extensions = ['sphinx.ext.mathjax', 'jinja']
 source_encoding = 'utf-8-sig'
 source_suffix = '.rst'
 master_doc = 'index'

--- a/doc/rst/source/gallery.rst
+++ b/doc/rst/source/gallery.rst
@@ -3,6 +3,9 @@
 Example Gallery
 ===============
 
+.. Don't change anything before this line unless you know what you're doing.
+.. The title is used as a CSS ID in style.css
+
 The 50 Examples
 ----------------
 
@@ -13,425 +16,39 @@ diagram or map view. The resulting plots will have in common that they
 are all made up of simpler plots that have been overlaid to create a
 complex illustration.
 
-+------------------+--------------------+
-|:ref:`example_01` | :ref:`example_02`  |
-|                  |                    |
-| |ex01|           | |ex02|             |
-+------------------+--------------------+
-|:ref:`example_03` | :ref:`example_04`  |
-|                  |                    |
-| |ex03|           | |ex04|             |
-+------------------+--------------------+
-|:ref:`example_05` | :ref:`example_06`  |
-|                  |                    |
-| |ex05|           | |ex06|             |
-+------------------+--------------------+
-|:ref:`example_07` | :ref:`example_08`  |
-|                  |                    |
-| |ex07|           | |ex08|             |
-+------------------+--------------------+
-|:ref:`example_09` | :ref:`example_10`  |
-|                  |                    |
-| |ex09|           | |ex10|             |
-+------------------+--------------------+
-|:ref:`example_11` | :ref:`example_12`  |
-|                  |                    |
-| |ex11|           | |ex12|             |
-+------------------+--------------------+
-|:ref:`example_13` | :ref:`example_14`  |
-|                  |                    |
-| |ex13|           | |ex14|             |
-+------------------+--------------------+
-|:ref:`example_15` | :ref:`example_16`  |
-|                  |                    |
-| |ex15|           | |ex16|             |
-+------------------+--------------------+
-|:ref:`example_17` | :ref:`example_18`  |
-|                  |                    |
-| |ex17|           | |ex18|             |
-+------------------+--------------------+
-|:ref:`example_19` | :ref:`example_20`  |
-|                  |                    |
-| |ex19|           | |ex20|             |
-+------------------+--------------------+
-|:ref:`example_21` | :ref:`example_22`  |
-|                  |                    |
-| |ex21|           | |ex22|             |
-+------------------+--------------------+
-|:ref:`example_23` | :ref:`example_24`  |
-|                  |                    |
-| |ex23|           | |ex24|             |
-+------------------+--------------------+
-|:ref:`example_25` | :ref:`example_26`  |
-|                  |                    |
-| |ex25|           | |ex26|             |
-+------------------+--------------------+
-|:ref:`example_27` | :ref:`example_28`  |
-|                  |                    |
-| |ex27|           | |ex28|             |
-+------------------+--------------------+
-|:ref:`example_29` | :ref:`example_30`  |
-|                  |                    |
-| |ex29|           | |ex30|             |
-+------------------+--------------------+
-|:ref:`example_31` | :ref:`example_32`  |
-|                  |                    |
-| |ex31|           | |ex32|             |
-+------------------+--------------------+
-|:ref:`example_33` | :ref:`example_34`  |
-|                  |                    |
-| |ex33|           | |ex34|             |
-+------------------+--------------------+
-|:ref:`example_35` | :ref:`example_36`  |
-|                  |                    |
-| |ex35|           | |ex36|             |
-+------------------+--------------------+
-|:ref:`example_37` | :ref:`example_38`  |
-|                  |                    |
-| |ex37|           | |ex38|             |
-+------------------+--------------------+
-|:ref:`example_39` | :ref:`example_40`  |
-|                  |                    |
-| |ex39|           | |ex40|             |
-+------------------+--------------------+
-|:ref:`example_41` | :ref:`example_42`  |
-|                  |                    |
-| |ex41|           | |ex42|             |
-+------------------+--------------------+
-|:ref:`example_43` | :ref:`example_44`  |
-|                  |                    |
-| |ex43|           | |ex44|             |
-+------------------+--------------------+
-|:ref:`example_45` | :ref:`example_46`  |
-|                  |                    |
-| |ex45|           | |ex46|             |
-+------------------+--------------------+
-|:ref:`example_47` | :ref:`example_48`  |
-|                  |                    |
-| |ex47|           | |ex48|             |
-+------------------+--------------------+
-|:ref:`example_49` | :ref:`example_50`  |
-|                  |                    |
-| |ex49|           | |ex50|             |
-+------------------+--------------------+
+.. jinja::
 
-.. |ex01| image:: /_images/ex01.*
-   :width: 150 px
-   :target: ./gallery/ex01.html
+   {% for i in range(1, 51) %}
+   {% set i = '%02d' % i %}
+   -  .. figure:: /_images/ex{{i}}.*
+         :target: ./gallery/ex{{i}}.html
 
-.. |ex02| image:: /_images/ex02.*
-   :width: 150 px
-   :target: ./gallery/ex02.html
-
-.. |ex03| image:: /_images/ex03.*
-   :width: 150 px
-   :target: ./gallery/ex03.html
-
-.. |ex04| image:: /_images/ex04.*
-   :width: 150 px
-   :target: ./gallery/ex04.html
-
-.. |ex05| image:: /_images/ex05.*
-   :width: 150 px
-   :target: ./gallery/ex05.html
-
-.. |ex06| image:: /_images/ex06.*
-   :width: 150 px
-   :target: ./gallery/ex06.html
-
-.. |ex07| image:: /_images/ex07.*
-   :width: 150 px
-   :target: ./gallery/ex07.html
-
-.. |ex08| image:: /_images/ex08.*
-   :width: 150 px
-   :target: ./gallery/ex08.html
-
-.. |ex09| image:: /_images/ex09.*
-   :width: 150 px
-   :target: ./gallery/ex09.html
-
-.. |ex10| image:: /_images/ex10.*
-   :width: 150 px
-   :target: ./gallery/ex10.html
-
-.. |ex11| image:: /_images/ex11.*
-   :width: 150 px
-   :target: ./gallery/ex11.html
-
-.. |ex12| image:: /_images/ex12.*
-   :width: 150 px
-   :target: ./gallery/ex12.html
-
-.. |ex13| image:: /_images/ex13.*
-   :width: 150 px
-   :target: ./gallery/ex13.html
-
-.. |ex14| image:: /_images/ex14.*
-   :width: 150 px
-   :target: ./gallery/ex14.html
-
-.. |ex15| image:: /_images/ex15.*
-   :width: 150 px
-   :target: ./gallery/ex15.html
-
-.. |ex16| image:: /_images/ex16.*
-   :width: 150 px
-   :target: ./gallery/ex16.html
-
-.. |ex17| image:: /_images/ex17.*
-   :width: 150 px
-   :target: ./gallery/ex17.html
-
-.. |ex18| image:: /_images/ex18.*
-   :width: 150 px
-   :target: ./gallery/ex18.html
-
-.. |ex19| image:: /_images/ex19.*
-   :width: 150 px
-   :target: ./gallery/ex19.html
-
-.. |ex20| image:: /_images/ex20.*
-   :width: 150 px
-   :target: ./gallery/ex20.html
-
-.. |ex21| image:: /_images/ex21.*
-   :width: 150 px
-   :target: ./gallery/ex21.html
-
-.. |ex22| image:: /_images/ex22.*
-   :width: 150 px
-   :target: ./gallery/ex22.html
-
-.. |ex23| image:: /_images/ex23.*
-   :width: 150 px
-   :target: ./gallery/ex23.html
-
-.. |ex24| image:: /_images/ex24.*
-   :width: 150 px
-   :target: ./gallery/ex24.html
-
-.. |ex25| image:: /_images/ex25.*
-   :width: 150 px
-   :target: ./gallery/ex25.html
-
-.. |ex26| image:: /_images/ex26.*
-   :width: 150 px
-   :target: ./gallery/ex26.html
-
-.. |ex27| image:: /_images/ex27.*
-   :width: 150 px
-   :target: ./gallery/ex27.html
-
-.. |ex28| image:: /_images/ex28.*
-   :width: 150 px
-   :target: ./gallery/ex28.html
-
-.. |ex29| image:: /_images/ex29.*
-   :width: 150 px
-   :target: ./gallery/ex29.html
-
-.. |ex30| image:: /_images/ex30.*
-   :width: 150 px
-   :target: ./gallery/ex30.html
-
-.. |ex31| image:: /_images/ex31.*
-   :width: 150 px
-   :target: ./gallery/ex31.html
-
-.. |ex32| image:: /_images/ex32.*
-   :width: 150 px
-   :target: ./gallery/ex32.html
-
-.. |ex33| image:: /_images/ex33.*
-   :width: 150 px
-   :target: ./gallery/ex33.html
-
-.. |ex34| image:: /_images/ex34.*
-   :width: 150 px
-   :target: ./gallery/ex34.html
-
-.. |ex35| image:: /_images/ex35.*
-   :width: 150 px
-   :target: ./gallery/ex35.html
-
-.. |ex36| image:: /_images/ex36.*
-   :width: 150 px
-   :target: ./gallery/ex36.html
-
-.. |ex37| image:: /_images/ex37.*
-   :width: 150 px
-   :target: ./gallery/ex37.html
-
-.. |ex38| image:: /_images/ex38.*
-   :width: 150 px
-   :target: ./gallery/ex38.html
-
-.. |ex39| image:: /_images/ex39.*
-   :width: 150 px
-   :target: ./gallery/ex39.html
-
-.. |ex40| image:: /_images/ex40.*
-   :width: 150 px
-   :target: ./gallery/ex40.html
-
-.. |ex41| image:: /_images/ex41.*
-   :width: 150 px
-   :target: ./gallery/ex41.html
-
-.. |ex42| image:: /_images/ex42.*
-   :width: 150 px
-   :target: ./gallery/ex42.html
-
-.. |ex43| image:: /_images/ex43.*
-   :width: 150 px
-   :target: ./gallery/ex43.html
-
-.. |ex44| image:: /_images/ex44.*
-   :width: 150 px
-   :target: ./gallery/ex44.html
-
-.. |ex45| image:: /_images/ex45.*
-   :width: 150 px
-   :target: ./gallery/ex45.html
-
-.. |ex46| image:: /_images/ex46.*
-   :width: 150 px
-   :target: ./gallery/ex46.html
-
-.. |ex47| image:: /_images/ex47.*
-   :width: 150 px
-   :target: ./gallery/ex47.html
-
-.. |ex48| image:: /_images/ex48.*
-   :width: 150 px
-   :target: ./gallery/ex48.html
-
-.. |ex49| image:: /_images/ex49.*
-   :width: 150 px
-   :target: ./gallery/ex49.html
-
-.. |ex50| image:: /_images/ex50.*
-   :width: 150 px
-   :target: ./gallery/ex50.html
+         :ref:`example_{{i}}`
+   {% endfor %}
 
 .. toctree::
    :hidden:
+   :glob:
 
-   gallery/ex01.rst
-   gallery/ex02.rst
-   gallery/ex03.rst
-   gallery/ex04.rst
-   gallery/ex05.rst
-   gallery/ex06.rst
-   gallery/ex07.rst
-   gallery/ex08.rst
-   gallery/ex09.rst
-   gallery/ex10.rst
-   gallery/ex11.rst
-   gallery/ex12.rst
-   gallery/ex13.rst
-   gallery/ex14.rst
-   gallery/ex15.rst
-   gallery/ex16.rst
-   gallery/ex17.rst
-   gallery/ex18.rst
-   gallery/ex19.rst
-   gallery/ex20.rst
-   gallery/ex21.rst
-   gallery/ex22.rst
-   gallery/ex23.rst
-   gallery/ex24.rst
-   gallery/ex25.rst
-   gallery/ex26.rst
-   gallery/ex27.rst
-   gallery/ex28.rst
-   gallery/ex29.rst
-   gallery/ex30.rst
-   gallery/ex31.rst
-   gallery/ex32.rst
-   gallery/ex33.rst
-   gallery/ex34.rst
-   gallery/ex35.rst
-   gallery/ex36.rst
-   gallery/ex37.rst
-   gallery/ex38.rst
-   gallery/ex39.rst
-   gallery/ex40.rst
-   gallery/ex41.rst
-   gallery/ex42.rst
-   gallery/ex43.rst
-   gallery/ex44.rst
-   gallery/ex45.rst
-   gallery/ex46.rst
-   gallery/ex47.rst
-   gallery/ex48.rst
-   gallery/ex49.rst
-   gallery/ex50.rst
-
+   gallery/ex*
 
 Animations
 ----------
 
-+------------------+----------------+
-|:ref:`anim_01`    | :ref:`anim_02` |
-|                  |                |
-| |anim01|         | |anim02|       |
-+------------------+----------------+
-|:ref:`anim_03`    | :ref:`anim_04` |
-|                  |                |
-| |anim03|         | |anim04|       |
-+------------------+----------------+
-|:ref:`anim_05`    | :ref:`anim_06` |
-|                  |                |
-| |anim05|         | |anim06|       |
-+------------------+----------------+
-|:ref:`anim_07`    |:ref:`anim_08`  |
-|                  |                |
-| |anim07|         | |anim08|       |
-+------------------+----------------+
+.. jinja::
 
-.. |anim01| image:: /_images/anim_01.*
-   :width: 150 px
-   :target: ./gallery/anim01.html
+    {% for i in range(1, 9) %}
+    {% set i = '%02d' % i %}
+    -  .. figure:: /_images/anim_{{i}}.*
+          :target: ./gallery/anim{{i}}.html
 
-.. |anim02| image:: /_images/anim_02.*
-   :width: 150 px
-   :target: ./gallery/anim02.html
+          :ref:`anim_{{i}}`
 
-.. |anim03| image:: /_images/anim_03.*
-   :width: 150 px
-   :target: ./gallery/anim03.html
-
-.. |anim04| image:: /_images/anim_04.*
-   :width: 150 px
-   :target: ./gallery/anim04.html
-
-.. |anim05| image:: /_images/anim_05.*
-   :width: 150 px
-   :target: ./gallery/anim05.html
-
-.. |anim06| image:: /_images/anim_06.*
-   :width: 150 px
-   :target: ./gallery/anim06.html
-
-.. |anim07| image:: /_images/anim_07.*
-   :width: 150 px
-   :target: ./gallery/anim07.html
-
-.. |anim08| image:: /_images/anim_08.*
-   :width: 150 px
-   :target: ./gallery/anim08.html
+    {% endfor %}
 
 .. toctree::
    :hidden:
+   :glob:
 
    gallery/anim_introduction.rst
-   gallery/anim01.rst
-   gallery/anim02.rst
-   gallery/anim03.rst
-   gallery/anim04.rst
-   gallery/anim05.rst
-   gallery/anim06.rst
-   gallery/anim07.rst
-   gallery/anim08.rst
+   gallery/anim*


### PR DESCRIPTION
- Use [sphinx-jinja](https://github.com/tardyp/sphinx-jinja) to write jinja template in reST files directly
- Use the glob flag of toctree to include all examples directly
- More compact layout of figures

screenshot:

![image](https://user-images.githubusercontent.com/3974108/66177004-b1a7ed00-e62d-11e9-8876-a31b73fc3452.png)
