### PR TITLE
Reset font settings when building PostScript macros

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -7066,6 +7066,10 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 			else	
 				PSL_plottext (PSL, plot_x, plot_y, Tfont.size, label, 0.0, justify, form);
 			gmt_M_str_free (movie_label_arg[T]);
+			/* Because PSL_plot_completion is called at the end of the module, we must forget we used fonts here */
+			PSL->internal.font[PSL->current.font_no].encoded = 0;	/* Since truly not used yet */
+			PSL->current.font_no = -1;	/* To force setting of next font since the PSL stuff might have changed it */
+			gmt_M_memcpy (PSL->current.rgb[PSL_IS_FONT], GMT->session.no_rgb, 3, double);	/* Reset to -1,-1,-1 since text setting must set the color desired */
 		}
 		PSL_comment (PSL, "End of movie labels\n");
 		PSL_command (PSL, "U\n}!\n");


### PR DESCRIPTION
Like we did for the _PSL_plot_completion_ PostScript macro used by subplots to add the panel label after the plotting, we must do the same for the _PSL_movie_completion_ macro used to label a movie panel: We may compute the font and font encoding to build the macro, but since the macro is not called until the end we must undo any PSL memory of having encoded this font so that when the beginning of the plot needs those fonts it will have to encode them at that time.  Otherwise, when movie labels are selected the degree symbols for the frame disappeared (or similar) since no encoding takes place...

