### PR TITLE
Use recommended colon-range syntax in scripts for -i, -o.

### DIFF
--- a/doc/examples/ex08/ex08.sh
+++ b/doc/examples/ex08/ex08.sh
@@ -8,6 +8,6 @@
 gmt begin ex08
 	gmt makecpt -Ccubhelix -T-5000/0
 	gmt grd2xyz @guinea_bay.nc | gmt plot3d -B -Bz1000+l"Topography (m)" -BWSneZ+b+tETOPO5 \
-		-R-0.1/5.1/-0.1/5.1/-5000/0 -JM5i -JZ6i -p200/30 -So0.0833333ub-5000 -Wthinnest -C -i0-2,2
+		-R-0.1/5.1/-0.1/5.1/-5000/0 -JM5i -JZ6i -p200/30 -So0.0833333ub-5000 -Wthinnest -C -i0:2,2
 	echo '0.1 4.9 This is the surface of cube' | gmt text -JZ -Z0 -F+f24p,Helvetica-Bold+jTL -p
 gmt end show

--- a/doc/examples/ex10/ex10.sh
+++ b/doc/examples/ex10/ex10.sh
@@ -7,7 +7,7 @@
 gmt begin ex10
 	gmt coast -Rd -JQ0/37.5/8i -Sazure2 -Gwheat -Wfaint -A5000 -p200/40
 	gmt makecpt -Cpurple,blue,darkgreen,yellow,red -T0,1,2,3,4,5
-	gmt math -T @languages_10.txt -o0-2 -C2 3 COL ADD 4 COL ADD 5 COL ADD 6 COL ADD = \
+	gmt math -T @languages_10.txt -o0:2 -C2 3 COL ADD 4 COL ADD 5 COL ADD 6 COL ADD = \
 		| gmt text -p -Gwhite@30 -D-0.25i/0 -F+f30p,Helvetica-Bold,firebrick=thinner+jRM+z
 	gmt plot3d @languages_10.txt -R-180/180/-90/90/0/2500 -JZ2.5i -So0.3i+Z5 -C -Wthinner \
 		--FONT_TITLE=30p,Times-Bold --MAP_TITLE_OFFSET=-0.7i -p --FORMAT_GEO_MAP=dddF \

--- a/doc/examples/ex23/ex23.sh
+++ b/doc/examples/ex23/ex23.sh
@@ -36,7 +36,7 @@ gmt begin ex23
 	echo "$lon $lat" | gmt plot -Sa0.2i -Gyellow -Wthin
 
 	# Sample the distance grid at the cities and use the distance in integer km for labels
-	gmt grdtrack -Gdist.nc cities.txt -o0-2 --FORMAT_FLOAT_OUT=0:%g,1:%g,2:%.0f \
+	gmt grdtrack -Gdist.nc cities.txt -o0:2 --FORMAT_FLOAT_OUT=0:%g,1:%g,2:%.0f \
 		| gmt text -D0/-0.2i -N -Gwhite -W -C0.02i -F+f12p,Helvetica-Bold+jCT
 
 	# Clean up after ourselves:

--- a/test/blockmean/gmean.sh
+++ b/test/blockmean/gmean.sh
@@ -4,7 +4,7 @@
 # else it is 0.  If any of the 4 outputs fail then the test fails, and
 # the file fail will indicate which one(s) caused the problem.
 
-gmt blockmean @ship_15.txt -I1 -R-115/-105/20/30 -fg -E -o2-5 > dump.txt
+gmt blockmean @ship_15.txt -I1 -R-115/-105/20/30 -fg -E -o2:5 > dump.txt
 gmt blockmean @ship_15.txt -I1 -R-115/-105/20/30 -fg -E -Gfield_%s.grd -Az,s,l,h
 # Mean z:
 gmt grd2xyz field_z.grd -s -o2 > tmp

--- a/test/blockmedian/gmedian.sh
+++ b/test/blockmedian/gmedian.sh
@@ -4,7 +4,7 @@
 # else it is 0.  If any of the 6 outputs fail then the test fails, and
 # the file fail will indicate which one(s) caused the problem.
 
-gmt blockmedian @ship_15.txt -I1 -R-115/-105/20/30 -fg -E -o2-5 > dump.txt
+gmt blockmedian @ship_15.txt -I1 -R-115/-105/20/30 -fg -E -o2:5 > dump.txt
 gmt blockmedian @ship_15.txt -I1 -R-115/-105/20/30 -fg -E -Gfield_%s.grd -Az,s,l,h
 gmt blockmedian @ship_15.txt -I1 -R-115/-105/20/30 -fg -Eb -o4,5 > qdump.txt
 gmt blockmedian @ship_15.txt -I1 -R-115/-105/20/30 -fg -Eb -Gfield_%s.grd -Aq25,q75

--- a/test/blockmode/gmode.sh
+++ b/test/blockmode/gmode.sh
@@ -4,7 +4,7 @@
 # else it is 0.  If any of the 4 outputs fail then the test fails, and
 # the file fail will indicate which one(s) caused the problem.
 
-gmt blockmode @ship_15.txt -I1 -R-115/-105/20/30 -fg -E -o2-5 > dump.txt
+gmt blockmode @ship_15.txt -I1 -R-115/-105/20/30 -fg -E -o2:5 > dump.txt
 gmt blockmode @ship_15.txt -I1 -R-115/-105/20/30 -fg -E -Gfield_%s.grd -Az,s,l,h
 # Mode z:
 gmt grd2xyz field_z.grd -s -o2 > tmp

--- a/test/fitcircle/circles.sh
+++ b/test/fitcircle/circles.sh
@@ -11,10 +11,10 @@ ps=circles.ps
 
 gmt fitcircle gcircle.txt -L3 > g.txt
 gmt fitcircle scircle.txt -L3 -S > s.txt
-gpole1=`gmt convert g.txt -e"L1 N Hemisphere" -o0-1 --IO_COL_SEPARATOR=/`
-gpole2=`gmt convert g.txt -e"L2 N Hemisphere" -o0-1 --IO_COL_SEPARATOR=/`
-spole1=`gmt convert s.txt -e"L1 Small Circle Pole" -o0-1 --IO_COL_SEPARATOR=/`
-spole2=`gmt convert s.txt -e"L2 Small Circle Pole" -o0-1 --IO_COL_SEPARATOR=/`
+gpole1=`gmt convert g.txt -e"L1 N Hemisphere" -o0:1 --IO_COL_SEPARATOR=/`
+gpole2=`gmt convert g.txt -e"L2 N Hemisphere" -o0:1 --IO_COL_SEPARATOR=/`
+spole1=`gmt convert s.txt -e"L1 Small Circle Pole" -o0:1 --IO_COL_SEPARATOR=/`
+spole2=`gmt convert s.txt -e"L2 Small Circle Pole" -o0:1 --IO_COL_SEPARATOR=/`
 slat1=`grep "L1 Small Circle" s.txt | $AWK '{print 90-$NF}'`
 slat2=`grep "L2 Small Circle" s.txt | $AWK '{print 90-$NF}'`
 gmt psxy -Rg -JG-30/40/7i -P -Bg -K gcircle.txt -Sc0.04i -Gred -Xc -Yc > $ps

--- a/test/geodesy/gpsgridder1.sh
+++ b/test/geodesy/gpsgridder1.sh
@@ -7,12 +7,12 @@ ps=gpsgridder1.ps
 #V=-Vl
 INC=5m
 DEC=2
-gmt select @wus_gps_final.txt -R122.5W/115W/32.5N/40N -fg -o0-5 > data.lluv
+gmt select @wus_gps_final.txt -R122.5W/115W/32.5N/40N -fg -o0:5 > data.lluv
 # Use blockmean to avoid aliasing
 R=-R122.5W/115W/32.5N/38N
-gmt blockmean $R -I${INC} data.lluv -fg -i0,1,2,4 -W > blk.llu
+gmt blockmean $R -I${INC} data.lluv -fg -i:2,4 -W > blk.llu
 gmt blockmean $R -I${INC} data.lluv -fg -i0,1,3,5 -W > blk.llv
-gmt convert -A blk.llu blk.llv -o0-2,6,3,7 > blk.lluv
+gmt convert -A blk.llu blk.llv -o0:2,6,3,7 > blk.lluv
 #
 #  do the gridding. There are 2682 data and use about 1/4 this number of singular values
 #

--- a/test/geodesy/gpsgridder2.sh
+++ b/test/geodesy/gpsgridder2.sh
@@ -7,12 +7,12 @@ ps=gpsgridder2.ps
 #V=-Vl
 INC=5m
 DEC=2
-gmt select @wus_gps_final.txt -R122.5W/115W/32.5N/40N -fg -o0-5 > data.lluv
+gmt select @wus_gps_final.txt -R122.5W/115W/32.5N/40N -fg -o0:5 > data.lluv
 # Use blockmean to avoid aliasing
 R=-R122.5W/115W/32.5N/38N
-gmt blockmean $R -I${INC} data.lluv -fg -i0,1,2,4 -W > blk.llu
+gmt blockmean $R -I${INC} data.lluv -fg -i0:2,4 -W > blk.llu
 gmt blockmean $R -I${INC} data.lluv -fg -i0,1,3,5 -W > blk.llv
-gmt convert -A blk.llu blk.llv -o0-2,6,3,7 > blk.lluv
+gmt convert -A blk.llu blk.llv -o0:2,6,3,7 > blk.lluv
 #
 #  do the gridding. There are 2682 data so use about 1/4 this number of singular values
 #

--- a/test/geodesy/test_earthtide.sh
+++ b/test/geodesy/test_earthtide.sh
@@ -6,7 +6,7 @@
 rm -f test_earthtide.dat
 
 # Skip the first column with the time since the fortran version prints seconds since t0
-gmt earthtide -T2018-7-7T/2018-7-7T00:04:00/1m -L0/0  --FORMAT_FLOAT_OUT=%.6f -o1,2,3 > test_earthtide.dat
+gmt earthtide -T2018-7-7T/2018-7-7T00:04:00/1m -L0/0  --FORMAT_FLOAT_OUT=%.6f -o1:3 > test_earthtide.dat
 
 # Output from the Fortran version
 #-0.015781 -0.012347 -0.027025

--- a/test/makecpt/timecpt.sh
+++ b/test/makecpt/timecpt.sh
@@ -4,7 +4,7 @@
 ps=timecpt.ps
 gmt set FORMAT_DATE_MAP "o" FORMAT_TIME_PRIMARY_MAP Abbrev
 gmt makecpt -T2017T/2018T/1o -Cjet > t.cpt
-gmt psxy -R2017-01-01T/2018-01-01T/10000/40000 @HI_arrivals_2017.txt -JX6iT/3.5i -Ct.cpt -i0,1,0 -Sc0.1c -BWsNe -P -Bxa1Og1o -Byafg -K -Xc -Y1.5i> $ps
+gmt psxy -R2017-01-01T/2018-01-01T/10000/40000 @HI_arrivals_2017.txt -JX6iT/3.5i -Ct.cpt -i0,1,0 -Sc0.1c -BWsNe -P -Bxa1Og1o -Byafg -K -Xc -Y1.5i > $ps
 gmt psscale -Ct.cpt -DJBC -O -K -R -J -Bxa1Og1o >> $ps
 gmt psxy -R10000/40000/2017-01-01T/2018-01-01T @HI_arrivals_2017.txt -JX6i/3.5iT -Ct.cpt -i1,0,0 -Sc0.1c -BWSne+t"Hawaii 2017 Visitor Arrivals" -Bya1Og1o -Bxafg -O -K -Y4.5i >> $ps
 gmt psscale -Ct.cpt -DJRM -O -R -J -Bxa1Og1o >> $ps

--- a/test/mapproject/waypoints.sh
+++ b/test/mapproject/waypoints.sh
@@ -2,7 +2,7 @@
 # Test mapproject's distance and time calculations
 ps=waypoints.ps
 data=`gmt which -G @waypoints.txt`
-gmt mapproject -G+un+i+a -Af -Z20+i+a+t2017-01-01T --TIME_UNIT=h $data -: -o2-4,7 --FORMAT_FLOAT_OUT=%.1f > tmp
+gmt mapproject -G+un+i+a -Af -Z20+i+a+t2017-01-01T --TIME_UNIT=h $data -: -o2:4,7 --FORMAT_FLOAT_OUT=%.1f > tmp
 gmt psxy -R181/185/-7:30/-2 -JM6.5i -P -Baf -BWSne -W0.25p $data -: -K > $ps
 gmt psxy -R -J -O -K -Sc0.2c -Gblue $data -: >> $ps
 awk '{if (NR == 2) print $2, $1}' $data | gmt psxy -R -J -O -K -Sa0.4c -Gred >> $ps

--- a/test/ogr/quakes.sh
+++ b/test/ogr/quakes.sh
@@ -8,6 +8,6 @@
 ps=quakes.ps
 
 gmt makecpt -Crainbow -T0/300 > t.cpt
-gmt psxy @quakes.gmt -R15/25/15/25 -JM6i -B5 -Sci -Ct.cpt -P -K -Wthin -a2=depth,3=magnitude -i0,1,2,3+s0.05 -Yc -Xc > $ps
+gmt psxy @quakes.gmt -R15/25/15/25 -JM6i -B5 -Sci -Ct.cpt -P -K -Wthin -a2=depth,3=magnitude -i0:2,3+s0.05 -Yc -Xc > $ps
 gmt pstext @quakes.gmt -R -J -O -K -a2=name -F+jCT -Dj0/0.2i >> $ps
 gmt psscale -Ct.cpt -D3i/-0.5i+w6i/0.1i+h+jTC -O -Bxa50+l"Epicenter Depth" -By+lkm >> $ps

--- a/test/psxy/gview_caps.sh
+++ b/test/psxy/gview_caps.sh
@@ -5,7 +5,7 @@ gmt grdmath -R0.5/6.5/0.5/9.5 -I1.5 XCOL 36 MUL 72 SUB = lat.nc
 gmt grdmath -R0.5/6.5/0.5/9.5 -I1.5 YROW 50 MUL 5 ADD  = lon.nc
 gmt grd2xyz lat.nc > lat.txt
 gmt grd2xyz lon.nc > lon.txt
-gmt convert -A lon.txt lat.txt -o0-2,5 > tmp.txt
+gmt convert -A lon.txt lat.txt -o0:2,5 > tmp.txt
 gmt pstext -R0/8.5/0/11 -Jx1i -P -Xa0 -Ya0 -K -F+f10+j -N << EOF > $ps
 1.25    0.45	CT	72S
 2.75	0.45	CT	36S

--- a/test/psxy/vectypes.sh
+++ b/test/psxy/vectypes.sh
@@ -19,10 +19,10 @@ gmt psxy t.txt -J -R-4/4/58/62 -SV0.3i+e+z0.1 -W2p,red -Gred -Bafg1 -BWsne -O -K
 # Scale vector lengths via -i..+s
 echo 2	0	0	100 > t.txt
 echo 2	0	90	100 >> t.txt
-gmt psxy t.txt -JM6i -R-4/4/-2/2 -SV0.3i+e -i0-2,3+s0.01 -W2p,blue -Gblue -O -K -Y-3.3i --PROJ_LENGTH_UNIT=inch >> $ps
+gmt psxy t.txt -JM6i -R-4/4/-2/2 -SV0.3i+e -i0:2,3+s0.01 -W2p,blue -Gblue -O -K -Y-3.3i --PROJ_LENGTH_UNIT=inch >> $ps
 echo 2	60	0	100 > t.txt
 echo 2	60	90	100 >> t.txt
-gmt psxy t.txt -J -R-4/4/58/62 -SV0.3i+e -i0-2,3+s0.01 -W2p,blue -Gblue -O -K -Y3.3i --PROJ_LENGTH_UNIT=inch >> $ps
+gmt psxy t.txt -J -R-4/4/58/62 -SV0.3i+e -i0:2,3+s0.01 -W2p,blue -Gblue -O -K -Y3.3i --PROJ_LENGTH_UNIT=inch >> $ps
 # Try geovector on these 111.13 km vectors pointing east and north
 echo 0	0	0	111.13 > t.txt
 echo 0	0	90	111.13 >> t.txt

--- a/test/trend2d/trend.sh
+++ b/test/trend2d/trend.sh
@@ -11,7 +11,7 @@ gmt triangulate -M @Table_5_11.txt | gmt psxy -R -J -O -K -W0.25p,- >> $ps
 gmt psxy -R -J -O -K @Table_5_11.txt -Sc0.1c -Gblack >> $ps
 gmt psscale -Cz.cpt -D1.5i/-0.5i+w3i/0.1i+h+jTC -O -K -Ba >> $ps
 gmt trend2d @Table_5_11.txt -Fxyrmw -N3r > trend.txt
-gmt pscontour -R trend.txt -Cr.cpt -J -Baf -B+tRedisual -I -O -K -X3.5i -i0-2 >> $ps
+gmt pscontour -R trend.txt -Cr.cpt -J -Baf -B+tRedisual -I -O -K -X3.5i -i0:2 >> $ps
 gmt psscale -Cr.cpt -D1.5i/-0.5i+w3i/0.1i+h+jTC -O -K -Ba >> $ps
 gmt pscontour -R trend.txt -Cz.cpt -J -Baf -B+tTrend -I -O -K -X-3.5i -Y-5i -i0,1,3 >> $ps
 gmt psscale -Cz.cpt -D1.5i/-0.5i+w3i/0.1i+h+jTC -O -K -Ba >> $ps


### PR DESCRIPTION
Since **-i**, **-o**, **-f** all document column ranges to use _start_:_stop_ we should also do that in our examples and tests.  This PR updates the scripts accordingly.
