### PR TITLE
Allow fronts, quoted, and decorated lines to be invisible

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -88,9 +88,9 @@
         beginning of the front by that amount [0]. The chosen symbol is drawn
         with the same pen as set for the line (i.e., via **-W**). To use an
         alternate pen, append **+p**\ *pen*. To skip the outline, just use
-        **+p**.  **Note**: By placing **-Sf**
-        options in the segment header you can change the front types on a
-        segment-by-segment basis.
+        **+p**.  To make the main front line invisible, add **+i**.  **Note**:
+        By placing **-Sf** options in the segment header you can change the front
+        types on a segment-by-segment basis.
 
     **-Sg**
         octa\ **g**\ on. *size* is diameter of circumscribing circle.
@@ -236,6 +236,9 @@
             **+g**\ [*color*]
                 Selects opaque text boxes [Default is transparent]; optionally
                 specify the color [Default is :term:`PS_PAGE_COLOR`].
+
+           **+i**
+                Make the main quoted line invisible [Draw it per **-W**].
 
             **+j**\ *just*
                 Sets label justification [Default is MC]. Ignored when
@@ -459,6 +462,9 @@
 
             **+g**\ [*fill*]
                 Sets the symbol fill [no fill].
+
+            **+i**
+                Make the main decorated line invisible [Draw it per **-W**].
 
             **+n**\ *dx*\ [/*dy*]
                 Nudges the placement of symbols by the specified amount (append

--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -464,7 +464,7 @@
                 Sets the symbol fill [no fill].
 
             **+i**
-                Make the main decorated line invisible [Draw it per **-W**].
+                Make the main decorated line invisible [Draw it using pen settings provided by **-W**].
 
             **+n**\ *dx*\ [/*dy*]
                 Nudges the placement of symbols by the specified amount (append

--- a/doc/rst/source/explain_symbols2.rst_
+++ b/doc/rst/source/explain_symbols2.rst_
@@ -70,7 +70,7 @@
 	the desired diameter to **-SE-** and this fixed diameter is used instead.
 	For allowable geographical units, see `Units`_ [Default is k for km].
 
-    **-Sf**\ [±]\ *gap*\ [/*size*][**+l**\|\ **+r**][**+b+c+f+s+t**][**+o**\ *offset*][**+p**\ [*pen*]].
+    **-Sf**\ [±]\ *gap*\ [/*size*][**+l**\|\ **+r**][**+b+c+f+s+t**][**+i**][**+o**\ *offset*][**+p**\ [*pen*]].
         Draw a **f**\ ront.  Supply distance *gap* between symbols and symbol size. If *gap* is
         negative, it is interpreted to mean the number of symbols along the
         front instead. If *gap* has a leading + then we use the value exactly as given
@@ -87,9 +87,9 @@
         beginning of the front by that amount [0]. The chosen symbol is drawn
         with the same pen as set for the line (i.e., via **-W**). To use an
         alternate pen, append **+p**\ *pen*. To skip the outline, just use
-        **+p**. **Note**: By placing **-Sf**
-        options in the segment header you can change the front types on a
-        segment-by-segment basis.
+        **+p**.  To make the main front line invisible, add **+i**.  **Note**:
+        By placing **-Sf** options in the segment header you can change the front
+        types on a segment-by-segment basis.
 
     **-Sg**
         octa\ **g**\ on. *size* is diameter of circumscribing circle.
@@ -252,6 +252,9 @@
             **+g**\ [*color*]
                 Selects opaque text boxes [Default is transparent]; optionally
                 specify the color [Default is **PS\_PAGE\_COLOR**].
+
+            **+i**
+                Make the main quoted line invisible [Draw it per **-W**].
 
             **+j**\ *just*
                 Sets label justification [Default is MC]. Ignored when
@@ -470,6 +473,9 @@
 
             **+g**\ [*fill*]
                 Sets the symbol fill [no fill].
+
+            **+i**
+                Make the main decorated line invisible [Draw it per **-W**].
 
             **+n**\ *dx*\ [/*dy*]
                 Nudges the placement of symbols by the specified amount (append

--- a/doc/rst/source/explain_symbols2.rst_
+++ b/doc/rst/source/explain_symbols2.rst_
@@ -475,7 +475,7 @@
                 Sets the symbol fill [no fill].
 
             **+i**
-                Make the main decorated line invisible [Draw it per **-W**].
+                Make the main decorated line invisible [Draw it using pen settings provided by **-W**].
 
             **+n**\ *dx*\ [/*dy*]
                 Nudges the placement of symbols by the specified amount (append

--- a/src/gmt_decorate.h
+++ b/src/gmt_decorate.h
@@ -63,6 +63,7 @@ struct GMT_DECORATE {
 	bool do_interpolate;		/* true if we must resample the crossing lines */
 	bool fixed;			/* true if we chose fixed positions */
 	bool debug;			/* true of we want to draw helper lines/points */
+	bool invisible;			/* true if we do not want to draw the line itself */
 	char line_name[16];		/* Name of line: "contour" or "line" */
 	char file[PATH_MAX];		/* File with crossing lines, if specified */
 	char option[GMT_BUFSIZ];	/* Copy of the option string */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -5240,7 +5240,7 @@ GMT_LOCAL int gmtinit_parse_front (struct GMT_CTRL *GMT, char *text, struct GMT_
 	char p[GMT_BUFSIZ] = {""}, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""};
 
 	/* text[0] is the leading 'f' for front */
-	if (text[1] == '+' && !strchr ("bcflrsStop", text[2])) S->f.f_exact = true, k0 = 2;	/* Special leading + to be skipped when looking for modifiers */
+	if (text[1] == '+' && !strchr ("bcfilrsStop", text[2])) S->f.f_exact = true, k0 = 2;	/* Special leading + to be skipped when looking for modifiers */
 	for (k = k0; text[k] && text[k] != '+'; k++);	/* Either find the first plus or run out or chars */
 	strncpy (p, text, k); p[k] = 0;
 	mods = (text[k] == '+');
@@ -5263,6 +5263,7 @@ GMT_LOCAL int gmtinit_parse_front (struct GMT_CTRL *GMT, char *text, struct GMT_
 			case 'b':	S->f.f_symbol = GMT_FRONT_BOX;		break;	/* [half-]square front */
 			case 'c':	S->f.f_symbol = GMT_FRONT_CIRCLE;	break;	/* [half-]circle front */
 			case 'f':	S->f.f_symbol = GMT_FRONT_FAULT;	break;	/* Fault front */
+			case 'i':	S->f.invisible = true;				break;	/* Do not draw line */
 			case 'l':	S->f.f_sense  = GMT_FRONT_LEFT;		break;	/* Symbols to the left */
 			case 'r':	S->f.f_sense  = GMT_FRONT_RIGHT;	break;	/* Symbols to the right */
 			case 's':	S->f.f_symbol = GMT_FRONT_SLIP;				/* Strike-slip front */
@@ -7126,6 +7127,7 @@ void gmt_label_syntax (struct GMT_CTRL *GMT, unsigned int indent, unsigned int k
 	else
 		gmt_message (GMT, "%s +g<fill> sets the fill for the symbol [transparent]\n", pad);
 	if (kind == 1) gmt_message (GMT, "%s +h hide the lines [Draw the lines].\n", pad);
+	if (kind) gmt_message (GMT, "%s +i makes the main line invisible [drawn per -W].\n", pad);
 	if (kind < 2) gmt_message (GMT, "%s +j<just> sets %s justification [Default is MC].\n", pad, feature[kind]);
 	if (kind == 1) {
 		gmt_message (GMT, "%s +l<text> Use text as label (quote text if containing spaces).\n", pad);

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7127,7 +7127,7 @@ void gmt_label_syntax (struct GMT_CTRL *GMT, unsigned int indent, unsigned int k
 	else
 		gmt_message (GMT, "%s +g<fill> sets the fill for the symbol [transparent]\n", pad);
 	if (kind == 1) gmt_message (GMT, "%s +h hide the lines [Draw the lines].\n", pad);
-	if (kind) gmt_message (GMT, "%s +i makes the main line invisible [drawn per -W].\n", pad);
+	if (kind) gmt_message (GMT, "%s +i makes the main line invisible [drawn using pen settings from -W].\n", pad);
 	if (kind < 2) gmt_message (GMT, "%s +j<just> sets %s justification [Default is MC].\n", pad, feature[kind]);
 	if (kind == 1) {
 		gmt_message (GMT, "%s +l<text> Use text as label (quote text if containing spaces).\n", pad);

--- a/src/gmt_plot.h
+++ b/src/gmt_plot.h
@@ -89,6 +89,7 @@ struct GMT_FRONTLINE {
 	double f_off;		/* Offset of first symbol from start of front in inches */
 	double f_angle;		/* Angle of the slip vector hook [30] */
 	bool f_exact;		/* Take given positive gap exactly [Default will adjust gap to distribute evenly along length of front] */
+	bool invisible;		/* True if we dont want to draw the front line itself */
 	int f_sense;		/* Draw symbols to left (+1), centered (0), or right (-1) of line */
 	int f_symbol;		/* Which symbol to draw along the front line */
 	int f_pen;		/* -1 for no outline (+p), 0 for default outline [-1], +1 if +p<pen> was used to set separate pen for outline */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -9193,7 +9193,8 @@ int gmt_contlabel_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_CONTOUR *G)
 				G->must_clip = (G->rgb[3] > 0.0);	/* May still be transparent if gave transparency; else opaque */
 				break;
 
-			case 'h':	/* Hide the lines used to place labels */
+			case 'h':	/* Hide the lines used to place labels [Was this ever documented? If not, remove] */
+			case 'i':	/* Make line invisible */
 				G->draw = false;
 				break;
 
@@ -9478,7 +9479,7 @@ int gmtlib_decorate_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_DECORATE 
 	char p[GMT_BUFSIZ] = {""}, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""};
 	char *specs = NULL;
 
-	/* Decode [+a<angle>|n|p[u|d]][+d][+g<fill>][+n|N<dx>[/<dy>]][+p[<pen>]]+s<symbolinfo>[+w<width>] strings */
+	/* Decode [+a<angle>|n|p[u|d]][+d][+g<fill>][+i][+n|N<dx>[/<dy>]][+p[<pen>]]+s<symbolinfo>[+w<width>] strings */
 
 	for (k = 0; txt[k] && txt[k] != '+'; k++);	/* Look for +<options> strings */
 
@@ -9510,6 +9511,10 @@ int gmtlib_decorate_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_DECORATE 
 
 			case 'g':	/* Symbol Fill specification */
 				if (p[1]) strncpy (G->fill, &p[1], GMT_LEN64-1);
+				break;
+
+			case 'i':	/* Invisible main line (do not draw line) */
+				G->invisible = true;
 				break;
 
 			case 'n':	/* Nudge specification; dx/dy are increments along local line axes */

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -484,7 +484,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     If <tickgap> has leading + then <tickgap> is used exactly [adjusted to fit line length].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     The <ticklen> defaults to 15%% of <tickgap> if not given.  Append\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     +l or +r   : Plot symbol to left or right of front [centered]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     +i         : Make main front line invisible [drawn per -W]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     +i         : Make main front line invisible [drawn using pen settings from -W]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     +<type>    : +b(ox), +c(ircle), +f(ault), +s|S(lip), +t(riangle) [f]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     	      +s optionally accepts the arrow angle [20].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t       box      : square when centered, half-square otherwise.\n");

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -479,11 +479,12 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     in column 3, or append a fixed dimension to -SJ- instead.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Append any of the units in %s to the dimensions [Default is k].\n", GMT_LEN_UNITS_DISPLAY);
 	GMT_Message (API, GMT_TIME_NONE, "\t     For linear projection we scale dimensions by the map scale.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Fronts: Give <tickgap>[/<ticklen>][+l|r][+<type>][+o<offset>][+p[<pen>]].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Fronts: Give <tickgap>[/<ticklen>][+l|r][i][+<type>][+o<offset>][+p[<pen>]].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     If <tickgap> is negative it means the number of gaps instead.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     If <tickgap> has leading + then <tickgap> is used exactly [adjusted to fit line length].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     The <ticklen> defaults to 15%% of <tickgap> if not given.  Append\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     +l or +r   : Plot symbol to left or right of front [centered]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     +i         : Make main front line invisible [drawn per -W]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     +<type>    : +b(ox), +c(ircle), +f(ault), +s|S(lip), +t(riangle) [f]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     	      +s optionally accepts the arrow angle [20].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t       box      : square when centered, half-square otherwise.\n");
@@ -2085,7 +2086,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 					bool split = false;
 					uint64_t k0;
 					if ((GMT->current.plot.n = gmt_geo_to_xy_line (GMT, L->data[GMT_X], L->data[GMT_Y], L->n_rows)) == 0) continue;
-					gmt_plot_line (GMT, GMT->current.plot.x, GMT->current.plot.y, GMT->current.plot.pen, GMT->current.plot.n, PSL_LINEAR);
+					if (!S.D.invisible) gmt_plot_line (GMT, GMT->current.plot.x, GMT->current.plot.y, GMT->current.plot.pen, GMT->current.plot.n, PSL_LINEAR);
 					/* gmt_geo_to_xy_line may have chopped the line into multiple pieces if exiting and reentering the domain */
 					for (k0 = 1; !split && k0 < GMT->current.plot.n; k0++) if (GMT->current.plot.pen[k0] & PSL_MOVE) split = true;
 					if (split) {	/* Must write out separate sections via gmt_hold_contour */
@@ -2196,7 +2197,7 @@ int GMT_psxy (void *V_API, int mode, void *args) {
 					}
 					if (draw_line) {
 						if ((GMT->current.plot.n = gmt_geo_to_xy_line (GMT, L->data[GMT_X], L->data[GMT_Y], L->n_rows)) == 0) continue;
-						gmt_plot_line (GMT, GMT->current.plot.x, GMT->current.plot.y, GMT->current.plot.pen, GMT->current.plot.n, current_pen.mode);
+						if (S.symbol != GMT_SYMBOL_FRONT || !S.f.invisible) gmt_plot_line (GMT, GMT->current.plot.x, GMT->current.plot.y, GMT->current.plot.pen, GMT->current.plot.n, current_pen.mode);
 						plot_end_vectors (GMT, GMT->current.plot.x, GMT->current.plot.y, GMT->current.plot.n, &current_pen);	/* Maybe add vector heads */
 					}
 				}

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1901,7 +1901,7 @@ int GMT_psxyz (void *V_API, int mode, void *args) {
 					else {
 						for (i = 0; i < n; i++) gmt_geoz_to_xy (GMT, L->data[GMT_X][i], L->data[GMT_Y][i], L->data[GMT_Z][i], &xp[i], &yp[i]);
 					}
-					if (draw_line) {
+					if (draw_line && (S.symbol != GMT_SYMBOL_FRONT || !S.f.invisible)) {
 						PSL_plotline (PSL, xp, yp, (int)n, PSL_MOVE|PSL_STROKE);
 					}
 				}


### PR DESCRIPTION
Sometimes it is desirable to just plot the items along the lines but not the lines themselves.  The new modifier **+i** for _invisible lines_ does that.  Closes #3017.
