### PR TITLE
Make single-use functions internal and static

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -690,7 +690,7 @@ GMT_LOCAL void gmtapi_check_for_modern_oneliner (struct GMTAPI_CTRL *API, const 
 /* Function to get PPID under Windows is a bit different */
 #ifdef _WIN32
 #include <TlHelp32.h>
-int winppid (int pidin) {
+GMT_LOCAL int winppid (int pidin) {
 	/* If pidin == 0 get the PPID of current process
 	   otherwise, get the PPID of pidin process
 	*/
@@ -7565,7 +7565,7 @@ int GMT_Set_Geometry_ (unsigned int *direction, unsigned int *geometry) {	/* For
 }
 #endif
 
-void *api_get_record_fp_sub (struct GMTAPI_CTRL *API, unsigned int mode, int *n_fields, struct GMTAPI_DATA_OBJECT **S_obj) {
+GMT_LOCAL void *api_get_record_fp_sub (struct GMTAPI_CTRL *API, unsigned int mode, int *n_fields, struct GMTAPI_DATA_OBJECT **S_obj) {
 	/* Gets next data record from current open stream */
 	int status;
 	struct GMTAPI_DATA_OBJECT *S = API->current_get_obj;
@@ -7728,7 +7728,7 @@ struct GMT_RECORD *api_get_record_vector (struct GMTAPI_CTRL *API, unsigned int 
 	return record;
 }
 
-struct GMT_RECORD *api_get_record_dataset (struct GMTAPI_CTRL *API, unsigned int mode, int *n_fields) {
+GMT_LOCAL struct GMT_RECORD *api_get_record_dataset (struct GMTAPI_CTRL *API, unsigned int mode, int *n_fields) {
 	/* Gets next data record from current dataset */
 	struct GMTAPI_DATA_OBJECT *S = API->current_get_obj;
 	struct GMT_CTRL *GMT = API->GMT;
@@ -8648,7 +8648,7 @@ int GMT_Destroy_Data_ (void *object) {
 }
 #endif
 
-int api_destroy_grids (struct GMTAPI_CTRL *API, struct GMT_GRID ***obj, unsigned int n_items)
+GMT_LOCAL int api_destroy_grids (struct GMTAPI_CTRL *API, struct GMT_GRID ***obj, unsigned int n_items)
 {	/* Used to destroy a group of grids read via GMT_Read_Group */
 	unsigned int k;
 	int error;
@@ -8658,7 +8658,7 @@ int api_destroy_grids (struct GMTAPI_CTRL *API, struct GMT_GRID ***obj, unsigned
 	return_error (API, GMT_NOERROR);
 }
 
-int api_destroy_datasets (struct GMTAPI_CTRL *API, struct GMT_DATASET ***obj, unsigned int n_items)
+GMT_LOCAL int api_destroy_datasets (struct GMTAPI_CTRL *API, struct GMT_DATASET ***obj, unsigned int n_items)
 {	/* Used to destroy a group of datasets read via GMT_Read_Group */
 	unsigned int k;
 	int error;
@@ -8668,7 +8668,7 @@ int api_destroy_datasets (struct GMTAPI_CTRL *API, struct GMT_DATASET ***obj, un
 	return_error (API, GMT_NOERROR);
 }
 
-int api_destroy_images (struct GMTAPI_CTRL *API, struct GMT_IMAGE ***obj, unsigned int n_items)
+GMT_LOCAL int api_destroy_images (struct GMTAPI_CTRL *API, struct GMT_IMAGE ***obj, unsigned int n_items)
 {	/* Used to destroy a group of images read via GMT_Read_Group */
 	unsigned int k;
 	int error;
@@ -8678,7 +8678,7 @@ int api_destroy_images (struct GMTAPI_CTRL *API, struct GMT_IMAGE ***obj, unsign
 	return_error (API, GMT_NOERROR);
 }
 
-int api_destroy_palettes (struct GMTAPI_CTRL *API, struct GMT_PALETTE ***obj, unsigned int n_items)
+GMT_LOCAL int api_destroy_palettes (struct GMTAPI_CTRL *API, struct GMT_PALETTE ***obj, unsigned int n_items)
 {
 	unsigned int k;
 	int error;
@@ -8688,7 +8688,7 @@ int api_destroy_palettes (struct GMTAPI_CTRL *API, struct GMT_PALETTE ***obj, un
 	return_error (API, GMT_NOERROR);
 }
 
-int api_destroy_postscripts (struct GMTAPI_CTRL *API, struct GMT_POSTSCRIPT ***obj, unsigned int n_items)
+GMT_LOCAL int api_destroy_postscripts (struct GMTAPI_CTRL *API, struct GMT_POSTSCRIPT ***obj, unsigned int n_items)
 {	/* Used to destroy a group of palettes read via GMT_Read_Group */
 	unsigned int k;
 	int error;
@@ -8698,7 +8698,7 @@ int api_destroy_postscripts (struct GMTAPI_CTRL *API, struct GMT_POSTSCRIPT ***o
 	return_error (API, GMT_NOERROR);
 }
 
-int api_destroy_matrices (struct GMTAPI_CTRL *API, struct GMT_MATRIX ***obj, unsigned int n_items)
+GMT_LOCAL int api_destroy_matrices (struct GMTAPI_CTRL *API, struct GMT_MATRIX ***obj, unsigned int n_items)
 {	/* Used to destroy a group of matrices read via GMT_Read_Group */
 	unsigned int k;
 	int error;
@@ -8708,7 +8708,7 @@ int api_destroy_matrices (struct GMTAPI_CTRL *API, struct GMT_MATRIX ***obj, uns
 	return_error (API, GMT_NOERROR);
 }
 
-int api_destroy_vectors (struct GMTAPI_CTRL *API, struct GMT_VECTOR ***obj, unsigned int n_items)
+GMT_LOCAL int api_destroy_vectors (struct GMTAPI_CTRL *API, struct GMT_VECTOR ***obj, unsigned int n_items)
 {	/* Used to destroy a group of vectors read via GMT_Read_Group */
 	unsigned int k;
 	int error;
@@ -8718,7 +8718,7 @@ int api_destroy_vectors (struct GMTAPI_CTRL *API, struct GMT_VECTOR ***obj, unsi
 	return_error (API, GMT_NOERROR);
 }
 
-void **void3_to_void2 (void ***p) { return (*p); }	/* To avoid warnings and troubles */
+GMT_LOCAL void **void3_to_void2 (void ***p) { return (*p); }	/* To avoid warnings and troubles */
 
 /*! . */
 int GMT_Destroy_Group (void *V_API, void *object, unsigned int n_items) {

--- a/src/gmt_gdalwrite.c
+++ b/src/gmt_gdalwrite.c
@@ -166,10 +166,10 @@ int gmt_export_image (struct GMT_CTRL *GMT, char *fname, struct GMT_IMAGE *I) {
 	}
 
 	if (I->n_indexed_colors > 0 && I->colormap) {
-		int n_colors = I->n_indexed_colors;
+		uint64_t n_colors = I->n_indexed_colors;
 
 		if (n_colors > 2000)		/* If colormap is Mx4 or has encoded the alpha color */
-			n_colors = (int)(floor(n_colors / 1000.0));
+			n_colors = (uint64_t)(floor(n_colors / 1000.0));
 
 		to_GDALW->C.active = true;
 		to_GDALW->C.n_colors = I->n_indexed_colors;

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -54,7 +54,6 @@ EXTERN_MSC int gmtlib_set_current_item_file (struct GMT_CTRL *GMT, const char *i
 EXTERN_MSC int gmtlib_polar_prepare_label (struct GMT_CTRL *GMT, double angle, unsigned int side, double *line_angle, double *text_angle, unsigned int *justify);
 EXTERN_MSC bool gmtinit_B_is_frame (struct GMT_CTRL *GMT, char *in);
 EXTERN_MSC int64_t gmt_parse_index_range (struct GMT_CTRL *GMT, char *p, int64_t *start, int64_t *stop);
-EXTERN_MSC void gmtlib_handle_escape_text (char *text, char key, int way);
 EXTERN_MSC int gmtlib_ascii_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double *ptr, char *txt);
 EXTERN_MSC void gmtlib_reparse_i_option (struct GMT_CTRL *GMT, uint64_t n_columns);
 EXTERN_MSC void gmtlib_reparse_o_option (struct GMT_CTRL *GMT, uint64_t n_columns);
@@ -77,7 +76,6 @@ EXTERN_MSC char *gmtlib_get_srtmlist  (struct GMTAPI_CTRL *API, double wesn[], u
 EXTERN_MSC struct GMT_GRID * gmtlib_assemble_srtm (struct GMTAPI_CTRL *API, double *region, char *file);
 EXTERN_MSC bool gmtlib_fig_is_ps (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmtlib_refpoint_to_panel_xy (struct GMT_CTRL *GMT, int refpoint, struct GMT_SUBPLOT *P, double *x, double *y);
-EXTERN_MSC int gmtlib_read_figures (struct GMT_CTRL *API, unsigned int mode, struct GMT_FIGURE **figs);
 EXTERN_MSC bool gmtlib_file_is_downloadable (struct GMT_CTRL *GMT, const char *file, unsigned int *kind);
 EXTERN_MSC unsigned int gmtlib_get_pos_of_filename (const char *url);
 EXTERN_MSC bool gmtlib_is_color (struct GMT_CTRL *GMT, char *word);
@@ -162,7 +160,6 @@ EXTERN_MSC int gmtlib_io_banner (struct GMT_CTRL *GMT, unsigned int direction);
 EXTERN_MSC double gmtlib_great_circle_dist_degree (struct GMT_CTRL *GMT, double lon1, double lat1, double lon2, double lat2);
 EXTERN_MSC int gmtlib_gmonth_length (int year, int month);
 EXTERN_MSC int gmtlib_great_circle_intersection (struct GMT_CTRL *GMT, double A[], double B[], double C[], double X[], double *CX_dist);
-EXTERN_MSC int gmtlib_small_circle_intersection (struct GMT_CTRL *GMT, double Ax, double Ay, double Ar, double Bx, double By, double Br, double lon[], double lat[]);
 EXTERN_MSC void gmtlib_get_point_from_r_az (struct GMT_CTRL *GMT, double lon0, double lat0, double r, double azim, double *lon1, double *lat1);
 EXTERN_MSC bool gmtlib_check_url_name (char *fname);
 EXTERN_MSC int64_t gmtlib_splitinteger (double value, int epsilon, double *doublepart);
@@ -175,7 +172,6 @@ EXTERN_MSC void gmtlib_grd_get_units (struct GMT_CTRL *GMT, struct GMT_GRID_HEAD
 EXTERN_MSC void gmtlib_grd_set_units (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header);
 EXTERN_MSC int gmtinit_backwards_SQ_parsing (struct GMT_CTRL *GMT, char option, char *item);
 EXTERN_MSC int gmtlib_process_binary_input (struct GMT_CTRL *GMT, uint64_t n_read);
-EXTERN_MSC uint64_t gmtlib_bin_colselect (struct GMT_CTRL *GMT);
 EXTERN_MSC bool gmtlib_gap_detected (struct GMT_CTRL *GMT);
 EXTERN_MSC int gmtlib_set_gap (struct GMT_CTRL *GMT);
 EXTERN_MSC struct GMT_POSTSCRIPT * gmtlib_create_ps (struct GMT_CTRL *GMT, uint64_t length);
@@ -199,12 +195,10 @@ EXTERN_MSC void gmtlib_free_list (struct GMT_CTRL *GMT, char **list, uint64_t n)
 EXTERN_MSC p_to_io_func gmtlib_get_io_ptr (struct GMT_CTRL *GMT, int direction, enum GMT_swap_direction swap, char type);
 EXTERN_MSC void gmtlib_io_binary_header (struct GMT_CTRL *GMT, FILE *fp, unsigned int dir);
 EXTERN_MSC void gmtlib_write_tableheader (struct GMT_CTRL *GMT, FILE *fp, char *txt);
-EXTERN_MSC void gmtlib_write_textrecord (struct GMT_CTRL *GMT, FILE *fp, char *txt);
 EXTERN_MSC struct GMT_DATASET * gmtlib_create_dataset (struct GMT_CTRL *GMT, uint64_t n_tables, uint64_t n_segments, uint64_t n_rows, uint64_t n_columns, unsigned int geometry, unsigned int mode, bool alloc_only);
 EXTERN_MSC struct GMT_DATATABLE * gmtlib_read_table (struct GMT_CTRL *GMT, void *source, unsigned int source_type, bool greenwich, unsigned int *geometry, unsigned int *datatype, bool use_GMT_io);
 EXTERN_MSC int gmtlib_write_dataset (struct GMT_CTRL *GMT, void *dest, unsigned int dest_type, struct GMT_DATASET *D, bool use_GMT_io, int table);
 EXTERN_MSC void gmtlib_free_palette (struct GMT_CTRL *GMT, struct GMT_PALETTE **P);
-EXTERN_MSC int gmtlib_append_ogr_item (struct GMT_CTRL *GMT, char *name, enum GMT_enum_type type, struct GMT_OGR *S);
 EXTERN_MSC void gmtlib_write_ogr_header (FILE *fp, struct GMT_OGR *G);
 EXTERN_MSC struct GMT_IMAGE * gmtlib_create_image (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmtlib_free_image (struct GMT_CTRL *GMT, struct GMT_IMAGE **I, bool free_image);
@@ -228,7 +222,6 @@ EXTERN_MSC int gmtlib_decorate_specs (struct GMT_CTRL *GMT, char *txt, struct GM
 EXTERN_MSC int gmtlib_decorate_info (struct GMT_CTRL *GMT, char flag, char *txt, struct GMT_DECORATE *D);
 EXTERN_MSC unsigned int gmtlib_get_arc (struct GMT_CTRL *GMT, double x0, double y0, double r, double dir1, double dir2, double **x, double **y);
 EXTERN_MSC struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsigned int source_type, unsigned int cpt_flags);
-EXTERN_MSC char * gmtlib_trim_segheader (struct GMT_CTRL *GMT, char *line);
 EXTERN_MSC int gmtlib_alloc_univector (struct GMT_CTRL *GMT, union GMT_UNIVECTOR *u, unsigned int type, uint64_t n_rows);
 EXTERN_MSC unsigned int gmtlib_get_arc (struct GMT_CTRL *GMT, double x0, double y0, double r, double dir1, double dir2, double **x, double **y);
 EXTERN_MSC unsigned int gmtlib_expand_headerpad (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h, double *new_wesn, unsigned int *orig_pad, double *orig_wesn);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -52,7 +52,6 @@
  * gmtlib_write_tableheader
  * gmt_fgets
  * gmt_skip_xy_duplicates
- * gmt_is_ascii_record
  * gmtlib_gap_detected
  * gmt_ascii_output_col
  * gmtlib_set_gap
@@ -62,22 +61,18 @@
  * gmt_z_input
  * gmtlib_process_binary_input
  * gmtlib_nc_get_att_text
- * gmt_input_is_bin
  * gmtlib_io_banner
  * gmt_get_cols
  * gmt_set_cols
  * gmt_access
  * gmt_get_ogr_id
- * gmtlib_trim_segheader
- * gmt_is_segment_header
  * gmtio_ascii_textinput
  * gmt_is_a_blank_line
- * gmtlib_bin_colselect
+ * gmtio_bin_colselect
  * gmt_skip_output
  * gmtlib_set_bin_io
  * gmt_format_abstime_output
  * gmt_ascii_format_col
- * gmt_init_io_columns
  * gmt_disable_bghi_opts
  * gmt_reenable_bghi_opts
  * gmt_lon_range_adjust
@@ -92,7 +87,6 @@
  * gmtlib_geo_to_dms
  * gmt_add_to_record
  * gmtlib_io_binary_header
- * gmtlib_write_textrecord
  * gmt_parse_z_io
  * gmt_get_io_type
  * gmtlib_get_io_ptr
@@ -203,9 +197,32 @@ typedef enum {
 /* These functions are defined and used below but not in any *.h file so we repeat them here */
 int gmt_get_ogr_id (struct GMT_OGR *G, char *name);
 void gmt_format_abstime_output (struct GMT_CTRL *GMT, double dt, char *text);
-unsigned int gmt_is_segment_header (struct GMT_CTRL *GMT, char *line);
 
 /* Local functions */
+
+/*! Returns true if record is NaN NaN [NaN NaN] etc */
+GMT_LOCAL bool gmtio_is_a_NaN_line (struct GMT_CTRL *GMT, char *line) {
+	unsigned int pos = 0;
+	char p[GMT_LEN256] = {""};
+
+	while ((gmt_strtok (line, GMT->current.io.scan_separators, &pos, p))) {
+		gmt_str_tolower (p);
+		if (strncmp (p, "nan", 3U)) return (false);
+	}
+	return (true);
+}
+
+/*! . */
+GMT_LOCAL unsigned int gmtio_is_segment_header (struct GMT_CTRL *GMT, char *line)
+{	/* Returns 1 if this record is a GMT segment header;
+	 * Returns 2 if this record is a segment breaker;
+	 * Otherwise returns 0 */
+	if (GMT->current.setting.io_blankline[GMT_IN] && gmt_is_a_blank_line (line)) return (2);	/* Treat blank line as segment break */
+	if (GMT->current.setting.io_nanline[GMT_IN] && gmtio_is_a_NaN_line (GMT, line)) return (2);		/* Treat NaN-records as segment break */
+	if (line[0] == GMT->current.setting.io_seg_marker[GMT_IN]) return (1);	/* Got a regular GMT segment header */
+	return (0);	/* Not a segment header */
+}
+
 
 /*! . */
 static inline bool outside_in_row_range (struct GMT_CTRL *GMT, int64_t row) {
@@ -365,6 +382,19 @@ GMT_LOCAL bool gmtio_traverse_dir (const char *file, char *path) {
 #endif /* HAVE_DIRENT_H_ */
 
 /*! . */
+GMT_LOCAL char *gmtio_trim_segheader (struct GMT_CTRL *GMT, char *line) {
+	/* Trim trailing junk and return pointer to first non-space/tab/> part of segment header
+	 * Do not try to free the returned pointer!
+	 */
+	gmt_strstrip (line, false); /* Strip trailing whitespace */
+	/* Skip over leading whitespace and segment marker */
+	while (*line && (isspace(*line) || *line == GMT->current.setting.io_seg_marker[GMT_IN]))
+		++line;
+	/* Return header string */
+	return (line);
+}
+
+/*! . */
 GMT_LOCAL void gmtio_adjust_periodic_lon (struct GMT_CTRL *GMT, double *val) {
 	while (*val > GMT->common.R.wesn[XHI] && (*val - 360.0) >= GMT->common.R.wesn[XLO])
 		*val -= 360.0;
@@ -382,6 +412,37 @@ GMT_LOCAL void gmtio_adjust_projected (struct GMT_CTRL *GMT) {
 	}
 	(*GMT->current.proj.inv) (GMT, &GMT->current.io.curr_rec[GMT_X], &GMT->current.io.curr_rec[GMT_Y],
 	                          GMT->current.io.curr_rec[GMT_X], GMT->current.io.curr_rec[GMT_Y]);
+}
+
+/*! . */
+GMT_LOCAL uint64_t gmtio_bin_colselect (struct GMT_CTRL *GMT) {
+	/* When -i<cols> is used we must pull out and reset the current record */
+	uint64_t col, order;
+	static double tmp[GMT_BUFSIZ];
+	struct GMT_COL_INFO *S = NULL;
+	for (col = 0; col < GMT->common.i.n_cols; col++) {
+		S = &(GMT->current.io.col[GMT_IN][col]);
+		order = S->order;
+		tmp[order] = gmt_convert_col (GMT->current.io.col[GMT_IN][col], GMT->current.io.curr_rec[S->col]);
+		switch (gmt_M_type (GMT, GMT_IN, order)) {
+			case GMT_IS_LON:	/* Must account for periodicity in 360 as per current rule */
+				gmtio_adjust_periodic_lon (GMT, &tmp[order]);
+				break;
+			case GMT_IS_LAT:
+				if (tmp[order] < -90.0 || tmp[order] > +90.0) {
+					GMT_Report (GMT->parent, GMT_MSG_WARNING, "Latitude (%g) at line # %" PRIu64 " exceeds -|+ 90! - set to NaN\n", tmp[order], GMT->current.io.rec_no);
+					tmp[S->order] = GMT->session.d_NaN;
+				}
+				break;
+			case GMT_IS_DIMENSION:	/* Convert to internal inches */
+				tmp[order] *= GMT->session.u2u[GMT->current.setting.proj_length_unit][GMT_INCH];
+				break;
+			default:	/* Nothing to do */
+				break;
+		}
+	}
+	gmt_M_memcpy (GMT->current.io.curr_rec, tmp, GMT->common.i.n_cols, double);
+	return (GMT->common.i.n_cols);
 }
 
 /*! Return the floating point value associated with the aspatial value V given its type as a double */
@@ -867,18 +928,6 @@ void gmt_list_aspatials (struct GMT_CTRL *GMT, char buffer[]) {
 		sprintf (item, " %s[%s]", GMT->common.a.name[k], GMT_type[GMT->common.a.type[k]]);
 		strcat (buffer, item);
 	}
-}
-
-/*! Returns true if record is NaN NaN [NaN NaN] etc */
-GMT_LOCAL bool gmtio_is_a_NaN_line (struct GMT_CTRL *GMT, char *line) {
-	unsigned int pos = 0;
-	char p[GMT_LEN256] = {""};
-
-	while ((gmt_strtok (line, GMT->current.io.scan_separators, &pos, p))) {
-		gmt_str_tolower (p);
-		if (strncmp (p, "nan", 3U)) return (false);
-	}
-	return (true);
 }
 
 /* Sub functions for gmtio_bin_input */
@@ -3088,7 +3137,7 @@ GMT_LOCAL void * gmtio_bin_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, i
 		status = gmtlib_process_binary_input (GMT, n_use);
 		if (status == 1) { *retval = 0; return (NULL); }		/* A segment header */
 	} while (status == 2);	/* Continue reading when record is to be skipped */
-	n_read = (GMT->common.i.select) ? gmtlib_bin_colselect (GMT) : *n;	/* We may use -i and select fewer of the input columns */
+	n_read = (GMT->common.i.select) ? gmtio_bin_colselect (GMT) : *n;	/* We may use -i and select fewer of the input columns */
 
 	if (gmtlib_gap_detected (GMT)) { *retval = gmtlib_set_gap (GMT); return (&GMT->current.io.record); }
 	GMT->current.io.has_previous_rec = true;
@@ -3428,7 +3477,7 @@ GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, 
 		GMT->current.io.data_record_number_in_tbl[GMT_IN]++;
 		GMT->current.io.data_record_number_in_seg[GMT_IN]++;
 		if (outside_in_row_range (GMT, *(GMT->common.q.rec))) {	/* Records is outside desired row range of interest */
-			if (!gmt_is_segment_header (GMT, line))
+			if (!gmtio_is_segment_header (GMT, line))
 				continue;
 		}
 		/* First chop off trailing whitespace and commas */
@@ -3443,7 +3492,7 @@ GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, 
 			return (NULL);
 		}
 
-		if ((kind = gmt_is_segment_header (GMT, line))) {	/* Got a segment header, take action and return */
+		if ((kind = gmtio_is_segment_header (GMT, line))) {	/* Got a segment header, take action and return */
 			GMT->current.io.status = GMT_IO_SEGMENT_HEADER;
 			gmt_set_segmentheader (GMT, GMT_OUT, true);	/* Turn on segment headers on output */
 			GMT->current.io.seg_no++;
@@ -3472,7 +3521,7 @@ GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, 
 						ungetc (c, fp);
 				}
 				else
-					strncpy (GMT->current.io.segment_header, gmtlib_trim_segheader (GMT, line), GMT_BUFSIZ-1);
+					strncpy (GMT->current.io.segment_header, gmtio_trim_segheader (GMT, line), GMT_BUFSIZ-1);
 				/* Just save the header content, not the marker and leading whitespace */
 			}
 			/* else we got a segment break instead - and header was set to NULL */
@@ -4161,21 +4210,7 @@ bool gmt_input_is_nan_proxy (struct GMT_CTRL *GMT, double value) {
 	return doubleAlmostEqual (GMT->common.d.nan_proxy[GMT_IN], value);		/* Change to NaN if value ~nan_proxy */
 }
 
-/*! Appends one more metadata item to this OGR structure */
-int gmtlib_append_ogr_item (struct GMT_CTRL *GMT, char *name, enum GMT_enum_type type, struct GMT_OGR *S) {
-	if (S == NULL) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtio_append_ogr_item: No GMT_OGR structure available\n");
-		return (GMT_PTR_IS_NULL);
-	}
-	S->n_aspatial++;
-	S->name = gmt_M_memory (GMT, S->name, S->n_aspatial, char *);
-	S->name[S->n_aspatial-1] = strdup (name);
-	S->type = gmt_M_memory (GMT, S->type, S->n_aspatial, enum GMT_enum_type);
-	S->type[S->n_aspatial-1] = type;
-	return (GMT_NOERROR);
-}
-
-/*! . */
+//*! . */
 void gmtlib_write_ogr_header (FILE *fp, struct GMT_OGR *G) {
 	/* Write out table-level OGR/GMT header metadata */
 	unsigned int k, col;
@@ -4307,29 +4342,6 @@ void gmt_skip_xy_duplicates (struct GMT_CTRL *GMT, bool mode) {
 	GMT->current.io.skip_duplicates = mode;
 }
 
-/*! . */
-bool gmt_is_ascii_record (struct GMT_CTRL *GMT, struct GMT_OPTION *head) {
-	/* Modules that read/write data records one at the time via GMT_Get_Record and
-	 * GMT_Put_Record needs to know they are writing to files or memory.  Only if
-	 * we are writing to files (or stdout) AND no -b has bee specified can we truly
-	 * say we are doing ASCII i/o.  Otherwise we must do binary i/o.  We check for
-	 * the various situations and returns true or false accordingly. */
-
-	if (GMT->common.b.active[GMT_IN] || GMT->common.b.active[GMT_OUT]) return (false);	/* Binary, so clearly false */
-	if (GMT->current.io.ndim > 0) return (false);						/* netCDF, so clearly false */
-	if (GMT->common.i.select || GMT->common.o.select) return (false);			/* Selected columns via -i and/or -o, so false */
-	if (GMT->parent->external) {	/* External interface (e.g., mex, Python) so must check if writing files or memory */
-		struct GMT_OPTION *current = head;
-		while (current) {	/* Look for file names */
-			if (current->option == GMT_OPT_INFILE || current->option == GMT_OPT_OUTFILE) {	/* File given, see if memory */
-				if (gmt_M_file_is_memory (current->arg)) return (false);	/* Planning to read/write via memory */
-			}
-			current = current->next;
-		}
-	}
-	return (true);	/* Should be able to treat record as an ASCII record */
-}
-
 /*! Determine if two points are "far enough apart" to constitude a data gap and thus "pen up" */
 bool gmtlib_gap_detected (struct GMT_CTRL *GMT) {
 	uint64_t i;
@@ -4416,7 +4428,7 @@ int gmtlib_process_binary_input (struct GMT_CTRL *GMT, uint64_t n_read) {
 		if (!gmt_M_is_dnan (GMT->current.io.curr_rec[col_no])) {	/* Clean data */
 			if (col_no > 1 && gmt_input_is_nan_proxy (GMT, GMT->current.io.curr_rec[col_no]))	/* Input matched no-data setting, so change to NaN */
 				GMT->current.io.curr_rec[col_no] = GMT->session.d_NaN;
-			else if (GMT->common.i.select)	/* Cannot check here, done in gmtlib_bin_colselect instead when order is set */
+			else if (GMT->common.i.select)	/* Cannot check here, done in gmtio_bin_colselect instead when order is set */
 				continue;
 			else {	/* Still clean, so possibly adjust value and skip to next column */
 				switch (gmt_M_type (GMT, GMT_IN, col_no)) {
@@ -4615,23 +4627,6 @@ int gmtlib_write_dataset (struct GMT_CTRL *GMT, void *dest, unsigned int dest_ty
 	if (close_file) gmt_fclose (GMT, fp);
 
 	return (0);	/* OK status */
-}
-
-/*! . */
-bool gmt_input_is_bin (struct GMT_CTRL *GMT, const char *filename) {
-	FILE *fd = NULL;
-
-	if (GMT->common.b.active[GMT_IN]) return true;	/* Clearly a binary file */
-	if (gmt_M_compat_check (GMT, 4) && GMT->common.b.varnames[0]) return true;	/* Definitely netCDF */
-	if (!filename)  return false;			/* Cannot be netCDF without a filename */
-	if (strchr (filename, '?'))  return true;	/* Definitely netCDF */
-	/* Might still be netCDF; try to open it */
-	fd = gmt_nc_fopen (GMT, filename, "r");
-	if (fd) {	/* Yes, it was */
-		gmt_fclose (GMT, fd);
-		return true;
-	}
-	else return false;	/* No, must be ASCII */
 }
 
 /*! . */
@@ -5117,30 +5112,6 @@ int gmt_get_ogr_id (struct GMT_OGR *G, char *name) {
 }
 
 /*! . */
-char *gmtlib_trim_segheader (struct GMT_CTRL *GMT, char *line) {
-	/* Trim trailing junk and return pointer to first non-space/tab/> part of segment header
-	 * Do not try to free the returned pointer!
-	 */
-	gmt_strstrip (line, false); /* Strip trailing whitespace */
-	/* Skip over leading whitespace and segment marker */
-	while (*line && (isspace(*line) || *line == GMT->current.setting.io_seg_marker[GMT_IN]))
-		++line;
-	/* Return header string */
-	return (line);
-}
-
-/*! . */
-unsigned int gmt_is_segment_header (struct GMT_CTRL *GMT, char *line)
-{	/* Returns 1 if this record is a GMT segment header;
-	 * Returns 2 if this record is a segment breaker;
-	 * Otherwise returns 0 */
-	if (GMT->current.setting.io_blankline[GMT_IN] && gmt_is_a_blank_line (line)) return (2);	/* Treat blank line as segment break */
-	if (GMT->current.setting.io_nanline[GMT_IN] && gmtio_is_a_NaN_line (GMT, line)) return (2);		/* Treat NaN-records as segment break */
-	if (line[0] == GMT->current.setting.io_seg_marker[GMT_IN]) return (1);	/* Got a regular GMT segment header */
-	return (0);	/* Not a segment header */
-}
-
-/*! . */
 void * gmtio_ascii_textinput (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, int *status) {
 	bool more = true;
 	char line[GMT_BUFSIZ] = {""}, *p = NULL;
@@ -5187,7 +5158,7 @@ void * gmtio_ascii_textinput (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, int *
 			gmt_set_segmentheader (GMT, GMT_OUT, true);	/* Turn on segment headers on output */
 			GMT->current.io.seg_no++;
 			/* Just save the header content, not the marker and leading whitespace */
-			strncpy (GMT->current.io.segment_header, gmtlib_trim_segheader (GMT, line), GMT_BUFSIZ-1);
+			strncpy (GMT->current.io.segment_header, gmtio_trim_segheader (GMT, line), GMT_BUFSIZ-1);
 			*n = 1ULL;
 			*status = 0;
 			return (NULL);
@@ -5219,37 +5190,6 @@ bool gmt_is_a_blank_line (char *line) {
 	while (line[i] && (line[i] == ' ' || line[i] == '\t')) i++;	/* Wind past leading whitespace or tabs */
 	if (line[i] == '\n' || line[i] == '\r' || line[i] == '\0') return (true);
 	return (false);
-}
-
-/*! . */
-uint64_t gmtlib_bin_colselect (struct GMT_CTRL *GMT) {
-	/* When -i<cols> is used we must pull out and reset the current record */
-	uint64_t col, order;
-	static double tmp[GMT_BUFSIZ];
-	struct GMT_COL_INFO *S = NULL;
-	for (col = 0; col < GMT->common.i.n_cols; col++) {
-		S = &(GMT->current.io.col[GMT_IN][col]);
-		order = S->order;
-		tmp[order] = gmt_convert_col (GMT->current.io.col[GMT_IN][col], GMT->current.io.curr_rec[S->col]);
-		switch (gmt_M_type (GMT, GMT_IN, order)) {
-			case GMT_IS_LON:	/* Must account for periodicity in 360 as per current rule */
-				gmtio_adjust_periodic_lon (GMT, &tmp[order]);
-				break;
-			case GMT_IS_LAT:
-				if (tmp[order] < -90.0 || tmp[order] > +90.0) {
-					GMT_Report (GMT->parent, GMT_MSG_WARNING, "Latitude (%g) at line # %" PRIu64 " exceeds -|+ 90! - set to NaN\n", tmp[order], GMT->current.io.rec_no);
-					tmp[S->order] = GMT->session.d_NaN;
-				}
-				break;
-			case GMT_IS_DIMENSION:	/* Convert to internal inches */
-				tmp[order] *= GMT->session.u2u[GMT->current.setting.proj_length_unit][GMT_INCH];
-				break;
-			default:	/* Nothing to do */
-				break;
-		}
-	}
-	gmt_M_memcpy (GMT->current.io.curr_rec, tmp, GMT->common.i.n_cols, double);
-	return (GMT->common.i.n_cols);
 }
 
 /*! . */
@@ -5317,7 +5257,7 @@ static double tcount[N_T_UNITS] = {31557600.0, 2629800.0, 86400.0, 3600.0, 60.0}
 static char *tformat[N_T_UNITS] = {"%uY","%2.2uM", "%2.2uD", "%2.2uH", "%2.2uM"};
 
 /*! . */
-void gmt_format_duration_output (struct GMT_CTRL *GMT, double dt, char *text) {
+GMT_LOCAL void gmtio_format_duration_output (struct GMT_CTRL *GMT, double dt, char *text) {
 	unsigned int k, k0 = N_T_UNITS, n[N_T_UNITS];
 	char item[GMT_LEN16] = {""};
 	double sec;	/* Get seconds */
@@ -5365,7 +5305,7 @@ void gmt_ascii_format_col (struct GMT_CTRL *GMT, char *text, double x, unsigned 
 			gmt_format_abstime_output (GMT, x, text);
 			break;
 		case GMT_IS_DURATION:
-			gmt_format_duration_output (GMT, x, text);
+			gmtio_format_duration_output (GMT, x, text);
 			break;
 		default:	/* Floating point */
 			if (GMT->current.io.o_format[col])	/* Specific to this column */
@@ -5398,7 +5338,7 @@ void gmt_ascii_format_one (struct GMT_CTRL *GMT, char *text, double x, unsigned 
 }
 
 /*! . */
-void gmt_init_io_columns (struct GMT_CTRL *GMT, unsigned int dir) {
+GMT_LOCAL void gmtio_init_io_columns (struct GMT_CTRL *GMT, unsigned int dir) {
 	/* Initialize (reset) information per column which may have changed due to -i -o */
 	unsigned int i;
 	for (i = 0; i < GMT_MAX_COLUMNS; i++) GMT->current.io.col[dir][i].col = GMT->current.io.col[dir][i].order = i;	/* Default order */
@@ -5448,8 +5388,8 @@ void gmtlib_io_init (struct GMT_CTRL *GMT) {
 	strcpy (GMT->current.io.clock_input.ampm_suffix[1],  "pm");
 	strcpy (GMT->current.io.clock_output.ampm_suffix[1], "pm");
 
-	gmt_init_io_columns (GMT, GMT_IN);	/* Set default input column order */
-	gmt_init_io_columns (GMT, GMT_OUT);	/* Set default output column order */
+	gmtio_init_io_columns (GMT, GMT_IN);	/* Set default input column order */
+	gmtio_init_io_columns (GMT, GMT_OUT);	/* Set default output column order */
 	for (i = 0; i < 2; i++) GMT->current.io.skip_if_NaN[i] = true;								/* x/y must be non-NaN */
 	for (i = 0; i < 2; i++) gmt_set_column (GMT, GMT_IO, i, GMT_IS_UNKNOWN);	/* Must be told [or find out] what x/y are */
 	for (i = 2; i < GMT_MAX_COLUMNS; i++) gmt_set_column (GMT, GMT_IO, i, GMT_IS_FLOAT);	/* Other columns default to floats */
@@ -5880,17 +5820,6 @@ void gmtlib_io_binary_header (struct GMT_CTRL *GMT, FILE *fp, unsigned int dir) 
 	else {
 		for (k = 0; k < GMT->current.setting.io_n_header_items; k++) gmt_M_fwrite (&c, sizeof (char), 1U, fp);
 	}
-}
-
-/*! . */
-void gmtlib_write_textrecord (struct GMT_CTRL *GMT, FILE *fp, char *txt) {
-	/* Output ASCII segment header; skip if mode is binary.
-	 * We append a newline (\n) if not is present */
-
-	if (GMT->common.b.active[GMT_OUT]) return;		/* Cannot write text records if binary output */
-	if (!txt || !txt[0]) return;				/* Skip blank lines */
-	fprintf (fp, "%s", txt);				/* May or may not have \n at end */
-	if (txt[strlen(txt)-1] != '\n') fputc ('\n', fp);	/* Make sure we have \n at end */
 }
 
 /*! . */
@@ -8064,7 +7993,7 @@ void gmt_free_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET **data) {
 	gmt_M_free (GMT, *data);
 }
 
-struct GMT_IMAGE *gmt_get_image (struct GMT_CTRL *GMT) {
+GMT_LOCAL struct GMT_IMAGE *gmtio_get_image (struct GMT_CTRL *GMT) {
 	struct GMT_IMAGE *I = gmt_M_memory (GMT, NULL, 1, struct GMT_IMAGE);
 	I->hidden = gmt_M_memory (GMT, NULL, 1, struct GMT_IMAGE_HIDDEN);
 	return (I);
@@ -8074,7 +8003,7 @@ struct GMT_IMAGE *gmt_get_image (struct GMT_CTRL *GMT) {
 struct GMT_IMAGE *gmtlib_create_image (struct GMT_CTRL *GMT) {
 	/* Allocates space for a new image container. */
 	struct GMT_IMAGE_HIDDEN *IH = NULL;
-	struct GMT_IMAGE *I = gmt_get_image (GMT);
+	struct GMT_IMAGE *I = gmtio_get_image (GMT);
 	IH = gmt_get_I_hidden (I);
 	I->header = gmt_get_header (GMT);
 	IH->alloc_mode = GMT_ALLOC_INTERNALLY;		/* Memory can be freed by GMT. */

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -7255,6 +7255,7 @@ double gmt_mindist_to_point (struct GMT_CTRL *GMT, double lon, double lat, struc
 	return (d_min);
 }
 
+#if 0
 int gmtlib_small_circle_intersection (struct GMT_CTRL *GMT, double Ax, double Ay, double Ar, double Bx, double By, double Br, double Xx[2], double Yy[2]) {
 	/* Let (Ax,Ay) and (Bx,By) be the poles of two small circles, each with radius Ar and Br, respectively, in degrees.
 	 * Pass out the 0-2 intersections via Xx, Yx and return the number of intersections 0-2.
@@ -7293,6 +7294,7 @@ int gmtlib_small_circle_intersection (struct GMT_CTRL *GMT, double Ax, double Ay
 	gmt_cart_to_geo (GMT, &Yy[1], &Xx[1], P, true);		/* Recover lon,lat of 2nd intersection point */
 	return 2;
 }
+#endif
 
 /*! . */
 int gmtlib_great_circle_intersection (struct GMT_CTRL *GMT, double A[], double B[], double C[], double X[], double *CX_dist) {
@@ -8886,6 +8888,7 @@ void gmt_ECEF_inverse (struct GMT_CTRL *GMT, double in[], double out[]) {
 	out[GMT_Z] = (p / cos_lat) - N;
 }
 
+#if 0
 /*! Convert ECEF coordinates to geodetic lon, lat, height given the 'to' parameters. Used in 7 params Bursa-Wolf transform */
 void gmt_ECEF_inverse_dest_datum (struct GMT_CTRL *GMT, double in[], double out[]) {
 	double sin_lat, cos_lat, N, p, theta, sin_theta, cos_theta;
@@ -8899,6 +8902,7 @@ void gmt_ECEF_inverse_dest_datum (struct GMT_CTRL *GMT, double in[], double out[
 	N = GMT->current.proj.datum.to.a / sqrt (1.0 - GMT->current.proj.datum.to.e_squared * sin_lat * sin_lat);
 	out[GMT_Z] = (p / cos_lat) - N;
 }
+#endif
 
 /*! . */
 double gmt_line_length (struct GMT_CTRL *GMT, double x[], double y[], uint64_t n, bool project) {

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -67,7 +67,6 @@
  *	gmtlib_read_ps              :
  *	gmtlib_write_ps             :
  *	gmtlib_duplicate_ps         :
- *	gmtlib_copy_ps              :
  *
  */
 
@@ -9281,16 +9280,7 @@ int gmtlib_write_ps (struct GMT_CTRL *GMT, void *dest, unsigned int dest_type, u
 	return (GMT_NOERROR);
 }
 
-/*! . */
-struct GMT_POSTSCRIPT * gmtlib_duplicate_ps (struct GMT_CTRL *GMT, struct GMT_POSTSCRIPT *P_from, unsigned int mode) {
-	/* Duplicates a GMT_POSTSCRIPT structure.  Mode not used yet */
-	struct GMT_POSTSCRIPT *P = gmtlib_create_ps (GMT, P_from->n_bytes);
-	gmt_M_unused(mode);
-	gmtlib_copy_ps (GMT, P, P_from);
-	return (P);
-}
-
-void gmtlib_copy_ps (struct GMT_CTRL *GMT, struct GMT_POSTSCRIPT *P_copy, struct GMT_POSTSCRIPT *P_obj) {
+void gmtplot_copy_ps (struct GMT_CTRL *GMT, struct GMT_POSTSCRIPT *P_copy, struct GMT_POSTSCRIPT *P_obj) {
 	/* Just duplicate from P_obj into P_copy */
 	struct GMT_POSTSCRIPT_HIDDEN *PH = gmt_get_P_hidden (P_copy);
 	if (P_obj->n_bytes > PH->n_alloc) P_copy->data = gmt_M_memory (GMT, P_copy->data, P_obj->n_bytes, char);
@@ -9299,6 +9289,15 @@ void gmtlib_copy_ps (struct GMT_CTRL *GMT, struct GMT_POSTSCRIPT *P_copy, struct
 	P_copy->mode = P_obj->mode;
 	PH->n_alloc = P_copy->n_bytes = P_obj->n_bytes;
 	PH->alloc_mode = GMT_ALLOC_INTERNALLY;	/* So GMT can free the data array */
+}
+
+/*! . */
+struct GMT_POSTSCRIPT * gmtlib_duplicate_ps (struct GMT_CTRL *GMT, struct GMT_POSTSCRIPT *P_from, unsigned int mode) {
+	/* Duplicates a GMT_POSTSCRIPT structure.  Mode not used yet */
+	struct GMT_POSTSCRIPT *P = gmtlib_create_ps (GMT, P_from->n_bytes);
+	gmt_M_unused(mode);
+	gmtplot_copy_ps (GMT, P, P_from);
+	return (P);
 }
 
 struct GMT_POSTSCRIPT * gmt_get_postscript (struct GMT_CTRL *GMT) {

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -56,7 +56,6 @@ EXTERN_MSC int gmt_get_option_id (int start, char *this_option);
 EXTERN_MSC bool gmt_is_integer (char *L);
 EXTERN_MSC int gmt_get_next_panel (struct GMTAPI_CTRL *API, int fig, int *row, int *col);
 EXTERN_MSC int gmt_report_usage (struct GMTAPI_CTRL *API, struct GMT_OPTION *options, unsigned int special, int (*usage)(struct GMTAPI_CTRL *, int));
-EXTERN_MSC bool gmt_option_set (struct GMT_CTRL *GMT, bool *active, unsigned int *errors);
 EXTERN_MSC void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int justify);
 EXTERN_MSC struct GMT_SUBPLOT *gmt_subplot_info (struct GMTAPI_CTRL *API, int fig);
 EXTERN_MSC int get_V (char arg);
@@ -64,8 +63,6 @@ EXTERN_MSC int gmt_get_V (char arg);
 EXTERN_MSC char gmt_set_V (int mode);
 EXTERN_MSC void gmt_conf_US (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmt_conf (struct GMT_CTRL *GMT);
-EXTERN_MSC int gmt_put_history (struct GMT_CTRL *GMT);
-EXTERN_MSC int gmt_get_history (struct GMT_CTRL *GMT);
 EXTERN_MSC int gmt_truncate_file (struct GMTAPI_CTRL *API, char *file, size_t size);
 EXTERN_MSC int gmt_set_current_panel (struct GMTAPI_CTRL *API, int fig, int row, int col, double gap[], char *label, unsigned int first);
 EXTERN_MSC int gmt_get_current_figure (struct GMTAPI_CTRL *API);
@@ -124,7 +121,6 @@ EXTERN_MSC int gmt_parse_vector (struct GMT_CTRL *GMT, char symbol, char *text, 
 EXTERN_MSC bool gmt_check_region (struct GMT_CTRL *GMT, double wesn[]);
 EXTERN_MSC int gmt_pickdefaults (struct GMT_CTRL *GMT, bool lines, struct GMT_OPTION *options);
 EXTERN_MSC unsigned int gmt_setdefaults (struct GMT_CTRL *GMT, struct GMT_OPTION *options);
-EXTERN_MSC int gmt_loaddefaults (struct GMT_CTRL *GMT, char *file);
 EXTERN_MSC int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL *p, unsigned int mode, bool cmd);
 EXTERN_MSC int gmt_message (struct GMT_CTRL *GMT, char *format, ...);
 #ifdef WIN32
@@ -263,7 +259,6 @@ EXTERN_MSC void gmt_find_range (struct GMT_CTRL *GMT, struct GMT_RANGE *Z, uint6
 EXTERN_MSC void gmt_eliminate_lon_jumps (struct GMT_CTRL *GMT, double *lon, uint64_t n_rows);
 EXTERN_MSC bool gmt_polygon_is_hole (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S);
 EXTERN_MSC void gmt_free_header (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER **header);
-EXTERN_MSC struct GMT_IMAGE *gmt_get_image (struct GMT_CTRL *GMT);
 EXTERN_MSC struct GMT_GRID_HEADER * gmt_get_header (struct GMT_CTRL *GMT);
 EXTERN_MSC struct GMT_POSTSCRIPT * gmt_get_postscript (struct GMT_CTRL *GMT);
 EXTERN_MSC struct GMT_DATASET * gmt_get_dataset (struct GMT_CTRL *GMT);
@@ -282,7 +277,6 @@ EXTERN_MSC bool gmt_is_a_blank_line (char *line);
 EXTERN_MSC void gmt_set_geographic (struct GMT_CTRL *GMT, unsigned int dir);
 EXTERN_MSC void gmt_set_cartesian (struct GMT_CTRL *GMT, unsigned int dir);
 EXTERN_MSC void gmt_set_xycolnames (struct GMT_CTRL *GMT, char *string);
-EXTERN_MSC bool gmt_is_ascii_record (struct GMT_CTRL *GMT, struct GMT_OPTION *head);
 EXTERN_MSC void gmt_set_segmentheader (struct GMT_CTRL *GMT, int direction, bool true_false);
 EXTERN_MSC void gmt_set_tableheader (struct GMT_CTRL *GMT, int direction, bool true_false);
 EXTERN_MSC void *gmt_z_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, int *status);
@@ -336,8 +330,6 @@ EXTERN_MSC int gmt_parse_z_io (struct GMT_CTRL *GMT, char *txt, struct GMT_PARSE
 EXTERN_MSC int gmt_init_z_io (struct GMT_CTRL *GMT, char format[], bool repeat[], enum GMT_swap_direction swab, off_t skip, char type, struct GMT_Z_IO *r);
 EXTERN_MSC int gmt_set_z_io (struct GMT_CTRL *GMT, struct GMT_Z_IO *r, struct GMT_GRID *G);
 EXTERN_MSC void gmt_check_z_io (struct GMT_CTRL *GMT, struct GMT_Z_IO *r, struct GMT_GRID *G);
-EXTERN_MSC void gmt_init_io_columns (struct GMT_CTRL *GMT, unsigned int dir);
-EXTERN_MSC bool gmt_input_is_bin (struct GMT_CTRL *GMT, const char *filename);
 EXTERN_MSC bool gmt_skip_output (struct GMT_CTRL *GMT, double *cols, uint64_t n_cols);
 
 /* gmt_M_memory.c: */

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -274,7 +274,7 @@ GMT_LOCAL int gmthash_get_url (struct GMT_CTRL *GMT, char *url, char *file, char
 	return 0;
 }
 
-struct GMT_DATA_HASH * hash_load (struct GMT_CTRL *GMT, char *file, int *n) {
+GMT_LOCAL struct GMT_DATA_HASH * hash_load (struct GMT_CTRL *GMT, char *file, int *n) {
 	/* Read contents of the hash file into an array of structs */
 	int k;
 	FILE *fp = NULL;

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -5816,7 +5816,7 @@ static int chmatch (const char *target, const char *pat) {
    [[] - match '['.
    [][abc] match ], [, a, b or c
 */
-int matchwild (const char *str, const char *pattern) {
+GMT_LOCAL int matchwild (const char *str, const char *pattern) {
 	const char *target = str;
 	const char *pat = pattern;
 	int gobble;
@@ -7210,7 +7210,7 @@ int gmt_list_cpt (struct GMT_CTRL *GMT, char option) {
 }
 
 /*! . */
-void gmtlib_make_continuous_colorlist (struct GMT_CTRL *GMT, struct GMT_PALETTE *P) {
+GMT_LOCAL void support_make_continuous_colorlist (struct GMT_CTRL *GMT, struct GMT_PALETTE *P) {
 	/* Convert a (by default) discrete CPT made from a color list to a continuous CPT instead */
 	unsigned int k, i;
 	gmt_M_unused(GMT);
@@ -7230,7 +7230,7 @@ void gmtlib_make_continuous_colorlist (struct GMT_CTRL *GMT, struct GMT_PALETTE 
 unsigned int gmt_validate_cpt_parameters (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, char *file, bool *interpolate, bool *force_continuous) {
 	if (P->mode & GMT_CPT_COLORLIST && !P->categorical && !(*interpolate) && P->n_colors > 1) {	/* Color list with -T/min/max should be seen as continuous */
 		*force_continuous = true, P->mode |= GMT_CPT_CONTINUOUS;
-		gmtlib_make_continuous_colorlist (GMT, P);
+		support_make_continuous_colorlist (GMT, P);
 	}
 	if (*interpolate) {
 		if (!P->is_continuous && !(P->mode & GMT_CPT_COLORLIST)) {
@@ -7981,7 +7981,7 @@ unsigned int gmt_parse_inv_cpt (struct GMT_CTRL *GMT, char *arg) {
 	return (mode);
 }
 
-int gmtsupport_validate_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, double *z_low, double *z_high) {
+GMT_LOCAL int gmtsupport_validate_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, double *z_low, double *z_high) {
 	int ks;
 	if (!P->has_hinge) return GMT_NOTSET;	/* Not our concern here */
 	/* Claims to have a hinge */
@@ -13858,7 +13858,7 @@ unsigned int gmtlib_pow_array (struct GMT_CTRL *GMT, double min, double max, dou
 }
 
 /*! . */
-uint64_t gmt_time_array (struct GMT_CTRL *GMT, double min, double max, double inc, char unit, bool interval, double **array) {
+GMT_LOCAL uint64_t support_time_array (struct GMT_CTRL *GMT, double min, double max, double inc, char unit, bool interval, double **array) {
 	/* When T->active is true we must return interval start/stop even if outside min/max range */
 	uint64_t n = 0;
 	size_t n_alloc = GMT_SMALL_CHUNK;
@@ -13894,7 +13894,7 @@ unsigned int gmtlib_time_array (struct GMT_CTRL *GMT, double min, double max, st
 
 	if (!T->active) return (0);
 	interval = (T->type == 'i' || T->type == 'I');	/* Only true for i/I axis items */
-	n = (unsigned int)gmt_time_array (GMT, min, max, T->interval, T->unit, interval, array);
+	n = (unsigned int)support_time_array (GMT, min, max, T->interval, T->unit, interval, array);
 
 	return (n);
 }
@@ -16275,7 +16275,7 @@ unsigned int gmt_create_array (struct GMT_CTRL *GMT, char option, struct GMT_ARR
 		T->n = 1;
 	}
 	else if (T->vartime)	/* Must call special function that knows about variable months and years */
-		T->n = gmt_time_array (GMT, t0, t1, inc, GMT->current.setting.time_system.unit, false, &(T->array));
+		T->n = support_time_array (GMT, t0, t1, inc, GMT->current.setting.time_system.unit, false, &(T->array));
 	else if (T->logarithmic)	/* Must call special function that deals with logarithmic arrays */
 		T->n = gmtlib_log_array (GMT, t0, t1, inc, &(T->array));
 	else if (T->logarithmic2)	/* Must call special function that deals with logarithmic arrays */

--- a/src/gmtmath.c
+++ b/src/gmtmath.c
@@ -5976,7 +5976,7 @@ GMT_LOCAL void gmtmath_expand_recall_cmd (struct GMT_OPTION *list) {
 	}
 }
 
-bool color_operator_on_table (bool scalar, char *arg) {
+GMT_LOCAL bool color_operator_on_table (bool scalar, char *arg) {
 	if (scalar) return false;
 	if (strlen (arg) < 7) return false;
 	if (arg[3] != '2') return false;

--- a/src/grdfilter_mt.c
+++ b/src/grdfilter_mt.c
@@ -183,7 +183,7 @@ struct THREAD_STRUCT {
 static void *threading_function (void *args);
 void threaded_function (struct THREAD_STRUCT *t);
 
-void *New_grdfilter_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
+static void *New_grdfilter_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
 	struct GRDFILTER_CTRL *C;
 
 	C = gmt_M_memory (GMT, NULL, 1, struct GRDFILTER_CTRL);
@@ -195,7 +195,7 @@ void *New_grdfilter_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a n
 	return (C);
 }
 
-void Free_grdfilter_Ctrl (struct GMT_CTRL *GMT, struct GRDFILTER_CTRL *C) {	/* Deallocate control structure */
+static void Free_grdfilter_Ctrl (struct GMT_CTRL *GMT, struct GRDFILTER_CTRL *C) {	/* Deallocate control structure */
 	if (!C) return;
 	gmt_M_str_free (C->In.file);
 	gmt_M_str_free (C->F.file);

--- a/src/gshhg_version.c
+++ b/src/gshhg_version.c
@@ -47,7 +47,7 @@
 
 /* Get value from VERSION_ATT_NAME of netCDF file and populate gshhg_version,
  * gshhg_version_major, gshhg_version_minor, and gshhg_version_patch */
-int gshhg_get_version (const char* filename, struct GSHHG_VERSION *gshhg_version) {
+static int gshhg_get_version (const char* filename, struct GSHHG_VERSION *gshhg_version) {
 	int    status;                         /* error status */
 	int    ncid;                           /* netCDF ID */
 	size_t v_len;                          /* version length */

--- a/src/gshhg_version.h
+++ b/src/gshhg_version.h
@@ -52,7 +52,6 @@ struct GSHHG_VERSION {
 };
 
 /* Prototypes */
-EXTERN_MSC int gshhg_get_version (const char* filename, struct GSHHG_VERSION *gshhg_version);
 EXTERN_MSC int gshhg_require_min_version (const char* filename, const struct GSHHG_VERSION min_version);
 
 #ifdef __cplusplus

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -593,7 +593,7 @@ GMT_LOCAL void fix_format (char *unit, char *format) {
 	}
 }
 
-void plot_cycle (struct GMT_CTRL *GMT, double x, double y, double width) {
+GMT_LOCAL void plot_cycle (struct GMT_CTRL *GMT, double x, double y, double width) {
 	double vdim[PSL_MAX_DIMS], s = width / 0.1, p_width;
 	struct GMT_SYMBOL S;
 	struct GMT_FILL black;


### PR DESCRIPTION
Moving a bunch of functions (~20-30) from external to internal since they are only used within a single file and thus should not be exported.
