### PR TITLE
Better print format for -I option

### DIFF
--- a/src/pssolar.c
+++ b/src/pssolar.c
@@ -492,9 +492,15 @@ int GMT_pssolar (void *V_API, int mode, void *args) {
 				Return (API->error);
 			}
 
-			sprintf (record, "Sun current position:    Longitude = %f\tLatitude  = %f", -Sun->HourAngle, Sun->SolarDec);
+			sprintf (record, "Sun current position:");
 			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
-			sprintf (record, "                         Azimuth   = %.4f\tElevation = %.4f", Sun->SolarAzim, Sun->SolarElevation);
+			sprintf (record, "\tLongitude = %f", -Sun->HourAngle);
+			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+			sprintf (record, "\tLatitude  = %f", Sun->SolarDec);
+			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+			sprintf (record, "\tAzimuth   = %.4f", Sun->SolarAzim);
+			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+			sprintf (record, "\tElevation = %.4f", Sun->SolarElevation);
 			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 			if (Ctrl->I.position) {
 				if (isnan(Sun->Sunrise)) {
@@ -503,13 +509,13 @@ int GMT_pssolar (void *V_API, int mode, void *args) {
 				}
 				else {
 					hour = (int)(Sun->Sunrise * 24);	min = irint((Sun->Sunrise * 24 - hour) * 60);
-					sprintf(record, "\n                         Sunrise   = %02d:%02d", hour, min);	GMT_Put_Record(API, GMT_WRITE_DATA, Out);
+					sprintf(record, "\n\tSunrise   = %02d:%02d", hour, min);	GMT_Put_Record(API, GMT_WRITE_DATA, Out);
 					hour = (int)(Sun->Sunset * 24);		min = irint((Sun->Sunset * 24 - hour) * 60);
-					sprintf(record, "                         Sunset    = %02d:%02d", hour, min);	GMT_Put_Record(API, GMT_WRITE_DATA, Out);
+					sprintf(record, "\tSunset    = %02d:%02d", hour, min);	GMT_Put_Record(API, GMT_WRITE_DATA, Out);
 					hour = (int)(Sun->SolarNoon * 24);	min = irint((Sun->SolarNoon * 24 - hour) * 60);
-					sprintf(record, "                         Noon      = %02d:%02d", hour, min);	GMT_Put_Record(API, GMT_WRITE_DATA, Out);
+					sprintf(record, "\tNoon      = %02d:%02d", hour, min);	GMT_Put_Record(API, GMT_WRITE_DATA, Out);
 					hour = (int)(Sun->Sunlight_duration / 60);	min = irint(Sun->Sunlight_duration - hour * 60);
-					sprintf(record, "                         Duration  = %02d:%02d", hour, min);	GMT_Put_Record(API, GMT_WRITE_DATA, Out);
+					sprintf(record, "\tDuration  = %02d:%02d", hour, min);	GMT_Put_Record(API, GMT_WRITE_DATA, Out);
 				}
 			}
 			gmt_M_free (GMT, Out);


### PR DESCRIPTION
It also gets more friendly for externals parsing. It now prints

```
$ gmt pssolar -I-8/37
Sun current position:
        Longitude = -35.100010
        Latitude  = -16.556080
        Azimuth   = 218.2347
        Elevation = 27.0537

        Sunrise   = 07:33
        Sunset    = 17:58
        Noon      = 12:46
        Duration  = 10:25
```