### PR TITLE
grdinfo did not print x and y unit names unless containing the word degree

### DIFF
--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -840,9 +840,11 @@ int GMT_grdinfo (void *V_API, int mode, void *args) {
 				gmt_ascii_format_col (GMT, text, G->header->wesn[XHI], GMT_OUT, GMT_X);	strcat (record, text);
 				strcat (record, " x_inc: ");	smart_increments (GMT, G->header->inc, GMT_X, text);	strcat (record, text);
 				strcat (record, " name: ");
-				if ((c = strstr (G->header->x_units, " [degrees"))) {
+				if ((c = strstr (G->header->x_units, " [degrees"))) {	/* Strip off [degrees ...] from the name of the longitude variable */
 					c[0] = '\0'; strcat (record, G->header->x_units); if (c) c[0] = ' ';
 				}
+				else	/* Just output what it says */
+					strcat (record, G->header->x_units);
 				sprintf (text, " n_columns: %d", G->header->n_columns);	strcat (record, text);
 				GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 				sprintf (record, "%s: y_min: ", HH->name);
@@ -851,9 +853,11 @@ int GMT_grdinfo (void *V_API, int mode, void *args) {
 				gmt_ascii_format_col (GMT, text, G->header->wesn[YHI], GMT_OUT, GMT_Y);	strcat (record, text);
 				strcat (record, " y_inc: ");	smart_increments (GMT, G->header->inc, GMT_Y, text);	strcat (record, text);
 				strcat (record, " name: ");
-				if ((c = strstr (G->header->y_units, " [degrees"))) {
+				if ((c = strstr (G->header->y_units, " [degrees"))) {	/* Strip off [degrees ...] from the name of the latitude variable */
 					c[0] = '\0'; strcat (record, G->header->y_units); if (c) c[0] = ' ';
 				}
+				else	/* Just output what it says */
+					strcat (record, G->header->y_units);
 				sprintf (text, " n_rows: %d", G->header->n_rows);	strcat (record, text);
 				GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 			}


### PR DESCRIPTION
There was a special provision to look for " [degrees" as part of the x and y unit strings and if so we just stripped off that part from the name.  However, if we had a Cartesian grid then that strstr returned NULL and we did nothng, including not printing out the original unit name.
