### PR TITLE
Improve grdtrack -A documentation

### DIFF
--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -93,8 +93,8 @@ Optional Arguments
     to resample at equidistant locations; input points are not
     necessarily included in the output, and **R** as **r**, but adjust
     given spacing to fit the track length exactly. Finally, append
-    **+l** if distances should be measured along rhumb lines
-    (loxodromes). Ignored unless **-C** is used.
+    **+l** if geographic distances should be measured along rhumb lines
+    (loxodromes) instead of great circles. Ignored unless **-C** is used.
 
 .. _-C:
 


### PR DESCRIPTION
Clarify that **+l** is for geographic data and switches from great circles to loxodromes.
