### PR TITLE
inset missed an else clause for a file i/o operation

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8687,7 +8687,7 @@ void gmtlib_free_dir_list (struct GMT_CTRL *GMT, char ***addr) {
 int gmt_remove_file (struct GMT_CTRL *GMT, const char *file) {
 	/* Try to remove a file - give error message if it fails.  Depends on extern int errno */
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Delete %s\n", file);
-	if (remove (file)) {
+	if (!access (file, F_OK) && remove (file)) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failed to remove %s! [remove error: %s]\n", file, strerror (errno));
 		return errno;
 	}

--- a/src/inset.c
+++ b/src/inset.c
@@ -284,9 +284,11 @@ int GMT_inset (void *V_API, int mode, void *args) {
 		sprintf (ffile, "%s/gmt%d.%s/gmt.frame", API->session_dir, GMT_MAJOR_VERSION, API->session_name);
 		if ((fp = fopen (ffile, "r")) == NULL)
 			GMT_Report (API, GMT_MSG_INFORMATION, "No file %s with frame information - no adjustments made\n", ffile);
-		fgets (Bopts, GMT_LEN256, fp);
-		gmt_chop (Bopts);
-		fclose (fp);
+		else {
+			fgets (Bopts, GMT_LEN256, fp);
+			gmt_chop (Bopts);
+			fclose (fp);
+		}
 
 		/* Write out the inset information file */
 


### PR DESCRIPTION
If a frameB info file was not found then we still tried to read from it.  Also, let _gmt_remove_file_ only try to remove the file if it actually exists - we were getting bogus messages about failing to remove when the file did not exist.  Closes #2787.
