### PR TITLE
Misc doc fixes plus upgrading contour -A- syntax

### DIFF
--- a/doc/rst/source/blockmean.rst
+++ b/doc/rst/source/blockmean.rst
@@ -92,9 +92,9 @@ Optional Arguments
     Provide Extended report which includes **s** (the standard deviation
     about the mean), **l**, the lowest value, and **h**, the high value
     for each block. Output order becomes
-    *x*,\ *y*,\ *z*,\ *s*,\ *l*,\ *h*\ [,\ *w*]. [Default outputs
-    *x*,\ *y*,\ *z*\ [,\ *w*]. See **-W** for *w* output.
-    If **-E+p**\|\ **P** are used then input data uncertainties are expected and *s*
+    *x*,\ *y*,\ *z*,\ *s*,\ *l*,\ *h*\ [,\ *w*]. Default outputs
+    *x*,\ *y*,\ *z*\ [,\ *w*]. See **-W** for enabling *w* output.
+    If **-E+p**\|\ **P** is used then input data uncertainties are expected and *s*
     becomes the propagated error of the weighted (**+p**) or simple (**+P**) *z* mean.
 
 .. _-G:
@@ -159,8 +159,8 @@ Optional Arguments
 
 .. |Add_nodereg| replace::
     Each block is the locus of points nearest the grid value location. Consider an example with
-    **-R**\ 10/15/10/15 and **-I**\ 1: With the |SYN_OPT-r| option, 10 <=
-    (*x*,\ *y*) < 11 is one of 25 blocks; without it 9.5 <= (*x*,\ *y*)
+    **-R**\ 10/15/10/15 and **-I**\ 1: With **-r** or **-rp**, 10 <=
+    (*x*,\ *y*) < 11 is one of 25 blocks; otherwise 9.5 <= (*x*,\ *y*)
     < 10.5 is one of 36 blocks.
 .. include:: explain_nodereg.rst_
 

--- a/doc/rst/source/blockmedian.rst
+++ b/doc/rst/source/blockmedian.rst
@@ -97,7 +97,7 @@ Optional Arguments
     Provide Extended report which includes **s** (the L1 scale of the
     median, i.e., 1.4826 \* median absolute deviation [MAD]), **l**, the lowest
     value, and **h**, the high value for each block. Output order becomes
-    *x*,\ *y*,\ *z*,\ *s*,\ *l*,\ *h*\ [,\ *w*]. [Default outputs
+    *x*,\ *y*,\ *z*,\ *s*,\ *l*,\ *h*\ [,\ *w*]. Default outputs
     *x*,\ *y*,\ *z*\ [,\ *w*]. For box-and-whisker calculation, use
     **-Eb** which will output
     *x*,\ *y*,\ *z*,\ *l*,\ *q25*,\ *q75*,\ *h*\ [,\ *w*], where *q25* and
@@ -178,8 +178,8 @@ Optional Arguments
 
 .. |Add_nodereg| replace::
     Each block is the locus of points nearest the grid value location. Consider an example with
-    **-R**\ 10/15/10/15 and **-I**\ 1: With the |SYN_OPT-r| option, 10 <=
-    (*x*,\ *y*) < 11 is one of 25 blocks; without it 9.5 <= (*x*,\ *y*)
+    **-R**\ 10/15/10/15 and **-I**\ 1: With **-r** or **-rp**, 10 <=
+    (*x*,\ *y*) < 11 is one of 25 blocks; otherwise 9.5 <= (*x*,\ *y*)
     < 10.5 is one of 36 blocks.
 .. include:: explain_nodereg.rst_
 

--- a/doc/rst/source/blockmode.rst
+++ b/doc/rst/source/blockmode.rst
@@ -68,7 +68,7 @@ Optional Arguments
 ------------------
 
 *table*
-   3 (or 4, see **-W**) column ASCII data table file(s) (or binary, see
+    3 (or 4, see **-W**) column ASCII data table file(s) (or binary, see
     **-bi**) holding (*x*,\ *y*,\ *z*\ [,\ *w*])
     data values, where [*w*] is an optional weight for the data.
     If no file is specified, **blockmode** will read from standard input.
@@ -108,7 +108,7 @@ Optional Arguments
     Provide Extended report which includes **s** (the L1 scale of the
     mode), **l**, the lowest value, and **h**, the high value for each
     block. Output order becomes
-    *x*,\ *y*,\ *z*,\ *s*,\ *l*,\ *h*\ [,\ *w*]. [Default outputs
+    *x*,\ *y*,\ *z*,\ *s*,\ *l*,\ *h*\ [,\ *w*]. Default outputs
     *x*,\ *y*,\ *z*\ [,\ *w*]. See **-W** for *w* output.
 **-E**\ **r**\|\ **s**\ [**+l**\|\ **h**]
     Provide source id **s** or record number **r** output, i.e., append
@@ -178,8 +178,8 @@ Optional Arguments
 
 .. |Add_nodereg| replace::
     Each block is the locus of points nearest the grid value location. Consider an example with
-    **-R**\ 10/15/10/15 and **-I**\ 1: With the |SYN_OPT-r| option, 10 <=
-    (*x*,\ *y*) < 11 is one of 25 blocks; without it 9.5 <= (*x*,\ *y*)
+    **-R**\ 10/15/10/15 and **-I**\ 1: With **-r** or **-rp**, 10 <=
+    (*x*,\ *y*) < 11 is one of 25 blocks; otherwise 9.5 <= (*x*,\ *y*)
     < 10.5 is one of 36 blocks.
 .. include:: explain_nodereg.rst_
 

--- a/doc/rst/source/contour.rst
+++ b/doc/rst/source/contour.rst
@@ -15,7 +15,7 @@ Synopsis
 
 **gmt contour** [ *table* ] |-J|\ *parameters*
 |SYN_OPT-Rz|
-[ |-A|\ [**-**\|\ *contours*][*labelinfo*] ]
+[ |-A|\ [**n**\|\ *contours*][*labelinfo*] ]
 [ |SYN_OPT-B| ]
 [ |-C|\ *contours* ]
 [ |-D|\ [*template*] ] [ |-E|\ *indexfile* ]

--- a/doc/rst/source/contour_common.rst_
+++ b/doc/rst/source/contour_common.rst_
@@ -38,10 +38,10 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ [**-**\|\ *contours*][*labelinfo*]
+**-A**\ [**n**\|\ *contours*][*labelinfo*]
     *contours* is annotation interval in data units; it is ignored if
-    contour levels are given in a file vua **-C**. [Default is no annotations]. Prepend
-    **-** to disable all annotations implied by **-C**. To just select a few specific
+    contour levels are given in a file via **-C**. [Default is no annotations]. Prepend
+    **n** to disable all annotations implied by **-C**. To just select a few specific
     contours give them as a comma-separated string; if only a single contour please add
     a trailing comma so it is seen as a list and not a contour interval. The optional
     *labelinfo* controls the specifics of the label formatting and consists
@@ -62,7 +62,7 @@ Optional Arguments
         file, it is assumed to be a CPT. The color
         boundaries are then used as contour levels. If the CPT has
         annotation flags in the last column then those contours will be
-        annotated. By default all contours are labeled; use **-A-** to
+        annotated. By default all contours are labeled; use **-An** to
         disable all annotations.
 
     (2) If *contours* is a file but not a CPT, it is expected to

--- a/doc/rst/source/gmtconvert.rst
+++ b/doc/rst/source/gmtconvert.rst
@@ -26,7 +26,6 @@ Synopsis
 [ |-T|\ [**h**\|\ **d**] ]
 [ |SYN_OPT-V| ]
 [ |-W|\ [**+n**] ]
-[ |-Z|\ [*first*][/\ *last*] ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
@@ -214,11 +213,6 @@ Optional Arguments
     (because they are not numbers) will appear as NaNs.  Use modifier **+n** to
     exclude the columns with NaNs.  Note: These columns are identified based on
     the first input record only.
-
-**-Z**\ [*first*][/\ *last*]
-    Limit output to the specified record range.  If *first* is not set it defaults
-    to record 0 (very first record) and if *last* is not set then it defaults to the
-    very last record.  Only records in the given range will be written out [all].
 
 .. include:: explain_-aspatial.rst_
 

--- a/doc/rst/source/grdcontour-classic.rst
+++ b/doc/rst/source/grdcontour-classic.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt grdcontour** *grid*
 |-J|\ *parameters*
-[ |-A|\ [**-**\ *contours*][*labelinfo*] ]
+[ |-A|\ [**n**\ *contours*][*labelinfo*] ]
 [ |SYN_OPT-B| ]
 [ |-C|\ *contours* ]
 [ |-D|\ *template* ]

--- a/doc/rst/source/grdcontour.rst
+++ b/doc/rst/source/grdcontour.rst
@@ -13,7 +13,7 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt grdcontour** *grid*
-|-J|\ *parameters* [ |-A|\ [**-**\|\ *contours*][*labelinfo*] ]
+|-J|\ *parameters* [ |-A|\ [**n**\|\ *contours*][*labelinfo*] ]
 [ |SYN_OPT-B| ]
 [ |-C|\ *contours*\|\ *cpt* ]
 [ |-D|\ *template* ]

--- a/doc/rst/source/grdcontour_common.rst_
+++ b/doc/rst/source/grdcontour_common.rst_
@@ -24,10 +24,10 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ [**-**]\|\ [*contours*][*labelinfo*]
+**-A**\ [**n**]\|\ [*contours*][*labelinfo*]
     *contours* is annotation interval in data units; it is ignored if
     contour levels are given in a file via **-C**. [Default is no annotations]. Prepend
-    **-** to disable all annotations implied by **-C**. To just select a few specific
+    **n** to disable all annotations implied by **-C**. To just select a few specific
     contours give them as a comma-separated string; if only a single contour please add
     a trailing comma so it is seen as a list and not a contour interval. The optional
     *labelinfo* controls the specifics of the label formatting and consists
@@ -48,7 +48,7 @@ Optional Arguments
         file, it is assumed to be a CPT. The color
         boundaries are then used as contour levels. If the CPT has
         annotation flags in the last column then those contours will be
-        annotated. By default all contours are labeled; use **-A-** to
+        annotated. By default all contours are labeled; use **-An** to
         disable all annotations.
 
     (2) If *contours* is a file but not a CPT, it is expected to

--- a/doc/rst/source/grdgdal.rst
+++ b/doc/rst/source/grdgdal.rst
@@ -51,9 +51,9 @@ Required Arguments
 .. _-A:
 
 **-A**\ *prog*\ [**+m**\ *method*\ **+c**\ *cpt*]
-    Select which GDAL program to run (currently one of *info*, *dem*, *grid*, *rasterize*, *translate or *warp*)
-    When program is *dem* append **+m**\ *method* (pick one of *hillshade*, *color-relief*, *slope*, *TRI*, *TPI*
-    or *roughness*) and, for *color-relief*, need also to specify a colormap with **+c**\ *cpt_name*.
+    Select which GDAL program to run (currently one of *info*, *dem*, *grid*, *rasterize*, *translate* or *warp*).
+    When program is *dem* then please append **+m**\ *method* (pick one of *hillshade*, *color-relief*, *slope*, *TRI*, *TPI*
+    or *roughness*) and, for *color-relief*, you also need to specify a colormap with **+c**\ *cpt_name*.
 
 .. _-G:
 
@@ -72,7 +72,7 @@ Optional Arguments
 
 **-M**\ [**+r+w**]
     Read and write files via GDAL. **-M** alone selects both reading and writing with GDAL.
-    Whilst **-M+r** alone instructs the program to read with GDAL (and save with GMT). This option is needed when reading
+    Option **-M+r** alone instructs the program to read with GDAL (and save with GMT). This option is needed when reading
     OGR vector data. **-M+w** indicates that the output will be saved with GDAL.
 
 .. _-R:
@@ -88,7 +88,7 @@ Optional Arguments
 ..  include:: explain_-V.rst_
 
 .. |Add_-bi| replace:: [Default is 3]. This option
-    only applies to xyz input via GMT
+    only applies to xyz input via GMT.
 .. include:: explain_-bi.rst_
 
 .. |Add_-d| unicode:: 0x20 .. just an invisible code

--- a/src/gmtconvert.c
+++ b/src/gmtconvert.c
@@ -101,7 +101,7 @@ struct GMTCONVERT_CTRL {
 		bool active;
 		unsigned int mode;
 	} W;
-	struct Z {	/* -Z[<first>]:[<last>] */
+	struct Z {	/* -Z[<first>]:[<last>] [DEPRECATED - use -q instead]*/
 		bool active;
 		int64_t first, last;
 	} Z;
@@ -131,7 +131,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] [-A] [-C[+l<min>][+u<max>][+i]] [-D[<template>[+o<orig>]]] [-E[f|l|m|M<stride>]] [-F<arg>] [-I[tsr]]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-L] [-N<col>[+a|d]] [-Q[~]<selection>] [-S[~]\"search string\"] [-T[hd]] [%s] [-W[+n]] [-Z[<first>][/<last>]] [%s]\n\t[%s] [%s] [%s] [%s] [%s]\n", GMT_V_OPT, GMT_a_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-L] [-N<col>[+a|d]] [-Q[~]<selection>] [-S[~]\"search string\"] [-T[hd]] [%s] [-W[+n]] [%s]\n\t[%s] [%s] [%s] [%s] [%s]\n", GMT_V_OPT, GMT_a_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s]\n\t[%s] [%s] [%s] [%s] [%s]\n\n", GMT_h_OPT, GMT_i_OPT, GMT_o_OPT, GMT_q_OPT, GMT_s_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -183,7 +183,6 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   d: Prevent the writing of duplicate data records.\n");
 	GMT_Option (API, "V");
 	GMT_Message (API, GMT_TIME_NONE, "\t-W Convert trailing text to numbers, if possible.  Append +n to suppress NaN columns.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-Z Select range of output records.  If not set, <first> = 0 and <last> = last record [all records].\n");
 	GMT_Option (API, "a,bi,bo,d,e,f,g,h,i,o,q,s,:,.");
 
 	return (GMT_MODULE_USAGE);
@@ -341,6 +340,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMTCONVERT_CTRL *Ctrl, struct 
 				break;
 			case 'Z':
 				Ctrl->Z.active = true;
+				GMT_Report (API, GMT_MSG_COMPAT, "Option -Z is deprecated (but still works); Use common option -q instead\n");
 				if ((c = strchr (opt->arg, ':')) || (c = strchr (opt->arg, '/'))) {	/* Got [<first>]:[<last>] or [<first>]/[<last>] */
 					char div = c[0];	/* Either : or / */
 					if (opt->arg[0] == div) /* No first given, default to 0 */
@@ -410,6 +410,8 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMTCONVERT_CTRL *Ctrl, struct 
 	                                 "Only one of -Q and -S can be used simultaneously\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->N.active && Ctrl->F.active,
 	                                 "The -N option cannot be used with -F\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active && GMT->common.q.active[GMT_OUT],
+	                                 "The deprecated -Z option cannot be used with -qo\n");
 	n_errors += gmt_M_check_condition (GMT, n_files > 1, "Only one output destination can be specified\n");
 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -42,7 +42,7 @@ struct GRDCONTOUR_CTRL {
 		char *file;
 	} In;
 	struct GMT_CONTOUR contour;
-	struct GRDCONTOUR_A {	/* -A[-][labelinfo] */
+	struct GRDCONTOUR_A {	/* -A[n|[+]<int>][labelinfo] */
 		bool active;
 		char *file;
 		unsigned int mode;	/* 1 turns off all labels */
@@ -182,7 +182,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s <grid> [-A[-|[+]<int>|<list>][<labelinfo>] [%s] [-C<contours>] [%s]\n", name, GMT_B_OPT, GMT_J_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s <grid> [-A[n|[+]<int>|<list>][<labelinfo>] [%s] [-C<contours>] [%s]\n", name, GMT_B_OPT, GMT_J_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-D<template>] [-F[l|r]] [%s] %s[-L<low>/<high>|n|N|P|p]\n", GMT_CONTG, API->K_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-N[<cpt>]] %s%s[-Q[<cut>][+z]] [%s]\n", API->O_OPT, API->P_OPT, GMT_Rgeoz_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-S<smooth>] [%s]\n", GMT_CONTT);
@@ -198,7 +198,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-A Annotation label settings [Default is no annotated contours].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Give annotation interval or comma-separated list of contours.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Alternatively, give - to disable all contour annotations\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Alternatively, give -An to disable all contour annotations\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     implied by the information provided in -C.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Alternatively prepend + to annotation interval to plot that as a single contour.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   <labelinfo> controls the specifics of the labels.  Choose from:\n");
@@ -373,13 +373,13 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDCONTOUR_CTRL *Ctrl, struct 
 			case 'A':	/* Annotation control */
 				Ctrl->A.active = true;
 				if (gmt_contlabel_specs (GMT, opt->arg, &Ctrl->contour)) {
-					GMT_Report (API, GMT_MSG_ERROR, "Option -A: Expected\n\t-A[-|[+]<aint>][+a<angle>|n|p[u|d]][+c<dx>[/<dy>]][+d][+e][+f<font>][+g<fill>][+j<just>][+l<label>][+n|N<dx>[/<dy>]][+o][+p<pen>][+r<min_rc>][+t[<file>]][+u<unit>][+v][+w<width>][+=<prefix>]\n");
+					GMT_Report (API, GMT_MSG_ERROR, "Option -A: Expected\n\t-A[n|[+]<aint>][+a<angle>|n|p[u|d]][+c<dx>[/<dy>]][+d][+e][+f<font>][+g<fill>][+j<just>][+l<label>][+n|N<dx>[/<dy>]][+o][+p<pen>][+r<min_rc>][+t[<file>]][+u<unit>][+v][+w<width>][+=<prefix>]\n");
 					n_errors ++;
 				}
 				c = NULL;
 				if (opt->arg[0] != '+') c = strchr (opt->arg, '+');	/* Find start of modifiers */
 				if (c) c[0] = '\0';	/* Chop off modifiers since parsed by gmt_contlabel_specs */
-				if (opt->arg[0] == '-')
+				if (opt->arg[0] == 'n' || opt->arg[0] == '-')	/* -A- is deprecated */
 					Ctrl->A.mode = 1;	/* Turn off all labels */
 				else if (opt->arg[0] == '+' && (isdigit(opt->arg[1]) || strchr ("-+.", opt->arg[1]))) {
 					Ctrl->A.single_cont = atof (&opt->arg[1]);

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -36,7 +36,7 @@
 
 struct PSCONTOUR_CTRL {
 	struct GMT_CONTOUR contour;
-	struct PSCONT_A {	/* -A[-][labelinfo] */
+	struct PSCONT_A {	/* -A[n|<int>][labelinfo] */
 		bool active;
 		char *file;
 		unsigned int mode;	/* 1 turns off all labels */
@@ -397,7 +397,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s <table> %s %s\n", name, GMT_J_OPT, GMT_Rgeoz_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-A[-|<contours>][<labelinfo>] [%s] [-C<contours>] [-D<template>]\n", GMT_B_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-A[n|<contours>][<labelinfo>] [%s] [-C<contours>] [-D<template>]\n", GMT_B_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-E<indextable>] [%s] [-I] %s[-L<pen>] [-N]\n", GMT_CONTG, API->K_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t%s%s[-Q[<cut>][+z]] [-S[p|t]] [%s]\n", API->O_OPT, API->P_OPT, GMT_CONTT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-W[a|c]<pen>[+c[l|f]]] [%s] [%s]\n", GMT_U_OPT, GMT_V_OPT, GMT_X_OPT);
@@ -411,7 +411,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Option (API, "<");
 	GMT_Message (API, GMT_TIME_NONE, "\t-A Annotation label information. [Default is no annotated contours].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Give annotation interval or comma-separated list of contours.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Alternatively, give - to disable all contour annotations\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Alternatively, give -An to disable all contour annotations\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     implied by the information provided in -C.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   <labelinfo> controls the specifics of the labels.  Choose from:\n");
 	gmt_label_syntax (API->GMT, 5, 0);
@@ -543,13 +543,13 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCONTOUR_CTRL *Ctrl, struct G
 			case 'A':	/* Annotation control */
 				Ctrl->A.active = true;
 				if (gmt_contlabel_specs (GMT, opt->arg, &Ctrl->contour)) {
-					GMT_Report (API, GMT_MSG_ERROR, "Option -A: Expected\n\t-A[-|<aint>][+a<angle>|n|p[u|d]][+c<dx>[/<dy>]][+d][+e][+f<font>][+g<fill>][+j<just>][+l<label>][+n|N<dx>[/<dy>]][+o][+p<pen>][+r<min_rc>][+t[<file>]][+u<unit>][+v][+w<width>][+=<prefix>]\n");
+					GMT_Report (API, GMT_MSG_ERROR, "Option -A: Expected\n\t-A[n|<aint>][+a<angle>|n|p[u|d]][+c<dx>[/<dy>]][+d][+e][+f<font>][+g<fill>][+j<just>][+l<label>][+n|N<dx>[/<dy>]][+o][+p<pen>][+r<min_rc>][+t[<file>]][+u<unit>][+v][+w<width>][+=<prefix>]\n");
 					n_errors ++;
 				}
 				c = NULL;
 				if (opt->arg[0] != '+') c = strchr (opt->arg, '+');	/* Find start of modifiers */
 				if (c) c[0] = '\0';	/* Chop off modifiers since parsed by gmt_contlabel_specs */
-				if (opt->arg[0] == '-')
+				if (opt->arg[0] == 'n' || opt->arg[0] == '-')	/* -A- is deprecated */
 					Ctrl->A.mode = 1;	/* Turn off all labels */
 				else if (opt->arg[0] == '+' && (isdigit(opt->arg[1]) || strchr ("-+.", opt->arg[1]))) {
 					Ctrl->A.single_cont = atof (&opt->arg[1]);

--- a/test/grdcontour/colorwithtitle.sh
+++ b/test/grdcontour/colorwithtitle.sh
@@ -2,4 +2,4 @@
 # Address issue #1231
 ps=colorwithtitle.ps
 gmt makecpt -Cgeo -T-2000/2000/200 > col.cpt
-gmt grdcontour -P -Bafg -BWesN+t"Title problem" @earth_relief_15m -JM6i -RIS -Ccol.cpt -N -A- -Xc > $ps
+gmt grdcontour -P -Bafg -BWesN+t"Title problem" @earth_relief_15m -JM6i -RIS -Ccol.cpt -N -An -Xc > $ps

--- a/test/grdcontour/polcont.sh
+++ b/test/grdcontour/polcont.sh
@@ -4,4 +4,4 @@
 ps=polcont.ps
 gmt grd2xyz -s @test.dat.nc > t.txt
 gmt psxy -R@test.dat.nc -JP6i t.txt -Sc0.05c -By30 -Bx30 -BWSnE -C@test.dat.cpt -K -P > $ps
-gmt grdcontour @test.dat.nc -J -C@test.dat.cpt -A- -W1p+cl -By30 -Bx30 -BWSnE -O -Y4i >> $ps
+gmt grdcontour @test.dat.nc -J -C@test.dat.cpt -An -W1p+cl -By30 -Bx30 -BWSnE -O -Y4i >> $ps

--- a/test/grdcontour/polcontr.sh
+++ b/test/grdcontour/polcontr.sh
@@ -3,4 +3,4 @@
 ps=polcontr.ps
 gmt grd2xyz -s @test.dat.nc > t.txt
 gmt psxy -R@test.dat.nc -JP6i+fe t.txt -Sc0.05c -By30 -Bx30 -BWSnE -C@test.dat.cpt -K -P > $ps
-gmt grdcontour @test.dat.nc -J -C@test.dat.cpt -A- -W1p+cl -By30 -Bx30 -BWSnE -O -Y4i >> $ps
+gmt grdcontour @test.dat.nc -J -C@test.dat.cpt -An -W1p+cl -By30 -Bx30 -BWSnE -O -Y4i >> $ps

--- a/test/grdcontour/saddle.sh
+++ b/test/grdcontour/saddle.sh
@@ -106,6 +106,6 @@ gmt xyz2grd -Z -R36/45/50/59 -I1 -Gtmp.nc <<EOF
 12617.8066406
 EOF
 gmt makecpt -Cblack,red -T8000/10000 -N > tmp.cpt
-gmt grdcontour -Ctmp.cpt -A- -R -JX4i tmp.nc -W+c -B1g1 -B+t"Direct contour" -K > $ps
-gmt grdcontour -Ctmp.cpt -A- -R -JX4i tmp.nc -D | gmt psxy -O -X5i -J -R -B1g1 -B+t"Via -D then psxy" -Ctmp.cpt >> $ps
+gmt grdcontour -Ctmp.cpt -An -R -JX4i tmp.nc -W+c -B1g1 -B+t"Direct contour" -K > $ps
+gmt grdcontour -Ctmp.cpt -An -R -JX4i tmp.nc -D | gmt psxy -O -X5i -J -R -B1g1 -B+t"Via -D then psxy" -Ctmp.cpt >> $ps
 

--- a/test/grdview/icelandbox.sh
+++ b/test/grdview/icelandbox.sh
@@ -83,7 +83,7 @@ EOF
 ### Start plotting gmt surface
 gmt grdimage @D3-25TV24-resid.nc -E100 -nl -p -R -J -JZ -C$cpt -O -K >> $ps
 
-gmt grdcontour --PS_COMMENTS=1 @D3-25TV24-resid.nc -p -R -J -JZ -Wthinner -A- -C$cpt -W -K -O >> $ps
+gmt grdcontour --PS_COMMENTS=1 @D3-25TV24-resid.nc -p -R -J -JZ -Wthinner -An -C$cpt -W -K -O >> $ps
 
 gmt pscoast -p -R -J -JZ -Dh -A100 -Wthinnest -S135/190/240 -O -K >> $ps
 gmt psclip -C -O >> $ps


### PR DESCRIPTION
**Description of proposed changes**

Mostly minor documentation fixes.  However the pscontour and grdcontour **-A-** option to turn off annotation is not so good going forward.  I have implemented **-An** for none but this is backwards compatible so **-A-** will still work but documentation has changed.
For gmtconvert the **-Z** option is deprecated since **-q** was added.  IT is still there fore backwards compatibility but the documentation only uses **-q**.
