### PR TITLE
ci: disable Windows batch scripts in CI

### DIFF
--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -123,6 +123,7 @@ steps:
     set GMT_END_SHOW=off && call do_examples.bat
   displayName: Run DOS batch examples
   condition: eq(variables['TEST'], true)
+  enabled: false
 
 # Publish the whole build directory for debugging purpose
 - task: CopyFiles@2


### PR DESCRIPTION
Don't know why but running these batch scripts take forever.
Disable them temporarily.