### PR TITLE
Standardize ref to PSL

### DIFF
--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -67,5 +67,5 @@ Quick links
    Contributing Guide <https://github.com/GenericMappingTools/gmt/blob/master/CONTRIBUTING.md>
    Code of Conduct <https://github.com/GenericMappingTools/gmt/blob/master/CODE_OF_CONDUCT.md>
    GMT C API <api>
-   PostScriptLight Library <postscriptlight>
+   PostScriptLight C API <postscriptlight>
 

--- a/doc/rst/source/postscriptlight.rst
+++ b/doc/rst/source/postscriptlight.rst
@@ -1,7 +1,7 @@
 .. index:: ! postscriptlight
 
 ***************
-postscriptlight
+PostScriptLight
 ***************
 
 .. only:: not man


### PR DESCRIPTION
Since PSL is also a C API we should use the same index as for GMT C API.
