### PR TITLE
docs: Small fixes

### DIFF
--- a/doc/rst/source/begin.rst
+++ b/doc/rst/source/begin.rst
@@ -99,8 +99,6 @@ Supported Graphic Formats
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To initiate a new modern session that will produce a single
 map called Figure_2 saved as both a PDF vector graphics file
 and an opaque PNG raster image, we would run::
@@ -117,7 +115,7 @@ be called gmtsession.pdf (assuming :ref:`GMT_GRAPHICS_FORMAT <GMT_GRAPHICS_FORMA
 
 To set up proceedings for a jpg figure with 0.5c white margin, we would run::
 
-    gmt begin 'My Figure4' pdf,png A+m1c
+    gmt begin 'My Figure4' pdf,png A+m0.5c
 
 .. include:: explain_postscript.rst_
 

--- a/doc/rst/source/clear.rst
+++ b/doc/rst/source/clear.rst
@@ -13,7 +13,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt clear** [ **all** \| **cache** \| **defaults** \| **data** \| **sessions** ]
+**gmt clear** **all** \| **cache** \| **defaults** \| **data** \| **sessions**
 [ |SYN_OPT-V| ]
 
 |No-spaces|
@@ -61,8 +61,6 @@ Optional Arguments
 
 Examples
 --------
-
-.. include:: explain_example.rst_
 
 To remove the current default settings in a modern mode session, use::
 

--- a/doc/rst/source/docs.rst
+++ b/doc/rst/source/docs.rst
@@ -68,8 +68,6 @@ Optional Module Arguments
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To see the documentation of *grdimage*::
 
     gmt docs grdimage
@@ -82,9 +80,9 @@ To see the link to the documentation of *grdimage* on the GMT server::
 
     gmt docs -Q -S grdimage
 
-To see the documentation of the **-B** option in *pscoast*::
+To see the documentation of the **-B** option in *coast*::
 
-    gmt docs pscoast -B
+    gmt docs coast -B
 
 To examine the list of GMT defaults, try::
 

--- a/doc/rst/source/end.rst
+++ b/doc/rst/source/end.rst
@@ -42,8 +42,6 @@ Optional Arguments
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To close the current modern session and finalize any plots requested, we use::
 
     gmt end

--- a/doc/rst/source/figure.rst
+++ b/doc/rst/source/figure.rst
@@ -73,8 +73,6 @@ Optional Arguments
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To start a new figure in your current modern mode session by the name Regional and
 request we make both a PDF and an EPS file, try::
 
@@ -87,14 +85,14 @@ To start a new figure GlobalMap that should be returned as a JPEG file with a 1 
 around the image, try::
 
     gmt begin
-    gmt figure GlobalMap jpg A1c
+    gmt figure GlobalMap jpg A+m1c
     gmt ...
     gmt end show
 
 If the same figure were to be called Global Map.jpg you would need quotes::
 
     gmt begin
-    gmt figure 'Global Map' jpg A1c
+    gmt figure 'Global Map' jpg A+m1c
     gmt ...
     gmt end show
 

--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -44,7 +44,7 @@ Synopsis
     as figure name for single-figure sessions [gmtsession].  Likewise, the optional
     *format* can be used to override the default graphics format [PDF].
 
-**gmt figure** [*prefix*] [*format(s)*] [*options*]
+**gmt figure** *prefix* [*format(s)*] [*options*]
     Specifies the desired name, output format(s) and any custom arguments that should
     be passed to :doc:`psconvert` when producing this figure.  All subsequent plotting
     will be directed to this current figure until another **gmt figure** command is issued
@@ -69,7 +69,7 @@ If no module is given then several other options are available:
 **--help**
     List and description of GMT modules.
 
-**--new-script**\ [=*L*]
+**--new-script**\ [=\ *L*]
     Write a GMT modern mode script template to stdout. Optionally append the desired
     scripting language among *bash*, *csh*, or *batch*.  Default is the main shell
     closest to your current shell (e.g., bash for zsh, csh for tcsh).

--- a/doc/rst/source/gmtdefaults.rst
+++ b/doc/rst/source/gmtdefaults.rst
@@ -66,11 +66,7 @@ are user-definable in GMT.
 Examples
 --------
 
-.. include:: explain_example.rst_
-
-To get a copy of the GMT parameter defaults in your home directory, run
-
-   ::
+To get a copy of the GMT parameter defaults in your home directory, run::
 
     gmt defaults -D > ~/gmt.conf
 

--- a/doc/rst/source/gmtget.rst
+++ b/doc/rst/source/gmtget.rst
@@ -50,18 +50,12 @@ Optional Arguments
 Examples
 --------
 
-.. include:: explain_example.rst_
-
-To list the value of the parameter PS_COMMENTS:
-
-   ::
+To list the value of the parameter PS_COMMENTS::
 
     gmt get PS_COMMENTS
 
 To get both the values of the parameter
-MAP_GRID_CROSS_SIZE_PRIMARY and MAP_GRID_CROSS_SIZE_SECONDARY on one line, try
-
-   ::
+MAP_GRID_CROSS_SIZE_PRIMARY and MAP_GRID_CROSS_SIZE_SECONDARY on one line, try::
 
     gmt get MAP_GRID_CROSS_SIZE_PRIMARY MAP_GRID_CROSS_SIZE_SECONDARY
 

--- a/doc/rst/source/gmtset.rst
+++ b/doc/rst/source/gmtset.rst
@@ -73,12 +73,8 @@ Optional Arguments
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To change annotation font to 12-point Helvetica, select grid-crosses of
-size 0.1 inch, and set annotation offset to 0.2 cm:
-
-   ::
+size 0.1 inch, and set annotation offset to 0.2 cm::
 
     gmt set FONT_ANNOT_PRIMARY 12p,Helvetica \
             MAP_GRID_CROSS_SIZE_PRIMARY 0.1i MAP_ANNOT_OFFSET_PRIMARY 0.2c

--- a/doc/rst/source/inset.rst
+++ b/doc/rst/source/inset.rst
@@ -127,8 +127,6 @@ Optional Arguments
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To make a simple basemap plot called inset.pdf that demonstrates the inset module, try
 
    ::

--- a/doc/rst/source/isogmt.rst
+++ b/doc/rst/source/isogmt.rst
@@ -27,15 +27,11 @@ variable GMT_TMPDIR.
 Examples
 --------
 
-.. include:: explain_example.rst_
-
-Run the shell script *script.gmt* in isolation mode
-
-  ::
+Run the shell script *script.gmt* in isolation mode::
 
     isogmt sh script.gmt
 
-`See Also <#toc4>`_
--------------------
+See Also
+--------
 
 :doc:`gmt`, :doc:`gmt.conf`

--- a/doc/rst/source/subplot.rst
+++ b/doc/rst/source/subplot.rst
@@ -245,11 +245,7 @@ Optional Arguments
 Examples
 --------
 
-.. include:: explain_example.rst_
-
-To make a minimalistic 2x2 basemap layout called panels.pdf, try
-
-   ::
+To make a minimalistic 2x2 basemap layout called panels.pdf, try::
 
     gmt begin panels pdf
       gmt subplot begin 2x2 -Fs8c -M5p -A -SCb -SRl -Bwstr


### PR DESCRIPTION
- The examples in some manpages can be run verbatim as written. So no
  need to include the explain_example.rst_
- Fixes some typos