### PR TITLE
Make test and doc scripts shorter

### DIFF
--- a/doc/rst/source/pswiggle.rst
+++ b/doc/rst/source/pswiggle.rst
@@ -50,6 +50,11 @@ Examples
 
 .. include:: explain_example.rst_
 
+To demonstrate a basic wiggle plot we create some synthetic data with
+:doc:`gmtmath` and pipe it through **pswiggle**::
+
+    gmt math -T-8/6/0.01 -N3/0 -C2 T 3 DIV 2 POW NEG EXP T PI 2 MUL MUL COS MUL 50 MUL = | gmt pswiggle -R-10/10/-3/3 -JM6i -Baf -Z100i -DjRM+w100+lnT -Tfaint -Gred+p -W1p -BWSne -P > map.ps
+
 To plot the magnetic anomaly stored in the file track.xym along track @
 500 nTesla/cm (after removing a mean value of 32000 nTesla), using a
 15-cm-wide Polar Stereographic map ticked every 5 degrees in Portrait

--- a/doc/rst/source/wiggle.rst
+++ b/doc/rst/source/wiggle.rst
@@ -48,6 +48,11 @@ Examples
 
 .. include:: oneliner_info.rst_
 
+To demonstrate a basic wiggle plot we create some synthetic data with
+:doc:`gmtmath` and pipe it through **wiggle**::
+
+    gmt math -T-8/6/0.01 -N3/0 -C2 T 3 DIV 2 POW NEG EXP T PI 2 MUL MUL COS MUL 50 MUL = | gmt wiggle -R-10/10/-3/3 -JM6i -B -Z100i -DjRM+w100+lnT -Tfaint -Gred+p -W1p -BWSne -pdf map
+
 To plot the magnetic anomaly stored in the file track.xym along track @
 500 nTesla/cm (after removing a mean value of 32000 nTesla), using a
 15-cm-wide Polar Stereographic map ticked every 5 degrees in Portrait

--- a/doc/scripts/GMT_CPTscale.sh
+++ b/doc/scripts/GMT_CPTscale.sh
@@ -20,11 +20,11 @@ gmt plot -R0/6/0/6 -Jx1i -W0.25p << EOF
 3	1.5
 5	0.785
 EOF
-gmt colorbar -Cglobe -Baf -Dx3i/1.5i+w2.8i/0.15i+jCM -W0.001 
+gmt colorbar -Cglobe -B -Dx3i/1.5i+w2.8i/0.15i+jCM -W0.001 
 gmt makecpt -Cglobe -T-500/3000
-gmt colorbar -C -Baf -Dx5i/1.5i+w2.0i/0.15i+jLM -W0.001 
+gmt colorbar -C -B -Dx5i/1.5i+w2.0i/0.15i+jLM -W0.001 
 gmt makecpt -Cglobe -G-3000/5000 -T-500/3000
-gmt colorbar -C -Baf -Dx1i/1.5i+w2.0i/0.15i+jRM+ma -W0.001 
+gmt colorbar -C -B -Dx1i/1.5i+w2.0i/0.15i+jRM+ma -W0.001 
 gmt text -N -F+f14p+j << EOF 
 0	0	LB	Scale a subset (via @%1%-G@%%)
 6	0	RB	Scale entire range

--- a/doc/scripts/GMT_SRTM.sh
+++ b/doc/scripts/GMT_SRTM.sh
@@ -2,7 +2,7 @@
 #	Show distribution of SRTM tiles
 gmt begin GMT_SRTM
 gmt set MAP_FRAME_TYPE plain
-gmt coast -R-180/180/-60/60 -JQ0/6i -Baf -BWStr -Dc -A5000 -Glightgray --FORMAT_GEO_MAP=dddF
+gmt coast -R-180/180/-60/60 -JQ0/6i -B -BWStr -Dc -A5000 -Glightgray --FORMAT_GEO_MAP=dddF
 echo "1	red" > t.cpt
 gmt grdmath @srtm_tiles.nc 0 NAN = t.nc
 gmt grdimage t.nc -Ct.cpt

--- a/doc/scripts/GMT_colorbar.sh
+++ b/doc/scripts/GMT_colorbar.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 gmt begin GMT_colorbar
 	gmt makecpt -T-15/15 -Cpolar
-	gmt basemap -R0/20/0/1 -JM5i -BWse -Baf 
-	gmt colorbar -C -Baf -Bx+u"\\232" -By+l@~D@~T -DJBC+e
+	gmt basemap -R0/20/0/1 -JM5i -BWse -B
+	gmt colorbar -C -B -Bx+u"\\232" -By+l@~D@~T -DJBC+e
 gmt end show

--- a/doc/scripts/GMT_cyclic.sh
+++ b/doc/scripts/GMT_cyclic.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 gmt begin GMT_cyclic
 	gmt makecpt -T0/100 -Cjet -Ww
-	gmt basemap -R0/20/0/1 -JM5i -BWse -Baf
-	gmt colorbar -C -Baf -DJBC 
+	gmt basemap -R0/20/0/1 -JM5i -BWse -B
+	gmt colorbar -C -B -DJBC 
 gmt end show

--- a/doc/scripts/GMT_hinge.sh
+++ b/doc/scripts/GMT_hinge.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 gmt begin GMT_hinge
 	gmt makecpt -Cglobe -T-8000/3000
-	gmt colorbar -Baf -Dx0/0+w4.5i/0.1i+h -W0.001 
-	gmt colorbar -Cglobe  -Baf -Dx0/0+w4.5i/0.1i+h -W0.001 -Y0.5i 
+	gmt colorbar -B -Dx0/0+w4.5i/0.1i+h -W0.001 
+	gmt colorbar -Cglobe -B -Dx0/0+w4.5i/0.1i+h -W0.001 -Y0.5i 
 	echo 2.25 0.1 90 0.2i | gmt plot -R0/4.5/0/1 -Jx1i -Sv0.1i+a80+b -W1p -Gblack 
 	gmt text -F+f12p+jCB <<- EOF 
 	2.25	0.35	HINGE

--- a/doc/scripts/GMT_inset.sh
+++ b/doc/scripts/GMT_inset.sh
@@ -4,7 +4,7 @@
 
 gmt begin GMT_inset
 # Bottom map of Australia
-gmt coast -R110E/170E/44S/9S -JM6i -Baf -BWSne -Wfaint -N2/1p  -EAU+gbisque -Gbrown -Sazure1 -Da -Xc --FORMAT_GEO_MAP=dddF
+gmt coast -R110E/170E/44S/9S -JM6i -B -BWSne -Wfaint -N2/1p  -EAU+gbisque -Gbrown -Sazure1 -Da -Xc --FORMAT_GEO_MAP=dddF
 gmt inset begin -DjTR+w1.5i+o0.15i -F+gwhite+p1p+s -M0.05i
   gmt coast -Rg -JG120/30S/1.4i -Da -Gbrown -A5000 -Bg -Wfaint -EAU+gbisque 
 gmt inset end 

--- a/doc/scripts/GMT_mag_rose.sh
+++ b/doc/scripts/GMT_mag_rose.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 gmt begin GMT_mag_rose
 # Magnetic rose with a specified declination
-gmt basemap -R-10/-2/12.8812380332/0.661018975345+r -JOc0/0/50/60/7i -Baf -BWSne -X1.25i --MAP_ANNOT_OBLIQUE=34 --FONT_ANNOT_PRIMARY=12p 
+gmt basemap -R-10/-2/12.8812380332/0.661018975345+r -JOc0/0/50/60/7i -B -BWSne -X1.25i --MAP_ANNOT_OBLIQUE=34 --FONT_ANNOT_PRIMARY=12p 
 gmt basemap -Tmg-2/0.5+w2.5i+d-14.5+t45/10/5+i0.25p,blue+p0.25p,red+l+jCM \
 	--FONT_ANNOT_PRIMARY=9p,Helvetica,blue --FONT_ANNOT_SECONDARY=12p,Helvetica,red --FONT_LABEL=14p,Times-Italic,darkgreen --FONT_TITLE=24p \
 	--MAP_TITLE_OFFSET=7p --MAP_FRAME_WIDTH=10p --COLOR_BACKGROUND=green --MAP_DEFAULT_PEN=2p,darkgreen --COLOR_BACKGROUND=darkgreen \

--- a/doc/scripts/GMT_mapscale.sh
+++ b/doc/scripts/GMT_mapscale.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 gmt begin GMT_mapscale
-gmt basemap -R0/40/50/56 -JM5i -Baf -LjML+c53+w1000k+f+l"Scale at 53\\232N" -F+glightcyan+c0+p 
+gmt basemap -R0/40/50/56 -JM5i -B -LjML+c53+w1000k+f+l"Scale at 53\\232N" -F+glightcyan+c0+p 
 gmt basemap -LjBR+c53+w1000k+l+f -F+p1p+i+gwhite+c0.1i 
 h=`gmt mapproject -Wh -Di`
 h=`gmt math -Q $h 2 DIV =`

--- a/doc/scripts/GMT_vertscale.sh
+++ b/doc/scripts/GMT_vertscale.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 gmt begin GMT_vertscale
 gmt math -T-8/6/0.01 -N3/0 -C2 T 3 DIV 2 POW NEG EXP T PI 2 MUL MUL COS MUL 50 MUL = t.txt
-gmt wiggle -R-10/10/-3/3 -JM6i -Baf -Z100i -DjRM+w100+lnT t.txt -Tfaint -W1p -BWSne --MAP_FRAME_TYPE=plain 
+gmt wiggle -R-10/10/-3/3 -JM6i -B -Z100i -DjRM+w100+lnT t.txt -Tfaint -W1p -BWSne --MAP_FRAME_TYPE=plain 
 gmt end show

--- a/test/pslegend/subplotlegend.sh
+++ b/test/pslegend/subplotlegend.sh
@@ -7,7 +7,7 @@ gmt begin subplotlegend ps
     gmt subplot begin 2x2 -Fs7c/5c -A
 
     gmt subplot set 0
-    gmt basemap -R0/10/0/10 -Baf
+    gmt basemap -R0/10/0/10 -B
     gmt legend -DjRT+w1.2c -F+p0.5p << EOF
 S 0.1c c 0.1c red - 0.3c a
 S 0.1c s 0.1c blue - 0.3c b
@@ -16,7 +16,7 @@ EOF
 
     gmt subplot set 1 -Cw1c -Cs1c
     #gmt subplot set 1
-    gmt basemap -R0/10/0/10 -Baf
+    gmt basemap -R0/10/0/10 -B
     gmt legend -DjRT+w1.2c -F+p0.5p << EOF
 S 0.1c c 0.1c red - 0.3c a
 S 0.1c s 0.1c blue - 0.3c b
@@ -25,7 +25,7 @@ EOF
 
     gmt subplot set 2 -Ce1c
     #gmt subplot set 1
-    gmt basemap -R0/10/0/10 -Baf
+    gmt basemap -R0/10/0/10 -B
     gmt legend -DjRT+w1.2c -F+p0.5p << EOF
 S 0.1c c 0.1c red - 0.3c a
 S 0.1c s 0.1c blue - 0.3c b
@@ -34,7 +34,7 @@ EOF
 
     gmt subplot set 3 -Ce1c -Cn2c
     #gmt subplot set 1
-    gmt basemap -R0/10/0/10 -Baf
+    gmt basemap -R0/10/0/10 -B
     gmt legend -DjRT+w1.2c -F+p0.5p << EOF
 S 0.1c c 0.1c red - 0.3c a
 S 0.1c s 0.1c blue - 0.3c b


### PR DESCRIPTION
Many modern mode scripts used -**Baf** when **-B** means the same thing in modern mode.  Also added working example to wiggle.
