### PR TITLE
ci: Add the git bin to PATH to have access to the UNIX tar command

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -187,7 +187,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Windows | Build Docs + Package'
-  #condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
   timeoutInMinutes: 120
 
   pool:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -187,7 +187,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Windows | Build Docs + Package'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  #condition: eq(variables['Build.Reason'], 'Schedule')
   timeoutInMinutes: 120
 
   pool:

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -70,7 +70,9 @@ steps:
     echo "##vso[task.setvariable variable=COASTLINEDIR]$BUILD_SOURCESDIRECTORY/coastline"
   displayName: Set install location and coastline location
 
-- bash: echo "##vso[task.prependpath]$INSTALLDIR/bin"
+- bash: |
+    echo "##vso[task.prependpath]$INSTALLDIR/bin"
+    echo "##vso[task.prependpath]C:\\Program Files\\Git\\usr\\bin"
   displayName: Set PATH
 
 - task: Cache@2


### PR DESCRIPTION
One of the Windows CI jobs fails recently when packaging GMT, due to
recent upstream breaking changes (see https://github.com/actions/virtual-environments/issues/282)

As suggested by the upstream maintainers, we need to add the git bin to PATH.