### PR TITLE
xyz2grd -Z unable to scale input data via -i

### DIFF
--- a/doc/rst/source/xyz2grd.rst
+++ b/doc/rst/source/xyz2grd.rst
@@ -159,7 +159,8 @@ Optional Arguments
     Note that **-Z** only applies to 1-column input. The difference
     between **A** and **a** is that the latter can decode both
     *date*\ **T**\ *clock* and *ddd:mm:ss[.xx]* formats while the former
-    is strictly for regular floating point values.
+    is strictly for regular floating point values.  To translate the incoming
+    *z*-values you may use the **-i**\ 0 option with the desirable modifiers.
 
 .. |Add_-bi| replace:: [Default is 3 input columns]. This option only applies
     to xyz input files; see **-Z** for z tables.

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -4307,13 +4307,17 @@ int gmt_z_output (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double *data, char
 	return (err ? -1 : 0);	/* Return -1 if failed, else n items written */
 }
 
-/* gmt_z_input and gmt_z_output are used in grd2xyz/xyz2grd to fascilitate reading of one-col items via the general i/o machinery */
+/* gmt_z_input and gmt_z_output are used in grd2xyz/xyz2grd to fascilitate reading of one-col items via the general i/o machinery
+ * Despite taking uint64_t *n we KNOW that this value is 1 and hence column is always GMT_X. */
 /*! . */
 void * gmt_z_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, int *status) {
 	if ((*status = GMT->current.io.read_item (GMT, fp, *n, GMT->current.io.curr_rec)) == GMT_DATA_READ_ERROR) {
 		GMT->current.io.status = GMT_IO_EOF;
 		return (NULL);
 	}
+	if (GMT->common.i.select)	/* We need to scale this single item */
+		gmt_convert_col (GMT->current.io.col[GMT_IN][GMT_X], GMT->current.io.curr_rec[GMT_X]);
+
 	return (&GMT->current.io.record);
 }
 


### PR DESCRIPTION
The **-Z** option to xyz2grd detours the input to the _gmt_z_input_ function which failed to consider any translation given by **-i**0.  Now fixed, and pointed out in documentation if you need to scale those incoming (and likely binary) data.
