### PR TITLE
Fix a few GCC warnings

### DIFF
--- a/src/gmt_gdalwrite.c
+++ b/src/gmt_gdalwrite.c
@@ -364,7 +364,7 @@ int gmt_gdalwrite (struct GMT_CTRL *GMT, char *fname, struct GMT_GDALWRITE_CTRL 
 		   we assume that the decimal * 1000 is the number on the color matrix of the transparent color. And
 		   then we use it to set prhs->nan_value. In gmt_gdalwrite it will be used by GDALSetRasterNoDataValue.
 		*/
-		float dc = 0.0, nc;
+		float dc = 0.0, nc = 0.0;
 
 		nColors = prhs->C.n_colors;
 		if (nColors > 2000) {			/* If colormap is Mx4 or has encoded the alpha color */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -703,9 +703,9 @@ GMT_LOCAL void gmtinit_kw_replace (struct GMTAPI_CTRL *API, struct GMT_KEYWORD_D
 #endif
 
 GMT_LOCAL int gmtinit_check_markers (struct GMT_CTRL *GMT) {
+	int error = GMT_NOERROR;
 	/* Make sure segment header markers and header markers are not the same */
 	strcpy (GMT->current.setting.io_head_marker_in, "#%\"\'");	/* Accept GMT or MATLAB header records or comments or quoted text */
-	int error = GMT_NOERROR;
 
 	if (strchr (GMT->current.setting.io_head_marker_in, GMT->current.setting.io_seg_marker[GMT_IN])) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot let %c be both a header record flag and multiple segment header flag for input data\n", GMT->current.setting.io_seg_marker[GMT_IN]);

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -2202,7 +2202,7 @@ GMT_LOCAL void plot_consider_internal_annotations (struct GMT_CTRL *GMT, struct 
 		}
 		else
 			do_grid = true;
-			
+
 		if (do_grid) {
 			/* Either pick current grid-cross size or use half the annotation size as backup */
 			L = 0.5 * fabs ((GMT->current.setting.map_grid_cross_size[GMT_PRIMARY] > 0.0) ? GMT->current.setting.map_grid_cross_size[GMT_PRIMARY] : 0.5 * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH);
@@ -2240,7 +2240,7 @@ GMT_LOCAL void plot_consider_internal_annotations (struct GMT_CTRL *GMT, struct 
 		if (GMT->current.plot.r_theta_annot)	/* Restore the format */
 			strcpy (GMT->current.setting.format_float_map, format);
 	}
-	
+
 	if (GMT->current.map.frame.internal_annot == 2) {	/* Placement of longitude annotations along selected parallel */
 		dx = gmtlib_get_map_interval (GMT, &GMT->current.map.frame.axis[GMT_X].item[GMT_ANNOT_UPPER]);
 		do_minutes = (fabs (fmod (dx, 1.0)) > GMT_CONV4_LIMIT);
@@ -2265,7 +2265,7 @@ GMT_LOCAL void plot_consider_internal_annotations (struct GMT_CTRL *GMT, struct 
 		}
 		else
 			do_grid = true;
-			
+
 		if (do_grid) {
 			/* Either pick current grid-cross size or use half the annotation size as backup */
 			L = 0.5 * fabs ((GMT->current.setting.map_grid_cross_size[GMT_PRIMARY] > 0.0) ? GMT->current.setting.map_grid_cross_size[GMT_PRIMARY] : 0.5 * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH);
@@ -5419,9 +5419,10 @@ GMT_LOCAL void plot_check_primary_secondary (struct GMT_CTRL *GMT) {
 	struct GMT_PLOT_AXIS_ITEM *P = NULL, *S = NULL;
 	static char *kind[3] = {"annotation", "tick", "grid-line"};
 	static char *axis[2][3] = { {"x", "y", "z"}, {"longitude", "latitude", "z"}};
-	unsigned int no, k, type = gmt_M_is_geographic (GMT, GMT_IN);;
+	unsigned int no, k, type;
 	double dP, dS;
 
+	type = gmt_M_is_geographic (GMT, GMT_IN);
 	for (no = 0; no <= GMT_Z; no++) {
 		A = &GMT->current.map.frame.axis[no];
 		if (A->type == GMT_TIME) continue;	/* We assume those are set correctly */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7872,7 +7872,7 @@ char * gmt_get_current_item (struct GMT_CTRL *GMT, const char *item, bool strict
 		return (file);
 	}
 
-FOUND_NOTHING:	
+FOUND_NOTHING:
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "No current %s file found\n", item);
 	return (NULL);
 }
@@ -8566,7 +8566,7 @@ int gmtlib_write_cpt (struct GMT_CTRL *GMT, void *dest, unsigned int dest_type, 
 	return (GMT_NOERROR);
 }
 
-void GMT_LOCAL gmtsupport_reset_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P) {
+GMT_LOCAL void gmtsupport_reset_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P) {
 	/* Determine if CPT is continuous, B/W, or gray-scale */
 	unsigned int k;
 	gmt_M_unused (GMT);


### PR DESCRIPTION
Here are the warnings:

- ‘nc’ may be used uninitialized in this function [-Wmaybe-uninitialized]
- ‘static’ is not at beginning of declaration [-Wold-style-declaration]
- ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]