### PR TITLE
Add a CI job to check if gmt_make_*.sh need to be run manually

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -18,6 +18,26 @@ variables:
 
 jobs:
 
+- job:
+  displayName: 'Code Checker'
+
+  steps:
+  - bash: |
+      set -x
+      cd src
+      bash gmt_make_PSL_strings.sh
+      bash gmt_make_pattern_include.sh
+      bash gmt_make_module_src.sh core
+      bash gmt_make_module_src.sh supplements
+      bash gmt_make_enum_dicts.sh
+
+      # check if any files are changed
+      if [ $(git ls-files -m) ]; then
+        git diff HEAD
+        exit 1
+      fi
+    displayName: Check if any C codes and headers need to be manually updated
+
 # Lint Checker
 - job:
   displayName: 'Lint Checker'

--- a/src/gmt_make_enum_dicts.sh
+++ b/src/gmt_make_enum_dicts.sh
@@ -7,6 +7,10 @@
 # This script just makes the include snippet gmt_enum_dict.h
 # needed for GMT_API_Enum () to work.
 #
+
+# Set LC_ALL to get the same sort order on Linux and macOS
+export LC_ALL=C
+
 egrep -v 'struct|union|enum|_GMT|define|char' gmt_resources.h | tr ',' ' ' | awk '{if (substr($1,1,4) == "GMT_") print $1, $3}' > /tmp/junk1.txt
 grep -v GMT_OPT_ /tmp/junk1.txt > /tmp/junk2.txt
 grep GMT_OPT_ /tmp/junk1.txt | awk '{print $1, substr($2,1,2)} '> /tmp/junk3.txt

--- a/src/gmt_make_module_src.sh
+++ b/src/gmt_make_module_src.sh
@@ -25,6 +25,9 @@ EOF
 fi
 set -e
 
+# Set LC_ALL to get the same sort order on Linux and macOS
+export LC_ALL=C
+
 LIB=$1
 # Make sure we get both upper- and lower-case versions of the tag
 U_TAG=$(echo $LIB | tr '[a-z]' '[A-Z]')


### PR DESCRIPTION
This PR adds a CI job to check if gmt_core_modules.c et al. are outdated.

Also add `export LC_ALL=C` to `gmt_make_enum_dicts.sh` and `gmt_make_module_src.sh` so that `sort` command gives the same sort order on Linux and macOS.

