### PR TITLE
Handle 3-D layer in grdinterpolate

### DIFF
--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -644,7 +644,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 					GMT_Report (GMT->parent, GMT_MSG_WARNING, "The x-coordinates and range attribute are in conflict but range is exactly 360; we rely on this range\n");
 					if (set_reg && (header->n_columns%2) == 0) {	/* Pixel registration */
 						registration = header->registration = GMT_GRID_PIXEL_REG;
-						GMT_Report (GMT->parent, GMT_MSG_WARNING, "Global longitudes, guessing registration to be %s since nx is odd\n", regtype[header->registration]);
+						GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Global longitudes, guessing registration to be %s since nx is odd\n", regtype[header->registration]);
 					}
 				}
 			}
@@ -662,12 +662,12 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 				if (gmt_M_360_range (dummy[0], dummy[1]))
 					GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Grid x-coordinates after pixel registration adjustment have exactly 360 range\n");
 			}
-			GMT_Report (GMT->parent, GMT_MSG_WARNING, "No range attribute, guessing registration to be %s\n", regtype[header->registration]);
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "No range attribute, guessing registration to be %s\n", regtype[header->registration]);
 		}
 		else {	/* Only has the valid_range settings.  If no registration set, and no dx available, guess based on nx */
 			if (set_reg && (header->n_columns%2) == 0) {	/* Pixel registration */
 				registration = header->registration = GMT_GRID_PIXEL_REG;
-				GMT_Report (GMT->parent, GMT_MSG_WARNING, "No x-coordinates, guessing registration to be %s since nx is odd\n", regtype[header->registration]);
+				GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "No x-coordinates, guessing registration to be %s since nx is odd\n", regtype[header->registration]);
 			}
 		}
 
@@ -814,7 +814,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 			header->z_min = dummy[0], header->z_max = dummy[1];
 		}
 		if (gmt_M_is_dnan (header->z_min) && gmt_M_is_dnan (header->z_max)) {
-			GMT_Report (GMT->parent, GMT_MSG_WARNING, "netCDF grid %s information has zmin = zmax = NaN. Reset to 0/0.\n", HH->name);
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "netCDF grid %s information has zmin = zmax = NaN. Reset to 0/0.\n", HH->name);
 			header->z_min = header->z_max = 0.0;
 		}
 		{	/* Get deflation and chunking info */

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -206,7 +206,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDINTERPOLATE_CTRL *Ctrl, str
 	n_errors += gmt_M_check_condition (GMT, Ctrl->In.n_files < 1, "Error: No input grid(s) specified.\n");
 	n_errors += gmt_M_check_condition (GMT, !Ctrl->Z.active[GMT_IN] && Ctrl->In.n_files != 1, "Must specify one input 3D grid cube file unless -Zi is set\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->F.type > 2, "Option -F: Only 1st or 2nd derivatives may be requested\n");
-	n_errors += gmt_M_check_condition (GMT, !Ctrl->T.active, "Option -T: Must specify desired output time/level(s)\n");
+	n_errors += gmt_M_check_condition (GMT, !Ctrl->T.active, "Option -T: Must specify desired output level(s)\n");
 	n_errors += gmt_M_check_condition (GMT, !Ctrl->G.file, "Option -G: Must specify output grid file\n");
 	n_errors += gmt_M_check_condition (GMT, n_files != 1, "Must specify only one output grid file\n");
 

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -260,8 +260,8 @@ int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 	}
 	else {	/* See if we got a 3D netCDF data cube; if so return number of layers and their levels */
 		nc_layer = strchr (Ctrl->In.file[0], '?');	/* Maybe given a specific variable? */
-		if (nc_layer) {
-			strcpy (cube_layer, &nc_layer[1]);	/* Gave a specific layer. Keep variable name and remove from filename */
+		if (nc_layer) {	/* Gave a specific layer. Keep variable name and remove from filename */
+			strcpy (cube_layer, &nc_layer[1]);
 			nc_layer[0] = '\0';	/* Chop off layer name for now */
 		}
 		if ((error = gmt_examine_nc_cube (GMT, Ctrl->In.file[0], &n_layers, &level))) Return (error);
@@ -315,7 +315,7 @@ int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 	for (k = start_k; k <= stop_k; k++) {	/* Read the required layers into individual grid structures */
 		if (Ctrl->Z.active[GMT_IN])	/* Get the k'th file */
 			sprintf (file, "%s", Ctrl->In.file[k]);
-		else	/* Get the k'th layer from 3D cube possibly via a seleted variable */
+		else	/* Get the k'th layer from 3D cube possibly via a selected variable */
 			sprintf (file, "%s?%s[%" PRIu64 "]", Ctrl->In.file[0], cube_layer, k);
 		if ((G[GMT_IN][k] = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_GRID_ALL, wesn, file, NULL)) == NULL) {
 			GMT_Report (API, GMT_MSG_ERROR, "Unable to read layer %" PRIu64 " from file %s.\n", k, file);

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -100,8 +100,8 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Specify output grid file name (or template; see -Zo).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-T Interpolate the 3-D grid at given levels across the 3rd dimension\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Make evenly spaced output time steps from <min> to <max> by <inc>.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append +n to indicate <inc> is the number of knot-values to produce over the range instead.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Alternatively, give a file with output knots in the first column, or a comma-separated list.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Append +n to indicate <inc> is the number of levels to produce over the range instead.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Alternatively, give a file with output levels in the first column, or a comma-separated list.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-F Set the grid interpolation mode.  Choose from:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   l Linear interpolation.\n");
@@ -206,7 +206,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDINTERPOLATE_CTRL *Ctrl, str
 	n_errors += gmt_M_check_condition (GMT, Ctrl->In.n_files < 1, "Error: No input grid(s) specified.\n");
 	n_errors += gmt_M_check_condition (GMT, !Ctrl->Z.active[GMT_IN] && Ctrl->In.n_files != 1, "Must specify one input 3D grid cube file unless -Zi is set\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->F.type > 2, "Option -F: Only 1st or 2nd derivatives may be requested\n");
-	n_errors += gmt_M_check_condition (GMT, !Ctrl->T.active, "Option -T: Must specify output knot(s)\n");
+	n_errors += gmt_M_check_condition (GMT, !Ctrl->T.active, "Option -T: Must specify desired output time/level(s)\n");
 	n_errors += gmt_M_check_condition (GMT, !Ctrl->G.file, "Option -G: Must specify output grid file\n");
 	n_errors += gmt_M_check_condition (GMT, n_files != 1, "Must specify only one output grid file\n");
 

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -206,7 +206,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDINTERPOLATE_CTRL *Ctrl, str
 	n_errors += gmt_M_check_condition (GMT, Ctrl->In.n_files < 1, "Error: No input grid(s) specified.\n");
 	n_errors += gmt_M_check_condition (GMT, !Ctrl->Z.active[GMT_IN] && Ctrl->In.n_files != 1, "Must specify one input 3D grid cube file unless -Zi is set\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->F.type > 2, "Option -F: Only 1st or 2nd derivatives may be requested\n");
-	n_errors += gmt_M_check_condition (GMT, !Ctrl->T.active, "Option -R: Must specify output knot(s)\n");
+	n_errors += gmt_M_check_condition (GMT, !Ctrl->T.active, "Option -T: Must specify output knot(s)\n");
 	n_errors += gmt_M_check_condition (GMT, !Ctrl->G.file, "Option -G: Must specify output grid file\n");
 	n_errors += gmt_M_check_condition (GMT, n_files != 1, "Must specify only one output grid file\n");
 

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -217,7 +217,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDINTERPOLATE_CTRL *Ctrl, str
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
 int GMT_grdinterpolate (void *V_API, int mode, void *args) {
-	char file[PATH_MAX] = {""};
+	char file[PATH_MAX] = {""}, cube_layer[GMT_LEN64] = {""}, *nc_layer = NULL;
 	int error = 0;
 	unsigned int int_mode, row, col;
 	uint64_t n_layers = 0, k, node, start_k, stop_k, n_use;
@@ -259,6 +259,11 @@ int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 		level = Ctrl->Z.T.array;
 	}
 	else {	/* See if we got a 3D netCDF data cube; if so return number of layers and their levels */
+		nc_layer = strchr (Ctrl->In.file[0], '?');	/* Maybe given a specific variable? */
+		if (nc_layer) {
+			strcpy (cube_layer, &nc_layer[1]);	/* Gave a specific layer. Keep variable name and remove from filename */
+			nc_layer[0] = '\0';	/* Chop off layer name for now */
+		}
 		if ((error = gmt_examine_nc_cube (GMT, Ctrl->In.file[0], &n_layers, &level))) Return (error);
 	}
 
@@ -310,13 +315,14 @@ int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 	for (k = start_k; k <= stop_k; k++) {	/* Read the required layers into individual grid structures */
 		if (Ctrl->Z.active[GMT_IN])	/* Get the k'th file */
 			sprintf (file, "%s", Ctrl->In.file[k]);
-		else	/* Get the k'th layer from 3D cube */
-			sprintf (file, "%s?[%" PRIu64 "]", Ctrl->In.file[0], k);
+		else	/* Get the k'th layer from 3D cube possibly via a seleted variable */
+			sprintf (file, "%s?%s[%" PRIu64 "]", Ctrl->In.file[0], cube_layer, k);
 		if ((G[GMT_IN][k] = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_GRID_ALL, wesn, file, NULL)) == NULL) {
 			GMT_Report (API, GMT_MSG_ERROR, "Unable to read layer %" PRIu64 " from file %s.\n", k, file);
 			Return (API->error);
 		}
 	}
+	if (nc_layer) nc_layer[0] = '?';	/* Restore layer name */
 
 	/* Create grid layers for each output level */
 


### PR DESCRIPTION
Regarding #2785.  Needed to determine if 3D netCDF cube filename contained a specific variable and then use that variable when pulling out 2-D layers.  E.g., this now works:

`grdinterpolate S362ANI_kmps.nc?vsh -Glayer.nc -T200`

Also modified the verbosity of some test regarding grid registration which were erroneously labeled as warnings.