### PR TITLE
More warning fixes

### DIFF
--- a/doc/examples/ex38/ex38.sh
+++ b/doc/examples/ex38/ex38.sh
@@ -30,7 +30,7 @@ gmt begin ex38
 		gmt grdimage out.nc -Cq.cpt
 	gmt subplot end
 
-	gmt colorbar -DJTC+w12c/0.4c+jTC+o0c/6c+h+e+n -Ct.cpt -Ba500 -By+lm
+	gmt colorbar -DJTC+w12c/0.4c+jTC+o0c/6c+h+e+n -Ct.cpt -Bxa500 -By+lm
 	gmt colorbar -DJBC+w12c/0.4c+h+e+n -Cn.cpt -Bx1 -By+l"z@-n@-"
 	gmt colorbar -DJBC+w12c/0.4c+h+e+n+o0c/2.5c -Cq.cpt -Bx1 -By+l"z@-q@-"
 	rm -f out.nc ?.cpt

--- a/doc/scripts/GMT_colorbar.sh
+++ b/doc/scripts/GMT_colorbar.sh
@@ -2,5 +2,5 @@
 gmt begin GMT_colorbar
 	gmt makecpt -T-15/15 -Cpolar
 	gmt basemap -R0/20/0/1 -JM5i -BWse -B
-	gmt colorbar -C -B -Bx+u"\\232" -By+l@~D@~T -DJBC+e
+	gmt colorbar -C -Bx+u"\\232" -By+l@~D@~T -DJBC+e
 gmt end show

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -373,7 +373,7 @@ static struct GMT_FONTSPEC GMT_standard_fonts[GMT_N_STANDARD_FONTS] = {
 GMT_LOCAL struct GMT_KEYWORD_DICTIONARY gmt_common_kw[] = {
 	/* separator, short-option, long-option, short-directives, long-directives, short-modifiers, long-modifiers */
 	{   0, 'B', "frame",         "",        "",                                         "b,g,n,o,t",				"box,fill,noframe,oblique-pole,title" },
-	{   0, 'B', "axis",          "",        "",                                         "a,l,L,p,s,S,u",			"angle,label,Label,prefix,second-label,Second-label,unit" },
+	{   0, 'B', "axis",          "",        "",                                         "a,f,l,L,p,s,S,u",			"angle,fancy,label,Label,prefix,second-label,Second-label,unit" },
 	{   0, 'J', "projection",    "",        "",                                         "",         				""},
 	{   0, 'R', "region",        "",        "",                                         "r,u",        				"rectangular,unit"},
 	{   0, 'U', "timestamp",     "",        "",                                         "c,j,o",    				"command,justify,offset"},

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -373,7 +373,7 @@ static struct GMT_FONTSPEC GMT_standard_fonts[GMT_N_STANDARD_FONTS] = {
 GMT_LOCAL struct GMT_KEYWORD_DICTIONARY gmt_common_kw[] = {
 	/* separator, short-option, long-option, short-directives, long-directives, short-modifiers, long-modifiers */
 	{   0, 'B', "frame",         "",        "",                                         "b,g,n,o,t",				"box,fill,noframe,oblique-pole,title" },
-	{   0, 'B', "axis",          "",        "",                                         "a,f,l,L,p,s,S,u",			"angle,fancy,label,Label,prefix,second-label,Second-label,unit" },
+	{   0, 'B', "axis",          "x,y,z",   "x,y,z",                                    "a,f,l,L,p,s,S,u",			"angle,fancy,label,Label,prefix,second-label,Second-label,unit" },
 	{   0, 'J', "projection",    "",        "",                                         "",         				""},
 	{   0, 'R', "region",        "",        "",                                         "r,u",        				"rectangular,unit"},
 	{   0, 'U', "timestamp",     "",        "",                                         "c,j,o",    				"command,justify,offset"},

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -50,6 +50,7 @@ struct GMT_XINGS {
 
 EXTERN_MSC char *opt (struct GMTAPI_CTRL *API,char code);
 
+EXTERN_MSC bool gmtinit_B_is_frame (struct GMT_CTRL *GMT, char *in);
 EXTERN_MSC int64_t gmt_parse_index_range (struct GMT_CTRL *GMT, char *p, int64_t *start, int64_t *stop);
 EXTERN_MSC void gmtlib_handle_escape_text (char *text, char key, int way);
 EXTERN_MSC int gmtlib_ascii_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double *ptr, char *txt);

--- a/src/gmt_macros.h
+++ b/src/gmt_macros.h
@@ -114,7 +114,6 @@
 #define gmt_M_uint_swap(x, y) {unsigned int uint_tmp; uint_tmp = x, x = y, y = uint_tmp;}
 #define gmt_M_double_swap(x, y) {double double_tmp; double_tmp = x, x = y, y = double_tmp;}
 #define gmt_M_float_swap(x, y) {float float_tmp; float_tmp = x, x = y, y = float_tmp;}
-#define gmt_M_voidp_swap(x, y) {void *ptr_tmp; ptr_tmp = x, x = y, y = ptr_tmp;}
 
 /*! Macro to ensure proper value and sign of a change in longitude from lon1 to lon2 */
 #define gmt_M_set_delta_lon(lon1,lon2,delta) {delta = fmod ((lon2) - (lon1), 360.0); if (fabs (delta) > 180.0) delta = copysign (360.0 - fabs (delta), -delta);}

--- a/src/gmt_macros.h
+++ b/src/gmt_macros.h
@@ -114,6 +114,7 @@
 #define gmt_M_uint_swap(x, y) {unsigned int uint_tmp; uint_tmp = x, x = y, y = uint_tmp;}
 #define gmt_M_double_swap(x, y) {double double_tmp; double_tmp = x, x = y, y = double_tmp;}
 #define gmt_M_float_swap(x, y) {float float_tmp; float_tmp = x, x = y, y = float_tmp;}
+#define gmt_M_voidp_swap(x, y) {void *ptr_tmp; ptr_tmp = x, x = y, y = ptr_tmp;}
 
 /*! Macro to ensure proper value and sign of a change in longitude from lon1 to lon2 */
 #define gmt_M_set_delta_lon(lon1,lon2,delta) {delta = fmod ((lon2) - (lon1), 360.0); if (fabs (delta) > 180.0) delta = copysign (360.0 - fabs (delta), -delta);}

--- a/src/gmt_parse.c
+++ b/src/gmt_parse.c
@@ -454,6 +454,37 @@ GMT_LOCAL struct GMT_OPTION *fix_gdal_files (struct GMT_OPTION *opt) {
 	return opt;
 }
 
+/*! */
+GMT_LOCAL void ensure_b_options_order (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
+	bool do_sort = false;
+	char *c = NULL;
+	unsigned int k, n_B = 0, this_priority, priority[12]; /* Worst case is -Bpx, -Bsx, ... */
+	struct GMT_OPTION *opt;
+
+	gmt_M_memset (priority, 12, unsigned int);
+
+	for (opt = options; opt; opt = opt->next) {
+		if (opt->option != 'B') continue;	/* Only look at -B options here */
+		if (gmtinit_B_is_frame (GMT, opt->arg)) continue;	/* Don't care about the frame setting here */
+		if ((c = gmt_first_modifier (GMT, opt->arg, "aflLpsSu"))) {	/* Option has axis modifier(s) */
+			c[0] = '\0';	/* Temporary chop them off */
+			k = 0;	/* Start of option string, then advance past any leading [p|s][x|y|z] */
+			if (strchr ("ps",  opt->arg[k])) k++;
+			if (strchr ("xyz", opt->arg[k])) k++;
+			this_priority = (opt->arg[k]) ? 1 : 2;	/* If nothing then probably just a label setting, else we have a leading interval setting */
+			c[0] = '+';	/* Restore modifiers */
+		}
+		else /* Must be interval setting */
+			this_priority = 1;
+		priority[n_B] = this_priority;
+		n_B++;
+	}
+	if (n_B < 2) return;	/* Nothing to sort */
+	for (k = 1; k < n_B; k++) if (priority[k] < priority[k-1]) do_sort = true;
+	if (!do_sort) return;	/* No need to sort */
+	GMT_Report (GMT->parent, GMT_MSG_WARNING, "GMT_Parse_Options: List interval-setting -B options before other axis -B options to ensure proper parsing.\n");
+}
+
 /*! . */
 struct GMT_OPTION *GMT_Create_Options (void *V_API, int n_args_in, const void *in) {
 	/* This function will loop over the n_args_in supplied command line arguments (in) and
@@ -1007,6 +1038,8 @@ int GMT_Parse_Common (void *V_API, const char *given_options, struct GMT_OPTION 
 	if (parse_complete_options (API->GMT, options)) return_error (API, GMT_OPTION_HISTORY_ERROR);	/* Replace shorthand failed */
 
 	if (API->GMT->common.B.mode == 0) API->GMT->common.B.mode = parse_check_b_options (API->GMT, options);	/* Determine the syntax of the -B option(s) */
+
+	ensure_b_options_order (API->GMT, options);	/* Avoid parsing axes labels etc before axis increments since we may auto-set increments in the former */
 
 	n_errors = parse_check_extended_R (API->GMT, options);	/* Possibly parse -I if required by -R */
 


### PR DESCRIPTION
**Description of proposed changes**

Various fixes to scripts and code to avoid some warnings.

1. Some scripts played loose with **-B** and would inadvertently set **-B** increments twice.
2. Parsing of **-B** was improved to avoid some of those **-B** cases (Axis sub-item a set more than once (typo?)).
3. Added new **-B** option checker determine if options are given in an order that may lead to such warnings. For now we warn when this happens. Ideally we should reorder the option array but that is more work.
4. Added library function gmtinit_B_is_frame to help determine type of -B option.
5. Fixed typo in long-options parsing and added directives to the **--axis** long option.
