### PR TITLE
Upgrading grd2kml to handle global grids

### DIFF
--- a/doc/rst/source/grd2kml.rst
+++ b/doc/rst/source/grd2kml.rst
@@ -13,6 +13,7 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt grd2kml** *grid*
+[ |-A|\ *LOD* ]
 [ |-C|\ *cpt* ]
 [ |-E|\ *URL* ]
 [ |-F|\ *filtercode* ]
@@ -51,6 +52,12 @@ Required Arguments
 
 Optional Arguments
 ------------------
+
+.. _-A:
+
+**-A**\ *LOD*
+    Sets the finale (minLodPixels)[https://developers.google.com/kml/documentation/kmlreference#minlodpixels]
+    for the final, high-resolution PNG views [128].
 
 .. _-C:
 

--- a/doc/rst/source/grd2kml.rst
+++ b/doc/rst/source/grd2kml.rst
@@ -105,7 +105,9 @@ Optional Arguments
 
 **-L**\ *tilesize*
     Sets the fixed size of the image building blocks.  Must be an integer that
-    is radix 2.  Typical values are 256 or 512 [256].
+    is radix 2.  Typical values are 256 or 512 [256].  **Note**: For global
+    grids (here meaning 360-degree longitude range), we will compute an optimal
+    *tilesize* if **-L** is not specified.
 
 .. _-N:
 
@@ -154,11 +156,14 @@ Examples
 
 .. include:: explain_example.rst_
 
-To make a quadtree image representation of the large topography grid file ellice_basin.nc, using
-the default tile size, supply automatic shading based on the topography, and use the larger 512x512 tiles,
-supplying a suitable title, and using color masking for unmapped area, try
+To test a quadtree image representation of the coarse topography grid earth_relief06m, using
+the optimally determined tile size, auto color, and supplying a suitable title, try::
 
-   ::
+    gmt grd2kml @earth_relief_06m -NEarth6m -T"Earth Relief 6x6 arc minutes" -Cearth
+
+To make a quadtree image representation of the large topography grid file ellice_basin.nc,
+supplying automatic shading based on the topography, and using 512x512 tiles,
+supplying a suitable title, and using color masking for unmapped area, try::
 
     gmt grd2kml ellice_basin.nc -I+d -Nellice -L512 -Q -T"Ellice Basin Bathymetry"
 

--- a/doc/rst/source/grd2kml.rst
+++ b/doc/rst/source/grd2kml.rst
@@ -56,7 +56,7 @@ Optional Arguments
 .. _-A:
 
 **-A**\ *LOD*
-    Sets the finale (minLodPixels)[https://developers.google.com/kml/documentation/kmlreference#minlodpixels]
+    Sets `minLodPixels <https://developers.google.com/kml/documentation/kmlreference#minlodpixels>`_
     for the final, high-resolution PNG views [128].
 
 .. _-C:

--- a/src/grd2kml.c
+++ b/src/grd2kml.c
@@ -768,7 +768,7 @@ int GMT_grd2kml (void *V_API, int mode, void *args) {
 					else {	/* Made a meaningful plot, time to rip. */
 						/* Create the psconvert command to convert the PS to transparent PNG */
 						sprintf (region, "%s/%s/%s/%s", W, E, S, N);
-						GMT_Report (GMT->parent, GMT_MSG_WARNING, "Level %d: Mapped tile %s\n", level, region);
+						GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Level %d: Mapped tile %s\n", level, region);
 						if (Ctrl->D.single)
 							sprintf (cmd, "%s -D%s -FL%dR%dC%d %s", ps_cmd, Ctrl->N.prefix, level, row, col, psfile);
 						else
@@ -803,7 +803,7 @@ int GMT_grd2kml (void *V_API, int mode, void *args) {
 			wesn[YLO] = wesn[YHI];
 			strcpy (S, N);
 		}
-		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Summary Level %d: %d by %d = %d tiles, %d mapped, %d empty\n", level, row, col, row*col, row*col - n_skip, n_skip);
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Summary Level %d: %d by %d = %d tiles, %d mapped, %d empty\n", level, row, col, row*col, row*col - n_skip, n_skip);
 		if (level < max_level) {	/* Delete the temporary filtered grid(s) */
 			gmt_remove_file (GMT, Zgrid);
 			if (Ctrl->I.active) gmt_remove_file (GMT, Igrid);
@@ -823,7 +823,7 @@ int GMT_grd2kml (void *V_API, int mode, void *args) {
 
 	/* Process quadtree links */
 
-	GMT_Report (GMT->parent, GMT_MSG_WARNING, "Processes quadtree links for %d tiles.\n", n);
+	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Processes quadtree links for %d tiles.\n", n);
 	Q = gmt_M_memory (GMT, Q, n, struct GMT_QUADTREE *);	/* Final size */
 	for (level = max_level; level > 0; level--) {
 		for (k = 0; k < n; k++) {
@@ -835,8 +835,8 @@ int GMT_grd2kml (void *V_API, int mode, void *args) {
 			quad = 2 * (Q[k]->row - 2 * row) + (Q[k]->col - 2 * col);
 			kk = find_quad_above (Q, n, row, col, level-1);	/* kk is the parent of k */
 			if (kk < 0) {	/* THis can happen when the lower-level tile grazes one above it but there really are no data involved */
-				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Tile %s: Unable to link tile for row = %d, col = %d at level %d to a parent (!?).  Probably empty - skipped.\n", Q[k]->tag, row, col, level);
-				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Tile %s: Region was %g/%g/%g/%g.\n", Q[k]->tag, Q[k]->wesn[XLO], Q[k]->wesn[XHI], Q[k]->wesn[YLO], Q[k]->wesn[YHI]);
+				GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Tile %s: Unable to link tile for row = %d, col = %d at level %d to a parent (!?).  Probably empty - skipped.\n", Q[k]->tag, row, col, level);
+				GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Tile %s: Region was %g/%g/%g/%g.\n", Q[k]->tag, Q[k]->wesn[XLO], Q[k]->wesn[XHI], Q[k]->wesn[YLO], Q[k]->wesn[YHI]);
 				continue;
 			}
 			assert (quad < 4);	/* Sanity check */
@@ -952,7 +952,7 @@ int GMT_grd2kml (void *V_API, int mode, void *args) {
 		gmt_M_free (GMT, Q[k]);		/* Free this tile information */
 	}
 	gmt_M_free (GMT, Q);
-	GMT_Report (API, GMT_MSG_WARNING, "Done: %d files written to directory %s\n", 2*n+1, Ctrl->N.prefix);
+	GMT_Report (API, GMT_MSG_INFORMATION, "Done: %d files written to directory %s\n", 2*n+1, Ctrl->N.prefix);
 	if (tmp_cpt) gmt_remove_file (GMT, Ctrl->C.file);
 	Return (GMT_NOERROR);
 }

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1195,6 +1195,7 @@ int GMT_grdimage (void *V_API, int mode, void *args) {
 				for (col = 0; col < n_columns; col++) {	/* Compute rgb for each pixel along this scanline */
 					node = kk + actual_col[col];
 					index = gmt_get_rgb_from_z (GMT, P, Grid_proj[0]->data[node], rgb);
+					if (index != (GMT_NAN - 3)) has_content = true;
 					if (index != (GMT_NAN - 3) && Ctrl->I.active) {	/* Need to deal with illumination */
 						if (intensity_mode & 1)	/* Intensity value comes from the grid */
 							gmt_illuminate (GMT, Intens_proj->data[node], rgb);


### PR DESCRIPTION
**Description of proposed changes**

The **grd2kml** module was added when I needed the ability to build a quadree of images from a high-resolution multibeam grid and display it in Google Earth.  Now, when trying to use it on, say, global grids we have ran into a few issues, as reported by @btozer.  This PR addresses them in the following way:

1. For global grids (here, grids with 360 degree longitude range; latitudes do not have to go to the poles), let the tile size be optimally computed when **-L** is not given.  This is to ensure that periodic grids end up with tile sizes that nicely fit into the number of columns and rows which  tend to be multiples of 2, 3 and 5 (e.g., arc minutes) that make up global grids.  We do this by computing the common integer factors of _nx_ and _ny_ and then use these factors to find an optimal tile that is ~50% of 512.  With **-V** we report all the factors involved in case the user needs to determine a suitable size other than the one we report.
2. Because we rely on module calls for filtering, imaging, and rasterizing to PNGs, I needed to fix some formatting of longitudes to ensure continuity.
3. If a master CPT is given then we need to scale it using the full grid z-range and use that table consistently for all levels.
4. A post-6.0 change in how **psconvert** names output images (now, always append the image extension even if one is already present) was not addressed in **grd2kml** which resulted in output files called .png.png.
5. Finally, **grdimage** had a tiny bug that only affected **grd2kml**, for grayshade CPTs.

I also added a new option **-A**_LOD_ that lets users override the LOD setting in the KML [128].  Man page has been updated and a simple oneliner that users can test is added. For instance, this gives a quadtree of 90 tiles from the 6x6 arc minute global topography:

`gmt grd2kml @earth_relief_06m -NEarth6m -T"6 arc min relief" -Cearth
`
