### PR TITLE
Ensure both a and b use same format in proj4 string

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -6692,7 +6692,7 @@ char *gmt_export2proj4 (struct GMT_CTRL *GMT) {
 		a = GMT->current.setting.ref_ellipsoid[GMT->current.setting.proj_ellipsoid].eq_radius;
 		f = GMT->current.setting.ref_ellipsoid[GMT->current.setting.proj_ellipsoid].flattening;
 		b = a * (1 - f);
-		snprintf (szProj4+len, GMT_LEN512-len, " +a=%.3f +b=%.6f", a, b);
+		snprintf (szProj4+len, GMT_LEN512-len, " +a=%.3f +b=%.3f", a, b);
 		len = strlen (szProj4);
 		if (fabs(a - b) > 1) {		/* WGS84 is not spherical */
 			plot_ellipsoid_name_convert(GMT->current.setting.ref_ellipsoid[GMT->current.setting.proj_ellipsoid].name, proj4_ename);


### PR DESCRIPTION
Since _a_ used 3 decimals and _b_ used 6 they would sometimes differ and then GDAL would compute a negative eccentricity and fail to make WKT:

```
grdedit [INFORMATION]: Proj4 string to be converted to WKT:
	+proj=merc +lon_0=180 +k=1 +x_0=0 +y_0=0 +units=m +a=6371008.771 +b=6371008.771400 +units=m +no_defs
ERROR 1: PROJ: proj_create: Error -12: squared eccentricity < 0
grdedit [WARNING]: gmtnc_grd_info failed to convert the proj4 string
```