### PR TITLE
Install latest cppcheck via Ubuntu snap

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -29,7 +29,8 @@ jobs:
   steps:
   - bash: |
       set -x -e
-      sudo apt-get install -y cppcheck
+      sudo snap install cppcheck
+      cppcheck --version
     displayName: Install cppcheck
 
   - bash: bash ci/run-cppcheck.sh


### PR DESCRIPTION
The cppcheck installed via apt-get is old (v1.82). Ubuntu snap provides the latest v1.90.