### PR TITLE
Fix y vector reconstruction on a pix-reg grid created by GDAL (where Y is top down)

### DIFF
--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -746,7 +746,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 					GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Guessing of registration in conflict between x and y, using %s\n", regtype[header->registration]);
 				else {	/* Pixel registration confirmed */
 					if (dummy[0] > dummy[1]) {		/* Check for reverse order of y-coordinate */
-						tmp = dummy[1], dummy[1] = dummy[0], dummy[0] = tmp;
+						gmt_M_double_swap (dummy[0], dummy[1]);
 					}
 					dummy[0] -= 0.5 * dy;	dummy[1] += 0.5 * dy;
 					registration = GMT_GRID_PIXEL_REG;
@@ -763,7 +763,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 		/* Check for reverse order of y-coordinate */
 		if (dummy[0] > dummy[1]) {
 			HH->row_order = k_nc_start_north;
-			tmp = dummy[1], dummy[1] = dummy[0], dummy[0] = tmp;
+			gmt_M_double_swap (dummy[0], dummy[1]);
 		}
 		else if (has_vector && (xy[0] > xy[header->n_rows-1]) && (dummy[0] > dummy[1])) 	/* Here the lat vector is top-down but range is bottum-up */
 			HH->row_order = k_nc_start_north;

--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -745,6 +745,9 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 				if (header->registration == GMT_GRID_NODE_REG)	/* No, somehow messed up now */
 					GMT_Report (GMT->parent, GMT_MSG_VERBOSE, "Guessing of registration in conflict between x and y, using %s\n", regtype[header->registration]);
 				else {	/* Pixel registration confirmed */
+					if (dummy[0] > dummy[1]) {		/* Check for reverse order of y-coordinate */
+						tmp = dummy[1], dummy[1] = dummy[0], dummy[0] = tmp;
+					}
 					dummy[0] -= 0.5 * dy;	dummy[1] += 0.5 * dy;
 					registration = GMT_GRID_PIXEL_REG;
 					if (gmt_M_180_range (dummy[0], dummy[1]))


### PR DESCRIPTION

Fix #2589





