### PR TITLE
CI: Run a supplemental module to check if suppl lib is correctly built and linked

### DIFF
--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -78,6 +78,7 @@ steps:
     gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
     gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
     gmt grdimage @earth_relief_60m -JH10c -Baf -pdf map
+    gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
   displayName: Check a few simple commands
 
 # Run the full tests

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -79,6 +79,7 @@ steps:
     gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
     gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
     gmt grdimage @earth_relief_60m -JH10c -Baf -pdf map
+    gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
   displayName: Check a few simple commands
 
 # Run the full tests

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -119,6 +119,7 @@ steps:
     gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
     gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
     gmt grdimage @earth_relief_60m -JH10c -Baf -pdf map
+    gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
   displayName: Check a few simple commands
 
 - bash: |


### PR DESCRIPTION
Run `gmt earthtide` to check if supplement lib is correctly built and linked.