### PR TITLE
Various mapproject fixes

### DIFF
--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -169,7 +169,7 @@ Optional Arguments
     Determine the shortest distance from the input data points to the
     line(s) given in the ASCII multisegment file *line.xy*. The distance
     and the coordinates of the nearest point will be appended to the
-    output as three new columns. Append the distance unit (see `Units`_
+    output as three new columns. Append the distance unit via **+u** (see `Units`_
     for available units and how distances are computed [great circle using authalic radius]),
     including **c** (Cartesian distance using input coordinates) or
     **C** (Cartesian distance using projected coordinates). The **C**

--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -144,16 +144,18 @@ Optional Arguments
 
 **-G**\ [*lon0*/*lat0*][**+a**][**+i**][**+u**\ *unit*][**+v**]
     Calculate distances along track *or* to the optional *fixed* point set
-    with **-G**\ *lon0*/*lat0*. Append the distance unit with **+u** (see `Units`_ for available
-    units and how distances are computed [great circle using authalic radius]), including
-    **c** (Cartesian distance using input coordinates) or **C**
+    with **-G**\ *lon0*/*lat0*. Append the distance unit with **+u** (see `Units`_
+    for available units and how distances are computed [great circle using authalic
+    radius]), including **c** (Cartesian distance using input coordinates) or **C**
     (Cartesian distance using projected coordinates). The **C** unit
-    requires **-R** and **-J** to be set. When no fixed point is given
-    we calculate accumulated distances [or by adding **+a**] along the
-    track defined by the input points. Append **+i** to obtain *incremental*
-    distances between successive points, or append both modifiers to get
-    both distance measurements. Alternatively, append **+v** to obtain a
-    *variable* 2nd point (*lon0*/*lat0*) via columns 3-4 in the input file.
+    requires **-R** and **-J** to be set. If no fixed point is given
+    we calculate *accumulated* distances whereas if a fixed point is given
+    we calculate *incremental* distances.  You can override these defaults
+    by adding **+a** for accumulated or **+i** for incremental distances.
+    If both *+a** and **+i** are given we will report both types of distances.
+    Append **+v** to obtain a *variable* 2nd point (*lon0*/*lat0*) via columns
+    3-4 in the input file; this updates the fixed point per record and thus the
+    selection defaults to incremental distances.
     See `Output Order`_ for how **-G** affects the output record.
 
 .. _-I:
@@ -344,7 +346,7 @@ assuming a fixed speed of 12 knots.  We do this with
 
    ::
 
-    gmt mapproject track.txt -Gn+a+i -Z12+a --TIME_UNIT=h > elapsed_time.txt
+    gmt mapproject track.txt -G+un+a+i -Z12+a --TIME_UNIT=h > elapsed_time.txt
 
 where :term:`TIME_UNIT` is set to hour so that the speed is
 measured in nm (set by **-G**) per hour (set by :term:`TIME_UNIT`).

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -534,7 +534,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct 
 					if (q) q[2] = '+';
 					p[0] = '\0';	/* Chop off all modifiers */
 					/* Here, opt->arg is -G[<lon0/lat0>] */
-					if (opt->arg[0]) /* Just gave -G, should mean -G+ue+a */
+					if (opt->arg[0] == '\0') /* Just gave -G, should mean -G+ue+a */
 						Ctrl->G.mode |= GMT_MP_CUMUL_DIST;
 					else if (n_slash == 1) {	/* Got -G<lon0/lat0> so we were given a fixed point */
 						Ctrl->G.mode |= GMT_MP_FIXED_POINT;

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -222,7 +222,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use -G[+u<unit>]+a for accumulated distances along track [Default if <lon0>/<lat0> not given].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use -G[+u<unit>]+i for distance increments [Default if <lon0>/<lat0> given].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use -G[+u<unit>]+v to obtain distance increments via variable <lon0> <lat0> points from input columns 3-4.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append +a to force accumulated distsances, +i to force incremental distances, or both to get both distances.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Append +a to force accumulated distances, +i to force incremental distances, or both to get both distances.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Give unit as arc (d)egree, m(e)ter, (f)oot, (k)m, arc (m)inute, (M)ile, (n)autical mile, s(u)rvey foot,\n\t   arc (s)econd, or (c)artesian [e].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Unit C means Cartesian distances after projecting the input coordinates to plot coordinates (requires -R, -J).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Inverse mode, i.e., get lon/lat from x/y input. [Default is lon/lat -> x/y].\n");
@@ -1167,7 +1167,6 @@ int GMT_mapproject (void *V_API, int mode, void *args) {
 		Return (API->error);
 	}
 	along_track = (Ctrl->G.mode && ((Ctrl->G.mode & GMT_MP_CUMUL_DIST) || (Ctrl->G.mode & GMT_MP_INCR_DIST)));
-	//if ((Ctrl->G.mode & GMT_MP_PAIR_DIST) && (Ctrl->G.mode & GMT_MP_INCR_DIST)) along_track = false;	/* Not along track (i.e., per record) when doing it per record */
 	n = n_read_in_seg = 0;
 	out = gmt_M_memory (GMT, NULL, GMT_MAX_COLUMNS, double);
 	Out->data = out;

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -1350,9 +1350,9 @@ int GMT_mapproject (void *V_API, int mode, void *args) {
 				if (Ctrl->G.mode) {	/* Distances of some sort */
 					if (Ctrl->G.mode & GMT_MP_PAIR_DIST)	/* Segment distances from each data record using two extra coordinates */
 						extra[MP_COL_DS] = gmt_distance (GMT, in[GMT_X], in[GMT_Y], in[2], in[3]);
-					else if (Ctrl->G.mode & GMT_MP_FIXED_POINT)	/* Distance from fixed point via -G OR the previous track point */
+					else if (Ctrl->G.mode & GMT_MP_FIXED_POINT || !line_start)	/* Distance from fixed point via -G OR the previous track point */
 						extra[MP_COL_DS] = gmt_distance (GMT, Ctrl->G.lon, Ctrl->G.lat, in[GMT_X], in[GMT_Y]);
-					else if (line_start)	/* Incremental distance at start of line is zero */
+					else	/* Incremental distance at start of line is zero */
 						extra[MP_COL_DS] = 0.0;
 
 					if (along_track) {	/* Along-track calculation */

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -1348,21 +1348,24 @@ int GMT_mapproject (void *V_API, int mode, void *args) {
 
 			if (geodetic_calc) {	/* Get either distances, azimuths, or travel times */
 				if (Ctrl->G.mode) {	/* Distances of some sort */
-					if (Ctrl->G.mode & GMT_MP_PAIR_DIST)	/* Segment distances from each data record using 2 extra coordinates */
+					if (Ctrl->G.mode & GMT_MP_PAIR_DIST)	/* Segment distances from each data record using two extra coordinates */
 						extra[MP_COL_DS] = gmt_distance (GMT, in[GMT_X], in[GMT_Y], in[2], in[3]);
-					else	/* Distance from fixed point via -G OR the last track point */
+					else if (Ctrl->G.mode & GMT_MP_FIXED_POINT)	/* Distance from fixed point via -G OR the previous track point */
 						extra[MP_COL_DS] = gmt_distance (GMT, Ctrl->G.lon, Ctrl->G.lat, in[GMT_X], in[GMT_Y]);
+					else if (line_start)	/* Incremental distance at start of line is zero */
+						extra[MP_COL_DS] = 0.0;
+
 					if (along_track) {	/* Along-track calculation */
-						if (line_start && (Ctrl->G.mode & GMT_MP_VAR_POINT))
+						if (line_start && (Ctrl->G.mode & GMT_MP_VAR_POINT))	/* Initialize for new line */
 							extra[MP_COL_CS] = extra[MP_COL_DS] = 0.0;
 						else
 							extra[MP_COL_CS] += extra[MP_COL_DS];
-						line_start = false;
 						if ((Ctrl->G.mode & GMT_MP_FIXED_POINT) == 0) {	/* Save previous point in G */
 							Ctrl->G.lon = in[GMT_X];
 							Ctrl->G.lat = in[GMT_Y];
 						}
 					}
+					line_start = false;	/* After processing first line we are no longer at the start of the line */
 				}
 				if (Ctrl->L.active) {	/* Compute closest distance to line */
 					y_in = (do_geo_conv) ? gmt_lat_swap (GMT, (*data)[GMT_Y], GMT_LATSWAP_G2O) : (*data)[GMT_Y];	/* Convert to geocentric */

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -217,13 +217,14 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   If <datum> = - or not given we assume WGS-84.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-F Force projected values to be in actual distances [Default uses the given plot scale].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Specify unit by appending e (meter), f (foot) k (km), M (mile), n (nautical mile), u (survey foot),\n\t   i (inch), c (cm), or p (points) [e].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-G Calculate distances to <lon0>/<lat0> OR cumulative distances along track (if point not given).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Spherical calculations method determined by -j [Default is great-circle calculations].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-G Calculate distances to <lon0>/<lat0> OR cumulative distances along track (if fixed point not given).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Spherical calculation method is determined by -j [Default is great-circle calculations].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use -G[+u<unit>]+a for accumulated distances along track [Default if <lon0>/<lat0> not given].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use -G[+u<unit>]+i for distance increments [Default if <lon0>/<lat0> given].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Use -G[+u<unit>]+v to obtain variable <lon0> <lat0> points from input columns 3-4.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Use -G[+u<unit>]+v to obtain distance increments via variable <lon0> <lat0> points from input columns 3-4.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Append +a to force accumulated distsances, +i to force incremental distances, or both to get both distances.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Give unit as arc (d)egree, m(e)ter, (f)oot, (k)m, arc (m)inute, (M)ile, (n)autical mile, s(u)rvey foot,\n\t   arc (s)econd, or (c)artesian [e].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Unit C means Cartesian distances after first projecting the input coordinates (-R, -J).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Unit C means Cartesian distances after projecting the input coordinates to plot coordinates (requires -R, -J).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Inverse mode, i.e., get lon/lat from x/y input. [Default is lon/lat -> x/y].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-L Calculate minimum distances to specified line(s) in the file <table>.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +u<unit> as arc (d)egree, m(e)ter, (f)oot, (k)m, arc (m)inute, (M)ile, (n)autical mile, s(u)rvey foot, arc (s)econd, or (c)artesian [e].\n");
@@ -323,15 +324,25 @@ GMT_LOCAL unsigned int old_L_parse (struct GMTAPI_CTRL *API, char *arg, struct M
 }
 
 GMT_LOCAL bool is_old_G (struct GMT_CTRL *GMT, char *arg) {
-	/* -G[<lon0/lat0>][/[+|-]unit][+|-] */
+	/* Return true if we find:  -G[<lon0/lat0>/][[+|-]unit][+|-]
+	 * Return false if we find: -G[<lon0/lat0>][+i][+a][+u<unit>][+v] */
 	size_t len = strlen (arg);
 	unsigned int n_slashes;
-	if (len == 0) return false;
-	if (arg[0] == '/') return true;
-	if (strchr ("-+", arg[len-1])) return true;
+	if (len == 0) return false;	/* Might as well parse as modern syntax */
+	/* If any of the modern modifiers +a|i|u|v given then it is the new way */
 	if (strstr (arg, "+a") || strstr (arg, "+i") || strstr (arg, "+u") || strstr (arg, "+v")) return false;
+	/* If no point given and we just get -G<unit> then it is the old way */
+	if (strchr (GMT_LEN_UNITS, arg[0])) return true;
+	/* Check if we have a leading + before a valid unit: This is the old way of saying ellipsoidal distances in that unit */
+	if (strstr (arg, "+d") || strstr (arg, "+m") || strstr (arg, "+s") || strstr (arg, "+e") || strstr (arg, "+f") || strstr (arg, "+k") || \
+		strstr (arg, "+M") || strstr (arg, "+n") || strstr (arg, "+u")) return true;
+	/* Check if we have a leading - before a valid unit: This is the old way of saying flat earth distances in that unit */
+	if (strstr (arg, "-d") || strstr (arg, "-m") || strstr (arg, "-s") || strstr (arg, "-e") || strstr (arg, "-f") || strstr (arg, "-k") || \
+		strstr (arg, "-M") || strstr (arg, "-n") || strstr (arg, "-u")) return true;
+	if (arg[0] == '/') return true;	/* DOn't this this was ever correct but the old usage said so */
+	if (strchr ("-+", arg[len-1])) return true;	/* If last char is - or + it means the old way of saying incremental vs accumulated distances */
 	n_slashes = gmt_count_char (GMT, arg, '/');	/* Count slashes */
-	if (n_slashes == 3) return true;
+	if (n_slashes == 3) return true;	/* Leading point plus more stuff is the old way */
 	return false;
 }
 
@@ -523,7 +534,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct 
 					if (q) q[2] = '+';
 					p[0] = '\0';	/* Chop off all modifiers */
 					/* Here, opt->arg is -G[<lon0/lat0>] */
-					if (n_slash == 1) {	/* Got -G<lon0/lat0> so we were given a fixed point */
+					if (opt->arg[0]) /* Just gave -G, should mean -G+ue+a */
+						Ctrl->G.mode |= GMT_MP_CUMUL_DIST;
+					else if (n_slash == 1) {	/* Got -G<lon0/lat0> so we were given a fixed point */
 						Ctrl->G.mode |= GMT_MP_FIXED_POINT;
 						n = sscanf (opt->arg, "%[^/]/%s", txt_a, txt_b);
 						if (Ctrl->G.unit == 'c') gmt_set_cartesian (GMT, GMT_IN);	/* Cartesian input */
@@ -541,6 +554,8 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct 
 						Ctrl->G.mode |= GMT_MP_VAR_POINT;
 						if ((Ctrl->G.mode & GMT_MP_INCR_DIST) == 0) Ctrl->G.mode |= GMT_MP_CUMUL_DIST;
 					}
+					else if ((Ctrl->G.mode & GMT_MP_PAIR_DIST) && (Ctrl->G.mode & GMT_MP_CUMUL_DIST) == 0)
+						Ctrl->G.mode |= GMT_MP_INCR_DIST;
 					else {
 						if ((Ctrl->G.mode & GMT_MP_INCR_DIST) == 0) Ctrl->G.mode |= GMT_MP_CUMUL_DIST;
 					}
@@ -1152,7 +1167,7 @@ int GMT_mapproject (void *V_API, int mode, void *args) {
 		Return (API->error);
 	}
 	along_track = (Ctrl->G.mode && ((Ctrl->G.mode & GMT_MP_CUMUL_DIST) || (Ctrl->G.mode & GMT_MP_INCR_DIST)));
-	if ((Ctrl->G.mode & GMT_MP_PAIR_DIST) && (Ctrl->G.mode & GMT_MP_INCR_DIST)) along_track = false;	/* Not along track (i.e., per record) when doing it per record */
+	//if ((Ctrl->G.mode & GMT_MP_PAIR_DIST) && (Ctrl->G.mode & GMT_MP_INCR_DIST)) along_track = false;	/* Not along track (i.e., per record) when doing it per record */
 	n = n_read_in_seg = 0;
 	out = gmt_M_memory (GMT, NULL, GMT_MAX_COLUMNS, double);
 	Out->data = out;

--- a/src/x2sys/test_x2sys.sh
+++ b/src/x2sys/test_x2sys.sh
@@ -12,13 +12,13 @@ delete=0	# Set to 0 for debug where files are not removed
 gmt grdmath -R-4/4/-4/4 -I0.1 0 0 CDIST DUP DUP MUL NEG 4 DIV EXP EXCH 3 MUL COS MUL = hat.nc
 
 # 2. Create 3 fake tracks
-cat << EOF | gmt mapproject -Gc | gmt sample1d -Fl -T2 -I0.1 | gmt grdtrack -Ghat.nc > trackA.xydz
+cat << EOF | gmt mapproject -G+uc | gmt sample1d -Fl -T2 -I0.1 | gmt grdtrack -Ghat.nc > trackA.xydz
 -3	-3
 3	3
 3	1
 -2	1
 EOF
-cat << EOF | gmt mapproject -Gc | gmt sample1d -Fl -T2 -I0.1 | gmt grdtrack -Ghat.nc > trackB.xydz
+cat << EOF | gmt mapproject -G+uc | gmt sample1d -Fl -T2 -I0.1 | gmt grdtrack -Ghat.nc > trackB.xydz
 3	-1
 0	2
 0	-2
@@ -26,7 +26,7 @@ cat << EOF | gmt mapproject -Gc | gmt sample1d -Fl -T2 -I0.1 | gmt grdtrack -Gha
 EOF
 # THrow in a wrench by scaling the grid by 1.1 before sampling track C:
 gmt grdmath hat.nc 1.1 MUL = $$.nc
-cat << EOF | gmt mapproject -Gc | gmt sample1d -Fl -T2 -I0.1 | gmt grdtrack -G$$.nc > trackC.xydz
+cat << EOF | gmt mapproject -G+uc | gmt sample1d -Fl -T2 -I0.1 | gmt grdtrack -G$$.nc > trackC.xydz
 -3	-1
 2	-1
 2	3


### PR DESCRIPTION
**Description of proposed changes**

This PR addresses the concerns in #2676 by ensuring that the **-G** defaults are honored, that the old deprecated syntax is correctly processed, and that a 2nd distance column is added when both **+a** and **+i** are used.  Some tests were adjusted to use modern syntax and the documentation and usage were clarified as well.
