### PR TITLE
doc: Update gmtlogo usage and manpage

### DIFF
--- a/doc/rst/source/explain_-T_rose.rst_
+++ b/doc/rst/source/explain_-T_rose.rst_
@@ -7,12 +7,12 @@
     (3) use **n** for normalized (0-1) coordinates, or (4) use **x** for plot coordinates
     (inches, cm, etc.) [Default].  You can offset the reference point by *dx*/*dy* in
     the direction implied by *justify*.
-    By default, the anchor point on the scale is assumed to be the center of the rose (MC), but this
+    By default, the anchor point on the directional rose is assumed to be the center of the rose (MC), but this
     can be changed by appending **+j** followed by a 2-char justification code *justify*
     (see :doc:`text` for list and explanation of codes).
     Note: If **-Dj** is used then *justify* defaults to the same as *refpoint*,
     if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*.
-    Add **+o** to offset the color scale by *dx*/*dy* away from the *refpoint* in
+    Add **+o** to offset the directional rose by *dx*/*dy* away from the *refpoint* in
     the direction implied by *justify* (or the direction implied by **-Dj** or **-DJ**).
     Append **+w**\ *width* to set the width of the rose in plot coordinates (in inches, cm, or points).
     Add **+f** to get a "fancy" rose, and specify in *level* what
@@ -22,7 +22,7 @@
     NNW-SSE, NNE-SSW, and ENE-WSW.
     Label the cardinal points W,E,S,N by adding **+l** and append your own four
     comma-separated strings to override the default.  Skip a specific label by leaving it blank.
-    See :ref:`Placing-dir-map-roses` and **-F** on how to place a panel behind the scale.
+    See :ref:`Placing-dir-map-roses` and **-F** on how to place a panel behind the directional rose.
 
 **-Tm**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ **+w**\ *width*\ [**+d**\ *dec*\ [/\ *dlabel*]]]\ [**+i**\ *pen*]\ [**+j**\ *justify*][**+l**\ *w,e,s,n*][**+p**\ *pen*]\ [**+t**\ *ints*][**+o**\ *dx*\ [/*dy*]]
 
@@ -34,12 +34,12 @@
     (3) use **n** for normalized (0-1) coordinates, or (4) use **x** for plot coordinates
     (inches, cm, etc.) [Default]. You can offset the reference point by *dx*/*dy* in
     the direction implied by *justify*.
-    By default, the anchor point on the scale is assumed to be the center of the rose (MC), but this
+    By default, the anchor point on the magnetic rose is assumed to be the center of the rose (MC), but this
     can be changed by appending **+j** followed by a 2-char justification code *justify*
     (see :doc:`text` for list and explanation of codes).
     Note: If **-Dj** is used then *justify* defaults to the same as *refpoint*,
     if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*.
-    Add **+o** to offset the color scale by *dx*/*dy* away from the *refpoint* in
+    Add **+o** to offset the color magnetic rose by *dx*/*dy* away from the *refpoint* in
     the direction implied by *justify* (or the direction implied by **-Dj** or **-DJ**).
     Append **+w**\ *width* to set the width of the rose in plot coordinates (in inches, cm, or points).
     Use **+d** to assign the magnetic declination and set *dlabel*, which is a label for
@@ -54,5 +54,5 @@
     Label the cardinal points W,E,S,N by adding **+l** and append your own four comma-separated
     strings to override the default.  Skip a specific label by leaving it blank.
     Number GMT default parameters control pens, fonts, and color.
-    See :ref:`Placing-dir-map-roses` and **-F** on how to place a panel behind the scale.
- 
+    See :ref:`Placing-mag-map-roses` and **-F** on how to place a panel behind the magnetic rose.
+

--- a/doc/rst/source/gmtlogo.rst
+++ b/doc/rst/source/gmtlogo.rst
@@ -29,23 +29,19 @@ Synopsis
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 .. include:: oneliner_info.rst_
 
-To plot the GMT logo of a 2 inch width as a stand-alone pdf plot, use
+To plot the GMT logo of a 2 inch width as a stand-alone pdf plot, use::
 
-   ::
-
-    gmt logo -Dx0/0+w2i -pdf logo
+    gmt logo -pdf logo
 
 To append a GMT logo overlay in the upper right corner of the current map, but
-scaled up to be 3 inches wide and offset by 0.1 inches from the border, try
+scaled up to be 3 inches wide and offset by 0.1 inches from the border, try::
 
-   ::
-
+    gmt begin map
+    gmt ...
     gmt logo -DjTR+o0.1i/0.1i+w3i
-
+    gmt end show
 
 Notes
 -----

--- a/doc/rst/source/gmtlogo_classic.rst
+++ b/doc/rst/source/gmtlogo_classic.rst
@@ -33,18 +33,12 @@ Synopsis
 Examples
 --------
 
-.. include:: explain_example.rst_
+To plot the GMT logo of a 2 inch width as a stand-alone plot, use::
 
-To plot the GMT logo of a 2 inch width as a stand-alone plot, use
-
-   ::
-
-    gmt logo -P -Dx0/0+w2i > logo.ps
+    gmt logo -P > logo.ps
 
 To append a GMT logo overlay in the upper right corner of the current map, but
-scaled up to be 3 inches wide and offset by 0.1 inches from the border, try
-
-   ::
+scaled up to be 3 inches wide and offset by 0.1 inches from the border, try::
 
     gmt logo -O -K -R -J -DjTR+o0.1i/0.1i+w3i >> bigmap.ps
 

--- a/doc/rst/source/gmtlogo_common.rst_
+++ b/doc/rst/source/gmtlogo_common.rst_
@@ -25,11 +25,11 @@ Optional Arguments
     (inches, cm, etc.).  All but **-Dx** requires both **-R** and **-J** to be specified.
     Use **+w**\ *width* to set the width of the GMT logo in plot coordinates
     (inches, cm, etc.).
-    By default, the anchor point on the scale is assumed to be the bottom left corner (BL), but this
+    By default, the anchor point on the GMT logo is assumed to be the bottom left corner (BL), but this
     can be changed by appending **+j** followed by a 2-char justification code *justify* (see :doc:`text`).
     Note: If **-Dj** is used then *justify* defaults to the same as *refpoint*,
     if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*.
-    Add **+o** to offset the color scale by *dx*/*dy* away from the *refpoint* point in
+    Add **+o** to offset the GMT logo by *dx*/*dy* away from the *refpoint* point in
     the direction implied by *justify* (or the direction implied by **-Dj** or **-DJ**).
 
 .. _-F:
@@ -55,6 +55,9 @@ Optional Arguments
 .. |Add_-R| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-R.rst_
 
+.. |Add_-Rz| unicode:: 0x20 .. just an invisible code
+.. include:: explain_-Rz.rst_
+
 .. _-S:
 
 **-S**\ [\ **l**\ \|\ **n**\ \|\ **u**\ ]
@@ -62,9 +65,6 @@ Optional Arguments
     Append **l** (or skip **-S** entirely) to plot the text label "The Generic Mapping Tools"
     beneath the logo.  Append **n** to skip the label placement, and append
     **u** to place the URL to the GMT site instead [plot the label].
-
-.. |Add_-Rz| unicode:: 0x20 .. just an invisible code
-.. include:: explain_-Rz.rst_
 
 .. _-U:
 

--- a/src/gmtlogo.c
+++ b/src/gmtlogo.c
@@ -203,7 +203,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [-D%s[+w<width>]%s]\n", name, GMT_XYANCHOR, GMT_OFFSET);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-F%s]\n\t[%s] %s%s%s[%s]\n", GMT_PANEL, GMT_J_OPT, API->K_OPT, API->O_OPT, API->P_OPT, GMT_Rgeoz_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-S[l|n|u]] [%s] [%s] %s[%s] [%s]\n\n", GMT_X_OPT, GMT_Y_OPT, API->c_OPT, GMT_t_OPT, GMT_PAR_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-S[l|n|u]] [%s] [%s]\n\t[%s] [%s] %s[%s] [%s]\n\n", GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, API->c_OPT, GMT_t_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -310,7 +310,7 @@ int GMT_gmtlogo (void *V_API, int mode, void *args) {
 	int error, fmode;
 
 	uint64_t par[4] = {0, 0, 0, 0};
-	
+
 	double wesn[4] = {0.0, 0.0, 0.0, 0.0};	/* Dimensions in inches */
 	double scale, y, dim[2];
 
@@ -433,7 +433,7 @@ int GMT_gmtlogo (void *V_API, int mode, void *args) {
 	GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Calling psxy with args %s\n", cmd);
 	GMT_Call_Module (API, "psxy", GMT_MODULE_CMD, cmd);
 	GMT_Close_VirtualFile (API, file);
-	
+
 	PSL_setorigin (PSL, -Ctrl->D.refpoint->x, -Ctrl->D.refpoint->y, 0.0, PSL_INV);
 	gmt_plane_perspective (GMT, -1, 0.0);
 	PSL_command (PSL, "U\n");	/* Ending the encapsulation for gmtlogo */


### PR DESCRIPTION
1. -U and -V are missing in the gmtlogo usage
2. Improve the examples
3. Fix a few copy-paste bugs