### PR TITLE
Fix -i and -o documentations

### DIFF
--- a/doc/rst/source/explain_-icols.rst_
+++ b/doc/rst/source/explain_-icols.rst_
@@ -1,2 +1,2 @@
-**-i**\ *cols*\ [**+l**\ ][\ **+s**\ *scale*][\ **+o**\ *offset*][,\ *...*][,\ *t*\ [*word*]] :ref:`(more ...) <-icols_full>`
-    Select input columns and transformations (0 is first column, *t* is trailing text, append *word* to read one word only).
+**-i**\ *cols*\ [**+l**\ ][\ **+s**\ *scale*][\ **+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]] :ref:`(more ...) <-icols_full>`
+    Select input columns and transformations (0 is first column, **t** is trailing text, append *word* to read one word only).

--- a/doc/rst/source/explain_-icols_full.rst_
+++ b/doc/rst/source/explain_-icols_full.rst_
@@ -1,6 +1,6 @@
 .. _-icols_full:
 
-**-i**\ *cols*\ [**+l**\ ][\ **+s**\ *scale*][\ **+o**\ *offset*][,\ *...*][,\ *t*\ [*word*]]
+**-i**\ *cols*\ [**+l**\ ][\ **+s**\ *scale*][\ **+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
     Select specific data columns for primary input, in arbitrary order. Columns
     not listed will be skipped. Give individual columns (or column ranges
     in the format *start*\ [:*inc*]:*stop*, where *inc* defaults to 1 if
@@ -10,7 +10,7 @@
     the input values first; **+s**\ *scale*, subsequently multiplies by a
     given  scale factor [1]; **+o**\ *offset*, finally adds a given offset [0].
     To read from a given column until the end of the record, leave off *stop*.
-    Normally, any trailing text is read but when **i** is used you must explicitly add
-    the column *t* to retain the text. To only ingest a single word from the
+    Normally, any trailing text is read but when **-i** is used you must explicitly add
+    the column **t** to retain the text. To only ingest a single word from the
     trailing text, append the word number (first word is 0).  Finally, **-in**
     will simply read the numerical input and skip any trailing text.

--- a/doc/rst/source/explain_-ocols.rst_
+++ b/doc/rst/source/explain_-ocols.rst_
@@ -1,2 +1,2 @@
-**-o**\ *cols*\ [,...][*t*\ [*word*]] :ref:`(more ...) <-ocols_full>`
-    Select output columns (0 is first column; *t* is trailing text, append *word* to write one word only).
+**-o**\ *cols*\ [,...][,\ **t**\ [*word*]] :ref:`(more ...) <-ocols_full>`
+    Select output columns (0 is first column; **t** is trailing text, append *word* to write one word only).

--- a/doc/rst/source/explain_-ocols_full.rst_
+++ b/doc/rst/source/explain_-ocols_full.rst_
@@ -1,6 +1,6 @@
 .. _-ocols_full:
 
-**-o**\ *cols*\ [,...][*t*\ [*word*]]
+**-o**\ *cols*\ [,...][,\ **t**\ [*word*]]
     Select specific data columns for primary output, in arbitrary order. Columns
     not listed will be skipped. Give columns (or column ranges
     in the format *start*\ [:*inc*]:*stop*, where *inc* defaults to 1 if
@@ -8,7 +8,7 @@
     To write from a given column until the end the columns, leave off *stop*.
     [Default writes all columns in order].
     Normally, any trailing text in the internal records will be written but
-    when **-o** is used you must explicitly add the column *t*. To only output a single word from the
+    when **-o** is used you must explicitly add the column **t**. To only output a single word from the
     trailing text, append the word number (first word is 0).  Finally, **-on** will
     simply write the numerical output only and skip any trailing text, while **-ot**
     will only output the trailing text (or selected word).  Note: If **-i** is


### PR DESCRIPTION
For -i and -o, **t** is a keyword and should be in bold.