### PR TITLE
Fix copyright_year.sh: mv does not retain permissions

### DIFF
--- a/admin/copyright_year.sh
+++ b/admin/copyright_year.sh
@@ -29,8 +29,8 @@ EOF
 
 # 2. Update the files
 while read f; do
-    sed -E "s/Copyright \(c\) ([0-9]+)-${lastyear}/Copyright \(c\) \1-${newyear}/" $f > $f.new
-    mv -f $f.new $f
+    sed -E -i.bak "s/Copyright \(c\) ([0-9]+)-${lastyear}/Copyright \(c\) \1-${newyear}/" $f
+    rm -f $f.bak
 done < $$.tmp.lis
 
 # 3. Clean up


### PR DESCRIPTION
The old script breaks permissions of scripts, because newly created
files `$f.new` always have permission `rw-r--r--`.

In this PR, the issue is fixed by using `sed -i` to do the in-place
replacements.