### PR TITLE
Repurpose movie -W to set working directory

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -220,8 +220,8 @@ Optional Arguments
 .. _-W:
 
 **-W**\ *workdir*
-    In addition to the current directory, the *prefix* directory, and any directories specified via the
-    GMT defaults setting :ref:`DIR_DATA <DIR_DATA>`, add *workdir* as a place to scan for data files needed by the scripts.
+    By default, all temporary files and frame PNG file are built in the subdirectory *prefix* set via **-N**.
+    You can override that by giving another *workdir* as a relative or full directory path.
 
 .. _-Z:
 
@@ -266,8 +266,7 @@ Data Files
 The movie scripts will be able to find any files present in the starting directory when **movie** was initiated,
 as well as any new files produced by *mainscript* or the optional scripts set via **-S**.
 No path specification is needed to access these files.  Other files may
-require full paths unless their directories were already included in the :ref:`DIR_DATA <DIR_DATA>` setting
-or specified via **-W**.
+require full paths unless their directories were already included in the :ref:`DIR_DATA <DIR_DATA>` setting.
 
 Your Canvas
 -----------

--- a/src/movie.c
+++ b/src/movie.c
@@ -1085,19 +1085,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		sprintf (datadir, "%s,%s,%s", topdir, cwd, GMT->session.DATADIR);	/* Start with topdir */
 	else	/* Set the initial and prefix subdirectory as data dirs */
 		sprintf (datadir, "%s,%s", topdir, cwd);
-	if (Ctrl->W.active && strlen (Ctrl->W.dir) > 2) {	/* Also append a specific work directory with data files that we should search */
-		char work_dir[PATH_MAX] = {""};
-#ifdef WIN32
-		if (Ctrl->W.dir[1] != ':') /* Not hard path */
-#else
-		if (Ctrl->W.dir[0] != '/') /* Not hard path */
-#endif
-			/* Prepend cwd to the given relative path and update Ctrl->D.dir */
-			sprintf (work_dir, ",%s,%s", topdir, Ctrl->W.dir);
-		else
-			sprintf (work_dir, ",%s", Ctrl->W.dir);
-		strcat (datadir, work_dir);
-	}
+
 	gmt_replace_backslash_in_path (datadir);	/* Since we will be fprintf the path we must use // for a slash */
 	
 	/* Create the initialization file with settings common to all frames */
@@ -1518,7 +1506,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		rewind (Ctrl->In.fp);	/* Get ready for main_frame reading */
 		set_comment (fp, Ctrl->In.mode, "Move master file up to top directory and cd up one level");
 		fprintf (fp, "%s %s.%s %s\n", mvfile[Ctrl->In.mode], Ctrl->N.prefix, Ctrl->M.format, topdir);	/* Move master plot up to top dir */
-		fprintf (fp, "cd ..\n");	/* cd up to prefix dir */
+		fprintf (fp, "cd ..\n");	/* cd up to workdir */
 		if (!Ctrl->Q.active) {	/* Remove the work dir and any files in it */
 			set_comment (fp, Ctrl->In.mode, "Remove frame directory");
 			fprintf (fp, "%s master\n", rmdir[Ctrl->In.mode]);

--- a/src/movie.c
+++ b/src/movie.c
@@ -155,7 +155,7 @@ struct MOVIE_CTRL {
 		unsigned int precision;
 		char *file;
 	} T;
-	struct MOVIE_W {	/* -W<dir> */
+	struct MOVIE_W {	/* -W<workingdirectory> */
 		bool active;
 		char *dir;
 	} W;
@@ -453,8 +453,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   -Sf Append name of foreground GMT modern mode script which will\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t       build a static foreground plot overlay appended to all frames.\n");
 	GMT_Option (API, "V");
-	GMT_Message (API, GMT_TIME_NONE, "\t-W Add the given <workdir> to the search path where data files may be found.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   [Default searches current dir, <prefix> dir, and directories set via DIR_DATA].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-W Give <workdir> where temporary files will be built [<workdir> = <prefix> set by -N].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Z Erase directory <prefix> after converting to movie [leave directory with PNGs alone].\n");
 	GMT_Option (API, "f");
 	/* Number of threads (repurposed from -x in GMT_Option since this local option is always available and not using OpenMP) */
@@ -929,7 +928,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	char init_file[PATH_MAX] = {""}, state_tag[GMT_LEN16] = {""}, state_prefix[GMT_LEN64] = {""}, param_file[PATH_MAX] = {""}, cwd[PATH_MAX] = {""};
 	char pre_file[PATH_MAX] = {""}, post_file[PATH_MAX] = {""}, main_file[PATH_MAX] = {""}, line[PATH_MAX] = {""}, version[GMT_LEN32] = {""};
 	char string[GMT_LEN128] = {""}, extra[GMT_LEN256] = {""}, cmd[GMT_LEN256] = {""}, cleanup_file[PATH_MAX] = {""}, L_txt[GMT_LEN128] = {""};
-	char png_file[PATH_MAX] = {""}, topdir[PATH_MAX] = {""}, datadir[PATH_MAX] = {""}, frame_products[GMT_LEN32] = {MOVIE_RASTER_FORMAT};
+	char png_file[PATH_MAX] = {""}, topdir[PATH_MAX] = {""}, workdir[PATH_MAX] = {""}, datadir[PATH_MAX] = {""}, frame_products[GMT_LEN32] = {MOVIE_RASTER_FORMAT};
 	char dir_sep = '/';
 	double percent = 0.0, L_col = 0;
 	
@@ -1047,7 +1046,12 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			Return (GMT_RUNTIME_ERROR);
 		}
 	}
-	
+
+	if (Ctrl->W.active)
+		strcpy (workdir, Ctrl->W.dir);
+	else
+		strcpy (workdir, Ctrl->N.prefix);
+
 	/* Get full path to the current working directory */
 	if (getcwd (topdir, PATH_MAX) == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Unable to determine current working directory - exiting.\n");
@@ -1056,15 +1060,15 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	}
 	
 	/* Create a working directory which will house every local file and all subdirectories created */
-	if (gmt_mkdir (Ctrl->N.prefix)) {
-		GMT_Report (API, GMT_MSG_NORMAL, "An old directory named %s exists OR we were unable to create new working directory %s - exiting.\n", Ctrl->N.prefix, Ctrl->N.prefix);
+	if (gmt_mkdir (workdir)) {
+		GMT_Report (API, GMT_MSG_NORMAL, "An old directory named %s exists OR we were unable to create new working directory %s - exiting.\n", workdir, workdir);
 		close_files (Ctrl);
 		Return (GMT_RUNTIME_ERROR);
 	}
 	/* Make this directory the current working directory */
-	if (chdir (Ctrl->N.prefix)) {
-		GMT_Report (API, GMT_MSG_NORMAL, "Unable to change directory to %s - exiting.\n", Ctrl->N.prefix);
-		perror (Ctrl->N.prefix);
+	if (chdir (workdir)) {
+		GMT_Report (API, GMT_MSG_NORMAL, "Unable to change directory to %s - exiting.\n", workdir);
+		perror (workdir);
 		close_files (Ctrl);
 		Return (GMT_RUNTIME_ERROR);
 	}
@@ -1513,7 +1517,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		}
 		rewind (Ctrl->In.fp);	/* Get ready for main_frame reading */
 		set_comment (fp, Ctrl->In.mode, "Move master file up to top directory and cd up one level");
-		fprintf (fp, "%s %s.%s ..%c..\n", mvfile[Ctrl->In.mode], Ctrl->N.prefix, Ctrl->M.format, dir_sep);	/* Move master plot up to parent dir */
+		fprintf (fp, "%s %s.%s %s\n", mvfile[Ctrl->In.mode], Ctrl->N.prefix, Ctrl->M.format, topdir);	/* Move master plot up to top dir */
 		fprintf (fp, "cd ..\n");	/* cd up to prefix dir */
 		if (!Ctrl->Q.active) {	/* Remove the work dir and any files in it */
 			set_comment (fp, Ctrl->In.mode, "Remove frame directory");
@@ -1546,16 +1550,16 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		}
 		if (Ctrl->M.exit) {	/* Well, we are done */
 			fclose (Ctrl->In.fp);
-			/* Cd back up to the parent directory */
-			if (chdir ("..")) {	/* Should never happen but we do check */
-				GMT_Report (API, GMT_MSG_NORMAL, "Unable to change directory to parent directory - exiting.\n");
-				perror (Ctrl->N.prefix);
+			/* Cd back up to the starting directory */
+			if (chdir (topdir)) {	/* Should never happen but we do check */
+				GMT_Report (API, GMT_MSG_NORMAL, "Unable to change directory to starting directory - exiting.\n");
+				perror (topdir);
 				Return (GMT_RUNTIME_ERROR);
 			}
 			if (!Ctrl->Q.active) {	/* Delete the entire directory */
-				sprintf (line, "%s %s\n", rmdir[Ctrl->In.mode], Ctrl->N.prefix);
+				sprintf (line, "%s %s\n", rmdir[Ctrl->In.mode], workdir);
 				if ((error = system (line))) {
-					GMT_Report (API, GMT_MSG_NORMAL, "Deleting the prefix directory %s returned error %d.\n", Ctrl->N.prefix, error);
+					GMT_Report (API, GMT_MSG_NORMAL, "Deleting the working directory %s returned error %d.\n", workdir, error);
 					Return (GMT_RUNTIME_ERROR);
 				}
 			}
@@ -1689,9 +1693,9 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	gmt_M_free (GMT, status);	/* Done with this structure array */
 	
 	/* Cd back up to the parent directory */
-	if (chdir ("..")) {	/* Should never happen but we should check */
-		GMT_Report (API, GMT_MSG_NORMAL, "Unable to change directory to parent directory - exiting.\n");
-		perror (Ctrl->N.prefix);
+	if (chdir (topdir)) {	/* Should never happen but we should check */
+		GMT_Report (API, GMT_MSG_NORMAL, "Unable to change directory to starting directory - exiting.\n");
+		perror (topdir);
 		Return (GMT_RUNTIME_ERROR);
 	}
 
@@ -1714,7 +1718,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			else if (Ctrl->A.stride > 10)
 				strcat (files, "0");
 		}
-		sprintf (cmd, "gm convert -delay %u -loop %u +dither %s%c%s_%s.%s %s.gif", delay, Ctrl->A.loops, Ctrl->N.prefix, dir_sep, Ctrl->N.prefix, files, MOVIE_RASTER_FORMAT, Ctrl->N.prefix);
+		sprintf (cmd, "gm convert -delay %u -loop %u +dither %s%c%s_%s.%s %s.gif", delay, Ctrl->A.loops, workdir, dir_sep, Ctrl->N.prefix, files, MOVIE_RASTER_FORMAT, Ctrl->N.prefix);
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Running: %s\n", cmd);
 		if ((error = system (cmd))) {
 			GMT_Report (API, GMT_MSG_NORMAL, "Running GIF conversion returned error %d - exiting.\n", error);
@@ -1735,7 +1739,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			sprintf (extra, "quiet");
 		sprintf (png_file, "%%0%dd", precision);
 		sprintf (cmd, "ffmpeg -loglevel %s -f image2 -framerate %g -y -i \"%s%c%s_%s.%s\" -vcodec libx264 %s -pix_fmt yuv420p %s.mp4",
-			extra, Ctrl->D.framerate, Ctrl->N.prefix, dir_sep, Ctrl->N.prefix, png_file, MOVIE_RASTER_FORMAT, (Ctrl->F.options[MOVIE_MP4]) ? Ctrl->F.options[MOVIE_MP4] : "", Ctrl->N.prefix);
+			extra, Ctrl->D.framerate, workdir, dir_sep, Ctrl->N.prefix, png_file, MOVIE_RASTER_FORMAT, (Ctrl->F.options[MOVIE_MP4]) ? Ctrl->F.options[MOVIE_MP4] : "", Ctrl->N.prefix);
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Running: %s\n", cmd);
 		if ((error = system (cmd))) {
 			GMT_Report (API, GMT_MSG_NORMAL, "Running ffmpeg conversion to MP4 returned error %d - exiting.\n", error);
@@ -1755,7 +1759,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			sprintf (extra, "quiet");
 		sprintf (png_file, "%%0%dd", precision);
 		sprintf (cmd, "ffmpeg -loglevel %s -f image2 -framerate %g -y -i \"%s%c%s_%s.%s\" -vcodec libvpx %s -pix_fmt yuv420p %s.webm",
-			extra, Ctrl->D.framerate, Ctrl->N.prefix, dir_sep, Ctrl->N.prefix, png_file, MOVIE_RASTER_FORMAT, (Ctrl->F.options[MOVIE_WEBM]) ? Ctrl->F.options[MOVIE_WEBM] : "", Ctrl->N.prefix);
+			extra, Ctrl->D.framerate, workdir, dir_sep, Ctrl->N.prefix, png_file, MOVIE_RASTER_FORMAT, (Ctrl->F.options[MOVIE_WEBM]) ? Ctrl->F.options[MOVIE_WEBM] : "", Ctrl->N.prefix);
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Running: %s\n", cmd);
 		if ((error = system (cmd))) {
 			GMT_Report (API, GMT_MSG_NORMAL, "Running ffmpeg conversion to webM returned error %d - exiting.\n", error);
@@ -1772,8 +1776,8 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	}
 	set_script (fp, Ctrl->In.mode);		/* Write 1st line of a script */
 	if (Ctrl->Z.active) {	/* Want to delete the entire frame directory */
-		set_comment (fp, Ctrl->In.mode, "Cleanup script removes directory with frame files");
-		fprintf (fp, "%s %s\n", rmdir[Ctrl->In.mode], Ctrl->N.prefix);	/* Delete the entire directory with PNG frames and tmp files */
+		set_comment (fp, Ctrl->In.mode, "Cleanup script removes working directory with frame files");
+		fprintf (fp, "%s %s\n", rmdir[Ctrl->In.mode], workdir);	/* Delete the entire working directory with PNG frames and tmp files */
 	}
 	else {	/* Just delete the remaining scripts and PS files */
 #ifdef WIN32		/* On Windows to do remove a file in a subdir one need to use back slashes */
@@ -1783,13 +1787,13 @@ int GMT_movie (void *V_API, int mode, void *args) {
 #endif
 		GMT_Report (API, GMT_MSG_LONG_VERBOSE, "%u frame PNG files saved in directory: %s\n", n_frames, Ctrl->N.prefix);
 		if (Ctrl->S[MOVIE_PREFLIGHT].active)	/* Remove the preflight script */
-			fprintf (fp, "%s %s%c%s\n", rmfile[Ctrl->In.mode], Ctrl->N.prefix, dir_sep_, pre_file);
+			fprintf (fp, "%s %s%c%s\n", rmfile[Ctrl->In.mode], workdir, dir_sep_, pre_file);
 		if (Ctrl->S[MOVIE_POSTFLIGHT].active)	/* Remove the postflight script */
-			fprintf (fp, "%s %s%c%s\n", rmfile[Ctrl->In.mode], Ctrl->N.prefix, dir_sep_, post_file);
-		fprintf (fp, "%s %s%c%s\n", rmfile[Ctrl->In.mode], Ctrl->N.prefix, dir_sep_, init_file);	/* Delete the init script */
-		fprintf (fp, "%s %s%c%s\n", rmfile[Ctrl->In.mode], Ctrl->N.prefix, dir_sep_, main_file);	/* Delete the main script */
+			fprintf (fp, "%s %s%c%s\n", rmfile[Ctrl->In.mode], workdir, dir_sep_, post_file);
+		fprintf (fp, "%s %s%c%s\n", rmfile[Ctrl->In.mode], workdir, dir_sep_, init_file);	/* Delete the init script */
+		fprintf (fp, "%s %s%c%s\n", rmfile[Ctrl->In.mode], workdir, dir_sep_, main_file);	/* Delete the main script */
 		if (layers) 
-			fprintf (fp, "%s %s%c*.ps\n", rmfile[Ctrl->In.mode], Ctrl->N.prefix, dir_sep_);	/* Delete any PostScript layers */
+			fprintf (fp, "%s %s%c*.ps\n", rmfile[Ctrl->In.mode], workdir, dir_sep_);	/* Delete any PostScript layers */
 	}
 	fclose (fp);
 #ifndef _WIN32

--- a/src/movie.c
+++ b/src/movie.c
@@ -820,7 +820,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_O
 					"Syntax error -A: Cannot specify a GIF stride > 1 without selecting a movie product (-F)\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->M.active && Ctrl->M.frame < Ctrl->T.start_frame,
 					"Syntax error -M: Cannot specify a frame before the first frame number set via -T\n");
-	
+	n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active && Ctrl->W.active && !strcmp (Ctrl->W.dir, "/tmp"),
+					"Syntax error option -Z: Cannot delete working directory %s\n", Ctrl->W.dir);
+
 	if (n_errors) return (GMT_PARSE_ERROR);	/* No point going further */
 	
 	/* Note: We open script files for reading below since we are changing cwd later and sometimes need to rewind and re-read */


### PR DESCRIPTION
This is needed so temp files are not required to be placed in a subdir in the current directory [the default]. Now, **-W**_dir_ will set the directory where all the work is done.  if not set we default to subdir _prefix_ wet via **-N**_prefix_.
