### PR TITLE
Clean up unused codes in animate.in

### DIFF
--- a/doc/examples/animate.in
+++ b/doc/examples/animate.in
@@ -9,11 +9,7 @@ test -z "$1" && exit 1
 # Where the current script resides (need absolute path)
 script_name="$1"
 script_dir=$(dirname "${script_name}")
-local_script=$(basename "${script_name}")
 script="@GMT_SOURCE_DIR@/doc/examples/${script_name}"
-# Any script override of GRAPHICSMAGICK_RMS?  Must be a comment line of the format
-# GRAPHICSMAGICK_RMS = <custom-limit>
-GRAPHICSMAGICK_RMS=$(grep "GRAPHICSMAGICK_RMS" "$script" | awk '{print $4}')
 if ! [ -x "${script}" ]; then
   echo "error: cannot execute script ${script}." >&2
   exit 1
@@ -31,25 +27,8 @@ fi
 # Temporary change LANG to C
 LANG=C
 
-# Define variables that are needed *within* test scripts
-GMT_SOURCE_DIR="@GMT_SOURCE_DIR@"
-GRAPHICSMAGICK="@GRAPHICSMAGICK@"
-# If no script-specific rms we use the system default
-if [ -z "$GRAPHICSMAGICK_RMS" ]; then
-	GRAPHICSMAGICK_RMS="@GRAPHICSMAGICK_RMS@"
-fi
-src="@GMT_SOURCE_DIR@/doc/examples/${script_dir}"
-
-# Font lookup path for Ghostscript (invoked from gm compare and psconvert)
-export GS_FONTPATH="@CMAKE_CURRENT_SOURCE_DIR@/ex31/fonts"
-
 # Use executables from GMT_BINARY_DIR, fallback to CMAKE_INSTALL_PREFIX/GMT_BINDIR
-unset GMT5_SHAREDIR
-export PATH="@GMT_BINARY_DIR@/src:$PATH" # for gmt_shell_functions.sh
 export GMT_SHAREDIR="@GMT_SOURCE_DIR@/share"
-
-# Reset error count
-ERROR=0
 
 # gmt wrapper
 function gmt()
@@ -60,17 +39,6 @@ function gmt()
 # export function definitions to subshells
 export -f gmt
 
-set -E # Shell functions and subshells need to inherit ERR trap
-
-function on_err()
-{
-  trap - ERR SIGSEGV SIGTRAP SIGBUS # Restore trap
-  ((++ERROR))
-  echo "ERROR: ${1}:${2}" >&2 # Report error line
-  exit $ERROR
-}
-trap 'on_err "${BASH_SOURCE}" "${LINENO}"' ERR SIGSEGV SIGTRAP SIGBUS
-
 # Create a temporary directory exec_dir in the build dir
 # Then copy all of its contents (except files excluded by GLOBIGNORE)
 # Run remainder of this GMT script there
@@ -79,7 +47,7 @@ rm -rf "$exec_dir"
 mkdir -p "$exec_dir"
 cd "$exec_dir"
 shopt -s extglob
-GLOBIGNORE="!(*.bat|*.ps|*.sh)"
+GLOBIGNORE="!(*.bat|*.sh)"
 for file in "$src"/* ; do
   test -f "$file" && ln -s "$file" .
 done


### PR DESCRIPTION
animate.in is used to run animation scripts. The testings of animation
scripts are done in another script `gmtest.in`. Thus some codes in
animate.in are unnecessary.

Tested locally and it still works.