### PR TITLE
Ensure -B options are only applied the first time in a subplot

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12596,17 +12596,16 @@ GMT_LOCAL bool build_new_J_option (struct GMTAPI_CTRL *API, struct GMT_OPTION *o
 	return true;
 }
 
-/* The way we avoid applying -B settings mroe than once per subplot panel is to write
- * an empty file called gmt.B.<fig>.<row>.<col> after applying -B and once that file
+/* The way we avoid applying -B settings more than once per subplot panel is to write
+ * an empty file called gmt.B.<fig>.<row>.<col> after applying -B, and once that file
  * exist we do not apply -B again. */
 
 void panel_B_set (struct GMTAPI_CTRL *API, int fig, int row, int col) {
-	/* Mark that -B options have been applied for this subplot panels */
+	/* Mark that -B options have been applied for this subplot panel */
 	char Bfile[PATH_MAX] = {""};
 	FILE *fp = NULL;
 	sprintf (Bfile, "%s/gmt.B.%d.%d.%d", API->gwf_dir, fig, row, col);
 	if ((fp = fopen (Bfile, "w"))) fclose (fp);
-
 }
 
 bool panel_B_get (struct GMTAPI_CTRL *API, int fig, int row, int col) {


### PR DESCRIPTION
GMT got tricked if you repeatedly moved back and forth between panels and it thought each time you entered it was the first time and therefore **-B** needed to be set.  This PR keeps track and fixes #613.
