### PR TITLE
test: Increase GRAPHICSMAGICK_RMS to let the test pass

### DIFF
--- a/test/pscoast/oblsuite_N.sh
+++ b/test/pscoast/oblsuite_N.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Higer RMS threshold due to hairline differences in many gridlines betweent different OS
+# GRAPHICSMAGICK_RMS = 0.004
 ps=oblsuite_N.ps
 gmt pscoast -R-2000/2000/-1000/1000+uk -Joa-30/60/-180/1:60000000 -Ba0fg -P -Gred -K -X1.25i -Y9i > $ps
 gmt pscoast -R-2000/2000/-1000/1000+uk -Joa-30/60/-150/1:60000000 -Ba0fg -O -K -Gred -Y-1.7i >> $ps


### PR DESCRIPTION
test oblsuite_N.sh is failing on Windows due to tiny difference of grdlines.

The gm diff file is attached:
![oblsuite_N](https://user-images.githubusercontent.com/3974108/76898770-b6273180-686c-11ea-8160-da791bd81b09.png)