### PR TITLE
Set HAVE_GIT_VERSION to TRUE if it is a git repository

### DIFF
--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -40,7 +40,7 @@ endif (NOT CMAKE_BUILD_TYPE)
 # Here we change it to add the git commit hash for non-public releases
 set (GMT_PACKAGE_VERSION_WITH_GIT_REVISION ${GMT_PACKAGE_VERSION})
 
-# Check if it's a git repository of not
+# Check if it's a git repository or not
 if (EXISTS ${GMT_SOURCE_DIR}/.git)
 	set (HAVE_GIT_VERSION TRUE)
 endif (EXISTS ${GMT_SOURCE_DIR}/.git)

--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -39,9 +39,14 @@ endif (NOT CMAKE_BUILD_TYPE)
 
 # Here we change it to add the git commit hash for non-public releases
 set (GMT_PACKAGE_VERSION_WITH_GIT_REVISION ${GMT_PACKAGE_VERSION})
+
+# Check if it's a git repository of not
+if (EXISTS ${GMT_SOURCE_DIR}/.git)
+	set (HAVE_GIT_VERSION TRUE)
+endif (EXISTS ${GMT_SOURCE_DIR}/.git)
+
 # Add the last git commit hash and date to the package version if this is a non-public release.
 # A non-public release has a FALSE 'GMT_PUBLIC_RELEASE' variable in 'ConfigDefault.cmake'.
-#set (HAVE_GIT_VERSION)
 if (GIT_FOUND AND NOT GMT_PUBLIC_RELEASE)
 	# Get the last git commit hash
 	execute_process (
@@ -55,7 +60,6 @@ if (GIT_FOUND AND NOT GMT_PUBLIC_RELEASE)
 		message (STATUS "Unable to determine git commit hash for non-public release - ignoring.")
 	else (GIT_RETURN_CODE)
 		if (GIT_COMMIT_HASH)
-			set (HAVE_GIT_VERSION TRUE)
 			# For non-public release, add the last git commit hash and date
 			execute_process (
 				COMMAND ${GIT_EXECUTABLE} log -1 --date=short --pretty=format:%cd


### PR DESCRIPTION
Check if the `.git` directory exists to determine if it's a git repository.

For a git repository, set HAVE_GIT_VERSION to TRUE, and enable the `gmt_release` target.