### PR TITLE
Adjust Mercator projection origin to (lon0, lat0)

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -874,9 +874,6 @@ GMT_LOCAL int gmtinit_rectR_to_geoR (struct GMT_CTRL *GMT, char unit, double rec
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "UTM projection insufficiently specified to auto-determine geographic region\n");
 				return (GMT_MAP_NO_PROJECTION);
 			}
-			else {
-				wesn[YLO] = -1.0;	wesn[YHI] = 1.0;
-			}
 			break;
 		case 2: /* Conical: Use default patch */
 			break;

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -2877,6 +2877,7 @@ GMT_LOCAL bool map_init_merc (struct GMT_CTRL *GMT) {
 	map_cyl_validate_clon (GMT, 0);	/* Make sure the central longitude is valid */
 	gmt_vmerc (GMT, GMT->current.proj.pars[0], GMT->current.proj.pars[1]);
 	GMT->current.proj.j_x *= D;
+	GMT->current.proj.j_yc *= D;
 	GMT->current.proj.j_ix /= D;
 	GMT->current.proj.fwd = &gmt_merc_sph;
 	GMT->current.proj.inv = &gmt_imerc_sph;

--- a/src/gmt_proj.c
+++ b/src/gmt_proj.c
@@ -653,11 +653,14 @@ void gmt_ipolar (struct GMT_CTRL *GMT, double *x, double *y, double x_i, double 
 /* -JM MERCATOR PROJECTION */
 
 void gmt_vmerc (struct GMT_CTRL *GMT, double lon0, double slat) {
-	/* Set up a Mercator transformation */
+	/* Set up a Mercator transformation with origin at (lon0, lat0) */
+
+	if (GMT->current.proj.GMT_convert_latitudes) slat = gmt_M_latg_to_latc (GMT, slat);
 
 	GMT->current.proj.central_meridian = lon0;
 	GMT->current.proj.j_x = cosd (slat) / d_sqrt (1.0 - GMT->current.proj.ECC2 * sind (slat) * sind (slat)) * GMT->current.proj.EQ_RAD;
 	GMT->current.proj.j_ix = 1.0 / GMT->current.proj.j_x;
+	GMT->current.proj.j_yc = (fabs (slat) > 0.0) ? GMT->current.proj.j_x * d_log (GMT, tand (45.0 + 0.5 * slat)) : 0.0;
 }
 
 /* Mercator projection for the sphere */
@@ -669,14 +672,14 @@ void gmt_merc_sph (struct GMT_CTRL *GMT, double lon, double lat, double *x, doub
 	if (GMT->current.proj.GMT_convert_latitudes) lat = gmt_M_latg_to_latc (GMT, lat);
 
 	*x = GMT->current.proj.j_x * D2R * lon;
-	*y = (fabs (lat) < 90.0) ? GMT->current.proj.j_x * d_log (GMT, tand (45.0 + 0.5 * lat)) : copysign (DBL_MAX, lat);
+	*y = (fabs (lat) < 90.0) ? GMT->current.proj.j_x * d_log (GMT, tand (45.0 + 0.5 * lat)) - GMT->current.proj.j_yc : copysign (DBL_MAX, lat);
 }
 
 void gmt_imerc_sph (struct GMT_CTRL *GMT, double *lon, double *lat, double x, double y) {
 	/* Convert Mercator x/y to lon/lat  (GMT->current.proj.EQ_RAD in GMT->current.proj.j_ix) */
 
 	*lon = x * GMT->current.proj.j_ix * R2D + GMT->current.proj.central_meridian;
-	*lat = atand (sinh (y * GMT->current.proj.j_ix));
+	*lat = atand (sinh ((y + GMT->current.proj.j_yc) * GMT->current.proj.j_ix));
 	if (GMT->current.proj.GMT_convert_latitudes) *lat = gmt_M_latc_to_latg (GMT, *lat);
 }
 

--- a/src/gmt_project.h
+++ b/src/gmt_project.h
@@ -378,7 +378,7 @@ struct GMT_PROJ {
 
 	/* All Cylindrical Projections */
 
-	double j_x, j_y, j_ix, j_iy;
+	double j_x, j_y, j_ix, j_iy, j_yc;
 
 	/* Albers Equal-area conic parameters. */
 


### PR DESCRIPTION
The x-cordinates out of the Mercator projection are relative to lon0 but the y-coordinates were always relative to Equator and not lat0.  This caused troubles when relative shifts from an origin was given, such as in #2287.  This PR addresses this issue by keeping _j_yc_, the y-coordinate of the standard parallel and using that to ensure the origin has coordinates (0,0).  Closes #2287.
