### PR TITLE
Initialise potentially uninitialised variables

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -4174,12 +4174,12 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 	 */
 
 	int i, j, k = 0, m, n, nlen, slash, l_pos[3], p_pos[3], t_pos[3], d_pos[3], id, project;
-	int n_slashes = 0, last_pos, error = 0;
+	int n_slashes = 0, last_pos = 0, error = 0;
 	unsigned int mod_flag = 0;
 	bool width_given = false;
 	double c, az, GMT_units[3] = {0.01, 0.0254, 1.0};      /* No of meters in a cm, inch, m */
 	char mod, args_cp[GMT_BUFSIZ] = {""}, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""};
-	char txt_d[GMT_LEN256] = {""}, txt_e[GMT_LEN256] = {""}, last_char, *d = NULL;
+	char txt_d[GMT_LEN256] = {""}, txt_e[GMT_LEN256] = {""}, last_char = 0, *d = NULL;
 	char txt_arr[11][GMT_LEN256];
 
 	if (args == NULL) {

--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -1887,6 +1887,8 @@ int gmt_write_nc_cube (struct GMT_CTRL *GMT, struct GMT_GRID **G, uint64_t nlaye
 		first_col = first_row = 0;
 		last_col  = header->n_columns - 1;
 		last_row  = header->n_rows - 1;
+		level_min = DBL_MAX;
+		level_max = -DBL_MAX;
 		
 		/* Adjust first_row */
 		if (HH->row_order == k_nc_start_south)
@@ -1899,8 +1901,6 @@ int gmt_write_nc_cube (struct GMT_CTRL *GMT, struct GMT_GRID **G, uint64_t nlaye
 			goto nc_err;
 
 		/* Get stats */
-		level_min = DBL_MAX;
-		level_max = -DBL_MAX;
 		adj_nan_value = !isnan (header->nan_value);
 		dim[0]    = height,    dim[1]    = width;
 

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -9443,7 +9443,7 @@ struct GMT_DATASET *gmt_make_profiles (struct GMT_CTRL *GMT, char option, char *
 	bool continuous = false;
 	uint64_t dim[GMT_DIM_SIZE] = {1, 1, 0, 0};
 	int n, error = 0;
-	double L, az = 0.0, length = 0.0, r = 0.0, orig_step = step, last_x, last_y;
+	double L, az = 0.0, length = 0.0, r = 0.0, orig_step = step, last_x = 0, last_y = 0;
 	size_t len;
 	char p[GMT_BUFSIZ] = {""}, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""}, txt_d[GMT_LEN256] = {""};
 	char modifiers[GMT_BUFSIZ] = {""}, p2[GMT_BUFSIZ] = {""};

--- a/src/grdfill.c
+++ b/src/grdfill.c
@@ -474,7 +474,7 @@ GMT_LOCAL void nearest_interp (struct GMT_CTRL *GMT, struct GMT_GRID *In, struct
 
 int GMT_grdfill (void *V_API, int mode, void *args) {
 	char *ID = NULL, *RG_orig_hist = NULL;
-	int error = 0, RG_id;
+	int error = 0, RG_id = 0;
 	unsigned int hole_number = 0, row, col, limit[4], n_nodes;
 	uint64_t node, offset;
 	int64_t off[4];

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -131,7 +131,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDINTERPOLATE_CTRL *Ctrl, str
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int n_errors = 0, n_files = 0, n_alloc = 0, mode;
+	unsigned int n_errors = 0, n_files = 0, n_alloc = 0, mode = 0;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 


### PR DESCRIPTION
**Description of proposed changes**

Get rid of some warnings by properly initialising some variables.
Applies to "master" only.
