### PR TITLE
Add acknowledgment of software GMT relies on

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,21 @@ Copyright (c) 1991-2020 by [the GMT Team](AUTHORS.md).
 GMT is released under the
 [GNU Lesser General Public License](http://www.gnu.org/licenses/lgpl.html)
 version 3 or any later version. See [LICENSE.TXT](LICENSE.TXT) for full details.
+
+## Acknowledgment
+
+GMT relies on several other Open Source software libraries and programs for its
+operation.  We gratefullly acknowledge the importance to GMT of these products.
+GMT may be linked with these libraries (some are optional):
+[Geospatial Data Abstraction Library (GDAL)](https://gdal.org),
+[Network Common Data Form (netCDF)](https://www.unidata.ucar.edu/software/netcdf/),
+[Perl Compatible Regular Expressions (PCRE)](https://www.pcre.org), 
+[Fastest Fourier Transform in the West (FFTW)](http://www.fftw.org),
+[Linear Algebra Package (LAPACK)](http://www.netlib.org/lapack/),
+[Basic Linear Algebra Subprograms (BLAS)](http://www.netlib.org/blas/), and
+[ZLIB](https://www.zlib.net). GMT may call these executables:
+GDAL (ogr2ogr, gdal_info), [Ghostscript](https://www.ghostscript.com),
+[FFmpeg(https://www.ffmpeg.org)],
+[dxg-open](https://www.freedesktop.org/wiki/Software/xdg-utils/), and
+[GraphicsMagick](http://www.graphicsmagick.org).
+

--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ GMT may be linked with these libraries (some are optional):
 [Basic Linear Algebra Subprograms (BLAS)](http://www.netlib.org/blas/), and
 [ZLIB](https://www.zlib.net). GMT may call these executables:
 GDAL (ogr2ogr, gdal_info), [Ghostscript](https://www.ghostscript.com),
-[FFmpeg(https://www.ffmpeg.org)],
+[FFmpeg](https://www.ffmpeg.org),
 [dxg-open](https://www.freedesktop.org/wiki/Software/xdg-utils/), and
 [GraphicsMagick](http://www.graphicsmagick.org).
-

--- a/README.md
+++ b/README.md
@@ -103,5 +103,5 @@ GMT may be linked with these libraries (some are optional):
 [ZLIB](https://www.zlib.net). GMT may call these executables:
 GDAL (ogr2ogr, gdal_info), [Ghostscript](https://www.ghostscript.com),
 [FFmpeg](https://www.ffmpeg.org),
-[dxg-open](https://www.freedesktop.org/wiki/Software/xdg-utils/), and
+[xdg-open](https://www.freedesktop.org/wiki/Software/xdg-utils/), and
 [GraphicsMagick](http://www.graphicsmagick.org).

--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ version 3 or any later version. See [LICENSE.TXT](LICENSE.TXT) for full details.
 
 GMT relies on several other Open Source software libraries and programs for its
 operation.  We gratefully acknowledge the importance to GMT of these products.
-GMT may be linked with these libraries (some are optional):
-[Geospatial Data Abstraction Library (GDAL)](https://gdal.org),
+GMT may be linked with these libraries (* means optional):
 [Network Common Data Form (netCDF)](https://www.unidata.ucar.edu/software/netcdf/),
-[Perl Compatible Regular Expressions (PCRE)](https://www.pcre.org), 
-[Fastest Fourier Transform in the West (FFTW)](http://www.fftw.org),
-[Linear Algebra Package (LAPACK)](http://www.netlib.org/lapack/),
-[Basic Linear Algebra Subprograms (BLAS)](http://www.netlib.org/blas/), and
-[ZLIB](https://www.zlib.net). GMT may call these executables:
+[Geospatial Data Abstraction Library (GDAL*)](https://gdal.org),
+[Perl Compatible Regular Expressions (PCRE*)](https://www.pcre.org), 
+[Fastest Fourier Transform in the West (FFTW*)](http://www.fftw.org),
+[Linear Algebra Package (LAPACK*)](http://www.netlib.org/lapack/),
+[Basic Linear Algebra Subprograms (BLAS*)](http://www.netlib.org/blas/), and
+[ZLIB*](https://www.zlib.net). GMT may call these executables:
 GDAL (ogr2ogr, gdal_info), [Ghostscript](https://www.ghostscript.com),
 [FFmpeg](https://www.ffmpeg.org),
 [xdg-open](https://www.freedesktop.org/wiki/Software/xdg-utils/), and

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ version 3 or any later version. See [LICENSE.TXT](LICENSE.TXT) for full details.
 ## Acknowledgment
 
 GMT relies on several other Open Source software libraries and programs for its
-operation.  We gratefullly acknowledge the importance to GMT of these products.
+operation.  We gratefully acknowledge the importance to GMT of these products.
 GMT may be linked with these libraries (some are optional):
 [Geospatial Data Abstraction Library (GDAL)](https://gdal.org),
 [Network Common Data Form (netCDF)](https://www.unidata.ucar.edu/software/netcdf/),

--- a/src/gmt.c
+++ b/src/gmt.c
@@ -286,7 +286,24 @@ int main (int argc, char *argv[]) {
 			fprintf (stderr, "Shared libraries must be in standard system paths or set via environmental parameter %s.\n\n", LIB_PATH);
 		}
 		else {
+			char libraries[GMT_LEN128] = {"netCDF"};	/* Always linked with netCDF */
+#ifdef HAVE_GDAL
+			strcat (libraries, ", GDAL");
+#endif
+#ifdef HAVE_PCRE
+			strcat (libraries, ", PCRE");
+#endif
+#ifdef HAVE_FFTW3F
+			strcat (libraries, ", FFTW");
+#endif
+#ifdef HAVE_LAPACK
+			strcat (libraries, ", LAPACK");
+#endif
+#ifdef HAVE_ZLIB
+			strcat (libraries, ", ZLIB");
+#endif
 			fprintf (stderr, "\n\tGMT - The Generic Mapping Tools, Version %s [%u cores]\n", GMT_VERSION, api_ctrl->n_cores);
+			fprintf (stderr, "\t[Linked with %s]\n", libraries);
 			fprintf (stderr, "\t(c) 1991-%d The GMT Team (https://www.generic-mapping-tools.org/team.html).\n\n", GMT_VERSION_YEAR);
 			fprintf (stderr, "Supported in part by the US National Science Foundation (http://www.nsf.gov/)\n");
 			fprintf (stderr, "and volunteers from around the world.\n\n");


### PR DESCRIPTION
The usual list is now added to the end of the README in a new  acknowledgment section.
