### PR TITLE
Address subplot auto-B issues

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13405,7 +13405,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 				for (opt = *options; opt; opt = opt->next) {	/* Loop over all options */
 					if (opt->option != 'B') continue;	/* Just interested in -B here */
 					/* Deal with the frame option check first */
-					if (strchr ("WESNwesnlrbt", opt->arg[0]))	/* User is overriding the axes settings - that is their choice */
+					if (strchr ("WESNwesnlrbt", opt->arg[0]))	/* User is overriding the frame settings - that is their choice */
 						frame_set = true;
 					else if (strstr (opt->arg, "+t") || strstr (opt->arg, "+g")) {	/* No axis specs means we have to add default */
 						/* Frame but no sides specified.  Insert the required sides */
@@ -13413,11 +13413,13 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 						strncat (arg, opt->arg, GMT_LEN256-1);
 						GMT_Update_Option (API, opt, arg);
 						frame_set = true;
+						GMT_Report (API, GMT_MSG_DEBUG, "Subplot-checker revised -B frame option arg to %s\n", arg);
 					}
 					else if (opt->arg[0] == 'x') {	/* Gave specific x-setting */
 						if (opt->arg[1] == '+')	{	/* No x-axis annot/tick given, prepend default determined in subplot  */
 							snprintf (arg, GMT_LEN256, "x%s%s", P->Bxannot, &opt->arg[1]);
 							GMT_Update_Option (API, opt, arg);
+							GMT_Report (API, GMT_MSG_DEBUG, "Subplot-checker revised -Bx axis option arg to %s\n", arg);
 						}
 						if (P->Bxlabel[0]) {	/* Provided a label during subplot initialization */
 							strcpy (arg, opt->arg);	/* Start with what we were given */
@@ -13430,6 +13432,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 								strcat (arg, P->Bxlabel);
 							}
 							GMT_Update_Option (API, opt, arg);
+							GMT_Report (API, GMT_MSG_DEBUG, "Subplot-checker revised -Bx axis label option arg to %s\n", arg);
 						}
 						x_set = true;
 					}
@@ -13437,6 +13440,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 						if (opt->arg[1] == '+')	{	/* No x-axis annot/tick set, prepend default af */
 							snprintf (arg, GMT_LEN256, "y%s%s", P->Byannot, &opt->arg[1]);
 							GMT_Update_Option (API, opt, arg);
+							GMT_Report (API, GMT_MSG_DEBUG, "Subplot-checker revised -By axis option arg to %s\n", arg);
 						}
 						if (P->Bylabel[0]) {
 							strcpy (arg, opt->arg);	/* Start with what we were given */
@@ -13449,6 +13453,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 								strcat (arg, P->Bylabel);
 							}
 							GMT_Update_Option (API, opt, arg);
+							GMT_Report (API, GMT_MSG_DEBUG, "Subplot-checker revised -By axis label option arg to %s\n", arg);
 						}
 						y_set = true;
 					}
@@ -13461,18 +13466,21 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 					}
 					else if ((opt = GMT_Make_Option (API, 'B', "0")) == NULL) return NULL;	/* Add -B0 to just draw frame */
 					if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
+					GMT_Report (API, GMT_MSG_DEBUG, "Subplot-checker added -B frame option with arg %s\n", arg);
 				}
 				if (!x_set) {	/* Did not specify x-axis setting either via -Bx or -B so do that now */
 					snprintf (arg, GMT_LEN256, "x%s", P->Bxannot);	/* Start with the x tick,annot,grid choices */
 					if (P->Bxlabel[0]) {strcat (arg, "+l"); strcat (arg, P->Bxlabel);}	/* Add label, if active */
 					if ((opt = GMT_Make_Option (API, 'B', arg)) == NULL) return NULL;	/* Failure to make option */
 					if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
+					GMT_Report (API, GMT_MSG_DEBUG, "Subplot-checker added -Bx axis option with arg %s\n", arg);
 				}
 				if (!y_set) {	/* Did not specify y-axis setting so do that now */
 					snprintf (arg, GMT_LEN256, "y%s", P->Byannot);	/* Start with the x tick,annot,grid choices */
 					if (P->Bylabel[0]) {strcat (arg, "+l"); strcat (arg, P->Bylabel);}	/* Add label, if active */
 					if ((opt = GMT_Make_Option (API, 'B', arg)) == NULL) return NULL;	/* Failure to make option */
 					if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
+					GMT_Report (API, GMT_MSG_DEBUG, "Subplot-checker added -By axis option with arg %s\n", arg);
 				}
 				panel_B_set (API, fig, row, col);
 			}
@@ -13601,6 +13609,11 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 		}
 	}
 
+	if (gmt_M_is_verbose (GMT, GMT_MSG_DEBUG) && options) {
+		char *string = GMT_Create_Cmd (API, *options);
+		GMT_Report (API, GMT_MSG_DEBUG, "Revised options: %s\n", string);
+		GMT_Destroy_Cmd (API, &string);
+	}
 	/* Here we can call the rest of the initialization */
 
 	return (gmt_begin_module_sub (API, lib_name, mod_name, Ccopy));

--- a/test/modern/sublegend.sh
+++ b/test/modern/sublegend.sh
@@ -2,10 +2,10 @@
 # Test that the auto-legend works in subplots
 gmt begin sublegend ps
   gmt subplot begin 2x1 -Fs7i/3i -T"Subplots with legends" -X0.7i
-    gmt plot -R0/7/3/7 -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+hLEGEND+f16p+d -c0
+    gmt plot -R0/7/3/7 @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+hLEGEND+f16p+d -c0
     gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"+s0.2i
     gmt plot @Table_5_11.txt -St0.15i -Gorange -lOranges
-    gmt plot -R0/7/3/7 -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+hLEGEND+f16p+d+jTL -c1
+    gmt plot -R0/7/3/7 @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+hLEGEND+f16p+d+jTL -c1
     gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"+s0.2i
     gmt plot @Table_5_11.txt -St0.15i -Gred -lRed
   gmt subplot end

--- a/test/psbasemap/fancyannot.ps
+++ b/test/psbasemap/fancyannot.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.1.0_5686e15_2020.02.02 [64-bit] Document from pstext
+%%Title: GMT v6.1.0_0f386a2-dirty_2020.02.16 [64-bit] Document from pstext
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Feb  2 21:18:47 2020
+%%CreationDate: Sun Feb 16 15:34:59 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -115,39 +115,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -661,13 +661,13 @@ FQ
 O0
 1200 1200 TM
 % PostScript produced by:
-%@GMT: gmt pstext -R0/6/0/8.66433 -Jx1i -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
-%@PROJ: xy 0.00000000 6.00000000 0.00000000 8.66433000 0.000 6.000 0.000 8.664 +xy
+%@GMT: gmt pstext -R0/6/0/8.85644 -Jx1i -N -F+jBC+f32p,Helvetica,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 8.85644000 0.000 6.000 0.000 8.856 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-3600 10981 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+3600 11442 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 533 F0
 (FANCY ANNOTATIONS) bc Z
 %%EndObject
@@ -675,9 +675,9 @@ PSL_plot_completion /PSL_plot_completion {} def
 0 A
 FQ
 O0
-0 5613 TM
+0 5844 TM
 % PostScript produced by:
-%@GMT: gmt psbasemap -JM6i -B+f -BWEnS -Xa0i -Ya4.6643i -R-1.5/1.5/-1/1
+%@GMT: gmt psbasemap -JM6i -B+f -BWENS -Xa0i -Ya4.8564i -R-1.5/1.5/-1/1
 %@PROJ: merc -1.50000000 1.50000000 -1.00000000 1.00000000 -166979.236 166979.236 -110579.965 110579.965 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -807,34 +807,41 @@ N 7283 4768 M -7366 0 D S
 N 7283 4851 M -7366 0 D S
 N 0 4851 M 0 -4934 D S
 N -83 4851 M 0 -4934 D S
-0 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 -167 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(1∞30úW) tc Z
-1200 -167 M (1∞00úW) tc Z
-2400 -167 M (0∞30úW) tc Z
-3600 -167 M (0∞00ú) tc Z
-4800 -167 M (0∞30úE) tc Z
-6000 -167 M (1∞00úE) tc Z
-7200 -167 M (1∞30úE) tc Z
--167 0 M (1∞00úS) mr Z
-7367 0 M (1∞00úS) ml Z
--167 1192 M (0∞30úS) mr Z
-7367 1192 M (0∞30úS) ml Z
--167 2384 M (0∞00ú) mr Z
-7367 2384 M (0∞00ú) ml Z
--167 3576 M (0∞30úN) mr Z
-7367 3576 M (0∞30úN) ml Z
--167 4768 M (1∞00úN) mr Z
-7367 4768 M (1∞00úN) ml Z
+(1è30©W) tc Z
+0 4935 M (1è30©W) bc Z
+1200 -167 M (1è00©W) tc Z
+1200 4935 M (1è00©W) bc Z
+2400 -167 M (0è30©W) tc Z
+2400 4935 M (0è30©W) bc Z
+3600 -167 M (0è00©) tc Z
+3600 4935 M (0è00©) bc Z
+4800 -167 M (0è30©E) tc Z
+4800 4935 M (0è30©E) bc Z
+6000 -167 M (1è00©E) tc Z
+6000 4935 M (1è00©E) bc Z
+7200 -167 M (1è30©E) tc Z
+7200 4935 M (1è30©E) bc Z
+-167 0 M (1è00©S) mr Z
+7367 0 M (1è00©S) ml Z
+-167 1192 M (0è30©S) mr Z
+7367 1192 M (0è30©S) ml Z
+-167 2384 M (0è00©) mr Z
+7367 2384 M (0è00©) ml Z
+-167 3576 M (0è30©N) mr Z
+7367 3576 M (0è30©N) ml Z
+-167 4768 M (1è00©N) mr Z
+7367 4768 M (1è00©N) ml Z
 %%EndObject
-0 -5613 TM
+0 -5844 TM
 PSL_plot_completion /PSL_plot_completion {} def
 0 A
 FQ
 O0
 0 16 TM
 % PostScript produced by:
-%@GMT: gmt psbasemap -JM6i -B -Bxaf -Byaf -Xa0i -Ya0i -R-1.5/1.5/-1/1
+%@GMT: gmt psbasemap -JM6i -BWENS -Bxaf -Byaf -Xa0i -Ya0i -R-1.5/1.5/-1/1
 %@PROJ: merc -1.50000000 1.50000000 -1.00000000 1.00000000 -166979.236 166979.236 -110579.965 110579.965 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -964,32 +971,32 @@ N 7283 4768 M -7366 0 D S
 N 7283 4851 M -7366 0 D S
 N 0 4851 M 0 -4934 D S
 N -83 4851 M 0 -4934 D S
-0 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 -167 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(-1∞30ú) tc Z
-0 4935 M (-1∞30ú) bc Z
-1200 -167 M (-1∞00ú) tc Z
-1200 4935 M (-1∞00ú) bc Z
-2400 -167 M (-0∞30ú) tc Z
-2400 4935 M (-0∞30ú) bc Z
-3600 -167 M (0∞00ú) tc Z
-3600 4935 M (0∞00ú) bc Z
-4800 -167 M (0∞30ú) tc Z
-4800 4935 M (0∞30ú) bc Z
-6000 -167 M (1∞00ú) tc Z
-6000 4935 M (1∞00ú) bc Z
-7200 -167 M (1∞30ú) tc Z
-7200 4935 M (1∞30ú) bc Z
--167 0 M (-1∞00ú) mr Z
-7367 0 M (-1∞00ú) ml Z
--167 1192 M (-0∞30ú) mr Z
-7367 1192 M (-0∞30ú) ml Z
--167 2384 M (0∞00ú) mr Z
-7367 2384 M (0∞00ú) ml Z
--167 3576 M (0∞30ú) mr Z
-7367 3576 M (0∞30ú) ml Z
--167 4768 M (1∞00ú) mr Z
-7367 4768 M (1∞00ú) ml Z
+(î1è30©) tc Z
+0 4935 M (î1è30©) bc Z
+1200 -167 M (î1è00©) tc Z
+1200 4935 M (î1è00©) bc Z
+2400 -167 M (î0è30©) tc Z
+2400 4935 M (î0è30©) bc Z
+3600 -167 M (0è00©) tc Z
+3600 4935 M (0è00©) bc Z
+4800 -167 M (0è30©) tc Z
+4800 4935 M (0è30©) bc Z
+6000 -167 M (1è00©) tc Z
+6000 4935 M (1è00©) bc Z
+7200 -167 M (1è30©) tc Z
+7200 4935 M (1è30©) bc Z
+-167 0 M (î1è00©) mr Z
+7367 0 M (î1è00©) ml Z
+-167 1192 M (î0è30©) mr Z
+7367 1192 M (î0è30©) ml Z
+-167 2384 M (0è00©) mr Z
+7367 2384 M (0è00©) ml Z
+-167 3576 M (0è30©) mr Z
+7367 3576 M (0è30©) ml Z
+-167 4768 M (1è00©) mr Z
+7367 4768 M (1è00©) ml Z
 %%EndObject
 0 -16 TM
 PSL_plot_completion /PSL_plot_completion {} def

--- a/test/psbasemap/fancyannot.sh
+++ b/test/psbasemap/fancyannot.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Test the new +f modifier to -B
 gmt begin fancyannot ps
-  gmt subplot begin 2x1 -M12p -Fs6i/4i -SR+ -R-1.5/1.5/-1/1 -BWSne -T"FANCY ANNOTATIONS"
+  gmt subplot begin 2x1 -M12p -Fs6i/4i -SR -R-1.5/1.5/-1/1 -T"FANCY ANNOTATIONS"
     gmt basemap -JM? -B+f 
-    gmt basemap -JM? -B -c
+    gmt basemap -JM? -c
   gmt subplot end
 gmt end show

--- a/test/pslegend/subplotlegend.sh
+++ b/test/pslegend/subplotlegend.sh
@@ -7,7 +7,7 @@ gmt begin subplotlegend ps
     gmt subplot begin 2x2 -Fs7c/5c -A
 
     gmt subplot set 0
-    gmt basemap -R0/10/0/10 -B
+    gmt basemap -R0/10/0/10
     gmt legend -DjRT+w1.2c -F+p0.5p << EOF
 S 0.1c c 0.1c red - 0.3c a
 S 0.1c s 0.1c blue - 0.3c b
@@ -16,7 +16,7 @@ EOF
 
     gmt subplot set 1 -Cw1c -Cs1c
     #gmt subplot set 1
-    gmt basemap -R0/10/0/10 -B
+    gmt basemap -R0/10/0/10
     gmt legend -DjRT+w1.2c -F+p0.5p << EOF
 S 0.1c c 0.1c red - 0.3c a
 S 0.1c s 0.1c blue - 0.3c b
@@ -25,7 +25,7 @@ EOF
 
     gmt subplot set 2 -Ce1c
     #gmt subplot set 1
-    gmt basemap -R0/10/0/10 -B
+    gmt basemap -R0/10/0/10
     gmt legend -DjRT+w1.2c -F+p0.5p << EOF
 S 0.1c c 0.1c red - 0.3c a
 S 0.1c s 0.1c blue - 0.3c b
@@ -34,7 +34,7 @@ EOF
 
     gmt subplot set 3 -Ce1c -Cn2c
     #gmt subplot set 1
-    gmt basemap -R0/10/0/10 -B
+    gmt basemap -R0/10/0/10
     gmt legend -DjRT+w1.2c -F+p0.5p << EOF
 S 0.1c c 0.1c red - 0.3c a
 S 0.1c s 0.1c blue - 0.3c b


### PR DESCRIPTION
**Description of proposed changes**

The tests reveled a bunch of messages like this:

```
basemap [WARNING]: Axis sub-item a set more than once (typo?)
basemap [WARNING]: Axis sub-item f set more than once (typo?)
```

which are tracked to various subplot examples.  Basically, they were "user" errors in which some stray **-B** strings were added to plot commands even though the subplot begin deals with this.  in the process I fixed related issues in some scripts, added better debug output for tracking similar issues in the future, and updated a _PostScript_ original that changed after fixing the script.
