### PR TITLE
docs: Set tab-width to 2 spaces

### DIFF
--- a/doc/rst/_static/style.css
+++ b/doc/rst/_static/style.css
@@ -25,3 +25,8 @@
     display: inline-grid;
     margin-right: 15px;
 }
+
+/* Set tab-width to 2 spaces */
+.highlight {
+    tab-size: 2;
+}


### PR DESCRIPTION
Of course it works for HTML only.

Address #1714.