### PR TITLE
cmake: Use cmake -E sha256sum to report sha256 values

### DIFF
--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -163,9 +163,6 @@ steps:
     cmake --build . --target gmt_release_tar
     # Don't use cpack here. Chocolatey also provides a cpack command.
     cmake --build . --target package
-    # get sha256 hash value
-    CertUtil -hashfile gmt-*.tar.gz sha256
-    CertUtil -hashfile gmt-*.tar.xz sha256
-    CertUtil -hashfile gmt-*.exe    sha256
+    cmake -E sha256sum gmt-*.tar.gz gmt-*.tar.xz gmt-*.exe
   displayName: Package GMT
   condition: eq(variables['PACKAGE'], true)


### PR DESCRIPTION
cmake 3.10 (released in 2017) provides the platform independent command
`cmake -E sha256sum` to report sha256 hash values.

It's simpler than the Windows builtin command.