### PR TITLE
Fix output of gmt --show-citation

### DIFF
--- a/src/gmt.c
+++ b/src/gmt.c
@@ -147,7 +147,7 @@ int main (int argc, char *argv[]) {
 			}
 
 			/* Print all classic modules and exit */
-			else if (!strncmp (argv[arg_n], "--show-classic", 8U)) {
+			else if (!strncmp (argv[arg_n], "--show-classic", 9U)) {
 				GMT_Call_Module (api_ctrl, NULL, GMT_MODULE_CLASSIC, NULL);
 				status = GMT_NOERROR;
 			}


### PR DESCRIPTION
`gmt --show-citation` outputs a list of classic module names.
This PR fixes the issue.