### PR TITLE
Fix side effect of the #2590 y limits guess on pix-reg GDAL grids.

### DIFF
--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -747,6 +747,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 				else {	/* Pixel registration confirmed */
 					if (dummy[0] > dummy[1]) {		/* Check for reverse order of y-coordinate */
 						gmt_M_double_swap (dummy[0], dummy[1]);
+						HH->row_order = k_nc_start_north;
 					}
 					dummy[0] -= 0.5 * dy;	dummy[1] += 0.5 * dy;
 					registration = GMT_GRID_PIXEL_REG;
@@ -767,7 +768,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 		}
 		else if (has_vector && (xy[0] > xy[header->n_rows-1]) && (dummy[0] > dummy[1])) 	/* Here the lat vector is top-down but range is bottum-up */
 			HH->row_order = k_nc_start_north;
-		else
+		else if (HH->row_order != k_nc_start_north)		/* If not already set to north in an above test */
 			HH->row_order = k_nc_start_south;
 
 		/* Determine grid step */


### PR DESCRIPTION
#2590 introduced a subtle bug because it prevented to set ``HH->row_order = k_nc_start_north;``.
But because the tests to detect the need to set this may follow different paths we now only set ``HH->row_order = k_nc_start_south;`` if ``HH->row_order`` was not already set to ``north``.