### PR TITLE
Make sure grdtrack finds numerical input

### DIFF
--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -1154,7 +1154,10 @@ int GMT_grdtrack (void *V_API, int mode, void *args) {
 			}
 
 			/* Data record to process */
-			in = In->data;	/* Only need to process numerical part here */
+			if ((in = In->data) == NULL) {	/* Only need to process numerical part here */
+				GMT_Report (API, GMT_MSG_NORMAL, "Record %" PRIu64 " did not have two coordinates - skipped.\n", n_read);
+				continue;
+			}
 			if (n_out == 0) {	/* First time we need to determine # of columns and allocate output vector */
 				n_lead = (unsigned int)gmt_get_cols (GMT, GMT_IN);	/* Get total # of input cols */
 				n_out = n_lead + Ctrl->G.n_grids;	/* Get total # of output cols */


### PR DESCRIPTION
It crashed because no space between x and y meant the resulting beast was seen as a trailing text and hence `In->data` was NULL. Closes #2478.