### PR TITLE
Let GMT recognize MATLAB headers/comments

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -474,9 +474,10 @@ I/O Parameters
 
     **IO_HEADER_MARKER**
         Give a string from which any character will indicate a header record in
-        an incoming ASCII data table if found in the first position [#%]. If another marker should be
+        an incoming ASCII data table if found in the first position [#%"']. If another marker should be
         used for output than the first character in the list, then append a single character
         for the output header record marker. The two sets must be separated by a comma.
+        **Note**: A maximum of 7 input markers can be specified.
 
     **IO_LONLAT_TOGGLE**
         (**-:**) Set if the first two columns of input and output files

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -473,10 +473,10 @@ I/O Parameters
         (**-h**) Specifies whether input/output ASCII files have header record(s) or not [false].
 
     **IO_HEADER_MARKER**
-        This holds the character we expect to indicate a header record in
-        an incoming ASCII data or text table [#]. If this marker should be
-        different for output then append another character for the output
-        header record marker. The two characters must be separated by a comma.
+        Give a string from which any character will indicate a header record in
+        an incoming ASCII data table if found in the first position [#%]. If another marker should be
+        used for output than the first character in the list, then append a single character
+        for the output header record marker. The two sets must be separated by a comma.
 
     **IO_LONLAT_TOGGLE**
         (**-:**) Set if the first two columns of input and output files

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -474,9 +474,9 @@ I/O Parameters
 
     **IO_HEADER_MARKER**
         Give a string from which any character will indicate a header record in
-        an incoming ASCII data table if found in the first position [#%"']. If another marker should be
-        used for output than the first character in the list, then append a single character
-        for the output header record marker. The two sets must be separated by a comma.
+        an incoming ASCII data table if found in the first position [#%!;"']. If another marker
+        should be used for output than the first character in the list, then append a single
+        character for the output header record marker. The two sets must be separated by a comma.
         **Note**: A maximum of 7 input markers can be specified.
 
     **IO_LONLAT_TOGGLE**

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -2985,7 +2985,7 @@ GMT_LOCAL struct GMT_MATRIX *api_read_matrix (struct GMT_CTRL *GMT, void *source
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Read Matrix from %s\n", M_file);
 
 	while (!error && fgets (line, GMT_BUFSIZ, fp)) {
-		if (line[0] == GMT->current.setting.io_head_marker[GMT_IN]) continue;	/* Just skip headers */
+		if (strchr (GMT->current.setting.io_head_marker_in, line[0])) continue;	/* Just skip headers */
 		if (line[0] == '>') {
 			if (first) {	/* Have not allocated yet so just skip that row for now and deal with it later */
 				first = false;
@@ -3424,7 +3424,7 @@ GMT_LOCAL struct GMT_VECTOR *api_read_vector (struct GMT_CTRL *GMT, void *source
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Read Vector from %s\n", V_file);
 
 	while (fgets (line, GMT_BUFSIZ, fp)) {
-		if (line[0] == GMT->current.setting.io_head_marker[GMT_IN]) continue;	/* Just skip headers */
+		if (strchr (GMT->current.setting.io_head_marker_in, line[0])) continue;	/* Just skip headers */
 		if (line[0] == '>') {
 			if (first) {	/* Have not allocated yet so just skip that row for now */
 				first = false;

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -122,7 +122,7 @@ struct GMT_DEFAULTS {
 	char io_col_separator[GMT_LEN8];    /* Separator between output ASCII data columns [tab] */
 	char io_gridfile_format[GMT_LEN64]; /* Default grid file format */
 	char io_seg_marker[2];              /* Character used to recognize and write segment headers [>,>] */
-	char io_head_marker_in[8];          /* Character used to recognize input header records [#%] */
+	char io_head_marker_in[GMT_LEN32];  /* Characters used to recognize input header records [#%!;"'] */
 	char io_head_marker_out;            /* Character used to recognize and write header records [#,#] */
 	/* MAP group */
 	double map_annot_offset[2];		/* Distance between primary or secondary annotation and tickmarks [5p/5p] */

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -122,7 +122,8 @@ struct GMT_DEFAULTS {
 	char io_col_separator[GMT_LEN8];    /* Separator between output ASCII data columns [tab] */
 	char io_gridfile_format[GMT_LEN64]; /* Default grid file format */
 	char io_seg_marker[2];              /* Character used to recognize and write segment headers [>,>] */
-	char io_head_marker[2];             /* Character used to recognize and write header records [#,#] */
+	char io_head_marker_in[8];          /* Character used to recognize input header records [#%] */
+	char io_head_marker_out;            /* Character used to recognize and write header records [#,#] */
 	/* MAP group */
 	double map_annot_offset[2];		/* Distance between primary or secondary annotation and tickmarks [5p/5p] */
 	double map_annot_min_angle;		/* If angle between map boundary and annotation is less, no annotation is drawn [20] */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -700,6 +700,22 @@ GMT_LOCAL void gmtinit_kw_replace (struct GMTAPI_CTRL *API, struct GMT_KEYWORD_D
 }
 #endif
 
+GMT_LOCAL int gmtinit_check_markers (struct GMT_CTRL *GMT) {
+	/* Make sure segment header markers and header markers are not the same */
+	strcpy (GMT->current.setting.io_head_marker_in, "#%\"\'");	/* Accept GMT or MATLAB header records or comments or quoted text */
+	int error = GMT_NOERROR;
+
+	if (strchr (GMT->current.setting.io_head_marker_in, GMT->current.setting.io_seg_marker[GMT_IN])) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot let %c be both a header record flag and multiple segment header flag for input data\n", GMT->current.setting.io_seg_marker[GMT_IN]);
+		error++;
+	}
+	if (GMT->current.setting.io_seg_marker[GMT_OUT] == GMT->current.setting.io_head_marker_out) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot let %c be both a header record flag and multiple segment header flag for output data\n", GMT->current.setting.io_seg_marker[GMT_OUT]);
+		error++;
+	}
+	return (error);
+}
+
 GMT_LOCAL int get_psl_encoding (const char *encoding) {
 	/* Return the specified encoding ID */
 	int k = 0, match = 0;
@@ -10175,6 +10191,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				strcpy (GMT->current.setting.io_head_marker_in, txt[GMT_IN]);
 				GMT->current.setting.io_head_marker_out = txt[GMT_OUT][0];	/* Only pick the first character */
 			}
+			if (gmtinit_check_markers (GMT)) error = true;
 			break;
 		case GMTCASE_N_HEADER_RECS:
 			GMT_COMPAT_TRANSLATE ("IO_N_HEADER_RECS");
@@ -10286,6 +10303,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 					}
 				}
 			}
+			if (gmtinit_check_markers (GMT)) error = true;
 			break;
 
 		/* PROJ GROUP */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -5884,7 +5884,7 @@ void gmt_conf (struct GMT_CTRL *GMT) {
 	/* IO_HEADER */
 	GMT->current.setting.io_header[GMT_IN] = GMT->current.setting.io_header[GMT_OUT] = false;
 	/* IO_HEADER_MARKER */
-	strcpy (GMT->current.setting.io_head_marker_in, "#%");	/* Accept GMT or MATLAB header records or comments */
+	strcpy (GMT->current.setting.io_head_marker_in, "#%\"\'");	/* Accept GMT or MATLAB header records or comments or quoted text */
 	GMT->current.setting.io_head_marker_out = '#';
 	/* IO_N_HEADER_RECS */
 	GMT->current.setting.io_n_header_items = 0;
@@ -10161,7 +10161,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 		case GMTCASE_IO_HEADER_MARKER:
 			if (len == 0) {	/* Blank gives default */
-				strcpy (GMT->current.setting.io_head_marker_in, "#%");	/* Handle GMT and MATLAB headers and comments */
+				strcpy (GMT->current.setting.io_head_marker_in, "#%\"\'");	/* Handle GMT and MATLAB headers and comments */
 				GMT->current.setting.io_head_marker_out = '#';
 			}
 			else {

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -355,6 +355,8 @@ static struct GMT_FONTSPEC GMT_standard_fonts[GMT_N_STANDARD_FONTS] = {
 #include "standard_adobe_fonts.h"
 };
 
+#define DEF_HEADER_MARKERS "#%!;\"\'"
+
 #if defined(USE_COMMON_LONG_OPTIONS)
 /* List of GMT common keyword/options pairs.  This list is used in gmtinit_kw_replace to convert
  * the new long-format GMT options (e.g., --timestamp="My plot"+offset=5c/6c) to regular GMT short format
@@ -5900,7 +5902,7 @@ void gmt_conf (struct GMT_CTRL *GMT) {
 	/* IO_HEADER */
 	GMT->current.setting.io_header[GMT_IN] = GMT->current.setting.io_header[GMT_OUT] = false;
 	/* IO_HEADER_MARKER */
-	strcpy (GMT->current.setting.io_head_marker_in, "#%\"\'");	/* Accept GMT or MATLAB header records or comments or quoted text */
+	strcpy (GMT->current.setting.io_head_marker_in, DEF_HEADER_MARKERS);	/* Accept GMT or MATLAB header records or comments or quoted text */
 	GMT->current.setting.io_head_marker_out = '#';
 	/* IO_N_HEADER_RECS */
 	GMT->current.setting.io_n_header_items = 0;
@@ -10177,16 +10179,16 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 		case GMTCASE_IO_HEADER_MARKER:
 			if (len == 0) {	/* Blank gives default */
-				strcpy (GMT->current.setting.io_head_marker_in, "#%\"\'");	/* Handle GMT and MATLAB headers and comments */
+				strcpy (GMT->current.setting.io_head_marker_in, DEF_HEADER_MARKERS);	/* Handle GMT and MATLAB headers and comments */
 				GMT->current.setting.io_head_marker_out = '#';
 			}
 			else {
-				char txt[2][GMT_LEN8];
+				char txt[2][GMT_LEN32];
 				if (strchr (value, ',')) {	/* Got separate header record markers for input,output */
 					sscanf (value, "%[^,],%s", txt[GMT_IN], txt[GMT_OUT]);
 				}
 				else {	/* Just duplicate */
-					strncpy (txt[GMT_IN], value, GMT_LEN8-1);	strncpy (txt[GMT_OUT], value, GMT_LEN8-1);
+					strncpy (txt[GMT_IN], value, GMT_LEN32-1);	strncpy (txt[GMT_OUT], value, GMT_LEN32-1);
 				}
 				strcpy (GMT->current.setting.io_head_marker_in, txt[GMT_IN]);
 				GMT->current.setting.io_head_marker_out = txt[GMT_OUT][0];	/* Only pick the first character */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3484,7 +3484,7 @@ GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, 
 		gmt_strstrip (line, false); /* Eliminate DOS endings and trailing white space, add linefeed */
 
 		if (gmtio_ogr_parser (GMT, line)) continue;	/* If we parsed a GMT/OGR record we must go up to top of loop and get the next record */
-		if (line[0] == GMT->current.setting.io_head_marker[GMT_IN]) {	/* Got a file header, copy it and return */
+		if (strchr (GMT->current.setting.io_head_marker_in, line[0])) {	/* Got a file header, copy it and return */
 			if (GMT->common.h.mode == GMT_COMMENT_IS_RESET) continue;	/* Simplest way to replace headers on output is to ignore them on input */
 			gmtio_set_current_record (GMT, line);
 			GMT->current.io.status = GMT_IO_TABLE_HEADER;
@@ -4244,11 +4244,11 @@ void gmtlib_write_tableheader (struct GMT_CTRL *GMT, FILE *fp, char *txt) {
 	if (gmt_M_binary_header (GMT, GMT_OUT))		/* Must write a binary header */
 		gmtlib_io_binary_header (GMT, fp, GMT_OUT);
 	else if (!txt || !txt[0])				/* Blank header */
-		fprintf (fp, "%c\n", GMT->current.setting.io_head_marker[GMT_OUT]);
+		fprintf (fp, "%c\n", GMT->current.setting.io_head_marker_out);
 	else if (txt[0] == GMT->current.setting.io_seg_marker[GMT_OUT])
 		fprintf (fp, "%s\n", txt);
 	else {
-		fputc (GMT->current.setting.io_head_marker[GMT_OUT], fp);	/* Make sure we have # at start */
+		fputc (GMT->current.setting.io_head_marker_out, fp);	/* Make sure we have # at start */
 		while (strchr ("#\t ", *txt)) txt++;	/* Skip header record indicator and leading whitespace */
 		fprintf (fp, " %s", txt);
 		if (txt[strlen(txt)-1] != '\n') fputc ('\n', fp);	/* Make sure we have \n at end */
@@ -5144,7 +5144,7 @@ void * gmtio_ascii_textinput (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, int *
 			*status = -1;
 			return (NULL);
 		}
-		if (line[0] == GMT->current.setting.io_head_marker[GMT_IN]) {	/* Got a file header, take action and return */
+		if (strchr (GMT->current.setting.io_head_marker_in, line[0])) {	/* Got a file header, take action and return */
 			if (GMT->common.h.mode == GMT_COMMENT_IS_RESET) continue;	/* Simplest way to replace headers on output is to ignore them on input */
 			gmtio_set_current_record (GMT, line);
 			GMT->current.io.status = GMT_IO_TABLE_HEADER;

--- a/src/mgd77/mgd77manage.c
+++ b/src/mgd77/mgd77manage.c
@@ -680,7 +680,7 @@ int GMT_mgd77manage (void *V_API, int mode, void *args) {
 			ok_to_read = false;
 			tmp_string = gmt_M_memory (GMT, NULL, n_alloc, char *);
 			while (gmt_fgets (GMT, word, GMT_BUFSIZ, fp)) {
-				if (word[0] == GMT->current.setting.io_head_marker[GMT_IN]) continue;
+				if (gmt_is_a_blank_line (line) || strchr (GMT->current.setting.io_head_marker_in, word[0])) continue;	/* Skip all headers or blank lines  */
 				width = (int)strlen (word);
 				tmp_string[n] = gmt_M_memory (GMT, NULL, width + 1, char);
 				strcpy (tmp_string[n], word);

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -549,7 +549,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 		for (seg = 0; seg < In->table[tbl]->n_segments; seg++) {	/* We only expect one segment in each table but again... */
 			for (row = 0; row < In->table[tbl]->segment[seg]->n_rows; row++) {	/* Finally processing the rows */
 				line = In->table[tbl]->segment[seg]->text[row];
-				if (line[0] == GMT->current.setting.io_head_marker[GMT_IN] || gmt_is_a_blank_line (line)) continue;	/* Skip all headers or blank lines  */
+				if (gmt_is_a_blank_line (line) || strchr (GMT->current.setting.io_head_marker_in, line[0])) continue;	/* Skip all headers or blank lines  */
 
 				/* Data record to process */
 
@@ -932,7 +932,7 @@ int GMT_pslegend (void *V_API, int mode, void *args) {
 		for (seg = 0; seg < In->table[tbl]->n_segments; seg++) {	/* We only expect one segment in each table but again... */
 			for (row = 0; row < In->table[tbl]->segment[seg]->n_rows; row++) {	/* Finally processing the rows */
 				line = In->table[tbl]->segment[seg]->text[row];
-				if (line[0] == GMT->current.setting.io_head_marker[GMT_IN] || gmt_is_a_blank_line (line)) continue;	/* Skip all headers */
+				if (gmt_is_a_blank_line (line) || strchr (GMT->current.setting.io_head_marker_in, line[0])) continue;	/* Skip all headers or blank lines  */
 
 				/* Data record to process */
 


### PR DESCRIPTION
By extending the **IO_HEADER_MARKER** setting to accept a string of possible input-header markers we can set the default to `#%'"` which means either GMT or MATLAB header records as well as quoted text records are automatically recognized.  For output only one marker can be selected `[#]`.
