### PR TITLE
Disable unit scramble for virtual files

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -479,5 +479,6 @@
                 Specifies how many (*x*,\ *y*) points will be used to estimate
                 symbol angles [Default is 10].
 
+        If neither **+g** nor **+p** are set we select the default pen outline (:term:`MAP_DEFAULT_PEN`.
         **Note**: By placing **-S~** options in the segment header you can change
         the decorated lines on a segment-by-segment basis.

--- a/doc/rst/source/explain_symbols2.rst_
+++ b/doc/rst/source/explain_symbols2.rst_
@@ -490,5 +490,6 @@
                 Specifies how many (*x*,\ *y*) points will be used to estimate
                 symbol angles [Default is 10].
 
+        If neither **+g** nor **+p** are set we select the default pen outline (:term:`MAP_DEFAULT_PEN`.
         **Note**: By placing **-S~** options in the segment header you can change
         the decorated lines on a segment-by-segment basis.

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -6682,6 +6682,7 @@ int GMT_End_IO (void *V_API, unsigned int direction, unsigned int mode) {
 	else {	/* Input files were closed when we tried to go to next item */
 		if (API->current_get_V_val) gmt_M_free (API->GMT, API->current_get_V_val);
 	}
+	API->is_file = true;
 	API->io_enabled[direction] = false;	/* No longer OK to access resources or destinations */
 	API->current_rec[direction] = 0;	/* Reset count for next time */
 	for (item = 0; item < API->n_objects; item++) {	/* Deselect the used resources */
@@ -7795,6 +7796,7 @@ GMT_LOCAL void api_get_record_init (struct GMTAPI_CTRL *API) {
 		return;
 	}
 	API->error = GMT_NOERROR;
+	API->is_file = false;
 	S = API->current_get_obj;	/* Shorthand for the current data source we are working on */
 	GMT = API->GMT;			/* Shorthand for GMT access */
 	/* Reset to default association for current record's data and text pointers */
@@ -7811,6 +7813,7 @@ GMT_LOCAL void api_get_record_init (struct GMTAPI_CTRL *API) {
 			API->api_get_record = api_get_record_fp_first;
 			GMT->current.io.first_rec = true;
 			gmtlib_reset_input (GMT);	/* Go back to being agnostic about number of columns, etc. */
+			API->is_file = true;
 			break;
 
 		case GMT_IS_DUPLICATE|GMT_VIA_MATRIX:	/* Here we copy/read from a user memory location which is a matrix */

--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -142,6 +142,7 @@ struct GMTAPI_CTRL {
 	bool module_input;			/* true when we are about to read inputs to the module (command line) */
 	bool usage;				/* Flag when 1-liner modern mode modules just want usage */
 	bool allow_reuse;				/* Flag when get_region_from_data can read a file and not flag it as "used" */
+	bool is_file;					/* True if current rec-by-rec i/o is from a physical file */
 	size_t n_objects_alloc;			/* Allocation counter for data objects */
 	int error;				/* Error code from latest API call [GMT_OK] */
 	int last_error;				/* Error code from previous API call [GMT_OK] */
@@ -162,7 +163,7 @@ struct GMTAPI_CTRL {
 	bool internal;				/* true if session was initiated by gmt.c */
 	bool deep_debug;			/* temporary for debugging */
 	int (*print_func) (FILE *, const char *);	/* Pointer to fprintf function (may be reset by external APIs like MEX) */
-	unsigned int do_not_exit;		/* 0 by default, mieaning it is OK to call exit  (may be reset by external APIs like MEX to call return instead) */
+	unsigned int do_not_exit;		/* 0 by default, meaning it is OK to call exit  (may be reset by external APIs like MEX to call return instead) */
 	struct Gmt_libinfo *lib;		/* List of shared libs to consider */
 	unsigned int n_shared_libs;		/* How many in lib */
 	/* Items used by GMT_Put_Record and sub-functions */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -9523,7 +9523,7 @@ int gmtlib_decorate_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_DECORATE 
 				if (k == 0) bad++;
 				break;
 
-			case 'p':	/* Draw text box outline [with optional textbox pen specification] */
+			case 'p':	/* Set symbol outline specification */
 				if (p[1]) strncpy (G->pen, &p[1], GMT_LEN64-1);
 				break;
 
@@ -9563,6 +9563,9 @@ int gmtlib_decorate_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_DECORATE 
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "No symbol size specified!\n");
 		bad++;
 	}
+	if (G->fill[0] == '\0' && G->pen[0] == '\0')	/* Neither fill nor pen - select default outline */
+		sprintf (G->pen, "%s", gmt_putpen (GMT, &GMT->current.setting.map_default_pen));
+
 	return (bad);
 }
 

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1007,7 +1007,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 	 * angles via the input data file.  S.n_nondim and S.nondim_col are used to reset the in_col_type back to GMT_IS_FLOAT
 	 * for those columns are expected to contain angles.  When NO SYMBOL is specified in -S we must parse the ASCII data
 	 * record to determine the symbol, and this happens AFTER we have already converted the dimensions.  We must therefore
-	 * undo this scaling based on what columns might be angles. */
+	 * undo this scaling based on what columns might be angles. Exception: When input is a virtual file. */
 
 	/* Extra columns 1, 2 and 3 */
 	ex1 = (rgb_from_z) ? 3 : 2;
@@ -1276,7 +1276,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 				QR_symbol = (S.symbol == GMT_SYMBOL_CUSTOM && (!strcmp (S.custom->name, "QR") || !strcmp (S.custom->name, "QR_transparent")));
 				/* Since we only now know if some of the input columns should NOT be considered dimensions we
 				 * must visit such columns and if the current length unit is NOT inch then we must undo the scaling */
-				if (S.n_nondim && GMT->current.setting.proj_length_unit != GMT_INCH) {	/* Since these are not dimensions but angles or other quantities */
+				if (S.n_nondim && API->is_file && GMT->current.setting.proj_length_unit != GMT_INCH) {	/* Since these are not dimensions but angles or other quantities */
 					for (j = 0; j < S.n_nondim; j++) in[S.nondim_col[j]+rgb_from_z] *= GMT->session.u2u[GMT_INCH][GMT->current.setting.proj_length_unit];
 				}
 

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1012,7 +1012,7 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 				}
 				/* Since we only now know if some of the input columns should NOT be considered dimensions we
 				 * must visit such columns and if the current length unit is NOT inch then we must undo the scaling */
-				if (S.n_nondim && GMT->current.setting.proj_length_unit != GMT_INCH) {	/* Since these are not dimensions but angles or other quantities */
+				if (S.n_nondim && API->is_file && GMT->current.setting.proj_length_unit != GMT_INCH) {	/* Since these are not dimensions but angles or other quantities */
 					for (j = 0; j < S.n_nondim; j++) in[S.nondim_col[j]+rgb_from_z] *= GMT->session.u2u[GMT_INCH][GMT->current.setting.proj_length_unit];
 				}
 


### PR DESCRIPTION
The angles determined for decorated symbols placed along the line got multiplied by 2.54 because we were trying to defeat the automatic scaling during reading from files.  But here we are reading from a _virtual_ file and no scaling should take place.  This addresses the [concern](https://forum.generic-mapping-tools.org/t/proper-usage-of-s/338/4) reported by @KristofKoch.  I also let the decorated symbols get drawn by the default pen if nether fill nor pen was chosen by user; otherwise nothing is plotted and that confuses the user.
