### PR TITLE
Let gmt5syntax work with a few compatibility modules

### DIFF
--- a/share/tools/gmt5syntax.in
+++ b/share/tools/gmt5syntax.in
@@ -18,6 +18,10 @@ my $progname = 'gmt@GMT_INSTALL_NAME_SUFFIX@';
 my @modulenames = `$progname --show-classic`;
 chomp (@modulenames);
 
+# add more compatibility modules
+my @compat_modules = split (";", "@GMT_COMPAT_MODULES@");
+push @modulenames, @compat_modules;
+
 # Regexp::Assemble creates a single efficient regexp from multiple regexp
 my $have_assemble = eval "use Regexp::Assemble; 1" ? 1 : 0;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -339,7 +339,7 @@ endif (NOT LICENSE_RESTRICTED)
 set (GMT_PROGRAM ${GMT_SOURCE_DIR}/src/gmtprogram.c)
 
 # Legacy modules for which to install compatibility links via install_module_symlink
-set (GMT_COMPAT_MODULES minmax gmtstitch gmtdp grdreformat ps2raster originator)
+set (GMT_COMPAT_MODULES minmax gmtstitch gmtdp grdreformat ps2raster originator PARENT_SCOPE)
 
 # gmt core modules
 set (GMT_PROGS_SRCS blockmean.c blockmedian.c blockmode.c docs.c dimfilter.c filter1d.c grd2kml.c


### PR DESCRIPTION
Allow gmt5syntax converting "ps2raster" to "gmt ps2raster".