### PR TITLE
Give error if a -Tmin/max/inc yields no points

### DIFF
--- a/doc/rst/source/explain_array.rst_
+++ b/doc/rst/source/explain_array.rst_
@@ -2,8 +2,9 @@ Generate 1D Array
 -----------------
 
 Make an evenly spaced coordinate array from *min* to *max* in steps of *inc*.
-Append **+b** if we should take log2 of *min* and *max* and build an equidistant
-log2-array using *inc* integer increments in log2.
+Append **+b** if we should take log2 of *min* and *max*, get their nearest integers, build an equidistant
+log2-array using *inc* integer increments in log2, then undo the log2 conversion
+(e.g., 3/20/1+b will yield 4,8,16).
 Append **+l** if we should take log10 of *min* and *max* and build an
 array where *inc* can be 1 (every magnitude), 2, (1, 2, 5 times magnitude) or 3
 (1-9 times magnitude).  For less than every magnitude, use a negative integer *inc*.

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16042,6 +16042,10 @@ unsigned int gmt_create_array (struct GMT_CTRL *GMT, char option, struct GMT_ARR
 		(void) gmt_init_time_system_structure (GMT, &GMT->current.setting.time_system);
 		for (k = 0; k < T->n; k++) T->array[k] *= scale;
 	}
+	if (T->n == 0) {
+		GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Syntax error -%c option: Your min/max/inc arguments resulted in no items\n", option);
+		return (GMT_PARSE_ERROR);
+	}
 	return (GMT_NOERROR);
 }
 


### PR DESCRIPTION
This can happen when bad args are given for logarithmic of log2 sequences.  Also fixed order of allocations in filter1d and free memory before quitting.  Closes #2483.

