### PR TITLE
cmake: Simplify cmake script in doc/scripts

### DIFF
--- a/doc/rst/CMakeLists.txt
+++ b/doc/rst/CMakeLists.txt
@@ -38,6 +38,11 @@ if (SPHINX_FOUND)
 		${CMAKE_CURRENT_BINARY_DIR}/source/_verbatim
 		DEPENDS _docs_copy_rst_tree_source)
 
+	add_custom_target (_docs_rst_mkdir_images
+		COMMAND ${CMAKE_COMMAND} -E make_directory
+		${CMAKE_CURRENT_BINARY_DIR}/source/_images
+		DEPENDS _docs_copy_rst_tree_source)
+
 	# clean target
 	add_custom_target (_rst_clean
 		COMMAND ${CMAKE_COMMAND} -E remove_directory

--- a/doc/scripts/CMakeLists.txt
+++ b/doc/scripts/CMakeLists.txt
@@ -15,65 +15,12 @@
 # Contact info: www.generic-mapping-tools.org
 #-------------------------------------------------------------------------------
 
-# Scripts which have to be converted to verbatim (with comments)
-set (_scr_nostrip GMT_App_M_2.sh GMT_App_P_1.sh GMT_App_P_2.sh)
-
-# Scripts which have to be converted to verbatim (without comments)
-set (_scr_strip GMT_-B_custom.sh GMT_-B_time1.sh GMT_-B_time2.sh
-	GMT_-B_time3.sh GMT_-B_time4.sh GMT_-B_time5.sh GMT_-B_time6.sh
-	GMT_-B_time7.sh GMT_albers.sh GMT_App_K_1.sh GMT_App_K_2.sh GMT_App_K_3.sh
-	GMT_App_K_4.sh GMT_App_K_5.sh GMT_App_O_1.sh GMT_App_O_2.sh GMT_App_O_3.sh
-	GMT_App_O_4.sh GMT_App_O_5.sh GMT_App_O_6.sh GMT_App_O_7.sh GMT_App_O_8.sh
-	GMT_App_O_9.sh GMT_az_equidistant.sh GMT_cassini.sh GMT_eckert4.sh
-	GMT_eckert6.sh GMT_equi_cyl.sh GMT_equidistant_conic.sh GMT_gall_stereo.sh
-	GMT_general_cyl.sh GMT_gnomonic.sh GMT_grinten.sh GMT_hammer.sh
-	GMT_lambert_az_hemi.sh GMT_lambert_az_rect.sh GMT_lambert_conic.sh
-	GMT_linear_cal.sh GMT_linear_d.sh GMT_linear.sh GMT_log.sh GMT_mercator.sh
-	GMT_miller.sh GMT_mollweide.sh GMT_obl_merc.sh GMT_orthographic.sh
-	GMT_perspective.sh GMT_polar.sh GMT_polyconic.sh GMT_pow.sh GMT_robinson.sh
-	GMT_sinus_int.sh GMT_sinusoidal.sh GMT_stereographic_general.sh
-	GMT_stereographic_polar.sh GMT_stereographic_rect.sh GMT_stereonets.sh
-	GMT_TM.sh GMT_transverse_merc.sh GMT_winkel.sh
-	GMT_tut_1.sh GMT_tut_2.sh GMT_tut_3.sh GMT_tut_4.sh GMT_tut_5.sh
-	GMT_tut_6.sh GMT_tut_7.sh GMT_tut_8.sh GMT_tut_9.sh GMT_tut_10.sh
-	GMT_tut_11.sh GMT_tut_12.sh GMT_tut_13.sh GMT_tut_14.sh GMT_tut_15.sh
-	GMT_tut_16.sh GMT_tut_17.sh GMT_tut_18.sh GMT_tut_19.sh)
-
-# Scripts that are not used in the documentation (but the figures are)
-# do not include GMT_-U.sh as this would always fail
-set (_scr_other GMT_-B_geo_1.sh GMT_-B_geo_2.sh GMT_-B_linear.sh GMT_-B_log.sh
-	GMT_-B_pow.sh GMT_-B_slanted.sh GMT_-J.sh GMT_-R.sh GMT_-XY.sh
-	GMT_App_E.sh GMT_App_F_stand+_iso+.sh GMT_App_F_symbol_dingbats.sh
-	GMT_App_G.sh GMT_App_J_1.sh GMT_App_J_2.sh GMT_App_J_3.sh GMT_App_M_1a.sh GMT_App_M_1b.sh GMT_App_M_1c.sh
-	GMT_App_N_1.sh GMT_arrows.sh GMT_arrows_types.sh GMT_atan.sh GMT_color_interpolate.sh
-	GMT_chunking.sh GMT_coverlogo.sh GMT_Defaults_1a.sh GMT_Defaults_1b.sh GMT_Defaults_1c.sh
-	GMT_bezier.sh GMT_linecap.sh GMT_lineoffset.sh GMT_nearneighbor.sh GMT_anchor.sh GMT_API_use.sh
-	GMT_API_flow.sh GMT_pstext_clearance.sh GMT_pstext_justify.sh GMT_registration.sh GMT_obl_nz.sh
-	GMT_utm_zones.sh GMT_volcano.sh GMT_panel.sh GMT_mapscale.sh GMT_inset.sh GMT_linearrow.sh
-	GMT_dir_rose.sh GMT_images.sh GMT_colorbar.sh GMT_cyclic.sh GMT_legend.sh GMT_mag_rose.sh
-	GMT_hinge.sh GMT_CPTscale.sh GMT_SRTM.sh GMT_vertscale.sh GMT_fatline.sh GMT_autolegend.sh
-	psevents_intensity.sh psevents_size.sh psevents_transparency.sh)
-
-# Scripts that are only used for testing, figures are not in the documentation
-set (_scr_test GMT_RGBchart.sh)
-# This is no test: GMT_encoding.sh
-
-set (_scripts_tests ${_scr_nostrip} ${_scr_strip} ${_scr_other} ${_scr_test})
-
-set (_scripts_ps2png ${_scr_nostrip} ${_scr_strip} ${_scr_other} GMT_-U.ps GMT_RGBchart.ps)
-string (REPLACE ".sh" ".ps" _scripts_ps2png "${_scripts_ps2png}")
-set (_scripts_ps2pdf GMT_RGBchart_a4.ps GMT_RGBchart_letter.ps GMT_RGBchart_tabloid.ps)
-
-set (_scripts_pdf)
-set (_scripts_png)
-set (_scripts_txt)
-set (_install_pdf GMT_RGBchart_a4.pdf GMT_RGBchart_tabloid.pdf GMT_RGBchart_letter.pdf)
-
 # Convert PS to PNG
+file (GLOB _scripts_ps2png RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*.ps")
+set (_scripts_png)
 foreach (_fig ${_scripts_ps2png})
 	string (REPLACE ".ps" ".png" _png_fig ${_fig})
 	list (APPEND _scripts_png ${RST_BINARY_DIR}/_images/${_png_fig})
-	FILE(MAKE_DIRECTORY ${RST_BINARY_DIR}/_images)
 	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
 		COMMAND ${CMAKE_COMMAND} -E env
 		GMT_USERDIR=${GMT_BINARY_DIR}/share
@@ -83,14 +30,15 @@ foreach (_fig ${_scripts_ps2png})
 		-D${RST_BINARY_DIR}/_images
 		${CMAKE_CURRENT_SOURCE_DIR}/${_fig}
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-		DEPENDS gmt_for_img_convert ${_fig})
+		DEPENDS gmt_for_img_convert _docs_rst_mkdir_images ${_fig})
 endforeach (_fig ${_scripts_ps2png})
 
 # Convert PS to PDF
+set (_scripts_ps2pdf GMT_RGBchart_a4.ps GMT_RGBchart_letter.ps GMT_RGBchart_tabloid.ps)
+set (_scripts_pdf)
 foreach (_fig ${_scripts_ps2pdf})
 	string (REPLACE ".ps" ".pdf" _pdf_fig ${_fig})
 	list (APPEND _scripts_pdf ${RST_BINARY_DIR}/_images/${_pdf_fig})
-	FILE(MAKE_DIRECTORY ${RST_BINARY_DIR}/_images)
 	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_pdf_fig}
 		COMMAND ${CMAKE_COMMAND} -E env
 		GMT_USERDIR=${GMT_BINARY_DIR}/share
@@ -99,26 +47,15 @@ foreach (_fig ${_scripts_ps2pdf})
 		-D${RST_BINARY_DIR}/_images
 		${CMAKE_CURRENT_SOURCE_DIR}/${_fig}
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-		DEPENDS gmt_for_img_convert ${_fig})
+		DEPENDS gmt_for_img_convert _docs_rst_mkdir_images ${_fig})
 endforeach (_fig ${_scripts_ps})
 
-foreach (_script ${_scr_nostrip})
+# Convert script to verbatim txt
+file (GLOB _scripts_sh2txt RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*.sh")
+set (_scripts_txt)
+foreach (_script ${_scripts_sh2txt})
 	string (REPLACE ".sh" ".txt" _txt ${_script})
 	list (APPEND _scripts_txt ${RST_BINARY_DIR}/_verbatim/${_txt})
-	FILE(MAKE_DIRECTORY ${RST_BINARY_DIR}/_verbatim)
-	# Add command that triggers generator macro when output does not exist
-	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_verbatim/${_txt}
-		COMMAND ${GMT_BINARY_DIR}/src/script2verbatim
-		${CMAKE_CURRENT_SOURCE_DIR}/${_script}
-		${RST_BINARY_DIR}/_verbatim/${_txt}
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-		DEPENDS script2verbatim _docs_rst_mkdir_verbatim ${CMAKE_CURRENT_SOURCE_DIR}/${_script})
-endforeach (_script)
-
-foreach (_script ${_scr_strip})
-	string (REPLACE ".sh" ".txt" _txt ${_script})
-	list (APPEND _scripts_txt ${RST_BINARY_DIR}/_verbatim/${_txt})
-	FILE(MAKE_DIRECTORY ${RST_BINARY_DIR}/_verbatim)
 	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_verbatim/${_txt}
 		COMMAND ${GMT_BINARY_DIR}/src/script2verbatim --strip-comments
 		${CMAKE_CURRENT_SOURCE_DIR}/${_script}
@@ -133,13 +70,15 @@ add_custom_target (_docs_html_scripts_fig DEPENDS ${_scripts_png} ${_scripts_pdf
 add_depend_to_target (docs_depends _docs_html_scripts_fig _docs_scripts_verbatim)
 
 # run tests
-if (DO_TESTS)
+file (GLOB _scripts_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*.sh")
+# GMT_-U.sh always fails
+list (REMOVE_ITEM _scripts_tests GMT_-U.sh GMT_encoding.sh gen_data_App_O.sh gen_data_dummy.sh)
+if (DO_TESTS AND BASH)
 	# this file takes care of setting up the test environment
 	configure_file (gmtest.in gmtest @ONLY)
-
 	foreach (_job ${_scripts_tests})
 		add_test (NAME ${_job}
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 			COMMAND ${BASH} gmtest ${_job})
 	endforeach (_job)
-endif (DO_TESTS)
+endif (DO_TESTS AND BASH)


### PR DESCRIPTION
The old cmake script in doc/scripts is too complicated to read.
The bash scripts are manually listed in four groups:

- Scripts which have to be converted to verbatim (with comments)
- Scripts which have to be converted to verbatim (without comments)
- Scripts that are not used in the documentation
- Scripts that are only used for testing

Each time a new script is added, we have to manually add the script to one of the groups.

Currently, the first group is no longer needed, as these scripts are no longer
included in the documentation; for the 3rd group, there is no harm to convert
them to verbatim txt.

This PR simplifies the cmake script by using `file (GLOB)` to match all *.ps or *.sh
files and convert all scripts to verbatim txt.