### PR TITLE
doc: Fix docs of gmt-config and clear

### DIFF
--- a/doc/rst/source/clear.rst
+++ b/doc/rst/source/clear.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt clear** **all** \| **cache** \| **defaults** \| **data** \| **sessions**
+**gmt clear** **all** \| **cache** \| **data** \| **sessions** \| **settings**
 [ |SYN_OPT-V| ]
 
 |No-spaces|
@@ -31,11 +31,6 @@ Optional Arguments
 **all**
     Deletes all the items under the control of the individual targets.
 
-.. _clear-defaults:
-
-**defaults**
-    Delete the current defaults (gmt.conf) file used for the current modern session.
-
 .. _clear-cache:
 
 **cache**
@@ -51,6 +46,11 @@ Optional Arguments
 **sessions**
     Delete the user's sessions directory.
 
+.. _clear-settings:
+
+**settings**
+    Delete the current default settings file (gmt.conf) used for the current modern session.
+
 .. _-V:
 
 .. |Add_-V| unicode:: 0x20 .. just an invisible code
@@ -63,7 +63,7 @@ Examples
 
 To remove the current default settings in a modern mode session, use::
 
-    gmt clear defaults
+    gmt clear settings
 
 To completely wipe your GMT cache directory, try::
 

--- a/doc/rst/source/gmt-config.rst
+++ b/doc/rst/source/gmt-config.rst
@@ -11,11 +11,7 @@ gmt-config
 Synopsis
 --------
 
-.. include:: common_SYN_OPTs.rst_
-
 **gmt-config** [ *options* ]
-
-|No-spaces|
 
 Description
 -----------
@@ -95,18 +91,14 @@ Optional Arguments
 **--version**
     The library version
 
-
 Examples
 --------
-
 
 To Determine the compiler flags that is required for an external to to find the GMT function prototypes, try::
 
     gmt-config --cflags
 
-
 See Also
 --------
 
 :doc:`gmt`
-

--- a/src/clear.c
+++ b/src/clear.c
@@ -20,7 +20,7 @@
  * Version:	6 API
  *
  * Brief synopsis: gmt clear cleans up by removing files or dirs.
- *	gmt clear [all | cache | defaults | data | sessions ]
+ *	gmt clear [all | cache | data | sessions | settings ]
  */
 
 #include "gmt_dev.h"
@@ -51,7 +51,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   all       All of the above.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Option (API, "V,;");
-	
+
 	return (GMT_MODULE_USAGE);
 }
 
@@ -66,7 +66,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
 		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "No target specified\n");
 		n_errors++;
 	}
-	
+
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
 
@@ -158,7 +158,7 @@ int GMT_clear (void *V_API, int mode, void *args) {
 
 	for (opt = options; opt; opt = opt->next) {
 		if (opt->option != GMT_OPT_INFILE) continue;	/* action target will appear as file name */
-		
+
 		n_given++;
 		if (!strcmp (opt->arg, "all")) {	/* Clear all */
 			if (clear_cache (API))
@@ -198,6 +198,6 @@ int GMT_clear (void *V_API, int mode, void *args) {
 		GMT_Report (API, GMT_MSG_NORMAL, "No clear target given\n");
 		Return (GMT_RUNTIME_ERROR);
 	}
-		
+
 	Return (error);
 }


### PR DESCRIPTION
`gmt clear settings` is the recommended way to remove "gmt.conf", although `gmt clear conf` and `gmt clear defaults` are also supported.