### PR TITLE
Check if netcdf4 grid before calling nc_inq_var_deflate

### DIFF
--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -818,7 +818,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 			header->z_min = header->z_max = 0.0;
 		}
 		{	/* Get deflation and chunking info */
-			int storage_mode, shuffle, deflate, deflate_level;
+			int storage_mode, shuffle = 0, deflate = 0, deflate_level = 0;
 			size_t chunksize[5]; /* chunksize of z */
 			gmt_M_err_trap (nc_inq_var_chunking (ncid, z_id, &storage_mode, chunksize));
 			if (storage_mode == NC_CHUNKED) {
@@ -828,7 +828,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 			else { /* NC_CONTIGUOUS */
 				HH->z_chunksize[0] = HH->z_chunksize[1] = 0;
 			}
-			gmt_M_err_trap (nc_inq_var_deflate (ncid, z_id, &shuffle, &deflate, &deflate_level));
+			if (HH->is_netcdf4) gmt_M_err_trap (nc_inq_var_deflate (ncid, z_id, &shuffle, &deflate, &deflate_level));
 			HH->z_shuffle = shuffle ? true : false; /* if shuffle filter is turned on */
 			HH->z_deflate_level = deflate ? deflate_level : 0; /* if deflate filter is in use */
 		}


### PR DESCRIPTION
netCDF 4.7.4 released April 4, 2020 on macports caused massive crashes when reading netcdf3 grids as the nc_inq_var_deflate now suddenly crashes with an error instead of previous behavior.  Isolating this call by first checking if netcdf4 before calling the problematic function.  As this change in netcdf is backwards incompatible I have posted an [issue](https://github.com/Unidata/netcdf-c/issues/1689) on their site.
