### PR TITLE
doc: The "Edit On GitHub" icon should link to the master branch by default

### DIFF
--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -28,8 +28,8 @@ version = '@GMT_PACKAGE_VERSION_MAJOR@.@GMT_PACKAGE_VERSION_MINOR@'
 # The full version shown in the page title
 release = '@GMT_PACKAGE_VERSION@'
 # Make the "Edit on GitHub" button link to the correct branch
-# Default to 'version' if Azure Pipelines environmental variable BUILD_SOURCEBRANCHNAME is not defined
-github_version = os.getenv("BUILD_SOURCEBRANCHNAME", version)
+# Default to master branch if Azure Pipelines environmental variable BUILD_SOURCEBRANCHNAME is not defined
+github_version = os.getenv("BUILD_SOURCEBRANCHNAME", 'master')
 
 # -- Options for HTML output ---------------------------------------------------
 html_theme = 'rtd'


### PR DESCRIPTION
For the "Edit On GitHub" icon on the documentations, we need to specify
a branch to link.

Previously, it's by default linked to the branch "version", i.e.
for master branch, the GMT version is 6.1, which doesn't exist.

This PR fixes the issue, by linking the icon to the master branch, which
is always available.