### PR TITLE
Make bash/sh jobs on Windows also run in parallel

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -1653,7 +1653,14 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Execute movie frame scripts in parallel\n");
 	while (!done) {	/* Keep running jobs until all frames have completed */
 		while (n_frames_not_started && n_cores_unused) {	/* Launch new jobs if possible */
+#ifdef WIN32
+			if (Ctrl->In.mode < 2)		/* A bash or sh run from Windows. Need to call via "start" to get parallel */
+				sprintf (cmd, "start /B %s %s %*.*d", sc_call[Ctrl->In.mode], main_file, precision, precision, frame);
+			else						/* Runing batch, so no need for the above trick */
+				sprintf (cmd, "%s %s %*.*d &", sc_call[Ctrl->In.mode], main_file, precision, precision, frame);
+#else 
 			sprintf (cmd, "%s %s %*.*d &", sc_call[Ctrl->In.mode], main_file, precision, precision, frame);
+#endif
 
 			GMT_Report (API, GMT_MSG_DEBUG, "Launch script for frame %*.*d\n", precision, precision, frame);
 			if ((error = system (cmd))) {


### PR DESCRIPTION
On Windows doing ``bash blabla.sh &`` is no good. The background instruction ``&`` is ignored. To achieve the same result as on unix we need to call it with ``start /B bash blabla.sh``