### PR TITLE
Verbose message uses opposite test

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1617,7 +1617,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 						}
 						else
 							S.v.v_width = (float)(current_pen.width * GMT->session.u2u[GMT_PT][GMT_INCH]);
-						if (length > S.v.h_length && S.v.v_norm < 0.0)	/* No shrink requested by head length exceeds total vector length */
+						if (length < S.v.h_length && S.v.v_norm < 0.0)	/* No shrink requested but head length exceeds total vector length */
 							GMT_Report (API, GMT_MSG_VERBOSE, "Vector head length exceeds overall vector length near line %d. Consider using +n<norm>\n", n_total_read);
 						s = (length < S.v.v_norm) ? length / S.v.v_norm : 1.0;
 						dim[0] = x_2, dim[1] = y_2;


### PR DESCRIPTION
We want to warn when a vector is shorted than the vector head (and recommend **+n**) but the test was backwards and would warn when the vector is longer than the head (which is most of the time).  Only affects the verbose message and not the plotting.
