### PR TITLE
doc: include explain_distunit.rst_ to surface

### DIFF
--- a/doc/rst/source/surface.rst
+++ b/doc/rst/source/surface.rst
@@ -232,6 +232,8 @@ Optional Arguments
 
 .. include:: explain_float.rst_
 
+.. include:: explain_distunits.rst_
+
 
 Examples
 --------


### PR DESCRIPTION
To suppress the `Unknown target name: "units"` warning.