### PR TITLE
colorbar does not take -C if hidden CPT is to be used

### DIFF
--- a/test/modern/imagepluscpt.sh
+++ b/test/modern/imagepluscpt.sh
@@ -3,5 +3,5 @@
 gmt begin imagepluscpt ps
 	gmt grdimage @earth_relief_01m -RMG+r2 -Cgeo -I+
 	gmt coast -Wthin -N1/thick,red -BWSne -B
-	gmt colorbar -DJTC -B -C
+	gmt colorbar -DJTC -B
 gmt end show

--- a/test/modern/viewpluscpt.sh
+++ b/test/modern/viewpluscpt.sh
@@ -3,5 +3,5 @@
 gmt begin viewpluscpt ps
 	gmt grdview @earth_relief_01m -RMG+r2 -Cgeo -I+ -Qi
 	gmt coast -Wthin -N1/thick,red -BWSne -B
-	gmt colorbar -DJTC -B -C
+	gmt colorbar -DJTC -B
 gmt end show


### PR DESCRIPTION
We had to early test scripts in modern that passed -C to colorbar but the syntax has changed since then.
