### PR TITLE
Warn if auto-legend in plot[3d] cannot be used

### DIFF
--- a/doc/rst/source/plot3d_notes.rst_
+++ b/doc/rst/source/plot3d_notes.rst_
@@ -39,6 +39,15 @@ circles) can be designed - these polygons can be painted and filled with
 a pattern. Other standard geometric symbols can also be used. See Appendix
 :ref:`App-custom_symbols` for macro definitions.
 
+Auto-Legend
+-----------
+
+The **-l** option for symbols expects the symbol color, size, and type to be given
+on the command line.  If you have variable symbol sizes then you must append **+s**\ *size* to set
+a suitable size for the legend entry.  For other symbol cases the **-l** option will
+be ignored.  Legend entries also work for lines and polygons, but not more complicated
+features such as decorated and quoted lines, fronts, etc.
+
 Bugs
 ----
 

--- a/doc/rst/source/plot_notes.rst_
+++ b/doc/rst/source/plot_notes.rst_
@@ -66,3 +66,12 @@ cannot handle polygons crossing the Dateline.  They work around this
 problem by splitting polygons into a west and east polygon or inserting
 artificial helper lines that makes a cut into the pole and back.  Such
 doctored polygons may be misrepresented in GMT.
+
+Auto-Legend
+-----------
+
+The **-l** option for symbols expects the symbol color, size, and type to be given
+on the command line.  If you have variable symbol sizes then you must append **+s**\ *size* to set
+a suitable size for the legend entry.  For other symbol cases the **-l** option will
+be ignored.  Legend entries also work for lines and polygons, but not more complicated
+features such as decorated and quoted lines, fronts, etc.

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1178,13 +1178,23 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 		struct GMT_DATASET *Diag = NULL;
 		struct GMT_DATASEGMENT *S_Diag = NULL;
 
-		if (S.read_symbol_cmd)	/* Must prepare for a rough ride */
+		if (S.read_symbol_cmd) {	/* Must prepare for a rough ride */
 			GMT_Set_Columns (API, GMT_IN, 0, GMT_COL_VAR);
+			if (GMT->common.l.active)
+				GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for variable symbol types. Option -l ignored.\n");
+		}
 		else { /* Fixed symbol type throughout */
 			GMT_Set_Columns (API, GMT_IN, n_needed, GMT_COL_FIX);
-			if (GMT->common.l.active && !get_rgb && (!S.read_size || GMT->common.l.item.size > 0.0)) {
-				/* For specified symbol, size, color we can do an auto-legend entry under modern mode */
-				gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
+			if (GMT->common.l.active) {	/* Can we do auto-legend? */
+				if (get_rgb)
+					GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for variable symbol color. Option -l ignored.\n");
+				else if (S.read_size && gmt_M_is_zero (GMT->common.l.item.size))
+					GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for variable symbol size unless +s<size> is used. Option -l ignored.\n");
+				else {
+					/* For specified symbol, size, color we can do an auto-legend entry under modern mode */
+					gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
+				}
+
 			}
 		}
 		/* Determine if we need to worry about repeating periodic symbols */
@@ -1875,15 +1885,19 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 		}
 		if (GMT->current.io.OGR && (GMT->current.io.OGR->geometry == GMT_IS_POLYGON || GMT->current.io.OGR->geometry == GMT_IS_MULTIPOLYGON)) polygon = true;
 
-		if (GMT->common.l.active && S.symbol == GMT_SYMBOL_LINE) {
-			if (polygon) {	/* Place a rectangle in the legend */
-				int symbol = S.symbol;
-				S.symbol = PSL_RECT;
-				gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
-				S.symbol = symbol;
+		if (GMT->common.l.active) {
+			if (S.symbol == GMT_SYMBOL_LINE) {
+				if (polygon) {	/* Place a rectangle in the legend */
+					int symbol = S.symbol;
+					S.symbol = PSL_RECT;
+					gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
+					S.symbol = symbol;
+				}
+				else	/* For specified line, width, color we can do an auto-legend entry under modern mode */
+					gmt_add_legend_item (API, &S, false, NULL, Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
 			}
-			else	/* For specified line, width, color we can do an auto-legend entry under modern mode */
-				gmt_add_legend_item (API, &S, false, NULL, Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
+			else
+				GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for selected feature. Option -l ignored.\n");
 		}
 
 		if (Ctrl->W.cpt_effect && Ctrl->W.pen.cptmode & 2) polygon = true;

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -918,11 +918,20 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 		}
 
 		if (!read_symbol) API->object[API->current_item[GMT_IN]]->n_expected_fields = n_needed;
-		if (S.read_symbol_cmd)	/* Must prepare for a rough ride */
+		if (S.read_symbol_cmd) {	/* Must prepare for a rough ride */
 			GMT_Set_Columns (API, GMT_IN, 0, GMT_COL_VAR);
-		else if (GMT->common.l.active && !get_rgb && (!S.read_size || GMT->common.l.item.size > 0.0)) {
-			/* For specified symbol, size, color we can do an auto-legend entry under modern mode */
-			gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
+			if (GMT->common.l.active)
+				GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for variable symbol types. Option -l ignored.\n");
+		}
+		else if (GMT->common.l.active) {	/* Can we do auto-legend? */
+			if (get_rgb)
+				GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for variable symbol color. Option -l ignored.\n");
+			else if (S.read_size && gmt_M_is_zero (GMT->common.l.item.size))
+				GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for variable symbol size unless +s<size> is used. Option -l ignored.\n");
+			else {
+				/* For specified symbol, size, color we can do an auto-legend entry under modern mode */
+				gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
+			}
 		}
 		n = 0;
 		do {	/* Keep returning records until we reach EOF */
@@ -1636,15 +1645,19 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 			z_for_cpt = Zin->table[0]->segment[0]->data[Zin->n_columns-1];	/* Short hand to the required z-array */
 		}
 
-		if (GMT->common.l.active && S.symbol == GMT_SYMBOL_LINE) {
-			if (polygon) {	/* Place a rectangle in the legend */
-				int symbol = S.symbol;
-				S.symbol = PSL_RECT;
-				gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
-				S.symbol = symbol;
+		if (GMT->common.l.active) {
+			if (S.symbol == GMT_SYMBOL_LINE) {
+				if (polygon) {	/* Place a rectangle in the legend */
+					int symbol = S.symbol;
+					S.symbol = PSL_RECT;
+					gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
+					S.symbol = symbol;
+				}
+				else	/* For specified line, width, color we can do an auto-legend entry under modern mode */
+					gmt_add_legend_item (API, &S, false, NULL, Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
 			}
-			else	/* For specified line, width, color we can do an auto-legend entry under modern mode */
-				gmt_add_legend_item (API, &S, false, NULL, Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
+			else
+				GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for selected feature. Option -l ignored.\n");
 		}
 
 		for (tbl = 0; tbl < D->n_tables; tbl++) {


### PR DESCRIPTION
We cannot deal with variable symbol types or colors, or sizes if one is not prescribed for the legend entry. Now warn, and update the docs. Closes #2982.
