### PR TITLE
Eliminate cmake variable EXTRA_MODULES for testing new modules

### DIFF
--- a/cmake/ConfigUserAdvancedTemplate.cmake
+++ b/cmake/ConfigUserAdvancedTemplate.cmake
@@ -196,9 +196,6 @@
 # that only need the GMT API, see the gmt-custom project).
 #set (EXTRA_BUILD_DIRS apidemo)
 
-# List extra new modules for testing without adding them to the module list
-#set (EXTRA_MODULES newmodule1.c newmodule2.c)
-
 # List extra new supplemental modules for testing without adding them to the module list
 #set (EXTRA_MODULES_SUPPL newsuppl1.c newsuppl2.c)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -307,7 +307,6 @@ else (NOT LICENSE_RESTRICTED) # on
 	set (GMT_TRIANGULATE "Watson" PARENT_SCOPE)
 endif (NOT LICENSE_RESTRICTED)
 
-# Note: Developers can set EXTRA_MODULES in ConfigUserAdvanced.cmake to test new modules
 set (GMT_PROGS_SRCS blockmean.c blockmedian.c blockmode.c docs.c dimfilter.c filter1d.c grd2kml.c
 	fitcircle.c gmt2kml.c gmtconvert.c gmtlogo.c gmtmath.c gmtselect.c gmtsimplify.c
 	gmtspatial.c gmtconnect.c grdgdal.c gmtregress.c gmtvector.c gmtwhich.c grd2cpt.c
@@ -320,7 +319,7 @@ set (GMT_PROGS_SRCS blockmean.c blockmedian.c blockmode.c docs.c dimfilter.c fil
 	surface.c trend1d.c trend2d.c triangulate.c xyz2grd.c gmtdefaults.c gmtget.c
 	gmtset.c grdcontour.c grdimage.c grdvector.c grdview.c psbasemap.c psclip.c
 	pscoast.c pscontour.c psevents.c pshistogram.c psimage.c psmask.c psrose.c psscale.c
-	pssolar.c psternary.c pstext.c pswiggle.c psxy.c psxyz.c pslegend.c ${EXTRA_MODULES})
+	pssolar.c psternary.c pstext.c pswiggle.c psxy.c psxyz.c pslegend.c)
 
 # Legacy modules for which to install compatibility links via
 # install_module_symlink


### PR DESCRIPTION
EXTRA_MODULES was used to add new modules temporarily for testing puropose.
The best practice is to create a new branch then work on the new module.

Thus EXTRA_MODULES is no longer needed.

Address #2917.