### PR TITLE
Fix bug in -Dj conversion to map location

### DIFF
--- a/doc/rst/source/colorbar_common.rst_
+++ b/doc/rst/source/colorbar_common.rst_
@@ -63,7 +63,7 @@ Optional Arguments
 **-D**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ [\ **+w**\ *length*\ [/\ *width*\ ]]\ [**+e**\ [**b**\ \|\ **f**][*length*]][**+h**\ \|\ **v**\ ][**+j**\ *justify*]\ [**+m**\ [**a**\ \|\ **c**\ \|\ **l**\ \|\ **u**]][**+n**\ [*txt*]][**+o**\ *dx*\ [/*dy*]]
     Defines the reference point on the map for the color scale using one of four coordinate systems:
     (1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) map domain rectangle,
+    a 2-char justification code that refers to the (invisible) projected map bounding box,
     (3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
     (inches, cm, etc.).  All but **-Dx** requires both **-R** and **-J** to be specified.
     For **-Dj** or **-DJ** with codes TC, BC, ML, MR (i.e., centered on one of the map sides) we

--- a/doc/rst/source/explain_-L_scale.rst_
+++ b/doc/rst/source/explain_-L_scale.rst_
@@ -2,7 +2,7 @@
     Draws a simple map scale centered on the reference point specified
     using one of four coordinate systems:
     (1) Use **-Lg** for map (user) coordinates, (2) use **-Lj** or **-LJ** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) map domain rectangle,
+    a 2-char justification code that refers to the (invisible) projected map bounding box,
     (3) use **-Ln** for normalized (0-1) coordinates, or (4) use **-Lx** for plot coordinates
     (inches, cm, etc.).  Scale is calculated for latitude *slat*
     (optionally supply longitude *slon* for oblique projections [Default

--- a/doc/rst/source/explain_-T_rose.rst_
+++ b/doc/rst/source/explain_-T_rose.rst_
@@ -3,7 +3,7 @@
     the reference and anchor points:
     Give the reference point on the map for the rose using one of four coordinate systems:
     (1) Use **g** for map (user) coordinates, (2) use **j** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) map domain rectangle,
+    a 2-char justification code that refers to the (invisible) projected map bounding box,
     (3) use **n** for normalized (0-1) coordinates, or (4) use **x** for plot coordinates
     (inches, cm, etc.) [Default].  You can offset the reference point by *dx*/*dy* in
     the direction implied by *justify*.
@@ -29,7 +29,7 @@
     the reference and anchor points:
     Give the reference point on the map for the rose using one of four coordinate systems:
     (1) Use **g** for map (user) coordinates, (2) use **j** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) map domain rectangle,
+    a 2-char justification code that refers to the (invisible) projected map bounding box,
     (3) use **n** for normalized (0-1) coordinates, or (4) use **x** for plot coordinates
     (inches, cm, etc.) [Default]. You can offset the reference point by *dx*/*dy* in
     the direction implied by *justify*.

--- a/doc/rst/source/image_common.rst_
+++ b/doc/rst/source/image_common.rst_
@@ -36,7 +36,7 @@ Optional Arguments
 **-D**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ **+r**\ *dpi*\ **+w**\ [**-**]\ *width*\ [/*height*]\ [**+j**\ *justify*]\ [**+n**\ *nx*\ [/*ny*] ]\ [**+o**\ *dx*\ [/*dy*]]
     Sets reference point on the map for the image using one of four coordinate systems:
     (1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) map domain rectangle,
+    a 2-char justification code that refers to the (invisible) projected map bounding box,
     (3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
     (inches, cm, etc.).  All but **-Dx** requires both **-R** and **-J** to be specified.
     By default, the anchor point on the scale is assumed to be the bottom left corner (BL), but this

--- a/doc/rst/source/inset.rst
+++ b/doc/rst/source/inset.rst
@@ -52,7 +52,7 @@ Required Arguments
     of bounding rectangle in projected coordinates and optionally append **+u**\ *unit* [Default coordinate unit is meter (e)].
     (c) Give the reference point on the map for the inset using one of four coordinate systems:
     (1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) map domain rectangle,
+    a 2-char justification code that refers to the (invisible) projected map bounding box,
     (3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
     (inches, cm, etc.).
     Append **+w**\ *width*\ [/*height*] of bounding rectangle or box in plot coordinates (inches, cm, etc.).

--- a/doc/rst/source/legend_common.rst_
+++ b/doc/rst/source/legend_common.rst_
@@ -16,7 +16,7 @@ Required Arguments
 **-D**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ **+w**\ *width*\ [/*height*]\ [**+j**\ *justify*]\ [**+l**\ *spacing*]\ [**+o**\ *dx*\ [/*dy*]]
     Defines the reference point on the map for the legend using one of four coordinate systems:
     (1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) map domain rectangle,
+    a 2-char justification code that refers to the (invisible) projected map bounding box,
     (3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
     (inches, cm, etc.).  All but **-Dx** requires both **-R** and **-J** to be specified.
     Append **+w**\ *width*\ [/*height*] to set

--- a/doc/rst/source/wiggle_common.rst_
+++ b/doc/rst/source/wiggle_common.rst_
@@ -65,7 +65,7 @@ Optional Arguments
 **-D**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ \ **+w**\ *length*\ [**+j**\ *justify*]\ [**+a**\ **l**\ \|\ **r**\ ]\ [**+o**\ *dx*\ [/*dy*]]\ [**+l**\ [*label*]]
     Defines the reference point on the map for the vertical scale bar using one of four coordinate systems:
     (1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) map domain rectangle,
+    a 2-char justification code that refers to the (invisible) projected map bounding box,
     (3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
     (inches, cm, etc.).  All but **-Dx** requires both **-R** and **-J** to be specified.
     Append **+w** followed by the *length* or the scale bar in data (*z*) units.

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7168,7 +7168,7 @@ void gmt_refpoint_syntax (struct GMT_CTRL *GMT, char *option, char *string, unsi
 		if (string) gmt_message (GMT, "\t-%s %s\n", option, string);
 		gmt_message (GMT, "\t   %sPositioning is specified via one of four coordinate systems:\n", tab[shift]);
 		gmt_message (GMT, "\t   %s  Use -%sg to specify <refpoint> with map coordinates.\n", tab[shift], option);
-		gmt_message (GMT, "\t   %s  Use -%sj or -%sJ to specify <refpoint> with 2-char justification code (BL, MC, etc).\n", tab[shift], option, option);
+		gmt_message (GMT, "\t   %s  Use -%sj or -%sJ to specify bounding-box <refpoint> with 2-char justification code (BL, MC, etc).\n", tab[shift], option, option);
 		gmt_message (GMT, "\t   %s  Use -%sn to specify <refpoint> with normalized coordinates in 0-1 range.\n", tab[shift], option);
 		gmt_message (GMT, "\t   %s  Use -%sx to specify <refpoint> with plot coordinates.\n", tab[shift], option);
 		gmt_message (GMT, "\t   %sAll except -%sx require the -R and -J options to be set.\n", tab[shift], option);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15234,9 +15234,8 @@ void gmt_set_refpoint (struct GMT_CTRL *GMT, struct GMT_REFPOINT *A) {
 		A->x = x;	A->y = y;
 	}
 	else if (A->mode == GMT_REFPOINT_JUST) {	/* Convert from justify code to map coordinates, then to plot coordinates */
-		/* Since intended for inside frame items (scales) we use the wesn rectangle to get the lon/lat coordinate from the code */
-		gmt_just_to_lonlat (GMT, A->justify, gmt_M_is_geographic (GMT, GMT_IN), &A->x, &A->y);
-		gmt_geo_to_xy (GMT, A->x, A->y, &x, &y);
+		/* Since intended for inside frame items (scales) we use the bounding box rectangle to get the plot coordinate from the code */
+		gmt_just_to_xy (GMT, A->justify, &x, &y);
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Convert code inside reference point coordinates from justification %s to %g, %g\n", GMT_just_code[A->justify], A->x, A->y);
 		A->x = x;	A->y = y;
 	}


### PR DESCRIPTION
The -Dj and **-DJ** conversion from justify code to position on the map were different.  The inside (**-Dj**) converted the code to lon,lat first, then to x,y, but for non-rectangular projections you may never be able to use BL, TR, etc. that way.  Also clarify the documentation.  Closes issue #2451.
