### PR TITLE
Alternatively determine balance point of each profile

### DIFF
--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-C|\ *length*/\ *ds*\ [*/spacing*][**+a**\|\ **+v**][**l**\|\ **r**] ]
 [ |-D|\ *dfile* ]
 [ |-E|\ *line* ]
-[ |-F|\ [**+n**][**+z**\ *z0*] ]
+[ |-F|\ [**+b**][**+n**][**+z**\ *z0*] ]
 [ |-N| ]
 [ |SYN_OPT-R| ]
 [ |-S|\ *method*/*modifiers* ]
@@ -168,7 +168,7 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ [**+n**][**+z**\ *z0*]
+**-F**\ [**+b**][**+n**][**+z**\ *z0*]
     Find critical points along each cross-profile.
     Requires **-C** and a single input grid. We examine each cross-profile generated
     and report (*lonc*, *latc*, *distc*, *azimuthc*, *zc*) at the center peak of
@@ -179,6 +179,7 @@ Optional Arguments
     we assume the profile is positive up.  If we instead are looking
     for a trough then you must use **+n** to temporarily flip the profile to positive.
     The threshold *z0* value is always given as >= 0; use **+z** to change it [0].
+    Alternatively, use **+b** to determine the balance point and standard deviation of the profile.
     We write 12 output columns per track with an identified center peak, with values
     *lonc, latc, distc, azimuthc, zc, lonl, latl, distl, lonr, latr, distr, width*.
 

--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -180,6 +180,7 @@ Optional Arguments
     for a trough then you must use **+n** to temporarily flip the profile to positive.
     The threshold *z0* value is always given as >= 0; use **+z** to change it [0].
     Alternatively, use **+b** to determine the balance point and standard deviation of the profile.
+    Note that we round the exact results to the nearest distance nodes.
     We write 12 output columns per track with an identified center peak, with values
     *lonc, latc, distc, azimuthc, zc, lonl, latl, distl, lonr, latr, distr, width*.
 

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -97,9 +97,10 @@ struct GRDTRACK_CTRL {
 		double step;
 		char unit;
 	} E;
-	struct GRDTRACK_F {	/* -F[+n][+z<z0>] */
+	struct GRDTRACK_F {	/* -F[+b][+n][+z<z0>] */
 		bool active;
 		bool negative;
+		unsigned int mode;
 		double z0;
 	} F;
 	struct GRDTRACK_G {	/* -G<grdfile> */
@@ -164,7 +165,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s -G<grid1> -G<grid2> ... [<table>] [-A[f|m|p|r|R][+l]] [-C<length>/<ds>[/<spacing>][+a|v][+l|r]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-D<dfile>] [-E<line1>[,<line2>,...][+a<az>][+c][+d][+g][+i<step>][+l<length>][+n<np][+o<az>][+r<radius>]]\n\t[-F[+n][+z<z0>]] [-N] [%s] [-S[<method>][<modifiers>]] [-T<radius>>[+e|p]]\n\t[%s] [-Z] [%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s]\n\t[%s] [%s] %s] [%s] [%s]\n\n",
+	GMT_Message (API, GMT_TIME_NONE, "\t[-D<dfile>] [-E<line1>[,<line2>,...][+a<az>][+c][+d][+g][+i<step>][+l<length>][+n<np][+o<az>][+r<radius>]]\n\t[-F[+b][+n][+z<z0>]] [-N] [%s] [-S[<method>][<modifiers>]] [-T<radius>>[+e|p]]\n\t[%s] [-Z] [%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s]\n\t[%s] [%s] %s] [%s] [%s]\n\n",
 		GMT_Rgeo_OPT, GMT_V_OPT, GMT_b_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT, GMT_i_OPT, GMT_j_OPT, GMT_n_OPT, GMT_o_OPT, GMT_q_OPT, GMT_s_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -187,7 +188,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   1. <length>: The full-length of each cross profile.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Append distance unit u (%s); it also applies to <ds>, <spacing>.\n", GMT_LEN_UNITS_DISPLAY);
 	GMT_Message (API, GMT_TIME_NONE, "\t     Default unit is meter (geographic grids) or user unit (Cartesian grids).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   2. <dz>: The sampling interval along the cross-profiles, in units of u.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   2. <ds>: The sampling interval along the cross-profiles, in units of u.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   3. Optionally, append /<spacing> to set the spacing between cross-profiles [Default use input locations].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +a to alternate direction of cross-profiles [Default orients all the same way].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +l or +r to only use the left or right halves of the profiles [entire profile].\n");
@@ -215,6 +216,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-F Report center, left, and right point per cross-track; requires -C and a single input grid.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   We assume a positive center peak; append +n if dealing with a negative trough.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +z<z0> to change the detection level for left or right [0].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Alternatively, use +b to compute the balance point and standard devition of the profile instead.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Do NOT skip points outside the grid domain [Default only returns points inside domain].\n");
 	GMT_Option (API, "R,V");
 	GMT_Message (API, GMT_TIME_NONE, "\t-S In conjunction with -C, compute a single stacked profile from all profiles across each segment.\n");
@@ -356,6 +358,8 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDTRACK_CTRL *Ctrl, struct GM
 				break;
 			case 'F':
 				Ctrl->F.active = true;
+				if ((c = strstr (opt->arg, "+b")))	/* Gave +b */
+					Ctrl->F.mode = 1;
 				if ((c = strstr (opt->arg, "+z")))	/* Gave +z<z0> */
 					Ctrl->F.z0 = atof (&c[2]);
 				if ((c = strstr (opt->arg, "+n")))	/* Gave +n*/
@@ -973,9 +977,9 @@ int GMT_grdtrack (void *V_API, int mode, void *args) {
 		}
 		if (Ctrl->F.active) {	/* Find left, center, right point along the crosslines, with width */
 			bool do_headers = (Dout->n_tables > 1);
-			unsigned int col, tbl, seg, row;
+			unsigned int col, tbl, seg, row, n;
 			int kl, kc, kr;
-			double out[12], z, this_zc, this_zr, z_scl = (Ctrl->F.negative) ? -1 : +1;
+			double out[12], z, this_zc, this_zr, Sw, Swd, Swd2, z_scl = (Ctrl->F.negative) ? -1 : +1;
 			struct GMT_DATASEGMENT *S = NULL;
 
 			if ((error = GMT_Set_Columns (API, GMT_OUT, 12, GMT_COL_FIX_NO_TEXT)) != GMT_NOERROR) {
@@ -1003,6 +1007,10 @@ int GMT_grdtrack (void *V_API, int mode, void *args) {
 				for (seg = 0; seg < T->n_segments; seg++) {	/* For each segment to examine */
 					S = T->segment[seg];	/* Shorthand pointer */
 					z = -DBL_MAX;	/* I.e., not set */
+					if (Ctrl->F.mode) {
+						Sw = Swd = Swd2 = 0.0;
+						n = 0;
+					}
 					kr = kl = kc = GMT_NOTSET;	/* Not yet found */
 					for (row = 0; row < S->n_rows; row++) {	/* For each row across this segment */
 						if (gmt_M_is_dnan (T->segment[seg]->data[4][row])) continue;	/* Must skip any NaN entries in any profile */
@@ -1011,8 +1019,24 @@ int GMT_grdtrack (void *V_API, int mode, void *args) {
 						if (kl == GMT_NOTSET && this_zc >= Ctrl->F.z0) kl = row;		/* Found the first point on the left */
 						if (kr == GMT_NOTSET && this_zr >= Ctrl->F.z0) kr = S->n_rows-row-1;	/* Found the last point on the right */
 						if (this_zc > z) z = this_zc, kc = row;	/* Found a new maximum point */
+						if (Ctrl->F.mode) {	/* FInd weighted mean and std */
+							Sw   += this_zc;
+							Swd  += this_zc * T->segment[seg]->data[GMT_Z][row];
+							Swd2 += this_zc * T->segment[seg]->data[GMT_Z][row] * T->segment[seg]->data[GMT_Z][row];
+							n++;
+						}
 					}
-					if (kc == GMT_NOTSET) continue;	/* Nothing to print */
+					if (Ctrl->F.mode) {	/* Compute mean and std and find corresponding points */
+						double d, d0, s;
+						if (n == 0) continue;	/* Nothing to do */
+						d = Swd / Sw;
+						s = sqrt ((Sw * Swd2 - Swd*Swd) / (Sw*Sw*(n-1)/n));
+						d0 = T->segment[seg]->data[GMT_Z][0];	/* Left distance start value */
+						kc = irint ((d - d0) / Ctrl->C.ds);		/* Nearest point to the mean location */
+						kl = ((d - s) < d0) ? GMT_NOTSET : irint ((d - s - d0)/ Ctrl->C.ds);	/* Nearest point to 1-sigma left of center */
+						kr = ((d + s) > T->segment[seg]->data[GMT_Z][S->n_rows-1]) ? GMT_NOTSET : irint ((d + s - d0)/ Ctrl->C.ds);	/* Nearest point to 1-sigma right of center */
+					}
+					else if (kc == GMT_NOTSET) continue;	/* Nothing to print */
 					for (col = 0; col < 5; col++)	/* Copy over lon, lat, dist, azimuth, z */
 						out[col] = T->segment[seg]->data[col][kc];
 					if (kl == GMT_NOTSET)	/* Left start not detected, report NaN */


### PR DESCRIPTION
**Description of proposed changes**

The recently introduced **-F** option processes each cross-profile created via **-C** and determines the location of the center peak (or trough).  This PR adds a modifier **+b** to **-F** to compute the balance point instead: The weighted mean location, with profile heights as the weights.  We compute the one-sigma weighted standard deviation on that location and find the left/right point using that deviation.