### PR TITLE
Improve admin/src_replace_word.sh

### DIFF
--- a/admin/src_replace_word.sh
+++ b/admin/src_replace_word.sh
@@ -4,15 +4,15 @@
 # wish to replace one word with another word throughout all
 # C source and include files.  E.g.,
 #
-# admin/replace.sh GMT_MSG_LONG_VERBOSE GMT_MSG_INFORMATION
+#   admin/src_replace_word.sh GMT_MSG_LONG_VERBOSE GMT_MSG_INFORMATION
 #
 
 if [ ! -d cmake ]; then
 	echo "Must be run from top-level gmt directory"
 	exit 1
 fi
-if [ ! $# -eq 2 ]; then
-	echo "usage: replace oldword newword"
+if [ $# -ne 2 ]; then
+	echo "usage: admin/src_replace_word.sh oldword newword"
 	exit 1
 fi
 # 1. Find all source files with word $1 in them
@@ -23,7 +23,7 @@ find -E src \
 
 # 2. Update the files and replace $1 by $2
 while read f; do
-	sed -E -i.bak "s/$1/$2/" $f
+	sed -i.bak "s/$1/$2/g" $f
 	rm -f $f.bak
 done < /tmp/$$.tmp.lis
 


### PR DESCRIPTION
Changes to `admin/src_replace_word.sh`:

- Update comments
- `! $# -eq 2` is equivalent to `$# -ne 2`
- **sed -E** enables extended regular expressions. The script works
  with simple words only, so **-E** is not needed
- When a word occurs multiple times in one line,
  `"s/$1/$2/"` only replaces the first one.
  `"s/$1/$2/g"` can replace any number of occurrences.