### PR TITLE
Optimize images before making a release or deploying to GitHub

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -16,11 +16,14 @@ To build the GMT documentation you need to install the [Sphinx](http://www.sphin
 documentation builder. After configuring and building GMT, you can build GMT documentation with:
 
 ```
-cmake --build . --target docs_depends   # Generate images included in the documentation
-cmake --build . --target animation      # Generate animations included in the documentation [optional]
-cmake --build . --target docs_man       # UNIX manual pages
-cmake --build . --target docs_html      # HTML manual, tutorial, cookbook, and API reference
+cmake --build . --target docs_depends     # Generate images included in the documentation
+cmake --build . --target optimize_images  # Optimize PNG images for documentation [optional]
+cmake --build . --target animation        # Generate animations included in the documentation [optional]
+cmake --build . --target docs_man         # UNIX manual pages
+cmake --build . --target docs_html        # HTML manual, tutorial, cookbook, and API reference
 ```
+
+Note: [pngquant](https://pngquant.org/) is needed for optimizing images.
 
 ## Running tests
 

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -31,6 +31,12 @@ if [ ! -d cmake ]; then
 	exit 1
 fi
 
+# pngquant is need to optimize images
+if ! [ -x "$(command -v gmt)" ]; then
+	echo 'Error: pngquant is not found in your search PATH.' >&2
+	exit 1
+fi
+
 # 0. Make sure GMT_GSHHG_SOURCE and GMT_DCW_SOURCE are set in the environment
 if [ "X${GMT_GSHHG_SOURCE}" = "X" ]; then
 	echo "Need to setenv GMT_GSHHG_SOURCE to point to directory with GSHHG files"

--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -60,6 +60,7 @@ steps:
     set -x -e
     cd build
     cmake --build . --target docs_depends
+    cmake --build . --target optimize_images
     cmake --build . --target animation
     cmake --build . --target docs_html
     cmake --build . --target docs_man
@@ -119,10 +120,6 @@ steps:
     CODECOV_TOKEN: $(codecov.token)
   condition: and(eq(variables['TEST'], true), succeededOrFailed())
   displayName: Upload test coverage
-
-- bash: bash admin/image_optimize.sh build/doc/rst/html/_images/*.png
-  condition: eq(variables['DEPLOY_DOCS'], true)
-  displayName: Optimize images in documentations
 
 - bash: bash ci/deploy-gh-pages.sh
   displayName: Deploy documentations

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -16,6 +16,7 @@ steps:
 
 - bash: |
     set -x -e
+    brew install pngquant
     pip3 install --user sphinx
     echo "##vso[task.prependpath]$HOME/Library/Python/3.7/bin"
   displayName: Install dependencies for building documentation
@@ -61,6 +62,7 @@ steps:
     set -x -e
     cd build
     cmake --build . --target docs_depends
+    cmake --build . --target optimize_images
     cmake --build . --target docs_html
     cmake --build . --target docs_man
   displayName: Build documentations

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -51,6 +51,7 @@ steps:
 
 - bash: |
     set -x -e
+    choco install pngquant
     pip install --user sphinx
     echo "##vso[task.prependpath]C:\\Users\\VssAdministrator\\AppData\\Roaming\\Python\\Python36\\Scripts"
   displayName: Install dependencies for documentation
@@ -105,6 +106,7 @@ steps:
     set -x -e
     cd build
     cmake --build . --target docs_depends
+    cmake --build . --target optimize_images
     cmake --build . --target docs_html
     cmake --build . --target docs_man
   displayName: Build documentations

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -41,12 +41,21 @@ add_subdirectory (fig)
 add_subdirectory (scripts)
 add_subdirectory (examples)
 
-if (NOT WIN32)
-	# Do not install .bat files
-	set (_exclude_bat "*.bat")
-endif (NOT WIN32)
+# Optimize images for HTML documentation
+find_program (PNGQUANT pngquant)
+if (PNGQUANT)
+	add_custom_target (optimize_images
+		COMMAND ${PNGQUANT} --strip --force --ext .png ${RST_BINARY_DIR}/_images/*.png
+	)
+	add_dependencies (optimize_images docs_depends)
+	add_dependencies (gmt_release optimize_images)
+endif (PNGQUANT)
+
 
 # Install target for examples
+if (NOT WIN32)
+	set (_exclude_bat "*.bat")  # Do not install .bat files
+endif (NOT WIN32)
 install (DIRECTORY examples
 	DESTINATION ${GMT_DOCDIR}
 	COMPONENT Documentation


### PR DESCRIPTION
In this PR, I added a new optional cmake target "optimize_images", which compresses all PNG images used in the documentation. Currently, the compression can reduce the images from 33 Mb to 18 Mb.

"optimize_images" is also added as a dependency of "gmt_release". So, when we make release tarballs, the images in the `doc_release` directory are also compressed.

Note that, the target "optimize_images" needs "pngquant" installed.