### PR TITLE
Long verbose message if we cannot find the standard font listing

### DIFF
--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -3159,8 +3159,7 @@ static int psl_init_fonts (struct PSL_CTRL *PSL) {
 		PSL->internal.N_FONTS = i;
 	}
 	else {
-		PSL_message (PSL, PSL_MSG_NORMAL, "ERROR: Unable to find PSL_custom_fonts.txt - was told to look in %s (?)\n", PSL->internal.SHAREDIR);
-		PSL_exit (EXIT_FAILURE);
+		PSL_message (PSL, PSL_MSG_LONG_VERBOSE, "No PSL_custom_fonts.txt found\n");
 	}
 	
 	/* Final allocation of font array */

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -3158,6 +3158,11 @@ static int psl_init_fonts (struct PSL_CTRL *PSL) {
 		fclose (in);
 		PSL->internal.N_FONTS = i;
 	}
+	else {
+		PSL_message (PSL, PSL_MSG_NORMAL, "ERROR: Unable to find PSL_custom_fonts.txt - was told to look in %s (?)\n", PSL->internal.SHAREDIR);
+		PSL_exit (EXIT_FAILURE);
+	}
+	
 	/* Final allocation of font array */
 	PSL->internal.font = PSL_memory (PSL, PSL->internal.font, PSL->internal.N_FONTS, struct PSL_FONT);
 	return PSL_NO_ERROR;


### PR DESCRIPTION
Added long verbose message if _psl_init_fonts_ function does not find any custom fonts.
