### PR TITLE
Not an error of hash file cannot be reached

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -247,15 +247,15 @@ GMT_LOCAL int gmthash_get_url (struct GMT_CTRL *GMT, char *url, char *file, char
 	if ((curl_err = curl_easy_perform (Curl))) {	/* Failed, give error message */
 		end = time (NULL);
 		time_spent = (long)(end - begin);
-		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unable to download file %s\n", url);
-		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Libcurl Error: %s\n", curl_easy_strerror (curl_err));
+		GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Unable to download file %s\n", url);
+		GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Libcurl Error: %s\n", curl_easy_strerror (curl_err));
 		if (urlfile.fp != NULL) {
 			fclose (urlfile.fp);
 			urlfile.fp = NULL;
 		}
 		if (time_spent >= GMT_HASH_TIME_OUT) {	/* Ten seconds is too long time - server down? */
-			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "GMT data server may be down - delay checking hash file for 24 hours\n");
-			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "You can turn remote file download off by setting GMT_DATA_SERVER_LIMIT = 0.\n");
+			GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "GMT data server may be down - delay checking hash file for 24 hours\n");
+			GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "You can turn remote file download off by setting GMT_DATA_SERVER_LIMIT = 0.\n");
 			if (orig && !access (orig, F_OK)) {	/* Refresh modification time of original hash file */
 #ifdef WIN32
 				_utime (orig, NULL);
@@ -340,7 +340,7 @@ GMT_LOCAL int hash_refresh (struct GMT_CTRL *GMT) {
 		snprintf (url, PATH_MAX, "%s/gmt_hash_server.txt", GMT->session.DATASERVER);
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Download remote file %s for the first time\n", url);
 		if (gmthash_get_url (GMT, url, hashpath, NULL)) {
-			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Failed to get remote file %s\n", url);
+			GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Failed to get remote file %s\n", url);
 			if (!access (hashpath, F_OK)) gmt_remove_file (GMT, hashpath);	/* Remove hash file just in case it got corrupted or zero size */
 			GMT->current.setting.auto_download = GMT_NO_DOWNLOAD;		/* Temporarily turn off auto download in this session only */
 			GMT->current.io.internet_error = true;				/* No point trying again */
@@ -515,7 +515,7 @@ unsigned int gmt_download_file_if_not_found (struct GMT_CTRL *GMT, const char* f
 	}
 
 	if (hash_refresh (GMT)) {	/* Watch out for changes on the server once a day */
-		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Unable to obtain remote file %s\n", file);
+		GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Unable to obtain remote file %s\n", file);
 		gmt_M_free (GMT, file);
 		return 1;
 	}


### PR DESCRIPTION
See issue #2119.  If we cannot update the hash table we can still use the cached data files so this should not be an error; changed to long verbose message.
