### PR TITLE
Update a few URLs for the upcoming 6.1 release

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Fixes #
 
 **Reminders**
 
-- [ ] Correct base branch selected? `master` for new features, `6.0` for bug fixes
+- [ ] Correct base branch selected? `master` for new features, `6.1` for bug fixes
 - [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
 - [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
 - [ ] Describe changes to function behavior and arguments in a comment below the function declaration.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ The GMT documentation is written in the plaintext markup language
 by documentation generator [Sphinx](https://www.sphinx-doc.org/en/master/).
 The reST plaintext files for the GMT documentation are located in the [doc/rst/source](/doc/rst/source) folder.
 You may need to know some basic reST syntax before making changes. Please refer to our
-[reStructuredText Cheatsheet](https://docs.generic-mapping-tools.org/latest/rst_cheatsheet.html) for details.
+[reStructuredText Cheatsheet](https://docs.generic-mapping-tools.org/latest/rst-cheatsheet.html) for details.
 
 Usually you don't need to build the documentation locally for small changes.
 If you want, you can install Sphinx locally,

--- a/doc/examples/README.examples
+++ b/doc/examples/README.examples
@@ -18,7 +18,7 @@
 # Those who plan to use the .bat files should seriously ask
 # themselves why they have not installed
 # [cygwin](https://www.cygwin.com) or [git bash](https://git-scm.com/downloads).
-# See https://docs.generic-mapping-tools.org/latest/cookbook/non_unix_platforms.html
+# See https://docs.generic-mapping-tools.org/latest/cookbook/non-unix-platforms.html
 # for more on that.
 #
 # Scripts that are known to fail can be excluded from the test


### PR DESCRIPTION
In PR #2811, we changed the underscores to dashes for most URLs.