### PR TITLE
Avoid separate file with gridline spacing

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -2843,7 +2843,7 @@ GMT_LOCAL int gmtinit_get_history (struct GMT_CTRL *GMT) {
 			if (option[1] == 'C')	/* Read clip level */
 				GMT->current.ps.clip_level = atoi (value);
 			else if (option[1] == 'G')	/* Read gridline spacings */
-				sscanf (value, "%lg %lg", &GMT->current.plot.gridline_spacing[GMT_X], &GMT->current.plot.gridline_spacing[GMT_Y]);	/* Read last gridline spacing */
+				sscanf (value, "%lg %lg", &GMT->current.plot.gridline_spacing[GMT_X], &GMT->current.plot.gridline_spacing[GMT_Y]);
 			else if (option[1] == 'L')	/* Read PS layer */
 				GMT->current.ps.layer = atoi (value);
 			continue;

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -8148,7 +8148,7 @@ void gmt_plotend (struct GMT_CTRL *GMT) {
 	GMT->current.ps.title[0] = '\0';	/* Reset title */
 	if (GMT->current.ps.oneliner) GMT->current.ps.active = true;	/* Since we are plotting we reset this here in case other modules have turned it off */
 
-	if (!K_active) GMT->current.plot.gridline_spacing[GMT_X]= GMT->current.plot.gridline_spacing[GMT_Y] = 0.0;	/* Done, if ever used */
+	if (!K_active) GMT->current.plot.gridline_spacing[GMT_X] = GMT->current.plot.gridline_spacing[GMT_Y] = 0.0;	/* Done, if they ever were used */
 #if 0
 	if (GMT->current.setting.run_mode == GMT_CLASSIC) {	/* Remove any gridline file we may have made in /tmp */
 		char file[PATH_MAX] = {""};

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7812,13 +7812,13 @@ void gmt_save_current_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, unsigned
 
 char * gmt_get_current_item (struct GMT_CTRL *GMT, const char *item, bool strict) {
 	/* If modern and a current item file exists, allocate a string with its name and return, else NULL.
-	 * Currently, item can be cpt or grid (gridlines).
+	 * Currently, item can be cpt.
 	 * if strict is true the file must be available for the current item, otherwise we may look up the hierarchical chain */
 	char path[PATH_MAX] = {""}, panel[GMT_LEN16] = {""}, *file = NULL;
 	int fig, subplot, inset;
 
 	if (GMT->current.setting.run_mode == GMT_CLASSIC) {	/* A few more checks */
-		if (!strncmp (item, "cpt", 3U)) return NULL;	/* Current CPT cocept not available in classic mode */
+		if (!strncmp (item, "cpt", 3U)) return NULL;	/* Current CPT concept not available in classic mode */
 		/* For gridlines we must use a global file in the tmp dir */
 		snprintf (path, PATH_MAX, "%s/%s-gmt.%s", GMT->parent->tmp_dir, GMT->parent->session_name, item);
 		if (!access (path, R_OK)) file = strdup (path);	/* Yes, found it */

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -329,6 +329,7 @@ struct GMT_PLOT {		/* Holds all plotting-related parameters */
 	/* The rest of the struct contains pointers that may point to memory not included by this struct */
 	double *x;			/* Holds the x/y (inches) of a line to be plotted */
 	double *y;
+	double gridline_spacing[2];		/* Holds last gridline spacing used for this plot, via gmt.history */
 	char format[3][2][GMT_LEN256];	/* Keeps the 6 formats for dd:mm:ss plot output */
 	struct GMT_SUBPLOT panel;	/* Current subplot panel settings */
 	struct GMT_INSET inset;		/* Current inset settings */


### PR DESCRIPTION
The new gridline tick feature requires us to know the past regular gridline spacings.  Initialy, I implemented this via a separate gridline save file.  However, this meant that every plot that drew gridlines but not gridticks ended up writing a file and then deleting it without every being needed; e.g., see #2989 .  This PR places that information in the gmt.history which is always read and written, so no separate file is necessary.  Closes #2989.

