### PR TITLE
Allow grdfilter -F?width to take a grid of filter widths

### DIFF
--- a/doc/rst/source/grdfilter.rst
+++ b/doc/rst/source/grdfilter.rst
@@ -84,6 +84,9 @@ Required Arguments
     diameter *width*. This gives an isotropic filter; append /*width2*
     for a rectangular filter (requires **-Dp** or **-D0**).  By default we
     perform low-pass filtering; append **+h** to select high-pass filtering.
+    For isotropic filters, *width* may be a grid for variable filter width,
+    in which case the grid must have the same registration and dimensions as
+    the output filtered grid.
     Some filters allow for optional arguments and modifiers.
 
     Convolution filters (and their codes) are:

--- a/src/grdfilter.c
+++ b/src/grdfilter.c
@@ -81,7 +81,9 @@ struct GRDFILTER_CTRL {
 		char *file;
 		double width, width2, quantile, bin, span;
 		bool rect;
+		bool varwidth;
 		int mode;	/*-1 0 +1 */
+		struct GMT_GRID *W;
 	} F;
 	struct GRDFILT_G {	/* -G<file> */
 		bool active;
@@ -172,6 +174,8 @@ enum Grdfilter_mode {
 
 
 struct FILTER_INFO {
+	unsigned int nx;		/* Original columns in input grid */
+	unsigned int ny;		/* Original rows in input grid */
 	unsigned int n_columns;		/* The max number of filter weights in x-direction */
 	unsigned int n_rows;		/* The max number of filter weights in y-direction */
 	int x_half_width;		/* Number of filter nodes to either side needed at this latitude */
@@ -179,12 +183,15 @@ struct FILTER_INFO {
 	unsigned int d_flag;
 	bool rect;		/* For 2-D rectangular filtering */
 	bool debug;		/* Normally unused except under DEBUG */
+	bool varwidth;		/* We have a variable filterwidth with widths in W below, coregistered with output */
 	double dx, dy;		/* Grid spacing in original units */
 	double y_min, y_max;	/* Grid limits in y(lat) */
 	double *x, *y;		/* Distances in original units along x and y to distance nodes */
 	double par[5];		/* [0] is filter width, [1] is 0.5*filter_width, [2] is xscale, [3] is yscale, [4] is 1/r_half for filter */
 	double x_off, y_off;	/* Offsets relative to original grid */
 	char *visit;		/* true/false array to keep track of which longitude nodes we have already visited once */
+	int mode;	/*-1 0 +1 */
+	gmt_grdfloat *W;
 	double (*weight_func) (double, double *);
 	double (*radius_func) (struct GMT_CTRL *, double, double, double, double, double *);
 };
@@ -361,7 +368,41 @@ GMT_LOCAL double GMT_histmode_weighted (struct GMT_CTRL *GMT, struct GMT_OBSERVA
 	return (value);
 }
 
-GMT_LOCAL void set_weight_matrix (struct GMT_CTRL *GMT, struct FILTER_INFO *F, double *weight, double output_lat, double par[], double x_off, double y_off) {
+void reset_F_parameters (struct FILTER_INFO *F, double width, double par[]) {
+	/* Parameters computed from width and other settings */
+	double x_width, y_width;
+	
+	x_width = width / (F->dx * par[GRDFILTER_X_SCALE]);
+	y_width = width / (F->dy * par[GRDFILTER_Y_SCALE]);
+	F->x_half_width = irint (ceil (x_width / 2.0));
+	if (gmt_M_is_zero (par[GRDFILTER_X_SCALE]) || F->x_half_width < 0) {	/* Safety valve when x_scale -> 0.0 */
+		F->n_columns = F->nx;
+		F->x_half_width = (F->n_columns - 1) / 2;
+		if ((F->n_columns - 2 * F->x_half_width - 1) > 0) F->x_half_width++;		/* When n_columns is even we may come up short by 1 */
+		F->n_columns = 2 * F->x_half_width + 1;
+	}
+	else {
+		F->n_columns = 2 * F->x_half_width + 1;
+		if (F->n_columns > F->nx) {
+			F->n_columns = F->nx;
+			F->x_half_width = (F->n_columns - 1) / 2;
+		}
+	}
+	F->y_half_width = irint (ceil (y_width / 2.0));
+	if (gmt_M_is_zero (par[GRDFILTER_Y_SCALE]) || F->y_half_width < 0) {	/* Safety valve when y_scale -> 0.0 */
+		F->n_rows = F->ny;
+		F->y_half_width = (F->n_rows - 1) / 2;
+	}
+	else {
+		F->n_rows = 2 * F->y_half_width + 1;
+		if (F->n_rows > F->ny) {
+			F->n_rows = F->ny;
+			F->y_half_width = (F->n_rows - 1) / 2;
+		}
+	}
+}
+
+GMT_LOCAL void set_weight_matrix (struct GMT_CTRL *GMT, struct FILTER_INFO *F, double *weight, double output_lat, double par[], double x_off, double y_off, uint64_t node, bool variable) {
 	/* x_off and y_off give offset between output node and 'origin' input node for this window (0,0 for integral grids).
 	 * fast is true when input/output grids are offset by integer values in dx/dy.
 	 * Here, par[0] = filter_width, par[1] = filter_width / 2, par[2] = x_scale, part[3] = y_scale, and
@@ -372,6 +413,10 @@ GMT_LOCAL void set_weight_matrix (struct GMT_CTRL *GMT, struct FILTER_INFO *F, d
 	int64_t ij;
 	double x, y, yc, y0, r, ry = 0.0, inv_x_half_width = 0.0, inv_y_half_width = 0.0;
 
+	if (variable) {	/* Update since filterwidth has changed */
+		reset_F_parameters (F, F->W[node], par);
+	}
+	
 	yc = y0 = output_lat - y_off;		/* Input latitude of central point input grid (i,j) = (0,0) */
 	if (F->d_flag == GRDFILTER_GEO_MERCATOR) yc = IMG2LAT (yc);	/* Recover actual latitude in IMG grid at this center point */
 	if (F->rect) {
@@ -601,6 +646,30 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
+GMT_LOCAL double get_filter_width (struct GMTAPI_CTRL *API, struct GRDFILTER_CTRL *Ctrl, char *text) {
+	/* Most filter setups expact a constant filter width, but some may pass a grid.  if so
+	   then we must read the grid and find the largest filter and return that value. */
+	double width = 0.0;
+		
+	if (gmt_access (API->GMT, text, R_OK))	/* Not a readable file */
+		width = atof (text);
+	else {	/* Must read the grid */
+		unsigned int row, col;
+		uint64_t node;
+		struct GMT_GRID *W = NULL;
+		if ((W = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, text, NULL)) == NULL) {	/* Get entire grid */
+			GMT_Report (API, GMT_MSG_NORMAL, "Unable to read the grid with filterwidths: %s\n", text);
+			return 0.0;
+		}
+		gmt_M_grd_loop (GMT, W, row, col, node) {	/* Find max filter width */
+			if (W->data[node] > width) width = W->data[node];
+		}
+		Ctrl->F.W = W;
+		Ctrl->F.varwidth = true;	
+	}
+	return (width);
+}
+
 GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDFILTER_CTRL *Ctrl, struct GMT_OPTION *options) {
 	/* This parses the options provided to grdfilter and sets parameters in Ctrl.
 	 * Note Ctrl has already been initialized and non-zero default values set.
@@ -704,7 +773,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDFILTER_CTRL *Ctrl, struct G
 							}
 							c[0] = '\0';	/* Hide modifiers */
 						}
-						Ctrl->F.width = atof (&txt[1]);
+						Ctrl->F.width = get_filter_width (API, Ctrl, &txt[1]);
 						if (c) c[0] = '+';	/* Restore modifiers */
 					}
 					else if (strchr (txt, '/')) {	/* Gave xwidth/ywidth for rectangular Cartesian filtering */
@@ -714,7 +783,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDFILTER_CTRL *Ctrl, struct G
 						Ctrl->F.rect = true;
 					}
 					else
-						Ctrl->F.width = atof (&txt[1]);
+						Ctrl->F.width = get_filter_width (API, Ctrl, &txt[1]);
 					if ((p = strstr (txt, "+h"))) Ctrl->F.highpass = true;
 					if (Ctrl->F.width < 0.0) {	/* Old-style specification for high-pass filtering */
 						if (gmt_M_compat_check (GMT, 5)) { 
@@ -912,18 +981,26 @@ int GMT_grdfilter (void *V_API, int mode, void *args) {
 
 	/* BECAUSE IT'S NOT TESTED LEAVE THIS (TEMP) WARNING ON TILL WE ARE SURE IT WORKS */
 	if (Ctrl->F.custom && GMT->common.x.n_threads > 1)
-			GMT_Report (API, GMT_MSG_NORMAL, "Custom filter and multi-threading is not gurantied to work.\n");
+			GMT_Report (API, GMT_MSG_NORMAL, "Custom filter and multi-threading is not guarantied to work.\n");
 
 	/* Allocate space and determine the header for the new grid; croak if there are issues. */
 	if ((Gout = GMT_Create_Data (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, wesn, inc, \
 		!one_or_zero, GMT_NOTSET, NULL)) == NULL) Return (API->error);
 
+	if (Ctrl->F.varwidth) {
+		if (!(gmt_M_grd_same_region (GMT, Ctrl->F.W, Gout) && gmt_M_grd_same_inc (GMT, Ctrl->F.W, Gout) && Ctrl->F.W->header->registration == Gout->header->registration)) {
+			GMT_Report (API, GMT_MSG_NORMAL, "For variable filterwidth the utput grid must be the same shape as the filterwidth grid!\n");
+			Return (GMT_RUNTIME_ERROR);
+		}
+		fast_way = false;
+	}
+	
 	/* We can save time by computing a weight matrix once [or once pr scanline] only
 	   if output grid spacing is a multiple of input grid spacing */
 
 	fast_way = (fabs (remainder (Gout->header->inc[GMT_X] / Gin->header->inc[GMT_X], 1.0)) < GMT_CONV4_LIMIT && fabs (remainder (Gout->header->inc[GMT_Y] / Gin->header->inc[GMT_Y], 1.0)) < GMT_CONV4_LIMIT);
 	same_grid = !(GMT->common.R.active[RSET] || GMT->common.R.active[ISET] || Gin->header->registration == one_or_zero);
-	if (!fast_way) {	/* Not optimal... */
+	if (!fast_way && !Ctrl->F.varwidth) {	/* Not optimal... */
 		if (Ctrl->F.custom) {
 			GMT_Report (API, GMT_MSG_NORMAL, "Syntax error: For -Ff or -Fo the input and output grids must be coregistered.\n");
 			Return (GMT_RUNTIME_ERROR);
@@ -1031,12 +1108,16 @@ int GMT_grdfilter (void *V_API, int mode, void *args) {
 	par[GRDFILTER_Y_SCALE] = (Ctrl->D.mode == GRDFILTER_GEO_MERCATOR) ? GMT->current.proj.DIST_KM_PR_DEG : y_scale;
 	F.d_flag = Ctrl->D.mode;
 	F.rect = Ctrl->F.rect;
+	F.nx = Gin->header->n_columns;
+	F.ny = Gin->header->n_rows;
 	F.dx = Gin->header->inc[GMT_X];
 	F.dy = Gin->header->inc[GMT_Y];
 	F.y_min = Gin->header->wesn[YLO];
 	F.y_max = Gin->header->wesn[YHI];
 	x_width = Ctrl->F.width / (Gin->header->inc[GMT_X] * x_scale);
 	y_width = ((F.rect) ? Ctrl->F.width2 : Ctrl->F.width) / (Gin->header->inc[GMT_Y] * y_scale);
+	F.varwidth = Ctrl->F.varwidth;
+	if (F.varwidth) F.W = Ctrl->F.W->data;
 	if (!Ctrl->F.custom) {	/* Parameters computed from width and other settings */
 		F.x_half_width = irint (ceil (x_width / 2.0));
 		if (gmt_M_is_zero (x_scale) || F.x_half_width < 0) {	/* Safety valve when x_scale -> 0.0 */
@@ -1139,7 +1220,9 @@ int GMT_grdfilter (void *V_API, int mode, void *args) {
 		3 = Compute weights for every output point [slower]
 	*/
 
-	if (Ctrl->F.custom)
+	if (Ctrl->F.varwidth)
+		effort_level = 3;
+	else if (Ctrl->F.custom)
 		effort_level = 0;
 	else if (fast_way && Ctrl->D.mode <= GRDFILTER_GEO_FLATEARTH1)
 		effort_level = 1;
@@ -1348,7 +1431,7 @@ GMT_LOCAL void threaded_function (struct THREAD_STRUCT *t) {
 	else
 		weight = t->weight;	/* The F.custom case, where weights were obtained in main and allows NOT multi-threading */
 
-	if (effort_level == 1) set_weight_matrix (GMT, &F, weight, 0.0, par, x_fix, y_fix);
+	if (effort_level == 1) set_weight_matrix (GMT, &F, weight, 0.0, par, x_fix, y_fix, 0, false);
 
 	if (slow) {
 		if (slower)		/* Spherical (weighted) median/modes requires even more work */
@@ -1380,7 +1463,7 @@ GMT_LOCAL void threaded_function (struct THREAD_STRUCT *t) {
 			visit_check = ((2 * F.x_half_width + 1) >= (int)Gin->header->n_columns);	/* Must make sure we only visit each node once along a row */
 		}
 
-		if (effort_level == 2) set_weight_matrix (GMT, &F, weight, y_out, par, x_fix, y_fix);	/* Compute new weights for this latitude */
+		if (effort_level == 2) set_weight_matrix (GMT, &F, weight, y_out, par, x_fix, y_fix, 0, false);	/* Compute new weights for this latitude */
 		if (!fast_way) y_shift = y_out - gmt_M_grd_row_to_y (GMT, row_origin, Gin->header);
 
 		for (col_out = 0; col_out < Gout->header->n_columns; col_out++) {
@@ -1396,7 +1479,7 @@ GMT_LOCAL void threaded_function (struct THREAD_STRUCT *t) {
 			}
 
 			if (effort_level == 3) /* Update weights for this location */
-				set_weight_matrix (GMT, &F, weight, y_out, par, x_shift[col_out], y_shift);
+				set_weight_matrix (GMT, &F, weight, y_out, par, x_shift[col_out], y_shift, ij_out, F.varwidth);
 			wt_sum = value = 0.0;	n_in_median = 0;	go_on = true;	/* Reset all counters */
 #ifdef DEBUG
 			n_conv = 0;	/* Just to check # of points in the convolution - not used in any calculations */

--- a/test/grdfilter/varfilter.ps
+++ b/test/grdfilter/varfilter.ps
@@ -1,0 +1,1424 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.1.0_3c1d6c3-dirty_2019.10.22 [64-bit] Document from pstext
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Tue Oct 22 17:41:55 2019
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R0/6.53259/0/6.53259 -Jx1i -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 6.53259000 0.00000000 6.53259000 0.000 6.533 0.000 6.533 +xy
+%GMTBoundingBox: 72 72 470.346 470.346
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+3920 8459 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+533 F0
+(Variable Filter Width) bc Z
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 4239 TM
+
+% PostScript produced by:
+%@GMT: gmt grdimage in.grd -Ct.cpt -BWN -Bxaf -Byaf -Xa0i -Ya3.5326i -R-20/20/-20/20 -JX15c
+%@PROJ: xy -20.00000000 20.00000000 -20.00000000 20.00000000 -20.000 20.000 -20.000 20.000 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+3600 0 D
+0 3600 D
+-3600 0 D
+P
+PSL_clip N
+V N -11 -11 T 3780 3622 scale [/Indexed /DeviceGray 1 <00FF>] setcolorspace
+<< /ImageType 1 /Decode [0 1] /Width 168 /Height 161 /BitsPerComponent 1
+   /ImageMatrix [168 0 0 -161 0 161] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[BdW0bFBc#R$ga7b7^VkrHRJ2fPM.!8q(8!BUD)&LNP~>
+U
+PSL_cliprestore
+25 W
+2 setlinecap
+N 0 3600 M 0 -3600 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 900 M -83 0 D S
+N 0 1800 M -83 0 D S
+N 0 2700 M -83 0 D S
+N 0 3600 M -83 0 D S
+/PSL_AH0 0
+/MM {neg exch M} def
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-20) sw mx
+(-10) sw mx
+(0) sw mx
+(10) sw mx
+(20) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(-20) mr Z
+900 PSL_A0_y MM
+(-10) mr Z
+1800 PSL_A0_y MM
+(0) mr Z
+2700 PSL_A0_y MM
+(10) mr Z
+3600 PSL_A0_y MM
+(20) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 180 M -42 0 D S
+N 0 360 M -42 0 D S
+N 0 540 M -42 0 D S
+N 0 720 M -42 0 D S
+N 0 1080 M -42 0 D S
+N 0 1260 M -42 0 D S
+N 0 1440 M -42 0 D S
+N 0 1620 M -42 0 D S
+N 0 1980 M -42 0 D S
+N 0 2160 M -42 0 D S
+N 0 2340 M -42 0 D S
+N 0 2520 M -42 0 D S
+N 0 2880 M -42 0 D S
+N 0 3060 M -42 0 D S
+N 0 3240 M -42 0 D S
+N 0 3420 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3600 T
+25 W
+N 0 0 M 3600 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 900 0 M 0 83 D S
+N 1800 0 M 0 83 D S
+N 2700 0 M 0 83 D S
+N 3600 0 M 0 83 D S
+/PSL_AH0 0
+/MM {M} def
+(-20) sh mx
+(-10) sh mx
+(0) sh mx
+(10) sh mx
+(20) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(-20) bc Z
+900 PSL_A0_y MM
+(-10) bc Z
+1800 PSL_A0_y MM
+(0) bc Z
+2700 PSL_A0_y MM
+(10) bc Z
+3600 PSL_A0_y MM
+(20) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 180 0 M 0 42 D S
+N 360 0 M 0 42 D S
+N 540 0 M 0 42 D S
+N 720 0 M 0 42 D S
+N 1080 0 M 0 42 D S
+N 1260 0 M 0 42 D S
+N 1440 0 M 0 42 D S
+N 1620 0 M 0 42 D S
+N 1980 0 M 0 42 D S
+N 2160 0 M 0 42 D S
+N 2340 0 M 0 42 D S
+N 2520 0 M 0 42 D S
+N 2880 0 M 0 42 D S
+N 3060 0 M 0 42 D S
+N 3240 0 M 0 42 D S
+N 3420 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3600 T
+0 setlinecap
+%%EndObject
+0 -4239 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4072 4239 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -BEN -Bxaf -Byaf -Xa3.3937i -Ya3.5326i -R-20/20/-20/20 -JX15c
+%@PROJ: xy -20.00000000 20.00000000 -20.00000000 20.00000000 -20.000 20.000 -20.000 20.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+2 setlinecap
+3600 0 T
+N 0 3600 M 0 -3600 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 900 M 83 0 D S
+N 0 1800 M 83 0 D S
+N 0 2700 M 83 0 D S
+N 0 3600 M 83 0 D S
+/PSL_AH0 0
+/MM {exch M} def
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-20) sw mx
+(-10) sw mx
+(0) sw mx
+(10) sw mx
+(20) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(-20) mr Z
+900 PSL_A0_y MM
+(-10) mr Z
+1800 PSL_A0_y MM
+(0) mr Z
+2700 PSL_A0_y MM
+(10) mr Z
+3600 PSL_A0_y MM
+(20) mr Z
+N 0 180 M 42 0 D S
+N 0 360 M 42 0 D S
+N 0 540 M 42 0 D S
+N 0 720 M 42 0 D S
+N 0 1080 M 42 0 D S
+N 0 1260 M 42 0 D S
+N 0 1440 M 42 0 D S
+N 0 1620 M 42 0 D S
+N 0 1980 M 42 0 D S
+N 0 2160 M 42 0 D S
+N 0 2340 M 42 0 D S
+N 0 2520 M 42 0 D S
+N 0 2880 M 42 0 D S
+N 0 3060 M 42 0 D S
+N 0 3240 M 42 0 D S
+N 0 3420 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3600 0 T
+0 3600 T
+25 W
+N 0 0 M 3600 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 900 0 M 0 83 D S
+N 1800 0 M 0 83 D S
+N 2700 0 M 0 83 D S
+N 3600 0 M 0 83 D S
+/PSL_AH0 0
+/MM {M} def
+(-20) sh mx
+(-10) sh mx
+(0) sh mx
+(10) sh mx
+(20) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(-20) bc Z
+900 PSL_A0_y MM
+(-10) bc Z
+1800 PSL_A0_y MM
+(0) bc Z
+2700 PSL_A0_y MM
+(10) bc Z
+3600 PSL_A0_y MM
+(20) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 180 0 M 0 42 D S
+N 360 0 M 0 42 D S
+N 540 0 M 0 42 D S
+N 720 0 M 0 42 D S
+N 1080 0 M 0 42 D S
+N 1260 0 M 0 42 D S
+N 1440 0 M 0 42 D S
+N 1620 0 M 0 42 D S
+N 1980 0 M 0 42 D S
+N 2160 0 M 0 42 D S
+N 2340 0 M 0 42 D S
+N 2520 0 M 0 42 D S
+N 2880 0 M 0 42 D S
+N 3060 0 M 0 42 D S
+N 3240 0 M 0 42 D S
+N 3420 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3600 T
+0 setlinecap
+%%EndObject
+-4072 -4239 TM
+0 A
+FQ
+O0
+4072 4239 TM
+
+% PostScript produced by:
+%@GMT: gmt grdimage fw.grd -Cjet -t50 -Xa3.3937i -Ya3.5326i -R-20/20/-20/20 -JX15c
+%@PROJ: xy -20.00000000 20.00000000 -20.00000000 20.00000000 -20.000 20.000 -20.000 20.000 +xy
+%%BeginObject PSL_Layer_3
+0.5 /Normal PSL_transp
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+3600 0 D
+0 3600 D
+-3600 0 D
+P
+PSL_clip N
+V N -11 -11 T 3622 3622 scale [/Indexed /DeviceRGB 3 <
+00D5FF7F000000007FFFD500>] setcolorspace
+<< /ImageType 1 /Decode [0 3] /Width 161 /Height 161 /BitsPerComponent 2
+   /ImageMatrix [161 0 0 -161 0 161] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[Bd[;%Wd>!!P((PYa\'.HF?X!+#Zn[dTK%CI&D*'Lbk578XafnV>aeY_+6ZU*tnn.#Obo<h'E9PLqk~>
+U
+PSL_cliprestore
+%%EndObject
+1 /Normal PSL_transp
+-4072 -4239 TM
+0 A
+FQ
+O0
+4072 4239 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -F+f36p -Xa3.3937i -Ya3.5326i -R-20/20/-20/20 -JX15c
+%@PROJ: xy -20.00000000 20.00000000 -20.00000000 20.00000000 -20.000 20.000 -20.000 20.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+3600 0 D
+0 3600 D
+-3600 0 D
+P
+PSL_clip N
+900 900 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+600 F0
+(5) mc Z
+2700 900 M (15) mc Z
+900 2700 M (10) mc Z
+2700 2700 M (20) mc Z
+PSL_cliprestore
+%%EndObject
+-4072 -4239 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 167 TM
+
+% PostScript produced by:
+%@GMT: gmt grdimage g.grd -Cf.cpt -BWS -Bxaf -Byaf -Xa0i -Ya0.1389i -R-20/20/-20/20 -JX15c
+%@PROJ: xy -20.00000000 20.00000000 -20.00000000 20.00000000 -20.000 20.000 -20.000 20.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+3600 0 D
+0 3600 D
+-3600 0 D
+P
+PSL_clip N
+V N -11 -11 T 3622 3622 scale [/Indexed /DeviceRGB 179 <
+00007F00008300008400008500008600008700008200008800008900008A00008B00008C00008D00008E00008F000090
+00009100009200009300009400009500009600009700009800009900009A00009B00009C00009D00009E00009F0000A0
+0000A10000A20000A30000A40000810000A60000A70000A80000A90000AA0000AB0000AC0000AD0000AE0000B00000B1
+0000B20000B30000AF0000B40000B50000B60000B80000B90000B70000A50000BB0000BD0000BE0000BF0000BC0000C1
+0000C30000C40000C50000C60000BA0000C80000CA0000CB0000CC0000CD0000C00000C70000CF0000D10000D30000D4
+0000D50000D20000C20000D60000D80000DA0000DB0000DC0000D00000C90000DE0000E00000E20000E30000E40000DD
+0000D70000CE0000DF0000E50000E80000EA0000EB0000EC0000E70000D90000E60000E90000ED0000EF0000F20000F3
+0000F40000E10000F10000F70000FA0000FB0000FC0000FD0000F90000F00000F80000FF0002FF0004FF0005FF0006FF
+0000F60007FF000AFF000CFF000DFF0000F5000BFF000EFF0011FF0013FF0014FF0015FF0003FF0008FF0018FF001AFF
+001BFF001CFF0000EE0017FF001EFF0020FF0022FF0001FF001DFF0021FF0024FF0026FF0027FF0028FF0012FF0000FE
+0029FF002BFF002DFF0025FF002AFF002FFF0031FF0030FF0033FF0034FF0035FF0023FF0010FF0009FF0037FF0019FF
+0038FF0039FF002CFF0016FF>] setcolorspace
+<< /ImageType 1 /Decode [0 255] /Width 161 /Height 161 /BitsPerComponent 8
+   /ImageMatrix [161 0 0 -161 0 161] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[Bd.q,^MH(<6HJ=@(*&U54bj0SU,E&4.KB63orG$1g7u_B=Ji105G]&WqZEn^Z5pC1#_Fn=>!q4m*:],kPZ]Fh?3d5BPSd
+l=YP>E2J&,DS<^<)r@asK*r0Mn[uQKICOk-c.-0?0g*URYY348DkWcaYr#/N#;ZY9ql_]e)5&eB?dVDYQun`6KSko+Xq63D
+l]QH8M*rE&]#"o2$:sWD8G'm:F*SRaaPei>)`4_7J3U837\[)5&q,0ghIQrK'oqISahE.J_"-Li:g'UK7+P[G]M!/)%3L@>
+rr2oKaRJq:R0`&S'<1j7cVM@JV`Zn4(?.#!+Q-H\!oY4%!=4Q>!g4k@:rqohp0sVc':ut2d,aeD!h;Kj!X"(,Jsd2b'H$Ts
+ep*Gk>q!Yf=F75\FcO+bC]6Yacf6bV#S,5n/0s<Qoc#Tf?OmGL%RR#tYS(4kV"t?-!QD^E5g$_*8td(,[-KYgh@'k,"X>kr
+k04jsYt"I%MY*IW':F4`cN/f7TsnopL#$0,=P3"FTf2uY7$e8VqS6F!kCe'>\tdBmGs$KlLZBW4Saa6'Oj&Wk)h'1$2F<-$
+1W4>LEr$W"K0ta2:3a7P6tES2KgKh_K0hi[Sa_HVW9BW$=IDhu)]KG2'c@U4#>)j%<Zt'S?f-2?]R*0l:2&"0m7$T9o8pnP
+TKlp^cI'\"MfEqcULI\DEH6=e%(SJq()mp@-">kZ$AJ>l?7aD/0Cg`*1(MI[$JG4_qN/69=`/oo:)4Y<OI29&![B]S0`a!p
+@b<7T#-^@*6"U2B!l83[P7)X**%qF"jVuc]n]'oGe-G+;:7dQ3X@Q?gV5[FoZnu@*+up6saCp]&Ym[f="o;%T^tck=769P,
+.[#u.j<0Qk$=BLR@VY=2<aSsRA@*m?+Xn]p/OQ(sQ'Io2SYaG-X-Dit8b$f*5\(S'ZuH^h&mu+NI:-u0>^TFA\l,BMe6lT`
+VE,qR2'j[p:)4if*l]\B8qXtsaQ^;@qJM!1F)qmF<Me8WCNFWD0Qd-EClK>V'BQO`Li?1HJLjSFO<J(c6!nk)ZqR'IbQV<:
+bKC'\$;$3&5sYgh"U_GQ$AJ<nS0-.6bY:W':K(n?F7]#-L;K[ZU-_4u4tkNTV+srs+t,iEG+o7I8-=g%TF]eX5WkftVa\8j
+j9-/2U<nrU=eO-2iW90)^7[,67@BjslLY6K`MO8hBkaQW`)Ku@:mPnHW)AfmEag4h*ejgVX:`(+FWaGpTFd?;&MZ9Paf-bL
+0t0ipe*FB0$tW$T<f!Ii(dLgX":F<2egF6m.+R"]AVP5(Bn`ChWiEY1Wl@qF2O,)Cj_&.T_J#b7##7Oj$TSFnn-7;W%Jhic
+o#hB_:$)dU%H^Yo.S<FsL9fTN[8N,8`sRN9!u8l]fUp(aq+m-=C"1ZKR7]&2FnH3p`l:J`6[`6O;e^<H*f.r.3RIh[R##%h
+3=p_^i96^+A?]-BfNd-0al?B(8kha^3b)cj!r7pgNB[`TfR]-7-m"L*=J%Lt:i($LWjfFD[^C=$FL8NbFuFGB23jCBkd&a<
+amlYb":PU4o7XW83"XEo&7faE/3Z'oSZOCj057HOC?VJ+(2J=uPI]>-Vo9!Q,&u1APPHi,%YT([L-[q"Pb>4j];Ed*e(3:*
+5;5&V37'n>gXaeL=&W:]'P=-gaT6W2R(?*>&6fPDNf9)JV.Up!`MGG7%4uG16S,FE\#m^)<R]b4$C*'%2(/odWQ@>'+EcUb
+em>3,M"F\H%<o8:[uK$1a2Z0?a%#HK[bckdqF[P;2bTu<KHT<#!a,eE+VBN(Ahjod"9P*l:hA`4I?jJr'>:h?ar@VADsJCG
+W^$oNO>T!Ef6JujF<F8e3,C8!f@/,+nmHicC3o%$bk18_ptT7aHOE_R?CS,a^f]kg?ArTOM$%7M_4(;UEhon8]l.k-Hu^"o
+VC'>*N:_8b@"gQeEA;RpnQ[Jai8#ea6;![n\$idcl0I`GO3c-'/1s(hI^HJl0KhX4[ro(-f9hK=N9^&R\ELP@(1(tlG_ODX
+]?tVTl"X^2Oh%@'V8HmeS"HRjRJCiLIkO^P?!Nl"8P;X:7GW*.Tl<GNKLo0ZJVWk,bcOPl/?Q(WDes6kYH9E/9Pr)JGBA!c
+R1-[.ZkRI&9OpGJ\Hp(e"p_$$Aa'W#VQS4)rjg9&!H39qD?)*gMm_hLP1JFB"Tmq[)8sb/KG50A>FAW!rU04,PGc`u51t8[
+h=BRtVVTg8XmRgnCQT!GU;LmW@dJfp0jKBMLSG8O=)7Kjh::(7Rsf@(ELFjO?(>'V/67<0@:]_=Hb:cDBF:LC9Eea:Q*ma?
+^,#<X`Q$K8QeOU*G.(aAgY-n''YYW'*NghGkVR"qnsG4eLbWfhF)r0BN.CK[1l]dW;D[)hoGZs-nXe(.f_aC(<Ma)C.V'].
+>Zhl+#[[rb)3$DU^gsG5\N_j0G`SK`m_%5"qtBF6S"8@_)lrkBUB;NraG"3F$q5aV`u%<7+HW#/&7J^n,/[N;*8&mu0KQh\
+\foup7M_&Gh!_5OQjQY*P'IjgNJk&d9gu_]]HV<fmD8]%ik9_`nGV=nqkM't&)Ou^?=3\?dQZ.f_#2F+`13cFR)_l5ilqUE
+,>8FgMo2<1&lUUX_;NlfqrA:2lc0&JZ?TgWJIPjdPa;gpMcP=jJpq7TMG&U.(K]+ooT"mV/:G"8qsNk1LQ<f1-QbR#3dA'E
+[J"u_CnTTfBeInLPY!Qiq+6AGnkp#"PEZtkTt/V*4tnnfHu3Zne\NW!GPLmfmacST1ZK^n/ThfI&7\fZ_K]])+"EAJTKGf6
+M'Lg0B:iF2IJdpEi:*?d5CWV0q8\\KIbNP%]!;0PF/6:O\f4dGPL-9oRXuq3h:8(0,F]412kKI(IA4BlK:QY9<u34NI5iL_
+RE?d80*td4A<$fQ2$*6o*%n4,B^6b2>$Tg.q<%Pb-ia&-k:]("oWOJQ^V&5_rH3VH51J&8/2jNT66d3.bF?FP+Bi;T7MLuf
+Sg""/ri`63Dglt-GosbMo5\V`EGDkqXeE$'<j#sn?Fb[P/7A]gj]6f:B]TttWurV89C#B^pC9FepsYS5?b_'cl,Sj?HbUT)
+/^?Pa[FR8ola7T;Pgj-8r+YN:T>[F3#cPhklC4:.>AXm_(Y=[s'CiN'X=m:8c;^2>o@Tn)fq#9,'duERj#PQ?0fVAg#Y!hA
+dE1RD^]+-)It.Fmo,gI-!(7Su$sT09[Ho_6>9G_Y[C+8Fi<^210_jSi&'?soHAch+dEMAn7jFTO-mUR15^J_+'F:cEJLG*$
+]mBSTjR\_A^]4<1f.RDSYk&Q3N!5Ybd8K?Sd+^i/>,H(0=<NLBe")+9*q0'^=3j]@K>;5Q^d*4KQFmJ&-93KA`HYmE=Zl"0
+Mr3on^*'blbjAP<7V;1Ke(o5.ZZm6t1"eZ0B<gJX8/H_e*Mi#PLJN9ONpGWjF4S1^NpGWshPUm+>p\eZfp\G6KArFIS_6Rq
+HO%ThnP4,ol2AXe:B(%`*pk5&T&O;hFqV[rFqOoD,^<`\rUUbbLNepGn\O'WAg^/oZBI99`@ss/BVi/^bqCWC^%g.708E%f
+7u+kG^"PVUJ+R[`)r+\f&*GOsMjX\+-/MsUM)c&$HZ?VX+3bE(ai_Lklc6V"*nlO=(ZsmsBUq'!*-&D'Mq/c1KM"5K1j-4u
+%ZX8We'Tn?4q8&4p>0ZdH-Ddjg6pEK9#7*$cTBCE=e]A#1[WD#k4m9iGF4.\1WS_W2DmDFgO]ogkVT'Q.4AG4*7'94J<%p-
+%24//^0Ft$HFj".p<NAM]2)5S=8/WFdua\&gc>riM[f%KD/+QCrKQl]elUf5gc*W2c@a=e_XTbPjWfX;/2Xm@btW>OmC'RM
+l2B_ONRQo8:S/W!DQH"TTA"\K2ds\<N-'*o3r;=i`&Ij'Cn9d:]fEM#LrW`VTAH*E[<L1Z25?'R>%C#5p>Oh!fS,&?;B*dd
+9AkiZDr7)`iVE&JC[:<PCG1ti+3on][^A&'*aKH#^!iJ-8\E0IPHJ0Cil6/rlg`Y`Mp!b-n(6[a5Kn$!qr&;k;MZ<K&(Kqi
+_n2-%@SC(+ak,QW@Ya@DkiC72rPbV0V8`Cg;_+UfII3S2QBK*Ilp18F-b-\p@sf5u`Q3aYKdE%fcM"u7d1m^@EqD6E'%&jC
+T<Fpu']82cGoV26]9%6_DAsLuO)<1g:/+O/c>S`s#OYAEG$3$XH>TOB3:NGb0l`mB;l_Q,>Ik_#mLRr?.<!Eo0\"+C"CMK*
+m`"&Djt:Tr![abLQ&720CWFf;M#G0Rki`-G8H2M5O1!8BB'a)HZ-9VC/2CNW`lpQb/nAkR-miP!S[GADW1WVbL,rM??#2(r
+>rm!$8F/T-EJl9[d9;UAWHu(Z[Cpe*f&,A')sV9YD60pU.OidZHNiL_B=/V_1-eP*73tZ.oci73Fd&5o7c=E=6[;=$*[K8u
+W0YsLRC[16l`H^@XV2?]XZ`6+qJ$Dfht"*Qkt,F-E[VJ[PQr?Yl)Lh4W4lD&]UE_:;(\s6nLBRY![1WQrK^LqKmKMf]VO:[
+=l!(B4?Qm+<F'>'2O,*>Bf0!7S'_.d%-/p,-F4?r/(A8($Hc'e?:h\Y<(,E.mC/*%<aUUhAkYsI1*RWZH:,6bgg/<<YumGE
+]$8Jr&;>.7&h/Vt.oHaIe>-WE"=6nnff&GHVK.;qB12G?o;^Y(^g*G&pBVAPf&WOeX]/qIF_(`17E*NrVWR%#,"!rHW1g$2
+ki5GuB16oGF2ULY.!d+p[0Fc(/1At]Zd_UGb-UO@J\6aDb2]'br910c]Ga&'?Xq=3jluHG[C,k:4C(.67uQr3,[^NoIOO0H
+8c1Q%pt6blo?&a_O*OR_a6sr-jb5$(s.RAts/sAS$UpaC-`/"sVC(&rKjfX9%40$50Fog5P'?cP`-Z0,*tD-$@$?lFnj7Vi
+aP<"J'](8+m>AXXnT`hf,#nnE9sOKT.TMn6b/dClA>km)0R6DEo5k/^Il*c<"`e;_5/^5k3HF7.N:Km:gKH-j1^Wf2*@Oh,
+51\OY&p'GL5D::eTn(b0GU+p\?A1*$/:A^rXN:l(?GK3AGhc6R)>]$4Z-;P%XY>hR,Kkq-a2]PQ,fIaHj)W64.D0@nIGt5?
+Kg%VQXN=<oYl^LJ#393>\Yhi.qS_js(Oj_S&GTTrBKLLe(:5Uq#bLOR2uEsZKTE_\Jjcfg%M#:#AqL.:&@c5dJO`lP!aPG5
+pl_Kgde(BJB](M!0W##*l%&h['^'Ol5,-DZB6"R,]?Tp!SdMnt6ND5F'6X]PqbhAX8LSI#ETeT,>G$O7GBi<9j7c\^iHO8a
+LQK?ZiAfbclf0Fi&kT,8iUQeuR.-]F%i"Sj9^<I9=p:)Z/Yc(n)0Mf?XH4\OQK[Lr-gHY2d;)1@aEWh(Ws-9]m;KM0Nl.Ei
+O"0d1H/CUC?"J;!ki392m.YR+?UVPR(Z_-&0.(.^/<XebA-Zt=Uc=]'cK%W2nn89*COKMOM6uN3D*'&'Z)#Ro4WNV[]"rGd
+Sej9<gP=CibA/Z+1tV/*`][@s2qt/[!r?m,guEYdOURHp/F4SO?r3H('A`o;AI!k+9Lbih@55+si]PNX![PZoTOdi'ZjYnV
+c@\ENK(2oVT','PmiI8'Is1K$>RXF"k]".ph9Fn5Su416.*p@&j&mG"H"bcSR-3^VbJQH!mj(fgM^<h@Ons?b_mt$orZ@c2
+q=:>+-fO*]GcRV-PN]^4!U%$,n3=$+38c&_S"\LZdHVKST-W`THul,d@AWfG>,)ksP@BealL-":>fj]:&UdQ*X-<Hs-SM)<
+q-GUC5UjFWo)^JjScuDB8@7^#>;5"]fJb$qTEI?;pa^q1HaeB9KVdB#`f%&XqZghg-/F,$jW7HKlB#`sY`EbNQXCmmR3Rm^
+7&R)YP^E3Pr+cSc.eE\tP?camJ!1k:oWQ+Of0P8lY"lWn8F;b#NdJ%LIbRFH@+,$s/H7g\[GMcnrYO;:s,B*)`Y/5B!1h0Y
+r6BoT^Js_^pso\rKp)@;MO-^/;I\OQOo?/D,lc+6l$kQ_o&&8drg1eRs6Vb6L.%`r^7H_Nmgi%i$]Y:BP5GN]:n\T<+t?VA
+^$i1O8cDAk<$;feX,rR["\]V:P3gebYsOb$=d%[;p>VSjd4]fm;'Nb`;GuC?p[XLD=63l;SmC-PHhfF2La@J](Qes?f-TlP
+nmLsVT"1G%6G"qse,O%_4@lA/6Y0ALS`Y2=*YdlGR$Zu]FEe54%_$``!@kX,@/~>
+U
+PSL_cliprestore
+25 W
+2 setlinecap
+N 0 3600 M 0 -3600 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 900 M -83 0 D S
+N 0 1800 M -83 0 D S
+N 0 2700 M -83 0 D S
+N 0 3600 M -83 0 D S
+/PSL_AH0 0
+/MM {neg exch M} def
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-20) sw mx
+(-10) sw mx
+(0) sw mx
+(10) sw mx
+(20) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(-20) mr Z
+900 PSL_A0_y MM
+(-10) mr Z
+1800 PSL_A0_y MM
+(0) mr Z
+2700 PSL_A0_y MM
+(10) mr Z
+3600 PSL_A0_y MM
+(20) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 180 M -42 0 D S
+N 0 360 M -42 0 D S
+N 0 540 M -42 0 D S
+N 0 720 M -42 0 D S
+N 0 1080 M -42 0 D S
+N 0 1260 M -42 0 D S
+N 0 1440 M -42 0 D S
+N 0 1620 M -42 0 D S
+N 0 1980 M -42 0 D S
+N 0 2160 M -42 0 D S
+N 0 2340 M -42 0 D S
+N 0 2520 M -42 0 D S
+N 0 2880 M -42 0 D S
+N 0 3060 M -42 0 D S
+N 0 3240 M -42 0 D S
+N 0 3420 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+25 W
+N 0 0 M 3600 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 900 0 M 0 -83 D S
+N 1800 0 M 0 -83 D S
+N 2700 0 M 0 -83 D S
+N 3600 0 M 0 -83 D S
+/PSL_AH0 0
+/MM {neg M} def
+(-20) sh mx
+(-10) sh mx
+(0) sh mx
+(10) sh mx
+(20) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(-20) bc Z
+900 PSL_A0_y MM
+(-10) bc Z
+1800 PSL_A0_y MM
+(0) bc Z
+2700 PSL_A0_y MM
+(10) bc Z
+3600 PSL_A0_y MM
+(20) bc Z
+N 180 0 M 0 -42 D S
+N 360 0 M 0 -42 D S
+N 540 0 M 0 -42 D S
+N 720 0 M 0 -42 D S
+N 1080 0 M 0 -42 D S
+N 1260 0 M 0 -42 D S
+N 1440 0 M 0 -42 D S
+N 1620 0 M 0 -42 D S
+N 1980 0 M 0 -42 D S
+N 2160 0 M 0 -42 D S
+N 2340 0 M 0 -42 D S
+N 2520 0 M 0 -42 D S
+N 2880 0 M 0 -42 D S
+N 3060 0 M 0 -42 D S
+N 3240 0 M 0 -42 D S
+N 3420 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 setlinecap
+%%EndObject
+0 -167 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4072 167 TM
+
+% PostScript produced by:
+%@GMT: gmt grdimage fg.grd -Cf.cpt -BES -Bxaf -Byaf -Xa3.3937i -Ya0.1389i -R-20/20/-20/20 -JX15c
+%@PROJ: xy -20.00000000 20.00000000 -20.00000000 20.00000000 -20.000 20.000 -20.000 20.000 +xy
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+3600 0 D
+0 3600 D
+-3600 0 D
+P
+PSL_clip N
+V N -11 -11 T 3622 3622 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Decode [0 1 0 1 0 1] /Width 161 /Height 161 /BitsPerComponent 8
+   /ImageMatrix [161 0 0 -161 0 161] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[Bd.HYc^&S]>BlA4b73Q6^>=>Y#q^D+TqkO/2%jOfD#FgHW.#Xu>S2O/c3eRm1S_8sQ]^ao\7p&+_Qr4D_5&@r,sf"q8M%
+0a,?D+b:=I+9;Q&'qf8-#S8aQk;2qYc9:>S9X1cSB$aULB$QpWkFU#t*]*P\3D'`X62Ams>SVjn((D'CQV4Jnc8L<$>Zn:k
+8>h"8C=2NmE+:a)P"o/9#M''Q@@>6WBGRFC-K5&J+_[6erI)1IVT$*1,T]5FXG/$[f7t:i44;TV<;F.8\<ER+j^G\p0B`b.
+ep)VQ5$<eaF>!C-3s.N?mNuL"?3`D\FpokBX>-FplPShncJ>M-I%Bg(E#i(SE%DpjBmf2qD$;$UkR=,:3Hq*)I+'#&W!$6r
+dqAfOQqhhVGiA(0VZiXBS-.k'<u/MA\77[#[9-)L,ZL'Z>A,P^\AtEJ*AckD\Z9gTHt-\=e&eO.9hCU%Zk^^dpV]gWp76B"
+HmS%d?f-*V\<DX2<2HIcl02`&9blZJ[1>;pmNuN.Rl"FZ[nP^T's&-B<@TjnWL<!-K=r"OgTlijG30bmGG0b;M#I63`n*0+
+8KM,0embaZW`lB)9$KhH7/"C%fNTZ3/ScGMWL1#5g4Ag[X7L^UjL)uHK3KX(%F)FUeY7>gZA!@RpafiZ.A3g/[cSQNg4Ag[
+.-[K)q!7No`]F>_lbdjUl]eDNC;*RT8i<KGJb"-PbS/PC['f+3@a:1US?:789A.XrF+2/F=YUTX,i@jRhFnIJ4P1O-$^=hn
+e7,8?TI,g"Y:3gH*K.Oi?K$N[k$3'iP_1,l;C34IkKblsei?spSLngDA#,ElTt*jrj[qB\[6gjXU(q?%H^B>2&P$!NetT50
+2V+DI;GP6n_K=Bu\LQZ76Sl5cTC99h^=G;G6_kL@D$8E&fJQ$;Pu=_VX\ihMW_CNLp9(4R1AZV*D7W=Kjua:n@@ai&3E,Y%
+j6kWn0lXJkA%^](lj;ikVot@E7GG.#Oo3nq3thrY@_<'OY-H=h#d.0BSPnd=g7Zse8o58*:W[qVXqfM<3-GTLTL$eI2D-0e
+ATuN/+Xe/)g-Ti62WfV^$p(Ksa$R#TT3_Ac+aiSuZ3W7&(:\2m1c/Q9C5YtoQ.i+bG0r3?[]jtNY[.FqAmG(>bdfo'fm.Bm
+Or>p=Ws9*E=KK;-Z*M=/J/e:<o=&34Hh-t5S_\tt&7"AfX\Rui'JjP?\=4US:qiaTb=]IBe1UBnr3;IVQQX"rqAVD;26M9D
+PSZTq2F6#UUp?e&q4V'3-*hJ_3B+_EgS&)I$kdF@Z"[aZFOUq,kjE\dh1U1m?-YmA'Ya1s],2_BTsG4V]GYZMi:pBMp*fU&
+;L=\_-e_58*qo#R[0:Cu\fGj0+W4K.PcZO``$2)$81GLAPO:KpGJ=bniuLdB/*G]f3E=\oD)Tfdq8Q=T)lQ\0rGmo=gWelN
+ab4/,FK$(.X2qL,a`k";f8/s7"g.m8)ijf\3hXtGV;>2:YineR9_n#4hF%5^=T&Vpo3.Z-N3^^BVTX3E(6nE,aHl9S3nlKo
+8M-jOS?BT_lfTq-h+l(<p+E7T/OrO1KlPp?3A'6X$2Z?$-C;<0r+[B<e+%j;0CfIYq&9#:a!41s<U,68-^B!^FHVeslnrqB
+!;(/hI?@1];mp\V%_kl#URRPfeAgY,O=fA[SATG29ESRK/LS:H:M%--EMZDZFdh];9(oN61GtM=e8/;:UU>!64OiEg>e2?M
+Z7Om%f@(8"LqfuR^,n&@A%;i\G9!8gPkr!imje"%kZpg+aEN+Ad,q8:bkWQGEf7lt#5lI\H@B%AS]Qt7?@g:"Ok=RiB2V)u
+D^!9iienbQ(Xrmth5jU@X_qWar\c("4PG.DRN"8%+Y?[?R^M7[NQYJ;F=%Zmm=jJ1nuHs3ZfCpDh=VV(rs$hk8tB&KU/E'_
+Fc#KS^?dlR^'!S/3:Jj>Ph4h>Q?"G:Mn>Q(m^bmsGn_>ZM0#U=<37K0mGj+PUctn\J#rohoc:16<NF0mIYSP7DYBM[;9aM/
+[@.kGBPeA6O32SHQ_dA^3c,S6P]WXk$bhQpfLBf7L6&`i%qCu>0\$],WRZ,p>u*EYB=?Dj@`fqN*ru-GY5=#Fq*dD53u=TY
+TPWHW*6G@1`/ooQTS`HNfj'<_FRK=Z\+l1g"/,HWXa[.tdom43lM#+eVW<O!20DU;kZ].ef[[>bRl2YBIM]T]lsACAUjWno
+jFXSN`&<\`mi[e]L[PP.pFLIpbs#=eKW")c\s\^Fm#=9"DX]h[Sb+>F6I4=U03Uf*>(e'NVWM/U6ge!n2?]Aqbo5g,>9S,A
+o#A[ET?ulT>!8odM,k?pc./hSD$;63ZM+Z?Rei-g4$X0*ZrTW=2CR`NP>8-A?@&W1#\lI8?H!Ii'B]!<q9gFkhm3p&l`aO@
+?#PjeFLtSGAS]34/aVk7/c%i.I"HgQT0BT6raXdW$:;LGa=\[ke2fL-mJH1=f:eD6-="\`f5_H]ic!_4^<XW"r</T1Y>q>u
+cYKpYX2A*]A%RMZ7eZhQRL`WFn'T!A>-"L]d]PCem('LlV5MFS^6['Q"OCdVGUqq-6#SkX/g5U\`*iInoa\+ldct_PmU:GY
+-(eae?YY$V$fs1_j[8[.?21[!oHiCV>sril+o1ZYUVqhdaYqakL8Uc+3XBJM`*1n?VUt'*GNbe(FiW,+0!dEbS!&SM4*CNn
+rB]"ET;%maZrnu8ga*OmM)^nrqd+RY(:8VQa$sKM_YZ%#PN9jKeN[K3IBhAL_t7:A5[P'3T]C"ahM+&JBPmPh^%rF'p)=//
+QSIRo?:;6$p$?e7\thE9FYSkOj?r)cRbLMRr)**/T"m5n]?ONmVsi/k*nP6ndrYOn:EHSbR'$2=PaHKt2l]eBr?o)h;>,-o
+es=eUF?X80<u>so;C`W@>qTul404cT`0muQfscK>O-oDSK$-ZHIl>^J<_W0mXmX['93MeSl@,iV?osI5qq-6#Pl&lZU:C+%
+3VMuB6f(?]\#K%P%)+bq?JQo`8()i(hP5WS[kmSYT-f3e2'07jibNB(Vn1hirKhR'?Zl30([@W[Xng_9Qu]MlU>/NB?ZU%J
+A"TX+e[.Gk:Dq>'juf^2)VXF@luM@d10.Sr7--=%CbMQZPGHPA,+!Wi*r,?:A]+&]>(&i?YA*[&k\HCk`1l^sAj9POobr$k
+%J^;*q-P")]o_N[lX^RQc<A9*n`]BIa.p-kjhusDo^I:Vp[(bJr%)j]E+H_<is>TJL?qS0iPYN[PPTI/21M).;f;:u[X=J=
+cZ6+$+\GK'dH2Y,0B][EgfJ,YS0\`M`25GMQei75;afS;OU:b.Vn*g#AGCTgX:K%<%FIP-Hkjfu;=h-(l]2MNS4)E?$"%Ns
+]3J[54WJYtimE.l<4pm^r9Bd!!,rLETopgn1==Zt@q2Wqk'm74rK5OKPWm1^,@sJ@\_1c`6ui$JNqsVF7'e(UdcOH]T?:eP
+H![%)SW4k:_ke[]nN&5e-1]nO`(PRk7H%$Wobe1e7,'BSR3*]$r2*NPdd#S'^IcP"f^bB-GmB(OPE!X"M!6;VeZ[p[[X*5,
+%EGk_3%gQTT!Dm33NknINL&OB/UhM_'MWJbdlpKBh4m\>AR_h4ai7p;^)]hT/)A(N,GK"sc!F>he;SG7$BG&pE@m&BgM+3!
+#0>VO313O.o5QPiZ-B]CE+q+\)B4Kn'0sl6J8QP<hh_XM`$[bP;Zlb+dC1QMLqNniGo%(gB'ZKNiq#soZ#)JW7U0%GL`8-\
+>Rka/j2uX)Em!KIoC-6O,0/5pRB+/_Hk/_EfOS#0nf#go=froPYOjBSm?&uiEjOBIM'DM!NZ(S!dHKg/D6B[_QZ;+LX6f*s
+iab*`MFj_j\Bk_k_%YJW"a)tqD?JR?A6+?Pbhn$=UKW)4m3@jC"%0epLjV.q]ruQ]2B9J+QG,#7EA\'^3I+"t,`!t\%P<)&
+e'U+&N81oq)ZQ8rOia5T2`C1bo$8oWS]8)ao%9hplnroZc"Oapa0C\F`M/=WAQl7s;_6q&>UPh+_uCmuDUP:cdV0fn7<LbL
+D'69C*sADtiU;Z*+^;kqJG:2&EF3<NU3UPsnZ/3M4?i(Z+??VsFp0Dah,ZW``8YPT(11hpF^)kEqF8T*n,8"tlLUtmoda?<
+h;!&hFY=dP:]1O=`HTG6pa_cQ`F$nG/j>^@(Us,%\9R)B2nQI@F`pEpZ1ZYeO?_pQDEWMG*X(.^r;D08NR)KJPX'VLcBFdS
+>1c3K>K'\D*;,,058GX0W,5Ggl=F6"*;02k+l=D`e92=C!$9n?;;X$Je6f$L*cI'"b,$t:e:3ZBC-1mh/N)/FWB'5ef>'%6
+0&p\=pIiu)Bmsd-'jJB[;]UD5>5>oih($/eIQXh,Y*e_EhG;/Wjd2j`M*RT'&X-5b2=l1"p!p,)Q4IcPDt".m.F.b+a-:M^
+A)@d=467jM]D29pPhZ)dqRBlFccYVH5tlNir*J/*pZX:%DRdskn&7Y-Isc1IlQbYprL]%X_dY9(NlbQ-:qhLjg_\>Hb)ILP
+nb6ZE^BspVC4=D$DfRY6NP[ciH]S-adUd^g/d]Hk`E2H?>F+he3oR,F?JXu('>=PmqrHnue"$I6-n\j3`#Ih3XdeFlX\Vh9
+h<aYD2:'DcHA?LfHXs5M]P#*>&iX5GLJ-IdV4C*KME<MU^3XPZ:"7IMf0WmrmWphCpEm=rMR`RJiUp)ZVq7%b?SAlq7[ABm
+DRKF)^#HQBGGfXX:TJ[EAm,knS!UQ5ie,8DUALlF)=h7"HoofbOhB:DhT&]BMsTa<ps,$MTB?SgA:'o2ZQrUbW-MA1Q?R^`
+n6C'6l=2KmKO(=;-("%?`'``WUT_P4+Yr000gi+,q<CFhf<''DVPX2lipn%9USIV@;fI*hgfEmbUC\4/@A;1VH03*9>pD<"
+/<]7Xfr5Lcjkk`^MT(l/onmCNS0>MoH>_`1(Mh2ujdEM>o[j7r4p&dbi3k[AaV"4fTOnF]Y9!8!9ci2'nhct[d?U\lTT8X3
+b"F'bh1p62:`deoP[B,?-H6JIV:NAmSkgbKOsc1>Gu($G%'i%Kk'i9c!"RfL!%%O(Z,B`*J[I*#r97tb.H?04B@^O%iRj)i
+*k\k`,-Fg8l47ql$MF5S9G,t&F?+PN+mZW4PadNQCVAoO?Ng!r#jqn.LM.2EYKDLY04OpMj=0Y#qMab3Ff?0i8idcZ2NdEF
+^.uZ(`4iX5nuHMj!9^L4VERH:;dM^o?LFosYlSC)EP*q[cYTB)b7^:NU3rH>7)1j/GeBG.ZV^R@NBH1Z6Ei]+Oi9a"bOrid
+<kdH1=/]n_Uc%5/]1u8,-i7'u!Q]h0LYYGJVp/n5r:,B?la!+NCV1Bf(=QpY$f>]%CsDKEB$ibT_D)eK72mgBE/]I5dGER=
+Co>Gk6_)B4Z;[>FMgd4qS/pfo=cTHj,Ae7!PI5_f:o?b5AQg:t>>NS5j2Ko_I'\La4I^:*Fa'AC]X#%_QX.3XPbVJ,lNYQF
+F)FNS=3Y<AX&A'MbiQ.Ag-Sr=a#W<4=V>dJ#/81jg`nHJC6=Q:HVf_K("9i"oP-M8$bY"%S)CeUQHNJ^b9S_6ek!/ekL*,5
+"Q*pak$+3">\NCJA`p<GaYI,MA/WU+&+mNa2,4qnFSeQQjn!&[;`gjqE%AmfgD%"O2-1*3Y=+e1E[Jr*WTJ"_=5daCla_W%
+NY(MeS7m\8F/^sNqEE]%n](?a%",6D6T[du2DhZ#lp+Y1\nAmk>&_g5bECldEG(Ne>plt^0j\P%'-e"Z'Q;K.#sM#;QS#:4
+bR?J@2Y+kXF5YeQ8lAFHfJ.I@6'lkuVoh,_Kg&dm:(s^-4L1.RY4Kj`RJB#_pg0@@MfMB=k_U?rMq\m=2-I0'aH"RM2t63$
+AYGUt[*RIbcD6;rA2D%r3p4;fX5k[A$I(<P8_+Z$-98/fX:Mcr`Z+\Z\^FANRWG`!M+u<^LrQ=7Q,fb@PEq]WGQZj+da635
+gBX9[m;Q^cW)T6<QDS]>*Lc<$K.]eaZ^Pq^edcm>'rN:G(2i'"#PjToTOUIY=;N9Vq`p_#OpuAW6pib\:9ollc_;!XZC0VT
+^3NWmd)/dRNQ@sZ;O&LHi:`h,TOY'Y-O;%6Wul+/^b#Zuc+lAs4-Pg4%Lm@b;H[+G;M"17UnOd1%Q%S\9cBV(6;UKT:f'tb
+:f'tb:f'tb:f(!).a2f'-?\JF6rtaKCI*ZL(tQ'<J>Bk)+L!J;q.+oHBlDm$hR2J*%]g%75$UT9H,FJmYo@I!CBlo`k6C$6
+0t@5#&ahq%s+^?4F>q>=GK:R(cikZWR?MU=50N(0EH6QlHpV[<nCp+(9Q8HEFR25a3'#eNM%4a,kJW!5k?0OR0t=L/ao+Zh
+I)R-GGHA,%Qkh+57m:9q]VAEa-C=_1p==h_S[o0HbfhTHPgH]nk<M%GMX_]5I$74+c'62Wk'B\pba2=Uk'K`Tc&qZ0h%I-p
+&uIQP#Klj>P-8-p@R=P?lIi0&kq/3D\!Dm;\m()(Xh6\tDTf2Zk-$X*<h+?+gtg,iGEON*4#=/2kq\RG>K)bmCKW"3C+Ua4
+A4>K(ZKPk:lJ$U>Ei+D.*],t]hm1c+^XU@djNT5nkq?b_Q$$lOZe\6q-?"%dB(%T]2=gGG]C'bfauRd.W:R;Am.0>eWI-50
+e^PBCgidt.^^_-Jhp!q+YHc+BC](l8nf>#pI(Oo8m&dm;ST^FaZ!EA1%(U.b?$)3q5?n/(q9Hjn2I_CkZ-&&.lV<`]hp6X4
+Nptbhj7:cOA!@s*IG`(7Na4)P.'BE.9$_".PoRCa(iktcRBUh]-*inT\\&Bfnm+k(?-eDWY@+75GgFRf]^4Z0YB7;tDg8Oj
+GBntWDc*inUUJOd.U$%!PUhFXGWn:#l`Se-<"g;tbKE[.,HAVU>/%-00%<t-c*ucACEH%7gZl]R`VT-0gV3UAa1d>p6gC2=
+rdKm`7Q[`ZBl1E7H^Va\i3'[q8JANUGUduW%<8]\]A%kBh2P!ti,*8BbP2iZU3ENJ):RkW8oA9[oYT'Me3CdS]4km[D)Tdj
+%A,N&$d,5UH8?E/Pq-RcejWXq\u?o9>)@IZ#+^DAhK+g5p>r][rHX[q+R_b[p(cY@..9s&^=K%)EU6!Ffg_G_ZsV-lfq;T-
+]=-D#1ZY(`U1[JkX$R=HP6k%VhE9=^NjJs3HN6MW6uS+Oa1I2sLZY@84g*<GGiRtNCk"^lU[5[dRf2UMk!#Gl"15LjQCF9`
+WT=ek'-MZi[Lp%MI<>uOW(gTKZC/Is.*m0T539f$2Na#fn9iNlPt^rf,3as*&oZ\[JHN.*8$r-,<^51#hmIc&X.O2#9=@Vn
+nmhAW6HoNN'i@.b40R,q-JECtZfZLelpp,'o@6i7k3Rm:N),9DlYg-QHCFD9Kk/f\9A@";nYEQN$I9G#DC9OLO>"9`q:gAf
+qRT_b_e+CueZZ@VX]Ed;Nn<0nI>3nlZ1gh)I\!81=c`M&X``!240O'PL?p+iT3<$@in7H"nVF1/aV2$bU")W@'.>Tsd?q1u
+RQ4U<DPd$S2NaS"'OHBJD.6IkJ1c-sMQ6DYQ%n"RYh%^IoT*2S8ZVmAC)G\i;)4NP:Jp_1*-Dd33Qf'2e)jEOODRCg^l;%[
+`lNkoX/fY&DY,jA9&3!en;Ju(V#P:irjLLK^J0P6O7l$r")TOg>P8Z`kq)"okK&QFgB]W_0Y4SfDYuM(lQb'E;nSIm%pJp7
+X!6E:D0g4OgCd-Xbhf7sq'8Jd:CC$[I?p3LG0k[WDh2UJONf1]?bJ"rd)R?"r=;%u?W-_:d<B9cS!^rbM(+K:3hh"lqDm<s
+<Xhjcd_;&S80Y`ui3Jspl,.0;e=R07qfq&V5g\0M(p,,T*EuNZ22c;t-"GU)#AX7&UE699dnV`+I[c/+K25XlMdUp>mA</V
+,d4A-::5TDeKV`n,-j9&?W=<@b*COfn*'$&.lLWN0=c0^^[j'igq&>fk!RNYeL)3s%O=jL0l_@jG%s!3JS`##$aa*U[[rX2
+m/8^tJ&P9Gd_bB0,/6Lg]>Rc(+Z`SLH$)E,j/+67r&jPr``eRRs.Aj.'mXU/Q_Rs<PcNJTQ(Mj&iK=YgopjcO`WEc?D*Ao`
+<o$>0I@P-L[m\spXOY[6e7ts`/%',#]9JI]ln+soD`R*&>.Bb4dmn=1IuF$0n5?]kjOH..:\MYFJKSigEom\^`8&E]BDM90
+PAHORd43;DgN#1+X\'e/biQ7MV5=+P]9R>\//li`ME._m)=p$\cMT&!DC%2VR'pb;:9/QHXd%>A[tL3rE7>D3iElEScdT0-
+a3.!Rm*M^oJTsScYLD=]*;SG+g145S1RPEFBD.cT;+-Flp#]N(G,s&gdgiY+[9b)!\.E5g".6WFK$hDBip6dlmfG%a*Q*Y,
+CtDOiJ@uVp3LHS5TS3D)YJ.dPGqVO_F_"_\Mmt7J'Eb,6B(G+Y?J>B7HVL'p,+/5S"mi5$3]UZ<kTP-6oQCe9LjhS""Z5*\
+2uY,`hdPTlZ\Z@JfWX8GR;G#3MqD6+c/3NjPI*$ZAm?,cL`8LqV$/bp$<GroXa!Bm`Rd@+%N0Dmc`"ak\CZe"LP4?_hEJP/
+,g9+m"*;sZ_CnWsrKek3Wpk@TYPu5fW@$End<k?Y8?-WF2Q:Zaf!V16&p^m'aE?GObc>*=%(XFIUV9pEFQ%"[3^_3g1rS_M
+V]fqO4:Q:?nnEp348h!hDo0=`?b)>SCnGF1i]Ybt+N$!08*-/9pR-)GcSV2j`'2Xl1d'5d!:gTP4aELiai"s8UeUDj@L'>e
+#U;Ke/%.K.aW^A$aHMIM34:.'AE),.A7G;V)01[VR4S>F.6$=6^3Hi[,M2P+5$o+Xh*<F!kjFNO,8\NsaLK`"!ijA#l5AV=
+0ji=c<Gm?F(0Mhh].=Z#-$>K''caWC(2@Nb6MO:aWs%KP0(2D1[N9dAl<58FoQ#[cXo'*i`\73iD3VE5GIbM[+4g;PBr.Zm
+ic;R\a&L#O<%[gra=fqSA@\;nU1KQ?@;dAJCH8E;>FK8hkFY8@5&D55G+UNe*\WGO9p$1@Wj'M^f[\*$>7CRLOO^i*fN[Af
+a#%(fE%.&p[fYIb.n4ep@eICU@%'P=SH6?;+O3R/Cs&fW;aL@2hJui\_WlD0.\F#kZ$g\bi%:-P`EN>K10#'p%-Ef(V%J.9
+Fnp+:Rt&C*4*.j'X[Q#"ers[e;dY`"4kik;_0DKc*UPlM^paP[.E=]7'$qrAHG&1-.+$f-'/D44mDBB\HWDkBFr'JO[^_MN
+8WYNi7Y:.GRXB2M?+4B^E@3V9aH#oJZ>[B95;t!_o)6#Cg>[8oRJPg8<3j=r?PQ2V3f='mX&k=h:OGP[dm1A9.F8J1$47+I
+$47+I$47+I$47+I\nq<e)`sNa~>
+U
+PSL_cliprestore
+25 W
+2 setlinecap
+3600 0 T
+N 0 3600 M 0 -3600 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 900 M 83 0 D S
+N 0 1800 M 83 0 D S
+N 0 2700 M 83 0 D S
+N 0 3600 M 83 0 D S
+/PSL_AH0 0
+/MM {exch M} def
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-20) sw mx
+(-10) sw mx
+(0) sw mx
+(10) sw mx
+(20) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(-20) mr Z
+900 PSL_A0_y MM
+(-10) mr Z
+1800 PSL_A0_y MM
+(0) mr Z
+2700 PSL_A0_y MM
+(10) mr Z
+3600 PSL_A0_y MM
+(20) mr Z
+N 0 180 M 42 0 D S
+N 0 360 M 42 0 D S
+N 0 540 M 42 0 D S
+N 0 720 M 42 0 D S
+N 0 1080 M 42 0 D S
+N 0 1260 M 42 0 D S
+N 0 1440 M 42 0 D S
+N 0 1620 M 42 0 D S
+N 0 1980 M 42 0 D S
+N 0 2160 M 42 0 D S
+N 0 2340 M 42 0 D S
+N 0 2520 M 42 0 D S
+N 0 2880 M 42 0 D S
+N 0 3060 M 42 0 D S
+N 0 3240 M 42 0 D S
+N 0 3420 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3600 0 T
+25 W
+N 0 0 M 3600 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 900 0 M 0 -83 D S
+N 1800 0 M 0 -83 D S
+N 2700 0 M 0 -83 D S
+N 3600 0 M 0 -83 D S
+/PSL_AH0 0
+/MM {neg M} def
+(-20) sh mx
+(-10) sh mx
+(0) sh mx
+(10) sh mx
+(20) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(-20) bc Z
+900 PSL_A0_y MM
+(-10) bc Z
+1800 PSL_A0_y MM
+(0) bc Z
+2700 PSL_A0_y MM
+(10) bc Z
+3600 PSL_A0_y MM
+(20) bc Z
+N 180 0 M 0 -42 D S
+N 360 0 M 0 -42 D S
+N 540 0 M 0 -42 D S
+N 720 0 M 0 -42 D S
+N 1080 0 M 0 -42 D S
+N 1260 0 M 0 -42 D S
+N 1440 0 M 0 -42 D S
+N 1620 0 M 0 -42 D S
+N 1980 0 M 0 -42 D S
+N 2160 0 M 0 -42 D S
+N 2340 0 M 0 -42 D S
+N 2520 0 M 0 -42 D S
+N 2880 0 M 0 -42 D S
+N 3060 0 M 0 -42 D S
+N 3240 0 M 0 -42 D S
+N 3420 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 setlinecap
+%%EndObject
+-4072 -167 TM
+PSL_plot_completion /PSL_plot_completion {} def
+
+grestore
+PSL_movie_completion /PSL_movie_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/grdfilter/varfilter.sh
+++ b/test/grdfilter/varfilter.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Make a series of 4 spikes on a grid, then create a variable
+# filter width grid with 4 quandrants of different widths
+gmt begin varfilter ps
+	# Make the data:
+	gmt grdmath -R-20/20/-20/20 -I0.25 0 = a.grd
+	gmt grdmath -R-10/10/-10/10 -I20 1 = b.grd
+	gmt grd2xyz a.grd > tmp
+	gmt grd2xyz b.grd >> tmp
+	gmt xyz2grd -R-20/20/-20/20 -I0.25 tmp -Az -Gin.grd
+	# Make the filter width grid
+	gmt grdmath -R-20/20/-20/20 -I0.25 X 0 GE 2 MUL Y 0 GE ADD 1 ADD 5 MUL = fw.grd
+	# Make the plot
+	gmt subplot begin 2x2 -Fs3i -SR -SC -T"Variable Filter Width" -M0.5c
+	gmt makecpt -T0/1 -Cwhite,black -H -Z > t.cpt
+	gmt makecpt -T0/0.005 -Cjet -H -Z > f.cpt
+	gmt grdimage in.grd -c0 -Ct.cpt
+	gmt basemap -c1
+	gmt grdimage fw.grd -Cjet -t50
+	gmt text -F+f36p<<- EOF
+	-10 -10 5
+	+10 -10 15
+	-10 +10 10
+	+10 +10 20
+	EOF
+	gmt grdfilter in.grd -Fg20 -Gg.grd -D0
+	gmt grdimage g.grd  -c2 -Cf.cpt
+	gmt grdfilter in.grd -Fgfw.grd -Gfg.grd -D0
+	gmt grdimage fg.grd  -c3  -Cf.cpt
+	gmt subplot end
+gmt end show
+rm -f a.grd b.grd tmp in.grd fw.grd t.cpt f.cpt


### PR DESCRIPTION
Needed to supply a spatially variable filter _width_ via a grid.  Compiles, need to test it.  We will enforce that the grid must have same dimensions and registration as the desired output grid.
