### PR TITLE
Add new --show-classic option to gmt

### DIFF
--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -85,6 +85,9 @@ If no module is given then several other options are available:
 **--show-citation**
     Show the citation for the latest GMT publication.
 
+**--show-classic**
+    List classic module names on stdout and exit.
+
 **--show-cores**
     Show number of available cores.
 
@@ -98,7 +101,7 @@ If no module is given then several other options are available:
     Show the DOI of the current release.
 
 **--show-modules**
-    List module names on stdout and exit.
+    List modern module names on stdout and exit.
 
 **--show-library**
     Show the path of the shared GMT library.

--- a/share/tools/gmt_aliases.csh
+++ b/share/tools/gmt_aliases.csh
@@ -16,7 +16,7 @@ if ($? == 1) then
   exit 1
 endif
 
-set gmt_modules = (`gmt --show-modules`)
+set gmt_modules = (`gmt --show-classic`)
 set compat_modules = (minmax gmtstitch gmtdp grdreformat ps2raster originator)
 
 foreach module ( $gmt_modules $compat_modules )

--- a/share/tools/gmt_functions.sh
+++ b/share/tools/gmt_functions.sh
@@ -20,7 +20,7 @@ if ! [ -x "$(command -v gmt)" ]; then
   exit 1
 fi
 
-gmt_modules=`gmt --show-modules`
+gmt_modules=`gmt --show-classic`
 compat_modules="minmax gmtstitch gmtdp grdreformat ps2raster originator"
 
 for module in ${gmt_modules} ${compat_modules}; do

--- a/share/tools/gmt_links.sh
+++ b/share/tools/gmt_links.sh
@@ -33,7 +33,7 @@ fi
 bin=`gmt --show-bindir`
 cwd=`pwd`
 
-gmt_modules=`gmt --show-modules`
+gmt_modules=`gmt --show-classic`
 compat_modules="minmax gmtstitch gmtdp grdreformat ps2raster originator"
 
 cd $bin

--- a/src/gmt.c
+++ b/src/gmt.c
@@ -140,9 +140,15 @@ int main (int argc, char *argv[]) {
 				status = GMT_NOERROR;
 			}
 
-			/* Print all modules and exit */
+			/* Print all modern modules and exit */
 			else if (!strncmp (argv[arg_n], "--show-modules", 8U)) {
 				GMT_Call_Module (api_ctrl, NULL, GMT_MODULE_LIST, NULL);
+				status = GMT_NOERROR;
+			}
+
+			/* Print all classic modules and exit */
+			else if (!strncmp (argv[arg_n], "--show-classic", 8U)) {
+				GMT_Call_Module (api_ctrl, NULL, GMT_MODULE_CLASSIC, NULL);
 				status = GMT_NOERROR;
 			}
 
@@ -294,11 +300,12 @@ int main (int argc, char *argv[]) {
 			fprintf (stderr, "                    Optionally specify bash|csh|batch [Default is current shell]\n");
 			fprintf (stderr, "  --show-bindir     Show directory with GMT executables.\n");
 			fprintf (stderr, "  --show-citation   Show the most recent citation for GMT.\n");
+			fprintf (stderr, "  --show-classic    Show all classic module names.\n");
 			fprintf (stderr, "  --show-cores      Show number of available cores.\n");
 			fprintf (stderr, "  --show-datadir    Show directory/ies with user data.\n");
 			fprintf (stderr, "  --show-dataserver Show URL of the remote GMT data server.\n");
 			fprintf (stderr, "  --show-doi        Show the DOI for the current release.\n");
-			fprintf (stderr, "  --show-modules    Show all module names.\n");
+			fprintf (stderr, "  --show-modules    Show all modern module names.\n");
 			fprintf (stderr, "  --show-library    Show path of the shared GMT library.\n");
 			fprintf (stderr, "  --show-plugindir  Show directory for plug-ins.\n");
 			fprintf (stderr, "  --show-sharedir   Show directory for shared GMT resources.\n");

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -10048,7 +10048,7 @@ int GMT_Call_Module (void *V_API, const char *module, int mode, void *args) {
 	int status = GMT_NOERROR;
 	unsigned int lib;
 	struct GMTAPI_CTRL *API = NULL;
-	char gmt_module[GMT_LEN32] = "GMT_";
+	char gmt_module[GMT_LEN64] = "GMT_";
 	int (*p_func)(void*, int, void*) = NULL;       /* function pointer */
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
@@ -10064,7 +10064,7 @@ int GMT_Call_Module (void *V_API, const char *module, int mode, void *args) {
 
 		/* Here we list purpose of all the available modules in each shared library */
 		for (lib = 0; lib < API->n_shared_libs; lib++) {
-			snprintf (gmt_module, GMT_LEN32, "gmt_%s_module_%s_all", API->lib[lib].name, listfunc);
+			snprintf (gmt_module, GMT_LEN64, "gmt_%s_module_%s_all", API->lib[lib].name, listfunc);
 			*(void **) (&l_func) = api_get_module_func (API, gmt_module, lib);
 			if (l_func == NULL) continue;	/* Not found in this shared library */
 			(*l_func) (V_API);	/* Run this function */
@@ -10074,7 +10074,7 @@ int GMT_Call_Module (void *V_API, const char *module, int mode, void *args) {
 
 	/* Here we call a named module */
 
-	strncat (gmt_module, module, GMT_LEN32-5);		/* Concatenate GMT_-prefix and module name to get function name */
+	strncat (gmt_module, module, GMT_LEN64-5);		/* Concatenate GMT_-prefix and module name to get function name */
 	for (lib = 0; lib < API->n_shared_libs; lib++) {	/* Look for gmt_module in any of the shared libs */
 		*(void **) (&p_func) = api_get_module_func (API, gmt_module, lib);
 		if (p_func) break;	/* Found it in this shared library */
@@ -10082,8 +10082,8 @@ int GMT_Call_Module (void *V_API, const char *module, int mode, void *args) {
 	if (p_func == NULL) {	/* Not in any of the shared libraries */
 		status = GMT_NOT_A_VALID_MODULE;	/* Most likely, but we will try again: */
 		if (strncasecmp (module, "gmt", 3)) {	/* For any module not already starting with "gmt..." */
-			char gmt_module[GMT_LEN32] = "gmt";
-			strncat (gmt_module, module, GMT_LEN32-4);	/* Prepend "gmt" to module and try again */
+			char gmt_module[GMT_LEN64] = "gmt";
+			strncat (gmt_module, module, GMT_LEN64-4);	/* Prepend "gmt" to module and try again */
 			status = GMT_Call_Module (V_API, gmt_module, mode, args);	/* Recursive call to try with the 'gmt' prefix this time */
 		}
 	}

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -10037,7 +10037,8 @@ GMT_LOCAL void *api_get_module_func (struct GMTAPI_CTRL *API, const char *module
 int GMT_Call_Module (void *V_API, const char *module, int mode, void *args) {
 	/* Call the specified shared module and pass it the mode and args.
  	 * mode can be one of the following:
-	 * GMT_MODULE_LIST [-4]:	As GMT_MODULE_PURPOSE, but only lists the modules.
+	 * GMT_MODULE_CLASSIC [-5]:	As GMT_MODULE_PURPOSE, but only lists the classic modules.
+	 * GMT_MODULE_LIST [-4]:	As GMT_MODULE_PURPOSE, but only lists the modern modules.
 	 * GMT_MODULE_EXIST [-3]:	Return GMT_NOERROR (0) if module exists, GMT_NOT_A_VALID_MODULE otherwise.
 	 * GMT_MODULE_PURPOSE [-2]:	As GMT_MODULE_EXIST, but also print the module purpose.
 	 * GMT_MODULE_OPT [-1]:		Args is a linked list of option structures.
@@ -10051,14 +10052,14 @@ int GMT_Call_Module (void *V_API, const char *module, int mode, void *args) {
 	int (*p_func)(void*, int, void*) = NULL;       /* function pointer */
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
-	if (module == NULL && !(mode == GMT_MODULE_LIST || mode == GMT_MODULE_PURPOSE))
+	if (module == NULL && !(mode == GMT_MODULE_LIST || mode == GMT_MODULE_CLASSIC || mode == GMT_MODULE_PURPOSE))
 		return_error (V_API, GMT_ARG_IS_NULL);
 	API = api_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 
 	if (module == NULL) {	/* Did not specify any specific module, so list purpose of all modules in all shared libs */
 		char gmt_module[GMT_LEN256] = {""};	/* To form name of gmt_<lib>_module_show|list_all function */
-		char *listfunc = (mode == GMT_MODULE_LIST) ? "list" : "show";
+		char *listfunc = (mode == GMT_MODULE_LIST) ? "list" : ( (mode == GMT_MODULE_CLASSIC) ? "classic" : "show");
 		void (*l_func)(void*);       /* function pointer to gmt_<lib>_module_show|list_all which takes one arg (the API) */
 
 		/* Here we list purpose of all the available modules in each shared library */

--- a/src/gmt_core_module.c
+++ b/src/gmt_core_module.c
@@ -297,7 +297,7 @@ void gmt_core_module_classic_all (void *V_API) {
 	unsigned int module_id = 0;
 	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);
 	while (g_core_module[module_id].cname != NULL) {
-		if (API->external || !skip_this_module (g_core_module[module_id].cname) || !skip_modern_module (g_core_module[module_id].cname))
+		if (API->external || !(skip_this_module (g_core_module[module_id].cname) || skip_modern_module (g_core_module[module_id].cname)))
 			printf ("%s\n", g_core_module[module_id].cname);
 		++module_id;
 	}

--- a/src/gmt_core_module.c
+++ b/src/gmt_core_module.c
@@ -246,6 +246,19 @@ GMT_LOCAL int skip_this_module (const char *name) {
 	return 0;	/* Display this one */
 }
 
+/* Function to exclude modern mode modules from being reported by gmt --show-classic */
+GMT_LOCAL int skip_modern_module (const char *name) {
+	if (!strncmp (name, "subplot", 7U)) return 1;	/* Skip the subplot module */
+	if (!strncmp (name, "figure", 6U)) return 1;	/* Skip the figure module */
+	if (!strncmp (name, "begin", 5U)) return 1;		/* Skip the begin module */
+	if (!strncmp (name, "clear", 5U)) return 1;		/* Skip the clear module */
+	if (!strncmp (name, "inset", 5U)) return 1;		/* Skip the inset module */
+	if (!strncmp (name, "movie", 5U)) return 1;		/* Skip the movie module */
+	if (!strncmp (name, "docs", 4U)) return 1;		/* Skip the docs module */
+	if (!strncmp (name, "end", 3U)) return 1;		/* Skip the end module */
+	return 0;	/* Display this one */
+}
+
 /* Pretty print all GMT core module names and their purposes for gmt --help */
 void gmt_core_module_show_all (void *V_API) {
 	unsigned int module_id = 0;
@@ -275,6 +288,17 @@ void gmt_core_module_list_all (void *V_API) {
 	while (g_core_module[module_id].cname != NULL) {
 		if (API->external || !skip_this_module (g_core_module[module_id].cname))
 			printf ("%s\n", g_core_module[module_id].mname);
+		++module_id;
+	}
+}
+
+/* Produce single list on stdout of all GMT core module names for gmt --show-classic [i.e., classic mode names] */
+void gmt_core_module_classic_all (void *V_API) {
+	unsigned int module_id = 0;
+	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);
+	while (g_core_module[module_id].cname != NULL) {
+		if (API->external || !skip_this_module (g_core_module[module_id].cname) || !skip_modern_module (g_core_module[module_id].cname))
+			printf ("%s\n", g_core_module[module_id].cname);
 		++module_id;
 	}
 }

--- a/src/gmt_core_module.h
+++ b/src/gmt_core_module.h
@@ -119,8 +119,10 @@ EXTERN_MSC int GMT_xyz2grd (void *API, int mode, void *args);
 
 /* Pretty print all modules in the GMT core library and their purposes */
 EXTERN_MSC void gmt_core_module_show_all (void *API);
-/* List all modules in the GMT core library to stdout */
+/* List all modern modules in the GMT core library to stdout */
 EXTERN_MSC void gmt_core_module_list_all (void *API);
+/* List all classic modules in the GMT core library to stdout */
+EXTERN_MSC void gmt_core_module_classic_all (void *API);
 /* Function called by GMT_Encode_Options so developers can get information about a module */
 EXTERN_MSC const char * gmt_core_module_keys (void *API, char *candidate);
 /* Function returns name of group that module belongs to (core, spotter, etc.) */

--- a/src/gmt_enum_dict.h
+++ b/src/gmt_enum_dict.h
@@ -20,7 +20,7 @@
  * Rerun gmt_make_enum_dicts.sh after adding or changing enums.
  *
  * Author:      Paul Wessel
- * Date:        30-October-2019
+ * Date:        23-November-2019
  * Version:     6 API
  */
 
@@ -29,7 +29,7 @@ struct GMT_API_DICT {
 	int value;
 };
 
-#define GMT_N_API_ENUMS 222
+#define GMT_N_API_ENUMS 223
 
 GMT_LOCAL struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_ADD_DEFAULT", 6},
@@ -152,12 +152,13 @@ GMT_LOCAL struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_LOG_ONCE", 1},
 	{"GMT_LOG_SET", 2},
 	{"GMT_LONG", 6},
+	{"GMT_MODULE_CLASSIC", -5},
 	{"GMT_MODULE_CMD", 0},
 	{"GMT_MODULE_EXIST", -3},
 	{"GMT_MODULE_LIST", -4},
 	{"GMT_MODULE_PURPOSE", -2},
-	{"GMT_MODULE_SYNOPSIS", -5},
-	{"GMT_MODULE_USAGE", -6},
+	{"GMT_MODULE_SYNOPSIS", -6},
+	{"GMT_MODULE_USAGE", -7},
 	{"GMT_MSG_COMPAT", 3},
 	{"GMT_MSG_DEBUG", 6},
 	{"GMT_MSG_LONG_VERBOSE", 5},

--- a/src/gmt_make_module_src.sh
+++ b/src/gmt_make_module_src.sh
@@ -113,8 +113,10 @@ cat << EOF >> ${FILE_GMT_MODULE_H}
 
 /* Pretty print all modules in the GMT ${L_TAG} library and their purposes */
 EXTERN_MSC void gmt_${L_TAG}_module_show_all (void *API);
-/* List all modules in the GMT ${L_TAG} library to stdout */
+/* List all modern modules in the GMT ${L_TAG} library to stdout */
 EXTERN_MSC void gmt_${L_TAG}_module_list_all (void *API);
+/* List all classic modules in the GMT ${L_TAG} library to stdout */
+EXTERN_MSC void gmt_${L_TAG}_module_classic_all (void *API);
 /* Function called by GMT_Encode_Options so developers can get information about a module */
 EXTERN_MSC const char * gmt_${L_TAG}_module_keys (void *API, char *candidate);
 /* Function returns name of group that module belongs to (core, spotter, etc.) */
@@ -260,6 +262,19 @@ GMT_LOCAL int skip_this_module (const char *name) {
 	if (!strncmp (name, "gmtwrite", 8U)) return 1;	/* Skip the gmtwrite module */
 	return 0;	/* Display this one */
 }
+
+/* Function to exclude modern mode modules from being reported by gmt --show-classic */
+GMT_LOCAL int skip_modern_module (const char *name) {
+	if (!strncmp (name, "subplot", 7U)) return 1;	/* Skip the subplot module */
+	if (!strncmp (name, "figure", 6U)) return 1;	/* Skip the figure module */
+	if (!strncmp (name, "begin", 5U)) return 1;		/* Skip the begin module */
+	if (!strncmp (name, "clear", 5U)) return 1;		/* Skip the clear module */
+	if (!strncmp (name, "inset", 5U)) return 1;		/* Skip the inset module */
+	if (!strncmp (name, "movie", 5U)) return 1;		/* Skip the movie module */
+	if (!strncmp (name, "docs", 4U)) return 1;		/* Skip the docs module */
+	if (!strncmp (name, "end", 3U)) return 1;		/* Skip the end module */
+	return 0;	/* Display this one */
+}
 EOF
 fi
 cat << EOF >> ${FILE_GMT_MODULE_C}
@@ -331,6 +346,37 @@ EOF
 else
 		cat << EOF >> ${FILE_GMT_MODULE_C}
 		printf ("%s\n", g_${L_TAG}_module[module_id].mname);
+EOF
+fi
+cat << EOF >> ${FILE_GMT_MODULE_C}
+		++module_id;
+	}
+}
+
+/* Produce single list on stdout of all GMT ${L_TAG} module names for gmt --show-classic [i.e., classic mode names] */
+void gmt_${L_TAG}_module_classic_all (void *V_API) {
+	unsigned int module_id = 0;
+EOF
+if [ "$U_TAG" = "CORE" ]; then
+	cat << EOF >> ${FILE_GMT_MODULE_C}
+	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);
+EOF
+else
+	cat << EOF >> ${FILE_GMT_MODULE_C}
+	gmt_M_unused(V_API);
+EOF
+fi
+cat << EOF >> ${FILE_GMT_MODULE_C}
+	while (g_${L_TAG}_module[module_id].cname != NULL) {
+EOF
+if [ "$U_TAG" = "CORE" ]; then
+		cat << EOF >> ${FILE_GMT_MODULE_C}
+		if (API->external || !skip_this_module (g_${L_TAG}_module[module_id].cname) || !skip_modern_module (g_${L_TAG}_module[module_id].cname))
+			printf ("%s\n", g_${L_TAG}_module[module_id].cname);
+EOF
+else
+		cat << EOF >> ${FILE_GMT_MODULE_C}
+		printf ("%s\n", g_${L_TAG}_module[module_id].cname);
 EOF
 fi
 cat << EOF >> ${FILE_GMT_MODULE_C}

--- a/src/gmt_make_module_src.sh
+++ b/src/gmt_make_module_src.sh
@@ -371,7 +371,7 @@ cat << EOF >> ${FILE_GMT_MODULE_C}
 EOF
 if [ "$U_TAG" = "CORE" ]; then
 		cat << EOF >> ${FILE_GMT_MODULE_C}
-		if (API->external || !skip_this_module (g_${L_TAG}_module[module_id].cname) || !skip_modern_module (g_${L_TAG}_module[module_id].cname))
+		if (API->external || !(skip_this_module (g_${L_TAG}_module[module_id].cname) || skip_modern_module (g_${L_TAG}_module[module_id].cname)))
 			printf ("%s\n", g_${L_TAG}_module[module_id].cname);
 EOF
 else

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -181,9 +181,10 @@ enum GMT_enum_apierr {
 };
 
 enum GMT_enum_module {
-	GMT_MODULE_USAGE	= -6,	/* What GMT_Call_Module returns if told to print usage only */
-	GMT_MODULE_SYNOPSIS	= -5,	/* What GMT_Call_Module returns if told to print synopsis only */
-	GMT_MODULE_LIST		= -4,	/* mode for GMT_Call_Module to print list of all modules */
+	GMT_MODULE_USAGE	= -7,	/* What GMT_Call_Module returns if told to print usage only */
+	GMT_MODULE_SYNOPSIS	= -6,	/* What GMT_Call_Module returns if told to print synopsis only */
+	GMT_MODULE_CLASSIC	= -5,	/* mode for GMT_Call_Module to print list of all classic modules */
+	GMT_MODULE_LIST		= -4,	/* mode for GMT_Call_Module to print list of all modern modules */
 	GMT_MODULE_EXIST	= -3,	/* mode for GMT_Call_Module to return 0 if it exists */
 	GMT_MODULE_PURPOSE	= -2,	/* mode for GMT_Call_Module to print purpose of module, or all modules */
 	GMT_MODULE_OPT		= -1,	/* Gave linked list of option structures to GMT_Call_Module */

--- a/src/gmt_supplements_module.c
+++ b/src/gmt_supplements_module.c
@@ -123,6 +123,16 @@ void gmt_supplements_module_list_all (void *V_API) {
 	}
 }
 
+/* Produce single list on stdout of all GMT supplements module names for gmt --show-classic [i.e., classic mode names] */
+void gmt_supplements_module_classic_all (void *V_API) {
+	unsigned int module_id = 0;
+	gmt_M_unused(V_API);
+	while (g_supplements_module[module_id].cname != NULL) {
+		printf ("%s\n", g_supplements_module[module_id].cname);
+		++module_id;
+	}
+}
+
 /* Lookup module id by name, return option keys pointer (for external API developers) */
 const char *gmt_supplements_module_keys (void *API, char *candidate) {
 	int module_id = 0;

--- a/src/gmt_supplements_module.h
+++ b/src/gmt_supplements_module.h
@@ -75,8 +75,10 @@ EXTERN_MSC int GMT_x2sys_solve (void *API, int mode, void *args);
 
 /* Pretty print all modules in the GMT supplements library and their purposes */
 EXTERN_MSC void gmt_supplements_module_show_all (void *API);
-/* List all modules in the GMT supplements library to stdout */
+/* List all modern modules in the GMT supplements library to stdout */
 EXTERN_MSC void gmt_supplements_module_list_all (void *API);
+/* List all classic modules in the GMT supplements library to stdout */
+EXTERN_MSC void gmt_supplements_module_classic_all (void *API);
 /* Function called by GMT_Encode_Options so developers can get information about a module */
 EXTERN_MSC const char * gmt_supplements_module_keys (void *API, char *candidate);
 /* Function returns name of group that module belongs to (core, spotter, etc.) */


### PR DESCRIPTION
This is needed so that the backwards compatibility helper scripts gmt_aliases.csh, gmt_functions.sh and gmt_links.sh can do their things for the classic (not modern) functions.
Closes issue #2104.