### PR TITLE
Allow -Ls<string> to specify a fixed label

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -160,6 +160,7 @@ Optional Arguments
     Automatic labeling of individual frames.  Repeatable up to 32 labels.  Places the chosen label at the frame perimeter:
     **e** selects the elapsed time in seconds as the label; append **+s**\ *scale* to set the length
     in seconds of each frame [Default is 1/*framerate*],
+    **s**\ *string* uses the fixed text *string* as the label,
     **f** selects the running frame number as the label, **c**\ *col* uses the value in column
     number *col* of *timefile* as label (first column is 0), while **t**\ *col* uses word number
     *col* from the trailing text in *timefile* (requires **-T**\ ...\ **+w**; first word is 0).  Note: If you use **-Lc**


### PR DESCRIPTION
It is often desirable to place a fixed label on all movie frames but there was no option to do that, meaning you would have to add a gmt text call somewher.  Now we can use **-Ls**_string_[_modifiers_].
