### PR TITLE
Imrove verbosity levels throughout based on test log

### DIFF
--- a/src/gmt_gdal_librarified.c
+++ b/src/gmt_gdal_librarified.c
@@ -187,7 +187,7 @@ GMT_LOCAL int save_grid_with_GMT(struct GMT_CTRL *GMT, GDALDatasetH hDstDS, stru
 	if (GMT_Write_Data (GMT->parent, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA,
 						NULL, fname, Grid) != GMT_NOERROR)
 		return GMT->parent->error;
-	Grid->data = NULL;	/* SInce we cannot delete later */
+	Grid->data = NULL;	/* Since we must avoid deleting this GDAL memory later */
 	return 0;
 }
 

--- a/src/gmt_gdal_librarified.c
+++ b/src/gmt_gdal_librarified.c
@@ -187,6 +187,7 @@ GMT_LOCAL int save_grid_with_GMT(struct GMT_CTRL *GMT, GDALDatasetH hDstDS, stru
 	if (GMT_Write_Data (GMT->parent, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA,
 						NULL, fname, Grid) != GMT_NOERROR)
 		return GMT->parent->error;
+	Grid->data = NULL;	/* SInce we cannot delete later */
 	return 0;
 }
 

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -7024,21 +7024,22 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 		O_active = (k) ? true : false;	/* -O is determined by presence or absence of hidden PS file */
 		/* Determine paper size */
 		wants_PS = gmtlib_fig_is_ps (GMT);	/* True if we have requested a PostScript output format */
-		if (wants_PS) {	/* Requesting a PostScript file in modern mode */
+		if (wants_PS && !O_active) {	/* Requesting a new PostScript file in modern mode */
 			if (auto_media) {	/* Cannot use "auto" if requesting a PostScript file */
-				GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Must specify a paper size when requesting a PostScript file\n");
+				GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "You should specify a paper size when requesting a PostScript file.\n");
 				if (GMT->current.setting.proj_length_unit == GMT_INCH) {	/* Use US settings */
-					GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Changing paper size to US Letter, but we cannot know if this is adequate for your plot; use PS_MEDIA.\n");
+					GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Changing paper size to US Letter, but we cannot know if this is adequate for your plot; better to use PS_MEDIA explicitly.\n");
 					media_size[GMT_X] = 612.0; media_size[GMT_Y] = 792.0;
 				}
 				else {	/* Use SI settings */
-					GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Changing paper size to A4, but we cannot know if this is adequate for your plot.\n");
+					GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Changing paper size to A4, but we cannot know if this is adequate for your plot; better to use PS_MEDIA explicitly.\n");
 					media_size[GMT_X] = 595.0; media_size[GMT_Y] = 842.0;
 				}
 			}
 			if ((GMT->current.map.width > GMT->current.map.height) && (((GMT->current.map.width + GMT->current.setting.map_origin[GMT_X]) * 72) > media_size[GMT_X]) && GMT->current.setting.ps_orientation == PSL_PORTRAIT) {
 				GMT->current.setting.ps_orientation = PSL_LANDSCAPE;
-				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Changing to PostScript landscape orientation based on plot and paper dimensions but cannot not sure.  Use PS_PAGE_ORIENTATION to correct any error\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Changing to PostScript landscape orientation based on your plot and paper dimensions, but we cannot be 100%% sure.\n");
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Use PS_MEDIA and/or PS_PAGE_ORIENTATION to specify correct paper dimensions and/or orientation if our guesses are inadequate.\n");
 			}
 		}
 		else if (!O_active) {	/* Not desiring PS output so we can add safety margin of GMT_PAPER_MARGIN inches for initial layer unless PS_MEDIA was set */

--- a/src/gmtinfo.c
+++ b/src/gmtinfo.c
@@ -491,13 +491,13 @@ int GMT_gmtinfo (void *V_API, int mode, void *args) {
 		if (!strcmp (GMT->current.setting.format_geo_out, "D")) {
 			strcpy (GMT->current.setting.format_geo_out, "+D");
 			gmt_M_err_fail (GMT, gmtlib_geo_C_format (GMT), "");
-			GMT_Report (API, GMT_MSG_WARNING, "FORMAT_GEO_OUT reset from D to %s to ensure wesn[XHI] > wesn[XLO]\n",
+			GMT_Report (API, GMT_MSG_INFORMATION, "FORMAT_GEO_OUT reset from D to %s to ensure wesn[XHI] > wesn[XLO]\n",
 			            GMT->current.setting.format_geo_out);
 		}
 		else if (!strcmp (GMT->current.setting.format_geo_out, "ddd:mm:ss")) {
 			strcpy (GMT->current.setting.format_geo_out, "ddd:mm:ssF");
 			gmt_M_err_fail (GMT, gmtlib_geo_C_format (GMT), "");
-			GMT_Report (API, GMT_MSG_WARNING, "FORMAT_GEO_OUT reset from ddd:mm:ss to %s to ensure wesn[XHI] > wesn[XLO]\n",
+			GMT_Report (API, GMT_MSG_INFORMATION, "FORMAT_GEO_OUT reset from ddd:mm:ss to %s to ensure wesn[XHI] > wesn[XLO]\n",
 			            GMT->current.setting.format_geo_out);
 		}
 	}

--- a/src/mgd77/mgd77convert.c
+++ b/src/mgd77/mgd77convert.c
@@ -386,9 +386,8 @@ int GMT_mgd77convert (void *V_API, int mode, void *args) {
 			Return (GMT_DATA_WRITE_ERROR);
 		}
 		GMT_Report (API, GMT_MSG_INFORMATION, "Converted cruise %s to %s format\n", list[argno], format_name[Ctrl->T.format]);
-		if (D->H.errors[0]) GMT_Report (API, GMT_MSG_WARNING, " [%02d header problems (%d warnings + %d errors)]", D->H.errors[0], D->H.errors[1], D->H.errors[2]);
-		if (D->errors) GMT_Report (API, GMT_MSG_WARNING, " [%d data errors]", D->errors);
-		GMT_Report (API, GMT_MSG_WARNING, "\n");
+		if (D->H.errors[0]) GMT_Report (API, GMT_MSG_WARNING, "%s [%02d header problems (%d warnings + %d errors)]", list[argno], D->H.errors[0], D->H.errors[1], D->H.errors[2]);
+		if (D->errors) GMT_Report (API, GMT_MSG_WARNING, "%s [%d data errors]", list[argno], D->errors);
 
 		MGD77_Free_Dataset (GMT, &D);	/* Free memory allocated by MGD77_Read_File */
 		n_cruises++;

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -965,7 +965,7 @@ static void psl_set_reducedpath_arrays (struct PSL_CTRL *PSL, double *x, double 
 	PSL_command (PSL, "] def\n");
 	PSL_comment (PSL, "Set array with number of points per line segments:\n");
 	psl_set_int_array (PSL, "path_n", new_n, npath);
-	if (k > 100000) PSL_message (PSL, PSL_MSG_WARNING, "Warning: PSL array placed has %d items - may exceed gs_init.ps MaxOpStack setting\n", k);
+	if (k > PSL_MaxOpStack_Size) PSL_message (PSL, PSL_MSG_WARNING, "Warning: PSL array placed has %d items - may exceed gs_init.ps MaxOpStack setting [%d].\n", k, PSL_MaxOpStack_Size);
 
 	/* Free up temp arrays */
 	PSL_free (use);

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -45,6 +45,8 @@ extern "C" {
 
 #include <stdio.h>
 
+#define PSL_MaxOpStack_Size	300000	/* As of GhostSCript 9.50; see declaration in gs_init.ps */
+
 /* Number of PostScript points in one inch */
 
 #define PSL_POINTS_PER_INCH	72.0

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -936,11 +936,12 @@ int GMT_pscoast (void *V_API, int mode, void *args) {
 		anti_lat = -GMT->current.proj.pole;
 		anti_bin = irint (floor ((90.0 - anti_lat) / c.bsize)) * c.bin_nx + irint (floor (anti_lon / c.bsize));
 		gmt_geo_to_xy (GMT, GMT->current.proj.central_meridian, GMT->current.proj.pole, &x_0, &y_0);
-		if (Ctrl->G.active)
-			GMT_Report (API, GMT_MSG_WARNING, "Fill/clip continent option (-G) may not work for this projection.\n"
-			                                  "If the antipole (%g/%g) is in the ocean then chances are good\n"
-			                                  "Else: avoid projection center coordinates that are exact multiples of %g degrees\n",
-			                                  anti_lon, anti_lat, c.bsize);
+		if (Ctrl->G.active) {
+			GMT_Report (API, GMT_MSG_WARNING, "Fill/clip continent option (-G) may not work for this projection.\n");
+			GMT_Report (API, GMT_MSG_WARNING, "If the antipole (%g/%g) is in the ocean then chances are good it will work.\n");
+			GMT_Report (API, GMT_MSG_WARNING, "Otherwise, avoid projection center coordinates that are exact multiples of %g degrees.\n",
+				anti_lon, anti_lat, c.bsize);
+		}
 	}
 
 	if (possibly_donut_hell && paint_polygons && !clobber_background) {	/* Force clobber when donuts may be called for now */

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -803,7 +803,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 		if (gmt_M_err_pass (GMT, gmt_map_setup (GMT, wesn), "")) Return (GMT_PROJECTION_ERROR);
 		if (GMT->common.B.active[GMT_PRIMARY] || GMT->common.B.active[GMT_SECONDARY]) {	/* Cannot use -B if no -R -J */
 			GMT->common.B.active[GMT_PRIMARY] = GMT->common.B.active[GMT_SECONDARY] = false;
-			GMT_Report (API, GMT_MSG_WARNING, "Disabling your -B option since -R -J were not set\n");
+			GMT_Report (API, GMT_MSG_INFORMATION, "Disabling your -B option since -R -J were not set\n");
 		}
 	}
 	else if (gmt_M_err_pass (GMT, gmt_map_setup (GMT, GMT->common.R.wesn), ""))

--- a/src/segy/segy2grd.c
+++ b/src/segy/segy2grd.c
@@ -551,15 +551,15 @@ int GMT_segy2grd (void *V_API, int mode, void *args) {
 			}
 		}
 
-		if (gmt_M_is_verbose (GMT, GMT_MSG_WARNING)) {
+		if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) {
 			if (gmt_M_is_dnan (Ctrl->N.d_value))
 				strcpy (line, "NaN\n");
 			else
 				sprintf (line, GMT->current.setting.format_float_out, Ctrl->N.d_value);
-			GMT_Report (API, GMT_MSG_WARNING, " n_read: %d  n_used: %d  n_filled: %d  n_empty: %d set to %s\n", n_read, n_used, n_filled, n_empty, line);
-			if (n_stuffed) GMT_Report (API, GMT_MSG_WARNING, "%d nodes had multiple entries that were averaged\n", n_stuffed);
-			if (n_confused) GMT_Report (API, GMT_MSG_WARNING, "%d values gave bad indices: Pixel vs gridline confusion?\n", n_confused);
+			GMT_Report (API, GMT_MSG_INFORMATION, " n_read: %d  n_used: %d  n_filled: %d  n_empty: %d set to %s\n", n_read, n_used, n_filled, n_empty, line);
 		}
+		if (n_stuffed) GMT_Report (API, GMT_MSG_WARNING, "%d nodes had multiple entries that were averaged\n", n_stuffed);
+		if (n_confused) GMT_Report (API, GMT_MSG_WARNING, "%d values gave bad indices: Pixel vs gridline confusion?\n", n_confused);
 	}
 	if (fpi != stdin) fclose (fpi);
 	gmt_M_free (GMT, flag);

--- a/src/sphtriangulate.c
+++ b/src/sphtriangulate.c
@@ -149,7 +149,7 @@ GMT_LOCAL int stripack_delaunay_output (struct GMT_CTRL *GMT, double *lon, doubl
 			Dout[0]->table[0]->n_records += S[0]->n_rows;
 		}
 		Dout[0]->n_records = Dout[0]->table[0]->n_records;
-		if (get_area) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Total surface area = %g\n", area_sphere * R2);
+		if (get_area) GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Total surface area = %g\n", area_sphere * R2);
 	}
 	else {	/* Want just the arcs (to draw then, probably).  This avoids repeating shared arcs between triangles */
 		uint64_t j, ij1, ij2, ij3, n_arcs, kk;
@@ -646,7 +646,7 @@ int GMT_sphtriangulate (void *V_API, int mode, void *args) {
 	gmt_M_malloc3 (GMT, xx, yy, zz, 0, &n_alloc, double);
 	GMT->session.min_meminc = GMT_MIN_MEMINC;		/* Reset to the default value */
 
-	if (Ctrl->D.active && n_dup) GMT_Report (API, GMT_MSG_WARNING, "Skipped %d duplicate points in segments\n", n_dup);
+	if (Ctrl->D.active && n_dup) GMT_Report (API, GMT_MSG_INFORMATION, "Skipped %d duplicate points in segments\n", n_dup);
 	GMT_Report (API, GMT_MSG_INFORMATION, "Do Voronoi construction using %d points\n", n);
 
 	gmt_M_memset (&T, 1, struct STRIPACK);

--- a/src/spotter/grdspotter.c
+++ b/src/spotter/grdspotter.c
@@ -604,7 +604,7 @@ int GMT_grdspotter (void *V_API, int mode, void *args) {
 	if (Ctrl->S2.dist != 0.0) sampling_int_in_km = Ctrl->S2.dist;
 	GMT_Report (API, GMT_MSG_INFORMATION, "Flowline sampling interval = %.3f km\n", sampling_int_in_km);
 
-	if (Ctrl->T.active[TRUNC]) GMT_Report (API, GMT_MSG_WARNING, "Ages truncated to %g\n", Ctrl->N.t_upper);
+	if (Ctrl->T.active[TRUNC]) GMT_Report (API, GMT_MSG_INFORMATION, "Ages truncated to %g\n", Ctrl->N.t_upper);
 
 	/* Start to read input data */
 
@@ -708,7 +708,7 @@ int GMT_grdspotter (void *V_API, int mode, void *args) {
 		flowline = gmt_M_memory (GMT, NULL, n_alloc, struct FLOWLINE);
 		if (gmt_M_is_verbose (GMT, GMT_MSG_WARNING)) {
 			GMT_Report (API, GMT_MSG_WARNING, "Will attempt to keep all flowlines in memory.  However, should this not be possible\n");
-			GMT_Report (API, GMT_MSG_WARNING, "the program might crash.  If so consider using the -M option\n");
+			GMT_Report (API, GMT_MSG_WARNING, "then the program might crash.  If so consider using the -M option.\n");
 		}
 	}
 
@@ -977,10 +977,10 @@ int GMT_grdspotter (void *V_API, int mode, void *args) {
 		struct GMT_RECORD *Out = gmt_new_record (GMT, out, NULL);
 
 		if (gmt_M_is_verbose (GMT, GMT_MSG_WARNING)) {
-			GMT_Report (API, GMT_MSG_WARNING, "Preprocessed %5" PRIu64 " flowlines\n", n_nodes);
-			GMT_Report (API, GMT_MSG_WARNING, "%" PRIu64 " of %" PRIu64 " total flowlines entered CVA region\n", n_nodes, n_flow);
-			GMT_Report (API, GMT_MSG_WARNING, "Flowlines consumed %d Mb of memory\n", lrint (mem * B_TO_MB));
-			GMT_Report (API, GMT_MSG_WARNING, "Estimate %d CVA max locations using bootstrapping\n", Ctrl->W.n_try);
+			GMT_Report (API, GMT_MSG_WARNING, "Preprocessed %5" PRIu64 " flowlines.\n", n_nodes);
+			GMT_Report (API, GMT_MSG_WARNING, "%" PRIu64 " of %" PRIu64 " total flowlines entered CVA region.\n", n_nodes, n_flow);
+			GMT_Report (API, GMT_MSG_WARNING, "Flowlines consumed %d Mb of memory.\n", lrint (mem * B_TO_MB));
+			GMT_Report (API, GMT_MSG_WARNING, "Estimate %d CVA max locations using bootstrapping.\n", Ctrl->W.n_try);
 		}
 
 		if ((error = GMT_Set_Columns (API, GMT_OUT, 3, GMT_COL_FIX_NO_TEXT)) != GMT_NOERROR) {

--- a/src/spotter/libspotter.c
+++ b/src/spotter/libspotter.c
@@ -596,7 +596,7 @@ unsigned int spotter_init (struct GMT_CTRL *GMT, char *file, struct EULER **p, u
 	/* Extend oldest stage pole back to t_max Ma */
 
 	if ((*t_max) > 0.0 && e[0].t_start < (*t_max)) {
-		GMT_Report (GMT->parent, GMT_MSG_WARNING, "libspotter: Extending oldest stage pole back to %g Ma\n", (*t_max));
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "libspotter: Extending oldest stage pole back to %g Ma\n", (*t_max));
 
 		e[0].t_start = (*t_max);
 		e[0].duration = e[0].t_start - e[0].t_stop;

--- a/src/x2sys/x2sys_init.c
+++ b/src/x2sys/x2sys_init.c
@@ -317,7 +317,7 @@ int GMT_x2sys_init (void *V_API, int mode, void *args) {
 					Return (GMT_ERROR_ON_FOPEN);
 				}
 			}
-			GMT_Report (API, GMT_MSG_WARNING, "Found deprecated file extension .%s, please rename to .%s\n", X2SYS_FMT_EXT_OLD, X2SYS_FMT_EXT);
+			GMT_Report (API, GMT_MSG_INFORMATION, "Found deprecated file extension .%s, please rename to .%s\n", X2SYS_FMT_EXT_OLD, X2SYS_FMT_EXT);
 		}
 	}
 	if ((fp_def = fopen (def_file, "r")) == NULL) {

--- a/test/grdfill/splinefill.sh
+++ b/test/grdfill/splinefill.sh
@@ -5,7 +5,7 @@ gmt begin splinefill ps
 	gmt grdclip @earth_relief_05m -R199:30/206/18/23 -Sa0/NaN -Gislands.nc
 	gmt makecpt -Csealand -T-5000/5000 -H > t.cpt
 	# Now replace NaN holes with cubic spline solutions
-	gmt grdfill islands.nc -As -Gnew.nc -Vd
+	gmt grdfill islands.nc -As -Gnew.nc
 	gmt grdimage islands.nc -JQ6i -Ct.cpt -B -BWSne -Xc -Y0.75i
 	gmt grdimage new.nc -Ct.cpt -B -BWSne -Y5.15i
 	gmt text -F+f24p+cTR+t"-As" -Dj0.2i -Gwhite


### PR DESCRIPTION
Based on the full output log from the tests I identified a series of messages that pointed to having the wrong verbosity level and in some cases incomplete messages.  Most were dealt with by changing WARNING to INFORMATION.  However, some rewriting here and there was needed to improve the reports.  Also removed repetitive PS warnings for overlays since paper size already set the first time.  We may wish to explicitly set PS_ORIENTATION in our landscape examples to avoid further warnings.  Fixed some memory leaks as well.

