### PR TITLE
Sort so that gmt --show-classic lists modules in alphabetical order

### DIFF
--- a/src/gmt_core_module.c
+++ b/src/gmt_core_module.c
@@ -43,6 +43,13 @@ struct Gmt_moduleinfo {
 #endif
 };
 
+static int sort_on_classic (const void *vA, const void *vB) {
+	const struct Gmt_moduleinfo *A = vA, *B = vB;
+	if (A == NULL) return +1;	/* Get the NULL entry to the end */
+	if (B == NULL) return -1;	/* Get the NULL entry to the end */
+	return strcmp(A->cname, B->cname);
+}
+
 static struct Gmt_moduleinfo g_core_module[] = {
 #ifdef BUILD_SHARED_LIBS
 	{"basemap", "psbasemap", "core", "Plot base maps and frames", ">X},>DA@AD)"},
@@ -299,7 +306,15 @@ void gmt_core_module_list_all (void *V_API) {
 /* Produce single list on stdout of all GMT core module names for gmt --show-classic [i.e., classic mode names] */
 void gmt_core_module_classic_all (void *V_API) {
 	unsigned int module_id = 0;
+	size_t n_modules = 0;
 	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);
+
+	while (g_core_module[n_modules].cname != NULL)	/* Count the modules */
+		++n_modules;
+
+	/* Sort array on classic names since original array is sorted on modern names */
+	qsort (g_core_module, n_modules, sizeof (struct Gmt_moduleinfo), sort_on_classic);
+
 	while (g_core_module[module_id].cname != NULL) {
 		if (API->external || !(skip_this_module (g_core_module[module_id].cname) || skip_modern_module (g_core_module[module_id].cname)))
 			printf ("%s\n", g_core_module[module_id].cname);

--- a/src/gmt_make_module_src.sh
+++ b/src/gmt_make_module_src.sh
@@ -202,6 +202,13 @@ EOF
 fi
 cat << EOF >> ${FILE_GMT_MODULE_C}
 };
+
+static int sort_on_classic (const void *vA, const void *vB) {
+	const struct Gmt_moduleinfo *A = vA, *B = vB;
+	if (A == NULL) return +1;	/* Get the NULL entry to the end */
+	if (B == NULL) return -1;	/* Get the NULL entry to the end */
+	return strcmp(A->cname, B->cname);
+}
 EOF
 
 if [ "$U_TAG" = "CORE" ]; then
@@ -359,6 +366,7 @@ cat << EOF >> ${FILE_GMT_MODULE_C}
 /* Produce single list on stdout of all GMT ${L_TAG} module names for gmt --show-classic [i.e., classic mode names] */
 void gmt_${L_TAG}_module_classic_all (void *V_API) {
 	unsigned int module_id = 0;
+	size_t n_modules = 0;
 EOF
 if [ "$U_TAG" = "CORE" ]; then
 	cat << EOF >> ${FILE_GMT_MODULE_C}
@@ -370,6 +378,13 @@ else
 EOF
 fi
 cat << EOF >> ${FILE_GMT_MODULE_C}
+
+	while (g_${L_TAG}_module[n_modules].cname != NULL)	/* Count the modules */
+		++n_modules;
+
+	/* Sort array on classic names since original array is sorted on modern names */
+	qsort (g_${L_TAG}_module, n_modules, sizeof (struct Gmt_moduleinfo), sort_on_classic);
+
 	while (g_${L_TAG}_module[module_id].cname != NULL) {
 EOF
 if [ "$U_TAG" = "CORE" ]; then

--- a/src/gmt_supplements_module.c
+++ b/src/gmt_supplements_module.c
@@ -40,6 +40,13 @@ struct Gmt_moduleinfo {
 	const char *keys;             /* Program option info for external APIs */
 };
 
+static int sort_on_classic (const void *vA, const void *vB) {
+	const struct Gmt_moduleinfo *A = vA, *B = vB;
+	if (A == NULL) return +1;	/* Get the NULL entry to the end */
+	if (B == NULL) return -1;	/* Get the NULL entry to the end */
+	return strcmp(A->cname, B->cname);
+}
+
 static struct Gmt_moduleinfo g_supplements_module[] = {
 	{"earthtide", "earthtide", "geodesy", "Compute grids or time-series of solid Earth tides", ">D},GG),>DL,>DS"},
 	{"gpsgridder", "gpsgridder", "geodesy", "Interpolate GPS strains using Green's functions for elastic deformation", "<D{,ND(,TG(,CD)=f,GG}"},
@@ -126,7 +133,15 @@ void gmt_supplements_module_list_all (void *V_API) {
 /* Produce single list on stdout of all GMT supplements module names for gmt --show-classic [i.e., classic mode names] */
 void gmt_supplements_module_classic_all (void *V_API) {
 	unsigned int module_id = 0;
+	size_t n_modules = 0;
 	gmt_M_unused(V_API);
+
+	while (g_supplements_module[n_modules].cname != NULL)	/* Count the modules */
+		++n_modules;
+
+	/* Sort array on classic names since original array is sorted on modern names */
+	qsort (g_supplements_module, n_modules, sizeof (struct Gmt_moduleinfo), sort_on_classic);
+
 	while (g_supplements_module[module_id].cname != NULL) {
 		printf ("%s\n", g_supplements_module[module_id].cname);
 		++module_id;


### PR DESCRIPTION
The internal static array of type _struct Gmt_moduleinfo_ is arranged alphabetically on modern names, but with `gmt --show-classic` we wish to sort the array on classic names before output.  This PR writes a local compare function and calls _qsort_ before listing the output.
Closes #2854.
