### PR TITLE
docs: Remove "del .gmt*" from batch scripts

### DIFF
--- a/doc/examples/ex01/ex01.bat
+++ b/doc/examples/ex01/ex01.bat
@@ -16,5 +16,4 @@ gmt grdcontour @osu91a1f_16.nc -J -C10 -A50+f7p -Gd4i -L-1/1000 -O -K -T+d0.1i/0
 gmt pscoast -Rg -JH6i -Y3.4i -O -K -B+t"Low Order Geoid" -Bg30 -Dc -Glightbrown -Slightblue >> %ps%
 gmt grdcontour @osu91a1f_16.nc -J -C10 -A50+f7p -Gd4i -L-1000/-1 -Wcthinnest,- -Wathin,- -O -K -T+d0.1i/0.02i+l >> %ps%
 gmt grdcontour @osu91a1f_16.nc -J -C10 -A50+f7p -Gd4i -L-1/1000 -O -T+d0.1i/0.02i+l >> %ps%
-del .gmt*
 del gmt.conf

--- a/doc/examples/ex02/ex02.bat
+++ b/doc/examples/ex02/ex02.bat
@@ -17,7 +17,6 @@ gmt psscale -Ct.cpt -DJRM+o0.6i/0+mc -J -R -O -K -I0.3 -Bx2+lTOPO -By+lkm >> %ps
 echo -0.4 7.5 a) > tmp
 echo -0.4 3.0 b) >> tmp
 gmt pstext tmp -R0/8.5/0/11 -Jx1i -F+f30p,Helvetica-Bold+jCB -O -N -Y-4.5i >> %ps%
-del .gmt*
 del ?.cpt
 del tmp
 del gmt.conf

--- a/doc/examples/ex03/ex03.bat
+++ b/doc/examples/ex03/ex03.bat
@@ -52,4 +52,3 @@ del tmp
 del *.pg
 del spectrum.*
 del samp.x
-del .gmt*

--- a/doc/examples/ex04/ex04.bat
+++ b/doc/examples/ex04/ex04.bat
@@ -23,4 +23,3 @@ gmt psscale -R -J -p -DjBC+o0/0.5i+jTC+w5i/0.3i+h -C@geoid_04.cpt -I -O -K -Bx2+
 gmt psbasemap -R -J -p -O -K -TdjBR+o0.1i+w1i+l --COLOR_BACKGROUND=red --MAP_TICK_PEN_PRIMARY=thinner,red --FONT=red >> %ps%
 gmt grdview @HI_topo_04.nc -I+a0+nt0.75 -R195/210/18/25/-6/4 -J -JZ3.4i -p -C@topo_04.cpt -N-6+glightgray -Qc100 -O -K -Y2.2i -B2 -Bz2+l"Topo (km)" -BneswZ >> %ps%
 echo 3.25 5.75 H@#awaiian@# R@#idge@# | gmt pstext -R0/10/0/10 -Jx1i -F+f60p,ZapfChancery-MediumItalic+jCB -O >> %ps%
-del .gmt*

--- a/doc/examples/ex05/ex05.bat
+++ b/doc/examples/ex05/ex05.bat
@@ -13,4 +13,3 @@ gmt grdview sombrero.nc -JX6i -JZ2i -B5 -Bz0.5 -BSEwnZ -N-1+gwhite -Qs -I+a225+n
 echo 4.1 5.5 z(r) = cos (2@~p@~r/8) @~\327@~e@+-r/10@+ | gmt pstext -R0/11/0/8.5 -Jx1i -F+f50p,ZapfChancery-MediumItalic+jBC -O >> %ps%
 del g.cpt
 del sombrero.nc
-del .gmt*

--- a/doc/examples/ex06/ex06.bat
+++ b/doc/examples/ex06/ex06.bat
@@ -9,4 +9,3 @@ echo GMT EXAMPLE 06
 set ps=example_06.ps
 gmt psrose @fractures_06.txt -: -A10r -S -JX3.6i -P -Gorange -R0/1/0/360 -X2.5i -K -Bx0.2g0.2 -By30g30 -B+glightblue -W1p > %ps%
 gmt pshistogram -Bxa2000f1000+l"Topography (m)" -Bya10f5+l"Frequency"+u" %%" -BWSne+t"Histograms"+glightblue @v3206_06.txt -R-6000/0/0/30 -JX4.8i/2.4i -Gorange -O -Y5.0i -X-0.5i -L1p -Z1 -W250 >> %ps%
-del .gmt*

--- a/doc/examples/ex07/ex07.bat
+++ b/doc/examples/ex07/ex07.bat
@@ -18,5 +18,4 @@ echo -43 -5 SOUTH > tmp
 echo -43 -8 AMERICA >> tmp
 echo -7 11 AFRICA >> tmp
 gmt pstext -R -J -O -F+f30,Helvetica-Bold,white=thin tmp >> %ps%
-del .gmt*
 del tmp

--- a/doc/examples/ex08/ex08.bat
+++ b/doc/examples/ex08/ex08.bat
@@ -10,4 +10,3 @@ set ps=example_08.ps
 gmt makecpt -Ccubhelix -T-5000/0 > t.cpt
 gmt grd2xyz @guinea_bay.nc | gmt psxyz -B1 -Bz1000+l"Topography (m)" -BWSneZ+b+tETOPO5 -R-0.1/5.1/-0.1/5.1/-5000/0 -JM5i -JZ6i -p200/30 -So0.0833333ub-5000 -P -Wthinnest -Ct.cpt -K -i0-2,2 > %ps%
 echo 0.1 4.9 This is the gmt surface of cube | gmt pstext -R -J -JZ -Z0 -F+f24p,Helvetica-Bold+jTL -p -O >> %ps%
-del .gmt*

--- a/doc/examples/ex09/ex09.bat
+++ b/doc/examples/ex09/ex09.bat
@@ -12,4 +12,3 @@ gmt psxy -R -J -O -K @ridge_09.txt -Wthicker >> %ps%
 gmt psxy -R -J -O -K @fz_09.txt -Wthinner,- >> %ps%
 REM Take label from segment header and plot near coordinates of last record of each track
 gmt convert -El @tracks_09.txt | gmt pstext -R -J -F+f10p,Helvetica-Bold+a50+jRM+h -D-0.05i -O >> %ps%
-del .gmt*

--- a/doc/examples/ex11/ex11.bat
+++ b/doc/examples/ex11/ex11.bat
@@ -79,5 +79,4 @@ echo 26 204 0.8 | gmt pstext -J -R -F+a180 -K -O >> %ps%
 echo 200 200 GMT 4 | gmt pstext -J -F+f16p+a225 -R -O >> %ps%
 
 del *.nc
-del .gmt*
 del gmt.conf

--- a/doc/examples/ex12/ex12.bat
+++ b/doc/examples/ex12/ex12.bat
@@ -33,4 +33,3 @@ echo 3.16 8 Delaunay Triangulation | gmt pstext -R0/8/0/11 -Jx1i -F+f30p,Helveti
 REM
 del net.xy
 del topo.cpt
-del .gmt*

--- a/doc/examples/ex13/ex13.bat
+++ b/doc/examples/ex13/ex13.bat
@@ -17,4 +17,3 @@ gmt grdcontour z.nc -J -B -C0.05 -O -K -Gd2i -S4 -X3.45i >> %ps%
 gmt grdvector dzdx.nc dzdy.nc -I0.2 -J -O -K -Q0.1i+e+n0.25i -Gblack -W1p -S5i --MAP_VECTOR_SHAPE=0.5 >> %ps%
 echo 3.2 3.6 z(x,y) = x@~\327@~exp(-x@+2@+-y@+2@+) | gmt pstext -R0/6/0/4.5 -Jx1i -F+f40p,Times-Italic+jCB -O -X-3.45i >> %ps%
 del *.nc
-del .gmt*

--- a/doc/examples/ex14/ex14.bat
+++ b/doc/examples/ex14/ex14.bat
@@ -38,5 +38,4 @@ del mean.xyz
 del track
 del *.nc
 del *.d
-del .gmt*
 del gmt.conf

--- a/doc/examples/ex15/ex15.bat
+++ b/doc/examples/ex15/ex15.bat
@@ -29,4 +29,3 @@ gmt grdinfo -C -M ship.nc | gmt psxy -R -J -O -K -Sa0.15i -Wthick -i11,12 >> %ps
 echo -0.3 3.6 Gridding with missing data | gmt pstext -R0/3/0/4 -Jx1i -F+f24p,Helvetica-Bold+jCB -O -N >> %ps%
 del ship*.nc
 del ship*.b
-del .gmt*

--- a/doc/examples/ex16/ex16.bat
+++ b/doc/examples/ex16/ex16.bat
@@ -32,5 +32,4 @@ echo 3.25 7 triangulate @~\256@~ gmt grdfilter | gmt pstext -R -J -O -K -N -F+f1
 echo 3.2125 7.5 Gridding of Data | gmt pstext -R0/10/0/10 -Jx1i -O -K -N -F+f32p,Times-Roman+jCB -X-3.5i >> %ps%
 gmt psscale -Dx3.25i/-0.4i+jTC+w5i/0.25i+h -C@ex_16.cpt -O >> %ps%
 del *.nc
-del .gmt*
 del gmt.conf

--- a/doc/examples/ex17/ex17.bat
+++ b/doc/examples/ex17/ex17.bat
@@ -43,4 +43,3 @@ REM Clean up
 
 del *.cpt
 del tmp
-del .gmt*

--- a/doc/examples/ex18/ex18.bat
+++ b/doc/examples/ex18/ex18.bat
@@ -71,5 +71,4 @@ del tmp.nc
 del mask.nc
 del pratt.txt
 del center*.*
-del .gmt*
 del gmt.conf

--- a/doc/examples/ex19/ex19.bat
+++ b/doc/examples/ex19/ex19.bat
@@ -42,4 +42,3 @@ echo 0 -30 Honolulu, Hawaii, April 1, 2019 | gmt pstext -R -J -O -F+f18p,Helveti
 
 del l*.nc
 del l*.cpt
-del .gmt*

--- a/doc/examples/ex20/ex20.bat
+++ b/doc/examples/ex20/ex20.bat
@@ -25,4 +25,3 @@ echo 56.16W 34.9S 0.5 >> cities.txt
 gmt psxy -R -J cities.txt -Sk@bullseye -O >> %ps%
 
 del cities.txt
-del .gmt*

--- a/doc/examples/ex21/ex21.bat
+++ b/doc/examples/ex21/ex21.bat
@@ -84,5 +84,4 @@ gmt psxy -R -J RHAT.pw -Wthinner,- -O >> %ps%
 REM Clean up after ourselves:
 
 del RHAT.*
-del .gmt*
 del gmt.conf

--- a/doc/examples/ex22/ex22.bat
+++ b/doc/examples/ex22/ex22.bat
@@ -94,5 +94,4 @@ gmt pslegend -DjCB+o0/0.4i+w7i/1.7i+jTC -R -J -O -F+p+glightyellow neis.legend >
 REM Clean up after ourselves:
 
 del neis.*
-del .gmt*
 del gmt.conf

--- a/doc/examples/ex23/ex23.bat
+++ b/doc/examples/ex23/ex23.bat
@@ -49,4 +49,3 @@ REM Clean up after ourselves:
 
 del cities.txt
 del dist.nc
-del .gmt*

--- a/doc/examples/ex24/ex24.bat
+++ b/doc/examples/ex24/ex24.bat
@@ -27,4 +27,3 @@ gmt psxy -R -J -O dateline.txt -Wfat,white -A >> %ps%
 del point.txt
 del dateline.txt
 del awk.txt
-del .gmt*

--- a/doc/examples/ex25/ex25.bat
+++ b/doc/examples/ex25/ex25.bat
@@ -47,5 +47,4 @@ del key.*
 del tmp
 del awk.txt
 del script*.bat
-del .gmt*
 del gmt.conf

--- a/doc/examples/ex26/ex26.bat
+++ b/doc/examples/ex26/ex26.bat
@@ -36,4 +36,3 @@ set Height=30.0
 set PROJ=-JG%longitude%/%latitude%/%altitude%/%azimuth%/%tilt%/%twist%/%Width%/%Height%/5i
 
 gmt pscoast -R %PROJ% -B5g5 -Glightbrown -Slightblue -W -Ia/blue -Di -Na -O -X1i -Y-4i >> %ps%
-del .gmt*

--- a/doc/examples/ex27/ex27.bat
+++ b/doc/examples/ex27/ex27.bat
@@ -32,4 +32,3 @@ gmt psscale -DjTL+o1c+w2i/0.15i -R -J -Cgrav.cpt -Bx50f10 -By+lmGal  -F+gwhite+p
 REM Clean up
 
 del grav.cpt
-del .gmt*

--- a/doc/examples/ex28/ex28.bat
+++ b/doc/examples/ex28/ex28.bat
@@ -25,4 +25,3 @@ gmt psbasemap -R@Kilauea.utm.nc+Uk -Jx1:160 -B5g5+u"@:8:000m@::" -BWSne -O --FON
 REM Clean up
 
 del Kilauea.cpt
-del .gmt*

--- a/doc/examples/ex29/ex29.bat
+++ b/doc/examples/ex29/ex29.bat
@@ -37,4 +37,3 @@ echo 0 90 a) | gmt pstext -R -J -O -N -D-3.5i/-0.2i -F+f14p,Helvetica-Bold+jLB >
 REM Clean up
 del *.nc
 del mars.cpt
-del .gmt*

--- a/doc/examples/ex30/ex30.bat
+++ b/doc/examples/ex30/ex30.bat
@@ -59,5 +59,4 @@ gmt pstext -R -J -O -K -Dj0.05i tmp -F+f+a+j >> %ps%
 echo 0 0 0.5i 0 120 | gmt psxy -R -J -O -Sm0.15i+e -W1p -Gblack >> %ps%
 
 REM Clean up
-del .gmt*
 del gmt.conf

--- a/doc/examples/ex31/ex31.bat
+++ b/doc/examples/ex31/ex31.bat
@@ -81,7 +81,6 @@ REM gmt psconvert -P -A -Tf %ps%
 REM gmt psconvert -P -A -Tg -E110 %ps%
 
 REM clean up
-del .gmt*
 del PSL_custom_fonts.txt
 del legend.txt
 rem del ex31CropNoLogo.eps


### PR DESCRIPTION
The DOS batch scripts complain that ".gmt* cannot be found"
because GMT5 no longer generates .gmt* files.