### PR TITLE
Alert users to the colon that separates info and label

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -153,6 +153,7 @@
     **-Sq**
         **q**\ uoted line, i.e., lines with annotations such as contours. Append
         [**d**\|\ **D**\|\ **f**\|\ **l**\|\ **L**\|\ **n**\|\ **N**\|\ **s**\|\ **S**\|\ **x**\|\ **X**]\ *info*\ [:*labelinfo*].
+        Note the colon that separates the algorithm settings from the label information.
         The required argument controls the placement of labels along the quoted
         lines. Choose among six controlling algorithms:
 
@@ -394,6 +395,7 @@
     **-S~**
         decorated line, i.e., lines with symbols along them. Append
         [**d**\|\ **D**\|\ **f**\|\ **l**\|\ **L**\|\ **n**\|\ **N**\|\ **s**\|\ **S**\|\ **x**\|\ **X**]\ *info*\ [:*symbolinfo*].
+        Note the colon that separates the algorithm settings from the symbol information.
         The required argument controls the placement of symbols along the decorated
         lines. Choose among six controlling algorithms:
 

--- a/doc/rst/source/explain_symbols2.rst_
+++ b/doc/rst/source/explain_symbols2.rst_
@@ -172,6 +172,7 @@
         It is assumed that each individual line has a constant *z* level
         (i.e., each line must lie in the *x-y* plane).  Append
         [**d**\|\ **D**\|\ **f**\|\ **l**\|\ **L**\|\ **n**\|\ **x**\|\ **X**]\ *info*\ [:*labelinfo*].
+        Note the colon that separates the algorithm settings from the label information.
         The required argument controls the placement of labels along the quoted
         lines. Choose among five controlling algorithms:
 
@@ -405,6 +406,7 @@
     **-S~**
         decorated line, i.e., lines with symbols along them. Append
         [**d**\|\ **D**\|\ **f**\|\ **l**\|\ **L**\|\ **n**\|\ **N**\|\ **s**\|\ **S**\|\ **x**\|\ **X**]\ *info*\ [:*symbolinfo*].
+        Note the colon that separates the algorithm settings from the symbol information.
         The required argument controls the placement of symbols along the decorated
         lines. Choose among six controlling algorithms:
 


### PR DESCRIPTION
It is subtle and can be missed, like [here](https://forum.generic-mapping-tools.org/t/trouble-plotting-labels-on-lines/249/2).  It would be good to follow-up and ensure the parser complains if there is no colon and we still find label modifiers.
