### PR TITLE
psl_fix_utf8: out_string needs one more byte

### DIFF
--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -655,7 +655,7 @@ static void psl_fix_utf8 (struct PSL_CTRL *PSL, char *in_string) {
 	}
 	if (utf8_codes == 0) return;	/* Nothing to do */
 
-	out_string = PSL_memory (PSL, NULL, strlen(in_string), char);	/* Get a new string of same length */
+	out_string = PSL_memory (PSL, NULL, strlen(in_string) + 1, char);	/* Get a new string of same length (extra byte for '\0') */
 	
 	for (k = kout = 0; in_string[k]; k++) {
 		if ((unsigned char)(in_string[k]) == 0303) {    /* Found octal 303 */


### PR DESCRIPTION
In the function `psl_fix_utf8`, out_string is a new string with some UTF8
codes fixed. out_string should be the same length as in_string. When
allocating memory for `out_string`, we should give it one more byte for '\0'.
Otherwise, we may lose one byte in the `in_string` or have a
un-terminated `in_string` (no '\0') at the end of the function.