### PR TITLE
Decorated lines with custom symbol

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -472,8 +472,9 @@
                 optionally specify pen for outline [Default is width = 0.25p,
                 color = black, style = solid].
 
-            **+s**\ <symbol><size>
+            **+s**\ <symbol><size> or **+sk**\ *customsymbol*/*size*
                 Specifies the code and size of the decorative symbol.
+                Custom symbols need to be simple, i.e., not require data columns.
 
             **+w**
                 Specifies how many (*x*,\ *y*) points will be used to estimate

--- a/doc/rst/source/explain_symbols2.rst_
+++ b/doc/rst/source/explain_symbols2.rst_
@@ -483,8 +483,9 @@
                 optionally specify pen for outline [Default is width = 0.25p,
                 color = black, style = solid].
 
-            **+s**\ <symbol><size>
+            **+s**\ <symbol><size> or **+sk**\ *customsymbol*/*size*
                 Specifies the code and size of the decorative symbol.
+                Custom symbols need to be simple, i.e., not require data columns.
 
             **+w**
                 Specifies how many (*x*,\ *y*) points will be used to estimate

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -304,6 +304,11 @@ enum GMT_enum_autolegend {
 	GMT_LEGEND_PEN_D  = 0, GMT_LEGEND_PEN_V  = 1,
 	GMT_LEGEND_DRAW_D = 1, GMT_LEGEND_DRAW_V = 2};
 
+/*! Various mode for custom symbols */
+enum GMT_enum_customsymb {
+	GMT_CUSTOM_DEF  = 1,
+	GMT_CUSTOM_EPS  = 2};
+
 //#define GMT_LEGEND_DX1_MUL 1.0	/* Default offset from margin to center of symbol if given as '-' times max symbol size */
 //#define GMT_LEGEND_DX2_MUL 2.0	/* Default offset from margin to start of label if given as '-' times max symbol size */
 #define GMT_LEGEND_DX1_MUL 0.5	/* Default offset from margin to center of symbol if given as '-' times max symbol size */

--- a/src/gmt_decorate.h
+++ b/src/gmt_decorate.h
@@ -69,7 +69,7 @@ struct GMT_DECORATE {
 	char size[GMT_LEN64];		/* The symbol size */
 	char fill[GMT_LEN64];		/* The symbol fill */
 	char pen[GMT_LEN64];		/* The symbol outline pen */
-	char symbol_code[GMT_LEN64];		/* The symbol code only as a null-terminated string */
+	char symbol_code[GMT_LEN64];	/* The symbol code only as a null-terminated string */
 	char flag;			/* Char for the option key */
 	struct GMT_DATASET *X;		/* Dataset with list of structures with crossing-line coordinates */
 	struct GMT_XSEGMENT *ylist_XP;	/* Sorted y-segments for crossing-lines */

--- a/src/gmt_decorate.h
+++ b/src/gmt_decorate.h
@@ -69,7 +69,7 @@ struct GMT_DECORATE {
 	char size[GMT_LEN64];		/* The symbol size */
 	char fill[GMT_LEN64];		/* The symbol fill */
 	char pen[GMT_LEN64];		/* The symbol outline pen */
-	char symbol_code[2];		/* The symbol code only as a null-terminated string */
+	char symbol_code[GMT_LEN64];		/* The symbol code only as a null-terminated string */
 	char flag;			/* Char for the option key */
 	struct GMT_DATASET *X;		/* Dataset with list of structures with crossing-line coordinates */
 	struct GMT_XSEGMENT *ylist_XP;	/* Sorted y-segments for crossing-lines */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -343,6 +343,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC int gmt_locate_custom_symbol (struct GMT_CTRL *GMT, const char *in_name, char *name, char *path, unsigned int *pos);
 EXTERN_MSC unsigned int gmt_set_interpolate_mode (struct GMT_CTRL *GMT, unsigned int mode, unsigned int type);
 EXTERN_MSC unsigned int gmt_get_dist_units (struct GMT_CTRL *GMT, char *args, char *unit, unsigned int *mode);
 EXTERN_MSC unsigned int gmt_validate_cpt_parameters (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, char *file, bool *interpolate, bool *force_continuous);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -9570,7 +9570,7 @@ int gmtlib_decorate_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_DECORATE 
 				break;
 
 			default:
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Modifier +%s not recognized!\n", p);
+				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -S~: Modifier +%s not recognized!\n", p);
 				bad++;
 				break;
 		}

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4692,13 +4692,13 @@ int gmt_locate_custom_symbol (struct GMT_CTRL *GMT, const char *in_name, char *n
 			*pos = gmt_download_file_if_not_found (GMT, file, 0);	/* Deal with downloadable GMT data sets first */
 		if (gmt_getsharepath (GMT, "custom", &name[*pos], ".eps", path, R_OK) || gmtlib_getuserpath (GMT, &file[*pos], path)) {
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Found EPS macro %s\n", path);
-			type = 2;
+			type = GMT_CUSTOM_EPS;
 		}
 		else
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not find either custom symbol or EPS macro %s\n", name);
 	}
 	else {
-		type = 1;
+		type = GMT_CUSTOM_DEF;
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Found custom symbol %s\n", path);
 	}
 	return (type);
@@ -4723,11 +4723,9 @@ GMT_LOCAL int support_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name, s
 	struct GMT_CUSTOM_SYMBOL *head = NULL;
 	struct stat buf;
 	struct GMT_CUSTOM_SYMBOL_ITEM *s = NULL, *previous = NULL;
-	bool got_EPS = false;
 
 	if ((type = gmt_locate_custom_symbol (GMT, in_name, name, path, &pos)) == 0) return GMT_RUNTIME_ERROR;
-	if (type == 2) {
-		got_EPS = true;
+	if (type == GMT_CUSTOM_EPS) {
 		if (stat (path, &buf)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not determine size of EPS macro %s\n", path);
 			GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
@@ -4742,7 +4740,7 @@ GMT_LOCAL int support_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name, s
 	head = gmt_M_memory (GMT, NULL, 1, struct GMT_CUSTOM_SYMBOL);
 	strncpy (head->name, basename (&name[pos]), GMT_LEN64-1);
 	while (fgets (buffer, GMT_BUFSIZ, fp)) {
-		if (got_EPS) {	/* Working on an EPS symbol, just append the text as is */
+		if (type == GMT_CUSTOM_EPS) {	/* Working on an EPS symbol, just append the text as is */
 			if (head->PS == 0) {	/* Allocate memory for the EPS symbol */
 				head->PS_macro = gmt_M_memory (GMT, NULL, (size_t)buf.st_size, char);
 				head->PS = 1;	/* Flag to indicate we already allocated memory */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -9570,6 +9570,7 @@ int gmtlib_decorate_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_DECORATE 
 				break;
 
 			default:
+				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Modifier +%s not recognized!\n", p);
 				bad++;
 				break;
 		}

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -317,6 +317,10 @@ GMT_LOCAL int plot_decorations (struct GMT_CTRL *GMT, struct GMT_DATASET *D, cha
 		bool first = true;
 		while (fgets (buffer, GMT_BUFSIZ, fpc)) {
 			if (buffer[0] == '#') { fprintf (fp, "%s", buffer); continue; }	/* Pass comments */
+			if (!strncmp (buffer, "N: ", 3U)) {
+				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot use custom symbols that expect extra parameters: %s\n", name);
+				return (GMT_RUNTIME_ERROR);
+			}
 			if (first) {	/* Insert our count and rotation as first actionable macro command */
 				fprintf (fp, "# Rotated custom symbol, read size and rotation from data file\nN: 1 o\n$1 R\n");
 				first = false;

--- a/test/psxy/custom_decorate.ps
+++ b/test/psxy/custom_decorate.ps
@@ -1,0 +1,1988 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.1.0_58d597c-dirty_2020.04.02 [64-bit] Document from psxy
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Thu Apr  2 18:32:52 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt psxy path.txt -S~d2c:+sklcrescent/60p+gred+pthin -W0.25p -R-2/2/-1/1.2 -JM15c
+%@PROJ: merc -2.00000000 2.00000000 -1.00000000 1.20000000 -222638.982 222638.982 -110579.965 132698.963 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+4 W
+clipsave
+0 0 M
+7087 0 D
+0 3872 D
+-7087 0 D
+P
+PSL_clip N
+886 0 M
+80 79 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+45 43 D
+35 36 D
+27 26 D
+8 9 D
+23 11 D
+157 78 D
+157 78 D
+134 67 D
+45 22 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+258 128 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+258 128 D
+157 78 D
+157 78 D
+101 50 D
+134 67 D
+23 11 D
+134 67 D
+23 11 D
+56 28 D
+S
+PSL_cliprestore
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt psxy -R0/5.90551/0/3.22649 -Jx1i -O -K -Sk/tmp/GMT_symbol3149 @GMTAPI@-S-I-D-D-T-N-000001 --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 5.90551000 0.00000000 3.22649000 0.000 5.906 0.000 3.226 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+7087 0 D
+0 3872 D
+-7087 0 D
+P
+PSL_clip N
+4 W
+V
+{1 0 0 C} FS
+O1
+12 W
+V 1556 666 T
+44.8086 R
+250 500 M
+-13 0 D
+-12 -1 D
+-13 0 D
+-12 -2 D
+-13 -1 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-12 -3 D
+-12 -3 D
+-12 -3 D
+-13 -4 D
+-11 -3 D
+-12 -5 D
+-12 -4 D
+-12 -5 D
+-11 -5 D
+-12 -5 D
+-22 -12 D
+-22 -13 D
+-21 -13 D
+-40 -31 D
+-45 -43 D
+-39 -49 D
+-27 -43 D
+-23 -45 D
+-18 -46 D
+-15 -61 D
+-7 -50 D
+-2 -38 D
+1 -37 D
+4 -38 D
+9 -49 D
+10 -37 D
+18 -46 D
+29 -56 D
+28 -42 D
+32 -39 D
+45 -43 D
+40 -31 D
+43 -26 D
+22 -12 D
+59 -24 D
+60 -16 D
+62 -9 D
+38 -1 D
+-32 20 D
+-31 22 D
+-48 41 D
+-43 46 D
+-37 50 D
+-27 43 D
+-27 57 D
+-21 59 D
+-14 62 D
+-5 37 D
+-4 63 D
+5 75 D
+9 50 D
+13 49 D
+22 59 D
+22 45 D
+27 43 D
+37 50 D
+43 46 D
+58 49 D
+42 28 D
+P
+FO
+U
+V 2227 1332 T
+44.8114 R
+250 500 M
+-13 0 D
+-12 -1 D
+-13 0 D
+-12 -2 D
+-13 -1 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-12 -3 D
+-12 -3 D
+-12 -3 D
+-13 -4 D
+-11 -3 D
+-12 -5 D
+-12 -4 D
+-12 -5 D
+-11 -5 D
+-12 -5 D
+-22 -12 D
+-22 -13 D
+-21 -13 D
+-40 -31 D
+-45 -43 D
+-39 -49 D
+-27 -43 D
+-23 -45 D
+-18 -46 D
+-15 -61 D
+-7 -50 D
+-2 -38 D
+1 -37 D
+4 -38 D
+9 -49 D
+10 -37 D
+18 -46 D
+29 -56 D
+28 -42 D
+32 -39 D
+45 -43 D
+40 -31 D
+43 -26 D
+22 -12 D
+59 -24 D
+60 -16 D
+62 -9 D
+38 -1 D
+-32 20 D
+-31 22 D
+-48 41 D
+-43 46 D
+-37 50 D
+-27 43 D
+-27 57 D
+-21 59 D
+-14 62 D
+-5 37 D
+-4 63 D
+5 75 D
+9 50 D
+13 49 D
+22 59 D
+22 45 D
+27 43 D
+37 50 D
+43 46 D
+58 49 D
+42 28 D
+P
+FO
+U
+V 2960 1910 T
+26.4183 R
+250 500 M
+-13 0 D
+-12 -1 D
+-13 0 D
+-12 -2 D
+-13 -1 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-12 -3 D
+-12 -3 D
+-12 -3 D
+-13 -4 D
+-11 -3 D
+-12 -5 D
+-12 -4 D
+-12 -5 D
+-11 -5 D
+-12 -5 D
+-22 -12 D
+-22 -13 D
+-21 -13 D
+-40 -31 D
+-45 -43 D
+-39 -49 D
+-27 -43 D
+-23 -45 D
+-18 -46 D
+-15 -61 D
+-7 -50 D
+-2 -38 D
+1 -37 D
+4 -38 D
+9 -49 D
+10 -37 D
+18 -46 D
+29 -56 D
+28 -42 D
+32 -39 D
+45 -43 D
+40 -31 D
+43 -26 D
+22 -12 D
+59 -24 D
+60 -16 D
+62 -9 D
+38 -1 D
+-32 20 D
+-31 22 D
+-48 41 D
+-43 46 D
+-37 50 D
+-27 43 D
+-27 57 D
+-21 59 D
+-14 62 D
+-5 37 D
+-4 63 D
+5 75 D
+9 50 D
+13 49 D
+22 59 D
+22 45 D
+27 43 D
+37 50 D
+43 46 D
+58 49 D
+42 28 D
+P
+FO
+U
+V 3806 2330 T
+26.4165 R
+250 500 M
+-13 0 D
+-12 -1 D
+-13 0 D
+-12 -2 D
+-13 -1 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-12 -3 D
+-12 -3 D
+-12 -3 D
+-13 -4 D
+-11 -3 D
+-12 -5 D
+-12 -4 D
+-12 -5 D
+-11 -5 D
+-12 -5 D
+-22 -12 D
+-22 -13 D
+-21 -13 D
+-40 -31 D
+-45 -43 D
+-39 -49 D
+-27 -43 D
+-23 -45 D
+-18 -46 D
+-15 -61 D
+-7 -50 D
+-2 -38 D
+1 -37 D
+4 -38 D
+9 -49 D
+10 -37 D
+18 -46 D
+29 -56 D
+28 -42 D
+32 -39 D
+45 -43 D
+40 -31 D
+43 -26 D
+22 -12 D
+59 -24 D
+60 -16 D
+62 -9 D
+38 -1 D
+-32 20 D
+-31 22 D
+-48 41 D
+-43 46 D
+-37 50 D
+-27 43 D
+-27 57 D
+-21 59 D
+-14 62 D
+-5 37 D
+-4 63 D
+5 75 D
+9 50 D
+13 49 D
+22 59 D
+22 45 D
+27 43 D
+37 50 D
+43 46 D
+58 49 D
+42 28 D
+P
+FO
+U
+V 4652 2751 T
+26.4129 R
+250 500 M
+-13 0 D
+-12 -1 D
+-13 0 D
+-12 -2 D
+-13 -1 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-12 -3 D
+-12 -3 D
+-12 -3 D
+-13 -4 D
+-11 -3 D
+-12 -5 D
+-12 -4 D
+-12 -5 D
+-11 -5 D
+-12 -5 D
+-22 -12 D
+-22 -13 D
+-21 -13 D
+-40 -31 D
+-45 -43 D
+-39 -49 D
+-27 -43 D
+-23 -45 D
+-18 -46 D
+-15 -61 D
+-7 -50 D
+-2 -38 D
+1 -37 D
+4 -38 D
+9 -49 D
+10 -37 D
+18 -46 D
+29 -56 D
+28 -42 D
+32 -39 D
+45 -43 D
+40 -31 D
+43 -26 D
+22 -12 D
+59 -24 D
+60 -16 D
+62 -9 D
+38 -1 D
+-32 20 D
+-31 22 D
+-48 41 D
+-43 46 D
+-37 50 D
+-27 43 D
+-27 57 D
+-21 59 D
+-14 62 D
+-5 37 D
+-4 63 D
+5 75 D
+9 50 D
+13 49 D
+22 59 D
+22 45 D
+27 43 D
+37 50 D
+43 46 D
+58 49 D
+42 28 D
+P
+FO
+U
+V 5498 3171 T
+26.4072 R
+250 500 M
+-13 0 D
+-12 -1 D
+-13 0 D
+-12 -2 D
+-13 -1 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-12 -3 D
+-12 -3 D
+-12 -3 D
+-13 -4 D
+-11 -3 D
+-12 -5 D
+-12 -4 D
+-12 -5 D
+-11 -5 D
+-12 -5 D
+-22 -12 D
+-22 -13 D
+-21 -13 D
+-40 -31 D
+-45 -43 D
+-39 -49 D
+-27 -43 D
+-23 -45 D
+-18 -46 D
+-15 -61 D
+-7 -50 D
+-2 -38 D
+1 -37 D
+4 -38 D
+9 -49 D
+10 -37 D
+18 -46 D
+29 -56 D
+28 -42 D
+32 -39 D
+45 -43 D
+40 -31 D
+43 -26 D
+22 -12 D
+59 -24 D
+60 -16 D
+62 -9 D
+38 -1 D
+-32 20 D
+-31 22 D
+-48 41 D
+-43 46 D
+-37 50 D
+-27 43 D
+-27 57 D
+-21 59 D
+-14 62 D
+-5 37 D
+-4 63 D
+5 75 D
+9 50 D
+13 49 D
+22 59 D
+22 45 D
+27 43 D
+37 50 D
+43 46 D
+58 49 D
+42 28 D
+P
+FO
+U
+U
+PSL_cliprestore
+%%EndObject
+%%EndObject
+0 A
+FQ
+O0
+0 2362 TM
+% PostScript produced by:
+%@GMT: gmt psxy path.txt -S~d2c:+skdeltoid/50p+pthin+gblue -W0,white -Y5c -R-2/2/-1/1.2 -JM15c
+%@PROJ: merc -2.00000000 2.00000000 -1.00000000 1.20000000 -222638.982 222638.982 -110579.965 132698.963 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+0 W
+1 A
+clipsave
+0 0 M
+7087 0 D
+0 3872 D
+-7087 0 D
+P
+PSL_clip N
+886 0 M
+80 79 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+45 43 D
+35 36 D
+27 26 D
+8 9 D
+23 11 D
+157 78 D
+157 78 D
+134 67 D
+45 22 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+258 128 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+258 128 D
+157 78 D
+157 78 D
+101 50 D
+134 67 D
+23 11 D
+134 67 D
+23 11 D
+56 28 D
+S
+PSL_cliprestore
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt psxy -R0/5.90551/0/3.22649 -Jx1i -O -K -Sk/tmp/GMT_symbol3150 @GMTAPI@-S-I-D-D-T-N-000001 --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 5.90551000 0.00000000 3.22649000 0.000 5.906 0.000 3.226 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+7087 0 D
+0 3872 D
+-7087 0 D
+P
+PSL_clip N
+4 W
+V
+{0 0 1 C} FS
+O1
+12 W
+V 1556 666 T
+44.8086 R
+-361 -208 M
+45 24 D
+35 16 D
+60 22 D
+62 17 D
+76 13 D
+64 4 D
+64 -1 D
+51 -5 D
+63 -11 D
+62 -17 D
+36 -13 D
+24 -9 D
+46 -22 D
+34 -18 D
+-54 34 D
+-41 31 D
+-48 43 D
+-27 27 D
+-33 39 D
+-16 20 D
+-29 42 D
+-38 67 D
+-21 47 D
+-29 85 D
+-14 62 D
+-9 76 D
+-2 39 D
+0 13 D
+-1 -39 D
+-6 -63 D
+-12 -63 D
+-10 -38 D
+-25 -72 D
+-21 -47 D
+-38 -67 D
+-37 -52 D
+-24 -30 D
+-35 -37 D
+-37 -35 D
+-40 -33 D
+-31 -22 D
+-22 -14 D
+P
+FO
+U
+V 2227 1332 T
+44.8114 R
+-361 -208 M
+45 24 D
+35 16 D
+60 22 D
+62 17 D
+76 13 D
+64 4 D
+64 -1 D
+51 -5 D
+63 -11 D
+62 -17 D
+36 -13 D
+24 -9 D
+46 -22 D
+34 -18 D
+-54 34 D
+-41 31 D
+-48 43 D
+-27 27 D
+-33 39 D
+-16 20 D
+-29 42 D
+-38 67 D
+-21 47 D
+-29 85 D
+-14 62 D
+-9 76 D
+-2 39 D
+0 13 D
+-1 -39 D
+-6 -63 D
+-12 -63 D
+-10 -38 D
+-25 -72 D
+-21 -47 D
+-38 -67 D
+-37 -52 D
+-24 -30 D
+-35 -37 D
+-37 -35 D
+-40 -33 D
+-31 -22 D
+-22 -14 D
+P
+FO
+U
+V 2960 1910 T
+26.4183 R
+-361 -208 M
+45 24 D
+35 16 D
+60 22 D
+62 17 D
+76 13 D
+64 4 D
+64 -1 D
+51 -5 D
+63 -11 D
+62 -17 D
+36 -13 D
+24 -9 D
+46 -22 D
+34 -18 D
+-54 34 D
+-41 31 D
+-48 43 D
+-27 27 D
+-33 39 D
+-16 20 D
+-29 42 D
+-38 67 D
+-21 47 D
+-29 85 D
+-14 62 D
+-9 76 D
+-2 39 D
+0 13 D
+-1 -39 D
+-6 -63 D
+-12 -63 D
+-10 -38 D
+-25 -72 D
+-21 -47 D
+-38 -67 D
+-37 -52 D
+-24 -30 D
+-35 -37 D
+-37 -35 D
+-40 -33 D
+-31 -22 D
+-22 -14 D
+P
+FO
+U
+V 3806 2330 T
+26.4165 R
+-361 -208 M
+45 24 D
+35 16 D
+60 22 D
+62 17 D
+76 13 D
+64 4 D
+64 -1 D
+51 -5 D
+63 -11 D
+62 -17 D
+36 -13 D
+24 -9 D
+46 -22 D
+34 -18 D
+-54 34 D
+-41 31 D
+-48 43 D
+-27 27 D
+-33 39 D
+-16 20 D
+-29 42 D
+-38 67 D
+-21 47 D
+-29 85 D
+-14 62 D
+-9 76 D
+-2 39 D
+0 13 D
+-1 -39 D
+-6 -63 D
+-12 -63 D
+-10 -38 D
+-25 -72 D
+-21 -47 D
+-38 -67 D
+-37 -52 D
+-24 -30 D
+-35 -37 D
+-37 -35 D
+-40 -33 D
+-31 -22 D
+-22 -14 D
+P
+FO
+U
+V 4652 2751 T
+26.4129 R
+-361 -208 M
+45 24 D
+35 16 D
+60 22 D
+62 17 D
+76 13 D
+64 4 D
+64 -1 D
+51 -5 D
+63 -11 D
+62 -17 D
+36 -13 D
+24 -9 D
+46 -22 D
+34 -18 D
+-54 34 D
+-41 31 D
+-48 43 D
+-27 27 D
+-33 39 D
+-16 20 D
+-29 42 D
+-38 67 D
+-21 47 D
+-29 85 D
+-14 62 D
+-9 76 D
+-2 39 D
+0 13 D
+-1 -39 D
+-6 -63 D
+-12 -63 D
+-10 -38 D
+-25 -72 D
+-21 -47 D
+-38 -67 D
+-37 -52 D
+-24 -30 D
+-35 -37 D
+-37 -35 D
+-40 -33 D
+-31 -22 D
+-22 -14 D
+P
+FO
+U
+V 5498 3171 T
+26.4072 R
+-361 -208 M
+45 24 D
+35 16 D
+60 22 D
+62 17 D
+76 13 D
+64 4 D
+64 -1 D
+51 -5 D
+63 -11 D
+62 -17 D
+36 -13 D
+24 -9 D
+46 -22 D
+34 -18 D
+-54 34 D
+-41 31 D
+-48 43 D
+-27 27 D
+-33 39 D
+-16 20 D
+-29 42 D
+-38 67 D
+-21 47 D
+-29 85 D
+-14 62 D
+-9 76 D
+-2 39 D
+0 13 D
+-1 -39 D
+-6 -63 D
+-12 -63 D
+-10 -38 D
+-25 -72 D
+-21 -47 D
+-38 -67 D
+-37 -52 D
+-24 -30 D
+-35 -37 D
+-37 -35 D
+-40 -33 D
+-31 -22 D
+-22 -14 D
+P
+FO
+U
+U
+PSL_cliprestore
+%%EndObject
+%%EndObject
+0 A
+FQ
+O0
+0 2362 TM
+% PostScript produced by:
+%@GMT: gmt psxy path.txt -S~d2c:+skstarp/40p+pthick+ggreen+a0 -Wthinnest,red -Y5c -R-2/2/-1/1.2 -JM15c
+%@PROJ: merc -2.00000000 2.00000000 -1.00000000 1.20000000 -222638.982 222638.982 -110579.965 132698.963 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+4 W
+1 0 0 C
+clipsave
+0 0 M
+7087 0 D
+0 3872 D
+-7087 0 D
+P
+PSL_clip N
+886 0 M
+80 79 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+45 43 D
+35 36 D
+27 26 D
+8 9 D
+23 11 D
+157 78 D
+157 78 D
+134 67 D
+45 22 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+258 128 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+258 128 D
+157 78 D
+157 78 D
+101 50 D
+134 67 D
+23 11 D
+134 67 D
+23 11 D
+56 28 D
+S
+PSL_cliprestore
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt psxy -R0/5.90551/0/3.22649 -Jx1i -O -K -Sk/tmp/GMT_symbol3151 @GMTAPI@-S-I-D-D-T-N-000001 --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 5.90551000 0.00000000 3.22649000 0.000 5.906 0.000 3.226 +xy
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+7087 0 D
+0 3872 D
+-7087 0 D
+P
+PSL_clip N
+4 W
+V
+{0 1 0 C} FS
+O1
+17 W
+V 1556 666 T
+67 266 67 -266 266 -67 -266 -67 -67 -266 -67 266 -266 67 7 333 0 SP
+U
+V 2227 1332 T
+67 266 67 -266 266 -67 -266 -67 -67 -266 -67 266 -266 67 7 333 0 SP
+U
+V 2960 1910 T
+67 266 67 -266 266 -67 -266 -67 -67 -266 -67 266 -266 67 7 333 0 SP
+U
+V 3806 2330 T
+67 266 67 -266 266 -67 -266 -67 -67 -266 -67 266 -266 67 7 333 0 SP
+U
+V 4652 2751 T
+67 266 67 -266 266 -67 -266 -67 -67 -266 -67 266 -266 67 7 333 0 SP
+U
+V 5498 3171 T
+67 266 67 -266 266 -67 -266 -67 -67 -266 -67 266 -266 67 7 333 0 SP
+U
+U
+PSL_cliprestore
+%%EndObject
+%%EndObject
+0 A
+FQ
+O0
+0 2362 TM
+% PostScript produced by:
+%@GMT: gmt psxy path.txt -S~d1c:+skcrosshair/25p+pthin -W2p -Y5c -R-2/2/-1/1.2 -JM15c
+%@PROJ: merc -2.00000000 2.00000000 -1.00000000 1.20000000 -222638.982 222638.982 -110579.965 132698.963 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+33 W
+clipsave
+0 0 M
+7087 0 D
+0 3872 D
+-7087 0 D
+P
+PSL_clip N
+886 0 M
+80 79 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+107 105 D
+26 27 D
+36 35 D
+8 9 D
+54 52 D
+35 36 D
+27 26 D
+17 18 D
+45 43 D
+35 36 D
+27 26 D
+8 9 D
+23 11 D
+157 78 D
+157 78 D
+134 67 D
+45 22 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+258 128 D
+157 78 D
+157 78 D
+157 78 D
+157 78 D
+258 128 D
+157 78 D
+157 78 D
+101 50 D
+134 67 D
+23 11 D
+134 67 D
+23 11 D
+56 28 D
+S
+PSL_cliprestore
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt psxy -R0/5.90551/0/3.22649 -Jx1i -O -K -Sk/tmp/GMT_symbol3152 @GMTAPI@-S-I-D-D-T-N-000001 --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 5.90551000 0.00000000 3.22649000 0.000 5.906 0.000 3.226 +xy
+%%BeginObject PSL_Layer_8
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+7087 0 D
+0 3872 D
+-7087 0 D
+P
+PSL_clip N
+4 W
+V
+O1
+12 W
+V 1221 333 T
+44.8062 R
+416 0 1 -208 0 SP
+0 416 1 0 -208 SP
+104 0 0 Sc
+52 0 0 Sc
+U
+V 1556 666 T
+44.8086 R
+416 0 1 -208 0 SP
+0 416 1 0 -208 SP
+104 0 0 Sc
+52 0 0 Sc
+U
+V 1891 999 T
+44.8103 R
+416 0 1 -208 0 SP
+0 416 1 0 -208 SP
+104 0 0 Sc
+52 0 0 Sc
+U
+V 2227 1332 T
+44.8114 R
+416 0 1 -208 0 SP
+0 416 1 0 -208 SP
+104 0 0 Sc
+52 0 0 Sc
+U
+V 2562 1665 T
+44.8119 R
+416 0 1 -208 0 SP
+0 416 1 0 -208 SP
+104 0 0 Sc
+52 0 0 Sc
+U
+V 2960 1910 T
+26.4183 R
+416 0 1 -208 0 SP
+0 416 1 0 -208 SP
+104 0 0 Sc
+52 0 0 Sc
+U
+V 3383 2120 T
+26.4177 R
+416 0 1 -208 0 SP
+0 416 1 0 -208 SP
+104 0 0 Sc
+52 0 0 Sc
+U
+V 3806 2330 T
+26.4165 R
+416 0 1 -208 0 SP
+0 416 1 0 -208 SP
+104 0 0 Sc
+52 0 0 Sc
+U
+V 4229 2541 T
+26.4149 R
+416 0 1 -208 0 SP
+0 416 1 0 -208 SP
+104 0 0 Sc
+52 0 0 Sc
+U
+V 4652 2751 T
+26.4129 R
+416 0 1 -208 0 SP
+0 416 1 0 -208 SP
+104 0 0 Sc
+52 0 0 Sc
+U
+V 5075 2961 T
+26.4103 R
+416 0 1 -208 0 SP
+0 416 1 0 -208 SP
+104 0 0 Sc
+52 0 0 Sc
+U
+V 5498 3171 T
+26.4072 R
+416 0 1 -208 0 SP
+0 416 1 0 -208 SP
+104 0 0 Sc
+52 0 0 Sc
+U
+V 5922 3381 T
+26.4036 R
+416 0 1 -208 0 SP
+0 416 1 0 -208 SP
+104 0 0 Sc
+52 0 0 Sc
+U
+U
+PSL_cliprestore
+%%EndObject
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psxy/custom_decorate.sh
+++ b/test/psxy/custom_decorate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Decorate lines with custom symbols
+
+cat > path.txt << END
+-1.5 -1
+-0.5  0
+ 1.5  1
+END
+gmt begin custom_decorate ps
+  gmt plot path.txt -S~d2c:+sklcrescent/60p+gred+pthin -W0.25p -R-2/2/-1/1.2 -JM15c
+  gmt plot path.txt -S~d2c:+skdeltoid/50p+pthin+gblue -W0,white -Y5c
+  gmt plot path.txt -S~d2c:+skstarp/40p+pthick+ggreen+a0 -Wthinnest,red -Y5c
+  gmt plot path.txt -S~d1c:+skcrosshair/25p+pthin -W2p -Y5c
+gmt end show


### PR DESCRIPTION
**Description of proposed changes**

The decorated lines symbol option (**-S~**) in plot has so far been limited to the fixed geometric symbols (circles, triangles, etc.) specified with the modifier **+s**`<symbol><size>`.  This PR allows the use of custom symbols via **+sk**_customsymbol_/_size_, just like in plot's **-Sk** option. The custom symbol must be a plain symbol that does not require any additional parameters other than symbol size.  We automatically modify the symbol to insert the rotation macro so that the symbol can be aligned with the path.  The rotation can be fixed via **+a**_angle_.  New test _psxy/custom_decorate.sh_ has been added.
