### PR TITLE
Clarify how to escape plus-characters in text

### DIFF
--- a/doc/rst/source/explain_-D_cap.rst_
+++ b/doc/rst/source/explain_-D_cap.rst_
@@ -5,5 +5,9 @@
     *invalid* (a value to represent missing data [NaN]), *title* (anything you
     like), and *remark* (anything you like). Items not listed will remain untouched.
     Give a blank name to completely reset a particular string.
-    Use quotes to group texts with more than one word.
+    Use quotes to group texts with more than one word.  If any of your text contains plus symbols
+    you need to escape them (place a backslash before each plus-sign) so they are not confused with the
+    option modifiers.  Alternatively, you can place the entire double-quoted string inside single
+    quotes.  If you have shell variables that contain plus symbols you cannot use single quotes but
+    you can escape the plus symbols in a variable using constructs like ${variable/+/\\+}.
     Note that for geographic grids (**-fg**) *xname* and *yname* are set automatically.


### PR DESCRIPTION
Some options, in particular grdedit's **-D** option uses a series of modifiers (e.g., **+t** for title) to separate out various text.  However, if the text itself contains plus symbols they will be confusing the parser looking for modifier.  The simplest is to escape these pluses with a backslash (\\+).  Alternatively, we can place single quotes around a double-quoted string.  However, if you have shell variables that hold text that contain plus symbols then singe quotes cannot be used.  Here we upgrade the documentation for **-D** to show the varous ways to handle these cases.
