### PR TITLE
cmake: Get release name by get_file_component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ if (GIT_FOUND AND HAVE_GIT_VERSION)
 	find_program (XZ NAMES xz)
 	if (GNUTAR AND GZIP AND XZ)
 		# Targets for creating tarballs
-		string (REGEX REPLACE ".*/" "" _release_dirname "${GMT_RELEASE_PREFIX}")
+		get_filename_component (_release_name ${GMT_RELEASE_PREFIX} NAME)
 		add_custom_command (OUTPUT ${_release_dirname}-src.tar
 			COMMAND ${GNUTAR} -c --owner 0 --group 0 --mode a=rX,u=rwX --force-local
 			-f ${GMT_BINARY_DIR}/${_release_dirname}-src.tar ${_release_dirname}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ if (GIT_FOUND AND HAVE_GIT_VERSION)
 	find_program (XZ NAMES xz)
 	if (GNUTAR AND GZIP AND XZ)
 		# Targets for creating tarballs
-		get_filename_component (_release_name ${GMT_RELEASE_PREFIX} NAME)
+		get_filename_component (_release_name "${GMT_RELEASE_PREFIX}" NAME)
 		add_custom_command (OUTPUT ${_release_dirname}-src.tar
 			COMMAND ${GNUTAR} -c --owner 0 --group 0 --mode a=rX,u=rwX --force-local
 			-f ${GMT_BINARY_DIR}/${_release_dirname}-src.tar ${_release_dirname}


### PR DESCRIPTION
The cmake code get release name from variable GMT_RELEASE_PREFIX using
a string replacement function.
```
string (REGEX REPLACE ".*/" "" _release_dirname "${GMT_RELEASE_PREFIX}")
```

It's equivalent to:
```
get_filename_component (_release_name ${GMT_RELEASE_PREFIX} NAME)
```
The latter is simpler and more readable.