### PR TITLE
Add ellipsoid to proj4 string in grdproject

### DIFF
--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -234,6 +234,7 @@ EXTERN_MSC void gmtlib_contract_headerpad (struct GMT_CTRL *GMT, struct GMT_GRID
 EXTERN_MSC void gmtlib_contract_pad (struct GMT_CTRL *GMT, void *object, int family, unsigned int *orig_pad, double *orig_wesn);
 EXTERN_MSC uint64_t gmtlib_glob_list (struct GMT_CTRL *GMT, const char *pattern, char ***list);
 EXTERN_MSC void gmtlib_change_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET *D);
+EXTERN_MSC void gmtlib_ellipsoid_name_convert (char *inname, char outname[]);
 
 #ifdef HAVE_GDAL
 EXTERN_MSC int gmtlib_read_image (struct GMT_CTRL *GMT, char *file, struct GMT_IMAGE *I, double *wesn,

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -3043,7 +3043,7 @@ GMT_LOCAL void plot_ellipsoid_name_convert2 (char *inname, char outname[]) {
 }
 #endif
 
-GMT_LOCAL void plot_ellipsoid_name_convert (char *inname, char outname[]) {
+void gmtlib_ellipsoid_name_convert (char *inname, char outname[]) {
 	/* Convert the ellipsoid names to the slightly different way that they are called in proj4 */
 	if (!strcmp(inname, "WGS-84"))
 		sprintf(outname, "WGS84");
@@ -6693,7 +6693,7 @@ char *gmt_export2proj4 (struct GMT_CTRL *GMT) {
 		snprintf (szProj4+len, GMT_LEN512-len, " +a=%.3f +b=%.3f", a, b);
 		len = strlen (szProj4);
 		if (fabs(a - b) > 1) {		/* WGS84 is not spherical */
-			plot_ellipsoid_name_convert(GMT->current.setting.ref_ellipsoid[GMT->current.setting.proj_ellipsoid].name, proj4_ename);
+			gmtlib_ellipsoid_name_convert (GMT->current.setting.ref_ellipsoid[GMT->current.setting.proj_ellipsoid].name, proj4_ename);
 			snprintf(szProj4+len, GMT_LEN512-len, " +ellps=%s", proj4_ename);
 			len = strlen (szProj4);
 			if (!strcmp(proj4_ename, "WGS84"))


### PR DESCRIPTION
Convert between ellipsoid names known to both GMT & GDAL and add +ellps=xxx to the ``+proj4=longlat ...`` string.