### PR TITLE
Only lines and polygons can use Bezier spline mode

### DIFF
--- a/doc/rst/source/plot3d_notes.rst_
+++ b/doc/rst/source/plot3d_notes.rst_
@@ -39,6 +39,13 @@ circles) can be designed - these polygons can be painted and filled with
 a pattern. Other standard geometric symbols can also be used. See Appendix
 :ref:`App-custom_symbols` for macro definitions.
 
+Bezier spline
+-------------
+
+The **+s** modifier to pen settings (**-W**) is limited to plotting lines and
+polygons.  Lines with embellishments (fronts, decorated, or quoted lines) are
+excluded.
+
 Auto-Legend
 -----------
 

--- a/doc/rst/source/plot_notes.rst_
+++ b/doc/rst/source/plot_notes.rst_
@@ -67,6 +67,13 @@ problem by splitting polygons into a west and east polygon or inserting
 artificial helper lines that makes a cut into the pole and back.  Such
 doctored polygons may be misrepresented in GMT.
 
+Bezier spline
+-------------
+
+The **+s** modifier to pen settings (**-W**) is limited to plotting lines and
+polygons.  Lines with embellishments (fronts, decorated, or quoted lines) are
+excluded.
+
 Auto-Legend
 -----------
 

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1972,6 +1972,10 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 							GMT_Report (API, GMT_MSG_INFORMATION, "Segment header contained -S%s - ignored\n", s_args);
 					}
 				}
+				if (current_pen.mode == PSL_BEZIER && (S.symbol == GMT_SYMBOL_DECORATED_LINE || S.symbol == GMT_SYMBOL_QUOTED_LINE || S.symbol == GMT_SYMBOL_FRONT)) {
+					GMT_Report (API, GMT_MSG_WARNING, "Bezier spline mode (modifier +s) is not supported for fronts, quoted, or decorated lines - mode ignored\n");
+					current_pen.mode = PSL_LINEAR;
+				}
 				if (S.symbol == GMT_SYMBOL_DECORATED_LINE) {
 					s_args[0] = '\0';	/* Recycle this string for this purpose */
 					strcat (s_args, " -G");

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1709,6 +1709,10 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 							GMT_Report (API, GMT_MSG_INFORMATION, "Segment header contained -S%s - ignored\n", s_args);
 					}
 				}
+				if (current_pen.mode == PSL_BEZIER && (S.symbol == GMT_SYMBOL_DECORATED_LINE || S.symbol == GMT_SYMBOL_QUOTED_LINE || S.symbol == GMT_SYMBOL_FRONT)) {
+					GMT_Report (API, GMT_MSG_WARNING, "Bezier spline mode (modifier +s) is not supported for fronts, quoted, or decorated lines - mode ignored\n");
+					current_pen.mode = PSL_LINEAR;
+				}
 				if (S.fq_parse) { /* Did not supply -Sf or -Sq in the segment header */
 					if (S.symbol == GMT_SYMBOL_QUOTED_LINE) /* Did not supply -Sf in the segment header */
 						GMT_Report (API, GMT_MSG_ERROR, "Segment header did not supply enough parameters for -Sf; skipping this segment\n");


### PR DESCRIPTION
Check for exceptions and clarify the documentation on what modifier **+s** to pen selections can be used for.  Closes #2993.
