### PR TITLE
Replace Gitter chat link with new Discourse forum

### DIFF
--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -43,7 +43,7 @@ html_context = {
         ),
         (
             '<i class="fa fa-comment fa-fw"></i> Contact',
-            "https://gitter.im/GenericMappingTools/Lobby",
+            "https://forum.generic-mapping-tools.org/",
         ),
         (
             '<i class="fa fa-github fa-fw"></i> Source Code',


### PR DESCRIPTION
The Contact link in the documentation was pointing to our Gitter chat
room. Replace it with a link to the Discourse Forum.

Fixes #2026


**Reminders**

- [ ] Correct base branch selected? `master` for new features, `6.0` for bug fixes
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
