### PR TITLE
Improve cppcheck in CI

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -21,6 +21,7 @@ jobs:
 # Lint Checker
 - job:
   displayName: 'Lint Checker'
+  timeoutInMinutes: 180
 
   pool:
     vmImage: 'ubuntu-18.04'

--- a/ci/run-cppcheck.sh
+++ b/ci/run-cppcheck.sh
@@ -6,7 +6,7 @@
 # For PRs, check changed files only.
 #
 
-CPPCHECK="cppcheck --error-exitcode=1 --force"
+CPPCHECK="cppcheck --error-exitcode=1 --std=c99 --force --quiet"
 
 if [ "$BUILD_REASON" == "Schedule" ]; then
     # Check all C codes for scheduled jobs


### PR DESCRIPTION
- Increase timeout to 3 hours
- Don't show progress report
- Set to standard c99