### PR TITLE
Default dpi for patterns was incorrect

### DIFF
--- a/doc/rst/source/explain_fill.rst_
+++ b/doc/rst/source/explain_fill.rst_
@@ -7,7 +7,7 @@
     Patterns are specified as **p**\ *pattern*, where *pattern*
     set the number of the built-in pattern (1-90) *or* the name of a
     raster image file. The optional **+r**\ *dpi* sets the resolution of
-    the image [1200]. For 1-bit rasters: use upper case **P**  for inverse
+    the image [300]. For 1-bit rasters: use upper case **P**  for inverse
     video, or append **+f**\ *color* and/or **+b**\ *color* to specify
     fore- and background colors (no *color* given means transparency). See
     GMT Cookbook & Technical Reference Appendix E for information on

--- a/doc/scripts/GMT_volcano.ps
+++ b/doc/scripts/GMT_volcano.ps
@@ -1,17 +1,16 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_831abca_2019.06.27 [64-bit] Document from psxy
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.0.1_7efa70f-dirty_2019.12.09 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Jun 27 12:16:19 2019
+%%CreationDate: Tue Dec 10 16:44:07 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
 %%Pages: 1
 %%EndComments
-
 %%BeginProlog
 250 dict begin
 /! {bind def} bind def
@@ -643,21 +642,16 @@ end
 /PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
 /PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
 %%EndProlog
-
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
-PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
-
 %%Page: 1 1
-
 %%BeginPageSetup
 V 0.06 0.06 scale
 %%EndPageSetup
-
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
+/PSL_plot_completion {} def
 /PSL_movie_completion {} def
 %PSL_End_Header
 gsave
@@ -665,11 +659,9 @@ gsave
 FQ
 O0
 1200 1200 TM
-
 % PostScript produced by:
 %@GMT: gmt psxy -R-0.5/0.5/-0.5/0.5 -JX2i -Ba0.25g0.05 -BWSne -Wthick -Skvolcano/2i
 %@PROJ: xy -0.50000000 0.50000000 -0.50000000 0.50000000 -0.500 0.500 -0.500 0.500 +xy
-%GMTBoundingBox: 72 72 144 144
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
@@ -931,7 +923,6 @@ PSL_cliprestore
 FQ
 O0
 3000 0 TM
-
 % PostScript produced by:
 %@GMT: gmt psxy -N -Ba0.25g0.05 -BwSnE -Wthick -Skbullseye/2i -X2.5i -R-0.5/0.5/-0.5/0.5 -JX2i
 %@PROJ: xy -0.50000000 0.50000000 -0.50000000 0.50000000 -0.500 0.500 -0.500 0.500 +xy
@@ -1170,7 +1161,7 @@ V 1200 1200 T
 /image12 {<~
 G[=nX`s@D.runV?*Wcl)6f8&l#lMIKJNqd1n..;X6FAU9[51(U2aFbmJ80Q6ec#TLr<H=!+3%1T#Ln2&OE(:$~>
 /FlateDecode filter} def
-/pattern12 {V 64 64 scale
+/pattern12 {V 256 256 scale
 << /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
    {begin [/Indexed /DeviceGray 1 <FF00>] setcolorspace
 << /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
@@ -1189,7 +1180,7 @@ FQ
 G[@^@?k8"b
 %1r<,!<W9U6Jrqt#lMLKJKOY1n:<\)6FGQ8[F[dRs+b@h#M&eYWr30%qZj(n#POqd&#fF,OE(:$~>
 /FlateDecode filter} def
-/pattern9 {V 64 64 scale
+/pattern9 {V 256 256 scale
 << /PaintType 1 /PatternType 1 /TilingType 1 /BBox [0 0 1 1] /XStep 1 /YStep 1 /PaintProc
    {begin [/Indexed /DeviceGray 1 <FF00>] setcolorspace
 << /ImageType 1 /Decode [0 1] /Width 64 /Height 64 /BitsPerComponent 1
@@ -1213,15 +1204,12 @@ currentdict /image9 undef
 currentdict /pattern9 undef
 currentdict /image12 undef
 currentdict /pattern12 undef
-
 grestore
 PSL_movie_completion /PSL_movie_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage
-
 %%Trailer
-
 end
 %%EOF

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6873,7 +6873,7 @@ void gmt_fill_syntax (struct GMT_CTRL *GMT, char option, char *longoption, char 
 	gmt_message (GMT, "\t   4) <hue>-<sat>-<val> in ranges 0-360, 0-1, 0-1;\n");
 	gmt_message (GMT, "\t   5) any valid color name;\n");
 	gmt_message (GMT, "\t   6) P|p<pattern>[+b<color>][+f<color>][+r<dpi>];\n");
-	gmt_message (GMT, "\t      Give <pattern> number from 1-90 or a filename, optionally add +r<dpi> [300].\n");
+	gmt_message (GMT, "\t      Give <pattern> number from 1-90 or a filename, optionally add +r<dpi> [%d].\n", PSL_DOTS_PER_INCH_PATTERN);
 	gmt_message (GMT, "\t      Optionally, use +f<color> or +b<color> to change fore- or background colors (no <color> sets transparency).\n");
 	gmt_message (GMT, "\t   For PDF fill transparency, append @<transparency> in the range 0-100 [0 = opaque].\n");
 }

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -176,7 +176,7 @@ GMT_LOCAL int gmtsupport_parse_pattern_new (struct GMT_CTRL *GMT, char *line, st
 	unsigned int first = 1;
 	double fb_rgb[4];
 
-	fill->dpi = irint (PSL_DOTS_PER_INCH);
+	fill->dpi = irint (PSL_DOTS_PER_INCH_PATTERN);
 	if ((c = strchr (line, '+'))) {	/* Got modifiers */
 		unsigned int pos = 0, uerr = 0;
 		char p[GMT_BUFSIZ] = {""};

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -49,6 +49,7 @@ extern "C" {
 
 #define PSL_POINTS_PER_INCH	72.0
 #define PSL_DOTS_PER_INCH	1200.0	/* Effective dots per inch resolution */
+#define PSL_DOTS_PER_INCH_PATTERN	300.0	/* Effective dots per inch resolution for a bitmap pattern -Gp */
 #define PSL_ALL_CLIP		INT_MAX	/* Terminates all clipping */
 
 /* PSL codes for geometric symbols as expected by PSL_plotsymbol */


### PR DESCRIPTION
It got set to 1200 at some point despite always having been 300 and taht is what the documentation said (with one exception).  Reset to 300; this also affects the GMT_volcano.ps file.  Closes issue #2247.