### PR TITLE
Testing and fixing the release script to work as intended

### DIFF
--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -2,13 +2,19 @@
 # Script that builds a GMT release and makes the compressed tarballs.
 # If run under macOS it also builds the macOS Bundle
 reset_config() {
-	rm -f ${CMAKEDIR}/ConfigUser.cmake
-	if [ -f ${CMAKEDIR}/ConfigUser.cmake.orig ]; then
-		mv -f ${CMAKEDIR}/ConfigUser.cmake.orig ${CMAKEDIR}/ConfigUser.cmake
+	rm -f ${TOPDIR}/cmake/ConfigUser.cmake
+	if [ -f ${TOPDIR}/cmake/ConfigUser.cmake.orig ]; then # Restore what we had
+		mv -f ${TOPDIR}/cmake/ConfigUser.cmake.orig ${TOPDIR}/cmake/ConfigUser.cmake
 	fi
 }
 
-CMAKEDIR=`pwd`/cmake
+abort_build() {	# Called when we abort this script via Crtl-C
+	reset_config
+	rm -rf ${TOPDIR}/build
+	exit -1
+}
+
+TOPDIR=`pwd`
 
 if [ $# -gt 0 ]; then
 	echo "Usage: build-release.sh"
@@ -39,7 +45,7 @@ if [ -f cmake/ConfigUser.cmake ]; then
 	cp cmake/ConfigUser.cmake cmake/ConfigUser.cmake.orig
 fi
 cp -f admin/ConfigReleaseBuild.cmake cmake/ConfigUser.cmake
-trap reset_config SIGINT
+trap abort_build SIGINT
 # 2a. Make build dir and configure it
 rm -rf build
 mkdir build


### PR DESCRIPTION
Needed to call exit after cleaning up.  Original version just continued after calling the reset code... Tested and Ctrl-C now works as expected (restore the user's (e.g., my) ConfigUser.cmake file and deletes the half-baked build directory before exiting).