### PR TITLE
Allow gmtdefaults to run without args

### DIFF
--- a/doc/rst/source/gmtdefaults.rst
+++ b/doc/rst/source/gmtdefaults.rst
@@ -21,7 +21,7 @@ Description
 
 **defaults** lists all the GMT parameter defaults if the option
 **-D** is used. There are three ways to change some of the settings: (1)
-Use the command :doc:`gmtset`, (2) use any text editor to edit the file
+Use the command :doc:`gmtset`, (2) in classic mode you may use any text editor to edit the file
 :doc:`gmt.conf` in your home, ~/.gmt or current directory (if you do not
 have this file, run :doc:`gmtset` **-D** to get one with the system default
 settings), or (3) override any parameter by specifying one
@@ -51,7 +51,8 @@ Optional Arguments
 .. include:: explain_help.rst_
 
 Your currently active defaults come from the :doc:`gmt.conf` file in
-the current working directory, if present; else from the
+the current working directory (in classic mode) or in your session directory
+(in modern mode), if present; else from the
 :doc:`gmt.conf` file in your home directory, if present; else from the
 file **~/.gmt/gmt.conf** if present; else from the system defaults
 set at the time GMT was compiled.

--- a/src/gmtdefaults.c
+++ b/src/gmtdefaults.c
@@ -132,7 +132,7 @@ int GMT_gmtdefaults (void *V_API, int mode, void *args) {
 	if (mode == GMT_MODULE_PURPOSE) return (usage (API, GMT_MODULE_PURPOSE));	/* Return the purpose of program */
 	options = GMT_Create_Options (API, mode, args);	if (API->error) return (API->error);	/* Set or get option list */
 
-	if ((error = gmt_report_usage (API, options, 0, usage)) != GMT_NOERROR) bailout (error);	/* Give usage if requested */
+	if ((error = gmt_report_usage (API, options, 1, usage)) != GMT_NOERROR) bailout (error);	/* Give usage if requested */
 
 	/* Parse the command-line arguments */
 
@@ -144,6 +144,7 @@ int GMT_gmtdefaults (void *V_API, int mode, void *args) {
 	/*---------------------------- This is the gmtdefaults main code ----------------------------*/
 
 	if (Ctrl->D.active) {	/* Start with default params using SI settings */
+		gmt_conf (GMT);		/* Get SI defaults */
 		if (Ctrl->D.mode == 'u')
 			gmt_conf_US (GMT);	/* Change a few to US defaults */
 	}


### PR DESCRIPTION
gmt defaults without arguments are supposed to print the users current defaults, but not working.  Also, **-D** should print the system defaults (SI or US) but it did not reset to those values before reporting . This PR fixes both issues.  Closes issue #2143.
