### PR TITLE
Cannot use -U in tests since time changes...

### DIFF
--- a/test/modern/longbasemap.ps
+++ b/test/modern/longbasemap.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.1.0_ea731fd_2019.12.19 [64-bit] Document from psxy
+%%Title: GMT v6.1.0_0cc216c_2019.12.20 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec 19 14:50:41 2019
+%%CreationDate: Sat Dec 21 12:24:20 2019
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -115,39 +115,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/Standard+_Encoding [
+/ISOLatin1+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
-/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
-/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
-/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
-/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
-/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
-/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
-/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
-/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
-/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
-/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
-/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
-/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
-/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
-/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
-/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -673,49 +673,16 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt psbasemap -R0/40/0/50 -JX6i -BWSne+glightblue -Bx0af+uk+a45 -By0afg+p$ '-UTime stamp+c' -Xa0i -Ya0i
+%@GMT: gmt psbasemap -R0/40/0/50 -JX6i -BWSne+glightblue -Bx0af+uk+a45 -By0afg+p$ -Xa0i -Ya0i
 %@PROJ: xy 0.00000000 40.00000000 0.00000000 50.00000000 0.000 40.000 0.000 50.000 +xy
 %%BeginObject PSL_Layer_1
-% Begin GMT time-stamp
-V
--900 -900 T
-4 W
-/PSL_g_w 438 def
-/PSL_g_h 180 def
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-133 F0
-(  2019 Dec 19 14:50:41  ) V MU 0 0 M E /PSL_b_w edef FP pathbbox N /PSL_b_h edef /PSL_b_x1 edef /PSL_b_d edef /PSL_b_x0 edef U
-{0 A} FS
-O1
-180 438 219 90 Sr
-V N 0 0 T 438 180 scale /DeviceGray setcolorspace
-<< /ImageType 1 /Decode [0 1] /Width 220 /Height 90 /BitsPerComponent 1
-   /ImageMatrix [220 0 0 -90 0 90] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
->> image
-G[Bde95`N=$jL)W>%jl[kU8K\'_DAg6B>"H=_*pF<&^bA>.A1dT9S_7ita&KN.Dkjkd+u$%m"o]`I%HgO0WeEJZ.F.+rYZk
-M.jT-_R<a/g1`tOTNRR"(E$>R_8`j9s'SsC3c(E(8^d;<9VVTgR:bT\Mes?_e/!A7"RBegmgCP3p'BF&P/KA>E%<:@.oZVk
-#cO,m3]n/I\rAr7Yf`*j]EH?iS@8"XDO*i9(gQ/d/Wa,g*fZq>#qUi'Or-ntCp%o\:A^%h:^bnV@__]iU/i0`b2!m2-Eeg<
-L0EG;f(I5(/8b;#Z_Sq/4([&GM'KjrAZN&CBb?(tbW%\&[]@r&/AV263rd/]bCi>8>qLtgX1?\iU&Jd*0TV3`#$2f<46(2K
-5K:$l[WcO$g])0O;M3!r;WH^uihJMp<t-4m4oR1.du)jaL\3@HTX9X1g6u#>ZZXk_Jb6q41eu5l/bERcq[C4cYm@CF\j'&Q
-R\OMqLgtd5(QcD^oGs);cAE;JeR!K4g3J_*Nm,Z3Nam+"^G91slmI;6bIL?19]BBpj1L<]k<5OqR!"1'ZVR5qAQmbBFmO1>
-/bC+K!G'asZLZLiKNGY!<f^jt:.'+"d<JXI\iVu<B9.H-0ZQt!-^g[7^R2uKBpqW?04M4bI4gMJ"FV0rQ6J2A.@hdpgVF*6
-A_IXcBTI'a1DeVhHggg<&%:Ao`&On~>
-U
-{1 A} FS
-PSL_g_h PSL_b_w PSL_g_w 0 Sb
-438 38 M (  2019 Dec 19 14:50:41  ) bl Z
-117 F0
-(   psbasemap -R0/40/0/50 -JX6i -BWSne+glightblue -Bx0af+uk+a45 -By0afg+p$ -UTime stamp+c -Xa0i -Ya0i) bl Z
-U
-% End GMT time-stamp
-FQ
-O0
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 /PSL_plot_completion {
 V
-0 A 240 4463 M 333 F0
+0 A 240 4463 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
 (2) tl Z
 U
 }!
@@ -741,7 +708,7 @@ N 0 4703 M 0 -4703 D S
 N 0 0 M -83 0 D S
 N 0 1881 M -83 0 D S
 N 0 3762 M -83 0 D S
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH0 0
 /MM {neg exch M} def
 200 F0
@@ -873,7 +840,7 @@ O0
 /PSL_plot_completion {
 V
 19 5497 T
-0 A 221 4463 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 A 221 4463 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (1) tl Z
 U
@@ -7799,21 +7766,21 @@ N 7246 4703 M -7329 0 D S
 N 7246 4786 M -7329 0 D S
 N 0 4786 M 0 -4869 D S
 N -83 4786 M 0 -4869 D S
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 0 -167 M 200 F0
-(0è) tc Z
-1023 -167 M (10è) tc Z
-2047 -167 M (20è) tc Z
-3070 -167 M (30è) tc Z
-4093 -167 M (40è) tc Z
-5116 -167 M (50è) tc Z
-6140 -167 M (60è) tc Z
-7163 -167 M (70è) tc Z
--167 0 M (î20è) mr Z
--167 1054 M (î10è) mr Z
--167 2076 M (0è) mr Z
--167 3098 M (10è) mr Z
--167 4152 M (20è) mr Z
+(0∞) tc Z
+1023 -167 M (10∞) tc Z
+2047 -167 M (20∞) tc Z
+3070 -167 M (30∞) tc Z
+4093 -167 M (40∞) tc Z
+5116 -167 M (50∞) tc Z
+6140 -167 M (60∞) tc Z
+7163 -167 M (70∞) tc Z
+-167 0 M (-20∞) mr Z
+-167 1054 M (-10∞) mr Z
+-167 2076 M (0∞) mr Z
+-167 3098 M (10∞) mr Z
+-167 4152 M (20∞) mr Z
 %%EndObject
 -19 -5497 TM
 PSL_plot_completion /PSL_plot_completion {} def

--- a/test/modern/longbasemap.sh
+++ b/test/modern/longbasemap.sh
@@ -2,7 +2,7 @@
   # Test the long-format version of -R -J -B and -U
   gmt begin longbasemap ps
     gmt subplot begin 2x1 -F6i/8.5i -M5p -A1+c+o0.2i
-  	gmt basemap --region=0/40/0/50 --projection=X? --frame=WSne+fill=lightblue --axis=x:af+unit=k+angle=45 --axis=y:afg+prefix="$" --timestamp="Time stamp"+command -c1
+  	gmt basemap --region=0/40/0/50 --projection=X? --frame=WSne+fill=lightblue --axis=x:af+unit=k+angle=45 --axis=y:afg+prefix="$" -c1
   	gmt basemap --region=0/70/-20/25 --projection=M? --frame=WSne+fill=lightgreen+oblique-pole=60/20 --axis=x:afg --axis=y:afg -c0
   	gmt subplot end
  gmt end show


### PR DESCRIPTION
This was the test for **--timestamp**;  it works but cannot be in the tests since it will always fail as time changes.  It is now removed, but we should at least manually test that it handles the options and modifiers. 
