### PR TITLE
doc: Change link name from "GMT Defaults" to "GMT Default Settings (gmt.conf)"

### DIFF
--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -14,7 +14,7 @@ Quick links
 
    - :doc:`std_opts`
    - :doc:`proj_codes`
-   - :doc:`GMT Defaults <gmt.conf>`
+   - :doc:`GMT Default Settings (gmt.conf) <gmt.conf>`
    - :doc:`GMT Colors <gmtcolors>`
    - :doc:`35 Postscript Fonts </cookbook/postscript_fonts>`
    - :doc:`Built-in CPTs </cookbook/cpts>`


### PR DESCRIPTION
screenshot:
![image](https://user-images.githubusercontent.com/3974108/69396369-096ae800-0cb0-11ea-9567-1555f97d9fd4.png)
