### PR TITLE
Update GMT_VERSION_YEAR in cmake/ConfigDefault.cmake to 2020

### DIFF
--- a/admin/copyright_year.sh
+++ b/admin/copyright_year.sh
@@ -33,5 +33,9 @@ while read f; do
     rm -f $f.bak
 done < $$.tmp.lis
 
+# 3. Update GMT_VERSION_YEAR in cmake/ConfigDefault.cmake
+sed -i.bak "s/set (GMT_VERSION_YEAR \"${lastyear}\")/set (GMT_VERSION_YEAR \"${newyear}\")/" cmake/ConfigDefault.cmake
+rm -f cmake/ConfigDefault.cmake.bak
+
 # 3. Clean up
 rm -f $$.tmp.lis

--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -35,7 +35,7 @@ set (GMT_PACKAGE_NAME "GMT")
 set (GMT_PACKAGE_DESCRIPTION_SUMMARY "The Generic Mapping Tools")
 
 # Year of the current GMT release.
-set (GMT_VERSION_YEAR "2019")
+set (GMT_VERSION_YEAR "2020")
 
 # The GMT release DOI
 set (GMT_VERSION_DOI "https://doi.org/10.5281/zenodo.3407866")


### PR DESCRIPTION
The script `admin/copyright_year.sh` is also updated.