### PR TITLE
Change many error messages to warnings

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -678,7 +678,7 @@ GMT_LOCAL void gmtapi_check_for_modern_oneliner (struct GMTAPI_CTRL *API, const 
 		API->GMT->current.setting.use_modern_name = true;
 
 	if (GMT_Destroy_Options (API, &head))	/* Done with these here */
-		GMT_Report (API, GMT_MSG_ERROR, "Unable to free options in gmtapi_check_for_modern_oneliner?\n");
+		GMT_Report (API, GMT_MSG_WARNING, "Unable to free options in gmtapi_check_for_modern_oneliner?\n");
 }
 
 /* Function to get PPID under Windows is a bit different */
@@ -1304,7 +1304,7 @@ GMT_LOCAL char **api_process_keys (void *V_API, const char *string, char type, s
 	k = 0;
 	while ((next = strsep (&tmp, ",")) != NULL) {	/* Get each comma-separated key */
 		if (strlen (next) < 3) {
-			GMT_Report (API, GMT_MSG_ERROR,
+			GMT_Report (API, GMT_MSG_WARNING,
 			            "api_process_keys: Key %s contains less than 3 characters\n", next);
 			continue;
 		}
@@ -1321,7 +1321,7 @@ GMT_LOCAL char **api_process_keys (void *V_API, const char *string, char type, s
 		s[k] = strdup (next);
 		if (next[K_DIR] == API_PRIMARY_OUTPUT) {	/* Identified primary output key */
 			if (o_id >= 0)	/* Already had a primary output key */
-				GMT_Report (API, GMT_MSG_ERROR,
+				GMT_Report (API, GMT_MSG_WARNING,
 				            "api_process_keys: Keys %s contain more than one primary output key\n", tmp);
 			else
 				o_id = (int)k;
@@ -1348,7 +1348,7 @@ GMT_LOCAL char **api_process_keys (void *V_API, const char *string, char type, s
 				}
 			}
 			else
-				GMT_Report (API, GMT_MSG_ERROR,
+				GMT_Report (API, GMT_MSG_WARNING,
 				            "api_process_keys: Required runtime type-getting option (-%c) was not given\n", s[k][K_FAMILY]);
 			gmt_M_str_free (s[k]);		/* Free the inactive key that has now served its purpose */
 		}
@@ -1378,7 +1378,7 @@ GMT_LOCAL char **api_process_keys (void *V_API, const char *string, char type, s
 				char modifier[3] = {'+', '?', 0};	/* We will replace ? with an actual modifier */
 				size_t this_k;
 				if (o_id == GMT_NOTSET)
-					GMT_Report (API, GMT_MSG_ERROR, "api_process_keys: No primary output identified but magic Z key present\n");
+					GMT_Report (API, GMT_MSG_WARNING, "api_process_keys: No primary output identified but magic Z key present\n");
 				/* Check if modifier(s) were given also and that one of them were selected */
 				if (strlen (s[k]) > 3) {	/* Not enough to just find option, must examine the modifiers */
 					/* Full syntax: XYZ+abc...-def...: We do the substitution of output type to Y only if
@@ -1458,7 +1458,7 @@ GMT_LOCAL int api_get_key (void *API, char option, char *keys[], int n_keys) {
 	/* Returns the position in the keys array that matches this option, or GMT_NOTSET if not found */
 	int k;
 	if (n_keys && keys == NULL)
-		GMT_Report (API, GMT_MSG_ERROR, "api_get_key: Keys array is NULL but n_keys = %d\n", n_keys);
+		GMT_Report (API, GMT_MSG_WARNING, "api_get_key: Keys array is NULL but n_keys = %d\n", n_keys);
 	for (k = 0; keys && k < n_keys; k++) if (keys[k][K_OPT] == option) return (k);
 	return (GMT_NOTSET);
 }
@@ -2130,7 +2130,7 @@ GMT_LOCAL void api_dataset_comment (struct GMTAPI_CTRL *API, unsigned int mode, 
 	if (api_add_comment (API, mode, txt)) return;	/* Updated one -h item, or nothing */
 
 	if (D->table == NULL) {
-		GMT_Report (API, GMT_MSG_ERROR, "api_dataset_comment: Trying to access an empty D->table object\n");
+		GMT_Report (API, GMT_MSG_WARNING, "api_dataset_comment: Trying to access an empty D->table object\n");
 		return;
 	}
 
@@ -2244,7 +2244,7 @@ GMT_LOCAL int api_next_io_source (struct GMTAPI_CTRL *API, unsigned int directio
 				operation[direction+first], GMT_family[S_obj->family], dir[direction], &(S_obj->filename[first]));
 			if (gmt_M_binary_header (GMT, direction)) {
 				gmtlib_io_binary_header (GMT, S_obj->fp, direction);
-				GMT_Report (API, GMT_MSG_ERROR, "%s %d bytes of header %s binary file %s\n",
+				GMT_Report (API, GMT_MSG_INFORMATION, "%s %d bytes of header %s binary file %s\n",
 					operation[direction], GMT->current.setting.io_n_header_items, dir[direction], &(S_obj->filename[first]));
 			}
 			break;
@@ -2260,7 +2260,7 @@ GMT_LOCAL int api_next_io_source (struct GMTAPI_CTRL *API, unsigned int directio
 				operation[direction], GMT_family[S_obj->family], dir[direction], GMT_stream[kind], GMT_direction[direction]);
 			if (gmt_M_binary_header (GMT, direction)) {
 				gmtlib_io_binary_header (GMT, S_obj->fp, direction);
-				GMT_Report (API, GMT_MSG_ERROR, "%s %d bytes of header %s binary %s stream\n",
+				GMT_Report (API, GMT_MSG_INFORMATION, "%s %d bytes of header %s binary %s stream\n",
 					operation[direction], GMT->current.setting.io_n_header_items, dir[direction], GMT_stream[kind]);
 			}
 			break;
@@ -2278,7 +2278,7 @@ GMT_LOCAL int api_next_io_source (struct GMTAPI_CTRL *API, unsigned int directio
 				operation[direction], GMT_family[S_obj->family], dir[direction], GMT_stream[kind], GMT_direction[direction]);
 			if (gmt_M_binary_header (GMT, direction)) {
 				gmtlib_io_binary_header (GMT, S_obj->fp, direction);
-				GMT_Report (API, GMT_MSG_ERROR, "%s %d bytes of header %s binary %s stream via supplied file descriptor\n",
+				GMT_Report (API, GMT_MSG_INFORMATION, "%s %d bytes of header %s binary %s stream via supplied file descriptor\n",
 					operation[direction], GMT->current.setting.io_n_header_items, dir[direction], GMT_stream[kind]);
 			}
 			break;
@@ -2457,7 +2457,7 @@ GMT_LOCAL void *api_pass_object (struct GMTAPI_CTRL *API, struct GMTAPI_DATA_OBJ
 	struct GMT_GRID_HEADER_HIDDEN *HH = NULL;
 
 	if (object->resource == NULL)
-		GMT_Report (API, GMT_MSG_ERROR, "ERROR?: api_pass_object given a NULL resource!\n");
+		GMT_Report (API, GMT_MSG_ERROR, "api_pass_object given a NULL resource!\n");
 
 	switch (family) {	/* Do family-specific prepping before passing back the input object */
 		case GMT_IS_PALETTE:	/* Make sure the hidden support arrays etc. have been initialized as external interfaces may not care */
@@ -2502,7 +2502,7 @@ GMT_LOCAL void *api_pass_object (struct GMTAPI_CTRL *API, struct GMTAPI_DATA_OBJ
 				if (gmt_grd_is_global (API->GMT, I->header)) {	/* May have to rotate geographic grid since we are not reading from file here */
 					double shift_amount = wesn[XLO] - I->header->wesn[XLO];
 					if (fabs (shift_amount) >= I->header->inc[GMT_X]) {	/* Must do it */
-						GMT_Report (API, GMT_MSG_ERROR, "Longitudinal roll for images not implemented yet\n");
+						GMT_Report (API, GMT_MSG_WARNING, "Longitudinal roll for images not implemented yet\n");
 #if 0
 						GMT_Report (API, GMT_MSG_DEBUG, "Shifting longitudes in grid by %g degrees to fit -R\n", shift_amount);
 						gmt_grd_shift (API->GMT, I, shift_amount);
@@ -4171,8 +4171,8 @@ GMT_LOCAL int api_export_dataset (struct GMTAPI_CTRL *API, int object_ID, unsign
 				GMT_Report (API, GMT_MSG_WARNING, "Row-selection via -qo is not implemented for GMT_IS_REFERENCE|GMT_VIA_VECTOR external memory objects\n");
 			GMT_Report (API, GMT_MSG_DEBUG, "Referencing data table to users column-vector location\n");
 			if (D_obj->n_tables > 1 || D_obj->n_segments > 1) {
-				GMT_Report (API, GMT_MSG_ERROR, "Reference by vector requires a single segment!\n");
-				GMT_Report (API, GMT_MSG_ERROR, "Output may be truncated or an error may occur!\n");
+				GMT_Report (API, GMT_MSG_WARNING, "Reference by vector requires a single segment!\n");
+				GMT_Report (API, GMT_MSG_WARNING, "Output may be truncated or an error may occur!\n");
 			}
 			GMT_Report (API, GMT_MSG_INFORMATION, "Duplicating data table to user column arrays location\n");
 			n_columns = (GMT->common.o.select) ? GMT->common.o.n_cols : D_obj->n_columns;	/* Number of columns needed to hold the data records */
@@ -5748,7 +5748,7 @@ void gmtapi_garbage_collection (struct GMTAPI_CTRL *API, int level) {
 	while (i < API->n_objects) {	/* While there are more objects to consider */
 		S_obj = API->object[i];	/* Shorthand for the the current object */
 		if (!S_obj) {		/* Skip empty object [NOTE: Should not happen?] */
-			GMT_Report (API, GMT_MSG_ERROR, "gmtapi_garbage_collection found empty object number %d [Bug?]\n", i++);
+			GMT_Report (API, GMT_MSG_WARNING, "gmtapi_garbage_collection found empty object number %d [Bug?]\n", i++);
 			continue;
 		}
 		if (!(level == GMT_NOTSET || S_obj->alloc_level == u_level)) {	/* Not the right module level (or not end of session yet) */
@@ -5779,7 +5779,7 @@ void gmtapi_garbage_collection (struct GMTAPI_CTRL *API, int level) {
 		}
 
 		if (error < 0) {	/* Failed to destroy this memory; that cannot be a good thing... */
-			GMT_Report (API, GMT_MSG_ERROR, "gmtapi_garbage_collection failed to destroy memory for object % d [Bug?]\n", i++);
+			GMT_Report (API, GMT_MSG_WARNING, "gmtapi_garbage_collection failed to destroy memory for object % d [Bug?]\n", i++);
 			/* Skip it for now; but this is possibly a fatal error [Bug]? */
 		}
 		else  {	/* Successfully freed.  See if this address occurs more than once (e.g., both for in and output); if so just set repeated data pointer to NULL */
@@ -8203,7 +8203,7 @@ GMT_LOCAL int api_put_record_init (struct GMTAPI_CTRL *API, unsigned int mode, s
 				return GMT_NOERROR;
 			}
 			if (S_obj->n_rows && S_obj->rec >= S_obj->n_rows)
-				GMT_Report (API, GMT_MSG_ERROR, "GMTAPI: GMT_Put_Record exceeding limits on rows(?) - possible bug\n");
+				GMT_Report (API, GMT_MSG_WARNING, "GMTAPI: GMT_Put_Record exceeding limits on rows(?) - possible bug\n");
 			if (S_obj->resource == NULL) {	/* First time allocating space; S_obj->n_rows == S_obj->n_alloc == 0 */
 				size_t size;
 				col = (GMT->common.o.select) ? GMT->common.o.n_cols : GMT->common.b.ncol[GMT_OUT];	/* Number of columns needed to hold the data records */
@@ -8245,7 +8245,7 @@ GMT_LOCAL int api_put_record_init (struct GMTAPI_CTRL *API, unsigned int mode, s
 				return GMT_NOERROR;
 			}
 			if (S_obj->n_rows && S_obj->rec >= S_obj->n_rows)
-				GMT_Report (API, GMT_MSG_ERROR, "GMTAPI: GMT_Put_Record exceeding limits on rows(?) - possible bug\n");
+				GMT_Report (API, GMT_MSG_WARNING, "GMTAPI: GMT_Put_Record exceeding limits on rows(?) - possible bug\n");
 			if ((V_obj = S_obj->resource) == NULL) {	/* First time allocating space; S_obj->n_rows == S_obj->n_alloc == 0 */
 				col = (GMT->common.o.select) ? GMT->common.o.n_cols : GMT->common.b.ncol[GMT_OUT];	/* Number of columns needed to hold the data records */
 				if (col == 0 && mode == GMT_WRITE_SEGMENT_HEADER && GMT->current.io.multi_segments[GMT_OUT]) {
@@ -10641,7 +10641,7 @@ struct GMT_RESOURCE *GMT_Encode_Options (void *V_API, const char *module_name, i
 		if (k >= 0) {	/* Got a key, so split out family and geometry flags */
 			sdir = api_key_to_family (API, key[k], &family, &geometry);	/* Get dir, datatype, and geometry */
 			if (sdir < 0) {	/* Could not determine direction */
-				GMT_Report (API, GMT_MSG_ERROR, "GMT_Encode_Options: Key not understood so direction is undefined? Notify developers\n");
+				GMT_Report (API, GMT_MSG_WARNING, "GMT_Encode_Options: Key not understood so direction is undefined? Notify developers\n");
 				sdir = GMT_IN;
 			}
 			direction = (unsigned int) sdir;
@@ -10667,7 +10667,7 @@ struct GMT_RESOURCE *GMT_Encode_Options (void *V_API, const char *module_name, i
 				direction = GMT_IN;
 			}
 			else if (k == GMT_NOTSET) {	/* Found questionmark but no corresponding key found? */
-				GMT_Report (API, GMT_MSG_ERROR, "GMT_Encode_Options: Got a -<option>? argument but not listed in keys\n");
+				GMT_Report (API, GMT_MSG_WARNING, "GMT_Encode_Options: Got a -<option>? argument but not listed in keys\n");
 				direction = GMT_IN;	/* Have to assume it is an input file if not specified */
 			}
 			info[n_items].mode = (k >= 0 && api_is_required_IO (key[k][K_DIR])) ? K_PRIMARY : K_SECONDARY;
@@ -10758,7 +10758,7 @@ struct GMT_RESOURCE *GMT_Encode_Options (void *V_API, const char *module_name, i
 		if (api_is_required_IO (key[ku][K_DIR])) {	/* Required input|output that was not specified explicitly above */
 			char str[2] = {'?',0};
 			if ((sdir = api_key_to_family (API, key[ku], &family, &geometry)) == GMT_NOTSET) {	/* Extract family and geometry */
-				GMT_Report (API, GMT_MSG_ERROR, "Failure to extract family, geometry, and direction!!!!\n");
+				GMT_Report (API, GMT_MSG_WARNING, "Failure to extract family, geometry, and direction!!!!\n");
 				continue;
 			}
 			direction = (unsigned int) sdir;
@@ -12137,7 +12137,7 @@ GMT_LOCAL int api_change_gridlayout (struct GMTAPI_CTRL *API, char *code, unsign
 				tmp[out_node] = G->data[(uint64_t)col * (uint64_t)G->header->n_rows + (G->header->n_rows - row - 1)];
 	}
 	else {		/* Other cases to be added later ...*/
-		GMT_Report (API, GMT_MSG_ERROR, "api_change_gridlayout: reordering function for case %s -> %s not yet written. Doing nothing\n",
+		GMT_Report (API, GMT_MSG_WARNING, "api_change_gridlayout: reordering function for case %s -> %s not yet written. Doing nothing\n",
 		            G->header->mem_layout, code);
 		for (out_node = 0; out_node < G->header->size; out_node++)
 			tmp[out_node] = G->data[out_node];
@@ -12202,7 +12202,7 @@ GMT_LOCAL int api_change_imagelayout (struct GMTAPI_CTRL *API, char *code, unsig
 	}
 	//else if (old_layout == 2 && new_layout == 0) {}	/* Change from TCB to TRB */
 	else {		/* Other cases to be added later ...*/
-		GMT_Report (API, GMT_MSG_ERROR, "api_change_imagelayout: reordering function for case %s -> %s not yet written. Doing nothing.\n",
+		GMT_Report (API, GMT_MSG_WARNING, "api_change_imagelayout: reordering function for case %s -> %s not yet written. Doing nothing.\n",
 		            I->header->mem_layout, code);
 		for (out_node = 0; out_node < I->header->size; out_node++)
 			tmp[out_node] = I->data[out_node];

--- a/src/gmt_calclock.c
+++ b/src/gmt_calclock.c
@@ -1000,7 +1000,7 @@ void gmtlib_get_time_label (struct GMT_CTRL *GMT, char *string, struct GMT_PLOT_
 				gmt_format_calendar (GMT, NULL, string, &P->date, &P->clock, T->upper_case, T->flavor, t);
 			}
 			else {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Wrong unit passed to gmtlib_get_time_label\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Wrong unit passed to gmtlib_get_time_label - return NaN\n");
 				sprintf (string, "NaN");
 			}
 			break;
@@ -1013,7 +1013,7 @@ void gmtlib_get_time_label (struct GMT_CTRL *GMT, char *string, struct GMT_PLOT_
 				(P->date.compact) ? sprintf (string, "%d", irint(calendar.sec)) : sprintf (string, "%02d", irint(calendar.sec));
 			}
 			else {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Wrong unit passed to gmtlib_get_time_label\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Wrong unit passed to gmtlib_get_time_label - return NaN\n");
 				sprintf (string, "NaN");
 			}
 			break;
@@ -1021,7 +1021,7 @@ void gmtlib_get_time_label (struct GMT_CTRL *GMT, char *string, struct GMT_PLOT_
 			(P->date.compact) ? sprintf (string, "%d", irint(calendar.sec)) : sprintf (string, "%02d", irint(calendar.sec));
 			break;
 		default:
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Wrong unit passed to gmtlib_get_time_label\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Wrong unit passed to gmtlib_get_time_label - return NaN\n");
 			sprintf (string, "NaN");
 			break;
 	}

--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -283,7 +283,7 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 				if (n_items)
 					GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Continent code expanded from %s to %s [%d countries]\n", F->item[j]->codes, list, n_items);
 				else
-					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Continent code %s unrecognized\n", code);
+					GMT_Report (GMT->parent, GMT_MSG_WARNING, "Continent code %s unrecognized\n", code);
 			}
 			else {	/* Just append this single one */
 				if (n_items) strcat (list, ",");
@@ -375,13 +375,13 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 		}
 		ks = dcw_find_country (code, GMT_DCW_country, GMT_DCW_COUNTRIES);
 		if (ks == -1) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "No country code matching %s (skipped)\n", code);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "No country code matching %s (skipped)\n", code);
 			continue;
 		}
 		k = ks;
 		if (want_state) {
 			if ((item = dcw_find_state (state, code, GMT_DCW_state, GMT_DCW_STATES)) == -1) {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Country %s does not have states (skipped)\n", code);
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Country %s does not have states (skipped)\n", code);
 				continue;
 			}
 			snprintf (TAG, GMT_LEN16, "%s%s", GMT_DCW_country[k].code, GMT_DCW_state[item].code);

--- a/src/gmt_gdalread.c
+++ b/src/gmt_gdalread.c
@@ -1107,7 +1107,7 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 
 			if ((gdal_code = GDALRasterIO(hBand, GF_Read, xOrigin, nYOff, nXSize, buffy, tmp,
 		                 nBufXSize, buffy, GDALGetRasterDataType(hBand), 0, 0)) != CE_None) {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "GDALRasterIO failed to open band %d [err = %d]\n", i, gdal_code);
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "GDALRasterIO failed to open band %d [err = %d]\n", i, gdal_code);
 				continue;
 			}
 

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -175,7 +175,7 @@ GMT_LOCAL void grdio_grd_parse_xy_units (struct GMT_CTRL *GMT, struct GMT_GRID_H
 	mode = (c[1] == 'u') ? 0 : 1;
 	u_number = gmtlib_get_unit_number (GMT, c[2]);		/* Convert char unit to enumeration constant for this unit */
 	if (u_number == GMT_IS_NOUNIT) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Grid file x/y unit specification %s was unrecognized (part of file name?) and is ignored.\n", c);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Grid file x/y unit specification %s was unrecognized (part of file name?) and is ignored.\n", c);
 		return;
 	}
 	/* Got a valid unit */
@@ -932,7 +932,7 @@ void gmt_grd_mux_demux (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gm
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (header);
 
 	if (! (desired_mode == GMT_GRID_IS_INTERLEAVED || desired_mode == GMT_GRID_IS_SERIAL)) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_grd_mux_demux called with inappropriate mode - skipped.\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_grd_mux_demux called with inappropriate mode - skipped.\n");
 		return;
 	}
 	if ((header->complex_mode & GMT_GRID_IS_COMPLEX_MASK) == 0) return;	/* Nuthin' to do */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -676,7 +676,7 @@ GMT_LOCAL void gmtinit_kw_replace (struct GMTAPI_CTRL *API, struct GMT_KEYWORD_D
 					if ((code = gmtinit_find_argument (API, kw[k].long_modifiers, kw[k].short_modifiers, item, '=', argument)))	/* Get the modifier, or return 0 if unrecognized */
 						sprintf (add, "+%c%s", code, argument);	/* Append modifier with argument next to it (may be empty) */
 					else {
-						GMT_Report (API, GMT_MSG_ERROR, "Long-modifier form %s for option -%c not recognized!\n", &directive[1], opt->option);
+						GMT_Report (API, GMT_MSG_WARNING, "Long-modifier form %s for option -%c not recognized!\n", &directive[1], opt->option);
 						add[0] = '\0';
 					}
 					strcat (new_arg, add);	/* Add to the short-format option argument */
@@ -753,7 +753,7 @@ GMT_LOCAL int gmtinit_parse_h_option (struct GMT_CTRL *GMT, char *item) {
 		c[0] = '\0';	/* Truncate modifiers for now */
 	if (isdigit (item[k])) {	/* Specified how many records for input */
 		if (col == GMT_OUT) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Can only set the number of input header records; %s ignored\n", &item[k]);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Can only set the number of input header records; %s ignored\n", &item[k]);
 		}
 		else {
 			i = atoi (&item[k]);
@@ -3011,7 +3011,7 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 		/* If HOME not set: use root directory instead (http://gmt.soest.hawaii.edu/issues/710) */
 		GMT->session.HOMEDIR = strdup ("/"); /* Note: Windows will use the current drive if drive letter unspecified. */
 #ifdef DEBUG
-		GMT_Report (API, GMT_MSG_ERROR, "HOME environment not set. Using root directory instead.\n");
+		GMT_Report (API, GMT_MSG_WARNING, "HOME environment not set. Using root directory instead.\n");
 #endif
 	}
 	if (GMT->session.HOMEDIR) {	/* Mostly to keep Coverity happy */
@@ -3036,8 +3036,8 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 	if (GMT->session.USERDIR != NULL) {
 		err = stat (GMT->session.USERDIR, &S);	/* Stat the userdir path (which may not exist) */
 		if (err == ENOENT && gmt_mkdir (GMT->session.USERDIR)) { /* Path does not exist so we create that dir */
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to create GMT User directory : %s\n", GMT->session.USERDIR);
-			GMT_Report (API, GMT_MSG_ERROR, "Auto-downloading of @earth_relief_##m|s.grd files has been disabled.\n");
+			GMT_Report (API, GMT_MSG_WARNING, "Unable to create GMT User directory : %s\n", GMT->session.USERDIR);
+			GMT_Report (API, GMT_MSG_WARNING, "Auto-downloading of @earth_relief_##m|s.grd files has been disabled.\n");
 			GMT->current.setting.auto_download = GMT_NO_DOWNLOAD;
 			gmt_M_str_free (GMT->session.USERDIR);
 		}
@@ -3056,8 +3056,8 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 	if (GMT->session.CACHEDIR != NULL) {
 		err = stat (GMT->session.CACHEDIR, &S);	/* Stat the cachedir path (which may not exist) */
 		if (err == ENOENT && gmt_mkdir (GMT->session.CACHEDIR)) {	/* Path does not exist so we create that dir */
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to create GMT User cache directory : %s\n", GMT->session.CACHEDIR);
-			GMT_Report (API, GMT_MSG_ERROR, "Auto-downloading of cache data has been disabled.\n");
+			GMT_Report (API, GMT_MSG_WARNING, "Unable to create GMT User cache directory : %s\n", GMT->session.CACHEDIR);
+			GMT_Report (API, GMT_MSG_WARNING, "Auto-downloading of cache data has been disabled.\n");
 			GMT->current.setting.auto_download = GMT_NO_DOWNLOAD;
 			gmt_M_str_free (GMT->session.CACHEDIR);
 		}
@@ -3071,7 +3071,7 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 	}
 	else {	/* Use the temp dir as the session dir */
 		API->session_dir = gmt_strdup_noquote (API->tmp_dir);
-		GMT_Report (API, GMT_MSG_ERROR, "No GMT User directory set, GMT session dir selected: %s\n", API->session_dir);
+		GMT_Report (API, GMT_MSG_WARNING, "No GMT User directory set, GMT session dir selected: %s\n", API->session_dir);
 	}
 	if (API->session_dir) {
 		gmt_dos_path_fix (API->session_dir);
@@ -5172,7 +5172,7 @@ GMT_LOCAL int gmtinit_parse_text (struct GMT_CTRL *GMT, char *text, struct GMT_S
 			if ((c = strchr (text, '%'))) {	/* Gave font name or number, too */
 				*c = 0;	/* Chop off the %font info */
 				c++;		/* Go to next character */
-				if (gmt_getfont (GMT, c, &S->font)) GMT_Report (GMT->parent, GMT_MSG_ERROR, "-Sl contains bad font (set to %s)\n", gmt_putfont (GMT, &S->font));
+				if (gmt_getfont (GMT, c, &S->font)) GMT_Report (GMT->parent, GMT_MSG_WARNING, "-Sl contains bad font (set to %s)\n", gmt_putfont (GMT, &S->font));
 			}
 			/* Look for a slash that separates size and string: */
 			for (j = 1, slash = 0; text[j] && !slash; j++) if (text[j] == '/') slash = j;
@@ -5203,7 +5203,7 @@ GMT_LOCAL int gmtinit_parse_text (struct GMT_CTRL *GMT, char *text, struct GMT_S
 			switch (p[0]) {
 				case 'f':	/* Change font */
 					if (gmt_getfont (GMT, &p[1], &S->font))
-						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -Sl contains bad +<font> modifier (set to %s)\n", gmt_putfont (GMT, &S->font));
+						GMT_Report (GMT->parent, GMT_MSG_WARNING, "Option -Sl contains bad +<font> modifier (set to %s)\n", gmt_putfont (GMT, &S->font));
 					break;
 				case 'j':	S->justify = gmt_just_decode (GMT, &p[1], PSL_NO_DEF);	break;	/* text justification */
 				case 't':	strncpy (S->string, &p[1], GMT_LEN256-1);	break;	/* Get the symbol text */
@@ -8016,7 +8016,7 @@ int gmt_parse_R_option (struct GMT_CTRL *GMT, char *arg) {
 		if (n_rect_read == 4 && (fabs (rect[XLO]) > 360.0 || fabs (rect[XHI]) > 360.0 || fabs (rect[YLO]) > 90.0 || fabs (rect[YHI]) > 90.0)) {	/* Oh, yeah... */
 			inv_project = true;
 			r_unit = 'e';	/* Must specify the "missing" leading e for meter */
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "For a UTM or TM projection, your region %s is too large to be in degrees and thus assumed to be in meters\n", string);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "For a UTM or TM projection, your region %s is too large to be in degrees and thus assumed to be in meters\n", string);
 		}
 	}
 	else {	/* Plain old -Rw/e/s/n */
@@ -10252,7 +10252,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			else if (!strncmp (lower_value, "off", 3))
 				GMT->current.setting.auto_download = GMT_NO_DOWNLOAD;
 			else {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "GMT_AUTO_DOWNLOAD: Expects either on or off - set to off\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "GMT_AUTO_DOWNLOAD: Expects either on or off - set to off\n");
 				GMT->current.setting.auto_download = GMT_NO_DOWNLOAD;
 			}
 			break;
@@ -10344,7 +10344,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			else
 				error = true;
 			if (error) {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "GMT_EXTRAPOLATE_VAL: resetting to 'extrapolated is NaN' to avoid later crash.\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "GMT_EXTRAPOLATE_VAL: resetting to 'extrapolated is NaN' to avoid later crash.\n");
 				GMT->current.setting.extrapolate_val[0] = GMT_EXTRAPOLATE_NONE;
 			}
 			break;
@@ -11222,7 +11222,7 @@ char *gmtlib_putparameter (struct GMT_CTRL *GMT, const char *keyword) {
 			break;
 		case GMTCASE_TRANSPARENCY:
 			if (gmt_M_compat_check (GMT, 4))
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Transparency is now part of pen and fill specifications.  TRANSPARENCY is ignored\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Transparency is now part of pen and fill specifications.  TRANSPARENCY is ignored\n");
 			else
 				error = gmtinit_badvalreport (GMT, keyword);
 			break;
@@ -14055,7 +14055,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 		else if (n == 1)
 			p->size_y = p->given_size_y = p->size_x;
 		else
-			decode_error = true;
+			decode_error++;
 		symbol_type = '*';
 		if (cmd) p->read_symbol_cmd = 1;
 	}
@@ -14077,7 +14077,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 		else {
 			n = sscanf (&text_cp[1], "%[^+]+%*s", txt_a);
 			p->size_x = p->given_size_x = gmt_M_to_inch (GMT, txt_a);
-			decode_error = (n != 1);
+			decode_error += (n != 1);
 		}
 	}
 	else if (text[0] == 'k' || text[0] == 'K') {	/* Custom symbol spec -Sk|K<path_to_custom_symbol>[/<size>]*/
@@ -14141,7 +14141,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 		if (text[k] && strchr (GMT_DIM_UNITS, (int) text[k])) {	/* No size given, only unit information */
 			if (p->size_x == 0.0) p->size_x = p->given_size_x;
 			if (p->size_y == 0.0) p->size_y = p->given_size_y;
-			if ((j = gmtinit_get_unit (GMT, text[k])) < 0) decode_error = true; else { p->u = j; p->u_set = true;}
+			if ((j = gmtinit_get_unit (GMT, text[k])) < 0) decode_error++; else { p->u = j; p->u_set = true;}
 			col_off++;
 			if (cmd) p->read_size_cmd = true;
 		}
@@ -14164,7 +14164,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 		if (p->size_y == 0.0) p->size_y = p->given_size_y;
 		if (text[1]) {	/* Gave unit information */
 			if ((j = gmtinit_get_unit (GMT, text[1])) < 0)
-				decode_error = true;
+				decode_error++;
 			else {
 				p->u = j; p->u_set = true;
 			}
@@ -14204,7 +14204,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 		}
 		if (slash) {	/* Separate x/y sizes */
 			n = sscanf (text_cp, "%c%[^/]/%s", &symbol_type, txt_a, txt_b);
-			decode_error = (n != 3);
+			decode_error += (n != 3);
 			if (((len = (int)strlen (txt_a)) > 0) && txt_a[len-1] == 'u') {
 				p->user_unit[GMT_X] = true;	/* Specified xwidth in user units */
 				txt_a[len-1] = '\0';	/* Chop off the 'u' */
@@ -14325,7 +14325,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 			else if (n == 2)
 				p->size_y = p->given_size_y = p->size_x;
 			else
-				decode_error = true;
+				decode_error++;
 		}
 	}
 	switch (symbol_type) {
@@ -14586,7 +14586,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 				}
 			}
 			if (mode == 0) {
-				decode_error = true;
+				decode_error++;
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -S: Symbol type %c is 3-D only\n", symbol_type);
 			}
 			break;
@@ -14649,7 +14649,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 		case 'U':	/* Same but disable shading */
 			p->symbol = GMT_SYMBOL_CUBE;
 			if (mode == 0) {
-				decode_error = true;
+				decode_error++;
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -S: Symbol type %c is 3-D only\n", symbol_type);
 			}
 			break;
@@ -14825,7 +14825,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 			p->fq_parse = false;	/* No need to parse more later */
 			break;
 		default:
-			decode_error = true;
+			decode_error++;
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -S: Unrecognized symbol type %c\n", symbol_type);
 			break;
 	}
@@ -15567,7 +15567,7 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 			break;
 
 		case '^':
-			if (GMT->common.synopsis.active) GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option - given more than once\n");
+			if (GMT->common.synopsis.active) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Option - given more than once\n");
 			GMT->common.synopsis.active = true;
 			break;
 
@@ -16092,7 +16092,7 @@ int gmt_remove_dir (struct GMTAPI_CTRL *API, char *dir, bool recreate) {
 	if ((n_files = (unsigned int)gmtlib_glob_list (GMT, "*", &filelist))) {
 		for (k = 0; k < n_files; k++) {
 			if (gmt_remove_file (GMT, filelist[k]))
-				GMT_Report (API, GMT_MSG_ERROR, "Unable to remove %s [permissions?]\n", filelist[k]);
+				GMT_Report (API, GMT_MSG_WARNING, "Unable to remove %s [permissions?]\n", filelist[k]);
 		}
 		gmtlib_free_list (GMT, filelist, n_files);	/* Free the file list */
 	}
@@ -16941,7 +16941,7 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 			fig = gmt_get_current_figure (API);	/* Get current figure number */
 			snprintf (file, PATH_MAX, "%s/gmt.subplot.%d", API->gwf_dir, fig);
 			if (!access (file, R_OK))	/* subplot end was never called */
-				GMT_Report (API, GMT_MSG_ERROR, "subplot was never completed - plot items in last panel may be missing\n");
+				GMT_Report (API, GMT_MSG_WARNING, "subplot was never completed - plot items in last panel may be missing\n");
 			GMT_Report (API, GMT_MSG_DEBUG, "%s Workflow.  Session ID = %s. Directory %s %s.\n", smode[mode], API->session_name, API->gwf_dir, fstatus[3]);
 			if ((error = process_figures (API, text)))
 				GMT_Report (API, GMT_MSG_ERROR, "process_figures returned error %d\n", error);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -481,7 +481,7 @@ GMT_LOCAL unsigned int gmtio_ogr_decode_aspatial_values (struct GMT_CTRL *GMT, c
 	stringp = buffer;
 	while ( (token = strsep (&stringp, "|")) != NULL ) {
 		if (col >= S->n_aspatial) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad OGR/GMT: @D record has more items than declared by @N\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Bad OGR/GMT: @D record has more items than declared by @N\n");
 			continue;
 		}
 		gmtio_handle_bars (GMT, token, 1);		/* Put back any vertical bars replaced above */
@@ -516,12 +516,12 @@ GMT_LOCAL unsigned int gmtio_ogr_decode_aspatial_types (struct GMT_CTRL *GMT, ch
 	gmtio_copy_and_truncate (buffer, record);
 	while ((gmt_strtok (buffer, "|", &pos, p))) {
 		if (col >= S->n_aspatial) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad OGR/GMT: @T record has more items than declared by @N - skipping\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Bad OGR/GMT: @T record has more items than declared by @N - skipping\n");
 			continue;
 		}
 		if (col == n_alloc) S->type = gmt_M_memory (GMT, S->type, n_alloc += GMT_TINY_CHUNK, enum GMT_enum_type);
 		if ((t = gmtlib_ogr_get_type (p)) < 0) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad OGR/GMT: @T: No such type: %s - skipping\n", p);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Bad OGR/GMT: @T: No such type: %s - skipping\n", p);
 			continue;
 		}
 		S->type[col] = t;
@@ -908,7 +908,7 @@ GMT_LOCAL bool gmtio_get_binary_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t 
 			GMT->current.io.status = (feof (fp)) ? GMT_IO_EOF : GMT_IO_MISMATCH;
 			if (GMT->current.io.give_report && GMT->current.io.n_bad_records) {
 				/* Report summary and reset */
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "This file had %" PRIu64 " data records with invalid x and/or y values\n", GMT->current.io.n_bad_records);
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "This file had %" PRIu64 " data records with invalid x and/or y values\n", GMT->current.io.n_bad_records);
 				GMT->current.io.n_bad_records = GMT->current.io.rec_no = GMT->current.io.data_record_number_in_set[GMT_IN] = GMT->current.io.n_clean_rec = 0;
 			}
 			return (true);	/* Done with this file */
@@ -1080,7 +1080,7 @@ GMT_LOCAL void gmtio_format_geo_output (struct GMT_CTRL *GMT, bool is_lat, doubl
 
 	if (is_lat) {	/* Column is supposedly latitudes */
 		if (fabs (geo) > 90.0) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Column selected for latitude-formatting has values that exceed +/- 90; set to NaN\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Column selected for latitude-formatting has values that exceed +/- 90; set to NaN\n");
 			sprintf (text, "NaN");
 			return;
 		}
@@ -2629,7 +2629,7 @@ GMT_LOCAL void gmtio_write_formatted_ogr_value (struct GMT_CTRL *GMT, FILE *fp, 
 			fprintf (fp, "%s", text);
 			break;
 		default:
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad type passed to gmtio_write_formatted_ogr_value - assumed to be double\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Bad type passed to gmtio_write_formatted_ogr_value - assumed to be double\n");
 			gmt_ascii_format_col (GMT, text, G->dvalue[col], GMT_OUT, GMT_Z);
 			fprintf (fp, "%s", text);
 			break;
@@ -3362,7 +3362,7 @@ GMT_LOCAL void gmtio_extract_trailing_text (struct GMT_CTRL *GMT, size_t start_o
 GMT_LOCAL inline int reached_EOF (struct GMT_CTRL *GMT) {
 	GMT->current.io.status = GMT_IO_EOF;
 	if (GMT->current.io.give_report && GMT->current.io.n_bad_records) {	/* Report summary and reset counters */
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "This file had %" PRIu64 " data records with invalid x and/or y values\n",
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "This file had %" PRIu64 " data records with invalid x and/or y values\n",
 			GMT->current.io.n_bad_records);
 		GMT->current.io.n_bad_records = GMT->current.io.n_clean_rec = 0;
 		GMT->current.io.rec_no = GMT->current.io.rec_in_tbl_no = 0;
@@ -3602,12 +3602,12 @@ GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, 
 		if (bad_record) {	/* This record failed our test and had NaNs */
 			GMT->current.io.n_bad_records++;
 			if (GMT->current.io.give_report && (GMT->current.io.n_bad_records == 1)) {	/* Report 1st occurrence of bad record */
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Encountered first invalid ASCII data record near/at line # %" PRIu64 "\n",
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Encountered first invalid ASCII data record near/at line # %" PRIu64 "\n",
 				            GMT->current.io.rec_no);
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Likely causes:\n");
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "(1) Invalid x and/or y values, i.e. NaNs or garbage in text strings.\n");
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "(2) Incorrect data type assumed if -J, -f are not set or set incorrectly.\n");
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "(3) The -: switch is implied but not set.\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Likely causes:\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "(1) Invalid x and/or y values, i.e. NaNs or garbage in text strings.\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "(2) Incorrect data type assumed if -J, -f are not set or set incorrectly.\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "(3) The -: switch is implied but not set.\n");
 			}
 		}
 		else if (GMT->current.io.skip_duplicates && GMT->current.io.has_previous_rec) {	/* Test to determine if we should skip repeated duplicate records with same x,y */
@@ -3620,7 +3620,7 @@ GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, 
 	GMT->current.io.status = (GMT->current.io.variable_in_columns || n_ok == n_use || *n == GMT_MAX_COLUMNS) ? 0 : GMT_IO_MISMATCH;	/* Hopefully set status to 0 (OK) */
 	if (*n == GMT_MAX_COLUMNS) *n = n_ok;							/* Update the number of expected fields */
 	if (gmt_M_rec_is_error (GMT))
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Mismatch between actual (%d) and expected (%d) fields near line %" PRIu64 " in file %s\n",
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Mismatch between actual (%d) and expected (%d) fields near line %" PRIu64 " in file %s\n",
 		            col_no, *n, GMT->current.io.rec_no, GMT->current.io.filename[GMT_IN]);
 
 	if (GMT->current.setting.io_lonlat_toggle[GMT_IN] && col_no >= 2) {
@@ -3962,11 +3962,11 @@ GMT_LOCAL FILE *gmt_nc_fopen (struct GMT_CTRL *GMT, const char *filename, const 
 			GMT_exit (GMT, GMT_DIM_TOO_LARGE); return NULL;
 		}
 		if (ndims - in < 1) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "NetCDF variable %s has %" PRIuS " dimensions, cannot specify more than %d indices; ignoring remainder\n", varname, ndims, ndims-1);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "NetCDF variable %s has %" PRIuS " dimensions, cannot specify more than %d indices; ignoring remainder\n", varname, ndims, ndims-1);
 			for (j = in; j < ndims; j++) GMT->current.io.t_index[i][j] = 0;
 		}
 		if (ndims - in > 2)
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "NetCDF variable %s has %" PRIuS " dimensions, showing only 2\n", varname, ndims);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "NetCDF variable %s has %" PRIuS " dimensions, showing only 2\n", varname, ndims);
 
 		/* Get information of the first two dimensions */
 		nc_inq_vardimid(GMT->current.io.ncid, GMT->current.io.varid[i], dimids);
@@ -4261,7 +4261,7 @@ char *gmt_fgets (struct GMT_CTRL *GMT, char *str, int size, FILE *stream) {
 			/* EOF without '\n' */
 			--n;
 		/* This will report wrong lengths if last line has no '\n' but we don't care */
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Long input record (%d bytes) was truncated to first %d bytes!\n", size+n, size-2);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Long input record (%d bytes) was truncated to first %d bytes!\n", size+n, size-2);
 	}
 	return (str);
 }
@@ -4430,7 +4430,7 @@ int gmtlib_process_binary_input (struct GMT_CTRL *GMT, uint64_t n_read) {
 						break;
 					case GMT_IS_LAT:
 						if (GMT->current.io.curr_rec[col_no] < -90.0 || GMT->current.io.curr_rec[col_no] > +90.0) {
-							GMT_Report (GMT->parent, GMT_MSG_ERROR, "Latitude (%g) at line # %" PRIu64 " exceeds -|+ 90! - set to NaN\n", GMT->current.io.curr_rec[col_no], GMT->current.io.rec_no);
+							GMT_Report (GMT->parent, GMT_MSG_WARNING, "Latitude (%g) at line # %" PRIu64 " exceeds -|+ 90! - set to NaN\n", GMT->current.io.curr_rec[col_no], GMT->current.io.rec_no);
 							GMT->current.io.curr_rec[col_no] = GMT->session.d_NaN;
 						}
 						break;
@@ -4467,10 +4467,10 @@ int gmtlib_process_binary_input (struct GMT_CTRL *GMT, uint64_t n_read) {
 	if (bad_record) {
 		GMT->current.io.n_bad_records++;
 		if (GMT->current.io.give_report && GMT->current.io.n_bad_records == 1) {	/* Report 1st occurrence */
-			GMT_Report (GMT->parent, GMT_MSG_ERROR,
+			GMT_Report (GMT->parent, GMT_MSG_WARNING,
 			            "Encountered first invalid binary data record near/at line # %" PRIu64 "\n", GMT->current.io.rec_no);
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Likely causes:\n");
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "(1) Invalid x and/or y values, i.e. NaNs.\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Likely causes:\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "(1) Invalid x and/or y values, i.e. NaNs.\n");
 		}
 		return (2);	/* 2 means skip this record and try again */
 	}
@@ -5237,7 +5237,7 @@ uint64_t gmtlib_bin_colselect (struct GMT_CTRL *GMT) {
 				break;
 			case GMT_IS_LAT:
 				if (tmp[order] < -90.0 || tmp[order] > +90.0) {
-					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Latitude (%g) at line # %" PRIu64 " exceeds -|+ 90! - set to NaN\n", tmp[order], GMT->current.io.rec_no);
+					GMT_Report (GMT->parent, GMT_MSG_WARNING, "Latitude (%g) at line # %" PRIu64 " exceeds -|+ 90! - set to NaN\n", tmp[order], GMT->current.io.rec_no);
 					tmp[S->order] = GMT->session.d_NaN;
 				}
 				break;
@@ -5258,7 +5258,7 @@ bool gmt_skip_output (struct GMT_CTRL *GMT, double *cols, uint64_t n_cols) {
 	uint64_t c, n_nan;
 
 	if (n_cols > GMT_MAX_COLUMNS) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Number of output data columns (%d) exceeds limit (GMT_MAX_COLUMNS = %d)\n", n_cols, GMT_MAX_COLUMNS);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Number of output data columns (%d) exceeds limit (GMT_MAX_COLUMNS = %d)\n", n_cols, GMT_MAX_COLUMNS);
 		return (true);	/* Skip record since we cannot access that many columns */
 	}
 	GMT->current.io.data_record_number_in_set[GMT_OUT]++;
@@ -5964,7 +5964,7 @@ bool gmt_byteswap_file (struct GMT_CTRL *GMT, FILE *outfp, FILE *infp, const Swa
 				GMT_Report (GMT->parent, GMT_MSG_INFORMATION, message);
 #endif
 				if (extrabytes != 0) {
-					snprintf (message, GMT_LEN256, "%s: warning: the last %" PRIuS " bytes were ignored during swapping.\n",
+					snprintf (message, GMT_LEN256, "%s: The last %" PRIuS " bytes were ignored during swapping.\n",
 							__func__, extrabytes);
 					GMT_Report (GMT->parent, GMT_MSG_WARNING, message);
 				}
@@ -5988,7 +5988,7 @@ bool gmt_byteswap_file (struct GMT_CTRL *GMT, FILE *outfp, FILE *infp, const Swa
 		extrabytes = nbytes % swapwidth;
 		if (extrabytes != 0) {
 			/* this can only happen on EOF, ignore extra bytes while swapping. */
-			snprintf (message, GMT_LEN256, "%s: warning: read buffer contains %" PRIuS " bytes which are "
+			snprintf (message, GMT_LEN256, "%s: Read buffer contains %" PRIuS " bytes which are "
 					"not aligned with the swapwidth of %" PRIuS " bytes.\n",
 					__func__, nbytes, extrabytes);
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, message);
@@ -6155,7 +6155,7 @@ int gmt_get_io_type (struct GMT_CTRL *GMT, char type) {
 		case 'f': t = GMT_FLOAT;  break; /* Binary 4-byte float */
 		case 'd': t = GMT_DOUBLE; break; /* Binary 8-byte double */
 		default:
-			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Valid data type not set [%c]!\n", type);
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Valid data type not set [%c]!\n", type);
 			GMT_exit (GMT, GMT_NOT_A_VALID_TYPE); return GMT_NOT_A_VALID_TYPE;
 			break;
 	}

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -8666,7 +8666,7 @@ void gmtlib_init_geodesic (struct GMT_CTRL *GMT) {
 			GMT->current.map.geodesic_az_backaz = map_az_backaz_rudoe;
 			break;
 		default:
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "The PROJ_GEODESIC is not set! - use Vincenty\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "The PROJ_GEODESIC is not set! - use Vincenty\n");
 			GMT->current.setting.proj_geodesic = GMT_GEODESIC_VINCENTY;
 			GMT->current.map.geodesic_meter = map_vincenty_dist_meter;
 			GMT->current.map.geodesic_az_backaz = map_az_backaz_vincenty;

--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -144,7 +144,7 @@ GMT_LOCAL int gmtnc_n_chunked_rows_in_cache (struct GMT_CTRL *GMT, struct GMT_GR
 		size_t chunks_per_row = (size_t) ceil ((double)width / chunksize[yx_dim[1]]);
 		*n_contiguous_chunk_rows = NC_CACHE_SIZE / (width_t * z_size) / chunksize[yx_dim[0]];
 #ifdef NC4_DEBUG
-		level = GMT_MSG_ERROR;
+		level = GMT_MSG_WARNING;
 #else
 		level = GMT_MSG_DEBUG;
 #endif
@@ -180,7 +180,7 @@ GMT_LOCAL int gmtnc_io_nc_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *he
 	assert (io_mode == k_put_netcdf || io_mode == k_get_netcdf);
 
 #ifdef NC4_DEBUG
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "%s n_columns:%u n_rows:%u x0:%u y0:%u y-order:%s\n",
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "%s n_columns:%u n_rows:%u x0:%u y0:%u y-order:%s\n",
 			io_mode == k_put_netcdf ? "writing," : "reading,",
 			dim[1], dim[0], origin[1], origin[0],
 			HH->row_order == k_nc_start_south ? "S->N" : "N->S");
@@ -204,7 +204,7 @@ GMT_LOCAL int gmtnc_io_nc_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *he
 		size_t remainder;
 #ifdef NC4_DEBUG
 		unsigned row_num = 0;
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "stride: %u width: %u\n",
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "stride: %u width: %u\n",
 					stride, width);
 #endif
 
@@ -216,7 +216,7 @@ GMT_LOCAL int gmtnc_io_nc_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *he
 		count[yx_dim[1]] = width_t;
 		while ( (start[yx_dim[0]] + count[yx_dim[0]]) <= height_t && status == NC_NOERR) {
 #ifdef NC4_DEBUG
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "chunked row #%u start-y:%" PRIuS " height:%" PRIuS "\n",
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "chunked row #%u start-y:%" PRIuS " height:%" PRIuS "\n",
 					++row_num, start[yx_dim[0]], count[yx_dim[0]]);
 #endif
 			/* get/put chunked rows */
@@ -238,7 +238,7 @@ GMT_LOCAL int gmtnc_io_nc_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *he
 			/* get/put last chunked row */
 			count[yx_dim[0]] = height_t - start[yx_dim[0]] + origin[0];
 #ifdef NC4_DEBUG
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "chunked row #%u start-y:%" PRIuS " height:%" PRIuS "\n",
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "chunked row #%u start-y:%" PRIuS " height:%" PRIuS "\n",
 					++row_num, start[yx_dim[0]], count[yx_dim[0]]);
 #endif
 			if (stride)
@@ -505,7 +505,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 			gmt_M_err_trap (nc_inq_dim (ncid, dims[i], dimname, &lens[i]));
 			//if (nc_inq_varid (ncid, dimname, &ids[i])) return (GMT_GRDIO_NC_NOT_COARDS);
 			if ((status = nc_inq_varid (ncid, dimname, &ids[i])) != NC_NOERR)
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "\"%s\", %s\n\tIf something bad happens later, try importing via GDAL.\n",
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "\"%s\", %s\n\tIf something bad happens later, try importing via GDAL.\n",
 				                                         dimname, nc_strerror(status));
 		}
 		HH->xy_dim[0] = ndims-1;
@@ -676,10 +676,10 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 		if (gmt_M_is_dnan(header->inc[GMT_X])) header->inc[GMT_X] = 1.0;
 
 #ifdef NC4_DEBUG
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "x registration: %u\n", header->registration);
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "x dummy: %g %g\n", dummy[0], dummy[1]);
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "x[0] x[nx-1]: %g %g\n", xy[0], xy[header->n_columns-1]);
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "xinc: %g %g\n", header->inc[GMT_X]);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "x registration: %u\n", header->registration);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "x dummy: %g %g\n", dummy[0], dummy[1]);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "x[0] x[nx-1]: %g %g\n", xy[0], xy[header->n_columns-1]);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "xinc: %g %g\n", header->inc[GMT_X]);
 #endif
 
 		/* Extend x boundaries by half if we found pixel registration */
@@ -776,10 +776,10 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 		if (gmt_M_is_dnan(header->inc[GMT_Y])) header->inc[GMT_Y] = 1.0;
 
 #ifdef NC4_DEBUG
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "y registration: %u\n", header->registration);
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "y dummy: %g %g\n", dummy[0], dummy[1]);
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "y[0] y[ny-1]: %g %g\n", xy[0], xy[header->n_rows-1]);
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "xinc: %g %g\n", header->inc[GMT_Y]);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "y registration: %u\n", header->registration);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "y dummy: %g %g\n", dummy[0], dummy[1]);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "y[0] y[ny-1]: %g %g\n", xy[0], xy[header->n_rows-1]);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "xinc: %g %g\n", header->inc[GMT_Y]);
 #endif
 
 		/* Extend y boundaries by half if we found pixel registration */
@@ -849,22 +849,22 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 		}
 
 #ifdef NC4_DEBUG
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->wesn: %g %g %g %g\n",
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->wesn: %g %g %g %g\n",
 	            header->wesn[XLO], header->wesn[XHI], header->wesn[YLO], header->wesn[YHI]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->registration:%u\n", header->registration);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->row_order: %s\n",
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->registration:%u\n", header->registration);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->row_order: %s\n",
 	            HH->row_order == k_nc_start_south ? "S->N" : "N->S");
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->n_columns: %3d   head->n_rows:%3d\n", header->n_columns, header->n_rows);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->inc: %g %g\n", header->inc[GMT_X], header->inc[GMT_Y]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->mx: %3d   head->my:%3d\n", header->mx, header->my);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->nm: %3d head->size:%3d\n", header->nm, header->size);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->t-index %d,%d,%d\n",
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->n_columns: %3d   head->n_rows:%3d\n", header->n_columns, header->n_rows);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->inc: %g %g\n", header->inc[GMT_X], header->inc[GMT_Y]);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->mx: %3d   head->my:%3d\n", header->mx, header->my);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->nm: %3d head->size:%3d\n", header->nm, header->size);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->t-index %d,%d,%d\n",
 	            HH->t_index[0], HH->t_index[1], HH->t_index[2]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->pad xlo:%u xhi:%u ylo:%u yhi:%u\n",
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->pad xlo:%u xhi:%u ylo:%u yhi:%u\n",
 	            header->pad[XLO], header->pad[XHI], header->pad[YLO], header->pad[YHI]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->BC  xlo:%u xhi:%u ylo:%u yhi:%u\n",
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->BC  xlo:%u xhi:%u ylo:%u yhi:%u\n",
 	            HH->BC[XLO], HH->BC[XHI], HH->BC[YLO], HH->BC[YHI]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->grdtype:%u %u\n", HH->grdtype, GMT_GRID_GEOGRAPHIC_EXACT360_REPEAT);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->grdtype:%u %u\n", HH->grdtype, GMT_GRID_GEOGRAPHIC_EXACT360_REPEAT);
 #endif
 	}
 	else {
@@ -1304,8 +1304,8 @@ GMT_LOCAL int gmtnc_grd_prep_io (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h
 	is_gridline_reg = header->registration != GMT_GRID_PIXEL_REG;
 
 #ifdef NC4_DEBUG
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "  x-region: %g %g, grid: %g %g\n", wesn[XLO], wesn[XHI], header->wesn[XLO], header->wesn[XHI]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "  y-region: %g %g, grid: %g %g\n", wesn[YLO], wesn[YHI], header->wesn[YLO], header->wesn[YHI]);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "  x-region: %g %g, grid: %g %g\n", wesn[XLO], wesn[XHI], header->wesn[XLO], header->wesn[XHI]);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "  y-region: %g %g, grid: %g %g\n", wesn[YLO], wesn[YHI], header->wesn[YLO], header->wesn[YHI]);
 #endif
 
 	if (wesn[XLO] == 0 && wesn[XHI] == 0 && wesn[YLO] == 0 && wesn[YHI] == 0) {
@@ -1372,7 +1372,7 @@ GMT_LOCAL int gmtnc_grd_prep_io (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h
 			last_col2 = is_global_repeat + last_col - header->n_columns;
 			last_col = header->n_columns - 1;
 #ifdef NC4_DEBUG
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "col2: %u %u\n", first_col2, last_col2);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "col2: %u %u\n", first_col2, last_col2);
 #endif
 
 			origin2[0] = first_row;
@@ -1395,11 +1395,11 @@ GMT_LOCAL int gmtnc_grd_prep_io (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h
 	dim[1] = 1 + last_col - first_col;
 
 #ifdef NC4_DEBUG
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "-> x-region: %g %g, grid: %g %g\n", wesn[XLO], wesn[XHI], header->wesn[XLO], header->wesn[XHI]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "-> y-region: %g %g, grid: %g %g\n", wesn[YLO], wesn[YHI], header->wesn[YLO], header->wesn[YHI]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "row: %u %u  col: %u %u  r_shift: %d\n", first_row, last_row, first_col, last_col, *n_shift);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "origin : %u,%u  dim : %u,%u\n", origin[0], origin[1], dim[0], dim[1]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "origin2: %u,%u  dim2: %u,%u\n", origin2[0], origin2[1], dim2[0], dim2[1]);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "-> x-region: %g %g, grid: %g %g\n", wesn[XLO], wesn[XHI], header->wesn[XLO], header->wesn[XHI]);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "-> y-region: %g %g, grid: %g %g\n", wesn[YLO], wesn[YHI], header->wesn[YLO], header->wesn[YHI]);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "row: %u %u  col: %u %u  r_shift: %d\n", first_row, last_row, first_col, last_col, *n_shift);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "origin : %u,%u  dim : %u,%u\n", origin[0], origin[1], dim[0], dim[1]);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "origin2: %u,%u  dim2: %u,%u\n", origin2[0], origin2[1], dim2[0], dim2[1]);
 #endif
 
 	return GMT_NOERROR;
@@ -1522,20 +1522,20 @@ int gmt_nc_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_g
 	pgrid = grid + imag_offset;	/* Start of this complex component (or start of non-complex grid) */
 
 #ifdef NC4_DEBUG
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "      wesn: %g %g %g %g\n", wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->wesn: %g %g %g %g\n", header->wesn[XLO], header->wesn[XHI], header->wesn[YLO], header->wesn[YHI]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->registration:%u\n", header->registration);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->row_order: %s\n", HH->row_order == k_nc_start_south ? "S->N" : "N->S");
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "width:    %3d     height:%3d\n", width, height);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->n_columns: %3d   head->n_rows:%3d\n", header->n_columns, header->n_rows);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->mx: %3d   head->my:%3d\n", header->mx, header->my);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->nm: %3d head->size:%3d\n", header->nm, header->size);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->t-index %d,%d,%d\n", HH->t_index[0], HH->t_index[1], HH->t_index[2]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "      pad xlo:%u xhi:%u ylo:%u yhi:%u\n", pad[XLO], pad[XHI], pad[YLO], pad[YHI]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->pad xlo:%u xhi:%u ylo:%u yhi:%u\n", header->pad[XLO], header->pad[XHI], header->pad[YLO], header->pad[YHI]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->BC  xlo:%u xhi:%u ylo:%u yhi:%u\n", HH->BC[XLO], HH->BC[XHI], HH->BC[YLO], HH->BC[YHI]);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "head->grdtype:%u %u\n", HH->grdtype, GMT_GRID_GEOGRAPHIC_EXACT360_REPEAT);
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "imag_offset: %" PRIu64 "\n", imag_offset);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "      wesn: %g %g %g %g\n", wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI]);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->wesn: %g %g %g %g\n", header->wesn[XLO], header->wesn[XHI], header->wesn[YLO], header->wesn[YHI]);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->registration:%u\n", header->registration);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->row_order: %s\n", HH->row_order == k_nc_start_south ? "S->N" : "N->S");
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "width:    %3d     height:%3d\n", width, height);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->n_columns: %3d   head->n_rows:%3d\n", header->n_columns, header->n_rows);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->mx: %3d   head->my:%3d\n", header->mx, header->my);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->nm: %3d head->size:%3d\n", header->nm, header->size);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->t-index %d,%d,%d\n", HH->t_index[0], HH->t_index[1], HH->t_index[2]);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "      pad xlo:%u xhi:%u ylo:%u yhi:%u\n", pad[XLO], pad[XHI], pad[YLO], pad[YHI]);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->pad xlo:%u xhi:%u ylo:%u yhi:%u\n", header->pad[XLO], header->pad[XHI], header->pad[YLO], header->pad[YHI]);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->BC  xlo:%u xhi:%u ylo:%u yhi:%u\n", HH->BC[XLO], HH->BC[XHI], HH->BC[YLO], HH->BC[YHI]);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "head->grdtype:%u %u\n", HH->grdtype, GMT_GRID_GEOGRAPHIC_EXACT360_REPEAT);
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "imag_offset: %" PRIu64 "\n", imag_offset);
 #endif
 
 	/* Open the NetCDF file */
@@ -1557,7 +1557,7 @@ int gmt_nc_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_g
 	/* If we need to shift grid */
 	if (n_shift) {
 #ifdef NC4_DEBUG
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtnc_right_shift_grid: %d\n", n_shift);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtnc_right_shift_grid: %d\n", n_shift);
 #endif
 		gmtnc_right_shift_grid (pgrid, dim[1], dim[0], n_shift, sizeof(grid[0]));
 	}
@@ -1606,7 +1606,7 @@ int gmt_nc_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_g
 		/* Report z-range of grid (with scale and offset applied): */
 		unsigned int level;
 #ifdef NC4_DEBUG
-		level = GMT_MSG_ERROR;
+		level = GMT_MSG_WARNING;
 #else
 		level = GMT_MSG_DEBUG;
 #endif
@@ -1761,7 +1761,7 @@ int gmt_nc_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_
 
 		/* Report z-range of grid (with scale and offset applied): */
 #ifdef NC4_DEBUG
-		level = GMT_MSG_ERROR;
+		level = GMT_MSG_WARNING;
 #else
 		level = GMT_MSG_DEBUG;
 #endif
@@ -1831,7 +1831,7 @@ int gmt_examine_nc_cube (struct GMT_CTRL *GMT, char *file, uint64_t *nz, double 
 		}
 		z_id = ID;	/* Pick the higher dimensioned cube instead, get its name, and warn */
 		nc_inq_varname (ncid, z_id, varname);
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "No 3-D array in file %s.  Selecting first 3-D slice in the %d-D array %s\n", file, dim, varname);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "No 3-D array in file %s.  Selecting first 3-D slice in the %d-D array %s\n", file, dim, varname);
 	}
 	gmt_M_err_trap (nc_inq_vardimid (ncid, z_id, dims));
 
@@ -1839,7 +1839,7 @@ int gmt_examine_nc_cube (struct GMT_CTRL *GMT, char *file, uint64_t *nz, double 
 	for (i = 0; i < ndims; i++) {
 		gmt_M_err_trap (nc_inq_dim (ncid, dims[i], dimname, &lens[i]));
 		if ((status = nc_inq_varid (ncid, dimname, &ids[i])) != NC_NOERR)
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "\"%s\", %s\n\tIf something bad happens later, try importing via GDAL.\n",
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "\"%s\", %s\n\tIf something bad happens later, try importing via GDAL.\n",
 				dimname, nc_strerror(status));
 	}
 	z_dim = ndims-3;
@@ -1988,7 +1988,7 @@ int gmt_write_nc_cube (struct GMT_CTRL *GMT, struct GMT_GRID **G, uint64_t nlaye
 
 			/* Report level-range of grid layer (with scale and offset applied): */
 #ifdef NC4_DEBUG
-			level = GMT_MSG_ERROR;
+			level = GMT_MSG_WARNING;
 #else
 			level = GMT_MSG_DEBUG;
 #endif

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -6111,11 +6111,11 @@ char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
 		/* Rely on GDAL to tell us the proj4 string of this EPSG code */
 		hSRS = OSRNewSpatialReference(NULL);
 		if ((eErr = OSRImportFromEPSG(hSRS, EPSGID)) != OGRERR_NONE) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Did not get the SRS from input EPSG  %d\n", EPSGID);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Did not get the SRS from input EPSG  %d\n", EPSGID);
 			return (pStrOut);
 		}
 		if ((eErr = OSRExportToProj4(hSRS, &pszResult)) != OGRERR_NONE) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failed to convert the SRS to proj4 syntax\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Failed to convert the SRS to proj4 syntax\n");
 			return (pStrOut);
 		}
 		snprintf(szProj4, GMT_LEN256-1, "%s", pszResult);
@@ -6221,7 +6221,7 @@ char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
 			opt_J[1] = 'A';
 		}
 		else {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "In projection %s proj parameters\n", prjcode);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "In projection %s proj parameters\n", prjcode);
 			return (pStrOut);
 		}
 	}
@@ -6246,11 +6246,11 @@ char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
 			}
 		}
 		if (zone == 100) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "UTM proj selected but no info about utm zone.\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "UTM proj selected but no info about utm zone.\n");
 			return (pStrOut);
 		}
 		else if (zone > 64) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "UTM proj The lon_0 argument was not correctly parsed.\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "UTM proj The lon_0 argument was not correctly parsed.\n");
 		}
 		else {
 			char t[4];
@@ -6288,7 +6288,7 @@ char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
 		if (!lat_0[0]) strcat(lat_0, "0");
 		if (strcmp(prjcode, "poly")) {			/* i.e. if NOT Poly */
 			if (!lat_1[0] || !lat_2[0]) {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Projection %s needs the lat_1 & lat_2 proj parameters\n", prjcode);
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Projection %s needs the lat_1 & lat_2 proj parameters\n", prjcode);
 				return (pStrOut);
 			}
 			strcat(opt_J, lon_0);	strcat (opt_J, "/");	strcat(opt_J, lat_0);	strcat (opt_J, "/");
@@ -7548,9 +7548,9 @@ void gmt_plotend (struct GMT_CTRL *GMT) {
 
 	if (!K_active) {
 		if (GMT->current.ps.clip_level > 0)
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "%d external clip operations were not terminated!\n", GMT->current.ps.clip_level);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "%d external clip operations were not terminated!\n", GMT->current.ps.clip_level);
 		if (GMT->current.ps.clip_level < 0)
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "%d extra terminations of external clip operations!\n", -GMT->current.ps.clip_level);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "%d extra terminations of external clip operations!\n", -GMT->current.ps.clip_level);
 		GMT->current.ps.clip_level = 0;	/* Reset to zero, so it will no longer show up in gmt.history */
 	}
 	for (i = 0; i < 3; i++) gmt_M_str_free (GMT->current.map.frame.axis[i].file_custom);
@@ -7561,7 +7561,7 @@ void gmt_plotend (struct GMT_CTRL *GMT) {
 		char file[PATH_MAX] = {""};
 		FILE *fp = NULL;
 		if (stat (GMT->current.ps.filename, &buf))
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not determine size of file %s\n", GMT->current.ps.filename);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Could not determine size of file %s\n", GMT->current.ps.filename);
 		else
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Current size of half-baked PS file %s = %" PRIuS ".\n", GMT->current.ps.filename, buf.st_size);
 		GMT->current.ps.fp = NULL;
@@ -7588,7 +7588,7 @@ void gmt_plotend (struct GMT_CTRL *GMT) {
 		P->mode = PSL->internal.pmode;  /* Mode of plot (GMT_PS_{HEADER,TRAILER,COMPLETE}) */
 		PH->alloc_mode = GMT_ALLOC_EXTERNALLY;	/* Since created in PSL */
 		if (GMT_Write_Data (GMT->parent, GMT_IS_POSTSCRIPT, GMT_IS_REFERENCE, GMT_IS_TEXT, 0, NULL, GMT->current.ps.memname, P) != GMT_OK) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to write PS structure to file %s!\n", GMT->current.ps.memname);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Unable to write PS structure to file %s!\n", GMT->current.ps.memname);
 		}
 		/* coverity[leaked_storage] */	/* We can't free P because it was written into a 'memory file' */
 	}

--- a/src/gmt_shore.c
+++ b/src/gmt_shore.c
@@ -317,7 +317,7 @@ L1:
 						sprintf(path, "%s/%s%s", dir, stem, ".cdf");
 						if (access(path, R_OK) == 0)	/* Yes, old .cdf version found */
 							goto L1;
-						GMT_Report (GMT->parent, GMT_MSG_ERROR, "2. GSHHG: Did not find %s nor ithe older *.cdf version\n", path);
+						GMT_Report (GMT->parent, GMT_MSG_ERROR, "2. GSHHG: Did not find %s nor the older *.cdf version\n", path);
 					}
 				}
 			}
@@ -353,7 +353,7 @@ L1:
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "4. GSHHG: Failure, could not access any GSHHG files\n");
 	if (warn_once && reset) {
 		warn_once = false;
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "GSHHG version %d.%d.%d or newer is "
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "GSHHG version %d.%d.%d or newer is "
 								"needed to use coastlines with GMT.\n\tGet and install GSHHG from "
 								GSHHG_SITE ".\n", version.major, version.minor, version.patch);
 	}
@@ -479,7 +479,7 @@ int gmt_set_resolution (struct GMT_CTRL *GMT, char *res, char opt) {
 					base = 0;	/* full */
 			}
 			else {	/* No basis - select low */
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "-%c option: Cannot select automatic resolution without -R or -J [Default to low]\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "-%c option: Cannot select automatic resolution without -R or -J [Default to low]\n");
 				base = 3;	/* low */
 			}
 			*res = choice[base];
@@ -501,7 +501,7 @@ int gmt_set_resolution (struct GMT_CTRL *GMT, char *res, char opt) {
 			base = 4;
 			break;
 		default:
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Unknown modifier %c [Defaults to -%cl]\n", opt, *res, opt);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Option -%c: Unknown modifier %c [Defaults to -%cl]\n", opt, *res, opt);
 			base = 3;
 			*res = 'l';
 			break;
@@ -576,7 +576,7 @@ int gmt_init_shore (struct GMT_CTRL *GMT, char res, struct GMT_SHORE *c, double 
 		int_areas = true;
 	}
 	else if (nc_inq_varid (c->cdfid, "The_km_squared_area_of_polygons", &c->GSHHS_area_id) != NC_NOERR) {	/* New file with km^2 areas as doubles */
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "GSHHS: Unable to determine how polygon areas were stored.\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "GSHHS: Unable to determine how polygon areas were stored.\n");
 	}
 	if (nc_inq_varid (c->cdfid, "Embedded_node_levels_in_a_bin_ANT", &c->bin_info_id_ANT) == NC_NOERR) {	/* New file with two Antarcticas */
 		gmt_M_err_trap (nc_inq_varid (c->cdfid, "Embedded_ANT_flag", &c->seg_info_id_ANT));

--- a/src/gmt_stat.c
+++ b/src/gmt_stat.c
@@ -148,7 +148,7 @@ GMT_LOCAL int gmtstat_ln_gamma_r (struct GMT_CTRL *GMT, double x, double *lngam)
 		*lngam = 0.0;
 		return (0);
 	}
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "Ln Gamma:  Bad x (x <= 0).\n");
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "Ln Gamma:  Bad x (x <= 0).\n");
 	return (-1);
 }
 
@@ -165,7 +165,7 @@ GMT_LOCAL void gmtstat_gamma_ser (struct GMT_CTRL *GMT, double *gamser, double a
 	}
 
 	if (x < 0.0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "x < 0 in gmtstat_gamma_ser(x)\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "x < 0 in gmtstat_gamma_ser(x)\n");
 		*gamser = GMT->session.d_NaN;
 		return;
 	}
@@ -184,7 +184,7 @@ GMT_LOCAL void gmtstat_gamma_ser (struct GMT_CTRL *GMT, double *gamser, double a
 	 		return;
 	 	}
 	}
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "a too large, ITMAX too small in gmtstat_gamma_ser(x)\n");
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "a too large, ITMAX too small in gmtstat_gamma_ser(x)\n");
 }
 
 GMT_LOCAL void gmtstat_gamma_cf (struct GMT_CTRL *GMT, double *gammcf, double a, double x, double *gln) {
@@ -218,7 +218,7 @@ GMT_LOCAL void gmtstat_gamma_cf (struct GMT_CTRL *GMT, double *gammcf, double a,
 			gold = g;
 		}
 	}
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "a too large, ITMAX too small in gmtstat_gamma_cf(x)\n");
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "a too large, ITMAX too small in gmtstat_gamma_cf(x)\n");
 }
 
 GMT_LOCAL double gmtstat_gammq (struct GMT_CTRL *GMT, double a, double x) {
@@ -227,7 +227,7 @@ GMT_LOCAL double gmtstat_gammq (struct GMT_CTRL *GMT, double a, double x) {
 	double G = 0.0, gln;
 
 	if (x < 0.0 || a <= 0.0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Invalid arguments to GMT_gammaq\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Invalid arguments to GMT_gammaq\n");
 		return (GMT->session.d_NaN);
 	}
 
@@ -271,7 +271,7 @@ GMT_LOCAL double gmtstat_cf_beta (struct GMT_CTRL *GMT, double a, double b, doub
 		bz = 1.0;
 	} while (((fabs (az-aold) ) >= (BETA_EPS * fabs (az))) && (m < ITMAX));
 
-	if (m == ITMAX) GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtstat_cf_beta:  A or B too big, or ITMAX too small.\n");
+	if (m == ITMAX) GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_cf_beta:  A or B too big, or ITMAX too small.\n");
 
 	return (az);
 }
@@ -280,11 +280,11 @@ GMT_LOCAL int gmtstat_inc_beta (struct GMT_CTRL *GMT, double a, double b, double
 	double bt, gama, gamb, gamab;
 
 	if (a <= 0.0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtstat_inc_beta:  Bad a (a <= 0).\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_inc_beta:  Bad a (a <= 0).\n");
 		return(-1);
 	}
 	if (b <= 0.0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtstat_inc_beta:  Bad b (b <= 0).\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_inc_beta:  Bad b (b <= 0).\n");
 		return(-1);
 	}
 	if (x > 0.0 && x < 1.0) {
@@ -318,11 +318,11 @@ GMT_LOCAL int gmtstat_inc_beta (struct GMT_CTRL *GMT, double a, double b, double
 		return (0);
 	}
 	else if (x < 0.0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtstat_inc_beta:  Bad x (x < 0).\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_inc_beta:  Bad x (x < 0).\n");
 		*ibeta = 0.0;
 	}
 	else if (x > 1.0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtstat_inc_beta:  Bad x (x > 1).\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_inc_beta:  Bad x (x > 1).\n");
 		*ibeta = 1.0;
 	}
 	return (-1);
@@ -358,7 +358,7 @@ GMT_LOCAL int gmtstat_f_q (struct GMT_CTRL *GMT, double chisq1, uint64_t nu1, do
 	/* Check range of arguments:  */
 
 	if (nu1 <= 0 || nu2 <= 0 || chisq1 < 0.0 || chisq2 < 0.0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtstat_f_q:  Bad argument(s).\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_f_q:  Bad argument(s).\n");
 		return (-1);
 	}
 
@@ -377,7 +377,7 @@ GMT_LOCAL int gmtstat_f_q (struct GMT_CTRL *GMT, double chisq1, uint64_t nu1, do
 		the value.  All subsequent code is not used.  */
 
 	if (gmtstat_inc_beta (GMT, 0.5*nu2, 0.5*nu1, chisq2/(chisq2+chisq1), prob) ) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtstat_f_q:  Trouble in gmtstat_inc_beta call.\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_f_q:  Trouble in gmtstat_inc_beta call.\n");
 		return (-1);
 	}
 	return (0);
@@ -410,7 +410,7 @@ GMT_LOCAL int gmtstat_f_test_new (struct GMT_CTRL *GMT, double chisq1, uint64_t 
 
 	if (chisq1 <= 0.0 || chisq2 <= 0.0 || nu1 < 1 || nu2 < 1) {
 		*prob = GMT->session.d_NaN;
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtstat_f_test_new: Bad argument(s).\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_f_test_new: Bad argument(s).\n");
 		return (-1);
 	}
 
@@ -432,7 +432,7 @@ GMT_LOCAL double gmtstat_factln (struct GMT_CTRL *GMT, int n) {
 	/* returns log(n!) */
 	static double a[101];	/* Automatically initialized to zero */
 	if (n < 0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "n < 0 in gmtstat_factln(n)\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "n < 0 in gmtstat_factln(n)\n");
 		return (GMT->session.d_NaN);
 	}
 	if (n <= 1) return 0.0;
@@ -537,7 +537,7 @@ GMT_LOCAL int gmtstat_student_t_a (struct GMT_CTRL *GMT, double t, uint64_t n, d
 	int64_t	k, kstop, kt, kb;
 
 	if (t < 0.0 || n == 0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtstat_student_t_a:  Bad argument(s).\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_student_t_a:  Bad argument(s).\n");
 		*prob = GMT->session.d_NaN;
 		return (-1);
 	}
@@ -745,7 +745,7 @@ double gmt_ker (struct GMT_CTRL *GMT, double x) {
 	double t, rxsq, alpha, beta;
 
 	if (x <= 0.0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "x <= 0 in gmt_ker(x)\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "x <= 0 in gmt_ker(x)\n");
 		return (GMT->session.d_NaN);
 	}
 
@@ -785,7 +785,7 @@ double gmt_kei (struct GMT_CTRL *GMT, double x) {
 		/* Zero is valid.  If near enough to zero, return kei(0)  */
 		if (x > -GMT_CONV8_LIMIT) return (-0.25 * M_PI);
 
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "x < 0 in gmt_kei(x)\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "x < 0 in gmt_kei(x)\n");
 		return (GMT->session.d_NaN);
 	}
 
@@ -951,12 +951,12 @@ double gmt_plm (struct GMT_CTRL *GMT, int l, int m, double x) {
 
 	/* x is cosine of colatitude and must be -1 <= x <= +1 */
 	if (fabs(x) > 1.0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "|x| > 1.0 in gmt_plm\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "|x| > 1.0 in gmt_plm\n");
 		return (GMT->session.d_NaN);
 	}
 
 	if (m < 0 || m > l) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_plm requires 0 <= m <= l.\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_plm requires 0 <= m <= l.\n");
 		return (GMT->session.d_NaN);
 	}
 
@@ -1026,7 +1026,7 @@ double gmt_plm_bar (struct GMT_CTRL *GMT, int l, int m, double x, bool ortho) {
 	/* x is cosine of colatitude (sine of latitude) and must be -1 <= x <= +1 */
 
 	if (fabs (x) > 1.0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "|x| > 1.0 in gmt_plm_bar\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "|x| > 1.0 in gmt_plm_bar\n");
 		return (GMT->session.d_NaN);
 	}
 
@@ -1038,7 +1038,7 @@ double gmt_plm_bar (struct GMT_CTRL *GMT, int l, int m, double x, bool ortho) {
 	}
 
 	if (m > l) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_plm_bar requires 0 <= m <= l.\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_plm_bar requires 0 <= m <= l.\n");
 		return (GMT->session.d_NaN);
 	}
 
@@ -1135,7 +1135,7 @@ void gmt_plm_bar_all (struct GMT_CTRL *GMT, int lmax, double x, bool ortho, doub
 	/* x is cosine of colatitude (sine of latitude) and must be -1 <= x <= +1 */
 
 	if (fabs (x) > 1.0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "|x| > 1.0 in gmt_plm_bar_all\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "|x| > 1.0 in gmt_plm_bar_all\n");
 		return;
 	}
 
@@ -1214,7 +1214,7 @@ double gmt_factorial (struct GMT_CTRL *GMT, int n) {
 	int i;
 
 	if (n < 0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "n < 0 in gmt_factorial(n)\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "n < 0 in gmt_factorial(n)\n");
 		return (GMT->session.d_NaN);
 		/* This could be set to return 0 without warning, to facilitate
 			sums over binomial coefficients, if desired.  -whfs  */
@@ -1230,7 +1230,7 @@ double gmt_factorial (struct GMT_CTRL *GMT, int n) {
 double gmt_permutation (struct GMT_CTRL *GMT, int n, int r) {
 	/* Compute Permutations n_P_r */
 	if (n < 0 || r < 0 || r > n) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "n < 0 or r < 0 or r > n in gmt_permutation(n,r)\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "n < 0 or r < 0 or r > n in gmt_permutation(n,r)\n");
 		return (GMT->session.d_NaN);
 	}
 	return (floor (0.5 + exp (gmtstat_factln (GMT, n) - gmtstat_factln (GMT, n-r))));
@@ -1239,7 +1239,7 @@ double gmt_permutation (struct GMT_CTRL *GMT, int n, int r) {
 double gmt_combination (struct GMT_CTRL *GMT, int n, int r) {
 	/* Compute Combinations n_C_r */
 	if (n < 0 || r < 0 || r > n) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "n < 0 or r < 0 or r > n in gmt_combination(n,r)\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "n < 0 or r < 0 or r > n in gmt_combination(n,r)\n");
 		return (GMT->session.d_NaN);
 	}
 	return (floor (0.5 + exp (gmtstat_factln (GMT, n) - gmtstat_factln (GMT, r) - gmtstat_factln (GMT, n-r))));
@@ -1925,7 +1925,7 @@ int gmt_mode (struct GMT_CTRL *GMT, double *x, uint64_t n, uint64_t j, bool sort
 	for (i = 0; i < istop; i++) {
 		length = x[i + j] - x[i];
 		if (length < 0.0) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_mode: Array not sorted in non-decreasing order.\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_mode: Array not sorted in non-decreasing order.\n");
 			return (-1);
 		}
 		else if (length == short_length) {	/* Possibly multiple mode */
@@ -1981,7 +1981,7 @@ int gmt_mode_f (struct GMT_CTRL *GMT, gmt_grdfloat *x, uint64_t n, uint64_t j, b
 	for (i = 0; i < istop; i++) {
 		length = x[i + j] - x[i];
 		if (length < 0.0) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_mode_f: Array not sorted in non-decreasing order.\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_mode_f: Array not sorted in non-decreasing order.\n");
 			return (-1);
 		}
 		else if (length == short_length) {	/* Possibly multiple mode */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -1212,7 +1212,7 @@ GMT_LOCAL struct CPT_Z_SCALE *support_cpt_parse (struct GMT_CTRL *GMT, char *fil
 	if ((c = strstr (file, "+h"))) {	/* Gave hinge modifier, examine and set parameters */
 		if (c[2]) {	/* Gave hinge value for soft hinge */
 			if (gmt_verify_expectations (GMT, gmt_M_type (GMT, GMT_IN, GMT_Z), gmt_scanf (GMT, &c[2], gmt_M_type (GMT, GMT_IN, GMT_Z), z_hinge), &c[2])) {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "support_cpt_parse: CPT hinge modifier %s was not successfully parsed and is ignored.\n", c);
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "support_cpt_parse: CPT hinge modifier %s was not successfully parsed and is ignored.\n", c);
 			}
 			else {	/* Parsed successfully, this turns a soft CPT hinge to a hard user hinge */
 				c[0] = '\0';	/* Chop off the hinge specification from the file name */
@@ -1231,7 +1231,7 @@ GMT_LOCAL struct CPT_Z_SCALE *support_cpt_parse (struct GMT_CTRL *GMT, char *fil
 	mode = (c[1] == 'u') ? 0 : 1;
 	u_number = gmtlib_get_unit_number (GMT, c[2]);		/* Convert char unit to enumeration constant for this unit */
 	if (u_number == GMT_IS_NOUNIT) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "CPT z unit specification %s was unrecognized (part of file name?) and is ignored.\n", c);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "CPT z unit specification %s was unrecognized (part of file name?) and is ignored.\n", c);
 		return NULL;
 	}
 	/* Got a valid unit */
@@ -3858,15 +3858,15 @@ GMT_LOCAL uint64_t support_delaunay_watson (struct GMT_CTRL *GMT, double *x_in, 
 		qsort (P, n, sizeof (struct GMT_PAIR), support_sort_pair);
 		for (i = 1; i < n; i++) {
 			if (doubleAlmostEqualZero (P[i].x, P[i-1].x) && doubleAlmostEqualZero (P[i].y, P[i-1].y)) {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Records %" PRIu64 " and %" PRIu64 " are duplicates!\n", P[i-1].rec, P[i].rec);
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Records %" PRIu64 " and %" PRIu64 " are duplicates!\n", P[i-1].rec, P[i].rec);
 				n_duplicates++;
 			}
 		}
 		if (n_duplicates) {	/* Clearly not monotonically increasing or decreasing in x */
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bug Report Advice for Watson ACORD External Code:\n");
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "The Watson algorithm can fail if there are duplicate (x,y) records.\n");
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "We found %" PRIu64 " duplicate records in your data set.\n", n_duplicates);
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Please remove duplicates and redo your analysis if the results are corrupted.\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Bug Report Advice for Watson ACORD External Code:\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "The Watson algorithm can fail if there are duplicate (x,y) records.\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "We found %" PRIu64 " duplicate records in your data set.\n", n_duplicates);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Please remove duplicates and redo your analysis if the results are corrupted.\n");
 		}
 		gmt_M_free (GMT, P);
 	}
@@ -4050,12 +4050,12 @@ GMT_LOCAL int support_ensure_new_mapinset_syntax (struct GMT_CTRL *GMT, char opt
 					}
 					break;
 				case 'g':	/* Fill specification [Obsolete, now done via panel attributes ] */
-					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  Insert fill attributes now given with panel setting (-F)\n", option);
+					GMT_Report (GMT->parent, GMT_MSG_WARNING, "Option -%c:  Insert fill attributes now given with panel setting (-F)\n", option);
 					strcat (panel_txt, "+g");
 					strcat (panel_txt, &p[1]);
 					break;
 				case 'p':	/* Pen specification [Obsolete, now done via panel attributes ] */
-					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  Insert pen attributes now given with panel setting (-F)\n", option);
+					GMT_Report (GMT->parent, GMT_MSG_WARNING, "Option -%c:  Insert pen attributes now given with panel setting (-F)\n", option);
 					strcat (panel_txt, "+p");
 					strcat (panel_txt, &p[1]);
 					break;
@@ -4834,7 +4834,7 @@ GMT_LOCAL int support_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name, s
 				 	if (OP[k+1] == '=') s->operator = 'G';	/* Let >= be called operator G */
 					break;
 				case '=':	/* Equal [Default] */
-					if (OP[k+1] != '=') GMT_Report (GMT->parent, GMT_MSG_ERROR, "Please use == to indicate equality operator\n");
+					if (OP[k+1] != '=') GMT_Report (GMT->parent, GMT_MSG_WARNING, "Please use == to indicate equality operator\n");
 					if (gmt_M_is_dnan (s->const_val[0])) s->operator = 'E';	/* Let var == NaN be called operator E (equals NaN) */
 					break;
 			}
@@ -4955,7 +4955,7 @@ GMT_LOCAL int support_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name, s
 						switch (p[0]) {
 							case 'f':	/* Change font [Note: font size is ignored as the size argument take precedent] */
 								if (gmt_getfont (GMT, &p[1], &s->font))
-									GMT_Report (GMT->parent, GMT_MSG_ERROR, "Macro code l contains bad +<font> modifier (set to %s)\n", gmt_putfont (GMT, &s->font));
+									GMT_Report (GMT->parent, GMT_MSG_WARNING, "Macro code l contains bad +<font> modifier (set to %s)\n", gmt_putfont (GMT, &s->font));
 								break;
 							case 'j':	s->justify = gmt_just_decode (GMT, &p[1], PSL_NO_DEF);	break;	/* text justification */
 							default:
@@ -4970,7 +4970,7 @@ GMT_LOCAL int support_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name, s
 					GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Warning in macro l: <string>[%%<font>] is deprecated syntax, use +f<font> instead\n");
 					*c = 0;		/* Replace % with the end of string NUL indicator */
 					c++;		/* Go to next character */
-					if (gmt_getfont (GMT, c, &s->font)) GMT_Report (GMT->parent, GMT_MSG_ERROR, "Custom symbol subcommand l contains bad GMT4-style font information (set to %s)\n", gmt_putfont (GMT, &GMT->current.setting.font_annot[GMT_PRIMARY]));
+					if (gmt_getfont (GMT, c, &s->font)) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Custom symbol subcommand l contains bad GMT4-style font information (set to %s)\n", gmt_putfont (GMT, &GMT->current.setting.font_annot[GMT_PRIMARY]));
 				}
 
 				break;
@@ -6251,7 +6251,7 @@ bool gmt_getrgb (struct GMT_CTRL *GMT, char *line, double rgb[]) {
 	if ((t = strstr (buffer, "@")) && strlen (t) > 1) {	/* User requested transparency via @<transparency> */
 		double transparency = atof (&t[1]);
 		if (transparency < 0.0 || transparency > 100.0)
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Representation of transparency (%s) not recognized. Using default [0 or opaque].\n", line);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Representation of transparency (%s) not recognized. Using default [0 or opaque].\n", line);
 		else
 			rgb[3] = hsv[3] = cmyk[4] = transparency / 100.0;	/* Transparency is in 0-1 range */
 		t[0] = '\0';	/* Chop off transparency for the rest of this function */
@@ -6355,7 +6355,7 @@ void gmtlib_enforce_rgb_triplets (struct GMT_CTRL *GMT, char *text, unsigned int
 	while (text[i]) buffer[k++] = text[i++];
 	buffer[k++] = '\0';	/* Properly terminate buffer */
 
-	if (k > size) GMT_Report (GMT->parent, GMT_MSG_ERROR, "Replacement string too long - truncated\n");
+	if (k > size) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Replacement string too long - truncated\n");
 	strncpy (text, buffer, k);	/* Copy back the revised string */
 }
 
@@ -6382,7 +6382,7 @@ int gmt_getfont (struct GMT_CTRL *GMT, char *buffer, struct GMT_FONT *F) {
 		s[0] = 0, i = 1;	/* Chop of this modifier */
 		if (s[1] == '~') F->form |= 8, i = 2;	/* Want to have an outline that does not obscure the text */
 		if (gmt_getpen (GMT, &s[i], &F->pen))
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Representation of font outline pen not recognized - ignored.\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Representation of font outline pen not recognized - ignored.\n");
 		else
 			F->form |= 2;	/* Turn on outline font flag */
 		F->set = 2;	/* Means we specified font pen */
@@ -6599,10 +6599,10 @@ bool gmt_getpen (struct GMT_CTRL *GMT, char *buffer, struct GMT_PEN *P) {
 				case 'a': case 'b': case 'e': case 'g': case 'h': case 'j': case 'l': case 'm': case 'n': case 'p': case 'q':
 					 case 'r': case 't': case 'z':	/* These are possible modifiers within +v vector specifications */
 					if (processed_vector) break;
-					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Pen modifier (%s) not recognized.\n", p);
+					GMT_Report (GMT->parent, GMT_MSG_WARNING, "Pen modifier (%s) not recognized.\n", p);
 					break;
 				default:
-					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Pen modifier (%s) not recognized.\n", p);
+					GMT_Report (GMT->parent, GMT_MSG_WARNING, "Pen modifier (%s) not recognized.\n", p);
 					break;
 			}
 		}
@@ -9780,7 +9780,7 @@ struct GMT_DATASET *gmt_make_profiles (struct GMT_CTRL *GMT, char option, char *
 			struct GMT_DATASEGMENT *prev_S = T->segment[T->n_segments-1];
 			uint64_t start = prev_S->n_rows, add = S->n_rows - 1, rec;
 			if (gmt_alloc_segment (GMT, prev_S, prev_S->n_rows + S->n_rows - 1, prev_S->n_columns, GMT_NO_STRINGS, false)) {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_make_profiles: Cannot reallocate the existing segment");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_make_profiles: Cannot reallocate the existing segment");
 				T->segment[T->n_segments++] = S;	/* Hook into table */
 			}
 			else {	/* Copy over but avoid repeating the joint */
@@ -9910,7 +9910,7 @@ int gmt_decorate_prep (struct GMT_CTRL *GMT, struct GMT_DECORATE *G, double xyz[
 			gmt_M_free (GMT, G->f_xy[GMT_Y]);
 		}
 		if (GMT_Destroy_Data (GMT->parent, &T) != GMT_NOERROR)
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  Failed to free DATASET allocated to parse %s\n",
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Option -%c:  Failed to free DATASET allocated to parse %s\n",
 				G->flag, G->file);
 	}
 
@@ -10034,7 +10034,7 @@ int gmt_contlabel_prep (struct GMT_CTRL *GMT, struct GMT_CONTOUR *G, double xyz[
 			if (G->f_label) gmt_M_free (GMT, G->f_label);
 		}
 		if (GMT_Destroy_Data (GMT->parent, &T) != GMT_NOERROR)
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  Failed to free DATASET allocated to parse %s\n",
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Option -%c:  Failed to free DATASET allocated to parse %s\n",
 			            G->flag, G->file);
 	}
 
@@ -12678,7 +12678,7 @@ void gmt_str_setcase (struct GMT_CTRL *GMT, char *value, int mode) {
 	else if (mode == +1)
 		gmt_str_toupper (value);
 	else
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad mode (%d)\n", mode);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Bad mode (%d) passed to gmt_str_setcase\n", mode);
 }
 
 char *gmt_first_modifier (struct GMT_CTRL *GMT, char *string, const char *sep) {
@@ -14114,7 +14114,7 @@ int gmt_flip_justify (struct GMT_CTRL *GMT, unsigned int justify) {
 		case 11: j = 1;		break;
 		default:
 			j = justify;
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_flip_justify called with incorrect argument (%d)\n", j);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_flip_justify called with incorrect argument (%d)\n", j);
 			break;
 	}
 

--- a/src/gmt_vector.c
+++ b/src/gmt_vector.c
@@ -217,7 +217,7 @@ GMT_LOCAL int vector_svdcmp_nr (struct GMT_CTRL *GMT, double *a, unsigned int m_
 				break;
 			}
 			if (its == 30) {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Error in gmt_svdcmp: No convergence in 30 iterations\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Error in gmt_svdcmp: No convergence in 30 iterations\n");
 #ifndef _OPENMP
 				return (GMT_RUNTIME_ERROR);
 #endif
@@ -829,7 +829,7 @@ int gmt_jacobi (struct GMT_CTRL *GMT, double *a, unsigned int n, unsigned int m,
 	/* Return 0 if converged; else print warning and return -1:  */
 
 	if (nsweeps == MAX_SWEEPS) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_jacobi failed to converge in %d sweeps\n", nsweeps);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_jacobi failed to converge in %d sweeps\n", nsweeps);
 		return(-1);
 	}
 	return(0);
@@ -1495,12 +1495,12 @@ uint64_t gmt_fix_up_path (struct GMT_CTRL *GMT, double **a_lon, double **a_lat, 
 		/* Follow great circle */
 		else if ((theta = d_acosd (gmt_dot3v (GMT, a, b))) == 180.0) {	/* trouble, no unique great circle */
 			if (gmt_M_is_spherical (GMT) || ((lat[i] + lat[i-1]) == 0.0)) {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Two points in input list are antipodal - great circle resampling is not unique!\n");
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Fix input data or use project -A to generate the desired great circle by providing an azimuth.\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Two points in input list are antipodal - great circle resampling is not unique!\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Fix input data or use project -A to generate the desired great circle by providing an azimuth.\n");
 			}
 			else {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Two points in input list are antipodal - great circle resampling is not unique!\n");
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "There are two possible geodesics but GMT does not currently calculate geodesics.\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Two points in input list are antipodal - great circle resampling is not unique!\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "There are two possible geodesics but GMT does not currently calculate geodesics.\n");
 			}
 			return 0;
 		}


### PR DESCRIPTION
Error messages should really be bad things and most likely exit the program.  Because of how the verbosity settings worked, we had over the years elevated may warnings to errors so the users would see the ones we thought were important.  Now, with default verbosity showing warnings we move these to MSG_WARNING again.
