### PR TITLE
Let plot and plot3d add auto-legend entry for polygons also

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6539,10 +6539,10 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 
 		case 'l':	/* -l option to set up auto-legend items*/
 
-			gmt_message (GMT, "\t-l Add a symbol or line to the legend; append symbol label.  Optionally, add any of the legend codes\n");
+			gmt_message (GMT, "\t-l Add symbol, line or polygon to the legend. Optionally, append label and add any of the legend codes\n");
 			gmt_message (GMT, "\t   +d<pen>, +f<font>, +g<gap>, +h<header>, +l[<just>/]<txt>, +n<cols>, +s<size>, +v[<pen>].\n");
 			gmt_message (GMT, "\t   You can also choose legend placement codes +j<just> and +x<scale>, corresponding\n");
-			gmt_message (GMT, "\t   to legend options -DJ<just> and -S<scale>.\n");
+			gmt_message (GMT, "\t   to legend command line options -Dj|J<just> and -S<scale>.\n");
 			break;
 
 		case 'm':	/* -do option to tell GMT the relationship between NaN and a nan-proxy for output */

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -1468,6 +1468,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 								}
 								else {	/* Ellipse needs more arguments; we use minor = 0.65*major, az = 0 */
 									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+									if (x == 0.0) x = Ctrl->S.scale * def_size;	/* Safety valve */
 									az1 = 0.0;
 									y = 0.65 * x;
 								}
@@ -1484,6 +1485,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 								}
 								else {	/* Rotated rectangle needs more arguments; we use height = 0.65*width, az = 30 */
 									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+									if (x == 0.0) x = Ctrl->S.scale * def_size;	/* Safety valve */
 									y = 0.65 * x;
 									az1 = 30.0;
 								}
@@ -1540,6 +1542,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 								}
 								else {	/* Rectangle also need more args, we use h = 0.65*w */
 									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+									if (x == 0.0) x = Ctrl->S.scale * def_size;	/* Safety valve */
 									y = 0.65 * x;
 								}
 								S[SYM]->data[2][0] = x;
@@ -1554,6 +1557,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 								}
 								else {	/* Rounded rectangle also need more args, we use h = 0.65*w and r = 0.1*w */
 									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+									if (x == 0.0) x = Ctrl->S.scale * def_size;	/* Safety valve */
 									y = 0.65 * x;
 									r = 0.1 * x;
 								}
@@ -1570,6 +1574,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 								}
 								else {	/* Math angle need more args, we set fixed az1,az22 as 10 45 */
 									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+									if (x == 0.0) x = Ctrl->S.scale * def_size;	/* Safety valve */
 									az1 = 10;	az2 = 45;
 								}
 								/* We want to center the arc around its mid-point */
@@ -1596,6 +1601,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 								}
 								else {
 									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+									if (x == 0.0) x = Ctrl->S.scale * def_size;	/* Safety valve */
 									az1 = -30;	az2 = 30;
 								}
 								/* We want to center the wedge around its mid-point */
@@ -1607,8 +1613,9 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 								S[SYM]->data[4][0] = az2;
 							}
 							else {
-								x = gmt_M_to_inch (GMT, size);
-								S[SYM]->data[2][0] = Ctrl->S.scale * ((x == 0.0) ? def_size : x);
+								x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+								if (x == 0.0) x = Ctrl->S.scale * def_size;	/* Safety valve */
+								S[SYM]->data[2][0] = x;
 							}
 							/* Place pen and fill colors in segment header */
 							sprintf (buffer, "-G"); strcat (buffer, txt_c);

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -1607,8 +1607,8 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 								S[SYM]->data[4][0] = az2;
 							}
 							else {
-								x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-								S[SYM]->data[2][0] = x;
+								x = gmt_M_to_inch (GMT, size);
+								S[SYM]->data[2][0] = Ctrl->S.scale * ((x == 0.0) ? def_size : x);
 							}
 							/* Place pen and fill colors in segment header */
 							sprintf (buffer, "-G"); strcat (buffer, txt_c);

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -1468,7 +1468,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 								}
 								else {	/* Ellipse needs more arguments; we use minor = 0.65*major, az = 0 */
 									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-									if (x == 0.0) x = Ctrl->S.scale * def_size;	/* Safety valve */
+									if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
 									az1 = 0.0;
 									y = 0.65 * x;
 								}
@@ -1485,7 +1485,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 								}
 								else {	/* Rotated rectangle needs more arguments; we use height = 0.65*width, az = 30 */
 									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-									if (x == 0.0) x = Ctrl->S.scale * def_size;	/* Safety valve */
+									if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
 									y = 0.65 * x;
 									az1 = 30.0;
 								}
@@ -1542,7 +1542,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 								}
 								else {	/* Rectangle also need more args, we use h = 0.65*w */
 									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-									if (x == 0.0) x = Ctrl->S.scale * def_size;	/* Safety valve */
+									if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
 									y = 0.65 * x;
 								}
 								S[SYM]->data[2][0] = x;
@@ -1557,7 +1557,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 								}
 								else {	/* Rounded rectangle also need more args, we use h = 0.65*w and r = 0.1*w */
 									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-									if (x == 0.0) x = Ctrl->S.scale * def_size;	/* Safety valve */
+									if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
 									y = 0.65 * x;
 									r = 0.1 * x;
 								}
@@ -1574,7 +1574,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 								}
 								else {	/* Math angle need more args, we set fixed az1,az22 as 10 45 */
 									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-									if (x == 0.0) x = Ctrl->S.scale * def_size;	/* Safety valve */
+									if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
 									az1 = 10;	az2 = 45;
 								}
 								/* We want to center the arc around its mid-point */
@@ -1601,7 +1601,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 								}
 								else {
 									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-									if (x == 0.0) x = Ctrl->S.scale * def_size;	/* Safety valve */
+									if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
 									az1 = -30;	az2 = 30;
 								}
 								/* We want to center the wedge around its mid-point */
@@ -1614,7 +1614,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 							}
 							else {
 								x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-								if (x == 0.0) x = Ctrl->S.scale * def_size;	/* Safety valve */
+								if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
 								S[SYM]->data[2][0] = x;
 							}
 							/* Place pen and fill colors in segment header */

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1821,9 +1821,9 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 		if (GMT->current.io.OGR && (GMT->current.io.OGR->geometry == GMT_IS_POLYGON || GMT->current.io.OGR->geometry == GMT_IS_MULTIPOLYGON)) polygon = true;
 
 		if (GMT->common.l.active && S.symbol == GMT_SYMBOL_LINE) {
-			if (polygon) {	/* Place a square in the legend */
+			if (polygon) {	/* Place a rectangle in the legend */
 				int symbol = S.symbol;
-				S.symbol = PSL_SQUARE;
+				S.symbol = PSL_RECT;
 				gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
 				S.symbol = symbol;
 			}

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1820,9 +1820,15 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 		}
 		if (GMT->current.io.OGR && (GMT->current.io.OGR->geometry == GMT_IS_POLYGON || GMT->current.io.OGR->geometry == GMT_IS_MULTIPOLYGON)) polygon = true;
 
-		if (GMT->common.l.active && S.symbol == GMT_SYMBOL_LINE && !polygon) {
-			/* For specified line, width, color we can do an auto-legend entry under modern mode */
-			gmt_add_legend_item (API, &S, false, NULL, Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
+		if (GMT->common.l.active && S.symbol == GMT_SYMBOL_LINE) {
+			if (polygon) {	/* Place a square in the legend */
+				int symbol = S.symbol;
+				S.symbol = PSL_SQUARE;
+				gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
+				S.symbol = symbol;
+			}
+			else	/* For specified line, width, color we can do an auto-legend entry under modern mode */
+				gmt_add_legend_item (API, &S, false, NULL, Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
 		}
 
 		if (Ctrl->W.cpt_effect && Ctrl->W.pen.cptmode & 2) polygon = true;

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1585,9 +1585,9 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 		}
 
 		if (GMT->common.l.active && S.symbol == GMT_SYMBOL_LINE) {
-			if (polygon) {	/* Place a square in the legend */
+			if (polygon) {	/* Place a rectangle in the legend */
 				int symbol = S.symbol;
-				S.symbol = PSL_SQUARE;
+				S.symbol = PSL_RECT;
 				gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
 				S.symbol = symbol;
 			}

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1584,9 +1584,15 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 			Return (GMT_DIM_TOO_SMALL);
 		}
 
-		if (GMT->common.l.active && S.symbol == GMT_SYMBOL_LINE && !polygon) {
-			/* For specified line, width, color we can do an auto-legend entry under modern mode */
-			gmt_add_legend_item (API, &S, false, NULL, Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
+		if (GMT->common.l.active && S.symbol == GMT_SYMBOL_LINE) {
+			if (polygon) {	/* Place a square in the legend */
+				int symbol = S.symbol;
+				S.symbol = PSL_SQUARE;
+				gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
+				S.symbol = symbol;
+			}
+			else	/* For specified line, width, color we can do an auto-legend entry under modern mode */
+				gmt_add_legend_item (API, &S, false, NULL, Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
 		}
 		
 		for (tbl = 0; tbl < D->n_tables; tbl++) {


### PR DESCRIPTION
It seems arbitrary and silly to not allow plot and plot3d to add an auto-legend item for a polygon when we do so for lines.  This PR adds the rectangle symbol for polygons.  I also added some safety valves in pslegend in case no items have a valid size.  This allows one to do things like this:

```
gmt begin oz
    gmt plot -R110/155/-40/-10 -JM6i -B @GSHHS_h_Australia.txt -L -Glightgreen -Wfaint -lAustralia+hLEGEND+f16p+d+jTL+s0.15i
gmt end show
```

Further expansions into *contour and others will await 6.1.
