### PR TITLE
Add title sequence and fading options to movie

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -18,6 +18,7 @@ Synopsis
 |-T|\ *nframes*\ \|\ *min*/*max*/*inc*\ [**+n**\ ]\ \|\ *timefile*\ [**+p**\ *width*]\ [**+s**\ *first*]\ [**+w**]
 [ |-A|\ [**+l**\ [*n*]]\ [**+s**\ *stride*] ]
 [ |-D|\ *displayrate* ]
+[ |-E|\ *titlepage*\ [**+d**\ *duration*\ [**s**]][**+f**\ [**+i**\ \|\ **o**]\ *fade*\ [**s**]]]
 [ |-F|\ *format*\ [**+o**\ *options*\ ]]
 [ |-G|\ [*fill*]\ [**+p**\ *pen*] ]
 [ |-H|\ *factor*\ ]
@@ -122,6 +123,15 @@ Optional Arguments
 
 **-D**\ *displayrate*
     Set the display frame rate in frames per seconds for the final animation [24].
+
+.. _-E:
+
+**-E**\ *titlepage*\ [**+d**\ *duration*\ [**s**]][**+f**\ [**i**\ \|\ **o**]\ *fade*\ [**s**]]]
+    Give *titlepage* script that creates a static title page for the movie [no title].
+    Alternatively, *titlepage* can be a PostScript plot layer of dimensions exacly matching the cancas size.
+    Control how long it should be displayed with **+d** in frames (append *s** for duration in seconds instead) [4s].
+    Optionally, supply fade **i**\ n and **o**\ ut durations (in frames or seconds) as well [no fading].
+    Fading affects the beginning and end of the title page *duration*.
 
 .. _-F:
 

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -420,7 +420,7 @@ Title Sequence and Fading
    :width: 500 px
    :align: center
 
-   The fade-level (0 means black, 1 means normal visibility) for the complete movie, including
+   The fade-level (0 means black, 100 means normal visibility) for the complete movie, including
    an optional title sequence.
 
 The complete movie may have a leading title sequence (**-E**) of given *duration*. A short section

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -413,6 +413,22 @@ The default pen thickness for the linear static lines is the smallest of 2.5% of
 If no size is specified (**+w**) then we default to 5% of cancas width for the three circular indicators and
 60% of the relevant canvas dimension for the linear indicators.
 
+Title Sequence and Fading
+-------------------------
+
+.. figure:: /_images/GMT_title_fade.*
+   :width: 500 px
+   :align: center
+
+   The fade-level (0 means black, 1 means normal visibility) for the complete movie, including
+   an optional title sequence.
+
+The complete movie may have a leading title sequence (**-E**) of a given duration. A short part
+at the beginning and end may be designated to fade in/out via black.  The main animation
+sequence may also have fade in/out (**-K**). Here, you can choose to fade in/out during parts of
+the animation or you can "freeze" the first and last animation frame and only fade in/out using
+those static images (via modifier **+p** to preserve the animation sequence).
+
 Examples
 --------
 

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -131,7 +131,7 @@ Optional Arguments
     Give *titlepage* script that creates a static title page for the movie [no title].
     Alternatively, *titlepage* can be a PostScript plot layer of dimensions exacly matching the cancas size.
     Control how long it should be displayed with **+d** in frames (append *s** for duration in seconds instead) [4s].
-    Optionally, supply fade **i**\ n and **o**\ ut durations (in frames or seconds) as well [no fading].
+    Optionally, supply fade **i**\ n and **o**\ ut durations (in frames or seconds [1s]) as well [no fading].
     Fading affects the beginning and end of the title page *duration*.
 
 .. _-F:
@@ -174,7 +174,7 @@ Optional Arguments
 
 **-K**\ [**+i**\ \|\ **o**]\ *fade*\ [**s**]\ [**+p**]]
     Add fading in and out for the main animation sequence [no fading]. Append
-    the length of the fading in number of frames (or seconds by appending **s**).
+    the length of the fading in number of frames (or seconds by appending **s**) [1s].
     For different lengths of fading in and out you can repeat the **-K** option
     by appending the **i** or **o** directives.  Normally, fading will affect the
     first and last animation frames.  Append **+p** to preserve these by instead

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -23,6 +23,7 @@ Synopsis
 [ |-G|\ [*fill*]\ [**+p**\ *pen*] ]
 [ |-H|\ *factor*\ ]
 [ |-I|\ *includefile* ]
+[ |-K|\ [**+i**\ \|\ **o**]\ *fade*\ [**s**]\ [**+p**]]
 [ |-L|\ *labelinfo* ]
 [ |-M|\ [*frame*],[*format*] ]
 [ |-P|\ *progress* ]
@@ -167,6 +168,17 @@ Optional Arguments
     Insert the contents of *includefile* into the movie_init.sh script that is accessed by all movie scripts.
     This mechanism is used to add information (typically constant variable assignments) that the *mainscript*
     and any optional **-S** scripts rely on.
+
+.. _-K:
+
+
+**-K**\ [**+i**\ \|\ **o**]\ *fade*\ [**s**]\ [**+p**]]
+    Add fading in and out for the main animation sequence [no fading]. Append
+    the length of the fading in number of frames (or seconds by appending **s**).
+    For different lengths of fading in and out you can repeat the **-K** option
+    by appending the **i** or **o** directives.  Normally, fading will affect the
+    first and last animation frames.  Append **+p** to preserve these by instead
+    fading in and out on only the first and last animation frame.
 
 .. _-L:
 

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -18,12 +18,12 @@ Synopsis
 |-T|\ *nframes*\ \|\ *min*/*max*/*inc*\ [**+n**\ ]\ \|\ *timefile*\ [**+p**\ *width*]\ [**+s**\ *first*]\ [**+w**]
 [ |-A|\ [**+l**\ [*n*]]\ [**+s**\ *stride*] ]
 [ |-D|\ *displayrate* ]
-[ |-E|\ *titlepage*\ [**+d**\ *duration*\ [**s**]][**+f**\ [**+i**\ \|\ **o**]\ *fade*\ [**s**]]]
+[ |-E|\ *titlepage*\ [**+d**\ *duration*\ [**s**]][**+f**\ [**+i**\ \|\ **o**]\ *fade*\ [**s**]] ]
 [ |-F|\ *format*\ [**+o**\ *options*\ ]]
 [ |-G|\ [*fill*]\ [**+p**\ *pen*] ]
 [ |-H|\ *factor*\ ]
 [ |-I|\ *includefile* ]
-[ |-K|\ [**+i**\ \|\ **o**]\ *fade*\ [**s**]\ [**+p**]]
+[ |-K|\ [**+i**\ \|\ **o**]\ *fade*\ [**s**]\ [**+p**] ]
 [ |-L|\ *labelinfo* ]
 [ |-M|\ [*frame*],[*format*] ]
 [ |-P|\ *progress* ]
@@ -127,11 +127,11 @@ Optional Arguments
 
 .. _-E:
 
-**-E**\ *titlepage*\ [**+d**\ *duration*\ [**s**]][**+f**\ [**i**\ \|\ **o**]\ *fade*\ [**s**]]]
+**-E**\ *titlepage*\ [**+d**\ *duration*\ [**s**]][**+f**\ [**i**\ \|\ **o**]\ *fade*\ [**s**]]
     Give *titlepage* script that creates a static title page for the movie [no title].
     Alternatively, *titlepage* can be a PostScript plot layer of dimensions exacly matching the cancas size.
-    Control how long it should be displayed with **+d** in frames (append *s** for duration in seconds instead) [4s].
-    Optionally, supply fade **i**\ n and **o**\ ut durations (in frames or seconds [1s]) as well [no fading].
+    Control how long it should be displayed with **+d** in number of frames (append *s** for duration in seconds instead) [4s].
+    Optionally, supply *fade* **i**\ n and **o**\ ut durations (in frames or seconds [1s]) as well [no fading].
     Fading affects the beginning and end of the title page *duration*.
 
 .. _-F:
@@ -172,13 +172,13 @@ Optional Arguments
 .. _-K:
 
 
-**-K**\ [**+i**\ \|\ **o**]\ *fade*\ [**s**]\ [**+p**]]
+**-K**\ [**+i**\ \|\ **o**]\ *fade*\ [**s**]\ [**+p**]
     Add fading in and out for the main animation sequence [no fading]. Append
     the length of the fading in number of frames (or seconds by appending **s**) [1s].
     For different lengths of fading in and out you can repeat the **-K** option
     by appending the **i** or **o** directives.  Normally, fading will affect the
     first and last animation frames.  Append **+p** to preserve these by instead
-    fading in and out on only the first and last animation frame.
+    fading in and out on only the first and last (repeated) animation frames.
 
 .. _-L:
 
@@ -217,7 +217,7 @@ Optional Arguments
 
 **-P**\ *progress*
     Automatic placement of progress indicator(s). Repeatable up to 32 indicators.  Places the chosen indicator at the frame perimeter.
-    Select from six indicators called a-f.  Indicators a-c are different types of circular indicators while d-f are
+    Select from six indicators called a-f [a].  Indicators a-c are different types of circular indicators while d-f are
     linear (axis-like) indicators.  Specify dimension of the indicator with **+w**\ *width* [5% of max canvas dimension for
     circular indicators and 60% of relevant canvas dimension for the linear indicators] and placement via **+j**\ *justify*
     [TR for circular and BC for axes]. Indicators b-f can optionally add annotations if modifier **+a** is used, append one of
@@ -331,7 +331,7 @@ Instead of passing GMT modern scripts to **-S** you can alternatively provide th
 plot layer files. Note that these must exactly match the canvas size.  As a simple example, if you are
 making a HD movie using the US unit dimensions then a background pink layer would be created by::
 
-    gmt psbasemap -R0/9.6/0/5.4 -Jx1i -B+gpink -X0 -Y0 -P --PS_MEDIA=9.6ix5.4i > background.ps
+    gmt basemap -R0/9.6/0/5.4 -Jx1i -B+gpink -X0 -Y0 --PS_MEDIA=9.6ix5.4i -ps background
 
 Note the canvas selection via :ref:`PS_MEDIA <PS_MEDIA>`, the matching region and projection, and
 the zero location of the origin.
@@ -423,20 +423,20 @@ Title Sequence and Fading
    The fade-level (0 means black, 1 means normal visibility) for the complete movie, including
    an optional title sequence.
 
-The complete movie may have a leading title sequence (**-E**) of a given duration. A short part
+The complete movie may have a leading title sequence (**-E**) of given *duration*. A short section
 at the beginning and end may be designated to fade in/out via black.  The main animation
-sequence may also have fade in/out (**-K**). Here, you can choose to fade in/out during parts of
+sequence may also have fade in/out (**-K**). Here, you can choose to fade in/out during the beginning and end section of
 the animation or you can "freeze" the first and last animation frame and only fade in/out using
-those static images (via modifier **+p** to preserve the animation sequence).
+those static images (via modifier **+p** to preserve the whole animation sequence).
 
 Examples
 --------
 
 To make an animated GIF movie based on the script globe.sh, which simply spins a globe using the
 frame number to serve as the view longitude, using a custom square 600x600 pixel canvas and 360 frames,
-and place a frame counter in the top left corner, try::
+place a frame counter in the top left corner, and place a progress indicator in the top right corner, try::
 
-    gmt movie globe.sh -Nglobe -T360 -Agif -C6ix6ix100 -Lf
+    gmt movie globe.sh -Nglobe -T360 -Agif -C6ix6ix100 -Lf -P
 
 Here, the globe.sh bash script simply plots a map with :doc:`coast` but uses the frame number variable
 as the center longitude::
@@ -448,7 +448,7 @@ as the center longitude::
 As the automatic frame loop is executed the different frames will be produced with different
 longitudes.  The equivalent DOS batch script setup would be::
 
-    gmt movie globe.bat -Nglobe -T360 -Agif -C6ix6ix100 -Lf
+    gmt movie globe.bat -Nglobe -T360 -Agif -C6ix6ix100 -Lf -P
 
 Now, the globe.bat DOS script is simply::
 

--- a/doc/rst/source/psconvert.rst
+++ b/doc/rst/source/psconvert.rst
@@ -64,7 +64,7 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ [**+g**\ *paint*\ ][**+m**\ *margins*][**+n**][**+p**\ [\ *pen*\ ]][**+r**][**+s**\ [**m**]\ \|\ **S**\ *width*\ [**u**]/\ *height*\ [**u**]][**+u**]
+**-A**\ [**+f**\ *fade*\ ][**+g**\ *paint*\ ][**+m**\ *margins*][**+n**][**+p**\ [\ *pen*\ ]][**+r**][**+s**\ [**m**]\ \|\ **S**\ *width*\ [**u**]/\ *height*\ [**u**]][**+u**]
     Adjust the BoundingBox and HiResBoundingBox to the minimum required
     by the image content. Append **+n** to leave the BoundingBoxes as they are
     (e.g., to override any automatic setting of **-A** by **-W**).
@@ -86,6 +86,7 @@ Optional Arguments
     This is going against Adobe Law but can be useful when creating very small images
     where the difference of one pixel might matter.
     If **-V** is used we also report the dimensions of the illustration.
+    Use **-A+f**\ *fade* to fade the entire plot towards black (100%) [no fading, 0].
     Use **-A+g**\ *paint* to paint the BoundingBox behind the illustration and
     use **-A+p**\ [\ *pen*] to draw the BoundingBox outline (append a pen or accept
     the default pen of 0.25p,black).

--- a/doc/scripts/GMT_title_fade.ps
+++ b/doc/scripts/GMT_title_fade.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.1.0_a7ee8a3_2020.01.20 [64-bit] Document from psxy
+%%Title: GMT v6.1.0_838c135_2020.01.20 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Jan 20 11:10:06 2020
+%%CreationDate: Mon Jan 20 11:39:49 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -661,8 +661,8 @@ FQ
 O0
 1200 1200 TM
 % PostScript produced by:
-%@GMT: gmt psxy -R0/15/0/1.4 -JX6i/1i -BxcB.txt -Bya1f+lfade-level -W1.5p -BWS curve.txt
-%@PROJ: xy 0.00000000 15.00000000 0.00000000 1.40000000 0.000 15.000 0.000 1.400 +xy
+%@GMT: gmt psxy -R0/15/0/140 -JX6i/1i -BxcB.txt -Byaf+lfade-level -W1.5p -BWS curve.txt
+%@PROJ: xy 0.00000000 15.00000000 0.00000000 140.00000000 0.000 15.000 0.000 140.000 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
@@ -683,25 +683,28 @@ N 0 1200 M 0 -1200 D S
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
+N 0 429 M -83 0 D S
 N 0 857 M -83 0 D S
 /PSL_AH0 0
 /MM {neg exch M} def
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sw mx
-(1) sw mx
+(50) sw mx
+(100) sw mx
 def
 /PSL_A0_y PSL_A0_y 83 add def
 0 PSL_A0_y MM
 (0) mr Z
+429 PSL_A0_y MM
+(50) mr Z
 857 PSL_A0_y MM
-(1) mr Z
+(100) mr Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
 N 0 86 M -42 0 D S
 N 0 171 M -42 0 D S
 N 0 257 M -42 0 D S
 N 0 343 M -42 0 D S
-N 0 429 M -42 0 D S
 N 0 514 M -42 0 D S
 N 0 600 M -42 0 D S
 N 0 686 M -42 0 D S
@@ -866,8 +869,8 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt pstext -F+f10p+jCB -R0/15/0/1.4 -JX6i/1i
-%@PROJ: xy 0.00000000 15.00000000 0.00000000 1.40000000 0.000 15.000 0.000 1.400 +xy
+%@GMT: gmt pstext -F+f10p+jCB -R0/15/0/140 -JX6i/1i
+%@PROJ: xy 0.00000000 15.00000000 0.00000000 140.00000000 0.000 15.000 0.000 140.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
@@ -890,8 +893,8 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt psxy -Sv24p+bt+et+s -W1.5p,red -N -R0/15/0/1.4 -JX6i/1i
-%@PROJ: xy 0.00000000 15.00000000 0.00000000 1.40000000 0.000 15.000 0.000 1.400 +xy
+%@GMT: gmt psxy -Sv24p+bt+et+s -W1.5p,red -N -R0/15/0/140 -JX6i/1i
+%@PROJ: xy 0.00000000 15.00000000 0.00000000 140.00000000 0.000 15.000 0.000 140.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin

--- a/doc/scripts/GMT_title_fade.ps
+++ b/doc/scripts/GMT_title_fade.ps
@@ -1,0 +1,943 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.1.0_a7ee8a3_2020.01.20 [64-bit] Document from psxy
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Mon Jan 20 11:10:06 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt psxy -R0/15/0/1.4 -JX6i/1i -BxcB.txt -Bya1f+lfade-level -W1.5p -BWS curve.txt
+%@PROJ: xy 0.00000000 15.00000000 0.00000000 1.40000000 0.000 15.000 0.000 1.400 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+N 0 0 M 0 1200 D S
+N 480 0 M 0 1200 D S
+N 2400 0 M 0 1200 D S
+N 2880 0 M 0 1200 D S
+N 3360 0 M 0 1200 D S
+N 6720 0 M 0 1200 D S
+N 7200 0 M 0 1200 D S
+2 setlinecap
+25 W
+N 0 1200 M 0 -1200 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 857 M -83 0 D S
+/PSL_AH0 0
+/MM {neg exch M} def
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) sw mx
+(1) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+857 PSL_A0_y MM
+(1) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 86 M -42 0 D S
+N 0 171 M -42 0 D S
+N 0 257 M -42 0 D S
+N 0 343 M -42 0 D S
+N 0 429 M -42 0 D S
+N 0 514 M -42 0 D S
+N 0 600 M -42 0 D S
+N 0 686 M -42 0 D S
+N 0 771 M -42 0 D S
+N 0 943 M -42 0 D S
+N 0 1029 M -42 0 D S
+N 0 1114 M -42 0 D S
+N 0 1200 M -42 0 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
+600 PSL_L_y MM
+V 90 R (fade­level) bc Z U
+25 W
+N 0 0 M 7200 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 480 0 M 0 -83 D S
+N 2400 0 M 0 -83 D S
+N 2880 0 M 0 -83 D S
+N 3360 0 M 0 -83 D S
+N 6720 0 M 0 -83 D S
+N 7200 0 M 0 -83 D S
+/PSL_AH0 0
+/MM {neg M} def
+200 F0
+(0) sh mx
+V MU 0 0 M (t) FP 0 -50 G 140 F0 (i) FP 0 50 G pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (t) FP 0 -50 G 140 F0 (o) FP 0 50 G pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (t) FP 0 -50 G 140 F0 (b) FP 0 50 G pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (f) FP 0 -50 G 140 F0 (i) FP 0 50 G pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (f) FP 0 -50 G 140 F0 (o) FP 0 50 G pathbbox N 4 1 roll pop pop pop U mx
+V MU 0 0 M (t) FP 0 -50 G 140 F0 (e) FP 0 50 G pathbbox N 4 1 roll pop pop pop U mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+480 PSL_A0_y MM
+V MU 0 0 M (t) FP 0 -50 G 140 F0 (i) FP 0 50 G pathbbox N pop exch pop add U -2 div 0 G
+(t) Z
+0 -50 G 140 F0 (i) Z
+0 50 G 2400 PSL_A0_y MM
+200 F0
+V MU 0 0 M (t) FP 0 -50 G 140 F0 (o) FP 0 50 G pathbbox N pop exch pop add U -2 div 0 G
+(t) Z
+0 -50 G 140 F0 (o) Z
+0 50 G 2880 PSL_A0_y MM
+200 F0
+V MU 0 0 M (t) FP 0 -50 G 140 F0 (b) FP 0 50 G pathbbox N pop exch pop add U -2 div 0 G
+(t) Z
+0 -50 G 140 F0 (b) Z
+0 50 G 3360 PSL_A0_y MM
+200 F0
+V MU 0 0 M (f) FP 0 -50 G 140 F0 (i) FP 0 50 G pathbbox N pop exch pop add U -2 div 0 G
+(f) Z
+0 -50 G 140 F0 (i) Z
+0 50 G 6720 PSL_A0_y MM
+200 F0
+V MU 0 0 M (f) FP 0 -50 G 140 F0 (o) FP 0 50 G pathbbox N pop exch pop add U -2 div 0 G
+(f) Z
+0 -50 G 140 F0 (o) Z
+0 50 G 7200 PSL_A0_y MM
+200 F0
+V MU 0 0 M (t) FP 0 -50 G 140 F0 (e) FP 0 50 G pathbbox N pop exch pop add U -2 div 0 G
+(t) Z
+0 -50 G 140 F0 (e) Z
+0 50 G N 0 0 M 0 -42 D S
+N 480 0 M 0 -42 D S
+N 2400 0 M 0 -42 D S
+N 2880 0 M 0 -42 D S
+N 3360 0 M 0 -42 D S
+N 6720 0 M 0 -42 D S
+N 7200 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 setlinecap
+25 W
+clipsave
+0 0 M
+7200 0 D
+0 1200 D
+-7200 0 D
+P
+PSL_clip N
+0 0 M
+20 4 D
+20 11 D
+20 18 D
+20 24 D
+20 32 D
+20 37 D
+40 88 D
+60 159 D
+80 220 D
+40 96 D
+20 43 D
+20 37 D
+20 31 D
+20 25 D
+20 18 D
+20 10 D
+20 4 D
+1920 0 D
+20 -4 D
+20 -10 D
+20 -18 D
+20 -25 D
+20 -31 D
+20 -37 D
+40 -89 D
+40 -104 D
+100 -274 D
+20 -51 D
+40 -88 D
+20 -37 D
+20 -32 D
+20 -24 D
+20 -18 D
+20 -11 D
+20 -4 D
+20 4 D
+20 11 D
+20 18 D
+20 24 D
+20 32 D
+20 37 D
+40 88 D
+60 159 D
+80 220 D
+40 96 D
+20 43 D
+20 37 D
+20 31 D
+20 25 D
+20 18 D
+20 10 D
+20 4 D
+3360 0 D
+20 -4 D
+20 -10 D
+20 -18 D
+20 -25 D
+20 -31 D
+20 -37 D
+40 -89 D
+40 -104 D
+100 -274 D
+20 -51 D
+40 -88 D
+20 -37 D
+20 -32 D
+20 -24 D
+20 -18 D
+20 -11 D
+20 -4 D
+S
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt pstext -F+f10p+jCB -R0/15/0/1.4 -JX6i/1i
+%@PROJ: xy 0.00000000 15.00000000 0.00000000 1.40000000 0.000 15.000 0.000 1.400 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 1200 D
+-7200 0 D
+P
+PSL_clip N
+1440 1029 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+167 F0
+(TITLE SEQUENCE) bc Z
+5040 1029 M (ANIMATION SEQUENCE) bc Z
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt psxy -Sv24p+bt+et+s -W1.5p,red -N -R0/15/0/1.4 -JX6i/1i
+%@PROJ: xy 0.00000000 15.00000000 0.00000000 1.40000000 0.000 15.000 0.000 1.400 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_vecheadpen {25 W 1 0 0 C [] 0 B} def
+25 W
+1 0 0 C
+V
+O1
+25 W
+V 0 943 T N 0 0 M 2880 0 D S
+PSL_vecheadpen
+25 W
+0 -107 M
+0 214 D
+S
+U
+V 2880 943 T PSL_vecheadpen
+25 W
+0 -107 M
+0 214 D
+S
+U
+25 W
+V 2880 943 T N 0 0 M 4320 0 D S
+PSL_vecheadpen
+25 W
+0 -107 M
+0 214 D
+S
+U
+V 7200 943 T PSL_vecheadpen
+25 W
+0 -107 M
+0 214 D
+S
+U
+U
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/doc/scripts/GMT_title_fade.sh
+++ b/doc/scripts/GMT_title_fade.sh
@@ -9,19 +9,19 @@ gmt begin GMT_title_fade
 	14	afg	f@-o@-
 	15	afg	t@-e@-
 	EOF
-	gmt math -T0/1/25+n 1 PI T MUL COS SUB 2 DIV = curve.txt
-	gmt math -T1/5/1 1 = >> curve.txt
-	gmt math -T5/6/25+n 1 PI T 5 SUB MUL COS ADD 2 DIV = >> curve.txt
-	gmt math -T6/7/25+n 1 PI T 6 SUB MUL COS SUB 2 DIV = >> curve.txt
-	gmt math -T7/14/1 1 = >> curve.txt
-	gmt math -T14/15/25+n 1 PI T 14 SUB MUL COS ADD 2 DIV = >> curve.txt
-	gmt plot -R0/15/0/1.4 -JX6i/1i -BxcB.txt -Bya1f+l"fade-level" -W1.5p -BWS curve.txt
+	gmt math -T0/1/25+n 1 PI T MUL COS SUB 2 DIV 100 MUL = curve.txt
+	gmt math -T1/5/1 100 = >> curve.txt
+	gmt math -T5/6/25+n 1 PI T 5 SUB MUL COS ADD 2 DIV 100 MUL = >> curve.txt
+	gmt math -T6/7/25+n 1 PI T 6 SUB MUL COS SUB 2 DIV 100 MUL = >> curve.txt
+	gmt math -T7/14/1 100 = >> curve.txt
+	gmt math -T14/15/25+n 1 PI T 14 SUB MUL COS ADD 2 DIV 100 MUL = >> curve.txt
+	gmt plot -R0/15/0/140 -JX6i/1i -BxcB.txt -Byaf+l"fade-level" -W1.5p -BWS curve.txt
 	gmt text -F+f10p+jCB <<- EOF
-	3 1.2 TITLE SEQUENCE
-	10.5 1.2 ANIMATION SEQUENCE
+	3 120 TITLE SEQUENCE
+	10.5 120 ANIMATION SEQUENCE
 	EOF
 	gmt plot -Sv24p+bt+et+s -W1.5p,red -N <<- EOF
-	0    1.1     6     1.1
-	6    1.1     15     1.1
+	0	110	6	110
+	6	110	15	110
 	EOF
 gmt end show

--- a/doc/scripts/GMT_title_fade.sh
+++ b/doc/scripts/GMT_title_fade.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+gmt begin GMT_title_fade
+	cat <<- EOF > B.txt
+	0	afg	0
+	1	afg	t@-i@-
+	5	afg	t@-o@-
+	6	afg	t@-b@-
+	7	afg	f@-i@-
+	14	afg	f@-o@-
+	15	afg	t@-e@-
+	EOF
+	gmt math -T0/1/25+n 1 PI T MUL COS SUB 2 DIV = curve.txt
+	gmt math -T1/5/1 1 = >> curve.txt
+	gmt math -T5/6/25+n 1 PI T 5 SUB MUL COS ADD 2 DIV = >> curve.txt
+	gmt math -T6/7/25+n 1 PI T 6 SUB MUL COS SUB 2 DIV = >> curve.txt
+	gmt math -T7/14/1 1 = >> curve.txt
+	gmt math -T14/15/25+n 1 PI T 14 SUB MUL COS ADD 2 DIV = >> curve.txt
+	gmt plot -R0/15/0/1.4 -JX6i/1i -BxcB.txt -Bya1f+l"fade-level" -W1.5p -BWS curve.txt
+	gmt text -F+f10p+jCB <<- EOF
+	3 1.2 TITLE SEQUENCE
+	10.5 1.2 ANIMATION SEQUENCE
+	EOF
+	gmt plot -Sv24p+bt+et+s -W1.5p,red -N <<- EOF
+	0    1.1     6     1.1
+	6    1.1     15     1.1
+	EOF
+gmt end show

--- a/src/movie.c
+++ b/src/movie.c
@@ -497,7 +497,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-M Create a master frame plot as well; append comma-separated frame number [0] and format [pdf].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Master plot will be named <prefix>.<format> and placed in the current directory.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-P Automatic plotting of progress indicator(s); repeatable (max 32).  Places chosen indicator at frame perimeter.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append desired indicator (a-f) and consult the movie documentation for which attributes are needed:\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Append desired indicator (a-f) [a] and consult the movie documentation for which attributes are needed:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use +j<refpoint> to specify where the indicator should be plotted [TR for circles, BC for axes].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use +w<width> to specify size [5%% of max canvas dimension for circles, 60%% for axes].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +a[e|f|p|c<col>] to add annotations (see -L for details):\n");
@@ -984,7 +984,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_O
 					break;
 				}
 				I = &Ctrl->item[MOVIE_ITEM_IS_PROG_INDICATOR][T];	/* Shorthand for the current progress indicator item */
-				I->kind = opt->arg[0];	/* This is a progress indicator item */
+				I->kind = (opt->arg[0] && strchr ("abcdef", opt->arg[0])) ? opt->arg[0] : 'a';	/* This is a progress indicator item [Default to a] */
 				n_errors += parse_common_item_attributes (GMT, 'P', opt->arg, I);
 				if (gmt_get_modifier (opt->arg, 'G', I->fill2) && I->fill2[0]) {	/* Secondary fill */
 					if (gmt_getfill (GMT, I->fill2, &fill)) n_errors++;

--- a/src/movie.c
+++ b/src/movie.c
@@ -1875,6 +1875,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 				char label[GMT_LEN256] = {""}, name[GMT_LEN32] = {""};
 				unsigned int type, use_frame, p;
 				double t;
+				struct GMT_FONT *F = (k == MOVIE_ITEM_IS_LABEL) ? &GMT->current.setting.font_title : &GMT->current.setting.font_annot[GMT_SECONDARY];	/* Default font for labels and progress indicators  */
 				/* Set MOVIE_N_{LABEL|PROG_INDICATOR}S as exported environmental variable. gmt_add_figure will check for this and if found create gmt.movielabels in session directory */
 				/* Note: All dimensions are written in inches and read as inches in gmt_plotinit */
 				fprintf (fp, "%s", export[Ctrl->In.mode]);
@@ -1887,7 +1888,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 					/* Place kind|x|y|t|width|just|clearance_x|clearance_Y|pen|pen2|fill|fill2|font|txt in MOVIE_{LABEL|PROG_INDICATOR}_ARG */
 					sprintf (label, "%c|%g|%g|%g|%g|%d|%g|%g|%s|%s|%s|%s|%s|", I->kind, I->x, I->y, t, I->width,
 						I->justify, I->clearance[GMT_X], I->clearance[GMT_Y], I->pen, I->pen2,
-						I->fill, I->fill2, (I->font.size > 0.0) ? gmt_putfont (GMT, &I->font) : "-");
+						I->fill, I->fill2, (I->font.size > 0.0) ? gmt_putfont (GMT, &I->font) : gmt_putfont (GMT, F));
 					string[0] = '\0';
 					for (p = 0; p < I->n_labels; p++) {	/* Here, n_lables is 0 (no labels), 1 (just at the current time) or 2 (start/end times) */
 						if (I->n_labels == 2)	/* Want start/stop values, not currrent frame value */


### PR DESCRIPTION
This PR adds several two major new features to movie and in the process closes #1391:

- A new option **-E**_titlepage_[**+d**_duration_][**+f**[**i**|**o**]_fade_][**s**] that accepts a GMT modern mode script for producing a title page [alternatively, it can be a _PostScript_ page]. The title page is rendered before the main animation sequence for the selected duration [4 seconds].  The beginning and end of this sequence can optionally fade in/out via black [no fading].
- A new option **-K**[**i**|**o**]_fade_[**s**][**+p**] adds fading in/out to the main animation sequence [no fading].  Normally, this means the beginning and end of the sequence will be affected.  If you do not want to loose some of the sequence to fading you can preserve (**+p**) the sequence and then we instead only fade using the static first and last image in the sequence.

The movie documentation has been updated with a fade-level chart indicating how fading affects the title sequence and the main animation sequence.  The implementation of fading required a new modifier to psconvert **-A**: **+f**_fade_ since it has to be applied by painting the entire bounding box black with transparency at the very end.  The *fade* value is in the 0-100 range with 0 meaning no fade (and no bounding box painting takes place) to 100 (resulting in a pure black picture).

As an example of the use of **-E -K** I have updated the _globequakes_ movie I presented at AGU's 2019 eLightning session.  I added a plain title page with fading as well as preserved fading for the main animation sequence (I also added a progress indicator in the upper right corner).  You can see the updated movie [here](https://www.dropbox.com/s/3cr0ont2xowhkpx/globequakes.mp4?dl=0).