### PR TITLE
We use deprecated variable names in a few places

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7789,7 +7789,7 @@ struct GMT_PALETTE *gmt_get_palette (struct GMT_CTRL *GMT, char *file, enum GMT_
 			GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Auto-stretching CPT file %s to fit rounded data range %g to %g\n", master, zmin, zmax);
 		}
 		gmt_stretch_cpt (GMT, P, zmin, zmax);
-		gmt_save_current_cpt (GMT, P, P->cpt_flags);	/* Save for use by session, if modern */
+		gmt_save_current_cpt (GMT, P, 0);	/* Save for use by session, if modern */
 	}
 	else if (file) {	/* Gave a CPT file */
 		P = GMT_Read_Data (GMT->parent, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, &file[first], NULL);
@@ -13592,10 +13592,10 @@ unsigned int gmt_load_custom_annot (struct GMT_CTRL *GMT, struct GMT_PLOT_AXIS *
 		nc = sscanf (S->text[row], "%s %[^\n]", type, txt);
 		found = ((item == 'a' && (strchr (type, 'a') || strchr (type, 'i'))) || (strchr (type, item) != NULL));
 		if (!found) continue;	/* Not the type we were requesting */
-		if (S->coord[GMT_X][row] < limit[0] || S->coord[GMT_X][row] > limit[1]) continue;
+		if (S->data[GMT_X][row] < limit[0] || S->data[GMT_X][row] > limit[1]) continue;
 		if (strchr (type, 'i')) n_int++;
 		if (strchr (type, 'a')) n_annot++;
-		x[k] = S->coord[GMT_X][row];
+		x[k] = S->data[GMT_X][row];
 		if (text && nc == 2) L[k] = strdup (txt);
 		k++;
 	}

--- a/src/project.c
+++ b/src/project.c
@@ -880,8 +880,8 @@ int GMT_project (void *V_API, int mode, void *args) {
 			else {	/* Geographic ellipse */
 				struct GMT_DATASEGMENT *S = gmt_get_geo_ellipse (GMT, Ctrl->C.x, Ctrl->C.y, Ctrl->Z.major, Ctrl->Z.minor, Ctrl->Z.azimuth, ne);
 				for (rec = 0; rec < P.n_used; rec++) {
-					p_data[rec].a[4] = S->coord[GMT_X][rec];
-					p_data[rec].a[5] = S->coord[GMT_Y][rec];
+					p_data[rec].a[4] = S->data[GMT_X][rec];
+					p_data[rec].a[5] = S->data[GMT_Y][rec];
 				}
 				z_header = strdup (S->header);
 				gmt_free_segment (GMT, &S);


### PR DESCRIPTION
When I commented out **GMT_BACKWARDS_API** in gmt_resources.h I found a few places where we had not changed the variable names from the very early ones used in 5.x (e.g., coords instead of data).  Now, GMT compiles if **GMT_BACKWARDS_API** is not set.  I think by GMT 7 we should remove all that stuff entirely.
