### PR TITLE
doc: Add missing -a option to block* manpages

### DIFF
--- a/doc/rst/source/blockmean.rst
+++ b/doc/rst/source/blockmean.rst
@@ -19,8 +19,10 @@ Synopsis
 [ |-C| ]
 [ |-E|\ [**+p**\ \|\ **P**] ]
 [ |-G|\ [*grdfile*] ]
+[ |-S|\ [**m**\ \|\ **n**\ \|\ **s**\ \|\ **w**] ]
 [ |SYN_OPT-V| ]
 [ |-W|\ [**i**\ \|\ **o**][**+s**] ]
+[ |SYN_OPT-a| ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
 [ |SYN_OPT-e| ]
@@ -107,7 +109,7 @@ Optional Arguments
 **-S**\ [**m**\ \|\ **n**\ \|\ **s**\ \|\ **w**]
     Use **-Sn** to report the number of input points inside each block,
     **-Ss** to report the sum of all *z*-values inside a block, **-Sw**
-    to report the sum of weights [Default (or **-Sm** reports mean value]. 
+    to report the sum of weights [Default (or **-Sm** reports mean value].
 
 .. _-V:
 
@@ -126,15 +128,17 @@ Optional Arguments
     unweighted i/o]. If your weights are actually uncertainties (one sigma)
     then append **+s** and we compute weight = 1/sigma.
 
+.. include:: explain_-aspatial.rst_
+
 .. |Add_-bi| replace:: [Default is 3 (or 4 if **-Wi** is set)].
 .. include:: explain_-bi.rst_
-   
- 
+
+
 .. |Add_-bo| replace:: [Default is 3 (or 4 if **-Wo** is set)]. **-E** adds 3 additional columns.
    The **-Sn** option will work with only 2 input columns (x and y).
 
 .. include:: explain_-bo.rst_
- 
+
 .. |Add_-d| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-d.rst_
 
@@ -150,7 +154,7 @@ Optional Arguments
 .. include:: explain_-icols.rst_
 .. include:: explain_-ocols.rst_
 
-.. |Add_nodereg| replace:: 
+.. |Add_nodereg| replace::
     Each block is the locus of points nearest the grid value location. Consider an example with
     **-R**\ 10/15/10/15 and **-I**\ 1: With the |SYN_OPT-r| option, 10 <=
     (*x*,\ *y*) < 11 is one of 25 blocks; without it 9.5 <= (*x*,\ *y*)

--- a/doc/rst/source/blockmedian.rst
+++ b/doc/rst/source/blockmedian.rst
@@ -23,6 +23,7 @@ Synopsis
 [ |-T|\ *quantile* ]
 [ |SYN_OPT-V| ]
 [ |-W|\ [**i**\ \|\ **o**][**+s**] ]
+[ |SYN_OPT-a| ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
 [ |SYN_OPT-e| ]
@@ -148,6 +149,8 @@ Optional Arguments
     input only, and **-Wo** for weighted output only. [Default uses
     unweighted i/o]. If your weights are actually uncertainties (one sigma)
     then append **+s** and we compute weight = 1/sigma.
+
+.. include:: explain_-aspatial.rst_
 
 .. |Add_-bi| replace:: [Default is 3 (or 4 if **-Wi** is set)].
 .. include:: explain_-bi.rst_

--- a/doc/rst/source/blockmode.rst
+++ b/doc/rst/source/blockmode.rst
@@ -23,6 +23,7 @@ Synopsis
 [ |-Q| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ [**i**\ \|\ **o**][**+s**] ]
+[ |SYN_OPT-a| ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
 [ |SYN_OPT-e| ]
@@ -50,7 +51,7 @@ or **blockmode** should be used as a pre-processor before running
 generally useful for decimating or averaging (*x*,\ *y*,\ *z*) data. You
 can modify the precision of the output format by editing the
 :ref:`FORMAT_FLOAT_OUT <FORMAT_FLOAT_OUT>` parameter in your :doc:`gmt.conf` file, or you may
-choose binary input and/or output to avoid loss of precision. 
+choose binary input and/or output to avoid loss of precision.
 
 Required Arguments
 ------------------
@@ -131,7 +132,7 @@ Optional Arguments
 
 **-Q**
     (Quicker) Finds mode *z* and mean (*x*,\ *y*) [Default finds mode
-    *x*, mode *y*, mode *z*]. 
+    *x*, mode *y*, mode *z*].
 
 .. _-V:
 
@@ -146,9 +147,11 @@ Optional Arguments
     Weights can be used in input to construct weighted modal values for each
     block. Weight sums can be reported in output for later combining
     several runs, etc. Use **-W** for weighted i/o, **-Wi** for weighted
-    input only, and **-Wo** for weighted output only. [Default uses unweighted i/o]. 
+    input only, and **-Wo** for weighted output only. [Default uses unweighted i/o].
     If your weights are actually uncertainties (one sigma)
     then append **+s** and we compute weight = 1/sigma.
+
+.. include:: explain_-aspatial.rst_
 
 .. |Add_-bi| replace:: [Default is 3 (or 4 if **-Wi** is set)].
 .. include:: explain_-bi.rst_
@@ -171,7 +174,7 @@ Optional Arguments
 .. include:: explain_-icols.rst_
 .. include:: explain_-ocols.rst_
 
-.. |Add_nodereg| replace:: 
+.. |Add_nodereg| replace::
     Each block is the locus of points nearest the grid value location. Consider an example with
     **-R**\ 10/15/10/15 and **-I**\ 1: With the |SYN_OPT-r| option, 10 <=
     (*x*,\ *y*) < 11 is one of 25 blocks; without it 9.5 <= (*x*,\ *y*)


### PR DESCRIPTION
**-a** is missing in the manpage of block* modules.