### PR TITLE
Let pscoast -M consider the levels given in -W

### DIFF
--- a/doc/rst/source/coast_common.rst_
+++ b/doc/rst/source/coast_common.rst_
@@ -171,7 +171,9 @@ Optional Arguments
     occurs. Specify one of **-E**, **-I**, **-N** or **-W**.
     Note: if **-M** is used with **-E** then **-R** or the **+r** modifier
     to **-E** are not required as we automatically determine the region
-    given the selected geographic entities.
+    given the selected geographic entities.  If using **-W** and you want
+    just certain levels (1-4) then use the full syntax **-W**\ *level*/\ *pen*
+    and repeat for each level (pen is not used but required to parse the level correctly).
 
 .. _-N:
 

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -238,7 +238,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Option (API, "K");
 	gmt_mapscale_syntax (API->GMT, 'L', "Draw a map scale at specified reference point.");
 	GMT_Message (API, GMT_TIME_NONE, "\t-M Dump a multisegment ASCII (or binary, see -bo) file to standard output.  No plotting occurs.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Specify one of -E, -I, -N, or -W.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Specify one of -E, -I, -N, or -W (and optionally specific levels; see -W<level>/<pen>).\n");
 	gmt_pen_syntax (API->GMT, 'N', NULL, "Draw boundaries.  Specify feature and optionally append pen [Default for all levels: %s].", 0);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Choose from the features below.  Repeat the -N option as many times as needed.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     1 = National boundaries.\n");
@@ -1119,8 +1119,11 @@ int GMT_pscoast (void *V_API, int mode, void *args) {
 
 			for (i = 0; i < np; i++) {
 				if (Ctrl->M.active) {	/* Clip to specified region - this gives x,y coordinates in inches */
-					uint64_t unused, n_out = map_wesn_clip (GMT, p[i].lon, p[i].lat, p[i].n, &xtmp, &ytmp, &unused);
+					uint64_t unused, n_out;
 					
+					if (!Ctrl->W.use[p[i].level-1]) continue;
+
+					n_out = map_wesn_clip (GMT, p[i].lon, p[i].lat, p[i].n, &xtmp, &ytmp, &unused);
 					if (!Ctrl->M.single) {
 						sprintf (GMT->current.io.segment_header, "Shore Bin # %d, Level %d", bin, p[i].level);
 						GMT_Put_Record (API, GMT_WRITE_SEGMENT_HEADER, NULL);


### PR DESCRIPTION
The coastline dump also included lakes etc.  We now honor the **-W** settings if the user want just certain levels only.  Closes issue #2433.
