### PR TITLE
doc: Put common -D description to explain_-Drefpoint.rst_

### DIFF
--- a/doc/rst/source/colorbar_common.rst_
+++ b/doc/rst/source/colorbar_common.rst_
@@ -62,10 +62,9 @@ Optional Arguments
 
 **-D**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ [\ **+w**\ *length*\ [/\ *width*\ ]]\ [**+e**\ [**b**\ \|\ **f**][*length*]][**+h**\ \|\ **v**\ ][**+j**\ *justify*]\ [**+m**\ [**a**\ \|\ **c**\ \|\ **l**\ \|\ **u**]][**+n**\ [*txt*]][**+o**\ *dx*\ [/*dy*]]
     Defines the reference point on the map for the color scale using one of four coordinate systems:
-    (1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) projected map bounding box,
-    (3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
-    (inches, cm, etc.).  All but **-Dx** requires both **-R** and **-J** to be specified.
+ 
+    .. include:: explain_refpoint.rst_
+
     For **-Dj** or **-DJ** with codes TC, BC, ML, MR (i.e., centered on one of the map sides) we
     pre-calculate all further settings.  Specifically, the *length* is set to 80% of the map side,
     horizontal or vertical depends on the side, the offset is MAP_LABEL_OFFSET for **Dj** with an
@@ -81,12 +80,9 @@ Optional Arguments
     Note: If **-Dj** is used then *justify* defaults to the same as *refpoint*,
     if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*. Consequently,
     **-DJ** is used to place a scale outside the map frame while **-Dj** is used to place it inside the frame.
-    Finally, add **+o** to offset the color scale by *dx*/*dy* away from the *refpoint* point in
-    the direction implied by *justify* (or the direction implied by **-Dj** or **-DJ**).
     Add sidebar triangles for back- and/or foreground
     colors with **+e**. Append **f** (foreground) or **b** (background) for only one sidebar triangle [Default
-    gives both]. Optionally, append triangle height [Default is half the
-    barwidth].
+    gives both]. Optionally, append triangle height [Default is half the barwidth].
     Move text to opposite side with **+m**\ [**a**\ \|\ **c**\ \|\ **l**\ \|\ **u**].
     Horizontal scale bars: Move annotations and labels above the scale bar [Default is below];
     the unit remains on the left.

--- a/doc/rst/source/explain_-Drefpoint.rst_
+++ b/doc/rst/source/explain_-Drefpoint.rst_
@@ -1,4 +1,0 @@
-(1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
-a 2-char justification code that refers to the (invisible) projected map bounding box,
-(3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
-(inches, cm, etc.).  All but **-Dx** requires both **-R** and **-J** to be specified.

--- a/doc/rst/source/explain_-Drefpoint.rst_
+++ b/doc/rst/source/explain_-Drefpoint.rst_
@@ -1,0 +1,4 @@
+(1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
+a 2-char justification code that refers to the (invisible) projected map bounding box,
+(3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
+(inches, cm, etc.).  All but **-Dx** requires both **-R** and **-J** to be specified.

--- a/doc/rst/source/explain_-L_scale.rst_
+++ b/doc/rst/source/explain_-L_scale.rst_
@@ -1,10 +1,10 @@
 **-L**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ **+c**\ [*slon*/]\ *slat*\ **+w**\ *length*\ [**e**\ \|\ **f**\ \|\ **k**\ \|\ **M**\ \|\ **n**\ \|\ **u**]\ [\ **+a**\ *align*]\ [**+f**]\ [**+j**\ *justify*]\ [\ **+l**\ [*label*]\ ]\ [**+o**\ *dx*\ [/*dy*]]\ [**+u**][**+v**]
     Draws a simple map scale centered on the reference point specified
     using one of four coordinate systems:
-    (1) Use **-Lg** for map (user) coordinates, (2) use **-Lj** or **-LJ** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) projected map bounding box,
-    (3) use **-Ln** for normalized (0-1) coordinates, or (4) use **-Lx** for plot coordinates
-    (inches, cm, etc.).  Scale is calculated for latitude *slat*
+ 
+    .. include:: explain_refpoint.rst_
+
+    Scale is calculated for latitude *slat*
     (optionally supply longitude *slon* for oblique projections [Default
     is central meridian]), *length* is in km, or append unit from
     **e**\ \|\ **f**\ \|\ **k**\ \|\ **M**\ \|\ **n**\ \|\ **u**.
@@ -18,8 +18,6 @@
     unit (meter, foot, km, mile, nautical mile, US survey foot) and is
     justified on top of the scale [t]. Change this by giving your own
     label (append **+l**\ *label*).
-    Add **+o** to offset the map scale by *dx*/*dy* away from the *refpoint* in
-    the direction implied by *justify* (or the direction implied by **-Dj** or **-DJ**).
     Select **+u** to append the unit to all distance annotations along the
     scale (for the plain scale, **+u** will instead select the unit to be
     appended to the distance length). Cartesian projections: Origin **+c** is

--- a/doc/rst/source/explain_-T_rose.rst_
+++ b/doc/rst/source/explain_-T_rose.rst_
@@ -2,18 +2,14 @@
     Draw a map directional rose on the map at the location defined by
     the reference and anchor points:
     Give the reference point on the map for the rose using one of four coordinate systems:
-    (1) Use **g** for map (user) coordinates, (2) use **j** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) projected map bounding box,
-    (3) use **n** for normalized (0-1) coordinates, or (4) use **x** for plot coordinates
-    (inches, cm, etc.) [Default].  You can offset the reference point by *dx*/*dy* in
-    the direction implied by *justify*.
+
+    .. include:: explain_refpoint.rst_
+
     By default, the anchor point on the directional rose is assumed to be the center of the rose (MC), but this
     can be changed by appending **+j** followed by a 2-char justification code *justify*
     (see :doc:`text` for list and explanation of codes).
     Note: If **-Dj** is used then *justify* defaults to the same as *refpoint*,
     if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*.
-    Add **+o** to offset the directional rose by *dx*/*dy* away from the *refpoint* in
-    the direction implied by *justify* (or the direction implied by **-Dj** or **-DJ**).
     Append **+w**\ *width* to set the width of the rose in plot coordinates (in inches, cm, or points).
     Add **+f** to get a "fancy" rose, and specify in *level* what
     you want drawn. The default [1] draws the two principal E-W,
@@ -28,18 +24,14 @@
     Draw a map magnetic rose on the map at the location defined by
     the reference and anchor points:
     Give the reference point on the map for the rose using one of four coordinate systems:
-    (1) Use **g** for map (user) coordinates, (2) use **j** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) projected map bounding box,
-    (3) use **n** for normalized (0-1) coordinates, or (4) use **x** for plot coordinates
-    (inches, cm, etc.) [Default]. You can offset the reference point by *dx*/*dy* in
-    the direction implied by *justify*.
+ 
+    .. include:: explain_refpoint.rst_
+
     By default, the anchor point on the magnetic rose is assumed to be the center of the rose (MC), but this
     can be changed by appending **+j** followed by a 2-char justification code *justify*
     (see :doc:`text` for list and explanation of codes).
     Note: If **-Dj** is used then *justify* defaults to the same as *refpoint*,
     if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*.
-    Add **+o** to offset the color magnetic rose by *dx*/*dy* away from the *refpoint* in
-    the direction implied by *justify* (or the direction implied by **-Dj** or **-DJ**).
     Append **+w**\ *width* to set the width of the rose in plot coordinates (in inches, cm, or points).
     Use **+d** to assign the magnetic declination and set *dlabel*, which is a label for
     the magnetic compass needle (Leave empty to format a label from
@@ -54,4 +46,3 @@
     strings to override the default.  Skip a specific label by leaving it blank.
     Number GMT default parameters control pens, fonts, and color.
     See :ref:`Placing-mag-map-roses` and **-F** on how to place a panel behind the magnetic rose.
-

--- a/doc/rst/source/explain_refpoint.rst_
+++ b/doc/rst/source/explain_refpoint.rst_
@@ -1,0 +1,5 @@
+(1) Append **g**\ *lon*/*lat* for map (user) coordinates, (2)  **j**\ *code* or **J**\ *code* for setting
+the *refpoint* via a 2-char justification code that refers to the (invisible) projected map bounding box,
+(3) **n**\ *xn*/*yn* for normalized (0-1) bounding box coordinates, or (4) **x**\ *x*/*y* for plot coordinates
+(inches, cm, points, append unit).  All but **x** requires both **-R** and **-J** to be specified.
+You can offset the reference point via **+o**\ *dx*/*dy* in the direction implied by *code* or **+j**\ *justify*.

--- a/doc/rst/source/image_common.rst_
+++ b/doc/rst/source/image_common.rst_
@@ -36,14 +36,12 @@ Optional Arguments
 **-D**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ **+r**\ *dpi*\ **+w**\ [**-**]\ *width*\ [/*height*]\ [**+j**\ *justify*]\ [**+n**\ *nx*\ [/*ny*] ]\ [**+o**\ *dx*\ [/*dy*]]
     Sets reference point on the map for the image using one of four coordinate systems:
 
-    .. include:: explain_-Drefpoint.rst_
+    .. include:: explain_refpoint.rst_
 
     By default, the anchor point on the scale is assumed to be the bottom left corner (BL), but this
     can be changed by appending **+j** followed by a 2-char justification code *justify* (see :doc:`text`).
     Note: If **-Dj** is used then *justify* defaults to the same as *refpoint*,
     if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*.
-    Add **+o** to offset the color scale by *dx*/*dy* away from the *refpoint* point in
-    the direction implied by *justify* (or the direction implied by **-Dj** or **-DJ**).
     Specify image size in one of two ways:
     Use **+r**\ *dpi* to set the dpi of the image in dots per inch, or use
     **+w**\ [**-**]\ *width*\ [/*height*] to

--- a/doc/rst/source/image_common.rst_
+++ b/doc/rst/source/image_common.rst_
@@ -35,10 +35,9 @@ Optional Arguments
 
 **-D**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ **+r**\ *dpi*\ **+w**\ [**-**]\ *width*\ [/*height*]\ [**+j**\ *justify*]\ [**+n**\ *nx*\ [/*ny*] ]\ [**+o**\ *dx*\ [/*dy*]]
     Sets reference point on the map for the image using one of four coordinate systems:
-    (1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) projected map bounding box,
-    (3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
-    (inches, cm, etc.).  All but **-Dx** requires both **-R** and **-J** to be specified.
+
+    .. include:: explain_-Drefpoint.rst_
+
     By default, the anchor point on the scale is assumed to be the bottom left corner (BL), but this
     can be changed by appending **+j** followed by a 2-char justification code *justify* (see :doc:`text`).
     Note: If **-Dj** is used then *justify* defaults to the same as *refpoint*,
@@ -82,7 +81,7 @@ Optional Arguments
     or the foreground (**+f**) pixels, or give no color to make those pixels
     transparent.  Alternatively, for color images you can select a single *color*
     that should be made transparent instead  (**+t**).
-    
+
 .. _-I:
 
 **-I**

--- a/doc/rst/source/inset.rst
+++ b/doc/rst/source/inset.rst
@@ -46,22 +46,18 @@ Required Arguments
 
 **-D**\ *xmin/xmax/ymin/ymax*\ [**+r**][**+u**\ *unit*]] \| **-D**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ **+w**\ *width*\ [/*height*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
     Define the map inset rectangle on the map.  Specify the rectangle in one of three ways:
-    (a) Give *west/east/south/north* of geographic rectangle bounded by parallels
+ 
+    .. include:: explain_refpoint.rst_
+
+    Alternatively, Give *west/east/south/north* of geographic rectangle bounded by parallels
     and meridians; append **+r** if the coordinates instead are the lower left and
-    upper right corners of the desired rectangle. (b) Give *xmin/xmax/ymin/ymax*
+    upper right corners of the desired rectangle. (Or, give *xmin/xmax/ymin/ymax*
     of bounding rectangle in projected coordinates and optionally append **+u**\ *unit* [Default coordinate unit is meter (e)].
-    (c) Give the reference point on the map for the inset using one of four coordinate systems:
-    (1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) projected map bounding box,
-    (3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
-    (inches, cm, etc.).
     Append **+w**\ *width*\ [/*height*] of bounding rectangle or box in plot coordinates (inches, cm, etc.).
     By default, the anchor point on the scale is assumed to be the bottom left corner (BL), but this
     can be changed by appending **+j** followed by a 2-char justification code *justify* (see :doc:`text`).
     Note: If **-Dj** is used then *justify* defaults to the same as *refpoint*,
     if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*.
-    Add **+o** to offset the inset fig by *dx*/*dy* away from the *refpoint* point in
-    the direction implied by *justify* (or the direction implied by **-Dj** or **-DJ**).
     Specify inset box attributes via the **-F** option [outline only].
 
 Optional Arguments

--- a/doc/rst/source/legend_common.rst_
+++ b/doc/rst/source/legend_common.rst_
@@ -15,10 +15,9 @@ Required Arguments
 
 **-D**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ **+w**\ *width*\ [/*height*]\ [**+j**\ *justify*]\ [**+l**\ *spacing*]\ [**+o**\ *dx*\ [/*dy*]]
     Defines the reference point on the map for the legend using one of four coordinate systems:
-    (1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) projected map bounding box,
-    (3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
-    (inches, cm, etc.).  All but **-Dx** requires both **-R** and **-J** to be specified.
+
+    .. include:: explain_refpoint.rst_
+
     Append **+w**\ *width*\ [/*height*] to set
     the width (and height) of the legend box in plot coordinates (inches, cm, etc.).
     If *height* is zero or not given then we estimate *height* based the expected
@@ -29,8 +28,6 @@ Required Arguments
     if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*.
     Use **+l**\ *spacing* to change the line-spacing factor in units of the current
     font size [1.1].
-    Finally, add **+o** to offset the legend by *dx*/*dy* away from the *refpoint* point in
-    the direction implied by *justify* (or the direction implied by **-Dj** or **-DJ**).
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/wiggle_common.rst_
+++ b/doc/rst/source/wiggle_common.rst_
@@ -64,18 +64,15 @@ Optional Arguments
 
 **-D**\ [**g**\ \|\ **j**\ \|\ **J**\ \|\ **n**\ \|\ **x**]\ *refpoint*\ \ **+w**\ *length*\ [**+j**\ *justify*]\ [**+a**\ **l**\ \|\ **r**\ ]\ [**+o**\ *dx*\ [/*dy*]]\ [**+l**\ [*label*]]
     Defines the reference point on the map for the vertical scale bar using one of four coordinate systems:
-    (1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) projected map bounding box,
-    (3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
-    (inches, cm, etc.).  All but **-Dx** requires both **-R** and **-J** to be specified.
+
+    .. include:: explain_refpoint.rst_
+
     Append **+w** followed by the *length* or the scale bar in data (*z*) units.
     By default, the anchor point on the scale is assumed to be the middle left corner (ML), but this
     can be changed by appending **+j** followed by a 2-char justification code *justify* (see :doc:`text`).
     Note: If **-Dj** is used then *justify* defaults to the same as *refpoint*,
     if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*. Consequently,
     **-DJ** is used to place a scale outside the map frame while **-Dj** is used to place it inside the frame.
-    Add **+o** to offset the vertical scale bar by *dx*/*dy* away from the *refpoint* point in
-    the direction implied by *justify* (or the direction implied by **-Dj** or **-DJ**).
     Move scale label to the left side with **+al** [Default is to the right of the scale].
     Append **+l** to set the *z* unit label that is used in the scale label [no unit].
     The **FONT\_ANNOT\_PRIMARY** is used for the font setting.


### PR DESCRIPTION
Sphinx supports nested "include" directive, but we have to add at least one blank line before the "include" directive.

This is what you will see. The generate webpage has two blank lines before and after the included paragraph.
![image](https://user-images.githubusercontent.com/3974108/72490298-ec045700-37e4-11ea-9521-cbaf2ca88989.png)

You can work on this branch if you're OK with it.
