### PR TITLE
Giving a minus to indicate transparent pixels is lame

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -800,8 +800,8 @@ use **-G** for this task and some have several options specifying different fill
     predefined bit-image patterns). For these patterns and other 1-bit
     images one may specify alternative background and foreground colors
     (by appending **+b**\ *color* and/or **+f**\ *color*) that will replace
-    the default white and black pixels, respectively. Setting one of the
-    fore- or background colors to - yields a *transparent* image where
+    the default white and black pixels, respectively. Excluding *color* from
+    a fore- or background specification yields a *transparent* image where
     only the back- *or* foreground pixels will be painted.
 
 Due to PostScript implementation limitations the raster images used

--- a/doc/rst/source/explain_fill.rst_
+++ b/doc/rst/source/explain_fill.rst_
@@ -9,6 +9,6 @@
     raster image file. The optional **+r**\ *dpi* sets the resolution of
     the image [1200]. For 1-bit rasters: use upper case **P**  for inverse
     video, or append **+f**\ *color* and/or **+b**\ *color* to specify
-    fore- and background colors (use *color* = - for transparency). See
+    fore- and background colors (no *color* given means transparency). See
     GMT Cookbook & Technical Reference Appendix E for information on
     individual built-in patterns.

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6875,7 +6875,7 @@ void gmt_fill_syntax (struct GMT_CTRL *GMT, char option, char *longoption, char 
 	gmt_message (GMT, "\t   4) any valid color name;\n");
 	gmt_message (GMT, "\t   5) P|p<pattern>[+b<color>][+f<color>][+r<dpi>];\n");
 	gmt_message (GMT, "\t      Give <pattern> number from 1-90 or a filename, optionally add +r<dpi> [300].\n");
-	gmt_message (GMT, "\t      Optionally, use +f,+b to change fore- or background colors (set - for transparency).\n");
+	gmt_message (GMT, "\t      Optionally, use +f<color> or +b<color> to change fore- or background colors (no <color> sets transparency).\n");
 	gmt_message (GMT, "\t   For PDF fill transparency, append @<transparency> in the range 0-100 [0 = opaque].\n");
 }
 

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -182,8 +182,8 @@ GMT_LOCAL int gmtsupport_parse_pattern_new (struct GMT_CTRL *GMT, char *line, st
 		char p[GMT_BUFSIZ] = {""};
 		while (gmt_getmodopt (GMT, 0, c, "bfr", &pos, p, &uerr) && uerr == 0) {	/* Looking for +b, +f, +r */
 			switch (p[0]) {
-				case 'b':	/* Background color */
-					if (p[1] == '-') {	/* Transparent */
+				case 'b':	/* Background color. Giving no argument means transparent [also checking for obsolete -] */
+					if (p[1] == '\0' || p[1] == '-') {	/* Transparent */
 						fill->b_rgb[0] = fill->b_rgb[1] = fill->b_rgb[2] = -1,	fill->b_rgb[3] = 0;
 						GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Background pixels set to transparent!\n");
 					}
@@ -195,8 +195,8 @@ GMT_LOCAL int gmtsupport_parse_pattern_new (struct GMT_CTRL *GMT, char *line, st
 						GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Background pixels set to colors %s\n", gmt_putrgb (GMT, fill->b_rgb));
 					}
 					break;
-				case 'f':	/* Foreround color */
-					if (p[1] == '-') {	/* Transparent */
+				case 'f':	/* Foreround color. Giving no argument means transparent [also checking for obsolete -] */
+					if (p[1] == '\0' || p[1] == '-') {	/* Transparent */
 						fill->f_rgb[0] = fill->f_rgb[1] = fill->f_rgb[2] = -1,	fill->f_rgb[3] = 0;
 						GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Foreground pixels set to transparent!\n");
 					}


### PR DESCRIPTION
The GMT4 syntax for transparent patters had ugly syntax like BredF-.  We replaced that with separate **+b**_color_ and **+f**_color_ modifiers that take the required color.  However, we still let - signify transparency, yet there is no reason not to just assume no _color_ given means transparency.  To be backwards compatible we now accept either - or nothing, but the docs have been updated to say the default is transparent.
