### PR TITLE
Fix the legend examples

### DIFF
--- a/doc/rst/source/legend.rst
+++ b/doc/rst/source/legend.rst
@@ -43,7 +43,7 @@ To add an example of a legend to a Mercator plot (map.ps) with the given
 specifications, use::
 
     gmt begin legend
-    gmt makecpt -Cpanoply -T-8/8/1 -H > tt.cpt
+    gmt makecpt -Cpanoply -T-8/8 -H > tt.cpt
     gmt set FONT_ANNOT_PRIMARY 12p
     gmt legend -R0/10/0/10 -JM6i -Dx0.5i/0.5i+w5i+jBL+l1.2 -C0.1i/0.1i -F+p+gazure1+r -B5f1 << EOF
     # Legend test for gmt pslegend

--- a/doc/rst/source/pslegend.rst
+++ b/doc/rst/source/pslegend.rst
@@ -42,7 +42,7 @@ Examples
 To add an example of a legend to a Mercator plot (map.ps) with the given
 specifications, use::
 
-    gmt makecpt -Cpanoply -T-8/8/1 > tt.cpt
+    gmt makecpt -Cpanoply -T-8/8 > tt.cpt
     gmt set FONT_ANNOT_PRIMARY 12p
 
     gmt pslegend -R0/10/0/10 -JM6i -Dx0.5i/0.5i+w5i+jBL+l1.2 -C0.1i/0.1i -F+p+gazure1+r -B5f1 -P > legend.ps <<EOF

--- a/test/pslegend/legend.sh
+++ b/test/pslegend/legend.sh
@@ -4,7 +4,7 @@
 
 ps=legend.ps
 
-gmt makecpt -Cpanoply -T-8/8/1 > tt.cpt
+gmt makecpt -Cpanoply -T-8/8 > tt.cpt
 gmt set FONT_ANNOT_PRIMARY 12p
 
 gmt pslegend -R0/10/0/10 -JM6i -Dx0.5i/0.5i+w5i+jBL+l1.2 -C0.1i/0.1i -F+p+gazure1+r -B5f1 -P > $ps <<EOF


### PR DESCRIPTION
The old example gives an warning:
```
makecpt [WARNING]: panoply is a discrete CPT. You can stretch it (-T<min>/<max>) but not interpolate it (-T<min>/<max>/<inc>).
makecpt [WARNING]: Selecting the given range and ignoring the increment setting.
```