### PR TITLE
Do not round off w/e/sn when -D -I are used for tiling grids

### DIFF
--- a/doc/rst/source/grdinfo.rst
+++ b/doc/rst/source/grdinfo.rst
@@ -91,7 +91,8 @@ Optional Arguments
     then we return the actual grid region instead).  If no
     argument is given then we report the grid increment in the form
     **-I**\ *xinc*\ [/*yinc*\ ]. If **-Ib** is given we write each grid's
-    bounding box polygon instead.
+    bounding box polygon instead.  Finally, if **-D** is in effect then
+    *dx* and *dy* are the dimensions of the desired tiles.
 
 .. _-L:
 

--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -960,10 +960,12 @@ int GMT_grdinfo (void *V_API, int mode, void *args) {
 	if (global_zmax == -DBL_MAX) global_zmax = GMT->session.d_NaN;
 
 	if (Ctrl->C.active && (Ctrl->I.active && Ctrl->I.status == GRDINFO_GIVE_REG_ROUNDED)) {
-		global_xmin = floor (global_xmin / Ctrl->I.inc[GMT_X]) * Ctrl->I.inc[GMT_X];
-		global_xmax = ceil  (global_xmax / Ctrl->I.inc[GMT_X]) * Ctrl->I.inc[GMT_X];
-		global_ymin = floor (global_ymin / Ctrl->I.inc[GMT_Y]) * Ctrl->I.inc[GMT_Y];
-		global_ymax = ceil  (global_ymax / Ctrl->I.inc[GMT_Y]) * Ctrl->I.inc[GMT_Y];
+		if (!Ctrl->D.active) {	/* Don't want to round if getting tile regions */
+			global_xmin = floor (global_xmin / Ctrl->I.inc[GMT_X]) * Ctrl->I.inc[GMT_X];
+			global_xmax = ceil  (global_xmax / Ctrl->I.inc[GMT_X]) * Ctrl->I.inc[GMT_X];
+			global_ymin = floor (global_ymin / Ctrl->I.inc[GMT_Y]) * Ctrl->I.inc[GMT_Y];
+			global_ymax = ceil  (global_ymax / Ctrl->I.inc[GMT_Y]) * Ctrl->I.inc[GMT_Y];
+		}
 		if (!Ctrl->D.active && gmt_M_is_geographic (GMT, GMT_IN)) {	/* Must make sure we don't get outside valid bounds */
 			if (global_ymin < -90.0) {
 				global_ymin = -90.0;
@@ -1043,10 +1045,12 @@ int GMT_grdinfo (void *V_API, int mode, void *args) {
 		GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 	}
 	else if ((Ctrl->I.active && Ctrl->I.status == GRDINFO_GIVE_REG_ROUNDED)) {
-		global_xmin = floor (global_xmin / Ctrl->I.inc[GMT_X]) * Ctrl->I.inc[GMT_X];
-		global_xmax = ceil  (global_xmax / Ctrl->I.inc[GMT_X]) * Ctrl->I.inc[GMT_X];
-		global_ymin = floor (global_ymin / Ctrl->I.inc[GMT_Y]) * Ctrl->I.inc[GMT_Y];
-		global_ymax = ceil  (global_ymax / Ctrl->I.inc[GMT_Y]) * Ctrl->I.inc[GMT_Y];
+		if (!Ctrl->D.active) {	/* Don't want to round if getting tile regions */
+			global_xmin = floor (global_xmin / Ctrl->I.inc[GMT_X]) * Ctrl->I.inc[GMT_X];
+			global_xmax = ceil  (global_xmax / Ctrl->I.inc[GMT_X]) * Ctrl->I.inc[GMT_X];
+			global_ymin = floor (global_ymin / Ctrl->I.inc[GMT_Y]) * Ctrl->I.inc[GMT_Y];
+			global_ymax = ceil  (global_ymax / Ctrl->I.inc[GMT_Y]) * Ctrl->I.inc[GMT_Y];
+		}
 		if (!Ctrl->D.active && gmt_M_is_geographic (GMT, GMT_IN)) {	/* Must make sure we don't get outside valid bounds */
 			if (global_ymin < -90.0) {
 				global_ymin = -90.0;


### PR DESCRIPTION
The **-D** option in grdinfo is used in conjunction with **-I**_dx/dy_ to report the subregions of tiles of given size.  However, the code got caught by a desire to round off the w/e/s/n region before tiling, leading to tiles exceeding the range of the grid.  Now fixed.
