### PR TITLE
Implement minimum-curvature spline infill for grdfill

### DIFF
--- a/doc/rst/source/grdfill.rst
+++ b/doc/rst/source/grdfill.rst
@@ -42,8 +42,8 @@ Required Arguments
 
 **-A**\ *mode*\ [*arg*]
     Specify the hole-filling algorithm to use.  Choose from **c** for constant
-    fill and append the constant value, **n** for nearest neighbor (and optionally
-    append a search radius in pixels), or **s** for bicubic spline [NOT IMPLEMENTED YET].
+    fill (and append the constant value), **n** for nearest neighbor (and optionally
+    append a search radius in *pixels*), or **s** for minimum curvature splines.
 
 .. _-G:
 

--- a/src/grdfill.c
+++ b/src/grdfill.c
@@ -223,14 +223,14 @@ GMT_LOCAL int do_splinefill (struct GMTAPI_CTRL *API, struct GMT_GRID *G, double
 	for (k = 1; k <= 2; k++) {
 		if (d_limit[XLO]) d_limit[XLO]--, wesn[XLO] -= G->header->inc[GMT_X];	/* Move one column westward */
 		if (d_limit[XHI] < (G->header->n_columns-1)) d_limit[XHI]++, wesn[XHI] += G->header->inc[GMT_X];	/* Move one column eastward */
-		if (d_limit[YLO]) d_limit[YLO]--, wesn[YLO] -= G->header->inc[GMT_Y];	/* Move one row northward */
-		if (d_limit[YHI] < (G->header->n_rows-1)) d_limit[YHI]++, wesn[YHI] += G->header->inc[GMT_Y];	/* Move one row southward */
+		if (d_limit[YLO]) d_limit[YLO]--, wesn[YHI] += G->header->inc[GMT_Y];	/* Move one row northward */
+		if (d_limit[YHI] < (G->header->n_rows-1)) d_limit[YHI]++, wesn[YLO] -= G->header->inc[GMT_Y];	/* Move one row southward */
 	}
 	n_constraints = (d_limit[YHI] - d_limit[YLO] - 1) * (d_limit[XHI] - d_limit[XLO] - 1) - n_in_hole;
 	x = gmt_M_memory (GMT, NULL, n_constraints, double);
 	y = gmt_M_memory (GMT, NULL, n_constraints, double);
 	z = gmt_M_memory (GMT, NULL, n_constraints, gmt_grdfloat);
-	for (row = d_limit[YLO]; row < d_limit[YHI]; row++) {
+	for (row = d_limit[YLO], k = 0; row < d_limit[YHI]; row++) {
 		for (col = d_limit[XLO]; col < d_limit[XHI]; col++) {
 			node = gmt_M_ijp (G->header, row, col);
 			if (gmt_M_is_fnan (G->data[node])) continue;

--- a/src/grdfill.c
+++ b/src/grdfill.c
@@ -91,7 +91,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   n<radius> Fill in NaNs with nearest neighbor values;\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     append <max_radius> nodes for the outward search.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     [Default radius is sqrt(xn^2+by^2)]\n");
-//	GMT_Message (API, GMT_TIME_NONE, "\t   s Fill in NaNs with a spline (optionally append tension).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   s Fill in NaNs with a spline (optionally append tension).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-G <outgrid> is the file to write the filled-in grid.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-L Just list the subregions w/e/s/n of each hole.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   No grid fill takes place and -G is ignored.\n");
@@ -199,7 +199,7 @@ GMT_LOCAL int do_constant_fill (struct GMT_GRID *G, unsigned int limit[], gmt_gr
 	return GMT_NOERROR;
 }
 
-#if 0
+#if 1
 GMT_LOCAL int do_splinefill (struct GMTAPI_CTRL *API, struct GMT_GRID *G, double wesn[], unsigned int limit[], unsigned int n_in_hole, double value) {
 	/* Algorithm 2: Replace NaNs with a spline */
 	char input[GMT_STR16] = {""}, output[GMT_STR16] = {""}, args[GMT_LEN256] = {""}, method[GMT_LEN32] = {""};
@@ -607,7 +607,7 @@ int GMT_grdfill (void *V_API, int mode, void *args) {
 						error = do_constant_fill (Grid, limit, (gmt_grdfloat)Ctrl->A.value);
 						break;
 					case ALG_SPLINE:	/* Fill in using a spline */
-						//error = do_splinefill (API, Grid, wesn, limit, n_nodes, Ctrl->A.value);
+						error = do_splinefill (API, Grid, wesn, limit, n_nodes, Ctrl->A.value);
 						break;
 				}
 				if (error) {

--- a/src/grdfill.c
+++ b/src/grdfill.c
@@ -220,18 +220,23 @@ GMT_LOCAL int do_splinefill (struct GMTAPI_CTRL *API, struct GMT_GRID *G, double
 	}
 	/* Add up to 2 rows/cols around hole, but watch for grid edges */
 	gmt_M_memcpy (d_limit, limit, 4, unsigned int);	/* d_limit will be used to set the grid domain */
+	/* Undo the half grid inc padding done in the main */
+	wesn[XLO] += 0.5 * G->header->inc[GMT_X];
+	wesn[XHI] -= 0.5 * G->header->inc[GMT_X];
+	wesn[YLO] += 0.5 * G->header->inc[GMT_Y];
+	wesn[YHI] -= 0.5 * G->header->inc[GMT_Y];
 	for (k = 1; k <= 2; k++) {
 		if (d_limit[XLO]) d_limit[XLO]--, wesn[XLO] -= G->header->inc[GMT_X];	/* Move one column westward */
 		if (d_limit[XHI] < (G->header->n_columns-1)) d_limit[XHI]++, wesn[XHI] += G->header->inc[GMT_X];	/* Move one column eastward */
 		if (d_limit[YLO]) d_limit[YLO]--, wesn[YHI] += G->header->inc[GMT_Y];	/* Move one row northward */
 		if (d_limit[YHI] < (G->header->n_rows-1)) d_limit[YHI]++, wesn[YLO] -= G->header->inc[GMT_Y];	/* Move one row southward */
 	}
-	n_constraints = (d_limit[YHI] - d_limit[YLO] - 1) * (d_limit[XHI] - d_limit[XLO] - 1) - n_in_hole;
+	n_constraints = (d_limit[YHI] - d_limit[YLO] + 1) * (d_limit[XHI] - d_limit[XLO] + 1) - n_in_hole;
 	x = gmt_M_memory (GMT, NULL, n_constraints, double);
 	y = gmt_M_memory (GMT, NULL, n_constraints, double);
 	z = gmt_M_memory (GMT, NULL, n_constraints, gmt_grdfloat);
-	for (row = d_limit[YLO], k = 0; row < d_limit[YHI]; row++) {
-		for (col = d_limit[XLO]; col < d_limit[XHI]; col++) {
+	for (row = d_limit[YLO], k = 0; row <= d_limit[YHI]; row++) {
+		for (col = d_limit[XLO]; col <= d_limit[XHI]; col++) {
 			node = gmt_M_ijp (G->header, row, col);
 			if (gmt_M_is_fnan (G->data[node])) continue;
 			x[k] = gmt_M_grd_col_to_x (GMT, col, G->header);
@@ -240,12 +245,13 @@ GMT_LOCAL int do_splinefill (struct GMTAPI_CTRL *API, struct GMT_GRID *G, double
 			k++;
 		}
 	}
+	V->n_rows = n_constraints;	/* Must specify how many input points we have */
 	GMT_Put_Vector (API, V, GMT_X, GMT_DOUBLE, x);
 	GMT_Put_Vector (API, V, GMT_Y, GMT_DOUBLE, y);
 	GMT_Put_Vector (API, V, GMT_Z, GMT_FLOAT,  z);
-	V->n_rows = k;	/* Must specify how many input points we have */
 	/* Associate our input data vectors with a virtual input file */
-	GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_POINT, GMT_IN, V, input);
+	if (GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_VECTOR, GMT_IS_POINT, GMT_IN, V, input) == GMT_NOTSET)
+		return (API->error);
 	/* Prepare the greenspline command-line arguments */
 	mode = (gmt_M_is_geographic (GMT, GMT_IN)) ? 2 : 1;
 	if (value > 0.0)
@@ -466,8 +472,8 @@ GMT_LOCAL void nearest_interp (struct GMT_CTRL *GMT, struct GMT_GRID *In, struct
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
 int GMT_grdfill (void *V_API, int mode, void *args) {
-	char *ID = NULL;
-	int error = 0;
+	char *ID = NULL, *RG_orig_hist = NULL;
+	int error = 0, RG_id;
 	unsigned int hole_number = 0, row, col, limit[4], n_nodes;
 	uint64_t node, offset;
 	int64_t off[4];
@@ -547,6 +553,11 @@ int GMT_grdfill (void *V_API, int mode, void *args) {
 			Return (API->error);
 		}
 		if (Ctrl->L.mode) gmt_set_segmentheader (GMT, GMT_OUT, true);
+	}
+	
+	if (Ctrl->A.mode == ALG_SPLINE) {	/* Must preserve the original -RG history which greenspline messes with */
+		RG_id = gmt_get_option_id (0, "R") + 1;
+		if (GMT->init.history[RG_id]) RG_orig_hist = strdup (GMT->init.history[RG_id]);
 	}
 	
 	/* To avoid having to check every row,col for being inside the grid we set
@@ -635,6 +646,11 @@ int GMT_grdfill (void *V_API, int mode, void *args) {
 	else {
 		GMT_Report (API, GMT_MSG_VERBOSE, "No holes detected in grid - grid was not updated\n");
 	}
-	
+
+	if (Ctrl->A.mode == ALG_SPLINE) {
+		if (GMT->init.history[RG_id]) gmt_M_str_free (GMT->init.history[RG_id]);
+		if (RG_orig_hist) GMT->init.history[RG_id] = RG_orig_hist;
+	}
+
 	Return (GMT_NOERROR);
 }

--- a/test/grdfill/splinefill.ps
+++ b/test/grdfill/splinefill.ps
@@ -1,0 +1,1286 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.1.0_d0c986d_2019.10.22 [64-bit] Document from grdimage
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Tue Oct 22 12:35:48 2019
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+-3600 PSL_xorig sub PSL_page_xsize 2 div add 900 TM
+
+% PostScript produced by:
+%@GMT: gmt grdimage islands.nc -JQ6i -Ct.cpt -B -BWSne -Xc -Y0.75i -R199.5/206/18/23
+%@PROJ: eqc 199.50000000 206.00000000 18.00000000 23.00000000 -361383.919 361383.919 2001510.936 2557486.195 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=202.75 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.180918 +units=m +no_defs
+%GMTBoundingBox: -216 54 432 332.308
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 5538 D
+-7200 0 D
+P
+PSL_clip N
+V N -46 -46 T 7292 5631 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Decode [0 1 0 1 0 1] /Width 79 /Height 61 /BitsPerComponent 8
+   /ImageMatrix [79 0 0 -61 0 61] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[@LV$%#Y5(&k[TQ94uX:M,cXX=OBM6.UW##\_Zo86Hi4LaZ.8AC2kBEOXL6;6)kYc?nui\R@foZ$FVNc^d.Aq;/G2?V883
+TGI&'E<Dj$\3o&jEKdn%SAIjo-E'[E-8#ptE8WqO`&Zg.ELJjQ*%-aZ;hQU>P[I*<V4"V_"f<JBRAn>.B50+XRG(=dV@fS`
+OZOUq)T/aAcoBK"a;rKW7e*E,SsdQ%o[O7nHOL-s0n_u=5V7M$!JQ,J*(U]T#]!'>h?pJTEE=%u8E*;X5F$c4!6?&UjPf*S
+6B3iJ!BJ&^"6:(nKrG9t2*`5!B+*AHL:RaPUNS=#g;A"P#:&r@17hF]CA"DX3KQ2>j_N9E2BgNROLDFh)H\.YR(u<@^s!GB
+X?<kFjDhG&'r4aQ)E1\b*+e\7b1Y=,93>rbYVuQm'nRD2I2"FW"$M>o,qQ$L<OkW]mBI7b#N8-?3Yg+8?#:IRaf@](@-.qQ
+E%;Xb!5@l2H3QU!78,^?m!rB!2_<r'XX6;nLD2gg<&EMJ/7)14:!),o^C.LE9poX5R9j7.kLB#>o+`]K^19l+]##F^M@QG%
+q]D1@R#WpBA%KnV2l;f6HkotX((jMRg26_')q2Z-XbNp7*=3i9Yb(4nE=POiS-+\PRU$/qh)#U`!5FB^'uO5cWCe)Ta"(Uq
+ju=3L0]/&0P4U,IPd?9L?lBiLmP2DmoFDop!P9$;DW,Zl%"&b6]B7SlOK/Su?uJU;ZC7&^hWi$AQug8(4HIIJboTl.[FIra
+J4cJb@p(pi#eVU39+5`4WQQJmX6#<QS5CMR?nX7J`q1,^Ims8k^!8t-R22LBPHlI[>^)gM#K\kkMB03E`NB\5$P!R*rUQp[
+m^j2+@nA4/(BRns4]fN0Qr(#&dNJ438Mf3/IYGVLQcb_tnY?Te`aKZZ"4Y(*bYO(6&cY+'1>QNQa`IQp]pEG*St?&3$0#rT
+<QD7Gh(d`'L%)*g4.^ereJV3K&LEK@bXre8S6<<&f7U^h6%PH@`<d[@JEs!$fEh7$:Mp0$MdIEk%RQW5cqfGh(PhWd?XE/d
+I"h>BnL=<bkuCjR%d6eWf%C2#3`'M&*\hZ8HFG'ZMHOpj&S6A\.UQh"<B3FKEfYpZLOE@KKHA2kAIM/!_iL6N/BFT,YYa;o
+I]0*lfFK"6%tX%li]6#_/POcaXt]gBktc>8Rf:S(.FT6GX![:5QX54#3i9ocIWQb!*Y.JNR)+-?15g#ahuNd*Xu-JhWonY(
+g73FN$s^d=JPcGkcZC;g,P@"*=ko1Z$:TcrgY@!,h^%&LI$FD&"RbGI(W9ASQ/lf>&jHr94:asYOg%J]f*lrb&ie5lQdmiM
+V$iB4jp4qk,6jFB)cc'2\2UM_"Uj+"_sSm%;.qW0q9k&Q;8%rU8[>kFr@589ilGtloLJX`Vo!KVB;;fh(C-&55H+4t`-:HO
+VGkhHrgrmX$+hp;=qp:ZdgD^G=E>bW8.i)[1$Tq2\%YQsJ5/AiYkl'o3i15ceMf%X(!XO(.dMm$:f@YJP=\nH!DJ^Kp^3EM
+]j5g<lO;5_n9Zt`p(=+0E"hbAih&W3:7jaI0>0jqom=2u%h*qmCf")Q(.#]DN\LhF^('A7M<Pu,;TGCaiYc-oGmmEb!=%1V
+:\&,U)F/_)!=-PH4n(AtB=:P97'\#fO597@%G`#b],=6;pCQCAnt]R0pPC!?"*`@HM-hAh6bJV-"7a.FA)E'RILgi$K^!?P
+lT>T^K%+Z=rpVr<92XnTa5B&ikp&"clBoUBi?9'Hic.VK7!7JXa$\/hU$rl:gM^MgbAb[5o4u8\M>'"_DEs_3f*G%tf'f!?
+E];j8^g`rf;4-K7)#dh#'CPBrq.U%Jrsq-i2;!*]c<Q"[R)l`@/KK^gOSY9YBH5?,*=59cjVqC?9\@>L8VlPLD>aP24XDV+
+OnbQes+1g<;NDJ5+[/O`0tkp*3TT;-WW0JT(C@QMX[E0SfePnCAXN-K3I-SYLA:S"@-C1XeccBG$1ln=TrgmbjBHredde=P
+hD2U<MkA-Ofoj=E-N6)#B0YoH&]#JB-kRYQ5l<P1qo$7*;n@WAF;!<;!9`KDQb=011hS.^&cp0i^-d'GSj/"nru`BI$R@4F
+IMNWO34cjnN<cG$<o8E\o&(/Z+B=2<fI"^-66nWFmdr"HmqH0tLT>\fFnH]lRYS2oH`.41_>q%fTA0E<nR^_)*hIZm(iP0\
+r=pS,E#V=.;*T\mfAW]6UcsS3oB6j&o(j'AI0qf&LbVCBOptNC&!jU'juX\-6Z8MWqBs`r81^WW9uF85-dd.g`SDbfaaq#_
+i5X+<&^?`k+/&FJaCDEJ?p'4b*YT3YGl4js.nr:[?$qZ7*p\j*m>doAW`j8iJ<4q!r4&QmAV?tn82?2k0iG=L\0`Rn264@n
+fAuME`OWAX[!U4RW5B#L_=4\-MR2:aU"^ppr$c&d'PeYFBH8"DrMgq\`Rh,AD22:R.8[kgBD:[YE*K4P9jWD]9T!+d&D8Aq
+3rkuG8&X#90>OK^%Lq@0NCn1PkQl]_"KsVe-,d!X\@i)PS!)fMEEtk(HU\H`j!qP0A0_Zo1+kObNR?`iHP"1TZmM*s>7ZV*
+-*>Ko;I3YU"RHs"0c.osh0iqpVZ)O+p_rT"X*$DI+FIP5_`!9RBQNZTLN3<DXMp%jN[Xfe\1KQXb90MF`!m\^P-7be7jlB]
+qm=;-T5%KN-Ib!_B[0T<Z@^U[_K2%m\a&Vg.&76er1.nj;cr`UQFRg+g^TY6J:18?h;9Lao.]#WO1X-:ppYolLtNHg`h<Ca
++jUcQXlU;!js5E-80.IB5kRPTPT*en#i7*8q$XjgB5lQ7232Fol2Y!I:5<a)h))?EVu7r)ib<W@7kXl2(4g^8,eMgb9fZ(]
+nR8(37nI)fQs*C!9t33!.>[c+1$Ha2XE>#\N?]<c(%LK\"R*=7^n4A1_2#8i2aKBa4Y=SG++g/h,4\tA.I,N(c"6+S!@4&X
+0#WEK9]%:F'a9d__f2_Lkn):MXZpYraFqj7Xo"XrWlq3G5da0=%k4*h>",r6T7sbg$D^`7ge^V%jWU[k%A6<UORaDR^&WOo
+".p:?(Ld,DrDa;\p,K:-Hlo&X;8T]oY:4L2CCL92[[qjQqK`.5aSD_%,s=<qg'!??ZHd)6&9"PA5R[YL5Z0Bnn9<\a3"lRb
+P>YgPJ@ZheZcuqBec\&?/K$%F@mT4T%C$o*?%j:^A(d)iju&1e5a07-/:MMq?Wl_^RIH%pKDa3[hPD5n<SbI,<Ffr*f7H-N
+#Dsk@e.0U-+6)SUi;ar#Rp6EOZfi&YMQ5*>V`,,&?%K2L6cukW#<aaa@#0TA#>s<,!>#&C3jHterN'#gp`:jZM\+Cq@&0,?
+i=,`<q^"]5Bu2dfVhk(>:?"#`=(]b<.9f4CL)P**`efdi<e-')UQW8C&(N6V&2]M.mXhXq$a=JtU(jp?OZ&=i!MY[&"%p:1
+b9\OhS\&jAA&DY)pc<)>Vg9)XJ_[#S;IVTT5o>3S_Z#EbC-fuX^*`O&4m6!g#Zts*,mIaHK0E)L`9KWcCGpp7"\h@oP;nWf
+Nt0H5!*cicRG=qiL+06i>S^Up)GKuP!mMGo#FFq&%^@%WC_?pE%`n1Ce0FEcMgc8_JZf[V*f=l@+/[JZl@ra4/,^>j!h-+5
+q*&I#bN_IAg58]&K>KUd=p!?R-C.4/\$(M6;>4\$Ss]:4[)UhD:S[B`%5;)e\O/kJ&Fg0X4bgtn"&Xb@@B!JGo-$J`c4"B)
+,Wp()XL>s@c(S+N3^E%!7B8DI]j,Dj7Xb*p9X0;&,B.4<[6<Lpoa^MkXREl0+o[P`LEE58qMET_\57n=rs=k<W;RFe#5^P9
+IUH2SrLkp_@,iC<V;OTB)Rib@%V#!J`Tj,-d,uai(9LkLZ'lm!VkE;gjJT-$#`i);k!RY,hkQFGMB)L7PZ*P;F6C6#@*`.8
+kA,U\'g*h7,sEuIp]mPfrF%CF_@#Xt=FI!MeU@5:lENtc6)Oc52_;-\g,qfno.b%DC@9Kg/^H_sgQ;^o"8a6P,M+fV5(iQO
+1Q(qViU#G-\S/)up'=u+Y^RoZq5Z9P)2`M_'Omd[o$o^]BkfM'"^A5-[pg"N*?)Y)NbA_8A1T?O6Z0./N-4&q!U2dQn)=%_
+7Nc#hfa>VH!4t'!O)Et<5(U?l%?Pc:aAB)IPO&Y)R"a%KBl?0l9e.-I6Mgn#2FXa8#FiZS2aa#p3o:EC1l%9>6G_eJAK,O0
+N@2)T]&Dp(%ggr6Wl6jeX4t];B=2'U/K,7+([S0/!PqtOV'*:XNRC]_rQO#\YS\:JenmZWa4ET!l?bC\gkVOX@Q'ekp(hM>
+=14(t21>@rHEcej#<9'@+=@#q$kAsN5=GFW"L.mZ@/Ys0DH"En8fB8'S.?&<2hs6#A7.oD2hDOUlh4Jjq-Y9o]bB*]%d/G[
+@MUX4B`PSZo.RZ&<DVCm$bs)%dLd0'Vm%0#kJWuW"G8aaPo9jrZ-]\d.<I?S;+RdW$r>W6YR#;#fiYnHKk[c-fj:#Mcuta.
+Y#hi;/%J0o3WLJT@1C?o4!X0^YFQMb<<',BOq14GpO,$:j)B47LgGeOp(6k=;ARa`?@XtjYc5tRJ0I8'R31jd\onNm)ZY$\
+P&BOKR[t>o$$$.l=M]<P(o.=U%UYb4jBh*1DAWT-s$Q,C;e4]K8q4`)*r@$Zj"Au_,JpMkD::ch&7)tV.r3.oZ+W_Op:'?]
+R?i"jVW.k]:NjODZA#Ej>dMl%3[diskHbJCn#Q`K,Hq)-iP+6JQVkik-!++Xg8lcCh5hq?'kM4pl8trOc+"L)_-ki2%oU<R
+lh#&K;VPg[UZRc0G4B\l_L79%H(3PLk*2.K:ZKSp$jugQpoae#Iou7^Q]WWHE_ngfDOQojf\eh-m^dY:D-D6^2V2+?\R3Sc
+<M1AeYr3@!X3=^5rjN1ljeD%H/)-7[Gct4D+-Je&(eO@+s)iQpHoIkQ?!l>*GASR3FnKW#S]_983o[/CRM74'c/tcX$u**9
+@@a0Z8[_!5oD2k6'nfFU*mRFLj!sooj:rsK6TSuS1T*Z8pA(Pi@:1fbm7FM\XnAt-SabncT()0=U.Mn//]UsifW*+ER&i/H
+<.41h7+i't/^2lqOP2UdW-hOTmUqXsVu7Fn'l4'!ru#>U0%K.^>93n?4G!uPEaD3hB4ZdX6TTjc:sV%K"?Z/Ep?Ej(/0ji/
+L*\_<3qD%:-&o;DbRpVVdX78M:^fSYmXQn18^cQeFNg,\'9[K]bpNaEeFV%aQsU]e'Q*k>DP*fb-2\J<)r@6a_+56MRdCF/
+[[s+0,XH&tfP2V`aG$K[FXXI<Ee.UC1a+H.&QPSS6;\+ELV0/IOiHmh&YtagCf1R'GB,Rn9tiGC+QHZkhr@A-2X=kC#n9B$
+Taf"a)rT;k9/g[gT=<&mIb:3HZK9>fV(AoGJbEOOZ,p01#sVFRp>'U#4!f-FSo>eSs5J6OC1*^`AD+!D"ID,VGgH9L\JIW-
+j&.&36?l1MQP79P"uHA>Fq+#@.<aP@2<ed9YKf-=0m0SGnLWis=V>iYh%K]QA6Q;0a0W]8M@D?`6LI"lA];CQTo9\^#g9oS
+`Vq19;"9hoX\%-iT0(OJfQjdPT`>=ogp]F,1U^@:fOWje/C)@qYD\SaPIG51mjHaJe8^fulV$ZO^IXEpA#3#Y=(C-g]3:7k
+967c0mi@AfBcKp,Wh+-\:Ku=7TrW7$*EQdpfd>I'bJM@KSq]o>mf^3C>oR[)D24^Y3mPZg=c-7=S\/?I;65>8S?Zf69Tl-0
+&@C$]=snXIHkUk^,&'DnAZ&SQqXB(N7NkRqUKg%+fSFQHe/lh*Ol,LD$>Lug/Pd;;XpJ/6ctKu.Tid^ZIm_)11c[X,6lXcs
+T*?a=2Q8f;@jb43M3;I^=t6kbrTLNXG</K^U@0#sO$2Q04)B7\9T8<3m)4.%-:'fLK%R@,Q:7;5AM))_/(atuliP%;gWG2,
+Q,"<)';,CrgG1#K6@s6rDgY-_@KNh$U:b/E3D^Fm(CTNF9MT"5p9c<s:^Fgm-;D#1[cs`"gMAtlk7"l!pO4YQAHd#"9JpVM
+FO%H>*_cGPEeY05XP,gnJU8lSBpdF-hVQ((ggYq<Qf4J>MONEu;g=4HXd56B7DLH?c*Fp2cS:_Y_?D718@tQF.Hjq%[?P\b
+)D2\P'/BU0BfnEBEticC%dFu0)G`?6>G%c%m"B(n44H^`BJ=JRpjk8KlP<a2f"B.-n1DO6]B#("8Y8,#Mk?8]@oc"<XL@d+
+Jn?.e);F9GIl,e39pc:PY5"#o(U)bUhsGVbL4>N^-d=YuI]$Jc<Y0Xc:lj<Fmo6UmEU\?_Q`u3H"tH0t&;)i6!op(br:Tm'
+'@<Q.:<PteVAX5ql+1&'),Xn5*62p^JuIH=ZG%83;LVnt@bW%%JtLjGC^QpB>'/uHXW1N^R(:A5X8VuR'sc^OK@rXtDHV:R
+[k:1r3WPo8:42uBF;O8!*TqDhl3C?C"Of028_^SF`CR4`*a\]41;i!:RR3(i6-BblQ986NcVl_O6Kf%h4SoZ$Lu6GK<f_uF
+ef)\uc]?`Z-()C>b]!-HD_ke<ct+a+%oMI0bQ~>
+U
+PSL_cliprestore
+25 W
+8 W
+N 554 0 M 0 -83 D S
+N 554 5538 M 0 84 D S
+N 1662 0 M 0 -83 D S
+N 1662 5538 M 0 84 D S
+N 2769 0 M 0 -83 D S
+N 2769 5538 M 0 84 D S
+N 3877 0 M 0 -83 D S
+N 3877 5538 M 0 84 D S
+N 4985 0 M 0 -83 D S
+N 4985 5538 M 0 84 D S
+N 6092 0 M 0 -83 D S
+N 6092 5538 M 0 84 D S
+N 7200 0 M 0 -83 D S
+N 7200 5538 M 0 84 D S
+N 0 0 M -83 0 D S
+N 7200 0 M 83 0 D S
+N 0 1108 M -83 0 D S
+N 7200 1108 M 83 0 D S
+N 0 2215 M -83 0 D S
+N 7200 2215 M 83 0 D S
+N 0 3323 M -83 0 D S
+N 7200 3323 M 83 0 D S
+N 0 4431 M -83 0 D S
+N 7200 4431 M 83 0 D S
+N 0 5538 M -83 0 D S
+N 7200 5538 M 83 0 D S
+83 W
+N -42 0 M 0 277 D S
+N 7242 0 M 0 277 D S
+1 A
+N -42 277 M 0 277 D S
+N 7242 277 M 0 277 D S
+0 A
+N -42 554 M 0 277 D S
+N 7242 554 M 0 277 D S
+1 A
+N -42 831 M 0 277 D S
+N 7242 831 M 0 277 D S
+0 A
+N -42 1108 M 0 277 D S
+N 7242 1108 M 0 277 D S
+1 A
+N -42 1385 M 0 277 D S
+N 7242 1385 M 0 277 D S
+0 A
+N -42 1662 M 0 276 D S
+N 7242 1662 M 0 276 D S
+1 A
+N -42 1938 M 0 277 D S
+N 7242 1938 M 0 277 D S
+0 A
+N -42 2215 M 0 277 D S
+N 7242 2215 M 0 277 D S
+1 A
+N -42 2492 M 0 277 D S
+N 7242 2492 M 0 277 D S
+0 A
+N -42 2769 M 0 277 D S
+N 7242 2769 M 0 277 D S
+1 A
+N -42 3046 M 0 277 D S
+N 7242 3046 M 0 277 D S
+0 A
+N -42 3323 M 0 277 D S
+N 7242 3323 M 0 277 D S
+1 A
+N -42 3600 M 0 277 D S
+N 7242 3600 M 0 277 D S
+0 A
+N -42 3877 M 0 277 D S
+N 7242 3877 M 0 277 D S
+1 A
+N -42 4154 M 0 277 D S
+N 7242 4154 M 0 277 D S
+0 A
+N -42 4431 M 0 277 D S
+N 7242 4431 M 0 277 D S
+1 A
+N -42 4708 M 0 277 D S
+N 7242 4708 M 0 277 D S
+0 A
+N -42 4985 M 0 277 D S
+N 7242 4985 M 0 277 D S
+1 A
+N -42 5262 M 0 276 D S
+N 7242 5262 M 0 276 D S
+0 A
+N 0 -42 M 277 0 D S
+N 0 5580 M 277 0 D S
+1 A
+N 277 -42 M 277 0 D S
+N 277 5580 M 277 0 D S
+0 A
+N 554 -42 M 277 0 D S
+N 554 5580 M 277 0 D S
+1 A
+N 831 -42 M 277 0 D S
+N 831 5580 M 277 0 D S
+0 A
+N 1108 -42 M 277 0 D S
+N 1108 5580 M 277 0 D S
+1 A
+N 1385 -42 M 277 0 D S
+N 1385 5580 M 277 0 D S
+0 A
+N 1662 -42 M 276 0 D S
+N 1662 5580 M 276 0 D S
+1 A
+N 1938 -42 M 277 0 D S
+N 1938 5580 M 277 0 D S
+0 A
+N 2215 -42 M 277 0 D S
+N 2215 5580 M 277 0 D S
+1 A
+N 2492 -42 M 277 0 D S
+N 2492 5580 M 277 0 D S
+0 A
+N 2769 -42 M 277 0 D S
+N 2769 5580 M 277 0 D S
+1 A
+N 3046 -42 M 277 0 D S
+N 3046 5580 M 277 0 D S
+0 A
+N 3323 -42 M 277 0 D S
+N 3323 5580 M 277 0 D S
+1 A
+N 3600 -42 M 277 0 D S
+N 3600 5580 M 277 0 D S
+0 A
+N 3877 -42 M 277 0 D S
+N 3877 5580 M 277 0 D S
+1 A
+N 4154 -42 M 277 0 D S
+N 4154 5580 M 277 0 D S
+0 A
+N 4431 -42 M 277 0 D S
+N 4431 5580 M 277 0 D S
+1 A
+N 4708 -42 M 277 0 D S
+N 4708 5580 M 277 0 D S
+0 A
+N 4985 -42 M 277 0 D S
+N 4985 5580 M 277 0 D S
+1 A
+N 5262 -42 M 276 0 D S
+N 5262 5580 M 276 0 D S
+0 A
+N 5538 -42 M 277 0 D S
+N 5538 5580 M 277 0 D S
+1 A
+N 5815 -42 M 277 0 D S
+N 5815 5580 M 277 0 D S
+0 A
+N 6092 -42 M 277 0 D S
+N 6092 5580 M 277 0 D S
+1 A
+N 6369 -42 M 277 0 D S
+N 6369 5580 M 277 0 D S
+0 A
+N 6646 -42 M 277 0 D S
+N 6646 5580 M 277 0 D S
+1 A
+N 6923 -42 M 277 0 D S
+N 6923 5580 M 277 0 D S
+0 A
+8 W
+N -83 0 M 7366 0 D S
+N -83 -83 M 7366 0 D S
+N 7200 -83 M 0 5705 D S
+N 7283 -83 M 0 5705 D S
+N 7283 5538 M -7366 0 D S
+N 7283 5622 M -7366 0 D S
+N 0 5622 M 0 -5705 D S
+N -83 5622 M 0 -5705 D S
+554 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-160°) tc Z
+1662 -167 M (-159°) tc Z
+2769 -167 M (-158°) tc Z
+3877 -167 M (-157°) tc Z
+4985 -167 M (-156°) tc Z
+6092 -167 M (-155°) tc Z
+7200 -167 M (-154°) tc Z
+-167 0 M (18°) mr Z
+-167 1108 M (19°) mr Z
+-167 2215 M (20°) mr Z
+-167 3323 M (21°) mr Z
+-167 4431 M (22°) mr Z
+-167 5538 M (23°) mr Z
+%%EndObject
+0 A
+FQ
+O0
+0 6180 TM
+
+% PostScript produced by:
+%@GMT: gmt grdimage new.nc -Ct.cpt -B -BWSne -Y5.15i -R199.5/206/18/23 -JQ6i
+%@PROJ: eqc 199.50000000 206.00000000 18.00000000 23.00000000 -361383.919 361383.919 2001510.936 2557486.195 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=202.75 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.180918 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 5538 D
+-7200 0 D
+P
+PSL_clip N
+V N -46 -46 T 7292 5631 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Decode [0 1 0 1 0 1] /Width 79 /Height 61 /BitsPerComponent 8
+   /ImageMatrix [79 0 0 -61 0 61] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[@LVLO0`c(B8=AQJ(-lAiJC;V+MGt50s<CcmVnO+d@L$d\KH3"DimGJfom4h=E^L-5.Ti'ArPT0Al-_cCOho^"a;1on+0;
+q@(pDf3Yop[;fJ2<&'WQ9qaVHC8beoDlA0oq_r:=@jl1BBddRAC+*o>KZHR&`5j4F,fuk(jN-E('ZlT]<6<Y2eB'Ph1s#;<
+[?U$#5FDP"gAqbH)$\cPc(KM:<Q:JA]L?-Ij0qNt@5h]#aVLfU:^s'/Ya,B26RdZ$,oCP,=Mf;4#nFmnVi7ed^n(Yh'Y\VW
+j,cNdP)09]MG+59$Y2k?.Y(b)j?EKY!..XA[fNC601J7naR$c4T.X-^3X+kN?5hc1IUeU,`YDl%19CRk':Z1U'thBpFts24
+(9hH1Te;MIO+k_!O`FX90dks7)+UNnSe&A^X]?0`%?MM0aM-$u+k$J=>I[VIQ5\D@>q2nuL-Q6%)e/&r<$u7d7>N9@!ptT-
+X2)M0TJ2l)E<DVQn5YUiPYoEnfd1lq,+d7u"3Al?@V:ts$G;&:$gP;QGuN\2_=k#]o,)p'^G"n6<W%i$MNfrhA.)#8_[LFg
+%OCT>Rq*keCa69MbR$$HPM(l/mt.U8/:nL.];^:Lb-[gBM]n!fLO@/tlt7V4S,lMBBA]H,C=g16f9HFi^oudI8b!PuWfk<s
+GXVbX*!O5il<@0=P'k5A=hFG3VK%jE9et>A>fH@mYZjDsANiW7_#&\lXZfGf\ZESfqN_7,Mck>j/PaN@3N#ioZe0Y&m87Cq
+REpO)VuZBKQGt+oi(`]F,'[Ta>aFoeRbnt!*ALG"G*^?bA:>dkpC7(8c4JH51/lQ_@G[0BY.JJJ"3K*rMXA#n_(H3[%1Y2T
+NVlkBgiFq(a5Y`d-3-0+H7js:1Ei[28V4nX`RT3#p_F'L?cmT@b*+%%)hhS1%8]8lQp2G!B]t<KL!0u](W[SIDQbED_X"+M
+FNDfO^kuV<X_t+U2Ze4m]e.PNe`mhsnUcoo1hO]A84K^cJBLC4P9@b:i5[Pp>(kdgH.`c(aXbsCc,Qs+A6_ZH'`)O+5.='Y
+GPU?Db9ma)0XT0]-M&Z;G853K`quh>;&(K)?MCG/7D51PE_3CC+GeI;,NY!0GZPbO/TQmTYm5\\6A=jN1nb>7X2>IK5KrXq
+)-A;.?mF1LC?ut!mLF3LB5$)Ik]/HAaIFOI!L`]XdA6T+bR\70ii*:"93ccQJnq>(9D[%jX?3qj!b2T+[E?_)Ob3c6&%bk,
+Cl+`r5tQ4]d3*B?[f]+qfH&LnR"s0gNhu8:)EVIQ>&SK*_Yh9t@RJlYD$e&WI)2-6dOgf'](E[/J%,Z2gM_ff0jELe,Q3q]
+-*4-P]Q!rlW2[sTW1/qZE'?&a<G\p+AbA@:q$<Q$WdRVEG>b\mM+SW=$Zr!4iH@V-_bcLQ*jOV.mFXC=aeJXL/o4O4SDc$-
+[_'T:Hf3<]Qd33bcDBhZ4a*OI`spiYf?*B351&bQIc7LMiRPft:XmVY3Is>KI#esCX"C(fPPNJ0.1=K0BFn5%<C\Fd+0bU1
+#.;)^GXQ'_nc28h@H;$j[ugdApc^l.VH.VJXS4b@jtc_F'REDJ+P&%q?"2c!`']8S)1'F,[JG8T]_"7.e6h21FYN_Z[R!sA
+AI/,iFc:<"n.ect-"MI9/[bKo0Jium@kXNQ3'\RtkXeea>QUk%0]2q8Wrq3J^!,%W!)&WsqORTA`_ZH[4U^5/"0Y_QcgAti
+/rTM=H[o1$A*B5Pa6&N_i\*Y\$lq%/g<_$25I8DE"aBn[q!^G70;5P<@@/@:FqaA#gY"66Tjo[.o.m*pck*.P*j:)_;B!KK
+RM<$l_Vl"0en:]'4[U_Q@[f/mb[C$TL5m2+@(EcQEQ8!4@9Tp",]hj,GUWcRJ[0r;RR^f]2[o)^bI@;J0rY%N^Ae3"gBhLF
+6#_A9>Ci+6`41o?R_VH6cX7hL8CQ]?;Sik,O2[;"g5OoiO+?+4]Ycme^,GTsKP7j+bL!&YKB=VNDog^f]PKM!bW\+"n46\T
+"JB(%6teU^ZX1I,G8`NgIf;&=\eh>gNl-0:rH:tMInM$+Zh1>rjV?g$9E-qfHr\,0#&e+gU!I..)\!fs&R8q#@Nj0:6XLc.
+`mAdM9!a=@H_HE4E,J^!a_="4j(blH&[8?6=CbW]rGeq=KK[aH,UtTV()2K_gAaR#(K+>:^'7s*^a4:mWX@pnJs1s,96QEQ
+l$XE;IULh;=*%DaoiK)#a1T`fW!KiJ!1+q&>QdXG#t%?+XEocJ'la=OfmDIeoa-cq\;a'dl;+YS*'BLGe;'-8DL5)PIPpqA
+*rufi`0a,PA.eOmJRqQ+q%h%qcs,gr^'9PjTsYn#=NNn37'DN,]4pJr"a*e+5'#n]9>A+2S37f8RPgj!U%r>Hfi':9%q4.^
+Cr/OmhtB:2+iq6S^O;Qkg1tlDrMZ"(>$KN"UpUIm2JG:6n8nb(`_IpOK!uedjCF`jPo&DJCd'j:/irn8,\r%a1\U<]V);))
+0bArq<`TrN`IC.^G6@VEbfhd7ee?F]BE7`VI^gIAb6#*iB\aq!0eJp_X1,l]m7/un"s"Om]1=*NF4Rf,6Dn`2SMP?j4tX#C
+Gcb;B\)0;lXmo^aV77-p$/dDTCQ3-KnS:!'Y<^]/q"crI0#shP-3gu)T%eNRiW]:>$dM^\2#Gi6KWtT\M.u`cQh;r5IC=as
+l3JO6HO`8P"5/W]mNC<7#:PC(j6;W3_f5\8HPVMk%CFL%iQ\gjr[-K[(%5^7phP+*d2U7q)M*][\/mQ"8kC$D1LAlb,rU6Q
+_,ckp`gK)5VSk^BC&Pn2\!`D]rgl@uD$["oej5=(gRGImoap4g^cVbd6n\GW.G<n2QXesq/;1PKn(EYtR_8P5jr._&&@A\i
+^fQVmM3cZ^!`j=SYA5BnHiThNX9QNN.81Rs)M3>HDtYEG[REo=d^%S[(="P2[*SuP'dqtI0B(2Zpk'HOb>-Coi*FV>GHk]1
+C:bq4.Q>ufeB96MMulpMWjE*lUFcWbT/6`mrg;9^TsSf!""tl?rIP%J,qeD:&Su\"2ZEsE4CHIMpMYVU:Ef9K"c8%"_f&:8
+#<!aA[!'84Ch*<VeuLKlh!0UZD^cPhRah9`PmOG*SYUGD'7P'Af+t;A8N&qn#I.>Gm_O,+X\Su^8H^u:&d):XlF71),^p5F
+&Ic!<IL4;-[FYW>bBT)bo&&q[eJ$Z[_#!VMJ`99VeS;:baM=q.!+8cQnce7C-?pa#RssPmbQTR!7Kcl[1F<M^YFn/Y!k>B5
+XCsJ\o.pO5LE*tPGmS*l!HXVYX@H*2Qg`LPU&/&u$_bNAKm(D<*2OgE!P?OZUN\PaP0U_Yd8alNfU,*7/b^`Q2(0-P[s*p`
+g>'<E$4]\Xqf=1$=ina$:@bGYpHXepj/<[.j#Xj&.aGCCj4Aps!PSOl4s-Ysd3kY&(8[9kD\at:"CF0LP]&-+3adQc&-j:/
+s(un.%j(EO3jI7mfo2&oi5'P4ni[Q6a"YqE5j$Gk#^,5rNmTXhM%N+DYenakL=UE@@P]`CAo>U<Dm0H<1h9sQ@fan,!!T,c
+-%92:W`qk6W$?4c"(/AU@%6"@.A@J"Bd0e`KH^(.P^KHp93/@!fAKNLL(?0:SqgUC!9?qL)TY&[-mdF_Ea]6^$Mt*oe-)*i
+FIMNpS'\Eb&$XL)M_0GspA6rq'rqF*XlpU2)/'`$*QEM$Iq3Ma!8+T;anTin0oSZ*A@(LbgL/HZ&84hU43cdF3+=sSfe<cu
+<KQ5MY",X1Mgc#XJHlI+O4cJ+)Q(kJeIBB[=*c[4(c50[o3K]C[ag))V%k*H#),p1[/dFR8M&m5DHG&&Rsd(lO%k!5>,,rs
+\'aqP!LPeF>Vupr6H!C/Fse19O'!-oR&,!+eq`lc3jq;#6c"U`BYFqqFUf_gPlY>1.U'hdl/bNI1[N4BUPd;)m"6gp2$IWX
+<`7NXm7VfolOuY33'[<VFk0JXpY\R[MZ5jc.8fso]FFSHMuCFH:A&tN%"aHC/CaG2,1*9s$=sd4Ke!oDeV69>nM.67qNBDD
+&MF;&T>4gIJW+PGq_NFmg]!42iY98p9dhA.oj-msj'^2ZR.FnMR8[4_TD,k>csa)qDmS;EHbgC'.^5[WooMZ*pYf'Ba"AY@
+SJ%`'e%?m.o+Yoa8$ng;\ORU"CkmC>+qL7Gp+=?Tc:M>j!:B)u)"4H@fq2h]E,>lPebW_qj0]'VO.;D`b/9[>8B1cT-6+.(
+NI@3Ajs(VF3N[d(3`.Khj&bN%VX];'`oRrV/LH"Q$G6fjh14BE\@tTA`7$DEAlo@IV^:6)ai78?0&YjrL-3]iOD>9#-eOeY
+Fq/4S6Y]6$2]J-]jcp1(Erm)IU6a;]%:eQo+\`iFYCn8Aa%`Xse%&7OLR\5"DCM.%gUbNnJi3dH1>%@Q1O]>[jZn2"q;X60
+(G;tI6s^1C?J9qfc%luD>Z=4-$(ZNWF\8#3N(p?6+Kj_!04j[eP##s\;!CmtcS0_;3mfJC_1mi[I7cWS9'HEtOK?kSr=0Ku
+b@oU:_,08ADMHAc6R^!a(j`suXS_a"]o"/:;o6md)U-?o%1E]4"uNl`@/KRQJdfJrqR<Kr_(J]527.Q=c38j>1ggYg+)Fs?
+?i3Q$4]-PAV#gPWdVY='\oc)kj"ATfFMak1/mVsi?UeB'F/\KmcQ@d*/[%bUJk]tCQdZXh(rhqn=="h+eIc42k#Tj6GS;$[
+@+io5/d$[b/oCMm^^eTM*YIc>'NBi6.$sQ9]5'I@>@`$fo;6"M*H5_R9=nL+aJEU;5)"fBFAMIn[rUO')`YW=E-L3G?3S/g
+&G0O3k19ZpO4TGsM80.B4@"n,+7?/?[M<9c!9O-A*9h1<T'*cnEX3gj^cIVq,T1V,+0>hD=mk9%@V`XaC$p+Xb,&r-9tI^f
+V%6kcL\kGikBXg\@W$W:4eaHsG\hb)NS@j9N!RlnZq^C25^<9RXgB!b9$\haosi;'C2$m`3iHHJAdcg3C=nF7Dru@K/k74U
+cc5%Zb9Z"@g;(SjHGlX#/krk:K!k[M#Jb\L-`T8@oJ-ic*OB>M6CS\nY,^%IUS>+j69PR=e/>`Gbpgl:SjBC@ELj6R>AEFs
+^L)D0?%753L2`(2@ohd$Q8qCmnD!_L56cg`EfcJ6+PHpKD?X2=^'EWbKmI+fq?Ut!b%?!O2nop*N4eKA,t^5nc31a3:>hM*
+>SP_r<W_\jZ9](992DVu"Mb@cVNLm1JPFgrqX3//U]TDr<mub52\ALlSMMJF__1<X^g.N8a"GU:ko"ZoqdFaiZOZS2(*XdJ
+Z$8]C6s8CqF8;&\IA<N?Oq\5TV<Xg$$q[hn@%[Cd8N$Z`o=A>K8VBr9*Y*8^@k7D2r/-)\+\jR%RQ4)NZ;8LF7(Al"F9lsi
+rotsWd4Htt0i%+TYPu\FZ4!)iar-dki:KcNV4?/'A&L$:`F\.1erhP@5.:WgC^0)Ik3PH+D<k"t]"n9PK?/q6hM\Z@[KPdn
+%Pe6XlI.>S@r`c5#4C*[r0fF!o9`SZAdWhSGBUC`bE7gY-.L=p+9"jEXM-`6k-gCsiP:TnEY\Ce<KkEp!+qjd777CV4qtn-
+]N\bOEfst;&KO`GXbLAg?.3-R;.&A!_ZcCpY^*qfD2NRli<@g+?hs4he%:8TJUE(TZm6J[,$3/J+k"s5nr5Wm+9l%m,TE/e
+[&=<8(.:%l/;>Js=Y[d&'R;*A%d&l74!)fUQKgh`BuS)Wi-(SBda'OoK<4=B]>Toq,%Q'7k^35:e`PC!`r^n@DW$%b<<p#K
+p!P]<lY#n[M&1=o6eSd1`"Etk7R.p>lX-A<SX>bDEVjW*MOag]:kq&mJq*;O58>m!C,-l2Z@Y_d6ALus]8&Q@>`U&U0!5b&
++[!QRbFr6MI2[]VgBtJu't^L/RUidr($D*@Qs*\X31=n81l9qGD@&I7R231-EATBXj1rkZaM!5([+K"T'To-N@C\n(fUmj,
+jY&C;$?tmM\O2('S\n\!$#lT&]6Yf:9[Ba7LWg^#`E@K63HgPfr"^aT]`^EL3pm,]4_oQ@+np4c=peh(2>4\oXn??l\(L9.
+g!L@m7^6-!oR$smg6<!QD4Nau\\^k^QK\-K@SXZ21h6`6LX>^-lYs24-hKCKYpMpr>dRu,jS4'0@h1D5NE&#IS.mQ0TV\fX
+3ml@;)r'Cn:)gK[-ab/PLM*D:$=:9$Ed\nc+NajgHS?gU]Ok5@:d%BdH!%nk<Ob/A7a!(b`C^=1)]Vngak:,J>,:Oa5=Le`
+Q(r)1AP0!`,k]DV96k]h&Nt;`.,uR*qG*gcfKnB%8rqRnfXOCXZME+F@8KIT+L^pTAR9"sC!ErX!]C5r4+]0?e2!_n-*Y>L
+(at._(=*9SEDT,;O"FfRH99%3iu5:_3Da;iB+&Il9_Q;&4^^_D$/luRYR5SN%ipr-R#QaaMumYbhM;Ug[,B30WMVPDc=lsi
+JSF"0cHta2<OrDIE)38f$F:YigKW<bh$io?"ME38U?:@^#i6b3X.^hP*\[suZa=Q,0#hpO\=g>MBff-;q)teORSp:Y_e$o)
+6H0!cM3W]W7o4F%U+3FOp6pWH=4=+"*E#UL#.c37#t>[K4lU'l<J*qJRo_$J^.!9YT&gsO5'[>sI[?[dBFu94g=BC<1jpg6
+kp`h9UVR.K86)SjUb+_^?G[_dgM`hqrQ4qtX)iHs:-3qV+o(I:O4n47<7(YbE'.JDdtUs3.\2;*rB1Pkj03"jht)WTTOG7!
+L5$sF1Rdg]<O'%XU;dPSNp>!q<]LZ72]/2F;ED]YYn[gucHC*83e`\(.6;#!<Xe>'5[@sIh>Va>$/"]s_Q4t72`/4lC6p0?
+*<9,\.mCPih8LjQa'ma0H\']R^iU9,>gI4W1#d,EK9uS4bjaMOUsOa?dEmfK-I68jo+[J\&3@iJ8,pIZj>A`aq4lo)[Y@]F
+o-6:]nRo$Goc"q8gDH=)F5'%]"`1='"T~>
+U
+PSL_cliprestore
+25 W
+8 W
+N 554 0 M 0 -83 D S
+N 554 5538 M 0 84 D S
+N 1662 0 M 0 -83 D S
+N 1662 5538 M 0 84 D S
+N 2769 0 M 0 -83 D S
+N 2769 5538 M 0 84 D S
+N 3877 0 M 0 -83 D S
+N 3877 5538 M 0 84 D S
+N 4985 0 M 0 -83 D S
+N 4985 5538 M 0 84 D S
+N 6092 0 M 0 -83 D S
+N 6092 5538 M 0 84 D S
+N 7200 0 M 0 -83 D S
+N 7200 5538 M 0 84 D S
+N 0 0 M -83 0 D S
+N 7200 0 M 83 0 D S
+N 0 1108 M -83 0 D S
+N 7200 1108 M 83 0 D S
+N 0 2215 M -83 0 D S
+N 7200 2215 M 83 0 D S
+N 0 3323 M -83 0 D S
+N 7200 3323 M 83 0 D S
+N 0 4431 M -83 0 D S
+N 7200 4431 M 83 0 D S
+N 0 5538 M -83 0 D S
+N 7200 5538 M 83 0 D S
+83 W
+N -42 0 M 0 277 D S
+N 7242 0 M 0 277 D S
+1 A
+N -42 277 M 0 277 D S
+N 7242 277 M 0 277 D S
+0 A
+N -42 554 M 0 277 D S
+N 7242 554 M 0 277 D S
+1 A
+N -42 831 M 0 277 D S
+N 7242 831 M 0 277 D S
+0 A
+N -42 1108 M 0 277 D S
+N 7242 1108 M 0 277 D S
+1 A
+N -42 1385 M 0 277 D S
+N 7242 1385 M 0 277 D S
+0 A
+N -42 1662 M 0 276 D S
+N 7242 1662 M 0 276 D S
+1 A
+N -42 1938 M 0 277 D S
+N 7242 1938 M 0 277 D S
+0 A
+N -42 2215 M 0 277 D S
+N 7242 2215 M 0 277 D S
+1 A
+N -42 2492 M 0 277 D S
+N 7242 2492 M 0 277 D S
+0 A
+N -42 2769 M 0 277 D S
+N 7242 2769 M 0 277 D S
+1 A
+N -42 3046 M 0 277 D S
+N 7242 3046 M 0 277 D S
+0 A
+N -42 3323 M 0 277 D S
+N 7242 3323 M 0 277 D S
+1 A
+N -42 3600 M 0 277 D S
+N 7242 3600 M 0 277 D S
+0 A
+N -42 3877 M 0 277 D S
+N 7242 3877 M 0 277 D S
+1 A
+N -42 4154 M 0 277 D S
+N 7242 4154 M 0 277 D S
+0 A
+N -42 4431 M 0 277 D S
+N 7242 4431 M 0 277 D S
+1 A
+N -42 4708 M 0 277 D S
+N 7242 4708 M 0 277 D S
+0 A
+N -42 4985 M 0 277 D S
+N 7242 4985 M 0 277 D S
+1 A
+N -42 5262 M 0 276 D S
+N 7242 5262 M 0 276 D S
+0 A
+N 0 -42 M 277 0 D S
+N 0 5580 M 277 0 D S
+1 A
+N 277 -42 M 277 0 D S
+N 277 5580 M 277 0 D S
+0 A
+N 554 -42 M 277 0 D S
+N 554 5580 M 277 0 D S
+1 A
+N 831 -42 M 277 0 D S
+N 831 5580 M 277 0 D S
+0 A
+N 1108 -42 M 277 0 D S
+N 1108 5580 M 277 0 D S
+1 A
+N 1385 -42 M 277 0 D S
+N 1385 5580 M 277 0 D S
+0 A
+N 1662 -42 M 276 0 D S
+N 1662 5580 M 276 0 D S
+1 A
+N 1938 -42 M 277 0 D S
+N 1938 5580 M 277 0 D S
+0 A
+N 2215 -42 M 277 0 D S
+N 2215 5580 M 277 0 D S
+1 A
+N 2492 -42 M 277 0 D S
+N 2492 5580 M 277 0 D S
+0 A
+N 2769 -42 M 277 0 D S
+N 2769 5580 M 277 0 D S
+1 A
+N 3046 -42 M 277 0 D S
+N 3046 5580 M 277 0 D S
+0 A
+N 3323 -42 M 277 0 D S
+N 3323 5580 M 277 0 D S
+1 A
+N 3600 -42 M 277 0 D S
+N 3600 5580 M 277 0 D S
+0 A
+N 3877 -42 M 277 0 D S
+N 3877 5580 M 277 0 D S
+1 A
+N 4154 -42 M 277 0 D S
+N 4154 5580 M 277 0 D S
+0 A
+N 4431 -42 M 277 0 D S
+N 4431 5580 M 277 0 D S
+1 A
+N 4708 -42 M 277 0 D S
+N 4708 5580 M 277 0 D S
+0 A
+N 4985 -42 M 277 0 D S
+N 4985 5580 M 277 0 D S
+1 A
+N 5262 -42 M 276 0 D S
+N 5262 5580 M 276 0 D S
+0 A
+N 5538 -42 M 277 0 D S
+N 5538 5580 M 277 0 D S
+1 A
+N 5815 -42 M 277 0 D S
+N 5815 5580 M 277 0 D S
+0 A
+N 6092 -42 M 277 0 D S
+N 6092 5580 M 277 0 D S
+1 A
+N 6369 -42 M 277 0 D S
+N 6369 5580 M 277 0 D S
+0 A
+N 6646 -42 M 277 0 D S
+N 6646 5580 M 277 0 D S
+1 A
+N 6923 -42 M 277 0 D S
+N 6923 5580 M 277 0 D S
+0 A
+8 W
+N -83 0 M 7366 0 D S
+N -83 -83 M 7366 0 D S
+N 7200 -83 M 0 5705 D S
+N 7283 -83 M 0 5705 D S
+N 7283 5538 M -7366 0 D S
+N 7283 5622 M -7366 0 D S
+N 0 5622 M 0 -5705 D S
+N -83 5622 M 0 -5705 D S
+554 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-160°) tc Z
+1662 -167 M (-159°) tc Z
+2769 -167 M (-158°) tc Z
+3877 -167 M (-157°) tc Z
+4985 -167 M (-156°) tc Z
+6092 -167 M (-155°) tc Z
+7200 -167 M (-154°) tc Z
+-167 0 M (18°) mr Z
+-167 1108 M (19°) mr Z
+-167 2215 M (20°) mr Z
+-167 3323 M (21°) mr Z
+-167 4431 M (22°) mr Z
+-167 5538 M (23°) mr Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -F+f24p+cTR+t-As -Dj0.2i -Gwhite -R199.5/206/18/23 -JQ6i
+%@PROJ: eqc 199.50000000 206.00000000 18.00000000 23.00000000 -361383.919 361383.919 2001510.936 2557486.195 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=202.75 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.180918 +units=m +no_defs
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 5538 D
+-7200 0 D
+P
+PSL_clip N
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+400 F0
+V
+(­As) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 60 def
+/PSL_dy 60 def
+6960 5298 T PSL_dim_w neg PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+6960 5298 M (­As) tr Z
+PSL_cliprestore
+%%EndObject
+
+grestore
+PSL_movie_completion /PSL_movie_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/grdfill/splinefill.sh
+++ b/test/grdfill/splinefill.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Testing grdfill with spline infill of NaN areas
+gmt begin splinefill ps
+	# Get topo for Hawaiian Islands and set data on land to NaN
+	gmt grdclip @earth_relief_05m -R199:30/206/18/23 -Sa0/NaN -Gislands.nc
+	gmt makecpt -Csealand -T-5000/5000 -H > t.cpt
+	# Now replace NaN holes with cubic spline solutions
+	gmt grdfill islands.nc -As -Gnew.nc -Vd
+	gmt grdimage islands.nc -JQ6i -Ct.cpt -B -BWSne -Xc -Y0.75i
+	gmt grdimage new.nc -Ct.cpt -B -BWSne -Y5.15i
+	gmt text -F+f24p+cTR+t"-As" -Dj0.2i -Gwhite
+gmt end show


### PR DESCRIPTION
**Description of proposed changes**

This is the third way (**-As**) to fill in NaN holes in an existing grid: use the data around the holes to fit a surface via greenspline and patch in the predictions.  The plot below shows how this worked on a grid where NaN holes were created (bottom panel), then filled in by this method (top panel).

![splinefill](https://user-images.githubusercontent.com/26473567/67340526-5a2ccc80-f4c9-11e9-9d49-c4f9d76e8ada.png)
