### PR TITLE
Fix an sprintf warning

### DIFF
--- a/src/grdproject.c
+++ b/src/grdproject.c
@@ -229,7 +229,7 @@ int GMT_grdproject (void *V_API, int mode, void *args) {
 	unsigned int use_nx = 0, use_ny = 0, offset, k, unit = 0;
 	int error = 0;
 
-	char format[GMT_LEN128] = {""}, unit_name[GMT_GRID_UNIT_LEN80] = {""}, scale_unit_name[GMT_GRID_UNIT_LEN80] = {""};
+	char format[GMT_LEN256+6] = {""}, unit_name[GMT_GRID_UNIT_LEN80] = {""}, scale_unit_name[GMT_GRID_UNIT_LEN80] = {""};
 
 	double wesn[4];
 	double xmin, xmax, ymin, ymax, inch_to_unit, unit_to_inch, fwd_scale, inv_scale;


### PR DESCRIPTION
GCC reports the following warning:
```
../src/grdproject.c:402:26: warning: ‘/’ directive writing 1 byte into a region of size between 0 and 126 [-Wformat-overflow=]
  sprintf (format, "(%s/%s/%s/%s)", GMT->current.setting.format_float_out, GMT->current.setting.format_float_out,
                          ^
In file included from /usr/include/stdio.h:862:0,
                 from ../src/postscriptlight.h:46,
                 from ../src/gmt_dev.h:101,
                 from ../src/grdproject.c:28:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:33:10: note: ‘__builtin___sprintf_chk’ output between 6 and 258 bytes into a destination of size 128
   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __bos (__s), __fmt, __va_arg_pack ());
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

`format` should be at least 258 bytes.