### PR TITLE
Enable CI testing for long options

### DIFF
--- a/ci/config-gmt-unix.sh
+++ b/ci/config-gmt-unix.sh
@@ -30,6 +30,11 @@ set (DO_API_TESTS ON)
 set (N_TEST_JOBS 2)
 set (SUPPORT_EXEC_IN_BINARY_DIR TRUE)
 set (CMAKE_C_FLAGS "-coverage -O0 ${CMAKE_C_FLAGS}")
+
+# Turn on testing of upcoming long-option syntax for common GMT options
+add_definitions(-DUSE_COMMON_LONG_OPTIONS)
+# Turn on testing of upcoming long-option syntax for module options
+add_definitions(-DUSE_MODULE_LONG_OPTIONS)
 EOF
 fi
 

--- a/ci/config-gmt-windows.sh
+++ b/ci/config-gmt-windows.sh
@@ -24,6 +24,11 @@ set (DO_EXAMPLES TRUE)
 set (DO_TESTS TRUE)
 set (DO_API_TESTS ON)
 set (SUPPORT_EXEC_IN_BINARY_DIR TRUE)
+
+# Turn on testing of upcoming long-option syntax for common GMT options
+add_definitions(-DUSE_COMMON_LONG_OPTIONS)
+# Turn on testing of upcoming long-option syntax for module options
+add_definitions(-DUSE_MODULE_LONG_OPTIONS)
 EOF
 fi
 


### PR DESCRIPTION
Add following statements to CI cmake script.
```
add_definitions(-DUSE_COMMON_LONG_OPTIONS) 	# Turn on testing of upcoming long-option syntax for common GMT options
add_definitions(-DUSE_MODULE_LONG_OPTIONS) 	# Turn on testing of upcoming long-option syntax for module options
```
