### PR TITLE
Replace backticks (``) with $() for command substitution

### DIFF
--- a/admin/build-macos-external-list.sh
+++ b/admin/build-macos-external-list.sh
@@ -10,10 +10,10 @@
 # 1. Separate install command to avoid version number in GraphicsMagick directory name
 # 2. Build gs from 9.50 tarball and place in /opt (until 9.50 appears in port)
 
-if [ `which cmake` = "/opt/local/bin/cmake" ]; then
+if [ $(which cmake) = "/opt/local/bin/cmake" ]; then
 	distro=MacPorts
 	top=/opt/local
-elif [ `which cmake` = "/usr/local/bin/cmake" ]; then
+elif [ $(which cmake) = "/usr/local/bin/cmake" ]; then
 	distro=HomeBrew
 	top=/usr/local
 else
@@ -36,7 +36,7 @@ EXESHARED="gdal /opt/share/ghostscript /opt/local/lib/proj6/share/proj"
 # 2a. Add the executables to the list given their paths
 rm -f /tmp/raw.lis
 for P in ${EXEONLY} ${EXEPLUSLIBS}; do
-	path=`which $P`
+	path=$(which $P)
 	if [ -L $path ]; then # A symlink
 		grealpath $path >> /tmp/raw.lis
 	else
@@ -49,7 +49,7 @@ for P in $EXELINKS; do
 done
 # 2c. Call otool -L recursively to list shared libraries used but exclude system libraries
 cc admin/otoolr.c -o build/otoolr
-build/otoolr `pwd` ${EXEPLUSLIBS} >> /tmp/raw.lis
+build/otoolr $(pwd) ${EXEPLUSLIBS} >> /tmp/raw.lis
 # 4. sort into unique list then separate executables from libraries
 sort -u /tmp/raw.lis > /tmp/final.lis
 grep dylib /tmp/final.lis > /tmp/libraries.lis
@@ -80,7 +80,7 @@ if [ ! "X$EXESHARED" = "X" ]; then
 	echo "install (DIRECTORY"
 fi
 for P in $EXESHARED; do
-	if [ $P = `basename $P` ]; then
+	if [ $P = $(basename $P) ]; then
 		echo "	$top/share/$P"
 	else
 		echo "	$P"

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -15,7 +15,7 @@ abort_build() {	# Called when we abort this script via Crtl-C
 	exit -1
 }
 
-TOPDIR=`pwd`
+TOPDIR=$(pwd)
 
 if [ $# -gt 0 ]; then
 	echo "Usage: build-release.sh"
@@ -59,12 +59,12 @@ cmake -G Ninja ..
 cmake --build . --target gmt_release
 cmake --build . --target gmt_release_tar
 # 4. get the version string
-Version=`src/gmt --version`
+Version=$(src/gmt --version)
 # 5. Remove the uncompressed tarball
 rm -f gmt-${Version}-src.tar
 # 6. Install executables before building macOS Bundle
 cmake --build . --target install
-if [ `uname` = "Darwin" ]; then
+if [ $(uname) = "Darwin" ]; then
 	echo "build-release.sh: Build macOS bundle"
 	# 7. Build the macOS Bundle
 	cpack -G Bundle

--- a/ci/deploy-gh-pages.sh
+++ b/ci/deploy-gh-pages.sh
@@ -63,7 +63,7 @@ echo -e "Add and commit changes"
 git add -A .
 git status
 # Reuse the last commit if possible
-if [[ `git log -1 --format='%s'` == *"${VERSION}"* ]]; then
+if [[ $(git log -1 --format='%s') == *"${VERSION}"* ]]; then
     echo -e "Amending last commit"
     git commit --amend --reset-author --no-edit
 else

--- a/cmake/dist/startup_macosx.sh.in
+++ b/cmake/dist/startup_macosx.sh.in
@@ -9,8 +9,8 @@ if [ "$1" = "GMT_PROMPT" ]; then
   export BUNDLE_RESOURCES="${PWD}/Resources"
   cd "${OLDPWD}"
   # Getting and setting terminal width so wide enough to not wrap the gmt splash screen
-  dim=(`osascript -e 'tell application "Terminal" to get size of front window' | tr ',' ' '`)
-  w=`echo "${dim[0]} 1.25" | awk '{print int($1*$2)}'`
+  dim=($(osascript -e 'tell application "Terminal" to get size of front window' | tr ',' ' '))
+  w=$(echo "${dim[0]} 1.25" | awk '{print int($1*$2)}')
   osascript << EOF
 tell application "Terminal" to set size of front window to {$w, ${dim[1]}}
 EOF

--- a/doc/examples/anim01/anim01.sh
+++ b/doc/examples/anim01/anim01.sh
@@ -25,7 +25,7 @@ EOF
 cat << EOF > main.sh
 gmt begin
 #	Plot smooth blue curve and dark red dots at all angle steps so far
-	last=\$(gmt math -Q \${MOVIE_FRAME} 10 MUL =\)
+	last=\$(gmt math -Q \${MOVIE_FRAME} 10 MUL =)
 	gmt convert sin_curve.txt -Z0:\${last} | gmt plot -W1p,blue -R0/360/-1.2/1.6 -JX3.5i/1.65i -X0.35i -Y0.25i
 	gmt convert sin_point.txt -Z0:\${MOVIE_FRAME} | gmt plot -Sc0.1i -Gdarkred
 #	Plot bright red dot at current angle and annotate

--- a/doc/examples/anim01/anim01.sh
+++ b/doc/examples/anim01/anim01.sh
@@ -25,7 +25,7 @@ EOF
 cat << EOF > main.sh
 gmt begin
 #	Plot smooth blue curve and dark red dots at all angle steps so far
-	last=\`gmt math -Q \${MOVIE_FRAME} 10 MUL =\`
+	last=\$(gmt math -Q \${MOVIE_FRAME} 10 MUL =\)
 	gmt convert sin_curve.txt -Z0:\${last} | gmt plot -W1p,blue -R0/360/-1.2/1.6 -JX3.5i/1.65i -X0.35i -Y0.25i
 	gmt convert sin_point.txt -Z0:\${MOVIE_FRAME} | gmt plot -Sc0.1i -Gdarkred
 #	Plot bright red dot at current angle and annotate

--- a/doc/examples/anim02/anim02.sh
+++ b/doc/examples/anim02/anim02.sh
@@ -22,7 +22,7 @@ EOF
 # 2. Set up the main frame script
 cat << EOF > main.sh
 gmt begin
-	width=\$(gmt math -Q \${MOVIE_WIDTH} 0.5i SUB =\)
+	width=\$(gmt math -Q \${MOVIE_WIDTH} 0.5i SUB =)
 	gmt grdimage @tut_relief.nc -I+a\${MOVIE_COL0}+nt2 -JM\${width} -Cmain.cpt \
 		-BWSne -B1 -X0.35i -Y0.3i --FONT_ANNOT_PRIMARY=9p
 	gmt plot -Sc0.8i -Gwhite -Wthin <<< "256.25 35.6"

--- a/doc/examples/anim02/anim02.sh
+++ b/doc/examples/anim02/anim02.sh
@@ -22,7 +22,7 @@ EOF
 # 2. Set up the main frame script
 cat << EOF > main.sh
 gmt begin
-	width=\`gmt math -Q \${MOVIE_WIDTH} 0.5i SUB =\`
+	width=\$(gmt math -Q \${MOVIE_WIDTH} 0.5i SUB =\)
 	gmt grdimage @tut_relief.nc -I+a\${MOVIE_COL0}+nt2 -JM\${width} -Cmain.cpt \
 		-BWSne -B1 -X0.35i -Y0.3i --FONT_ANNOT_PRIMARY=9p
 	gmt plot -Sc0.8i -Gwhite -Wthin <<< "256.25 35.6"

--- a/doc/examples/anim06/anim06.sh
+++ b/doc/examples/anim06/anim06.sh
@@ -66,7 +66,7 @@ gmt begin
 	# Add time counter in upper left corner
 	printf "%4.1f 2 t = %6.3f s\n" -7.5 \${MOVIE_COL1} | gmt text -F+f18p,Helvetica-Bold+jTL -Dj0.1i/0.1i
 	# Add cycles counter in upper right corner
-	fnow=\$(gmt math -Q \${MOVIE_COL1} 60 DIV \$f MUL =\)
+	fnow=\$(gmt math -Q \${MOVIE_COL1} 60 DIV \$f MUL =)
 	printf "2.5 2 f = %6.4f Hz\n" \$fnow | gmt text -F+f16p,Helvetica-Bold+jTR -Dj0.1i/0.1i
 	# Add frame counter in lower right corner
 	printf "2.5 -1.5 %04d\n" \${MOVIE_FRAME} | gmt text -F+f14p,Helvetica-Bold+jBR -Dj0.1i/0.1i

--- a/doc/examples/anim06/anim06.sh
+++ b/doc/examples/anim06/anim06.sh
@@ -46,7 +46,7 @@ gmt begin
 	# Plot the shifted chirp
 	gmt plot \$R \$J chirp_shifted.txt -W1p,red -X0.2i -Y0.3i
 	# Compute index of most recent sample number
-	last_sample=\$(gmt math -Q \${MOVIE_FRAME} \$rate 2 DIV DIV FLOOR RINT =\)
+	last_sample=\$(gmt math -Q \${MOVIE_FRAME} \$rate 2 DIV DIV FLOOR RINT =)
 	# Extract all the old samples before the present
 	gmt convert chirp_samples.txt -Z:\$last_sample > tmp.txt
 	if [ -s tmp.txt ]; then

--- a/doc/examples/anim06/anim06.sh
+++ b/doc/examples/anim06/anim06.sh
@@ -60,7 +60,7 @@ gmt begin
 		gmt plot -W2.5p,blue resampled.txt
 	fi
 	if [ \$take_sample -eq 1 ]; then	# Take and plot sample at zero time
-		y=\$(gmt math -Q \${MOVIE_COL1} 2 POW 2 DIV 60 DIV \$f MUL 2 MUL PI MUL COS =\)
+		y=\$(gmt math -Q \${MOVIE_COL1} 2 POW 2 DIV 60 DIV \$f MUL 2 MUL PI MUL COS =)
 		echo 0 \$y | gmt plot -Sc0.5c -Gred
 	fi
 	# Add time counter in upper left corner

--- a/doc/examples/anim06/anim06.sh
+++ b/doc/examples/anim06/anim06.sh
@@ -54,7 +54,7 @@ gmt begin
 		gmt plot -Sc0.3c -Gblue samples.txt
 	fi
 	# Take a new sample every 12 frames = 0.5 seconds
-	take_sample=\$(gmt math -Q \${MOVIE_FRAME} \$rate 2 DIV MOD 0 EQ =\)
+	take_sample=\$(gmt math -Q \${MOVIE_FRAME} \$rate 2 DIV MOD 0 EQ =)
 	if [ \${MOVIE_FRAME} -gt 12 ]; then	# Interpolating up to most recent sample
 		gmt sample1d samples.txt -I0.001 > resampled.txt
 		gmt plot -W2.5p,blue resampled.txt

--- a/doc/examples/anim06/anim06.sh
+++ b/doc/examples/anim06/anim06.sh
@@ -13,7 +13,7 @@ else	# Make movie in MP4 format and a thumbnail animated GIF using every 10th fr
 	opt="-Fmp4 -A+l+s5"
 fi
 rate=6			# Frames per seconds
-frames=`gmt math -Q 60 $rate MUL =`
+frames=$(gmt math -Q 60 $rate MUL =)
 # 0. Initial parameters
 cat << EOF > init.sh
 R=-R-7.5/2.5/-1.5/2	# Fixed plot domain window
@@ -46,7 +46,7 @@ gmt begin
 	# Plot the shifted chirp
 	gmt plot \$R \$J chirp_shifted.txt -W1p,red -X0.2i -Y0.3i
 	# Compute index of most recent sample number
-	last_sample=\`gmt math -Q \${MOVIE_FRAME} \$rate 2 DIV DIV FLOOR RINT =\`
+	last_sample=\$(gmt math -Q \${MOVIE_FRAME} \$rate 2 DIV DIV FLOOR RINT =\)
 	# Extract all the old samples before the present
 	gmt convert chirp_samples.txt -Z:\$last_sample > tmp.txt
 	if [ -s tmp.txt ]; then
@@ -54,19 +54,19 @@ gmt begin
 		gmt plot -Sc0.3c -Gblue samples.txt
 	fi
 	# Take a new sample every 12 frames = 0.5 seconds
-	take_sample=\`gmt math -Q \${MOVIE_FRAME} \$rate 2 DIV MOD 0 EQ =\`
+	take_sample=\$(gmt math -Q \${MOVIE_FRAME} \$rate 2 DIV MOD 0 EQ =\)
 	if [ \${MOVIE_FRAME} -gt 12 ]; then	# Interpolating up to most recent sample
 		gmt sample1d samples.txt -I0.001 > resampled.txt
 		gmt plot -W2.5p,blue resampled.txt
 	fi
 	if [ \$take_sample -eq 1 ]; then	# Take and plot sample at zero time
-		y=\`gmt math -Q \${MOVIE_COL1} 2 POW 2 DIV 60 DIV \$f MUL 2 MUL PI MUL COS =\`
+		y=\$(gmt math -Q \${MOVIE_COL1} 2 POW 2 DIV 60 DIV \$f MUL 2 MUL PI MUL COS =\)
 		echo 0 \$y | gmt plot -Sc0.5c -Gred
 	fi
 	# Add time counter in upper left corner
 	printf "%4.1f 2 t = %6.3f s\n" -7.5 \${MOVIE_COL1} | gmt text -F+f18p,Helvetica-Bold+jTL -Dj0.1i/0.1i
 	# Add cycles counter in upper right corner
-	fnow=\`gmt math -Q \${MOVIE_COL1} 60 DIV \$f MUL =\`
+	fnow=\$(gmt math -Q \${MOVIE_COL1} 60 DIV \$f MUL =\)
 	printf "2.5 2 f = %6.4f Hz\n" \$fnow | gmt text -F+f16p,Helvetica-Bold+jTR -Dj0.1i/0.1i
 	# Add frame counter in lower right corner
 	printf "2.5 -1.5 %04d\n" \${MOVIE_FRAME} | gmt text -F+f14p,Helvetica-Bold+jBR -Dj0.1i/0.1i

--- a/doc/examples/ex03/ex03.sh
+++ b/doc/examples/ex03/ex03.sh
@@ -22,15 +22,15 @@ gmt begin ex03
 	gmt set GMT_FFT kiss
 	# First, we use "gmt fitcircle" to find the parameters of a great circle
 	# most closely fitting the x,y points in "sat_03.txt":
-	cpos=`gmt fitcircle @sat_03.txt -L2 -Fm --IO_COL_SEPARATOR=/`
-	ppos=`gmt fitcircle @sat_03.txt -L2 -Fn --IO_COL_SEPARATOR=/`
+	cpos=$(gmt fitcircle @sat_03.txt -L2 -Fm --IO_COL_SEPARATOR=/)
+	ppos=$(gmt fitcircle @sat_03.txt -L2 -Fn --IO_COL_SEPARATOR=/)
 	# Now we use "gmt project" to project the data in both sat_03.txt and ship_03.txt
 	# into data.pg, where g is the same and p is the oblique longitude around
 	# the great circle.  We use -Q to get the p distance in kilometers, and -S
 	# to sort the output into increasing p values.
 	gmt project  @sat_03.txt -C$cpos -T$ppos -S -Fpz -Q > sat.pg
 	gmt project @ship_03.txt -C$cpos -T$ppos -S -Fpz -Q > ship.pg
-	bounds=`gmt info ship.pg sat.pg -I1 -Af -L -C -i0  --IO_COL_SEPARATOR=/`
+	bounds=$(gmt info ship.pg sat.pg -I1 -Af -L -C -i0  --IO_COL_SEPARATOR=/)
 	# Now we can use $bounds in gmt math to make a sampling points file for gmt sample1d:
 	gmt math -T$bounds/1 -N1/0 T = samp.x
 	# Now we can resample the gmt projected satellite data:

--- a/doc/examples/ex12/ex12.sh
+++ b/doc/examples/ex12/ex12.sh
@@ -8,7 +8,7 @@
 gmt begin ex12
 	# Contour the data and draw triangles using dashed pen; use "gmt gmtinfo" and "gmt makecpt" to make a
 	# color palette (.cpt) file
-	T=`gmt info -T25+c2 @Table_5_11.txt`
+	T=$(gmt info -T25+c2 @Table_5_11.txt)
 	gmt makecpt -Cjet $T
 	gmt subplot begin 2x2 -M0.1c -Fs8c/0 -SCb -SRl -R0/6.5/-0.2/6.5 -JX8c -BWSne -T"Delaunay Triangulation"
 	# First draw network and label the nodes

--- a/doc/examples/ex15/ex15.sh
+++ b/doc/examples/ex15/ex15.sh
@@ -8,7 +8,7 @@
 #
 gmt begin ex15
 	gmt convert @ship_15.txt -bo > ship.b
-	region=`gmt info ship.b -I1 -bi3d`
+	region=$(gmt info ship.b -I1 -bi3d)
 	gmt subplot begin 2x2 -M0.3c/0.1c -Fs7.5c/0 $region -JM7.5c -BWSne -T"Gridding with missing data"
 		#   Raw nearest neighbor contouring
 		gmt nearneighbor $region -I10m -S40k -Gship.nc ship.b -bi

--- a/doc/examples/ex18/ex18.sh
+++ b/doc/examples/ex18/ex18.sh
@@ -43,8 +43,8 @@ gmt begin ex18
 		gmt grdmath pratt.txt POINT SDIST = mask.nc -fg
 		gmt grdclip mask.nc -Sa200/NaN -Sb200/1 -Gmask.nc
 		gmt grdmath @AK_gulf_grav.nc mask.nc MUL = tmp.nc
-		area=`gmt grdvolume tmp.nc -C50 -Sk -o1`
-		volume=`gmt grdvolume tmp.nc -C50 -Sk -o2`
+		area=$(gmt grdvolume tmp.nc -C50 -Sk -o1)
+		volume=$(gmt grdvolume tmp.nc -C50 -Sk -o2)
 		gmt text -M -Gwhite -Wthin -Dj0.7c -F+f14p,Helvetica-Bold+jLB -C8p <<- END
 		> -149 52.5 14p 6.6c j
 		Volumes: $volume mGal\264km@+2@+

--- a/doc/examples/ex21/ex21.sh
+++ b/doc/examples/ex21/ex21.sh
@@ -11,7 +11,7 @@ gmt begin ex21
 	gmt set FORMAT_TIME_PRIMARY_MAP abbreviated PS_CHAR_ENCODING ISOLatin1+
 
 	# Pull out a suitable region string in yyy-mm-dd format
-	wesn=(`gmt info -fT -I50 -C @RHAT_price.csv --FORMAT_DATE_IN=dd-o-yy`)
+	wesn=($(gmt info -fT -I50 -C @RHAT_price.csv --FORMAT_DATE_IN=dd-o-yy))
 	R="-R${wesn[0]}/${wesn[1]}/${wesn[2]}/${wesn[3]}"
 
 	# Lay down the basemap:

--- a/doc/examples/ex22/ex22.sh
+++ b/doc/examples/ex22/ex22.sh
@@ -18,17 +18,17 @@ gmt begin ex22
 	# curl -s $URL > usgs_quakes_22.txt
 
 	# Count the number of events (to be used in title later. one less due to header)
-	file=`gmt which @usgs_quakes_22.txt -G`
-	n=`gmt info $file -h1 -Fi -o2`
+	file=$(gmt which @usgs_quakes_22.txt -G)
+	n=$(gmt info $file -h1 -Fi -o2)
 
 	# Pull out the first and last timestamp to use in legend title
-	first=`gmt info -h1 -f0T -i0 $file -C --TIME_UNIT=d -I1 -o0 --FORMAT_CLOCK_OUT=-`
-	last=`gmt info -h1 -f0T -i0 $file -C --TIME_UNIT=d -I1 -o1 --FORMAT_CLOCK_OUT=-`
+	first=$(gmt info -h1 -f0T -i0 $file -C --TIME_UNIT=d -I1 -o0 --FORMAT_CLOCK_OUT=-)
+	last=$(gmt info -h1 -f0T -i0 $file -C --TIME_UNIT=d -I1 -o1 --FORMAT_CLOCK_OUT=-)
 
 	# Assign a string that contains the current user @ the current computer node.
 	# Note that two @@ is needed to print a single @ in gmt text:
 
-	#set me = "$user@@`hostname`"
+	#set me = "$user@@$(hostname)"
 	me="GMT guru @@ GMTbox"
 
 	# Create standard seismicity color table

--- a/doc/examples/ex24/ex24.sh
+++ b/doc/examples/ex24/ex24.sh
@@ -13,7 +13,7 @@ gmt begin ex24
 	180	0
 	180	-90
 	END
-	R=`gmt info -I10 @oz_quakes_24.txt`
+	R=$(gmt info -I10 @oz_quakes_24.txt)
 	gmt coast $R -JM22c -Gtan -Sdarkblue -Wthin,white -Dl -A500 -Ba20f10g10 -BWeSn
 	gmt plot @oz_quakes_24.txt -Sc0.1c -Gred
 	gmt select @oz_quakes_24.txt -Ldateline.txt+d1000k -Nk/s -Cpoint.txt+d3000k -fg -Il \

--- a/doc/examples/ex25/ex25.sh
+++ b/doc/examples/ex25/ex25.sh
@@ -15,13 +15,13 @@ gmt begin ex25
 	gmt grdmath -Rg -I${D}m -r Y COSD 60 $D DIV 360 MUL DUP MUL PI DIV DIV 100 MUL = scale.nc
 	gmt grdmath key.nc -1 EQ 0 NAN scale.nc MUL = tmp.nc
 	gmt grd2xyz tmp.nc -s -ZTLf > key.b
-	ocean=`gmt math -bi1f -Ca -S key.b SUM UPPER RINT =`
+	ocean=$(gmt math -bi1f -Ca -S key.b SUM UPPER RINT =)
 	gmt grdmath key.nc 1 EQ 0 NAN scale.nc MUL = tmp.nc
 	gmt grd2xyz tmp.nc -s -ZTLf > key.b
-	land=`gmt math -bi1f -Ca -S key.b SUM UPPER RINT =`
+	land=$(gmt math -bi1f -Ca -S key.b SUM UPPER RINT =)
 	gmt grdmath key.nc 0 EQ 0 NAN scale.nc MUL = tmp.nc
 	gmt grd2xyz tmp.nc -s -ZTLf > key.b
-	mixed=`gmt math -bi1f -Ca -S key.b SUM UPPER RINT =`
+	mixed=$(gmt math -bi1f -Ca -S key.b SUM UPPER RINT =)
 	# Generate corresponding color table
 	gmt makecpt -Cblue,gray,red -T-1.5/1.5/1 -N
 	# Create the final plot and overlay coastlines

--- a/doc/examples/ex27/ex27.sh
+++ b/doc/examples/ex27/ex27.sh
@@ -16,7 +16,7 @@ gmt begin ex27
 
 	# Then use gmt coast to plot land; get original -R from grid img remark
 	# and use Mercator gmt projection with same scale as above on a spherical Earth
-	R=`gmt grdinfo @tasman_grav.nc -Ii`
+	R=$(gmt grdinfo @tasman_grav.nc -Ii)
 	gmt coast $R -Jm0.6c -B -BWSne -Gblack --PROJ_ELLIPSOID=Sphere -Cwhite -Dh+ --FORMAT_GEO_MAP=dddF
 
 	# Put a color legend in top-left corner of the land mask

--- a/doc/examples/ex31/ex31.sh
+++ b/doc/examples/ex31/ex31.sh
@@ -19,7 +19,7 @@ gmt begin ex31
 	LinLibertineOB
 	EOF
 
-	capitals=`gmt which -G @europe-capitals-ru.csv`
+	capitals=$(gmt which -G @europe-capitals-ru.csv)
 	# common settings
 	gmt set FORMAT_GEO_MAP ddd:mm:ssF MAP_DEGREE_SYMBOL colon MAP_TITLE_OFFSET 20p \
 		MAP_GRID_CROSS_SIZE_PRIMARY 0.4c PS_LINE_JOIN round PS_CHAR_ENCODING ISO-8859-5 \

--- a/doc/examples/ex43/ex43.sh
+++ b/doc/examples/ex43/ex43.sh
@@ -12,7 +12,7 @@ AWK=${AWK:-awk}
 # Data from Table 7 in Rousseeuw and Leroy, 1987.
 gmt begin ex43
 
-	file=`gmt which -G @bb_weights.txt`
+	file=$(gmt which -G @bb_weights.txt)
 	gmt regress -Ey -Nw -i0:1+l $file > model.txt
 	gmt regress -Ey -Nw -i0:1+l $file -Fxmc -T-2/6/0.1 > rls_line.txt
 	gmt regress -Ey -N2 -i0:1+l $file -Fxm -T-2/6/2+n > ls_line.txt

--- a/doc/examples/ex47/ex47.sh
+++ b/doc/examples/ex47/ex47.sh
@@ -17,7 +17,7 @@ function plot_one { # First 3-4 args are: -E -N -c [-Barg]
 }
 
 gmt begin ex47
-	file=`gmt which -G @hertzsprung-russell.txt`
+	file=$(gmt which -G @hertzsprung-russell.txt)
 	# Allow outliers (commented out by #) to be included in the analysis:
 	sed -e s/#//g $file > data.txt
 	# Identify the red giants (outliers)

--- a/doc/scripts/GMT_App_G.sh
+++ b/doc/scripts/GMT_App_G.sh
@@ -40,8 +40,8 @@ do
 	k1=$i
 	k2=$(( i+17 ))
 
-	f1=`sed -n ${k1}p tt.d`
-	f2=`sed -n ${k2}p tt.d`
+	f1=$(sed -n ${k1}p tt.d)
+	f2=$(sed -n ${k2}p tt.d)
 
 	if [ $i1 -eq "12" ]; then
 		f1="Symbol @%0%(Symbol)@%%"

--- a/doc/scripts/GMT_App_M_1a.sh
+++ b/doc/scripts/GMT_App_M_1a.sh
@@ -7,7 +7,7 @@
 # 44 original GMT 5 CPTs and the last page has 24 scientific colormaps
 # from Fabio [www.fabiocrameri.ch/visualisation]
 
-GMT_SHAREDIR=`gmt --show-sharedir`
+GMT_SHAREDIR=$(gmt --show-sharedir)
 
 cat << EOF > skip.lis
 acton
@@ -40,12 +40,12 @@ EOF
 #sed -e 's/"//g' "${GMT_SOURCE_DIR}"/src/gmt_cpt_masters.h | grep -v srtm | awk '{print $1}' | sort -r > tt.lis
 sed -e 's/"//g' "${GMT_SOURCE_DIR}"/src/gmt_cpt_masters.h | fgrep -v -f skip.lis | awk '{print $1}' | sort -r > tt.lis
 
-n=`cat tt.lis | wc -l`
+n=$(cat tt.lis | wc -l)
 let n2=n/2
 let n2=22
 # dy is line spacing and y0 is total box height
 dy=0.75
-y0=`gmt math -Q $n2 2 ADD $dy MUL 0.5 MUL =`
+y0=$(gmt math -Q $n2 2 ADD $dy MUL 0.5 MUL =)
 
 gmt begin GMT_App_M_1a
 gmt set MAP_FRAME_PEN thinner FONT_ANNOT_PRIMARY 8p MAP_TICK_LENGTH_PRIMARY 0.1i MAP_ANNOT_OFFSET_PRIMARY 0.04i
@@ -56,9 +56,9 @@ y=0.475
 y2=0.35
 while [ $i -le $n ]
 do
-	j=`expr $i + 1`
-	left=`sed -n ${j}p tt.lis`
-	right=`sed -n ${i}p tt.lis`
+	j=$(expr $i + 1)
+	left=$(sed -n ${j}p tt.lis)
+	right=$(sed -n ${i}p tt.lis)
 	if [ "$left" = "categorical" ]; then
 		gmt makecpt -H -C$left > tt.left.cpt
 	else
@@ -79,19 +79,19 @@ do
 	1.55 $y ${left}
 	4.50 $y ${right}
 	END
-	if [ `grep -c HARD_HINGE ${GMT_SHAREDIR}/cpt/${left}.cpt` -eq 1 ]; then # Plot hard hinge symbol for left CPT
+	if [ $(grep -c HARD_HINGE ${GMT_SHAREDIR}/cpt/${left}.cpt) -eq 1 ]; then # Plot hard hinge symbol for left CPT
 		echo 1.55 $y | gmt plot -St0.2c -Gblack -Wfaint -D0/-0.29i
-	elif [ `grep -c SOFT_HINGE ${GMT_SHAREDIR}/cpt/${left}.cpt` -eq 1 ]; then # Plot soft hinge symbol for left CPT
+	elif [ $(grep -c SOFT_HINGE ${GMT_SHAREDIR}/cpt/${left}.cpt) -eq 1 ]; then # Plot soft hinge symbol for left CPT
 		echo 1.55 $y | gmt plot -St0.2c -Gwhite -Wfaint -D0/-0.29i
 	fi
-	if [ `grep -c HARD_HINGE ${GMT_SHAREDIR}/cpt/${right}.cpt` -eq 1 ]; then # Plot hard hinge symbol for right CPT
+	if [ $(grep -c HARD_HINGE ${GMT_SHAREDIR}/cpt/${right}.cpt) -eq 1 ]; then # Plot hard hinge symbol for right CPT
 		echo 4.50 $y | gmt plot -St0.2c -Gblack -Wfaint -D0/-0.29i
-	elif [ `grep -c SOFT_HINGE ${GMT_SHAREDIR}/cpt/${right}.cpt` -eq 1 ]; then # Plot soft hinge symbol for right CPT
+	elif [ $(grep -c SOFT_HINGE ${GMT_SHAREDIR}/cpt/${right}.cpt) -eq 1 ]; then # Plot soft hinge symbol for right CPT
 		echo 4.50 $y | gmt plot -St0.2c -Gwhite -Wfaint -D0/-0.29i
 	fi
-	i=`expr $i + 2`
-	y=`gmt math -Q $y $dy ADD =`
-	y2=`gmt math -Q $y2 $dy ADD =`
+	i=$(expr $i + 2)
+	y=$(gmt math -Q $y $dy ADD =)
+	y2=$(gmt math -Q $y2 $dy ADD =)
 done
 
 gmt end show

--- a/doc/scripts/GMT_App_M_1b.sh
+++ b/doc/scripts/GMT_App_M_1b.sh
@@ -7,7 +7,7 @@
 # 44 original GMT 5 CPTs and the last page has 24 scientific colormaps
 # from Fabio [www.fabiocrameri.ch/visualisation]
 
-GMT_SHAREDIR=`gmt --show-sharedir`
+GMT_SHAREDIR=$(gmt --show-sharedir)
 
 cat << EOF > skip.lis
 acton
@@ -40,12 +40,12 @@ EOF
 #sed -e 's/"//g' "${GMT_SOURCE_DIR}"/src/gmt_cpt_masters.h | grep -v srtm | awk '{print $1}' | sort -r > tt.lis
 sed -e 's/"//g' "${GMT_SOURCE_DIR}"/src/gmt_cpt_masters.h | fgrep -v -f skip.lis | awk '{print $1}' | sort -r > tt.lis
 
-n=`cat tt.lis | wc -l`
+n=$(cat tt.lis | wc -l)
 let n2=n/2
 let n2=22
 # dy is line spacing and y0 is total box height
 dy=0.75
-y0=`gmt math -Q $n2 $dy MUL 0.5 MUL =`
+y0=$(gmt math -Q $n2 $dy MUL 0.5 MUL =)
 
 gmt begin GMT_App_M_1b
 gmt set MAP_FRAME_PEN thinner FONT_ANNOT_PRIMARY 8p MAP_TICK_LENGTH_PRIMARY 0.1i MAP_ANNOT_OFFSET_PRIMARY 0.04i
@@ -55,9 +55,9 @@ y=0.475
 y2=0.35
 while [ $i -le $n2 ]
 do
-	j=`expr $i + 1`
-	left=`sed -n ${j}p tt.lis`
-	right=`sed -n ${i}p tt.lis`
+	j=$(expr $i + 1)
+	left=$(sed -n ${j}p tt.lis)
+	right=$(sed -n ${i}p tt.lis)
 	if [ "$left" = "paired" ]; then
 		gmt makecpt -H -C$left > tt.left.cpt
 	else
@@ -78,18 +78,18 @@ do
 	1.55 $y ${left}
 	4.50 $y ${right}
 	END
-	if [ `grep -c HARD_HINGE ${GMT_SHAREDIR}/cpt/${left}.cpt` -eq 1 ]; then # Plot hard hinge symbol for left CPT
+	if [ $(grep -c HARD_HINGE ${GMT_SHAREDIR}/cpt/${left}.cpt) -eq 1 ]; then # Plot hard hinge symbol for left CPT
 		echo 1.55 $y | gmt plot -St0.2c -Gblack -Wfaint -D0/-0.29i
-	elif [ `grep -c SOFT_HINGE ${GMT_SHAREDIR}/cpt/${left}.cpt` -eq 1 ]; then # Plot soft hinge symbol for left CPT
+	elif [ $(grep -c SOFT_HINGE ${GMT_SHAREDIR}/cpt/${left}.cpt) -eq 1 ]; then # Plot soft hinge symbol for left CPT
 		echo 1.55 $y | gmt plot -St0.2c -Gwhite -Wfaint -D0/-0.29i
 	fi
-	if [ `grep -c HARD_HINGE ${GMT_SHAREDIR}/cpt/${right}.cpt` -eq 1 ]; then # Plot hard hinge symbol for right CPT
+	if [ $(grep -c HARD_HINGE ${GMT_SHAREDIR}/cpt/${right}.cpt) -eq 1 ]; then # Plot hard hinge symbol for right CPT
 		echo 4.50 $y | gmt plot -St0.2c -Gblack -Wfaint -D0/-0.29i
-	elif [ `grep -c SOFT_HINGE ${GMT_SHAREDIR}/cpt/${right}.cpt` -eq 1 ]; then # Plot soft hinge symbol for right CPT
+	elif [ $(grep -c SOFT_HINGE ${GMT_SHAREDIR}/cpt/${right}.cpt) -eq 1 ]; then # Plot soft hinge symbol for right CPT
 		echo 4.50 $y | gmt plot -St0.2c -Gwhite -Wfaint -D0/-0.29i
 	fi
-	i=`expr $i + 2`
-	y=`gmt math -Q $y $dy ADD =`
-	y2=`gmt math -Q $y2 $dy ADD =`
+	i=$(expr $i + 2)
+	y=$(gmt math -Q $y $dy ADD =)
+	y2=$(gmt math -Q $y2 $dy ADD =)
 done
 gmt end show

--- a/doc/scripts/GMT_App_M_1c.sh
+++ b/doc/scripts/GMT_App_M_1c.sh
@@ -7,7 +7,7 @@
 # 44 original GMT 5 CPTs and the last page has 24 scientific colormaps
 # from Fabio [www.fabiocrameri.ch/visualisation]
 
-GMT_SHAREDIR=`gmt --show-sharedir`
+GMT_SHAREDIR=$(gmt --show-sharedir)
 
 cat << EOF > tt.lis
 acton
@@ -36,12 +36,12 @@ turku
 vik
 EOF
 
-n=`cat tt.lis | wc -l`
+n=$(cat tt.lis | wc -l)
 let n2=n/2
 let n2=n
 # dy is line spacing and y0 is total box height
 dy=0.75
-y0=`gmt math -Q $n2 $dy MUL 0.5 MUL =`
+y0=$(gmt math -Q $n2 $dy MUL 0.5 MUL =)
 
 gmt begin GMT_App_M_1c
 gmt set MAP_FRAME_PEN thinner FONT_ANNOT_PRIMARY 8p MAP_TICK_LENGTH_PRIMARY 0.1i MAP_ANNOT_OFFSET_PRIMARY 0.04i
@@ -52,9 +52,9 @@ y=0.475
 y2=0.35
 while [ $i -le $n2 ]
 do
-	j=`expr $i + 1`
-	left=`sed -n ${j}p tt.lis`
-	right=`sed -n ${i}p tt.lis`
+	j=$(expr $i + 1)
+	left=$(sed -n ${j}p tt.lis)
+	right=$(sed -n ${i}p tt.lis)
 	gmt makecpt -H -C$left -T-1/1 > tt.left.cpt
 	gmt makecpt -H -C$left -T-1/1/0.25 > tt.left2.cpt
 	gmt makecpt -H -C$right -T-1/1 > tt.right.cpt
@@ -67,18 +67,18 @@ do
 	1.55 $y ${left}
 	4.50 $y ${right}
 	END
-	if [ `grep -c HARD_HINGE ${GMT_SHAREDIR}/cpt/${left}.cpt` -eq 1 ]; then # Plot hard hinge symbol for left CPT
+	if [ $(grep -c HARD_HINGE ${GMT_SHAREDIR}/cpt/${left}.cpt) -eq 1 ]; then # Plot hard hinge symbol for left CPT
 		echo 1.55 $y | gmt plot -St0.2c -Gblack -Wfaint -D0/-0.29i
-	elif [ `grep -c SOFT_HINGE ${GMT_SHAREDIR}/cpt/${left}.cpt` -eq 1 ]; then # Plot soft hinge symbol for left CPT
+	elif [ $(grep -c SOFT_HINGE ${GMT_SHAREDIR}/cpt/${left}.cpt) -eq 1 ]; then # Plot soft hinge symbol for left CPT
 		echo 1.55 $y | gmt plot -St0.2c -Gwhite -Wfaint -D0/-0.29i
 	fi
-	if [ `grep -c HARD_HINGE ${GMT_SHAREDIR}/cpt/${right}.cpt` -eq 1 ]; then # Plot hard hinge symbol for right CPT
+	if [ $(grep -c HARD_HINGE ${GMT_SHAREDIR}/cpt/${right}.cpt) -eq 1 ]; then # Plot hard hinge symbol for right CPT
 		echo 4.50 $y | gmt plot -St0.2c -Gblack -Wfaint -D0/-0.29i
-	elif [ `grep -c SOFT_HINGE ${GMT_SHAREDIR}/cpt/${right}.cpt` -eq 1 ]; then # Plot soft hinge symbol for right CPT
+	elif [ $(grep -c SOFT_HINGE ${GMT_SHAREDIR}/cpt/${right}.cpt) -eq 1 ]; then # Plot soft hinge symbol for right CPT
 		echo 4.50 $y | gmt plot -St0.2c -Gwhite -Wfaint -D0/-0.29i
 	fi
-	i=`expr $i + 2`
-	y=`gmt math -Q $y $dy ADD =`
-	y2=`gmt math -Q $y2 $dy ADD =`
+	i=$(expr $i + 2)
+	y=$(gmt math -Q $y $dy ADD =)
+	y2=$(gmt math -Q $y2 $dy ADD =)
 done
 gmt end show

--- a/doc/scripts/GMT_App_N_1.sh
+++ b/doc/scripts/GMT_App_N_1.sh
@@ -3,7 +3,7 @@
 #	Makes the inset for Appendix N (custom symbols)
 #
 grep -v '^#' "${GMT_SOURCE_DIR}"/share/custom/gmt_custom_symbols.conf | $AWK '{print $1}' > tt.lis
-n=`cat tt.lis | wc -l`
+n=$(cat tt.lis | wc -l)
 
 # Because of text, the first page figure will contain less symbol rows than
 # subsequent pages.
@@ -15,25 +15,25 @@ n_rows_p1=7
 fs=9
 dy=0.15
 
-n_pages=`gmt math -Q $n $n_cols DIV CEIL $n_rows_p1 SUB 0 MAX $n_rows DIV CEIL 1 ADD =`
+n_pages=$(gmt math -Q $n $n_cols DIV CEIL $n_rows_p1 SUB 0 MAX $n_rows DIV CEIL 1 ADD =)
 
 p=0
 s=0
 while [ $p -lt $n_pages ]; do
-	p=`expr $p + 1`
+	p=$(expr $p + 1)
 	if [ $p -eq 1 ]; then
 		max_rows=$n_rows_p1
 	else
 		max_rows=$n_rows
 	fi
 
-	n_rows_to_go=`gmt math -Q $n $s SUB $n_cols DIV CEIL $max_rows MIN =`
-	H=`gmt math -Q $n_rows_to_go 1 $dy ADD MUL =`
+	n_rows_to_go=$(gmt math -Q $n $s SUB $n_cols DIV CEIL $max_rows MIN =)
+	H=$(gmt math -Q $n_rows_to_go 1 $dy ADD MUL =)
 	rm -f tt.lines tt.symbols tt.text tt.bars
 	touch tt.lines tt.symbols tt.text tt.bars
 	c=0
 	while [ $c -lt $n_cols ]; do
-		c=`expr $c + 1`
+		c=$(expr $c + 1)
 		cat << EOF >> tt.lines
 > vertical line
 $c	0
@@ -42,11 +42,11 @@ EOF
 	done
 	r=0
 	while [ $r -lt $n_rows_to_go ]; do			# Loop over the rows that will fit this page
-		r=`expr $r + 1`
-		yt=`gmt math -Q $n_rows_to_go $r SUB 1.0 $dy ADD MUL 0.5 $dy MUL ADD =`
-		ys=`gmt math -Q $yt 1.0 $dy ADD 0.5 MUL ADD =`
-		ysb=`gmt math -Q $ys 0.5 SUB =`
-		ytb=`gmt math -Q $yt 0.5 $dy MUL SUB =`
+		r=$(expr $r + 1)
+		yt=$(gmt math -Q $n_rows_to_go $r SUB 1.0 $dy ADD MUL 0.5 $dy MUL ADD =)
+		ys=$(gmt math -Q $yt 1.0 $dy ADD 0.5 MUL ADD =)
+		ysb=$(gmt math -Q $ys 0.5 SUB =)
+		ytb=$(gmt math -Q $yt 0.5 $dy MUL SUB =)
 		cat << EOF >> tt.lines
 > base of symbol line
 0	$ysb
@@ -57,12 +57,12 @@ $n_cols	$ytb
 EOF
 		c=0
 		while [ $c -lt $n_cols ] && [ $s -lt $n ]; do	# Loop over this row, but watch for end of symbols
-			c=`expr $c + 1`
-			s=`expr $s + 1`
-			x=`gmt math -Q $c 1 SUB 0.5 ADD =`
-			symbol=`sed -n ${s}p tt.lis`
+			c=$(expr $c + 1)
+			s=$(expr $s + 1)
+			x=$(gmt math -Q $c 1 SUB 0.5 ADD =)
+			symbol=$(sed -n ${s}p tt.lis)
 			echo "$x $ys k${symbol}" >> tt.symbols
-			name=`echo $symbol | tr 'a-z' 'A-Z'`
+			name=$(echo $symbol | tr 'a-z' 'A-Z')
 			echo "$x $yt $name" >> tt.text
 			echo "$x $yt $width $dy" >> tt.bars
 		done

--- a/doc/scripts/GMT_App_O_9.sh
+++ b/doc/scripts/GMT_App_O_9.sh
@@ -8,7 +8,7 @@ gmt grdgradient @App_O_topo5.nc -Nt1 -A45 -Gtopo5_int.nc
 gmt set FORMAT_GEO_MAP ddd:mm:ssF FONT_ANNOT_PRIMARY +9p FONT_TITLE 22p
 gmt project -E-74/41 -C-17/28 -G10 -Q > great_NY_Canaries.txt
 gmt project -E-74/41 -C2.33/48.87 -G100 -Q > great_NY_Paris.txt
-km=`echo -17 28 | gmt mapproject -G-74/41+uk -fg --FORMAT_FLOAT_OUT=%.0f -o2`
+km=$(echo -17 28 | gmt mapproject -G-74/41+uk -fg --FORMAT_FLOAT_OUT=%.0f -o2)
 gmt makecpt -Clightred,lightyellow,lightgreen -T0,3,6,100 -N
 gmt grdimage @App_O_ttt.nc -Itopo5_int.nc -C $R -JM5.3i -nc+t1
 gmt grdcontour @App_O_ttt.nc -C0.5 -A1+u" hour"+v+f8p,Bookman-Demi \

--- a/doc/scripts/GMT_RGBchart.sh
+++ b/doc/scripts/GMT_RGBchart.sh
@@ -32,11 +32,11 @@ labels=labels.tmp
 gmt set PS_MEDIA $SIZE PS_PAGE_ORIENTATION landscape
 
 rectheight=0.56
-W=`gmt math -Q $WIDTH $COL DIV 0.95 MUL =`
-H=`gmt math -Q $HEIGHT $ROW DIV $rectheight MUL =`
-textheight=`gmt math -Q 1 $rectheight SUB =`
-fontsize=`gmt math -Q $HEIGHT $ROW DIV $rectheight MUL 0.6 MUL 72 MUL =`
-fontsizeL=`gmt math -Q $HEIGHT $ROW DIV $textheight MUL 0.7 MUL 72 MUL =`
+W=$(gmt math -Q $WIDTH $COL DIV 0.95 MUL =)
+H=$(gmt math -Q $HEIGHT $ROW DIV $rectheight MUL =)
+textheight=$(gmt math -Q 1 $rectheight SUB =)
+fontsize=$(gmt math -Q $HEIGHT $ROW DIV $rectheight MUL 0.6 MUL 72 MUL =)
+fontsizeL=$(gmt math -Q $HEIGHT $ROW DIV $textheight MUL 0.7 MUL 72 MUL =)
 
 # Produce $allinfo from color and name files
 paste ${GMT_SOURCE_DIR}/src/gmt_color_rgb.h ${GMT_SOURCE_DIR}/src/gmt_colornames.h | tr '{,}"\r' ' ' > Colors.txt
@@ -60,7 +60,7 @@ gmt pstext -R -J -O -K $whitetags -F+f --FONT=white >> $ps
 # Put logo in top left corner
 gmt logo -R -J -O -K -Dg0.5/1+jMC+w$W >> $ps
 
-height=`gmt math -Q $HEIGHT $ROW DIV =`
+height=$(gmt math -Q $HEIGHT $ROW DIV =)
 gmt pslegend -O -R -J -DjBR+w$WIDTH >> $ps <<END
 L ${fontsizeL}p,Helvetica-Bold R Values are R/G/B. Names are case-insensitive.
 L ${fontsizeL}p,Helvetica-Bold R Optionally, use GREY instead of GRAY.

--- a/doc/scripts/GMT_encoding.sh
+++ b/doc/scripts/GMT_encoding.sh
@@ -24,7 +24,7 @@ cat << EOF > tt.awk
 }
 EOF
 # Need access to PS source files for this plot
-GMT_SHAREDIR=`gmt --show-sharedir`
+GMT_SHAREDIR=$(gmt --show-sharedir)
 egrep -v '\[|\]' "${GMT_SHAREDIR}"/share/postscriptlight/$1.ps | $AWK -f tt.awk > tt.chart
 cat << EOF > tt.awk
 # This awk script creates a file for gmt plot to plot a rectangle for undefined entries

--- a/doc/scripts/GMT_mapscale.sh
+++ b/doc/scripts/GMT_mapscale.sh
@@ -2,9 +2,9 @@
 gmt begin GMT_mapscale
 	gmt basemap -R0/40/50/56 -JM5i -B -LjML+c53+w1000k+f+l"Scale at 53\\232N" -F+glightcyan+c0+p
 	gmt basemap -LjBR+c53+w1000k+l+f -F+p1p+i+gwhite+c0.1i
-h=`gmt mapproject -Wh -Di`
-h=`gmt math -Q $h 2 DIV =`
-lat=`echo 0 $h | gmt mapproject -I -Di -o1`
+h=$(gmt mapproject -Wh -Di)
+h=$(gmt math -Q $h 2 DIV =)
+lat=$(echo 0 $h | gmt mapproject -I -Di -o1)
 	gmt plot -Wfaint -A -N << EOF
 >
 0	$lat

--- a/doc/scripts/GMT_obl_nz.sh
+++ b/doc/scripts/GMT_obl_nz.sh
@@ -9,8 +9,8 @@ h=1000
 plon=180
 plat=40S
 # Centered
-w2=`gmt math -Q $w 2 DIV =`
-h2=`gmt math -Q $h 2 DIV =`
+w2=$(gmt math -Q $w 2 DIV =)
+h2=$(gmt math -Q $h 2 DIV =)
 R=-Rk-${w2}/$w2/-${h2}/$h2
 gmt coast $R -JOA$lon/$lat/$az/3i -Ba5f5g5 -Gred -Dh -TdjBR+w0.5i+l+o0.2i/-0.05i --FONT_TITLE=9p --MAP_ANNOT_OBLIQUE=34 --FORMAT_GEO_MAP=dddF
 echo $plon $plat | gmt plot -Sc0.2c -Gblue -W0.25p

--- a/doc/scripts/gen_data_App_O.sh
+++ b/doc/scripts/gen_data_App_O.sh
@@ -23,14 +23,14 @@ cat << EOF > App_O_cross.txt
 148	3
 158	13
 EOF
-info=`gmt grdinfo -M -Cn App_O_geoid.nc`
-x0=`echo $info | cut -f11 -d ' '`
-y0=`echo $info | cut -f12 -d ' '`
-x1=`echo $info | cut -f13 -d ' '`
-y1=`echo $info | cut -f14 -d ' '`
+info=$(gmt grdinfo -M -Cn App_O_geoid.nc)
+x0=$(echo $info | cut -f11 -d ' ')
+y0=$(echo $info | cut -f12 -d ' ')
+x1=$(echo $info | cut -f13 -d ' ')
+y1=$(echo $info | cut -f14 -d ' ')
 gmt project -C$x0/$y0 -E$x1/$y1 -G10 -Q > tt.d
-dist=`gmt convert tt.d --FORMAT_FLOAT_OUT=%.0lf -El -o2`
-R=`gmt info -I1 tt.d`
+dist=$(gmt convert tt.d --FORMAT_FLOAT_OUT=%.0lf -El -o2)
+R=$(gmt info -I1 tt.d)
 echo "# Geoid Extrema Separation is $dist km" > App_O_transect.txt
 gmt grdtrack tt.d -GApp_O_geoid.nc | gmt grdtrack -GGMT_App_O.nc >> App_O_transect.txt
 rm -f tt.d gmt.history

--- a/share/tools/gmt_aliases.csh
+++ b/share/tools/gmt_aliases.csh
@@ -16,7 +16,7 @@ if ($? == 1) then
   exit 1
 endif
 
-set gmt_modules = (`gmt --show-classic`)
+set gmt_modules = ($(gmt --show-classic))
 set compat_modules = (minmax gmtstitch gmtdp grdreformat ps2raster originator)
 
 foreach module ( $gmt_modules $compat_modules )

--- a/share/tools/gmt_aliases.csh
+++ b/share/tools/gmt_aliases.csh
@@ -16,7 +16,7 @@ if ($? == 1) then
   exit 1
 endif
 
-set gmt_modules = ($(gmt --show-classic))
+set gmt_modules = (`gmt --show-classic`)
 set compat_modules = (minmax gmtstitch gmtdp grdreformat ps2raster originator)
 
 foreach module ( $gmt_modules $compat_modules )

--- a/share/tools/gmt_completion.bash
+++ b/share/tools/gmt_completion.bash
@@ -40,7 +40,7 @@ _gmt()
     opts=( --help --show-datadir --show-bindir --version )
 
     # strip off any leading "gmt" in module names:
-    progs=(`gmt --show-modules | sed -e 's/^gmt//g'`)
+    progs=($(gmt --show-modules | sed -e 's/^gmt//g'))
 
     # complete first arg
     if [[ ${COMP_CWORD} -eq 1 ]]; then

--- a/share/tools/gmt_functions.sh
+++ b/share/tools/gmt_functions.sh
@@ -20,7 +20,7 @@ if ! [ -x "$(command -v gmt)" ]; then
   exit 1
 fi
 
-gmt_modules=`gmt --show-classic`
+gmt_modules=$(gmt --show-classic)
 compat_modules="minmax gmtstitch gmtdp grdreformat ps2raster originator"
 
 for module in ${gmt_modules} ${compat_modules}; do

--- a/share/tools/gmt_getremote.sh
+++ b/share/tools/gmt_getremote.sh
@@ -33,7 +33,7 @@ elif [ "X$1" = "Xdata" ]; then	# Not do cache
 fi
 
 # Get current remote data server
-SERVER=`gmt get GMT_DATA_SERVER`
+SERVER=$(gmt get GMT_DATA_SERVER)
 curl -sk ${SERVER}/gmt_hash_server.txt > /tmp/gmt_hash_server.txt
 if [ $? -ne 0 ]; then
 	echo "Error: curl failed with error $?" >&2

--- a/share/tools/gmt_links.sh
+++ b/share/tools/gmt_links.sh
@@ -30,10 +30,10 @@ elif [ "X$1" = "Xcreate" ]; then
 else
 	mode=0
 fi
-bin=`gmt --show-bindir`
-cwd=`pwd`
+bin=$(gmt --show-bindir)
+cwd=$(pwd)
 
-gmt_modules=`gmt --show-classic`
+gmt_modules=$(gmt --show-classic)
 compat_modules="minmax gmtstitch gmtdp grdreformat ps2raster originator"
 
 cd $bin

--- a/share/tools/gmt_make_custom_code.sh
+++ b/share/tools/gmt_make_custom_code.sh
@@ -48,8 +48,8 @@ set -e
 LIB=$1
 echo "gmt_make_custom_code.sh: Scanning for modules" >&2
 # Make sure we get both upper- and lower-case versions of the tag
-U_TAG=`echo $LIB | tr '[a-z]' '[A-Z]'`
-L_TAG=`echo $LIB | tr '[A-Z]' '[a-z]'`
+U_TAG=$(echo $LIB | tr '[a-z]' '[A-Z]')
+L_TAG=$(echo $LIB | tr '[A-Z]' '[a-z]')
 
 # Look in current dir
 grep "#define THIS_MODULE_LIB" *.c | awk -F: '{print $1}' | sort > /tmp/tmp.lis
@@ -68,7 +68,7 @@ rm -f /tmp/tmp.lis /tmp/NAME.lis /tmp/LIB.lis /tmp/PURPOSE.lis /tmp/KEYS.lis /tm
 
 # Extract the extension purpose string from CMakeLists.txt
 if [ -f CMakeLists.txt ]; then
-	LIB_STRING=`grep LIB_STRING CMakeLists.txt | awk -F= '{print $NF}'`
+	LIB_STRING=$(grep LIB_STRING CMakeLists.txt | awk -F= '{print $NF}')
 else
 	LIB_STRING="R${L_TAG} modules accessible via gmt"
 fi

--- a/share/tools/gmt_prepmex.sh
+++ b/share/tools/gmt_prepmex.sh
@@ -18,17 +18,17 @@
 # This will require sudo privileges.
 #
 #-------------------------------------------------------------------------
-Rel=`gmt --version | awk '{print substr($1,1,3)}'`
+Rel=$(gmt --version | awk '{print substr($1,1,3)}')
 printf "\ngmt_prepmex.sh will convert a GMT %s.x bundle so libraries are suitable for building the MATLAB interface.\n" $Rel >&2
 printf "You must have sudo privileges on this computer.\n\nContinue? (y/n) [y]:" >&2
 read answer
 if [ "X$answer" = "Xn" ]; then
 	exit 0
 fi
-here=`pwd`
+here=$(pwd)
 # First get a reliable absolute path to the bundle's top directory
-pushd `dirname $0` > /dev/null
-BUNDLEDIR=`pwd | sed -e sB/Contents/Resources/share/toolsBBg`
+pushd $(dirname $0) > /dev/null
+BUNDLEDIR=$(pwd | sed -e sB/Contents/Resources/share/toolsBBg)
 popd > /dev/null
 # Set path to the new gmt installation
 MEXGMT5DIR=/tmp/$$/gmt
@@ -58,7 +58,7 @@ cd $BUNDLEDIR/Contents/Resources/lib
 ls *.dylib | egrep -v 'libgmt.dylib|libpostscriptlight.dylib' > /tmp/l.lis
 # For each, duplicate into /opt/gmt but add a leading X to each name
 while read lib; do
-	new=`echo $lib | awk '{printf "libX%s\n", substr($1,4)}'`
+	new=$(echo $lib | awk '{printf "libX%s\n", substr($1,4)}')
 	cp $lib $MEXLIBDIR/$new
 done < /tmp/l.lis
 # Copy the supplement shared plugin
@@ -71,9 +71,9 @@ while read lib; do
 	otool -L $lib | grep executable_path | awk '{print $1}' > /tmp/t.lis
 	let k=1
 	while read old; do
-		new=`echo $old | awk -F/ '{printf "libX%s\n", substr($NF,4)}'`
+		new=$(echo $old | awk -F/ '{printf "libX%s\n", substr($NF,4)}')
 		if [ $k -eq 1 ]; then # Do the id change
-			was=`echo $lib | awk -F/ '{print substr($1,4)}'`
+			was=$(echo $lib | awk -F/ '{print substr($1,4)}')
 			install_name_tool -id /opt/gmt/lib/$new $lib
 		else
 			install_name_tool -change $old /opt/gmt/lib/$new $lib
@@ -90,7 +90,7 @@ ln -s libXpostscriptlight.6.dylib libXpostscriptlight.dylib
 if [ "$1" == "gs" ]; then
 	# Same stuff for gs which is called by psconvert as a system call.
 	# Here we must determine from where to copy...
-	GSV=`gs --version`
+	GSV=$(gs --version)
 	if [ -d /sw/lib ]; then			# Fink has no shared lib yet...
 		FROM=/sw/lib
 		echo "Sorry, no libgs.dylib under fink yet"
@@ -113,7 +113,7 @@ cd gmt/plugins
 otool -L supplements.so | grep executable_path | awk '{print $1}' > /tmp/t.lis
 let k=1
 while read old; do
-	new=`echo $old | awk -F/ '{printf "libX%s\n", substr($NF,4)}'`
+	new=$(echo $old | awk -F/ '{printf "libX%s\n", substr($NF,4)}')
 	install_name_tool -change $old /opt/gmt/lib/$new supplements.so
 	let k=k+1
 done < /tmp/t.lis
@@ -123,7 +123,7 @@ cd $MEXBINDIR
 otool -L gmt | grep executable_path | awk '{print $1}' > /tmp/t.lis
 let k=1
 while read old; do
-	new=`echo $old | awk -F/ '{printf "libX%s\n", substr($NF,4)}'`
+	new=$(echo $old | awk -F/ '{printf "libX%s\n", substr($NF,4)}')
 	install_name_tool -change $old /opt/gmt/lib/$new gmt
 	let k=k+1
 done < /tmp/t.lis
@@ -132,7 +132,7 @@ printf "gmt_prepmex.sh: Install /opt/gmt\n" >&2
 sudo cp -fpR $MEXGMT5DIR /opt
 rm -rf /tmp/$$
 cd $here
-version=`/opt/gmt/bin/gmt-config --version`
+version=$(/opt/gmt/bin/gmt-config --version)
 # Report
 cat << EOF >&2
 gmt_prepmex.sh: Made updated GMT $version installation in /opt/gmt

--- a/share/tools/gmt_uninstall.sh
+++ b/share/tools/gmt_uninstall.sh
@@ -21,20 +21,20 @@ if ! [ -x "$(command -v gmt)" ]; then
   exit 1
 fi
 
-inc=`gmt-config --includedir`
-share=`gmt --show-sharedir`
-bin=`gmt --show-bindir`
-lib=`gmt --show-plugindir`
+inc=$(gmt-config --includedir)
+share=$(gmt --show-sharedir)
+bin=$(gmt --show-bindir)
+lib=$(gmt --show-plugindir)
 
-cwd=`pwd`
+cwd=$(pwd)
 
-gmt_modules=`gmt --show-classic`
+gmt_modules=$(gmt --show-classic)
 compat_modules="minmax gmtstitch gmtdp grdreformat ps2raster originator"
 
 # 2. Remove include directory
 cd $inc
 cd ..
-here=`pwd`
+here=$(pwd)
 printf "Remove: %s\n" $inc
 rm -rf $inc
 if find "$here" -mindepth 1 -print -quit | grep -q .; then
@@ -84,7 +84,7 @@ fi
 # 5. Lastly remove libs and plugin directory
 cd $lib
 cd ../..
-here=`pwd`
+here=$(pwd)
 if [ -d gmt ]; then	# plugin directory inside a gmt directory; delete gmt instead
 	printf "Remove: %s\n" $here
 	rm -rf gmt

--- a/src/gmt-config.in
+++ b/src/gmt-config.in
@@ -21,7 +21,7 @@
 #
 GMT_EXEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Use the executable dir to figure out the lib and include dirs
-GMT_TOP=`dirname $GMT_EXEDIR`
+GMT_TOP=$(dirname $GMT_EXEDIR)
 CONFIG_INCLUDEDIR="$GMT_TOP/@GMT_INCLUDEDIR@"
 # Check if the configure include directory exist.  If so then we craft
 # the cflags and lib settings off its parent, else stick with config.

--- a/src/gmt_make_PSL_strings.sh
+++ b/src/gmt_make_PSL_strings.sh
@@ -35,9 +35,9 @@ PSL_prologue.ps
 EOF
 while read file; do
 	printf "\n/* Placing content of $file */\n\n" >> PSL_strings.h
-	n=`cat $file | wc -l`
+	n=$(cat $file | wc -l)
 	let n1=n-1
-	varname=`basename $file .ps`
+	varname=$(basename $file .ps)
 	sed -n 1,${n1}p $file | awk 'BEGIN {printf "static char *%s_str = \n", "'$varname'"}; {printf "\"%s\\n\"\n", $0}' >> PSL_strings.h
 	sed -n ${n}p $file | awk '{printf "\"%s\\n\";\n", $0}'>> PSL_strings.h
 done < /tmp/t.lis

--- a/src/gmt_make_enum_dicts.sh
+++ b/src/gmt_make_enum_dicts.sh
@@ -13,7 +13,7 @@ grep GMT_OPT_ /tmp/junk1.txt | awk '{print $1, substr($2,1,2)} '> /tmp/junk3.txt
 while read key value; do
 	printf "%s %d\n" $key "$value" >> /tmp/junk2.txt
 done < /tmp/junk3.txt
-n=`wc -l < /tmp/junk2.txt | awk '{printf "%d\n", $1}'`
+n=$(wc -l < /tmp/junk2.txt | awk '{printf "%d\n", $1}')
 COPY_YEAR=$(date +%Y)
 NOW=$(date +%d-%B-%Y)
 cat << EOF > gmt_enum_dict.h

--- a/src/gmt_make_module_src.sh
+++ b/src/gmt_make_module_src.sh
@@ -27,8 +27,8 @@ set -e
 
 LIB=$1
 # Make sure we get both upper- and lower-case versions of the tag
-U_TAG=`echo $LIB | tr '[a-z]' '[A-Z]'`
-L_TAG=`echo $LIB | tr '[A-Z]' '[a-z]'`
+U_TAG=$(echo $LIB | tr '[a-z]' '[A-Z]')
+L_TAG=$(echo $LIB | tr '[A-Z]' '[a-z]')
 
 if [ "$U_TAG" = "SUPPLEMENTS" ]; then	# Look in directories under the current directory and set LIB_STRING
 	grep "#define THIS_MODULE_LIB		" */*.c | gawk -F: '{print $1}' | sort -u > /tmp/tmp.lis

--- a/src/gmt_make_pattern_include.sh
+++ b/src/gmt_make_pattern_include.sh
@@ -36,7 +36,7 @@ static unsigned char PSL_pattern[90][512] = {
 EOF
 let k=1
 while [ $k -le 90 ]; do
-	name=`echo $k | awk '{printf "PSL_pattern_%2.2d.ras\n", $1}'`
+	name=$(echo $k | awk '{printf "PSL_pattern_%2.2d.ras\n", $1}')
 	printf "\t{\t/* $name */\n" >> PSL_patterns.h
 	od -j32 -t uC -v -An $name | sed '/^$/d' | awk '{printf "\t\t%3d", $1}; {for (i=2; i<=NF;i++) printf ", %3d", $i}; {printf ",\n"}' >> PSL_patterns.h
 	printf "\t},\n" >> PSL_patterns.h

--- a/src/gmt_shell_functions.sh
+++ b/src/gmt_shell_functions.sh
@@ -13,7 +13,7 @@
 #----GMT SHELL FUNCTIONS--------------------
 #	Creates a unique temp directory and points GMT_TMPDIR to it
 gmt_init_tmpdir () {
-	export GMT_TMPDIR=`mktemp -d ${TMPDIR:-/tmp}/gmt.XXXXXX`
+	export GMT_TMPDIR=$(mktemp -d ${TMPDIR:-/tmp}/gmt.XXXXXX)
 }
 
 #	Remove the temp directory created by gmt_init_tmpdir
@@ -59,22 +59,22 @@ gmt_get_field() {
 #	Return w/e/s/n from given table file(s)
 #	May also add -Idx/dy to round off answer
 gmt_get_region() {
-	printf "%s/%s/%s/%s\n" `gmt info -C $* | cut -d'	' -f1-4`
+	printf "%s/%s/%s/%s\n" $(gmt info -C $* | cut -d'	' -f1-4)
 }
 
 #	Return the w/e/s/n from the header in grd file
 gmt_get_gridregion() {
-	printf "%s/%s/%s/%s\n" `gmt grdinfo -Cn $* | cut -d'	' -f1-4`
+	printf "%s/%s/%s/%s\n" $(gmt grdinfo -Cn $* | cut -d'	' -f1-4)
 }
 
 # Make output PostScript file name based on script base name
 gmt_set_psfile() {
-	echo `basename $1 '.sh'`.ps
+	echo $(basename $1 '.sh').ps
 }
 
 # Make output PDF file name based on script base name
 gmt_set_pdffile() {
-	echo `basename $1 '.sh'`.pdf
+	echo $(basename $1 '.sh').pdf
 }
 
 # For animations: Create a lexically increasing file namestem (no extension) based on prefix and frame number
@@ -120,7 +120,7 @@ EOF
 	EOF
 	ls kml/*.kml > /tmp/$$.lis
 	while read file; do
-	        name=`basename $file .kml`
+	        name=$(basename $file .kml)
 		cat << EOF >> doc.kml
 			<NetworkLink>
 	        	<name>$name</name>
@@ -169,7 +169,7 @@ EOF
 		esac
 		shift
 	done
-	delay=`gmt math -Q 100 $rate DIV RINT =`	# Delay to nearest 1/100 s
+	delay=$(gmt math -Q 100 $rate DIV RINT =)	# Delay to nearest 1/100 s
 	if [ $dryrun -eq 1 ]; then
 		cat <<- EOF
 ${GRAPHICSMAGICK-gm} convert -delay $delay -loop $loop +dither "$dir/${1}_*.*" ${1}.gif
@@ -278,12 +278,12 @@ EOF
 			width=9.60; height=5.40; dpi=400
 		fi
 	fi
-	w=`gmt math -Q ${width} ${margin} 2 MUL SUB =`
-	h=`gmt math -Q ${height} ${margin} 2 MUL SUB =`
-	iw=`gmt math -Q ${width} $dpi MUL =`
-	ih=`gmt math -Q ${height} $dpi MUL =`
-	now=`date`
-	you=`finger $LOGNAME | head -1 | awk -F': ' '{print $3}'`
+	w=$(gmt math -Q ${width} ${margin} 2 MUL SUB =)
+	h=$(gmt math -Q ${height} ${margin} 2 MUL SUB =)
+	iw=$(gmt math -Q ${width} $dpi MUL =)
+	ih=$(gmt math -Q ${height} $dpi MUL =)
+	now=$(date)
+	you=$(finger $LOGNAME | head -1 | awk -F': ' '{print $3}')
 	cat << EOF > $name.sh
 #!/usr/bin/env bash
 # Author:	$you
@@ -352,7 +352,7 @@ let frame=0
 while [ \$frame -lt \${VIDEO_FRAMES} ]; do
 	echo "Working on frame \$frame" >&2
 	# 2a. Set current frame prefix for lexically increasing file name
-	ps=\`gmt_set_framename \${VIDEO_PREFIX} \$frame\`.ps
+	ps=\$(gmt_set_framename \${VIDEO_PREFIX} \$frame\).ps
 
 	# 2b. Perform any calculations that depends on the frame number
 
@@ -427,7 +427,7 @@ cat << EOF >> $name.html
 </CENTER>
 Please add a movie caption here.
 <HR>
-<I>Created by $you on `date`</I>
+<I>Created by $you on $(date)</I>
 </BODY>
 </HTML>
 EOF
@@ -440,7 +440,7 @@ gmt_launch_jobs() {
 	# gmt_launch_jobs -c <n_cpu> -j <nlines_per_cluster> <commandfile>
 	# Split the non-comment records in <commandfile> into <n_cpu> files
 	# so that number of lines per file is a multiple of <nlines_per_cluster>.
-	n_cpu=`gmt --show-cores`
+	n_cpu=$(gmt --show-cores)
 	if [ $# -eq 0 ]; then
 		cat << EOF >&2
 gmt_launch_jobs - Run chunks of commands in parallel
@@ -471,9 +471,9 @@ EOF
 		shift
 	done
 	egrep -v '^#|^$' $1 > /tmp/$$.sh
-	nL=`wc -l /tmp/$$.sh | awk '{printf "%d\n", $1}'`
-	n_chunks=`gmt math -Q $nL $n_lines DIV =`
-	bad=`gmt math -Q $n_chunks DUP RINT SUB ABS 1e-10 GT =`
+	nL=$(wc -l /tmp/$$.sh | awk '{printf "%d\n", $1}')
+	n_chunks=$(gmt math -Q $nL $n_lines DIV =)
+	bad=$(gmt math -Q $n_chunks DUP RINT SUB ABS 1e-10 GT =)
 	if [ $bad -eq 1 ]; then
 		echo "gmt_launch_jobs: Your number of commands is not a multiple of $n_lines" >&2
 		exit 1

--- a/src/gmtswitch
+++ b/src/gmtswitch
@@ -53,12 +53,12 @@ fi
 #--------------------------------------------------------------------------------
 # Get the functionality of echo -n
 #--------------------------------------------------------------------------------
-if [ x`echo -n` = x ]; then	# echo -n works
+if [ x$(echo -n) = x ]; then	# echo -n works
   echon()
   {
     echo -n "$*"
   }
-elif [ x`echo -e` = x ]; then	# echo -e works
+elif [ x$(echo -e) = x ]; then	# echo -e works
   echon()
   {
     echo -e "$*"'\c'
@@ -71,7 +71,7 @@ else				# echo with escapes better work
 fi
 
 cd ~
-home=`pwd`
+home=$(pwd)
 if [ ! -f "$home/.gmtversions" ]; then	# No .gmtversions exists yet, first do that part
   cat << EOF >&2
 
@@ -104,7 +104,7 @@ EOF
   fi
   echon "--> Searching..." >&2
   ( find "$top" -type d -name 'GMT[345].*' -print > "$home/.gmtversions" ) 2> /dev/null
-  n=`cat "$home/.gmtversions" | wc -l | awk '{print $1}'`
+  n=$(cat "$home/.gmtversions" | wc -l | awk '{print $1}')
   cat << EOF >&2
 
 There are $n GMT versions currently installed on your system.
@@ -133,13 +133,13 @@ EOF
 fi
 
 if [ "X$1" = "XD" ]; then	# First entry is default
-  line=`head -1 "$home/.gmtversions"`
+  line=$(head -1 "$home/.gmtversions")
   exists "$line"
   rm -f "$home/this_gmt"
   ln -sf "$line" "$home/this_gmt"
 elif [ $# -eq 1 ]; then
-  line=`grep $1 "$home/.gmtversions"`
-  nl=`grep $1 "$home/.gmtversions" | wc -l`
+  line=$(grep $1 "$home/.gmtversions")
+  nl=$(grep $1 "$home/.gmtversions" | wc -l)
   if [ $nl -eq 0 ]; then
     echo "Version $1 is not listed among recognized GMT versions" >&2
     echo "Run gmtswitch -help for more information" >&2
@@ -154,13 +154,13 @@ elif [ $# -eq 1 ]; then
   rm -f "$home/this_gmt"
   ln -sf "$line" "$home/this_gmt"
 else
-  n=`cat "$home/.gmtversions" | wc -l | awk '{print $1}'`
+  n=$(cat "$home/.gmtversions" | wc -l | awk '{print $1}')
   i=0
   while [ $i -lt $n ]; do
-    i=`expr $i + 1`
-    line=`sed -n 's/#.*//;'${i}p "$home/.gmtversions"`
-    comment=`sed -n ${i}'s/.*# *\(.*\)/ (\1)/p' "$home/.gmtversions"`
-    version=`basename $line`
+    i=$(expr $i + 1)
+    line=$(sed -n 's/#.*//;'${i}p "$home/.gmtversions")
+    comment=$(sed -n ${i}'s/.*# *\(.*\)/ (\1)/p' "$home/.gmtversions")
+    version=$(basename $line)
     echo "$i. Select ${line}" >&2
   done
   echo "" >&2
@@ -176,7 +176,7 @@ else
       v=-1
     fi
   done
-  line=`sed -n 's/#.*//;'${v}p "$home/.gmtversions"`
+  line=$(sed -n 's/#.*//;'${v}p "$home/.gmtversions")
   exists "$line"
   rm -f "$home/this_gmt"
   ln -sf "$line" "$home/this_gmt"

--- a/src/img/img2google
+++ b/src/img/img2google
@@ -100,19 +100,19 @@ if [ ! -f $TOPO ]; then
 fi
 
 # Compute dimension of plot in inches and use that as our papersize
-w=`echo $R | awk -F/ '{print substr($1,3)}'`
-e=`echo $R | awk -F/ '{print $2}'`
-s=`echo $R | awk -F/ '{print $3}'`
-n=`echo $R | awk -F/ '{print $4}'`
+w=$(echo $R | awk -F/ '{print substr($1,3)}')
+e=$(echo $R | awk -F/ '{print $2}')
+s=$(echo $R | awk -F/ '{print $3}')
+n=$(echo $R | awk -F/ '{print $4}')
 
 # Extend by two boundary rows/cols
 
-w2=`gmt math -Q -fg --FORMAT_GEO_OUT=ddd:mm $w $INC 60 DIV 2 MUL SUB =`
-e2=`gmt math -Q -fg --FORMAT_GEO_OUT=ddd:mm $e $INC 60 DIV 2 MUL ADD =`
-s2=`gmt math -Q -fg --FORMAT_GEO_OUT=ddd:mm $s $INC 60 DIV 2 MUL SUB =`
-n2=`gmt math -Q -fg --FORMAT_GEO_OUT=ddd:mm $n $INC 60 DIV 2 MUL ADD =`
-W=`gmt math -Q -fg $e2 $w2 SUB =`
-H=`gmt math -Q -fg $n2 $s2 SUB =`
+w2=$(gmt math -Q -fg --FORMAT_GEO_OUT=ddd:mm $w $INC 60 DIV 2 MUL SUB =)
+e2=$(gmt math -Q -fg --FORMAT_GEO_OUT=ddd:mm $e $INC 60 DIV 2 MUL ADD =)
+s2=$(gmt math -Q -fg --FORMAT_GEO_OUT=ddd:mm $s $INC 60 DIV 2 MUL SUB =)
+n2=$(gmt math -Q -fg --FORMAT_GEO_OUT=ddd:mm $n $INC 60 DIV 2 MUL ADD =)
+W=$(gmt math -Q -fg $e2 $w2 SUB =)
+H=$(gmt math -Q -fg $n2 $s2 SUB =)
 R2=-R$w2/$e2/$s2/$n2
 
 # 2. Extract the (x,y,z) of constrained nodes by extracting a grid with
@@ -153,7 +153,7 @@ gmt grdgradient $$.tile.nc $V -A340 -G$$.nc
 gmt grdmath $$.nc 12000 DIV = $$.tile_grad.nc
 gmt psclip $R -Jx1id -Y0 -X0 -P -K -N -T $V --PROJ_ELLIPSOID=WGS-84 --PS_MEDIA=${W}ix${H}i > $$.ps
 #Set up (0,0) to match the even LL corner
-off=`gmt math -Q $INC 2 MUL 60 DIV NEG =`
+off=$(gmt math -Q $INC 2 MUL 60 DIV NEG =)
 if [ X"$C" = "X" ]; then	# No clipping, just lay down image
 	gmt grdimage $$.tile.nc -I$$.tile_grad.nc -C$$.cpt -Jx1id -Y$off -X$off -O -K $V --PROJ_ELLIPSOID=WGS-84 >> $$.ps
 else	# Use GSHHS high clip path to only show ocean areas
@@ -173,35 +173,35 @@ gmt psclip -C -O >> $$.ps
 #  5. make the geotiff file
 #
 if [ X"$G" = "X" ]; then
-	xtag=`echo $w | awk '{if ($1 < 0.0) {printf "W%g\n", -$1} else if ($1 > 180.0) {printf ("W%g\n", 360-$1)} else {printf "E%g\n", $1}}'`
-	ytag=`echo $n | awk '{if ($1 < 0.0) {printf "S%g\n", -$1} else {printf "N%g\n", $1}}'`
+	xtag=$(echo $w | awk '{if ($1 < 0.0) {printf "W%g\n", -$1} else if ($1 > 180.0) {printf ("W%g\n", 360-$1)} else {printf "E%g\n", $1}}')
+	ytag=$(echo $n | awk '{if ($1 < 0.0) {printf "S%g\n", -$1} else {printf "N%g\n", $1}}')
 	name="topo${ytag}${xtag}"
 else
-	name=`echo $G | awk '{print substr($1,3)}'`
+	name=$(echo $G | awk '{print substr($1,3)}')
 fi
 if [ X"$A" = "X" ]; then
 	A=+aS
 else
-	A=+a`echo $A | awk '{print substr($1,3)}'`
+	A=+a$(echo $A | awk '{print substr($1,3)}')
 fi
 if [ ! X"$F" = "X" ]; then
-	F=+f`echo $F | awk '{print substr($1,3)}'`
+	F=+f$(echo $F | awk '{print substr($1,3)}')
 fi
 if [ ! X"$L" = "X" ]; then
-	L=+l`echo $L | awk '{print substr($1,3)}'`
+	L=+l$(echo $L | awk '{print substr($1,3)}')
 fi
 if [ ! X"$U" = "X" ]; then
-	U=+u`echo $U | awk '{print substr($1,3)}'`
+	U=+u$(echo $U | awk '{print substr($1,3)}')
 fi
 if [ X"$N" = "X" ]; then
 	N="+n$name"
 else
-	N=+n`echo $N | awk '{print substr($0,3)}'`
+	N=+n$(echo $N | awk '{print substr($0,3)}')
 fi
 if [ X"$T" = "X" ]; then
 	T="+tPredicted bathymetry"
 else
-	T=+t`echo $T | awk '{print substr($0,3)}'`
+	T=+t$(echo $T | awk '{print substr($0,3)}')
 fi
 mv -f $$.ps $name.ps
 gmt psconvert $name.ps -E${DPI} -A- -TG -W+k${A}${F}${L}"${N}${T}"${U} $V

--- a/src/isogmt.in
+++ b/src/isogmt.in
@@ -29,7 +29,7 @@ END
 	exit
 fi
 
-export GMT_TMPDIR=`mktemp -d ${TMPDIR:-/tmp}/gmt.XXXXXX`
+export GMT_TMPDIR=$(mktemp -d ${TMPDIR:-/tmp}/gmt.XXXXXX)
 gmt $1 =
 if test $? -eq 0; then
 	gmt "$@"

--- a/src/mgd77/make_new_dst.sh
+++ b/src/mgd77/make_new_dst.sh
@@ -44,7 +44,7 @@ else if (NR % 24 == 1) printf("DST%02d%02dQ%02d       000%4.3d", substr($1,3,2),
 else printf("%4.3d", $2, som+=$2) }' > Dst_pli.dat
 
 # Count number of definitive values
-nl=`wc -l Dst_lis.dat | awk '{print $1 + 1}'`
+nl=$(wc -l Dst_lis.dat | awk '{print $1 + 1}')
 
 cat Dst_lis.dat > Dst_all.wdc
 # Complement the file with the still preliminary DSTs

--- a/src/mgd77/mgd77_codes.sh
+++ b/src/mgd77/mgd77_codes.sh
@@ -11,8 +11,8 @@ sed -e 's/ *$//g' < trkdas.cod > $$.dat
 awk '{if (length($1) == 2) {printf "\t{\"%s\", \"%s\"},\n", $1, substr($0, 6)}}' $$.dat > $$.1
 awk 'BEGIN {code = -1; last = "--"}; {if (length($1) > 2) {printf "\t{ %d, \"%s\", \"%s\"},\n", code, $1, substr($0, 6)} else {code++}}' $$.dat > $$.2
 awk '{if (length($1) == 2) {printf "(%s) %s,\n", $1, substr($0, 6)}}' $$.dat > $$.4
-n_agencies=`cat $$.1 | wc -l | awk '{printf "%d\n", $1}'`
-n_vessels=`cat $$.2 | wc -l | awk '{printf "%d\n", $1}'`
+n_agencies=$(cat $$.1 | wc -l | awk '{printf "%d\n", $1}')
+n_vessels=$(cat $$.2 | wc -l | awk '{printf "%d\n", $1}')
 awk -F, '{if (NR == "'${n_agencies}'") {printf "%s.\n", $1} else {printf "%s,\n", $1}}' $$.4 > mgd77_codes.txt
 
 YEAR=$(date +%Y)

--- a/src/mgd77/mgd77netcdfhelper.sh
+++ b/src/mgd77/mgd77netcdfhelper.sh
@@ -81,10 +81,10 @@ while read name rec item size check; do
 	cast=""
 	n_item=1
 	fmt="%s"
-	R=`echo $rec  | awk '{printf "%d\n", $1}'`
-	I=`echo $item | awk '{printf "%d\n", $1}'`
+	R=$(echo $rec  | awk '{printf "%d\n", $1}')
+	I=$(echo $item | awk '{printf "%d\n", $1}')
 	REV="L[MGD77_Param_Key(C,$R,$I)].revised"
-	n=`echo $size | awk -F'*' '{print NF}'`
+	n=$(echo $size | awk -F'*' '{print NF}')
 	if [ $n -eq 1 ]; then   # Single item
 		if [ $size -eq 1 ]; then
 			echo "	char $name;" >> mgd77_functions.h
@@ -94,8 +94,8 @@ while read name rec item size check; do
 		L=$size
 		M=0
 	else                    # 2-D array
-		L=`echo $size | awk -F'*' '{print $1}'`
-		M=`echo $size | awk -F'*' '{print $2}'`
+		L=$(echo $size | awk -F'*' '{print $1}')
+		M=$(echo $size | awk -F'*' '{print $2}')
 		echo "	char $name[$L][$M];" >> mgd77_functions.h
 	fi
 	if [ $L -eq 1 ]; then   # Single character
@@ -108,7 +108,7 @@ while read name rec item size check; do
 		length2="strlen (${pre}P[1]->$name)"
 	else                    # 2-D text array, dim and length given, calc total size
 		n_item=$L
-		length1=`echo $M $L | awk '{print $1*$2}'`
+		length1=$(echo $M $L | awk '{print $1*$2}')
 		length2=$length1
 		cast="(char *)"
 	fi
@@ -135,11 +135,11 @@ while read name rec item size check; do
 	else
 		echo "	\"$name\" $L $rec $item FALSE FALSE NULL" >> $$.6
 	fi
-	key=`expr $key + 1`
+	key=$(expr $key + 1)
 	last=$rec
 done < $$.1
 
-n_names=`cat $$.6 | wc -l | awk '{printf "%d\n", $1}'`
+n_names=$(cat $$.6 | wc -l | awk '{printf "%d\n", $1}')
 cat << EOF >> mgd77_functions.c
 
 	for (i = 0, F->revised = FALSE; !F->revised && i < MGD77_N_HEADER_PARAMS; i++) if (L[i].revised) F->revised = TRUE;

--- a/src/mgd77/mgd77view
+++ b/src/mgd77/mgd77view
@@ -17,7 +17,7 @@ size=0.015i
 gmt mgd77list $1 -Flon,lat,time,faa,gobs,ngrav,eot,mag,mtf1,mtf2,diur,igrf,depth,twt -G4 -bod -Z- > $$.1
 
 # Get region to nearest degree
-Rxy=`gmt gmtinfo -I1 -bi14d $$.1 -fg`
+Rxy=$(gmt gmtinfo -I1 -bi14d $$.1 -fg)
 
 #gmt pscoast $Rxy -JM6 -P -B10f5 -Gbrown -K > t.ps
 #gmt psxy -R -J -O -W0.25p $$.1 -bi14d >> t.ps
@@ -32,19 +32,19 @@ gmt grdtrack -G$RELIEF  $$.2 -bi15d -bod $Rxy -fg > $$.b
 
 gmt mgd77info $1 -E > $$.info
 
-do_twt=`awk '{if (NR == 2) printf "%d\n", $14}' $$.info`
-do_mf=`awk '{if (NR == 2) printf "%d\n", $18+$19}' $$.info`
-do_ma=`awk '{if (NR == 2) printf "%d\n", $20}' $$.info`
-do_gf=`awk '{if (NR == 2) printf "%d\n", $24}' $$.info`
-do_ga=`awk '{if (NR == 2) printf "%d\n", $26}' $$.info`
+do_twt=$(awk '{if (NR == 2) printf "%d\n", $14}' $$.info)
+do_mf=$(awk '{if (NR == 2) printf "%d\n", $18+$19}' $$.info)
+do_ma=$(awk '{if (NR == 2) printf "%d\n", $20}' $$.info)
+do_gf=$(awk '{if (NR == 2) printf "%d\n", $24}' $$.info)
+do_ga=$(awk '{if (NR == 2) printf "%d\n", $26}' $$.info)
 
 # Lay down relief pane:
 
 gmt gmtconvert -F2,12 -bi16d -bod $$.b > $$.depth
 gmt gmtconvert -F2,13 -bi16d -bod $$.b > $$.twt
 gmt gmtconvert -F2,15 -bi16d -bod $$.b > $$.s2004
-Rz=`gmt gmtinfo -I3600/500 $$.depth $$.s2004 -bi2d -f0T --TIME_SYSTEM=unix`
-Rt=`gmt gmtinfo -I3600/1 $$.twt -bi2d -f0T --TIME_SYSTEM=unix`
+Rz=$(gmt gmtinfo -I3600/500 $$.depth $$.s2004 -bi2d -f0T --TIME_SYSTEM=unix)
+Rt=$(gmt gmtinfo -I3600/1 $$.twt -bi2d -f0T --TIME_SYSTEM=unix)
 
 B=
 if [ $do_twt -eq 0 ]; then
@@ -67,8 +67,8 @@ gmt gmtconvert -F2,8 -bi16d -bod $$.b > $$.mtf1
 gmt gmtconvert -F2,9 -bi16d -bod $$.b > $$.mtf2
 gmt gmtconvert -F2,10 -bi16d -bod $$.b > $$.diur
 gmt gmtconvert -F2,11 -bi16d -bod $$.b > $$.igrf
-Rr=`gmt gmtinfo -I3600/500 $$.mtf? $$.igrf -bi2d -f0T --TIME_SYSTEM=unix`
-Ra=`gmt gmtinfo -I3600/500 $$.mag $$.diur -bi2d -f0T --TIME_SYSTEM=unix`
+Rr=$(gmt gmtinfo -I3600/500 $$.mtf? $$.igrf -bi2d -f0T --TIME_SYSTEM=unix)
+Ra=$(gmt gmtinfo -I3600/500 $$.mag $$.diur -bi2d -f0T --TIME_SYSTEM=unix)
 
 B=
 if [ $do_ma -eq 0 ]; then
@@ -93,8 +93,8 @@ gmt gmtconvert -F2,4 -bi16d -bod $$.b > $$.gobs
 gmt gmtconvert -F2,5 -bi16d -bod $$.b > $$.ngrav
 gmt gmtconvert -F2,6 -bi16d -bod $$.b > $$.eot
 gmt gmtconvert -F2,14 -bi16d -bod $$.b > $$.ss
-Rr=`gmt gmtinfo -I3600/500 $$.gobs $$.ngrav -bi2d -f0T --TIME_SYSTEM=unix`
-Ra=`gmt gmtinfo -I3600/50 $$.ss $$.faa $$.eot -bi2d -f0T --TIME_SYSTEM=unix`
+Rr=$(gmt gmtinfo -I3600/500 $$.gobs $$.ngrav -bi2d -f0T --TIME_SYSTEM=unix)
+Ra=$(gmt gmtinfo -I3600/50 $$.ss $$.faa $$.eot -bi2d -f0T --TIME_SYSTEM=unix)
 
 B=
 if [ $do_ga -eq 0 ]; then

--- a/src/shelltest.sh
+++ b/src/shelltest.sh
@@ -18,30 +18,30 @@ cat << EOF > $GMT_TMPDIR/crap.txt
 7 8
 EOF
 
-n=`gmt_nrecords $GMT_TMPDIR/crap.txt`
+n=$(gmt_nrecords $GMT_TMPDIR/crap.txt)
 gmt_message "We got $n records"
 
 rec=0
 while read line; do
-	rec=`expr $rec + 1`
-	n=`gmt_nfields $line`
+	rec=$(expr $rec + 1)
+	n=$(gmt_nfields $line)
 	i=1
 	while [ $i -le $n ]; do
-		x=`gmt_get_field $i "$line"`
+		x=$(gmt_get_field $i "$line")
 		gmt_message "Rec $rec Field $i is $x"
-		i=`expr $i + 1`
+		i=$(expr $i + 1)
 	done
 done < $GMT_TMPDIR/crap.txt
 
-R=`gmt_get_region $GMT_TMPDIR/crap.txt -I2`
+R=$(gmt_get_region $GMT_TMPDIR/crap.txt -I2)
 gmt_message "Found the table region to be $R"
 
 gmt grdmath -R0/50/10/90 -I10 X Y MUL = $GMT_TMPDIR/crap.nc
 
-R=`gmt_get_gridregion $GMT_TMPDIR/crap.nc`
+R=$(gmt_get_gridregion $GMT_TMPDIR/crap.nc)
 gmt_message "Found the grid region to be $R"
 
-PS=`gmt_set_psfile $0`
+PS=$(gmt_set_psfile $0)
 
 gmt_message "PS name is $PS"
 

--- a/src/x2sys/test_x2sys.sh
+++ b/src/x2sys/test_x2sys.sh
@@ -104,9 +104,9 @@ gv $PS &
 
 # Solve for constants
 gmt x2sys_solve COE.txt -TFAKE -Cz -Ec -V > $X2SYS_HOME/FAKE/corr_const.lis
-A=`grep trackA corr.lis | cut -f3`
-B=`grep trackB corr.lis | cut -f3`
-C=`grep trackC corr.lis | cut -f3`
+A=$(grep trackA corr.lis | cut -f3)
+B=$(grep trackB corr.lis | cut -f3)
+C=$(grep trackC corr.lis | cut -f3)
 
 # Correct tracks
 gmt x2sys_datalist -TFAKE -Lcorr_const.lis trackAc.xydz > trackAcc.xydz

--- a/test/api/apicheck_G.sh
+++ b/test/api/apicheck_G.sh
@@ -5,7 +5,7 @@
 function gridset_check {
 	testapi -I$1 -W$2 -Tg
 	gmt grdmath gtesti.nc gtesto.nc SUB = tmp.nc
-	N=(`gmt grd2xyz tmp.nc -ZTLa | uniq | wc -l`)
+	N=($(gmt grd2xyz tmp.nc -ZTLa | uniq | wc -l))
 	if [ $N -ne 1 ]; then
 		echo "gridset_check $1 $2 failed" >> fail
 	fi

--- a/test/api/apicheck_I.sh
+++ b/test/api/apicheck_I.sh
@@ -7,11 +7,11 @@
 # gmt psimage itesti.jpg -W6i -F0.25p -P --PS_CHAR_ENCODING=Standard+ > apicheck_I.ps
 
 # Only do this when GDAL is installed
-GDAL=`gmt grdconvert 2>&1 | grep -c gd`
+GDAL=$(gmt grdconvert 2>&1 | grep -c gd)
 if [ $GDAL -eq 0 ]; then exit; fi
 
 # Use another image as test to avoid storing one for the test
-orig=`gmt which -G @needle.jpg`
+orig=$(gmt which -G @needle.jpg)
 cp -f $orig itesti.jpg
 ps=apicheck_I_f.ps
 testapi -If -Wf -Ti > $ps

--- a/test/api/test_grid_io.sh
+++ b/test/api/test_grid_io.sh
@@ -8,7 +8,7 @@
 
 function check_if_zero {
 	gmt grdmath ${2}=$1 ${3}=$1 SUB = diff.nc
-        N=(`gmt grd2xyz diff.nc -ZTLa | uniq | wc -l`)
+        N=($(gmt grd2xyz diff.nc -ZTLa | uniq | wc -l))
         if [ $N -ne 1 ]; then
                 echo "check_if_zero: $1 : $2 $3 not equal" >> fail
         fi

--- a/test/blockmean/gmean.sh
+++ b/test/blockmean/gmean.sh
@@ -8,16 +8,16 @@ gmt blockmean @ship_15.txt -I1 -R-115/-105/20/30 -fg -E -o2:5 > dump.txt
 gmt blockmean @ship_15.txt -I1 -R-115/-105/20/30 -fg -E -Gfield_%s.grd -Az,s,l,h
 # Mean z:
 gmt grd2xyz field_z.grd -s -o2 > tmp
-z=`gmt convert -A dump.txt tmp -o0,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =`
+z=$(gmt convert -A dump.txt tmp -o0,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =)
 # s:
 gmt grd2xyz field_s.grd -s -o2 > tmp
-s=`gmt convert -A dump.txt tmp -o1,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =`
+s=$(gmt convert -A dump.txt tmp -o1,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =)
 # l:
 gmt grd2xyz field_l.grd -s -o2 > tmp
-l=`gmt convert -A dump.txt tmp -o2,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =`
+l=$(gmt convert -A dump.txt tmp -o2,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =)
 # h:
 gmt grd2xyz field_h.grd -s -o2 > tmp
-h=`gmt convert -A dump.txt tmp -o3,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =`
+h=$(gmt convert -A dump.txt tmp -o3,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =)
 echo $z $s $l $h
 if [ ! "$z $s $l $h" = "1 1 1 1" ] ; then
  	echo "$z $s $l $h" > fail

--- a/test/blockmedian/gmedian.sh
+++ b/test/blockmedian/gmedian.sh
@@ -11,22 +11,22 @@ gmt blockmedian @ship_15.txt -I1 -R-115/-105/20/30 -fg -Eb -Gfield_%s.grd -Aq25,
 
 # Median z:
 gmt grd2xyz field_z.grd -s -o2 > tmp
-z=`gmt convert -A dump.txt tmp -o0,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =`
+z=$(gmt convert -A dump.txt tmp -o0,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =)
 # L1 s:
 gmt grd2xyz field_s.grd -s -o2 > tmp
-s=`gmt convert -A dump.txt tmp -o1,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =`
+s=$(gmt convert -A dump.txt tmp -o1,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =)
 # l:
 gmt grd2xyz field_l.grd -s -o2 > tmp
-l=`gmt convert -A dump.txt tmp -o2,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =`
+l=$(gmt convert -A dump.txt tmp -o2,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =)
 # h:
 gmt grd2xyz field_h.grd -s -o2 > tmp
-h=`gmt convert -A dump.txt tmp -o3,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =`
+h=$(gmt convert -A dump.txt tmp -o3,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =)
 # 25% quartile:
 gmt grd2xyz field_q25.grd -s -o2 > tmp
-q25=`gmt convert -A qdump.txt tmp -o0,2 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =`
+q25=$(gmt convert -A qdump.txt tmp -o0,2 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =)
 # 75% quartile:
 gmt grd2xyz field_q75.grd -s -o2 > tmp
-q75=`gmt convert -A qdump.txt tmp -o1,2 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =`
+q75=$(gmt convert -A qdump.txt tmp -o1,2 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =)
 echo $z $s $l $q25 $q75 $h
 if [ ! "$z $s $l $q25 $q75 $h" = "1 1 1 1 1 1" ] ; then
  	echo "$z $s $l $q25 $q75 $h" > fail

--- a/test/blockmode/gmode.sh
+++ b/test/blockmode/gmode.sh
@@ -8,16 +8,16 @@ gmt blockmode @ship_15.txt -I1 -R-115/-105/20/30 -fg -E -o2:5 > dump.txt
 gmt blockmode @ship_15.txt -I1 -R-115/-105/20/30 -fg -E -Gfield_%s.grd -Az,s,l,h
 # Mode z:
 gmt grd2xyz field_z.grd -s -o2 > tmp
-z=`gmt convert -A dump.txt tmp -o0,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =`
+z=$(gmt convert -A dump.txt tmp -o0,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =)
 # L1 :
 gmt grd2xyz field_s.grd -s -o2 > tmp
-s=`gmt convert -A dump.txt tmp -o1,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =`
+s=$(gmt convert -A dump.txt tmp -o1,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =)
 # l:
 gmt grd2xyz field_l.grd -s -o2 > tmp
-l=`gmt convert -A dump.txt tmp -o2,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =`
+l=$(gmt convert -A dump.txt tmp -o2,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =)
 # h:
 gmt grd2xyz field_h.grd -s -o2 > tmp
-h=`gmt convert -A dump.txt tmp -o3,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =`
+h=$(gmt convert -A dump.txt tmp -o3,4 | awk '{print ($1-$2)/$1}' | gmt math STDIN  -T -Sf ABS UPPER 1e-7 LT =)
 echo $z $s $l $h
 if [ ! "$z $s $l $h" = "1 1 1 1" ] ; then
  	echo "$z $s $l $h" > fail

--- a/test/fitcircle/circles.sh
+++ b/test/fitcircle/circles.sh
@@ -11,12 +11,12 @@ ps=circles.ps
 
 gmt fitcircle gcircle.txt -L3 > g.txt
 gmt fitcircle scircle.txt -L3 -S > s.txt
-gpole1=`gmt convert g.txt -e"L1 N Hemisphere" -o0:1 --IO_COL_SEPARATOR=/`
-gpole2=`gmt convert g.txt -e"L2 N Hemisphere" -o0:1 --IO_COL_SEPARATOR=/`
-spole1=`gmt convert s.txt -e"L1 Small Circle Pole" -o0:1 --IO_COL_SEPARATOR=/`
-spole2=`gmt convert s.txt -e"L2 Small Circle Pole" -o0:1 --IO_COL_SEPARATOR=/`
-slat1=`grep "L1 Small Circle" s.txt | $AWK '{print 90-$NF}'`
-slat2=`grep "L2 Small Circle" s.txt | $AWK '{print 90-$NF}'`
+gpole1=$(gmt convert g.txt -e"L1 N Hemisphere" -o0:1 --IO_COL_SEPARATOR=/)
+gpole2=$(gmt convert g.txt -e"L2 N Hemisphere" -o0:1 --IO_COL_SEPARATOR=/)
+spole1=$(gmt convert s.txt -e"L1 Small Circle Pole" -o0:1 --IO_COL_SEPARATOR=/)
+spole2=$(gmt convert s.txt -e"L2 Small Circle Pole" -o0:1 --IO_COL_SEPARATOR=/)
+slat1=$(grep "L1 Small Circle" s.txt | $AWK '{print 90-$NF}')
+slat2=$(grep "L2 Small Circle" s.txt | $AWK '{print 90-$NF}')
 gmt psxy -Rg -JG-30/40/7i -P -Bg -K gcircle.txt -Sc0.04i -Gred -Xc -Yc > $ps
 gmt psxy -R -J -O -K scircle.txt -Sc0.04i -Ggreen >> $ps
 gmt project -G1 -T$gpole1 -L-180/180 | gmt psxy -R -J -O -K -W3p >> $ps

--- a/test/geodesy/case_largeR_noW.sh
+++ b/test/geodesy/case_largeR_noW.sh
@@ -6,7 +6,7 @@
 # GRAPHICSMAGICK_RMS = 0.0435
 ps=case_largeR_noW.ps
 # Use real GPS data with uncertainties
-data=`gmt which -G @wus_gps_final_crowell.txt`
+data=$(gmt which -G @wus_gps_final_crowell.txt)
 #  Large region
 R=122.5W/115W/33N/38N
 # blockmean interval

--- a/test/geodesy/case_largeR_withW.sh
+++ b/test/geodesy/case_largeR_withW.sh
@@ -6,7 +6,7 @@
 # GRAPHICSMAGICK_RMS = 0.0435
 ps=case_largeR_withW.ps
 # Use real GPS data with uncertainties
-data=`gmt which -G @wus_gps_final_crowell.txt`
+data=$(gmt which -G @wus_gps_final_crowell.txt)
 #  Large region
 R=122.5W/115W/33N/38N
 # blockmean interval

--- a/test/geodesy/case_smallR_noW.sh
+++ b/test/geodesy/case_smallR_noW.sh
@@ -6,7 +6,7 @@
 # GRAPHICSMAGICK_RMS = 0.0655
 ps=case_smallR_noW.ps
 # Use real GPS data with uncertainties
-data=`gmt which -G @wus_gps_final_crowell.txt`
+data=$(gmt which -G @wus_gps_final_crowell.txt)
 #  Small region
 R=118.5W/115.2W/33.0N/34.5N
 # blockmean interval

--- a/test/geodesy/case_smallR_withW.sh
+++ b/test/geodesy/case_smallR_withW.sh
@@ -6,7 +6,7 @@
 # GRAPHICSMAGICK_RMS = 0.0655
 ps=case_smallR_withW.ps
 # Use real GPS data with uncertainties
-data=`gmt which -G @wus_gps_final_crowell.txt`
+data=$(gmt which -G @wus_gps_final_crowell.txt)
 #  Select small region
 R=118.5W/115.2W/33.0N/34.5N
 # blockmean interval

--- a/test/gmtconvert/binheader.sh
+++ b/test/gmtconvert/binheader.sh
@@ -7,7 +7,7 @@ cat << EOF > header.txt
 # This is another line of junky stuff........................
 EOF
 # Compute the size of the header in bytes
-h=`ls -l header.txt | awk '{print $5}'`
+h=$(ls -l header.txt | awk '{print $5}')
 # Make binary file with leading junk header
 cat header.txt > junk.b
 cat t.b >> junk.b

--- a/test/gmtconvert/conversion.sh
+++ b/test/gmtconvert/conversion.sh
@@ -3,8 +3,8 @@
 echo 1 2 3 4 5 > t.txt
 gmt convert t.txt -o0,1,4 -bo3d > d.b
 gmt convert t.txt -o0,1,4 -bo3f > s.b
-D=`ls -l d.b | awk '{print $5}'`
-S=`ls -l d.b | awk '{print $5}'`
+D=$(ls -l d.b | awk '{print $5}')
+S=$(ls -l d.b | awk '{print $5}')
 touch fail
 if [ $D -ne $S ]; then
 	echo "db and sb differ in size" >> fail

--- a/test/gmtinfo/binascregion.sh
+++ b/test/gmtinfo/binascregion.sh
@@ -3,8 +3,8 @@
 # access the same files and apply the same col-type tests
 # Based on msg7140 by John.
 
-A=`gmt info -I1d/0.5d -i3,2 tp2.xyz`
-B=`gmt info -I1d/0.5d -i3,2 tp2.bin -bi7d`
+A=$(gmt info -I1d/0.5d -i3,2 tp2.xyz)
+B=$(gmt info -I1d/0.5d -i3,2 tp2.bin -bi7d)
 if [ ! "X$A" = "X$B" ]; then
 	echo "Ascii: $A  Bin: $B" > fail
 fi

--- a/test/gmtmath/lsfit.sh
+++ b/test/gmtmath/lsfit.sh
@@ -14,10 +14,10 @@ x0=0.5
 # gmt math -T-3/3/0.1 T $b MUL $a ADD $x0 STEPT $c MUL ADD 0 0.1 NRAND ADD = stepdata.txt
 gmt math -A@stepdata.txt+r -N4/1 -C0 1 ADD -C1 T ADD -C2 0.5 STEPT ADD -Ca LSQFIT = solution.txt
 # For this example we use the coefficients to evaluate the function the hard way
-q=(`cat solution.txt`)
+q=($(cat solution.txt))
 gmt math -T-3/3/0.1 T ${q[1]} MUL ${q[0]} ADD 0.5 STEPT ${q[2]} MUL ADD = stepfit_lsq.txt
 gmt math -A@stepdata.txt+r -N4/1 -C0 1 ADD -C1 T ADD -C2 0.5 STEPT ADD -Ca SVDFIT = solution.txt
-q=(`cat solution.txt`)
+q=($(cat solution.txt))
 gmt math -T-3/3/0.1 T ${q[1]} MUL ${q[0]} ADD 0.5 STEPT ${q[2]} MUL ADD = stepfit_svd.txt
 gmt psxy -R-3/3/0/4 -JX6.5i/4i -P -Baf -BWSne @stepdata.txt -Sc0.15c -Gblue -K -Xc > $ps
 gmt psxy -R -J -O -K stepfit_lsq.txt -W2p >> $ps

--- a/test/gmtregress/draper.sh
+++ b/test/gmtregress/draper.sh
@@ -32,7 +32,7 @@ cat << EOF > draper.txt
 28.6	11.08
 EOF
 # First plot data and basic LS fit with equation
-txt=$(gmt regress -Ey -N2 -Fxm -T25/80/2+n draper.txt -T0 | awk '{printf "85 13 @!y\\\\303 = %.4f %.4f x\n", $17, $15}')
+txt=$(gmt regress -Ey -N2 -Fxm -T25/80/2+n draper.txt -T0 | awk '{printf "85 13 @!y\\303 = %.4f %.4f x\n", $17, $15}')
 gmt psbasemap -R20/85/6/13 -JX6.5i/4i -P -Xc -K -Baf -BWSne > $ps
 gmt regress -Ey -N2 -Fxym draper.txt | awk '{printf "> error\n%s %s\n%s %s\n", $1, $2, $1, $3}' | gmt psxy -R -J -O -K -W0.25p,red,- >> $ps
 gmt psxy -R -J -O -K draper.txt -Sc0.2c -Gblue >> $ps

--- a/test/gmtregress/draper.sh
+++ b/test/gmtregress/draper.sh
@@ -32,7 +32,7 @@ cat << EOF > draper.txt
 28.6	11.08
 EOF
 # First plot data and basic LS fit with equation
-txt=`gmt regress -Ey -N2 -Fxm -T25/80/2+n draper.txt -T0 | awk '{printf "85 13 @!y\\\\303 = %.4f %.4f x\n", $17, $15}'`
+txt=$(gmt regress -Ey -N2 -Fxm -T25/80/2+n draper.txt -T0 | awk '{printf "85 13 @!y\\\\303 = %.4f %.4f x\n", $17, $15}')
 gmt psbasemap -R20/85/6/13 -JX6.5i/4i -P -Xc -K -Baf -BWSne > $ps
 gmt regress -Ey -N2 -Fxym draper.txt | awk '{printf "> error\n%s %s\n%s %s\n", $1, $2, $1, $3}' | gmt psxy -R -J -O -K -W0.25p,red,- >> $ps
 gmt psxy -R -J -O -K draper.txt -Sc0.2c -Gblue >> $ps

--- a/test/gmtregress/regress_1.sh
+++ b/test/gmtregress/regress_1.sh
@@ -15,7 +15,7 @@ function plot_one {	# 5 args are: -E -N axes -X -Y
 	gmt math tmp -i0,1 DUP DUP LOWER EQ MUL = | awk '{if (NF == 2 && $2 > 0) printf "%s %s %s 0.001\n", $1, $2, $1}' | gmt psxy -R -J -O -K -Sv0.2i+s+b+h1 -Gred $4 $5
 }
 # Allow outliers to be included in the analysis:
-file=`gmt which -G @hertzsprung-russell.txt`
+file=$(gmt which -G @hertzsprung-russell.txt)
 sed -e s/#//g $file > data
 gmt psxy -R-90/90/0.001/100 -JX2i/2il -T -P -K -Xa1i -Ya1i > $ps
 # L1

--- a/test/gmtregress/regress_2.sh
+++ b/test/gmtregress/regress_2.sh
@@ -15,7 +15,7 @@ function plot_one {	# 5 args are: -E -N axes -X -Y
 	gmt psxy -R -W1p,red -J -O -K $4 $5 tmp -W1p
 }
 # Allow outliers to be included in the analysis:
-file=`gmt which -G @hertzsprung-russell.txt`
+file=$(gmt which -G @hertzsprung-russell.txt)
 sed -e s/#//g $file > data
 # Identify the red giants (outliers)
 grep '#' $file | sed -e s/#//g > giants

--- a/test/gmtspatial/crossings.sh
+++ b/test/gmtspatial/crossings.sh
@@ -7,7 +7,7 @@ gmt project -C22/49 -E-60/-20 -G10 -Q > line1.dat
 gmt project -C0/-60 -E-60/30  -G10 -Q > line2.dat
 gmt spatial line1.dat line2.dat -Ie -Fl > intersections.dat
 echo "-45.1337990939  -2.32614829776" > answer.txt
-n=`gmt info -Fi -o2 intersections.dat`
+n=$(gmt info -Fi -o2 intersections.dat)
 gmt pscoast -N1 -R-65/25/-62/65 -JQ22/6i -P -A5000 -Wthinnest -Slightblue -Glightbrown -Bafg -B+t"Number of intersections: $n" -Dl -K -Xc > $ps
 gmt psxy -R -J -O -K -Sc0.1i -Ggreen answer.txt >> $ps
 gmt psxy line1.dat -R -J -O -Wthick,blue -K >> $ps

--- a/test/gmtspatial/nn.sh
+++ b/test/gmtspatial/nn.sh
@@ -7,7 +7,7 @@
 #gmt math -T0/9/1 -o1 0 100 RAND = z
 #paste x y z > points.txt
 ps=nn.ps
-DATA=`gmt which -G @nn_points.txt`
+DATA=$(gmt which -G @nn_points.txt)
 # NN analysis
 gmt spatial -Aa0k -fg $DATA > results.txt
 gmt set MAP_FRAME_TYPE plain

--- a/test/gmtspatial/poldecimate.sh
+++ b/test/gmtspatial/poldecimate.sh
@@ -7,13 +7,13 @@
 #gmt math -T0/2000/1 -o1 0 100 RAND = z
 #paste x y z > polar.txt
 ps=poldecimate.ps
-DATA=`gmt which -G @nn_polar.txt`
+DATA=$(gmt which -G @nn_polar.txt)
 # NN averaging
 gmt spatial -Aa100k -fg $DATA > results.txt
 gmt psxy -R0/360/60/90 -JA0/90/4.5i -P -K -Bafg -BWsne $DATA -Sc0.05i -Ggreen -X1.5i -Y0.75i > $ps
 echo "90 60 N = 2000" | gmt pstext -R -J -O -K -N -F+f12+jLM -Dj0.25i >> $ps
 gmt psxy -R -J -O -K $DATA -Sc0.05i -Bafg -BWsne -Gdarkseagreen1 -Y5i >> $ps
 gmt psxy -R -J -O -K results.txt -Sc0.05i -Gred >> $ps
-N=`wc -l results.txt | awk '{printf "%d\n", $1}'`
+N=$(wc -l results.txt | awk '{printf "%d\n", $1}')
 echo "90 60 N = $N" | gmt pstext -R -J -O -K -N -F+f12+jLM -Dj0.25i >> $ps
 gmt psxy -R -J -O -T >> $ps

--- a/test/grdcontour/contours.sh
+++ b/test/grdcontour/contours.sh
@@ -11,7 +11,7 @@ color_contour () {
 	for name in contour_*.txt; do
 		# For each contour we compute distance a
 		gmt mapproject -G+uk $name > contour.d
-		L=`gmt info -C contour.d | cut -f8`
+		L=$(gmt info -C contour.d | cut -f8)
 		$AWK -v L=$L '{print $1, $2, $4/L}' contour.d | gmt psxy -R -J -O -K -Ccontour.cpt -Sc0.005i >> $ps
 	done
 }

--- a/test/grdconvert/reformat_af.sh
+++ b/test/grdconvert/reformat_af.sh
@@ -16,5 +16,5 @@ gmt grdconvert lixo.af=af lixo.nc
 gmt grdmath lixo.nc lixo.af=af SUB = lixo_dif.nc
 gmt grd2xyz lixo_dif.nc -ZTLa >> $log
 
-res=`gmt info -C $log`
+res=$(gmt info -C $log)
 echo ${res[0]} ${res[1]} | $AWK '{if($1 != 0 || $2 != 0) print 1}' > fail

--- a/test/grdconvert/reformat_bb.sh
+++ b/test/grdconvert/reformat_bb.sh
@@ -16,5 +16,5 @@ gmt grdconvert lixo.bb=bb lixo.nc
 gmt grdmath lixo.nc lixo.bb=bb SUB = lixo_dif.nc
 gmt grd2xyz lixo_dif.nc -ZTLa >> $log
 
-res=`gmt info -C $log`
+res=$(gmt info -C $log)
 echo ${res[0]} ${res[1]} | $AWK '{if($1 != 0 || $2 != 0) print 1}' > fail

--- a/test/grdconvert/reformat_bd.sh
+++ b/test/grdconvert/reformat_bd.sh
@@ -16,5 +16,5 @@ gmt grdconvert lixo.bd=bd lixo.nc
 gmt grdmath lixo.nc lixo.bd=bd SUB = lixo_dif.nc
 gmt grd2xyz lixo_dif.nc -ZTLa >> $log
 
-res=`gmt info -C $log`
+res=$(gmt info -C $log)
 echo ${res[0]} ${res[1]} | $AWK '{if($1 != 0 || $2 != 0) print 1}' > fail

--- a/test/grdconvert/reformat_bf.sh
+++ b/test/grdconvert/reformat_bf.sh
@@ -16,5 +16,5 @@ gmt grdconvert lixo.bf=bf lixo.nc
 gmt grdmath lixo.nc lixo.bf=bf SUB = lixo_dif.nc
 gmt grd2xyz lixo_dif.nc -ZTLa >> $log
 
-res=`gmt info -C $log`
+res=$(gmt info -C $log)
 echo ${res[0]} ${res[1]} | $AWK '{if($1 != 0 || $2 != 0) print 1}' > fail

--- a/test/grdconvert/reformat_bi.sh
+++ b/test/grdconvert/reformat_bi.sh
@@ -16,5 +16,5 @@ gmt grdconvert lixo.bi=bi lixo.nc
 gmt grdmath lixo.nc lixo.bi=bi SUB = lixo_dif.nc
 gmt grd2xyz lixo_dif.nc -ZTLa >> $log
 
-res=`gmt info -C $log`
+res=$(gmt info -C $log)
 echo ${res[0]} ${res[1]} | $AWK '{if($1 != 0 || $2 != 0) print 1}' > fail

--- a/test/grdconvert/reformat_bs.sh
+++ b/test/grdconvert/reformat_bs.sh
@@ -16,5 +16,5 @@ gmt grdconvert lixo.bs=bs lixo.nc
 gmt grdmath lixo.nc lixo.bs=bs SUB = lixo_dif.nc
 gmt grd2xyz lixo_dif.nc -ZTLa >> $log
 
-res=`gmt info -C $log`
+res=$(gmt info -C $log)
 echo ${res[0]} ${res[1]} | $AWK '{if($1 != 0 || $2 != 0) print 1}' > fail

--- a/test/grdconvert/reformat_ef.sh
+++ b/test/grdconvert/reformat_ef.sh
@@ -16,5 +16,5 @@ gmt grdconvert lixo.ef=ef lixo.nc
 gmt grdmath lixo.nc lixo.ef=ef SUB = lixo_dif.nc
 gmt grd2xyz lixo_dif.nc -ZTLa >> $log
 
-res=`gmt info -C $log`
+res=$(gmt info -C $log)
 echo ${res[0]} ${res[1]} | $AWK '{if($1 != 0 || $2 != 0) print 1}' > fail

--- a/test/grdconvert/reformat_ei.sh
+++ b/test/grdconvert/reformat_ei.sh
@@ -16,5 +16,5 @@ gmt grdconvert lixo.ei=ei lixo.nc
 gmt grdmath lixo.nc lixo.ei=ei SUB = lixo_dif.nc
 gmt grd2xyz lixo_dif.nc -ZTLa >> $log
 
-res=`gmt info -C $log`
+res=$(gmt info -C $log)
 echo ${res[0]} ${res[1]} | $AWK '{if($1 != 0 || $2 != 0) print 1}' > fail

--- a/test/grdconvert/reformat_rf.sh
+++ b/test/grdconvert/reformat_rf.sh
@@ -16,5 +16,5 @@ gmt grdconvert lixo.rf=rf lixo.nc
 gmt grdmath lixo.nc lixo.rf=rf SUB = lixo_dif.nc
 gmt grd2xyz lixo_dif.nc -ZTLa >> $log
 
-res=`gmt info -C $log`
+res=$(gmt info -C $log)
 echo ${res[0]} ${res[1]} | $AWK '{if($1 != 0 || $2 != 0) print 1}' > fail

--- a/test/grdconvert/reformat_sf.sh
+++ b/test/grdconvert/reformat_sf.sh
@@ -16,5 +16,5 @@ gmt grdconvert lixo.sf=sf lixo.nc
 gmt grdmath lixo.nc lixo.sf=sf SUB = lixo_dif.nc
 gmt grd2xyz lixo_dif.nc -ZTLa >> $log
 
-res=`gmt info -C $log`
+res=$(gmt info -C $log)
 echo ${res[0]} ${res[1]} | $AWK '{if($1 != 0 || $2 != 0) print 1}' > fail

--- a/test/grdfft/bworthr.sh
+++ b/test/grdfft/bworthr.sh
@@ -5,14 +5,14 @@ ps=bworthr.ps
 
 F0=0.25
 gmt math -T0/0.5/0.001 T $F0 DIV 12 POW 1 ADD INV 128 PI DIV DIV T MUL = curve.txt
-L=`gmt math -Q 128 INV PI MUL 2 DIV =`
+L=$(gmt math -Q 128 INV PI MUL 2 DIV =)
 # White noise of unit amplitude: Saved since otherwise it would change each time
 # gmt grdmath -R0/256/0/256 -I1 -r 0 1 NRAND = @white_noise.nc
 gmt grdfft @white_noise.nc -Er -N+a > bworth_r.txt
 gmt grdfft @white_noise.nc -Er+n -N+a > bworth_rn.txt
 gmt grdfft @white_noise.nc -Fr-/4/6 -Er -N+a > bworth_br.txt
 gmt grdfft @white_noise.nc -Fr-/4/6 -Er+n -N+a > bworth_brn.txt
-A=`gmt math -Sf -o1 bworth_rn.txt MEAN =`
+A=$(gmt math -Sf -o1 bworth_rn.txt MEAN =)
 gmt math -T0/0.5/0.001 T $F0 DIV 12 POW 1 ADD INV $A MUL = curven.txt
 gmt psbasemap -R0/0.5/0/0.0125 -JX6i/4i -Baf -BWSne -P -K -X1.25i > $ps
 gmt psxy -R -J -O -K -W0.5p << EOF >> $ps

--- a/test/grdfft/bworthxy.sh
+++ b/test/grdfft/bworthxy.sh
@@ -5,7 +5,7 @@ ps=bworthxy.ps
 
 F0=0.25
 gmt math -T0/0.5/0.001 T $F0 DIV 12 POW 1 ADD INV 128 DIV = curve.txt
-L=`gmt math -Q 128 INV =`
+L=$(gmt math -Q 128 INV =)
 # White noise of unit amplitude: Saved since otherwise it would change each time
 # gmt grdmath -R0/256/0/256 -I1 -r 0 1 NRAND = @white_noise.nc
 gmt grdfft @white_noise.nc -Ex -N+a > bworth_x.txt

--- a/test/grdfft/cylundulation.sh
+++ b/test/grdfft/cylundulation.sh
@@ -24,8 +24,8 @@ gmt grdfft @surf.nc -Ex+w -N+zp --GMT_FFT=brenner > /dev/null
 gmt makecpt -Cwhite,gray -T0/0.5 -N > t.cpt
 gmt makecpt -N -T0.5/3.5/1 -Crainbow >> t.cpt
 gmt grdimage surf_mag.nc -R-1/1/-1/1 -J -O -K -Ct.cpt -Bafg1+u" m@+-1@+" -BWSne+t"Two cylindrical undulations and noise" -Y5i >> $ps
-y=`gmt math -Q 18 TAND =`
-x=`gmt math -Q 90 -60 ADD TAND =`
+y=$(gmt math -Q 18 TAND =)
+x=$(gmt math -Q 90 -60 ADD TAND =)
 gmt psxy -R-1/1/-1/1 -J -O -K -Wthin << EOF >> $ps
 >
 -1	-$y

--- a/test/grdfft/in_taper.sh
+++ b/test/grdfft/in_taper.sh
@@ -14,10 +14,10 @@ cat << EOF > box
 EOF
 
 scl=0.01
-x=`gmt math -Q 512 2 DIV $scl MUL =`
-xoff=`gmt math -Q 512 300 SUB 2 DIV $scl MUL NEG =`
-yoff=`gmt math -Q 200 $scl MUL 0.5 ADD =`
-yoffe=`gmt math -Q 384 $scl MUL 0.5 ADD =`
+x=$(gmt math -Q 512 2 DIV $scl MUL =)
+xoff=$(gmt math -Q 512 300 SUB 2 DIV $scl MUL NEG =)
+yoff=$(gmt math -Q 200 $scl MUL 0.5 ADD =)
+yoffe=$(gmt math -Q 384 $scl MUL 0.5 ADD =)
 gmt makecpt -Cpolar -T-1/1 > t.cpt
 gmt grdimage t.nc -Jx${scl}i -Ct.cpt -P -Ba -BWSne -K -X1.75i > $ps
 echo "350 100 Original Data" | gmt pstext -R -J -O -K -N -F+jLM+f16p -D0.5i/0 >> $ps

--- a/test/grdfft/out_taper.sh
+++ b/test/grdfft/out_taper.sh
@@ -16,14 +16,14 @@ cat << EOF > box
 EOF
 
 scl=0.008
-x=`gmt math -Q 512 2 DIV $scl MUL =`
-xoff=`gmt math -Q 512 300 SUB 2 DIV $scl MUL NEG =`
-yoff=`gmt math -Q 200 $scl MUL 0.5 ADD =`
-yoffe=`gmt math -Q 384 $scl MUL 0.5 ADD =`
+x=$(gmt math -Q 512 2 DIV $scl MUL =)
+xoff=$(gmt math -Q 512 300 SUB 2 DIV $scl MUL NEG =)
+yoff=$(gmt math -Q 200 $scl MUL 0.5 ADD =)
+yoffe=$(gmt math -Q 384 $scl MUL 0.5 ADD =)
 gmt makecpt -Cpolar -T-1/1 > t.cpt
 gmt grdimage t.nc -Jx${scl}i -Ct.cpt -P -Ba -BWSne -K > $ps
 gmt grd2xyz t_tmp2.nc | awk '{if ($2 == 100) print $1, $3}' > tmp
-R=`gmt info tmp -I10/3`
+R=$(gmt info tmp -I10/3)
 gmt psxy $R -JX3.5i/1.6i -O -K -W1p,green -Bxaf -Byafg10 -BWSne -X3i tmp >> $ps
 gmt psxy -R -J -O -K -W0.5p,- << EOF >> $ps
 >

--- a/test/grdfilter/filtertest.sh
+++ b/test/grdfilter/filtertest.sh
@@ -24,11 +24,11 @@ mode=c
 no_U=1
 gmt set PROJ_ELLIPSOID Sphere
 # Set contour limits so we just draw the filter radius
-lo=`gmt math -Q $D 2 DIV 0.5 SUB =`
-hi=`gmt math -Q $D 2 DIV 0.5 ADD =`
+lo=$(gmt math -Q $D 2 DIV 0.5 SUB =)
+hi=$(gmt math -Q $D 2 DIV 0.5 ADD =)
 # Run gmt grdfilter as specified
 gmt grdfilter -A${mode}${lon}/$lat -D4 -F${FILT}$D -I$INC $DATA -Gt.nc -fg ${_thread_opt}
-n_conv=`cat n_conv.txt`
+n_conv=$(cat n_conv.txt)
 if [ $lat -lt 0 ]; then	# S hemisphere view
 	plat=-90
 	range=-90/0

--- a/test/grdimage/readwrite_withgdal.sh
+++ b/test/grdimage/readwrite_withgdal.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 
-GDAL=`gmt grdconvert 2>&1 | grep -c gd`
+GDAL=$(gmt grdconvert 2>&1 | grep -c gd)
 if [ $GDAL -eq 0 ]; then exit; fi
 
 ps=readwrite_withgdal.ps

--- a/test/grdpaste/paste_esri.sh
+++ b/test/grdpaste/paste_esri.sh
@@ -9,7 +9,7 @@ gmt grdmath -R-15/15/0/15 -I0.5 X = lixo_y2.asc=ef
 gmt grdpaste lixo_y1.asc lixo_y2.asc -Glixo_y.nc
 gmt grdmath -R-15/15/-15/15 -I0.5 X = answer.nc
 gmt grdmath lixo_y.nc answer.nc SUB 0 EQ = tmp.nc
-n=`gmt grd2xyz tmp.nc -Z | uniq | wc -l | $AWK '{print $1}'`
+n=$(gmt grd2xyz tmp.nc -Z | uniq | wc -l | $AWK '{print $1}')
 if [ $n -gt 1 ]; then
 	echo "Found $n different results instead of just 1" > fail
 else

--- a/test/grdproject/units.sh
+++ b/test/grdproject/units.sh
@@ -4,10 +4,10 @@
 # Make a small geographic grid
 gmt grdmath -R-70:10:17.05/-70:10:0.10/-42:40:31.10/-42:40:19.95 -I1.31151346331e-05/1.29590887959e-05 X Y MUL = tmp.nc
 gmt grdproject -JM-70:10:13.525/-42:40:25.525/8 -R-70:10:17.05/-70:10:0.10/-42:40:31.10/-42:40:19.95 tmp.nc -Gc.nc -nb --PROJ_LENGTH_UNIT=cm
-w_cm=`gmt grdinfo c.nc -C | cut -f3`
+w_cm=$(gmt grdinfo c.nc -C | cut -f3)
 gmt grdproject -JM-70:10:13.525/-42:40:25.525/8 -R-70:10:17.05/-70:10:0.10/-42:40:31.10/-42:40:19.95 tmp.nc -Gi.nc -nb --PROJ_LENGTH_UNIT=inch
-w_inch=`gmt grdinfo i.nc -C | cut -f3`
-err=`gmt math -Q $w_inch $w_cm NEQ =`
+w_inch=$(gmt grdinfo i.nc -C | cut -f3)
+err=$(gmt math -Q $w_inch $w_cm NEQ =)
 if [ $err -eq 1 ]; then
 	echo "cm gave $w_cm cm and inch gave $w_inch inc" > fail
 else

--- a/test/grdvolume/sphere_volume.sh
+++ b/test/grdvolume/sphere_volume.sh
@@ -5,8 +5,8 @@
 ps=sphere_volume.ps
 gmt grdmath -R-10.1/10.1/-10.1/10.1 -I0.1 X Y HYPOT 10 DIV ACOS SIN 10 MUL NEG = bot_half.grd
 gmt grdmath bot_half.grd NEG = top_half.grd
-T=(`gmt grdvolume top_half.grd -C0 --FORMAT_FLOAT_OUT=%.3f`)
-B=(`gmt grdvolume bot_half.grd -Cr-10/0 --FORMAT_FLOAT_OUT=%.3f`)
+T=($(gmt grdvolume top_half.grd -C0 --FORMAT_FLOAT_OUT=%.3f))
+B=($(gmt grdvolume bot_half.grd -Cr-10/0 --FORMAT_FLOAT_OUT=%.3f))
 gmt grdgradient top_half.grd -Nt1 -A45 -Gint.grd
 echo "-100 gray 100 gray" > t.cpt
 gmt grdview bot_half.grd -Iint.grd -Ct.cpt -Qi100 -Jx0.2i -Jz0.2i -p125/35 -P -Baf -BwSnE -K -X1.5i > $ps

--- a/test/greenspline/gspline_4.sh
+++ b/test/greenspline/gspline_4.sh
@@ -19,14 +19,14 @@ rm -f total_dump
 gmt psbasemap -R$R2D/$Z -JX6i/3i -JZ2.5i -p$view -Bx5f1g1 -By1g1 -Bz2f1 -BWSneZ+b -P -K > $ps
 gmt psxyz -R -JX -JZ -p$view -O -K @Table_5_23.txt -Su0.05i -Gblack -Wfaint >> $ps
 while [ $k -lt 22 ]; do
-	z=`gmt math -Q 5 $k $dz MUL ADD =`
+	z=$(gmt math -Q 5 $k $dz MUL ADD =)
 #	echo "Doing z = $z"
 	$AWK '{if ($3 == '$z') print $1, $2, $4}' 3D.xyzw | gmt xyz2grd -R$R2D -I0.25/0.5 -Gslice_$k.nc
 	gmt grdcontour $Rcut slice_$k.nc -JX -C10 -L9/11 -S8 -Ddump
 	$AWK '{if ($1 == ">") {print $0} else {print $1, $2, '$z'}}' dump > tmp
 	cat tmp >> total_dump
 	gmt psxyz -R$R2D/$Z -JX -JZ -p$view -O -K tmp -Gp39+r300+fgray+b- -Wthin >> $ps
-	k=`expr $k + 1`
+	k=$(expr $k + 1)
 done
 #gmt info -M total_dump
 echo "12 6 Volume exceeding 10% UO@-2@- concentration" | gmt pstext -R$R2D/$Z -JX -JZ -p$view -F+jLT+f16p -O -K -Z10 -Dj0.1i >> $ps

--- a/test/greenspline/gspline_5.sh
+++ b/test/greenspline/gspline_5.sh
@@ -7,7 +7,7 @@ ps=gspline_5.ps
 # Generalized Green's Function for a Spherical Surface Spline in Tension,
 # Geophys. J. Int., 174, 21-28.
 
-data=`gmt which -G @mag_obs_1990.txt`
+data=$(gmt which -G @mag_obs_1990.txt)
 # First find Parker's solution for no tension:
 gmt greenspline -Rg -I1 $data -Sp -GFig_2_p0.nc
 # Then repeat but use the wrong Oslo longitude to recreate Parker's original figure in his book

--- a/test/invalidate_modules.sh
+++ b/test/invalidate_modules.sh
@@ -9,7 +9,7 @@
 # executable from the build dir.
 #
 
-gmt_modules=`gmt --show-classic`
+gmt_modules=$(gmt --show-classic)
 
 for module in ${gmt_modules}; do
   eval "function ${module} () { false; }"

--- a/test/mapproject/azimuth.sh
+++ b/test/mapproject/azimuth.sh
@@ -9,9 +9,9 @@ gmt begin azimuth ps
   lon=156.293957716
   lat=-8.06651671195
   # Get az from point to pole
-  az=`echo $lon $lat | gmt mapproject -Ab${plon}/${plat} -o2 -fg`
+  az=$(echo $lon $lat | gmt mapproject -Ab${plon}/${plat} -o2 -fg)
   # Add 90 to aziumth:
-  az2=`gmt math -Q $az 90 SUB 360 FMOD =`
+  az2=$(gmt math -Q $az 90 SUB 360 FMOD =)
   gmt basemap -R140/210/-65/15 -JM6i -Bafg2 -BWEsn+o${plon}/${plat}+t"Parallel az = $az2"
   echo ${plon} ${plat} | gmt plot -Sc0.1i -Gred
   echo ${lon} ${lat}   | gmt plot -Sc0.1i -Ggreen

--- a/test/mapproject/oblmerc_down.sh
+++ b/test/mapproject/oblmerc_down.sh
@@ -8,9 +8,9 @@ ps=oblmerc_down.ps
 lon=-30
 lat=60
 az_x=-75
-az_y=`gmt math -Q $az_x 90 SUB =`
-plon=`gmt vector -A$lon/$lat -Tp$az_x} | cut -f1`
-plat=`gmt vector -A$lon/$lat -Tp$az_x} | cut -f2`
+az_y=$(gmt math -Q $az_x 90 SUB =)
+plon=$(gmt vector -A$lon/$lat -Tp$az_x} | cut -f1)
+plat=$(gmt vector -A$lon/$lat -Tp$az_x} | cut -f2)
 scale=1:30000000
 scale_km=1:30000
 LL_lon=-56
@@ -19,16 +19,16 @@ UR_lon=20
 UR_lat=50
 # Find gmt projected coordinates of LL and UR points in desired gmt projection
 echo $LL_lon $LL_lat | gmt mapproject -C -R$LL_lon/$LL_lat/$UR_lon/${UR_lat}r -Joa${lon}/${lat}/${az_x}/$scale -Fk >tmp
-LL_x=`cut -f1 tmp`
-LL_y=`cut -f2 tmp`
+LL_x=$(cut -f1 tmp)
+LL_y=$(cut -f2 tmp)
 echo $UR_lon $UR_lat | gmt mapproject -C -R$LL_lon/$LL_lat/$UR_lon/${UR_lat}r -Joa${lon}/${lat}/${az_x}/$scale -Fk >tmp
-UR_x=`cut -f1 tmp`
-UR_y=`cut -f2 tmp`
+UR_x=$(cut -f1 tmp)
+UR_y=$(cut -f2 tmp)
 # Create rectangle in these gmt projected units
-xstart=`gmt math -Q $LL_x $UR_x MIN =`
-xstop=`gmt math -Q $LL_x $UR_x MAX =`
-ystart=`gmt math -Q $LL_y $UR_y MIN =`
-ystop=`gmt math -Q $LL_y $UR_y MAX =`
+xstart=$(gmt math -Q $LL_x $UR_x MIN =)
+xstop=$(gmt math -Q $LL_x $UR_x MAX =)
+ystart=$(gmt math -Q $LL_y $UR_y MIN =)
+ystop=$(gmt math -Q $LL_y $UR_y MAX =)
 gmt math -T$xstart/$xstop/101+n $LL_y = > box.xy
 gmt math -o1,0 -T$ystart/$ystop/101+n $UR_x = >> box.xy
 gmt math -I -T$xstart/$xstop/101+n $UR_y = >> box.xy

--- a/test/mapproject/oblmerc_up.sh
+++ b/test/mapproject/oblmerc_up.sh
@@ -7,9 +7,9 @@ ps=oblmerc_up.ps
 lon=-30
 lat=60
 az_x=105
-az_y=`gmt math -Q $az_x 90 SUB =`
-plon=`gmt vector -A$lon/$lat -Tp$az_x} | cut -f1`
-plat=`gmt vector -A$lon/$lat -Tp$az_x} | cut -f2`
+az_y=$(gmt math -Q $az_x 90 SUB =)
+plon=$(gmt vector -A$lon/$lat -Tp$az_x} | cut -f1)
+plat=$(gmt vector -A$lon/$lat -Tp$az_x} | cut -f2)
 scale=1:30000000
 scale_km=1:30000
 LL_lon=-56
@@ -18,16 +18,16 @@ UR_lon=20
 UR_lat=50
 # Find gmt projected coordinates of LL and UR points in desired gmt projection
 echo $LL_lon $LL_lat | gmt mapproject -C -R$LL_lon/$LL_lat/$UR_lon/${UR_lat}r -Joa${lon}/${lat}/${az_x}/$scale -Fk > tmp
-LL_x=`cut -f1 tmp`
-LL_y=`cut -f2 tmp`
+LL_x=$(cut -f1 tmp)
+LL_y=$(cut -f2 tmp)
 echo $UR_lon $UR_lat | gmt mapproject -C -R$LL_lon/$LL_lat/$UR_lon/${UR_lat}r -Joa${lon}/${lat}/${az_x}/$scale -Fk > tmp
-UR_x=`cut -f1 tmp`
-UR_y=`cut -f2 tmp`
+UR_x=$(cut -f1 tmp)
+UR_y=$(cut -f2 tmp)
 # Create rectangle in these gmt projected units
-xstart=`gmt math -Q $LL_x $UR_x MIN =`
-xstop=`gmt math -Q $LL_x $UR_x MAX =`
-ystart=`gmt math -Q $LL_y $UR_y MIN =`
-ystop=`gmt math -Q $LL_y $UR_y MAX =`
+xstart=$(gmt math -Q $LL_x $UR_x MIN =)
+xstop=$(gmt math -Q $LL_x $UR_x MAX =)
+ystart=$(gmt math -Q $LL_y $UR_y MIN =)
+ystop=$(gmt math -Q $LL_y $UR_y MAX =)
 gmt math -T$xstart/$xstop/101+n $LL_y = > box.xy
 gmt math -o1,0 -T$ystart/$ystop/101+n $UR_x = >> box.xy
 gmt math -I -T$xstart/$xstop/101+n $UR_y = >> box.xy

--- a/test/mapproject/proj4.sh
+++ b/test/mapproject/proj4.sh
@@ -29,7 +29,7 @@ gmt mapproject pt.txt -J+proj=laea+ellps=WGS84+units=m | gmt math -o1 STDIN -C0 
 # The test is failing, because GDAL1 gives 828919.243654 12511653.4997, while GDAL2 & GDAL3 gives 414459.6218269 6255826.7498713
 #gmt mapproject pt.txt -J+proj=stere+ellps=WGS84+units=m+lat_ts=30n | gmt math -o1 STDIN -C0 414459.6218269 SUB -C1 6255826.7498713 SUB 0 COL HYPOT 0.01 GT = >> results.txt
 gmt mapproject pt.txt -J+proj=sterea+lat_0=52.15616055555555+lon_0=5.38763888888889+k=0.9999079+x_0=155000+y_0=463000+ellps=bessel+units=m | gmt math -o1 STDIN -C0 121590.388077 SUB -C1 487013.903377 SUB 0 COL HYPOT 0.01 GT = >> results.txt
-errors=`gmt math -T -Sl results.txt SUM =`
+errors=$(gmt math -T -Sl results.txt SUM =)
 if [ $errors -ne 0 ]; then
 	cp -f results.txt fail
 fi

--- a/test/mapproject/snyder.sh
+++ b/test/mapproject/snyder.sh
@@ -9,8 +9,8 @@
 #	Slop is 0.11 m for gmt projected values
 
 blabber () {
-	gf=(`echo "${sf[*]}" | gmt mapproject $* -F -C`)
-	gi=(`echo "${gf[*]}" | gmt mapproject $* -F -C -I --FORMAT_FLOAT_OUT=%lg`)
+	gf=($(echo "${sf[*]}" | gmt mapproject $* -F -C))
+	gi=($(echo "${gf[*]}" | gmt mapproject $* -F -C -I --FORMAT_FLOAT_OUT=%lg))
 	echo "${sf[*]} ${gi[*]} ${si[*]} ${gf[*]} $p" | $AWK -f test.awk
 }
 

--- a/test/mapproject/waypoints.sh
+++ b/test/mapproject/waypoints.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Test mapproject's distance and time calculations
 ps=waypoints.ps
-data=`gmt which -G @waypoints.txt`
+data=$(gmt which -G @waypoints.txt)
 gmt mapproject -G+un+i+a -Af -Z20+i+a+t2017-01-01T --TIME_UNIT=h $data -: -o2:4,7 --FORMAT_FLOAT_OUT=%.1f > tmp
 gmt psxy -R181/185/-7:30/-2 -JM6.5i -P -Baf -BWSne -W0.25p $data -: -K > $ps
 gmt psxy -R -J -O -K -Sc0.2c -Gblue $data -: >> $ps

--- a/test/mgd77/cm4.sh
+++ b/test/mgd77/cm4.sh
@@ -5,43 +5,43 @@
 ps=cm4.ps
 
 gmt set FORMAT_DATE_MAP "o dd" FORMAT_CLOCK_MAP hh:mm FONT_ANNOT_PRIMARY +9p
-dia=`gmt which -G @clf20010501d.min`
+dia=$(gmt which -G @clf20010501d.min)
 
 # Get Station location
-lon=`tail -n +6 $dia | head -1 | $AWK '{print $3}'`
-lat=`tail -n +5 $dia | head -1 | $AWK '{print $3}'`
-alt=`tail -n +7 $dia | head -1 | $AWK '{print $2/1000}'`
-data=`tail -n +27 $dia | head -1 | $AWK '{print $1}'`
+lon=$(tail -n +6 $dia | head -1 | $AWK '{print $3}')
+lat=$(tail -n +5 $dia | head -1 | $AWK '{print $3}')
+alt=$(tail -n +7 $dia | head -1 | $AWK '{print $2/1000}')
+data=$(tail -n +27 $dia | head -1 | $AWK '{print $1}')
 
-IGRF=`echo $lon $lat $alt $data | gmt mgd77magref -Fxyz/0`
+IGRF=$(echo $lon $lat $alt $data | gmt mgd77magref -Fxyz/0)
 
 tail -n +27 $dia | $AWK '{print $1"T"$2, sqrt($4*$4+$5*$5+$6*$6)}' > zz1.dat
 $AWK -v x=$lon -v y=$lat -v z=$alt '{print x, y, z, $1}' zz1.dat | gmt mgd77magref -Frt/923456 | awk '{print $4, $5}' > zz2.dat
 # Compute data & model min/max
-m1=(`gmt info zz1.dat -C -f0T`)
-m2=(`gmt info zz2.dat -C -f0T`)
+m1=($(gmt info zz1.dat -C -f0T))
+m2=($(gmt info zz2.dat -C -f0T))
 
 # Compute limits such that both Y axes have the same scale
-max_Y=`echo ${m1[2]} ${m1[3]} ${m2[2]} ${m2[3]} | $AWK '{if (($2-$1) > ($4-$3)) print($2-$1); else print($4-$3)}'`
-y1_max=`echo ${m1[2]} $max_Y | $AWK '{print $1 + $2}'`
-y2_max=`echo ${m2[2]} $max_Y | $AWK '{print $1 + $2}'`
+max_Y=$(echo ${m1[2]} ${m1[3]} ${m2[2]} ${m2[3]} | $AWK '{if (($2-$1) > ($4-$3)) print($2-$1); else print($4-$3)}')
+y1_max=$(echo ${m1[2]} $max_Y | $AWK '{print $1 + $2}')
+y2_max=$(echo ${m2[2]} $max_Y | $AWK '{print $1 + $2}')
 gmt psxy zz1.dat -R${m1[0]}/${m1[1]}/${m1[2]}/$y1_max -JX16c/6c -Bpxa6Hf1h -By10 -BWSn -W1p -Y5.0c -P -K > $ps
 gmt psxy zz2.dat -R${m2[0]}/${m2[1]}/${m2[2]}/$y2_max -J -Bpxa6Hf1h -By10 -BE -W1p,red --MAP_DEFAULT_PEN=+1p,red -O -K >> $ps
 
 gmt math zz1.dat zz2.dat SUB -o1 -f0T = dif_T.dat
-std=`gmt math dif_T.dat STD -S = | $AWK '{printf "%.2f\n", $1}'`
-mean=`gmt math dif_T.dat MEAN -S = | $AWK '{printf "%.2f\n", $1}'`
+std=$(gmt math dif_T.dat STD -S = | $AWK '{printf "%.2f\n", $1}')
+mean=$(gmt math dif_T.dat MEAN -S = | $AWK '{printf "%.2f\n", $1}')
 
 # Write Date, MEAN & STD
-t=(`echo ${m2[2]} | $AWK '{print $1 + 4, $1 + 7, $1+12}'`)
+t=($(echo ${m2[2]} | $AWK '{print $1 + 4, $1 + 7, $1+12}'))
 echo ${m1[0]} ${t[1]} Mean = $mean | gmt pstext -F+f11p,Bookman-Demi+jLB -R -J -N -X0.5c -O -K >> $ps
 echo ${m1[0]} ${t[0]} STD = $std | gmt pstext -F+f11p,Bookman-Demi+jLB -R -J -N -O -K >> $ps
 echo ${m1[0]} ${t[2]} $data | gmt pstext -F+f12p,Bookman-Demi+jLB -R -J -N -O -K >> $ps
-station=`tail -n +4 $dia | head -1 | $AWK '{print $3}'`
+station=$(tail -n +4 $dia | head -1 | $AWK '{print $3}')
 echo ${m1[0]} ${t[0]} Station -- $station | gmt pstext -F+f14p,Bookman-Demi+jLB -R -J -N -Xa7.5c -Ya4.7c -O -K >> $ps
 
 # Compute and write the IGRF for this day
-IGRF=`echo $lon $lat $alt $data | gmt mgd77magref -Ft/0 | $AWK '{printf "%.2f\n", $1}'`
+IGRF=$(echo $lon $lat $alt $data | gmt mgd77magref -Ft/0 | $AWK '{printf "%.2f\n", $1}')
 echo ${m1[0]} ${t[0]} IGRF = $IGRF | gmt pstext -F+f15p,Bookman-Demi+jCT -R -J -N -Xa7.5c -Ya3.0c -O -K >> $ps
 
 # Plot histogram of differences with mean removed

--- a/test/postscriptlight/psldemo.sh
+++ b/test/postscriptlight/psldemo.sh
@@ -6,5 +6,5 @@
 # Unix progs:   -
 #
 ps=psldemo.ps
-export PSL_SHAREDIR=`gmt --show-sharedir`
+export PSL_SHAREDIR=$(gmt --show-sharedir)
 psldemo > $ps

--- a/test/potential/cyltest.sh
+++ b/test/potential/cyltest.sh
@@ -7,8 +7,8 @@ ps=cyltest.ps
 #cylinder 25 10 10 1333 5084
 # Make a 1st order correction for the fact that the cubes extend 12.5 meter outside given limits.
 # This works out to a factor of 0.992386602589:
-data=`gmt which -G @cylinder25.txt`
-corr=`gmt math -Q 25000 2 POW 5084 1333 SUB MUL 25000 25 2 DIV ADD 2 POW 5084 1333 SUB 25 ADD MUL DIV =`
+data=$(gmt which -G @cylinder25.txt)
+corr=$(gmt math -Q 25000 2 POW 5084 1333 SUB MUL 25000 25 2 DIV ADD 2 POW 5084 1333 SUB 25 ADD MUL DIV =)
 gmt math -T-100/100/1 0 = trk
 gmt talwani3d @cylinder_mod.txt -D1670 -Mh -Ntrk -o0,3 > faa.txt
 gmt talwani3d @cylinder_mod.txt -D1670 -Mh -Ntrk -o0,3 -Fv > vgg.txt

--- a/test/potential/fields.sh
+++ b/test/potential/fields.sh
@@ -10,11 +10,11 @@ function Ugly {
 	z=$1
 	b=$2
 	c=$3
-	beta2=`gmt math -Q 1.0 $b $b MUL ADD =`
-	beta=`gmt math -Q $beta2 SQRT =`
-	beta3=`gmt math -Q $beta2 $beta MUL =`
-	P1=`gmt math -Q $z $z MUL 2 $b MUL $c MUL $z MUL $c $c MUL ADD $beta2 DIV ADD SQRT $beta DIV =`
-	P2=`gmt math -Q $z $b $c MUL $beta2 ADD DIV $z $z MUL 2 $b MUL $c MUL $z MUL $c $c MUL ADD $beta2 DIV ADD SQRT ADD LOG =`
+	beta2=$(gmt math -Q 1.0 $b $b MUL ADD =)
+	beta=$(gmt math -Q $beta2 SQRT =)
+	beta3=$(gmt math -Q $beta2 $beta MUL =)
+	P1=$(gmt math -Q $z $z MUL 2 $b MUL $c MUL $z MUL $c $c MUL ADD $beta2 DIV ADD SQRT $beta DIV =)
+	P2=$(gmt math -Q $z $b $c MUL $beta2 ADD DIV $z $z MUL 2 $b MUL $c MUL $z MUL $c $c MUL ADD $beta2 DIV ADD SQRT ADD LOG =)
 	gmt math -Q $z $P1 SUB $b $c MUL $P2 MUL $beta3 DIV ADD =
 #	v = z - sqrt (z * z + (2.0 * b * c * z  + c * c) / beta2) / beta + ...
 #		b * c * log (z + b * c / beta2 + sqrt (z * z + (2.0 * b * c * z  + c * c) / beta2)) / beta3;
@@ -48,15 +48,15 @@ echo "-100 100 VGG" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -C+tO >
 gmt gravfft smt.nc+uk -D1670 -Nf+a -Ff -E$order -Gfaa.nc
 # Compute the exact analytical result for peak amplitude at center
 r0=10000
-z0=`gmt math -Q 5084 3751 SUB =`
+z0=$(gmt math -Q 5084 3751 SUB =)
 r1=35000
 z1=5084
-rho=`gmt math -Q 2800 1030 SUB =`
-b=`gmt math -Q $r1 $r0 SUB $z1 $z0 SUB DIV =`
-c=`gmt math -Q $r0 $b $z0 MUL SUB =`
-I1=`Ugly $z1 $b $c`
-I2=`Ugly $z0 $b $c`
-gmax=`gmt math -Q 2 PI MUL 6.673e-6 MUL $rho MUL $I1 $I2 SUB MUL =`
+rho=$(gmt math -Q 2800 1030 SUB =)
+b=$(gmt math -Q $r1 $r0 SUB $z1 $z0 SUB DIV =)
+c=$(gmt math -Q $r0 $b $z0 MUL SUB =)
+I1=$(Ugly $z1 $b $c)
+I2=$(Ugly $z0 $b $c)
+gmax=$(gmt math -Q 2 PI MUL 6.673e-6 MUL $rho MUL $I1 $I2 SUB MUL =)
 echo "Max FAA should be $gmax mGal"
 # ML plot the FAA anomaly
 gmt makecpt -Crainbow -T-50/250 > t.cpt

--- a/test/potential/firmoviscous.sh
+++ b/test/potential/firmoviscous.sh
@@ -32,7 +32,7 @@ let col=2
 while read t color; do
 	let c=2*col
 	gmt psxy -R -J a.txt -i0,${col} -W0.5p,$color -O -K >> $ps
-	y=`gmt info a.txt -C -o${c}`
+	y=$(gmt info a.txt -C -o${c})
 	echo 0 $y $t | gmt pstext -R -J -O -K -F+f10p,+jCM -Gwhite >> $ps
 	let col=col+1
 done < times.txt
@@ -43,10 +43,10 @@ gmt grdtrack -Gsmt.nc t.txt | gmt psxy -R -J -i0,2 -O -K -L+yb -Gbrown >> $ps
 echo -200 -6000 LOAD | gmt pstext -R -J -O -K -F+f18p+jLB -Dj0.1i >> $ps
 # Calc and plot gravity
 gmt psbasemap -R-200/200/-40/200 -J -O -K -BWsne+t"T@-e@- = 10 km   @~\150@~ = 2\26410@+20@+ Pa\264s" -Bafg1000 -Y3i >> $ps
-drho=`gmt math -Q ${rhol} ${rhow} SUB =`
+drho=$(gmt math -Q ${rhol} ${rhow} SUB =)
 gmt gravfft smt.nc+uk -Gsmt_grav.nc -Nf+a -Ff -E4 -D${drho} -W6k
 paste flist times.txt > flist.txt
-drho=`gmt math -Q ${rhom} ${rhos} SUB =`
+drho=$(gmt math -Q ${rhom} ${rhos} SUB =)
 while read file t t2 color; do
 	gmt gravfft ${file}+uk -Gflx_grav.nc -Nf+a -Ff -E2 -D${drho} -W13k
 	gmt grdtrack t.txt -Gflx_grav.nc > b.txt

--- a/test/potential/flex2d.sh
+++ b/test/potential/flex2d.sh
@@ -3,7 +3,7 @@
 flex () {	# $1 is width, $2 is Te, $3 is dy build a 4.05 km tall ridge and compute flexure
 	gmt math -T-800/800/1 T ABS $1 LT 4.05 MUL = topo.txt
 	gmt flexure -Qttopo.txt -D3300/2700/2300/1030 -E${2}k -Mx > flex.txt
-	R=`gmt info -I100/1 flex.txt topo.txt`
+	R=$(gmt info -I100/1 flex.txt topo.txt)
 	gmt psxy $R -JX3i/1.4i -O -K -W1p flex.txt -Y1.65i -Bafg1000 $3
 	gmt psxy -R -J -O -K -Ggray topo.txt
 	gmt pstext -R -J -O -K -F+cTR+f9p+jTR+t"Te = $2, W = $1" -Dj0.03i

--- a/test/potential/flexapprox.sh
+++ b/test/potential/flexapprox.sh
@@ -18,17 +18,17 @@ echo 0 0 $r $h | gmt grdseamount -R-511000/511000/-511000/511000 -I2000 -Cd -Glo
 # we compute the ratio of the exact and approximate volumes and adjust the flexure for this difference.
 # Do this by counting number of nonzero entries, multiply by prism volumes dx*dx*h
 gmt grdmath load.nc 0 NAN = tmp.nc
-n_nan=`gmt grdinfo -M tmp.nc -C | cut -f16`
-disc_vol_grid=`gmt math -Q 512 512 MUL $n_nan SUB 2000 2000 MUL MUL $h MUL =`
-disc_vol_exact=`gmt math -Q $r $r MUL PI MUL $h MUL =`
-scale=`gmt math -Q $disc_vol_exact $disc_vol_grid DIV =`
+n_nan=$(gmt grdinfo -M tmp.nc -C | cut -f16)
+disc_vol_grid=$(gmt math -Q 512 512 MUL $n_nan SUB 2000 2000 MUL MUL $h MUL =)
+disc_vol_exact=$(gmt math -Q $r $r MUL PI MUL $h MUL =)
+scale=$(gmt math -Q $disc_vol_exact $disc_vol_grid DIV =)
 # Traditional rhoi = rhol
 gmt gravfft load.nc -Gflex_a.nc -Q -Nf+l -T$Te/$rhol/$rhom/$rhow
-z0=`echo -511000 -511000 | gmt grdtrack -Gflex_a.nc -o2`
+z0=$(echo -511000 -511000 | gmt grdtrack -Gflex_a.nc -o2)
 gmt grdmath flex_a.nc $z0 SUB = flex_a.nc
 # Approximate rhoi < rhol
 gmt gravfft load.nc -Gflex_c.nc -Q -Nf+l -T$Te/$rhol/$rhom/$rhow/$rhoi
-z0=`echo -511000 -511000 | gmt grdtrack -Gflex_c.nc -o2`
+z0=$(echo -511000 -511000 | gmt grdtrack -Gflex_c.nc -o2)
 gmt grdmath flex_c.nc $z0 SUB = flex_c.nc
 gmt grdtrack -Gflex_a.nc+Uk -Gflex_c.nc+Uk -ELM/RM > result.txt
 # Plot the exact single-domain case

--- a/test/potential/growth.sh
+++ b/test/potential/growth.sh
@@ -21,7 +21,7 @@ gmt makecpt -Cjet -T1/10/0.25 -N -I > t2.cpt
 gmt psbasemap -R0/200/0/5100 -JX6i/3i -O -K -Y6i -Bafg >> $ps
 let k=1
 while read file; do
-	rgb=`sed -n ${k}p t.cpt | awk '{print $2}'`
+	rgb=$(sed -n ${k}p t.cpt | awk '{print $2}')
 	if [ $k -eq 18 ]; then
 		rgb=black
 	fi

--- a/test/potential/sphtest.sh
+++ b/test/potential/sphtest.sh
@@ -12,9 +12,9 @@ gmt talwani3d @sphere_mod.txt -D1670 -Mh -Ntrk -o0,3 > faa.txt
 gmt talwani3d @sphere_mod.txt -D1670 -Mh -Ntrk -o0,3 -Fv > vgg.txt
 gmt talwani3d @sphere_mod.txt -D1670 -Mh -Ntrk -o0,3 -Fn > n.txt
 gmt psbasemap -R-25/25/-5/120 -JX6i/6i -P -K -Xc -Y4i -Bxafg1000 -Byafg1000+l"mGal or Eotvos" -BWsn+t"Testing FAA, VGG and Geoid over sphere" > $ps
-cg=`gmt math -Q 1.0e5 4.0 MUL PI MUL 6.673e-11 MUL $R 3 POW MUL $z0 MUL 1670.0 MUL 3.0 DIV =`
-cv=`gmt math -Q 1.0e9 4.0 MUL PI MUL 6.673e-11 MUL $R 3 POW MUL 1670.0 MUL 3.0 DIV =`
-cn=`gmt math -Q 4.0 3.0 DIV PI MUL $R 3 POW MUL 1670.0 MUL 6.673e-11 MUL =`
+cg=$(gmt math -Q 1.0e5 4.0 MUL PI MUL 6.673e-11 MUL $R 3 POW MUL $z0 MUL 1670.0 MUL 3.0 DIV =)
+cv=$(gmt math -Q 1.0e9 4.0 MUL PI MUL 6.673e-11 MUL $R 3 POW MUL 1670.0 MUL 3.0 DIV =)
+cn=$(gmt math -Q 4.0 3.0 DIV PI MUL $R 3 POW MUL 1670.0 MUL 6.673e-11 MUL =)
 gmt math -T-25/25/0.1 $cg $z0 T 1000 MUL HYPOT 3 POW DIV = s_g.txt
 gmt math -T-25/25/0.1 $cv $z0 T 1000 MUL R2 $z0 2 POW 3 MUL SUB $z0 T 1000 MUL HYPOT 5 POW DIV MUL NEG = s_v.txt
 gmt math -T-25/25/0.1 $cn $z0 T 1000 MUL HYPOT DIV 9.81 DIV = s_n.txt
@@ -34,8 +34,8 @@ S 0.2i c 0.1i brown - 0.5i N (Talwani3D)
 EOF
 gmt pslegend -R -J -O -K -DjTL+w2.2i+jTL+o0.1i/0.1i legend.txt -F+gwhite+p >> $ps
 # Plot sphere
-mx=`gmt math -Q $R 2 MUL 1000 DIV 50 DIV 6 MUL =`
-mz=`gmt math -Q $R 2 MUL 6000 DIV 2.5 MUL =`
+mx=$(gmt math -Q $R 2 MUL 1000 DIV 50 DIV 6 MUL =)
+mz=$(gmt math -Q $R 2 MUL 6000 DIV 2.5 MUL =)
 gmt psxy -R-25/25/0/6000 -JX6i/-2.5i -O -K -Y-2.75i -Se -Gblack -Bxafg1000+u" km" -Byafg4000 -BWSne << EOF >> $ps
 0 4000 0 ${mx}i ${mz}i
 EOF


### PR DESCRIPTION
Replace the legacy syntax of backticks (``) with the preferred $() for command substitution.