### PR TITLE
Warn if remote download is turned off

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -402,7 +402,8 @@ Three classes of files are given special treatment in GMT.
    the default setting for :term:`GMT_DATA_SERVER`.  Alternatively, configure the CMake
    parameter GMT_DATA_SERVER at compile time.
 #. If your Internet connection is slow or nonexistent (e.g., on a plane) you can also
-   set the size of the largest datafile to download via :term:`GMT_DATA_SERVER_LIMIT` to be 0.
+   limit the size of the largest datafile to download via :term:`GMT_DATA_SERVER_LIMIT` or
+   you can temporarily turn off such downloads by setting :term:`GMT_AUTO_DOWNLOAD` off.
 
 The user cache (:term:`DIR_CACHE`) and all its contents can be cleared any time
 via the command **gmt clear cache**, while the server directory with downloaded data

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -477,10 +477,6 @@ unsigned int gmt_download_file_if_not_found (struct GMT_CTRL *GMT, const char* f
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Remote download is currently deactivated\n");
 		return 0; 
 	}
-	if (GMT->current.setting.url_size_limit == 0) {	/* Zero means nothing can be downloaded */
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Remote download turned of as max file size limit is zero\n");
-		return 0;
-	}
 	if (GMT->current.io.internet_error) return 0;   			/* Not able to use remote copying in this session */
 
 	be_fussy = ((mode & 4) == 0);	if (be_fussy == 0) mode -= 4;	/* Handle the optional 4 value */

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -255,7 +255,7 @@ GMT_LOCAL int gmthash_get_url (struct GMT_CTRL *GMT, char *url, char *file, char
 		}
 		if (time_spent >= GMT_HASH_TIME_OUT) {	/* Ten seconds is too long time - server down? */
 			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "GMT data server may be down - delay checking hash file for 24 hours\n");
-			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "You can turn remote file download off by setting GMT_DATA_SERVER_LIMIT = 0.\n");
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "You can turn remote file download off by setting GMT_AUTO_DOWNLOAD off.\n");
 			if (orig && !access (orig, F_OK)) {	/* Refresh modification time of original hash file */
 #ifdef WIN32
 				_utime (orig, NULL);
@@ -666,7 +666,7 @@ unsigned int gmt_download_file_if_not_found (struct GMT_CTRL *GMT, const char* f
 	if ((curl_err = curl_easy_perform (Curl))) {	/* Failed, give error message */
 		if (be_fussy || !(curl_err == CURLE_REMOTE_FILE_NOT_FOUND || curl_err == CURLE_HTTP_RETURNED_ERROR)) {	/* Unexpected failure - want to bitch about it */
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Libcurl Error: %s\n", curl_easy_strerror (curl_err));
-			GMT_Report (GMT->parent, GMT_MSG_WARNING, "You can turn remote file download off by setting GMT_DATA_SERVER_LIMIT = 0.\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "You can turn remote file download off by setting GMT_AUTO_DOWNLOAD off.\n");
 			if (urlfile.fp != NULL) {
 				fclose (urlfile.fp);
 				urlfile.fp = NULL;

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -473,7 +473,14 @@ unsigned int gmt_download_file_if_not_found (struct GMT_CTRL *GMT, const char* f
 
 	if (!file_name || !file_name[0]) return 0;   /* Got nutin' */
 
-	if (GMT->current.setting.auto_download == GMT_NO_DOWNLOAD) return 0;   /* Not allowed to use remote copying */
+	if (GMT->current.setting.auto_download == GMT_NO_DOWNLOAD) {  /* Not allowed to use remote copying */
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Remote download is currently deactivated\n");
+		return 0; 
+	}
+	if (GMT->current.setting.url_size_limit == 0) {	/* Zero means nothing can be downloaded */
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Remote download turned of as max file size limit is zero\n");
+		return 0;
+	}
 	if (GMT->current.io.internet_error) return 0;   			/* Not able to use remote copying in this session */
 
 	be_fussy = ((mode & 4) == 0);	if (be_fussy == 0) mode -= 4;	/* Handle the optional 4 value */


### PR DESCRIPTION
This value or no download should both result in a message when people try to download files if they do not exist in cache.  Closes #2954.
