### PR TITLE
Fix solar manpage

### DIFF
--- a/doc/rst/source/pssolar.rst
+++ b/doc/rst/source/pssolar.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-K| ]
 [ |-M| ]
 [ |-N| ]
-[ |-O| ] [|-P| ] [ |-Q| ]
+[ |-O| ] [|-P| ]
 [ |SYN_OPT-R| ]
 [ |-T|\ **dcna**\ [**+d**\ *date*][**+z**\ *TZ*]]
 [ |SYN_OPT-U| ]
@@ -30,7 +30,6 @@ Synopsis
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
 [ |SYN_OPT-bo| ]
-[ |SYN_OPT-h| ]
 [ |SYN_OPT-o| ]
 [ |SYN_OPT-p| ]
 [ |SYN_OPT-t| ]
@@ -45,26 +44,18 @@ Examples
 
 .. include:: explain_example.rst_
 
-Print current Sun position and Sunrise, Sunset times at:
-
-   ::
+Print current Sun position and Sunrise, Sunset times at::
 
     gmt pssolar -I-7.93/37.079+d2016-02-04T10:01:00
 
-Plot the day-night and civil twilight 
-
-   ::
+Plot the day-night and civil twilight::
 
     gmt pscoast -Rd -W0.1p -JQ0/14c -Ba -BWSen -Dl -A1000 -P -K > terminator.ps
-
     gmt pssolar -R -J -W1p -Tdc -O >> terminator.ps
 
-Set up a clip path overlay based on the day/night terminator: 
-
-   ::
+Set up a clip path overlay based on the day/night terminator::
 
     gmt pssolar -R -J -G -Tc -O -K >> someplot.ps
-
 
 .. include:: solar_notes.rst_
 

--- a/doc/rst/source/solar.rst
+++ b/doc/rst/source/solar.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt solar** 
+**gmt solar**
 [ |SYN_OPT-B| ]
 [ |-C| ]
 [ |-G|\ [*fill*] ]
@@ -20,7 +20,6 @@ Synopsis
 [ |-J|\ *parameters* ]
 [ |-M| ]
 [ |-N| ]
-[ |-Q| ]
 [ |SYN_OPT-R| ]
 [ |-T|\ **dcna**\ [**+d**\ *date*][**+z**\ *TZ*]]
 [ |SYN_OPT-U| ]
@@ -29,7 +28,6 @@ Synopsis
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
 [ |SYN_OPT-bo| ]
-[ |SYN_OPT-h| ]
 [ |SYN_OPT-o| ]
 [ |SYN_OPT-p| ]
 [ |SYN_OPT-t| ]
@@ -42,27 +40,20 @@ Examples
 
 .. include:: explain_example.rst_
 
-Print current Sun position and Sunrise, Sunset times at:
-
-   ::
+Print current Sun position and Sunrise, Sunset times at::
 
     gmt solar -I-7.93/37.079+d2016-02-04T10:01:00
 
-Plot the day-night and civil twilight 
-
-   ::
+Plot the day-night and civil twilight::
 
     gmt begin
       gmt coast -Rd -W0.1p -JQ0/14c -B -BWSen -Dl -A1000
       gmt solar -W1p -Tdc
     gmt end show
 
-Set up a clip path overlay based on the day/night terminator: 
-
-   ::
+Set up a clip path overlay based on the day/night terminator::
 
     gmt solar -G -Tc
-
 
 .. include:: solar_notes.rst_
 

--- a/doc/rst/source/solar_common.rst_
+++ b/doc/rst/source/solar_common.rst_
@@ -55,7 +55,7 @@ Optional Arguments
 
 **-N**
     Invert the sense of what is inside and outside the terminator.  Only
-    used with clipping (**-Gc**) and cannot be used together with **-B**.
+    used with clipping (**-G**) and cannot be used together with **-B**.
 
 .. _-R:
 
@@ -70,6 +70,8 @@ Optional Arguments
     **a** means astronomical twilight.  Add **+d**\ *date* in ISO format, e.g, **+d**\ *2000-04-25T12:15:00*
     to know where the day-night was at that date. If necessary, append time zone via **+z**\ *TZ*.
 
+    Refer to https://en.wikipedia.org/wiki/Twilight for definitions of different twilights.
+
 .. _-U:
 
 .. include:: explain_-U.rst_
@@ -81,7 +83,7 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ [**-**\ \|\ **+**][*pen*] :ref:`(more ...) <-Wpen_attrib>`
+**-W**\ [*pen*] :ref:`(more ...) <-Wpen_attrib>`
     Set pen attributes for lines or the outline of symbols [Defaults:
     width = default, color = black, style = solid].
 
@@ -92,12 +94,11 @@ Optional Arguments
 .. |Add_-bo| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-bo.rst_
 
-.. |Add_-h| unicode:: 0x20 .. just an invisible code
-.. include:: explain_-h.rst_
-
 .. include:: explain_-ocols.rst_
 
 .. |Add_perspective| unicode:: 0x20 .. just an invisible code
 .. include:: explain_perspective.rst_
 
 .. include:: explain_-t.rst_
+
+.. include:: explain_help.rst_


### PR DESCRIPTION
- Remove -Q and -h from solar synopsis
- Include "explain_help.rst_"
- Use **-G** instead of **-Gc** for clipping
- Add a link to Twilight wikipedia page to explain different twilights.
- Fix `-W[-|+]<pen>` to `-W<pen>`