### PR TITLE
Redirect users to the forum if they have questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: GMT Community Forum
+    url: https://forum.generic-mapping-tools.org/
+    about: Please ask and answer questions here.


### PR DESCRIPTION
Add an issue configuration file, following the [github documentation](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser).

When a user wants to open an issue and ask questions, he will see something like below (The screenshot is from a node.js repository.).
![image](https://user-images.githubusercontent.com/3974108/71697617-a0828f80-2d86-11ea-98d4-4386fa2dc1ea.png)
