### PR TITLE
Use codesign to identify bundle to GateKeeper

### DIFF
--- a/admin/ConfigReleaseBuild.cmake
+++ b/admin/ConfigReleaseBuild.cmake
@@ -15,6 +15,9 @@ set (GMT_USE_THREADS TRUE)
 set (GMT_ENABLE_OPENMP TRUE)
 set (GMT_PUBLIC_RELEASE TRUE)
 
+set (CPACK_BUNDLE_APPLE_CERT_APP "Developer ID Application: University of Hawaii (B8Y298FMLQ)")
+set (CPACK_BUNDLE_APPLE_CODESIGN_PARAMETER "--deep -f --options runtime")
+
 # recommended even for release build
 set (CMAKE_C_FLAGS "-Wall -Wdeclaration-after-statement ${CMAKE_C_FLAGS}")
 # extra warnings

--- a/admin/ConfigReleaseBuild.cmake
+++ b/admin/ConfigReleaseBuild.cmake
@@ -15,8 +15,10 @@ set (GMT_USE_THREADS TRUE)
 set (GMT_ENABLE_OPENMP TRUE)
 set (GMT_PUBLIC_RELEASE TRUE)
 
-set (CPACK_BUNDLE_APPLE_CERT_APP "Developer ID Application: University of Hawaii (B8Y298FMLQ)")
-set (CPACK_BUNDLE_APPLE_CODESIGN_PARAMETER "--deep -f --options runtime")
+if ($ENV{USER} STREQUAL "pwessel")	# Only do this if Paul is running it
+	set (CPACK_BUNDLE_APPLE_CERT_APP "Developer ID Application: University of Hawaii (B8Y298FMLQ)")
+	set (CPACK_BUNDLE_APPLE_CODESIGN_PARAMETER "--deep -f --options runtime")
+endif
 
 # recommended even for release build
 set (CMAKE_C_FLAGS "-Wall -Wdeclaration-after-statement ${CMAKE_C_FLAGS}")


### PR DESCRIPTION
Not out of the woods yet on this given all the 3rd party things we dont build ourselves.  This will be harder down the road.

Maybe this could go inside an if test checking if the user running the script is pwessel so that others can at least build the bundle for testing?