### PR TITLE
cmake: Document SUPP_DLL_RENAME

### DIFF
--- a/cmake/ConfigUserAdvancedTemplate.cmake
+++ b/cmake/ConfigUserAdvancedTemplate.cmake
@@ -273,6 +273,7 @@
 # endif ()
 # set (GMT_DLL_RENAME gmt_w${BITAGE})
 # set (PSL_DLL_RENAME psl_w${BITAGE})
+# set (SUPP_DLL_RENAME supplements_w${BITAGE})
 #endif(WIN32)
 
 # On Windows Visual C 2012 needs _ALLOW_KEYWORD_MACROS to build


### PR DESCRIPTION
Windows users may want to name their DLL filenames differently for x86 and x64.
**GMT_DLL_RENAME** and **PSL_DLL_RENAME** can do that, but
**SUPP_DLL_RENAME** is not documented.