### PR TITLE
Wipe text strings holding virtual file names

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -6196,6 +6196,7 @@ GMT_LOCAL int api_encode_id (struct GMTAPI_CTRL *API, unsigned int module_input,
 	if (!(messenger == 0 || messenger == 1)) return_error (API, GMT_RUNTIME_ERROR);
 	if (module_input) module_input = 1;	/* It may be GMT_VIA_MODULE_INPUT but here we want just 0 or 1 */
 
+	gmt_M_memset (filename, GMT_VF_LEN, char);	/* Wipe any trace of previous text */
 	sprintf (filename, "@GMTAPI@-%c-%c-%s-%s-%c-%c-%06d", (module_input) ? 'P' : 'S', (direction == GMT_IN) ? 'I' : 'O', GMT_family_abbrev[family], GMT_family_abbrev[actual_family], api_debug_geometry_code (geometry), (messenger) ? 'Y' : 'N', object_ID);
 	GMT_Report (API, GMT_MSG_DEBUG, "VirtualFile name created: %s\n", filename);
 	


### PR DESCRIPTION
We don't know where those strings have been so now **api_encode_id** will first wipe the string clean (first 32 bytes) before printing the name.
