### PR TITLE
CI: Install the latest ghostscript in Windows CI

### DIFF
--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -41,7 +41,7 @@ steps:
 - bash: |
     set -x -e
     choco install ninja
-    choco install ghostscript --version 9.26 # gs 9.27 is buggy
+    choco install ghostscript
   displayName: Install dependencies via chocolatey
 
 - bash: |


### PR DESCRIPTION
We used to install ghostscript 9.26, as gs9.27 has critical bugs.
Now chocolatey provides gs9.50, so we can install the latest
ghostscript.