### PR TITLE
Let psscale rely on -B machinery for labels if possible

### DIFF
--- a/src/psscale.c
+++ b/src/psscale.c
@@ -1367,7 +1367,7 @@ GMT_LOCAL void gmt_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctr
 			gmt_M_uint_swap (GMT->current.proj.xyz_projection[GMT_X], GMT->current.proj.xyz_projection[GMT_Y]);
 			tmp = GMT->current.proj.fwd_x; GMT->current.proj.fwd_y = GMT->current.proj.fwd_x; GMT->current.proj.fwd_x = tmp;
 			GMT->current.map.frame.axis[GMT_Y].id = GMT_Y;
-			if (label[0] && !flip && (strchr (label, '@') || strchr (label, '(') || !(flip & PSSCALE_FLIP_VERT))) { /* Can let gmt_xy_axis2 set the label directly, else do separately later */
+			if (label[0] && !flip) { /* Can let gmt_xy_axis2 set the label directly, else do separately later */
 				strcpy (GMT->current.map.frame.axis[GMT_Y].label, label);
 				label_set = true;
 			}

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -634,7 +634,7 @@ GMT_LOCAL void gmt_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctr
 	unsigned int Label_justify, form, cap, join, n_xpos, nx = 0, ny = 0, nm, barmem, k, justify;
 	int this_just, p_val, center = 0;
 	bool reverse, all = true, use_image, const_width = true, do_annot, use_labels, cpt_auto_fmt = true;
-	bool B_set = GMT->current.map.frame.draw, skip_lines = Ctrl->S.active, need_image;
+	bool B_set = GMT->current.map.frame.draw, skip_lines = Ctrl->S.active, need_image, label_set = false;
 	char format[GMT_LEN256] = {""}, text[GMT_LEN256] = {""}, test[GMT_LEN256] = {""}, unit[GMT_LEN256] = {""}, label[GMT_LEN256] = {""}, endash;
 	static char *method[2] = {"polygons", "colorimage"};
 	unsigned char *bar = NULL, *tmp = NULL;
@@ -1367,6 +1367,10 @@ GMT_LOCAL void gmt_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctr
 			gmt_M_uint_swap (GMT->current.proj.xyz_projection[GMT_X], GMT->current.proj.xyz_projection[GMT_Y]);
 			tmp = GMT->current.proj.fwd_x; GMT->current.proj.fwd_y = GMT->current.proj.fwd_x; GMT->current.proj.fwd_x = tmp;
 			GMT->current.map.frame.axis[GMT_Y].id = GMT_Y;
+			if (label[0] && !flip && (strchr (label, '@') || strchr (label, '(') || !(flip & PSSCALE_FLIP_VERT))) { /* Can let gmt_xy_axis2 set the label directly, else do separately later */
+				strcpy (GMT->current.map.frame.axis[GMT_Y].label, label);
+				label_set = true;
+			}
 			for (i = 0; i < 5; i++) GMT->current.map.frame.axis[GMT_Y].item[i].parent = GMT_Y;
 			gmt_xy_axis2 (GMT, -y_base, 0.0, length, start_val, stop_val, &GMT->current.map.frame.axis[GMT_Y], flip & PSSCALE_FLIP_ANNOT, GMT->current.map.frame.side[flip & PSSCALE_FLIP_ANNOT ? W_SIDE : E_SIDE] & GMT_AXIS_ANNOT, GMT->current.map.frame.side[flip & PSSCALE_FLIP_ANNOT ? W_SIDE : E_SIDE]);
 			PSL_setorigin (PSL, 0.0, 0.0, 90.0, PSL_INV);	/* Rotate back to where we started in this branch */
@@ -1448,7 +1452,7 @@ GMT_LOCAL void gmt_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctr
 			PSL_settextmode (PSL, PSL_TXTMODE_HYPHEN);	/* Back to leave as is */
 		}
 
-		if (label[0]) {	/* Add label */
+		if (label[0] && !label_set) {	/* Add label */
 			form = gmt_setfont (GMT, &GMT->current.setting.font_label);
 			if (strchr (label, '@') || strchr (label, '(') || !(flip & PSSCALE_FLIP_VERT)) { /* Must set text along-side color bar */
 				PSL_plottext (PSL, xleft + 0.5 * length, y_label, GMT->current.setting.font_label.size, label, 0.0, Label_justify, form);

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -634,7 +634,7 @@ GMT_LOCAL void gmt_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctr
 	unsigned int Label_justify, form, cap, join, n_xpos, nx = 0, ny = 0, nm, barmem, k, justify;
 	int this_just, p_val, center = 0;
 	bool reverse, all = true, use_image, const_width = true, do_annot, use_labels, cpt_auto_fmt = true;
-	bool B_set = GMT->current.map.frame.draw, skip_lines = Ctrl->S.active, need_image, label_set = false;
+	bool B_set = GMT->current.map.frame.draw, skip_lines = Ctrl->S.active, need_image;
 	char format[GMT_LEN256] = {""}, text[GMT_LEN256] = {""}, test[GMT_LEN256] = {""}, unit[GMT_LEN256] = {""}, label[GMT_LEN256] = {""}, endash;
 	static char *method[2] = {"polygons", "colorimage"};
 	unsigned char *bar = NULL, *tmp = NULL;
@@ -1367,10 +1367,8 @@ GMT_LOCAL void gmt_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctr
 			gmt_M_uint_swap (GMT->current.proj.xyz_projection[GMT_X], GMT->current.proj.xyz_projection[GMT_Y]);
 			tmp = GMT->current.proj.fwd_x; GMT->current.proj.fwd_y = GMT->current.proj.fwd_x; GMT->current.proj.fwd_x = tmp;
 			GMT->current.map.frame.axis[GMT_Y].id = GMT_Y;
-			if (label[0] && !flip) { /* Can let gmt_xy_axis2 set the label directly, else do separately later */
+			if (label[0] && !flip) /* Can let gmt_xy_axis2 set the label directly, else do separately later */
 				strcpy (GMT->current.map.frame.axis[GMT_Y].label, label);
-				label_set = true;
-			}
 			for (i = 0; i < 5; i++) GMT->current.map.frame.axis[GMT_Y].item[i].parent = GMT_Y;
 			gmt_xy_axis2 (GMT, -y_base, 0.0, length, start_val, stop_val, &GMT->current.map.frame.axis[GMT_Y], flip & PSSCALE_FLIP_ANNOT, GMT->current.map.frame.side[flip & PSSCALE_FLIP_ANNOT ? W_SIDE : E_SIDE] & GMT_AXIS_ANNOT, GMT->current.map.frame.side[flip & PSSCALE_FLIP_ANNOT ? W_SIDE : E_SIDE]);
 			PSL_setorigin (PSL, 0.0, 0.0, 90.0, PSL_INV);	/* Rotate back to where we started in this branch */
@@ -1452,7 +1450,7 @@ GMT_LOCAL void gmt_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctr
 			PSL_settextmode (PSL, PSL_TXTMODE_HYPHEN);	/* Back to leave as is */
 		}
 
-		if (label[0] && !label_set) {	/* Add label */
+		if (label[0] && (flip || !B_set)) {	/* Add label separately */
 			form = gmt_setfont (GMT, &GMT->current.setting.font_label);
 			if (strchr (label, '@') || strchr (label, '(') || !(flip & PSSCALE_FLIP_VERT)) { /* Must set text along-side color bar */
 				PSL_plottext (PSL, xleft + 0.5 * length, y_label, GMT->current.setting.font_label.size, label, 0.0, Label_justify, form);

--- a/test/grdimage/SST.ps
+++ b/test/grdimage/SST.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.1.0_f5f2ed6-dirty_2020.01.09 [64-bit] Document from grdimage
+%%Title: GMT v6.1.0_07d3b13-dirty_2020.03.19 [64-bit] Document from grdimage
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Fri Jan 10 10:30:57 2020
+%%CreationDate: Thu Mar 19 12:12:10 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -659,7 +659,8 @@ V 0.06 0.06 scale
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_plot_completion {} def
-/PSL_movie_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
@@ -70550,10 +70551,12 @@ def
 (16) mr Z
 6120 PSL_A0_y MM
 (24) mr Z
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
+3600 PSL_L_y MM
+V 90 R (SST) bc Z U
 90 R
-3600 -624 M 267 F0
-(SST) tc Z
 -90 R
 -240 0 T
 0 setlinecap
@@ -70561,7 +70564,8 @@ def
 %%EndObject
 
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U

--- a/test/psscale/cyclecpt.ps
+++ b/test/psscale/cyclecpt.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612 792             
-%%Title: GMT v6.0.0_r19503 [64-bit] Document from psscale
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.1.0_07d3b13-dirty_2020.03.19 [64-bit] Document from psscale
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Dec 11 16:55:23 2017
+%%CreationDate: Thu Mar 19 12:12:10 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -646,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -657,14 +658,18 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
 0 A
 FQ
 O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: psscale -P -K -Ctemp_cpt.cpt -Dx3/5 -By+lm '-Bxa+lCyclic CPT with NaN and unit' -X1i
+%@GMT: gmt psscale -P -K -Ctemp_cpt.cpt -Dx3c/5c+w10c/0.618c+n -By+lm '-Bxa+lCyclic CPT with NaN and unit' -X1i
 %@PROJ: xy 0.00000000 180.00000000 0.00000000 0.24330709 0.000 180.000 0.000 0.243 +xy
 %GMTBoundingBox: 72 72 283.465 17.5181
 %%BeginObject PSL_Layer_1
@@ -709,7 +714,7 @@ U
 {0.75 A} FS
 O1
 0 292 -292 0 0 -292 3 -146 292 SP
--521 146 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-521 146 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V -90 R (NaN) tc Z U
 2 setlinecap
@@ -741,18 +746,23 @@ def
 (100) mr Z
 3937 PSL_A0_y MM
 (150) mr Z
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
+2362 PSL_L_y MM
+V 90 R (Cyclic CPT with NaN and unit) bc Z U
 90 R
-2362 -624 M 267 F0
-(Cyclic CPT with NaN and unit) tc Z
 4808 146 M 200 F0
 V -90 R (m) bc Z U
 {0 A} FS
 O0
 9 W
+/PSL_vecheadpen {0 W 0 A [] 0 B} def
 V 2362 146 T
 N 0 0 118 50 166.436 arc S
 O1
+PSL_vecheadpen
+0 W
 V
 N -16 22 118 -136.827 -216.585 arcn
 -4 -65 D
@@ -760,7 +770,10 @@ N -16 22 118 -136.827 -216.585 arcn
 P clip fs N U
 U 
 V 2362 146 T
+9 W
 N 0 0 118 230 346.436 arc S
+PSL_vecheadpen
+0 W
 V
 N 16 -22 118 43.1731 -36.5853 arcn
 4 65 D
@@ -778,7 +791,7 @@ O0
 4800 0 TM
 
 % PostScript produced by:
-%@GMT: psscale -O -K -Ctemp_cpt.cpt -Dx3/5 '-Bxa+lCyclic CPT with NaN' -X4i
+%@GMT: gmt psscale -O -K -Ctemp_cpt.cpt -Dx3c/5c+w10c/0.618c+n '-Bxa+lCyclic CPT with NaN' -X4i
 %@PROJ: xy 0.00000000 180.00000000 0.00000000 0.24330709 0.000 180.000 0.000 0.243 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -822,7 +835,7 @@ U
 {0.75 A} FS
 O1
 0 292 -292 0 0 -292 3 -146 292 SP
--521 146 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-521 146 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V -90 R (NaN) tc Z U
 2 setlinecap
@@ -854,16 +867,21 @@ def
 (100) mr Z
 3937 PSL_A0_y MM
 (150) mr Z
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
+2362 PSL_L_y MM
+V 90 R (Cyclic CPT with NaN) bc Z U
 90 R
-2362 -624 M 267 F0
-(Cyclic CPT with NaN) tc Z
 {0 A} FS
 O0
 9 W
+/PSL_vecheadpen {0 W 0 A [] 0 B} def
 V 4939 146 T
 N 0 0 118 50 166.436 arc S
 O1
+PSL_vecheadpen
+0 W
 V
 N -16 22 118 -136.827 -216.585 arcn
 -4 -65 D
@@ -871,7 +889,10 @@ N -16 22 118 -136.827 -216.585 arcn
 P clip fs N U
 U 
 V 4939 146 T
+9 W
 N 0 0 118 230 346.436 arc S
+PSL_vecheadpen
+0 W
 V
 N 16 -22 118 43.1731 -36.5853 arcn
 4 65 D
@@ -889,7 +910,7 @@ O0
 -4800 6000 TM
 
 % PostScript produced by:
-%@GMT: psscale -O -K -Ctemp_cpt.cpt -Dx5/5 -By+lm '-Bxa+lCyclic CPT with NaN and unit' -X-4i -Y5i
+%@GMT: gmt psscale -O -K -Ctemp_cpt.cpt -Dx5c/5c+w10c/0.618c+n+h -By+lm '-Bxa+lCyclic CPT with NaN and unit' -X-4i -Y5i
 %@PROJ: xy 0.00000000 180.00000000 0.00000000 0.24330709 0.000 180.000 0.000 0.243 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -931,7 +952,7 @@ U
 {0.75 A} FS
 O1
 0 292 -292 0 0 -292 3 -146 292 SP
--521 146 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-521 146 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (NaN) mr Z
 2 setlinecap
@@ -970,9 +991,12 @@ def
 {0 A} FS
 O0
 9 W
+/PSL_vecheadpen {0 W 0 A [] 0 B} def
 V 2362 146 T
 N 0 0 118 50 166.436 arc S
 O1
+PSL_vecheadpen
+0 W
 V
 N -16 22 118 -136.827 -216.585 arcn
 -4 -65 D
@@ -980,7 +1004,10 @@ N -16 22 118 -136.827 -216.585 arcn
 P clip fs N U
 U 
 V 2362 146 T
+9 W
 N 0 0 118 230 346.436 arc S
+PSL_vecheadpen
+0 W
 V
 N 16 -22 118 43.1731 -36.5853 arcn
 4 65 D
@@ -996,7 +1023,7 @@ O0
 0 1200 TM
 
 % PostScript produced by:
-%@GMT: psscale -O -Ctemp_cpt.cpt -Dx5/5 '-Bxa+lCyclic CPT with NaN' -Y1i
+%@GMT: gmt psscale -O -Ctemp_cpt.cpt -Dx5c/5c+w10c/0.618c+n+h '-Bxa+lCyclic CPT with NaN' -Y1i
 %@PROJ: xy 0.00000000 180.00000000 0.00000000 0.24330709 0.000 180.000 0.000 0.243 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -1038,7 +1065,7 @@ U
 {0.75 A} FS
 O1
 0 292 -292 0 0 -292 3 -146 292 SP
--521 146 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-521 146 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (NaN) mr Z
 2 setlinecap
@@ -1075,9 +1102,12 @@ def
 {0 A} FS
 O0
 9 W
+/PSL_vecheadpen {0 W 0 A [] 0 B} def
 V 4939 146 T
 N 0 0 118 50 166.436 arc S
 O1
+PSL_vecheadpen
+0 W
 V
 N -16 22 118 -136.827 -216.585 arcn
 -4 -65 D
@@ -1085,7 +1115,10 @@ N -16 22 118 -136.827 -216.585 arcn
 P clip fs N U
 U 
 V 4939 146 T
+9 W
 N 0 0 118 230 346.436 arc S
+PSL_vecheadpen
+0 W
 V
 N 16 -22 118 43.1731 -36.5853 arcn
 4 65 D
@@ -1095,6 +1128,11 @@ U
 0 setlinecap
 -2362 -2362 T
 %%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage

--- a/test/psscale/vertical.ps
+++ b/test/psscale/vertical.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from psscale
+%%Title: GMT v6.1.0_07d3b13-dirty_2020.03.19 [64-bit] Document from psscale
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:52:58 2018
+%%CreationDate: Thu Mar 19 12:07:06 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -336,9 +336,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +592,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +635,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -651,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -662,8 +658,9 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
-/PSL_movie_completion {} def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
@@ -822,10 +819,12 @@ N 0 2000 M 42 0 D S
 N 0 2800 M 42 0 D S
 N 0 3600 M 42 0 D S
 N 0 4400 M 42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
+2400 PSL_L_y MM
+V 90 R (topography) bc Z U
 90 R
-2400 -732 M 267 F0
-(topography) tc Z
 4883 120 M 200 F0
 V -90 R (km) bc Z U
 -90 R
@@ -905,10 +904,12 @@ N 0 2000 M 42 0 D S
 N 0 2800 M 42 0 D S
 N 0 3600 M 42 0 D S
 N 0 4400 M 42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
+2400 PSL_L_y MM
+V 90 R (topography) bc Z U
 90 R
-2400 -732 M 267 F0
-(topography) tc Z
 4883 120 M 200 F0
 V -90 R (km) bc Z U
 -90 R
@@ -1491,7 +1492,8 @@ V -90 R (t) mc Z U
 %%EndObject
 
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U


### PR DESCRIPTION
The **-B** machinery is more robust in handling things like label placement provided it is on the default side of the axis, such as the case with #2943.  The solution was to rely more on that function except for the cases that are different.  Closes #2943. Updates a few PS originals by a tiny amount.
Now, the OP's example looks like this (`gmt colorbar -Dx0/0+w6/0.618c -Ccolor.cpt -Ba+l"Axis Label" -Q -png map1`):

![map1](https://user-images.githubusercontent.com/26473567/77120095-14beed80-69dc-11ea-8376-073881b0ee81.png)

while if we want a 10^p annotation we slip in the 1p code (`gmt colorbar -Dx0/0+w6/0.618c -Ccolor.cpt -Ba1p+l"Axis Label" -Q -png map2`):

![map2](https://user-images.githubusercontent.com/26473567/77120101-18527480-69dc-11ea-9288-2985229390f6.png)
