### PR TITLE
Clarify that fill is not always -G

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -772,7 +772,8 @@ Specifying area fill attributes
 -------------------------------
 
 Many plotting programs will allow the user to draw filled polygons or
-symbols. The fill specification may take two forms:
+symbols. The fill specification may take two forms (note: not all modules
+use **-G** for this task and some have several options specifying different fills):
 
 **-G**\ *fill*
     In the first case we may specify a *gray* shade (0–255), RGB color

--- a/doc/rst/source/supplements/geodesy/velo_common.rst_
+++ b/doc/rst/source/supplements/geodesy/velo_common.rst_
@@ -137,7 +137,7 @@ Optional Arguments
 
 .. _-E:
 
-**-E**\ *fill*
+**-E**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
     Sets the color or shade used for filling uncertainty wedges
     (**-Sw**) or velocity error ellipses (**-Se** or **-Sr**). [If
     **-E** is not specified, the uncertainty regions will be transparent.]

--- a/doc/rst/source/supplements/seis/coupe.rst
+++ b/doc/rst/source/supplements/seis/coupe.rst
@@ -16,9 +16,9 @@ Synopsis
 |SYN_OPT-R| |-A|\ *parameters*
 |-S|\ *<format><scale>*\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
 [ |SYN_OPT-B| ]
-[ |-E|\ *color* ]
+[ |-E|\ *fill* ]
 [ |-F|\ *mode*\ [*args*] ]
-[ |-G|\ *color* ]
+[ |-G|\ *fill* ]
 [ |-L|\ *[pen]* ]
 [ |-M| ] [ |-N| ]
 [ |-Q| ]

--- a/doc/rst/source/supplements/seis/coupe_common.rst_
+++ b/doc/rst/source/supplements/seis/coupe_common.rst_
@@ -76,7 +76,7 @@ Optional Arguments
 
 .. _-E:
 
-**-E**\ *color*
+**-E**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
     Sets color or fill pattern for extensive quadrants [Default is white].
 
 .. _-F:
@@ -108,10 +108,10 @@ Optional Arguments
     triangle, (**p**) point, (**s**) square, (**t**) triangle, (**x**)
     cross. [Default: 6\ **p**/**cc**]
 
-**-Fe**\ *fill*
+**-Fe**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
     Sets the color or fill pattern for the T axis symbol. [Default as set by |-E|]
 
-**-Fg**\ *fill*
+**-Fg**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
     Sets the color or fill pattern for the P axis symbol. [Default as set by |-G|]
 
 **-Fp**\ [*pen*]
@@ -125,7 +125,7 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *fill*
+**-G**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
     Sets color or fill pattern for compressional quadrants [Default is black].
 
 .. _-L:

--- a/doc/rst/source/supplements/seis/meca_common.rst_
+++ b/doc/rst/source/supplements/seis/meca_common.rst_
@@ -51,7 +51,7 @@ Optional Arguments
 
 .. _-E:
 
-**-E**\ *fill*
+**-E**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
     Selects filling of extensive quadrants. Usually white. Set the color
     [Default is white].
 
@@ -86,7 +86,7 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *fill*
+**-G**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
     Selects filling of focal mechanisms. By convention, the
     compressional quadrants of the focal mechanism beach balls are
     shaded. Set the color [Default is black].

--- a/doc/rst/source/supplements/seis/polar.rst
+++ b/doc/rst/source/supplements/seis/polar.rst
@@ -18,9 +18,9 @@ Synopsis
 |-S|\ *<symbol><size>*
 [ |SYN_OPT-B| ]
 [ |-C|\ *lon*/*lat*\ [**+p**\ *pen*\ ][**+s**\ *pointsize*] ]
-[ |-E|\ *color* ]
-[ |-F|\ *color* ]
-[ |-G|\ *color* ]
+[ |-E|\ *fill* ]
+[ |-F|\ *fill* ]
+[ |-G|\ *fill* ]
 [ |-N| ]
 [ |-Q|\ *mode*\ [*args*] ]
 [ |-T|\ *angle*/*form*/*justify*/*fontsize* ]

--- a/doc/rst/source/supplements/seis/polar_common.rst_
+++ b/doc/rst/source/supplements/seis/polar_common.rst_
@@ -73,19 +73,19 @@ Optional Arguments
 
 .. _-E:
 
-**-E**\ *color*
+**-E**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
     Selects filling of symbols for stations in extensive quadrants. Set
-    the color [Default is 250]. If **-E**\ *color* is the same as
-    **-F**\ *color*, use **-Qe** to outline.
+    the color [Default is 250]. If **-E**\ *fill* is the same as
+    **-F**\ *fill*, use **-Qe** to outline.
 
 .. _-F:
 
-**-F**\ *color*
+**-F**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
     Sets background color of the beach ball. Default is no fill.
 
 .. _-G:
 
-**-G**\ *color*
+**-G**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
     Selects filling of symbols for stations in compressional quadrants.
     Set the color [Default is black].
 

--- a/doc/rst/source/supplements/seis/pscoupe.rst
+++ b/doc/rst/source/supplements/seis/pscoupe.rst
@@ -16,9 +16,9 @@ Synopsis
 |SYN_OPT-R| |-A|\ *parameters*
 |-S|\ *<format><scale>*\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
 [ |SYN_OPT-B| ]
-[ |-E|\ *color* ]
+[ |-E|\ *fill* ]
 [ |-F|\ *mode*\ [*args*] ]
-[ |-G|\ *color* ]
+[ |-G|\ *fill* ]
 [ |-K| ]
 [ |-L|\ *[pen]* ]
 [ |-M| ] [ |-N| ]

--- a/doc/rst/source/supplements/seis/pspolar.rst
+++ b/doc/rst/source/supplements/seis/pspolar.rst
@@ -18,9 +18,9 @@ Synopsis
 |-S|\ *<symbol><size>*
 [ |SYN_OPT-B| ]
 [ |-C|\ *lon*/*lat*\ [**+p**\ *pen*\ ][**+s**\ *pointsize*] ]
-[ |-E|\ *color* ]
-[ |-F|\ *color* ]
-[ |-G|\ *color* ]
+[ |-E|\ *fill* ]
+[ |-F|\ *fill* ]
+[ |-G|\ *fill* ]
 [ |-K| ] [ |-N| ]
 [ |-O| ]
 [ |-Q|\ *mode*\ [*args*] ]


### PR DESCRIPTION
Since man pages link to the cookbook section on fill which uses **-G** I added a sentence saying it is not always **-G** and some modules may have several settings for different fills).

