### PR TITLE
Point out the effect of softing on event order

### DIFF
--- a/doc/rst/source/events_common.rst_
+++ b/doc/rst/source/events_common.rst_
@@ -222,3 +222,11 @@ and can be selected or ignored as you wish via **-E**.  You can choose to specif
 of the three time histories.  By default the symbol size is constant, there is no intensity
 variation, and all symbols are opaque.  If trailing text is plotted (requires **-Et**) then
 only a transparency time-function is used.
+
+Sorting the data
+----------------
+
+While only the events that should be visible will be plotted at the given time set via **-T**,
+the order of plotting is simply given by the order of records in the file.  Thus, if the
+file is *not* sorted into ascending time then later events might plot *beneath* earlier events.
+To prevent this, you can sort your file into ascending order via the :doc:`gmtconvert` **-N** option.


### PR DESCRIPTION
The **events** module cannot sort the data for you.  If your data are not sorted into ascending time then you should probably do so first.  The documentation has been updated to point this out.
