### PR TITLE
Address some cppcheck warnings

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -11776,6 +11776,10 @@ char *gmtlib_putfill (struct GMT_CTRL *GMT, struct GMT_FILL *F) {
 	static char text[PATH_MAX+GMT_LEN256] = {""};
 	int i;
 
+	if (F == NULL) {	/* Mostly for the benefit of cppcheck */
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtlib_putfill called with NULL fill pointer!\n");
+		return (text);
+	}
 	if (F->use_pattern) {
 		if (F->pattern_no)
 			snprintf (text, PATH_MAX+GMT_LEN256, "p%d/%d", F->dpi, F->pattern_no);

--- a/src/gmt_parse.c
+++ b/src/gmt_parse.c
@@ -276,7 +276,7 @@ GMT_LOCAL int parse_complete_options (struct GMT_CTRL *GMT, struct GMT_OPTION *o
 	}
 	for (k = 0, B_id = GMT_NOTSET; k < GMT_N_UNIQUE && B_id == GMT_NOTSET; k++)
 		if (!strcmp (GMT_unique_option[k], "B")) B_id = k;	/* B_id === 0 but just in case this changes we do this search anyway */
-	assert (B_id != GMT_NOTSET);
+	assert (B_id != GMT_NOTSET);	/* Safety valve just in case */
 	check_B = (strncmp (GMT->init.module_name, "psscale", 7U) && strncmp (GMT->init.module_name, "docs", 4U));
 	if (GMT->current.setting.run_mode == GMT_MODERN && n_B && check_B) {	/* Write gmt.frame file unless module is psscale, overwriting any previous file */
 		char file[PATH_MAX] = {""};

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -2462,7 +2462,7 @@ static int psl_search_userimages (struct PSL_CTRL *PSL, char *imagefile) {
 }
 
 static int psl_pattern_init (struct PSL_CTRL *PSL, int image_no, char *imagefile, unsigned char *image, unsigned int width, unsigned int height, unsigned int depth) {
-	int k;
+	int k, i;
 	unsigned char *picture = NULL;
 	/* image_no is 1-90 (PSL_N_PATTERNS) if a standard PSL pattern, else we examine imagefile.
 	 * User images are numbered PSL_N_PATTERNS+1,2,3 etc. */
@@ -2472,7 +2472,11 @@ static int psl_pattern_init (struct PSL_CTRL *PSL, int image_no, char *imagefile
 		picture = PSL_pattern[k];
 	}
 	else {	/* User image, check to see if already used */
-		int i = psl_search_userimages (PSL, imagefile);	/* i = 0 is the first user image */
+		if (imagefile == NULL) {
+			PSL_message (PSL, PSL_MSG_ERROR, "Error: Gave NULL as imagefile name\n");
+			PSL_exit (EXIT_FAILURE);
+		}
+		i = psl_search_userimages (PSL, imagefile);	/* i = 0 is the first user image */
 		if (i >= 0) return (PSL_N_PATTERNS + i + 1);	/* Already registered, just return number */
 		if (PSL->internal.n_userimages > (PSL_N_PATTERNS-1)) {
 			PSL_message (PSL, PSL_MSG_ERROR, "Error: Already maintaining %d user images and cannot accept any more\n", PSL->internal.n_userimages+1);


### PR DESCRIPTION
These situations are not curently happening in GMT but we might as well prevent them.  I notice that cppcheck does not understand the assert statement and thinks the value of the variable that would trigger the assert exit somehow can exist afterwards...
