### PR TITLE
Add wiki link to reverse polish notation page

### DIFF
--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -38,9 +38,9 @@ Description
 -----------
 
 **math** will perform operations like add, subtract, multiply, and
-divide on one or more table data files or constants using Reverse Polish
-Notation (RPN) syntax (e.g., Hewlett-Packard calculator-style).
-Arbitrarily complicated expressions may therefore be evaluated; the
+numerous other operands on one or more table data files or constants using
+`Reverse Polish Notation (RPN) <https://en.wikipedia.org/wiki/Reverse_Polish_notation>`
+syntax.  Arbitrarily complicated expressions may therefore be evaluated; the
 final result is written to an output file [or standard output]. Data
 operations are element-by-element, not matrix manipulations (except
 where noted). Some operators only require one operand (see below). If no

--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -39,7 +39,7 @@ Description
 
 **math** will perform operations like add, subtract, multiply, and
 numerous other operands on one or more table data files or constants using
-`Reverse Polish Notation (RPN) <https://en.wikipedia.org/wiki/Reverse_Polish_notation>`
+`Reverse Polish Notation (RPN) <https://en.wikipedia.org/wiki/Reverse_Polish_notation>`_
 syntax.  Arbitrarily complicated expressions may therefore be evaluated; the
 final result is written to an output file [or standard output]. Data
 operations are element-by-element, not matrix manipulations (except

--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -38,9 +38,9 @@ Description
 -----------
 
 **grdmath** will perform operations like add, subtract, multiply, and
-divide on one or more grid files or constants using Reverse Polish
-Notation (RPN) syntax (e.g., Hewlett-Packard calculator-style).
-Arbitrarily complicated expressions may therefore be evaluated; the
+numerous other operands on one or more grid files or constants using
+`Reverse Polish Notation (RPN) <https://en.wikipedia.org/wiki/Reverse_Polish_notation>`
+syntax.  Arbitrarily complicated expressions may therefore be evaluated; the
 final result is written to an output grid file. Grid operations are
 element-by-element, not matrix manipulations. Some operators only
 require one operand (see below). If no grid files are used in the

--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -39,7 +39,7 @@ Description
 
 **grdmath** will perform operations like add, subtract, multiply, and
 numerous other operands on one or more grid files or constants using
-`Reverse Polish Notation (RPN) <https://en.wikipedia.org/wiki/Reverse_Polish_notation>`
+`Reverse Polish Notation (RPN) <https://en.wikipedia.org/wiki/Reverse_Polish_notation>`_
 syntax.  Arbitrarily complicated expressions may therefore be evaluated; the
 final result is written to an output grid file. Grid operations are
 element-by-element, not matrix manipulations. Some operators only


### PR DESCRIPTION
Wikipedia has more space to explain what it is and why it is used.
