### PR TITLE
Modernize ancient /fontsize in psvelo

### DIFF
--- a/doc/rst/source/supplements/geodesy/psvelo.rst
+++ b/doc/rst/source/supplements/geodesy/psvelo.rst
@@ -47,7 +47,7 @@ The following should make big red arrows with green ellipses, outlined
 in red. Note that the 39% confidence scaling will give an ellipse which
 fits inside a rectangle of dimension Esig by Nsig::
 
-    gmt psvelo << END -R-10/10/-10/10 -W0.25p,red -Ggreen -L -Se0.2/0.39+f18p \
+    gmt psvelo << END -R-10/10/-10/10 -W0.25p,red -Ggreen -L -Se0.2i/0.39+f18p \
         -B1g1 -Jx0.4/0.4 -A1c+p3p+e -P -V > test.ps
     #Long. Lat. Evel Nvel Esig Nsig CorEN SITE
     #(deg) (deg) (mm/yr) (mm/yr)
@@ -63,7 +63,7 @@ This example should plot some residual rates of rotation in the Western
 Transverse Ranges, California. The wedges will be dark gray, with light
 gray wedges to represent the 2-sigma uncertainties::
 
-    gmt psvelo << END -Sw0.4/1.e7 -W0.75p -Gdarkgray -Elightgray -D2 -Jm2.2i \
+    gmt psvelo << END -Sw0.4i/1.e7 -W0.75p -Gdarkgray -Elightgray -D2 -Jm2.2i \
         -R240./243./32.5/34.75 -Baf -BWeSn -P > test.ps
     #lon lat spin(rad/yr) spin_sigma (rad/yr)
     241.4806 34.2073 5.65E-08 1.17E-08

--- a/doc/rst/source/supplements/geodesy/psvelo.rst
+++ b/doc/rst/source/supplements/geodesy/psvelo.rst
@@ -16,9 +16,8 @@ Synopsis
 |SYN_OPT-R|
 [ |-A|\ *parameters* ]
 [ |SYN_OPT-B| ]
-[ |-E|\ *color* ]
-[ |-F|\ *color* ]
-[ |-G|\ *color* ]
+[ |-E|\ *fill* ]
+[ |-G|\ *fill* ]
 [ |-K| ]
 [ |-L| ]
 [ |-N| ] [ |-O| ] [ |-P| ]

--- a/doc/rst/source/supplements/geodesy/psvelo.rst
+++ b/doc/rst/source/supplements/geodesy/psvelo.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-K| ]
 [ |-L| ]
 [ |-N| ] [ |-O| ] [ |-P| ]
-[ |-S|\ *symbol*/*args*\ [**+f**\ *font* ] ]
+[ |-S|\ *symbol*/*args*\ [**+f**\ *font*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]

--- a/doc/rst/source/supplements/geodesy/psvelo.rst
+++ b/doc/rst/source/supplements/geodesy/psvelo.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-K| ]
 [ |-L| ]
 [ |-N| ] [ |-O| ] [ |-P| ]
-[ |-S|\ *symbol*/*args*\ [**+f**\ *font*] ]
+[ |-S|\ *<format><args>*\ [**+f**\ *font*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]

--- a/doc/rst/source/supplements/geodesy/psvelo.rst
+++ b/doc/rst/source/supplements/geodesy/psvelo.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-K| ]
 [ |-L| ]
 [ |-N| ] [ |-O| ] [ |-P| ]
-[ |-S|\ *symbol*/*scale*\ [/*args* ] ]
+[ |-S|\ *symbol*/*args*\ [**+f**\ *font* ] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]
@@ -47,7 +47,7 @@ The following should make big red arrows with green ellipses, outlined
 in red. Note that the 39% confidence scaling will give an ellipse which
 fits inside a rectangle of dimension Esig by Nsig::
 
-    gmt psvelo << END -R-10/10/-10/10 -W0.25p,red -Ggreen -L -Se0.2/0.39/18 \
+    gmt psvelo << END -R-10/10/-10/10 -W0.25p,red -Ggreen -L -Se0.2/0.39+f18p \
         -B1g1 -Jx0.4/0.4 -A1c+p3p+e -P -V > test.ps
     #Long. Lat. Evel Nvel Esig Nsig CorEN SITE
     #(deg) (deg) (mm/yr) (mm/yr)

--- a/doc/rst/source/supplements/geodesy/velo.rst
+++ b/doc/rst/source/supplements/geodesy/velo.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-G|\ *color* ]
 [ |-L| ]
 [ |-N| ]
-[ |-S|\ *symbol*/*scale*\ [/*args* ] ]
+[ |-S|\ *symbol*/*args*\ [**+f**\ *font* ] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]
@@ -46,7 +46,7 @@ The following should make big red arrows with green ellipses, outlined
 in red. Note that the 39% confidence scaling will give an ellipse which
 fits inside a rectangle of dimension Esig by Nsig::
 
-    gmt velo << END -R-10/10/-10/10 -W0.25p,red -Ggreen -L -Se0.2/0.39/18 -B1g1 -Jx0.4/0.4 -A1c+p3p+e -V -pdf test
+    gmt velo << END -R-10/10/-10/10 -W0.25p,red -Ggreen -L -Se0.2/0.39+f18p -B1g1 -Jx0.4/0.4 -A1c+p3p+e -V -pdf test
     #Long. Lat. Evel Nvel Esig Nsig CorEN SITE
     #(deg) (deg) (mm/yr) (mm/yr)
     0. -8. 0.0 0.0 4.0 6.0 0.500 4x6

--- a/doc/rst/source/supplements/geodesy/velo.rst
+++ b/doc/rst/source/supplements/geodesy/velo.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-G|\ *color* ]
 [ |-L| ]
 [ |-N| ]
-[ |-S|\ *symbol*/*args*\ [**+f**\ *font* ] ]
+[ |-S|\ *symbol*/*args*\ [**+f**\ *font*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]

--- a/doc/rst/source/supplements/geodesy/velo.rst
+++ b/doc/rst/source/supplements/geodesy/velo.rst
@@ -16,9 +16,8 @@ Synopsis
 |SYN_OPT-R|
 [ |-A|\ *parameters* ]
 [ |SYN_OPT-B| ]
-[ |-E|\ *color* ]
-[ |-F|\ *color* ]
-[ |-G|\ *color* ]
+[ |-E|\ *fill* ]
+[ |-G|\ *fill* ]
 [ |-L| ]
 [ |-N| ]
 [ |-S|\ *symbol*/*args*\ [**+f**\ *font*] ]

--- a/doc/rst/source/supplements/geodesy/velo.rst
+++ b/doc/rst/source/supplements/geodesy/velo.rst
@@ -46,7 +46,7 @@ The following should make big red arrows with green ellipses, outlined
 in red. Note that the 39% confidence scaling will give an ellipse which
 fits inside a rectangle of dimension Esig by Nsig::
 
-    gmt velo << END -R-10/10/-10/10 -W0.25p,red -Ggreen -L -Se0.2/0.39+f18p -B1g1 -Jx0.4/0.4 -A1c+p3p+e -V -pdf test
+    gmt velo << END -R-10/10/-10/10 -W0.25p,red -Ggreen -L -Se0.2i/0.39+f18p -B1g1 -Jx0.4/0.4 -A1c+p3p+e -V -pdf test
     #Long. Lat. Evel Nvel Esig Nsig CorEN SITE
     #(deg) (deg) (mm/yr) (mm/yr)
     0. -8. 0.0 0.0 4.0 6.0 0.500 4x6
@@ -61,7 +61,7 @@ This example should plot some residual rates of rotation in the Western
 Transverse Ranges, California. The wedges will be dark gray, with light
 gray wedges to represent the 2-sigma uncertainties::
 
-    gmt velo << END -Sw0.4/1.e7 -W0.75p -Gdarkgray -Elightgray -D2 -Jm2.2i -R240./243./32.5/34.75 -Baf -BWeSn -pdf test
+    gmt velo << END -Sw0.4i/1.e7 -W0.75p -Gdarkgray -Elightgray -D2 -Jm2.2i -R240./243./32.5/34.75 -Baf -BWeSn -pdf test
     #lon lat spin(rad/yr) spin_sigma (rad/yr)
     241.4806 34.2073 5.65E-08 1.17E-08
     241.6024 34.4468 -4.85E-08 1.85E-08

--- a/doc/rst/source/supplements/geodesy/velo.rst
+++ b/doc/rst/source/supplements/geodesy/velo.rst
@@ -20,7 +20,7 @@ Synopsis
 [ |-G|\ *fill* ]
 [ |-L| ]
 [ |-N| ]
-[ |-S|\ *symbol*/*args*\ [**+f**\ *font*] ]
+[ |-S|\ *<format><args>*\ [**+f**\ *font*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]

--- a/doc/rst/source/supplements/geodesy/velo_common.rst_
+++ b/doc/rst/source/supplements/geodesy/velo_common.rst_
@@ -29,13 +29,13 @@ Required Arguments
 
 Selects the meaning of the columns in the data file and the figure to be plotted.
 
-    **-Se**\ *velscale/confidence/fontsize*.
+    **-Se**\ *velscale/confidence*\ [**+f**\ *font* ]
 
         Velocity ellipses in (N,E) convention. *velscale* sets the scaling of the
         velocity arrows. This scaling gives inches (unless **c**, **i**,
         or **p** is appended). *confidence* sets the 2-dimensional confidence
-        limit for the ellipse, e.g., 0.95 for 95% confidence ellipse. *fontsize*
-        sets the size of the text in points. The ellipse will be filled with the
+        limit for the ellipse, e.g., 0.95 for 95% confidence ellipse. *font*
+        sets the font and size of the text [9p,Helvetica,black]. The ellipse will be filled with the
         color or shade specified by the |-G| option [default transparent]. The
         arrow and the circumference of the ellipse will be drawn with the pen
         attributes specified by the |-W| option. Parameters are expected to be
@@ -52,7 +52,7 @@ Selects the meaning of the columns in the data file and the figure to be plotted
             **8**:
             name of station (optional).
 
-    **-Sn**\ *barscale.*
+    **-Sn**\ *barscale*
 
         Anisotropy bars. *barscale* sets the scaling of the bars. This scaling
         gives inches (unless **c**, **i**, or **p** is appended).
@@ -63,13 +63,13 @@ Selects the meaning of the columns in the data file and the figure to be plotted
             **3**,\ **4**:
             eastward, northward components of anisotropy vector (**-:** option interchanges order)
 
-    **-Sr**\ *velscale/confidence/fontsize*
+    **-Sr**\ *velscale/confidence*\ [**+f**\ *font* ]
 
         Velocity ellipses in rotated convention. *velscale* sets the scaling of
         the velocity arrows. This scaling gives inches (unless **c**, **i**,
         or **p** is appended). *confidence* sets the 2-dimensional
         confidence limit for the ellipse, e.g., 0.95 for 95% confidence ellipse.
-        *fontsize* sets the size of the text in points. The ellipse will be
+        *font* sets the font and size of the text [9p,Helvetica,black]. The ellipse will be
         filled with the color or shade specified by the |-G| option [default
         transparent]. The arrow and the circumference of the ellipse will be
         drawn with the pen attributes specified by the |-W| option. Parameters
@@ -86,7 +86,7 @@ Selects the meaning of the columns in the data file and the figure to be plotted
             **8**:
             name of station (optional)
 
-    **-Sw**\ *wedgescale/wedgemag*.
+    **-Sw**\ *wedgescale/wedgemag*
 
         Rotational wedges. *wedgescale* sets the size of the wedges in inches
         (unless **c**, **i**, or **p** is appended). Values are

--- a/doc/rst/source/supplements/geodesy/velo_common.rst_
+++ b/doc/rst/source/supplements/geodesy/velo_common.rst_
@@ -142,21 +142,10 @@ Optional Arguments
     (**-Sw**) or velocity error ellipses (**-Se** or **-Sr**). [If
     **-E** is not specified, the uncertainty regions will be transparent.]
 
-.. _-F:
-
-**-F**\ *fill*
-    Sets the color or shade used for frame and annotation. [Default is black]
-
 .. _-G:
 
-**-G**\ *fill*
-    Specify color (for symbols/polygons) or pattern (for polygons)
-    [Default is black]. Optionally, specify
-    **-Gp**\ *icon\_size/pattern*, where *pattern* gives the number of
-    the image pattern (1-90) OR the name of a icon-format file.
-    *icon\_size* sets the unit size in inches. To invert black and white
-    pixels, use **-GP** instead of **-Gp**. See the CookBook for
-    information on individual patterns.
+**-G**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
+    Select color or pattern for filling of symbols or polygons [Default is no fill].
 
 .. _-L:
 

--- a/doc/rst/source/supplements/geodesy/velo_common.rst_
+++ b/doc/rst/source/supplements/geodesy/velo_common.rst_
@@ -29,7 +29,7 @@ Required Arguments
 
 Selects the meaning of the columns in the data file and the figure to be plotted.
 
-    **-Se**\ *velscale/confidence*\ [**+f**\ *font* ]
+    **-Se**\ *velscale/confidence*\ [**+f**\ *font*]
 
         Velocity ellipses in (N,E) convention. *velscale* sets the scaling of the
         velocity arrows. This scaling gives inches (unless **c**, **i**,
@@ -63,7 +63,7 @@ Selects the meaning of the columns in the data file and the figure to be plotted
             **3**,\ **4**:
             eastward, northward components of anisotropy vector (**-:** option interchanges order)
 
-    **-Sr**\ *velscale/confidence*\ [**+f**\ *font* ]
+    **-Sr**\ *velscale/confidence*\ [**+f**\ *font*]
 
         Velocity ellipses in rotated convention. *velscale* sets the scaling of
         the velocity arrows. This scaling gives inches (unless **c**, **i**,

--- a/doc/rst/source/supplements/geodesy/velo_common.rst_
+++ b/doc/rst/source/supplements/geodesy/velo_common.rst_
@@ -27,13 +27,14 @@ Required Arguments
 
 **-S**
 
-Selects the meaning of the columns in the data file and the figure to be plotted.
+Selects the meaning of the columns in the data file and the figure to be plotted.  In all
+cases, the scales are in data units per length unit and sizes are in length units (default length
+unit is controlled by :ref:`PROJ_LENGTH_UNIT <PROJ_LENGTH_UNIT>` unless **c**, **i**, or **p** is appended).
 
     **-Se**\ *velscale/confidence*\ [**+f**\ *font*]
 
         Velocity ellipses in (N,E) convention. *velscale* sets the scaling of the
-        velocity arrows. This scaling gives inches (unless **c**, **i**,
-        or **p** is appended). *confidence* sets the 2-dimensional confidence
+        velocity arrows. The *confidence* sets the 2-dimensional confidence
         limit for the ellipse, e.g., 0.95 for 95% confidence ellipse. *font*
         sets the font and size of the text [9p,Helvetica,black]. The ellipse will be filled with the
         color or shade specified by the |-G| option [default transparent]. The
@@ -54,8 +55,7 @@ Selects the meaning of the columns in the data file and the figure to be plotted
 
     **-Sn**\ *barscale*
 
-        Anisotropy bars. *barscale* sets the scaling of the bars. This scaling
-        gives inches (unless **c**, **i**, or **p** is appended).
+        Anisotropy bars. *barscale* sets the scaling of the bars.
         Parameters are expected to be in the following columns:
 
             **1**,\ **2**:
@@ -66,8 +66,7 @@ Selects the meaning of the columns in the data file and the figure to be plotted
     **-Sr**\ *velscale/confidence*\ [**+f**\ *font*]
 
         Velocity ellipses in rotated convention. *velscale* sets the scaling of
-        the velocity arrows. This scaling gives inches (unless **c**, **i**,
-        or **p** is appended). *confidence* sets the 2-dimensional
+        the velocity arrows. The *confidence* sets the 2-dimensional
         confidence limit for the ellipse, e.g., 0.95 for 95% confidence ellipse.
         *font* sets the font and size of the text [9p,Helvetica,black]. The ellipse will be
         filled with the color or shade specified by the |-G| option [default
@@ -88,8 +87,7 @@ Selects the meaning of the columns in the data file and the figure to be plotted
 
     **-Sw**\ *wedgescale/wedgemag*
 
-        Rotational wedges. *wedgescale* sets the size of the wedges in inches
-        (unless **c**, **i**, or **p** is appended). Values are
+        Rotational wedges. *wedgescale* sets the size of the wedges. Values are
         multiplied by *wedgemag* before plotting. For example, setting
         *wedgemag* to 1.e7 works well for rotations of the order of 100
         nanoradians/yr. Use **-G** to set the fill color or shade for the wedge,
@@ -105,8 +103,7 @@ Selects the meaning of the columns in the data file and the figure to be plotted
 
     **-Sx**\ *cross_scale*
 
-        gives Strain crosses. *cross_scale* sets the size of the cross in
-        inches (unless **c**, **i**, or **p** is appended). Parameters
+        gives Strain crosses. *cross_scale* sets the size of the cross. Parameters
         are expected to be in the following columns:
 
             **1**,\ **2**:

--- a/src/geodesy/psvelo.c
+++ b/src/geodesy/psvelo.c
@@ -83,8 +83,9 @@ struct PSVELO_CTRL {
 		unsigned int readmode;
 		unsigned int n_cols;
 		double scale, wedge_amp, conrad;
-		double fontsize, confidence;
+		double confidence;
 		struct GMT_FILL fill;
+		struct GMT_FONT font;
 	} S;
 	struct W {	/* -W<pen> */
 		bool active;
@@ -111,7 +112,8 @@ GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a n
 	gmt_init_fill (GMT, &C->G.fill, 0.0, 0.0, 0.0);
 	C->S.wedge_amp = 1.e7;
 	C->S.conrad = 1.0;
-	C->S.fontsize = DEFAULT_FONTSIZE;
+	C->S.font = GMT->current.setting.font_annot[GMT_PRIMARY];
+	C->S.font.size = 9;
 	C->W.pen = GMT->current.setting.map_default_pen;
 	return (C);
 }
@@ -127,7 +129,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] %s %s [-A<vecpar>] [%s] [-D<sigscale>]\n", name, GMT_J_OPT, GMT_Rgeo_OPT, GMT_B_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-G<fill>] %s[-L] [-N] %s%s[-S<symbol><scale>[/<args>]]\n", API->K_OPT, API->O_OPT, API->P_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-G<fill>] %s[-L] [-N] %s%s[-S<symbol><scale>[+f<font>]]\n", API->K_OPT, API->O_OPT, API->P_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-V] [-W<pen>] [%s]\n", GMT_U_OPT, GMT_X_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] %s[%s] [%s] [%s]\n\t[%s] [%s] [%s] [%s]\n\n", GMT_Y_OPT, API->c_OPT, GMT_di_OPT, GMT_e_OPT, GMT_h_OPT, GMT_i_OPT, GMT_t_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
@@ -148,7 +150,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-L Draw line or symbol outline using the current pen (see -W).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Do Not skip/clip symbols that fall outside map border [Default will ignore those outside].\n");
 	GMT_Option (API, "O,P");
-	GMT_Message (API, GMT_TIME_NONE, "\t-S Select symbol type and scale (plus optional args; see documentation). Choose between:\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-S Select symbol type and scale (plus optional font; see documentation). Choose between:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     e  Velocity ellipses: in X,Y,Vx,Vy,SigX,SigY,CorXY,name format.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     r  Velocity ellipses: in X,Y,Vx,Vy,a,b,theta,name format.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     n  Anisotropy : in X,Y,Vx,Vy.\n");
@@ -172,7 +174,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSVELO_CTRL *Ctrl, struct GMT_
 	unsigned int n_errors = 0, n_set;
 	int n;
 	bool no_size_needed, got_A = false;
-	char txt[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""}, symbol;
+	char txt[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""}, symbol, *c = NULL;
 	struct GMT_OPTION *opt = NULL;
 
 	symbol = (gmt_M_is_geographic (GMT, GMT_IN)) ? '=' : 'v';	/* Type of vector */
@@ -237,6 +239,10 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSVELO_CTRL *Ctrl, struct GMT_
 				break;
 			case 'S':	/* Get symbol [and size] */
  				txt_b[0] = '\0';
+				if ((c = strstr (opt->arg, "+f"))) {	/* Gave font directly */
+					n_errors += gmt_getfont (GMT, &c[2], &(Ctrl->S.font));
+					c[0] = '\0';	/* Temporarily chop off the font specification */
+				}
  				if (opt->arg[0] == 'e' || opt->arg[0] == 'r') {
 					strncpy (txt, &opt->arg[1], GMT_LEN256);
 					n = 0; while (txt[n] && txt[n] != '/') n++; txt[n] = 0;
@@ -244,7 +250,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSVELO_CTRL *Ctrl, struct GMT_
 					sscanf (strchr(&opt->arg[1],'/')+1, "%lf/%s", &Ctrl->S.confidence, txt_b);
 					/* confidence scaling */
 					Ctrl->S.conrad = sqrt (-2.0 * log (1.0 - Ctrl->S.confidence));
-					if (txt_b[0]) Ctrl->S.fontsize = gmt_convert_units (GMT, txt_b, GMT_PT, GMT_PT);
+					if (txt_b[0]) Ctrl->S.font.size = gmt_convert_units (GMT, txt_b, GMT_PT, GMT_PT);
 				}
 				if (opt->arg[0] == 'n' || opt->arg[0] == 'x' ) Ctrl->S.scale = gmt_M_to_inch (GMT, &opt->arg[1]);
 				if (opt->arg[0] == 'w' && strlen(opt->arg) > 3) {
@@ -278,6 +284,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSVELO_CTRL *Ctrl, struct GMT_
 						n_errors++;
 						break;
 				}
+				if (c) c[0] = '+';	/* Restore font specification */
 				break;
 			case 'W':	/* Set line attributes */
 				Ctrl->W.active = true;
@@ -512,16 +519,16 @@ int GMT_psvelo (void *V_API, int mode, void *args) {
 					if (Ctrl->A.S.v.status & PSL_VEC_OUTLINE2) gmt_setpen (GMT, &Ctrl->W.pen);
 
 					justify = plot_vx - plot_x > 0. ? PSL_MR : PSL_ML;
-					if (Ctrl->S.fontsize > 0.0 && station_name)	/* 1 inch = 2.54 cm */
-						PSL_plottext (PSL, plot_x + (6 - justify) / 25.4 , plot_y, Ctrl->S.fontsize, station_name, ANGLE, justify, FORM);
+					if (Ctrl->S.font.size > 0.0 && station_name)	/* 1 inch = 2.54 cm */
+						PSL_plottext (PSL, plot_x + (6 - justify) / 25.4 , plot_y, Ctrl->S.font.size, station_name, ANGLE, justify, FORM);
 				}
 				else {
 					gmt_setfill (GMT, &Ctrl->G.fill, 1);
 					ssize = GMT_DOT_SIZE;
 					PSL_plotsymbol (PSL, plot_x, plot_y, &ssize, PSL_CIRCLE);
 					justify = PSL_TC;
-					if (Ctrl->S.fontsize > 0.0 && station_name) {
-						PSL_plottext (PSL, plot_x, plot_y - 1. / 25.4, Ctrl->S.fontsize, station_name, ANGLE, justify, FORM);
+					if (Ctrl->S.font.size > 0.0 && station_name) {
+						PSL_plottext (PSL, plot_x, plot_y - 1. / 25.4, Ctrl->S.font.size, station_name, ANGLE, justify, FORM);
 					}
 					/*  1 inch = 2.54 cm */
 				}

--- a/test/geodesy/geodesy_01.sh
+++ b/test/geodesy/geodesy_01.sh
@@ -39,7 +39,7 @@ gmt pscoast -O -R -J -W0.25p -Di -K >> $ps
  
 # 
 gmt psvelo -Y-4.5i -R-10/10/-10/10 -Wthin,red \
-	-Se0.2/0.39/12 -B1g1 -BWeSn -Jx0.2i -Ggreen -Eblue -L -N \
+	-Se0.2/0.39+f12p -B1g1 -BWeSn -Jx0.2i -Ggreen -Eblue -L -N \
 	-A1c+p3p+e -O -K << EOF >> $ps    
 # Long.   Lat.   Evel   Nvel   Esig   Nsig  CorEN SITE
 # (deg)  (deg)    (mm/yr)        (mm/yr)
@@ -52,7 +52,7 @@ EOF
 
 # simpler colors, labeled with following font
 gmt set FONT_ANNOT_PRIMARY Helvetica
-gmt psvelo -Se0.2/0.39/18 -R -J -A0.25c+p0.25p+e -O -Umeca_4 << EOF >> $ps    
+gmt psvelo -Se0.2/0.39+f18p -R -J -A0.25c+p0.25p+e -O -Umeca_4 << EOF >> $ps    
 # Long.   Lat.   Evel   Nvel   Esig   Nsig  CorEN SITE
 # (deg)  (deg)    (mm/yr)        (mm/yr)
    0.    -8.     0.0    0.0     4.0    6.0  0.100  4x6

--- a/test/geodesy/geodesy_03.sh
+++ b/test/geodesy/geodesy_03.sh
@@ -7,7 +7,7 @@ ps=geodesy_03.ps
 #     scaling will give an ellipse which fits inside a rectangle
 #     of dimension Esig by Nsig. [K. Feigl, 2015-11/08]
  
-gmt psvelo -Xc -R-3/6/-3/7 -Wthin,red -Se1.5c/0.39/12 -Bpxa1g1 \
+gmt psvelo -Xc -R-3/6/-3/7 -Wthin,red -Se1.5c/0.39+f12p -Bpxa1g1 \
 	-Bpya1g1 -BWeSn+t"E = 3 @~\261@~ 1; N = 4 @~\261@~ 2" -Jx1.5c -Ggreen -Eblue -L -N \
 	-A1c+p3p+e -P -h2 << EOF > $ps    
 # Long.   Lat.   Evel   Nvel   Esig   Nsig  CorEN SITE

--- a/test/geodesy/geodesy_04.sh
+++ b/test/geodesy/geodesy_04.sh
@@ -7,8 +7,8 @@ cat << EOF > record.txt
 0     0     5.0    5.0     2.0    4.0  0.500  3x3
 EOF
 # Old GMT4 syntax for arrow
-gmt psvelo -R-0.5/4/-0.5/3.8 -W1.2p,red -Se0.4i/0.39/12 -BWSne -B1g1 -Jx1i -Ggreen -Eblue -L -N -A0.1i/0.76c/0.3i -P -K -Xc record.txt > $ps
+gmt psvelo -R-0.5/4/-0.5/3.8 -W1.2p,red -Se0.4i/0.39+f12p -BWSne -B1g1 -Jx1i -Ggreen -Eblue -L -N -A0.1i/0.76c/0.3i -P -K -Xc record.txt > $ps
 gmt pstext -R -J -O -K -F+f18p+cRB+tGMT4 -Dj0.1i >> $ps
 # New GMT5 syntax for arrow
-gmt psvelo -R -J -W1.2p,red -Se0.4i/0.39/12 -BWSne -B1g1 -Ggreen -Eblue -L -N -A0.3i+p3p+e+a90 -O -K -Y4.8i record.txt >> $ps    
+gmt psvelo -R -J -W1.2p,red -Se0.4i/0.39+f12p -BWSne -B1g1 -Ggreen -Eblue -L -N -A0.3i+p3p+e+a90 -O -K -Y4.8i record.txt >> $ps    
 gmt pstext -R -J -O -F+f18p+cRB+tGMT5 -Dj0.1i >> $ps

--- a/test/geodesy/geodesy_05.sh
+++ b/test/geodesy/geodesy_05.sh
@@ -4,6 +4,6 @@
 # regardless of map projection and region.
 ps=geodesy_05.ps
 echo 0	0	0	1	0.1	0.1  0 > t.txt
-gmt psvelo t.txt -Jm1.5i -R-1/1/-0.5/1.5 -Se1.5i/0.95/12 -A9p+e -W1.5p,red -P -Bafg1 -BWSne -K -Xc > $ps
+gmt psvelo t.txt -Jm1.5i -R-1/1/-0.5/1.5 -Se1.5i/0.95+f12p -A9p+e -W1.5p,red -P -Bafg1 -BWSne -K -Xc > $ps
 echo 0	60	0	1	0.1	0.1  0 > t.txt
-gmt psvelo t.txt -Jm1.5i -R-1/1/59.5/61.5 -Se1.5i/0.95/12 -A9p+e -W1.5p,red -O -Bxafg1 -Byafg0.5 -BWsne -Xc -Y3.25i >> $ps
+gmt psvelo t.txt -Jm1.5i -R-1/1/59.5/61.5 -Se1.5i/0.95+f12p -A9p+e -W1.5p,red -O -Bxafg1 -Byafg0.5 -BWsne -Xc -Y3.25i >> $ps

--- a/test/geodesy/geodesy_06.sh
+++ b/test/geodesy/geodesy_06.sh
@@ -28,6 +28,6 @@ cat << EOF > test.csv
 1800 2600 0.00228223 -5.6886e-07 0 0 0
 EOF
 gmt begin geodesy_06 ps 
-  gmt velo -JX6.5i/9i -R0/2100/0/2700 -B test.csv -A+pthicker+ea -Se600c/0/8 -Gblack -W0.1p,black
-  gmt velo test.csv -A+pthicker+ea+n1c -Se600c/0/8 -Gorange -W0.1p,orange
+  gmt velo -JX6.5i/9i -R0/2100/0/2700 -B test.csv -A+pthicker+ea -Se600c/0+f8p -Gblack -W0.1p,black
+  gmt velo test.csv -A+pthicker+ea+n1c -Se600c/0+f8p -Gorange -W0.1p,orange
 gmt end show

--- a/test/geodesy/gpsgridder1.sh
+++ b/test/geodesy/gpsgridder1.sh
@@ -44,7 +44,7 @@ gmt grdmath GPS_v.grd mask.grd MUL = GPS_v.nc
 #
 gmt pscoast $R -JM7i -P -Glightgray -Ba1f30m -BWSne -K -Df -X1i -Wfaint > $ps
 gmt psxy @CA_fault_data.txt -J -R -W0.5p -O -K >> $ps
-gmt psvelo data.lluvenct -J -R -Se.008i/0.95/8 -A9p -W0.2p,red -O -K >> $ps
+gmt psvelo data.lluvenct -J -R -Se.008i/0.95+f8p -A9p -W0.2p,red -O -K >> $ps
 # Shrink down heads of vectors shorter than 10 km
 gmt grdvector GPS_u.nc GPS_v.nc -Ix${DEC}/${DEC} -J -R -O -K -Q0.06i+e+n10 -Gblue -W0.2p,blue -S100i --MAP_VECTOR_SHAPE=0.2 >> $ps
 #

--- a/test/geodesy/gpsgridder2.sh
+++ b/test/geodesy/gpsgridder2.sh
@@ -44,7 +44,7 @@ gmt grdmath GPS_v.grd mask.grd MUL = GPS_v.nc
 #
 gmt pscoast $R -JM7i -P -Glightgray -Ba1f30m -BWSne -K -Df -X1i -Wfaint > $ps
 gmt psxy @CA_fault_data.txt -J -R -W0.5p -O -K >> $ps
-gmt psvelo data.lluvenct -J -R -Se.008i/0.95/8 -A9p -W0.2p,red -O -K >> $ps
+gmt psvelo data.lluvenct -J -R -Se.008i/0.95+f8p -A9p -W0.2p,red -O -K >> $ps
 # Shrink down heads of vectors shorter than 10 km
 gmt grdvector GPS_u.nc GPS_v.nc -Ix${DEC}/${DEC} -J -R -O -K -Q0.06i+e+n10 -Gblue -W0.2p,blue -S100i --MAP_VECTOR_SHAPE=0.2 >> $ps
 #


### PR DESCRIPTION
This one was missed during the reformation.  In other tools (e.g., psmeca) we replaced this slash-delimited size-only setting with the modifier **+f**_font_ which not only controls font size but all attributes of the font.  Backwards compatible, and default set to 9p as before.  Tests seems to all run just as well.  Closes issue #2045.
