### PR TITLE
Better checking of floating point arguments

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8318,6 +8318,19 @@ bool gmt_not_numeric (struct GMT_CTRL *GMT, char *text) {
 	return (false);	/* This may in fact be numeric */
 }
 
+bool gmt_is_float (struct GMT_CTRL *GMT, char *text) {
+	/* Returns true if text is a valid floating point number.
+	 * Only called if we know text is not longitude or time, etc. */
+	int len;
+	double dummy = 0.0;
+	gmt_M_unused(GMT);
+
+	if (sscanf (text, "%lf %n", &dummy, &len) == 1 && len == (int)strlen(text))
+		return true;
+	else
+		return false;
+}
+
 /*! . */
 unsigned int gmtlib_conv_text2datarec (struct GMT_CTRL *GMT, char *record, unsigned int ncols, double *out) {
 	/* Used when we read text records and need to obtain doubles */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -236,6 +236,7 @@ EXTERN_MSC int gmt_set_psfilename (struct GMT_CTRL *GMT);
 
 /* gmt_io.c: */
 
+EXTERN_MSC bool gmt_is_float (struct GMT_CTRL *GMT, char *text);
 EXTERN_MSC void gmt_replace_backslash_in_path (char *dir);
 EXTERN_MSC void gmt_disable_bhi_opts (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmt_reenable_bhi_opts (struct GMT_CTRL *GMT);

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -367,7 +367,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDIMAGE_CTRL *Ctrl, struct GM
 					Ctrl->I.file = strdup (opt->arg);
 				else if (gmt_M_file_is_cache (opt->arg))	/* Got a remote file */
 					Ctrl->I.file = strdup (opt->arg);
-				else if (opt->arg[0] && !gmt_not_numeric (GMT, opt->arg)) {	/* Looks like a constant value */
+				else if (opt->arg[0] && gmt_is_float (GMT, opt->arg)) {	/* Looks like a constant value */
 					Ctrl->I.value = atof (opt->arg);
 					Ctrl->I.constant = true;
 				}

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -562,7 +562,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT
 					Ctrl->I.derive = true;
 				else if (!gmt_access (GMT, opt->arg, R_OK))	/* Got a file */
 					Ctrl->I.file = strdup (opt->arg);
-				else if (opt->arg[0] && !gmt_not_numeric (GMT, opt->arg)) {	/* Looks like a constant value */
+				else if (opt->arg[0] && gmt_is_float (GMT, opt->arg)) {	/* Looks like a constant value */
 					Ctrl->I.value = atof (opt->arg);
 					Ctrl->I.constant = true;
 				}


### PR DESCRIPTION
When we know that an argument must be a valid floating point number (i.e., cannot be a longitude 10:30W or time 2000-12-15T, etc) we can be more hardcore with checking for valid numbers.

Found that grdimage -I2m did not complained when a student mixed up -I for increments and -I for intensity...