### PR TITLE
Use strncpy and fixes #1860

### DIFF
--- a/src/gmtwhich.c
+++ b/src/gmtwhich.c
@@ -213,7 +213,7 @@ int GMT_gmtwhich (void *V_API, int mode, void *args) {
 				/* File found on system but we want a copy in the current directory */
 				if (gmt_rename_file (GMT, path, &L[1], GMT_COPY_FILE))
 					Return (GMT_RUNTIME_ERROR);
-				strcpy (path, &L[1]);	/* Report the file in the local directory now */
+				strncpy (path, &L[1], PATH_MAX);	/* Report the file in the local directory now */
 			}
 			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 		}


### PR DESCRIPTION
I don't know why but replacing `strcpy` with `strncpy` can fix the gmtwhich issue #1860.

The 5 failing tests reported in #1860 now all pass, see the CI reports https://dev.azure.com/GenericMappingTools/GMT/_build/results?buildId=3437&view=results.