### PR TITLE
New -B modifier +i for internal annotations

### DIFF
--- a/doc/rst/source/cookbook/options.rst
+++ b/doc/rst/source/cookbook/options.rst
@@ -286,7 +286,7 @@ tick, and gridline intervals, axes labels, and annotation units.
 
 The Frame settings are specified by
 
--  **-B**\ [*axes*][**+b**][**+g**\ *fill*][**+n**][**+o**\ *lon/lat*][**+t**\ *title*]
+-  **-B**\ [*axes*][**+b**][**+g**\ *fill*][**+i**\ [*val*]][**+n**][**+o**\ *lon/lat*][**+t**\ *title*]
 
 Here, the optional *axes* dictates which of the axes should be drawn
 and possibly annotated.  By default, all 4 map boundaries (or plot axes)
@@ -303,6 +303,10 @@ corner and the order goes counter-clockwise.  Append **+b** to draw the outline
 of the 3-D box defined by **-R**; this modifier is also needed to display
 gridlines in the x–z, y–z planes.  You may paint the
 map canvas by appending the **+g**\ *fill* modifier [Default is no fill].
+Use **+i** to annotate an internal meridian or parallel when the axis that normally
+would be drawn and annotated does not exist (e.g., azimuthal map with 360-degree range
+has no latitude axis, and a global Hammer map has no longitude axis);
+optionally append the parallel or meridian [0].
 If gridlines are specified via the Axes parameters (discussed below) then
 by default these are referenced to the North pole.  If, however, you wish
 to produce oblique gridlines about another pole you can append **+o**\ *lon/lat*

--- a/doc/rst/source/explain_-B_full.rst_
+++ b/doc/rst/source/explain_-B_full.rst_
@@ -3,7 +3,7 @@
 **-B**\ [**p**\|\ **s**]\ *parameters*
     Set map Frame and Axes parameters. The Frame parameters are specified by
 
-    **-B**\ [*axes*][**+b**][**+g**\ *fill*][**+n**][**+o**\ *lon/lat*][**+t**\ *title*]
+    **-B**\ [*axes*][**+b**][**+g**\ *fill*][**+i**\ [*val*]][**+n**][**+o**\ *lon/lat*][**+t**\ *title*]
 
     where *axes* selects which axes to plot. By default, all 4 map boundaries
     (or plot axes) are plotted (named **W**, **E**, **S**, **N**). To customize,
@@ -19,6 +19,9 @@
     cube defined by **-R**; this modifier is also needed to display gridlines in
     the x-z, y-z planes. Note that for 3-D views the title, if given, will be
     suppressed. You can paint the interior of the canvas with **+g**\ *fill*.
+    Use **+i** to annotate an internal meridian or parallel when the axis that normally
+    would be drawn and annotated does not exist (e.g., azimuthal map with 360-degree range
+    has no latitude axis, and a global Hammer map has no longitude axis); optionally append the parallel or meridian [0].
     Append **+n** to have no frame and annotations at all [Default is controlled by the codes].
     Optionally append **+o**\ *plon/plat* to draw oblique gridlines about
     specified pole [regular gridlines]. Ignored if gridlines are not

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6368,7 +6368,7 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 
 			gmt_message (GMT, "\t-B Specify both (1) basemap frame settings and (2) axes parameters.\n");
 			gmt_message (GMT, "\t   Frame settings are modified via an optional single invocation of\n");
-			gmt_message (GMT, "\t     -B[<axes>][+b][+g<fill>][+n][+o<lon>/<lat>][+t<title>]\n");
+			gmt_message (GMT, "\t     -B[<axes>][+b][+g<fill>][+i[<val>]][+n][+o<lon>/<lat>][+t<title>]\n");
 			gmt_message (GMT, "\t   Axes parameters are specified via one or more invocations of\n");
 			gmt_message (GMT, "\t     -B[p|s][x|y|z]<info>\n\n");
 			gmt_message (GMT, "\t   1. Frame settings control which axes to plot, frame fill, title, and type of gridlines:\n");
@@ -6381,6 +6381,7 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 			gmt_message (GMT, "\t     The optional +b will erect a 3-D frame box to outline the 3-D domain [no frame box]. The +b\n");
 			gmt_message (GMT, "\t     is also required for x-z or y-z gridlines to be plotted (if such gridlines are selected below).\n");
 			gmt_message (GMT, "\t     Append +g<fill> to paint the inside of the map region before further plotting [no fill].\n");
+			gmt_message (GMT, "\t     Append +i<val> to annotate along parallel or meridian <val> [0] when no such axes can be plotted.\n");
 			gmt_message (GMT, "\t     Append +n to have no frame and annotations whatsoever [Default is controlled by WESNZ/wesnz].\n");
 			gmt_message (GMT, "\t     Append +o<plon>/<plat> to draw oblique gridlines about this pole [regular gridlines].\n");
 			gmt_message (GMT, "\t     Note: the +o modifier is ignored unless gridlines are specified via the axes parameters (below).\n");

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -3853,6 +3853,7 @@ bool gmtinit_B_is_frame (struct GMT_CTRL *GMT, char *in) {
 	gmt_M_unused (GMT);
 	if (strstr (in, "+b")) return true;	/* Found a +b so likely frame */
 	if (strstr (in, "+g")) return true;	/* Found a +g so likely frame */
+	if (strstr (in, "+i")) return true;	/* Found a +i so likely frame */
 	if (strstr (in, "+n")) return true;	/* Found a +n so likely frame */
 	if (strstr (in, "+o")) return true;	/* Found a +o so likely frame */
 	if (strstr (in, "+t")) return true;	/* Found a +t so likely frame */
@@ -3887,7 +3888,7 @@ GMT_LOCAL int gmtinit_parse5_B_frame_setting (struct GMT_CTRL *GMT, char *in) {
 	/* OK, here we are pretty sure this is a frame -B statement */
 
 	strncpy (text, in, GMT_BUFSIZ-1);
-	gmt_handle5_plussign (GMT, text, "bgnot", 0);	/* Temporarily change double plus-signs to double ASCII 1 to avoid +<modifier> angst */
+	gmt_handle5_plussign (GMT, text, "bginot", 0);	/* Temporarily change double plus-signs to double ASCII 1 to avoid +<modifier> angst */
 	GMT->current.map.frame.header[0] = '\0';
 
 	if ((mod = strchr (text, '+'))) {	/* Find start of modifiers, if any */
@@ -3902,6 +3903,29 @@ GMT_LOCAL int gmtinit_parse5_B_frame_setting (struct GMT_CTRL *GMT, char *in) {
 						error++;
 					}
 					GMT->current.map.frame.paint = true;
+					break;
+				case 'i':	/* Turn on internal annotation for radiual or longitudinal axes when there is no other place to annotate */
+					GMT->current.map.frame.internal_annot = 1;	/* Longitude/angle */
+					if (GMT->current.proj.projection == GMT_POLAR)	/* Argument is an angle */
+						GMT->current.map.frame.internal_arg = (p[1]) ? atof (&p[1]) : GMT->common.R.wesn[XLO];
+					else if (gmt_M_is_azimuthal (GMT)) {	/* Argment is a longitude */
+						if (p[1])
+							error += gmt_verify_expectations (GMT, GMT_IS_LON, gmt_scanf (GMT, &p[1], GMT_IS_LON, &GMT->current.map.frame.internal_arg), &p[1]);
+						else
+							GMT->current.map.frame.internal_arg = GMT->common.R.wesn[XLO];
+					}
+					else if (gmt_M_is_misc (GMT) && gmt_M_pole_is_point (GMT) && gmt_M_180_range (GMT->common.R.wesn[YLO], GMT->common.R.wesn[YHI])) {	/* Giving a latitude */
+						GMT->current.map.frame.internal_annot = 2;	/* Latitude */
+						if (p[1])
+							error += gmt_verify_expectations (GMT, GMT_IS_LAT, gmt_scanf (GMT, &p[1], GMT_IS_LAT, &GMT->current.map.frame.internal_arg), &p[1]);
+						else
+							GMT->current.map.frame.internal_arg = 0.0;	/* Equator */
+					}
+					else {
+						GMT_Report (GMT->parent, GMT_MSG_ERROR,
+							"Option -B: Cannot specify internal annotation for this projection or region selection\n");
+						error++;
+					}
 					break;
 				case 'n':	/* Turn off frame entirely; this is also done in gmtinit_decode5_wesnz */
 					GMT->current.map.frame.no_frame = true;
@@ -4008,8 +4032,8 @@ GMT_LOCAL int gmtinit_parse5_B_option (struct GMT_CTRL *GMT, char *in) {
 	if ((error = gmtinit_parse5_B_frame_setting (GMT, in)) >= 0) return (error);	/* Parsed the -B frame settings separately */
 	error = 0;	/* Reset since otherwise it is -1 */
 
-	if (strstr (in, "+b") || strstr (in, "+g") || strstr (in, "+n") || strstr (in, "+o") || strstr (in, "+t")) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -B: Found frame setting modifiers (+b|g|n|o|p) mixed with axes settings!\n");
+	if (strstr (in, "+b") || strstr (in, "+g") || strstr (in, "+i") || strstr (in, "+n") || strstr (in, "+o") || strstr (in, "+o") || strstr (in, "+t")) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -B: Found frame setting modifiers (+b|g|i|n|o|p) mixed with axes settings!\n");
 		return (GMT_PARSE_ERROR);
 	}
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -3906,24 +3906,24 @@ GMT_LOCAL int gmtinit_parse5_B_frame_setting (struct GMT_CTRL *GMT, char *in) {
 					break;
 				case 'i':	/* Turn on internal annotation for radiual or longitudinal axes when there is no other place to annotate */
 					GMT->current.map.frame.internal_annot = 1;	/* Longitude/angle */
-					if (GMT->current.proj.projection == GMT_POLAR)	/* Argument is an angle */
+					if (GMT->current.proj.projection == GMT_POLAR)	/* Optional argument is an angle, not longitude, so atof will do */
 						GMT->current.map.frame.internal_arg = (p[1]) ? atof (&p[1]) : GMT->common.R.wesn[XLO];
-					else if (gmt_M_is_azimuthal (GMT)) {	/* Argment is a longitude */
-						if (p[1])
+					else if (gmt_M_is_azimuthal (GMT)) {	/* Optional argument is a longitude */
+						if (p[1])	/* Giving a specific meridian along which to annotate latitudes or radii */
 							error += gmt_verify_expectations (GMT, GMT_IS_LON, gmt_scanf (GMT, &p[1], GMT_IS_LON, &GMT->current.map.frame.internal_arg), &p[1]);
-						else
+						else	/* Default to west */
 							GMT->current.map.frame.internal_arg = GMT->common.R.wesn[XLO];
 					}
-					else if (gmt_M_is_misc (GMT) && gmt_M_pole_is_point (GMT) && gmt_M_180_range (GMT->common.R.wesn[YLO], GMT->common.R.wesn[YHI])) {	/* Giving a latitude */
-						GMT->current.map.frame.internal_annot = 2;	/* Latitude */
-						if (p[1])
+					else if (gmt_M_is_misc (GMT) && gmt_M_pole_is_point (GMT) && gmt_M_180_range (GMT->common.R.wesn[YLO], GMT->common.R.wesn[YHI])) {
+						GMT->current.map.frame.internal_annot = 2;	/* Want longitude annotations along a parallel */
+						if (p[1])	/* Giving a specific latitude */
 							error += gmt_verify_expectations (GMT, GMT_IS_LAT, gmt_scanf (GMT, &p[1], GMT_IS_LAT, &GMT->current.map.frame.internal_arg), &p[1]);
-						else
-							GMT->current.map.frame.internal_arg = 0.0;	/* Equator */
+						else	/* Default to Equator */
+							GMT->current.map.frame.internal_arg = 0.0;
 					}
 					else {
 						GMT_Report (GMT->parent, GMT_MSG_ERROR,
-							"Option -B: Cannot specify internal annotation for this projection or region selection\n");
+							"Option -B: Cannot specify internal annotation with +i for this projection and region selection\n");
 						error++;
 					}
 					break;

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -50,6 +50,7 @@ struct GMT_XINGS {
 
 EXTERN_MSC char *opt (struct GMTAPI_CTRL *API,char code);
 
+EXTERN_MSC int gmtlib_polar_prepare_label (struct GMT_CTRL *GMT, double angle, unsigned int side, double *line_angle, double *text_angle, unsigned int *justify);
 EXTERN_MSC bool gmtinit_B_is_frame (struct GMT_CTRL *GMT, char *in);
 EXTERN_MSC int64_t gmt_parse_index_range (struct GMT_CTRL *GMT, char *p, int64_t *start, int64_t *stop);
 EXTERN_MSC void gmtlib_handle_escape_text (char *text, char key, int way);

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -1947,9 +1947,9 @@ GMT_LOCAL void plot_consider_internal_annotations (struct GMT_CTRL *GMT, struct 
 			tval = val;	/* Here they are the same thing */
 		}
 
-		if (GMT->current.proj.north_pole && GMT->current.proj.projection_GMT != GMT_POLAR)
+		if (GMT->current.proj.north_pole && GMT->current.proj.projection_GMT != GMT_POLAR && doubleAlmostEqualZero (tval[0], s))
 			first = 1;
-		else
+		else if (!GMT->current.proj.north_pole && doubleAlmostEqualZero (tval[ny-1], n))
 			ny--;
 
 		plot_radial_annot_setup (GMT, GMT->current.map.frame.internal_arg, &justify, &text_angle, &line_angle, &dc, &ds);

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -1908,6 +1908,8 @@ GMT_LOCAL void plot_consider_internal_annotations (struct GMT_CTRL *GMT, struct 
 	if (GMT->current.map.frame.internal_annot == 0) return;	/* Not requested */
 
 	form = gmt_setfont (GMT, &GMT->current.setting.font_annot[GMT_PRIMARY]);
+	PSL_comment (PSL, "Map annotations (Internal)\n");
+	PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus signs */
 
 	if (GMT->current.map.frame.internal_annot == 1) {	/* Placement of latitude or radial annotations along selected meridian */
 		dy = gmtlib_get_map_interval (GMT, &GMT->current.map.frame.axis[GMT_Y].item[GMT_ANNOT_UPPER]);
@@ -2081,6 +2083,7 @@ GMT_LOCAL void plot_consider_internal_annotations (struct GMT_CTRL *GMT, struct 
 			gmt_M_free (GMT, label_c);
 		}
 	}
+	PSL_settextmode (PSL, PSL_TXTMODE_HYPHEN);	/* Back to leave as is */
 }
 
 GMT_LOCAL void plot_map_annotate (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double w, double e, double s, double n) {
@@ -2152,7 +2155,7 @@ GMT_LOCAL void plot_map_annotate (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, do
 	is_dual = (dual[GMT_X] | dual[GMT_Y]);
 	check_edges = (!GMT->common.R.oblique && (GMT->current.setting.map_frame_type & GMT_IS_INSIDE));
 
-	PSL_comment (PSL, "Map annotations\n");
+	PSL_comment (PSL, "Map annotations (external)\n");
 	PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus signs */
 
 	form = gmt_setfont (GMT, &GMT->current.setting.font_annot[GMT_PRIMARY]);

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -1867,6 +1867,15 @@ GMT_LOCAL void plot_label_trim (char *label, int stage) {
 	label[stage] = '\0';
 }
 
+GMT_LOCAL void plot_consider_internal_annotations (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double w, double e, double s, double n) {
+	if (GMT->current.map.frame.internal_annot == 0) return;	/* Not requested */
+
+	if (GMT->current.map.frame.internal_annot == 1) {	/* Placement of latitude or radial annotations along selected meridian */
+	}
+	else if (GMT->current.map.frame.internal_annot == 2) {	/* Placement of longitude annotations along selected parallel */
+	}
+}
+
 GMT_LOCAL void plot_map_annotate (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double w, double e, double s, double n) {
 	unsigned int i, k, nx = 0, ny = 0, last, form, remove[2] = {0,0}, trim, add;
 	bool do_minutes, do_seconds, done_Greenwich, done_Dateline, check_edges;
@@ -1900,6 +1909,8 @@ GMT_LOCAL void plot_map_annotate (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, do
 		PSL_plottext (PSL, 0.0, 0.0, -GMT->current.setting.font_title.size, GMT->current.map.frame.header, 0.0, PSL_BC, form);
 		GMT->current.map.frame.plotted_header = true;
 	}
+
+	plot_consider_internal_annotations (GMT, PSL, w, e, s, n);	/* Handle any special case of internal annotations */
 
 	if (GMT->current.proj.edge[S_SIDE] || GMT->current.proj.edge[N_SIDE]) {
 		dx[0] = gmtlib_get_map_interval (GMT, &GMT->current.map.frame.axis[GMT_X].item[GMT_ANNOT_UPPER]);

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -1949,7 +1949,7 @@ GMT_LOCAL void plot_consider_internal_annotations (struct GMT_CTRL *GMT, struct 
 
 		if (GMT->current.proj.north_pole && GMT->current.proj.projection_GMT != GMT_POLAR && doubleAlmostEqualZero (tval[0], s))
 			first = 1;
-		else if (!GMT->current.proj.north_pole && doubleAlmostEqualZero (tval[ny-1], n))
+		else if (!GMT->current.proj.north_pole && ny && doubleAlmostEqualZero (tval[ny-1], n))
 			ny--;
 
 		plot_radial_annot_setup (GMT, GMT->current.map.frame.internal_arg, &justify, &text_angle, &line_angle, &dc, &ds);

--- a/src/gmt_project.h
+++ b/src/gmt_project.h
@@ -511,12 +511,12 @@ struct GMT_PLOT_FRAME {		/* Various parameters for plotting of time axis boundar
 	bool primary;			/* true if current axis is primary, false if secondary */
 	bool set_both;			/* true if -B argument applies to both x and y axes */
 	bool obl_grid;			/* true if +o was given to draw oblique gridlines */
-	unsigned int internal_annot;	/* 1 or 2 if +i was given to draw internal annotations */
+	unsigned int internal_annot;	/* 1 (longitude) or 2 (latitude or radius) if +i was given to draw internal annotations */
 	unsigned int set_frame[2];	/* 1 if a -B<WESNframe> setting was given */
 	unsigned int horizontal;	/* 1 is S/N annotations should be parallel to axes, 2 if forced */
 	unsigned int side[5];		/* Which sides (0-3 in plane; 4 = z) to plot. 2 is annot/draw, 1 is draw, 0 is not */
 	unsigned int z_axis[4];		/* Which axes to use for the 3-D z-axis [auto] */
-	double internal_arg;		/* Internal annotation latitude or longitude location */
+	double internal_arg;		/* Internal annotation latitude or longitude location set via +i<val> */
 };
 
 #endif /* GMT_PROJECT_H */

--- a/src/gmt_project.h
+++ b/src/gmt_project.h
@@ -511,10 +511,12 @@ struct GMT_PLOT_FRAME {		/* Various parameters for plotting of time axis boundar
 	bool primary;			/* true if current axis is primary, false if secondary */
 	bool set_both;			/* true if -B argument applies to both x and y axes */
 	bool obl_grid;			/* true if +o was given to draw oblique gridlines */
+	unsigned int internal_annot;	/* 1 or 2 if +i was given to draw internal annotations */
 	unsigned int set_frame[2];	/* 1 if a -B<WESNframe> setting was given */
 	unsigned int horizontal;	/* 1 is S/N annotations should be parallel to axes, 2 if forced */
 	unsigned int side[5];		/* Which sides (0-3 in plane; 4 = z) to plot. 2 is annot/draw, 1 is draw, 0 is not */
 	unsigned int z_axis[4];		/* Which axes to use for the 3-D z-axis [auto] */
+	double internal_arg;		/* Internal annotation latitude or longitude location */
 };
 
 #endif /* GMT_PROJECT_H */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14037,7 +14037,7 @@ int gmtlib_get_coordinate_label (struct GMT_CTRL *GMT, char *string, struct GMT_
 	return (GMT_OK);
 }
 
-GMT_LOCAL int gmtlib_polar_prepare_label (struct GMT_CTRL *GMT, double angle, unsigned int side, double *line_angle, double *text_angle, unsigned int *justify) {
+int gmtlib_polar_prepare_label (struct GMT_CTRL *GMT, double angle, unsigned int side, double *line_angle, double *text_angle, unsigned int *justify) {
 	/* Special function to set justification and text angle for polar projections (r/theta, i.e. GMT_POLAR) */
 	/* Normally y-min (south) is at r = 0 and y-max (north) is on the perimeter, but +f reverses that */
 	/* Normally x-min (west) is the boundary with the region on the leeft, and x-max (east) on the right, but +a reverses that */
@@ -14046,21 +14046,19 @@ GMT_LOCAL int gmtlib_polar_prepare_label (struct GMT_CTRL *GMT, double angle, un
 		side = 2 - side;	/* Turns 2 to 0 and 0 to 2 */
 
 	switch (side) {
-		case 0:	/* We are annotating angles on the inner (donut) boundary */
+		case S_SIDE:	/* We are annotating angles on the inner (donut) boundary */
 			if (gmt_M_is_zero (angle) || ((angle+GMT_CONV8_LIMIT) >= 180.0 && (angle-GMT_CONV8_LIMIT) < 360.0)) *justify = 10, *text_angle = angle - 270.0;
 			else *justify = 2, *text_angle = angle - 90;
 			break;
-		case 1:
+		case E_SIDE:
 			if ((angle+GMT_CONV8_LIMIT) >= 90.0 && (angle-GMT_CONV8_LIMIT) < 270.0) *justify = 7, *text_angle = angle - 180;
 			else  *justify = 5, *text_angle = angle;
 			break;
-		case 2:	/* We are annotating angles on the outer boundary */
+		case N_SIDE:	/* We are annotating angles on the outer boundary */
 			if ((angle+GMT_CONV8_LIMIT) >= 0.0 && (angle-GMT_CONV8_LIMIT) <= 180.0) *justify = 2, *text_angle = angle - 90.0;
 			else *justify = 10, *text_angle = angle + 90.0;
 			break;
-		case 3:
-			//if (angle >= 0.0 && angle < 180.0) *justify = 5, *text_angle = angle;
-			//else  *justify = 7, *text_angle = 180.0 - angle;
+		case W_SIDE:
 			if ((angle+GMT_CONV8_LIMIT) >= 90.0 && (angle-GMT_CONV8_LIMIT) < 270.0) *justify = 7, *text_angle = angle - 180;
 			else  *justify = 5, *text_angle = angle;
 			break;

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -619,7 +619,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT
 			}
 			else if (Bframe) {
 				static char *Bx_items = "SsNnbt", *By_items = "WwEelr";
-				if ((c = gmt_first_modifier (GMT, Bframe->arg, "bgnot"))) {	/* Gave valid frame modifiers */
+				if ((c = gmt_first_modifier (GMT, Bframe->arg, "bginot"))) {	/* Gave valid frame modifiers */
 					Ctrl->S[GMT_X].extra = strdup (c);
 					c[0] = '\0';	/* Chop off for now */
 				}

--- a/test/psbasemap/azim_global.ps
+++ b/test/psbasemap/azim_global.ps
@@ -1,0 +1,5176 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.1.0_549fa7d-dirty_2020.03.04 [64-bit] Document from psxy
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Thu Mar  5 08:55:35 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1417 472 TM
+% PostScript produced by:
+%@GMT: gmt psxy -R0/5.51181/0/9.55394 -Jx1i -T -Xr1.1811i -Yr0.393701i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 5.51181000 0.00000000 9.55394000 0.000 5.512 0.000 9.554 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 8158 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -Rd -JH0/5.5118i -BWENS+tHammer+i30 -Bxa30fg30 -Bya30fg30 -Xa0i -Ya6.798i
+%@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+3018 6 M
+-185 11 D
+-183 16 D
+-162 18 D
+-160 23 D
+-148 25 D
+-118 23 D
+-197 43 D
+-43 11 D
+-147 39 D
+-142 43 D
+-113 38 D
+-103 37 D
+-130 51 D
+-110 48 D
+-112 54 D
+-101 53 D
+-96 55 D
+-12 8 D
+-13 7 D
+-84 54 D
+-68 47 D
+-65 49 D
+-71 57 D
+-62 55 D
+-4 5 D
+-45 43 D
+-8 9 D
+-9 8 D
+-41 44 D
+-52 63 D
+-41 54 D
+-38 56 D
+-33 55 D
+-25 47 D
+-30 66 D
+-24 67 D
+-19 67 D
+-9 39 D
+-11 77 D
+-4 68 D
+1 58 D
+5 58 D
+13 77 D
+18 68 D
+19 57 D
+19 48 D
+32 66 D
+31 56 D
+29 46 D
+39 55 D
+57 72 D
+39 44 D
+25 27 D
+9 8 D
+17 18 D
+36 34 D
+4 5 D
+72 63 D
+77 62 D
+106 76 D
+101 65 D
+13 7 D
+37 23 D
+13 7 D
+72 40 D
+101 52 D
+56 27 D
+116 52 D
+152 61 D
+103 38 D
+105 35 D
+141 43 D
+138 37 D
+105 26 D
+197 43 D
+184 33 D
+187 27 D
+143 17 D
+163 16 D
+165 11 D
+78 4 D
+S
+3031 25 M
+-128 15 D
+-117 17 D
+-177 30 D
+-129 26 D
+-126 28 D
+-155 39 D
+-127 36 D
+-153 49 D
+-154 56 D
+-112 45 D
+-75 32 D
+-91 42 D
+-113 57 D
+-43 23 D
+-11 7 D
+-59 33 D
+-105 65 D
+-79 54 D
+-59 43 D
+-66 52 D
+-79 68 D
+-65 62 D
+-73 80 D
+-58 72 D
+-35 49 D
+-27 42 D
+-39 66 D
+-41 84 D
+-29 77 D
+-22 77 D
+-15 77 D
+-8 78 D
+-1 78 D
+6 69 D
+7 52 D
+15 68 D
+21 69 D
+26 68 D
+32 67 D
+23 42 D
+35 58 D
+34 49 D
+43 57 D
+54 64 D
+52 56 D
+48 46 D
+42 39 D
+100 82 D
+69 51 D
+31 22 D
+31 21 D
+48 32 D
+84 51 D
+95 53 D
+61 32 D
+108 53 D
+114 51 D
+140 56 D
+22 8 D
+118 42 D
+137 44 D
+119 34 D
+121 32 D
+125 29 D
+85 19 D
+147 28 D
+160 26 D
+172 23 D
+46 5 D
+S
+3062 41 M
+-120 25 D
+-109 25 D
+-136 35 D
+-117 33 D
+-134 43 D
+-82 29 D
+-92 35 D
+-96 39 D
+-117 52 D
+-88 43 D
+-89 47 D
+-76 43 D
+-72 43 D
+-30 19 D
+-95 65 D
+-89 67 D
+-58 48 D
+-63 56 D
+-37 35 D
+-69 72 D
+-44 51 D
+-13 15 D
+-11 15 D
+-18 22 D
+-32 45 D
+-31 45 D
+-36 61 D
+-33 61 D
+-31 70 D
+-26 70 D
+-16 55 D
+-15 63 D
+-9 55 D
+-7 63 D
+-2 56 D
+1 63 D
+5 55 D
+9 63 D
+12 56 D
+12 47 D
+30 86 D
+26 62 D
+35 69 D
+9 15 D
+41 68 D
+36 53 D
+34 45 D
+12 14 D
+5 8 D
+25 29 D
+32 37 D
+76 79 D
+69 63 D
+48 42 D
+26 20 D
+79 61 D
+65 46 D
+39 25 D
+29 20 D
+93 56 D
+143 78 D
+35 17 D
+76 37 D
+92 41 D
+115 47 D
+134 49 D
+118 39 D
+115 35 D
+173 46 D
+140 32 D
+104 21 D
+S
+3108 55 M
+-133 43 D
+-133 49 D
+-29 12 D
+-74 31 D
+-142 65 D
+-103 53 D
+-88 50 D
+-65 40 D
+-89 58 D
+-67 48 D
+-57 43 D
+-15 13 D
+-16 12 D
+-80 70 D
+-69 65 D
+-25 27 D
+-7 6 D
+-43 47 D
+-57 68 D
+-46 62 D
+-39 56 D
+-43 70 D
+-39 72 D
+-33 71 D
+-29 73 D
+-19 59 D
+-15 51 D
+-13 59 D
+-9 51 D
+-10 82 D
+-3 59 D
+-1 52 D
+6 96 D
+14 97 D
+13 59 D
+13 51 D
+32 95 D
+40 94 D
+33 64 D
+45 78 D
+37 56 D
+50 70 D
+11 13 D
+22 28 D
+58 67 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+97 90 D
+60 51 D
+16 12 D
+15 13 D
+73 55 D
+69 48 D
+81 52 D
+19 11 D
+96 56 D
+92 48 D
+95 46 D
+100 45 D
+93 37 D
+97 36 D
+112 38 D
+45 14 D
+S
+3168 65 M
+-71 38 D
+-35 19 D
+-123 75 D
+-69 47 D
+-93 71 D
+-35 28 D
+-65 57 D
+-56 53 D
+-24 23 D
+-40 42 D
+-16 19 D
+-28 30 D
+-71 88 D
+-19 25 D
+-53 77 D
+-53 85 D
+-43 80 D
+-29 61 D
+-41 95 D
+-29 83 D
+-25 83 D
+-21 91 D
+-14 78 D
+-11 85 D
+-6 92 D
+-1 113 D
+6 92 D
+9 78 D
+11 71 D
+17 77 D
+20 77 D
+29 90 D
+21 55 D
+47 108 D
+31 61 D
+37 66 D
+36 59 D
+13 19 D
+49 71 D
+49 63 D
+52 62 D
+56 61 D
+35 36 D
+49 46 D
+45 41 D
+54 45 D
+63 49 D
+67 49 D
+78 51 D
+108 65 D
+89 47 D
+S
+3235 72 M
+-45 50 D
+-17 21 D
+-38 47 D
+-48 65 D
+-11 17 D
+-47 73 D
+-43 75 D
+-34 65 D
+-32 66 D
+-47 111 D
+-34 95 D
+-37 117 D
+-29 111 D
+-23 107 D
+-22 129 D
+-12 88 D
+-11 117 D
+-6 110 D
+-2 90 D
+1 131 D
+7 124 D
+10 103 D
+13 103 D
+18 108 D
+18 87 D
+24 99 D
+26 92 D
+18 58 D
+34 95 D
+25 62 D
+35 80 D
+47 96 D
+53 93 D
+39 62 D
+19 27 D
+11 17 D
+56 75 D
+52 62 D
+32 35 D
+S
+3307 74 M
+0 3159 D
+S
+3379 72 M
+50 56 D
+50 62 D
+48 65 D
+11 17 D
+47 73 D
+40 69 D
+34 65 D
+38 78 D
+44 105 D
+43 121 D
+30 97 D
+27 105 D
+19 87 D
+22 121 D
+17 123 D
+11 124 D
+6 117 D
+2 110 D
+-3 118 D
+-9 131 D
+-10 96 D
+-17 122 D
+-23 121 D
+-20 87 D
+-19 72 D
+-31 104 D
+-33 95 D
+-35 88 D
+-30 67 D
+-53 108 D
+-7 11 D
+-29 53 D
+-50 79 D
+-19 27 D
+-11 17 D
+-60 80 D
+-39 47 D
+-41 45 D
+S
+3447 65 M
+114 62 D
+122 75 D
+15 11 D
+46 31 D
+51 38 D
+77 61 D
+59 51 D
+56 53 D
+36 35 D
+67 73 D
+47 56 D
+35 44 D
+19 25 D
+9 13 D
+40 58 D
+37 58 D
+24 40 D
+39 73 D
+45 95 D
+30 75 D
+26 76 D
+25 83 D
+21 91 D
+17 106 D
+8 71 D
+5 92 D
+1 50 D
+-3 85 D
+-6 71 D
+-13 98 D
+-15 78 D
+-23 91 D
+-28 90 D
+-31 82 D
+-26 61 D
+-36 75 D
+-48 86 D
+-45 72 D
+-39 58 D
+-58 76 D
+-46 56 D
+-33 36 D
+-11 13 D
+-58 60 D
+-68 64 D
+-80 68 D
+-70 55 D
+-75 53 D
+-55 36 D
+-116 70 D
+-88 47 D
+S
+3506 55 M
+77 24 D
+117 41 D
+89 34 D
+98 41 D
+130 60 D
+103 53 D
+88 50 D
+65 40 D
+36 23 D
+62 41 D
+59 42 D
+64 50 D
+23 18 D
+37 32 D
+29 25 D
+42 39 D
+41 39 D
+38 40 D
+6 7 D
+7 6 D
+59 68 D
+64 82 D
+57 84 D
+38 63 D
+7 15 D
+19 35 D
+31 65 D
+18 43 D
+25 66 D
+24 81 D
+17 73 D
+13 81 D
+6 75 D
+2 66 D
+-3 82 D
+-9 81 D
+-14 74 D
+-16 66 D
+-25 81 D
+-25 65 D
+-33 72 D
+-22 43 D
+-15 29 D
+-47 77 D
+-53 77 D
+-21 28 D
+-11 13 D
+-33 41 D
+-53 61 D
+-7 6 D
+-31 34 D
+-7 6 D
+-6 7 D
+-68 65 D
+-29 25 D
+-37 32 D
+-62 50 D
+-65 49 D
+-69 48 D
+-109 69 D
+-87 50 D
+-91 48 D
+-107 51 D
+-89 40 D
+-93 37 D
+-96 36 D
+-113 38 D
+-45 14 D
+S
+3552 41 M
+120 25 D
+109 25 D
+144 37 D
+109 31 D
+134 43 D
+129 46 D
+110 44 D
+75 32 D
+103 47 D
+109 55 D
+103 57 D
+113 69 D
+29 20 D
+66 45 D
+98 74 D
+65 55 D
+62 56 D
+22 21 D
+69 72 D
+32 37 D
+25 29 D
+29 37 D
+53 75 D
+42 68 D
+37 69 D
+31 70 D
+26 70 D
+16 55 D
+17 71 D
+10 63 D
+6 71 D
+1 47 D
+-3 72 D
+-10 79 D
+-15 71 D
+-12 47 D
+-21 62 D
+-21 55 D
+-37 77 D
+-38 68 D
+-44 69 D
+-50 67 D
+-29 37 D
+-51 58 D
+-70 72 D
+-69 63 D
+-48 42 D
+-17 13 D
+-88 68 D
+-74 52 D
+-30 19 D
+-29 20 D
+-103 62 D
+-133 72 D
+-29 14 D
+-82 40 D
+-73 33 D
+-134 55 D
+-86 32 D
+-89 31 D
+-105 34 D
+-109 32 D
+-158 41 D
+-109 26 D
+-128 26 D
+S
+3584 25 M
+127 15 D
+117 17 D
+159 27 D
+130 25 D
+160 36 D
+138 35 D
+127 36 D
+153 49 D
+154 56 D
+92 36 D
+115 50 D
+72 33 D
+25 13 D
+87 44 D
+101 56 D
+91 55 D
+43 28 D
+36 25 D
+11 7 D
+75 54 D
+84 67 D
+77 69 D
+48 46 D
+59 64 D
+54 64 D
+53 73 D
+22 33 D
+21 34 D
+32 58 D
+21 42 D
+31 76 D
+22 69 D
+17 68 D
+10 69 D
+5 52 D
+1 78 D
+-6 69 D
+-7 52 D
+-15 68 D
+-21 69 D
+-19 51 D
+-26 59 D
+-36 67 D
+-19 33 D
+-38 58 D
+-61 81 D
+-55 64 D
+-45 48 D
+-65 62 D
+-43 38 D
+-36 30 D
+-75 59 D
+-70 51 D
+-16 10 D
+-42 29 D
+-89 55 D
+-93 53 D
+-80 42 D
+-95 47 D
+-127 57 D
+-119 48 D
+-43 16 D
+-118 42 D
+-137 44 D
+-119 34 D
+-121 32 D
+-176 41 D
+-181 35 D
+-186 30 D
+-155 20 D
+-36 4 D
+S
+3597 6 M
+184 11 D
+183 16 D
+162 18 D
+160 23 D
+148 25 D
+119 23 D
+196 43 D
+173 45 D
+101 30 D
+107 34 D
+65 22 D
+118 43 D
+114 45 D
+37 16 D
+116 52 D
+70 34 D
+87 46 D
+84 47 D
+80 49 D
+100 66 D
+82 60 D
+76 62 D
+62 55 D
+4 5 D
+19 17 D
+8 9 D
+18 17 D
+8 9 D
+9 8 D
+49 53 D
+37 45 D
+29 36 D
+20 27 D
+43 65 D
+37 65 D
+15 28 D
+30 66 D
+24 67 D
+22 77 D
+11 58 D
+8 68 D
+2 67 D
+-3 68 D
+-7 58 D
+-11 58 D
+-16 58 D
+-19 57 D
+-23 57 D
+-28 57 D
+-31 56 D
+-35 55 D
+-26 37 D
+-27 36 D
+-37 45 D
+-47 53 D
+-17 18 D
+-9 8 D
+-17 18 D
+-9 8 D
+-17 18 D
+-10 8 D
+-4 5 D
+-52 46 D
+-65 54 D
+-48 37 D
+-90 64 D
+-101 65 D
+-50 30 D
+-13 7 D
+-71 40 D
+-102 52 D
+-78 37 D
+-94 42 D
+-113 46 D
+-141 53 D
+-106 35 D
+-141 43 D
+-129 35 D
+-105 26 D
+-169 37 D
+-101 20 D
+-166 28 D
+-141 20 D
+-143 17 D
+-163 16 D
+-165 11 D
+-77 4 D
+S
+3307 0 M
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-193 5 D
+-24 1 D
+S
+3307 0 M
+-166 45 D
+-33 10 D
+S
+3307 0 M
+0 74 D
+S
+3307 0 M
+167 45 D
+32 10 D
+S
+3307 0 M
+137 1 D
+153 5 D
+S
+3018 6 M
+1 5 D
+6 9 D
+4 3 D
+1 2 D
+5 3 D
+18 10 D
+28 10 D
+42 10 D
+22 4 D
+38 5 D
+43 4 D
+40 2 D
+76 1 D
+67 -4 D
+57 -7 D
+45 -9 D
+34 -10 D
+24 -10 D
+16 -10 D
+6 -7 D
+2 -1 D
+4 -10 D
+S
+3018 3301 M
+136 4 D
+145 2 D
+8 0 D
+S
+3108 3252 M
+143 41 D
+56 14 D
+S
+3307 3233 M
+0 74 D
+S
+3506 3252 M
+-142 41 D
+-57 14 D
+S
+3597 3301 M
+-8 0 D
+-129 4 D
+-137 2 D
+-8 0 D
+-8 0 D
+S
+3018 3301 M
+1 -5 D
+6 -9 D
+4 -3 D
+1 -2 D
+23 -13 D
+39 -13 D
+41 -9 D
+50 -7 D
+44 -4 D
+41 -2 D
+72 -1 D
+69 4 D
+63 8 D
+46 10 D
+24 7 D
+27 11 D
+16 10 D
+6 7 D
+2 1 D
+4 10 D
+S
+1648 223 M
+8 6 D
+2 3 D
+48 32 D
+40 21 D
+53 23 D
+73 26 D
+50 15 D
+81 21 D
+82 18 D
+80 15 D
+131 21 D
+103 14 D
+151 16 D
+180 14 D
+187 10 D
+150 5 D
+176 3 D
+240 -1 D
+199 -6 D
+186 -10 D
+159 -12 D
+160 -16 D
+131 -17 D
+131 -21 D
+68 -12 D
+116 -26 D
+79 -22 D
+44 -14 D
+51 -18 D
+54 -23 D
+50 -26 D
+45 -30 D
+10 -9 D
+S
+440 830 M
+115 30 D
+142 30 D
+151 26 D
+152 22 D
+219 26 D
+319 29 D
+269 18 D
+231 12 D
+273 11 D
+279 8 D
+270 5 D
+285 3 D
+510 -1 D
+345 -6 D
+279 -8 D
+273 -11 D
+198 -10 D
+237 -15 D
+229 -18 D
+220 -21 D
+217 -27 D
+177 -27 D
+130 -25 D
+123 -27 D
+91 -24 D
+S
+0 1654 M
+6614 0 D
+S
+440 2478 M
+52 -15 D
+112 -27 D
+110 -22 D
+116 -20 D
+141 -21 D
+177 -22 D
+303 -30 D
+277 -20 D
+287 -16 D
+296 -12 D
+242 -7 D
+307 -6 D
+310 -3 D
+472 1 D
+394 7 D
+327 10 D
+271 12 D
+230 13 D
+190 13 D
+194 16 D
+248 25 D
+186 24 D
+139 22 D
+131 24 D
+99 22 D
+101 25 D
+22 7 D
+S
+1648 3084 M
+24 -19 D
+41 -26 D
+11 -5 D
+18 -10 D
+52 -23 D
+78 -28 D
+87 -25 D
+102 -24 D
+104 -20 D
+131 -21 D
+103 -14 D
+173 -18 D
+189 -14 D
+179 -9 D
+175 -5 D
+152 -2 D
+216 1 D
+222 7 D
+179 10 D
+187 15 D
+165 18 D
+162 23 D
+113 20 D
+88 19 D
+93 24 D
+64 20 D
+51 18 D
+54 23 D
+33 17 D
+30 17 D
+29 20 D
+13 11 D
+S
+8 W
+N 4970 224 M 50 0 D S
+N 1644 224 M -50 0 D S
+N 4970 224 M 50 0 D S
+N 1644 224 M -50 0 D S
+N 6175 831 M 50 0 D S
+N 439 831 M -50 -1 D S
+N 6175 831 M 50 -1 D S
+N 439 831 M -50 0 D S
+N 6614 1654 M 50 0 D S
+N 0 1654 M -50 0 D S
+N 6614 1654 M 50 0 D S
+N 0 1654 M -50 0 D S
+N 6175 2476 M 50 0 D S
+N 439 2476 M -50 1 D S
+N 6175 2476 M 50 1 D S
+N 439 2476 M -50 0 D S
+N 4970 3083 M 50 0 D S
+N 1644 3083 M -50 0 D S
+N 4970 3083 M 50 0 D S
+N 1644 3083 M -50 0 D S
+N 4171 57 M 25 0 D S
+N 2443 57 M -25 0 D S
+N 4171 57 M 25 0 D S
+N 2443 57 M -25 0 D S
+N 4970 224 M 25 0 D S
+N 1644 224 M -25 0 D S
+N 4970 224 M 25 0 D S
+N 1644 224 M -25 0 D S
+N 5653 488 M 25 0 D S
+N 961 488 M -25 0 D S
+N 5653 488 M 25 0 D S
+N 961 488 M -25 0 D S
+N 6175 831 M 25 0 D S
+N 439 831 M -25 0 D S
+N 6175 831 M 25 0 D S
+N 439 831 M -25 0 D S
+N 6503 1228 M 25 0 D S
+N 111 1228 M -25 0 D S
+N 6503 1228 M 25 0 D S
+N 111 1228 M -25 0 D S
+N 6614 1654 M 25 0 D S
+N 0 1654 M -25 0 D S
+N 6614 1654 M 25 0 D S
+N 0 1654 M -25 0 D S
+N 6503 2079 M 25 0 D S
+N 111 2079 M -25 0 D S
+N 6503 2079 M 25 0 D S
+N 111 2079 M -25 0 D S
+N 6175 2476 M 25 0 D S
+N 439 2476 M -25 1 D S
+N 6175 2476 M 25 1 D S
+N 439 2476 M -25 0 D S
+N 5653 2819 M 25 0 D S
+N 961 2819 M -25 0 D S
+N 5653 2819 M 25 0 D S
+N 961 2819 M -25 0 D S
+N 4970 3083 M 25 0 D S
+N 1644 3083 M -25 0 D S
+N 4970 3083 M 25 0 D S
+N 1644 3083 M -25 0 D S
+N 4171 3250 M 25 0 D S
+N 2443 3250 M -25 0 D S
+N 4171 3250 M 25 0 D S
+N 2443 3250 M -25 0 D S
+25 W
+3307 0 M
+0 0 D
+P
+137 1 D
+215 8 D
+185 13 D
+145 13 D
+181 22 D
+159 24 D
+121 21 D
+118 23 D
+126 27 D
+80 19 D
+147 39 D
+135 40 D
+139 46 D
+118 43 D
+100 39 D
+44 19 D
+131 59 D
+83 41 D
+48 25 D
+85 47 D
+31 19 D
+13 7 D
+12 8 D
+13 7 D
+84 54 D
+101 72 D
+58 45 D
+70 58 D
+4 5 D
+15 12 D
+4 5 D
+10 8 D
+4 5 D
+45 43 D
+8 9 D
+9 8 D
+57 62 D
+51 63 D
+47 64 D
+24 37 D
+11 19 D
+32 56 D
+9 19 D
+22 47 D
+27 67 D
+23 77 D
+11 48 D
+10 68 D
+4 49 D
+1 68 D
+-5 68 D
+-7 48 D
+-7 39 D
+-18 68 D
+-19 57 D
+-28 67 D
+-33 66 D
+-22 37 D
+-35 56 D
+-47 64 D
+-36 45 D
+-55 62 D
+-52 53 D
+-36 34 D
+-5 4 D
+-4 5 D
+-15 12 D
+-4 5 D
+-86 71 D
+-53 40 D
+-16 13 D
+-28 20 D
+-41 27 D
+-65 43 D
+-30 19 D
+-13 7 D
+-12 8 D
+-13 7 D
+-84 48 D
+-108 56 D
+-70 34 D
+-87 39 D
+-105 44 D
+-125 48 D
+-137 47 D
+-150 46 D
+-128 35 D
+-105 26 D
+-125 29 D
+-174 34 D
+-139 23 D
+-132 19 D
+-123 15 D
+-87 10 D
+-164 14 D
+-195 11 D
+-127 4 D
+-147 2 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 -1 D
+-10 0 D
+-10 0 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-9 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-9 -1 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-9 -1 D
+-9 -1 D
+-10 -2 D
+-9 -1 D
+-10 -1 D
+-9 -2 D
+-9 -1 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-9 -1 D
+-9 -1 D
+-10 -2 D
+-9 -1 D
+-9 -2 D
+-10 -1 D
+-9 -2 D
+-9 -2 D
+-9 -1 D
+-10 -2 D
+-9 -1 D
+-9 -2 D
+-10 -1 D
+-9 -2 D
+-9 -2 D
+-9 -1 D
+-9 -2 D
+-10 -2 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -1 D
+-10 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-8 -2 D
+-9 -3 D
+-9 -2 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-9 -3 D
+-8 -2 D
+-9 -2 D
+-8 -3 D
+-9 -2 D
+-9 -2 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-9 -2 D
+-8 -2 D
+-9 -3 D
+-8 -2 D
+-9 -3 D
+-8 -2 D
+-9 -3 D
+-8 -2 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-8 -2 D
+-9 -3 D
+-8 -2 D
+-8 -3 D
+-9 -3 D
+-8 -2 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-9 -3 D
+-8 -2 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-15 -7 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-8 -3 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-7 -3 D
+-14 -7 D
+-13 -7 D
+-14 -7 D
+-14 -7 D
+-13 -7 D
+-13 -7 D
+-14 -7 D
+-13 -7 D
+-13 -7 D
+-13 -8 D
+-13 -7 D
+-13 -7 D
+-13 -8 D
+-13 -7 D
+-12 -8 D
+-13 -7 D
+-12 -8 D
+-13 -7 D
+-18 -12 D
+-12 -7 D
+-18 -12 D
+-12 -7 D
+-18 -12 D
+-17 -12 D
+-17 -12 D
+-12 -8 D
+-17 -11 D
+-22 -16 D
+-22 -17 D
+-21 -16 D
+-21 -16 D
+-26 -21 D
+-30 -25 D
+-29 -25 D
+-47 -43 D
+-53 -52 D
+-57 -62 D
+-51 -63 D
+-40 -55 D
+-31 -46 D
+-42 -75 D
+-15 -28 D
+-33 -76 D
+-26 -77 D
+-12 -48 D
+-12 -58 D
+-8 -68 D
+-2 -68 D
+3 -68 D
+9 -68 D
+10 -49 D
+7 -29 D
+17 -57 D
+22 -58 D
+25 -57 D
+46 -84 D
+29 -46 D
+46 -65 D
+43 -54 D
+55 -62 D
+17 -18 D
+9 -8 D
+26 -27 D
+55 -51 D
+44 -38 D
+82 -66 D
+124 -88 D
+79 -50 D
+88 -52 D
+93 -50 D
+111 -55 D
+124 -55 D
+137 -55 D
+103 -38 D
+138 -46 D
+177 -52 D
+148 -38 D
+125 -29 D
+154 -31 D
+157 -27 D
+122 -18 D
+133 -17 D
+77 -9 D
+193 -17 D
+175 -10 D
+186 -6 D
+118 -1 D
+P S
+/PSL_H_y 333 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+117 F0
+(100°) sh add def
+3307 3307 PSL_H_y add M
+200 F0
+(Hammer) bc Z
+464 2521 M 117 F0
+V -15.9 R (­180°) bl Z U
+833 2439 M V -9.42 R (­150°) bl Z U
+1265 2381 M V -5.88 R (­120°) bl Z U
+1744 2340 M V -3.69 R (­90°) bl Z U
+2258 2313 M V -2.18 R (­60°) bl Z U
+2794 2297 M V -1.01 R (­30°) bl Z U
+3342 2292 M V 0.0114 R (0°) bl Z U
+3891 2296 M V 1.04 R (30°) bl Z U
+4427 2310 M V 2.21 R (60°) bl Z U
+4941 2335 M V 3.73 R (90°) bl Z U
+5420 2373 M V 5.94 R (120°) bl Z U
+5851 2427 M V 9.52 R (150°) bl Z U
+1548 223 M V -0.0367 R (-60°) mr Z U
+5066 223 M V 0.0367 R (-60°) ml Z U
+340 830 M V -0.0211 R (-30°) mr Z U
+6274 830 M V 0.0211 R (-30°) ml Z U
+-100 1654 M (0°) mr Z
+6714 1654 M (0°) ml Z
+340 2477 M V 0.0211 R (30°) mr Z U
+6274 2477 M V -0.0211 R (30°) ml Z U
+1548 3084 M V 0.0367 R (60°) mr Z U
+5066 3084 M V -0.0367 R (60°) ml Z U
+%%EndObject
+0 -8158 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 4079 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -Rg -JW0/5.5118i -BWENS+tMollweide+i -Bxa30fg30 -Bya30fg30 -Xa0i -Ya3.399i
+%@PROJ: moll -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +proj=moll +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+2621 36 M
+-152 18 D
+-205 30 D
+-206 38 D
+-146 32 D
+-183 46 D
+-151 44 D
+-109 35 D
+-103 36 D
+-91 34 D
+-93 38 D
+-149 66 D
+-45 21 D
+-121 63 D
+-29 16 D
+-11 7 D
+-77 45 D
+-84 53 D
+-68 47 D
+-82 62 D
+-51 41 D
+-72 63 D
+-65 64 D
+-40 43 D
+-61 73 D
+-43 59 D
+-39 59 D
+-34 59 D
+-36 75 D
+-24 60 D
+-21 68 D
+-16 69 D
+-10 68 D
+-4 68 D
+1 61 D
+5 54 D
+9 60 D
+10 46 D
+17 60 D
+25 68 D
+23 53 D
+12 22 D
+11 23 D
+39 66 D
+29 45 D
+49 66 D
+42 51 D
+53 57 D
+42 43 D
+85 77 D
+86 70 D
+55 41 D
+78 53 D
+63 40 D
+59 36 D
+57 32 D
+29 16 D
+84 44 D
+83 40 D
+94 43 D
+113 47 D
+30 11 D
+138 51 D
+114 38 D
+175 52 D
+152 39 D
+132 30 D
+141 29 D
+190 33 D
+179 25 D
+117 13 D
+S
+2735 36 M
+-132 19 D
+-170 30 D
+-162 36 D
+-147 39 D
+-81 24 D
+-115 38 D
+-94 34 D
+-48 19 D
+-74 30 D
+-83 37 D
+-96 46 D
+-124 66 D
+-31 19 D
+-92 56 D
+-85 58 D
+-63 46 D
+-50 40 D
+-33 27 D
+-61 55 D
+-29 27 D
+-62 63 D
+-44 49 D
+-41 50 D
+-28 36 D
+-51 73 D
+-27 44 D
+-41 74 D
+-31 67 D
+-19 44 D
+-23 68 D
+-21 76 D
+-14 75 D
+-9 76 D
+-3 77 D
+3 76 D
+11 91 D
+14 68 D
+14 53 D
+23 68 D
+17 45 D
+42 89 D
+28 52 D
+46 73 D
+46 65 D
+40 50 D
+55 64 D
+47 49 D
+50 49 D
+45 41 D
+39 33 D
+50 41 D
+107 78 D
+68 45 D
+92 56 D
+43 25 D
+131 69 D
+131 60 D
+127 52 D
+115 42 D
+131 42 D
+108 31 D
+79 20 D
+101 24 D
+140 29 D
+144 24 D
+97 13 D
+S
+2850 36 M
+-106 19 D
+-136 30 D
+-130 36 D
+-77 25 D
+-74 26 D
+-93 37 D
+-60 26 D
+-73 34 D
+-96 50 D
+-70 40 D
+-84 53 D
+-62 42 D
+-99 75 D
+-97 84 D
+-35 33 D
+-13 14 D
+-7 6 D
+-19 21 D
+-7 6 D
+-49 55 D
+-47 55 D
+-68 91 D
+-33 50 D
+-38 65 D
+-32 58 D
+-34 74 D
+-18 44 D
+-20 53 D
+-23 74 D
+-21 83 D
+-13 76 D
+-10 84 D
+-4 99 D
+4 98 D
+13 107 D
+17 83 D
+27 98 D
+27 74 D
+8 22 D
+26 60 D
+25 51 D
+44 80 D
+27 43 D
+43 64 D
+59 77 D
+65 76 D
+25 27 D
+7 6 D
+19 21 D
+14 13 D
+6 7 D
+49 46 D
+83 71 D
+99 75 D
+108 72 D
+88 52 D
+94 50 D
+101 48 D
+115 48 D
+112 40 D
+57 18 D
+81 24 D
+112 29 D
+115 24 D
+78 13 D
+S
+2964 36 M
+-79 19 D
+-53 15 D
+-56 17 D
+-46 17 D
+-66 26 D
+-92 42 D
+-101 55 D
+-44 26 D
+-89 60 D
+-67 52 D
+-83 71 D
+-20 18 D
+-12 13 D
+-19 18 D
+-6 7 D
+-19 18 D
+-18 19 D
+-17 20 D
+-23 25 D
+-48 59 D
+-26 33 D
+-52 75 D
+-13 21 D
+-9 13 D
+-57 98 D
+-15 28 D
+-37 79 D
+-31 73 D
+-29 81 D
+-24 81 D
+-21 82 D
+-18 98 D
+-10 69 D
+-7 83 D
+-3 76 D
+1 107 D
+5 68 D
+9 83 D
+14 84 D
+18 82 D
+22 82 D
+32 96 D
+35 87 D
+30 65 D
+22 43 D
+55 98 D
+45 69 D
+43 60 D
+47 60 D
+51 58 D
+35 38 D
+13 12 D
+18 19 D
+13 12 D
+6 7 D
+75 66 D
+57 46 D
+54 40 D
+48 33 D
+77 47 D
+103 55 D
+82 37 D
+77 30 D
+78 27 D
+46 13 D
+84 21 D
+15 3 D
+S
+3078 36 M
+-48 17 D
+-77 34 D
+-75 43 D
+-74 52 D
+-60 50 D
+-51 48 D
+-5 6 D
+-6 5 D
+-15 17 D
+-6 5 D
+-45 52 D
+-28 35 D
+-40 54 D
+-57 88 D
+-12 19 D
+-50 92 D
+-38 81 D
+-35 83 D
+-33 92 D
+-25 79 D
+-31 116 D
+-20 96 D
+-14 82 D
+-10 68 D
+-10 98 D
+-6 99 D
+-2 91 D
+1 107 D
+6 99 D
+8 83 D
+9 75 D
+15 90 D
+15 74 D
+23 95 D
+29 102 D
+32 92 D
+36 91 D
+31 68 D
+26 53 D
+36 66 D
+43 70 D
+37 56 D
+55 72 D
+39 46 D
+15 17 D
+6 5 D
+15 17 D
+6 5 D
+21 22 D
+52 47 D
+63 50 D
+40 28 D
+66 39 D
+39 21 D
+70 30 D
+39 13 D
+S
+3193 36 M
+-20 13 D
+-43 38 D
+-37 43 D
+-28 37 D
+-43 71 D
+-38 75 D
+-34 81 D
+-33 91 D
+-28 89 D
+-31 119 D
+-25 117 D
+-19 106 D
+-19 122 D
+-17 147 D
+-12 150 D
+-6 121 D
+-3 106 D
+-1 168 D
+5 151 D
+9 144 D
+13 141 D
+17 139 D
+22 136 D
+30 146 D
+30 120 D
+39 127 D
+31 85 D
+37 86 D
+39 75 D
+37 60 D
+42 54 D
+31 34 D
+35 30 D
+20 13 D
+S
+3307 36 M
+0 3235 D
+S
+3421 36 M
+20 13 D
+43 38 D
+23 26 D
+22 26 D
+13 19 D
+20 29 D
+30 51 D
+22 42 D
+36 79 D
+21 53 D
+24 67 D
+33 108 D
+20 73 D
+29 129 D
+21 112 D
+21 137 D
+17 147 D
+11 135 D
+6 106 D
+4 129 D
+1 182 D
+-5 152 D
+-13 188 D
+-15 141 D
+-14 109 D
+-19 114 D
+-22 111 D
+-29 122 D
+-26 91 D
+-28 88 D
+-32 83 D
+-30 69 D
+-22 43 D
+-17 32 D
+-37 60 D
+-27 37 D
+-38 43 D
+-43 38 D
+-20 13 D
+S
+3536 36 M
+48 17 D
+77 34 D
+39 21 D
+57 36 D
+53 38 D
+61 50 D
+5 6 D
+34 31 D
+48 50 D
+49 57 D
+42 54 D
+67 99 D
+11 20 D
+23 38 D
+35 66 D
+16 34 D
+7 13 D
+53 124 D
+35 99 D
+24 79 D
+29 110 D
+25 126 D
+15 97 D
+13 121 D
+6 121 D
+1 137 D
+-5 107 D
+-9 98 D
+-11 91 D
+-18 104 D
+-21 96 D
+-33 124 D
+-28 86 D
+-29 77 D
+-50 117 D
+-7 13 D
+-34 67 D
+-37 65 D
+-8 12 D
+-7 13 D
+-50 75 D
+-50 66 D
+-44 52 D
+-47 50 D
+-56 53 D
+-68 55 D
+-47 33 D
+-36 22 D
+-22 13 D
+-47 25 D
+-70 30 D
+-39 13 D
+S
+3650 36 M
+73 17 D
+115 34 D
+91 34 D
+113 51 D
+102 55 D
+68 42 D
+64 44 D
+60 46 D
+50 41 D
+60 54 D
+12 13 D
+44 43 D
+47 51 D
+49 59 D
+15 20 D
+11 13 D
+53 74 D
+22 35 D
+9 13 D
+61 105 D
+42 86 D
+37 87 D
+29 81 D
+20 66 D
+25 97 D
+16 83 D
+13 91 D
+8 99 D
+2 99 D
+-4 99 D
+-10 98 D
+-10 68 D
+-17 83 D
+-31 119 D
+-30 89 D
+-38 95 D
+-45 93 D
+-59 105 D
+-54 82 D
+-44 61 D
+-16 19 D
+-10 14 D
+-56 65 D
+-53 56 D
+-32 31 D
+-6 7 D
+-81 72 D
+-29 23 D
+-37 29 D
+-87 61 D
+-77 47 D
+-103 55 D
+-82 37 D
+-77 30 D
+-66 23 D
+-98 28 D
+-59 13 D
+S
+3764 36 M
+106 19 D
+145 32 D
+121 34 D
+78 25 D
+73 26 D
+124 50 D
+69 31 D
+98 49 D
+101 57 D
+57 35 D
+89 60 D
+99 75 D
+97 84 D
+42 40 D
+6 7 D
+14 13 D
+69 75 D
+46 55 D
+58 77 D
+15 21 D
+9 15 D
+19 28 D
+55 94 D
+7 15 D
+8 14 D
+7 15 D
+27 59 D
+22 52 D
+33 97 D
+13 45 D
+20 91 D
+16 113 D
+4 76 D
+1 61 D
+-6 99 D
+-11 84 D
+-17 83 D
+-9 38 D
+-18 60 D
+-32 89 D
+-32 74 D
+-26 51 D
+-23 44 D
+-48 79 D
+-15 21 D
+-9 15 D
+-46 63 D
+-45 56 D
+-48 55 D
+-51 54 D
+-7 6 D
+-13 14 D
+-49 46 D
+-83 71 D
+-107 81 D
+-109 72 D
+-109 63 D
+-97 49 D
+-68 32 D
+-23 10 D
+-111 45 D
+-86 31 D
+-100 31 D
+-115 32 D
+-157 34 D
+-78 13 D
+S
+3879 36 M
+132 19 D
+109 19 D
+72 13 D
+58 13 D
+93 21 D
+148 39 D
+96 29 D
+114 38 D
+100 37 D
+108 44 D
+76 34 D
+96 46 D
+124 66 D
+21 13 D
+32 18 D
+90 57 D
+93 65 D
+77 59 D
+72 61 D
+59 55 D
+69 70 D
+79 92 D
+16 22 D
+37 50 D
+48 73 D
+49 89 D
+40 89 D
+22 61 D
+20 67 D
+16 69 D
+11 68 D
+6 76 D
+1 76 D
+-5 68 D
+-4 38 D
+-12 69 D
+-21 83 D
+-28 83 D
+-25 59 D
+-29 60 D
+-28 52 D
+-46 73 D
+-35 51 D
+-45 57 D
+-67 78 D
+-90 91 D
+-23 20 D
+-70 61 D
+-42 34 D
+-70 52 D
+-95 65 D
+-91 56 D
+-22 12 D
+-21 13 D
+-142 75 D
+-131 60 D
+-127 52 D
+-130 47 D
+-116 37 D
+-116 33 D
+-71 18 D
+-92 22 D
+-149 31 D
+-179 29 D
+-62 8 D
+S
+3993 36 M
+152 18 D
+205 30 D
+206 38 D
+146 32 D
+165 41 D
+169 49 D
+109 35 D
+103 36 D
+91 34 D
+94 38 D
+174 78 D
+111 56 D
+11 7 D
+75 41 D
+82 49 D
+72 47 D
+68 47 D
+55 41 D
+52 41 D
+88 77 D
+65 64 D
+40 43 D
+61 73 D
+43 59 D
+39 59 D
+34 59 D
+36 75 D
+24 60 D
+21 68 D
+13 53 D
+11 69 D
+6 68 D
+-1 84 D
+-6 61 D
+-11 61 D
+-19 75 D
+-27 76 D
+-26 60 D
+-35 67 D
+-32 52 D
+-29 44 D
+-44 59 D
+-48 58 D
+-20 21 D
+-13 15 D
+-63 64 D
+-86 77 D
+-78 63 D
+-55 41 D
+-29 20 D
+-70 47 D
+-79 49 D
+-56 32 D
+-11 7 D
+-53 28 D
+-11 7 D
+-105 53 D
+-126 58 D
+-120 50 D
+-136 51 D
+-121 41 D
+-137 42 D
+-147 40 D
+-158 38 D
+-139 29 D
+-173 32 D
+-67 11 D
+-78 11 D
+-145 19 D
+-67 7 D
+S
+3307 0 M
+-10 0 D
+-11 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-12 0 D
+-11 0 D
+-198 5 D
+-209 12 D
+-143 12 D
+-70 7 D
+S
+3307 0 M
+-8 0 D
+-8 0 D
+-13 0 D
+-111 6 D
+-125 15 D
+-78 15 D
+S
+3307 0 M
+0 36 D
+S
+3307 0 M
+64 1 D
+86 6 D
+115 14 D
+78 15 D
+S
+3307 0 M
+141 1 D
+144 5 D
+189 11 D
+142 12 D
+70 7 D
+S
+2621 36 M
+1372 0 D
+S
+2621 3271 M
+6 1 D
+7 0 D
+6 1 D
+6 1 D
+7 0 D
+6 1 D
+7 1 D
+6 0 D
+7 1 D
+7 1 D
+6 0 D
+7 1 D
+7 1 D
+6 0 D
+7 1 D
+7 0 D
+7 1 D
+7 1 D
+7 0 D
+7 1 D
+7 0 D
+7 1 D
+7 1 D
+7 0 D
+8 1 D
+7 0 D
+7 1 D
+8 0 D
+7 1 D
+8 1 D
+8 0 D
+7 1 D
+8 0 D
+8 1 D
+8 0 D
+8 1 D
+8 0 D
+8 1 D
+8 0 D
+8 1 D
+9 0 D
+8 1 D
+9 0 D
+8 1 D
+9 0 D
+9 1 D
+9 0 D
+9 1 D
+9 0 D
+10 1 D
+9 0 D
+10 1 D
+10 0 D
+10 0 D
+10 1 D
+10 0 D
+11 1 D
+11 0 D
+11 0 D
+11 1 D
+12 0 D
+12 0 D
+7 1 D
+6 0 D
+6 0 D
+7 0 D
+3466 3305 M
+-159 2 D
+S
+2964 3271 M
+74 14 D
+86 12 D
+79 7 D
+92 3 D
+12 0 D
+S
+3307 3271 M
+0 36 D
+S
+3650 3271 M
+-73 14 D
+-104 14 D
+-86 6 D
+-72 2 D
+-8 0 D
+S
+3993 3271 M
+-6 1 D
+-7 0 D
+-6 1 D
+-6 1 D
+-7 0 D
+-6 1 D
+-7 1 D
+-6 0 D
+-7 1 D
+-6 1 D
+-7 0 D
+-7 1 D
+-6 1 D
+-7 0 D
+-7 1 D
+-7 0 D
+-7 1 D
+-7 1 D
+-7 0 D
+-7 1 D
+-7 0 D
+-7 1 D
+-7 1 D
+-7 0 D
+-8 1 D
+-7 0 D
+-7 1 D
+-8 0 D
+-7 1 D
+-8 1 D
+-7 0 D
+-8 1 D
+-8 0 D
+-8 1 D
+-8 0 D
+-8 1 D
+-8 0 D
+-8 1 D
+-8 0 D
+-8 1 D
+-8 0 D
+-9 1 D
+-9 0 D
+-8 1 D
+-9 0 D
+-9 1 D
+-9 0 D
+-9 1 D
+-9 0 D
+-10 1 D
+-9 0 D
+-10 1 D
+-10 0 D
+-10 0 D
+-10 1 D
+-10 0 D
+-11 1 D
+-11 0 D
+-11 0 D
+-11 1 D
+-12 0 D
+-12 0 D
+-6 1 D
+-7 0 D
+-6 0 D
+-7 0 D
+3480 3309 M
+-332 -4 D
+159 2 D
+S
+2621 3271 M
+1372 0 D
+S
+1162 395 M
+4290 0 D
+S
+280 988 M
+6054 0 D
+S
+0 1654 M
+6614 0 D
+S
+280 2319 M
+6054 0 D
+S
+1162 2912 M
+4290 0 D
+S
+8 W
+N 5452 395 M 50 0 D S
+N 1162 395 M -50 0 D S
+N 5452 395 M 50 0 D S
+N 1162 395 M -50 0 D S
+N 6334 988 M 50 0 D S
+N 280 988 M -50 0 D S
+N 6334 988 M 50 0 D S
+N 280 988 M -50 0 D S
+N 6614 1654 M 50 0 D S
+N 0 1654 M -50 0 D S
+N 6614 1654 M 50 0 D S
+N 0 1654 M -50 0 D S
+N 6334 2319 M 50 0 D S
+N 280 2319 M -50 0 D S
+N 6334 2319 M 50 0 D S
+N 280 2319 M -50 0 D S
+N 5452 2912 M 50 0 D S
+N 1162 2912 M -50 0 D S
+N 5452 2912 M 50 0 D S
+N 1162 2912 M -50 0 D S
+N 4710 156 M 25 0 D S
+N 1904 156 M -25 0 D S
+N 4710 156 M 25 0 D S
+N 1904 156 M -25 0 D S
+N 5452 395 M 25 0 D S
+N 1162 395 M -25 0 D S
+N 5452 395 M 25 0 D S
+N 1162 395 M -25 0 D S
+N 5976 677 M 25 0 D S
+N 638 677 M -25 0 D S
+N 5976 677 M 25 0 D S
+N 638 677 M -25 0 D S
+N 6334 988 M 25 0 D S
+N 280 988 M -25 0 D S
+N 6334 988 M 25 0 D S
+N 280 988 M -25 0 D S
+N 6545 1316 M 25 0 D S
+N 69 1316 M -25 0 D S
+N 6545 1316 M 25 0 D S
+N 69 1316 M -25 0 D S
+N 6614 1654 M 25 0 D S
+N 0 1654 M -25 0 D S
+N 6614 1654 M 25 0 D S
+N 0 1654 M -25 0 D S
+N 6545 1991 M 25 0 D S
+N 69 1991 M -25 0 D S
+N 6545 1991 M 25 0 D S
+N 69 1991 M -25 0 D S
+N 6334 2319 M 25 0 D S
+N 280 2319 M -25 0 D S
+N 6334 2319 M 25 0 D S
+N 280 2319 M -25 0 D S
+N 5976 2630 M 25 0 D S
+N 638 2630 M -25 0 D S
+N 5976 2630 M 25 0 D S
+N 638 2630 M -25 0 D S
+N 5452 2912 M 25 0 D S
+N 1162 2912 M -25 0 D S
+N 5452 2912 M 25 0 D S
+N 1162 2912 M -25 0 D S
+N 4710 3151 M 25 0 D S
+N 1904 3151 M -25 0 D S
+N 4710 3151 M 25 0 D S
+N 1904 3151 M -25 0 D S
+25 W
+3307 0 M
+P
+135 1 D
+190 7 D
+133 8 D
+124 10 D
+149 15 D
+121 15 D
+143 21 D
+167 28 D
+153 31 D
+171 40 D
+176 48 D
+121 37 D
+122 41 D
+130 48 D
+129 53 D
+107 48 D
+19 10 D
+45 21 D
+114 60 D
+69 39 D
+16 10 D
+90 56 D
+70 47 D
+28 21 D
+19 13 D
+80 62 D
+89 78 D
+51 49 D
+42 43 D
+19 22 D
+38 44 D
+29 36 D
+42 59 D
+29 45 D
+26 44 D
+24 45 D
+27 60 D
+21 53 D
+23 76 D
+18 91 D
+6 54 D
+2 69 D
+-3 68 D
+-6 54 D
+-14 68 D
+-21 76 D
+-32 83 D
+-33 68 D
+-16 30 D
+-41 67 D
+-47 66 D
+-35 44 D
+-37 43 D
+-47 51 D
+-29 28 D
+-14 15 D
+-78 70 D
+-95 77 D
+-56 41 D
+-79 53 D
+-85 53 D
+-67 39 D
+-65 35 D
+-67 35 D
+-83 40 D
+-157 69 D
+-51 21 D
+-30 11 D
+-115 43 D
+-147 49 D
+-150 44 D
+-122 32 D
+-130 31 D
+-139 29 D
+-173 32 D
+-87 14 D
+-175 23 D
+-81 10 D
+-180 17 D
+-187 12 D
+-153 6 D
+-180 2 D
+-72 0 D
+-12 0 D
+-10 -1 D
+-11 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-7 -1 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-12 -1 D
+-12 0 D
+-12 -1 D
+-12 0 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 -1 D
+-11 0 D
+-10 -1 D
+-11 0 D
+-10 -1 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-9 -1 D
+-9 0 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 0 D
+-8 -1 D
+-9 -1 D
+-9 0 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 0 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 0 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 0 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-8 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 0 D
+-6 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-12 -2 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-12 -2 D
+-12 -3 D
+-11 -2 D
+-12 -2 D
+-12 -2 D
+-11 -2 D
+-12 -2 D
+-11 -2 D
+-12 -2 D
+-11 -2 D
+-11 -3 D
+-11 -2 D
+-11 -2 D
+-12 -2 D
+-11 -2 D
+-10 -2 D
+-11 -3 D
+-11 -2 D
+-11 -2 D
+-11 -2 D
+-10 -3 D
+-11 -2 D
+-10 -2 D
+-11 -2 D
+-10 -3 D
+-10 -2 D
+-11 -2 D
+-10 -3 D
+-10 -2 D
+-10 -2 D
+-10 -3 D
+-11 -2 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-10 -3 D
+-10 -2 D
+-10 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-9 -3 D
+-9 -2 D
+-8 -3 D
+-9 -2 D
+-9 -3 D
+-8 -3 D
+-9 -2 D
+-9 -3 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-9 -3 D
+-8 -2 D
+-8 -3 D
+-9 -3 D
+-8 -2 D
+-8 -3 D
+-9 -3 D
+-8 -2 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -2 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-13 -7 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -7 D
+-13 -6 D
+-12 -6 D
+-12 -6 D
+-12 -7 D
+-7 -3 D
+-12 -6 D
+-12 -6 D
+-11 -7 D
+-12 -6 D
+-12 -7 D
+-12 -6 D
+-11 -6 D
+-12 -7 D
+-11 -6 D
+-11 -7 D
+-11 -6 D
+-11 -7 D
+-11 -6 D
+-11 -7 D
+-11 -7 D
+-11 -6 D
+-26 -17 D
+-21 -13 D
+-30 -20 D
+-30 -20 D
+-29 -20 D
+-38 -28 D
+-36 -27 D
+-43 -35 D
+-50 -42 D
+-69 -63 D
+-7 -8 D
+-36 -35 D
+-13 -15 D
+-27 -29 D
+-43 -51 D
+-34 -43 D
+-46 -67 D
+-40 -67 D
+-20 -37 D
+-31 -68 D
+-23 -60 D
+-20 -69 D
+-13 -61 D
+-9 -61 D
+-4 -68 D
+1 -61 D
+5 -54 D
+9 -61 D
+16 -68 D
+19 -61 D
+27 -68 D
+29 -60 D
+33 -60 D
+10 -14 D
+14 -23 D
+14 -22 D
+49 -66 D
+35 -44 D
+39 -43 D
+13 -15 D
+49 -50 D
+38 -35 D
+7 -8 D
+73 -63 D
+98 -76 D
+29 -20 D
+89 -60 D
+80 -50 D
+34 -19 D
+16 -10 D
+94 -51 D
+113 -56 D
+94 -43 D
+69 -29 D
+80 -33 D
+38 -14 D
+93 -34 D
+147 -49 D
+150 -44 D
+142 -37 D
+121 -28 D
+85 -18 D
+123 -24 D
+125 -22 D
+204 -29 D
+173 -19 D
+154 -13 D
+164 -10 D
+162 -5 D
+150 -2 D
+P S
+/PSL_H_y 333 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+117 F0
+(100°) sh add def
+3307 3307 PSL_H_y add M
+200 F0
+(Mollweide) bc Z
+35 1689 M 117 F0
+(­180°) bl Z
+587 1689 M (­150°) bl Z
+1138 1689 M (­120°) bl Z
+1689 1689 M (­90°) bl Z
+2240 1689 M (­60°) bl Z
+2791 1689 M (­30°) bl Z
+3342 1689 M (0°) bl Z
+3894 1689 M (30°) bl Z
+4445 1689 M (60°) bl Z
+4996 1689 M (90°) bl Z
+5547 1689 M (120°) bl Z
+6098 1689 M (150°) bl Z
+1062 395 M (-60°) mr Z
+5552 395 M (-60°) ml Z
+180 988 M (-30°) mr Z
+6434 988 M (-30°) ml Z
+-100 1654 M (0°) mr Z
+6714 1654 M (0°) ml Z
+180 2319 M (30°) mr Z
+6434 2319 M (30°) ml Z
+1062 2912 M (60°) mr Z
+5552 2912 M (60°) ml Z
+%%EndObject
+0 -4079 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -JI0/5.5118i -BWENS+tSinusoidal+i -Bxa30fg30 -Bya30fg30 -Xa0i -Ya0i -Rg
+%@PROJ: sinu -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.355 20015109.355 -10007554.678 10007554.678 +proj=sinu +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+3018 92 M
+-98 31 D
+-29 10 D
+-145 46 D
+-38 13 D
+-220 71 D
+-47 16 D
+-298 99 D
+-339 119 D
+-69 24 D
+-34 13 D
+-51 18 D
+-50 19 D
+-180 68 D
+-80 31 D
+-23 10 D
+-130 52 D
+-44 19 D
+-172 74 D
+-13 7 D
+-54 24 D
+-130 62 D
+-126 65 D
+-68 38 D
+-54 30 D
+-109 68 D
+-98 68 D
+-40 31 D
+-45 37 D
+-35 31 D
+-6 7 D
+-32 30 D
+-34 37 D
+-30 37 D
+-30 44 D
+-24 43 D
+-17 37 D
+-11 31 D
+-10 43 D
+-5 49 D
+1 37 D
+5 37 D
+13 50 D
+18 43 D
+19 37 D
+19 31 D
+27 37 D
+36 43 D
+12 12 D
+11 13 D
+45 43 D
+65 56 D
+73 55 D
+101 68 D
+92 56 D
+38 21 D
+16 10 D
+98 52 D
+110 56 D
+26 12 D
+19 10 D
+114 52 D
+41 19 D
+158 68 D
+91 37 D
+30 13 D
+255 99 D
+176 65 D
+236 84 D
+244 84 D
+337 112 D
+115 37 D
+47 16 D
+126 40 D
+38 13 D
+166 53 D
+S
+3066 92 M
+-441 171 D
+-219 87 D
+-30 13 D
+-39 15 D
+-30 13 D
+-38 15 D
+-37 16 D
+-97 40 D
+-51 22 D
+-221 96 D
+-41 19 D
+-154 71 D
+-19 10 D
+-109 52 D
+-139 72 D
+-97 52 D
+-16 10 D
+-39 21 D
+-21 13 D
+-32 18 D
+-110 69 D
+-47 30 D
+-96 68 D
+-49 38 D
+-38 30 D
+-43 38 D
+-33 30 D
+-6 7 D
+-25 24 D
+-35 37 D
+-41 50 D
+-39 55 D
+-25 44 D
+-26 55 D
+-15 43 D
+-10 44 D
+-6 43 D
+-1 37 D
+2 37 D
+10 55 D
+15 50 D
+25 55 D
+16 31 D
+8 12 D
+7 13 D
+30 43 D
+34 43 D
+22 25 D
+47 49 D
+7 6 D
+6 7 D
+27 24 D
+6 7 D
+58 49 D
+55 43 D
+51 37 D
+17 13 D
+73 49 D
+98 62 D
+74 43 D
+21 13 D
+130 71 D
+113 59 D
+88 43 D
+25 13 D
+105 49 D
+13 7 D
+116 52 D
+13 7 D
+184 80 D
+140 59 D
+37 16 D
+106 43 D
+30 13 D
+39 15 D
+30 13 D
+307 121 D
+216 84 D
+114 44 D
+S
+3114 92 M
+-65 31 D
+-19 10 D
+-39 18 D
+-19 10 D
+-39 18 D
+-19 10 D
+-39 18 D
+-31 16 D
+-26 12 D
+-25 13 D
+-32 15 D
+-31 16 D
+-82 40 D
+-55 28 D
+-116 59 D
+-108 56 D
+-11 7 D
+-99 52 D
+-51 28 D
+-56 31 D
+-16 10 D
+-50 28 D
+-85 49 D
+-41 25 D
+-111 68 D
+-19 13 D
+-29 18 D
+-110 75 D
+-26 18 D
+-25 19 D
+-106 80 D
+-15 13 D
+-23 18 D
+-64 56 D
+-52 49 D
+-12 13 D
+-19 18 D
+-11 13 D
+-34 37 D
+-46 55 D
+-40 56 D
+-31 49 D
+-29 56 D
+-23 56 D
+-17 55 D
+-11 56 D
+-3 24 D
+-2 50 D
+3 49 D
+6 43 D
+14 56 D
+17 49 D
+25 56 D
+24 43 D
+35 55 D
+37 50 D
+46 55 D
+35 37 D
+11 13 D
+19 18 D
+12 13 D
+20 18 D
+6 7 D
+55 49 D
+44 37 D
+16 12 D
+15 13 D
+89 68 D
+87 62 D
+102 68 D
+20 12 D
+19 13 D
+111 68 D
+95 56 D
+126 71 D
+51 28 D
+40 22 D
+82 44 D
+198 102 D
+55 28 D
+125 62 D
+114 56 D
+232 112 D
+26 13 D
+S
+3162 92 M
+-174 112 D
+-19 13 D
+-29 18 D
+-28 19 D
+-57 37 D
+-74 50 D
+-92 62 D
+-90 63 D
+-35 24 D
+-17 13 D
+-26 18 D
+-17 13 D
+-59 43 D
+-106 81 D
+-92 74 D
+-29 25 D
+-79 68 D
+-27 25 D
+-7 6 D
+-6 7 D
+-27 24 D
+-12 13 D
+-50 49 D
+-30 31 D
+-11 13 D
+-23 24 D
+-21 25 D
+-36 43 D
+-30 38 D
+-44 61 D
+-43 68 D
+-24 44 D
+-29 61 D
+-18 44 D
+-17 49 D
+-14 55 D
+-11 62 D
+-4 37 D
+-1 74 D
+2 37 D
+11 74 D
+14 56 D
+13 43 D
+22 56 D
+35 74 D
+40 68 D
+41 61 D
+37 50 D
+50 62 D
+22 24 D
+16 19 D
+71 74 D
+38 37 D
+6 7 D
+27 24 D
+6 7 D
+27 24 D
+49 44 D
+59 49 D
+22 19 D
+117 93 D
+125 93 D
+52 37 D
+17 13 D
+18 12 D
+17 13 D
+136 93 D
+92 62 D
+95 62 D
+28 19 D
+97 62 D
+19 13 D
+87 56 D
+S
+3211 92 M
+-7 6 D
+-6 7 D
+-20 18 D
+-6 7 D
+-20 18 D
+-6 7 D
+-26 24 D
+-6 7 D
+-20 18 D
+-12 13 D
+-45 43 D
+-12 13 D
+-19 18 D
+-6 7 D
+-19 18 D
+-6 7 D
+-25 24 D
+-12 13 D
+-19 18 D
+-90 94 D
+-97 105 D
+-16 19 D
+-38 43 D
+-83 100 D
+-62 80 D
+-49 68 D
+-58 87 D
+-48 81 D
+-23 43 D
+-28 55 D
+-15 31 D
+-13 31 D
+-29 74 D
+-12 37 D
+-17 56 D
+-13 56 D
+-10 49 D
+-10 86 D
+-3 74 D
+1 62 D
+7 74 D
+5 37 D
+18 87 D
+18 61 D
+5 19 D
+27 74 D
+32 74 D
+30 62 D
+37 68 D
+61 99 D
+64 93 D
+71 93 D
+29 37 D
+100 118 D
+56 62 D
+81 87 D
+84 87 D
+13 12 D
+49 50 D
+7 6 D
+18 19 D
+7 6 D
+12 13 D
+45 43 D
+12 13 D
+20 18 D
+6 7 D
+52 49 D
+6 7 D
+20 18 D
+6 7 D
+7 6 D
+S
+3259 92 M
+-115 224 D
+-82 168 D
+-59 131 D
+-52 124 D
+-33 86 D
+-20 56 D
+-43 130 D
+-29 105 D
+-27 118 D
+-20 111 D
+-16 136 D
+-6 99 D
+-1 111 D
+6 123 D
+12 111 D
+13 86 D
+21 106 D
+23 92 D
+19 68 D
+41 130 D
+22 62 D
+21 56 D
+35 87 D
+29 68 D
+36 81 D
+55 118 D
+39 81 D
+25 49 D
+86 168 D
+20 38 D
+S
+3307 92 M
+0 3123 D
+S
+3355 92 M
+74 143 D
+41 81 D
+88 181 D
+64 142 D
+58 143 D
+34 93 D
+25 74 D
+22 68 D
+7 25 D
+31 118 D
+22 105 D
+16 92 D
+13 111 D
+7 112 D
+1 123 D
+-7 123 D
+-11 99 D
+-15 99 D
+-23 111 D
+-29 111 D
+-22 75 D
+-32 99 D
+-46 124 D
+-54 130 D
+-53 118 D
+-86 180 D
+-19 37 D
+-41 81 D
+-65 125 D
+S
+3404 92 M
+32 31 D
+6 7 D
+20 18 D
+6 7 D
+26 24 D
+6 7 D
+20 18 D
+12 13 D
+20 18 D
+12 13 D
+13 12 D
+6 7 D
+81 80 D
+6 7 D
+25 24 D
+107 112 D
+80 87 D
+16 19 D
+49 56 D
+67 80 D
+58 75 D
+14 18 D
+13 19 D
+31 43 D
+62 93 D
+7 13 D
+23 37 D
+34 62 D
+31 61 D
+26 56 D
+31 80 D
+17 50 D
+17 62 D
+13 61 D
+7 37 D
+7 62 D
+4 62 D
+-1 86 D
+-7 74 D
+-7 49 D
+-13 62 D
+-17 62 D
+-13 43 D
+-23 62 D
+-29 68 D
+-36 74 D
+-41 74 D
+-50 81 D
+-68 99 D
+-14 18 D
+-9 13 D
+-33 43 D
+-54 68 D
+-68 81 D
+-78 87 D
+-81 87 D
+-90 93 D
+-7 6 D
+-30 32 D
+-82 80 D
+-6 7 D
+-20 18 D
+-12 13 D
+-20 18 D
+-12 13 D
+-46 43 D
+-12 13 D
+-26 25 D
+S
+3452 92 M
+136 87 D
+28 19 D
+58 37 D
+28 19 D
+57 37 D
+65 44 D
+101 68 D
+125 87 D
+17 13 D
+69 49 D
+147 112 D
+31 25 D
+53 43 D
+22 19 D
+86 74 D
+34 31 D
+6 7 D
+27 24 D
+6 7 D
+26 24 D
+66 69 D
+28 30 D
+16 19 D
+52 62 D
+42 55 D
+57 87 D
+31 56 D
+30 61 D
+26 68 D
+15 50 D
+12 55 D
+9 62 D
+3 62 D
+-3 61 D
+-12 80 D
+-18 68 D
+-17 50 D
+-21 49 D
+-27 56 D
+-21 37 D
+-51 80 D
+-27 37 D
+-48 62 D
+-37 43 D
+-34 37 D
+-11 13 D
+-60 62 D
+-26 24 D
+-6 7 D
+-27 24 D
+-6 7 D
+-83 74 D
+-44 37 D
+-30 25 D
+-46 37 D
+-79 62 D
+-108 81 D
+-61 43 D
+-17 13 D
+-134 93 D
+-129 87 D
+-95 62 D
+-28 19 D
+-58 37 D
+-19 13 D
+-107 68 D
+-19 13 D
+S
+3500 92 M
+65 31 D
+19 10 D
+97 46 D
+19 10 D
+39 18 D
+25 13 D
+32 15 D
+25 13 D
+32 15 D
+25 13 D
+32 15 D
+43 22 D
+130 65 D
+168 88 D
+110 59 D
+51 27 D
+11 7 D
+45 25 D
+92 52 D
+105 62 D
+100 62 D
+19 13 D
+29 18 D
+37 25 D
+99 68 D
+43 31 D
+65 50 D
+61 49 D
+64 56 D
+52 49 D
+6 7 D
+25 24 D
+40 44 D
+51 61 D
+23 31 D
+41 62 D
+27 49 D
+20 44 D
+14 37 D
+15 49 D
+11 56 D
+4 37 D
+1 49 D
+-6 62 D
+-10 49 D
+-19 62 D
+-21 49 D
+-22 43 D
+-26 44 D
+-38 55 D
+-29 37 D
+-36 43 D
+-46 50 D
+-19 18 D
+-12 13 D
+-20 18 D
+-6 7 D
+-62 55 D
+-68 56 D
+-47 37 D
+-59 43 D
+-17 13 D
+-99 68 D
+-66 43 D
+-49 31 D
+-80 50 D
+-74 43 D
+-21 13 D
+-87 49 D
+-16 10 D
+-40 21 D
+-16 10 D
+-35 18 D
+-11 7 D
+-99 52 D
+-11 7 D
+-199 102 D
+-55 28 D
+-220 109 D
+-20 9 D
+-25 13 D
+-90 43 D
+-19 10 D
+-117 56 D
+S
+3548 92 M
+323 125 D
+119 46 D
+23 10 D
+117 46 D
+147 59 D
+30 13 D
+38 15 D
+30 13 D
+104 43 D
+51 22 D
+221 96 D
+195 90 D
+65 31 D
+31 16 D
+32 15 D
+179 93 D
+123 69 D
+42 24 D
+100 62 D
+57 37 D
+96 68 D
+57 44 D
+30 24 D
+50 44 D
+26 24 D
+6 7 D
+25 24 D
+35 37 D
+41 50 D
+14 18 D
+33 50 D
+17 31 D
+13 24 D
+18 43 D
+12 37 D
+9 44 D
+5 37 D
+1 49 D
+-4 37 D
+-8 43 D
+-15 50 D
+-24 55 D
+-32 56 D
+-30 43 D
+-39 49 D
+-40 44 D
+-31 30 D
+-12 13 D
+-48 43 D
+-52 43 D
+-82 62 D
+-35 25 D
+-83 56 D
+-89 55 D
+-101 59 D
+-17 9 D
+-11 7 D
+-103 55 D
+-102 53 D
+-82 40 D
+-25 13 D
+-39 18 D
+-13 7 D
+-53 24 D
+-13 7 D
+-164 74 D
+-149 65 D
+-140 59 D
+-44 19 D
+-99 40 D
+-30 13 D
+-241 96 D
+-214 84 D
+-251 97 D
+S
+3597 92 M
+444 143 D
+47 16 D
+123 40 D
+56 19 D
+286 96 D
+326 115 D
+161 59 D
+179 69 D
+63 25 D
+145 58 D
+37 16 D
+179 77 D
+54 25 D
+14 6 D
+13 7 D
+116 55 D
+126 65 D
+63 34 D
+16 10 D
+43 24 D
+110 68 D
+46 31 D
+17 13 D
+59 43 D
+16 12 D
+15 13 D
+64 55 D
+38 37 D
+34 37 D
+30 37 D
+13 19 D
+21 31 D
+29 55 D
+15 37 D
+12 44 D
+5 37 D
+2 37 D
+-2 37 D
+-8 43 D
+-11 37 D
+-16 37 D
+-19 37 D
+-23 37 D
+-14 18 D
+-9 13 D
+-36 43 D
+-35 37 D
+-13 12 D
+-6 7 D
+-86 74 D
+-66 49 D
+-18 12 D
+-17 13 D
+-66 43 D
+-102 62 D
+-72 40 D
+-64 34 D
+-116 59 D
+-26 12 D
+-19 10 D
+-107 49 D
+-62 28 D
+-144 62 D
+-144 59 D
+-24 9 D
+-23 10 D
+-193 74 D
+-168 62 D
+-165 59 D
+-215 75 D
+-267 90 D
+-342 112 D
+-116 37 D
+-38 13 D
+-49 15 D
+-29 10 D
+-87 28 D
+S
+3307 0 M
+-289 92 D
+S
+3307 0 M
+-129 82 D
+-16 10 D
+S
+3307 0 M
+0 92 D
+S
+3307 0 M
+145 92 D
+S
+3307 0 M
+290 92 D
+S
+3018 92 M
+579 0 D
+S
+3018 3215 M
+201 64 D
+88 28 D
+S
+3162 3215 M
+145 92 D
+S
+3307 3215 M
+0 92 D
+S
+3452 3215 M
+-145 92 D
+S
+3597 3215 M
+-290 92 D
+S
+3018 3215 M
+579 0 D
+S
+1648 553 M
+3318 0 D
+S
+440 1104 M
+5734 0 D
+S
+0 1654 M
+6614 0 D
+S
+440 2203 M
+5734 0 D
+S
+1648 2754 M
+3318 0 D
+S
+8 W
+N 4966 553 M 50 0 D S
+N 1648 553 M -50 0 D S
+N 4966 553 M 50 0 D S
+N 1648 553 M -50 0 D S
+N 6174 1104 M 50 0 D S
+N 440 1104 M -50 0 D S
+N 6174 1104 M 50 0 D S
+N 440 1104 M -50 0 D S
+N 6614 1654 M 50 0 D S
+N 0 1654 M -50 0 D S
+N 6614 1654 M 50 0 D S
+N 0 1654 M -50 0 D S
+N 6174 2203 M 50 0 D S
+N 440 2203 M -50 0 D S
+N 6174 2203 M 50 0 D S
+N 440 2203 M -50 0 D S
+N 4966 2754 M 50 0 D S
+N 1648 2754 M -50 0 D S
+N 4966 2754 M 50 0 D S
+N 1648 2754 M -50 0 D S
+N 4167 277 M 25 0 D S
+N 2448 277 M -25 0 D S
+N 4167 277 M 25 0 D S
+N 2448 277 M -25 0 D S
+N 4966 553 M 25 0 D S
+N 1648 553 M -25 0 D S
+N 4966 553 M 25 0 D S
+N 1648 553 M -25 0 D S
+N 5651 829 M 25 0 D S
+N 963 829 M -25 0 D S
+N 5651 829 M 25 0 D S
+N 963 829 M -25 0 D S
+N 6174 1104 M 25 0 D S
+N 440 1104 M -25 0 D S
+N 6174 1104 M 25 0 D S
+N 440 1104 M -25 0 D S
+N 6502 1379 M 25 0 D S
+N 112 1379 M -25 0 D S
+N 6502 1379 M 25 0 D S
+N 112 1379 M -25 0 D S
+N 6614 1654 M 25 0 D S
+N 0 1654 M -25 0 D S
+N 6614 1654 M 25 0 D S
+N 0 1654 M -25 0 D S
+N 6502 1928 M 25 0 D S
+N 112 1928 M -25 0 D S
+N 6502 1928 M 25 0 D S
+N 112 1928 M -25 0 D S
+N 6174 2203 M 25 0 D S
+N 440 2203 M -25 0 D S
+N 6174 2203 M 25 0 D S
+N 440 2203 M -25 0 D S
+N 5651 2478 M 25 0 D S
+N 963 2478 M -25 0 D S
+N 5651 2478 M 25 0 D S
+N 963 2478 M -25 0 D S
+N 4966 2754 M 25 0 D S
+N 1648 2754 M -25 0 D S
+N 4966 2754 M 25 0 D S
+N 1648 2754 M -25 0 D S
+N 4167 3030 M 25 0 D S
+N 2448 3030 M -25 0 D S
+N 4167 3030 M 25 0 D S
+N 2448 3030 M -25 0 D S
+25 W
+3307 0 M
+P
+518 165 D
+38 13 D
+288 94 D
+66 21 D
+56 19 D
+259 87 D
+303 106 D
+34 13 D
+187 68 D
+163 63 D
+117 46 D
+209 87 D
+126 56 D
+139 66 D
+44 21 D
+114 59 D
+106 59 D
+102 62 D
+92 62 D
+25 19 D
+49 37 D
+72 62 D
+38 37 D
+29 31 D
+30 37 D
+23 31 D
+31 50 D
+23 49 D
+11 31 D
+10 44 D
+5 43 D
+-1 37 D
+-5 44 D
+-13 49 D
+-18 43 D
+-19 37 D
+-28 44 D
+-33 43 D
+-22 25 D
+-35 37 D
+-40 37 D
+-58 50 D
+-57 43 D
+-35 25 D
+-74 50 D
+-113 68 D
+-27 15 D
+-11 7 D
+-98 52 D
+-104 53 D
+-78 37 D
+-13 7 D
+-165 74 D
+-124 53 D
+-153 62 D
+-120 47 D
+-164 62 D
+-215 78 D
+-214 75 D
+-173 59 D
+-310 103 D
+-96 31 D
+-38 13 D
+-39 12 D
+-38 13 D
+-49 15 D
+-38 13 D
+-489 156 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-10 -4 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-10 -3 D
+-9 -3 D
+-10 -4 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -4 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -4 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -4 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -4 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-8 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -4 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-15 -7 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-15 -7 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -7 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-13 -6 D
+-12 -7 D
+-7 -3 D
+-13 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-13 -7 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-12 -7 D
+-12 -6 D
+-12 -6 D
+-12 -6 D
+-11 -6 D
+-12 -7 D
+-11 -6 D
+-11 -6 D
+-12 -6 D
+-11 -6 D
+-11 -7 D
+-11 -6 D
+-16 -9 D
+-21 -13 D
+-21 -12 D
+-21 -12 D
+-20 -13 D
+-20 -12 D
+-29 -19 D
+-19 -12 D
+-27 -19 D
+-27 -18 D
+-25 -19 D
+-33 -25 D
+-31 -25 D
+-50 -43 D
+-51 -49 D
+-28 -31 D
+-44 -56 D
+-24 -37 D
+-23 -44 D
+-13 -31 D
+-7 -18 D
+-11 -43 D
+-5 -38 D
+-1 -37 D
+5 -49 D
+7 -31 D
+5 -19 D
+12 -31 D
+17 -37 D
+22 -37 D
+25 -37 D
+46 -56 D
+29 -31 D
+39 -37 D
+65 -56 D
+57 -43 D
+35 -25 D
+55 -37 D
+49 -31 D
+51 -31 D
+59 -34 D
+97 -53 D
+116 -59 D
+20 -9 D
+25 -13 D
+40 -18 D
+13 -7 D
+151 -68 D
+139 -59 D
+153 -62 D
+193 -75 D
+228 -84 D
+221 -78 D
+172 -59 D
+204 -69 D
+266 -87 D
+164 -53 D
+38 -13 D
+362 -115 D
+29 -10 D
+98 -31 D
+P S
+/PSL_H_y 333 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+117 F0
+(100°) sh add def
+3307 3307 PSL_H_y add M
+200 F0
+(Sinusoidal) bc Z
+35 1689 M 117 F0
+(­180°) bl Z
+587 1689 M (­150°) bl Z
+1138 1689 M (­120°) bl Z
+1689 1689 M (­90°) bl Z
+2240 1689 M (­60°) bl Z
+2791 1689 M (­30°) bl Z
+3342 1689 M (0°) bl Z
+3894 1689 M (30°) bl Z
+4445 1689 M (60°) bl Z
+4996 1689 M (90°) bl Z
+5547 1689 M (120°) bl Z
+6098 1689 M (150°) bl Z
+1548 553 M (-60°) mr Z
+5066 553 M (-60°) ml Z
+340 1104 M (-30°) mr Z
+6274 1104 M (-30°) ml Z
+-100 1654 M (0°) mr Z
+6714 1654 M (0°) ml Z
+340 2203 M (30°) mr Z
+6274 2203 M (30°) ml Z
+1548 2754 M (60°) mr Z
+5066 2754 M (60°) ml Z
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psbasemap/azim_global.ps
+++ b/test/psbasemap/azim_global.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.1.0_549fa7d-dirty_2020.03.04 [64-bit] Document from psxy
+%%Title: GMT v6.1.0_4d56427_2020.03.05 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar  5 08:55:35 2020
+%%CreationDate: Thu Mar  5 09:33:21 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -2209,12 +2209,12 @@ P S
 200 F0
 (Hammer) bc Z
 464 2521 M 117 F0
-V -15.9 R (­180°) bl Z U
-833 2439 M V -9.42 R (­150°) bl Z U
-1265 2381 M V -5.88 R (­120°) bl Z U
-1744 2340 M V -3.69 R (­90°) bl Z U
-2258 2313 M V -2.18 R (­60°) bl Z U
-2794 2297 M V -1.01 R (­30°) bl Z U
+V -15.9 R (-180°) bl Z U
+833 2439 M V -9.42 R (-150°) bl Z U
+1265 2381 M V -5.88 R (-120°) bl Z U
+1744 2340 M V -3.69 R (-90°) bl Z U
+2258 2313 M V -2.18 R (-60°) bl Z U
+2794 2297 M V -1.01 R (-30°) bl Z U
 3342 2292 M V 0.0114 R (0°) bl Z U
 3891 2296 M V 1.04 R (30°) bl Z U
 4427 2310 M V 2.21 R (60°) bl Z U
@@ -3707,12 +3707,12 @@ P S
 200 F0
 (Mollweide) bc Z
 35 1689 M 117 F0
-(­180°) bl Z
-587 1689 M (­150°) bl Z
-1138 1689 M (­120°) bl Z
-1689 1689 M (­90°) bl Z
-2240 1689 M (­60°) bl Z
-2791 1689 M (­30°) bl Z
+(-180°) bl Z
+587 1689 M (-150°) bl Z
+1138 1689 M (-120°) bl Z
+1689 1689 M (-90°) bl Z
+2240 1689 M (-60°) bl Z
+2791 1689 M (-30°) bl Z
 3342 1689 M (0°) bl Z
 3894 1689 M (30°) bl Z
 4445 1689 M (60°) bl Z
@@ -5139,12 +5139,12 @@ P S
 200 F0
 (Sinusoidal) bc Z
 35 1689 M 117 F0
-(­180°) bl Z
-587 1689 M (­150°) bl Z
-1138 1689 M (­120°) bl Z
-1689 1689 M (­90°) bl Z
-2240 1689 M (­60°) bl Z
-2791 1689 M (­30°) bl Z
+(-180°) bl Z
+587 1689 M (-150°) bl Z
+1138 1689 M (-120°) bl Z
+1689 1689 M (-90°) bl Z
+2240 1689 M (-60°) bl Z
+2791 1689 M (-30°) bl Z
 3342 1689 M (0°) bl Z
 3894 1689 M (30°) bl Z
 4445 1689 M (60°) bl Z

--- a/test/psbasemap/azim_global.sh
+++ b/test/psbasemap/azim_global.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Test new implementation of internal latitude annotations for azimuthal maps
-gmt begin azim_global png
+gmt begin azim_global ps
 	gmt set FONT_ANNOT_PRIMARY 7p MAP_TICK_LENGTH_PRIMARY 3p MAP_ANNOT_OFFSET_PRIMARY 3p FONT_TITLE 12p MAP_FRAME_WIDTH 3p
 	gmt subplot begin 3x1 -Fs14c/7c -BWSNE -Ba30fg30 -M12p -X3c -Y1c
 		gmt basemap -Rd -JH0/? -c -B+t"Hammer"+i30

--- a/test/psbasemap/azim_global.sh
+++ b/test/psbasemap/azim_global.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Test new implementation of internal latitude annotations for azimuthal maps
+gmt begin azim_global png
+	gmt set FONT_ANNOT_PRIMARY 7p MAP_TICK_LENGTH_PRIMARY 3p MAP_ANNOT_OFFSET_PRIMARY 3p FONT_TITLE 12p MAP_FRAME_WIDTH 3p
+	gmt subplot begin 3x1 -Fs14c/7c -BWSNE -Ba30fg30 -M12p -X3c -Y1c
+		gmt basemap -Rd -JH0/? -c -B+t"Hammer"+i30
+		gmt basemap -Rg -JW0/? -c -B+t"Mollweide"+i
+		gmt basemap -JI0/? -c -B+t"Sinusoidal"+i
+	gmt subplot end
+gmt end show

--- a/test/psbasemap/azim_polar.ps
+++ b/test/psbasemap/azim_polar.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.1.0_12f0465-dirty_2020.03.04 [64-bit] Document from psxy
+%%Title: GMT v6.1.0_2600522_2020.03.04 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Wed Mar  4 17:59:28 2020
+%%CreationDate: Wed Mar  4 21:56:24 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -1478,10 +1478,11 @@ N 1890 1890 1940 0 360 arc S
 1890 3780 PSL_H_y add M
 200 F0
 (North Pole) bc Z
-1925 516 M 117 F0
-(30°) tl Z
-1925 1160 M (60°) tl Z
-1925 1854 M (90°) tl Z
+1854 35 M 117 F0
+(0°) br Z
+1854 587 M (30°) br Z
+1854 1231 M (60°) br Z
+1854 1925 M (90°) br Z
 1890 -100 M (0°) tc Z
 2885 167 M V 30 R (30°) tc Z U
 3613 895 M V 60 R (60°) tc Z U
@@ -2046,9 +2047,9 @@ N 1890 1890 588 0 360 arc S
 1890 3780 PSL_H_y add M
 200 F0
 (North Annulus) bc Z
-3397 1925 M 117 F0
-V -90 R (30°) br Z U
-2688 1925 M V -90 R (60°) br Z U
+3326 1854 M 117 F0
+V -90 R (30°) tl Z U
+2618 1854 M V -90 R (60°) tl Z U
 1890 -100 M (0°) tc Z
 1890 1351 M (0°) bc Z
 2885 167 M V 30 R (30°) tc Z U
@@ -2890,10 +2891,11 @@ N 1890 1890 1940 0 360 arc S
 1890 3780 PSL_H_y add M
 200 F0
 (South Pole) bc Z
-1861 1849 M 117 F0
-V 90 R (­90°) br Z U
-1167 1849 M V 90 R (­60°) br Z U
-523 1849 M V 90 R (­30°) br Z U
+1918 1931 M 117 F0
+V -90 R (­90°) br Z U
+1224 1931 M V -90 R (­60°) br Z U
+580 1931 M V -90 R (­30°) br Z U
+29 1931 M V -90 R (0°) br Z U
 1890 3880 M (0°) bc Z
 2885 3613 M V -30 R (30°) bc Z U
 3613 2885 M V -60 R (60°) bc Z U
@@ -3462,9 +3464,9 @@ N 1890 1890 1940 0 360 arc S
 1890 3780 PSL_H_y add M
 200 F0
 (South Annulus) bc Z
-1849 2682 M 117 F0
-(­60°) br Z
-1849 3390 M (­30°) br Z
+1931 2624 M 117 F0
+(­60°) tl Z
+1931 3333 M (­30°) tl Z
 1890 2428 M (0°) tc Z
 1890 3880 M (0°) bc Z
 2159 2356 M V -30 R (30°) tc Z U

--- a/test/psbasemap/azim_polar.ps
+++ b/test/psbasemap/azim_polar.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.1.0_2600522_2020.03.04 [64-bit] Document from psxy
+%%Title: GMT v6.1.0_4d56427_2020.03.05 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Wed Mar  4 21:56:24 2020
+%%CreationDate: Thu Mar  5 09:30:40 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -115,39 +115,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -1472,29 +1472,29 @@ N 1890 1890 1915 -105 -90 arc S
 5 W
 N 1890 1890 1890 0 360 arc S
 N 1890 1890 1940 0 360 arc S
-/PSL_H_y 333 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/PSL_H_y 333 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 117 F0
-(100∞) sh add def
+(100è) sh add def
 1890 3780 PSL_H_y add M
 200 F0
 (North Pole) bc Z
 1854 35 M 117 F0
-(0∞) br Z
-1854 587 M (30∞) br Z
-1854 1231 M (60∞) br Z
-1854 1925 M (90∞) br Z
-1890 -100 M (0∞) tc Z
-2885 167 M V 30 R (30∞) tc Z U
-3613 895 M V 60 R (60∞) tc Z U
-3880 1890 M V 90 R (90∞) tc Z U
-3613 2885 M V -60 R (120∞) bc Z U
-2885 3613 M V -30 R (150∞) bc Z U
-1890 3880 M (180∞) bc Z
-895 3613 M V 30 R (-150∞) bc Z U
-167 2885 M V 60 R (-120∞) bc Z U
--100 1890 M V 90 R (-90∞) bc Z U
-167 895 M V -60 R (-60∞) tc Z U
-895 167 M V -30 R (-30∞) tc Z U
+(0è) br Z
+1854 587 M (30è) br Z
+1854 1231 M (60è) br Z
+1854 1925 M (90è) br Z
+1890 -100 M (0è) tc Z
+2885 167 M V 30 R (30è) tc Z U
+3613 895 M V 60 R (60è) tc Z U
+3880 1890 M V 90 R (90è) tc Z U
+3613 2885 M V -60 R (120è) bc Z U
+2885 3613 M V -30 R (150è) bc Z U
+1890 3880 M (180è) bc Z
+895 3613 M V 30 R (î150è) bc Z U
+167 2885 M V 60 R (î120è) bc Z U
+-100 1890 M V 90 R (î90è) bc Z U
+167 895 M V -60 R (î60è) tc Z U
+895 167 M V -30 R (î30è) tc Z U
 %%EndObject
 0 -4751 TM
 PSL_plot_completion /PSL_plot_completion {} def
@@ -2041,39 +2041,39 @@ N 1890 1890 1890 0 360 arc S
 N 1890 1890 1940 0 360 arc S
 N 1890 1890 638 0 360 arc S
 N 1890 1890 588 0 360 arc S
-/PSL_H_y 333 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/PSL_H_y 333 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 117 F0
-(100∞) sh add def
+(100è) sh add def
 1890 3780 PSL_H_y add M
 200 F0
 (North Annulus) bc Z
 3326 1854 M 117 F0
-V -90 R (30∞) tl Z U
-2618 1854 M V -90 R (60∞) tl Z U
-1890 -100 M (0∞) tc Z
-1890 1351 M (0∞) bc Z
-2885 167 M V 30 R (30∞) tc Z U
-2159 1423 M V 30 R (30∞) bc Z U
-3613 895 M V 60 R (60∞) tc Z U
-2356 1621 M V 60 R (60∞) bc Z U
-3880 1890 M V 90 R (90∞) tc Z U
-2428 1890 M V 90 R (90∞) bc Z U
-3613 2885 M V -60 R (120∞) bc Z U
-2356 2159 M V -60 R (120∞) tc Z U
-2885 3613 M V -30 R (150∞) bc Z U
-2159 2356 M V -30 R (150∞) tc Z U
-1890 3880 M (180∞) bc Z
-1890 2428 M (180∞) tc Z
-895 3613 M V 30 R (-150∞) bc Z U
-1621 2356 M V 30 R (-150∞) tc Z U
-167 2885 M V 60 R (-120∞) bc Z U
-1423 2159 M V 60 R (-120∞) tc Z U
--100 1890 M V 90 R (-90∞) bc Z U
-1351 1890 M V 90 R (-90∞) tc Z U
-167 895 M V -60 R (-60∞) tc Z U
-1423 1621 M V -60 R (-60∞) bc Z U
-895 167 M V -30 R (-30∞) tc Z U
-1621 1423 M V -30 R (-30∞) bc Z U
+V -90 R (30è) tl Z U
+2618 1854 M V -90 R (60è) tl Z U
+1890 -100 M (0è) tc Z
+1890 1351 M (0è) bc Z
+2885 167 M V 30 R (30è) tc Z U
+2159 1423 M V 30 R (30è) bc Z U
+3613 895 M V 60 R (60è) tc Z U
+2356 1621 M V 60 R (60è) bc Z U
+3880 1890 M V 90 R (90è) tc Z U
+2428 1890 M V 90 R (90è) bc Z U
+3613 2885 M V -60 R (120è) bc Z U
+2356 2159 M V -60 R (120è) tc Z U
+2885 3613 M V -30 R (150è) bc Z U
+2159 2356 M V -30 R (150è) tc Z U
+1890 3880 M (180è) bc Z
+1890 2428 M (180è) tc Z
+895 3613 M V 30 R (î150è) bc Z U
+1621 2356 M V 30 R (î150è) tc Z U
+167 2885 M V 60 R (î120è) bc Z U
+1423 2159 M V 60 R (î120è) tc Z U
+-100 1890 M V 90 R (î90è) bc Z U
+1351 1890 M V 90 R (î90è) tc Z U
+167 895 M V -60 R (î60è) tc Z U
+1423 1621 M V -60 R (î60è) bc Z U
+895 167 M V -30 R (î30è) tc Z U
+1621 1423 M V -30 R (î30è) bc Z U
 %%EndObject
 -4751 -4751 TM
 PSL_plot_completion /PSL_plot_completion {} def
@@ -2885,29 +2885,29 @@ N 1890 1890 1915 90 105 arc S
 5 W
 N 1890 1890 1890 0 360 arc S
 N 1890 1890 1940 0 360 arc S
-/PSL_H_y 333 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/PSL_H_y 333 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 117 F0
-(100∞) sh add def
+(100è) sh add def
 1890 3780 PSL_H_y add M
 200 F0
 (South Pole) bc Z
 1918 1931 M 117 F0
-V -90 R (≠90∞) br Z U
-1224 1931 M V -90 R (≠60∞) br Z U
-580 1931 M V -90 R (≠30∞) br Z U
-29 1931 M V -90 R (0∞) br Z U
-1890 3880 M (0∞) bc Z
-2885 3613 M V -30 R (30∞) bc Z U
-3613 2885 M V -60 R (60∞) bc Z U
-3880 1890 M V 90 R (90∞) tc Z U
-3613 895 M V 60 R (120∞) tc Z U
-2885 167 M V 30 R (150∞) tc Z U
-1890 -100 M (180∞) tc Z
-895 167 M V -30 R (-150∞) tc Z U
-167 895 M V -60 R (-120∞) tc Z U
--100 1890 M V 90 R (-90∞) bc Z U
-167 2885 M V 60 R (-60∞) bc Z U
-895 3613 M V 30 R (-30∞) bc Z U
+V -90 R (î90è) br Z U
+1224 1931 M V -90 R (î60è) br Z U
+580 1931 M V -90 R (î30è) br Z U
+29 1931 M V -90 R (0è) br Z U
+1890 3880 M (0è) bc Z
+2885 3613 M V -30 R (30è) bc Z U
+3613 2885 M V -60 R (60è) bc Z U
+3880 1890 M V 90 R (90è) tc Z U
+3613 895 M V 60 R (120è) tc Z U
+2885 167 M V 30 R (150è) tc Z U
+1890 -100 M (180è) tc Z
+895 167 M V -30 R (î150è) tc Z U
+167 895 M V -60 R (î120è) tc Z U
+-100 1890 M V 90 R (î90è) bc Z U
+167 2885 M V 60 R (î60è) bc Z U
+895 3613 M V 30 R (î30è) bc Z U
 %%EndObject
 0 0 TM
 PSL_plot_completion /PSL_plot_completion {} def
@@ -3458,39 +3458,39 @@ N 1890 1890 638 0 360 arc S
 N 1890 1890 588 0 360 arc S
 N 1890 1890 1890 0 360 arc S
 N 1890 1890 1940 0 360 arc S
-/PSL_H_y 333 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/PSL_H_y 333 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 117 F0
-(100∞) sh add def
+(100è) sh add def
 1890 3780 PSL_H_y add M
 200 F0
 (South Annulus) bc Z
 1931 2624 M 117 F0
-(≠60∞) tl Z
-1931 3333 M (≠30∞) tl Z
-1890 2428 M (0∞) tc Z
-1890 3880 M (0∞) bc Z
-2159 2356 M V -30 R (30∞) tc Z U
-2885 3613 M V -30 R (30∞) bc Z U
-2356 2159 M V -60 R (60∞) tc Z U
-3613 2885 M V -60 R (60∞) bc Z U
-2428 1890 M V 90 R (90∞) bc Z U
-3880 1890 M V 90 R (90∞) tc Z U
-2356 1621 M V 60 R (120∞) bc Z U
-3613 895 M V 60 R (120∞) tc Z U
-2159 1423 M V 30 R (150∞) bc Z U
-2885 167 M V 30 R (150∞) tc Z U
-1890 1351 M V 2.84e-14 R (180∞) bc Z U
-1890 -100 M (180∞) tc Z
-1621 1423 M V -30 R (-150∞) bc Z U
-895 167 M V -30 R (-150∞) tc Z U
-1423 1621 M V -60 R (-120∞) bc Z U
-167 895 M V -60 R (-120∞) tc Z U
-1351 1890 M V 90 R (-90∞) tc Z U
--100 1890 M V 90 R (-90∞) bc Z U
-1423 2159 M V 60 R (-60∞) tc Z U
-167 2885 M V 60 R (-60∞) bc Z U
-1621 2356 M V 30 R (-30∞) tc Z U
-895 3613 M V 30 R (-30∞) bc Z U
+(î60è) tl Z
+1931 3333 M (î30è) tl Z
+1890 2428 M (0è) tc Z
+1890 3880 M (0è) bc Z
+2159 2356 M V -30 R (30è) tc Z U
+2885 3613 M V -30 R (30è) bc Z U
+2356 2159 M V -60 R (60è) tc Z U
+3613 2885 M V -60 R (60è) bc Z U
+2428 1890 M V 90 R (90è) bc Z U
+3880 1890 M V 90 R (90è) tc Z U
+2356 1621 M V 60 R (120è) bc Z U
+3613 895 M V 60 R (120è) tc Z U
+2159 1423 M V 30 R (150è) bc Z U
+2885 167 M V 30 R (150è) tc Z U
+1890 1351 M V 2.84e-14 R (180è) bc Z U
+1890 -100 M (180è) tc Z
+1621 1423 M V -30 R (î150è) bc Z U
+895 167 M V -30 R (î150è) tc Z U
+1423 1621 M V -60 R (î120è) bc Z U
+167 895 M V -60 R (î120è) tc Z U
+1351 1890 M V 90 R (î90è) tc Z U
+-100 1890 M V 90 R (î90è) bc Z U
+1423 2159 M V 60 R (î60è) tc Z U
+167 2885 M V 60 R (î60è) bc Z U
+1621 2356 M V 30 R (î30è) tc Z U
+895 3613 M V 30 R (î30è) bc Z U
 %%EndObject
 -4751 0 TM
 PSL_plot_completion /PSL_plot_completion {} def

--- a/test/psbasemap/azim_polar.ps
+++ b/test/psbasemap/azim_polar.ps
@@ -1,0 +1,3504 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.1.0_12f0465-dirty_2020.03.04 [64-bit] Document from psxy
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Wed Mar  4 17:59:28 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+709 1200 TM
+% PostScript produced by:
+%@GMT: gmt psxy -R0/7.10899/0/7.10899 -Jx1i -T -Xr0.590551i -Yr1i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 7.10899000 0.00000000 7.10899000 0.000 7.109 0.000 7.109 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 4751 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/0/90 -JA0/90/3.1496i '-BWENS+tNorth Pole+i' -Bxa30fg30 -Bya30fg30 -Xa0i -Ya3.9594i
+%@PROJ: laea 0.00000000 360.00000000 0.00000000 90.00000000 -9009964.761 9009964.761 -9009964.761 9009964.761 +proj=laea +lat_0=90 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+1890 0 M
+0 1539 D
+S
+2835 253 M
+-770 1333 D
+S
+3526 945 M
+-1333 770 D
+S
+3780 1890 M
+-1540 0 D
+S
+3526 2835 M
+-1333 -770 D
+S
+2835 3526 M
+-770 -1333 D
+S
+1890 3780 M
+0 -1540 D
+S
+945 3526 M
+770 -1333 D
+S
+253 2835 M
+1333 -770 D
+S
+0 1890 M
+1539 0 D
+S
+253 945 M
+1333 770 D
+S
+945 253 M
+770 1333 D
+S
+1890 1539 M
+0 351 D
+S
+2240 1890 M
+-350 0 D
+S
+1890 2240 M
+0 -350 D
+S
+1539 1890 M
+351 0 D
+S
+1890 1539 M
+50 4 D
+50 11 D
+48 18 D
+38 21 D
+30 21 D
+32 29 D
+20 21 D
+26 35 D
+24 45 D
+14 33 D
+11 42 D
+5 36 D
+2 29 D
+-1 37 D
+-8 50 D
+-13 41 D
+-11 27 D
+-14 26 D
+-15 24 D
+-18 24 D
+-19 21 D
+-27 25 D
+-35 26 D
+-45 24 D
+-27 11 D
+-56 15 D
+-43 5 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-8 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-6 -2 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-13 -7 D
+-12 -7 D
+-18 -12 D
+-29 -23 D
+-31 -30 D
+-19 -23 D
+-27 -42 D
+-19 -40 D
+-17 -55 D
+-6 -43 D
+-2 -37 D
+4 -43 D
+7 -36 D
+13 -41 D
+11 -27 D
+18 -32 D
+21 -30 D
+23 -27 D
+32 -30 D
+48 -33 D
+39 -19 D
+48 -16 D
+51 -9 D
+P S
+1890 0 M
+68 1 D
+108 7 D
+87 10 D
+97 17 D
+29 5 D
+95 23 D
+85 25 D
+83 28 D
+73 29 D
+72 31 D
+62 30 D
+86 47 D
+50 30 D
+66 43 D
+72 51 D
+61 48 D
+82 71 D
+28 27 D
+15 13 D
+68 70 D
+71 82 D
+42 53 D
+47 64 D
+38 56 D
+56 92 D
+38 69 D
+38 79 D
+35 81 D
+28 74 D
+28 83 D
+28 104 D
+21 96 D
+14 87 D
+14 127 D
+4 98 D
+1 39 D
+-2 78 D
+-5 78 D
+-13 117 D
+-19 106 D
+-17 77 D
+-32 113 D
+-32 92 D
+-33 82 D
+-36 80 D
+-36 70 D
+-19 35 D
+-50 84 D
+-38 57 D
+-46 64 D
+-23 31 D
+-13 15 D
+-43 53 D
+-46 51 D
+-54 56 D
+-64 61 D
+-67 58 D
+-31 24 D
+-15 13 D
+-71 52 D
+-49 33 D
+-49 31 D
+-76 45 D
+-70 36 D
+-80 37 D
+-63 27 D
+-73 27 D
+-75 25 D
+-104 28 D
+-96 21 D
+-87 14 D
+-126 14 D
+-98 4 D
+-10 0 D
+-10 0 D
+-19 1 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-10 -2 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -2 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-10 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-17 -8 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-17 -9 D
+-17 -9 D
+-18 -9 D
+-17 -9 D
+-17 -10 D
+-17 -10 D
+-17 -10 D
+-17 -10 D
+-17 -10 D
+-24 -16 D
+-17 -10 D
+-24 -16 D
+-24 -17 D
+-24 -17 D
+-32 -24 D
+-31 -24 D
+-38 -30 D
+-59 -52 D
+-43 -40 D
+-49 -48 D
+-13 -15 D
+-27 -28 D
+-70 -82 D
+-48 -62 D
+-56 -80 D
+-52 -83 D
+-20 -34 D
+-41 -78 D
+-42 -89 D
+-30 -72 D
+-30 -83 D
+-32 -103 D
+-21 -85 D
+-10 -48 D
+-13 -68 D
+-14 -107 D
+-6 -68 D
+-4 -117 D
+1 -79 D
+7 -107 D
+10 -88 D
+17 -97 D
+5 -28 D
+18 -77 D
+27 -94 D
+31 -93 D
+29 -73 D
+31 -71 D
+39 -79 D
+43 -78 D
+25 -42 D
+32 -49 D
+28 -40 D
+5 -9 D
+77 -101 D
+32 -37 D
+32 -37 D
+61 -64 D
+49 -48 D
+36 -33 D
+53 -44 D
+22 -19 D
+86 -65 D
+25 -16 D
+40 -28 D
+92 -56 D
+104 -55 D
+89 -41 D
+100 -39 D
+112 -37 D
+104 -27 D
+48 -11 D
+116 -20 D
+107 -12 D
+127 -6 D
+P S
+1890 551 M
+90 3 D
+69 7 D
+48 6 D
+75 14 D
+68 17 D
+59 17 D
+79 28 D
+51 22 D
+63 29 D
+61 33 D
+59 36 D
+41 27 D
+45 33 D
+49 38 D
+15 14 D
+11 9 D
+51 47 D
+58 60 D
+41 47 D
+25 33 D
+13 16 D
+17 23 D
+35 51 D
+53 90 D
+28 55 D
+26 57 D
+19 45 D
+25 72 D
+25 87 D
+16 74 D
+15 96 D
+7 97 D
+1 97 D
+-5 77 D
+-8 69 D
+-11 68 D
+-17 74 D
+-21 74 D
+-15 46 D
+-28 71 D
+-29 63 D
+-31 62 D
+-39 66 D
+-46 69 D
+-9 11 D
+-33 44 D
+-45 53 D
+-33 36 D
+-29 30 D
+-41 38 D
+-47 41 D
+-54 42 D
+-12 8 D
+-11 9 D
+-81 53 D
+-60 34 D
+-100 49 D
+-71 28 D
+-59 20 D
+-80 23 D
+-75 16 D
+-96 15 D
+-76 6 D
+-69 2 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-6 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+-6 -2 D
+-7 -3 D
+-6 -2 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+-13 -6 D
+-6 -2 D
+-13 -6 D
+-6 -2 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-12 -7 D
+-12 -6 D
+-12 -7 D
+-12 -7 D
+-12 -7 D
+-12 -7 D
+-12 -7 D
+-18 -12 D
+-17 -11 D
+-18 -12 D
+-17 -11 D
+-22 -17 D
+-17 -12 D
+-16 -13 D
+-27 -22 D
+-37 -32 D
+-35 -33 D
+-40 -39 D
+-42 -46 D
+-13 -16 D
+-35 -43 D
+-33 -45 D
+-24 -34 D
+-40 -65 D
+-27 -48 D
+-37 -75 D
+-11 -26 D
+-23 -58 D
+-27 -78 D
+-20 -74 D
+-17 -82 D
+-10 -61 D
+-8 -83 D
+-3 -97 D
+3 -83 D
+7 -69 D
+6 -49 D
+10 -54 D
+19 -81 D
+19 -67 D
+31 -85 D
+33 -76 D
+18 -38 D
+44 -78 D
+26 -42 D
+39 -57 D
+12 -17 D
+13 -16 D
+48 -59 D
+57 -61 D
+45 -44 D
+41 -37 D
+54 -43 D
+45 -33 D
+52 -35 D
+90 -52 D
+43 -22 D
+76 -34 D
+78 -29 D
+67 -21 D
+80 -20 D
+62 -11 D
+48 -8 D
+83 -8 D
+P S
+1890 1196 M
+50 1 D
+71 9 D
+50 11 D
+68 21 D
+60 25 D
+51 27 D
+18 12 D
+13 7 D
+41 29 D
+44 37 D
+36 35 D
+15 16 D
+45 56 D
+35 54 D
+11 19 D
+23 45 D
+24 60 D
+17 55 D
+12 57 D
+8 64 D
+2 57 D
+-1 36 D
+-5 50 D
+-8 50 D
+-16 63 D
+-14 41 D
+-25 59 D
+-24 45 D
+-27 43 D
+-25 35 D
+-42 49 D
+-52 50 D
+-33 27 D
+-47 33 D
+-31 19 D
+-51 26 D
+-47 20 D
+-61 20 D
+-56 13 D
+-57 8 D
+-51 4 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-8 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-8 -1 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -3 D
+-6 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-12 -7 D
+-13 -7 D
+-12 -7 D
+-13 -7 D
+-18 -12 D
+-18 -12 D
+-12 -8 D
+-11 -9 D
+-28 -23 D
+-11 -9 D
+-51 -50 D
+-42 -50 D
+-17 -24 D
+-16 -24 D
+-32 -56 D
+-24 -52 D
+-19 -54 D
+-17 -63 D
+-11 -64 D
+-4 -64 D
+1 -65 D
+6 -57 D
+13 -64 D
+23 -75 D
+32 -73 D
+14 -25 D
+30 -49 D
+30 -41 D
+28 -33 D
+45 -46 D
+27 -24 D
+58 -43 D
+49 -30 D
+51 -26 D
+67 -26 D
+77 -21 D
+71 -11 D
+50 -3 D
+P S
+8 W
+N 1890 0 M 0 -50 D S
+N 2835 253 M 25 -43 D S
+N 3526 945 M 44 -25 D S
+N 3780 1890 M 50 0 D S
+N 3526 2835 M 44 25 D S
+N 2835 3526 M 25 44 D S
+N 1890 3780 M 0 50 D S
+N 945 3526 M -25 44 D S
+N 253 2835 M -43 25 D S
+N 0 1890 M -50 0 D S
+N 253 945 M -43 -25 D S
+N 945 253 M -25 -43 D S
+N 1890 0 M 0 -50 D S
+50 W
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+N 1890 1890 1915 -90 -75 arc S
+1 A
+N 1890 1890 1915 -75 -60 arc S
+0 A
+N 1890 1890 1915 -60 -45 arc S
+1 A
+N 1890 1890 1915 -45 -30 arc S
+0 A
+N 1890 1890 1915 -30 -15 arc S
+1 A
+N 1890 1890 1915 -15 0 arc S
+0 A
+N 1890 1890 1915 0 15 arc S
+1 A
+N 1890 1890 1915 15 30 arc S
+0 A
+N 1890 1890 1915 30 45 arc S
+1 A
+N 1890 1890 1915 45 60 arc S
+0 A
+N 1890 1890 1915 60 75 arc S
+1 A
+N 1890 1890 1915 75 90 arc S
+0 A
+N 1890 1890 1915 90 105 arc S
+1 A
+N 1890 1890 1915 105 120 arc S
+0 A
+N 1890 1890 1915 120 135 arc S
+1 A
+N 1890 1890 1915 135 150 arc S
+0 A
+N 1890 1890 1915 150 165 arc S
+1 A
+N 1890 1890 1915 165 180 arc S
+0 A
+N 1890 1890 1915 180 195 arc S
+1 A
+N 1890 1890 1915 -165 -150 arc S
+0 A
+N 1890 1890 1915 -150 -135 arc S
+1 A
+N 1890 1890 1915 -135 -120 arc S
+0 A
+N 1890 1890 1915 -120 -105 arc S
+1 A
+N 1890 1890 1915 -105 -90 arc S
+0 A
+5 W
+N 1890 1890 1890 0 360 arc S
+N 1890 1890 1940 0 360 arc S
+/PSL_H_y 333 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+117 F0
+(100°) sh add def
+1890 3780 PSL_H_y add M
+200 F0
+(North Pole) bc Z
+1925 516 M 117 F0
+(30°) tl Z
+1925 1160 M (60°) tl Z
+1925 1854 M (90°) tl Z
+1890 -100 M (0°) tc Z
+2885 167 M V 30 R (30°) tc Z U
+3613 895 M V 60 R (60°) tc Z U
+3880 1890 M V 90 R (90°) tc Z U
+3613 2885 M V -60 R (120°) bc Z U
+2885 3613 M V -30 R (150°) bc Z U
+1890 3880 M (180°) bc Z
+895 3613 M V 30 R (-150°) bc Z U
+167 2885 M V 60 R (-120°) bc Z U
+-100 1890 M V 90 R (-90°) bc Z U
+167 895 M V -60 R (-60°) tc Z U
+895 167 M V -30 R (-30°) tc Z U
+%%EndObject
+0 -4751 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4751 4751 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/10/65 -JA0/90/3.1496i '-BWENS+tNorth Annulus+i90' -Bxa30fg30 -Bya30fg30 -Xa3.9594i -Ya3.9594i
+%@PROJ: laea 0.00000000 360.00000000 10.00000000 65.00000000 -8194139.417 8194139.417 -8194139.417 8194139.417 +proj=laea +lat_0=90 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+1890 0 M
+0 1251 D
+S
+2835 253 M
+-626 1084 D
+S
+3526 945 M
+-1083 626 D
+S
+3780 1890 M
+-1252 0 D
+S
+3526 2835 M
+-1083 -626 D
+S
+2835 3526 M
+-626 -1083 D
+S
+1890 3780 M
+0 -1252 D
+S
+945 3526 M
+626 -1083 D
+S
+253 2835 M
+1084 -626 D
+S
+0 1890 M
+1251 0 D
+S
+253 945 M
+1084 626 D
+S
+945 253 M
+626 1084 D
+S
+1890 418 M
+61 1 D
+83 6 D
+69 8 D
+82 15 D
+82 19 D
+66 19 D
+72 25 D
+92 38 D
+68 33 D
+74 41 D
+71 45 D
+56 39 D
+78 62 D
+45 40 D
+39 37 D
+5 6 D
+6 5 D
+15 17 D
+6 5 D
+20 23 D
+6 5 D
+73 88 D
+53 75 D
+33 51 D
+16 26 D
+40 74 D
+36 76 D
+29 70 D
+25 72 D
+31 111 D
+14 67 D
+11 67 D
+9 76 D
+5 84 D
+1 53 D
+-3 84 D
+-8 84 D
+-12 83 D
+-19 89 D
+-31 110 D
+-26 72 D
+-29 71 D
+-33 69 D
+-44 80 D
+-32 52 D
+-48 69 D
+-47 60 D
+-39 47 D
+-69 72 D
+-61 57 D
+-59 49 D
+-55 41 D
+-69 47 D
+-72 43 D
+-68 35 D
+-69 32 D
+-57 23 D
+-79 27 D
+-103 29 D
+-67 14 D
+-75 12 D
+-69 8 D
+-83 5 D
+-8 0 D
+-8 0 D
+-7 0 D
+-31 1 D
+-7 -1 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-7 -1 D
+-8 -1 D
+-8 0 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-7 -2 D
+-7 -1 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-8 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-13 -7 D
+-14 -7 D
+-13 -7 D
+-14 -7 D
+-13 -7 D
+-14 -8 D
+-13 -7 D
+-13 -8 D
+-13 -8 D
+-13 -8 D
+-13 -8 D
+-19 -13 D
+-19 -13 D
+-19 -13 D
+-24 -18 D
+-19 -13 D
+-30 -24 D
+-35 -29 D
+-23 -20 D
+-5 -6 D
+-23 -20 D
+-5 -6 D
+-17 -15 D
+-5 -6 D
+-6 -5 D
+-47 -50 D
+-50 -58 D
+-51 -66 D
+-51 -76 D
+-36 -59 D
+-39 -74 D
+-26 -55 D
+-27 -64 D
+-26 -71 D
+-28 -95 D
+-19 -82 D
+-17 -106 D
+-8 -83 D
+-3 -84 D
+1 -76 D
+6 -84 D
+8 -68 D
+15 -83 D
+17 -74 D
+21 -73 D
+28 -80 D
+41 -98 D
+38 -75 D
+26 -47 D
+44 -71 D
+35 -50 D
+37 -49 D
+44 -53 D
+30 -34 D
+6 -5 D
+15 -17 D
+6 -5 D
+21 -22 D
+6 -5 D
+5 -6 D
+17 -15 D
+5 -6 D
+69 -60 D
+55 -42 D
+31 -22 D
+50 -34 D
+65 -40 D
+75 -39 D
+55 -26 D
+92 -38 D
+79 -26 D
+74 -21 D
+74 -16 D
+53 -9 D
+53 -8 D
+91 -8 D
+P S
+1890 1126 M
+63 3 D
+47 5 D
+62 12 D
+61 17 D
+52 19 D
+44 19 D
+49 26 D
+34 20 D
+13 9 D
+26 18 D
+37 29 D
+42 37 D
+5 6 D
+6 5 D
+16 18 D
+6 5 D
+41 49 D
+49 71 D
+27 49 D
+20 43 D
+23 59 D
+18 61 D
+11 54 D
+7 47 D
+4 71 D
+-1 55 D
+-6 63 D
+-10 55 D
+-9 38 D
+-17 53 D
+-26 66 D
+-29 57 D
+-29 47 D
+-37 51 D
+-36 42 D
+-11 12 D
+-6 5 D
+-22 23 D
+-67 56 D
+-52 36 D
+-55 31 D
+-57 27 D
+-52 19 D
+-53 16 D
+-70 14 D
+-71 8 D
+-8 0 D
+-63 1 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-8 -2 D
+-7 -3 D
+-8 -2 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-14 -7 D
+-8 -3 D
+-14 -7 D
+-14 -8 D
+-13 -7 D
+-14 -8 D
+-14 -8 D
+-13 -9 D
+-20 -13 D
+-12 -10 D
+-13 -9 D
+-31 -25 D
+-41 -37 D
+-43 -47 D
+-35 -43 D
+-35 -52 D
+-35 -62 D
+-26 -58 D
+-18 -52 D
+-17 -61 D
+-11 -63 D
+-6 -55 D
+-2 -55 D
+4 -71 D
+10 -71 D
+17 -69 D
+15 -45 D
+14 -37 D
+27 -57 D
+36 -62 D
+32 -45 D
+46 -55 D
+33 -34 D
+6 -5 D
+5 -6 D
+49 -41 D
+44 -32 D
+68 -41 D
+57 -27 D
+37 -15 D
+60 -19 D
+54 -13 D
+63 -10 D
+55 -4 D
+P S
+8 W
+N 1890 0 M 0 -50 D S
+N 1890 1251 M 0 50 D S
+N 2835 253 M 25 -43 D S
+N 2209 1337 M -25 43 D S
+N 3526 945 M 44 -25 D S
+N 2443 1571 M -44 25 D S
+N 3780 1890 M 50 0 D S
+N 2528 1890 M -50 0 D S
+N 3526 2835 M 44 25 D S
+N 2443 2209 M -44 -25 D S
+N 2835 3526 M 25 44 D S
+N 2209 2443 M -25 -44 D S
+N 1890 3780 M 0 50 D S
+N 1890 2528 M 0 -50 D S
+N 945 3526 M -25 44 D S
+N 1571 2443 M 25 -44 D S
+N 253 2835 M -43 25 D S
+N 1337 2209 M 43 -25 D S
+N 0 1890 M -50 0 D S
+N 1251 1890 M 50 0 D S
+N 253 945 M -43 -25 D S
+N 1337 1571 M 43 25 D S
+N 945 253 M -25 -43 D S
+N 1571 1337 M 25 43 D S
+N 1890 0 M 0 -50 D S
+N 1890 1251 M 0 50 D S
+50 W
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+N 1890 1890 1915 -90 -75 arc S
+N 1890 1890 613 -90 -75 arc S
+1 A
+N 1890 1890 1915 -75 -60 arc S
+N 1890 1890 613 -75 -60 arc S
+0 A
+N 1890 1890 1915 -60 -45 arc S
+N 1890 1890 613 -60 -45 arc S
+1 A
+N 1890 1890 1915 -45 -30 arc S
+N 1890 1890 613 -45 -30 arc S
+0 A
+N 1890 1890 1915 -30 -15 arc S
+N 1890 1890 613 -30 -15 arc S
+1 A
+N 1890 1890 1915 -15 0 arc S
+N 1890 1890 613 -15 0 arc S
+0 A
+N 1890 1890 1915 0 15 arc S
+N 1890 1890 613 0 15 arc S
+1 A
+N 1890 1890 1915 15 30 arc S
+N 1890 1890 613 15 30 arc S
+0 A
+N 1890 1890 1915 30 45 arc S
+N 1890 1890 613 30 45 arc S
+1 A
+N 1890 1890 1915 45 60 arc S
+N 1890 1890 613 45 60 arc S
+0 A
+N 1890 1890 1915 60 75 arc S
+N 1890 1890 613 60 75 arc S
+1 A
+N 1890 1890 1915 75 90 arc S
+N 1890 1890 613 75 90 arc S
+0 A
+N 1890 1890 1915 90 105 arc S
+N 1890 1890 613 90 105 arc S
+1 A
+N 1890 1890 1915 105 120 arc S
+N 1890 1890 613 105 120 arc S
+0 A
+N 1890 1890 1915 120 135 arc S
+N 1890 1890 613 120 135 arc S
+1 A
+N 1890 1890 1915 135 150 arc S
+N 1890 1890 613 135 150 arc S
+0 A
+N 1890 1890 1915 150 165 arc S
+N 1890 1890 613 150 165 arc S
+1 A
+N 1890 1890 1915 165 180 arc S
+N 1890 1890 613 165 180 arc S
+0 A
+N 1890 1890 1915 180 195 arc S
+N 1890 1890 613 180 195 arc S
+1 A
+N 1890 1890 1915 -165 -150 arc S
+N 1890 1890 613 -165 -150 arc S
+0 A
+N 1890 1890 1915 -150 -135 arc S
+N 1890 1890 613 -150 -135 arc S
+1 A
+N 1890 1890 1915 -135 -120 arc S
+N 1890 1890 613 -135 -120 arc S
+0 A
+N 1890 1890 1915 -120 -105 arc S
+N 1890 1890 613 -120 -105 arc S
+1 A
+N 1890 1890 1915 -105 -90 arc S
+N 1890 1890 613 -105 -90 arc S
+0 A
+5 W
+N 1890 1890 1890 0 360 arc S
+N 1890 1890 1940 0 360 arc S
+N 1890 1890 638 0 360 arc S
+N 1890 1890 588 0 360 arc S
+/PSL_H_y 333 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+117 F0
+(100°) sh add def
+1890 3780 PSL_H_y add M
+200 F0
+(North Annulus) bc Z
+3397 1925 M 117 F0
+V -90 R (30°) br Z U
+2688 1925 M V -90 R (60°) br Z U
+1890 -100 M (0°) tc Z
+1890 1351 M (0°) bc Z
+2885 167 M V 30 R (30°) tc Z U
+2159 1423 M V 30 R (30°) bc Z U
+3613 895 M V 60 R (60°) tc Z U
+2356 1621 M V 60 R (60°) bc Z U
+3880 1890 M V 90 R (90°) tc Z U
+2428 1890 M V 90 R (90°) bc Z U
+3613 2885 M V -60 R (120°) bc Z U
+2356 2159 M V -60 R (120°) tc Z U
+2885 3613 M V -30 R (150°) bc Z U
+2159 2356 M V -30 R (150°) tc Z U
+1890 3880 M (180°) bc Z
+1890 2428 M (180°) tc Z
+895 3613 M V 30 R (-150°) bc Z U
+1621 2356 M V 30 R (-150°) tc Z U
+167 2885 M V 60 R (-120°) bc Z U
+1423 2159 M V 60 R (-120°) tc Z U
+-100 1890 M V 90 R (-90°) bc Z U
+1351 1890 M V 90 R (-90°) tc Z U
+167 895 M V -60 R (-60°) tc Z U
+1423 1621 M V -60 R (-60°) bc Z U
+895 167 M V -30 R (-30°) tc Z U
+1621 1423 M V -30 R (-30°) bc Z U
+%%EndObject
+-4751 -4751 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/-90/0 -JA0/-90/3.1496i '-BWENS+tSouth Pole+i-90' -Bxa30fg30 -Bya30fg30 -Xa0i -Ya0i
+%@PROJ: laea 0.00000000 360.00000000 -90.00000000 0.00000000 -9009964.761 9009964.761 -9009964.761 9009964.761 +proj=laea +lat_0=-90 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+1890 2240 M
+0 1540 D
+S
+2065 2193 M
+770 1333 D
+S
+2193 2065 M
+1333 770 D
+S
+2240 1890 M
+1540 0 D
+S
+2193 1715 M
+1333 -770 D
+S
+2065 1586 M
+770 -1333 D
+S
+1890 1539 M
+0 -1539 D
+S
+1715 1586 M
+-770 -1333 D
+S
+1586 1715 M
+-1333 -770 D
+S
+1539 1890 M
+-1539 0 D
+S
+1586 2065 M
+-1333 770 D
+S
+1715 2193 M
+-770 1333 D
+S
+1890 1890 M
+0 350 D
+S
+1890 1890 M
+350 0 D
+S
+1890 1890 M
+0 -351 D
+S
+1890 1890 M
+-351 0 D
+S
+1890 2240 M
+36 -2 D
+43 -7 D
+49 -15 D
+39 -18 D
+31 -19 D
+18 -13 D
+32 -29 D
+29 -33 D
+21 -30 D
+20 -38 D
+14 -34 D
+11 -42 D
+5 -29 D
+2 -36 D
+-1 -36 D
+-8 -50 D
+-13 -42 D
+-11 -27 D
+-25 -44 D
+-31 -40 D
+-15 -16 D
+-16 -15 D
+-23 -18 D
+-18 -12 D
+-13 -8 D
+-12 -7 D
+-7 -3 D
+-13 -6 D
+-13 -6 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-8 -1 D
+-36 2 D
+-50 8 D
+-42 13 D
+-52 25 D
+-42 29 D
+-32 29 D
+-20 22 D
+-17 23 D
+-23 37 D
+-20 47 D
+-13 49 D
+-4 21 D
+-3 51 D
+3 36 D
+6 36 D
+15 49 D
+11 26 D
+18 32 D
+25 36 D
+24 27 D
+33 29 D
+30 21 D
+31 17 D
+41 17 D
+49 13 D
+50 6 D
+P S
+1890 2584 M
+57 -2 D
+50 -6 D
+50 -10 D
+55 -15 D
+54 -20 D
+46 -21 D
+38 -21 D
+43 -27 D
+46 -34 D
+32 -29 D
+41 -40 D
+46 -56 D
+36 -54 D
+14 -25 D
+26 -51 D
+21 -54 D
+17 -55 D
+13 -63 D
+7 -57 D
+2 -51 D
+-1 -43 D
+-5 -50 D
+-8 -50 D
+-14 -56 D
+-16 -47 D
+-19 -47 D
+-30 -57 D
+-19 -31 D
+-24 -36 D
+-46 -55 D
+-30 -31 D
+-49 -43 D
+-23 -17 D
+-23 -17 D
+-12 -8 D
+-13 -7 D
+-12 -8 D
+-13 -7 D
+-12 -7 D
+-7 -3 D
+-12 -6 D
+-13 -7 D
+-7 -3 D
+-7 -3 D
+-6 -2 D
+-7 -3 D
+-13 -6 D
+-7 -2 D
+-7 -3 D
+-6 -2 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 0 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-7 0 D
+-57 5 D
+-57 9 D
+-83 23 D
+-74 30 D
+-57 31 D
+-42 27 D
+-46 35 D
+-37 34 D
+-45 47 D
+-35 45 D
+-25 36 D
+-25 44 D
+-13 25 D
+-26 60 D
+-25 82 D
+-14 78 D
+-4 65 D
+1 65 D
+6 57 D
+13 63 D
+16 55 D
+10 28 D
+29 65 D
+25 44 D
+19 31 D
+17 23 D
+41 50 D
+45 46 D
+16 15 D
+34 27 D
+23 17 D
+42 27 D
+32 18 D
+25 13 D
+53 23 D
+55 18 D
+56 14 D
+50 8 D
+50 4 D
+P S
+1890 3228 M
+62 -1 D
+76 -6 D
+96 -13 D
+75 -16 D
+61 -16 D
+79 -25 D
+71 -28 D
+63 -29 D
+62 -31 D
+66 -39 D
+69 -46 D
+11 -9 D
+44 -33 D
+53 -45 D
+36 -33 D
+30 -29 D
+38 -41 D
+41 -47 D
+42 -54 D
+8 -12 D
+9 -11 D
+53 -81 D
+34 -60 D
+49 -100 D
+28 -71 D
+20 -59 D
+23 -80 D
+16 -75 D
+15 -96 D
+6 -76 D
+2 -69 D
+-1 -70 D
+-6 -76 D
+-13 -96 D
+-16 -75 D
+-18 -67 D
+-16 -53 D
+-27 -71 D
+-25 -58 D
+-30 -62 D
+-52 -90 D
+-42 -64 D
+-17 -22 D
+-12 -17 D
+-13 -16 D
+-35 -43 D
+-47 -51 D
+-44 -45 D
+-46 -42 D
+-16 -13 D
+-27 -22 D
+-22 -17 D
+-22 -17 D
+-17 -12 D
+-17 -12 D
+-17 -12 D
+-12 -7 D
+-12 -8 D
+-17 -11 D
+-12 -7 D
+-12 -7 D
+-12 -7 D
+-12 -7 D
+-12 -6 D
+-12 -7 D
+-7 -3 D
+-12 -7 D
+-12 -6 D
+-7 -3 D
+-12 -6 D
+-13 -6 D
+-12 -6 D
+-7 -2 D
+-12 -6 D
+-7 -3 D
+-6 -3 D
+-6 -2 D
+-7 -3 D
+-6 -2 D
+-7 -3 D
+-6 -3 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+-6 -2 D
+-7 -3 D
+-6 -2 D
+-7 -2 D
+-6 -3 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -3 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -1 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-6 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-76 3 D
+-69 7 D
+-49 6 D
+-54 10 D
+-81 19 D
+-67 19 D
+-85 31 D
+-76 33 D
+-38 18 D
+-78 44 D
+-42 26 D
+-57 39 D
+-17 12 D
+-16 13 D
+-59 48 D
+-61 57 D
+-44 45 D
+-37 41 D
+-43 54 D
+-33 45 D
+-35 52 D
+-52 90 D
+-22 43 D
+-34 76 D
+-29 78 D
+-21 67 D
+-20 80 D
+-11 62 D
+-8 48 D
+-8 83 D
+-3 97 D
+3 83 D
+7 69 D
+6 48 D
+14 75 D
+17 68 D
+17 59 D
+28 79 D
+22 51 D
+29 63 D
+33 61 D
+36 59 D
+27 41 D
+33 45 D
+38 49 D
+14 15 D
+9 11 D
+47 51 D
+60 58 D
+47 41 D
+33 25 D
+16 13 D
+23 17 D
+51 35 D
+90 53 D
+55 28 D
+57 26 D
+45 19 D
+72 25 D
+87 25 D
+74 16 D
+96 15 D
+97 7 D
+P S
+1890 3780 M
+78 -2 D
+78 -5 D
+117 -13 D
+106 -19 D
+77 -17 D
+113 -32 D
+92 -32 D
+82 -33 D
+80 -36 D
+70 -36 D
+35 -19 D
+84 -50 D
+57 -38 D
+64 -46 D
+31 -23 D
+15 -13 D
+53 -43 D
+51 -46 D
+56 -54 D
+61 -64 D
+58 -67 D
+24 -31 D
+13 -15 D
+52 -71 D
+33 -49 D
+31 -49 D
+45 -76 D
+36 -70 D
+37 -80 D
+27 -63 D
+27 -73 D
+25 -75 D
+28 -104 D
+21 -96 D
+14 -87 D
+14 -126 D
+4 -98 D
+1 -39 D
+-2 -79 D
+-6 -88 D
+-12 -107 D
+-19 -106 D
+-17 -76 D
+-21 -76 D
+-23 -75 D
+-38 -101 D
+-51 -116 D
+-36 -70 D
+-39 -68 D
+-30 -50 D
+-38 -57 D
+-46 -64 D
+-36 -47 D
+-24 -30 D
+-65 -74 D
+-75 -77 D
+-15 -13 D
+-28 -27 D
+-52 -45 D
+-38 -31 D
+-31 -24 D
+-31 -23 D
+-24 -18 D
+-24 -16 D
+-24 -17 D
+-17 -11 D
+-16 -10 D
+-17 -11 D
+-17 -10 D
+-16 -10 D
+-17 -10 D
+-17 -10 D
+-17 -9 D
+-18 -9 D
+-17 -10 D
+-17 -9 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-17 -8 D
+-18 -9 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 0 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-107 5 D
+-88 8 D
+-87 13 D
+-77 14 D
+-77 18 D
+-94 27 D
+-93 31 D
+-73 29 D
+-71 31 D
+-79 39 D
+-78 43 D
+-42 25 D
+-49 32 D
+-40 28 D
+-9 5 D
+-101 77 D
+-37 32 D
+-37 32 D
+-64 61 D
+-48 49 D
+-33 36 D
+-44 53 D
+-19 22 D
+-65 86 D
+-16 25 D
+-28 40 D
+-56 92 D
+-55 104 D
+-41 89 D
+-39 100 D
+-37 112 D
+-27 104 D
+-11 48 D
+-20 116 D
+-12 107 D
+-6 127 D
+1 98 D
+7 108 D
+10 87 D
+17 97 D
+5 29 D
+23 95 D
+25 85 D
+28 83 D
+29 73 D
+31 72 D
+30 62 D
+47 86 D
+30 50 D
+43 66 D
+51 72 D
+48 61 D
+71 82 D
+27 28 D
+13 15 D
+70 68 D
+82 71 D
+53 42 D
+64 47 D
+56 38 D
+92 56 D
+69 38 D
+79 38 D
+81 35 D
+74 28 D
+83 28 D
+104 28 D
+96 21 D
+87 14 D
+127 14 D
+98 4 D
+P S
+8 W
+N 1890 3780 M 0 50 D S
+N 2835 3526 M 25 44 D S
+N 3526 2835 M 44 25 D S
+N 3780 1890 M 50 0 D S
+N 3526 945 M 44 -25 D S
+N 2835 253 M 25 -43 D S
+N 1890 0 M 0 -50 D S
+N 945 253 M -25 -43 D S
+N 253 945 M -43 -25 D S
+N 0 1890 M -50 0 D S
+N 253 2835 M -43 25 D S
+N 945 3526 M -25 44 D S
+N 1890 3780 M 0 50 D S
+50 W
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+N 1890 1890 1915 75 90 arc S
+1 A
+N 1890 1890 1915 60 75 arc S
+0 A
+N 1890 1890 1915 45 60 arc S
+1 A
+N 1890 1890 1915 30 45 arc S
+0 A
+N 1890 1890 1915 15 30 arc S
+1 A
+N 1890 1890 1915 0 15 arc S
+0 A
+N 1890 1890 1915 -15 0 arc S
+1 A
+N 1890 1890 1915 -30 -15 arc S
+0 A
+N 1890 1890 1915 -45 -30 arc S
+1 A
+N 1890 1890 1915 -60 -45 arc S
+0 A
+N 1890 1890 1915 -75 -60 arc S
+1 A
+N 1890 1890 1915 -90 -75 arc S
+0 A
+N 1890 1890 1915 -105 -90 arc S
+1 A
+N 1890 1890 1915 -120 -105 arc S
+0 A
+N 1890 1890 1915 -135 -120 arc S
+1 A
+N 1890 1890 1915 -150 -135 arc S
+0 A
+N 1890 1890 1915 -165 -150 arc S
+1 A
+N 1890 1890 1915 180 195 arc S
+0 A
+N 1890 1890 1915 165 180 arc S
+1 A
+N 1890 1890 1915 150 165 arc S
+0 A
+N 1890 1890 1915 135 150 arc S
+1 A
+N 1890 1890 1915 120 135 arc S
+0 A
+N 1890 1890 1915 105 120 arc S
+1 A
+N 1890 1890 1915 90 105 arc S
+0 A
+5 W
+N 1890 1890 1890 0 360 arc S
+N 1890 1890 1940 0 360 arc S
+/PSL_H_y 333 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+117 F0
+(100°) sh add def
+1890 3780 PSL_H_y add M
+200 F0
+(South Pole) bc Z
+1861 1849 M 117 F0
+V 90 R (­90°) br Z U
+1167 1849 M V 90 R (­60°) br Z U
+523 1849 M V 90 R (­30°) br Z U
+1890 3880 M (0°) bc Z
+2885 3613 M V -30 R (30°) bc Z U
+3613 2885 M V -60 R (60°) bc Z U
+3880 1890 M V 90 R (90°) tc Z U
+3613 895 M V 60 R (120°) tc Z U
+2885 167 M V 30 R (150°) tc Z U
+1890 -100 M (180°) tc Z
+895 167 M V -30 R (-150°) tc Z U
+167 895 M V -60 R (-120°) tc Z U
+-100 1890 M V 90 R (-90°) bc Z U
+167 2885 M V 60 R (-60°) bc Z U
+895 3613 M V 30 R (-30°) bc Z U
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4751 0 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/-65/-10 -JA0/-90/3.1496i '-BWENS+tSouth Annulus+i' -Bxa30fg30 -Bya30fg30 -Xa3.9594i -Ya0i
+%@PROJ: laea 0.00000000 360.00000000 -65.00000000 -10.00000000 -8194139.417 8194139.417 -8194139.417 8194139.417 +proj=laea +lat_0=-90 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+1890 2528 M
+0 1252 D
+S
+2209 2443 M
+626 1083 D
+S
+2443 2209 M
+1083 626 D
+S
+2528 1890 M
+1252 0 D
+S
+2443 1571 M
+1083 -626 D
+S
+2209 1337 M
+626 -1084 D
+S
+1890 1251 M
+0 -1251 D
+S
+1571 1337 M
+-626 -1084 D
+S
+1337 1571 M
+-1084 -626 D
+S
+1251 1890 M
+-1251 0 D
+S
+1337 2209 M
+-1084 626 D
+S
+1571 2443 M
+-626 1083 D
+S
+1890 2653 M
+55 -2 D
+71 -8 D
+77 -17 D
+75 -25 D
+58 -26 D
+56 -30 D
+53 -35 D
+37 -29 D
+42 -36 D
+22 -23 D
+6 -5 D
+47 -54 D
+19 -25 D
+35 -53 D
+27 -48 D
+23 -51 D
+20 -51 D
+18 -61 D
+11 -54 D
+7 -47 D
+4 -71 D
+-1 -56 D
+-6 -63 D
+-10 -54 D
+-9 -39 D
+-17 -53 D
+-26 -66 D
+-37 -70 D
+-39 -59 D
+-29 -38 D
+-26 -30 D
+-6 -5 D
+-16 -18 D
+-6 -5 D
+-5 -6 D
+-48 -42 D
+-25 -19 D
+-12 -10 D
+-20 -13 D
+-20 -13 D
+-13 -8 D
+-14 -8 D
+-14 -8 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-15 -7 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 -1 D
+-8 0 D
+-63 3 D
+-48 5 D
+-70 14 D
+-53 15 D
+-52 19 D
+-43 19 D
+-43 22 D
+-60 37 D
+-57 43 D
+-30 26 D
+-5 6 D
+-23 22 D
+-32 35 D
+-35 43 D
+-31 46 D
+-39 69 D
+-26 58 D
+-18 52 D
+-17 61 D
+-11 62 D
+-6 55 D
+-2 56 D
+5 79 D
+9 62 D
+17 69 D
+18 53 D
+11 29 D
+31 65 D
+32 54 D
+37 52 D
+46 54 D
+22 23 D
+41 37 D
+37 30 D
+13 9 D
+26 18 D
+34 21 D
+34 19 D
+65 30 D
+67 23 D
+31 9 D
+70 14 D
+70 8 D
+P S
+1890 3362 M
+91 -3 D
+84 -8 D
+83 -12 D
+89 -19 D
+110 -31 D
+72 -26 D
+71 -29 D
+69 -33 D
+80 -44 D
+52 -32 D
+69 -48 D
+60 -47 D
+47 -39 D
+72 -69 D
+57 -61 D
+49 -59 D
+41 -55 D
+47 -69 D
+43 -72 D
+35 -68 D
+32 -69 D
+23 -57 D
+27 -79 D
+29 -103 D
+14 -67 D
+12 -75 D
+8 -69 D
+5 -83 D
+1 -54 D
+-3 -84 D
+-8 -83 D
+-12 -83 D
+-14 -68 D
+-27 -103 D
+-27 -79 D
+-28 -71 D
+-35 -76 D
+-40 -75 D
+-43 -71 D
+-39 -57 D
+-14 -18 D
+-13 -19 D
+-73 -88 D
+-6 -5 D
+-20 -23 D
+-6 -5 D
+-15 -17 D
+-6 -5 D
+-5 -6 D
+-50 -47 D
+-46 -40 D
+-30 -24 D
+-24 -19 D
+-24 -18 D
+-19 -13 D
+-19 -13 D
+-19 -13 D
+-13 -8 D
+-13 -8 D
+-13 -8 D
+-13 -8 D
+-13 -8 D
+-13 -8 D
+-13 -7 D
+-14 -7 D
+-13 -8 D
+-14 -7 D
+-13 -7 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-13 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-7 -1 D
+-8 -1 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-7 0 D
+-8 -1 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 0 D
+-91 5 D
+-91 10 D
+-83 15 D
+-74 17 D
+-73 21 D
+-80 28 D
+-98 41 D
+-75 38 D
+-47 26 D
+-71 44 D
+-50 35 D
+-49 37 D
+-53 44 D
+-34 30 D
+-5 6 D
+-17 15 D
+-5 6 D
+-22 21 D
+-5 6 D
+-6 5 D
+-15 17 D
+-6 5 D
+-60 69 D
+-42 55 D
+-22 31 D
+-34 50 D
+-40 65 D
+-39 75 D
+-26 55 D
+-38 92 D
+-26 79 D
+-21 74 D
+-16 74 D
+-9 53 D
+-8 53 D
+-8 91 D
+-2 91 D
+1 54 D
+6 83 D
+8 69 D
+15 82 D
+19 82 D
+19 66 D
+25 72 D
+38 92 D
+33 68 D
+41 74 D
+45 71 D
+39 56 D
+62 78 D
+40 45 D
+37 39 D
+6 5 D
+5 6 D
+17 15 D
+5 6 D
+23 20 D
+5 6 D
+88 73 D
+75 53 D
+51 33 D
+26 16 D
+74 40 D
+76 36 D
+70 29 D
+72 25 D
+111 31 D
+67 14 D
+67 11 D
+76 9 D
+84 5 D
+P S
+8 W
+N 1890 2528 M 0 -50 D S
+N 1890 3780 M 0 50 D S
+N 2209 2443 M -25 -44 D S
+N 2835 3526 M 25 44 D S
+N 2443 2209 M -44 -25 D S
+N 3526 2835 M 44 25 D S
+N 2528 1890 M -50 0 D S
+N 3780 1890 M 50 0 D S
+N 2443 1571 M -44 25 D S
+N 3526 945 M 44 -25 D S
+N 2209 1337 M -25 43 D S
+N 2835 253 M 25 -43 D S
+N 1890 1251 M 0 50 D S
+N 1890 0 M 0 -50 D S
+N 1571 1337 M 25 43 D S
+N 945 253 M -25 -43 D S
+N 1337 1571 M 43 25 D S
+N 253 945 M -43 -25 D S
+N 1251 1890 M 50 0 D S
+N 0 1890 M -50 0 D S
+N 1337 2209 M 43 -25 D S
+N 253 2835 M -43 25 D S
+N 1571 2443 M 25 -44 D S
+N 945 3526 M -25 44 D S
+N 1890 2528 M 0 -50 D S
+N 1890 3780 M 0 50 D S
+50 W
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+1 A
+0 A
+N 1890 1890 613 75 90 arc S
+N 1890 1890 1915 75 90 arc S
+1 A
+N 1890 1890 613 60 75 arc S
+N 1890 1890 1915 60 75 arc S
+0 A
+N 1890 1890 613 45 60 arc S
+N 1890 1890 1915 45 60 arc S
+1 A
+N 1890 1890 613 30 45 arc S
+N 1890 1890 1915 30 45 arc S
+0 A
+N 1890 1890 613 15 30 arc S
+N 1890 1890 1915 15 30 arc S
+1 A
+N 1890 1890 613 0 15 arc S
+N 1890 1890 1915 0 15 arc S
+0 A
+N 1890 1890 613 -15 0 arc S
+N 1890 1890 1915 -15 0 arc S
+1 A
+N 1890 1890 613 -30 -15 arc S
+N 1890 1890 1915 -30 -15 arc S
+0 A
+N 1890 1890 613 -45 -30 arc S
+N 1890 1890 1915 -45 -30 arc S
+1 A
+N 1890 1890 613 -60 -45 arc S
+N 1890 1890 1915 -60 -45 arc S
+0 A
+N 1890 1890 613 -75 -60 arc S
+N 1890 1890 1915 -75 -60 arc S
+1 A
+N 1890 1890 613 -90 -75 arc S
+N 1890 1890 1915 -90 -75 arc S
+0 A
+N 1890 1890 613 -105 -90 arc S
+N 1890 1890 1915 -105 -90 arc S
+1 A
+N 1890 1890 613 -120 -105 arc S
+N 1890 1890 1915 -120 -105 arc S
+0 A
+N 1890 1890 613 -135 -120 arc S
+N 1890 1890 1915 -135 -120 arc S
+1 A
+N 1890 1890 613 -150 -135 arc S
+N 1890 1890 1915 -150 -135 arc S
+0 A
+N 1890 1890 613 -165 -150 arc S
+N 1890 1890 1915 -165 -150 arc S
+1 A
+N 1890 1890 613 180 195 arc S
+N 1890 1890 1915 180 195 arc S
+0 A
+N 1890 1890 613 165 180 arc S
+N 1890 1890 1915 165 180 arc S
+1 A
+N 1890 1890 613 150 165 arc S
+N 1890 1890 1915 150 165 arc S
+0 A
+N 1890 1890 613 135 150 arc S
+N 1890 1890 1915 135 150 arc S
+1 A
+N 1890 1890 613 120 135 arc S
+N 1890 1890 1915 120 135 arc S
+0 A
+N 1890 1890 613 105 120 arc S
+N 1890 1890 1915 105 120 arc S
+1 A
+N 1890 1890 613 90 105 arc S
+N 1890 1890 1915 90 105 arc S
+0 A
+5 W
+N 1890 1890 638 0 360 arc S
+N 1890 1890 588 0 360 arc S
+N 1890 1890 1890 0 360 arc S
+N 1890 1890 1940 0 360 arc S
+/PSL_H_y 333 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+117 F0
+(100°) sh add def
+1890 3780 PSL_H_y add M
+200 F0
+(South Annulus) bc Z
+1849 2682 M 117 F0
+(­60°) br Z
+1849 3390 M (­30°) br Z
+1890 2428 M (0°) tc Z
+1890 3880 M (0°) bc Z
+2159 2356 M V -30 R (30°) tc Z U
+2885 3613 M V -30 R (30°) bc Z U
+2356 2159 M V -60 R (60°) tc Z U
+3613 2885 M V -60 R (60°) bc Z U
+2428 1890 M V 90 R (90°) bc Z U
+3880 1890 M V 90 R (90°) tc Z U
+2356 1621 M V 60 R (120°) bc Z U
+3613 895 M V 60 R (120°) tc Z U
+2159 1423 M V 30 R (150°) bc Z U
+2885 167 M V 30 R (150°) tc Z U
+1890 1351 M V 2.84e-14 R (180°) bc Z U
+1890 -100 M (180°) tc Z
+1621 1423 M V -30 R (-150°) bc Z U
+895 167 M V -30 R (-150°) tc Z U
+1423 1621 M V -60 R (-120°) bc Z U
+167 895 M V -60 R (-120°) tc Z U
+1351 1890 M V 90 R (-90°) tc Z U
+-100 1890 M V 90 R (-90°) bc Z U
+1423 2159 M V 60 R (-60°) tc Z U
+167 2885 M V 60 R (-60°) bc Z U
+1621 2356 M V 30 R (-30°) tc Z U
+895 3613 M V 30 R (-30°) bc Z U
+%%EndObject
+-4751 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psbasemap/azim_polar.sh
+++ b/test/psbasemap/azim_polar.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Test new implementation of internal latitude annotations for azimuthal maps
+gmt begin azim_polar ps
+	gmt set FONT_ANNOT_PRIMARY 7p MAP_TICK_LENGTH_PRIMARY 3p MAP_ANNOT_OFFSET_PRIMARY 3p MAP_POLAR_CAP 75/90 FONT_TITLE 12p MAP_FRAME_WIDTH 3p
+	gmt subplot begin 2x2 -Fs8c -BWSNE -Ba30fg30 -M18p -X1.5c
+		gmt basemap -R0/360/0/90 -JA0/90/? -c -B+t"North Pole"+i
+		gmt basemap -R0/360/10/65 -JA0/90/? -c -B+t"North Annulus"+i90
+		gmt basemap -R0/360/-90/0 -JA0/-90/? -c -B+t"South Pole"+i-90
+		gmt basemap -R0/360/-65/-10 -JA0/-90/? -c -B+t"South Annulus"+i
+	gmt subplot end
+gmt end show

--- a/test/psbasemap/azim_radial.ps
+++ b/test/psbasemap/azim_radial.ps
@@ -1,0 +1,11467 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.1.0_2600522_2020.03.04 [64-bit] Document from psxy
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Wed Mar  4 21:55:46 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+945 709 TM
+% PostScript produced by:
+%@GMT: gmt psxy -R0/6.99885/0/9.51402 -Jx1i -T -Xr0.787402i -Yr0.590551i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 6.99885000 0.00000000 9.51402000 0.000 6.999 0.000 9.514 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 9055 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/0.4/1 -JP1.9685i -BWENS+i60+tDefault -Bxxa30fg -Byyafg -Xa0i -Ya7.5455i
+%@PROJ: polar 0.00000000 360.00000000 0.40000000 1.00000000 -1.000 1.000 -1.000 1.000 +unavailable +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+1654 1181 M
+708 0 D
+S
+1590 1417 M
+614 355 D
+S
+1417 1590 M
+355 614 D
+S
+1181 1654 M
+0 708 D
+S
+945 1590 M
+-354 614 D
+S
+772 1417 M
+-614 355 D
+S
+709 1181 M
+-709 0 D
+S
+772 945 M
+-614 -354 D
+S
+945 772 M
+-354 -614 D
+S
+1181 709 M
+0 -709 D
+S
+1417 772 M
+355 -614 D
+S
+1590 945 M
+614 -354 D
+S
+1654 1181 M
+-3 47 D
+-8 54 D
+-15 53 D
+-17 43 D
+-22 42 D
+-12 20 D
+-28 37 D
+-26 30 D
+-28 27 D
+-36 29 D
+-26 18 D
+-41 23 D
+-43 19 D
+-44 14 D
+-38 9 D
+-62 7 D
+-8 0 D
+-16 1 D
+-8 -1 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-13 -8 D
+-20 -13 D
+-19 -13 D
+-42 -36 D
+-32 -34 D
+-29 -37 D
+-25 -39 D
+-24 -49 D
+-18 -52 D
+-12 -53 D
+-6 -54 D
+1 -63 D
+8 -54 D
+11 -45 D
+19 -52 D
+25 -48 D
+8 -14 D
+32 -44 D
+31 -35 D
+35 -32 D
+37 -28 D
+33 -21 D
+50 -24 D
+51 -18 D
+53 -12 D
+55 -6 D
+62 1 D
+54 8 D
+46 11 D
+51 19 D
+49 25 D
+39 26 D
+36 29 D
+34 33 D
+34 42 D
+22 33 D
+19 34 D
+19 43 D
+16 52 D
+8 38 D
+6 55 D
+P S
+1890 1181 M
+-3 59 D
+-5 46 D
+-11 58 D
+-16 56 D
+-25 66 D
+-20 42 D
+-29 51 D
+-34 48 D
+-29 37 D
+-48 50 D
+-44 39 D
+-67 48 D
+-30 18 D
+-74 36 D
+-77 27 D
+-57 14 D
+-58 9 D
+-70 5 D
+-12 0 D
+-12 0 D
+-11 -1 D
+-12 0 D
+-12 -1 D
+-11 -1 D
+-12 -1 D
+-12 -1 D
+-11 -1 D
+-12 -2 D
+-12 -2 D
+-11 -2 D
+-12 -2 D
+-11 -3 D
+-11 -2 D
+-12 -3 D
+-11 -3 D
+-11 -3 D
+-12 -3 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-11 -5 D
+-21 -10 D
+-21 -10 D
+-20 -11 D
+-21 -12 D
+-20 -13 D
+-28 -20 D
+-37 -28 D
+-52 -48 D
+-32 -34 D
+-36 -46 D
+-39 -59 D
+-27 -52 D
+-19 -43 D
+-23 -66 D
+-14 -57 D
+-9 -58 D
+-4 -58 D
+-1 -24 D
+3 -58 D
+7 -59 D
+12 -57 D
+17 -56 D
+21 -55 D
+20 -42 D
+12 -20 D
+11 -21 D
+33 -48 D
+36 -46 D
+40 -43 D
+53 -47 D
+56 -41 D
+30 -19 D
+21 -11 D
+31 -16 D
+43 -19 D
+67 -23 D
+56 -14 D
+58 -9 D
+59 -4 D
+23 -1 D
+59 3 D
+58 7 D
+57 12 D
+56 17 D
+55 21 D
+42 20 D
+41 23 D
+49 33 D
+46 36 D
+42 40 D
+47 53 D
+41 56 D
+25 41 D
+21 41 D
+19 43 D
+20 55 D
+17 68 D
+9 58 D
+5 70 D
+P S
+2126 1181 M
+-2 63 D
+-8 77 D
+-17 84 D
+-12 46 D
+-20 59 D
+-21 51 D
+-23 49 D
+-34 61 D
+-8 14 D
+-22 32 D
+-18 26 D
+-39 49 D
+-36 40 D
+-11 12 D
+-6 5 D
+-5 6 D
+-52 47 D
+-37 30 D
+-38 27 D
+-39 26 D
+-54 31 D
+-56 27 D
+-43 18 D
+-37 14 D
+-67 20 D
+-46 11 D
+-77 13 D
+-70 6 D
+-8 0 D
+-62 1 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-7 0 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-8 -2 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -2 D
+-7 -3 D
+-14 -7 D
+-8 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-14 -7 D
+-14 -7 D
+-13 -8 D
+-14 -7 D
+-14 -8 D
+-13 -8 D
+-20 -13 D
+-19 -13 D
+-19 -13 D
+-25 -19 D
+-31 -25 D
+-40 -36 D
+-23 -22 D
+-10 -12 D
+-6 -5 D
+-41 -47 D
+-29 -37 D
+-39 -58 D
+-17 -27 D
+-26 -48 D
+-23 -49 D
+-29 -73 D
+-24 -83 D
+-14 -68 D
+-6 -39 D
+-6 -70 D
+-1 -63 D
+4 -70 D
+4 -39 D
+12 -69 D
+17 -68 D
+17 -52 D
+23 -58 D
+19 -43 D
+18 -35 D
+23 -40 D
+39 -59 D
+43 -56 D
+36 -41 D
+6 -5 D
+27 -28 D
+6 -5 D
+5 -6 D
+53 -46 D
+31 -24 D
+58 -39 D
+27 -17 D
+48 -26 D
+42 -20 D
+58 -24 D
+52 -17 D
+60 -17 D
+69 -13 D
+31 -5 D
+70 -6 D
+63 -1 D
+70 4 D
+39 4 D
+77 14 D
+60 15 D
+52 17 D
+73 29 D
+63 31 D
+40 23 D
+59 39 D
+50 38 D
+29 25 D
+18 16 D
+5 6 D
+12 10 D
+43 46 D
+45 54 D
+27 38 D
+26 39 D
+31 54 D
+27 56 D
+15 36 D
+17 44 D
+18 60 D
+13 53 D
+13 77 D
+6 70 D
+P S
+2362 1181 M
+-1 59 D
+-10 107 D
+-16 86 D
+-19 76 D
+-31 92 D
+-26 63 D
+-21 45 D
+-42 77 D
+-42 65 D
+-53 71 D
+-51 59 D
+-55 56 D
+-43 39 D
+-61 49 D
+-64 45 D
+-58 36 D
+-69 36 D
+-53 25 D
+-82 31 D
+-85 26 D
+-85 19 D
+-68 10 D
+-87 8 D
+-98 1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-17 -9 D
+-17 -9 D
+-18 -9 D
+-17 -9 D
+-16 -10 D
+-17 -10 D
+-17 -11 D
+-24 -16 D
+-24 -17 D
+-24 -17 D
+-31 -24 D
+-52 -44 D
+-63 -62 D
+-26 -28 D
+-56 -68 D
+-51 -72 D
+-26 -41 D
+-14 -26 D
+-32 -60 D
+-21 -44 D
+-32 -82 D
+-21 -65 D
+-21 -86 D
+-9 -47 D
+-9 -68 D
+-6 -68 D
+-1 -88 D
+5 -78 D
+8 -68 D
+12 -67 D
+16 -67 D
+29 -93 D
+37 -90 D
+40 -79 D
+45 -75 D
+51 -72 D
+43 -53 D
+53 -57 D
+42 -41 D
+59 -51 D
+63 -47 D
+40 -27 D
+76 -45 D
+88 -43 D
+81 -32 D
+65 -21 D
+95 -23 D
+87 -14 D
+88 -8 D
+87 -1 D
+78 5 D
+68 8 D
+67 12 D
+67 16 D
+93 29 D
+55 22 D
+35 15 D
+36 17 D
+60 33 D
+17 9 D
+57 37 D
+64 46 D
+45 37 D
+57 53 D
+48 49 D
+44 52 D
+53 71 D
+52 82 D
+45 87 D
+27 63 D
+20 55 D
+26 84 D
+19 85 D
+10 68 D
+8 88 D
+P S
+8 W
+N 1654 1181 M -34 0 D S
+N 2362 1181 M 34 0 D S
+N 1590 1417 M -29 -16 D S
+N 2204 1772 M 29 16 D S
+N 1417 1590 M -16 -29 D S
+N 1772 2204 M 16 29 D S
+N 1181 1654 M 0 -34 D S
+N 1181 2362 M 0 34 D S
+N 945 1590 M 17 -29 D S
+N 591 2204 M -17 29 D S
+N 772 1417 M 29 -16 D S
+N 158 1772 M -29 16 D S
+N 709 1181 M 33 0 D S
+N 0 1181 M -33 0 D S
+N 772 945 M 29 17 D S
+N 158 591 M -29 -17 D S
+N 945 772 M 17 29 D S
+N 591 158 M -17 -29 D S
+N 1181 709 M 0 33 D S
+N 1181 0 M 0 -33 D S
+N 1417 772 M -16 29 D S
+N 1772 158 M 16 -29 D S
+N 1590 945 M -29 17 D S
+N 2204 591 M 29 -17 D S
+N 1654 1181 M -34 0 D S
+N 2362 1181 M 34 0 D S
+25 W
+2362 1181 M
+0 40 D
+-2 39 D
+-8 79 D
+-13 77 D
+-19 77 D
+-23 76 D
+-29 73 D
+-33 72 D
+-18 35 D
+-40 68 D
+-45 65 D
+-49 62 D
+-53 58 D
+-57 55 D
+-29 26 D
+-62 49 D
+-65 45 D
+-68 40 D
+-71 35 D
+-72 31 D
+-37 14 D
+-76 23 D
+-77 19 D
+-77 13 D
+-79 8 D
+-39 2 D
+-40 0 D
+-39 0 D
+-40 -2 D
+-39 -4 D
+-39 -4 D
+-39 -6 D
+-39 -7 D
+-39 -9 D
+-38 -10 D
+-38 -11 D
+-37 -12 D
+-37 -14 D
+-37 -15 D
+-36 -16 D
+-36 -17 D
+-35 -18 D
+-67 -40 D
+-66 -45 D
+-61 -49 D
+-59 -53 D
+-55 -57 D
+-26 -29 D
+-49 -62 D
+-23 -32 D
+-62 -101 D
+-35 -71 D
+-31 -72 D
+-14 -37 D
+-23 -76 D
+-10 -38 D
+-16 -77 D
+-10 -79 D
+-5 -78 D
+-1 -40 D
+3 -79 D
+3 -39 D
+10 -78 D
+16 -78 D
+21 -76 D
+12 -37 D
+29 -74 D
+33 -72 D
+18 -35 D
+41 -67 D
+21 -33 D
+23 -33 D
+49 -61 D
+53 -59 D
+57 -55 D
+60 -51 D
+31 -24 D
+33 -23 D
+66 -42 D
+34 -20 D
+71 -35 D
+73 -31 D
+37 -14 D
+75 -23 D
+38 -10 D
+78 -16 D
+78 -10 D
+79 -5 D
+39 -1 D
+79 3 D
+79 8 D
+39 5 D
+77 16 D
+76 21 D
+38 12 D
+73 29 D
+72 33 D
+35 18 D
+101 62 D
+63 47 D
+31 25 D
+58 53 D
+55 57 D
+51 60 D
+24 31 D
+45 66 D
+40 67 D
+35 71 D
+31 73 D
+14 37 D
+23 75 D
+19 77 D
+13 78 D
+8 78 D
+P S
+1654 1181 M
+-5 63 D
+-8 47 D
+-19 60 D
+-19 43 D
+-15 28 D
+-17 26 D
+-29 38 D
+-32 35 D
+-36 31 D
+-26 19 D
+-26 17 D
+-42 22 D
+-44 17 D
+-45 14 D
+-47 8 D
+-63 5 D
+-16 -1 D
+-15 -1 D
+-16 -1 D
+-16 -2 D
+-15 -2 D
+-16 -3 D
+-15 -3 D
+-16 -4 D
+-15 -5 D
+-15 -5 D
+-15 -5 D
+-14 -6 D
+-15 -6 D
+-28 -15 D
+-14 -7 D
+-26 -17 D
+-38 -29 D
+-35 -32 D
+-31 -36 D
+-35 -52 D
+-16 -28 D
+-19 -43 D
+-15 -45 D
+-10 -46 D
+-6 -63 D
+1 -47 D
+5 -47 D
+10 -47 D
+15 -45 D
+19 -43 D
+24 -41 D
+27 -39 D
+31 -35 D
+35 -33 D
+25 -19 D
+39 -26 D
+28 -16 D
+43 -19 D
+45 -15 D
+47 -10 D
+47 -5 D
+47 -1 D
+63 6 D
+46 10 D
+60 21 D
+28 13 D
+41 24 D
+39 27 D
+36 31 D
+42 47 D
+19 26 D
+17 26 D
+22 42 D
+17 44 D
+14 46 D
+8 46 D
+P S
+/PSL_H_y 300 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+83 F0
+(100°) sh add def
+1181 2362 PSL_H_y add M
+200 F0
+(Default) bc Z
+1544 1763 M 83 F0
+V -30 R (0.6) tl Z U
+1662 1967 M V -30 R (0.8) tl Z U
+1780 2172 M V -30 R (1.0) tl Z U
+1587 1181 M V -90 R (0°) tc Z U
+2429 1181 M V -90 R (0°) bc Z U
+1533 1384 M V -60 R (30°) tc Z U
+2262 1805 M V -60 R (30°) bc Z U
+1384 1533 M V -30 R (60°) tc Z U
+1805 2262 M V -30 R (60°) bc Z U
+1181 1587 M (90°) tc Z
+1181 2429 M V -2.84e-14 R (90°) bc Z U
+978 1533 M V 30 R (120°) tc Z U
+557 2262 M V 30 R (120°) bc Z U
+830 1384 M V 60 R (150°) tc Z U
+101 1805 M V 60 R (150°) bc Z U
+775 1181 M V -270 R (180°) tc Z U
+-67 1181 M V 90 R (180°) bc Z U
+830 978 M V -60 R (-150°) bc Z U
+101 557 M V 300 R (-150°) tc Z U
+978 830 M V -30 R (-120°) bc Z U
+557 101 M V 330 R (-120°) tc Z U
+1181 775 M (-90°) bc Z
+1181 -67 M V 360 R (-90°) tc Z U
+1384 830 M V 30 R (-60°) bc Z U
+1805 101 M V 390 R (-60°) tc Z U
+1533 978 M V 60 R (-30°) bc Z U
+2262 557 M V 420 R (-30°) tc Z U
+%%EndObject
+0 -9055 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3018 9055 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/0.4/1 -JP1.9685i+f -BWENS+i60+t\053f -Bxxa30fg -Byyafg -Xa2.5152i -Ya7.5455i
+%@PROJ: polar 0.00000000 360.00000000 0.40000000 1.00000000 -0.600 0.600 -0.600 0.600 +unavailable +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+2362 1181 M
+-1181 0 D
+S
+2204 1772 M
+-1023 -591 D
+S
+1772 2204 M
+-591 -1023 D
+S
+1181 2362 M
+0 -1181 D
+S
+591 2204 M
+590 -1023 D
+S
+158 1772 M
+1023 -591 D
+S
+0 1181 M
+1181 0 D
+S
+158 591 M
+1023 590 D
+S
+591 158 M
+590 1023 D
+S
+1181 0 M
+0 1181 D
+S
+1772 158 M
+-591 1023 D
+S
+2204 591 M
+-1023 590 D
+S
+2362 1181 M
+-1 59 D
+-10 107 D
+-16 86 D
+-19 76 D
+-31 92 D
+-26 63 D
+-21 45 D
+-42 77 D
+-42 65 D
+-53 71 D
+-51 59 D
+-55 56 D
+-43 39 D
+-61 49 D
+-64 45 D
+-58 36 D
+-69 36 D
+-53 25 D
+-82 31 D
+-85 26 D
+-85 19 D
+-68 10 D
+-87 8 D
+-98 1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-17 -9 D
+-17 -9 D
+-18 -9 D
+-17 -9 D
+-16 -10 D
+-17 -10 D
+-17 -11 D
+-24 -16 D
+-24 -17 D
+-24 -17 D
+-31 -24 D
+-52 -44 D
+-63 -62 D
+-26 -28 D
+-56 -68 D
+-51 -72 D
+-26 -41 D
+-14 -26 D
+-32 -60 D
+-21 -44 D
+-32 -82 D
+-21 -65 D
+-21 -86 D
+-9 -47 D
+-9 -68 D
+-6 -68 D
+-1 -88 D
+5 -78 D
+8 -68 D
+12 -67 D
+16 -67 D
+29 -93 D
+37 -90 D
+40 -79 D
+45 -75 D
+51 -72 D
+43 -53 D
+53 -57 D
+42 -41 D
+59 -51 D
+63 -47 D
+40 -27 D
+76 -45 D
+88 -43 D
+81 -32 D
+65 -21 D
+95 -23 D
+87 -14 D
+88 -8 D
+87 -1 D
+78 5 D
+68 8 D
+67 12 D
+67 16 D
+93 29 D
+55 22 D
+35 15 D
+36 17 D
+60 33 D
+17 9 D
+57 37 D
+64 46 D
+45 37 D
+57 53 D
+48 49 D
+44 52 D
+53 71 D
+52 82 D
+45 87 D
+27 63 D
+20 55 D
+26 84 D
+19 85 D
+10 68 D
+8 88 D
+P S
+1968 1181 M
+-1 52 D
+-8 71 D
+-7 39 D
+-18 69 D
+-19 55 D
+-21 48 D
+-20 41 D
+-30 50 D
+-26 38 D
+-53 66 D
+-5 4 D
+-13 15 D
+-5 4 D
+-4 5 D
+-5 4 D
+-9 10 D
+-10 8 D
+-4 5 D
+-71 57 D
+-60 39 D
+-46 25 D
+-54 24 D
+-48 18 D
+-31 10 D
+-83 19 D
+-58 8 D
+-58 3 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-12 -6 D
+-12 -6 D
+-6 -2 D
+-11 -6 D
+-12 -6 D
+-11 -7 D
+-11 -6 D
+-12 -7 D
+-11 -7 D
+-11 -7 D
+-16 -11 D
+-16 -11 D
+-21 -16 D
+-25 -20 D
+-34 -30 D
+-9 -10 D
+-5 -4 D
+-4 -5 D
+-5 -4 D
+-13 -15 D
+-5 -4 D
+-57 -71 D
+-7 -11 D
+-25 -38 D
+-22 -40 D
+-29 -59 D
+-25 -67 D
+-16 -56 D
+-9 -44 D
+-6 -33 D
+-6 -64 D
+-1 -78 D
+5 -59 D
+5 -39 D
+17 -76 D
+15 -50 D
+24 -60 D
+29 -59 D
+29 -50 D
+34 -48 D
+41 -51 D
+31 -33 D
+48 -44 D
+52 -40 D
+43 -29 D
+51 -28 D
+53 -26 D
+67 -25 D
+56 -16 D
+77 -15 D
+65 -6 D
+78 -1 D
+58 5 D
+39 5 D
+57 12 D
+63 18 D
+66 26 D
+65 32 D
+17 9 D
+49 32 D
+21 15 D
+61 49 D
+4 5 D
+15 13 D
+4 5 D
+5 4 D
+9 10 D
+5 4 D
+38 44 D
+36 47 D
+38 60 D
+6 12 D
+7 11 D
+28 59 D
+21 54 D
+17 57 D
+15 69 D
+8 65 D
+2 46 D
+P S
+1575 1181 M
+-3 46 D
+-9 51 D
+-7 25 D
+-17 42 D
+-21 40 D
+-22 33 D
+-25 30 D
+-5 4 D
+-9 10 D
+-5 4 D
+-4 5 D
+-35 29 D
+-39 24 D
+-47 23 D
+-24 9 D
+-44 11 D
+-52 7 D
+-39 1 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -2 D
+-7 -1 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -1 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-12 -6 D
+-12 -6 D
+-11 -6 D
+-11 -6 D
+-17 -11 D
+-16 -11 D
+-30 -25 D
+-4 -5 D
+-10 -9 D
+-4 -5 D
+-5 -4 D
+-25 -30 D
+-28 -44 D
+-20 -41 D
+-19 -55 D
+-10 -58 D
+-2 -45 D
+4 -46 D
+8 -45 D
+19 -55 D
+23 -47 D
+18 -27 D
+15 -21 D
+17 -20 D
+5 -4 D
+9 -10 D
+5 -4 D
+4 -5 D
+30 -25 D
+11 -7 D
+33 -21 D
+41 -20 D
+55 -19 D
+58 -10 D
+46 -2 D
+45 4 D
+45 8 D
+55 19 D
+47 23 D
+43 29 D
+25 21 D
+4 5 D
+10 9 D
+4 5 D
+5 4 D
+29 36 D
+24 38 D
+23 47 D
+9 24 D
+11 44 D
+7 52 D
+P S
+8 W
+N 2362 1181 M 34 0 D S
+N 2204 1772 M 29 16 D S
+N 1772 2204 M 16 29 D S
+N 1181 2362 M 0 34 D S
+N 591 2204 M -17 29 D S
+N 158 1772 M -29 16 D S
+N 0 1181 M -33 0 D S
+N 158 591 M -29 -17 D S
+N 591 158 M -17 -29 D S
+N 1181 0 M 0 -33 D S
+N 1772 158 M 16 -29 D S
+N 2204 591 M 29 -17 D S
+N 2362 1181 M 34 0 D S
+25 W
+2362 1181 M
+0 40 D
+-2 39 D
+-8 79 D
+-13 77 D
+-19 77 D
+-23 76 D
+-29 73 D
+-33 72 D
+-18 35 D
+-40 68 D
+-45 65 D
+-49 62 D
+-53 58 D
+-57 55 D
+-29 26 D
+-62 49 D
+-65 45 D
+-68 40 D
+-71 35 D
+-72 31 D
+-37 14 D
+-76 23 D
+-77 19 D
+-77 13 D
+-79 8 D
+-39 2 D
+-40 0 D
+-39 0 D
+-40 -2 D
+-39 -4 D
+-39 -4 D
+-39 -6 D
+-39 -7 D
+-39 -9 D
+-38 -10 D
+-38 -11 D
+-37 -12 D
+-37 -14 D
+-37 -15 D
+-36 -16 D
+-36 -17 D
+-35 -18 D
+-67 -40 D
+-66 -45 D
+-61 -49 D
+-59 -53 D
+-55 -57 D
+-26 -29 D
+-49 -62 D
+-23 -32 D
+-62 -101 D
+-35 -71 D
+-31 -72 D
+-14 -37 D
+-23 -76 D
+-10 -38 D
+-16 -77 D
+-10 -79 D
+-5 -78 D
+-1 -40 D
+3 -79 D
+3 -39 D
+10 -78 D
+16 -78 D
+21 -76 D
+12 -37 D
+29 -74 D
+33 -72 D
+18 -35 D
+41 -67 D
+21 -33 D
+23 -33 D
+49 -61 D
+53 -59 D
+57 -55 D
+60 -51 D
+31 -24 D
+33 -23 D
+66 -42 D
+34 -20 D
+71 -35 D
+73 -31 D
+37 -14 D
+75 -23 D
+38 -10 D
+78 -16 D
+78 -10 D
+79 -5 D
+39 -1 D
+79 3 D
+79 8 D
+39 5 D
+77 16 D
+76 21 D
+38 12 D
+73 29 D
+72 33 D
+35 18 D
+101 62 D
+63 47 D
+31 25 D
+58 53 D
+55 57 D
+51 60 D
+24 31 D
+45 66 D
+40 67 D
+35 71 D
+31 73 D
+14 37 D
+23 75 D
+19 77 D
+13 78 D
+8 78 D
+P S
+/PSL_H_y 267 def
+1181 2362 PSL_H_y add M
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(\053f) bc Z
+1780 2172 M 83 F0
+V -30 R (0.4) tl Z U
+1583 1831 M V -30 R (0.6) tl Z U
+1387 1490 M V -30 R (0.8) tl Z U
+1190 1149 M V -30 R (1.0) tl Z U
+2429 1181 M V -90 R (0°) bc Z U
+2262 1805 M V -60 R (30°) bc Z U
+1805 2262 M V -30 R (60°) bc Z U
+1181 2429 M V -1.42e-14 R (90°) bc Z U
+557 2262 M V 30 R (120°) bc Z U
+101 1805 M V 60 R (150°) bc Z U
+-67 1181 M V 90 R (180°) bc Z U
+101 557 M V 300 R (-150°) tc Z U
+557 101 M V 330 R (-120°) tc Z U
+1181 -67 M V 360 R (-90°) tc Z U
+1805 101 M V 390 R (-60°) tc Z U
+2262 557 M V 420 R (-30°) tc Z U
+%%EndObject
+-3018 -9055 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+6036 9055 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/0/50 -JP1.9685i+fe -BWENS+i60+t\053fe -Bxxa30fg -Byyafg -Xa5.0303i -Ya7.5455i
+%@PROJ: polar 0.00000000 360.00000000 0.00000000 50.00000000 -90.000 90.000 -90.000 90.000 +unavailable +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+2362 1181 M
+-656 0 D
+S
+2204 1772 M
+-568 -328 D
+S
+1772 2204 M
+-328 -568 D
+S
+1181 2362 M
+0 -656 D
+S
+591 2204 M
+328 -568 D
+S
+158 1772 M
+568 -328 D
+S
+0 1181 M
+656 0 D
+S
+158 591 M
+568 328 D
+S
+591 158 M
+328 568 D
+S
+1181 0 M
+0 656 D
+S
+1772 158 M
+-328 568 D
+S
+2204 591 M
+-568 328 D
+S
+2362 1181 M
+-1 59 D
+-10 107 D
+-16 86 D
+-19 76 D
+-31 92 D
+-26 63 D
+-21 45 D
+-42 77 D
+-42 65 D
+-53 71 D
+-51 59 D
+-55 56 D
+-43 39 D
+-61 49 D
+-64 45 D
+-58 36 D
+-69 36 D
+-53 25 D
+-82 31 D
+-85 26 D
+-85 19 D
+-68 10 D
+-87 8 D
+-98 1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-17 -9 D
+-17 -9 D
+-18 -9 D
+-17 -9 D
+-16 -10 D
+-17 -10 D
+-17 -11 D
+-24 -16 D
+-24 -17 D
+-24 -17 D
+-31 -24 D
+-52 -44 D
+-63 -62 D
+-26 -28 D
+-56 -68 D
+-51 -72 D
+-26 -41 D
+-14 -26 D
+-32 -60 D
+-21 -44 D
+-32 -82 D
+-21 -65 D
+-21 -86 D
+-9 -47 D
+-9 -68 D
+-6 -68 D
+-1 -88 D
+5 -78 D
+8 -68 D
+12 -67 D
+16 -67 D
+29 -93 D
+37 -90 D
+40 -79 D
+45 -75 D
+51 -72 D
+43 -53 D
+53 -57 D
+42 -41 D
+59 -51 D
+63 -47 D
+40 -27 D
+76 -45 D
+88 -43 D
+81 -32 D
+65 -21 D
+95 -23 D
+87 -14 D
+88 -8 D
+87 -1 D
+78 5 D
+68 8 D
+67 12 D
+67 16 D
+93 29 D
+55 22 D
+35 15 D
+36 17 D
+60 33 D
+17 9 D
+57 37 D
+64 46 D
+45 37 D
+57 53 D
+48 49 D
+44 52 D
+53 71 D
+52 82 D
+45 87 D
+27 63 D
+20 55 D
+26 84 D
+19 85 D
+10 68 D
+8 88 D
+P S
+2231 1181 M
+-2 69 D
+-8 78 D
+-14 77 D
+-17 67 D
+-16 50 D
+-31 81 D
+-34 70 D
+-30 53 D
+-43 65 D
+-37 49 D
+-57 65 D
+-19 18 D
+-24 25 D
+-59 51 D
+-63 47 D
+-58 37 D
+-61 34 D
+-63 29 D
+-89 34 D
+-92 25 D
+-69 13 D
+-69 9 D
+-78 4 D
+-8 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 -1 D
+-8 0 D
+-9 0 D
+-9 -1 D
+-8 0 D
+-9 -1 D
+-9 -1 D
+-8 0 D
+-9 -1 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-9 -2 D
+-8 -1 D
+-9 -1 D
+-8 -2 D
+-9 -1 D
+-8 -2 D
+-9 -2 D
+-8 -1 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-8 -3 D
+-9 -2 D
+-8 -2 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-8 -2 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-15 -8 D
+-8 -3 D
+-16 -8 D
+-8 -4 D
+-8 -3 D
+-15 -8 D
+-15 -9 D
+-15 -8 D
+-15 -9 D
+-15 -9 D
+-15 -9 D
+-22 -15 D
+-21 -14 D
+-28 -21 D
+-34 -27 D
+-58 -52 D
+-60 -63 D
+-33 -40 D
+-61 -85 D
+-31 -52 D
+-36 -69 D
+-27 -64 D
+-26 -74 D
+-22 -84 D
+-16 -94 D
+-6 -69 D
+-2 -78 D
+6 -96 D
+13 -85 D
+13 -60 D
+17 -58 D
+26 -74 D
+28 -63 D
+36 -69 D
+32 -52 D
+56 -78 D
+45 -53 D
+54 -55 D
+32 -30 D
+61 -49 D
+64 -45 D
+67 -39 D
+70 -35 D
+48 -20 D
+49 -18 D
+59 -17 D
+50 -13 D
+94 -16 D
+69 -6 D
+78 -2 D
+96 6 D
+68 10 D
+77 16 D
+75 22 D
+81 31 D
+47 22 D
+62 32 D
+59 37 D
+77 56 D
+46 40 D
+56 54 D
+35 39 D
+38 47 D
+31 42 D
+33 51 D
+38 68 D
+29 63 D
+34 90 D
+23 83 D
+14 68 D
+10 78 D
+4 78 D
+P S
+2100 1181 M
+-2 61 D
+-8 75 D
+-13 67 D
+-15 59 D
+-25 72 D
+-31 70 D
+-17 33 D
+-15 27 D
+-32 51 D
+-36 49 D
+-44 53 D
+-31 33 D
+-56 51 D
+-48 38 D
+-56 38 D
+-39 24 D
+-61 31 D
+-77 32 D
+-73 23 D
+-59 14 D
+-75 12 D
+-68 5 D
+-8 0 D
+-45 1 D
+-8 -1 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 -1 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -1 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -7 D
+-7 -3 D
+-14 -7 D
+-13 -7 D
+-13 -7 D
+-14 -8 D
+-13 -8 D
+-13 -8 D
+-19 -12 D
+-18 -13 D
+-19 -13 D
+-24 -19 D
+-35 -29 D
+-34 -31 D
+-26 -27 D
+-6 -5 D
+-40 -46 D
+-41 -54 D
+-33 -51 D
+-30 -53 D
+-26 -55 D
+-23 -56 D
+-16 -51 D
+-9 -29 D
+-13 -59 D
+-9 -53 D
+-6 -68 D
+-2 -60 D
+3 -61 D
+5 -53 D
+12 -67 D
+14 -59 D
+16 -51 D
+22 -57 D
+19 -42 D
+24 -47 D
+31 -52 D
+34 -50 D
+38 -48 D
+30 -34 D
+6 -5 D
+10 -11 D
+6 -5 D
+10 -11 D
+6 -5 D
+5 -6 D
+46 -40 D
+48 -37 D
+70 -45 D
+54 -29 D
+62 -28 D
+50 -19 D
+65 -20 D
+59 -13 D
+53 -9 D
+68 -6 D
+61 -2 D
+60 3 D
+53 5 D
+68 12 D
+59 14 D
+65 21 D
+77 32 D
+74 39 D
+51 32 D
+37 27 D
+48 38 D
+28 25 D
+5 6 D
+38 37 D
+45 52 D
+32 42 D
+45 70 D
+29 54 D
+19 41 D
+23 56 D
+23 73 D
+14 59 D
+12 75 D
+5 68 D
+P S
+1968 1181 M
+-1 52 D
+-8 71 D
+-7 39 D
+-18 69 D
+-19 55 D
+-21 48 D
+-20 41 D
+-30 50 D
+-26 38 D
+-53 66 D
+-5 4 D
+-13 15 D
+-5 4 D
+-4 5 D
+-5 4 D
+-9 10 D
+-10 8 D
+-4 5 D
+-71 57 D
+-60 39 D
+-46 25 D
+-54 24 D
+-48 18 D
+-31 10 D
+-83 19 D
+-58 8 D
+-58 3 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-12 -6 D
+-12 -6 D
+-6 -2 D
+-11 -6 D
+-12 -6 D
+-11 -7 D
+-11 -6 D
+-12 -7 D
+-11 -7 D
+-11 -7 D
+-16 -11 D
+-16 -11 D
+-21 -16 D
+-25 -20 D
+-34 -30 D
+-9 -10 D
+-5 -4 D
+-4 -5 D
+-5 -4 D
+-13 -15 D
+-5 -4 D
+-57 -71 D
+-7 -11 D
+-25 -38 D
+-22 -40 D
+-29 -59 D
+-25 -67 D
+-16 -56 D
+-9 -44 D
+-6 -33 D
+-6 -64 D
+-1 -78 D
+5 -59 D
+5 -39 D
+17 -76 D
+15 -50 D
+24 -60 D
+29 -59 D
+29 -50 D
+34 -48 D
+41 -51 D
+31 -33 D
+48 -44 D
+52 -40 D
+43 -29 D
+51 -28 D
+53 -26 D
+67 -25 D
+56 -16 D
+77 -15 D
+65 -6 D
+78 -1 D
+58 5 D
+39 5 D
+57 12 D
+63 18 D
+66 26 D
+65 32 D
+17 9 D
+49 32 D
+21 15 D
+61 49 D
+4 5 D
+15 13 D
+4 5 D
+5 4 D
+9 10 D
+5 4 D
+38 44 D
+36 47 D
+38 60 D
+6 12 D
+7 11 D
+28 59 D
+21 54 D
+17 57 D
+15 69 D
+8 65 D
+2 46 D
+P S
+1837 1181 M
+-2 54 D
+-5 43 D
+-13 64 D
+-9 32 D
+-14 41 D
+-16 40 D
+-36 67 D
+-36 54 D
+-42 50 D
+-8 7 D
+-15 16 D
+-8 7 D
+-7 8 D
+-50 42 D
+-64 42 D
+-57 30 D
+-71 27 D
+-31 9 D
+-32 8 D
+-64 11 D
+-65 4 D
+-11 0 D
+-11 0 D
+-11 0 D
+-10 -1 D
+-11 0 D
+-11 -1 D
+-11 -1 D
+-11 -1 D
+-10 -1 D
+-11 -2 D
+-11 -2 D
+-11 -2 D
+-10 -2 D
+-11 -2 D
+-10 -2 D
+-11 -3 D
+-10 -3 D
+-11 -2 D
+-10 -4 D
+-11 -3 D
+-10 -3 D
+-10 -4 D
+-10 -4 D
+-10 -4 D
+-11 -4 D
+-9 -4 D
+-10 -4 D
+-20 -10 D
+-19 -10 D
+-19 -10 D
+-19 -12 D
+-27 -18 D
+-26 -19 D
+-57 -50 D
+-15 -16 D
+-8 -7 D
+-41 -50 D
+-37 -54 D
+-31 -58 D
+-21 -49 D
+-14 -41 D
+-14 -53 D
+-11 -64 D
+-4 -65 D
+1 -54 D
+6 -54 D
+13 -64 D
+19 -62 D
+16 -40 D
+29 -59 D
+41 -64 D
+41 -50 D
+30 -32 D
+57 -50 D
+35 -25 D
+46 -29 D
+59 -29 D
+60 -23 D
+63 -17 D
+64 -11 D
+65 -4 D
+54 1 D
+54 6 D
+64 13 D
+62 19 D
+51 21 D
+48 24 D
+46 29 D
+35 25 D
+42 35 D
+7 8 D
+16 15 D
+50 57 D
+25 35 D
+29 46 D
+29 59 D
+23 60 D
+7 21 D
+14 63 D
+7 43 D
+4 65 D
+P S
+1706 1181 M
+-2 43 D
+-1 18 D
+-11 60 D
+-17 58 D
+-24 56 D
+-12 23 D
+-33 51 D
+-27 34 D
+-42 43 D
+-40 34 D
+-43 29 D
+-46 25 D
+-56 23 D
+-67 18 D
+-43 7 D
+-61 3 D
+-9 0 D
+-8 0 D
+-9 -1 D
+-9 0 D
+-8 -1 D
+-9 -1 D
+-9 0 D
+-8 -2 D
+-9 -1 D
+-8 -1 D
+-9 -2 D
+-8 -1 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-9 -3 D
+-8 -2 D
+-8 -3 D
+-8 -2 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-15 -8 D
+-15 -8 D
+-15 -9 D
+-15 -9 D
+-21 -15 D
+-28 -22 D
+-38 -35 D
+-24 -25 D
+-32 -41 D
+-23 -37 D
+-17 -30 D
+-17 -40 D
+-7 -16 D
+-17 -58 D
+-8 -43 D
+-6 -61 D
+1 -52 D
+9 -68 D
+13 -51 D
+8 -25 D
+17 -40 D
+15 -31 D
+32 -51 D
+32 -41 D
+36 -38 D
+33 -29 D
+35 -26 D
+52 -31 D
+39 -18 D
+24 -10 D
+59 -17 D
+42 -8 D
+61 -6 D
+52 1 D
+69 9 D
+50 13 D
+25 8 D
+40 17 D
+31 15 D
+30 18 D
+29 19 D
+34 27 D
+37 36 D
+29 33 D
+31 42 D
+26 45 D
+15 31 D
+16 41 D
+16 58 D
+9 51 D
+P S
+8 W
+N 2362 1181 M 34 0 D S
+N 1706 1181 M -33 0 D S
+N 2204 1772 M 29 16 D S
+N 1636 1444 M -29 -17 D S
+N 1772 2204 M 16 29 D S
+N 1444 1636 M -17 -29 D S
+N 1181 2362 M 0 34 D S
+N 1181 1706 M 0 -33 D S
+N 591 2204 M -17 29 D S
+N 919 1636 M 16 -29 D S
+N 158 1772 M -29 16 D S
+N 726 1444 M 29 -17 D S
+N 0 1181 M -33 0 D S
+N 656 1181 M 33 0 D S
+N 158 591 M -29 -17 D S
+N 726 919 M 29 16 D S
+N 591 158 M -17 -29 D S
+N 919 726 M 16 29 D S
+N 1181 0 M 0 -33 D S
+N 1181 656 M 0 33 D S
+N 1772 158 M 16 -29 D S
+N 1444 726 M -17 29 D S
+N 2204 591 M 29 -17 D S
+N 1636 919 M -29 16 D S
+N 2362 1181 M 34 0 D S
+N 1706 1181 M -33 0 D S
+25 W
+1706 1181 M
+-1 35 D
+-9 70 D
+-19 67 D
+-20 49 D
+-7 16 D
+-26 46 D
+-31 42 D
+-23 27 D
+-24 25 D
+-26 24 D
+-42 32 D
+-29 19 D
+-31 17 D
+-48 21 D
+-67 21 D
+-35 7 D
+-69 7 D
+-18 0 D
+-17 0 D
+-18 -1 D
+-17 -2 D
+-18 -2 D
+-17 -2 D
+-17 -3 D
+-18 -4 D
+-17 -5 D
+-16 -5 D
+-17 -5 D
+-17 -6 D
+-16 -7 D
+-16 -7 D
+-16 -7 D
+-30 -17 D
+-30 -19 D
+-42 -32 D
+-38 -36 D
+-24 -26 D
+-32 -42 D
+-19 -29 D
+-31 -63 D
+-13 -33 D
+-15 -50 D
+-9 -52 D
+-5 -52 D
+1 -53 D
+6 -52 D
+7 -35 D
+21 -67 D
+22 -48 D
+16 -30 D
+29 -44 D
+22 -28 D
+36 -38 D
+26 -24 D
+42 -32 D
+30 -19 D
+46 -24 D
+49 -20 D
+50 -15 D
+52 -9 D
+53 -5 D
+52 1 D
+52 6 D
+35 7 D
+67 21 D
+48 22 D
+31 16 D
+43 29 D
+28 22 D
+38 36 D
+24 26 D
+32 42 D
+19 30 D
+17 30 D
+21 48 D
+21 67 D
+9 52 D
+5 53 D
+P S
+2362 1181 M
+0 40 D
+-2 39 D
+-8 79 D
+-13 77 D
+-19 77 D
+-23 76 D
+-29 73 D
+-33 72 D
+-18 35 D
+-40 68 D
+-45 65 D
+-49 62 D
+-53 58 D
+-57 55 D
+-29 26 D
+-62 49 D
+-65 45 D
+-68 40 D
+-71 35 D
+-72 31 D
+-37 14 D
+-76 23 D
+-77 19 D
+-77 13 D
+-79 8 D
+-39 2 D
+-40 0 D
+-39 0 D
+-40 -2 D
+-39 -4 D
+-39 -4 D
+-39 -6 D
+-39 -7 D
+-39 -9 D
+-38 -10 D
+-38 -11 D
+-37 -12 D
+-37 -14 D
+-37 -15 D
+-36 -16 D
+-36 -17 D
+-35 -18 D
+-67 -40 D
+-66 -45 D
+-61 -49 D
+-59 -53 D
+-55 -57 D
+-26 -29 D
+-49 -62 D
+-23 -32 D
+-62 -101 D
+-35 -71 D
+-31 -72 D
+-14 -37 D
+-23 -76 D
+-10 -38 D
+-16 -77 D
+-10 -79 D
+-5 -78 D
+-1 -40 D
+3 -79 D
+3 -39 D
+10 -78 D
+16 -78 D
+21 -76 D
+12 -37 D
+29 -74 D
+33 -72 D
+18 -35 D
+41 -67 D
+21 -33 D
+23 -33 D
+49 -61 D
+53 -59 D
+57 -55 D
+60 -51 D
+31 -24 D
+33 -23 D
+66 -42 D
+34 -20 D
+71 -35 D
+73 -31 D
+37 -14 D
+75 -23 D
+38 -10 D
+78 -16 D
+78 -10 D
+79 -5 D
+39 -1 D
+79 3 D
+79 8 D
+39 5 D
+77 16 D
+76 21 D
+38 12 D
+73 29 D
+72 33 D
+35 18 D
+101 62 D
+63 47 D
+31 25 D
+58 53 D
+55 57 D
+51 60 D
+24 31 D
+45 66 D
+40 67 D
+35 71 D
+31 73 D
+14 37 D
+23 75 D
+19 77 D
+13 78 D
+8 78 D
+P S
+/PSL_H_y 300 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+83 F0
+(100°) sh add def
+1181 2362 PSL_H_y add M
+200 F0
+(\053fe) bc Z
+1780 2172 M 83 F0
+V -30 R (0°) tl Z U
+1715 2058 M V -30 R (10°) tl Z U
+1649 1944 M V -30 R (20°) tl Z U
+1583 1831 M V -30 R (30°) tl Z U
+1518 1717 M V -30 R (40°) tl Z U
+2429 1181 M V -90 R (0°) bc Z U
+1639 1181 M V -90 R (0°) tc Z U
+2262 1805 M V -60 R (30°) bc Z U
+1578 1410 M V -60 R (30°) tc Z U
+1805 2262 M V -30 R (60°) bc Z U
+1410 1578 M V -30 R (60°) tc Z U
+1181 2429 M V -2.84e-14 R (90°) bc Z U
+1181 1639 M (90°) tc Z
+557 2262 M V 30 R (120°) bc Z U
+952 1578 M V 30 R (120°) tc Z U
+101 1805 M V 60 R (150°) bc Z U
+784 1410 M V 60 R (150°) tc Z U
+-67 1181 M V 90 R (180°) bc Z U
+723 1181 M V -270 R (180°) tc Z U
+101 557 M V 300 R (-150°) tc Z U
+784 952 M V -60 R (-150°) bc Z U
+557 101 M V 330 R (-120°) tc Z U
+952 784 M V -30 R (-120°) bc Z U
+1181 -67 M V 360 R (-90°) tc Z U
+1181 723 M (-90°) bc Z
+1805 101 M V 390 R (-60°) tc Z U
+1410 784 M V 30 R (-60°) bc Z U
+2262 557 M V 420 R (-30°) tc Z U
+1578 952 M V 60 R (-30°) bc Z U
+%%EndObject
+-6036 -9055 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 6036 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/1000/3000 -JP1.9685i+fp -BWENS+i60+t\053fp -Bxxa30fg -Byyafg -Xa0i -Ya5.0303i
+%@PROJ: polar 0.00000000 360.00000000 1000.00000000 3000.00000000 -5378.137 5378.137 -5378.137 5378.137 +unavailable +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+2362 1181 M
+-439 0 D
+S
+2204 1772 M
+-380 -220 D
+S
+1772 2204 M
+-220 -380 D
+S
+1181 2362 M
+0 -439 D
+S
+591 2204 M
+219 -380 D
+S
+158 1772 M
+381 -220 D
+S
+0 1181 M
+439 0 D
+S
+158 591 M
+381 219 D
+S
+591 158 M
+219 381 D
+S
+1181 0 M
+0 439 D
+S
+1772 158 M
+-220 381 D
+S
+2204 591 M
+-380 219 D
+S
+2362 1181 M
+-1 59 D
+-10 107 D
+-16 86 D
+-19 76 D
+-31 92 D
+-26 63 D
+-21 45 D
+-42 77 D
+-42 65 D
+-53 71 D
+-51 59 D
+-55 56 D
+-43 39 D
+-61 49 D
+-64 45 D
+-58 36 D
+-69 36 D
+-53 25 D
+-82 31 D
+-85 26 D
+-85 19 D
+-68 10 D
+-87 8 D
+-98 1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-17 -9 D
+-17 -9 D
+-18 -9 D
+-17 -9 D
+-16 -10 D
+-17 -10 D
+-17 -11 D
+-24 -16 D
+-24 -17 D
+-24 -17 D
+-31 -24 D
+-52 -44 D
+-63 -62 D
+-26 -28 D
+-56 -68 D
+-51 -72 D
+-26 -41 D
+-14 -26 D
+-32 -60 D
+-21 -44 D
+-32 -82 D
+-21 -65 D
+-21 -86 D
+-9 -47 D
+-9 -68 D
+-6 -68 D
+-1 -88 D
+5 -78 D
+8 -68 D
+12 -67 D
+16 -67 D
+29 -93 D
+37 -90 D
+40 -79 D
+45 -75 D
+51 -72 D
+43 -53 D
+53 -57 D
+42 -41 D
+59 -51 D
+63 -47 D
+40 -27 D
+76 -45 D
+88 -43 D
+81 -32 D
+65 -21 D
+95 -23 D
+87 -14 D
+88 -8 D
+87 -1 D
+78 5 D
+68 8 D
+67 12 D
+67 16 D
+93 29 D
+55 22 D
+35 15 D
+36 17 D
+60 33 D
+17 9 D
+57 37 D
+64 46 D
+45 37 D
+57 53 D
+48 49 D
+44 52 D
+53 71 D
+52 82 D
+45 87 D
+27 63 D
+20 55 D
+26 84 D
+19 85 D
+10 68 D
+8 88 D
+P S
+2252 1181 M
+-1 62 D
+-10 97 D
+-17 87 D
+-16 60 D
+-35 100 D
+-22 49 D
+-19 39 D
+-44 77 D
+-45 66 D
+-39 49 D
+-35 40 D
+-30 32 D
+-59 54 D
+-41 34 D
+-57 41 D
+-45 29 D
+-85 47 D
+-73 32 D
+-75 27 D
+-86 23 D
+-78 15 D
+-97 10 D
+-9 0 D
+-88 1 D
+-9 -1 D
+-9 0 D
+-9 0 D
+-9 -1 D
+-9 -1 D
+-8 0 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-8 -2 D
+-9 -1 D
+-9 -2 D
+-9 -1 D
+-8 -2 D
+-9 -2 D
+-9 -1 D
+-8 -2 D
+-9 -2 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-8 -3 D
+-9 -2 D
+-9 -2 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-16 -8 D
+-8 -4 D
+-8 -3 D
+-16 -8 D
+-16 -9 D
+-16 -8 D
+-15 -9 D
+-15 -9 D
+-15 -9 D
+-15 -9 D
+-23 -15 D
+-21 -15 D
+-22 -16 D
+-28 -21 D
+-47 -41 D
+-51 -49 D
+-42 -46 D
+-39 -48 D
+-36 -50 D
+-15 -22 D
+-40 -69 D
+-35 -71 D
+-21 -49 D
+-29 -84 D
+-20 -77 D
+-11 -61 D
+-10 -79 D
+-3 -71 D
+1 -71 D
+6 -71 D
+10 -70 D
+13 -60 D
+17 -60 D
+29 -84 D
+29 -64 D
+32 -63 D
+37 -61 D
+30 -44 D
+38 -49 D
+35 -40 D
+30 -32 D
+7 -6 D
+12 -13 D
+46 -42 D
+48 -39 D
+50 -36 D
+60 -38 D
+63 -33 D
+48 -23 D
+49 -20 D
+75 -26 D
+78 -20 D
+61 -11 D
+79 -10 D
+79 -3 D
+62 1 D
+62 5 D
+61 8 D
+78 16 D
+60 17 D
+84 29 D
+65 29 D
+62 32 D
+61 37 D
+44 30 D
+56 44 D
+40 35 D
+44 43 D
+48 53 D
+33 41 D
+36 50 D
+20 30 D
+35 61 D
+21 40 D
+32 72 D
+27 75 D
+23 86 D
+12 61 D
+11 88 D
+3 70 D
+P S
+2143 1181 M
+-3 72 D
+-9 79 D
+-14 70 D
+-21 76 D
+-28 75 D
+-30 65 D
+-43 76 D
+-9 13 D
+-36 52 D
+-40 50 D
+-49 52 D
+-23 22 D
+-35 32 D
+-50 39 D
+-46 32 D
+-34 21 D
+-55 31 D
+-73 33 D
+-74 27 D
+-77 21 D
+-70 13 D
+-71 8 D
+-80 3 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-8 -2 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-7 -2 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-14 -7 D
+-8 -3 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-8 -4 D
+-13 -7 D
+-14 -8 D
+-14 -8 D
+-14 -8 D
+-20 -13 D
+-20 -13 D
+-25 -19 D
+-13 -9 D
+-31 -25 D
+-48 -42 D
+-5 -6 D
+-12 -11 D
+-5 -6 D
+-6 -5 D
+-43 -47 D
+-30 -38 D
+-32 -45 D
+-30 -47 D
+-31 -55 D
+-36 -80 D
+-19 -52 D
+-20 -69 D
+-14 -62 D
+-11 -79 D
+-4 -71 D
+1 -80 D
+8 -79 D
+11 -62 D
+17 -70 D
+23 -68 D
+17 -44 D
+27 -57 D
+19 -35 D
+20 -35 D
+9 -13 D
+17 -27 D
+48 -63 D
+42 -48 D
+22 -23 D
+47 -43 D
+49 -41 D
+45 -32 D
+27 -17 D
+13 -9 D
+48 -27 D
+50 -25 D
+52 -22 D
+60 -21 D
+76 -21 D
+71 -13 D
+71 -8 D
+55 -2 D
+72 1 D
+79 8 D
+62 11 D
+70 17 D
+68 23 D
+44 17 D
+65 31 D
+62 35 D
+46 31 D
+45 33 D
+43 36 D
+29 27 D
+5 6 D
+12 11 D
+5 6 D
+6 5 D
+57 66 D
+15 19 D
+9 13 D
+27 39 D
+29 48 D
+15 27 D
+25 50 D
+25 59 D
+18 53 D
+21 76 D
+13 71 D
+8 71 D
+P S
+2033 1181 M
+-2 56 D
+-5 49 D
+-11 70 D
+-16 61 D
+-12 41 D
+-23 59 D
+-27 57 D
+-28 49 D
+-39 59 D
+-21 28 D
+-27 32 D
+-29 31 D
+-40 39 D
+-32 28 D
+-45 34 D
+-59 39 D
+-31 17 D
+-37 19 D
+-58 26 D
+-53 18 D
+-68 19 D
+-63 11 D
+-56 7 D
+-70 3 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -3 D
+-7 -2 D
+-6 -2 D
+-7 -3 D
+-6 -2 D
+-7 -3 D
+-7 -3 D
+-6 -2 D
+-7 -3 D
+-12 -6 D
+-7 -3 D
+-13 -6 D
+-12 -6 D
+-7 -3 D
+-12 -7 D
+-12 -6 D
+-13 -7 D
+-12 -7 D
+-12 -8 D
+-12 -7 D
+-17 -12 D
+-18 -12 D
+-17 -12 D
+-11 -9 D
+-27 -22 D
+-32 -28 D
+-49 -50 D
+-19 -21 D
+-39 -50 D
+-43 -65 D
+-17 -31 D
+-19 -37 D
+-15 -32 D
+-27 -73 D
+-19 -68 D
+-11 -55 D
+-9 -70 D
+-2 -49 D
+-1 -28 D
+3 -63 D
+11 -84 D
+16 -69 D
+14 -47 D
+28 -72 D
+24 -51 D
+28 -49 D
+39 -59 D
+17 -22 D
+31 -38 D
+29 -31 D
+40 -39 D
+32 -28 D
+23 -17 D
+16 -13 D
+65 -43 D
+56 -30 D
+44 -21 D
+53 -20 D
+74 -23 D
+69 -14 D
+70 -9 D
+49 -2 D
+28 -1 D
+63 3 D
+84 11 D
+69 16 D
+67 21 D
+59 24 D
+44 21 D
+49 28 D
+59 39 D
+28 21 D
+32 27 D
+31 29 D
+39 40 D
+28 32 D
+17 23 D
+13 16 D
+43 65 D
+30 56 D
+26 57 D
+20 53 D
+23 82 D
+11 62 D
+7 56 D
+P S
+1923 1181 M
+-1 37 D
+-7 73 D
+-12 60 D
+-16 59 D
+-17 46 D
+-36 78 D
+-12 22 D
+-27 41 D
+-28 40 D
+-48 56 D
+-18 17 D
+-8 9 D
+-56 48 D
+-60 42 D
+-43 25 D
+-78 36 D
+-46 17 D
+-71 19 D
+-48 9 D
+-85 8 D
+-13 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-13 -1 D
+-12 -1 D
+-12 -1 D
+-12 -1 D
+-13 -1 D
+-12 -2 D
+-12 -1 D
+-12 -2 D
+-12 -2 D
+-12 -3 D
+-12 -2 D
+-12 -3 D
+-12 -3 D
+-12 -3 D
+-12 -3 D
+-11 -4 D
+-12 -3 D
+-12 -4 D
+-11 -4 D
+-12 -5 D
+-11 -4 D
+-12 -5 D
+-11 -5 D
+-11 -5 D
+-11 -5 D
+-22 -11 D
+-22 -11 D
+-21 -13 D
+-21 -13 D
+-30 -21 D
+-20 -14 D
+-64 -57 D
+-26 -26 D
+-47 -57 D
+-35 -50 D
+-41 -76 D
+-29 -67 D
+-18 -59 D
+-14 -60 D
+-8 -60 D
+-4 -62 D
+2 -61 D
+6 -61 D
+12 -60 D
+13 -47 D
+11 -35 D
+29 -68 D
+35 -65 D
+27 -41 D
+29 -39 D
+49 -55 D
+45 -42 D
+48 -38 D
+41 -28 D
+64 -36 D
+67 -29 D
+23 -9 D
+59 -17 D
+60 -13 D
+61 -7 D
+61 -3 D
+61 3 D
+61 7 D
+60 13 D
+36 10 D
+35 11 D
+78 34 D
+65 36 D
+60 43 D
+47 39 D
+43 44 D
+40 46 D
+42 61 D
+25 42 D
+36 78 D
+17 46 D
+19 71 D
+9 48 D
+8 86 D
+P S
+8 W
+N 2362 1181 M 34 0 D S
+N 1923 1181 M -33 0 D S
+N 2204 1772 M 29 16 D S
+N 1824 1552 M -29 -17 D S
+N 1772 2204 M 16 29 D S
+N 1552 1824 M -17 -29 D S
+N 1181 2362 M 0 34 D S
+N 1181 1923 M 0 -33 D S
+N 591 2204 M -17 29 D S
+N 810 1824 M 17 -29 D S
+N 158 1772 M -29 16 D S
+N 539 1552 M 28 -17 D S
+N 0 1181 M -33 0 D S
+N 439 1181 M 34 0 D S
+N 158 591 M -29 -17 D S
+N 539 810 M 28 17 D S
+N 591 158 M -17 -29 D S
+N 810 539 M 17 28 D S
+N 1181 0 M 0 -33 D S
+N 1181 439 M 0 34 D S
+N 1772 158 M 16 -29 D S
+N 1552 539 M -17 28 D S
+N 2204 591 M 29 -17 D S
+N 1824 810 M -29 17 D S
+N 2362 1181 M 34 0 D S
+N 1923 1181 M -33 0 D S
+25 W
+1923 1181 M
+0 25 D
+-7 74 D
+-8 49 D
+-11 48 D
+-15 47 D
+-18 47 D
+-32 67 D
+-39 63 D
+-45 59 D
+-51 54 D
+-37 34 D
+-59 45 D
+-63 39 D
+-67 32 D
+-70 26 D
+-48 13 D
+-49 10 D
+-73 8 D
+-25 2 D
+-25 0 D
+-25 0 D
+-24 -2 D
+-25 -2 D
+-25 -3 D
+-24 -3 D
+-25 -5 D
+-24 -5 D
+-24 -6 D
+-24 -7 D
+-23 -8 D
+-24 -9 D
+-23 -9 D
+-22 -10 D
+-44 -22 D
+-43 -26 D
+-21 -13 D
+-59 -45 D
+-54 -51 D
+-33 -37 D
+-31 -39 D
+-15 -20 D
+-38 -63 D
+-23 -45 D
+-19 -45 D
+-16 -47 D
+-14 -48 D
+-13 -73 D
+-5 -49 D
+-2 -50 D
+4 -74 D
+11 -74 D
+5 -24 D
+21 -71 D
+18 -47 D
+21 -44 D
+24 -44 D
+26 -42 D
+30 -40 D
+32 -38 D
+34 -35 D
+37 -33 D
+39 -31 D
+20 -15 D
+42 -26 D
+66 -35 D
+45 -19 D
+47 -16 D
+48 -14 D
+73 -13 D
+74 -6 D
+25 -1 D
+74 4 D
+74 11 D
+24 5 D
+71 21 D
+47 18 D
+45 21 D
+64 37 D
+21 13 D
+40 30 D
+38 32 D
+35 34 D
+34 37 D
+45 59 D
+39 64 D
+32 66 D
+26 70 D
+13 48 D
+10 49 D
+8 74 D
+2 24 D
+P S
+2362 1181 M
+0 40 D
+-2 39 D
+-8 79 D
+-13 77 D
+-19 77 D
+-23 76 D
+-29 73 D
+-33 72 D
+-18 35 D
+-40 68 D
+-45 65 D
+-49 62 D
+-53 58 D
+-57 55 D
+-29 26 D
+-62 49 D
+-65 45 D
+-68 40 D
+-71 35 D
+-72 31 D
+-37 14 D
+-76 23 D
+-77 19 D
+-77 13 D
+-79 8 D
+-39 2 D
+-40 0 D
+-39 0 D
+-40 -2 D
+-39 -4 D
+-39 -4 D
+-39 -6 D
+-39 -7 D
+-39 -9 D
+-38 -10 D
+-38 -11 D
+-37 -12 D
+-37 -14 D
+-37 -15 D
+-36 -16 D
+-36 -17 D
+-35 -18 D
+-67 -40 D
+-66 -45 D
+-61 -49 D
+-59 -53 D
+-55 -57 D
+-26 -29 D
+-49 -62 D
+-23 -32 D
+-62 -101 D
+-35 -71 D
+-31 -72 D
+-14 -37 D
+-23 -76 D
+-10 -38 D
+-16 -77 D
+-10 -79 D
+-5 -78 D
+-1 -40 D
+3 -79 D
+3 -39 D
+10 -78 D
+16 -78 D
+21 -76 D
+12 -37 D
+29 -74 D
+33 -72 D
+18 -35 D
+41 -67 D
+21 -33 D
+23 -33 D
+49 -61 D
+53 -59 D
+57 -55 D
+60 -51 D
+31 -24 D
+33 -23 D
+66 -42 D
+34 -20 D
+71 -35 D
+73 -31 D
+37 -14 D
+75 -23 D
+38 -10 D
+78 -16 D
+78 -10 D
+79 -5 D
+39 -1 D
+79 3 D
+79 8 D
+39 5 D
+77 16 D
+76 21 D
+38 12 D
+73 29 D
+72 33 D
+35 18 D
+101 62 D
+63 47 D
+31 25 D
+58 53 D
+55 57 D
+51 60 D
+24 31 D
+45 66 D
+40 67 D
+35 71 D
+31 73 D
+14 37 D
+23 75 D
+19 77 D
+13 78 D
+8 78 D
+P S
+/PSL_H_y 300 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+83 F0
+(100°) sh add def
+1181 2362 PSL_H_y add M
+200 F0
+(\053fp) bc Z
+1780 2172 M 83 F0
+V -30 R (1000) tl Z U
+1725 2077 M V -30 R (1500) tl Z U
+1670 1982 M V -30 R (2000) tl Z U
+1616 1886 M V -30 R (2500) tl Z U
+2429 1181 M V -90 R (0°) bc Z U
+1856 1181 M V -90 R (0°) tc Z U
+2262 1805 M V -60 R (30°) bc Z U
+1766 1519 M V -60 R (30°) tc Z U
+1805 2262 M V -30 R (60°) bc Z U
+1519 1766 M V -30 R (60°) tc Z U
+1181 2429 M V -4.26e-14 R (90°) bc Z U
+1181 1856 M (90°) tc Z
+557 2262 M V 30 R (120°) bc Z U
+843 1766 M V 30 R (120°) tc Z U
+101 1805 M V 60 R (150°) bc Z U
+596 1519 M V 60 R (150°) tc Z U
+-67 1181 M V 90 R (180°) bc Z U
+506 1181 M V -270 R (180°) tc Z U
+101 557 M V 300 R (-150°) tc Z U
+596 843 M V -60 R (-150°) bc Z U
+557 101 M V 330 R (-120°) tc Z U
+843 596 M V -30 R (-120°) bc Z U
+1181 -67 M V 360 R (-90°) tc Z U
+1181 506 M (-90°) bc Z
+1805 101 M V 390 R (-60°) tc Z U
+1519 596 M V 30 R (-60°) bc Z U
+2262 557 M V 420 R (-30°) tc Z U
+1766 843 M V 60 R (-30°) bc Z U
+%%EndObject
+0 -6036 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3018 6036 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/1000/3000 -JP1.9685i+z -BWENS+i60+t\053z -Bxxa30fg -Byyafg -Xa2.5152i -Ya5.0303i
+%@PROJ: polar 0.00000000 360.00000000 1000.00000000 3000.00000000 -3000.000 3000.000 -3000.000 3000.000 +unavailable +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+1575 1181 M
+787 0 D
+S
+1522 1378 M
+682 394 D
+S
+1378 1522 M
+394 682 D
+S
+1181 1575 M
+0 787 D
+S
+984 1522 M
+-393 682 D
+S
+840 1378 M
+-682 394 D
+S
+787 1181 M
+-787 0 D
+S
+840 984 M
+-682 -393 D
+S
+984 840 M
+-393 -682 D
+S
+1181 787 M
+0 -787 D
+S
+1378 840 M
+394 -682 D
+S
+1522 984 M
+682 -393 D
+S
+2362 1181 M
+-1 59 D
+-10 107 D
+-16 86 D
+-19 76 D
+-31 92 D
+-26 63 D
+-21 45 D
+-42 77 D
+-42 65 D
+-53 71 D
+-51 59 D
+-55 56 D
+-43 39 D
+-61 49 D
+-64 45 D
+-58 36 D
+-69 36 D
+-53 25 D
+-82 31 D
+-85 26 D
+-85 19 D
+-68 10 D
+-87 8 D
+-98 1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-17 -9 D
+-17 -9 D
+-18 -9 D
+-17 -9 D
+-16 -10 D
+-17 -10 D
+-17 -11 D
+-24 -16 D
+-24 -17 D
+-24 -17 D
+-31 -24 D
+-52 -44 D
+-63 -62 D
+-26 -28 D
+-56 -68 D
+-51 -72 D
+-26 -41 D
+-14 -26 D
+-32 -60 D
+-21 -44 D
+-32 -82 D
+-21 -65 D
+-21 -86 D
+-9 -47 D
+-9 -68 D
+-6 -68 D
+-1 -88 D
+5 -78 D
+8 -68 D
+12 -67 D
+16 -67 D
+29 -93 D
+37 -90 D
+40 -79 D
+45 -75 D
+51 -72 D
+43 -53 D
+53 -57 D
+42 -41 D
+59 -51 D
+63 -47 D
+40 -27 D
+76 -45 D
+88 -43 D
+81 -32 D
+65 -21 D
+95 -23 D
+87 -14 D
+88 -8 D
+87 -1 D
+78 5 D
+68 8 D
+67 12 D
+67 16 D
+93 29 D
+55 22 D
+35 15 D
+36 17 D
+60 33 D
+17 9 D
+57 37 D
+64 46 D
+45 37 D
+57 53 D
+48 49 D
+44 52 D
+53 71 D
+52 82 D
+45 87 D
+27 63 D
+20 55 D
+26 84 D
+19 85 D
+10 68 D
+8 88 D
+P S
+2165 1181 M
+-1 57 D
+-7 73 D
+-11 64 D
+-19 79 D
+-15 47 D
+-26 68 D
+-28 59 D
+-31 57 D
+-17 28 D
+-52 73 D
+-47 56 D
+-17 18 D
+-6 5 D
+-17 18 D
+-6 5 D
+-11 12 D
+-24 22 D
+-57 46 D
+-67 46 D
+-64 37 D
+-58 28 D
+-68 28 D
+-46 15 D
+-79 21 D
+-56 10 D
+-56 8 D
+-73 4 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -2 D
+-8 -1 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-8 -2 D
+-8 -3 D
+-8 -2 D
+-7 -2 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-8 -3 D
+-15 -7 D
+-15 -7 D
+-14 -7 D
+-15 -7 D
+-14 -7 D
+-14 -8 D
+-15 -8 D
+-14 -8 D
+-14 -9 D
+-20 -13 D
+-21 -14 D
+-19 -14 D
+-20 -14 D
+-26 -20 D
+-30 -27 D
+-13 -11 D
+-35 -34 D
+-5 -6 D
+-12 -11 D
+-68 -81 D
+-50 -74 D
+-29 -49 D
+-7 -15 D
+-8 -14 D
+-30 -67 D
+-20 -53 D
+-21 -70 D
+-13 -56 D
+-13 -80 D
+-5 -65 D
+-1 -81 D
+5 -65 D
+3 -33 D
+13 -72 D
+17 -71 D
+29 -85 D
+29 -67 D
+38 -72 D
+17 -28 D
+14 -20 D
+23 -33 D
+14 -20 D
+58 -69 D
+34 -35 D
+29 -28 D
+69 -57 D
+54 -37 D
+55 -34 D
+73 -37 D
+68 -28 D
+77 -25 D
+71 -17 D
+80 -13 D
+65 -5 D
+82 -1 D
+97 8 D
+72 13 D
+71 17 D
+77 26 D
+31 12 D
+66 31 D
+14 8 D
+15 7 D
+56 34 D
+47 32 D
+38 29 D
+56 48 D
+11 12 D
+18 17 D
+28 29 D
+26 31 D
+16 19 D
+20 26 D
+41 60 D
+37 64 D
+28 58 D
+28 68 D
+22 70 D
+19 79 D
+13 89 D
+4 73 D
+P S
+1968 1181 M
+-1 52 D
+-8 71 D
+-7 39 D
+-18 69 D
+-19 55 D
+-21 48 D
+-20 41 D
+-30 50 D
+-26 38 D
+-53 66 D
+-5 4 D
+-13 15 D
+-5 4 D
+-4 5 D
+-5 4 D
+-9 10 D
+-10 8 D
+-4 5 D
+-71 57 D
+-60 39 D
+-46 25 D
+-54 24 D
+-48 18 D
+-31 10 D
+-83 19 D
+-58 8 D
+-58 3 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-12 -6 D
+-12 -6 D
+-6 -2 D
+-11 -6 D
+-12 -6 D
+-11 -7 D
+-11 -6 D
+-12 -7 D
+-11 -7 D
+-11 -7 D
+-16 -11 D
+-16 -11 D
+-21 -16 D
+-25 -20 D
+-34 -30 D
+-9 -10 D
+-5 -4 D
+-4 -5 D
+-5 -4 D
+-13 -15 D
+-5 -4 D
+-57 -71 D
+-7 -11 D
+-25 -38 D
+-22 -40 D
+-29 -59 D
+-25 -67 D
+-16 -56 D
+-9 -44 D
+-6 -33 D
+-6 -64 D
+-1 -78 D
+5 -59 D
+5 -39 D
+17 -76 D
+15 -50 D
+24 -60 D
+29 -59 D
+29 -50 D
+34 -48 D
+41 -51 D
+31 -33 D
+48 -44 D
+52 -40 D
+43 -29 D
+51 -28 D
+53 -26 D
+67 -25 D
+56 -16 D
+77 -15 D
+65 -6 D
+78 -1 D
+58 5 D
+39 5 D
+57 12 D
+63 18 D
+66 26 D
+65 32 D
+17 9 D
+49 32 D
+21 15 D
+61 49 D
+4 5 D
+15 13 D
+4 5 D
+5 4 D
+9 10 D
+5 4 D
+38 44 D
+36 47 D
+38 60 D
+6 12 D
+7 11 D
+28 59 D
+21 54 D
+17 57 D
+15 69 D
+8 65 D
+2 46 D
+P S
+1772 1181 M
+-4 68 D
+-8 49 D
+-9 38 D
+-11 37 D
+-26 63 D
+-28 52 D
+-27 40 D
+-37 46 D
+-41 42 D
+-45 37 D
+-24 17 D
+-41 26 D
+-53 26 D
+-54 21 D
+-47 13 D
+-48 9 D
+-39 5 D
+-59 2 D
+-9 -1 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -1 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -3 D
+-10 -3 D
+-9 -2 D
+-9 -3 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-18 -9 D
+-17 -9 D
+-17 -9 D
+-17 -10 D
+-24 -16 D
+-31 -24 D
+-37 -32 D
+-34 -35 D
+-37 -46 D
+-27 -40 D
+-28 -52 D
+-19 -45 D
+-10 -27 D
+-17 -66 D
+-9 -58 D
+-2 -59 D
+1 -39 D
+5 -48 D
+9 -48 D
+13 -47 D
+25 -64 D
+27 -52 D
+21 -33 D
+35 -47 D
+40 -43 D
+21 -20 D
+46 -37 D
+41 -27 D
+16 -10 D
+53 -26 D
+55 -21 D
+66 -17 D
+58 -9 D
+48 -2 D
+49 1 D
+20 1 D
+67 11 D
+38 10 D
+19 5 D
+63 25 D
+44 22 D
+41 26 D
+47 35 D
+43 40 D
+27 29 D
+36 46 D
+31 49 D
+26 53 D
+21 55 D
+13 47 D
+9 48 D
+5 38 D
+P S
+1575 1181 M
+-3 46 D
+-9 51 D
+-7 25 D
+-17 42 D
+-21 40 D
+-22 33 D
+-25 30 D
+-5 4 D
+-9 10 D
+-5 4 D
+-4 5 D
+-35 29 D
+-39 24 D
+-47 23 D
+-24 9 D
+-44 11 D
+-52 7 D
+-39 1 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -2 D
+-7 -1 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -1 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-12 -6 D
+-12 -6 D
+-11 -6 D
+-11 -6 D
+-17 -11 D
+-16 -11 D
+-30 -25 D
+-4 -5 D
+-10 -9 D
+-4 -5 D
+-5 -4 D
+-25 -30 D
+-28 -44 D
+-20 -41 D
+-19 -55 D
+-10 -58 D
+-2 -45 D
+4 -46 D
+8 -45 D
+19 -55 D
+23 -47 D
+18 -27 D
+15 -21 D
+17 -20 D
+5 -4 D
+9 -10 D
+5 -4 D
+4 -5 D
+30 -25 D
+11 -7 D
+33 -21 D
+41 -20 D
+55 -19 D
+58 -10 D
+46 -2 D
+45 4 D
+45 8 D
+55 19 D
+47 23 D
+43 29 D
+25 21 D
+4 5 D
+10 9 D
+4 5 D
+5 4 D
+29 36 D
+24 38 D
+23 47 D
+9 24 D
+11 44 D
+7 52 D
+P S
+8 W
+N 1575 1181 M -34 0 D S
+N 2362 1181 M 34 0 D S
+N 1522 1378 M -29 -17 D S
+N 2204 1772 M 29 16 D S
+N 1378 1522 M -17 -29 D S
+N 1772 2204 M 16 29 D S
+N 1181 1575 M 0 -34 D S
+N 1181 2362 M 0 34 D S
+N 984 1522 M 17 -29 D S
+N 591 2204 M -17 29 D S
+N 840 1378 M 29 -17 D S
+N 158 1772 M -29 16 D S
+N 787 1181 M 34 0 D S
+N 0 1181 M -33 0 D S
+N 840 984 M 29 17 D S
+N 158 591 M -29 -17 D S
+N 984 840 M 17 29 D S
+N 591 158 M -17 -29 D S
+N 1181 787 M 0 34 D S
+N 1181 0 M 0 -33 D S
+N 1378 840 M -17 29 D S
+N 1772 158 M 16 -29 D S
+N 1522 984 M -29 17 D S
+N 2204 591 M 29 -17 D S
+N 1575 1181 M -34 0 D S
+N 2362 1181 M 34 0 D S
+25 W
+2362 1181 M
+0 40 D
+-2 39 D
+-8 79 D
+-13 77 D
+-19 77 D
+-23 76 D
+-29 73 D
+-33 72 D
+-18 35 D
+-40 68 D
+-45 65 D
+-49 62 D
+-53 58 D
+-57 55 D
+-29 26 D
+-62 49 D
+-65 45 D
+-68 40 D
+-71 35 D
+-72 31 D
+-37 14 D
+-76 23 D
+-77 19 D
+-77 13 D
+-79 8 D
+-39 2 D
+-40 0 D
+-39 0 D
+-40 -2 D
+-39 -4 D
+-39 -4 D
+-39 -6 D
+-39 -7 D
+-39 -9 D
+-38 -10 D
+-38 -11 D
+-37 -12 D
+-37 -14 D
+-37 -15 D
+-36 -16 D
+-36 -17 D
+-35 -18 D
+-67 -40 D
+-66 -45 D
+-61 -49 D
+-59 -53 D
+-55 -57 D
+-26 -29 D
+-49 -62 D
+-23 -32 D
+-62 -101 D
+-35 -71 D
+-31 -72 D
+-14 -37 D
+-23 -76 D
+-10 -38 D
+-16 -77 D
+-10 -79 D
+-5 -78 D
+-1 -40 D
+3 -79 D
+3 -39 D
+10 -78 D
+16 -78 D
+21 -76 D
+12 -37 D
+29 -74 D
+33 -72 D
+18 -35 D
+41 -67 D
+21 -33 D
+23 -33 D
+49 -61 D
+53 -59 D
+57 -55 D
+60 -51 D
+31 -24 D
+33 -23 D
+66 -42 D
+34 -20 D
+71 -35 D
+73 -31 D
+37 -14 D
+75 -23 D
+38 -10 D
+78 -16 D
+78 -10 D
+79 -5 D
+39 -1 D
+79 3 D
+79 8 D
+39 5 D
+77 16 D
+76 21 D
+38 12 D
+73 29 D
+72 33 D
+35 18 D
+101 62 D
+63 47 D
+31 25 D
+58 53 D
+55 57 D
+51 60 D
+24 31 D
+45 66 D
+40 67 D
+35 71 D
+31 73 D
+14 37 D
+23 75 D
+19 77 D
+13 78 D
+8 78 D
+P S
+1575 1181 M
+-2 40 D
+-9 51 D
+-11 38 D
+-9 25 D
+-24 47 D
+-22 33 D
+-25 30 D
+-18 19 D
+-30 26 D
+-32 23 D
+-34 19 D
+-24 12 D
+-50 17 D
+-38 8 D
+-40 5 D
+-39 1 D
+-13 -1 D
+-13 -1 D
+-13 -2 D
+-13 -2 D
+-13 -2 D
+-13 -3 D
+-13 -3 D
+-13 -4 D
+-12 -4 D
+-12 -5 D
+-13 -4 D
+-23 -12 D
+-24 -12 D
+-22 -14 D
+-41 -33 D
+-19 -18 D
+-26 -30 D
+-23 -32 D
+-19 -34 D
+-21 -49 D
+-11 -38 D
+-9 -51 D
+-2 -40 D
+2 -39 D
+9 -52 D
+11 -38 D
+15 -37 D
+18 -35 D
+38 -53 D
+27 -29 D
+30 -26 D
+43 -30 D
+47 -23 D
+37 -14 D
+39 -10 D
+52 -7 D
+26 -1 D
+40 2 D
+51 9 D
+38 11 D
+49 21 D
+34 19 D
+32 23 D
+39 35 D
+26 30 D
+23 32 D
+13 23 D
+18 35 D
+17 50 D
+8 39 D
+5 39 D
+P S
+/PSL_H_y 300 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+83 F0
+(100°) sh add def
+1181 2362 PSL_H_y add M
+200 F0
+(\053z) bc Z
+1780 2172 M 83 F0
+V -30 R (0) tl Z U
+1682 2001 M V -30 R (500) tl Z U
+1583 1831 M V -30 R (1000) tl Z U
+1485 1660 M V -30 R (1500) tl Z U
+1508 1181 M V -90 R (0°) tc Z U
+2429 1181 M V -90 R (0°) bc Z U
+1464 1345 M V -60 R (30°) tc Z U
+2262 1805 M V -60 R (30°) bc Z U
+1345 1464 M V -30 R (60°) tc Z U
+1805 2262 M V -30 R (60°) bc Z U
+1181 1508 M (90°) tc Z
+1181 2429 M V -2.84e-14 R (90°) bc Z U
+1018 1464 M V 30 R (120°) tc Z U
+557 2262 M V 30 R (120°) bc Z U
+898 1345 M V 60 R (150°) tc Z U
+101 1805 M V 60 R (150°) bc Z U
+854 1181 M V -270 R (180°) tc Z U
+-67 1181 M V 90 R (180°) bc Z U
+898 1018 M V -60 R (-150°) bc Z U
+101 557 M V 300 R (-150°) tc Z U
+1018 898 M V -30 R (-120°) bc Z U
+557 101 M V 330 R (-120°) tc Z U
+1181 854 M (-90°) bc Z
+1181 -67 M V 360 R (-90°) tc Z U
+1345 898 M V 30 R (-60°) bc Z U
+1805 101 M V 390 R (-60°) tc Z U
+1464 1018 M V 60 R (-30°) bc Z U
+2262 557 M V 420 R (-30°) tc Z U
+%%EndObject
+-3018 -6036 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+6036 6036 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/0/2891 -JP1.9685i+zp -BWENS+i60+t\053zp -Bxxa30fg -Byyafg -Xa5.0303i -Ya5.0303i
+%@PROJ: polar 0.00000000 360.00000000 0.00000000 2891.00000000 -6378.137 6378.137 -6378.137 6378.137 +unavailable +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+2362 1181 M
+-535 0 D
+S
+2204 1772 M
+-464 -268 D
+S
+1772 2204 M
+-268 -464 D
+S
+1181 2362 M
+0 -535 D
+S
+591 2204 M
+267 -464 D
+S
+158 1772 M
+464 -268 D
+S
+0 1181 M
+535 0 D
+S
+158 591 M
+464 267 D
+S
+591 158 M
+267 464 D
+S
+1181 0 M
+0 535 D
+S
+1772 158 M
+-268 464 D
+S
+2204 591 M
+-464 267 D
+S
+1922 1181 M
+-3 61 D
+-7 61 D
+-13 60 D
+-17 59 D
+-23 57 D
+-26 55 D
+-32 52 D
+-35 50 D
+-48 56 D
+-35 34 D
+-47 40 D
+-60 42 D
+-42 25 D
+-78 36 D
+-46 17 D
+-71 19 D
+-48 9 D
+-73 7 D
+-49 1 D
+-12 -1 D
+-13 0 D
+-12 -1 D
+-12 -1 D
+-12 -1 D
+-12 -1 D
+-13 -2 D
+-12 -1 D
+-12 -2 D
+-12 -2 D
+-12 -3 D
+-12 -2 D
+-12 -3 D
+-12 -3 D
+-12 -3 D
+-11 -3 D
+-12 -4 D
+-12 -3 D
+-11 -4 D
+-12 -4 D
+-11 -5 D
+-12 -4 D
+-11 -5 D
+-11 -5 D
+-12 -5 D
+-11 -5 D
+-22 -11 D
+-21 -11 D
+-21 -13 D
+-21 -13 D
+-30 -21 D
+-20 -14 D
+-56 -48 D
+-8 -9 D
+-9 -8 D
+-49 -55 D
+-36 -50 D
+-20 -30 D
+-35 -65 D
+-24 -56 D
+-23 -70 D
+-11 -48 D
+-5 -24 D
+-7 -61 D
+-3 -61 D
+3 -61 D
+7 -61 D
+13 -60 D
+14 -47 D
+21 -57 D
+26 -56 D
+30 -53 D
+43 -60 D
+39 -47 D
+43 -43 D
+57 -47 D
+50 -35 D
+64 -36 D
+56 -25 D
+81 -27 D
+48 -11 D
+24 -5 D
+73 -8 D
+61 -2 D
+74 5 D
+36 5 D
+60 13 D
+35 10 D
+58 20 D
+67 31 D
+53 30 D
+50 35 D
+29 23 D
+46 41 D
+8 9 D
+9 8 D
+48 56 D
+42 60 D
+25 43 D
+21 43 D
+24 57 D
+18 58 D
+14 60 D
+8 61 D
+4 61 D
+P S
+2107 1181 M
+-2 61 D
+-7 69 D
+-12 68 D
+-17 66 D
+-28 80 D
+-31 70 D
+-41 73 D
+-48 70 D
+-33 42 D
+-41 45 D
+-6 5 D
+-5 6 D
+-6 5 D
+-5 6 D
+-51 46 D
+-42 33 D
+-70 47 D
+-74 40 D
+-70 31 D
+-80 27 D
+-59 15 D
+-76 13 D
+-61 6 D
+-69 2 D
+-7 0 D
+-8 0 D
+-8 -1 D
+-7 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-7 0 D
+-8 -1 D
+-8 -1 D
+-7 0 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-13 -7 D
+-14 -7 D
+-13 -7 D
+-14 -8 D
+-13 -8 D
+-13 -7 D
+-19 -13 D
+-19 -13 D
+-19 -13 D
+-19 -14 D
+-24 -19 D
+-29 -24 D
+-5 -6 D
+-23 -20 D
+-5 -6 D
+-6 -5 D
+-41 -45 D
+-44 -53 D
+-35 -50 D
+-43 -73 D
+-30 -62 D
+-23 -57 D
+-25 -80 D
+-16 -75 D
+-8 -53 D
+-5 -69 D
+-1 -61 D
+5 -69 D
+5 -45 D
+10 -53 D
+14 -59 D
+21 -66 D
+9 -21 D
+8 -22 D
+22 -49 D
+29 -54 D
+36 -58 D
+41 -56 D
+55 -63 D
+16 -17 D
+45 -41 D
+47 -39 D
+50 -36 D
+72 -43 D
+41 -21 D
+56 -25 D
+22 -8 D
+29 -10 D
+58 -18 D
+75 -16 D
+53 -8 D
+84 -6 D
+69 1 D
+84 8 D
+60 11 D
+60 14 D
+65 21 D
+71 29 D
+75 39 D
+58 36 D
+56 41 D
+58 50 D
+22 21 D
+5 6 D
+6 5 D
+20 23 D
+6 5 D
+43 53 D
+23 31 D
+25 39 D
+9 13 D
+40 73 D
+31 71 D
+20 57 D
+17 59 D
+17 90 D
+7 69 D
+P S
+2292 1181 M
+-1 55 D
+-7 83 D
+-17 99 D
+-18 71 D
+-26 79 D
+-28 68 D
+-32 66 D
+-37 64 D
+-41 61 D
+-27 37 D
+-59 70 D
+-7 6 D
+-12 14 D
+-7 6 D
+-6 7 D
+-7 6 D
+-6 7 D
+-14 12 D
+-6 7 D
+-70 59 D
+-52 38 D
+-62 40 D
+-64 35 D
+-75 35 D
+-69 26 D
+-53 17 D
+-80 20 D
+-100 16 D
+-73 6 D
+-92 1 D
+-9 -1 D
+-9 0 D
+-9 -1 D
+-9 0 D
+-9 -1 D
+-10 -1 D
+-9 0 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-9 -2 D
+-10 -1 D
+-9 -1 D
+-9 -2 D
+-9 -1 D
+-9 -2 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -3 D
+-9 -2 D
+-9 -2 D
+-8 -2 D
+-9 -3 D
+-9 -2 D
+-9 -3 D
+-9 -3 D
+-8 -2 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-8 -3 D
+-9 -3 D
+-9 -3 D
+-8 -4 D
+-9 -3 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-9 -4 D
+-8 -3 D
+-9 -4 D
+-16 -8 D
+-9 -4 D
+-16 -8 D
+-16 -8 D
+-17 -9 D
+-16 -9 D
+-16 -9 D
+-16 -9 D
+-23 -15 D
+-23 -15 D
+-23 -16 D
+-22 -16 D
+-29 -23 D
+-42 -35 D
+-47 -44 D
+-50 -54 D
+-41 -49 D
+-43 -60 D
+-30 -46 D
+-40 -72 D
+-24 -50 D
+-21 -51 D
+-22 -61 D
+-20 -70 D
+-19 -90 D
+-10 -73 D
+-4 -64 D
+-1 -73 D
+4 -65 D
+3 -36 D
+13 -82 D
+16 -72 D
+27 -87 D
+23 -60 D
+27 -59 D
+34 -65 D
+34 -55 D
+31 -45 D
+45 -58 D
+30 -35 D
+7 -6 D
+12 -14 D
+7 -6 D
+12 -14 D
+14 -12 D
+6 -7 D
+14 -12 D
+6 -7 D
+56 -47 D
+67 -49 D
+46 -30 D
+65 -36 D
+57 -28 D
+77 -31 D
+61 -20 D
+62 -16 D
+72 -15 D
+73 -10 D
+83 -5 D
+82 1 D
+73 6 D
+82 13 D
+89 21 D
+79 25 D
+52 20 D
+83 39 D
+72 41 D
+46 30 D
+59 44 D
+56 47 D
+40 38 D
+50 54 D
+35 42 D
+39 52 D
+45 69 D
+31 57 D
+32 66 D
+27 68 D
+23 70 D
+20 80 D
+12 72 D
+7 64 D
+4 65 D
+P S
+8 W
+N 2362 1181 M 34 0 D S
+N 1827 1181 M -33 0 D S
+N 2204 1772 M 29 16 D S
+N 1740 1504 M -29 -17 D S
+N 1772 2204 M 16 29 D S
+N 1504 1740 M -17 -29 D S
+N 1181 2362 M 0 34 D S
+N 1181 1827 M 0 -33 D S
+N 591 2204 M -17 29 D S
+N 858 1740 M 17 -29 D S
+N 158 1772 M -29 16 D S
+N 622 1504 M 29 -17 D S
+N 0 1181 M -33 0 D S
+N 535 1181 M 34 0 D S
+N 158 591 M -29 -17 D S
+N 622 858 M 29 17 D S
+N 591 158 M -17 -29 D S
+N 858 622 M 17 29 D S
+N 1181 0 M 0 -33 D S
+N 1181 535 M 0 34 D S
+N 1772 158 M 16 -29 D S
+N 1504 622 M -17 29 D S
+N 2204 591 M 29 -17 D S
+N 1740 858 M -29 17 D S
+N 2362 1181 M 34 0 D S
+N 1827 1181 M -33 0 D S
+25 W
+1827 1181 M
+-3 65 D
+-10 64 D
+-16 62 D
+-22 61 D
+-19 39 D
+-20 38 D
+-36 54 D
+-41 50 D
+-30 31 D
+-49 43 D
+-52 37 D
+-19 12 D
+-57 30 D
+-40 17 D
+-61 20 D
+-63 14 D
+-43 6 D
+-65 3 D
+-21 -1 D
+-22 -1 D
+-22 -1 D
+-21 -3 D
+-21 -3 D
+-22 -4 D
+-21 -5 D
+-21 -5 D
+-20 -6 D
+-21 -7 D
+-20 -7 D
+-20 -8 D
+-20 -9 D
+-38 -20 D
+-19 -10 D
+-54 -36 D
+-50 -41 D
+-31 -30 D
+-43 -49 D
+-37 -52 D
+-12 -19 D
+-30 -57 D
+-24 -60 D
+-13 -41 D
+-14 -63 D
+-7 -65 D
+-2 -43 D
+4 -65 D
+9 -64 D
+16 -62 D
+23 -61 D
+8 -20 D
+30 -57 D
+36 -54 D
+41 -50 D
+30 -31 D
+49 -43 D
+35 -25 D
+36 -24 D
+57 -30 D
+60 -24 D
+41 -13 D
+64 -14 D
+64 -7 D
+43 -2 D
+65 4 D
+43 5 D
+63 14 D
+41 13 D
+60 24 D
+57 30 D
+54 36 D
+50 41 D
+31 30 D
+43 49 D
+25 35 D
+24 36 D
+30 57 D
+17 40 D
+20 61 D
+14 64 D
+6 42 D
+P S
+2362 1181 M
+0 40 D
+-2 39 D
+-8 79 D
+-13 77 D
+-19 77 D
+-23 76 D
+-29 73 D
+-33 72 D
+-18 35 D
+-40 68 D
+-45 65 D
+-49 62 D
+-53 58 D
+-57 55 D
+-29 26 D
+-62 49 D
+-65 45 D
+-68 40 D
+-71 35 D
+-72 31 D
+-37 14 D
+-76 23 D
+-77 19 D
+-77 13 D
+-79 8 D
+-39 2 D
+-40 0 D
+-39 0 D
+-40 -2 D
+-39 -4 D
+-39 -4 D
+-39 -6 D
+-39 -7 D
+-39 -9 D
+-38 -10 D
+-38 -11 D
+-37 -12 D
+-37 -14 D
+-37 -15 D
+-36 -16 D
+-36 -17 D
+-35 -18 D
+-67 -40 D
+-66 -45 D
+-61 -49 D
+-59 -53 D
+-55 -57 D
+-26 -29 D
+-49 -62 D
+-23 -32 D
+-62 -101 D
+-35 -71 D
+-31 -72 D
+-14 -37 D
+-23 -76 D
+-10 -38 D
+-16 -77 D
+-10 -79 D
+-5 -78 D
+-1 -40 D
+3 -79 D
+3 -39 D
+10 -78 D
+16 -78 D
+21 -76 D
+12 -37 D
+29 -74 D
+33 -72 D
+18 -35 D
+41 -67 D
+21 -33 D
+23 -33 D
+49 -61 D
+53 -59 D
+57 -55 D
+60 -51 D
+31 -24 D
+33 -23 D
+66 -42 D
+34 -20 D
+71 -35 D
+73 -31 D
+37 -14 D
+75 -23 D
+38 -10 D
+78 -16 D
+78 -10 D
+79 -5 D
+39 -1 D
+79 3 D
+79 8 D
+39 5 D
+77 16 D
+76 21 D
+38 12 D
+73 29 D
+72 33 D
+35 18 D
+101 62 D
+63 47 D
+31 25 D
+58 53 D
+55 57 D
+51 60 D
+24 31 D
+45 66 D
+40 67 D
+35 71 D
+31 73 D
+14 37 D
+23 75 D
+19 77 D
+13 78 D
+8 78 D
+P S
+/PSL_H_y 300 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+83 F0
+(100°) sh add def
+1181 2362 PSL_H_y add M
+200 F0
+(\053zp) bc Z
+1560 1790 M 83 F0
+V -30 R (4000) tl Z U
+1653 1951 M V -30 R (5000) tl Z U
+1745 2111 M V -30 R (6000) tl Z U
+2429 1181 M V -90 R (0°) bc Z U
+1760 1181 M V -90 R (0°) tc Z U
+2262 1805 M V -60 R (30°) bc Z U
+1683 1471 M V -60 R (30°) tc Z U
+1805 2262 M V -30 R (60°) bc Z U
+1471 1683 M V -30 R (60°) tc Z U
+1181 2429 M V -2.84e-14 R (90°) bc Z U
+1181 1760 M (90°) tc Z
+557 2262 M V 30 R (120°) bc Z U
+892 1683 M V 30 R (120°) tc Z U
+101 1805 M V 60 R (150°) bc Z U
+680 1471 M V 60 R (150°) tc Z U
+-67 1181 M V 90 R (180°) bc Z U
+602 1181 M V -270 R (180°) tc Z U
+101 557 M V 300 R (-150°) tc Z U
+680 892 M V -60 R (-150°) bc Z U
+557 101 M V 330 R (-120°) tc Z U
+892 680 M V -30 R (-120°) bc Z U
+1181 -67 M V 360 R (-90°) tc Z U
+1181 602 M (-90°) bc Z
+1805 101 M V 390 R (-60°) tc Z U
+1471 680 M V 30 R (-60°) bc Z U
+2262 557 M V 420 R (-30°) tc Z U
+1683 892 M V 60 R (-30°) bc Z U
+%%EndObject
+-6036 -6036 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 3018 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/0.4/1 -JP1.9685i+a -BWENS+i60+t\053a -Bxxa30fg -Byyafg -Xa0i -Ya2.5152i
+%@PROJ: polar 0.00000000 360.00000000 0.40000000 1.00000000 -1.000 1.000 -1.000 1.000 +unavailable +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_8
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+1181 1654 M
+0 708 D
+S
+1417 1590 M
+355 614 D
+S
+1590 1417 M
+614 355 D
+S
+1654 1181 M
+708 0 D
+S
+1590 945 M
+614 -354 D
+S
+1417 772 M
+355 -614 D
+S
+1181 709 M
+0 -709 D
+S
+945 772 M
+-354 -614 D
+S
+772 945 M
+-614 -354 D
+S
+709 1181 M
+-709 0 D
+S
+772 1417 M
+-614 355 D
+S
+945 1590 M
+-354 614 D
+S
+1181 1654 M
+47 -3 D
+54 -8 D
+53 -15 D
+43 -17 D
+42 -22 D
+20 -12 D
+37 -28 D
+30 -26 D
+27 -28 D
+29 -36 D
+18 -26 D
+23 -41 D
+19 -43 D
+14 -44 D
+9 -38 D
+7 -62 D
+1 -24 D
+-3 -47 D
+-8 -54 D
+-15 -52 D
+-17 -44 D
+-18 -35 D
+-25 -39 D
+-19 -25 D
+-26 -30 D
+-34 -32 D
+-30 -24 D
+-19 -13 D
+-14 -9 D
+-13 -8 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-7 -3 D
+-8 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-38 3 D
+-39 6 D
+-45 11 D
+-52 19 D
+-48 25 D
+-14 8 D
+-44 32 D
+-35 31 D
+-32 35 D
+-28 37 D
+-21 33 D
+-24 50 D
+-18 51 D
+-12 53 D
+-6 55 D
+1 62 D
+8 54 D
+11 46 D
+19 51 D
+25 49 D
+26 39 D
+29 36 D
+33 34 D
+42 34 D
+33 22 D
+34 19 D
+43 19 D
+52 16 D
+38 8 D
+55 6 D
+P S
+1181 1890 M
+59 -3 D
+46 -5 D
+58 -11 D
+56 -16 D
+66 -25 D
+42 -20 D
+51 -29 D
+48 -34 D
+37 -29 D
+50 -48 D
+39 -44 D
+48 -67 D
+18 -30 D
+36 -74 D
+27 -77 D
+14 -57 D
+9 -58 D
+5 -70 D
+-2 -59 D
+-6 -58 D
+-11 -57 D
+-16 -57 D
+-25 -66 D
+-20 -42 D
+-29 -51 D
+-41 -57 D
+-22 -27 D
+-48 -51 D
+-44 -39 D
+-38 -28 D
+-29 -19 D
+-20 -13 D
+-21 -11 D
+-20 -11 D
+-11 -5 D
+-11 -5 D
+-10 -5 D
+-11 -4 D
+-11 -5 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-11 -3 D
+-11 -4 D
+-12 -3 D
+-11 -3 D
+-11 -3 D
+-12 -2 D
+-11 -3 D
+-12 -2 D
+-11 -2 D
+-12 -2 D
+-11 -1 D
+-12 -2 D
+-12 -1 D
+-11 -1 D
+-12 -1 D
+-12 -1 D
+-11 0 D
+-12 0 D
+-12 -1 D
+-58 3 D
+-59 7 D
+-57 12 D
+-56 17 D
+-55 21 D
+-42 20 D
+-20 12 D
+-21 11 D
+-48 33 D
+-46 36 D
+-43 40 D
+-47 53 D
+-41 56 D
+-19 30 D
+-11 21 D
+-16 31 D
+-19 43 D
+-23 67 D
+-14 56 D
+-9 58 D
+-4 59 D
+-1 23 D
+3 59 D
+7 58 D
+12 57 D
+17 56 D
+21 55 D
+20 42 D
+23 41 D
+33 49 D
+36 46 D
+40 42 D
+53 47 D
+56 41 D
+41 25 D
+41 21 D
+43 19 D
+55 20 D
+68 17 D
+58 9 D
+70 5 D
+P S
+1181 2126 M
+63 -2 D
+77 -8 D
+84 -17 D
+46 -12 D
+59 -20 D
+51 -21 D
+49 -23 D
+61 -34 D
+14 -8 D
+32 -22 D
+26 -18 D
+49 -39 D
+40 -36 D
+12 -11 D
+5 -6 D
+6 -5 D
+47 -52 D
+30 -37 D
+27 -38 D
+26 -39 D
+31 -54 D
+27 -56 D
+18 -43 D
+14 -37 D
+20 -67 D
+11 -46 D
+13 -77 D
+6 -70 D
+1 -70 D
+-6 -86 D
+-8 -54 D
+-13 -61 D
+-12 -46 D
+-23 -66 D
+-14 -36 D
+-27 -57 D
+-34 -61 D
+-8 -14 D
+-22 -32 D
+-18 -26 D
+-44 -55 D
+-37 -40 D
+-16 -17 D
+-12 -10 D
+-5 -6 D
+-47 -41 D
+-25 -19 D
+-12 -10 D
+-19 -13 D
+-20 -14 D
+-13 -8 D
+-20 -13 D
+-13 -8 D
+-14 -7 D
+-13 -8 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-8 0 D
+-70 3 D
+-47 5 D
+-69 12 D
+-68 17 D
+-52 17 D
+-58 23 D
+-43 19 D
+-35 18 D
+-40 23 D
+-59 39 D
+-56 43 D
+-41 36 D
+-5 6 D
+-28 27 D
+-5 6 D
+-6 5 D
+-46 53 D
+-24 31 D
+-39 58 D
+-17 27 D
+-26 48 D
+-20 42 D
+-24 58 D
+-17 52 D
+-17 60 D
+-13 69 D
+-5 31 D
+-6 70 D
+-1 63 D
+4 70 D
+4 39 D
+14 77 D
+15 60 D
+17 52 D
+29 73 D
+31 63 D
+23 40 D
+39 59 D
+38 50 D
+25 29 D
+16 18 D
+6 5 D
+10 12 D
+46 43 D
+54 45 D
+38 27 D
+39 26 D
+54 31 D
+56 27 D
+36 15 D
+44 17 D
+60 18 D
+53 13 D
+77 13 D
+70 6 D
+P S
+1181 2362 M
+59 -1 D
+107 -10 D
+86 -16 D
+76 -19 D
+92 -31 D
+63 -26 D
+45 -21 D
+77 -42 D
+65 -42 D
+71 -53 D
+59 -51 D
+56 -55 D
+39 -43 D
+49 -61 D
+45 -64 D
+36 -58 D
+36 -69 D
+25 -53 D
+31 -82 D
+26 -85 D
+19 -85 D
+10 -68 D
+8 -87 D
+1 -98 D
+-5 -68 D
+-9 -78 D
+-17 -86 D
+-18 -66 D
+-28 -83 D
+-34 -81 D
+-36 -70 D
+-29 -50 D
+-32 -49 D
+-53 -71 D
+-51 -59 D
+-55 -56 D
+-28 -26 D
+-45 -38 D
+-31 -24 D
+-24 -17 D
+-24 -17 D
+-24 -16 D
+-17 -10 D
+-16 -11 D
+-17 -9 D
+-17 -10 D
+-17 -9 D
+-18 -9 D
+-17 -9 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-8 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-10 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-9 -3 D
+-9 -2 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 0 D
+-10 0 D
+-10 -1 D
+-9 0 D
+-10 0 D
+-10 0 D
+-10 0 D
+-9 0 D
+-69 3 D
+-87 10 D
+-67 12 D
+-67 16 D
+-93 29 D
+-90 37 D
+-79 40 D
+-75 45 D
+-72 51 D
+-53 43 D
+-57 53 D
+-41 42 D
+-51 59 D
+-47 63 D
+-27 40 D
+-45 76 D
+-43 88 D
+-32 81 D
+-21 65 D
+-23 95 D
+-14 87 D
+-8 88 D
+-1 87 D
+5 78 D
+8 68 D
+12 67 D
+16 67 D
+29 93 D
+22 55 D
+15 35 D
+17 36 D
+33 60 D
+9 17 D
+37 57 D
+46 64 D
+37 45 D
+53 57 D
+49 48 D
+52 44 D
+71 53 D
+82 52 D
+87 45 D
+63 27 D
+55 20 D
+84 26 D
+85 19 D
+68 10 D
+88 8 D
+P S
+8 W
+N 1181 1654 M 0 -34 D S
+N 1181 2362 M 0 34 D S
+N 1417 1590 M -16 -29 D S
+N 1772 2204 M 16 29 D S
+N 1590 1417 M -29 -16 D S
+N 2204 1772 M 29 16 D S
+N 1654 1181 M -34 0 D S
+N 2362 1181 M 34 0 D S
+N 1590 945 M -29 17 D S
+N 2204 591 M 29 -17 D S
+N 1417 772 M -16 29 D S
+N 1772 158 M 16 -29 D S
+N 1181 709 M 0 33 D S
+N 1181 0 M 0 -33 D S
+N 945 772 M 17 29 D S
+N 591 158 M -17 -29 D S
+N 772 945 M 29 17 D S
+N 158 591 M -29 -17 D S
+N 709 1181 M 33 0 D S
+N 0 1181 M -33 0 D S
+N 772 1417 M 29 -16 D S
+N 158 1772 M -29 16 D S
+N 945 1590 M 17 -29 D S
+N 591 2204 M -17 29 D S
+N 1181 1654 M 0 -34 D S
+N 1181 2362 M 0 34 D S
+25 W
+1181 2362 M
+40 0 D
+39 -2 D
+79 -8 D
+77 -13 D
+77 -19 D
+76 -23 D
+73 -29 D
+72 -33 D
+35 -18 D
+68 -40 D
+65 -45 D
+62 -49 D
+58 -53 D
+55 -57 D
+26 -29 D
+49 -62 D
+45 -65 D
+40 -68 D
+35 -71 D
+31 -72 D
+14 -37 D
+23 -76 D
+19 -77 D
+13 -77 D
+8 -79 D
+2 -39 D
+0 -79 D
+-2 -40 D
+-8 -78 D
+-13 -78 D
+-19 -77 D
+-23 -75 D
+-29 -74 D
+-33 -72 D
+-18 -35 D
+-40 -67 D
+-45 -66 D
+-49 -61 D
+-53 -59 D
+-57 -55 D
+-29 -26 D
+-62 -49 D
+-32 -23 D
+-67 -42 D
+-34 -20 D
+-71 -35 D
+-36 -16 D
+-36 -15 D
+-37 -14 D
+-38 -12 D
+-38 -11 D
+-38 -10 D
+-39 -8 D
+-38 -8 D
+-39 -5 D
+-40 -5 D
+-39 -3 D
+-39 -2 D
+-40 -1 D
+-79 3 D
+-39 3 D
+-78 10 D
+-78 16 D
+-76 21 D
+-37 12 D
+-74 29 D
+-72 33 D
+-35 18 D
+-67 41 D
+-33 21 D
+-33 23 D
+-61 49 D
+-59 53 D
+-55 57 D
+-51 60 D
+-24 31 D
+-23 33 D
+-42 66 D
+-20 34 D
+-35 71 D
+-31 73 D
+-14 37 D
+-23 75 D
+-10 38 D
+-16 78 D
+-10 78 D
+-5 79 D
+-1 39 D
+3 79 D
+8 79 D
+5 39 D
+16 77 D
+21 76 D
+12 38 D
+29 73 D
+33 72 D
+18 35 D
+62 101 D
+47 63 D
+25 31 D
+53 58 D
+57 55 D
+60 51 D
+31 24 D
+66 45 D
+67 40 D
+71 35 D
+73 31 D
+37 14 D
+75 23 D
+77 19 D
+78 13 D
+78 8 D
+P S
+1181 1654 M
+63 -5 D
+47 -8 D
+60 -19 D
+43 -19 D
+28 -15 D
+26 -17 D
+38 -29 D
+35 -32 D
+31 -36 D
+19 -26 D
+17 -26 D
+22 -42 D
+17 -44 D
+14 -45 D
+8 -47 D
+5 -63 D
+-5 -63 D
+-8 -46 D
+-19 -61 D
+-19 -43 D
+-15 -28 D
+-17 -26 D
+-29 -38 D
+-32 -35 D
+-36 -31 D
+-39 -27 D
+-27 -16 D
+-14 -8 D
+-14 -6 D
+-14 -7 D
+-15 -6 D
+-15 -5 D
+-15 -5 D
+-15 -5 D
+-15 -3 D
+-16 -4 D
+-15 -3 D
+-16 -2 D
+-16 -2 D
+-15 -1 D
+-16 -1 D
+-16 0 D
+-47 2 D
+-47 7 D
+-31 7 D
+-45 15 D
+-43 19 D
+-41 24 D
+-39 27 D
+-35 31 D
+-33 35 D
+-19 25 D
+-26 39 D
+-16 28 D
+-19 43 D
+-15 45 D
+-10 47 D
+-5 47 D
+-1 47 D
+6 63 D
+10 46 D
+21 60 D
+13 28 D
+24 41 D
+27 39 D
+31 36 D
+47 42 D
+26 19 D
+26 17 D
+42 22 D
+44 17 D
+46 14 D
+46 8 D
+P S
+/PSL_H_y 300 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+83 F0
+(100°) sh add def
+1181 2362 PSL_H_y add M
+200 F0
+(\053a) bc Z
+1786 1503 M 83 F0
+V -60 R (0.6) tl Z U
+1991 1621 M V -60 R (0.8) tl Z U
+2195 1739 M V -60 R (1.0) tl Z U
+1181 1587 M (0°) tc Z
+1181 2429 M V -2.84e-14 R (0°) bc Z U
+1384 1533 M V -30 R (30°) tc Z U
+1805 2262 M V -30 R (30°) bc Z U
+1533 1384 M V -60 R (60°) tc Z U
+2262 1805 M V -60 R (60°) bc Z U
+1587 1181 M V -90 R (90°) tc Z U
+2429 1181 M V -90 R (90°) bc Z U
+1533 978 M V 60 R (120°) bc Z U
+2262 557 M V 420 R (120°) tc Z U
+1384 830 M V 30 R (150°) bc Z U
+1805 101 M V 390 R (150°) tc Z U
+1181 775 M (180°) bc Z
+1181 -67 M V 360 R (180°) tc Z U
+978 830 M V -30 R (-150°) bc Z U
+557 101 M V 330 R (-150°) tc Z U
+830 978 M V -60 R (-120°) bc Z U
+101 557 M V 300 R (-120°) tc Z U
+775 1181 M V -270 R (-90°) tc Z U
+-67 1181 M V 90 R (-90°) bc Z U
+830 1384 M V 60 R (-60°) tc Z U
+101 1805 M V 60 R (-60°) bc Z U
+978 1533 M V 30 R (-30°) tc Z U
+557 2262 M V 30 R (-30°) bc Z U
+%%EndObject
+0 -3018 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3018 3018 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/0.4/1 -JP1.9685i+t30 -BWENS+i60+t\053t30 -Bxxa30fg -Byyafg -Xa2.5152i -Ya2.5152i
+%@PROJ: polar 0.00000000 360.00000000 0.40000000 1.00000000 -1.000 1.000 -1.000 1.000 +unavailable +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_9
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+1590 945 M
+614 -354 D
+S
+1654 1181 M
+708 0 D
+S
+1590 1417 M
+614 355 D
+S
+1417 1590 M
+355 614 D
+S
+1181 1654 M
+0 708 D
+S
+945 1590 M
+-354 614 D
+S
+772 1417 M
+-614 355 D
+S
+709 1181 M
+-709 0 D
+S
+772 945 M
+-614 -354 D
+S
+945 772 M
+-354 -614 D
+S
+1181 709 M
+0 -709 D
+S
+1417 772 M
+355 -614 D
+S
+1590 945 M
+22 42 D
+12 28 D
+16 53 D
+10 53 D
+3 39 D
+1 24 D
+-4 54 D
+-6 39 D
+-14 53 D
+-17 43 D
+-29 56 D
+-27 38 D
+-35 42 D
+-6 5 D
+-5 6 D
+-42 36 D
+-38 26 D
+-41 23 D
+-43 19 D
+-52 16 D
+-54 10 D
+-39 3 D
+-24 1 D
+-7 -1 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-14 -7 D
+-14 -7 D
+-20 -13 D
+-19 -13 D
+-13 -9 D
+-36 -30 D
+-17 -16 D
+-31 -36 D
+-14 -18 D
+-33 -53 D
+-23 -50 D
+-19 -59 D
+-10 -54 D
+-3 -55 D
+1 -47 D
+8 -54 D
+17 -60 D
+11 -29 D
+25 -49 D
+20 -33 D
+19 -25 D
+25 -30 D
+6 -5 D
+16 -17 D
+30 -26 D
+38 -27 D
+47 -27 D
+43 -18 D
+23 -8 D
+30 -9 D
+53 -10 D
+55 -3 D
+47 1 D
+54 8 D
+60 17 D
+29 11 D
+49 25 D
+40 25 D
+48 39 D
+33 34 D
+24 30 D
+22 32 D
+P S
+1795 827 M
+27 52 D
+19 43 D
+19 55 D
+17 68 D
+7 47 D
+4 34 D
+2 71 D
+-5 70 D
+-15 80 D
+-16 57 D
+-21 55 D
+-14 32 D
+-34 61 D
+-19 30 D
+-35 47 D
+-31 35 D
+-16 17 D
+-43 40 D
+-37 29 D
+-58 39 D
+-52 28 D
+-53 24 D
+-33 12 D
+-68 19 D
+-58 11 D
+-46 5 D
+-71 2 D
+-11 -1 D
+-12 0 D
+-12 -1 D
+-11 -1 D
+-12 -1 D
+-12 -1 D
+-11 -2 D
+-12 -2 D
+-11 -2 D
+-12 -2 D
+-11 -2 D
+-12 -2 D
+-11 -3 D
+-12 -3 D
+-11 -3 D
+-11 -3 D
+-11 -4 D
+-12 -3 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-21 -10 D
+-11 -4 D
+-21 -11 D
+-21 -11 D
+-20 -11 D
+-20 -12 D
+-29 -20 D
+-37 -28 D
+-53 -47 D
+-47 -52 D
+-29 -38 D
+-32 -48 D
+-38 -73 D
+-22 -54 D
+-17 -56 D
+-8 -35 D
+-7 -34 D
+-8 -82 D
+-1 -35 D
+4 -70 D
+11 -69 D
+14 -57 D
+19 -56 D
+34 -74 D
+23 -41 D
+40 -58 D
+45 -54 D
+42 -41 D
+54 -45 D
+59 -39 D
+51 -28 D
+43 -19 D
+33 -13 D
+56 -17 D
+34 -8 D
+34 -7 D
+82 -8 D
+35 -1 D
+70 4 D
+70 11 D
+56 14 D
+56 19 D
+64 29 D
+41 22 D
+59 39 D
+46 37 D
+25 23 D
+33 34 D
+38 45 D
+40 58 D
+P S
+1999 709 M
+23 41 D
+23 49 D
+18 43 D
+25 74 D
+19 76 D
+9 54 D
+8 70 D
+2 70 D
+-2 63 D
+-10 85 D
+-18 84 D
+-20 67 D
+-25 66 D
+-23 50 D
+-34 62 D
+-20 33 D
+-36 51 D
+-10 12 D
+-9 13 D
+-31 36 D
+-31 34 D
+-6 5 D
+-5 6 D
+-40 37 D
+-55 45 D
+-38 27 D
+-39 25 D
+-62 35 D
+-49 23 D
+-29 13 D
+-81 28 D
+-83 21 D
+-54 9 D
+-70 8 D
+-70 2 D
+-8 0 D
+-8 0 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-7 -1 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-14 -7 D
+-13 -8 D
+-14 -7 D
+-14 -8 D
+-13 -8 D
+-13 -8 D
+-14 -8 D
+-19 -13 D
+-25 -19 D
+-13 -9 D
+-25 -19 D
+-23 -20 D
+-24 -21 D
+-5 -6 D
+-12 -10 D
+-5 -6 D
+-6 -5 D
+-47 -52 D
+-30 -37 D
+-14 -18 D
+-35 -52 D
+-32 -54 D
+-31 -63 D
+-29 -72 D
+-17 -52 D
+-19 -76 D
+-12 -77 D
+-5 -55 D
+-2 -70 D
+4 -70 D
+7 -62 D
+14 -69 D
+9 -38 D
+27 -82 D
+34 -79 D
+33 -62 D
+33 -53 D
+32 -44 D
+15 -18 D
+9 -13 D
+10 -12 D
+6 -5 D
+20 -24 D
+6 -5 D
+33 -34 D
+52 -46 D
+44 -34 D
+51 -35 D
+54 -32 D
+63 -31 D
+72 -29 D
+60 -19 D
+68 -17 D
+77 -12 D
+55 -5 D
+70 -2 D
+70 4 D
+62 7 D
+69 14 D
+38 9 D
+82 27 D
+79 34 D
+35 18 D
+60 35 D
+58 40 D
+49 39 D
+40 37 D
+33 34 D
+6 5 D
+60 72 D
+40 58 D
+P S
+2204 591 M
+28 51 D
+25 53 D
+27 63 D
+31 92 D
+17 66 D
+17 87 D
+10 87 D
+3 78 D
+-1 68 D
+-7 88 D
+-14 87 D
+-18 76 D
+-29 93 D
+-29 73 D
+-33 70 D
+-34 60 D
+-36 58 D
+-28 40 D
+-49 61 D
+-38 44 D
+-41 42 D
+-73 65 D
+-54 42 D
+-65 44 D
+-58 35 D
+-61 31 D
+-71 32 D
+-65 23 D
+-74 23 D
+-105 23 D
+-97 12 D
+-49 3 D
+-88 1 D
+-9 -1 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-9 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-17 -9 D
+-9 -4 D
+-18 -9 D
+-17 -9 D
+-17 -10 D
+-17 -10 D
+-16 -10 D
+-17 -10 D
+-24 -16 D
+-25 -17 D
+-31 -23 D
+-31 -24 D
+-44 -38 D
+-29 -27 D
+-21 -20 D
+-59 -65 D
+-49 -61 D
+-39 -56 D
+-41 -67 D
+-36 -69 D
+-31 -71 D
+-21 -55 D
+-18 -56 D
+-17 -66 D
+-15 -77 D
+-10 -77 D
+-5 -88 D
+1 -78 D
+5 -68 D
+13 -87 D
+7 -39 D
+22 -85 D
+28 -83 D
+34 -81 D
+35 -70 D
+40 -67 D
+33 -49 D
+53 -69 D
+32 -37 D
+41 -43 D
+49 -47 D
+52 -44 D
+63 -47 D
+74 -47 D
+77 -42 D
+99 -43 D
+92 -31 D
+76 -19 D
+67 -13 D
+68 -9 D
+97 -6 D
+98 2 D
+49 4 D
+87 13 D
+38 7 D
+85 22 D
+83 28 D
+64 26 D
+70 34 D
+68 39 D
+57 37 D
+55 41 D
+45 37 D
+50 47 D
+54 56 D
+44 52 D
+47 63 D
+47 74 D
+P S
+8 W
+N 1590 945 M -29 17 D S
+N 2204 591 M 29 -17 D S
+N 1654 1181 M -34 0 D S
+N 2362 1181 M 34 0 D S
+N 1590 1417 M -29 -16 D S
+N 2204 1772 M 29 16 D S
+N 1417 1590 M -16 -29 D S
+N 1772 2204 M 16 29 D S
+N 1181 1654 M 0 -34 D S
+N 1181 2362 M 0 34 D S
+N 945 1590 M 17 -29 D S
+N 591 2204 M -17 29 D S
+N 772 1417 M 29 -16 D S
+N 158 1772 M -29 16 D S
+N 709 1181 M 33 0 D S
+N 0 1181 M -33 0 D S
+N 772 945 M 29 17 D S
+N 158 591 M -29 -17 D S
+N 945 772 M 17 29 D S
+N 591 158 M -17 -29 D S
+N 1181 709 M 0 33 D S
+N 1181 0 M 0 -33 D S
+N 1417 772 M -16 29 D S
+N 1772 158 M 16 -29 D S
+N 1590 945 M -29 17 D S
+N 2204 591 M 29 -17 D S
+25 W
+2204 591 M
+37 69 D
+33 72 D
+27 74 D
+23 76 D
+17 77 D
+7 39 D
+10 78 D
+4 79 D
+-1 79 D
+-2 39 D
+-9 79 D
+-14 77 D
+-19 77 D
+-25 75 D
+-29 73 D
+-16 36 D
+-18 36 D
+-38 68 D
+-21 34 D
+-46 64 D
+-49 62 D
+-54 58 D
+-57 54 D
+-61 50 D
+-32 24 D
+-65 44 D
+-69 39 D
+-71 35 D
+-36 16 D
+-74 27 D
+-76 23 D
+-77 17 D
+-38 7 D
+-79 10 D
+-79 4 D
+-39 0 D
+-40 -1 D
+-39 -2 D
+-39 -4 D
+-39 -5 D
+-39 -7 D
+-39 -7 D
+-38 -9 D
+-39 -10 D
+-37 -12 D
+-38 -13 D
+-37 -14 D
+-36 -15 D
+-36 -16 D
+-70 -37 D
+-34 -19 D
+-33 -21 D
+-65 -46 D
+-61 -49 D
+-58 -54 D
+-55 -57 D
+-50 -61 D
+-24 -32 D
+-43 -65 D
+-21 -34 D
+-37 -70 D
+-17 -36 D
+-30 -73 D
+-25 -75 D
+-20 -76 D
+-15 -77 D
+-12 -118 D
+-2 -79 D
+1 -40 D
+6 -78 D
+5 -39 D
+14 -78 D
+20 -77 D
+24 -75 D
+29 -73 D
+16 -36 D
+37 -70 D
+41 -67 D
+45 -65 D
+24 -31 D
+52 -60 D
+27 -28 D
+58 -55 D
+60 -50 D
+32 -24 D
+100 -64 D
+69 -37 D
+36 -17 D
+73 -30 D
+75 -25 D
+76 -20 D
+78 -15 D
+78 -9 D
+79 -5 D
+79 1 D
+78 6 D
+40 5 D
+77 14 D
+39 9 D
+76 22 D
+74 27 D
+72 31 D
+36 18 D
+68 39 D
+34 21 D
+64 45 D
+31 24 D
+60 52 D
+29 27 D
+54 58 D
+50 60 D
+24 32 D
+44 66 D
+P S
+1590 945 M
+22 42 D
+17 44 D
+13 46 D
+8 46 D
+3 32 D
+1 31 D
+-5 63 D
+-10 47 D
+-13 45 D
+-19 44 D
+-14 28 D
+-25 40 D
+-19 25 D
+-32 35 D
+-35 32 D
+-38 29 D
+-40 24 D
+-43 20 D
+-45 16 D
+-46 11 D
+-47 7 D
+-47 2 D
+-16 -1 D
+-16 -1 D
+-15 -1 D
+-16 -2 D
+-16 -3 D
+-15 -3 D
+-16 -4 D
+-15 -4 D
+-15 -4 D
+-15 -5 D
+-15 -6 D
+-14 -6 D
+-15 -7 D
+-28 -14 D
+-27 -17 D
+-13 -8 D
+-25 -19 D
+-35 -32 D
+-32 -35 D
+-19 -25 D
+-18 -26 D
+-16 -27 D
+-20 -43 D
+-16 -45 D
+-11 -46 D
+-5 -31 D
+-3 -47 D
+1 -48 D
+9 -62 D
+12 -46 D
+17 -44 D
+21 -43 D
+26 -40 D
+39 -49 D
+34 -33 D
+24 -20 D
+39 -27 D
+42 -23 D
+43 -19 D
+45 -14 D
+47 -10 D
+47 -5 D
+63 1 D
+62 9 D
+46 12 D
+44 17 D
+43 21 D
+53 35 D
+36 30 D
+33 34 D
+30 37 D
+P S
+/PSL_H_y 300 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+83 F0
+(100°) sh add def
+1181 2362 PSL_H_y add M
+200 F0
+(\053t30) bc Z
+1786 1503 M 83 F0
+V -60 R (0.6) tl Z U
+1991 1621 M V -60 R (0.8) tl Z U
+2195 1739 M V -60 R (1.0) tl Z U
+1533 978 M V 60 R (0°) bc Z U
+2262 557 M V 420 R (0°) tc Z U
+1587 1181 M V -90 R (30°) tc Z U
+2429 1181 M V -90 R (30°) bc Z U
+1533 1384 M V -60 R (60°) tc Z U
+2262 1805 M V -60 R (60°) bc Z U
+1384 1533 M V -30 R (90°) tc Z U
+1805 2262 M V -30 R (90°) bc Z U
+1181 1587 M (120°) tc Z
+1181 2429 M V -2.84e-14 R (120°) bc Z U
+978 1533 M V 30 R (150°) tc Z U
+557 2262 M V 30 R (150°) bc Z U
+830 1384 M V 60 R (180°) tc Z U
+100 1805 M V 60 R (180°) bc Z U
+775 1181 M V -270 R (-150°) tc Z U
+-67 1181 M V 90 R (-150°) bc Z U
+830 978 M V -60 R (-120°) bc Z U
+100 557 M V 300 R (-120°) tc Z U
+978 830 M V -30 R (-90°) bc Z U
+557 100 M V 330 R (-90°) tc Z U
+1181 775 M (-60°) bc Z
+1181 -67 M V 360 R (-60°) tc Z U
+1384 830 M V 30 R (-30°) bc Z U
+1805 100 M V 390 R (-30°) tc Z U
+%%EndObject
+-3018 -3018 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+6036 3018 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/0.4/1 -JP1.9685i+a+t30 -BWENS+i60+t\053a\053t30 -Bxxa30fg -Byyafg -Xa5.0303i -Ya2.5152i
+%@PROJ: polar 0.00000000 360.00000000 0.40000000 1.00000000 -1.000 1.000 -1.000 1.000 +unavailable +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_10
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+945 1590 M
+-354 614 D
+S
+1181 1654 M
+0 708 D
+S
+1417 1590 M
+355 614 D
+S
+1590 1417 M
+614 355 D
+S
+1654 1181 M
+708 0 D
+S
+1590 945 M
+614 -354 D
+S
+1417 772 M
+355 -614 D
+S
+1181 709 M
+0 -709 D
+S
+945 772 M
+-354 -614 D
+S
+772 945 M
+-614 -354 D
+S
+709 1181 M
+-709 0 D
+S
+772 1417 M
+-614 355 D
+S
+945 1590 M
+42 22 D
+28 12 D
+53 16 D
+53 10 D
+39 3 D
+24 1 D
+54 -4 D
+39 -6 D
+53 -14 D
+43 -17 D
+56 -29 D
+38 -27 D
+42 -35 D
+5 -6 D
+6 -5 D
+36 -42 D
+26 -38 D
+23 -41 D
+19 -43 D
+16 -52 D
+10 -54 D
+3 -39 D
+1 -24 D
+-4 -54 D
+-6 -39 D
+-17 -60 D
+-14 -36 D
+-25 -49 D
+-31 -45 D
+-35 -41 D
+-11 -12 D
+-36 -31 D
+-18 -14 D
+-20 -13 D
+-13 -8 D
+-13 -8 D
+-14 -7 D
+-14 -7 D
+-15 -7 D
+-7 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -2 D
+-8 -2 D
+-7 -3 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 0 D
+-39 3 D
+-46 8 D
+-53 15 D
+-29 11 D
+-49 25 D
+-33 20 D
+-25 19 D
+-30 25 D
+-5 6 D
+-17 16 D
+-26 30 D
+-27 38 D
+-27 47 D
+-18 43 D
+-8 23 D
+-9 30 D
+-10 53 D
+-3 55 D
+1 47 D
+8 54 D
+17 60 D
+11 29 D
+25 49 D
+25 40 D
+39 48 D
+34 33 D
+30 24 D
+32 22 D
+P S
+827 1795 M
+52 27 D
+43 19 D
+55 19 D
+68 17 D
+47 7 D
+34 4 D
+71 2 D
+70 -5 D
+80 -15 D
+57 -16 D
+55 -21 D
+32 -14 D
+61 -34 D
+30 -19 D
+47 -35 D
+35 -31 D
+17 -16 D
+40 -43 D
+29 -37 D
+39 -58 D
+28 -52 D
+24 -53 D
+12 -33 D
+19 -68 D
+11 -58 D
+5 -46 D
+2 -71 D
+-5 -70 D
+-15 -80 D
+-16 -57 D
+-16 -44 D
+-19 -42 D
+-28 -52 D
+-25 -39 D
+-35 -47 D
+-47 -53 D
+-52 -47 D
+-38 -29 D
+-29 -19 D
+-19 -13 D
+-21 -11 D
+-20 -11 D
+-21 -11 D
+-11 -5 D
+-11 -4 D
+-11 -5 D
+-10 -4 D
+-11 -5 D
+-11 -4 D
+-11 -3 D
+-12 -4 D
+-11 -4 D
+-11 -3 D
+-11 -3 D
+-12 -3 D
+-11 -3 D
+-12 -2 D
+-11 -2 D
+-12 -3 D
+-11 -2 D
+-12 -1 D
+-11 -2 D
+-12 -1 D
+-12 -1 D
+-11 -1 D
+-12 -1 D
+-12 -1 D
+-11 0 D
+-12 -1 D
+-82 4 D
+-69 11 D
+-57 14 D
+-56 19 D
+-74 34 D
+-41 23 D
+-58 40 D
+-54 45 D
+-41 42 D
+-45 54 D
+-39 59 D
+-28 51 D
+-19 43 D
+-13 33 D
+-17 56 D
+-8 34 D
+-7 34 D
+-8 82 D
+-1 35 D
+4 70 D
+11 70 D
+14 56 D
+19 56 D
+29 64 D
+22 41 D
+39 59 D
+37 46 D
+23 25 D
+34 33 D
+45 38 D
+58 40 D
+P S
+709 1999 M
+41 23 D
+49 23 D
+43 18 D
+74 25 D
+76 19 D
+54 9 D
+70 8 D
+70 2 D
+63 -2 D
+85 -10 D
+84 -18 D
+67 -20 D
+66 -25 D
+50 -23 D
+62 -34 D
+33 -20 D
+51 -36 D
+12 -10 D
+13 -9 D
+36 -31 D
+34 -31 D
+5 -6 D
+6 -5 D
+37 -40 D
+45 -55 D
+27 -38 D
+25 -39 D
+35 -62 D
+23 -49 D
+13 -29 D
+28 -81 D
+21 -83 D
+9 -54 D
+8 -70 D
+2 -70 D
+-2 -63 D
+-10 -85 D
+-18 -84 D
+-20 -67 D
+-25 -66 D
+-23 -50 D
+-34 -61 D
+-20 -34 D
+-27 -38 D
+-43 -56 D
+-31 -35 D
+-6 -5 D
+-10 -12 D
+-6 -5 D
+-5 -6 D
+-52 -47 D
+-37 -30 D
+-18 -14 D
+-19 -13 D
+-20 -14 D
+-13 -8 D
+-13 -8 D
+-14 -8 D
+-13 -8 D
+-14 -8 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-8 0 D
+-7 0 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-7 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-70 4 D
+-62 7 D
+-69 14 D
+-38 9 D
+-82 27 D
+-79 34 D
+-62 33 D
+-53 33 D
+-44 32 D
+-18 15 D
+-13 9 D
+-12 10 D
+-5 6 D
+-24 20 D
+-5 6 D
+-34 33 D
+-46 52 D
+-34 44 D
+-35 51 D
+-32 54 D
+-31 63 D
+-29 72 D
+-19 60 D
+-17 68 D
+-12 77 D
+-5 55 D
+-2 70 D
+4 70 D
+7 62 D
+14 69 D
+9 38 D
+27 82 D
+34 79 D
+18 35 D
+35 60 D
+40 58 D
+39 49 D
+37 40 D
+34 33 D
+5 6 D
+72 60 D
+58 40 D
+P S
+591 2204 M
+51 28 D
+53 25 D
+63 27 D
+92 31 D
+66 17 D
+87 17 D
+87 10 D
+78 3 D
+68 -1 D
+88 -7 D
+87 -14 D
+76 -18 D
+93 -29 D
+73 -29 D
+70 -33 D
+60 -34 D
+58 -36 D
+40 -28 D
+61 -49 D
+44 -38 D
+42 -41 D
+65 -73 D
+42 -54 D
+44 -65 D
+35 -58 D
+31 -61 D
+32 -71 D
+23 -65 D
+23 -74 D
+23 -105 D
+12 -97 D
+3 -49 D
+1 -88 D
+-7 -97 D
+-10 -68 D
+-11 -57 D
+-23 -85 D
+-28 -83 D
+-39 -90 D
+-9 -17 D
+-28 -52 D
+-35 -58 D
+-33 -49 D
+-48 -61 D
+-32 -37 D
+-27 -29 D
+-20 -21 D
+-65 -59 D
+-38 -31 D
+-31 -24 D
+-24 -17 D
+-24 -16 D
+-17 -10 D
+-25 -16 D
+-16 -10 D
+-17 -9 D
+-17 -10 D
+-18 -9 D
+-17 -9 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-17 -8 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-10 -4 D
+-9 -4 D
+-9 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -2 D
+-9 -3 D
+-9 -3 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-9 -1 D
+-10 0 D
+-10 0 D
+-88 2 D
+-48 4 D
+-87 13 D
+-39 7 D
+-85 22 D
+-83 28 D
+-81 34 D
+-70 35 D
+-67 40 D
+-49 33 D
+-69 53 D
+-37 32 D
+-43 41 D
+-47 49 D
+-44 52 D
+-47 63 D
+-47 74 D
+-42 77 D
+-43 99 D
+-31 92 D
+-19 76 D
+-13 67 D
+-9 68 D
+-6 97 D
+1 78 D
+5 69 D
+13 87 D
+7 38 D
+22 85 D
+28 83 D
+26 64 D
+34 70 D
+39 68 D
+37 57 D
+41 55 D
+37 45 D
+47 50 D
+56 54 D
+52 44 D
+63 47 D
+74 47 D
+P S
+8 W
+N 945 1590 M 17 -29 D S
+N 591 2204 M -17 29 D S
+N 1181 1654 M 0 -34 D S
+N 1181 2362 M 0 34 D S
+N 1417 1590 M -16 -29 D S
+N 1772 2204 M 16 29 D S
+N 1590 1417 M -29 -16 D S
+N 2204 1772 M 29 16 D S
+N 1654 1181 M -34 0 D S
+N 2362 1181 M 34 0 D S
+N 1590 945 M -29 17 D S
+N 2204 591 M 29 -17 D S
+N 1417 772 M -16 29 D S
+N 1772 158 M 16 -29 D S
+N 1181 709 M 0 33 D S
+N 1181 0 M 0 -33 D S
+N 945 772 M 17 29 D S
+N 591 158 M -17 -29 D S
+N 772 945 M 29 17 D S
+N 158 591 M -29 -17 D S
+N 709 1181 M 33 0 D S
+N 0 1181 M -33 0 D S
+N 772 1417 M 29 -16 D S
+N 158 1772 M -29 16 D S
+N 945 1590 M 17 -29 D S
+N 591 2204 M -17 29 D S
+25 W
+591 2204 M
+69 37 D
+72 33 D
+74 27 D
+76 23 D
+77 17 D
+39 7 D
+78 10 D
+79 4 D
+79 -1 D
+39 -2 D
+79 -9 D
+77 -14 D
+77 -19 D
+75 -25 D
+73 -29 D
+36 -16 D
+36 -18 D
+68 -38 D
+34 -21 D
+64 -46 D
+62 -49 D
+58 -54 D
+54 -57 D
+50 -61 D
+24 -32 D
+44 -65 D
+39 -69 D
+35 -71 D
+16 -36 D
+27 -74 D
+23 -76 D
+17 -77 D
+7 -38 D
+10 -79 D
+4 -79 D
+-1 -79 D
+-2 -39 D
+-9 -78 D
+-14 -78 D
+-19 -77 D
+-25 -75 D
+-29 -73 D
+-16 -36 D
+-56 -104 D
+-21 -33 D
+-46 -65 D
+-49 -61 D
+-54 -58 D
+-57 -55 D
+-61 -50 D
+-32 -24 D
+-65 -43 D
+-34 -21 D
+-70 -37 D
+-36 -17 D
+-36 -15 D
+-37 -15 D
+-37 -13 D
+-38 -12 D
+-38 -10 D
+-38 -10 D
+-39 -8 D
+-38 -7 D
+-40 -5 D
+-39 -4 D
+-39 -3 D
+-40 -2 D
+-79 1 D
+-78 6 D
+-39 5 D
+-78 14 D
+-77 20 D
+-75 24 D
+-73 29 D
+-36 16 D
+-70 37 D
+-67 41 D
+-65 45 D
+-31 24 D
+-60 52 D
+-28 27 D
+-55 58 D
+-50 60 D
+-24 32 D
+-64 100 D
+-37 69 D
+-17 36 D
+-30 73 D
+-25 75 D
+-20 76 D
+-15 78 D
+-9 78 D
+-5 79 D
+1 79 D
+6 78 D
+5 40 D
+14 77 D
+9 39 D
+22 76 D
+27 74 D
+31 72 D
+18 36 D
+39 68 D
+21 34 D
+45 64 D
+24 31 D
+52 60 D
+27 29 D
+58 54 D
+60 50 D
+32 24 D
+66 44 D
+P S
+945 1590 M
+42 22 D
+44 17 D
+46 13 D
+46 8 D
+32 3 D
+31 1 D
+63 -5 D
+47 -10 D
+45 -13 D
+44 -19 D
+28 -14 D
+40 -25 D
+25 -19 D
+35 -32 D
+32 -35 D
+29 -38 D
+24 -40 D
+20 -43 D
+16 -45 D
+11 -46 D
+7 -47 D
+2 -47 D
+-5 -63 D
+-10 -47 D
+-13 -45 D
+-19 -44 D
+-14 -28 D
+-25 -40 D
+-19 -25 D
+-32 -35 D
+-35 -32 D
+-25 -19 D
+-26 -18 D
+-27 -16 D
+-15 -7 D
+-14 -7 D
+-14 -6 D
+-15 -6 D
+-15 -5 D
+-15 -5 D
+-15 -4 D
+-16 -4 D
+-15 -3 D
+-16 -3 D
+-15 -2 D
+-16 -1 D
+-16 -2 D
+-15 0 D
+-16 0 D
+-32 1 D
+-62 9 D
+-46 12 D
+-44 17 D
+-43 21 D
+-40 26 D
+-49 39 D
+-33 34 D
+-20 24 D
+-27 39 D
+-23 42 D
+-19 43 D
+-14 45 D
+-10 47 D
+-5 47 D
+1 63 D
+9 62 D
+12 46 D
+17 44 D
+21 43 D
+35 53 D
+30 36 D
+34 33 D
+37 30 D
+P S
+/PSL_H_y 300 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+83 F0
+(100°) sh add def
+1181 2362 PSL_H_y add M
+200 F0
+(\053a\053t30) bc Z
+1544 1763 M 83 F0
+V -30 R (0.6) tl Z U
+1662 1967 M V -30 R (0.8) tl Z U
+1780 2172 M V -30 R (1.0) tl Z U
+978 1533 M V 30 R (0°) tc Z U
+557 2262 M V 30 R (0°) bc Z U
+1181 1587 M (30°) tc Z
+1181 2429 M V -2.84e-14 R (30°) bc Z U
+1384 1533 M V -30 R (60°) tc Z U
+1805 2262 M V -30 R (60°) bc Z U
+1533 1384 M V -60 R (90°) tc Z U
+2262 1805 M V -60 R (90°) bc Z U
+1587 1181 M V -90 R (120°) tc Z U
+2429 1181 M V -90 R (120°) bc Z U
+1533 978 M V 60 R (150°) bc Z U
+2262 557 M V 420 R (150°) tc Z U
+1384 830 M V 30 R (180°) bc Z U
+1805 100 M V 390 R (180°) tc Z U
+1181 775 M (-150°) bc Z
+1181 -67 M V 360 R (-150°) tc Z U
+978 830 M V -30 R (-120°) bc Z U
+557 100 M V 330 R (-120°) tc Z U
+830 978 M V -60 R (-90°) bc Z U
+100 557 M V 300 R (-90°) tc Z U
+775 1181 M V -270 R (-60°) tc Z U
+-67 1181 M V 90 R (-60°) bc Z U
+830 1384 M V 60 R (-30°) tc Z U
+100 1805 M V 60 R (-30°) bc Z U
+%%EndObject
+-6036 -3018 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/0/1 -JP1.9685i -BWENS+i60+tDefault -Bxxa30fg -Byyafg -Xa0i -Ya0i
+%@PROJ: polar 0.00000000 360.00000000 0.00000000 1.00000000 -1.000 1.000 -1.000 1.000 +unavailable +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_11
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+1181 1181 M
+1181 0 D
+S
+1181 1181 M
+1023 591 D
+S
+1181 1181 M
+591 1023 D
+S
+1181 1181 M
+0 1181 D
+S
+1181 1181 M
+-590 1023 D
+S
+1181 1181 M
+-1023 591 D
+S
+1181 1181 M
+-1181 0 D
+S
+1181 1181 M
+-1023 -590 D
+S
+1181 1181 M
+-590 -1023 D
+S
+1181 1181 M
+0 -1181 D
+S
+1181 1181 M
+591 -1023 D
+S
+1181 1181 M
+1023 -590 D
+S
+1417 1181 M
+-1 23 D
+-5 31 D
+-9 30 D
+-13 29 D
+-12 20 D
+-19 24 D
+-11 12 D
+-30 24 D
+-27 17 D
+-43 17 D
+-46 9 D
+-8 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-7 0 D
+-8 -1 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-14 -7 D
+-20 -13 D
+-30 -24 D
+-29 -36 D
+-13 -20 D
+-13 -29 D
+-9 -30 D
+-6 -38 D
+1 -39 D
+7 -39 D
+13 -36 D
+15 -28 D
+19 -25 D
+21 -23 D
+24 -19 D
+20 -13 D
+43 -19 D
+38 -9 D
+39 -2 D
+31 2 D
+38 9 D
+43 19 D
+32 22 D
+23 21 D
+16 18 D
+21 33 D
+16 35 D
+9 38 D
+3 31 D
+P S
+1654 1181 M
+-3 47 D
+-8 54 D
+-15 53 D
+-17 43 D
+-22 42 D
+-12 20 D
+-28 37 D
+-26 30 D
+-28 27 D
+-36 29 D
+-26 18 D
+-41 23 D
+-43 19 D
+-44 14 D
+-38 9 D
+-62 7 D
+-8 0 D
+-16 1 D
+-8 -1 D
+-8 0 D
+-7 0 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-14 -7 D
+-14 -7 D
+-14 -7 D
+-13 -8 D
+-20 -13 D
+-19 -13 D
+-42 -36 D
+-32 -34 D
+-29 -37 D
+-25 -39 D
+-24 -49 D
+-18 -52 D
+-12 -53 D
+-6 -54 D
+1 -63 D
+8 -54 D
+11 -45 D
+19 -52 D
+25 -48 D
+8 -14 D
+32 -44 D
+31 -35 D
+35 -32 D
+37 -28 D
+33 -21 D
+50 -24 D
+51 -18 D
+53 -12 D
+55 -6 D
+62 1 D
+54 8 D
+46 11 D
+51 19 D
+49 25 D
+39 26 D
+36 29 D
+34 33 D
+34 42 D
+22 33 D
+19 34 D
+19 43 D
+16 52 D
+8 38 D
+6 55 D
+P S
+1890 1181 M
+-3 59 D
+-5 46 D
+-11 58 D
+-16 56 D
+-25 66 D
+-20 42 D
+-29 51 D
+-34 48 D
+-29 37 D
+-48 50 D
+-44 39 D
+-67 48 D
+-30 18 D
+-74 36 D
+-77 27 D
+-57 14 D
+-58 9 D
+-70 5 D
+-12 0 D
+-12 0 D
+-11 -1 D
+-12 0 D
+-12 -1 D
+-11 -1 D
+-12 -1 D
+-12 -1 D
+-11 -1 D
+-12 -2 D
+-12 -2 D
+-11 -2 D
+-12 -2 D
+-11 -3 D
+-11 -2 D
+-12 -3 D
+-11 -3 D
+-11 -3 D
+-12 -3 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-11 -5 D
+-21 -10 D
+-21 -10 D
+-20 -11 D
+-21 -12 D
+-20 -13 D
+-28 -20 D
+-37 -28 D
+-52 -48 D
+-32 -34 D
+-36 -46 D
+-39 -59 D
+-27 -52 D
+-19 -43 D
+-23 -66 D
+-14 -57 D
+-9 -58 D
+-4 -58 D
+-1 -24 D
+3 -58 D
+7 -59 D
+12 -57 D
+17 -56 D
+21 -55 D
+20 -42 D
+12 -20 D
+11 -21 D
+33 -48 D
+36 -46 D
+40 -43 D
+53 -47 D
+56 -41 D
+30 -19 D
+21 -11 D
+31 -16 D
+43 -19 D
+67 -23 D
+56 -14 D
+58 -9 D
+59 -4 D
+23 -1 D
+59 3 D
+58 7 D
+57 12 D
+56 17 D
+55 21 D
+42 20 D
+41 23 D
+49 33 D
+46 36 D
+42 40 D
+47 53 D
+41 56 D
+25 41 D
+21 41 D
+19 43 D
+20 55 D
+17 68 D
+9 58 D
+5 70 D
+P S
+2126 1181 M
+-2 63 D
+-8 77 D
+-17 84 D
+-12 46 D
+-20 59 D
+-21 51 D
+-23 49 D
+-34 61 D
+-8 14 D
+-22 32 D
+-18 26 D
+-39 49 D
+-36 40 D
+-11 12 D
+-6 5 D
+-5 6 D
+-52 47 D
+-37 30 D
+-38 27 D
+-39 26 D
+-54 31 D
+-56 27 D
+-43 18 D
+-37 14 D
+-67 20 D
+-46 11 D
+-77 13 D
+-70 6 D
+-8 0 D
+-62 1 D
+-8 -1 D
+-8 0 D
+-8 0 D
+-8 -1 D
+-7 0 D
+-8 -1 D
+-8 0 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-8 -1 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-8 -2 D
+-7 -1 D
+-8 -2 D
+-8 -1 D
+-7 -2 D
+-8 -1 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-8 -2 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-8 -2 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -2 D
+-7 -3 D
+-14 -7 D
+-8 -3 D
+-7 -3 D
+-14 -7 D
+-7 -3 D
+-14 -7 D
+-14 -7 D
+-13 -8 D
+-14 -7 D
+-14 -8 D
+-13 -8 D
+-20 -13 D
+-19 -13 D
+-19 -13 D
+-25 -19 D
+-31 -25 D
+-40 -36 D
+-23 -22 D
+-10 -12 D
+-6 -5 D
+-41 -47 D
+-29 -37 D
+-39 -58 D
+-17 -27 D
+-26 -48 D
+-23 -49 D
+-29 -73 D
+-24 -83 D
+-14 -68 D
+-6 -39 D
+-6 -70 D
+-1 -63 D
+4 -70 D
+4 -39 D
+12 -69 D
+17 -68 D
+17 -52 D
+23 -58 D
+19 -43 D
+18 -35 D
+23 -40 D
+39 -59 D
+43 -56 D
+36 -41 D
+6 -5 D
+27 -28 D
+6 -5 D
+5 -6 D
+53 -46 D
+31 -24 D
+58 -39 D
+27 -17 D
+48 -26 D
+42 -20 D
+58 -24 D
+52 -17 D
+60 -17 D
+69 -13 D
+31 -5 D
+70 -6 D
+63 -1 D
+70 4 D
+39 4 D
+77 14 D
+60 15 D
+52 17 D
+73 29 D
+63 31 D
+40 23 D
+59 39 D
+50 38 D
+29 25 D
+18 16 D
+5 6 D
+12 10 D
+43 46 D
+45 54 D
+27 38 D
+26 39 D
+31 54 D
+27 56 D
+15 36 D
+17 44 D
+18 60 D
+13 53 D
+13 77 D
+6 70 D
+P S
+2362 1181 M
+-1 59 D
+-10 107 D
+-16 86 D
+-19 76 D
+-31 92 D
+-26 63 D
+-21 45 D
+-42 77 D
+-42 65 D
+-53 71 D
+-51 59 D
+-55 56 D
+-43 39 D
+-61 49 D
+-64 45 D
+-58 36 D
+-69 36 D
+-53 25 D
+-82 31 D
+-85 26 D
+-85 19 D
+-68 10 D
+-87 8 D
+-98 1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-17 -9 D
+-17 -9 D
+-18 -9 D
+-17 -9 D
+-16 -10 D
+-17 -10 D
+-17 -11 D
+-24 -16 D
+-24 -17 D
+-24 -17 D
+-31 -24 D
+-52 -44 D
+-63 -62 D
+-26 -28 D
+-56 -68 D
+-51 -72 D
+-26 -41 D
+-14 -26 D
+-32 -60 D
+-21 -44 D
+-32 -82 D
+-21 -65 D
+-21 -86 D
+-9 -47 D
+-9 -68 D
+-6 -68 D
+-1 -88 D
+5 -78 D
+8 -68 D
+12 -67 D
+16 -67 D
+29 -93 D
+37 -90 D
+40 -79 D
+45 -75 D
+51 -72 D
+43 -53 D
+53 -57 D
+42 -41 D
+59 -51 D
+63 -47 D
+40 -27 D
+76 -45 D
+88 -43 D
+81 -32 D
+65 -21 D
+95 -23 D
+87 -14 D
+88 -8 D
+87 -1 D
+78 5 D
+68 8 D
+67 12 D
+67 16 D
+93 29 D
+55 22 D
+35 15 D
+36 17 D
+60 33 D
+17 9 D
+57 37 D
+64 46 D
+45 37 D
+57 53 D
+48 49 D
+44 52 D
+53 71 D
+52 82 D
+45 87 D
+27 63 D
+20 55 D
+26 84 D
+19 85 D
+10 68 D
+8 88 D
+P S
+8 W
+N 2362 1181 M 34 0 D S
+N 2204 1772 M 29 16 D S
+N 1772 2204 M 16 29 D S
+N 1181 2362 M 0 34 D S
+N 591 2204 M -17 29 D S
+N 158 1772 M -29 16 D S
+N 0 1181 M -33 0 D S
+N 158 591 M -29 -17 D S
+N 591 158 M -17 -29 D S
+N 1181 0 M 0 -33 D S
+N 1772 158 M 16 -29 D S
+N 2204 591 M 29 -17 D S
+N 2362 1181 M 34 0 D S
+25 W
+2362 1181 M
+0 40 D
+-2 39 D
+-8 79 D
+-13 77 D
+-19 77 D
+-23 76 D
+-29 73 D
+-33 72 D
+-18 35 D
+-40 68 D
+-45 65 D
+-49 62 D
+-53 58 D
+-57 55 D
+-29 26 D
+-62 49 D
+-65 45 D
+-68 40 D
+-71 35 D
+-72 31 D
+-37 14 D
+-76 23 D
+-77 19 D
+-77 13 D
+-79 8 D
+-39 2 D
+-40 0 D
+-39 0 D
+-40 -2 D
+-39 -4 D
+-39 -4 D
+-39 -6 D
+-39 -7 D
+-39 -9 D
+-38 -10 D
+-38 -11 D
+-37 -12 D
+-37 -14 D
+-37 -15 D
+-36 -16 D
+-36 -17 D
+-35 -18 D
+-67 -40 D
+-66 -45 D
+-61 -49 D
+-59 -53 D
+-55 -57 D
+-26 -29 D
+-49 -62 D
+-23 -32 D
+-62 -101 D
+-35 -71 D
+-31 -72 D
+-14 -37 D
+-23 -76 D
+-10 -38 D
+-16 -77 D
+-10 -79 D
+-5 -78 D
+-1 -40 D
+3 -79 D
+3 -39 D
+10 -78 D
+16 -78 D
+21 -76 D
+12 -37 D
+29 -74 D
+33 -72 D
+18 -35 D
+41 -67 D
+21 -33 D
+23 -33 D
+49 -61 D
+53 -59 D
+57 -55 D
+60 -51 D
+31 -24 D
+33 -23 D
+66 -42 D
+34 -20 D
+71 -35 D
+73 -31 D
+37 -14 D
+75 -23 D
+38 -10 D
+78 -16 D
+78 -10 D
+79 -5 D
+39 -1 D
+79 3 D
+79 8 D
+39 5 D
+77 16 D
+76 21 D
+38 12 D
+73 29 D
+72 33 D
+35 18 D
+101 62 D
+63 47 D
+31 25 D
+58 53 D
+55 57 D
+51 60 D
+24 31 D
+45 66 D
+40 67 D
+35 71 D
+31 73 D
+14 37 D
+23 75 D
+19 77 D
+13 78 D
+8 78 D
+P S
+/PSL_H_y 300 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+83 F0
+(100°) sh add def
+1181 2362 PSL_H_y add M
+200 F0
+(Default) bc Z
+1190 1149 M 83 F0
+V -30 R (0.0) tl Z U
+1308 1353 M V -30 R (0.2) tl Z U
+1426 1558 M V -30 R (0.4) tl Z U
+1544 1763 M V -30 R (0.6) tl Z U
+1662 1967 M V -30 R (0.8) tl Z U
+1780 2172 M V -30 R (1.0) tl Z U
+2429 1181 M V -90 R (0°) bc Z U
+2262 1805 M V -60 R (30°) bc Z U
+1805 2262 M V -30 R (60°) bc Z U
+1181 2429 M V -1.42e-14 R (90°) bc Z U
+557 2262 M V 30 R (120°) bc Z U
+101 1805 M V 60 R (150°) bc Z U
+-67 1181 M V 90 R (180°) bc Z U
+101 557 M V 300 R (-150°) tc Z U
+557 101 M V 330 R (-120°) tc Z U
+1181 -67 M V 360 R (-90°) tc Z U
+1805 101 M V 390 R (-60°) tc Z U
+2262 557 M V 420 R (-30°) tc Z U
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3018 0 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/0/1 -JP1.9685i+r4c -BWENS+i60+t\053r4c -Bxxa30fg -Byyafg -Xa2.5152i -Ya0i
+%@PROJ: polar 0.00000000 360.00000000 0.00000000 1.00000000 -1.800 1.800 -1.800 1.800 +unavailable +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_12
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+1706 1181 M
+656 0 D
+S
+1636 1444 M
+568 328 D
+S
+1444 1636 M
+328 568 D
+S
+1181 1706 M
+0 656 D
+S
+919 1636 M
+-328 568 D
+S
+726 1444 M
+-568 328 D
+S
+656 1181 M
+-656 0 D
+S
+726 919 M
+-568 -328 D
+S
+919 726 M
+-328 -568 D
+S
+1181 656 M
+0 -656 D
+S
+1444 726 M
+328 -568 D
+S
+1636 919 M
+568 -328 D
+S
+1706 1181 M
+-2 43 D
+-1 18 D
+-11 60 D
+-17 58 D
+-24 56 D
+-12 23 D
+-33 51 D
+-27 34 D
+-42 43 D
+-40 34 D
+-43 29 D
+-46 25 D
+-56 23 D
+-67 18 D
+-43 7 D
+-61 3 D
+-9 0 D
+-8 0 D
+-9 -1 D
+-9 0 D
+-8 -1 D
+-9 -1 D
+-9 0 D
+-8 -2 D
+-9 -1 D
+-8 -1 D
+-9 -2 D
+-8 -1 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-9 -3 D
+-8 -2 D
+-8 -3 D
+-8 -2 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-15 -8 D
+-15 -8 D
+-15 -9 D
+-15 -9 D
+-21 -15 D
+-28 -22 D
+-38 -35 D
+-24 -25 D
+-32 -41 D
+-23 -37 D
+-17 -30 D
+-17 -40 D
+-7 -16 D
+-17 -58 D
+-8 -43 D
+-6 -61 D
+1 -52 D
+9 -68 D
+13 -51 D
+8 -25 D
+17 -40 D
+15 -31 D
+32 -51 D
+32 -41 D
+36 -38 D
+33 -29 D
+35 -26 D
+52 -31 D
+39 -18 D
+24 -10 D
+59 -17 D
+42 -8 D
+61 -6 D
+52 1 D
+69 9 D
+50 13 D
+25 8 D
+40 17 D
+31 15 D
+30 18 D
+29 19 D
+34 27 D
+37 36 D
+29 33 D
+31 42 D
+26 45 D
+15 31 D
+16 41 D
+16 58 D
+9 51 D
+P S
+1837 1181 M
+-2 54 D
+-5 43 D
+-13 64 D
+-9 32 D
+-14 41 D
+-16 40 D
+-36 67 D
+-36 54 D
+-42 50 D
+-8 7 D
+-15 16 D
+-8 7 D
+-7 8 D
+-50 42 D
+-64 42 D
+-57 30 D
+-71 27 D
+-31 9 D
+-32 8 D
+-64 11 D
+-65 4 D
+-11 0 D
+-11 0 D
+-11 0 D
+-10 -1 D
+-11 0 D
+-11 -1 D
+-11 -1 D
+-11 -1 D
+-10 -1 D
+-11 -2 D
+-11 -2 D
+-11 -2 D
+-10 -2 D
+-11 -2 D
+-10 -2 D
+-11 -3 D
+-10 -3 D
+-11 -2 D
+-10 -4 D
+-11 -3 D
+-10 -3 D
+-10 -4 D
+-10 -4 D
+-10 -4 D
+-11 -4 D
+-9 -4 D
+-10 -4 D
+-20 -10 D
+-19 -10 D
+-19 -10 D
+-19 -12 D
+-27 -18 D
+-26 -19 D
+-57 -50 D
+-15 -16 D
+-8 -7 D
+-41 -50 D
+-37 -54 D
+-31 -58 D
+-21 -49 D
+-14 -41 D
+-14 -53 D
+-11 -64 D
+-4 -65 D
+1 -54 D
+6 -54 D
+13 -64 D
+19 -62 D
+16 -40 D
+29 -59 D
+41 -64 D
+41 -50 D
+30 -32 D
+57 -50 D
+35 -25 D
+46 -29 D
+59 -29 D
+60 -23 D
+63 -17 D
+64 -11 D
+65 -4 D
+54 1 D
+54 6 D
+64 13 D
+62 19 D
+51 21 D
+48 24 D
+46 29 D
+35 25 D
+42 35 D
+7 8 D
+16 15 D
+50 57 D
+25 35 D
+29 46 D
+29 59 D
+23 60 D
+7 21 D
+14 63 D
+7 43 D
+4 65 D
+P S
+1969 1181 M
+-3 65 D
+-9 71 D
+-16 70 D
+-19 62 D
+-28 66 D
+-20 41 D
+-30 50 D
+-26 38 D
+-53 66 D
+-5 4 D
+-13 15 D
+-5 4 D
+-4 5 D
+-5 4 D
+-9 10 D
+-10 8 D
+-4 5 D
+-71 57 D
+-60 39 D
+-46 25 D
+-54 24 D
+-48 18 D
+-31 10 D
+-83 19 D
+-58 8 D
+-58 3 D
+-7 0 D
+-13 1 D
+-6 -1 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-12 -6 D
+-12 -6 D
+-6 -2 D
+-11 -6 D
+-12 -6 D
+-11 -7 D
+-11 -6 D
+-12 -7 D
+-11 -7 D
+-11 -7 D
+-16 -11 D
+-16 -11 D
+-21 -16 D
+-25 -20 D
+-34 -30 D
+-9 -10 D
+-5 -4 D
+-4 -5 D
+-5 -4 D
+-13 -15 D
+-5 -4 D
+-57 -71 D
+-7 -11 D
+-25 -38 D
+-22 -40 D
+-29 -59 D
+-25 -67 D
+-16 -56 D
+-9 -44 D
+-6 -33 D
+-6 -64 D
+-1 -78 D
+5 -59 D
+5 -39 D
+17 -76 D
+15 -50 D
+24 -60 D
+29 -59 D
+29 -50 D
+34 -48 D
+41 -51 D
+31 -33 D
+48 -44 D
+52 -40 D
+43 -29 D
+51 -28 D
+53 -26 D
+67 -25 D
+56 -16 D
+77 -15 D
+65 -6 D
+78 -1 D
+58 5 D
+39 5 D
+57 12 D
+63 18 D
+66 26 D
+65 32 D
+17 9 D
+49 32 D
+21 15 D
+61 49 D
+4 5 D
+15 13 D
+4 5 D
+5 4 D
+9 10 D
+5 4 D
+38 44 D
+36 47 D
+38 60 D
+6 12 D
+7 11 D
+28 59 D
+21 54 D
+17 57 D
+15 69 D
+8 65 D
+2 46 D
+P S
+2100 1181 M
+-2 61 D
+-8 75 D
+-13 67 D
+-15 59 D
+-25 72 D
+-31 70 D
+-17 33 D
+-15 27 D
+-32 51 D
+-36 49 D
+-44 53 D
+-31 33 D
+-56 51 D
+-48 38 D
+-56 38 D
+-39 24 D
+-61 31 D
+-77 32 D
+-73 23 D
+-59 14 D
+-75 12 D
+-68 5 D
+-8 0 D
+-45 1 D
+-8 -1 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 -1 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -1 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -7 D
+-7 -3 D
+-14 -7 D
+-13 -7 D
+-13 -7 D
+-14 -8 D
+-13 -8 D
+-13 -8 D
+-19 -12 D
+-18 -13 D
+-19 -13 D
+-24 -19 D
+-35 -29 D
+-34 -31 D
+-26 -27 D
+-6 -5 D
+-40 -46 D
+-41 -54 D
+-33 -51 D
+-30 -53 D
+-26 -55 D
+-23 -56 D
+-16 -51 D
+-9 -29 D
+-13 -59 D
+-9 -53 D
+-6 -68 D
+-2 -60 D
+3 -61 D
+5 -53 D
+12 -67 D
+14 -59 D
+16 -51 D
+22 -57 D
+19 -42 D
+24 -47 D
+31 -52 D
+34 -50 D
+38 -48 D
+30 -34 D
+6 -5 D
+10 -11 D
+6 -5 D
+10 -11 D
+6 -5 D
+5 -6 D
+46 -40 D
+48 -37 D
+70 -45 D
+54 -29 D
+62 -28 D
+50 -19 D
+65 -20 D
+59 -13 D
+53 -9 D
+68 -6 D
+61 -2 D
+60 3 D
+53 5 D
+68 12 D
+59 14 D
+65 21 D
+77 32 D
+74 39 D
+51 32 D
+37 27 D
+48 38 D
+28 25 D
+5 6 D
+38 37 D
+45 52 D
+32 42 D
+45 70 D
+29 54 D
+19 41 D
+23 56 D
+23 73 D
+14 59 D
+12 75 D
+5 68 D
+P S
+2231 1181 M
+-2 69 D
+-8 78 D
+-14 77 D
+-17 67 D
+-16 50 D
+-31 81 D
+-34 70 D
+-30 53 D
+-43 65 D
+-37 49 D
+-57 65 D
+-19 18 D
+-24 25 D
+-59 51 D
+-63 47 D
+-58 37 D
+-61 34 D
+-63 29 D
+-89 34 D
+-92 25 D
+-69 13 D
+-69 9 D
+-78 4 D
+-8 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 -1 D
+-8 0 D
+-9 0 D
+-9 -1 D
+-8 0 D
+-9 -1 D
+-9 -1 D
+-8 0 D
+-9 -1 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-9 -2 D
+-8 -1 D
+-9 -1 D
+-8 -2 D
+-9 -1 D
+-8 -2 D
+-9 -2 D
+-8 -1 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-8 -3 D
+-9 -2 D
+-8 -2 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-8 -2 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-15 -8 D
+-8 -3 D
+-16 -8 D
+-8 -4 D
+-8 -3 D
+-15 -8 D
+-15 -9 D
+-15 -8 D
+-15 -9 D
+-15 -9 D
+-15 -9 D
+-22 -15 D
+-21 -14 D
+-28 -21 D
+-34 -27 D
+-58 -52 D
+-60 -63 D
+-33 -40 D
+-61 -85 D
+-31 -52 D
+-36 -69 D
+-27 -64 D
+-26 -74 D
+-22 -84 D
+-16 -94 D
+-6 -69 D
+-2 -78 D
+6 -96 D
+13 -85 D
+13 -60 D
+17 -58 D
+26 -74 D
+28 -63 D
+36 -69 D
+32 -52 D
+56 -78 D
+45 -53 D
+54 -55 D
+32 -30 D
+61 -49 D
+64 -45 D
+67 -39 D
+70 -35 D
+48 -20 D
+49 -18 D
+59 -17 D
+50 -13 D
+94 -16 D
+69 -6 D
+78 -2 D
+96 6 D
+68 10 D
+77 16 D
+75 22 D
+81 31 D
+47 22 D
+62 32 D
+59 37 D
+77 56 D
+46 40 D
+56 54 D
+35 39 D
+38 47 D
+31 42 D
+33 51 D
+38 68 D
+29 63 D
+34 90 D
+23 83 D
+14 68 D
+10 78 D
+4 78 D
+P S
+2362 1181 M
+-1 59 D
+-10 107 D
+-16 86 D
+-19 76 D
+-31 92 D
+-26 63 D
+-21 45 D
+-42 77 D
+-42 65 D
+-53 71 D
+-51 59 D
+-55 56 D
+-43 39 D
+-61 49 D
+-64 45 D
+-58 36 D
+-69 36 D
+-53 25 D
+-82 31 D
+-85 26 D
+-85 19 D
+-68 10 D
+-87 8 D
+-98 1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-17 -9 D
+-17 -9 D
+-18 -9 D
+-17 -9 D
+-16 -10 D
+-17 -10 D
+-17 -11 D
+-24 -16 D
+-24 -17 D
+-24 -17 D
+-31 -24 D
+-52 -44 D
+-63 -62 D
+-26 -28 D
+-56 -68 D
+-51 -72 D
+-26 -41 D
+-14 -26 D
+-32 -60 D
+-21 -44 D
+-32 -82 D
+-21 -65 D
+-21 -86 D
+-9 -47 D
+-9 -68 D
+-6 -68 D
+-1 -88 D
+5 -78 D
+8 -68 D
+12 -67 D
+16 -67 D
+29 -93 D
+37 -90 D
+40 -79 D
+45 -75 D
+51 -72 D
+43 -53 D
+53 -57 D
+42 -41 D
+59 -51 D
+63 -47 D
+40 -27 D
+76 -45 D
+88 -43 D
+81 -32 D
+65 -21 D
+95 -23 D
+87 -14 D
+88 -8 D
+87 -1 D
+78 5 D
+68 8 D
+67 12 D
+67 16 D
+93 29 D
+55 22 D
+35 15 D
+36 17 D
+60 33 D
+17 9 D
+57 37 D
+64 46 D
+45 37 D
+57 53 D
+48 49 D
+44 52 D
+53 71 D
+52 82 D
+45 87 D
+27 63 D
+20 55 D
+26 84 D
+19 85 D
+10 68 D
+8 88 D
+P S
+8 W
+N 1706 1181 M -33 0 D S
+N 2362 1181 M 34 0 D S
+N 1636 1444 M -29 -17 D S
+N 2204 1772 M 29 16 D S
+N 1444 1636 M -17 -29 D S
+N 1772 2204 M 16 29 D S
+N 1181 1706 M 0 -33 D S
+N 1181 2362 M 0 34 D S
+N 919 1636 M 16 -29 D S
+N 591 2204 M -17 29 D S
+N 726 1444 M 29 -17 D S
+N 158 1772 M -29 16 D S
+N 656 1181 M 33 0 D S
+N 0 1181 M -33 0 D S
+N 726 919 M 29 16 D S
+N 158 591 M -29 -17 D S
+N 919 726 M 16 29 D S
+N 591 158 M -17 -29 D S
+N 1181 656 M 0 33 D S
+N 1181 0 M 0 -33 D S
+N 1444 726 M -17 29 D S
+N 1772 158 M 16 -29 D S
+N 1636 919 M -29 16 D S
+N 2204 591 M 29 -17 D S
+N 1706 1181 M -33 0 D S
+N 2362 1181 M 34 0 D S
+25 W
+2362 1181 M
+0 40 D
+-2 39 D
+-8 79 D
+-13 77 D
+-19 77 D
+-23 76 D
+-29 73 D
+-33 72 D
+-18 35 D
+-40 68 D
+-45 65 D
+-49 62 D
+-53 58 D
+-57 55 D
+-29 26 D
+-62 49 D
+-65 45 D
+-68 40 D
+-71 35 D
+-72 31 D
+-37 14 D
+-76 23 D
+-77 19 D
+-77 13 D
+-79 8 D
+-39 2 D
+-40 0 D
+-39 0 D
+-40 -2 D
+-39 -4 D
+-39 -4 D
+-39 -6 D
+-39 -7 D
+-39 -9 D
+-38 -10 D
+-38 -11 D
+-37 -12 D
+-37 -14 D
+-37 -15 D
+-36 -16 D
+-36 -17 D
+-35 -18 D
+-67 -40 D
+-66 -45 D
+-61 -49 D
+-59 -53 D
+-55 -57 D
+-26 -29 D
+-49 -62 D
+-23 -32 D
+-62 -101 D
+-35 -71 D
+-31 -72 D
+-14 -37 D
+-23 -76 D
+-10 -38 D
+-16 -77 D
+-10 -79 D
+-5 -78 D
+-1 -40 D
+3 -79 D
+3 -39 D
+10 -78 D
+16 -78 D
+21 -76 D
+12 -37 D
+29 -74 D
+33 -72 D
+18 -35 D
+41 -67 D
+21 -33 D
+23 -33 D
+49 -61 D
+53 -59 D
+57 -55 D
+60 -51 D
+31 -24 D
+33 -23 D
+66 -42 D
+34 -20 D
+71 -35 D
+73 -31 D
+37 -14 D
+75 -23 D
+38 -10 D
+78 -16 D
+78 -10 D
+79 -5 D
+39 -1 D
+79 3 D
+79 8 D
+39 5 D
+77 16 D
+76 21 D
+38 12 D
+73 29 D
+72 33 D
+35 18 D
+101 62 D
+63 47 D
+31 25 D
+58 53 D
+55 57 D
+51 60 D
+24 31 D
+45 66 D
+40 67 D
+35 71 D
+31 73 D
+14 37 D
+23 75 D
+19 77 D
+13 78 D
+8 78 D
+P S
+1706 1181 M
+-1 35 D
+-9 70 D
+-19 67 D
+-20 49 D
+-7 16 D
+-26 46 D
+-31 42 D
+-23 27 D
+-24 25 D
+-26 24 D
+-42 32 D
+-29 19 D
+-31 17 D
+-48 21 D
+-67 21 D
+-35 7 D
+-69 7 D
+-18 0 D
+-17 0 D
+-18 -1 D
+-17 -2 D
+-18 -2 D
+-17 -2 D
+-17 -3 D
+-18 -4 D
+-17 -5 D
+-16 -5 D
+-17 -5 D
+-17 -6 D
+-16 -7 D
+-16 -7 D
+-16 -7 D
+-30 -17 D
+-30 -19 D
+-42 -32 D
+-38 -36 D
+-24 -26 D
+-32 -42 D
+-19 -29 D
+-31 -63 D
+-13 -33 D
+-15 -50 D
+-9 -52 D
+-5 -52 D
+1 -53 D
+6 -52 D
+7 -35 D
+21 -67 D
+22 -48 D
+16 -30 D
+29 -44 D
+22 -28 D
+36 -38 D
+26 -24 D
+42 -32 D
+30 -19 D
+46 -24 D
+49 -20 D
+50 -15 D
+52 -9 D
+53 -5 D
+52 1 D
+52 6 D
+35 7 D
+67 21 D
+48 22 D
+31 16 D
+43 29 D
+28 22 D
+38 36 D
+24 26 D
+32 42 D
+19 30 D
+17 30 D
+21 48 D
+21 67 D
+9 52 D
+5 53 D
+P S
+/PSL_H_y 300 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+83 F0
+(100°) sh add def
+1181 2362 PSL_H_y add M
+200 F0
+(\053r4c) bc Z
+1518 1717 M 83 F0
+V -30 R (0.2) tl Z U
+1583 1831 M V -30 R (0.4) tl Z U
+1649 1944 M V -30 R (0.6) tl Z U
+1715 2058 M V -30 R (0.8) tl Z U
+1780 2172 M V -30 R (1.0) tl Z U
+1639 1181 M V -90 R (0°) tc Z U
+2429 1181 M V -90 R (0°) bc Z U
+1578 1410 M V -60 R (30°) tc Z U
+2262 1805 M V -60 R (30°) bc Z U
+1410 1578 M V -30 R (60°) tc Z U
+1805 2262 M V -30 R (60°) bc Z U
+1181 1639 M (90°) tc Z
+1181 2429 M V -2.84e-14 R (90°) bc Z U
+952 1578 M V 30 R (120°) tc Z U
+557 2262 M V 30 R (120°) bc Z U
+784 1410 M V 60 R (150°) tc Z U
+101 1805 M V 60 R (150°) bc Z U
+723 1181 M V -270 R (180°) tc Z U
+-67 1181 M V 90 R (180°) bc Z U
+784 952 M V -60 R (-150°) bc Z U
+101 557 M V 300 R (-150°) tc Z U
+952 784 M V -30 R (-120°) bc Z U
+557 101 M V 330 R (-120°) tc Z U
+1181 723 M (-90°) bc Z
+1181 -67 M V 360 R (-90°) tc Z U
+1410 784 M V 30 R (-60°) bc Z U
+1805 101 M V 390 R (-60°) tc Z U
+1578 952 M V 60 R (-30°) bc Z U
+2262 557 M V 420 R (-30°) tc Z U
+%%EndObject
+-3018 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+6036 0 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/360/0/1 -JP1.9685i+f+r4c -BWENS+i60+t\053f\053r4c -Bxxa30fg -Byyafg -Xa5.0303i -Ya0i
+%@PROJ: polar 0.00000000 360.00000000 0.00000000 1.00000000 -1.800 1.800 -1.800 1.800 +unavailable +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_13
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+4 W
+2362 1181 M
+-656 0 D
+S
+2204 1772 M
+-568 -328 D
+S
+1772 2204 M
+-328 -568 D
+S
+1181 2362 M
+0 -656 D
+S
+591 2204 M
+328 -568 D
+S
+158 1772 M
+568 -328 D
+S
+0 1181 M
+656 0 D
+S
+158 591 M
+568 328 D
+S
+591 158 M
+328 568 D
+S
+1181 0 M
+0 656 D
+S
+1772 158 M
+-328 568 D
+S
+2204 591 M
+-568 328 D
+S
+2362 1181 M
+-1 59 D
+-10 107 D
+-16 86 D
+-19 76 D
+-31 92 D
+-26 63 D
+-21 45 D
+-42 77 D
+-42 65 D
+-53 71 D
+-51 59 D
+-55 56 D
+-43 39 D
+-61 49 D
+-64 45 D
+-58 36 D
+-69 36 D
+-53 25 D
+-82 31 D
+-85 26 D
+-85 19 D
+-68 10 D
+-87 8 D
+-98 1 D
+-10 -1 D
+-9 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-10 -1 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -2 D
+-9 -3 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -3 D
+-9 -4 D
+-9 -4 D
+-9 -4 D
+-18 -9 D
+-9 -4 D
+-17 -9 D
+-17 -9 D
+-18 -9 D
+-17 -9 D
+-16 -10 D
+-17 -10 D
+-17 -11 D
+-24 -16 D
+-24 -17 D
+-24 -17 D
+-31 -24 D
+-52 -44 D
+-63 -62 D
+-26 -28 D
+-56 -68 D
+-51 -72 D
+-26 -41 D
+-14 -26 D
+-32 -60 D
+-21 -44 D
+-32 -82 D
+-21 -65 D
+-21 -86 D
+-9 -47 D
+-9 -68 D
+-6 -68 D
+-1 -88 D
+5 -78 D
+8 -68 D
+12 -67 D
+16 -67 D
+29 -93 D
+37 -90 D
+40 -79 D
+45 -75 D
+51 -72 D
+43 -53 D
+53 -57 D
+42 -41 D
+59 -51 D
+63 -47 D
+40 -27 D
+76 -45 D
+88 -43 D
+81 -32 D
+65 -21 D
+95 -23 D
+87 -14 D
+88 -8 D
+87 -1 D
+78 5 D
+68 8 D
+67 12 D
+67 16 D
+93 29 D
+55 22 D
+35 15 D
+36 17 D
+60 33 D
+17 9 D
+57 37 D
+64 46 D
+45 37 D
+57 53 D
+48 49 D
+44 52 D
+53 71 D
+52 82 D
+45 87 D
+27 63 D
+20 55 D
+26 84 D
+19 85 D
+10 68 D
+8 88 D
+P S
+2231 1181 M
+-2 69 D
+-8 78 D
+-14 77 D
+-17 67 D
+-16 50 D
+-31 81 D
+-34 70 D
+-30 53 D
+-43 65 D
+-37 49 D
+-57 65 D
+-19 18 D
+-24 25 D
+-59 51 D
+-63 47 D
+-58 37 D
+-61 34 D
+-63 29 D
+-89 34 D
+-92 25 D
+-69 13 D
+-69 9 D
+-78 4 D
+-8 0 D
+-9 0 D
+-9 0 D
+-8 0 D
+-9 0 D
+-9 -1 D
+-8 0 D
+-9 0 D
+-9 -1 D
+-8 0 D
+-9 -1 D
+-9 -1 D
+-8 0 D
+-9 -1 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-9 -2 D
+-8 -1 D
+-9 -1 D
+-8 -2 D
+-9 -1 D
+-8 -2 D
+-9 -2 D
+-8 -1 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-8 -3 D
+-9 -2 D
+-8 -2 D
+-8 -3 D
+-9 -2 D
+-8 -3 D
+-8 -2 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -3 D
+-15 -8 D
+-8 -3 D
+-16 -8 D
+-8 -4 D
+-8 -3 D
+-15 -8 D
+-15 -9 D
+-15 -8 D
+-15 -9 D
+-15 -9 D
+-15 -9 D
+-22 -15 D
+-21 -14 D
+-28 -21 D
+-34 -27 D
+-58 -52 D
+-60 -63 D
+-33 -40 D
+-61 -85 D
+-31 -52 D
+-36 -69 D
+-27 -64 D
+-26 -74 D
+-22 -84 D
+-16 -94 D
+-6 -69 D
+-2 -78 D
+6 -96 D
+13 -85 D
+13 -60 D
+17 -58 D
+26 -74 D
+28 -63 D
+36 -69 D
+32 -52 D
+56 -78 D
+45 -53 D
+54 -55 D
+32 -30 D
+61 -49 D
+64 -45 D
+67 -39 D
+70 -35 D
+48 -20 D
+49 -18 D
+59 -17 D
+50 -13 D
+94 -16 D
+69 -6 D
+78 -2 D
+96 6 D
+68 10 D
+77 16 D
+75 22 D
+81 31 D
+47 22 D
+62 32 D
+59 37 D
+77 56 D
+46 40 D
+56 54 D
+35 39 D
+38 47 D
+31 42 D
+33 51 D
+38 68 D
+29 63 D
+34 90 D
+23 83 D
+14 68 D
+10 78 D
+4 78 D
+P S
+2100 1181 M
+-2 61 D
+-8 75 D
+-13 67 D
+-15 59 D
+-25 72 D
+-31 70 D
+-17 33 D
+-15 27 D
+-32 51 D
+-36 49 D
+-44 53 D
+-31 33 D
+-56 51 D
+-48 38 D
+-56 38 D
+-39 24 D
+-61 31 D
+-77 32 D
+-73 23 D
+-59 14 D
+-75 12 D
+-68 5 D
+-8 0 D
+-45 1 D
+-8 -1 D
+-7 0 D
+-8 0 D
+-7 0 D
+-8 -1 D
+-8 0 D
+-7 -1 D
+-8 0 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 0 D
+-8 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-8 -2 D
+-7 -1 D
+-7 -2 D
+-8 -1 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -1 D
+-8 -2 D
+-7 -2 D
+-7 -2 D
+-8 -2 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -7 D
+-7 -3 D
+-14 -7 D
+-13 -7 D
+-13 -7 D
+-14 -8 D
+-13 -8 D
+-13 -8 D
+-19 -12 D
+-18 -13 D
+-19 -13 D
+-24 -19 D
+-35 -29 D
+-34 -31 D
+-26 -27 D
+-6 -5 D
+-40 -46 D
+-41 -54 D
+-33 -51 D
+-30 -53 D
+-26 -55 D
+-23 -56 D
+-16 -51 D
+-9 -29 D
+-13 -59 D
+-9 -53 D
+-6 -68 D
+-2 -60 D
+3 -61 D
+5 -53 D
+12 -67 D
+14 -59 D
+16 -51 D
+22 -57 D
+19 -42 D
+24 -47 D
+31 -52 D
+34 -50 D
+38 -48 D
+30 -34 D
+6 -5 D
+10 -11 D
+6 -5 D
+10 -11 D
+6 -5 D
+5 -6 D
+46 -40 D
+48 -37 D
+70 -45 D
+54 -29 D
+62 -28 D
+50 -19 D
+65 -20 D
+59 -13 D
+53 -9 D
+68 -6 D
+61 -2 D
+60 3 D
+53 5 D
+68 12 D
+59 14 D
+65 21 D
+77 32 D
+74 39 D
+51 32 D
+37 27 D
+48 38 D
+28 25 D
+5 6 D
+38 37 D
+45 52 D
+32 42 D
+45 70 D
+29 54 D
+19 41 D
+23 56 D
+23 73 D
+14 59 D
+12 75 D
+5 68 D
+P S
+1969 1181 M
+-3 65 D
+-9 71 D
+-16 70 D
+-19 62 D
+-28 66 D
+-20 41 D
+-30 50 D
+-26 38 D
+-53 66 D
+-5 4 D
+-13 15 D
+-5 4 D
+-4 5 D
+-5 4 D
+-9 10 D
+-10 8 D
+-4 5 D
+-71 57 D
+-60 39 D
+-46 25 D
+-54 24 D
+-48 18 D
+-31 10 D
+-83 19 D
+-58 8 D
+-58 3 D
+-7 0 D
+-13 1 D
+-6 -1 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-7 -2 D
+-6 -1 D
+-6 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-6 -1 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-6 -2 D
+-7 -2 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-6 -3 D
+-6 -2 D
+-12 -6 D
+-12 -6 D
+-6 -2 D
+-11 -6 D
+-12 -6 D
+-11 -7 D
+-11 -6 D
+-12 -7 D
+-11 -7 D
+-11 -7 D
+-16 -11 D
+-16 -11 D
+-21 -16 D
+-25 -20 D
+-34 -30 D
+-9 -10 D
+-5 -4 D
+-4 -5 D
+-5 -4 D
+-13 -15 D
+-5 -4 D
+-57 -71 D
+-7 -11 D
+-25 -38 D
+-22 -40 D
+-29 -59 D
+-25 -67 D
+-16 -56 D
+-9 -44 D
+-6 -33 D
+-6 -64 D
+-1 -78 D
+5 -59 D
+5 -39 D
+17 -76 D
+15 -50 D
+24 -60 D
+29 -59 D
+29 -50 D
+34 -48 D
+41 -51 D
+31 -33 D
+48 -44 D
+52 -40 D
+43 -29 D
+51 -28 D
+53 -26 D
+67 -25 D
+56 -16 D
+77 -15 D
+65 -6 D
+78 -1 D
+58 5 D
+39 5 D
+57 12 D
+63 18 D
+66 26 D
+65 32 D
+17 9 D
+49 32 D
+21 15 D
+61 49 D
+4 5 D
+15 13 D
+4 5 D
+5 4 D
+9 10 D
+5 4 D
+38 44 D
+36 47 D
+38 60 D
+6 12 D
+7 11 D
+28 59 D
+21 54 D
+17 57 D
+15 69 D
+8 65 D
+2 46 D
+P S
+1837 1181 M
+-2 54 D
+-5 43 D
+-13 64 D
+-9 32 D
+-14 41 D
+-16 40 D
+-36 67 D
+-36 54 D
+-42 50 D
+-8 7 D
+-15 16 D
+-8 7 D
+-7 8 D
+-50 42 D
+-64 42 D
+-57 30 D
+-71 27 D
+-31 9 D
+-32 8 D
+-64 11 D
+-65 4 D
+-11 0 D
+-11 0 D
+-11 0 D
+-10 -1 D
+-11 0 D
+-11 -1 D
+-11 -1 D
+-11 -1 D
+-10 -1 D
+-11 -2 D
+-11 -2 D
+-11 -2 D
+-10 -2 D
+-11 -2 D
+-10 -2 D
+-11 -3 D
+-10 -3 D
+-11 -2 D
+-10 -4 D
+-11 -3 D
+-10 -3 D
+-10 -4 D
+-10 -4 D
+-10 -4 D
+-11 -4 D
+-9 -4 D
+-10 -4 D
+-20 -10 D
+-19 -10 D
+-19 -10 D
+-19 -12 D
+-27 -18 D
+-26 -19 D
+-57 -50 D
+-15 -16 D
+-8 -7 D
+-41 -50 D
+-37 -54 D
+-31 -58 D
+-21 -49 D
+-14 -41 D
+-14 -53 D
+-11 -64 D
+-4 -65 D
+1 -54 D
+6 -54 D
+13 -64 D
+19 -62 D
+16 -40 D
+29 -59 D
+41 -64 D
+41 -50 D
+30 -32 D
+57 -50 D
+35 -25 D
+46 -29 D
+59 -29 D
+60 -23 D
+63 -17 D
+64 -11 D
+65 -4 D
+54 1 D
+54 6 D
+64 13 D
+62 19 D
+51 21 D
+48 24 D
+46 29 D
+35 25 D
+42 35 D
+7 8 D
+16 15 D
+50 57 D
+25 35 D
+29 46 D
+29 59 D
+23 60 D
+7 21 D
+14 63 D
+7 43 D
+4 65 D
+P S
+1706 1181 M
+-2 43 D
+-1 18 D
+-11 60 D
+-17 58 D
+-24 56 D
+-12 23 D
+-33 51 D
+-27 34 D
+-42 43 D
+-40 34 D
+-43 29 D
+-46 25 D
+-56 23 D
+-67 18 D
+-43 7 D
+-61 3 D
+-9 0 D
+-8 0 D
+-9 -1 D
+-9 0 D
+-8 -1 D
+-9 -1 D
+-9 0 D
+-8 -2 D
+-9 -1 D
+-8 -1 D
+-9 -2 D
+-8 -1 D
+-9 -2 D
+-8 -2 D
+-9 -2 D
+-8 -2 D
+-9 -3 D
+-8 -2 D
+-8 -3 D
+-8 -2 D
+-9 -3 D
+-8 -3 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-8 -4 D
+-8 -3 D
+-15 -8 D
+-15 -8 D
+-15 -9 D
+-15 -9 D
+-21 -15 D
+-28 -22 D
+-38 -35 D
+-24 -25 D
+-32 -41 D
+-23 -37 D
+-17 -30 D
+-17 -40 D
+-7 -16 D
+-17 -58 D
+-8 -43 D
+-6 -61 D
+1 -52 D
+9 -68 D
+13 -51 D
+8 -25 D
+17 -40 D
+15 -31 D
+32 -51 D
+32 -41 D
+36 -38 D
+33 -29 D
+35 -26 D
+52 -31 D
+39 -18 D
+24 -10 D
+59 -17 D
+42 -8 D
+61 -6 D
+52 1 D
+69 9 D
+50 13 D
+25 8 D
+40 17 D
+31 15 D
+30 18 D
+29 19 D
+34 27 D
+37 36 D
+29 33 D
+31 42 D
+26 45 D
+15 31 D
+16 41 D
+16 58 D
+9 51 D
+P S
+8 W
+N 2362 1181 M 34 0 D S
+N 1706 1181 M -33 0 D S
+N 2204 1772 M 29 16 D S
+N 1636 1444 M -29 -17 D S
+N 1772 2204 M 16 29 D S
+N 1444 1636 M -17 -29 D S
+N 1181 2362 M 0 34 D S
+N 1181 1706 M 0 -33 D S
+N 591 2204 M -17 29 D S
+N 919 1636 M 16 -29 D S
+N 158 1772 M -29 16 D S
+N 726 1444 M 29 -17 D S
+N 0 1181 M -33 0 D S
+N 656 1181 M 33 0 D S
+N 158 591 M -29 -17 D S
+N 726 919 M 29 16 D S
+N 591 158 M -17 -29 D S
+N 919 726 M 16 29 D S
+N 1181 0 M 0 -33 D S
+N 1181 656 M 0 33 D S
+N 1772 158 M 16 -29 D S
+N 1444 726 M -17 29 D S
+N 2204 591 M 29 -17 D S
+N 1636 919 M -29 16 D S
+N 2362 1181 M 34 0 D S
+N 1706 1181 M -33 0 D S
+25 W
+1706 1181 M
+-1 35 D
+-9 70 D
+-19 67 D
+-20 49 D
+-7 16 D
+-26 46 D
+-31 42 D
+-23 27 D
+-24 25 D
+-26 24 D
+-42 32 D
+-29 19 D
+-31 17 D
+-48 21 D
+-67 21 D
+-35 7 D
+-69 7 D
+-18 0 D
+-17 0 D
+-18 -1 D
+-17 -2 D
+-18 -2 D
+-17 -2 D
+-17 -3 D
+-18 -4 D
+-17 -5 D
+-16 -5 D
+-17 -5 D
+-17 -6 D
+-16 -7 D
+-16 -7 D
+-16 -7 D
+-30 -17 D
+-30 -19 D
+-42 -32 D
+-38 -36 D
+-24 -26 D
+-32 -42 D
+-19 -29 D
+-31 -63 D
+-13 -33 D
+-15 -50 D
+-9 -52 D
+-5 -52 D
+1 -53 D
+6 -52 D
+7 -35 D
+21 -67 D
+22 -48 D
+16 -30 D
+29 -44 D
+22 -28 D
+36 -38 D
+26 -24 D
+42 -32 D
+30 -19 D
+46 -24 D
+49 -20 D
+50 -15 D
+52 -9 D
+53 -5 D
+52 1 D
+52 6 D
+35 7 D
+67 21 D
+48 22 D
+31 16 D
+43 29 D
+28 22 D
+38 36 D
+24 26 D
+32 42 D
+19 30 D
+17 30 D
+21 48 D
+21 67 D
+9 52 D
+5 53 D
+P S
+2362 1181 M
+0 40 D
+-2 39 D
+-8 79 D
+-13 77 D
+-19 77 D
+-23 76 D
+-29 73 D
+-33 72 D
+-18 35 D
+-40 68 D
+-45 65 D
+-49 62 D
+-53 58 D
+-57 55 D
+-29 26 D
+-62 49 D
+-65 45 D
+-68 40 D
+-71 35 D
+-72 31 D
+-37 14 D
+-76 23 D
+-77 19 D
+-77 13 D
+-79 8 D
+-39 2 D
+-40 0 D
+-39 0 D
+-40 -2 D
+-39 -4 D
+-39 -4 D
+-39 -6 D
+-39 -7 D
+-39 -9 D
+-38 -10 D
+-38 -11 D
+-37 -12 D
+-37 -14 D
+-37 -15 D
+-36 -16 D
+-36 -17 D
+-35 -18 D
+-67 -40 D
+-66 -45 D
+-61 -49 D
+-59 -53 D
+-55 -57 D
+-26 -29 D
+-49 -62 D
+-23 -32 D
+-62 -101 D
+-35 -71 D
+-31 -72 D
+-14 -37 D
+-23 -76 D
+-10 -38 D
+-16 -77 D
+-10 -79 D
+-5 -78 D
+-1 -40 D
+3 -79 D
+3 -39 D
+10 -78 D
+16 -78 D
+21 -76 D
+12 -37 D
+29 -74 D
+33 -72 D
+18 -35 D
+41 -67 D
+21 -33 D
+23 -33 D
+49 -61 D
+53 -59 D
+57 -55 D
+60 -51 D
+31 -24 D
+33 -23 D
+66 -42 D
+34 -20 D
+71 -35 D
+73 -31 D
+37 -14 D
+75 -23 D
+38 -10 D
+78 -16 D
+78 -10 D
+79 -5 D
+39 -1 D
+79 3 D
+79 8 D
+39 5 D
+77 16 D
+76 21 D
+38 12 D
+73 29 D
+72 33 D
+35 18 D
+101 62 D
+63 47 D
+31 25 D
+58 53 D
+55 57 D
+51 60 D
+24 31 D
+45 66 D
+40 67 D
+35 71 D
+31 73 D
+14 37 D
+23 75 D
+19 77 D
+13 78 D
+8 78 D
+P S
+/PSL_H_y 300 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+83 F0
+(100°) sh add def
+1181 2362 PSL_H_y add M
+200 F0
+(\053f\053r4c) bc Z
+1780 2172 M 83 F0
+V -30 R (0.0) tl Z U
+1715 2058 M V -30 R (0.2) tl Z U
+1649 1944 M V -30 R (0.4) tl Z U
+1583 1831 M V -30 R (0.6) tl Z U
+1518 1717 M V -30 R (0.8) tl Z U
+2429 1181 M V -90 R (0°) bc Z U
+1639 1181 M V -90 R (0°) tc Z U
+2262 1805 M V -60 R (30°) bc Z U
+1578 1410 M V -60 R (30°) tc Z U
+1805 2262 M V -30 R (60°) bc Z U
+1410 1578 M V -30 R (60°) tc Z U
+1181 2429 M V -2.84e-14 R (90°) bc Z U
+1181 1639 M (90°) tc Z
+557 2262 M V 30 R (120°) bc Z U
+952 1578 M V 30 R (120°) tc Z U
+101 1805 M V 60 R (150°) bc Z U
+784 1410 M V 60 R (150°) tc Z U
+-67 1181 M V 90 R (180°) bc Z U
+723 1181 M V -270 R (180°) tc Z U
+101 557 M V 300 R (-150°) tc Z U
+784 952 M V -60 R (-150°) bc Z U
+557 101 M V 330 R (-120°) tc Z U
+952 784 M V -30 R (-120°) bc Z U
+1181 -67 M V 360 R (-90°) tc Z U
+1181 723 M (-90°) bc Z
+1805 101 M V 390 R (-60°) tc Z U
+1410 784 M V 30 R (-60°) bc Z U
+2262 557 M V 420 R (-30°) tc Z U
+1578 952 M V 60 R (-30°) bc Z U
+%%EndObject
+-6036 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psbasemap/azim_radial.sh
+++ b/test/psbasemap/azim_radial.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Test new implementation of -JP modifiers
+gmt begin azim_radial ps
+	gmt set FONT_ANNOT_PRIMARY 5p MAP_TICK_LENGTH_PRIMARY 2p MAP_ANNOT_OFFSET_PRIMARY 2p FONT_TITLE 12p
+	gmt subplot begin 4x3 -Fs5c -BWSNE+i60 -Bxa30fg -Byafg -M12p -X2c -Y1.5c
+		gmt basemap -R0/360/0.4/1 -JP? -c -B+t"Default"
+		gmt basemap -R0/360/0.4/1 -JP?+f -c -B+t"\053f"
+		gmt basemap -R0/360/0/50 -JP?+fe -c -B+t"\053fe"
+		gmt basemap -R0/360/1000/3000 -JP?+fp -c -B+t"\053fp"
+		gmt basemap -R0/360/1000/3000 -JP?+z -c -B+t"\053z"
+		gmt basemap -R0/360/0/2891 -JP?+zp -c -B+t"\053zp"
+		gmt basemap -R0/360/0.4/1 -JP?+a -c -B+t"\053a"
+		gmt basemap -R0/360/0.4/1 -JP?+t30 -c -B+t"\053t30"
+		gmt basemap -R0/360/0.4/1 -JP?+a+t30 -c -B+t"\053a\053t30"
+		gmt basemap -R0/360/0/1 -JP? -c -B+t"Default"
+		gmt basemap -R0/360/0/1 -JP?+r4c -c -B+t"\053r4c"
+		gmt basemap -R0/360/0/1 -JP?+f+r4c -c -B+t"\053f\053r4c"
+	gmt subplot end
+gmt end show


### PR DESCRIPTION
For some projections, such as azimuthal or polar with 360 longitude range or global projections with 180 latitude range and where the poles are points, selected annotations may be excluded since the required axis along which to plot them do not exist.  This new modifier will force additional annotations inside the map frame along the specified parallel of meridian.
