### PR TITLE
Let surface -D take a modifier +z to set a constant level

### DIFF
--- a/doc/rst/source/surface.rst
+++ b/doc/rst/source/surface.rst
@@ -18,7 +18,7 @@ Synopsis
 [ |-A|\ *aspect_ratio*\ \|\ **m** ]
 [ |-C|\ *convergence_limit*\ [%] ]
 [ |-J|\ *parameters* ]
-[ |-D|\ *breakline_file*]
+[ |-D|\ *breakline_file*\ [**+z**\ [*level*]] ]
 [ |-L|\ **l**\ *lower* ] [ **-Lu**\ *upper* ]
 [ |-M|\ *max_radius*\ [**u**] ]
 [ |-N|\ *max_iterations* ]
@@ -124,11 +124,13 @@ Optional Arguments
 
 .. _-D:
 
-**-D**\ *breakline*\
-    Use xyz data in the <breakline> file as a 'soft breakline'. A 'soft breakline'
+**-D**\ *breakline*\ [**+z**\ [*level*]]
+    Use xyz data in the *breakline* file as a 'soft breakline'. A 'soft breakline'
     is a line whose vertices will be used to constrain the nearest grid nodes without
     any further interpolation. A coastline or a lake shore are good examples of
-    'soft breaklines'. Multi-segments files are accepted.
+    'soft breaklines'. Multi-segments files are accepted.  If your lines do not have
+    *z*-values or you wish to override those with a constant z-value, then append
+    **+z**\ *level* to the filename. If no value is given then we default to 0.
 
 .. _-L:
 

--- a/src/surface.c
+++ b/src/surface.c
@@ -62,9 +62,11 @@ struct SURFACE_CTRL {
 		unsigned int mode;	/* 1 if given as fraction */
 		double value;
 	} C;
-	struct SRF_D {	/* -D<line.xyz>[+d] */
+	struct SRF_D {	/* -D<line.xyz>[+d][+z[<zval>]] */
 		bool active;
 		bool debug;
+		bool fix_z;
+		double z;
 		char *file;	/* Name of file with breaklines */
 	} D;
 	struct SRF_G {	/* -G<file> */
@@ -1412,7 +1414,7 @@ GMT_LOCAL double find_closest_point (double *x, double *y, double *z, uint64_t k
 	return r;
 }
 
-GMT_LOCAL void interpolate_add_breakline (struct GMT_CTRL *GMT, struct SURFACE_INFO *C, struct GMT_DATATABLE *T, char *file) {
+GMT_LOCAL void interpolate_add_breakline (struct GMT_CTRL *GMT, struct SURFACE_INFO *C, struct GMT_DATATABLE *T, char *file, bool fix_z, double z_level) {
 	int srow, scol;
 	uint64_t new_n = 0, n_int = 0, nb = 0;
 	uint64_t k = 0, n, kmax = 0, kmin = 0, row, seg, node_this, node_prev;
@@ -1453,13 +1455,13 @@ GMT_LOCAL void interpolate_add_breakline (struct GMT_CTRL *GMT, struct SURFACE_I
 	for (seg = 0; seg < T->n_segments; seg++) {
 		xline = T->segment[seg]->data[GMT_X];
 		yline = T->segment[seg]->data[GMT_Y];
-		zline = T->segment[seg]->data[GMT_Z];
+		if (!fix_z) zline = T->segment[seg]->data[GMT_Z];
 		/* 1. Interpolate the breakline to ensure there are points in every bin that it crosses */
 		if (file) fprintf (fp1, "> Segment %d\n", (int)seg);
 		for (row = k = 0, new_n = 1; row < T->segment[seg]->n_rows - 1; row++) {
 			dx = xline[row+1] - xline[row];
 			dy = yline[row+1] - yline[row];
-			dz = zline[row+1] - zline[row];
+			if (!fix_z) dz = zline[row+1] - zline[row];
 			/* Given point spacing and grid spacing, how many points to interpolate? */
 			n_int = lrint (hypot (dx, dy) * MAX (C->r_inc[GMT_X], C->r_inc[GMT_Y])) + 1;
 			new_n += n_int;
@@ -1474,11 +1476,11 @@ GMT_LOCAL void interpolate_add_breakline (struct GMT_CTRL *GMT, struct SURFACE_I
 			for (n = 0; n < n_int; k++, n++) {
 				x[k] = xline[row] + n * dx;
 				y[k] = yline[row] + n * dy;
-				z[k] = zline[row] + n * dz;
+				z[k] = (fix_z) ? z_level : zline[row] + n * dz;
 				if (file) fprintf (fp1, "%g\t%g\t%g\n", x[k], y[k], z[k]);
 			}
 		}
-		x[k] = xline[row];	y[k] = yline[row];	z[k] = zline[row];
+		x[k] = xline[row];	y[k] = yline[row];	z[k] = (fix_z) ? z_level : zline[row];
 		if (file) fprintf (fp1, "%g\t%g\t%g\n", x[k], y[k], z[k]);
 	
 		/* 2. Go along the (x,y,z), k = 1:new_n line and find the closest point to each bin node */
@@ -1622,7 +1624,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] -G<outgrid> %s\n", name, GMT_I_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t%s [-A<aspect_ratio>|m] [-C<convergence_limit>]\n", GMT_Rgeo_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-D<breakline>] [%s] [-Ll<limit>] [-Lu<limit>] [-M<radius>[<unit>]] [-N<n_iterations>] [-Q]\n", GMT_J_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-D<breakline>[+z[<zlevel>]]] [%s] [-Ll<limit>] [-Lu<limit>] [-M<radius>[<unit>]] [-N<n_iterations>] [-Q]\n", GMT_J_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-S<search_radius>[m|s]] [-T[i|b]<tension>] [%s] [-W[<logfile>]] [-Z<over_relaxation_parameter>]\n\t[%s] [%s] [%s] [%s]\n\t[%s] [%s\n\t[%s] [%s] [%s]%s[%s] [%s]\n\n",
 		GMT_V_OPT, GMT_bi_OPT, GMT_di_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_qi_OPT, GMT_r_OPT, GMT_s_OPT, GMT_x_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
@@ -1641,6 +1643,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Default will choose %g of the rms of your z data after removing L2 plane (%u ppm precision).\n", SURFACE_CONV_LIMIT, ppm);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Enter your own convergence limit in the same units as your z data.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-D Use xyz data in the <breakline> file as a 'soft breakline'.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   To set a fixed z_level, append modifier +z[<z_level>] which overrides any z from the <breakline> file [0].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-J Select the data map projection. This projection is only used to add a CRS info to the\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   grid formats that support it. E.g. netCDF, GeoTIFF, and others supported by GDAL.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-L Constrain the range of output values:\n");
@@ -1690,7 +1693,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct SURFACE_CTRL *Ctrl, struct GMT
 	 */
 
 	unsigned int n_errors = 0, k, end;
-	char modifier, *c = NULL;
+	char modifier, *c = NULL, *d = NULL;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
@@ -1719,15 +1722,21 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct SURFACE_CTRL *Ctrl, struct GMT
 				}
 				break;
 			case 'D':
-				if ((c = strstr (opt->arg, "+d"))) {
-					c[0] = '\0';	/* Temporarily chop off +d part */
+				if ((d = strstr (opt->arg, "+d"))) {
+					d[0] = '\0';	/* Temporarily chop off +d part */
 					Ctrl->D.debug = true;
+				}
+				if ((c = strstr (opt->arg, "+z"))) {
+					c[0] = '\0';	/* Temporarily chop off +z part */
+					if (c[2]) Ctrl->D.z = atof (&c[2]);	/* Get the constant z-value [0] */
+					Ctrl->D.fix_z = true;
 				}
 				if ((Ctrl->D.active = gmt_check_filearg (GMT, 'D', opt->arg, GMT_IN, GMT_IS_DATASET)) != 0)
 					Ctrl->D.file = strdup (opt->arg);
 				else
 					n_errors++;
 				if (c) c[0] = '+';	/* Restore original string */
+				if (d) d[0] = '+';	/* Restore original string */
 				break;
 			case 'G':
 				if ((Ctrl->G.active = gmt_check_filearg (GMT, 'G', opt->arg, GMT_OUT, GMT_IS_GRID)) != 0)
@@ -1943,13 +1952,18 @@ int GMT_surface (void *V_API, int mode, void *args) {
 	if (Ctrl->D.active) {	/* Append breakline dataset */
 		struct GMT_DATASET *Lin = NULL;
 		char *file = (Ctrl->D.debug) ? Ctrl->D.file : NULL;
+		if (Ctrl->D.fix_z) {	/* Either provide a fixed z value or override whatever input file may supply with this value */
+			//GMT->common.b.ncol[GMT_IN] = 0;	/* So Set_Columns will work */
+			if ((error = GMT_Set_Columns (GMT->parent, GMT_IN, 2, GMT_COL_FIX_NO_TEXT)) != GMT_NOERROR)	/* Only read 2 columns */
+				Return (GMT_RUNTIME_ERROR);
+		}
 		if ((Lin = GMT_Read_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_LINE, GMT_READ_NORMAL, NULL, Ctrl->D.file, NULL)) == NULL)
 			Return (API->error);
 		if (Lin->n_columns < 2) {
 			GMT_Report (API, GMT_MSG_NORMAL, "Input file %s has %d column(s) but at least 2 are needed\n", Ctrl->D.file, (int)Lin->n_columns);
 			Return (GMT_DIM_TOO_SMALL);
 		}
-		interpolate_add_breakline (GMT, &C, Lin->table[0], file);	/* Pass the single table since we read a single file */
+		interpolate_add_breakline (GMT, &C, Lin->table[0], file, Ctrl->D.fix_z, Ctrl->D.z);	/* Pass the single table since we read a single file */
 	}
 	
 	throw_away_unusables (GMT, &C);		/* Eliminate data points that will not serve as constraints */


### PR DESCRIPTION
Breaklines just given by their _x,y_ coordinates can now be used provided you supply a constant level to serve as all _z_ values via the modifier **+z**[_level_] with a default _level_ of zero.  This also required some changes to gmt_set_cols so that we could change the expected columns back to 2.
