### PR TITLE
Compute require colatitude when setting a pole a point for small circle

### DIFF
--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt project** [ *table* ] |-C|\ *cx*/*cy* [ |-A|\ *azimuth* ]
 [ |-E|\ *bx*/*by* ] [ |-F|\ *flags* ]
-[ |-G|\ *dist*\ [/*colat*][**+h**] ]
+[ |-G|\ *dist*\ [/*colat*][**+c**\|\ h**] ]
 [ |-L|\ [**w**\|\ *l\_min*/*l\_max*] ]
 [ |-N| ] [ |-Q| ] [ |-S| ]
 [ |-T|\ *px*/*py* ]
@@ -147,11 +147,13 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *dist*\ [/*colat*][**+h**]
+**-G**\ *dist*\ [/*colat*][**+c**\|\ h**]
     Generate mode. No input is read. Create (*r*, *s*, *p*) output
     points every *dist* units of *p*. See **-Q** option. Alternatively,
     append **/**\ *colat* for a small circle instead [Default is a
-    colatitude of 90, i.e., a great circle]. Use **-C** and **-E** to
+    colatitude of 90, i.e., a great circle]. If setting a pole with **-T**
+    and you want to small circle to go through *cx*/*cy*, append **+c** to
+    compute the required colatitude. Use **-C** and **-E** to
     generate a circle that goes through the center and end point. Note,
     in this case the center and end point cannot be farther apart than
     2\*\|\ *colat*\|. Finally, if you append **+h** the we will report

--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt project** [ *table* ] |-C|\ *cx*/*cy* [ |-A|\ *azimuth* ]
 [ |-E|\ *bx*/*by* ] [ |-F|\ *flags* ]
-[ |-G|\ *dist*\ [/*colat*][**+c**\|\ h**] ]
+[ |-G|\ *dist*\ [/*colat*][**+c**\|\ **h**] ]
 [ |-L|\ [**w**\|\ *l\_min*/*l\_max*] ]
 [ |-N| ] [ |-Q| ] [ |-S| ]
 [ |-T|\ *px*/*py* ]

--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -147,7 +147,7 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *dist*\ [/*colat*][**+c**\|\ h**]
+**-G**\ *dist*\ [/*colat*][**+c**\|\ **h**]
     Generate mode. No input is read. Create (*r*, *s*, *p*) output
     points every *dist* units of *p*. See **-Q** option. Alternatively,
     append **/**\ *colat* for a small circle instead [Default is a

--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -152,7 +152,7 @@ Optional Arguments
     points every *dist* units of *p*. See **-Q** option. Alternatively,
     append **/**\ *colat* for a small circle instead [Default is a
     colatitude of 90, i.e., a great circle]. If setting a pole with **-T**
-    and you want to small circle to go through *cx*/*cy*, append **+c** to
+    and you want the small circle to go through *cx*/*cy*, append **+c** to
     compute the required colatitude. Use **-C** and **-E** to
     generate a circle that goes through the center and end point. Note,
     in this case the center and end point cannot be farther apart than


### PR DESCRIPTION
project can draw a small circle, but if you specify the projection via a pole by **-T** and a point by **-C**, it is complicated to draw the small circle through C because you do not know its colatitude needed in **-G** without computing it first separately (e.g., with mapproject).  This PR adds a new modifier **+c** to **-G** that will automatically supply the required colatitude to active the desired small circle.

