### PR TITLE
cmake: Absolute path of macOS cpack file

### DIFF
--- a/admin/ConfigReleaseBuild.cmake
+++ b/admin/ConfigReleaseBuild.cmake
@@ -22,5 +22,5 @@ set (CMAKE_C_FLAGS "-Wextra ${CMAKE_C_FLAGS}")
 # Include all the external executables and shared libraries
 # The add_macOS_cpack.txt is created by build-release.sh and placed in build
 if (APPLE)
-	set (EXTRA_INCLUDE_EXES "../../build/add_macOS_cpack.txt")
+	set (EXTRA_INCLUDE_EXES "${CMAKE_BINARY_DIR}/add_macOS_cpack.txt")
 endif (APPLE)


### PR DESCRIPTION
The relative path is fragile. Use `${CMAKE_BINARY_DIR}` for absolute path.

It should work, but I can't test it. @PaulWessel Please try it on your machine.