### PR TITLE
Improved parsing of modifier strings with quotes

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -12624,6 +12624,10 @@ unsigned int gmt_getmodopt (struct GMT_CTRL *GMT, const char option, const char 
 		if (string[i] == '\"' || string[i] == '\'') in_quote = !in_quote;	/* Check when we get past the quoted section */
 	}
 	token[j] = 0;	/* Add terminating \0 */
+	if (j > 2 && token[1] == '\"' && token[j-1] == '\"') { /* The whole thing was given in quotes */
+		memmove (&token[1], &token[2], strlen(token)-3);
+		token[j-2] = 0;
+	}
 
 	*pos = i;
 


### PR DESCRIPTION
In oder to properly parse grdedit -D arguments that contain other plus symbols followed by letters that are not modifiers:

`gmt grdedit t+V.grd -D+t"Earth Relief at 04 arc minute"+r"Obtained from t+V.nc"
`

they have to be given this way

`gmt grdedit t+V.grd -D+t'"Earth Relief at 04 arc minute"'+r'"Obtained from t+V.nc"'
`

otherwise we get dumb errors like this:

`grdedit [ERROR]: Error -D: Unrecognized modifier +V
`

However, the gmt_getmodopt function did not strip off the quotes when it returned the next token.
