### PR TITLE
Do not free ProjRefPROJ4||WKT fields when operating on externals

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -2660,8 +2660,10 @@ void gmt_free_header (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER **header) {
 	if (h == NULL) return;	/* Nothing to deallocate */
 	/* Free the header structure and anything allocated by it */
 	HH = gmt_get_H_hidden (h);
-	gmt_M_str_free (h->ProjRefWKT);
-	gmt_M_str_free (h->ProjRefPROJ4);
+	if (!GMT->parent->external) {
+		gmt_M_str_free (h->ProjRefWKT);
+		gmt_M_str_free (h->ProjRefPROJ4);
+	}
 	gmt_M_str_free (HH->pocket);
 	gmt_M_free (GMT, h->hidden);
 	gmt_M_free (GMT, *header);

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1417,7 +1417,7 @@ int GMT_grdimage (void *V_API, int mode, void *args) {
 		I->x = Ix;	I->y = Iy;
 	}
 
-	if (!need_to_project) {
+	if (!need_to_project && !API->external) {
 		for (k = 0; k < n_grids; k++) {	/* If memory grids are passed in we must restore the headers */
 			if (mem_G[k]) {
 				gmt_copy_gridheader (GMT, Grid_orig[k]->header, header_G[k]);


### PR DESCRIPTION
Without this PR the following example would crash Julia because the ``ProjRefWKT`` or ``ProjRefPROJ4`` header fields were attempted to be freed, but they were not allocated by GMT. 

```
julia> G = gmt("grdmath -R-10/0/35/45 -I0.1 X Y MUL");

julia> G.proj4 = "longlat";

julia> imshow(G, Vd=1)
        grdimage  -JX12c/0 -Baf -BWSen -R-10/0/35/45 -C -P -K > C:\TMP\GMTjl_tmp.ps
```