### PR TITLE
Fix bad modifiers in -JP and update documentation

### DIFF
--- a/doc/rst/source/basemap.rst
+++ b/doc/rst/source/basemap.rst
@@ -49,13 +49,13 @@ Linear x-y plot
 ~~~~~~~~~~~~~~~
 
 To make a linear x/y frame with all axes, but with only left and bottom
-axes annotated, using xscale = yscale = 1.0, ticking every 1 unit and
+axes annotated, using xscale = yscale = 1cm per unit, ticking every 1 unit and
 annotating every 2, and using xlabel = "Distance" and ylabel = "No of samples", use
 
    ::
 
     gmt begin linear
-      gmt basemap -R0/9/0/5 -Jx1 -Bf1a2 -Bx+lDistance -By+l"No of samples" -BWeSn
+      gmt basemap -R0/9/0/5 -Jx1c -Bf1a2 -Bx+lDistance -By+l"No of samples" -BWeSn
     gmt end show
 
 As mentioned above, such simple modern mode script can take advantage of the one-liner
@@ -64,7 +64,7 @@ format for the remaining examples:
 
    ::
 
-    gmt basemap -R0/9/0/5 -Jx1 -Bf1a2 -Bx+lDistance -By+l"No of samples" -BWeSn -pdf linear
+    gmt basemap -R0/9/0/5 -Jx1c -Bf1a2 -Bx+lDistance -By+l"No of samples" -BWeSn -pdf linear
 
 Log-log plot
 ~~~~~~~~~~~~
@@ -81,12 +81,12 @@ Power axes
 ~~~~~~~~~~
 
 To design an axis system to be used for a depth-sqrt(age) plot with
-depth positive down, ticked and annotated every 500m, and ages annotated
-at 1 my, 4 my, 9 my etc, use
+depth positive down, ticked and annotated every 500m, and ages (in millions of years) annotated
+at 1 My, 4 My, 9 My etc., use
 
    ::
 
-    gmt basemap -R0/100/0/5000 -Jx1p0.5/-0.001 -Bx1p+l"Crustal age" -By500+lDepth -pdf power
+    gmt basemap -R0/100/0/5000 -Jx1cp0.5/-0.001c -Bx1p+l"Crustal age" -By500+lDepth -pdf power
 
 Polar (theta,r) plot
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/rst/source/blockmean.rst
+++ b/doc/rst/source/blockmean.rst
@@ -67,9 +67,9 @@ Optional Arguments
 ------------------
 
 *table*
-    3 [or 4, see **-W**] column ASCII data table file(s) [or binary, see
-    **-bi**] holding (*x*,\ *y*,\ *z*\ [,\ *w*])
-    data values. [*w*] is an optional weight for the data. If no file
+    3 (or 4, see **-W**) column ASCII data table file(s) (or binary, see
+    **-bi**) holding (*x*,\ *y*,\ *z*\ [,\ *w*])
+    data values, where [*w*] is an optional weight for the data. If no file
     is specified, **blockmean** will read from standard input.
 
 .. _-A:

--- a/doc/rst/source/blockmedian.rst
+++ b/doc/rst/source/blockmedian.rst
@@ -68,10 +68,10 @@ Optional Arguments
 ------------------
 
 *table*
-    3 [or 4, see **-W**] column ASCII data table] column ASCII file(s)
-    [or binary, see **-bi**] holding
-    (*x*,\ *y*,\ *z*\ [,\ *w*]) data values. [*w*] is an optional weight
-    for the data. If no file is specified, **blockmedian** will read
+    3 (or 4, see **-W**) column ASCII data table file(s) (or binary, see
+    **-bi**) holding (*x*,\ *y*,\ *z*\ [,\ *w*])
+    data values, where [*w*] is an optional weight for the data.
+    If no file is specified, **blockmedian** will read
     from standard input.
 
 .. _-A:

--- a/doc/rst/source/blockmode.rst
+++ b/doc/rst/source/blockmode.rst
@@ -68,10 +68,10 @@ Optional Arguments
 ------------------
 
 *table*
-    3 [or 4, see **-W**] column ASCII data table file(s) [or binary, see
-    **-bi**] holding (*x*,\ *y*,\ *z*\ [,\ *w*])
-    data values. [*w*] is an optional weight for the data. If no file
-    is specified, **blockmode** will read from standard input.
+   3 (or 4, see **-W**) column ASCII data table file(s) (or binary, see
+    **-bi**) holding (*x*,\ *y*,\ *z*\ [,\ *w*])
+    data values, where [*w*] is an optional weight for the data.
+    If no file is specified, **blockmode** will read from standard input.
 
 .. _-A:
 

--- a/doc/rst/source/explain_-J_full.rst_
+++ b/doc/rst/source/explain_-J_full.rst_
@@ -158,7 +158,7 @@ projection names stands for Equal-Area and Conformal, respectively):
     **AZIMUTHAL PROJECTIONS:**
 
     Except for polar aspects, **-R**\ w/e/s/n will be reset to **-Rg**.
-    Use **-R**\ <...>\ **r** for smaller regions.
+    Use **-R**\ <...>\ **+r** for smaller regions.
 
 
 .. _-Ja_full:
@@ -273,14 +273,14 @@ projection names stands for Equal-Area and Conformal, respectively):
 
 .. _-Jp_full:
 
-    **-Jp**\ [**a**]\ *scale*\ [*/origin*][**r**\|\ **z**] or **-JP**\ [**a**]\ *width*\ [*/origin*][**r**\|\ **z**]
-    (Polar coordinates (theta,r))
+    **-Jp**\ [**a**]\ *scale*\ [*/origin*][**+r**\|\ **+z**] or **-JP**\ [**a**]\ *width*\ [*/origin*][**r**\|\ **z**]
+    (Polar coordinates (*theta*, *r*))
 
-    Optionally insert **a** after **-Jp** [ or **-JP**] for azimuths CW
+    Optionally insert **a** after **-Jp** [or **-JP**] if *theta* is azimuths CW
     from North instead of directions CCW from East [Default]. Optionally
-    append /*origin* in degrees to indicate an angular offset [0]).
-    Finally, append **r** if r is elevations in degrees (requires s >= 0
-    and n <= 90) or **z** if you want to annotate depth rather than
+    append /*origin* in degrees to indicate an angular offset [0].
+    Finally, append **+r** if *r* represents elevations in degrees (requires *south* >= 0
+    and *north* <= 90), or append **+z** if you want to annotate depth rather than
     radius [Default]. Give *scale* in UNIT/r-unit.
 
 .. _-Jx_full:

--- a/doc/rst/source/explain_-U.rst_
+++ b/doc/rst/source/explain_-U.rst_
@@ -1,2 +1,2 @@
-**-U**\ [*label*][**+c**][**+j**\ *just*][**+o**\ *dx*/*dy*] :ref:`(more ...) <-U_full>`
+**-U**\ [*label*][**+c**][**+j**\ *just*][**+o**\ *dx*\ [*unit*]/*dy*\ [*unit*]] :ref:`(more ...) <-U_full>`
     Draw GMT time stamp logo on plot.

--- a/doc/rst/source/explain_-U_full.rst_
+++ b/doc/rst/source/explain_-U_full.rst_
@@ -1,13 +1,13 @@
 .. _-U_full:
 
-**-U**\ [*label*][**+c**][**+j**\ *just*][**+o**\ *dx*/*dy*]
+**-U**\ [*label*][**+c**][**+j**\ *just*][**+o**\ *dx*\ [*unit*]/*dy*\ [*unit*]]
     Draw the GMT Unix System time stamp on the plot.
-    By appending **+j**\ *just* and/or **+o**\ *dx/dy*, the
+    By appending **+j**\ *just* [BL] and/or **+o**\ *dx/dy* [-54p], the
     user may specify the justification of the stamp and where the stamp
     should fall on the page relative to lower left corner of the plot.
-    For example, +jBL+o0/0 will align the lower left corner of the time
-    stamp with the bottom left corner of the plot [BL]. Optionally, append a
-    *label*, or give **+c** which will plot the command string. The GMT
+    For example, **+jBL+o**\ 0/0 will align the lower left corner of the time
+    stamp with the bottom left corner of the plot. Optionally, append a
+    *label*, or give **+c** which will plot the module command string. The GMT
     parameters :term:`MAP_LOGO`, :term:`MAP_LOGO_POS`,
     :term:`FONT_LOGO` and :term:`FORMAT_TIME_STAMP`
     can affect the appearance; see the :doc:`gmt.conf` man page for details.

--- a/doc/rst/source/explain_-V.rst_
+++ b/doc/rst/source/explain_-V.rst_
@@ -1,2 +1,2 @@
 **-V**\ [*level*] :ref:`(more ...) <-V_full>`
-    Select verbosity level [w]. |Add_-V|
+    Select verbosity level [**w**]. |Add_-V|

--- a/doc/rst/source/explain_-V_full.rst_
+++ b/doc/rst/source/explain_-V_full.rst_
@@ -3,10 +3,10 @@
 **-V**\ [*level*]
     Select verbose mode, which modulates the messages written to *stderr*.
     Choose among 7 levels of verbosity; each level adds more messages:
-    **q** - Quiet, not even fatal error messages are produced.
-    **e** - Error messages only.
-    **w** - Warnings [Default].
-    **t** - Timings (report runtimes for time-intensive algorithms).
-    **i** - Informational messages (same as **-V** only).
-    **c** - Compatibility warnings.
+    **q** - Quiet, not even fatal error messages are produced,
+    **e** - Error messages only,
+    **w** - Warnings [Default],
+    **t** - Timings (report runtimes for time-intensive algorithms),
+    **i** - Informational messages (same as **-V** only),
+    **c** - Compatibility warnings, or
     **d** - Debugging messages.

--- a/doc/rst/source/explain_-XY_full.rst_
+++ b/doc/rst/source/explain_-XY_full.rst_
@@ -11,7 +11,7 @@
     prepend **f** to shift the origin relative to the fixed lower left
     corner of the page, or prepend **r** [Default] to move the origin
     relative to its current location. For overlays the default
-    (*xshift*,\ *yshift*) is (r0), otherwise it is (r1i). When **-X**
+    (*xshift*,\ *yshift*) is (**r**\ 0), otherwise it is (**r**\ 72p). When **-X**
     or **-Y** are used without any further arguments, the values from
     the last use of that option in a previous GMT command will be used.
     Note that **-X** and **-Y** can also access the previous plot dimensions

--- a/doc/rst/source/explain_-q_full.rst_
+++ b/doc/rst/source/explain_-q_full.rst_
@@ -5,7 +5,7 @@
     Give individual rows (or row ranges in the format *start*\ [:*inc*]:*stop*, where
     *inc* defaults to 1 if not specified) separated by commas [Default reads/writes all rows,
     starting with the first row (0)]. By default (**+a**) we count rows in the data set;
-    append **+f** or **+s** to reset the count at the start of each file or segment.
+    append **+f** or **+s** to reset the count at the start of each file or segment, respectively.
     Alternatively, use **+c**\ *col* to indicate that the arguments instead
     are min/max *data limits* for the values in column *col*.
     Note: Because arguments may contain colons or be negative, your must specify *start*/*stop* instead.

--- a/doc/rst/source/explain_-qo_full.rst_
+++ b/doc/rst/source/explain_-qo_full.rst_
@@ -5,7 +5,7 @@
     Give individual rows (or row ranges in the format *start*\ [:*inc*]:*stop*, where
     *inc* defaults to 1 if not specified) separated by commas [Default writes all rows,
     starting with the first row (0)]. By default (**+a**) we count rows in the data set;
-    append **+f** or **+s** to reset the count at the start of each file or segment.
+    append **+f** or **+s** to reset the count at the start of each file or segment, respectively.
     Alternatively, use **+c**\ *col* to indicate that the arguments instead
     are min/max *data limits* for the values in column *col*.
     Note: Because data limits may contain colons or be negative, your must specify *start*/*stop* instead.

--- a/doc/rst/source/explain_colon_full.rst_
+++ b/doc/rst/source/explain_colon_full.rst_
@@ -5,4 +5,4 @@
     swapping]. Append **i** to select input only or **o** to select
     output only. [Default affects both]. This option is typically used
     to handle (latitude, longitude) files; see also
-    **-i**\ *cols*\ [**+l**][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ *t*\ [*word*]].
+    **-i**\ *cols*\ [**+l**][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]].

--- a/doc/rst/source/explain_nodereg_full.rst_
+++ b/doc/rst/source/explain_nodereg_full.rst_
@@ -1,7 +1,7 @@
 .. _nodereg_full:
 
 **-r**\ [**g**\|\ **p**]
-    Force **g**\ridline or **p**\ ixel node registration [Just **-r** sets pixel registration].
+    Force **g**\ridline or **p**\ ixel node registration [gridline]. Just **-r** sets pixel registration.
     If no **-r** is given then gridline registration is selected.
     (Node registrations are defined in Section :ref:`option_nodereg`
     of the GMT Technical Reference and Cookbook.)

--- a/doc/rst/source/gmtswitch.rst
+++ b/doc/rst/source/gmtswitch.rst
@@ -54,7 +54,7 @@ The fastest way to get up and running is this:
 1. Edit/Create ~/.gmtversions and add the paths to all GMT installations
     you have or care to consider. Each path goes on separate lines and
     points to the top dir of each distribution, e.g.,
-    /Users/pwessel/UH/RESEARCH/PROJECTS/GMTdev/GMT4.5.7
+    /Users/pwessel/UH/RESEARCH/PROJECTS/GMTdev/gmt-4.5.18
 
 2. In your .bashrc or .[t]csrh or wherever you are maintaining your PATH
     or path variable, remove any directories you have added that contain
@@ -78,12 +78,12 @@ The fastest way to get up and running is this:
 Examples
 --------
 
-To switch to GMT version 4.5.7 (assuming it was installed as such and not
+To switch to GMT version 4.5.18 (assuming it was installed as such and not
 via a package manager), try
 
   ::
 
-    gmtswitch GMT4.5.7
+    gmtswitch gmt-4.5.18
 
 To switch to the default (your top choice), do
 

--- a/doc/rst/source/psbasemap.rst
+++ b/doc/rst/source/psbasemap.rst
@@ -78,12 +78,12 @@ Linear x-y plot
 ~~~~~~~~~~~~~~~
 
 To make a linear x/y frame with all axes, but with only left and bottom
-axes annotated, using xscale = yscale = 1.0, ticking every 1 unit and
+axes annotated, using xscale = yscale = 1 cm per unit, ticking every 1 unit and
 annotating every 2, and using xlabel = "Distance" and ylabel = "No of samples", use
 
    ::
 
-    gmt psbasemap -R0/9/0/5 -Jx1 -Bf1a2 -Bx+lDistance -By+l"No of samples" -BWeSn -P > linear.ps
+    gmt psbasemap -R0/9/0/5 -Jx1c -Bf1a2 -Bx+lDistance -By+l"No of samples" -BWeSn -P > linear.ps
 
 Log-log plot
 ~~~~~~~~~~~~
@@ -100,12 +100,12 @@ Power axes
 ~~~~~~~~~~
 
 To design an axis system to be used for a depth-sqrt(age) plot with
-depth positive down, ticked and annotated every 500m, and ages annotated
-at 1 my, 4 my, 9 my etc, use
+depth positive down, ticked and annotated every 500m, and ages (in millions of years) annotated
+at 1 My, 4 My, 9 My etc., use
 
    ::
 
-    gmt psbasemap -R0/100/0/5000 -Jx1p0.5/-0.001 -Bx1p+l"Crustal age" -By500+lDepth -P > power.ps
+    gmt psbasemap -R0/100/0/5000 -Jx1cp0.5/-0.001c -Bx1p+l"Crustal age" -By500+lDepth -P > power.ps
 
 Polar (theta,r) plot
 ~~~~~~~~~~~~~~~~~~~~

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -4366,7 +4366,7 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 	bool width_given = false;
 	double c, az, GMT_units[3] = {0.01, 0.0254, 1.0};      /* No of meters in a cm, inch, m */
 	char mod, args_cp[GMT_BUFSIZ] = {""}, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""};
-	char txt_d[GMT_LEN256] = {""}, txt_e[GMT_LEN256] = {""}, last_char = 0, *d = NULL;
+	char txt_d[GMT_LEN256] = {""}, txt_e[GMT_LEN256] = {""}, last_char = 0, *d = NULL, *c = NULL;
 	char txt_arr[11][GMT_LEN256];
 
 	if (args == NULL) {
@@ -4613,14 +4613,14 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 				GMT->current.proj.got_azimuths = false;
 				i = 0;
 			}
-			j = (int)strlen (args) - 1;
-			if (args[j] == 'r') {	/* Gave optional r for reverse (elevations, presumably) */
+			j = (int)strlen (args) - 1;	/* Last character */
+			if ((c = strstr (args, "+r")) || args[j] == 'r') {	/* Gave optional +r for reverse (elevations, presumably) (r is deprecated) */
 				GMT->current.proj.got_elevations = true;
-				args[j] = '\0';	/* Temporarily chop off the r */
+				if (c) c[0] = '\0'; else args[j] = '\0';	/* Temporarily chop off the [+]r */
 			}
-			else if (args[j] == 'z') {	/* Gave optional z for annotating depths rather than radius */
+			else if ((c = strstr (args, "+z")) || aargs[j] == 'z') {	/* Gave optional +z for annotating depths rather than radius (z is deprecated) */
 				GMT->current.proj.z_down = true;
-				args[j] = '\0';	/* Temporarily chop off the z */
+				if (c) c[0] = '\0'; else args[j] = '\0';	/* Temporarily chop off the [+]z */
 			}
 			else
 				GMT->current.proj.got_elevations = GMT->current.proj.z_down = false;
@@ -4636,8 +4636,12 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 			}
 			else
 				error++;
-			if (GMT->current.proj.got_elevations) args[j] = 'r';	/* Put the r back in the argument */
-			if (GMT->current.proj.z_down) args[j] = 'z';	/* Put the z back in the argument */
+			if (GMT->current.proj.got_elevations) {
+				if (c) c[0] = '+'; else args[j] = 'r';	/* Put the r back in the argument */
+			}
+			if (GMT->current.proj.z_down) {
+				if (c) c[0] = '+'; else args[j] = 'z';	/* Put the z back in the argument */
+			}
 			if (GMT->current.proj.got_azimuths) GMT->current.proj.pars[1] = -GMT->current.proj.pars[1];	/* Because azimuths go clockwise */
 			break;
 
@@ -6447,12 +6451,12 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 			gmt_message (GMT, "\t       Specify region in oblique degrees OR use -R<>r\n");
 			gmt_message (GMT, "\t       Upper-case A|B|C removes enforcement of a northern hemisphere pole.\n");
 
-			gmt_message (GMT, "\t   -Jp|P[a]<scale>|<width>[/<base>][r|z] (Polar (theta,radius))\n");
+			gmt_message (GMT, "\t   -Jp|P[a]<scale>|<width>[/<base>][+r|+z] (Polar (theta,radius))\n");
 			gmt_message (GMT, "\t     Linear scaling for polar coordinates.\n");
 			gmt_message (GMT, "\t     Optionally append 'a' to -Jp or -JP to use azimuths (CW from North) instead of directions (CCW from East) [default].\n");
 			gmt_message (GMT, "\t     Give scale in %s/units, and append theta value for angular offset (base) [0]\n",
 			             GMT->session.unit_name[GMT->current.setting.proj_length_unit]);
-			gmt_message (GMT, "\t     Append r to reverse radial direction (s/n must be in 0-90 range) or z to annotate depths rather than radius [Default]\n");
+			gmt_message (GMT, "\t     Append +r to reverse radial direction (s/n must be in 0-90 range) or +z to annotate depths rather than radius [Default]\n");
 
 			gmt_message (GMT, "\t   -Jpoly|Poly/[<lon0>/[<lat0>/]]<scale>|<width> ((American) Polyconic)\n");
 			gmt_message (GMT, "\t     Give central meridian (opt), reference parallel (opt, default = equator), and scale\n");
@@ -6565,7 +6569,7 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 
 			gmt_message (GMT, "\t   -Jy|Y[<lon0>/[<lat0>/]]<scl>|<width> (Cylindrical Equal-area)\n");
 
-			gmt_message (GMT, "\t   -Jp|P[a]<scl>|<width>[/<origin>][r|z] (Polar [azimuth] (theta,radius))\n");
+			gmt_message (GMT, "\t   -Jp|P[a]<scl>|<width>[/<origin>][+r|+z] (Polar [azimuth] (theta,radius))\n");
 
 			gmt_message (GMT, "\t   -Jx|X<x-scl>|<width>[d|l|p<power>|t|T][/<y-scl>|<height>[d|l|p<power>|t|T]] (Linear, log, and power projections)\n");
 			gmt_message (GMT, "\t   (See psbasemap for more details on projection syntax)\n");

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -4366,7 +4366,7 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 	bool width_given = false;
 	double c, az, GMT_units[3] = {0.01, 0.0254, 1.0};      /* No of meters in a cm, inch, m */
 	char mod, args_cp[GMT_BUFSIZ] = {""}, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""};
-	char txt_d[GMT_LEN256] = {""}, txt_e[GMT_LEN256] = {""}, last_char = 0, *d = NULL, *c = NULL;
+	char txt_d[GMT_LEN256] = {""}, txt_e[GMT_LEN256] = {""}, last_char = 0, *d = NULL;
 	char txt_arr[11][GMT_LEN256];
 
 	if (args == NULL) {
@@ -4439,6 +4439,7 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 
 	GMT->current.proj.unit = GMT_units[GMT_INCH];	/* No of meters in an inch */
 	n = 0;	/* Initialize with no fields found */
+	d = NULL;
 	switch (project) {
 		case GMT_LINEAR:	/* Linear x/y scaling */
 			gmt_set_cartesian (GMT, GMT_IN);	/* This will be overridden below if -Jx or -Jp, for instance */
@@ -4614,13 +4615,13 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 				i = 0;
 			}
 			j = (int)strlen (args) - 1;	/* Last character */
-			if ((c = strstr (args, "+r")) || args[j] == 'r') {	/* Gave optional +r for reverse (elevations, presumably) (r is deprecated) */
+			if ((d = strstr (args, "+r")) || args[j] == 'r') {	/* Gave optional +r for reverse (elevations, presumably) (r is deprecated) */
 				GMT->current.proj.got_elevations = true;
-				if (c) c[0] = '\0'; else args[j] = '\0';	/* Temporarily chop off the [+]r */
+				if (d) d[0] = '\0'; else args[j] = '\0';	/* Temporarily chop off the [+]r */
 			}
-			else if ((c = strstr (args, "+z")) || aargs[j] == 'z') {	/* Gave optional +z for annotating depths rather than radius (z is deprecated) */
+			else if ((d = strstr (args, "+z")) || args[j] == 'z') {	/* Gave optional +z for annotating depths rather than radius (z is deprecated) */
 				GMT->current.proj.z_down = true;
-				if (c) c[0] = '\0'; else args[j] = '\0';	/* Temporarily chop off the [+]z */
+				if (d) d[0] = '\0'; else args[j] = '\0';	/* Temporarily chop off the [+]z */
 			}
 			else
 				GMT->current.proj.got_elevations = GMT->current.proj.z_down = false;
@@ -4637,10 +4638,10 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 			else
 				error++;
 			if (GMT->current.proj.got_elevations) {
-				if (c) c[0] = '+'; else args[j] = 'r';	/* Put the r back in the argument */
+				if (d) d[0] = '+'; else args[j] = 'r';	/* Put the r back in the argument */
 			}
 			if (GMT->current.proj.z_down) {
-				if (c) c[0] = '+'; else args[j] = 'z';	/* Put the z back in the argument */
+				if (d) d[0] = '+'; else args[j] = 'z';	/* Put the z back in the argument */
 			}
 			if (GMT->current.proj.got_azimuths) GMT->current.proj.pars[1] = -GMT->current.proj.pars[1];	/* Because azimuths go clockwise */
 			break;


### PR DESCRIPTION
The **-JP** projection had trailing **r** or **z** 'modifiers' but they need to be **+r** and **+z** so that long-options machinery will work.  I implemented a backwards compatible fix.
Also fixed many small issues in the man pages.