### PR TITLE
cmake: Old cmake doesn't support removing mulitple directories in one command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,15 +104,14 @@ if (GIT_FOUND AND HAVE_GIT_VERSION)
 	# so that they are not included in the final release tarball
 	add_custom_target (git_export_release
 		COMMAND ${GIT_EXECUTABLE} -C ${GMT_SOURCE_DIR} checkout-index -a -f --prefix=${GMT_RELEASE_PREFIX}/
-		COMMAND ${CMAKE_COMMAND} -E remove_directory
-			${GMT_RELEASE_PREFIX}/.git
-			${GMT_RELEASE_PREFIX}/.github
-			${GMT_RELEASE_PREFIX}/admin
-			${GMT_RELEASE_PREFIX}/ci
-			${GMT_RELEASE_PREFIX}/test
-		COMMAND ${CMAKE_COMMAND} -E remove
-			${GMT_RELEASE_PREFIX}/.azure-pipelines.yml
-			${GMT_RELEASE_PREFIX}/.gitignore
+		# cmake<3.15 can't remove multiple directories using cmake -E remove_directory
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${GMT_RELEASE_PREFIX}/.git
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${GMT_RELEASE_PREFIX}/.github
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${GMT_RELEASE_PREFIX}/admin
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${GMT_RELEASE_PREFIX}/ci
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${GMT_RELEASE_PREFIX}/test
+		COMMAND ${CMAKE_COMMAND} -E remove ${GMT_RELEASE_PREFIX}/.azure-pipelines.yml
+		COMMAND ${CMAKE_COMMAND} -E remove ${GMT_RELEASE_PREFIX}/.gitignore
 	)
 	add_depend_to_target (gmt_release git_export_release)
 	find_program (GNUTAR NAMES gnutar gtar tar)

--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -126,6 +126,7 @@ steps:
   condition: and(eq(variables['DEPLOY_DOCS'], true), in(variables['Build.SourceBranchName'], 'master', '6.0'))
 
 - bash: |
+    set -x -e
     cd build
     cmake --build . --target gmt_release
     cmake --build . --target gmt_release_tar

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -119,6 +119,7 @@ steps:
   displayName: Upload test coverage
 
 - bash: |
+    set -x -e
     cd build
     cmake --build . --target gmt_release
     cmake --build . --target gmt_release_tar

--- a/doc/rst/CMakeLists.txt
+++ b/doc/rst/CMakeLists.txt
@@ -45,15 +45,15 @@ if (SPHINX_FOUND)
 
 	# clean target
 	add_custom_target (_rst_clean
-		COMMAND ${CMAKE_COMMAND} -E remove_directory
-		${CMAKE_CURRENT_BINARY_DIR}/_doctrees
-		${CMAKE_CURRENT_BINARY_DIR}/_extensions
-		${CMAKE_CURRENT_BINARY_DIR}/_static
-		${CMAKE_CURRENT_BINARY_DIR}/_templates
-		${CMAKE_CURRENT_BINARY_DIR}/source
-		${CMAKE_CURRENT_BINARY_DIR}/themes
-		${CMAKE_CURRENT_BINARY_DIR}/html
-		${CMAKE_CURRENT_BINARY_DIR}/man
+		# cmake<3.15 can't remove multiple directories using cmake -E remove_directory
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/_doctrees
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/_extensions
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/_static
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/_templates
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/source
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/themes
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/html
+		COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/man
 		COMMENT "Removing rst tree")
 	# register with spotless target
 	add_depend_to_target (spotless _rst_clean)


### PR DESCRIPTION
Revert some changes in #1977 