### PR TITLE
cmake: Set different GMT_DOC_URL for public and non-public releases

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -71,7 +71,11 @@ set (GMT_LIB_SOVERSION 6)
 set (GMT_LIB_VERSION "${GMT_LIB_SOVERSION}.${GMT_PACKAGE_VERSION_MINOR}.${GMT_PACKAGE_VERSION_PATCH}")
 
 # The GMT documentation URL
-set (GMT_DOC_URL "https://docs.generic-mapping-tools.org/dev")
+if (GMT_PUBLIC_RELEASE OR GMT_PACKAGE_VERSION_PATCH)
+	set (GMT_DOC_URL "https://docs.generic-mapping-tools.org/${GMT_PACKAGE_VERSION_MAJOR}.${GMT_PACKAGE_VERSION_MINOR}")
+else (GMT_PUBLIC_RELEASE OR GMT_PACKAGE_VERSION_PATCH)
+	set (GMT_DOC_URL "https://docs.generic-mapping-tools.org/dev")
+endif (GMT_PUBLIC_RELEASE OR GMT_PACKAGE_VERSION_PATCH)
 
 # Use SI units per default
 if (NOT UNITS)


### PR DESCRIPTION
Set **GMT_DOC_URL** to *dev* or *major.minor* (e.g. 6.1) for different cases:

- Public releases: always set **GMT_DOC_URL** to *major.minor*, e.g. 6.1
- Non-public releases:

  - bug-fix releases: set **GMT_DOC_URL** to *major.minor*.
    e.g. link GMT 6.1.1 to the documentation version 6.1
  - other releases: set **GMT_DOC_URL** to *dev*