### PR TITLE
Update description of -r

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6638,8 +6638,8 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 
 		case 'F':	/* -r Pixel registration option  */
 
-			gmt_message (GMT, "\t-r Set (g)ridline- or (p)ixel-registration [Default].\n");
-			gmt_message (GMT, "\t   If not given we default to gridline registration\n");
+			gmt_message (GMT, "\t-r Set (g)ridline- or (p)ixel-registration.\n");
+			gmt_message (GMT, "\t   If not given we default to gridline registration.\n");
 			break;
 
 		case 't':	/* -t layer transparency option  */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6638,7 +6638,7 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 
 		case 'F':	/* -r Pixel registration option  */
 
-			gmt_message (GMT, "\t-r Set (g)ridline- or (p)ixel-registration.\n");
+			gmt_message (GMT, "\t-r Set (g)ridline- or (p)ixel-registration [Just -r sets pixel registration].\n");
 			gmt_message (GMT, "\t   If not given we default to gridline registration.\n");
 			break;
 


### PR DESCRIPTION
The old description of -r option was:

```
	-r Set (g)ridline- or (p)ixel-registration [Default].
	   If not given we default to gridline registration
```

It's not clear what the `[Default]` means here. Now it's:
```
	-r Set (g)ridline- or (p)ixel-registration [Just -r sets pixel registration].
	   If not given we default to gridline registration.
```