### PR TITLE
Fix wrong THIS_MODULE_KEYS in movie.c

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -41,7 +41,7 @@
 #define THIS_MODULE_MODERN_NAME	"movie"
 #define THIS_MODULE_LIB		"core"
 #define THIS_MODULE_PURPOSE	"Create animation sequences and movies"
-#define THIS_MODULE_KEYS	"<T("
+#define THIS_MODULE_KEYS	"<D("
 #define THIS_MODULE_NEEDS	""
 #define THIS_MODULE_OPTIONS	"-Vf"
 


### PR DESCRIPTION
For whatever reason it had the old 'T' for text file but that makes no sense anyway since input is likely to be a numerical file with optional trailing text.  Changed to 'D'.
