### PR TITLE
Fix warnings for experimental features

### DIFF
--- a/src/nearneighbor.c
+++ b/src/nearneighbor.c
@@ -219,7 +219,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct NEARNEIGHBOR_CTRL *Ctrl, struc
 				Ctrl->N.active = true;
 				if (opt->arg[0] == 'n') {
 					Ctrl->N.mode = 1;
-					GMT_Report (API, GMT_MSG_ERROR, "Option -Nn is experimental and unstable.\n");
+					GMT_Report (API, GMT_MSG_WARNING, "Option -Nn is experimental and unstable.\n");
 				}
 				else if (opt->arg[0]) {	/* Override default -N4+m4 */
 					if ((c = strstr (opt->arg, "+m"))) {	/* Set sectors and min sectors using current syntax */

--- a/src/triangulate.c
+++ b/src/triangulate.c
@@ -228,7 +228,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct TRIANGULATE_CTRL *Ctrl, struct
 					n_errors += gmt_parse_common_options (GMT, "r", 'r', "");
 					break;
 				}
-				GMT_Report (API, GMT_MSG_ERROR, "-F is experimental and unstable.\n");
+				GMT_Report (API, GMT_MSG_WARNING, "-F is experimental and unstable.\n");
 				if ((c = strstr (opt->arg, "+d"))) {	/* Got modifier to also use input data */
 					c[0] = '\0';	/* Temporarily chop off modifier */
 					Ctrl->F.mode = 1;
@@ -264,7 +264,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct TRIANGULATE_CTRL *Ctrl, struct
 			case 'Q':
 				Ctrl->Q.active = true;
 				if (strchr (opt->arg, 'n')) {
-					GMT_Report (API, GMT_MSG_ERROR, "-Qn is experimental and unstable.\n");
+					GMT_Report (API, GMT_MSG_WARNING, "-Qn is experimental and unstable.\n");
 					Ctrl->Q.mode |= 1;
 				}
 				break;


### PR DESCRIPTION
These had the wrong verbosity level to ensure they were printed.