### PR TITLE
Fix links in gmt.conf

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -45,7 +45,8 @@ THEMATIC SUB-SECTIONS             *prefix*
 `Calendar/Time Parameters`_       **TIME_**
 ================================= ================
 
-.. _COLOR Parameters:
+COLOR Parameters
+~~~~~~~~~~~~~~~~
 
 .. glossary::
 
@@ -82,8 +83,8 @@ THEMATIC SUB-SECTIONS             *prefix*
     **COLOR_NAN**
         Color used for the non-defined areas of images (i.e., where z = NaN) [127.5].
 
-
-.. _DIR Parameters:
+DIR Parameters
+~~~~~~~~~~~~~~
 
 .. glossary::
 
@@ -100,7 +101,8 @@ THEMATIC SUB-SECTIONS             *prefix*
     **DIR_GSHHG**
         Path to GSHHG files. Defaults to **$GMT_SHAREDIR**/coast if empty.
 
-.. _FONT Parameters:
+FONT Parameters
+~~~~~~~~~~~~~~~
 
 .. glossary::
 
@@ -138,7 +140,8 @@ THEMATIC SUB-SECTIONS             *prefix*
     **FONT_TITLE**
         Font to use when plotting titles over graphs [24p,Helvetica,black].
 
-.. _FORMAT Parameters:
+FORMAT Parameters
+~~~~~~~~~~~~~~~~~
 
 .. glossary::
 
@@ -281,7 +284,8 @@ THEMATIC SUB-SECTIONS             *prefix*
         virtually any text can be used (even not containing any time
         information) [%Y %b %d %H:%M:%S].
 
-.. _GMT Miscellaneous Parameters:
+GMT Miscellaneous Parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. glossary::
 
@@ -420,7 +424,8 @@ THEMATIC SUB-SECTIONS             *prefix*
         **t**\ imings (for slow algorithms only), **i**\ nformation,
         **c**\ ompatibility warnings, and **d**\ ebugging messages [**w**].
 
-.. _I/O Parameters:
+I/O Parameters
+~~~~~~~~~~~~~~
 
 .. glossary::
 
@@ -530,7 +535,8 @@ THEMATIC SUB-SECTIONS             *prefix*
         or N as regular segment markers you must escape them with a leading
         backslash.
 
-.. _MAP Parameters:
+MAP Parameters
+~~~~~~~~~~~~~~
 
 .. glossary::
 
@@ -729,7 +735,8 @@ THEMATIC SUB-SECTIONS             *prefix*
         Intermediate settings give something in between. Negative values (up
         to -2) are allowed as well [0].
 
-.. _Projection Parameters:
+Projection Parameters
+~~~~~~~~~~~~~~~~~~~~~
 
 .. glossary::
 
@@ -868,7 +875,8 @@ THEMATIC SUB-SECTIONS             *prefix*
         projections in order to minimize areal distortion. Provide a new
         scale-factor or leave as default.
 
-.. _PostScript Parameters:
+PostScript Parameters
+~~~~~~~~~~~~~~~~~~~~~
 
 .. glossary::
 
@@ -996,7 +1004,8 @@ THEMATIC SUB-SECTIONS             *prefix*
         Exclusion, HardLight, Hue, Lighten, Luminosity, Multiply, Normal,
         Overlay, Saturation, SoftLight, and Screen [Normal].
 
-.. _Calendar/Time Parameters:
+Calendar/Time Parameters
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. glossary::
 


### PR DESCRIPTION
Closes #2760.

It seems we can't add lables before the glossary directive.
Here I split the parameter groups into subsections and then
we can reference titles of subsections.