### PR TITLE
Clarify the transparency layer

### DIFF
--- a/doc/rst/source/begin.rst
+++ b/doc/rst/source/begin.rst
@@ -81,7 +81,7 @@ eps    Encapsulated PostScript
 jpg    Joint Photographic Experts Group Format
 pdf    Portable Document Format [Default]
 png    Portable Network Graphics
-PNG    Portable Network Graphics (with transparentcy layer)
+PNG    Portable Network Graphics (with transparency layer)
 ppm    Portable Pixel Map
 ps     Plain PostScript
 tif    Tagged Image Format File

--- a/doc/rst/source/begin.rst
+++ b/doc/rst/source/begin.rst
@@ -73,19 +73,19 @@ Supported Graphic Formats
 
 .. _tbl-formats:
 
-====== ===================================================
+====== ====================================================
 Format Explanation
-====== ===================================================
+====== ====================================================
 bmp    Microsoft Bit Map
 eps    Encapsulated PostScript
 jpg    Joint Photographic Experts Group Format
 pdf    Portable Document Format [Default]
-png    Portable Network Graphics (opaque background)
-PNG    Portable Network Graphics (transparent background)
+png    Portable Network Graphics
+PNG    Portable Network Graphics (with transparentcy layer)
 ppm    Portable Pixel Map
 ps     Plain PostScript
 tif    Tagged Image Format File
-====== ===================================================
+====== ====================================================
 
 Examples
 --------

--- a/doc/rst/source/explain_-t_full.rst_
+++ b/doc/rst/source/explain_-t_full.rst_
@@ -3,3 +3,4 @@
 **-t**\ [*transp*\ ]
     Set transparency level for an overlay, in (0-100] percent range. [Default
     is 0, i.e., opaque].  Only visible when PDF or raster format output is selected.
+    Only the PNG format selection adds a transparency layer in the image (for futher processing).

--- a/src/begin.c
+++ b/src/begin.c
@@ -49,8 +49,8 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     eps:	Encapsulated PostScript.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     jpg:	Joint Photographic Experts Group format.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     pdf:	Portable Document Format [Default].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     png:	Portable Network Graphics (opaque background).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     PNG:	Portable Network Graphics (transparent background).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     png:	Portable Network Graphics.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     PNG:	Portable Network Graphics (with transparency layer).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     ppm:	Portable Pixel Map.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     ps:	PostScript.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     tif:	Tagged Image Format File.\n");

--- a/src/figure.c
+++ b/src/figure.c
@@ -50,8 +50,8 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     eps:	Encapsulated PostScript.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     jpg:	Joint Photographic Experts Group format.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     pdf:	Portable Document Format [Default].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     png:	Portable Network Graphics (opaque background).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     PNG:	Portable Network Graphics (transparent background).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     png:	Portable Network Graphics.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     PNG:	Portable Network Graphics (with transparency layer).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     ppm:	Portable Pixel Map.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     ps:	PostScript.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     tif:	Tagged Image Format File.\n");


### PR DESCRIPTION
Only the PNG format adds a layer, while all non-PostScript formats can do transparency.
