### PR TITLE
Let positively defined front gaps be used exactly as given

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -70,10 +70,12 @@
         the desired diameter to **-SE-** and this fixed diameter is used instead.
 	For allowable geographical units, see `Units`_ [Default is k for km].
 
-    **-Sf**\ *gap*\ [/*size*][**+l**\|\ **+r**][**+b+c+f+s+t**][**+o**\ *offset*][**+p**\ [*pen*]].
+    **-Sf**\ [±]\ *gap*\ [/*size*][**+l**\|\ **+r**][**+b+c+f+s+t**][**+o**\ *offset*][**+p**\ [*pen*]].
         Draw a **f**\ ront. Supply distance *gap* between symbols and symbol *size*. If *gap* is
         negative, it is interpreted to mean the number of symbols along the
-        front instead. If *size* is missing it is set to 30% of the *gap*, except
+        front instead. If *gap* has a leading + then we use the value exactly as given
+        [Default will start and end each line with a symbol, hence the *gap* is adjusted to fit].
+        If *size* is missing it is set to 30% of the *gap*, except
         when *gap* is negative and *size* is thus required.  Append **+l** or
         **+r** to plot symbols on the left or
         right side of the front [Default is centered]. Append **+**\ *type* to

--- a/doc/rst/source/explain_symbols2.rst_
+++ b/doc/rst/source/explain_symbols2.rst_
@@ -70,10 +70,12 @@
 	the desired diameter to **-SE-** and this fixed diameter is used instead.
 	For allowable geographical units, see `Units`_ [Default is k for km].
 
-    **-Sf**\ *gap*\ [/*size*][**+l**\|\ **+r**][**+b+c+f+s+t**][**+o**\ *offset*][**+p**\ [*pen*]].
-        Draw a **f**\ ront.  Supply distance gap between symbols and symbol size. If *gap* is
+    **-Sf**\ [±]\ *gap*\ [/*size*][**+l**\|\ **+r**][**+b+c+f+s+t**][**+o**\ *offset*][**+p**\ [*pen*]].
+        Draw a **f**\ ront.  Supply distance *gap* between symbols and symbol size. If *gap* is
         negative, it is interpreted to mean the number of symbols along the
-        front instead. If *size* is missing it is set to 30% of the *gap*, except
+        front instead. If *gap* has a leading + then we use the value exactly as given
+        [Default will start and end each line with a symbol, hence the *gap* is adjusted to fit].
+        If *size* is missing it is set to 30% of the *gap*, except
         when *gap* is negative and *size* is thus required.  Append **+l** or
         **+r** to plot symbols on the left or
         right side of the front [Default is centered]. Append **+**\ *type* to

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -5224,17 +5224,20 @@ GMT_LOCAL int gmtinit_get_unit (struct GMT_CTRL *GMT, char c) {
 
 /*! . */
 GMT_LOCAL int gmtinit_parse_front (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL *S) {
-	/* Parser for -Sf<tickgap>[/<ticklen>][+l|+r][+<type>][+o<offset>][+p<pen>]
+	/* Parser for -Sf[+|-]<tickgap>[/<ticklen>][+l|+r][+<type>][+o<offset>][+p<pen>]
 	 * <tickgap> is required and is either a distance in some unit (append c|i|p)
 	 * or it starts with - and gives the number of desired ticks instead.
 	 * <ticklen> defaults to 15% of <tickgap> but is required if the number
-	 * of ticks are specified. */
+	 * of ticks are specified. If + is prepended to <tickgap> then we use that
+	 * gap distance as given [Default distributes n gaps evenly along length] */
 
-	unsigned int pos = 0, k, error = 0;
+	unsigned int pos = 0, k, k0 = 1, error = 0;
 	int mods, n;
 	char p[GMT_BUFSIZ] = {""}, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""};
 
-	for (k = 0; text[k] && text[k] != '+'; k++);	/* Either find the first plus or run out or chars */
+	/* text[0] is the leading 'f' for front */
+	if (text[1] == '+' && !strchr ("bcflrsStop", text[2])) S->f.f_exact = true, k0 = 2;	/* Special leading = to be skipped when looking for modifiers */
+	for (k = k0; text[k] && text[k] != '+'; k++);	/* Either find the first plus or run out or chars */
 	strncpy (p, text, k); p[k] = 0;
 	mods = (text[k] == '+');
 	if (mods) text[k] = 0;		/* Temporarily chop off the modifiers */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -5236,7 +5236,7 @@ GMT_LOCAL int gmtinit_parse_front (struct GMT_CTRL *GMT, char *text, struct GMT_
 	char p[GMT_BUFSIZ] = {""}, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""};
 
 	/* text[0] is the leading 'f' for front */
-	if (text[1] == '+' && !strchr ("bcflrsStop", text[2])) S->f.f_exact = true, k0 = 2;	/* Special leading = to be skipped when looking for modifiers */
+	if (text[1] == '+' && !strchr ("bcflrsStop", text[2])) S->f.f_exact = true, k0 = 2;	/* Special leading + to be skipped when looking for modifiers */
 	for (k = k0; text[k] && text[k] != '+'; k++);	/* Either find the first plus or run out or chars */
 	strncpy (p, text, k); p[k] = 0;
 	mods = (text[k] == '+');

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -8739,11 +8739,18 @@ void gmt_draw_front (struct GMT_CTRL *GMT, double x[], double y[], uint64_t n, s
 		s[i] = s[i-1] + hypot (dx, y[i] - y[i-1]);
 	}
 
-	if (f->f_gap > 0.0) {	/* Gave positive interval; adjust so we start and end with a tick on each line */
-		ngap = irint (s[n-1] / f->f_gap);
-		gap = s[n-1] / ngap;
+	if (f->f_gap > 0.0) {	/* Gave positive interval */
+		if (f->f_exact) {	/* Use gap exactly as given, not worry about ending line with tick */
+			ngap = floor ((s[n-1] * (1.0 + GMT_CONV6_LIMIT)) / f->f_gap);	/* Allow 1 ppm noise since we use floor */
+			gap = f->f_gap;	/* As given */
+		}
+		else {	/* Adjust so we start and end with a tick on each line */
+			ngap = irint (s[n-1] / f->f_gap);
+			gap = s[n-1] / ngap;	/* Adjust gap to fit line length */
+			ngap++;
+		}
 		dist = f->f_off;	/* Start off at the offset distance [0] */
-		ngap++;
+		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Given gap: %g Adjusted gap: %g Number of front gaps: %d\n", f->f_gap, gap, ngap);
 	}
 	else {	/* Gave negative interval which means the # of ticks required */
 		ngap = irint (fabs (f->f_gap));
@@ -8755,6 +8762,7 @@ void gmt_draw_front (struct GMT_CTRL *GMT, double x[], double y[], uint64_t n, s
 			dist = 0.5 * s[n-1], gap = s[n-1];
 		else		/* Equidistantly spaced tick starting at 1st point and ending at last */
 			gap = s[n-1] / (ngap - 1);
+		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Given number of front gaps: %d Computed gap: %g\n", ngap, gap);
 	}
 
 	len2 = 0.5 * f->f_len;

--- a/src/gmt_plot.h
+++ b/src/gmt_plot.h
@@ -88,6 +88,7 @@ struct GMT_FRONTLINE {
 	double f_len;		/* Length of front symbols in inches */
 	double f_off;		/* Offset of first symbol from start of front in inches */
 	double f_angle;		/* Angle of the slip vector hook [30] */
+	bool f_exact;		/* Take given positive gap exactly [Default will adjust gap to distribute evenly along length of front] */
 	int f_sense;		/* Draw symbols to left (+1), centered (0), or right (-1) of line */
 	int f_symbol;		/* Which symbol to draw along the front line */
 	int f_pen;		/* -1 for no outline (+p), 0 for default outline [-1], +1 if +p<pen> was used to set separate pen for outline */

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -481,6 +481,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     For linear projection we scale dimensions by the map scale.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Fronts: Give <tickgap>[/<ticklen>][+l|r][+<type>][+o<offset>][+p[<pen>]].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     If <tickgap> is negative it means the number of gaps instead.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     If <tickgap> has leading + then <tickgap> is used exactly [adjusted to fit line length].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     The <ticklen> defaults to 15%% of <tickgap> if not given.  Append\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     +l or +r   : Plot symbol to left or right of front [centered]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     +<type>    : +b(ox), +c(ircle), +f(ault), +s|S(lip), +t(riangle) [f]\n");

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -232,6 +232,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     For a linear projection we scale dimensions by the map scale.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Fronts: Give <tickgap>[/<ticklen>][+l|r][+<type>][+o<offset>][+p[<pen>]].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     If <tickgap> is negative it means the number of gaps instead.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     If <tickgap> has leading + then <tickgap> is used exactly [adjusted to fit line length].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     The <ticklen> defaults to 15%% of <tickgap> if not given.  Append\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     +l or +r   : Plot symbol to left or right of front [centered]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     +<type>    : +b(ox), +c(ircle), +f(ault), +s|S(lip), +t(riangle) [f]\n");


### PR DESCRIPTION
If the front gap is specified with an explicit plus-symbol then we take that to mean the gap should be used as given.  The default remains to distribute front symbols exactly along the line and thus adjust the gap accordingly.  See #2995 for context.
