### PR TITLE
cmake: Fix the GMT_DATA_URL compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,10 +187,6 @@ endif (GMT_INSTALL_MODULE_LINKS)
 # Configure header file to pass some of the CMake settings to the source code
 configure_file (src/config.h.in src/config.h)
 
-if (GMT_DATA_URL) # Backwards compatibility with old ConfigUser.cmake files
-	set (GMT_DATA_SERVER ${GMT_DATA_URL})
-endif (GMT_DATA_URL)
-
 # Configuration done
 message(
 	"*\n"

--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -141,6 +141,10 @@ if (NOT GMT_INCLUDEDIR)
 	set (GMT_INCLUDEDIR include/gmt${GMT_INSTALL_NAME_SUFFIX})
 endif(NOT GMT_INCLUDEDIR)
 
+if (GMT_DATA_URL) # Backwards compatibility with old ConfigUser.cmake files
+	set (GMT_DATA_SERVER ${GMT_DATA_URL})
+endif (GMT_DATA_URL)
+
 # use, i.e. don't skip the full RPATH for the build tree
 set (CMAKE_SKIP_BUILD_RPATH FALSE)
 


### PR DESCRIPTION
GMT_DATA_URL was renamed to GMT_DATA_SERVER in GMT 6.

To keep backwards compatibility, these lines were added to the top diretory CMakeLists.txt,
```
if (GMT_DATA_URL) # Backwards compatibility with old ConfigUser.cmake files
       set (GMT_DATA_SERVER ${GMT_DATA_URL})
endif (GMT_DATA_URL)
```

However, these lines only affect the cmake configuration output, and don't change the settings
in `src/CMakeLists.txt`, as these lines are executed later than `src/CMakeLists.txt`.

This PR fixes the issue.