### PR TITLE
Update share/tools for GMT 6

### DIFF
--- a/share/tools/gmt_aliases.csh
+++ b/share/tools/gmt_aliases.csh
@@ -10,8 +10,14 @@
 # If the GMT executable is not in the search path, set an extra alias:
 #   alias gmt path/to/gmt
 
+which gmt > /dev/null
+if ($? == 1) then
+  echo 'Error: gmt is not found in your search PATH.'
+  exit 1
+endif
+
 set gmt_modules = (`gmt --show-modules`)
-set compat_modules = (minmax gmt2rgb gmtstitch gmtdp grdreformat ps2raster)
+set compat_modules = (minmax gmtstitch gmtdp grdreformat ps2raster originator)
 
 foreach module ( $gmt_modules $compat_modules )
   	eval 'alias $module "gmt $module"'

--- a/share/tools/gmt_functions.sh
+++ b/share/tools/gmt_functions.sh
@@ -15,8 +15,13 @@
 # check for bash
 [ -z "$BASH_VERSION" ] && return
 
+if ! [ -x "$(command -v gmt)" ]; then
+  echo 'Error: gmt is not found in your search PATH.' >&2
+  exit 1
+fi
+
 gmt_modules=`gmt --show-modules`
-compat_modules="minmax gmt2rgb gmtstitch gmtdp grdreformat ps2raster"
+compat_modules="minmax gmtstitch gmtdp grdreformat ps2raster originator"
 
 for module in ${gmt_modules} ${compat_modules}; do
 	eval "function ${module} () { gmt ${module} \"\$@\"; }"

--- a/share/tools/gmt_links.sh
+++ b/share/tools/gmt_links.sh
@@ -8,7 +8,7 @@
 # directly.
 #
 # Run this script on the command line with:
-#   $(gmt --show-datadir)/tools/gmt_links.sh create|remove
+#   $(gmt --show-sharedir)/tools/gmt_links.sh create|remove
 #
 # With no arguments we simply check for the links.
 #
@@ -17,6 +17,11 @@
 
 # check for bash
 [ -z "$BASH_VERSION" ] && return
+
+if ! [ -x "$(command -v gmt)" ]; then
+  echo 'Error: gmt is not found in your search PATH.' >&2
+  exit 1
+fi
 
 if [ "X$1" = "Xdelete" ]; then
 	mode=1
@@ -29,7 +34,7 @@ bin=`gmt --show-bindir`
 cwd=`pwd`
 
 gmt_modules=`gmt --show-modules`
-compat_modules="minmax gmt2rgb gmtstitch gmtdp grdreformat ps2raster"
+compat_modules="minmax gmtstitch gmtdp grdreformat ps2raster originator"
 
 cd $bin
 for module in ${gmt_modules} ${compat_modules}; do

--- a/share/tools/gmt_uninstall.sh
+++ b/share/tools/gmt_uninstall.sh
@@ -16,6 +16,11 @@
 # check for bash
 [ -z "$BASH_VERSION" ] && return
 
+if ! [ -x "$(command -v gmt)" ]; then
+  echo 'Error: gmt is not found in your search PATH.' >&2
+  exit 1
+fi
+
 inc=`gmt-config --includedir`
 share=`gmt --show-sharedir`
 bin=`gmt --show-bindir`
@@ -24,7 +29,7 @@ lib=`gmt --show-plugindir`
 cwd=`pwd`
 
 gmt_modules=`gmt --show-modules`
-compat_modules="minmax gmt2rgb gmtstitch gmtdp grdreformat ps2raster"
+compat_modules="minmax gmtstitch gmtdp grdreformat ps2raster originator"
 
 # 2. Remove include directory
 cd $inc
@@ -41,7 +46,7 @@ else
 fi
 
 # 3. Remove share directory
-for dir in conf cpt custom doc localization man mgd77 mgg postscriptlight spotter tools x2sys; do
+for dir in cpt custom doc localization man mgd77 mgg spotter tools x2sys; do
 	printf "Remove: %s/%s\n" $share $dir
 	rm -rf $share/$dir
 done


### PR DESCRIPTION
There is no gmt2rgb module anymore, and also check if gmt is in the user's path before calling gmt. Nextstep is to add documentation for using these helper scripts.
