### PR TITLE
Do more than just check if the last letter in string is a unit

### DIFF
--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -155,6 +155,7 @@ enum GMT_swap_direction {
 #define GMT_LEN_UNITS	"dmsefkMnu"	/* Distances in arc-{degree,minute,second} or meter, foot, km, Mile, nautical mile, survey foot */
 #define GMT_TIME_UNITS	"yowdhms"	/* Time increments in year, month, week, day, hour, min, sec */
 #define GMT_TIME_VAR_UNITS	"yo"	/* Variable time increments in year or month*/
+#define GMT_WESN_UNITS	"WESN"		/* Sign-letters for geographic coordinates */
 #define GMT_DIM_UNITS_DISPLAY	"c|i|p"			/* Same, used to display as options */
 #define GMT_LEN_UNITS_DISPLAY	"d|m|s|e|f|k|M|n|u"	/* Same, used to display as options */
 #define GMT_LEN_UNITS2_DISPLAY	"e|f|k|M|n|u"		/* Same, used to display as options */


### PR DESCRIPTION
While not perfect, the proposed change will be more careful in accepting a trailing letter as a valid unit (and hence parse the string as a number).  We now insist that the unit must be a single trailing letter, thus catching stuff like 123.4kkkkkkkkmmmmm as text.  We don't check the front of the string on purpose since it can be almost anything, like January/31/1999 so too many possibilities.
Tests passes, stuff like 10km is now seen as text and not the number 10 miles.
