### PR TITLE
docs: Remove unnecessary -h option from examples

### DIFF
--- a/doc/rst/source/supplements/geodesy/psvelo.rst
+++ b/doc/rst/source/supplements/geodesy/psvelo.rst
@@ -45,11 +45,9 @@ Examples
 
 The following should make big red arrows with green ellipses, outlined
 in red. Note that the 39% confidence scaling will give an ellipse which
-fits inside a rectangle of dimension Esig by Nsig.
+fits inside a rectangle of dimension Esig by Nsig::
 
-   ::
-
-    gmt psvelo << END -h2 -R-10/10/-10/10 -W0.25p,red -Ggreen -L -Se0.2/0.39/18 \
+    gmt psvelo << END -R-10/10/-10/10 -W0.25p,red -Ggreen -L -Se0.2/0.39/18 \
         -B1g1 -Jx0.4/0.4 -A1c+p3p+e -P -V > test.ps
     #Long. Lat. Evel Nvel Esig Nsig CorEN SITE
     #(deg) (deg) (mm/yr) (mm/yr)
@@ -63,11 +61,9 @@ fits inside a rectangle of dimension Esig by Nsig.
 
 This example should plot some residual rates of rotation in the Western
 Transverse Ranges, California. The wedges will be dark gray, with light
-gray wedges to represent the 2-sigma uncertainties.
+gray wedges to represent the 2-sigma uncertainties::
 
-   ::
-
-    gmt psvelo << END -Sw0.4/1.e7 -W0.75p -Gdarkgray -Elightgray -h1 -D2 -Jm2.2i \
+    gmt psvelo << END -Sw0.4/1.e7 -W0.75p -Gdarkgray -Elightgray -D2 -Jm2.2i \
         -R240./243./32.5/34.75 -Baf -BWeSn -P > test.ps
     #lon lat spin(rad/yr) spin_sigma (rad/yr)
     241.4806 34.2073 5.65E-08 1.17E-08

--- a/doc/rst/source/supplements/geodesy/velo.rst
+++ b/doc/rst/source/supplements/geodesy/velo.rst
@@ -44,11 +44,9 @@ Examples
 
 The following should make big red arrows with green ellipses, outlined
 in red. Note that the 39% confidence scaling will give an ellipse which
-fits inside a rectangle of dimension Esig by Nsig.
+fits inside a rectangle of dimension Esig by Nsig::
 
-   ::
-
-    gmt velo << END -h2 -R-10/10/-10/10 -W0.25p,red -Ggreen -L -Se0.2/0.39/18 -B1g1 -Jx0.4/0.4 -A1c+p3p+e -V -pdf test
+    gmt velo << END -R-10/10/-10/10 -W0.25p,red -Ggreen -L -Se0.2/0.39/18 -B1g1 -Jx0.4/0.4 -A1c+p3p+e -V -pdf test
     #Long. Lat. Evel Nvel Esig Nsig CorEN SITE
     #(deg) (deg) (mm/yr) (mm/yr)
     0. -8. 0.0 0.0 4.0 6.0 0.500 4x6
@@ -61,11 +59,9 @@ fits inside a rectangle of dimension Esig by Nsig.
 
 This example should plot some residual rates of rotation in the Western
 Transverse Ranges, California. The wedges will be dark gray, with light
-gray wedges to represent the 2-sigma uncertainties.
+gray wedges to represent the 2-sigma uncertainties::
 
-   ::
-
-    gmt velo << END -Sw0.4/1.e7 -W0.75p -Gdarkgray -Elightgray -h1 -D2 -Jm2.2i -R240./243./32.5/34.75 -Baf -BWeSn -pdf test
+    gmt velo << END -Sw0.4/1.e7 -W0.75p -Gdarkgray -Elightgray -D2 -Jm2.2i -R240./243./32.5/34.75 -Baf -BWeSn -pdf test
     #lon lat spin(rad/yr) spin_sigma (rad/yr)
     241.4806 34.2073 5.65E-08 1.17E-08
     241.6024 34.4468 -4.85E-08 1.85E-08

--- a/doc/rst/source/supplements/seis/meca.rst
+++ b/doc/rst/source/supplements/seis/meca.rst
@@ -43,12 +43,10 @@ Examples
 
 .. include:: ../../oneliner_info.rst_
 
-The following file should give a normal-faulting CMT mechanism:
+The following file should give a normal-faulting CMT mechanism::
 
-   ::
-
-    gmt meca -R239/240/34/35.2 -Jm4c -Sc2c -h1 -pdf test << END
-    #lon lat depth str dip slip st dip slip mant exp plon plat
+    gmt meca -R239/240/34/35.2 -Jm4c -Sc2c -pdf test << END
+    # lon lat depth str dip slip st dip slip mant exp plon plat
     239.384 34.556 12. 180 18 -88 0 72 -90 5.5 0 0 0
     END
 

--- a/doc/rst/source/supplements/seis/psmeca.rst
+++ b/doc/rst/source/supplements/seis/psmeca.rst
@@ -43,12 +43,10 @@ Synopsis
 Examples
 --------
 
-The following file should give a normal-faulting CMT mechanism:
+The following file should give a normal-faulting CMT mechanism::
 
-   ::
-
-    gmt psmeca -R239/240/34/35.2 -Jm4c -Sc2c -h1 << END > test.ps
-    lon lat depth str dip slip st dip slip mant exp plon plat
+    gmt psmeca -R239/240/34/35.2 -Jm4c -Sc2c << END > test.ps
+    # lon lat depth str dip slip st dip slip mant exp plon plat
     239.384 34.556 12. 180 18 -88 0 72 -90 5.5 0 0 0
     END
 


### PR DESCRIPTION
Lines start with '#' are comments in GMT.
There is no need to add `-h` option to skip these comment lines.