### PR TITLE
Revert "CI: Workaround to let CI jobs run for PRs"

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -11,13 +11,6 @@ trigger:
     - 5.4
     - refs/tags/*
 
-# build all PRs
-# Workdround for a bug of Azure Pipelines, see https://github.com/GenericMappingTools/gmt/issues/2913
-pr:
-  branches:
-    include:
-    - '*'  # must quote since "*" is a YAML reserved character; we want a string
-
 # Global variables
 variables:
   # disable auto-display of GMT plots


### PR DESCRIPTION
Azure Pipelines has fixed the issue. Now PR triggers are ON by default.

Reverts GenericMappingTools/gmt#2914. 

Closes #2913 