### PR TITLE
Simplify gmt5syntax with "gmt --show-classic"

### DIFF
--- a/share/tools/gmt5syntax.in
+++ b/share/tools/gmt5syntax.in
@@ -15,23 +15,8 @@ use warnings;
 my $progname = 'gmt@GMT_INSTALL_NAME_SUFFIX@';
 
 # words to prepend with $progname
-my @modulenames = qw( backtracker blockmean blockmedian blockmode dimfilter
-filter1d fitcircle gmt2kml gmtconnect gmtconvert gmtdefaults gmtflexure
-gmtget gmtgravmag3d gmtinfo gmtlogo gmtregress
-gmtmath gmtselect gmtset gmtsimplify gmtspatial gmtstitch gmtvector gmtwhich
-gravfft grd2cpt grd2xyz grdblend grdclip grdcontour grdcut grdedit
-grdfft grdfilter grdflexure grdgradient grdgravmag3d grdhisteq grdimage grdinfo
-grdlandmask grdmask grdmath grdpaste grdpmodeler grdproject grdredpol
-grdconvert grdrotater grdsample grdseamount grdspotter grdtrack grdtrend
-grdvector grdview grdvolume greenspline gshhg hotspotter img2grd kml2gmt
-makecpt mapproject mgd77convert mgd77info mgd77list mgd77magref mgd77manage
-mgd77path mgd77sniffer mgd77track minmax nearneighbor originator project
-psconvert psbasemap psclip pscoast pscontour pscoupe pshistogram psimage
-pslegend psmask psmeca pspolar psrose pssac psscale pssegy pssegyz pstext psvelo
-pswiggle psxy psxyz rotconverter sample1d segy2grd spectrum1d sph2grd
-sphdistance sphinterpolate sphtriangulate splitxyz surface talwani2d talwani3d trend1d trend2d
-triangulate x2sys_binlist x2sys_cross x2sys_datalist x2sys_get x2sys_init
-x2sys_list x2sys_merge x2sys_put x2sys_report x2sys_solve xyz2grd );
+my @modulenames = `$progname --show-classic`;
+chomp (@modulenames);
 
 # Regexp::Assemble creates a single efficient regexp from multiple regexp
 my $have_assemble = eval "use Regexp::Assemble; 1" ? 1 : 0;


### PR DESCRIPTION
Use `gmt --show-classic` to list all the module names.