### PR TITLE
Allow both -i and -o to specify an open-ended list to end of record

### DIFF
--- a/doc/rst/source/explain_-icols_full.rst_
+++ b/doc/rst/source/explain_-icols_full.rst_
@@ -9,6 +9,7 @@
     column, optionally add any of  the following: **+l** takes **log10** of
     the input values first; **+s**\ *scale*, subsequently multiplies by a
     given  scale factor [1]; **+o**\ *offset*, finally adds a given offset [0].
+    To read from a given column until the end of the record, leave off *stop*.
     Normally, any trailing text is read but when **i** is used you must explicitly add
     the column *t* to retain the text. To only ingest a single word from the
     trailing text, append the word number (first word is 0).  Finally, **-in**

--- a/doc/rst/source/explain_-ocols_full.rst_
+++ b/doc/rst/source/explain_-ocols_full.rst_
@@ -10,6 +10,7 @@
     Normally, any trailing text in the internal records will be written but
     when **-o** is used you must explicitly add the column *t*. To only output a single word from the
     trailing text, append the word number (first word is 0).  Finally, **-on** will
-    simply write the numerical output only and skip any trailing text.  Note: If **-i** is
+    simply write the numerical output only and skip any trailing text, while **-ot**
+    will only output the trailing text (or selected word).  Note: If **-i** is
     also used then columns given to **-o** correspond to the order *after* the **-i** selection
     and not the columns in the original record.

--- a/doc/rst/source/explain_-ocols_full.rst_
+++ b/doc/rst/source/explain_-ocols_full.rst_
@@ -5,6 +5,7 @@
     not listed will be skipped. Give columns (or column ranges
     in the format *start*\ [:*inc*]:*stop*, where *inc* defaults to 1 if
     not specified) separated by commas.  Columns may be repeated.
+    To write from a given column until the end the columns, leave off *stop*.
     [Default writes all columns in order].
     Normally, any trailing text in the internal records will be written but
     when **-o** is used you must explicitly add the column *t*. To only output a single word from the

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -4002,6 +4002,9 @@ GMT_LOCAL int api_export_dataset (struct GMTAPI_CTRL *API, int object_ID, unsign
 #endif
 	}
 	gmt_set_dataset_minmax (GMT, D_obj);	/* Update all counters and min/max arrays */
+	if (API->GMT->common.o.end)	/* Asked for unspecified last column on input (e.g., -i3,2,5:), supply the missing last column number */
+		gmtlib_reparse_o_option (API->GMT, D_obj->n_columns);
+
 	DH = gmt_get_DD_hidden (D_obj);
 	DH->io_mode = mode;	/* Handles if tables or segments should be written to separate files, according to mode */
 	method = api_set_method (S_obj);	/* Get the actual method to use */
@@ -8079,6 +8082,8 @@ GMT_LOCAL int api_put_record_init (struct GMTAPI_CTRL *API, unsigned int mode, s
 			API->api_put_record = api_put_record_fp;
 			API->current_fp = S_obj->fp;
 			API->current_put_n_columns = S_obj->n_columns;
+			if (API->GMT->common.o.end)	/* Asked for unspecified last column on input (e.g., -i3,2,5:), supply the missing last column number */
+				gmtlib_reparse_o_option (API->GMT, S_obj->n_columns);
 			error = api_put_record_fp (API, mode, record);
 			break;
 

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -4002,8 +4002,8 @@ GMT_LOCAL int api_export_dataset (struct GMTAPI_CTRL *API, int object_ID, unsign
 #endif
 	}
 	gmt_set_dataset_minmax (GMT, D_obj);	/* Update all counters and min/max arrays */
-	if (API->GMT->common.o.end)	/* Asked for unspecified last column on input (e.g., -i3,2,5:), supply the missing last column number */
-		gmtlib_reparse_o_option (API->GMT, D_obj->n_columns);
+	if (API->GMT->common.o.end || GMT->common.o.text)	/* Asked for unspecified last column on input (e.g., -i3,2,5:), supply the missing last column number */
+		gmtlib_reparse_o_option (GMT, (GMT->common.o.text) ? 0 : D_obj->n_columns);
 
 	DH = gmt_get_DD_hidden (D_obj);
 	DH->io_mode = mode;	/* Handles if tables or segments should be written to separate files, according to mode */
@@ -8082,8 +8082,8 @@ GMT_LOCAL int api_put_record_init (struct GMTAPI_CTRL *API, unsigned int mode, s
 			API->api_put_record = api_put_record_fp;
 			API->current_fp = S_obj->fp;
 			API->current_put_n_columns = S_obj->n_columns;
-			if (API->GMT->common.o.end)	/* Asked for unspecified last column on input (e.g., -i3,2,5:), supply the missing last column number */
-				gmtlib_reparse_o_option (API->GMT, S_obj->n_columns);
+			if (API->GMT->common.o.end || API->GMT->common.o.text)	/* Asked for unspecified last column on input (e.g., -i3,2,5:), supply the missing last column number */
+				gmtlib_reparse_o_option (API->GMT, (API->GMT->common.o.text) ? 0 : S_obj->n_columns);
 			error = api_put_record_fp (API, mode, record);
 			break;
 

--- a/src/gmt_common.h
+++ b/src/gmt_common.h
@@ -218,7 +218,7 @@ struct GMT_COMMON {
 		char string[GMT_LEN64];	/* Copy of argument */
 	} n;
 	struct o {	/* -o[<col>|<colrange>,...][t[<word>]] */
-		bool active, select, orig, word, end;
+		bool active, select, orig, word, end, text;
 		uint64_t n_cols, w_col;
 		char string[GMT_LEN64];
 	} o;

--- a/src/gmt_common.h
+++ b/src/gmt_common.h
@@ -191,7 +191,7 @@ struct GMT_COMMON {
 		char string[GMT_LEN256];
 	} h;
 	struct i {	/* -i[<col>|<colrange>,...][t[<word>]] */
-		bool active, select, orig, word;
+		bool active, select, orig, word, end;
 		uint64_t n_cols, w_col;
 		uint64_t n_actual_cols;
 		char string[GMT_LEN64];
@@ -218,8 +218,9 @@ struct GMT_COMMON {
 		char string[GMT_LEN64];	/* Copy of argument */
 	} n;
 	struct o {	/* -o[<col>|<colrange>,...][t[<word>]] */
-		bool active, select, orig, word;
+		bool active, select, orig, word, end;
 		uint64_t n_cols, w_col;
+		char string[GMT_LEN64];
 	} o;
 	struct p {	/* -p<az>[/<el>[/<z0>]]+wlon0/lat0[/z0]][+vx0[cip]/y0[cip]] */
 		bool active;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7884,7 +7884,7 @@ int gmt_parse_R_option (struct GMT_CTRL *GMT, char *arg) {
 int64_t gmt_parse_range (struct GMT_CTRL *GMT, char *p, int64_t *start, int64_t *stop) {
 	/* Parses p looking for range or columns or individual columns.
 	 * If neither then we just increment both start and stop. */
-	int64_t inc = 1;
+	int64_t inc = 1, r = 0;
 	int got;
 	char *c = NULL;
 	if ((c = strchr (p, '-'))) {	/* Range of columns given. e.g., 7-9 */
@@ -7903,6 +7903,10 @@ int64_t gmt_parse_range (struct GMT_CTRL *GMT, char *p, int64_t *start, int64_t 
 	else				/* Just assume it goes column by column */
 		(*start)++, (*stop)++;
 	if ((*stop) < (*start)) inc = 0L;	/* Not good */
+	if (inc > 1 && (*stop != (GMT_MAX_COLUMNS - 1)) && (r = ((*stop - *start) % inc)) != 0) {	/* Must adjust stop to fit the sequence */
+		*stop -= r;
+		GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "For -i: Sequence %s does not end at given stop value, reduced to %" PRIu64 "\n", p, *stop);
+	}
 	if (inc == 0)
 		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Bad range [%s]: col, start-stop, start:stop, or start:step:stop must yield monotonically increasing positive selections\n", p);
 	return (inc);	/* Either > 0 or 0 for error */
@@ -16650,3 +16654,4 @@ void gmtlib_reparse_o_option (struct GMT_CTRL *GMT, uint64_t n_columns) {
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Reparse -o%s\n", token);
 	gmt_parse_common_options (GMT, "o", 'o', token);	/* Re-parse updated -o */
 }
+

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7889,11 +7889,13 @@ int64_t gmt_parse_range (struct GMT_CTRL *GMT, char *p, int64_t *start, int64_t 
 	char *c = NULL;
 	if ((c = strchr (p, '-'))) {	/* Range of columns given. e.g., 7-9 */
 		got = sscanf (p, "%" PRIu64 "-%" PRIu64, start, stop);
-		if (got != 2) inc = 0L;	/* Error flag */
+		if (c[1] == '\0') *stop = GMT_MAX_COLUMNS - 1;	/* Did not specify stop, set to max */
+		else if (got != 2) inc = 0L;	/* Error flag */
 	}
 	else if ((c = strchr (p, ':'))) {	/* Range of columns given. e.g., 7:9 or 1:2:5 */
 		got = sscanf (p, "%" PRIu64 ":%" PRIu64 ":%" PRIu64, start, &inc, stop);
-		if (got == 2) { *stop = inc; inc = 1L;}	/* Just got start:stop with implicit inc = 1 */
+		if (p[strlen(p)-1] == ':') *stop = GMT_MAX_COLUMNS - 1;	/* Did not specify stop, set to max */
+		else if (got == 2) { *stop = inc; inc = 1L;}	/* Just got start:stop with implicit inc = 1 */
 		else if (got != 3 || inc < 1) inc = 0L;	/* Error flag */
 	}
 	else if (isdigit ((int)p[0]))	/* Just a single column, e.g., 3 */
@@ -7960,6 +7962,7 @@ int gmt_parse_i_option (struct GMT_CTRL *GMT, char *arg) {
 	strncpy (copy, arg, GMT_BUFSIZ-1);
 
 	GMT->current.io.trailing_text[GMT_IN] = GMT->current.io.trailing_text[GMT_OUT] = false;	/* When using -i you have to specifically add column t to parse trailing text */
+	GMT->common.i.end = false;
 	if (!strcmp (arg, "n")) return GMT_NOERROR;	/* We just wanted to process the numerical columns */
 	if (!strcmp (arg, "t") || !strcmp (arg, ",t")) {	/* Cannot just get trailing text, must use -ot instead */
 		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Selection -i%s (just trailing text, no numerical input) is not allowed.  Consider using -ot instead, if available.\n", arg);
@@ -8034,7 +8037,7 @@ int gmt_parse_i_option (struct GMT_CTRL *GMT, char *arg) {
 		}
 		else {	/* Now process column range */
 			if ((inc = gmt_parse_range (GMT, p, &start, &stop)) == 0) return (GMT_PARSE_ERROR);
-
+			if (stop == (GMT_MAX_COLUMNS-1)) GMT->common.i.end = true;	/* Gave an open interval, e.g., 3: or 4- to mean "until last column" */
 			/* Now set the code for these columns */
 
 			for (i = start; i <= stop; i += inc, k++) {
@@ -8149,6 +8152,7 @@ int gmt_parse_o_option (struct GMT_CTRL *GMT, char *arg) {
 	if (!arg || !arg[0]) return (GMT_PARSE_ERROR);	/* -o requires an argument */
 
 	strncpy (copy, arg, GMT_BUFSIZ-1);
+	strncpy (GMT->common.o.string, arg, GMT_LEN64-1);	/* Verbatim copy */
 
 	GMT->current.io.trailing_text[GMT_OUT] = false;	/* When using -o you have to specifically add column t to parse trailing text */
 	if (! strcmp (arg, "n")) return GMT_NOERROR;	/* We just wanted to select numerical output only */
@@ -8170,6 +8174,7 @@ int gmt_parse_o_option (struct GMT_CTRL *GMT, char *arg) {
 		}
 		else {
 			if ((inc = gmt_parse_range (GMT, p, &start, &stop)) == 0) return (GMT_PARSE_ERROR);
+			if (stop == (GMT_MAX_COLUMNS-1)) GMT->common.o.end = true;	/* Gave an open interval, e.g., 3: or 4- to mean "until last column" */
 
 			/* Now set the code for these columns */
 
@@ -16614,4 +16619,34 @@ int gmt_report_usage (struct GMTAPI_CTRL *API, struct GMT_OPTION *options, unsig
 	if (code)	/* Must call the usage function */
 		usage (API, code);
 	return (code);	
+}
+
+void gmtlib_reparse_i_option (struct GMT_CTRL *GMT, uint64_t n_columns) {
+	char text[GMT_LEN8] = {""}, token[GMT_BUFSIZ] = {""};
+	bool o_trailing = GMT->current.io.trailing_text[GMT_OUT];	/* Since -i parsing below will wipe any -o setting that excludes trailing text */
+	size_t k;
+	if (n_columns == 0) return;	/* Cannot update the string */
+	for (k = strlen (GMT->common.i.string) - 1; k && !(GMT->common.i.string[k] == ':' || GMT->common.i.string[k] == '-'); k--);	/* Find the last : or - in open-ended sequence */
+	strncpy (token, GMT->common.i.string, k+1);	/* Get duplicate, this ends with - or : */
+	sprintf (text, "%d", (int)n_columns-1);
+	strcat (token, text);	/* Add explicit last column to include */
+	if (GMT->common.i.string[k+1] == ',') strcat (token, &GMT->common.i.string[k+1]);	/* Probably trailing text selections */
+	GMT->common.i.active = false;	/* So we can parse again */
+	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Reparse -i%s\n", token);
+	gmt_parse_common_options (GMT, "i", 'i', token);	/* Re-parse updated -i */
+	GMT->current.io.trailing_text[GMT_OUT] = o_trailing;	/* Reset to what was parsed initially */
+}
+
+void gmtlib_reparse_o_option (struct GMT_CTRL *GMT, uint64_t n_columns) {
+	char text[GMT_LEN8] = {""}, token[GMT_BUFSIZ] = {""};
+	size_t k;
+	if (n_columns == 0) return;	/* Cannot update the string */
+	for (k = strlen (GMT->common.o.string) - 1; k && !(GMT->common.o.string[k] == ':' || GMT->common.o.string[k] == '-'); k--);	/* Find the last : or - in open-ended sequence */
+	strncpy (token, GMT->common.o.string, k+1);	/* Get duplicate, this ends with - or : */
+	sprintf (text, "%d", (int)n_columns-1);
+	strcat (token, text);	/* Add explicit last column to include */
+	if (GMT->common.o.string[k+1] == ',') strcat (token, &GMT->common.o.string[k+1]);	/* Probably trailing text selections */
+	GMT->common.o.active = false;	/* So we can parse again */
+	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Reparse -o%s\n", token);
+	gmt_parse_common_options (GMT, "o", 'o', token);	/* Re-parse updated -o */
 }

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -50,6 +50,7 @@ struct GMT_XINGS {
 
 EXTERN_MSC char *opt (struct GMTAPI_CTRL *API,char code);
 
+EXTERN_MSC int gmtlib_ascii_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double *ptr, char *txt);
 EXTERN_MSC void gmtlib_reparse_i_option (struct GMT_CTRL *GMT, uint64_t n_columns);
 EXTERN_MSC void gmtlib_reparse_o_option (struct GMT_CTRL *GMT, uint64_t n_columns);
 EXTERN_MSC void gmtlib_get_cpt_level (struct GMTAPI_CTRL *API, int *fig, int *subplot, char *panel, int *inset);

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -50,6 +50,8 @@ struct GMT_XINGS {
 
 EXTERN_MSC char *opt (struct GMTAPI_CTRL *API,char code);
 
+EXTERN_MSC void gmtlib_reparse_i_option (struct GMT_CTRL *GMT, uint64_t n_columns);
+EXTERN_MSC void gmtlib_reparse_o_option (struct GMT_CTRL *GMT, uint64_t n_columns);
 EXTERN_MSC void gmtlib_get_cpt_level (struct GMTAPI_CTRL *API, int *fig, int *subplot, char *panel, int *inset);
 EXTERN_MSC unsigned int gmtlib_char_count (char *txt, char c);
 EXTERN_MSC void gmt_check_modern_oneliner (struct GMTAPI_CTRL *API, const char *module, struct GMT_OPTION *head);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3223,6 +3223,8 @@ GMT_LOCAL unsigned int gmtio_examine_current_record (struct GMT_CTRL *GMT, char 
 		*tpos = pos;
 	}
 	*n_columns = col;	/* Pass back the numerical column count */
+	if (GMT->common.i.end)	/* Asked for unspecified last column on input (e.g., -i3,2,5:), supply the missing last column number */
+		gmtlib_reparse_i_option (GMT, col);
 	
 	if (found_text) {	/* Determine record type */
 		if (GMT->current.io.trailing_text[GMT_IN]) ret_val = (*n_columns) ? GMT_READ_MIXED : GMT_READ_TEXT;	/* Possibly update record type */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -958,7 +958,7 @@ GMT_LOCAL void gmtio_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, char 
 }
 
 /*! . */
-GMT_LOCAL int gmtio_ascii_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double *ptr, char *txt) {
+int gmtlib_ascii_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double *ptr, char *txt) {
 
 	if (gmt_skip_output (GMT, ptr, n)) return (-1);	/* Record was skipped via -s[a|r] */
 
@@ -1003,7 +1003,7 @@ GMT_LOCAL int gmtio_ascii_output (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, do
 	/* First time we decide if we have floats only or a mix and finalize pointer settings */
 	if (txt && GMT->current.io.trailing_text[GMT_OUT]) {
 		if (n == 0 || (GMT->common.o.select && GMT->common.o.n_cols == 0))
-			GMT->current.io.output = gmtio_ascii_output_trailing_text;	/* Just print trailing text */
+			GMT->current.io.output = gmtlib_ascii_output_trailing_text;	/* Just print trailing text */
 		else
 			GMT->current.io.output = gmtio_ascii_output_with_text;	/* Have trailing text after numerical output */
 		return GMT->current.io.output (GMT, fp, n, ptr, txt);


### PR DESCRIPTION
If a user wants to shuffle the order of cols 0 and 1 but otherwise read the entire record, they have to list everything that follows the **-i**1,0 list to ensure all numerical columns are added.  She also needs to add ,t to ensure the trailing text is added.  Likewise for output.  This is tedious and requires you to first determine how many columns are present.  This PR allows open-ended ranges to be given, such as

```
-i1,0,4:,t [read col 1, 0, then 4 to the end or external record, plus trailing text]
-o3:,t1  [Write cols 3 to end of internal record, plus 2nd word of trailing text]
```

This adds new capability to GMT.  Also while not pretty (yet), this means **-:** i can be specified as **-i**1,0,2:
