### PR TITLE
Extract tick length as size of fronts in legends

### DIFF
--- a/doc/rst/source/legend_common.rst_
+++ b/doc/rst/source/legend_common.rst_
@@ -252,7 +252,9 @@ Defaults
 When attributes are not provided, or extended symbol information (for symbols taking more than just an overall size) are
 not given as comma-separated quantities, we will provide the following defaults:
 
-Front: Front symbol is left-side (here, that means upper side) box, with dimensions 30% of the given symbol size.
+Front: The *size* argument is *length*\ [/*gap*\ [*ticklength*]]. Front symbol is left-side (here, that means upper side) box,
+with *ticklength* set 30% of the given symbol *length (if not specified separately), and *gap* defaulting to -1 (one
+entered front symbol) if not specified.  Modifiers to the symbol argument can be provided.
 
 Vector: Head size is 30% of given symbol size.
 

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -716,7 +716,10 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 						text[0] = '\0';
 						n_scan = sscanf (line, "%*s %*s %*s %s %*s %*s %s %[^\n]", size, txt_b, text);
 						/* Find the largest symbol size specified */
-						x = (strcmp (size, "-")) ? gmt_M_to_inch (GMT, size) : 0.0;
+						if ((c = strrchr (size, '/')))	/* Front, use the last arg as size since closest to height */
+							x = gmt_M_to_inch (GMT, &c[1]);
+						else
+							x = (strcmp (size, "-")) ? gmt_M_to_inch (GMT, size) : 0.0;
 						if (x > def_size) def_size = x;
 						if (n_scan > 1 && strcmp (txt_b, "-")) {
 							x = gmt_M_to_inch (GMT, txt_b);


### PR DESCRIPTION
The initial screening of symbols in legend tries to determine the largest symbol size so it can use that as a default later.  However, the front symbol gets _size/gap/tlength_ so to parse that we need to isolate _tlength_ since it is closest to the notion of symbol size (_size_ here is actually front length).  This is all done to avoid messages like
`pslegend [WARNING]: 2i/0.6i/0.25 not a valid number and may not be decoded properly.`
when running.
