### PR TITLE
Fix outdated pstext doc description

### DIFF
--- a/doc/rst/source/text_common.rst_
+++ b/doc/rst/source/text_common.rst_
@@ -97,7 +97,7 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ [**+a**\ [*angle*]][\ **+c**\ [*justify*]][\ **+f**\ [*font*]][\ **+j**\ [*justify*]][\ **+h**\ \|\ **+l**\|\ **+r**\ [*first*] \|\ **+t**\ *text*\ \|\ **+w**\ *word*\ \|\ **+z**\ [*format*]]
+**-F**\ [**+a**\ [*angle*]][\ **+c**\ [*justify*]][\ **+f**\ [*font*]][\ **+j**\ [*justify*]][\ **+h**\ \|\ **+l**\|\ **+r**\ [*first*] \|\ **+t**\ *text*\ \|\ **+z**\ [*format*]]
     By default, text will be placed horizontally, using the primary
     annotation font attributes (:ref:`FONT_ANNOT_PRIMARY <FONT_ANNOT_PRIMARY>`), and centered
     on the data point. Use this option to override these defaults by
@@ -126,7 +126,7 @@ Optional Arguments
     to a string using the supplied *format* [use FORMAT_FLOAT_MAP].  Note: If **-Z** is
     in effect then the *z* value used for formatting is in the 4th, not 3rd column.
     If you only want a specific word from the trailing text and not the whole line,
-    use **+w**\ *word* to indicate which word (0 is the first word) you want.
+    use **-it**\ *word* to indicate which word (0 is the first word) you want.
 
 .. _-G:
 


### PR DESCRIPTION
We initially had picked **-F+w**_word_ to select a word from the trialing text but eventually implemented it via **-it**_word_.  The docs were out of date.
