### PR TITLE
Run cppcheck in CI jobs

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -18,6 +18,22 @@ variables:
 
 jobs:
 
+# Lint Checker
+- job:
+  displayName: 'Lint Checker'
+
+  pool:
+    vmImage: 'ubuntu-18.04'
+
+  steps:
+  - bash: |
+      set -x -e
+      sudo apt-get install -y cppcheck
+    displayName: Install cppcheck
+
+  - bash: bash ci/run-cppcheck.sh
+    displayName: Run cppcheck
+
 # Linux - Compile only
 ########################################################################################
 - job:

--- a/ci/run-cppcheck.sh
+++ b/ci/run-cppcheck.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Check C source codes
+#
+# For scheduled CI jobs, check all C source codes;
+# For PRs, check changed files only.
+#
+
+CPPCHECK="cppcheck --error-exitcode=1 --force"
+
+if [ "$BUILD_REASON" == "Schedule" ]; then
+    # Check all C codes for scheduled jobs
+    find . -name '*.[ch]' -exec ${CPPCHECK} {} +
+else
+    # Check changed files only for PRs
+    target_branch=${SYSTEM_PULLREQUEST_TARGETBRANCH:-master}
+    changed_files=$(git diff --name-only origin/${target_branch}..HEAD | grep -E '.*\.(c|h)$')
+    if [ $? == 0 ]; then
+        ${CPPCHECK} $changed_files
+    else
+        echo "No C files changed! Skip cppcheck."
+    fi
+fi


### PR DESCRIPTION
For scheduled CI jobs, check all C source codes (it may take one hour);
For PRs, check changed files only (very quick for small changes).

Address #2596.