### PR TITLE
Fix GraphicsMagick path in startup_macosx.sh

### DIFF
--- a/cmake/dist/startup_macosx.sh.in
+++ b/cmake/dist/startup_macosx.sh.in
@@ -16,7 +16,7 @@ tell application "Terminal" to set size of front window to {$w, ${dim[1]}}
 EOF
   export PATH="${BUNDLE_RESOURCES}/@GMT_BINDIR@:${PATH}"
   export PROJ_LIB="${BUNDLE_RESOURCES}/share/proj"
-  export MAGICK_CONFIGURE_PATH=${BUNDLE_RESOURCES}/lib/GraphicsMagick-1.3.33/config
+  export MAGICK_CONFIGURE_PATH=${BUNDLE_RESOURCES}/lib/GraphicsMagick/config
 
   function gmt () { "${BUNDLE_RESOURCES}/@GMT_BINDIR@/gmt" "$@"; }
   export -f gmt


### PR DESCRIPTION
In `admin/build-macos-external-list.sh`, GraphicksMagick's configuration directory
will be installed to ${GMT_LIBDIR}/GraphicsMagick/config.
Thus, no gm version information is needed.