### PR TITLE
CI: Update vcpkg cache

### DIFF
--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -7,13 +7,17 @@ steps:
 # To rebuild the cache, you have to change the date in the key list
 - task: CacheBeta@0
   inputs:
-    key: $(Agent.OS) | vcpkg | 20191017
+    key: $(Agent.OS) | vcpkg | 20191102
     path: $(VCPKG_INSTALLATION_ROOT)/installed/
     cacheHitVar: CACHE_VCPKG_RESTORED
   displayName: Cache vcpkg libraries
 
 - bash: |
     set -x -e
+    # Update vcpkg and checkout specific tag
+    cd ${VCPKG_INSTALLATION_ROOT}
+    git pull
+    git checkout 2019.10
     # By default, vcpkg builds both release and debug configurations.
     # Set VCPKG_BUILD_TYPE to build release only to save half time
     echo 'set (VCPKG_BUILD_TYPE release)' >> ${VCPKG_INSTALLATION_ROOT}/triplets/${WIN_PLATFORM}.cmake


### PR DESCRIPTION
vcpkg recently updated their proj port to 6.2.0 and correctly ships the proj.dll library.

This PR update our vcpkg cache to the 2019.10 version. 