### PR TITLE
Fix contour wrapping in the y-direction

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -10280,7 +10280,7 @@ void gmt_hold_contour (struct GMT_CTRL *GMT, double **xxx, double **yyy, uint64_
 		support_hold_contour_sub (GMT, &xs, &ys, n, zval, label, ctype, cangle, closed, contour, G);
 		gmt_M_free (GMT, xs);
 		gmt_M_free (GMT, ys);
-		first = n;	/* First point in next segment */
+		first += n;	/* First point in the next segment */
 	}
 	gmt_M_free (GMT, split);
 }

--- a/test/grdcontour/TMcontours.ps
+++ b/test/grdcontour/TMcontours.ps
@@ -1,0 +1,19040 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.0.1_05fbb15_2020.01.03 [64-bit] Document from pscoast
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Fri Jan  3 17:41:44 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt pscoast -R0/360/-80/80 -JT180/-30/6i -Glightgray -A1000 -Bag
+%@PROJ: tmerc 0.00000000 360.00000000 -90.00000000 90.00000000 -15512672.854 15512672.854 -10001965.729 30005897.188 +proj=tmerc +lat_0=-30 +lon_0=180 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+3504 5681 M
+12 -9 D
+1 7 D
+11 -15 D
+-9 28 D
+14 -19 D
+0 14 D
+9 -7 D
+-4 -9 D
+12 12 D
+-18 32 D
+-8 -20 D
+-3 10 D
+-4 -8 D
+-6 6 D
+17 15 D
+-4 8 D
+-15 -10 D
+10 10 D
+-9 3 D
+13 2 D
+-12 11 D
+-12 7 D
+4 -48 D
+-4 -5 D
+P
+{0.827 A} FS
+FO
+3515 5650 M
+3 -2 D
+-3 10 D
+7 2 D
+-7 9 D
+-6 -3 D
+P
+FO
+3415 5902 M
+P
+FO
+3397 5895 M
+18 -2 D
+-5 7 D
+-4 -1 D
+-3 -1 D
+P
+FO
+3352 5875 M
+5 -3 D
+-14 -4 D
+-3 -12 D
+22 -2 D
+3 15 D
+1 -16 D
+9 0 D
+-3 18 D
+3 5 D
+6 -15 D
+2 27 D
+3 -22 D
+11 1 D
+-1 28 D
+-9 -4 D
+-9 -4 D
+-8 -4 D
+-5 -2 D
+-8 -4 D
+P
+FO
+3509 5666 M
+-7 -4 D
+4 11 D
+-18 1 D
+-6 -25 D
+13 -5 D
+5 9 D
+5 -9 D
+-3 13 D
+13 -7 D
+P
+FO
+3499 5696 M
+-6 -8 D
+11 -7 D
+P
+FO
+3470 5710 M
+12 -12 D
+9 7 D
+-7 16 D
+-6 -7 D
+-5 8 D
+P
+FO
+3491 5702 M
+0 -11 D
+6 6 D
+P
+FO
+3147 5683 M
+15 4 D
+-10 7 D
+-6 -10 D
+P
+FO
+3285 5600 M
+-5 34 D
+-15 3 D
+-2 17 D
+-10 -4 D
+9 6 D
+-2 14 D
+-13 -11 D
+1 15 D
+-13 -14 D
+12 -6 D
+-8 -6 D
+10 3 D
+-8 -6 D
+11 -4 D
+-7 -2 D
+12 -8 D
+-6 -4 D
+5 -10 D
+P
+FO
+3393 5536 M
+0 2 D
+-9 4 D
+0 -1 D
+P
+FO
+3193 5717 M
+-19 -25 D
+38 -2 D
+15 -10 D
+6 -18 D
+10 9 D
+5 12 D
+-7 2 D
+2 10 D
+-8 -7 D
+-5 28 D
+-10 4 D
+-7 -13 D
+P
+FO
+3413 5591 M
+-4 -20 D
+9 -6 D
+P
+FO
+3145 5682 M
+2 1 D
+-1 1 D
+P
+FO
+3096 5576 M
+22 -8 D
+18 3 D
+29 -19 D
+9 8 D
+7 16 D
+-31 22 D
+-6 18 D
+-28 12 D
+-17 -42 D
+P
+FO
+3134 5500 M
+11 10 D
+-3 9 D
+-11 -2 D
+6 17 D
+-31 -16 D
+12 19 D
+46 -1 D
+-17 3 D
+-16 23 D
+-24 -5 D
+-15 7 D
+-10 -39 D
+-3 -15 D
+P
+FO
+3384 5541 M
+6 -13 D
+3 8 D
+P
+FO
+3256 5617 M
+7 -15 D
+2 -52 D
+18 -9 D
+-6 29 D
+10 20 D
+-2 10 D
+P
+FO
+3181 5563 M
+7 -5 D
+2 9 D
+-9 4 D
+P
+FO
+3384 5527 M
+8 -14 D
+P
+FO
+3074 5483 M
+6 4 D
+21 -7 D
+-10 9 D
+30 -15 D
+2 15 D
+11 11 D
+-55 10 D
+P
+FO
+3194 5344 M
+2 6 D
+4 -5 D
+51 9 D
+-1 7 D
+-10 -8 D
+4 7 D
+-14 19 D
+8 -2 D
+-2 18 D
+-6 2 D
+2 -8 D
+-22 48 D
+-14 0 D
+7 8 D
+-28 -8 D
+-2 51 D
+-30 3 D
+-25 -21 D
+-44 6 D
+-3 -27 D
+-1 -56 D
+6 -55 D
+3 -16 D
+P
+FO
+3339 5370 M
+5 6 D
+-7 4 D
+9 2 D
+-18 20 D
+-14 -16 D
+1 -21 D
+P
+FO
+3340 5399 M
+7 -16 D
+12 -2 D
+15 12 D
+-28 16 D
+P
+FO
+3331 5402 M
+7 -3 D
+3 13 D
+-10 -2 D
+P
+FO
+3214 5190 M
+-1 1 D
+1 13 D
+9 1 D
+-7 24 D
+-20 9 D
+17 13 D
+-8 0 D
+6 9 D
+-5 10 D
+-9 0 D
+4 -10 D
+-25 30 D
+-13 3 D
+26 -5 D
+57 -29 D
+12 15 D
+-5 -11 D
+9 1 D
+15 26 D
+-16 25 D
+13 -3 D
+-2 21 D
+11 -11 D
+6 15 D
+-20 12 D
+-17 -2 D
+-1 7 D
+-5 -1 D
+-5 -1 D
+-5 -1 D
+-5 -1 D
+-5 -1 D
+-6 -1 D
+-5 -1 D
+-5 -1 D
+-5 -1 D
+-5 0 D
+2 -4 D
+14 6 D
+-12 -12 D
+9 -18 D
+9 2 D
+-5 -13 D
+-14 19 D
+-9 4 D
+4 11 D
+-15 -6 D
+11 5 D
+0 5 D
+-6 -2 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-6 -1 D
+7 -33 D
+12 -39 D
+5 -16 D
+21 -46 D
+22 -40 D
+P
+FO
+3315 5365 M
+24 5 D
+-5 -1 D
+-5 -1 D
+-5 -1 D
+-4 -1 D
+P
+FO
+3291 5359 M
+19 -24 D
+16 13 D
+-11 5 D
+15 3 D
+P
+FO
+3220 5261 M
+-4 -9 D
+9 -1 D
+P
+FO
+3174 5108 M
+12 4 D
+17 -7 D
+11 12 D
+-10 -12 D
+-18 6 D
+-12 -4 D
+24 -29 D
+26 -28 D
+4 -3 D
+7 -8 D
+24 -21 D
+9 -6 D
+23 30 D
+-10 12 D
+-9 -8 D
+-3 21 D
+-17 9 D
+4 16 D
+-35 -12 D
+13 42 D
+9 -6 D
+0 12 D
+8 -3 D
+8 13 D
+-11 16 D
+4 20 D
+-28 -5 D
+-10 21 D
+-10 -6 D
+-14 -9 D
+-10 -6 D
+-10 -6 D
+-14 -9 D
+-10 -6 D
+22 -33 D
+P
+FO
+3304 5057 M
+-9 -1 D
+-2 -13 D
+8 11 D
+P
+FO
+3307 5061 M
+-8 2 D
+6 -4 D
+P
+FO
+3325 5083 M
+-2 0 D
+1 -1 D
+P
+FO
+3363 5131 M
+1 13 D
+-19 -4 D
+-8 -19 D
+11 -9 D
+P
+FO
+3426 4927 M
+-2 24 D
+-22 14 D
+-29 6 D
+-17 35 D
+12 0 D
+-7 16 D
+-9 5 D
+-22 -9 D
+11 14 D
+-3 -10 D
+13 6 D
+-19 10 D
+19 -9 D
+-30 38 D
+-3 -8 D
+-11 2 D
+-2 -2 D
+2 -1 D
+-3 -1 D
+-9 -10 D
+-3 -6 D
+-1 1 D
+-23 -30 D
+26 -20 D
+47 -29 D
+39 -19 D
+30 -13 D
+15 -5 D
+P
+FO
+3348 5112 M
+20 -14 D
+7 22 D
+-6 -18 D
+18 2 D
+-10 29 D
+-14 -8 D
+0 6 D
+P
+FO
+3324 5082 M
+15 -18 D
+7 3 D
+-2 16 D
+-19 0 D
+P
+FO
+3390 5087 M
+7 -13 D
+17 3 D
+-20 25 D
+P
+FO
+3426 4926 M
+0 1 D
+-1 -1 D
+P
+FO
+3524 4902 M
+-7 5 D
+-1 -3 D
+P
+FO
+3600 4933 M
+-9 -15 D
+9 3 D
+P
+FO
+3771 4938 M
+-2 3 D
+-13 -13 D
+-2 -8 D
+21 6 D
+P
+FO
+3600 4921 M
+22 9 D
+-19 8 D
+-3 -5 D
+P
+FO
+3913 4997 M
+-6 0 D
+-64 -32 D
+-13 -1 D
+-1 8 D
+-14 -8 D
+-11 5 D
+-3 -12 D
+-1 11 D
+-10 3 D
+-5 -17 D
+-14 -7 D
+2 -13 D
+-2 4 D
+4 -12 D
+40 15 D
+53 27 D
+41 26 D
+P
+FO
+3999 5074 M
+-3 7 D
+-1 -11 D
+P
+FO
+4018 5096 M
+-19 2 D
+12 -4 D
+0 -6 D
+P
+FO
+4031 5114 M
+-5 3 D
+3 -5 D
+P
+FO
+3957 5207 M
+-13 -4 D
+-9 -22 D
+17 -4 D
+29 -42 D
+5 7 D
+28 -1 D
+3 24 D
+-10 9 D
+-1 4 D
+P
+FO
+3894 5245 M
+15 -28 D
+0 13 D
+8 1 D
+P
+FO
+4120 5313 M
+-6 1 D
+-29 -26 D
+-49 7 D
+-16 -7 D
+0 -12 D
+41 -10 D
+-41 -4 D
+-2 -7 D
+17 2 D
+-7 -5 D
+6 -6 D
+-3 -8 D
+-8 12 D
+-12 -9 D
+5 -18 D
+-20 10 D
+6 -39 D
+15 -14 D
+8 8 D
+5 -7 D
+9 26 D
+-2 -31 D
+13 -1 D
+14 32 D
+18 16 D
+-17 -53 D
+2 0 D
+21 44 D
+21 56 D
+P
+FO
+4042 5337 M
+4 -2 D
+-11 -15 D
+9 -6 D
+33 16 D
+P
+FO
+4019 5341 M
+-2 -6 D
+12 1 D
+-4 -9 D
+9 11 D
+P
+FO
+3972 5350 M
+5 -7 D
+11 3 D
+0 1 D
+P
+FO
+3964 5351 M
+-17 -9 D
+18 3 D
+2 -14 D
+3 19 D
+P
+FO
+3950 5354 M
+-3 -6 D
+16 3 D
+P
+FO
+3894 5364 M
+-7 -1 D
+-19 -22 D
+15 -1 D
+3 8 D
+11 -9 D
+-1 9 D
+12 13 D
+P
+FO
+3917 5231 M
+3 0 D
+-16 23 D
+14 -2 D
+-19 21 D
+-7 -7 D
+-3 -13 D
+5 -8 D
+16 -9 D
+P
+FO
+4006 5178 M
+-16 51 D
+-25 -6 D
+0 -13 D
+-8 -3 D
+P
+FO
+3954 5245 M
+-7 15 D
+10 -4 D
+3 20 D
+5 -28 D
+12 11 D
+-7 30 D
+7 18 D
+-20 9 D
+-7 -5 D
+10 -5 D
+-6 -6 D
+-29 2 D
+9 -12 D
+26 2 D
+-7 -15 D
+-34 -11 D
+3 -8 D
+6 6 D
+1 -15 D
+6 11 D
+0 -18 D
+4 14 D
+2 -21 D
+P
+FO
+3896 5307 M
+-6 -16 D
+9 -4 D
+8 11 D
+P
+FO
+4032 5298 M
+-15 9 D
+-7 -15 D
+5 -5 D
+P
+FO
+3881 5296 M
+3 20 D
+-10 -4 D
+P
+FO
+3929 5239 M
+-8 7 D
+6 -16 D
+P
+FO
+3918 5330 M
+-11 -3 D
+19 3 D
+P
+FO
+3980 5320 M
+-10 1 D
+P
+FO
+3954 5327 M
+-4 10 D
+P
+FO
+3938 5331 M
+10 0 D
+-9 0 D
+P
+FO
+4129 5392 M
+-6 2 D
+2 8 D
+-51 -24 D
+30 -21 D
+3 7 D
+20 -6 D
+P
+FO
+4125 5490 M
+-8 -9 D
+7 11 D
+0 4 D
+-4 -3 D
+1 17 D
+-6 -1 D
+-5 -1 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-5 -1 D
+-6 -1 D
+-6 -1 D
+15 -6 D
+-24 2 D
+-25 -14 D
+14 -25 D
+8 11 D
+1 -15 D
+6 14 D
+-3 -15 D
+23 15 D
+-6 -9 D
+7 -7 D
+10 14 D
+19 0 D
+-7 -3 D
+5 -40 D
+16 7 D
+7 9 D
+-9 13 D
+14 6 D
+P
+FO
+4022 5491 M
+0 -6 D
+20 10 D
+-4 -1 D
+-4 0 D
+-4 -1 D
+-4 -1 D
+P
+FO
+3988 5485 M
+0 -2 D
+-9 1 D
+-3 -1 D
+-2 0 D
+-6 -12 D
+16 -32 D
+-9 -15 D
+7 -1 D
+-15 -7 D
+5 -8 D
+-7 7 D
+-5 -9 D
+1 15 D
+-6 -14 D
+-5 3 D
+6 -16 D
+-14 0 D
+-4 -19 D
+21 7 D
+-2 15 D
+37 4 D
+13 15 D
+-11 10 D
+12 6 D
+-4 30 D
+-10 -1 D
+10 14 D
+-10 11 D
+-3 0 D
+P
+FO
+3933 5475 M
+-1 -11 D
+-13 -3 D
+4 12 D
+-6 -1 D
+-6 -1 D
+-5 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-5 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-5 -1 D
+9 -13 D
+18 15 D
+-16 -17 D
+0 -12 D
+31 17 D
+2 -6 D
+-3 16 D
+6 -9 D
+7 6 D
+-8 -15 D
+6 -9 D
+16 -2 D
+-7 8 D
+7 3 D
+-13 3 D
+28 2 D
+-16 12 D
+22 -10 D
+-13 -22 D
+17 10 D
+17 -18 D
+4 7 D
+-10 1 D
+12 5 D
+-8 0 D
+7 6 D
+-8 0 D
+9 9 D
+-10 5 D
+5 8 D
+-9 -3 D
+9 8 D
+-11 -4 D
+17 13 D
+-5 6 D
+-4 -1 D
+-4 0 D
+-5 -1 D
+-4 -1 D
+P
+FO
+3783 5448 M
+6 -7 D
+15 10 D
+-9 -19 D
+8 -5 D
+8 9 D
+-6 -13 D
+12 -14 D
+1 9 D
+7 -4 D
+-4 13 D
+13 -10 D
+-8 20 D
+11 -19 D
+7 9 D
+-16 20 D
+11 -12 D
+7 -2 D
+-9 11 D
+0 7 D
+8 -5 D
+-4 9 D
+-6 3 D
+-5 -1 D
+-5 -1 D
+-6 -1 D
+-5 -1 D
+-5 -1 D
+-5 -1 D
+-6 -1 D
+-5 -1 D
+-5 -1 D
+P
+FO
+3908 5361 M
+4 5 D
+-18 -2 D
+P
+FO
+3963 5351 M
+2 1 D
+-1 -1 D
+6 -1 D
+0 3 D
+2 -3 D
+16 -3 D
+1 14 D
+-9 6 D
+-35 -3 D
+7 -5 D
+-2 -5 D
+P
+FO
+4034 5338 M
+1 2 D
+17 -5 D
+25 -5 D
+9 6 D
+0 9 D
+-13 2 D
+7 -1 D
+-2 10 D
+-27 8 D
+-9 -15 D
+-18 14 D
+-5 -22 D
+P
+FO
+3887 5395 M
+12 12 D
+2 -7 D
+7 5 D
+2 14 D
+-12 -3 D
+12 6 D
+-23 3 D
+10 3 D
+-18 13 D
+-9 -5 D
+3 -8 D
+-23 -2 D
+9 -2 D
+-35 -22 D
+14 -9 D
+9 7 D
+3 -13 D
+11 9 D
+-6 -10 D
+7 -1 D
+4 11 D
+13 -5 D
+2 23 D
+P
+FO
+4093 5460 M
+-18 -11 D
+-20 -3 D
+-29 9 D
+-2 -13 D
+19 -19 D
+47 -7 D
+6 27 D
+P
+FO
+4074 5374 M
+-12 14 D
+-9 -7 D
+2 18 D
+-32 16 D
+-4 -38 D
+P
+FO
+3915 5383 M
+-13 7 D
+-13 -16 D
+21 -1 D
+P
+FO
+3920 5393 M
+2 -13 D
+6 15 D
+-8 -1 D
+P
+FO
+3991 5370 M
+11 21 D
+-26 -5 D
+P
+FO
+3926 5416 M
+-1 -7 D
+10 5 D
+P
+FO
+4119 5519 M
+-9 -7 D
+-10 3 D
+17 14 D
+-10 40 D
+-14 39 D
+-7 2 D
+9 -12 D
+-19 12 D
+-3 -13 D
+13 -7 D
+-13 2 D
+27 -6 D
+-15 -1 D
+6 -6 D
+-21 6 D
+18 -13 D
+-21 6 D
+-6 -15 D
+19 -5 D
+-20 -4 D
+20 -8 D
+-14 0 D
+1 -6 D
+-13 7 D
+11 -17 D
+-20 6 D
+-2 -21 D
+10 -6 D
+6 15 D
+0 -16 D
+11 12 D
+-16 -21 D
+3 -1 D
+64 12 D
+P
+FO
+4086 5623 M
+-5 -10 D
+11 -4 D
+P
+FO
+3784 5522 M
+4 -5 D
+18 10 D
+-1 -8 D
+10 7 D
+-7 -9 D
+24 -4 D
+7 5 D
+-9 12 D
+29 2 D
+8 -13 D
+28 -12 D
+11 26 D
+-10 15 D
+8 4 D
+7 -17 D
+-3 17 D
+12 -27 D
+2 23 D
+11 -7 D
+5 9 D
+0 15 D
+-7 -8 D
+1 12 D
+-14 8 D
+-3 16 D
+5 9 D
+-11 -6 D
+-10 -6 D
+-11 -6 D
+-16 -10 D
+-10 -6 D
+-11 -6 D
+-10 -6 D
+-10 -6 D
+-11 -6 D
+-10 -6 D
+-11 -7 D
+-10 -6 D
+P
+FO
+3779 5520 M
+1 0 D
+P
+FO
+3835 5458 M
+-18 9 D
+16 -5 D
+-2 10 D
+11 -13 D
+81 14 D
+2 8 D
+-17 0 D
+-3 12 D
+-5 -7 D
+-5 9 D
+-3 -9 D
+-5 10 D
+-7 -25 D
+-4 22 D
+-4 -19 D
+-10 21 D
+-8 -7 D
+0 14 D
+-11 1 D
+0 -9 D
+-3 9 D
+-8 -6 D
+3 7 D
+-33 8 D
+16 -16 D
+-15 8 D
+-1 -11 D
+-3 13 D
+-15 7 D
+-10 -1 D
+-7 -13 D
+12 -13 D
+-11 4 D
+6 -34 D
+9 -8 D
+P
+FO
+3954 5479 M
+-7 9 D
+-14 -1 D
+0 -12 D
+P
+FO
+3982 5484 M
+-7 2 D
+-1 -3 D
+P
+FO
+3994 5486 M
+-4 4 D
+-2 -5 D
+P
+FO
+4042 5495 M
+5 6 D
+-9 25 D
+-16 -14 D
+0 -21 D
+P
+FO
+4016 5737 M
+-2 -6 D
+8 -11 D
+5 3 D
+-9 12 D
+P
+FO
+3721 5560 M
+1 -19 D
+10 3 D
+-8 15 D
+6 7 D
+6 -21 D
+2 18 D
+6 -6 D
+8 10 D
+1 -30 D
+15 19 D
+0 -16 D
+10 2 D
+-14 -12 D
+16 -10 D
+9 18 D
+-6 -15 D
+1 -1 D
+41 25 D
+95 55 D
+14 41 D
+15 0 D
+-9 5 D
+25 21 D
+6 18 D
+7 -8 D
+-3 7 D
+13 4 D
+-11 0 D
+19 -1 D
+-5 17 D
+-21 -12 D
+12 12 D
+-9 10 D
+14 -3 D
+-10 10 D
+13 -3 D
+-9 5 D
+8 -2 D
+-5 10 D
+5 -7 D
+7 22 D
+4 -24 D
+12 -10 D
+0 26 D
+-13 15 D
+2 1 D
+-7 8 D
+-8 7 D
+-7 8 D
+-4 3 D
+-7 8 D
+-32 27 D
+-4 3 D
+-117 -146 D
+-28 -33 D
+-23 -29 D
+-40 -47 D
+P
+FO
+3743 5543 M
+4 17 D
+-8 -8 D
+P
+FO
+3839 5879 M
+5 -6 D
+-20 0 D
+21 -10 D
+-18 -12 D
+-6 10 D
+-15 -3 D
+20 -18 D
+-10 1 D
+4 -11 D
+-21 29 D
+-1 25 D
+-11 -7 D
+4 10 D
+-8 2 D
+1 -16 D
+-8 -9 D
+6 -2 D
+-7 -4 D
+10 -1 D
+-7 -6 D
+10 -18 D
+10 4 D
+-5 -5 D
+8 -4 D
+-14 4 D
+2 -10 D
+12 2 D
+3 -10 D
+-19 2 D
+17 -10 D
+-11 2 D
+4 -9 D
+-6 10 D
+-12 -2 D
+3 -14 D
+-5 14 D
+-5 -6 D
+-11 10 D
+12 -6 D
+-7 15 D
+-16 -1 D
+-4 -9 D
+8 -8 D
+4 10 D
+1 -12 D
+-8 -13 D
+-11 13 D
+-2 -6 D
+6 -5 D
+-6 -9 D
+10 -7 D
+-12 4 D
+8 -13 D
+-12 14 D
+-5 -14 D
+10 -9 D
+-13 0 D
+0 -1 D
+10 -5 D
+1 -14 D
+-16 4 D
+-6 -16 D
+5 -5 D
+-7 0 D
+-2 -6 D
+3 -5 D
+9 6 D
+-5 -11 D
+-16 -16 D
+-8 -21 D
+2 0 D
+-2 -8 D
+-3 -1 D
+-3 -9 D
+5 -3 D
+-6 1 D
+-8 -22 D
+3 -3 D
+25 19 D
+-23 -33 D
+24 8 D
+-12 -11 D
+28 -11 D
+-10 -5 D
+-22 12 D
+-17 -5 D
+14 -11 D
+-7 -8 D
+35 -7 D
+-12 -6 D
+-23 8 D
+27 -23 D
+15 14 D
+1 -1 D
+19 24 D
+44 52 D
+27 34 D
+28 33 D
+93 117 D
+-25 19 D
+-22 15 D
+-41 23 D
+P
+FO
+3795 5899 M
+-4 -2 D
+23 -18 D
+20 3 D
+-17 8 D
+-18 7 D
+P
+FO
+3783 5834 M
+-10 13 D
+0 -19 D
+10 -5 D
+P
+FO
+3752 5796 M
+-12 7 D
+4 -9 D
+P
+FO
+3770 5822 M
+7 -13 D
+11 2 D
+P
+FO
+3834 5868 M
+-22 5 D
+-2 -12 D
+P
+FO
+3779 5823 M
+-14 11 D
+2 -9 D
+P
+FO
+3683 5645 M
+-23 0 D
+-12 -20 D
+12 -8 D
+10 10 D
+5 -4 D
+P
+FO
+3687 5656 M
+-19 -3 D
+16 -6 D
+P
+FO
+3698 5686 M
+-20 -22 D
+12 1 D
+P
+FO
+3709 5718 M
+-5 -1 D
+3 -5 D
+P
+FO
+3717 5739 M
+-10 2 D
+-4 -13 D
+8 -5 D
+P
+FO
+3722 5755 M
+-1 0 D
+1 -1 D
+P
+FO
+3730 5778 M
+-2 3 D
+-6 -15 D
+3 -2 D
+P
+FO
+3738 5800 M
+-2 2 D
+-6 -4 D
+6 -4 D
+P
+FO
+3724 5786 M
+-9 2 D
+1 -12 D
+P
+FO
+3301 6293 M
+7 10 D
+-4 -13 D
+14 12 D
+16 -9 D
+43 32 D
+-1 11 D
+28 -16 D
+30 17 D
+-2 -11 D
+15 4 D
+13 -12 D
+1 -23 D
+-18 -21 D
+13 -6 D
+-3 -27 D
+26 20 D
+-3 61 D
+-4 -4 D
+-7 10 D
+6 6 D
+-22 17 D
+19 -7 D
+1 14 D
+9 -8 D
+13 4 D
+-6 9 D
+24 -2 D
+8 9 D
+-9 12 D
+9 8 D
+9 -17 D
+10 27 D
+-11 6 D
+20 6 D
+-14 4 D
+43 14 D
+-2 17 D
+6 5 D
+-10 0 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-10 0 D
+-10 -2 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-10 -2 D
+-10 -1 D
+-10 -2 D
+-10 -2 D
+-10 -1 D
+-10 -2 D
+-10 -2 D
+-10 -2 D
+-10 -2 D
+-10 -3 D
+-10 -2 D
+-10 -2 D
+-10 -3 D
+-10 -2 D
+-10 -3 D
+-10 -3 D
+P
+3478 6275 M
+-5 -15 D
+-13 0 D
+10 5 D
+-4 10 D
+5 -7 D
+P
+FO
+3304 6282 M
+1 1 D
+-1 7 D
+-2 -1 D
+P
+FO
+3420 5923 M
+0 1 D
+3 -11 D
+0 9 D
+3 -11 D
+5 7 D
+-8 9 D
+14 -3 D
+-2 22 D
+10 7 D
+-14 -2 D
+15 6 D
+-6 13 D
+8 -10 D
+5 7 D
+-6 2 D
+9 4 D
+-12 5 D
+14 11 D
+-13 2 D
+19 8 D
+-6 3 D
+6 18 D
+-11 -6 D
+14 9 D
+-6 5 D
+6 -1 D
+3 20 D
+-10 -5 D
+16 15 D
+-9 -4 D
+7 8 D
+-6 5 D
+6 5 D
+5 -7 D
+12 28 D
+-11 0 D
+-8 -16 D
+1 18 D
+13 5 D
+3 -7 D
+12 8 D
+-4 14 D
+10 -3 D
+-8 7 D
+19 -5 D
+-15 5 D
+22 5 D
+-12 12 D
+7 -6 D
+1 7 D
+7 -3 D
+-5 4 D
+15 -2 D
+-1 7 D
+-21 -1 D
+21 2 D
+1 8 D
+-10 2 D
+10 2 D
+-8 1 D
+5 7 D
+-16 -4 D
+-3 -6 D
+-8 6 D
+-2 -9 D
+-2 6 D
+6 11 D
+7 -8 D
+20 6 D
+-7 3 D
+7 3 D
+-4 6 D
+-6 -5 D
+7 10 D
+-4 6 D
+-4 -7 D
+2 13 D
+-19 -18 D
+22 28 D
+-6 6 D
+-12 -9 D
+9 13 D
+-11 0 D
+5 6 D
+10 -4 D
+-3 12 D
+-20 13 D
+-15 -5 D
+-14 -29 D
+-13 0 D
+0 -22 D
+-13 39 D
+-6 -3 D
+-1 13 D
+-2 -11 D
+-1 16 D
+-22 26 D
+6 8 D
+-10 23 D
+-20 -4 D
+-3 -21 D
+-17 -2 D
+-4 -38 D
+11 -25 D
+-7 -2 D
+11 -1 D
+-16 -8 D
+0 -11 D
+-6 9 D
+-7 -15 D
+10 -2 D
+-11 -11 D
+20 -18 D
+11 1 D
+10 -60 D
+-7 4 D
+-15 -25 D
+38 -116 D
+P
+3415 6192 M
+0 16 D
+18 13 D
+1 -16 D
+-11 0 D
+4 -12 D
+P
+3391 6181 M
+-23 -3 D
+4 -9 D
+-8 10 D
+P
+3401 6202 M
+4 29 D
+P
+FO
+3600 6355 M
+P
+FO
+3600 6362 M
+0 -1 D
+P
+FO
+3600 6432 M
+-23 -9 D
+0 -7 D
+19 -1 D
+-11 -4 D
+-13 -23 D
+8 -11 D
+20 1 D
+P
+FO
+3423 6308 M
+-8 -17 D
+8 -13 D
+1 13 D
+6 -8 D
+12 9 D
+-21 27 D
+P
+FO
+3454 6299 M
+-2 10 D
+-11 0 D
+4 -14 D
+P
+FO
+3457 5962 M
+-11 -18 D
+6 9 D
+4 -9 D
+P
+FO
+3438 5925 M
+6 -2 D
+2 15 D
+P
+FO
+3364 6242 M
+1 22 D
+-3 -32 D
+P
+FO
+3345 6237 M
+-5 -26 D
+10 13 D
+P
+FO
+3179 5935 M
+18 6 D
+1 8 D
+0 -8 D
+19 3 D
+-3 11 D
+-21 0 D
+-2 15 D
+37 1 D
+17 -17 D
+1 -14 D
+23 2 D
+-5 -8 D
+27 -7 D
+-79 -19 D
+-2 -14 D
+25 -32 D
+4 -1 D
+52 1 D
+15 8 D
+-2 12 D
+4 -14 D
+10 6 D
+5 -7 D
+-8 -5 D
+11 0 D
+2 13 D
+11 -3 D
+4 8 D
+9 -5 D
+44 20 D
+0 1 D
+1 -1 D
+13 5 D
+-5 6 D
+10 -4 D
+5 21 D
+-26 74 D
+-22 70 D
+-6 -10 D
+-4 -19 D
+12 -21 D
+-7 2 D
+5 -14 D
+-8 3 D
+1 -10 D
+-21 -6 D
+-17 16 D
+26 72 D
+-19 30 D
+-3 24 D
+-17 5 D
+-6 -7 D
+-2 15 D
+-61 -52 D
+-4 10 D
+-25 -1 D
+25 17 D
+-2 11 D
+30 5 D
+24 22 D
+-11 20 D
+-12 -3 D
+-8 28 D
+8 10 D
+21 -15 D
+11 9 D
+1 30 D
+-17 38 D
+11 3 D
+-2 -22 D
+2 19 D
+7 6 D
+-2 7 D
+-6 -2 D
+5 6 D
+-33 114 D
+-10 -2 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-9 -4 D
+-10 -4 D
+-10 -4 D
+-10 -4 D
+-10 -5 D
+-9 -4 D
+-10 -4 D
+-10 -5 D
+-19 -9 D
+-19 -10 D
+-20 -10 D
+-19 -10 D
+-19 -11 D
+-19 -12 D
+-18 -11 D
+36 -56 D
+48 -71 D
+30 -42 D
+7 -11 D
+34 -47 D
+23 -31 D
+7 -11 D
+P
+3259 6090 M
+13 -10 D
+-12 1 D
+-5 -13 D
+26 -7 D
+-1 -13 D
+17 -12 D
+-36 18 D
+15 -4 D
+-5 13 D
+-17 -5 D
+6 -11 D
+-9 0 D
+-5 16 D
+10 19 D
+-8 0 D
+P
+3302 6052 M
+-8 17 D
+2 -13 D
+-8 3 D
+7 -6 D
+-10 0 D
+9 28 D
+-6 17 D
+-8 -7 D
+-2 13 D
+16 -8 D
+0 -25 D
+6 -14 D
+8 0 D
+P
+3206 6009 M
+-19 2 D
+-25 24 D
+2 12 D
+14 3 D
+-8 -8 D
+25 -7 D
+13 -14 D
+-15 7 D
+11 -11 D
+-14 8 D
+-3 -8 D
+P
+3110 6074 M
+-18 2 D
+0 16 D
+26 -5 D
+-14 -4 D
+16 -10 D
+-10 -8 D
+6 8 D
+P
+3222 5988 M
+-17 3 D
+8 3 D
+-9 14 D
+P
+3306 6079 M
+-3 8 D
+11 8 D
+-5 13 D
+9 -24 D
+P
+3303 6020 M
+6 -7 D
+-20 4 D
+P
+3354 5908 M
+-8 -20 D
+-3 16 D
+P
+3231 6058 M
+-37 13 D
+9 28 D
+35 -22 D
+P
+3231 6159 M
+-12 9 D
+26 -17 D
+-8 -7 D
+P
+3254 6035 M
+20 -10 D
+-21 10 D
+P
+3133 6044 M
+-5 5 D
+10 4 D
+P
+3274 5956 M
+-14 8 D
+P
+FO
+3196 5913 M
+0 5 D
+-9 6 D
+2 -3 D
+3 -2 D
+P
+FO
+3421 5920 M
+2 -14 D
+-1 9 D
+P
+FO
+3304 6169 M
+5 4 D
+-8 4 D
+-6 -7 D
+P
+FO
+3301 6198 M
+-13 -20 D
+20 7 D
+P
+FO
+2864 6205 M
+3 -12 D
+17 -21 D
+-7 -26 D
+5 22 D
+-9 17 D
+-18 6 D
+9 11 D
+-1 3 D
+-50 -42 D
+-33 -30 D
+-24 -23 D
+-38 -41 D
+-51 -62 D
+65 -48 D
+23 -17 D
+12 -8 D
+11 -9 D
+92 -64 D
+29 -19 D
+67 -45 D
+150 -95 D
+-7 8 D
+19 -4 D
+-1 21 D
+11 16 D
+-5 11 D
+11 12 D
+10 -14 D
+-2 -10 D
+4 6 D
+-4 23 D
+6 -4 D
+11 39 D
+-9 2 D
+8 10 D
+-11 15 D
+10 13 D
+20 -4 D
+-6 -20 D
+7 -5 D
+33 11 D
+-14 2 D
+-40 47 D
+25 2 D
+4 21 D
+0 13 D
+-4 6 D
+-3 2 D
+-2 3 D
+-13 9 D
+5 2 D
+-50 66 D
+-7 11 D
+-45 62 D
+-12 16 D
+-7 11 D
+-45 64 D
+-18 28 D
+-33 49 D
+-14 23 D
+-26 -17 D
+-25 -18 D
+P
+2906 6063 M
+-1 12 D
+-12 4 D
+-8 -15 D
+-2 21 D
+-14 -7 D
+10 17 D
+-2 -8 D
+27 -7 D
+7 -30 D
+9 -5 D
+-7 3 D
+5 -8 D
+-10 -1 D
+-12 -21 D
+4 -8 D
+-5 5 D
+-4 -8 D
+18 49 D
+P
+2926 5891 M
+14 -13 D
+-28 15 D
+0 11 D
+-10 3 D
+-9 -8 D
+4 7 D
+-13 5 D
+25 -5 D
+9 7 D
+-3 -14 D
+10 4 D
+P
+3058 5779 M
+26 -7 D
+-6 32 D
+16 19 D
+44 -38 D
+0 -26 D
+0 26 D
+-44 37 D
+-15 -19 D
+5 -32 D
+P
+3086 5950 M
+49 2 D
+17 -9 D
+5 -14 D
+17 3 D
+-17 -4 D
+-5 14 D
+-17 9 D
+-49 -2 D
+P
+3010 6079 M
+-26 0 D
+-17 -26 D
+-20 -9 D
+-27 1 D
+27 0 D
+20 9 D
+17 26 D
+P
+2892 5961 M
+-2 -28 D
+14 -6 D
+-18 8 D
+P
+3031 6065 M
+-6 -12 D
+-12 30 D
+P
+FO
+3152 5694 M
+-13 -6 D
+7 -4 D
+P
+FO
+3210 5894 M
+-1 -22 D
+26 -10 D
+P
+FO
+3182 5788 M
+-1 -16 D
+15 0 D
+-2 15 D
+P
+FO
+2776 5569 M
+10 9 D
+30 9 D
+29 38 D
+30 79 D
+-15 -4 D
+-22 9 D
+-5 18 D
+-30 26 D
+31 -25 D
+4 -19 D
+23 -8 D
+89 30 D
+19 -20 D
+32 -9 D
+24 -18 D
+9 -15 D
+-7 -26 D
+-5 13 D
+11 14 D
+-8 13 D
+-24 19 D
+-36 9 D
+-16 20 D
+-63 -22 D
+-32 -76 D
+-33 -45 D
+-34 -11 D
+-7 -9 D
+273 -53 D
+26 -5 D
+10 44 D
+3 10 D
+-21 10 D
+-4 -22 D
+-14 -13 D
+-18 -2 D
+-12 11 D
+-11 -12 D
+12 15 D
+34 -3 D
+0 20 D
+-29 8 D
+-31 40 D
+23 27 D
+-3 -30 D
+34 -32 D
+17 6 D
+27 -11 D
+16 43 D
+4 9 D
+-11 5 D
+-6 -11 D
+-19 -4 D
+-17 18 D
+37 13 D
+-4 -5 D
+43 35 D
+-4 9 D
+-23 3 D
+4 11 D
+-139 88 D
+-96 64 D
+-109 75 D
+-11 9 D
+-18 12 D
+-11 9 D
+-65 48 D
+-49 -71 D
+-34 -59 D
+-18 -34 D
+-26 -58 D
+-29 -79 D
+-19 -68 D
+-1 -7 D
+203 -45 D
+P
+2659 5644 M
+-4 -14 D
+-8 11 D
+7 15 D
+P
+2582 5851 M
+0 -22 D
+-1 14 D
+-6 -1 D
+P
+FO
+3139 5688 M
+3 -7 D
+3 1 D
+1 2 D
+P
+FO
+2468 5360 M
+14 8 D
+9 -14 D
+-12 -11 D
+-11 16 D
+7 -74 D
+13 -72 D
+3 -12 D
+143 32 D
+192 40 D
+227 44 D
+26 5 D
+-7 44 D
+-2 49 D
+1 39 D
+3 22 D
+-8 1 D
+8 6 D
+5 27 D
+-244 47 D
+-55 11 D
+-11 -17 D
+-48 -35 D
+-20 -8 D
+-25 11 D
+25 -10 D
+34 20 D
+41 40 D
+-182 39 D
+-103 23 D
+-12 -60 D
+-9 -74 D
+-4 -75 D
+P
+2902 5446 M
+-19 6 D
+-30 -23 D
+31 23 D
+66 -12 D
+19 5 D
+7 14 D
+80 -5 D
+10 19 D
+1 -13 D
+-11 -7 D
+-80 4 D
+-7 -13 D
+-15 -4 D
+3 -13 D
+-9 -11 D
+-24 -5 D
+-12 -21 D
+11 21 D
+24 5 D
+9 14 D
+-4 9 D
+P
+2622 5399 M
+24 -26 D
+-6 -4 D
+-12 22 D
+-18 -7 D
+-20 3 D
+P
+3020 5415 M
+5 9 D
+2 -33 D
+P
+2611 5581 M
+20 -42 D
+P
+FO
+2917 5002 M
+-28 13 D
+8 28 D
+-6 27 D
+-55 15 D
+55 -15 D
+6 -27 D
+-6 -29 D
+26 -12 D
+80 52 D
+-10 9 D
+10 -9 D
+59 38 D
+90 56 D
+-27 50 D
+-18 42 D
+-15 49 D
+-7 33 D
+-7 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -2 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -2 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-6 -2 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+13 -51 D
+13 -43 D
+28 -72 D
+30 -63 D
+27 -49 D
+40 -63 D
+25 -35 D
+18 13 D
+11 9 D
+35 25 D
+11 9 D
+119 83 D
+45 31 D
+P
+2695 5206 M
+4 -13 D
+-15 -8 D
+-46 -18 D
+7 7 D
+-6 -1 D
+-14 -15 D
+-19 2 D
+18 6 D
+0 10 D
+2 -8 D
+67 25 D
+-5 17 D
+-30 -10 D
+10 9 D
+6 -3 D
+10 17 D
+10 -17 D
+P
+2721 5084 M
+2 -9 D
+-46 -12 D
+-26 10 D
+-1 -10 D
+-49 35 D
+-21 1 D
+-16 19 D
+0 22 D
+17 -26 D
+33 -16 D
+47 -15 D
+P
+2541 5204 M
+-12 -10 D
+-23 6 D
+35 3 D
+P
+FO
+2898 4601 M
+12 10 D
+66 0 D
+14 21 D
+-1 9 D
+5 -2 D
+18 26 D
+-1 6 D
+-15 10 D
+-6 -6 D
+-24 1 D
+19 14 D
+-23 -3 D
+16 19 D
+-15 9 D
+-1 13 D
+64 5 D
+40 10 D
+53 73 D
+38 51 D
+38 51 D
+73 94 D
+-17 13 D
+-20 18 D
+-3 4 D
+-12 11 D
+-35 40 D
+-7 9 D
+-61 -19 D
+-47 -50 D
+-4 -63 D
+35 -50 D
+-6 -7 D
+14 -28 D
+-46 -44 D
+-5 7 D
+5 -4 D
+45 41 D
+-14 28 D
+6 6 D
+-30 35 D
+-19 -28 D
+-33 -6 D
+-56 35 D
+-22 34 D
+-9 3 D
+-5 -11 D
+-1 15 D
+-4 1 D
+-17 -11 D
+-16 -11 D
+-17 -12 D
+-17 -11 D
+-17 -12 D
+-17 -12 D
+-17 -12 D
+-17 -12 D
+-17 -12 D
+-17 -12 D
+-12 -8 D
+-11 -9 D
+-23 -17 D
+-12 -8 D
+-11 -9 D
+-12 -9 D
+30 -37 D
+47 -53 D
+32 -33 D
+60 -53 D
+P
+FO
+2971 4603 M
+-17 5 D
+-37 1 D
+-5 -11 D
+-3 6 D
+-9 -4 D
+34 -24 D
+14 -9 D
+17 27 D
+P
+FO
+2994 4638 M
+-4 1 D
+0 -7 D
+P
+FO
+2997 5054 M
+37 -29 D
+7 -19 D
+16 -2 D
+5 31 D
+44 52 D
+68 21 D
+-15 20 D
+-13 20 D
+-11 -6 D
+-15 -10 D
+-11 -7 D
+-11 -6 D
+-16 -10 D
+-16 -10 D
+-16 -10 D
+-16 -11 D
+-16 -10 D
+-11 -7 D
+P
+FO
+2917 5002 M
+20 -8 D
+22 -33 D
+71 -31 D
+31 24 D
+-1 49 D
+-20 2 D
+-6 20 D
+-37 29 D
+-11 -7 D
+-16 -10 D
+-15 -10 D
+-16 -11 D
+-11 -7 D
+P
+FO
+2997 4700 M
+1 11 D
+-13 -6 D
+P
+FO
+2954 4563 M
+11 17 D
+38 24 D
+2 32 D
+6 -9 D
+8 5 D
+-7 33 D
+-18 -26 D
+11 -5 D
+-11 4 D
+-4 -6 D
+1 -14 D
+-17 -12 D
+10 6 D
+-7 -7 D
+7 -7 D
+-13 5 D
+-23 -36 D
+P
+FO
+3010 4530 M
+9 44 D
+34 73 D
+-8 1 D
+-1 -18 D
+-19 1 D
+-18 -24 D
+-8 -34 D
+-17 -27 D
+P
+FO
+3297 4524 M
+1 6 D
+1 0 D
+22 74 D
+15 51 D
+-31 -21 D
+-21 2 D
+-22 -24 D
+-19 -35 D
+-22 -114 D
+41 27 D
+4 18 D
+25 -5 D
+P
+FO
+3355 4715 M
+-4 -6 D
+-3 -8 D
+3 0 D
+P
+FO
+3066 4743 M
+55 17 D
+41 -19 D
+0 -9 D
+10 4 D
+26 -21 D
+13 10 D
+29 -30 D
+-16 4 D
+0 -8 D
+52 -13 D
+0 9 D
+-11 4 D
+6 9 D
+45 29 D
+43 -4 D
+49 150 D
+17 51 D
+-30 11 D
+-45 21 D
+-47 28 D
+-18 12 D
+-17 14 D
+-85 -109 D
+-34 -46 D
+-68 -93 D
+P
+FO
+2976 4611 M
+4 0 D
+11 9 D
+-1 12 D
+P
+FO
+3206 4454 M
+4 10 D
+-19 -14 D
+P
+FO
+3600 4871 M
+-35 24 D
+-26 -1 D
+-18 9 D
+-5 1 D
+-5 -10 D
+7 -16 D
+-7 -6 D
+-18 15 D
+-2 15 D
+-10 -6 D
+-38 15 D
+-15 -9 D
+-2 24 D
+-1 0 D
+-50 -149 D
+-16 -52 D
+5 0 D
+-9 -10 D
+-4 -14 D
+6 0 D
+-6 -10 D
+34 19 D
+11 -3 D
+5 22 D
+17 0 D
+7 -7 D
+-15 -2 D
+-13 -35 D
+-26 -4 D
+-35 -26 D
+-37 -125 D
+35 6 D
+9 35 D
+18 -3 D
+-2 32 D
+12 8 D
+-18 11 D
+36 45 D
+12 0 D
+2 -9 D
+23 13 D
+-4 -16 D
+13 13 D
+29 0 D
+10 -20 D
+5 13 D
+42 29 D
+45 18 D
+24 -8 D
+6 12 D
+-16 44 D
+0 -7 D
+-8 15 D
+-16 -7 D
+2 7 D
+-12 1 D
+49 0 D
+5 8 D
+P
+FO
+3291 4503 M
+6 21 D
+P
+FO
+3501 4895 M
+5 7 D
+-11 5 D
+P
+FO
+3398 4528 M
+-8 10 D
+11 -18 D
+P
+FO
+3377 4625 M
+21 11 D
+-14 3 D
+P
+FO
+3884 4588 M
+-3 -5 D
+5 -13 D
+-23 -3 D
+-16 -34 D
+5 7 D
+6 0 D
+-3 9 D
+11 -3 D
+2 15 D
+7 -6 D
+14 16 D
+P
+FO
+3835 4744 M
+5 -18 D
+-19 -17 D
+-10 9 D
+-17 -1 D
+-11 15 D
+10 -14 D
+22 1 D
+6 -9 D
+17 23 D
+-5 11 D
+-1 11 D
+-48 143 D
+-9 28 D
+-4 -1 D
+-4 -2 D
+-4 -1 D
+-4 -1 D
+-5 -1 D
+-6 -30 D
+-20 -8 D
+-3 -15 D
+30 -12 D
+8 -11 D
+21 3 D
+5 -12 D
+13 3 D
+-13 -5 D
+-13 10 D
+20 -17 D
+-27 -9 D
+-10 11 D
+-33 -31 D
+24 -6 D
+-9 -5 D
+12 -13 D
+34 4 D
+-1 6 D
+5 -7 D
+8 16 D
+11 0 D
+-6 -10 D
+14 -11 D
+-2 -10 D
+-14 -3 D
+-7 -17 D
+-14 2 D
+-10 -48 D
+9 -9 D
+9 4 D
+-3 -7 D
+23 0 D
+-13 -7 D
+9 -17 D
+23 14 D
+16 -24 D
+-5 -14 D
+20 18 D
+6 -3 D
+P
+FO
+3600 4770 M
+8 11 D
+-2 21 D
+10 1 D
+1 -23 D
+21 2 D
+12 -19 D
+21 -10 D
+3 8 D
+3 -9 D
+10 5 D
+-12 8 D
+11 9 D
+-1 11 D
+-11 5 D
+22 -4 D
+-5 9 D
+10 -4 D
+7 15 D
+-24 17 D
+-20 3 D
+-10 -3 D
+9 -23 D
+-16 38 D
+-47 33 D
+P
+FO
+3800 4488 M
+8 15 D
+-11 -3 D
+5 -8 D
+-14 -11 D
+P
+FO
+3723 4725 M
+8 10 D
+-37 7 D
+2 -11 D
+P
+FO
+3839 4526 M
+12 5 D
+-12 7 D
+-14 -17 D
+P
+FO
+3785 4658 M
+-9 10 D
+-15 -9 D
+18 -9 D
+P
+FO
+3799 4680 M
+-7 3 D
+-7 -10 D
+6 -3 D
+P
+FO
+3772 4467 M
+16 20 D
+P
+FO
+3680 4435 M
+15 9 D
+-16 -9 D
+P
+FO
+3940 5001 M
+-27 -4 D
+-13 -9 D
+-14 -9 D
+-9 -6 D
+-9 -5 D
+-10 -5 D
+-9 -5 D
+-10 -5 D
+-10 -5 D
+-9 -4 D
+-10 -5 D
+-5 -2 D
+-5 -2 D
+-5 -2 D
+-5 -2 D
+-5 -1 D
+-5 -2 D
+-5 -2 D
+58 -176 D
+6 56 D
+-5 -56 D
+31 -100 D
+19 -8 D
+-2 20 D
+9 -12 D
+14 17 D
+-4 -19 D
+10 -22 D
+-27 -38 D
+5 -17 D
+2 3 D
+6 -7 D
+35 75 D
+15 16 D
+5 23 D
+-13 -1 D
+-3 9 D
+20 67 D
+15 12 D
+-6 -14 D
+17 -2 D
+-20 -3 D
+-8 -13 D
+6 -26 D
+11 6 D
+-3 -20 D
+19 24 D
+-4 7 D
+6 -4 D
+-4 10 D
+14 2 D
+-1 15 D
+-13 3 D
+5 18 D
+4 -12 D
+0 10 D
+5 -5 D
+9 13 D
+-2 -8 D
+9 2 D
+-5 -7 D
+5 7 D
+6 -8 D
+12 8 D
+14 -6 D
+30 24 D
+19 -1 D
+2 5 D
+-69 93 D
+-58 76 D
+P
+3934 4700 M
+-20 -21 D
+P
+3917 4644 M
+10 -9 D
+P
+FO
+3960 4630 M
+4 6 D
+0 -11 D
+12 21 D
+-6 4 D
+9 1 D
+-4 10 D
+-14 -2 D
+1 -10 D
+-7 4 D
+9 -13 D
+-15 2 D
+-1 -8 D
+P
+FO
+3966 4662 M
+8 13 D
+-12 -3 D
+P
+FO
+4468 4748 M
+-12 2 D
+-50 -32 D
+13 -2 D
+5 12 D
+3 -17 D
+11 12 D
+5 -1 D
+P
+FO
+4482 4764 M
+-1 5 D
+5 -1 D
+47 57 D
+-65 48 D
+-23 17 D
+-12 8 D
+-11 9 D
+-86 60 D
+-29 19 D
+-84 56 D
+-56 36 D
+0 -17 D
+-13 19 D
+5 -26 D
+-15 -10 D
+-5 23 D
+-9 -3 D
+8 16 D
+-15 -14 D
+-5 -22 D
+-10 5 D
+15 56 D
+-47 30 D
+-9 5 D
+-18 -9 D
+-3 -27 D
+-15 10 D
+-2 -2 D
+11 -17 D
+-22 1 D
+-7 -8 D
+-4 -32 D
+-8 18 D
+-4 -4 D
+-3 -28 D
+-6 -10 D
+-10 7 D
+-2 -20 D
+16 -6 D
+-50 -12 D
+51 -64 D
+46 -61 D
+61 -83 D
+1 9 D
+12 0 D
+-1 -9 D
+-9 8 D
+3 -13 D
+58 -2 D
+5 10 D
+-24 6 D
+15 0 D
+-5 7 D
+15 -12 D
+12 5 D
+-25 24 D
+25 -18 D
+11 2 D
+-1 11 D
+5 -13 D
+14 5 D
+-4 -7 D
+13 2 D
+-13 -3 D
+14 -2 D
+-3 -9 D
+42 2 D
+5 -21 D
+3 23 D
+11 -3 D
+17 -22 D
+-2 20 D
+-10 15 D
+15 -21 D
+8 4 D
+-3 -16 D
+12 -2 D
+-12 2 D
+5 -7 D
+14 8 D
+-1 -12 D
+22 -2 D
+-6 20 D
+9 -10 D
+9 7 D
+-12 -10 D
+31 -2 D
+2 -17 D
+0 10 D
+9 -5 D
+1 21 D
+7 -29 D
+10 -4 D
+1 10 D
+1 -15 D
+9 10 D
+-6 -13 D
+14 16 D
+-7 -16 D
+19 17 D
+-3 -8 D
+8 2 D
+2 16 D
+-2 -18 D
+12 4 D
+-3 9 D
+4 -7 D
+7 6 D
+-7 15 D
+10 -16 D
+5 14 D
+5 -17 D
+1 0 D
+P
+4151 5020 M
+-13 2 D
+-42 -17 D
+-13 12 D
+-36 2 D
+-12 -17 D
+-20 -2 D
+-19 21 D
+26 -19 D
+28 21 D
+32 -4 D
+13 -12 D
+44 17 D
+P
+4322 4883 M
+23 -2 D
+18 23 D
+-15 -21 D
+26 -7 D
+P
+FO
+4135 5098 M
+1 -6 D
+3 4 D
+P
+FO
+4317 4719 M
+0 9 D
+-11 -5 D
+-10 28 D
+2 -22 D
+-5 13 D
+-15 -7 D
+27 -18 D
+38 -2 D
+P
+FO
+4271 4760 M
+11 -2 D
+-11 12 D
+-11 -6 D
+5 9 D
+-34 3 D
+17 -13 D
+5 5 D
+3 -11 D
+P
+FO
+4193 4788 M
+-18 1 D
+13 3 D
+-3 7 D
+-19 -9 D
+20 -14 D
+-6 9 D
+P
+FO
+4265 4787 M
+5 -11 D
+5 3 D
+-4 6 D
+6 -8 D
+4 7 D
+P
+FO
+4359 4751 M
+0 6 D
+12 -5 D
+-25 12 D
+P
+FO
+4207 4795 M
+-15 14 D
+-14 -2 D
+29 -27 D
+P
+FO
+4215 4786 M
+14 -8 D
+6 5 D
+-8 11 D
+P
+FO
+4221 4779 M
+-8 3 D
+19 -19 D
+P
+FO
+4207 4771 M
+15 -10 D
+-34 23 D
+P
+FO
+4328 4759 M
+15 -3 D
+-23 6 D
+P
+FO
+4626 5220 M
+-7 0 D
+-6 -18 D
+-9 2 D
+3 11 D
+6 8 D
+-6 1 D
+-12 -16 D
+-1 13 D
+-20 8 D
+14 -3 D
+-1 2 D
+-180 38 D
+-2 -1 D
+-13 4 D
+-52 11 D
+-4 -6 D
+-12 6 D
+11 1 D
+-63 12 D
+-4 -9 D
+1 10 D
+-31 6 D
+-9 -19 D
+2 20 D
+-46 9 D
+-5 -23 D
+-16 -9 D
+-5 -16 D
+-24 -5 D
+9 -31 D
+7 11 D
+-5 21 D
+14 -29 D
+20 4 D
+8 -3 D
+-6 -6 D
+19 0 D
+-24 -7 D
+-4 8 D
+-27 -14 D
+2 -21 D
+-18 -29 D
+-10 4 D
+1 14 D
+-17 -4 D
+-9 -18 D
+-28 -17 D
+56 -35 D
+1 2 D
+9 6 D
+2 -15 D
+4 -2 D
+9 13 D
+-3 14 D
+22 -15 D
+-13 -18 D
+12 -5 D
+1 -7 D
+118 -77 D
+45 -31 D
+29 -19 D
+69 -48 D
+11 -9 D
+18 -12 D
+11 -9 D
+65 -48 D
+49 71 D
+34 59 D
+18 34 D
+26 58 D
+29 79 D
+19 68 D
+1 7 D
+P
+4304 5072 M
+-29 -26 D
+15 18 D
+-12 13 D
+3 13 D
+-31 -4 D
+36 21 D
+-10 43 D
+12 21 D
+-8 -33 D
+6 -6 D
+-2 19 D
+4 9 D
+-2 -15 D
+4 11 D
+-2 -16 D
+21 -50 D
+P
+4498 5190 M
+-16 8 D
+12 -4 D
+-7 12 D
+-21 -1 D
+-16 24 D
+34 -12 D
+P
+4453 5108 M
+16 6 D
+21 -19 D
+-19 -3 D
+11 6 D
+-7 10 D
+P
+4385 5093 M
+-14 35 D
+28 46 D
+-14 -48 D
+9 -30 D
+P
+4172 5167 M
+13 -7 D
+-9 -4 D
+8 5 D
+-13 0 D
+P
+4434 5213 M
+21 -10 D
+-2 -10 D
+-18 9 D
+P
+4377 5209 M
+-20 4 D
+9 -1 D
+-2 10 D
+14 -13 D
+P
+4303 5191 M
+-2 10 D
+3 -7 D
+15 8 D
+P
+4308 5258 M
+-10 21 D
+23 -11 D
+P
+4266 5204 M
+-14 -29 D
+-5 17 D
+P
+4233 5076 M
+-16 -9 D
+0 8 D
+16 2 D
+P
+4442 5155 M
+10 0 D
+0 -17 D
+P
+4397 5237 M
+-10 -7 D
+-12 8 D
+P
+4390 5077 M
+-14 6 D
+P
+4195 5177 M
+29 12 D
+7 -7 D
+P
+4521 5159 M
+7 -14 D
+-7 15 D
+P
+4249 5145 M
+-1 29 D
+P
+4450 4996 M
+-20 -17 D
+P
+FO
+4589 5228 M
+4 -6 D
+6 4 D
+P
+FO
+4067 5170 M
+18 -1 D
+22 21 D
+15 -3 D
+10 41 D
+-13 30 D
+20 9 D
+6 33 D
+-15 -2 D
+9 -11 D
+-17 1 D
+7 7 D
+-9 13 D
+9 3 D
+-9 2 D
+-16 -58 D
+-27 -66 D
+P
+FO
+4733 5443 M
+-10 8 D
+10 7 D
+-5 63 D
+-11 74 D
+-8 36 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-7 -1 D
+0 -14 D
+-14 -2 D
+-33 -42 D
+-70 -11 D
+5 -52 D
+-61 -99 D
+11 -35 D
+-13 8 D
+-43 -10 D
+-3 -16 D
+12 -2 D
+-21 -9 D
+-43 7 D
+-34 25 D
+-7 -5 D
+-17 25 D
+-8 -7 D
+2 13 D
+-10 11 D
+-16 -14 D
+4 -10 D
+-6 3 D
+-6 -21 D
+-9 2 D
+24 40 D
+-20 8 D
+0 24 D
+-30 13 D
+-21 -48 D
+-2 13 D
+18 30 D
+-24 15 D
+-10 -11 D
+8 35 D
+-20 -18 D
+-2 14 D
+15 8 D
+-34 19 D
+-25 -19 D
+-8 14 D
+-5 -10 D
+-10 6 D
+-6 -20 D
+-6 6 D
+-1 -29 D
+31 11 D
+0 -9 D
+40 -6 D
+7 -11 D
+-50 -9 D
+-9 -11 D
+29 -10 D
+-32 -11 D
+-3 11 D
+-7 -25 D
+-9 4 D
+-1 -24 D
+-1 -10 D
+3 -1 D
+16 26 D
+1 -9 D
+16 -5 D
+-7 9 D
+12 3 D
+13 -22 D
+25 -1 D
+-10 -11 D
+-22 8 D
+7 -9 D
+-8 4 D
+-7 -8 D
+1 -15 D
+14 4 D
+1 9 D
+12 -2 D
+-19 -11 D
+11 -5 D
+-1 -12 D
+46 -9 D
+1 16 D
+1 0 D
+6 -16 D
+-1 -1 D
+31 -6 D
+3 36 D
+8 -20 D
+-8 -17 D
+63 -12 D
+7 1 D
+-2 -2 D
+58 -12 D
+-13 5 D
+-5 18 D
+14 -15 D
+7 5 D
+-5 -8 D
+19 0 D
+-8 -7 D
+180 -38 D
+-3 9 D
+5 -9 D
+10 -2 D
+15 8 D
+-7 -10 D
+6 -1 D
+5 5 D
+41 -11 D
+-33 3 D
+83 -19 D
+9 43 D
+12 83 D
+4 83 D
+P
+4618 5252 M
+-12 -13 D
+-16 10 D
+9 18 D
+-23 1 D
+11 4 D
+97 14 D
+26 -12 D
+-40 4 D
+4 -11 D
+-24 -1 D
+4 -12 D
+-32 -12 D
+P
+4709 5384 M
+16 -4 D
+2 -16 D
+-16 -15 D
+11 18 D
+P
+4656 5231 M
+54 9 D
+-37 -7 D
+-10 -12 D
+-8 10 D
+P
+4599 5329 M
+8 10 D
+-1 -15 D
+-8 5 D
+P
+4493 5268 M
+-17 15 D
+17 -4 D
+6 -27 D
+P
+4330 5305 M
+-9 10 D
+16 3 D
+P
+4575 5349 M
+10 -22 D
+-13 7 D
+P
+4294 5363 M
+-7 -26 D
+P
+FO
+4524 5590 M
+P
+FO
+4351 5554 M
+1 0 D
+0 1 D
+P
+FO
+4121 5509 M
+0 1 D
+P
+FO
+4124 5492 M
+6 11 D
+-6 -7 D
+P
+FO
+4128 5458 M
+0 36 D
+-3 -4 D
+P
+FO
+4305 5532 M
+-11 9 D
+-8 -11 D
+6 -13 D
+-17 0 D
+-22 -36 D
+8 -4 D
+-19 -10 D
+53 -3 D
+15 -11 D
+-5 18 D
+17 8 D
+-34 25 D
+14 8 D
+P
+FO
+4152 5326 M
+17 23 D
+-10 15 D
+-32 -23 D
+P
+FO
+4326 5509 M
+13 -11 D
+9 4 D
+-26 21 D
+P
+FO
+4245 5486 M
+0 10 D
+-10 -16 D
+P
+FO
+4621 5571 M
+5 27 D
+-14 -11 D
+P
+FO
+4185 5449 M
+7 3 D
+-16 -1 D
+P
+FO
+4608 5892 M
+-10 1 D
+-72 109 D
+-22 -17 D
+-21 -16 D
+-16 -11 D
+-22 -16 D
+16 -6 D
+-16 6 D
+-16 -11 D
+-20 -15 D
+-5 -4 D
+13 -5 D
+-23 -8 D
+9 -1 D
+-7 -3 D
+7 -19 D
+-11 2 D
+6 -10 D
+-5 5 D
+1 -12 D
+-7 7 D
+3 -15 D
+-5 14 D
+-14 -4 D
+0 -22 D
+-9 7 D
+-1 -16 D
+-8 0 D
+13 -9 D
+-19 3 D
+13 -11 D
+-17 3 D
+-6 -9 D
+8 -11 D
+-10 6 D
+-11 -29 D
+-8 2 D
+0 -8 D
+21 -1 D
+5 12 D
+8 -8 D
+3 9 D
+11 -7 D
+14 9 D
+-12 -14 D
+31 -7 D
+-13 -12 D
+20 -2 D
+-23 -5 D
+12 -27 D
+-10 3 D
+5 7 D
+-16 -2 D
+3 -7 D
+-18 -7 D
+5 -16 D
+-8 16 D
+-28 -10 D
+10 -2 D
+-1 -26 D
+-13 -4 D
+5 -9 D
+-19 -27 D
+14 -7 D
+-2 -42 D
+11 -8 D
+18 15 D
+24 -5 D
+-4 10 D
+22 10 D
+45 -11 D
+13 30 D
+46 21 D
+38 -10 D
+28 -32 D
+12 16 D
+57 27 D
+18 -9 D
+18 8 D
+-14 -12 D
+19 -5 D
+0 -5 D
+38 8 D
+-19 72 D
+-16 47 D
+-28 67 D
+-21 44 D
+P
+4457 5856 M
+12 21 D
+-4 12 D
+13 -13 D
+-1 -14 D
+15 -4 D
+5 10 D
+4 -7 D
+-13 -5 D
+-9 -29 D
+10 6 D
+-21 -15 D
+19 36 D
+-8 7 D
+-12 -16 D
+10 13 D
+-7 11 D
+P
+4486 5680 M
+8 9 D
+0 -14 D
+-8 4 D
+P
+4572 5840 M
+36 5 D
+-27 -27 D
+P
+4579 5835 M
+11 -7 D
+5 10 D
+P
+4622 5762 M
+50 -13 D
+-30 -5 D
+P
+4517 5707 M
+-15 21 D
+16 -21 D
+P
+FO
+4092 5609 M
+13 -5 D
+-12 4 D
+17 -49 D
+7 -30 D
+6 4 D
+-7 5 D
+9 0 D
+-3 9 D
+10 9 D
+17 -6 D
+-11 9 D
+10 15 D
+-6 5 D
+32 27 D
+16 -4 D
+-1 11 D
+3 -12 D
+19 -10 D
+16 17 D
+14 -24 D
+-2 -20 D
+31 -1 D
+-11 43 D
+-13 -6 D
+12 17 D
+-10 0 D
+19 15 D
+0 20 D
+9 -10 D
+6 9 D
+1 82 D
+-30 -57 D
+3 20 D
+-9 -8 D
+12 50 D
+-27 -21 D
+9 17 D
+-18 -11 D
+-2 -16 D
+-7 5 D
+-6 -12 D
+9 -4 D
+-9 -9 D
+8 3 D
+-21 -17 D
+11 -7 D
+-16 -9 D
+-5 14 D
+-12 -16 D
+-4 13 D
+8 13 D
+-9 2 D
+13 1 D
+-18 10 D
+21 -3 D
+11 31 D
+-26 -14 D
+4 14 D
+-12 -11 D
+-2 12 D
+-3 -14 D
+-7 13 D
+-4 -10 D
+-6 8 D
+-5 -12 D
+13 -2 D
+-7 -5 D
+9 -7 D
+-16 0 D
+14 -1 D
+-10 -2 D
+12 -8 D
+-10 4 D
+1 -10 D
+-3 9 D
+-9 -12 D
+8 -4 D
+-11 0 D
+12 -1 D
+-7 -9 D
+10 3 D
+-11 -5 D
+9 0 D
+-9 -4 D
+6 -2 D
+-9 -7 D
+6 -7 D
+-10 9 D
+2 -29 D
+-6 15 D
+-7 -8 D
+7 -6 D
+-10 6 D
+0 -10 D
+-4 23 D
+-5 -8 D
+8 -26 D
+-15 24 D
+-6 -4 D
+P
+4238 5651 M
+3 -17 D
+-20 -6 D
+P
+FO
+4121 5510 M
+1 12 D
+-3 -3 D
+P
+FO
+4352 5555 M
+-11 7 D
+-10 -6 D
+20 -2 D
+P
+FO
+4524 5590 M
+-8 12 D
+6 1 D
+-17 2 D
+11 -2 D
+-17 -5 D
+P
+FO
+4164 5570 M
+-3 -18 D
+28 4 D
+-7 16 D
+P
+FO
+4306 5572 M
+-9 3 D
+2 -12 D
+P
+FO
+4160 5583 M
+3 -10 D
+2 16 D
+P
+FO
+4291 5753 M
+-9 0 D
+5 -9 D
+P
+FO
+4147 5522 M
+-12 7 D
+P
+FO
+4489 6060 M
+-35 -10 D
+-2 -10 D
+-7 8 D
+-1 -11 D
+40 -4 D
+19 11 D
+P
+FO
+4485 6065 M
+-4 -2 D
+6 0 D
+P
+FO
+4001 5756 M
+21 8 D
+-7 9 D
+8 2 D
+0 -10 D
+10 15 D
+7 -15 D
+15 -3 D
+-21 17 D
+11 1 D
+-2 13 D
+14 -28 D
+-3 14 D
+5 -10 D
+15 5 D
+-24 8 D
+8 -2 D
+-14 15 D
+33 -21 D
+-15 21 D
+21 -17 D
+-5 19 D
+13 -7 D
+-5 11 D
+8 -10 D
+1 8 D
+9 -1 D
+-37 7 D
+-2 7 D
+39 -11 D
+-13 14 D
+17 -7 D
+2 13 D
+-18 3 D
+-3 9 D
+24 -12 D
+-5 5 D
+13 8 D
+-12 4 D
+14 -2 D
+9 10 D
+-22 2 D
+-7 -11 D
+7 27 D
+4 -15 D
+-2 9 D
+18 -9 D
+-12 16 D
+14 -12 D
+-4 8 D
+11 -1 D
+-9 10 D
+11 -3 D
+-8 11 D
+9 -8 D
+-7 12 D
+12 6 D
+-11 0 D
+17 5 D
+-5 14 D
+10 2 D
+-10 6 D
+11 -1 D
+-10 3 D
+9 2 D
+-4 7 D
+8 -4 D
+-9 9 D
+10 -5 D
+-9 12 D
+7 13 D
+-32 14 D
+19 1 D
+-13 2 D
+14 3 D
+-12 3 D
+7 8 D
+-12 -1 D
+17 7 D
+-15 -2 D
+12 9 D
+-13 -2 D
+-5 14 D
+3 -19 D
+-14 11 D
+2 -11 D
+-13 2 D
+9 -9 D
+-10 9 D
+2 -10 D
+-11 3 D
+5 -8 D
+-10 5 D
+5 -7 D
+-12 2 D
+0 -18 D
+-6 9 D
+4 -16 D
+-15 10 D
+-4 -12 D
+-4 10 D
+-1 -13 D
+-5 9 D
+1 -7 D
+-10 4 D
+3 -11 D
+-7 11 D
+-6 -10 D
+7 -10 D
+-13 7 D
+-6 -23 D
+-6 10 D
+-9 -8 D
+-37 -49 D
+-38 -48 D
+20 -16 D
+20 -18 D
+3 -4 D
+8 -7 D
+7 -8 D
+4 -3 D
+P
+FO
+4027 5723 M
+9 7 D
+-8 11 D
+9 2 D
+-17 9 D
+-4 -15 D
+9 -11 D
+P
+FO
+4445 5942 M
+-33 11 D
+17 -14 D
+-37 22 D
+5 -15 D
+-7 0 D
+14 -12 D
+-8 -6 D
+8 -2 D
+-8 -2 D
+19 -2 D
+-15 0 D
+7 -7 D
+-8 -1 D
+5 -2 D
+P
+FO
+4526 6002 M
+-40 1 D
+-24 23 D
+-31 5 D
+-2 -15 D
+-7 9 D
+7 -16 D
+-9 11 D
+0 -11 D
+-16 -4 D
+-3 -18 D
+19 -5 D
+-15 -6 D
+4 -20 D
+36 -14 D
+70 51 D
+P
+FO
+3809 6007 M
+3 -6 D
+14 21 D
+-5 -22 D
+14 -17 D
+-1 17 D
+7 -12 D
+3 13 D
+7 -6 D
+-1 8 D
+8 -3 D
+-28 13 D
+12 3 D
+-7 7 D
+25 -6 D
+-24 23 D
+20 9 D
+-20 3 D
+-9 10 D
+P
+FO
+3834 5882 M
+3 0 D
+2 -3 D
+23 -12 D
+32 -19 D
+34 -24 D
+4 -4 D
+57 73 D
+18 24 D
+-3 -2 D
+-16 10 D
+-15 -16 D
+-5 7 D
+13 6 D
+-4 6 D
+-5 -8 D
+2 7 D
+-17 3 D
+-2 -9 D
+-8 9 D
+-33 -22 D
+-14 0 D
+-5 -19 D
+0 18 D
+-14 6 D
+-5 -7 D
+-2 8 D
+-32 2 D
+-47 -17 D
+17 -8 D
+18 -7 D
+P
+FO
+3600 6378 M
+0 -17 D
+3 -3 D
+9 -1 D
+-12 -2 D
+1 -9 D
+17 -12 D
+13 -35 D
+25 -6 D
+-19 -3 D
+11 -4 D
+-12 -4 D
+-11 -27 D
+37 2 D
+-21 -29 D
+26 -1 D
+3 21 D
+10 -2 D
+-4 20 D
+12 9 D
+-17 1 D
+15 36 D
+-9 -14 D
+-9 -8 D
+-4 8 D
+7 -2 D
+6 28 D
+-4 6 D
+-1 -6 D
+-27 -1 D
+10 12 D
+-7 12 D
+-6 -5 D
+6 18 D
+-7 5 D
+24 3 D
+10 10 D
+-12 -3 D
+-1 10 D
+23 16 D
+-30 15 D
+-17 -11 D
+12 16 D
+19 -1 D
+26 27 D
+-35 -2 D
+-3 -12 D
+-57 -1 D
+P
+FO
+3827 6062 M
+-12 12 D
+-22 -4 D
+-26 -6 D
+-17 -13 D
+5 -5 D
+-8 1 D
+11 -30 D
+-8 -6 D
+10 4 D
+6 -12 D
+7 10 D
+16 -7 D
+2 14 D
+3 -16 D
+10 10 D
+5 -7 D
+P
+FO
+3728 6397 M
+-28 -7 D
+-3 -46 D
+-15 -10 D
+9 -21 D
+18 4 D
+-7 -5 D
+7 -4 D
+4 10 D
+5 -7 D
+14 12 D
+-10 2 D
+7 11 D
+24 -4 D
+-7 12 D
+11 9 D
+-19 8 D
+18 15 D
+-19 0 D
+27 7 D
+-9 3 D
+11 7 D
+-13 1 D
+10 6 D
+-11 -2 D
+6 7 D
+P
+FO
+3696 6242 M
+0 6 D
+-7 -5 D
+-4 -15 D
+P
+FO
+3684 6261 M
+8 -10 D
+-7 16 D
+P
+FO
+3152 6906 M
+20 18 D
+29 -12 D
+50 -5 D
+16 -24 D
+41 -8 D
+24 4 D
+48 -20 D
+5 -10 D
+-21 -29 D
+17 -22 D
+-9 -26 D
+11 11 D
+16 -15 D
+37 17 D
+32 -4 D
+21 13 D
+30 -6 D
+58 13 D
+23 16 D
+0 151 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+P
+FO
+3578 6452 M
+22 18 D
+0 242 D
+-19 -28 D
+-43 -23 D
+6 -25 D
+-7 -12 D
+-14 -7 D
+-39 11 D
+-46 -40 D
+-28 9 D
+-22 38 D
+-99 47 D
+-17 29 D
+9 23 D
+-10 1 D
+-7 -25 D
+-11 -8 D
+18 -16 D
+-4 -19 D
+-20 0 D
+-13 11 D
+-1 -10 D
+57 -24 D
+-1 -12 D
+27 1 D
+28 -35 D
+26 -13 D
+9 -30 D
+-23 -15 D
+-11 26 D
+-10 -16 D
+-35 41 D
+-18 -1 D
+-19 11 D
+15 -1 D
+-36 6 D
+-21 14 D
+-2 37 D
+-18 16 D
+26 -109 D
+30 -115 D
+11 -42 D
+50 13 D
+60 13 D
+70 10 D
+30 4 D
+90 5 D
+P
+FO
+3600 6746 M
+-5 -3 D
+5 -5 D
+P
+FO
+3430 6728 M
+-23 -10 D
+0 -32 D
+13 -18 D
+20 11 D
+P
+FO
+3540 6727 M
+-9 -11 D
+5 -6 D
+17 10 D
+P
+FO
+3288 6771 M
+-7 -43 D
+64 16 D
+-5 11 D
+P
+FO
+3425 6663 M
+-8 -17 D
+5 -23 D
+15 18 D
+P
+FO
+2853 6854 M
+17 -32 D
+11 -5 D
+21 5 D
+40 35 D
+53 -4 D
+42 8 D
+8 -10 D
+39 4 D
+8 -12 D
+33 -1 D
+32 27 D
+-6 36 D
+1 1 D
+-4 21 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -2 D
+-7 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -1 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -1 D
+-6 -2 D
+-7 -2 D
+-7 -1 D
+-6 -2 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-7 -1 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+P
+FO
+2813 6490 M
+32 18 D
+43 10 D
+38 -9 D
+31 17 D
+32 41 D
+41 12 D
+-6 10 D
+-14 -2 D
+18 9 D
+-2 7 D
+45 14 D
+8 17 D
+-3 12 D
+-17 -8 D
+-3 25 D
+-11 2 D
+10 7 D
+8 -8 D
+0 12 D
+-23 1 D
+2 10 D
+-16 7 D
+5 10 D
+-22 -10 D
+17 17 D
+-21 -13 D
+-33 11 D
+-15 -7 D
+2 -19 D
+-12 -4 D
+-43 9 D
+-23 -15 D
+-9 -21 D
+-18 0 D
+-14 -15 D
+-5 38 D
+-18 25 D
+7 104 D
+45 19 D
+-17 31 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+46 -105 D
+55 -113 D
+P
+2914 6617 M
+11 -3 D
+0 -13 D
+P
+FO
+3201 6673 M
+-20 16 D
+-7 -4 D
+6 7 D
+-10 11 D
+-45 -6 D
+5 7 D
+34 1 D
+3 11 D
+-19 24 D
+-8 -8 D
+-11 15 D
+-1 -12 D
+-14 7 D
+17 -27 D
+-17 -1 D
+14 -9 D
+-10 -7 D
+-13 8 D
+2 -14 D
+37 -10 D
+-10 -7 D
+5 -8 D
+-9 2 D
+24 -29 D
+-6 -6 D
+-25 12 D
+7 -10 D
+-15 2 D
+18 -12 D
+-25 -15 D
+-37 -1 D
+8 20 D
+-19 -33 D
+-28 -11 D
+37 -28 D
+8 4 D
+-14 -37 D
+9 -40 D
+-5 6 D
+-9 -9 D
+9 -25 D
+-4 5 D
+-4 -10 D
+4 11 D
+-8 -18 D
+9 -6 D
+-9 6 D
+0 -15 D
+-18 -18 D
+-12 7 D
+17 5 D
+-10 0 D
+2 6 D
+-33 -12 D
+-6 7 D
+17 22 D
+-13 -8 D
+-13 21 D
+-13 -1 D
+-36 -48 D
+20 12 D
+22 -15 D
+-22 16 D
+10 2 D
+16 -9 D
+-5 -22 D
+-3 13 D
+-8 -23 D
+-48 -47 D
+2 22 D
+16 7 D
+-25 8 D
+9 -2 D
+1 29 D
+14 14 D
+-86 9 D
+27 -47 D
+53 -85 D
+18 -28 D
+56 34 D
+87 44 D
+68 29 D
+99 33 D
+10 2 D
+-32 120 D
+-34 140 D
+P
+3010 6349 M
+-6 -7 D
+-16 29 D
+20 12 D
+-1 17 D
+16 13 D
+-13 -12 D
+2 -21 D
+-18 -9 D
+6 -19 D
+80 -9 D
+P
+FO
+3071 6771 M
+-31 -8 D
+-1 -9 D
+9 8 D
+52 -1 D
+-3 11 D
+P
+FO
+2885 6726 M
+-21 -20 D
+8 -7 D
+-11 -17 D
+45 35 D
+P
+FO
+3068 6657 M
+-6 -3 D
+8 -8 D
+9 7 D
+P
+FO
+3100 6694 M
+9 -15 D
+20 -6 D
+9 7 D
+P
+FO
+3009 6725 M
+-2 -14 D
+9 11 D
+P
+FO
+2468 6690 M
+2 -1 D
+-25 -12 D
+6 -12 D
+-23 2 D
+-11 -13 D
+-6 4 D
+-22 -14 D
+-15 -9 D
+-15 -10 D
+-15 -9 D
+-22 -15 D
+-22 -16 D
+-23 -16 D
+-22 -16 D
+-30 -23 D
+-15 -11 D
+-45 -37 D
+-7 -6 D
+60 -68 D
+49 -51 D
+72 -73 D
+13 -11 D
+54 -51 D
+90 -79 D
+6 -5 D
+3 5 D
+14 -3 D
+17 21 D
+30 -21 D
+16 -29 D
+-12 -14 D
+13 -9 D
+-12 -3 D
+9 -11 D
+28 -21 D
+32 -26 D
+27 -20 D
+51 62 D
+46 49 D
+49 45 D
+50 42 D
+-10 46 D
+11 -46 D
+41 31 D
+43 29 D
+-36 56 D
+-38 63 D
+-24 41 D
+-37 3 D
+-20 19 D
+0 16 D
+17 26 D
+3 1 D
+-60 117 D
+-40 82 D
+-43 99 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-14 -7 D
+-8 -3 D
+-14 -8 D
+-14 -7 D
+-8 -4 D
+-14 -7 D
+-15 -8 D
+-14 -8 D
+P
+2602 6414 M
+13 -24 D
+-13 -18 D
+22 5 D
+70 -24 D
+24 -30 D
+-2 13 D
+33 -19 D
+9 -35 D
+-22 -20 D
+6 -25 D
+-19 -38 D
+-29 -21 D
+-11 3 D
+-16 31 D
+-13 -2 D
+30 26 D
+-3 18 D
+-17 0 D
+24 14 D
+-4 8 D
+-14 -4 D
+-29 18 D
+-35 -12 D
+-7 20 D
+-30 18 D
+18 -23 D
+-9 -16 D
+-44 8 D
+9 28 D
+26 2 D
+-13 23 D
+-18 8 D
+8 -5 D
+-14 -10 D
+-12 9 D
+12 4 D
+-8 14 D
+-4 -11 D
+-18 4 D
+-46 53 D
+41 42 D
+75 15 D
+32 -28 D
+P
+2885 6239 M
+-13 3 D
+-10 46 D
+13 13 D
+7 -11 D
+-12 -4 D
+9 -17 D
+-8 -3 D
+0 -18 D
+P
+2664 6496 M
+-26 16 D
+6 13 D
+26 -21 D
+P
+2732 6528 M
+-21 -28 D
+1 23 D
+P
+2625 6660 M
+-14 14 D
+14 -15 D
+P
+2711 6440 M
+-20 2 D
+P
+2653 6630 M
+-17 14 D
+P
+FO
+2575 6079 M
+7 -13 D
+-17 -10 D
+-2 -17 D
+-6 28 D
+-12 8 D
+-30 -7 D
+-1 16 D
+-8 28 D
+-14 3 D
+10 23 D
+-84 73 D
+-66 62 D
+-25 23 D
+-85 86 D
+-72 80 D
+-12 14 D
+-70 -64 D
+-53 -54 D
+-37 -40 D
+-58 -70 D
+-42 -56 D
+-65 -101 D
+-42 -76 D
+-11 -23 D
+-29 -63 D
+-28 -72 D
+-2 -7 D
+118 -40 D
+132 -42 D
+160 -46 D
+132 -35 D
+228 -56 D
+13 51 D
+13 43 D
+28 72 D
+30 63 D
+27 49 D
+40 63 D
+25 35 D
+-54 41 D
+-27 22 D
+P
+2414 5793 M
+6 -25 D
+-37 -69 D
+1 -24 D
+-8 23 D
+35 63 D
+-12 37 D
+-32 15 D
+34 6 D
+P
+2256 5745 M
+-8 -6 D
+-7 26 D
+19 31 D
+P
+FO
+2014 5076 M
+1 14 D
+10 -10 D
+172 48 D
+208 53 D
+86 20 D
+-12 60 D
+-8 61 D
+-5 75 D
+2 75 D
+7 74 D
+13 73 D
+3 12 D
+-211 51 D
+-195 53 D
+-95 28 D
+-99 30 D
+-137 46 D
+-33 11 D
+-23 -68 D
+-17 -64 D
+-15 -73 D
+-8 -46 D
+-10 -95 D
+-3 -102 D
+5 -95 D
+7 -60 D
+4 -34 D
+14 -73 D
+18 -71 D
+25 -81 D
+3 -6 D
+136 46 D
+147 46 D
+P
+2397 5552 M
+22 25 D
+27 -31 D
+19 16 D
+2 -15 D
+-8 9 D
+-13 -17 D
+-14 22 D
+-11 -6 D
+-3 10 D
+-15 -22 D
+P
+2352 5629 M
+9 -14 D
+-24 -2 D
+P
+2412 5360 M
+-6 -9 D
+-16 16 D
+P
+2446 5351 M
+-7 -20 D
+-5 9 D
+P
+2182 5496 M
+-8 -6 D
+2 22 D
+P
+1691 5403 M
+0 -32 D
+-19 31 D
+P
+1733 5473 M
+4 -30 D
+P
+FO
+2047 4462 M
+-15 51 D
+15 -15 D
+-1 -32 D
+3 -7 D
+21 -21 D
+81 -5 D
+34 15 D
+20 -20 D
+-22 17 D
+-34 -14 D
+-78 6 D
+62 -59 D
+25 -22 D
+29 34 D
+1 5 D
+4 0 D
+45 49 D
+28 30 D
+6 5 D
+-10 25 D
+8 8 D
+35 1 D
+47 45 D
+-26 8 D
+22 33 D
+-17 29 D
+20 16 D
+26 -25 D
+39 -1 D
+54 47 D
+76 65 D
+53 42 D
+69 53 D
+-49 71 D
+-34 59 D
+-18 34 D
+-26 58 D
+-29 79 D
+-19 68 D
+-1 7 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-9 -3 D
+-8 -2 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-9 -3 D
+-8 -2 D
+-9 -2 D
+-9 -2 D
+-8 -3 D
+-9 -2 D
+-9 -2 D
+-8 -3 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-10 -2 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -2 D
+8 -9 D
+-21 -20 D
+2 25 D
+-10 -2 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-11 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-11 -4 D
+-10 -3 D
+-11 -4 D
+-10 -3 D
+-11 -4 D
+-10 -3 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-10 -3 D
+15 -43 D
+25 -58 D
+27 -57 D
+35 -65 D
+50 -82 D
+54 -76 D
+36 -45 D
+28 -34 D
+52 -57 D
+P
+2186 4484 M
+8 -4 D
+-2 13 D
+7 -15 D
+5 15 D
+9 -11 D
+7 9 D
+-12 -19 D
+P
+2621 4850 M
+-2 -10 D
+-24 8 D
+P
+FO
+2208 4315 M
+-9 24 D
+-32 20 D
+63 -16 D
+-6 50 D
+-14 19 D
+39 -46 D
+-4 47 D
+29 58 D
+-3 8 D
+-6 -5 D
+-67 -72 D
+-6 -7 D
+11 1 D
+-2 -21 D
+-15 5 D
+1 10 D
+-29 -34 D
+P
+FO
+2735 4190 M
+-6 -7 D
+4 1 D
+P
+FO
+2793 4303 M
+-30 -28 D
+-65 -13 D
+-5 14 D
+17 6 D
+-15 3 D
+-41 -37 D
+-67 37 D
+-73 -4 D
+-6 -11 D
+27 -20 D
+16 11 D
+-2 -11 D
+48 -3 D
+26 -16 D
+-19 -19 D
+9 -22 D
+10 5 D
+29 5 D
+-3 15 D
+10 8 D
+0 -11 D
+5 6 D
+6 -10 D
+-11 -1 D
+28 -14 D
+19 9 D
+-5 -16 D
+16 14 D
+10 -9 D
+10 14 D
+4 -4 D
+P
+FO
+2812 4339 M
+-6 -4 D
+-12 -16 D
+6 -2 D
+P
+FO
+2839 4388 M
+-5 -1 D
+-12 -29 D
+1 0 D
+P
+FO
+2900 4600 M
+-37 -18 D
+-55 10 D
+-33 1 D
+-34 12 D
+51 -8 D
+-19 17 D
+20 -17 D
+77 -10 D
+17 9 D
+0 7 D
+10 -3 D
+1 1 D
+-71 55 D
+-59 54 D
+-56 60 D
+-23 27 D
+-22 28 D
+-23 -17 D
+-29 -23 D
+-23 -18 D
+-29 -23 D
+-30 -24 D
+-41 -35 D
+-41 -35 D
+-36 -32 D
+38 0 D
+21 -12 D
+-7 -21 D
+-45 -6 D
+13 -13 D
+-32 -1 D
+76 -17 D
+30 -40 D
+-25 -13 D
+4 -14 D
+-14 10 D
+-16 -6 D
+11 -12 D
+-9 1 D
+10 -10 D
+5 2 D
+12 -23 D
+-13 -31 D
+-2 13 D
+-14 -1 D
+-2 -15 D
+8 6 D
+-12 -14 D
+9 -7 D
+-36 -16 D
+-1 -20 D
+-9 5 D
+-1 -12 D
+27 1 D
+-5 -11 D
+13 9 D
+1 -13 D
+6 13 D
+11 -18 D
+13 10 D
+8 -13 D
+29 19 D
+17 30 D
+10 59 D
+-9 29 D
+13 11 D
+65 -7 D
+19 23 D
+28 -1 D
+6 10 D
+8 -11 D
+24 12 D
+11 -34 D
+53 -6 D
+97 33 D
+66 35 D
+23 36 D
+-41 28 D
+P
+2730 4525 M
+8 21 D
+12 -12 D
+P
+FO
+2304 4513 M
+13 1 D
+3 9 D
+10 -14 D
+14 12 D
+34 -14 D
+8 -14 D
+16 10 D
+-29 48 D
+-22 7 D
+P
+FO
+2451 4191 M
+23 0 D
+45 34 D
+-11 42 D
+-42 7 D
+2 -20 D
+-4 12 D
+-8 -16 D
+17 -7 D
+2 17 D
+12 -1 D
+-7 -21 D
+-36 -27 D
+8 -15 D
+14 13 D
+P
+FO
+2541 4214 M
+23 8 D
+9 -17 D
+23 9 D
+3 14 D
+-14 13 D
+-25 -3 D
+-1 9 D
+-35 -9 D
+12 -3 D
+-7 -22 D
+P
+FO
+2385 4329 M
+22 -9 D
+P
+FO
+2982 4546 M
+-60 -97 D
+19 14 D
+12 -12 D
+-6 -14 D
+8 7 D
+1 45 D
+26 29 D
+19 -6 D
+3 -22 D
+6 40 D
+P
+FO
+2925 4531 M
+13 8 D
+16 24 D
+-6 4 D
+-15 -22 D
+P
+FO
+2823 4358 M
+26 -6 D
+-11 21 D
+8 6 D
+6 -12 D
+18 2 D
+21 -33 D
+26 17 D
+40 -4 D
+-12 4 D
+15 24 D
+-16 -5 D
+-17 14 D
+-13 53 D
+-40 -51 D
+-19 12 D
+-2 -11 D
+-14 -1 D
+P
+FO
+2800 4317 M
+2 0 D
+-4 -9 D
+-5 -5 D
+-52 -102 D
+2 -3 D
+-8 -8 D
+-2 -6 D
+28 10 D
+1 19 D
+18 15 D
+15 33 D
+14 -5 D
+27 28 D
+13 55 D
+-12 7 D
+-2 -18 D
+-10 19 D
+-13 -8 D
+P
+FO
+2961 4366 M
+-6 -8 D
+29 12 D
+-8 5 D
+P
+FO
+2992 4366 M
+45 12 D
+-18 5 D
+P
+FO
+3061 4377 M
+14 7 D
+-28 -8 D
+P
+FO
+4486 4768 M
+9 -3 D
+-1 -11 D
+6 16 D
+16 -13 D
+15 5 D
+34 -21 D
+1 -21 D
+-5 16 D
+-12 7 D
+6 -21 D
+-13 23 D
+-33 -25 D
+41 -23 D
+5 7 D
+12 -19 D
+10 10 D
+-8 -10 D
+68 -85 D
+41 -24 D
+17 -30 D
+47 -25 D
+36 -10 D
+13 16 D
+20 -10 D
+-18 0 D
+16 -14 D
+88 -18 D
+14 -15 D
+18 9 D
+-54 55 D
+-85 80 D
+-25 21 D
+-42 37 D
+-72 61 D
+-42 33 D
+-23 19 D
+-53 40 D
+P
+FO
+4472 4752 M
+13 3 D
+-3 9 D
+P
+FO
+4443 4722 M
+39 -3 D
+6 17 D
+8 -15 D
+32 22 D
+-60 5 D
+P
+FO
+5179 4489 M
+-67 42 D
+64 31 D
+51 -19 D
+34 42 D
+26 36 D
+7 8 D
+50 75 D
+36 59 D
+11 21 D
+27 52 D
+21 44 D
+32 78 D
+8 24 D
+-118 40 D
+-132 42 D
+-160 46 D
+-132 35 D
+-228 56 D
+-13 -51 D
+-13 -43 D
+-28 -72 D
+-30 -63 D
+-27 -49 D
+-40 -63 D
+-25 -35 D
+71 -54 D
+41 -34 D
+66 -54 D
+72 -64 D
+19 -16 D
+97 -93 D
+30 -31 D
+42 23 D
+46 4 D
+131 -50 D
+P
+4751 5121 M
+15 5 D
+-3 9 D
+11 -3 D
+9 25 D
+-7 -31 D
+-19 -4 D
+-8 -20 D
+P
+4728 5004 M
+10 44 D
+10 -6 D
+-11 -1 D
+1 -36 D
+P
+4816 5159 M
+79 -14 D
+-15 -18 D
+-7 18 D
+-58 13 D
+P
+4856 4806 M
+33 4 D
+-8 -3 D
+10 -10 D
+P
+FO
+5555 5432 M
+-11 -34 D
+-8 101 D
+-24 4 D
+20 11 D
+8 -10 D
+-23 42 D
+14 -6 D
+-13 43 D
+7 -13 D
+-1 41 D
+15 7 D
+-7 41 D
+-10 13 D
+3 16 D
+-13 58 D
+-17 56 D
+-51 -34 D
+-57 23 D
+-11 -10 D
+8 11 D
+-29 16 D
+-10 -3 D
+-11 -4 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -2 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-8 -2 D
+-9 -2 D
+-9 -3 D
+-8 -2 D
+-9 -2 D
+-9 -3 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-9 -3 D
+39 -41 D
+1 -51 D
+-40 14 D
+9 11 D
+8 -16 D
+10 5 D
+-25 31 D
+-13 41 D
+0 -10 D
+-8 11 D
+-7 -2 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -1 D
+4 -2 D
+1 -22 D
+-20 -25 D
+21 16 D
+48 -2 D
+16 -16 D
+-35 -17 D
+16 -29 D
+-25 13 D
+-34 -7 D
+-11 -43 D
+37 -9 D
+-16 -3 D
+21 -16 D
+63 7 D
+42 -7 D
+13 -22 D
+-60 -18 D
+-59 12 D
+3 -17 D
+-45 23 D
+11 10 D
+-21 25 D
+0 41 D
+-15 -12 D
+0 -18 D
+-10 1 D
+15 -58 D
+-14 -12 D
+6 -16 D
+-16 -5 D
+24 -43 D
+-2 -12 D
+-13 2 D
+6 -30 D
+-59 71 D
+4 9 D
+-17 5 D
+15 -1 D
+-7 8 D
+-13 -2 D
+5 42 D
+26 16 D
+-1 23 D
+50 15 D
+2 93 D
+22 26 D
+-7 -2 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -1 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -1 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-7 -1 D
+-1 -2 D
+1 2 D
+-6 -2 D
+-7 -1 D
+-6 -2 D
+-6 -1 D
+-6 -1 D
+-6 -2 D
+12 -61 D
+9 -68 D
+3 -44 D
+1 2 D
+21 -9 D
+-13 -15 D
+-9 7 D
+1 -45 D
+-5 -77 D
+-14 -95 D
+-6 -25 D
+211 -51 D
+195 -53 D
+95 -28 D
+99 -30 D
+137 -46 D
+33 -11 D
+29 89 D
+19 80 D
+14 75 D
+10 90 D
+3 71 D
+P
+4730 5317 M
+25 9 D
+-5 -17 D
+8 17 D
+6 -29 D
+-23 17 D
+-1 -12 D
+P
+4767 5341 M
+23 18 D
+-12 -20 D
+P
+4789 5307 M
+9 -14 D
+P
+FO
+7 36 7 -39 2 4856 5624 SP
+4630 6082 M
+-2 -9 D
+23 3 D
+6 -6 D
+-26 1 D
+-19 -14 D
+41 -1 D
+10 15 D
+-29 15 D
+P
+FO
+4746 5640 M
+10 20 D
+-10 -20 D
+125 30 D
+9 11 D
+13 -5 D
+65 16 D
+-19 27 D
+19 -2 D
+19 -20 D
+194 54 D
+184 57 D
+-59 29 D
+-77 65 D
+4 -23 D
+-17 12 D
+-2 -20 D
+-5 29 D
+-18 9 D
+-11 -10 D
+15 0 D
+-13 -7 D
+11 -20 D
+-21 11 D
+3 16 D
+-22 -15 D
+30 28 D
+-37 -33 D
+-1 -35 D
+-1 20 D
+-12 -19 D
+8 14 D
+-15 1 D
+-8 -25 D
+7 23 D
+-12 -1 D
+-4 -39 D
+-13 -1 D
+13 35 D
+-42 -26 D
+-19 17 D
+31 -4 D
+24 34 D
+36 5 D
+-59 6 D
+-42 -34 D
+20 31 D
+-38 8 D
+-24 -17 D
+-27 11 D
+-36 48 D
+-16 -6 D
+10 11 D
+-23 27 D
+-11 -9 D
+14 -1 D
+-12 -29 D
+-52 -3 D
+-7 10 D
+-10 -6 D
+-2 16 D
+-27 -4 D
+11 6 D
+-16 8 D
+5 8 D
+-28 15 D
+-9 -12 D
+-4 18 D
+-50 27 D
+23 -2 D
+-22 30 D
+20 -7 D
+-4 -14 D
+45 -17 D
+21 12 D
+0 21 D
+-47 2 D
+-6 16 D
+-8 -6 D
+-45 35 D
+-8 4 D
+-2 -28 D
+24 -23 D
+1 -38 D
+-19 -15 D
+7 -12 D
+-27 -1 D
+15 -13 D
+-6 -8 D
+8 -20 D
+-18 29 D
+-22 10 D
+-15 -17 D
+14 -30 D
+37 -29 D
+85 -33 D
+-42 13 D
+-13 -9 D
+-57 34 D
+-26 1 D
+28 -53 D
+29 -67 D
+21 -57 D
+17 -60 D
+6 -24 D
+P
+4864 5779 M
+17 -8 D
+17 11 D
+18 -16 D
+21 -73 D
+-24 13 D
+-16 49 D
+-12 4 D
+6 -18 D
+P
+4749 5852 M
+115 -72 D
+-48 30 D
+20 -55 D
+-14 -39 D
+14 39 D
+-21 54 D
+-66 42 D
+P
+4713 5756 M
+11 16 D
+-1 -21 D
+12 0 D
+-11 -1 D
+8 -6 D
+P
+4694 5808 M
+7 10 D
+0 -14 D
+P
+4820 5836 M
+46 12 D
+P
+FO
+4673 6032 M
+-25 8 D
+26 -37 D
+-16 -11 D
+17 1 D
+P
+FO
+4580 5991 M
+-8 -2 D
+1 -21 D
+15 -35 D
+P
+FO
+4975 5877 M
+-20 34 D
+-17 4 D
+P
+FO
+4487 6063 M
+17 1 D
+-15 -4 D
+14 -16 D
+14 9 D
+9 -7 D
+6 14 D
+2 -11 D
+27 -1 D
+-14 15 D
+30 -6 D
+5 10 D
+-17 10 D
+-14 29 D
+-25 7 D
+16 5 D
+-25 18 D
+35 -5 D
+-12 12 D
+-36 -2 D
+5 14 D
+20 7 D
+-19 1 D
+14 12 D
+-7 7 D
+-27 -12 D
+-4 -9 D
+13 -1 D
+-19 -9 D
+24 5 D
+-2 -13 D
+-9 1 D
+1 -9 D
+-20 7 D
+20 -14 D
+-29 -9 D
+14 -14 D
+-7 -6 D
+24 -2 D
+-14 -7 D
+15 -12 D
+-21 -2 D
+11 -9 D
+-2 -2 D
+P
+FO
+4634 6086 M
+-3 1 D
+-1 -5 D
+P
+FO
+3600 6817 M
+20 3 D
+21 17 D
+19 -2 D
+3 -8 D
+36 4 D
+16 -19 D
+10 3 D
+21 44 D
+57 34 D
+15 29 D
+-1 35 D
+1 1 D
+-32 3 D
+-96 5 D
+-90 2 D
+P
+FO
+3600 6738 M
+5 -5 D
+-1 -16 D
+-4 -5 D
+0 -242 D
+32 -11 D
+-9 29 D
+23 3 D
+6 -11 D
+30 8 D
+-10 8 D
+8 -2 D
+-4 13 D
+-34 9 D
+-10 27 D
+-12 4 D
+2 16 D
+-2 4 D
+10 55 D
+102 -7 D
+12 -9 D
+32 16 D
+-12 20 D
+10 57 D
+18 33 D
+-12 -5 D
+7 15 D
+-12 1 D
+5 0 D
+6 35 D
+-45 -3 D
+-24 35 D
+-25 -17 D
+-48 1 D
+-14 -19 D
+-15 -3 D
+-5 -19 D
+-10 -7 D
+P
+FO
+3485 7480 M
+5 -10 D
+-9 -13 D
+14 -12 D
+-16 12 D
+4 23 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 -1 D
+-7 0 D
+-8 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-7 0 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-7 0 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-8 0 D
+5 -71 D
+12 -129 D
+15 -122 D
+29 -190 D
+5 -26 D
+83 14 D
+90 12 D
+123 10 D
+102 4 D
+54 1 D
+0 513 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 -1 D
+-7 0 D
+-6 0 D
+-6 0 D
+P
+3215 7391 M
+29 17 D
+22 -35 D
+-10 -4 D
+-7 17 D
+-9 -5 D
+-1 9 D
+P
+FO
+2528 7233 M
+5 -5 D
+2 14 D
+57 -85 D
+40 -17 D
+26 -68 D
+-7 3 D
+20 -27 D
+41 -17 D
+14 -27 D
+-9 -2 D
+23 -12 D
+68 -84 D
+34 -24 D
+12 -25 D
+-2 -1 D
+1 -2 D
+20 7 D
+102 29 D
+114 26 D
+59 11 D
+-32 197 D
+-18 147 D
+-12 136 D
+-4 58 D
+-8 -1 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-9 -1 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-9 -1 D
+-8 0 D
+-9 -1 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-9 -1 D
+-9 -1 D
+-8 -1 D
+-9 0 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 0 D
+-8 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-10 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -2 D
+-10 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+10 -68 D
+P
+2795 7021 M
+-13 30 D
+26 13 D
+19 40 D
+-9 -36 D
+-23 -11 D
+P
+2589 7365 M
+13 -15 D
+-14 -7 D
+P
+FO
+2852 6854 M
+-1 2 D
+-60 49 D
+-3 -57 D
+-2 44 D
+-17 -4 D
+-79 65 D
+-13 22 D
+-33 9 D
+-32 35 D
+-14 40 D
+-29 14 D
+24 -79 D
+42 -118 D
+16 -41 D
+19 -47 D
+113 43 D
+P
+FO
+2113 7337 M
+2 -12 D
+-19 -10 D
+15 4 D
+3 -57 D
+20 -1 D
+45 37 D
+72 22 D
+31 25 D
+24 -2 D
+40 25 D
+56 -34 D
+20 7 D
+-25 -21 D
+5 -16 D
+84 -57 D
+33 -4 D
+9 -10 D
+-22 112 D
+-9 60 D
+-10 -1 D
+-9 -2 D
+-9 -1 D
+-10 -2 D
+-9 -1 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-10 -2 D
+-10 -2 D
+-10 -2 D
+-10 -1 D
+-10 -2 D
+-10 -2 D
+-10 -2 D
+-10 -2 D
+-11 -1 D
+-10 -2 D
+-10 -2 D
+-11 -2 D
+-10 -2 D
+-11 -2 D
+-10 -2 D
+-11 -2 D
+-11 -3 D
+-10 -2 D
+-11 -2 D
+-11 -2 D
+-11 -2 D
+-11 -3 D
+P
+FO
+2411 6658 M
+-68 43 D
+-34 -8 D
+-54 8 D
+-35 -12 D
+-38 -58 D
+-50 33 D
+-91 -41 D
+27 -37 D
+45 -57 D
+45 -53 D
+59 49 D
+38 28 D
+37 27 D
+60 41 D
+P
+FO
+2569 7073 M
+-30 14 D
+-84 80 D
+-9 50 D
+-48 79 D
+-52 -14 D
+-16 -25 D
+-99 -52 D
+-17 -28 D
+-91 -68 D
+1 -35 D
+-84 -57 D
+-2 -37 D
+-31 -19 D
+-2 -39 D
+-33 -29 D
+25 -46 D
+-5 -21 D
+-15 1 D
+-4 -93 D
+64 -24 D
+59 18 D
+29 -8 D
+35 -31 D
+8 -28 D
+27 117 D
+47 23 D
+10 17 D
+31 0 D
+19 -57 D
+18 7 D
+-15 44 D
+43 -29 D
+7 -23 D
+52 -10 D
+48 -42 D
+11 5 D
+-10 -12 D
+12 -11 D
+66 35 D
+65 31 D
+71 32 D
+-30 74 D
+-42 118 D
+-27 86 D
+P
+FO
+2014 7214 M
+-18 -15 D
+48 15 D
+-30 1 D
+P
+FO
+2191 6659 M
+-3 -13 D
+20 32 D
+P
+FO
+570 6629 M
+8 -28 D
+-39 -45 D
+107 -85 D
+32 -58 D
+35 -29 D
+118 -89 D
+83 -56 D
+63 -41 D
+47 -28 D
+84 -48 D
+102 -55 D
+112 -54 D
+67 -31 D
+114 -49 D
+115 -45 D
+103 -38 D
+13 37 D
+30 71 D
+22 46 D
+50 92 D
+39 61 D
+34 49 D
+63 82 D
+52 58 D
+53 55 D
+8 7 D
+7 8 D
+16 14 D
+7 8 D
+43 38 D
+-51 60 D
+-50 64 D
+-16 23 D
+-62 -31 D
+-124 -145 D
+-31 20 D
+-21 -17 D
+-35 24 D
+-25 -29 D
+-12 16 D
+-6 -28 D
+-1 25 D
+-49 -2 D
+-36 -48 D
+-7 25 D
+33 51 D
+-127 -5 D
+-25 -68 D
+39 -49 D
+-21 -21 D
+1 26 D
+-15 10 D
+-12 -16 D
+-5 27 D
+-35 6 D
+-30 48 D
+-200 132 D
+-369 166 D
+-80 61 D
+-27 -19 D
+-35 -26 D
+-36 -28 D
+-45 -36 D
+-64 -55 D
+P
+1859 6270 M
+10 61 D
+-11 30 D
+-60 25 D
+-33 71 D
+-13 -2 D
+11 13 D
+36 -82 D
+60 -24 D
+10 -31 D
+P
+FO
+401 4374 M
+41 8 D
+-32 -18 D
+31 -34 D
+5 -5 D
+25 27 D
+193 55 D
+31 26 D
+51 46 D
+3 -3 D
+59 44 D
+107 74 D
+64 41 D
+130 76 D
+95 50 D
+105 52 D
+14 6 D
+13 7 D
+66 30 D
+52 22 D
+105 43 D
+105 40 D
+57 21 D
+-23 68 D
+-17 64 D
+-15 72 D
+-8 47 D
+-10 95 D
+-3 102 D
+5 95 D
+7 60 D
+4 34 D
+14 73 D
+18 71 D
+25 81 D
+3 6 D
+-151 56 D
+-130 54 D
+-91 40 D
+-124 60 D
+-95 50 D
+-82 46 D
+-86 52 D
+-81 53 D
+-83 58 D
+-111 86 D
+-9 8 D
+50 -80 D
+142 -69 D
+32 -42 D
+-26 -48 D
+29 -46 D
+-18 -83 D
+35 -17 D
+43 -166 D
+61 -88 D
+20 -101 D
+48 -57 D
+45 4 D
+18 -61 D
+34 -17 D
+-46 -11 D
+33 -28 D
+-34 -23 D
+33 -3 D
+-23 -10 D
+23 -20 D
+-19 -17 D
+39 -8 D
+-40 -19 D
+55 -20 D
+-41 -7 D
+11 -13 D
+41 11 D
+2 -47 D
+-170 -105 D
+31 -17 D
+-33 0 D
+-8 -55 D
+-36 -27 D
+-8 39 D
+-33 -41 D
+42 -3 D
+-131 -71 D
+-142 -8 D
+35 -24 D
+-42 8 D
+29 -13 D
+-23 -36 D
+37 -4 D
+-23 -38 D
+50 -6 D
+32 -42 D
+24 27 D
+-15 -34 D
+39 -23 D
+52 23 D
+-61 -67 D
+18 -26 D
+-128 -69 D
+-90 -87 D
+38 13 D
+-67 -99 D
+-85 -39 D
+6 -39 D
+-112 -31 D
+-52 -57 D
+P
+1303 5435 M
+105 -3 D
+31 -47 D
+-32 44 D
+-104 5 D
+P
+FO
+368 5108 M
+-28 -30 D
+68 12 D
+P
+FO
+300 5083 M
+26 15 D
+-91 -23 D
+P
+FO
+958 3920 M
+1 16 D
+7 -20 D
+6 -4 D
+-1 18 D
+24 -24 D
+-14 29 D
+21 -16 D
+10 21 D
+25 -33 D
+143 0 D
+54 67 D
+16 -8 D
+67 156 D
+6 67 D
+-25 82 D
+30 154 D
+57 27 D
+42 -12 D
+20 19 D
+5 -14 D
+9 22 D
+24 -32 D
+37 3 D
+26 -26 D
+17 10 D
+1 -41 D
+29 -3 D
+2 -23 D
+-32 -10 D
+-17 -37 D
+14 -12 D
+47 42 D
+-6 -11 D
+54 -27 D
+11 9 D
+20 -24 D
+11 10 D
+14 -23 D
+22 24 D
+-8 -22 D
+15 6 D
+4 -14 D
+23 39 D
+5 -58 D
+5 12 D
+28 -5 D
+-5 -13 D
+25 1 D
+2 -16 D
+39 -14 D
+16 4 D
+-3 15 D
+29 -15 D
+13 9 D
+1 -13 D
+32 5 D
+-4 17 D
+28 -19 D
+7 14 D
+12 -11 D
+6 15 D
+10 -12 D
+13 14 D
+3 -16 D
+14 27 D
+21 -1 D
+-10 10 D
+8 -4 D
+1 18 D
+9 -15 D
+67 83 D
+17 19 D
+-69 63 D
+-18 18 D
+-18 2 D
+-15 -13 D
+12 -18 D
+-16 -6 D
+-3 29 D
+23 9 D
+-7 22 D
+-8 7 D
+-73 83 D
+-56 72 D
+-47 68 D
+-49 83 D
+-29 55 D
+-32 68 D
+-28 71 D
+-4 13 D
+-12 -4 D
+-11 -4 D
+-11 -5 D
+-11 -4 D
+-12 -4 D
+-11 -4 D
+-12 -4 D
+-11 -5 D
+-12 -4 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-5 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-7 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-7 -2 D
+-6 -3 D
+-6 -2 D
+-13 -6 D
+-6 -2 D
+-13 -6 D
+-6 -3 D
+-6 -2 D
+-7 -3 D
+-13 -6 D
+-6 -3 D
+-7 -2 D
+-13 -6 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-13 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -7 D
+-7 -3 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-8 -4 D
+-14 -7 D
+-14 -7 D
+-15 -8 D
+-15 -8 D
+-14 -8 D
+-15 -8 D
+-15 -8 D
+-15 -9 D
+-15 -8 D
+-15 -9 D
+-16 -9 D
+-15 -9 D
+-16 -9 D
+-23 -15 D
+-16 -9 D
+-16 -10 D
+-24 -16 D
+-16 -10 D
+-24 -16 D
+-25 -17 D
+-24 -17 D
+-25 -18 D
+-25 -18 D
+-26 -19 D
+-17 -13 D
+66 -56 D
+-64 -41 D
+59 -56 D
+19 -83 D
+-43 -113 D
+45 -3 D
+-32 -48 D
+28 1 D
+50 -107 D
+41 -25 D
+13 -9 D
+P
+927 3939 M
+-15 77 D
+52 145 D
+-24 -79 D
+73 16 D
+27 -15 D
+106 150 D
+-11 43 D
+35 9 D
+5 78 D
+46 39 D
+13 78 D
+-44 38 D
+24 0 D
+21 -38 D
+-13 -78 D
+-46 -39 D
+5 -57 D
+-25 -73 D
+-40 -43 D
+-8 -47 D
+-18 4 D
+-46 -68 D
+-97 0 D
+-20 -86 D
+55 -58 D
+-63 62 D
+9 -59 D
+P
+919 3997 M
+21 83 D
+P
+FO
+1674 3609 M
+48 12 D
+4 46 D
+-12 -32 D
+-9 14 D
+-5 -22 D
+-30 -17 D
+P
+FO
+1837 3874 M
+-3 5 D
+-14 -16 D
+-8 -42 D
+P
+FO
+2049 4459 M
+8 -20 D
+13 -1 D
+P
+FO
+664 4407 M
+5 2 D
+26 24 D
+P
+FO
+1440 4265 M
+16 -30 D
+53 -8 D
+60 19 D
+9 19 D
+-67 54 D
+-50 -2 D
+P
+FO
+1872 3552 M
+24 31 D
+-13 13 D
+-26 -36 D
+-7 -2 D
+P
+FO
+1889 3548 M
+22 12 D
+12 38 D
+-37 -50 D
+P
+FO
+1929 3537 M
+0 2 D
+-15 9 D
+-9 -5 D
+P
+FO
+2074 4254 M
+3 -4 D
+51 23 D
+-2 13 D
+33 -17 D
+2 19 D
+16 -1 D
+-3 14 D
+17 -10 D
+9 11 D
+-18 8 D
+29 -2 D
+-3 7 D
+-50 41 D
+-45 -53 D
+P
+FO
+1812 3821 M
+-2 -14 D
+10 -23 D
+10 16 D
+14 -15 D
+-29 -29 D
+25 -21 D
+25 9 D
+23 -47 D
+9 34 D
+18 -51 D
+27 -11 D
+-2 -19 D
+11 20 D
+-17 6 D
+-2 24 D
+20 0 D
+-7 13 D
+-17 12 D
+-11 -14 D
+-4 31 D
+-23 5 D
+-6 -14 D
+-15 30 D
+4 44 D
+71 44 D
+4 41 D
+18 20 D
+-59 39 D
+-56 -92 D
+-14 15 D
+P
+FO
+1934 3581 M
+15 -48 D
+2 16 D
+11 -6 D
+0 48 D
+-25 15 D
+P
+FO
+1990 4076 M
+104 81 D
+-6 18 D
+-84 -26 D
+-16 -17 D
+P
+FO
+1963 3587 M
+27 -20 D
+3 51 D
+-9 20 D
+-35 11 D
+20 -44 D
+P
+FO
+1824 3586 M
+58 18 D
+7 18 D
+-14 -4 D
+-36 34 D
+P
+FO
+1808 3718 M
+3 -39 D
+13 -2 D
+20 33 D
+-46 37 D
+P
+FO
+1927 3620 M
+-21 44 D
+-13 -29 D
+20 8 D
+P
+FO
+2301 4096 M
+14 7 D
+-32 -15 D
+P
+FO
+4139 3680 M
+9 1 D
+-10 10 D
+-7 -5 D
+P
+FO
+4205 3625 M
+24 18 D
+-31 17 D
+P
+FO
+4193 3671 M
+-19 5 D
+8 -10 D
+P
+FO
+4092 3692 M
+11 6 D
+P
+FO
+5227 4543 M
+45 -16 D
+62 3 D
+18 17 D
+20 -18 D
+76 18 D
+14 -29 D
+62 29 D
+19 -11 D
+135 22 D
+89 -15 D
+21 -40 D
+19 6 D
+-8 -27 D
+24 -6 D
+161 27 D
+80 69 D
+76 22 D
+66 50 D
+-83 49 D
+-116 63 D
+-110 54 D
+-92 43 D
+-45 19 D
+-139 57 D
+-142 53 D
+-21 -58 D
+-29 -66 D
+-32 -64 D
+-12 -20 D
+-11 -21 D
+-48 -77 D
+-32 -47 D
+-27 -35 D
+-20 -26 D
+P
+5900 4610 M
+15 5 D
+-29 -33 D
+13 28 D
+P
+FO
+5148 4456 M
+10 -4 D
+82 7 D
+12 -23 D
+16 1 D
+-32 -27 D
+71 8 D
+4 21 D
+56 0 D
+45 -40 D
+102 18 D
+35 -12 D
+6 30 D
+-44 16 D
+-37 -19 D
+-99 45 D
+-76 -1 D
+-27 16 D
+-93 -3 D
+P
+FO
+5262 4518 M
+14 1 D
+-15 11 D
+P
+FO
+7045 6095 M
+-17 -46 D
+3 73 D
+-28 52 D
+-42 68 D
+-47 71 D
+-4 5 D
+-73 -173 D
+-314 -84 D
+-70 -51 D
+-11 -157 D
+87 -266 D
+-13 -74 D
+-102 54 D
+-119 -2 D
+1 -24 D
+-41 23 D
+51 22 D
+-114 17 D
+-3 -24 D
+-130 49 D
+-9 -90 D
+46 -141 D
+126 -34 D
+69 -68 D
+-26 -58 D
+20 -166 D
+-66 -43 D
+-14 -47 D
+-266 -44 D
+-34 5 D
+-112 41 D
+-40 16 D
+-3 23 D
+21 -13 D
+-46 35 D
+-74 7 D
+-6 -17 D
+3 19 D
+-41 21 D
+-5 40 D
+-18 -8 D
+11 30 D
+6 -13 D
+-19 56 D
+-32 12 D
+12 22 D
+7 -15 D
+-10 44 D
+-16 1 D
+16 -1 D
+16 68 D
+-14 23 D
+41 43 D
+-14 19 D
+12 16 D
+-23 -4 D
+5 20 D
+29 17 D
+-14 19 D
+-20 -34 D
+-17 21 D
+-5 -18 D
+-2 -84 D
+-6 -71 D
+-10 -76 D
+-18 -87 D
+-22 -79 D
+-18 -53 D
+124 -46 D
+139 -56 D
+56 -25 D
+33 -14 D
+106 -50 D
+77 -39 D
+139 -76 D
+53 -32 D
+217 196 D
+22 197 D
+263 243 D
+83 305 D
+-9 -28 D
+-37 138 D
+51 22 D
+10 -42 D
+148 289 D
+32 -25 D
+1 39 D
+95 39 D
+-31 66 D
+P
+6839 5908 M
+70 155 D
+14 -120 D
+P
+6816 5840 M
+29 28 D
+-3 -58 D
+P
+FO
+5838 5995 M
+11 -66 D
+83 -151 D
+50 -2 D
+19 -39 D
+-17 55 D
+-73 59 D
+-16 51 D
+7 16 D
+16 -27 D
+6 25 D
+-24 107 D
+-21 -10 D
+-10 -4 D
+-21 -10 D
+P
+FO
+5525 5688 M
+2 9 D
+42 59 D
+54 4 D
+-10 19 D
+28 -6 D
+25 24 D
+-8 16 D
+52 31 D
+7 41 D
+25 5 D
+-13 26 D
+12 4 D
+-106 -13 D
+-140 -105 D
+22 -75 D
+P
+5628 5867 M
+25 9 D
+-9 -21 D
+P
+FO
+5539 5618 M
+16 8 D
+-23 33 D
+P
+FO
+5993 5863 M
+-17 25 D
+-16 -16 D
+3 -19 D
+P
+FO
+6130 6975 M
+-52 -30 D
+-7 -66 D
+-68 1 D
+17 -43 D
+140 9 D
+53 -40 D
+23 16 D
+32 -32 D
+41 1 D
+62 24 D
+6 11 D
+-55 37 D
+-98 59 D
+-77 44 D
+P
+FO
+5594 7201 M
+12 -25 D
+-57 -1 D
+120 -39 D
+-28 21 D
+81 -5 D
+51 -56 D
+108 -36 D
+-4 -47 D
+61 -52 D
+-1 -53 D
+31 25 D
+-27 10 D
+8 16 D
+15 -19 D
+112 -1 D
+0 63 D
+-71 35 D
+-77 36 D
+-123 51 D
+-63 25 D
+-98 35 D
+P
+FO
+5900 6023 M
+-21 72 D
+31 59 D
+-24 49 D
+12 17 D
+49 -14 D
+-100 131 D
+-46 26 D
+34 -87 D
+-22 -15 D
+29 -62 D
+-6 -193 D
+2 -11 D
+P
+FO
+5780 6577 M
+-36 0 D
+-76 79 D
+-26 -6 D
+35 -64 D
+-27 7 D
+24 -19 D
+-6 -24 D
+98 -120 D
+35 -16 D
+-18 41 D
+22 12 D
+3 40 D
+69 -85 D
+22 -1 D
+-5 44 D
+-85 67 D
+-1 53 D
+P
+FO
+5723 6087 M
+6 -13 D
+-18 -1 D
+14 -8 D
+11 22 D
+-14 0 D
+P
+FO
+5518 7218 M
+-14 -32 D
+37 -6 D
+-4 24 D
+27 4 D
+P
+FO
+5622 6041 M
+2 13 D
+-37 -10 D
+-5 -33 D
+8 29 D
+P
+FO
+6030 6322 M
+-37 39 D
+2 -57 D
+57 -76 D
+6 54 D
+P
+FO
+5435 6940 M
+-23 -2 D
+6 -17 D
+18 1 D
+P
+FO
+5567 6747 M
+-28 -7 D
+68 -47 D
+11 21 D
+P
+FO
+5718 6057 M
+-24 1 D
+-15 -34 D
+36 4 D
+P
+FO
+5732 6377 M
+-19 -8 D
+37 -16 D
+P
+FO
+5440 7015 M
+3 -18 D
+P
+FO
+4207 7319 M
+-8 1 D
+7 -10 D
+0 9 D
+P
+FO
+3818 6958 M
+13 17 D
+32 24 D
+33 5 D
+21 32 D
+20 10 D
+15 39 D
+27 20 D
+-5 -3 D
+37 53 D
+6 26 D
+-5 -9 D
+-16 27 D
+11 22 D
+-8 44 D
+18 53 D
+27 24 D
+-25 25 D
+1 14 D
+-25 -3 D
+21 6 D
+9 -6 D
+3 23 D
+-15 0 D
+15 5 D
+-20 2 D
+10 7 D
+-13 3 D
+3 7 D
+-27 -5 D
+15 4 D
+-12 5 D
+13 7 D
+-7 9 D
+-6 -4 D
+2 7 D
+-10 -4 D
+-5 23 D
+-12 6 D
+-181 6 D
+-7 0 D
+-8 0 D
+-163 2 D
+0 -513 D
+102 -2 D
+109 -7 D
+P
+3921 7340 M
+37 -42 D
+45 -1 D
+8 6 D
+-7 -7 D
+-46 2 D
+-21 14 D
+P
+FO
+3984 6993 M
+-15 -14 D
+19 3 D
+P
+FO
+3921 6995 M
+-5 -14 D
+17 16 D
+P
+FO
+3953 6997 M
+7 -6 D
+4 7 D
+P
+FO
+3074 7692 M
+18 5 D
+25 17 D
+-1 24 D
+60 56 D
+1 25 D
+2 -23 D
+-43 -47 D
+-14 -77 D
+12 77 D
+-18 -40 D
+-42 -23 D
+1 -82 D
+6 -127 D
+1 -12 D
+157 8 D
+145 5 D
+99 2 D
+0 4 D
+2 -4 D
+115 1 D
+0 55 D
+-2 2 D
+-4 -30 D
+4 72 D
+0 -9 D
+2 -1 D
+0 24 D
+-34 -15 D
+-64 -12 D
+11 6 D
+-27 1 D
+-16 15 D
+-8 -5 D
+7 6 D
+-11 3 D
+9 1 D
+-5 4 D
+-8 -4 D
+8 10 D
+-16 22 D
+-19 -1 D
+0 -7 D
+-4 7 D
+2 -8 D
+-6 7 D
+-1 -9 D
+-7 7 D
+-25 -2 D
+2 -10 D
+-9 11 D
+-7 -7 D
+-10 21 D
+-13 -4 D
+-3 7 D
+7 0 D
+-11 19 D
+16 50 D
+-9 2 D
+1 16 D
+9 -1 D
+-18 9 D
+13 3 D
+4 -8 D
+6 28 D
+11 -2 D
+-24 46 D
+-55 54 D
+-11 33 D
+-13 8 D
+11 3 D
+-28 60 D
+11 18 D
+-10 24 D
+-174 9 D
+-5 -101 D
+-3 -108 D
+-1 -89 D
+P
+3437 7514 M
+-10 22 D
+-59 -3 D
+58 3 D
+7 61 D
+-6 -62 D
+P
+3123 7810 M
+4 -26 D
+-13 -4 D
+7 10 D
+-9 4 D
+P
+FO
+3600 7543 M
+P
+FO
+3600 7564 M
+-3 -13 D
+3 -6 D
+P
+FO
+3382 7650 M
+-6 4 D
+-6 -14 D
+P
+FO
+2685 8045 M
+1 -10 D
+-5 -6 D
+-12 18 D
+-64 7 D
+-98 14 D
+7 -58 D
+-8 -15 D
+7 1 D
+-14 -26 D
+23 -34 D
+-18 -44 D
+-29 -51 D
+-2 -86 D
+1 -110 D
+8 -117 D
+11 -100 D
+4 -23 D
+152 20 D
+189 21 D
+211 17 D
+33 2 D
+-5 101 D
+-3 107 D
+0 13 D
+-6 -4 D
+-63 -5 D
+-60 41 D
+63 -40 D
+66 14 D
+-1 70 D
+3 133 D
+6 114 D
+-193 15 D
+-152 15 D
+P
+2741 7799 M
+-13 -60 D
+-20 -11 D
+-10 6 D
+-12 -12 D
+-4 10 D
+-15 -3 D
+-9 20 D
+-14 -9 D
+-4 7 D
+25 8 D
+3 29 D
+24 16 D
+-19 6 D
+13 10 D
+15 -5 D
+-3 14 D
+9 4 D
+-3 -15 D
+18 -9 D
+14 18 D
+P
+2819 7863 M
+-9 -28 D
+-15 74 D
+7 13 D
+-23 22 D
+-14 54 D
+20 -8 D
+7 -37 D
+26 -38 D
+-5 -59 D
+P
+2850 8014 M
+-1 -13 D
+-24 -12 D
+13 23 D
+P
+2711 7694 M
+-28 -8 D
+12 5 D
+-5 9 D
+P
+2602 7590 M
+-17 71 D
+26 -38 D
+P
+2796 7989 M
+20 11 D
+-8 -13 D
+P
+2823 7809 M
+-7 -25 D
+-8 13 D
+P
+2773 7707 M
+1 -15 D
+-29 -27 D
+5 21 D
+P
+2803 7742 M
+-12 -1 D
+16 15 D
+P
+2723 7983 M
+17 -5 D
+0 -13 D
+P
+2544 7523 M
+13 20 D
+P
+2646 7855 M
+-18 -13 D
+16 14 D
+P
+FO
+2502 7936 M
+2 -10 D
+5 14 D
+-10 12 D
+P
+FO
+2475 7841 M
+-7 -12 D
+-28 -15 D
+7 -11 D
+-18 1 D
+-79 -92 D
+-88 -64 D
+-68 -82 D
+-84 -206 D
+3 -23 D
+149 30 D
+188 31 D
+47 7 D
+-7 46 D
+-10 101 D
+-6 101 D
+-1 141 D
+P
+FO
+450 6632 M
+-75 120 D
+27 -12 D
+-111 92 D
+63 -87 D
+51 -63 D
+P
+FO
+491 6587 M
+5 9 D
+-11 -3 D
+P
+FO
+786 6801 M
+-81 65 D
+-123 16 D
+-28 -55 D
+22 -64 D
+-57 -80 D
+37 3 D
+14 -57 D
+55 48 D
+63 51 D
+71 54 D
+P
+FO
+58 3511 M
+-22 49 D
+-36 46 D
+0 -590 D
+2 -2 D
+-2 87 D
+1 55 D
+5 72 D
+12 101 D
+16 85 D
+P
+FO
+414 4160 M
+29 58 D
+-53 45 D
+56 62 D
+-32 34 D
+-4 5 D
+-189 -113 D
+51 -17 D
+-2 -265 D
+63 90 D
+51 65 D
+P
+FO
+399 4376 M
+-2 -2 D
+4 0 D
+P
+FO
+485 6593 M
+-47 -13 D
+35 17 D
+-23 35 D
+-52 59 D
+-51 63 D
+-56 78 D
+-96 89 D
+-105 -101 D
+9 -138 D
+179 -95 D
+201 -19 D
+12 19 D
+P
+FO
+1718 2629 M
+-3 2 D
+-45 -26 D
+55 -9 D
+2 1 D
+P
+FO
+1709 2665 M
+-8 -11 D
+10 2 D
+P
+FO
+1654 3123 M
+-8 -33 D
+-12 4 D
+14 -43 D
+-8 11 D
+-20 -28 D
+3 -38 D
+-28 -49 D
+13 -40 D
+30 4 D
+12 -105 D
+28 4 D
+-9 57 D
+-11 104 D
+-4 105 D
+P
+FO
+1670 3610 M
+-105 -59 D
+50 16 D
+52 40 D
+7 2 D
+P
+FO
+966 3916 M
+8 -22 D
+-2 18 D
+P
+FO
+877 3970 M
+-74 -74 D
+34 -24 D
+91 8 D
+0 58 D
+28 -57 D
+2 39 D
+-34 20 D
+-13 9 D
+P
+FO
+270 3969 M
+2 -23 D
+-79 -277 D
+32 -209 D
+229 -226 D
+51 37 D
+32 -34 D
+-64 165 D
+49 174 D
+-4 91 D
+-83 220 D
+-91 100 D
+70 173 D
+-59 -72 D
+-43 -58 D
+P
+FO
+2 3014 M
+50 -41 D
+220 -277 D
+327 -141 D
+74 -36 D
+-19 36 D
+65 -5 D
+-1 35 D
+52 -26 D
+-33 241 D
+-56 69 D
+-76 -1 D
+-8 -33 D
+9 53 D
+-41 4 D
+-22 98 D
+-119 26 D
+48 109 D
+-43 31 D
+-75 -35 D
+49 25 D
+-21 31 D
+-57 14 D
+-146 208 D
+-27 -62 D
+-94 174 D
+-21 -82 D
+-16 -84 D
+-14 -102 D
+-5 -71 D
+-2 -71 D
+1 -72 D
+P
+FO
+1392 2853 M
+68 61 D
+-12 15 D
+13 -5 D
+13 45 D
+-27 21 D
+29 43 D
+11 -10 D
+40 29 D
+-9 48 D
+32 38 D
+-7 18 D
+25 -18 D
+34 9 D
+-60 50 D
+-5 18 D
+20 5 D
+-52 77 D
+42 -3 D
+-19 31 D
+66 2 D
+-19 31 D
+63 15 D
+-42 33 D
+-24 -5 D
+8 21 D
+-26 -4 D
+16 25 D
+-25 38 D
+-23 -20 D
+2 27 D
+-66 -70 D
+-30 -4 D
+11 -13 D
+-16 -16 D
+-87 -3 D
+-73 -81 D
+-112 -17 D
+-27 -92 D
+-91 30 D
+-17 31 D
+-62 -66 D
+-3 -67 D
+30 -24 D
+-13 -41 D
+37 -17 D
+-27 6 D
+32 -24 D
+-15 -24 D
+39 16 D
+36 -135 D
+101 25 D
+21 -50 D
+68 51 D
+40 -9 D
+3 -19 D
+55 14 D
+11 -49 D
+P
+FO
+1397 2573 M
+37 1 D
+-26 52 D
+-75 -20 D
+-53 43 D
+-105 0 D
+-30 -48 D
+-104 -26 D
+-60 28 D
+-186 -32 D
+-1 -57 D
+-40 -42 D
+111 26 D
+6 -35 D
+117 19 D
+68 37 D
+136 7 D
+205 46 D
+P
+FO
+787 2830 M
+7 39 D
+-51 7 D
+-31 71 D
+-66 -11 D
+-16 -45 D
+61 3 D
+26 -59 D
+P
+FO
+1567 2597 M
+103 56 D
+-70 10 D
+-10 -12 D
+35 -13 D
+-63 -1 D
+-15 -21 D
+P
+FO
+551 3197 M
+14 -20 D
+3 43 D
+-40 -11 D
+P
+FO
+940 3416 M
+-7 21 D
+-24 -14 D
+9 -33 D
+P
+FO
+365 3211 M
+-29 19 D
+-12 -33 D
+71 -24 D
+P
+FO
+1446 2614 M
+-27 -6 D
+44 -29 D
+25 34 D
+P
+FO
+900 2828 M
+15 43 D
+-52 9 D
+4 -55 D
+P
+FO
+1510 2599 M
+32 1 D
+-1 32 D
+-25 -2 D
+P
+FO
+1296 2644 M
+49 -3 D
+32 27 D
+P
+FO
+263 3344 M
+-44 13 D
+5 -26 D
+P
+FO
+310 3214 M
+27 27 D
+-30 25 D
+P
+FO
+1453 2863 M
+8 47 D
+P
+FO
+1764 2608 M
+-46 21 D
+9 -32 D
+P
+FO
+1927 2652 M
+101 92 D
+-88 -29 D
+-53 -56 D
+0 -18 D
+P
+FO
+2474 3021 M
+-73 23 D
+-27 -12 D
+3 -11 D
+-28 -5 D
+-21 -33 D
+-23 -10 D
+-19 31 D
+-6 -14 D
+-11 18 D
+-9 60 D
+-59 14 D
+-46 -19 D
+-11 -24 D
+41 -1 D
+14 -30 D
+61 10 D
+-9 -24 D
+-17 11 D
+-18 -16 D
+-30 0 D
+35 -18 D
+4 -30 D
+20 10 D
+11 36 D
+-5 -21 D
+14 -14 D
+35 1 D
+-11 -8 D
+22 -11 D
+105 -24 D
+-1 -12 D
+10 3 D
+4 -23 D
+19 -14 D
+-12 -6 D
+24 -4 D
+-19 -4 D
+17 -11 D
+-3 -23 D
+33 12 D
+-10 108 D
+P
+FO
+1905 3543 M
+-11 -6 D
+7 -11 D
+26 0 D
+2 11 D
+P
+FO
+1886 3548 M
+-17 -22 D
+20 22 D
+-1 0 D
+P
+FO
+1850 3558 M
+-17 -3 D
+19 -43 D
+16 8 D
+4 32 D
+P
+FO
+1678 2810 M
+23 3 D
+-31 131 D
+27 20 D
+18 -4 D
+-6 -42 D
+37 -21 D
+1 -34 D
+23 -3 D
+3 19 D
+36 9 D
+-37 34 D
+12 22 D
+-62 60 D
+18 -4 D
+84 59 D
+-88 -3 D
+-25 -32 D
+-21 0 D
+-33 39 D
+13 53 D
+193 -3 D
+41 57 D
+-57 -36 D
+-145 29 D
+-17 -30 D
+-16 12 D
+-12 -13 D
+-3 -9 D
+1 -94 D
+7 -104 D
+14 -104 D
+P
+FO
+1711 2656 M
+79 12 D
+55 41 D
+-9 11 D
+-15 -26 D
+-41 -14 D
+-55 6 D
+-16 -21 D
+P
+FO
+1913 3355 M
+13 8 D
+2 -24 D
+16 16 D
+-9 35 D
+18 22 D
+14 -47 D
+3 27 D
+21 13 D
+1 52 D
+-12 7 D
+11 28 D
+-27 29 D
+-4 -37 D
+-31 8 D
+-7 -21 D
+-14 8 D
+-37 -22 D
+12 20 D
+-18 17 D
+-59 -23 D
+-23 -36 D
+10 -11 D
+29 35 D
+32 -26 D
+16 18 D
+22 -24 D
+-17 -43 D
+P
+FO
+2025 3082 M
+-4 32 D
+42 -11 D
+-30 24 D
+21 12 D
+2 20 D
+-47 -26 D
+17 16 D
+-1 39 D
+-25 -49 D
+10 -53 D
+33 -29 D
+P
+FO
+2029 2967 M
+-2 -21 D
+9 22 D
+13 -15 D
+58 9 D
+39 -18 D
+-22 34 D
+-53 4 D
+P
+FO
+2423 2807 M
+31 16 D
+3 16 D
+-32 -2 D
+-15 -31 D
+P
+FO
+1804 2859 M
+-1 17 D
+-16 -7 D
+0 -31 D
+15 0 D
+P
+FO
+2284 2876 M
+-1 -35 D
+17 27 D
+-7 30 D
+-14 -12 D
+P
+FO
+1808 2860 M
+-2 -34 D
+24 23 D
+-15 4 D
+3 38 D
+P
+FO
+1994 3075 M
+8 -15 D
+19 2 D
+-15 19 D
+P
+FO
+1932 2727 M
+2 9 D
+-24 -3 D
+-6 -15 D
+P
+FO
+2026 3032 M
+-16 7 D
+-10 -13 D
+32 -1 D
+P
+FO
+1944 2952 M
+32 -22 D
+23 13 D
+-21 21 D
+P
+FO
+2146 3081 M
+12 7 D
+-43 -2 D
+P
+FO
+1964 2749 M
+41 19 D
+-37 -3 D
+P
+FO
+2334 3054 M
+14 2 D
+-37 16 D
+P
+FO
+1804 3023 M
+25 12 D
+-30 4 D
+4 -16 D
+P
+FO
+2334 3030 M
+33 2 D
+-54 5 D
+P
+FO
+2037 3177 M
+13 5 D
+1 21 D
+P
+FO
+2120 3015 M
+2 14 D
+-26 -9 D
+P
+FO
+2147 3045 M
+1 14 D
+-16 -2 D
+15 -13 D
+P
+FO
+1784 3417 M
+-5 -15 D
+19 6 D
+P
+FO
+1940 3017 M
+-29 -4 D
+45 4 D
+P
+FO
+1856 2702 M
+29 20 D
+P
+FO
+1869 3004 M
+41 12 D
+-35 5 D
+P
+FO
+2176 2786 M
+17 36 D
+P
+FO
+2800 2800 M
+-6 4 D
+8 7 D
+-23 1 D
+-1 15 D
+-19 -4 D
+-16 29 D
+-31 16 D
+-8 21 D
+27 5 D
+-8 16 D
+-58 15 D
+0 20 D
+-42 30 D
+-149 46 D
+3 -70 D
+11 -123 D
+42 -35 D
+34 9 D
+14 -7 D
+22 22 D
+-40 14 D
+47 3 D
+-10 9 D
+17 -1 D
+-11 17 D
+29 -9 D
+-6 11 D
+6 -7 D
+6 9 D
+4 -11 D
+39 -6 D
+53 -53 D
+P
+FO
+3081 2838 M
+-9 4 D
+-2 -7 D
+11 -3 D
+P
+FO
+2825 2919 M
+30 20 D
+-6 11 D
+13 20 D
+-8 5 D
+-19 -3 D
+6 -19 D
+-22 -19 D
+-23 -2 D
+-1 15 D
+-6 -16 D
+-46 -4 D
+40 -19 D
+P
+FO
+2938 2919 M
+16 -17 D
+12 3 D
+-37 37 D
+P
+FO
+2878 2977 M
+-65 43 D
+46 -31 D
+17 -34 D
+3 22 D
+P
+FO
+3008 2873 M
+-5 -9 D
+17 -8 D
+P
+FO
+2698 3028 M
+14 5 D
+-29 -4 D
+P
+FO
+3052 2874 M
+25 -13 D
+-42 27 D
+P
+FO
+2996 2892 M
+15 -1 D
+-32 20 D
+16 -19 D
+P
+FO
+2814 2819 M
+15 -7 D
+P
+FO
+2789 3021 M
+14 -4 D
+P
+FO
+3081 2832 M
+23 -4 D
+-23 10 D
+P
+FO
+3108 2844 M
+11 -9 D
+-25 34 D
+P
+FO
+7122 8216 M
+0 2 D
+78 122 D
+0 112 D
+-104 104 D
+11 60 D
+-180 -1 D
+27 -41 D
+29 -49 D
+28 -50 D
+17 -33 D
+23 -47 D
+31 -69 D
+25 -65 D
+P
+FO
+7200 7720 M
+0 416 D
+-18 5 D
+-22 -58 D
+19 -96 D
+13 -91 D
+6 -84 D
+2 -69 D
+P
+FO
+7195 7620 M
+5 0 D
+-1 60 D
+P
+FO
+6872 6781 M
+-7 -100 D
+-69 3 D
+-31 -36 D
+7 -6 D
+-16 -4 D
+-13 -15 D
+129 -41 D
+34 -102 D
+14 30 D
+32 -46 D
+-42 -146 D
+36 -52 D
+42 -67 D
+33 -57 D
+10 -20 D
+0 8 D
+27 191 D
+62 55 D
+-19 37 D
+-30 -42 D
+33 114 D
+-46 -9 D
+-76 100 D
+22 69 D
+-61 19 D
+41 82 D
+-48 31 D
+-62 5 D
+P
+FO
+7082 6017 M
+12 5 D
+10 91 D
+-49 12 D
+-10 -30 D
+31 -64 D
+P
+FO
+5538 7905 M
+90 47 D
+33 -12 D
+58 52 D
+8 -21 D
+-16 -7 D
+84 -27 D
+4 14 D
+35 -45 D
+46 -13 D
+88 13 D
+45 69 D
+76 9 D
+19 39 D
+-18 7 D
+34 30 D
+35 -32 D
+90 7 D
+36 -38 D
+95 40 D
+-26 -20 D
+21 -5 D
+-41 2 D
+-47 -20 D
+-38 39 D
+-90 -11 D
+-40 32 D
+-27 -23 D
+19 -6 D
+-19 -42 D
+-82 -17 D
+-42 -62 D
+-124 -19 D
+-71 58 D
+-76 22 D
+-35 -26 D
+-28 11 D
+-48 -24 D
+-5 -23 D
+-43 -3 D
+0 -1 D
+31 -4 D
+61 -79 D
+114 -55 D
+166 2 D
+-31 -11 D
+-131 2 D
+-119 60 D
+-91 84 D
+3 -23 D
+5 -108 D
+-1 -95 D
+-5 -84 D
+-13 -106 D
+-21 -115 D
+-14 -57 D
+9 -9 D
+33 -6 D
+-13 -41 D
+31 -34 D
+36 -7 D
+6 -12 D
+95 -33 D
+100 -37 D
+122 -51 D
+120 -55 D
+45 -23 D
+0 23 D
+15 25 D
+50 -3 D
+3 -64 D
+-14 -8 D
+120 -68 D
+81 -50 D
+46 -31 D
+21 43 D
+145 5 D
+18 61 D
+26 -157 D
+58 -103 D
+47 -48 D
+40 -1 D
+0 60 D
+-43 23 D
+-12 100 D
+-35 15 D
+59 23 D
+-29 182 D
+122 226 D
+-45 47 D
+20 27 D
+98 91 D
+101 6 D
+11 85 D
+68 7 D
+-5 78 D
+153 24 D
+4 60 D
+-7 32 D
+8 8 D
+-1 77 D
+-6 84 D
+-11 91 D
+-19 97 D
+-3 14 D
+-12 -28 D
+-35 47 D
+9 114 D
+-10 30 D
+-19 51 D
+-29 71 D
+-19 41 D
+-7 13 D
+-20 40 D
+-28 51 D
+-29 49 D
+-30 48 D
+-4 5 D
+-3 0 D
+-190 73 D
+-174 97 D
+-33 -27 D
+-27 -21 D
+-21 -16 D
+-21 -16 D
+-16 -12 D
+-16 -11 D
+-16 -11 D
+-20 -15 D
+-11 -7 D
+-21 -13 D
+-30 -21 D
+-21 -12 D
+-20 -13 D
+-20 -12 D
+-20 -12 D
+-19 -12 D
+-20 -11 D
+-19 -11 D
+-19 -11 D
+-20 -10 D
+-18 -10 D
+-19 -10 D
+-19 -10 D
+-18 -9 D
+-19 -10 D
+-18 -9 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-17 -8 D
+-9 -4 D
+-9 -4 D
+-17 -8 D
+-9 -4 D
+-8 -4 D
+-9 -3 D
+-17 -8 D
+-8 -3 D
+-8 -4 D
+-9 -3 D
+-8 -4 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+29 -111 D
+16 -79 D
+13 -81 D
+P
+5932 7332 M
+-38 -52 D
+-55 -18 D
+-50 -2 D
+-37 26 D
+-150 -10 D
+-7 -14 D
+-4 -46 D
+2 56 D
+-22 11 D
+137 2 D
+46 3 D
+38 -26 D
+46 2 D
+P
+5638 7314 M
+19 48 D
+1 -45 D
+P
+FO
+6756 6638 M
+-23 -6 D
+0 -5 D
+10 -4 D
+P
+FO
+6796 6684 M
+-63 2 D
+0 -15 D
+16 -6 D
+16 -17 D
+P
+FO
+6874 6782 M
+-2 -1 D
+P
+FO
+4725 7832 M
+78 4 D
+41 -17 D
+48 39 D
+-1 -26 D
+-13 -11 D
+22 5 D
+-18 -15 D
+14 -23 D
+14 16 D
+4 -19 D
+7 7 D
+-4 -8 D
+10 6 D
+11 -14 D
+6 9 D
+2 -15 D
+6 8 D
+36 -18 D
+2 8 D
+27 -6 D
+16 32 D
+-16 3 D
+14 6 D
+8 -12 D
+32 40 D
+7 12 D
+-15 -38 D
+50 10 D
+15 -41 D
+55 34 D
+21 -3 D
+-30 -10 D
+-11 -17 D
+-16 -38 D
+-58 -51 D
+9 0 D
+-8 -20 D
+33 -17 D
+15 -89 D
+10 -8 D
+6 15 D
+22 -39 D
+75 -50 D
+132 -17 D
+48 -59 D
+21 21 D
+-19 -43 D
+20 -36 D
+39 -37 D
+16 68 D
+21 116 D
+12 106 D
+5 119 D
+-1 84 D
+-5 83 D
+-2 12 D
+-78 -7 D
+-38 -39 D
+-44 5 D
+-27 -31 D
+-53 -1 D
+-16 5 D
+1 14 D
+-14 -3 D
+-65 -38 D
+43 27 D
+15 11 D
+39 7 D
+15 52 D
+-4 -57 D
+-22 0 D
+42 -4 D
+-25 -3 D
+24 -9 D
+47 31 D
+41 -6 D
+50 51 D
+55 -5 D
+14 7 D
+-14 105 D
+-17 92 D
+-22 89 D
+-12 44 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-7 -1 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-7 -1 D
+-6 -2 D
+-6 -2 D
+-7 -1 D
+-6 -2 D
+-7 -1 D
+-6 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-6 -1 D
+-6 -2 D
+-7 -1 D
+-6 -2 D
+-6 -1 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-6 -2 D
+-13 -2 D
+-12 -3 D
+-12 -3 D
+-12 -3 D
+-12 -2 D
+-11 -3 D
+-12 -2 D
+-12 -3 D
+-11 -2 D
+-12 -3 D
+-12 -2 D
+-11 -2 D
+-11 -3 D
+-12 -2 D
+-11 -2 D
+-11 -2 D
+-11 -2 D
+-11 -2 D
+-11 -3 D
+-11 -2 D
+-11 -2 D
+-11 -2 D
+-11 -2 D
+-11 -1 D
+-10 -2 D
+-11 -2 D
+-10 -2 D
+-11 -2 D
+-11 -2 D
+-10 -1 D
+-10 -2 D
+-11 -2 D
+-10 -2 D
+-10 -1 D
+-11 -2 D
+-10 -1 D
+-10 -2 D
+-10 -2 D
+-10 -1 D
+-10 -2 D
+-10 -1 D
+-10 -2 D
+-10 -1 D
+-5 -1 D
+5 -30 D
+12 -114 D
+P
+5147 7833 M
+11 -22 D
+-38 -1 D
+11 17 D
+-6 12 D
+19 -27 D
+P
+5291 7517 M
+-2 18 D
+22 1 D
+P
+5185 7809 M
+-19 54 D
+20 -55 D
+P
+FO
+5538 7900 M
+-4 0 D
+4 -1 D
+P
+FO
+5125 7769 M
+-13 10 D
+13 3 D
+-10 26 D
+-31 1 D
+-37 -16 D
+-17 -45 D
+77 -7 D
+P
+FO
+5162 7779 M
+9 20 D
+-20 -14 D
+-11 -22 D
+8 -4 D
+P
+FO
+5093 7740 M
+-14 -17 D
+30 5 D
+P
+FO
+4581 8053 M
+-31 -56 D
+-1 -37 D
+18 -51 D
+12 -11 D
+49 -1 D
+45 -39 D
+52 -26 D
+-3 62 D
+-9 99 D
+-7 54 D
+-3 22 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+P
+FO
+3600 7570 M
+18 -8 D
+-17 5 D
+-1 -22 D
+6 -1 D
+-6 -1 D
+17 1 D
+-15 -6 D
+18 -8 D
+4 -14 D
+20 0 D
+-18 -2 D
+3 -10 D
+-29 32 D
+0 -55 D
+148 -1 D
+173 -5 D
+38 -2 D
+-12 6 D
+5 8 D
+-10 4 D
+-3 22 D
+-9 -1 D
+12 4 D
+-21 17 D
+2 10 D
+-34 17 D
+-64 53 D
+-32 11 D
+-35 -16 D
+-55 -6 D
+-52 13 D
+-51 -21 D
+P
+3740 7529 M
+6 17 D
+-3 6 D
+-7 -6 D
+2 13 D
+12 -11 D
+P
+FO
+3256 8000 M
+-10 27 D
+7 32 D
+30 30 D
+24 62 D
+2 56 D
+-57 125 D
+0 100 D
+-39 104 D
+-65 11 D
+-32 -197 D
+-18 -147 D
+-12 -135 D
+-4 -59 D
+P
+FO
+2892 8608 M
+-13 -13 D
+-35 -17 D
+-35 -65 D
+5 5 D
+6 -12 D
+-93 -30 D
+-17 -57 D
+12 -54 D
+-6 -26 D
+-5 7 D
+-48 -19 D
+-22 -27 D
+-100 -24 D
+-7 -6 D
+-28 -141 D
+-8 -52 D
+9 -9 D
+138 -19 D
+24 -2 D
+-8 47 D
+13 28 D
+-7 63 D
+18 -13 D
+8 -59 D
+-12 -17 D
+4 -51 D
+154 -17 D
+188 -15 D
+55 -4 D
+5 72 D
+14 148 D
+20 153 D
+22 140 D
+5 25 D
+-73 14 D
+-81 19 D
+P
+2916 8250 M
+-26 -29 D
+-34 -1 D
+25 3 D
+P
+2808 8057 M
+1 13 D
+10 2 D
+-10 -15 D
+P
+2802 8200 M
+-54 7 D
+P
+FO
+2534 8270 M
+-36 -38 D
+2 -65 D
+-9 -4 D
+2 -49 D
+-14 -19 D
+19 -18 D
+13 82 D
+20 96 D
+P
+FO
+2482 8609 M
+-66 11 D
+-164 -196 D
+-12 -34 D
+-18 -8 D
+-8 -49 D
+-11 -1 D
+-3 23 D
+-17 -16 D
+-7 -95 D
+20 -34 D
+-6 -12 D
+25 13 D
+5 35 D
+24 11 D
+11 -12 D
+1 26 D
+9 -3 D
+18 27 D
+-3 -15 D
+19 14 D
+-3 11 D
+12 2 D
+-6 -13 D
+19 6 D
+4 17 D
+8 -13 D
+62 0 D
+28 39 D
+8 87 D
+44 32 D
+19 29 D
+9 92 D
+P
+FO
+2003 8613 M
+15 17 D
+-18 -1 D
+P
+FO
+2400 8145 M
+-8 7 D
+1 -19 D
+P
+FO
+2100 8609 M
+-12 21 D
+-3 -18 D
+P
+FO
+1910 2179 M
+-28 -27 D
+-42 -72 D
+-28 -4 D
+-39 -107 D
+10 -35 D
+-32 15 D
+61 -108 D
+85 -39 D
+-22 2 D
+4 -13 D
+-28 17 D
+44 -26 D
+-34 -6 D
+140 -42 D
+30 -22 D
+50 51 D
+51 48 D
+26 22 D
+-65 78 D
+-11 15 D
+-35 45 D
+-51 71 D
+-16 25 D
+-38 59 D
+P
+FO
+1723 2596 M
+5 -1 D
+-1 2 D
+-2 -1 D
+P
+FO
+2545 2519 M
+-12 -2 D
+-23 16 D
+-82 13 D
+-49 23 D
+11 48 D
+-8 11 D
+18 6 D
+-3 16 D
+14 18 D
+-17 13 D
+-14 -25 D
+-2 15 D
+-13 -7 D
+7 10 D
+-21 -17 D
+-18 9 D
+-19 -12 D
+-12 13 D
+-13 -8 D
+-60 16 D
+-6 -9 D
+36 -3 D
+6 -19 D
+-45 -16 D
+-9 8 D
+-14 -18 D
+8 -8 D
+-16 6 D
+8 -11 D
+-14 -1 D
+6 -26 D
+-17 -10 D
+-7 -36 D
+26 -7 D
+-8 -22 D
+-15 9 D
+-1 -17 D
+-6 13 D
+-21 -1 D
+-9 -15 D
+11 -14 D
+-12 8 D
+-1 -13 D
+-2 32 D
+-38 20 D
+-24 1 D
+-3 -22 D
+-7 11 D
+-8 -16 D
+-13 10 D
+7 -31 D
+-18 14 D
+-11 -27 D
+20 -12 D
+-26 -9 D
+22 -10 D
+-26 4 D
+-6 -21 D
+10 -11 D
+7 11 D
+-5 -26 D
+22 8 D
+-18 -16 D
+-39 2 D
+7 -20 D
+20 1 D
+6 -18 D
+-18 3 D
+10 -23 D
+-45 38 D
+-13 -47 D
+23 -30 D
+-17 -79 D
+-36 -31 D
+21 -36 D
+11 -17 D
+43 -67 D
+45 -64 D
+46 -62 D
+12 -14 D
+11 -15 D
+59 -71 D
+39 33 D
+55 43 D
+47 34 D
+78 52 D
+47 28 D
+70 39 D
+62 32 D
+76 35 D
+38 16 D
+-30 75 D
+-47 132 D
+-39 130 D
+P
+2171 2436 M
+-11 20 D
+14 7 D
+P
+FO
+1887 2641 M
+0 -16 D
+22 9 D
+18 18 D
+-7 -2 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+P
+FO
+1728 2595 M
+25 -7 D
+13 19 D
+-2 1 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -1 D
+-6 -2 D
+-7 -2 D
+P
+FO
+2195 2659 M
+-5 -9 D
+-20 11 D
+29 -24 D
+17 22 D
+P
+FO
+2404 2608 M
+-1 -9 D
+21 3 D
+-12 20 D
+P
+FO
+2162 2634 M
+23 7 D
+-15 14 D
+P
+FO
+2511 2542 M
+17 8 D
+P
+FO
+1873 2598 M
+11 23 D
+P
+FO
+2992 2252 M
+-1 38 D
+-23 34 D
+-5 38 D
+-47 45 D
+-28 9 D
+-11 32 D
+1 -9 D
+-19 11 D
+4 -15 D
+-8 7 D
+-4 -7 D
+-37 62 D
+-78 25 D
+-20 57 D
+-19 11 D
+-10 44 D
+-29 19 D
+-21 -11 D
+-15 47 D
+-41 63 D
+-12 -10 D
+4 -33 D
+-13 -21 D
+13 1 D
+-9 -43 D
+13 -36 D
+-13 -88 D
+-19 -3 D
+15 -59 D
+42 -136 D
+33 -90 D
+32 -82 D
+3 -7 D
+72 29 D
+91 32 D
+132 39 D
+P
+FO
+2734 2793 M
+3 -3 D
+60 -1 D
+14 -9 D
+18 16 D
+-26 1 D
+-3 3 D
+-6 -1 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+P
+FO
+2955 2374 M
+4 -7 D
+-1 29 D
+P
+FO
+3600 2681 M
+-37 -17 D
+35 1 D
+0 8 D
+-11 -6 D
+P
+FO
+3284 2675 M
+-5 -3 D
+7 -11 D
+9 0 D
+P
+FO
+3567 2633 M
+-12 18 D
+-23 -17 D
+16 -8 D
+P
+FO
+3263 2700 M
+6 -17 D
+12 4 D
+-18 23 D
+P
+FO
+3137 2804 M
+10 0 D
+-31 15 D
+P
+FO
+3288 2509 M
+-80 52 D
+27 -31 D
+P
+FO
+3294 2544 M
+-9 7 D
+P
+FO
+3600 2681 M
+P
+FO
+3805 2733 M
+10 -1 D
+-16 4 D
+P
+FO
+3780 2746 M
+16 -5 D
+P
+FO
+4377 2578 M
+12 -11 D
+P
+FO
+5320 17 M
+-2 5 D
+-15 -22 D
+-261 0 D
+1518 0 D
+-1198 0 D
+P
+FO
+5363 9284 M
+-60 1 D
+-43 -59 D
+-14 -16 D
+-13 -17 D
+-62 -71 D
+-35 -36 D
+-51 -49 D
+-43 -38 D
+84 -103 D
+53 -71 D
+62 -92 D
+22 -35 D
+43 -72 D
+65 -126 D
+27 -61 D
+38 -94 D
+30 -88 D
+7 -22 D
+127 40 D
+113 40 D
+103 39 D
+126 54 D
+97 45 D
+102 53 D
+29 15 D
+77 45 D
+91 56 D
+20 14 D
+21 13 D
+79 56 D
+69 53 D
+33 27 D
+-117 57 D
+-208 50 D
+-17 39 D
+-65 15 D
+-77 0 D
+-254 -68 D
+-94 7 D
+-66 58 D
+-56 54 D
+-60 94 D
+-76 54 D
+P
+FO
+5804 8718 M
+-72 9 D
+0 26 D
+25 -18 D
+5 17 D
+50 5 D
+12 -31 D
+P
+FQ
+FO
+5568 8803 M
+30 -11 D
+13 -30 D
+P
+FO
+5033 8991 M
+17 -23 D
+2 -12 D
+23 -59 D
+-10 -19 D
+-77 -44 D
+85 62 D
+-29 77 D
+-13 16 D
+-36 -29 D
+-14 -12 D
+-22 -16 D
+-29 -22 D
+-21 -15 D
+-22 -15 D
+-22 -15 D
+-21 -14 D
+-15 -9 D
+-21 -14 D
+-14 -8 D
+-8 -5 D
+2 -27 D
+-12 -36 D
+14 -47 D
+23 -21 D
+-2 -29 D
+14 -1 D
+-16 -5 D
+-7 -33 D
+-24 -40 D
+-27 -14 D
+-18 -39 D
+-26 -5 D
+-9 -17 D
+-5 9 D
+-29 -10 D
+3 -15 D
+-23 -26 D
+8 -14 D
+-16 -60 D
+16 -58 D
+26 -113 D
+17 -91 D
+8 -54 D
+174 28 D
+142 26 D
+81 17 D
+139 32 D
+90 23 D
+109 30 D
+35 10 D
+-37 110 D
+-29 74 D
+-41 91 D
+-65 125 D
+-54 89 D
+-57 85 D
+-58 79 D
+-60 75 D
+-30 36 D
+P
+4783 8492 M
+16 -5 D
+5 9 D
+-3 -12 D
+17 -12 D
+-23 -12 D
+-1 7 D
+-16 7 D
+25 -8 D
+8 9 D
+P
+4799 8405 M
+10 3 D
+-1 -19 D
+8 8 D
+-3 -18 D
+-20 17 D
+5 10 D
+P
+{0.827 A} FS
+FO
+4636 8385 M
+-3 -10 D
+7 -39 D
+-12 -26 D
+24 -155 D
+-4 -9 D
+-9 13 D
+-11 -14 D
+-47 -92 D
+122 16 D
+-13 85 D
+-24 113 D
+-22 89 D
+P
+FO
+3213 8536 M
+-16 48 D
+1 23 D
+12 6 D
+-5 41 D
+-10 -5 D
+-22 25 D
+-25 -127 D
+P
+FO
+3173 8674 M
+-61 -10 D
+-49 18 D
+-53 -4 D
+-86 -41 D
+-32 -29 D
+89 -25 D
+114 -26 D
+53 -10 D
+P
+FO
+2562 335 M
+-10 2 D
+-2 21 D
+-4 -16 D
+-6 17 D
+-10 -3 D
+15 -20 D
+-11 0 D
+10 -8 D
+-12 -9 D
+P
+FO
+2031 1712 M
+17 -13 D
+63 -19 D
+35 -40 D
+-8 -23 D
+28 -18 D
+51 19 D
+29 29 D
+11 74 D
+2 2 D
+-11 12 D
+-12 11 D
+-17 18 D
+-16 19 D
+-23 25 D
+-22 25 D
+-32 -28 D
+-64 -61 D
+P
+FO
+2259 1723 M
+79 71 D
+-4 39 D
+25 52 D
+112 108 D
+91 13 D
+3 -14 D
+20 1 D
+41 -29 D
+-10 -5 D
+26 -1 D
+-8 13 D
+21 65 D
+-8 15 D
+20 -28 D
+-4 -23 D
+11 -21 D
+-10 -5 D
+2 -12 D
+18 15 D
+-6 31 D
+20 -14 D
+1 -27 D
+16 12 D
+20 -5 D
+9 -6 D
+-5 2 D
+17 -26 D
+9 -5 D
+-18 38 D
+-13 25 D
+-36 77 D
+-17 40 D
+-11 26 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-15 -7 D
+-15 -7 D
+-8 -3 D
+-15 -7 D
+-15 -7 D
+-15 -8 D
+-8 -3 D
+-15 -8 D
+-16 -8 D
+-15 -8 D
+-16 -8 D
+-15 -8 D
+-16 -9 D
+-15 -9 D
+-16 -8 D
+-15 -10 D
+-16 -9 D
+-16 -10 D
+-15 -9 D
+-16 -10 D
+-24 -16 D
+-23 -16 D
+-24 -16 D
+-31 -23 D
+-31 -24 D
+-40 -32 D
+-23 -20 D
+39 -44 D
+17 -18 D
+11 -13 D
+17 -18 D
+6 -5 D
+P
+FO
+2680 1944 M
+22 19 D
+-35 -17 D
+P
+FO
+2765 1939 M
+21 -9 D
+72 8 D
+17 40 D
+7 -7 D
+-8 -8 D
+17 9 D
+1 -9 D
+24 -4 D
+-5 8 D
+28 35 D
+-9 -9 D
+2 8 D
+46 27 D
+-13 49 D
+10 22 D
+-7 4 D
+2 40 D
+22 38 D
+-6 6 D
+8 35 D
+-2 30 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+37 -85 D
+36 -77 D
+19 -37 D
+P
+FO
+2960 1844 M
+20 -1 D
+-5 27 D
+21 -7 D
+-10 35 D
+6 -5 D
+-21 35 D
+-23 -25 D
+-45 -2 D
+10 -19 D
+27 -17 D
+-10 1 D
+7 -10 D
+P
+FO
+2963 1944 M
+7 0 D
+-13 10 D
+P
+FO
+2884 1913 M
+-9 10 D
+P
+FO
+3501 2039 M
+-6 -7 D
+13 -8 D
+14 10 D
+19 54 D
+19 2 D
+10 37 D
+-11 4 D
+-17 -13 D
+-23 8 D
+-13 30 D
+3 -19 D
+-20 8 D
+4 14 D
+-12 13 D
+-1 17 D
+-4 -5 D
+-16 14 D
+-3 -6 D
+-5 15 D
+-8 -1 D
+32 -49 D
+-3 10 D
+12 -6 D
+0 -10 D
+-7 5 D
+8 -15 D
+9 0 D
+-8 0 D
+10 -19 D
+-6 -27 D
+-16 -13 D
+27 -15 D
+P
+FO
+3421 1896 M
+12 11 D
+5 49 D
+17 5 D
+-11 8 D
+11 -8 D
+16 2 D
+-9 5 D
+2 14 D
+26 38 D
+-1 13 D
+-7 -2 D
+7 8 D
+-21 -10 D
+-12 16 D
+6 4 D
+-16 -10 D
+-21 -60 D
+-26 -26 D
+-15 -4 D
+-22 -33 D
+5 -7 D
+-7 2 D
+1 -23 D
+18 4 D
+26 -10 D
+P
+FO
+3389 1868 M
+-6 11 D
+-3 -16 D
+P
+FO
+4678 453 M
+2 -11 D
+39 -7 D
+-21 11 D
+7 12 D
+-23 -2 D
+16 -17 D
+P
+FO
+4837 2 M
+6 -2 D
+-27 0 D
+487 0 D
+15 22 D
+-14 27 D
+-114 67 D
+-100 114 D
+0 19 D
+-81 22 D
+-45 45 D
+-25 -3 D
+-3 9 D
+0 -25 D
+-8 -7 D
+3 -11 D
+-10 24 D
+-15 -9 D
+-9 8 D
+11 6 D
+-15 -4 D
+7 6 D
+-28 21 D
+-16 -3 D
+-5 18 D
+-19 -12 D
+-12 31 D
+-14 -14 D
+5 17 D
+-10 6 D
+0 -11 D
+-23 23 D
+14 0 D
+4 14 D
+-3 -11 D
+4 7 D
+8 -10 D
+-5 11 D
+11 4 D
+0 9 D
+-9 -10 D
+-8 11 D
+-6 21 D
+-9 -5 D
+9 3 D
+4 -18 D
+-13 4 D
+-3 -15 D
+-17 0 D
+-3 15 D
+-7 -12 D
+0 20 D
+-5 -22 D
+-17 -6 D
+7 8 D
+-14 -1 D
+19 23 D
+-19 -12 D
+-1 13 D
+-8 -5 D
+-17 15 D
+3 -10 D
+-19 -2 D
+8 13 D
+-13 -1 D
+-28 -67 D
+-20 -40 D
+9 1 D
+-9 -1 D
+-5 -11 D
+23 -21 D
+13 -52 D
+19 -13 D
+18 17 D
+37 1 D
+15 -27 D
+-8 -36 D
+33 -27 D
+5 -35 D
+19 8 D
+-5 -15 D
+-14 1 D
+-1 -16 D
+18 -7 D
+1 22 D
+19 5 D
+38 -29 D
+-32 -16 D
+-16 -35 D
+43 -38 D
+P
+4697 405 M
+17 -9 D
+-16 -1 D
+11 -6 D
+-25 1 D
+P
+4756 376 M
+16 -12 D
+-17 -32 D
+9 23 D
+P
+4665 399 M
+15 11 D
+P
+FO
+4884 352 M
+3 -16 D
+45 -18 D
+6 13 D
+-46 30 D
+P
+FO
+4827 348 M
+14 -7 D
+-4 15 D
+P
+FO
+4724 440 M
+-6 -10 D
+18 -1 D
+P
+FO
+4860 9280 M
+-29 -21 D
+-15 -27 D
+60 -57 D
+18 -17 D
+89 -93 D
+30 -33 D
+-5 38 D
+-37 29 D
+41 -29 D
+2 -39 D
+28 -32 D
+51 45 D
+57 56 D
+63 69 D
+27 32 D
+13 17 D
+33 43 D
+17 24 D
+15 0 D
+-645 0 D
+-6 0 D
+-1 0 D
+-41 0 D
+-5 0 D
+223 0 D
+P
+FO
+5085 9089 M
+14 0 D
+-16 -21 D
+P
+FQ
+FO
+5031 8989 M
+-16 19 D
+-2 24 D
+-66 71 D
+-59 61 D
+-72 68 D
+-22 -36 D
+-7 -29 D
+11 -47 D
+14 -13 D
+22 2 D
+12 -21 D
+51 4 D
+30 -39 D
+-21 23 D
+-26 3 D
+-48 -20 D
+-39 -44 D
+-3 -71 D
+18 -42 D
+-3 -60 D
+12 -8 D
+-27 2 D
+6 74 D
+-13 -51 D
+3 -44 D
+58 36 D
+93 64 D
+36 28 D
+15 11 D
+P
+4801 8975 M
+14 -14 D
+-6 -41 D
+-11 20 D
+10 6 D
+P
+4894 9015 M
+-21 -38 D
+8 22 D
+-8 2 D
+P
+{0.827 A} FS
+FO
+5014 9031 M
+0 -17 D
+19 -23 D
+9 8 D
+P
+FO
+3598 255 M
+2 -11 D
+0 11 D
+P
+FO
+3585 255 M
+7 -3 D
+3 3 D
+-4 0 D
+-3 0 D
+P
+FO
+3549 257 M
+1 0 D
+P
+FO
+3501 264 M
+24 -8 D
+4 3 D
+P
+FO
+3423 277 M
+10 4 D
+9 -12 D
+20 -1 D
+4 -11 D
+19 10 D
+-46 12 D
+-14 5 D
+P
+FO
+3408 290 M
+15 -13 D
+2 7 D
+P
+FO
+3278 361 M
+5 -13 D
+-12 -5 D
+13 3 D
+12 -40 D
+76 -1 D
+-42 22 D
+-44 28 D
+P
+FO
+3248 344 M
+2 0 D
+26 19 D
+-8 6 D
+P
+FO
+3087 469 M
+5 -8 D
+4 -25 D
+-14 -5 D
+-1 -23 D
+9 -20 D
+35 -19 D
+14 20 D
+4 -21 D
+11 -3 D
+-1 13 D
+11 -1 D
+9 -21 D
+8 6 D
+67 -18 D
+20 25 D
+-34 29 D
+-35 36 D
+-18 21 D
+-16 23 D
+-7 9 D
+-12 19 D
+-10 -6 D
+-10 -6 D
+-14 -9 D
+-10 -6 D
+P
+FO
+3025 670 M
+8 -12 D
+25 -3 D
+26 -27 D
+3 -8 D
+-13 2 D
+-14 -20 D
+10 -22 D
+-22 -17 D
+39 -94 D
+59 37 D
+-25 44 D
+-20 47 D
+-7 22 D
+-12 44 D
+-3 17 D
+-6 -1 D
+-5 -1 D
+-5 -1 D
+-6 -1 D
+-5 -1 D
+-5 -1 D
+-6 -1 D
+-5 -1 D
+-5 -1 D
+P
+FO
+2962 890 M
+-4 -23 D
+-24 -16 D
+6 -11 D
+26 -3 D
+12 -15 D
+-5 -26 D
+9 -27 D
+-14 -40 D
+13 -22 D
+7 6 D
+14 -29 D
+15 -2 D
+8 -12 D
+54 10 D
+-7 45 D
+-2 57 D
+3 46 D
+6 40 D
+P
+FO
+3075 1086 M
+-12 -23 D
+-29 -24 D
+-24 -4 D
+-3 -27 D
+10 -7 D
+4 -25 D
+-43 -44 D
+-11 5 D
+-15 -10 D
+20 -9 D
+-18 -15 D
+8 -10 D
+0 -3 D
+117 -22 D
+7 33 D
+12 38 D
+5 16 D
+18 42 D
+22 40 D
+3 4 D
+P
+FO
+3214 1248 M
+-57 -23 D
+-31 -36 D
+7 -29 D
+-34 -7 D
+1 -20 D
+-8 -2 D
+-5 -20 D
+-9 -1 D
+0 -18 D
+-3 -6 D
+46 -29 D
+25 -16 D
+19 29 D
+16 22 D
+37 42 D
+28 26 D
+17 15 D
+5 3 D
+-51 65 D
+P
+FO
+3422 1273 M
+-3 2 D
+-43 -1 D
+-20 11 D
+-17 -19 D
+-9 4 D
+-27 -15 D
+-32 6 D
+-4 24 D
+-5 -20 D
+-16 1 D
+-6 -10 D
+-26 -8 D
+32 -42 D
+22 -28 D
+26 20 D
+28 18 D
+38 21 D
+65 27 D
+P
+FO
+3430 1265 M
+-8 8 D
+3 -9 D
+P
+FO
+4108 627 M
+9 3 D
+-3 11 D
+-3 -5 D
+P
+FO
+4090 577 M
+38 5 D
+1 16 D
+-19 3 D
+9 9 D
+-13 8 D
+P
+FO
+4060 515 M
+15 -5 D
+53 -50 D
+23 -8 D
+25 8 D
+2 -15 D
+-11 -9 D
+3 -2 D
+11 3 D
+2 -12 D
+15 -10 D
+2 14 D
+-15 38 D
+8 5 D
+-14 8 D
+-4 26 D
+-14 6 D
+6 9 D
+-18 7 D
+12 7 D
+-34 5 D
+-23 16 D
+3 17 D
+-17 3 D
+-15 -33 D
+P
+FO
+4499 209 M
+8 9 D
+-17 -3 D
+9 9 D
+-8 -6 D
+2 19 D
+-10 -17 D
+P
+FO
+4625 330 M
+-5 -1 D
+-1 -10 D
+1 0 D
+P
+FO
+4666 421 M
+-15 -22 D
+3 22 D
+-9 2 D
+22 -1 D
+6 15 D
+-11 -1 D
+9 16 D
+-11 -13 D
+-14 7 D
+11 -14 D
+-11 -1 D
+-1 20 D
+-9 -9 D
+-14 11 D
+-16 -6 D
+12 -4 D
+-14 0 D
+16 -2 D
+-12 -11 D
+15 11 D
+6 -12 D
+-10 8 D
+-12 -9 D
+-18 16 D
+14 -9 D
+-10 9 D
+9 -3 D
+6 13 D
+-23 8 D
+3 -18 D
+-11 14 D
+-5 -6 D
+15 -7 D
+-10 -25 D
+-18 4 D
+-9 16 D
+10 -6 D
+-1 13 D
+-23 -15 D
+31 -21 D
+2 -37 D
+-12 -13 D
+26 1 D
+6 11 D
+-5 -12 D
+18 2 D
+17 -33 D
+6 0 D
+29 60 D
+P
+FO
+4678 453 M
+P
+FO
+4470 372 M
+-3 -30 D
+44 30 D
+44 -1 D
+7 32 D
+-17 8 D
+-11 -18 D
+-11 21 D
+-20 -13 D
+-4 9 D
+11 -3 D
+-4 8 D
+21 13 D
+-18 -7 D
+3 11 D
+9 -3 D
+-1 23 D
+-49 -80 D
+P
+FO
+4493 426 M
+-16 -5 D
+8 -2 D
+-4 -10 D
+-7 4 D
+-12 -12 D
+25 9 D
+-1 -11 D
+P
+FO
+4542 463 M
+3 -18 D
+18 11 D
+-4 15 D
+-14 -6 D
+2 -10 D
+P
+FO
+4569 453 M
+-12 -5 D
+9 -1 D
+5 -25 D
+9 20 D
+P
+FO
+4530 426 M
+-11 -8 D
+21 -4 D
+P
+FO
+4523 432 M
+14 6 D
+-7 4 D
+P
+FO
+4676 457 M
+5 7 D
+-13 3 D
+P
+FO
+4577 470 M
+-13 -13 D
+29 23 D
+P
+FO
+4482 395 M
+-13 -15 D
+P
+FO
+4532 448 M
+10 -6 D
+P
+FO
+4199 456 M
+11 1 D
+-7 16 D
+P
+FO
+4483 220 M
+6 -23 D
+10 12 D
+P
+FO
+4183 425 M
+0 -8 D
+-10 -3 D
+15 -18 D
+-7 -17 D
+12 -1 D
+5 37 D
+P
+FO
+4167 436 M
+-6 -5 D
+9 3 D
+P
+FO
+4471 206 M
+-4 -7 D
+9 1 D
+-12 -20 D
+10 -3 D
+-2 11 D
+18 2 D
+-13 11 D
+0 17 D
+-10 -1 D
+P
+FO
+4184 398 M
+-11 8 D
+-6 -9 D
+6 -7 D
+P
+FO
+4186 366 M
+-4 7 D
+-8 -16 D
+P
+FO
+4124 3 M
+5 -3 D
+31 0 D
+3 2 D
+P
+FO
+4142 9277 M
+18 8 D
+-36 0 D
+5 0 D
+P
+FO
+3600 244 M
+15 11 D
+-4 0 D
+-4 0 D
+-3 0 D
+-4 0 D
+P
+FO
+3485 267 M
+3 1 D
+29 -7 D
+12 -2 D
+6 5 D
+15 -7 D
+15 6 D
+20 -8 D
+10 0 D
+3 3 D
+0 -3 D
+2 0 D
+0 519 D
+-8 -24 D
+-7 -17 D
+-73 -204 D
+-7 -17 D
+-20 -58 D
+-39 -112 D
+-7 -17 D
+-14 -41 D
+32 -10 D
+P
+FO
+3276 363 M
+1 1 D
+1 -3 D
+26 -18 D
+49 -29 D
+19 -9 D
+18 2 D
+18 -17 D
+17 -6 D
+18 53 D
+7 17 D
+35 100 D
+24 70 D
+7 17 D
+54 151 D
+19 53 D
+7 17 D
+4 12 D
+-79 -95 D
+-108 -129 D
+-31 -39 D
+-44 -53 D
+-70 -89 D
+P
+FO
+3600 774 M
+-11 -6 D
+-16 -10 D
+-10 -6 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-16 -10 D
+-10 -6 D
+-11 -6 D
+-11 -6 D
+-11 -7 D
+-10 -6 D
+-11 -6 D
+-11 -6 D
+-11 -7 D
+-10 -6 D
+-11 -6 D
+-11 -6 D
+-11 -7 D
+-10 -6 D
+-11 -6 D
+-11 -7 D
+-11 -6 D
+-11 -7 D
+-10 -6 D
+-11 -6 D
+-11 -7 D
+-11 -6 D
+-11 -7 D
+-11 -6 D
+-11 -7 D
+-10 -6 D
+-11 -7 D
+-11 -6 D
+-11 -7 D
+-11 -7 D
+-11 -6 D
+-11 -7 D
+-11 -7 D
+-11 -6 D
+-11 -7 D
+15 -24 D
+10 -13 D
+21 -27 D
+42 -44 D
+34 -29 D
+110 138 D
+32 38 D
+31 39 D
+87 104 D
+P
+FO
+3600 774 M
+-6 -1 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -2 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -2 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -2 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -2 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+7 -34 D
+12 -38 D
+5 -16 D
+21 -47 D
+22 -39 D
+147 89 D
+98 57 D
+21 13 D
+22 12 D
+21 13 D
+22 12 D
+21 13 D
+27 15 D
+21 13 D
+38 21 D
+P
+FO
+3600 774 M
+-269 47 D
+-252 47 D
+-7 -46 D
+-2 -51 D
+3 -52 D
+6 -39 D
+276 50 D
+P
+FO
+3600 774 M
+-43 24 D
+-21 13 D
+-81 46 D
+-21 13 D
+-22 12 D
+-21 13 D
+-98 57 D
+-59 36 D
+-88 53 D
+-17 -29 D
+-17 -36 D
+-12 -31 D
+-11 -33 D
+-9 -39 D
+-1 -5 D
+133 -25 D
+236 -42 D
+P
+FO
+3600 774 M
+-72 85 D
+-23 29 D
+-92 109 D
+-43 54 D
+-32 38 D
+-70 89 D
+-13 -10 D
+-37 -34 D
+-30 -33 D
+-33 -45 D
+-9 -15 D
+93 -56 D
+65 -39 D
+71 -41 D
+21 -13 D
+54 -31 D
+21 -13 D
+81 -46 D
+21 -13 D
+P
+FO
+3600 774 M
+-46 128 D
+-7 17 D
+-65 181 D
+-57 164 D
+-5 -2 D
+-5 -2 D
+-5 -2 D
+-5 -2 D
+-5 -2 D
+-5 -2 D
+-5 -2 D
+-5 -2 D
+-5 -2 D
+-10 -5 D
+-5 -2 D
+-10 -5 D
+-9 -5 D
+-10 -5 D
+-9 -6 D
+-10 -5 D
+-14 -9 D
+-18 -13 D
+-17 -13 D
+98 -123 D
+44 -53 D
+23 -29 D
+92 -109 D
+23 -29 D
+P
+FO
+3600 1090 M
+-76 8 D
+5 -18 D
+-12 -8 D
+-19 25 D
+-10 36 D
+21 7 D
+-23 0 D
+6 18 D
+9 2 D
+-8 13 D
+10 3 D
+0 13 D
+17 7 D
+-1 32 D
+8 12 D
+-8 13 D
+1 -10 D
+-34 21 D
+-49 -5 D
+-7 6 D
+-2 0 D
+-3 -1 D
+57 -164 D
+69 -193 D
+7 -17 D
+42 -116 D
+P
+FO
+3705 1065 M
+-20 -8 D
+-66 20 D
+-14 12 D
+-5 1 D
+0 -316 D
+41 114 D
+7 17 D
+P
+FO
+3843 1067 M
+-6 1 D
+-23 21 D
+-21 2 D
+-39 -28 D
+-30 23 D
+-10 -19 D
+-9 -2 D
+-28 -80 D
+-33 -92 D
+-9 -22 D
+-35 -97 D
+31 37 D
+67 80 D
+48 57 D
+19 24 D
+43 52 D
+32 38 D
+P
+FO
+3966 988 M
+-6 17 D
+-11 8 D
+-2 28 D
+-26 -12 D
+-40 34 D
+-38 4 D
+-23 -29 D
+-71 -85 D
+-27 -34 D
+-31 -37 D
+-67 -80 D
+-24 -28 D
+43 24 D
+21 13 D
+81 46 D
+21 13 D
+22 12 D
+21 13 D
+141 83 D
+P
+FO
+4071 858 M
+-16 26 D
+-24 -7 D
+-9 -17 D
+-2 12 D
+-13 -15 D
+-10 6 D
+-3 -10 D
+-11 2 D
+1 34 D
+-18 8 D
+21 24 D
+-2 29 D
+-9 4 D
+-10 34 D
+-11 -6 D
+-11 -7 D
+-16 -10 D
+-11 -6 D
+-11 -7 D
+-10 -6 D
+-11 -6 D
+-11 -7 D
+-11 -6 D
+-11 -7 D
+-10 -6 D
+-11 -6 D
+-11 -7 D
+-11 -6 D
+-11 -6 D
+-16 -10 D
+-10 -6 D
+-11 -6 D
+-11 -6 D
+-11 -7 D
+-10 -6 D
+-11 -6 D
+-11 -6 D
+-11 -7 D
+-10 -6 D
+-11 -6 D
+-11 -6 D
+-10 -6 D
+-11 -7 D
+-11 -6 D
+-11 -6 D
+-10 -6 D
+-11 -6 D
+313 55 D
+P
+FO
+4038 695 M
+5 4 D
+-22 16 D
+42 58 D
+-8 6 D
+5 29 D
+16 19 D
+1 21 D
+-6 10 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -2 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -2 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+-6 -1 D
+426 -76 D
+P
+FO
+3934 579 M
+15 4 D
+42 -39 D
+19 -11 D
+50 -18 D
+24 47 D
+6 14 D
+-2 1 D
+2 0 D
+13 32 D
+3 9 D
+-7 5 D
+9 4 D
+4 12 D
+-18 -11 D
+-8 27 D
+-2 -29 D
+-12 4 D
+-9 21 D
+-18 -19 D
+-23 4 D
+36 47 D
+-17 6 D
+-4 -15 D
+-8 2 D
+-1 11 D
+10 8 D
+-322 58 D
+-116 21 D
+100 -58 D
+85 -49 D
+21 -13 D
+27 -15 D
+26 -16 D
+P
+FO
+3798 536 M
+41 26 D
+22 -6 D
+11 9 D
+62 14 D
+-27 15 D
+-26 16 D
+-85 50 D
+-75 43 D
+-31 19 D
+-64 36 D
+-26 16 D
+27 -33 D
+28 -32 D
+19 -24 D
+16 -18 D
+19 -24 D
+16 -18 D
+19 -24 D
+16 -18 D
+23 -29 D
+P
+FO
+3988 546 M
+7 -8 D
+15 -5 D
+P
+FO
+3748 361 M
+4 33 D
+16 -5 D
+9 11 D
+-14 24 D
+9 17 D
+-11 9 D
+21 48 D
+-3 28 D
+19 10 D
+-35 42 D
+-15 19 D
+-20 23 D
+-15 19 D
+-20 23 D
+-15 19 D
+-20 23 D
+-15 19 D
+-24 27 D
+-19 24 D
+27 -76 D
+7 -17 D
+14 -41 D
+7 -17 D
+14 -41 D
+7 -17 D
+18 -52 D
+P
+FO
+3615 255 M
+15 12 D
+45 7 D
+26 25 D
+2 19 D
+43 29 D
+2 14 D
+-54 152 D
+-22 64 D
+-7 17 D
+-14 41 D
+-7 17 D
+-14 41 D
+-7 17 D
+-23 64 D
+0 -519 D
+P
+FO
+25 W
+4 W
+3600 774 M
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -2 D
+3600 9285 M
+0 -5 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+S
+3600 774 M
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -4 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-5 -3 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-5 -4 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-5 -3 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-6 -4 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -4 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-5 -4 D
+-6 -3 D
+-6 -4 D
+-5 -3 D
+-6 -4 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-6 -4 D
+-5 -4 D
+-6 -3 D
+-6 -4 D
+-5 -3 D
+-6 -4 D
+-6 -4 D
+-5 -3 D
+-6 -4 D
+-6 -4 D
+-6 -3 D
+-5 -4 D
+-6 -4 D
+-6 -3 D
+-5 -4 D
+-6 -4 D
+-6 -4 D
+-6 -3 D
+-5 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-5 -4 D
+-6 -3 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-5 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-5 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-5 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -5 D
+-5 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-7 -5 D
+-6 -4 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-6 -6 D
+-7 -5 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-6 -6 D
+-6 -5 D
+-7 -5 D
+-6 -5 D
+-6 -6 D
+-6 -5 D
+-6 -6 D
+-6 -5 D
+-2 -1 D
+-1 -2 D
+2444 9286 M
+-2 -1 D
+-5 -5 D
+-6 -5 D
+-6 -6 D
+-6 -5 D
+-6 -6 D
+-7 -6 D
+-6 -5 D
+-6 -6 D
+-6 -6 D
+-6 -5 D
+-7 -6 D
+-6 -6 D
+-6 -6 D
+-6 -6 D
+-7 -6 D
+-6 -6 D
+-6 -6 D
+-6 -6 D
+-6 -6 D
+-7 -6 D
+-6 -6 D
+-6 -6 D
+-6 -6 D
+-7 -6 D
+-6 -7 D
+-6 -6 D
+-6 -6 D
+-6 -7 D
+-7 -6 D
+-6 -7 D
+-6 -6 D
+-6 -7 D
+-7 -6 D
+-6 -7 D
+-6 -6 D
+-6 -7 D
+-6 -7 D
+-7 -7 D
+-6 -6 D
+-6 -7 D
+-6 -7 D
+-6 -7 D
+-6 -7 D
+-7 -7 D
+-6 -7 D
+-6 -7 D
+-6 -7 D
+-6 -8 D
+-6 -7 D
+-7 -7 D
+-6 -8 D
+-6 -7 D
+-6 -7 D
+-6 -8 D
+-6 -7 D
+-6 -8 D
+-6 -8 D
+-6 -7 D
+-6 -8 D
+-6 -8 D
+-6 -8 D
+-6 -7 D
+-6 -8 D
+-6 -8 D
+-6 -8 D
+-6 -8 D
+-6 -8 D
+-6 -9 D
+-6 -8 D
+-6 -8 D
+-5 -8 D
+-6 -9 D
+-6 -8 D
+-6 -9 D
+-6 -8 D
+-5 -9 D
+-6 -8 D
+-6 -9 D
+-5 -9 D
+-6 -9 D
+-6 -8 D
+-5 -9 D
+-6 -9 D
+-5 -9 D
+-6 -9 D
+-5 -10 D
+-6 -9 D
+-5 -9 D
+-6 -9 D
+-5 -10 D
+-5 -9 D
+-6 -9 D
+-5 -10 D
+-5 -9 D
+-5 -10 D
+-5 -10 D
+-6 -9 D
+-5 -10 D
+-5 -10 D
+-5 -10 D
+-5 -10 D
+-5 -10 D
+-4 -10 D
+-5 -10 D
+-5 -10 D
+-5 -10 D
+-4 -11 D
+-5 -10 D
+-5 -10 D
+-4 -11 D
+-5 -10 D
+-4 -11 D
+-4 -10 D
+-5 -11 D
+-4 -11 D
+-4 -11 D
+-4 -10 D
+-5 -11 D
+-4 -11 D
+-4 -11 D
+-4 -11 D
+-3 -11 D
+-4 -11 D
+-4 -11 D
+-4 -12 D
+-3 -11 D
+-4 -11 D
+-3 -11 D
+-4 -12 D
+-3 -11 D
+-3 -12 D
+-3 -11 D
+-4 -12 D
+-3 -11 D
+-3 -12 D
+-3 -12 D
+-2 -11 D
+-3 -12 D
+-3 -12 D
+-2 -12 D
+-3 -12 D
+-2 -11 D
+-3 -12 D
+-2 -12 D
+-2 -12 D
+-3 -12 D
+-2 -12 D
+-2 -12 D
+-1 -13 D
+-2 -12 D
+-2 -12 D
+-2 -12 D
+-1 -12 D
+-2 -12 D
+-1 -13 D
+-1 -12 D
+-1 -12 D
+-2 -12 D
+-1 -13 D
+-1 -12 D
+0 -12 D
+-1 -13 D
+-1 -12 D
+0 -13 D
+-1 -12 D
+0 -12 D
+-1 -13 D
+0 -12 D
+0 -12 D
+0 -13 D
+0 -12 D
+0 -13 D
+0 -12 D
+1 -12 D
+0 -13 D
+1 -12 D
+0 -13 D
+1 -12 D
+1 -12 D
+0 -13 D
+1 -12 D
+1 -12 D
+2 -13 D
+1 -12 D
+1 -12 D
+1 -12 D
+2 -13 D
+1 -12 D
+2 -12 D
+2 -12 D
+2 -12 D
+1 -12 D
+2 -12 D
+2 -12 D
+3 -12 D
+2 -12 D
+2 -12 D
+3 -12 D
+2 -12 D
+3 -12 D
+2 -12 D
+3 -12 D
+3 -11 D
+2 -12 D
+3 -12 D
+3 -11 D
+3 -12 D
+4 -12 D
+3 -11 D
+3 -12 D
+3 -11 D
+4 -11 D
+3 -12 D
+4 -11 D
+3 -11 D
+4 -11 D
+4 -12 D
+4 -11 D
+3 -11 D
+4 -11 D
+4 -11 D
+4 -11 D
+5 -10 D
+4 -11 D
+4 -11 D
+4 -11 D
+5 -10 D
+4 -11 D
+4 -10 D
+5 -11 D
+4 -10 D
+5 -11 D
+5 -10 D
+4 -10 D
+5 -11 D
+5 -10 D
+5 -10 D
+4 -10 D
+5 -10 D
+5 -10 D
+5 -10 D
+5 -9 D
+5 -10 D
+6 -10 D
+5 -10 D
+5 -9 D
+5 -10 D
+5 -9 D
+6 -10 D
+5 -9 D
+5 -10 D
+6 -9 D
+5 -9 D
+6 -9 D
+5 -9 D
+6 -9 D
+5 -9 D
+6 -9 D
+5 -9 D
+6 -9 D
+6 -9 D
+5 -9 D
+6 -8 D
+6 -9 D
+5 -9 D
+6 -8 D
+6 -9 D
+6 -8 D
+6 -8 D
+5 -9 D
+6 -8 D
+6 -8 D
+6 -8 D
+6 -8 D
+6 -8 D
+6 -8 D
+6 -8 D
+6 -8 D
+6 -8 D
+6 -8 D
+6 -8 D
+6 -8 D
+6 -7 D
+6 -8 D
+6 -7 D
+6 -8 D
+6 -7 D
+6 -8 D
+6 -7 D
+6 -8 D
+7 -7 D
+6 -7 D
+6 -7 D
+6 -7 D
+6 -8 D
+6 -7 D
+7 -7 D
+6 -7 D
+6 -7 D
+6 -6 D
+6 -7 D
+6 -7 D
+7 -7 D
+6 -7 D
+6 -6 D
+6 -7 D
+6 -7 D
+7 -6 D
+6 -7 D
+6 -6 D
+6 -7 D
+7 -6 D
+6 -6 D
+6 -7 D
+6 -6 D
+6 -6 D
+7 -7 D
+6 -6 D
+6 -6 D
+6 -6 D
+7 -6 D
+6 -6 D
+6 -6 D
+6 -6 D
+6 -6 D
+7 -6 D
+6 -6 D
+6 -6 D
+6 -6 D
+7 -5 D
+6 -6 D
+6 -6 D
+6 -5 D
+6 -6 D
+7 -6 D
+6 -5 D
+6 -6 D
+6 -5 D
+6 -6 D
+7 -5 D
+6 -6 D
+6 -5 D
+6 -6 D
+6 -5 D
+6 -5 D
+7 -5 D
+6 -6 D
+6 -5 D
+6 -5 D
+6 -5 D
+6 -6 D
+6 -5 D
+7 -5 D
+6 -5 D
+6 -5 D
+6 -5 D
+6 -5 D
+6 -5 D
+6 -5 D
+6 -5 D
+7 -5 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -5 D
+6 -5 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -5 D
+5 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -4 D
+5 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+5 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -3 D
+5 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+5 -4 D
+6 -3 D
+6 -4 D
+6 -4 D
+5 -4 D
+6 -4 D
+6 -3 D
+6 -4 D
+5 -4 D
+6 -4 D
+6 -3 D
+5 -4 D
+6 -4 D
+6 -3 D
+6 -4 D
+5 -4 D
+6 -3 D
+6 -4 D
+5 -4 D
+6 -3 D
+6 -4 D
+5 -3 D
+6 -4 D
+6 -4 D
+5 -3 D
+6 -4 D
+6 -3 D
+5 -4 D
+6 -3 D
+6 -4 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -4 D
+6 -3 D
+5 -4 D
+6 -3 D
+5 -4 D
+6 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -4 D
+6 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -4 D
+6 -3 D
+5 -4 D
+6 -3 D
+6 -3 D
+5 -4 D
+6 -3 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -4 D
+6 -3 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -4 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -4 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -4 D
+6 -3 D
+5 -3 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -4 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -4 D
+6 -3 D
+5 -3 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -3 D
+5 -4 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -4 D
+5 -3 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -3 D
+S
+3600 774 M
+-169 97 D
+-16 10 D
+-39 22 D
+-16 10 D
+-66 39 D
+-144 87 D
+-51 31 D
+-45 29 D
+-80 51 D
+-104 69 D
+-99 69 D
+-84 61 D
+-84 65 D
+-98 79 D
+-86 75 D
+-56 52 D
+-69 66 D
+-24 26 D
+-7 6 D
+-18 20 D
+-7 6 D
+-55 61 D
+-68 79 D
+-84 109 D
+-47 67 D
+-45 70 D
+-38 65 D
+-21 37 D
+-10 20 D
+-11 19 D
+-39 80 D
+-36 84 D
+-29 76 D
+-32 101 D
+-19 70 D
+-27 130 D
+-13 98 D
+-6 61 D
+-4 111 D
+1 75 D
+5 86 D
+10 86 D
+9 60 D
+20 96 D
+14 58 D
+31 102 D
+23 67 D
+13 32 D
+31 74 D
+43 91 D
+52 96 D
+61 99 D
+35 51 D
+23 33 D
+72 95 D
+36 45 D
+56 64 D
+49 54 D
+7 6 D
+18 20 D
+13 12 D
+43 44 D
+56 54 D
+13 11 D
+49 45 D
+19 16 D
+61 53 D
+62 50 D
+90 70 D
+90 66 D
+18 12 D
+11 9 D
+100 69 D
+35 23 D
+108 71 D
+124 77 D
+45 27 D
+11 7 D
+55 33 D
+45 26 D
+16 10 D
+55 32 D
+16 10 D
+39 22 D
+21 13 D
+44 25 D
+16 10 D
+82 47 D
+S
+3600 774 M
+0 4642 D
+S
+3600 774 M
+169 97 D
+16 10 D
+39 22 D
+16 10 D
+66 39 D
+144 87 D
+51 31 D
+45 29 D
+80 51 D
+104 69 D
+99 69 D
+84 61 D
+84 65 D
+98 79 D
+86 75 D
+56 52 D
+69 66 D
+24 26 D
+7 6 D
+18 20 D
+7 6 D
+55 61 D
+68 79 D
+84 109 D
+47 67 D
+45 70 D
+38 65 D
+21 37 D
+10 20 D
+11 19 D
+39 80 D
+36 84 D
+29 76 D
+32 101 D
+19 70 D
+27 130 D
+13 98 D
+6 61 D
+4 111 D
+-1 75 D
+-5 86 D
+-10 86 D
+-9 60 D
+-20 96 D
+-14 58 D
+-31 102 D
+-23 67 D
+-13 32 D
+-31 74 D
+-43 91 D
+-52 96 D
+-61 99 D
+-35 51 D
+-23 33 D
+-72 95 D
+-36 45 D
+-56 64 D
+-49 54 D
+-7 6 D
+-18 20 D
+-13 12 D
+-43 44 D
+-56 54 D
+-13 11 D
+-49 45 D
+-19 16 D
+-61 53 D
+-62 50 D
+-90 70 D
+-90 66 D
+-18 12 D
+-11 9 D
+-100 69 D
+-35 23 D
+-108 71 D
+-124 77 D
+-45 27 D
+-11 7 D
+-55 33 D
+-45 26 D
+-16 10 D
+-55 32 D
+-16 10 D
+-39 22 D
+-21 13 D
+-44 25 D
+-16 10 D
+-82 47 D
+S
+3600 774 M
+5 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -4 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -4 D
+6 -3 D
+5 -3 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -3 D
+5 -4 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -4 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -3 D
+5 -4 D
+6 -3 D
+5 -3 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -4 D
+6 -3 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -4 D
+6 -3 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+6 -4 D
+5 -3 D
+6 -3 D
+5 -4 D
+6 -3 D
+5 -4 D
+6 -3 D
+6 -3 D
+5 -4 D
+6 -3 D
+5 -4 D
+6 -3 D
+6 -4 D
+5 -3 D
+6 -4 D
+5 -3 D
+6 -4 D
+6 -3 D
+5 -3 D
+6 -4 D
+5 -4 D
+6 -3 D
+6 -4 D
+5 -3 D
+6 -4 D
+6 -3 D
+5 -4 D
+6 -3 D
+6 -4 D
+5 -4 D
+6 -3 D
+6 -4 D
+5 -3 D
+6 -4 D
+6 -4 D
+5 -3 D
+6 -4 D
+6 -4 D
+6 -3 D
+5 -4 D
+6 -4 D
+6 -3 D
+5 -4 D
+6 -4 D
+6 -4 D
+6 -3 D
+5 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+5 -4 D
+6 -3 D
+6 -4 D
+6 -4 D
+6 -4 D
+5 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+5 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+5 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -5 D
+5 -4 D
+6 -4 D
+6 -4 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -5 D
+6 -4 D
+6 -5 D
+6 -5 D
+6 -5 D
+6 -5 D
+6 -5 D
+7 -5 D
+6 -4 D
+6 -5 D
+6 -5 D
+6 -5 D
+6 -5 D
+6 -5 D
+6 -6 D
+7 -5 D
+6 -5 D
+6 -5 D
+6 -5 D
+6 -5 D
+6 -6 D
+6 -5 D
+7 -5 D
+6 -5 D
+6 -6 D
+6 -5 D
+6 -6 D
+6 -5 D
+2 -1 D
+1 -2 D
+4756 9286 M
+2 -1 D
+5 -5 D
+6 -5 D
+6 -6 D
+6 -5 D
+6 -6 D
+7 -6 D
+6 -5 D
+6 -6 D
+6 -6 D
+6 -5 D
+7 -6 D
+6 -6 D
+6 -6 D
+6 -6 D
+7 -6 D
+6 -6 D
+6 -6 D
+6 -6 D
+6 -6 D
+7 -6 D
+6 -6 D
+6 -6 D
+6 -6 D
+7 -6 D
+6 -7 D
+6 -6 D
+6 -6 D
+6 -7 D
+7 -6 D
+6 -7 D
+6 -6 D
+6 -7 D
+7 -6 D
+6 -7 D
+6 -6 D
+6 -7 D
+6 -7 D
+7 -7 D
+6 -6 D
+6 -7 D
+6 -7 D
+6 -7 D
+6 -7 D
+7 -7 D
+6 -7 D
+6 -7 D
+6 -7 D
+6 -8 D
+6 -7 D
+7 -7 D
+6 -8 D
+6 -7 D
+6 -7 D
+6 -8 D
+6 -7 D
+6 -8 D
+6 -8 D
+6 -7 D
+6 -8 D
+6 -8 D
+6 -8 D
+6 -7 D
+6 -8 D
+6 -8 D
+6 -8 D
+6 -8 D
+6 -8 D
+6 -9 D
+6 -8 D
+6 -8 D
+5 -8 D
+6 -9 D
+6 -8 D
+6 -9 D
+6 -8 D
+5 -9 D
+6 -8 D
+6 -9 D
+5 -9 D
+6 -9 D
+6 -8 D
+5 -9 D
+6 -9 D
+5 -9 D
+6 -9 D
+5 -10 D
+6 -9 D
+5 -9 D
+6 -9 D
+5 -10 D
+5 -9 D
+6 -9 D
+5 -10 D
+5 -9 D
+5 -10 D
+5 -10 D
+6 -9 D
+5 -10 D
+5 -10 D
+5 -10 D
+5 -10 D
+5 -10 D
+4 -10 D
+5 -10 D
+5 -10 D
+5 -10 D
+4 -11 D
+5 -10 D
+5 -10 D
+4 -11 D
+5 -10 D
+4 -11 D
+4 -10 D
+5 -11 D
+4 -11 D
+4 -11 D
+4 -10 D
+5 -11 D
+4 -11 D
+4 -11 D
+4 -11 D
+3 -11 D
+4 -11 D
+4 -11 D
+4 -12 D
+3 -11 D
+4 -11 D
+3 -11 D
+4 -12 D
+3 -11 D
+3 -12 D
+3 -11 D
+4 -12 D
+3 -11 D
+3 -12 D
+3 -12 D
+2 -11 D
+3 -12 D
+3 -12 D
+2 -12 D
+3 -12 D
+2 -11 D
+3 -12 D
+2 -12 D
+2 -12 D
+3 -12 D
+2 -12 D
+2 -12 D
+1 -13 D
+2 -12 D
+2 -12 D
+2 -12 D
+1 -12 D
+2 -12 D
+1 -13 D
+1 -12 D
+1 -12 D
+2 -12 D
+1 -13 D
+1 -12 D
+0 -12 D
+1 -13 D
+1 -12 D
+0 -13 D
+1 -12 D
+0 -12 D
+1 -13 D
+0 -12 D
+0 -12 D
+0 -13 D
+0 -12 D
+0 -13 D
+0 -12 D
+-1 -12 D
+0 -13 D
+-1 -12 D
+0 -13 D
+-1 -12 D
+-1 -12 D
+0 -13 D
+-1 -12 D
+-1 -12 D
+-2 -13 D
+-1 -12 D
+-1 -12 D
+-1 -12 D
+-2 -13 D
+-1 -12 D
+-2 -12 D
+-2 -12 D
+-2 -12 D
+-1 -12 D
+-2 -12 D
+-2 -12 D
+-3 -12 D
+-2 -12 D
+-2 -12 D
+-3 -12 D
+-2 -12 D
+-3 -12 D
+-2 -12 D
+-3 -12 D
+-3 -11 D
+-2 -12 D
+-3 -12 D
+-3 -11 D
+-3 -12 D
+-4 -12 D
+-3 -11 D
+-3 -12 D
+-3 -11 D
+-4 -11 D
+-3 -12 D
+-4 -11 D
+-3 -11 D
+-4 -11 D
+-4 -12 D
+-4 -11 D
+-3 -11 D
+-4 -11 D
+-4 -11 D
+-4 -11 D
+-5 -10 D
+-4 -11 D
+-4 -11 D
+-4 -11 D
+-5 -10 D
+-4 -11 D
+-4 -10 D
+-5 -11 D
+-4 -10 D
+-5 -11 D
+-5 -10 D
+-4 -10 D
+-5 -11 D
+-5 -10 D
+-5 -10 D
+-4 -10 D
+-5 -10 D
+-5 -10 D
+-5 -10 D
+-5 -9 D
+-5 -10 D
+-6 -10 D
+-5 -10 D
+-5 -9 D
+-5 -10 D
+-5 -9 D
+-6 -10 D
+-5 -9 D
+-5 -10 D
+-6 -9 D
+-5 -9 D
+-6 -9 D
+-5 -9 D
+-6 -9 D
+-5 -9 D
+-6 -9 D
+-5 -9 D
+-6 -9 D
+-6 -9 D
+-5 -9 D
+-6 -8 D
+-6 -9 D
+-5 -9 D
+-6 -8 D
+-6 -9 D
+-6 -8 D
+-6 -8 D
+-5 -9 D
+-6 -8 D
+-6 -8 D
+-6 -8 D
+-6 -8 D
+-6 -8 D
+-6 -8 D
+-6 -8 D
+-6 -8 D
+-6 -8 D
+-6 -8 D
+-6 -8 D
+-6 -8 D
+-6 -7 D
+-6 -8 D
+-6 -7 D
+-6 -8 D
+-6 -7 D
+-6 -8 D
+-6 -7 D
+-6 -8 D
+-7 -7 D
+-6 -7 D
+-6 -7 D
+-6 -7 D
+-6 -8 D
+-6 -7 D
+-7 -7 D
+-6 -7 D
+-6 -7 D
+-6 -6 D
+-6 -7 D
+-6 -7 D
+-7 -7 D
+-6 -7 D
+-6 -6 D
+-6 -7 D
+-6 -7 D
+-7 -6 D
+-6 -7 D
+-6 -6 D
+-6 -7 D
+-7 -6 D
+-6 -6 D
+-6 -7 D
+-6 -6 D
+-6 -6 D
+-7 -7 D
+-6 -6 D
+-6 -6 D
+-6 -6 D
+-7 -6 D
+-6 -6 D
+-6 -6 D
+-6 -6 D
+-6 -6 D
+-7 -6 D
+-6 -6 D
+-6 -6 D
+-6 -6 D
+-7 -5 D
+-6 -6 D
+-6 -6 D
+-6 -5 D
+-6 -6 D
+-7 -6 D
+-6 -5 D
+-6 -6 D
+-6 -5 D
+-6 -6 D
+-7 -5 D
+-6 -6 D
+-6 -5 D
+-6 -6 D
+-6 -5 D
+-6 -5 D
+-7 -5 D
+-6 -6 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-6 -6 D
+-6 -5 D
+-7 -5 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-7 -5 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -5 D
+-5 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -5 D
+-6 -4 D
+-6 -4 D
+-5 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-5 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -3 D
+-5 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-6 -4 D
+-5 -4 D
+-6 -3 D
+-6 -4 D
+-6 -4 D
+-5 -4 D
+-6 -4 D
+-6 -3 D
+-6 -4 D
+-5 -4 D
+-6 -4 D
+-6 -3 D
+-5 -4 D
+-6 -4 D
+-6 -3 D
+-6 -4 D
+-5 -4 D
+-6 -3 D
+-6 -4 D
+-5 -4 D
+-6 -3 D
+-6 -4 D
+-5 -3 D
+-6 -4 D
+-6 -4 D
+-5 -3 D
+-6 -4 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-6 -4 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -4 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-5 -3 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -4 D
+-6 -3 D
+-5 -3 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-5 -4 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+-6 -4 D
+-5 -3 D
+-6 -3 D
+-5 -3 D
+S
+3600 774 M
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -2 D
+3600 9285 M
+0 -5 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+0 -6 D
+0 -6 D
+0 -7 D
+0 -6 D
+S
+3600 9280 M
+-8 0 D
+-8 0 D
+-8 1 D
+-8 0 D
+-8 0 D
+-8 1 D
+-9 0 D
+-8 1 D
+-8 0 D
+-8 1 D
+-5 1 D
+-21 2 D
+3535 -2 M
+-21 2 D
+-3 0 D
+-8 1 D
+-8 1 D
+-8 1 D
+-8 1 D
+-8 1 D
+-8 2 D
+-8 1 D
+-8 1 D
+-8 2 D
+-8 2 D
+-8 1 D
+-8 2 D
+-8 2 D
+-8 2 D
+-8 2 D
+-8 2 D
+-8 2 D
+-8 2 D
+-7 2 D
+-8 2 D
+-8 3 D
+-8 2 D
+-8 3 D
+-7 3 D
+-8 2 D
+-8 3 D
+-8 3 D
+-7 3 D
+-8 3 D
+-8 3 D
+-7 3 D
+-8 4 D
+-8 3 D
+-7 3 D
+-8 4 D
+-7 4 D
+-8 3 D
+-7 4 D
+-8 4 D
+-7 4 D
+-7 4 D
+-8 4 D
+-7 4 D
+-7 4 D
+-8 5 D
+-7 4 D
+-7 5 D
+-7 4 D
+-7 5 D
+-7 4 D
+-7 5 D
+-7 5 D
+-7 5 D
+-7 5 D
+-7 5 D
+-7 6 D
+-7 5 D
+-6 5 D
+-7 6 D
+-7 5 D
+-6 6 D
+-7 5 D
+-6 6 D
+-7 6 D
+-6 6 D
+-6 6 D
+-7 6 D
+-6 6 D
+-6 6 D
+-6 7 D
+-6 6 D
+-6 7 D
+-6 6 D
+-6 7 D
+-5 7 D
+-6 6 D
+-6 7 D
+-5 7 D
+-6 7 D
+-5 7 D
+-6 7 D
+-5 7 D
+-5 8 D
+-5 7 D
+-5 8 D
+-5 7 D
+-5 8 D
+-5 7 D
+-5 8 D
+-4 8 D
+-5 7 D
+-4 8 D
+-5 8 D
+-4 8 D
+-4 8 D
+-4 9 D
+-4 8 D
+-4 8 D
+-4 8 D
+-4 9 D
+-3 8 D
+-4 9 D
+-3 8 D
+-4 9 D
+-3 8 D
+-3 9 D
+-3 9 D
+-3 8 D
+-3 9 D
+-2 9 D
+-3 9 D
+-2 9 D
+-3 9 D
+-2 9 D
+-2 9 D
+-2 9 D
+-2 9 D
+-2 9 D
+-2 9 D
+-1 10 D
+-2 9 D
+-1 9 D
+-2 9 D
+-1 9 D
+-1 10 D
+-1 9 D
+0 9 D
+-1 10 D
+-1 9 D
+0 9 D
+0 10 D
+-1 9 D
+0 9 D
+0 10 D
+1 9 D
+0 9 D
+0 10 D
+1 9 D
+0 9 D
+1 10 D
+1 9 D
+1 9 D
+1 10 D
+1 9 D
+1 9 D
+2 9 D
+1 10 D
+2 9 D
+2 9 D
+2 9 D
+2 9 D
+2 9 D
+2 9 D
+2 9 D
+3 9 D
+2 9 D
+3 9 D
+3 9 D
+3 8 D
+3 9 D
+3 9 D
+3 8 D
+3 9 D
+4 9 D
+3 8 D
+4 9 D
+3 8 D
+4 8 D
+4 9 D
+4 8 D
+4 8 D
+4 8 D
+4 8 D
+5 8 D
+4 8 D
+5 8 D
+4 8 D
+5 7 D
+5 8 D
+4 8 D
+5 7 D
+5 8 D
+5 7 D
+6 7 D
+5 8 D
+5 7 D
+5 7 D
+6 7 D
+5 7 D
+6 7 D
+6 7 D
+5 6 D
+6 7 D
+6 6 D
+6 7 D
+6 6 D
+6 7 D
+6 6 D
+6 6 D
+7 6 D
+6 6 D
+6 6 D
+7 6 D
+6 6 D
+7 6 D
+6 5 D
+7 6 D
+6 6 D
+7 5 D
+7 5 D
+7 6 D
+6 5 D
+7 5 D
+7 5 D
+7 5 D
+7 5 D
+7 4 D
+7 5 D
+7 5 D
+8 4 D
+7 5 D
+7 4 D
+7 4 D
+8 4 D
+7 5 D
+7 4 D
+8 4 D
+7 3 D
+7 4 D
+8 4 D
+7 4 D
+8 3 D
+8 4 D
+7 3 D
+8 3 D
+7 4 D
+8 3 D
+8 3 D
+7 3 D
+8 3 D
+8 3 D
+8 2 D
+7 3 D
+8 3 D
+8 2 D
+8 3 D
+8 2 D
+8 2 D
+7 3 D
+8 2 D
+8 2 D
+8 2 D
+8 2 D
+8 2 D
+8 1 D
+8 2 D
+8 2 D
+8 1 D
+8 2 D
+8 1 D
+8 1 D
+8 2 D
+8 1 D
+8 1 D
+8 1 D
+8 1 D
+8 1 D
+8 0 D
+8 1 D
+8 1 D
+8 0 D
+9 1 D
+8 0 D
+8 0 D
+8 0 D
+8 1 D
+8 0 D
+8 0 D
+8 0 D
+8 -1 D
+8 0 D
+8 0 D
+8 0 D
+9 -1 D
+8 0 D
+8 -1 D
+8 -1 D
+8 0 D
+8 -1 D
+8 -1 D
+8 -1 D
+8 -1 D
+8 -1 D
+8 -2 D
+8 -1 D
+8 -1 D
+8 -2 D
+8 -1 D
+8 -2 D
+8 -2 D
+8 -1 D
+8 -2 D
+8 -2 D
+8 -2 D
+8 -2 D
+8 -2 D
+7 -3 D
+8 -2 D
+8 -2 D
+8 -3 D
+8 -2 D
+8 -3 D
+7 -3 D
+8 -2 D
+8 -3 D
+8 -3 D
+7 -3 D
+8 -3 D
+8 -3 D
+7 -4 D
+8 -3 D
+7 -3 D
+8 -4 D
+8 -3 D
+7 -4 D
+8 -4 D
+7 -4 D
+7 -3 D
+8 -4 D
+7 -4 D
+7 -5 D
+8 -4 D
+7 -4 D
+7 -4 D
+7 -5 D
+8 -4 D
+7 -5 D
+7 -5 D
+7 -4 D
+7 -5 D
+7 -5 D
+7 -5 D
+7 -5 D
+6 -5 D
+7 -6 D
+7 -5 D
+7 -5 D
+6 -6 D
+7 -6 D
+6 -5 D
+7 -6 D
+6 -6 D
+7 -6 D
+6 -6 D
+6 -6 D
+7 -6 D
+6 -6 D
+6 -6 D
+6 -7 D
+6 -6 D
+6 -7 D
+6 -6 D
+6 -7 D
+5 -6 D
+6 -7 D
+6 -7 D
+5 -7 D
+6 -7 D
+5 -7 D
+5 -7 D
+5 -8 D
+6 -7 D
+5 -7 D
+5 -8 D
+5 -7 D
+4 -8 D
+5 -8 D
+5 -7 D
+4 -8 D
+5 -8 D
+4 -8 D
+5 -8 D
+4 -8 D
+4 -8 D
+4 -8 D
+4 -8 D
+4 -9 D
+4 -8 D
+3 -8 D
+4 -9 D
+3 -8 D
+4 -9 D
+3 -9 D
+3 -8 D
+3 -9 D
+3 -9 D
+3 -8 D
+3 -9 D
+3 -9 D
+2 -9 D
+3 -9 D
+2 -9 D
+2 -9 D
+2 -9 D
+2 -9 D
+2 -9 D
+2 -9 D
+2 -9 D
+1 -10 D
+2 -9 D
+1 -9 D
+1 -9 D
+1 -10 D
+1 -9 D
+1 -9 D
+1 -10 D
+0 -9 D
+1 -9 D
+0 -10 D
+0 -9 D
+1 -9 D
+0 -10 D
+0 -9 D
+-1 -9 D
+0 -10 D
+0 -9 D
+-1 -9 D
+-1 -10 D
+0 -9 D
+-1 -9 D
+-1 -10 D
+-1 -9 D
+-2 -9 D
+-1 -9 D
+-2 -9 D
+-1 -10 D
+-2 -9 D
+-2 -9 D
+-2 -9 D
+-2 -9 D
+-2 -9 D
+-2 -9 D
+-3 -9 D
+-2 -9 D
+-3 -9 D
+-2 -9 D
+-3 -9 D
+-3 -8 D
+-3 -9 D
+-3 -9 D
+-3 -8 D
+-4 -9 D
+-3 -8 D
+-4 -9 D
+-3 -8 D
+-4 -9 D
+-4 -8 D
+-4 -8 D
+-4 -8 D
+-4 -9 D
+-4 -8 D
+-4 -8 D
+-5 -8 D
+-4 -8 D
+-5 -7 D
+-4 -8 D
+-5 -8 D
+-5 -7 D
+-5 -8 D
+-5 -7 D
+-5 -8 D
+-5 -7 D
+-5 -8 D
+-5 -7 D
+-6 -7 D
+-5 -7 D
+-6 -7 D
+-5 -7 D
+-6 -7 D
+-6 -6 D
+-5 -7 D
+-6 -7 D
+-6 -6 D
+-6 -7 D
+-6 -6 D
+-6 -7 D
+-6 -6 D
+-6 -6 D
+-7 -6 D
+-6 -6 D
+-6 -6 D
+-7 -6 D
+-6 -6 D
+-7 -5 D
+-6 -6 D
+-7 -5 D
+-7 -6 D
+-6 -5 D
+-7 -5 D
+-7 -6 D
+-7 -5 D
+-7 -5 D
+-7 -5 D
+-7 -5 D
+-7 -5 D
+-7 -4 D
+-7 -5 D
+-7 -4 D
+-7 -5 D
+-7 -4 D
+-8 -5 D
+-7 -4 D
+-7 -4 D
+-8 -4 D
+-7 -4 D
+-7 -4 D
+-8 -4 D
+-7 -4 D
+-8 -3 D
+-7 -4 D
+-8 -4 D
+-7 -3 D
+-8 -3 D
+-8 -4 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -2 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-3 0 D
+-21 -2 D
+3707 9287 M
+-21 -2 D
+-5 -1 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+S
+3600 7737 M
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-11 0 D
+-12 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-12 0 D
+-11 0 D
+-11 0 D
+-12 0 D
+-12 0 D
+-11 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-11 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-12 0 D
+-11 0 D
+-11 0 D
+-12 0 D
+-11 0 D
+-12 0 D
+-11 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-10 0 D
+-12 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-12 0 D
+-11 0 D
+-9 0 D
+0 3095 M
+3 0 D
+12 0 D
+11 0 D
+11 0 D
+12 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+10 0 D
+11 0 D
+10 0 D
+11 0 D
+10 0 D
+11 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+9 0 D
+10 0 D
+9 0 D
+10 0 D
+9 0 D
+10 0 D
+9 0 D
+9 0 D
+9 0 D
+10 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+7 0 D
+8 0 D
+8 0 D
+8 0 D
+7 0 D
+8 0 D
+7 0 D
+8 0 D
+8 0 D
+7 0 D
+7 0 D
+8 0 D
+7 0 D
+8 0 D
+7 0 D
+7 0 D
+7 0 D
+8 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+6 0 D
+7 0 D
+7 0 D
+7 0 D
+6 0 D
+7 0 D
+7 0 D
+6 0 D
+7 0 D
+7 0 D
+6 0 D
+7 0 D
+6 0 D
+7 0 D
+6 0 D
+6 0 D
+7 0 D
+6 0 D
+6 0 D
+7 0 D
+6 0 D
+12 0 D
+13 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+11 0 D
+12 0 D
+11 0 D
+12 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+10 0 D
+11 0 D
+10 0 D
+11 0 D
+10 0 D
+10 0 D
+10 0 D
+11 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+9 0 D
+10 0 D
+10 0 D
+10 0 D
+9 0 D
+10 0 D
+9 0 D
+10 0 D
+9 0 D
+9 0 D
+10 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+8 0 D
+9 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+7 0 D
+8 0 D
+8 0 D
+8 0 D
+7 0 D
+8 0 D
+7 0 D
+8 0 D
+7 0 D
+8 0 D
+7 0 D
+8 0 D
+7 0 D
+8 0 D
+7 0 D
+7 0 D
+7 0 D
+8 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+6 0 D
+7 0 D
+7 0 D
+6 0 D
+7 0 D
+7 0 D
+6 0 D
+7 0 D
+7 0 D
+6 0 D
+7 0 D
+6 0 D
+7 0 D
+6 0 D
+7 0 D
+6 0 D
+6 0 D
+7 0 D
+6 0 D
+6 0 D
+7 0 D
+6 0 D
+6 0 D
+13 0 D
+12 0 D
+13 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+11 0 D
+12 0 D
+12 0 D
+11 0 D
+12 0 D
+11 0 D
+12 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+10 0 D
+11 0 D
+11 0 D
+10 0 D
+11 0 D
+10 0 D
+10 0 D
+11 0 D
+10 0 D
+10 0 D
+10 0 D
+11 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+9 0 D
+10 0 D
+10 0 D
+10 0 D
+9 0 D
+10 0 D
+9 0 D
+10 0 D
+10 0 D
+9 0 D
+10 0 D
+9 0 D
+9 0 D
+10 0 D
+9 0 D
+9 0 D
+10 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+10 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+8 0 D
+9 0 D
+8 0 D
+9 0 D
+8 0 D
+9 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+9 0 D
+8 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+10 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+10 0 D
+9 0 D
+9 0 D
+10 0 D
+9 0 D
+9 0 D
+10 0 D
+9 0 D
+10 0 D
+9 0 D
+10 0 D
+10 0 D
+9 0 D
+10 0 D
+10 0 D
+9 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+11 0 D
+10 0 D
+10 0 D
+11 0 D
+10 0 D
+11 0 D
+10 0 D
+11 0 D
+10 0 D
+11 0 D
+11 0 D
+11 0 D
+10 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+12 0 D
+11 0 D
+11 0 D
+11 0 D
+12 0 D
+11 0 D
+12 0 D
+11 0 D
+12 0 D
+11 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+13 0 D
+12 0 D
+12 0 D
+7 0 D
+6 0 D
+6 0 D
+6 0 D
+7 0 D
+6 0 D
+6 0 D
+7 0 D
+6 0 D
+7 0 D
+6 0 D
+7 0 D
+6 0 D
+7 0 D
+6 0 D
+7 0 D
+6 0 D
+7 0 D
+7 0 D
+6 0 D
+7 0 D
+7 0 D
+6 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+6 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+8 0 D
+7 0 D
+7 0 D
+7 0 D
+8 0 D
+7 0 D
+7 0 D
+8 0 D
+7 0 D
+7 0 D
+8 0 D
+7 0 D
+8 0 D
+7 0 D
+8 0 D
+8 0 D
+7 0 D
+8 0 D
+8 0 D
+7 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+10 0 D
+9 0 D
+9 0 D
+9 0 D
+10 0 D
+9 0 D
+10 0 D
+9 0 D
+10 0 D
+9 0 D
+10 0 D
+10 0 D
+10 0 D
+9 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+11 0 D
+10 0 D
+10 0 D
+11 0 D
+10 0 D
+11 0 D
+10 0 D
+11 0 D
+11 0 D
+10 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+12 0 D
+11 0 D
+11 0 D
+12 0 D
+12 0 D
+11 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+12 0 D
+13 0 D
+6 0 D
+6 0 D
+7 0 D
+6 0 D
+6 0 D
+7 0 D
+6 0 D
+6 0 D
+7 0 D
+6 0 D
+7 0 D
+6 0 D
+7 0 D
+7 0 D
+6 0 D
+7 0 D
+7 0 D
+6 0 D
+7 0 D
+7 0 D
+7 0 D
+6 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+7 0 D
+8 0 D
+7 0 D
+7 0 D
+7 0 D
+8 0 D
+7 0 D
+8 0 D
+7 0 D
+7 0 D
+8 0 D
+8 0 D
+7 0 D
+8 0 D
+7 0 D
+8 0 D
+8 0 D
+8 0 D
+7 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+8 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+9 0 D
+8 0 D
+9 0 D
+9 0 D
+9 0 D
+9 0 D
+10 0 D
+9 0 D
+9 0 D
+9 0 D
+10 0 D
+9 0 D
+10 0 D
+9 0 D
+10 0 D
+9 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+10 0 D
+11 0 D
+10 0 D
+11 0 D
+10 0 D
+11 0 D
+10 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+11 0 D
+12 0 D
+11 0 D
+11 0 D
+12 0 D
+3 0 D
+7200 7737 M
+-3 0 D
+-12 0 D
+-11 0 D
+-11 0 D
+-12 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-11 0 D
+-12 0 D
+-11 0 D
+-12 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-11 0 D
+-12 0 D
+-12 0 D
+-11 0 D
+-12 0 D
+-11 0 D
+-12 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-11 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-11 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-3 0 D
+S
+3600 6194 M
+-8 0 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-15 -7 D
+-8 -3 D
+-15 -7 D
+-15 -8 D
+-15 -7 D
+-14 -8 D
+-15 -8 D
+-15 -9 D
+-14 -9 D
+-21 -14 D
+-21 -14 D
+-28 -21 D
+-33 -28 D
+-32 -29 D
+-42 -45 D
+-33 -41 D
+-36 -52 D
+-19 -31 D
+-37 -73 D
+-23 -60 D
+-18 -62 D
+-13 -64 D
+-6 -46 D
+-3 -75 D
+4 -65 D
+7 -56 D
+19 -81 D
+25 -70 D
+18 -42 D
+25 -48 D
+33 -54 D
+37 -50 D
+29 -34 D
+30 -32 D
+45 -41 D
+47 -37 D
+42 -29 D
+51 -30 D
+22 -12 D
+61 -27 D
+62 -23 D
+79 -21 D
+64 -11 D
+56 -6 D
+65 -2 D
+57 2 D
+72 8 D
+64 13 D
+63 17 D
+77 29 D
+53 25 D
+37 20 D
+57 37 D
+48 36 D
+45 40 D
+13 12 D
+42 45 D
+38 49 D
+26 37 D
+36 63 D
+23 49 D
+17 43 D
+20 62 D
+17 82 D
+7 74 D
+1 47 D
+-5 74 D
+-11 65 D
+-13 54 D
+-20 61 D
+-26 59 D
+-25 48 D
+-24 39 D
+-36 51 D
+-46 54 D
+-24 25 D
+-19 18 D
+-20 17 D
+-26 22 D
+-35 26 D
+-49 32 D
+-52 29 D
+-45 21 D
+-46 19 D
+-70 22 D
+-64 15 D
+-64 10 D
+-57 4 D
+P S
+8 W
+N 3600 0 M 0 -83 D S
+N 3600 9285 M 0 83 D S
+N 2442 0 M -62 -55 D S
+N 2442 9285 M 63 55 D S
+N 4758 0 M 62 -55 D S
+N 4758 9285 M -63 55 D S
+N 3600 0 M 0 -83 D S
+N 3600 9285 M 0 83 D S
+N 3514 9285 M -83 8 D S
+N 3514 0 M 83 -8 D S
+N 3686 0 M -83 -8 D S
+N 3686 9285 M 83 8 D S
+N 0 7737 M -83 0 D S
+N 0 7737 M -83 0 D S
+N 0 3095 M -83 0 D S
+N 0 3095 M -83 0 D S
+N 7200 3095 M 83 0 D S
+N 7200 3095 M 83 0 D S
+N 7200 7737 M 83 0 D S
+N 7200 7737 M 83 0 D S
+25 W
+2 setlinecap
+N 0 0 M 0 9285 D S
+N 7200 0 M 0 9285 D S
+N 0 0 M 7200 0 D S
+N 0 9285 M 7200 0 D S
+0 setlinecap
+3600 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0°) tc Z
+3600 9451 M (0°) bc Z
+2317 -110 M V -48.6 R (60°) tc Z U
+2567 9395 M V -48.6 R (60°) bc Z U
+4883 -110 M V 48.6 R (-60°) tc Z U
+4633 9395 M V 48.6 R (-60°) bc Z U
+-167 7737 M (0°) mr Z
+-167 7737 M (0°) mr Z
+-167 3095 M (0°) mr Z
+-167 3095 M (0°) mr Z
+7367 3095 M (0°) ml Z
+7367 3095 M (0°) ml Z
+7367 7737 M (0°) ml Z
+7367 7737 M (0°) ml Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt grdcontour dist.nc -C1000 -Wc1p,red -R0/360/-80/80 -JT180/-30/6i
+%@PROJ: tmerc 0.00000000 360.00000000 -90.00000000 90.00000000 -15512672.854 15512672.854 -10001965.729 30005897.188 +proj=tmerc +lat_0=-30 +lon_0=180 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 9285 D
+-7200 0 D
+P
+PSL_clip N
+17 W
+1 0 0 C
+2532 4937 M
+33 -31 D
+26 -33 D
+22 -36 D
+17 -40 D
+13 -44 D
+5 -52 D
+-1 -43 D
+-3 -22 D
+-12 -50 D
+-28 -60 D
+-38 -52 D
+-50 -44 D
+-63 -35 D
+-32 -11 D
+-50 -12 D
+-36 -3 D
+-75 6 D
+-67 21 D
+-59 35 D
+-51 46 D
+-41 58 D
+-29 69 D
+-6 35 D
+-5 46 D
+11 91 D
+46 97 D
+60 64 D
+66 43 D
+72 24 D
+76 7 D
+19 -2 D
+63 -11 D
+20 -7 D
+55 -25 D
+P S
+2723 5148 M
+25 -26 D
+23 -26 D
+39 -53 D
+17 -26 D
+30 -56 D
+24 -60 D
+11 -32 D
+17 -73 D
+7 -63 D
+1 -74 D
+-7 -67 D
+-12 -60 D
+-18 -57 D
+-23 -55 D
+-27 -51 D
+-32 -50 D
+-38 -48 D
+-43 -45 D
+-51 -43 D
+-58 -41 D
+-69 -37 D
+-32 -14 D
+-51 -19 D
+-30 -8 D
+-74 -16 D
+-82 -8 D
+-78 1 D
+-77 11 D
+-76 19 D
+-75 28 D
+-73 38 D
+-70 48 D
+-71 65 D
+-55 66 D
+-51 83 D
+-40 94 D
+-21 85 D
+-3 19 D
+-7 113 D
+8 76 D
+7 42 D
+40 120 D
+67 116 D
+78 89 D
+25 22 D
+58 46 D
+84 48 D
+82 35 D
+81 22 D
+78 11 D
+75 3 D
+74 -5 D
+72 -13 D
+71 -20 D
+31 -12 D
+66 -31 D
+50 -29 D
+40 -28 D
+38 -31 D
+P S
+2991 5236 M
+14 -19 D
+35 -57 D
+41 -78 D
+27 -66 D
+23 -69 D
+14 -56 D
+12 -66 D
+7 -67 D
+3 -75 D
+-4 -75 D
+-11 -86 D
+-12 -54 D
+-15 -52 D
+-17 -52 D
+-21 -51 D
+-23 -49 D
+-27 -49 D
+-30 -49 D
+-34 -47 D
+-38 -47 D
+-42 -47 D
+-47 -45 D
+-53 -45 D
+-59 -44 D
+-67 -43 D
+-78 -42 D
+-81 -35 D
+-74 -26 D
+-49 -15 D
+-27 -7 D
+-78 -15 D
+-43 -7 D
+-36 -4 D
+-80 -6 D
+-83 0 D
+-86 7 D
+-87 13 D
+-90 20 D
+-92 29 D
+-94 39 D
+-96 50 D
+-95 63 D
+-93 79 D
+-90 95 D
+-80 113 D
+-68 133 D
+-50 159 D
+-20 154 D
+7 171 D
+40 170 D
+29 73 D
+42 88 D
+66 102 D
+33 42 D
+89 97 D
+32 28 D
+92 72 D
+47 31 D
+73 41 D
+113 52 D
+107 35 D
+100 23 D
+94 13 D
+88 6 D
+83 -1 D
+78 -6 D
+75 -10 D
+70 -15 D
+68 -18 D
+65 -22 D
+62 -25 D
+60 -29 D
+59 -32 D
+80 -52 D
+44 -33 D
+65 -57 D
+26 -25 D
+43 -46 D
+35 -42 D
+P S
+3187 5387 M
+41 -65 D
+39 -70 D
+29 -60 D
+40 -99 D
+28 -93 D
+14 -55 D
+18 -107 D
+6 -69 D
+3 -64 D
+-3 -97 D
+-7 -65 D
+-5 -40 D
+-9 -51 D
+-25 -102 D
+-16 -50 D
+-39 -99 D
+-23 -50 D
+-25 -49 D
+-33 -56 D
+-26 -41 D
+-37 -53 D
+-63 -80 D
+-9 -11 D
+-55 -58 D
+-36 -37 D
+-52 -47 D
+-57 -47 D
+-63 -48 D
+-50 -34 D
+-66 -41 D
+-68 -38 D
+-61 -30 D
+-78 -36 D
+-33 -13 D
+-38 -15 D
+-74 -26 D
+-29 -9 D
+-46 -14 D
+-78 -20 D
+-74 -16 D
+-89 -16 D
+-87 -11 D
+-91 -7 D
+-94 -4 D
+-100 1 D
+-106 7 D
+-111 13 D
+-119 21 D
+-127 30 D
+-136 43 D
+-145 60 D
+-153 81 D
+-162 108 D
+-109 94 D
+-54 52 D
+-156 191 D
+-130 244 D
+-20 57 D
+-56 236 D
+0 316 D
+6 41 D
+76 264 D
+99 193 D
+47 70 D
+183 209 D
+16 14 D
+183 143 D
+57 36 D
+144 79 D
+71 33 D
+126 48 D
+63 21 D
+126 34 D
+40 9 D
+148 26 D
+133 13 D
+120 5 D
+109 -2 D
+101 -7 D
+93 -11 D
+87 -14 D
+81 -17 D
+76 -19 D
+113 -35 D
+92 -34 D
+121 -54 D
+56 -29 D
+54 -31 D
+103 -65 D
+49 -36 D
+81 -65 D
+50 -45 D
+51 -50 D
+59 -65 D
+47 -59 D
+P S
+3447 5416 M
+37 -72 D
+20 -43 D
+8 -16 D
+45 -116 D
+35 -116 D
+12 -52 D
+19 -104 D
+11 -103 D
+4 -103 D
+-1 -52 D
+-3 -52 D
+-11 -104 D
+-19 -104 D
+-27 -103 D
+-16 -51 D
+-18 -51 D
+-22 -55 D
+-47 -101 D
+-24 -46 D
+-28 -50 D
+-64 -99 D
+-38 -53 D
+-55 -69 D
+-64 -74 D
+-49 -51 D
+-58 -57 D
+-58 -52 D
+-60 -50 D
+-49 -39 D
+-71 -51 D
+0 -1 D
+-62 -41 D
+-17 -12 D
+-91 -55 D
+-17 -11 D
+-64 -36 D
+-132 -67 D
+-69 -32 D
+-70 -30 D
+-48 -20 D
+-98 -38 D
+-77 -27 D
+-79 -27 D
+-83 -25 D
+-87 -25 D
+-92 -23 D
+-96 -23 D
+-102 -22 D
+-110 -21 D
+-118 -20 D
+-127 -18 D
+-140 -16 D
+-155 -15 D
+-173 -11 D
+-96 -4 D
+-101 -3 D
+-230 -1 D
+-273 10 D
+-49 4 D
+0 3946 D
+88 6 D
+200 7 D
+121 2 D
+272 -5 D
+237 -15 D
+212 -20 D
+193 -26 D
+115 -18 D
+139 -27 D
+125 -27 D
+119 -29 D
+194 -55 D
+98 -32 D
+152 -56 D
+74 -30 D
+135 -61 D
+124 -63 D
+63 -35 D
+102 -62 D
+100 -67 D
+48 -35 D
+86 -68 D
+4 -2 D
+83 -73 D
+79 -77 D
+73 -79 D
+35 -41 D
+34 -43 D
+41 -56 D
+45 -66 D
+34 -57 D
+P S
+3600 5615 M
+53 -91 D
+15 -27 D
+5 -11 D
+13 -24 D
+40 -87 D
+35 -85 D
+30 -87 D
+25 -88 D
+20 -82 D
+19 -107 D
+9 -78 D
+7 -110 D
+-1 -112 D
+-8 -111 D
+-7 -57 D
+-20 -109 D
+-17 -73 D
+-26 -92 D
+-18 -54 D
+-20 -54 D
+-45 -106 D
+-53 -105 D
+-29 -52 D
+-64 -103 D
+-72 -101 D
+-38 -50 D
+-52 -63 D
+-53 -60 D
+-54 -58 D
+-72 -71 D
+-55 -52 D
+-59 -52 D
+-90 -74 D
+-56 -44 D
+-56 -42 D
+-57 -42 D
+-116 -78 D
+-117 -76 D
+-121 -72 D
+-125 -72 D
+-65 -35 D
+-134 -72 D
+-142 -73 D
+-74 -37 D
+-61 -30 D
+-98 -49 D
+-174 -86 D
+-193 -97 D
+-86 -43 D
+-254 -135 D
+-132 -75 D
+-142 -85 D
+-155 -101 D
+-24 -16 D
+-144 -104 D
+-183 -149 D
+-194 -188 D
+-28 -29 D
+-87 -109 D
+0 -1190 D
+S
+0 9285 M
+0 -1093 D
+50 -69 D
+111 -119 D
+118 -113 D
+184 -154 D
+38 -29 D
+209 -147 D
+233 -144 D
+144 -82 D
+214 -114 D
+282 -142 D
+334 -165 D
+268 -136 D
+240 -131 D
+178 -105 D
+117 -74 D
+109 -74 D
+102 -73 D
+95 -74 D
+46 -37 D
+118 -104 D
+92 -89 D
+39 -40 D
+74 -83 D
+35 -42 D
+35 -43 D
+66 -89 D
+64 -96 D
+5 -9 D
+S
+3600 6012 M
+70 -88 D
+64 -89 D
+23 -34 D
+42 -64 D
+66 -112 D
+48 -94 D
+31 -66 D
+32 -76 D
+40 -110 D
+32 -106 D
+23 -96 D
+16 -83 D
+11 -78 D
+11 -109 D
+3 -84 D
+0 -58 D
+-2 -60 D
+-4 -64 D
+-7 -68 D
+-17 -113 D
+-27 -123 D
+-35 -120 D
+-20 -59 D
+-47 -117 D
+-36 -78 D
+-38 -77 D
+-70 -121 D
+-33 -54 D
+-77 -111 D
+-74 -98 D
+-76 -91 D
+-55 -62 D
+-49 -52 D
+-104 -105 D
+-52 -50 D
+-105 -94 D
+-104 -89 D
+-49 -40 D
+-158 -124 D
+-104 -78 D
+-104 -77 D
+-159 -114 D
+-163 -117 D
+-52 -37 D
+-178 -129 D
+-61 -45 D
+-190 -147 D
+-135 -111 D
+-143 -126 D
+-74 -71 D
+-77 -76 D
+-52 -54 D
+-106 -120 D
+-80 -100 D
+-80 -111 D
+-47 -70 D
+-32 -53 D
+-75 -135 D
+-70 -150 D
+-22 -55 D
+-38 -110 D
+-47 -178 D
+-20 -108 D
+-11 -83 D
+-10 -199 D
+1 -41 D
+S
+744 9285 M
+1 -55 D
+10 -107 D
+35 -202 D
+7 -30 D
+49 -166 D
+46 -122 D
+28 -63 D
+92 -178 D
+95 -153 D
+32 -46 D
+74 -99 D
+54 -67 D
+56 -66 D
+68 -74 D
+44 -46 D
+74 -74 D
+112 -104 D
+106 -93 D
+151 -123 D
+133 -103 D
+175 -130 D
+456 -326 D
+233 -172 D
+60 -46 D
+51 -41 D
+51 -40 D
+96 -80 D
+1 -2 D
+54 -46 D
+99 -89 D
+44 -41 D
+78 -77 D
+41 -43 D
+55 -58 D
+73 -85 D
+1 0 D
+21 -26 D
+S
+3600 6361 M
+110 -119 D
+88 -104 D
+73 -92 D
+61 -83 D
+40 -57 D
+70 -110 D
+61 -106 D
+56 -110 D
+36 -78 D
+35 -86 D
+26 -71 D
+25 -80 D
+29 -103 D
+26 -124 D
+10 -59 D
+13 -110 D
+6 -98 D
+1 -120 D
+-5 -108 D
+-13 -120 D
+-13 -78 D
+-14 -71 D
+-38 -148 D
+-24 -75 D
+-41 -110 D
+-55 -126 D
+-34 -70 D
+-40 -75 D
+-55 -93 D
+-36 -57 D
+-44 -66 D
+-48 -68 D
+-100 -130 D
+-103 -121 D
+-51 -57 D
+-103 -108 D
+-102 -101 D
+-91 -86 D
+-58 -53 D
+-131 -117 D
+-150 -129 D
+-85 -73 D
+-98 -83 D
+-115 -98 D
+-106 -91 D
+-43 -39 D
+-132 -118 D
+-88 -82 D
+-134 -132 D
+-91 -95 D
+-92 -103 D
+-93 -112 D
+-46 -60 D
+-47 -64 D
+-47 -67 D
+-46 -70 D
+-46 -75 D
+-45 -80 D
+-43 -84 D
+-42 -89 D
+-39 -96 D
+-36 -100 D
+-32 -106 D
+-27 -112 D
+-21 -117 D
+-15 -122 D
+-7 -126 D
+0 -90 D
+S
+1401 9285 M
+12 -172 D
+6 -48 D
+14 -85 D
+29 -132 D
+38 -131 D
+46 -128 D
+29 -72 D
+24 -53 D
+61 -120 D
+66 -115 D
+70 -111 D
+1 0 D
+76 -109 D
+76 -98 D
+77 -93 D
+81 -90 D
+80 -86 D
+81 -82 D
+107 -103 D
+133 -121 D
+118 -105 D
+117 -100 D
+325 -276 D
+167 -145 D
+50 -46 D
+34 -29 D
+146 -138 D
+34 -33 D
+14 -15 D
+22 -21 D
+65 -67 D
+S
+3600 6690 M
+32 -31 D
+6 -7 D
+49 -47 D
+120 -123 D
+85 -92 D
+76 -86 D
+104 -125 D
+65 -85 D
+71 -100 D
+66 -99 D
+46 -76 D
+30 -51 D
+57 -108 D
+54 -116 D
+39 -95 D
+25 -67 D
+35 -111 D
+22 -80 D
+24 -105 D
+20 -126 D
+11 -106 D
+6 -94 D
+1 -99 D
+-4 -96 D
+-16 -154 D
+-20 -117 D
+-24 -105 D
+-21 -77 D
+-25 -78 D
+-28 -79 D
+-31 -79 D
+-55 -122 D
+-35 -69 D
+-67 -121 D
+-46 -75 D
+-48 -73 D
+-71 -102 D
+-86 -111 D
+-49 -62 D
+-53 -63 D
+-78 -88 D
+-134 -143 D
+-103 -104 D
+-113 -110 D
+-35 -32 D
+-47 -45 D
+-90 -85 D
+-128 -118 D
+-243 -227 D
+-146 -142 D
+-138 -141 D
+-100 -109 D
+-98 -113 D
+-64 -78 D
+-64 -83 D
+-94 -132 D
+-61 -95 D
+-31 -50 D
+-59 -105 D
+-58 -115 D
+-64 -147 D
+-39 -111 D
+-34 -109 D
+-28 -116 D
+-17 -83 D
+-12 -82 D
+-11 -101 D
+-5 -77 D
+-2 -95 D
+1 -42 D
+S
+1870 9285 M
+1 -52 D
+7 -97 D
+16 -122 D
+14 -78 D
+23 -102 D
+28 -101 D
+39 -117 D
+32 -85 D
+43 -99 D
+48 -97 D
+76 -137 D
+89 -140 D
+77 -110 D
+56 -74 D
+111 -137 D
+111 -125 D
+108 -115 D
+107 -108 D
+138 -133 D
+122 -115 D
+52 -47 D
+3 -4 D
+303 -280 D
+126 -120 D
+S
+3600 7010 M
+45 -42 D
+0 -1 D
+85 -80 D
+152 -146 D
+3 -4 D
+138 -137 D
+93 -98 D
+66 -71 D
+128 -147 D
+99 -124 D
+93 -127 D
+88 -134 D
+43 -71 D
+41 -73 D
+41 -78 D
+39 -81 D
+46 -107 D
+44 -122 D
+22 -68 D
+25 -89 D
+18 -75 D
+27 -148 D
+10 -81 D
+6 -68 D
+5 -143 D
+-3 -103 D
+-10 -128 D
+-15 -104 D
+-29 -143 D
+-22 -85 D
+-25 -85 D
+-32 -90 D
+-35 -90 D
+-38 -86 D
+-40 -82 D
+-41 -78 D
+-47 -82 D
+-50 -81 D
+-80 -120 D
+-46 -64 D
+-94 -121 D
+-95 -114 D
+-97 -109 D
+-48 -53 D
+-157 -162 D
+-90 -89 D
+-51 -49 D
+-18 -19 D
+-190 -181 D
+-111 -105 D
+-64 -62 D
+-115 -112 D
+-71 -70 D
+-65 -67 D
+-2 -1 D
+-31 -34 D
+-44 -45 D
+-48 -51 D
+-28 -32 D
+-29 -31 D
+-80 -94 D
+-8 -8 D
+-69 -84 D
+-101 -132 D
+-107 -157 D
+-65 -105 D
+-62 -112 D
+-59 -121 D
+-57 -133 D
+-55 -159 D
+-27 -95 D
+-26 -115 D
+-21 -125 D
+-13 -116 D
+-6 -131 D
+0 -80 D
+S
+2240 9285 M
+1 -45 D
+11 -138 D
+13 -95 D
+20 -108 D
+25 -104 D
+34 -113 D
+30 -86 D
+34 -87 D
+37 -86 D
+41 -85 D
+45 -84 D
+47 -83 D
+50 -80 D
+74 -110 D
+46 -64 D
+94 -122 D
+63 -76 D
+58 -68 D
+71 -79 D
+98 -104 D
+98 -101 D
+18 -17 D
+32 -33 D
+152 -148 D
+168 -159 D
+S
+3600 7330 M
+97 -93 D
+261 -241 D
+227 -211 D
+166 -160 D
+138 -141 D
+100 -109 D
+66 -74 D
+96 -117 D
+64 -82 D
+93 -132 D
+62 -95 D
+60 -102 D
+58 -109 D
+29 -59 D
+27 -60 D
+39 -94 D
+37 -104 D
+35 -116 D
+26 -107 D
+17 -92 D
+11 -73 D
+12 -110 D
+4 -67 D
+1 -105 D
+-2 -82 D
+-7 -98 D
+-12 -98 D
+-18 -100 D
+-22 -101 D
+-30 -106 D
+-41 -123 D
+-46 -115 D
+-49 -107 D
+-52 -100 D
+-77 -132 D
+-58 -89 D
+-84 -121 D
+-56 -74 D
+-56 -70 D
+-55 -66 D
+-110 -125 D
+-153 -160 D
+-128 -127 D
+-90 -87 D
+-150 -140 D
+-55 -51 D
+-51 -47 D
+-3 -4 D
+-98 -90 D
+-51 -48 D
+-132 -125 D
+-131 -129 D
+-85 -87 D
+-61 -64 D
+-56 -61 D
+-76 -87 D
+-110 -134 D
+-59 -77 D
+-54 -75 D
+-67 -99 D
+-62 -101 D
+-30 -51 D
+-57 -108 D
+-61 -131 D
+-45 -113 D
+-37 -107 D
+-33 -119 D
+-23 -101 D
+-22 -131 D
+-11 -106 D
+-6 -88 D
+-1 -100 D
+1 -22 D
+S
+2554 9285 M
+2 -74 D
+8 -93 D
+20 -142 D
+25 -121 D
+29 -108 D
+43 -131 D
+42 -106 D
+50 -112 D
+34 -69 D
+73 -131 D
+47 -76 D
+71 -107 D
+84 -115 D
+87 -109 D
+66 -79 D
+118 -131 D
+94 -99 D
+3 -2 D
+101 -102 D
+49 -48 D
+S
+3600 7658 M
+102 -104 D
+101 -96 D
+158 -144 D
+67 -58 D
+18 -17 D
+217 -185 D
+279 -237 D
+131 -115 D
+88 -79 D
+122 -114 D
+10 -11 D
+90 -89 D
+136 -145 D
+93 -107 D
+46 -58 D
+47 -60 D
+93 -130 D
+46 -71 D
+77 -130 D
+56 -108 D
+41 -89 D
+43 -106 D
+31 -89 D
+32 -106 D
+27 -111 D
+21 -117 D
+14 -121 D
+6 -126 D
+-1 -128 D
+-11 -131 D
+-19 -132 D
+-29 -132 D
+-37 -129 D
+-17 -51 D
+-29 -77 D
+-53 -124 D
+-60 -119 D
+-68 -121 D
+-76 -118 D
+-77 -108 D
+-76 -98 D
+-75 -89 D
+-73 -83 D
+-78 -84 D
+-80 -82 D
+-160 -153 D
+-79 -71 D
+-152 -135 D
+-146 -125 D
+-200 -171 D
+-61 -53 D
+-59 -51 D
+-51 -44 D
+-99 -88 D
+-98 -90 D
+-48 -46 D
+-79 -76 D
+-116 -119 D
+-100 -111 D
+-53 -61 D
+-69 -85 D
+-81 -108 D
+-34 -47 D
+-20 -31 D
+-37 -55 D
+-65 -108 D
+-49 -89 D
+-55 -112 D
+-35 -82 D
+-28 -72 D
+-25 -69 D
+-25 -82 D
+-25 -94 D
+-22 -107 D
+-13 -80 D
+-15 -143 D
+-3 -98 D
+0 -73 D
+S
+2831 9285 M
+3 -66 D
+8 -102 D
+17 -122 D
+17 -86 D
+18 -73 D
+34 -120 D
+23 -66 D
+25 -66 D
+26 -63 D
+58 -124 D
+50 -94 D
+49 -83 D
+39 -62 D
+47 -71 D
+64 -89 D
+85 -108 D
+86 -101 D
+68 -76 D
+52 -55 D
+S
+3600 8006 M
+54 -64 D
+45 -51 D
+4 -3 D
+52 -56 D
+52 -53 D
+52 -51 D
+53 -50 D
+113 -101 D
+95 -80 D
+155 -124 D
+207 -155 D
+319 -229 D
+112 -79 D
+234 -171 D
+190 -147 D
+135 -111 D
+70 -61 D
+72 -65 D
+74 -71 D
+77 -76 D
+77 -83 D
+80 -91 D
+79 -101 D
+80 -110 D
+55 -83 D
+23 -39 D
+75 -136 D
+68 -149 D
+29 -72 D
+31 -92 D
+46 -177 D
+23 -127 D
+7 -62 D
+10 -197 D
+-4 -117 D
+-8 -85 D
+-35 -200 D
+-12 -51 D
+-43 -143 D
+-54 -143 D
+-19 -41 D
+-87 -171 D
+-14 -25 D
+-83 -133 D
+-44 -64 D
+-61 -81 D
+-67 -83 D
+-42 -49 D
+-111 -121 D
+-112 -110 D
+-87 -81 D
+-133 -115 D
+-107 -88 D
+-105 -82 D
+-103 -78 D
+-100 -73 D
+-80 -58 D
+-111 -81 D
+-91 -65 D
+-74 -53 D
+-98 -71 D
+-82 -60 D
+-59 -44 D
+-93 -70 D
+-69 -54 D
+-101 -81 D
+-90 -74 D
+-55 -48 D
+-92 -83 D
+-89 -85 D
+-108 -112 D
+-81 -91 D
+-82 -100 D
+-28 -36 D
+-69 -95 D
+-72 -110 D
+-53 -91 D
+-49 -93 D
+-52 -114 D
+-33 -83 D
+-36 -106 D
+-20 -67 D
+-20 -81 D
+-19 -99 D
+-12 -79 D
+-10 -105 D
+-4 -90 D
+1 -76 D
+S
+3086 9285 M
+4 -92 D
+9 -84 D
+5 -43 D
+18 -102 D
+17 -76 D
+21 -78 D
+35 -108 D
+22 -59 D
+23 -58 D
+53 -113 D
+29 -55 D
+40 -73 D
+44 -72 D
+47 -71 D
+75 -105 D
+72 -90 D
+S
+3600 8400 M
+48 -73 D
+54 -76 D
+80 -101 D
+43 -50 D
+81 -87 D
+109 -106 D
+111 -96 D
+112 -89 D
+113 -83 D
+115 -78 D
+122 -77 D
+139 -82 D
+103 -59 D
+198 -106 D
+264 -134 D
+111 -56 D
+268 -132 D
+208 -106 D
+230 -124 D
+131 -74 D
+142 -86 D
+194 -129 D
+126 -93 D
+181 -149 D
+192 -188 D
+48 -51 D
+77 -99 D
+0 -2236 D
+-56 -77 D
+-135 -147 D
+-90 -86 D
+-209 -175 D
+-11 -9 D
+-207 -148 D
+-194 -123 D
+-181 -105 D
+-169 -92 D
+-158 -82 D
+-149 -75 D
+-141 -71 D
+-126 -62 D
+-102 -51 D
+-94 -48 D
+-60 -31 D
+-111 -58 D
+-78 -42 D
+-145 -80 D
+-67 -39 D
+-126 -76 D
+-59 -37 D
+-46 -30 D
+-66 -44 D
+-105 -74 D
+-88 -66 D
+-57 -45 D
+-89 -76 D
+-85 -77 D
+-41 -39 D
+-78 -80 D
+-73 -82 D
+-36 -42 D
+-70 -91 D
+-62 -89 D
+-43 -67 D
+-49 -85 D
+-16 -31 D
+-37 -74 D
+-44 -104 D
+-33 -90 D
+-15 -48 D
+-18 -63 D
+-11 -43 D
+-21 -109 D
+-9 -55 D
+-11 -120 D
+-3 -101 D
+1 -41 D
+S
+3327 9285 M
+3 -71 D
+13 -124 D
+17 -98 D
+27 -110 D
+19 -66 D
+35 -97 D
+32 -78 D
+39 -84 D
+55 -102 D
+33 -55 D
+S
+3600 382 M
+21 81 D
+1 0 D
+27 82 D
+17 46 D
+19 46 D
+26 56 D
+14 30 D
+48 88 D
+43 69 D
+45 66 D
+33 45 D
+34 43 D
+1 0 D
+34 41 D
+73 80 D
+78 76 D
+83 74 D
+90 71 D
+95 68 D
+51 34 D
+108 66 D
+117 64 D
+128 62 D
+70 31 D
+105 43 D
+139 51 D
+78 26 D
+95 29 D
+215 57 D
+224 47 D
+195 33 D
+180 24 D
+213 21 D
+259 16 D
+247 6 D
+323 -7 D
+71 -5 D
+0 -2042 D
+S
+7200 9285 M
+0 -1935 D
+-52 -4 D
+-272 -8 D
+-229 3 D
+-197 8 D
+-173 12 D
+-154 15 D
+-140 17 D
+-245 38 D
+-110 21 D
+-102 22 D
+-97 23 D
+-178 48 D
+-86 26 D
+-153 53 D
+-75 28 D
+-72 29 D
+-126 56 D
+-78 38 D
+-66 34 D
+-64 36 D
+-125 77 D
+-69 46 D
+-71 52 D
+-64 51 D
+-59 50 D
+-54 49 D
+-40 39 D
+-57 60 D
+-56 64 D
+-55 69 D
+-53 75 D
+-56 87 D
+-28 50 D
+-26 50 D
+-46 101 D
+-35 93 D
+-19 61 D
+-18 70 D
+S
+3600 8989 M
+-8 33 D
+-18 103 D
+-11 104 D
+-3 56 D
+S
+3560 0 M
+1 100 D
+3 52 D
+11 103 D
+19 103 D
+6 24 D
+S
+5998 8006 M
+-127 -30 D
+-119 -21 D
+-112 -13 D
+-106 -6 D
+-50 -1 D
+-49 0 D
+-95 3 D
+-91 7 D
+-86 11 D
+-98 17 D
+-66 14 D
+-78 20 D
+-75 23 D
+-73 25 D
+-72 28 D
+-70 31 D
+-109 56 D
+-27 15 D
+-66 41 D
+-58 39 D
+-72 55 D
+-64 54 D
+-36 33 D
+-47 48 D
+-43 48 D
+-40 47 D
+-36 48 D
+-33 48 D
+-31 49 D
+-51 94 D
+-24 53 D
+-20 50 D
+-28 82 D
+-6 18 D
+-25 102 D
+-9 51 D
+-11 104 D
+-1 36 D
+S
+3794 0 M
+-1 73 D
+4 73 D
+12 97 D
+13 66 D
+25 93 D
+34 97 D
+28 64 D
+29 59 D
+56 96 D
+27 39 D
+0 2 D
+51 68 D
+50 60 D
+51 56 D
+79 75 D
+46 39 D
+47 37 D
+48 35 D
+50 34 D
+52 32 D
+54 31 D
+56 29 D
+58 28 D
+62 27 D
+64 25 D
+68 23 D
+72 22 D
+76 20 D
+80 17 D
+87 15 D
+93 12 D
+138 9 D
+71 1 D
+120 -3 D
+161 -17 D
+119 -20 D
+64 -14 D
+102 -27 D
+88 -29 D
+101 -39 D
+96 -44 D
+120 -64 D
+82 -52 D
+160 -124 D
+39 -36 D
+184 -211 D
+28 -42 D
+117 -225 D
+67 -233 D
+13 -75 D
+-3 -199 D
+S
+7132 9285 M
+-1 -120 D
+-50 -206 D
+-31 -86 D
+-132 -244 D
+-158 -190 D
+-38 -36 D
+-127 -108 D
+-162 -108 D
+-155 -80 D
+-145 -58 D
+-118 -38 D
+-17 -5 D
+S
+5987 8725 M
+-90 -95 D
+-94 -78 D
+-96 -63 D
+-95 -50 D
+-94 -38 D
+-92 -30 D
+-90 -20 D
+-88 -13 D
+-64 -5 D
+-21 -2 D
+-83 0 D
+-80 5 D
+-79 10 D
+-77 16 D
+-76 20 D
+-75 26 D
+-89 38 D
+-78 42 D
+-67 43 D
+-59 44 D
+-53 45 D
+-46 46 D
+-42 46 D
+-38 47 D
+-33 48 D
+-30 48 D
+-27 49 D
+-23 50 D
+-21 51 D
+-17 51 D
+-14 53 D
+-11 54 D
+-8 55 D
+-6 67 D
+S
+4031 0 M
+-1 50 D
+3 64 D
+8 71 D
+16 78 D
+11 43 D
+24 71 D
+17 43 D
+39 79 D
+34 57 D
+25 38 D
+46 61 D
+42 48 D
+62 61 D
+59 49 D
+57 43 D
+57 37 D
+59 32 D
+60 29 D
+62 26 D
+65 22 D
+80 22 D
+58 12 D
+74 12 D
+78 6 D
+83 2 D
+88 -5 D
+94 -13 D
+100 -22 D
+107 -35 D
+114 -50 D
+92 -53 D
+28 -18 D
+110 -86 D
+15 -14 D
+105 -112 D
+19 -26 D
+77 -120 D
+34 -69 D
+35 -93 D
+37 -159 D
+7 -181 D
+S
+6211 9285 M
+-19 -140 D
+-6 -25 D
+-49 -150 D
+-69 -132 D
+-52 -75 D
+-29 -38 D
+S
+5447 8886 M
+-67 -60 D
+-70 -48 D
+-44 -24 D
+-29 -14 D
+-75 -29 D
+-76 -19 D
+-77 -11 D
+-24 -1 D
+-53 -1 D
+-90 8 D
+-66 13 D
+-38 11 D
+-41 15 D
+-42 18 D
+-69 37 D
+-61 42 D
+-48 42 D
+-43 46 D
+-37 47 D
+-32 50 D
+-27 52 D
+-22 54 D
+-18 57 D
+-12 61 D
+-5 53 D
+S
+4281 0 M
+-1 67 D
+4 47 D
+6 42 D
+17 72 D
+23 63 D
+27 57 D
+15 27 D
+17 27 D
+39 52 D
+22 26 D
+54 53 D
+33 27 D
+46 33 D
+73 42 D
+71 30 D
+71 21 D
+72 13 D
+74 6 D
+76 -2 D
+78 -11 D
+81 -22 D
+82 -33 D
+14 -7 D
+70 -41 D
+84 -67 D
+79 -90 D
+10 -13 D
+60 -107 D
+41 -130 D
+5 -28 D
+8 -90 D
+-4 -64 D
+S
+5628 9285 M
+-3 -48 D
+-26 -104 D
+-41 -94 D
+-51 -83 D
+-60 -70 D
+S
+5189 9245 M
+-29 -69 D
+-42 -58 D
+-51 -46 D
+-59 -35 D
+-64 -22 D
+-75 -8 D
+-45 3 D
+-39 9 D
+-44 13 D
+-63 36 D
+-49 44 D
+-38 52 D
+-27 60 D
+-13 61 D
+S
+4551 0 M
+-2 12 D
+0 50 D
+6 50 D
+13 44 D
+18 39 D
+22 36 D
+26 34 D
+33 31 D
+40 29 D
+53 26 D
+27 10 D
+51 10 D
+31 4 D
+76 -7 D
+73 -23 D
+67 -42 D
+60 -65 D
+4 -6 D
+40 -87 D
+4 -16 D
+9 -89 D
+-5 -40 D
+S
+5197 9285 M
+-8 -40 D
+S
+4863 52 M
+-17 -5 D
+0 17 D
+14 2 D
+P S
+PSL_cliprestore
+%%EndObject
+grestore
+PSL_movie_completion /PSL_movie_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/grdcontour/TMcontours.sh
+++ b/test/grdcontour/TMcontours.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Show that contours in TM projection no longer wrap in y-direction
+# https://github.com/GenericMappingTools/gmt/issues/2389
+gmt begin TMcontours ps
+	gmt grdmath -Rg -I2 116.40 39.90 SDIST = dist.nc
+    gmt coast -R0/360/-80/80 -JT180/-30/6i -Glightgray -A1000 -Bag
+	gmt grdcontour dist.nc -C1000 -Wc1p,red
+gmt end show


### PR DESCRIPTION
See #2389 for context.  When contours are converted to (x,y) locations on the map we determine if there is any wrapping across the map due to the periodic nature of longitudes.  However, for the transverse Mercator projection such wrapping can only happen in the _y-direction_ yet we had no check for that.  I have now added a new check that deals with both of these potential wrapping lines.  In the process I discovered a bug or two in the old x-only wrapping checker but apparently it did not cause any actual damage.  Anyway, now fixed, but I added a basic example to the grdcontour tests to show this is fixed.  Closes issue #2389.
