### PR TITLE
Add missing dependencies to CMake rules for gmt_dimensions.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -396,7 +396,8 @@ add_custom_command (OUTPUT gmt_dimensions.h
 	-D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
 	-D GMT_SRC=${GMT_SOURCE_DIR}
 	-P ${CMAKE_MODULE_PATH}/GmtGenExtraHeaders.cmake
-	DEPENDS gmt_media_name.h gmt_pennames.h gmt_unique.h gmt_cpt_masters.h
+	DEPENDS gmt_media_name.h gmt_pennames.h gmt_unique.h gmt_ellipsoids.h
+	gmt_datums.h gmt_colornames.h gmt_cpt_masters.h gmt_datasets.h
 	gmt_keycases.h)
 	# depends on cached line numbers from these generated files:
 


### PR DESCRIPTION
**Description of proposed changes**

This adds the proper dependencies to the rules to make gmt_dimensions.h
This came to bare in trunk when gmt_ellipsoids.h was extended but its dimension was not updated.

This commit needs also to be merged with trunk.