### PR TITLE
cmake: Bump minimum required cmake to 2.8.7 and remove cygwin workaround

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -38,7 +38,7 @@ For package maintainers:
 
 To build GMT, you must install:
 
-- [CMake](https://cmake.org/) (>=2.8.5)
+- [CMake](https://cmake.org/) (>=2.8.7)
 - [netCDF](https://www.unidata.ucar.edu/software/netcdf/) (>=4.0, netCDF-4/HDF5 support mandatory)
 - [curl](https://curl.haxx.se/)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if (${srcdir} STREQUAL ${bindir})
 endif (${srcdir} STREQUAL ${bindir})
 
 # Define minimum CMake version required
-cmake_minimum_required (VERSION 2.8.5)
+cmake_minimum_required (VERSION 2.8.7)
 
 # Use NEW behavior with newer CMake releases
 foreach(p

--- a/doc/examples/CMakeLists.txt
+++ b/doc/examples/CMakeLists.txt
@@ -110,15 +110,6 @@ if (DO_EXAMPLES) # AND UNIX)
 	# this file takes care of setting up the test environment
 	configure_file (gmtest.in gmtest @ONLY)
 
-	# Workaround cmake bug 3957: CRLF line ending
-	find_package (UnixCommands)
-	if (CYGWIN_INSTALL_PATH)
-		find_program (D2U d2u
-			${CYGWIN_INSTALL_PATH}/bin)
-		execute_process (COMMAND ${D2U}
-			${CMAKE_CURRENT_BINARY_DIR}/gmtest)
-	endif (CYGWIN_INSTALL_PATH)
-
 	foreach (_job ${_examples})
 		string (REPLACE "//" "/" _job ${_job})	# GLOB creates double slashes we do not want
 		add_test (NAME ${_job}

--- a/doc/scripts/CMakeLists.txt
+++ b/doc/scripts/CMakeLists.txt
@@ -137,14 +137,6 @@ if (DO_TESTS)
 	# this file takes care of setting up the test environment
 	configure_file (gmtest.in gmtest @ONLY)
 
-	# Workaround cmake bug 3957: CRLF line ending
-	if (CYGWIN_INSTALL_PATH)
-		find_program (D2U d2u
-			${CYGWIN_INSTALL_PATH}/bin)
-		execute_process (COMMAND ${D2U}
-			${CMAKE_CURRENT_BINARY_DIR}/gmtest)
-	endif (CYGWIN_INSTALL_PATH)
-
 	foreach (_job ${_scripts_tests})
 		add_test (NAME ${_job}
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,15 +36,6 @@ if (DO_TESTS)
 
 	configure_file (gmtest.in gmtest @ONLY)
 
-	# Workaround cmake bug 3957: CRLF line ending
-	find_package (UnixCommands)
-	if (CYGWIN_INSTALL_PATH)
-		find_program (D2U d2u
-			${CYGWIN_INSTALL_PATH}/bin)
-		execute_process (COMMAND ${D2U}
-			${CMAKE_CURRENT_BINARY_DIR}/gmtest)
-	endif (CYGWIN_INSTALL_PATH)
-
 	# add tests
 	foreach (_test_dir ${GMT_TEST_DIRS})
 		# find files RELATIVE so that test NAMEs are not absolute paths


### PR DESCRIPTION
CMake bug #3957 (https://cmake.org/Bug/view.php?id=3957) was fixed in cmake 2.8.7 (released in 2012).
Since all supported Linux distros have cmake >= 2.8.7 (e.g. CentOS 6 and
Ubuntu 14.04 provide cmake 2.8.12), we can bump the minimum required cmake
version to 2.8.7 and remove the ugly patch for CYGWIN.