### PR TITLE
Let one-color CPTs remain discrete

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7204,7 +7204,7 @@ void gmtlib_make_continuous_colorlist (struct GMT_CTRL *GMT, struct GMT_PALETTE 
 
 /*! . */
 unsigned int gmt_validate_cpt_parameters (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, char *file, bool *interpolate, bool *force_continuous) {
-	if (P->mode & GMT_CPT_COLORLIST && !P->categorical && !(*interpolate)) {	/* Color list with -T/min/max should be seen as continuous */
+	if (P->mode & GMT_CPT_COLORLIST && !P->categorical && !(*interpolate) && P->n_colors > 1) {	/* Color list with -T/min/max should be seen as continuous */
 		*force_continuous = true, P->mode |= GMT_CPT_CONTINUOUS;
 		gmtlib_make_continuous_colorlist (GMT, P);
 	}


### PR DESCRIPTION
In commands like

`gmt makecpt -T10/20 -Cred`

we only have one slice with a constant color hence we cannot change it to continuous: that takes at least 2 colors.  Closes #2495.
