### PR TITLE
Address complications for filenames with spaces in psconvert and show

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12951,7 +12951,7 @@ GMT_LOCAL int set_modern_mode_if_oneliner (struct GMTAPI_CTRL *API, struct GMT_O
 			}
 		}
 		if (opt->next && opt->next->option == GMT_OPT_INFILE) {	/* Found a -ext[,ext,ext,...] <prefix> pair */
-			if (strchr (opt->next->arg, ' '))
+			if (strchr (opt->next->arg, ' '))	/* File name has spaces, must surround it in single quotes */
 				snprintf (session, GMT_LEN128, "\'%s\' %s", opt->next->arg, figure);
 			else
 				snprintf (session, GMT_LEN128, "%s %s", opt->next->arg, figure);
@@ -16433,14 +16433,14 @@ GMT_LOCAL int process_figures (struct GMTAPI_CTRL *API, char *show) {
 				char ext[GMT_LEN8] = {""};
 				strcpy (ext, gmt_session_format[gcode[f]]);	/* Set extension */
 				gmt_str_tolower (ext);	/* In case it was PNG */
-				/* File names with spaces with be given in single quotes - remove those here */
+				/* File names with spaces will be given in single quotes - remove those here when making single command string */
 				if (fig[k].prefix[0] == '\'') start = 1, fig[k].prefix[end] = '\0';	/* Remove the quote */
 				if (dir[0])
 					snprintf (cmd, GMT_BUFSIZ, "%s/%s.%s", dir, &fig[k].prefix[start], ext);
 				else
 					snprintf (cmd, GMT_BUFSIZ, "%s.%s", &fig[k].prefix[start], ext);
 				if (fig[k].prefix[0] == '\'') fig[k].prefix[end] = '\'';	/* Restore the quote */
-				gmt_filename_set (cmd);
+				gmt_filename_set (cmd);	/* Protect filename spaces by substitution */
 				if ((error = GMT_Call_Module (API, "docs", GMT_MODULE_CMD, cmd))) {
 					GMT_Report (API, GMT_MSG_ERROR, "Failed to call docs\n");
 					gmt_M_free (API->GMT, fig);

--- a/src/gmt_parse.c
+++ b/src/gmt_parse.c
@@ -505,7 +505,7 @@ struct GMT_OPTION *GMT_Create_Options (void *V_API, int n_args_in, const void *i
 		 * these items by temporarily replacing spaces inside quoted strings with ASCII 31 US (Unit Separator), do the strtok on
 		 * space, and then replace all ASCII 31 with space at the end (we do the same for tab using ASCII 29 GS (group separator) */
 		for (k = 0, quoted = false; txt_in[k]; k++) {
-			if (txt_in[k] == '\"') quoted = !quoted;	/* Initially false, becomes true at start of quote, then false when exit quote */
+			if (txt_in[k] == '\"' || txt_in[k] == '\'') quoted = !quoted;	/* Initially false, becomes true at start of quote, then false when exit quote */
 			else if (quoted && txt_in[k] == '\t') txt_in[k] = GMT_ASCII_GS;
 			else if (quoted && txt_in[k] == ' ')  txt_in[k] = GMT_ASCII_US;
 		}

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -677,6 +677,15 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
+char *noquote_name (char *file) {
+	if (file[0] == '\'') {	/* Skip single quotes */
+		size_t len = strlen (file);
+		return (strndup (&file[1], len-2));
+	}
+	else
+		return strdup (file);
+}
+
 GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PS2RASTER_CTRL *Ctrl, struct GMT_OPTION *options) {
 	/* This parses the options provided to psconvert and sets parameters in CTRL.
 	 * Any GMT common options will override values set previously by other commands.
@@ -723,7 +732,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PS2RASTER_CTRL *Ctrl, struct G
 				break;
 			case 'F':	/* Set explicitly the output file name */
 				if ((Ctrl->F.active = gmt_check_filearg (GMT, 'F', opt->arg, GMT_OUT, GMT_IS_DATASET)) != 0) {
-					Ctrl->F.file = strdup (opt->arg);
+					Ctrl->F.file = noquote_name (opt->arg);
 					gmt_filename_get (Ctrl->F.file);
 				}
 				else
@@ -1447,15 +1456,6 @@ GMT_LOCAL int get_extension_period (char *file) {
 }
 
 EXTERN_MSC int gmt_copy (struct GMTAPI_CTRL *API, enum GMT_enum_family family, unsigned int direction, char *ifile, char *ofile);
-
-char *noquote_name (char *file) {
-	if (file[0] == '\'') {	/* Skip single quotes */
-		size_t len = strlen (file);
-		return (strndup (&file[1], len-2));
-	}
-	else
-		return strdup (file);
-}
 
 GMT_LOCAL int make_dir_if_needed (struct GMTAPI_CTRL *API, char *dir) {
 	struct stat S;


### PR DESCRIPTION
See #2646 for background.  The solution involved several steps:

- The filename argument to psconvert **-F** needed to be de-quoted.  This is necessary because when we build the gs command we always surround the final output name with quotes.
- _GMT_Create_Options_ needs to consider both single and double quotes when converting a single text string commands that contain filenames in quotes to linked options.
- The gmt end **show** code also needed to be mindful of the presence of quotes in file names.

With these changes, GMT handles filenames with spaces provided given in quotes; these two commands work equally well for me (macOS):

```
gmt basemap -R-10/10/-10/5/0/10 -JX10c/3c -Baf -pdf 'My map'
gmt basemap -R-10/10/-10/5/0/10 -JX10c/3c -Baf -pdf "My map"
```

Hopefully this addresses all of #2646 but that needs to be determined.
