### PR TITLE
blockmode: Remove redundant %s format string

### DIFF
--- a/src/blockmode.c
+++ b/src/blockmode.c
@@ -63,7 +63,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 		GMT_Message (API, GMT_TIME_NONE, "\t[-A<fields>] [-C] [-D<width>[+c][+l|h]] [-E] [-Er|s[+l|h]] [-Q] [-W[i][o][+s]]\n", GMT_V_OPT);
 	else
 		GMT_Message (API, GMT_TIME_NONE, "\t[-A<fields>] [-C] [-D<width>[+c][+l|h]] [-E] [-Er|s[+l|h]] [-G<grdfile>] [-Q] [-W[i][o][+s]]\n", GMT_V_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s] [%s] [%s]\n\n",
+	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s] [%s]\n\n",
 		GMT_a_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_o_OPT, GMT_r_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);


### PR DESCRIPTION
`gmt blockmode -` crashes due to a redundant %s format string.
This PR fixes it.

```
gmt blockmode [core] 6.0.1_296d3b9_2019.11.29 [64-bit] - Block average (x,y,z) data tables by mode estimation

usage: gmt blockmode [<table>] -I<xinc>[<unit>][+e|n][/<yinc>[<unit>][+e|n]] -R<west>/<east>/<south>/<north>[+r]
	[-A<fields>] [-C] [-D<width>[+c][+l|h]] [-E] [-Er|s[+l|h]] [-G<grdfile>] [-Q] [-W[i][o][+s]]
ERROR: Caught signal number 11 (Segmentation fault) at
0   libsystem_platform.dylib            0x00007fff67fbe6f2 _platform_strlen + 18
1   ???                                 0x0000000000000000 0x0 + 0
Stack backtrace:
0   libgmt.6.dylib                      0x000000010dd3e927 sig_handler + 583
1   libsystem_platform.dylib            0x00007fff67fc1b5d _sigtramp + 29
2   ???                                 0x0000000000000000 0x0 + 0
3   libsystem_c.dylib                   0x00007fff67e6516a __vfprintf + 8812
4   libsystem_c.dylib                   0x00007fff67e8b1c3 __v2printf + 475
5   libsystem_c.dylib                   0x00007fff67e70b03 _vsnprintf + 410
6   libsystem_c.dylib                   0x00007fff67e70baa vsnprintf + 68
7   libgmt.6.dylib                      0x000000010dd4e8b5 GMT_Message + 293
8   libgmt.6.dylib                      0x000000010def5c57 usage + 247
9   libgmt.6.dylib                      0x000000010de82818 gmt_report_usage + 120
10  libgmt.6.dylib                      0x000000010def2762 GMT_blockmode + 306
11  libgmt.6.dylib                      0x000000010dd5cf0f GMT_Call_Module + 1919
12  gmt                                 0x000000010dd36d33 main + 2051
13  libdyld.dylib                       0x00007fff67dd63d5 start + 1
```