### PR TITLE
Rename g*math static functions to follow code convention

### DIFF
--- a/src/gmtmath.c
+++ b/src/gmtmath.c
@@ -223,7 +223,7 @@ GMT_LOCAL int gmtmath_find_stored_item (struct GMTMATH_STORED *recall[], int n_s
 	return (k == n_stored ? GMT_NOTSET : k);
 }
 
-GMT_LOCAL void load_column (struct GMT_DATASET *to, uint64_t to_col, struct GMT_DATATABLE *from, uint64_t from_col) {
+GMT_LOCAL void gmtmath_load_column (struct GMT_DATASET *to, uint64_t to_col, struct GMT_DATATABLE *from, uint64_t from_col) {
 	/* Copies data from one column to another */
 	uint64_t seg;
 	for (seg = 0; seg < from->n_segments; seg++) {
@@ -233,7 +233,7 @@ GMT_LOCAL void load_column (struct GMT_DATASET *to, uint64_t to_col, struct GMT_
 
 /* ---------------------- start convenience functions --------------------- */
 
-GMT_LOCAL int solve_LS_system (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S, uint64_t n_col, bool skip[], char *file, bool svd, double eigen_min, struct GMT_OPTION *options, struct GMT_DATASET *A) {
+GMT_LOCAL int gmtmath_solve_LS_system (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S, uint64_t n_col, bool skip[], char *file, bool svd, double eigen_min, struct GMT_OPTION *options, struct GMT_DATASET *A) {
 
 	/* Consider the current table the augmented matrix [A | b], making up the linear system Ax = b.
 	 * We will set up the normal equations, solve for x, and output the solution before quitting.
@@ -403,7 +403,7 @@ GMT_LOCAL int solve_LS_system (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, 
 		D = GMT_Duplicate_Data (GMT->parent, GMT_IS_DATASET, GMT_DUPLICATE_ALLOC, S->D);	/* Same table length as S->D, but with up to n_cols columns (lon, lat, dist, g1, g2, ...) */
 		DH->dim[GMT_COL] = k;	/* Reset the original columns */
 		if (D->table[0]->n_segments > 1) gmt_set_segmentheader (GMT, GMT_OUT, true);	/* More than one segment triggers -mo */
-		load_column (D, 0, info->T, COL_T);	/* Place the time-column in first output column */
+		gmtmath_load_column (D, 0, info->T, COL_T);	/* Place the time-column in first output column */
 		for (seg = k = 0; seg < info->T->n_segments; seg++) {
 			for (row = 0; row < T->segment[seg]->n_rows; row++, k++) {
 				D->table[0]->segment[seg]->data[1][row] = T->segment[seg]->data[rhs][row];
@@ -437,15 +437,15 @@ GMT_LOCAL int solve_LS_system (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, 
 	return (GMT_NOERROR);
 }
 
-GMT_LOCAL int solve_LSQFIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S, uint64_t n_col, bool skip[], double eigen, char *file, struct GMT_OPTION *options, struct GMT_DATASET *A) {
-	return (solve_LS_system (GMT, info, S, n_col, skip, file, false, eigen, options, A));
+GMT_LOCAL int gmtmath_solve_LSQFIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S, uint64_t n_col, bool skip[], double eigen, char *file, struct GMT_OPTION *options, struct GMT_DATASET *A) {
+	return (gmtmath_solve_LS_system (GMT, info, S, n_col, skip, file, false, eigen, options, A));
 }
 
-GMT_LOCAL int solve_SVDFIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S, uint64_t n_col, bool skip[], double eigen, char *file, struct GMT_OPTION *options, struct GMT_DATASET *A) {
-	return (solve_LS_system (GMT, info, S, n_col, skip, file, true, eigen, options, A));
+GMT_LOCAL int gmtmath_solve_SVDFIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S, uint64_t n_col, bool skip[], double eigen, char *file, struct GMT_OPTION *options, struct GMT_DATASET *A) {
+	return (gmtmath_solve_LS_system (GMT, info, S, n_col, skip, file, true, eigen, options, A));
 }
 
-GMT_LOCAL void load_const_column (struct GMT_DATASET *to, uint64_t to_col, double factor) {
+GMT_LOCAL void gmtmath_load_const_column (struct GMT_DATASET *to, uint64_t to_col, double factor) {
 	/* Sets all rows in a column to a constant factor */
 	uint64_t row, seg;
 	for (seg = 0; seg < to->n_segments; seg++) {
@@ -453,7 +453,7 @@ GMT_LOCAL void load_const_column (struct GMT_DATASET *to, uint64_t to_col, doubl
 	}
 }
 
-GMT_LOCAL bool same_size (struct GMT_DATASET *A, struct GMT_DATASET *B) {
+GMT_LOCAL bool gmtmath_same_size (struct GMT_DATASET *A, struct GMT_DATASET *B) {
 	/* Are the two dataset the same size */
 	uint64_t seg;
 	if (!(A->table[0]->n_segments == B->table[0]->n_segments && A->table[0]->n_columns == B->table[0]->n_columns)) return (false);
@@ -461,7 +461,7 @@ GMT_LOCAL bool same_size (struct GMT_DATASET *A, struct GMT_DATASET *B) {
 	return (true);
 }
 
-GMT_LOCAL bool same_domain (struct GMT_DATASET *A, uint64_t t_col, struct GMT_DATATABLE *B) {
+GMT_LOCAL bool gmtmath_same_domain (struct GMT_DATASET *A, uint64_t t_col, struct GMT_DATATABLE *B) {
 	/* Are the two dataset the same domain */
 	uint64_t seg;
 	for (seg = 0; seg < A->table[0]->n_segments; seg++) {
@@ -874,7 +874,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMTMATH_CTRL *Ctrl, struct GMT
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
 
-GMT_LOCAL unsigned int gmt_assign_ptrs (struct GMT_CTRL *GMT, unsigned int last, struct GMTMATH_STACK *S[], struct GMT_DATATABLE **T, struct GMT_DATATABLE **T_prev) {	/* Centralize the assignment of previous stack ID and the current and previous stack tables */
+GMT_LOCAL unsigned int gmtmath_assign_ptrs (struct GMT_CTRL *GMT, unsigned int last, struct GMTMATH_STACK *S[], struct GMT_DATATABLE **T, struct GMT_DATATABLE **T_prev) {	/* Centralize the assignment of previous stack ID and the current and previous stack tables */
 	unsigned int prev;
 	if (last == 0) {	/* User error in requesting more items that presently on the stack */
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Not enough items on the stack\n");
@@ -892,7 +892,7 @@ GMT_LOCAL unsigned int gmt_assign_ptrs (struct GMT_CTRL *GMT, unsigned int last,
 /* Note: The OPERATOR: **** lines were used to extract syntax for documentation in the old days.
  * the first number is input args and the second is the output args. */
 
-GMT_LOCAL int table_ABS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_ABS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: ABS 1 1 abs (A).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -906,7 +906,7 @@ GMT_LOCAL int table_ABS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_ACOS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_ACOS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: ACOS 1 1 acos (A).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -920,7 +920,7 @@ GMT_LOCAL int table_ACOS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_ACOSH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_ACOSH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: ACOSH 1 1 acosh (A).  */
 {
 	uint64_t s, row;
@@ -935,7 +935,7 @@ GMT_LOCAL int table_ACOSH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_ACOT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_ACOT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: ACOT 1 1 acot (A).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -949,7 +949,7 @@ GMT_LOCAL int table_ACOT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_ACOTH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_ACOTH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: ACOTH 1 1 acoth (A).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -963,7 +963,7 @@ GMT_LOCAL int table_ACOTH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_ACSC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_ACSC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: ACSC 1 1 acsc (A).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -977,7 +977,7 @@ GMT_LOCAL int table_ACSC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_ACSCH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_ACSCH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: ACSCH 1 1 acsch (A).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -991,14 +991,14 @@ GMT_LOCAL int table_ACSCH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_ADD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_ADD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: ADD 2 1 A + B.  */
 	uint64_t s, row;
 	unsigned int prev;
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 	if (S[prev]->constant && S[prev]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "ADD: Operand one == 0!\n");
 	if (S[last]->constant && S[last]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "ADD: Operand two == 0!\n");
 	for (s = 0; s < info->T->n_segments; s++) {
@@ -1011,7 +1011,7 @@ GMT_LOCAL int table_ADD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_AND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_AND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: AND 2 1 B if A == NaN, else A.  */
 	uint64_t s, row;
 	unsigned int prev;
@@ -1019,7 +1019,7 @@ GMT_LOCAL int table_AND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 	gmt_M_unused(GMT);
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) {
 		for (row = 0; row < info->T->segment[s]->n_rows; row++) {
@@ -1031,7 +1031,7 @@ GMT_LOCAL int table_AND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_ASEC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_ASEC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: ASEC 1 1 asec (A).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -1045,7 +1045,7 @@ GMT_LOCAL int table_ASEC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_ASECH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_ASECH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: ASECH 1 1 asech (A).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -1059,7 +1059,7 @@ GMT_LOCAL int table_ASECH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_ASIN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_ASIN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: ASIN 1 1 asin (A).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -1073,7 +1073,7 @@ GMT_LOCAL int table_ASIN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_ASINH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_ASINH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: ASINH 1 1 asinh (A).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -1087,7 +1087,7 @@ GMT_LOCAL int table_ASINH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_ATAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_ATAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: ATAN 1 1 atan (A).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -1101,14 +1101,14 @@ GMT_LOCAL int table_ATAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_ATAN2 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_ATAN2 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: ATAN2 2 1 atan2 (A, B).  */
 	uint64_t s, row;
 	unsigned int prev;
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && S[prev]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Operand one == 0 for ATAN2!\n");
 	if (S[last]->constant && S[last]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Operand two == 0 for ATAN2!\n");
@@ -1122,7 +1122,7 @@ GMT_LOCAL int table_ATAN2 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_ATANH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_ATANH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: ATANH 1 1 atanh (A).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -1136,7 +1136,7 @@ GMT_LOCAL int table_ATANH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_BCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_BCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: BCDF 3 1 Binomial cumulative distribution function for p = A, n = B and x = C.  */
 	unsigned int prev1 = last - 1, prev2 = last - 2;
 	uint64_t s, row, x, n;
@@ -1176,7 +1176,7 @@ GMT_LOCAL int table_BCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_BEI (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_BEI (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: BEI 1 1 bei (A).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -1189,7 +1189,7 @@ GMT_LOCAL int table_BEI (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_BER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_BER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: BER 1 1 ber (A).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -1202,7 +1202,7 @@ GMT_LOCAL int table_BER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_BPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_BPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: BPDF 3 1 Binomial probability density function for p = A, n = B and x = C.  */
 {
 	unsigned int prev1 = last - 1, prev2 = last - 2;
@@ -1240,7 +1240,7 @@ GMT_LOCAL int table_BPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_BITAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_BITAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: BITAND 2 1 A & B (bitwise AND operator).  */
 {
 	uint64_t s, row, a = 0, b = 0, n_warn = 0, result, result_trunc;
@@ -1248,7 +1248,7 @@ GMT_LOCAL int table_BITAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, str
 	double ad = 0.0, bd = 0.0;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) ad = S[prev]->factor;
 	if (S[last]->constant) bd = S[last]->factor;
@@ -1269,7 +1269,7 @@ GMT_LOCAL int table_BITAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, str
 	return 0;
 }
 
-GMT_LOCAL int table_BITLEFT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_BITLEFT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: BITLEFT 2 1 A << B (bitwise left-shift operator).  */
 {
 	uint64_t s, row, a = 0, b = 0, n_warn = 0, result, result_trunc;
@@ -1279,7 +1279,7 @@ GMT_LOCAL int table_BITLEFT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	double ad = 0.0, bd = 0.0;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) ad = S[prev]->factor;
 	if (S[last]->constant) bd = S[last]->factor;
@@ -1308,7 +1308,7 @@ GMT_LOCAL int table_BITLEFT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_BITNOT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_BITNOT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: BITNOT 1 1 ~A (bitwise NOT operator, i.e., return two's complement).  */
 {
 	uint64_t s, row, a = 0, n_warn = 0, result, result_trunc;
@@ -1332,7 +1332,7 @@ GMT_LOCAL int table_BITNOT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, str
 	return 0;
 }
 
-GMT_LOCAL int table_BITOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_BITOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: BITOR 2 1 A | B (bitwise OR operator).  */
 {
 	uint64_t s, row, a = 0, b = 0, n_warn = 0, result, result_trunc;
@@ -1340,7 +1340,7 @@ GMT_LOCAL int table_BITOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	double ad = 0.0, bd = 0.0;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) ad = S[prev]->factor;
 	if (S[last]->constant) bd = S[last]->factor;
@@ -1361,7 +1361,7 @@ GMT_LOCAL int table_BITOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_BITRIGHT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_BITRIGHT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: BITRIGHT 2 1 A >> B (bitwise right-shift operator).  */
 {
 	uint64_t s, row, a = 0, b = 0, n_warn = 0, result, result_trunc;
@@ -1371,7 +1371,7 @@ GMT_LOCAL int table_BITRIGHT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, s
 	double ad = 0.0, bd = 0.0;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) ad = S[prev]->factor;
 	if (S[last]->constant) bd = S[last]->factor;
@@ -1400,7 +1400,7 @@ GMT_LOCAL int table_BITRIGHT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, s
 	return 0;
 }
 
-GMT_LOCAL int table_BITTEST (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_BITTEST (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: BITTEST 2 1 1 if bit B of A is set, else 0 (bitwise TEST operator).  */
 {
 	uint64_t s, row, a = 0, b = 0, n_warn = 0, result, result_trunc;
@@ -1410,7 +1410,7 @@ GMT_LOCAL int table_BITTEST (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	double ad = 0.0, bd = 0.0;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) ad = S[prev]->factor;
 	if (S[last]->constant) bd = S[last]->factor;
@@ -1440,7 +1440,7 @@ GMT_LOCAL int table_BITTEST (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_BITXOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_BITXOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: BITXOR 2 1 A ^ B (bitwise XOR operator).  */
 {
 	uint64_t s, row, a = 0, b = 0, n_warn = 0, result, result_trunc;
@@ -1448,7 +1448,7 @@ GMT_LOCAL int table_BITXOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, str
 	double ad = 0.0, bd = 0.0;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) ad = S[prev]->factor;
 	if (S[last]->constant) bd = S[last]->factor;
@@ -1469,7 +1469,7 @@ GMT_LOCAL int table_BITXOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, str
 	return 0;
 }
 
-GMT_LOCAL int table_CEIL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_CEIL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: CEIL 1 1 ceil (A) (smallest integer >= A).  */
 {
 	uint64_t s, row;
@@ -1482,7 +1482,7 @@ GMT_LOCAL int table_CEIL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_CHI2CRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_CHI2CRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: CHI2CRIT 2 1 Chi-squared distribution critical value for alpha = A and nu = B.  */
 {
 	uint64_t s, row;
@@ -1490,7 +1490,7 @@ GMT_LOCAL int table_CHI2CRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, s
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && S[prev]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Operand one == 0 for CHI2CRIT!\n");
 	if (S[last]->constant && S[last]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Operand two == 0 for CHI2CRIT!\n");
@@ -1502,14 +1502,14 @@ GMT_LOCAL int table_CHI2CRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, s
 	return 0;
 }
 
-GMT_LOCAL int table_CHI2CDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_CHI2CDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: CHI2CDF 2 1 Chi-squared cumulative distribution function for chi2 = A and nu = B.  */
 	uint64_t s, row;
 	unsigned int prev;
 	double a, b, q;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && S[prev]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Operand one == 0 for CHI2CDF!\n");
 	if (S[last]->constant && S[last]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Operand two == 0 for CHI2CDF!\n");
@@ -1522,14 +1522,14 @@ GMT_LOCAL int table_CHI2CDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_CHI2PDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_CHI2PDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: CHI2PDF 2 1 Chi-squared probability density function for chi = A and nu = B.  */
 	uint64_t s, row, nu;
 	unsigned int prev;
 	double c;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && S[prev]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Operand one == 0 for CHI2PDF!\n");
 	if (S[last]->constant && S[last]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Operand two == 0 for CHI2PDF!\n");
@@ -1541,13 +1541,13 @@ GMT_LOCAL int table_CHI2PDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_COL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_COL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: COL 1 1 Places column A on the stack.  */
 	uint64_t s, row;
 	unsigned int k;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if (gmt_assign_ptrs (GMT, last, S, &T, &T_prev) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if (gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (!S[last]->constant || S[last]->factor < 0.0 || ((k = urint (S[last]->factor)) >= info->n_col)) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Argument to COL must be a constant column number (0 <= k < n_col)!\n");
@@ -1559,14 +1559,14 @@ GMT_LOCAL int table_COL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_COMB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_COMB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: COMB 2 1 Combinations n_C_r, with n = A and r = B.  */
 	uint64_t s, row;
 	unsigned int prev;
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && S[prev]->factor < 0.0) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Argument n to COMB must be a positive integer (n >= 0)!\n");
@@ -1589,14 +1589,14 @@ GMT_LOCAL int table_COMB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_CORRCOEFF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_CORRCOEFF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: CORRCOEFF 2 1 Correlation coefficient r(A, B).  */
 	uint64_t s, row, i;
 	unsigned int prev;
 	double *a, *b, coeff;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && S[last]->constant) {	/* Correlation is undefined */
 		for (s = 0; s < info->T->n_segments; s++)
@@ -1642,7 +1642,7 @@ GMT_LOCAL int table_CORRCOEFF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, 
 }
 
 
-GMT_LOCAL int table_COS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_COS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: COS 1 1 cos (A) (A in radians).  */
 {
 	uint64_t s, row;
@@ -1657,7 +1657,7 @@ GMT_LOCAL int table_COS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_COSD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_COSD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: COSD 1 1 cos (A) (A in degrees).  */
 {
 	uint64_t s, row;
@@ -1670,7 +1670,7 @@ GMT_LOCAL int table_COSD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_COSH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_COSH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: COSH 1 1 cosh (A).  */
 {
 	uint64_t s, row;
@@ -1683,7 +1683,7 @@ GMT_LOCAL int table_COSH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_COT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_COT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: COT 1 1 cot (A) (A in radians).  */
 {
 	uint64_t s, row;
@@ -1699,7 +1699,7 @@ GMT_LOCAL int table_COT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 }
 
 
-GMT_LOCAL int table_COTD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_COTD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: COTD 1 1 cot (A) (A in degrees).  */
 {
 	uint64_t s, row;
@@ -1714,7 +1714,7 @@ GMT_LOCAL int table_COTD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_COTH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_COTH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: COTH 1 1 coth (A).  */
 {
 	uint64_t s, row;
@@ -1727,7 +1727,7 @@ GMT_LOCAL int table_COTH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_CSC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_CSC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: CSC 1 1 csc (A) (A in radians).  */
 {
 	uint64_t s, row;
@@ -1742,7 +1742,7 @@ GMT_LOCAL int table_CSC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_CSCD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_CSCD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: CSCD 1 1 csc (A) (A in degrees).  */
 {
 	uint64_t s, row;
@@ -1757,7 +1757,7 @@ GMT_LOCAL int table_CSCD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_CSCH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_CSCH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: CSCH 1 1 csch (A).  */
 {
 	uint64_t s, row;
@@ -1770,7 +1770,7 @@ GMT_LOCAL int table_CSCH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_PCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_PCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: PCDF 2 1 Poisson cumulative distribution function for x = A and lambda = B.  */
 {
 	uint64_t s, row;
@@ -1778,7 +1778,7 @@ GMT_LOCAL int table_PCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[last]->constant && S[last]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Operand two == 0 for PCDF!\n");
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
@@ -1789,7 +1789,7 @@ GMT_LOCAL int table_PCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_DDT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_DDT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: DDT 1 1 d(A)/dt Central 1st derivative.  */
 {
 	uint64_t s, row;
@@ -1819,7 +1819,7 @@ GMT_LOCAL int table_DDT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_D2DT2 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_D2DT2 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: D2DT2 1 1 d^2(A)/dt^2 2nd derivative.  */
 {
 	uint64_t s, row;
@@ -1851,7 +1851,7 @@ GMT_LOCAL int table_D2DT2 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_D2R (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_D2R (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: D2R 1 1 Converts Degrees to Radians.  */
 {
 	uint64_t s, row;
@@ -1864,13 +1864,13 @@ GMT_LOCAL int table_D2R (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_DENAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_DENAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: DENAN 2 1 Replace NaNs in A with values from B.  */
 {	/* Just a more straightforward application of AND */
-	return (table_AND (GMT, info, S, last, col));
+	return (gmtmath_AND (GMT, info, S, last, col));
 }
 
-GMT_LOCAL int table_DILOG (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_DILOG (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: DILOG 1 1 dilog (A).  */
 {
 	uint64_t s, row;
@@ -1882,7 +1882,7 @@ GMT_LOCAL int table_DILOG (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_DIFF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_DIFF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: DIFF 1 1 Difference (forward) between adjacent elements of A (A[1]-A[0], A[2]-A[1], ..., NaN). */
 {
 	uint64_t s, row;
@@ -1899,7 +1899,7 @@ GMT_LOCAL int table_DIFF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_DIV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_DIV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: DIV 2 1 A / B.  */
 {
 	uint64_t s, row;
@@ -1907,7 +1907,7 @@ GMT_LOCAL int table_DIV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[last]->constant && S[last]->factor == 0.0) {
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Divide by zero gives NaNs\n");
@@ -1920,7 +1920,7 @@ GMT_LOCAL int table_DIV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_DUP (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_DUP (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: DUP 1 2 Places duplicate of A on the stack.  */
 {
 	uint64_t s, row;
@@ -1941,7 +1941,7 @@ GMT_LOCAL int table_DUP (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_ECDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_ECDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: ECDF 2 1 Exponential cumulative distribution function for x = A and lambda = B.  */
 {
 	uint64_t s, row;
@@ -1949,7 +1949,7 @@ GMT_LOCAL int table_ECDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	double x, lambda;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		lambda = (S[last]->constant) ? S[last]->factor : T->segment[s]->data[col][row];
@@ -1959,7 +1959,7 @@ GMT_LOCAL int table_ECDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_ECRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_ECRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: ECRIT 2 1 Exponential distribution critical value for alpha = A and lambda = B.  */
 {
 	uint64_t s, row;
@@ -1967,7 +1967,7 @@ GMT_LOCAL int table_ECRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	double alpha, lambda;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		lambda = (S[last]->constant) ? S[last]->factor : T->segment[s]->data[col][row];
@@ -1977,7 +1977,7 @@ GMT_LOCAL int table_ECRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_EPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_EPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: EPDF 2 1 Exponential probability density function for x = A and lambda = B.  */
 {
 	uint64_t s, row;
@@ -1985,7 +1985,7 @@ GMT_LOCAL int table_EPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	double x, lambda;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		lambda = (S[last]->constant) ? S[last]->factor : T->segment[s]->data[col][row];
@@ -1995,7 +1995,7 @@ GMT_LOCAL int table_EPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_ERF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_ERF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: ERF 1 1 Error function erf (A).  */
 {
 	uint64_t s, row;
@@ -2008,7 +2008,7 @@ GMT_LOCAL int table_ERF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_ERFC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_ERFC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: ERFC 1 1 Complementary Error function erfc (A).  */
 {
 	uint64_t s, row;
@@ -2021,7 +2021,7 @@ GMT_LOCAL int table_ERFC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_ERFINV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_ERFINV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: ERFINV 1 1 Inverse error function of A.  */
 {
 	uint64_t s, row;
@@ -2033,7 +2033,7 @@ GMT_LOCAL int table_ERFINV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, str
 	return 0;
 }
 
-GMT_LOCAL int table_EQ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_EQ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: EQ 2 1 1 if A == B, else 0.  */
 {
 	uint64_t s, row;
@@ -2042,7 +2042,7 @@ GMT_LOCAL int table_EQ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 	gmt_M_unused(GMT);
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		a = (S[prev]->constant) ? S[prev]->factor : T_prev->segment[s]->data[col][row];
@@ -2052,7 +2052,7 @@ GMT_LOCAL int table_EQ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_EXCH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_EXCH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: EXCH 2 2 Exchanges A and B on the stack.  */
 {
 	unsigned int prev;
@@ -2067,7 +2067,7 @@ GMT_LOCAL int table_EXCH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_EXP (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_EXP (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: EXP 1 1 exp (A).  */
 {
 	uint64_t s, row;
@@ -2080,7 +2080,7 @@ GMT_LOCAL int table_EXP (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_FACT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_FACT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: FACT 1 1 A! (A factorial).  */
 {
 	uint64_t s, row;
@@ -2092,7 +2092,7 @@ GMT_LOCAL int table_FACT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_FCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_FCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: FCRIT 3 1 F distribution critical value for alpha = A, nu1 = B, and nu2 = C.  */
 {
 	uint64_t s, row;
@@ -2113,7 +2113,7 @@ GMT_LOCAL int table_FCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_FCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_FCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: FCDF 3 1 F cumulative distribution function for F = A, nu1 = B, and nu2 = C.  */
 {
 	uint64_t s, row, nu1, nu2;
@@ -2132,7 +2132,7 @@ GMT_LOCAL int table_FCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_FLIPUD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_FLIPUD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: FLIPUD 1 1 Reverse order of each column.  */
 {
 	uint64_t s, row, k;
@@ -2144,7 +2144,7 @@ GMT_LOCAL int table_FLIPUD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, str
 	return 0;
 }
 
-GMT_LOCAL int table_FLOOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_FLOOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: FLOOR 1 1 floor (A) (greatest integer <= A).  */
 {
 	uint64_t s, row;
@@ -2157,7 +2157,7 @@ GMT_LOCAL int table_FLOOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_FMOD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_FMOD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: FMOD 2 1 A % B (remainder after truncated division).  */
 {
 	uint64_t s, row;
@@ -2165,7 +2165,7 @@ GMT_LOCAL int table_FMOD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[last]->constant && S[last]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "using FMOD 0!\n");
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
@@ -2176,7 +2176,7 @@ GMT_LOCAL int table_FMOD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_FPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_FPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: FPDF 3 1 F probability density distribution for F = A, nu1 = B and nu2 = C.  */
 {
 	unsigned int prev1 = last - 1, prev2 = last - 2;
@@ -2213,7 +2213,7 @@ GMT_LOCAL int table_FPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_GE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_GE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: GE 2 1 1 if A >= B, else 0.  */
 {
 	uint64_t s, row;
@@ -2222,7 +2222,7 @@ GMT_LOCAL int table_GE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 	gmt_M_unused(GMT);
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		a = (S[prev]->constant) ? S[prev]->factor : T_prev->segment[s]->data[col][row];
@@ -2232,7 +2232,7 @@ GMT_LOCAL int table_GE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_GT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_GT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: GT 2 1 1 if A > B, else 0.  */
 {
 	uint64_t s, row;
@@ -2241,7 +2241,7 @@ GMT_LOCAL int table_GT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 	gmt_M_unused(GMT);
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		a = (S[prev]->constant) ? S[prev]->factor : T_prev->segment[s]->data[col][row];
@@ -2251,7 +2251,7 @@ GMT_LOCAL int table_GT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_HSV2LAB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_HSV2LAB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: HSV2LAB 3 3 Convert HSV to LAB, with h = A, s = B and v = C.  */
 	uint64_t s, row;
 	double hsv[4], rgb[4], lab[3];
@@ -2300,7 +2300,7 @@ GMT_LOCAL int table_HSV2LAB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_HSV2RGB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_HSV2RGB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: HSV2RGB 3 3 Convert HSV to RGB, with h = A, s = B and v = C.  */
 	uint64_t s, row;
 	double rgb[4], hsv[4];
@@ -2347,7 +2347,7 @@ GMT_LOCAL int table_HSV2RGB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_HSV2XYZ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_HSV2XYZ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: HSV2XYZ 3 3 Convert HSV to XYZ, with h = A, s = B and v = C.  */
 	uint64_t s, row;
 	double hsv[4], xyz[4], rgb[4];
@@ -2396,7 +2396,7 @@ GMT_LOCAL int table_HSV2XYZ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_HYPOT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_HYPOT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: HYPOT 2 1 hypot (A, B) = sqrt (A*A + B*B).  */
 {
 	uint64_t s, row;
@@ -2404,7 +2404,7 @@ GMT_LOCAL int table_HYPOT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && S[prev]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "HYPOT: Operand one == 0!\n");
 	if (S[last]->constant && S[last]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "HYPOT: Operand two == 0!\n");
@@ -2416,7 +2416,7 @@ GMT_LOCAL int table_HYPOT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_I0 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_I0 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: I0 1 1 Modified Bessel function of A (1st kind, order 0).  */
 {
 	uint64_t s, row;
@@ -2428,7 +2428,7 @@ GMT_LOCAL int table_I0 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_I1 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_I1 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: I1 1 1 Modified Bessel function of A (1st kind, order 1).  */
 {
 	uint64_t s, row;
@@ -2440,7 +2440,7 @@ GMT_LOCAL int table_I1 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_IFELSE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_IFELSE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: IFELSE 3 1 B if A != 0, else C.  */
 {
 	uint64_t s, row;
@@ -2467,7 +2467,7 @@ GMT_LOCAL int table_IFELSE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, str
 	return 0;
 }
 
-GMT_LOCAL int table_IN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_IN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: IN 2 1 Modified Bessel function of A (1st kind, order B).  */
 {
 	uint64_t s, row;
@@ -2476,7 +2476,7 @@ GMT_LOCAL int table_IN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	double b = 0.0;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[last]->constant) {
 		if (S[last]->factor < 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "order < 0 for IN!\n");
@@ -2498,7 +2498,7 @@ GMT_LOCAL int table_IN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_INRANGE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_INRANGE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: INRANGE 3 1 1 if B <= A <= C, else 0.  */
 {
 	uint64_t s, row;
@@ -2531,7 +2531,7 @@ GMT_LOCAL int table_INRANGE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_INT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_INT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: INT 1 1 Numerically integrate A.  */
 {
 	uint64_t s, row, k;
@@ -2570,7 +2570,7 @@ GMT_LOCAL int table_INT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_INV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_INV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: INV 1 1 1 / A.  */
 {
 	uint64_t s, row;
@@ -2583,7 +2583,7 @@ GMT_LOCAL int table_INV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_ISFINITE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_ISFINITE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: ISFINITE 1 1 1 if A is finite, else 0.  */
 {
 	uint64_t s, row;
@@ -2596,7 +2596,7 @@ GMT_LOCAL int table_ISFINITE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, s
 	return 0;
 }
 
-GMT_LOCAL int table_ISNAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_ISNAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: ISNAN 1 1 1 if A == NaN, else 0.  */
 {
 	uint64_t s, row;
@@ -2609,7 +2609,7 @@ GMT_LOCAL int table_ISNAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_J0 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_J0 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: J0 1 1 Bessel function of A (1st kind, order 0).  */
 {
 	uint64_t s, row;
@@ -2622,7 +2622,7 @@ GMT_LOCAL int table_J0 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_J1 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_J1 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: J1 1 1 Bessel function of A (1st kind, order 1).  */
 {
 	uint64_t s, row;
@@ -2635,7 +2635,7 @@ GMT_LOCAL int table_J1 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_JN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_JN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: JN 2 1 Bessel function of A (1st kind, order B).  */
 {
 	uint64_t s, row;
@@ -2644,7 +2644,7 @@ GMT_LOCAL int table_JN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	double b = 0.0;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[last]->constant) {
 		if (S[last]->factor < 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "order < 0 for JN!\n");
@@ -2666,7 +2666,7 @@ GMT_LOCAL int table_JN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_K0 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_K0 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: K0 1 1 Modified Kelvin function of A (2nd kind, order 0).  */
 {
 	uint64_t s, row;
@@ -2678,7 +2678,7 @@ GMT_LOCAL int table_K0 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_K1 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_K1 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: K1 1 1 Modified Bessel function of A (2nd kind, order 1).  */
 {
 	uint64_t s, row;
@@ -2690,7 +2690,7 @@ GMT_LOCAL int table_K1 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_KN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_KN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: KN 2 1 Modified Bessel function of A (2nd kind, order B).  */
 {
 	uint64_t s, row;
@@ -2699,7 +2699,7 @@ GMT_LOCAL int table_KN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	double b = 0.0;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[last]->constant) {
 		if (S[last]->factor < 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "order < 0 for KN!\n");
@@ -2721,7 +2721,7 @@ GMT_LOCAL int table_KN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_KEI (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_KEI (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: KEI 1 1 kei (A).  */
 {
 	uint64_t s, row;
@@ -2733,7 +2733,7 @@ GMT_LOCAL int table_KEI (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_KER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_KER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: KER 1 1 ker (A).  */
 {
 	uint64_t s, row;
@@ -2745,7 +2745,7 @@ GMT_LOCAL int table_KER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_KURT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_KURT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: KURT 1 1 Kurtosis of A.  */
 {
 	uint64_t s, row, n = 0;
@@ -2800,7 +2800,7 @@ GMT_LOCAL int table_KURT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_LAB2HSV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_LAB2HSV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: LAB2HSV 3 3 Convert LAB to HSV, with L = A, a = B and b = C.  */
 	uint64_t s, row;
 	double hsv[4], lab[4], rgb[4];
@@ -2851,7 +2851,7 @@ GMT_LOCAL int table_LAB2HSV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_LAB2RGB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_LAB2RGB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: LAB2RGB 3 3 Convert LAB to RGB, with L = A, a = B and b = C.  */
 	uint64_t s, row;
 	double lab[3], rgb[3];
@@ -2899,7 +2899,7 @@ GMT_LOCAL int table_LAB2RGB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_LAB2XYZ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_LAB2XYZ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: LAB2XYZ 3 3 Convert LAB to XYZ, with L = A, a = B and b = C.  */
 	uint64_t s, row;
 	double lab[3], xyz[3];
@@ -2949,7 +2949,7 @@ GMT_LOCAL int table_LAB2XYZ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 
 /* Laplace stuff based on https://en.wikipedia.org/wiki/Laplace_distribution */
 
-GMT_LOCAL int table_LCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_LCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: LCDF 1 1 Laplace cumulative distribution function for z = A.  */
 {
 	uint64_t s, row;
@@ -2962,7 +2962,7 @@ GMT_LOCAL int table_LCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_LCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_LCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: LCRIT 1 1 Laplace distribution critical value for alpha = A.  */
 {
 	uint64_t s, row;
@@ -2985,7 +2985,7 @@ GMT_LOCAL int table_LCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_LE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_LE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: LE 2 1 1 if A <= B, else 0.  */
 {
 	uint64_t s, row;
@@ -2994,7 +2994,7 @@ GMT_LOCAL int table_LE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 	gmt_M_unused(GMT);
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		a = (S[prev]->constant) ? S[prev]->factor : T_prev->segment[s]->data[col][row];
@@ -3004,7 +3004,7 @@ GMT_LOCAL int table_LE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_LMSSCL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_LMSSCL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: LMSSCL 1 1 LMS scale estimate (LMS STD) of A.  */
 {
 	uint64_t s, row, k;
@@ -3054,7 +3054,7 @@ GMT_LOCAL int table_LMSSCL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, str
 	return 0;
 }
 
-GMT_LOCAL int table_LMSSCLW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_LMSSCLW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: LMSSCLW 1 1 Weighted LMS scale estimate (LMS STD) of A for weights in B.  */
 	uint64_t s, row, k = 0;
 	unsigned int prev;
@@ -3062,7 +3062,7 @@ GMT_LOCAL int table_LMSSCLW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 	struct GMT_OBSERVATION *pair = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) {	/* Trivial case */
 		for (s = 0; s < info->T->n_segments; s++)
@@ -3114,7 +3114,7 @@ GMT_LOCAL int table_LMSSCLW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_LOG (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_LOG (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: LOG 1 1 log (A) (natural log).  */
 	uint64_t s, row;
 	double a = 0.0;
@@ -3127,7 +3127,7 @@ GMT_LOCAL int table_LOG (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_LOG10 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_LOG10 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: LOG10 1 1 log10 (A) (base 10).  */
 {
 	uint64_t s, row;
@@ -3141,7 +3141,7 @@ GMT_LOCAL int table_LOG10 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_LOG1P (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_LOG1P (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: LOG1P 1 1 log (1+A) (accurate for small A).  */
 {
 	uint64_t s, row;
@@ -3155,7 +3155,7 @@ GMT_LOCAL int table_LOG1P (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_LOG2 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_LOG2 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: LOG2 1 1 log2 (A) (base 2).  */
 {
 	uint64_t s, row;
@@ -3169,7 +3169,7 @@ GMT_LOCAL int table_LOG2 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_LOWER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_LOWER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: LOWER 1 1 The lowest (minimum) value of A.  */
 {
 	uint64_t s, row;
@@ -3195,7 +3195,7 @@ GMT_LOCAL int table_LOWER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_LPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_LPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: LPDF 1 1 Laplace probability density function for z = A.  */
 {
 	uint64_t s, row;
@@ -3208,7 +3208,7 @@ GMT_LOCAL int table_LPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_LRAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_LRAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: LRAND 2 1 Laplace random noise with mean A and std. deviation B.  */
 {
 	uint64_t s, row;
@@ -3216,7 +3216,7 @@ GMT_LOCAL int table_LRAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	double a = 0.0, b = 0.0;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) a = S[prev]->factor;
 	if (S[last]->constant) b = S[last]->factor;
@@ -3228,17 +3228,17 @@ GMT_LOCAL int table_LRAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_LSQFIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_LSQFIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: LSQFIT 1 0 Current table is [A | b]; return LS solution to A * x = b via Cholesky decomposition.  */
 {
 	gmt_M_unused(GMT); gmt_M_unused(info); gmt_M_unused(S); gmt_M_unused(last); gmt_M_unused(col);
-	/* Dummy routine needed since the automatically generated include file will have table_LSQFIT
+	/* Dummy routine needed since the automatically generated include file will have gmtmath_LSQFIT
 	 * with these parameters just like any other function.  However, when we find LSQFIT we will
-	 * instead call solve_LSQFIT which can be found at the end of these functions */
+	 * instead call gmtmath_solve_LSQFIT which can be found at the end of these functions */
 	return 0;
 }
 
-GMT_LOCAL int table_LT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_LT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: LT 2 1 1 if A < B, else 0.  */
 {
 	uint64_t s, row;
@@ -3247,7 +3247,7 @@ GMT_LOCAL int table_LT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 	gmt_M_unused(GMT);
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		a = (S[prev]->constant) ? S[prev]->factor : T_prev->segment[s]->data[col][row];
@@ -3257,7 +3257,7 @@ GMT_LOCAL int table_LT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_MAD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_MAD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: MAD 1 1 Median Absolute Deviation (L1 STD) of A.  */
 {
 	uint64_t s, row, k;
@@ -3302,7 +3302,7 @@ GMT_LOCAL int table_MAD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_MADW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_MADW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: MADW 2 1 Weighted Median Absolute Deviation (L1 STD) of A for weights in B.  */
 	uint64_t s, row, k = 0;
 	unsigned int prev;
@@ -3310,7 +3310,7 @@ GMT_LOCAL int table_MADW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 	struct GMT_OBSERVATION *pair = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) {	/* Trivial case */
 		for (s = 0; s < info->T->n_segments; s++)
@@ -3362,7 +3362,7 @@ GMT_LOCAL int table_MADW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_MAX (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_MAX (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: MAX 2 1 Maximum of A and B.  */
 {
 	uint64_t s, row;
@@ -3370,7 +3370,7 @@ GMT_LOCAL int table_MAX (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		a = (S[prev]->constant) ? S[prev]->factor : T_prev->segment[s]->data[col][row];
@@ -3380,7 +3380,7 @@ GMT_LOCAL int table_MAX (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_MEAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_MEAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: MEAN 1 1 Mean value of A.  */
 {
 	uint64_t s, row, n_a = 0;
@@ -3410,7 +3410,7 @@ GMT_LOCAL int table_MEAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_MEANW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_MEANW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: MEANW 2 1 Weighted mean value of A for weights in B.  */
 {
 	uint64_t s, row, n_a = 0;
@@ -3418,7 +3418,7 @@ GMT_LOCAL int table_MEANW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	double sum_zw = 0.0, sum_w = 0.0, zm, w;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) {	/* Trivial case */
 		for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) T_prev->segment[s]->data[col][row] = S[prev]->factor;
@@ -3450,7 +3450,7 @@ GMT_LOCAL int table_MEANW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_MEDIAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_MEDIAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: MEDIAN 1 1 Median value of A.  */
 {
 	uint64_t s, row, k;
@@ -3493,7 +3493,7 @@ GMT_LOCAL int table_MEDIAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, str
 	return 0;
 }
 
-GMT_LOCAL int table_MEDIANW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_MEDIANW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: MEDIANW 2 1 Weighted median value of A for weights in B.  */
 	uint64_t s, row, k = 0;
 	unsigned int prev;
@@ -3501,7 +3501,7 @@ GMT_LOCAL int table_MEDIANW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 	struct GMT_OBSERVATION *pair = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) {	/* Trivial case */
 		for (s = 0; s < info->T->n_segments; s++)
@@ -3542,7 +3542,7 @@ GMT_LOCAL int table_MEDIANW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_MIN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_MIN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: MIN 2 1 Minimum of A and B.  */
 {
 	uint64_t s, row;
@@ -3550,7 +3550,7 @@ GMT_LOCAL int table_MIN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		a = (S[prev]->constant) ? S[prev]->factor : T_prev->segment[s]->data[col][row];
@@ -3560,7 +3560,7 @@ GMT_LOCAL int table_MIN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_MOD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_MOD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: MOD 2 1 A mod B (remainder after floored division).  */
 {
 	uint64_t s, row;
@@ -3568,7 +3568,7 @@ GMT_LOCAL int table_MOD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[last]->constant && S[last]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "using MOD 0!\n");
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
@@ -3579,7 +3579,7 @@ GMT_LOCAL int table_MOD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_MODE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_MODE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: MODE 1 1 Mode value (Least Median of Squares) of A.  */
 	uint64_t s, row, k = 0;
 	unsigned int gmt_mode_selection = 0, GMT_n_multiples = 0;
@@ -3613,7 +3613,7 @@ GMT_LOCAL int table_MODE (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_MODEW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_MODEW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: MODEW 2 1 Weighted mode value of A for weights in B.  */
 {
 	uint64_t s, row, k = 0;
@@ -3622,7 +3622,7 @@ GMT_LOCAL int table_MODEW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 	struct GMT_OBSERVATION *pair = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) {	/* Trivial case */
 		for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) T_prev->segment[s]->data[col][row] = S[prev]->factor;
@@ -3661,7 +3661,7 @@ GMT_LOCAL int table_MODEW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_MUL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_MUL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: MUL 2 1 A * B.  */
 {
 	uint64_t s, row;
@@ -3669,7 +3669,7 @@ GMT_LOCAL int table_MUL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && S[prev]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "MUL: Operand one == 0!\n");
 	if (S[last]->constant && S[last]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "MUL: Operand two == 0!\n");
@@ -3681,7 +3681,7 @@ GMT_LOCAL int table_MUL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_NAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_NAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: NAN 2 1 NaN if A == B, else A.  */
 {
 	uint64_t s, row;
@@ -3689,7 +3689,7 @@ GMT_LOCAL int table_NAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	double a = 0.0, b = 0.0;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) a = S[prev]->factor;
 	if (S[last]->constant) b = S[last]->factor;
@@ -3701,7 +3701,7 @@ GMT_LOCAL int table_NAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_NEG (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_NEG (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: NEG 1 1 -A.  */
 {
 	uint64_t s, row;
@@ -3714,7 +3714,7 @@ GMT_LOCAL int table_NEG (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_NEQ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_NEQ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: NEQ 2 1 1 if A != B, else 0.  */
 {
 	uint64_t s, row;
@@ -3723,7 +3723,7 @@ GMT_LOCAL int table_NEQ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 	gmt_M_unused(GMT);
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		a = (S[prev]->constant) ? S[prev]->factor : T_prev->segment[s]->data[col][row];
@@ -3733,7 +3733,7 @@ GMT_LOCAL int table_NEQ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_NORM (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_NORM (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: NORM 1 1 Normalize (A) so max(A)-min(A) = 1.  */
 {
 	uint64_t s, row, n;
@@ -3758,7 +3758,7 @@ GMT_LOCAL int table_NORM (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_NOT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_NOT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: NOT 1 1 NaN if A == NaN, 1 if A == 0, else 0.  */
 {
 	uint64_t s, row;
@@ -3771,7 +3771,7 @@ GMT_LOCAL int table_NOT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_NRAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_NRAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: NRAND 2 1 Normal, random values with mean A and std. deviation B.  */
 {
 	uint64_t s, row;
@@ -3779,7 +3779,7 @@ GMT_LOCAL int table_NRAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	double a = 0.0, b = 0.0;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) a = S[prev]->factor;
 	if (S[last]->constant) b = S[last]->factor;
@@ -3791,7 +3791,7 @@ GMT_LOCAL int table_NRAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_OR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_OR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: OR 2 1 NaN if B == NaN, else A.  */
 {
 	uint64_t s, row;
@@ -3799,7 +3799,7 @@ GMT_LOCAL int table_OR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		a = (S[prev]->constant) ? S[prev]->factor : T_prev->segment[s]->data[col][row];
@@ -3809,7 +3809,7 @@ GMT_LOCAL int table_OR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_PERM (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_PERM (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: PERM 2 1 Permutations n_P_r, with n = A and r = B.  */
 {
 	uint64_t s, row;
@@ -3817,7 +3817,7 @@ GMT_LOCAL int table_PERM (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && S[prev]->factor < 0.0) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Argument n to PERM must be a positive integer (n >= 0)!\n");
@@ -3841,7 +3841,7 @@ GMT_LOCAL int table_PERM (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_PLM (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_PLM (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: PLM 3 1 Associated Legendre polynomial P(A) degree B order C.  */
 {
 	uint64_t s, row;
@@ -3866,7 +3866,7 @@ GMT_LOCAL int table_PLM (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_PLMg (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_PLMg (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: PLMg 3 1 Normalized associated Legendre polynomial P(A) degree B order C (geophysical convention).  */
 {
 	uint64_t s, row;
@@ -3890,7 +3890,7 @@ GMT_LOCAL int table_PLMg (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_POP (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_POP (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: POP 1 0 Delete top element from the stack.  */
 {
 	gmt_M_unused(GMT); gmt_M_unused(info); gmt_M_unused(S); gmt_M_unused(last); gmt_M_unused(col);
@@ -3898,7 +3898,7 @@ GMT_LOCAL int table_POP (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_POW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_POW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: POW 2 1 A ^ B.  */
 {
 	uint64_t s, row;
@@ -3906,7 +3906,7 @@ GMT_LOCAL int table_POW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && S[prev]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "POW: Operand one == 0!\n");
 	if (S[last]->constant && S[last]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "POW: Operand two == 0!\n");
@@ -3918,7 +3918,7 @@ GMT_LOCAL int table_POW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_PPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_PPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: PPDF 2 1 Poisson probability density function for x = A and lambda = B.  */
 {
 	uint64_t s, row;
@@ -3926,7 +3926,7 @@ GMT_LOCAL int table_PPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	double x, lambda;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		lambda = (S[last]->constant) ? S[last]->factor : T->segment[s]->data[col][row];
@@ -3936,7 +3936,7 @@ GMT_LOCAL int table_PPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_PQUANT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_PQUANT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: PQUANT 2 1 The B'th Quantile (0-100%) of A.  */
 {
 	uint64_t s, row, k;
@@ -3983,7 +3983,7 @@ GMT_LOCAL int table_PQUANT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, str
 	return 0;
 }
 
-GMT_LOCAL int table_PQUANTW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_PQUANTW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: PQUANTW 3 1 The C'th Quantile (0-100%) of A for weights in B.  */
 {
 	uint64_t s, row, k = 0;
@@ -4042,7 +4042,7 @@ GMT_LOCAL int table_PQUANTW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_PSI (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_PSI (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: PSI 1 1 Psi (or Digamma) of A.  */
 {
 	uint64_t s, row;
@@ -4064,7 +4064,7 @@ GMT_LOCAL int table_PSI (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_PVQV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col, unsigned int kind)
+GMT_LOCAL int gmtmath_PVQV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col, unsigned int kind)
 {	/* kind: 0 = Pv, 1 = Qv */
 	uint64_t s, row;
 	unsigned int n, prev, first, calc;
@@ -4104,21 +4104,21 @@ GMT_LOCAL int table_PVQV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_PV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_PV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: PV 3 1 Legendre function Pv(A) of degree v = real(B) + imag(C).  */
 {
-	table_PVQV (GMT, info, S, last, col, 0);
+	gmtmath_PVQV (GMT, info, S, last, col, 0);
 	return 0;
 }
 
-GMT_LOCAL int table_QV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_QV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: QV 3 1 Legendre function Qv(A) of degree v = real(B) + imag(C).  */
 {
-	table_PVQV (GMT, info, S, last, col, 1);
+	gmtmath_PVQV (GMT, info, S, last, col, 1);
 	return 0;
 }
 
-GMT_LOCAL int table_R2 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_R2 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: R2 2 1 R2 = A^2 + B^2.  */
 {
 	uint64_t s, row;
@@ -4126,7 +4126,7 @@ GMT_LOCAL int table_R2 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && S[prev]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "R2: Operand one == 0!\n");
 	if (S[last]->constant && S[last]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "R2: Operand two == 0!\n");
@@ -4140,7 +4140,7 @@ GMT_LOCAL int table_R2 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_R2D (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_R2D (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: R2D 1 1 Convert Radians to Degrees.  */
 {
 	uint64_t s, row;
@@ -4153,7 +4153,7 @@ GMT_LOCAL int table_R2D (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_RAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_RAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: RAND 2 1 Uniform random values between A and B.  */
 {
 	uint64_t s, row;
@@ -4161,7 +4161,7 @@ GMT_LOCAL int table_RAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	double a = 0.0, b = 0.0;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) a = S[prev]->factor;
 	if (S[last]->constant) b = S[last]->factor;
@@ -4173,7 +4173,7 @@ GMT_LOCAL int table_RAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_RCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_RCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: RCDF 1 1 Rayleigh cumulative distribution function for z = A.  */
 {
 	uint64_t s, row;
@@ -4188,7 +4188,7 @@ GMT_LOCAL int table_RCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_RCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_RCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: RCRIT 1 1 Rayleigh distribution critical value for alpha = A.  */
 {
 	uint64_t s, row;
@@ -4203,7 +4203,7 @@ GMT_LOCAL int table_RCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_RPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_RPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: RPDF 1 1 Rayleigh probability density function for z = A.  */
 {
 	uint64_t s, row;
@@ -4218,7 +4218,7 @@ GMT_LOCAL int table_RPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_RGB2HSV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_RGB2HSV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: RGB2HSV 3 3 Convert RGB to HSV, with r = A, b = B and b = C.  */
 	uint64_t s = 0, row;
 	double rgb[4], hsv[4];
@@ -4266,7 +4266,7 @@ GMT_LOCAL int table_RGB2HSV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_RGB2LAB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_RGB2LAB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: RGB2LAB 3 3 Convert RGB to LAB, with r = A, g = B and b = C.  */
 	uint64_t s = 0, row;
 	double rgb[3], lab[3];
@@ -4313,7 +4313,7 @@ GMT_LOCAL int table_RGB2LAB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_RGB2XYZ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_RGB2XYZ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: RGB2XYZ 3 3 Convert RGB to LAB, with r = A, g = B and b = C.  */
 	uint64_t s = 0, row;
 	double rgb[3], xyz[3];
@@ -4360,7 +4360,7 @@ GMT_LOCAL int table_RGB2XYZ (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_RINT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_RINT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: RINT 1 1 rint (A) (round to integral value nearest to A).  */
 {
 	uint64_t s, row;
@@ -4373,7 +4373,7 @@ GMT_LOCAL int table_RINT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_RMS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_RMS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: RMS 1 1 Root-mean-square of A.  */
 {
 	uint64_t s, row, n = 0;
@@ -4403,7 +4403,7 @@ GMT_LOCAL int table_RMS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_RMSW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_RMSW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: RMSW 2 1 Weighted Root-mean-square of A for weights in B.  */
 {
 	uint64_t s, row, n = 0;
@@ -4411,7 +4411,7 @@ GMT_LOCAL int table_RMSW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	double sum2 = 0.0, sumw = 0.0, w;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) sum2 = S[prev]->factor;
 	for (s = 0; s < info->T->n_segments; s++) {
@@ -4443,14 +4443,14 @@ GMT_LOCAL int table_RMSW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL void assign_gmtstack (struct GMTMATH_STACK *Sto, struct GMTMATH_STACK *Sfrom)
+GMT_LOCAL void gmtmath_assign_stack (struct GMTMATH_STACK *Sto, struct GMTMATH_STACK *Sfrom)
 {	/* Copy contents of Sfrom to Sto */
 	Sto->D          = Sfrom->D;
 	Sto->constant   = Sfrom->constant;
 	Sto->factor     = Sfrom->factor;
 }
 
-GMT_LOCAL int table_ROLL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_ROLL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: ROLL 2 0 Cyclicly shifts the top A stack items by an amount B.  */
 {
 	unsigned int prev, top, bottom, k, kk, n_items;
@@ -4473,22 +4473,22 @@ GMT_LOCAL int table_ROLL (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	bottom = prev - n_items;
 	for (k = 0; k < (unsigned int)abs (n_shift); k++) {	/* Do the cyclical shift */
 		if (n_shift > 0) {	/* Positive roll */
-			assign_gmtstack (&Stmp, S[top]);	/* Keep copy of top item */
+			gmtmath_assign_stack (&Stmp, S[top]);	/* Keep copy of top item */
 			for (kk = 1; kk < n_items; kk++)	/* Move all others up one step */
-				assign_gmtstack (S[top-kk+1], S[top-kk]);
-			assign_gmtstack (S[bottom], &Stmp);	/* Place copy on bottom */
+				gmtmath_assign_stack (S[top-kk+1], S[top-kk]);
+			gmtmath_assign_stack (S[bottom], &Stmp);	/* Place copy on bottom */
 		}
 		else if (n_shift < 0) {	/* Negative roll */
-			assign_gmtstack (&Stmp, S[bottom]);	/* Keep copy of bottom item */
+			gmtmath_assign_stack (&Stmp, S[bottom]);	/* Keep copy of bottom item */
 			for (kk = 1; kk < n_items; kk++)	/* Move all others down one step */
-				assign_gmtstack (S[bottom+kk-1], S[bottom+kk]);
-			assign_gmtstack (S[top], &Stmp);	/* Place copy on top */
+				gmtmath_assign_stack (S[bottom+kk-1], S[bottom+kk]);
+			gmtmath_assign_stack (S[top], &Stmp);	/* Place copy on top */
 		}
 	}
 	return 0;
 }
 
-GMT_LOCAL int table_ROTT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_ROTT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: ROTT 2 1 Rotate A by the (constant) shift B in the t-direction.  */
 {
 	uint64_t s, row, j, k;
@@ -4532,7 +4532,7 @@ GMT_LOCAL int table_ROTT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_SEC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SEC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SEC 1 1 sec (A) (A in radians).  */
 {
 	uint64_t s, row;
@@ -4545,7 +4545,7 @@ GMT_LOCAL int table_SEC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_SECD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SECD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SECD 1 1 sec (A) (A in degrees).  */
 {
 	uint64_t s, row;
@@ -4558,7 +4558,7 @@ GMT_LOCAL int table_SECD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_SECH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SECH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SECH 1 1 sech (A).  */
 {
 	uint64_t s, row;
@@ -4571,7 +4571,7 @@ GMT_LOCAL int table_SECH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_SIGN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SIGN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SIGN 1 1 sign (+1 or -1) of A.  */
 {
 	uint64_t s, row;
@@ -4584,7 +4584,7 @@ GMT_LOCAL int table_SIGN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_SIN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SIN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SIN 1 1 sin (A) (A in radians).  */
 {
 	uint64_t s, row;
@@ -4597,7 +4597,7 @@ GMT_LOCAL int table_SIN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_SINC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SINC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SINC 1 1 sinc (A) (sin (pi*A)/(pi*A)).  */
 {
 	uint64_t s, row;
@@ -4609,7 +4609,7 @@ GMT_LOCAL int table_SINC (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_SIND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SIND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SIND 1 1 sin (A) (A in degrees).  */
 {
 	uint64_t s, row;
@@ -4622,7 +4622,7 @@ GMT_LOCAL int table_SIND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_SINH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SINH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SINH 1 1 sinh (A).  */
 {
 	uint64_t s, row;
@@ -4635,7 +4635,7 @@ GMT_LOCAL int table_SINH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_SKEW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SKEW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SKEW 1 1 Skewness of A.  */
 {
 	uint64_t s, row, n = 0;
@@ -4688,7 +4688,7 @@ GMT_LOCAL int table_SKEW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL void free_sort_list (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info) {
+GMT_LOCAL void gmtmath_free_sort_list (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info) {
 	/* Free any column sorting helper arrays */
 	uint64_t s;
 	if (info->Q == NULL) return;
@@ -4697,7 +4697,7 @@ GMT_LOCAL void free_sort_list (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info) 
 	gmt_M_free (GMT, info->Q);
 }
 
-GMT_LOCAL int table_SORT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SORT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SORT 3 1 Sort all columns in stack based on column A in direction of B (-1 descending |+1 ascending).  */
 {
 	uint64_t s, seg, row, k0 = 0, k = 0;
@@ -4760,7 +4760,7 @@ GMT_LOCAL int table_SORT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_SQR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SQR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SQR 1 1 A^2.  */
 {
 	uint64_t s, row;
@@ -4773,7 +4773,7 @@ GMT_LOCAL int table_SQR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_SQRT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SQRT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SQRT 1 1 sqrt (A).  */
 {
 	uint64_t s, row;
@@ -4786,7 +4786,7 @@ GMT_LOCAL int table_SQRT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_STD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_STD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: STD 1 1 Standard deviation of A.  */
 {
 	uint64_t s, row;
@@ -4819,7 +4819,7 @@ GMT_LOCAL int table_STD (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_STDW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_STDW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: STDW 2 1 Weighted standard deviation of A for weights in B.  */
 {
 	uint64_t s, row;
@@ -4827,7 +4827,7 @@ GMT_LOCAL int table_STDW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	double std;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && info->T->n_records < 2)	/* Trivial case: std is undefined */
 		std = GMT->session.d_NaN;
@@ -4864,7 +4864,7 @@ GMT_LOCAL int table_STDW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_STEP (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_STEP (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: STEP 1 1 Heaviside step function H(A).  */
 {
 	uint64_t s, row;
@@ -4882,7 +4882,7 @@ GMT_LOCAL int table_STEP (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_STEPT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_STEPT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: STEPT 1 1 Heaviside step function H(t-A).  */
 {
 	uint64_t s, row;
@@ -4900,7 +4900,7 @@ GMT_LOCAL int table_STEPT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_SUB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SUB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SUB 2 1 A - B.  */
 {
 	uint64_t s, row;
@@ -4908,7 +4908,7 @@ GMT_LOCAL int table_SUB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && S[prev]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "SUB: Operand one == 0!\n");
 	if (S[last]->constant && S[last]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "SUB: Operand two == 0!\n");
@@ -4920,7 +4920,7 @@ GMT_LOCAL int table_SUB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_SUM (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SUM (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SUM 1 1 Cumulative sum of A.  */
 {
 	uint64_t s, row;
@@ -4940,17 +4940,17 @@ GMT_LOCAL int table_SUM (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_SVDFIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_SVDFIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: SVDFIT 1 0 Current table is [A | b]; return LS solution to A * x = B via SVD decomposition (see -E).  */
 {
 	gmt_M_unused(GMT); gmt_M_unused(info); gmt_M_unused(S); gmt_M_unused(last); gmt_M_unused(col);
-	/* Dummy routine needed since the automatically generated include file will have table_SVDFIT
+	/* Dummy routine needed since the automatically generated include file will have gmtmath_SVDFIT
 	 * with these parameters just like any other function.  However, when we find SVDFIT we will
-	 * instead call solve_SVDFIT which can be found at the end of these functions */
+	 * instead call gmtmath_solve_SVDFIT which can be found at the end of these functions */
 	return 0;
 }
 
-GMT_LOCAL int table_TAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_TAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: TAN 1 1 tan (A) (A in radians).  */
 {
 	uint64_t s, row;
@@ -4963,7 +4963,7 @@ GMT_LOCAL int table_TAN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_TAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_TAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: TAND 1 1 tan (A) (A in degrees).  */
 {
 	uint64_t s, row;
@@ -4976,7 +4976,7 @@ GMT_LOCAL int table_TAND (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_TANH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_TANH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: TANH 1 1 tanh (A).  */
 {
 	uint64_t s, row;
@@ -4989,7 +4989,7 @@ GMT_LOCAL int table_TANH (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_TAPER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_TAPER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: TAPER 1 1 Unit weights cosine-tapered to zero within A of end margins.  */
 {
 	/* If no time, then A is interpreted to mean number of nodes instead */
@@ -5026,7 +5026,7 @@ GMT_LOCAL int table_TAPER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_TCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_TCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: TCDF 2 1 Student's t cumulative distribution function for t = A and nu = B.  */
 {
 	uint64_t s, row, nu;
@@ -5034,7 +5034,7 @@ GMT_LOCAL int table_TCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	double t;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		nu = lrint ((S[last]->constant) ? S[last]->factor : T->segment[s]->data[col][row]);
@@ -5044,7 +5044,7 @@ GMT_LOCAL int table_TCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_TN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_TN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: TN 2 1 Chebyshev polynomial Tn(-1<A<+1) of degree B.  */
 {
 	uint64_t s, row;
@@ -5053,7 +5053,7 @@ GMT_LOCAL int table_TN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	double a;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		n = irint ((S[last]->constant) ? S[last]->factor : T->segment[s]->data[col][row]);
@@ -5063,7 +5063,7 @@ GMT_LOCAL int table_TN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_TPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_TPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: TPDF 2 1 Student's t probability density function for t = A and nu = B.  */
 {
 	uint64_t s, row, nu;
@@ -5071,7 +5071,7 @@ GMT_LOCAL int table_TPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	double t;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	for (s = 0; s < info->T->n_segments; s++) for (row = 0; row < info->T->segment[s]->n_rows; row++) {
 		nu = lrint ((S[last]->constant) ? S[last]->factor : T->segment[s]->data[col][row]);
@@ -5081,7 +5081,7 @@ GMT_LOCAL int table_TPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_TCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_TCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: TCRIT 2 1 Student's t distribution critical value for alpha = A and nu = B.  */
 {
 	uint64_t s, row;
@@ -5089,7 +5089,7 @@ GMT_LOCAL int table_TCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	double a, b;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && S[prev]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Operand one == 0 for TCRIT!\n");
 	if (S[last]->constant && S[last]->factor == 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "Operand two == 0 for TCRIT!\n");
@@ -5101,7 +5101,7 @@ GMT_LOCAL int table_TCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_UPPER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_UPPER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: UPPER 1 1 The highest (maximum) value of A.  */
 {
 	uint64_t s, row;
@@ -5127,7 +5127,7 @@ GMT_LOCAL int table_UPPER (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_VAR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_VAR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: VAR 1 1 Variance of A.  */
 {
 	uint64_t s, row;
@@ -5160,7 +5160,7 @@ GMT_LOCAL int table_VAR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_VARW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_VARW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: VARW 2 1 Weighted variance of A for weights in B.  */
 {
 	uint64_t s, row;
@@ -5168,7 +5168,7 @@ GMT_LOCAL int table_VARW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	double var;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant && info->T->n_records < 2)	/* Trivial case: variance is undefined */
 		var = GMT->session.d_NaN;
@@ -5205,7 +5205,7 @@ GMT_LOCAL int table_VARW (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_WCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_WCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: WCDF 3 1 Weibull cumulative distribution function for x = A, scale = B, and shape = C.  */
 {
 	uint64_t s, row;
@@ -5224,7 +5224,7 @@ GMT_LOCAL int table_WCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_WCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_WCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: WCRIT 3 1 Weibull distribution critical value for alpha = A, scale = B, and shape = C.  */
 {
 	uint64_t s, row;
@@ -5243,7 +5243,7 @@ GMT_LOCAL int table_WCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_WPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_WPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: WPDF 3 1 Weibull probability density function for x = A, scale = B and shape = C.  */
 {
 	unsigned int prev1 = last - 1, prev2 = last - 2;
@@ -5280,7 +5280,7 @@ GMT_LOCAL int table_WPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_XOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_XOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: XOR 2 1 B if A == NaN, else A.  */
 {
 	uint64_t s, row;
@@ -5289,7 +5289,7 @@ GMT_LOCAL int table_XOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 	gmt_M_unused(GMT);
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[prev]->constant) a = S[prev]->factor;
 	if (S[last]->constant) b = S[last]->factor;
@@ -5301,7 +5301,7 @@ GMT_LOCAL int table_XOR (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct
 	return 0;
 }
 
-GMT_LOCAL int table_XYZ2HSV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_XYZ2HSV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: XYZ2HSV 3 3 Convert XYZ to HSV, with x = A, y = B and z = C.  */
 	uint64_t s = 0, row;
 	double rgb[4], hsv[4], xyz[3];
@@ -5353,7 +5353,7 @@ GMT_LOCAL int table_XYZ2HSV (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_XYZ2LAB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_XYZ2LAB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: XYZ2LAB 3 3 Convert XYZ to LAB, with x = A, y = B and z = C.  */
 	uint64_t s = 0, row;
 	double lab[3], xyz[3];
@@ -5403,7 +5403,7 @@ GMT_LOCAL int table_XYZ2LAB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_XYZ2RGB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
+GMT_LOCAL int gmtmath_XYZ2RGB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col) {
 /*OPERATOR: XYZ2RGB 3 3 Convert XYZ to RGB, with x = A, y = B and z = C.  */
 	uint64_t s = 0, row;
 	double rgb[3], xyz[3];
@@ -5453,7 +5453,7 @@ GMT_LOCAL int table_XYZ2RGB (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 	return 0;
 }
 
-GMT_LOCAL int table_Y0 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_Y0 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: Y0 1 1 Bessel function of A (2nd kind, order 0).  */
 {
 	uint64_t s, row;
@@ -5466,7 +5466,7 @@ GMT_LOCAL int table_Y0 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_Y1 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_Y1 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: Y1 1 1 Bessel function of A (2nd kind, order 1).  */
 {
 	uint64_t s, row;
@@ -5479,7 +5479,7 @@ GMT_LOCAL int table_Y1 (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_YN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_YN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: YN 2 1 Bessel function of A (2nd kind, order B).  */
 {
 	uint64_t s, row;
@@ -5488,7 +5488,7 @@ GMT_LOCAL int table_YN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	double b = 0.0;
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 
-	if ((prev = gmt_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if ((prev = gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev)) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	if (S[last]->constant && S[last]->factor < 0.0) GMT_Report (GMT->parent, GMT_MSG_WARNING, "order < 0 for YN!\n");
 	if (S[last]->constant && fabs (rint(S[last]->factor) - S[last]->factor) > GMT_CONV4_LIMIT) GMT_Report (GMT->parent, GMT_MSG_WARNING, "order not an integer for YN!\n");
@@ -5509,7 +5509,7 @@ GMT_LOCAL int table_YN (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct 
 	return 0;
 }
 
-GMT_LOCAL int table_ZCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_ZCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: ZCRIT 1 1 Normal distribution critical value for alpha = A.  */
 {
 	uint64_t s, row;
@@ -5521,7 +5521,7 @@ GMT_LOCAL int table_ZCRIT (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	return 0;
 }
 
-GMT_LOCAL int table_ZCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_ZCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: ZCDF 1 1 Normal cumulative distribution function for z = A.  */
 {
 	uint64_t s, row;
@@ -5533,7 +5533,7 @@ GMT_LOCAL int table_ZCDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_ZPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_ZPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: ZPDF 1 1 Normal probability density function for z = A.  */
 {
 	uint64_t s, row;
@@ -5546,7 +5546,7 @@ GMT_LOCAL int table_ZPDF (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL int table_ROOTS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
+GMT_LOCAL int gmtmath_ROOTS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, struct GMTMATH_STACK *S[], unsigned int last, unsigned int col)
 /*OPERATOR: ROOTS 2 1 Treats col A as f(t) = 0 and returns its roots.  */
 {
 	uint64_t seg, row;
@@ -5556,7 +5556,7 @@ GMT_LOCAL int table_ROOTS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, stru
 	struct GMT_DATATABLE *T = NULL, *T_prev = NULL;
 	gmt_M_unused(col);
 
-	if (gmt_assign_ptrs (GMT, last, S, &T, &T_prev) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
+	if (gmtmath_assign_ptrs (GMT, last, S, &T, &T_prev) == UINT_MAX) return -1;	/* Set up pointers and prev; exit if running out of stack */
 
 	/* Treats the chosen column (at there is only one) as f(t) and solves for t that makes f(t) == 0.
 	 * For now we only solve using a linear spline but in the future this should depend on the users
@@ -5608,206 +5608,206 @@ GMT_LOCAL void gmtmath_init (int (*ops[])(struct GMT_CTRL *, struct GMTMATH_INFO
 {
 	/* Operator function	# of operands	# of outputs */
 
-	ops[0] = table_ABS;	n_args[0] = 1;	n_out[0] = 1;
-	ops[1] = table_ACOS;	n_args[1] = 1;	n_out[1] = 1;
-	ops[2] = table_ACOSH;	n_args[2] = 1;	n_out[2] = 1;
-	ops[3] = table_ACOT;	n_args[3] = 1;	n_out[3] = 1;
-	ops[4] = table_ACOTH;	n_args[4] = 1;	n_out[4] = 1;
-	ops[5] = table_ACSC;	n_args[5] = 1;	n_out[5] = 1;
-	ops[6] = table_ACSCH;	n_args[6] = 1;	n_out[6] = 1;
-	ops[7] = table_ADD;	n_args[7] = 2;	n_out[7] = 1;
-	ops[8] = table_AND;	n_args[8] = 2;	n_out[8] = 1;
-	ops[9] = table_ASEC;	n_args[9] = 1;	n_out[9] = 1;
-	ops[10] = table_ASECH;	n_args[10] = 1;	n_out[10] = 1;
-	ops[11] = table_ASIN;	n_args[11] = 1;	n_out[11] = 1;
-	ops[12] = table_ASINH;	n_args[12] = 1;	n_out[12] = 1;
-	ops[13] = table_ATAN;	n_args[13] = 1;	n_out[13] = 1;
-	ops[14] = table_ATAN2;	n_args[14] = 2;	n_out[14] = 1;
-	ops[15] = table_ATANH;	n_args[15] = 1;	n_out[15] = 1;
-	ops[16] = table_BCDF;	n_args[16] = 3;	n_out[16] = 1;
-	ops[17] = table_BEI;	n_args[17] = 1;	n_out[17] = 1;
-	ops[18] = table_BER;	n_args[18] = 1;	n_out[18] = 1;
-	ops[19] = table_BPDF;	n_args[19] = 3;	n_out[19] = 1;
-	ops[20] = table_BITAND;	n_args[20] = 2;	n_out[20] = 1;
-	ops[21] = table_BITLEFT;	n_args[21] = 2;	n_out[21] = 1;
-	ops[22] = table_BITNOT;	n_args[22] = 1;	n_out[22] = 1;
-	ops[23] = table_BITOR;	n_args[23] = 2;	n_out[23] = 1;
-	ops[24] = table_BITRIGHT;	n_args[24] = 2;	n_out[24] = 1;
-	ops[25] = table_BITTEST;	n_args[25] = 2;	n_out[25] = 1;
-	ops[26] = table_BITXOR;	n_args[26] = 2;	n_out[26] = 1;
-	ops[27] = table_CEIL;	n_args[27] = 1;	n_out[27] = 1;
-	ops[28] = table_CHI2CRIT;	n_args[28] = 2;	n_out[28] = 1;
-	ops[29] = table_CHI2CDF;	n_args[29] = 2;	n_out[29] = 1;
-	ops[30] = table_CHI2PDF;	n_args[30] = 2;	n_out[30] = 1;
-	ops[31] = table_COL;	n_args[31] = 1;	n_out[31] = 1;
-	ops[32] = table_COMB;	n_args[32] = 2;	n_out[32] = 1;
-	ops[33] = table_CORRCOEFF;	n_args[33] = 2;	n_out[33] = 1;
-	ops[34] = table_COS;	n_args[34] = 1;	n_out[34] = 1;
-	ops[35] = table_COSD;	n_args[35] = 1;	n_out[35] = 1;
-	ops[36] = table_COSH;	n_args[36] = 1;	n_out[36] = 1;
-	ops[37] = table_COT;	n_args[37] = 1;	n_out[37] = 1;
-	ops[38] = table_COTD;	n_args[38] = 1;	n_out[38] = 1;
-	ops[39] = table_COTH;	n_args[39] = 1;	n_out[39] = 1;
-	ops[40] = table_CSC;	n_args[40] = 1;	n_out[40] = 1;
-	ops[41] = table_CSCD;	n_args[41] = 1;	n_out[41] = 1;
-	ops[42] = table_CSCH;	n_args[42] = 1;	n_out[42] = 1;
-	ops[43] = table_PCDF;	n_args[43] = 2;	n_out[43] = 1;
-	ops[44] = table_DDT;	n_args[44] = 1;	n_out[44] = 1;
-	ops[45] = table_D2DT2;	n_args[45] = 1;	n_out[45] = 1;
-	ops[46] = table_D2R;	n_args[46] = 1;	n_out[46] = 1;
-	ops[47] = table_DENAN;	n_args[47] = 2;	n_out[47] = 1;
-	ops[48] = table_DILOG;	n_args[48] = 1;	n_out[48] = 1;
-	ops[49] = table_DIFF;	n_args[49] = 1;	n_out[49] = 1;
-	ops[50] = table_DIV;	n_args[50] = 2;	n_out[50] = 1;
-	ops[51] = table_DUP;	n_args[51] = 1;	n_out[51] = 2;
-	ops[52] = table_ECDF;	n_args[52] = 2;	n_out[52] = 1;
-	ops[53] = table_ECRIT;	n_args[53] = 2;	n_out[53] = 1;
-	ops[54] = table_EPDF;	n_args[54] = 2;	n_out[54] = 1;
-	ops[55] = table_ERF;	n_args[55] = 1;	n_out[55] = 1;
-	ops[56] = table_ERFC;	n_args[56] = 1;	n_out[56] = 1;
-	ops[57] = table_ERFINV;	n_args[57] = 1;	n_out[57] = 1;
-	ops[58] = table_EQ;	n_args[58] = 2;	n_out[58] = 1;
-	ops[59] = table_EXCH;	n_args[59] = 2;	n_out[59] = 2;
-	ops[60] = table_EXP;	n_args[60] = 1;	n_out[60] = 1;
-	ops[61] = table_FACT;	n_args[61] = 1;	n_out[61] = 1;
-	ops[62] = table_FCRIT;	n_args[62] = 3;	n_out[62] = 1;
-	ops[63] = table_FCDF;	n_args[63] = 3;	n_out[63] = 1;
-	ops[64] = table_FLIPUD;	n_args[64] = 1;	n_out[64] = 1;
-	ops[65] = table_FLOOR;	n_args[65] = 1;	n_out[65] = 1;
-	ops[66] = table_FMOD;	n_args[66] = 2;	n_out[66] = 1;
-	ops[67] = table_FPDF;	n_args[67] = 3;	n_out[67] = 1;
-	ops[68] = table_GE;	n_args[68] = 2;	n_out[68] = 1;
-	ops[69] = table_GT;	n_args[69] = 2;	n_out[69] = 1;
-	ops[70] = table_HYPOT;	n_args[70] = 2;	n_out[70] = 1;
-	ops[71] = table_I0;	n_args[71] = 1;	n_out[71] = 1;
-	ops[72] = table_I1;	n_args[72] = 1;	n_out[72] = 1;
-	ops[73] = table_IFELSE;	n_args[73] = 3;	n_out[73] = 1;
-	ops[74] = table_IN;	n_args[74] = 2;	n_out[74] = 1;
-	ops[75] = table_INRANGE;	n_args[75] = 3;	n_out[75] = 1;
-	ops[76] = table_INT;	n_args[76] = 1;	n_out[76] = 1;
-	ops[77] = table_INV;	n_args[77] = 1;	n_out[77] = 1;
-	ops[78] = table_ISFINITE;	n_args[78] = 1;	n_out[78] = 1;
-	ops[79] = table_ISNAN;	n_args[79] = 1;	n_out[79] = 1;
-	ops[80] = table_J0;	n_args[80] = 1;	n_out[80] = 1;
-	ops[81] = table_J1;	n_args[81] = 1;	n_out[81] = 1;
-	ops[82] = table_JN;	n_args[82] = 2;	n_out[82] = 1;
-	ops[83] = table_K0;	n_args[83] = 1;	n_out[83] = 1;
-	ops[84] = table_K1;	n_args[84] = 1;	n_out[84] = 1;
-	ops[85] = table_KN;	n_args[85] = 2;	n_out[85] = 1;
-	ops[86] = table_KEI;	n_args[86] = 1;	n_out[86] = 1;
-	ops[87] = table_KER;	n_args[87] = 1;	n_out[87] = 1;
-	ops[88] = table_KURT;	n_args[88] = 1;	n_out[88] = 1;
-	ops[89] = table_LCDF;	n_args[89] = 1;	n_out[89] = 1;
-	ops[90] = table_LCRIT;	n_args[90] = 1;	n_out[90] = 1;
-	ops[91] = table_LE;	n_args[91] = 2;	n_out[91] = 1;
-	ops[92] = table_LMSSCL;	n_args[92] = 1;	n_out[92] = 1;
-	ops[93] = table_LMSSCLW;	n_args[93] = 1;	n_out[93] = 1;
-	ops[94] = table_LOG;	n_args[94] = 1;	n_out[94] = 1;
-	ops[95] = table_LOG10;	n_args[95] = 1;	n_out[95] = 1;
-	ops[96] = table_LOG1P;	n_args[96] = 1;	n_out[96] = 1;
-	ops[97] = table_LOG2;	n_args[97] = 1;	n_out[97] = 1;
-	ops[98] = table_LOWER;	n_args[98] = 1;	n_out[98] = 1;
-	ops[99] = table_LPDF;	n_args[99] = 1;	n_out[99] = 1;
-	ops[100] = table_LRAND;	n_args[100] = 2;	n_out[100] = 1;
-	ops[101] = table_LSQFIT;	n_args[101] = 1;	n_out[101] = 0;
-	ops[102] = table_LT;	n_args[102] = 2;	n_out[102] = 1;
-	ops[103] = table_MAD;	n_args[103] = 1;	n_out[103] = 1;
-	ops[104] = table_MADW;	n_args[104] = 2;	n_out[104] = 1;
-	ops[105] = table_MAX;	n_args[105] = 2;	n_out[105] = 1;
-	ops[106] = table_MEAN;	n_args[106] = 1;	n_out[106] = 1;
-	ops[107] = table_MEANW;	n_args[107] = 2;	n_out[107] = 1;
-	ops[108] = table_MEDIAN;	n_args[108] = 1;	n_out[108] = 1;
-	ops[109] = table_MEDIANW;	n_args[109] = 2;	n_out[109] = 1;
-	ops[110] = table_MIN;	n_args[110] = 2;	n_out[110] = 1;
-	ops[111] = table_MOD;	n_args[111] = 2;	n_out[111] = 1;
-	ops[112] = table_MODE;	n_args[112] = 1;	n_out[112] = 1;
-	ops[113] = table_MODEW;	n_args[113] = 2;	n_out[113] = 1;
-	ops[114] = table_MUL;	n_args[114] = 2;	n_out[114] = 1;
-	ops[115] = table_NAN;	n_args[115] = 2;	n_out[115] = 1;
-	ops[116] = table_NEG;	n_args[116] = 1;	n_out[116] = 1;
-	ops[117] = table_NEQ;	n_args[117] = 2;	n_out[117] = 1;
-	ops[118] = table_NORM;	n_args[118] = 1;	n_out[118] = 1;
-	ops[119] = table_NOT;	n_args[119] = 1;	n_out[119] = 1;
-	ops[120] = table_NRAND;	n_args[120] = 2;	n_out[120] = 1;
-	ops[121] = table_OR;	n_args[121] = 2;	n_out[121] = 1;
-	ops[122] = table_PERM;	n_args[122] = 2;	n_out[122] = 1;
-	ops[123] = table_PLM;	n_args[123] = 3;	n_out[123] = 1;
-	ops[124] = table_PLMg;	n_args[124] = 3;	n_out[124] = 1;
-	ops[125] = table_POP;	n_args[125] = 1;	n_out[125] = 0;
-	ops[126] = table_POW;	n_args[126] = 2;	n_out[126] = 1;
-	ops[127] = table_PPDF;	n_args[127] = 2;	n_out[127] = 1;
-	ops[128] = table_PQUANT;	n_args[128] = 2;	n_out[128] = 1;
-	ops[129] = table_PQUANTW;	n_args[129] = 3;	n_out[129] = 1;
-	ops[130] = table_PSI;	n_args[130] = 1;	n_out[130] = 1;
-	ops[131] = table_PV;	n_args[131] = 3;	n_out[131] = 1;
-	ops[132] = table_QV;	n_args[132] = 3;	n_out[132] = 1;
-	ops[133] = table_R2;	n_args[133] = 2;	n_out[133] = 1;
-	ops[134] = table_R2D;	n_args[134] = 1;	n_out[134] = 1;
-	ops[135] = table_RAND;	n_args[135] = 2;	n_out[135] = 1;
-	ops[136] = table_RCDF;	n_args[136] = 1;	n_out[136] = 1;
-	ops[137] = table_RCRIT;	n_args[137] = 1;	n_out[137] = 1;
-	ops[138] = table_RPDF;	n_args[138] = 1;	n_out[138] = 1;
-	ops[139] = table_RINT;	n_args[139] = 1;	n_out[139] = 1;
-	ops[140] = table_RMS;	n_args[140] = 1;	n_out[140] = 1;
-	ops[141] = table_RMSW;	n_args[141] = 2;	n_out[141] = 1;
-	ops[142] = table_ROLL;	n_args[142] = 2;	n_out[142] = 0;
-	ops[143] = table_ROTT;	n_args[143] = 2;	n_out[143] = 1;
-	ops[144] = table_SEC;	n_args[144] = 1;	n_out[144] = 1;
-	ops[145] = table_SECD;	n_args[145] = 1;	n_out[145] = 1;
-	ops[146] = table_SECH;	n_args[146] = 1;	n_out[146] = 1;
-	ops[147] = table_SIGN;	n_args[147] = 1;	n_out[147] = 1;
-	ops[148] = table_SIN;	n_args[148] = 1;	n_out[148] = 1;
-	ops[149] = table_SINC;	n_args[149] = 1;	n_out[149] = 1;
-	ops[150] = table_SIND;	n_args[150] = 1;	n_out[150] = 1;
-	ops[151] = table_SINH;	n_args[151] = 1;	n_out[151] = 1;
-	ops[152] = table_SKEW;	n_args[152] = 1;	n_out[152] = 1;
-	ops[153] = table_SORT;	n_args[153] = 3;	n_out[153] = 1;
-	ops[154] = table_SQR;	n_args[154] = 1;	n_out[154] = 1;
-	ops[155] = table_SQRT;	n_args[155] = 1;	n_out[155] = 1;
-	ops[156] = table_STD;	n_args[156] = 1;	n_out[156] = 1;
-	ops[157] = table_STDW;	n_args[157] = 2;	n_out[157] = 1;
-	ops[158] = table_STEP;	n_args[158] = 1;	n_out[158] = 1;
-	ops[159] = table_STEPT;	n_args[159] = 1;	n_out[159] = 1;
-	ops[160] = table_SUB;	n_args[160] = 2;	n_out[160] = 1;
-	ops[161] = table_SUM;	n_args[161] = 1;	n_out[161] = 1;
-	ops[162] = table_SVDFIT;	n_args[162] = 1;	n_out[162] = 0;
-	ops[163] = table_TAN;	n_args[163] = 1;	n_out[163] = 1;
-	ops[164] = table_TAND;	n_args[164] = 1;	n_out[164] = 1;
-	ops[165] = table_TANH;	n_args[165] = 1;	n_out[165] = 1;
-	ops[166] = table_TAPER;	n_args[166] = 1;	n_out[166] = 1;
-	ops[167] = table_TCDF;	n_args[167] = 2;	n_out[167] = 1;
-	ops[168] = table_TN;	n_args[168] = 2;	n_out[168] = 1;
-	ops[169] = table_TPDF;	n_args[169] = 2;	n_out[169] = 1;
-	ops[170] = table_TCRIT;	n_args[170] = 2;	n_out[170] = 1;
-	ops[171] = table_UPPER;	n_args[171] = 1;	n_out[171] = 1;
-	ops[172] = table_VAR;	n_args[172] = 1;	n_out[172] = 1;
-	ops[173] = table_VARW;	n_args[173] = 2;	n_out[173] = 1;
-	ops[174] = table_WCDF;	n_args[174] = 3;	n_out[174] = 1;
-	ops[175] = table_WCRIT;	n_args[175] = 3;	n_out[175] = 1;
-	ops[176] = table_WPDF;	n_args[176] = 3;	n_out[176] = 1;
-	ops[177] = table_XOR;	n_args[177] = 2;	n_out[177] = 1;
-	ops[178] = table_Y0;	n_args[178] = 1;	n_out[178] = 1;
-	ops[179] = table_Y1;	n_args[179] = 1;	n_out[179] = 1;
-	ops[180] = table_YN;	n_args[180] = 2;	n_out[180] = 1;
-	ops[181] = table_ZCRIT;	n_args[181] = 1;	n_out[181] = 1;
-	ops[182] = table_ZCDF;	n_args[182] = 1;	n_out[182] = 1;
-	ops[183] = table_ZPDF;	n_args[183] = 1;	n_out[183] = 1;
-	ops[184] = table_ROOTS;	n_args[184] = 2;	n_out[184] = 1;
-	ops[185] = table_HSV2LAB;	n_args[185] = 3;	n_out[185] = 3;
-	ops[186] = table_HSV2RGB;	n_args[186] = 3;	n_out[186] = 3;
-	ops[187] = table_HSV2XYZ;	n_args[187] = 3;	n_out[187] = 3;
-	ops[188] = table_LAB2HSV;	n_args[188] = 3;	n_out[188] = 3;
-	ops[189] = table_LAB2RGB;	n_args[189] = 3;	n_out[189] = 3;
-	ops[190] = table_LAB2XYZ;	n_args[190] = 3;	n_out[190] = 3;
-	ops[191] = table_RGB2HSV;	n_args[191] = 3;	n_out[191] = 3;
-	ops[192] = table_RGB2LAB;	n_args[192] = 3;	n_out[192] = 3;
-	ops[193] = table_RGB2XYZ;	n_args[193] = 3;	n_out[193] = 3;
-	ops[194] = table_XYZ2HSV;	n_args[194] = 3;	n_out[194] = 3;
-	ops[195] = table_XYZ2LAB;	n_args[195] = 3;	n_out[195] = 3;
-	ops[196] = table_XYZ2RGB;	n_args[196] = 3;	n_out[196] = 3;
+	ops[0] = gmtmath_ABS;	n_args[0] = 1;	n_out[0] = 1;
+	ops[1] = gmtmath_ACOS;	n_args[1] = 1;	n_out[1] = 1;
+	ops[2] = gmtmath_ACOSH;	n_args[2] = 1;	n_out[2] = 1;
+	ops[3] = gmtmath_ACOT;	n_args[3] = 1;	n_out[3] = 1;
+	ops[4] = gmtmath_ACOTH;	n_args[4] = 1;	n_out[4] = 1;
+	ops[5] = gmtmath_ACSC;	n_args[5] = 1;	n_out[5] = 1;
+	ops[6] = gmtmath_ACSCH;	n_args[6] = 1;	n_out[6] = 1;
+	ops[7] = gmtmath_ADD;	n_args[7] = 2;	n_out[7] = 1;
+	ops[8] = gmtmath_AND;	n_args[8] = 2;	n_out[8] = 1;
+	ops[9] = gmtmath_ASEC;	n_args[9] = 1;	n_out[9] = 1;
+	ops[10] = gmtmath_ASECH;	n_args[10] = 1;	n_out[10] = 1;
+	ops[11] = gmtmath_ASIN;	n_args[11] = 1;	n_out[11] = 1;
+	ops[12] = gmtmath_ASINH;	n_args[12] = 1;	n_out[12] = 1;
+	ops[13] = gmtmath_ATAN;	n_args[13] = 1;	n_out[13] = 1;
+	ops[14] = gmtmath_ATAN2;	n_args[14] = 2;	n_out[14] = 1;
+	ops[15] = gmtmath_ATANH;	n_args[15] = 1;	n_out[15] = 1;
+	ops[16] = gmtmath_BCDF;	n_args[16] = 3;	n_out[16] = 1;
+	ops[17] = gmtmath_BEI;	n_args[17] = 1;	n_out[17] = 1;
+	ops[18] = gmtmath_BER;	n_args[18] = 1;	n_out[18] = 1;
+	ops[19] = gmtmath_BPDF;	n_args[19] = 3;	n_out[19] = 1;
+	ops[20] = gmtmath_BITAND;	n_args[20] = 2;	n_out[20] = 1;
+	ops[21] = gmtmath_BITLEFT;	n_args[21] = 2;	n_out[21] = 1;
+	ops[22] = gmtmath_BITNOT;	n_args[22] = 1;	n_out[22] = 1;
+	ops[23] = gmtmath_BITOR;	n_args[23] = 2;	n_out[23] = 1;
+	ops[24] = gmtmath_BITRIGHT;	n_args[24] = 2;	n_out[24] = 1;
+	ops[25] = gmtmath_BITTEST;	n_args[25] = 2;	n_out[25] = 1;
+	ops[26] = gmtmath_BITXOR;	n_args[26] = 2;	n_out[26] = 1;
+	ops[27] = gmtmath_CEIL;	n_args[27] = 1;	n_out[27] = 1;
+	ops[28] = gmtmath_CHI2CRIT;	n_args[28] = 2;	n_out[28] = 1;
+	ops[29] = gmtmath_CHI2CDF;	n_args[29] = 2;	n_out[29] = 1;
+	ops[30] = gmtmath_CHI2PDF;	n_args[30] = 2;	n_out[30] = 1;
+	ops[31] = gmtmath_COL;	n_args[31] = 1;	n_out[31] = 1;
+	ops[32] = gmtmath_COMB;	n_args[32] = 2;	n_out[32] = 1;
+	ops[33] = gmtmath_CORRCOEFF;	n_args[33] = 2;	n_out[33] = 1;
+	ops[34] = gmtmath_COS;	n_args[34] = 1;	n_out[34] = 1;
+	ops[35] = gmtmath_COSD;	n_args[35] = 1;	n_out[35] = 1;
+	ops[36] = gmtmath_COSH;	n_args[36] = 1;	n_out[36] = 1;
+	ops[37] = gmtmath_COT;	n_args[37] = 1;	n_out[37] = 1;
+	ops[38] = gmtmath_COTD;	n_args[38] = 1;	n_out[38] = 1;
+	ops[39] = gmtmath_COTH;	n_args[39] = 1;	n_out[39] = 1;
+	ops[40] = gmtmath_CSC;	n_args[40] = 1;	n_out[40] = 1;
+	ops[41] = gmtmath_CSCD;	n_args[41] = 1;	n_out[41] = 1;
+	ops[42] = gmtmath_CSCH;	n_args[42] = 1;	n_out[42] = 1;
+	ops[43] = gmtmath_PCDF;	n_args[43] = 2;	n_out[43] = 1;
+	ops[44] = gmtmath_DDT;	n_args[44] = 1;	n_out[44] = 1;
+	ops[45] = gmtmath_D2DT2;	n_args[45] = 1;	n_out[45] = 1;
+	ops[46] = gmtmath_D2R;	n_args[46] = 1;	n_out[46] = 1;
+	ops[47] = gmtmath_DENAN;	n_args[47] = 2;	n_out[47] = 1;
+	ops[48] = gmtmath_DILOG;	n_args[48] = 1;	n_out[48] = 1;
+	ops[49] = gmtmath_DIFF;	n_args[49] = 1;	n_out[49] = 1;
+	ops[50] = gmtmath_DIV;	n_args[50] = 2;	n_out[50] = 1;
+	ops[51] = gmtmath_DUP;	n_args[51] = 1;	n_out[51] = 2;
+	ops[52] = gmtmath_ECDF;	n_args[52] = 2;	n_out[52] = 1;
+	ops[53] = gmtmath_ECRIT;	n_args[53] = 2;	n_out[53] = 1;
+	ops[54] = gmtmath_EPDF;	n_args[54] = 2;	n_out[54] = 1;
+	ops[55] = gmtmath_ERF;	n_args[55] = 1;	n_out[55] = 1;
+	ops[56] = gmtmath_ERFC;	n_args[56] = 1;	n_out[56] = 1;
+	ops[57] = gmtmath_ERFINV;	n_args[57] = 1;	n_out[57] = 1;
+	ops[58] = gmtmath_EQ;	n_args[58] = 2;	n_out[58] = 1;
+	ops[59] = gmtmath_EXCH;	n_args[59] = 2;	n_out[59] = 2;
+	ops[60] = gmtmath_EXP;	n_args[60] = 1;	n_out[60] = 1;
+	ops[61] = gmtmath_FACT;	n_args[61] = 1;	n_out[61] = 1;
+	ops[62] = gmtmath_FCRIT;	n_args[62] = 3;	n_out[62] = 1;
+	ops[63] = gmtmath_FCDF;	n_args[63] = 3;	n_out[63] = 1;
+	ops[64] = gmtmath_FLIPUD;	n_args[64] = 1;	n_out[64] = 1;
+	ops[65] = gmtmath_FLOOR;	n_args[65] = 1;	n_out[65] = 1;
+	ops[66] = gmtmath_FMOD;	n_args[66] = 2;	n_out[66] = 1;
+	ops[67] = gmtmath_FPDF;	n_args[67] = 3;	n_out[67] = 1;
+	ops[68] = gmtmath_GE;	n_args[68] = 2;	n_out[68] = 1;
+	ops[69] = gmtmath_GT;	n_args[69] = 2;	n_out[69] = 1;
+	ops[70] = gmtmath_HYPOT;	n_args[70] = 2;	n_out[70] = 1;
+	ops[71] = gmtmath_I0;	n_args[71] = 1;	n_out[71] = 1;
+	ops[72] = gmtmath_I1;	n_args[72] = 1;	n_out[72] = 1;
+	ops[73] = gmtmath_IFELSE;	n_args[73] = 3;	n_out[73] = 1;
+	ops[74] = gmtmath_IN;	n_args[74] = 2;	n_out[74] = 1;
+	ops[75] = gmtmath_INRANGE;	n_args[75] = 3;	n_out[75] = 1;
+	ops[76] = gmtmath_INT;	n_args[76] = 1;	n_out[76] = 1;
+	ops[77] = gmtmath_INV;	n_args[77] = 1;	n_out[77] = 1;
+	ops[78] = gmtmath_ISFINITE;	n_args[78] = 1;	n_out[78] = 1;
+	ops[79] = gmtmath_ISNAN;	n_args[79] = 1;	n_out[79] = 1;
+	ops[80] = gmtmath_J0;	n_args[80] = 1;	n_out[80] = 1;
+	ops[81] = gmtmath_J1;	n_args[81] = 1;	n_out[81] = 1;
+	ops[82] = gmtmath_JN;	n_args[82] = 2;	n_out[82] = 1;
+	ops[83] = gmtmath_K0;	n_args[83] = 1;	n_out[83] = 1;
+	ops[84] = gmtmath_K1;	n_args[84] = 1;	n_out[84] = 1;
+	ops[85] = gmtmath_KN;	n_args[85] = 2;	n_out[85] = 1;
+	ops[86] = gmtmath_KEI;	n_args[86] = 1;	n_out[86] = 1;
+	ops[87] = gmtmath_KER;	n_args[87] = 1;	n_out[87] = 1;
+	ops[88] = gmtmath_KURT;	n_args[88] = 1;	n_out[88] = 1;
+	ops[89] = gmtmath_LCDF;	n_args[89] = 1;	n_out[89] = 1;
+	ops[90] = gmtmath_LCRIT;	n_args[90] = 1;	n_out[90] = 1;
+	ops[91] = gmtmath_LE;	n_args[91] = 2;	n_out[91] = 1;
+	ops[92] = gmtmath_LMSSCL;	n_args[92] = 1;	n_out[92] = 1;
+	ops[93] = gmtmath_LMSSCLW;	n_args[93] = 1;	n_out[93] = 1;
+	ops[94] = gmtmath_LOG;	n_args[94] = 1;	n_out[94] = 1;
+	ops[95] = gmtmath_LOG10;	n_args[95] = 1;	n_out[95] = 1;
+	ops[96] = gmtmath_LOG1P;	n_args[96] = 1;	n_out[96] = 1;
+	ops[97] = gmtmath_LOG2;	n_args[97] = 1;	n_out[97] = 1;
+	ops[98] = gmtmath_LOWER;	n_args[98] = 1;	n_out[98] = 1;
+	ops[99] = gmtmath_LPDF;	n_args[99] = 1;	n_out[99] = 1;
+	ops[100] = gmtmath_LRAND;	n_args[100] = 2;	n_out[100] = 1;
+	ops[101] = gmtmath_LSQFIT;	n_args[101] = 1;	n_out[101] = 0;
+	ops[102] = gmtmath_LT;	n_args[102] = 2;	n_out[102] = 1;
+	ops[103] = gmtmath_MAD;	n_args[103] = 1;	n_out[103] = 1;
+	ops[104] = gmtmath_MADW;	n_args[104] = 2;	n_out[104] = 1;
+	ops[105] = gmtmath_MAX;	n_args[105] = 2;	n_out[105] = 1;
+	ops[106] = gmtmath_MEAN;	n_args[106] = 1;	n_out[106] = 1;
+	ops[107] = gmtmath_MEANW;	n_args[107] = 2;	n_out[107] = 1;
+	ops[108] = gmtmath_MEDIAN;	n_args[108] = 1;	n_out[108] = 1;
+	ops[109] = gmtmath_MEDIANW;	n_args[109] = 2;	n_out[109] = 1;
+	ops[110] = gmtmath_MIN;	n_args[110] = 2;	n_out[110] = 1;
+	ops[111] = gmtmath_MOD;	n_args[111] = 2;	n_out[111] = 1;
+	ops[112] = gmtmath_MODE;	n_args[112] = 1;	n_out[112] = 1;
+	ops[113] = gmtmath_MODEW;	n_args[113] = 2;	n_out[113] = 1;
+	ops[114] = gmtmath_MUL;	n_args[114] = 2;	n_out[114] = 1;
+	ops[115] = gmtmath_NAN;	n_args[115] = 2;	n_out[115] = 1;
+	ops[116] = gmtmath_NEG;	n_args[116] = 1;	n_out[116] = 1;
+	ops[117] = gmtmath_NEQ;	n_args[117] = 2;	n_out[117] = 1;
+	ops[118] = gmtmath_NORM;	n_args[118] = 1;	n_out[118] = 1;
+	ops[119] = gmtmath_NOT;	n_args[119] = 1;	n_out[119] = 1;
+	ops[120] = gmtmath_NRAND;	n_args[120] = 2;	n_out[120] = 1;
+	ops[121] = gmtmath_OR;	n_args[121] = 2;	n_out[121] = 1;
+	ops[122] = gmtmath_PERM;	n_args[122] = 2;	n_out[122] = 1;
+	ops[123] = gmtmath_PLM;	n_args[123] = 3;	n_out[123] = 1;
+	ops[124] = gmtmath_PLMg;	n_args[124] = 3;	n_out[124] = 1;
+	ops[125] = gmtmath_POP;	n_args[125] = 1;	n_out[125] = 0;
+	ops[126] = gmtmath_POW;	n_args[126] = 2;	n_out[126] = 1;
+	ops[127] = gmtmath_PPDF;	n_args[127] = 2;	n_out[127] = 1;
+	ops[128] = gmtmath_PQUANT;	n_args[128] = 2;	n_out[128] = 1;
+	ops[129] = gmtmath_PQUANTW;	n_args[129] = 3;	n_out[129] = 1;
+	ops[130] = gmtmath_PSI;	n_args[130] = 1;	n_out[130] = 1;
+	ops[131] = gmtmath_PV;	n_args[131] = 3;	n_out[131] = 1;
+	ops[132] = gmtmath_QV;	n_args[132] = 3;	n_out[132] = 1;
+	ops[133] = gmtmath_R2;	n_args[133] = 2;	n_out[133] = 1;
+	ops[134] = gmtmath_R2D;	n_args[134] = 1;	n_out[134] = 1;
+	ops[135] = gmtmath_RAND;	n_args[135] = 2;	n_out[135] = 1;
+	ops[136] = gmtmath_RCDF;	n_args[136] = 1;	n_out[136] = 1;
+	ops[137] = gmtmath_RCRIT;	n_args[137] = 1;	n_out[137] = 1;
+	ops[138] = gmtmath_RPDF;	n_args[138] = 1;	n_out[138] = 1;
+	ops[139] = gmtmath_RINT;	n_args[139] = 1;	n_out[139] = 1;
+	ops[140] = gmtmath_RMS;	n_args[140] = 1;	n_out[140] = 1;
+	ops[141] = gmtmath_RMSW;	n_args[141] = 2;	n_out[141] = 1;
+	ops[142] = gmtmath_ROLL;	n_args[142] = 2;	n_out[142] = 0;
+	ops[143] = gmtmath_ROTT;	n_args[143] = 2;	n_out[143] = 1;
+	ops[144] = gmtmath_SEC;	n_args[144] = 1;	n_out[144] = 1;
+	ops[145] = gmtmath_SECD;	n_args[145] = 1;	n_out[145] = 1;
+	ops[146] = gmtmath_SECH;	n_args[146] = 1;	n_out[146] = 1;
+	ops[147] = gmtmath_SIGN;	n_args[147] = 1;	n_out[147] = 1;
+	ops[148] = gmtmath_SIN;	n_args[148] = 1;	n_out[148] = 1;
+	ops[149] = gmtmath_SINC;	n_args[149] = 1;	n_out[149] = 1;
+	ops[150] = gmtmath_SIND;	n_args[150] = 1;	n_out[150] = 1;
+	ops[151] = gmtmath_SINH;	n_args[151] = 1;	n_out[151] = 1;
+	ops[152] = gmtmath_SKEW;	n_args[152] = 1;	n_out[152] = 1;
+	ops[153] = gmtmath_SORT;	n_args[153] = 3;	n_out[153] = 1;
+	ops[154] = gmtmath_SQR;	n_args[154] = 1;	n_out[154] = 1;
+	ops[155] = gmtmath_SQRT;	n_args[155] = 1;	n_out[155] = 1;
+	ops[156] = gmtmath_STD;	n_args[156] = 1;	n_out[156] = 1;
+	ops[157] = gmtmath_STDW;	n_args[157] = 2;	n_out[157] = 1;
+	ops[158] = gmtmath_STEP;	n_args[158] = 1;	n_out[158] = 1;
+	ops[159] = gmtmath_STEPT;	n_args[159] = 1;	n_out[159] = 1;
+	ops[160] = gmtmath_SUB;	n_args[160] = 2;	n_out[160] = 1;
+	ops[161] = gmtmath_SUM;	n_args[161] = 1;	n_out[161] = 1;
+	ops[162] = gmtmath_SVDFIT;	n_args[162] = 1;	n_out[162] = 0;
+	ops[163] = gmtmath_TAN;	n_args[163] = 1;	n_out[163] = 1;
+	ops[164] = gmtmath_TAND;	n_args[164] = 1;	n_out[164] = 1;
+	ops[165] = gmtmath_TANH;	n_args[165] = 1;	n_out[165] = 1;
+	ops[166] = gmtmath_TAPER;	n_args[166] = 1;	n_out[166] = 1;
+	ops[167] = gmtmath_TCDF;	n_args[167] = 2;	n_out[167] = 1;
+	ops[168] = gmtmath_TN;	n_args[168] = 2;	n_out[168] = 1;
+	ops[169] = gmtmath_TPDF;	n_args[169] = 2;	n_out[169] = 1;
+	ops[170] = gmtmath_TCRIT;	n_args[170] = 2;	n_out[170] = 1;
+	ops[171] = gmtmath_UPPER;	n_args[171] = 1;	n_out[171] = 1;
+	ops[172] = gmtmath_VAR;	n_args[172] = 1;	n_out[172] = 1;
+	ops[173] = gmtmath_VARW;	n_args[173] = 2;	n_out[173] = 1;
+	ops[174] = gmtmath_WCDF;	n_args[174] = 3;	n_out[174] = 1;
+	ops[175] = gmtmath_WCRIT;	n_args[175] = 3;	n_out[175] = 1;
+	ops[176] = gmtmath_WPDF;	n_args[176] = 3;	n_out[176] = 1;
+	ops[177] = gmtmath_XOR;	n_args[177] = 2;	n_out[177] = 1;
+	ops[178] = gmtmath_Y0;	n_args[178] = 1;	n_out[178] = 1;
+	ops[179] = gmtmath_Y1;	n_args[179] = 1;	n_out[179] = 1;
+	ops[180] = gmtmath_YN;	n_args[180] = 2;	n_out[180] = 1;
+	ops[181] = gmtmath_ZCRIT;	n_args[181] = 1;	n_out[181] = 1;
+	ops[182] = gmtmath_ZCDF;	n_args[182] = 1;	n_out[182] = 1;
+	ops[183] = gmtmath_ZPDF;	n_args[183] = 1;	n_out[183] = 1;
+	ops[184] = gmtmath_ROOTS;	n_args[184] = 2;	n_out[184] = 1;
+	ops[185] = gmtmath_HSV2LAB;	n_args[185] = 3;	n_out[185] = 3;
+	ops[186] = gmtmath_HSV2RGB;	n_args[186] = 3;	n_out[186] = 3;
+	ops[187] = gmtmath_HSV2XYZ;	n_args[187] = 3;	n_out[187] = 3;
+	ops[188] = gmtmath_LAB2HSV;	n_args[188] = 3;	n_out[188] = 3;
+	ops[189] = gmtmath_LAB2RGB;	n_args[189] = 3;	n_out[189] = 3;
+	ops[190] = gmtmath_LAB2XYZ;	n_args[190] = 3;	n_out[190] = 3;
+	ops[191] = gmtmath_RGB2HSV;	n_args[191] = 3;	n_out[191] = 3;
+	ops[192] = gmtmath_RGB2LAB;	n_args[192] = 3;	n_out[192] = 3;
+	ops[193] = gmtmath_RGB2XYZ;	n_args[193] = 3;	n_out[193] = 3;
+	ops[194] = gmtmath_XYZ2HSV;	n_args[194] = 3;	n_out[194] = 3;
+	ops[195] = gmtmath_XYZ2LAB;	n_args[195] = 3;	n_out[195] = 3;
+	ops[196] = gmtmath_XYZ2RGB;	n_args[196] = 3;	n_out[196] = 3;
 }
 
-GMT_LOCAL void Free_Stack (struct GMTAPI_CTRL *API, struct GMTMATH_STACK **stack) {
+GMT_LOCAL void gmtmath_free_stack (struct GMTAPI_CTRL *API, struct GMTMATH_STACK **stack) {
 	unsigned int k, error = 0;
 	bool is_object;
 	struct GMT_DATASET_HIDDEN *DH = NULL;
@@ -5833,7 +5833,7 @@ GMT_LOCAL void Free_Stack (struct GMTAPI_CTRL *API, struct GMTMATH_STACK **stack
 	}
 }
 
-GMT_LOCAL void Free_Store (struct GMTAPI_CTRL *API, struct GMTMATH_STORED **recall) {
+GMT_LOCAL void gmtmath_free_store (struct GMTAPI_CTRL *API, struct GMTMATH_STORED **recall) {
 	unsigned int k;
 	for (k = 0; k < GMTMATH_STORE_SIZE; k++) {
 		if (recall[k] && !recall[k]->stored.constant) {
@@ -5847,9 +5847,9 @@ GMT_LOCAL void Free_Store (struct GMTAPI_CTRL *API, struct GMTMATH_STORED **reca
 #define Free_Misc {if (T_in) GMT_Destroy_Data (API, &T_in); GMT_Destroy_Data (API, &Template); GMT_Destroy_Data (API, &Time); if (read_stdin) GMT_Destroy_Data (API, &D_stdin); }
 #define bailout(code) {gmt_M_free_options (mode); return (code);}
 #define Return1(code) {GMT_Destroy_Options (API, &list); Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code); }
-#define Return(code) {GMT_Destroy_Options (API, &list); Free_Ctrl (GMT, Ctrl); Free_Stack(API,stack); Free_Store(API,recall); Free_Misc;  gmt_end_module (GMT, GMT_cpy); bailout (code); }
+#define Return(code) {GMT_Destroy_Options (API, &list); Free_Ctrl (GMT, Ctrl); gmtmath_free_stack(API,stack); gmtmath_free_store(API,recall); Free_Misc;  gmt_end_module (GMT, GMT_cpy); bailout (code); }
 
-GMT_LOCAL int decode_gmt_argument (struct GMT_CTRL *GMT, char *txt, double *value, bool *dimension, struct GMT_HASH *H) {
+GMT_LOCAL int gmtmath_decode_argument (struct GMT_CTRL *GMT, char *txt, double *value, bool *dimension, struct GMT_HASH *H) {
 	unsigned int expect;
 	int key;
 	size_t last;
@@ -5976,7 +5976,7 @@ GMT_LOCAL void gmtmath_expand_recall_cmd (struct GMT_OPTION *list) {
 	}
 }
 
-GMT_LOCAL bool color_operator_on_table (bool scalar, char *arg) {
+GMT_LOCAL bool gmtmath_color_operator_on_table (bool scalar, char *arg) {
 	if (scalar) return false;
 	if (strlen (arg) < 7) return false;
 	if (arg[3] != '2') return false;
@@ -6277,7 +6277,7 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 		if (!(opt->option == GMT_OPT_INFILE))	continue;	/* Skip command line options and output */
 		/* Filenames,  operators, some numbers and = will all have been flagged as files by the parser */
 		gmtmath_backwards_fixing (GMT, &(opt->arg));	/* Possibly exchange obsolete operator name for new one unless compatibility is off */
-		op = decode_gmt_argument (GMT, opt->arg, &value, &dimension, localhashnode);	/* Determine what this is */
+		op = gmtmath_decode_argument (GMT, opt->arg, &value, &dimension, localhashnode);	/* Determine what this is */
 		if (op == GMTMATH_ARG_IS_BAD) Return (GMT_RUNTIME_ERROR);		/* Horrible */
 		if (op != GMTMATH_ARG_IS_FILE) continue;				/* Skip operators and numbers */
 		if (!got_t_from_file) {
@@ -6432,8 +6432,8 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 	if (Ctrl->A.active) {	/* Set up A * x = b, with the table holding the extended matrix [ A | [w | ] b ], with w the optional weights */
 		if (!stack[0]->D)
 			stack[0]->D = gmt_alloc_dataset (GMT, Template, 0, n_columns, GMT_ALLOC_NORMAL);
-		load_column (stack[0]->D, n_columns-1, rhs, 1);		/* Always put the r.h.s of the Ax = b equation in the last column of the item on the stack */
-		if (!Ctrl->A.null) load_column (stack[0]->D, Ctrl->N.tcol, rhs, 0);	/* Optionally, put the t vector in the time column of the item on the stack */
+		gmtmath_load_column (stack[0]->D, n_columns-1, rhs, 1);		/* Always put the r.h.s of the Ax = b equation in the last column of the item on the stack */
+		if (!Ctrl->A.null) gmtmath_load_column (stack[0]->D, Ctrl->N.tcol, rhs, 0);	/* Optionally, put the t vector in the time column of the item on the stack */
 		gmt_set_tbl_minmax (GMT, stack[0]->D->geometry, stack[0]->D->table[0]);
 		nstack = 1;
 		info.fit_mode = Ctrl->A.e_mode;
@@ -6455,7 +6455,7 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 	special_symbol[GMTMATH_ARG_IS_PI-GMTMATH_ARG_IS_N]      = (double)n_records;
 
 	gmtmath_init (call_operator, consumed_operands, produced_operands);
-	op = decode_gmt_argument (GMT, "EXCH", &value, &dimension, localhashnode);
+	op = gmtmath_decode_argument (GMT, "EXCH", &value, &dimension, localhashnode);
 	if (op == GMTMATH_ARG_IS_BAD) {
 		GMT_Report (API, GMT_MSG_ERROR, "Bad input argument!\n");
 		Return (GMT_RUNTIME_ERROR);
@@ -6476,7 +6476,7 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 
 		gmtmath_backwards_fixing (GMT, &(opt->arg));	/* Possibly exchange obsolete operator name for new one unless compatibility is off */
 
-		op = decode_gmt_argument (GMT, opt->arg, &value, &dimension, localhashnode);
+		op = gmtmath_decode_argument (GMT, opt->arg, &value, &dimension, localhashnode);
 
 		if (op != GMTMATH_ARG_IS_FILE && !gmt_access (GMT, opt->arg, R_OK)) GMT_Message (API, GMT_TIME_NONE, "The number or operator %s may be confused with an existing file %s!  The file will be ignored.\n", opt->arg, opt->arg);
 
@@ -6511,7 +6511,7 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 				}
 				if ((label = gmtmath_setlabel (GMT, opt->arg)) == NULL) Return (GMT_RUNTIME_ERROR);
 				if ((k = gmtmath_find_stored_item (recall, n_stored, label)) != GMT_NOTSET) {
-					if (!stack[last]->constant) for (j = 0; j < n_columns; j++) if (no_C || !Ctrl->C.cols[j]) load_column (recall[k]->stored.D, j, stack[last]->D->table[0], j);
+					if (!stack[last]->constant) for (j = 0; j < n_columns; j++) if (no_C || !Ctrl->C.cols[j]) gmtmath_load_column (recall[k]->stored.D, j, stack[last]->D->table[0], j);
 					GMT_Report (API, GMT_MSG_DEBUG, "Stored memory cell %d named %s is overwritten with new information\n", k, label);
 				}
 				else {	/* Need new named storage place; use gmt_duplicate_dataset/gmt_free_dataset since no point adding to registered resources when internal use only */
@@ -6543,7 +6543,7 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 					stack[nstack]->constant = false;
 					if (!stack[nstack]->D)
 						stack[nstack]->D = gmt_alloc_dataset (GMT, Template, 0, n_columns, GMT_ALLOC_NORMAL);
-					for (j = 0; j < n_columns; j++) if (no_C || !Ctrl->C.cols[j]) load_column (stack[nstack]->D, j, recall[k]->stored.D->table[0], j);
+					for (j = 0; j < n_columns; j++) if (no_C || !Ctrl->C.cols[j]) gmtmath_load_column (stack[nstack]->D, j, recall[k]->stored.D->table[0], j);
 					DH = gmt_get_DD_hidden (stack[nstack]->D);
 					gmt_set_tbl_minmax (GMT, stack[nstack]->D->geometry, stack[nstack]->D->table[0]);
 				}
@@ -6577,7 +6577,7 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 				if (!stack[nstack]->D)
 					stack[nstack]->D = gmt_alloc_dataset (GMT, Template, 0, n_columns, GMT_ALLOC_NORMAL);
 				if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) GMT_Message (API, GMT_TIME_NONE, "T ");
-				for (j = 0; j < n_columns; j++) if (no_C || !Ctrl->C.cols[j]) load_column (stack[nstack]->D, j, info.T, COL_T);
+				for (j = 0; j < n_columns; j++) if (no_C || !Ctrl->C.cols[j]) gmtmath_load_column (stack[nstack]->D, j, info.T, COL_T);
 				DH = gmt_get_DD_hidden (stack[nstack]->D);
 				gmt_set_tbl_minmax (GMT, stack[nstack]->D->geometry, stack[nstack]->D->table[0]);
 			}
@@ -6589,7 +6589,7 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 				if (!stack[nstack]->D)
 					stack[nstack]->D = gmt_alloc_dataset (GMT, Template, 0, n_columns, GMT_ALLOC_NORMAL);
 				if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) GMT_Message (API, GMT_TIME_NONE, "TNORM ");
-				for (j = 0; j < n_columns; j++) if (no_C || !Ctrl->C.cols[j]) load_column (stack[nstack]->D, j, info.T, COL_TN);
+				for (j = 0; j < n_columns; j++) if (no_C || !Ctrl->C.cols[j]) gmtmath_load_column (stack[nstack]->D, j, info.T, COL_TN);
 				DH = gmt_get_DD_hidden (stack[nstack]->D);
 				gmt_set_tbl_minmax (GMT, stack[nstack]->D->geometry, stack[nstack]->D->table[0]);
 			}
@@ -6597,7 +6597,7 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 				if (!stack[nstack]->D)
 					stack[nstack]->D = gmt_alloc_dataset (GMT, Template, 0, n_columns, GMT_ALLOC_NORMAL);
 				if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) GMT_Message (API, GMT_TIME_NONE, "TROW ");
-				for (j = 0; j < n_columns; j++) if (no_C || !Ctrl->C.cols[j]) load_column (stack[nstack]->D, j, info.T, COL_TJ);
+				for (j = 0; j < n_columns; j++) if (no_C || !Ctrl->C.cols[j]) gmtmath_load_column (stack[nstack]->D, j, info.T, COL_TJ);
 				DH = gmt_get_DD_hidden (stack[nstack]->D);
 				gmt_set_tbl_minmax (GMT, stack[nstack]->D->geometry, stack[nstack]->D->table[0]);
 			}
@@ -6620,14 +6620,14 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 					if (Ctrl->N.ncol > F->n_columns) gmt_adjust_dataset (GMT, F, Ctrl->N.ncol);	/* Add more input columns */
 					T_in = F->table[0];	/* Only one table since only a single file */
 				}
-				for (j = 0; j < n_columns; j++) if (no_C || !Ctrl->C.cols[j]) load_column (stack[nstack]->D, j, T_in, j);
+				for (j = 0; j < n_columns; j++) if (no_C || !Ctrl->C.cols[j]) gmtmath_load_column (stack[nstack]->D, j, T_in, j);
 				DH = gmt_get_DD_hidden (stack[nstack]->D);
 				gmt_set_tbl_minmax (GMT, stack[nstack]->D->geometry, stack[nstack]->D->table[0]);
-				if (!same_size (stack[nstack]->D, Template)) {
+				if (!gmtmath_same_size (stack[nstack]->D, Template)) {
 					GMT_Report (API, GMT_MSG_ERROR, "tables not of same size!\n");
 					Return (GMT_RUNTIME_ERROR);
 				}
-				else if (!Ctrl->C.cols[Ctrl->N.tcol] && !(Ctrl->T.notime || same_domain (stack[nstack]->D, Ctrl->N.tcol, info.T))) {
+				else if (!Ctrl->C.cols[Ctrl->N.tcol] && !(Ctrl->T.notime || gmtmath_same_domain (stack[nstack]->D, Ctrl->N.tcol, info.T))) {
 					GMT_Report (API, GMT_MSG_ERROR, "tables do not cover the same domain!\n");
 					Return (GMT_RUNTIME_ERROR);
 				}
@@ -6642,7 +6642,7 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 		/* Here we have an operator */
 
 		eaten = consumed_operands[op];	created = produced_operands[op];
-		if (color_operator_on_table (info.scalar, opt->arg)) {	/* These operators read across 3 columns instead */
+		if (gmtmath_color_operator_on_table (info.scalar, opt->arg)) {	/* These operators read across 3 columns instead */
 			if (info.n_col != 3) {
 				GMT_Report (API, GMT_MSG_ERROR, "Input tables must have 3 columns for using the color triplet operator %s!\n", opt->arg);
 				Return (GMT_RUNTIME_ERROR);
@@ -6679,16 +6679,16 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 		for (j = 0, i = nstack - eaten; j < created; j++, i++) {
 			if (stack[i]->constant && !stack[i]->D) {
 				stack[i]->D = gmt_alloc_dataset (GMT, Template, 0, n_columns, GMT_ALLOC_NORMAL);
-				if (!Ctrl->T.notime) load_column (stack[i]->D, COL_T, info.T, COL_T);	/* Make sure t-column is copied if needed */
+				if (!Ctrl->T.notime) gmtmath_load_column (stack[i]->D, COL_T, info.T, COL_T);	/* Make sure t-column is copied if needed */
 			}
 		}
 
 		if (!strcmp (operator[op], "LSQFIT")) {	/* Special case, solve LSQ system and return */
-			solve_LSQFIT (GMT, &info, stack[nstack-1], n_columns, Ctrl->C.cols, Ctrl->E.eigen, Ctrl->Out.file, options, A_in);
+			gmtmath_solve_LSQFIT (GMT, &info, stack[nstack-1], n_columns, Ctrl->C.cols, Ctrl->E.eigen, Ctrl->Out.file, options, A_in);
 			Return (GMT_NOERROR);
 		}
 		else if (!strcmp (operator[op], "SVDFIT")) {	/* Special case, solve SVD system and return */
-			solve_SVDFIT (GMT, &info, stack[nstack-1], n_columns, Ctrl->C.cols, Ctrl->E.eigen, Ctrl->Out.file, options, A_in);
+			gmtmath_solve_SVDFIT (GMT, &info, stack[nstack-1], n_columns, Ctrl->C.cols, Ctrl->E.eigen, Ctrl->Out.file, options, A_in);
 			Return (GMT_NOERROR);
 		}
 		else if (!strcmp (operator[op], "SORT")) {	/* Special case, sort all columns inside operator */
@@ -6703,7 +6703,7 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 				}
 			}
 		}
-		free_sort_list (GMT, &info);	/* Frees helper array if SORT was called */
+		gmtmath_free_sort_list (GMT, &info);	/* Frees helper array if SORT was called */
 
 		nstack = new_stack;
 
@@ -6725,9 +6725,9 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 			stack[last]->D = gmt_alloc_dataset (GMT, Template, 0, n_columns, GMT_ALLOC_NORMAL);
 		for (j = 0; j < n_columns; j++) {
 			if (j == COL_T && !Ctrl->Q.active && Ctrl->C.cols[j])
-				load_column (stack[last]->D, j, info.T, COL_T);
+				gmtmath_load_column (stack[last]->D, j, info.T, COL_T);
 			else if (!Ctrl->C.cols[j])
-				load_const_column (stack[last]->D, j, stack[last]->factor);
+				gmtmath_load_const_column (stack[last]->D, j, stack[last]->factor);
 		}
 		DH = gmt_get_DD_hidden (stack[last]->D);
 		gmt_set_tbl_minmax (GMT, stack[last]->D->geometry, stack[last]->D->table[0]);
@@ -6766,7 +6766,7 @@ int GMT_gmtmath (void *V_API, int mode, void *args) {
 			R->table[0]->segment[0]->data[0][0] *= GMT->session.u2u[GMT_INCH][GMT->current.setting.proj_length_unit];
 		}
 		if (place_t_col && Ctrl->N.tcol < R->n_columns) {
-			load_column (R, Ctrl->N.tcol, info.T, COL_T);	/* Put T in the time column of the item on the stack if possible */
+			gmtmath_load_column (R, Ctrl->N.tcol, info.T, COL_T);	/* Put T in the time column of the item on the stack if possible */
 			gmt_set_tbl_minmax (GMT, R->geometry, R->table[0]);
 		}
 		if ((error = GMT_Set_Columns (API, GMT_OUT, (unsigned int)R->n_columns, GMT_COL_FIX_NO_TEXT)) != GMT_NOERROR) Return (error);	/* Since -bo might have been used */

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -530,7 +530,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDMATH_CTRL *Ctrl, struct GMT
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
 
-GMT_LOCAL struct GMT_GRID *alloc_stack_grid (struct GMT_CTRL *GMT, struct GMT_GRID *Template) {
+GMT_LOCAL struct GMT_GRID *grdmath_alloc_stack_grid (struct GMT_CTRL *GMT, struct GMT_GRID *Template) {
 	/* Allocate a new GMT_GRID structure based on dimensions etc of the Template */
 	struct GMT_GRID *New = GMT_Create_Data (GMT->parent, GMT_IS_GRID, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, Template->header->wesn, Template->header->inc, \
 		Template->header->registration, GMT_NOTSET, NULL);
@@ -546,7 +546,7 @@ GMT_LOCAL int grdmath_find_stored_item (struct GMT_CTRL *GMT, struct GRDMATH_STO
 
 /* Stack collapsing operators that work on same nodes across all stack items */
 
-GMT_LOCAL double stack_collapse_add (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_add (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	uint64_t k;
 	double sum = array[0];
 	gmt_M_unused (GMT);
@@ -554,7 +554,7 @@ GMT_LOCAL double stack_collapse_add (struct GMT_CTRL *GMT, double *array, uint64
 	return sum;
 }
 
-GMT_LOCAL double stack_collapse_and (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_and (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	uint64_t k;
 	double x = array[0];
 	gmt_M_unused (GMT);
@@ -563,7 +563,7 @@ GMT_LOCAL double stack_collapse_and (struct GMT_CTRL *GMT, double *array, uint64
 	return x;
 }
 
-GMT_LOCAL double stack_collapse_lmsscl (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_lmsscl (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	double lmsscl;
 	gmt_sort_array (GMT, array, n, GMT_DOUBLE);
 	while (n > 1 && gmt_M_is_dnan (array[n-1])) n--;
@@ -578,7 +578,7 @@ GMT_LOCAL double stack_collapse_lmsscl (struct GMT_CTRL *GMT, double *array, uin
 	return lmsscl;
 }
 
-GMT_LOCAL double stack_collapse_mad (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_mad (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	double mad;
 	gmt_sort_array (GMT, array, n, GMT_DOUBLE);
 	while (n > 1 && gmt_M_is_dnan (array[n-1])) n--;
@@ -591,7 +591,7 @@ GMT_LOCAL double stack_collapse_mad (struct GMT_CTRL *GMT, double *array, uint64
 	return mad;
 }
 
-GMT_LOCAL double stack_collapse_max (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_max (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	uint64_t k;
 	double max = array[0];
 	gmt_M_unused (GMT);
@@ -600,12 +600,12 @@ GMT_LOCAL double stack_collapse_max (struct GMT_CTRL *GMT, double *array, uint64
 	return max;
 }
 
-GMT_LOCAL double stack_collapse_mean (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_mean (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	double std = 0.0;
 	return gmt_mean_and_std (GMT, array, n, &std);
 }
 
-GMT_LOCAL double stack_collapse_median (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_median (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	double med;
 	gmt_sort_array (GMT, array, n, GMT_DOUBLE);
 	while (n > 1 && gmt_M_is_dnan (array[n-1])) n--;
@@ -616,7 +616,7 @@ GMT_LOCAL double stack_collapse_median (struct GMT_CTRL *GMT, double *array, uin
 	return med;
 }
 
-GMT_LOCAL double stack_collapse_min (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_min (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	uint64_t k;
 	double min = array[0];
 	gmt_M_unused (GMT);
@@ -625,14 +625,14 @@ GMT_LOCAL double stack_collapse_min (struct GMT_CTRL *GMT, double *array, uint64
 	return min;
 }
 
-GMT_LOCAL double stack_collapse_mode (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_mode (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	unsigned int gmt_mode_selection = 0, GMT_n_multiples = 0;
 	double mode;
 	gmt_mode (GMT, array, n, n/2, true, gmt_mode_selection, &GMT_n_multiples, &mode);
 	return mode;
 }
 
-GMT_LOCAL double stack_collapse_mul (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_mul (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	uint64_t k;
 	double prod = array[0];
 	gmt_M_unused (GMT);
@@ -641,7 +641,7 @@ GMT_LOCAL double stack_collapse_mul (struct GMT_CTRL *GMT, double *array, uint64
 	return prod;
 }
 
-GMT_LOCAL double stack_collapse_or (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_or (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	uint64_t k;
 	double x = array[0];
 	gmt_M_unused (GMT);
@@ -650,7 +650,7 @@ GMT_LOCAL double stack_collapse_or (struct GMT_CTRL *GMT, double *array, uint64_
 	return x;
 }
 
-GMT_LOCAL double stack_collapse_rms (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_rms (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	uint64_t k;
 	double rms = 0.0;
 	gmt_M_unused (GMT);
@@ -659,13 +659,13 @@ GMT_LOCAL double stack_collapse_rms (struct GMT_CTRL *GMT, double *array, uint64
 	return sqrt (rms / n);
 }
 
-GMT_LOCAL double stack_collapse_std (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_std (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	double std = 0.0;
 	(void)gmt_mean_and_std (GMT, array, n, &std);
 	return std;
 }
 
-GMT_LOCAL double stack_collapse_sub (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_sub (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	uint64_t k;
 	double sum = array[0];
 	gmt_M_unused (GMT);
@@ -674,13 +674,13 @@ GMT_LOCAL double stack_collapse_sub (struct GMT_CTRL *GMT, double *array, uint64
 	return sum;
 }
 
-GMT_LOCAL double stack_collapse_var (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_var (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	double std = 0.0;
 	(void)gmt_mean_and_std (GMT, array, n, &std);
 	return (std * std);
 }
 
-GMT_LOCAL double stack_collapse_xor (struct GMT_CTRL *GMT, double *array, uint64_t n) {
+GMT_LOCAL double grdmath_stack_collapse_xor (struct GMT_CTRL *GMT, double *array, uint64_t n) {
 	uint64_t k;
 	double x = array[0];
 	gmt_M_unused (GMT);
@@ -693,7 +693,7 @@ GMT_LOCAL double stack_collapse_xor (struct GMT_CTRL *GMT, double *array, uint64
  *              Definitions of all operator functions
  * -----------------------------------------------------------------*/
 
-GMT_LOCAL int collapse_stack (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last, char *OP)
+GMT_LOCAL int grdmath_collapse_stack (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last, char *OP)
 {
 	/* Collapse stack will apply the given operator to all items on the stack, per node.
 	 * E.g., you may have 7 grids on the stack and you want to return the mean value per node
@@ -710,37 +710,37 @@ GMT_LOCAL int collapse_stack (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, s
 	/* First ensure we have a reducing operator */
 
 	if (!strcmp (OP, "ADD"))
-		func = &stack_collapse_add;
+		func = &grdmath_stack_collapse_add;
 	else if (!strcmp (OP, "AND"))
-		func = &stack_collapse_and;
+		func = &grdmath_stack_collapse_and;
 	else if (!strcmp (OP, "LMSSCL"))
-		func = &stack_collapse_lmsscl;
+		func = &grdmath_stack_collapse_lmsscl;
 	else if (!strcmp (OP, "MAD"))
-		func = &stack_collapse_mad;
+		func = &grdmath_stack_collapse_mad;
 	else if (!strcmp (OP, "MAX"))
-		func = &stack_collapse_max;
+		func = &grdmath_stack_collapse_max;
 	else if (!strcmp (OP, "MEAN"))
-		func = &stack_collapse_mean;
+		func = &grdmath_stack_collapse_mean;
 	else if (!strcmp (OP, "MEDIAN"))
-		func = &stack_collapse_median;
+		func = &grdmath_stack_collapse_median;
 	else if (!strcmp (OP, "MIN"))
-		func = &stack_collapse_min;
+		func = &grdmath_stack_collapse_min;
 	else if (!strcmp (OP, "MODE"))
-		func = &stack_collapse_mode;
+		func = &grdmath_stack_collapse_mode;
 	else if (!strcmp (OP, "MUL"))
-		func = &stack_collapse_mul;
+		func = &grdmath_stack_collapse_mul;
 	else if (!strcmp (OP, "OR"))
-		func = &stack_collapse_or;
+		func = &grdmath_stack_collapse_or;
 	else if (!strcmp (OP, "STD"))
-		func = &stack_collapse_std;
+		func = &grdmath_stack_collapse_std;
 	else if (!strcmp (OP, "SUB"))
-		func = &stack_collapse_sub;
+		func = &grdmath_stack_collapse_sub;
 	else if (!strcmp (OP, "RMS"))
-		func = &stack_collapse_rms;
+		func = &grdmath_stack_collapse_rms;
 	else if (!strcmp (OP, "VAR"))
-		func = &stack_collapse_var;
+		func = &grdmath_stack_collapse_var;
 	else if (!strcmp (OP, "XOR"))
-		func = &stack_collapse_xor;
+		func = &grdmath_stack_collapse_xor;
 	else {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unrecognized stack reduction operator %s - ignored\n", OP);
 		return 1;
@@ -759,7 +759,7 @@ GMT_LOCAL int collapse_stack (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, s
 
 /* Note: The OPERATOR: **** lines are used to extract syntax for documentation */
 
-GMT_LOCAL void grd_ABS (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ABS (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ABS 1 1 abs (A).  */
 {
 	uint64_t node;
@@ -771,7 +771,7 @@ GMT_LOCAL void grd_ABS (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	gmt_grd_pad_zero (GMT, stack[last]->G);	/* Reset the boundary pad, if needed */
 }
 
-GMT_LOCAL void grd_ACOS (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ACOS (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ACOS 1 1 acos (A).  */
 {
 	uint64_t node;
@@ -783,7 +783,7 @@ GMT_LOCAL void grd_ACOS (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : d_acosf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_ACOSH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ACOSH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ACOSH 1 1 acosh (A).  */
 {
 	uint64_t node;
@@ -796,7 +796,7 @@ GMT_LOCAL void grd_ACOSH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 		stack[last]->G->data[node] = (stack[last]->constant) ? a : acoshf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_ACOT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ACOT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ACOT 1 1 acot (A).  */
 {
 	uint64_t node;
@@ -810,7 +810,7 @@ GMT_LOCAL void grd_ACOT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 		stack[last]->G->data[node] = (stack[last]->constant) ? a : atanf (1.0f / stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_ACOTH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ACOTH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ACOTH 1 1 acoth (A).  */
 {
 	uint64_t node;
@@ -821,7 +821,7 @@ GMT_LOCAL void grd_ACOTH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : atanhf (1.0f/stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_ACSC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ACSC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ACSC 1 1 acsc (A).  */
 {
 	uint64_t node;
@@ -835,7 +835,7 @@ GMT_LOCAL void grd_ACSC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 		stack[last]->G->data[node] = (stack[last]->constant) ? a : d_asinf (1.0f / stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_ACSCH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ACSCH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ACSCH 1 1 acsch (A).  */
 {
 	uint64_t node;
@@ -846,7 +846,7 @@ GMT_LOCAL void grd_ACSCH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : asinhf (1.0f/stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_ADD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ADD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ADD 2 1 A + B.  */
 {
 	uint64_t node;
@@ -861,7 +861,7 @@ GMT_LOCAL void grd_ADD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_AND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_AND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: AND 2 1 B if A == NaN, else A.  */
 {
 	uint64_t node;
@@ -876,7 +876,7 @@ GMT_LOCAL void grd_AND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_ARC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ARC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ARC 2 1 arc(A, B) = pi - |pi - |a-b|| for A, B in radians.  */
 	/*
 	given phase values a and b each in radians on [-pi,pi]
@@ -905,13 +905,13 @@ GMT_LOCAL void grd_ARC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_AREA (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_AREA (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: AREA 0 1 Area of each gridnode cell (spherical calculation in km^2 if geographic).  */
 	gmt_M_unused(info);
 	gmt_get_cellarea (GMT, stack[last]->G);
 }
 
-GMT_LOCAL void grd_ASEC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_ASEC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: ASEC 1 1 asec (A).  */
 	uint64_t node;
 	float a = 0.0f;
@@ -923,7 +923,7 @@ GMT_LOCAL void grd_ASEC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 		stack[last]->G->data[node] = (stack[last]->constant) ? a : d_acosf (1.0f / stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_ASECH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_ASECH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: ASECH 1 1 asech (A).  */
 	uint64_t node;
 	float a = 0.0f;
@@ -935,7 +935,7 @@ GMT_LOCAL void grd_ASECH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 		stack[last]->G->data[node] = (stack[last]->constant) ? a : acoshf (1.0f/stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_ASIN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ASIN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ASIN 1 1 asin (A).  */
 {
 	uint64_t node;
@@ -948,7 +948,7 @@ GMT_LOCAL void grd_ASIN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 		stack[last]->G->data[node] = (stack[last]->constant) ? a : d_asinf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_ASINH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ASINH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ASINH 1 1 asinh (A).  */
 {
 	uint64_t node;
@@ -959,7 +959,7 @@ GMT_LOCAL void grd_ASINH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : asinhf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_ATAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ATAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ATAN 1 1 atan (A).  */
 {
 	uint64_t node;
@@ -972,7 +972,7 @@ GMT_LOCAL void grd_ATAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 		stack[last]->G->data[node] = (stack[last]->constant) ? a : atanf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_ATAN2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ATAN2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ATAN2 2 1 atan2 (A, B).  */
 {
 	uint64_t node;
@@ -989,7 +989,7 @@ GMT_LOCAL void grd_ATAN2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_ATANH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ATANH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ATANH 1 1 atanh (A).  */
 {
 	uint64_t node;
@@ -1000,7 +1000,7 @@ GMT_LOCAL void grd_ATANH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : atanhf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_BCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_BCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: BCDF 3 1 Binomial cumulative distribution function for p = A, n = B and x = C.  */
 {
 	uint64_t node;
@@ -1037,7 +1037,7 @@ GMT_LOCAL void grd_BCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_BPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_BPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: BPDF 3 1 Binomial probability density function for p = A, n = B and x = C.  */
 {
 	uint64_t node;
@@ -1077,7 +1077,7 @@ GMT_LOCAL void grd_BPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_BEI (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_BEI (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: BEI 1 1 bei (A).  */
 {
 	uint64_t node;
@@ -1087,7 +1087,7 @@ GMT_LOCAL void grd_BEI (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : gmt_bei (GMT, fabs((double)stack[last]->G->data[node])));
 }
 
-GMT_LOCAL void grd_BER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_BER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: BER 1 1 ber (A).  */
 {
 	uint64_t node;
@@ -1097,7 +1097,7 @@ GMT_LOCAL void grd_BER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : gmt_ber (GMT, fabs ((double)stack[last]->G->data[node])));
 }
 
-GMT_LOCAL void grd_BITAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_BITAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: BITAND 2 1 A & B (bitwise AND operator).  */
 {
 	uint64_t node, n_warn = 0;
@@ -1124,7 +1124,7 @@ GMT_LOCAL void grd_BITAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 
 }
 
-GMT_LOCAL void grd_BITLEFT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_BITLEFT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: BITLEFT 2 1 A << B (bitwise left-shift operator).  */
 {
 	uint64_t node, n_warn = 0;
@@ -1160,7 +1160,7 @@ GMT_LOCAL void grd_BITLEFT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	if (n_warn) GMT_Report (GMT->parent, GMT_MSG_WARNING, "BITLEFT resulted in %" PRIu64 " values truncated to fit in the 24 available bits\n");
 }
 
-GMT_LOCAL void grd_BITNOT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_BITNOT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: BITNOT 1 1  ~A (bitwise NOT operator, i.e., return two's complement).  */
 {
 	uint64_t node, n_warn = 0;
@@ -1183,7 +1183,7 @@ GMT_LOCAL void grd_BITNOT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	if (n_warn) GMT_Report (GMT->parent, GMT_MSG_WARNING, "BITNOT resulted in %" PRIu64 " values truncated to fit in the 24 available bits\n");
 }
 
-GMT_LOCAL void grd_BITOR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_BITOR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: BITOR 2 1 A | B (bitwise OR operator).  */
 {
 	uint64_t node, n_warn = 0;
@@ -1209,7 +1209,7 @@ GMT_LOCAL void grd_BITOR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	if (n_warn) GMT_Report (GMT->parent, GMT_MSG_WARNING, "BITOR resulted in %" PRIu64 " values truncated to fit in the 24 available bits\n");
 }
 
-GMT_LOCAL void grd_BITRIGHT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_BITRIGHT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: BITRIGHT 2 1 A >> B (bitwise right-shift operator).  */
 {
 	uint64_t node, n_warn = 0;
@@ -1245,7 +1245,7 @@ GMT_LOCAL void grd_BITRIGHT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, st
 	if (n_warn) GMT_Report (GMT->parent, GMT_MSG_WARNING, "BITRIGHT resulted in %" PRIu64 " values truncated to fit in the 24 available bits\n");
 }
 
-GMT_LOCAL void grd_BITTEST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_BITTEST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: BITTEST 2 1 1 if bit B of A is set, else 0 (bitwise TEST operator).  */
 {
 	uint64_t node, n_warn = 0;
@@ -1282,7 +1282,7 @@ GMT_LOCAL void grd_BITTEST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	if (n_warn) GMT_Report (GMT->parent, GMT_MSG_WARNING, "BITTEST resulted in %" PRIu64 " values truncated to fit in the 24 available bits\n");
 }
 
-GMT_LOCAL void grd_BITXOR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_BITXOR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: BITXOR 2 1 A ^ B (bitwise XOR operator).  */
 {
 	uint64_t node, n_warn = 0;
@@ -1308,7 +1308,7 @@ GMT_LOCAL void grd_BITXOR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	if (n_warn) GMT_Report (GMT->parent, GMT_MSG_WARNING, "BITXOR resulted in %" PRIu64 " values truncated to fit in the 24 available bits\n");
 }
 
-GMT_LOCAL void grd_CAZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_CAZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: CAZ 2 1 Cartesian azimuth from grid nodes to stack x,y.  */
 {
 	uint64_t node, row, col;
@@ -1327,7 +1327,7 @@ GMT_LOCAL void grd_CAZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_CBAZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_CBAZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: CBAZ 2 1 Cartesian back-azimuth from grid nodes to stack x,y.  */
 {
 	uint64_t node, row, col;
@@ -1346,7 +1346,7 @@ GMT_LOCAL void grd_CBAZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_CDIST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_CDIST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: CDIST 2 1 Cartesian distance between grid nodes and stack x,y.  */
 {
 	uint64_t node, row, col;
@@ -1364,7 +1364,7 @@ GMT_LOCAL void grd_CDIST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_CDIST2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_CDIST2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: CDIST2 2 1 As CDIST but only to nodes that are != 0.  */
 {
 	uint64_t node, row, col;
@@ -1386,7 +1386,7 @@ GMT_LOCAL void grd_CDIST2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	}
 }
 
-GMT_LOCAL void grd_CEIL (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_CEIL (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: CEIL 1 1 ceil (A) (smallest integer >= A).  */
 {
 	uint64_t node;
@@ -1397,7 +1397,7 @@ GMT_LOCAL void grd_CEIL (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : ceilf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_CHI2CRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_CHI2CRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: CHI2CRIT 2 1 Chi-squared distribution critical value for alpha = A and nu = B.  */
 {
 	uint64_t node;
@@ -1413,7 +1413,7 @@ GMT_LOCAL void grd_CHI2CRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, st
 	}
 }
 
-GMT_LOCAL void grd_CHI2CDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_CHI2CDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: CHI2CDF 2 1 Chi-squared cumulative distribution function for chi2 = A and nu = B.  */
 {
 	uint64_t node;
@@ -1432,7 +1432,7 @@ GMT_LOCAL void grd_CHI2CDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_CHI2PDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_CHI2PDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: CHI2PDF 2 1 Chi-squared probability density function for chi = A and nu = B.  */
 {
 	uint64_t node, nu;
@@ -1450,7 +1450,7 @@ GMT_LOCAL void grd_CHI2PDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_COMB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_COMB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: COMB 2 1 Combinations n_C_r, with n = A and r = B.  */
 {
 	uint64_t node;
@@ -1479,7 +1479,7 @@ GMT_LOCAL void grd_COMB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_CORRCOEFF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_CORRCOEFF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: CORRCOEFF 2 1 Correlation coefficient r(A, B).  */
 {
 	uint64_t node;
@@ -1500,7 +1500,7 @@ GMT_LOCAL void grd_CORRCOEFF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, s
 	for (node = 0; node < info->size; node++) stack[prev]->G->data[node] = (float)coeff;
 }
 
-GMT_LOCAL void grd_COS (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_COS (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: COS 1 1 cos (A) (A in radians).  */
 {
 	uint64_t node;
@@ -1511,7 +1511,7 @@ GMT_LOCAL void grd_COS (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : cosf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_COSD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_COSD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: COSD 1 1 cos (A) (A in degrees).  */
 {
 	uint64_t node;
@@ -1522,7 +1522,7 @@ GMT_LOCAL void grd_COSD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : cosd (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_COSH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_COSH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: COSH 1 1 cosh (A).  */
 {
 	uint64_t node;
@@ -1533,7 +1533,7 @@ GMT_LOCAL void grd_COSH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : coshf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_COT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_COT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: COT 1 1 cot (A) (A in radians).  */
 {
 	uint64_t node;
@@ -1544,7 +1544,7 @@ GMT_LOCAL void grd_COT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : (1.0 / tan (stack[last]->G->data[node])));
 }
 
-GMT_LOCAL void grd_COTD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_COTD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: COTD 1 1 cot (A) (A in degrees).  */
 {
 	uint64_t node;
@@ -1555,7 +1555,7 @@ GMT_LOCAL void grd_COTD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : 1.0 / tand (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_COTH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_COTH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: COTH 1 1 coth (A).  */
 {
 	uint64_t node;
@@ -1566,7 +1566,7 @@ GMT_LOCAL void grd_COTH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : 1.0f / tanhf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_PCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_PCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: PCDF 2 1 Poisson cumulative distribution function x = A and lambda = B.  */
 {
 	uint64_t node;
@@ -1584,7 +1584,7 @@ GMT_LOCAL void grd_PCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_PPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_PPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: PPDF 2 1 Poisson probability density function for x = A and lambda = B.  */
 {
 	uint64_t node;
@@ -1601,7 +1601,7 @@ GMT_LOCAL void grd_PPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_CSC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_CSC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: CSC 1 1 csc (A) (A in radians).  */
 {
 	uint64_t node;
@@ -1612,7 +1612,7 @@ GMT_LOCAL void grd_CSC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : 1.0 / sinf (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_CSCD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_CSCD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: CSCD 1 1 csc (A) (A in degrees).  */
 {
 	uint64_t node;
@@ -1623,7 +1623,7 @@ GMT_LOCAL void grd_CSCD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : 1.0 / sind (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_CSCH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_CSCH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: CSCH 1 1 csch (A).  */
 {
 	uint64_t node;
@@ -1634,7 +1634,7 @@ GMT_LOCAL void grd_CSCH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : 1.0f / sinhf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_CURV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_CURV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: CURV 1 1 Curvature of A (Laplacian).  */
 {
 	uint64_t node;
@@ -1680,7 +1680,7 @@ GMT_LOCAL void grd_CURV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	gmt_M_free (GMT, cx);
 }
 
-GMT_LOCAL void grd_D2DX2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_D2DX2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: D2DX2 1 1 d^2(A)/dx^2 2nd derivative.  */
 {
 	uint64_t node, ij;
@@ -1716,7 +1716,7 @@ GMT_LOCAL void grd_D2DX2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	gmt_grd_pad_zero (GMT, stack[last]->G);	/* Reset the boundary pad */
 }
 
-GMT_LOCAL void grd_D2DY2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_D2DY2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: D2DY2 1 1 d^2(A)/dy^2 2nd derivative.  */
 {
 	uint64_t node, ij;
@@ -1753,7 +1753,7 @@ GMT_LOCAL void grd_D2DY2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	gmt_grd_pad_zero (GMT, stack[last]->G);	/* Reset the boundary pad */
 }
 
-GMT_LOCAL void grd_D2DXY (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_D2DXY (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: D2DXY 1 1 d^2(A)/dxdy 2nd derivative.  */
 {
 	uint64_t node;
@@ -1797,7 +1797,7 @@ GMT_LOCAL void grd_D2DXY (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	gmt_M_free (GMT, cx);
 }
 
-GMT_LOCAL void grd_D2R (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_D2R (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: D2R 1 1 Converts Degrees to Radians.  */
 {
 	uint64_t node;
@@ -1809,7 +1809,7 @@ GMT_LOCAL void grd_D2R (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : (stack[last]->G->data[node] * D2R));
 }
 
-GMT_LOCAL void grd_DDX (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_DDX (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: DDX 1 1 d(A)/dx Central 1st derivative.  */
 {
 	uint64_t node, ij;
@@ -1844,7 +1844,7 @@ GMT_LOCAL void grd_DDX (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_DDY (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_DDY (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: DDY 1 1 d(A)/dy Central 1st derivative.  */
 {
 	uint64_t node, ij;
@@ -1881,7 +1881,7 @@ GMT_LOCAL void grd_DDY (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	gmt_grd_pad_zero (GMT, stack[last]->G);	/* Reset the boundary pad */
 }
 
-GMT_LOCAL void grd_DEG2KM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_DEG2KM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: DEG2KM 1 1 Converts Spherical Degrees to Kilometers.  */
 {
 	uint64_t node;
@@ -1896,13 +1896,13 @@ GMT_LOCAL void grd_DEG2KM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : stack[last]->G->data[node] * GMT->current.proj.DIST_KM_PR_DEG);
 }
 
-GMT_LOCAL void grd_DENAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_DENAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: DENAN 2 1 Replace NaNs in A with values from B.  */
 {	/* Just a more straightforward application of AND */
-	grd_AND (GMT, info, stack, last);
+	grdmath_AND (GMT, info, stack, last);
 }
 
-GMT_LOCAL void grd_DILOG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_DILOG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: DILOG 1 1 dilog (A).  */
 {
 	uint64_t node;
@@ -1912,7 +1912,7 @@ GMT_LOCAL void grd_DILOG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : gmt_dilog (GMT, stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_DIV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_DIV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: DIV 2 1 A / B.  */
 {
 	uint64_t node;
@@ -1928,7 +1928,7 @@ GMT_LOCAL void grd_DIV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_dot2d (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_dot2d (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 {	/* Get x,y and compute 2-D unit vector then take dot products with vectors represented by grid locations */
 	uint64_t node;
 	unsigned int prev = last - 1, row, col;
@@ -1953,7 +1953,7 @@ GMT_LOCAL void grd_dot2d (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_dot3d (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_dot3d (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 {	/* Get lon,lat and compute 3-D unit vector then take dot products with vectors represented by grid locations */
 	uint64_t node;
 	unsigned int prev = last - 1, row, col;
@@ -1974,16 +1974,16 @@ GMT_LOCAL void grd_dot3d (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_DOT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_DOT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: DOT 2 1 1 Dot product of vector (A,B) with grid nodes.  */
 {
 	if (gmt_M_is_geographic (GMT, GMT_IN))
-		grd_dot3d (GMT, info, stack, last);
+		grdmath_dot3d (GMT, info, stack, last);
 	else
-		grd_dot2d (GMT, info, stack, last);
+		grdmath_dot2d (GMT, info, stack, last);
 }
 
-GMT_LOCAL void grd_DUP (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_DUP (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: DUP 1 2 Places duplicate of A on the stack.  */
 {
 	uint64_t node;
@@ -2000,7 +2000,7 @@ GMT_LOCAL void grd_DUP (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	gmt_M_memcpy (stack[next]->G->data, stack[last]->G->data, info->size, float);
 }
 
-GMT_LOCAL void grd_ECDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ECDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ECDF 2 1 Exponential cumulative distribution function for x = A and lambda = B.  */
 {
 	uint64_t node;
@@ -2015,7 +2015,7 @@ GMT_LOCAL void grd_ECDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_ECRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ECRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ECRIT 2 1 Exponential distribution critical value for alpha = A and lambda = B.  */
 {
 	uint64_t node;
@@ -2030,7 +2030,7 @@ GMT_LOCAL void grd_ECRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_EPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_EPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: EPDF 2 1 Exponential probability density function for x = A and lambda = B.  */
 {
 	uint64_t node;
@@ -2045,7 +2045,7 @@ GMT_LOCAL void grd_EPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_ERF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ERF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ERF 1 1 Error function erf (A).  */
 {
 	uint64_t node;
@@ -2056,7 +2056,7 @@ GMT_LOCAL void grd_ERF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : erff (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_ERFC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ERFC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ERFC 1 1 Complementary Error function erfc (A).  */
 {
 	uint64_t node;
@@ -2067,7 +2067,7 @@ GMT_LOCAL void grd_ERFC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : erfcf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_EQ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_EQ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: EQ 2 1 1 if A == B, else 0.  */
 {
 	uint64_t node;
@@ -2081,7 +2081,7 @@ GMT_LOCAL void grd_EQ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	}
 }
 
-GMT_LOCAL void grd_ERFINV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ERFINV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ERFINV 1 1 Inverse error function of A.  */
 {
 	uint64_t node;
@@ -2098,7 +2098,7 @@ GMT_LOCAL void grd_ERFINV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	}
 }
 
-GMT_LOCAL void grd_EXCH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_EXCH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: EXCH 2 2 Exchanges A and B on the stack.  */
 {
 	uint64_t node;
@@ -2114,7 +2114,7 @@ GMT_LOCAL void grd_EXCH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	gmt_M_bool_swap (stack[last]->constant, stack[prev]->constant);
 }
 
-GMT_LOCAL void grd_EXP (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_EXP (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: EXP 1 1 exp (A).  */
 {
 	uint64_t node;
@@ -2125,7 +2125,7 @@ GMT_LOCAL void grd_EXP (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : expf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_FACT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_FACT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: FACT 1 1 A! (A factorial).  */
 {
 	uint64_t node;
@@ -2137,9 +2137,9 @@ GMT_LOCAL void grd_FACT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 		stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : gmt_factorial (GMT, irint((double)stack[last]->G->data[node])));
 }
 
-/* Subroutines for grd_EXTREMA */
+/* Subroutines for grdmath_EXTREMA */
 
-GMT_LOCAL int do_derivative (gmt_grdfloat *z, uint64_t this_node, int off, unsigned int type)
+GMT_LOCAL int grdmath_do_derivative (gmt_grdfloat *z, uint64_t this_node, int off, unsigned int type)
 {	/* Examine a line of 3-points centered on the current this_node.
 	 * z is the data matrix.
 	 * off is shift to add to get index of the next value and subtract to get previous node.
@@ -2171,7 +2171,7 @@ GMT_LOCAL int do_derivative (gmt_grdfloat *z, uint64_t this_node, int off, unsig
 	return (0);									/* No extrema found */
 }
 
-GMT_LOCAL void grd_EXTREMA (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_EXTREMA (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: EXTREMA 1 1 Local Extrema: +2/-2 is max/min, +1/-1 is saddle with max/min in x, 0 elsewhere.  */
 {
 	uint64_t node;
@@ -2218,8 +2218,8 @@ GMT_LOCAL void grd_EXTREMA (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 
 		if (gmt_M_is_fnan (stack[last]->G->data[node])) continue;	/* No extrema if point is NaN */
 
-		if ((dx = do_derivative (stack[last]->G->data, node, 1, 0)) == -2) continue;	/* Too many NaNs or flat x-line */
-		if ((dy = do_derivative (stack[last]->G->data, node, info->G->header->mx, 0)) == -2) continue;	/* Too many NaNs or flat y-line */
+		if ((dx = grdmath_do_derivative (stack[last]->G->data, node, 1, 0)) == -2) continue;	/* Too many NaNs or flat x-line */
+		if ((dy = grdmath_do_derivative (stack[last]->G->data, node, info->G->header->mx, 0)) == -2) continue;	/* Too many NaNs or flat y-line */
 
 		if ((product = dx * dy) == 0) continue;	/* No min or max possible */
 		if (product < 0) {	/* Saddle point - don't need to check diagonals */
@@ -2229,9 +2229,9 @@ GMT_LOCAL void grd_EXTREMA (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 
 		/* Need to examine diagonal trends to verify min or max */
 
-		if ((diag = do_derivative (stack[last]->G->data, node, -mx1, 1)) == -2) continue;	/* Sorry, no extrema along diagonal N45E */
+		if ((diag = grdmath_do_derivative (stack[last]->G->data, node, -mx1, 1)) == -2) continue;	/* Sorry, no extrema along diagonal N45E */
 		if (diag != 0 && diag != dx) continue;						/* Sorry, extrema of opposite sign along diagonal N45E  */
-		if ((diag = do_derivative (stack[last]->G->data, node,  mx1, 1)) == -2) continue;	/* Sorry, no extrema along diagonal N135E */
+		if ((diag = grdmath_do_derivative (stack[last]->G->data, node,  mx1, 1)) == -2) continue;	/* Sorry, no extrema along diagonal N135E */
 		if (diag != 0 && diag != dx) continue;						/* Sorry, extrema of opposite sign along diagonal N135E  */
 
 		/* OK, we have a min or max point; just use dx to check which kind */
@@ -2244,7 +2244,7 @@ GMT_LOCAL void grd_EXTREMA (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	gmt_M_free (GMT, z);
 }
 
-GMT_LOCAL void grd_FCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_FCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: FCRIT 3 1 F distribution critical value for alpha = A, nu1 = B, and nu2 = C.  */
 {
 	uint64_t node;
@@ -2267,7 +2267,7 @@ GMT_LOCAL void grd_FCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_FCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_FCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: FCDF 3 1 F cumulative distribution function for F = A, nu1 = B, and nu2 = C.  */
 {
 	uint64_t node, nu1, nu2;
@@ -2288,7 +2288,7 @@ GMT_LOCAL void grd_FCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_FLIPLR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_FLIPLR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: FLIPLR 1 1 Reverse order of values in each row.  */
 {
 	uint64_t node;
@@ -2310,7 +2310,7 @@ GMT_LOCAL void grd_FLIPLR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	}
 }
 
-GMT_LOCAL void grd_FLIPUD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_FLIPUD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: FLIPUD 1 1 Reverse order of values in each column.  */
 {
 	unsigned int my1, mx, row_t, row_b, col, my_half;
@@ -2332,7 +2332,7 @@ GMT_LOCAL void grd_FLIPUD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	}
 }
 
-GMT_LOCAL void grd_FLOOR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_FLOOR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: FLOOR 1 1 floor (A) (greatest integer <= A).  */
 {
 	uint64_t node;
@@ -2343,7 +2343,7 @@ GMT_LOCAL void grd_FLOOR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : floorf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_FMOD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_FMOD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: FMOD 2 1 A % B (remainder after truncated division).  */
 {
 	uint64_t node;
@@ -2359,7 +2359,7 @@ GMT_LOCAL void grd_FMOD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_FPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_FPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: FPDF 3 1 F probability density function for F = A, nu1 = B and nu2 = C.  */
 {
 	uint64_t node, nu1, nu2;
@@ -2381,7 +2381,7 @@ GMT_LOCAL void grd_FPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_GE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_GE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: GE 2 1 1 if A >= B, else 0.  */
 {
 	uint64_t node;
@@ -2396,7 +2396,7 @@ GMT_LOCAL void grd_GE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	}
 }
 
-GMT_LOCAL void grd_GT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_GT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: GT 2 1 1 if A > B, else 0.  */
 {
 	uint64_t node;
@@ -2411,7 +2411,7 @@ GMT_LOCAL void grd_GT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	}
 }
 
-GMT_LOCAL void grd_HSV2LAB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_HSV2LAB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: HSV2LAB 3 3 Convert hsv to lab, with h = A, s = B and v = C.  */
 {
 	uint64_t node;
@@ -2458,7 +2458,7 @@ GMT_LOCAL void grd_HSV2LAB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_HSV2RGB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_HSV2RGB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: HSV2RGB 3 3 Convert hsv to rgb, with h = A, s = B and v = C.  */
 {
 	uint64_t node;
@@ -2503,7 +2503,7 @@ GMT_LOCAL void grd_HSV2RGB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_HSV2XYZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_HSV2XYZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: HSV2XYZ 3 3 Convert hsv to xyz, with h = A, s = B and v = C.  */
 {
 	uint64_t node;
@@ -2550,7 +2550,7 @@ GMT_LOCAL void grd_HSV2XYZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_HYPOT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_HYPOT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: HYPOT 2 1 hypot (A, B) = sqrt (A*A + B*B).  */
 {
 	uint64_t node;
@@ -2566,7 +2566,7 @@ GMT_LOCAL void grd_HYPOT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_I0 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_I0 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: I0 1 1 Modified Bessel function of A (1st kind, order 0).  */
 {
 	uint64_t node;
@@ -2576,7 +2576,7 @@ GMT_LOCAL void grd_I0 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : gmt_i0 (GMT, stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_I1 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_I1 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: I1 1 1 Modified Bessel function of A (1st kind, order 1).  */
 {
 	uint64_t node;
@@ -2586,7 +2586,7 @@ GMT_LOCAL void grd_I1 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : gmt_i1 (GMT, stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_IFELSE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_IFELSE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: IFELSE 3 1 B if A != 0, else C.  */
 {
 	uint64_t node;
@@ -2614,7 +2614,7 @@ GMT_LOCAL void grd_IFELSE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	}
 }
 
-GMT_LOCAL void grd_IN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_IN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: IN 2 1 Modified Bessel function of A (1st kind, order B).  */
 {
 	uint64_t node;
@@ -2644,7 +2644,7 @@ GMT_LOCAL void grd_IN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	}
 }
 
-GMT_LOCAL void grd_INRANGE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_INRANGE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: INRANGE 3 1 1 if B <= A <= C, else 0.  */
 {
 	uint64_t node;
@@ -2677,7 +2677,7 @@ GMT_LOCAL void grd_INRANGE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_INSIDE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_INSIDE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: INSIDE 1 1 1 when inside or on polygon(s) in A, else 0.  */
 {	/* Suitable for geographic (lon, lat) data and polygons */
 	int64_t row, col;			/* int since VS 2013/OMP 2.0 doesn't allow unsigned index variables */
@@ -2727,7 +2727,7 @@ GMT_LOCAL void grd_INSIDE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	}
 }
 
-GMT_LOCAL void grd_INV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_INV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: INV 1 1 1 / A.  */
 {
 	uint64_t node;
@@ -2741,7 +2741,7 @@ GMT_LOCAL void grd_INV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_ISFINITE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ISFINITE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ISFINITE 1 1 1 if A is finite, else 0.  */
 {
 	uint64_t node;
@@ -2752,7 +2752,7 @@ GMT_LOCAL void grd_ISFINITE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, st
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : isfinite (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_ISNAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ISNAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ISNAN 1 1 1 if A == NaN, else 0.  */
 {
 	uint64_t node;
@@ -2763,7 +2763,7 @@ GMT_LOCAL void grd_ISNAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : gmt_M_is_fnan (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_J0 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_J0 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: J0 1 1 Bessel function of A (1st kind, order 0).  */
 {
 	uint64_t node;
@@ -2774,7 +2774,7 @@ GMT_LOCAL void grd_J0 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : (float)j0 (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_J1 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_J1 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: J1 1 1 Bessel function of A (1st kind, order 1).  */
 {
 	uint64_t node;
@@ -2785,7 +2785,7 @@ GMT_LOCAL void grd_J1 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : (float)j1 (fabsf (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_JN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_JN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: JN 2 1 Bessel function of A (1st kind, order B).  */
 {
 	uint64_t node;
@@ -2813,7 +2813,7 @@ GMT_LOCAL void grd_JN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	}
 }
 
-GMT_LOCAL void grd_K0 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_K0 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: K0 1 1 Modified Kelvin function of A (2nd kind, order 0).  */
 {
 	uint64_t node;
@@ -2823,7 +2823,7 @@ GMT_LOCAL void grd_K0 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : (float)gmt_k0 (GMT, stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_K1 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_K1 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: K1 1 1 Modified Bessel function of A (2nd kind, order 1).  */
 {
 	uint64_t node;
@@ -2833,7 +2833,7 @@ GMT_LOCAL void grd_K1 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : (float)gmt_k1 (GMT, stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_KEI (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_KEI (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: KEI 1 1 kei (A).  */
 {
 	uint64_t node;
@@ -2843,7 +2843,7 @@ GMT_LOCAL void grd_KEI (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : (float)gmt_kei (GMT, fabsf (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_KER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_KER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: KER 1 1 ker (A).  */
 {
 	uint64_t node;
@@ -2853,7 +2853,7 @@ GMT_LOCAL void grd_KER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : gmt_ker (GMT, fabsf (stack[last]->G->data[node])));
 }
 
-GMT_LOCAL void grd_KM2DEG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_KM2DEG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: KM2DEG 1 1 Converts Kilometers to Spherical Degrees.  */
 {
 	uint64_t node;
@@ -2868,7 +2868,7 @@ GMT_LOCAL void grd_KM2DEG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : (stack[last]->G->data[node] * f));
 }
 
-GMT_LOCAL void grd_KN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_KN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: KN 2 1 Modified Bessel function of A (2nd kind, order B).  */
 {
 	uint64_t node;
@@ -2898,7 +2898,7 @@ GMT_LOCAL void grd_KN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	}
 }
 
-GMT_LOCAL void grd_KURT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_KURT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: KURT 1 1 Kurtosis of A.  */
 {
 	uint64_t node, n = 0;
@@ -2934,9 +2934,9 @@ GMT_LOCAL void grd_KURT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = f_kurt;
 }
 
-/* Helper functions ASCII_read and ASCII_free are used in LDIST*, PDIST and *POINT */
+/* Helper functions grdmath_ASCII_read and grdmath_ASCII_free are used in LDIST*, PDIST and *POINT */
 
-GMT_LOCAL struct GMT_DATASET *ASCII_read (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, int geometry, char *op)
+GMT_LOCAL struct GMT_DATASET *grdmath_ASCII_read (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, int geometry, char *op)
 {
 	struct GMT_DATASET *D = NULL;
 	if (gmt_M_is_geographic (GMT, GMT_IN))
@@ -2958,7 +2958,7 @@ GMT_LOCAL struct GMT_DATASET *ASCII_read (struct GMT_CTRL *GMT, struct GRDMATH_I
 	return (D);
 }
 
-GMT_LOCAL int ASCII_free (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GMT_DATASET **D, char *op)
+GMT_LOCAL int grdmath_ASCII_free (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GMT_DATASET **D, char *op)
 {
 	if (GMT_Destroy_Data (GMT->parent, D) != GMT_NOERROR) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in operator %s destroying allocated data from %s!\n", op, info->ASCII_file);
@@ -2968,7 +2968,7 @@ GMT_LOCAL int ASCII_free (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	return 0;
 }
 
-GMT_LOCAL void grd_LAB2HSV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_LAB2HSV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: LAB2HSV 3 3 Convert lab to hsv, with l = A, a = B and b = C.  */
 {
 	uint64_t node;
@@ -3017,7 +3017,7 @@ GMT_LOCAL void grd_LAB2HSV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_LAB2RGB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_LAB2RGB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: LAB2RGB 3 3 Convert lab to rgb, with l = A, a = B and b = C.  */
 {
 	uint64_t node;
@@ -3063,7 +3063,7 @@ GMT_LOCAL void grd_LAB2RGB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_LAB2XYZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_LAB2XYZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: LAB2XYZ 3 3 Convert lab to xyz, with l = A, a = B and b = C.  */
 {
 	uint64_t node;
@@ -3109,7 +3109,7 @@ GMT_LOCAL void grd_LAB2XYZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_LCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_LCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: LCDF 1 1 Laplace cumulative distribution function for z = A.  */
 {
 	uint64_t node;
@@ -3120,7 +3120,7 @@ GMT_LOCAL void grd_LCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : 0.5f + copysignf (0.5f, stack[last]->G->data[node]) * (1.0 - expf (-fabsf (stack[last]->G->data[node]))));
 }
 
-GMT_LOCAL void grd_LCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_LCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: LCRIT 1 1 Laplace distribution critical value for alpha = A.  */
 {
 	uint64_t node;
@@ -3141,7 +3141,7 @@ GMT_LOCAL void grd_LCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_LDIST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_LDIST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: LDIST 1 1 Compute minimum distance (in km if -fg) from lines in multi-segment ASCII file A.  */
 {
 	int64_t node, row, col;			/* int since VS 2013/OMP 2.0 doesn't allow unsigned index variables */
@@ -3149,7 +3149,7 @@ GMT_LOCAL void grd_LDIST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	struct GMT_DATATABLE *T = NULL;
 	struct GMT_DATASET *D = NULL;
 
-	if ((D = ASCII_read (GMT, info, GMT_IS_LINE, "LDIST")) == NULL) return;
+	if ((D = grdmath_ASCII_read (GMT, info, GMT_IS_LINE, "LDIST")) == NULL) return;
 	T = D->table[0];	/* Only one table in a single file */
 
 #ifdef _OPENMP
@@ -3164,10 +3164,10 @@ GMT_LOCAL void grd_LDIST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 		}
 	}
 
-	ASCII_free (GMT, info, &D, "LDIST");	/* Free memory used for line */
+	grdmath_ASCII_free (GMT, info, &D, "LDIST");	/* Free memory used for line */
 }
 
-GMT_LOCAL void grd_LDISTG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_LDISTG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: LDISTG 0 1 As LDIST, but operates on the GSHHG dataset (see -A, -D for options).  */
 {
 #ifdef _OPENMP
@@ -3254,7 +3254,7 @@ GMT_LOCAL void grd_LDISTG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	gmt_free_dataset (GMT, &D);
 }
 
-GMT_LOCAL void grd_LDIST2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_LDIST2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: LDIST2 2 1 As LDIST, from lines in ASCII file B but only to nodes where A != 0.  */
 {
 	int64_t node, row, col;			/* int since VS 2013/OMP 2.0 doesn't allow unsigned index variables */
@@ -3263,7 +3263,7 @@ GMT_LOCAL void grd_LDIST2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	struct GMT_DATATABLE *T = NULL;
 	struct GMT_DATASET *D = NULL;
 
-	if ((D = ASCII_read (GMT, info, GMT_IS_LINE, "LDIST2")) == NULL) return;
+	if ((D = grdmath_ASCII_read (GMT, info, GMT_IS_LINE, "LDIST2")) == NULL) return;
 	T = D->table[0];	/* Only one table in a single file */
 	prev = last - 1;
 
@@ -3283,10 +3283,10 @@ GMT_LOCAL void grd_LDIST2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 		}
 	}
 
-	ASCII_free (GMT, info, &D, "LDIST2");	/* Free memory used for line */
+	grdmath_ASCII_free (GMT, info, &D, "LDIST2");	/* Free memory used for line */
 }
 
-GMT_LOCAL void grd_LE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_LE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: LE 2 1 1 if A <= B, else 0.  */
 {
 	uint64_t node;
@@ -3301,7 +3301,7 @@ GMT_LOCAL void grd_LE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	}
 }
 
-GMT_LOCAL void grd_LOG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_LOG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: LOG 1 1 log (A) (natural log).  */
 {
 	uint64_t node;
@@ -3313,7 +3313,7 @@ GMT_LOCAL void grd_LOG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : d_logf (GMT, fabsf (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_LOG10 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_LOG10 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: LOG10 1 1 log10 (A) (base 10).  */
 {
 	uint64_t node;
@@ -3325,7 +3325,7 @@ GMT_LOCAL void grd_LOG10 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : d_log10f (GMT, fabsf (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_LOG1P (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_LOG1P (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: LOG1P 1 1 log (1+A) (accurate for small A).  */
 {
 	uint64_t node;
@@ -3337,7 +3337,7 @@ GMT_LOCAL void grd_LOG1P (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : d_log1pf (GMT, fabsf (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_LOG2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_LOG2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: LOG2 1 1 log2 (A) (base 2).  */
 {
 	uint64_t node;
@@ -3349,7 +3349,7 @@ GMT_LOCAL void grd_LOG2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : d_logf (GMT, fabsf (stack[last]->G->data[node])) * M_LN2_INV);
 }
 
-GMT_LOCAL void grd_LMSSCL (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_LMSSCL (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: LMSSCL 1 1 LMS scale estimate (LMS STD) of A.  */
 	uint64_t node;
 	float lmsscl_f;
@@ -3372,7 +3372,7 @@ GMT_LOCAL void grd_LMSSCL (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = lmsscl_f;
 }
 
-GMT_LOCAL void grd_LMSSCLW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_LMSSCLW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: LMSSCLW 1 1 Weighted LMS scale estimate (LMS STD) of A for weights in B.  */
 	uint64_t node;
 	unsigned int prev = last - 1;
@@ -3387,7 +3387,7 @@ GMT_LOCAL void grd_LMSSCLW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	for (node = 0; node < info->size; node++) stack[prev]->G->data[node] = lmsscl;
 }
 
-GMT_LOCAL void grd_LOWER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_LOWER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: LOWER 1 1 The lowest (minimum) value of A.  */
 	uint64_t node;
 	unsigned int row, col;
@@ -3408,7 +3408,7 @@ GMT_LOCAL void grd_LOWER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) if (!gmt_M_is_fnan (stack[last]->G->data[node])) stack[last]->G->data[node] = low;
 }
 
-GMT_LOCAL void grd_LPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_LPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: LPDF 1 1 Laplace probability density function for z = A.  */
 	uint64_t node;
 	double a = 0.0;
@@ -3418,7 +3418,7 @@ GMT_LOCAL void grd_LPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : 0.5 * expf (-fabsf (stack[last]->G->data[node])));
 }
 
-GMT_LOCAL void grd_LRAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_LRAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: LRAND 2 1 Laplace random noise with mean A and std. deviation B.  */
 	uint64_t node;
 	unsigned int prev;
@@ -3434,7 +3434,7 @@ GMT_LOCAL void grd_LRAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_LT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_LT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: LT 2 1 1 if A < B, else 0.  */
 	uint64_t node;
 	unsigned int prev;
@@ -3448,7 +3448,7 @@ GMT_LOCAL void grd_LT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	}
 }
 
-GMT_LOCAL void grd_MAD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_MAD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: MAD 1 1 Median Absolute Deviation (L1 STD) of A.  */
 	uint64_t node;
 	float mad_f;
@@ -3471,7 +3471,7 @@ GMT_LOCAL void grd_MAD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = mad_f;
 }
 
-GMT_LOCAL void grd_MADW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_MADW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: MADW 2 1 Weighted Median Absolute Deviation (L1 STD) of A for weights in B.  */
 	uint64_t node;
 	unsigned int prev = last - 1;
@@ -3486,7 +3486,7 @@ GMT_LOCAL void grd_MADW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[prev]->G->data[node] = wmad;
 }
 
-GMT_LOCAL void grd_MAX (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_MAX (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: MAX 2 1 Maximum of A and B.  */
 	uint64_t node;
 	unsigned int prev;
@@ -3500,7 +3500,7 @@ GMT_LOCAL void grd_MAX (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_MEAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_MEAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: MEAN 1 1 Mean value of A.  */
 	uint64_t node;
 	float zm;
@@ -3524,7 +3524,7 @@ GMT_LOCAL void grd_MEAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = zm;
 }
 
-GMT_LOCAL void grd_MEANW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_MEANW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: MEANW 2 1 Weighted mean value of A for weights in B.  */
 	uint64_t node;
 	unsigned int prev = last - 1;
@@ -3543,7 +3543,7 @@ GMT_LOCAL void grd_MEANW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) stack[prev]->G->data[node] = zm;
 }
 
-GMT_LOCAL void grd_MEDIAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_MEDIAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: MEDIAN 1 1 Median value of A.  */
 	uint64_t node;
 	float med;
@@ -3565,7 +3565,7 @@ GMT_LOCAL void grd_MEDIAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = med;
 }
 
-GMT_LOCAL void grd_MEDIANW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_MEDIANW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: MEDIANW 2 1 Weighted median value of A for weights in B.  */
 	uint64_t node;
 	unsigned int prev = last - 1;
@@ -3580,7 +3580,7 @@ GMT_LOCAL void grd_MEDIANW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	for (node = 0; node < info->size; node++) stack[prev]->G->data[node] = wmed;
 }
 
-GMT_LOCAL void grd_MIN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_MIN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: MIN 2 1 Minimum of A and B.  */
 	uint64_t node;
 	unsigned int prev;
@@ -3594,7 +3594,7 @@ GMT_LOCAL void grd_MIN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_MOD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_MOD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: MOD 2 1 A mod B (remainder after floored division).  */
 	uint64_t node;
 	unsigned int prev;
@@ -3609,7 +3609,7 @@ GMT_LOCAL void grd_MOD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_MODE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_MODE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: MODE 1 1 Mode value (Least Median of Squares) of A.  */
 	uint64_t node;
 	float mode = 0.0f;
@@ -3631,7 +3631,7 @@ GMT_LOCAL void grd_MODE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = mode;
 }
 
-GMT_LOCAL void grd_MODEW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_MODEW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: MODEW 2 1 Weighted mode value of A for weights in B.  */
 	uint64_t node;
 	unsigned int prev = last - 1;
@@ -3646,7 +3646,7 @@ GMT_LOCAL void grd_MODEW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) stack[prev]->G->data[node] = wmode;
 }
 
-GMT_LOCAL void grd_MUL (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_MUL (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: MUL 2 1 A * B.  */
 	uint64_t node;
 	unsigned int prev;
@@ -3662,7 +3662,7 @@ GMT_LOCAL void grd_MUL (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_NAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_NAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: NAN 2 1 NaN if A == B, else A.  */
 	uint64_t node;
 	unsigned int prev;
@@ -3678,7 +3678,7 @@ GMT_LOCAL void grd_NAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_NEG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_NEG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: NEG 1 1 -A.  */
 	uint64_t node;
 	float a = 0.0f;
@@ -3688,7 +3688,7 @@ GMT_LOCAL void grd_NEG (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : -stack[last]->G->data[node];
 }
 
-GMT_LOCAL void grd_NEQ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_NEQ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: NEQ 2 1 1 if A != B, else 0.  */
 	uint64_t node;
 	unsigned int prev;
@@ -3703,7 +3703,7 @@ GMT_LOCAL void grd_NEQ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_NORM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_NORM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: NORM 1 1 Normalize (A) so max(A)-min(A) = 1.  */
 	uint64_t node, n = 0;
 	unsigned int row, col;
@@ -3727,7 +3727,7 @@ GMT_LOCAL void grd_NORM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	gmt_M_grd_loop (GMT, info->G, row, col, node) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : a * stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_NOT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_NOT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: NOT 1 1 NaN if A == NaN, 1 if A == 0, else 0.  */
 	uint64_t node;
 	float a = 0.0f;
@@ -3737,7 +3737,7 @@ GMT_LOCAL void grd_NOT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : ((fabsf (stack[last]->G->data[node]) > GMT_CONV8_LIMIT) ? 0.0f : 1.0f);
 }
 
-GMT_LOCAL void grd_NRAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_NRAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: NRAND 2 1 Normal, random values with mean A and std. deviation B.  */
 	uint64_t node;
 	unsigned int prev;
@@ -3753,7 +3753,7 @@ GMT_LOCAL void grd_NRAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_OR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_OR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: OR 2 1 NaN if B == NaN, else A.  */
 	uint64_t node;
 	unsigned int prev;
@@ -3767,14 +3767,14 @@ GMT_LOCAL void grd_OR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	}
 }
 
-GMT_LOCAL void grd_PDIST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_PDIST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: PDIST 1 1 Compute minimum distance (in km if -fg) from points in ASCII file A.  */
 	int64_t node, row, col;			/* int since VS 2013/OMP 2.0 doesn't allow unsigned index variables */
 	uint64_t dummy[2];
 	struct GMT_DATATABLE *T = NULL;
 	struct GMT_DATASET *D = NULL;
 
-	if ((D = ASCII_read (GMT, info, GMT_IS_POINT, "PDIST")) == NULL) return;
+	if ((D = grdmath_ASCII_read (GMT, info, GMT_IS_POINT, "PDIST")) == NULL) return;
 
 	T = D->table[0];	/* Only one table in a single file */
 
@@ -3787,10 +3787,10 @@ GMT_LOCAL void grd_PDIST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 			stack[last]->G->data[node] = (float)gmt_mindist_to_point (GMT, info->d_grd_x[col], info->d_grd_y[row], T, dummy);
 		}
 	}
-	ASCII_free (GMT, info, &D, "PDIST");	/* Free memory used for points */
+	grdmath_ASCII_free (GMT, info, &D, "PDIST");	/* Free memory used for points */
 }
 
-GMT_LOCAL void grd_PDIST2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_PDIST2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: PDIST2 2 1 As PDIST, from points in ASCII file B but only to nodes where A != 0.  */
 	int64_t node, row, col;			/* int since VS 2013/OMP 2.0 doesn't allow unsigned index variables */
 	uint64_t dummy[2];
@@ -3798,7 +3798,7 @@ GMT_LOCAL void grd_PDIST2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	struct GMT_DATATABLE *T = NULL;
 	struct GMT_DATASET *D = NULL;
 
-	if ((D = ASCII_read (GMT, info, GMT_IS_POINT, "PDIST")) == NULL) return;
+	if ((D = grdmath_ASCII_read (GMT, info, GMT_IS_POINT, "PDIST")) == NULL) return;
 
 	T = D->table[0];	/* Only one table in a single file */
 	prev = last - 1;
@@ -3816,10 +3816,10 @@ GMT_LOCAL void grd_PDIST2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 		}
 	}
 
-	ASCII_free (GMT, info, &D, "PDIST2");	/* Free memory used for points */
+	grdmath_ASCII_free (GMT, info, &D, "PDIST2");	/* Free memory used for points */
 }
 
-GMT_LOCAL void grd_PERM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_PERM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: PERM 2 1 Permutations n_P_r, with n = A and r = B.  */
 	uint64_t node;
 	unsigned int prev = last - 1, row, col, error = 0;
@@ -3847,14 +3847,14 @@ GMT_LOCAL void grd_PERM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_POP (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_POP (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: POP 1 0 Delete top element from the stack.  */
 {
 	gmt_M_unused(GMT); gmt_M_unused(info); gmt_M_unused(stack); gmt_M_unused(last);
 	/* Dummy routine that does nothing but consume the top element of stack */
 }
 
-GMT_LOCAL void grd_PLM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_PLM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: PLM 3 1 Associated Legendre polynomial P(A) degree B order C.  */
 {
 	int64_t node;	/* Because of Win OpenMP */
@@ -3885,7 +3885,7 @@ GMT_LOCAL void grd_PLM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 }
 
 
-GMT_LOCAL void grd_PLMg (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_PLMg (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: PLMg 3 1 Normalized associated Legendre polynomial P(A) degree B order C (geophysical convention).  */
 {
 	int64_t node;	/* Because of Win OpenMP */
@@ -3915,7 +3915,7 @@ GMT_LOCAL void grd_PLMg (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_POINT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_POINT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: POINT 1 2 Return mean_x mean_y of points in ASCII file A.  */
 {
 	uint64_t node, n = 0;
@@ -3926,7 +3926,7 @@ GMT_LOCAL void grd_POINT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	int geo = gmt_M_is_geographic (GMT, GMT_IN) ? 1 : 0;
 
 	/* Read a table and compute mean location */
-	if ((D = ASCII_read (GMT, info, GMT_IS_POINT, "POINT")) == NULL) return;
+	if ((D = grdmath_ASCII_read (GMT, info, GMT_IS_POINT, "POINT")) == NULL) return;
 	T = D->table[0];	/* Only one table in a single file */
 	if (T->n_records == 1) {	/* Got a single point record; no need to average etc */
 		pos[GMT_X] = T->segment[0]->data[GMT_X][0];
@@ -3965,10 +3965,10 @@ GMT_LOCAL void grd_POINT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 		gmt_M_free (GMT, x);
 		gmt_M_free (GMT, y);
 	}
-	ASCII_free (GMT, info, &D, "POINT");	/* Free memory used for points */
+	grdmath_ASCII_free (GMT, info, &D, "POINT");	/* Free memory used for points */
 }
 
-GMT_LOCAL void grd_POW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_POW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: POW 2 1 A ^ B.  */
 {
 	uint64_t node;
@@ -3986,7 +3986,7 @@ GMT_LOCAL void grd_POW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL float grd_wquant_sub (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GMT_GRID *G, struct GMT_GRID *W, double q, bool use_grid, double weight) {
+GMT_LOCAL float grdmath_wquant_sub (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GMT_GRID *G, struct GMT_GRID *W, double q, bool use_grid, double weight) {
 	uint64_t node, n = 0;
 	unsigned int row, col;
 	float p;
@@ -4011,7 +4011,7 @@ GMT_LOCAL float grd_wquant_sub (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info,
 	return p;
 }
 
-GMT_LOCAL void grd_PQUANT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_PQUANT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: PQUANT 2 1 The B'th Quantile (0-100%) of A.  */
 {
 	uint64_t node;
@@ -4034,7 +4034,7 @@ GMT_LOCAL void grd_PQUANT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	else if (gmt_M_is_geographic (GMT, GMT_IN)) {	/* Must use spherical weights */
 		struct GMT_GRID *W = gmt_duplicate_grid (GMT, stack[prev]->G, GMT_DUPLICATE_ALLOC);
 		gmt_get_cellarea (GMT, W);
-		p = grd_wquant_sub (GMT, info, stack[prev]->G, W, stack[last]->factor, true, 0.0);
+		p = grdmath_wquant_sub (GMT, info, stack[prev]->G, W, stack[last]->factor, true, 0.0);
 		gmt_free_grid (GMT, &W, true);
 	}
 	else {
@@ -4049,7 +4049,7 @@ GMT_LOCAL void grd_PQUANT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	for (node = 0; node < info->size; node++) stack[prev]->G->data[node] = p;
 }
 
-GMT_LOCAL void grd_PQUANTW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_PQUANTW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: PQUANTW 3 1 The C'th Quantile (0-100%) of A for weights in B.  */
 {
 	uint64_t node;
@@ -4069,11 +4069,11 @@ GMT_LOCAL void grd_PQUANTW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 		p = GMT->session.f_NaN;
 	}
 	else
-		p = grd_wquant_sub (GMT, info, stack[prev2]->G, stack[prev]->G, stack[last]->factor, !stack[prev]->constant, stack[prev]->factor);
+		p = grdmath_wquant_sub (GMT, info, stack[prev2]->G, stack[prev]->G, stack[last]->factor, !stack[prev]->constant, stack[prev]->factor);
 	for (node = 0; node < info->size; node++) stack[prev2]->G->data[node] = p;
 }
 
-GMT_LOCAL void grd_PSI (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_PSI (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: PSI 1 1 Psi (or Digamma) of A.  */
 {
 	int64_t node;
@@ -4098,7 +4098,7 @@ GMT_LOCAL void grd_PSI (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_PVQV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last, unsigned int kind)
+GMT_LOCAL void grdmath_PVQV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last, unsigned int kind)
 {
 	bool calc;
 	unsigned int prev = last - 1, first = last - 2, n;
@@ -4130,19 +4130,19 @@ GMT_LOCAL void grd_PVQV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_PV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_PV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: PV 3 1 Legendre function Pv(A) of degree v = real(B) + imag(C).  */
 {
-	grd_PVQV (GMT, info, stack, last, 0);
+	grdmath_PVQV (GMT, info, stack, last, 0);
 }
 
-GMT_LOCAL void grd_QV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_QV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: QV 3 1 Legendre function Qv(A) of degree v = real(B) + imag(C).  */
 {
-	grd_PVQV (GMT, info, stack, last, 1);
+	grdmath_PVQV (GMT, info, stack, last, 1);
 }
 
-GMT_LOCAL void grd_R2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_R2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: R2 2 1 R2 = A^2 + B^2.  */
 {
 	uint64_t node;
@@ -4161,7 +4161,7 @@ GMT_LOCAL void grd_R2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	}
 }
 
-GMT_LOCAL void grd_R2D (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_R2D (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: R2D 1 1 Convert Radians to Degrees.  */
 {
 	uint64_t node;
@@ -4174,7 +4174,7 @@ GMT_LOCAL void grd_R2D (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 		stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : R2D * stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_RAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_RAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: RAND 2 1 Uniform random values between A and B.  */
 {
 	uint64_t node;
@@ -4191,7 +4191,7 @@ GMT_LOCAL void grd_RAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_RCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_RCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: RCDF 1 1 Rayleigh cumulative distribution function for z = A.  */
 {
 	uint64_t node;
@@ -4202,7 +4202,7 @@ GMT_LOCAL void grd_RCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : 1.0 - expf (-0.5f*stack[last]->G->data[node]*stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_RCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_RCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: RCRIT 1 1 Rayleigh distribution critical value for alpha = A.  */
 {
 	uint64_t node;
@@ -4213,7 +4213,7 @@ GMT_LOCAL void grd_RCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : M_SQRT2 * sqrtf (-logf (1.0f - stack[last]->G->data[node])));
 }
 
-GMT_LOCAL void grd_RGB2HSV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_RGB2HSV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: RGB2HSV 3 3 Convert rgb to hsv, with r = A, g = B and b = C.  */
 {
 	uint64_t node;
@@ -4258,7 +4258,7 @@ GMT_LOCAL void grd_RGB2HSV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_RGB2LAB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_RGB2LAB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: RGB2LAB 3 3 Convert rgb to lab, with r = A, g = B and b = C.  */
 {
 	uint64_t node;
@@ -4302,7 +4302,7 @@ GMT_LOCAL void grd_RGB2LAB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_RGB2XYZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_RGB2XYZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: RGB2XYZ 3 3 Convert rgb to xyz, with r = A, g = B and b = C.  */
 {
 	uint64_t node;
@@ -4346,7 +4346,7 @@ GMT_LOCAL void grd_RGB2XYZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_RINT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_RINT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: RINT 1 1 rint (A) (round to integral value nearest to A).  */
 {
 	uint64_t node;
@@ -4358,7 +4358,7 @@ GMT_LOCAL void grd_RINT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 		stack[last]->G->data[node] = (stack[last]->constant) ? a : rintf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_RMS (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_RMS (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: RMS 1 1 Root-mean-square of A.  */
 {
 	uint64_t node;
@@ -4384,7 +4384,7 @@ GMT_LOCAL void grd_RMS (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = rms;
 }
 
-GMT_LOCAL void grd_RMSW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_RMSW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: RMSW 2 1 Weighted Root-mean-square of A for weights in B.  */
 {
 	uint64_t node;
@@ -4403,7 +4403,7 @@ GMT_LOCAL void grd_RMSW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[prev]->G->data[node] = rms;
 }
 
-GMT_LOCAL void grd_RPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_RPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: RPDF 1 1 Rayleigh probability density function for z = A.  */
 {
 	uint64_t node;
@@ -4414,14 +4414,14 @@ GMT_LOCAL void grd_RPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : stack[last]->G->data[node] * expf (-0.5f * stack[last]->G->data[node] * stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void assign_grdstack (struct GRDMATH_STACK *Sto, struct GRDMATH_STACK *Sfrom)
+GMT_LOCAL void grdmath_assign_grdstack (struct GRDMATH_STACK *Sto, struct GRDMATH_STACK *Sfrom)
 {	/* Copy contents of Sfrom to Sto */
 	Sto->G          = Sfrom->G;
 	Sto->constant   = Sfrom->constant;
 	Sto->factor     = Sfrom->factor;
 }
 
-GMT_LOCAL void grd_ROLL (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ROLL (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ROLL 2 0 Cyclicly shifts the top A stack items by an amount B.  */
 {
 	unsigned int prev, top, bottom, k, kk, n_items;
@@ -4444,22 +4444,22 @@ GMT_LOCAL void grd_ROLL (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	bottom = prev - n_items;
 	for (k = 0; k < (unsigned int)abs (n_shift); k++) {	/* Do the cyclical shift */
 		if (n_shift > 0) {	/* Positive roll */
-			assign_grdstack (&Stmp, stack[top]);	/* Keep copy of top item */
+			grdmath_assign_grdstack (&Stmp, stack[top]);	/* Keep copy of top item */
 			for (kk = 1; kk < n_items; kk++)	/* Move all others up one step */
-				assign_grdstack (stack[top-kk+1], stack[top-kk]);
-			assign_grdstack (stack[bottom], &Stmp);	/* Place copy on bottom */
+				grdmath_assign_grdstack (stack[top-kk+1], stack[top-kk]);
+			grdmath_assign_grdstack (stack[bottom], &Stmp);	/* Place copy on bottom */
 		}
 		else if (n_shift < 0) {	/* Negative roll */
-			assign_grdstack (&Stmp, stack[bottom]);	/* Keep copy of bottom item */
+			grdmath_assign_grdstack (&Stmp, stack[bottom]);	/* Keep copy of bottom item */
 			for (kk = 1; kk < n_items; kk++)	/* Move all others down one step */
-				assign_grdstack (stack[bottom+kk-1], stack[bottom+kk]);
-			assign_grdstack (stack[top], &Stmp);	/* Place copy on top */
+				grdmath_assign_grdstack (stack[bottom+kk-1], stack[bottom+kk]);
+			grdmath_assign_grdstack (stack[top], &Stmp);	/* Place copy on top */
 		}
 	}
 	return;
 }
 
-GMT_LOCAL void grd_ROTX (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_ROTX (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: ROTX 2 1 Rotate A by the (constant) shift B in x-direction.  */
 	uint64_t node;
 	unsigned int col, row, prev = last - 1, *new_col = NULL, n_columns;
@@ -4492,7 +4492,7 @@ GMT_LOCAL void grd_ROTX (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	gmt_M_free (GMT, new_col);
 }
 
-GMT_LOCAL void grd_ROTY (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_ROTY (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: ROTY 2 1 Rotate A by the (constant) shift B in y-direction.  */
 	unsigned int row, col, prev = last - 1, *new_row = NULL;
 	int rowx, shift;
@@ -4521,7 +4521,7 @@ GMT_LOCAL void grd_ROTY (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	gmt_M_free (GMT, new_row);
 }
 
-GMT_LOCAL void grd_SDIST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_SDIST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: SDIST 2 1 Spherical distance (in km) between grid nodes and stack lon,lat (A, B).  */
 	int64_t node, row, col;			/* int since VS 2013/OMP 2.0 doesn't allow unsigned index variables */
 	unsigned int prev = last - 1;
@@ -4547,7 +4547,7 @@ GMT_LOCAL void grd_SDIST (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_SDIST2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
+GMT_LOCAL void grdmath_SDIST2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last) {
 /*OPERATOR: SDIST2 2 1 As SDIST but only to nodes that are != 0.  */
 	int64_t node, row, col;			/* int since VS 2013/OMP 2.0 doesn't allow unsigned index variables */
 	unsigned int prev = last - 1;
@@ -4577,7 +4577,7 @@ GMT_LOCAL void grd_SDIST2 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	}
 }
 
-GMT_LOCAL void grd_AZ_sub (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last, bool reverse) {
+GMT_LOCAL void grdmath_AZ_sub (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last, bool reverse) {
 	int64_t node, row, col;			/* int since VS 2013/OMP 2.0 still doesn't allow unsigned index variables */
 	unsigned int prev = last - 1;
 	double x0 = 0.0, y0 = 0.0, az;
@@ -4600,21 +4600,21 @@ GMT_LOCAL void grd_AZ_sub (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, stru
 	}
 }
 
-GMT_LOCAL void grd_SAZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SAZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SAZ 2 1 Spherical azimuth from grid nodes to stack x,y.  */
 /* Azimuth from grid ones to stack point */
 {
-	grd_AZ_sub (GMT, info, stack, last, false);
+	grdmath_AZ_sub (GMT, info, stack, last, false);
 }
 
-GMT_LOCAL void grd_SBAZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SBAZ (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SBAZ 2 1 Spherical back-azimuth from grid nodes to stack x,y.  */
 /* Azimuth from stack point to grid ones (back azimuth) */
 {
-	grd_AZ_sub (GMT, info, stack, last, true);
+	grdmath_AZ_sub (GMT, info, stack, last, true);
 }
 
-GMT_LOCAL void grd_SEC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SEC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SEC 1 1 sec (A) (A in radians).  */
 {
 	uint64_t node;
@@ -4625,7 +4625,7 @@ GMT_LOCAL void grd_SEC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : (1.0f / cosf (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_SECD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SECD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SECD 1 1 sec (A) (A in degrees).  */
 {
 	uint64_t node;
@@ -4637,7 +4637,7 @@ GMT_LOCAL void grd_SECD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 		stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : 1.0 / cosd (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_SECH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SECH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SECH 1 1 sech (A).  */
 {
 	uint64_t node;
@@ -4648,7 +4648,7 @@ GMT_LOCAL void grd_SECH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : 1.0f/coshf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_SIGN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SIGN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SIGN 1 1 sign (+1 or -1) of A.  */
 {
 	uint64_t node;
@@ -4661,7 +4661,7 @@ GMT_LOCAL void grd_SIGN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 		stack[last]->G->data[node] = (stack[last]->constant) ? a : copysignf (1.0f, stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_SIN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SIN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SIN 1 1 sin (A) (A in radians).  */
 {
 	uint64_t node;
@@ -4673,7 +4673,7 @@ GMT_LOCAL void grd_SIN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 		stack[last]->G->data[node] = (stack[last]->constant) ? a : sinf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_SINC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SINC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SINC 1 1 sinc (A) (sin (pi*A)/(pi*A)).  */
 {
 	uint64_t node;
@@ -4684,7 +4684,7 @@ GMT_LOCAL void grd_SINC (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 		stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : gmt_sinc (GMT, stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_SIND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SIND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SIND 1 1 sin (A) (A in degrees).  */
 {
 	uint64_t node;
@@ -4695,7 +4695,7 @@ GMT_LOCAL void grd_SIND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : sind (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_SINH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SINH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SINH 1 1 sinh (A).  */
 {
 	uint64_t node;
@@ -4706,7 +4706,7 @@ GMT_LOCAL void grd_SINH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : sinhf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_SKEW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SKEW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SKEW 1 1 Skewness of A.  */
 {
 	uint64_t node, n = 0;
@@ -4742,7 +4742,7 @@ GMT_LOCAL void grd_SKEW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = f_skew;
 }
 
-GMT_LOCAL void grd_SQR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SQR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SQR 1 1 A^2.  */
 {
 	uint64_t node;
@@ -4753,7 +4753,7 @@ GMT_LOCAL void grd_SQR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : stack[last]->G->data[node] * stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_SQRT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SQRT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SQRT 1 1 sqrt (A).  */
 {
 	uint64_t node;
@@ -4764,7 +4764,7 @@ GMT_LOCAL void grd_SQRT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : sqrtf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_STD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_STD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: STD 1 1 Standard deviation of A.  */
 {
 	uint64_t node;
@@ -4789,7 +4789,7 @@ GMT_LOCAL void grd_STD (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = std;
 }
 
-GMT_LOCAL void grd_STDW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_STDW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: STDW 2 1 Weighted standard deviation of A for weights in B.  */
 {
 	uint64_t node;
@@ -4805,7 +4805,7 @@ GMT_LOCAL void grd_STDW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[prev]->G->data[node] = std;
 }
 
-GMT_LOCAL void grd_STEP (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_STEP (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: STEP 1 1 Heaviside step function: H(A).  */
 {
 	uint64_t node;
@@ -4822,7 +4822,7 @@ GMT_LOCAL void grd_STEP (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_STEPX (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_STEPX (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: STEPX 1 1 Heaviside step function in x: H(x-A).  */
 {
 	uint64_t node, row, col;
@@ -4838,7 +4838,7 @@ GMT_LOCAL void grd_STEPX (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_STEPY (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_STEPY (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: STEPY 1 1 Heaviside step function in y: H(y-A).  */
 {
 	uint64_t node, row, col;
@@ -4854,7 +4854,7 @@ GMT_LOCAL void grd_STEPY (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_SUB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SUB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SUB 2 1 A - B.  */
 {
 	uint64_t node;
@@ -4870,7 +4870,7 @@ GMT_LOCAL void grd_SUB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_SUM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_SUM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: SUM 1 1 Sum of all values in A.  */
 {
 	uint64_t node, n_used = 0;
@@ -4889,7 +4889,7 @@ GMT_LOCAL void grd_SUM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)sum;
 }
 
-GMT_LOCAL void grd_TAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_TAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: TAN 1 1 tan (A) (A in radians).  */
 {
 	uint64_t node;
@@ -4900,7 +4900,7 @@ GMT_LOCAL void grd_TAN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : tanf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_TAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_TAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: TAND 1 1 tan (A) (A in degrees).  */
 {
 	uint64_t node;
@@ -4911,7 +4911,7 @@ GMT_LOCAL void grd_TAND (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : tand (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_TANH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_TANH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: TANH 1 1 tanh (A).  */
 {
 	uint64_t node;
@@ -4922,7 +4922,7 @@ GMT_LOCAL void grd_TANH (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : tanhf (stack[last]->G->data[node]);
 }
 
-GMT_LOCAL void grd_TAPER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_TAPER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: TAPER 2 1 Unit weights cosine-tapered to zero within A and B of x and y grid margins.  */
 {
 	uint64_t node;
@@ -4976,7 +4976,7 @@ GMT_LOCAL void grd_TAPER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	gmt_M_free (GMT, w_x);
 }
 
-GMT_LOCAL void grd_TN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_TN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: TN 2 1 Chebyshev polynomial Tn(-1<t<+1,n), with t = A, and n = B.  */
 {
 	uint64_t node;
@@ -4992,7 +4992,7 @@ GMT_LOCAL void grd_TN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	}
 }
 
-GMT_LOCAL void grd_TCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_TCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: TCRIT 2 1 Student's t-distribution critical value for alpha = A and nu = B.  */
 {
 	uint64_t node;
@@ -5025,7 +5025,7 @@ GMT_LOCAL void grd_TCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_TCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_TCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: TCDF 2 1 Student's t cumulative distribution function for t = A, and nu = B.  */
 {
 	uint64_t node, b;
@@ -5044,7 +5044,7 @@ GMT_LOCAL void grd_TCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_TPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_TPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: TPDF 2 1 Student's t probability density function for t = A and nu = B.  */
 {
 	uint64_t node, b;
@@ -5063,7 +5063,7 @@ GMT_LOCAL void grd_TPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_TRIM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_TRIM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: TRIM 3 1 Alpha-trimming for %%-left = A, %%-right = B, and grid = C.  */
 {
 	/* Determine cumulative distribution and find left and right tail z cutoffs,
@@ -5113,7 +5113,7 @@ GMT_LOCAL void grd_TRIM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_UPPER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_UPPER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: UPPER 1 1 The highest (maximum) value of A.  */
 {
 	uint64_t node;
@@ -5134,7 +5134,7 @@ GMT_LOCAL void grd_UPPER (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) if (!gmt_M_is_fnan (stack[last]->G->data[node])) stack[last]->G->data[node] = high;
 }
 
-GMT_LOCAL float grd_wvar_sub (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GMT_GRID *G, struct GMT_GRID *W, bool use_grid, double weight) {
+GMT_LOCAL float grdmath_wvar_sub (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GMT_GRID *G, struct GMT_GRID *W, bool use_grid, double weight) {
 	/* Use West (1979) algorithm to compute mean and corrected sum of squares.
 	 * https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance */
 	uint64_t node, n = 0;
@@ -5160,7 +5160,7 @@ GMT_LOCAL float grd_wvar_sub (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, s
 	return (n <= 1 || sumw == 0.0) ? GMT->session.f_NaN : (float) ((n * M2) / (sumw * (n - 1.0)));
 }
 
-GMT_LOCAL void grd_VAR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_VAR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: VAR 1 1 Variance of A.  */
 {
 	uint64_t node;
@@ -5172,7 +5172,7 @@ GMT_LOCAL void grd_VAR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	else if (gmt_M_is_geographic (GMT, GMT_IN)) {	/* Must use spherical weights */
 		struct GMT_GRID *W = gmt_duplicate_grid (GMT, stack[last]->G, GMT_DUPLICATE_ALLOC);
 		gmt_get_cellarea (GMT, W);
-		var = grd_wvar_sub (GMT, info, stack[last]->G, W, true, 0.0);
+		var = grdmath_wvar_sub (GMT, info, stack[last]->G, W, true, 0.0);
 		gmt_free_grid (GMT, &W, true);
 	}
 	else {	/* Use Welford (1962) algorithm to compute mean and corrected sum of squares */
@@ -5191,7 +5191,7 @@ GMT_LOCAL void grd_VAR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = var;
 }
 
-GMT_LOCAL void grd_VARW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_VARW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: VARW 2 1 Weighted variance of A for weights in B.  */
 {
 	uint64_t node;
@@ -5202,11 +5202,11 @@ GMT_LOCAL void grd_VARW (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	if (stack[prev]->constant)	/* Trivial case: variance is undefined  */
 		var = GMT->session.f_NaN;
 	else
-		var = grd_wvar_sub (GMT, info, stack[prev]->G, stack[last]->G, !stack[last]->constant, stack[last]->factor);
+		var = grdmath_wvar_sub (GMT, info, stack[prev]->G, stack[last]->G, !stack[last]->constant, stack[last]->factor);
 	for (node = 0; node < info->size; node++) stack[prev]->G->data[node] = var;
 }
 
-GMT_LOCAL void grd_WCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_WCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: WCDF 3 1 Weibull cumulative distribution function for x = A, scale = B, and shape = C.  */
 {
 	uint64_t node;
@@ -5225,7 +5225,7 @@ GMT_LOCAL void grd_WCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_WCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_WCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: WCRIT 3 1 Weibull distribution critical value for alpha = A, scale = B, and shape = C.  */
 {
 	uint64_t node;
@@ -5244,7 +5244,7 @@ GMT_LOCAL void grd_WCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	}
 }
 
-GMT_LOCAL void grd_WPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_WPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: WPDF 3 1 Weibull probability density function for x = A, scale = B and shape = C.  */
 {
 	uint64_t node;
@@ -5263,7 +5263,7 @@ GMT_LOCAL void grd_WPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	}
 }
 
-GMT_LOCAL void grd_WRAP (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_WRAP (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: WRAP 1 1 wrap (A). (A in radians). */
 /*
 wrap a value in radians onto [-pi,pi]
@@ -5300,7 +5300,7 @@ away from zero instead of to the nearest integer (or other current rounding mode
 	}
 }
 
-GMT_LOCAL void grd_XOR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_XOR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: XOR 2 1 0 if A == NaN and B == NaN, NaN if B == NaN, else A.  */
 {
 	uint64_t node;
@@ -5317,7 +5317,7 @@ GMT_LOCAL void grd_XOR (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct 
 	}
 }
 
-GMT_LOCAL void grd_XYZ2HSV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_XYZ2HSV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: XYZ2HSV 3 3 Convert xyz to hsv, with x = A, y = B and z = C.  */
 {
 	uint64_t node;
@@ -5367,7 +5367,7 @@ GMT_LOCAL void grd_XYZ2HSV (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_XYZ2LAB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_XYZ2LAB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: XYZ2LAB 3 3 Convert xyz to lab, with x = A, y = B and z = C.  */
 {
 	uint64_t node;
@@ -5414,7 +5414,7 @@ GMT_LOCAL void grd_XYZ2LAB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_XYZ2RGB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_XYZ2RGB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: XYZ2RGB 3 3 Convert xyz to rgb, with x = A, y = B and z = C.  */
 {
 	uint64_t node;
@@ -5461,7 +5461,7 @@ GMT_LOCAL void grd_XYZ2RGB (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_Y0 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_Y0 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: Y0 1 1 Bessel function of A (2nd kind, order 0).  */
 {
 	uint64_t node;
@@ -5472,7 +5472,7 @@ GMT_LOCAL void grd_Y0 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : (float)y0 ((double)fabsf (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_Y1 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_Y1 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: Y1 1 1 Bessel function of A (2nd kind, order 1).  */
 {
 	uint64_t node;
@@ -5483,7 +5483,7 @@ GMT_LOCAL void grd_Y1 (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (stack[last]->constant) ? a : (float)y1 ((double)fabsf (stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_YLM_sub (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last, bool ortho)
+GMT_LOCAL void grdmath_YLM_sub (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last, bool ortho)
 {
 	/* Returns geophysical normalization, unless M < 0, then orthonormalized form */
 	int64_t node, row, col;			/* int since VS 2013/OMP 2.0 doesn't allow unsigned index variables */
@@ -5524,19 +5524,19 @@ GMT_LOCAL void grd_YLM_sub (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, str
 	}
 }
 
-GMT_LOCAL void grd_YLM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_YLM (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: YLM 2 2 Re and Im orthonormalized spherical harmonics degree A order B.  */
 {
-	grd_YLM_sub (GMT, info, stack, last, true);
+	grdmath_YLM_sub (GMT, info, stack, last, true);
 }
 
-GMT_LOCAL void grd_YLMg (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_YLMg (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: YLMg 2 2 Cos and Sin normalized spherical harmonics degree A order B (geophysical convention).  */
 {
-	grd_YLM_sub (GMT, info, stack, last, false);
+	grdmath_YLM_sub (GMT, info, stack, last, false);
 }
 
-GMT_LOCAL void grd_YN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_YN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: YN 2 1 Bessel function of A (2nd kind, order B).  */
 {
 	uint64_t node;
@@ -5565,7 +5565,7 @@ GMT_LOCAL void grd_YN (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct G
 	}
 }
 
-GMT_LOCAL void grd_ZCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ZCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ZCRIT 1 1 Normal distribution critical value for alpha = A.  */
 {
 	uint64_t node;
@@ -5575,7 +5575,7 @@ GMT_LOCAL void grd_ZCRIT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struc
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : gmt_zcrit (GMT, stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_ZCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ZCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ZCDF 1 1 Normal cumulative distribution function for z = A.  */
 {
 	uint64_t node;
@@ -5585,7 +5585,7 @@ GMT_LOCAL void grd_ZCDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct
 	for (node = 0; node < info->size; node++) stack[last]->G->data[node] = (float)((stack[last]->constant) ? a : gmt_zdist (GMT, stack[last]->G->data[node]));
 }
 
-GMT_LOCAL void grd_ZPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
+GMT_LOCAL void grdmath_ZPDF (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last)
 /*OPERATOR: ZPDF 1 1 Normal probability density function for z = A.  */
 {
 	uint64_t node;
@@ -5604,228 +5604,228 @@ static void grdmath_init (void (*ops[]) (struct GMT_CTRL *, struct GRDMATH_INFO 
 {
 	/* Operator function	# of operands	# of outputs */
 
-	ops[0] = grd_ABS;	n_args[0] = 1;	n_out[0] = 1;
-	ops[1] = grd_ACOS;	n_args[1] = 1;	n_out[1] = 1;
-	ops[2] = grd_ACOSH;	n_args[2] = 1;	n_out[2] = 1;
-	ops[3] = grd_ACOT;	n_args[3] = 1;	n_out[3] = 1;
-	ops[4] = grd_ACOTH;	n_args[4] = 1;	n_out[4] = 1;
-	ops[5] = grd_ACSC;	n_args[5] = 1;	n_out[5] = 1;
-	ops[6] = grd_ACSCH;	n_args[6] = 1;	n_out[6] = 1;
-	ops[7] = grd_ADD;	n_args[7] = 2;	n_out[7] = 1;
-	ops[8] = grd_AND;	n_args[8] = 2;	n_out[8] = 1;
-	ops[9] = grd_ARC;	n_args[9] = 2;	n_out[9] = 1;
-	ops[10] = grd_AREA;	n_args[10] = 0;	n_out[10] = 1;
-	ops[11] = grd_ASEC;	n_args[11] = 1;	n_out[11] = 1;
-	ops[12] = grd_ASECH;	n_args[12] = 1;	n_out[12] = 1;
-	ops[13] = grd_ASIN;	n_args[13] = 1;	n_out[13] = 1;
-	ops[14] = grd_ASINH;	n_args[14] = 1;	n_out[14] = 1;
-	ops[15] = grd_ATAN;	n_args[15] = 1;	n_out[15] = 1;
-	ops[16] = grd_ATAN2;	n_args[16] = 2;	n_out[16] = 1;
-	ops[17] = grd_ATANH;	n_args[17] = 1;	n_out[17] = 1;
-	ops[18] = grd_BCDF;	n_args[18] = 3;	n_out[18] = 1;
-	ops[19] = grd_BPDF;	n_args[19] = 3;	n_out[19] = 1;
-	ops[20] = grd_BEI;	n_args[20] = 1;	n_out[20] = 1;
-	ops[21] = grd_BER;	n_args[21] = 1;	n_out[21] = 1;
-	ops[22] = grd_BITAND;	n_args[22] = 2;	n_out[22] = 1;
-	ops[23] = grd_BITLEFT;	n_args[23] = 2;	n_out[23] = 1;
-	ops[24] = grd_BITNOT;	n_args[24] = 1;	n_out[24] = 1;
-	ops[25] = grd_BITOR;	n_args[25] = 2;	n_out[25] = 1;
-	ops[26] = grd_BITRIGHT;	n_args[26] = 2;	n_out[26] = 1;
-	ops[27] = grd_BITTEST;	n_args[27] = 2;	n_out[27] = 1;
-	ops[28] = grd_BITXOR;	n_args[28] = 2;	n_out[28] = 1;
-	ops[29] = grd_CAZ;	n_args[29] = 2;	n_out[29] = 1;
-	ops[30] = grd_CBAZ;	n_args[30] = 2;	n_out[30] = 1;
-	ops[31] = grd_CDIST;	n_args[31] = 2;	n_out[31] = 1;
-	ops[32] = grd_CDIST2;	n_args[32] = 2;	n_out[32] = 1;
-	ops[33] = grd_CEIL;	n_args[33] = 1;	n_out[33] = 1;
-	ops[34] = grd_CHI2CRIT;	n_args[34] = 2;	n_out[34] = 1;
-	ops[35] = grd_CHI2CDF;	n_args[35] = 2;	n_out[35] = 1;
-	ops[36] = grd_CHI2PDF;	n_args[36] = 2;	n_out[36] = 1;
-	ops[37] = grd_COMB;	n_args[37] = 2;	n_out[37] = 1;
-	ops[38] = grd_CORRCOEFF;	n_args[38] = 2;	n_out[38] = 1;
-	ops[39] = grd_COS;	n_args[39] = 1;	n_out[39] = 1;
-	ops[40] = grd_COSD;	n_args[40] = 1;	n_out[40] = 1;
-	ops[41] = grd_COSH;	n_args[41] = 1;	n_out[41] = 1;
-	ops[42] = grd_COT;	n_args[42] = 1;	n_out[42] = 1;
-	ops[43] = grd_COTD;	n_args[43] = 1;	n_out[43] = 1;
-	ops[44] = grd_COTH;	n_args[44] = 1;	n_out[44] = 1;
-	ops[45] = grd_PCDF;	n_args[45] = 2;	n_out[45] = 1;
-	ops[46] = grd_PPDF;	n_args[46] = 2;	n_out[46] = 1;
-	ops[47] = grd_CSC;	n_args[47] = 1;	n_out[47] = 1;
-	ops[48] = grd_CSCD;	n_args[48] = 1;	n_out[48] = 1;
-	ops[49] = grd_CSCH;	n_args[49] = 1;	n_out[49] = 1;
-	ops[50] = grd_CURV;	n_args[50] = 1;	n_out[50] = 1;
-	ops[51] = grd_D2DX2;	n_args[51] = 1;	n_out[51] = 1;
-	ops[52] = grd_D2DY2;	n_args[52] = 1;	n_out[52] = 1;
-	ops[53] = grd_D2DXY;	n_args[53] = 1;	n_out[53] = 1;
-	ops[54] = grd_D2R;	n_args[54] = 1;	n_out[54] = 1;
-	ops[55] = grd_DDX;	n_args[55] = 1;	n_out[55] = 1;
-	ops[56] = grd_DDY;	n_args[56] = 1;	n_out[56] = 1;
-	ops[57] = grd_DEG2KM;	n_args[57] = 1;	n_out[57] = 1;
-	ops[58] = grd_DENAN;	n_args[58] = 2;	n_out[58] = 1;
-	ops[59] = grd_DILOG;	n_args[59] = 1;	n_out[59] = 1;
-	ops[60] = grd_DIV;	n_args[60] = 2;	n_out[60] = 1;
-	ops[61] = grd_DUP;	n_args[61] = 1;	n_out[61] = 2;
-	ops[62] = grd_ECDF;	n_args[62] = 2;	n_out[62] = 1;
-	ops[63] = grd_ECRIT;	n_args[63] = 2;	n_out[63] = 1;
-	ops[64] = grd_EPDF;	n_args[64] = 2;	n_out[64] = 1;
-	ops[65] = grd_ERF;	n_args[65] = 1;	n_out[65] = 1;
-	ops[66] = grd_ERFC;	n_args[66] = 1;	n_out[66] = 1;
-	ops[67] = grd_EQ;	n_args[67] = 2;	n_out[67] = 1;
-	ops[68] = grd_ERFINV;	n_args[68] = 1;	n_out[68] = 1;
-	ops[69] = grd_EXCH;	n_args[69] = 2;	n_out[69] = 2;
-	ops[70] = grd_EXP;	n_args[70] = 1;	n_out[70] = 1;
-	ops[71] = grd_FACT;	n_args[71] = 1;	n_out[71] = 1;
-	ops[72] = grd_EXTREMA;	n_args[72] = 1;	n_out[72] = 1;
-	ops[73] = grd_FCRIT;	n_args[73] = 3;	n_out[73] = 1;
-	ops[74] = grd_FCDF;	n_args[74] = 3;	n_out[74] = 1;
-	ops[75] = grd_FLIPLR;	n_args[75] = 1;	n_out[75] = 1;
-	ops[76] = grd_FLIPUD;	n_args[76] = 1;	n_out[76] = 1;
-	ops[77] = grd_FLOOR;	n_args[77] = 1;	n_out[77] = 1;
-	ops[78] = grd_FMOD;	n_args[78] = 2;	n_out[78] = 1;
-	ops[79] = grd_FPDF;	n_args[79] = 3;	n_out[79] = 1;
-	ops[80] = grd_GE;	n_args[80] = 2;	n_out[80] = 1;
-	ops[81] = grd_GT;	n_args[81] = 2;	n_out[81] = 1;
-	ops[82] = grd_HYPOT;	n_args[82] = 2;	n_out[82] = 1;
-	ops[83] = grd_I0;	n_args[83] = 1;	n_out[83] = 1;
-	ops[84] = grd_I1;	n_args[84] = 1;	n_out[84] = 1;
-	ops[85] = grd_IFELSE;	n_args[85] = 3;	n_out[85] = 1;
-	ops[86] = grd_IN;	n_args[86] = 2;	n_out[86] = 1;
-	ops[87] = grd_INRANGE;	n_args[87] = 3;	n_out[87] = 1;
-	ops[88] = grd_INSIDE;	n_args[88] = 1;	n_out[88] = 1;
-	ops[89] = grd_INV;	n_args[89] = 1;	n_out[89] = 1;
-	ops[90] = grd_ISFINITE;	n_args[90] = 1;	n_out[90] = 1;
-	ops[91] = grd_ISNAN;	n_args[91] = 1;	n_out[91] = 1;
-	ops[92] = grd_J0;	n_args[92] = 1;	n_out[92] = 1;
-	ops[93] = grd_J1;	n_args[93] = 1;	n_out[93] = 1;
-	ops[94] = grd_JN;	n_args[94] = 2;	n_out[94] = 1;
-	ops[95] = grd_K0;	n_args[95] = 1;	n_out[95] = 1;
-	ops[96] = grd_K1;	n_args[96] = 1;	n_out[96] = 1;
-	ops[97] = grd_KEI;	n_args[97] = 1;	n_out[97] = 1;
-	ops[98] = grd_KER;	n_args[98] = 1;	n_out[98] = 1;
-	ops[99] = grd_KM2DEG;	n_args[99] = 1;	n_out[99] = 1;
-	ops[100] = grd_KN;	n_args[100] = 2;	n_out[100] = 1;
-	ops[101] = grd_KURT;	n_args[101] = 1;	n_out[101] = 1;
-	ops[102] = grd_LCDF;	n_args[102] = 1;	n_out[102] = 1;
-	ops[103] = grd_LCRIT;	n_args[103] = 1;	n_out[103] = 1;
-	ops[104] = grd_LDIST;	n_args[104] = 1;	n_out[104] = 1;
-	ops[105] = grd_LDISTG;	n_args[105] = 0;	n_out[105] = 1;
-	ops[106] = grd_LDIST2;	n_args[106] = 2;	n_out[106] = 1;
-	ops[107] = grd_LE;	n_args[107] = 2;	n_out[107] = 1;
-	ops[108] = grd_LOG;	n_args[108] = 1;	n_out[108] = 1;
-	ops[109] = grd_LOG10;	n_args[109] = 1;	n_out[109] = 1;
-	ops[110] = grd_LOG1P;	n_args[110] = 1;	n_out[110] = 1;
-	ops[111] = grd_LOG2;	n_args[111] = 1;	n_out[111] = 1;
-	ops[112] = grd_LMSSCL;	n_args[112] = 1;	n_out[112] = 1;
-	ops[113] = grd_LMSSCLW;	n_args[113] = 1;	n_out[113] = 1;
-	ops[114] = grd_LOWER;	n_args[114] = 1;	n_out[114] = 1;
-	ops[115] = grd_LPDF;	n_args[115] = 1;	n_out[115] = 1;
-	ops[116] = grd_LRAND;	n_args[116] = 2;	n_out[116] = 1;
-	ops[117] = grd_LT;	n_args[117] = 2;	n_out[117] = 1;
-	ops[118] = grd_MAD;	n_args[118] = 1;	n_out[118] = 1;
-	ops[119] = grd_MADW;	n_args[119] = 2;	n_out[119] = 1;
-	ops[120] = grd_MAX;	n_args[120] = 2;	n_out[120] = 1;
-	ops[121] = grd_MEAN;	n_args[121] = 1;	n_out[121] = 1;
-	ops[122] = grd_MEANW;	n_args[122] = 2;	n_out[122] = 1;
-	ops[123] = grd_MEDIAN;	n_args[123] = 1;	n_out[123] = 1;
-	ops[124] = grd_MEDIANW;	n_args[124] = 2;	n_out[124] = 1;
-	ops[125] = grd_MIN;	n_args[125] = 2;	n_out[125] = 1;
-	ops[126] = grd_MOD;	n_args[126] = 2;	n_out[126] = 1;
-	ops[127] = grd_MODE;	n_args[127] = 1;	n_out[127] = 1;
-	ops[128] = grd_MODEW;	n_args[128] = 2;	n_out[128] = 1;
-	ops[129] = grd_MUL;	n_args[129] = 2;	n_out[129] = 1;
-	ops[130] = grd_NAN;	n_args[130] = 2;	n_out[130] = 1;
-	ops[131] = grd_NEG;	n_args[131] = 1;	n_out[131] = 1;
-	ops[132] = grd_NEQ;	n_args[132] = 2;	n_out[132] = 1;
-	ops[133] = grd_NORM;	n_args[133] = 1;	n_out[133] = 1;
-	ops[134] = grd_NOT;	n_args[134] = 1;	n_out[134] = 1;
-	ops[135] = grd_NRAND;	n_args[135] = 2;	n_out[135] = 1;
-	ops[136] = grd_OR;	n_args[136] = 2;	n_out[136] = 1;
-	ops[137] = grd_PDIST;	n_args[137] = 1;	n_out[137] = 1;
-	ops[138] = grd_PDIST2;	n_args[138] = 2;	n_out[138] = 1;
-	ops[139] = grd_PERM;	n_args[139] = 2;	n_out[139] = 1;
-	ops[140] = grd_POP;	n_args[140] = 1;	n_out[140] = 0;
-	ops[141] = grd_PLM;	n_args[141] = 3;	n_out[141] = 1;
-	ops[142] = grd_PLMg;	n_args[142] = 3;	n_out[142] = 1;
-	ops[143] = grd_POINT;	n_args[143] = 1;	n_out[143] = 2;
-	ops[144] = grd_POW;	n_args[144] = 2;	n_out[144] = 1;
-	ops[145] = grd_PQUANT;	n_args[145] = 2;	n_out[145] = 1;
-	ops[146] = grd_PQUANTW;	n_args[146] = 3;	n_out[146] = 1;
-	ops[147] = grd_PSI;	n_args[147] = 1;	n_out[147] = 1;
-	ops[148] = grd_PV;	n_args[148] = 3;	n_out[148] = 1;
-	ops[149] = grd_QV;	n_args[149] = 3;	n_out[149] = 1;
-	ops[150] = grd_R2;	n_args[150] = 2;	n_out[150] = 1;
-	ops[151] = grd_R2D;	n_args[151] = 1;	n_out[151] = 1;
-	ops[152] = grd_RAND;	n_args[152] = 2;	n_out[152] = 1;
-	ops[153] = grd_RCDF;	n_args[153] = 1;	n_out[153] = 1;
-	ops[154] = grd_RCRIT;	n_args[154] = 1;	n_out[154] = 1;
-	ops[155] = grd_RINT;	n_args[155] = 1;	n_out[155] = 1;
-	ops[156] = grd_RMS;	n_args[156] = 1;	n_out[156] = 1;
-	ops[157] = grd_RMSW;	n_args[157] = 2;	n_out[157] = 1;
-	ops[158] = grd_RPDF;	n_args[158] = 1;	n_out[158] = 1;
-	ops[159] = grd_ROLL;	n_args[159] = 2;	n_out[159] = 0;
-	ops[160] = grd_ROTX;	n_args[160] = 2;	n_out[160] = 1;
-	ops[161] = grd_ROTY;	n_args[161] = 2;	n_out[161] = 1;
-	ops[162] = grd_SDIST;	n_args[162] = 2;	n_out[162] = 1;
-	ops[163] = grd_SDIST2;	n_args[163] = 2;	n_out[163] = 1;
-	ops[164] = grd_SAZ;	n_args[164] = 2;	n_out[164] = 1;
-	ops[165] = grd_SBAZ;	n_args[165] = 2;	n_out[165] = 1;
-	ops[166] = grd_SEC;	n_args[166] = 1;	n_out[166] = 1;
-	ops[167] = grd_SECD;	n_args[167] = 1;	n_out[167] = 1;
-	ops[168] = grd_SECH;	n_args[168] = 1;	n_out[168] = 1;
-	ops[169] = grd_SIGN;	n_args[169] = 1;	n_out[169] = 1;
-	ops[170] = grd_SIN;	n_args[170] = 1;	n_out[170] = 1;
-	ops[171] = grd_SINC;	n_args[171] = 1;	n_out[171] = 1;
-	ops[172] = grd_SIND;	n_args[172] = 1;	n_out[172] = 1;
-	ops[173] = grd_SINH;	n_args[173] = 1;	n_out[173] = 1;
-	ops[174] = grd_SKEW;	n_args[174] = 1;	n_out[174] = 1;
-	ops[175] = grd_SQR;	n_args[175] = 1;	n_out[175] = 1;
-	ops[176] = grd_SQRT;	n_args[176] = 1;	n_out[176] = 1;
-	ops[177] = grd_STD;	n_args[177] = 1;	n_out[177] = 1;
-	ops[178] = grd_STDW;	n_args[178] = 2;	n_out[178] = 1;
-	ops[179] = grd_STEP;	n_args[179] = 1;	n_out[179] = 1;
-	ops[180] = grd_STEPX;	n_args[180] = 1;	n_out[180] = 1;
-	ops[181] = grd_STEPY;	n_args[181] = 1;	n_out[181] = 1;
-	ops[182] = grd_SUB;	n_args[182] = 2;	n_out[182] = 1;
-	ops[183] = grd_SUM;	n_args[183] = 1;	n_out[183] = 1;
-	ops[184] = grd_TAN;	n_args[184] = 1;	n_out[184] = 1;
-	ops[185] = grd_TAND;	n_args[185] = 1;	n_out[185] = 1;
-	ops[186] = grd_TANH;	n_args[186] = 1;	n_out[186] = 1;
-	ops[187] = grd_TAPER;	n_args[187] = 2;	n_out[187] = 1;
-	ops[188] = grd_TN;	n_args[188] = 2;	n_out[188] = 1;
-	ops[189] = grd_TCRIT;	n_args[189] = 2;	n_out[189] = 1;
-	ops[190] = grd_TCDF;	n_args[190] = 2;	n_out[190] = 1;
-	ops[191] = grd_TPDF;	n_args[191] = 2;	n_out[191] = 1;
-	ops[192] = grd_TRIM;	n_args[192] = 3;	n_out[192] = 1;
-	ops[193] = grd_UPPER;	n_args[193] = 1;	n_out[193] = 1;
-	ops[194] = grd_VAR;	n_args[194] = 1;	n_out[194] = 1;
-	ops[195] = grd_VARW;	n_args[195] = 2;	n_out[195] = 1;
-	ops[196] = grd_WCDF;	n_args[196] = 3;	n_out[196] = 1;
-	ops[197] = grd_WCRIT;	n_args[197] = 3;	n_out[197] = 1;
-	ops[198] = grd_WPDF;	n_args[198] = 3;	n_out[198] = 1;
-	ops[199] = grd_WRAP;	n_args[199] = 1;	n_out[199] = 1;
-	ops[200] = grd_XOR;	n_args[200] = 2;	n_out[200] = 1;
-	ops[201] = grd_Y0;	n_args[201] = 1;	n_out[201] = 1;
-	ops[202] = grd_Y1;	n_args[202] = 1;	n_out[202] = 1;
-	ops[203] = grd_YLM;	n_args[203] = 2;	n_out[203] = 2;
-	ops[204] = grd_YLMg;	n_args[204] = 2;	n_out[204] = 2;
-	ops[205] = grd_YN;	n_args[205] = 2;	n_out[205] = 1;
-	ops[206] = grd_ZCRIT;	n_args[206] = 1;	n_out[206] = 1;
-	ops[207] = grd_ZCDF;	n_args[207] = 1;	n_out[207] = 1;
-	ops[208] = grd_ZPDF;	n_args[208] = 1;	n_out[208] = 1;
-	ops[209] = grd_HSV2LAB;	n_args[209] = 3;	n_out[209] = 3;
-	ops[210] = grd_HSV2RGB;	n_args[210] = 3;	n_out[210] = 3;
-	ops[211] = grd_HSV2XYZ;	n_args[211] = 3;	n_out[211] = 3;
-	ops[212] = grd_LAB2HSV;	n_args[212] = 3;	n_out[212] = 3;
-	ops[213] = grd_LAB2RGB;	n_args[213] = 3;	n_out[213] = 3;
-	ops[214] = grd_LAB2XYZ;	n_args[214] = 3;	n_out[214] = 3;
-	ops[215] = grd_RGB2HSV;	n_args[215] = 3;	n_out[215] = 3;
-	ops[216] = grd_RGB2LAB;	n_args[216] = 3;	n_out[216] = 3;
-	ops[217] = grd_RGB2XYZ;	n_args[217] = 3;	n_out[217] = 3;
-	ops[218] = grd_XYZ2HSV;	n_args[218] = 3;	n_out[218] = 3;
-	ops[219] = grd_XYZ2LAB;	n_args[219] = 3;	n_out[219] = 3;
-	ops[220] = grd_XYZ2RGB;	n_args[220] = 3;	n_out[220] = 3;
-	ops[221] = grd_DOT;	n_args[221] = 2;	n_out[221] = 1;
+	ops[0] = grdmath_ABS;	n_args[0] = 1;	n_out[0] = 1;
+	ops[1] = grdmath_ACOS;	n_args[1] = 1;	n_out[1] = 1;
+	ops[2] = grdmath_ACOSH;	n_args[2] = 1;	n_out[2] = 1;
+	ops[3] = grdmath_ACOT;	n_args[3] = 1;	n_out[3] = 1;
+	ops[4] = grdmath_ACOTH;	n_args[4] = 1;	n_out[4] = 1;
+	ops[5] = grdmath_ACSC;	n_args[5] = 1;	n_out[5] = 1;
+	ops[6] = grdmath_ACSCH;	n_args[6] = 1;	n_out[6] = 1;
+	ops[7] = grdmath_ADD;	n_args[7] = 2;	n_out[7] = 1;
+	ops[8] = grdmath_AND;	n_args[8] = 2;	n_out[8] = 1;
+	ops[9] = grdmath_ARC;	n_args[9] = 2;	n_out[9] = 1;
+	ops[10] = grdmath_AREA;	n_args[10] = 0;	n_out[10] = 1;
+	ops[11] = grdmath_ASEC;	n_args[11] = 1;	n_out[11] = 1;
+	ops[12] = grdmath_ASECH;	n_args[12] = 1;	n_out[12] = 1;
+	ops[13] = grdmath_ASIN;	n_args[13] = 1;	n_out[13] = 1;
+	ops[14] = grdmath_ASINH;	n_args[14] = 1;	n_out[14] = 1;
+	ops[15] = grdmath_ATAN;	n_args[15] = 1;	n_out[15] = 1;
+	ops[16] = grdmath_ATAN2;	n_args[16] = 2;	n_out[16] = 1;
+	ops[17] = grdmath_ATANH;	n_args[17] = 1;	n_out[17] = 1;
+	ops[18] = grdmath_BCDF;	n_args[18] = 3;	n_out[18] = 1;
+	ops[19] = grdmath_BPDF;	n_args[19] = 3;	n_out[19] = 1;
+	ops[20] = grdmath_BEI;	n_args[20] = 1;	n_out[20] = 1;
+	ops[21] = grdmath_BER;	n_args[21] = 1;	n_out[21] = 1;
+	ops[22] = grdmath_BITAND;	n_args[22] = 2;	n_out[22] = 1;
+	ops[23] = grdmath_BITLEFT;	n_args[23] = 2;	n_out[23] = 1;
+	ops[24] = grdmath_BITNOT;	n_args[24] = 1;	n_out[24] = 1;
+	ops[25] = grdmath_BITOR;	n_args[25] = 2;	n_out[25] = 1;
+	ops[26] = grdmath_BITRIGHT;	n_args[26] = 2;	n_out[26] = 1;
+	ops[27] = grdmath_BITTEST;	n_args[27] = 2;	n_out[27] = 1;
+	ops[28] = grdmath_BITXOR;	n_args[28] = 2;	n_out[28] = 1;
+	ops[29] = grdmath_CAZ;	n_args[29] = 2;	n_out[29] = 1;
+	ops[30] = grdmath_CBAZ;	n_args[30] = 2;	n_out[30] = 1;
+	ops[31] = grdmath_CDIST;	n_args[31] = 2;	n_out[31] = 1;
+	ops[32] = grdmath_CDIST2;	n_args[32] = 2;	n_out[32] = 1;
+	ops[33] = grdmath_CEIL;	n_args[33] = 1;	n_out[33] = 1;
+	ops[34] = grdmath_CHI2CRIT;	n_args[34] = 2;	n_out[34] = 1;
+	ops[35] = grdmath_CHI2CDF;	n_args[35] = 2;	n_out[35] = 1;
+	ops[36] = grdmath_CHI2PDF;	n_args[36] = 2;	n_out[36] = 1;
+	ops[37] = grdmath_COMB;	n_args[37] = 2;	n_out[37] = 1;
+	ops[38] = grdmath_CORRCOEFF;	n_args[38] = 2;	n_out[38] = 1;
+	ops[39] = grdmath_COS;	n_args[39] = 1;	n_out[39] = 1;
+	ops[40] = grdmath_COSD;	n_args[40] = 1;	n_out[40] = 1;
+	ops[41] = grdmath_COSH;	n_args[41] = 1;	n_out[41] = 1;
+	ops[42] = grdmath_COT;	n_args[42] = 1;	n_out[42] = 1;
+	ops[43] = grdmath_COTD;	n_args[43] = 1;	n_out[43] = 1;
+	ops[44] = grdmath_COTH;	n_args[44] = 1;	n_out[44] = 1;
+	ops[45] = grdmath_PCDF;	n_args[45] = 2;	n_out[45] = 1;
+	ops[46] = grdmath_PPDF;	n_args[46] = 2;	n_out[46] = 1;
+	ops[47] = grdmath_CSC;	n_args[47] = 1;	n_out[47] = 1;
+	ops[48] = grdmath_CSCD;	n_args[48] = 1;	n_out[48] = 1;
+	ops[49] = grdmath_CSCH;	n_args[49] = 1;	n_out[49] = 1;
+	ops[50] = grdmath_CURV;	n_args[50] = 1;	n_out[50] = 1;
+	ops[51] = grdmath_D2DX2;	n_args[51] = 1;	n_out[51] = 1;
+	ops[52] = grdmath_D2DY2;	n_args[52] = 1;	n_out[52] = 1;
+	ops[53] = grdmath_D2DXY;	n_args[53] = 1;	n_out[53] = 1;
+	ops[54] = grdmath_D2R;	n_args[54] = 1;	n_out[54] = 1;
+	ops[55] = grdmath_DDX;	n_args[55] = 1;	n_out[55] = 1;
+	ops[56] = grdmath_DDY;	n_args[56] = 1;	n_out[56] = 1;
+	ops[57] = grdmath_DEG2KM;	n_args[57] = 1;	n_out[57] = 1;
+	ops[58] = grdmath_DENAN;	n_args[58] = 2;	n_out[58] = 1;
+	ops[59] = grdmath_DILOG;	n_args[59] = 1;	n_out[59] = 1;
+	ops[60] = grdmath_DIV;	n_args[60] = 2;	n_out[60] = 1;
+	ops[61] = grdmath_DUP;	n_args[61] = 1;	n_out[61] = 2;
+	ops[62] = grdmath_ECDF;	n_args[62] = 2;	n_out[62] = 1;
+	ops[63] = grdmath_ECRIT;	n_args[63] = 2;	n_out[63] = 1;
+	ops[64] = grdmath_EPDF;	n_args[64] = 2;	n_out[64] = 1;
+	ops[65] = grdmath_ERF;	n_args[65] = 1;	n_out[65] = 1;
+	ops[66] = grdmath_ERFC;	n_args[66] = 1;	n_out[66] = 1;
+	ops[67] = grdmath_EQ;	n_args[67] = 2;	n_out[67] = 1;
+	ops[68] = grdmath_ERFINV;	n_args[68] = 1;	n_out[68] = 1;
+	ops[69] = grdmath_EXCH;	n_args[69] = 2;	n_out[69] = 2;
+	ops[70] = grdmath_EXP;	n_args[70] = 1;	n_out[70] = 1;
+	ops[71] = grdmath_FACT;	n_args[71] = 1;	n_out[71] = 1;
+	ops[72] = grdmath_EXTREMA;	n_args[72] = 1;	n_out[72] = 1;
+	ops[73] = grdmath_FCRIT;	n_args[73] = 3;	n_out[73] = 1;
+	ops[74] = grdmath_FCDF;	n_args[74] = 3;	n_out[74] = 1;
+	ops[75] = grdmath_FLIPLR;	n_args[75] = 1;	n_out[75] = 1;
+	ops[76] = grdmath_FLIPUD;	n_args[76] = 1;	n_out[76] = 1;
+	ops[77] = grdmath_FLOOR;	n_args[77] = 1;	n_out[77] = 1;
+	ops[78] = grdmath_FMOD;	n_args[78] = 2;	n_out[78] = 1;
+	ops[79] = grdmath_FPDF;	n_args[79] = 3;	n_out[79] = 1;
+	ops[80] = grdmath_GE;	n_args[80] = 2;	n_out[80] = 1;
+	ops[81] = grdmath_GT;	n_args[81] = 2;	n_out[81] = 1;
+	ops[82] = grdmath_HYPOT;	n_args[82] = 2;	n_out[82] = 1;
+	ops[83] = grdmath_I0;	n_args[83] = 1;	n_out[83] = 1;
+	ops[84] = grdmath_I1;	n_args[84] = 1;	n_out[84] = 1;
+	ops[85] = grdmath_IFELSE;	n_args[85] = 3;	n_out[85] = 1;
+	ops[86] = grdmath_IN;	n_args[86] = 2;	n_out[86] = 1;
+	ops[87] = grdmath_INRANGE;	n_args[87] = 3;	n_out[87] = 1;
+	ops[88] = grdmath_INSIDE;	n_args[88] = 1;	n_out[88] = 1;
+	ops[89] = grdmath_INV;	n_args[89] = 1;	n_out[89] = 1;
+	ops[90] = grdmath_ISFINITE;	n_args[90] = 1;	n_out[90] = 1;
+	ops[91] = grdmath_ISNAN;	n_args[91] = 1;	n_out[91] = 1;
+	ops[92] = grdmath_J0;	n_args[92] = 1;	n_out[92] = 1;
+	ops[93] = grdmath_J1;	n_args[93] = 1;	n_out[93] = 1;
+	ops[94] = grdmath_JN;	n_args[94] = 2;	n_out[94] = 1;
+	ops[95] = grdmath_K0;	n_args[95] = 1;	n_out[95] = 1;
+	ops[96] = grdmath_K1;	n_args[96] = 1;	n_out[96] = 1;
+	ops[97] = grdmath_KEI;	n_args[97] = 1;	n_out[97] = 1;
+	ops[98] = grdmath_KER;	n_args[98] = 1;	n_out[98] = 1;
+	ops[99] = grdmath_KM2DEG;	n_args[99] = 1;	n_out[99] = 1;
+	ops[100] = grdmath_KN;	n_args[100] = 2;	n_out[100] = 1;
+	ops[101] = grdmath_KURT;	n_args[101] = 1;	n_out[101] = 1;
+	ops[102] = grdmath_LCDF;	n_args[102] = 1;	n_out[102] = 1;
+	ops[103] = grdmath_LCRIT;	n_args[103] = 1;	n_out[103] = 1;
+	ops[104] = grdmath_LDIST;	n_args[104] = 1;	n_out[104] = 1;
+	ops[105] = grdmath_LDISTG;	n_args[105] = 0;	n_out[105] = 1;
+	ops[106] = grdmath_LDIST2;	n_args[106] = 2;	n_out[106] = 1;
+	ops[107] = grdmath_LE;	n_args[107] = 2;	n_out[107] = 1;
+	ops[108] = grdmath_LOG;	n_args[108] = 1;	n_out[108] = 1;
+	ops[109] = grdmath_LOG10;	n_args[109] = 1;	n_out[109] = 1;
+	ops[110] = grdmath_LOG1P;	n_args[110] = 1;	n_out[110] = 1;
+	ops[111] = grdmath_LOG2;	n_args[111] = 1;	n_out[111] = 1;
+	ops[112] = grdmath_LMSSCL;	n_args[112] = 1;	n_out[112] = 1;
+	ops[113] = grdmath_LMSSCLW;	n_args[113] = 1;	n_out[113] = 1;
+	ops[114] = grdmath_LOWER;	n_args[114] = 1;	n_out[114] = 1;
+	ops[115] = grdmath_LPDF;	n_args[115] = 1;	n_out[115] = 1;
+	ops[116] = grdmath_LRAND;	n_args[116] = 2;	n_out[116] = 1;
+	ops[117] = grdmath_LT;	n_args[117] = 2;	n_out[117] = 1;
+	ops[118] = grdmath_MAD;	n_args[118] = 1;	n_out[118] = 1;
+	ops[119] = grdmath_MADW;	n_args[119] = 2;	n_out[119] = 1;
+	ops[120] = grdmath_MAX;	n_args[120] = 2;	n_out[120] = 1;
+	ops[121] = grdmath_MEAN;	n_args[121] = 1;	n_out[121] = 1;
+	ops[122] = grdmath_MEANW;	n_args[122] = 2;	n_out[122] = 1;
+	ops[123] = grdmath_MEDIAN;	n_args[123] = 1;	n_out[123] = 1;
+	ops[124] = grdmath_MEDIANW;	n_args[124] = 2;	n_out[124] = 1;
+	ops[125] = grdmath_MIN;	n_args[125] = 2;	n_out[125] = 1;
+	ops[126] = grdmath_MOD;	n_args[126] = 2;	n_out[126] = 1;
+	ops[127] = grdmath_MODE;	n_args[127] = 1;	n_out[127] = 1;
+	ops[128] = grdmath_MODEW;	n_args[128] = 2;	n_out[128] = 1;
+	ops[129] = grdmath_MUL;	n_args[129] = 2;	n_out[129] = 1;
+	ops[130] = grdmath_NAN;	n_args[130] = 2;	n_out[130] = 1;
+	ops[131] = grdmath_NEG;	n_args[131] = 1;	n_out[131] = 1;
+	ops[132] = grdmath_NEQ;	n_args[132] = 2;	n_out[132] = 1;
+	ops[133] = grdmath_NORM;	n_args[133] = 1;	n_out[133] = 1;
+	ops[134] = grdmath_NOT;	n_args[134] = 1;	n_out[134] = 1;
+	ops[135] = grdmath_NRAND;	n_args[135] = 2;	n_out[135] = 1;
+	ops[136] = grdmath_OR;	n_args[136] = 2;	n_out[136] = 1;
+	ops[137] = grdmath_PDIST;	n_args[137] = 1;	n_out[137] = 1;
+	ops[138] = grdmath_PDIST2;	n_args[138] = 2;	n_out[138] = 1;
+	ops[139] = grdmath_PERM;	n_args[139] = 2;	n_out[139] = 1;
+	ops[140] = grdmath_POP;	n_args[140] = 1;	n_out[140] = 0;
+	ops[141] = grdmath_PLM;	n_args[141] = 3;	n_out[141] = 1;
+	ops[142] = grdmath_PLMg;	n_args[142] = 3;	n_out[142] = 1;
+	ops[143] = grdmath_POINT;	n_args[143] = 1;	n_out[143] = 2;
+	ops[144] = grdmath_POW;	n_args[144] = 2;	n_out[144] = 1;
+	ops[145] = grdmath_PQUANT;	n_args[145] = 2;	n_out[145] = 1;
+	ops[146] = grdmath_PQUANTW;	n_args[146] = 3;	n_out[146] = 1;
+	ops[147] = grdmath_PSI;	n_args[147] = 1;	n_out[147] = 1;
+	ops[148] = grdmath_PV;	n_args[148] = 3;	n_out[148] = 1;
+	ops[149] = grdmath_QV;	n_args[149] = 3;	n_out[149] = 1;
+	ops[150] = grdmath_R2;	n_args[150] = 2;	n_out[150] = 1;
+	ops[151] = grdmath_R2D;	n_args[151] = 1;	n_out[151] = 1;
+	ops[152] = grdmath_RAND;	n_args[152] = 2;	n_out[152] = 1;
+	ops[153] = grdmath_RCDF;	n_args[153] = 1;	n_out[153] = 1;
+	ops[154] = grdmath_RCRIT;	n_args[154] = 1;	n_out[154] = 1;
+	ops[155] = grdmath_RINT;	n_args[155] = 1;	n_out[155] = 1;
+	ops[156] = grdmath_RMS;	n_args[156] = 1;	n_out[156] = 1;
+	ops[157] = grdmath_RMSW;	n_args[157] = 2;	n_out[157] = 1;
+	ops[158] = grdmath_RPDF;	n_args[158] = 1;	n_out[158] = 1;
+	ops[159] = grdmath_ROLL;	n_args[159] = 2;	n_out[159] = 0;
+	ops[160] = grdmath_ROTX;	n_args[160] = 2;	n_out[160] = 1;
+	ops[161] = grdmath_ROTY;	n_args[161] = 2;	n_out[161] = 1;
+	ops[162] = grdmath_SDIST;	n_args[162] = 2;	n_out[162] = 1;
+	ops[163] = grdmath_SDIST2;	n_args[163] = 2;	n_out[163] = 1;
+	ops[164] = grdmath_SAZ;	n_args[164] = 2;	n_out[164] = 1;
+	ops[165] = grdmath_SBAZ;	n_args[165] = 2;	n_out[165] = 1;
+	ops[166] = grdmath_SEC;	n_args[166] = 1;	n_out[166] = 1;
+	ops[167] = grdmath_SECD;	n_args[167] = 1;	n_out[167] = 1;
+	ops[168] = grdmath_SECH;	n_args[168] = 1;	n_out[168] = 1;
+	ops[169] = grdmath_SIGN;	n_args[169] = 1;	n_out[169] = 1;
+	ops[170] = grdmath_SIN;	n_args[170] = 1;	n_out[170] = 1;
+	ops[171] = grdmath_SINC;	n_args[171] = 1;	n_out[171] = 1;
+	ops[172] = grdmath_SIND;	n_args[172] = 1;	n_out[172] = 1;
+	ops[173] = grdmath_SINH;	n_args[173] = 1;	n_out[173] = 1;
+	ops[174] = grdmath_SKEW;	n_args[174] = 1;	n_out[174] = 1;
+	ops[175] = grdmath_SQR;	n_args[175] = 1;	n_out[175] = 1;
+	ops[176] = grdmath_SQRT;	n_args[176] = 1;	n_out[176] = 1;
+	ops[177] = grdmath_STD;	n_args[177] = 1;	n_out[177] = 1;
+	ops[178] = grdmath_STDW;	n_args[178] = 2;	n_out[178] = 1;
+	ops[179] = grdmath_STEP;	n_args[179] = 1;	n_out[179] = 1;
+	ops[180] = grdmath_STEPX;	n_args[180] = 1;	n_out[180] = 1;
+	ops[181] = grdmath_STEPY;	n_args[181] = 1;	n_out[181] = 1;
+	ops[182] = grdmath_SUB;	n_args[182] = 2;	n_out[182] = 1;
+	ops[183] = grdmath_SUM;	n_args[183] = 1;	n_out[183] = 1;
+	ops[184] = grdmath_TAN;	n_args[184] = 1;	n_out[184] = 1;
+	ops[185] = grdmath_TAND;	n_args[185] = 1;	n_out[185] = 1;
+	ops[186] = grdmath_TANH;	n_args[186] = 1;	n_out[186] = 1;
+	ops[187] = grdmath_TAPER;	n_args[187] = 2;	n_out[187] = 1;
+	ops[188] = grdmath_TN;	n_args[188] = 2;	n_out[188] = 1;
+	ops[189] = grdmath_TCRIT;	n_args[189] = 2;	n_out[189] = 1;
+	ops[190] = grdmath_TCDF;	n_args[190] = 2;	n_out[190] = 1;
+	ops[191] = grdmath_TPDF;	n_args[191] = 2;	n_out[191] = 1;
+	ops[192] = grdmath_TRIM;	n_args[192] = 3;	n_out[192] = 1;
+	ops[193] = grdmath_UPPER;	n_args[193] = 1;	n_out[193] = 1;
+	ops[194] = grdmath_VAR;	n_args[194] = 1;	n_out[194] = 1;
+	ops[195] = grdmath_VARW;	n_args[195] = 2;	n_out[195] = 1;
+	ops[196] = grdmath_WCDF;	n_args[196] = 3;	n_out[196] = 1;
+	ops[197] = grdmath_WCRIT;	n_args[197] = 3;	n_out[197] = 1;
+	ops[198] = grdmath_WPDF;	n_args[198] = 3;	n_out[198] = 1;
+	ops[199] = grdmath_WRAP;	n_args[199] = 1;	n_out[199] = 1;
+	ops[200] = grdmath_XOR;	n_args[200] = 2;	n_out[200] = 1;
+	ops[201] = grdmath_Y0;	n_args[201] = 1;	n_out[201] = 1;
+	ops[202] = grdmath_Y1;	n_args[202] = 1;	n_out[202] = 1;
+	ops[203] = grdmath_YLM;	n_args[203] = 2;	n_out[203] = 2;
+	ops[204] = grdmath_YLMg;	n_args[204] = 2;	n_out[204] = 2;
+	ops[205] = grdmath_YN;	n_args[205] = 2;	n_out[205] = 1;
+	ops[206] = grdmath_ZCRIT;	n_args[206] = 1;	n_out[206] = 1;
+	ops[207] = grdmath_ZCDF;	n_args[207] = 1;	n_out[207] = 1;
+	ops[208] = grdmath_ZPDF;	n_args[208] = 1;	n_out[208] = 1;
+	ops[209] = grdmath_HSV2LAB;	n_args[209] = 3;	n_out[209] = 3;
+	ops[210] = grdmath_HSV2RGB;	n_args[210] = 3;	n_out[210] = 3;
+	ops[211] = grdmath_HSV2XYZ;	n_args[211] = 3;	n_out[211] = 3;
+	ops[212] = grdmath_LAB2HSV;	n_args[212] = 3;	n_out[212] = 3;
+	ops[213] = grdmath_LAB2RGB;	n_args[213] = 3;	n_out[213] = 3;
+	ops[214] = grdmath_LAB2XYZ;	n_args[214] = 3;	n_out[214] = 3;
+	ops[215] = grdmath_RGB2HSV;	n_args[215] = 3;	n_out[215] = 3;
+	ops[216] = grdmath_RGB2LAB;	n_args[216] = 3;	n_out[216] = 3;
+	ops[217] = grdmath_RGB2XYZ;	n_args[217] = 3;	n_out[217] = 3;
+	ops[218] = grdmath_XYZ2HSV;	n_args[218] = 3;	n_out[218] = 3;
+	ops[219] = grdmath_XYZ2LAB;	n_args[219] = 3;	n_out[219] = 3;
+	ops[220] = grdmath_XYZ2RGB;	n_args[220] = 3;	n_out[220] = 3;
+	ops[221] = grdmath_DOT;	n_args[221] = 2;	n_out[221] = 1;
 }
 
 #define bailout(code) {gmt_M_free_options (mode); return (code);}
@@ -5850,7 +5850,7 @@ GMT_LOCAL void grdmath_backwards_fixing (struct GMT_CTRL *GMT, char **arg)
 		GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Operator %s is deprecated; use %s instead.\n", old, t);
 }
 
-GMT_LOCAL int decode_grd_argument (struct GMT_CTRL *GMT, struct GMT_OPTION *opt, double *value, struct GMT_HASH *H) {
+GMT_LOCAL int grdmath_decode_argument (struct GMT_CTRL *GMT, struct GMT_OPTION *opt, double *value, struct GMT_HASH *H) {
 	int i, expect, check = GMT_IS_NAN;
 	bool possible_number = false;
 	double tmp = 0.0;
@@ -6313,7 +6313,7 @@ int GMT_grdmath (void *V_API, int mode, void *args) {
 		while (next && next->option != GMT_OPT_INFILE) next = next->next;	/* Skip any options splitting the operand OPERATOR sequence */
 		if (next && !(strncmp (next->arg, "LDIST", 5U) && strncmp (next->arg, "PDIST", 5U) && strncmp (next->arg, "POINT", 5U) && strncmp (next->arg, "INSIDE", 6U))) continue;
 		/* Filenames,  operators, some numbers and = will all have been flagged as input files by the parser */
-		status = decode_grd_argument (GMT, opt, &value, localhashnode);		/* Determine what this is */
+		status = grdmath_decode_argument (GMT, opt, &value, localhashnode);		/* Determine what this is */
 		if (status == GRDMATH_ARG_IS_BAD) Return (GMT_RUNTIME_ERROR);		/* Horrible */
 		if (status != GRDMATH_ARG_IS_FILE) continue;				/* Skip operators and numbers */
 		in_file = opt->arg;
@@ -6439,12 +6439,12 @@ int GMT_grdmath (void *V_API, int mode, void *args) {
 		if (strchr ("ADIMNRVbfnr-" GMT_OPT("F") GMT_ADD_x_OPT, opt->option)) continue;
 		if (opt->option == 'S' && nstack > 1) {	/* Turn on reducing stack behavior */
 			opt = opt->next;	/* Skip to actual operator */
-			if (collapse_stack (GMT, &info, stack, nstack, opt->arg)) continue;	/* Failed, just ignore */
+			if (grdmath_collapse_stack (GMT, &info, stack, nstack, opt->arg)) continue;	/* Failed, just ignore */
 			nstack = 1;	/* Collapsed back to a single item on stack */
 			continue;
 		}
 
-		op = decode_grd_argument (GMT, opt, &value, localhashnode);
+		op = grdmath_decode_argument (GMT, opt, &value, localhashnode);
 		if (op == GRDMATH_ARG_IS_BAD) Return (GMT_RUNTIME_ERROR);		/* Horrible way to go... */
 
 		if (op == GRDMATH_ARG_IS_SAVE) {	/* Time to save the current stack to output and pop the stack */
@@ -6460,7 +6460,7 @@ int GMT_grdmath (void *V_API, int mode, void *args) {
 
 			if (n_items && (new_stack < 0 || stack[nstack-1]->constant)) {	/* Only a constant provided, set grid accordingly */
 				if (!stack[nstack-1]->G)
-					stack[nstack-1]->G = alloc_stack_grid (GMT, info.G);
+					stack[nstack-1]->G = grdmath_alloc_stack_grid (GMT, info.G);
 				if (stack[nstack-1]->constant) {
 					gmt_M_grd_loop (GMT, info.G, row, col, node) stack[nstack-1]->G->data[node] = (float)stack[nstack-1]->factor;
 				}
@@ -6551,7 +6551,7 @@ int GMT_grdmath (void *V_API, int mode, void *args) {
 				else {	/* Place the stored grid on the stack */
 					stack[nstack]->constant = false;
 					if (!stack[nstack]->G)
-						stack[nstack]->G = alloc_stack_grid (GMT, info.G);
+						stack[nstack]->G = grdmath_alloc_stack_grid (GMT, info.G);
 					gmt_M_memcpy (stack[nstack]->G->data, recall[k]->stored.G->data, info.size, float);
 				}
 				if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) GMT_Message (API, GMT_TIME_NONE, "@%s ", recall[k]->label);
@@ -6581,7 +6581,7 @@ int GMT_grdmath (void *V_API, int mode, void *args) {
 
 			if (op == GRDMATH_ARG_IS_X_MATRIX) {		/* Need to set up matrix of x-values */
 				if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) GMT_Message (API, GMT_TIME_NONE, "X ");
-				if (!stack[nstack]->G) stack[nstack]->G = alloc_stack_grid (GMT, info.G);
+				if (!stack[nstack]->G) stack[nstack]->G = grdmath_alloc_stack_grid (GMT, info.G);
 				grdmath_row_padloop (GMT, info.G, row, node) {
 					node = row * info.G->header->mx;
 					gmt_M_memcpy (&stack[nstack]->G->data[node], info.f_grd_x, info.G->header->mx, float);
@@ -6589,7 +6589,7 @@ int GMT_grdmath (void *V_API, int mode, void *args) {
 			}
 			else if (op == GRDMATH_ARG_IS_x_MATRIX) {		/* Need to set up matrix of normalized x-values */
 				if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) GMT_Message (API, GMT_TIME_NONE, "XNORM ");
-				if (!stack[nstack]->G) stack[nstack]->G = alloc_stack_grid (GMT, info.G);
+				if (!stack[nstack]->G) stack[nstack]->G = grdmath_alloc_stack_grid (GMT, info.G);
 				grdmath_row_padloop (GMT, info.G, row, node) {
 					node = row * info.G->header->mx;
 					gmt_M_memcpy (&stack[nstack]->G->data[node], info.f_grd_xn, info.G->header->mx, float);
@@ -6597,37 +6597,37 @@ int GMT_grdmath (void *V_API, int mode, void *args) {
 			}
 			else if (op == GRDMATH_ARG_IS_XCOL_MATRIX) {		/* Need to set up matrix of column numbers */
 				if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) GMT_Message (API, GMT_TIME_NONE, "XCOL ");
-				if (!stack[nstack]->G) stack[nstack]->G = alloc_stack_grid (GMT, info.G);
+				if (!stack[nstack]->G) stack[nstack]->G = grdmath_alloc_stack_grid (GMT, info.G);
 				grdmath_grd_padloop (GMT, info.G, row, col, node) stack[nstack]->G->data[node] = (float)(col - stack[nstack]->G->header->pad[XLO]);
 			}
 			else if (op == GRDMATH_ARG_IS_Y_MATRIX) {	/* Need to set up matrix of y-values */
 				if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) GMT_Message (API, GMT_TIME_NONE, "Y ");
-				if (!stack[nstack]->G) stack[nstack]->G = alloc_stack_grid (GMT, info.G);
+				if (!stack[nstack]->G) stack[nstack]->G = grdmath_alloc_stack_grid (GMT, info.G);
 				grdmath_grd_padloop (GMT, info.G, row, col, node) stack[nstack]->G->data[node] = info.f_grd_y[row];
 			}
 			else if (op == GRDMATH_ARG_IS_y_MATRIX) {	/* Need to set up matrix of normalized y-values */
 				if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) GMT_Message (API, GMT_TIME_NONE, "YNORM ");
-				if (!stack[nstack]->G) stack[nstack]->G = alloc_stack_grid (GMT, info.G);
+				if (!stack[nstack]->G) stack[nstack]->G = grdmath_alloc_stack_grid (GMT, info.G);
 				grdmath_grd_padloop (GMT, info.G, row, col, node) stack[nstack]->G->data[node] = info.f_grd_yn[row];
 			}
 			else if (op == GRDMATH_ARG_IS_YROW_MATRIX) {		/* Need to set up matrix of row numbers */
 				if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) GMT_Message (API, GMT_TIME_NONE, "YROW ");
-				if (!stack[nstack]->G) stack[nstack]->G = alloc_stack_grid (GMT, info.G);
+				if (!stack[nstack]->G) stack[nstack]->G = grdmath_alloc_stack_grid (GMT, info.G);
 				grdmath_grd_padloop (GMT, info.G, row, col, node) stack[nstack]->G->data[node] = (float)(row - stack[nstack]->G->header->pad[YHI]);
 			}
 			else if (op == GRDMATH_ARG_IS_NODE_MATRIX) {		/* Need to set up matrix of continuous node numbers (pad not considered) */
 				if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) GMT_Message (API, GMT_TIME_NONE, "NODE ");
-				if (!stack[nstack]->G) stack[nstack]->G = alloc_stack_grid (GMT, info.G);
+				if (!stack[nstack]->G) stack[nstack]->G = grdmath_alloc_stack_grid (GMT, info.G);
 				gmt_M_grd_loop (GMT, info.G, row, col, node) stack[nstack]->G->data[node] = (float)gmt_M_ij0(stack[nstack]->G->header,row,col);
 			}
 			else if (op == GRDMATH_ARG_IS_NODEP_MATRIX) {		/* Need to set up matrix of node numbers (in presence of pad) */
 				if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) GMT_Message (API, GMT_TIME_NONE, "NODEP ");
-				if (!stack[nstack]->G) stack[nstack]->G = alloc_stack_grid (GMT, info.G);
+				if (!stack[nstack]->G) stack[nstack]->G = grdmath_alloc_stack_grid (GMT, info.G);
 				gmt_M_grd_loop (GMT, info.G, row, col, node) stack[nstack]->G->data[node] = (float)gmt_M_ijp(stack[nstack]->G->header,row,col);
 			}
 			else if (op == GRDMATH_ARG_IS_ASCIIFILE) {
 				gmt_M_str_free (info.ASCII_file);
-				if (!stack[nstack]->G) stack[nstack]->G = alloc_stack_grid (GMT, info.G);
+				if (!stack[nstack]->G) stack[nstack]->G = grdmath_alloc_stack_grid (GMT, info.G);
 				info.ASCII_file = strdup (opt->arg);
 				if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) GMT_Message (API, GMT_TIME_NONE, "(%s) ", opt->arg);
 			}
@@ -6674,14 +6674,14 @@ int GMT_grdmath (void *V_API, int mode, void *args) {
 			if (stack[nstack+k-1]->G) continue;
 
 			/* Must make space for more */
-			stack[nstack+k-1]->G = alloc_stack_grid (GMT, info.G);
+			stack[nstack+k-1]->G = grdmath_alloc_stack_grid (GMT, info.G);
 		}
 
 		/* If operators operates on constants only we may have to make space as well */
 
 		for (kk = 0, k = nstack - consumed_operands[op]; kk < produced_operands[op]; kk++, k++) {
 			if (stack[k]->constant && !stack[k]->G)
-				stack[k]->G = alloc_stack_grid (GMT, info.G);
+				stack[k]->G = grdmath_alloc_stack_grid (GMT, info.G);
 		}
 
 		gmt_set_column (GMT, GMT_OUT, GMT_Z, GMT_IS_FLOAT);


### PR DESCRIPTION
Per our [naming convention](CODE_CONVENTIONS.md), static functions in a particular file (here in **gmtmath.c** and **grdmath.c**) should be called _gmtmath_names_ and _grdmath_names_.  This PR uses the new convention scanner tool in admin to identify these misnamed functions.
