### PR TITLE
Ensure a default pen is selected if neither -W -G set

### DIFF
--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -868,7 +868,6 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 			if (!Ctrl->W.active)	/* No outline of QR code */
 				PSL_command (PSL, "/QR_outline false def\n");
 		}
-		outline_active =  Ctrl->W.active;
 		if (S.read_size && GMT->current.io.col[GMT_IN][ex1].convert) {	/* Doing math on the size column, must delay unit conversion unless inch */
 			gmt_set_column (GMT, GMT_IN, ex1, GMT_IS_FLOAT);
 			if (S.u_set)


### PR DESCRIPTION
Unlike psxy, the psxyz module failed to set outline if no fill nor outline was selected for a symbol.  Addresses point 2 of #2209.
