### PR TITLE
docs: Add fill syntax to quick links

### DIFF
--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -9,15 +9,19 @@ it can do.
 Quick links
 -----------
 
-- :doc:`std_opts`
-- :doc:`proj_codes`
-- :doc:`GMT Defaults <gmt.conf>`
-- :doc:`GMT Colors <gmtcolors>`
-- :doc:`35 Postscript Fonts </cookbook/postscript_fonts>`
-- :doc:`Built-in CPTs </cookbook/cpts>`
-- :doc:`Octal Codes of Characters </cookbook/octal_codes>`
-- :ref:`Pen Syntax <-Wpen_attrib>`
-- :ref:`Grid File Format Specifications <tbl-grdformats>`
+.. hlist::
+   :columns: 3
+
+   - :doc:`std_opts`
+   - :doc:`proj_codes`
+   - :doc:`GMT Defaults <gmt.conf>`
+   - :doc:`GMT Colors <gmtcolors>`
+   - :doc:`35 Postscript Fonts </cookbook/postscript_fonts>`
+   - :doc:`Built-in CPTs </cookbook/cpts>`
+   - :doc:`Octal Codes of Characters </cookbook/octal_codes>`
+   - :ref:`Pen Syntax <-Wpen_attrib>`
+   - :ref:`Fill Syntax <-Gfill_attrib>`
+   - :ref:`Grid File Format Specifications <tbl-grdformats>`
 
 .. Add a hidden toctree to suppress "document isn't included in any toctree" warnings
 .. toctree::


### PR DESCRIPTION
Closes #2084

screenshot:

![image](https://user-images.githubusercontent.com/3974108/69062763-65501b00-09e9-11ea-84c7-a7a3c154ce95.png)
