### PR TITLE
Address bad wrapping in pscoast

### DIFF
--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -1709,7 +1709,7 @@ uint64_t map_wesn_clip (struct GMT_CTRL *GMT, double *lon, double *lat, uint64_t
 /* This is new approach to get rid of those crossing lines for filled polygons,
  * i.e., issue # 949.  Also see comments further down.
  * P. Wessel, Dec 1 2016 */
-	if (GMT->current.map.coastline) {	/* Make data longitudes have no jumps [This is for pscoast] */
+	if (GMT->current.map.coastline && periodic) {	/* Make data longitudes have no jumps [This is for pscoast] */
 		for (i = 0; i < n; i++) {
 			if (lon[i] < border[GMT_LEFT] && (lon[i] + 360.0) <= border[GMT_RIGHT])
 				lon[i] += 360.0;

--- a/test/pscoast/pscoast_JQ.ps
+++ b/test/pscoast/pscoast_JQ.ps
@@ -1,0 +1,16158 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.0.0_4513654_2019.10.09 [64-bit] Document from pscoast
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Wed Oct  9 21:46:45 2019
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt pscoast -JQ200/6i -R-42.2839/223.375/-90/90 -BWeSn -Baf -Dc -S180/220/255 -G200 -Wfaint -P
+%@PROJ: eqc -42.28390000 223.37500000 -90.00000000 90.00000000 -14769977.597 14769977.597 -10007554.678 10007554.678 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=90.54554999999999 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.180918 +units=m +no_defs
+%GMTBoundingBox: 72 72 432 292.706
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+{0.706 0.863 1 C} FS
+-7200 0 0 4878 7200 0 3 0 0 SP
+0 W
+clipsave
+0 0 M
+7200 0 D
+0 4878 D
+-7200 0 D
+P
+PSL_clip N
+1688 4619 M
+-10 2 D
+-2 -10 D
+-49 0 D
+27 -11 D
+34 1 D
+0 -16 D
+-46 12 D
+-17 -7 D
+-38 19 D
+7 -31 D
+-49 24 D
+-18 -15 D
+-46 9 D
+39 8 D
+-85 -9 D
+63 -36 D
+64 17 D
+2 -10 D
+31 7 D
+23 -8 D
+-103 -10 D
+9 -9 D
+83 5 D
+-62 -7 D
+37 -5 D
+-59 1 D
+41 -14 D
+42 -11 D
+56 50 D
+26 3 D
+0 -232 D
+-542 0 D
+0 542 D
+542 0 D
+P
+FO
+{0.784 A} FS
+-45 19 32 -8 2 1444 4567 SP
+1688 4585 M
+-46 12 D
+-17 -7 D
+-38 19 D
+7 -31 D
+-49 24 D
+-18 -15 D
+-46 9 D
+39 8 D
+-85 -9 D
+63 -36 D
+64 17 D
+2 -10 D
+31 7 D
+23 -8 D
+-103 -10 D
+9 -9 D
+83 5 D
+-62 -7 D
+37 -5 D
+-59 1 D
+41 -14 D
+42 -11 D
+56 50 D
+26 3 D
+P
+FO
+34 1 27 -11 -49 0 -2 -10 -10 2 5 1688 4619 SP
+-45 19 32 -8 2 1444 4567 SP
+1688 4585 M
+-46 12 D
+-17 -7 D
+-38 19 D
+7 -31 D
+-49 24 D
+-18 -15 D
+-46 9 D
+39 8 D
+-85 -9 D
+63 -36 D
+64 17 D
+2 -10 D
+31 7 D
+23 -8 D
+-103 -10 D
+9 -9 D
+83 5 D
+-62 -7 D
+37 -5 D
+-59 1 D
+41 -14 D
+42 -11 D
+56 50 D
+26 3 D
+S
+1688 4619 M
+-10 2 D
+-2 -10 D
+-49 0 D
+27 -11 D
+34 1 D
+S
+1444 4567 M
+32 -8 D
+-45 19 D
+P S
+{0.706 0.863 1 C} FS
+1928 4336 M
+-8 5 D
+44 -3 D
+23 9 D
+-56 13 D
+-30 -12 D
+19 15 D
+-24 4 D
+-16 -18 D
+-16 -3 D
+5 17 D
+-41 -25 D
+20 22 D
+-34 3 D
+-31 -27 D
+-4 0 D
+-49 9 D
+9 -9 D
+-16 0 D
+-1 1 D
+-34 -1 D
+0 232 D
+42 5 D
+-42 12 D
+0 16 D
+46 1 D
+-43 -9 D
+96 -8 D
+91 21 D
+-59 11 D
+-48 -7 D
+-7 11 D
+-15 -14 D
+-61 12 D
+0 259 D
+542 0 D
+0 -542 D
+P
+FO
+{0.784 A} FS
+36 10 6 -10 43 5 1 -18 -54 -4 -31 17 6 1796 4543 SP
+-42 -4 19 11 2 1715 4559 SP
+-48 -2 46 2 2 1905 4576 SP
+19 -3 -20 3 2 1851 4363 SP
+44 4 0 -1 2 2013 4610 SP
+-18 1 1 1769 4344 SP
+41 6 1 1742 4352 SP
+16 7 1 1769 4346 SP
+-1 -1 -1 1 2 1723 4336 SP
+9 -9 -49 9 2 1779 4336 SP
+-31 -27 -34 3 20 22 -41 -25 5 17 -16 -3 -16 -18 -24 4 19 15 -30 -12 -56 13 23 9 44 -3 -8 5 14 1928 4336 SP
+-61 12 -15 -14 -7 11 -48 -7 -59 11 91 21 96 -8 -43 -9 46 1 9 1688 4601 SP
+-42 12 42 5 2 1688 4568 SP
+36 10 6 -10 43 5 1 -18 -54 -4 -31 17 6 1796 4543 SP
+-42 -4 19 11 2 1715 4559 SP
+-48 -2 46 2 2 1905 4576 SP
+19 -3 -20 3 2 1851 4363 SP
+44 4 0 -1 2 2013 4610 SP
+-18 1 1 1769 4344 SP
+41 6 1 1742 4352 SP
+16 7 1 1769 4346 SP
+1928 4336 M
+-8 5 D
+44 -3 D
+23 9 D
+-56 13 D
+-30 -12 D
+19 15 D
+-24 4 D
+-16 -18 D
+-16 -3 D
+5 17 D
+-41 -25 D
+20 22 D
+-34 3 D
+-31 -27 D
+S
+1688 4601 M
+46 1 D
+-43 -9 D
+96 -8 D
+91 21 D
+-59 11 D
+-48 -7 D
+-7 11 D
+-15 -14 D
+-61 12 D
+S
+1796 4543 M
+-31 17 D
+-54 -4 D
+1 -18 D
+43 5 D
+6 -10 D
+36 10 D
+P S
+1715 4559 M
+19 11 D
+-42 -4 D
+P S
+1905 4576 M
+46 2 D
+-48 -2 D
+P S
+1851 4363 M
+-20 3 D
+P S
+2013 4610 M
+0 -1 D
+44 4 D
+P S
+1769 4344 M
+-18 1 D
+P S
+1742 4352 M
+41 6 D
+P S
+1769 4346 M
+16 7 D
+P S
+1723 4336 M
+-1 1 D
+-1 -1 D
+S
+1779 4336 M
+-49 9 D
+9 -9 D
+S
+1688 4568 M
+42 5 D
+-42 12 D
+S
+{0.706 0.863 1 C} FS
+2772 4634 M
+-1 0 D
+1 0 D
+0 -5 D
+-9 0 D
+8 -11 D
+1 0 D
+0 -118 D
+-108 -23 D
+26 -14 D
+-50 -12 D
+34 -6 D
+-36 4 D
+-37 -10 D
+59 -4 D
+-48 -8 D
+71 -3 D
+-9 14 D
+33 -3 D
+-27 7 D
+35 -4 D
+-11 12 D
+21 -5 D
+-1 15 D
+25 -4 D
+23 10 D
+0 -128 D
+-33 10 D
+-2 -12 D
+-507 0 D
+0 542 D
+542 0 D
+P
+FO
+{0.784 A} FS
+43 2 14 -10 -61 -22 35 -2 -34 -5 11 -7 -43 -3 -47 3 39 16 -3 18 -65 32 98 0 12 2609 4356 SP
+-105 -21 -4 11 108 10 3 2420 4612 SP
+-63 3 40 6 22 -9 3 2691 4619 SP
+9 7 1 2582 4611 SP
+-34 2 1 2528 4605 SP
+77 -5 1 2636 4633 SP
+28 8 1 2663 4609 SP
+-39 -5 1 2691 4645 SP
+35 0 -2 -12 -33 10 3 2772 4338 SP
+2772 4500 M
+-108 -23 D
+26 -14 D
+-50 -12 D
+34 -6 D
+-36 4 D
+-37 -10 D
+59 -4 D
+-48 -8 D
+71 -3 D
+-9 14 D
+33 -3 D
+-27 7 D
+35 -4 D
+-11 12 D
+21 -5 D
+-1 15 D
+25 -4 D
+23 10 D
+P
+FO
+1 0 8 -11 -9 0 3 2772 4629 SP
+-1 0 1 2772 4634 SP
+43 2 14 -10 -61 -22 35 -2 -34 -5 11 -7 -43 -3 -47 3 39 16 -3 18 -65 32 98 0 12 2609 4356 SP
+-105 -21 -4 11 108 10 3 2420 4612 SP
+-63 3 40 6 22 -9 3 2691 4619 SP
+9 7 1 2582 4611 SP
+-34 2 1 2528 4605 SP
+77 -5 1 2636 4633 SP
+28 8 1 2663 4609 SP
+-39 -5 1 2691 4645 SP
+2772 4500 M
+-108 -23 D
+26 -14 D
+-50 -12 D
+34 -6 D
+-36 4 D
+-37 -10 D
+59 -4 D
+-48 -8 D
+71 -3 D
+-9 14 D
+33 -3 D
+-27 7 D
+35 -4 D
+-11 12 D
+21 -5 D
+-1 15 D
+25 -4 D
+23 10 D
+S
+2609 4356 M
+98 0 D
+-65 32 D
+-3 18 D
+39 16 D
+-47 3 D
+-43 -3 D
+11 -7 D
+-34 -5 D
+35 -2 D
+-61 -22 D
+14 -10 D
+43 2 D
+P S
+2420 4612 M
+108 10 D
+-4 11 D
+-105 -21 D
+P S
+2772 4629 M
+-9 0 D
+8 -11 D
+1 0 D
+S
+2691 4619 M
+22 -9 D
+40 6 D
+-63 3 D
+P S
+2582 4611 M
+9 7 D
+P S
+2528 4605 M
+-34 2 D
+P S
+2772 4338 M
+-33 10 D
+-2 -12 D
+S
+2636 4633 M
+77 -5 D
+P S
+2663 4609 M
+28 8 D
+P S
+2691 4645 M
+-39 -5 D
+P S
+2772 4634 M
+-1 0 D
+P S
+{0.706 0.863 1 C} FS
+3116 4336 M
+3 24 D
+-27 16 D
+29 33 D
+-34 6 D
+-60 1 D
+-29 -37 D
+-43 -13 D
+1 -30 D
+-178 0 D
+-6 2 D
+0 128 D
+36 14 D
+192 25 D
+5 20 D
+-103 -17 D
+-99 -1 D
+-31 -7 D
+0 118 D
+55 13 D
+-55 -2 D
+0 5 D
+45 3 D
+-45 -3 D
+0 244 D
+542 0 D
+0 -486 D
+-42 9 D
+-27 -5 D
+15 -10 D
+-55 1 D
+69 -26 D
+-65 7 D
+-35 45 D
+5 -17 D
+-54 -22 D
+35 -22 D
+-6 -16 D
+P
+FO
+{0.784 A} FS
+-2 -10 -34 -1 8 8 3 3070 4421 SP
+55 13 1 2853 4626 SP
+15 -8 1 3287 4418 SP
+22 1 1 3154 4418 SP
+0 -2 -6 2 2 2778 4336 SP
+1 -30 -43 -13 -29 -37 -60 1 -34 6 29 33 -27 16 3 24 8 3116 4336 SP
+160 0 -6 -16 35 -22 -54 -22 5 -17 -35 45 -65 7 69 -26 -55 1 15 -10 -27 -5 -42 9 12 3314 4392 SP
+45 3 1 2772 4634 SP
+-55 -2 55 13 2 2772 4618 SP
+-31 -7 -99 -1 -103 -17 5 20 192 25 36 14 6 2772 4466 SP
+-2 -10 -34 -1 8 8 3 3070 4421 SP
+55 13 1 2853 4626 SP
+15 -8 1 3287 4418 SP
+22 1 1 3154 4418 SP
+3314 4392 M
+-42 9 D
+-27 -5 D
+15 -10 D
+-55 1 D
+69 -26 D
+-65 7 D
+-35 45 D
+5 -17 D
+-54 -22 D
+35 -22 D
+-6 -16 D
+S
+3116 4336 M
+3 24 D
+-27 16 D
+29 33 D
+-34 6 D
+-60 1 D
+-29 -37 D
+-43 -13 D
+1 -30 D
+S
+2772 4466 M
+36 14 D
+192 25 D
+5 20 D
+-103 -17 D
+-99 -1 D
+-31 -7 D
+S
+3070 4421 M
+8 8 D
+-34 -1 D
+-2 -10 D
+P S
+2853 4626 M
+55 13 D
+P S
+3287 4418 M
+15 -8 D
+P S
+2772 4634 M
+45 3 D
+P S
+3154 4418 M
+22 1 D
+P S
+2772 4618 M
+55 13 D
+-55 -2 D
+S
+2778 4336 M
+-6 2 D
+S
+{0.706 0.863 1 C} FS
+0 -2 6 2 2 3525 4336 SP
+3392 4336 M
+-12 5 D
+11 21 D
+-22 -11 D
+34 32 D
+-49 0 D
+-40 9 D
+0 486 D
+542 0 D
+0 -275 D
+-33 6 D
+-30 -6 D
+0 9 D
+-130 -17 D
+85 -15 D
+108 -2 D
+0 -66 D
+-30 0 D
+26 -12 D
+-28 6 D
+-84 -12 D
+11 8 D
+-77 0 D
+-12 -6 D
+35 1 D
+-194 -21 D
+1 -15 D
+-29 7 D
+35 -28 D
+-182 -7 D
+9 -31 D
+77 -21 D
+-1 -45 D
+P
+FO
+23 3 -23 2 2 3856 4454 SP
+12 3 -12 -2 2 3856 4378 SP
+{0.784 A} FS
+-114 -28 -68 17 24 12 97 6 4 3686 4607 SP
+47 0 7 -10 -76 4 21 6 4 3667 4599 SP
+18 5 1 3744 4526 SP
+3 9 1 3368 4477 SP
+{0.706 0.863 1 C} FS
+-24 2 23 -2 2 3833 4400 SP
+{0.784 A} FS
+0 -56 -40 9 -49 0 34 32 -22 -11 11 21 -12 5 7 3392 4336 SP
+3525 4336 M
+6 2 D
+0 -2 D
+325 0 D
+0 42 D
+-12 -2 D
+12 3 D
+0 75 D
+-23 2 D
+23 3 D
+0 53 D
+-30 0 D
+26 -12 D
+-28 6 D
+-84 -12 D
+11 8 D
+-77 0 D
+-12 -6 D
+35 1 D
+-194 -21 D
+1 -15 D
+-29 7 D
+35 -28 D
+-182 -7 D
+9 -31 D
+77 -21 D
+-1 -45 D
+P
+FO
+108 -2 1 0 84 -15 -130 -17 0 9 -30 -6 -33 6 7 3856 4603 SP
+-114 -28 -68 17 24 12 97 6 4 3686 4607 SP
+47 0 7 -10 -76 4 21 6 4 3667 4599 SP
+18 5 1 3744 4526 SP
+3 9 1 3368 4477 SP
+{0.706 0.863 1 C} FS
+-24 2 23 -2 2 3833 4400 SP
+3856 4512 M
+-30 0 D
+26 -12 D
+-28 6 D
+-84 -12 D
+11 8 D
+-77 0 D
+-12 -6 D
+35 1 D
+-194 -21 D
+1 -15 D
+-29 7 D
+35 -28 D
+-182 -7 D
+9 -31 D
+77 -21 D
+-1 -45 D
+S
+3856 4603 M
+-33 6 D
+-30 -6 D
+0 9 D
+-130 -17 D
+85 -15 D
+108 -2 D
+S
+3392 4336 M
+-12 5 D
+11 21 D
+-22 -11 D
+34 32 D
+-49 0 D
+-40 9 D
+S
+3686 4607 M
+97 6 D
+24 12 D
+-68 17 D
+-114 -28 D
+P S
+3667 4599 M
+21 6 D
+-76 4 D
+7 -10 D
+P S
+3744 4526 M
+18 5 D
+P S
+3368 4477 M
+3 9 D
+P S
+3525 4336 M
+6 2 D
+0 -2 D
+S
+3833 4400 M
+23 -2 D
+-24 2 D
+P S
+3856 4454 M
+-23 2 D
+23 3 D
+S
+3856 4378 M
+-12 -2 D
+12 3 D
+S
+-55 -10 -26 10 23 -11 -80 -22 1 -1 137 33 6 3856 4379 SP
+-17 2 -8 12 9 -16 -38 6 -22 -8 -81 -9 43 -8 0 9 77 4 36 -14 -15 15 16 2 12 3856 4459 SP
+3856 4578 M
+3 24 D
+-3 1 D
+0 275 D
+542 0 D
+0 -462 D
+-43 8 D
+13 8 D
+-87 5 D
+-58 -14 D
+-19 21 D
+-14 -8 D
+-20 10 D
+-42 -1 D
+-9 -9 D
+36 0 D
+-127 -13 D
+-23 -12 D
+41 24 D
+178 43 D
+-33 17 D
+33 -9 D
+10 9 D
+-77 25 D
+-124 -7 D
+28 11 D
+-92 4 D
+59 8 D
+-59 10 D
+-76 -17 D
+-6 -17 D
+-31 0 D
+P
+FO
+{0.784 A} FS
+0 17 -39 -10 -43 18 140 14 4 3865 4553 SP
+17 8 24 -8 2 4181 4455 SP
+4398 4416 M
+-43 8 D
+13 8 D
+-87 5 D
+-58 -14 D
+-19 21 D
+-14 -8 D
+-20 10 D
+-42 -1 D
+-9 -9 D
+36 0 D
+-127 -13 D
+-23 -12 D
+41 24 D
+178 43 D
+-33 17 D
+33 -9 D
+10 9 D
+-77 25 D
+-124 -7 D
+28 11 D
+-92 4 D
+59 8 D
+-59 10 D
+-76 -17 D
+-6 -17 D
+-31 0 D
+0 -53 D
+16 2 D
+-15 15 D
+36 -14 D
+77 4 D
+0 9 D
+43 -8 D
+-81 -9 D
+-22 -8 D
+-38 6 D
+9 -16 D
+-8 12 D
+-17 2 D
+0 -75 D
+137 33 D
+1 -1 D
+-80 -22 D
+23 -11 D
+-26 10 D
+-55 -10 D
+0 -42 D
+542 0 D
+P
+FO
+-3 1 3 24 2 3856 4578 SP
+0 17 -39 -10 -43 18 140 14 4 3865 4553 SP
+17 8 24 -8 2 4181 4455 SP
+4398 4416 M
+-43 8 D
+13 8 D
+-87 5 D
+-58 -14 D
+-19 21 D
+-14 -8 D
+-20 10 D
+-42 -1 D
+-9 -9 D
+36 0 D
+-127 -13 D
+-23 -12 D
+41 24 D
+178 43 D
+-33 17 D
+33 -9 D
+10 9 D
+-77 25 D
+-124 -7 D
+28 11 D
+-92 4 D
+59 8 D
+-59 10 D
+-76 -17 D
+-6 -17 D
+-31 0 D
+S
+3865 4553 M
+140 14 D
+-43 18 D
+-39 -10 D
+0 17 D
+P S
+4181 4455 M
+24 -8 D
+17 8 D
+P S
+3856 4578 M
+3 24 D
+-3 1 D
+S
+3856 4459 M
+16 2 D
+-15 15 D
+36 -14 D
+77 4 D
+0 9 D
+43 -8 D
+-81 -9 D
+-22 -8 D
+-38 6 D
+9 -16 D
+-8 12 D
+-17 2 D
+S
+3856 4379 M
+137 33 D
+1 -1 D
+-80 -22 D
+23 -11 D
+-26 10 D
+-55 -10 D
+S
+{0.706 0.863 1 C} FS
+-12 -13 -48 -9 9 -16 -7 16 49 9 12 13 6 4542 4336 SP
+4940 4493 M
+-33 11 D
+-48 -16 D
+27 -20 D
+54 0 D
+0 -38 D
+-5 -1 D
+5 -1 D
+0 -27 D
+-23 -4 D
+23 1 D
+0 -2 D
+-18 -7 D
+18 -12 D
+0 -2 D
+-51 4 D
+-7 -13 D
+-49 14 D
+-60 -5 D
+-28 14 D
+-47 -34 D
+-75 38 D
+34 3 D
+-30 9 D
+27 3 D
+-17 15 D
+-68 2 D
+-50 14 D
+-44 -25 D
+-77 2 D
+0 462 D
+542 0 D
+P
+FO
+{0.784 A} FS
+-5 12 1 4832 4483 SP
+-27 0 27 1 2 4859 4377 SP
+{0.706 0.863 1 C} FS
+-83 23 31 27 -34 -29 3 4500 4393 SP
+{0.784 A} FS
+4542 4336 M
+12 13 D
+49 9 D
+-7 16 D
+9 -16 D
+-48 -9 D
+-12 -13 D
+395 0 D
+0 39 D
+-51 4 D
+-7 -13 D
+-49 14 D
+-60 -5 D
+-28 14 D
+-47 -34 D
+-75 38 D
+34 3 D
+-30 9 D
+27 3 D
+-17 15 D
+-68 2 D
+-50 14 D
+-44 -25 D
+-77 2 D
+0 -80 D
+P
+FO
+18 -12 -18 -7 2 4940 4396 SP
+23 1 -23 -4 2 4940 4401 SP
+5 -1 -5 -1 2 4940 4430 SP
+54 0 27 -20 -48 -16 -33 11 4 4940 4493 SP
+-5 12 1 4832 4483 SP
+-27 0 27 1 2 4859 4377 SP
+{0.706 0.863 1 C} FS
+-83 23 31 27 -34 -29 3 4500 4393 SP
+4940 4375 M
+-51 4 D
+-7 -13 D
+-49 14 D
+-60 -5 D
+-28 14 D
+-47 -34 D
+-75 38 D
+34 3 D
+-30 9 D
+27 3 D
+-17 15 D
+-68 2 D
+-50 14 D
+-44 -25 D
+-77 2 D
+S
+4940 4493 M
+-33 11 D
+-48 -16 D
+27 -20 D
+54 0 D
+S
+4832 4483 M
+-5 12 D
+P S
+4859 4377 M
+27 1 D
+-27 0 D
+P S
+4940 4401 M
+-23 -4 D
+23 1 D
+S
+4940 4396 M
+-18 -7 D
+18 -12 D
+S
+4940 4430 M
+-5 -1 D
+5 -1 D
+S
+4542 4336 M
+12 13 D
+49 9 D
+-7 16 D
+9 -16 D
+-48 -9 D
+-12 -13 D
+S
+4500 4393 M
+-34 -29 D
+31 27 D
+-83 23 D
+P S
+0 -7 -69 -26 1 0 70 23 0 10 5 5141 4336 SP
+-4 0 4 -2 2 4940 4377 SP
+-6 -2 6 0 2 4940 4398 SP
+4940 4428 M
+82 -5 D
+14 7 D
+-40 12 D
+-56 -12 D
+0 38 D
+98 1 D
+-33 23 D
+28 -19 D
+54 12 D
+-109 19 D
+-22 -16 D
+-16 5 D
+0 385 D
+542 0 D
+0 -541 D
+-29 24 D
+-81 5 D
+-92 -8 D
+-100 24 D
+33 7 D
+-46 11 D
+-34 -1 D
+-48 -20 D
+4 18 D
+13 -10 D
+27 12 D
+-74 -2 D
+71 3 D
+-162 14 D
+12 -8 D
+-36 -5 D
+P
+FO
+{0.784 A} FS
+-122 13 53 10 51 -7 3 5134 4472 SP
+-19 7 1 4967 4444 SP
+5141 4336 M
+0 10 D
+71 23 D
+-69 -26 D
+0 -7 D
+339 0 D
+0 1 D
+-29 24 D
+-81 5 D
+-92 -8 D
+-100 24 D
+33 7 D
+-46 11 D
+-34 -1 D
+-48 -20 D
+4 18 D
+13 -10 D
+27 12 D
+-74 -2 D
+71 3 D
+-162 14 D
+12 -8 D
+-36 -5 D
+0 -3 D
+6 0 D
+-6 -2 D
+0 -19 D
+4 -2 D
+-4 0 D
+0 -39 D
+P
+FO
+-16 5 -22 -16 -109 19 54 12 28 -19 -33 23 98 1 7 4940 4468 SP
+-56 -12 -40 12 14 7 82 -5 4 4940 4428 SP
+-122 13 53 10 51 -7 3 5134 4472 SP
+-19 7 1 4967 4444 SP
+5482 4337 M
+-29 24 D
+-81 5 D
+-92 -8 D
+-100 24 D
+33 7 D
+-46 11 D
+-34 -1 D
+-48 -20 D
+4 18 D
+13 -10 D
+27 12 D
+-74 -2 D
+71 3 D
+-162 14 D
+12 -8 D
+-36 -5 D
+S
+4940 4468 M
+98 1 D
+-33 23 D
+28 -19 D
+54 12 D
+-109 19 D
+-22 -16 D
+-16 5 D
+S
+5134 4472 M
+51 -7 D
+53 10 D
+-122 13 D
+P S
+4940 4428 M
+82 -5 D
+14 7 D
+-40 12 D
+-56 -12 D
+S
+4967 4444 M
+-19 7 D
+P S
+4940 4398 M
+6 0 D
+-6 -2 D
+S
+4940 4377 M
+4 -2 D
+-4 0 D
+S
+5141 4336 M
+0 10 D
+71 23 D
+-69 -26 D
+0 -7 D
+S
+{0.706 0.863 1 C} FS
+0 -26 27 3 -27 -15 0 -504 542 0 0 541 -2 1 -282 0 -2 -4 -25 4 10 5793 4336 SP
+{0.784 A} FS
+0 -1 -2 1 2 5484 4336 SP
+-2 -4 -25 4 2 5793 4336 SP
+27 3 -27 -15 2 6024 4374 SP
+6024 4374 M
+-27 -15 D
+27 3 D
+S
+5793 4336 M
+-25 4 D
+-2 -4 D
+S
+5484 4336 M
+-2 1 D
+S
+{0.706 0.863 1 C} FS
+-478 0 -12 -8 -49 -9 -3 4 0 -529 542 0 0 504 -9 -5 -62 9 71 8 10 6024 4362 SP
+{0.784 A} FS
+12 5 1 6498 4339 SP
+64 0 -12 -8 -49 -9 -3 4 4 6566 4349 SP
+-9 -5 -62 9 71 8 3 6024 4362 SP
+12 5 1 6498 4339 SP
+6024 4362 M
+71 8 D
+-62 9 D
+-9 -5 D
+S
+6566 4349 M
+-3 4 D
+-49 -9 D
+-12 -8 D
+S
+6498 4339 M
+12 5 D
+P S
+{0.706 0.863 1 C} FS
+0 -542 543 0 0 529 -5 4 -5 -13 -50 -2 -36 -14 -25 6 12 11 -25 -10 -24 10 -52 -2 9 8 -38 5 -215 6 -18 4 16 7038 4336 SP
+36 -2 -19 6 2 6741 4349 SP
+{0.784 A} FS
+0 -13 -5 4 -5 -13 -50 -2 -36 -14 -25 6 12 11 -25 -10 -24 10 -52 -2 9 8 -38 5 -215 6 -18 4 14 7038 4336 SP
+{0.706 0.863 1 C} FS
+36 -2 -19 6 2 6741 4349 SP
+7038 4336 M
+-18 4 D
+-215 6 D
+-38 5 D
+9 8 D
+-52 -2 D
+-24 10 D
+-25 -10 D
+12 11 D
+-25 6 D
+-36 -14 D
+-50 -2 D
+-5 -13 D
+-5 4 D
+S
+6741 4349 M
+-19 6 D
+36 -2 D
+P S
+91 0 0 542 -91 0 3 7200 4336 SP
+62 0 0 204 -38 3 8 -10 30 -1 0 -8 -62 7 7 62 4683 SP
+{0.784 A} FS
+27 -5 -29 5 2 29 4688 SP
+62 0 0 -338 -38 3 8 -10 30 -1 0 -8 -62 7 7 62 4683 SP
+27 -5 -29 5 2 29 4688 SP
+62 4683 M
+-62 7 D
+0 4682 M
+30 -1 D
+8 -10 D
+-38 3 D
+S
+0 4693 M
+29 -5 D
+P S
+{0.706 0.863 1 C} FS
+539 4336 M
+8 3 D
+-86 9 D
+-52 -12 D
+-16 0 D
+-22 3 D
+56 10 D
+-74 0 D
+36 19 D
+31 -6 D
+37 9 D
+-82 7 D
+30 5 D
+-28 8 D
+101 -18 D
+34 -24 D
+24 11 D
+2 -11 D
+25 1 D
+-22 15 D
+15 12 D
+-22 -1 D
+18 8 D
+-34 -3 D
+17 8 D
+-56 13 D
+-24 -8 D
+6 7 D
+-29 0 D
+48 3 D
+-19 8 D
+-37 -7 D
+-22 8 D
+64 6 D
+-71 2 D
+37 3 D
+-27 7 D
+36 -7 D
+36 7 D
+-29 12 D
+35 -11 D
+9 8 D
+52 -6 D
+-51 2 D
+46 -12 D
+54 7 D
+3 10 D
+-39 6 D
+-3 -12 D
+-17 11 D
+10 15 D
+57 -8 D
+0 -117 D
+P
+FO
+604 4649 M
+-29 2 D
+-101 -29 D
+50 42 D
+-132 -19 D
+45 16 D
+-220 -5 D
+40 11 D
+190 -1 D
+105 13 D
+-136 4 D
+19 10 D
+-289 -12 D
+56 12 D
+218 5 D
+-327 5 D
+-24 -21 D
+-7 1 D
+0 195 D
+542 0 D
+P
+FO
+-19 -4 1 604 4634 SP
+35 2 -35 0 2 604 4623 SP
+17 2 -6 9 -11 -1 3 604 4602 SP
+50 22 4 12 -30 -9 -24 4 4 604 4550 SP
+30 3 -30 3 2 604 4538 SP
+74 2 -24 13 -50 1 3 604 4504 SP
+51 5 -51 5 2 604 4493 SP
+68 -10 -53 10 52 0 -50 4 12 11 -29 2 6 604 4460 SP
+{0.784 A} FS
+-38 0 -27 18 51 -8 3 495 4403 SP
+-27 7 51 -2 2 550 4452 SP
+-31 -6 -44 9 2 523 4420 SP
+-11 12 67 5 2 393 4349 SP
+-16 8 58 -5 2 495 4415 SP
+-10 8 1 603 4465 SP
+{0.706 0.863 1 C} FS
+-47 1 1 597 4528 SP
+-21 8 20 -8 2 563 4539 SP
+{0.784 A} FS
+393 4336 M
+-22 3 D
+56 10 D
+-74 0 D
+36 19 D
+31 -6 D
+37 9 D
+-82 7 D
+30 5 D
+-28 8 D
+101 -18 D
+34 -24 D
+24 11 D
+2 -11 D
+25 1 D
+-22 15 D
+15 12 D
+-22 -1 D
+18 8 D
+-34 -3 D
+17 8 D
+-56 13 D
+-24 -8 D
+6 7 D
+-29 0 D
+48 3 D
+-19 8 D
+-37 -7 D
+-22 8 D
+64 6 D
+-71 2 D
+37 3 D
+-27 7 D
+36 -7 D
+36 7 D
+-29 12 D
+35 -11 D
+9 8 D
+52 -6 D
+-51 2 D
+46 -12 D
+54 7 D
+3 10 D
+-39 6 D
+-3 -12 D
+-17 11 D
+10 15 D
+57 -8 D
+0 7 D
+-29 2 D
+12 11 D
+-50 4 D
+52 0 D
+-53 10 D
+68 -10 D
+0 16 D
+-51 5 D
+51 5 D
+0 1 D
+-50 1 D
+-24 13 D
+74 2 D
+0 18 D
+-30 3 D
+30 3 D
+0 6 D
+-24 4 D
+-30 -9 D
+4 12 D
+50 22 D
+0 23 D
+-11 -1 D
+-6 9 D
+17 2 D
+0 11 D
+-35 0 D
+35 2 D
+0 9 D
+-19 -4 D
+19 4 D
+0 15 D
+-29 2 D
+-101 -29 D
+50 42 D
+-132 -19 D
+45 16 D
+-220 -5 D
+40 11 D
+190 -1 D
+105 13 D
+-136 4 D
+19 10 D
+-289 -12 D
+56 12 D
+218 5 D
+-327 5 D
+-24 -21 D
+-7 1 D
+0 -347 D
+P
+FO
+-52 -12 -86 9 8 3 3 539 4336 SP
+-38 0 -27 18 51 -8 3 495 4403 SP
+-27 7 51 -2 2 550 4452 SP
+-31 -6 -44 9 2 523 4420 SP
+-11 12 67 5 2 393 4349 SP
+-16 8 58 -5 2 495 4415 SP
+-10 8 1 603 4465 SP
+{0.706 0.863 1 C} FS
+-47 1 1 597 4528 SP
+-21 8 20 -8 2 563 4539 SP
+393 4336 M
+-22 3 D
+56 10 D
+-74 0 D
+36 19 D
+31 -6 D
+37 9 D
+-82 7 D
+30 5 D
+-28 8 D
+101 -18 D
+34 -24 D
+24 11 D
+2 -11 D
+25 1 D
+-22 15 D
+15 12 D
+-22 -1 D
+18 8 D
+-34 -3 D
+17 8 D
+-56 13 D
+-24 -8 D
+6 7 D
+-29 0 D
+48 3 D
+-19 8 D
+-37 -7 D
+-22 8 D
+64 6 D
+-71 2 D
+37 3 D
+-27 7 D
+36 -7 D
+36 7 D
+-29 12 D
+35 -11 D
+9 8 D
+52 -6 D
+-51 2 D
+46 -12 D
+54 7 D
+3 10 D
+-39 6 D
+-3 -12 D
+-17 11 D
+10 15 D
+57 -8 D
+S
+604 4649 M
+-29 2 D
+-101 -29 D
+50 42 D
+-132 -19 D
+45 16 D
+-220 -5 D
+40 11 D
+190 -1 D
+105 13 D
+-136 4 D
+19 10 D
+-289 -12 D
+56 12 D
+218 5 D
+-327 5 D
+-24 -21 D
+-7 1 D
+S
+604 4460 M
+-29 2 D
+12 11 D
+-50 4 D
+52 0 D
+-53 10 D
+68 -10 D
+S
+495 4403 M
+51 -8 D
+-27 18 D
+-38 0 D
+P S
+550 4452 M
+51 -2 D
+-27 7 D
+P S
+523 4420 M
+-44 9 D
+-31 -6 D
+P S
+604 4550 M
+-24 4 D
+-30 -9 D
+4 12 D
+50 22 D
+S
+539 4336 M
+8 3 D
+-86 9 D
+-52 -12 D
+S
+604 4504 M
+-50 1 D
+-24 13 D
+74 2 D
+S
+604 4602 M
+-11 -1 D
+-6 9 D
+17 2 D
+S
+393 4349 M
+67 5 D
+-11 12 D
+P S
+495 4415 M
+58 -5 D
+-16 8 D
+P S
+603 4465 M
+-10 8 D
+P S
+604 4493 M
+-51 5 D
+51 5 D
+S
+604 4623 M
+-35 0 D
+35 2 D
+S
+604 4538 M
+-30 3 D
+30 3 D
+S
+597 4528 M
+-47 1 D
+P S
+563 4539 M
+20 -8 D
+-21 8 D
+P S
+604 4634 M
+-19 -4 D
+P S
+604 4453 M
+10 -2 D
+18 7 D
+-28 2 D
+0 17 D
+11 -2 D
+7 16 D
+-18 2 D
+0 10 D
+6 0 D
+-6 1 D
+0 16 D
+47 1 D
+-4 14 D
+-43 3 D
+0 6 D
+22 2 D
+-22 4 D
+0 29 D
+64 28 D
+-64 -5 D
+0 10 D
+105 9 D
+-105 2 D
+0 2 D
+141 7 D
+52 23 D
+-106 5 D
+-44 -14 D
+-43 3 D
+0 229 D
+542 0 D
+0 -542 D
+-542 0 D
+P
+FO
+1 0 43 8 2 604 4634 SP
+{0.784 A} FS
+-18 11 38 1 2 637 4472 SP
+-24 -8 1 925 4367 SP
+7 7 1 658 4544 SP
+-18 20 1 646 4499 SP
+-43 3 -44 -14 -106 5 52 23 141 7 0 -9 -44 -8 1 0 43 8 9 604 4634 SP
+-105 2 105 9 2 604 4612 SP
+-64 -5 64 28 2 604 4579 SP
+-22 4 22 2 2 604 4544 SP
+-43 3 -4 14 47 1 3 604 4520 SP
+-6 1 6 0 2 604 4503 SP
+-18 2 7 16 11 -2 3 604 4477 SP
+-28 2 18 7 10 -2 3 604 4453 SP
+-18 11 38 1 2 637 4472 SP
+-24 -8 1 925 4367 SP
+7 7 1 658 4544 SP
+-18 20 1 646 4499 SP
+604 4625 M
+141 7 D
+52 23 D
+-106 5 D
+-44 -14 D
+-43 3 D
+S
+637 4472 M
+38 1 D
+-18 11 D
+P S
+925 4367 M
+-24 -8 D
+P S
+658 4544 M
+7 7 D
+P S
+604 4477 M
+11 -2 D
+7 16 D
+-18 2 D
+S
+604 4520 M
+47 1 D
+-4 14 D
+-43 3 D
+S
+604 4453 M
+10 -2 D
+18 7 D
+-28 2 D
+S
+646 4499 M
+-18 20 D
+P S
+604 4612 M
+105 9 D
+-105 2 D
+S
+604 4503 M
+6 0 D
+-6 1 D
+S
+604 4544 M
+22 2 D
+-22 4 D
+S
+604 4579 M
+64 28 D
+-64 -5 D
+S
+604 4634 M
+44 8 D
+P S
+{0.706 0.863 1 C} FS
+1146 3816 M
+38 10 D
+1 6 D
+-32 2 D
+18 3 D
+23 25 D
+-13 12 D
+-34 -1 D
+-1 0 D
+0 463 D
+542 0 D
+0 -7 D
+-10 -8 D
+2 10 D
+-21 -5 D
+17 -11 D
+-38 7 D
+-13 -22 D
+-33 -4 D
+39 -3 D
+-44 -1 D
+7 -15 D
+-14 12 D
+-20 -5 D
+16 -4 D
+-28 -1 D
+29 -8 D
+-43 -9 D
+31 -4 D
+-53 -4 D
+13 -4 D
+-26 -17 D
+31 4 D
+-40 -7 D
+14 -7 D
+-15 3 D
+-17 -19 D
+25 2 D
+-45 -11 D
+24 2 D
+-21 -8 D
+12 -6 D
+-17 -4 D
+-7 8 D
+-39 -26 D
+24 -2 D
+27 15 D
+-12 -18 D
+-31 -4 D
+-4 8 D
+-31 -6 D
+5 -15 D
+-22 4 D
+17 -8 D
+-42 7 D
+32 -7 D
+-51 -3 D
+25 -13 D
+-14 7 D
+-3 -7 D
+-17 4 D
+10 -5 D
+-33 4 D
+2 -8 D
+46 -1 D
+-45 0 D
+-6 -8 D
+24 -3 D
+-24 -1 D
+19 -2 D
+-12 -7 D
+35 3 D
+6 6 D
+16 -7 D
+7 9 D
+3 -7 D
+-16 -10 D
+-13 8 D
+-44 -4 D
+15 -4 D
+-17 -2 D
+9 -7 D
+14 5 D
+-17 -9 D
+7 -7 D
+9 7 D
+-6 -14 D
+44 17 D
+-52 -26 D
+11 -8 D
+26 8 D
+-19 -12 D
+20 -1 D
+-10 -6 D
+-19 5 D
+2 -13 D
+38 -15 D
+32 3 D
+35 28 D
+24 -2 D
+9 23 D
+13 -42 D
+13 2 D
+-3 -14 D
+9 11 D
+-6 -17 D
+34 -30 D
+-14 -8 D
+10 -25 D
+38 0 D
+13 21 D
+32 -2 D
+23 37 D
+-8 28 D
+14 0 D
+-20 5 D
+35 3 D
+4 11 D
+8 -10 D
+21 13 D
+-17 4 D
+27 9 D
+-29 23 D
+-22 2 D
+13 63 D
+12 -7 D
+51 21 D
+0 -233 D
+-2 0 D
+-1 -8 D
+3 0 D
+0 -4 D
+-17 -7 D
+14 11 D
+-30 -8 D
+-23 13 D
+-87 -22 D
+-4 -11 D
+-42 23 D
+-58 -13 D
+7 11 D
+-27 -2 D
+-20 14 D
+4 24 D
+38 20 D
+-23 7 D
+15 28 D
+-56 -17 D
+-9 -64 D
+9 4 D
+11 -11 D
+-12 -5 D
+34 -21 D
+-31 10 D
+-4 -14 D
+-15 9 D
+-24 -3 D
+9 -10 D
+-42 4 D
+-14 -8 D
+13 -14 D
+-16 -7 D
+-14 18 D
+-19 -27 D
+17 -7 D
+-33 -5 D
+22 -5 D
+-72 -13 D
+2 -19 D
+-10 -5 D
+-35 0 D
+P
+FO
+2 4 -2 -1 2 1688 4318 SP
+-39 12 1 1688 4283 SP
+{0.784 A} FS
+30 -32 -25 -6 -8 8 -7 -12 -10 14 21 16 6 1469 3930 SP
+-3 15 21 -1 -1 -11 3 1417 3944 SP
+-4 10 -23 -7 44 15 3 1552 4290 SP
+-19 -15 -14 5 2 1634 4321 SP
+-22 -9 5 12 2 1552 4298 SP
+20 32 -11 -22 2 1601 3984 SP
+-24 -10 22 25 2 1639 3984 SP
+-13 -5 1 1525 4289 SP
+-5 -8 1 1441 3930 SP
+-12 -4 1 1545 3903 SP
+0 7 1 1281 4071 SP
+17 3 1 1370 4165 SP
+-7 -5 7 6 2 1480 4228 SP
+2 -6 1 1432 3957 SP
+6 -5 1 1644 4079 SP
+9 -3 1 1423 3929 SP
+-11 -2 11 3 2 1286 3885 SP
+-21 -4 1 1390 4164 SP
+6 -8 -7 8 2 1553 3930 SP
+-21 -5 1 1552 4292 SP
+18 9 1 1565 4309 SP
+-9 6 1 1417 3926 SP
+-13 -6 -1 8 2 1518 3910 SP
+-26 -2 1 1679 4336 SP
+{0.706 0.863 1 C} FS
+-14 -7 -8 8 5 -11 -20 -3 24 -2 13 14 6 1378 3973 SP
+-2 12 22 -1 3 16 -41 -10 -6 -16 5 1527 4047 SP
+11 -12 -3 10 46 -2 3 1580 4052 SP
+5 -8 1 1446 4064 SP
+2 -8 1 1543 4146 SP
+25 -7 -24 7 2 1685 4292 SP
+23 0 1 1374 4102 SP
+-18 5 1 0 2 1650 4236 SP
+7 -6 1 1362 4065 SP
+-16 7 0 -1 2 1619 4217 SP
+4 -7 1 1496 4056 SP
+1 -8 1 1375 4047 SP
+16 0 1 0 2 1587 4251 SP
+-15 0 1 1446 4154 SP
+10 -6 -9 5 2 1622 4279 SP
+5 -7 1 1502 4060 SP
+10 -5 -9 5 2 1597 4240 SP
+14 -3 -13 3 2 1660 4266 SP
+13 -6 1 1505 4110 SP
+-4 7 3 -6 2 1499 4068 SP
+17 0 1 1376 4116 SP
+3 -8 1 1450 4111 SP
+6 -7 1 1384 4065 SP
+-2 7 1 -7 2 1356 4034 SP
+-1 -6 1 1327 4029 SP
+-21 -29 0 1 2 1551 4033 SP
+-29 20 0 -1 2 1636 4221 SP
+6 -14 1 1531 4155 SP
+23 0 1 1568 4047 SP
+-74 22 1 1682 4255 SP
+54 -24 1 1521 4191 SP
+21 -19 1 1429 4095 SP
+9 -6 1 1543 4091 SP
+17 6 1 1595 4264 SP
+2 -15 1 1467 4051 SP
+-25 -9 1 1618 4079 SP
+-44 7 1 1670 4246 SP
+-10 -6 11 6 2 1526 4219 SP
+-5 -7 1 1521 3985 SP
+-21 10 1 1608 4203 SP
+-1 -14 1 1470 4131 SP
+2 -8 1 1506 4166 SP
+8 -6 1 1554 4014 SP
+23 -12 1 1578 4199 SP
+5 -6 1 1542 3977 SP
+-20 10 1 1541 4168 SP
+2 8 -3 -8 2 1560 4133 SP
+9 -6 1 1555 4145 SP
+6 -7 1 1569 4180 SP
+7 -6 -6 6 2 1517 4193 SP
+-6 15 5 -15 2 1423 4087 SP
+-22 -6 21 6 2 1460 4175 SP
+-14 8 1 1630 4240 SP
+9 -8 1 1484 4056 SP
+-12 8 1 1594 4198 SP
+5 -7 1 1475 4048 SP
+-9 5 1 1565 4214 SP
+-13 4 1 1553 4227 SP
+{0.784 A} FS
+1688 3916 M
+-17 -7 D
+14 11 D
+-30 -8 D
+-23 13 D
+-87 -22 D
+-4 -11 D
+-42 23 D
+-58 -13 D
+7 11 D
+-27 -2 D
+-20 14 D
+4 24 D
+38 20 D
+-23 7 D
+15 28 D
+-56 -17 D
+-9 -64 D
+9 4 D
+11 -11 D
+-12 -5 D
+34 -21 D
+-31 10 D
+-4 -14 D
+-15 9 D
+-24 -3 D
+9 -10 D
+-42 4 D
+-14 -8 D
+13 -14 D
+-16 -7 D
+-14 18 D
+-19 -27 D
+17 -7 D
+-33 -5 D
+22 -5 D
+-72 -13 D
+2 -19 D
+-10 -5 D
+507 0 D
+P
+FO
+3 0 -1 -8 -2 0 3 1688 3928 SP
+1688 4283 M
+-39 12 D
+39 -12 D
+0 35 D
+-2 -1 D
+2 4 D
+0 8 D
+-10 -8 D
+2 10 D
+-21 -5 D
+17 -11 D
+-38 7 D
+-13 -22 D
+-33 -4 D
+39 -3 D
+-44 -1 D
+7 -15 D
+-14 12 D
+-20 -5 D
+16 -4 D
+-28 -1 D
+29 -8 D
+-43 -9 D
+31 -4 D
+-53 -4 D
+13 -4 D
+-26 -17 D
+31 4 D
+-40 -7 D
+14 -7 D
+-15 3 D
+-17 -19 D
+25 2 D
+-45 -11 D
+24 2 D
+-21 -8 D
+12 -6 D
+-17 -4 D
+-7 8 D
+-39 -26 D
+24 -2 D
+27 15 D
+-12 -18 D
+-31 -4 D
+-4 8 D
+-31 -6 D
+5 -15 D
+-22 4 D
+17 -8 D
+-42 7 D
+32 -7 D
+-51 -3 D
+25 -13 D
+-14 7 D
+-3 -7 D
+-17 4 D
+10 -5 D
+-33 4 D
+2 -8 D
+46 -1 D
+-45 0 D
+-6 -8 D
+24 -3 D
+-24 -1 D
+19 -2 D
+-12 -7 D
+35 3 D
+6 6 D
+16 -7 D
+7 9 D
+3 -7 D
+-16 -10 D
+-13 8 D
+-44 -4 D
+15 -4 D
+-17 -2 D
+9 -7 D
+14 5 D
+-17 -9 D
+7 -7 D
+9 7 D
+-6 -14 D
+44 17 D
+-52 -26 D
+11 -8 D
+26 8 D
+-19 -12 D
+20 -1 D
+-10 -6 D
+-19 5 D
+2 -13 D
+38 -15 D
+32 3 D
+35 28 D
+24 -2 D
+9 23 D
+13 -42 D
+13 2 D
+-3 -14 D
+9 11 D
+-6 -17 D
+34 -30 D
+-14 -8 D
+10 -25 D
+38 0 D
+13 21 D
+32 -2 D
+23 37 D
+-8 28 D
+14 0 D
+-20 5 D
+35 3 D
+4 11 D
+8 -10 D
+21 13 D
+-17 4 D
+27 9 D
+-29 23 D
+-22 2 D
+13 63 D
+12 -7 D
+51 21 D
+P
+FO
+-1 0 -34 -1 -13 12 23 25 18 3 -32 2 1 6 38 10 8 1146 3816 SP
+30 -32 -25 -6 -8 8 -7 -12 -10 14 21 16 6 1469 3930 SP
+-3 15 21 -1 -1 -11 3 1417 3944 SP
+-4 10 -23 -7 44 15 3 1552 4290 SP
+-19 -15 -14 5 2 1634 4321 SP
+-22 -9 5 12 2 1552 4298 SP
+20 32 -11 -22 2 1601 3984 SP
+-24 -10 22 25 2 1639 3984 SP
+-13 -5 1 1525 4289 SP
+-5 -8 1 1441 3930 SP
+-12 -4 1 1545 3903 SP
+0 7 1 1281 4071 SP
+17 3 1 1370 4165 SP
+-7 -5 7 6 2 1480 4228 SP
+2 -6 1 1432 3957 SP
+6 -5 1 1644 4079 SP
+9 -3 1 1423 3929 SP
+-11 -2 11 3 2 1286 3885 SP
+-21 -4 1 1390 4164 SP
+6 -8 -7 8 2 1553 3930 SP
+-21 -5 1 1552 4292 SP
+18 9 1 1565 4309 SP
+-9 6 1 1417 3926 SP
+-13 -6 -1 8 2 1518 3910 SP
+-26 -2 1 1679 4336 SP
+{0.706 0.863 1 C} FS
+-14 -7 -8 8 5 -11 -20 -3 24 -2 13 14 6 1378 3973 SP
+-2 12 22 -1 3 16 -41 -10 -6 -16 5 1527 4047 SP
+11 -12 -3 10 46 -2 3 1580 4052 SP
+5 -8 1 1446 4064 SP
+2 -8 1 1543 4146 SP
+25 -7 -24 7 2 1685 4292 SP
+23 0 1 1374 4102 SP
+-18 5 1 0 2 1650 4236 SP
+7 -6 1 1362 4065 SP
+-16 7 0 -1 2 1619 4217 SP
+4 -7 1 1496 4056 SP
+1 -8 1 1375 4047 SP
+16 0 1 0 2 1587 4251 SP
+-15 0 1 1446 4154 SP
+10 -6 -9 5 2 1622 4279 SP
+5 -7 1 1502 4060 SP
+10 -5 -9 5 2 1597 4240 SP
+14 -3 -13 3 2 1660 4266 SP
+13 -6 1 1505 4110 SP
+-4 7 3 -6 2 1499 4068 SP
+17 0 1 1376 4116 SP
+3 -8 1 1450 4111 SP
+6 -7 1 1384 4065 SP
+-2 7 1 -7 2 1356 4034 SP
+-1 -6 1 1327 4029 SP
+-21 -29 0 1 2 1551 4033 SP
+-29 20 0 -1 2 1636 4221 SP
+6 -14 1 1531 4155 SP
+23 0 1 1568 4047 SP
+-74 22 1 1682 4255 SP
+54 -24 1 1521 4191 SP
+21 -19 1 1429 4095 SP
+9 -6 1 1543 4091 SP
+17 6 1 1595 4264 SP
+2 -15 1 1467 4051 SP
+-25 -9 1 1618 4079 SP
+-44 7 1 1670 4246 SP
+-10 -6 11 6 2 1526 4219 SP
+-5 -7 1 1521 3985 SP
+-21 10 1 1608 4203 SP
+-1 -14 1 1470 4131 SP
+2 -8 1 1506 4166 SP
+8 -6 1 1554 4014 SP
+23 -12 1 1578 4199 SP
+5 -6 1 1542 3977 SP
+-20 10 1 1541 4168 SP
+2 8 -3 -8 2 1560 4133 SP
+9 -6 1 1555 4145 SP
+6 -7 1 1569 4180 SP
+7 -6 -6 6 2 1517 4193 SP
+-6 15 5 -15 2 1423 4087 SP
+-22 -6 21 6 2 1460 4175 SP
+-14 8 1 1630 4240 SP
+9 -8 1 1484 4056 SP
+-12 8 1 1594 4198 SP
+5 -7 1 1475 4048 SP
+-9 5 1 1565 4214 SP
+-13 4 1 1553 4227 SP
+1688 4329 M
+-10 -8 D
+2 10 D
+-21 -5 D
+17 -11 D
+-38 7 D
+-13 -22 D
+-33 -4 D
+39 -3 D
+-44 -1 D
+7 -15 D
+-14 12 D
+-20 -5 D
+16 -4 D
+-28 -1 D
+29 -8 D
+-43 -9 D
+31 -4 D
+-53 -4 D
+13 -4 D
+-26 -17 D
+31 4 D
+-40 -7 D
+14 -7 D
+-15 3 D
+-17 -19 D
+25 2 D
+-45 -11 D
+24 2 D
+-21 -8 D
+12 -6 D
+-17 -4 D
+-7 8 D
+-39 -26 D
+24 -2 D
+27 15 D
+-12 -18 D
+-31 -4 D
+-4 8 D
+-31 -6 D
+5 -15 D
+-22 4 D
+17 -8 D
+-42 7 D
+32 -7 D
+-51 -3 D
+25 -13 D
+-14 7 D
+-3 -7 D
+-17 4 D
+10 -5 D
+-33 4 D
+2 -8 D
+46 -1 D
+-45 0 D
+-6 -8 D
+24 -3 D
+-24 -1 D
+19 -2 D
+-12 -7 D
+35 3 D
+6 6 D
+16 -7 D
+7 9 D
+3 -7 D
+-16 -10 D
+-13 8 D
+-44 -4 D
+15 -4 D
+-17 -2 D
+9 -7 D
+14 5 D
+-17 -9 D
+7 -7 D
+9 7 D
+-6 -14 D
+44 17 D
+-52 -26 D
+11 -8 D
+26 8 D
+-19 -12 D
+20 -1 D
+-10 -6 D
+-19 5 D
+2 -13 D
+38 -15 D
+32 3 D
+35 28 D
+24 -2 D
+9 23 D
+13 -42 D
+13 2 D
+-3 -14 D
+9 11 D
+-6 -17 D
+34 -30 D
+-14 -8 D
+10 -25 D
+38 0 D
+13 21 D
+32 -2 D
+23 37 D
+-8 28 D
+14 0 D
+-20 5 D
+35 3 D
+4 11 D
+8 -10 D
+21 13 D
+-17 4 D
+27 9 D
+-29 23 D
+-22 2 D
+13 63 D
+12 -7 D
+51 21 D
+S
+1688 3916 M
+-17 -7 D
+14 11 D
+-30 -8 D
+-23 13 D
+-87 -22 D
+-4 -11 D
+-42 23 D
+-58 -13 D
+7 11 D
+-27 -2 D
+-20 14 D
+4 24 D
+38 20 D
+-23 7 D
+15 28 D
+-56 -17 D
+-9 -64 D
+9 4 D
+11 -11 D
+-12 -5 D
+34 -21 D
+-31 10 D
+-4 -14 D
+-15 9 D
+-24 -3 D
+9 -10 D
+-42 4 D
+-14 -8 D
+13 -14 D
+-16 -7 D
+-14 18 D
+-19 -27 D
+17 -7 D
+-33 -5 D
+22 -5 D
+-72 -13 D
+2 -19 D
+-10 -5 D
+S
+1146 3816 M
+38 10 D
+1 6 D
+-32 2 D
+18 3 D
+23 25 D
+-13 12 D
+-34 -1 D
+-1 0 D
+S
+1469 3930 M
+21 16 D
+-10 14 D
+-7 -12 D
+-8 8 D
+-25 -6 D
+30 -32 D
+P S
+1417 3944 M
+-1 -11 D
+21 -1 D
+-3 15 D
+P S
+1552 4290 M
+44 15 D
+-23 -7 D
+-4 10 D
+P S
+1146 3896 M
+P S
+1634 4321 M
+-14 5 D
+-19 -15 D
+P S
+1552 4298 M
+5 12 D
+-22 -9 D
+P S
+1601 3984 M
+-11 -22 D
+20 32 D
+P S
+1688 3928 M
+-2 0 D
+-1 -8 D
+3 0 D
+S
+1639 3984 M
+22 25 D
+-24 -10 D
+P S
+1525 4289 M
+-13 -5 D
+P S
+1441 3930 M
+-5 -8 D
+P S
+1545 3903 M
+-12 -4 D
+P S
+1281 4071 M
+0 7 D
+P S
+1370 4165 M
+17 3 D
+P S
+1480 4228 M
+7 6 D
+-7 -5 D
+P S
+1432 3957 M
+2 -6 D
+P S
+1644 4079 M
+6 -5 D
+P S
+1423 3929 M
+9 -3 D
+P S
+1286 3885 M
+11 3 D
+-11 -2 D
+P S
+1390 4164 M
+-21 -4 D
+P S
+1553 3930 M
+-7 8 D
+6 -8 D
+P S
+1552 4292 M
+-21 -5 D
+P S
+1565 4309 M
+18 9 D
+P S
+1417 3926 M
+-9 6 D
+P S
+1518 3910 M
+-1 8 D
+-13 -6 D
+P S
+1679 4336 M
+-26 -2 D
+P S
+1688 4318 M
+-2 -1 D
+2 4 D
+S
+1146 3890 M
+0 0 D
+P S
+1378 3973 M
+13 14 D
+24 -2 D
+-20 -3 D
+5 -11 D
+-8 8 D
+-14 -7 D
+P S
+1527 4047 M
+-6 -16 D
+-41 -10 D
+3 16 D
+22 -1 D
+-2 12 D
+P S
+1580 4052 M
+46 -2 D
+-3 10 D
+11 -12 D
+P S
+1446 4064 M
+5 -8 D
+P S
+1543 4146 M
+2 -8 D
+P S
+1685 4292 M
+-24 7 D
+25 -7 D
+P S
+1374 4102 M
+23 0 D
+P S
+1650 4236 M
+1 0 D
+-18 5 D
+P S
+1362 4065 M
+7 -6 D
+P S
+1619 4217 M
+0 -1 D
+-16 7 D
+P S
+1496 4056 M
+4 -7 D
+P S
+1375 4047 M
+1 -8 D
+P S
+1587 4251 M
+17 0 D
+P S
+1446 4154 M
+-15 0 D
+P S
+1622 4279 M
+-9 5 D
+10 -6 D
+P S
+1502 4060 M
+5 -7 D
+P S
+1597 4240 M
+-9 5 D
+10 -5 D
+P S
+1660 4266 M
+-13 3 D
+14 -3 D
+P S
+1505 4110 M
+13 -6 D
+P S
+1499 4068 M
+3 -6 D
+-4 7 D
+P S
+1376 4116 M
+17 0 D
+P S
+1450 4111 M
+3 -8 D
+P S
+1384 4065 M
+6 -7 D
+P S
+1356 4034 M
+1 -7 D
+-2 7 D
+P S
+1327 4029 M
+-1 -6 D
+P S
+1551 4033 M
+0 1 D
+-21 -29 D
+P S
+1636 4221 M
+0 -1 D
+-29 20 D
+P S
+1531 4155 M
+6 -14 D
+P S
+1568 4047 M
+23 0 D
+P S
+1682 4255 M
+-74 22 D
+P S
+1521 4191 M
+54 -24 D
+P S
+1429 4095 M
+21 -19 D
+P S
+1543 4091 M
+9 -6 D
+P S
+1595 4264 M
+17 6 D
+P S
+1467 4051 M
+2 -15 D
+P S
+1618 4079 M
+-25 -9 D
+P S
+1670 4246 M
+-44 7 D
+P S
+1526 4219 M
+11 6 D
+-10 -6 D
+P S
+1521 3985 M
+-5 -7 D
+P S
+1608 4203 M
+-21 10 D
+P S
+1470 4131 M
+-1 -14 D
+P S
+1506 4166 M
+2 -8 D
+P S
+1554 4014 M
+8 -6 D
+P S
+1578 4199 M
+23 -12 D
+P S
+1542 3977 M
+5 -6 D
+P S
+1541 4168 M
+-20 10 D
+P S
+1560 4133 M
+-3 -8 D
+2 8 D
+P S
+1555 4145 M
+9 -6 D
+P S
+1569 4180 M
+6 -7 D
+P S
+1517 4193 M
+-6 6 D
+7 -6 D
+P S
+1423 4087 M
+5 -15 D
+-6 15 D
+P S
+1460 4175 M
+21 6 D
+-22 -6 D
+P S
+1630 4240 M
+-14 8 D
+P S
+1484 4056 M
+9 -8 D
+P S
+1594 4198 M
+-12 8 D
+P S
+1475 4048 M
+5 -7 D
+P S
+1565 4214 M
+-9 5 D
+P S
+1553 4227 M
+-13 4 D
+P S
+1688 4283 M
+-39 12 D
+P S
+-11 -5 11 1 2 1688 3920 SP
+1688 4161 M
+18 7 D
+26 18 D
+-11 24 D
+14 -4 D
+0 15 D
+18 -6 D
+7 10 D
+52 -1 D
+25 -23 D
+-118 -60 D
+18 -35 D
+-10 -24 D
+29 -11 D
+16 4 D
+-6 -15 D
+157 25 D
+-1 -10 D
+46 -11 D
+-60 -4 D
+-5 -11 D
+-61 8 D
+-59 -12 D
+6 -24 D
+23 -1 D
+-5 -29 D
+-20 -8 D
+-28 22 D
+-25 -6 D
+-19 -28 D
+7 -42 D
+-20 0 D
+15 21 D
+-14 -18 D
+-15 -4 D
+P
+FO
+21 -6 1 1688 4283 SP
+-33 -18 33 0 0 7 -8 -7 8 15 5 1688 4321 SP
+-22 7 6 -7 2 1739 4336 SP
+-3 0 -1 0 2 1783 4336 SP
+302 0 -17 9 -22 -6 -26 9 -23 -11 -28 6 28 0 -1 9 -37 0 13 14 -15 -11 -47 1 -121 30 -6 4 14 2230 4282 SP
+2230 4218 M
+-8 -5 D
+8 -10 D
+0 -14 D
+-42 7 D
+-12 -6 D
+10 7 D
+-41 8 D
+-9 -12 D
+41 -11 D
+-17 -14 D
+-71 20 D
+-15 23 D
+17 13 D
+-51 11 D
+20 4 D
+-50 20 D
+196 -28 D
+24 10 D
+P
+FO
+{0.784 A} FS
+16 4 12 -6 -13 -2 3 1756 4038 SP
+-40 1 36 14 2 1742 4010 SP
+17 7 1 1752 4067 SP
+{0.706 0.863 1 C} FS
+-27 -2 15 -4 -39 -13 -6 -17 18 -4 -1 12 38 -3 -1 -13 -27 10 56 -33 -22 19 12 12 -44 17 22 10 22 -6 -15 15 16 1900 4096 SP
+-16 4 0 16 21 23 -25 14 -7 -13 22 4 -3 -19 -42 -23 20 -4 -9 9 13 -7 8 14 2 -19 13 1849 4149 SP
+15 5 16 -15 -7 16 20 -14 -9 19 -37 19 23 3 -28 5 -16 -9 17 -35 32 -11 11 2085 4143 SP
+-19 -4 26 1 -15 18 27 -5 -36 19 -18 -14 25 -12 7 2180 4037 SP
+-11 26 1 -16 -19 2 28 -12 4 2080 4170 SP
+0 26 -1 -14 -27 -3 -2 -9 4 1818 4125 SP
+-18 8 12 -6 -21 -13 3 1817 4112 SP
+11 7 -19 -4 -20 6 27 -9 4 1985 4206 SP
+-34 3 39 -12 -4 9 3 1876 4180 SP
+-36 2 -12 -16 47 14 3 1880 4307 SP
+-43 35 -42 -20 54 -29 3 1985 4112 SP
+21 4 -32 26 14 -13 3 1894 4020 SP
+9 -7 6 8 2 1851 4108 SP
+-19 5 6 -10 2 1989 4235 SP
+-12 -7 50 -2 -37 8 3 1893 4278 SP
+-22 2 14 -9 2 2058 4160 SP
+-25 2 11 -9 2 1995 4024 SP
+-22 -4 3 -21 2 2047 4291 SP
+-6 -10 1 2103 4284 SP
+-7 6 0 -1 2 1906 4153 SP
+4 -8 1 1880 4123 SP
+22 -2 1 1937 4227 SP
+4 -6 1 2049 4171 SP
+13 3 -12 -3 2 1837 4140 SP
+-8 -6 9 6 2 1806 4242 SP
+15 0 1 1886 4092 SP
+-7 7 1 1881 4227 SP
+-4 -11 1 1797 4141 SP
+-26 -7 1 0 2 2004 4299 SP
+-20 -7 1 1778 4105 SP
+-1 -9 1 1828 4126 SP
+-6 6 1 1836 4155 SP
+7 6 1 1932 4178 SP
+-29 2 1 2030 4272 SP
+-31 19 1 1964 4144 SP
+-22 2 4 -7 2 2173 4074 SP
+21 -14 1 2011 4225 SP
+14 -11 1 1860 4118 SP
+15 -12 1 2009 4252 SP
+0 -17 1 1973 3827 SP
+8 -13 1 1925 4146 SP
+34 4 1 1903 4232 SP
+2 -9 1 2204 4085 SP
+16 -11 0 1 2 2207 4061 SP
+3 -12 -2 11 2 1866 4146 SP
+-4 10 1 1950 4138 SP
+-6 -7 1 2201 4104 SP
+-1 -8 1 2147 4132 SP
+-5 -8 1 2038 4229 SP
+29 2 1 1915 4174 SP
+-3 16 1 1870 4095 SP
+3 -10 1 2077 4279 SP
+-1 -8 1 1854 4022 SP
+10 7 1 1973 4141 SP
+-4 13 1 1828 4143 SP
+-4 10 1 1953 4175 SP
+10 -9 1 1981 4172 SP
+4 7 -5 -7 2 1816 4103 SP
+-17 -9 18 9 2 1929 4197 SP
+19 3 1 1885 4242 SP
+-2 -6 1 2043 3993 SP
+-14 -3 1 2009 4189 SP
+{0.784 A} FS
+9 -7 -19 -2 2 1942 4123 SP
+-5 6 1 1906 4140 SP
+-2 -7 1 2103 4122 SP
+2230 4189 M
+-42 7 D
+-12 -6 D
+10 7 D
+-41 8 D
+-9 -12 D
+41 -11 D
+-17 -14 D
+-71 20 D
+-15 23 D
+17 13 D
+-51 11 D
+20 4 D
+-50 20 D
+196 -28 D
+24 10 D
+0 41 D
+-6 4 D
+-121 30 D
+-47 1 D
+-15 -11 D
+13 14 D
+-37 0 D
+-1 9 D
+28 0 D
+-28 6 D
+-23 -11 D
+-26 9 D
+-22 -6 D
+-17 9 D
+-145 0 D
+-1 0 D
+-3 0 D
+-40 0 D
+6 -7 D
+-24 7 D
+-33 -18 D
+0 -35 D
+21 -6 D
+-21 6 D
+0 -122 D
+18 7 D
+26 18 D
+-11 24 D
+14 -4 D
+0 15 D
+18 -6 D
+7 10 D
+52 -1 D
+25 -23 D
+-118 -60 D
+18 -35 D
+-10 -24 D
+29 -11 D
+16 4 D
+-6 -15 D
+157 25 D
+-1 -10 D
+46 -11 D
+-60 -4 D
+-5 -11 D
+-61 8 D
+-59 -12 D
+6 -24 D
+23 -1 D
+-5 -29 D
+-20 -8 D
+-28 22 D
+-25 -6 D
+-19 -28 D
+7 -42 D
+-20 0 D
+15 21 D
+-14 -18 D
+-15 -4 D
+0 -8 D
+11 1 D
+-11 -5 D
+0 -122 D
+542 0 D
+P
+FO
+8 -10 -8 -5 2 2230 4218 SP
+-8 -7 8 15 2 1688 4321 SP
+16 4 12 -6 -13 -2 3 1756 4038 SP
+-40 1 36 14 2 1742 4010 SP
+17 7 1 1752 4067 SP
+{0.706 0.863 1 C} FS
+-27 -2 15 -4 -39 -13 -6 -17 18 -4 -1 12 38 -3 -1 -13 -27 10 56 -33 -22 19 12 12 -44 17 22 10 22 -6 -15 15 16 1900 4096 SP
+-16 4 0 16 21 23 -25 14 -7 -13 22 4 -3 -19 -42 -23 20 -4 -9 9 13 -7 8 14 2 -19 13 1849 4149 SP
+15 5 16 -15 -7 16 20 -14 -9 19 -37 19 23 3 -28 5 -16 -9 17 -35 32 -11 11 2085 4143 SP
+-19 -4 26 1 -15 18 27 -5 -36 19 -18 -14 25 -12 7 2180 4037 SP
+-11 26 1 -16 -19 2 28 -12 4 2080 4170 SP
+0 26 -1 -14 -27 -3 -2 -9 4 1818 4125 SP
+-18 8 12 -6 -21 -13 3 1817 4112 SP
+11 7 -19 -4 -20 6 27 -9 4 1985 4206 SP
+-34 3 39 -12 -4 9 3 1876 4180 SP
+-36 2 -12 -16 47 14 3 1880 4307 SP
+-43 35 -42 -20 54 -29 3 1985 4112 SP
+21 4 -32 26 14 -13 3 1894 4020 SP
+9 -7 6 8 2 1851 4108 SP
+-19 5 6 -10 2 1989 4235 SP
+-12 -7 50 -2 -37 8 3 1893 4278 SP
+-22 2 14 -9 2 2058 4160 SP
+-25 2 11 -9 2 1995 4024 SP
+-22 -4 3 -21 2 2047 4291 SP
+-6 -10 1 2103 4284 SP
+-7 6 0 -1 2 1906 4153 SP
+4 -8 1 1880 4123 SP
+22 -2 1 1937 4227 SP
+4 -6 1 2049 4171 SP
+13 3 -12 -3 2 1837 4140 SP
+-8 -6 9 6 2 1806 4242 SP
+15 0 1 1886 4092 SP
+-7 7 1 1881 4227 SP
+-4 -11 1 1797 4141 SP
+-26 -7 1 0 2 2004 4299 SP
+-20 -7 1 1778 4105 SP
+-1 -9 1 1828 4126 SP
+-6 6 1 1836 4155 SP
+7 6 1 1932 4178 SP
+-29 2 1 2030 4272 SP
+-31 19 1 1964 4144 SP
+-22 2 4 -7 2 2173 4074 SP
+21 -14 1 2011 4225 SP
+14 -11 1 1860 4118 SP
+15 -12 1 2009 4252 SP
+0 -17 1 1973 3827 SP
+8 -13 1 1925 4146 SP
+34 4 1 1903 4232 SP
+2 -9 1 2204 4085 SP
+16 -11 0 1 2 2207 4061 SP
+3 -12 -2 11 2 1866 4146 SP
+-4 10 1 1950 4138 SP
+-6 -7 1 2201 4104 SP
+-1 -8 1 2147 4132 SP
+-5 -8 1 2038 4229 SP
+29 2 1 1915 4174 SP
+-3 16 1 1870 4095 SP
+3 -10 1 2077 4279 SP
+-1 -8 1 1854 4022 SP
+10 7 1 1973 4141 SP
+-4 13 1 1828 4143 SP
+-4 10 1 1953 4175 SP
+10 -9 1 1981 4172 SP
+4 7 -5 -7 2 1816 4103 SP
+-17 -9 18 9 2 1929 4197 SP
+19 3 1 1885 4242 SP
+-2 -6 1 2043 3993 SP
+-14 -3 1 2009 4189 SP
+{0.784 A} FS
+9 -7 -19 -2 2 1942 4123 SP
+-5 6 1 1906 4140 SP
+-2 -7 1 2103 4122 SP
+1688 4161 M
+18 7 D
+26 18 D
+-11 24 D
+14 -4 D
+0 15 D
+18 -6 D
+7 10 D
+52 -1 D
+25 -23 D
+-118 -60 D
+18 -35 D
+-10 -24 D
+29 -11 D
+16 4 D
+-6 -15 D
+157 25 D
+-1 -10 D
+46 -11 D
+-60 -4 D
+-5 -11 D
+-61 8 D
+-59 -12 D
+6 -24 D
+23 -1 D
+-5 -29 D
+-20 -8 D
+-28 22 D
+-25 -6 D
+-19 -28 D
+7 -42 D
+-20 0 D
+15 21 D
+-14 -18 D
+-15 -4 D
+S
+2230 4189 M
+-42 7 D
+-12 -6 D
+10 7 D
+-41 8 D
+-9 -12 D
+41 -11 D
+-17 -14 D
+-71 20 D
+-15 23 D
+17 13 D
+-51 11 D
+20 4 D
+-50 20 D
+196 -28 D
+24 10 D
+S
+2230 4282 M
+-6 4 D
+-121 30 D
+-47 1 D
+-15 -11 D
+13 14 D
+-37 0 D
+-1 9 D
+28 0 D
+-28 6 D
+-23 -11 D
+-26 9 D
+-22 -6 D
+-17 9 D
+S
+1756 4038 M
+-13 -2 D
+12 -6 D
+16 4 D
+P S
+1742 4010 M
+36 14 D
+-40 1 D
+P S
+1752 4067 M
+17 7 D
+P S
+1739 4336 M
+6 -7 D
+-22 7 D
+S
+1783 4336 M
+-1 0 D
+-3 0 D
+S
+1688 3920 M
+11 1 D
+-11 -5 D
+S
+1688 4321 M
+8 15 D
+-8 -7 D
+S
+2230 4218 M
+-8 -5 D
+8 -10 D
+S
+1721 4336 M
+-33 -18 D
+S
+1900 4096 M
+-15 15 D
+22 -6 D
+22 10 D
+-44 17 D
+12 12 D
+-22 19 D
+56 -33 D
+-27 10 D
+-1 -13 D
+38 -3 D
+-1 12 D
+18 -4 D
+-6 -17 D
+-39 -13 D
+15 -4 D
+-27 -2 D
+P S
+1849 4149 M
+2 -19 D
+8 14 D
+13 -7 D
+-9 9 D
+20 -4 D
+-42 -23 D
+-3 -19 D
+22 4 D
+-7 -13 D
+-25 14 D
+21 23 D
+0 16 D
+-16 4 D
+P S
+2085 4143 M
+32 -11 D
+17 -35 D
+-16 -9 D
+-28 5 D
+23 3 D
+-37 19 D
+-9 19 D
+20 -14 D
+-7 16 D
+16 -15 D
+15 5 D
+P S
+2180 4037 M
+25 -12 D
+-18 -14 D
+-36 19 D
+27 -5 D
+-15 18 D
+26 1 D
+-19 -4 D
+P S
+2080 4170 M
+28 -12 D
+-19 2 D
+1 -16 D
+-11 26 D
+P S
+1818 4125 M
+-2 -9 D
+-27 -3 D
+-1 -14 D
+0 26 D
+P S
+1817 4112 M
+-21 -13 D
+12 -6 D
+-18 8 D
+P S
+1985 4206 M
+27 -9 D
+-20 6 D
+-19 -4 D
+P S
+1876 4180 M
+-4 9 D
+39 -12 D
+P S
+1880 4307 M
+47 14 D
+-12 -16 D
+-36 2 D
+P S
+1985 4112 M
+54 -29 D
+-42 -20 D
+-43 35 D
+P S
+1894 4020 M
+14 -13 D
+-32 26 D
+21 4 D
+P S
+1851 4108 M
+6 8 D
+9 -7 D
+P S
+1989 4235 M
+6 -10 D
+-19 5 D
+P S
+1893 4278 M
+-37 8 D
+50 -2 D
+-12 -7 D
+P S
+2058 4160 M
+14 -9 D
+-22 2 D
+P S
+1995 4024 M
+11 -9 D
+-25 2 D
+P S
+2047 4291 M
+3 -21 D
+-22 -4 D
+P S
+2103 4284 M
+-6 -10 D
+P S
+1906 4153 M
+0 -1 D
+-7 6 D
+P S
+1880 4123 M
+4 -8 D
+P S
+1937 4227 M
+22 -2 D
+P S
+2049 4171 M
+4 -6 D
+P S
+1837 4140 M
+-12 -3 D
+13 3 D
+P S
+1806 4242 M
+9 6 D
+-8 -6 D
+P S
+1886 4092 M
+15 0 D
+P S
+1881 4227 M
+-7 7 D
+P S
+1797 4141 M
+-4 -11 D
+P S
+2004 4299 M
+1 0 D
+-26 -7 D
+P S
+1778 4105 M
+-20 -7 D
+P S
+1828 4126 M
+-1 -9 D
+P S
+1836 4155 M
+-6 6 D
+P S
+1932 4178 M
+7 6 D
+P S
+2030 4272 M
+-29 2 D
+P S
+1964 4144 M
+-31 19 D
+P S
+2173 4074 M
+4 -7 D
+-22 2 D
+P S
+2011 4225 M
+21 -14 D
+P S
+1860 4118 M
+14 -11 D
+P S
+2009 4252 M
+15 -12 D
+P S
+1973 3827 M
+0 -17 D
+P S
+1925 4146 M
+8 -13 D
+P S
+1688 4283 M
+21 -6 D
+P S
+1903 4232 M
+34 4 D
+P S
+2204 4085 M
+2 -9 D
+P S
+2207 4061 M
+0 1 D
+16 -11 D
+P S
+1866 4146 M
+-2 11 D
+3 -12 D
+P S
+1950 4138 M
+-4 10 D
+P S
+2201 4104 M
+-6 -7 D
+P S
+2147 4132 M
+-1 -8 D
+P S
+2038 4229 M
+-5 -8 D
+P S
+1915 4174 M
+29 2 D
+P S
+1870 4095 M
+-3 16 D
+P S
+2077 4279 M
+3 -10 D
+P S
+1854 4022 M
+-1 -8 D
+P S
+1973 4141 M
+10 7 D
+P S
+1828 4143 M
+-4 13 D
+P S
+1953 4175 M
+-4 10 D
+P S
+1981 4172 M
+10 -9 D
+P S
+1816 4103 M
+-5 -7 D
+4 7 D
+P S
+1929 4197 M
+18 9 D
+-17 -9 D
+P S
+1885 4242 M
+19 3 D
+P S
+2043 3993 M
+-2 -6 D
+P S
+2009 4189 M
+-14 -3 D
+P S
+1942 4123 M
+-19 -2 D
+9 -7 D
+P S
+1906 4140 M
+-5 6 D
+P S
+2103 4122 M
+-2 -7 D
+P S
+{0.706 0.863 1 C} FS
+-1 -2 -21 -4 15 -15 -4 -17 -28 -13 34 14 -1 25 8 12 8 2380 3794 SP
+-13 1 13 -15 2 2230 4203 SP
+2230 4241 M
+38 17 D
+-38 24 D
+0 54 D
+507 0 D
+35 -7 D
+0 -27 D
+-1 0 D
+-5 -11 D
+-21 18 D
+-46 -12 D
+-53 0 D
+-13 -11 D
+-45 1 D
+11 17 D
+26 5 D
+-19 -1 D
+-42 -18 D
+-3 8 D
+-98 -18 D
+13 -9 D
+-34 0 D
+-7 -19 D
+-42 -2 D
+-29 17 D
+48 10 D
+-4 9 D
+-89 14 D
+25 -11 D
+-3 -62 D
+-51 15 D
+-40 -14 D
+-20 -10 D
+P
+FO
+{0.784 A} FS
+-28 -11 -29 11 36 10 3 2474 4302 SP
+{0.706 0.863 1 C} FS
+2473 3921 M
+-11 -9 D
+9 -10 D
+25 5 D
+-20 -16 D
+24 -4 D
+-30 -4 D
+10 3 D
+-23 22 D
+25 26 D
+-6 9 D
+6 -6 D
+3 8 D
+13 -6 D
+38 6 D
+5 8 D
+1 -7 D
+13 3 D
+-78 -21 D
+P
+FO
+-17 5 22 7 -20 2 -20 22 6 -13 -13 -1 20 -2 8 -9 -17 -7 10 -29 3 18 11 2670 4045 SP
+22 -25 52 23 57 1 1 -58 -53 -15 54 15 0 58 -59 0 -52 -24 -22 26 10 2691 4211 SP
+18 -18 -11 -14 35 -8 -35 8 12 14 -17 18 -84 29 7 2369 4120 SP
+-52 -9 -35 7 -33 17 31 -18 37 -6 51 8 34 -16 7 2323 3975 SP
+9 -18 -7 14 38 15 3 2612 3979 SP
+-15 -2 9 -12 2 2741 3854 SP
+-18 -31 24 6 2 2307 3998 SP
+22 21 1 2441 3851 SP
+-33 1 33 -2 2 2267 3998 SP
+{0.784 A} FS
+2380 3794 M
+8 12 D
+-1 25 D
+34 14 D
+-28 -13 D
+-4 -17 D
+15 -15 D
+-21 -4 D
+-1 -2 D
+390 0 D
+0 508 D
+-1 0 D
+-5 -11 D
+-21 18 D
+-46 -12 D
+-53 0 D
+-13 -11 D
+-45 1 D
+11 17 D
+26 5 D
+-19 -1 D
+-42 -18 D
+-3 8 D
+-98 -18 D
+13 -9 D
+-34 0 D
+-7 -19 D
+-42 -2 D
+-29 17 D
+48 10 D
+-4 9 D
+-89 14 D
+25 -11 D
+-3 -62 D
+-51 15 D
+-40 -14 D
+-20 -10 D
+0 -15 D
+13 -15 D
+-13 1 D
+0 -395 D
+P
+FO
+0 7 35 -7 2 2737 4336 SP
+-38 24 38 17 2 2230 4241 SP
+-28 -11 -29 11 36 10 3 2474 4302 SP
+{0.706 0.863 1 C} FS
+2473 3921 M
+-11 -9 D
+9 -10 D
+25 5 D
+-20 -16 D
+24 -4 D
+-30 -4 D
+10 3 D
+-23 22 D
+25 26 D
+-6 9 D
+6 -6 D
+3 8 D
+13 -6 D
+38 6 D
+5 8 D
+1 -7 D
+13 3 D
+-78 -21 D
+P
+FO
+-17 5 22 7 -20 2 -20 22 6 -13 -13 -1 20 -2 8 -9 -17 -7 10 -29 3 18 11 2670 4045 SP
+22 -25 52 23 57 1 1 -58 -53 -15 54 15 0 58 -59 0 -52 -24 -22 26 10 2691 4211 SP
+18 -18 -11 -14 35 -8 -35 8 12 14 -17 18 -84 29 7 2369 4120 SP
+-52 -9 -35 7 -33 17 31 -18 37 -6 51 8 34 -16 7 2323 3975 SP
+9 -18 -7 14 38 15 3 2612 3979 SP
+-15 -2 9 -12 2 2741 3854 SP
+-18 -31 24 6 2 2307 3998 SP
+22 21 1 2441 3851 SP
+-33 1 33 -2 2 2267 3998 SP
+2772 4302 M
+-1 0 D
+-5 -11 D
+-21 18 D
+-46 -12 D
+-53 0 D
+-13 -11 D
+-45 1 D
+11 17 D
+26 5 D
+-19 -1 D
+-42 -18 D
+-3 8 D
+-98 -18 D
+13 -9 D
+-34 0 D
+-7 -19 D
+-42 -2 D
+-29 17 D
+48 10 D
+-4 9 D
+-89 14 D
+25 -11 D
+-3 -62 D
+-51 15 D
+-40 -14 D
+-20 -10 D
+S
+2474 4302 M
+36 10 D
+-29 11 D
+-28 -11 D
+P S
+2230 4241 M
+38 17 D
+-38 24 D
+S
+2230 4203 M
+13 -15 D
+-13 1 D
+S
+2737 4336 M
+35 -7 D
+S
+2473 3921 M
+-11 -9 D
+9 -10 D
+25 5 D
+-20 -16 D
+24 -4 D
+-30 -4 D
+10 3 D
+-23 22 D
+25 26 D
+-6 9 D
+6 -6 D
+3 8 D
+13 -6 D
+38 6 D
+5 8 D
+1 -7 D
+13 3 D
+-78 -21 D
+P S
+2670 4045 M
+3 18 D
+10 -29 D
+-17 -7 D
+8 -9 D
+20 -2 D
+-13 -1 D
+6 -13 D
+-20 22 D
+-20 2 D
+22 7 D
+-17 5 D
+P S
+2691 4211 M
+-22 26 D
+-52 -24 D
+-59 0 D
+0 58 D
+54 15 D
+-53 -15 D
+1 -58 D
+57 1 D
+52 23 D
+P S
+2369 4120 M
+-84 29 D
+-17 18 D
+12 14 D
+-35 8 D
+35 -8 D
+-11 -14 D
+18 -18 D
+P S
+2323 3975 M
+34 -16 D
+51 8 D
+37 -6 D
+31 -18 D
+-33 17 D
+-35 7 D
+-52 -9 D
+P S
+2380 3794 M
+8 12 D
+-1 25 D
+34 14 D
+-28 -13 D
+-4 -17 D
+15 -15 D
+-21 -4 D
+-1 -2 D
+S
+2612 3979 M
+38 15 D
+-7 14 D
+9 -18 D
+P S
+2741 3854 M
+9 -12 D
+-15 -2 D
+P S
+2307 3998 M
+24 6 D
+-18 -31 D
+P S
+2441 3851 M
+22 21 D
+P S
+2267 3998 M
+33 -2 D
+-33 1 D
+P S
+-32 -2 27 -21 -18 -8 -145 22 18 -2 -74 27 -27 -22 31 -16 35 0 1 -12 178 0 -6 1 12 6 13 2772 4329 SP
+4 28 -29 14 50 42 71 7 -81 12 -72 -41 3 -29 -52 -5 -13 32 -46 8 35 -7 -19 -14 14 -17 47 -10 59 2 -9 -22 16 3154 4336 SP
+3314 4045 M
+-19 7 D
+-28 24 D
+-83 18 D
+-162 0 D
+18 -11 D
+2 -22 D
+-28 -11 D
+-19 -34 D
+18 35 D
+28 10 D
+-2 22 D
+-131 64 D
+20 25 D
+-15 31 D
+12 29 D
+24 14 D
+66 4 D
+-24 -9 D
+-42 4 D
+-20 -13 D
+-14 -29 D
+17 -35 D
+-22 -22 D
+96 -44 D
+158 -3 D
+99 -18 D
+33 -29 D
+18 -3 D
+P
+FO
+-5 -1 1 3314 3942 SP
+{0.784 A} FS
+14 5 1 3070 4246 SP
+-19 2 1 3070 4243 SP
+{0.706 0.863 1 C} FS
+15 7 -23 3 -13 -9 21 0 4 3241 3928 SP
+5 -4 -16 -7 25 9 3 3009 3803 SP
+-14 -12 1 2907 3874 SP
+8 5 -9 -4 2 3098 3962 SP
+-19 4 0 -1 2 2927 4056 SP
+-15 -6 16 6 2 3016 4076 SP
+-8 7 1 3133 3879 SP
+{0.784 A} FS
+3314 3942 M
+-5 -1 D
+5 1 D
+0 103 D
+-19 7 D
+-28 24 D
+-83 18 D
+-162 0 D
+18 -11 D
+2 -22 D
+-28 -11 D
+-19 -34 D
+18 35 D
+28 10 D
+-2 22 D
+-131 64 D
+20 25 D
+-15 31 D
+12 29 D
+24 14 D
+66 4 D
+-24 -9 D
+-42 4 D
+-20 -13 D
+-14 -29 D
+17 -35 D
+-22 -22 D
+96 -44 D
+158 -3 D
+99 -18 D
+33 -29 D
+18 -3 D
+0 287 D
+-160 0 D
+-9 -22 D
+59 2 D
+47 -10 D
+14 -17 D
+-19 -14 D
+35 -7 D
+-46 8 D
+-13 32 D
+-52 -5 D
+3 -29 D
+-72 -41 D
+-81 12 D
+71 7 D
+50 42 D
+-29 14 D
+4 28 D
+-160 0 D
+1 -12 D
+35 0 D
+31 -16 D
+-27 -22 D
+-74 27 D
+18 -2 D
+-145 22 D
+-18 -8 D
+27 -21 D
+-32 -2 D
+0 -508 D
+542 0 D
+P
+FO
+-6 0 -6 1 12 6 3 2772 4329 SP
+14 5 1 3070 4246 SP
+-19 2 1 3070 4243 SP
+{0.706 0.863 1 C} FS
+15 7 -23 3 -13 -9 21 0 4 3241 3928 SP
+5 -4 -16 -7 25 9 3 3009 3803 SP
+-14 -12 1 2907 3874 SP
+8 5 -9 -4 2 3098 3962 SP
+-19 4 0 -1 2 2927 4056 SP
+-15 -6 16 6 2 3016 4076 SP
+-8 7 1 3133 3879 SP
+3154 4336 M
+-9 -22 D
+59 2 D
+47 -10 D
+14 -17 D
+-19 -14 D
+35 -7 D
+-46 8 D
+-13 32 D
+-52 -5 D
+3 -29 D
+-72 -41 D
+-81 12 D
+71 7 D
+50 42 D
+-29 14 D
+4 28 D
+S
+2956 4336 M
+1 -12 D
+35 0 D
+31 -16 D
+-27 -22 D
+-74 27 D
+18 -2 D
+-145 22 D
+-18 -8 D
+27 -21 D
+-32 -2 D
+S
+2772 4329 M
+12 6 D
+-6 1 D
+S
+3070 4246 M
+14 5 D
+P S
+3070 4243 M
+-19 2 D
+P S
+3314 4045 M
+-19 7 D
+-28 24 D
+-83 18 D
+-162 0 D
+18 -11 D
+2 -22 D
+-28 -11 D
+-19 -34 D
+18 35 D
+28 10 D
+-2 22 D
+-131 64 D
+20 25 D
+-15 31 D
+12 29 D
+24 14 D
+66 4 D
+-24 -9 D
+-42 4 D
+-20 -13 D
+-14 -29 D
+17 -35 D
+-22 -22 D
+96 -44 D
+158 -3 D
+99 -18 D
+33 -29 D
+18 -3 D
+S
+3241 3928 M
+21 0 D
+-13 -9 D
+-23 3 D
+15 7 D
+P S
+3009 3803 M
+25 9 D
+-16 -7 D
+5 -4 D
+P S
+2907 3874 M
+-14 -12 D
+P S
+3314 3942 M
+-5 -1 D
+P S
+3098 3962 M
+-9 -4 D
+8 5 D
+P S
+2927 4056 M
+0 -1 D
+-19 4 D
+P S
+3016 4076 M
+16 6 D
+-15 -6 D
+P S
+3133 3879 M
+-8 7 D
+P S
+-21 -8 13 -11 18 7 -9 12 4 3655 3794 SP
+9 3 1 3314 3942 SP
+-81 31 -40 27 12 22 -13 -22 17 -17 71 -38 34 -7 7 3314 4049 SP
+-20 7 -1 -7 2 3413 4336 SP
+12 3 -19 12 1 -15 3 3531 4336 SP
+3521 4174 M
+-10 -17 D
+48 -28 D
+-49 28 D
+20 63 D
+-13 18 D
+-35 6 D
+-4 77 D
+-56 9 D
+39 1 D
+21 -9 D
+4 -78 D
+32 -6 D
+10 -15 D
+30 4 D
+27 -8 D
+12 -24 D
+45 -11 D
+-46 11 D
+-11 23 D
+-32 8 D
+-21 -4 D
+P
+FO
+-6 -18 10 -15 -34 -9 6 -6 40 20 5 3610 3923 SP
+-64 -6 86 2 -22 5 3 3587 4287 SP
+-54 -22 55 22 2 3347 3901 SP
+60 1 1 3572 4304 SP
+28 7 -76 -2 2 3628 4320 SP
+54 19 1 3634 4275 SP
+-8 20 1 3700 4239 SP
+-9 9 1 3524 3833 SP
+-2 -6 1 3660 4262 SP
+-17 10 1 3698 4308 SP
+-7 8 1 3723 4247 SP
+10 7 1 3345 3858 SP
+11 -1 1 3773 3868 SP
+{0.784 A} FS
+3655 3794 M
+-9 12 D
+18 7 D
+13 -11 D
+-21 -8 D
+200 0 D
+0 542 D
+-325 0 D
+1 -15 D
+-19 12 D
+12 3 D
+-112 0 D
+-1 -7 D
+-20 7 D
+-78 0 D
+0 -287 D
+34 -7 D
+71 -38 D
+17 -17 D
+-13 -22 D
+12 22 D
+-40 27 D
+-81 31 D
+0 -103 D
+9 3 D
+-9 -3 D
+0 -148 D
+P
+FO
+{0.706 0.863 1 C} FS
+3521 4174 M
+-10 -17 D
+48 -28 D
+-49 28 D
+20 63 D
+-13 18 D
+-35 6 D
+-4 77 D
+-56 9 D
+39 1 D
+21 -9 D
+4 -78 D
+32 -6 D
+10 -15 D
+30 4 D
+27 -8 D
+12 -24 D
+45 -11 D
+-46 11 D
+-11 23 D
+-32 8 D
+-21 -4 D
+P
+FO
+-6 -18 10 -15 -34 -9 6 -6 40 20 5 3610 3923 SP
+-64 -6 86 2 -22 5 3 3587 4287 SP
+-54 -22 55 22 2 3347 3901 SP
+60 1 1 3572 4304 SP
+28 7 -76 -2 2 3628 4320 SP
+54 19 1 3634 4275 SP
+-8 20 1 3700 4239 SP
+-9 9 1 3524 3833 SP
+-2 -6 1 3660 4262 SP
+-17 10 1 3698 4308 SP
+-7 8 1 3723 4247 SP
+10 7 1 3345 3858 SP
+11 -1 1 3773 3868 SP
+3413 4336 M
+-1 -7 D
+-20 7 D
+S
+3521 4174 M
+-10 -17 D
+48 -28 D
+-49 28 D
+20 63 D
+-13 18 D
+-35 6 D
+-4 77 D
+-56 9 D
+39 1 D
+21 -9 D
+4 -78 D
+32 -6 D
+10 -15 D
+30 4 D
+27 -8 D
+12 -24 D
+45 -11 D
+-46 11 D
+-11 23 D
+-32 8 D
+-21 -4 D
+P S
+3610 3923 M
+40 20 D
+6 -6 D
+-34 -9 D
+10 -15 D
+-6 -18 D
+P S
+3314 4049 M
+34 -7 D
+71 -38 D
+17 -17 D
+-13 -22 D
+12 22 D
+-40 27 D
+-81 31 D
+S
+3655 3794 M
+-9 12 D
+18 7 D
+13 -11 D
+-21 -8 D
+S
+3587 4287 M
+-22 5 D
+86 2 D
+-64 -6 D
+P S
+3347 3901 M
+55 22 D
+-54 -22 D
+P S
+3572 4304 M
+60 1 D
+P S
+3628 4320 M
+-76 -2 D
+28 7 D
+P S
+3634 4275 M
+54 19 D
+P S
+3700 4239 M
+-8 20 D
+P S
+3524 3833 M
+-9 9 D
+P S
+3660 4262 M
+-2 -6 D
+P S
+3698 4308 M
+-17 10 D
+P S
+3723 4247 M
+-7 8 D
+P S
+3345 3858 M
+10 7 D
+P S
+3773 3868 M
+11 -1 D
+P S
+3531 4336 M
+1 -15 D
+-19 12 D
+12 3 D
+S
+3314 3942 M
+9 3 D
+P S
+-27 -3 1 4398 4163 SP
+45 15 40 -19 51 -7 71 39 -71 -39 -50 8 -38 20 -48 -16 8 4398 4072 SP
+29 5 -22 12 7 4 -10 10 4 -26 -27 -1 -8 62 11 -1 -14 2 -1 17 -11 -15 15 -15 -1 -5 -7 7 7 -43 6 -14 22 0 17 3917 3963 SP
+34 49 45 33 36 22 40 7 -27 5 -32 -7 -11 -17 -71 -27 12 -4 -28 -18 -11 -41 13 -1 12 4113 3949 SP
+-15 -16 8 -12 2 3868 3835 SP
+11 -9 1 3975 3855 SP
+14 -1 1 3879 3940 SP
+{0.784 A} FS
+542 0 0 -542 -542 0 0 173 27 3 -27 -3 0 90 45 15 40 -19 51 -7 71 39 -71 -39 -50 8 -38 20 -48 -16 15 4398 4072 SP
+{0.706 0.863 1 C} FS
+29 5 -22 12 7 4 -10 10 4 -26 -27 -1 -8 62 11 -1 -14 2 -1 17 -11 -15 15 -15 -1 -5 -7 7 7 -43 6 -14 22 0 17 3917 3963 SP
+34 49 45 33 36 22 40 7 -27 5 -32 -7 -11 -17 -71 -27 12 -4 -28 -18 -11 -41 13 -1 12 4113 3949 SP
+-15 -16 8 -12 2 3868 3835 SP
+11 -9 1 3975 3855 SP
+14 -1 1 3879 3940 SP
+3917 3963 M
+22 0 D
+6 -14 D
+7 -43 D
+-7 7 D
+-1 -5 D
+15 -15 D
+-11 -15 D
+-1 17 D
+-14 2 D
+11 -1 D
+-8 62 D
+-27 -1 D
+4 -26 D
+-10 10 D
+7 4 D
+-22 12 D
+29 5 D
+P S
+4113 3949 M
+13 -1 D
+-11 -41 D
+-28 -18 D
+12 -4 D
+-71 -27 D
+-11 -17 D
+-32 -7 D
+-27 5 D
+40 7 D
+36 22 D
+45 33 D
+34 49 D
+P S
+4398 4072 M
+-48 -16 D
+-38 20 D
+-50 8 D
+-71 -39 D
+71 39 D
+51 -7 D
+40 -19 D
+45 15 D
+S
+3868 3835 M
+8 -12 D
+-15 -16 D
+P S
+3975 3855 M
+11 -9 D
+P S
+3879 3940 M
+14 -1 D
+P S
+4398 4163 M
+-27 -3 D
+P S
+-7 -9 -9 3 4 -11 -47 -19 -26 -5 0 -9 83 36 5 14 8 4852 3794 SP
+4398 4073 M
+34 10 D
+78 -2 D
+139 33 D
+7 39 D
+-83 31 D
+-32 -14 D
+-43 6 D
+-100 -13 D
+100 14 D
+43 -6 D
+24 11 D
+-48 23 D
+-38 65 D
+63 66 D
+3 0 D
+-58 -60 D
+31 -67 D
+106 -41 D
+133 -11 D
+1 -8 D
+62 -11 D
+-12 -63 D
+-15 2 D
+13 0 D
+13 60 D
+-61 11 D
+-2 9 D
+-102 3 D
+17 -32 D
+-36 -28 D
+-125 -19 D
+-77 2 D
+-16 -6 D
+12 -10 D
+-24 7 D
+-7 -2 D
+P
+FO
+48 32 81 41 -14 9 -29 -2 1 24 -26 -15 11 21 -34 -13 -2 -8 -29 0 -7 4 11 4940 3907 SP
+8 1 -8 7 0 -1 6 -5 -6 -1 5 4940 3875 SP
+{0.784 A} FS
+-11 -12 -10 9 2 4886 3926 SP
+5 5 1 4859 3928 SP
+{0.706 0.863 1 C} FS
+-7 -8 1 4940 3854 SP
+10 -1 0 1 2 4843 3848 SP
+{0.784 A} FS
+-3 6 1 0 2 4491 4253 SP
+-13 0 13 1 2 4620 4099 SP
+4852 3794 M
+5 14 D
+83 36 D
+0 24 D
+-8 7 D
+8 1 D
+0 31 D
+-7 4 D
+-29 0 D
+-2 -8 D
+-34 -13 D
+11 21 D
+-26 -15 D
+1 24 D
+-29 -2 D
+-14 9 D
+81 41 D
+48 32 D
+0 336 D
+-395 0 D
+-58 -60 D
+31 -67 D
+106 -41 D
+133 -11 D
+1 -8 D
+62 -11 D
+-12 -63 D
+-15 2 D
+13 0 D
+13 60 D
+-61 11 D
+-2 9 D
+-102 3 D
+17 -32 D
+-36 -28 D
+-125 -19 D
+-77 2 D
+-16 -6 D
+12 -10 D
+-24 7 D
+-7 -2 D
+0 -278 D
+P
+FO
+85 0 -7 -9 -9 3 4 -11 -47 -19 -26 -5 6 4940 3835 SP
+6 -5 -6 -1 2 4940 3875 SP
+-144 0 63 66 -38 65 -48 23 24 11 43 -6 100 14 7 4398 4163 SP
+-100 -13 -43 6 -32 -14 -83 31 7 39 139 33 78 -2 34 10 8 4398 4073 SP
+-11 -12 -10 9 2 4886 3926 SP
+5 5 1 4859 3928 SP
+{0.706 0.863 1 C} FS
+-7 -8 1 4940 3854 SP
+10 -1 0 1 2 4843 3848 SP
+{0.784 A} FS
+-3 6 1 0 2 4491 4253 SP
+-13 0 13 1 2 4620 4099 SP
+4940 3907 M
+-7 4 D
+-29 0 D
+-2 -8 D
+-34 -13 D
+11 21 D
+-26 -15 D
+1 24 D
+-29 -2 D
+-14 9 D
+81 41 D
+48 32 D
+S
+4886 3926 M
+-10 9 D
+-11 -12 D
+P S
+4859 3928 M
+5 5 D
+P S
+4545 4336 M
+-58 -60 D
+31 -67 D
+106 -41 D
+133 -11 D
+1 -8 D
+62 -11 D
+-12 -63 D
+-15 2 D
+13 0 D
+13 60 D
+-61 11 D
+-2 9 D
+-102 3 D
+17 -32 D
+-36 -28 D
+-125 -19 D
+-77 2 D
+-16 -6 D
+12 -10 D
+-24 7 D
+-7 -2 D
+S
+4398 4073 M
+34 10 D
+78 -2 D
+139 33 D
+7 39 D
+-83 31 D
+-32 -14 D
+-43 6 D
+-100 -13 D
+S
+4398 4163 M
+100 14 D
+43 -6 D
+24 11 D
+-48 23 D
+-38 65 D
+63 66 D
+S
+4940 3835 M
+-26 -5 D
+-47 -19 D
+4 -11 D
+-9 3 D
+-7 -9 D
+S
+4940 3854 M
+-7 -8 D
+P S
+4843 3848 M
+0 1 D
+10 -1 D
+P S
+4940 3868 M
+-8 7 D
+8 1 D
+S
+4852 3794 M
+5 14 D
+83 36 D
+S
+4940 3875 M
+-6 -1 D
+6 -5 D
+S
+4491 4253 M
+1 0 D
+-3 6 D
+P S
+4620 4099 M
+13 1 D
+-13 0 D
+P S
+{0.706 0.863 1 C} FS
+5049 3794 M
+-22 41 D
+-13 79 D
+-13 -3 D
+15 -16 D
+-28 -9 D
+-4 -29 D
+17 -32 D
+-1 -31 D
+-48 0 D
+0 20 D
+30 39 D
+-25 27 D
+16 -4 D
+6 8 D
+-39 23 D
+0 93 D
+67 44 D
+88 6 D
+9 -8 D
+13 9 D
+65 -6 D
+14 14 D
+78 -15 D
+-33 -3 D
+7 -7 D
+104 9 D
+-6 9 D
+-23 -1 D
+3 11 D
+66 45 D
+90 10 D
+0 -11 D
+-6 -7 D
+1 -9 D
+5 1 D
+0 -50 D
+-45 -30 D
+-40 -5 D
+-23 -31 D
+-12 -40 D
+30 -117 D
+51 38 D
+-4 20 D
+43 2 D
+0 -84 D
+P
+FO
+-21 -3 15 -2 -4 -9 9 10 -13 -19 14 -11 0 1 -11 9 6 13 5 2 10 4940 3844 SP
+-18 -3 18 2 2 4940 3876 SP
+-1 26 -1 -26 2 5143 4336 SP
+41 -4 26 14 38 9 -2 8 62 5 -65 -4 -61 -30 -39 3 8 5482 4299 SP
+0 7 1 5482 3900 SP
+{0.784 A} FS
+-22 -19 1 10 2 5374 3805 SP
+-8 -4 8 5 2 5379 3813 SP
+4952 3794 M
+0 20 D
+30 39 D
+-25 27 D
+16 -4 D
+6 8 D
+-39 23 D
+0 -31 D
+18 2 D
+-18 -3 D
+0 -6 D
+14 -11 D
+-13 -19 D
+9 10 D
+-4 -9 D
+15 -2 D
+-21 -3 D
+0 -41 D
+P
+FO
+-1 -31 17 -32 -4 -29 -28 -9 15 -16 -13 -3 -13 79 -22 41 8 5049 3794 SP
+43 2 -4 20 51 38 30 -117 -12 -40 -23 -31 -40 -5 -45 -30 0 134 0 7 10 5482 3900 SP
+5 1 1 -9 -6 -7 3 5482 4106 SP
+5482 4299 M
+-39 3 D
+-61 -30 D
+-65 -4 D
+62 5 D
+-2 8 D
+38 9 D
+26 14 D
+41 -4 D
+0 36 D
+-339 0 D
+-1 -26 D
+-1 26 D
+-201 0 D
+0 -336 D
+67 44 D
+88 6 D
+9 -8 D
+13 9 D
+65 -6 D
+14 14 D
+78 -15 D
+-33 -3 D
+7 -7 D
+104 9 D
+-6 9 D
+-23 -1 D
+3 11 D
+66 45 D
+90 10 D
+P
+FO
+-11 9 6 13 5 2 3 4940 3844 SP
+-22 -19 1 10 2 5374 3805 SP
+-8 -4 8 5 2 5379 3813 SP
+4940 4000 M
+67 44 D
+88 6 D
+9 -8 D
+13 9 D
+65 -6 D
+14 14 D
+78 -15 D
+-33 -3 D
+7 -7 D
+104 9 D
+-6 9 D
+-23 -1 D
+3 11 D
+66 45 D
+90 10 D
+S
+5049 3794 M
+-22 41 D
+-13 79 D
+-13 -3 D
+15 -16 D
+-28 -9 D
+-4 -29 D
+17 -32 D
+-1 -31 D
+S
+5482 4041 M
+-45 -30 D
+-40 -5 D
+-23 -31 D
+-12 -40 D
+30 -117 D
+51 38 D
+-4 20 D
+43 2 D
+S
+4952 3794 M
+0 20 D
+30 39 D
+-25 27 D
+16 -4 D
+6 8 D
+-39 23 D
+S
+5374 3805 M
+1 10 D
+-22 -19 D
+P S
+5379 3813 M
+8 5 D
+-8 -4 D
+P S
+5482 4106 M
+-6 -7 D
+1 -9 D
+5 1 D
+S
+5482 3900 M
+0 7 D
+S
+5482 4299 M
+-39 3 D
+-61 -30 D
+-65 -4 D
+62 5 D
+-2 8 D
+38 9 D
+26 14 D
+41 -4 D
+S
+4940 3869 M
+14 -11 D
+-13 -19 D
+9 10 D
+-4 -9 D
+15 -2 D
+-21 -3 D
+S
+4940 3844 M
+5 2 D
+6 13 D
+-11 9 D
+S
+4940 3876 M
+18 2 D
+-18 -3 D
+S
+5482 4318 M
+-6 1 D
+P S
+5143 4336 M
+-1 -26 D
+-1 26 D
+S
+{0.706 0.863 1 C} FS
+5482 3878 M
+2 0 D
+-2 29 D
+58 16 D
+-1 37 D
+34 2 D
+-18 31 D
+17 11 D
+-38 7 D
+47 54 D
+23 3 D
+9 -9 D
+39 19 D
+1 -18 D
+19 17 D
+61 5 D
+29 -19 D
+6 14 D
+81 36 D
+97 21 D
+55 -7 D
+13 12 D
+-37 47 D
+0 -8 D
+-20 16 D
+-39 -8 D
+3 7 D
+-28 0 D
+119 2 D
+12 8 D
+0 -409 D
+-542 0 D
+P
+FO
+-53 -36 -50 -11 -10 -39 -31 -5 19 -6 36 4 -2 24 26 0 59 29 -6 -12 12 2 11 5482 4091 SP
+-11 -12 11 1 2 5482 4117 SP
+-21 2 1 0 20 -3 3 5482 4300 SP
+12 -3 1 5482 4318 SP
+-29 22 -33 -14 -123 6 -25 -8 -14 15 -58 12 -19 -7 27 -15 -8 -11 9 5766 4336 SP
+231 0 -48 6 -77 -3 -106 24 4 6024 4309 SP
+{0.784 A} FS
+-35 3 12 8 2 5726 4325 SP
+-23 7 13 -3 2 5997 3835 SP
+25 -16 -17 8 2 5655 3930 SP
+-28 -1 34 16 2 5577 4023 SP
+19 -5 1 5827 3876 SP
+9 3 -9 -4 2 5958 3849 SP
+17 -9 1 5682 3926 SP
+12 3 1 5844 3859 SP
+{0.706 0.863 1 C} FS
+7 5 1 5484 3923 SP
+{0.784 A} FS
+6024 4309 M
+-106 24 D
+-77 -3 D
+-48 6 D
+-27 0 D
+-8 -11 D
+27 -15 D
+-19 -7 D
+-58 12 D
+-14 15 D
+-25 -8 D
+-123 6 D
+-33 -14 D
+-29 22 D
+-2 0 D
+0 -18 D
+12 -3 D
+-12 3 D
+0 -18 D
+21 -3 D
+-21 2 D
+0 -182 D
+11 1 D
+-11 -12 D
+0 -15 D
+12 2 D
+-6 -12 D
+59 29 D
+26 0 D
+-2 24 D
+36 4 D
+19 -6 D
+-31 -5 D
+-10 -39 D
+-50 -11 D
+-53 -36 D
+0 -134 D
+58 16 D
+-1 37 D
+34 2 D
+-18 31 D
+17 11 D
+-38 7 D
+47 54 D
+23 3 D
+9 -9 D
+39 19 D
+1 -18 D
+19 17 D
+61 5 D
+29 -19 D
+6 14 D
+81 36 D
+97 21 D
+55 -7 D
+13 12 D
+-37 47 D
+0 -8 D
+-20 16 D
+-39 -8 D
+3 7 D
+-28 0 D
+119 2 D
+12 8 D
+P
+FO
+-2 22 2 0 2 5482 3878 SP
+-35 3 12 8 2 5726 4325 SP
+-23 7 13 -3 2 5997 3835 SP
+25 -16 -17 8 2 5655 3930 SP
+-28 -1 34 16 2 5577 4023 SP
+19 -5 1 5827 3876 SP
+9 3 -9 -4 2 5958 3849 SP
+17 -9 1 5682 3926 SP
+12 3 1 5844 3859 SP
+{0.706 0.863 1 C} FS
+7 5 1 5484 3923 SP
+5482 3907 M
+58 16 D
+-1 37 D
+34 2 D
+-18 31 D
+17 11 D
+-38 7 D
+47 54 D
+23 3 D
+9 -9 D
+39 19 D
+1 -18 D
+19 17 D
+61 5 D
+29 -19 D
+6 14 D
+81 36 D
+97 21 D
+55 -7 D
+13 12 D
+-37 47 D
+0 -8 D
+-20 16 D
+-39 -8 D
+3 7 D
+-28 0 D
+119 2 D
+12 8 D
+S
+5482 4091 M
+12 2 D
+-6 -12 D
+59 29 D
+26 0 D
+-2 24 D
+36 4 D
+19 -6 D
+-31 -5 D
+-10 -39 D
+-50 -11 D
+-53 -36 D
+S
+5766 4336 M
+-8 -11 D
+27 -15 D
+-19 -7 D
+-58 12 D
+-14 15 D
+-25 -8 D
+-123 6 D
+-33 -14 D
+-29 22 D
+S
+5726 4325 M
+12 8 D
+-35 3 D
+P S
+5997 3835 M
+13 -3 D
+-23 7 D
+P S
+5655 3930 M
+-17 8 D
+25 -16 D
+P S
+6024 4309 M
+-106 24 D
+-77 -3 D
+-48 6 D
+S
+5577 4023 M
+34 16 D
+-28 -1 D
+P S
+5827 3876 M
+19 -5 D
+P S
+5958 3849 M
+-9 -4 D
+9 3 D
+P S
+5682 3926 M
+17 -9 D
+P S
+5844 3859 M
+12 3 D
+P S
+5482 3878 M
+2 0 D
+-2 22 D
+S
+5482 4117 M
+11 1 D
+-11 -12 D
+S
+5482 4318 M
+12 -3 D
+P S
+5482 4300 M
+21 -3 D
+-21 2 D
+S
+5484 3923 M
+7 5 D
+P S
+6024 4203 M
+20 12 D
+-3 22 D
+25 1 D
+1 -24 D
+52 1 D
+29 -21 D
+48 -12 D
+9 8 D
+5 -10 D
+25 5 D
+-27 9 D
+30 8 D
+1 12 D
+-25 6 D
+53 -6 D
+-11 9 D
+24 -6 D
+24 15 D
+-54 22 D
+-53 4 D
+-27 -2 D
+19 -24 D
+-36 41 D
+-129 36 D
+0 27 D
+478 0 D
+-43 -27 D
+-61 -3 D
+-17 -15 D
+72 -19 D
+13 -14 D
+56 -2 D
+4 -14 D
+35 -2 D
+-37 0 D
+-24 14 D
+37 -23 D
+-72 -1 D
+-18 14 D
+-100 -25 D
+55 -11 D
+-24 -3 D
+20 -16 D
+83 -4 D
+1 6 D
+9 -8 D
+28 14 D
+26 -4 D
+-20 -8 D
+22 -15 D
+-11 -10 D
+-32 1 D
+-27 -14 D
+-30 5 D
+-47 -46 D
+16 -11 D
+21 1 D
+-10 -6 D
+47 -5 D
+-29 -5 D
+10 -19 D
+52 9 D
+18 -29 D
+-16 -13 D
+48 12 D
+9 -4 D
+0 -67 D
+-9 -4 D
+3 -14 D
+-42 3 D
+-42 -29 D
+10 6 D
+11 -2 D
+-2 9 D
+18 -5 D
+11 14 D
+9 -8 D
+33 12 D
+0 -17 D
+-4 -4 D
+4 4 D
+0 -140 D
+-542 0 D
+P
+FO
+5 6 -3 12 50 18 6 -11 48 -5 15 -16 -16 18 -37 3 -15 11 -52 -10 -1 -20 11 6566 4138 SP
+{0.784 A} FS
+-28 -9 6 -9 -21 0 20 13 4 6377 3889 SP
+0 -11 -83 13 23 9 3 6308 4146 SP
+-31 -14 -19 10 24 1 3 6458 3920 SP
+35 -12 -36 -6 -14 12 3 6414 4065 SP
+10 -4 -20 -8 -13 4 3 6453 4084 SP
+-15 -1 16 1 2 6223 4193 SP
+-16 1 10 4 2 6079 3841 SP
+33 18 1 6322 3872 SP
+27 9 1 6160 3849 SP
+-11 -11 1 6117 3849 SP
+28 0 1 6187 3851 SP
+9 -6 1 6543 3939 SP
+17 5 1 6087 3841 SP
+21 -4 1 6214 4078 SP
+{0.706 0.863 1 C} FS
+21 4 -20 -3 2 6474 4076 SP
+-16 0 1 6421 4206 SP
+-9 -5 0 1 2 6471 4098 SP
+{0.784 A} FS
+-4 -4 1 6566 3934 SP
+33 12 9 -8 11 14 18 -5 -2 9 11 -2 10 6 -42 -29 -42 3 3 -14 -9 -4 11 6566 3969 SP
+6566 4138 M
+-1 -20 D
+-52 -10 D
+-15 11 D
+-37 3 D
+-16 18 D
+15 -16 D
+48 -5 D
+6 -11 D
+50 18 D
+-3 12 D
+5 6 D
+0 192 D
+-64 0 D
+-43 -27 D
+-61 -3 D
+-17 -15 D
+72 -19 D
+13 -14 D
+56 -2 D
+4 -14 D
+35 -2 D
+-37 0 D
+-24 14 D
+37 -23 D
+-72 -1 D
+-18 14 D
+-100 -25 D
+55 -11 D
+-24 -3 D
+20 -16 D
+83 -4 D
+1 6 D
+9 -8 D
+28 14 D
+26 -4 D
+-20 -8 D
+22 -15 D
+-11 -10 D
+-32 1 D
+-27 -14 D
+-30 5 D
+-47 -46 D
+16 -11 D
+21 1 D
+-10 -6 D
+47 -5 D
+-29 -5 D
+10 -19 D
+52 9 D
+18 -29 D
+-16 -13 D
+48 12 D
+9 -4 D
+P
+FO
+6024 4203 M
+20 12 D
+-3 22 D
+25 1 D
+1 -24 D
+52 1 D
+29 -21 D
+48 -12 D
+9 8 D
+5 -10 D
+25 5 D
+-27 9 D
+30 8 D
+1 12 D
+-25 6 D
+53 -6 D
+-11 9 D
+24 -6 D
+24 15 D
+-54 22 D
+-53 4 D
+-27 -2 D
+19 -24 D
+-36 41 D
+-129 36 D
+P
+FO
+-28 -9 6 -9 -21 0 20 13 4 6377 3889 SP
+0 -11 -83 13 23 9 3 6308 4146 SP
+-31 -14 -19 10 24 1 3 6458 3920 SP
+35 -12 -36 -6 -14 12 3 6414 4065 SP
+10 -4 -20 -8 -13 4 3 6453 4084 SP
+-15 -1 16 1 2 6223 4193 SP
+-16 1 10 4 2 6079 3841 SP
+33 18 1 6322 3872 SP
+27 9 1 6160 3849 SP
+-11 -11 1 6117 3849 SP
+28 0 1 6187 3851 SP
+9 -6 1 6543 3939 SP
+17 5 1 6087 3841 SP
+21 -4 1 6214 4078 SP
+{0.706 0.863 1 C} FS
+21 4 -20 -3 2 6474 4076 SP
+-16 0 1 6421 4206 SP
+-9 -5 0 1 2 6471 4098 SP
+6502 4336 M
+-43 -27 D
+-61 -3 D
+-17 -15 D
+72 -19 D
+13 -14 D
+56 -2 D
+4 -14 D
+35 -2 D
+-37 0 D
+-24 14 D
+37 -23 D
+-72 -1 D
+-18 14 D
+-100 -25 D
+55 -11 D
+-24 -3 D
+20 -16 D
+83 -4 D
+1 6 D
+9 -8 D
+28 14 D
+26 -4 D
+-20 -8 D
+22 -15 D
+-11 -10 D
+-32 1 D
+-27 -14 D
+-30 5 D
+-47 -46 D
+16 -11 D
+21 1 D
+-10 -6 D
+47 -5 D
+-29 -5 D
+10 -19 D
+52 9 D
+18 -29 D
+-16 -13 D
+48 12 D
+9 -4 D
+S
+6024 4203 M
+20 12 D
+-3 22 D
+25 1 D
+1 -24 D
+52 1 D
+29 -21 D
+48 -12 D
+9 8 D
+5 -10 D
+25 5 D
+-27 9 D
+30 8 D
+1 12 D
+-25 6 D
+53 -6 D
+-11 9 D
+24 -6 D
+24 15 D
+-54 22 D
+-53 4 D
+-27 -2 D
+19 -24 D
+-36 41 D
+-129 36 D
+S
+6566 3969 M
+-9 -4 D
+3 -14 D
+-42 3 D
+-42 -29 D
+10 6 D
+11 -2 D
+-2 9 D
+18 -5 D
+11 14 D
+9 -8 D
+33 12 D
+S
+6377 3889 M
+20 13 D
+-21 0 D
+6 -9 D
+-28 -9 D
+P S
+6308 4146 M
+23 9 D
+-83 13 D
+0 -11 D
+P S
+6458 3920 M
+24 1 D
+-19 10 D
+-31 -14 D
+P S
+6414 4065 M
+-14 12 D
+-36 -6 D
+35 -12 D
+P S
+6453 4084 M
+-13 4 D
+-20 -8 D
+10 -4 D
+P S
+6566 3934 M
+-4 -4 D
+P S
+6223 4193 M
+16 1 D
+-15 -1 D
+P S
+6079 3841 M
+10 4 D
+-16 1 D
+P S
+6322 3872 M
+33 18 D
+P S
+6160 3849 M
+27 9 D
+P S
+6117 3849 M
+-11 -11 D
+P S
+6187 3851 M
+28 0 D
+P S
+6543 3939 M
+9 -6 D
+P S
+6087 3841 M
+17 5 D
+P S
+6214 4078 M
+21 -4 D
+P S
+6566 4138 M
+-1 -20 D
+-52 -10 D
+-15 11 D
+-37 3 D
+-16 18 D
+15 -16 D
+48 -5 D
+6 -11 D
+50 18 D
+-3 12 D
+5 6 D
+S
+6474 4076 M
+-20 -3 D
+21 4 D
+P S
+6421 4206 M
+-16 0 D
+P S
+6471 4098 M
+0 1 D
+-9 -5 D
+P S
+6566 3934 M
+4 4 D
+-4 -4 D
+0 17 D
+5 2 D
+6 -8 D
+108 61 D
+38 9 D
+26 19 D
+-24 5 D
+0 9 D
+97 54 D
+38 4 D
+-25 -9 D
+30 -10 D
+-38 7 D
+-28 -9 D
+-12 -26 D
+25 1 D
+-22 -17 D
+55 13 D
+0 8 D
+5 -7 D
+3 12 D
+27 -5 D
+13 13 D
+-21 10 D
+27 13 D
+-4 -12 D
+10 9 D
+3 -8 D
+29 7 D
+-11 -6 D
+18 -2 D
+-16 -4 D
+17 3 D
+2 -9 D
+29 0 D
+17 -12 D
+77 3 D
+30 -12 D
+9 4 D
+0 -267 D
+-543 0 D
+P
+FO
+-71 -28 4 -25 -19 -17 36 11 10 -14 9 20 31 -14 7 6566 4036 SP
+-1 -6 -56 -53 57 53 3 6566 4144 SP
+71 0 -71 13 2 7109 4323 SP
+{0.784 A} FS
+-7 -8 -24 9 6 -17 -10 7 -5 -10 -27 4 1 11 17 -2 -9 6 36 15 -6 -11 11 4 12 6725 3984 SP
+-22 -17 8 11 2 6908 4065 SP
+-25 1 24 10 2 6760 4011 SP
+-10 -5 -1 0 2 6995 4065 SP
+15 1 1 6929 4075 SP
+-6 -7 6 8 2 6894 4071 SP
+{0.706 0.863 1 C} FS
+-54 -11 1 6732 4059 SP
+22 -5 1 6671 4031 SP
+-8 -10 1 6660 4005 SP
+-32 -11 1 6740 4077 SP
+10 -7 1 6809 4073 SP
+26 -1 -1 1 2 6590 4064 SP
+15 -8 0 1 2 6590 4056 SP
+-6 -7 1 6939 4120 SP
+12 -1 1 6687 4039 SP
+17 -5 -1 0 2 6684 4033 SP
+14 -3 1 6594 4058 SP
+9 -5 0 1 2 6595 4050 SP
+16 1 1 6589 4066 SP
+11 -12 1 6660 4013 SP
+{0.784 A} FS
+7109 4323 M
+-71 13 D
+-472 0 D
+0 -192 D
+57 53 D
+-56 -53 D
+-1 -108 D
+31 -14 D
+9 20 D
+10 -14 D
+36 11 D
+-19 -17 D
+4 -25 D
+-71 -28 D
+0 -18 D
+5 2 D
+6 -8 D
+108 61 D
+38 9 D
+26 19 D
+-24 5 D
+0 9 D
+97 54 D
+38 4 D
+-25 -9 D
+30 -10 D
+-38 7 D
+-28 -9 D
+-12 -26 D
+25 1 D
+-22 -17 D
+55 13 D
+0 8 D
+5 -7 D
+3 12 D
+27 -5 D
+13 13 D
+-21 10 D
+27 13 D
+-4 -12 D
+10 9 D
+3 -8 D
+29 7 D
+-11 -6 D
+18 -2 D
+-16 -4 D
+17 3 D
+2 -9 D
+29 0 D
+17 -12 D
+77 3 D
+30 -12 D
+9 4 D
+P
+FO
+4 4 1 6566 3934 SP
+-7 -8 -24 9 6 -17 -10 7 -5 -10 -27 4 1 11 17 -2 -9 6 36 15 -6 -11 11 4 12 6725 3984 SP
+-22 -17 8 11 2 6908 4065 SP
+-25 1 24 10 2 6760 4011 SP
+-10 -5 -1 0 2 6995 4065 SP
+15 1 1 6929 4075 SP
+-6 -7 6 8 2 6894 4071 SP
+{0.706 0.863 1 C} FS
+-54 -11 1 6732 4059 SP
+22 -5 1 6671 4031 SP
+-8 -10 1 6660 4005 SP
+-32 -11 1 6740 4077 SP
+10 -7 1 6809 4073 SP
+26 -1 -1 1 2 6590 4064 SP
+15 -8 0 1 2 6590 4056 SP
+-6 -7 1 6939 4120 SP
+12 -1 1 6687 4039 SP
+17 -5 -1 0 2 6684 4033 SP
+14 -3 1 6594 4058 SP
+9 -5 0 1 2 6595 4050 SP
+16 1 1 6589 4066 SP
+11 -12 1 6660 4013 SP
+6566 3951 M
+5 2 D
+6 -8 D
+108 61 D
+38 9 D
+26 19 D
+-24 5 D
+0 9 D
+97 54 D
+38 4 D
+-25 -9 D
+30 -10 D
+-38 7 D
+-28 -9 D
+-12 -26 D
+25 1 D
+-22 -17 D
+55 13 D
+0 8 D
+5 -7 D
+3 12 D
+27 -5 D
+13 13 D
+-21 10 D
+27 13 D
+-4 -12 D
+10 9 D
+3 -8 D
+29 7 D
+-11 -6 D
+18 -2 D
+-16 -4 D
+17 3 D
+2 -9 D
+29 0 D
+17 -12 D
+77 3 D
+30 -12 D
+9 4 D
+S
+6725 3984 M
+11 4 D
+-6 -11 D
+36 15 D
+-9 6 D
+17 -2 D
+1 11 D
+-27 4 D
+-5 -10 D
+-10 7 D
+6 -17 D
+-24 9 D
+-7 -8 D
+P S
+6566 4036 M
+31 -14 D
+9 20 D
+10 -14 D
+36 11 D
+-19 -17 D
+4 -25 D
+-71 -28 D
+S
+6908 4065 M
+8 11 D
+-22 -17 D
+P S
+6760 4011 M
+24 10 D
+-25 1 D
+P S
+6995 4065 M
+-11 -5 D
+P S
+6929 4075 M
+15 1 D
+P S
+6894 4071 M
+6 8 D
+P S
+6566 3934 M
+4 4 D
+P S
+7109 4323 M
+-71 13 D
+S
+6566 4144 M
+57 53 D
+-56 -53 D
+-1 -6 D
+S
+6732 4059 M
+-54 -11 D
+P S
+6671 4031 M
+22 -5 D
+P S
+6660 4005 M
+-8 -10 D
+P S
+6740 4077 M
+-32 -11 D
+P S
+6809 4073 M
+10 -7 D
+P S
+6590 4064 M
+-1 1 D
+26 -1 D
+P S
+6590 4056 M
+0 1 D
+15 -8 D
+P S
+6939 4120 M
+-6 -7 D
+P S
+6687 4039 M
+12 -1 D
+P S
+6684 4033 M
+-1 0 D
+17 -5 D
+P S
+6594 4058 M
+14 -3 D
+P S
+6595 4050 M
+0 1 D
+9 -5 D
+P S
+6589 4066 M
+16 1 D
+P S
+6660 4013 M
+11 -12 D
+P S
+11 -4 -11 8 0 15 2 0 86 -36 -10 -12 -5 12 -12 -7 17 -7 13 6 0 267 -91 0 12 7200 3794 SP
+91 0 0 13 -91 17 3 7200 4306 SP
+-17 11 6 -16 2 7145 4109 SP
+12 -11 1 7178 4109 SP
+{0.784 A} FS
+11 -4 -11 8 0 15 2 0 86 -36 -10 -12 -5 12 -12 -7 17 -7 13 6 0 -262 -91 17 12 7200 4306 SP
+{0.706 0.863 1 C} FS
+-17 11 6 -16 2 7145 4109 SP
+12 -11 1 7178 4109 SP
+7109 4061 M
+13 6 D
+17 -7 D
+-12 -7 D
+-5 12 D
+-10 -12 D
+86 -36 D
+2 0 D
+7200 4032 M
+-11 8 D
+11 -4 D
+S
+7200 4306 M
+-91 17 D
+S
+7145 4109 M
+6 -16 D
+-17 11 D
+P S
+7178 4109 M
+12 -11 D
+P S
+0 4111 M
+1 0 D
+-1 7 D
+5 2 D
+-5 2 D
+0 8 D
+4 0 D
+-4 1 D
+0 10 D
+14 1 D
+-9 11 D
+21 -5 D
+-16 11 D
+21 -4 D
+-12 5 D
+23 2 D
+-21 8 D
+27 -5 D
+-2 12 D
+-27 4 D
+34 2 D
+-22 22 D
+25 -5 D
+6 12 D
+0 -418 D
+-62 0 D
+P
+FO
+{0.784 A} FS
+19 -13 1 38 4198 SP
+21 -7 1 11 4159 SP
+0 4111 M
+1 0 D
+-1 7 D
+5 2 D
+-5 2 D
+0 8 D
+4 0 D
+-4 1 D
+0 10 D
+14 1 D
+-9 11 D
+21 -5 D
+-16 11 D
+21 -4 D
+-12 5 D
+23 2 D
+-21 8 D
+27 -5 D
+-2 12 D
+-27 4 D
+34 2 D
+-22 22 D
+25 -5 D
+6 12 D
+0 124 D
+-62 0 D
+P
+FO
+19 -13 1 38 4198 SP
+21 -7 1 11 4159 SP
+0 4111 M
+1 0 D
+-1 1 D
+0 4118 M
+5 2 D
+-5 2 D
+0 4130 M
+4 0 D
+-4 1 D
+0 4141 M
+14 1 D
+-9 11 D
+21 -5 D
+-16 11 D
+21 -4 D
+-12 5 D
+23 2 D
+-21 8 D
+27 -5 D
+-2 12 D
+-27 4 D
+34 2 D
+-22 22 D
+25 -5 D
+6 12 D
+S
+38 4198 M
+19 -13 D
+P S
+11 4159 M
+21 -7 D
+P S
+{0.706 0.863 1 C} FS
+62 4212 M
+2 4 D
+47 2 D
+9 21 D
+19 -3 D
+-18 -12 D
+17 -3 D
+-2 10 D
+7 -7 D
+39 7 D
+-9 9 D
+30 -3 D
+42 37 D
+32 6 D
+-14 20 D
+26 -16 D
+42 2 D
+2 8 D
+16 -6 D
+82 12 D
+108 36 D
+65 0 D
+0 -110 D
+-11 4 D
+-19 -25 D
+-6 23 D
+-49 12 D
+19 -17 D
+-28 10 D
+6 -14 D
+-23 4 D
+9 -8 D
+-21 -1 D
+77 -1 D
+-25 -7 D
+22 -4 D
+-61 -4 D
+73 -14 D
+-36 -16 D
+44 4 D
+29 -7 D
+0 -371 D
+-542 0 D
+P
+FO
+-10 1 -6 -1 2 409 4336 SP
+{0.784 A} FS
+20 3 1 117 4218 SP
+29 -7 44 4 -36 -16 73 -14 -61 -4 22 -4 -25 -7 77 -1 -21 -1 9 -8 -23 4 6 -14 -28 10 19 -17 -49 12 -6 23 -19 -25 -11 4 18 604 4226 SP
+409 4336 M
+-6 -1 D
+-341 1 D
+0 -124 D
+2 4 D
+47 2 D
+9 21 D
+19 -3 D
+-18 -12 D
+17 -3 D
+-2 10 D
+7 -7 D
+39 7 D
+-9 9 D
+30 -3 D
+42 37 D
+32 6 D
+-14 20 D
+26 -16 D
+42 2 D
+2 8 D
+16 -6 D
+82 12 D
+108 36 D
+P
+FO
+20 3 1 117 4218 SP
+62 4212 M
+2 4 D
+47 2 D
+9 21 D
+19 -3 D
+-18 -12 D
+17 -3 D
+-2 10 D
+7 -7 D
+39 7 D
+-9 9 D
+30 -3 D
+42 37 D
+32 6 D
+-14 20 D
+26 -16 D
+42 2 D
+2 8 D
+16 -6 D
+82 12 D
+108 36 D
+S
+604 4226 M
+-11 4 D
+-19 -25 D
+-6 23 D
+-49 12 D
+19 -17 D
+-28 10 D
+6 -14 D
+-23 4 D
+9 -8 D
+-21 -1 D
+77 -1 D
+-25 -7 D
+22 -4 D
+-61 -4 D
+73 -14 D
+-36 -16 D
+44 4 D
+29 -7 D
+S
+117 4218 M
+20 3 D
+P S
+409 4336 M
+-6 -1 D
+-10 1 D
+S
+{0.706 0.863 1 C} FS
+604 4165 M
+34 -8 D
+103 23 D
+34 19 D
+-15 3 D
+20 1 D
+-46 28 D
+18 7 D
+-23 -6 D
+-22 11 D
+-10 -13 D
+-46 3 D
+6 -15 D
+-20 15 D
+-17 -13 D
+-16 6 D
+0 110 D
+542 0 D
+0 -440 D
+-2 10 D
+-31 12 D
+-25 37 D
+-46 5 D
+34 4 D
+-22 3 D
+23 5 D
+20 29 D
+-71 -4 D
+38 32 D
+-54 -1 D
+-1 -22 D
+-21 1 D
+12 -20 D
+-23 -10 D
+33 -1 D
+-21 -38 D
+13 15 D
+15 10 D
+9 -9 D
+-12 1 D
+-7 -29 D
+7 -6 D
+0 6 D
+49 3 D
+-16 -12 D
+14 -13 D
+9 5 D
+-8 -19 D
+11 -5 D
+-41 -4 D
+-15 -11 D
+19 4 D
+3 -10 D
+-37 -19 D
+52 -13 D
+28 11 D
+-19 -17 D
+-32 0 D
+-40 -30 D
+56 4 D
+5 13 D
+94 3 D
+0 -22 D
+-542 0 D
+P
+FO
+21 1 -15 2 -6 3 3 1146 3890 SP
+0 17 1 1146 3873 SP
+{0.784 A} FS
+929 3845 M
+46 10 D
+-2 48 D
+26 13 D
+-19 20 D
+-32 -6 D
+10 6 D
+-12 4 D
+-7 -11 D
+-9 7 D
+-23 -14 D
+19 -2 D
+-11 -12 D
+-43 1 D
+15 -12 D
+-17 -10 D
+35 -6 D
+-28 -17 D
+33 2 D
+-45 -11 D
+17 -2 D
+-18 -9 D
+23 1 D
+-16 -7 D
+19 3 D
+-9 -8 D
+P
+FO
+6 16 14 5 1 -6 3 956 4010 SP
+17 -16 -17 9 2 983 3992 SP
+17 4 -8 -9 2 983 3973 SP
+12 10 1 1016 3904 SP
+-8 5 8 -4 2 1000 3946 SP
+14 1 1 1103 3812 SP
+14 1 1 941 4000 SP
+9 -8 1 956 4129 SP
+-4 -6 1 1119 4084 SP
+14 1 1 1022 3883 SP
+11 6 1 969 3949 SP
+4 -7 1 1063 4038 SP
+{0.706 0.863 1 C} FS
+-10 -5 1 977 3922 SP
+-8 -6 1 925 3877 SP
+-12 -8 1 756 4211 SP
+10 6 -9 -6 2 1028 3994 SP
+{0.784 A} FS
+1146 3873 M
+0 17 D
+-6 3 D
+-15 2 D
+21 1 D
+-2 10 D
+-31 12 D
+-25 37 D
+-46 5 D
+34 4 D
+-22 3 D
+23 5 D
+20 29 D
+-71 -4 D
+38 32 D
+-54 -1 D
+-1 -22 D
+-21 1 D
+12 -20 D
+-23 -10 D
+33 -1 D
+-21 -38 D
+13 15 D
+15 10 D
+9 -9 D
+-12 1 D
+-7 -29 D
+7 -6 D
+0 6 D
+49 3 D
+-16 -12 D
+14 -13 D
+9 5 D
+-8 -19 D
+11 -5 D
+-41 -4 D
+-15 -11 D
+19 4 D
+3 -10 D
+-37 -19 D
+52 -13 D
+28 11 D
+-19 -17 D
+-32 0 D
+-40 -30 D
+56 4 D
+5 13 D
+94 3 D
+P
+FO
+-16 6 -17 -13 -20 15 6 -15 -46 3 -10 -13 -22 11 -23 -6 18 7 -46 28 20 1 -15 3 34 19 56 12 47 11 34 -8 16 604 4165 SP
+929 3845 M
+46 10 D
+-2 48 D
+26 13 D
+-19 20 D
+-32 -6 D
+10 6 D
+-12 4 D
+-7 -11 D
+-9 7 D
+-23 -14 D
+19 -2 D
+-11 -12 D
+-43 1 D
+15 -12 D
+-17 -10 D
+35 -6 D
+-28 -17 D
+33 2 D
+-45 -11 D
+17 -2 D
+-18 -9 D
+23 1 D
+-16 -7 D
+19 3 D
+-9 -8 D
+P
+FO
+6 16 14 5 1 -6 3 956 4010 SP
+17 -16 -17 9 2 983 3992 SP
+17 4 -8 -9 2 983 3973 SP
+12 10 1 1016 3904 SP
+-8 5 8 -4 2 1000 3946 SP
+14 1 1 1103 3812 SP
+14 1 1 941 4000 SP
+9 -8 1 956 4129 SP
+-4 -6 1 1119 4084 SP
+14 1 1 1022 3883 SP
+11 6 1 969 3949 SP
+4 -7 1 1063 4038 SP
+{0.706 0.863 1 C} FS
+-10 -5 1 977 3922 SP
+-8 -6 1 925 3877 SP
+-12 -8 1 756 4211 SP
+10 6 -9 -6 2 1028 3994 SP
+1146 3896 M
+-2 10 D
+-31 12 D
+-25 37 D
+-46 5 D
+34 4 D
+-22 3 D
+23 5 D
+20 29 D
+-71 -4 D
+38 32 D
+-54 -1 D
+-1 -22 D
+-21 1 D
+12 -20 D
+-23 -10 D
+33 -1 D
+-21 -38 D
+13 15 D
+15 10 D
+9 -9 D
+-12 1 D
+-7 -29 D
+7 -6 D
+0 6 D
+49 3 D
+-16 -12 D
+14 -13 D
+9 5 D
+-8 -19 D
+11 -5 D
+-41 -4 D
+-15 -11 D
+19 4 D
+3 -10 D
+-37 -19 D
+52 -13 D
+28 11 D
+-19 -17 D
+-32 0 D
+-40 -30 D
+56 4 D
+5 13 D
+94 3 D
+S
+929 3845 M
+46 10 D
+-2 48 D
+26 13 D
+-19 20 D
+-32 -6 D
+10 6 D
+-12 4 D
+-7 -11 D
+-9 7 D
+-23 -14 D
+19 -2 D
+-11 -12 D
+-43 1 D
+15 -12 D
+-17 -10 D
+35 -6 D
+-28 -17 D
+33 2 D
+-45 -11 D
+17 -2 D
+-18 -9 D
+23 1 D
+-16 -7 D
+19 3 D
+-9 -8 D
+P S
+604 4165 M
+34 -8 D
+103 23 D
+34 19 D
+-15 3 D
+20 1 D
+-46 28 D
+18 7 D
+-23 -6 D
+-22 11 D
+-10 -13 D
+-46 3 D
+6 -15 D
+-20 15 D
+-17 -13 D
+-16 6 D
+S
+956 4010 M
+1 -6 D
+14 5 D
+6 16 D
+P S
+983 3992 M
+-17 9 D
+17 -16 D
+P S
+983 3973 M
+-8 -9 D
+17 4 D
+P S
+1016 3904 M
+12 10 D
+P S
+1000 3946 M
+8 -4 D
+-8 5 D
+P S
+1103 3812 M
+14 1 D
+P S
+941 4000 M
+14 1 D
+P S
+956 4129 M
+9 -8 D
+P S
+1119 4084 M
+-4 -6 D
+P S
+1146 3890 M
+-6 3 D
+-15 2 D
+21 1 D
+S
+1022 3883 M
+14 1 D
+P S
+969 3949 M
+11 6 D
+P S
+1063 4038 M
+4 -7 D
+P S
+1146 3873 M
+0 17 D
+S
+977 3922 M
+-10 -5 D
+P S
+925 3877 M
+-8 -6 D
+P S
+756 4211 M
+-12 -8 D
+P S
+1028 3994 M
+-9 -6 D
+10 6 D
+P S
+1146 3486 M
+6 3 D
+-6 5 D
+0 28 D
+27 29 D
+60 24 D
+-7 25 D
+10 12 D
+21 8 D
+56 -15 D
+70 38 D
+39 -12 D
+25 -43 D
+124 -64 D
+15 -32 D
+-16 -22 D
+11 -3 D
+15 24 D
+16 6 D
+-19 20 D
+11 18 D
+26 -4 D
+13 -13 D
+5 9 D
+-69 36 D
+5 12 D
+-37 4 D
+-32 41 D
+-33 17 D
+-7 32 D
+38 11 D
+10 -27 D
+18 14 D
+37 -49 D
+26 -3 D
+23 -15 D
+-20 5 D
+48 -14 D
+22 -19 D
+-8 -37 D
+19 -20 D
+0 -240 D
+-27 -15 D
+-31 17 D
+-57 13 D
+-15 27 D
+-49 14 D
+-30 -2 D
+-56 26 D
+-5 11 D
+31 28 D
+-19 25 D
+15 25 D
+-16 -10 D
+-19 17 D
+-50 -13 D
+-40 6 D
+-29 -12 D
+-39 8 D
+-77 -12 D
+-29 -17 D
+P
+FO
+1 0 6 2 2 1146 3560 SP
+0 18 -35 -18 2 1181 3794 SP
+{0.784 A} FS
+-28 -8 -16 19 5 34 32 8 4 1375 3496 SP
+-23 -10 -7 6 13 11 3 1227 3505 SP
+63 -23 5 -13 -86 -6 17 42 4 1553 3434 SP
+-25 -17 -3 24 15 18 3 1390 3563 SP
+14 -11 -8 5 2 1553 3646 SP
+7 3 -7 -4 2 1444 3357 SP
+2 -11 1 1537 3659 SP
+13 0 1 1591 3613 SP
+7 -4 1 1534 3414 SP
+-9 -2 9 3 2 1420 3598 SP
+5 -6 1 1535 3651 SP
+{0.706 0.863 1 C} FS
+21 5 1 1313 3692 SP
+-12 9 1 1403 3726 SP
+11 -7 1 1663 3586 SP
+-11 -6 1 1337 3713 SP
+7 12 1 1379 3679 SP
+5 6 1 1598 3732 SP
+8 9 1 1392 3682 SP
+25 7 1 1613 3706 SP
+-8 4 1 1379 3710 SP
+{0.784 A} FS
+1688 3275 M
+-27 -15 D
+-31 17 D
+-57 13 D
+-15 27 D
+-49 14 D
+-30 -2 D
+-56 26 D
+-5 11 D
+31 28 D
+-19 25 D
+15 25 D
+-16 -10 D
+-19 17 D
+-50 -13 D
+-40 6 D
+-29 -12 D
+-39 8 D
+-77 -12 D
+-29 -17 D
+0 -159 D
+542 0 D
+P
+FO
+1181 3794 M
+-35 -18 D
+0 -216 D
+7 2 D
+-7 -2 D
+0 -38 D
+27 29 D
+60 24 D
+-7 25 D
+10 12 D
+21 8 D
+56 -15 D
+70 38 D
+39 -12 D
+25 -43 D
+124 -64 D
+15 -32 D
+-16 -22 D
+11 -3 D
+15 24 D
+16 6 D
+-19 20 D
+11 18 D
+26 -4 D
+13 -13 D
+5 9 D
+-69 36 D
+5 12 D
+-37 4 D
+-32 41 D
+-33 17 D
+-7 32 D
+38 11 D
+10 -27 D
+18 14 D
+37 -49 D
+26 -3 D
+23 -15 D
+-20 5 D
+48 -14 D
+22 -19 D
+-8 -37 D
+19 -20 D
+0 279 D
+P
+FO
+-6 5 6 3 2 1146 3486 SP
+-28 -8 -16 19 5 34 32 8 4 1375 3496 SP
+-23 -10 -7 6 13 11 3 1227 3505 SP
+63 -23 5 -13 -86 -6 17 42 4 1553 3434 SP
+-25 -17 -3 24 15 18 3 1390 3563 SP
+14 -11 -8 5 2 1553 3646 SP
+7 3 -7 -4 2 1444 3357 SP
+2 -11 1 1537 3659 SP
+13 0 1 1591 3613 SP
+7 -4 1 1534 3414 SP
+-9 -2 9 3 2 1420 3598 SP
+5 -6 1 1535 3651 SP
+{0.706 0.863 1 C} FS
+21 5 1 1313 3692 SP
+-12 9 1 1403 3726 SP
+11 -7 1 1663 3586 SP
+-11 -6 1 1337 3713 SP
+7 12 1 1379 3679 SP
+5 6 1 1598 3732 SP
+8 9 1 1392 3682 SP
+25 7 1 1613 3706 SP
+-8 4 1 1379 3710 SP
+1146 3522 M
+27 29 D
+60 24 D
+-7 25 D
+10 12 D
+21 8 D
+56 -15 D
+70 38 D
+39 -12 D
+25 -43 D
+124 -64 D
+15 -32 D
+-16 -22 D
+11 -3 D
+15 24 D
+16 6 D
+-19 20 D
+11 18 D
+26 -4 D
+13 -13 D
+5 9 D
+-69 36 D
+5 12 D
+-37 4 D
+-32 41 D
+-33 17 D
+-7 32 D
+38 11 D
+10 -27 D
+18 14 D
+37 -49 D
+26 -3 D
+23 -15 D
+-20 5 D
+48 -14 D
+22 -19 D
+-8 -37 D
+19 -20 D
+S
+1688 3275 M
+-27 -15 D
+-31 17 D
+-57 13 D
+-15 27 D
+-49 14 D
+-30 -2 D
+-56 26 D
+-5 11 D
+31 28 D
+-19 25 D
+15 25 D
+-16 -10 D
+-19 17 D
+-50 -13 D
+-40 6 D
+-29 -12 D
+-39 8 D
+-77 -12 D
+-29 -17 D
+S
+1375 3496 M
+32 8 D
+5 34 D
+-16 19 D
+-28 -8 D
+P S
+1227 3505 M
+13 11 D
+-7 6 D
+-23 -10 D
+P S
+1553 3434 M
+17 42 D
+-86 -6 D
+5 -13 D
+P S
+1390 3563 M
+15 18 D
+-3 24 D
+-25 -17 D
+P S
+1146 3486 M
+6 3 D
+-6 5 D
+S
+1553 3646 M
+-8 5 D
+14 -11 D
+P S
+1181 3794 M
+-35 -18 D
+S
+1444 3357 M
+-7 -4 D
+7 3 D
+P S
+1537 3659 M
+2 -11 D
+P S
+1591 3613 M
+13 0 D
+P S
+1534 3414 M
+7 -4 D
+P S
+1420 3598 M
+9 3 D
+-9 -2 D
+P S
+1535 3651 M
+5 -6 D
+P S
+1146 3560 M
+7 2 D
+P S
+1313 3692 M
+21 5 D
+P S
+1403 3726 M
+-12 9 D
+P S
+1663 3586 M
+11 -7 D
+P S
+1337 3713 M
+-11 -6 D
+P S
+1379 3679 M
+7 12 D
+P S
+1598 3732 M
+5 6 D
+P S
+1392 3682 M
+8 9 D
+P S
+1613 3706 M
+25 7 D
+P S
+1379 3710 M
+-8 4 D
+P S
+2028 3252 M
+-7 34 D
+-10 8 D
+-24 2 D
+-53 -21 D
+-57 16 D
+-48 3 D
+-6 12 D
+-45 5 D
+-6 13 D
+-38 8 D
+-43 -21 D
+-1 -36 D
+-2 0 D
+0 240 D
+20 -20 D
+10 2 D
+-10 -6 D
+10 -13 D
+57 -5 D
+-8 -6 D
+-42 8 D
+-7 -10 D
+16 -28 D
+12 6 D
+9 -18 D
+4 12 D
+16 -10 D
+-13 30 D
+21 -3 D
+-14 12 D
+14 4 D
+14 -10 D
+2 14 D
+-42 18 D
+14 5 D
+-3 9 D
+11 -5 D
+-21 35 D
+9 5 D
+28 -19 D
+-6 11 D
+18 -5 D
+-18 16 D
+38 7 D
+46 -10 D
+-17 -17 D
+36 26 D
+39 0 D
+-34 39 D
+-11 -1 D
+35 30 D
+7 40 D
+4 -8 D
+16 5 D
+1 26 D
+3 -6 D
+11 8 D
+-11 -8 D
+20 13 D
+-9 8 D
+9 -8 D
+8 13 D
+33 9 D
+12 -11 D
+-25 3 D
+14 -4 D
+-6 -5 D
+49 -3 D
+2 -9 D
+-33 -12 D
+20 2 D
+5 -24 D
+16 -5 D
+72 27 D
+-32 -2 D
+-17 23 D
+17 -24 D
+-13 3 D
+-14 15 D
+20 16 D
+-6 -12 D
+26 16 D
+90 16 D
+-18 -16 D
+-24 1 D
+24 -18 D
+-9 6 D
+-20 -24 D
+-25 -5 D
+92 -47 D
+0 -69 D
+-44 0 D
+-53 9 D
+-38 23 D
+-45 -2 D
+-58 -25 D
+-56 3 D
+3 -11 D
+18 -2 D
+-26 -2 D
+1 -8 D
+-61 1 D
+-16 -13 D
+-2 -12 D
+23 3 D
+-6 -25 D
+12 -6 D
+-13 -3 D
+-7 10 D
+-5 -12 D
+28 -8 D
+-7 -8 D
+17 -11 D
+-10 -8 D
+29 2 D
+-25 -10 D
+28 6 D
+34 -21 D
+19 2 D
+6 18 D
+15 0 D
+44 -22 D
+31 5 D
+19 16 D
+19 -8 D
+22 9 D
+-12 -34 D
+7 -29 D
+-47 -86 D
+-52 -4 D
+P
+FO
+17 3 -17 -2 2 2230 3718 SP
+{0.784 A} FS
+0 -11 -60 14 -14 -5 5 8 37 0 5 1817 3388 SP
+-63 -16 19 12 -5 8 30 11 4 2040 3376 SP
+-14 -3 -6 9 9 1 3 1858 3496 SP
+-13 -4 -23 10 -6 18 3 1807 3469 SP
+-15 -8 8 12 2 1903 3415 SP
+-7 10 13 -2 2 1697 3474 SP
+9 4 1 1878 3435 SP
+-9 0 1 1851 3527 SP
+10 5 1 1851 3456 SP
+-7 -3 1 1851 3439 SP
+-12 2 1 2040 3686 SP
+-13 5 1 2013 3691 SP
+-1 6 1 1769 3419 SP
+0 12 1 1851 3473 SP
+-11 -4 1 1836 3523 SP
+-12 1 1 1878 3461 SP
+10 -4 1 1705 3465 SP
+-9 5 1 1824 3463 SP
+10 -2 1 1780 3523 SP
+5 6 1 1879 3404 SP
+5 8 1 1703 3484 SP
+{0.706 0.863 1 C} FS
+-101 43 5 19 29 0 10 19 25 6 -29 -6 -9 -15 -34 -1 1 -32 14 3 10 2088 3754 SP
+5 11 -11 7 2 2055 3482 SP
+2 -10 1 1998 3468 SP
+-1 -11 1 0 2 1983 3476 SP
+0 7 -1 -7 2 1708 3555 SP
+5 5 -5 -4 2 2001 3485 SP
+3 -11 1 1921 3677 SP
+-10 -5 1 1970 3465 SP
+1 -8 1 2104 3704 SP
+-10 6 1 2064 3497 SP
+5 -6 1 1973 3707 SP
+6 -5 1 1726 3497 SP
+-3 -6 1 1716 3550 SP
+-4 -18 1 2110 3300 SP
+{0.784 A} FS
+0 -23 -2 0 -1 -36 -43 -21 -38 8 -6 13 -45 5 -6 12 -48 3 -57 16 -53 -21 -24 2 -10 8 -7 34 14 2028 3252 SP
+2230 3548 M
+-44 0 D
+-53 9 D
+-38 23 D
+-45 -2 D
+-58 -25 D
+-56 3 D
+3 -11 D
+18 -2 D
+-26 -2 D
+1 -8 D
+-61 1 D
+-16 -13 D
+-2 -12 D
+23 3 D
+-6 -25 D
+12 -6 D
+-13 -3 D
+-7 10 D
+-5 -12 D
+28 -8 D
+-7 -8 D
+17 -11 D
+-10 -8 D
+29 2 D
+-25 -10 D
+28 6 D
+34 -21 D
+19 2 D
+6 18 D
+15 0 D
+44 -22 D
+31 5 D
+19 16 D
+19 -8 D
+22 9 D
+-12 -34 D
+7 -29 D
+-47 -86 D
+-52 -4 D
+6 -33 D
+202 0 D
+P
+FO
+2230 3718 M
+-17 -2 D
+17 3 D
+0 75 D
+-542 0 D
+0 -279 D
+20 -20 D
+10 2 D
+-10 -6 D
+10 -13 D
+57 -5 D
+-8 -6 D
+-42 8 D
+-7 -10 D
+16 -28 D
+12 6 D
+9 -18 D
+4 12 D
+16 -10 D
+-13 30 D
+21 -3 D
+-14 12 D
+14 4 D
+14 -10 D
+2 14 D
+-42 18 D
+14 5 D
+-3 9 D
+11 -5 D
+-21 35 D
+9 5 D
+28 -19 D
+-6 11 D
+18 -5 D
+-18 16 D
+38 7 D
+46 -10 D
+-17 -17 D
+36 26 D
+39 0 D
+-34 39 D
+-11 -1 D
+35 30 D
+7 40 D
+4 -8 D
+16 5 D
+1 26 D
+3 -6 D
+11 8 D
+-11 -8 D
+20 13 D
+-9 8 D
+9 -8 D
+8 13 D
+33 9 D
+12 -11 D
+-25 3 D
+14 -4 D
+-6 -5 D
+49 -3 D
+2 -9 D
+-33 -12 D
+20 2 D
+5 -24 D
+16 -5 D
+72 27 D
+-32 -2 D
+-17 23 D
+17 -24 D
+-13 3 D
+-14 15 D
+20 16 D
+-6 -12 D
+26 16 D
+90 16 D
+-18 -16 D
+-24 1 D
+24 -18 D
+-9 6 D
+-20 -24 D
+-25 -5 D
+92 -47 D
+P
+FO
+0 -11 -60 14 -14 -5 5 8 37 0 5 1817 3388 SP
+-63 -16 19 12 -5 8 30 11 4 2040 3376 SP
+-14 -3 -6 9 9 1 3 1858 3496 SP
+-13 -4 -23 10 -6 18 3 1807 3469 SP
+-15 -8 8 12 2 1903 3415 SP
+-7 10 13 -2 2 1697 3474 SP
+9 4 1 1878 3435 SP
+-9 0 1 1851 3527 SP
+10 5 1 1851 3456 SP
+-7 -3 1 1851 3439 SP
+-12 2 1 2040 3686 SP
+-13 5 1 2013 3691 SP
+-1 6 1 1769 3419 SP
+0 12 1 1851 3473 SP
+-11 -4 1 1836 3523 SP
+-12 1 1 1878 3461 SP
+10 -4 1 1705 3465 SP
+-9 5 1 1824 3463 SP
+10 -2 1 1780 3523 SP
+5 6 1 1879 3404 SP
+5 8 1 1703 3484 SP
+{0.706 0.863 1 C} FS
+-101 43 5 19 29 0 10 19 25 6 -29 -6 -9 -15 -34 -1 1 -32 14 3 10 2088 3754 SP
+5 11 -11 7 2 2055 3482 SP
+2 -10 1 1998 3468 SP
+-1 -11 1 0 2 1983 3476 SP
+0 7 -1 -7 2 1708 3555 SP
+5 5 -5 -4 2 2001 3485 SP
+3 -11 1 1921 3677 SP
+-10 -5 1 1970 3465 SP
+1 -8 1 2104 3704 SP
+-10 6 1 2064 3497 SP
+5 -6 1 1973 3707 SP
+6 -5 1 1726 3497 SP
+-3 -6 1 1716 3550 SP
+-4 -18 1 2110 3300 SP
+1688 3515 M
+20 -20 D
+10 2 D
+-10 -6 D
+10 -13 D
+57 -5 D
+-8 -6 D
+-42 8 D
+-7 -10 D
+16 -28 D
+12 6 D
+9 -18 D
+4 12 D
+16 -10 D
+-13 30 D
+21 -3 D
+-14 12 D
+14 4 D
+14 -10 D
+2 14 D
+-42 18 D
+14 5 D
+-3 9 D
+11 -5 D
+-21 35 D
+9 5 D
+28 -19 D
+-6 11 D
+18 -5 D
+-18 16 D
+38 7 D
+46 -10 D
+-17 -17 D
+36 26 D
+39 0 D
+-34 39 D
+-11 -1 D
+35 30 D
+7 40 D
+4 -8 D
+16 5 D
+1 26 D
+3 -6 D
+11 8 D
+-11 -8 D
+20 13 D
+-9 8 D
+9 -8 D
+8 13 D
+33 9 D
+12 -11 D
+-25 3 D
+14 -4 D
+-6 -5 D
+49 -3 D
+2 -9 D
+-33 -12 D
+20 2 D
+5 -24 D
+16 -5 D
+72 27 D
+-32 -2 D
+-17 23 D
+17 -24 D
+-13 3 D
+-14 15 D
+20 16 D
+-6 -12 D
+26 16 D
+90 16 D
+-18 -16 D
+-24 1 D
+24 -18 D
+-9 6 D
+-20 -24 D
+-25 -5 D
+92 -47 D
+S
+2230 3548 M
+-44 0 D
+-53 9 D
+-38 23 D
+-45 -2 D
+-58 -25 D
+-56 3 D
+3 -11 D
+18 -2 D
+-26 -2 D
+1 -8 D
+-61 1 D
+-16 -13 D
+-2 -12 D
+23 3 D
+-6 -25 D
+12 -6 D
+-13 -3 D
+-7 10 D
+-5 -12 D
+28 -8 D
+-7 -8 D
+17 -11 D
+-10 -8 D
+29 2 D
+-25 -10 D
+28 6 D
+34 -21 D
+19 2 D
+6 18 D
+15 0 D
+44 -22 D
+31 5 D
+19 16 D
+19 -8 D
+22 9 D
+-12 -34 D
+7 -29 D
+-47 -86 D
+-52 -4 D
+6 -33 D
+S
+2028 3252 M
+-7 34 D
+-10 8 D
+-24 2 D
+-53 -21 D
+-57 16 D
+-48 3 D
+-6 12 D
+-45 5 D
+-6 13 D
+-38 8 D
+-43 -21 D
+-1 -36 D
+-2 0 D
+S
+1817 3388 M
+37 0 D
+5 8 D
+-14 -5 D
+-60 14 D
+0 -11 D
+P S
+2040 3376 M
+30 11 D
+-5 8 D
+19 12 D
+-63 -16 D
+P S
+1858 3496 M
+9 1 D
+-6 9 D
+-14 -3 D
+P S
+1807 3469 M
+-6 18 D
+-23 10 D
+-13 -4 D
+P S
+1903 3415 M
+8 12 D
+-15 -8 D
+P S
+1697 3474 M
+13 -2 D
+-7 10 D
+P S
+1878 3435 M
+9 4 D
+P S
+1851 3527 M
+-9 0 D
+P S
+1851 3456 M
+10 5 D
+P S
+1851 3439 M
+-7 -3 D
+P S
+2040 3686 M
+-12 2 D
+P S
+2013 3691 M
+-13 5 D
+P S
+1769 3419 M
+-1 6 D
+P S
+1851 3473 M
+0 12 D
+P S
+1836 3523 M
+-11 -4 D
+P S
+1878 3461 M
+-12 1 D
+P S
+1705 3465 M
+10 -4 D
+P S
+1824 3463 M
+-9 5 D
+P S
+1780 3523 M
+10 -2 D
+P S
+1879 3404 M
+5 6 D
+P S
+1703 3484 M
+5 8 D
+P S
+2088 3754 M
+14 3 D
+1 -32 D
+-34 -1 D
+-9 -15 D
+-29 -6 D
+25 6 D
+10 19 D
+29 0 D
+5 19 D
+-101 43 D
+P S
+2055 3482 M
+-11 7 D
+5 11 D
+P S
+1998 3468 M
+2 -10 D
+P S
+1983 3476 M
+1 0 D
+-1 -11 D
+P S
+1708 3555 M
+-1 -7 D
+0 7 D
+P S
+2001 3485 M
+-5 -4 D
+5 5 D
+P S
+1921 3677 M
+3 -11 D
+P S
+1970 3465 M
+-10 -5 D
+P S
+2104 3704 M
+1 -8 D
+P S
+2064 3497 M
+-10 6 D
+P S
+1973 3707 M
+5 -6 D
+P S
+1726 3497 M
+6 -5 D
+P S
+1716 3550 M
+-3 -6 D
+P S
+2110 3300 M
+-4 -18 D
+P S
+2230 3718 M
+-17 -2 D
+17 3 D
+S
+2 -5 15 5 17 -11 1 10 25 -1 -1 2 6 2447 3252 SP
+-5 0 -33 -13 -10 -12 9 -24 39 -20 5 2230 3617 SP
+-7 -2 1 0 6 1 3 2230 3719 SP
+26 40 -28 -40 2 2382 3794 SP
+3 5 12 -5 -1 13 22 0 13 26 -4 30 -31 -1 -8 11 -6 -1 0 -60 6 1 -6 -1 12 2772 3676 SP
+2484 3505 M
+3 22 D
+24 6 D
+-23 8 D
+-48 54 D
+-1 33 D
+-8 -10 D
+-19 31 D
+18 30 D
+38 2 D
+14 21 D
+51 14 D
+47 -4 D
+8 -9 D
+-13 -29 D
+14 -6 D
+-50 1 D
+-12 -14 D
+17 -9 D
+-34 4 D
+-3 -8 D
+17 -5 D
+11 -28 D
+40 -12 D
+-9 -17 D
+13 -28 D
+2 25 D
+19 4 D
+30 -30 D
+-27 -11 D
+-23 13 D
+-6 -22 D
+9 -15 D
+-3 8 D
+18 -2 D
+4 -12 D
+-12 4 D
+-3 -13 D
+11 5 D
+11 -12 D
+1 -57 D
+-58 -6 D
+-72 27 D
+-11 34 D
+P
+FO
+-10 4 -4 24 -34 17 -22 -2 -6 13 5 -13 30 -3 27 -12 3 -24 12 -4 10 2339 3363 SP
+-9 14 15 14 12 -2 3 18 16 -3 1 13 -25 -5 -19 -26 -6 -14 13 -9 10 2326 3781 SP
+-13 28 -12 -7 14 -24 3 2376 3476 SP
+-22 4 14 -8 2 2410 3552 SP
+-14 -17 36 13 2 2293 3482 SP
+6 -17 1 2326 3337 SP
+-18 12 17 -12 2 2366 3540 SP
+-35 13 33 -13 2 2287 3701 SP
+9 -18 1 2315 3370 SP
+5 -7 1 2321 3346 SP
+-9 -2 1 2736 3618 SP
+-23 11 1 2273 3705 SP
+9 2 -8 -2 2 2521 3325 SP
+1 -6 1 2364 3420 SP
+-5 -4 1 2390 3395 SP
+16 -18 1 2431 3713 SP
+{0.784 A} FS
+1 -7 1 2504 3661 SP
+2447 3252 M
+-1 2 D
+25 -1 D
+1 10 D
+17 -11 D
+15 5 D
+2 -5 D
+266 0 D
+0 364 D
+-6 -1 D
+-8 11 D
+-31 -1 D
+-4 30 D
+13 26 D
+22 0 D
+-1 13 D
+12 -5 D
+3 5 D
+0 100 D
+-390 0 D
+-28 -40 D
+26 40 D
+-150 0 D
+0 -75 D
+7 1 D
+-7 -2 D
+0 -101 D
+39 -20 D
+9 -24 D
+-10 -12 D
+-33 -13 D
+-5 0 D
+0 -296 D
+P
+FO
+-6 -1 1 2772 3676 SP
+{0.706 0.863 1 C} FS
+2484 3505 M
+3 22 D
+24 6 D
+-23 8 D
+-48 54 D
+-1 33 D
+-8 -10 D
+-19 31 D
+18 30 D
+38 2 D
+14 21 D
+51 14 D
+47 -4 D
+8 -9 D
+-13 -29 D
+14 -6 D
+-50 1 D
+-12 -14 D
+17 -9 D
+-34 4 D
+-3 -8 D
+17 -5 D
+11 -28 D
+40 -12 D
+-9 -17 D
+13 -28 D
+2 25 D
+19 4 D
+30 -30 D
+-27 -11 D
+-23 13 D
+-6 -22 D
+9 -15 D
+-3 8 D
+18 -2 D
+4 -12 D
+-12 4 D
+-3 -13 D
+11 5 D
+11 -12 D
+1 -57 D
+-58 -6 D
+-72 27 D
+-11 34 D
+P
+FO
+-10 4 -4 24 -34 17 -22 -2 -6 13 5 -13 30 -3 27 -12 3 -24 12 -4 10 2339 3363 SP
+-9 14 15 14 12 -2 3 18 16 -3 1 13 -25 -5 -19 -26 -6 -14 13 -9 10 2326 3781 SP
+-13 28 -12 -7 14 -24 3 2376 3476 SP
+-22 4 14 -8 2 2410 3552 SP
+-14 -17 36 13 2 2293 3482 SP
+6 -17 1 2326 3337 SP
+-18 12 17 -12 2 2366 3540 SP
+-35 13 33 -13 2 2287 3701 SP
+9 -18 1 2315 3370 SP
+5 -7 1 2321 3346 SP
+-9 -2 1 2736 3618 SP
+-23 11 1 2273 3705 SP
+9 2 -8 -2 2 2521 3325 SP
+1 -6 1 2364 3420 SP
+-5 -4 1 2390 3395 SP
+16 -18 1 2431 3713 SP
+{0.784 A} FS
+1 -7 1 2504 3661 SP
+2447 3252 M
+-1 2 D
+25 -1 D
+1 10 D
+17 -11 D
+15 5 D
+2 -5 D
+S
+2230 3617 M
+39 -20 D
+9 -24 D
+-10 -12 D
+-33 -13 D
+-5 0 D
+S
+2484 3505 M
+3 22 D
+24 6 D
+-23 8 D
+-48 54 D
+-1 33 D
+-8 -10 D
+-19 31 D
+18 30 D
+38 2 D
+14 21 D
+51 14 D
+47 -4 D
+8 -9 D
+-13 -29 D
+14 -6 D
+-50 1 D
+-12 -14 D
+17 -9 D
+-34 4 D
+-3 -8 D
+17 -5 D
+11 -28 D
+40 -12 D
+-9 -17 D
+13 -28 D
+2 25 D
+19 4 D
+30 -30 D
+-27 -11 D
+-23 13 D
+-6 -22 D
+9 -15 D
+-3 8 D
+18 -2 D
+4 -12 D
+-12 4 D
+-3 -13 D
+11 5 D
+11 -12 D
+1 -57 D
+-58 -6 D
+-72 27 D
+-11 34 D
+P S
+2339 3363 M
+12 -4 D
+3 -24 D
+27 -12 D
+30 -3 D
+5 -13 D
+-6 13 D
+-22 -2 D
+-34 17 D
+-4 24 D
+P S
+2326 3781 M
+13 -9 D
+-6 -14 D
+-19 -26 D
+-25 -5 D
+1 13 D
+16 -3 D
+3 18 D
+12 -2 D
+15 14 D
+-9 14 D
+P S
+2772 3616 M
+-6 -1 D
+-8 11 D
+-31 -1 D
+-4 30 D
+13 26 D
+22 0 D
+-1 13 D
+12 -5 D
+3 5 D
+S
+2376 3476 M
+14 -24 D
+-12 -7 D
+-13 28 D
+P S
+2410 3552 M
+14 -8 D
+-22 4 D
+P S
+2293 3482 M
+36 13 D
+-14 -17 D
+P S
+2326 3337 M
+6 -17 D
+P S
+2366 3540 M
+17 -12 D
+-18 12 D
+P S
+2287 3701 M
+33 -13 D
+-35 13 D
+P S
+2315 3370 M
+9 -18 D
+P S
+2321 3346 M
+5 -7 D
+P S
+2736 3618 M
+-9 -2 D
+P S
+2273 3705 M
+-23 11 D
+P S
+2521 3325 M
+-8 -2 D
+9 2 D
+P S
+2364 3420 M
+1 -6 D
+P S
+2390 3395 M
+-5 -4 D
+P S
+2382 3794 M
+-28 -40 D
+26 40 D
+S
+2431 3713 M
+16 -18 D
+P S
+2230 3719 M
+7 1 D
+-7 -2 D
+S
+2772 3676 M
+-6 -1 D
+P S
+2504 3661 M
+1 -7 D
+P S
+{0.706 0.863 1 C} FS
+-28 -6 8 -10 -19 -20 -1 0 -13 -8 28 -16 1 -13 -23 -17 17 7 23 -6 7 11 0 18 -3 -1 3 1 14 2772 3676 SP
+-19 23 -3 -27 -34 -19 -80 10 -22 -10 25 6 88 -11 24 11 8 3157 3698 SP
+-35 6 -23 -11 9 -4 3 3260 3597 SP
+-15 -4 0 -1 2 3053 3535 SP
+24 -5 1 3288 3354 SP
+-8 10 1 3223 3286 SP
+-8 -2 9 2 2 2816 3690 SP
+12 1 1 3183 3790 SP
+2 -7 1 3268 3334 SP
+-9 -3 1 2873 3769 SP
+-7 3 -1 0 2 2906 3460 SP
+-5 -6 1 3138 3499 SP
+-29 0 1 3265 3628 SP
+-10 0 1 2996 3556 SP
+{0.784 A} FS
+-542 0 0 542 542 0 0 -364 -28 -6 8 -10 -19 -20 -1 0 -13 -8 28 -16 1 -13 -23 -17 17 7 23 -6 7 11 15 2772 3694 SP
+3 1 1 2772 3676 SP
+{0.706 0.863 1 C} FS
+-19 23 -3 -27 -34 -19 -80 10 -22 -10 25 6 88 -11 24 11 8 3157 3698 SP
+-35 6 -23 -11 9 -4 3 3260 3597 SP
+-15 -4 0 -1 2 3053 3535 SP
+24 -5 1 3288 3354 SP
+-8 10 1 3223 3286 SP
+-8 -2 9 2 2 2816 3690 SP
+12 1 1 3183 3790 SP
+2 -7 1 3268 3334 SP
+-9 -3 1 2873 3769 SP
+-7 3 -1 0 2 2906 3460 SP
+-5 -6 1 3138 3499 SP
+-29 0 1 3265 3628 SP
+-10 0 1 2996 3556 SP
+2772 3694 M
+7 11 D
+23 -6 D
+17 7 D
+-23 -17 D
+1 -13 D
+28 -16 D
+-13 -8 D
+-1 0 D
+-19 -20 D
+8 -10 D
+-28 -6 D
+S
+3157 3698 M
+24 11 D
+88 -11 D
+25 6 D
+-22 -10 D
+-80 10 D
+-34 -19 D
+-3 -27 D
+-19 23 D
+P S
+3260 3597 M
+9 -4 D
+-23 -11 D
+-35 6 D
+P S
+3053 3535 M
+0 -1 D
+-15 -4 D
+P S
+3288 3354 M
+24 -5 D
+P S
+3223 3286 M
+-8 10 D
+P S
+2816 3690 M
+9 2 D
+-8 -2 D
+P S
+3183 3790 M
+12 1 D
+P S
+3268 3334 M
+2 -7 D
+P S
+2873 3769 M
+-9 -3 D
+P S
+2906 3460 M
+-8 3 D
+P S
+3138 3499 M
+-5 -6 D
+P S
+3265 3628 M
+-29 0 D
+P S
+2996 3556 M
+-10 0 D
+P S
+2772 3676 M
+3 1 D
+P S
+-1 0 1 3656 3794 SP
+10 4 -10 3 2 3856 3436 SP
+29 -9 -13 -4 10 -7 -23 -14 21 -9 -9 -6 18 2 -22 14 32 25 -33 13 10 3428 3733 SP
+7 -18 13 9 2 3352 3688 SP
+-9 -1 5 -7 2 3794 3390 SP
+-20 -12 10 -5 2 3651 3750 SP
+-12 -4 23 -6 2 3665 3776 SP
+-21 0 6 -6 2 3510 3579 SP
+16 -1 1 3332 3703 SP
+3 -18 1 3592 3546 SP
+-8 -3 1 3794 3479 SP
+-3 7 1 3445 3255 SP
+-19 -10 19 0 2 3594 3276 SP
+19 3 1 3549 3299 SP
+6 -17 1 3674 3746 SP
+7 15 1 3488 3274 SP
+-1 -9 1 3512 3723 SP
+-9 0 1 3647 3393 SP
+9 -2 1 3827 3775 SP
+-14 -1 1 3574 3458 SP
+13 -2 1 3393 3293 SP
+10 2 1 3421 3282 SP
+8 4 1 3469 3758 SP
+4 5 1 3353 3268 SP
+9 -2 1 3596 3385 SP
+13 6 1 3526 3296 SP
+4 6 1 3579 3342 SP
+-7 -3 1 3546 3446 SP
+-9 -2 1 3597 3395 SP
+7 -4 1 3356 3364 SP
+-9 -6 1 3478 3683 SP
+-10 1 1 3620 3404 SP
+3 6 1 3550 3291 SP
+-8 2 0 -1 2 3664 3409 SP
+7 -2 1 3557 3377 SP
+1 6 1 3346 3269 SP
+-9 -1 1 3348 3389 SP
+3 6 1 3421 3287 SP
+-8 0 1 3594 3408 SP
+{0.784 A} FS
+542 0 0 -542 -341 0 -1 0 -200 0 0 351 10 4 -10 3 8 3856 3436 SP
+{0.706 0.863 1 C} FS
+29 -9 -13 -4 10 -7 -23 -14 21 -9 -9 -6 18 2 -22 14 32 25 -33 13 10 3428 3733 SP
+7 -18 13 9 2 3352 3688 SP
+-9 -1 5 -7 2 3794 3390 SP
+-20 -12 10 -5 2 3651 3750 SP
+-12 -4 23 -6 2 3665 3776 SP
+-21 0 6 -6 2 3510 3579 SP
+16 -1 1 3332 3703 SP
+3 -18 1 3592 3546 SP
+-8 -3 1 3794 3479 SP
+-3 7 1 3445 3255 SP
+-19 -10 19 0 2 3594 3276 SP
+19 3 1 3549 3299 SP
+6 -17 1 3674 3746 SP
+7 15 1 3488 3274 SP
+-1 -9 1 3512 3723 SP
+-9 0 1 3647 3393 SP
+9 -2 1 3827 3775 SP
+-14 -1 1 3574 3458 SP
+13 -2 1 3393 3293 SP
+10 2 1 3421 3282 SP
+8 4 1 3469 3758 SP
+4 5 1 3353 3268 SP
+9 -2 1 3596 3385 SP
+13 6 1 3526 3296 SP
+4 6 1 3579 3342 SP
+-7 -3 1 3546 3446 SP
+-9 -2 1 3597 3395 SP
+7 -4 1 3356 3364 SP
+-9 -6 1 3478 3683 SP
+-10 1 1 3620 3404 SP
+3 6 1 3550 3291 SP
+-8 2 0 -1 2 3664 3409 SP
+7 -2 1 3557 3377 SP
+1 6 1 3346 3269 SP
+-9 -1 1 3348 3389 SP
+3 6 1 3421 3287 SP
+-8 0 1 3594 3408 SP
+3428 3733 M
+-33 13 D
+32 25 D
+-22 14 D
+18 2 D
+-9 -6 D
+21 -9 D
+-23 -14 D
+10 -7 D
+-13 -4 D
+29 -9 D
+P S
+3352 3688 M
+13 9 D
+7 -18 D
+P S
+3794 3390 M
+5 -7 D
+-9 -1 D
+P S
+3651 3750 M
+10 -5 D
+-20 -12 D
+P S
+3665 3776 M
+23 -6 D
+-12 -4 D
+P S
+3510 3579 M
+6 -6 D
+-21 0 D
+P S
+3332 3703 M
+16 -1 D
+P S
+3592 3546 M
+3 -18 D
+P S
+3794 3479 M
+-8 -3 D
+P S
+3445 3255 M
+-3 7 D
+P S
+3594 3276 M
+19 0 D
+-19 -10 D
+P S
+3549 3299 M
+19 3 D
+P S
+3674 3746 M
+6 -17 D
+P S
+3488 3274 M
+7 15 D
+P S
+3512 3723 M
+-1 -9 D
+P S
+3647 3393 M
+-9 0 D
+P S
+3827 3775 M
+9 -2 D
+P S
+3574 3458 M
+-14 -1 D
+P S
+3393 3293 M
+13 -2 D
+P S
+3421 3282 M
+10 2 D
+P S
+3469 3758 M
+8 4 D
+P S
+3353 3268 M
+4 5 D
+P S
+3596 3385 M
+9 -2 D
+P S
+3526 3296 M
+13 6 D
+P S
+3579 3342 M
+4 6 D
+P S
+3546 3446 M
+-7 -3 D
+P S
+3597 3395 M
+-9 -2 D
+P S
+3356 3364 M
+7 -4 D
+P S
+3478 3683 M
+-9 -6 D
+P S
+3620 3404 M
+-10 1 D
+P S
+3550 3291 M
+3 6 D
+P S
+3664 3409 M
+0 -1 D
+-8 2 D
+P S
+3557 3377 M
+7 -2 D
+P S
+3346 3269 M
+1 6 D
+P S
+3348 3389 M
+-9 -1 D
+P S
+3421 3287 M
+3 6 D
+P S
+3594 3408 M
+-8 0 D
+P S
+3656 3794 M
+-1 0 D
+S
+3856 3436 M
+-10 3 D
+10 4 D
+S
+-48 -35 -12 -23 -23 -1 0 -1 24 0 11 24 49 36 7 4304 3252 SP
+-10 -7 11 7 2 4294 3252 SP
+5 -2 18 -15 15 1 -35 16 4 4279 3252 SP
+2 4 1 4241 3252 SP
+-19 6 10 -16 0 -1 9 4 4 3856 3443 SP
+27 22 35 3 0 19 -31 5 -9 29 -22 -10 6 4398 3456 SP
+21 19 1 9 -22 7 3 4398 3372 SP
+2 2 -2 4 2 4398 3283 SP
+5 -15 -2 8 12 -1 -6 10 13 -5 -9 6 8 2 7 4343 3331 SP
+-7 -1 4 -12 11 4 -12 -1 5 10 5 4374 3327 SP
+-7 1 3 -8 4 6 3 4246 3256 SP
+17 -6 -3 6 2 4329 3293 SP
+-26 -13 10 -7 2 4335 3775 SP
+1 -7 1 4321 3380 SP
+-9 8 1 4388 3316 SP
+-6 -8 1 4339 3739 SP
+8 0 1 4261 3255 SP
+0 8 1 4313 3313 SP
+8 -1 1 4305 3261 SP
+8 -1 1 3872 3661 SP
+8 2 1 4309 3264 SP
+{0.784 A} FS
+4241 3252 M
+2 4 D
+-2 -4 D
+38 0 D
+-35 16 D
+15 1 D
+18 -15 D
+5 -2 D
+12 0 D
+11 7 D
+-10 -7 D
+9 0 D
+49 36 D
+11 24 D
+24 0 D
+0 -1 D
+-23 -1 D
+-12 -23 D
+-48 -35 D
+93 0 D
+0 31 D
+-2 4 D
+2 2 D
+0 83 D
+-22 7 D
+1 9 D
+21 19 D
+0 49 D
+-22 -10 D
+-9 29 D
+-31 5 D
+0 19 D
+35 3 D
+27 22 D
+0 270 D
+-542 0 D
+0 -351 D
+9 4 D
+10 -17 D
+-19 6 D
+0 -184 D
+P
+FO
+{0.706 0.863 1 C} FS
+5 -15 -2 8 12 -1 -6 10 13 -5 -9 6 8 2 7 4343 3331 SP
+-7 -1 4 -12 11 4 -12 -1 5 10 5 4374 3327 SP
+-7 1 3 -8 4 6 3 4246 3256 SP
+17 -6 -3 6 2 4329 3293 SP
+-26 -13 10 -7 2 4335 3775 SP
+1 -7 1 4321 3380 SP
+-9 8 1 4388 3316 SP
+-6 -8 1 4339 3739 SP
+8 0 1 4261 3255 SP
+0 8 1 4313 3313 SP
+8 -1 1 4305 3261 SP
+8 -1 1 3872 3661 SP
+8 2 1 4309 3264 SP
+4398 3456 M
+-22 -10 D
+-9 29 D
+-31 5 D
+0 19 D
+35 3 D
+27 22 D
+S
+4398 3372 M
+-22 7 D
+1 9 D
+21 19 D
+S
+4343 3331 M
+8 2 D
+-9 6 D
+13 -5 D
+-6 10 D
+12 -1 D
+-2 8 D
+5 -15 D
+P S
+4304 3252 M
+49 36 D
+11 24 D
+24 0 D
+0 -1 D
+-23 -1 D
+-12 -23 D
+-48 -35 D
+S
+4374 3327 M
+5 10 D
+-12 -1 D
+11 4 D
+4 -12 D
+-7 -1 D
+P S
+4246 3256 M
+4 6 D
+3 -8 D
+-7 1 D
+P S
+3856 3443 M
+9 4 D
+10 -17 D
+-19 6 D
+S
+4329 3293 M
+-3 6 D
+17 -6 D
+P S
+4279 3252 M
+-35 16 D
+15 1 D
+18 -15 D
+5 -2 D
+S
+4398 3283 M
+-2 4 D
+2 2 D
+S
+4335 3775 M
+10 -7 D
+-26 -13 D
+P S
+4321 3380 M
+1 -7 D
+P S
+4388 3316 M
+-9 8 D
+P S
+4339 3739 M
+-6 -8 D
+P S
+4261 3255 M
+8 0 D
+P S
+4313 3313 M
+0 8 D
+P S
+4305 3261 M
+8 -1 D
+P S
+3872 3661 M
+8 -1 D
+P S
+4309 3264 M
+8 2 D
+P S
+4241 3252 M
+2 4 D
+P S
+4294 3252 M
+11 7 D
+-10 -7 D
+P S
+4454 3252 M
+8 1 D
+-8 -1 D
+-4 0 D
+-17 9 D
+-31 -3 D
+48 20 D
+-30 25 D
+-20 3 D
+50 -7 D
+-29 24 D
+-15 46 D
+-8 3 D
+0 35 D
+8 7 D
+-4 6 D
+16 -1 D
+1 13 D
+33 11 D
+14 -4 D
+5 14 D
+-53 12 D
+-20 -9 D
+0 68 D
+27 22 D
+24 6 D
+11 -16 D
+-28 -29 D
+19 0 D
+-22 -18 D
+68 33 D
+52 -8 D
+-12 -21 D
+13 -6 D
+-17 -2 D
+-9 -12 D
+17 -2 D
+-8 -4 D
+15 -1 D
+3 4 D
+24 -7 D
+9 -27 D
+-10 8 D
+-10 -8 D
+8 -10 D
+3 7 D
+-1 -14 D
+11 0 D
+-18 -28 D
+11 -13 D
+-10 -1 D
+7 -8 D
+20 13 D
+2 -9 D
+5 12 D
+8 -8 D
+-2 11 D
+19 -7 D
+4 13 D
+14 -5 D
+13 26 D
+-4 29 D
+-29 44 D
+-27 14 D
+4 14 D
+60 30 D
+1 25 D
+25 15 D
+0 10 D
+14 -3 D
+15 21 D
+35 -18 D
+57 22 D
+80 74 D
+51 62 D
+0 -157 D
+-4 -3 D
+4 -28 D
+0 -21 D
+-3 -5 D
+-5 -19 D
+8 2 D
+0 -15 D
+-15 -35 D
+-57 -37 D
+-13 8 D
+13 12 D
+-16 -4 D
+-18 -46 D
+-81 -2 D
+-60 -35 D
+1 -11 D
+33 -2 D
+7 15 D
+5 -8 D
+44 18 D
+31 -1 D
+-8 -23 D
+19 -12 D
+7 8 D
+24 15 D
+-10 10 D
+5 11 D
+5 -9 D
+3 7 D
+10 -5 D
+-10 -6 D
+33 1 D
+14 14 D
+3 -14 D
+9 18 D
+14 -3 D
+2 14 D
+6 -2 D
+0 -10 D
+-3 -9 D
+3 2 D
+0 -135 D
+P
+FO
+-5 6 -12 -5 10 -12 7 5 4 4398 3289 SP
+1 1 14 3 -7 6 13 16 93 35 36 0 -35 1 59 24 -45 -12 -35 -18 -68 -23 -29 -33 12 4855 3794 SP
+{0.784 A} FS
+6 14 13 -7 -15 -33 5 -18 9 5 -6 12 17 3 1 -14 -9 7 13 -14 -39 -14 -30 25 20 43 19 10 14 4687 3279 SP
+6 -19 11 3 -25 -22 -5 7 -21 -13 -19 4 -4 11 15 16 17 -9 15 16 10 4751 3333 SP
+-5 -13 2 8 2 4696 3267 SP
+-22 -4 22 5 2 4565 3341 SP
+5 9 1 4895 3469 SP
+-7 -11 1 4805 3377 SP
+8 0 1 4680 3262 SP
+7 9 1 4648 3371 SP
+-2 -8 1 4633 3388 SP
+6 5 1 4631 3323 SP
+5 -5 1 4570 3463 SP
+5 5 1 4647 3364 SP
+6 6 1 4651 3339 SP
+{0.706 0.863 1 C} FS
+3 -7 1 4583 3625 SP
+-9 -6 1 4643 3631 SP
+-1 -6 1 4532 3613 SP
+10 -3 1 4734 3669 SP
+22 -1 -8 19 2 4731 3646 SP
+-8 -13 1 4837 3400 SP
+-9 2 1 4518 3665 SP
+{0.784 A} FS
+4450 3252 M
+-17 9 D
+-31 -3 D
+48 20 D
+-30 25 D
+-20 3 D
+50 -7 D
+-29 24 D
+-15 46 D
+-8 3 D
+0 -83 D
+7 5 D
+10 -12 D
+-12 -5 D
+-5 6 D
+0 -31 D
+P
+FO
+8 1 1 4454 3252 SP
+3 2 -3 -9 2 4940 3394 SP
+4940 3508 M
+-15 -35 D
+-57 -37 D
+-13 8 D
+13 12 D
+-16 -4 D
+-18 -46 D
+-81 -2 D
+-60 -35 D
+1 -11 D
+33 -2 D
+7 15 D
+5 -8 D
+44 18 D
+31 -1 D
+-8 -23 D
+19 -12 D
+7 8 D
+24 15 D
+-10 10 D
+5 11 D
+5 -9 D
+3 7 D
+10 -5 D
+-10 -6 D
+33 1 D
+14 14 D
+3 -14 D
+9 18 D
+14 -3 D
+2 14 D
+6 -2 D
+P
+FO
+8 2 -5 -19 -3 -5 3 4940 3545 SP
+0 1 4 -29 -4 -3 3 4940 3597 SP
+4855 3794 M
+-29 -33 D
+-68 -23 D
+-35 -18 D
+-45 -12 D
+59 24 D
+-35 1 D
+36 0 D
+93 35 D
+13 16 D
+-7 6 D
+15 4 D
+-454 0 D
+0 -270 D
+27 22 D
+24 6 D
+11 -16 D
+-28 -29 D
+19 0 D
+-22 -18 D
+68 33 D
+52 -8 D
+-12 -21 D
+13 -6 D
+-17 -2 D
+-9 -12 D
+17 -2 D
+-8 -4 D
+15 -1 D
+3 4 D
+24 -7 D
+9 -27 D
+-10 8 D
+-10 -8 D
+8 -10 D
+3 7 D
+-1 -14 D
+11 0 D
+-18 -28 D
+11 -13 D
+-10 -1 D
+7 -8 D
+20 13 D
+2 -9 D
+5 12 D
+8 -8 D
+-2 11 D
+19 -7 D
+4 13 D
+14 -5 D
+13 26 D
+-4 29 D
+-29 44 D
+-27 14 D
+4 14 D
+60 30 D
+1 25 D
+25 15 D
+0 10 D
+14 -3 D
+15 21 D
+35 -18 D
+57 22 D
+80 74 D
+51 62 D
+0 40 D
+P
+FO
+-20 -9 -53 12 5 14 14 -4 33 11 1 13 16 -1 -4 6 8 7 9 4398 3407 SP
+6 14 13 -7 -15 -33 5 -18 9 5 -6 12 17 3 1 -14 -9 7 13 -14 -39 -14 -30 25 20 43 19 10 14 4687 3279 SP
+6 -19 11 3 -25 -22 -5 7 -21 -13 -19 4 -4 11 15 16 17 -9 15 16 10 4751 3333 SP
+-5 -13 2 8 2 4696 3267 SP
+-22 -4 22 5 2 4565 3341 SP
+5 9 1 4895 3469 SP
+-7 -11 1 4805 3377 SP
+8 0 1 4680 3262 SP
+7 9 1 4648 3371 SP
+-2 -8 1 4633 3388 SP
+6 5 1 4631 3323 SP
+5 -5 1 4570 3463 SP
+5 5 1 4647 3364 SP
+6 6 1 4651 3339 SP
+{0.706 0.863 1 C} FS
+3 -7 1 4583 3625 SP
+-9 -6 1 4643 3631 SP
+-1 -6 1 4532 3613 SP
+10 -3 1 4734 3669 SP
+22 -1 -8 19 2 4731 3646 SP
+-8 -13 1 4837 3400 SP
+-9 2 1 4518 3665 SP
+4398 3524 M
+27 22 D
+24 6 D
+11 -16 D
+-28 -29 D
+19 0 D
+-22 -18 D
+68 33 D
+52 -8 D
+-12 -21 D
+13 -6 D
+-17 -2 D
+-9 -12 D
+17 -2 D
+-8 -4 D
+15 -1 D
+3 4 D
+24 -7 D
+9 -27 D
+-10 8 D
+-10 -8 D
+8 -10 D
+3 7 D
+-1 -14 D
+11 0 D
+-18 -28 D
+11 -13 D
+-10 -1 D
+7 -8 D
+20 13 D
+2 -9 D
+5 12 D
+8 -8 D
+-2 11 D
+19 -7 D
+4 13 D
+14 -5 D
+13 26 D
+-4 29 D
+-29 44 D
+-27 14 D
+4 14 D
+60 30 D
+1 25 D
+25 15 D
+0 10 D
+14 -3 D
+15 21 D
+35 -18 D
+57 22 D
+80 74 D
+51 62 D
+S
+4940 3508 M
+-15 -35 D
+-57 -37 D
+-13 8 D
+13 12 D
+-16 -4 D
+-18 -46 D
+-81 -2 D
+-60 -35 D
+1 -11 D
+33 -2 D
+7 15 D
+5 -8 D
+44 18 D
+31 -1 D
+-8 -23 D
+19 -12 D
+7 8 D
+24 15 D
+-10 10 D
+5 11 D
+5 -9 D
+3 7 D
+10 -5 D
+-10 -6 D
+33 1 D
+14 14 D
+3 -14 D
+9 18 D
+14 -3 D
+2 14 D
+6 -2 D
+S
+4687 3279 M
+19 10 D
+20 43 D
+-30 25 D
+-39 -14 D
+13 -14 D
+-9 7 D
+1 -14 D
+17 3 D
+-6 12 D
+9 5 D
+5 -18 D
+-15 -33 D
+13 -7 D
+6 14 D
+P S
+4751 3333 M
+15 16 D
+17 -9 D
+15 16 D
+-4 11 D
+-19 4 D
+-21 -13 D
+-5 7 D
+-25 -22 D
+11 3 D
+6 -19 D
+P S
+4398 3407 M
+8 7 D
+-4 6 D
+16 -1 D
+1 13 D
+33 11 D
+14 -4 D
+5 14 D
+-53 12 D
+-20 -9 D
+S
+4450 3252 M
+-17 9 D
+-31 -3 D
+48 20 D
+-30 25 D
+-20 3 D
+50 -7 D
+-29 24 D
+-15 46 D
+-8 3 D
+S
+4696 3267 M
+2 8 D
+-5 -13 D
+P S
+4940 3597 M
+-4 -3 D
+4 -28 D
+S
+4940 3545 M
+-3 -5 D
+-5 -19 D
+8 2 D
+S
+4565 3341 M
+22 5 D
+-22 -4 D
+P S
+4895 3469 M
+5 9 D
+P S
+4805 3377 M
+-7 -11 D
+P S
+4680 3262 M
+8 0 D
+P S
+4648 3371 M
+7 9 D
+P S
+4633 3388 M
+-2 -8 D
+P S
+4631 3323 M
+6 5 D
+P S
+4570 3463 M
+5 -5 D
+P S
+4647 3364 M
+5 5 D
+P S
+4651 3339 M
+6 6 D
+P S
+4940 3394 M
+-3 -9 D
+3 2 D
+S
+4454 3252 M
+8 1 D
+P S
+4855 3794 M
+-29 -33 D
+-68 -23 D
+-35 -18 D
+-45 -12 D
+59 24 D
+-35 1 D
+36 0 D
+93 35 D
+13 16 D
+-7 6 D
+15 4 D
+S
+4398 3289 M
+7 5 D
+10 -12 D
+-12 -5 D
+-5 6 D
+S
+4583 3625 M
+3 -7 D
+P S
+4643 3631 M
+-9 -6 D
+P S
+4532 3613 M
+-1 -6 D
+P S
+4734 3669 M
+10 -3 D
+P S
+4731 3646 M
+-8 19 D
+22 -1 D
+P S
+4837 3400 M
+-8 -13 D
+P S
+4518 3665 M
+-9 2 D
+P S
+4940 3387 M
+24 20 D
+-9 15 D
+12 20 D
+-2 33 D
+17 2 D
+14 34 D
+-16 51 D
+-17 0 D
+8 -15 D
+-21 10 D
+-10 -12 D
+0 21 D
+33 6 D
+-25 12 D
+5 9 D
+15 -7 D
+18 9 D
+43 -18 D
+20 26 D
+49 12 D
+-16 -1 D
+3 27 D
+-15 -11 D
+-28 5 D
+-50 38 D
+-13 -60 D
+-29 1 D
+5 -10 D
+-15 -7 D
+0 157 D
+11 13 D
+1 27 D
+48 0 D
+-5 -109 D
+13 20 D
+24 -4 D
+1 -14 D
+5 9 D
+-29 38 D
+12 37 D
+29 3 D
+19 -16 D
+-20 36 D
+433 0 D
+0 -542 D
+-542 0 D
+P
+FO
+-4 -9 4 -1 2 4940 3404 SP
+-3 -7 1 -8 2 0 3 4940 3523 SP
+{0.784 A} FS
+-13 2 29 22 -4 -10 3 5094 3632 SP
+-26 -2 51 28 2 5130 3645 SP
+-32 -18 16 11 2 5211 3681 SP
+9 1 1 5119 3626 SP
+9 7 1 5336 3777 SP
+-20 36 19 -16 29 3 12 37 -29 38 5 9 1 -14 24 -4 13 20 -5 -109 10 5000 3794 SP
+-12 0 1 27 11 13 3 4940 3754 SP
+4940 3566 M
+33 6 D
+-25 12 D
+5 9 D
+15 -7 D
+18 9 D
+43 -18 D
+20 26 D
+49 12 D
+-16 -1 D
+3 27 D
+-15 -11 D
+-28 5 D
+-50 38 D
+-13 -60 D
+-29 1 D
+5 -10 D
+-15 -7 D
+P
+FO
+4940 3523 M
+2 0 D
+1 -8 D
+-3 -7 D
+0 -104 D
+4 -1 D
+-4 -9 D
+0 -7 D
+24 20 D
+-9 15 D
+12 20 D
+-2 33 D
+17 2 D
+14 34 D
+-16 51 D
+-17 0 D
+8 -15 D
+-21 10 D
+-10 -12 D
+P
+FO
+-13 2 29 22 -4 -10 3 5094 3632 SP
+-26 -2 51 28 2 5130 3645 SP
+-32 -18 16 11 2 5211 3681 SP
+9 1 1 5119 3626 SP
+9 7 1 5336 3777 SP
+4940 3566 M
+33 6 D
+-25 12 D
+5 9 D
+15 -7 D
+18 9 D
+43 -18 D
+20 26 D
+49 12 D
+-16 -1 D
+3 27 D
+-15 -11 D
+-28 5 D
+-50 38 D
+-13 -60 D
+-29 1 D
+5 -10 D
+-15 -7 D
+S
+4940 3387 M
+24 20 D
+-9 15 D
+12 20 D
+-2 33 D
+17 2 D
+14 34 D
+-16 51 D
+-17 0 D
+8 -15 D
+-21 10 D
+-10 -12 D
+S
+5000 3794 M
+-5 -109 D
+13 20 D
+24 -4 D
+1 -14 D
+5 9 D
+-29 38 D
+12 37 D
+29 3 D
+19 -16 D
+-20 36 D
+S
+5094 3632 M
+-4 -10 D
+29 22 D
+-13 2 D
+P S
+5130 3645 M
+51 28 D
+-26 -2 D
+P S
+5211 3681 M
+16 11 D
+-32 -18 D
+P S
+5119 3626 M
+9 1 D
+P S
+4940 3523 M
+2 0 D
+1 -8 D
+-3 -7 D
+S
+5336 3777 M
+9 7 D
+P S
+4940 3754 M
+11 13 D
+1 27 D
+S
+4940 3404 M
+4 -1 D
+-4 -9 D
+S
+{0.706 0.863 1 C} FS
+542 0 0 542 -542 0 3 6024 3252 SP
+542 0 0 542 -542 0 3 6566 3252 SP
+543 0 0 542 -543 0 3 7109 3252 SP
+91 0 0 542 -91 0 3 7200 3252 SP
+-62 0 0 -542 62 0 3 0 3794 SP
+542 0 0 542 -542 0 3 604 3252 SP
+{0.784 A} FS
+20 -2 1 445 3465 SP
+-14 3 14 -2 2 372 3482 SP
+9 -1 1 404 3489 SP
+-9 3 1 387 3487 SP
+20 -2 1 445 3465 SP
+-14 3 14 -2 2 372 3482 SP
+9 -1 1 404 3489 SP
+-9 3 1 387 3487 SP
+445 3465 M
+20 -2 D
+P S
+372 3482 M
+14 -2 D
+-14 3 D
+P S
+404 3489 M
+9 -1 D
+P S
+387 3487 M
+-9 3 D
+P S
+{0.706 0.863 1 C} FS
+1146 3776 M
+-53 11 D
+16 -30 D
+-36 -3 D
+-10 10 D
+-47 -10 D
+17 -7 D
+-13 1 D
+7 -13 D
+54 -8 D
+16 -28 D
+19 -4 D
+-4 -17 D
+4 -4 D
+-14 -58 D
+-147 2 D
+-17 8 D
+-44 -20 D
+19 -19 D
+-5 -60 D
+-19 -37 D
+15 6 D
+-8 -16 D
+16 0 D
+-6 0 D
+-4 -37 D
+58 7 D
+34 -35 D
+32 19 D
+62 1 D
+19 20 D
+20 3 D
+5 20 D
+14 8 D
+0 -75 D
+-25 -3 D
+-28 -18 D
+-24 1 D
+-4 9 D
+-46 -7 D
+-21 20 D
+-13 -4 D
+-24 -48 D
+-67 -40 D
+-15 -31 D
+5 -36 D
+-1 -2 D
+-279 0 D
+0 542 D
+542 0 D
+P
+FO
+-9 -1 1 1146 3560 SP
+5 6 2 16 -7 6 3 1146 3494 SP
+{0.784 A} FS
+5 -5 1 1108 3686 SP
+8 -3 1 1104 3693 SP
+{0.706 0.863 1 C} FS
+-4 -5 1 1076 3542 SP
+-1 -7 1 961 3615 SP
+21 -1 1 984 3519 SP
+-7 -7 1 1012 3508 SP
+-5 -7 1 989 3572 SP
+10 -2 1 979 3566 SP
+{0.784 A} FS
+263 0 -1 -2 5 -36 -15 -31 -67 -40 -24 -48 -13 -4 -21 20 -46 -7 -4 9 -24 1 -28 -18 -25 -3 13 1146 3411 SP
+1146 3494 M
+-7 6 D
+2 16 D
+5 6 D
+0 38 D
+-9 -1 D
+9 1 D
+0 216 D
+-53 11 D
+16 -30 D
+-36 -3 D
+-10 10 D
+-47 -10 D
+17 -7 D
+-13 1 D
+7 -13 D
+54 -8 D
+16 -28 D
+19 -4 D
+-4 -17 D
+4 -4 D
+-14 -58 D
+-147 2 D
+-17 8 D
+-44 -20 D
+19 -19 D
+-5 -60 D
+-19 -37 D
+15 6 D
+-8 -16 D
+16 0 D
+-6 0 D
+-4 -37 D
+58 7 D
+34 -35 D
+32 19 D
+62 1 D
+19 20 D
+20 3 D
+5 20 D
+14 8 D
+P
+FO
+5 -5 1 1108 3686 SP
+8 -3 1 1104 3693 SP
+{0.706 0.863 1 C} FS
+-4 -5 1 1076 3542 SP
+-1 -7 1 961 3615 SP
+21 -1 1 984 3519 SP
+-7 -7 1 1012 3508 SP
+-5 -7 1 989 3572 SP
+10 -2 1 979 3566 SP
+1146 3776 M
+-53 11 D
+16 -30 D
+-36 -3 D
+-10 10 D
+-47 -10 D
+17 -7 D
+-13 1 D
+7 -13 D
+54 -8 D
+16 -28 D
+19 -4 D
+-4 -17 D
+4 -4 D
+-14 -58 D
+-147 2 D
+-17 8 D
+-44 -20 D
+19 -19 D
+-5 -60 D
+-19 -37 D
+15 6 D
+-8 -16 D
+16 0 D
+-6 0 D
+-4 -37 D
+58 7 D
+34 -35 D
+32 19 D
+62 1 D
+19 20 D
+20 3 D
+5 20 D
+14 8 D
+S
+1146 3411 M
+-25 -3 D
+-28 -18 D
+-24 1 D
+-4 9 D
+-46 -7 D
+-21 20 D
+-13 -4 D
+-24 -48 D
+-67 -40 D
+-15 -31 D
+5 -36 D
+-1 -2 D
+S
+1108 3686 M
+5 -5 D
+P S
+1104 3693 M
+8 -3 D
+P S
+1146 3494 M
+-7 6 D
+2 16 D
+5 6 D
+S
+1076 3542 M
+-4 -5 D
+P S
+961 3615 M
+-1 -7 D
+P S
+984 3519 M
+21 -1 D
+P S
+1012 3508 M
+-7 -7 D
+P S
+989 3572 M
+-5 -7 D
+P S
+979 3566 M
+10 -2 D
+P S
+1146 3560 M
+-9 -1 D
+P S
+-4 -25 17 -12 -16 13 11 13 -5 11 5 1268 2710 SP
+8 -10 1 1146 2878 SP
+1 -9 9 4 7 -17 11 3 -22 37 -31 -15 6 1557 2793 SP
+5 -7 1 1170 2839 SP
+8 -5 1 1242 2758 SP
+-3 -8 1 1166 2855 SP
+{0.784 A} FS
+1268 2710 M
+-5 11 D
+11 13 D
+-16 13 D
+17 -12 D
+-4 -25 D
+417 0 D
+0 542 D
+-542 0 D
+0 -374 D
+8 -10 D
+-8 10 D
+0 -168 D
+P
+FO
+{0.706 0.863 1 C} FS
+1 -9 9 4 7 -17 11 3 -22 37 -31 -15 6 1557 2793 SP
+5 -7 1 1170 2839 SP
+8 -5 1 1242 2758 SP
+-3 -8 1 1166 2855 SP
+1557 2793 M
+-31 -15 D
+-22 37 D
+11 3 D
+7 -17 D
+9 4 D
+1 -9 D
+P S
+1268 2710 M
+-5 11 D
+11 13 D
+-16 13 D
+17 -12 D
+-4 -25 D
+S
+1146 2878 M
+8 -10 D
+P S
+1170 2839 M
+5 -7 D
+P S
+1242 2758 M
+8 -5 D
+P S
+1166 2855 M
+-3 -8 D
+P S
+2028 3252 M
+46 -61 D
+21 48 D
+-12 -39 D
+18 -1 D
+54 -77 D
+5 -22 D
+28 -16 D
+19 -38 D
+1 -35 D
+22 -19 D
+0 -123 D
+-1 1 D
+1 -16 D
+-3 6 D
+-5 -12 D
+-31 81 D
+-31 22 D
+-8 63 D
+5 -4 D
+-11 27 D
+-33 24 D
+-6 27 D
+9 -1 D
+-18 17 D
+-42 90 D
+-26 31 D
+-4 26 D
+2 0 D
+P
+FO
+{0.784 A} FS
+-8 4 8 -3 2 2140 3131 SP
+{0.706 0.863 1 C} FS
+24 4 17 31 -27 -32 -28 -6 5 -29 5 2037 3089 SP
+13 4 -9 15 2 2158 2754 SP
+-8 11 1 2085 2748 SP
+{0.784 A} FS
+2230 2854 M
+-3 6 D
+-5 -12 D
+-31 81 D
+-31 22 D
+-8 63 D
+5 -4 D
+-11 27 D
+-33 24 D
+-6 27 D
+9 -1 D
+-18 17 D
+-42 90 D
+-26 31 D
+-4 26 D
+2 0 D
+0 1 D
+-340 0 D
+0 -542 D
+542 0 D
+P
+FO
+1 -8 -1 1 2 2230 2869 SP
+0 260 22 -19 1 -35 19 -38 28 -16 5 -22 54 -77 18 -1 -12 -39 21 48 45 -59 1 -2 12 2028 3252 SP
+-8 4 8 -3 2 2140 3131 SP
+{0.706 0.863 1 C} FS
+24 4 17 31 -27 -32 -28 -6 5 -29 5 2037 3089 SP
+13 4 -9 15 2 2158 2754 SP
+-8 11 1 2085 2748 SP
+2230 2854 M
+-3 6 D
+-5 -12 D
+-31 81 D
+-31 22 D
+-8 63 D
+5 -4 D
+-11 27 D
+-33 24 D
+-6 27 D
+9 -1 D
+-18 17 D
+-42 90 D
+-26 31 D
+-4 26 D
+2 0 D
+0 1 D
+S
+2028 3252 M
+46 -61 D
+21 48 D
+-12 -39 D
+18 -1 D
+54 -77 D
+5 -22 D
+28 -16 D
+19 -38 D
+1 -35 D
+22 -19 D
+S
+2140 3131 M
+8 -3 D
+-8 4 D
+P S
+2230 2869 M
+-1 1 D
+1 -8 D
+S
+2037 3089 M
+5 -29 D
+-28 -6 D
+-27 -32 D
+17 31 D
+24 4 D
+P S
+2158 2754 M
+-9 15 D
+13 4 D
+P S
+2085 2748 M
+-8 11 D
+P S
+2525 2710 M
+1 9 D
+13 3 D
+-10 0 D
+7 38 D
+-13 4 D
+-37 -17 D
+-55 -5 D
+-26 -13 D
+-18 5 D
+-33 -14 D
+-38 34 D
+-17 -2 D
+23 12 D
+-2 13 D
+-58 59 D
+-26 8 D
+-6 10 D
+0 8 D
+12 -1 D
+-12 8 D
+0 123 D
+22 -18 D
+51 -81 D
+-2 -41 D
+23 -69 D
+43 2 D
+16 16 D
+83 19 D
+17 16 D
+78 26 D
+7 23 D
+69 15 D
+11 22 D
+25 3 D
+12 22 D
+29 7 D
+0 34 D
+9 10 D
+9 -6 D
+35 49 D
+-29 36 D
+-42 11 D
+-15 15 D
+-10 31 D
+6 20 D
+-65 -61 D
+-41 2 D
+-13 -8 D
+-22 11 D
+8 44 D
+-16 1 D
+-6 -34 D
+-21 35 D
+5 17 D
+-36 26 D
+-20 48 D
+-11 0 D
+13 5 D
+-5 12 D
+59 0 D
+33 -56 D
+28 -8 D
+35 -25 D
+29 -6 D
+51 19 D
+17 -38 D
+73 -13 D
+0 -415 D
+P
+FO
+{0.784 A} FS
+-33 -1 15 7 2 2609 2773 SP
+-27 -11 7 6 2 2664 3164 SP
+10 1 1 2599 3094 SP
+9 -1 1 2557 2771 SP
+-8 -11 8 12 2 2735 2988 SP
+-4 6 1 2518 3144 SP
+-6 5 1 2284 2892 SP
+2525 2710 M
+1 9 D
+13 3 D
+-10 0 D
+7 38 D
+-13 4 D
+-37 -17 D
+-55 -5 D
+-26 -13 D
+-18 5 D
+-33 -14 D
+-38 34 D
+-17 -2 D
+23 12 D
+-2 13 D
+-58 59 D
+-26 8 D
+-6 10 D
+0 -144 D
+P
+FO
+0 127 73 -13 17 -38 51 19 29 -6 35 -25 28 -8 33 -56 8 2506 3252 SP
+2230 2992 M
+22 -18 D
+51 -81 D
+-2 -41 D
+23 -69 D
+43 2 D
+16 16 D
+83 19 D
+17 16 D
+78 26 D
+7 23 D
+69 15 D
+11 22 D
+25 3 D
+12 22 D
+29 7 D
+0 34 D
+9 10 D
+9 -6 D
+35 49 D
+-29 36 D
+-42 11 D
+-15 15 D
+-10 31 D
+6 20 D
+-65 -61 D
+-41 2 D
+-13 -8 D
+-22 11 D
+8 44 D
+-16 1 D
+-6 -34 D
+-21 35 D
+5 17 D
+-36 26 D
+-20 48 D
+-11 0 D
+13 5 D
+-5 12 D
+-217 0 D
+P
+FO
+-12 8 12 -1 2 2230 2862 SP
+-33 -1 15 7 2 2609 2773 SP
+-27 -11 7 6 2 2664 3164 SP
+10 1 1 2599 3094 SP
+9 -1 1 2557 2771 SP
+-8 -11 8 12 2 2735 2988 SP
+-4 6 1 2518 3144 SP
+-6 5 1 2284 2892 SP
+2230 2992 M
+22 -18 D
+51 -81 D
+-2 -41 D
+23 -69 D
+43 2 D
+16 16 D
+83 19 D
+17 16 D
+78 26 D
+7 23 D
+69 15 D
+11 22 D
+25 3 D
+12 22 D
+29 7 D
+0 34 D
+9 10 D
+9 -6 D
+35 49 D
+-29 36 D
+-42 11 D
+-15 15 D
+-10 31 D
+6 20 D
+-65 -61 D
+-41 2 D
+-13 -8 D
+-22 11 D
+8 44 D
+-16 1 D
+-6 -34 D
+-21 35 D
+5 17 D
+-36 26 D
+-20 48 D
+-11 0 D
+13 5 D
+-5 12 D
+S
+2525 2710 M
+1 9 D
+13 3 D
+-10 0 D
+7 38 D
+-13 4 D
+-37 -17 D
+-55 -5 D
+-26 -13 D
+-18 5 D
+-33 -14 D
+-38 34 D
+-17 -2 D
+23 12 D
+-2 13 D
+-58 59 D
+-26 8 D
+-6 10 D
+S
+2506 3252 M
+33 -56 D
+28 -8 D
+35 -25 D
+29 -6 D
+51 19 D
+17 -38 D
+73 -13 D
+S
+2609 2773 M
+15 7 D
+-33 -1 D
+P S
+2664 3164 M
+7 6 D
+-27 -11 D
+P S
+2599 3094 M
+10 1 D
+P S
+2557 2771 M
+9 -1 D
+P S
+2735 2988 M
+8 12 D
+P S
+2230 2862 M
+12 -1 D
+-12 8 D
+S
+2518 3144 M
+-4 6 D
+P S
+2284 2892 M
+-6 5 D
+P S
+{0.706 0.863 1 C} FS
+0 -63 6 17 -3 37 16 2 4 7 5 3291 2710 SP
+2772 3125 M
+48 -8 D
+127 17 D
+6 -22 D
+17 -1 D
+5 -24 D
+23 2 D
+-2 -11 D
+15 9 D
+-11 -11 D
+21 -18 D
+34 4 D
+-7 -12 D
+-34 -6 D
+51 -44 D
+35 14 D
+6 30 D
+16 -1 D
+-11 -8 D
+1 -9 D
+11 1 D
+-9 -11 D
+9 -14 D
+-8 -25 D
+22 -103 D
+65 -133 D
+10 -31 D
+-440 0 D
+P
+FO
+35 18 11 17 -14 36 20 46 -10 0 7 -5 -18 -41 14 -36 -10 -16 -36 -19 10 3033 3205 SP
+5 7 1 3191 3100 SP
+7 -1 1 3251 2763 SP
+4 -6 1 3175 2823 SP
+-2 -6 1 3195 2811 SP
+-4 -5 1 2993 3118 SP
+-9 -6 1 3212 2854 SP
+{0.784 A} FS
+3291 2710 M
+4 7 D
+16 2 D
+-3 37 D
+6 17 D
+0 479 D
+-542 0 D
+0 -127 D
+48 -8 D
+127 17 D
+6 -22 D
+17 -1 D
+5 -24 D
+23 2 D
+-2 -11 D
+15 9 D
+-11 -11 D
+21 -18 D
+34 4 D
+-7 -12 D
+-34 -6 D
+51 -44 D
+35 14 D
+6 30 D
+16 -1 D
+-11 -8 D
+1 -9 D
+11 1 D
+-9 -11 D
+9 -14 D
+-8 -25 D
+22 -103 D
+65 -133 D
+10 -31 D
+P
+FO
+{0.706 0.863 1 C} FS
+35 18 11 17 -14 36 20 46 -10 0 7 -5 -18 -41 14 -36 -10 -16 -36 -19 10 3033 3205 SP
+5 7 1 3191 3100 SP
+7 -1 1 3251 2763 SP
+4 -6 1 3175 2823 SP
+-2 -6 1 3195 2811 SP
+-4 -5 1 2993 3118 SP
+-9 -6 1 3212 2854 SP
+2772 3125 M
+48 -8 D
+127 17 D
+6 -22 D
+17 -1 D
+5 -24 D
+23 2 D
+-2 -11 D
+15 9 D
+-11 -11 D
+21 -18 D
+34 4 D
+-7 -12 D
+-34 -6 D
+51 -44 D
+35 14 D
+6 30 D
+16 -1 D
+-11 -8 D
+1 -9 D
+11 1 D
+-9 -11 D
+9 -14 D
+-8 -25 D
+22 -103 D
+65 -133 D
+10 -31 D
+S
+3291 2710 M
+4 7 D
+16 2 D
+-3 37 D
+6 17 D
+S
+3033 3205 M
+-36 -19 D
+-10 -16 D
+14 -36 D
+-18 -41 D
+7 -5 D
+-10 0 D
+20 46 D
+-14 36 D
+11 17 D
+P S
+3191 3100 M
+5 7 D
+P S
+3251 2763 M
+7 -1 D
+P S
+3175 2823 M
+4 -6 D
+P S
+3195 2811 M
+-2 -6 D
+P S
+2993 3118 M
+-4 -5 D
+P S
+3212 2854 M
+-9 -6 D
+P S
+0 -58 23 48 -1 10 3 3834 2710 SP
+-2 -9 6 9 2 3817 2710 SP
+3314 2773 M
+10 26 D
+-9 49 D
+6 16 D
+19 1 D
+9 16 D
+28 7 D
+0 13 D
+49 34 D
+25 30 D
+36 15 D
+19 21 D
+-4 17 D
+24 9 D
+6 15 D
+6 -18 D
+10 14 D
+11 -13 D
+0 13 D
+5 -9 D
+8 9 D
+7 -7 D
+4 15 D
+7 -16 D
+10 22 D
+2 -17 D
+6 5 D
+-4 16 D
+20 0 D
+36 -69 D
+9 10 D
+-3 -12 D
+21 -6 D
+7 -15 D
+-15 0 D
+13 -14 D
+4 14 D
+14 -49 D
+-10 -43 D
+11 8 D
+-7 -12 D
+7 7 D
+9 -9 D
+4 10 D
+9 -10 D
+7 14 D
+17 4 D
+-6 11 D
+9 -9 D
+12 9 D
+0 19 D
+13 -27 D
+10 1 D
+1 -46 D
+9 -35 D
+3 11 D
+14 -32 D
+-5 -25 D
+9 -5 D
+-12 -27 D
+3 -19 D
+-503 0 D
+P
+FO
+1 0 -1 20 2 3856 2780 SP
+{0.784 A} FS
+1 16 6 -8 2 3658 2781 SP
+1 -21 -2 7 2 3660 2764 SP
+3 6 1 3660 2767 SP
+4 -7 1 3650 2731 SP
+6 -6 1 3680 2951 SP
+4 -7 1 3812 2758 SP
+3 -7 1 3787 2886 SP
+2 10 1 3613 3038 SP
+-4 -9 4 10 2 3806 2749 SP
+3 -5 1 3668 2981 SP
+6 -5 1 3804 2734 SP
+3 -6 1 3677 2980 SP
+{0.706 0.863 1 C} FS
+-2 -45 -22 -15 24 14 1 46 4 3576 3090 SP
+-31 17 37 -31 2 3527 3118 SP
+-6 -5 1 3350 2893 SP
+-8 1 1 3497 3079 SP
+10 6 1 3386 3089 SP
+-12 -5 13 -6 2 3600 3230 SP
+1 -10 1 3653 3062 SP
+1 -15 1 3645 3064 SP
+2 7 1 3464 3219 SP
+{0.784 A} FS
+3817 2710 M
+6 9 D
+-2 -9 D
+13 0 D
+-1 10 D
+23 48 D
+-1 32 D
+1 0 D
+0 452 D
+-542 0 D
+0 -479 D
+10 26 D
+-9 49 D
+6 16 D
+19 1 D
+9 16 D
+28 7 D
+0 13 D
+49 34 D
+25 30 D
+36 15 D
+19 21 D
+-4 17 D
+24 9 D
+6 15 D
+6 -18 D
+10 14 D
+11 -13 D
+0 13 D
+5 -9 D
+8 9 D
+7 -7 D
+4 15 D
+7 -16 D
+10 22 D
+2 -17 D
+6 5 D
+-4 16 D
+20 0 D
+36 -69 D
+9 10 D
+-3 -12 D
+21 -6 D
+7 -15 D
+-15 0 D
+13 -14 D
+4 14 D
+14 -49 D
+-10 -43 D
+11 8 D
+-7 -12 D
+7 7 D
+9 -9 D
+4 10 D
+9 -10 D
+7 14 D
+17 4 D
+-6 11 D
+9 -9 D
+12 9 D
+0 19 D
+13 -27 D
+10 1 D
+1 -46 D
+9 -35 D
+3 11 D
+14 -32 D
+-5 -25 D
+9 -5 D
+-12 -27 D
+P
+FO
+1 16 6 -8 2 3658 2781 SP
+1 -21 -2 7 2 3660 2764 SP
+3 6 1 3660 2767 SP
+4 -7 1 3650 2731 SP
+6 -6 1 3680 2951 SP
+4 -7 1 3812 2758 SP
+3 -7 1 3787 2886 SP
+2 10 1 3613 3038 SP
+-4 -9 4 10 2 3806 2749 SP
+3 -5 1 3668 2981 SP
+6 -5 1 3804 2734 SP
+3 -6 1 3677 2980 SP
+{0.706 0.863 1 C} FS
+-2 -45 -22 -15 24 14 1 46 4 3576 3090 SP
+-31 17 37 -31 2 3527 3118 SP
+-6 -5 1 3350 2893 SP
+-8 1 1 3497 3079 SP
+10 6 1 3386 3089 SP
+-12 -5 13 -6 2 3600 3230 SP
+1 -10 1 3653 3062 SP
+1 -15 1 3645 3064 SP
+2 7 1 3464 3219 SP
+3314 2773 M
+10 26 D
+-9 49 D
+6 16 D
+19 1 D
+9 16 D
+28 7 D
+0 13 D
+49 34 D
+25 30 D
+36 15 D
+19 21 D
+-4 17 D
+24 9 D
+6 15 D
+6 -18 D
+10 14 D
+11 -13 D
+0 13 D
+5 -9 D
+8 9 D
+7 -7 D
+4 15 D
+7 -16 D
+10 22 D
+2 -17 D
+6 5 D
+-4 16 D
+20 0 D
+36 -69 D
+9 10 D
+-3 -12 D
+21 -6 D
+7 -15 D
+-15 0 D
+13 -14 D
+4 14 D
+14 -49 D
+-10 -43 D
+11 8 D
+-7 -12 D
+7 7 D
+9 -9 D
+4 10 D
+9 -10 D
+7 14 D
+17 4 D
+-6 11 D
+9 -9 D
+12 9 D
+0 19 D
+13 -27 D
+10 1 D
+1 -46 D
+9 -35 D
+3 11 D
+14 -32 D
+-5 -25 D
+9 -5 D
+-12 -27 D
+3 -19 D
+S
+3658 2781 M
+6 -8 D
+1 16 D
+P S
+3660 2764 M
+-2 7 D
+1 -21 D
+P S
+3660 2767 M
+3 6 D
+P S
+3650 2731 M
+4 -7 D
+P S
+3680 2951 M
+6 -6 D
+P S
+3812 2758 M
+4 -7 D
+P S
+3787 2886 M
+3 -7 D
+P S
+3613 3038 M
+2 10 D
+P S
+3806 2749 M
+4 10 D
+P S
+3668 2981 M
+3 -5 D
+P S
+3804 2734 M
+6 -5 D
+P S
+3677 2980 M
+3 -6 D
+P S
+3856 2780 M
+-1 20 D
+1 0 D
+S
+3834 2710 M
+-1 10 D
+23 48 D
+S
+3817 2710 M
+6 9 D
+-2 -9 D
+S
+3576 3090 M
+1 46 D
+24 14 D
+-22 -15 D
+-2 -45 D
+P S
+3527 3118 M
+37 -31 D
+-31 17 D
+P S
+3350 2893 M
+-6 -5 D
+P S
+3497 3079 M
+-8 1 D
+P S
+3386 3089 M
+10 6 D
+P S
+3600 3230 M
+13 -6 D
+-12 -5 D
+P S
+3653 3062 M
+1 -10 D
+P S
+3645 3064 M
+1 -15 D
+P S
+3464 3219 M
+2 7 D
+P S
+4368 2710 M
+23 14 D
+-6 25 D
+-1 -19 D
+-7 6 D
+1 -13 D
+-13 -13 D
+-333 0 D
+-3 5 D
+11 -3 D
+-9 7 D
+9 -1 D
+-1 8 D
+14 -6 D
+48 27 D
+4 35 D
+8 0 D
+-14 70 D
+-17 25 D
+-32 19 D
+-41 55 D
+8 27 D
+17 11 D
+0 13 D
+7 -2 D
+-6 9 D
+20 -1 D
+12 15 D
+19 1 D
+2 9 D
+17 -14 D
+12 10 D
+9 -8 D
+-8 -14 D
+7 -20 D
+10 1 D
+3 31 D
+1 -6 D
+33 9 D
+1 8 D
+18 -2 D
+0 7 D
+15 -4 D
+0 18 D
+6 -12 D
+4 8 D
+7 -4 D
+-4 25 D
+25 -23 D
+-3 7 D
+16 8 D
+3 -8 D
+11 10 D
+7 -7 D
+25 8 D
+7 8 D
+-8 6 D
+22 4 D
+3 9 D
+6 -6 D
+15 15 D
+-10 6 D
+24 2 D
+-3 9 D
+12 0 D
+-3 9 D
+11 -2 D
+1 12 D
+9 -7 D
+-4 20 D
+12 8 D
+-10 1 D
+7 1 D
+-8 10 D
+12 -4 D
+0 -280 D
+-3 2 D
+-4 -12 D
+7 -24 D
+0 -77 D
+-3 2 D
+3 -2 D
+-1 -16 D
+1 7 D
+0 -52 D
+P
+FO
+5 -5 -2 5 2 4026 2710 SP
+-138 0 33 -19 7 5 1 -18 12 8 13 -35 23 -15 26 2 -4 -23 27 5 0 20 -1 10 1 2 13 3856 2768 SP
+0 1 -1 -2 2 4241 3252 SP
+-16 7 7 14 -16 12 -5 -10 16 -3 -2 -13 -10 -7 1 0 7 5 15 -5 10 4282 3252 SP
+4 3 -5 -3 2 4295 3252 SP
+{0.784 A} FS
+-17 -18 -46 -3 -3 10 18 27 22 14 16 -6 6 4100 2937 SP
+-7 -1 1 4398 2726 SP
+7 -1 1 4032 2718 SP
+6 4 1 4325 3078 SP
+0 11 1 3965 2711 SP
+-5 5 1 3922 2764 SP
+{0.706 0.863 1 C} FS
+4014 2710 M
+-19 19 D
+-16 50 D
+11 -26 D
+17 20 D
+11 1 D
+-5 69 D
+-14 9 D
+7 12 D
+-21 23 D
+1 24 D
+-22 25 D
+-24 -5 D
+6 8 D
+18 -3 D
+22 -25 D
+-1 -24 D
+18 -14 D
+13 -28 D
+0 -22 D
+9 -16 D
+-6 -3 D
+2 -30 D
+-28 -21 D
+11 -28 D
+27 -6 D
+-30 6 D
+P
+FO
+-31 -1 -10 16 10 -16 31 0 7 -9 35 3 -35 -2 7 4165 3075 SP
+-14 -3 1 -8 13 10 3 4362 3237 SP
+-17 -7 26 1 2 4180 3225 SP
+6 4 1 4204 3232 SP
+2 -9 1 3861 3142 SP
+-1 -8 1 3934 3107 SP
+2 -6 1 4134 3034 SP
+0 -9 1 3928 3117 SP
+-3 -10 1 4250 3092 SP
+-29 27 1 4032 2989 SP
+-1 -10 2 10 2 4039 2729 SP
+{0.784 A} FS
+1 -7 1 4015 2826 SP
+-11 27 1 4001 2725 SP
+4026 2710 M
+-2 5 D
+5 -5 D
+3 0 D
+-3 5 D
+11 -3 D
+-9 7 D
+9 -1 D
+-1 8 D
+14 -6 D
+48 27 D
+4 35 D
+8 0 D
+-14 70 D
+-17 25 D
+-32 19 D
+-41 55 D
+8 27 D
+17 11 D
+0 13 D
+7 -2 D
+-6 9 D
+20 -1 D
+12 15 D
+19 1 D
+2 9 D
+17 -14 D
+12 10 D
+9 -8 D
+-8 -14 D
+7 -20 D
+10 1 D
+3 31 D
+1 -6 D
+33 9 D
+1 8 D
+18 -2 D
+0 7 D
+15 -4 D
+0 18 D
+6 -12 D
+4 8 D
+7 -4 D
+-4 25 D
+25 -23 D
+-3 7 D
+16 8 D
+3 -8 D
+11 10 D
+7 -7 D
+25 8 D
+7 8 D
+-8 6 D
+22 4 D
+3 9 D
+6 -6 D
+15 15 D
+-10 6 D
+24 2 D
+-3 9 D
+12 0 D
+-3 9 D
+11 -2 D
+1 12 D
+9 -7 D
+-4 20 D
+12 8 D
+-10 1 D
+7 1 D
+-8 10 D
+12 -4 D
+0 90 D
+-93 0 D
+-10 -7 D
+-2 -13 D
+16 -3 D
+-5 -10 D
+-16 12 D
+7 14 D
+-16 7 D
+-38 0 D
+-1 -2 D
+1 2 D
+-385 0 D
+0 -452 D
+27 5 D
+-4 -23 D
+26 2 D
+23 -15 D
+13 -35 D
+12 8 D
+1 -18 D
+7 5 D
+33 -19 D
+P
+FO
+-13 -13 1 -13 -7 6 -1 -19 -6 25 23 14 6 4368 2710 SP
+-1 -7 1 4398 2762 SP
+-3 2 1 4398 2771 SP
+7 -24 -4 -12 -3 2 3 4398 2882 SP
+7 5 15 -5 -12 0 4 3 -5 -3 5 4295 3252 SP
+-1 10 1 2 2 3856 2768 SP
+-17 -18 -46 -3 -3 10 18 27 22 14 16 -6 6 4100 2937 SP
+-7 -1 1 4398 2726 SP
+7 -1 1 4032 2718 SP
+6 4 1 4325 3078 SP
+0 11 1 3965 2711 SP
+-5 5 1 3922 2764 SP
+{0.706 0.863 1 C} FS
+4014 2710 M
+-19 19 D
+-16 50 D
+11 -26 D
+17 20 D
+11 1 D
+-5 69 D
+-14 9 D
+7 12 D
+-21 23 D
+1 24 D
+-22 25 D
+-24 -5 D
+6 8 D
+18 -3 D
+22 -25 D
+-1 -24 D
+18 -14 D
+13 -28 D
+0 -22 D
+9 -16 D
+-6 -3 D
+2 -30 D
+-28 -21 D
+11 -28 D
+27 -6 D
+-30 6 D
+P
+FO
+-31 -1 -10 16 10 -16 31 0 7 -9 35 3 -35 -2 7 4165 3075 SP
+-14 -3 1 -8 13 10 3 4362 3237 SP
+-17 -7 26 1 2 4180 3225 SP
+6 4 1 4204 3232 SP
+2 -9 1 3861 3142 SP
+-1 -8 1 3934 3107 SP
+2 -6 1 4134 3034 SP
+0 -9 1 3928 3117 SP
+-3 -10 1 4250 3092 SP
+-29 27 1 4032 2989 SP
+-1 -10 2 10 2 4039 2729 SP
+{0.784 A} FS
+1 -7 1 4015 2826 SP
+-11 27 1 4001 2725 SP
+4032 2710 M
+-3 5 D
+11 -3 D
+-9 7 D
+9 -1 D
+-1 8 D
+14 -6 D
+48 27 D
+4 35 D
+8 0 D
+-14 70 D
+-17 25 D
+-32 19 D
+-41 55 D
+8 27 D
+17 11 D
+0 13 D
+7 -2 D
+-6 9 D
+20 -1 D
+12 15 D
+19 1 D
+2 9 D
+17 -14 D
+12 10 D
+9 -8 D
+-8 -14 D
+7 -20 D
+10 1 D
+3 31 D
+1 -6 D
+33 9 D
+1 8 D
+18 -2 D
+0 7 D
+15 -4 D
+0 18 D
+6 -12 D
+4 8 D
+7 -4 D
+-4 25 D
+25 -23 D
+-3 7 D
+16 8 D
+3 -8 D
+11 10 D
+7 -7 D
+25 8 D
+7 8 D
+-8 6 D
+22 4 D
+3 9 D
+6 -6 D
+15 15 D
+-10 6 D
+24 2 D
+-3 9 D
+12 0 D
+-3 9 D
+11 -2 D
+1 12 D
+9 -7 D
+-4 20 D
+12 8 D
+-10 1 D
+7 1 D
+-8 10 D
+12 -4 D
+S
+3856 2800 M
+27 5 D
+-4 -23 D
+26 2 D
+23 -15 D
+13 -35 D
+12 8 D
+1 -18 D
+7 5 D
+33 -19 D
+S
+4100 2937 M
+16 -6 D
+22 14 D
+18 27 D
+-3 10 D
+-46 -3 D
+-17 -18 D
+P S
+4368 2710 M
+23 14 D
+-6 25 D
+-1 -19 D
+-7 6 D
+1 -13 D
+-13 -13 D
+S
+4398 2882 M
+-3 2 D
+-4 -12 D
+7 -24 D
+S
+4398 2726 M
+-7 -1 D
+P S
+4032 2718 M
+7 -1 D
+P S
+4325 3078 M
+6 4 D
+P S
+3965 2711 M
+0 11 D
+P S
+3922 2764 M
+-5 5 D
+P S
+3856 2768 M
+1 2 D
+-1 10 D
+S
+4026 2710 M
+-2 5 D
+5 -5 D
+S
+4398 2771 M
+-3 2 D
+P S
+4398 2762 M
+-1 -7 D
+P S
+4014 2710 M
+-19 19 D
+-16 50 D
+11 -26 D
+17 20 D
+11 1 D
+-5 69 D
+-14 9 D
+7 12 D
+-21 23 D
+1 24 D
+-22 25 D
+-24 -5 D
+6 8 D
+18 -3 D
+22 -25 D
+-1 -24 D
+18 -14 D
+13 -28 D
+0 -22 D
+9 -16 D
+-6 -3 D
+2 -30 D
+-28 -21 D
+11 -28 D
+27 -6 D
+-30 6 D
+P S
+4165 3075 M
+-35 -2 D
+35 3 D
+7 -9 D
+31 0 D
+10 -16 D
+-10 16 D
+-31 -1 D
+P S
+4305 3252 M
+-10 -7 D
+-2 -13 D
+16 -3 D
+-5 -10 D
+-16 12 D
+7 14 D
+-16 7 D
+S
+4362 3237 M
+13 10 D
+1 -8 D
+-14 -3 D
+P S
+4180 3225 M
+26 1 D
+-17 -7 D
+P S
+4204 3232 M
+6 4 D
+P S
+4241 3252 M
+-1 -2 D
+P S
+3861 3142 M
+2 -9 D
+P S
+3934 3107 M
+-1 -8 D
+P S
+4134 3034 M
+2 -6 D
+P S
+3928 3117 M
+0 -9 D
+P S
+4250 3092 M
+-3 -10 D
+P S
+4295 3252 M
+-5 -3 D
+4 3 D
+P S
+4032 2989 M
+-29 27 D
+P S
+4039 2729 M
+2 10 D
+-1 -10 D
+P S
+4282 3252 M
+15 -5 D
+7 5 D
+S
+4015 2826 M
+1 -7 D
+P S
+4001 2725 M
+-11 27 D
+P S
+{0.706 0.863 1 C} FS
+4562 2710 M
+1 2 D
+-1 -2 D
+-10 0 D
+-1 13 D
+1 -13 D
+-30 0 D
+0 1 D
+-11 3 D
+-5 -4 D
+-10 0 D
+11 11 D
+1 24 D
+-14 -35 D
+-9 0 D
+10 22 D
+-10 5 D
+-9 -25 D
+-5 -2 D
+-73 0 D
+0 61 D
+8 -7 D
+-8 7 D
+0 77 D
+2 -8 D
+11 -10 D
+2 11 D
+11 -5 D
+-9 -22 D
+18 -6 D
+13 10 D
+23 -22 D
+-2 22 D
+21 -26 D
+19 -1 D
+2 -12 D
+3 14 D
+-12 0 D
+-6 14 D
+12 4 D
+-7 6 D
+-13 4 D
+-3 -11 D
+-10 17 D
+-14 -2 D
+0 -9 D
+-16 14 D
+-8 25 D
+30 42 D
+-9 24 D
+5 16 D
+-46 5 D
+-5 -65 D
+-12 5 D
+0 280 D
+4 -1 D
+20 34 D
+-8 6 D
+28 4 D
+-7 12 D
+10 7 D
+-8 6 D
+15 1 D
+0 10 D
+-15 -3 D
+19 11 D
+-6 3 D
+490 0 D
+0 -542 D
+P
+FO
+{0.784 A} FS
+-18 5 -8 29 8 -1 -1 10 16 -27 5 4518 2737 SP
+-3 -15 -39 -45 -11 8 30 82 4 4422 3035 SP
+21 -22 -24 0 -10 10 -6 32 20 -8 5 4534 2746 SP
+-27 13 -8 -5 1 12 31 20 4 4452 2722 SP
+11 -13 -32 10 4 23 8 1 9 -20 5 4419 2791 SP
+10 8 -2 -19 -21 22 3 4507 2759 SP
+9 11 6 -4 2 4646 3205 SP
+-16 -22 7 10 2 4615 3158 SP
+-7 8 12 -12 -5 3 3 4483 2792 SP
+-3 10 1 4452 2797 SP
+6 -5 1 4400 2815 SP
+6 -4 0 -1 2 4452 2824 SP
+3 15 1 4452 2768 SP
+-4 10 1 4452 2837 SP
+7 7 1 4465 2723 SP
+-7 3 7 -2 2 4464 2776 SP
+6 -8 1 4495 2782 SP
+7 1 1 4498 3098 SP
+7 5 1 4509 3101 SP
+{0.706 0.863 1 C} FS
+-4 9 -4 -7 2 4435 2830 SP
+{0.784 A} FS
+-5 -2 -9 -25 -10 5 10 22 4 4485 2710 SP
+-14 -35 1 24 11 11 3 4496 2710 SP
+-5 -4 -11 3 0 1 3 4522 2710 SP
+-1 13 1 4552 2710 SP
+1 2 1 4562 2710 SP
+-52 0 -6 3 19 11 -15 -3 0 10 15 1 -8 6 10 7 -7 12 28 4 -8 6 20 34 4 -1 13 4398 3162 SP
+4398 2848 M
+2 -8 D
+11 -10 D
+2 11 D
+11 -5 D
+-9 -22 D
+18 -6 D
+13 10 D
+23 -22 D
+-2 22 D
+21 -26 D
+19 -1 D
+2 -12 D
+3 14 D
+-12 0 D
+-6 14 D
+12 4 D
+-7 6 D
+-13 4 D
+-3 -11 D
+-10 17 D
+-14 -2 D
+0 -9 D
+-16 14 D
+-8 25 D
+30 42 D
+-9 24 D
+5 16 D
+-46 5 D
+-5 -65 D
+-12 5 D
+P
+FO
+8 -7 1 4398 2771 SP
+-18 5 -8 29 8 -1 -1 10 16 -27 5 4518 2737 SP
+-3 -15 -39 -45 -11 8 30 82 4 4422 3035 SP
+21 -22 -24 0 -10 10 -6 32 20 -8 5 4534 2746 SP
+-27 13 -8 -5 1 12 31 20 4 4452 2722 SP
+11 -13 -32 10 4 23 8 1 9 -20 5 4419 2791 SP
+10 8 -2 -19 -21 22 3 4507 2759 SP
+9 11 6 -4 2 4646 3205 SP
+-16 -22 7 10 2 4615 3158 SP
+-7 8 12 -12 -5 3 3 4483 2792 SP
+-3 10 1 4452 2797 SP
+6 -5 1 4400 2815 SP
+6 -4 0 -1 2 4452 2824 SP
+3 15 1 4452 2768 SP
+-4 10 1 4452 2837 SP
+7 7 1 4465 2723 SP
+-7 3 7 -2 2 4464 2776 SP
+6 -8 1 4495 2782 SP
+7 1 1 4498 3098 SP
+7 5 1 4509 3101 SP
+{0.706 0.863 1 C} FS
+-4 9 -4 -7 2 4435 2830 SP
+4398 2848 M
+2 -8 D
+11 -10 D
+2 11 D
+11 -5 D
+-9 -22 D
+18 -6 D
+13 10 D
+23 -22 D
+-2 22 D
+21 -26 D
+19 -1 D
+2 -12 D
+3 14 D
+-12 0 D
+-6 14 D
+12 4 D
+-7 6 D
+-13 4 D
+-3 -11 D
+-10 17 D
+-14 -2 D
+0 -9 D
+-16 14 D
+-8 25 D
+30 42 D
+-9 24 D
+5 16 D
+-46 5 D
+-5 -65 D
+-12 5 D
+S
+4398 3162 M
+4 -1 D
+20 34 D
+-8 6 D
+28 4 D
+-7 12 D
+10 7 D
+-8 6 D
+15 1 D
+0 10 D
+-15 -3 D
+19 11 D
+-6 3 D
+S
+4518 2737 M
+16 -27 D
+-1 10 D
+8 -1 D
+-8 29 D
+-18 5 D
+P S
+4422 3035 M
+30 82 D
+-11 8 D
+-39 -45 D
+-3 -15 D
+P S
+4534 2746 M
+20 -8 D
+-6 32 D
+-10 10 D
+-24 0 D
+21 -22 D
+P S
+4452 2722 M
+31 20 D
+1 12 D
+-8 -5 D
+-27 13 D
+P S
+4419 2791 M
+9 -20 D
+8 1 D
+4 23 D
+-32 10 D
+P S
+4507 2759 M
+-21 22 D
+-2 -19 D
+10 8 D
+P S
+4646 3205 M
+6 -4 D
+9 11 D
+P S
+4485 2710 M
+10 22 D
+-10 5 D
+-9 -25 D
+-5 -2 D
+S
+4615 3158 M
+7 10 D
+-16 -22 D
+P S
+4483 2792 M
+-5 3 D
+12 -12 D
+P S
+4398 2771 M
+8 -7 D
+P S
+4452 2797 M
+-3 10 D
+P S
+4400 2815 M
+6 -5 D
+P S
+4522 2710 M
+0 1 D
+-11 3 D
+-5 -4 D
+S
+4452 2824 M
+0 -1 D
+6 -4 D
+P S
+4496 2710 M
+11 11 D
+1 24 D
+-14 -35 D
+S
+4452 2768 M
+3 15 D
+P S
+4452 2837 M
+-4 10 D
+P S
+4465 2723 M
+7 7 D
+P S
+4454 3252 M
+P S
+4464 2776 M
+7 -2 D
+-7 3 D
+P S
+4398 2762 M
+P S
+4495 2782 M
+6 -8 D
+P S
+4498 3098 M
+7 1 D
+P S
+4509 3101 M
+7 5 D
+P S
+4552 2710 M
+-1 13 D
+P S
+4562 2710 M
+1 2 D
+P S
+4435 2830 M
+-4 -7 D
+-4 9 D
+P S
+542 0 0 542 -542 0 3 5482 2710 SP
+542 0 0 542 -542 0 3 6024 2710 SP
+542 0 0 542 -542 0 3 6566 2710 SP
+{0.784 A} FS
+-4 -5 1 6564 3035 SP
+-4 -5 1 6564 3035 SP
+6564 3035 M
+-4 -5 D
+P S
+{0.706 0.863 1 C} FS
+543 0 0 542 -543 0 3 7109 2710 SP
+{0.784 A} FS
+-8 -4 -9 11 9 0 3 6621 3017 SP
+-28 21 26 14 2 6681 2954 SP
+8 -11 -19 8 2 6675 3000 SP
+9 -1 -17 -2 8 2 3 6648 3011 SP
+13 5 1 6573 3035 SP
+-8 -4 -9 11 9 0 3 6621 3017 SP
+-28 21 26 14 2 6681 2954 SP
+8 -11 -19 8 2 6675 3000 SP
+9 -1 -17 -2 8 2 3 6648 3011 SP
+13 5 1 6573 3035 SP
+6621 3017 M
+9 0 D
+-9 11 D
+-8 -4 D
+P S
+6681 2954 M
+26 14 D
+-28 21 D
+P S
+6675 3000 M
+-19 8 D
+8 -11 D
+P S
+6648 3011 M
+8 2 D
+-17 -2 D
+9 -1 D
+P S
+6573 3035 M
+13 5 D
+P S
+{0.706 0.863 1 C} FS
+91 0 0 542 -91 0 3 7200 2710 SP
+62 0 0 542 -62 0 3 62 2710 SP
+542 0 0 542 -542 0 3 604 2710 SP
+{0.784 A} FS
+-9 9 8 0 2 503 2846 SP
+9 3 1 460 2900 SP
+6 5 1 525 2873 SP
+11 -2 1 484 2890 SP
+3 -6 1 523 2895 SP
+-9 9 8 0 2 503 2846 SP
+9 3 1 460 2900 SP
+6 5 1 525 2873 SP
+11 -2 1 484 2890 SP
+3 -6 1 523 2895 SP
+503 2846 M
+8 0 D
+-9 9 D
+P S
+460 2900 M
+9 3 D
+P S
+525 2873 M
+6 5 D
+P S
+484 2890 M
+11 -2 D
+P S
+523 2895 M
+3 -6 D
+P S
+{0.706 0.863 1 C} FS
+883 3252 M
+-14 -18 D
+-35 -28 D
+-38 -9 D
+-20 -35 D
+-22 -13 D
+-12 -41 D
+-27 -24 D
+5 5 D
+-34 -59 D
+-4 -26 D
+6 9 D
+19 -26 D
+-9 -23 D
+13 -44 D
+-14 -55 D
+-26 -26 D
+27 -24 D
+1 -14 D
+25 5 D
+-21 -8 D
+-10 6 D
+-1 -24 D
+14 1 D
+-15 -6 D
+21 -1 D
+-9 -7 D
+13 -3 D
+-2 -7 D
+27 7 D
+-15 -5 D
+13 -4 D
+-13 -9 D
+7 -9 D
+6 5 D
+-2 -7 D
+11 4 D
+6 -23 D
+13 -6 D
+-163 0 D
+0 542 D
+P
+FO
+1 0 -2 2 2 1146 2878 SP
+{0.784 A} FS
+-21 -6 15 16 2 694 3198 SP
+-17 -19 4 15 2 766 3204 SP
+-4 -7 -8 5 2 729 3198 SP
+-11 -11 0 7 2 781 3225 SP
+5 -9 1 658 3219 SP
+{0.706 0.863 1 C} FS
+24 -13 49 2 7 7 -8 -7 -48 -2 -43 40 6 800 2850 SP
+-3 12 -7 -2 9 -10 3 1029 2864 SP
+28 30 1 908 2754 SP
+16 9 1 1044 2875 SP
+15 -3 1 1116 2902 SP
+7 -15 1 0 2 1135 2899 SP
+-8 -10 9 10 2 894 2739 SP
+7 10 1 1033 2836 SP
+17 7 1 1027 2889 SP
+-8 -3 1 1068 2870 SP
+-3 -12 1 1047 2896 SP
+-4 -6 1 718 2882 SP
+-8 -5 1 735 2898 SP
+76 31 1 0 2 948 2794 SP
+51 12 0 1 2 1062 2888 SP
+{0.784 A} FS
+1146 2878 M
+-2 2 D
+1 0 D
+1 -2 D
+0 374 D
+-263 0 D
+-14 -18 D
+-35 -28 D
+-38 -9 D
+-20 -35 D
+-22 -13 D
+-12 -41 D
+-27 -24 D
+5 5 D
+-34 -59 D
+-4 -26 D
+6 9 D
+19 -26 D
+-9 -23 D
+13 -44 D
+-14 -55 D
+-26 -26 D
+27 -24 D
+1 -14 D
+25 5 D
+-21 -8 D
+-10 6 D
+-1 -24 D
+14 1 D
+-15 -6 D
+21 -1 D
+-9 -7 D
+13 -3 D
+-2 -7 D
+27 7 D
+-15 -5 D
+13 -4 D
+-13 -9 D
+7 -9 D
+6 5 D
+-2 -7 D
+11 4 D
+6 -23 D
+13 -6 D
+379 0 D
+P
+FO
+-21 -6 15 16 2 694 3198 SP
+-17 -19 4 15 2 766 3204 SP
+-4 -7 -8 5 2 729 3198 SP
+-11 -11 0 7 2 781 3225 SP
+5 -9 1 658 3219 SP
+{0.706 0.863 1 C} FS
+24 -13 49 2 7 7 -8 -7 -48 -2 -43 40 6 800 2850 SP
+-3 12 -7 -2 9 -10 3 1029 2864 SP
+28 30 1 908 2754 SP
+16 9 1 1044 2875 SP
+15 -3 1 1116 2902 SP
+7 -15 1 0 2 1135 2899 SP
+-8 -10 9 10 2 894 2739 SP
+7 10 1 1033 2836 SP
+17 7 1 1027 2889 SP
+-8 -3 1 1068 2870 SP
+-3 -12 1 1047 2896 SP
+-4 -6 1 718 2882 SP
+-8 -5 1 735 2898 SP
+76 31 1 0 2 948 2794 SP
+51 12 0 1 2 1062 2888 SP
+883 3252 M
+-14 -18 D
+-35 -28 D
+-38 -9 D
+-20 -35 D
+-22 -13 D
+-12 -41 D
+-27 -24 D
+5 5 D
+-34 -59 D
+-4 -26 D
+6 9 D
+19 -26 D
+-9 -23 D
+13 -44 D
+-14 -55 D
+-26 -26 D
+27 -24 D
+1 -14 D
+25 5 D
+-21 -8 D
+-10 6 D
+-1 -24 D
+14 1 D
+-15 -6 D
+21 -1 D
+-9 -7 D
+13 -3 D
+-2 -7 D
+27 7 D
+-15 -5 D
+13 -4 D
+-13 -9 D
+7 -9 D
+6 5 D
+-2 -7 D
+11 4 D
+6 -23 D
+13 -6 D
+S
+694 3198 M
+15 16 D
+-21 -6 D
+P S
+766 3204 M
+4 15 D
+-17 -19 D
+P S
+729 3198 M
+-8 5 D
+-4 -7 D
+P S
+781 3225 M
+0 7 D
+-11 -11 D
+P S
+658 3219 M
+5 -9 D
+P S
+800 2850 M
+-43 40 D
+-48 -2 D
+-8 -7 D
+7 7 D
+49 2 D
+24 -13 D
+P S
+1029 2864 M
+9 -10 D
+-7 -2 D
+-3 12 D
+P S
+908 2754 M
+28 30 D
+P S
+1044 2875 M
+16 9 D
+P S
+1116 2902 M
+15 -3 D
+P S
+1135 2899 M
+1 0 D
+7 -15 D
+P S
+1146 2878 M
+-2 2 D
+1 0 D
+P S
+894 2739 M
+9 10 D
+-8 -10 D
+P S
+1033 2836 M
+7 10 D
+P S
+1027 2889 M
+17 7 D
+P S
+1068 2870 M
+-8 -3 D
+P S
+1047 2896 M
+-3 -12 D
+P S
+718 2882 M
+-4 -6 D
+P S
+735 2898 M
+-8 -5 D
+P S
+948 2794 M
+77 31 D
+P S
+1062 2888 M
+0 1 D
+51 12 D
+P S
+1146 2591 M
+36 15 D
+68 13 D
+-12 -6 D
+28 -2 D
+17 -16 D
+8 6 D
+-7 -7 D
+12 -2 D
+-10 -2 D
+5 -5 D
+9 4 D
+-9 -10 D
+17 -23 D
+20 1 D
+0 7 D
+4 -7 D
+-2 9 D
+6 -8 D
+2 10 D
+7 -8 D
+25 2 D
+-1 11 D
+9 -12 D
+7 7 D
+11 -22 D
+14 4 D
+3 -8 D
+-8 1 D
+11 -20 D
+-17 -52 D
+10 -3 D
+-1 -17 D
+-10 2 D
+19 -9 D
+-13 -3 D
+-5 8 D
+-6 -29 D
+-11 1 D
+25 -47 D
+57 -55 D
+12 -35 D
+13 -8 D
+-10 -3 D
+30 -61 D
+-11 -19 D
+11 -25 D
+-363 0 D
+P
+FO
+-2 1 -1 10 -4 -77 5 32 2 -2 0 8 0 1 -4 7 4 13 9 1146 2623 SP
+-2 4 -1 -4 2 1271 2710 SP
+42 22 18 40 -12 -77 14 78 43 48 -2 23 -1 -25 -60 -58 1 -23 -24 -18 -19 -4 11 1688 2484 SP
+{0.784 A} FS
+6 7 2 -6 2 1321 2446 SP
+7 15 7 -4 2 1374 2530 SP
+{0.706 0.863 1 C} FS
+7 66 -8 -64 -61 -3 62 2 10 -23 5 1319 2674 SP
+9 -4 -7 -10 13 4 -4 26 4 1639 2366 SP
+40 -17 1 1271 2693 SP
+-9 9 1 1637 2412 SP
+-7 -2 1 1567 2325 SP
+7 -5 1 1491 2616 SP
+1 9 -8 -5 2 1424 2414 SP
+-7 5 1 1448 2338 SP
+-6 -2 1 1497 2280 SP
+{0.784 A} FS
+1688 2484 M
+-19 -4 D
+-24 -18 D
+1 -23 D
+-60 -58 D
+-1 -25 D
+-2 23 D
+43 48 D
+14 78 D
+-12 -77 D
+18 40 D
+42 22 D
+0 220 D
+-417 0 D
+-1 -4 D
+-2 4 D
+-122 0 D
+0 -58 D
+2 -2 D
+5 32 D
+-4 -77 D
+-1 10 D
+-2 1 D
+0 -25 D
+36 15 D
+68 13 D
+-12 -6 D
+28 -2 D
+17 -16 D
+8 6 D
+-7 -7 D
+12 -2 D
+-10 -2 D
+5 -5 D
+9 4 D
+-9 -10 D
+17 -23 D
+20 1 D
+0 7 D
+4 -7 D
+-2 9 D
+6 -8 D
+2 10 D
+7 -8 D
+25 2 D
+-1 11 D
+9 -12 D
+7 7 D
+11 -22 D
+14 4 D
+3 -8 D
+-8 1 D
+11 -20 D
+-17 -52 D
+10 -3 D
+-1 -17 D
+-10 2 D
+19 -9 D
+-13 -3 D
+-5 8 D
+-6 -29 D
+-11 1 D
+25 -47 D
+57 -55 D
+12 -35 D
+13 -8 D
+-10 -3 D
+30 -61 D
+-11 -19 D
+11 -25 D
+179 0 D
+P
+FO
+-4 7 4 13 2 1146 2623 SP
+6 7 2 -6 2 1321 2446 SP
+7 15 7 -4 2 1374 2530 SP
+{0.706 0.863 1 C} FS
+7 66 -8 -64 -61 -3 62 2 10 -23 5 1319 2674 SP
+9 -4 -7 -10 13 4 -4 26 4 1639 2366 SP
+40 -17 1 1271 2693 SP
+-9 9 1 1637 2412 SP
+-7 -2 1 1567 2325 SP
+7 -5 1 1491 2616 SP
+1 9 -8 -5 2 1424 2414 SP
+-7 5 1 1448 2338 SP
+-6 -2 1 1497 2280 SP
+1146 2591 M
+36 15 D
+68 13 D
+-12 -6 D
+28 -2 D
+17 -16 D
+8 6 D
+-7 -7 D
+12 -2 D
+-10 -2 D
+5 -5 D
+9 4 D
+-9 -10 D
+17 -23 D
+20 1 D
+0 7 D
+4 -7 D
+-2 9 D
+6 -8 D
+2 10 D
+7 -8 D
+25 2 D
+-1 11 D
+9 -12 D
+7 7 D
+11 -22 D
+14 4 D
+3 -8 D
+-8 1 D
+11 -20 D
+-17 -52 D
+10 -3 D
+-1 -17 D
+-10 2 D
+19 -9 D
+-13 -3 D
+-5 8 D
+-6 -29 D
+-11 1 D
+25 -47 D
+57 -55 D
+12 -35 D
+13 -8 D
+-10 -3 D
+30 -61 D
+-11 -19 D
+11 -25 D
+S
+1321 2446 M
+2 -6 D
+6 7 D
+P S
+1374 2530 M
+7 -4 D
+7 15 D
+P S
+1688 2484 M
+-19 -4 D
+-24 -18 D
+1 -23 D
+-60 -58 D
+-1 -25 D
+-2 23 D
+43 48 D
+14 78 D
+-12 -77 D
+18 40 D
+42 22 D
+S
+1146 2652 M
+2 -2 D
+5 32 D
+-4 -77 D
+-1 10 D
+-2 1 D
+S
+1319 2674 M
+10 -23 D
+62 2 D
+-61 -3 D
+-8 -64 D
+7 66 D
+P S
+1639 2366 M
+-4 26 D
+13 4 D
+-7 -10 D
+9 -4 D
+P S
+1146 2623 M
+4 13 D
+-4 7 D
+S
+1146 2644 M
+P S
+1271 2693 M
+40 -17 D
+P S
+1637 2412 M
+-9 9 D
+P S
+1567 2325 M
+-7 -2 D
+P S
+1491 2616 M
+7 -5 D
+P S
+1424 2414 M
+-8 -5 D
+1 9 D
+P S
+1448 2338 M
+-7 5 D
+P S
+1497 2280 M
+-6 -2 D
+P S
+1271 2710 M
+-1 -4 D
+-2 4 D
+S
+0 -187 22 43 11 37 -21 26 9 23 -6 -1 5 13 -12 46 8 2222 2168 SP
+0 -1 12 -13 3 6 1 0 -2 8 5 2067 2168 SP
+-65 -14 -59 40 57 -40 61 5 6 3 5 1688 2490 SP
+{0.784 A} FS
+9 -8 -3 -12 -2 7 3 2213 2277 SP
+9 8 1 2219 2224 SP
+{0.706 0.863 1 C} FS
+2003 2384 M
+11 54 D
+17 9 D
+9 -5 D
+10 11 D
+4 -9 D
+13 3 D
+8 -18 D
+12 8 D
+3 -6 D
+-21 -7 D
+-3 -26 D
+-20 -14 D
+17 -5 D
+-11 -9 D
+-14 4 D
+3 -13 D
+-7 -3 D
+2 13 D
+-17 7 D
+-11 -16 D
+P
+FO
+1 55 -26 32 -9 34 -19 6 17 -48 23 -20 -7 -11 18 -68 7 27 9 1933 2322 SP
+-11 -23 21 13 1 12 3 1913 2181 SP
+5 -8 -11 -4 25 6 3 2029 2478 SP
+-22 34 13 -61 2 2126 2565 SP
+7 12 -18 -11 2 1962 2208 SP
+8 -12 6 24 2 1928 2372 SP
+-5 -19 26 24 0 13 3 1973 2467 SP
+6 -1 1 0 2 2063 2485 SP
+0 6 1 2129 2386 SP
+4 -5 1 1959 2376 SP
+6 -7 1 2030 2218 SP
+-15 -13 11 0 2 1946 2435 SP
+-1 12 -16 3 2 2028 2219 SP
+-13 -16 1 2180 2618 SP
+-14 -13 15 12 2 2088 2337 SP
+1 13 1 2121 2369 SP
+20 7 1 2021 2484 SP
+-6 -6 1 1864 2209 SP
+3 10 1 2115 2337 SP
+-3 -6 1 2201 2658 SP
+-4 -7 1 2168 2601 SP
+8 0 1 1960 2440 SP
+7 4 1 2160 2414 SP
+{0.784 A} FS
+15 1 1 1710 2494 SP
+-2 8 1 2017 2425 SP
+-2 6 1 2049 2441 SP
+0 -7 1 2009 2379 SP
+2067 2168 M
+-2 8 D
+1 0 D
+3 6 D
+12 -14 D
+141 0 D
+-12 46 D
+5 13 D
+-6 -1 D
+9 23 D
+-21 26 D
+11 37 D
+22 43 D
+0 355 D
+-542 0 D
+0 -220 D
+6 3 D
+61 5 D
+57 -40 D
+-59 40 D
+-65 -14 D
+0 -316 D
+P
+FO
+9 -8 -3 -12 -2 7 3 2213 2277 SP
+9 8 1 2219 2224 SP
+{0.706 0.863 1 C} FS
+2003 2384 M
+11 54 D
+17 9 D
+9 -5 D
+10 11 D
+4 -9 D
+13 3 D
+8 -18 D
+12 8 D
+3 -6 D
+-21 -7 D
+-3 -26 D
+-20 -14 D
+17 -5 D
+-11 -9 D
+-14 4 D
+3 -13 D
+-7 -3 D
+2 13 D
+-17 7 D
+-11 -16 D
+P
+FO
+1 55 -26 32 -9 34 -19 6 17 -48 23 -20 -7 -11 18 -68 7 27 9 1933 2322 SP
+-11 -23 21 13 1 12 3 1913 2181 SP
+5 -8 -11 -4 25 6 3 2029 2478 SP
+-22 34 13 -61 2 2126 2565 SP
+7 12 -18 -11 2 1962 2208 SP
+8 -12 6 24 2 1928 2372 SP
+-5 -19 26 24 0 13 3 1973 2467 SP
+6 -1 1 0 2 2063 2485 SP
+0 6 1 2129 2386 SP
+4 -5 1 1959 2376 SP
+6 -7 1 2030 2218 SP
+-15 -13 11 0 2 1946 2435 SP
+-1 12 -16 3 2 2028 2219 SP
+-13 -16 1 2180 2618 SP
+-14 -13 15 12 2 2088 2337 SP
+1 13 1 2121 2369 SP
+20 7 1 2021 2484 SP
+-6 -6 1 1864 2209 SP
+3 10 1 2115 2337 SP
+-3 -6 1 2201 2658 SP
+-4 -7 1 2168 2601 SP
+8 0 1 1960 2440 SP
+7 4 1 2160 2414 SP
+{0.784 A} FS
+15 1 1 1710 2494 SP
+-2 8 1 2017 2425 SP
+-2 6 1 2049 2441 SP
+0 -7 1 2009 2379 SP
+2222 2168 M
+-12 46 D
+5 13 D
+-6 -1 D
+9 23 D
+-21 26 D
+11 37 D
+22 43 D
+S
+2213 2277 M
+-2 7 D
+-3 -12 D
+9 -8 D
+P S
+2219 2224 M
+9 8 D
+P S
+2003 2384 M
+11 54 D
+17 9 D
+9 -5 D
+10 11 D
+4 -9 D
+13 3 D
+8 -18 D
+12 8 D
+3 -6 D
+-21 -7 D
+-3 -26 D
+-20 -14 D
+17 -5 D
+-11 -9 D
+-14 4 D
+3 -13 D
+-7 -3 D
+2 13 D
+-17 7 D
+-11 -16 D
+P S
+1933 2322 M
+7 27 D
+18 -68 D
+-7 -11 D
+23 -20 D
+17 -48 D
+-19 6 D
+-9 34 D
+-26 32 D
+1 55 D
+P S
+1688 2490 M
+6 3 D
+61 5 D
+57 -40 D
+-59 40 D
+-65 -14 D
+S
+1913 2181 M
+1 12 D
+21 13 D
+-11 -23 D
+P S
+2029 2478 M
+25 6 D
+-11 -4 D
+5 -8 D
+P S
+2067 2168 M
+-2 8 D
+1 0 D
+3 6 D
+12 -14 D
+S
+2126 2565 M
+13 -61 D
+-22 34 D
+P S
+1962 2208 M
+-18 -11 D
+7 12 D
+P S
+1928 2372 M
+6 24 D
+8 -12 D
+P S
+1973 2467 M
+0 13 D
+26 24 D
+-5 -19 D
+P S
+2063 2485 M
+7 -1 D
+P S
+2129 2386 M
+0 6 D
+P S
+1959 2376 M
+4 -5 D
+P S
+2030 2218 M
+6 -7 D
+P S
+1946 2435 M
+11 0 D
+-15 -13 D
+P S
+2028 2219 M
+-16 3 D
+-1 12 D
+P S
+2180 2618 M
+-13 -16 D
+P S
+2088 2337 M
+15 12 D
+-14 -13 D
+P S
+2121 2369 M
+1 13 D
+P S
+2021 2484 M
+20 7 D
+P S
+1864 2209 M
+-6 -6 D
+P S
+2115 2337 M
+3 10 D
+P S
+2201 2658 M
+-3 -6 D
+P S
+2168 2601 M
+-4 -7 D
+P S
+1960 2440 M
+8 0 D
+P S
+2160 2414 M
+7 4 D
+P S
+1710 2494 M
+15 1 D
+P S
+2017 2425 M
+-2 8 D
+P S
+2049 2441 M
+-2 6 D
+P S
+2009 2379 M
+0 -7 D
+P S
+{0.706 0.863 1 C} FS
+-542 0 0 -542 247 0 1 15 78 134 53 56 66 46 61 73 15 -1 -6 9 22 13 5 10 12 2230 2355 SP
+{0.784 A} FS
+4 -4 1 2647 2313 SP
+9 0 1 2398 2184 SP
+-295 0 1 15 78 134 53 56 66 46 61 73 15 -1 -6 9 22 13 5 10 10 2230 2355 SP
+4 -4 1 2647 2313 SP
+9 0 1 2398 2184 SP
+2230 2355 M
+5 10 D
+22 13 D
+-6 9 D
+15 -1 D
+61 73 D
+66 46 D
+53 56 D
+78 134 D
+1 15 D
+S
+2647 2313 M
+4 -4 D
+P S
+2398 2184 M
+9 0 D
+P S
+{0.706 0.863 1 C} FS
+3212 2710 M
+9 -30 D
+26 -22 D
+15 8 D
+5 18 D
+25 7 D
+-8 5 D
+7 14 D
+23 0 D
+0 -6 D
+-2 0 D
+2 -2 D
+0 -13 D
+-5 -34 D
+-3 6 D
+8 -32 D
+0 -461 D
+-542 0 D
+0 542 D
+P
+FO
+{0.784 A} FS
+6 -4 1 3293 2691 SP
+8 -32 -3 6 -5 -34 3 3314 2689 SP
+2 -2 -2 0 2 3314 2704 SP
+7 14 -8 5 25 7 5 18 15 8 26 -22 9 -30 7 3212 2710 SP
+6 -4 1 3293 2691 SP
+3212 2710 M
+9 -30 D
+26 -22 D
+15 8 D
+5 18 D
+25 7 D
+-8 5 D
+7 14 D
+S
+3314 2689 M
+-5 -34 D
+-3 6 D
+8 -32 D
+S
+3293 2691 M
+6 -4 D
+P S
+3314 2704 M
+-2 0 D
+2 -2 D
+S
+{0.706 0.863 1 C} FS
+3314 2629 M
+7 -27 D
+29 5 D
+15 23 D
+-14 39 D
+-31 37 D
+-6 -2 D
+0 6 D
+507 0 D
+-11 -48 D
+10 5 D
+36 -46 D
+0 -103 D
+-6 7 D
+-44 25 D
+4 9 D
+-21 23 D
+-62 9 D
+8 -25 D
+36 -27 D
+24 -38 D
+29 -15 D
+9 -40 D
+23 -22 D
+0 -256 D
+-542 0 D
+P
+FO
+-2 -10 -9 3 11 -6 3 3314 2702 SP
+22 0 -1 20 -17 -1 -4 15 4 3856 2676 SP
+{0.784 A} FS
+-7 -4 -16 14 2 11 12 -10 4 3786 2466 SP
+22 -11 -9 -1 2 3748 2515 SP
+18 -15 -10 -6 2 3828 2412 SP
+4 -12 -8 5 2 3693 2629 SP
+9 -2 1 3816 2443 SP
+1 6 1 3680 2656 SP
+-6 5 6 -4 2 3778 2499 SP
+9 -7 1 3843 2381 SP
+1 -7 1 3810 2656 SP
+4 8 1 3810 2425 SP
+-8 3 8 -2 2 3846 2613 SP
+4 -10 1 3813 2439 SP
+{0.706 0.863 1 C} FS
+-8 15 -9 -2 2 3833 2504 SP
+{0.784 A} FS
+23 -22 9 -40 29 -15 24 -38 36 -27 8 -25 -62 9 -21 23 4 9 -44 25 -6 7 11 3856 2518 SP
+36 -46 10 5 -11 -48 -13 0 -1 20 -17 -1 -4 15 7 3856 2676 SP
+-6 -2 -31 37 -14 39 15 23 29 5 7 -27 0 -60 -2 -10 -9 3 11 -6 10 3314 2702 SP
+-7 -4 -16 14 2 11 12 -10 4 3786 2466 SP
+22 -11 -9 -1 2 3748 2515 SP
+18 -15 -10 -6 2 3828 2412 SP
+4 -12 -8 5 2 3693 2629 SP
+9 -2 1 3816 2443 SP
+1 6 1 3680 2656 SP
+-6 5 6 -4 2 3778 2499 SP
+9 -7 1 3843 2381 SP
+1 -7 1 3810 2656 SP
+4 8 1 3810 2425 SP
+-8 3 8 -2 2 3846 2613 SP
+4 -10 1 3813 2439 SP
+{0.706 0.863 1 C} FS
+-8 15 -9 -2 2 3833 2504 SP
+3856 2518 M
+-6 7 D
+-44 25 D
+4 9 D
+-21 23 D
+-62 9 D
+8 -25 D
+36 -27 D
+24 -38 D
+29 -15 D
+9 -40 D
+23 -22 D
+S
+3314 2629 M
+7 -27 D
+29 5 D
+15 23 D
+-14 39 D
+-31 37 D
+-6 -2 D
+S
+3786 2466 M
+12 -10 D
+2 11 D
+-16 14 D
+-7 -4 D
+P S
+3748 2515 M
+-9 -1 D
+22 -11 D
+P S
+3828 2412 M
+-10 -6 D
+18 -15 D
+P S
+3693 2629 M
+-8 5 D
+4 -12 D
+P S
+3314 2702 M
+11 -6 D
+-9 3 D
+-2 -10 D
+S
+3816 2443 M
+9 -2 D
+P S
+3680 2656 M
+1 6 D
+P S
+3778 2499 M
+6 -4 D
+-6 5 D
+P S
+3843 2381 M
+9 -7 D
+P S
+3810 2656 M
+1 -7 D
+P S
+3810 2425 M
+4 8 D
+P S
+3846 2613 M
+8 -2 D
+-8 3 D
+P S
+3813 2439 M
+4 -10 D
+P S
+3856 2676 M
+-4 15 D
+-17 -1 D
+-1 20 D
+S
+3821 2710 M
+-11 -48 D
+10 5 D
+36 -46 D
+S
+3817 2710 M
+0 0 D
+P S
+3833 2504 M
+-9 -2 D
+-8 15 D
+P S
+3856 2424 M
+9 -8 D
+34 -64 D
+66 -57 D
+15 -17 D
+-1 12 D
+17 -8 D
+3 10 D
+12 -13 D
+10 73 D
+-12 22 D
+-21 3 D
+-4 -8 D
+4 14 D
+-10 2 D
+-3 27 D
+-30 8 D
+12 27 D
+-11 7 D
+-17 -9 D
+11 7 D
+-5 7 D
+-13 2 D
+-37 41 D
+-3 -14 D
+-26 30 D
+0 103 D
+3 -4 D
+12 -61 D
+20 -40 D
+60 -42 D
+12 10 D
+9 -8 D
+-22 40 D
+0 46 D
+-8 22 D
+-43 41 D
+-31 8 D
+-12 43 D
+0 34 D
+138 0 D
+-8 -32 D
+13 -2 D
+25 17 D
+-10 17 D
+18 -12 D
+-6 12 D
+3 0 D
+7 -5 D
+-4 5 D
+333 0 D
+-43 -45 D
+22 15 D
+20 28 D
+4 2 D
+30 0 D
+0 -129 D
+-5 -5 D
+5 3 D
+0 -125 D
+-4 -17 D
+-6 2 D
+7 -23 D
+-4 6 D
+-11 -14 D
+1 -20 D
+-17 -24 D
+5 -22 D
+16 1 D
+-2 -56 D
+15 0 D
+0 -80 D
+-5 -5 D
+5 0 D
+0 -15 D
+-1 1 D
+-27 -7 D
+26 -13 D
+-540 0 D
+P
+FO
+{0.784 A} FS
+4263 2330 M
+34 24 D
+-4 8 D
+5 -3 D
+8 21 D
+-12 10 D
+15 20 D
+5 -5 D
+20 13 D
+-4 24 D
+15 19 D
+-4 9 D
+13 -9 D
+17 5 D
+-31 24 D
+-3 9 D
+10 3 D
+-30 35 D
+21 1 D
+-11 14 D
+32 5 D
+-12 15 D
+31 12 D
+-24 13 D
+-12 -4 D
+2 11 D
+-12 -5 D
+5 14 D
+-16 16 D
+-9 -12 D
+-2 13 D
+-24 -40 D
+-13 -4 D
+6 -5 D
+-6 -9 D
+-38 -8 D
+-25 -39 D
+-44 -12 D
+-7 -37 D
+-35 9 D
+-6 11 D
+-20 -25 D
+0 -23 D
+10 -9 D
+-5 -14 D
+13 -6 D
+-9 2 D
+11 -9 D
+-6 -8 D
+14 5 D
+8 -50 D
+39 4 D
+6 -21 D
+30 18 D
+16 -6 D
+1 -9 D
+24 3 D
+2 -22 D
+P
+FO
+50 -16 27 4 39 -10 -3 -11 36 -6 -16 -7 -7 -17 -61 10 -17 16 -40 3 -17 -14 -41 11 -17 25 -35 1 -4 26 16 -4 16 4236 2206 SP
+5 -18 17 -2 -6 -12 -19 -1 -7 22 -15 5 4 11 7 4038 2358 SP
+-10 -7 -32 7 16 -11 -6 -4 -35 14 60 13 6 4317 2193 SP
+-10 -4 0 12 4 -5 3 3977 2466 SP
+5 -10 -7 -6 -4 6 3 4083 2548 SP
+17 -5 -3 -7 -7 4 3 3931 2466 SP
+16 13 16 -20 -13 1 3 4263 2218 SP
+-2 -18 -16 5 7 14 3 4073 2351 SP
+7 -15 -7 5 2 3868 2358 SP
+-12 3 4 15 15 -4 3 4290 2202 SP
+16 7 21 -6 2 4202 2249 SP
+1 -6 -9 2 2 3904 2493 SP
+-8 5 6 7 2 3918 2466 SP
+-2 -6 -14 8 2 3992 2431 SP
+14 4 -8 -4 2 3992 2676 SP
+1 -7 1 4383 2572 SP
+7 0 1 4353 2565 SP
+6 -6 1 3978 2446 SP
+7 21 1 4291 2331 SP
+5 -6 1 4021 2704 SP
+10 0 1 3971 2426 SP
+-10 -1 1 3965 2476 SP
+7 2 1 4271 2249 SP
+6 4 1 4318 2634 SP
+-9 0 9 1 2 3950 2429 SP
+4 5 1 3964 2466 SP
+8 -5 1 3913 2295 SP
+12 -1 1 4322 2535 SP
+6 5 1 4330 2213 SP
+2 7 1 4317 2651 SP
+3 -6 1 3861 2588 SP
+5 4 1 4388 2202 SP
+{0.706 0.863 1 C} FS
+7 2 1 4298 2431 SP
+-3 -7 1 4192 2369 SP
+{0.784 A} FS
+2 0 26 -13 -27 -7 -1 1 4 4398 2187 SP
+5 0 -5 -5 2 4398 2207 SP
+15 0 -1 -17 -1 -39 16 1 5 -22 -17 -24 1 -20 -11 -14 -4 6 7 -23 -6 2 -4 -17 12 4398 2454 SP
+5 3 -5 -5 2 4398 2581 SP
+4 2 20 28 22 15 -43 -45 4 4365 2710 SP
+-4 5 7 -5 2 4029 2710 SP
+-6 12 18 -12 -10 17 25 17 13 -2 -8 -32 6 3994 2710 SP
+-12 43 -31 8 -43 41 -8 22 0 46 -22 40 9 -8 12 10 60 -42 20 -40 12 -61 3 -4 12 3856 2621 SP
+3856 2424 M
+9 -8 D
+34 -64 D
+66 -57 D
+15 -17 D
+-1 12 D
+17 -8 D
+3 10 D
+12 -13 D
+10 73 D
+-12 22 D
+-21 3 D
+-4 -8 D
+4 14 D
+-10 2 D
+-3 27 D
+-30 8 D
+12 27 D
+-11 7 D
+-17 -9 D
+11 7 D
+-5 7 D
+-13 2 D
+-37 41 D
+-3 -14 D
+-26 30 D
+P
+FO
+4263 2330 M
+34 24 D
+-4 8 D
+5 -3 D
+8 21 D
+-12 10 D
+15 20 D
+5 -5 D
+20 13 D
+-4 24 D
+15 19 D
+-4 9 D
+13 -9 D
+17 5 D
+-31 24 D
+-3 9 D
+10 3 D
+-30 35 D
+21 1 D
+-11 14 D
+32 5 D
+-12 15 D
+31 12 D
+-24 13 D
+-12 -4 D
+2 11 D
+-12 -5 D
+5 14 D
+-16 16 D
+-9 -12 D
+-2 13 D
+-24 -40 D
+-13 -4 D
+6 -5 D
+-6 -9 D
+-38 -8 D
+-25 -39 D
+-44 -12 D
+-7 -37 D
+-35 9 D
+-6 11 D
+-20 -25 D
+0 -23 D
+10 -9 D
+-5 -14 D
+13 -6 D
+-9 2 D
+11 -9 D
+-6 -8 D
+14 5 D
+8 -50 D
+39 4 D
+6 -21 D
+30 18 D
+16 -6 D
+1 -9 D
+24 3 D
+2 -22 D
+P
+FO
+50 -16 27 4 39 -10 -3 -11 36 -6 -16 -7 -7 -17 -61 10 -17 16 -40 3 -17 -14 -41 11 -17 25 -35 1 -4 26 16 -4 16 4236 2206 SP
+5 -18 17 -2 -6 -12 -19 -1 -7 22 -15 5 4 11 7 4038 2358 SP
+-10 -7 -32 7 16 -11 -6 -4 -35 14 60 13 6 4317 2193 SP
+-10 -4 0 12 4 -5 3 3977 2466 SP
+5 -10 -7 -6 -4 6 3 4083 2548 SP
+17 -5 -3 -7 -7 4 3 3931 2466 SP
+16 13 16 -20 -13 1 3 4263 2218 SP
+-2 -18 -16 5 7 14 3 4073 2351 SP
+7 -15 -7 5 2 3868 2358 SP
+-12 3 4 15 15 -4 3 4290 2202 SP
+16 7 21 -6 2 4202 2249 SP
+1 -6 -9 2 2 3904 2493 SP
+-8 5 6 7 2 3918 2466 SP
+-2 -6 -14 8 2 3992 2431 SP
+14 4 -8 -4 2 3992 2676 SP
+1 -7 1 4383 2572 SP
+7 0 1 4353 2565 SP
+6 -6 1 3978 2446 SP
+7 21 1 4291 2331 SP
+5 -6 1 4021 2704 SP
+10 0 1 3971 2426 SP
+-10 -1 1 3965 2476 SP
+7 2 1 4271 2249 SP
+6 4 1 4318 2634 SP
+-9 0 9 1 2 3950 2429 SP
+4 5 1 3964 2466 SP
+8 -5 1 3913 2295 SP
+12 -1 1 4322 2535 SP
+6 5 1 4330 2213 SP
+2 7 1 4317 2651 SP
+3 -6 1 3861 2588 SP
+5 4 1 4388 2202 SP
+{0.706 0.863 1 C} FS
+7 2 1 4298 2431 SP
+-3 -7 1 4192 2369 SP
+4263 2330 M
+34 24 D
+-4 8 D
+5 -3 D
+8 21 D
+-12 10 D
+15 20 D
+5 -5 D
+20 13 D
+-4 24 D
+15 19 D
+-4 9 D
+13 -9 D
+17 5 D
+-31 24 D
+-3 9 D
+10 3 D
+-30 35 D
+21 1 D
+-11 14 D
+32 5 D
+-12 15 D
+31 12 D
+-24 13 D
+-12 -4 D
+2 11 D
+-12 -5 D
+5 14 D
+-16 16 D
+-9 -12 D
+-2 13 D
+-24 -40 D
+-13 -4 D
+6 -5 D
+-6 -9 D
+-38 -8 D
+-25 -39 D
+-44 -12 D
+-7 -37 D
+-35 9 D
+-6 11 D
+-20 -25 D
+0 -23 D
+10 -9 D
+-5 -14 D
+13 -6 D
+-9 2 D
+11 -9 D
+-6 -8 D
+14 5 D
+8 -50 D
+39 4 D
+6 -21 D
+30 18 D
+16 -6 D
+1 -9 D
+24 3 D
+2 -22 D
+P S
+3856 2424 M
+9 -8 D
+34 -64 D
+66 -57 D
+15 -17 D
+-1 12 D
+17 -8 D
+3 10 D
+12 -13 D
+10 73 D
+-12 22 D
+-21 3 D
+-4 -8 D
+4 14 D
+-10 2 D
+-3 27 D
+-30 8 D
+12 27 D
+-11 7 D
+-17 -9 D
+11 7 D
+-5 7 D
+-13 2 D
+-37 41 D
+-3 -14 D
+-26 30 D
+S
+4236 2206 M
+16 -4 D
+-4 26 D
+-35 1 D
+-17 25 D
+-41 11 D
+-17 -14 D
+-40 3 D
+-17 16 D
+-61 10 D
+-7 -17 D
+-16 -7 D
+36 -6 D
+-3 -11 D
+39 -10 D
+27 4 D
+50 -16 D
+P S
+4398 2454 M
+-4 -17 D
+-6 2 D
+7 -23 D
+-4 6 D
+-11 -14 D
+1 -20 D
+-17 -24 D
+5 -22 D
+16 1 D
+-2 -56 D
+15 0 D
+S
+3856 2621 M
+3 -4 D
+12 -61 D
+20 -40 D
+60 -42 D
+12 10 D
+9 -8 D
+-22 40 D
+0 46 D
+-8 22 D
+-43 41 D
+-31 8 D
+-12 43 D
+S
+4038 2358 M
+4 11 D
+-15 5 D
+-7 22 D
+-19 -1 D
+-6 -12 D
+17 -2 D
+5 -18 D
+P S
+4317 2193 M
+60 13 D
+-35 14 D
+-6 -4 D
+16 -11 D
+-32 7 D
+-10 -7 D
+P S
+3994 2710 M
+-8 -32 D
+13 -2 D
+25 17 D
+-10 17 D
+18 -12 D
+-6 12 D
+S
+3977 2466 M
+4 -5 D
+0 12 D
+-10 -4 D
+P S
+4083 2548 M
+-4 6 D
+-7 -6 D
+5 -10 D
+P S
+4365 2710 M
+-43 -45 D
+22 15 D
+20 28 D
+4 2 D
+S
+3931 2466 M
+-7 4 D
+-3 -7 D
+17 -5 D
+P S
+4263 2218 M
+-13 1 D
+16 -20 D
+16 13 D
+P S
+4073 2351 M
+7 14 D
+-16 5 D
+-2 -18 D
+P S
+3868 2358 M
+-7 5 D
+7 -15 D
+P S
+4290 2202 M
+15 -4 D
+4 15 D
+-12 3 D
+P S
+4202 2249 M
+21 -6 D
+16 7 D
+P S
+3904 2493 M
+-9 2 D
+1 -6 D
+P S
+3918 2466 M
+6 7 D
+-8 5 D
+P S
+3992 2431 M
+-14 8 D
+-2 -6 D
+P S
+3992 2676 M
+-8 -4 D
+14 4 D
+P S
+4383 2572 M
+1 -7 D
+P S
+4353 2565 M
+7 0 D
+P S
+3978 2446 M
+6 -6 D
+P S
+4291 2331 M
+7 21 D
+P S
+4398 2187 M
+-1 1 D
+-27 -7 D
+26 -13 D
+S
+4021 2704 M
+5 -6 D
+P S
+3971 2426 M
+10 0 D
+P S
+3965 2476 M
+-10 -1 D
+P S
+4271 2249 M
+7 2 D
+P S
+4318 2634 M
+6 4 D
+P S
+3950 2429 M
+9 1 D
+-9 0 D
+P S
+3964 2466 M
+4 5 D
+P S
+3913 2295 M
+8 -5 D
+P S
+4322 2535 M
+12 -1 D
+P S
+4330 2213 M
+6 5 D
+P S
+4317 2651 M
+2 7 D
+P S
+3861 2588 M
+3 -6 D
+P S
+4388 2202 M
+5 4 D
+P S
+4029 2710 M
+7 -5 D
+-4 5 D
+S
+4398 2207 M
+-5 -5 D
+5 0 D
+S
+4398 2581 M
+-5 -5 D
+5 3 D
+S
+4298 2431 M
+7 2 D
+P S
+4192 2369 M
+-3 -7 D
+P S
+4520 2168 M
+76 44 D
+-59 -7 D
+-39 -27 D
+-3 -10 D
+-75 0 D
+-22 19 D
+0 15 D
+45 -4 D
+37 15 D
+-4 8 D
+-12 -13 D
+-25 -3 D
+-29 11 D
+-12 -9 D
+0 80 D
+13 0 D
+-8 72 D
+16 9 D
+9 -2 D
+-5 -23 D
+19 -14 D
+-2 -19 D
+13 -4 D
+2 11 D
+21 3 D
+-18 22 D
+8 11 D
+-33 36 D
+10 -3 D
+49 32 D
+-50 0 D
+-14 -18 D
+-11 1 D
+-17 21 D
+7 29 D
+108 -1 D
+23 35 D
+-33 -23 D
+-82 14 D
+-9 -16 D
+-8 6 D
+-7 -7 D
+-1 -5 D
+0 125 D
+7 3 D
+-7 -1 D
+0 129 D
+73 0 D
+-8 -4 D
+17 -22 D
+8 7 D
+-3 19 D
+9 0 D
+-6 -16 D
+8 16 D
+10 0 D
+-5 -5 D
+6 -5 D
+0 -1 D
+15 4 D
+0 7 D
+40 0 D
+-1 -6 D
+1 6 D
+378 0 D
+0 -331 D
+-57 21 D
+-21 -9 D
+2 -9 D
+-21 -3 D
+-17 -24 D
+-18 -7 D
+-13 24 D
+-5 -10 D
+-8 13 D
+-5 45 D
+-42 10 D
+-33 -13 D
+-7 -17 D
+28 -1 D
+9 -22 D
+44 6 D
+-7 -18 D
+-12 9 D
+-14 -11 D
+-21 1 D
+24 -14 D
+2 -22 D
+15 6 D
+10 26 D
+-6 -15 D
+10 -11 D
+26 -1 D
+-9 -5 D
+16 -10 D
+79 -25 D
+-1 -9 D
+8 2 D
+1 -18 D
+14 -14 D
+-10 -3 D
+19 -5 D
+-16 -2 D
+13 -10 D
+-5 -19 D
+28 7 D
+0 -54 D
+P
+FO
+{0.784 A} FS
+4534 2598 M
+7 6 D
+3 -14 D
+8 11 D
+-8 21 D
+9 15 D
+13 -28 D
+-1 17 D
+12 11 D
+-5 33 D
+-9 3 D
+4 18 D
+-21 15 D
+2 -24 D
+-20 1 D
+-1 -13 D
+-10 2 D
+-19 -17 D
+4 13 D
+-12 8 D
+-31 -21 D
+-9 -23 D
+7 -6 D
+12 24 D
+22 -11 D
+7 12 D
+16 -12 D
+-6 -27 D
+P
+FO
+21 -19 7 -35 -15 -32 -2 25 11 11 -30 -18 1 14 14 7 -20 16 27 -7 -2 21 11 4615 2431 SP
+-35 5 -14 24 25 -14 40 3 7 -10 7 13 -2 -13 7 4615 2356 SP
+-15 -23 -25 1 4 13 26 9 4 4886 2212 SP
+9 -1 -3 -18 -10 -2 1 9 4 4472 2304 SP
+-11 -8 -4 22 15 19 -3 -26 4 4786 2277 SP
+4 22 -8 3 16 11 -4 -19 4 4474 2304 SP
+-7 -4 -9 13 11 1 5 -9 4 4596 2426 SP
+-5 -8 -15 1 2 5 3 4534 2213 SP
+21 -1 -7 -8 -10 5 3 4615 2398 SP
+-13 14 16 7 18 -15 3 4561 2350 SP
+-29 -2 8 5 2 4696 2430 SP
+-24 3 28 7 2 4556 2222 SP
+-27 13 10 1 2 4832 2408 SP
+-18 3 15 6 2 4480 2398 SP
+-40 5 24 1 2 4832 2390 SP
+0 15 9 3 2 4622 2493 SP
+-17 -6 2 9 2 4677 2385 SP
+-10 -1 1 10 2 4696 2404 SP
+10 6 -1 -9 2 4452 2622 SP
+27 1 -18 -2 2 4561 2391 SP
+4 9 4 -5 2 4507 2213 SP
+-2 -6 1 20 1 -13 3 4410 2276 SP
+4 -14 -3 8 2 4561 2378 SP
+-4 5 4 -4 2 4459 2433 SP
+9 3 1 4615 2341 SP
+7 -6 1 4651 2439 SP
+20 8 1 4485 2208 SP
+-7 0 7 1 2 4807 2398 SP
+-1 -9 1 4452 2299 SP
+10 0 1 4902 2213 SP
+-6 5 1 4664 2222 SP
+9 19 1 4746 2277 SP
+7 -8 1 4544 2539 SP
+10 4 -9 -4 2 4452 2428 SP
+-9 -3 9 4 2 4480 2211 SP
+5 4 1 4591 2428 SP
+14 4 1 4680 2414 SP
+4 -9 1 4740 2287 SP
+5 8 1 4790 2641 SP
+-6 4 1 4615 2215 SP
+7 -1 1 4492 2688 SP
+7 -1 1 4716 2245 SP
+6 2 1 4682 2425 SP
+-7 1 7 0 2 4600 2405 SP
+8 -6 1 4759 2328 SP
+-21 4 25 6 2 4517 2385 SP
+7 0 1 4662 2407 SP
+16 24 1 4700 2222 SP
+{0.706 0.863 1 C} FS
+-8 -6 6 -1 2 4438 2367 SP
+-6 3 5 -3 2 4433 2374 SP
+1 -8 1 4415 2391 SP
+{0.784 A} FS
+0 -19 -22 19 2 4420 2168 SP
+-3 -10 -39 -27 -59 -7 76 44 4 4520 2168 SP
+4940 2379 M
+-57 21 D
+-21 -9 D
+2 -9 D
+-21 -3 D
+-17 -24 D
+-18 -7 D
+-13 24 D
+-5 -10 D
+-8 13 D
+-5 45 D
+-42 10 D
+-33 -13 D
+-7 -17 D
+28 -1 D
+9 -22 D
+44 6 D
+-7 -18 D
+-12 9 D
+-14 -11 D
+-21 1 D
+24 -14 D
+2 -22 D
+15 6 D
+10 26 D
+-6 -15 D
+10 -11 D
+26 -1 D
+-9 -5 D
+16 -10 D
+79 -25 D
+-1 -9 D
+8 2 D
+1 -18 D
+14 -14 D
+-10 -3 D
+19 -5 D
+-16 -2 D
+13 -10 D
+-5 -19 D
+28 7 D
+P
+FO
+-1 -6 1 4562 2710 SP
+0 7 15 4 0 -1 6 -5 -5 -5 5 4506 2710 SP
+8 16 -6 -16 2 4494 2710 SP
+-3 19 8 7 17 -22 -8 -4 4 4471 2710 SP
+-7 -1 7 3 2 4398 2579 SP
+4398 2287 M
+13 0 D
+-8 72 D
+16 9 D
+9 -2 D
+-5 -23 D
+19 -14 D
+-2 -19 D
+13 -4 D
+2 11 D
+21 3 D
+-18 22 D
+8 11 D
+-33 36 D
+10 -3 D
+49 32 D
+-50 0 D
+-14 -18 D
+-11 1 D
+-17 21 D
+7 29 D
+108 -1 D
+23 35 D
+-33 -23 D
+-82 14 D
+-9 -16 D
+-8 6 D
+-7 -7 D
+P
+FO
+-12 -9 -29 11 -25 -3 -12 -13 -4 8 37 15 45 -4 7 4398 2202 SP
+4534 2598 M
+7 6 D
+3 -14 D
+8 11 D
+-8 21 D
+9 15 D
+13 -28 D
+-1 17 D
+12 11 D
+-5 33 D
+-9 3 D
+4 18 D
+-21 15 D
+2 -24 D
+-20 1 D
+-1 -13 D
+-10 2 D
+-19 -17 D
+4 13 D
+-12 8 D
+-31 -21 D
+-9 -23 D
+7 -6 D
+12 24 D
+22 -11 D
+7 12 D
+16 -12 D
+-6 -27 D
+P
+FO
+21 -19 7 -35 -15 -32 -2 25 11 11 -30 -18 1 14 14 7 -20 16 27 -7 -2 21 11 4615 2431 SP
+-35 5 -14 24 25 -14 40 3 7 -10 7 13 -2 -13 7 4615 2356 SP
+-15 -23 -25 1 4 13 26 9 4 4886 2212 SP
+9 -1 -3 -18 -10 -2 1 9 4 4472 2304 SP
+-11 -8 -4 22 15 19 -3 -26 4 4786 2277 SP
+4 22 -8 3 16 11 -4 -19 4 4474 2304 SP
+-7 -4 -9 13 11 1 5 -9 4 4596 2426 SP
+-5 -8 -15 1 2 5 3 4534 2213 SP
+21 -1 -7 -8 -10 5 3 4615 2398 SP
+-13 14 16 7 18 -15 3 4561 2350 SP
+-29 -2 8 5 2 4696 2430 SP
+-24 3 28 7 2 4556 2222 SP
+-27 13 10 1 2 4832 2408 SP
+-18 3 15 6 2 4480 2398 SP
+-40 5 24 1 2 4832 2390 SP
+0 15 9 3 2 4622 2493 SP
+-17 -6 2 9 2 4677 2385 SP
+-10 -1 1 10 2 4696 2404 SP
+10 6 -1 -9 2 4452 2622 SP
+27 1 -18 -2 2 4561 2391 SP
+4 9 4 -5 2 4507 2213 SP
+-2 -6 1 20 1 -13 3 4410 2276 SP
+4 -14 -3 8 2 4561 2378 SP
+-4 5 4 -4 2 4459 2433 SP
+9 3 1 4615 2341 SP
+7 -6 1 4651 2439 SP
+20 8 1 4485 2208 SP
+-7 0 7 1 2 4807 2398 SP
+-1 -9 1 4452 2299 SP
+10 0 1 4902 2213 SP
+-6 5 1 4664 2222 SP
+9 19 1 4746 2277 SP
+7 -8 1 4544 2539 SP
+10 4 -9 -4 2 4452 2428 SP
+-9 -3 9 4 2 4480 2211 SP
+5 4 1 4591 2428 SP
+14 4 1 4680 2414 SP
+4 -9 1 4740 2287 SP
+5 8 1 4790 2641 SP
+-6 4 1 4615 2215 SP
+7 -1 1 4492 2688 SP
+7 -1 1 4716 2245 SP
+6 2 1 4682 2425 SP
+-7 1 7 0 2 4600 2405 SP
+8 -6 1 4759 2328 SP
+-21 4 25 6 2 4517 2385 SP
+7 0 1 4662 2407 SP
+16 24 1 4700 2222 SP
+{0.706 0.863 1 C} FS
+-8 -6 6 -1 2 4438 2367 SP
+-6 3 5 -3 2 4433 2374 SP
+1 -8 1 4415 2391 SP
+4940 2379 M
+-57 21 D
+-21 -9 D
+2 -9 D
+-21 -3 D
+-17 -24 D
+-18 -7 D
+-13 24 D
+-5 -10 D
+-8 13 D
+-5 45 D
+-42 10 D
+-33 -13 D
+-7 -17 D
+28 -1 D
+9 -22 D
+44 6 D
+-7 -18 D
+-12 9 D
+-14 -11 D
+-21 1 D
+24 -14 D
+2 -22 D
+15 6 D
+10 26 D
+-6 -15 D
+10 -11 D
+26 -1 D
+-9 -5 D
+16 -10 D
+79 -25 D
+-1 -9 D
+8 2 D
+1 -18 D
+14 -14 D
+-10 -3 D
+19 -5 D
+-16 -2 D
+13 -10 D
+-5 -19 D
+28 7 D
+S
+4534 2598 M
+7 6 D
+3 -14 D
+8 11 D
+-8 21 D
+9 15 D
+13 -28 D
+-1 17 D
+12 11 D
+-5 33 D
+-9 3 D
+4 18 D
+-21 15 D
+2 -24 D
+-20 1 D
+-1 -13 D
+-10 2 D
+-19 -17 D
+4 13 D
+-12 8 D
+-31 -21 D
+-9 -23 D
+7 -6 D
+12 24 D
+22 -11 D
+7 12 D
+16 -12 D
+-6 -27 D
+P S
+4398 2287 M
+13 0 D
+-8 72 D
+16 9 D
+9 -2 D
+-5 -23 D
+19 -14 D
+-2 -19 D
+13 -4 D
+2 11 D
+21 3 D
+-18 22 D
+8 11 D
+-33 36 D
+10 -3 D
+49 32 D
+-50 0 D
+-14 -18 D
+-11 1 D
+-17 21 D
+7 29 D
+108 -1 D
+23 35 D
+-33 -23 D
+-82 14 D
+-9 -16 D
+-8 6 D
+-7 -7 D
+-1 -5 D
+S
+4615 2431 M
+-2 21 D
+27 -7 D
+-20 16 D
+14 7 D
+1 14 D
+-30 -18 D
+11 11 D
+-2 25 D
+-15 -32 D
+7 -35 D
+21 -19 D
+P S
+4615 2356 M
+-2 -13 D
+7 13 D
+7 -10 D
+40 3 D
+25 -14 D
+-14 24 D
+-35 5 D
+P S
+4398 2202 M
+45 -4 D
+37 15 D
+-4 8 D
+-12 -13 D
+-25 -3 D
+-29 11 D
+-12 -9 D
+S
+4886 2212 M
+26 9 D
+4 13 D
+-25 1 D
+-15 -23 D
+P S
+4472 2304 M
+1 9 D
+-10 -2 D
+-3 -18 D
+9 -1 D
+P S
+4471 2710 M
+-8 -4 D
+17 -22 D
+8 7 D
+-3 19 D
+S
+4786 2277 M
+-3 -26 D
+15 19 D
+-4 22 D
+-11 -8 D
+P S
+4474 2304 M
+-4 -19 D
+16 11 D
+-8 3 D
+4 22 D
+P S
+4506 2710 M
+-5 -5 D
+6 -5 D
+0 -1 D
+15 4 D
+0 7 D
+S
+4596 2426 M
+5 -9 D
+11 1 D
+-9 13 D
+-7 -4 D
+P S
+4534 2213 M
+2 5 D
+-15 1 D
+-5 -8 D
+P S
+4615 2398 M
+-10 5 D
+-7 -8 D
+21 -1 D
+P S
+4561 2350 M
+18 -15 D
+16 7 D
+-13 14 D
+P S
+4398 2579 M
+7 3 D
+-7 -1 D
+S
+4520 2168 M
+76 44 D
+-59 -7 D
+-39 -27 D
+-3 -10 D
+S
+4494 2710 M
+-6 -16 D
+8 16 D
+S
+4696 2430 M
+8 5 D
+-29 -2 D
+P S
+4556 2222 M
+28 7 D
+-24 3 D
+P S
+4832 2408 M
+10 1 D
+-27 13 D
+P S
+4480 2398 M
+15 6 D
+-18 3 D
+P S
+4832 2390 M
+24 1 D
+-40 5 D
+P S
+4622 2493 M
+9 3 D
+0 15 D
+P S
+4677 2385 M
+2 9 D
+-17 -6 D
+P S
+4696 2404 M
+1 10 D
+-10 -1 D
+P S
+4452 2622 M
+-1 -9 D
+10 6 D
+P S
+4561 2391 M
+-18 -2 D
+27 1 D
+P S
+4507 2213 M
+4 -5 D
+4 9 D
+P S
+4410 2276 M
+1 -13 D
+1 20 D
+P S
+4561 2378 M
+-3 8 D
+4 -14 D
+P S
+4459 2433 M
+4 -4 D
+-4 5 D
+P S
+4552 2710 M
+P S
+4615 2341 M
+9 3 D
+P S
+4651 2439 M
+7 -6 D
+P S
+4485 2208 M
+20 8 D
+P S
+4807 2398 M
+7 1 D
+-7 0 D
+P S
+4452 2299 M
+-1 -9 D
+P S
+4902 2213 M
+10 0 D
+P S
+4664 2222 M
+-6 5 D
+P S
+4746 2277 M
+9 19 D
+P S
+4544 2539 M
+7 -8 D
+P S
+4452 2428 M
+-9 -4 D
+10 4 D
+P S
+4480 2211 M
+9 4 D
+-9 -3 D
+P S
+4591 2428 M
+5 4 D
+P S
+4680 2414 M
+14 4 D
+P S
+4562 2710 M
+-1 -6 D
+P S
+4740 2287 M
+4 -9 D
+P S
+4790 2641 M
+5 8 D
+P S
+4615 2215 M
+-6 4 D
+P S
+4492 2688 M
+7 -1 D
+P S
+4716 2245 M
+7 -1 D
+P S
+4682 2425 M
+6 2 D
+P S
+4600 2405 M
+7 0 D
+-7 1 D
+P S
+4759 2328 M
+8 -6 D
+P S
+4517 2385 M
+25 6 D
+-21 4 D
+P S
+4662 2407 M
+7 0 D
+P S
+4700 2222 M
+16 24 D
+P S
+4420 2168 M
+-22 19 D
+S
+4438 2367 M
+6 -1 D
+-8 -6 D
+P S
+4433 2374 M
+5 -3 D
+-6 3 D
+P S
+4415 2391 M
+1 -8 D
+P S
+5240 2168 M
+-8 8 D
+7 -8 D
+-30 0 D
+-5 5 D
+8 5 D
+-21 4 D
+0 13 D
+-17 -2 D
+-13 28 D
+-26 16 D
+-6 20 D
+24 2 D
+-6 15 D
+-51 17 D
+2 17 D
+-35 28 D
+-123 43 D
+0 331 D
+542 0 D
+0 -526 D
+-8 5 D
+-3 -8 D
+11 -3 D
+0 -10 D
+P
+FO
+4940 2222 M
+1 0 D
+30 -33 D
+29 4 D
+12 -7 D
+21 16 D
+-33 16 D
+40 -2 D
+-8 8 D
+15 -1 D
+-8 15 D
+23 -11 D
+-3 11 D
+4 -7 D
+6 7 D
+3 -10 D
+33 -8 D
+42 -52 D
+-207 0 D
+P
+FO
+{0.784 A} FS
+39 7 35 -19 -42 -2 -6 -14 0 14 -22 0 -21 -17 5 -18 -18 -2 -7 5 13 18 -5 11 29 16 13 5240 2277 SP
+-34 37 12 2 14 -17 3 5347 2271 SP
+14 -32 42 -30 -60 42 3 5293 2328 SP
+16 -9 -5 -8 2 5412 2222 SP
+-25 -3 12 4 2 5130 2380 SP
+-40 28 25 -13 2 5455 2220 SP
+7 -9 -7 1 2 5157 2289 SP
+-1 8 6 -4 2 5406 2207 SP
+-30 21 15 -3 2 5401 2242 SP
+3 6 1 5401 2220 SP
+14 -8 1 5223 2185 SP
+13 -4 1 5211 2371 SP
+-15 3 1 5293 2191 SP
+7 -6 1 5214 2187 SP
+5 -8 1 5388 2232 SP
+3 -9 1 5334 2300 SP
+1 -7 1 5428 2208 SP
+6 -2 1 5130 2295 SP
+8 -1 1 5030 2212 SP
+6 -2 1 5413 2203 SP
+-6 -1 1 5238 2359 SP
+-2 -7 1 5103 2317 SP
+6 -2 1 5431 2627 SP
+7 -3 1 5198 2401 SP
+12 -8 1 5027 2211 SP
+4 -8 1 5238 2209 SP
+{0.706 0.863 1 C} FS
+4 -9 1 4977 2254 SP
+6 0 -6 1 2 4957 2368 SP
+{0.784 A} FS
+5209 2168 M
+-5 5 D
+8 5 D
+-21 4 D
+0 13 D
+-17 -2 D
+-13 28 D
+-26 16 D
+-6 20 D
+24 2 D
+-6 15 D
+-51 17 D
+2 17 D
+-35 28 D
+-123 43 D
+0 -157 D
+1 0 D
+30 -33 D
+29 4 D
+12 -7 D
+21 16 D
+-33 16 D
+40 -2 D
+-8 8 D
+15 -1 D
+-8 15 D
+23 -11 D
+-3 11 D
+4 -7 D
+6 7 D
+3 -10 D
+33 -8 D
+42 -52 D
+P
+FO
+7 -8 -8 8 2 5240 2168 SP
+11 -3 -3 -8 -8 5 3 5482 2184 SP
+39 7 35 -19 -42 -2 -6 -14 0 14 -22 0 -21 -17 5 -18 -18 -2 -7 5 13 18 -5 11 29 16 13 5240 2277 SP
+-34 37 12 2 14 -17 3 5347 2271 SP
+14 -32 42 -30 -60 42 3 5293 2328 SP
+16 -9 -5 -8 2 5412 2222 SP
+-25 -3 12 4 2 5130 2380 SP
+-40 28 25 -13 2 5455 2220 SP
+7 -9 -7 1 2 5157 2289 SP
+-1 8 6 -4 2 5406 2207 SP
+-30 21 15 -3 2 5401 2242 SP
+3 6 1 5401 2220 SP
+14 -8 1 5223 2185 SP
+13 -4 1 5211 2371 SP
+-15 3 1 5293 2191 SP
+7 -6 1 5214 2187 SP
+5 -8 1 5388 2232 SP
+3 -9 1 5334 2300 SP
+1 -7 1 5428 2208 SP
+6 -2 1 5130 2295 SP
+8 -1 1 5030 2212 SP
+6 -2 1 5413 2203 SP
+-6 -1 1 5238 2359 SP
+-2 -7 1 5103 2317 SP
+6 -2 1 5431 2627 SP
+7 -3 1 5198 2401 SP
+12 -8 1 5027 2211 SP
+4 -8 1 5238 2209 SP
+{0.706 0.863 1 C} FS
+4 -9 1 4977 2254 SP
+6 0 -6 1 2 4957 2368 SP
+4940 2222 M
+1 0 D
+30 -33 D
+29 4 D
+12 -7 D
+21 16 D
+-33 16 D
+40 -2 D
+-8 8 D
+15 -1 D
+-8 15 D
+23 -11 D
+-3 11 D
+4 -7 D
+6 7 D
+3 -10 D
+33 -8 D
+42 -52 D
+S
+5209 2168 M
+-5 5 D
+8 5 D
+-21 4 D
+0 13 D
+-17 -2 D
+-13 28 D
+-26 16 D
+-6 20 D
+24 2 D
+-6 15 D
+-51 17 D
+2 17 D
+-35 28 D
+-123 43 D
+S
+5240 2277 M
+29 16 D
+-5 11 D
+13 18 D
+-7 5 D
+-18 -2 D
+5 -18 D
+-21 -17 D
+-22 0 D
+0 14 D
+-6 -14 D
+-42 -2 D
+35 -19 D
+39 7 D
+P S
+5347 2271 M
+14 -17 D
+12 2 D
+-34 37 D
+P S
+5293 2328 M
+-60 42 D
+42 -30 D
+14 -32 D
+P S
+5412 2222 M
+-5 -8 D
+16 -9 D
+P S
+5130 2380 M
+12 4 D
+-25 -3 D
+P S
+5455 2220 M
+25 -13 D
+-40 28 D
+P S
+5157 2289 M
+-7 1 D
+7 -9 D
+P S
+5482 2184 M
+-8 5 D
+-3 -8 D
+11 -3 D
+S
+5406 2207 M
+6 -4 D
+-1 8 D
+P S
+5401 2242 M
+15 -3 D
+-30 21 D
+P S
+5401 2220 M
+3 6 D
+P S
+5223 2185 M
+14 -8 D
+P S
+5211 2371 M
+13 -4 D
+P S
+5293 2191 M
+-15 3 D
+P S
+5214 2187 M
+7 -6 D
+P S
+5388 2232 M
+5 -8 D
+P S
+5334 2300 M
+3 -9 D
+P S
+5428 2208 M
+1 -7 D
+P S
+5130 2295 M
+6 -2 D
+P S
+5030 2212 M
+8 -1 D
+P S
+5413 2203 M
+6 -2 D
+P S
+5238 2359 M
+-6 -1 D
+P S
+5103 2317 M
+-2 -7 D
+P S
+5431 2627 M
+6 -2 D
+P S
+5198 2401 M
+7 -3 D
+P S
+5027 2211 M
+12 -8 D
+P S
+5238 2209 M
+4 -8 D
+P S
+5240 2168 M
+-8 8 D
+7 -8 D
+S
+4977 2254 M
+4 -9 D
+P S
+4957 2368 M
+-6 1 D
+6 0 D
+P S
+-542 0 0 -542 542 0 0 526 -23 12 23 -6 6 5482 2178 SP
+{0.784 A} FS
+-23 35 11 -10 2 5509 2188 SP
+5 -12 1 5519 2186 SP
+8 -3 1 5486 2195 SP
+-3 6 1 5835 2486 SP
+8 -2 1 5782 2633 SP
+-23 12 23 -6 2 5482 2178 SP
+-23 35 11 -10 2 5509 2188 SP
+5 -12 1 5519 2186 SP
+8 -3 1 5486 2195 SP
+-3 6 1 5835 2486 SP
+8 -2 1 5782 2633 SP
+5509 2188 M
+11 -10 D
+-23 35 D
+P S
+5482 2178 M
+23 -6 D
+-23 12 D
+S
+5519 2186 M
+5 -12 D
+P S
+5486 2195 M
+8 -3 D
+P S
+5835 2486 M
+-3 6 D
+P S
+5782 2633 M
+8 -2 D
+P S
+{0.706 0.863 1 C} FS
+542 0 0 542 -542 0 3 6566 2168 SP
+543 0 0 542 -543 0 3 7109 2168 SP
+{0.784 A} FS
+10 -5 -5 -3 2 6638 2493 SP
+-6 3 6 -2 2 7102 2199 SP
+10 -5 -5 -3 2 6638 2493 SP
+-6 3 6 -2 2 7102 2199 SP
+6638 2493 M
+-5 -3 D
+10 -5 D
+P S
+7102 2199 M
+6 -2 D
+-6 3 D
+P S
+{0.706 0.863 1 C} FS
+91 0 0 542 -91 0 3 7200 2168 SP
+62 0 0 348 -1 0 -60 0 -1 0 5 62 2362 SP
+{0.784 A} FS
+62 0 0 -194 -1 0 -60 0 -1 0 5 62 2362 SP
+62 2362 M
+-1 0 D
+-60 0 D
+-1 0 D
+0 0 D S
+{0.706 0.863 1 C} FS
+0 -542 542 0 0 348 -41 23 -36 35 -42 3 -9 10 -13 46 4 32 32 45 10 167 2168 SP
+-10 -2 1 91 2270 SP
+-6 1 1 119 2246 SP
+{0.784 A} FS
+0 -194 -41 23 -36 35 -42 3 -9 10 -13 46 4 32 32 45 8 167 2168 SP
+{0.706 0.863 1 C} FS
+-10 -2 1 91 2270 SP
+-6 1 1 119 2246 SP
+167 2168 M
+32 45 D
+4 32 D
+-13 46 D
+-9 10 D
+-42 3 D
+-36 35 D
+-41 23 D
+S
+91 2270 M
+-10 -2 D
+P S
+119 2246 M
+-6 1 D
+P S
+767 2710 M
+12 -5 D
+-5 -8 D
+11 -5 D
+4 -22 D
+9 1 D
+-12 -4 D
+22 -17 D
+-1 -11 D
+35 -16 D
+68 -53 D
+33 -13 D
+37 18 D
+57 7 D
+55 -14 D
+54 23 D
+0 -423 D
+-542 0 D
+0 542 D
+P
+FO
+31 -34 -3 11 18 2 -20 0 -5 15 -19 9 16 6 -18 -1 8 1146 2644 SP
+7 1 -7 0 2 1146 2643 SP
+1 4 19 -6 -20 9 3 1146 2616 SP
+9 21 -12 11 -2 -14 7 7 3 -6 -6 -19 6 998 2659 SP
+3 -9 1 1058 2599 SP
+{0.784 A} FS
+1146 2616 M
+-20 9 D
+19 -6 D
+1 24 D
+-7 0 D
+7 1 D
+-18 -1 D
+16 6 D
+-19 9 D
+-5 15 D
+-20 0 D
+18 2 D
+-3 11 D
+31 -34 D
+0 58 D
+-379 0 D
+12 -5 D
+-5 -8 D
+11 -5 D
+4 -22 D
+9 1 D
+-12 -4 D
+22 -17 D
+-1 -11 D
+35 -16 D
+68 -53 D
+33 -13 D
+37 18 D
+57 7 D
+55 -14 D
+54 23 D
+P
+FO
+{0.706 0.863 1 C} FS
+9 21 -12 11 -2 -14 7 7 3 -6 -6 -19 6 998 2659 SP
+3 -9 1 1058 2599 SP
+767 2710 M
+12 -5 D
+-5 -8 D
+11 -5 D
+4 -22 D
+9 1 D
+-12 -4 D
+22 -17 D
+-1 -11 D
+35 -16 D
+68 -53 D
+33 -13 D
+37 18 D
+57 7 D
+55 -14 D
+54 23 D
+S
+1146 2644 M
+-18 -1 D
+16 6 D
+-19 9 D
+-5 15 D
+-20 0 D
+18 2 D
+-3 11 D
+31 -34 D
+S
+998 2659 M
+-6 -19 D
+3 -6 D
+7 7 D
+-2 -14 D
+-12 11 D
+9 21 D
+P S
+1146 2616 M
+-20 9 D
+19 -6 D
+1 4 D
+S
+1058 2599 M
+3 -9 D
+P S
+1146 2643 M
+-7 0 D
+7 1 D
+S
+0 542 -466 0 61 -100 12 -102 73 -124 2 -58 -22 -66 -30 -32 -6 -33 13 -27 10 1509 2168 SP
+{0.784 A} FS
+-3 7 3 -6 2 1462 1990 SP
+0 542 76 0 61 -100 12 -102 73 -124 2 -58 -22 -66 -30 -32 -6 -33 13 -27 10 1509 2168 SP
+-3 7 3 -6 2 1462 1990 SP
+1509 2168 M
+13 -27 D
+-6 -33 D
+-30 -32 D
+-22 -66 D
+2 -58 D
+73 -124 D
+12 -102 D
+61 -100 D
+S
+1462 1990 M
+3 -6 D
+-3 7 D
+P S
+{0.706 0.863 1 C} FS
+0 -374 4 6 81 39 15 27 39 27 6 -6 0 25 -24 44 1 52 81 50 -9 9 -3 -5 15 67 30 24 11 15 15 1983 1626 SP
+0 1 1 1817 1626 SP
+-9 44 9 17 -16 50 -18 8 15 -53 -7 -26 12 -40 7 2081 2168 SP
+8 0 0 1 -8 5 3 2230 2162 SP
+20 9 -12 5 9 -6 -13 3 -5 -11 5 1861 1697 SP
+-18 27 18 -28 20 -8 3 2071 1988 SP
+-24 -6 32 6 22 31 3 1878 1952 SP
+-8 8 3 -7 -6 1 3 1918 1708 SP
+8 15 -10 -3 1 -12 3 1957 2145 SP
+1 -7 1 0 2 1877 2147 SP
+-1 7 0 -7 2 2102 2046 SP
+-6 -4 7 4 2 1760 1883 SP
+-3 6 1 2014 1695 SP
+-3 -8 1 1953 2127 SP
+0 10 1 2114 2019 SP
+52 2 1 1980 2015 SP
+{0.784 A} FS
+1817 1626 M
+0 1 D
+0 -1 D
+166 0 D
+11 15 D
+30 24 D
+15 67 D
+-3 -5 D
+-9 9 D
+81 50 D
+1 52 D
+-24 44 D
+0 25 D
+6 -6 D
+39 27 D
+15 27 D
+81 39 D
+4 6 D
+0 162 D
+-8 5 D
+0 1 D
+-141 0 D
+12 -40 D
+-7 -26 D
+15 -53 D
+-18 8 D
+-16 50 D
+9 17 D
+-9 44 D
+-379 0 D
+0 -542 D
+P
+FO
+{0.706 0.863 1 C} FS
+20 9 -12 5 9 -6 -13 3 -5 -11 5 1861 1697 SP
+-18 27 18 -28 20 -8 3 2071 1988 SP
+-24 -6 32 6 22 31 3 1878 1952 SP
+-8 8 3 -7 -6 1 3 1918 1708 SP
+8 15 -10 -3 1 -12 3 1957 2145 SP
+1 -7 1 0 2 1877 2147 SP
+-1 7 0 -7 2 2102 2046 SP
+-6 -4 7 4 2 1760 1883 SP
+-3 6 1 2014 1695 SP
+-3 -8 1 1953 2127 SP
+0 10 1 2114 2019 SP
+52 2 1 1980 2015 SP
+1983 1626 M
+11 15 D
+30 24 D
+15 67 D
+-3 -5 D
+-9 9 D
+81 50 D
+1 52 D
+-24 44 D
+0 25 D
+6 -6 D
+39 27 D
+15 27 D
+81 39 D
+4 6 D
+S
+2230 2162 M
+-8 5 D
+0 1 D
+S
+2081 2168 M
+12 -40 D
+-7 -26 D
+15 -53 D
+-18 8 D
+-16 50 D
+9 17 D
+-9 44 D
+S
+1861 1697 M
+-5 -11 D
+-13 3 D
+9 -6 D
+-12 5 D
+P S
+2071 1988 M
+20 -8 D
+18 -28 D
+-18 27 D
+P S
+1878 1952 M
+22 31 D
+32 6 D
+-24 -6 D
+P S
+1918 1708 M
+-6 1 D
+3 -7 D
+-8 8 D
+P S
+1957 2145 M
+1 -12 D
+-10 -3 D
+8 15 D
+P S
+1877 2147 M
+1 0 D
+1 -7 D
+P S
+2102 2046 M
+0 -7 D
+-1 7 D
+P S
+1760 1883 M
+7 4 D
+-6 -4 D
+P S
+2014 1695 M
+-3 6 D
+P S
+1953 2127 M
+-3 -8 D
+P S
+1817 1626 M
+0 1 D
+P S
+2114 2019 M
+0 10 D
+P S
+1980 2015 M
+52 2 D
+P S
+-542 0 0 -542 542 0 0 6 -17 12 8 17 -8 39 6 5 -12 52 23 37 10 2230 2000 SP
+{0.784 A} FS
+2366 1748 M
+57 14 D
+63 185 D
+0 26 D
+11 10 D
+-6 35 D
+7 3 D
+7 -15 D
+9 15 D
+-15 65 D
+-20 20 D
+2 9 D
+-15 -13 D
+3 -25 D
+-15 -12 D
+-10 6 D
+4 -18 D
+-8 0 D
+-7 -23 D
+-1 12 D
+-11 -14 D
+4 -8 D
+-8 -4 D
+2 11 D
+-13 -8 D
+0 -13 D
+-9 8 D
+-47 -14 D
+-13 -35 D
+15 -67 D
+-27 -36 D
+-7 -28 D
+21 -72 D
+P
+FO
+10 6 -4 -14 2 2706 1897 SP
+-3 14 8 -4 2 2317 2121 SP
+-2 8 9 -5 2 2344 2109 SP
+-4 11 15 -9 2 2644 1870 SP
+4 -7 1 2367 2094 SP
+5 -4 1 2452 2080 SP
+7 -3 1 2328 2106 SP
+3 9 1 2498 1978 SP
+{0.706 0.863 1 C} FS
+3 9 1 2460 1961 SP
+{0.784 A} FS
+-17 12 8 17 -8 39 6 5 -12 52 23 37 6 2230 2000 SP
+2366 1748 M
+57 14 D
+63 185 D
+0 26 D
+11 10 D
+-6 35 D
+7 3 D
+7 -15 D
+9 15 D
+-15 65 D
+-20 20 D
+2 9 D
+-15 -13 D
+3 -25 D
+-15 -12 D
+-10 6 D
+4 -18 D
+-8 0 D
+-7 -23 D
+-1 12 D
+-11 -14 D
+4 -8 D
+-8 -4 D
+2 11 D
+-13 -8 D
+0 -13 D
+-9 8 D
+-47 -14 D
+-13 -35 D
+15 -67 D
+-27 -36 D
+-7 -28 D
+21 -72 D
+P
+FO
+10 6 -4 -14 2 2706 1897 SP
+-3 14 8 -4 2 2317 2121 SP
+-2 8 9 -5 2 2344 2109 SP
+-4 11 15 -9 2 2644 1870 SP
+4 -7 1 2367 2094 SP
+5 -4 1 2452 2080 SP
+7 -3 1 2328 2106 SP
+3 9 1 2498 1978 SP
+{0.706 0.863 1 C} FS
+3 9 1 2460 1961 SP
+2366 1748 M
+57 14 D
+63 185 D
+0 26 D
+11 10 D
+-6 35 D
+7 3 D
+7 -15 D
+9 15 D
+-15 65 D
+-20 20 D
+2 9 D
+-15 -13 D
+3 -25 D
+-15 -12 D
+-10 6 D
+4 -18 D
+-8 0 D
+-7 -23 D
+-1 12 D
+-11 -14 D
+4 -8 D
+-8 -4 D
+2 11 D
+-13 -8 D
+0 -13 D
+-9 8 D
+-47 -14 D
+-13 -35 D
+15 -67 D
+-27 -36 D
+-7 -28 D
+21 -72 D
+P S
+2230 2000 M
+23 37 D
+-12 52 D
+6 5 D
+-8 39 D
+8 17 D
+-17 12 D
+S
+2706 1897 M
+-4 -14 D
+10 6 D
+P S
+2317 2121 M
+8 -4 D
+-3 14 D
+P S
+2344 2109 M
+9 -5 D
+-2 8 D
+P S
+2644 1870 M
+15 -9 D
+-4 11 D
+P S
+2367 2094 M
+4 -7 D
+P S
+2452 2080 M
+5 -4 D
+P S
+2328 2106 M
+7 -3 D
+P S
+2498 1978 M
+3 9 D
+P S
+2460 1961 M
+3 9 D
+P S
+542 0 0 542 -542 0 3 3314 1626 SP
+542 0 0 542 -542 0 3 3856 1626 SP
+4396 2168 M
+2 -1 D
+0 -264 D
+-24 -5 D
+-47 -22 D
+-15 7 D
+-59 -36 D
+-8 -18 D
+-10 17 D
+-16 -68 D
+23 -52 D
+-10 10 D
+-4 -7 D
+-6 19 D
+9 -29 D
+-18 12 D
+46 -81 D
+3 -24 D
+-406 0 D
+0 542 D
+P
+FO
+{0.784 A} FS
+-7 13 1 4214 1735 SP
+4 5 1 4271 1874 SP
+-1 -8 1 4212 1762 SP
+1 6 1 4212 1762 SP
+136 0 3 -24 46 -81 -18 12 9 -29 -6 19 -4 -7 -10 10 23 -52 -16 -68 -10 17 -8 -18 -59 -36 -15 7 -47 -22 -24 -5 16 4398 1903 SP
+0 1 2 -1 2 4396 2168 SP
+-7 13 1 4214 1735 SP
+4 5 1 4271 1874 SP
+-1 -8 1 4212 1762 SP
+1 6 1 4212 1762 SP
+4398 1903 M
+-24 -5 D
+-47 -22 D
+-15 7 D
+-59 -36 D
+-8 -18 D
+-10 17 D
+-16 -68 D
+23 -52 D
+-10 10 D
+-4 -7 D
+-6 19 D
+9 -29 D
+-18 12 D
+46 -81 D
+3 -24 D
+S
+4214 1735 M
+-7 13 D
+P S
+4271 1874 M
+4 5 D
+P S
+4212 1762 M
+-1 -8 D
+P S
+4212 1762 M
+1 6 D
+P S
+4396 2168 M
+2 -1 D
+S
+{0.706 0.863 1 C} FS
+4398 2167 M
+13 -7 D
+10 7 D
+-1 1 D
+75 0 D
+-3 -10 D
+15 3 D
+13 7 D
+420 0 D
+0 -205 D
+-11 1 D
+-15 17 D
+-64 27 D
+-34 26 D
+18 35 D
+-5 10 D
+15 1 D
+0 13 D
+14 12 D
+-11 12 D
+-15 -17 D
+1 12 D
+-10 -4 D
+7 7 D
+-19 -9 D
+-13 9 D
+-16 -6 D
+-7 12 D
+-11 -4 D
+-41 21 D
+-6 -6 D
+26 -8 D
+1 -14 D
+-35 -4 D
+-5 7 D
+-13 -10 D
+4 -7 D
+-10 7 D
+4 -9 D
+-10 2 D
+-1 -19 D
+-14 -4 D
+-12 -22 D
+17 -10 D
+-10 -14 D
+-9 9 D
+-4 -11 D
+-1 10 D
+-15 4 D
+-9 -8 D
+4 -12 D
+-6 9 D
+-4 -9 D
+6 21 D
+-21 21 D
+-15 6 D
+-7 -14 D
+-3 9 D
+-8 -9 D
+-6 9 D
+-2 -21 D
+-9 13 D
+-12 -14 D
+10 -12 D
+-19 0 D
+12 -11 D
+-16 9 D
+-9 -11 D
+4 -9 D
+7 5 D
+-10 -15 D
+16 -1 D
+-15 -5 D
+-23 11 D
+-2 -13 D
+13 -5 D
+-1 -12 D
+-10 6 D
+0 -16 D
+-18 34 D
+-20 -24 D
+6 -23 D
+-35 -38 D
+-30 -7 D
+P
+FO
+{0.784 A} FS
+16 13 16 -21 -13 11 -4 -5 4 4696 2131 SP
+-6 17 17 -1 -2 -7 3 4843 2060 SP
+-9 11 17 1 2 4670 2120 SP
+6 4 1 4836 2122 SP
+15 3 1 4917 1988 SP
+10 11 1 4480 2145 SP
+8 3 1 4444 2153 SP
+0 -10 1 4739 2141 SP
+4 6 1 4825 2114 SP
+8 12 1 4845 2129 SP
+{0.706 0.863 1 C} FS
+11 1 -3 16 2 4635 1985 SP
+2 9 1 4763 1953 SP
+{0.784 A} FS
+4940 1963 M
+-11 1 D
+-15 17 D
+-64 27 D
+-34 26 D
+18 35 D
+-5 10 D
+15 1 D
+0 13 D
+14 12 D
+-11 12 D
+-15 -17 D
+1 12 D
+-10 -4 D
+7 7 D
+-19 -9 D
+-13 9 D
+-16 -6 D
+-7 12 D
+-11 -4 D
+-41 21 D
+-6 -6 D
+26 -8 D
+1 -14 D
+-35 -4 D
+-5 7 D
+-13 -10 D
+4 -7 D
+-10 7 D
+4 -9 D
+-10 2 D
+-1 -19 D
+-14 -4 D
+-12 -22 D
+17 -10 D
+-10 -14 D
+-9 9 D
+-4 -11 D
+-1 10 D
+-15 4 D
+-9 -8 D
+4 -12 D
+-6 9 D
+-4 -9 D
+6 21 D
+-21 21 D
+-15 6 D
+-7 -14 D
+-3 9 D
+-8 -9 D
+-6 9 D
+-2 -21 D
+-9 13 D
+-12 -14 D
+10 -12 D
+-19 0 D
+12 -11 D
+-16 9 D
+-9 -11 D
+4 -9 D
+7 5 D
+-10 -15 D
+16 -1 D
+-15 -5 D
+-23 11 D
+-2 -13 D
+13 -5 D
+-1 -12 D
+-10 6 D
+0 -16 D
+-18 34 D
+-20 -24 D
+6 -23 D
+-35 -38 D
+-30 -7 D
+0 -277 D
+542 0 D
+P
+FO
+13 7 15 3 -3 -10 3 4495 2168 SP
+-22 0 -1 1 10 7 13 -7 4 4398 2167 SP
+16 13 16 -21 -13 11 -4 -5 4 4696 2131 SP
+-6 17 17 -1 -2 -7 3 4843 2060 SP
+-9 11 17 1 2 4670 2120 SP
+6 4 1 4836 2122 SP
+15 3 1 4917 1988 SP
+10 11 1 4480 2145 SP
+8 3 1 4444 2153 SP
+0 -10 1 4739 2141 SP
+4 6 1 4825 2114 SP
+8 12 1 4845 2129 SP
+{0.706 0.863 1 C} FS
+11 1 -3 16 2 4635 1985 SP
+2 9 1 4763 1953 SP
+4940 1963 M
+-11 1 D
+-15 17 D
+-64 27 D
+-34 26 D
+18 35 D
+-5 10 D
+15 1 D
+0 13 D
+14 12 D
+-11 12 D
+-15 -17 D
+1 12 D
+-10 -4 D
+7 7 D
+-19 -9 D
+-13 9 D
+-16 -6 D
+-7 12 D
+-11 -4 D
+-41 21 D
+-6 -6 D
+26 -8 D
+1 -14 D
+-35 -4 D
+-5 7 D
+-13 -10 D
+4 -7 D
+-10 7 D
+4 -9 D
+-10 2 D
+-1 -19 D
+-14 -4 D
+-12 -22 D
+17 -10 D
+-10 -14 D
+-9 9 D
+-4 -11 D
+-1 10 D
+-15 4 D
+-9 -8 D
+4 -12 D
+-6 9 D
+-4 -9 D
+6 21 D
+-21 21 D
+-15 6 D
+-7 -14 D
+-3 9 D
+-8 -9 D
+-6 9 D
+-2 -21 D
+-9 13 D
+-12 -14 D
+10 -12 D
+-19 0 D
+12 -11 D
+-16 9 D
+-9 -11 D
+4 -9 D
+7 5 D
+-10 -15 D
+16 -1 D
+-15 -5 D
+-23 11 D
+-2 -13 D
+13 -5 D
+-1 -12 D
+-10 6 D
+0 -16 D
+-18 34 D
+-20 -24 D
+6 -23 D
+-35 -38 D
+-30 -7 D
+S
+4696 2131 M
+-4 -5 D
+-13 11 D
+16 -21 D
+16 13 D
+P S
+4843 2060 M
+-2 -7 D
+17 -1 D
+-6 17 D
+P S
+4398 2167 M
+13 -7 D
+10 7 D
+-1 1 D
+S
+4670 2120 M
+17 1 D
+-9 11 D
+P S
+4495 2168 M
+-3 -10 D
+15 3 D
+13 7 D
+S
+4836 2122 M
+6 4 D
+P S
+4917 1988 M
+15 3 D
+P S
+4480 2145 M
+10 11 D
+P S
+4444 2153 M
+8 3 D
+P S
+4739 2141 M
+0 -10 D
+P S
+4825 2114 M
+4 6 D
+P S
+4845 2129 M
+8 12 D
+P S
+4635 1985 M
+-3 16 D
+11 1 D
+P S
+4763 1953 M
+2 9 D
+P S
+5301 1626 M
+9 37 D
+-17 36 D
+5 37 D
+-39 52 D
+-26 14 D
+-4 32 D
+0 -9 D
+-17 15 D
+1 -15 D
+-7 8 D
+-5 -6 D
+-23 64 D
+-68 37 D
+-8 53 D
+-15 13 D
+-2 40 D
+-22 21 D
+-20 -6 D
+-7 42 D
+-27 59 D
+-11 -8 D
+-1 -28 D
+-14 -15 D
+11 -1 D
+-14 -34 D
+6 -32 D
+-29 -70 D
+-17 1 D
+0 205 D
+207 0 D
+3 -3 D
+54 -6 D
+13 -10 D
+18 13 D
+-24 4 D
+-2 2 D
+30 0 D
+5 -5 D
+-4 5 D
+242 0 D
+0 -542 D
+P
+FO
+{0.784 A} FS
+5 28 2 -8 2 5293 1750 SP
+2 -8 1 5302 1706 SP
+17 -7 1 5297 2131 SP
+2 9 1 5303 1688 SP
+9 -1 1 5280 2151 SP
+5301 1626 M
+9 37 D
+-17 36 D
+5 37 D
+-39 52 D
+-26 14 D
+-4 32 D
+0 -9 D
+-17 15 D
+1 -15 D
+-7 8 D
+-5 -6 D
+-23 64 D
+-68 37 D
+-8 53 D
+-15 13 D
+-2 40 D
+-22 21 D
+-20 -6 D
+-7 42 D
+-27 59 D
+-11 -8 D
+-1 -28 D
+-14 -15 D
+11 -1 D
+-14 -34 D
+6 -32 D
+-29 -70 D
+-17 1 D
+0 -337 D
+P
+FO
+-4 5 5 -5 2 5239 2168 SP
+-2 2 -24 4 18 13 13 -10 54 -6 3 -3 6 5147 2168 SP
+5 28 2 -8 2 5293 1750 SP
+2 -8 1 5302 1706 SP
+17 -7 1 5297 2131 SP
+2 9 1 5303 1688 SP
+9 -1 1 5280 2151 SP
+5301 1626 M
+9 37 D
+-17 36 D
+5 37 D
+-39 52 D
+-26 14 D
+-4 32 D
+0 -9 D
+-17 15 D
+1 -15 D
+-7 8 D
+-5 -6 D
+-23 64 D
+-68 37 D
+-8 53 D
+-15 13 D
+-2 40 D
+-22 21 D
+-20 -6 D
+-7 42 D
+-27 59 D
+-11 -8 D
+-1 -28 D
+-14 -15 D
+11 -1 D
+-14 -34 D
+6 -32 D
+-29 -70 D
+-17 1 D
+S
+5147 2168 M
+3 -3 D
+54 -6 D
+13 -10 D
+18 13 D
+-24 4 D
+-2 2 D
+S
+5293 1750 M
+2 -8 D
+5 28 D
+P S
+5239 2168 M
+5 -5 D
+-4 5 D
+S
+5302 1706 M
+2 -8 D
+P S
+5297 2131 M
+17 -7 D
+P S
+5303 1688 M
+2 9 D
+P S
+5280 2151 M
+9 -1 D
+P S
+{0.706 0.863 1 C} FS
+542 0 0 542 -542 0 0 -355 2 3 -2 -3 0 -20 14 15 -13 -7 0 8 39 2 -40 -19 12 6024 2002 SP
+{0.784 A} FS
+10 0 7 -12 -6 -3 3 5682 2006 SP
+17 -8 -25 -18 -13 19 3 5988 1951 SP
+-18 25 13 3 5 -18 3 5661 2033 SP
+-30 17 10 -1 2 5537 2147 SP
+-6 9 9 -2 2 5726 1927 SP
+25 -35 -81 61 2 5672 1834 SP
+-1 14 1 5705 2006 SP
+10 -4 1 5702 1987 SP
+14 3 1 5970 1921 SP
+-8 -5 1 5699 2025 SP
+5 4 1 5683 2051 SP
+3 9 1 5658 1878 SP
+-9 7 1 5682 1870 SP
+12 1 1 5703 1959 SP
+9 -3 1 5699 2000 SP
+-5 8 1 5699 1852 SP
+6 -5 1 5732 1912 SP
+-8 -1 1 5645 2147 SP
+-2 -3 1 6024 1981 SP
+14 15 -13 -7 0 8 39 2 -40 -19 5 6024 2002 SP
+10 0 7 -12 -6 -3 3 5682 2006 SP
+17 -8 -25 -18 -13 19 3 5988 1951 SP
+-18 25 13 3 5 -18 3 5661 2033 SP
+-30 17 10 -1 2 5537 2147 SP
+-6 9 9 -2 2 5726 1927 SP
+25 -35 -81 61 2 5672 1834 SP
+-1 14 1 5705 2006 SP
+10 -4 1 5702 1987 SP
+14 3 1 5970 1921 SP
+-8 -5 1 5699 2025 SP
+5 4 1 5683 2051 SP
+3 9 1 5658 1878 SP
+-9 7 1 5682 1870 SP
+12 1 1 5703 1959 SP
+9 -3 1 5699 2000 SP
+-5 8 1 5699 1852 SP
+6 -5 1 5732 1912 SP
+-8 -1 1 5645 2147 SP
+5682 2006 M
+-6 -3 D
+7 -12 D
+10 0 D
+P S
+5988 1951 M
+-13 19 D
+-25 -18 D
+17 -8 D
+P S
+5661 2033 M
+5 -18 D
+13 3 D
+-18 25 D
+P S
+6024 2002 M
+-40 -19 D
+39 2 D
+0 8 D
+-13 -7 D
+14 15 D
+S
+5537 2147 M
+10 -1 D
+-30 17 D
+P S
+5726 1927 M
+9 -2 D
+-6 9 D
+P S
+5672 1834 M
+-81 61 D
+25 -35 D
+P S
+5705 2006 M
+-1 14 D
+P S
+6024 1981 M
+-2 -3 D
+P S
+5702 1987 M
+10 -4 D
+P S
+5970 1921 M
+14 3 D
+P S
+5699 2025 M
+-8 -5 D
+P S
+5683 2051 M
+5 4 D
+P S
+5658 1878 M
+3 9 D
+P S
+5682 1870 M
+-9 7 D
+P S
+5703 1959 M
+12 1 D
+P S
+5699 2000 M
+9 -3 D
+P S
+5699 1852 M
+-5 8 D
+P S
+5732 1912 M
+6 -5 D
+P S
+5645 2147 M
+-8 -1 D
+P S
+{0.706 0.863 1 C} FS
+-542 0 0 -542 542 0 0 166 -1 0 1 1 0 20 -5 -6 5 6 9 6024 1981 SP
+{0.784 A} FS
+-17 4 10 -1 2 6246 2060 SP
+17 -4 1 6219 2073 SP
+-9 2 9 -1 2 6150 1867 SP
+8 2 1 6272 2051 SP
+-1 0 1 1 2 6024 2001 SP
+5 6 1 6024 1981 SP
+-17 4 10 -1 2 6246 2060 SP
+17 -4 1 6219 2073 SP
+-9 2 9 -1 2 6150 1867 SP
+8 2 1 6272 2051 SP
+6024 2001 M
+1 1 D
+-1 0 D
+S
+6246 2060 M
+10 -1 D
+-17 4 D
+P S
+6024 1981 M
+5 6 D
+P S
+6219 2073 M
+17 -4 D
+P S
+6150 1867 M
+9 -1 D
+-9 2 D
+P S
+6272 2051 M
+8 2 D
+P S
+{0.706 0.863 1 C} FS
+543 0 0 542 -543 0 3 7109 1626 SP
+{0.784 A} FS
+13 -8 1 6848 1963 SP
+5 -6 1 6954 2003 SP
+6 -4 1 7081 1949 SP
+13 -8 1 6848 1963 SP
+5 -6 1 6954 2003 SP
+6 -4 1 7081 1949 SP
+6848 1963 M
+13 -8 D
+P S
+6954 2003 M
+5 -6 D
+P S
+7081 1949 M
+6 -4 D
+P S
+{0.706 0.863 1 C} FS
+91 0 0 542 -91 0 3 7200 1626 SP
+-62 0 0 -274 29 44 -2 13 26 14 2 13 7 0 7 0 1816 SP
+{0.784 A} FS
+-62 0 0 268 29 44 -2 13 26 14 2 13 7 0 7 0 1816 SP
+0 1816 M
+7 0 D
+2 13 D
+26 14 D
+-2 13 D
+29 44 D
+S
+{0.706 0.863 1 C} FS
+-542 0 0 -542 437 0 53 72 11 10 6 -12 4 7 8 131 15 19 3 33 5 8 11 62 1900 SP
+{0.784 A} FS
+-105 0 53 72 11 10 6 -12 4 7 8 131 15 19 3 33 5 8 9 62 1900 SP
+62 1900 M
+5 8 D
+3 33 D
+15 19 D
+8 131 D
+4 7 D
+6 -12 D
+11 10 D
+53 72 D
+S
+{0.706 0.863 1 C} FS
+542 0 0 542 -542 0 3 1146 1626 SP
+0 542 -542 0 0 -412 33 -20 10 6 15 -40 -13 -8 4 -23 27 -45 9 1612 1626 SP
+{0.784 A} FS
+0 130 33 -20 10 6 15 -40 -13 -8 4 -23 27 -45 7 1612 1626 SP
+1612 1626 M
+27 -45 D
+4 -23 D
+-13 -8 D
+15 -40 D
+10 6 D
+33 -20 D
+S
+{0.706 0.863 1 C} FS
+-542 0 0 -542 247 0 24 35 81 61 59 18 62 -6 68 23 1 -1 9 1688 1496 SP
+6 -6 1 1817 1626 SP
+{0.784 A} FS
+8 1 1 2165 1167 SP
+{0.706 0.863 1 C} FS
+8 -1 1 1839 1610 SP
+{0.784 A} FS
+24 35 81 61 59 18 62 -6 68 23 1 -1 0 -130 -129 0 -6 6 6 -6 10 1817 1626 SP
+8 1 1 2165 1167 SP
+{0.706 0.863 1 C} FS
+8 -1 1 1839 1610 SP
+1688 1496 M
+1 -1 D
+68 23 D
+62 -6 D
+59 18 D
+81 61 D
+24 35 D
+S
+2165 1167 M
+8 1 D
+P S
+1839 1610 M
+8 -1 D
+P S
+1817 1626 M
+6 -6 D
+P S
+542 0 0 542 -542 0 3 2772 1084 SP
+542 0 0 542 -542 0 3 3314 1084 SP
+{0.784 A} FS
+-3 12 -15 -4 6 8 -31 -4 3 9 22 -2 -16 9 25 -6 8 6 9 3016 1092 SP
+-3 12 -15 -4 6 8 -31 -4 3 9 22 -2 -16 9 25 -6 8 6 9 3016 1092 SP
+3016 1092 M
+8 6 D
+25 -6 D
+-16 9 D
+22 -2 D
+3 9 D
+-31 -4 D
+6 8 D
+-15 -4 D
+-3 12 D
+P S
+{0.706 0.863 1 C} FS
+542 0 0 542 -542 0 3 3856 1084 SP
+0 542 -542 0 0 -436 2 0 53 33 36 -2 41 -19 3 -23 -19 -6 -5 -36 23 -39 2 -14 12 4262 1626 SP
+{0.784 A} FS
+0 106 2 0 53 33 36 -2 41 -19 3 -23 -19 -6 -5 -36 23 -39 2 -14 10 4262 1626 SP
+4262 1626 M
+2 -14 D
+23 -39 D
+-5 -36 D
+-19 -6 D
+3 -23 D
+41 -19 D
+36 -2 D
+53 33 D
+2 0 D
+S
+{0.706 0.863 1 C} FS
+4398 1520 M
+96 -1 D
+19 25 D
+47 20 D
+141 22 D
+82 -27 D
+-4 -12 D
+18 -7 D
+22 -39 D
+-11 1 D
+23 -12 D
+-1 13 D
+50 42 D
+-1 15 D
+7 -30 D
+-15 -16 D
+0 -21 D
+-12 0 D
+-4 -10 D
+25 4 D
+9 27 D
+13 -19 D
+-13 -21 D
+21 2 D
+17 -11 D
+6 -9 D
+-3 3 D
+3 -28 D
+7 -7 D
+0 -340 D
+-542 0 D
+P
+FO
+{0.784 A} FS
+-42 1 31 6 2 4859 1463 SP
+4398 1520 M
+96 -1 D
+19 25 D
+47 20 D
+141 22 D
+82 -27 D
+-4 -12 D
+18 -7 D
+22 -39 D
+-11 1 D
+23 -12 D
+-1 13 D
+50 42 D
+-1 15 D
+7 -30 D
+-15 -16 D
+0 -21 D
+-12 0 D
+-4 -10 D
+25 4 D
+9 27 D
+13 -19 D
+-13 -21 D
+21 2 D
+17 -11 D
+6 -9 D
+-3 3 D
+3 -28 D
+7 -7 D
+0 202 D
+-542 0 D
+P
+FO
+-42 1 31 6 2 4859 1463 SP
+4398 1520 M
+96 -1 D
+19 25 D
+47 20 D
+141 22 D
+82 -27 D
+-4 -12 D
+18 -7 D
+22 -39 D
+-11 1 D
+23 -12 D
+-1 13 D
+50 42 D
+-1 15 D
+7 -30 D
+-15 -16 D
+0 -21 D
+-12 0 D
+-4 -10 D
+25 4 D
+9 27 D
+13 -19 D
+-13 -21 D
+21 2 D
+17 -11 D
+6 -9 D
+-3 3 D
+3 -28 D
+7 -7 D
+S
+4859 1463 M
+31 6 D
+-42 1 D
+P S
+{0.706 0.863 1 C} FS
+4940 1424 M
+16 -16 D
+81 -22 D
+37 28 D
+5 -9 D
+-12 -4 D
+22 2 D
+-3 -8 D
+24 -13 D
+-1 8 D
+47 22 D
+-14 -5 D
+6 6 D
+63 10 D
+5 49 D
+18 17 D
+-6 5 D
+16 37 D
+36 29 D
+-5 7 D
+19 30 D
+7 29 D
+181 0 D
+0 -542 D
+-542 0 D
+P
+FO
+{0.784 A} FS
+3 -12 -11 5 22 -26 2 -20 -52 16 -40 -13 -8 38 4 -6 6 34 22 -13 8 25 24 -9 12 5103 1265 SP
+-11 14 9 -3 2 5157 1352 SP
+7 10 1 5133 1262 SP
+-5 11 1 5052 1355 SP
+{0.706 0.863 1 C} FS
+-8 7 1 5110 1273 SP
+1 7 1 5033 1401 SP
+2 10 1 5190 1548 SP
+-1 7 1 5133 1457 SP
+{0.784 A} FS
+4940 1424 M
+16 -16 D
+81 -22 D
+37 28 D
+5 -9 D
+-12 -4 D
+22 2 D
+-3 -8 D
+24 -13 D
+-1 8 D
+47 22 D
+-14 -5 D
+6 6 D
+63 10 D
+5 49 D
+18 17 D
+-6 5 D
+16 37 D
+36 29 D
+-5 7 D
+19 30 D
+7 29 D
+-361 0 D
+P
+FO
+3 -12 -11 5 22 -26 2 -20 -52 16 -40 -13 -8 38 4 -6 6 34 22 -13 8 25 24 -9 12 5103 1265 SP
+-11 14 9 -3 2 5157 1352 SP
+7 10 1 5133 1262 SP
+-5 11 1 5052 1355 SP
+{0.706 0.863 1 C} FS
+-8 7 1 5110 1273 SP
+1 7 1 5033 1401 SP
+2 10 1 5190 1548 SP
+-1 7 1 5133 1457 SP
+4940 1424 M
+16 -16 D
+81 -22 D
+37 28 D
+5 -9 D
+-12 -4 D
+22 2 D
+-3 -8 D
+24 -13 D
+-1 8 D
+47 22 D
+-14 -5 D
+6 6 D
+63 10 D
+5 49 D
+18 17 D
+-6 5 D
+16 37 D
+36 29 D
+-5 7 D
+19 30 D
+7 29 D
+S
+5103 1265 M
+24 -9 D
+8 25 D
+22 -13 D
+6 34 D
+4 -6 D
+-8 38 D
+-40 -13 D
+-52 16 D
+2 -20 D
+22 -26 D
+-11 5 D
+3 -12 D
+P S
+5157 1352 M
+9 -3 D
+-11 14 D
+P S
+5133 1262 M
+7 10 D
+P S
+5052 1355 M
+-5 11 D
+P S
+5110 1273 M
+-8 7 D
+P S
+5033 1401 M
+1 7 D
+P S
+5190 1548 M
+2 10 D
+P S
+5133 1457 M
+-1 7 D
+P S
+542 0 0 542 -542 0 3 6024 1084 SP
+{0.784 A} FS
+5887 1328 M
+-9 -8 D
+17 -9 D
+20 10 D
+29 56 D
+26 2 D
+15 39 D
+-15 4 D
+-23 -14 D
+-30 10 D
+-15 32 D
+3 -20 D
+-25 10 D
+5 14 D
+-15 14 D
+1 18 D
+-6 -5 D
+-19 16 D
+-5 -7 D
+-5 17 D
+-10 -1 D
+37 -53 D
+-4 10 D
+17 -6 D
+-2 -11 D
+-8 5 D
+9 -16 D
+12 0 D
+-11 0 D
+12 -20 D
+-10 -28 D
+-23 -12 D
+35 -18 D
+P
+FO
+5753 1186 M
+21 10 D
+15 51 D
+24 2 D
+-14 11 D
+15 -11 D
+23 2 D
+-12 5 D
+4 14 D
+40 38 D
+1 14 D
+-11 -2 D
+11 8 D
+-30 -9 D
+-15 18 D
+9 4 D
+-23 -9 D
+-37 -61 D
+-42 -24 D
+-23 -1 D
+-38 -30 D
+6 -9 D
+-10 4 D
+-4 -24 D
+27 1 D
+37 -14 D
+P
+FO
+-9 -16 -6 12 2 5699 1162 SP
+6 -4 1 5897 1458 SP
+5 6 1 5856 1330 SP
+{0.706 0.863 1 C} FS
+-9 6 -1 -10 2 5732 1238 SP
+-4 -7 1 5739 1237 SP
+2 -6 1 5679 1197 SP
+9 6 1 5909 1384 SP
+9 -14 1 5711 1225 SP
+-8 -25 1 5768 1259 SP
+-1 -12 1 5759 1254 SP
+10 -9 1 5776 1263 SP
+{0.784 A} FS
+5887 1328 M
+-9 -8 D
+17 -9 D
+20 10 D
+29 56 D
+26 2 D
+15 39 D
+-15 4 D
+-23 -14 D
+-30 10 D
+-15 32 D
+3 -20 D
+-25 10 D
+5 14 D
+-15 14 D
+1 18 D
+-6 -5 D
+-19 16 D
+-5 -7 D
+-5 17 D
+-10 -1 D
+37 -53 D
+-4 10 D
+17 -6 D
+-2 -11 D
+-8 5 D
+9 -16 D
+12 0 D
+-11 0 D
+12 -20 D
+-10 -28 D
+-23 -12 D
+35 -18 D
+P
+FO
+5753 1186 M
+21 10 D
+15 51 D
+24 2 D
+-14 11 D
+15 -11 D
+23 2 D
+-12 5 D
+4 14 D
+40 38 D
+1 14 D
+-11 -2 D
+11 8 D
+-30 -9 D
+-15 18 D
+9 4 D
+-23 -9 D
+-37 -61 D
+-42 -24 D
+-23 -1 D
+-38 -30 D
+6 -9 D
+-10 4 D
+-4 -24 D
+27 1 D
+37 -14 D
+P
+FO
+-9 -16 -6 12 2 5699 1162 SP
+6 -4 1 5897 1458 SP
+5 6 1 5856 1330 SP
+{0.706 0.863 1 C} FS
+-9 6 -1 -10 2 5732 1238 SP
+-4 -7 1 5739 1237 SP
+2 -6 1 5679 1197 SP
+9 6 1 5909 1384 SP
+9 -14 1 5711 1225 SP
+-8 -25 1 5768 1259 SP
+-1 -12 1 5759 1254 SP
+10 -9 1 5776 1263 SP
+5887 1328 M
+-9 -8 D
+17 -9 D
+20 10 D
+29 56 D
+26 2 D
+15 39 D
+-15 4 D
+-23 -14 D
+-30 10 D
+-15 32 D
+3 -20 D
+-25 10 D
+5 14 D
+-15 14 D
+1 18 D
+-6 -5 D
+-19 16 D
+-5 -7 D
+-5 17 D
+-10 -1 D
+37 -53 D
+-4 10 D
+17 -6 D
+-2 -11 D
+-8 5 D
+9 -16 D
+12 0 D
+-11 0 D
+12 -20 D
+-10 -28 D
+-23 -12 D
+35 -18 D
+P S
+5753 1186 M
+21 10 D
+15 51 D
+24 2 D
+-14 11 D
+15 -11 D
+23 2 D
+-12 5 D
+4 14 D
+40 38 D
+1 14 D
+-11 -2 D
+11 8 D
+-30 -9 D
+-15 18 D
+9 4 D
+-23 -9 D
+-37 -61 D
+-42 -24 D
+-23 -1 D
+-38 -30 D
+6 -9 D
+-10 4 D
+-4 -24 D
+27 1 D
+37 -14 D
+P S
+5699 1162 M
+-6 12 D
+-9 -16 D
+P S
+5897 1458 M
+6 -4 D
+P S
+5856 1330 M
+5 6 D
+P S
+5732 1238 M
+-1 -10 D
+-9 6 D
+P S
+5739 1237 M
+-4 -7 D
+P S
+5679 1197 M
+2 -6 D
+P S
+5909 1384 M
+9 6 D
+P S
+5711 1225 M
+9 -14 D
+P S
+5768 1259 M
+-8 -25 D
+P S
+5759 1254 M
+-1 -12 D
+P S
+5776 1263 M
+10 -9 D
+P S
+542 0 0 542 -542 0 3 6566 1084 SP
+{0.784 A} FS
+-16 0 12 7 2 6115 1247 SP
+-16 0 12 7 2 6115 1247 SP
+6115 1247 M
+12 7 D
+-16 0 D
+P S
+{0.706 0.863 1 C} FS
+543 0 0 542 -543 0 3 7109 1084 SP
+91 0 0 542 -91 0 3 7200 1084 SP
+-62 0 0 -542 62 0 3 0 1626 SP
+542 0 0 542 -542 0 3 604 1084 SP
+542 0 0 542 -542 0 3 1146 1084 SP
+1451 542 M
+-76 4 D
+-11 -4 D
+-62 0 D
+-1 0 D
+-1 0 D
+-107 0 D
+-23 3 D
+-8 -3 D
+-10 0 D
+-6 11 D
+0 531 D
+542 0 D
+0 -535 D
+-1 1 D
+-25 -8 D
+-35 9 D
+-59 -5 D
+-20 11 D
+-49 -15 D
+P
+FO
+{0.784 A} FS
+0 -11 -6 11 2 1152 542 SP
+-8 -3 -23 3 2 1193 542 SP
+-1 0 -1 0 2 1302 542 SP
+-11 -4 -76 4 2 1451 542 SP
+189 0 -49 -15 -20 11 -59 -5 -35 9 -25 -8 -1 1 7 1688 549 SP
+1688 549 M
+-1 1 D
+-25 -8 D
+-35 9 D
+-59 -5 D
+-20 11 D
+-49 -15 D
+S
+1152 542 M
+-6 11 D
+S
+1451 542 M
+-76 4 D
+-11 -4 D
+S
+1302 542 M
+-1 0 D
+-1 0 D
+S
+1193 542 M
+-23 3 D
+-8 -3 D
+S
+{0.706 0.863 1 C} FS
+-26 -32 -4 -1 0 -509 542 0 0 535 -55 7 -120 0 -194 -37 -93 28 -27 -11 21 12 -35 8 12 2191 542 SP
+{0.784 A} FS
+0 -7 -55 7 2 1743 542 SP
+-194 -37 -93 28 -27 -11 21 12 -35 8 5 2191 542 SP
+30 0 -26 -32 -4 -1 3 2230 575 SP
+2191 542 M
+-35 8 D
+21 12 D
+-27 -11 D
+-93 28 D
+-194 -37 D
+S
+2230 575 M
+-4 -1 D
+-26 -32 D
+S
+1743 542 M
+-55 7 D
+S
+{0.706 0.863 1 C} FS
+542 0 0 509 -170 -31 -4 -10 -55 8 -22 -6 25 -9 -23 -5 -46 10 13 -23 -92 -14 -49 5 -44 14 8 14 -59 11 -24 0 16 2772 611 SP
+{0.784 A} FS
+542 0 0 -33 -170 -31 -4 -10 -55 8 -22 -6 25 -9 -23 -5 -46 10 13 -23 -92 -14 -49 5 -44 14 8 14 -59 11 -24 0 16 2772 611 SP
+2772 611 M
+-24 0 D
+-59 11 D
+8 14 D
+-44 14 D
+-49 5 D
+-92 -14 D
+13 -23 D
+-46 10 D
+-23 -5 D
+25 -9 D
+-22 -6 D
+-55 8 D
+-4 -10 D
+-170 -31 D
+S
+{0.706 0.863 1 C} FS
+542 0 0 473 -260 8 -21 26 -64 -2 -42 19 16 11 -23 0 -91 -18 -24 -23 -33 -5 11 3314 595 SP
+{0.784 A} FS
+16 -3 1 3131 1003 SP
+542 0 0 -69 -260 8 -21 26 -64 -2 -42 19 16 11 -23 0 -91 -18 -24 -23 -33 -5 11 3314 595 SP
+16 -3 1 3131 1003 SP
+3131 1003 M
+16 -3 D
+P S
+3314 595 M
+-33 -5 D
+-24 -23 D
+-91 -18 D
+-23 0 D
+16 11 D
+-42 19 D
+-64 -2 D
+-21 26 D
+-260 8 D
+S
+{0.706 0.863 1 C} FS
+542 0 0 489 -34 -6 -13 -14 -75 -9 12 -8 -54 -10 -95 15 -66 -10 -64 4 -33 -13 1 -25 -23 -7 -43 20 -55 0 15 3856 658 SP
+{0.784 A} FS
+542 0 0 -53 -34 -6 -13 -14 -75 -9 12 -8 -54 -10 -95 15 -66 -10 -64 4 -33 -13 1 -25 -23 -7 -43 20 -55 0 15 3856 658 SP
+3856 658 M
+-55 0 D
+-43 20 D
+-23 -7 D
+1 -25 D
+-33 -13 D
+-64 4 D
+-66 -10 D
+-95 15 D
+-54 -10 D
+12 -8 D
+-75 -9 D
+-13 -14 D
+-34 -6 D
+S
+{0.706 0.863 1 C} FS
+542 0 0 426 -7 0 -18 -9 -44 13 -10 -20 -29 11 2 12 -132 26 -53 -12 -5 -12 -63 -8 -33 19 -86 15 -64 -2 15 4398 625 SP
+{0.784 A} FS
+542 0 0 -116 -7 0 -18 -9 -44 13 -10 -20 -29 11 2 12 -132 26 -53 -12 -5 -12 -63 -8 -33 19 -86 15 -64 -2 15 4398 625 SP
+4398 625 M
+-64 -2 D
+-86 15 D
+-33 19 D
+-63 -8 D
+-5 -12 D
+-53 -12 D
+-132 26 D
+2 12 D
+-29 11 D
+-10 -20 D
+-44 13 D
+-18 -9 D
+-7 0 D
+S
+{0.706 0.863 1 C} FS
+542 0 0 459 -19 -1 -37 -10 -14 8 -48 -9 -14 6 -38 -13 -68 22 -43 -25 -116 -4 -145 19 12 4940 632 SP
+{0.784 A} FS
+542 0 0 -83 -19 -1 -37 -10 -14 8 -48 -9 -14 6 -38 -13 -68 22 -43 -25 -116 -4 -145 19 12 4940 632 SP
+4940 632 M
+-145 19 D
+-116 -4 D
+-43 -25 D
+-68 22 D
+-38 -13 D
+-14 6 D
+-48 -9 D
+-14 8 D
+-37 -10 D
+-19 -1 D
+S
+{0.706 0.863 1 C} FS
+542 0 0 452 -68 9 -28 -5 -32 11 -41 -15 26 23 -67 22 -86 0 -14 8 -66 -10 -42 18 -118 16 -6 3 14 5482 552 SP
+{0.784 A} FS
+542 0 0 -90 -68 9 -28 -5 -32 11 -41 -15 26 23 -67 22 -86 0 -14 8 -66 -10 -42 18 -118 16 -6 3 14 5482 552 SP
+5482 552 M
+-6 3 D
+-118 16 D
+-42 18 D
+-66 -10 D
+-14 8 D
+-86 0 D
+-67 22 D
+26 23 D
+-41 -15 D
+-32 11 D
+-28 -5 D
+-68 9 D
+S
+{0.706 0.863 1 C} FS
+0 -542 542 0 0 532 -16 10 4 5498 542 SP
+{0.784 A} FS
+6 9 1 5645 1061 SP
+0 -10 -16 10 2 5498 542 SP
+6 9 1 5645 1061 SP
+5645 1061 M
+6 9 D
+P S
+5498 542 M
+-16 10 D
+S
+{0.706 0.863 1 C} FS
+542 0 0 542 -542 0 3 6566 542 SP
+543 0 0 542 -543 0 3 7109 542 SP
+91 0 0 542 -91 0 3 7200 542 SP
+-62 0 0 -542 62 0 3 0 1084 SP
+542 0 0 542 -542 0 3 604 542 SP
+{0.784 A} FS
+-38 3 -17 18 2 170 954 SP
+-38 3 -17 18 2 170 954 SP
+170 954 M
+-17 18 D
+-38 3 D
+P S
+{0.706 0.863 1 C} FS
+542 0 0 542 -497 0 -22 -5 -23 -6 5 1146 553 SP
+{0.784 A} FS
+45 0 -22 -5 -23 -6 3 1146 553 SP
+1146 553 M
+-23 -6 D
+-22 -5 D
+S
+{0.706 0.863 1 C} FS
+-2 3 -8 -3 2 1162 542 SP
+-63 8 -44 -8 2 1300 542 SP
+-45 6 -17 -6 2 1364 542 SP
+-42 2 -6 -2 2 1499 542 SP
+{0.784 A} FS
+1499 542 M
+-6 -2 D
+-42 2 D
+-87 0 D
+-17 -6 D
+-47 6 D
+-44 -8 D
+-63 8 D
+-31 0 D
+-8 -3 D
+-2 3 D
+-6 0 D
+0 -542 D
+542 0 D
+0 542 D
+P
+FO
+1499 542 M
+-6 -2 D
+-42 2 D
+S
+1364 542 M
+-17 -6 D
+-45 6 D
+S
+1300 542 M
+-44 -8 D
+-63 8 D
+S
+1162 542 M
+-8 -3 D
+-2 3 D
+S
+{0.706 0.863 1 C} FS
+-70 9 -50 -9 2 1863 542 SP
+-7 1 -2 -1 2 2200 542 SP
+{0.784 A} FS
+0 542 542 0 0 -542 -55 0 -70 9 -50 -9 -328 0 -7 1 -2 -1 9 2200 542 SP
+2200 542 M
+-2 -1 D
+-7 1 D
+S
+1863 542 M
+-50 -9 D
+-70 9 D
+S
+-542 0 0 542 542 0 3 2230 0 SP
+-542 0 0 542 542 0 3 2772 0 SP
+-542 0 0 542 542 0 3 3314 0 SP
+-542 0 0 542 542 0 3 3856 0 SP
+-542 0 0 542 542 0 3 4398 0 SP
+-542 0 0 542 542 0 3 4940 0 SP
+{0.706 0.863 1 C} FS
+6024 330 M
+-360 18 D
+4 -20 D
+-66 -5 D
+-58 31 D
+7 39 D
+89 1 D
+-88 6 D
+40 17 D
+38 -1 D
+-17 15 D
+39 0 D
+9 14 D
+70 3 D
+16 34 D
+33 10 D
+-19 15 D
+-3 -10 D
+-94 28 D
+-152 9 D
+-14 8 D
+526 0 D
+P
+FO
+{0.784 A} FS
+6024 330 M
+-360 18 D
+4 -20 D
+-66 -5 D
+-58 31 D
+7 39 D
+89 1 D
+-88 6 D
+40 17 D
+38 -1 D
+-17 15 D
+39 0 D
+9 14 D
+70 3 D
+16 34 D
+33 10 D
+-19 15 D
+-3 -10 D
+-94 28 D
+-152 9 D
+-14 8 D
+-16 0 D
+0 -542 D
+542 0 D
+P
+FO
+6024 330 M
+-360 18 D
+4 -20 D
+-66 -5 D
+-58 31 D
+7 39 D
+89 1 D
+-88 6 D
+40 17 D
+38 -1 D
+-17 15 D
+39 0 D
+9 14 D
+70 3 D
+16 34 D
+33 10 D
+-19 15 D
+-3 -10 D
+-94 28 D
+-152 9 D
+-14 8 D
+S
+{0.706 0.863 1 C} FS
+542 0 0 212 -26 1 -70 12 -358 8 -88 -14 6 6566 323 SP
+{0.784 A} FS
+542 0 0 -330 -26 1 -70 12 -358 8 -88 -14 6 6566 323 SP
+6566 323 M
+-88 -14 D
+-358 8 D
+-70 12 D
+-26 1 D
+S
+{0.706 0.863 1 C} FS
+543 0 0 219 -37 -6 -12 -21 -172 8 -94 -44 -77 -11 -127 5 -24 -4 9 7109 396 SP
+{0.784 A} FS
+543 0 0 -323 -37 -6 -12 -21 -172 8 -94 -44 -77 -11 -127 5 -24 -4 9 7109 396 SP
+7109 396 M
+-24 -4 D
+-127 5 D
+-77 -11 D
+-94 -44 D
+-172 8 D
+-12 -21 D
+-37 -6 D
+S
+{0.706 0.863 1 C} FS
+91 0 0 146 -91 -17 3 7200 413 SP
+{0.784 A} FS
+91 0 0 -396 -91 -17 3 7200 413 SP
+7200 413 M
+-91 -17 D
+S
+{0.706 0.863 1 C} FS
+-62 2 0 -219 62 0 3 0 542 SP
+{0.784 A} FS
+62 0 0 -325 -62 2 3 62 323 SP
+62 323 M
+-62 2 D
+0 0 D S
+{0.706 0.863 1 C} FS
+542 0 0 219 -107 4 -63 -25 -192 -33 28 -13 -66 -13 12 -28 -49 -7 -49 12 -56 -31 11 604 457 SP
+{0.784 A} FS
+542 0 0 -323 -107 4 -63 -25 -192 -33 28 -13 -66 -13 12 -28 -49 -7 -49 12 -56 -31 11 604 457 SP
+604 457 M
+-56 -31 D
+-49 12 D
+-49 -7 D
+12 -28 D
+-66 -13 D
+28 -13 D
+-192 -33 D
+-63 -25 D
+-107 4 D
+S
+{0.706 0.863 1 C} FS
+0 85 -23 -13 -169 -17 -18 -20 -95 -21 -144 -2 -47 -12 -1 0 8 1101 542 SP
+{0.784 A} FS
+0 542 542 0 0 -457 -23 -13 -169 -17 -18 -20 -95 -21 -144 -2 -47 -12 -1 0 10 1101 542 SP
+1101 542 M
+-48 -12 D
+-144 -2 D
+-95 -21 D
+-18 -20 D
+-169 -17 D
+-23 -13 D
+S
+PSL_cliprestore
+25 W
+8 W
+N 1146 0 M 0 -83 D S
+N 1146 4878 M 0 84 D S
+N 2772 0 M 0 -83 D S
+N 2772 4878 M 0 84 D S
+N 4398 0 M 0 -83 D S
+N 4398 4878 M 0 84 D S
+N 6024 0 M 0 -83 D S
+N 6024 4878 M 0 84 D S
+N 0 813 M -83 0 D S
+N 7200 813 M 83 0 D S
+N 0 2439 M -83 0 D S
+N 7200 2439 M 83 0 D S
+N 0 4065 M -83 0 D S
+N 7200 4065 M 83 0 D S
+83 W
+N -42 0 M 0 407 D S
+N 7242 0 M 0 407 D S
+1 A
+N -42 407 M 0 406 D S
+N 7242 407 M 0 406 D S
+0 A
+N -42 813 M 0 407 D S
+N 7242 813 M 0 407 D S
+1 A
+N -42 1220 M 0 406 D S
+N 7242 1220 M 0 406 D S
+0 A
+N -42 1626 M 0 407 D S
+N 7242 1626 M 0 407 D S
+1 A
+N -42 2033 M 0 406 D S
+N 7242 2033 M 0 406 D S
+0 A
+N -42 2439 M 0 407 D S
+N 7242 2439 M 0 407 D S
+1 A
+N -42 2846 M 0 406 D S
+N 7242 2846 M 0 406 D S
+0 A
+N -42 3252 M 0 407 D S
+N 7242 3252 M 0 407 D S
+1 A
+N -42 3659 M 0 406 D S
+N 7242 3659 M 0 406 D S
+0 A
+N -42 4065 M 0 407 D S
+N 7242 4065 M 0 407 D S
+1 A
+N -42 4472 M 0 406 D S
+N 7242 4472 M 0 406 D S
+N 0 -42 M 333 0 D S
+N 0 4920 M 333 0 D S
+0 A
+N 333 -42 M 406 0 D S
+N 333 4920 M 406 0 D S
+1 A
+N 739 -42 M 407 0 D S
+N 739 4920 M 407 0 D S
+0 A
+N 1146 -42 M 407 0 D S
+N 1146 4920 M 407 0 D S
+1 A
+N 1553 -42 M 406 0 D S
+N 1553 4920 M 406 0 D S
+0 A
+N 1959 -42 M 407 0 D S
+N 1959 4920 M 407 0 D S
+1 A
+N 2366 -42 M 406 0 D S
+N 2366 4920 M 406 0 D S
+0 A
+N 2772 -42 M 407 0 D S
+N 2772 4920 M 407 0 D S
+1 A
+N 3179 -42 M 406 0 D S
+N 3179 4920 M 406 0 D S
+0 A
+N 3585 -42 M 407 0 D S
+N 3585 4920 M 407 0 D S
+1 A
+N 3992 -42 M 406 0 D S
+N 3992 4920 M 406 0 D S
+0 A
+N 4398 -42 M 407 0 D S
+N 4398 4920 M 407 0 D S
+1 A
+N 4805 -42 M 406 0 D S
+N 4805 4920 M 406 0 D S
+0 A
+N 5211 -42 M 407 0 D S
+N 5211 4920 M 407 0 D S
+1 A
+N 5618 -42 M 406 0 D S
+N 5618 4920 M 406 0 D S
+0 A
+N 6024 -42 M 407 0 D S
+N 6024 4920 M 407 0 D S
+1 A
+N 6431 -42 M 407 0 D S
+N 6431 4920 M 407 0 D S
+0 A
+N 6838 -42 M 362 0 D S
+N 6838 4920 M 362 0 D S
+8 W
+N -83 0 M 7366 0 D S
+N -83 -83 M 7366 0 D S
+N 7200 -83 M 0 5045 D S
+N 7283 -83 M 0 5045 D S
+N 7283 4878 M -7366 0 D S
+N 7283 4962 M -7366 0 D S
+N 0 4962 M 0 -5045 D S
+N -83 4962 M 0 -5045 D S
+1146 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0°) tc Z
+2772 -167 M (60°) tc Z
+4398 -167 M (120°) tc Z
+6024 -167 M (180°) tc Z
+-167 813 M (-60°) mr Z
+-167 2439 M (0°) mr Z
+-167 4065 M (60°) mr Z
+%%EndObject
+
+grestore
+PSL_movie_completion /PSL_movie_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/pscoast/pscoast_JQ.sh
+++ b/test/pscoast/pscoast_JQ.sh
@@ -6,4 +6,4 @@
 
 ps=pscoast_JQ.ps
 
-gmt pscoast -JQ200/6i -R-42.2839/223.375/-90/90 -BWeSn -Baf -Dc -S180/220/255 -P > $ps
+gmt pscoast -JQ200/6i -R-42.2839/223.375/-90/90 -BWeSn -Baf -Dc -S180/220/255 -G200 -Wfaint -P > $ps


### PR DESCRIPTION
A 2016 longitude wrap fix should only apply for global maps (360-degree range) only.  Adding a test that now passes. Closes #1759.
