### PR TITLE
Clarify what the Bezier and linear splines do

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -739,8 +739,9 @@ specification. The line attribute modifiers are:
 
 * **+s**
     Normally, all PostScript line drawing is implemented as a linear spline, i.e., we simply
-    draw straight line-segments between the given data points.  Use this modifier to render the
-    line using Bezier splines for a smoother curve.
+    draw straight line-segments between the map-projected data points.  Use this modifier to render the
+    line using Bezier splines for a smoother curve. **Note**: The spline is fit to the projected
+    2-D coordinates, not the raw user coordinates (i.e., it is not a spherical surface spline).
 
 .. _Line_bezier:
 
@@ -749,7 +750,7 @@ specification. The line attribute modifiers are:
    :align: center
 
    (left) Normal plotting of line given input points (red circles) via **-W**\ 2p. (right) Letting
-   the points be interpolated by a Bezier cubic spline via **-W**\ 2p\ **+s**.
+   the projected points be interpolated by a Bezier cubic spline via **-W**\ 2p\ **+s**.
 
 * **+v**\ [**b**\|\ **e**]\ *vspecs*
     By default, lines are normally drawn from start to end.  Using the **+v** modifier you can

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7283,7 +7283,7 @@ void gmt_pen_syntax (struct GMT_CTRL *GMT, char option, char *longoption, char *
 		gmt_message (GMT, "\t        To trim the two ends differently, give two offsets separated by a slash (/).\n");
 	}
 	if (mode & 1)
-		gmt_message (GMT, "\t     +s Draw line using a Bezier spline in the PostScript [Linear spline].\n");
+		gmt_message (GMT, "\t     +s Draw line using a Bezier spline through projected coordinates [Linear spline].\n");
 	if (mode & 4) {
 		gmt_message (GMT, "\t     +v[b|e]<vecspecs> Add vector head with the given specs at the ends of lines.\n");
 		gmt_message (GMT, "\t        Use +ve and +vb separately to give different endings (+v applies to both).\n");


### PR DESCRIPTION
See [this forum entry](https://forum.generic-mapping-tools.org/t/s-for-spline-doesnt-work/310) for background posted by @KristofKoch.

The modifier **+s** to pen settings in psxy to fit a Bezier spline rather than linear to data points apply to the projected 2-D coordinates, not (say) the original longitude, latitude points on a spherical surface.  I am getting an article on the extension of the Bezier spline to spherical surfaces so possibly this could change in the future.  For Cartesian data this does not matter but it would affect geographic unprojected data.  For now, clearer documentation will do. 