### PR TITLE
docs: Update cmake script for fig directory

### DIFF
--- a/doc/fig/CMakeLists.txt
+++ b/doc/fig/CMakeLists.txt
@@ -15,10 +15,13 @@
 # Contact info: www.generic-mapping-tools.org
 #-------------------------------------------------------------------------------
 
-# Figure files
-set (_fig_fig GMT4_mode.png GMT6_Summit_2019.jpg GMT5_mode.png GMT5_external.png
-	GMT_Environment.png GMT_record.png dcw-figure.png dem.jpg gimp-sliders+panel.png
-	gshhg.jpg hsv-cone.png formatpicture.png rendering.png)
+# Include all PNG and JPG files
+file (GLOB _fig_fig RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+	"${CMAKE_CURRENT_SOURCE_DIR}/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/*.jpg")
+# Remove some unused figures
+list (REMOVE_ITEM _fig_fig
+	formatting.png highres.png noantialias.png withantialias.png)
 
 # Copy figures without converting
 FILE(MAKE_DIRECTORY ${RST_BINARY_DIR}/_images)


### PR DESCRIPTION
The new script includes all *.png (with a few excluded) and *.jpg files automatically. 