### PR TITLE
Shut up some warnings

### DIFF
--- a/src/gmt_gdal_librarified.c
+++ b/src/gmt_gdal_librarified.c
@@ -178,7 +178,7 @@ GMT_LOCAL int save_grid_with_GMT(struct GMT_CTRL *GMT, GDALDatasetH hDstDS, stru
 	nXSize = GDALGetRasterXSize(hDstDS);
 	nYSize = GDALGetRasterYSize(hDstDS);
 
-	if (nXSize != Grid->header->n_columns || nYSize != Grid->header->n_rows) {
+	if (nXSize != (int)Grid->header->n_columns || nYSize != (int)Grid->header->n_rows) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Programming error. Output grid dimensions not what is expected.\n");
 		return -1;
 	}


### PR DESCRIPTION
The GDAL function uses int and we use unsigned int, hence the cast.