### PR TITLE
Fix formatting plus missing -m option

### DIFF
--- a/doc/rst/source/supplements/x2sys/x2sys_cross.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_cross.rst
@@ -53,7 +53,7 @@ Optional Arguments
 **-A**\ *combi.lis*
     Only process the pair-combinations found in the file *combi.lis*
     [Default process all possible combinations among the specified
-    files]. The file *combi.lis* created by :doc:`x2sys_get` -L option
+    files]. The file *combi.lis* created by :doc:`x2sys_get` **-L** option
 
 .. _-C:
 

--- a/doc/rst/source/supplements/x2sys/x2sys_datalist.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_datalist.rst
@@ -55,7 +55,7 @@ Optional Arguments
     files for each track and data column are called *track.column*.adj
     and are expected to be in the **$X2SYS_HOME**/*TAG* directory. The
     adjustments are only applied if the corresponding adjust file can be
-    found [No residual adjustments]
+    found [No residual adjustments].
 
 .. _-E:
 

--- a/doc/rst/source/supplements/x2sys/x2sys_init.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_init.rst
@@ -17,7 +17,6 @@ Synopsis
 [ |-F| ]
 [ |-G|\ **d**\ \|\ **g** ]
 [ |-I|\ *dx*\ [/*dy*] ]
-[ |-m|\ [*char*] ]
 [ |-N|\ **d**\ \|\ **s**\ *unit* ]
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]
@@ -96,13 +95,6 @@ Optional Arguments
     data. These spacings refer to the binning used in the track
     bin-index data base.
 
-.. _-m:
-
-**-m**\ [*char* ]
-    Indicate that the ASCII data tables will contain multiple segments
-    separated by header records that start with '>'.  If another character
-    is used please append it to **-m**.
-
 .. _-N:
 
 **-Nd**\ \|\ **s**\ *unit*
@@ -162,8 +154,7 @@ reading native binary files). Not used with netCDF files.
 periodicities in the *x*-coordinate (longitudes). Alternatively, use **-G**.
 
 **MULTISEG** means each track consists of multiple segments separated by
-a GMT segment header (alternatively, use **-m** when defining the
-system TAG). Not used with netCDF files.
+a GMT segment header. Not used with netCDF files.
 
 The column information consists of one line per column in the order the
 columns appear in the data file. For each column you must provide seven

--- a/doc/rst/source/supplements/x2sys/x2sys_init.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_init.rst
@@ -17,6 +17,7 @@ Synopsis
 [ |-F| ]
 [ |-G|\ **d**\ \|\ **g** ]
 [ |-I|\ *dx*\ [/*dy*] ]
+[ |-m|\ [*char*] ]
 [ |-N|\ **d**\ \|\ **s**\ *unit* ]
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]
@@ -94,6 +95,13 @@ Optional Arguments
     to indicate minutes or **s** to indicate seconds for geographic
     data. These spacings refer to the binning used in the track
     bin-index data base.
+
+.. _-m:
+
+**-m**\ [*char* ]
+    Indicate that the ASCII data tables will contain multiple segments
+    separated by header records that start with '>'.  If another character
+    is used please append it to **-m**.
 
 .. _-N:
 

--- a/doc/rst/source/supplements/x2sys/x2sys_list.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_list.rst
@@ -18,7 +18,6 @@ Synopsis
 [ |-F|\ *flags* ]
 [ |-I|\ [*list*] ]
 [ |-L|\ [*corrtable*] ]
-[ |-m| ]
 [ |-N|\ *nx_min*\ [**+p**\ ] ]
 [ |-Q|\ **e**\ \|\ **i** ]
 [ |SYN_OPT-R| ]
@@ -118,13 +117,6 @@ Optional Arguments
     *TAG*\ \_corrections.txt which is expected to reside in the
     **$X2SYS_HOME**/*TAG* directory]. For the format of this file, see
     **x2sys_solve**.
-
-.. _-m:
-
-**-m**\ [*char* ]
-    Indicate that the ASCII data tables will contain multiple segments
-    separated by header records that start with '>'.  If another character
-    is used please append it to **-m**.
 
 .. _-N:
 

--- a/doc/rst/source/supplements/x2sys/x2sys_list.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_list.rst
@@ -18,6 +18,7 @@ Synopsis
 [ |-F|\ *flags* ]
 [ |-I|\ [*list*] ]
 [ |-L|\ [*corrtable*] ]
+[ |-m| ]
 [ |-N|\ *nx_min*\ [**+p**\ ] ]
 [ |-Q|\ **e**\ \|\ **i** ]
 [ |SYN_OPT-R| ]
@@ -69,7 +70,7 @@ Optional Arguments
 .. _-E:
 
 **-E**
-    Enhance ASCII output by writing GMT segment headers with name of the
+    Enhance ASCII output by writing GMT segment headers with names of the
     two tracks and their total number of cross-overs [no segment headers].
 
 .. _-F:
@@ -117,6 +118,13 @@ Optional Arguments
     *TAG*\ \_corrections.txt which is expected to reside in the
     **$X2SYS_HOME**/*TAG* directory]. For the format of this file, see
     **x2sys_solve**.
+
+.. _-m:
+
+**-m**\ [*char* ]
+    Indicate that the ASCII data tables will contain multiple segments
+    separated by header records that start with '>'.  If another character
+    is used please append it to **-m**.
 
 .. _-N:
 

--- a/doc/rst/source/supplements/x2sys/x2sys_solve.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_solve.rst
@@ -39,7 +39,7 @@ Required Arguments
     Name of file with the required crossover columns as produced by
     :doc:`x2sys_list`. NOTE: If **-bi** is used
     then the first two columns are expected to hold the integer track
-    IDs; otherwise we expect those columns to hold the text string names
+    IDs; otherwise we expect the trailing text to hold the text string names
     of the two tracks. If no file is given we will read from *stdin*.
 
 .. include:: explain_tag.rst_

--- a/src/x2sys/x2sys_init.c
+++ b/src/x2sys/x2sys_init.c
@@ -116,7 +116,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s <TAG> [-D<deffile>] [-E<suffix>] [-F] [-G[d|g]] [-I[<binsize>]]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-N[d|s][c|e|f|k|M|n]]] [%s] [%s] [-Wt|d|n<gap>]\n\t[-m] [%s]] [%s]\n\n", GMT_Rgeo_OPT, GMT_V_OPT, GMT_j_OPT, GMT_PAR_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-N[d|s][c|e|f|k|M|n]]] [%s] [%s] [-Wt|d|n<gap>]\n\t[-m[<char>]] [%s]] [%s]\n\n", GMT_Rgeo_OPT, GMT_V_OPT, GMT_j_OPT, GMT_PAR_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t<TAG> is the unique system identifier.  Files created will be placed in the directory %s/<TAG>.\n", par);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Note: The environmental parameter %s must be defined.\n\n", par);
 
@@ -131,6 +131,8 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Geographical coordinates; append g for discontinuity at Greenwich (output 0/360 [Default])\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   or append d for discontinuity at Dateline (output -180/+180).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Set bin size for track bin index output [1/1].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-m ASCII tracks have multiple segments separated by segment headers starting with >.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally, append another character to identify segment headers.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Append (d)istances or (s)peed, and your choice for unit. Choose among:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   c Cartesian distance (user-dist-units, user-dist-units/user-time-units).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   e Metric units I (meters, m/s).\n");

--- a/src/x2sys/x2sys_init.c
+++ b/src/x2sys/x2sys_init.c
@@ -69,10 +69,6 @@ struct X2SYS_INIT_CTRL {
 		double inc[2];
 		char *string;
 	} I;
-	struct m {	/* -m */
-		bool active;
-		char *string;
-	} m;
 	struct N {	/* -N */
 		bool active[2];
 		char *string[2];
@@ -99,7 +95,6 @@ GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct X2SYS_INIT_CTRL *C) {	/* 
 	gmt_M_str_free (C->E.string);
 	gmt_M_str_free (C->G.string);
 	gmt_M_str_free (C->I.string);
-	gmt_M_str_free (C->m.string);
 	gmt_M_str_free (C->N.string[0]);
 	gmt_M_str_free (C->N.string[1]);
 	gmt_M_str_free (C->W.string[0]);
@@ -116,7 +111,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s <TAG> [-D<deffile>] [-E<suffix>] [-F] [-G[d|g]] [-I[<binsize>]]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-N[d|s][c|e|f|k|M|n]]] [%s] [%s] [-Wt|d|n<gap>]\n\t[-m[<char>]] [%s]] [%s]\n\n", GMT_Rgeo_OPT, GMT_V_OPT, GMT_j_OPT, GMT_PAR_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-N[d|s][c|e|f|k|M|n]]] [%s] [%s] [-Wt|d|n<gap>]\n\t[%s]] [%s]\n\n", GMT_Rgeo_OPT, GMT_V_OPT, GMT_j_OPT, GMT_PAR_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t<TAG> is the unique system identifier.  Files created will be placed in the directory %s/<TAG>.\n", par);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Note: The environmental parameter %s must be defined.\n\n", par);
 
@@ -131,8 +126,6 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Geographical coordinates; append g for discontinuity at Greenwich (output 0/360 [Default])\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   or append d for discontinuity at Dateline (output -180/+180).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Set bin size for track bin index output [1/1].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-m ASCII tracks have multiple segments separated by segment headers starting with >.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally, append another character to identify segment headers.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Append (d)istances or (s)peed, and your choice for unit. Choose among:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   c Cartesian distance (user-dist-units, user-dist-units/user-time-units).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   e Metric units I (meters, m/s).\n");
@@ -223,10 +216,6 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct X2SYS_INIT_CTRL *Ctrl, struct 
 					n_errors++;
 				}
 				Ctrl->I.string = strdup (opt->arg);
-				break;
-			case 'm':
-				Ctrl->m.active = true;
-				Ctrl->m.string = strdup (opt->arg);
 				break;
 			case 'N':	/* Distance and speed unit selection */
 				switch (opt->arg[0]) {
@@ -448,7 +437,6 @@ int GMT_x2sys_init (void *V_API, int mode, void *args) {
 	else if (Ctrl->C.active) fprintf (fp, " -j%s", Ctrl->C.string);
 	if (Ctrl->E.active) fprintf (fp, " -E%s", Ctrl->E.string);
 	if (Ctrl->G.active) fprintf (fp, " -G%s", Ctrl->G.string);
-	if (Ctrl->m.active) fprintf (fp, " -m%s", Ctrl->m.string);
 	if (Ctrl->N.active[0]) fprintf (fp, " -N%s", Ctrl->N.string[0]);
 	if (Ctrl->N.active[1]) fprintf (fp, " -N%s", Ctrl->N.string[1]);
 	if (Ctrl->W.active[0]) fprintf (fp, " -W%s", Ctrl->W.string[0]);


### PR DESCRIPTION
The x2sys_init module has a **-m** option that was missing from the documentation.
