### PR TITLE
Allow gmt docs info and other gmt-prefixed modules

### DIFF
--- a/doc/rst/source/docs.rst
+++ b/doc/rst/source/docs.rst
@@ -21,15 +21,15 @@ Description
 -----------
 
 **docs** tells GMT to display the HTML version of a module's documentation using the default browser.
-Besides the modules names, the special targets *gmt*, *cookbook*, *gallery*, *defaults*, *api* and *tutorial*
+Besides the modules names, the special targets *gmt*, *cookbook*, *gallery*, *settings*, *api* and *tutorial*
 are also accepted.
 
 Required Arguments
 ------------------
 
 *module-name*
-    One of teh core or supplemental modules,
-    or one of api, cookbook, gallery, defaults, and tutorial.
+    One of the core or supplemental modules,
+    or one of api, cookbook, gallery, settings, and tutorial.
 
 Optional Arguments
 ------------------
@@ -84,9 +84,9 @@ To see the documentation of the **-B** option in *coast*::
 
     gmt docs coast -B
 
-To examine the list of GMT defaults, try::
+To examine the list of GMT default settings, try::
 
-    gmt docs defaults
+    gmt docs settings
 
 To see the Gallery::
 

--- a/src/docs.c
+++ b/src/docs.c
@@ -44,7 +44,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 	GMT_Message (API, GMT_TIME_NONE, "\t<module-name> is one of the core or supplemental modules,\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   or one of gmt, api, cookbook, gallery, defaults, and tutorial.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   or one of gmt, api, cookbook, gallery, settings, and tutorial.\n");
 
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Q will only display the URLs and not open them in a viewer.\n");
@@ -198,7 +198,7 @@ int GMT_docs (void *V_API, int mode, void *args) {
 			else if (!strcmp (t, "gallery")) {
 				docname = known_doc[3];	group   = known_group[0];	/* Pretend it is in the core */
 			}
-			else if (!strcmp (t, "gmt.conf") || !strncmp (t, "default", 7U)) {
+			else if (!strcmp (t, "gmt.conf") || !strncmp (t, "setting", 7U)) {
 				docname = known_doc[4];	group   = known_group[0];	/* Pretend it is in the core */
 			}
 			else if (!strcmp (t, "gmt")) {

--- a/src/docs.c
+++ b/src/docs.c
@@ -180,6 +180,9 @@ int GMT_docs (void *V_API, int mode, void *args) {
 	
 			if (strcmp (opt->arg, docname))	/* Gave classic name so change to what was given */
 				docname = opt->arg;
+			else
+				docname = gmt_get_full_name (API, opt->arg);
+				
 
 			t = strdup (docname);	/* Make a copy because gmt_str_tolower changes the input that may be a const char */
 			gmt_str_tolower (t);

--- a/src/gmt_modern.c
+++ b/src/gmt_modern.c
@@ -88,6 +88,33 @@ const char *gmt_current_name (const char *module, char modname[]) {
 	return module;
 }
 
+const char *gmt_get_full_name (struct GMTAPI_CTRL *API, const char *module) {
+	gmt_M_unused (API);
+	/* Given a named module, return its full name if a leading gmt is missing */
+	
+	/* Look for classic modules that now have a different modern mode name */
+	if      (!strcmp (module, "2kml"))      return "gmt2kml";
+	else if (!strcmp (module, "connect"))   return "gmtconnect";
+	else if (!strcmp (module, "convert"))   return "gmtconvert";
+	else if (!strcmp (module, "defaults"))  return "gmtdefaults";
+	else if (!strcmp (module, "get"))       return "gmtget";
+	else if (!strcmp (module, "info"))      return "gmtinfo";
+	else if (!strcmp (module, "logo"))      return "gmtlogo";
+	else if (!strcmp (module, "math"))      return "gmtmath";
+	else if (!strcmp (module, "regress"))   return "gmtregress";
+	else if (!strcmp (module, "select"))    return "gmtselect";
+	else if (!strcmp (module, "set"))       return "gmtset";
+	else if (!strcmp (module, "simplify"))  return "gmtsimplify";
+	else if (!strcmp (module, "spatial"))   return "gmtspatial";
+	else if (!strcmp (module, "vector"))    return "gmtvector";
+	else if (!strcmp (module, "which"))     return "gmtwhich";
+	else if (!strcmp (module, "pmodeler"))  return "gmtpmodeler";
+	else if (!strcmp (module, "flexure"))   return "gmtflexure";
+	else if (!strcmp (module, "gravmag3d")) return "gmtgravmag3d";
+	return module;
+}
+
+
 const char *gmtlib_get_active_name (struct GMTAPI_CTRL *API, const char *module) {
 	/* Given a classic name module, return its name according to the run mode */
 	

--- a/src/gmt_modern.h
+++ b/src/gmt_modern.h
@@ -72,5 +72,6 @@ EXTERN_MSC int GMT_segyz (void *API, int mode, void *args);
 EXTERN_MSC int GMT_segy (void *API, int mode, void *args);
 
 EXTERN_MSC const char *gmt_current_name (const char *module, char modname[]);
+EXTERN_MSC const char *gmt_get_full_name (struct GMTAPI_CTRL *API, const char *module);
 
 #endif  /* GMT_MODERN_H */


### PR DESCRIPTION
Need to obtain the full name for these modules.  Still need solution for gmt docs defaults which now returns gmtdefaults man page instead of gmt.conf.  I propose calling that alias settings.  Closes issue #1897.
