### PR TITLE
Deprecate modifiers +p- and +g- for vector head attributes

### DIFF
--- a/doc/rst/source/explain_vectors.rst_
+++ b/doc/rst/source/explain_vectors.rst_
@@ -23,8 +23,8 @@ end point of a segment:
     Further append **l**\ \|\ **r** to only draw the left or right
     half-sides of this head [both sides].
 
-    **+g**-\ \|\ *fill* turns off vector head fill (if -) or sets the vector
-    head fill [Default fill is used, which may be no fill].
+    **+g**\ [fill*] sets the vector head fill [Default fill is used, which may be no fill].
+    Turn off vector head fill by not appending a *fill*.
 
     **+h**\ *shape* sets the shape of the vector head (range -2/2). Default
     is controlled by :ref:`MAP_VECTOR_SHAPE <MAP_VECTOR_SHAPE>` [0].
@@ -48,8 +48,8 @@ end point of a segment:
     small circles.  Only needed for great circles if **+q** is given. If no
     pole is appended then we default to the north pole.
 
-    **+p**\ [-][*pen*] sets the vector pen attributes. If *pen* has a
-    leading - then the head outline is not drawn. [Default pen is half the width of stem pen, and
+    **+p**\ [*pen*] sets the vector pen attributes. If no *pen* is appended
+    then the head outline is not drawn. [Default pen is half the width of stem pen, and
     head outline is drawn]
 
     **+q** means the input *angle*, *length* data instead represent the *start* and *stop*

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7107,7 +7107,7 @@ void gmt_vector_syntax (struct GMT_CTRL *GMT, unsigned int mode) {
 	gmt_message (GMT, "\t       Append t for terminal, c for circle, s for square, a for arrow [Default],\n");
 	gmt_message (GMT, "\t       i for tail, A for plain arrow, and I for plain tail.\n");
 	gmt_message (GMT, "\t       Append l|r to only draw left or right side of this head [both sides].\n");
-	if (mode & 8) gmt_message (GMT, "\t     +g<fill> to set head fill or use - to turn off fill [default fill].\n");
+	if (mode & 8) gmt_message (GMT, "\t     +g<fill> to set head fill; oexclude <fill> to turn off fill [default fill].\n");
 	gmt_message (GMT, "\t     +h sets the vector head shape in -2/2 range [%g].\n", GMT->current.setting.map_vector_shape);
 	if (mode & 1) gmt_message (GMT, "\t     +j<just> to justify vector at (b)eginning [default], (e)nd, or (c)enter.\n");
 	gmt_message (GMT, "\t     +l to only draw left side of all specified vector heads [both sides].\n");
@@ -7117,7 +7117,7 @@ void gmt_vector_syntax (struct GMT_CTRL *GMT, unsigned int mode) {
 	gmt_message (GMT, "\t       Append l|r to only draw left or right side of this head [both sides].\n");
 	gmt_message (GMT, "\t     +n<norm> to shrink attributes if vector length < <norm> [none].\n");
 	gmt_message (GMT, "\t     +o[<plon/plat>] sets pole [north pole] for great or small circles; only give length via input.\n");
-	if (mode & 4) gmt_message (GMT, "\t     +p[-][<pen>] to set pen attributes, prepend - to turn off head outlines [default pen and outline].\n");
+	if (mode & 4) gmt_message (GMT, "\t     +p[<pen>] to set pen attributes, exclude <pen> to turn off head outlines [default pen and outline].\n");
 	gmt_message (GMT, "\t     +q if start and stop opening angle is given instead of (azimuth,length) on input.\n");
 	gmt_message (GMT, "\t     +r to only draw right side of all specified vector heads [both sides].\n");
 	if (mode & 2) gmt_message (GMT, "\t     +s if (x,y) coordinates of tip is given instead of (azimuth,length) on input.\n");
@@ -13328,9 +13328,9 @@ int gmt_parse_vector (struct GMT_CTRL *GMT, char symbol, char *text, struct GMT_
 	  	  			else if (p[2] == 'r') S->v.status |= PSL_VEC_END_R;	/* Only right half of head requested */
 				}
 				break;
-			case 'g':	/* Vector head fill +g[-|<fill>]*/
+			case 'g':	/* Vector head fill +g[<fill>]*/
 				g_opt = true;	/* Marks that +g was used */
-				if (p[1] == '-') break; /* Do NOT turn on fill */
+				if (p[1] == '-' || p[1] == '\0') break; /* Do NOT turn on fill [- is deprecated] */
 				S->v.status |= PSL_VEC_FILL;
 				if (p[1]) {
 					if (gmt_getfill (GMT, &p[1], &S->v.fill)) {
@@ -13426,9 +13426,11 @@ int gmt_parse_vector (struct GMT_CTRL *GMT, char symbol, char *text, struct GMT_
 				else {	/* Successful parsing of pole */
 					S->v.pole[GMT_X] = (float)value[GMT_X];	S->v.pole[GMT_Y] = (float)value[GMT_Y];}
 				break;
-			case 'p':	/* Vector pen and head outline +p[-][<pen>] */
+			case 'p':	/* Vector pen and head outline +p[<pen>] */
 				p_opt = true;	/* Marks that +p was used */
-				if (p[1] == '-')	/* Do NOT turn on head outlines */
+				if (p[1] == '\0')	/* Do NOT turn on head outlines */
+					j = 1;
+				else if (p[1] == '-')	/* Do NOT turn on head outlines [deprecated] */
 					j = 2;
 				else {	/* Do turn on head outlines */
 					j = 1;

--- a/test/modern/vector.ps
+++ b/test/modern/vector.ps
@@ -1,17 +1,16 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_a687508-dirty [64-bit] Document from psxy
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.0.1_827b25a_2019.11.30 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Wed Feb 13 13:57:29 2019
+%%CreationDate: Sat Nov 30 21:52:20 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
 %%Pages: 1
 %%EndComments
-
 %%BeginProlog
 250 dict begin
 /! {bind def} bind def
@@ -336,9 +335,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +591,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +634,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -648,21 +642,16 @@ end
 /PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
 /PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
 %%EndProlog
-
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
-PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
-
 %%Page: 1 1
-
 %%BeginPageSetup
 V 0.06 0.06 scale
 %%EndPageSetup
-
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
+/PSL_plot_completion {} def
 /PSL_movie_completion {} def
 %PSL_End_Header
 gsave
@@ -670,11 +659,9 @@ gsave
 FQ
 O0
 1200 1200 TM
-
 % PostScript produced by:
 %@GMT: gmt psxy -R0/5/0/2 -Jx1i -Sv0.2i+s+b+e
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 2.00000000 0.000 5.000 0.000 2.000 +xy
-%GMTBoundingBox: 72 72 360 144
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
@@ -712,7 +699,6 @@ PSL_cliprestore
 FQ
 O0
 0 472 TM
-
 % PostScript produced by:
 %@GMT: gmt psxy -Sv0.2i+s+b+e -W1p -Y1c -R0/5/0/2 -Jx1i
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 2.00000000 0.000 5.000 0.000 2.000 +xy
@@ -753,7 +739,6 @@ PSL_cliprestore
 FQ
 O0
 0 472 TM
-
 % PostScript produced by:
 %@GMT: gmt psxy -Sv0.2i+s+b+e+p -W1p -Y1c -R0/5/0/2 -Jx1i
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 2.00000000 0.000 5.000 0.000 2.000 +xy
@@ -779,13 +764,13 @@ PSL_vecheadpen
 0 0 M
 240 -64 D
 0 128 D
-P clip fs P S U
+P clip fs N U
 V 4800 1200 T PSL_vecheadpen
 17 W
 0 0 M
 -240 64 D
 0 -128 D
-P clip fs P S 
+P clip fs N 
 U
 U
 PSL_cliprestore
@@ -794,7 +779,6 @@ PSL_cliprestore
 FQ
 O0
 0 472 TM
-
 % PostScript produced by:
 %@GMT: gmt psxy -Sv0.2i+s+b+e+p- -W1p -Y1c -R0/5/0/2 -Jx1i
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 2.00000000 0.000 5.000 0.000 2.000 +xy
@@ -835,7 +819,6 @@ PSL_cliprestore
 FQ
 O0
 0 472 TM
-
 % PostScript produced by:
 %@GMT: gmt psxy -Sv0.2i+s+b+e+p3p -W1p -Y1c -R0/5/0/2 -Jx1i
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 2.00000000 0.000 5.000 0.000 2.000 +xy
@@ -876,7 +859,6 @@ PSL_cliprestore
 FQ
 O0
 0 472 TM
-
 % PostScript produced by:
 %@GMT: gmt psxy -Sv0.2i+s+b+e -Gblack -Y1c -R0/5/0/2 -Jx1i
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 2.00000000 0.000 5.000 0.000 2.000 +xy
@@ -918,7 +900,6 @@ PSL_cliprestore
 FQ
 O0
 0 472 TM
-
 % PostScript produced by:
 %@GMT: gmt psxy -Sv0.2i+s+b+e+g -Gblack -Y1c -R0/5/0/2 -Jx1i
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 2.00000000 0.000 5.000 0.000 2.000 +xy
@@ -945,13 +926,13 @@ PSL_vecheadpen
 0 0 M
 240 -64 D
 0 128 D
-P clip fs P S U
+P clip  P S U
 V 4800 1200 T PSL_vecheadpen
 4 W
 0 0 M
 -240 64 D
 0 -128 D
-P clip fs P S 
+P clip  P S 
 U
 U
 PSL_cliprestore
@@ -960,7 +941,6 @@ PSL_cliprestore
 FQ
 O0
 0 472 TM
-
 % PostScript produced by:
 %@GMT: gmt psxy -Sv0.2i+s+b+e+g- -Gblack -Y1c -R0/5/0/2 -Jx1i
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 2.00000000 0.000 5.000 0.000 2.000 +xy
@@ -1002,7 +982,6 @@ PSL_cliprestore
 FQ
 O0
 0 472 TM
-
 % PostScript produced by:
 %@GMT: gmt psxy -Sv0.2i+s+b+e+gred -Gblack -Y1c -R0/5/0/2 -Jx1i
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 2.00000000 0.000 5.000 0.000 2.000 +xy
@@ -1044,7 +1023,6 @@ PSL_cliprestore
 FQ
 O0
 0 472 TM
-
 % PostScript produced by:
 %@GMT: gmt psxy -Sv0.2i+s+b+e -W1p -Gblack -Y1c -R0/5/0/2 -Jx1i
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 2.00000000 0.000 5.000 0.000 2.000 +xy
@@ -1086,7 +1064,6 @@ PSL_cliprestore
 FQ
 O0
 0 472 TM
-
 % PostScript produced by:
 %@GMT: gmt psxy -Sv0.2i+s+b+e+p-+gred -W1p -Gblack -Y1c -R0/5/0/2 -Jx1i
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 2.00000000 0.000 5.000 0.000 2.000 +xy
@@ -1124,15 +1101,12 @@ U
 U
 PSL_cliprestore
 %%EndObject
-
 grestore
 PSL_movie_completion /PSL_movie_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage
-
 %%Trailer
-
 end
 %%EOF

--- a/test/modern/vector.sh
+++ b/test/modern/vector.sh
@@ -5,14 +5,16 @@ echo 1 1 4 1 | gmt plot -R0/5/0/2 -Jx1i -Sv0.2i+s+b+e
 
 echo 1 1 4 1 | gmt plot -Sv0.2i+s+b+e -W1p -Y1c
 echo 1 1 4 1 | gmt plot -Sv0.2i+s+b+e+p -W1p -Y1c
+# Try the deprecated +p-
 echo 1 1 4 1 | gmt plot -Sv0.2i+s+b+e+p- -W1p -Y1c
 echo 1 1 4 1 | gmt plot -Sv0.2i+s+b+e+p3p -W1p -Y1c
 
 echo 1 1 4 1 | gmt plot -Sv0.2i+s+b+e -Gblack -Y1c
 echo 1 1 4 1 | gmt plot -Sv0.2i+s+b+e+g -Gblack -Y1c
+# Try the deprecated +g-
 echo 1 1 4 1 | gmt plot -Sv0.2i+s+b+e+g- -Gblack -Y1c
 echo 1 1 4 1 | gmt plot -Sv0.2i+s+b+e+gred -Gblack -Y1c
 
 echo 1 1 4 1 | gmt plot -Sv0.2i+s+b+e -W1p -Gblack -Y1c
-echo 1 1 4 1 | gmt plot -Sv0.2i+s+b+e+p-+gred -W1p -Gblack -Y1c
+echo 1 1 4 1 | gmt plot -Sv0.2i+s+b+e+p+gred -W1p -Gblack -Y1c
 gmt end show


### PR DESCRIPTION
The trailing - is not needed to turn off vector head outline and fill, respectively, but we will accept them as backwards compatible versions of **+p** and **+g** (i.e., no arguments turns off the outline and fill).
