### PR TITLE
psconvert: Use -dNOSAFER to allow gs access file systems

### DIFF
--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -1602,7 +1602,7 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 	else	/* For rasters */
 		gs_params = (gsVersion.major >= 9 && gsVersion.minor >= 21) ? gs_params_rasnew : gs_params_rasold;
 
-	gs_BB = "-q -dSAFER -dNOPAUSE -dBATCH -sDEVICE=bbox -DPSL_no_pagefill"; /* -r defaults to 4000, see http://pages.cs.wisc.edu/~ghost/doc/cvs/Devices.htm#Test */
+	gs_BB = "-q -dNOSAFER -dNOPAUSE -dBATCH -sDEVICE=bbox -DPSL_no_pagefill"; /* -r defaults to 4000, see http://pages.cs.wisc.edu/~ghost/doc/cvs/Devices.htm#Test */
 
 	add_to_list (Ctrl->C.arg, "-dMaxBitmap=2147483647");	/* Add this as GS option to fix bug in GS */
 


### PR DESCRIPTION
See #2460 for context. We need to use `-dNOSAFER` since gs950.