### PR TITLE
Let multiple mode message be information

### DIFF
--- a/src/dimfilter.c
+++ b/src/dimfilter.c
@@ -1084,7 +1084,7 @@ int GMT_dimfilter (void *V_API, int mode, void *args) {
 #ifdef OBSOLETE
 		if (Ctrl->E.active && n_bad_planes) GMT_Report (API, GMT_MSG_WARNING, "Unable to detrend data at %" PRIu64 " nodes\n", n_bad_planes);
 #endif
-		if (GMT_n_multiples > 0) GMT_Report (API, GMT_MSG_WARNING, "%d multiple modes found\n", GMT_n_multiples);
+		if (GMT_n_multiples > 0) GMT_Report (API, GMT_MSG_INFORMATION, "%d separate modes found by the mode filter\n", GMT_n_multiples);
 
 		GMT_Report (API, GMT_MSG_INFORMATION, "Write filtered grid\n");
 		if (GMT_Set_Comment (API, GMT_IS_GRID, GMT_COMMENT_IS_OPTION | GMT_COMMENT_IS_COMMAND, options, Gout)) Return (API->error);

--- a/src/filter1d.c
+++ b/src/filter1d.c
@@ -1056,7 +1056,7 @@ int GMT_filter1d (void *V_API, int mode, void *args) {
 		Return (API->error, "Error in End_IO\n");
 	}
 
-	if (F.n_multiples > 0) GMT_Report (API, GMT_MSG_WARNING, "%d multiple modes found\n", F.n_multiples);
+	if (F.n_multiples > 0) GMT_Report (API, GMT_MSG_INFORMATION, "%d separate modes found by the mode filter\n", F.n_multiples);
 
 	free_space_filter1d (GMT, &F);
 

--- a/src/grdfilter.c
+++ b/src/grdfilter.c
@@ -1320,7 +1320,7 @@ int GMT_grdfilter (void *V_API, int mode, void *args) {
 	}
 
 	if (n_nan) GMT_Report (API, GMT_MSG_WARNING, "Unable to estimate value at %" PRIu64 " nodes, set to NaN\n", n_nan);
-	if (GMT_n_multiples > 0) GMT_Report (API, GMT_MSG_WARNING, "%d multiple modes found by the mode filter\n", GMT_n_multiples);
+	if (GMT_n_multiples > 0) GMT_Report (API, GMT_MSG_INFORMATION, "%d separate modes found by the mode filter\n", GMT_n_multiples);
 
 	if (Ctrl->F.highpass) {
 		if (GMT->common.R.active[RSET] || GMT->common.R.active[ISET] || GMT->common.R.active[GSET]) {	/* Must resample result so grids are coregistered */

--- a/src/grdfilter_mt.c
+++ b/src/grdfilter_mt.c
@@ -1005,7 +1005,7 @@ int GMT_grdfilter_mt (void *V_API, int mode, void *args)
 	}
 
 	if (n_nan) GMT_Report (API, GMT_MSG_WARNING, "Unable to estimate value at %" PRIu64 " nodes, set to NaN\n", n_nan);
-	if (GMT_n_multiples > 0) GMT_Report (API, GMT_MSG_WARNING, "%d multiple modes found by the mode filter\n", GMT_n_multiples);
+	if (GMT_n_multiples > 0) GMT_Report (API, GMT_MSG_INFORMATION, "%d separate modes found by the mode filter\n", GMT_n_multiples);
 
 	if (Ctrl->F.highpass) {
 		if (GMT->common.R.active[RSET] || GMT->common.R.active[ISET] || GMT->common.R.active[GSET]) {	/* Must resample result so grids are coregistered */

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -408,7 +408,7 @@ GMT_LOCAL int get_loc_scl (struct GMT_CTRL *GMT, double *data, uint64_t n, doubl
 	/* Get mode */
 
 	gmt_mode (GMT, data, n, j, 0, 0, &n_multiples, &stats[2]);
-	if (n_multiples > 0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "%d multiple modes found\n", n_multiples);
+	if (n_multiples > 0) GMT_Report (GMT->parent, GMT_MSG_INFORMATION "The histogram approximation to the pdf has %d multiple modes\n", n_multiples);
 
 	/* Get MAD for L1 */
 

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -408,7 +408,7 @@ GMT_LOCAL int get_loc_scl (struct GMT_CTRL *GMT, double *data, uint64_t n, doubl
 	/* Get mode */
 
 	gmt_mode (GMT, data, n, j, 0, 0, &n_multiples, &stats[2]);
-	if (n_multiples > 0) GMT_Report (GMT->parent, GMT_MSG_INFORMATION "The histogram approximation to the pdf has %d multiple modes\n", n_multiples);
+	if (n_multiples > 0) GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "The histogram approximation to the pdf has %d multiple modes\n", n_multiples);
 
 	/* Get MAD for L1 */
 

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -408,7 +408,7 @@ GMT_LOCAL int get_loc_scl (struct GMT_CTRL *GMT, double *data, uint64_t n, doubl
 	/* Get mode */
 
 	gmt_mode (GMT, data, n, j, 0, 0, &n_multiples, &stats[2]);
-	if (n_multiples > 0) GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "The histogram approximation to the pdf has %d multiple modes\n", n_multiples);
+	if (n_multiples > 0) GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "The histogram has multiple (%d) modes (peaks)\n", n_multiples);
 
 	/* Get MAD for L1 */
 


### PR DESCRIPTION
Various histogram or filtering operations involving mode estimation may report it found more than one mode.  We let this be flagged as INFORMATION.  Closes #2651.