### PR TITLE
Handle quotes in API->session_dir

### DIFF
--- a/src/common_string.c
+++ b/src/common_string.c
@@ -26,6 +26,7 @@
  *  gmt_chop                Chops off any CR or LF at end of string
  *  gmt_chop_ext            Chops off the trailing .xxx (file extension)
  *  gmt_get_ext             Returns a pointer to the tailing .xxx (file extension)
+ *  gmt_strdup_noquote		Duplicates a string but removes any surrounding single or double quotes
  *  gmt_strstrip            Strip leading and trailing whitespace from string
  *  gmt_strlshift           Left shift a string by n characters
  *  gmt_strrepc             Replaces all occurrences of a char in the string
@@ -58,6 +59,17 @@
 #include "common_string.h"
 
 #define BUF_SIZE 4096
+
+char *gmt_strdup_noquote (const char *file) {
+	size_t last;
+	if (file == NULL) return NULL;	/* No string given */
+	if (file[0] == '\0') return strdup (file);	/* Return empty string */
+	last = strlen (file) - 1;	/* We know here that the string is at least 1 character long, so len is >= 0 */
+	if ((file[0] == '\'' || file[0] == '\"') && (file[last] == '\'' || file[last] == '\"'))	/* Quoted file name */
+		return (strndup (&file[1], last-1));
+	else
+		return (strdup (file));
+}
 
 char *gmt_chop_ext (char *string) {
 	/* Chops off the filename extension (e.g., .ps) in the string by replacing the last

--- a/src/common_string.h
+++ b/src/common_string.h
@@ -60,6 +60,7 @@ EXTERN_MSC void gmt_strlshift (char *string, size_t n);
 EXTERN_MSC void gmt_strrepc (char *string, int c, int r);
 EXTERN_MSC char *gmt_strrep(const char *s1, const char *s2, const char *s3);
 EXTERN_MSC size_t gmt_strlcmp (char *str1, char *str2);
+EXTERN_MSC char *gmt_strdup_noquote(const char *string);
 
 #ifdef WIN32
 EXTERN_MSC void gmt_dos_path_fix (char *dir);

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -2970,22 +2970,22 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 	/* Note: gmtinit_set_env cannot use GMT_Report because the verbose level is not yet set */
 
 	if ((this_c = getenv ("GMT6_SHAREDIR")) != NULL)	/* GMT6_SHAREDIR was set */
-		GMT->session.SHAREDIR = strdup (this_c);
+		GMT->session.SHAREDIR = gmt_strdup_noquote (this_c);
 	else if ((this_c = getenv ("GMT5_SHAREDIR")) != NULL)	/* GMT5_SHAREDIR was set */
-		GMT->session.SHAREDIR = strdup (this_c);
+		GMT->session.SHAREDIR = gmt_strdup_noquote (this_c);
 	else if ((this_c = getenv ("GMT_SHAREDIR")) != NULL) /* GMT_SHAREDIR was set */
-		GMT->session.SHAREDIR = strdup (this_c);
+		GMT->session.SHAREDIR = gmt_strdup_noquote (this_c);
 #ifdef SUPPORT_EXEC_IN_BINARY_DIR
 	else if (running_in_bindir_src)
 		/* Use ${GMT_SOURCE_DIR}/share to simplify debugging and running in GMT_BINARY_DIR */
-		GMT->session.SHAREDIR = strdup (GMT_SHARE_DIR_DEBUG);
+		GMT->session.SHAREDIR = gmt_strdup_noquote (GMT_SHARE_DIR_DEBUG);
 #endif
 	else if (!access (GMT_SHARE_DIR, F_OK|R_OK))		/* Found in hardcoded GMT_SHARE_DIR pointing to an existent directory */
-		GMT->session.SHAREDIR = strdup (GMT_SHARE_DIR);
+		GMT->session.SHAREDIR = gmt_strdup_noquote (GMT_SHARE_DIR);
 	else {
 		/* SHAREDIR still not found, make a smart guess based on runpath: */
 		if (gmt_guess_sharedir (path, GMT->init.runtime_bindir))
-			GMT->session.SHAREDIR = strdup (path);
+			GMT->session.SHAREDIR = gmt_strdup_noquote (path);
 		else {
 			/* Still not found */
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not locate share directory for GMT.\n");
@@ -3000,12 +3000,12 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 	/* Determine HOMEDIR (user home directory) */
 
 	if ((this_c = getenv ("HOME")) != NULL)				/* HOME was set */
-		GMT->session.HOMEDIR = strdup (this_c);
+		GMT->session.HOMEDIR = gmt_strdup_noquote (this_c);
 #ifdef WIN32
 	else if ((this_c = getenv ("USERPROFILE")) != NULL)	/* USERPROFILE was set */
-		GMT->session.HOMEDIR = strdup (this_c);
+		GMT->session.HOMEDIR = gmt_strdup_noquote (this_c);
 	else if ((this_c = getenv ("HOMEPATH")) != NULL)	/* HOMEPATH was set */
-		GMT->session.HOMEDIR = strdup (this_c);
+		GMT->session.HOMEDIR = gmt_strdup_noquote (this_c);
 #endif
 	else {
 		/* If HOME not set: use root directory instead (http://gmt.soest.hawaii.edu/issues/710) */
@@ -3023,10 +3023,10 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 	/* Determine GMT_USERDIR (directory containing user replacements contents in GMT_SHAREDIR) */
 
 	if ((this_c = getenv ("GMT_USERDIR")) != NULL)		/* GMT_USERDIR was set */
-		GMT->session.USERDIR = strdup (this_c);
+		GMT->session.USERDIR = gmt_strdup_noquote (this_c);
 	else if (GMT->session.HOMEDIR) {	/* Use default path for GMT_USERDIR (~/.gmt) */
 		snprintf (path, PATH_MAX, "%s/%s", GMT->session.HOMEDIR, ".gmt");
-		GMT->session.USERDIR = strdup (path);
+		GMT->session.USERDIR = gmt_strdup_noquote (path);
 		u = 1;
 	}
 	if (GMT->session.USERDIR) {
@@ -3043,10 +3043,10 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 		}
 	}
 	if ((this_c = getenv ("GMT_CACHEDIR")) != NULL)		/* GMT_CACHEDIR was set */
-		GMT->session.CACHEDIR = strdup (this_c);
+		GMT->session.CACHEDIR = gmt_strdup_noquote (this_c);
 	else if (GMT->session.USERDIR != NULL) {	/* Use default path for GMT_CACHEDIR as GMT_USERDIR/cache */
 		snprintf (path, PATH_MAX, "%s/%s", GMT->session.USERDIR, "cache");
-		GMT->session.CACHEDIR = strdup (path);
+		GMT->session.CACHEDIR = gmt_strdup_noquote (path);
 		c = 1;
 	}
 	if (GMT->session.CACHEDIR) {
@@ -3064,13 +3064,13 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 	}
 
 	if ((this_c = getenv ("GMT_SESSIONDIR")) != NULL)		/* GMT_SESSIONDIR was set */
-		API->session_dir = strdup (this_c);
+		API->session_dir = gmt_strdup_noquote (this_c);
 	else if (GMT->session.USERDIR != NULL) {	/* Use GMT_USERDIR/sessions as default path for GMT_SESSIONDIR */
 		snprintf (path, PATH_MAX, "%s/%s", GMT->session.USERDIR, "sessions");
-		API->session_dir = strdup (path);
+		API->session_dir = gmt_strdup_noquote (path);
 	}
 	else {	/* Use the temp dir as the session dir */
-		API->session_dir = strdup (API->tmp_dir);
+		API->session_dir = gmt_strdup_noquote (API->tmp_dir);
 		GMT_Report (API, GMT_MSG_ERROR, "No GMT User directory set, GMT session dir selected: %s\n", API->session_dir);
 	}
 	if (API->session_dir) {
@@ -3139,7 +3139,7 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 			GMT->session.TMPDIR = NULL;
 		}
 		else {
-			GMT->session.TMPDIR = strdup (this_c);
+			GMT->session.TMPDIR = gmt_strdup_noquote (this_c);
 			gmt_dos_path_fix (GMT->session.TMPDIR);
 			trim_off_any_slash_at_end (GMT->session.TMPDIR);
 		}
@@ -16883,13 +16883,10 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 	char file[PATH_MAX] = {""}, dir[PATH_MAX] = {""};
 	static char *type[2] = {"classic", "modern"}, *smode[3] = {"Use", "Begin", "End"}, *fstatus[4] = {"found", "not found", "created", "removed"};
 	int err = 0, fig, error = GMT_NOERROR;
-	size_t start = 0, end = strlen (API->session_dir) - 1;
 	struct stat S;
 
-	if (strchr ("\'\"", API->session_dir[0]) && strchr ("\'\"", API->session_dir[end])) start++, API->session_dir[end] = '\0';	/* Remove quotes */
-	snprintf (dir, PATH_MAX, "%s/gmt%d.%s", &API->session_dir[start], GMT_MAJOR_VERSION, API->session_name);
+	snprintf (dir, PATH_MAX, "%s/gmt%d.%s", API->session_dir, GMT_MAJOR_VERSION, API->session_name);
 	API->gwf_dir = strdup (dir);
-	if (start) API->session_dir[end] = API->session_dir[0];	/* Restore quotes */
 	err = stat (API->gwf_dir, &S);	/* Stat the gwf_dir path (which may not exist) */
 
 	switch (mode) {

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -16883,10 +16883,13 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 	char file[PATH_MAX] = {""}, dir[PATH_MAX] = {""};
 	static char *type[2] = {"classic", "modern"}, *smode[3] = {"Use", "Begin", "End"}, *fstatus[4] = {"found", "not found", "created", "removed"};
 	int err = 0, fig, error = GMT_NOERROR;
+	size_t start = 0, end = strlen (API->session_dir) - 1;
 	struct stat S;
 
-	snprintf (dir, PATH_MAX, "%s/gmt%d.%s", API->session_dir, GMT_MAJOR_VERSION, API->session_name);
+	if (strchr ("\'\"", API->session_dir[0]) && strchr ("\'\"", API->session_dir[end])) start++, API->session_dir[end] = '\0';	/* Remove quotes */
+	snprintf (dir, PATH_MAX, "%s/gmt%d.%s", &API->session_dir[start], GMT_MAJOR_VERSION, API->session_name);
 	API->gwf_dir = strdup (dir);
+	if (start) API->session_dir[end] = API->session_dir[0];	/* Restore quotes */
 	err = stat (API->gwf_dir, &S);	/* Stat the gwf_dir path (which may not exist) */
 
 	switch (mode) {

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -677,15 +677,6 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
-char *noquote_name (char *file) {
-	if (file[0] == '\'') {	/* Skip single quotes */
-		size_t len = strlen (file);
-		return (strndup (&file[1], len-2));
-	}
-	else
-		return strdup (file);
-}
-
 GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PS2RASTER_CTRL *Ctrl, struct GMT_OPTION *options) {
 	/* This parses the options provided to psconvert and sets parameters in CTRL.
 	 * Any GMT common options will override values set previously by other commands.
@@ -732,7 +723,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PS2RASTER_CTRL *Ctrl, struct G
 				break;
 			case 'F':	/* Set explicitly the output file name */
 				if ((Ctrl->F.active = gmt_check_filearg (GMT, 'F', opt->arg, GMT_OUT, GMT_IS_DATASET)) != 0) {
-					Ctrl->F.file = noquote_name (opt->arg);
+					Ctrl->F.file = gmt_strdup_noquote (opt->arg);
 					gmt_filename_get (Ctrl->F.file);
 				}
 				else
@@ -1650,14 +1641,14 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 		Ctrl->In.n_files = (unsigned int)T->n_records;
 		ps_names = gmt_M_memory (GMT, NULL, T->n_records, char *);
 		for (k = 0; k < T->table[0]->segment[0]->n_rows; k++)	/* Set pointers */
-			ps_names[k] = noquote_name (T->table[0]->segment[0]->text[k]);
+			ps_names[k] = gmt_strdup_noquote (T->table[0]->segment[0]->text[k]);
 	}
 	else if (Ctrl->In.n_files) {	/* One or more files given on command line */
 		ps_names = gmt_M_memory (GMT, NULL, Ctrl->In.n_files, char *);
 		j = 0;
 		for (opt = options; opt; opt = opt->next) {
 			if (opt->option != '<') continue;
-			ps_names[j++] = noquote_name (opt->arg);
+			ps_names[j++] = gmt_strdup_noquote (opt->arg);
 		}
 	}
 	if (GMT->current.setting.run_mode == GMT_MODERN) {	/* Need to complete the half-baked PS file */
@@ -1668,7 +1659,7 @@ int GMT_psconvert (void *V_API, int mode, void *args) {
 			}
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Hidden PS file %s found\n", GMT->current.ps.filename);
 			ps_names = gmt_M_memory (GMT, NULL, 1, char *);
-			ps_names[0] = noquote_name (GMT->current.ps.filename);
+			ps_names[0] = gmt_strdup_noquote (GMT->current.ps.filename);
 			Ctrl->In.n_files = 1;
 		}
 		if (access (ps_names[0], F_OK) == 0) {	/* File exist, so complete it */


### PR DESCRIPTION
Avoid quotes in name when used to build a path.  Hopefully helping with #2646, @joa-quim.
