### PR TITLE
Remove GMT_KNOWN_FAILURE from pscoast_JQ.sh

### DIFF
--- a/test/pscoast/pscoast_JQ.sh
+++ b/test/pscoast/pscoast_JQ.sh
@@ -2,7 +2,6 @@
 #
 # Problem is https://github.com/GenericMappingTools/gmt/issues/1759
 # Can test with -+83 for a single square
-# GMT_KNOWN_FAILURE
 
 ps=pscoast_JQ.ps
 


### PR DESCRIPTION
pscoast_JQ.sh now passes after #1773 was merged.