### PR TITLE
Given information about byte-swab when selected

### DIFF
--- a/doc/rst/source/grd2xyz.rst
+++ b/doc/rst/source/grd2xyz.rst
@@ -107,7 +107,6 @@ Optional Arguments
     * **d** 8-byte floating point double precision
 
     Default format is scanline orientation of ASCII numbers: **-ZTLa**.
-    Note that **-Z** only applies to 1-column output. 
 
 .. |Add_-bo| replace:: [Default is 3]. This option
     only applies to xyz output; see **-Z** for z table output. 

--- a/doc/rst/source/xyz2grd.rst
+++ b/doc/rst/source/xyz2grd.rst
@@ -157,10 +157,10 @@ Optional Arguments
     **d** 8-byte floating point double precision
 
     Default format is scanline orientation of ASCII numbers: **-ZTLa**.
-    Note that **-Z** only applies to 1-column input. The difference
-    between **A** and **a** is that the latter can decode both
-    *date*\ **T**\ *clock* and *ddd:mm:ss[.xx]* formats while the former
-    is strictly for regular floating point values.
+    The difference between **A** and **a** is that the latter can decode both
+    *date*\ **T**\ *clock* and *ddd:mm:ss[.xx]* formats but expects each
+    input record to have a single value, while the former can handle multiple
+    values per record but can only parse regular floating point values.
 
 .. |Add_-bi| replace:: [Default is 3 input columns]. This option only applies
     to xyz input files; see **-Z** for z tables.

--- a/src/grd2xyz.c
+++ b/src/grd2xyz.c
@@ -92,6 +92,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     Then, append L or R to indicate starting point in row.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If data is in column format, state if first columns is L(left) or R(ight).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Then, append T or B to indicate starting point in column.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   To swap the byte-order of each word, append w.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append x if gridline-registered, periodic data in x without repeating column at xmax.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append y if gridline-registered, periodic data in y without repeating row at ymax.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Specify one of the following data types (all binary except a):\n");
@@ -316,6 +317,7 @@ int GMT_grd2xyz (void *V_API, int mode, void *args) {
 			save = GMT->current.io.output;
 			Out = gmt_new_record (GMT, &d_value, NULL);	/* Since we only need to worry about numerics in this module */
 			
+			if (Ctrl->Z.swab) GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Binary output data will be byte swapped\n");
 			GMT->current.io.output = gmt_z_output;		/* Override and use chosen output mode */
 			GMT->common.b.active[GMT_OUT] = io.binary;	/* May have to set binary as well */
 			GMT->current.setting.io_lonlat_toggle[GMT_OUT] = false;	/* Since no x,y involved here */

--- a/src/grd2xyz.c
+++ b/src/grd2xyz.c
@@ -96,7 +96,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append x if gridline-registered, periodic data in x without repeating column at xmax.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append y if gridline-registered, periodic data in y without repeating row at ymax.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Specify one of the following data types (all binary except a):\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     a  ASCII.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     a  ASCII (one value per record).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     c  int8_t, signed 1-byte character.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     u  uint8_t, unsigned 1-byte character.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     h  int16_t, signed short 2-byte integer.\n");

--- a/src/xyz2grd.c
+++ b/src/xyz2grd.c
@@ -592,6 +592,7 @@ int GMT_xyz2grd (void *V_API, int mode, void *args) {
 	n_read = ij = 0;
 	if (Ctrl->Z.active) {
 		size_t nr = 0;
+		if (Ctrl->Z.swab) GMT_Report (API, GMT_MSG_LONG_VERBOSE, "Binary input data will be byte swapped\n");
 		for (i = 0; i < io.skip; i++)
 			nr += fread (&c, sizeof (char), 1, API->object[API->current_item[GMT_IN]]->fp);
 	}


### PR DESCRIPTION
When the **w** swab indicator is given to **-Z** and **-Vl** is active we should print the message that binary data will be byte-swapped.  Also, grd2xyz usage did not list the **w** modifier as available (but docs do and code worked).  Finally, clarified that format **a** implies one item per record.
