### PR TITLE
The -o docs incorrectly talked about scaling

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6593,14 +6593,14 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 
 		case 'i':	/* -i option for input column order */
 
-			gmt_message (GMT, "\t-i Sets alternate input column order and optional transformations [Default reads all columns in original order].\n");
+			gmt_message (GMT, "\t-i Set alternate input column order and optional transformations [Default reads all columns in original order].\n");
 			gmt_message (GMT, "\t   Append list of columns; t[<word>] = trailing text; use <word> to pick a word from the text.\n");
 			gmt_message (GMT, "\t   Use -in for considering numerical input only.\n");
 			break;
 
 		case 'A':	/* -j option for spherical distance calculation mode */
 
-			gmt_message (GMT, "\t-j Sets spherical distance calculation mode for modules that offer that flexibility.\n");
+			gmt_message (GMT, "\t-j Set spherical distance calculation mode for modules that offer that flexibility.\n");
 			gmt_message (GMT, "\t   Append f for Flat Earth, g for Great Circle [Default], and e for Ellipsoidal mode.\n");
 			break;
 
@@ -7400,7 +7400,7 @@ void gmt_syntax (struct GMT_CTRL *GMT, char option) {
 		case 'i':	/* -i option for input column order */
 
 			gmt_message (GMT, "\t%s\n", GMT_i_OPT);
-			gmt_message (GMT, "\t   Sets alternate numerical input column order and/or scaling. Append ,t to include trailing text.\n");
+			gmt_message (GMT, "\t   Set alternate numerical input column order and optional translations. Append ,t to include trailing text.\n");
 			gmt_message (GMT, "\t   [Default reads all numerical columns in order, followed by any trailing text].\n");
 			break;
 
@@ -7424,7 +7424,7 @@ void gmt_syntax (struct GMT_CTRL *GMT, char option) {
 		case 'o':	/* -o option for output column order */
 
 			gmt_message (GMT, "\t%s\n", GMT_o_OPT);
-			gmt_message (GMT, "\t   Sets alternate numerical output column order and/or scaling; end with [,]t to output trailing text.\n");
+			gmt_message (GMT, "\t   Set alternate numerical output column order; end with [,]t[<word>] to output trailing text.\n");
 			gmt_message (GMT, "\t   [Default writes all numerical columns in order, followed by any trailing text].\n");
 			break;
 
@@ -8158,6 +8158,11 @@ int gmt_parse_o_option (struct GMT_CTRL *GMT, char *arg) {
 	int64_t i, start = -1, stop = -1, inc;
 
 	if (!arg || !arg[0]) return (GMT_PARSE_ERROR);	/* -o requires an argument */
+
+	if (strstr (arg, "+s") || strstr (arg, "+o") || strstr (arg, "+l")) {
+		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "The -o option does not take +l|o|s modifiers; consider -i instead.\n");
+		return GMT_PARSE_ERROR;
+	}
 
 	strncpy (copy, arg, GMT_BUFSIZ-1);
 	strncpy (GMT->common.o.string, arg, GMT_LEN64-1);	/* Verbatim copy */


### PR DESCRIPTION
Only **-i** has the scaling modifiers.  However, parsing of **-o** silently ignored any modifiers.  Now we give an error.  Also, improved the documentation for **-i** and **-o**.
