### PR TITLE
doc: Fix CSS style for Sphinx 2.x

### DIFF
--- a/doc/rst/_static/style.css
+++ b/doc/rst/_static/style.css
@@ -9,8 +9,20 @@
 }
 
 /* See https://github.com/GenericMappingTools/gmt/pull/1605 */
-.rst-content dl dt {
+/* For Sphinx 1.x only */
+.rst-content dl.docutils dt {
     font-weight: normal;
+}
+
+/* Override the default style for definition list to
+   make sphinx_rtd_theme compatible with Sphinx 2.x */
+.rst-content dl:not(.docutils) dt {
+    all: inherit;
+    margin-bottom: 12px;
+}
+.rst-content dl:not(.docutils) dl dt {
+    all: inherit;
+    margin-bottom: 6px;
 }
 
 /* https://github.com/readthedocs/sphinx_rtd_theme/pull/775 */


### PR DESCRIPTION
Our current theme sphinx_rtd_theme v0.4.3 doesn't work well with Sphinx 2.x, especially for the option lists.

This is what we see with Sphinx 1.x:
![image](https://user-images.githubusercontent.com/3974108/76718003-c247ad80-670b-11ea-8ee6-acf1106a7eaf.png)

This is what we see with Sphinx 2.x:
![image](https://user-images.githubusercontent.com/3974108/76718036-d095c980-670b-11ea-81f6-dc90d809871f.png)

We definitely want the style from Sphinx 1.x. These are known bugs of the sphinx_rtd_theme theme. Before they fix the bugs and make a new release, this PR provides a workaround, which works for both Sphinx 1.x and 2.x.

@PaulWessel you may try this PR locally with Sphinx 2.x.