### PR TITLE
doc: Remove explain_examples.rst_ from some manpages

### DIFF
--- a/doc/rst/source/blockmean.rst
+++ b/doc/rst/source/blockmean.rst
@@ -164,8 +164,6 @@ Optional Arguments
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To find 5 by 5 minute block mean values from the ASCII data in ship_15.txt, run
 
    ::

--- a/doc/rst/source/blockmedian.rst
+++ b/doc/rst/source/blockmedian.rst
@@ -184,28 +184,21 @@ Optional Arguments
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To find 5 by 5 minute block medians from the ASCII data in ship_15.txt
-and output a binary table with double precision triplets, run
+and output a binary table with double precision triplets, run::
 
-   ::
 
     gmt blockmedian @ship_15.txt -R245/255/20/30 -I5m -bo3d > ship_5x5.b
 
 To compute the shape of a data distribution per bin via a
 box-and-whisker diagram we need the 0%, 25%, 50%, 75%, and 100%
 quantiles. To do so on a global 5 by 5 degree basis from the ASCII table
-mars370.txt and send output to an ASCII table, run
-
-   ::
+mars370.txt and send output to an ASCII table, run::
 
     gmt blockmedian @mars370.txt -Rg -I5 -Eb -r > mars_5x5.txt
 
 To determine the median and L1 scale (MAD) on the median per 10 minute bin and save these to two separate grids
-called field_z.nc and field_s.nc, run
-
-   ::
+called field_z.nc and field_s.nc, run::
 
     gmt blockmedian @ship_15.txt -I10m -R-115/-105/20/30 -E -Gfield_%s.nc -Az,s
 

--- a/doc/rst/source/blockmode.rst
+++ b/doc/rst/source/blockmode.rst
@@ -185,26 +185,18 @@ Optional Arguments
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To find 5 by 5 minute block mode from the ASCII data in ship_15.txt
-and output a binary table with double precision triplets, run
-
-   ::
+and output a binary table with double precision triplets, run::
 
     gmt blockmedian @ship_15.txt -R245/255/20/30 -I5m -bo3d > ship_5x5.b
 
 To determine the most frequently occurring values per 2x2 block using histogram binning, with
-data representing integer counts, try
-
-   ::
+data representing integer counts, try::
 
     gmt blockmode @ship_15.txt -R245/255/20/30 -I2  -r -C -D
 
 To determine the mode and L1 scale (MAD) on the mode per 10 minute bin and save these to two separate grids
-called field_z.nc and field_s.nc, run
-
-   ::
+called field_z.nc and field_s.nc, run::
 
     gmt blockmode @ship_15.txt -I10m -R-115/-105/20/30 -E -Gfield_%s.nc -Az,s
 

--- a/doc/rst/source/clip.rst
+++ b/doc/rst/source/clip.rst
@@ -41,8 +41,6 @@ Synopsis
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To see the effect of a simple clip path which result in some symbols
 being partly visible or missing altogether, try::
 

--- a/doc/rst/source/events.rst
+++ b/doc/rst/source/events.rst
@@ -44,8 +44,6 @@ Synopsis
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To show the display of events visible for May 1, 2018 given the catalog of
 large (>5) magnitude earthquakes that year, using a 2-day rise time during
 which we boost symbol size by a factor of 5 and wash out the color, followed

--- a/doc/rst/source/gmtswitch.rst
+++ b/doc/rst/source/gmtswitch.rst
@@ -78,8 +78,6 @@ The fastest way to get up and running is this:
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To switch to GMT version 4.5.7 (assuming it was installed as such and not
 via a package manager), try
 

--- a/doc/rst/source/grd2xyz.rst
+++ b/doc/rst/source/grd2xyz.rst
@@ -147,18 +147,12 @@ for x, y, or z coordinate, respectively.
 Examples
 --------
 
-.. include:: explain_example.rst_
-
-To edit individual values in the 2' by 2' remote AFR.nc file, dump the .nc to ASCII:
-
-   ::
+To edit individual values in the 2' by 2' remote AFR.nc file, dump the .nc to ASCII::
 
     gmt grd2xyz @AFR.nc > AFR.xyz
 
 To write a single precision binary file without the x,y positions from
-the remote file @AFR.nc file, using scanline orientation, run
-
-   ::
+the remote file @AFR.nc file, using scanline orientation, run::
 
     gmt grd2xyz @AFR.nc -ZTLf > AFR.b
 

--- a/doc/rst/source/grdcontour.rst
+++ b/doc/rst/source/grdcontour.rst
@@ -47,8 +47,6 @@ Synopsis
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 .. include:: oneliner_info.rst_
 
 To contour the remote file AK_gulf_grav.nc every 25 mGal on a Mercator map at

--- a/doc/rst/source/grdinfo.rst
+++ b/doc/rst/source/grdinfo.rst
@@ -156,8 +156,6 @@ Optional Arguments
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To obtain all the information about the remote data set in file earth_relief_10m::
 
     gmt grdinfo -L1 -L2 -M @earth_relief_10m

--- a/doc/rst/source/psclip.rst
+++ b/doc/rst/source/psclip.rst
@@ -42,8 +42,6 @@ Synopsis
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To see the effect of a simple clip path which result in some symbols
 being partly visible or missing altogether, try
 

--- a/doc/rst/source/pscoast.rst
+++ b/doc/rst/source/pscoast.rst
@@ -48,8 +48,6 @@ Synopsis
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To plot a green Africa with white outline on blue background, with
 permanent major rivers in thick blue pen, additional major rivers in
 thin blue pen, and national borders as dashed lines on a Mercator map at

--- a/doc/rst/source/psevents.rst
+++ b/doc/rst/source/psevents.rst
@@ -48,8 +48,6 @@ Synopsis
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To show the display of events visible for May 1, 2018 given the catalog of
 large (>5) magnitude earthquakes that year, using a 2-day rise time during
 which we boost symbol size by a factor of 5 and wash out the color, followed

--- a/doc/rst/source/sph2grd.rst
+++ b/doc/rst/source/sph2grd.rst
@@ -124,8 +124,6 @@ Optional Arguments
 Examples
 --------
 
-.. include:: explain_example.rst_
-
 To create a 1 x 1 degree global grid file from the ASCII
 coefficients in the remote file EGM96_to_360.txt, use
 


### PR DESCRIPTION
For some manpages, all the examples use remote files. No need to include the
explain_examples.rst_ file.