### PR TITLE
Fix the comments in some bash tools and update the documentation

### DIFF
--- a/doc/rst/source/migrating.rst
+++ b/doc/rst/source/migrating.rst
@@ -32,14 +32,21 @@ There are several ways to address the lack of using the gmt program:
    or *delete* to make actual changes.
 
 #. If your default shell is bash or similar then you can call another **share/tools**
-   script called **gmt_functions.sh**.  It will instead create bash functions with the
+   script called **gmt_functions.sh** this way::
+
+     source $(gmt --show-sharedir)/tools/gmt_functions.sh
+
+   It will instead create bash functions with the
    names of the modules and thus let you run **blockmean**, etc. without a leading
    gmt invocation.
 
 #. If your default shell is csh or similar then you must instead call **gmt_aliases.csh**
-   which works similarly to the **gmt_functions.sh** but for csh.  Both of these two
-   solutions can be implemented via your login setup so they are always set once you
-   log in to your computer or open a new terminal window.
+   which works similarly to the **gmt_functions.sh** but for csh::
+
+     source `gmt --show-sharedir`/tools/gmt_aliases.csh
+
+   Both of these two solutions can be implemented via your login setup so they are
+   always set once you log in to your computer or open a new terminal window.
 
 #. Finally, if the old script is important and is expected to be used in the future,
    maybe it is worth the effort to migrate the script code to the stricter default

--- a/share/tools/gmt_aliases.csh
+++ b/share/tools/gmt_aliases.csh
@@ -6,7 +6,7 @@
 # name with "gmt". For example: alias psxy "gmt psxy"
 #
 # Include this file in your GMT (t)csh script or on the command line with:
-#   source path/to/gmt/share/tools/gmt_aliases.csh
+#   source `gmt --show-sharedir`/tools/gmt_aliases.csh
 # If the GMT executable is not in the search path, set an extra alias:
 #   alias gmt path/to/gmt
 

--- a/share/tools/gmt_functions.sh
+++ b/share/tools/gmt_functions.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #
 # Copyright (c) 1991-2020 by the GMT Team (https://www.generic-mapping-tools.org/team.html)
 # See LICENSE.TXT file for copying and redistribution conditions.
@@ -7,7 +6,7 @@
 # via the main GMT executable (gmt <module>).
 #
 # Include this file in your GMT bash script or on the command line with:
-#   source $(gmt --show-datadir)/tools/gmt_functions.sh
+#   source $(gmt --show-sharedir)/tools/gmt_functions.sh
 # If the GMT executable is not in the search path, set an extra function:
 #   function gmt () { path/to/gmt "$@"; }
 #   export -f gmt

--- a/share/tools/gmt_uninstall.sh
+++ b/share/tools/gmt_uninstall.sh
@@ -8,7 +8,7 @@
 # we also remove those parent directories since presumably under build dir.
 #
 # Run this script on the command line with:
-#   $(gmt --show-datadir)/tools/gmt_uninstall.sh
+#   $(gmt --show-sharedir)/tools/gmt_uninstall.sh
 #
 # It expects the GMT executable to be in the search path and that
 # you have permission to perform the changes in the bin directory.


### PR DESCRIPTION
- Improve the "Migration" documentation
- Remove shebang from `gmt_functions.sh` as it should be sourced
- Remove "x" permission from `gmt_functions.sh` and `gmt_aliases.csh`
- Fix `gmt --show-datadir` to `gmt --show-sharedir`