### PR TITLE
Move docs build and deployment back to scheduled jobs

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -35,8 +35,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Linux | Build docs + Deploy docs + Package'
-  #condition: eq(variables['Build.Reason'], 'Schedule')
-  condition: in(variables['Build.SourceBranchName'], 'master', '6.0')
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'ubuntu-16.04'


### PR DESCRIPTION
We have almost finished the documentation redesign, and we don't expect
to update the documentations too often. Thus no need to build and deploy
the documentations for every commit.

This PR moves the documentation build & deployment back to scheduled daily jobs.