### PR TITLE
CI: Set global variable GMT_END_SHOW to off

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -11,6 +11,11 @@ trigger:
     - 5.4
     - refs/tags/*
 
+# Global variables
+variables:
+  # disable auto-display of GMT plots
+  GMT_END_SHOW: off
+
 jobs:
 
 # Linux - Compile only

--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -76,7 +76,7 @@ steps:
     gmt defaults -Vd
     gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
     gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
-    export GMT_END_SHOW=off && gmt grdimage @earth_relief_60m -JH10c -Baf -pdf map
+    gmt grdimage @earth_relief_60m -JH10c -Baf -pdf map
   displayName: Check a few simple commands
 
 # Run the full tests

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -77,7 +77,7 @@ steps:
     gmt defaults -Vd
     gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
     gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
-    export GMT_END_SHOW=off && gmt grdimage @earth_relief_60m -JH10c -Baf -pdf map
+    gmt grdimage @earth_relief_60m -JH10c -Baf -pdf map
   displayName: Check a few simple commands
 
 # Run the full tests

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -118,7 +118,7 @@ steps:
     gmt defaults -Vd
     gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
     gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
-    setx GMT_END_SHOW off && gmt grdimage @earth_relief_60m -JH10c -Baf -pdf map
+    gmt grdimage @earth_relief_60m -JH10c -Baf -pdf map
   displayName: Check a few simple commands
 
 - bash: |
@@ -138,7 +138,7 @@ steps:
 
 - script: |
     cd doc/examples
-    set GMT_END_SHOW=off && call do_examples.bat
+    call do_examples.bat
   displayName: Run DOS batch examples
   condition: eq(variables['TEST'], true)
   enabled: false


### PR DESCRIPTION
Set global variable GMT_END_SHOW to off, so we don't need to
set the variable every time.