### PR TITLE
ex31: Set PS_CONVERT to make the example portable

### DIFF
--- a/doc/examples/ex31/ex31.bat
+++ b/doc/examples/ex31/ex31.bat
@@ -5,6 +5,9 @@ REM GMT modules:	set, coast, plot, text, legend
 REM
 
 gmt begin ex31
+	REM Set FONTPATH used in image conversion
+	REM %~dp0 is path to the current batch file
+	gmt set PS_CONVERT="C-sFONTPATH=%~dp0fonts"
 	REM create file PSL_custom_fonts.txt in current working directory
 	REM and add PostScript font names of Linux Biolinum and Libertine
 	echo LinBiolinumO   0.700 0 > PSL_custom_fonts.txt

--- a/doc/examples/ex31/ex31.bat
+++ b/doc/examples/ex31/ex31.bat
@@ -6,7 +6,7 @@ REM
 
 gmt begin ex31
 	REM Set FONTPATH used in image conversion
-	REM %~dp0 is path to the current batch file
+	REM %~dp0 is the path to the current batch file
 	gmt set PS_CONVERT="C-sFONTPATH=%~dp0fonts"
 	REM create file PSL_custom_fonts.txt in current working directory
 	REM and add PostScript font names of Linux Biolinum and Libertine

--- a/doc/examples/ex31/ex31.sh
+++ b/doc/examples/ex31/ex31.sh
@@ -8,12 +8,11 @@
 
 # set AWK to awk if undefined
 AWK=${AWK:-awk}
-# Path to current directory
-EX31DIR=$(dirname $0)
 
 gmt begin ex31
 	# Set FONTPATH used in image conversion
-	gmt set PS_CONVERT="C-sFONTPATH=${EX31DIR}/fonts"
+	# $(dirname 0) is the path to the current bash script
+	gmt set PS_CONVERT="C-sFONTPATH=$(dirname $0)/fonts"
 
 	# create file PSL_custom_fonts.txt in current working directory
 	# and add PostScript font names of Linux Biolinum and Libertine

--- a/doc/examples/ex31/ex31.sh
+++ b/doc/examples/ex31/ex31.sh
@@ -8,8 +8,13 @@
 
 # set AWK to awk if undefined
 AWK=${AWK:-awk}
+# Path to current directory
+EX31DIR=$(dirname $0)
 
 gmt begin ex31
+	# Set FONTPATH used in image conversion
+	gmt set PS_CONVERT="C-sFONTPATH=${EX31DIR}/fonts"
+
 	# create file PSL_custom_fonts.txt in current working directory
 	# and add PostScript font names of Linux Biolinum and Libertine
 	$AWK '{print $1, 0.700, 0}' <<- EOF > PSL_custom_fonts.txt


### PR DESCRIPTION
Partially address #2749.

With the following changes, users can run the example outside the ex31 directory.
```
# Path to current directory
EX31DIR=$(dirname $0)

gmt set PS_CONVERT="C-sFONTPATH=${EX31DIR}/fonts"
```
If you think the change is good, I'll work further to clean up some stuff.