### PR TITLE
Optimize images in documentation before deploying

### DIFF
--- a/admin/image_optimize.sh
+++ b/admin/image_optimize.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Optimize images to reduce file size
+#
+# Requirement: pngquant
+#
+
+if [ "$#" == 0 ]; then
+    echo "Usage: bash image_optimize.sh *.png"
+    exit 1
+fi
+
+if ! [ -x "$(command -v pngquant)" ]; then
+    echo 'Error: pngquant is not found in your search PATH.' >&2
+    exit 0
+fi
+
+for image in "$@"; do
+    echo "Optimizing ${image}"
+    pngquant --skip-if-larger --strip --ext .optimized.png ${image}
+    if [[ -f "${image%.png}.optimized.png" ]]; then
+        mv ${image%.png}.optimized.png ${image}
+    fi
+done

--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -20,7 +20,8 @@ steps:
 - bash: |
     set -x -e
     sudo apt-get install -y --no-install-recommends --no-install-suggests \
-        python3-pip python3-setuptools python3-wheel graphicsmagick ffmpeg pngquant
+        python3-pip python3-setuptools python3-wheel graphicsmagick ffmpeg
+    sudo snap install pngquant
     pip3 install --user sphinx==1.8.5
     echo "##vso[task.prependpath]$HOME/.local/bin"
   displayName: Install dependencies for building documentation

--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -20,7 +20,7 @@ steps:
 - bash: |
     set -x -e
     sudo apt-get install -y --no-install-recommends --no-install-suggests \
-        python3-pip python3-setuptools python3-wheel graphicsmagick ffmpeg
+        python3-pip python3-setuptools python3-wheel graphicsmagick ffmpeg pngquant
     pip3 install --user sphinx==1.8.5
     echo "##vso[task.prependpath]$HOME/.local/bin"
   displayName: Install dependencies for building documentation
@@ -118,6 +118,10 @@ steps:
     CODECOV_TOKEN: $(codecov.token)
   condition: and(eq(variables['TEST'], true), succeededOrFailed())
   displayName: Upload test coverage
+
+- bash: bash admin/image_optimize.sh build/doc/rst/html/_images/*.png
+  condition: eq(variables['DEPLOY_DOCS'], true)
+  displayName: Optimize images in documentations
 
 - bash: bash ci/deploy-gh-pages.sh
   displayName: Deploy documentations


### PR DESCRIPTION
The total size of images in the HTML documentation is ~33 Mb. Using `pngquant` to
optimize the images can reduce the total size to ~19 Mb, without visible quality loss.