### PR TITLE
If no refpoint given we default to x0/0

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15266,6 +15266,10 @@ struct GMT_REFPOINT * gmt_get_refpoint (struct GMT_CTRL *GMT, char *arg_in, char
 				mode = GMT_REFPOINT_JUST;
 				GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Your -%c option was interpreted to mean -%c%c\n", option, option, kind[mode]);
 			}
+			else if (n == 0) {	/* Got no reference point, default to x0/0 */
+				strcpy (txt_x, "0");	strcpy (txt_y, "0");
+				mode = GMT_REFPOINT_PLOT;
+			}
 			else if ((n2 = sscanf (&arg[k], "%[^/]/%s", txt_x, txt_y)) < 2) {
 				arg[n] = '+';	/* Restore modifiers */
 				gmt_M_str_free (arg);


### PR DESCRIPTION
Since we say it is the default we should be OK with a missing refpoint
Once again, it closes #1273.