### PR TITLE
Change container type for grdmath dataset operators in the API

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -10336,6 +10336,33 @@ GMT_LOCAL int api_B_custom_annotations (struct GMT_OPTION *opt) {
 	return 1;
 }
 
+GMT_LOCAL bool operator_takes_dataset (struct GMT_OPTION *opt, int *geometry) {
+	/* Check if the sequence ? OPERATOR is one that requires reading a dataset instead of a grid.
+	 * Here, opt is an input argument with value ? and we inquire about the next option (the operator).
+	 * geometry is already set to GMT_IS_GRID */
+	if (opt == NULL) return false;	/* Just being paranoid */
+	if (opt->next == NULL) return false;	/* Just being extra paranoid */
+	if (opt->next->option != GMT_OPT_INFILE) return false;	/* Cannot be an operator */
+	if (!opt->next->arg[0]) return false;	/* No argument given */
+	if (!strncmp (opt->next->arg, "INSIDE", 6U)) {	/* Are nodes inside/outside a polygon */
+		*geometry = GMT_IS_POLY;
+		return true;
+	}
+	if (!strncmp (opt->next->arg, "POINT", 5U)) {	/* Compute mean location */
+		*geometry = GMT_IS_POINT;
+		return true;	/* One of the dataset-requiring operators */
+	}
+	if (!strncmp (&opt->next->arg[1], "PDIST", 5U)) {	/* Distance to points of some sort */
+		*geometry = GMT_IS_POINT;
+		return true;	/* One of the dataset-requiring operators */
+	}
+	if (!strncmp (&opt->next->arg[1], "PDIST", 5U)) {	/* Distance to lines of some sort */
+		*geometry = GMT_IS_LINE;
+		return true;	/* One of the dataset-requiring operators */
+	}
+	return false;	/* No, something else */
+}
+
 #define api_is_required_IO(key) (key == API_PRIMARY_INPUT || key == API_PRIMARY_OUTPUT)			/* Returns true if this is a primary input or output item */
 #define api_not_required_io(key) ((key == API_PRIMARY_INPUT || key == API_SECONDARY_INPUT) ? API_SECONDARY_INPUT : API_SECONDARY_OUTPUT)	/* Returns the optional input or output flag */
 
@@ -10425,7 +10452,7 @@ struct GMT_RESOURCE *GMT_Encode_Options (void *V_API, const char *module_name, i
 	int family = GMT_NOTSET;	/* -1, or one of GMT_IS_DATASET, GMT_IS_GRID, GMT_IS_PALETTE, GMT_IS_IMAGE */
 	int geometry = GMT_NOTSET;	/* -1, or one of GMT_IS_NONE, GMT_IS_TEXT, GMT_IS_POINT, GMT_IS_LINE, GMT_IS_POLY, GMT_IS_SURFACE */
 	int sdir, k, n_in_added = 0, n_to_add, e, n_pre_arg, n_per_family[GMT_N_FAMILIES];
-	bool deactivate_output = false, deactivate_input = false, strip_colon = false, strip = false;
+	bool deactivate_output = false, deactivate_input = false, strip_colon = false, strip = false, is_grdmath = false;
 	size_t n_alloc, len;
 	const char *keys = NULL;	/* This module's option keys */
 	char **key = NULL;		/* Array of items in keys */
@@ -10478,7 +10505,7 @@ struct GMT_RESOURCE *GMT_Encode_Options (void *V_API, const char *module_name, i
 			GMT_Report (API, GMT_MSG_DEBUG, "GMT_Encode_Options: Got quoted or decorate line and must strip argument %s from colon to end\n", opt->arg);
 	}
 	/* 1c. Check if this is either gmtmath or grdmath which both use the special = outfile syntax and replace that by -=<outfile> */
-	else if (!strncmp (module, "gmtmath", 7U) || !strncmp (module, "grdmath", 7U)) {
+	else if (!strncmp (module, "gmtmath", 7U) || (is_grdmath = (strncmp (module, "grdmath", 7U) == 0))) {
 		struct GMT_OPTION *delete = NULL;
 		for (opt = *head; opt && opt->next; opt = opt->next) {	/* Here opt will end up being the last option */
 			if (!strcmp (opt->arg, "=")) {
@@ -10682,6 +10709,8 @@ struct GMT_RESOURCE *GMT_Encode_Options (void *V_API, const char *module_name, i
 				GMT_Report (API, GMT_MSG_WARNING, "GMT_Encode_Options: Got a -<option>? argument but not listed in keys\n");
 				direction = GMT_IN;	/* Have to assume it is an input file if not specified */
 			}
+			if (is_grdmath && operator_takes_dataset (opt, &geometry))
+				family = GMT_IS_DATASET;
 			info[n_items].mode = (k >= 0 && api_is_required_IO (key[k][K_DIR])) ? K_PRIMARY : K_SECONDARY;
 			if (k >= 0 && key[k][K_DIR] != '-')
 				key[k][K_DIR] = api_not_required_io (key[k][K_DIR]);	/* Make sure required { becomes ( and } becomes ) so we don't add them later */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -10348,15 +10348,11 @@ GMT_LOCAL bool operator_takes_dataset (struct GMT_OPTION *opt, int *geometry) {
 		*geometry = GMT_IS_POLY;
 		return true;
 	}
-	if (!strncmp (opt->next->arg, "POINT", 5U)) {	/* Compute mean location */
+	if (!strncmp (opt->next->arg, "POINT", 5U) || !strncmp (opt->next->arg, "PDIST", 5U)) {
 		*geometry = GMT_IS_POINT;
 		return true;	/* One of the dataset-requiring operators */
 	}
-	if (!strncmp (&opt->next->arg[1], "PDIST", 5U)) {	/* Distance to points of some sort */
-		*geometry = GMT_IS_POINT;
-		return true;	/* One of the dataset-requiring operators */
-	}
-	if (!strncmp (&opt->next->arg[1], "PDIST", 5U)) {	/* Distance to lines of some sort */
+	if (!strncmp (opt->next->arg, "LDIST", 5U)) {	/* Distance to lines of some sort */
 		*geometry = GMT_IS_LINE;
 		return true;	/* One of the dataset-requiring operators */
 	}

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -2628,7 +2628,7 @@ GMT_LOCAL void grd_INSIDE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 		return;
 	}
 	gmt_skip_xy_duplicates (GMT, true);	/* Avoid repeating x/y points in polygons */
-	if ((D = GMT_Read_Data (GMT->parent, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POLY, GMT_READ_NORMAL, NULL, info->ASCII_file, NULL)) == NULL) {
+	if ((D = GMT_Read_Data (GMT->parent, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POLY, GMT_READ_NORMAL|GMT_IO_RESET, NULL, info->ASCII_file, NULL)) == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in operator INSIDE reading file %s!\n", info->ASCII_file);
 		info->error = GMT->parent->error;
 		return;
@@ -2883,7 +2883,7 @@ GMT_LOCAL struct GMT_DATASET *ASCII_read (struct GMT_CTRL *GMT, struct GRDMATH_I
 		info->error = GMT->parent->error;
 		return NULL;
 	}
-	if ((D = GMT_Read_Data (GMT->parent, GMT_IS_DATASET, GMT_IS_FILE, geometry, GMT_READ_NORMAL, NULL, info->ASCII_file, NULL)) == NULL) {
+	if ((D = GMT_Read_Data (GMT->parent, GMT_IS_DATASET, GMT_IS_FILE, geometry, GMT_READ_NORMAL|GMT_IO_RESET, NULL, info->ASCII_file, NULL)) == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in operator %s reading file %s!\n", op, info->ASCII_file);
 		info->error = GMT->parent->error;
 		return NULL;


### PR DESCRIPTION
**Description of proposed changes**

See issue #2476 for background.  That solution had it backwards: we must check the _next_ operator, not previous.  So now we correctly flag operands as DATASET when they should be, but the example still does not work because of an other mode-related issue.  Anyway, please approve this so I can move to the next step.