### PR TITLE
grdfilter area weight wrong but does not matter

### DIFF
--- a/src/grdfilter.c
+++ b/src/grdfilter.c
@@ -488,7 +488,7 @@ GMT_LOCAL struct GMT_GRID *init_area_weights (struct GMT_CTRL *GMT, struct GMT_G
 	if (mode > GRDFILTER_XY_CARTESIAN) {	/* Geographic data */
 		if (mode == GRDFILTER_GEO_MERCATOR) dy_half = 0.5 * A->header->inc[GMT_Y];	/* Half img y-spacing */
 		dx = A->header->inc[GMT_X] * D2R;			/* Longitude increment in radians */
-		s2 = sind (0.5 * A->header->inc[GMT_Y]);	/* Holds sin (del_y/2) */
+		s2 = sind (0.5 * A->header->inc[GMT_Y]);		/* Holds sin (del_y/2) */
 	}
 	else	/* Cartesian */
 		dx = A->header->inc[GMT_X];

--- a/src/grdfilter.c
+++ b/src/grdfilter.c
@@ -487,8 +487,8 @@ GMT_LOCAL struct GMT_GRID *init_area_weights (struct GMT_CTRL *GMT, struct GMT_G
 		G->header->registration, GMT_NOTSET, NULL)) == NULL) return (NULL);
 	if (mode > GRDFILTER_XY_CARTESIAN) {	/* Geographic data */
 		if (mode == GRDFILTER_GEO_MERCATOR) dy_half = 0.5 * A->header->inc[GMT_Y];	/* Half img y-spacing */
-		dx = A->header->inc[GMT_X] * R2D;			/* Longitude increment in radians */
-		s2 = sind (0.5 * A->header->inc[GMT_Y]);		/* Holds sin (del_y/2) */
+		dx = A->header->inc[GMT_X] * D2R;			/* Longitude increment in radians */
+		s2 = sind (0.5 * A->header->inc[GMT_Y]);	/* Holds sin (del_y/2) */
 	}
 	else	/* Cartesian */
 		dx = A->header->inc[GMT_X];


### PR DESCRIPTION
The area of grid cells calculation in grdfilter used a wrong conversion from degree to radians (scaled longitude increment by **R2D** instead of **D2R**), but this affected all cells equally and hence the constant cancelled out in the _sum_wz/sum_w_ step.
I checked the similar calculation in gmt_cell_area (used in grdmath) and it has correct conversion.  I double-checked this by running 

```
gmt grdmath -Rg -I30m AREA = a.nc --PROJ_ELLIPSOID=1
gmt grdmath -f0-1f a.nc SUM 1e6 MUL = s.nc
```

and s.nc said total area was 12.56 (=4*pi).  The 1e6 above is there since we want to report in km^2.
