### PR TITLE
If transparency is <= 1, give warning about using percentage

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14998,6 +14998,9 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 					GMT->common.t.value = 0.0;
 					error++;
 				}
+				else if (GMT->common.t.value <= 1.0) {
+					GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Transparency is expected in percentage.  Did you mean %g?\n", GMT->common.t.value * 100.0);
+				}
 				GMT->common.t.active = true;
 			}
 			else if (!strncmp (GMT->init.module_name, "psxy", 4U) || !strncmp (GMT->init.module_name, "pstext", 6U)) {	/* Modules psxy, psxyz, and pstext can do variable transparency */


### PR DESCRIPTION
If user gives **-t**0.3 it is likely they forgot to specify transparency in percentage (i.e., **-t**30) but we don't know that, so we just warn.
