### PR TITLE
Report correct file when complaining about record

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -4599,10 +4599,12 @@ FILE * gmt_fopen (struct GMT_CTRL *GMT, const char *filename, const char *mode) 
 #else
 					snprintf (cmd, GMT_BUFSIZ+GMT_LEN256, "ogr2ogr -f \"GMT\" %s %s", GMT->current.io.tempfile, c);
 #endif
+					GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Running %s\n", cmd);
 					if ((error = system (cmd))) {
 						GMT_Report (GMT->parent, GMT_MSG_NORMAL, "System call [%s] FAILED with error %d.\n", cmd, error);
 						return NULL;
 					}
+					sprintf (GMT->current.io.filename[GMT_IN], "%s <converted from %s via ogr2ogr>", GMT->current.io.tempfile, c);
 					c = GMT->current.io.tempfile;	/* Open this temporary instead */
 				}
 #endif


### PR DESCRIPTION
See #2268 for context.  The issue is that when a ShapeFile is given then we convert it via ogr2ogr and make a temporary file, then read that file instead.  However, if an error occurs (such as here when we expect 3 columns but only 2 were present) the error message referred to a previous filename since we had not updated that variable.  Now we show more explicitly that we are reading a temp file created by ogr2ogr form the original input file.  Closes #2268.
