### PR TITLE
doc: Fix the description of psmeca and pscoupe -Sm|d|z

### DIFF
--- a/doc/rst/source/supplements/seis/explain_meca_-S.rst_
+++ b/doc/rst/source/supplements/seis/explain_meca_-S.rst_
@@ -80,16 +80,15 @@
 
 **-Sm\|d\|z**\ *scale*\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
 
-    Seismic moment tensor (Global CMT, with zero trace). *scale* adjusts
+    Seismic moment tensor. *scale* adjusts
     the scaling of the radius of the "beach ball", which will be
     proportional to the magnitude. *scale* is the size for magnitude = 5
     (that is scalar seismic moment = 4.0E23 dynes-cm).
     **-T**\ *0* option overlays best double couple transparently.
-    Use **-Sm** to plot the Global CMT
-    seismic moment tensor with zero trace. Use **-Sd** to plot only the
-    double couple part of moment tensor. Use **-Sz** to plot the anisotropic
-    part of moment tensor (zero trace). The color or shade of the
-    compressive quadrants can be specified with the **-G** option. The color
+    Use **-Sm** to plot the full seismic moment tensor (i.e. isotropic + double couple + CLVD parts).
+    Use **-Sd** to plot only the double couple part of moment tensor.
+    Use **-Sz** to plot the anisotropic part of moment tensor (zero trace, i.e. double couple + CLVD parts).
+    The color or shade of the compressive quadrants can be specified with the **-G** option. The color
     or shade of the extensive quadrants can be specified with the **-E** option.
     Append **+f**\ *font* to change the font of the text string;
     append **+j**\ *justify* to change the text location relative to the beachball

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -450,12 +450,12 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   c  Focal mechanisms in Global CMT convention\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth strike1 dip1 rake1 strike2 dip2 rake2 moment [newX newY] [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      with moment in 2 columns : mantissa and exponent corresponding to seismic moment in dynes-cm\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   d  Best double couple defined from seismic moment tensor (Global CMT, with zero trace):\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   d  Best double couple defined from seismic moment tensor:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp [newX newY] [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   p  Focal mechanism defined with:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth strike1 dip1 strike2 fault mag [newX newY] [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      fault = -1/+1 for a normal/inverse fault\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   m  Seismic moment tensor (Global CMT, with zero trace):\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   m  Seismic moment tensor (ISO + DC + CLVD):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp [newX newY] [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   t  Zero trace moment tensor defined from principal axis:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth T_value T_azim T_plunge N_value N_azim N_plunge P_value P_azim P_plunge exp [newX newY] [event_title]\n");
@@ -463,7 +463,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth T_value T_azim T_plunge N_value N_azim N_plunge P_value P_azim P_plunge exp [newX newY] [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   y  Best double couple defined from principal axis:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth T_value T_azim T_plunge N_value N_azim N_plunge P_value P_azim P_plunge exp [newX newY] [event_title]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   z  Anisotropic part of seismic moment tensor (Global CMT, with zero trace):\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   z  Anisotropic part of seismic moment tensor (i.e. DC + CLVD):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp [newX] [newY] [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally add +f<font>+j<justify>+o<dx>[/<dy>] to change the label font, location and offset.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   fontsize < 0 : no label written; offset is from the limit of the beach ball.\n");

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -187,12 +187,12 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   c  Focal mechanisms in Global CMT convention\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth strike1 dip1 rake1 strike2 dip2 rake2 moment [newX newY] [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      with moment in 2 columns : mantissa and exponent corresponding to seismic moment in dynes-cm\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   d  Best double couple defined from seismic moment tensor (Global CMT, with zero trace):\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   d  Best double couple defined from seismic moment tensor:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp [newX newY] [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   p  Focal mechanism defined with:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth strike1 dip1 strike2 fault mag [newX newY] [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      fault = -1/+1 for a normal/inverse fault\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   m  Seismic moment tensor (Global CMT, with zero trace):\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   m  Seismic moment tensor (ISO + DC + CLVD):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp [newX newY] [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   t  Zero trace moment tensor defined from principal axis:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth T_value T_azim T_plunge N_value N_azim N_plunge P_value P_azim P_plunge exp [newX newY] [event_title]\n");
@@ -200,7 +200,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth T_value T_azim T_plunge N_value N_azim N_plunge P_value P_azim P_plunge exp [newX newY] [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   y  Best double couple defined from principal axis:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth T_value T_azim T_plunge N_value N_azim N_plunge P_value P_azim P_plunge exp [newX newY] [event_title]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   z  Anisotropic part of seismic moment tensor (Global CMT, with zero trace):\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   z  Anisotropic part of seismic moment tensor (i.e. DC + CLVD):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp [newX newY] [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use -Fo option for old (psvelomeca) format (no depth in third column).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally add +f<font>+j<justify>+o<dx>[/<dy>] to change the label font, location and offset.\n");


### PR DESCRIPTION
As I understant it, a full seismic moment tensor can be decomposed into three
parts: isotropic (ISO) + double couple (DC) and compensated linear vector dipole (CLVD).
Of course, there are many different ways to decompose a moment tensor, but the
ISO + DC + CLVD decomposition is the most simple/used one.

The old documentation of psmeca says:

```
Use -Sm to plot the Global CMT seismic moment tensor with zero trace.
Use -Sd to plot only the double couple part of moment tensor.
Use -Sz to plot the anisotropic part of moment tensor (zero trace).
```

For a long time, I was confused about the difference between **-Sm** and **-Sz**. After reading the source codes and some tests, I think the above documentation is misleading and even wrong.
I believe the correct description is:

- **-Sm** plots the full moment tensor (ISO + DC + CLVD)
- **-Sz** plots the anisotropic part of moment tensor (DC + CLVD)
- **-Sd** plots the double couple part of the moment tensor (DC)

For the Global CMT solution, the ISO part is always zero (i.e. with zero trace),
**-Sm** and **-Sd** gives the same result.

This PR fixes the description of **-Sm|d|z**.

@carltape I'd appreciate it if you could help check if my understanding is correct.