### PR TITLE
Leave extensions alone

### DIFF
--- a/src/begin.c
+++ b/src/begin.c
@@ -93,32 +93,21 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
 char *get_session_name_and_format (struct GMTAPI_CTRL *API, struct GMT_OPTION *opt, int *error) {
 	/* Extract session arguments (including optional graphics format) from options:
 	 * gmt begin [<sessionname>] [<formats>] [<psconvertopts>] [-V<arg>]  */
-	char buffer[GMT_LEN256] = {""}, *c;
+	char buffer[GMT_LEN256] = {""};
 	bool space = false;
-	unsigned int n = 0, code = 0;
+	unsigned int n = 0;
 	size_t len = 0;
-	int pos = 0;
 	*error = GMT_NOERROR;
 	if (opt == NULL) return NULL;	/* Go with the default settings */
 	while (opt && n < 3) {
 		if (opt->option == GMT_OPT_INFILE) {	/* Valid "file" argument */
-			pos = strlen (opt->arg) - 3;
 			gmt_filename_set (opt->arg);	/* Replace any spaces with ASCII 29 */
-			while (pos > 0 && gmt_session_format[code] && (!strchr (opt->arg, '.') || strcmp (&opt->arg[pos], gmt_session_format[code])))	/* See if we end in .ext */
-				code++;
-			c = NULL;
-			if (pos > 0 && gmt_session_format[code]) {	/* Yes, ends with .ext */
-				c = strstr (opt->arg, gmt_session_format[code]);	/* Find start of extension */
-				c--;	/* Go back to the period */
-				c[0] = '\0';	/* Chop off extension */
-			}
 			if (space) len++, strncat (buffer, " ", GMT_LEN256-len);
 			len += strlen (opt->arg);
 			strncat (buffer, opt->arg, GMT_LEN256-len);
 			space = true;
 			gmt_filename_get (opt->arg);	/* Undo ASCII 29 */
 			n++;
-			if (c) c[0] = '.';	/* Restore extension */
 		}
 		else if (opt->option != 'V') {
 			GMT_Report (API, GMT_MSG_NORMAL, "Unrecognized argument -%c%s\n", opt->option, opt->arg);

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -711,6 +711,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PS2RASTER_CTRL *Ctrl, struct G
 				if ((Ctrl->F.active = gmt_check_filearg (GMT, 'F', opt->arg, GMT_OUT, GMT_IS_DATASET)) != 0) {
 					char *ext = NULL;
 					Ctrl->F.file = strdup (opt->arg);
+#if 0
 					if (!gmt_M_file_is_memory (Ctrl->F.file) && (ext = strchr (Ctrl->F.file, '.'))) {	/* Make sure file name has no graphics file format extension */
 						unsigned int kk = 0;
 						ext++;	/* Skip the period */
@@ -719,6 +720,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PS2RASTER_CTRL *Ctrl, struct G
 						if (gmt_session_format[kk])	/* Did match one of the extensions, remove it */
 							gmt_chop_ext (Ctrl->F.file);
 					}
+#endif
 					gmt_filename_get (Ctrl->F.file);
 				}
 				else

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -709,18 +709,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PS2RASTER_CTRL *Ctrl, struct G
 				break;
 			case 'F':	/* Set explicitly the output file name */
 				if ((Ctrl->F.active = gmt_check_filearg (GMT, 'F', opt->arg, GMT_OUT, GMT_IS_DATASET)) != 0) {
-					char *ext = NULL;
 					Ctrl->F.file = strdup (opt->arg);
-#if 0
-					if (!gmt_M_file_is_memory (Ctrl->F.file) && (ext = strchr (Ctrl->F.file, '.'))) {	/* Make sure file name has no graphics file format extension */
-						unsigned int kk = 0;
-						ext++;	/* Skip the period */
-						while (gmt_session_format[kk] && strcmp (ext, gmt_session_format[kk]))
-							kk++;	/* Not matching that format, go to next */
-						if (gmt_session_format[kk])	/* Did match one of the extensions, remove it */
-							gmt_chop_ext (Ctrl->F.file);
-					}
-#endif
 					gmt_filename_get (Ctrl->F.file);
 				}
 				else


### PR DESCRIPTION
Rather than second-guessing what the user's intent is, we will simply append the appropriate graphics format extension to the given prefix, whether it already contains an extension or not.  IT is up to the users to understand that this is how it works and if they want to avoid plot names like map.pdf.pdf they will learn now to supply the extension.  This fixes the declared bug in psconvert which, like begin, chopped off known extensions.
Closes issue #2082.