### PR TITLE
Be consistant with use of rgb macros

### DIFF
--- a/src/gmt2kml.c
+++ b/src/gmt2kml.c
@@ -169,7 +169,7 @@ GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a n
 	C->E.tessellate = true;	/* This is the default, use -E+s to turn that off (turned off for symbols later) */
 	C->F.mode = POINT;
 	C->F.geometry = GMT_IS_POINT;
-	gmt_init_fill (GMT, &C->G.fill[F_ID], 1.0, 192.0 / 255.0, 128.0 / 255.0);	/* Default fill color */
+	gmt_init_fill (GMT, &C->G.fill[F_ID], 1.0, gmt_M_is255(192), gmt_M_is255(128));	/* Default fill color */
 	gmt_init_fill (GMT, &C->G.fill[N_ID], 1.0, 1.0, 1.0);				/* Default text color */
 	C->G.fill[N_ID].rgb[3] = 0.25;	/* Default text transparency */
 	C->I.file = strdup ("http://maps.google.com/mapfiles/kml/pal4/icon57.png");	/* Default icon */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -12710,7 +12710,7 @@ int gmt_getpanel (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_
 	P = gmt_M_memory (GMT, NULL, 1, struct GMT_MAP_PANEL);
 	P->radius = GMT->session.u2u[GMT_PT][GMT_INCH] * GMT_FRAME_RADIUS;	/* 6 pt */
 	gmt_init_fill (GMT, &P->fill, -1.0, -1.0, -1.0);			/* Default is no fill unless specified */
-	gmt_init_fill (GMT, &P->sfill, 127.0/255.0, 127.0/255.0, 127.0/255.0);			/* Default if gray shade is used */
+	gmt_init_fill (GMT, &P->sfill, gmt_M_is255 (127), gmt_M_is255 (127), gmt_M_is255 (127));	/* Default if gray shade is used */
 	P->pen1 = GMT->current.setting.map_frame_pen;			/* Heavier pen for main outline */
 	P->pen2 = GMT->current.setting.map_default_pen;			/* Thinner pen for optional inner outline */
 	P->gap = GMT->session.u2u[GMT_PT][GMT_INCH] * GMT_FRAME_GAP;	/* Default is 2p */

--- a/src/psimage.c
+++ b/src/psimage.c
@@ -522,9 +522,9 @@ int GMT_psimage (void *V_API, int mode, void *args) {
 
 		/* If a transparent color was found, we replace it with a unique one */
 		if (has_trans) {
-			Ctrl->G.rgb[PSIMG_TRA][0] = r / 255.;
-			Ctrl->G.rgb[PSIMG_TRA][1] = g / 255.;
-			Ctrl->G.rgb[PSIMG_TRA][2] = b / 255.;
+			Ctrl->G.rgb[PSIMG_TRA][0] = gmt_M_is255(r);
+			Ctrl->G.rgb[PSIMG_TRA][1] = gmt_M_is255(g);
+			Ctrl->G.rgb[PSIMG_TRA][2] = gmt_M_is255(b);
 		}
 
 		picture = (unsigned char *)I->data;

--- a/src/seis/pspolar.c
+++ b/src/seis/pspolar.c
@@ -116,7 +116,7 @@ GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a n
 	C->C.pen = C->E.pen = C->F.pen = C->G.pen = GMT->current.setting.map_default_pen;
 
 	C->C.size = GMT_DOT_SIZE;
-	gmt_init_fill (GMT, &C->E.fill, 250.0 / 255.0, 250.0 / 255.0, 250.0 / 255.0);
+	gmt_init_fill (GMT, &C->E.fill, gmt_M_is255(250), gmt_M_is255(250), gmt_M_is255(250));
 	gmt_init_fill (GMT, &C->F.fill, -1.0, -1.0, -1.0);
 	gmt_init_fill (GMT, &C->G.fill, 0.0, 0.0, 0.0);
 	gmt_init_fill (GMT, &C->S2.fill, -1.0, -1.0, -1.0);


### PR DESCRIPTION
We have macros _gmt_M_s255_ for multipying and _gmt_M_is255_ for dividing by 255.  This PR fixes a few places where we are not using them.
