### PR TITLE
Fix link to Units page, and more

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -68,7 +68,7 @@
         For degenerate ellipses (circles) with just the diameter given, use **-SE-**.
         The diameter is excepted to be given in column 3.  Alternatively, append
         the desired diameter to **-SE-** and this fixed diameter is used instead.
-	For allowable geographical units, see UNITS [Default is k for km].
+	For allowable geographical units, see `Units`_ [Default is k for km].
 
     **-Sf**\ *gap*\ [/*size*][**+l**\ \|\ **+r**][**+b+c+f+s+t**][\ **+o**\ *offset*][**+p**\ [*pen*]].
         Draw a **f**\ ront. Supply distance *gap* between symbols and symbol *size*. If *gap* is
@@ -114,7 +114,7 @@
 	the dimension diameter to **-SJ-** and this fixed dimension is used instead.
 	An exception occurs for a linear projection in
         which we assume the dimensions are given in the same units as **-R**.
-	For allowable geographical units, see UNITS [Default is k for km].
+	For allowable geographical units, see `Units`_ [Default is k for km].
 
     **-Sk**
         **k**\ ustom symbol. Append *name*\ /\ *size*, and we will look for a
@@ -368,7 +368,7 @@
         be given instead of the two directions. The azimuths will be mapped
         into angles based on the chosen map projection (**-Sw** leaves the
         directions unchanged). Specify *size* as a geographical diameter.
-        For allowable geographical units, see UNITS [Default is k for km]. To instead
+        For allowable geographical units, see `Units`_ [Default is k for km]. To instead
         specify a diameter in plot units, you must append the desired unit.
         Append /*inner* to select a separate inner diameter [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);
@@ -389,7 +389,7 @@
         vector head. Vector width is set by **-W**. See `Vector Attributes`_
         for specifying attributes. Note: Geovector stems are drawn as thin
         filled polygons and hence pen attributes like dashed and dotted are
-        not available. For allowable geographical units, see UNITS.
+        not available. For allowable geographical units, see `Units`_.
 
     **-S~**
         decorated line, i.e., lines with symbols along them. Append

--- a/doc/rst/source/explain_symbols2.rst_
+++ b/doc/rst/source/explain_symbols2.rst_
@@ -68,7 +68,7 @@
 	For degenerate ellipses (circles) with just the diameter given, use **-SE-**.
 	The diameter is excepted to be given in column 4.  Alternatively, append
 	the desired diameter to **-SE-** and this fixed diameter is used instead.
-	For allowable geographical units, see UNITS [Default is k for km].
+	For allowable geographical units, see `Units`_ [Default is k for km].
 
     **-Sf**\ *gap*\ [/*size*\ ][**+l**\ \|\ **+r**][**+b+c+f+s+t**][\ **+o**\ *offset*][**+p**\ [*pen*]].
         Draw a **f**\ ront.  Supply distance gap between symbols and symbol size. If *gap* is
@@ -113,7 +113,7 @@
 	the dimension diameter to **-SJ-** and this fixed dimension is used instead.
 	An exception occurs for a linear projection in
         which we assume the dimensions are given in the same units as **-R**.
-	For allowable geographical units, see UNITS [Default is k for km].
+	For allowable geographical units, see `Units`_ [Default is k for km].
 
     **-Sk**
         **k**\ ustom symbol. Append <name>/*size*, and we will look for a
@@ -379,7 +379,7 @@
         be given instead of the two directions. The azimuths will be mapped
         into angles based on the chosen map projection (**-Sw** leaves the
         directions unchanged). Specify *size* as a geographical diameter.
-        For allowable geographical units, see UNITS [Default is k for km]. To instead
+        For allowable geographical units, see `Units`_ [Default is k for km]. To instead
         specify a diameter in plot units, you must append the desired unit.
         Append /*inner* to select a separate inner diameter [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);
@@ -400,7 +400,7 @@
         vector head. Vector width is set by **-W**. See `Vector Attributes`_
         for specifying attributes. Note: Geovector stems are drawn as thin
         filled polygons and hence pen attributes like dashed and dotted are
-        not available. For allowable geographical units, see UNITS.
+        not available. For allowable geographical units, see `Units`_.
 
     **-S~**
         decorated line, i.e., lines with symbols along them. Append

--- a/doc/rst/source/explain_symbols_only.rst_
+++ b/doc/rst/source/explain_symbols_only.rst_
@@ -122,7 +122,7 @@
         be given instead of the two directions. The azimuths will be mapped
         into angles based on the chosen map projection (**-Sw** leaves the
         directions unchanged). Specify *size* as a geographical diameter.
-        For allowable geographical units, see UNITS [Default is k for km]. To instead
+        For allowable geographical units, see `Units`_ [Default is k for km]. To instead
         specify a diameter in plot units, you must append the desired unit.
         Append /*inner* to select a separate inner diameter [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);

--- a/doc/rst/source/plot3d_common.rst_
+++ b/doc/rst/source/plot3d_common.rst_
@@ -90,10 +90,10 @@ Optional Arguments
     Append **+d** to build symmetrical envelope around y(x) using deviations dy(x) given in extra column 4.
     Append **+D** to build asymmetrical envelope around y(x) using deviations dy1(x) and dy2(x) from extra columns 4-5.
     Append **+b** to build asymmetrical envelope around y(x) using bounds yl(x) and yh(x) from extra columns 4-5.
-    Append **+xl**\ \|\ **r**\ \|\ *x0* to connect first and last point to anchor points at either xmin, xmax, or x0, or
-    append **+yb**\ \|\ **t**\ \|\ *y0* to connect first and last point to anchor points at either ymin, ymax, or y0.
+    Append **+xl**\ \|\ **r**\ \|\ *x0* to connect first and last point to anchor points at either *xmin*, *xmax*, or *x0*, or
+    append **+yb**\ \|\ **t**\ \|\ *y0* to connect first and last point to anchor points at either *ymin*, *ymax*, or *y0*.
     Polygon may be painted (**-G**) and optionally outlined by adding **+p**\ *pen* [no outline].
-    All constructed polygons are assumed to have a constant z value.
+    All constructed polygons are assumed to have a constant *z* value.
 
 .. _-N:
 

--- a/doc/rst/source/plot_common.rst_
+++ b/doc/rst/source/plot_common.rst_
@@ -138,8 +138,8 @@ Optional Arguments
     Append **+d** to build symmetrical envelope around y(x) using deviations dy(x) given in extra column 3.
     Append **+D** to build asymmetrical envelope around y(x) using deviations dy1(x) and dy2(x) from extra columns 3-4.
     Append **+b** to build asymmetrical envelope around y(x) using bounds yl(x) and yh(x) from extra columns 3-4.
-    Append **+xl**\ \|\ **r**\ \|\ *x0* to connect first and last point to anchor points at either xmin, xmax, or x0, or
-    append **+yb**\ \|\ **t**\ \|\ *y0* to connect first and last point to anchor points at either ymin, ymax, or y0.
+    Append **+xl**\ \|\ **r**\ \|\ *x0* to connect first and last point to anchor points at either *xmin*, *xmax*, or *x0*, or
+    append **+yb**\ \|\ **t**\ \|\ *y0* to connect first and last point to anchor points at either *ymin*, *ymax*, or *y0*.
     Polygon may be painted (**-G**) and optionally outlined by adding **+p**\ *pen* [no outline].
 
 .. _-N:

--- a/doc/rst/source/surface.rst
+++ b/doc/rst/source/surface.rst
@@ -137,7 +137,7 @@ Optional Arguments
 **-M**\ *max_radius*\ [**u**]
     After solving for the surface, apply a mask so that nodes farther
     than *max_radius* away from a data constraint is set to NaN [no masking].
-    Append a distance unit (see UNITS) if needed.
+    Append a distance unit (see `Units`_) if needed.
     One can also select the nodes to mask by using the **-M**\ *n_cells*\ **c** form.
     Here *n_cells* means the number of cells around the node controlled by a data point. As an example
     **-M0c** means that only the cell where point lies is filled, **-M1c** keeps one cell


### PR DESCRIPTION
We had the old UNITS reference but should be `Units`_.  Also, some attributes needed to be italicized.
