### PR TITLE
The -h+ttitle option would not write leading comment character (#)

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -745,6 +745,8 @@ GMT_LOCAL int gmtinit_parse_h_option (struct GMT_CTRL *GMT, char *item) {
 		k = 0;
 		strncpy (GMT->common.g.string, item, GMT_LEN64-1);	/* Verbatim copy */
 	}
+	if ((c = strchr (item, '+')))	/* Found modifiers */
+		c[0] = '\0';	/* Truncate modifiers for now */
 	if (isdigit (item[k])) {	/* Specified how many records for input */
 		if (col == GMT_OUT) {
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Can only set the number of input header records; %s ignored\n", &item[k]);
@@ -771,7 +773,8 @@ GMT_LOCAL int gmtinit_parse_h_option (struct GMT_CTRL *GMT, char *item) {
 		GMT->current.setting.io_header[GMT_OUT] = true;
 	}
 
-	if ((c = strchr (item, '+'))) {	/* Found modifiers */
+	if (c) {	/* Return to the modifiers modifiers */
+		c[0] = '+';	/* Put back so strtok can work */
 		while ((gmt_strtok (c, "+", &pos, p))) {
 			switch (p[0]) {
 				case 'd':	/* Delete existing headers */
@@ -798,9 +801,8 @@ GMT_LOCAL int gmtinit_parse_h_option (struct GMT_CTRL *GMT, char *item) {
 					break;
 			}
 		}
-
+		*c = '\0';	/* Truncate the various modifiers to avoid duplicate titles, remarks etc output in command */
 	}
-	if ((c = strstr (item, "+t"))) *c = '\0';	/* Truncate the -h...+t<txt> option to avoid duplicate title output in command */
 	return (error);
 }
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -745,7 +745,7 @@ GMT_LOCAL int gmtinit_parse_h_option (struct GMT_CTRL *GMT, char *item) {
 		k = 0;
 		strncpy (GMT->common.g.string, item, GMT_LEN64-1);	/* Verbatim copy */
 	}
-	if (item[k]) {	/* Specified how many records for input */
+	if (isdigit (item[k])) {	/* Specified how many records for input */
 		if (col == GMT_OUT) {
 			GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Can only set the number of input header records; %s ignored\n", &item[k]);
 		}

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -4215,6 +4215,8 @@ void gmtlib_write_tableheader (struct GMT_CTRL *GMT, FILE *fp, char *txt) {
 		gmtlib_io_binary_header (GMT, fp, GMT_OUT);
 	else if (!txt || !txt[0])				/* Blank header */
 		fprintf (fp, "%c\n", GMT->current.setting.io_head_marker[GMT_OUT]);
+	else if (txt[0] == GMT->current.setting.io_seg_marker[GMT_OUT])
+		fprintf (fp, "%s\n", txt);
 	else {
 		fputc (GMT->current.setting.io_head_marker[GMT_OUT], fp);	/* Make sure we have # at start */
 		while (strchr ("#\t ", *txt)) txt++;	/* Skip header record indicator and leading whitespace */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -4214,9 +4214,9 @@ void gmtlib_write_tableheader (struct GMT_CTRL *GMT, FILE *fp, char *txt) {
 	if (gmt_M_binary_header (GMT, GMT_OUT))		/* Must write a binary header */
 		gmtlib_io_binary_header (GMT, fp, GMT_OUT);
 	else if (!txt || !txt[0])				/* Blank header */
-		fprintf (fp, "#\n");
+		fprintf (fp, "%c\n", GMT->current.setting.io_head_marker[GMT_OUT]);
 	else {
-		if (txt[0] != GMT->current.setting.io_head_marker[GMT_OUT]) fputc (GMT->current.setting.io_head_marker[GMT_OUT], fp);	/* Make sure we have # at start ... if not multi-segment */
+		fputc (GMT->current.setting.io_head_marker[GMT_OUT], fp);	/* Make sure we have # at start */
 		while (strchr ("#\t ", *txt)) txt++;	/* Skip header record indicator and leading whitespace */
 		fprintf (fp, " %s", txt);
 		if (txt[strlen(txt)-1] != '\n') fputc ('\n', fp);	/* Make sure we have \n at end */


### PR DESCRIPTION
We failed to write out a valid comment line starting with #.  Here, always start with writing out the designed header marker character, then skip any # and tabs to find the start of the header.

