### PR TITLE
Set clip path for map insets by default

### DIFF
--- a/doc/rst/source/inset.rst
+++ b/doc/rst/source/inset.rst
@@ -23,6 +23,7 @@ Synopsis (begin mode)
 |-D|\ *inset-box*
 [ |-F|\ *box* ]
 [ |-M|\ *margins* ]
+[ |-N| ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT--| ]
 
@@ -92,6 +93,11 @@ Optional Arguments
     within the inner region only. The margins can be a single value, a pair of values separated by slashes
     (for setting separate horizontal and vertical margins), or the full set of four margins (for setting
     separate left, right, bottom, and top margins) [no margins].
+
+.. _inset_begin-N:
+
+**-N**
+    Do NOT clip features extruding outside map inset boundaries [Default will clip]. 
 
 .. _inset_begin-V:
 

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5223,12 +5223,15 @@ void gmt_draw_map_inset (struct GMT_CTRL *GMT, struct GMT_MAP_INSET *B, bool cli
 		double xc[4], yc[4];
 		xc[0] = xc[3] = rect[XLO];	xc[1] = xc[2] = rect[XHI];
 		yc[0] = yc[1] = rect[YLO];	yc[2] = yc[3] = rect[YHI];
-		PSL_comment (PSL, "Start of inset clip path\n");
-		PSL_command (PSL, "clipsave\n");
-		PSL_plotline (PSL, xc, yc, 4, PSL_MOVE | PSL_CLOSE_INTERIOR);	/* Must not close path since first point not given ! */
-		PSL_command (PSL, "clip N\n");
-		PSL_command (PSL, "/PSL_inset_clip 1 def\n");	/* Restore graphics state to what it was before the map inset */
+		PSL_comment (GMT->PSL, "Start of inset clip path\n");
+		PSL_command (GMT->PSL, "clipsave\n");
+		PSL_plotline (GMT->PSL, xc, yc, 4, PSL_MOVE | PSL_CLOSE);	/* Must not close path since first point not given ! */
+		PSL_command (GMT->PSL, "clip N\n");
+		PSL_command (GMT->PSL, "/PSL_inset_clip 1 def\n");	/* Remember that inset clipping is on */
 	}
+	else
+		PSL_command (GMT->PSL, "/PSL_inset_clip 0 def\n");	/* No inset clipping set */
+	
 	if (B->translate)	/* Translate the plot origin */
 		PSL_setorigin (GMT->PSL, rect[XLO], rect[YLO], 0.0, PSL_FWD);
 }

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5222,8 +5222,12 @@ void gmt_draw_map_inset (struct GMT_CTRL *GMT, struct GMT_MAP_INSET *B, bool cli
 	if (clip) {	/* Set up clip path for this inset */
 		double xc[4], yc[4];
 		/* Adjust for the padding so that clipping matches the panel rectangle which may be larger than inset */
-		xc[0] = xc[3] = rect[XLO] - panel->padding[XLO];	xc[1] = xc[2] = rect[XHI] + panel->padding[XHI];
-		yc[0] = yc[1] = rect[YLO] - panel->padding[YLO];	yc[2] = yc[3] = rect[YHI] + panel->padding[YHI];
+		xc[0] = xc[3] = rect[XLO];	xc[1] = xc[2] = rect[XHI];
+		yc[0] = yc[1] = rect[YLO];	yc[2] = yc[3] = rect[YHI];
+		if (panel) {	/* Adjust for clearance, if any */
+			xc[0] -= panel->padding[XLO]; xc[3] -= panel->padding[XLO];	xc[1] += panel->padding[XHI]; xc[2] += panel->padding[XHI];
+			yc[0] -= panel->padding[YLO]; yc[1] -= panel->padding[YLO];	yc[2] += panel->padding[YHI]; yc[3] += panel->padding[YHI];
+		}
 		PSL_comment (GMT->PSL, "Start of inset clip path\n");
 		PSL_command (GMT->PSL, "clipsave\n");
 		PSL_plotline (GMT->PSL, xc, yc, 4, PSL_MOVE | PSL_CLOSE);	/* Must not close path since first point not given ! */

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5221,16 +5221,17 @@ void gmt_draw_map_inset (struct GMT_CTRL *GMT, struct GMT_MAP_INSET *B, bool cli
 	}
 	if (clip) {	/* Set up clip path for this inset */
 		double xc[4], yc[4];
-		xc[0] = xc[3] = rect[XLO];	xc[1] = xc[2] = rect[XHI];
-		yc[0] = yc[1] = rect[YLO];	yc[2] = yc[3] = rect[YHI];
+		/* Adjust for the padding so that clipping matches the panel rectangle which may be larger than inset */
+		xc[0] = xc[3] = rect[XLO] - panel->padding[XLO];	xc[1] = xc[2] = rect[XHI] + panel->padding[XHI];
+		yc[0] = yc[1] = rect[YLO] - panel->padding[YLO];	yc[2] = yc[3] = rect[YHI] + panel->padding[YHI];
 		PSL_comment (GMT->PSL, "Start of inset clip path\n");
 		PSL_command (GMT->PSL, "clipsave\n");
 		PSL_plotline (GMT->PSL, xc, yc, 4, PSL_MOVE | PSL_CLOSE);	/* Must not close path since first point not given ! */
 		PSL_command (GMT->PSL, "clip N\n");
 		PSL_command (GMT->PSL, "/PSL_inset_clip 1 def\n");	/* Remember that inset clipping is on */
 	}
-	else
-		PSL_command (GMT->PSL, "/PSL_inset_clip 0 def\n");	/* No inset clipping set */
+	else	/* No inset clipping set */
+		PSL_command (GMT->PSL, "/PSL_inset_clip 0 def\n");
 	
 	if (B->translate)	/* Translate the plot origin */
 		PSL_setorigin (GMT->PSL, rect[XLO], rect[YLO], 0.0, PSL_FWD);
@@ -5542,7 +5543,7 @@ void gmt_draw_map_rose (struct GMT_CTRL *GMT, struct GMT_MAP_ROSE *mr) {
 }
 
 void gmt_draw_map_panel (struct GMT_CTRL *GMT, double x, double y, unsigned int mode, struct GMT_MAP_PANEL *P) {
-	/* Draw a recrangular backpanel behind things like logos, scales, legends, images.
+	/* Draw a rectangular backpanel behind things like logos, scales, legends, images.
 	 * Here, (x,y) is the center-point of the panel.
 	 * mode is a bit flag that can be 1,2, or 3:
 	 * mode = 1.  Lay down fills for background (if any fills) but no outlines

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -201,7 +201,7 @@ EXTERN_MSC void gmt_textpath_init (struct GMT_CTRL *GMT, struct GMT_PEN *BP, dou
 EXTERN_MSC void gmt_draw_map_rose (struct GMT_CTRL *GMT, struct GMT_MAP_ROSE *mr);
 EXTERN_MSC int gmt_draw_map_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *ms);
 EXTERN_MSC void gmt_draw_vertical_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *mv);
-EXTERN_MSC void gmt_draw_map_inset (struct GMT_CTRL *GMT, struct GMT_MAP_INSET *B);
+EXTERN_MSC void gmt_draw_map_inset (struct GMT_CTRL *GMT, struct GMT_MAP_INSET *B, bool clip);
 EXTERN_MSC void gmt_draw_map_panel (struct GMT_CTRL *GMT, double x, double y, unsigned int mode, struct GMT_MAP_PANEL *P);
 EXTERN_MSC void gmt_geo_line (struct GMT_CTRL *GMT, double *lon, double *lat, uint64_t n);
 EXTERN_MSC void gmt_geo_polygons (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S);

--- a/src/inset.c
+++ b/src/inset.c
@@ -60,6 +60,9 @@ struct INSET_CTRL {
 		bool active;
 		double margin[4];
 	} M;
+	struct N {	/* -N  */
+		bool active;
+	} N;
 };
 
 GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
@@ -161,6 +164,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct INSET_CTRL *Ctrl, struct GMT_O
 					for (k = 0; k < 4; k++) Ctrl->M.margin[k] *= GMT->session.u2u[GMT->current.setting.proj_length_unit][GMT_INCH];
 				}
 				break;
+			case 'N':	/* Turn off clipping  */
+				Ctrl->N.active = true;
+				break;
 
 			default:	/* Report bad options */
 				n_errors += gmt_default_error (GMT, opt->option);
@@ -260,7 +266,7 @@ int GMT_inset (void *V_API, int mode, void *args) {
 		/* OK, no other inset set for this figure (or panel).  Save graphics state before we draw the inset */
 		PSL_command (PSL, "V %% Begin inset\n");
 
-		gmt_draw_map_inset (GMT, &Ctrl->D.inset);	/* Draw the inset background */
+		gmt_draw_map_inset (GMT, &Ctrl->D.inset, !Ctrl->N.active);	/* Draw the inset background */
 
 		/* Set the new origin as indicated */
 		
@@ -299,6 +305,7 @@ int GMT_inset (void *V_API, int mode, void *args) {
 		 * and finally remove the inset information file */
 		char tag[GMT_LEN16] = {""};
 			
+		PSL_command (PSL, "PSL_inset_clip 1 eq {cliprestore /PSL_inset_clip 0 def} if\n");	/* Restore graphics state to what it was before the map inset */
 		PSL_command (PSL, "U %% End inset\n");	/* Restore graphics state to what it was before the map inset */
 
 		/* Remove the inset history file */

--- a/src/psbasemap.c
+++ b/src/psbasemap.c
@@ -326,7 +326,7 @@ int GMT_psbasemap (void *V_API, int mode, void *args) {
 			gmt_draw_map_scale (GMT, &Ctrl->L.scale);
 	}
 	if (Ctrl->T.active) gmt_draw_map_rose (GMT, &Ctrl->T.rose);
-	if (Ctrl->D.active) gmt_draw_map_inset (GMT, &Ctrl->D.inset);
+	if (Ctrl->D.active) gmt_draw_map_inset (GMT, &Ctrl->D.inset, false);
 
 	gmt_plane_perspective (GMT, -1, 0.0);
 


### PR DESCRIPTION
**Description of proposed changes**

As for gmt text, we now let gmt inset begin set a clip path so that anything extruding outside the inset panel will be clipped. This behavior can be turned off with **-N**.  Implemented with hidden parameter in the PostScript since gmt inset end needs to restore the previous clip path but does not take any options.