### PR TITLE
docs: Make the install commands work for both bash and csh

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -113,7 +113,7 @@ You then can install the GMT dependencies with:
 
     # to enable movie-making
     # ffmpeg is provided by [rmpfusion](https://rpmfusion.org/)
-    sudo yum localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm
+    sudo yum localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-`rpm -E %rhel`.noarch.rpm
     sudo yum install GraphicsMagick ffmpeg
 
     # to enable document viewing via gmt docs
@@ -138,7 +138,7 @@ Install the GMT dependencies with:
 
     # to enable movie-making
     # ffmpeg is provided by [rmpfusion](https://rpmfusion.org/)
-    sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
+    sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-`rpm -E %fedora`.noarch.rpm
     sudo dnf install GraphicsMagick ffmpeg
 
     # to enable document viewing via gmt docs

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -135,6 +135,8 @@ The GMT binary packages provided by the Fedora official repositories are usually
 We provide [the GMT official RPM repository](https://copr.fedorainfracloud.org/coprs/genericmappingtools/gmt)
 to allow Fedora users access the latest GMT releases in an easy way.
 
+**NOTE: The RPM repository provides GMT packages for Fedora 29 or newer only!**
+
 Fedora users can add the GMT official RPM repository and install gmt by:
 
 	# enable the RPM repository
@@ -148,7 +150,7 @@ Fedora users can add the GMT official RPM repository and install gmt by:
 
 You may also install other optional dependencies for more capabilities within GMT:
 
-    dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
+    dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-`rpm -E %fedora`.noarch.rpm
     dnf install GraphicsMagick ffmpeg gdal
 
 **Note**:
@@ -185,7 +187,7 @@ For RHEL/CentOS, run:
 
 You may also install other optional dependencies for more capabilities within GMT:
 
-    yum localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm
+    yum localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-`rpm -E %rhel`.noarch.rpm
     yum install GraphicsMagick ffmpeg gdal
 
 **Note**:


### PR DESCRIPTION
Closes #2043 and also add a note that the RPM repository works for Fedora >=29 only.