### PR TITLE
Fix movie fonts

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -7316,10 +7316,10 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 				return NULL;	/* Should never happen */
 			}
 			/* Because this PostScript procedure runs outside the main gsave/grestore block the origin is at (0,0) */
-			if (font[0] == '-')	/* Set default TAG font */
-				gmt_M_memcpy (&Tfont, &(GMT->current.setting.font_tag), 1, struct GMT_FONT);	/* Tag font is the default labeling font for labels */
-			else	/* Gave a specific font */
-				gmt_getfont (GMT, font, &Tfont);	/* We already parsed the font string in movie.c for correctness */
+			if (font[0] == '+')	/* User provided a specific font/size which we must honor */
+				gmt_getfont (GMT, &font[1], &Tfont);	/* We already parsed the font string in movie.c for correctness */
+			else	/* Pick up the default font written in movie and scale it as needed */
+				gmt_getfont (GMT, font, &Tfont);
 			gmt_getfont (GMT, font, &Tfont);	/* We already parsed the font string in movie.c for correctness so no need to check here */
 			form = gmt_setfont (GMT, &Tfont);	/* Obtain and set the tag font */
 			PSL_setfont (PSL, Tfont.id);
@@ -7380,13 +7380,13 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 			}
 			/* Because this runs outside main gsave/grestore block the origin is (0,0) */
 			if (isupper (kind) && kind != 'A') {	/* Requested text labels so initialize selected font */
-				if (font[0] == '-') {	/* Set default annotation secondary font */
-					gmt_M_memcpy (&Tfont, &(GMT->current.setting.font_annot[GMT_SECONDARY]), 1, struct GMT_FONT);	/* Secondary annotation font is the default labeling font for progress indicators */
-					fsize = 0.0;	/* So we can scale at will for b-e */
+				if (font[0] == '+') {	/* User provided a specific font/size which we must honor */
+					gmt_getfont (GMT, &font[1], &Tfont);	/* We already parsed the font string in movie.c for correctness */
+					fsize = Tfont.size;	/* Must honor the given size */
 				}
-				else {	/* Gave a specific font */
-					gmt_getfont (GMT, font, &Tfont);	/* We already parsed the font string in movie.c for correctness */
-					fsize = Tfont.size;	/* Must honor the given setting */
+				else {	/* Pick up the default font written in movie and scale it as needed */
+					gmt_getfont (GMT, font, &Tfont);
+					fsize = 0.0;	/* So we can scale at will for b-e */
 				}
 				form = gmt_setfont (GMT, &Tfont);	/* Set the font to be used */
 				PSL_setfont (PSL, Tfont.id);

--- a/src/movie.c
+++ b/src/movie.c
@@ -1871,7 +1871,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 		spacer = ' ';	/* Use a space to separate date and clock for labels; this will change to T for progress -R settings */
 		for (k = MOVIE_ITEM_IS_LABEL; k <= MOVIE_ITEM_IS_PROG_INDICATOR; k++) {
 			if (Ctrl->item_active[k]) {	/* Want to place a user label or progress indicator */
-				char label[GMT_LEN256] = {""}, name[GMT_LEN32] = {""};
+				char label[GMT_LEN256] = {""}, name[GMT_LEN32] = {""}, font[GMT_LEN64] = {""};
 				unsigned int type, use_frame, p;
 				double t;
 				struct GMT_FONT *F = (k == MOVIE_ITEM_IS_LABEL) ? &GMT->current.setting.font_tag : &GMT->current.setting.font_annot[GMT_SECONDARY];	/* Default font for labels and progress indicators  */
@@ -1884,10 +1884,14 @@ int GMT_movie (void *V_API, int mode, void *args) {
 					t = (frame + 1.0) / n_frames;
 					I = &Ctrl->item[k][T];	/* Shorthand for this item */
 					sprintf (name, "MOVIE_%s_ARG%d", LP_name[k], T);
+					/* Set selected font: Prepend + if user specified a font, else just give current default font */
+					if (I->font.size > 0.0)	/* Users selected font */
+						sprintf (font, "+%s", gmt_putfont (GMT, &I->font));
+					else	/* Default font */
+						sprintf (font, "%s", gmt_putfont (GMT, F));
 					/* Place kind|x|y|t|width|just|clearance_x|clearance_Y|pen|pen2|fill|fill2|font|txt in MOVIE_{LABEL|PROG_INDICATOR}_ARG */
 					sprintf (label, "%c|%g|%g|%g|%g|%d|%g|%g|%s|%s|%s|%s|%s|", I->kind, I->x, I->y, t, I->width,
-						I->justify, I->clearance[GMT_X], I->clearance[GMT_Y], I->pen, I->pen2,
-						I->fill, I->fill2, (I->font.size > 0.0) ? gmt_putfont (GMT, &I->font) : gmt_putfont (GMT, F));
+						I->justify, I->clearance[GMT_X], I->clearance[GMT_Y], I->pen, I->pen2, I->fill, I->fill2, font);
 					string[0] = '\0';
 					for (p = 0; p < I->n_labels; p++) {	/* Here, n_lables is 0 (no labels), 1 (just at the current time) or 2 (start/end times) */
 						if (I->n_labels == 2)	/* Want start/stop values, not currrent frame value */

--- a/src/movie.c
+++ b/src/movie.c
@@ -1216,7 +1216,7 @@ int GMT_movie (void *V_API, int mode, void *args) {
 	int (*run_script)(const char *);	/* pointer to system function or a dummy */
 
 	unsigned int n_values = 0, n_frames = 0, n_data_frames, first_fade_out_frame = 0, frame, i_frame, col, p_width, p_height, k, T;
-	unsigned int n_frames_not_started = 0, n_frames_completed = 0, first_frame = 0, data_frame, n_cores_unused, n_fade_frames;
+	unsigned int n_frames_not_started = 0, n_frames_completed = 0, first_frame = 0, data_frame, n_cores_unused, n_fade_frames = 0;
 	unsigned int dd, hh, mm, ss, start, flavor[2] = {0, 0};
 
 	bool done = false, layers = false, one_frame = false, upper_case[2] = {false, false};


### PR DESCRIPTION
**Description of proposed changes**

I broke how fonts and defaults were handled.  The intent (and restored by this PR) is this:

1. Both labels and progress indicators have modifiers to specify a specific font and size.  if the user does this (via **+f**) then we honor that choice verbatim.
2. If no **+f** is given then we use the default font (`tag_font` for labels and `annot_font[SECONDARY] `for progress indicators).
3. When no user font is given for progress indicators we are free to scale the font to a suitable size that depends on the size of the progress indicators.

With these fixes the 4-5 failing tests are back up again.
