### PR TITLE
Add options to the src_convention_check.c

### DIFF
--- a/admin/src_convention_check.sh
+++ b/admin/src_convention_check.sh
@@ -18,11 +18,11 @@ mkdir -p /tmp/gmt
 
 # Create include files based on current gmt status
 # Create the list of current API prototype (GMT_*) functions from gmt.h
-grep EXTERN_MSC src/gmt.h | awk -F'(' '{print $1}' | awk '{print $NF}' | grep -v '*' | awk '{printf "\t\"%s.c\",\n", $1}' > /tmp/gmt/api.h
+grep EXTERN_MSC src/gmt.h | awk -F'(' '{print $1}' | awk '{print $NF}' | tr '*' ' ' | awk '{printf "\t\"%s.c\",\n", $1}' > /tmp/gmt/api.h
 # Create the list of current prototype (gmt_*) functions from gmt_prototypess.h
-grep EXTERN_MSC src/gmt_prototypes.h | awk -F'(' '{print $1}' | awk '{print $NF}' | grep -v '*' | awk '{printf "\t\"%s.c\",\n", $1}' > /tmp/gmt/prototypes.h
+grep EXTERN_MSC src/gmt_prototypes.h | awk -F'(' '{print $1}' | awk '{print $NF}' | tr '*' ' ' | awk '{printf "\t\"%s.c\",\n", $1}' > /tmp/gmt/prototypes.h
 # Create the list of current prototype (gmtlib_*) functions from gmt_internals.h
-grep EXTERN_MSC src/gmt_internals.h | awk -F'(' '{print $1}' | awk '{print $NF}' | grep -v '*' | awk '{printf "\t\"%s.c\",\n", $1}' > /tmp/gmt/internals.h
+grep EXTERN_MSC src/gmt_internals.h | awk -F'(' '{print $1}' | awk '{print $NF}' | tr '*' ' ' | awk '{printf "\t\"%s.c\",\n", $1}' > /tmp/gmt/internals.h
 # Create list of module functions
 gmt --show-classic | awk '{printf "\t\"%s.c\",\n", $1}' > /tmp/gmt/modules.h
 gcc admin/src_convention_check.c -o /tmp/src_convention_check


### PR DESCRIPTION
To better monitor progress, add **-v** for more verbosity.  Also **-w** for only reporting the cases with wrong function names.

I also committed some earlier changes directly to master since it is decoupled from GMT itself.  This version uses the start script to build include files with the current list of modules, api functions, devlib functions and internal functions so we can directly check if naming convention is followed. 

Focus right now is to clean up static function names since they are guaranteed to have no ill side-effects on Julia, etc.