### PR TITLE
Revert "GMT needs single-precision FFTW  (#1892)"

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -81,7 +81,7 @@ Install the GMT dependencies with:
     sudo apt-get install build-essential cmake libcurl4-gnutls-dev libnetcdf-dev ghostscript
 
     # Install optional dependencies
-    sudo apt-get install gdal-bin libgdal-dev libfftw3-single3 libpcre3-dev liblapack-dev libblas-dev
+    sudo apt-get install gdal-bin libgdal-dev libfftw3-dev libpcre3-dev liblapack-dev libblas-dev
 
     # to enable movie-making
     sudo apt-get install graphicsmagick ffmpeg
@@ -133,7 +133,7 @@ Install the GMT dependencies with:
     sudo dnf install cmake libcurl-devel netcdf-devel ghostscript
 
     # Install optional dependencies
-    sudo dnf install gdal gdal-devel pcre-devel fftw-libs-single lapack-devel openblas-devel
+    sudo dnf install gdal gdal-devel pcre-devel fftw3-devel lapack-devel openblas-devel
 
     # to enable movie-making
     # ffmpeg is provided by [rmpfusion](https://rpmfusion.org/)

--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -7,7 +7,7 @@ steps:
     sudo apt-get update
     sudo apt-get install -y --no-install-recommends --no-install-suggests \
         cmake ninja-build libcurl4-gnutls-dev libnetcdf-dev libgdal-dev \
-        libfftw3-single3 libpcre3-dev liblapack-dev ghostscript curl
+        libfftw3-dev libpcre3-dev liblapack-dev ghostscript curl
   displayName: Install dependencies
 
 - bash: |


### PR DESCRIPTION
This reverts commit 19aa6eeabb13b00d538dc5f6ce595e71c55348d8.

GMT only needs single-precision FFTW. I thought it's enough to install
the single-precision FFTW library (i.e. libfftw3-single3, fftw-libs-single),
and made the changes in PR #1892.

It turns out we still need to install libfftw3-dev or fftw3-devel, because
fftw3.h is needed when building GMT.