### PR TITLE
Don't forget presence of earth_relief when setting -J

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12388,6 +12388,9 @@ GMT_LOCAL bool is_region_geographic (struct GMT_CTRL *GMT, struct GMT_OPTION *op
 	struct GMT_OPTION *opt = NULL;
 	unsigned int n_slashes;
 	size_t len;
+	/* If geographic is already set we just return true */
+
+	if (gmt_M_is_geographic (GMT, GMT_IN)) return true;
 	/* First deal with all the modules that only involve geographic data */
 	if (!strncmp (module, "grdlandmask", 11U)) return true;
 	if (!strncmp (module, "pscoast", 7U)) return true;


### PR DESCRIPTION
If a user ran a simple command using earth_relief_xxy, we might later find that the default -J was set for Cartesian plots since we did not consult the geo setting.  For instance, this command

`gmt grdimage @earth_relief_10m -B -I+d -png dem
`

ended up with a -JX15c projection instead of -JQ15c.
