### PR TITLE
Fix seg fault when GMT_DATADIR environment variable is defined but invalid

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -3129,8 +3129,8 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 
 	/* Determine GMT_DATADIR (data directories) */
 
-	if ((this_c = getenv ("GMT_DATADIR")) != NULL) {		/* GMT_DATADIR was set */
-		if (strchr (this_c, ',') || strchr (this_c, PATH_SEPARATOR) || access (this_c, R_OK) == 0) {
+	if ((this_c = getenv ("GMT_DATADIR")) != NULL && access (this_c, R_OK) == 0) {		/* GMT_DATADIR was set */
+		if (strchr (this_c, ',') || strchr (this_c, PATH_SEPARATOR)) {
 			/* A list of directories or a single directory that is accessible */
 			GMT->session.DATADIR = strdup (this_c);
 			gmt_dos_path_fix (GMT->session.DATADIR);


### PR DESCRIPTION
We've observed instances of gmt seg faulting on startup on some machines but not others. The problem turns out to be users with the GMT_DATADIR environment variable set to nonexistant directories, a case causing the current code to try parsing a null pointer value string. The change detects the case and avoids parsing the null pointer string.
