### PR TITLE
doc: Clarify difference between png and PNG

### DIFF
--- a/doc/rst/source/begin.rst
+++ b/doc/rst/source/begin.rst
@@ -73,27 +73,19 @@ Supported Graphic Formats
 
 .. _tbl-formats:
 
-    +--------+-----------------------------------------+
-    | Format | Explanation                             |
-    +========+=========================================+
-    |  bmp   | Microsoft Bit Map                       |
-    +--------+-----------------------------------------+
-    |  eps   | Encapsulated PostScript                 |
-    +--------+-----------------------------------------+
-    |  jpg   | Joint Photographic Experts Group Format |
-    +--------+-----------------------------------------+
-    |  pdf   | Portable Document Format [Default]      |
-    +--------+-----------------------------------------+
-    |  png   | Portable Network Graphics (opaque)      |
-    +--------+-----------------------------------------+
-    |  PNG   | Portable Network Graphics (transparent) |
-    +--------+-----------------------------------------+
-    |  ppm   | Portable Pixel Map                      |
-    +--------+-----------------------------------------+
-    |   ps   | Plain PostScript                        |
-    +--------+-----------------------------------------+
-    |  tif   | Tagged Image Format File                |
-    +--------+-----------------------------------------+
+====== ===================================================
+Format Explanation
+====== ===================================================
+bmp    Microsoft Bit Map
+eps    Encapsulated PostScript
+jpg    Joint Photographic Experts Group Format
+pdf    Portable Document Format [Default]
+png    Portable Network Graphics (opaque background)
+PNG    Portable Network Graphics (transparent background)
+ppm    Portable Pixel Map
+ps     Plain PostScript
+tif    Tagged Image Format File
+====== ===================================================
 
 Examples
 --------

--- a/src/begin.c
+++ b/src/begin.c
@@ -49,8 +49,8 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     eps:	Encapsulated PostScript.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     jpg:	Joint Photographic Experts Group format.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     pdf:	Portable Document Format [Default].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     png:	Portable Network Graphics (opaque).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     PNG:	Portable Network Graphics (transparent).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     png:	Portable Network Graphics (opaque background).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     PNG:	Portable Network Graphics (transparent background).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     ppm:	Portable Pixel Map.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     ps:	PostScript.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     tif:	Tagged Image Format File.\n");

--- a/src/figure.c
+++ b/src/figure.c
@@ -50,8 +50,8 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     eps:	Encapsulated PostScript.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     jpg:	Joint Photographic Experts Group format.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     pdf:	Portable Document Format [Default].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     png:	Portable Network Graphics (opaque).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     PNG:	Portable Network Graphics (transparent).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     png:	Portable Network Graphics (opaque background).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     PNG:	Portable Network Graphics (transparent background).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     ppm:	Portable Pixel Map.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     ps:	PostScript.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     tif:	Tagged Image Format File.\n");


### PR DESCRIPTION
For a long time, I thought the diffrence between png and PNG is that
PNG support tranparency while png doesn't. But that's not true.
The only difference is that the background is opaque (white) or transparent.

In this PR, I make small changes to clarify that.