### PR TITLE
Dont warn if movie background plot is missing since it may not exist

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -16385,8 +16385,8 @@ GMT_LOCAL int process_figures (struct GMTAPI_CTRL *API, char *show) {
 			if (access (cmd, F_OK)) {	/* No such file, check if the fully baked file is there instead */
 				mark = '+';	/* This is the last char in extension for a fully-baked GMT PostScript file */
 				snprintf (cmd, GMT_BUFSIZ, "%s/gmt_%d.ps%c", API->gwf_dir, fig[k].ID, mark);	/* Check if the file exists */
-				if (access (cmd, F_OK)) {	/* No such file ether, give up; warn if a fig set via gmt figure (k > 0) */
-					if (k) GMT_Report (API, GMT_MSG_WARNING, "Figure # %d was registered but no matching PostScript-|+ file found - skipping\n", fig[k].ID, cmd);
+				if (access (cmd, F_OK)) {	/* No such file ether, give up; warn if a fig set via gmt figure (k > 0) and it is not the movie_background case which may not have a plot to go with it */
+					if (k && strcmp (fig[k].prefix, "movie_background")) GMT_Report (API, GMT_MSG_WARNING, "Figure # %d (%s) was registered but no matching PostScript-|+ file found - skipping\n", fig[k].ID, fig[k].prefix);
 					continue;
 				}
 			}


### PR DESCRIPTION
The **movie** module automatically calls **gmt figure** to set the background figure plot.  However, many background scripts simply compute data and make no background plot.  Thus, we should not fuss about such a file not being present to be converted to PNG.  See #2738 for the type of message.
In the process I improved the _GMT_Report_ statement which had a superfluous 3rd argument with no corresponding format argument.  We now skip the warning if the "missing" plot is called _movie_background_ and report the name of the plot otherwise.
