### PR TITLE
Fix angle alignment and restore pen settings

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14047,21 +14047,21 @@ GMT_LOCAL int gmtlib_polar_prepare_label (struct GMT_CTRL *GMT, double angle, un
 
 	switch (side) {
 		case 0:	/* We are annotating angles on the inner (donut) boundary */
-			if (gmt_M_is_zero (angle) || (angle >= 180.0 && angle < 360.0)) *justify = 10, *text_angle = angle - 270.0;
+			if (gmt_M_is_zero (angle) || ((angle+GMT_CONV8_LIMIT) >= 180.0 && (angle-GMT_CONV8_LIMIT) < 360.0)) *justify = 10, *text_angle = angle - 270.0;
 			else *justify = 2, *text_angle = angle - 90;
 			break;
 		case 1:
-			if (angle >= 90.0 && angle < 270.0) *justify = 7, *text_angle = angle - 180;
+			if ((angle+GMT_CONV8_LIMIT) >= 90.0 && (angle-GMT_CONV8_LIMIT) < 270.0) *justify = 7, *text_angle = angle - 180;
 			else  *justify = 5, *text_angle = angle;
 			break;
 		case 2:	/* We are annotating angles on the outer boundary */
-			if (angle >= 0.0 && angle <= 180.0) *justify = 2, *text_angle = angle - 90.0;
+			if ((angle+GMT_CONV8_LIMIT) >= 0.0 && (angle-GMT_CONV8_LIMIT) <= 180.0) *justify = 2, *text_angle = angle - 90.0;
 			else *justify = 10, *text_angle = angle + 90.0;
 			break;
 		case 3:
-			if (angle >= 0.0 && angle < 180.0) *justify = 5, *text_angle = angle;
-			else  *justify = 7, *text_angle = 180.0 - angle;
-			if (angle >= 90.0 && angle < 270.0) *justify = 7, *text_angle = angle - 180;
+			//if (angle >= 0.0 && angle < 180.0) *justify = 5, *text_angle = angle;
+			//else  *justify = 7, *text_angle = 180.0 - angle;
+			if ((angle+GMT_CONV8_LIMIT) >= 90.0 && (angle-GMT_CONV8_LIMIT) < 270.0) *justify = 7, *text_angle = angle - 180;
 			else  *justify = 5, *text_angle = angle;
 			break;
 	}

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1927,6 +1927,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 				}
 				else {
 					change = gmt_parse_segment_header (GMT, L->header, P, &fill_active, &current_fill, &default_fill, &outline_active, &current_pen, &default_pen, default_outline, SH->ogr);
+					outline_setting = outline_active ? 1 : 0;
 				}
 				if (P && PH->skip) continue;	/* Chosen CPT indicates skip for this z */
 
@@ -1989,6 +1990,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 						polygon = false;
 						PSL_setcolor (PSL, current_fill.rgb, PSL_IS_STROKE);
 					}
+					if (change & 4) gmt_setpen (GMT, &current_pen);
 				}
 				if (S.G.label_type == GMT_LABEL_IS_HEADER) {	/* Get potential label from segment header */
 					SH = gmt_get_DS_hidden (L);

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1673,6 +1673,7 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 				}
 				else {
 					change = gmt_parse_segment_header (GMT, L->header, P, &fill_active, &current_fill, &default_fill, &outline_active, &current_pen, &default_pen, default_outline, SH->ogr);
+					outline_setting = outline_active ? 1 : 0;
 				}
 
 				if (P && PH->skip) continue;	/* Chosen CPT indicates skip for this z */
@@ -1708,6 +1709,7 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 					polygon = false;
 					PSL_setcolor (PSL, current_fill.rgb, PSL_IS_STROKE);
 				}
+				if (change & 4) gmt_setpen (GMT, &current_pen);
 				if (S.G.label_type == GMT_LABEL_IS_HEADER)	/* Get potential label from segment header */
 					gmt_extract_label (GMT, L->header, S.G.label, SH->ogr);
 

--- a/test/grdcontour/polcont.ps
+++ b/test/grdcontour/polcont.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.1.0_b745451_2020.02.29 [64-bit] Document from psxy
+%%Title: GMT v6.1.0_5032eae_2020.03.02 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sat Feb 29 10:21:52 2020
+%%CreationDate: Tue Mar  3 08:27:16 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -867,8 +867,8 @@ S
 S
 3600 -167 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-V 270 R (0) ml Z U
-3600 -167 M V 270 R (0) ml Z U
+V 90 R (0) mr Z U
+3600 -167 M V 90 R (0) mr Z U
 4950 -167 M V 270 R (30) ml Z U
 2250 -167 M V 89.8 R (30) mr Z U
 6300 -167 M V 270 R (60) ml Z U
@@ -34133,8 +34133,8 @@ S
 S
 3600 -167 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-V 270 R (0) ml Z U
-3600 -167 M V 270 R (0) ml Z U
+V 90 R (0) mr Z U
+3600 -167 M V 90 R (0) mr Z U
 4950 -167 M V 270 R (30) ml Z U
 2250 -167 M V 89.8 R (30) mr Z U
 6300 -167 M V 270 R (60) ml Z U

--- a/test/grdmask/polarhole.ps
+++ b/test/grdmask/polarhole.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.1.0_b745451_2020.02.29 [64-bit] Document from grdimage
+%%Title: GMT v6.1.0_5032eae_2020.03.02 [64-bit] Document from grdimage
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sat Feb 29 10:22:17 2020
+%%CreationDate: Tue Mar  3 08:28:59 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -1789,7 +1789,7 @@ P S
 (0è) bc Z
 3467 1650 M V -90 R (90è) bc Z U
 1650 -167 M V 360 R (180è) tc Z U
--167 1650 M V 270 R (î90è) tc Z U
+-167 1650 M V 90 R (î90è) bc Z U
 %%EndObject
 0 A
 FQ
@@ -2110,7 +2110,7 @@ P S
 (0è) bc Z
 3467 1650 M V -90 R (90è) bc Z U
 1650 -167 M V 360 R (180è) tc Z U
--167 1650 M V 270 R (î90è) tc Z U
+-167 1650 M V 90 R (î90è) bc Z U
 %%EndObject
 0 A
 FQ

--- a/test/psbasemap/polarapex.ps
+++ b/test/psbasemap/polarapex.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.1.0_a623ae1-dirty_2020.02.29 [64-bit] Document from psxy
+%%Title: GMT v6.1.0_5032eae_2020.03.02 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sat Feb 29 15:41:06 2020
+%%CreationDate: Tue Mar  3 08:28:28 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -1808,8 +1808,8 @@ V -90 R (0è) bc Z U
 1883 1184 M V -30 R (60è) bc Z U
 517 1184 M V 30 R (120è) bc Z U
 -167 0 M V 90 R (180è) bc Z U
-1200 -167 M V 270 R (0.0) ml Z U
-1200 -167 M V 270 R (0.0) ml Z U
+1200 -167 M V 90 R (0.0) mr Z U
+1200 -167 M V 90 R (0.0) mr Z U
 1441 -167 M V 270 R (0.2) ml Z U
 959 -167 M V 89.5 R (0.2) mr Z U
 1681 -167 M V 270 R (0.4) ml Z U
@@ -5451,7 +5451,7 @@ V -90 R (0è) bc Z U
 939 1628 M V -1.42e-14 R (90è) bc Z U
 125 1410 M V 30 R (120è) bc Z U
 811 -107 M V 40 R (0.0) mr Z U
-939 -167 M V 270 R (0.0) ml Z U
+939 -167 M V 90 R (0.0) mr Z U
 1232 -167 M V 270 R (0.2) ml Z U
 623 117 M V 39.7 R (0.2) mr Z U
 1524 -167 M V 270 R (0.4) ml Z U
@@ -6071,7 +6071,7 @@ V -90 R (0è) bc Z U
 800 1767 M V -1.42e-14 R (90è) bc Z U
 -83 1530 M V 30 R (120è) bc Z U
 656 -83 M V 30 R (0.0) mr Z U
-800 -167 M V 270 R (0.0) ml Z U
+800 -167 M V 90 R (0.0) mr Z U
 1121 -167 M V 270 R (0.2) ml Z U
 495 195 M V 29.7 R (0.2) mr Z U
 1441 -167 M V 270 R (0.4) ml Z U
@@ -6615,7 +6615,7 @@ V -90 R (0è) bc Z U
 1589 1693 M V -30 R (60è) bc Z U
 612 1955 M V -1.42e-14 R (90è) bc Z U
 455 -57 M V 20 R (0.0) mr Z U
-612 -167 M V 270 R (0.0) ml Z U
+612 -167 M V 90 R (0.0) mr Z U
 970 -167 M V 270 R (0.2) ml Z U
 332 280 M V 19.7 R (0.2) mr Z U
 1328 -167 M V 270 R (0.4) ml Z U
@@ -7059,7 +7059,7 @@ V -90 R (0è) bc Z U
 1461 1915 M V -30 R (60è) bc Z U
 355 2212 M (90è) bc Z
 191 -29 M V 10 R (0.0) mr Z U
-355 -167 M V 270 R (0.0) ml Z U
+355 -167 M V 90 R (0.0) mr Z U
 765 -167 M V 270 R (0.2) ml Z U
 120 375 M V 9.74 R (0.2) mr Z U
 1174 -167 M V 270 R (0.4) ml Z U
@@ -7371,7 +7371,7 @@ V -90 R (0è) bc Z U
 1283 2223 M V -30 R (60è) bc Z U
 0 2567 M (90è) bc Z
 -167 0 M (0.0) mr Z
-0 -167 M V 270 R (0.0) ml Z U
+0 -167 M V 90 R (0.0) mr Z U
 481 -167 M V 270 R (0.2) ml Z U
 -167 481 M V -0.234 R (0.2) mr Z U
 961 -167 M V 270 R (0.4) ml Z U


### PR DESCRIPTION
This PR addresses #2838 by allowing for some slight round-off in angle values near the cut-off limits used in the choices for justifications.  A few PS originals needed updates as well.

It also corrects some mistakes I introduced in #2839 that caused several checks to fail.
