### PR TITLE
Check if variable "file" is not NULL

### DIFF
--- a/src/gmt_macros.h
+++ b/src/gmt_macros.h
@@ -196,12 +196,12 @@
 #define gmt_M_just_default(GMT,refpoint,just) (refpoint->mode == GMT_REFPOINT_JUST_FLIP ? gmt_flip_justify(GMT,refpoint->justify) : refpoint->mode == GMT_REFPOINT_JUST ? refpoint->justify : just)
 
 /*! Determine if we have a special downloadable file */
-#define gmt_M_file_is_remotedata(file) (file && file[0] == '@' && !strncmp (&file[1], GMT_DATA_PREFIX, 13U))
-#define gmt_M_file_is_cache(file) (file && file[0] == '@' && strncmp (file, "@GMTAPI@-", 9U))
-#define gmt_M_file_is_url(file) (file && (!strncmp (file, "http:", 5U) || !strncmp (file, "https:", 6U) || !strncmp (file, "ftp:", 4U)))
+#define gmt_M_file_is_remotedata(file) (file != NULL && file[0] == '@' && !strncmp (&file[1], GMT_DATA_PREFIX, 13U))
+#define gmt_M_file_is_cache(file) (file != NULL && file[0] == '@' && strncmp (file, "@GMTAPI@-", 9U))
+#define gmt_M_file_is_url(file) (file != NULL && (!strncmp (file, "http:", 5U) || !strncmp (file, "https:", 6U) || !strncmp (file, "ftp:", 4U)))
 
 /*! Determine if file is an image GDAL can read */
-#define gmt_M_file_is_image(file) (file && (strstr (file, "=gd") || strstr (file, ".jpg") || strstr (file, ".png") || strstr (file, ".ppm") || strstr (file, ".tif") || strstr (file, ".bmp") || strstr (file, ".gif")))
+#define gmt_M_file_is_image(file) (file != NULL && (strstr (file, "=gd") || strstr (file, ".jpg") || strstr (file, ".png") || strstr (file, ".ppm") || strstr (file, ".tif") || strstr (file, ".bmp") || strstr (file, ".gif")))
 
 /*! Set the correct column mode (trailing vs no trailing text) based on the given string is NULL or not */
 #define gmt_M_colmode(text) ((text == NULL) ? GMT_COL_FIX_NO_TEXT : GMT_COL_FIX)


### PR DESCRIPTION
GCC reports many warnings like the one below.
```
../src/gmt_support.c: In function ‘support_init_custom_symbol’:
../src/gmt_support.c:4678:27: warning: the address of ‘file’ will always evaluate as ‘true’ [-Waddress]
  if (gmt_M_file_is_cache (file)) /* Must be a cache file */
                           ^
../src/gmt_macros.h:200:36: note: in definition of macro ‘gmt_M_file_is_cache’
 #define gmt_M_file_is_cache(file) (file && file[0] == '@' && strncmp (file, "@GMTAPI@-", 9U))
```

When variable `file` is declared as a pointer like `char *file = NULL`,
gcc doesn't raise an warning. But when variable `file` is declared as an
string array like `char file[PATH_MAX] = {""}`, gcc reports the warning,
since the address of string `file` is alawys evaluated to be "true".

One solution is checking if `file != NULL`, which works for both string
array and pointer.