### PR TITLE
Address bad memory freeing related to polar cap

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -3913,7 +3913,7 @@ GMT_LOCAL uint64_t plot_geo_polygon_segment (struct GMT_CTRL *GMT, struct GMT_DA
 	uint64_t n = S->n_rows, k;
 	double *plon = S->data[GMT_X], *plat = S->data[GMT_Y], t_lat;	/* Default is to plot incoming array as is via plon,plat pointers */
 	bool ap = at_pole (plat, n);	/* Is the first and last point exactly at the pole? */
-	bool free_memory = add_pole;
+	bool free_memory;
 	struct GMT_DATASEGMENT_HIDDEN *SH = gmt_get_DS_hidden (S);
 	if (ap) plon[n-1] = plon[0];	/* Just enforce the same longitude at the pole point */
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Polar cap: %d\n", (int)add_pole);
@@ -3947,6 +3947,7 @@ GMT_LOCAL uint64_t plot_geo_polygon_segment (struct GMT_CTRL *GMT, struct GMT_DA
 			n = gmt_geo_polarcap_segment (GMT, S, &plon, &plat);
 		}
 	}
+	free_memory = add_pole;
 	if (add_pole) {	/* If we get here then a detour will be needed */
 		if ((n = gmt_geo_polarcap_segment (GMT, S, &plon, &plat)) == 0) {	/* Not a global map */
 			/* Here we must detour to the N or S pole, then resample the path */


### PR DESCRIPTION
See [forum](https://forum.generic-mapping-tools.org/t/gmt-plot-malloc-error-message/348/4) background.  This PR fixes the issue by assigning _free_memory_ after _add_pole_ has been finalized.