### PR TITLE
Update old-style -C option in pscoast to use modifiers

### DIFF
--- a/doc/rst/source/coast.rst
+++ b/doc/rst/source/coast.rst
@@ -16,7 +16,7 @@ Synopsis
 |SYN_OPT-R|
 [ |SYN_OPT-Area| ]
 [ |SYN_OPT-B| ]
-[ |-C|\ [**l**\ \|\ **r**/]\ *fill* ]
+[ |-C|\ *fill*\ [**+l**\ \|\ **+r**\ ] ]
 [ |-D|\ *resolution*\ [**+f**] ]
 [ |-E|\ *dcw* ]
 [ |-F|\ *box* ]

--- a/doc/rst/source/coast_common.rst_
+++ b/doc/rst/source/coast_common.rst_
@@ -48,10 +48,10 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ [**l**\ \|\ **r**/]\ *fill* :ref:`(more ...) <-Gfill_attrib>`
+**-C**\ *fill*\ [**+l**\ \|\ **+r**\ ] :ref:`(more ...) <-Gfill_attrib>`
     Set the shade, color, or pattern for lakes and river-lakes [Default
     is the fill chosen for "wet" areas (**-S**)]. Optionally, specify
-    separate fills by prepending **l/** for lakes and **r/** for
+    separate fills by appending **+l** for lakes or **+r** for
     river-lakes, repeating the **-C** option as needed.
 
 .. _-D:

--- a/doc/rst/source/pscoast.rst
+++ b/doc/rst/source/pscoast.rst
@@ -16,7 +16,7 @@ Synopsis
 |SYN_OPT-R|
 [ |SYN_OPT-Area| ]
 [ |SYN_OPT-B| ]
-[ |-C|\ [**l**\ \|\ **r**/]\ *fill* ]
+[ |-C|\ *fill*\ [**+l**\ \|\ **+r**\ ] ]
 [ |-D|\ *resolution*\ [**+f**] ]
 [ |-E|\ *dcw* ]
 [ |-F|\ *box* ]


### PR DESCRIPTION
While **-A** uses **+l** or **+r** to set lakes or river-lakes, the **-C** option used **-Cl**/_fill_ and **-Cr**/_fill_ to set the fill.  This PR makes the new syntax **-C**_fill_[**+r**|**+l**] so it is more consistent with both itself and other modules.
