### PR TITLE
Tracking option to grdtrack

### DIFF
--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -111,7 +111,8 @@ Optional Arguments
     *length* sets the full length of each cross-profile, while *ds* is
     the sampling spacing along each cross-profile. Optionally, append
     **/**\ *spacing* for an equidistant spacing between cross-profiles
-    [Default erects cross-profiles at the input coordinates]. By
+    [Default erects cross-profiles at the input coordinates]; see **-A**
+    for how resampling the input track is controlled. By
     default, all cross-profiles have the same direction (left to right
     as we look in the direction of the input line segment). Append **+a**
     to alternate the direction of cross-profiles, or **v** to enforce
@@ -166,17 +167,18 @@ Optional Arguments
 .. _-F:
 
 **-F**\ [**+n**][**+z**\ *z0*]
-    Find critical points along each profile.
-    Run in conjunction with **-C** and a single input grid. We examine each cross-profile
-    and determine (a) the cross-distance to the first non-NaN point whose *z*-value exceeds *z0* [0], (b)
-    the center peak location and cross-distance of maximum *z* value, and the cross-distance to the
-    last non-NaN point whose *z*-value
-    exceeds *z0* [0]. Use **+z** to adjust the threshold value [0].  In searching
-    for values that exceed thresholds and finding the peak we assume the profile is
-    positive up.  If we are looking for a trough then use **+n** to
-    temporarily flip the profile to positive.  The *z0* value is always given as >= 0.
-    We write eight output columns per track with an identified center peak, with values
-    *lon, lat, dist, azimuth, z, left, right, width*.
+    Find critical points along each cross-profile.
+    Requires **-C** and a single input grid. We examine each cross-profile generated
+    and report (*lonc*, *latc*, *distc*, *azimuthc*, *zc*) at the center peak of
+    maximum *z* value, (*lonl*, *latl*, *distl*) and (*lonr*, *latr*, *distr*)
+    at the first and last non-NaN point whose *z*-value exceeds *z0*, respectively,
+    and the *width* based on the two extreme points found. When searching for
+    the center peak and the extreme first and last values that exceed the threshold
+    we assume the profile is positive up.  If we instead are looking
+    for a trough then you must use **+n** to temporarily flip the profile to positive.
+    The threshold *z0* value is always given as >= 0; use **+z** to change it [0].
+    We write 12 output columns per track with an identified center peak, with values
+    *lonc, latc, distc, azimuthc, zc, lonl, latl, distl, lonr, latr, distr, width*.
 
 .. _-N:
 
@@ -332,7 +334,7 @@ erecting cross-profiles every 25 km and sampling the grid every 3 km, try
 
     grdtrack track.xy -Ggrav.18.1.img,0.1,1 -C100k/3/25 -Ar > xprofiles.txt
 
-The same thing, but now determining the central anomaly location alont track,
+The same thing, but now determining the central anomaly location along track,
 with a threshold of 25 mGal, try::
 
     grdtrack track.xy -Ggrav.18.1.img,0.1,1 -C100k/3/25 -F+z25 > locations.txt

--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -14,12 +14,16 @@ Synopsis
 
 **gmt grdtrack** [ *xyfile* ] |-G|\ *grd1* |-G|\ *grd2* ...
 [ |-A|\ **f**\|\ **p**\|\ **m**\|\ **r**\|\ **R**\ [**+l**] ]
-[ |-C|\ *length*/\ *ds*\ [*/spacing*][**+a**][**l**\|\ **r**][**+v**] ] [|-D|\ *dfile* ]
+[ |-C|\ *length*/\ *ds*\ [*/spacing*][**+a**][**l**\|\ **r**][**+v**] ]
+[ |-D|\ *dfile* ]
 [ |-E|\ *line* ]
+[ |-F|\ [**+n**][**+z**\ *z0*] ]
 [ |-N| ]
 [ |SYN_OPT-R| ]
-[ |-S|\ *method*/*modifiers* ] [ |-T|\ [*radius*][**+e**\|\ **p**]]
-[ |-V|\ [*level*] ] [ |-Z| ]
+[ |-S|\ *method*/*modifiers* ]
+[ |-T|\ [*radius*][**+e**\|\ **p**]]
+[ |-V|\ [*level*] ]
+[ |-Z| ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
 [ |SYN_OPT-e| ]
@@ -159,6 +163,21 @@ Optional Arguments
     Note: If **-C** is set and *spacing* is given the that sampling scheme
     overrules any modifier set in **-E**.
 
+.. _-F:
+
+**-F**\ [**+n**][**+z**\ *z0*]
+    Find critical points along each profile.
+    Run in conjunction with **-C** and a single input grid. We examine each cross-profile
+    and determine (a) the cross-distance to the first non-NaN point whose *z*-value exceeds *z0* [0], (b)
+    the center peak location and cross-distance of maximum *z* value, and the cross-distance to the
+    last non-NaN point whose *z*-value
+    exceeds *z0* [0]. Use **+z** to adjust the threshold value [0].  In searching
+    for values that exceed thresholds and finding the peak we assume the profile is
+    positive up.  If we are looking for a trough then use **+n** to
+    temporarily flip the profile to positive.  The *z0* value is always given as >= 0.
+    We write eight output columns per track with an identified center peak, with values
+    *lon, lat, dist, azimuth, z, left, right, width*.
+
 .. _-N:
 
 **-N**
@@ -293,18 +312,14 @@ and only write out (dist, topo) records, try::
 
 To sample the file hawaii_topo.nc along the SEASAT track track_4.xyg
 (An ASCII table containing longitude, latitude, and SEASAT-derived
-gravity, preceded by one header record):
-
-   ::
+gravity, preceded by one header record)::
 
     grdtrack track_4.xyg -Ghawaii_topo.nc -h > track_4.xygt
 
 To sample the Sandwell/Smith IMG format file topo.8.2.img (2 minute
 predicted bathymetry on a Mercator grid) and the Muller et al age grid
 age.3.2.nc along the lon,lat coordinates given in the file
-cruise_track.xy, try
-
-   ::
+cruise_track.xy, try::
 
     grdtrack cruise_track.xy -Gtopo.8.2.img,1,1 -Gage.3.2.nc > depths-age.d
 
@@ -317,11 +332,14 @@ erecting cross-profiles every 25 km and sampling the grid every 3 km, try
 
     grdtrack track.xy -Ggrav.18.1.img,0.1,1 -C100k/3/25 -Ar > xprofiles.txt
 
+The same thing, but now determining the central anomaly location alont track,
+with a threshold of 25 mGal, try::
+
+    grdtrack track.xy -Ggrav.18.1.img,0.1,1 -C100k/3/25 -F+z25 > locations.txt
+
 To sample the grid data.nc along a line from the lower left to the upper
 right corner, using a grid spacing of 1 km on the geodesic, and output distances as well,
-try
-
-   ::
+try::
 
     gmt grdtrack -ELB/RT+i1k+d -Gdata.nc -je > profiles.txt
 

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -97,9 +97,10 @@ struct GRDTRACK_CTRL {
 		double step;
 		char unit;
 	} E;
-	struct GRDTRACK_F {	/* -Fu|l */
+	struct GRDTRACK_F {	/* -F[+n][+z<z0>] */
 		bool active;
-		int mode;
+		bool negative;
+		double z0;
 	} F;
 	struct GRDTRACK_G {	/* -G<grdfile> */
 		bool active;
@@ -163,7 +164,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s -G<grid1> -G<grid2> ... [<table>] [-A[f|m|p|r|R][+l]] [-C<length>/<ds>[/<spacing>][+a][+l|r][+v]]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-D<dfile>] [-E<line1>[,<line2>,...][+a<az>][+c][+d][+i<step>][+l<length>][+n<np][+o<az>][+r<radius>]]\n\t[-N] [%s] [-S[<method>][<modifiers>]] [-T<radius>>[+e|p]] [%s]\n\t[-Z] [%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s]\n\t[%s] [%s] %s] [%s] [%s]\n\n",
+	GMT_Message (API, GMT_TIME_NONE, "\t[-D<dfile>] [-E<line1>[,<line2>,...][+a<az>][+c][+d][+i<step>][+l<length>][+n<np][+o<az>][+r<radius>]]\n\t[-F[+n][+z<z0>]] [-N] [%s] [-S[<method>][<modifiers>]] [-T<radius>>[+e|p]]\n\t[%s] [-Z] [%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s]\n\t[%s] [%s] %s] [%s] [%s]\n\n",
 		GMT_Rgeo_OPT, GMT_V_OPT, GMT_b_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT, GMT_i_OPT, GMT_j_OPT, GMT_n_OPT, GMT_o_OPT, GMT_q_OPT, GMT_s_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -210,6 +211,9 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     +n<np> sets the number of output points and computes <inc> from <length>.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Note:  is optional unit.  Only ONE unit type from %s can be used throughout.\n", GMT_LEN_UNITS2_DISPLAY);
 	GMT_Message (API, GMT_TIME_NONE, "\t     Mixing of units is not allowed [Default unit is km if geographic].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-F Report left, center, and right point per cross-track; requires -C and a single input grid.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   We assume a positive center peak; append +n if dealing with negative trough.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Append +z<z0> to change the detection level for left or right [0].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Do NOT skip points outside the grid domain [Default only returns points inside domain].\n");
 	GMT_Option (API, "R,V");
 	GMT_Message (API, GMT_TIME_NONE, "\t-S In conjunction with -C, compute a single stacked profile from all profiles across each segment.\n");
@@ -351,7 +355,10 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDTRACK_CTRL *Ctrl, struct GM
 				break;
 			case 'F':
 				Ctrl->F.active = true;
-				Ctrl->F.mode = (opt->arg[0] == 'l') ? -1 : +1;
+				if ((c = strstr (opt->arg, "+z")))	/* Gave +z<z0> */
+					Ctrl->F.z0 = atof (&c[2]);
+				if ((c = strstr (opt->arg, "+n")))	/* Gave +n*/
+					Ctrl->F.negative = true;
 				break;
 			case 'G':	/* Input grid file */
 				if (ng == MAX_GRIDS) {
@@ -474,6 +481,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDTRACK_CTRL *Ctrl, struct GM
 	Ctrl->G.n_grids = ng;
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && Ctrl->C.mode & GMT_LEFT_ONLY && Ctrl->C.mode & GMT_RIGHT_ONLY, "Option -C: Cannot chose both +l and +r modifiers.\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->F.active && !Ctrl->C.active, "Option -F: Requires -C.\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->F.active && ng > 1, "Option -F: Can only accept a single grid.\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && !Ctrl->C.active, "Option -S: Requires -C.\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && !(Ctrl->S.selected[STACK_ADD_VAL] || Ctrl->S.selected[STACK_ADD_DEV] ||
 	                                   Ctrl->S.selected[STACK_ADD_RES] || Ctrl->S.selected[STACK_ADD_TBL]),
@@ -1054,62 +1062,66 @@ int GMT_grdtrack (void *V_API, int mode, void *args) {
 				Return (API->error);
 			}
 		}
+		if (Ctrl->F.active) {	/* Find left, center, right point along the crosslines, with width */
+			unsigned int col, tbl, seg, row;
+			int kl, kc, kr;
+			double out[8], z, this_zc, this_zr, z_scl = (Ctrl->F.negative) ? -1 : +1;;
+			struct GMT_DATASEGMENT *S = NULL;
 
-		DH = gmt_get_DD_hidden (Dout);
-		T = Dout->table[0];
-		T->n_headers = 2;
-		T->header = gmt_M_memory (GMT, NULL, T->n_headers, char *);
-		T->header[0] = strdup ("Equidistant cross-profiles normal to each input segment");
-		T->header[1] = strdup (run_cmd);
-		if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_LINE, DH->io_mode, NULL, Ctrl->Out.file, Dout) != GMT_NOERROR) {
-			Return (API->error);
-		}
-		if (GMT_Destroy_Data (API, &Dout) != GMT_NOERROR) {
-			Return (API->error);
-		}
-	}
-	else if (Ctrl->F.active) {	/* Find min/max along the crosslines */
-		unsigned int k, col, tbl, seg, row;
-		double out[5], z;
-		struct GMT_DATASEGMENT *S = NULL;
-
-		if ((error = GMT_Set_Columns (API, GMT_OUT, 5, GMT_COL_FIX_NO_TEXT)) != GMT_NOERROR) {
-			Return (error);
-		}
-		if (GMT_Init_IO (API, GMT_IS_DATASET, GMT_IS_POINT, GMT_OUT, GMT_ADD_DEFAULT, 0, options) != GMT_NOERROR) {	/* Establishes data output */
-			Return (API->error);
-		}
-		if (GMT_Begin_IO (API, GMT_IS_DATASET, GMT_OUT, GMT_HEADER_ON) != GMT_NOERROR) {	/* Enables data output and sets access mode */
-			Return (API->error);
-		}
-		if (GMT_Set_Geometry (API, GMT_OUT, GMT_IS_POINT) != GMT_NOERROR) {	/* Sets output geometry */
-			Return (API->error);
-		}
-		Out = gmt_new_record (GMT, out, NULL);
-		col = 4;	/* First and only grid resample */
-		for (tbl = 0; tbl < Dout->n_tables; tbl++) {
-			T = Dout->table[tbl];
-			for (seg = 0; seg < T->n_segments; seg++) {	/* For each segment to examine */
-				S = T->segment[seg];
-				z = (Ctrl->F.mode == -1) ? DBL_MAX : -DBL_MAX;
-				for (row = 0; row < S->n_rows; row++) {	/* For each row to stack across all segments, per data grid */
-					if (gmt_M_is_dnan (T->segment[seg]->data[col][row])) continue;	/* Must skip any NaN entries in any profile */
-					if (Ctrl->F.mode == -1 && T->segment[seg]->data[col][row] < z) {
-						z = T->segment[seg]->data[col][row];
-						k = row;
-					}
-					else if (Ctrl->F.mode == +1 && T->segment[seg]->data[col][row] > z) {
-						z = T->segment[seg]->data[col][row];
-						k = row;
-					}
-				}
-				for (col = 0; col < 5; col++)
-					out[col] = T->segment[seg]->data[col][k];
-				GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+			if ((error = GMT_Set_Columns (API, GMT_OUT, 8, GMT_COL_FIX_NO_TEXT)) != GMT_NOERROR) {
+				Return (error);
 			}
+			if (GMT_Init_IO (API, GMT_IS_DATASET, GMT_IS_POINT, GMT_OUT, GMT_ADD_DEFAULT, 0, options) != GMT_NOERROR) {	/* Establishes data output */
+				Return (API->error);
+			}
+			if (GMT_Begin_IO (API, GMT_IS_DATASET, GMT_OUT, GMT_HEADER_ON) != GMT_NOERROR) {	/* Enables data output and sets access mode */
+				Return (API->error);
+			}
+			if (GMT_Set_Geometry (API, GMT_OUT, GMT_IS_POINT) != GMT_NOERROR) {	/* Sets output geometry */
+				Return (API->error);
+			}
+			Out = gmt_new_record (GMT, out, NULL);
+			for (tbl = 0; tbl < Dout->n_tables; tbl++) {
+				T = Dout->table[tbl];
+				for (seg = 0; seg < T->n_segments; seg++) {	/* For each segment to examine */
+					S = T->segment[seg];
+					z = -DBL_MAX;
+					kr = kl = kc = GMT_NOTSET;
+					for (row = 0; row < S->n_rows; row++) {	/* For each row to stack across all segments, per data grid */
+						if (gmt_M_is_dnan (T->segment[seg]->data[4][row])) continue;	/* Must skip any NaN entries in any profile */
+						this_zc = T->segment[seg]->data[4][row] * z_scl;	/* Current z: Force positive if a trough */
+						this_zr = T->segment[seg]->data[4][S->n_rows-row-1] * z_scl;	/* Current symmatric point on the right: Force positive if a trough */
+						if (kl == GMT_NOTSET && this_zc >= Ctrl->F.z0) kl = row;			/* Found the first point on the left */
+						if (kr == GMT_NOTSET && this_zr >= Ctrl->F.z0) kr = S->n_rows-row-1;	/* Found the last point on the right */
+						if (this_zc > z) z = this_zc, kc = row;	/* Found a new maximum point */
+					}
+					if (kc == GMT_NOTSET) continue;	/* Nothing to print */
+					for (col = 0; col < 5; col++)	/* Copy over lon, lat, dist, azimuth, z */
+						out[col] = T->segment[seg]->data[col][kc];
+					out[5] = (kl == GMT_NOTSET) ? GMT->session.d_NaN : T->segment[seg]->data[GMT_Z][kl];	/* Left distance */
+					out[6] = (kr == GMT_NOTSET) ? GMT->session.d_NaN : T->segment[seg]->data[GMT_Z][kr];	/* Right distance */
+					out[7] = out[6] - out[5];	/* Width */
+					GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+				}
+			}
+			if (GMT_End_IO (API, GMT_OUT, 0) != GMT_NOERROR) {	/* Disables further data output */
+				Return (API->error);
+			}
+			gmt_M_free (GMT, Out);
 		}
-		if (GMT_End_IO (API, GMT_OUT, 0) != GMT_NOERROR) {	/* Disables further data output */
-			Return (API->error);
+		else {
+			DH = gmt_get_DD_hidden (Dout);
+			T = Dout->table[0];
+			T->n_headers = 2;
+			T->header = gmt_M_memory (GMT, NULL, T->n_headers, char *);
+			T->header[0] = strdup ("Equidistant cross-profiles normal to each input segment");
+			T->header[1] = strdup (run_cmd);
+			if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_LINE, DH->io_mode, NULL, Ctrl->Out.file, Dout) != GMT_NOERROR) {
+				Return (API->error);
+			}
+			if (GMT_Destroy_Data (API, &Dout) != GMT_NOERROR) {
+				Return (API->error);
+			}
 		}
 	}
 	else if (Ctrl->E.active) {	/* Quick sampling along given lines */

--- a/test/nearneighbor/nat_nn.ps
+++ b/test/nearneighbor/nat_nn.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612 792             
-%%Title: GMT v5.4.0_r17537M [64-bit] Document from grdimage
-%%Creator: GMT5
-%%For: pwessel
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.1.0_80db6d2-dirty_2020.02.12 [64-bit] Document from grdimage
+%%Creator: GMT6
+%%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Feb 16 15:19:05 2017
+%%CreationDate: Wed Feb 12 09:22:03 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -646,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -657,14 +658,20 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
 0 A
 FQ
 O0
 -3600 PSL_xorig sub PSL_page_xsize 2 div add 1200 TM
 
 % PostScript produced by:
-%@GMT: grdimage junk.nc -JX6i -P -Baf '-BWSnE+tNatural Nearest Neighbor Gridding' -Ct.cpt -Xc
+%@GMT: gmt grdimage junk.nc -JX6i -P -Baf '-BWSnE+tNatural Nearest Neighbor Gridding' -Ct.cpt -Xc
 %@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
+%GMTBoundingBox: -216 72 432 432
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
@@ -674,29 +681,30 @@ clipsave
 7200 0 D
 0 7200 D
 -7200 0 D
+P
 PSL_clip N
 V N -18 -18 T 7236 7236 scale [/Indexed /DeviceRGB 9 <
 00660000FFFFFF0000FF99EEAA55440000FFFFDD6600FF000088CC000066>] setcolorspace
 << /ImageType 1 /Decode [0 15] /Width 201 /Height 201 /BitsPerComponent 4
    /ImageMatrix [201 0 0 -201 0 201] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
 >> image
-G[Bde4cU1A&-ZH$!m'(4/HP*.aI:oT!S5*B^`&&k"ET1FO<G7hgO_S<e^[[uWiB\`N-MnjVcV@<X&mTZ1$=#.44KZ%<A0c&
-pCF3ejYa'0o6*D`U/i$kE_d80'NDc!,0hX9HHt7JED;9pl\r?NKFuNE<'?"Al[h*nKSBnkI>So96O(Im"a/-'&G$Uc4bjq#
-@\".Deq=m<e02g\W-_9Kb_Tt*E6+!*VO3Lq=:iXie3-;h/5oC>'Qu'[i$m&h&Hkm4"+aBIpCr'.MP)EW+UJ4IXFl$PW-_-[
-XV<3[602$#,=RJgXOkUM0VgO:25E&4Pu#L2NYJ@`nhIumNp'CkY*C0q'N@7b0JZ%eK$),)6ZPS_@_J(<jG5R&AON,Ab/]=i
-&eK<qC*+Z=&gC&L\sA"?;c*:Wc-D7R;c*@Y]cG4m(pC@;+P@GRZM,Kp'\#<Wj$WSU<'S<X0ZAFArSE1&#I>Qm2j-j#ogAFj
-KMHLqE?YqF5faX=5@bj%*dl$_7"3$7ZLqL=+%'3BZAB`AgH)LF%jS3%8.aI_ULHQeCWXm1+RPrm=tuh$7/c:bJk.s,!Tu"'
-&31llbmK88$FuH1g!5=\$8KIXCd?nm3lH^`"&>OZ(dV*O5n6=.\X!KR3fq:9,K5#+6c:pb+K85._MgHPR)4VX+GUau[N*\m
-E2*Ut-q6*_H<sW?S!"Y4,WCr:GO$IDPjTAX[M!VBN36A$&Z4?cNuXr=_S(naB]N+'93+O7Pe/DUCI8:N^K2G=hJ4*o:T6ZU
-VitY%aNfJ.l6W(/@gVlb,:=eDZ4+jPR#jcNLdI(,;Db8s64JAs!s4EI8VZ^`(kK[q8I^,%KJZ4ZSNdK<pq6[U+Q/D9*+;bG
-K'J-@+fKf_B!?Us&QCrj#!q'dE[8?M:.J.RSG\ST.6<'\Qc'Kc9HkY%]elNNbp4K"V^P)gMJ4=\]pFO3W&KQh,kmI`#1]T5
-&NW?G)Ut3Fr$2P^:b.HUd!Oj[.co%h15-qp:hLOGZE$G/KAPntOlMEEg*c.+]j;=3?5;F;GYOu<%4N.;Pab1SQ&sEA=f1P'
-*pM6Ab/SRcj#)qdM?nRH:'>t=q-G_4FLQkoa;FAGKCo*U69=(N\WF"CO/Gr$B*0[)3ojc.K2j(CDc:D4Y7lKtG)RZ(!L<!\
-Rh9,&K8#FO8JsMm&UH"0`"6g:K>eC>!9G%`Z6=Yl@%X%:nKF&mRPG_Hr%K@Y;,E''`.H'bHEbV<If>00q,k3P(`:X0nR.N2
-&`&PGL^$7>7]sf:641aokK.67";jh[%"KHF3LFQG&L@!jMJa+?GcYtXYYd_\`cSGJ;*n+V'PJ0lj,hI#b(bqDNB^@a6ifTu
-,i>=%.]/%HNambTQdPO^"LYOg&6-dc6(Gt&+`8NVTZTBG">pO+,Q;0V&6('sMkE6g:*aj20+p)!T3$oC2C0sYQ"fb2_.1$;
-Yi.lEPo`#=RL1bonRL77)T.N,SmmWaWW=gt<QFBa#V&-F+K,C^JCGX`K%(_D">q"t&QE-E6<6&]7"1ieS+?"ji6U^RP3,!g
-b27_srse,(RmI~>
+G[Bde4`9">&-ZJ)#W;h;JR,'/&.%V+*[!"U"+`_[1pKh!0O<T`d;:+cJ%IMCqdsGS!D`33]ao%kd*7P)\*Da3N;88j=]"dS
+a`r&X6DYqL;"^?j"o4*\8Po)CLB'&(6.JUp`&>SUXWB2kd3FRs,GlogH3lkg;c*.Wi*$r80ZA1:!RX\?,N4^bd8*'aEs+lm
+76Mp-eqe";W0(c7KIEakmPuJcS:\?87)k1aVDtb:,H<33Lh7"ZSeE%NU6sp\&g2FV)BhS#i$kUO:'Q8J;"kZMXUmcsgt.Dp
+0P)7-9L7K5fX50656[<J@7H2dVeE9QLCb^i"dMl788\baT>D%pUo+o3M^%C7CEgkLW-jJ10I/X^Q&h&^E$R07jB<Np9L7c=
+,XXiX.B%WQ3(-$M.GAQoL4i)r[)c"#85i@\R#N.!VP*W;[3":*Ph4Vk&2j^"O/X]:RtBA7e9,Una;"<T9F+L[88UcSK;%u^
+)`&+$61mT[1D3I1?#/IcSp\W)KEP4MrK,`cbYp&[XN8tIe1P:Hs'iLh`f#c_lG$jr`93CR[eioV?-@lmM@/%$+D1lN?W-c_
+rKmf^pXp6)HN`tD$n'IGiAO#G#%Te?MCHBL]L[[6E/4hR#=1g=`/QSR#n8hFVKe5?KJZgV\sE,G<ChR2CqL3DL)?$)aPMgl
+IO$_'%acM*MDTWik=3luW)8.'$%i]7,Kr\R@7CjWLrTD0NGJbdT$jd#1m67p$k_@#*YG:)T+O7UM26m?V-P0O;qalF7`^hk
+!F\oKaB")'Dh>q%)Mdg/m8Slm4J*i9Cl06YNq//MWrRE?AQG*?ls;.e.0N7VG`]!]I?r5fpVI1i"sk2)VEgqD`^P^n.oIPL
+\c45!T_ALYKn)h1;hRid,8I4#;M8#JI1.pQ]lk9h6KM-*&l6UmW-_8?Ju\#':I=K77Sraj$&PN)&_%d',4'S<RLL-kmNj*V
+2i;.a;adEJ]hs/JKkfYh89ccgWDI@MnWU?-'TQ.kPsg2i-rQa:RM6CiM^"ci-VFe\f0iNVFcaL&6^"&e][n)HLVF%-=$na_
+1?C",mL>;%,p`4VQ7;8EC"GZA`\cd,#^O<<,OJKm_[6\EmT2a/WuqZ+Go;_h10-ZO%P+Bs9@n=-(oI(jhS;`,E\[("MND]a
+64W>kl]IN/W>$J5!>"<_\fa7X,Jaq9Y_*UG%E0"ldZNT*qM'+u28I$<*eYL@/#RHILh($,G+/!%7jK=WSDq1r&D9Srm)8H&
+&b<4'*45u?P"%bM%#gtknR.L\Ods7QYG-T0bd%!a<<be\#+:W0!.p/#8K)jW*37C_@:Tt(Yp^J7MkL%mfZ557IEW9A)+8VK
+5"B.Z&[cUB(bjADC(Be:(eFiF7r]`-@s)+rAiLCP9&`06.?+Qe*m9>3:)4(d.XCB:q,e-F@Fu/k.)h(:4u)9IM]eU$=V797
+6r7)3-3TU1@R6O)1*LPQJtT,coE]3S7#gu&AO''h/m8DNjJ,(7Nn#S@6:6O$&eke,3a`Xml*3'9\Y28bK-Cjm"e$QEKk!F0
+2u:3;=$aWof7,'kJ&IS$#5S'"4AMQO~>
 U
 PSL_cliprestore
 25 W
@@ -713,7 +721,7 @@ N 0 5760 M -83 0 D S
 N 0 7200 M -83 0 D S
 /PSL_AH0 0
 /MM {neg exch M} def
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sw mx
 (2) sw mx
@@ -847,6 +855,11 @@ N 6480 0 M 0 42 D S
 400 F0
 (Natural Nearest Neighbor Gridding) bc Z
 %%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage


### PR DESCRIPTION
**Description of proposed changes**

I have added a new option **-F**[**+n**][**+z**_z0_] to grdtrack to be used in conjunction with **-C** and a single input grid.  It will examine all the cross-profiles and determine three points on each profile: The center peak and the left/right rise points (when first exceeding _z0_).  This is useful for tracing the center ridge line of an elongated feature and possibly its width.  Below you see a smoothed version of the Hawaii-Emperor Chain bathymetry, a rough predicted trail from a plate motion model (red) used to create the crossings (yellow lines), and the white center dots identified by **-F**.  The line connecting the white dots are a reasonable median line representation of the chain.  Green and red dots indicate the left/right extent above 250 m.

![smooth](https://user-images.githubusercontent.com/26473567/74370712-a7d08c00-4d7b-11ea-97a5-e9757a24f4d6.png)

Sorry, I also managed to run the tests and update the nat_nn.ps file as part of this.