### PR TITLE
movie_frame.XX creates the image directly in parent dir.

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -1707,13 +1707,12 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			status[k].completed = true;	/* Flag this frame as completed */
 			n_cores_unused++;		/* Free up the core */
 			percent = 100.0 * n_frames_completed / n_frames;
-			GMT_Report (API, GMT_MSG_VERBOSE, "Frame %*.*d of %d completed [%5.1f %%]\r", precision, precision, k, n_frames, percent);
+			GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Frame %*.*d of %d completed [%5.1f %%]\n", precision, precision, k, n_frames, percent);
 		}
 		/* Adjust first_frame, if needed */
 		while (first_frame < n_frames && status[first_frame].completed) first_frame++;
 		if (n_frames_completed == n_frames) done = true;	/* All frames completed! */
 	}
-	GMT_Report (API, GMT_MSG_VERBOSE, "\n");		/* Last was a '\r' */
 	/* END PARALLEL EXECUTION OF FRAME SCRIPTS */
 
 	gmt_M_free (GMT, status);	/* Done with this structure array */

--- a/src/movie.c
+++ b/src/movie.c
@@ -1632,7 +1632,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		if (is_gmt_module (line, "begin")) {	/* Need to insert a gmt figure call after this line */
 			fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
 			set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
-			fprintf (fp, "\tgmt figure %s %s", place_var (Ctrl->In.mode, "MOVIE_NAME"), frame_products);
+			fprintf (fp, "\tgmt figure ../%s %s", place_var (Ctrl->In.mode, "MOVIE_NAME"), frame_products);
 			fprintf (fp, " E%s,%s\n", place_var (Ctrl->In.mode, "MOVIE_DPU"), extra);
 			fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c DIR_DATA %s\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit, datadir);
 		}
@@ -1643,8 +1643,6 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		}
 	}
 	fclose (Ctrl->In.fp);	/* Done reading the main script */
-	set_comment (fp, Ctrl->In.mode, "Move PNG file up to parent directory and cd up one level");
-	fprintf (fp, "%s %s.%s ..\n", mvfile[Ctrl->In.mode], place_var (Ctrl->In.mode, "MOVIE_NAME"), MOVIE_RASTER_FORMAT);	/* Move PNG plot up to parent dir */
 	fprintf (fp, "cd ..\n");	/* cd up to parent dir */
 	if (!Ctrl->Q.active) {	/* Delete evidence; otherwise we want to leave debug evidence when doing a single frame only */
 		set_comment (fp, Ctrl->In.mode, "Remove frame directory and frame parameter file");
@@ -1709,12 +1707,13 @@ int GMT_movie (void *V_API, int mode, void *args) {
 			status[k].completed = true;	/* Flag this frame as completed */
 			n_cores_unused++;		/* Free up the core */
 			percent = 100.0 * n_frames_completed / n_frames;
-			GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Frame %*.*d of %d completed [%5.1f %%]\n", precision, precision, k, n_frames, percent);
+			GMT_Report (API, GMT_MSG_VERBOSE, "Frame %*.*d of %d completed [%5.1f %%]\r", precision, precision, k, n_frames, percent);
 		}
 		/* Adjust first_frame, if needed */
 		while (first_frame < n_frames && status[first_frame].completed) first_frame++;
 		if (n_frames_completed == n_frames) done = true;	/* All frames completed! */
 	}
+	GMT_Report (API, GMT_MSG_VERBOSE, "\n");		/* Last was a '\r' */
 	/* END PARALLEL EXECUTION OF FRAME SCRIPTS */
 
 	gmt_M_free (GMT, status);	/* Done with this structure array */


### PR DESCRIPTION
This PR changes the movie_frame.xxx to create the image directly in the parent directory instead of creating it in the subdir and move it down. On Windows this avoids the annoying message ``1 file(s) moved.`` that was printed for each frame.

On the other hand **-V** was doing nothing. Now it prints the processed frame number but without changing line. 

In Julia it now nicely reports

```
julia> movie("main_sc.jl", pre="pre_sc.jl", C="7.2ix4.8ix100", N=:anim04, T="flight_path.txt", H=2, L="f+o0.1i", F=:mp4, A="+l+s10", V=true, Vd=1)
        movie main_script.bat -V -C7.2ix4.8ix100 -Nanim04 -Tflight_path.txt -A+l+s10 -Fmp4 -H2 -Lf+o0.1i -Sbpre_script.bat
movie [WARNING]: Frame 59 of 60 completed [100.0 %]
```
