### PR TITLE
Let cppcheck ignore src/mergesort.c

### DIFF
--- a/ci/run-cppcheck.sh
+++ b/ci/run-cppcheck.sh
@@ -19,7 +19,7 @@ if [ "$BUILD_REASON" == "Schedule" ]; then
         ! -name 'gmt_datasets.h' \
         ! -name 'gmt_media_name.h' \
         ! -name 'gmt_unique.h' \
-        ! -name 'src/mergesort.c' \
+        ! -name 'mergesort.c' \
         -exec ${CPPCHECK} {} +
 else
     # Check changed files only for PRs


### PR DESCRIPTION
Fix a bug in #2699.