### PR TITLE
Check if arg is NULL before accessing it

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8645,6 +8645,7 @@ int gmt_rename_file (struct GMT_CTRL *GMT, const char *oldfile, const char *newf
 
 void gmt_replace_backslash_in_path (char *dir) {
 	size_t k = 0;
+	if (dir == NULL) return;	/* No can do */
 	while (dir[k]) {
 		if (dir[k] == '\\') dir[k] = '/';
 		k++;


### PR DESCRIPTION
Probably related to a Forum complaint about a SEGV in gmt_replace_backslash_in_path function.
