### PR TITLE
Only warn of invalid modifier if it is a letter code

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -12838,7 +12838,7 @@ char *gmt_first_modifier (struct GMT_CTRL *GMT, char *string, const char *sep) {
 		if (strchr (sep, string[k]))
 			done = true;
 		else {
-			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Modifier +%c found but not a valid modifier! - ignored\n", string[k]);
+			if (isalpha (string[k])) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Modifier +%c found but not a valid modifier! - ignored\n", string[k]);
 			return NULL;
 		}
 	}


### PR DESCRIPTION
This way our phase shifts in **-B** can avoid being called "bad modifiers" and have their feelings hurt.  Closes #2834.
