### PR TITLE
First-order corrections to the text that accompany gallery examples

### DIFF
--- a/doc/rst/source/gallery/ex01.rst
+++ b/doc/rst/source/gallery/ex01.rst
@@ -10,13 +10,14 @@ files later). We would like to show one map centered on Greenwich and
 one centered on the dateline. Positive contours should be drawn with a
 solid pen and negative contours with a dashed pen. Annotations should
 occur for every 50 m contour level, and both contour maps should show
-the continents in light brown in the background. Finally, we want a
-rectangular frame surrounding the two maps. This is how it is done:
+the continents in light brown in the background. This is how it is done:
 
 .. literalinclude:: /_verbatim/ex01.txt
    :language: bash
 
-The first command draws a box surrounding the maps. This is followed by
+The first command sets up a 2 by 1 :doc:`subplot` layout. The subplot determines
+the size of what map can fit so we use ? when specifying map widths in the
+commands below.  This initial setup is followed by
 two sequences of :doc:`coast </coast>`, :doc:`grdcontour </grdcontour>`,
 :doc:`grdcontour </grdcontour>`. They differ in that the
 first is centered on Greenwich; the second on the dateline. We use the
@@ -25,7 +26,8 @@ to select negative contours only and plot those with a dashed pen, then
 positive contours only and draw with a solid pen [Default]. The **-T**
 option causes tick marks pointing in the downhill direction to be drawn
 on the innermost, closed contours. For the upper panel we also added -
-and + to the local lows and highs. You can find this illustration as
+and + to the local lows and highs. The labeling of the two plots with a)
+and b) is automatically done by :doc:`subplot`. You can find this illustration as
 
 .. figure:: /_images/ex01.*
    :width: 500 px

--- a/doc/rst/source/gallery/ex02.rst
+++ b/doc/rst/source/gallery/ex02.rst
@@ -5,45 +5,34 @@
 
 As our second example we will demonstrate how to make color images from
 gridded data sets (again, we will defer the actual making of grid files
-to later examples). We will use :doc:`grdcut </grdcut>` to extract 2-D grid files
-of bathymetry and Geosat geoid heights from global grids and put the two images on the
-same page. The region of interest is the Hawaiian islands, and due to
+to later examples). We have prepared two 2-D grid files of bathymetry and
+Geosat geoid heights from global grids and will put the two images on the
+same page. The region of interest is the Hawaiian Islands, and due to
 the oblique trend of the island chain we prefer to rotate our
 geographical data sets using an oblique Mercator projection defined by
 the hotspot pole at (68W, 69N). We choose the point (190, 25.5) to be
 the center of our projection (e.g., the local origin), and we want to
 image a rectangular region defined by the longitudes and latitudes of
 the lower left and upper right corner of region. In our case we choose
-(160, 20) and (220, 30) as the corners. We use
+(160, 20) and (220, 30) as the corners. We twice use
 :doc:`grdimage </grdimage>` to make the illustration:
 
 .. literalinclude:: /_verbatim/ex02.txt
    :language: bash
 
-The first step extracts the 2-D data sets from the global data grids using
-:doc:`grdcut </grdcut>`. Given **-J**, it automatically figures out the
-required extent of the region given the two corners points and the
-projection. The extreme meridians and parallels enclosing the oblique
-region is **-R**\ 159:50/220:10/3:10/47:35. This is the area extracted
-by :doc:`grdcut </grdcut>`. For your convenience
-we have commented out those lines and provided the two extracted files
-so you do not need to run :doc:`grdcut </grdcut>` to try
-this example. By using the embedded grid file format mechanism we saved
-the topography using kilometers as the data unit. We now have two grid
-files with bathymetry and geoid heights, respectively. We use
-:doc:`makecpt </makecpt>` to generate a linear color
+We again set up a 2 by 1 subplot layout and specify the actual region and
+map projection we wish to use for the two map panels.
+We use :doc:`makecpt </makecpt>` to generate a linear color
 palette file ``geoid.cpt`` for the geoid and use
 :doc:`grd2cpt </grd2cpt>` to get a histogram-equalized
-CPT ``topo.cpt`` for the topography data. To emphasize the structures in the
-data we calculate the slopes in the north-south direction using
-:doc:`grdgradient </grdgradient>`; these will be used to
-modulate the color image. Next we run
-:doc:`grdimage </grdimage>` to create a color-code image
-of the Geosat geoid heights, and draw a color legend to the right of the
-image with :doc:`colorbar </colorbar>`. Similarly, we run
-:doc:`grdimage </grdimage>` but specify **-Y**\ 4.5i to
-plot above the previous image. Adding scale and label the two plots a)
-and b) completes the illustration.
+CPT ``topo.cpt`` for the topography data.  We run
+:doc:`grdimage </grdimage>` to create a color-coded image
+of the topography, and to emphasize the structures in the
+data we use the slopes in the north-south direction to
+modulate the color image via the **-I** option. Then, we place a color legend to the right of the
+image with :doc:`colorbar </colorbar>`. We repeat these steps for the
+Geosat geoid grid. Again, the labeling of the two plots with a)
+and b) is automatically done by :doc:`subplot`.
 
 .. figure:: /_images/ex02.*
    :width: 500 px

--- a/doc/rst/source/gallery/ex04.rst
+++ b/doc/rst/source/gallery/ex04.rst
@@ -5,8 +5,9 @@
 
 This example will illustrate how to make a fairly complicated composite
 figure. We need a subset of the ETOPO5 bathymetry [1]_ and Geosat geoid
-data sets which we will extract from the global data grids using
-:doc:`grdcut </grdcut>`. We would like to show a
+data sets which we have extracted from the global data grids using
+:doc:`grdcut </grdcut>` and access those files here as remote files
+on the GMT data server. We would like to show a
 2-layer perspective plot where layer one shows a contour map of the
 marine geoid with the location of the Hawaiian islands superposed, and a
 second layer showing the 3-D mesh plot of the topography. We also add an
@@ -44,4 +45,4 @@ have resulted in a much larger output file. The CPTs were taken
 from Example :ref:`example_02`.
 
 .. [1]
-   These data are available on CD-ROM from NGDC (www.ngdc.noaa.gov).
+   These data are available from NCEI (www.ncei.noaa.gov).

--- a/doc/rst/source/gallery/ex05.rst
+++ b/doc/rst/source/gallery/ex05.rst
@@ -8,14 +8,12 @@ artificial illumination. For this example we will use
 :doc:`grdmath </grdmath>` to make a grid file that
 contains the surface given by the function
 :math:`z(x, y) = \cos (2\pi r/8)\cdot e^{-r/10}`, where
-:math:`r^2 = (x^2 + y^2)`. The illumination is obtained by passing two
-grid files to :doc:`grdview </grdview>`: One with the
-*z*-values (the surface) and another with intensity values (which should
-be in the 1 range). We use
-:doc:`grdgradient </grdgradient>` to compute the
-horizontal gradients in the direction of the artificial light source.
-The ``gray.cpt`` file only has one line that states that all *z* values should have
-the gray level 128. Thus, variations in shade are entirely due to
+:math:`r^2 = (x^2 + y^2)`. The illumination is obtained by passing the
+grid file to :doc:`grdview </grdview>` and requesting that artificial
+shading be derived from the  horizontal gradients in the direction of
+the artificial light source (set by **-I**).
+The :doc:`makecpt` command creates a simple color scheme for a constant
+gray level of 128. Thus, variations in shade are entirely due to
 variations in gradients, or illuminations. We choose to illuminate from
 the SW and view the surface from SE:
 
@@ -25,8 +23,8 @@ the SW and view the surface from SE:
 The variations in intensity could be made more dramatic by using
 :doc:`grdmath </grdmath>` to scale the intensity file
 before running :doc:`grdview </grdview>`. For very rough
-data sets one may improve the smoothness of the intensities by passing
-the output of :doc:`grdgradient </grdgradient>` to
+data sets one may improve the smoothness of the intensities by computing
+them first with :doc:`grdgradient </grdgradient>` and then pass them to
 :doc:`grdhisteq </grdhisteq>`. The shell-script above
 will result in a plot like the one in Figure.
 

--- a/doc/rst/source/gallery/ex06.rst
+++ b/doc/rst/source/gallery/ex06.rst
@@ -7,10 +7,10 @@ GMT provides two tools to render histograms:
 :doc:`histogram </histogram>` and :doc:`rose </rose>`. The former takes care of
 regular histograms whereas the latter deals with polar histograms (rose
 diagrams, sector diagrams, and wind rose diagrams). We will show an
-example that involves both programs. The file ``fractures.yx`` contains a compilation of
-fracture lengths and directions as digitized from geological maps. The
-file ``v3206.t`` contains all the bathymetry measurements from *Vema* cruise 3206.
-Our complete figure was made running
+example that involves both programs. The remote file ``fractures_06.txt`` contains a compilation of
+fracture lengths and directions as digitized from geological maps. The remote
+file ``v3206_o6.txt`` contains all the bathymetry measurements from *Vema* cruise 3206.
+Our complete figure was made as a 2 by 1 subplot figure by running
 this script:
 
 .. literalinclude:: /_verbatim/ex06.txt

--- a/doc/rst/source/gallery/ex07.rst
+++ b/doc/rst/source/gallery/ex07.rst
@@ -8,10 +8,10 @@ of interest. This map will typically also contain certain features and
 labels. This example will present a location map for the equatorial
 Atlantic ocean, where fracture zones and mid-ocean ridge segments have
 been plotted. We also would like to plot earthquake locations and
-available isochrons. We have obtained one file, ``quakes.xym``, which contains the
+available isochrons. We have obtained one file, ``quakes_07.txt``, which contains the
 position and magnitude of available earthquakes in the region. We choose
 to use magnitude/100 for the symbol-size in inches. The digital fracture
-zone traces (``fz.xy``) and isochrons (0 isochron as ``ridge.xy``, the rest as ``isochrons.xy``) were
+zone traces (``fz_07.txt``) and isochrons (0 isochron as ``ridge_07.txt``, the rest as ``isochron_07.txt``) were
 digitized from available maps [1]_. We create the final location map
 with the following script:
 

--- a/doc/rst/source/gallery/ex08.rst
+++ b/doc/rst/source/gallery/ex08.rst
@@ -8,7 +8,7 @@ three-dimensional symbols, including columnar plots. As a simple
 demonstration, we will convert a gridded netCDF of bathymetry into an
 ASCII *xyz* table and use the height information to draw a 2-D
 histogram in a 3-D perspective view. We also use the height information
-to set to color of each column via a CPT file.  Our gridded bathymetry file is
+to set to color of each column via a CPT file.  Our gridded bathymetry file is a remote file
 called ``guinea_bay.nc`` and covers the region from 0 to 5 E and 0 to 5 N. Depth ranges
 from -5000 meter to sea-level. We produce the Figure by running this script:
 

--- a/doc/rst/source/gallery/ex09.rst
+++ b/doc/rst/source/gallery/ex09.rst
@@ -12,8 +12,8 @@ profiles from the south Pacific can be plotted as "wiggles" using the
 :doc:`wiggle </wiggle>` program. We will embellish
 the plot with track numbers, the location of the Pacific-Antarctic
 Ridge, recognized fracture zones in the area, and a "wiggle" scale. The
-Geosat tracks are stored in the file ``tracks.txt``, the ridge in ``ridge.xy``, and all the
-fracture zones are stored in the multiple segment file ``fz.xy``. The
+Geosat tracks are stored in the file ``tracks_09.txt``, the ridge in ``ridge_09.txt``, and all the
+fracture zones are stored in the multiple segment file ``fz_09.txt``. The
 profile id is contained in the segment headers and we wish to use the
 last data point in each of the track segments to construct an input file
 for :doc:`text </text>` that will label each profile

--- a/doc/rst/source/gallery/ex10.rst
+++ b/doc/rst/source/gallery/ex10.rst
@@ -14,7 +14,7 @@ The different bands in the columns indicate how commonly the languages are used,
 languages threatened by extinction.  We use :doc:`gmtmath </gmtmath>` to sum up the total languages per continent.
 The script also shows how to effectively use transparency of the boxes around the numbers
 and in the shade surrounding the legend.
-Our script that produces Figure ex_10 reads:
+Our script that produces Figure 10 reads:
 
 .. literalinclude:: /_verbatim/ex10.txt
    :language: bash

--- a/doc/rst/source/gallery/ex14.rst
+++ b/doc/rst/source/gallery/ex14.rst
@@ -4,7 +4,8 @@
 ----------------------------------------
 
 This example shows how one goes from randomly spaced data points to an
-evenly sampled surface. First we plot the distribution and values of our
+evenly sampled surface. We arrange for four panels using the :doc:`subplot`
+command.  First we plot the distribution and values of our
 raw data set (same as in Example :ref:`example_12`). We choose an equidistant grid and run
 :doc:`blockmean </blockmean>` which preprocesses the
 data to avoid aliasing. The dashed lines indicate the logical blocks

--- a/doc/rst/source/gallery/ex15.rst
+++ b/doc/rst/source/gallery/ex15.rst
@@ -5,7 +5,7 @@
 
 This example demonstrates some off the
 different ways one can use to grid data in GMT, and how to deal with
-unconstrained areas. We first convert a large ASCII file to binary with
+unconstrained areas. We first convert a large remote ASCII file to binary with
 :doc:`gmtconvert </gmtconvert>` since the binary file
 will read and process much faster. Our lower left plot illustrates the
 results of gridding using a nearest neighbor technique
@@ -23,7 +23,8 @@ simply employ :doc:`coast </coast>` to overlay gray
 land masses to cover up the unwanted contours, and end by plotting a
 star at the deepest point on the map with
 :doc:`plot </plot>`. This point was extracted from the
-grid files using :doc:`grdinfo </grdinfo>`.
+grid files using :doc:`grdinfo </grdinfo>`.  Placement of the four
+panels is simplified via :doc:`subplot`.
 
 .. literalinclude:: /_verbatim/ex15.txt
    :language: bash

--- a/doc/rst/source/gallery/ex16.rst
+++ b/doc/rst/source/gallery/ex16.rst
@@ -51,7 +51,8 @@ always do the "best" thing but it offers great flexibility through its
 combinations of tools. We illustrate all four solutions using a CPT
 that contains color fills, predefined patterns for interval (900,925)
 and NaN, an image pattern for interval (875,900), and a "skip slice"
-request for interval (700,725).
+request for interval (700,725).  Again, we use :doc:`subplot to set up
+and place the four panels, and place the colorbar beneath the subplot.
 
 .. literalinclude:: /_verbatim/ex16.txt
    :language: bash

--- a/doc/rst/source/gallery/ex17.rst
+++ b/doc/rst/source/gallery/ex17.rst
@@ -26,7 +26,7 @@ amounts (in red) are not very prevalent, that color spans a long range.
 
 For this image it is appropriate to use the **-I** option in
 :doc:`colorbar </colorbar>` so the legend gets shaded,
-similar to the geoid grid. See Appendix [app:M] to learn more about
+similar to the geoid grid. See :doc:`/cookbook/cpts` to learn more about
 CPTs and ways to draw color legends.
 
 .. literalinclude:: /_verbatim/ex17.txt

--- a/doc/rst/source/gallery/ex18.rst
+++ b/doc/rst/source/gallery/ex18.rst
@@ -16,7 +16,8 @@ and then pass these locations to
 points within 200 km of Pratt. We then mask out all the data outside
 this radius and use :doc:`grdvolume </grdvolume>` to
 determine the combined area and (gravimetric) volumes of the chosen seamounts. Our
-illustration is presented in Figure.
+illustration is presented in Figure 18 which also shows the automatic labeling
+offered by :doc:`subplot`.
 
 .. literalinclude:: /_verbatim/ex18.txt
    :language: bash

--- a/doc/rst/source/gallery/ex19.rst
+++ b/doc/rst/source/gallery/ex19.rst
@@ -14,10 +14,10 @@ patterns change at the coastlines. The middle panel demonstrates a
 simple :doc:`coast </coast>` call where the built-in
 pattern # 86 is drawn at 100 dpi but with the black and white pixels
 replaced with color combinations. At the same time the ocean is filled
-with a repeating image of a circuit board (provides in Sun raster
+with a repeating image of a circuit board (provides in PNG raster
 format). The text GMT in the center is an off-line PostScript file
-that was overlaid using :doc:`image </image>`. The
-final panel repeats the top panel except that the land and sea images
+that was overlaid using :doc:`image </image>`. The final panel in the 3 by 1
+subplot sequence repeats the top panel except that the land and sea images
 have changed places.
 
 .. literalinclude:: /_verbatim/ex19.txt

--- a/doc/rst/source/gallery/ex20.rst
+++ b/doc/rst/source/gallery/ex20.rst
@@ -93,6 +93,6 @@ components. E.g., to have yellow smoke coming out of red volcanoes we
 would make two symbols: one with just the cone and caldera and the other
 with the bubbles. These would be plotted consecutively using the desired
 colors. Alternatively, like in ``bullseye.def``, we may specify colors directly for the
-various segments. Note that the custom symbols (Appendix [app:N]),
+various segments. Note that the custom symbols (:doc:`/cookbook/custom_symbols`),
 unlike the built-in symbols in GMT, can be used with the built-in
-patterns (Appendix [app:E]). Other approaches are also possible, of course.
+patterns (:doc:`/cookbook/predefined_patterns`). Other approaches are also possible, of course.

--- a/doc/rst/source/gallery/ex20.rst
+++ b/doc/rst/source/gallery/ex20.rst
@@ -68,7 +68,7 @@ The following recipe is used when designing a new symbol.
 #. Given proper definition files we may now use them with
    :doc:`plot </plot>` or :doc:`plot3d </plot3d>`.
 
-We are now ready to give it a try. Based on the hotspot locations in the
+We are now ready to give it a try. Based on the hotspot locations in the remote
 file ``hotspots.txt`` (with a 3rd column giving the desired symbol sizes in inches) we
 lay down a world map and overlay red volcano symbols using our
 custom-built volcano symbol and :doc:`plot </plot>`. We

--- a/doc/rst/source/gallery/ex22.rst
+++ b/doc/rst/source/gallery/ex22.rst
@@ -3,14 +3,14 @@
 (22) World-wide seismicity the last 7 days
 ------------------------------------------
 
-The next example uses the command-line tool **wget** to obtain a data
+The next example uses the command-line tool **curl** to obtain a data
 file from a specified URL [1]_. In the example script this line is
 commented out so the example will run even if you do not have **wget**
-(we use the supplied ``neic_quakes.d`` which normally would be created by **wget**);
-remove the comment to get the actual current seismicity plot using the
+(we use the remote file ``usgs_quakes_22.txt`` which normally would be created by **curl**);
+remove the comments to get the actual current seismicity plot using the
 live data. The main purpose of this script is not to show how to plot a
 map background and a few circles, but rather demonstrate how a map
-legend may be composed using the new tool
+legend may be composed using the module
 :doc:`legend </legend>`. Some scripting is used to
 pull out information from the data file that is later used in the
 legend. The legend will normally have the email address of the script

--- a/doc/rst/source/gallery/ex24.rst
+++ b/doc/rst/source/gallery/ex24.rst
@@ -6,8 +6,8 @@
 Although we are not seismologists, we have yet another example involving
 seismicity. We use seismicity data for the Australia/New Zealand region
 to demonstrate how we can extract subsets of data using geospatial
-criteria. In particular, we wish to plot the epicenters given in the
-file ``oz_quakes.d`` as red or green circles. Green circles should only be used for
+criteria. In particular, we wish to plot the epicenters given in the remote
+file ``oz_quakes_24.txt`` as red or green circles. Green circles should only be used for
 epicenters that satisfy the following three criteria:
 
 #. They are located in the ocean and not on land

--- a/doc/rst/source/gallery/ex27.rst
+++ b/doc/rst/source/gallery/ex27.rst
@@ -13,10 +13,10 @@ non-Mercator map then you must extract a geographic grid using
 desired map projection. However, if you want to make a Mercator map then
 you can save time and preserve data quality by avoiding to re-project
 the data set twice since it is already in a Mercator projection. This
-example shows how this is accomplished. We use the **-M** option in
+example shows how this is accomplished. We have used the **-M** option in
 :doc:`img2grd </supplements/img/img2grd>`\  [1]_ to pull out the grid
 in Mercator units (i.e., do *not* invert the Mercator projection) and
-then simply plot the grid using a linear projection with a suitable
+then simply plot this remote grid using a linear projection with a suitable
 scale (here 0.25 inches per degrees of longitude). To overlay basemaps
 and features that has geographic longitude/latitude coordinates we must
 remember two key issues:

--- a/doc/rst/source/gallery/ex28.rst
+++ b/doc/rst/source/gallery/ex28.rst
@@ -15,7 +15,7 @@ on the same map you simply have to specify the region using the UTM
 meters but supply the actual UTM projection parameters. Make sure you
 use the same scale with both the linear and UTM projection.
 
-Our script illustrates how we would plot a UTM grid (with coordinates in
+Our script illustrates how we would plot a remote UTM grid (with coordinates in
 meters) of elevations near Kilauea volcano on the Big Island of Hawaii
 and overlay geographical information (with longitude, latitude
 coordinates). We first lay down the UTM grid using the linear

--- a/doc/rst/source/gallery/ex29.rst
+++ b/doc/rst/source/gallery/ex29.rst
@@ -10,7 +10,7 @@ coordinates hence the chosen approach. We use
 :doc:`greenspline </greenspline>` to produce a crude
 topography grid for Mars based on radii estimates from the Mariner 9 and
 Viking Orbiter spacecrafts. This data comes from *Smith and Zuber*
-[Science, 1996] and is used here as a small (*N* = 370) data set we can
+[Science, 1996] and is used here as a small (*N* = 370) remote data set we can
 use to demonstrate spherical surface gridding. Since
 :doc:`greenspline </greenspline>` must solve a *N* by
 *N* matrix system your system memory may impose limits on how large data
@@ -23,7 +23,7 @@ reference surface from the gridded radii. We run the gridding twice:
 First with no tension using *Parker*\ 's [1990] method and then with
 tension using the *Wessel and Becker* [2008] method. The grids are then
 imaged with :doc:`grdimage </grdimage>` and
-:doc:`grdcontour </grdcontour>` and a color scale is placed between them.
+:doc:`grdcontour </grdcontour>` and a color bar is placed between them.
 
 .. literalinclude:: /_verbatim/ex29.txt
    :language: bash

--- a/doc/rst/source/gallery/ex30.rst
+++ b/doc/rst/source/gallery/ex30.rst
@@ -3,7 +3,7 @@
 (30) Trigonometric functions plotted in graph mode
 --------------------------------------------------
 
-Finally, we end with a simple mathematical illustration of sine and
+Next, we continue with a simple mathematical illustration of sine and
 cosine, highlighting the *graph* mode for linear projections and the new
 curved vectors for angles.
 

--- a/doc/rst/source/gallery/ex31.rst
+++ b/doc/rst/source/gallery/ex31.rst
@@ -14,17 +14,10 @@ includes the following steps:
 
 -  set the GMT parameters ``MAP_DEGREE_SYMBOL``, ``PS_CHAR_ENCODING``, and ``FONT``;
 
--  replace the default Helvetica font in the GMT-PostScript-File with sed;
-
--  create a PostScript-File with outlined fonts (optional);
-
--  convert GMT's PostScript output to PDF or any image format (optional).
-
 The script produces the plot in Figure. All
 standard fonts have been substituted by the free OpenType fonts Linux
-Libertine (title) and Linux Biolinum (annotations). Uncomment the
-appropriate lines in the script to make a PostScript-file with
-outlined fonts or to convert to a PDF-file.
+Libertine (title) and Linux Biolinum (annotations).  Remote files with the locations
+and names of the cities are used, with awk providing help in data preparation.
 
 .. literalinclude:: /_verbatim/ex31.txt
    :language: bash

--- a/doc/rst/source/gallery/ex34.rst
+++ b/doc/rst/source/gallery/ex34.rst
@@ -5,10 +5,10 @@
 
 The script produces the plot in Figure. Here
 we demonstrate how :doc:`coast </coast>` can be used to extract
-and plot country polygons.  We show two panels; one in which we do
+and plot country polygons from the optional DCW dataset.  We show two panels; one in which we do
 a basic basemap and another where we lay down a color topography
 image and then place a transparent layer identifying the future
-Franco-Italian Union whose untimely breakup in 2045 the historians
+Franco-Italian Union, whose untimely breakup in 2045 the historians
 will continue to debate for some time.
 
 .. literalinclude:: /_verbatim/ex34.txt

--- a/doc/rst/source/gallery/ex39.rst
+++ b/doc/rst/source/gallery/ex39.rst
@@ -11,7 +11,8 @@ of the different resolutions.  The key tool
 used here is :doc:`sph2grd </sph2grd>`.
 
 Note that we use a special format in :doc:`colorbar </colorbar>` so that the
-annotations will include the separators for the thousands.
+annotations will include the separators for the thousands (note: this syntax
+is not supported by all operating systems).
 
 .. literalinclude:: /_verbatim/ex39.txt
    :language: bash

--- a/doc/rst/source/gallery/ex44.rst
+++ b/doc/rst/source/gallery/ex44.rst
@@ -3,15 +3,13 @@
 (44) Map insets
 ---------------
 
-In this example show how the two modules :doc:`basemap </basemap>`
-and :doc:`mapproject </mapproject>` can be used
+In this example show how  :doc:`inset </inset>` can be used
 to place map insets on top of your map.  The map inset is usually
 intended for placing a smaller-scale version of the larger geographical
 context of your main plot, so that reader unfamiliar with the detailed
-map can see what region we are looking at.  While the Australia example
-is simplest since we know the inset will be a square map, the Spain
-example requires us to compute the dimensions of the inset first, via
-:doc:`mapproject </mapproject>`, so that we can determine exact inset dimensions.
+map can see what region we are looking at.  The inset module automatically
+determines the possible extent of the map hence we simply pass ? for the
+unknown map sizes.
 
 .. literalinclude:: /_verbatim/ex44.txt
    :language: bash


### PR DESCRIPTION
Many of the descriptions, especially for the really old gallery examples, were wrong.  This PR fixes the bulk (if not  all) of them.  Closes issue #1717.
