### PR TITLE
Update meta-data for the earth_relief_xxy grids

### DIFF
--- a/doc/rst/source/datasets/earth_relief.rst
+++ b/doc/rst/source/datasets/earth_relief.rst
@@ -12,51 +12,51 @@ are ways to control how much is downloaded (see below).
 Usage
 -----
 
-We have processed and reformatted various publicly available global relief
+We have processed and reformatted publicly available global relief
 grids and standardized their file names.  In GMT, you may access a global relief grid
 (or a subset only by using the **-R** option) by specifying the special name
 
    @earth_relief_\ *rr*\ *u*
 
-where *rr* is a 2-digit integer specifying the grid resolution in the unit
-*u*, where *u* is either **m** or **s** for arc minute or arc second, respectively.
+where *rr* is a 2-digit integer specifying the grid resolution in the unit *u*, where
+*u* is either **d**, **m** or **s** for arc degree, arc minute or arc second, respectively.
 The following codes for *rr*\ *u* are supported:
 
 .. _tbl-earth_relief:
 
-    +------+------------------+--------+-----------------------------------------------+
-    | Code | Dimensions       | Size   | Description                                   |
-    +======+==================+========+===============================================+
-    | 60m  |     361 x    181 | 111 KB | 60 arc minute global relief (ETOPO1 @ 111 km) |
-    +------+------------------+--------+-----------------------------------------------+
-    | 30m  |     721 x    361 | 376 KB | 30 arc minute global relief (ETOPO1 @ 55 km)  |
-    +------+------------------+--------+-----------------------------------------------+
-    | 20m  |    1081 x    541 | 782 KB | 20 arc minute global relief (ETOPO1 @ 37 km)  |
-    +------+------------------+--------+-----------------------------------------------+
-    | 15m  |    1441 x    721 | 1.3 MB | 15 arc minute global relief (ETOPO1 @ 28 km)  |
-    +------+------------------+--------+-----------------------------------------------+
-    | 10m  |    2161 x   1081 | 2.8 MB | 10 arc minute global relief (ETOPO1 @ 18 km)  |
-    +------+------------------+--------+-----------------------------------------------+
-    | 06m  |    3601 x   1801 | 7.4 MB | 6 arc minute global relief (ETOPO1 @ 10 km)   |
-    +------+------------------+--------+-----------------------------------------------+
-    | 05m  |    4321 x   2161 |  11 MB | 5 arc minute global relief (ETOPO1 @ 9 km)    |
-    +------+------------------+--------+-----------------------------------------------+
-    | 04m  |    5401 x   2701 |  16 MB | 4 arc minute global relief (ETOPO1 @ 7.5 km)  |
-    +------+------------------+--------+-----------------------------------------------+
-    | 03m  |    7201 x   3601 |  27 MB | 3 arc minute global relief (ETOPO1 @ 5.6 km)  |
-    +------+------------------+--------+-----------------------------------------------+
-    | 02m  |   10801 x   5401 |  58 MB | 2 arc minute global relief (ETOPO2v2)         |
-    +------+------------------+--------+-----------------------------------------------+
-    | 01m  |   21601 x  10801 | 214 MB | 1 arc minute global relief (ETOPO1)           |
-    +------+------------------+--------+-----------------------------------------------+
-    | 30s  |   43201 x  21601 | 778 MB | 30 arc second global relief (SRTM30+)         |
-    +------+------------------+--------+-----------------------------------------------+
-    | 15s  |   86401 x  43201 | 2.6 GB | 15 arc second global relief (SRTM15+)         |
-    +------+------------------+--------+-----------------------------------------------+
-    | 03s  |  432001 x 216001 | 6.8 GB | 3 arc second global relief (SRTM3S)           |
-    +------+------------------+--------+-----------------------------------------------+
-    | 01s  | 1296001 x 432001 |  41 GB | 1 arc second global relief (SRTM1S)           |
-    +------+------------------+--------+-----------------------------------------------+
+    +------+------------------+--------+--------------------------------------------------+
+    | Code | Dimensions       | Size   | Description                                      |
+    +======+==================+========+==================================================+
+    | 01d  |     361 x    181 | 106 KB | 1 arc degree global relief (SRTM15+V2 @ 111 km)  |
+    +------+------------------+--------+--------------------------------------------------+
+    | 30m  |     721 x    361 | 363 KB | 30 arc minute global relief (SRTM15+V2 @ 55 km)  |
+    +------+------------------+--------+--------------------------------------------------+
+    | 20m  |    1081 x    541 | 759 KB | 20 arc minute global relief (SRTM15+V2 @ 37 km)  |
+    +------+------------------+--------+--------------------------------------------------+
+    | 15m  |    1441 x    721 | 1.3 MB | 15 arc minute global relief (SRTM15+V2 @ 28 km)  |
+    +------+------------------+--------+--------------------------------------------------+
+    | 10m  |    2161 x   1081 | 2.8 MB | 10 arc minute global relief (SRTM15+V2 @ 18 km)  |
+    +------+------------------+--------+--------------------------------------------------+
+    | 06m  |    3601 x   1801 | 7.3 MB | 6 arc minute global relief (SRTM15+V2 @ 10 km)   |
+    +------+------------------+--------+--------------------------------------------------+
+    | 05m  |    4321 x   2161 |  10 MB | 5 arc minute global relief (SRTM15+V2 @ 9 km)    |
+    +------+------------------+--------+--------------------------------------------------+
+    | 04m  |    5401 x   2701 |  16 MB | 4 arc minute global relief (SRTM15+V2 @ 7.5 km)  |
+    +------+------------------+--------+--------------------------------------------------+
+    | 03m  |    7201 x   3601 |  27 MB | 3 arc minute global relief (SRTM15+V2 @ 5.6 km)  |
+    +------+------------------+--------+--------------------------------------------------+
+    | 02m  |   10801 x   5401 |  58 MB | 2 arc minute global relief (SRTM15+V2 @ 3.7 km)  |
+    +------+------------------+--------+--------------------------------------------------+
+    | 01m  |   21601 x  10801 | 214 MB | 1 arc minute global relief (SRTM15+V2 @ 1.9 km)  |
+    +------+------------------+--------+--------------------------------------------------+
+    | 30s  |   43201 x  21601 | 765 MB | 30 arc second global relief (SRTM15+V2 @ 0.9 km) |
+    +------+------------------+--------+--------------------------------------------------+
+    | 15s  |   86400 x  43200 | 2.6 GB | 15 arc second global relief (SRTM15+V2)          |
+    +------+------------------+--------+--------------------------------------------------+
+    | 03s  |  432001 x 216001 | 6.8 GB | 3 arc second global relief (SRTM3S)              |
+    +------+------------------+--------+--------------------------------------------------+
+    | 01s  | 1296001 x 432001 |  41 GB | 1 arc second global relief (SRTM1S)              |
+    +------+------------------+--------+--------------------------------------------------+
 
 All of these data will, when downloaded, be placed in your ~/.gmt/server directory, with
 the SRTM data organized in sub-directories srtm1 and srtm3 within the server directory.
@@ -64,33 +64,33 @@ the SRTM data organized in sub-directories srtm1 and srtm3 within the server dir
 Technical Information
 ---------------------
 
-As you see, the 03m and lower resolutions are all derivatives of NOAA's ETOPO1 grid.  We have
-downsampled it via spherical Gaussian filtering to prevent aliasing.  The full (6 sigma)
-filter-widths are indicated in parenthesis. For 2 arc minute we use the original ETOPO2v2
-file from NOAA (with ice_surface).  The 30 and 15 arc second grids are the global SRTM30+
-and SRTM15+ products from Dave Sandwell (Scripps), while the 3 and 1 arc second data are
-the SRTM 1x1 degree tiles from NASA.  When the 15s or lower resolution grids are accessed
+As you see, the 30s and lower resolutions are all derivatives of Scripps' SRTM15+V2 grid
+(Tozer et al., 2019).  We have downsampled it via Cartesian Gaussian filtering to prevent
+aliasing while preserving the latitude-dependent resolution in the original 15 arc sec grid.
+The full (6 sigma) filter-widths are indicated in parenthesis. The 3 and 1 arc second data
+are the SRTM 1x1 degree tiles from NASA.  When the 15s or lower resolution grids are accessed
 the first time we download the entire file, regardless of your selected region (**-R**).
 However, for the SRTM tiles we only download the tiles that are inside your selected region
 the first time they are referenced. Also note that the 3 and 1 arc second grids only extend
-to latitudes ±60˚. The SRTM tiles are only valid over land.  However, when these grids
-are accessed as @earth_relief_01s or @earth_relief_03s we will automatically upsample the
-@earth_relief_15s grid to fill in the missing ocean values (but only if the region includes oceanic areas).
-If you just want the original land-only
-SRTM tiles you may use @srtm_relief_03s or @srtm_relief_01s instead. All grids are gridline-registered.
+to latitudes ±60˚. The SRTM tiles are only valid over land.  However, when these grids are
+accessed as @earth_relief_01s or @earth_relief_03s we will automatically upsample the
+@earth_relief_15s grid to fill in the missing ocean values (but only if the region includes
+oceanic areas). If you just want the original land-only SRTM tiles you may use @srtm_relief_03s
+or @srtm_relief_01s instead. All grids are gridline-registered except the original SRTM15+V2,
+here called @earth_relief_15s.
 
 The dimensions above reflect the number of nodes covered by the global grids and the sizes are
 the file sizes of the netCDF-4 compressed short int grids, making the files much smaller
 than their original source files without any loss of precision.  To improve download speed,
 the SRTM tiles are stored as JPEG2000 images on the GMT server due to superior compression,
-but once downloaded to your server directory they are converted to short int compressed netCDF4 grids.
-This step uses our GDAL bridge and thus requires that you have built GMT with GDAL support
+but once downloaded to your server directory they are converted to short int compressed netCDF4
+grids. This step uses our GDAL bridge and thus requires that you have built GMT with GDAL support
 *and* that your GDAL distribution was built with openjpeg support.
 
 Data Space Concerns
 -------------------
 
-There are several ways you can control the amount of space taken up by your server directory:
+There are several ways you can control the amount of space taken up by your own server directory:
 
 #. You can set an upper file size limit for download via the GMT default setting
    :ref:`GMT_DATA_SERVER_LIMIT <GMT_DATA_SERVER_LIMIT>`; the default is unlimited.
@@ -101,9 +101,6 @@ There are several ways you can control the amount of space taken up by your serv
 Data References
 ---------------
 
-#. ETOPO2v2 [https://dx.doi.org/10.7289/V5J1012Q].
-#. ETOPO1: Amante, C., and B. W. Eakins (2008), ETOPO1 1 arc-minute global relief model: Procedures, data sources and analysisRep., National Geophysical Data Center, Boulder, CO [https://www.ngdc.noaa.gov/mgg/global/relief/ETOPO1/data/ice_surface/grid_registered/netcdf/ETOPO1_Ice_g_gmt4.grd.gz].
-#. SRTM30+: Becker, J. J., et al. (2009), Global Bathymetry and Elevation Data at 30 Arc Seconds Resolution: SRTM30_PLUS, Marine Geodesy, 32, 355–371 [ftp://topex.ucsd.edu/pub/srtm30_plus/topo30/topo30.grd].
-#. SRTM15+: Olson, C. L., J. J. Becker, and D. T. Sandwell (2014), A new global bathymetry map at 15 arcsecond resolution for resolving seafloor fabric: SRTM15_PLUS, in Eos Trans. AGU, edited, pp. Abstract OS34A-03 [ftp://topex.ucsd.edu/pub/srtm15_plus/topo15.grd].
+#. SRTM15+V2 [http://dx.doi.org/10.1029/2019EA000658].
 #. SRTMGL3 tiles: [https://lpdaac.usgs.gov/dataset_discovery/measures/measures_products_table/srtmgl3_v003].
 #. SRTMGL1 tiles: [https://lpdaac.usgs.gov/dataset_discovery/measures/measures_products_table/srtmgl1_v003].

--- a/src/gmt_remote.h
+++ b/src/gmt_remote.h
@@ -19,7 +19,7 @@
  * Include file for list of data grids available via @earth_relief_*.grd references.
  *
  * Author:      Paul Wessel
- * Date:        11-Sept-2017
+ * Date:        19-Oct-2019
  * Version:     6 API
  */
 
@@ -38,22 +38,23 @@ struct GMT_DATA_HASH {	/* Holds file hashes (probably SHA256) */
 	size_t size;		/* File size in bytes */
 };
 
-#define GMT_N_DATA_INFO_ITEMS 15
+#define GMT_N_DATA_INFO_ITEMS 16
 
 GMT_LOCAL struct GMT_DATA_INFO gmt_data_info[GMT_N_DATA_INFO_ITEMS] = {
-	{"60m", "112K", "Earth Relief at 60x60 arc minutes obtained by Gaussian spherical filtering (111 km fullwidth) of ETOPO1 (Ice g) [NOAA]"},
-	{"30m", "377K", "Earth Relief at 30x30 arc minutes obtained by Gaussian spherical filtering (55 km fullwidth) of ETOPO1 (Ice g) [NOAA]"},
-	{"20m", "783K", "Earth Relief at 20x20 arc minutes obtained by Gaussian spherical filtering (37 km fullwidth) of ETOPO1 (Ice g) [NOAA]"},
-	{"15m", "1.4M", "Earth Relief at 15x15 arc minutes obtained by Gaussian spherical filtering (28 km fullwidth) of ETOPO1 (Ice g) [NOAA]"},
-	{"10m", "2.9M", "Earth Relief at 10x10 arc minutes obtained by Gaussian spherical filtering (18 km fullwidth) of ETOPO1 (Ice g) [NOAA]"},
-	{"06m", "7.5M", "Earth Relief at 6x6 arc minutes obtained by Gaussian spherical filtering (10 km fullwidth) of ETOPO1 (Ice g) [NOAA]"},
-	{"05m",  "11M", "Earth Relief at 5x5 arc minutes obtained by Gaussian spherical filtering (9 km fullwidth) of ETOPO1 (Ice g) [NOAA]"},
-	{"04m",  "16M", "Earth Relief at 4x4 arc minutes obtained by Gaussian spherical filtering (7.5 km fullwidth) of ETOPO1 (Ice g) [NOAA]"},
-	{"03m",  "28M", "Earth Relief at 3x3 arc minutes obtained by Gaussian spherical filtering (5.6 km fullwidth) of ETOPO1 (Ice g) [NOAA]"},
-	{"02m",  "58M", "Earth Relief at 2x2 arc minutes provided by ETOPO2v2g_f4 [NOAA]"},
-	{"01m", "214M", "Earth Relief at 1x1 arc minutes provided by ETOPO1 (Ice g) [NOAA]"},
-	{"30s", "778M", "Earth Relief at 30x30 arc seconds provided by SRTM30+ [Sandwell/SIO]"},
-	{"15s", "2.6G", "Earth Relief at 15x15 arc seconds provided by SRTM15+ [Sandwell/SIO]"},
+	{"60m", "106K", "Earth Relief at 60x60 arc minutes obtained by Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2 [Tozer et al., 2019]"},
+	{"01d", "106K", "Earth Relief at 1x1 arc degrees obtained by Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2 [Tozer et al., 2019]"},
+	{"30m", "363K", "Earth Relief at 30x30 arc minutes obtained by Gaussian Cartesian filtering (55 km fullwidth) of SRTM15+V2 [Tozer et al., 2019]"},
+	{"20m", "759K", "Earth Relief at 20x20 arc minutes obtained by Gaussian Cartesian filtering (37 km fullwidth) of SRTM15+V2 [Tozer et al., 2019]"},
+	{"15m", "1.3M", "Earth Relief at 15x15 arc minutes obtained by Gaussian Cartesian filtering (28 km fullwidth) of SRTM15+V2 [Tozer et al., 2019]"},
+	{"10m", "2.8M", "Earth Relief at 10x10 arc minutes obtained by Gaussian Cartesian filtering (18 km fullwidth) of SRTM15+V2 [Tozer et al., 2019]"},
+	{"06m", "7.3M", "Earth Relief at 6x6 arc minutes obtained by Gaussian Cartesian filtering (10 km fullwidth) of SRTM15+V2 [Tozer et al., 2019]"},
+	{"05m",  "10M", "Earth Relief at 5x5 arc minutes obtained by Gaussian Cartesian filtering (9 km fullwidth) of SRTM15+V2 [Tozer et al., 2019]"},
+	{"04m",  "16M", "Earth Relief at 4x4 arc minutes obtained by Gaussian Cartesian filtering (7.5 km fullwidth) of SRTM15+V2 [Tozer et al., 2019]"},
+	{"03m",  "27M", "Earth Relief at 3x3 arc minutes obtained by Gaussian Cartesian filtering (5.6 km fullwidth) of SRTM15+V2 [Tozer et al., 2019]"},
+	{"02m",  "58M", "Earth Relief at 2x2 arc minutes obtained by Gaussian Cartesian filtering (3.7 km fullwidth) of SRTM15+V2 [Tozer et al., 2019]"},
+	{"01m", "214M", "Earth Relief at 1x1 arc minutes obtained by Gaussian Cartesian filtering (1.9 km fullwidth) of SRTM15+V2 [Tozer et al., 2019]"},
+	{"30s", "765M", "Earth Relief at 30x30 arc seconds obtained by Gaussian Cartesian filtering (0.9 km fullwidth) of SRTM15+V2 [Tozer et al., 2019]"},
+	{"15s", "2.6G", "Earth Relief at 15x15 arc seconds provided by SRTM15+ [Tozer et al., 2019]"},
 	{"03s", "6.8G", "Earth Relief at 3x3 arc seconds tiles provided by SRTMGL3 (land only) [NASA/USGS]"},
 	{"01s",  "41G", "Earth Relief at 1x1 arc seconds tiles provided by SRTMGL1 (land only) [NASA/USGS]"}
 };


### PR DESCRIPTION
Since they are now all based on _Tozer et al, 2019_ using Cartesian filtering on SRTM15+V2, then we need to update the attributions.  Also allow 01d and 60m to be used for the coarsest file.
