### PR TITLE
Fix installation of qsort header files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -683,7 +683,7 @@ if (BUILD_DEVELOPER)
 		gmt_grdio.h gmt_hash.h gmt_io.h gmt_macros.h gmt_memory.h gmt_modern.h gmt_nan.h gmt_notposix.h gmt_plot.h
 		gmt_private.h gmt_project.h gmt_prototypes.h gmt_psl.h gmt_shore.h gmt_symbol.h gmt_synopsis.h
 		gmt_texture.h gmt_time.h gmt_types.h gmt_dev.h gmt_customio.h gmt_hidden.h gmt_mb.h
-		gmt_core_module.h gmt_supplements_module.h compat/qsort.h
+		gmt_core_module.h gmt_supplements_module.h
 		DESTINATION ${GMT_INCLUDEDIR}
 		COMPONENT Runtime)
 	install (FILES compat/qsort.h


### PR DESCRIPTION
If you check the GMT installation directory, you'll see that
the header file qsort.h is installed twice.
One in `include/gmt/qsort.h` and another in `include/gmt/compat/qsort.h`.

Is it on purpose?

If not, this PR fixes the issue by installing qsort.h to `include/gmt/compat/qsort.h` only.