### PR TITLE
30 arc sec filter is now 1.0 km, not 0.9 km

### DIFF
--- a/doc/rst/source/datasets/earth-relief.rst
+++ b/doc/rst/source/datasets/earth-relief.rst
@@ -44,7 +44,7 @@ Code Dimensions        Size     Description
 03m      7201 x   3601   27 MB  3 arc minute global relief (SRTM15+V2.1 @ 5.6 km)
 02m     10801 x   5401   58 MB  2 arc minute global relief (SRTM15+V2.1 @ 3.7 km)
 01m     21601 x  10801  214 MB  1 arc minute global relief (SRTM15+V2.1 @ 1.9 km)
-30s     43201 x  21601  765 MB  30 arc second global relief (SRTM15+V2.1 @ 0.9 km)
+30s     43201 x  21601  765 MB  30 arc second global relief (SRTM15+V2.1 @ 1.0 km)
 15s     86400 x  43200  2.6 GB  15 arc second global relief (SRTM15+V2.1)
 03s    432001 x 216001  6.8 GB  3 arc second global relief (SRTM3S)
 01s   1296001 x 432001   41 GB  1 arc second global relief (SRTM1S)

--- a/doc/rst/source/earth_relief.rst_
+++ b/doc/rst/source/earth_relief.rst_
@@ -13,7 +13,7 @@ Dataset            Resolution   Size                             Description
 earth_relief_01s     1 arc sec     41 Gb     1 arc second global relief (SRTM1S)
 earth_relief_03s     3 arc sec    6.8 Gb     3 arc second global relief (SRTM3S)
 earth_relief_15s    15 arc sec    2.6 Gb     15 arc second global relief (SRTM15+V2.1)
-earth_relief_30s    30 arc sec    765 Mb     30 arc second global relief (SRTM15+V2.1 @ 0.9 km)
+earth_relief_30s    30 arc sec    765 Mb     30 arc second global relief (SRTM15+V2.1 @ 1.0 km)
 earth_relief_01m     1 arc min    214 Mb     1 arc minute global relief (SRTM15+V2.1 @ 1.9 km)
 earth_relief_02m     2 arc min     58 Mb     2 arc minute global relief (SRTM15+V2.1 @ 3.7 km)
 earth_relief_03m     3 arc min     27 Mb     3 arc minute global relief (SRTM15+V2.1 @ 5.6 km)

--- a/src/gmt_remote.h
+++ b/src/gmt_remote.h
@@ -53,7 +53,7 @@ GMT_LOCAL struct GMT_DATA_INFO gmt_data_info[GMT_N_DATA_INFO_ITEMS] = {
 	{"03m",  "27M", "Earth Relief at 3x3 arc minutes obtained by Gaussian Cartesian filtering (5.6 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]"},
 	{"02m",  "58M", "Earth Relief at 2x2 arc minutes obtained by Gaussian Cartesian filtering (3.7 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]"},
 	{"01m", "214M", "Earth Relief at 1x1 arc minutes obtained by Gaussian Cartesian filtering (1.9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]"},
-	{"30s", "765M", "Earth Relief at 30x30 arc seconds obtained by Gaussian Cartesian filtering (0.9 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]"},
+	{"30s", "765M", "Earth Relief at 30x30 arc seconds obtained by Gaussian Cartesian filtering (1.0 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]"},
 	{"15s", "2.6G", "Earth Relief at 15x15 arc seconds provided by SRTM15+V2.1 [Tozer et al., 2019]"},
 	{"03s", "6.8G", "Earth Relief at 3x3 arc seconds tiles provided by SRTMGL3 (land only) [NASA/USGS]"},
 	{"01s",  "41G", "Earth Relief at 1x1 arc seconds tiles provided by SRTMGL1 (land only) [NASA/USGS]"}


### PR DESCRIPTION
0.9 was just too short and lead to NaNs at the S pole.
