### PR TITLE
Add a link to the Wikipedia page on country codes

### DIFF
--- a/doc/rst/source/explain_-Rgeo.rst_
+++ b/doc/rst/source/explain_-Rgeo.rst_
@@ -9,7 +9,7 @@
     Set geographic regions by specifying ISO country codes from the Digital Chart of the World using
     **-R**\ *code1,code2,...*\ [**+r**\|\ **R**\ [*incs*]] instead:
     Append one or more comma-separated countries using the 2-character
-    ISO 3166-1 alpha-2 convention.  To select a state of a country
+    `ISO 3166-1 alpha-2 convention <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>`_.  To select a state of a country
     (if available), append .state, e.g, US.TX for Texas.  To specify a
     whole continent, prepend = to any of the continent codes AF (Africa),
     AN (Antarctica), AS (Asia), EU (Europe), OC (Oceania),


### PR DESCRIPTION
Edited explain_-Rgeo.rst_ in the documentation to include a link to a table for the ISO 3166-1 alpha-2 convention for country codes on Wikipedia.



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Correct base branch selected? `master` for new features, `6.0` for bug fixes
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
