### PR TITLE
When postscript output is selected, psconvert uses the wrong file

### DIFF
--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -2430,8 +2430,8 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 			if (Ctrl->T.ps) {	/* Under modern mode we can also save the PS file by renaming it */
 				strncpy (out_file, Ctrl->F.file, PATH_MAX-1);
 				strcat (out_file, ".ps");
-				GMT_Report (API, GMT_MSG_DEBUG, "Rename %s -> %s\n", ps_names[0], out_file);
-				if (gmt_rename_file (GMT, ps_names[0], out_file, GMT_COPY_FILE))
+				GMT_Report (API, GMT_MSG_DEBUG, "Rename %s -> %s\n", tmp_file, out_file);
+				if (gmt_rename_file (GMT, tmp_file, out_file, GMT_COPY_FILE))
 					Return (GMT_RUNTIME_ERROR);
 			}
 		}


### PR DESCRIPTION
psconvert reads the original postscript file and writes it to a temp file, possibly adding more PostScript code for cropping or painting.  However, under modern mode, postscript is a choice, and then we simply copy the hidden postscript file to the output name.  However, the code copies the original file, not the updated temporary file.  Thus, any changes such as **-A+g**_color_ is lost.

I noticed anim02 and anim04 ps files fail with tiny differences, but surely that is part of the problem.
