### PR TITLE
Add FFTW_THREADS_LIBRARY to the cmake configuration output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ message(
 	"*  GDAL library               : ${GDAL_LIBRARY}\n"
 	"*  GDAL include dir           : ${GDAL_INCLUDE_DIR}\n"
 	"*  FFTW library               : ${FFTW3F_LIBRARY}\n"
+	"*  FFTW threads library       : ${FFTW3F_THREADS_LIBRARY}\n"
 	"*  FFTW include dir           : ${FFTW3_INCLUDE_DIR}\n"
 	"*  Accelerate Framework       : ${ACCELERATE_FRAMEWORK}\n"
 	"*  Regex support              : ${GMT_CONFIG_REGEX_MESSAGE}\n"


### PR DESCRIPTION
To help us know if fftw threads is enabled.