### PR TITLE
Fix FFTW_ESTIMATE undeclared error if FFTW is not available

### DIFF
--- a/src/gmt_fft.c
+++ b/src/gmt_fft.c
@@ -1675,7 +1675,9 @@ int GMT_FFT_2D (void *V_API, gmt_grdfloat *data, unsigned int n_columns, unsigne
 
 void gmt_fft_initialization (struct GMT_CTRL *GMT) {
 	/* Called by gmt_begin and sets up pointers to the available FFT calls */
+#ifdef HAVE_FFTW3F
 	GMT->current.setting.fftw_plan = FFTW_ESTIMATE; /* default planner flag [only accessed if FFTW is compiled in] */
+#endif /* HAVE_FFTW3F */
 #if defined HAVE_FFTW3F_THREADS
 	int n_cpu = gmtlib_get_num_processors();
 


### PR DESCRIPTION
If FFTW is not enabled, compilation reports an error:

```
src/gmt_fft.c:1678:35: error: ‘FFTW_ESTIMATE’ undeclared (first use in this function)
  GMT->current.setting.fftw_plan = FFTW_ESTIMATE; /* default planner flag [only accessed if FFTW is compiled in] */
                                   ^~~~~~~~~~~~~
src/gmt_fft.c:1678:35: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [src/CMakeFiles/gmtlib.dir/gmt_fft.c.o] Error 1
make[1]: *** [src/CMakeFiles/gmtlib.dir/all] Error 2
```