### PR TITLE
Ensure modern names are used in modern mode verbose messages

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -11082,7 +11082,8 @@ int GMT_Report (void *V_API, unsigned int level, const char *format, ...) {
 	/* Message whose output depends on verbosity setting */
 	size_t source_info_len = 0;
 	unsigned int g_level;
-	const char *module_name, not_used[GMT_LEN32];
+	const char *module_name;
+	char not_used[GMT_LEN32];
 	FILE *err = stderr;
 	struct GMTAPI_CTRL *API = NULL;
 	struct GMT_CTRL *GMT = NULL;

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -11082,7 +11082,7 @@ int GMT_Report (void *V_API, unsigned int level, const char *format, ...) {
 	/* Message whose output depends on verbosity setting */
 	size_t source_info_len = 0;
 	unsigned int g_level;
-	const char *module_name;
+	const char *module_name, not_used[GMT_LEN32];
 	FILE *err = stderr;
 	struct GMTAPI_CTRL *API = NULL;
 	struct GMT_CTRL *GMT = NULL;
@@ -11105,7 +11105,7 @@ int GMT_Report (void *V_API, unsigned int level, const char *format, ...) {
 		}
 	}
 	if (GMT && GMT->init.module_name)
-		module_name = ((GMT->current.setting.run_mode == GMT_MODERN)) ? gmtlib_get_active_name (API, GMT->init.module_name) : GMT->init.module_name;
+		module_name = ((GMT->current.setting.run_mode == GMT_MODERN)) ? gmt_current_name (GMT->init.module_name, not_used) : GMT->init.module_name;
 	else
 		module_name = API->session_tag;
 


### PR DESCRIPTION
Previous solution was sensitive to given module name but should only need to check if modern mode or not.  Closes #2210.
