### PR TITLE
filter1d also needs to honor obsolete -N if given

### DIFF
--- a/src/filter1d.c
+++ b/src/filter1d.c
@@ -385,7 +385,11 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct FILTER1D_CTRL *Ctrl, struct GM
 
 	if (Ctrl->T.active)	/* Do this one here since we need Ctrl->N.col to be set first, if selected */
 		n_errors += gmt_parse_array (GMT, 'T', t_arg, &(Ctrl->T.T), GMT_ARRAY_TIME | GMT_ARRAY_DIST | GMT_ARRAY_ROUND, Ctrl->N.col);
-	if (Ctrl->N.spatial) Ctrl->T.T.spatial = Ctrl->N.spatial;	/* Obsolete -N settings propagated to -T */
+	if (Ctrl->N.spatial) {	/* Obsolete -N settings propagated to -T */
+		Ctrl->T.T.spatial = Ctrl->N.spatial;
+		Ctrl->T.T.unit = Ctrl->N.unit;
+		Ctrl->T.T.distmode = Ctrl->N.mode;
+	}
 	if (Ctrl->N.add_col) Ctrl->T.T.add = true;	/* Obsolete -N+a settings propagated to -T */
 	
 	/* Check arguments */


### PR DESCRIPTION
I was too quick to assume my fixed worked, but it failed for old syntax (smooth_track.sh test) which used the obsolete **-Ngk+a**.

