### PR TITLE
Set implicit time unit when parsing -T

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15934,15 +15934,13 @@ unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument,
 		gmt_set_column (GMT, GMT_IN, tcol, GMT_IS_ABSTIME);	/* Set input column type as time */
 		/* Set output column type as time unless -fo has been set */
 		if (!GMT->common.f.active[GMT_OUT]) gmt_set_column (GMT, GMT_OUT, tcol, GMT_IS_ABSTIME);
-		if (has_inc) {
-			if (strchr (GMT_TIME_UNITS, T->unit)) {	/* Must set TIME_UNIT and update time system scalings */
-				T->vartime = (strchr (GMT_TIME_VAR_UNITS, T->unit) != NULL);
+		if (has_inc) {	/* Gave a time increment */
+			if (strchr (GMT_TIME_UNITS, T->unit))	/* Gave a valid time unit */
 				txt[ns][len] = '\0';	/* Chop off time unit since we are done with it */
-			}
-			else {	/* Means the user relies on the setting of TIME_UNIT, but we must check if it is set to a variable increment */
-				T->vartime = (strchr (GMT_TIME_VAR_UNITS, GMT->current.setting.time_system.unit) != NULL);
+			else	/* User relied on the setting of TIME_UNIT */
 				T->unit = GMT->current.setting.time_system.unit;	/* Set assumed time unit */
-			}
+			/* Check if unit is a variable increment */
+			T->vartime = (strchr (GMT_TIME_VAR_UNITS, T->unit) != NULL);
 		}
 	}
 	/* 4. Consider spatial distances */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15939,8 +15939,10 @@ unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument,
 				T->vartime = (strchr (GMT_TIME_VAR_UNITS, T->unit) != NULL);
 				txt[ns][len] = '\0';	/* Chop off time unit since we are done with it */
 			}
-			else	/* Means the user relies on the setting of TIME_UNIT, but we must check if it is set to a variable increment */
+			else {	/* Means the user relies on the setting of TIME_UNIT, but we must check if it is set to a variable increment */
 				T->vartime = (strchr (GMT_TIME_VAR_UNITS, GMT->current.setting.time_system.unit) != NULL);
+				T->unit = GMT->current.setting.time_system.unit;	/* Set assumed time unit */
+			}
 		}
 	}
 	/* 4. Consider spatial distances */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16027,6 +16027,7 @@ unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument,
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option %c: Unable to parse min temporal value from %s (ISO datetime format required)\n", option, txt[GMT_X]);
 				return GMT_PARSE_ERROR;
 			}
+			T->unit = GMT->current.setting.time_system.unit;	/* Set currently selected time unit so we don't run into issues later despite only having one time knot */
 		}
 		else if (gmt_verify_expectations (GMT, gmt_M_type (GMT, GMT_IN, GMT_X), gmt_scanf_arg (GMT, txt[GMT_X], gmt_M_type (GMT, GMT_IN, GMT_X), false, &(T->min)), txt[GMT_X])) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option %c: Unable to parse min value from %s\n", option, txt[GMT_X]);


### PR DESCRIPTION
See warning report number 4 under #2346. We rely on **TIME_UNIT** when no unit found but if so we must duplicate that unit back to the structure. The example runs correctly but the warning flagged that we did not copy over the implied time unit.
Review also showed that users could simply append the unit in the -T option:

`gmt math -T2011-02-01T/2011-02-28T/1d TROW 200 ADD = /tmp/shit`

instead of the more awkward

`gmt math -T2011-02-01T/2011-02-28T/1 --TIME_UNIT=d TROW 200 ADD = /tmp/shit`