### PR TITLE
Implement changes needed to write indexed images w/o transparency

### DIFF
--- a/src/gmt_gdalwrite.c
+++ b/src/gmt_gdalwrite.c
@@ -176,14 +176,14 @@ int gmt_export_image (struct GMT_CTRL *GMT, char *fname, struct GMT_IMAGE *I) {
 		to_GDALW->C.cpt = (float *)calloc(n_colors*4, sizeof(float));
 		for (k = 0; k < n_colors; k++) {
 			to_GDALW->C.cpt[k] = I->colormap[k] / 255.0;
-			to_GDALW->C.cpt[k + n_colors]   = I->colormap[k + n_colors]   / 255.0;
-			to_GDALW->C.cpt[k + n_colors*2] = I->colormap[k + n_colors*2] / 255.0;
+			to_GDALW->C.cpt[k + n_colors]   = gmt_M_is255(I->colormap[k + n_colors]);
+			to_GDALW->C.cpt[k + n_colors*2] = gmt_M_is255(I->colormap[k + n_colors*2]);
 		}
 		if (I->n_indexed_colors > 2000) {		/* Then we either have a Mx4 or a single alpha color */
 			float nc = I->n_indexed_colors / 1000.0;
 			if (nc - rint(nc) == 0) {			/* An Mx4 */
 				for (k = 0; k < n_colors; k++)
-					to_GDALW->C.cpt[k + n_colors*3] = I->colormap[k + n_colors*3] / 255.0;
+					to_GDALW->C.cpt[k + n_colors*3] = gmt_M_is255(I->colormap[k + n_colors*3]);
 			}
 		}
 	}
@@ -376,19 +376,19 @@ int gmt_gdalwrite (struct GMT_CTRL *GMT, char *fname, struct GMT_GDALWRITE_CTRL 
 		hColorTable = GDALCreateColorTable (GPI_RGB);
 		if (prhs->C.n_colors < 2000 || dc > 0) {			/* Simple case. Not overloaded meaning */
 			for (i = 0; i < nColors; i++) {
-				sEntry.c1 = (short)(ptr[i] * 255);
-				sEntry.c2 = (short)(ptr[i+nColors] * 255);
-				sEntry.c3 = (short)(ptr[i+2*nColors] * 255);
+				sEntry.c1 = (short)(gmt_M_s255(ptr[i]));
+				sEntry.c2 = (short)(gmt_M_s255(ptr[i+nColors]));
+				sEntry.c3 = (short)(gmt_M_s255(ptr[i+2*nColors]));
 				sEntry.c4 = (short)255;
 				GDALSetColorEntry(hColorTable, i, &sEntry);
 			}
 		}
 		else {			/* Means the pointer points into a 4 columns array: RGB+alpha */
 			for (i = 0; i < (int)nc; i++) {
-				sEntry.c1 = (short)(ptr[i] * 255);
-				sEntry.c2 = (short)(ptr[i+  nColors] * 255);
-				sEntry.c3 = (short)(ptr[i+2*nColors] * 255);
-				sEntry.c4 = (short)(ptr[i+3*nColors] * 255);
+				sEntry.c1 = (short)(gmt_M_s255(ptr[i]));
+				sEntry.c2 = (short)(gmt_M_s255(ptr[i+  nColors]));
+				sEntry.c3 = (short)(gmt_M_s255(ptr[i+2*nColors]));
+				sEntry.c4 = (short)(gmt_M_s255(ptr[i+3*nColors]));
 				GDALSetColorEntry(hColorTable, i, &sEntry);
 			}
 		}

--- a/src/gmt_gdalwrite.c
+++ b/src/gmt_gdalwrite.c
@@ -165,6 +165,12 @@ int gmt_export_image (struct GMT_CTRL *GMT, char *fname, struct GMT_IMAGE *I) {
 		return GMT_NOTSET;
 	}
 
+	if (I->n_indexed_colors > 0 && I->colormap) {
+		to_GDALW->C.active = true;
+		to_GDALW->C.n_colors = I->n_indexed_colors;
+		to_GDALW->C.cpt = I->colormap;
+	}
+
 	HH = gmt_get_H_hidden (I->header);
 	if (HH->pocket && (pch = strstr(HH->pocket, "+c")) != NULL) 		/* If we have a list of +c<options> */
 		to_GDALW->co_options = strdup(pch);				/* This memory is freed in gmt_gdalwrite */

--- a/src/gmt_gdalwrite.c
+++ b/src/gmt_gdalwrite.c
@@ -147,7 +147,7 @@ int gmt_export_image (struct GMT_CTRL *GMT, char *fname, struct GMT_IMAGE *I) {
 		}
 		free_data = true;
 	}
-	else if (!strncmp (I->header->mem_layout, "TRP", 3)) {
+	else if (!strncmp (I->header->mem_layout, "TRP", 3) || !strncmp (I->header->mem_layout, "BRP", 3)) {
 		to_GDALW->type = strdup("byte");
 		data = I->data;
 		if (to_GDALW->P.ProjRefPROJ4) {
@@ -159,16 +159,33 @@ int gmt_export_image (struct GMT_CTRL *GMT, char *fname, struct GMT_IMAGE *I) {
 		to_GDALW->alpha = I->alpha;
 	}
 	else {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "%s memory layout is not supported, for now only: T(op)C(ol)B(and) or TRP\n",
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "%s memory layout is not supported, for now only: T(op)C(ol)B(and) or TRP & BRP\n",
 		            I->header->mem_layout);
 		gmt_M_free (GMT, to_GDALW);
 		return GMT_NOTSET;
 	}
 
 	if (I->n_indexed_colors > 0 && I->colormap) {
+		int n_colors = I->n_indexed_colors;
+
+		if (n_colors > 2000)		/* If colormap is Mx4 or has encoded the alpha color */
+			n_colors = (int)(floor(n_colors / 1000.0));
+
 		to_GDALW->C.active = true;
 		to_GDALW->C.n_colors = I->n_indexed_colors;
-		to_GDALW->C.cpt = I->colormap;
+		to_GDALW->C.cpt = (float *)calloc(n_colors*4, sizeof(float));
+		for (k = 0; k < n_colors; k++) {
+			to_GDALW->C.cpt[k] = I->colormap[k] / 255.0;
+			to_GDALW->C.cpt[k + n_colors]   = I->colormap[k + n_colors]   / 255.0;
+			to_GDALW->C.cpt[k + n_colors*2] = I->colormap[k + n_colors*2] / 255.0;
+		}
+		if (I->n_indexed_colors > 2000) {		/* Then we either have a Mx4 or a single alpha color */
+			float nc = I->n_indexed_colors / 1000.0;
+			if (nc - rint(nc) == 0) {			/* An Mx4 */
+				for (k = 0; k < n_colors; k++)
+					to_GDALW->C.cpt[k + n_colors*3] = I->colormap[k + n_colors*3] / 255.0;
+			}
+		}
 	}
 
 	HH = gmt_get_H_hidden (I->header);
@@ -182,6 +199,7 @@ int gmt_export_image (struct GMT_CTRL *GMT, char *fname, struct GMT_IMAGE *I) {
 	free (to_GDALW->driver);
 	free (to_GDALW->type);
 	if (free_data && to_GDALW->alpha) gmt_M_free (GMT, to_GDALW->alpha);
+	if (to_GDALW->C.active) free(to_GDALW->C.cpt);
 	gmt_M_free (GMT, to_GDALW);
 
 	return GMT_NOERROR;
@@ -339,16 +357,45 @@ int gmt_gdalwrite (struct GMT_CTRL *GMT, char *fname, struct GMT_GDALWRITE_CTRL 
 		typeCLASS_f = typeCLASS;
 
 	if (prhs->C.active) {
+		/* Here we deal with contents of the prhs->C.cpt pointer. But there is the issue of the existence,
+		   or not, of transparency. Because it's a pointer we cannot know if it holds a Mx3 or Mx4 array.
+		   To know that the trick is to 'overload' the n_colors info. If it's > 2000 we interpret it as
+		   an indication that we are in the Mx4 case. If, after divided by 1000, we have a decimal part, then
+		   we assume that the decimal * 1000 is the number on the color matrix of the transparent color. And
+		   then we use it to set prhs->nan_value. In gmt_gdalwrite it will be used by GDALSetRasterNoDataValue.
+		*/
+		float dc = 0.0, nc;
+
 		nColors = prhs->C.n_colors;
+		if (nColors > 2000) {			/* If colormap is Mx4 or has encoded the alpha color */
+			nColors = (int)(floor(nColors / 1000.0));
+			nc = prhs->C.n_colors / 1000.0;
+			dc = nc - rint(nc);
+		}
 		ptr = prhs->C.cpt;
 		hColorTable = GDALCreateColorTable (GPI_RGB);
-		for (i = 0; i < nColors; i++) {
-			sEntry.c1 = (short)(ptr[i] * 255);
-			sEntry.c2 = (short)(ptr[i+nColors] * 255);
-			sEntry.c3 = (short)(ptr[i+2*nColors] * 255);
-			sEntry.c4 = (short)255;
-			GDALSetColorEntry(hColorTable, i, &sEntry);
+		if (prhs->C.n_colors < 2000 || dc > 0) {			/* Simple case. Not overloaded meaning */
+			for (i = 0; i < nColors; i++) {
+				sEntry.c1 = (short)(ptr[i] * 255);
+				sEntry.c2 = (short)(ptr[i+nColors] * 255);
+				sEntry.c3 = (short)(ptr[i+2*nColors] * 255);
+				sEntry.c4 = (short)255;
+				GDALSetColorEntry(hColorTable, i, &sEntry);
+			}
 		}
+		else {			/* Means the pointer points into a 4 columns array: RGB+alpha */
+			for (i = 0; i < (int)nc; i++) {
+				sEntry.c1 = (short)(ptr[i] * 255);
+				sEntry.c2 = (short)(ptr[i+  nColors] * 255);
+				sEntry.c3 = (short)(ptr[i+2*nColors] * 255);
+				sEntry.c4 = (short)(ptr[i+3*nColors] * 255);
+				GDALSetColorEntry(hColorTable, i, &sEntry);
+			}
+		}
+		if (dc == 0.0)
+			prhs->nan_value = 0.5;		/* Just a non-integer to prevent settng a transp color in gmt_gdalwrite(). */
+		else
+			prhs->nan_value = rint(dc * 1000) - 1;	/* This will be the alpha color as set in gmt_gdalwrite() */
 	}
 
 	/* If grid limits were in grid registration, convert them to pixel reg */
@@ -467,15 +514,14 @@ int gmt_gdalwrite (struct GMT_CTRL *GMT, char *fname, struct GMT_GDALWRITE_CTRL 
 		   Thanks to Even Roualt, see:
 		   osgeo-org.1560.n6.nabble.com/gdal-dev-writing-a-subregion-with-GDALRasterIO-td4960500.html */
 		hBand = GDALGetRasterBand(hDstDS, i+1);
-		if (i == 1 && hColorTable != NULL) {
+		if (i == 0 && hColorTable != NULL) {
 			if (GDALSetRasterColorTable(hBand, hColorTable) == CE_Failure)
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "\tERROR creating Color Table");
 			GDALDestroyColorTable(hColorTable);
 		}
 		switch (typeCLASS) {
 			case GDT_Byte:
-				if (rint(prhs->nan_value) == prhs->nan_value)
-					/* Only set NoData if nan_value contains an integer value */
+				if (rint(prhs->nan_value) == prhs->nan_value)	/* Only set NoData if nan_value contains an integer value */
 					GDALSetRasterNoDataValue(hBand, prhs->nan_value);
 				if (!strcmp(prhs->type, "byte")) {
 					/* This case arrives here from a separate path. It started in grdimage and an originally
@@ -504,8 +550,7 @@ int gmt_gdalwrite (struct GMT_CTRL *GMT, char *fname, struct GMT_GDALWRITE_CTRL 
 			case GDT_Int16:
 			case GDT_UInt32:
 			case GDT_Int32:
-				if (rint(prhs->nan_value) == prhs->nan_value)
-					/* Only set NoData if nan_value contains an integer value */
+				if (rint(prhs->nan_value) == prhs->nan_value)	/* Only set NoData if nan_value contains an integer value */
 					GDALSetRasterNoDataValue(hBand, prhs->nan_value);
 				if ((gdal_err = GDALRasterIO(hBand, GF_Write, 0, 0, n_cols, n_rows, data, n_cols, n_rows, typeCLASS, 0, 0)) != CE_None)
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "GDALRasterIO failed to write band %d [err = %d]\n", i, gdal_err);


### PR DESCRIPTION
Let externals write indexed images and play with transparency. For example this sets the 5th entry color as the transparent one

```
check = UInt8[zeros(9,9) ones(9,9) ones(9,9).*2; ones(9,9).*3 ones(9,9).*4 ones(9,9).*5; ones(9,9).*6 ones(9,9).*7 ones(9,9).*8];
C = makecpt(range=(0,9,1));
I = mat2img(check, cmap=C);
image_alpha!(I, alpha_ind=5);
gmtwrite("lixo1.png", I)
```
![lixo1](https://user-images.githubusercontent.com/537321/77836728-9804df80-7150-11ea-98d4-5e795d5402f9.png)

or assign an random transparency to the first 6 colors

```
image_alpha!(I, alpha_vec=round.(UInt32,rand(6).*255));
gmtwrite("lixo2.png", I)
```
![lixo2](https://user-images.githubusercontent.com/537321/77836775-00ec5780-7151-11ea-8a1c-f535d9fa69e8.png)

