### PR TITLE
Don't list -O -K -P in gmt common option listing

### DIFF
--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -148,7 +148,7 @@ The Common GMT Options
 
 |SYN_OPT-B|
 **-J**\ *parameters*
-**-Jz**\ \|\ **Z**\ *parameters* **-K** **-O**
+**-Jz**\ \|\ **Z**\ *parameters*
 |SYN_OPT-Rz|
 |SYN_OPT-U|
 |SYN_OPT-V|


### PR DESCRIPTION
There is a separate section further down in the man page that mentions them for classic mode.
