### PR TITLE
Let the "Edit on GitHub" button work for all branches

### DIFF
--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -27,6 +27,9 @@ copyright = "@GMT_VERSION_YEAR@, The GMT Team."
 version = '@GMT_PACKAGE_VERSION_MAJOR@.@GMT_PACKAGE_VERSION_MINOR@'
 # The full version shown in the page title
 release = '@GMT_PACKAGE_VERSION@'
+# Make the "Edit on GitHub" button link to the correct branch
+# Default to 'version' if Azure Pipelines environmental variable BUILD_SOURCEBRANCHNAME is not defined
+github_version = os.getenv("BUILD_SOURCEBRANCHNAME", version)
 
 # -- Options for HTML output ---------------------------------------------------
 html_theme = 'rtd'
@@ -55,7 +58,7 @@ html_context = {
     "display_github": True,
     "github_user": "GenericMappingTools",
     "github_repo": "gmt",
-    "github_version": version,
+    "github_version": github_version,
     "theme_vcs_pageview_mode": "edit",
     "conf_py_path": "/doc/rst/source/"
 }


### PR DESCRIPTION
For the documentation of the master branch, the "Edit on GitHub" should
be linked to the master branch, but now it's linked to the non-existent
6.1 branch.

In this PR, the conf.py script is modified to check the environmental
variable BUILD_SOURCEBRANCHNAME predefined by Azure Pipelines. So we
can get the branch name from the environmental variable and set the
correct branch name to link. For locally built documentations, the
variable is not defined, then the current major and minor version is
used.