### PR TITLE
Enable FFTW threads support on Windows

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -242,10 +242,10 @@ After installing vcpkg, you can install the GMT dependency libraries with (it ma
 
     # Build and install libraries
     # If you want to build x64 libraries (recommended)
-    vcpkg install netcdf-c gdal pcre fftw3 clapack openblas --triplet x64-windows
+    vcpkg install netcdf-c gdal pcre fftw3[core,threads] clapack openblas --triplet x64-windows
 
     # If you want to build x86 libraries
-    vcpkg install netcdf-c gdal pcre fftw3 clapack openblas --triplet x86-windows
+    vcpkg install netcdf-c gdal pcre fftw3[core,threads] clapack openblas --triplet x86-windows
 
     # hook up user-wide integration (note: requires admin on first use)
     vcpkg integrate install

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -7,7 +7,7 @@ steps:
 # To rebuild the cache, you have to change the date in the key list
 - task: CacheBeta@0
   inputs:
-    key: $(Agent.OS) | vcpkg | 20191102
+    key: $(Agent.OS) | vcpkg | 20191107
     path: $(VCPKG_INSTALLATION_ROOT)/installed/
     cacheHitVar: CACHE_VCPKG_RESTORED
   displayName: Cache vcpkg libraries
@@ -23,7 +23,7 @@ steps:
     echo 'set (VCPKG_BUILD_TYPE release)' >> ${VCPKG_INSTALLATION_ROOT}/triplets/${WIN_PLATFORM}.cmake
     cat ${VCPKG_INSTALLATION_ROOT}/triplets/${WIN_PLATFORM}.cmake
     # install libraries
-    vcpkg install netcdf-c gdal pcre fftw3 clapack openblas --triplet ${WIN_PLATFORM}
+    vcpkg install netcdf-c gdal pcre fftw3[core,threads] clapack openblas --triplet ${WIN_PLATFORM}
   displayName: Install dependencies via vcpkg
   env:
     WIN_PLATFORM: "x64-windows"

--- a/cmake/modules/FindFFTW3.cmake
+++ b/cmake/modules/FindFFTW3.cmake
@@ -52,12 +52,22 @@ find_library (FFTW3F_LIBRARY
 	/usr/local
 )
 
+get_filename_component (_fftw3_libname ${FFTW3F_LIBRARY} NAME)
 get_filename_component (_fftw3_libpath ${FFTW3F_LIBRARY} PATH)
 
-# threaded single precision
-find_library (FFTW3F_THREADS_LIBRARY
-	NAMES fftw3f_threads
-	HINTS ${_fftw3_libpath})
+# find single precision threaded library
+# the threaded functions may in the fftw3f library or the a separated fftw3f_threads library
+if (FFTW3F_LIBRARY)
+	include (CheckLibraryExists)
+	check_library_exists (${FFTW3F_LIBRARY} fftwf_plan_with_nthreads ${_fftw3_libpath} _fftw3_library_have_threads)
+	if (_fftw3_library_have_threads)
+		set (FFTW3F_THREADS_LIBRARY ${FFTW3F_LIBRARY} CACHE INTERNAL "FFTW3 threads support")
+	else (_fftw3_library_have_threads)
+		find_library (FFTW3F_THREADS_LIBRARY
+			NAMES fftw3f_threads
+			HINTS ${_fftw3_libpath})
+	endif (_fftw3_library_have_threads)
+endif (FFTW3F_LIBRARY)
 
 if (FFTW3F_LIBRARY)
 	# test if FFTW >= 3.3
@@ -93,4 +103,5 @@ set (FFTW3F_LIBRARIES ${FFTW3F_LIBRARY})
 if (FFTW3F_THREADS_LIBRARY)
 	list (APPEND FFTW3F_LIBRARIES ${FFTW3F_THREADS_LIBRARY})
 endif (FFTW3F_THREADS_LIBRARY)
+list (REMOVE_DUPLICATES FFTW3F_LIBRARIES)
 set (FFTW3_INCLUDE_DIRS ${FFTW3_INCLUDE_DIR})


### PR DESCRIPTION
The fftw3 package from vcpkg doesn't enable threads feature by default. To enable fftw3 threads, we need to install `fftw3[core,threads]` instead of `fftw3` (i.e. `fftw3[core]`. This is done in 88d7e260bb8317b00584b77a3f504b39bb4b630a.

After installing `fftw3[core,threads]`, the FindFFTW3.cmake script still can't find the threads library. The script tries to find libraries `fftw3f` and `fftw3f_threads`, but the fftw3 from vcpkg have all functions in a single library `fftw3f`. Thus, the script should check if the threading functions (e.g. `fftwf_plan_with_nthreads`) are included in the `fftw3f` library. If not, then tries to find the `fftw3_threads` library instead. This is fixed in 1e7f229811e5010e33d99286d3c445ee488b6372.