### PR TITLE
Supply -Baf when colorbar plots a stretched CPT

### DIFF
--- a/doc/rst/source/colorbar_common.rst_
+++ b/doc/rst/source/colorbar_common.rst_
@@ -33,7 +33,7 @@ Optional Arguments
     provided (classic mode only), the default is to annotate every color level based on the
     numerical entries in the CPT (which may be overridden by ULB
     flags in the CPT). The exception to this rule is for CPT files that were scaled to fit the range
-    of a grid exactly and thus have arbitrary color levels; these will trigger an automatic -Baf setting.
+    of a grid exactly and thus have arbitrary color levels; these will trigger an automatic **-Baf** setting.
     To specify custom text annotations for
     intervals, you must append ;\ *annotation* to each z-slice in the CPT.
     For standard **-B** operations, see below.

--- a/doc/rst/source/colorbar_common.rst_
+++ b/doc/rst/source/colorbar_common.rst_
@@ -30,9 +30,11 @@ Optional Arguments
     the right of a vertical bar), except when using the **+m** modifier of the **-D** option. As an
     option, use the y-axis label to plot the data unit to the right of a
     horizontal bar (and above a vertical bar). If **-B** is omitted, or no annotation intervals are
-    provided, the default is to annotate every color level based on the
+    provided (classic mode only), the default is to annotate every color level based on the
     numerical entries in the CPT (which may be overridden by ULB
-    flags in the CPT). To specify custom text annotations for
+    flags in the CPT). The exception to this rule is for CPT files that were scaled to fit the range
+    of a grid exactly and thus have arbitrary color levels; these will trigger an automatic -Baf setting.
+    To specify custom text annotations for
     intervals, you must append ;\ *annotation* to each z-slice in the CPT.
     For standard **-B** operations, see below.
 

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7768,6 +7768,7 @@ struct GMT_PALETTE *gmt_get_palette (struct GMT_CTRL *GMT, char *file, enum GMT_
 	if (is_cpt_master) {	/* Take master cpt and stretch to fit data range using continuous colors */
 		char *master = NULL, *current_cpt = NULL;
 		double noise;
+		struct GMT_PALETTE_HIDDEN *PH = NULL;
 
 		if (gmt_M_is_dnan (zmin) || gmt_M_is_dnan (zmax)) {	/* Safety valve 1 */
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Passing zmax or zmin == NaN prevents automatic CPT generation!\n");
@@ -7790,17 +7791,17 @@ struct GMT_PALETTE *gmt_get_palette (struct GMT_CTRL *GMT, char *file, enum GMT_
 		/* Stretch to fit the data range */
 		/* Prevent slight round-off from causing the min/max float data values to fall outside the cpt range */
 		if (gmt_M_is_zero (dz)) {
-			struct GMT_PALETTE_HIDDEN *PH = gmt_get_C_hidden (P);
 			GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Auto-stretching CPT file %s to fit data range %g to %g\n", master, zmin, zmax);
 			noise = (zmax - zmin) * GMT_CONV8_LIMIT;
 			zmin -= noise;	zmax += noise;
-			PH->auto_scale = 1;	/* Flag for colorbar to supply -Baf if not given */
 		}
 		else {	/* Round to multiple of dz */
 			zmin = (floor (zmin / dz) * dz);
 			zmax = (ceil (zmax / dz) * dz);
 			GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Auto-stretching CPT file %s to fit rounded data range %g to %g\n", master, zmin, zmax);
 		}
+		PH = gmt_get_C_hidden (P);
+		PH->auto_scale = 1;	/* Flag for colorbar to supply -Baf if not given */
 		gmt_stretch_cpt (GMT, P, zmin, zmax);
 		gmt_save_current_cpt (GMT, P, 0);	/* Save for use by session, if modern */
 	}

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7293,7 +7293,7 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 		}
 		else if ((h = strstr (line, "CYCLIC")))	/* CPT should wrap around */
 			X->is_wrapping = 1;
-		else if ((h = strstr (line, "STRETCHED")))	/* CPT was stretnch to exact min/max with no dz rounding */
+		else if ((h = strstr (line, "STRETCHED")))	/* CPT was stretched to exact min/max with no dz rounding */
 			XH->auto_scale = 1;
 
 		GMT->current.setting.color_model = X->model;

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7293,7 +7293,7 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 		}
 		else if ((h = strstr (line, "CYCLIC")))	/* CPT should wrap around */
 			X->is_wrapping = 1;
-		else if ((h = strstr (line, "STRETCHED")))	/* CPT was stretched to exact min/max with no dz rounding */
+		else if ((h = strstr (line, "ENABLE_B_OPTION")))	/* CPT was stretched to exact min/max with no dz rounding */
 			XH->auto_scale = 1;
 
 		GMT->current.setting.color_model = X->model;
@@ -8291,7 +8291,7 @@ int gmtlib_write_cpt (struct GMT_CTRL *GMT, void *dest, unsigned int dest_type, 
 	if (P->is_wrapping)
 		fprintf (fp, "# CYCLIC\n");
 	if (PH->auto_scale)
-		fprintf (fp, "# STRETCHED\n");
+		fprintf (fp, "# ENABLE_B_OPTION\n");
 
 	sprintf (format, "%%s\t%%s%%c");
 

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7794,7 +7794,7 @@ struct GMT_PALETTE *gmt_get_palette (struct GMT_CTRL *GMT, char *file, enum GMT_
 			GMT_Report (GMT->parent, GMT_MSG_LONG_VERBOSE, "Auto-stretching CPT file %s to fit data range %g to %g\n", master, zmin, zmax);
 			noise = (zmax - zmin) * GMT_CONV8_LIMIT;
 			zmin -= noise;	zmax += noise;
-			PH->auto_scale = 1;	/* Flag for colorbar to supply -B af if not given */
+			PH->auto_scale = 1;	/* Flag for colorbar to supply -Baf if not given */
 		}
 		else {	/* Round to multiple of dz */
 			zmin = (floor (zmin / dz) * dz);

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -1522,6 +1522,7 @@ int GMT_psscale (void *V_API, int mode, void *args) {
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;		/* General GMT internal parameters */
 	struct GMT_OPTION *options = NULL;
 	struct PSL_CTRL *PSL = NULL;		/* General PSL internal parameters */
+	struct GMT_PALETTE_HIDDEN *PH = NULL;
 	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);	/* Cast from void to GMTAPI_CTRL pointer */
 
 	/*----------------------- Standard module initialization and parsing ----------------------*/
@@ -1643,7 +1644,10 @@ int GMT_psscale (void *V_API, int mode, void *args) {
 		if (GMT->current.plot.panel.active) GMT->current.plot.panel.no_scaling = 0;	/* Reset no_scaling flag */
 	}
 
-	if (GMT->common.B.active[GMT_PRIMARY] || GMT->common.B.active[GMT_SECONDARY]) {	/* Must redo the -B parsing since projection has changed */
+	if (!GMT->current.map.frame.draw && (PH = gmt_get_C_hidden (P)) && PH->auto_scale) {	/* No -B given yet we have raw auto-scaling */
+		gmtlib_parse_B_option (GMT, "af");
+	}
+	else if (GMT->common.B.active[GMT_PRIMARY] || GMT->common.B.active[GMT_SECONDARY]) {	/* Must redo the -B parsing since projection has changed */
 		char p[GMT_LEN256] = {""}, group_sep[2] = {" "}, *tmp = NULL;
 		unsigned int pos = 0;
 		GMT_Report (API, GMT_MSG_DEBUG, "Clean re reparse -B settings\n");


### PR DESCRIPTION
Tools like _grdimage_ may produce a stretched CPT that fits the z-range of a grid exactly.  In those cases we cannot let psscale _use_ the CPT levels as annotation and tick intervals but must override via **-Baf**.  This PR does so by adding a comment keyword **STRETCHED** to such CPTs as they are written and then we watch for that word upon reading.  Closes issue #2307.
