### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,8 +10,6 @@ and [the GitHub repository](https://github.com/GenericMappingTools/gmt/releases)
 This file provides instructions for installing GMT binary packages on
 different operating systems. Please refer to the [Building Instructions](BUILDING.md)
 for compiling GMT source package (either stable release or development version).
-Note: Distributions may not all update at the same time so check if GMT 6 is
-available first.
 
 ## Contents
 
@@ -53,7 +51,8 @@ If you like, you can add the GMT programs contained in the application bundle to
 your search path for executables. For that, just run GMT-6.x.x.app once and follow
 the instructions at the end of the GMT splash screen.
 
-Note: The installer is always built for the latest macOS version only.
+**Note**: The installer is always built for the latest macOS version only,
+and works for macOS Sierra (10.12) or higher.
 
 ### Install via Homebrew
 


### PR DESCRIPTION
- All the package distributors are providing GMT6 now. Safe to remove the note.
- Mention that the macOS bundle works for macOS >= 10.12.