### PR TITLE
Only run cppcheck in scheduled jobs

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -30,7 +30,6 @@ jobs:
       bash gmt_make_module_src.sh core
       bash gmt_make_module_src.sh supplements
       bash gmt_make_enum_dicts.sh
-
       # check if any files are changed
       if [ $(git ls-files -m) ]; then
         git diff HEAD
@@ -41,7 +40,8 @@ jobs:
 # Lint Checker
 - job:
   displayName: 'Lint Checker'
-  timeoutInMinutes: 180
+  timeoutInMinutes: 360
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   pool:
     vmImage: 'ubuntu-18.04'


### PR DESCRIPTION
cppcheck is useful but slow.
This PR remove the cppcheck stuff from PR jobs. cppcheck will be run
nightly.