### PR TITLE
Add new share/tools script to get remote files

### DIFF
--- a/doc/rst/source/datasets/earth_relief.rst
+++ b/doc/rst/source/datasets/earth_relief.rst
@@ -104,6 +104,13 @@ There are several ways you can control the amount of space taken up by your own 
 #. You can be clever and set up a crontab job that deletes data files you have not
    touched in, say, 6 months (or some other interval).
 
+Offline Usage
+-------------
+
+If you anticipate to be without an Internet connection (or a very slow one), you can download
+all the remote files prior to loosing connection, using the shell script gmt_getremote.sh in
+share/tools.  It also allows you to download all the cache files used for examples.
+
 Data References
 ---------------
 

--- a/share/tools/CMakeLists.txt
+++ b/share/tools/CMakeLists.txt
@@ -27,6 +27,7 @@ install (PROGRAMS
 	gmt_prepmex.sh
 	gmt_make_custom_code.sh
 	gmt_uninstall.sh
+	gmt_getremote.sh
 	ncdeflate
 	${CMAKE_CURRENT_BINARY_DIR}/gmt5syntax
 	DESTINATION ${GMT_DATADIR}/tools

--- a/share/tools/gmt_getremote.sh
+++ b/share/tools/gmt_getremote.sh
@@ -46,6 +46,6 @@ if [ ${cache} -eq 1 ]; then
 fi
 if [ ${data} -eq 1 ]; then
 	echo "Download all remote DEM grids from ${SERVER} not in ~/gmt/server (be very patient)" >&2
-	awk 'NF==3 && $1~/earth/ {print "@"$1}' /tmp/gmt_hash_server.txt | xargs gmt which -Gu
+	awk 'NF==3 && $1~/earth_relief/ {print "@"$1}' /tmp/gmt_hash_server.txt | xargs gmt which -Gu
 fi
 rm -f /tmp/gmt_hash_server.txt

--- a/share/tools/gmt_getremote.sh
+++ b/share/tools/gmt_getremote.sh
@@ -45,7 +45,7 @@ if [ ${cache} -eq 1 ]; then
 	awk 'NF==3 && $1!~/^earth_relief/ {print "@"$1}' /tmp/gmt_hash_server.txt | xargs gmt which -Gc
 fi
 if [ ${data} -eq 1 ]; then
-	echo "Download all remote DEM grids from ${SERVER} not in ~/gmt/server (be very patient)" >&2
+	echo "Download all remote DEM grids from ${SERVER} not in ~/.gmt/server (be very patient)" >&2
 	awk 'NF==3 && $1~/earth_relief/ {print "@"$1}' /tmp/gmt_hash_server.txt | xargs gmt which -Gu
 fi
 rm -f /tmp/gmt_hash_server.txt

--- a/share/tools/gmt_getremote.sh
+++ b/share/tools/gmt_getremote.sh
@@ -42,7 +42,7 @@ fi
 
 if [ ${cache} -eq 1 ]; then
 	echo "Download all cache files from ${SERVER} not in ~/.gmt/cache (be patient)" >&2
-	awk 'NF==3 && $1!~/earth/ {print "@"$1}' /tmp/gmt_hash_server.txt | xargs gmt which -Gc
+	awk 'NF==3 && $1!~/^earth_relief/ {print "@"$1}' /tmp/gmt_hash_server.txt | xargs gmt which -Gc
 fi
 if [ ${data} -eq 1 ]; then
 	echo "Download all remote DEM grids from ${SERVER} not in ~/gmt/server (be very patient)" >&2

--- a/share/tools/gmt_getremote.sh
+++ b/share/tools/gmt_getremote.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 1991-2019 by the GMT Team (https://www.generic-mapping-tools.org/team.html)
+# See LICENSE.TXT file for copying and redistribution conditions.
+#
+# This script downloads any missing cache or data sets from the remote server.
+#
+# Run this script on the command line with:
+#   $(gmt --show-sharedir)/tools/gmt_getremote.sh [cache|data]
+#
+# It expects the GMT executable to be in the search path and that
+# you have the curl executable installed.
+
+# check for bash
+[ -z "$BASH_VERSION" ] && return
+
+if ! [ -x "$(command -v gmt)" ]; then
+	echo 'Error: gmt is not found in your search PATH.' >&2
+	exit 1
+fi
+if ! [ -x "$(command -v curl)" ]; then
+	echo 'Error: curl is not found in your search PATH.' >&2
+	exit 1
+fi
+
+# By default download both cache (=1) and data (=1)
+data=1
+cache=1
+if [ "X$1" = "Xcache" ]; then	# Not do data
+	data=0
+elif [ "X$1" = "Xdata" ]; then	# Not do cache
+	cache=0
+fi
+
+# Get current remote data server
+SERVER=`gmt get GMT_DATA_SERVER`
+curl -sk ${SERVER}/gmt_hash_server.txt > /tmp/gmt_hash_server.txt
+if [ $? -ne 0 ]; then
+	echo "Error: curl failed with error $?" >&2
+	exit 1
+fi
+
+if [ ${cache} -eq 1 ]; then
+	echo "Download all cache files from ${SERVER} not in ~/.gmt/cache (be patient)" >&2
+	awk 'NF==3 && $1!~/earth/ {print "@"$1}' /tmp/gmt_hash_server.txt | xargs gmt which -Gc
+fi
+if [ ${data} -eq 1 ]; then
+	echo "Download all remote DEM grids from ${SERVER} not in ~/gmt/server (be very patient)" >&2
+	awk 'NF==3 && $1~/earth/ {print "@"$1}' /tmp/gmt_hash_server.txt | xargs gmt which -Gu
+fi
+rm -f /tmp/gmt_hash_server.txt


### PR DESCRIPTION
It is convenient for users to download all the cache and server DEMs prior to trips where internet connectivity may be poor or lacking.  gmt_getremote.sh downloads all the files not already on the system.

Still need a few documentation-related things and possibly Cmake somewhere?