### PR TITLE
Macports now has gs 9.50 so no need to build separately

### DIFF
--- a/admin/build-macos-external-list.sh
+++ b/admin/build-macos-external-list.sh
@@ -6,9 +6,8 @@
 # List of executables whose shared libraries must also be included
 #
 # Exceptions:
-# For now (6.0.0), need to do a few things manually first, like
-# 1. Separate install command to avoid version number in GraphicsMagick directory name
-# 2. Build gs from 9.50 tarball and place in /opt (until 9.50 appears in port)
+# For now (6.0.1), need to do a few things manually:
+# 1. Separate install command to avoid version number in GraphicsMagick directory name (see at end)
 
 if [ `which cmake` = "/opt/local/bin/cmake" ]; then
 	distro=MacPorts
@@ -22,16 +21,16 @@ else
 fi
 # 1a. List of executables needed and whose shared libraries also are needed.
 #     Use full path if you need something not in your path
-EXEPLUSLIBS="/opt/bin/gs /opt/local/bin/gm /opt/local/bin/ffmpeg /opt/local/bin/ogr2ogr /opt/local/bin/gdal_translate /opt/local/lib/libfftw3f_threads.dylib"
+EXEPLUSLIBS="/opt/local/bin/gs /opt/local/bin/gm /opt/local/bin/ffmpeg /opt/local/bin/ogr2ogr /opt/local/bin/gdal_translate /opt/local/lib/libfftw3f_threads.dylib"
 # 1b. List of any symbolic links needed
-#     Use full path if you need something not in your path
-EXELINKS=
+#     Use full path if you need something not in your path (gs is a link to gsc in homewbrew)
+EXELINKS=/opt/local/bin/gs
 # 1c. List of executables whose shared libraries have already been included via other shared libraries
 #     Use full path if you need something not in your path
 EXEONLY=
 # 1d. Shared directories to be added
 #     Use full path if you need someting not in your path
-EXESHARED="gdal /opt/share/ghostscript /opt/local/lib/proj6/share/proj"
+EXESHARED="gdal /opt/local/share/ghostscript /opt/local/lib/proj6/share/proj"
 #-----------------------------------------
 # 2a. Add the executables to the list given their paths
 rm -f /tmp/raw.lis


### PR DESCRIPTION
We can now use the macports version of gs in our bundle building.  @seisman, I built a test gmt-6.0.1-darwin-x86_64.dmg in the usual ftp dir if you want to check.  This gs uses libgs.dylib and a symbolic link gs to gsc which is the ghostcsript application in macports.  Worked for me, and a basic plot worked.