### PR TITLE
CI: Fix cache key of coastline data

### DIFF
--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -37,7 +37,7 @@ steps:
 
 - task: Cache@2
   inputs:
-    key: coastline | "ci/download-coastlines.sh"
+    key: coastline | ci/download-coastlines.sh
     path: $(COASTLINEDIR)
     cacheHitVar: CACHE_COASTLINE_RESTORED
   displayName: Cache GSHHG and DCW data

--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -37,7 +37,7 @@ steps:
 
 - task: Cache@2
   inputs:
-    key: coastline
+    key: coastline | "ci/download-coastlines.sh"
     path: $(COASTLINEDIR)
     cacheHitVar: CACHE_COASTLINE_RESTORED
   displayName: Cache GSHHG and DCW data

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -40,7 +40,7 @@ steps:
 
 - task: Cache@2
   inputs:
-    key: coastline
+    key: coastline | "ci/download-coastlines.sh"
     path: $(COASTLINEDIR)
     cacheHitVar: CACHE_COASTLINE_RESTORED
   displayName: Cache GSHHG and DCW data

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -40,7 +40,7 @@ steps:
 
 - task: Cache@2
   inputs:
-    key: coastline | "ci/download-coastlines.sh"
+    key: coastline | ci/download-coastlines.sh
     path: $(COASTLINEDIR)
     cacheHitVar: CACHE_COASTLINE_RESTORED
   displayName: Cache GSHHG and DCW data

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -78,7 +78,7 @@ steps:
 
 - task: Cache@2
   inputs:
-    key: coastline | "ci/download-coastlines.sh"
+    key: coastline | ci/download-coastlines.sh
     path: $(COASTLINEDIR)
     cacheHitVar: CACHE_COASTLINE_RESTORED
   displayName: Cache GSHHG and DCW data

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -78,7 +78,7 @@ steps:
 
 - task: Cache@2
   inputs:
-    key: coastline
+    key: coastline | "ci/download-coastlines.sh"
     path: $(COASTLINEDIR)
     cacheHitVar: CACHE_COASTLINE_RESTORED
   displayName: Cache GSHHG and DCW data


### PR DESCRIPTION
Add the script `ci/download-coastlines.sh` to the CI cache key so that when the script changes, the cached data are also updated.