### PR TITLE
doc: Fixes sphinx warning "html_static_path entry '_source/_static' does not exist"

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -34,6 +34,7 @@ install (FILES
 # reST documentation
 add_subdirectory (rst)
 set (RST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/rst/source)
+set (RST_STATIC_DIR ${CMAKE_CURRENT_BINARY_DIR}/rst/_static)
 add_subdirectory (fig)
 
 # Add tests and make verbatim copies from scripts

--- a/doc/examples/CMakeLists.txt
+++ b/doc/examples/CMakeLists.txt
@@ -85,12 +85,12 @@ if (UNIX AND DO_ANIMATIONS)
 	# copy video files from anim 04, 06, 07, 08
 	foreach (_num 04 06 07 08)
 		add_custom_command (
-			OUTPUT ${RST_BINARY_DIR}/_static/anim${_num}.mp4
+			OUTPUT ${RST_STATIC_DIR}/anim${_num}.mp4
 			COMMAND ${CMAKE_COMMAND} -E copy_if_different
 			${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.mp4
-			${RST_BINARY_DIR}/_static/anim${_num}.mp4
+			${RST_STATIC_DIR}/anim${_num}.mp4
 			DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.gif)
-		list (APPEND _animations ${RST_BINARY_DIR}/_static/anim${_num}.mp4)
+		list (APPEND _animations ${RST_STATIC_DIR}/anim${_num}.mp4)
 	endforeach ()
 	add_custom_target (animation DEPENDS ${_animations})
 

--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -68,7 +68,7 @@ html_context = {
 }
 # favicon of the docs
 html_favicon = "_static/favicon.png"
-html_static_path = ['_static', 'source/_static']
+html_static_path = ['_static']
 html_last_updated_fmt = '%b %d, %Y'
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = True


### PR DESCRIPTION
Copy videos to the top level rst/_static directory to fix the
`rst/source/_static` not found warning.

The documentation build process is warning-free now.