### PR TITLE
Error in definition of grd_n and grd_e arrays

### DIFF
--- a/src/geodesy/earthtide.c
+++ b/src/geodesy/earthtide.c
@@ -1166,8 +1166,8 @@ GMT_LOCAL void solid_grd(struct GMT_CTRL *GMT, struct EARTHTIDE_CTRL *Ctrl, stru
 			detide(xsta, mjd, fmjd, rsun, rmoon, etide, &leapflag);
 			/* determine local geodetic horizon components (topocentric) */
 			rge(lat, lons[col], &ut, &vt, &wt, etide[0], etide[1], etide[2]);		/* tide vect */
-			grd_n[ij_n] = (float)ut;
-			grd_e[ij_e] = (float)vt;
+			grd_n[ij_n] = (float)vt;
+			grd_e[ij_e] = (float)ut;
 			grd_u[ij_u] = (float)wt;
 			ij_n += n_inc;
 			ij_e += e_inc;


### PR DESCRIPTION
**Description of proposed changes**
Assignment of vt and ut to grd_n and grd_e, respectively, appear to have been flipped.



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->

**Reminders**

- [ ] Correct base branch selected? `master` for new features, `6.0` for bug fixes
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
