### PR TITLE
Use -l auto-legend in batch scripts

### DIFF
--- a/doc/examples/ex03/ex03.bat
+++ b/doc/examples/ex03/ex03.bat
@@ -44,15 +44,13 @@ gmt begin ex03
 	REM Now to do the cross-spectra, assuming that the ship is the input and the sat is the output
 	REM data, we do this:
 	gmt convert -A samp_ship.pg samp_sat.pg -o1,3 | gmt spectrum1d -S256 -D1 -W -C -T
-	REM Time to plot spectra
+	REM Time to plot spectra, use -l to build a legend
 	gmt set FONT_TAG 18p,Helvetica-Bold
 	gmt subplot begin 2x1 -M0.1i -SCb+l"Wavelength (km)" -T"Ship and Satellite Gravity" -Fs4i/3.75i -A+jTR+o0.1i -BWeSn+g240/255/240 -X2i -Y1.5i
 		gmt subplot set 0,0 -A"Input Power"
-		gmt plot spectrum.xpower -JX-?l/?l -Bxa1f3p -Bya1f3p+l"Power (mGal@+2@+km)" -Gred -ST0.07i -R1/1000/0.1/10000 -Ey+p0.5p
-		gmt plot spectrum.ypower -Gblue -Sc0.07i -Ey+p0.5p
-		echo S 0.1i T 0.07i red  - 0.3i Ship		> legend.txt
-		echo S 0.1i c 0.07i blue - 0.3i Satellite	>> legend.txt
-		gmt legend legend.txt -DjBL+w1.2i+o0.25i -F+gwhite+pthicker --FONT_ANNOT_PRIMARY=14p,Helvetica-Bold
+		gmt plot spectrum.xpower -JX-?l/?l -Bxa1f3p -Bya1f3p+l"Power (mGal@+2@+km)" -Gred -ST0.07i -R1/1000/0.1/10000 -Ey+p0.5p -lShip
+		gmt plot spectrum.ypower -Gblue -Sc0.07i -Ey+p0.5p -lSatellite
+		gmt legend -DjBL+w1.2i+o0.25i -F+gwhite+pthicker --FONT_ANNOT_PRIMARY=14p,Helvetica-Bold
 		gmt subplot set 1,0 -A"Coherency@+2@+"
 		gmt plot spectrum.coh -JX-?l/? -Bxa1f3p -Bya0.25f0.05+l"Coherency@+2@+" -R1/1000/0/1 -Sc0.07i -Gpurple -Ey+p0.5p
 	gmt subplot end

--- a/doc/examples/ex07/ex07.bat
+++ b/doc/examples/ex07/ex07.bat
@@ -6,10 +6,10 @@ REM
 gmt begin ex07
 	gmt coast -R-50/0/-10/20 -JM9i -Slightblue -GP26+r300+ftan+bdarkbrown -Dl -Wthinnest -B --FORMAT_GEO_MAP=dddF
 	gmt plot @fz_07.txt -Wthinner,-
-	gmt plot @quakes_07.txt -h1 -Sci -i0,1,2+s0.01 -Gred -Wthinnest
+	gmt plot @quakes_07.txt -h1 -Sci -i0,1,2+s0.01 -Gred -Wthinnest -l"ISC Earthquakes"+s0.08i
 	gmt plot @isochron_07.txt -Wthin,blue
 	gmt plot @ridge_07.txt -Wthicker,orange
-	echo S 0.1i c 0.08i red thinnest 0.3i ISC Earthquakes | gmt legend -DjTR+w2.2i+o0.2i -F+pthick+ithinner+gwhite --FONT_ANNOT_PRIMARY=18p,Times-Italic
+	gmt legend -DjTR+w2i+o0.2i -F+pthick+ithinner+gwhite --FONT_ANNOT_PRIMARY=18p,Times-Italic
 	echo -43 -5 SOUTH	>  tmp
 	echo -43 -8 AMERICA >> tmp
 	echo -7 11 AFRICA	>> tmp


### PR DESCRIPTION
Update ex03.bat and ex07.bat batch scripts to use the new -l auto-legend feature.