### PR TITLE
Allow grdmath to take -a, plus handle options splitting args

### DIFF
--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -53,6 +53,8 @@ given on the command line. By default, all columns except the "time"
 column are operated on, but this can be changed (see **-C**).
 Complicated or frequently occurring expressions may be coded as a macro
 for future use or stored and recalled via named memory locations.
+**Note**: Do not place regular GMT options *between* operands and operators;
+each *operand(s)* **OPERATOR** sequence should be a contiguous group of arguments.
 
 Required Arguments
 ------------------

--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -53,8 +53,6 @@ given on the command line. By default, all columns except the "time"
 column are operated on, but this can be changed (see **-C**).
 Complicated or frequently occurring expressions may be coded as a macro
 for future use or stored and recalled via named memory locations.
-**Note**: Do not place regular GMT options *between* operands and operators;
-each *operand(s)* **OPERATOR** sequence should be a contiguous group of arguments.
 
 Required Arguments
 ------------------

--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -20,6 +20,7 @@ Synopsis
 [ |SYN_OPT-R| ]
 [ |-S| ]
 [ |SYN_OPT-V| ]
+[ |SYN_OPT-a| ]
 [ |SYN_OPT-bi| ]
 [ |SYN_OPT-di| ]
 [ |SYN_OPT-f| ]
@@ -38,7 +39,7 @@ Description
 -----------
 
 **grdmath** will perform operations like add, subtract, multiply, and
-numerous other operands on one or more grid files or constants using
+hundreds of other operands on one or more grid files or constants using
 `Reverse Polish Notation (RPN) <https://en.wikipedia.org/wiki/Reverse_Polish_notation>`_
 syntax.  Arbitrarily complicated expressions may therefore be evaluated; the
 final result is written to an output grid file. Grid operations are
@@ -49,6 +50,8 @@ expression then options **-R**, **-I** must be set (and optionally
 the depth of the stack allows in order to save intermediate results.
 Complicated or frequently occurring expressions may be coded as a macro
 for future use or stored and recalled via named memory locations.
+**Note**: Do not place regular GMT options *between* operands and operators;
+each *operand(s)* **OPERATOR** sequence should be a contiguous group of arguments.
 
 Required Arguments
 ------------------
@@ -116,6 +119,8 @@ Optional Arguments
 
 .. |Add_-V| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-V.rst_
+
+.. include:: explain_-aspatial.rst_
 
 .. |Add_-bi| replace:: The binary input option
     only applies to the data files needed by operators **LDIST**,
@@ -762,78 +767,56 @@ Examples
 
 .. include:: explain_example.rst_
 
-To compute all distances to north pole:
-
-    ::
+To compute all distances to north pole, try::
 
      gmt grdmath -Rg -I1 0 90 SDIST = dist_to_NP.nc
 
-To take log10 of the average of 2 files, use
-
-   ::
+To take log10 of the average of 2 files, use::
 
     gmt grdmath file1.nc file2.nc ADD 0.5 MUL LOG10 = file3.nc
 
 Given the file ages.nc, which holds seafloor ages in m.y., use the
-relation depth(in m) = 2500 + 350 \* sqrt (age) to estimate normal seafloor depths:
-
-   ::
+relation depth(in m) = 2500 + 350 \* sqrt (age) to estimate normal seafloor depths, try::
 
     gmt grdmath ages.nc SQRT 350 MUL 2500 ADD = depths.nc
 
 To find the angle a (in degrees) of the largest principal stress from
 the stress tensor given by the three files s_xx.nc s_yy.nc, and
-s_xy.nc from the relation tan (2\*a) = 2 \* s_xy / (s_xx - s_yy), use
-
-   ::
+s_xy.nc from the relation tan (2\*a) = 2 \* s_xy / (s_xx - s_yy), use::
 
     gmt grdmath 2 s_xy.nc MUL s_xx.nc s_yy.nc SUB DIV ATAN 2 DIV = direction.nc
 
 To calculate the fully normalized spherical harmonic of degree 8 and
 order 4 on a 1 by 1 degree world map, using the real amplitude 0.4 and
-the imaginary amplitude 1.1:
-
-   ::
+the imaginary amplitude 1.1, use::
 
     gmt grdmath -R0/360/-90/90 -I1 8 4 YLM 1.1 MUL EXCH 0.4 MUL ADD = harm.nc
 
-To extract the locations of local maxima that exceed 100 mGal in the file faa.nc:
-
-   ::
+To extract the locations of local maxima that exceed 100 mGal in the file faa.nc, use::
 
     gmt grdmath faa.nc DUP EXTREMA 2 EQ MUL DUP 100 GT MUL 0 NAN = z.nc
     gmt grd2xyz z.nc -s > max.xyz
 
 To demonstrate the use of named variables, consider this radial wave
-where we store and recall the normalized radial arguments in radians:
-
-   ::
+where we store and recall the normalized radial arguments in radians by::
 
     gmt grdmath -R0/10/0/10 -I0.25 5 5 CDIST 2 MUL PI MUL 5 DIV STO@r COS @r SIN MUL = wave.nc
 
-To create a dumb file saved as a 32 bits float GeoTiff using GDAL, run
-
-   ::
+To create a dumb file saved as a 32 bits float GeoTiff using GDAL, run::
 
     gmt grdmath -Rd -I10 X Y MUL = lixo.tiff=gd:GTiff
 
 To compute distances in km from the line trace.txt for the area represented by the
-geographic grid data.grd, run
-
-   ::
+geographic grid data.grd, run::
 
     gmt grdmath -Rdata.grd trace.txt LDIST = dist_from_line.grd
 
 To demonstrate the stack-reducing effect of **-S**, we compute the standard deviation
-per node of all the grids matching the name model_*.grd using
-
-   ::
+per node of all the grids matching the name model_*.grd using::
 
     gmt grdmath model_*.grd -S STD = std_of_models.grd
 
-To create a geotiff with resolution 0.5x0.5 degrees with distances in km from the coast line, use
-
-   ::
+To create a geotiff with resolution 0.5x0.5 degrees with distances in km from the coast line, use::
 
     grdmath -RNO,IS -Dc -I.5 LDISTG = distance.tif=gd:GTIFF
 

--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -50,8 +50,6 @@ expression then options **-R**, **-I** must be set (and optionally
 the depth of the stack allows in order to save intermediate results.
 Complicated or frequently occurring expressions may be coded as a macro
 for future use or stored and recalled via named memory locations.
-**Note**: Do not place regular GMT options *between* operands and operators;
-each *operand(s)* **OPERATOR** sequence should be a contiguous group of arguments.
 
 Required Arguments
 ------------------

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -42,7 +42,7 @@
 #define THIS_MODULE_PURPOSE	"Reverse Polish Notation (RPN) calculator for grids (element by element)"
 #define THIS_MODULE_KEYS	"<G(,=G}"
 #define THIS_MODULE_NEEDS	"r"
-#define THIS_MODULE_OPTIONS "-:RVbdefghinrs" GMT_OPT("F") GMT_ADD_x_OPT
+#define THIS_MODULE_OPTIONS "-:RVabdefghinrs" GMT_OPT("F") GMT_ADD_x_OPT
 
 EXTERN_MSC int gmt_load_macros (struct GMT_CTRL *GMT, char *mtype, struct GMT_MATH_MACRO **M);
 EXTERN_MSC int gmt_find_macro (char *arg, unsigned int n_macros, struct GMT_MATH_MACRO *M);
@@ -452,7 +452,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   ADD, AND, MAD, LMSSCL, MAX, MEAN, MEDIAN, MIN, MODE, MUL, RMS, STD, SUB, VAR or XOR.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Note: Select -S after you have placed all items of interest on the stack.\n");
 	GMT_Option (API, "V");
-	GMT_Option (API, "bi2,di,e,f,g,h,i");
+	GMT_Option (API, "a,bi2,di,e,f,g,h,i");
 	if (gmt_M_showusage (API)) GMT_Message (API, GMT_TIME_NONE, "\t   (Only applies to the input files for operators LDIST, PDIST, POINT and INSIDE).\n");
 	GMT_Option (API, "n,r,s,x,.");
 

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -172,8 +172,8 @@ GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct GRDMATH_CTRL *C) {	/* Dea
 GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [%s]\n\t[%s]\n\t[-D<resolution>][+f] [%s]\n\t[-M] [-N] [-S] [%s] [%s] [%s] [%s]\n\t[%s]"
-		" [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s]\n\t%s [%s]", name, GMT_Rgeo_OPT, GMT_A_OPT, GMT_I_OPT, GMT_V_OPT, GMT_bi_OPT, GMT_di_OPT,
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s [%s]\n\t[%s]\n\t[-D<resolution>][+f] [%s]\n\t[-M] [-N] [-S] [%s] [%s] [%s] [%s]\n\t[%s] [%s]"
+		" [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s]\n\t%s [%s]", name, GMT_Rgeo_OPT, GMT_A_OPT, GMT_I_OPT, GMT_V_OPT, GMT_a_OPT, GMT_bi_OPT, GMT_di_OPT,
 		GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT, GMT_i_OPT, GMT_n_OPT, GMT_r_OPT, GMT_s_OPT, GMT_x_OPT, GMT_PAR_OPT);
 	GMT_Message (API, GMT_TIME_NONE, " A B op C op D op ... = <outgrd>\n\n");
 


### PR DESCRIPTION
See #2967 for context.  Turns out the problem was not lack of ability to read the OGR file (GMT is happy to skip all the aspatial comments unless **-a** is supported).  The problem was the placement of GMT options _in between_ operands and operators which tricked our check to skip ascii files when looking for grids.  This PR deals with these issues thus:

1. Adds **-a** to **grdmath** in case users need access to the spatial values.
2. Handles the case of operand operator sequences being split by GMT options.

Closes #2967.
