### PR TITLE
Fix copyright_year.sh and update copyright year to 2020

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,4 +1,4 @@
-Copyright (c) 1991–2019 by the GMT Team (https://www.generic-mapping-tools.org/team.html)
+Copyright (c) 1991-2020 by the GMT Team (https://www.generic-mapping-tools.org/team.html)
 
 As of GMT 5.0.0, GMT is distributed under the GNU Lesser General Public
 License (LGPL) version 3 or later. Copies of the GNU General Public

--- a/admin/copyright_year.sh
+++ b/admin/copyright_year.sh
@@ -13,7 +13,7 @@ newyear=2020
 
 # 1. Find all files with "Copyright"
 find -E . \
-    -regex '.*\.(md|c|h|in|rst|bash|csh|sh|bat|m|cmake|txt)' \
+    -regex '.*\.(md|c|h|in|rst|bash|csh|sh|bat|m|cmake|txt|TXT)' \
     ! -path "./share/spotter/*" \
     -exec grep -H Copyright {} + | \
     grep -v ${newyear} | \

--- a/share/tools/gmt_getremote.sh
+++ b/share/tools/gmt_getremote.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 1991-2019 by the GMT Team (https://www.generic-mapping-tools.org/team.html)
+# Copyright (c) 1991-2020 by the GMT Team (https://www.generic-mapping-tools.org/team.html)
 # See LICENSE.TXT file for copying and redistribution conditions.
 #
 # This script downloads any missing cache or data sets from the remote server.


### PR DESCRIPTION
Changes in this PR:

- copyright_year.sh should aslo check *.TXT files
- Change the non-ASCII `–` to `-`
- Update copyright year of two files