### PR TITLE
grd2kml did not accept +idz in -C like the others

### DIFF
--- a/doc/rst/source/grd2kml.rst
+++ b/doc/rst/source/grd2kml.rst
@@ -53,16 +53,17 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ *cpt*
-    Name of the color palette table (CPT). Alternatively,
-    supply the name of a GMT color master dynamic CPT [turbo] to
+**-C**\ [*cpt* \|\ *master*\ [**+i**\ *zinc*] \|\ *color1,color2*\ [,\ *color3*\ ,...]]
+    Name of the CPT (for *grd_z* only). Alternatively,
+    supply the name of a GMT color master dynamic CPT [turbo, but geo
+    for @earth_relief and srtm for @srtm_relief data] to
     automatically determine a continuous CPT from
-    the grid's z-range.  If the dynamic CPT has a default range then
-    that range will be imposed instead.
-    Another option is to specify **-C**\ *color1*\ ,\ *color2*\ [,\ *color3*\ ,...]
-    to build a linear continuous CPT from those colors automatically, scaled to fit the data range.
-    In this case *color1*, etc., can be a *r/g/b* triplet, a color name,
-    or an HTML hexadecimal color (e.g. #aabbcc ).
+    the grid's z-range; you may round up/down the z-range by adding **+i**\ *zinc*.
+    Yet another option is to specify **-C**\ *color1*\ ,\ *color2*\ [,\ *color3*\ ,...]
+    to build a linear continuous CPT from those colors automatically.
+    In this case *color1* etc can be a r/g/b triplet, a color name,
+    or an HTML hexadecimal color (e.g. #aabbcc ).  If no argument is given to **-C**
+    then under modern mode we select the current CPT.
 
 .. _-E:
 

--- a/src/grd2kml.c
+++ b/src/grd2kml.c
@@ -46,8 +46,9 @@ struct GRD2KML_CTRL {
 		bool active;
 		unsigned int size;
 	} A;
-	struct GRD2KML_C {	/* -C<cpt> */
+	struct GRD2KML_C {	/* -C<cpt> or -C<color1>,<color2>[,<color3>,...][+i<dz>] */
 		bool active;
+		double dz;
 		char *file;
 	} C;
 	struct GRD2KML_D {	/* -D[+s][+d]  [DEBUG ONLY, NOT DOCUMENTED] */
@@ -148,7 +149,8 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   already exist we will overwrite the files.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Color palette file to convert z to rgb. Optionally, instead give name of a master cpt\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   to automatically assign 16 continuous colors over the data range [%s].\n", GMT_DEFAULT_CPT_NAME);
+	GMT_Message (API, GMT_TIME_NONE, "\t   to automatically assign continuous colors over the data range [%s]; if so,\n", GMT_DEFAULT_CPT_NAME);
+	GMT_Message (API, GMT_TIME_NONE, "\t   optionally append +i<dz> to quantize the range [the exact grid range].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Another option is to specify -C<color1>,<color2>[,<color3>,...] to build a\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   linear continuous cpt from those colors automatically.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-E To store all files remotely, give leading URL [local files only].\n");
@@ -208,8 +210,13 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRD2KML_CTRL *Ctrl, struct GMT
 				break;
 			case 'C':	/* CPT */
 				Ctrl->C.active = true;
+				if ((c = strstr (opt->arg, "+i"))) {	/* Gave auto-interval */
+					Ctrl->C.dz = atof (&c[2]);
+					c[0] = '\0';	/* Temporarily chop off the modifier */
+				}
 				gmt_M_str_free (Ctrl->C.file);
 				Ctrl->C.file = strdup (opt->arg);
+				if (c) c[0] = '+';	/* Restore */
 				break;
 			case 'D':	/* Debug options - may fade away when happy with the performance */
 				Ctrl->D.active = true;
@@ -416,7 +423,7 @@ int GMT_grd2kml (void *V_API, int mode, void *args) {
 		unsigned int zmode = gmt_cpt_default (GMT, G->header);
 		char cfile[PATH_MAX] = {""};
 		struct GMT_PALETTE *P = NULL;
-		if ((P = gmt_get_palette (GMT, Ctrl->C.file, GMT_CPT_OPTIONAL, G->header->z_min, G->header->z_max, 0.0, zmode)) == NULL) {
+		if ((P = gmt_get_palette (GMT, Ctrl->C.file, GMT_CPT_OPTIONAL, G->header->z_min, G->header->z_max, Ctrl->C.dz, zmode)) == NULL) {
 			GMT_Report (API, GMT_MSG_NORMAL, "Failed to create a CPT\n");
 			Return (API->error);	/* Well, that did not go well... */
 		}


### PR DESCRIPTION
This modifier is used to round an anto-generated range to a clean multiple of _dz_.
