### PR TITLE
Improve the custom axes machinery

### DIFF
--- a/doc/scripts/GMT_-B_custom.ps
+++ b/doc/scripts/GMT_-B_custom.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.1.0_3b68500_2020.01.23 [64-bit] Document from psbasemap
+%%Title: GMT v6.1.0_bd193e8_2020.03.26 [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Jan 27 12:20:04 2020
+%%CreationDate: Thu Mar 26 16:34:52 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -661,7 +661,7 @@ FQ
 O0
 1200 1200 TM
 % PostScript produced by:
-%@GMT: gmt psbasemap -R416/542/0/6.2831852 -JX-12c/6c '-Bpx25f5g25+u Ma' -Bpycyannots.txt -BWS+glightblue
+%@GMT: gmt psbasemap -R416/542/0/6.2831852 -JX-12c/6c '-Bpx25f5g25+u Ma' -Bpycyannots.txt -Bsxcxannots.txt -BWS+glightblue --MAP_ANNOT_OFFSET_SECONDARY=10p --MAP_GRID_PEN_SECONDARY=2p
 %@PROJ: xy 416.00000000 542.00000000 0.00000000 6.28318520 542.000 416.000 0.000 6.283 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -689,6 +689,12 @@ S
 N 5669 1226 M -5669 0 D S
 N 5669 1417 M -5669 0 D S
 N 5669 2835 M -5669 0 D S
+33 W
+N 5669 0 M 0 2835 D S
+N 4423 0 M 0 2835 D S
+N 2416 0 M 0 2835 D S
+N 0 0 M 0 2835 D S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2835 M 0 -2835 D S
@@ -700,8 +706,8 @@ N 0 451 M -83 0 D S
 N 0 1226 M -83 0 D S
 N 0 1417 M -83 0 D S
 N 0 2835 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sw mx
@@ -735,15 +741,15 @@ N 0 2707 M -42 0 D S
 25 W
 N 0 0 M 5669 0 D S
 /PSL_A0_y 83 def
-/PSL_A1_y 0 def
+/PSL_A1_y 250 def
 8 W
 N 5264 0 M 0 -83 D S
 N 4139 0 M 0 -83 D S
 N 3015 0 M 0 -83 D S
 N 1890 0 M 0 -83 D S
 N 765 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 200 F0
 (425 Ma) sh mx
 (450 Ma) sh mx
@@ -762,6 +768,23 @@ def
 (500 Ma) bc Z
 765 PSL_A0_y MM
 (525 Ma) bc Z
+N 5669 0 M 0 -250 D S
+N 4423 0 M 0 -250 D S
+N 2416 0 M 0 -250 D S
+N 0 0 M 0 -250 D S
+/PSL_AH1 0
+233 F0
+(Devonian) sh mx
+(Silurian) sh mx
+(Ordovician) sh mx
+def
+/PSL_A1_y PSL_A0_y PSL_A1_y mx 167 add PSL_AH1 add def
+5046 PSL_A1_y MM
+(Devonian) bc Z
+3420 PSL_A1_y MM
+(Silurian) bc Z
+1208 PSL_A1_y MM
+(Ordovician) bc Z
 N 5489 0 M 0 -42 D S
 N 5039 0 M 0 -42 D S
 N 4814 0 M 0 -42 D S
@@ -782,55 +805,10 @@ N 990 0 M 0 -42 D S
 N 540 0 M 0 -42 D S
 N 315 0 M 0 -42 D S
 N 90 0 M 0 -42 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 setlinecap
-%%EndObject
-0 A
-FQ
-O0
-0 0 TM
-% PostScript produced by:
-%@GMT: gmt psbasemap -R416/542/0/6.2831852 -Bsxcxannots.txt -Bsy0 -BWS --MAP_ANNOT_OFFSET_SECONDARY=10p --MAP_GRID_PEN_SECONDARY=2p -JX-12c/6c
-%@PROJ: xy 416.00000000 542.00000000 0.00000000 6.28318520 542.000 416.000 0.000 6.283 +xy
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32551 setmiterlimit
-25 W
-33 W
-N 5669 0 M 0 2835 D S
-N 4423 0 M 0 2835 D S
-N 2416 0 M 0 2835 D S
-N 0 0 M 0 2835 D S
-2 setlinecap
-25 W
-N 0 2835 M 0 -2835 D S
-/PSL_A0_y 0 def
-/PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-N 0 0 M 5669 0 D S
-/PSL_A0_y 0 def
-/PSL_A1_y 250 def
-8 W
-N 5669 0 M 0 -250 D S
-N 4423 0 M 0 -250 D S
-N 2416 0 M 0 -250 D S
-N 0 0 M 0 -250 D S
-/PSL_AH1 0
-/MM {neg M} def
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-233 F0
-(Devonian) sh mx
-(Silurian) sh mx
-(Ordovician) sh mx
-def
-/PSL_A1_y PSL_A0_y PSL_A1_y mx 167 add PSL_AH1 add def
-5046 PSL_A1_y MM
-(Devonian) bc Z
-3420 PSL_A1_y MM
-(Silurian) bc Z
-1208 PSL_A1_y MM
-(Ordovician) bc Z
+N 5669 0 M 0 -62 D S
+N 4423 0 M 0 -62 D S
+N 2416 0 M 0 -62 D S
+N 0 0 M 0 -62 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 setlinecap
 %%EndObject

--- a/doc/scripts/GMT_-B_custom.sh
+++ b/doc/scripts/GMT_-B_custom.sh
@@ -19,7 +19,6 @@ cat << EOF >| yannots.txt
 EOF
 
 gmt begin GMT_-B_custom
-	gmt basemap -R416/542/0/6.2831852 -JX-12c/6c -Bpx25f5g25+u" Ma" -Bpycyannots.txt -BWS+glightblue
-	gmt basemap -R416/542/0/6.2831852 -Bsxcxannots.txt -Bsy0 -BWS \
+	gmt basemap -R416/542/0/6.2831852 -JX-12c/6c -Bpx25f5g25+u" Ma" -Bpycyannots.txt -Bsxcxannots.txt -BWS+glightblue \
 		--MAP_ANNOT_OFFSET_SECONDARY=10p --MAP_GRID_PEN_SECONDARY=2p
 gmt end show

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -3563,7 +3563,10 @@ GMT_LOCAL int gmtinit_decode_tinfo (struct GMT_CTRL *GMT, int axis, char flag, c
 				if (!GMT->current.map.frame.primary) flag = (char)toupper ((int)flag);
 				gmtinit_set_titem (GMT, A, "0", flag, str[axis], true);	/* Store the findings for this segment */
 			}
-			if (n_int[1]) A->item[GMT_ANNOT_UPPER+!GMT->current.map.frame.primary].special = true;
+			if (n_int[0]) A->item[GMT_ANNOT_UPPER].special = true;	/* custom  annotations */
+			if (n_int[1]) A->item[GMT_ANNOT_UPPER+!GMT->current.map.frame.primary].special = true;	/* custom interval annotations */
+			if (n_int[2]) A->item[GMT_TICK_UPPER+!GMT->current.map.frame.primary].special = true;	/* custom tick annotations */
+			if (n_int[3]) A->item[GMT_GRID_UPPER+!GMT->current.map.frame.primary].special = true;	/* custom gridline annotations */
 			GMT->current.map.frame.draw = true;
 			if (axis == GMT_Z) GMT->current.map.frame.drawz = true;
 		}

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -13979,7 +13979,7 @@ unsigned int gmtlib_coordinate_array (struct GMT_CTRL *GMT, double min, double m
 
 	if (!T->active) return (0);	/* Nothing to do */
 
-	if (GMT->current.map.frame.axis[T->parent].file_custom) {	/* Want custom intervals */
+	if (T->special && GMT->current.map.frame.axis[T->parent].file_custom) {	/* Want custom intervals */
 		n = gmt_load_custom_annot (GMT, &GMT->current.map.frame.axis[T->parent], (char)tolower((unsigned char) T->type), array, labels);
 		return (n);
 	}
@@ -14013,9 +14013,10 @@ bool gmtlib_annot_pos (struct GMT_CTRL *GMT, double min, double max, struct GMT_
 	 * For instance, if our interval is 3 months we do not want "January" centered
 	 * on that quarter.  If the position is outside our range we return true
 	 */
+	bool is_interval = (T->type == 'i' || T->type == 'I');
 	double range, start, stop;
 
-	if (T->special) {
+	if (is_interval && T->special) {
 		range = 0.5 * (coord[1] - coord[0]);	/* Half width of interval in internal representation */
 		start = MAX (min, coord[0]);			/* Start of interval, but not less that start of axis */
 		stop  = MIN (max, coord[1]);			/* Stop of interval,  but not beyond end of axis */
@@ -14023,7 +14024,7 @@ bool gmtlib_annot_pos (struct GMT_CTRL *GMT, double min, double max, struct GMT_
 		*pos = 0.5 * (start + stop);				/* Set half-way point */
 		if (((*pos) - GMT_CONV8_LIMIT) < min || ((*pos) + GMT_CONV8_LIMIT) > max) return (true);	/* Outside axis range */
 	}
-	else if (T->type == 'i' || T->type == 'I') {
+	else if (is_interval) {
 		if (gmt_M_uneven_interval (T->unit) || T->interval != 1.0) {	/* Must find next month to get month centered correctly */
 			struct GMT_MOMENT_INTERVAL Inext;
 			gmt_M_memset (&Inext, 1, struct GMT_MOMENT_INTERVAL);	/* Wipe it */


### PR DESCRIPTION
The implementation of custom axes had several shortcomings:

- We could not use custom annotations on both x- and y-axis in the same module call
- Would not always pick right custom gridline intervals

As an example, the highlighted _GMT-B_custom.sh_ example in the cookbook where we had to use two separate basemap calls to make the figure.

This PR fixes the above, allows the script above to be a one-module call (the PS had to be updated since now the module is aware of what is being annotated and ticked), and all other tests are unaffected.
