### PR TITLE
cmake: Move GMTMEX installtion to admin/add_windows_cpack.txt

### DIFF
--- a/admin/add_windows_cpack.txt
+++ b/admin/add_windows_cpack.txt
@@ -78,3 +78,12 @@ if (GHOST_DATA_PATH)
 		DESTINATION ${GMT_BINDIR}
 		COMPONENT GHOSTSCRIPT)
 endif (GHOST_DATA_PATH)
+
+# Install the gmtmex on Windows
+if (GMTMEX_PATH)
+	install (PROGRAMS
+		"${GMTMEX_PATH}/gmtmex.mexw${BITAGE}"
+		"${GMTMEX_PATH}/gmt.m"
+		DESTINATION ${GMT_BINDIR}
+		COMPONENT Runtime)
+endif (GMTMEX_PATH)

--- a/cmake/dist/CMakeLists.txt
+++ b/cmake/dist/CMakeLists.txt
@@ -136,16 +136,6 @@ if (WIN32 AND NOT CYGWIN)
 		DESTINATION ${GMT_BINDIR}
 		COMPONENT Runtime)
 
-	if (WIN32 AND GMTMEX_PATH)
-		# Install the gmtmex on Windows. Its location is controlled by GMTMEX_PATH set in ConfigUserAdvanced.cmake
-		if (BITAGE EQUAL 64)
-			install (PROGRAMS "${GMTMEX_PATH}/gmtmex.mexw64" DESTINATION ${GMT_BINDIR} COMPONENT Runtime)
-		else ()
-			install (PROGRAMS "${GMTMEX_PATH}/gmtmex.mexw32" DESTINATION ${GMT_BINDIR} COMPONENT Runtime)
-		endif ()
-		install (PROGRAMS "${GMTMEX_PATH}/gmt.m" DESTINATION ${GMT_BINDIR} COMPONENT Runtime)
-	endif ()
-
 	# Fix bundle:
 	install (CODE "
 	if (CMAKE_INSTALL_PREFIX MATCHES \"_CPack_Packages\")


### PR DESCRIPTION
GMTMEX is only used when building Windows binaries.
It's better to move them to the admin/add_windows_cpaak.txt file.