### PR TITLE
cmake: Simplify cmake script via "cmake -E env"

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Linux | Build docs + Deploy docs + Package'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'ubuntu-18.04'
@@ -53,7 +53,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Linux | Test'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'ubuntu-18.04'
@@ -89,7 +89,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Build docs + Package'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.14'
@@ -107,7 +107,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Test'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.14'
@@ -144,7 +144,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Windows | Build Docs + Package'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: ne(variables['Build.Reason'], 'Schedule')
   timeoutInMinutes: 120
 
   pool:
@@ -163,7 +163,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Windows | Test'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: ne(variables['Build.Reason'], 'Schedule')
   timeoutInMinutes: 360
 
   pool:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Linux | Build docs + Deploy docs + Package'
-  condition: ne(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'ubuntu-18.04'
@@ -53,7 +53,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Linux | Test'
-  condition: ne(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'ubuntu-18.04'
@@ -89,7 +89,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Build docs + Package'
-  condition: ne(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.14'
@@ -107,7 +107,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Mac | Test'
-  condition: ne(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'macOS-10.14'
@@ -144,7 +144,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Windows | Build Docs + Package'
-  condition: ne(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
   timeoutInMinutes: 120
 
   pool:
@@ -163,7 +163,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Windows | Test'
-  condition: ne(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
   timeoutInMinutes: 360
 
   pool:

--- a/doc/examples/CMakeLists.txt
+++ b/doc/examples/CMakeLists.txt
@@ -27,38 +27,20 @@ foreach (_ps ${_examples})
 	string (REPLACE ".ps" ".png" _png_fig ${_fig})
 	list (APPEND _examples_png ${RST_BINARY_DIR}/_images/${_png_fig})
 
-	if (WIN32)
-		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
-			COMMAND
-			set GMT_USERDIR=${GMT_BINARY_DIR}/share
-			COMMAND
-			set GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
-			COMMAND
-			${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
-			-A -P -E150 -Tg -Qg4 -Qt4
-			-C-sFONTPATH="${GMT_SOURCE_DIR}/doc/examples/ex31/fonts"
-			-D${RST_BINARY_DIR}/_images
-			${CMAKE_CURRENT_SOURCE_DIR}/${_ps}
-			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-			DEPENDS gmt_for_img_convert ${CMAKE_CURRENT_SOURCE_DIR}/${_ps})
-	else (WIN32)
-		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
-			COMMAND
-			_dummy_var=cmake_assumes_this_is_a_command # needed for spaces to be escaped correctly
-			GMT_USERDIR=${GMT_BINARY_DIR}/share
-			GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
-			${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
-			-A -P -E150 -Tg -Qg4 -Qt4
-			-C-sFONTPATH="${GMT_SOURCE_DIR}/doc/examples/ex31/fonts"
-			-D${RST_BINARY_DIR}/_images
-			${CMAKE_CURRENT_SOURCE_DIR}/${_ps}
-			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-			DEPENDS gmt_for_img_convert ${CMAKE_CURRENT_SOURCE_DIR}/${_ps})
-	endif (WIN32)
+	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
+		COMMAND ${CMAKE_COMMAND} -E env
+		GMT_USERDIR=${GMT_BINARY_DIR}/share
+		GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
+		${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
+		-A -P -E150 -Tg -Qg4 -Qt4
+		-C-sFONTPATH="${GMT_SOURCE_DIR}/doc/examples/ex31/fonts"
+		-D${RST_BINARY_DIR}/_images
+		${CMAKE_CURRENT_SOURCE_DIR}/${_ps}
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+		DEPENDS gmt_for_img_convert ${CMAKE_CURRENT_SOURCE_DIR}/${_ps})
 endforeach (_ps ${_examples})
 
 # List of job scripts and convert to verbatim
-
 file (GLOB _examples RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*/*.sh")
 
 set (_examples_txt)
@@ -103,8 +85,7 @@ if (UNIX AND DO_ANIMATIONS)
 	# copy video files from anim 04, 06, 07, 08
 	foreach (_num 04 06 07 08)
 		add_custom_command (
-			OUTPUT
-			${RST_BINARY_DIR}/_static/anim_${_num}.mp4
+			OUTPUT ${RST_BINARY_DIR}/_static/anim_${_num}.mp4
 			COMMAND ${CMAKE_COMMAND} -E copy_if_different
 			${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim_${_num}.mp4
 			${RST_BINARY_DIR}/_static/anim_${_num}.mp4

--- a/doc/scripts/CMakeLists.txt
+++ b/doc/scripts/CMakeLists.txt
@@ -74,32 +74,16 @@ foreach (_fig ${_scripts_ps2png})
 	string (REPLACE ".ps" ".png" _png_fig ${_fig})
 	list (APPEND _scripts_png ${RST_BINARY_DIR}/_images/${_png_fig})
 	FILE(MAKE_DIRECTORY ${RST_BINARY_DIR}/_images)
-	if (WIN32)
-		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
-			COMMAND
-			set GMT_USERDIR=${GMT_BINARY_DIR}/share
-			COMMAND
-			set GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
-			COMMAND
-			${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
-			-A -P -E150 -Tg -Qg4 -Qt4
-			-D${RST_BINARY_DIR}/_images
-			${CMAKE_CURRENT_SOURCE_DIR}/${_fig}
-			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-			DEPENDS gmt_for_img_convert ${_fig})
-	else (WIN32)
-		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
-			COMMAND
-			_dummy_var=cmake_assumes_this_is_a_command # needed for spaces to be escaped correctly
-			GMT_USERDIR=${GMT_BINARY_DIR}/share
-			GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
-			${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
-			-A -P -E150 -Tg -Qg4 -Qt4
-			-D${RST_BINARY_DIR}/_images
-			${CMAKE_CURRENT_SOURCE_DIR}/${_fig}
-			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-			DEPENDS gmt_for_img_convert ${_fig})
-	endif (WIN32)
+	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
+		COMMAND ${CMAKE_COMMAND} -E env
+		GMT_USERDIR=${GMT_BINARY_DIR}/share
+		GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
+		${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
+		-A -P -E150 -Tg -Qg4 -Qt4
+		-D${RST_BINARY_DIR}/_images
+		${CMAKE_CURRENT_SOURCE_DIR}/${_fig}
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+		DEPENDS gmt_for_img_convert ${_fig})
 endforeach (_fig ${_scripts_ps2png})
 
 # Convert PS to PDF
@@ -107,30 +91,15 @@ foreach (_fig ${_scripts_ps2pdf})
 	string (REPLACE ".ps" ".pdf" _pdf_fig ${_fig})
 	list (APPEND _scripts_pdf ${RST_BINARY_DIR}/_images/${_pdf_fig})
 	FILE(MAKE_DIRECTORY ${RST_BINARY_DIR}/_images)
-	if (WIN32)
-		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_pdf_fig}
-			COMMAND
-			set GMT_USERDIR=${GMT_BINARY_DIR}/share
-			COMMAND
-			set GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
-			COMMAND
-			${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert -A -P -Tf
-			-D${RST_BINARY_DIR}/_images
-			${CMAKE_CURRENT_SOURCE_DIR}/${_fig}
-			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-			DEPENDS gmt_for_img_convert ${_fig})
-	else (WIN32)
-		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_pdf_fig}
-			COMMAND
-			_dummy_var=cmake_assumes_this_is_a_command # needed for spaces to be escaped correctly
-			GMT_USERDIR=${GMT_BINARY_DIR}/share
-			GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
-			${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert -A -P -Tf
-			-D${RST_BINARY_DIR}/_images
-			${CMAKE_CURRENT_SOURCE_DIR}/${_fig}
-			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-			DEPENDS gmt_for_img_convert ${_fig})
-	endif (WIN32)
+	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_pdf_fig}
+		COMMAND ${CMAKE_COMMAND} -E env
+		GMT_USERDIR=${GMT_BINARY_DIR}/share
+		GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
+		${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert -A -P -Tf
+		-D${RST_BINARY_DIR}/_images
+		${CMAKE_CURRENT_SOURCE_DIR}/${_fig}
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+		DEPENDS gmt_for_img_convert ${_fig})
 endforeach (_fig ${_scripts_ps})
 
 foreach (_script ${_scr_nostrip})


### PR DESCRIPTION
To generate PNG and PDF images for the documentations, we need to set environment variables
GMT_USERDIR and GMT_SHAREDIR before calling `gmt psconvert`.

Since the syntax to set environment varibals are different for UNIX and
Windows, the old scripts have the if-tests to check the OS and have some
duplicate codes.

Actually, cmake provides a platform independent command to set
environment variables (i.e. `cmake -E env var1=name1 var2=name2
commands`), which can greatly simplify the cmake scripts.