### PR TITLE
CI: Update vmImage to the latest Ubuntu-18.04 and windows-2019

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,13 +1,13 @@
 # Configuration for Azure Pipelines
 ########################################################################################
 
-# Only build the master branch, tags, and PRs (on by default) to avoid building random
-# branches in the repository until a PR is opened.
+# Only build the master, 6.x and 5.4 branches, tags, and PRs (on by default)
+# to avoid building random branches in the repository until a PR is opened.
 trigger:
   branches:
     include:
     - master
-    - 6.0
+    - 6.?
     - 5.4
     - refs/tags/*
 
@@ -20,7 +20,7 @@ jobs:
   condition: ne(variables['Build.Reason'], 'Schedule')
 
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
 
   variables:
     BUILD_DOCS: false
@@ -38,7 +38,7 @@ jobs:
   condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
 
   variables:
     BUILD_DOCS: true
@@ -56,7 +56,7 @@ jobs:
   condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
 
   variables:
     BUILD_DOCS: false
@@ -129,7 +129,7 @@ jobs:
   timeoutInMinutes: 120
 
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
 
   variables:
     BUILD_DOCS: false
@@ -148,7 +148,7 @@ jobs:
   timeoutInMinutes: 120
 
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
 
   variables:
     BUILD_DOCS: true
@@ -167,7 +167,7 @@ jobs:
   timeoutInMinutes: 360
 
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
 
   variables:
     BUILD_DOCS: false

--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -51,6 +51,7 @@ steps:
 - bash: |
     set -x -e
     gmt --version
+    gmt-config --all
     gmt defaults -Vd
     gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
     gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -53,6 +53,7 @@ steps:
 - bash: |
     set -x -e
     gmt --version
+    gmt-config --all
     gmt defaults -Vd
     gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
     gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -7,7 +7,7 @@ steps:
 # To rebuild the cache, you have to change the date in the key list
 - task: CacheBeta@0
   inputs:
-    key: $(Agent.OS) | vcpkg | 20190820
+    key: $(Agent.OS) | vcpkg | 20191017
     path: $(VCPKG_INSTALLATION_ROOT)/installed/
     cacheHitVar: CACHE_VCPKG_RESTORED
   displayName: Cache vcpkg libraries
@@ -89,7 +89,7 @@ steps:
 - script: |
     mkdir build
     cd build
-    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
     cmake .. -G "Ninja" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_C_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Release
     cmake --build .
     cmake --build . --target install
@@ -97,6 +97,7 @@ steps:
 
 - script: |
     gmt --version
+    bash %INSTALLDIR%/bin/gmt-config --all
     gmt defaults -Vd
     gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
     gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end

--- a/ci/build-gmt.sh
+++ b/ci/build-gmt.sh
@@ -37,9 +37,7 @@ fi
 if [[ "$BUILD_DOCS" == "true" ]]; then
     cat >> cmake/ConfigUser.cmake << 'EOF'
 set (DO_ANIMATIONS TRUE)
-#set (CMAKE_VERBOSE_MAKEFILE ON CACHE BOOL "ON")
 EOF
-EXTRA_CMAKE_OPTS="-DCMAKE_VERBOSE_MAKEFILE=ON"
 fi
 
 echo ""
@@ -50,10 +48,7 @@ echo ""
 mkdir -p build && cd build
 
 # Configure
-cmake ${EXTRA_CMAKE_OPTS} -G Ninja ..
-
-# Show CMakeCache.txt, strip comments
-grep -Ev "^(//|$)" CMakeCache.txt
+cmake -G Ninja ..
 
 # Build and install
 cmake --build .

--- a/ci/config-gmt-windows.sh
+++ b/ci/config-gmt-windows.sh
@@ -28,7 +28,6 @@ fi
 if [[ "$BUILD_DOCS" == "true" ]]; then
     cat >> cmake/ConfigUser.cmake << 'EOF'
 set (DO_ANIMATIONS TRUE)
-set (CMAKE_VERBOSE_MAKEFILE ON CACHE BOOL "ON")
 EOF
 fi
 


### PR DESCRIPTION
Changes in this PR:

- Update the host images to the latest ubuntu-18.04 and windows-2019
- Update vcpkg caches
- Build all 6.x branches