### PR TITLE
Fix a GCC warning of fscanf

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12342,7 +12342,7 @@ GMT_LOCAL int get_current_panel (struct GMTAPI_CTRL *API, int fig, int *row, int
 		return GMT_RUNTIME_ERROR;
 	}
 	if (gap == NULL) {
-		if ((ios = fscanf (fp, "%d %d %*lg %*lg %*lg %*lg %*d", row, col)) != 2) {
+		if ((ios = fscanf (fp, "%d %d %*g %*g %*g %*g %*d", row, col)) != 2) {
 			GMT_Report (API, GMT_MSG_ERROR, "Failed to decode record from %s!\n", file);
 			API->error = GMT_RUNTIME_ERROR;
 			fclose (fp);


### PR DESCRIPTION
GCC reports the following warning, because GCC doesn't like the combination
of assignment suppression `*` and length modifier `l`.
```
../src/gmt_init.c: In function ‘get_current_panel’:
../src/gmt_init.c:12345:26: warning: use of assignment suppression and length modifier together in gnu_scanf format [-Wformat=]
   if ((ios = fscanf (fp, "%d %d %*lg %*lg %*lg %*lg %*d", row, col)) != 2) {
                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/gmt_init.c:12345:26: warning: use of assignment suppression and length modifier together in gnu_scanf format [-Wformat=]
../src/gmt_init.c:12345:26: warning: use of assignment suppression and length modifier together in gnu_scanf format [-Wformat=]
../src/gmt_init.c:12345:26: warning: use of assignment suppression and length modifier together in gnu_scanf format [-Wformat=]
```

See https://www.thecodingforums.com/threads/assignment-suppression-in-sscanf.721569/ for discussion.