### PR TITLE
State syntax for old GMT 4 vectors under vector attributes

### DIFF
--- a/doc/rst/source/explain_vectors.rst_
+++ b/doc/rst/source/explain_vectors.rst_
@@ -76,3 +76,16 @@ Finally, Cartesian vectors may take these modifiers:
 
     **+z**\ *scale*\ [*unit*] expects input *dx*,\ *dy* vector components and
     uses the *scale* to convert to polar coordinates with length in given unit.
+
+Note: Vectors were completely redesigned for GMT5 which separated the vector head (a polygon)
+from the vector stem (a line).  In GMT4, the entire vector was a polygon and it could only
+be a straight Cartesian vector. Yes, the old GMT4 vector shape remains accessible if
+you specify a vector (**-Sv**\ \|\ **V**) using the GMT4 syntax, explained here: *size*, if present, will
+be interpreted as *arrowwidth/headlength/headwidth* [Default is 0.075c/0.3c/0.25c (or
+0.03i/0.12i/0.1i)]. By default, arrow attributes remain invariant to the length of the
+arrow. To have the size of the vector scale down with decreasing size, append **n**\ *norm*,
+where vectors shorter than *norm* will have their attributes scaled by length/*norm*.
+To center the vector on the balance point, use **−Svb**; to align point with the vector head,
+use **−Svh**; to align point with the vector tail, use **−Svt** [Default]. To give the
+head point’s coordinates instead of direction and length, use **−Svs**. Upper case
+**B**, **H**, **T**, **S** will draw a double-headed vector [Default is single head].


### PR DESCRIPTION
I guess we cannot debate taste.  Hence, I have added the syntax for the old (and in my opionion ugly - I designed it) GMT 4 vector symbol to the end of the Vector Attribute document.  This PR closes #1011.
