### PR TITLE
Update gmt_enum_dict.h

### DIFF
--- a/src/gmt_enum_dict.h
+++ b/src/gmt_enum_dict.h
@@ -20,7 +20,7 @@
  * Rerun gmt_make_enum_dicts.sh after adding or changing enums.
  *
  * Author:      Paul Wessel
- * Date:        23-November-2019
+ * Date:        07-February-2020
  * Version:     6 API
  */
 
@@ -29,7 +29,7 @@ struct GMT_API_DICT {
 	int value;
 };
 
-#define GMT_N_API_ENUMS 223
+#define GMT_N_API_ENUMS 230
 
 GMT_LOCAL struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_ADD_DEFAULT", 6},
@@ -65,12 +65,15 @@ GMT_LOCAL struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_COMMENT_IS_TITLE", 8},
 	{"GMT_CONTAINER_AND_DATA", 0},
 	{"GMT_CONTAINER_ONLY", 1},
+	{"GMT_CPT_COLORLIST", 32},
 	{"GMT_CPT_EXTEND_BNF", 2},
+	{"GMT_CPT_HARD_HINGE", 4},
 	{"GMT_CPT_HINGED", 4},
 	{"GMT_CPT_NO_BNF", 1},
 	{"GMT_CPT_OPTIONAL", 1},
 	{"GMT_CPT_REQUIRED", 0},
-	{"GMT_CPT_TIME", 8},
+	{"GMT_CPT_SOFT_HINGE", 8},
+	{"GMT_CPT_TIME", 16},
 	{"GMT_DATA_ONLY", 2},
 	{"GMT_DATETIME", 11},
 	{"GMT_DOUBLE", 9},
@@ -159,12 +162,16 @@ GMT_LOCAL struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_MODULE_PURPOSE", -2},
 	{"GMT_MODULE_SYNOPSIS", -6},
 	{"GMT_MODULE_USAGE", -7},
-	{"GMT_MSG_COMPAT", 3},
+	{"GMT_MSG_COMPAT", 5},
 	{"GMT_MSG_DEBUG", 6},
-	{"GMT_MSG_INFORMATION", 5},
 	{"GMT_MSG_ERROR", 1},
-	{"GMT_MSG_TICTOC", 2},
-	{"GMT_MSG_WARNING", 4},
+	{"GMT_MSG_INFORMATION", 4},
+	{"GMT_MSG_LONG_VERBOSE", 5},
+	{"GMT_MSG_NORMAL", 1},
+	{"GMT_MSG_QUIET", 0},
+	{"GMT_MSG_TICTOC", 3},
+	{"GMT_MSG_VERBOSE", 4},
+	{"GMT_MSG_WARNING", 2},
 	{"GMT_NAN", 2},
 	{"GMT_NOERROR", 0},
 	{"GMT_NOTSET", -1},

--- a/src/gmt_enum_dict.h
+++ b/src/gmt_enum_dict.h
@@ -20,7 +20,6 @@
  * Rerun gmt_make_enum_dicts.sh after adding or changing enums.
  *
  * Author:      Paul Wessel
- * Date:        07-February-2020
  * Version:     6 API
  */
 

--- a/src/gmt_make_PSL_strings.sh
+++ b/src/gmt_make_PSL_strings.sh
@@ -38,7 +38,7 @@ while read file; do
 	n=$(cat $file | wc -l)
 	let n1=n-1
 	varname=$(basename $file .ps)
-	sed -n 1,${n1}p $file | awk 'BEGIN {printf "static char *%s_str = \n", "'$varname'"}; {printf "\"%s\\n\"\n", $0}' >> PSL_strings.h
+	sed -n 1,${n1}p $file | awk 'BEGIN {printf "static char *%s_str =\n", "'$varname'"}; {printf "\"%s\\n\"\n", $0}' >> PSL_strings.h
 	sed -n ${n}p $file | awk '{printf "\"%s\\n\";\n", $0}'>> PSL_strings.h
 done < /tmp/t.lis
 rm -f /tmp/t.lis

--- a/src/gmt_make_enum_dicts.sh
+++ b/src/gmt_make_enum_dicts.sh
@@ -15,7 +15,6 @@ while read key value; do
 done < /tmp/junk3.txt
 n=$(wc -l < /tmp/junk2.txt | awk '{printf "%d\n", $1}')
 COPY_YEAR=$(date +%Y)
-NOW=$(date +%d-%B-%Y)
 cat << EOF > gmt_enum_dict.h
 /*--------------------------------------------------------------------
  *
@@ -39,7 +38,6 @@ cat << EOF > gmt_enum_dict.h
  * Rerun gmt_make_enum_dicts.sh after adding or changing enums.
  *
  * Author:      Paul Wessel
- * Date:        $NOW
  * Version:     6 API
  */
 


### PR DESCRIPTION
- Update `gmt_enum_dict.h` by running `gmt_make_enum_dicts.sh`
- Remove date from `gmt_enum_dict.h`
- Fix `gmt_make_PSL_strings.sh` to avoid a trailing whitespace