### PR TITLE
WIP: GMT needs single-precision FFTW 

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Linux | Build docs + Deploy docs + Package'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'ubuntu-18.04'
@@ -53,7 +53,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Linux | Test'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'ubuntu-18.04'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Linux | Build docs + Deploy docs + Package'
-  condition: ne(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'ubuntu-18.04'
@@ -53,7 +53,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Linux | Test'
-  condition: ne(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'ubuntu-18.04'

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -81,7 +81,7 @@ Install the GMT dependencies with:
     sudo apt-get install build-essential cmake libcurl4-gnutls-dev libnetcdf-dev ghostscript
 
     # Install optional dependencies
-    sudo apt-get install gdal-bin libgdal-dev libfftw3-dev libpcre3-dev liblapack-dev libblas-dev
+    sudo apt-get install gdal-bin libgdal-dev libfftw3-single3 libpcre3-dev liblapack-dev libblas-dev
 
     # to enable movie-making
     sudo apt-get install graphicsmagick ffmpeg
@@ -133,7 +133,7 @@ Install the GMT dependencies with:
     sudo dnf install cmake libcurl-devel netcdf-devel ghostscript
 
     # Install optional dependencies
-    sudo dnf install gdal gdal-devel pcre-devel fftw3-devel lapack-devel openblas-devel
+    sudo dnf install gdal gdal-devel pcre-devel fftw-libs-single lapack-devel openblas-devel
 
     # to enable movie-making
     # ffmpeg is provided by [rmpfusion](https://rpmfusion.org/)

--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -7,7 +7,7 @@ steps:
     sudo apt-get update
     sudo apt-get install -y --no-install-recommends --no-install-suggests \
         cmake ninja-build libcurl4-gnutls-dev libnetcdf-dev libgdal-dev \
-        libfftw3-dev libpcre3-dev liblapack-dev ghostscript curl
+        libfftw3-single3 libpcre3-dev liblapack-dev ghostscript curl
   displayName: Install dependencies
 
 - bash: |


### PR DESCRIPTION
GMT only needs single-precision FFTW. This PR updates the building instruction and the CI configuration.

However, there is a failing test `potential/flexure_e.sh`, but it seems irrelevant. The gm diff image is:
![image](https://user-images.githubusercontent.com/3974108/67536382-e0513a80-f6a4-11e9-937f-7b076a645895.png)
