### PR TITLE
Add version checks in build-release.sh

### DIFF
--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Script that builds a GMT release and makes the compressed tarballs.
 # If run under macOS it also builds the macOS Bundle
+# Requirements in addition to libraries and tools to build GMT:
+#	1) pngquant for squeezing PNG files down in size
+#	2) GMT_GSHHG_SOURCE and GMT_DCW_SOURCE enviromental parameters set
+#	3) A ghostscript version we can include in the macOS bundle [MacPort]
+
 reset_config() {
 	rm -f ${TOPDIR}/cmake/ConfigUser.cmake
 	if [ -f ${TOPDIR}/cmake/ConfigUser.cmake.orig ]; then # Restore what we had
@@ -18,36 +23,45 @@ abort_build() {	# Called when we abort this script via Crtl-C
 TOPDIR=$(pwd)
 
 if [ $# -gt 0 ]; then
-	echo "Usage: build-release.sh"
-	echo ""
-	echo "build-release.sh must be run from top-level gmt directory."
-	echo "Will create the release compressed tarballs and (under macOS) the bundle."
-	echo "Requires you have set GMT_PACKAGE_VERSION_* and GMT_PUBLIC_RELEASE in cmake/ConfigDefaults.cmake."
-	echo "Requires GMT_GSHHG_SOURCE and GMT_DCW_SOURCE to be set in the environment."
+	cat <<- EOF  >&2
+	Usage: build-release.sh
+	
+	build-release.sh must be run from top-level gmt directory.
+	Will create the release compressed tarballs and (under macOS) the bundle.
+	Requires you have set GMT_PACKAGE_VERSION_* and GMT_PUBLIC_RELEASE in cmake/ConfigDefaults.cmake.
+	Requires GMT_GSHHG_SOURCE and GMT_DCW_SOURCE to be set in the environment.
+	EOF
 	exit 1
 fi
 if [ ! -d cmake ]; then
-	echo "Must be run from top-level gmt directory"
+	echo "build-release.sh: Must be run from top-level gmt directory" >&2
 	exit 1
 fi
 
 # pngquant is need to optimize images
 if ! [ -x "$(command -v gmt)" ]; then
-	echo 'Error: pngquant is not found in your search PATH.' >&2
+	echo 'build-release.sh: Error: pngquant is not found in your search PATH.' >&2
 	exit 1
 fi
 
 # 0. Make sure GMT_GSHHG_SOURCE and GMT_DCW_SOURCE are set in the environment
 if [ "X${GMT_GSHHG_SOURCE}" = "X" ]; then
-	echo "Need to setenv GMT_GSHHG_SOURCE to point to directory with GSHHG files"
+	echo "build-release.sh: Need to setenv GMT_GSHHG_SOURCE to point to directory with GSHHG files" >&2
 	exit 1
 fi
 if [ "X${GMT_DCW_SOURCE}" = "X" ]; then
-	echo "Need to setenv GMT_DCW_SOURCE to point to directory with DCW files"
+	echo "build-release.sh: Need to setenv GMT_DCW_SOURCE to point to directory with DCW files" >&2
 	exit 1
 fi
 
-echo "build-release.sh: Remember to run admin/gs-check.sh to test latest GhostScript (must be installed)"
+S_ver=$(sphinx-build --version | awk '{print substr($2,1,1)}')
+if [ $S_ver -ne 1 ]; then
+	echo "build-release.sh: Need Sphinx version 1 to build release" >&2
+	exit 1
+fi
+G_ver=$(gs --version)
+echo "build-release.sh: You will be including Ghostscript version $G_ver"
+echo "build-release.sh: Remember to run admin/gs-check.sh to ensure it passes our test" >&2
 
 # 1. Set basic ConfigUser.cmake file for a release build
 if [ -f cmake/ConfigUser.cmake ]; then
@@ -61,7 +75,7 @@ mkdir build
 # 2b. Build list of external programs and shared libraries
 admin/build-macos-external-list.sh > build/add_macOS_cpack.txt
 cd build
-echo "build-release.sh: Configure and build tarballs"
+echo "build-release.sh: Configure and build tarballs" >&2
 cmake -G Ninja ..
 # 3. Build the release and the tarballs
 cmake --build . --target gmt_release
@@ -73,18 +87,18 @@ rm -f gmt-${Version}-src.tar
 # 6. Install executables before building macOS Bundle
 cmake --build . --target install
 if [ $(uname) = "Darwin" ]; then
-	echo "build-release.sh: Build macOS bundle"
+	echo "build-release.sh: Build macOS bundle" >&2
 	# 7. Build the macOS Bundle
 	cpack -G Bundle
 fi
 # 8. Report sha256 hash
-echo "build-release.sh: Report sha256sum per file"
+echo "build-release.sh: Report sha256sum per file" >&2
 shasum -a 256 gmt-${Version}-*
 # 9. Replace temporary ConfigReleaseBuild.cmake file with the original file
 reset_config
 # 10. Put the candidate products on my ftp site
-echo "Place gmt-${Version}-src.tar.* on the ftp site"
+echo "build-release.sh: Place gmt-${Version}-src.tar.* on the ftp site" >&2
 if [ -f gmt-${Version}-darwin-x86_64.dmg ]; then
-	echo "Place gmt-${Version}-darwin-x86_64.dmg on the ftp site"
+	echo "build-release.sh: Place gmt-${Version}-darwin-x86_64.dmg on the ftp site" >&2
 fi
 #scp gmt-${Version}-darwin-x86_64.dmg gmt-${Version}-src.tar.* ftp:/export/ftp1/ftp/pub/pwessel/release


### PR DESCRIPTION
Check if **sphinx-build** is version 1 (required for now) and remind us of testing **Ghostscript** before packing.  Write all messages to _stderr_.
