### PR TITLE
Add data record counters for both input and output

### DIFF
--- a/src/gmt_io.h
+++ b/src/gmt_io.h
@@ -263,7 +263,9 @@ struct GMT_IO {				/* Used to process input data records */
 					   8	NaNs encountered in first 2/3 cols */
 	uint64_t rec_no;		/* Number of current records (counts headers etc) in entire data set */
 	uint64_t rec_in_tbl_no;		/* Number of current record (counts headers etc) in current table */
-	uint64_t pt_no;			/* Number of current valid points in a row  */
+	uint64_t data_record_number_in_set[2];	/* Number of current valid data record number in the whole dataset, for input and output. Headers not counted.  */
+	uint64_t data_record_number_in_tbl[2];	/* Number of current valid data record number in the current table, for input and output. Headers not counted.  */
+	uint64_t data_record_number_in_seg[2];	/* Number of current valid data record number in the current segment, for input and output. Headers not counted.  */
 	int64_t curr_pos[2][4];		/* Keep track of current input/output table, segment, row, and table headers (for rec-by-rec action) */
 	char r_mode[4];			/* Current file opening mode for reading (r or rb) */
 	char w_mode[4];			/* Current file opening mode for writing (w or wb) */


### PR DESCRIPTION
For upcoming **-q** (regardless of final implementation) we need to count data records per data set, per table, and per segment for both input and output.  We did this for input only, and for set and table only, not segment.  This PR standardizes the counting and renames some of the existing variables.  The new output variables are not used yet in master but will be used in #2341 as that branch explores the new option.

