### PR TITLE
Fix the gmt-config output of openmp

### DIFF
--- a/src/gmt-config.in
+++ b/src/gmt-config.in
@@ -68,7 +68,7 @@ else
   CONFIG_LAPACK_ENABLED=no
 fi
 
-if [ "@CONFIG_OPENMP_MESSAGE@" == "enabled" ]; then
+if [ "@GMT_CONFIG_OPENMP_MESSAGE@" == "enabled" ]; then
   CONFIG_OPENMP_ENABLED=yes
 else
   CONFIG_OPENMP_ENABLED=no


### PR DESCRIPTION
CMake variable `GMT_CONFIG_OPENMP_MESSAGE` is set to `enabled`
if OpenMP is found and enabled. `gmt-config` checks the wrong
variable `CONFIG_OPENMP_MESSAGE` to determine OpenMP configuration.