### PR TITLE
Fix debug symbols error due to CMP0026

### DIFF
--- a/ci/config-gmt-unix.sh
+++ b/ci/config-gmt-unix.sh
@@ -5,7 +5,6 @@
 set -e
 
 cat > cmake/ConfigUser.cmake << 'EOF'
-set (CMAKE_BUILD_TYPE Release)
 set (CMAKE_INSTALL_PREFIX "$ENV{INSTALLDIR}")
 set (GSHHG_ROOT "$ENV{COASTLINEDIR}/gshhg")
 set (DCW_ROOT "$ENV{COASTLINEDIR}/dcw")
@@ -23,6 +22,8 @@ EOF
 
 if [[ "$TEST" == "true" ]]; then
     cat >> cmake/ConfigUser.cmake << 'EOF'
+set (CMAKE_BUILD_TYPE Debug)
+
 enable_testing()
 set (DO_EXAMPLES TRUE)
 set (DO_TESTS TRUE)

--- a/cmake/modules/CreateDebugSym.cmake
+++ b/cmake/modules/CreateDebugSym.cmake
@@ -37,7 +37,7 @@ if (APPLE AND DEBUG_BUILD)
 
 	# Macro for generating Mac debugging symbols
 	macro (CREATE_DEBUG_SYM DESTINATION)
-		if (DSYMUTIL AND "${CMAKE_GENERATOR}" MATCHES "Make")
+		if (DSYMUTIL AND ("${CMAKE_GENERATOR}" MATCHES "Make" OR "${CMAKE_GENERATOR}" MATCHES "Ninja"))
 			# create tag from current dirname
 			tag_from_current_source_dir (_tag "_")
 
@@ -72,8 +72,7 @@ if (APPLE AND DEBUG_BUILD)
 
 			# register with spotless target
 			add_depend_to_target (spotless dsym_clean${_tag})
-
-		endif (DSYMUTIL AND "${CMAKE_GENERATOR}" MATCHES "Make")
+		endif (DSYMUTIL AND ("${CMAKE_GENERATOR}" MATCHES "Make" OR "${CMAKE_GENERATOR}" MATCHES "Ninja"))
 	endmacro (CREATE_DEBUG_SYM _TARGETS)
 
 elseif (MSVC AND DEBUG_BUILD)

--- a/cmake/modules/CreateDebugSym.cmake
+++ b/cmake/modules/CreateDebugSym.cmake
@@ -80,17 +80,13 @@ elseif (MSVC AND DEBUG_BUILD)
 
 		foreach (target ${ARGN}) # get all args past the last expected
 			# clean target
-			get_target_property (_location ${target} LOCATION)
-			get_filename_component (_path ${_location} PATH)
-			get_filename_component (_name ${_location} NAME_WE)
-			set (_pdb_file "${_path}/${_name}.pdb")
 			add_custom_target (_pdb_clean_${target}
-				COMMAND ${CMAKE_COMMAND} remove -f ${_pdb_file}
+				COMMAND ${CMAKE_COMMAND} remove -f $<TARGET_PDB_FILE:${target}>
 				COMMENT "Removing .pdb file")
 			add_depend_to_target (pdb_clean${_tag} _pdb_clean_${target})
 
 			# install target
-			install (FILES ${_pdb_file}
+			install (FILES $<TARGET_PDB_FILE:${target}>
 				DESTINATION ${DESTINATION}
 				COMPONENT Debug)
 		endforeach (target)

--- a/cmake/modules/CreateDebugSym.cmake
+++ b/cmake/modules/CreateDebugSym.cmake
@@ -50,22 +50,19 @@ if (APPLE AND DEBUG_BUILD)
 					VERBATIM)
 
 				# clean target
-				get_target_property (_location ${target} LOCATION)
 				get_target_property (_type ${target} TYPE)
 				get_target_property (_version ${target} VERSION)
-				get_filename_component (_path ${_location} PATH)
-				get_filename_component (_name ${_location} NAME)
+				get_target_property (_name ${target} OUTPUT_NAME)
 				if (_type STREQUAL "SHARED_LIBRARY")
 					string (REPLACE ".dylib" ".${_version}.dylib" _name "${_name}")
 				endif (_type STREQUAL "SHARED_LIBRARY")
-				set (_dsym_bundle "${_path}/${_name}.dSYM")
 				add_custom_target (_dsym_clean_${target}
-					COMMAND ${RM} -rf ${_dsym_bundle}
+					COMMAND ${RM} -rf $<TARGET_FILE:${target}>.dSYM
 					COMMENT "Removing .dSYM bundle")
 				add_depend_to_target (dsym_clean${_tag} _dsym_clean_${target})
 
 				# install target
-				install (DIRECTORY ${_dsym_bundle}
+				install (DIRECTORY $<TARGET_FILE:${target}>
 					DESTINATION ${DESTINATION}
 					COMPONENT Debug)
 			endforeach (target)


### PR DESCRIPTION
Changes in this PR:

1. Set CMAKE_BUILD_TYPE to Debug for Linux & macOS testing jobs
2. Create debug symbols if using Ninja
3. Fix CMP0026 issue with the LOCATION property. Using generator expression instead.

Closes #2447.