### PR TITLE
Add reST cheatsheet to developer resources

### DIFF
--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -72,8 +72,8 @@ Quick links
 
    Contributing Guide <https://github.com/GenericMappingTools/gmt/blob/master/CONTRIBUTING.md>
    Code of Conduct <https://github.com/GenericMappingTools/gmt/blob/master/CODE_OF_CONDUCT.md>
+   reStructuredText Cheatsheet <rst_cheatsheet>
+   Debugging GMT <debug>
    GMT C API <api>
    PostScriptLight C API <postscriptlight>
-   Debugging GMT <debug>
-   reStructuredText Cheatsheet <rst_cheatsheet>
 

--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -75,4 +75,5 @@ Quick links
    GMT C API <api>
    PostScriptLight C API <postscriptlight>
    Debugging GMT <debug>
+   reStructuredText Cheatsheet <rst_cheatsheet>
 

--- a/doc/rst/source/rst_cheatsheet.rst
+++ b/doc/rst/source/rst_cheatsheet.rst
@@ -12,6 +12,9 @@ and the rendered web page on the left.
     Try a online reStructuredText editor (e.g. http://rst.ninjs.org/),
     if you want to preview texts written in ReST.
 
+    For a more complete description of ReST syntax, please visit
+    `the Sphinx documentation <http://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_.
+
 .. raw:: html
 
    <div style="float: left; width:49%">
@@ -25,6 +28,7 @@ and the rendered web page on the left.
    <div style="float: right; width:49%">
 
 .. literalinclude:: rst_cheatsheet.rst_
+   :language: none
 
 .. raw:: html
 

--- a/doc/rst/source/rst_cheatsheet.rst
+++ b/doc/rst/source/rst_cheatsheet.rst
@@ -1,15 +1,20 @@
 reStructuredText Cheatsheet
 ###########################
 
-This is a quick and dirty cheatsheet for reStructureText, the plaintext markup language
-used by GMT documentations.
+The GMT documentations are written in `reStructureText (ReST) <https://docutils.sourceforge.io/rst.html>`_
+and built by `Sphinx <https://www.sphinx-doc.org/>`_.
+Here is a quick and dirty cheat sheet for some common ReST stuff used in GMT documentations.
+You can see the literal source code of the ReST file on the right,
+and the rendered web page on the left.
 
-In this page, you'll see the the literal source code of the reStructureText file on the right side,
-and the rendered web page on the left side.
+.. note::
+
+    Try a online reStructuredText editor (e.g. http://rst.ninjs.org/),
+    if you want to preview texts written in ReST.
 
 .. raw:: html
 
-   <div style="float: left; width:50%">
+   <div style="float: left; width:49%">
 
 .. include:: rst_cheatsheet.rst_
 
@@ -17,7 +22,7 @@ and the rendered web page on the left side.
 
    </div>
    </div>
-   <div style="float: right; width:50%">
+   <div style="float: right; width:49%">
 
 .. literalinclude:: rst_cheatsheet.rst_
 

--- a/doc/rst/source/rst_cheatsheet.rst
+++ b/doc/rst/source/rst_cheatsheet.rst
@@ -1,0 +1,26 @@
+reStructuredText Cheatsheet
+###########################
+
+This is a quick and dirty cheatsheet for reStructureText, the plaintext markup language
+used by GMT documentations.
+
+In this page, you'll see the the literal source code of the reStructureText file on the right side,
+and the rendered web page on the left side.
+
+.. raw:: html
+
+   <div style="float: left; width:50%">
+
+.. include:: rst_cheatsheet.rst_
+
+.. raw:: html
+
+   </div>
+   </div>
+   <div style="float: right; width:50%">
+
+.. literalinclude:: rst_cheatsheet.rst_
+
+.. raw:: html
+
+   </div>

--- a/doc/rst/source/rst_cheatsheet.rst_
+++ b/doc/rst/source/rst_cheatsheet.rst_
@@ -1,27 +1,80 @@
-Paragraph
-=========
+Formatting text
+===============
 
-Simple paragraph for **bold**, *italic*.
+It's simple to use inline markup to have *italic text*,
+**bold text**, and ``inline source codes``.
 
 
 Lists
 =====
 
-- ABC
-- DEF
-- GHI
+**Bullet list:**
+
+- Point A
+- Point B
+- Point C
+- Point D
 
 
-#. ABC
-#. DEF
-#. GHI
+
+
+**Numbered list**:
+
+#. Point 1
+#. Point 2
+#. Point 3
+#. Point 4
 
 
 
+
+**Definition list**:
+
+term1
+    Definition of term1
+term2
+    Definition of term2
+
+
+
+Table
+=====
+
+ReST supports multiple ways to make a table.
+
+Simple Table
+------------
+
+Grid Table
+----------
 
 Links
 =====
 
+External links
+--------------
+
 https://generic-mapping-tools.org
 
 `GMT Forum <https://forum.generic-mapping-tools.org/>`_
+
+Internal links
+--------------
+
+This is a link to GMT's module :doc:`plot`.
+
+Codes
+=====
+
+
+::
+
+    gmt begin map
+    gmt basemap -R0/10/0/10 -JX10c/10c -Baf
+    gmt end
+
+
+Images
+======
+
+

--- a/doc/rst/source/rst_cheatsheet.rst_
+++ b/doc/rst/source/rst_cheatsheet.rst_
@@ -1,8 +1,21 @@
 Formatting text
 ===============
 
+Paragraphs are simply chunks of text separated by one or
+more blank lines.
+
+
 It's simple to use inline markup to have *italic text*,
 **bold text**, and ``inline source codes``.
+
+
+It's a little complicated to write a GMT option.
+You need to use backslash + pipe to have a pipe (|) and
+backslash + whitespace to separate inline markups.
+
+
+
+**-A**\ *value*\ [**+w**\ *pen*][**+a**\|\ **b**\|\ **c**]
 
 
 Lists
@@ -37,16 +50,45 @@ term2
 
 
 
+
+
+
+
 Table
 =====
 
 ReST supports multiple ways to make a table.
 
+
 Simple Table
 ------------
 
+=====  =====  =======
+A      B      A and B
+=====  =====  =======
+False  False  False
+True   False  False
+False  True   False
+True   True   True
+=====  =====  =======
+
+
+
+
+
 Grid Table
 ----------
+
+.. _tbl-grid:
+
++----------------------+------------+----------+----------+
+| Header row, column 1 | Header 2   | Header 3 | Header 4 |
+|                      |            |          |          |
++======================+============+==========+==========+
+| body row 1, column 1 | column 2   | column 3 | column 4 |
++----------------------+------------+----------+----------+
+| body row 2           | ...        | ...      |          |
++----------------------+------------+----------+----------+
 
 Links
 =====
@@ -61,11 +103,16 @@ https://generic-mapping-tools.org
 Internal links
 --------------
 
-This is a link to GMT's module :doc:`plot`.
+Link to the a module with :doc:`plot` or :doc:`/plot`.
+
+Link to a section title with `Lists`_.
+
+Link to a target with :ref:`Link to a table <tbl-grid>`.
+
+
 
 Codes
 =====
-
 
 ::
 
@@ -73,8 +120,12 @@ Codes
     gmt basemap -R0/10/0/10 -JX10c/10c -Baf
     gmt end
 
-
 Images
 ======
 
+Use the ``figure`` directive to include images:
 
+.. figure:: /_images/GMT_coverlogo.png
+   :width: 90%
+
+   Figure caption

--- a/doc/rst/source/rst_cheatsheet.rst_
+++ b/doc/rst/source/rst_cheatsheet.rst_
@@ -1,0 +1,27 @@
+Paragraph
+=========
+
+Simple paragraph for **bold**, *italic*.
+
+
+Lists
+=====
+
+- ABC
+- DEF
+- GHI
+
+
+#. ABC
+#. DEF
+#. GHI
+
+
+
+
+Links
+=====
+
+https://generic-mapping-tools.org
+
+`GMT Forum <https://forum.generic-mapping-tools.org/>`_


### PR DESCRIPTION
The reST language is powerful but also complicated. Sometimes we may forget the syntax and have to visit the sphinx website or search for a reST cheatsheet. I think it's useful to add a reST cheatsheet for developers, and potential contributors.

This PR adds a "cheatsheet" in the section "Developer Resources". The cheatsheet looks like below:

![image](https://user-images.githubusercontent.com/3974108/71381455-9c45bd80-25a1-11ea-83ca-828e86383161.png)

I'll work on improving the cheatsheet if you think it's useful.