### PR TITLE
Create build-macos-external-list.sh

### DIFF
--- a/admin/ConfigReleaseBuild.cmake
+++ b/admin/ConfigReleaseBuild.cmake
@@ -19,4 +19,6 @@ set (GMT_ENABLE_OPENMP TRUE)
 set (CMAKE_C_FLAGS "-Wall -Wdeclaration-after-statement ${CMAKE_C_FLAGS}")
 # extra warnings
 set (CMAKE_C_FLAGS "-Wextra ${CMAKE_C_FLAGS}")
-set (EXTRA_INCLUDE_EXES "add_macOS_cpack.txt")
+# Include all the external executables and shared libraries
+# The add_macOS_cpack.txt is created by build-release.sh
+set (EXTRA_INCLUDE_EXES "../../build/add_macOS_cpack.txt")

--- a/admin/ConfigReleaseBuild.cmake
+++ b/admin/ConfigReleaseBuild.cmake
@@ -19,3 +19,4 @@ set (GMT_ENABLE_OPENMP TRUE)
 set (CMAKE_C_FLAGS "-Wall -Wdeclaration-after-statement ${CMAKE_C_FLAGS}")
 # extra warnings
 set (CMAKE_C_FLAGS "-Wextra ${CMAKE_C_FLAGS}")
+set (EXTRA_INCLUDE_EXES "add_macOS_cpack.txt")

--- a/admin/build-macos-external-list.sh
+++ b/admin/build-macos-external-list.sh
@@ -19,7 +19,7 @@ cat << EOF
 # List of extra executables and shared libraries to include in the macOS installer
 # This file is prepared to use ${USER} installation paths.
 
-install (PROGRAMS)
+install (PROGRAMS
 EOF
 awk '{printf "\t%s\n", $1}' /tmp/programs.lis
 cat << EOF

--- a/admin/build-macos-external-list.sh
+++ b/admin/build-macos-external-list.sh
@@ -23,13 +23,13 @@ install (PROGRAMS)
 EOF
 awk '{printf "\t%s\n", $1}' /tmp/programs.lis
 cat << EOF
-	DESTINATION ${GMT_BINDIR}
+	DESTINATION \${GMT_BINDIR}
 	COMPONENT Runtime)
 
 install (PROGRAMS
 EOF
 awk '{printf "\t%s\n", $1}' /tmp/libraries.lis
 cat << EOF
-	DESTINATION ${GMT_LIBDIR}
+	DESTINATION \${GMT_LIBDIR}
 	COMPONENT Runtime)
 EOF

--- a/admin/build-macos-external-list.sh
+++ b/admin/build-macos-external-list.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Build include file for cpack to build complete macOS Bundle
+# List of executables whose shared libraries must also be included
+
+EXE="gs gm ffmpeg"
+# List of executables whose shared libraries have been included via GDAL
+which ogr2ogr > /tmp/raw.lis
+which gdal_translate >> /tmp/raw.lis
+for P in $EXE; do
+	path=`which $P`
+	echo $path >> /tmp/raw.lis
+	otool -L $path | egrep -v '/usr/lib|/System/Library' | tr ':' ' ' | awk '{print $1}' >> /tmp/raw.lis
+done
+sort -u /tmp/raw.lis > /tmp/unique.lis
+grep dylib /tmp/unique.lis > /tmp/libraries.lis
+grep -v dylib /tmp/unique.lis > /tmp/programs.lis
+
+cat << EOF
+# List of extra executables and shared libraries to include in the macOS installer
+# This file is prepared to use ${USER} installation paths.
+
+install (PROGRAMS)
+EOF
+awk '{printf "\t%s\n", $1}' /tmp/programs.lis
+cat << EOF
+	DESTINATION ${GMT_BINDIR}
+	COMPONENT Runtime)
+
+install (PROGRAMS
+EOF
+awk '{printf "\t%s\n", $1}' /tmp/libraries.lis
+cat << EOF
+	DESTINATION ${GMT_LIBDIR}
+	COMPONENT Runtime)
+EOF

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -30,9 +30,11 @@ if [ -f cmake/ConfigUser.cmake ]; then
 	cp cmake/ConfigUser.cmake cmake/ConfigUser.cmake.orig
 fi
 cp -f admin/ConfigReleaseBuild.cmake cmake/ConfigUser.cmake
-# 2. Make build dir and configure it
+# 2a. Make build dir and configure it
 rm -rf build
 mkdir build
+# 2b. Build list of external programs and shared libraries
+admin/build-macos-external-list.sh > build/add_macOS_cpack.txt
 cd build
 echo "build-release.sh: Configure and build tarballs"
 cmake -G Ninja ..


### PR DESCRIPTION
My suggestion is to let build-release.sh call build-macos-external-list.sh to produce a CMake include file that adds required external executables and shared libraries to the macOS bundle, similar to how @joa-quim uses add_exes_cpack.txt.

What is still needed:

1. Add the call to this function from build-release and have it write a macos-cpack.txt file that should be conditionally included by CMakeConfig.
2. CMake should check if this file exists and if so include it, otherwise not.
3. Check if the install CMake statement for shared libraries is correct
4. Give it a test
