### PR TITLE
Give an error if CPT file does not exist.

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -7102,6 +7102,7 @@ void *GMT_Read_Data (void *V_API, unsigned int family, unsigned int method, unsi
 				if (elen)	/* Master: Append extension and supply path */
 					gmt_getsharepath (API->GMT, "cpt", file, ext, CPT_file, R_OK);
 				else if (!gmt_getdatapath (API->GMT, file, CPT_file, R_OK)) {	/* Use name.cpt as is but look for it */
+					GMT_Report (API, GMT_MSG_NORMAL, "GMT_Read_Data: File not found: %s\n", file);
 					gmt_M_str_free (input);
 					return_null (API, GMT_FILE_NOT_FOUND);	/* Failed to find the file anywyere */
 				}


### PR DESCRIPTION
ThHe psxyz module would not check if **-C**file.cpt existed, just exit without a message.  This PR addresses the first of the three problems raised in #2209.

