### PR TITLE
doc: Fix wrong inclusion of explain_-r.rst_

### DIFF
--- a/doc/rst/source/grdgdal.rst
+++ b/doc/rst/source/grdgdal.rst
@@ -51,7 +51,7 @@ Required Arguments
 .. _-A:
 
 **-A**\ *prog*\ [**+m**\ *method*\ **+c**\ *cpt*]
-    Select which GDAL program to run (currently one of *info*, *dem*, *grid*, *rasterize*, *translate or *warp*) 
+    Select which GDAL program to run (currently one of *info*, *dem*, *grid*, *rasterize*, *translate or *warp*)
     When program is *dem* append **+m**\ *method* (pick one of *hillshade*, *color-relief*, *slope*, *TRI*, *TPI*
     or *roughness*) and, for *color-relief*, need also to specify a colormap with **+c**\ *cpt_name*.
 
@@ -107,7 +107,7 @@ Optional Arguments
 
 .. include:: explain_-qi.rst_
 
-.. include:: explain_-r.rst_
+.. include:: explain_nodereg.rst_
 
 .. include:: explain_colon.rst_
 


### PR DESCRIPTION
Replace `explain_-r.rst_` with `explain_nodereg.rst_`.