### PR TITLE
Set logo default with to 2i if not given

### DIFF
--- a/doc/rst/source/gmtlogo.rst
+++ b/doc/rst/source/gmtlogo.rst
@@ -39,7 +39,7 @@ To append a GMT logo overlay in the upper right corner of the current map, but
 scaled up to be 6 cm wide and offset by 0.25 cm from the border, try::
 
     gmt begin map
-    gmt ...<plot the map using -R J>
+    gmt ...<plot the map using -R -J>
     gmt logo -DjTR+o0.25c+w6c
     gmt end show
 

--- a/doc/rst/source/gmtlogo.rst
+++ b/doc/rst/source/gmtlogo.rst
@@ -31,16 +31,16 @@ Examples
 
 .. include:: oneliner_info.rst_
 
-To plot the GMT logo of a 2 inch width as a stand-alone pdf plot, use::
+To plot the GMT logo of a 144-point width as a stand-alone pdf plot, use::
 
     gmt logo -pdf logo
 
 To append a GMT logo overlay in the upper right corner of the current map, but
-scaled up to be 3 inches wide and offset by 0.1 inches from the border, try::
+scaled up to be 6 cm wide and offset by 0.25 cm from the border, try::
 
     gmt begin map
-    gmt ...
-    gmt logo -DjTR+o0.1i/0.1i+w3i
+    gmt ...<plot the map using -R J>
+    gmt logo -DjTR+o0.25c+w6c
     gmt end show
 
 Notes

--- a/doc/rst/source/gmtlogo_classic.rst
+++ b/doc/rst/source/gmtlogo_classic.rst
@@ -33,14 +33,14 @@ Synopsis
 Examples
 --------
 
-To plot the GMT logo of a 2 inch width as a stand-alone plot, use::
+To plot the GMT logo of a 144-point width as a stand-alone plot, use::
 
     gmt logo -P > logo.ps
 
 To append a GMT logo overlay in the upper right corner of the current map, but
-scaled up to be 3 inches wide and offset by 0.1 inches from the border, try::
+scaled up to be 6 cm wide and offset by 0.25 cm from the border, try::
 
-    gmt logo -O -K -R -J -DjTR+o0.1i/0.1i+w3i >> bigmap.ps
+    gmt logo -O -K -R -J -DjTR+o0.25c+w6c >> bigmap.ps
 
 Notes
 -----

--- a/doc/rst/source/gmtlogo_common.rst_
+++ b/doc/rst/source/gmtlogo_common.rst_
@@ -3,7 +3,7 @@
 Description
 -----------
 
-This module plots the GMT logo on a map. By default, the GMT logo is 2 inches wide and 1 inch high and will be
+This module plots the GMT logo on a map. By default, the GMT logo is 144 points (2 inches wide) and 72 points (1 inch) high and will be
 positioned relative to the current plot origin. Use various options to change this and to place a
 transparent or opaque rectangular map panel behind the GMT logo.
 

--- a/src/gmtlogo.c
+++ b/src/gmtlogo.c
@@ -210,7 +210,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\tOPTIONS:\n");
 	gmt_refpoint_syntax (API->GMT, "D", "Specify position of the GMT logo [0/0].", GMT_ANCHOR_LOGO, 1);
 	gmt_refpoint_syntax (API->GMT, "D", NULL, GMT_ANCHOR_LOGO, 2);
-	GMT_Message (API, GMT_TIME_NONE, "\t   Use +w<width> to set the width of the GMT logo. [2i]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Use +w<width> to set the width of the GMT logo. [144p]\n");
 	gmt_mappanel_syntax (API->GMT, 'F', "Specify a rectangular panel behind the GMT logo.", 0);
 	GMT_Option (API, "J-Z,K,O,P,R");
 	GMT_Message (API, GMT_TIME_NONE, "\t-S Control text label plotted beneath the logo:\n");

--- a/src/gmtlogo.c
+++ b/src/gmtlogo.c
@@ -210,7 +210,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\tOPTIONS:\n");
 	gmt_refpoint_syntax (API->GMT, "D", "Specify position of the GMT logo [0/0].", GMT_ANCHOR_LOGO, 1);
 	gmt_refpoint_syntax (API->GMT, "D", NULL, GMT_ANCHOR_LOGO, 2);
-	GMT_Message (API, GMT_TIME_NONE, "\t   Use +w<width> to set the width of the GMT logo.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Use +w<width> to set the width of the GMT logo. [2i]\n");
 	gmt_mappanel_syntax (API->GMT, 'F', "Specify a rectangular panel behind the GMT logo.", 0);
 	GMT_Option (API, "J-Z,K,O,P,R");
 	GMT_Message (API, GMT_TIME_NONE, "\t-S Control text label plotted beneath the logo:\n");
@@ -292,6 +292,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMTLOGO_CTRL *Ctrl, struct GMT
 			Ctrl->D.width = gmt_M_to_inch (GMT, string);
 		Ctrl->D.active = true;
 	}
+	if (Ctrl->D.width == 0.0) Ctrl->D.width = 2.0;	/* Default width */
 	if (Ctrl->D.refpoint && Ctrl->D.refpoint->mode != GMT_REFPOINT_PLOT) {	/* Anything other than -Dx need -R -J; other cases don't */
 		static char *kind = "gjJnx";	/* The five types of refpoint specifications */
 		n_errors += gmt_M_check_condition (GMT, !GMT->common.R.active[RSET], "Syntax error: -D%c requires the -R option\n", kind[Ctrl->D.refpoint->mode]);


### PR DESCRIPTION
But I think we should change to SI, or use 144 points.  Since changing it from 2 inches would be a backwards incompatibility I suggest we list 144 point as the default.  OK?

