### PR TITLE
Complete cleaning of gmt_api.c

### DIFF
--- a/src/docs.c
+++ b/src/docs.c
@@ -62,8 +62,6 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 #define bailout(code) {gmt_M_free_options (mode); return (code);}
 #define Return(code) {gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
-EXTERN_MSC const char *api_get_module_group (void *V_API, char *module);
-
 int GMT_docs (void *V_API, int mode, void *args) {
 	bool other_file = false, print_url = false, got_file = false, called = false, remote = false, direct_URL = false;
 	int error = 0, id;
@@ -228,7 +226,7 @@ int GMT_docs (void *V_API, int mode, void *args) {
 				group = known_group[1];
 				other_file = true;
 			}
-			else if ((group = api_get_module_group (API, name)) == NULL) {
+			else if ((group = gmt_get_module_group (API, name)) == NULL) {
 				gmt_M_str_free (t);
 				Return (GMT_RUNTIME_ERROR);
 			}

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -285,7 +285,7 @@ int gmtapi_validate_id (struct GMTAPI_CTRL *API, int family, int object_ID, int 
 int gmtapi_unregister_io (struct GMTAPI_CTRL *API, int object_ID, unsigned int direction);
 unsigned int gmtapi_count_objects (struct GMTAPI_CTRL *API, enum GMT_enum_family family, unsigned int geometry, unsigned int direction, int *first_ID);
 void gmtapi_close_grd (struct GMT_CTRL *GMT, struct GMT_GRID *G);
-char *gmtapi_create_header_item (struct GMTAPI_CTRL *API, unsigned int mode, void *arg);
+char * gmtapi_create_header_item (struct GMTAPI_CTRL *API, unsigned int mode, void *arg);
 GMT_LOCAL void gmtapi_get_record_init (struct GMTAPI_CTRL *API);
 
 /* Series of one-line functions to assign val to a particular union member of array u at position row, rounding if integer output */
@@ -536,7 +536,7 @@ GMT_LOCAL inline void gmtapi_exit (struct GMTAPI_CTRL *API, int code) {
 }
 
 /*! gmtapi_return_address is a convenience function that, given type, calls the correct converter */
-GMT_LOCAL void *gmtapi_return_address (void *data, unsigned int type) {
+GMT_LOCAL void * gmtapi_return_address (void *data, unsigned int type) {
 	void *p = NULL;
 	switch (type) {
 		case GMT_IS_GRID:	p = gmtapi_get_grid_ptr (data);	break;
@@ -561,7 +561,7 @@ struct GMTAPI_CTRL * gmt_get_api_ptr (struct GMTAPI_CTRL *ptr) {
 }
 
 /*! gmtapi_alloc_object_array is a convenience function that, given type, allocates an array of pointers to the corresponding container */
-GMT_LOCAL void *gmtapi_alloc_object_array (struct GMTAPI_CTRL *API, unsigned int n_items, unsigned int type) {
+GMT_LOCAL void * gmtapi_alloc_object_array (struct GMTAPI_CTRL *API, unsigned int n_items, unsigned int type) {
 	void *p = NULL;
 	switch (type) {
 		case GMT_IS_GRID:	p = gmt_M_memory (API->GMT, NULL, n_items, struct GMT_GRID *);		break;
@@ -773,7 +773,7 @@ GMT_LOCAL char * gmtapi_get_ppid (struct GMTAPI_CTRL *API) {
 }
 
 /*! . */
-GMT_LOCAL char *gmtapi_lib_tag (char *name) {
+GMT_LOCAL char * gmtapi_lib_tag (char *name) {
 	/* Pull out the tag from a name like <tag>[.extension] */
 	char *extension = NULL, *pch = NULL, *tag = NULL;
 	if (!strchr (name, '.')) return NULL;	/* No file with extension given, probably just a directory due to user confusion */
@@ -1261,7 +1261,7 @@ GMT_LOCAL int gmtapi_key_to_family (void *API, char *key, int *family, int *geom
 	return ((key[K_DIR] == API_SECONDARY_OUTPUT || key[K_DIR] == API_PRIMARY_OUTPUT) ? GMT_OUT : GMT_IN);	/* Return the direction of the i/o */
 }
 
-GMT_LOCAL char *gmtapi_prepare_keys (struct GMTAPI_CTRL *API, const char *string) {
+GMT_LOCAL char * gmtapi_prepare_keys (struct GMTAPI_CTRL *API, const char *string) {
 	char *tmp = NULL, *c = NULL, *string_;
 	string_ = strdup(string);	/* Have to make a copy because "string" is const and the c[0] = '\0' make it crash on Win for non-debug builds */
 	if ((c = strchr (string_, '@'))) {	/* Split KEYS: classic@modern, must get the relevant half */
@@ -1502,7 +1502,7 @@ GMT_LOCAL unsigned int gmtapi_determine_dimension (struct GMTAPI_CTRL *API, char
 }
 
 /*! . */
-GMT_LOCAL void *gmtapi_retrieve_data (void *V_API, int object_ID) {
+GMT_LOCAL void * gmtapi_retrieve_data (void *V_API, int object_ID) {
 	/* Function to return pointer to the container for a registered data set.
 	 * Typically used when we wish a module to "write" its results to a memory
 	 * location that we wish to access from the calling program.  The procedure
@@ -2453,7 +2453,7 @@ GMT_LOCAL int gmtapi_get_object (struct GMTAPI_CTRL *API, int sfamily, void *ptr
 }
 
 /*! . */
-GMT_LOCAL void *gmtapi_pass_object (struct GMTAPI_CTRL *API, struct GMTAPI_DATA_OBJECT *object, unsigned int family, unsigned int mode, double *wesn) {
+GMT_LOCAL void * gmtapi_pass_object (struct GMTAPI_CTRL *API, struct GMTAPI_DATA_OBJECT *object, unsigned int family, unsigned int mode, double *wesn) {
 	/* Passes back the input object pointer after possibly performing some minor adjustments to metadata.
 	 * For grids and images we must worry about possible subset requests */
 	void *data = object->resource;
@@ -2930,7 +2930,7 @@ GMT_LOCAL int gmtapi_export_postscript (struct GMTAPI_CTRL *API, int object_ID, 
 	return GMT_NOERROR;
 }
 
-GMT_LOCAL struct GMT_MATRIX *gmtapi_read_matrix (struct GMT_CTRL *GMT, void *source, unsigned int src_type, unsigned int mode) {
+GMT_LOCAL struct GMT_MATRIX * gmtapi_read_matrix (struct GMT_CTRL *GMT, void *source, unsigned int src_type, unsigned int mode) {
 	/* We read the MATRIX from fp [or stdin].
 	 * src_type can be GMT_IS_[FILE|STREAM|FDESC]
 	 * Notes: mode is not used yet.  We only do ascii file for now - later need to deal with -b, if needed.
@@ -3030,7 +3030,7 @@ GMT_LOCAL struct GMT_MATRIX *gmtapi_read_matrix (struct GMT_CTRL *GMT, void *sou
 }
 
 /*! . */
-GMT_LOCAL struct GMT_MATRIX *gmtapi_import_matrix (struct GMTAPI_CTRL *API, int object_ID, unsigned int mode) {
+GMT_LOCAL struct GMT_MATRIX * gmtapi_import_matrix (struct GMTAPI_CTRL *API, int object_ID, unsigned int mode) {
 	/* Does the actual work of loading in a GMT matrix. */
 	int item;
 	unsigned int kind;
@@ -3371,7 +3371,7 @@ GMT_LOCAL int gmtapi_export_vector (struct GMTAPI_CTRL *API, int object_ID, unsi
 	return GMT_NOERROR;
 }
 
-GMT_LOCAL struct GMT_VECTOR *gmtapi_read_vector (struct GMT_CTRL *GMT, void *source, unsigned int src_type, unsigned int mode) {
+GMT_LOCAL struct GMT_VECTOR * gmtapi_read_vector (struct GMT_CTRL *GMT, void *source, unsigned int src_type, unsigned int mode) {
 	/* We read the VECTOR from fp [or stdin].
 	 * src_type can be GMT_IS_[FILE|STREAM|FDESC]
 	 * mode is not used yet.  We only do ascii file for now - later need to deal with -b
@@ -3553,7 +3553,7 @@ GMT_LOCAL void gmtapi_increment_d (struct GMT_DATASET *D_obj, uint64_t n_rows, u
 }
 
 /*! . */
-GMT_LOCAL struct GMT_DATASET *gmtapi_import_dataset (struct GMTAPI_CTRL *API, int object_ID, unsigned int mode) {
+GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, int object_ID, unsigned int mode) {
 	/* Does the actual work of loading in the entire virtual data set (possibly via many sources)
 	 * If object_ID == GMT_NOTSET we get all registered input tables, otherwise we just get the one requested.
 	 * Note: Memory is allocated for the Dataset except for method GMT_IS_REFERENCE.
@@ -4217,7 +4217,7 @@ GMT_LOCAL int gmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, uns
 }
 
 /*! . */
-GMT_LOCAL struct GMT_IMAGE *gmtapi_import_image (struct GMTAPI_CTRL *API, int object_ID, unsigned int mode, struct GMT_IMAGE *image) {
+GMT_LOCAL struct GMT_IMAGE * gmtapi_import_image (struct GMTAPI_CTRL *API, int object_ID, unsigned int mode, struct GMT_IMAGE *image) {
 	/* Handles the reading of a 2-D grid given in one of several ways.
 	 * Get the entire image:
  	 * 	mode = GMT_CONTAINER_AND_DATA reads both header and image;
@@ -4573,7 +4573,7 @@ GMT_LOCAL int gmtapi_export_image (struct GMTAPI_CTRL *API, int object_ID, unsig
 }
 
 /*! . */
-GMT_LOCAL struct GMT_GRID *gmtapi_import_grid (struct GMTAPI_CTRL *API, int object_ID, unsigned int mode, struct GMT_GRID *grid) {
+GMT_LOCAL struct GMT_GRID * gmtapi_import_grid (struct GMTAPI_CTRL *API, int object_ID, unsigned int mode, struct GMT_GRID *grid) {
 	/* Handles the reading of a 2-D grid given in one of several ways.
 	 * Get the entire grid:
  	 * 	mode = GMT_CONTAINER_AND_DATA reads both header and grid;
@@ -5113,7 +5113,7 @@ GMT_LOCAL int gmtapi_export_grid (struct GMTAPI_CTRL *API, int object_ID, unsign
 }
 
 /*! . */
-GMT_LOCAL void *gmtapi_import_data (struct GMTAPI_CTRL *API, enum GMT_enum_family family, int object_ID, unsigned int mode, void *data) {
+GMT_LOCAL void * gmtapi_import_data (struct GMTAPI_CTRL *API, enum GMT_enum_family family, int object_ID, unsigned int mode, void *data) {
 
 	/* Function that will import the data object referred to by the object_ID (or all registered inputs if object_ID == GMT_NOTSET).
 	 * This is a wrapper functions for CPT, Dataset, Textset, Grid and Image imports; see the specific functions
@@ -5162,7 +5162,7 @@ GMT_LOCAL void *gmtapi_import_data (struct GMTAPI_CTRL *API, enum GMT_enum_famil
 }
 
 /*! . */
-GMT_LOCAL void *gmtapi_get_data (void *V_API, int object_ID, unsigned int mode, void *data) {
+GMT_LOCAL void * gmtapi_get_data (void *V_API, int object_ID, unsigned int mode, void *data) {
 	/* Function to import registered data sources directly into program memory as a set (not record-by-record).
 	 * data is pointer to an existing grid container when we read a grid in two steps, otherwise use NULL.
 	 * ID is the registered resource from which to import.
@@ -5960,7 +5960,7 @@ unsigned int gmtapi_count_objects (struct GMTAPI_CTRL *API, enum GMT_enum_family
 }
 
 /*! . */
-char *gmtapi_create_header_item (struct GMTAPI_CTRL *API, unsigned int mode, void *arg) {
+char * gmtapi_create_header_item (struct GMTAPI_CTRL *API, unsigned int mode, void *arg) {
 	size_t lim;
 	char *txt = (mode & GMT_COMMENT_IS_OPTION) ? GMT_Create_Cmd (API, arg) : (char *)arg;
 	static char buffer[GMT_BUFSIZ];
@@ -5999,7 +5999,7 @@ void gmtapi_close_grd (struct GMT_CTRL *GMT, struct GMT_GRID *G) {
 
 /*! ===>  Create a new GMT Session */
 
-void *GMT_Create_Session (const char *session, unsigned int pad, unsigned int mode, int (*print_func) (FILE *, const char *)) {
+void * GMT_Create_Session (const char *session, unsigned int pad, unsigned int mode, int (*print_func) (FILE *, const char *)) {
 	/* Initializes the GMT API for a new session. This is typically called once in a program,
 	 * but programs that manage many threads might call it several times to create as many
 	 * sessions as needed. [Note: There is of yet no thread support built into the GMT API
@@ -6105,7 +6105,7 @@ void *GMT_Create_Session (const char *session, unsigned int pad, unsigned int mo
 
 #ifdef FORTRAN_API
 /* Fortran binding [THESE MAY CHANGE ONCE WE ACTUALLY TRY TO USE THESE] */
-struct GMTAPI_CTRL *GMT_Create_Session_ (const char *tag, unsigned int *pad, unsigned int *mode, void *print, int len) {
+struct GMTAPI_CTRL * GMT_Create_Session_ (const char *tag, unsigned int *pad, unsigned int *mode, void *print, int len) {
 	/* Fortran version: We pass the hidden global GMT_FORTRAN structure */
 	return (GMT_Create_Session (tag, *pad, *mode, print));
 }
@@ -6982,7 +6982,7 @@ int GMT_Close_VirtualFile_ (unsigned int *family, char *string, int len) {
 }
 #endif
 
-void *GMT_Read_VirtualFile (void *V_API, const char *string) {
+void * GMT_Read_VirtualFile (void *V_API, const char *string) {
 	/* Given a VirtualFile name, retrieve the resulting object */
 	int object_ID;
 	void *object = NULL;
@@ -6996,7 +6996,7 @@ void *GMT_Read_VirtualFile (void *V_API, const char *string) {
 }
 
 #ifdef FORTRAN_API
-void *GMT_Read_VirtualFile_ (char *string, int len) {
+void * GMT_Read_VirtualFile_ (char *string, int len) {
 	/* Fortran version: We pass the global GMT_FORTRAN structure */
 	return (GMT_Read_VirtualFile (GMT_FORTRAN, string));
 }
@@ -7017,7 +7017,7 @@ int GMT_Inquire_VirtualFile (void *V_API, const char *string) {
 }
 
 #ifdef FORTRAN_API
-int *GMT_Inquire_VirtualFile_ (char *string, int len) {
+int GMT_Inquire_VirtualFile_ (char *string, int len) {
 	/* Fortran version: We pass the global GMT_FORTRAN structure */
 	return (GMT_Inquire_VirtualFile (GMT_FORTRAN, string));
 }
@@ -7070,7 +7070,7 @@ GMT_LOCAL bool gmtapi_is_passable (struct GMTAPI_DATA_OBJECT *S_obj, unsigned in
 }
 
 /*! . */
-void *GMT_Read_Data (void *V_API, unsigned int family, unsigned int method, unsigned int geometry, unsigned int mode, double wesn[], const char *infile, void *data) {
+void * GMT_Read_Data (void *V_API, unsigned int family, unsigned int method, unsigned int geometry, unsigned int mode, double wesn[], const char *infile, void *data) {
 	/* Function to read data files directly into program memory as a set (not record-by-record).
 	 * We can combine the <register resource - import resource > sequence in
 	 * one combined function.  See GMT_Register_IO for details on arguments.
@@ -7259,14 +7259,14 @@ void *GMT_Read_Data (void *V_API, unsigned int family, unsigned int method, unsi
 }
 
 #ifdef FORTRAN_API
-void *GMT_Read_Data_ (unsigned int *family, unsigned int *method, unsigned int *geometry, unsigned int *mode, double *wesn, char *input, void *data, int len) {
+void * GMT_Read_Data_ (unsigned int *family, unsigned int *method, unsigned int *geometry, unsigned int *mode, double *wesn, char *input, void *data, int len) {
 	/* Fortran version: We pass the global GMT_FORTRAN structure */
 	return (GMT_Read_Data (GMT_FORTRAN, *family, *method, *geometry, *mode, wesn, input, data));
 }
 #endif
 
 /*! . */
-void *GMT_Read_Group (void *V_API, unsigned int family, unsigned int method, unsigned int geometry, unsigned int mode, double wesn[], void *sources, unsigned int *n_items, void *data) {
+void * GMT_Read_Group (void *V_API, unsigned int family, unsigned int method, unsigned int geometry, unsigned int mode, double wesn[], void *sources, unsigned int *n_items, void *data) {
 	/* Function to read a group of data files directly into program memory givin an array of objects.
 	 * data is pointer to an existing array of grid container when we read a grid in two steps, otherwise use NULL.
 	 * *n_items = 0: sources is a character string with wildcard-specification for file names.
@@ -7311,14 +7311,14 @@ void *GMT_Read_Group (void *V_API, unsigned int family, unsigned int method, uns
 }
 
 #ifdef FORTRAN_API
-void *GMT_Read_Group_ (unsigned int *family, unsigned int *method, unsigned int *geometry, unsigned int *mode, double *wesn, void *sources, unsigned int *n_items, void *data) {
+void * GMT_Read_Group_ (unsigned int *family, unsigned int *method, unsigned int *geometry, unsigned int *mode, double *wesn, void *sources, unsigned int *n_items, void *data) {
 	/* Fortran version: We pass the global GMT_FORTRAN structure */
 	return (GMT_Read_Group (GMT_FORTRAN, *family, *method, *geometry, *mode, wesn, sources, n_items, data));
 }
 #endif
 
 /*! . */
-void *GMT_Duplicate_Data (void *V_API, unsigned int family, unsigned int mode, void *data) {
+void * GMT_Duplicate_Data (void *V_API, unsigned int family, unsigned int mode, void *data) {
 	/* Create an duplicate container of the requested kind and optionally allocate space
 	 * or duplicate content.
 	 * The known families are GMT_IS_{DATASET,GRID,PALETTE,IMAGE,POSTSCRIPT}.
@@ -7410,7 +7410,7 @@ void *GMT_Duplicate_Data (void *V_API, unsigned int family, unsigned int mode, v
 }
 
 #ifdef FORTRAN_API
-void *GMT_Duplicate_Data_ (unsigned int *family,  unsigned int *mode, void *data) {
+void * GMT_Duplicate_Data_ (unsigned int *family,  unsigned int *mode, void *data) {
 	/* Fortran version: We pass the global GMT_FORTRAN structure */
 	return (GMT_Duplicate_Data (GMT_FORTRAN, *family, *mode, data));
 }
@@ -7566,7 +7566,7 @@ int GMT_Set_Geometry_ (unsigned int *direction, unsigned int *geometry) {	/* For
 }
 #endif
 
-GMT_LOCAL void *gmtapi_get_record_fp_sub (struct GMTAPI_CTRL *API, unsigned int mode, int *n_fields, struct GMTAPI_DATA_OBJECT **S_obj) {
+GMT_LOCAL void * gmtapi_get_record_fp_sub (struct GMTAPI_CTRL *API, unsigned int mode, int *n_fields, struct GMTAPI_DATA_OBJECT **S_obj) {
 	/* Gets next data record from current open stream */
 	int status;
 	struct GMTAPI_DATA_OBJECT *S = API->current_get_obj;
@@ -7729,7 +7729,7 @@ struct GMT_RECORD *api_get_record_vector (struct GMTAPI_CTRL *API, unsigned int 
 	return record;
 }
 
-GMT_LOCAL struct GMT_RECORD *gmtapi_get_record_dataset (struct GMTAPI_CTRL *API, unsigned int mode, int *n_fields) {
+GMT_LOCAL struct GMT_RECORD * gmtapi_get_record_dataset (struct GMTAPI_CTRL *API, unsigned int mode, int *n_fields) {
 	/* Gets next data record from current dataset */
 	struct GMTAPI_DATA_OBJECT *S = API->current_get_obj;
 	struct GMT_CTRL *GMT = API->GMT;
@@ -7849,7 +7849,7 @@ GMT_LOCAL void gmtapi_get_record_init (struct GMTAPI_CTRL *API) {
 	}
 }
 
-void *GMT_Get_Record (void *V_API, unsigned int mode, int *retval) {
+void * GMT_Get_Record (void *V_API, unsigned int mode, int *retval) {
 	/* Retrieves the next data record from the virtual input source and
 	 * returns the number of columns found via *retval (unless retval == NULL).
 	 * If current record is a segment header then we return 0.
@@ -7889,7 +7889,7 @@ void *GMT_Get_Record (void *V_API, unsigned int mode, int *retval) {
 }
 
 #ifdef FORTRAN_API
-void *GMT_Get_Record_ (unsigned int *mode, int *status) {	/* Fortran version: We pass the global GMT_FORTRAN structure */
+void * GMT_Get_Record_ (unsigned int *mode, int *status) {	/* Fortran version: We pass the global GMT_FORTRAN structure */
 	return (GMT_Get_Record (GMT_FORTRAN, *mode, status));
 }
 #endif
@@ -8759,7 +8759,7 @@ int GMT_Destroy_Group_ (void *object, unsigned int *n_items) {
 #endif
 
 /*! . */
-void *GMT_Create_Data (void *V_API, unsigned int family, unsigned int geometry, unsigned int mode, uint64_t dim[], double *range, double *inc, unsigned int registration, int pad, void *data) {
+void * GMT_Create_Data (void *V_API, unsigned int family, unsigned int geometry, unsigned int mode, uint64_t dim[], double *range, double *inc, unsigned int registration, int pad, void *data) {
 	/* Create an empty container of the requested kind and allocate space for content.
 	 * The known families are GMT_IS_{DATASET,GRID,PALETTE,IMAGE,POSTSCRIPT}, but we
 	 * also allow for creation of the containers for GMT_IS_{VECTOR,MATRIX}. Note
@@ -8980,7 +8980,7 @@ void *GMT_Create_Data (void *V_API, unsigned int family, unsigned int geometry, 
 }
 
 #ifdef FORTRAN_API
-void *GMT_Create_Data_ (unsigned int *family, unsigned int *geometry, unsigned int *mode, uint64_t *dim, double *range, double *inc, unsigned int *registration, int *pad, void *container) {
+void * GMT_Create_Data_ (unsigned int *family, unsigned int *geometry, unsigned int *mode, uint64_t *dim, double *range, double *inc, unsigned int *registration, int *pad, void *container) {
 	/* Fortran version: We pass the global GMT_FORTRAN structure */
 	return (GMT_Create_Data (GMT_FORTRAN, *family, *geometry, *mode, dim, range, inc, *registration, *pad, container));
 }
@@ -9189,7 +9189,7 @@ int GMT_Set_Index_ (void *h, char *code, int len) {
 #endif
 
 /*! . */
-double *GMT_Get_Coord (void *V_API, unsigned int family, unsigned int dim, void *container) {
+double * GMT_Get_Coord (void *V_API, unsigned int family, unsigned int dim, void *container) {
 	/* Return an array of coordinates for the nodes along the specified dimension.
 	 * For GMT_GRID and GMT_IMAGE, dim is either 0 (GMT_X) or 1 (GMT_Y) while for
 	 * GMT_MATRIX it may be 2 (GMT_Z), provided the matrix has more than 1 layer.
@@ -9239,7 +9239,7 @@ double *GMT_Get_Coord (void *V_API, unsigned int family, unsigned int dim, void 
 }
 
 #ifdef FORTRAN_API
-double *GMT_Get_Coord_ (unsigned int *family, unsigned int *dim, void *container) {
+double * GMT_Get_Coord_ (unsigned int *family, unsigned int *dim, void *container) {
 	/* Fortran version: We pass the global GMT_FORTRAN structure */
 	return (GMT_Get_Coord (GMT_FORTRAN, *family, *dim, container));
 }
@@ -9366,7 +9366,7 @@ GMT_LOCAL void gmtapi_fft_Singleton_list (struct GMTAPI_CTRL *API) {
 }
 
 /*! . */
-void *GMT_FFT_Parse (void *V_API, char option, unsigned int dim, const char *args) {
+void * GMT_FFT_Parse (void *V_API, char option, unsigned int dim, const char *args) {
 	/* Parse the 1-D or 2-D FFT options such as -N in grdfft */
 	unsigned int n_errors = 0, pos = 0;
 	char p[GMT_BUFSIZ] = {""}, *c = NULL;
@@ -9475,7 +9475,7 @@ void *GMT_FFT_Parse (void *V_API, char option, unsigned int dim, const char *arg
 }
 
 #ifdef FORTRAN_API
-void *GMT_FFT_Parse_ (char *option, unsigned int *dim, char *args, int *length) {
+void * GMT_FFT_Parse_ (char *option, unsigned int *dim, char *args, int *length) {
 	/* Fortran version: We pass the global GMT_FORTRAN structure */
 	return (GMT_FFT_Parse (GMT_FORTRAN, *option, *dim, args));
 }
@@ -9660,7 +9660,7 @@ GMT_LOCAL void gmtapi_fft_taper2d (struct GMT_CTRL *GMT, struct GMT_GRID *Grid, 
 }
 
 /*! . */
-GMT_LOCAL struct GMT_FFT_WAVENUMBER *gmtapi_fft_init_2d (struct GMTAPI_CTRL *API, struct GMT_GRID *G, unsigned int mode, void *v_info) {
+GMT_LOCAL struct GMT_FFT_WAVENUMBER * gmtapi_fft_init_2d (struct GMTAPI_CTRL *API, struct GMT_GRID *G, unsigned int mode, void *v_info) {
 	/* Initialize grid dimensions for FFT machinery and set up wavenumbers */
 	unsigned int k, factors[32];
 	uint64_t node;
@@ -9803,7 +9803,7 @@ GMT_LOCAL struct GMT_FFT_WAVENUMBER *gmtapi_fft_init_2d (struct GMTAPI_CTRL *API
 }
 
 /*! . */
-void *GMT_FFT_Create (void *V_API, void *X, unsigned int dim, unsigned int mode, void *v_info) {
+void * GMT_FFT_Create (void *V_API, void *X, unsigned int dim, unsigned int mode, void *v_info) {
 	/* Initialize 1-D or 2-D FFT machinery and set up wavenumbers */
 	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
 	if (dim == 1) return (gmtapi_fft_init_1d (V_API, X, mode, v_info));
@@ -9813,7 +9813,7 @@ void *GMT_FFT_Create (void *V_API, void *X, unsigned int dim, unsigned int mode,
 }
 
 #ifdef FORTRAN_API
-void *GMT_FFT_Create_ (void *X, unsigned int *dim, unsigned int *mode, void *v_info) {
+void * GMT_FFT_Create_ (void *X, unsigned int *dim, unsigned int *mode, void *v_info) {
 	/* Fortran version: We pass the global GMT_FORTRAN structure */
 	return (GMT_FFT_Create (GMT_FORTRAN, X, *dim, *mode, v_info));
 }
@@ -9845,7 +9845,7 @@ GMT_LOCAL int gmtapi_fft_1d (struct GMTAPI_CTRL *API, struct GMT_DATASET *D, int
 	return (status);
 }
 
-GMT_LOCAL char *gmtapi_fft_file_name_with_suffix (struct GMT_CTRL *GMT, char *name, char *suffix) {
+GMT_LOCAL char * gmtapi_fft_file_name_with_suffix (struct GMT_CTRL *GMT, char *name, char *suffix) {
 	static char file[PATH_MAX] = {""};
 	uint64_t i, j;
 	size_t len;
@@ -10086,7 +10086,7 @@ const char * gmt_show_name_and_purpose (void *V_API, const char *component, cons
 /* Module Extension: Allow listing and calling modules by name */
 
 /*! . */
-GMT_LOCAL void *gmtapi_get_shared_module_func (struct GMTAPI_CTRL *API, const char *module, unsigned int lib_no) {
+GMT_LOCAL void * gmtapi_get_shared_module_func (struct GMTAPI_CTRL *API, const char *module, unsigned int lib_no) {
 	/* Function that returns a pointer to the function named module in specified shared library lib_no, or NULL if not found  */
 	void *p_func = NULL;       /* function pointer */
 	if (API->lib[lib_no].skip) return (NULL);	/* Tried to open this shared library before and it was not available */
@@ -10101,11 +10101,11 @@ GMT_LOCAL void *gmtapi_get_shared_module_func (struct GMTAPI_CTRL *API, const ch
 }
 
 #ifndef BUILD_SHARED_LIBS
-EXTERN_MSC void *gmt_core_module_lookup (struct GMTAPI_CTRL *API, const char *candidate);
+EXTERN_MSC void * gmtapi_core_module_lookup (struct GMTAPI_CTRL *API, const char *candidate);
 #endif
 
 /*! . */
-GMT_LOCAL void *gmtapi_get_module_func (struct GMTAPI_CTRL *API, const char *module, unsigned int lib_no) {
+GMT_LOCAL void * gmtapi_get_module_func (struct GMTAPI_CTRL *API, const char *module, unsigned int lib_no) {
 #ifndef BUILD_SHARED_LIBS
 	if (lib_no == 0)	/* Get core module */
 		return (gmtapi_core_module_lookup (API, module));
@@ -10390,7 +10390,7 @@ GMT_LOCAL bool gmtapi_operator_takes_dataset (struct GMT_OPTION *opt, int *geome
 #define api_not_required_io(key) ((key == API_PRIMARY_INPUT || key == API_SECONDARY_INPUT) ? API_SECONDARY_INPUT : API_SECONDARY_OUTPUT)	/* Returns the optional input or output flag */
 
 /*! . */
-struct GMT_RESOURCE *GMT_Encode_Options (void *V_API, const char *module_name, int n_in, struct GMT_OPTION **head, unsigned int *n) {
+struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, int n_in, struct GMT_OPTION **head, unsigned int *n) {
 	/* This function determines which input sources and output destinations are required given the module options.
 	 * It is only used to assist developers of external APIs, such as the MATLAB, Julia, Python, R, and others.
 	 * "Keys" referred to below is the unique combination given near the top of every module via the macro
@@ -11646,7 +11646,7 @@ int GMT_blind_change_struct(void *V_API, void *ptr, void *what, char *type, size
 
 /* GMT_DATASET to GMT_* : */
 
-GMT_LOCAL void *gmtapi_dataset2dataset (struct GMTAPI_CTRL *API, struct GMT_DATASET *In, struct GMT_DATASET *Out, unsigned int header, unsigned int mode) {
+GMT_LOCAL void * gmtapi_dataset2dataset (struct GMTAPI_CTRL *API, struct GMT_DATASET *In, struct GMT_DATASET *Out, unsigned int header, unsigned int mode) {
 	/* Convert a dataset to another dataset using current formatting and column type information.
 	 * If Out is not NULL then we assume it has exact same dimension as the dataset, but no headers/records allocated.
 	 * header controls what we do with headers.
@@ -11722,7 +11722,7 @@ GMT_LOCAL void *gmtapi_dataset2dataset (struct GMTAPI_CTRL *API, struct GMT_DATA
 	return Out;
 }
 
-GMT_LOCAL void *gmtapi_dataset2matrix (struct GMTAPI_CTRL *API, struct GMT_DATASET *In, struct GMT_MATRIX *Out, unsigned int header, unsigned int mode) {
+GMT_LOCAL void * gmtapi_dataset2matrix (struct GMTAPI_CTRL *API, struct GMT_DATASET *In, struct GMT_MATRIX *Out, unsigned int header, unsigned int mode) {
 	/* Convert a dataset to a matrix.
 	 * If Out is not NULL then we assume it has enough rows and columns to hold the dataset records.
 	 * Header controls if segment headers are written as NaN recs
@@ -11774,7 +11774,7 @@ GMT_LOCAL void *gmtapi_dataset2matrix (struct GMTAPI_CTRL *API, struct GMT_DATAS
 	return Out;
 }
 
-GMT_LOCAL void *gmtapi_dataset2vector (struct GMTAPI_CTRL *API, struct GMT_DATASET *In, struct GMT_VECTOR *Out, unsigned int header, unsigned int mode) {
+GMT_LOCAL void * gmtapi_dataset2vector (struct GMTAPI_CTRL *API, struct GMT_DATASET *In, struct GMT_VECTOR *Out, unsigned int header, unsigned int mode) {
 	/* Convert a dataset to vectors.
 	 * If Out is not NULL then we assume it has enough rows and columns to hold the dataset records.
 	 * If mode > 0 then it is assumed to hold GMT_TYPE-1, else we assume the GMT default setting.
@@ -11817,7 +11817,7 @@ GMT_LOCAL void *gmtapi_dataset2vector (struct GMTAPI_CTRL *API, struct GMT_DATAS
 
 /* GMT_MATRIX to GMT_* : */
 
-GMT_LOCAL void *gmtapi_matrix2dataset (struct GMTAPI_CTRL *API, struct GMT_MATRIX *In, struct GMT_DATASET *Out, unsigned int header) {
+GMT_LOCAL void * gmtapi_matrix2dataset (struct GMTAPI_CTRL *API, struct GMT_MATRIX *In, struct GMT_DATASET *Out, unsigned int header) {
 	/* Convert a matrix to a dataset (one table with one segment).
 	 * If Out is not NULL then we assume it has enough rows and columns to hold the dataset records.
 	 * header controls what we do with headers.
@@ -11845,7 +11845,7 @@ GMT_LOCAL void *gmtapi_matrix2dataset (struct GMTAPI_CTRL *API, struct GMT_MATRI
 	return Out;
 }
 
-GMT_LOCAL void *gmtapi_matrix2vector (struct GMTAPI_CTRL *API, struct GMT_MATRIX *In, struct GMT_VECTOR *Out, unsigned int header, unsigned int mode) {
+GMT_LOCAL void * gmtapi_matrix2vector (struct GMTAPI_CTRL *API, struct GMT_MATRIX *In, struct GMT_VECTOR *Out, unsigned int header, unsigned int mode) {
 	/* Convert a matrix to vectors.
 	 * If Out is not NULL then we assume it has enough rows to hold the vector rows.
 	 * header controls what we do with headers.
@@ -11886,7 +11886,7 @@ GMT_LOCAL void *gmtapi_matrix2vector (struct GMTAPI_CTRL *API, struct GMT_MATRIX
 
 /* GMT_VECTOR to GMT_* : */
 
-GMT_LOCAL void *gmtapi_vector2dataset (struct GMTAPI_CTRL *API, struct GMT_VECTOR *In, struct GMT_DATASET *Out, unsigned int header) {
+GMT_LOCAL void * gmtapi_vector2dataset (struct GMTAPI_CTRL *API, struct GMT_VECTOR *In, struct GMT_DATASET *Out, unsigned int header) {
 	/* Convert a vector to a dataset (one table with one segment).
 	 * header controls what we do with headers.
 	 * If Out is not NULL then we assume it has enough rows and columns to hold the dataset records.
@@ -11913,7 +11913,7 @@ GMT_LOCAL void *gmtapi_vector2dataset (struct GMTAPI_CTRL *API, struct GMT_VECTO
 	return Out;
 }
 
-GMT_LOCAL void *gmtapi_vector2matrix (struct GMTAPI_CTRL *API, struct GMT_VECTOR *In, struct GMT_MATRIX *Out, unsigned int header, unsigned int mode) {
+GMT_LOCAL void * gmtapi_vector2matrix (struct GMTAPI_CTRL *API, struct GMT_VECTOR *In, struct GMT_MATRIX *Out, unsigned int header, unsigned int mode) {
 	/* Convert a vector to a matrix.
 	 * If Out is not NULL then we assume it has enough rows to hold the rows.
 	 * header controls what we do with headers.
@@ -11960,7 +11960,7 @@ GMT_LOCAL void *gmtapi_vector2matrix (struct GMTAPI_CTRL *API, struct GMT_VECTOR
 #define GMT_TYPE_MODE	1
 #define GMT_FORMAT_MODE	1	/* Same as GMT_TYPE_MODE [not a typo] */
 
-void *GMT_Convert_Data (void *V_API, void *In, unsigned int family_in, void *Out, unsigned int family_out, unsigned int flag[]) {
+void * GMT_Convert_Data (void *V_API, void *In, unsigned int family_in, void *Out, unsigned int family_out, unsigned int flag[]) {
 	/* Convert between valid pairs of objects,  If Out == NULL then we allocate an output object,
 	 * otherwise we assume we are given adequate space already.  This is most likely restricted to a GMT_MATRIX.
 	 * flag is an array with two unsigned integers controlling various aspects of the conversion:
@@ -12058,13 +12058,13 @@ void *GMT_Convert_Data (void *V_API, void *In, unsigned int family_in, void *Out
 }
 
 #ifdef FORTRAN_API
-void *GMT_Convert_Data_ (void *In, unsigned int *family_in, void *Out, unsigned int *family_out, unsigned int flag[]) {
+void * GMT_Convert_Data_ (void *In, unsigned int *family_in, void *Out, unsigned int *family_out, unsigned int flag[]) {
 	/* Fortran version: We pass the global GMT_FORTRAN structure */
 	return (GMT_Convert_Data (GMT_FORTRAN, In, *family_in, Out, *family_out, flag));
 }
 #endif
 
-void *GMT_Alloc_Segment (void *V_API, unsigned int mode, uint64_t n_rows, uint64_t n_columns, char *header, void *S) {
+void * GMT_Alloc_Segment (void *V_API, unsigned int mode, uint64_t n_rows, uint64_t n_columns, char *header, void *S) {
 	/* Allocate or reallocate a GMT_DATASEGMENT.
 	 * The n_columns may be 0 if no numerical data in the segment.
 	 * header, if not NULL or blank, sets the segment header.
@@ -12099,7 +12099,7 @@ void *GMT_Alloc_Segment (void *V_API, unsigned int mode, uint64_t n_rows, uint64
 }
 
 #ifdef FORTRAN_API
-void *GMT_Alloc_Segment_ (unsigned int *family, uint64_t *n_rows, uint64_t *n_columns, char *header, void *S, int len) {
+void * GMT_Alloc_Segment_ (unsigned int *family, uint64_t *n_rows, uint64_t *n_columns, char *header, void *S, int len) {
 	/* Fortran version: We pass the global GMT_FORTRAN structure */
 	return (GMT_Alloc_Segment (GMT_FORTRAN, *family, *n_rows, *n_columns, header, S));
 }
@@ -12365,7 +12365,7 @@ int GMT_Put_Vector_ (struct GMT_VECTOR *V, unsigned int *col, unsigned int *type
 }
 #endif
 
-void *GMT_Get_Vector (void *API, struct GMT_VECTOR *V, unsigned int col) {
+void * GMT_Get_Vector (void *API, struct GMT_VECTOR *V, unsigned int col) {
 	/* Returns a pointer to the specified column array. Users can consult
 	 * V->type[col] to know what data type is pointed to.  */
 	void *vector = NULL;
@@ -12433,7 +12433,7 @@ int GMT_Put_Matrix_ (struct GMT_MATRIX *M, unsigned int *type, int *pad, void *m
 }
 #endif
 
-void *GMT_Get_Matrix (void *API, struct GMT_MATRIX *M) {
+void * GMT_Get_Matrix (void *API, struct GMT_MATRIX *M) {
 	/* Returns a pointer to the matrix.  Users can consult
 	 * M->type to know what data type is pointed to.  */
 	void *matrix = NULL;
@@ -12740,7 +12740,7 @@ float GMT_Get_Version (void *API, unsigned int *major, unsigned int *minor, unsi
 	return major_loc + (float)minor_loc / 10;
 }
 
-void *GMT_Get_Ctrl (void *V_API) {
+void * GMT_Get_Ctrl (void *V_API) {
 	/* For external environments that need to get the GMT pointer for calling
 	 * lower-level GMT library functions that expects the GMT pointer */
 	struct GMTAPI_CTRL *API = NULL;

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -30,14 +30,14 @@
  * There are 2 public functions used for GMT API session handling.
  * This part of the API helps the developer create and delete GMT sessions:
  *
- * GMT_Create_Session	  : Initialize a new GMT session
- * GMT_Destroy_Session	  : Destroy a GMT session
+ * GMT_Create_Session	   : Initialize a new GMT session
+ * GMT_Destroy_Session	   : Destroy a GMT session
  *
  * There is 2 public functions for common error reporting.
  * Errors will be reported to stderr or selected log file:
  *
- * GMT_Message		      : Report an message given a verbosity level
- * GMT_Report		      : Report an error given an error code
+ * GMT_Message		       : Report an message given a verbosity level
+ * GMT_Report		       : Report an error given an error code
  *
  * There are 31 further public functions used for GMT i/o activities:
  *
@@ -52,7 +52,7 @@
  * GMT_Get_Info            : Get meta-data from the object passed
  * GMT_Get_Record          : Get the next single data record from the source(s)
  * GMT_Get_Row             : Read one row from a grid
- * GMT_Get_Status          : Exmine current status of record-by-record i/o
+ * GMT_Get_Status          : Examine current status of record-by-record i/o
  * GMT_Get_Matrix          : Get user matrix from GMT_MATRIX array
  * GMT_Get_Vector          : Get user vector from GMT_VECTOR column
  * GMT_Put_Strings         : Get user strings from GMT_VECTOR or MATRIX container
@@ -73,7 +73,7 @@
  * GMT_Write_Data          : Place data set from program memory to selected destination
  * GMT_Encode_Options      : Used by external APIs to fill out options from implicit rules
 
- * The above 29 functions deal with registration of input sources (files,
+ * The above functions deal with registration of input sources (files,
  * streams, file handles, or memory locations) and output destinations
  * (same flavors as input), the setup of the i/o, and generic functions
  * to access the data either in one go (GMT_Get|Put_Data) or on a
@@ -82,42 +82,42 @@
  *
  * There are 6 functions that deal with options, defaults and arguments:
  *
- * GMT_Get_Common	      : Checks for and returns values for GMT common options
- * GMT_Get_Default	      : Return the value of a GMT parameter as a string
- * GMT_Get_Enum               : Return the integer constant of a GMT API enum.
- * GMT_Get_Values	      : Convert string to one or more coordinates or dimensions
- * GMT_Set_Default	      : Set a GMT parameter via a strings
- * GMT_Option		      : Display syntax for one or more GMT common options
+ * GMT_Get_Common          : Checks for and returns values for GMT common options
+ * GMT_Get_Default         : Return the value of a GMT parameter as a string
+ * GMT_Get_Enum            : Return the integer constant of a GMT API enum.
+ * GMT_Get_Values          : Convert string to one or more coordinates or dimensions
+ * GMT_Set_Default         : Set a GMT parameter via a strings
+ * GMT_Option              : Display syntax for one or more GMT common options
  *
  * One function handles the listing of modules and the calling of any GMT module:
  *
- * GMT_Call_Module		  : Call the specified GMT module
+ * GMT_Call_Module         : Call the specified GMT module
  *
  * Four functions are used to get grid index from row, col, and to obtain coordinates
  *
- * GMT_Get_Coord	      : Return array of coordinates for one dimension
- * GMT_Get_Index	      : Return 1-D grid index given row, col
- * GMT_Get_Pixel	      : Return 1-D image index given row, col, layer
- * GMT_Set_Columns            : Specify number of output columns for rec-by-rec writing
+ * GMT_Get_Coord           : Return array of coordinates for one dimension
+ * GMT_Get_Index           : Return 1-D grid index given row, col
+ * GMT_Get_Pixel           : Return 1-D image index given row, col, layer
+ * GMT_Set_Columns         : Specify number of output columns for rec-by-rec writing
  *
  * For FFT operations there are 8 additional API functions:
  *
- * GMT_FFT                    : Call the forward or inverse FFT
- * GMT_FFT_1D		      : Lower-level 1-D FFT call
- * GMT_FFT_2D		      : Lower-level 2-D FFT call
- * GMT_FFT_Create	      : Initialize the FFT machinery for given dimension
- * GMT_FFT_Destroy	      : Destroy FFT machinery
- * GMT_FFT_Option	      : Display the syntax of the GMT FFT option settings
- * GMT_FFT_Parse	      : Parse the GMT FFT option
- * GMT_FFT_Wavenumber         : Return selected wavenumber given its type
+ * GMT_FFT                 : Call the forward or inverse FFT
+ * GMT_FFT_1D              : Lower-level 1-D FFT call
+ * GMT_FFT_2D              : Lower-level 2-D FFT call
+ * GMT_FFT_Create          : Initialize the FFT machinery for given dimension
+ * GMT_FFT_Destroy         : Destroy FFT machinery
+ * GMT_FFT_Option          : Display the syntax of the GMT FFT option settings
+ * GMT_FFT_Parse           : Parse the GMT FFT option
+ * GMT_FFT_Wavenumber      : Return selected wavenumber given its type
  *
  * There are also 13 functions for argument and option parsing.  See gmt_parse.c for these.
  *
  * Finally, three low-level F77-callable functions for grid i/o are given:
  *
- * gmt_f77_readgrdinfo_   : Read the header of a GMT grid
- * gmt_f77_readgrd_       : Read a GMT grid from file
- * gmt_f77_writegrd_      : Write a GMT grid to file
+ * gmt_f77_readgrdinfo_    : Read the header of a GMT grid
+ * gmt_f77_readgrd_        : Read a GMT grid from file
+ * gmt_f77_writegrd_       : Write a GMT grid to file
  *
  * --------------------------------------------------------------------------------------------
  * Guru notes on memory management: Paul Wessel, June 2013.

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -435,7 +435,7 @@ GMT_LOCAL double * gmtapi_grid_coord (struct GMTAPI_CTRL *API, int dim, struct G
 }
 
 /*! . */
-GMT_LOCAL int gmtgmtapi_alloc_grid_xy (struct GMTAPI_CTRL *API, struct GMT_GRID *G) {
+GMT_LOCAL int gmtapi_alloc_grid_xy (struct GMTAPI_CTRL *API, struct GMT_GRID *G) {
 	/* Use information in Grid header to allocate the grid x/y vectors.
 	 * We assume gmtgrdio_init_grdheader has been called. */
 	if (G == NULL) return (GMT_PTR_IS_NULL);
@@ -467,7 +467,7 @@ GMT_LOCAL double * gmtapi_image_coord (struct GMTAPI_CTRL *API, int dim, struct 
 }
 
 /*! . */
-GMT_LOCAL int gmtgmtapi_alloc_image_xy (struct GMTAPI_CTRL *API, struct GMT_IMAGE *I) {
+GMT_LOCAL int gmtapi_alloc_image_xy (struct GMTAPI_CTRL *API, struct GMT_IMAGE *I) {
 	/* Use information in Grid header to allocate the image x,y vectors.
 	 * We assume gmtgrdio_init_grdheader has been called. */
 	if (I == NULL) return (GMT_PTR_IS_NULL);
@@ -505,27 +505,27 @@ GMT_LOCAL unsigned int gmtapi_gmtry (unsigned int geometry) {
  * This needs to be done on a per data-type basis, e.g., to cast that void * to a struct GMT_GRID **
  * so we may return the value at that address: */
 
-GMT_LOCAL inline struct GMTAPI_CTRL * api_get_api_ptr     (struct GMTAPI_CTRL *ptr)  {return (ptr);}
-GMT_LOCAL inline struct GMT_PALETTE * api_get_cpt_ptr     (struct GMT_PALETTE **ptr) {return (*ptr);}
+GMT_LOCAL inline struct GMTAPI_CTRL * gmtapi_get_api_ptr     (struct GMTAPI_CTRL *ptr)  {return (ptr);}
+GMT_LOCAL inline struct GMT_PALETTE * gmtapi_get_cpt_ptr     (struct GMT_PALETTE **ptr) {return (*ptr);}
 GMT_LOCAL inline struct GMT_DATASET * gmtapi_get_dataset_ptr (struct GMT_DATASET **ptr) {return (*ptr);}
-GMT_LOCAL inline struct GMT_GRID    * api_get_grid_ptr    (struct GMT_GRID **ptr)    {return (*ptr);}
-GMT_LOCAL inline struct GMT_POSTSCRIPT      * api_get_ps_ptr      (struct GMT_POSTSCRIPT **ptr)      {return (*ptr);}
-GMT_LOCAL inline struct GMT_MATRIX  * api_get_matrix_ptr  (struct GMT_MATRIX **ptr)  {return (*ptr);}
-GMT_LOCAL inline struct GMT_VECTOR  * api_get_vector_ptr  (struct GMT_VECTOR **ptr)  {return (*ptr);}
+GMT_LOCAL inline struct GMT_GRID    * gmtapi_get_grid_ptr    (struct GMT_GRID **ptr)    {return (*ptr);}
+GMT_LOCAL inline struct GMT_POSTSCRIPT      * gmtapi_get_ps_ptr      (struct GMT_POSTSCRIPT **ptr)      {return (*ptr);}
+GMT_LOCAL inline struct GMT_MATRIX  * gmtapi_get_matrix_ptr  (struct GMT_MATRIX **ptr)  {return (*ptr);}
+GMT_LOCAL inline struct GMT_VECTOR  * gmtapi_get_vector_ptr  (struct GMT_VECTOR **ptr)  {return (*ptr);}
 GMT_LOCAL inline double      	    * gmtapi_get_coord_ptr   (double **ptr)             {return (*ptr);}
-GMT_LOCAL inline struct GMT_IMAGE   * api_get_image_ptr (struct GMT_IMAGE **ptr) {return (*ptr);}
+GMT_LOCAL inline struct GMT_IMAGE   * gmtapi_get_image_ptr (struct GMT_IMAGE **ptr) {return (*ptr);}
 /* Various inline functs to convert void pointer to specific type */
-GMT_LOCAL inline struct GMT_GRID_ROWBYROW * api_get_rbr_ptr (struct GMT_GRID_ROWBYROW *ptr) {return (ptr);}
-GMT_LOCAL inline struct GMT_FFT_INFO * api_get_fftinfo_ptr (struct GMT_FFT_INFO *ptr) {return (ptr);}
-GMT_LOCAL inline struct GMT_FFT_WAVENUMBER * api_get_fftwave_ptr (struct GMT_FFT_WAVENUMBER *ptr) {return (ptr);}
-GMT_LOCAL inline struct GMT_FFT_WAVENUMBER ** api_get_fftwave_addr (struct GMT_FFT_WAVENUMBER **ptr) {return (ptr);}
-GMT_LOCAL inline struct GMT_GRID    * api_get_grid_data (struct GMT_GRID *ptr) {return (ptr);}
-GMT_LOCAL inline struct GMT_IMAGE   * api_get_image_data (struct GMT_IMAGE *ptr) {return (ptr);}
+GMT_LOCAL inline struct GMT_GRID_ROWBYROW * gmtapi_get_rbr_ptr (struct GMT_GRID_ROWBYROW *ptr) {return (ptr);}
+GMT_LOCAL inline struct GMT_FFT_INFO * gmtapi_get_fftinfo_ptr (struct GMT_FFT_INFO *ptr) {return (ptr);}
+GMT_LOCAL inline struct GMT_FFT_WAVENUMBER * gmtapi_get_fftwave_ptr (struct GMT_FFT_WAVENUMBER *ptr) {return (ptr);}
+GMT_LOCAL inline struct GMT_FFT_WAVENUMBER ** gmtapi_get_fftwave_addr (struct GMT_FFT_WAVENUMBER **ptr) {return (ptr);}
+GMT_LOCAL inline struct GMT_GRID    * gmtapi_get_grid_data (struct GMT_GRID *ptr) {return (ptr);}
+GMT_LOCAL inline struct GMT_IMAGE   * gmtapi_get_image_data (struct GMT_IMAGE *ptr) {return (ptr);}
 GMT_LOCAL inline struct GMT_DATASET * gmtapi_get_dataset_data (struct GMT_DATASET *ptr) {return (ptr);}
-GMT_LOCAL inline struct GMT_VECTOR  * api_get_vector_data (struct GMT_VECTOR *ptr) {return (ptr);}
-GMT_LOCAL inline struct GMT_MATRIX  * api_get_matrix_data (struct GMT_MATRIX *ptr) {return (ptr);}
-GMT_LOCAL inline struct GMT_POSTSCRIPT  * api_get_postscript_data (struct GMT_POSTSCRIPT *ptr) {return (ptr);}
-GMT_LOCAL inline struct GMT_PALETTE  * api_get_palette_data (struct GMT_PALETTE *ptr) {return (ptr);}
+GMT_LOCAL inline struct GMT_VECTOR  * gmtapi_get_vector_data (struct GMT_VECTOR *ptr) {return (ptr);}
+GMT_LOCAL inline struct GMT_MATRIX  * gmtapi_get_matrix_data (struct GMT_MATRIX *ptr) {return (ptr);}
+GMT_LOCAL inline struct GMT_POSTSCRIPT  * gmtapi_get_postscript_data (struct GMT_POSTSCRIPT *ptr) {return (ptr);}
+GMT_LOCAL inline struct GMT_PALETTE  * gmtapi_get_palette_data (struct GMT_PALETTE *ptr) {return (ptr);}
 
 /*! If API is not set or do_not_exit is false then we call system exit, else we move along.
  * This is required for some external interfaces where calling exit would bring down the
@@ -539,14 +539,14 @@ GMT_LOCAL inline void gmtapi_exit (struct GMTAPI_CTRL *API, int code) {
 GMT_LOCAL void *gmtapi_return_address (void *data, unsigned int type) {
 	void *p = NULL;
 	switch (type) {
-		case GMT_IS_GRID:	p = api_get_grid_ptr (data);	break;
+		case GMT_IS_GRID:	p = gmtapi_get_grid_ptr (data);	break;
 		case GMT_IS_DATASET:	p = gmtapi_get_dataset_ptr (data);	break;
-		case GMT_IS_PALETTE:	p = api_get_cpt_ptr (data);	break;
-		case GMT_IS_POSTSCRIPT:	p = api_get_ps_ptr (data);	break;
-		case GMT_IS_MATRIX:	p = api_get_matrix_ptr (data);	break;
-		case GMT_IS_VECTOR:	p = api_get_vector_ptr (data);	break;
+		case GMT_IS_PALETTE:	p = gmtapi_get_cpt_ptr (data);	break;
+		case GMT_IS_POSTSCRIPT:	p = gmtapi_get_ps_ptr (data);	break;
+		case GMT_IS_MATRIX:	p = gmtapi_get_matrix_ptr (data);	break;
+		case GMT_IS_VECTOR:	p = gmtapi_get_vector_ptr (data);	break;
 		case GMT_IS_COORD:	p = gmtapi_get_coord_ptr (data);	break;
-		case GMT_IS_IMAGE:	p = api_get_image_ptr (data);	break;
+		case GMT_IS_IMAGE:	p = gmtapi_get_image_ptr (data);	break;
 	}
 	return (p);
 }
@@ -1285,7 +1285,7 @@ GMT_LOCAL char ** gmtapi_process_keys (void *V_API, const char *string, char typ
 	bool change_type = false;
 	char **s = NULL, *next = NULL, *tmp = NULL, magic = 0, revised[GMT_LEN64] = {""};
 	struct GMT_OPTION *opt = NULL;
-	struct GMTAPI_CTRL *API = api_get_api_ptr (V_API);
+	struct GMTAPI_CTRL *API = gmtapi_get_api_ptr (V_API);
 
 	*n_items = 0;	/* No keys yet */
 
@@ -1519,7 +1519,7 @@ GMT_LOCAL void *gmtapi_retrieve_data (void *V_API, int object_ID) {
 	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
 
 	/* Determine the item in the object list that matches this object_ID */
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	if ((item = gmtapi_validate_id (API, GMT_NOTSET, object_ID, GMT_NOTSET, GMT_NOTSET)) == GMT_NOTSET) {
 		return_null (API, API->error);
@@ -1983,7 +1983,7 @@ GMT_LOCAL int gmtapi_open_grd (struct GMT_CTRL *GMT, char *file, struct GMT_GRID
 	char *fmt = NULL;
 	struct GMT_GRID_HIDDEN *GH = gmt_get_G_hidden (G);
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (G->header);
-	struct GMT_GRID_ROWBYROW *R = api_get_rbr_ptr (GH->extra);	/* Shorthand to row-by-row book-keeping structure */
+	struct GMT_GRID_ROWBYROW *R = gmtapi_get_rbr_ptr (GH->extra);	/* Shorthand to row-by-row book-keeping structure */
 
 	if (mode == 'r' || mode == 'R') {	/* Open file for reading */
 		if (mode == 'R') {	/* File has no header; can only work if G->header has been set already, somehow */
@@ -2043,7 +2043,7 @@ GMT_LOCAL int gmtapi_open_grd (struct GMT_CTRL *GMT, char *file, struct GMT_GRID
 #endif
 	}
 
-	R->size = gmt_grd_data_size (GMT, G->header->type, &G->header->nan_value);
+	R->size = gmtlib_grd_data_size (GMT, G->header->type, &G->header->nan_value);
 	R->check = !isnan (G->header->nan_value);
 	R->open = true;
 
@@ -2346,7 +2346,7 @@ GMT_LOCAL int gmtapi_next_io_source (struct GMTAPI_CTRL *API, unsigned int direc
 	GMT->current.io.rec_in_tbl_no = 0;	/* Start on new table */
 	if (direction == GMT_IN) API->current_get_obj = S_obj;
 	if (S_obj->geometry == GMT_IS_TEXT) {	/* Reading pure text, no coordinates */
-		S_obj->import = &gmtio_ascii_textinput;
+		S_obj->import = &gmtlib_ascii_textinput;
 		GMT->current.io.record.data = NULL;	/* Since there isn't any data */
 	}
 	else
@@ -2470,7 +2470,7 @@ GMT_LOCAL void *gmtapi_pass_object (struct GMTAPI_CTRL *API, struct GMTAPI_DATA_
 			if (data) gmtlib_init_cpt (API->GMT, data);
 			break;
 		case GMT_IS_GRID:	/* Grids need to update the grdtype setting, possibly rotate geographic grids, and maybe deal with subsets */
-			G = api_get_grid_data (data);	/* Get the right grid pointer */
+			G = gmtapi_get_grid_data (data);	/* Get the right grid pointer */
 			HH = gmt_get_H_hidden (G->header);
 			gmtlib_grd_get_units (API->GMT, G->header);	/* Set the unit names */
 			HH->grdtype = gmtlib_get_grdtype (API->GMT, GMT_IN, G->header);
@@ -2500,7 +2500,7 @@ GMT_LOCAL void *gmtapi_pass_object (struct GMTAPI_CTRL *API, struct GMTAPI_DATA_
 				return_null (API, GMT_GRID_BC_ERROR);	/* Failed to set boundary conditions */
 			break;
 		case GMT_IS_IMAGE:	/* Images need to update the grdtype setting, possibly rotate geographic grids, and maybe deal with subsets */
-			I = api_get_image_data (data);	/* Get the right image pointer */
+			I = gmtapi_get_image_data (data);	/* Get the right image pointer */
 			HH = gmt_get_H_hidden (I->header);
 			gmtlib_grd_get_units (API->GMT, I->header);	/* Set the unit names */
 			HH->grdtype = gmtlib_get_grdtype (API->GMT, GMT_IN, I->header);
@@ -2543,11 +2543,11 @@ GMT_LOCAL void *gmtapi_pass_object (struct GMTAPI_CTRL *API, struct GMTAPI_DATA_
 }
 
 /*! . */
-GMT_LOCAL int gmtgmtapi_get_object_id_from_data_ptr (struct GMTAPI_CTRL *API, void *ptr) {
+GMT_LOCAL int gmtapi_get_object_id_from_data_ptr (struct GMTAPI_CTRL *API, void *ptr) {
 	/* Returns the ID of the first object whose data pointer matches *ptr.
  	 * This is necessary since many objects may have the same pointer
 	 * but we only want to destroy the memory once.  This function is
-	 * only used in GMT_Destroy_Data and gmtlib_is_an_object.
+	 * only used in GMT_Destroy_Data and gmt_is_an_object.
 	 */
 	unsigned int item;
 	int object_ID = GMT_NOTSET;	/* Not found yet */
@@ -2565,9 +2565,9 @@ GMT_LOCAL int gmtgmtapi_get_object_id_from_data_ptr (struct GMTAPI_CTRL *API, vo
 }
 
 /*! . */
-bool gmtlib_is_an_object (struct GMT_CTRL *GMT, void *ptr) {
+bool gmt_is_an_object (struct GMT_CTRL *GMT, void *ptr) {
 	/* Needed by g*math.c so exported as part of the gmt_dev library */
-	return (gmtgmtapi_get_object_id_from_data_ptr (GMT->parent, ptr) == GMT_NOTSET) ? false : true;
+	return (gmtapi_get_object_id_from_data_ptr (GMT->parent, ptr) == GMT_NOTSET) ? false : true;
 }
 
 /*! Determine if resource is a filename that has already been registered */
@@ -2607,7 +2607,7 @@ GMT_LOCAL int gmtapi_is_registered (struct GMTAPI_CTRL *API, int family, int geo
 			if (family == GMT_IS_GRID && (mode & GMT_DATA_ONLY)) {	/* Requesting data only means we already did the header so OK to reset status */
 				if (mode & GMT_GRID_IS_COMPLEX_MASK) {	/* Complex grids are read in stages so handled separately */
 					/* Check if complex grid already has one layer and that we are reading the next layer */
-					struct GMT_GRID *G = api_get_grid_data (resource);	/* Get pointer to this grid */
+					struct GMT_GRID *G = gmtapi_get_grid_data (resource);	/* Get pointer to this grid */
 					unsigned int cmplx = mode & GMT_GRID_IS_COMPLEX_MASK;
 					if (G->header->complex_mode & GMT_GRID_IS_COMPLEX_MASK && G->header->complex_mode != cmplx && filename) {
 						/* Apparently so, either had real and now getting imag, or vice versa. */
@@ -3553,7 +3553,7 @@ GMT_LOCAL void gmtapi_increment_d (struct GMT_DATASET *D_obj, uint64_t n_rows, u
 }
 
 /*! . */
-GMT_LOCAL struct GMT_DATASET *gmtgmtapi_import_dataset (struct GMTAPI_CTRL *API, int object_ID, unsigned int mode) {
+GMT_LOCAL struct GMT_DATASET *gmtapi_import_dataset (struct GMTAPI_CTRL *API, int object_ID, unsigned int mode) {
 	/* Does the actual work of loading in the entire virtual data set (possibly via many sources)
 	 * If object_ID == GMT_NOTSET we get all registered input tables, otherwise we just get the one requested.
 	 * Note: Memory is allocated for the Dataset except for method GMT_IS_REFERENCE.
@@ -3577,7 +3577,7 @@ GMT_LOCAL struct GMT_DATASET *gmtgmtapi_import_dataset (struct GMTAPI_CTRL *API,
 	struct GMTAPI_DATA_OBJECT *S_obj = NULL;
 	struct GMT_CTRL *GMT = API->GMT;
 
-	GMT_Report (API, GMT_MSG_DEBUG, "gmtgmtapi_import_dataset: Passed ID = %d and mode = %d\n", object_ID, mode);
+	GMT_Report (API, GMT_MSG_DEBUG, "gmtapi_import_dataset: Passed ID = %d and mode = %d\n", object_ID, mode);
 
 	if (object_ID == GMT_NOTSET) {	/* Means there is more than one source: Merge all registered data tables into a single virtual data set */
 		last_item = API->n_objects - 1;	/* Must check all registered objects */
@@ -3605,7 +3605,7 @@ GMT_LOCAL struct GMT_DATASET *gmtgmtapi_import_dataset (struct GMTAPI_CTRL *API,
 	for (item = first_item; item <= last_item; item++) {	/* Look through all sources for registered inputs (or just one) */
 		S_obj = API->object[item];	/* S_obj is the current data object */
 		if (!S_obj) {	/* Probably not a good sign. NOTE: Probably cannot happen since skipped in api_next_source, no? */
-			GMT_Report (API, GMT_MSG_DEBUG, "gmtgmtapi_import_dataset: Skipped empty object (item = %d)\n", item);
+			GMT_Report (API, GMT_MSG_DEBUG, "gmtapi_import_dataset: Skipped empty object (item = %d)\n", item);
 			continue;
 		}
 		if (!S_obj->selected) continue;			/* Registered, but not selected */
@@ -3967,7 +3967,7 @@ GMT_LOCAL int gmtapi_destroy_data_ptr (struct GMTAPI_CTRL *API, enum GMT_enum_fa
 }
 
 /*! . */
-GMT_LOCAL int gmtgmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, unsigned int mode, struct GMT_DATASET *D_obj) {
+GMT_LOCAL int gmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, unsigned int mode, struct GMT_DATASET *D_obj) {
  	/* Does the actual work of writing out the specified data set to a single destination.
 	 * If object_ID == GMT_NOTSET we use the first registered output destination, otherwise we just use the one specified.
 	 * See the GMT API documentation for how mode is used to create multiple files from segments or tables of a dataset.
@@ -3990,7 +3990,7 @@ GMT_LOCAL int gmtgmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, 
 	void *ptr = NULL;
 	GMT_putfunction api_put_val = NULL;
 
-	GMT_Report (API, GMT_MSG_DEBUG, "gmtgmtapi_export_dataset: Passed ID = %d and mode = %d\n", object_ID, mode);
+	GMT_Report (API, GMT_MSG_DEBUG, "gmtapi_export_dataset: Passed ID = %d and mode = %d\n", object_ID, mode);
 
 	if (object_ID == GMT_NOTSET) return (gmtapi_report_error (API, GMT_OUTPUT_NOT_SET));
 	if ((item = gmtapi_validate_id (API, GMT_IS_DATASET, object_ID, GMT_OUT, GMT_NOTSET)) == GMT_NOTSET) return (gmtapi_report_error (API, API->error));
@@ -5033,7 +5033,7 @@ GMT_LOCAL int gmtapi_export_grid (struct GMTAPI_CTRL *API, int object_ID, unsign
 	 	case GMT_IS_DUPLICATE|GMT_VIA_MATRIX:	/* The user's 2-D grid array of some sort, + info in the args [NOT FULLY TESTED] */
 			if (mode & GMT_CONTAINER_ONLY) return (gmtapi_report_error (API, GMT_NOT_A_VALID_MODE));
 			if (S_obj->resource) {	/* The output resource pointer already exist for matrix */
-				M_obj = api_get_matrix_data (S_obj->resource);
+				M_obj = gmtapi_get_matrix_data (S_obj->resource);
 				if (M_obj->n_rows < G_obj->header->n_rows || M_obj->n_columns < G_obj->header->n_columns)
 					return (gmtapi_report_error (API, GMT_DIM_TOO_SMALL));
 			}
@@ -5065,7 +5065,7 @@ GMT_LOCAL int gmtapi_export_grid (struct GMTAPI_CTRL *API, int object_ID, unsign
 			if (mode & GMT_GRID_IS_COMPLEX_MASK)	/* Cannot do a complex grid this way */
 				return (gmtapi_report_error (API, GMT_NOT_A_VALID_IO_ACCESS));
 			if (S_obj->resource) {	/* The output resource pointer already exist for matrix */
-				M_obj = api_get_matrix_data (S_obj->resource);
+				M_obj = gmtapi_get_matrix_data (S_obj->resource);
 				if (M_obj->n_rows < G_obj->header->n_rows || M_obj->n_columns < G_obj->header->n_columns)
 					return (gmtapi_report_error (API, GMT_DIM_TOO_SMALL));
 				assert (M_obj->type == GMT_GRDFLOAT);	/* That is the whole point of getting here, no? */
@@ -5136,7 +5136,7 @@ GMT_LOCAL void *gmtapi_import_data (struct GMTAPI_CTRL *API, enum GMT_enum_famil
 			new_obj = gmtapi_import_palette (API, object_ID, mode);		/* Try to import a CPT */
 			break;
 		case GMT_IS_DATASET:
-			new_obj = gmtgmtapi_import_dataset (API, object_ID, mode);		/* Try to import data tables */
+			new_obj = gmtapi_import_dataset (API, object_ID, mode);		/* Try to import data tables */
 			break;
 		case GMT_IS_GRID:
 			new_obj = gmtapi_import_grid (API, object_ID, mode, data);	/* Try to import a grid */
@@ -5177,7 +5177,7 @@ GMT_LOCAL void *gmtapi_get_data (void *V_API, int object_ID, unsigned int mode, 
 	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
 
 	/* Determine the item in the object list that matches this ID and direction */
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	if (object_ID == GMT_NOTSET) {	/* Must pick up the family from the shelf */
 		family = API->shelf;
@@ -5284,7 +5284,7 @@ GMT_LOCAL int gmtapi_export_data (struct GMTAPI_CTRL *API, enum GMT_enum_family 
 			error = gmtapi_export_palette (API, object_ID, mode, data);
 			break;
 		case GMT_IS_DATASET:	/* Export a Data set */
-			error = gmtgmtapi_export_dataset (API, object_ID, mode, data);
+			error = gmtapi_export_dataset (API, object_ID, mode, data);
 			break;
 		case GMT_IS_GRID:	/* Export a GMT grid */
 			error = gmtapi_export_grid (API, object_ID, mode, data);
@@ -5330,7 +5330,7 @@ GMT_LOCAL int gmtapi_put_data (void *V_API, int object_ID, unsigned int mode, vo
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	if (data == NULL) return_error (V_API, GMT_PTR_IS_NULL);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 
 	/* Determine the item in the object list that matches this ID and direction */
@@ -5836,7 +5836,7 @@ int gmtapi_report_error (void *V_API, int error) {
 	FILE *fp = NULL;
 	bool report;
 	char message[GMT_LEN256];
-	struct GMTAPI_CTRL *API = api_get_api_ptr (V_API);
+	struct GMTAPI_CTRL *API = gmtapi_get_api_ptr (V_API);
 
 	report = (API) ? API->error != API->last_error : true;
 	if (report && error != GMT_NOERROR) {	/* Report error */
@@ -5983,7 +5983,7 @@ char *gmtapi_create_header_item (struct GMTAPI_CTRL *API, unsigned int mode, voi
 /*! . */
 void gmtapi_close_grd (struct GMT_CTRL *GMT, struct GMT_GRID *G) {
 	struct GMT_GRID_HIDDEN *GH = gmt_get_G_hidden (G);
-	struct GMT_GRID_ROWBYROW *R = api_get_rbr_ptr (GH->extra);	/* Shorthand to row-by-row book-keeping structure */
+	struct GMT_GRID_ROWBYROW *R = gmtapi_get_rbr_ptr (GH->extra);	/* Shorthand to row-by-row book-keeping structure */
 	gmt_M_free (GMT, R->v_row);
 	if (GMT->session.grdformat[G->header->type][0] == 'c' || GMT->session.grdformat[G->header->type][0] == 'n')
 		nc_close (R->fid);
@@ -6119,7 +6119,7 @@ int GMT_Destroy_Session (void *V_API) {
 
 	unsigned int i;
 	char *module = NULL;
-	struct GMTAPI_CTRL *API = api_get_api_ptr (V_API);
+	struct GMTAPI_CTRL *API = gmtapi_get_api_ptr (V_API);
 
 	if (API == NULL) return_error (API, GMT_NOT_A_SESSION);	/* GMT_Create_Session has not been called */
 	API->error = GMT_NOERROR;
@@ -6315,7 +6315,7 @@ int GMT_Register_IO (void *V_API, unsigned int family, unsigned int method, unsi
 	struct GMT_CTRL *GMT = NULL;
 
 	if (V_API == NULL) return_value (V_API, GMT_NOT_A_SESSION, GMT_NOTSET);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;	/* Reset in case it has some previous error */
 	module_input = (family & GMT_VIA_MODULE_INPUT);	/* Are we registering a resource that is a module input? */
 	family -= module_input;
@@ -6464,7 +6464,7 @@ int GMT_Init_IO (void *V_API, unsigned int family, unsigned int geometry, unsign
 	struct GMTAPI_CTRL *API = NULL;
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;	/* Reset in case it has some previous error */
 	if (gmtapi_validate_geometry (API, family, geometry)) return_error (API, GMT_BAD_GEOMETRY);
 	if (!(direction == GMT_IN || direction == GMT_OUT)) return_error (API, GMT_NOT_A_VALID_DIRECTION);
@@ -6653,7 +6653,7 @@ int GMT_End_IO (void *V_API, unsigned int direction, unsigned int mode) {
 	if (!(direction == GMT_IN || direction == GMT_OUT)) return_error (V_API, GMT_NOT_A_VALID_DIRECTION);
 	if (mode > GMT_IO_UNREG) return_error (V_API, GMT_NOT_A_VALID_IO_MODE);
 
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	gmtlib_free_ogr (API->GMT, &(API->GMT->current.io.OGR), 0);	/* Free segment-related array */
 	if (direction == GMT_OUT && API->io_mode[GMT_OUT] == GMTAPI_BY_REC) {
 		/* Finalize record-by-record output object dimensions */
@@ -6726,7 +6726,7 @@ int GMT_Get_Status (void *V_API, unsigned int mode) {
 
 	if (V_API == NULL) return_value (V_API, GMT_NOT_A_SESSION, GMT_NOTSET);
 
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	IO = &(API->GMT->current.io);	/* Pointer to the GMT IO structure */
 	if (mode == GMT_IO_DATA_RECORD) return (IO->status == 0 || IO->status == GMT_IO_NAN);
@@ -6748,7 +6748,7 @@ GMT_LOCAL int gmtapi_get_id (void *V_API, unsigned int family, unsigned int dire
 	struct GMTAPI_CTRL *API = NULL;
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);	/* GMT_Create_Session has not been called */
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	for (i = 0, item = GMT_NOTSET; item == GMT_NOTSET && i < API->n_objects; i++) {
 		if ((S_obj = API->object[i]) == NULL) continue;	/* Empty object */
@@ -6874,7 +6874,7 @@ int GMT_Open_VirtualFile (void *V_API, unsigned int family, unsigned int geometr
 	if (direction == GMT_OUT && !gmtapi_valid_output_family (family)) return GMT_NOT_A_VALID_FAMILY;
 	if (via_type && data && !gmtapi_valid_type (via_type-1)) return GMT_NOT_A_VALID_TYPE;	/* via type only valid if not passing any data but want vector or matrix */
 	if (actual_family != family && !gmtapi_valid_via_family (actual_family)) return GMT_NOT_A_VALID_FAMILY;
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 
 	if (data) {	/* Data container provided, see if registered */
 		for (item = 0; object_ID == GMT_NOTSET && item < API->n_objects; item++) {	/* Loop over all objects */
@@ -6966,7 +6966,7 @@ int GMT_Close_VirtualFile (void *V_API, const char *string) {
 	if (string == NULL) return_error (V_API, GMT_PTR_IS_NULL);
 	if ((object_ID = gmtapi_decode_id (string)) == GMT_NOTSET)
 		return_error (V_API, GMT_OBJECT_NOT_FOUND);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	if ((item = gmtapi_validate_id (API, GMT_NOTSET, object_ID, GMT_NOTSET, GMT_NOTSET)) == GMT_NOTSET)
 		return_error (API, GMT_OBJECT_NOT_FOUND);
 	S_obj = API->object[item];	/* Short-hand */
@@ -7012,7 +7012,7 @@ int GMT_Inquire_VirtualFile (void *V_API, const char *string) {
 		return_error (V_API, GMT_OBJECT_NOT_FOUND);
 	if ((item = gmtapi_validate_id (V_API, GMT_NOTSET, object_ID, GMT_NOTSET, GMT_NOTSET)) == GMT_NOTSET)
 		return_error (API, GMT_OBJECT_NOT_FOUND);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	return API->object[item]->family;
 }
 
@@ -7035,7 +7035,7 @@ int GMT_Init_VirtualFile (void *V_API, unsigned int mode, const char *name) {
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	if (name == NULL) return_error (V_API, GMT_PTR_IS_NULL);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	if ((object_ID = gmtapi_decode_id (name)) == GMT_NOTSET) return (GMT_OBJECT_NOT_FOUND);	/* Not a registered resource */
 	if ((item = gmtapi_validate_id (API, GMT_NOTSET, object_ID, GMT_NOTSET, GMT_NOTSET)) == GMT_NOTSET)
 		return_error (API, GMT_OBJECT_NOT_FOUND);
@@ -7059,11 +7059,11 @@ GMT_LOCAL bool gmtapi_is_passable (struct GMTAPI_DATA_OBJECT *S_obj, unsigned in
 	if (family != (unsigned int)S_obj->actual_family) return false;	/* Cannot deal with masquerading containers */
 	if (S_obj->resource == NULL) return false;	/* Certaintly cannot pass this guy */
 	if (S_obj->family == GMT_IS_GRID) {
-		struct GMT_GRID *G = api_get_grid_data (S_obj->resource);
+		struct GMT_GRID *G = gmtapi_get_grid_data (S_obj->resource);
 		return (G->data == NULL) ? false : true;
 	}
 	if (S_obj->family == GMT_IS_IMAGE) {
-		struct GMT_IMAGE *I = api_get_image_data (S_obj->resource);
+		struct GMT_IMAGE *I = gmtapi_get_image_data (S_obj->resource);
 		return (I->data == NULL) ? false : true;
 	}
 	return true; /* True to its word, otherwise we fall through and read the data */
@@ -7090,7 +7090,7 @@ void *GMT_Read_Data (void *V_API, unsigned int family, unsigned int method, unsi
 
 	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
 	if (infile) input = strdup (infile);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	just_get_data = (gmt_M_file_is_memory (input));	/* A regular GMT resource passed via memory */
 	reset = (mode & GMT_IO_RESET);	/* We want to reset resource as unread after reading it */
@@ -7281,7 +7281,7 @@ void *GMT_Read_Group (void *V_API, unsigned int family, unsigned int method, uns
 	void **object = NULL;
 	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
 
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 
 	if (data && !a_grid_or_image (family)) {
@@ -7340,7 +7340,7 @@ void *GMT_Duplicate_Data (void *V_API, unsigned int family, unsigned int mode, v
 
 	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
 	if (data == NULL)  return_null (V_API, GMT_PTR_IS_NULL);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	GMT = API->GMT;
 
@@ -7437,7 +7437,7 @@ int GMT_Write_Data (void *V_API, unsigned int family, unsigned int method, unsig
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	if (data == NULL) return_error (V_API, GMT_PTR_IS_NULL);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	if (outfile) output = strdup (outfile);
 
@@ -7536,7 +7536,7 @@ int GMT_Set_Geometry (void *V_API, unsigned int direction, unsigned int geometry
 	struct GMTAPI_CTRL *API = NULL;
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	if (!API->io_enabled[GMT_OUT]) return_error (API, GMT_ACCESS_NOT_ENABLED);
 	API->error = GMT_NOERROR;
 
@@ -7640,7 +7640,7 @@ struct GMT_RECORD *api_get_record_matrix (struct GMTAPI_CTRL *API, unsigned int 
 			S = API->current_get_obj = API->object[API->current_item[GMT_IN]];	/* Shorthand for the next data source to work on */
 			API->get_next_record = true;	/* Since we haven't read the next record yet */
 		}
-		API->current_get_M = api_get_matrix_data (S->resource);
+		API->current_get_M = gmtapi_get_matrix_data (S->resource);
 		API->current_get_n_columns = (GMT->common.i.select) ? GMT->common.i.n_cols : S->n_columns;
 		API->current_get_M_index = gmtapi_get_2d_to_index (API, API->current_get_M->shape, GMT_GRID_IS_REAL);
 		API->current_get_M_val = gmtapi_select_get_function (API, API->current_get_M->type);
@@ -7695,7 +7695,7 @@ struct GMT_RECORD *api_get_record_vector (struct GMTAPI_CTRL *API, unsigned int 
 			S = API->current_get_obj = API->object[API->current_item[GMT_IN]];	/* Shorthand for the next data source to work on */
 			API->get_next_record = true;	/* Since we haven't read the next record yet */
 		}
-		API->current_get_V = api_get_vector_data (S->resource);
+		API->current_get_V = gmtapi_get_vector_data (S->resource);
 		API->current_get_n_columns = (GMT->common.i.select) ? GMT->common.i.n_cols : S->n_columns;
 		API->current_get_V_val = gmt_M_memory (GMT, API->current_get_V_val, API->current_get_V->n_columns, GMT_getfunction);	/* Array of functions */
 		for (col = 0; col < API->current_get_V->n_columns; col++)	/* We know the number of columns from registration */
@@ -7818,7 +7818,7 @@ GMT_LOCAL void gmtapi_get_record_init (struct GMTAPI_CTRL *API) {
 
 		case GMT_IS_DUPLICATE|GMT_VIA_MATRIX:	/* Here we copy/read from a user memory location which is a matrix */
 		case GMT_IS_REFERENCE|GMT_VIA_MATRIX:
-			API->current_get_M = api_get_matrix_data (S->resource);
+			API->current_get_M = gmtapi_get_matrix_data (S->resource);
 			API->current_get_n_columns = (GMT->common.i.select) ? GMT->common.i.n_cols : S->n_columns;
 			API->current_get_M_index = gmtapi_get_2d_to_index (API, API->current_get_M->shape, GMT_GRID_IS_REAL);
 			API->current_get_M_val = gmtapi_select_get_function (API, API->current_get_M->type);
@@ -7829,7 +7829,7 @@ GMT_LOCAL void gmtapi_get_record_init (struct GMTAPI_CTRL *API) {
 		 case GMT_IS_DUPLICATE|GMT_VIA_VECTOR:	/* Here we copy from a user memory location that points to an array of column vectors */
 		 case GMT_IS_REFERENCE|GMT_VIA_VECTOR:
 			API->current_get_n_columns = (GMT->common.i.select) ? GMT->common.i.n_cols : S->n_columns;
-			API->current_get_V = api_get_vector_data (S->resource);
+			API->current_get_V = gmtapi_get_vector_data (S->resource);
 			API->current_get_V_val = gmt_M_memory (GMT, NULL, API->current_get_V->n_columns, GMT_getfunction);	/* Array of functions */
 			for (col = 0; col < API->current_get_V->n_columns; col++)	/* We know the number of columns from registration */
 				API->current_get_V_val[col] = gmtapi_select_get_function (API, API->current_get_V->type[col]);
@@ -7871,7 +7871,7 @@ void *GMT_Get_Record (void *V_API, unsigned int mode, int *retval) {
 	/* Top level check of active session */
 	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
 	/* Various initializations before reading */
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	if (retval) *retval = 0;
 	GMT = API->GMT;	/* Shorthand for GMT access */
@@ -8328,7 +8328,7 @@ int GMT_Put_Record (void *V_API, unsigned int mode, void *record) {
 	 * output functions.  It is initialized to gmtapi_put_record_init by GMT_Begin_IO.
 	 * gmtapi_put_record_init initializes the machinery and assigns api_put_record. */
 
-	struct GMTAPI_CTRL *API = api_get_api_ptr (V_API);
+	struct GMTAPI_CTRL *API = gmtapi_get_api_ptr (V_API);
 	return (API->api_put_record (API, mode, record));
 }
 
@@ -8356,7 +8356,7 @@ int GMT_Begin_IO (void *V_API, unsigned int family, unsigned int direction, unsi
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	if (!(direction == GMT_IN || direction == GMT_OUT)) return_error (V_API, GMT_NOT_A_VALID_DIRECTION);
 	if (!multiple_files_ok (family)) return_error (V_API, GMT_NOT_A_VALID_IO_ACCESS);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;	/* Reset in case it has some previous error */
 	if (!API->registered[direction]) GMT_Report (API, GMT_MSG_DEBUG, "GMT_Begin_IO: No %s resources registered\n", GMT_direction[direction]);
 	if (mode) GMT_Report (API, GMT_MSG_DEBUG, "GMT_Begin_IO: Mode value %u not considered (ignored)\n", mode);
@@ -8423,11 +8423,11 @@ int GMT_Get_Row (void *V_API, int row_no, struct GMT_GRID *G, gmt_grdfloat *row)
 	struct GMT_CTRL *GMT = NULL;
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	GMT = API->GMT;
 	GH = gmt_get_G_hidden (G);
-	R = api_get_rbr_ptr (GH->extra);
+	R = gmtapi_get_rbr_ptr (GH->extra);
 	HH = gmt_get_H_hidden (G->header);
 	fmt = GMT->session.grdformat[G->header->type];
 	if (fmt[0] == 'c') {		/* Get one NetCDF row, old format */
@@ -8517,11 +8517,11 @@ int GMT_Put_Row (void *V_API, int rec_no, struct GMT_GRID *G, gmt_grdfloat *row)
 	struct GMT_CTRL *GMT = NULL;
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	GMT = API->GMT;
 	GH = gmt_get_G_hidden (G);
-	R = api_get_rbr_ptr (GH->extra);
+	R = gmtapi_get_rbr_ptr (GH->extra);
 	HH = gmt_get_H_hidden (G->header);
 	gmt_scale_and_offset_f (GMT, row, G->header->n_columns, G->header->z_scale_factor, G->header->z_add_offset);
 	if (R->check) {	/* Replace NaNs with special value */
@@ -8586,8 +8586,8 @@ int GMT_Destroy_Data (void *V_API, void *object) {
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);	/* This is a cardinal sin */
 	if (object == NULL) return (false);	/* Null address, quietly skip */
 	if (!gmtapi_ptrvoid(object)) return (false);	/* Null pointer, quietly skip */
-	API = api_get_api_ptr (V_API);		/* Now we need to get that API pointer to check further */
-	if ((object_ID = gmtgmtapi_get_object_id_from_data_ptr (API, object)) == GMT_NOTSET) return_error (API, GMT_OBJECT_NOT_FOUND);	/* Could not find the object in the list */
+	API = gmtapi_get_api_ptr (V_API);		/* Now we need to get that API pointer to check further */
+	if ((object_ID = gmtapi_get_object_id_from_data_ptr (API, object)) == GMT_NOTSET) return_error (API, GMT_OBJECT_NOT_FOUND);	/* Could not find the object in the list */
 	if ((item = gmtapi_validate_id (API, GMT_NOTSET, object_ID, GMT_NOTSET, GMT_NOTSET)) == GMT_NOTSET) return_error (API, API->error);	/* Could not find that item */
 	family = API->object[item]->actual_family;
 
@@ -8651,7 +8651,7 @@ int GMT_Destroy_Data_ (void *object) {
 }
 #endif
 
-GMT_LOCAL int gmtgmtapi_destroy_grids (struct GMTAPI_CTRL *API, struct GMT_GRID ***obj, unsigned int n_items)
+GMT_LOCAL int gmtapi_destroy_grids (struct GMTAPI_CTRL *API, struct GMT_GRID ***obj, unsigned int n_items)
 {	/* Used to destroy a group of grids read via GMT_Read_Group */
 	unsigned int k;
 	int error;
@@ -8661,7 +8661,7 @@ GMT_LOCAL int gmtgmtapi_destroy_grids (struct GMTAPI_CTRL *API, struct GMT_GRID 
 	return_error (API, GMT_NOERROR);
 }
 
-GMT_LOCAL int gmtgmtapi_destroy_datasets (struct GMTAPI_CTRL *API, struct GMT_DATASET ***obj, unsigned int n_items)
+GMT_LOCAL int gmtapi_destroy_datasets (struct GMTAPI_CTRL *API, struct GMT_DATASET ***obj, unsigned int n_items)
 {	/* Used to destroy a group of datasets read via GMT_Read_Group */
 	unsigned int k;
 	int error;
@@ -8671,7 +8671,7 @@ GMT_LOCAL int gmtgmtapi_destroy_datasets (struct GMTAPI_CTRL *API, struct GMT_DA
 	return_error (API, GMT_NOERROR);
 }
 
-GMT_LOCAL int gmtgmtapi_destroy_images (struct GMTAPI_CTRL *API, struct GMT_IMAGE ***obj, unsigned int n_items)
+GMT_LOCAL int gmtapi_destroy_images (struct GMTAPI_CTRL *API, struct GMT_IMAGE ***obj, unsigned int n_items)
 {	/* Used to destroy a group of images read via GMT_Read_Group */
 	unsigned int k;
 	int error;
@@ -8681,7 +8681,7 @@ GMT_LOCAL int gmtgmtapi_destroy_images (struct GMTAPI_CTRL *API, struct GMT_IMAG
 	return_error (API, GMT_NOERROR);
 }
 
-GMT_LOCAL int gmtgmtapi_destroy_palettes (struct GMTAPI_CTRL *API, struct GMT_PALETTE ***obj, unsigned int n_items)
+GMT_LOCAL int gmtapi_destroy_palettes (struct GMTAPI_CTRL *API, struct GMT_PALETTE ***obj, unsigned int n_items)
 {
 	unsigned int k;
 	int error;
@@ -8691,7 +8691,7 @@ GMT_LOCAL int gmtgmtapi_destroy_palettes (struct GMTAPI_CTRL *API, struct GMT_PA
 	return_error (API, GMT_NOERROR);
 }
 
-GMT_LOCAL int gmtgmtapi_destroy_postscripts (struct GMTAPI_CTRL *API, struct GMT_POSTSCRIPT ***obj, unsigned int n_items)
+GMT_LOCAL int gmtapi_destroy_postscripts (struct GMTAPI_CTRL *API, struct GMT_POSTSCRIPT ***obj, unsigned int n_items)
 {	/* Used to destroy a group of palettes read via GMT_Read_Group */
 	unsigned int k;
 	int error;
@@ -8711,7 +8711,7 @@ GMT_LOCAL int gmtapi_destroy_matrices (struct GMTAPI_CTRL *API, struct GMT_MATRI
 	return_error (API, GMT_NOERROR);
 }
 
-GMT_LOCAL int gmtgmtapi_destroy_vectors (struct GMTAPI_CTRL *API, struct GMT_VECTOR ***obj, unsigned int n_items)
+GMT_LOCAL int gmtapi_destroy_vectors (struct GMTAPI_CTRL *API, struct GMT_VECTOR ***obj, unsigned int n_items)
 {	/* Used to destroy a group of vectors read via GMT_Read_Group */
 	unsigned int k;
 	int error;
@@ -8734,18 +8734,18 @@ int GMT_Destroy_Group (void *V_API, void *object, unsigned int n_items) {
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);	/* This is a cardinal sin */
 	if (object == NULL) return (false);	/* Null address, quietly skip */
-	API = api_get_api_ptr (V_API);		/* Now we need to get that API pointer to check further */
+	API = gmtapi_get_api_ptr (V_API);		/* Now we need to get that API pointer to check further */
 	ptr = gmtapi_void3_to_void2 (object);		/* Get the array of pointers */
-	if ((object_ID = gmtgmtapi_get_object_id_from_data_ptr (API, ptr)) == GMT_NOTSET) return_error (API, GMT_OBJECT_NOT_FOUND);	/* Could not find the object in the list */
+	if ((object_ID = gmtapi_get_object_id_from_data_ptr (API, ptr)) == GMT_NOTSET) return_error (API, GMT_OBJECT_NOT_FOUND);	/* Could not find the object in the list */
 	if ((item = gmtapi_validate_id (API, GMT_NOTSET, object_ID, GMT_NOTSET, GMT_NOTSET)) == GMT_NOTSET) return_error (API, API->error);	/* Could not find that item */
 	switch (API->object[item]->actual_family) {
-		case GMT_IS_GRID:       error = gmtgmtapi_destroy_grids    (API, object, n_items); break;
-		case GMT_IS_DATASET:    error = gmtgmtapi_destroy_datasets (API, object, n_items); break;
-		case GMT_IS_IMAGE:      error = gmtgmtapi_destroy_images   (API, object, n_items); break;
-		case GMT_IS_PALETTE:    error = gmtgmtapi_destroy_palettes (API, object, n_items); break;
-		case GMT_IS_POSTSCRIPT: error = gmtgmtapi_destroy_postscripts      (API, object, n_items); break;
+		case GMT_IS_GRID:       error = gmtapi_destroy_grids    (API, object, n_items); break;
+		case GMT_IS_DATASET:    error = gmtapi_destroy_datasets (API, object, n_items); break;
+		case GMT_IS_IMAGE:      error = gmtapi_destroy_images   (API, object, n_items); break;
+		case GMT_IS_PALETTE:    error = gmtapi_destroy_palettes (API, object, n_items); break;
+		case GMT_IS_POSTSCRIPT: error = gmtapi_destroy_postscripts      (API, object, n_items); break;
 		case GMT_IS_MATRIX:     error = gmtapi_destroy_matrices (API, object, n_items); break;
-		case GMT_IS_VECTOR:     error = gmtgmtapi_destroy_vectors  (API, object, n_items); break;
+		case GMT_IS_VECTOR:     error = gmtapi_destroy_vectors  (API, object, n_items); break;
 		default: return_error (API, GMT_NOT_A_VALID_FAMILY); break;
 	}
 	return_error (API, error);
@@ -8832,7 +8832,7 @@ void *GMT_Create_Data (void *V_API, unsigned int family, unsigned int geometry, 
 	struct GMTAPI_CTRL *API = NULL;
 
 	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 
 	module_input = (family & GMT_VIA_MODULE_INPUT);	/* Are we creating a resource that is a module input? */
@@ -8872,7 +8872,7 @@ void *GMT_Create_Data (void *V_API, unsigned int family, unsigned int geometry, 
 				if ((error = gmtapi_alloc_grid (API->GMT, new_obj)) != GMT_NOERROR)
 					return_null (API, error);	/* Allocation error */
 				/* Also allocate and populate the x,y vectors */
-				if ((error = gmtgmtapi_alloc_grid_xy (API, new_obj)) != GMT_NOERROR)
+				if ((error = gmtapi_alloc_grid_xy (API, new_obj)) != GMT_NOERROR)
 					return_null (API, error);	/* Allocation error */
 			}
 			break;
@@ -8896,7 +8896,7 @@ void *GMT_Create_Data (void *V_API, unsigned int family, unsigned int geometry, 
 				if ((error = gmtapi_alloc_image (API->GMT, dim, new_obj)) != GMT_NOERROR)
 					return_null (API, error);	/* Allocation error */
 					/* Also allocate and populate the image x,y vectors */
-				if ((error = gmtgmtapi_alloc_image_xy (API, new_obj)) != GMT_NOERROR)
+				if ((error = gmtapi_alloc_image_xy (API, new_obj)) != GMT_NOERROR)
 					return_null (API, error);	/* Allocation error */
 			}
 			break;
@@ -8998,13 +8998,13 @@ int GMT_Get_Info (void *V_API, unsigned int family, void *data, unsigned int *ge
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	if (data == NULL) return_error (API, GMT_PTR_IS_NULL);	/* Error if data is NULL */
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 
 	switch (family) {	/* dataset, cpt, text, grid , image, vector, matrix */
 		case GMT_IS_GRID:	/* GMT grid, allocate header but not data array */
 			{	/* Deal with a local grid pointer */
-				struct GMT_GRID *G = api_get_grid_data (data);
+				struct GMT_GRID *G = gmtapi_get_grid_data (data);
 				if (dim) { dim[GMT_X] = G->header->n_columns; dim[GMT_Y] = G->header->n_rows; }
 				if (range) gmt_M_memcpy (range, G->header->wesn, 4U, double);
 				if (inc) gmt_M_memcpy (inc, G->header->inc, 2U, double);
@@ -9024,7 +9024,7 @@ int GMT_Get_Info (void *V_API, unsigned int family, void *data, unsigned int *ge
 			break;
 		case GMT_IS_IMAGE:	/* GMT image, allocate header but not data array */
 			{	/* Deal with a local image pointer */
-				struct GMT_IMAGE *I = api_get_image_data (data);
+				struct GMT_IMAGE *I = gmtapi_get_image_data (data);
 				if (dim) { dim[GMT_X] = I->header->n_columns; dim[GMT_Y] = I->header->n_rows; dim[GMT_Z] = I->header->n_bands; }
 				if (range) gmt_M_memcpy (range, I->header->wesn, 4U, double);
 				if (inc) gmt_M_memcpy (inc, I->header->inc, 2U, double);
@@ -9051,7 +9051,7 @@ int GMT_Get_Info (void *V_API, unsigned int family, void *data, unsigned int *ge
 			break;
 		case GMT_IS_PALETTE:	/* GMT CPT, allocate one with space for dim[0] color entries */
 			{	/* Deal with a local palette pointer */
-				struct GMT_PALETTE *P = api_get_palette_data (data);
+				struct GMT_PALETTE *P = gmtapi_get_palette_data (data);
 				if (dim) dim[0] = P->n_colors;
 				if (range) gmt_M_memcpy (range, P->minmax, 2U, double);
 				if (geometry) *geometry = GMT_IS_NONE;
@@ -9059,14 +9059,14 @@ int GMT_Get_Info (void *V_API, unsigned int family, void *data, unsigned int *ge
 			break;
 		case GMT_IS_POSTSCRIPT:	/* GMT PS struct, allocate one struct */
 			{	/* Deal with a local PostScript pointer */
-				struct GMT_POSTSCRIPT *X = api_get_postscript_data (data);
+				struct GMT_POSTSCRIPT *X = gmtapi_get_postscript_data (data);
 				if (dim) dim[0] = X->n_bytes;
 				if (geometry) *geometry = GMT_IS_NONE;
 			}
 			break;
 		case GMT_IS_MATRIX:	/* GMT matrix container, allocate one with the requested number of layers, rows & columns */
 			{	/* Deal with a local matrix pointer */
-				struct GMT_MATRIX *M = api_get_matrix_data (data);
+				struct GMT_MATRIX *M = gmtapi_get_matrix_data (data);
 				if (dim) { dim[GMT_X] = M->n_columns; dim[GMT_Y] = M->n_rows; dim[GMT_Z] = M->n_layers; }
 				if (range) gmt_M_memcpy (range, M->range, (M->n_layers > 1) ? 6U : 4U, double);
 				if (inc) gmt_M_memcpy (inc, M->inc, (M->n_layers > 1) ? 3U : 2U, double);
@@ -9076,7 +9076,7 @@ int GMT_Get_Info (void *V_API, unsigned int family, void *data, unsigned int *ge
 			break;
 		case GMT_IS_VECTOR:	/* GMT vector container, allocate one with the requested number of columns & rows */
 			{	/* Deal with a local image pointer */
-				struct GMT_VECTOR *V = api_get_vector_data (data);
+				struct GMT_VECTOR *V = gmtapi_get_vector_data (data);
 				if (dim) { dim[GMT_X] = V->n_columns; dim[GMT_Y] = V->n_rows; }
 				if (range) gmt_M_memcpy (range, V->range, 2U, double);
 				if (registration) *registration = V->registration;
@@ -9134,7 +9134,7 @@ int GMT_Set_Index (void *V_API, struct GMT_GRID_HEADER *header, char *code) {
 	enum GMT_enum_family family;
 	unsigned int mode;
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	mode = gmtapi_decode_layout (API, code, &family);
 	switch (family) {
@@ -9203,7 +9203,7 @@ double *GMT_Get_Coord (void *V_API, unsigned int family, unsigned int dim, void 
 
 	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
 	if (container == NULL) return_null (V_API, GMT_ARG_IS_NULL);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 
 	switch (family) {	/* grid, image, or matrix */
@@ -9255,7 +9255,7 @@ int GMT_Set_Comment (void *V_API, unsigned int family, unsigned int mode, void *
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	if (container == NULL) return_error (V_API, GMT_ARG_IS_NULL);
 	if (arg == NULL) return_error (V_API, GMT_ARG_IS_NULL);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 
 	switch (family) {	/* grid, image, dataset, cpt, PS or matrix */
 		case GMT_IS_GRID:	/* GMT grid */
@@ -9377,7 +9377,7 @@ void *GMT_FFT_Parse (void *V_API, char option, unsigned int dim, const char *arg
 	if (args == NULL) return_null (V_API, GMT_ARG_IS_NULL);
 	if (dim == 0) return_null (V_API, GMT_DIM_TOO_SMALL);
 	if (dim > 2) return_null (V_API, GMT_DIM_TOO_LARGE);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	info = gmt_M_memory (API->GMT, NULL, 1, struct GMT_FFT_INFO);
 	info->taper_width = -1.0;				/* Not set yet */
@@ -9488,7 +9488,7 @@ GMT_LOCAL struct GMT_FFT_WAVENUMBER * gmtapi_fft_init_1d (struct GMTAPI_CTRL *AP
 
 #if 0	/* Have not finalized 1-D FFT usage in general; this will probably happen when we add gmtfft [1-D FFT equivalent to grdfft] */
 	unsigned n_cols = 1;
-	struct GMT_FFT_INFO *F = api_get_fftinfo_ptr (v_info);
+	struct GMT_FFT_INFO *F = gmtapi_get_fftinfo_ptr (v_info);
 	/* Determine number of columns in [t] x [y] input */
 	if (mode & GMT_FFT_CROSS_SPEC) n_cols++;
 	if (Din->n_columns < n_cols) {
@@ -9668,7 +9668,7 @@ GMT_LOCAL struct GMT_FFT_WAVENUMBER *gmtapi_fft_init_2d (struct GMTAPI_CTRL *API
 	bool stop;
 	double tdummy, edummy;
 	struct GMT_FFT_SUGGESTION fft_sug[GMT_FFT_N_SUGGEST];
-	struct GMT_FFT_INFO *F = NULL, *F_in = api_get_fftinfo_ptr (v_info);
+	struct GMT_FFT_INFO *F = NULL, *F_in = gmtapi_get_fftinfo_ptr (v_info);
 	struct GMT_FFT_WAVENUMBER *K = NULL;
 	struct GMT_GRID_HEADER_HIDDEN *HH;
 	struct GMT_CTRL *GMT = NULL;
@@ -10030,7 +10030,7 @@ GMT_LOCAL int gmtapi_fft_2d (struct GMTAPI_CTRL *API, struct GMT_GRID *G, int di
 /*! . */
 int GMT_FFT (void *V_API, void *X, int direction, unsigned int mode, void *v_K) {
 	/* The 1-D or 2-D FFT operating on GMT_DATASET or GMT_GRID arrays */
-	struct GMT_FFT_WAVENUMBER *K = api_get_fftwave_ptr (v_K);
+	struct GMT_FFT_WAVENUMBER *K = gmtapi_get_fftwave_ptr (v_K);
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	if (K->dim == 2) return (gmtapi_fft_2d (V_API, X, direction, mode, K));
 	else return (gmtapi_fft_1d (V_API, X, direction, mode, K));
@@ -10049,8 +10049,8 @@ int GMT_FFT_Destroy (void *V_API, void *v_info) {
 	struct GMT_FFT_WAVENUMBER **K = NULL;
 	struct GMTAPI_CTRL *API = NULL;
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
-	K = api_get_fftwave_addr (v_info);
+	API = gmtapi_get_api_ptr (V_API);
+	K = gmtapi_get_fftwave_addr (v_info);
 	gmt_M_free (API->GMT, (*K)->info);
 	gmt_M_free (API->GMT, (*K));
 	return_error (V_API, GMT_NOERROR);
@@ -10073,7 +10073,7 @@ const char * gmt_show_name_and_purpose (void *V_API, const char *component, cons
 	assert (V_API != NULL);
 	assert (name != NULL);
 	assert (purpose != NULL);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	mode_name = gmtlib_get_active_name (API, name);
 	lib = (component) ? component : core;
 	snprintf (full_name, GMT_LEN32, "gmt %s", mode_name);
@@ -10108,7 +10108,7 @@ EXTERN_MSC void *gmt_core_module_lookup (struct GMTAPI_CTRL *API, const char *ca
 GMT_LOCAL void *gmtapi_get_module_func (struct GMTAPI_CTRL *API, const char *module, unsigned int lib_no) {
 #ifndef BUILD_SHARED_LIBS
 	if (lib_no == 0)	/* Get core module */
-		return (gmt_core_module_lookup (API, module));
+		return (gmtapi_core_module_lookup (API, module));
 	/* Else we get custom module below */
 #endif
 	return (gmtapi_get_shared_module_func (API, module, lib_no));
@@ -10135,7 +10135,7 @@ int GMT_Call_Module (void *V_API, const char *module, int mode, void *args) {
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	if (module == NULL && !(mode == GMT_MODULE_LIST || mode == GMT_MODULE_CLASSIC || mode == GMT_MODULE_PURPOSE))
 		return_error (V_API, GMT_ARG_IS_NULL);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 
 	if (module == NULL) {	/* Did not specify any specific module, so list purpose of all modules in all shared libs */
@@ -10197,7 +10197,7 @@ GMT_LOCAL const char * gmtapi_get_shared_module_keys (struct GMTAPI_CTRL *API, c
 		API->lib[lib_no].skip = true;	/* Not bother the next time... */
 		return (NULL);			/* ...and obviously no keys would be found */
 	}
-	snprintf (function, GMT_LEN64, "gmt_%s_module_keys", API->lib[lib_no].name);
+	snprintf (function, GMT_LEN64, "gmtlib_%s_module_keys", API->lib[lib_no].name);
 	/* Here the library handle is available; try to get pointer to specified module */
 	*(void **) (&func) = dlsym (API->lib[lib_no].handle, function);
 	if (func) keys = (*func) (API, module);
@@ -10217,7 +10217,7 @@ GMT_LOCAL const char * gmtapi_get_shared_module_group (struct GMTAPI_CTRL *API, 
 		API->lib[lib_no].skip = true;	/* Not bother the next time... */
 		return (NULL);			/* ...and obviously no keys would be found */
 	}
-	snprintf (function, GMT_LEN64, "gmt_%s_module_group", API->lib[lib_no].name);
+	snprintf (function, GMT_LEN64, "gmtlib_%s_module_group", API->lib[lib_no].name);
 	/* Here the library handle is available; try to get pointer to specified module */
 	*(void **) (&func) = dlsym (API->lib[lib_no].handle, function);
 	if (func) group = (*func) (API, module);
@@ -10225,25 +10225,25 @@ GMT_LOCAL const char * gmtapi_get_shared_module_group (struct GMTAPI_CTRL *API, 
 }
 
 /*! . */
-GMT_LOCAL const char * gmt_get_module_group (struct GMTAPI_CTRL *API, char *module, unsigned int lib_no) {
+GMT_LOCAL const char * gmtapi_get_module_group (struct GMTAPI_CTRL *API, char *module, unsigned int lib_no) {
 	/* DO not rename this function */
 	if (lib_no == 0)	/* Get core module */
-		return (gmt_core_module_group (API, module));
+		return (gmtlib_core_module_group (API, module));
 	/* Else we get custom module below */
 	return (gmtapi_get_shared_module_group (API, module, lib_no));
 }
 
 /*! . */
-GMT_LOCAL const char * gmt_get_module_keys (struct GMTAPI_CTRL *API, char *module, unsigned int lib_no) {
+GMT_LOCAL const char * gmtapi_get_module_keys (struct GMTAPI_CTRL *API, char *module, unsigned int lib_no) {
 	/* DO not rename this function */
 	if (lib_no == 0)	/* Get core module */
-		return (gmt_core_module_keys (API, module));
+		return (gmtlib_core_module_keys (API, module));
 	/* Else we get custom module below */
 	return (gmtapi_get_shared_module_keys (API, module, lib_no));
 }
 
 /*! . */
-const char * api_get_module_group (void *V_API, char *module) {
+const char * gmt_get_module_group (void *V_API, char *module) {
 	/* Call the specified shared module and retrieve the group of the module.
  	 * This function, while in the API, is only for API developers and thus has a
 	 * "undocumented" status in the API documentation.
@@ -10255,17 +10255,17 @@ const char * api_get_module_group (void *V_API, char *module) {
 
 	if (V_API == NULL) return_null (NULL, GMT_NOT_A_SESSION);
 	if (module == NULL) return_null (V_API, GMT_ARG_IS_NULL);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 
 	for (lib = 0; lib < API->n_shared_libs; lib++) {	/* Look for module in any of the shared libs */
-		group = gmt_get_module_group (API, module, lib);
+		group = gmtapi_get_module_group (API, module, lib);
 		if (group) return (group);	/* Found it in this shared library, return the group */
 	}
 	/* If we get here we did not found it.  Try to prefix module with gmt */
 	strncat (gmt_module, module, GMT_LEN32-4);		/* Concatenate gmt and module name to get function name */
 	for (lib = 0; lib < API->n_shared_libs; lib++) {	/* Look for gmt_module in any of the shared libs */
-		group = gmt_get_module_group (API, gmt_module, lib);
+		group = gmtapi_get_module_group (API, gmt_module, lib);
 		if (group) {	/* Found it in this shared library, adjust module name and return the group */
 			strncpy (module, gmt_module, strlen(gmt_module));	/* Rewrite module name to contain prefix of gmt */
 			return (group);
@@ -10279,8 +10279,6 @@ const char * api_get_module_group (void *V_API, char *module) {
 /*! . */
 GMT_LOCAL const char * gmtapi_retrieve_module_keys (void *V_API, char *module) {
 	/* Call the specified shared module and retrieve the API developer options keys.
- 	 * This function, while in the API, is only for API developers and thus has a
-	 * "undocumented" status in the API documentation.
 	 */
 	unsigned int lib;
 	struct GMTAPI_CTRL *API = NULL;
@@ -10289,17 +10287,17 @@ GMT_LOCAL const char * gmtapi_retrieve_module_keys (void *V_API, char *module) {
 
 	if (V_API == NULL) return_null (NULL, GMT_NOT_A_SESSION);
 	if (module == NULL) return_null (V_API, GMT_ARG_IS_NULL);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 
 	for (lib = 0; lib < API->n_shared_libs; lib++) {	/* Look for module in any of the shared libs */
-		keys = gmt_get_module_keys (API, module, lib);
+		keys = gmtapi_get_module_keys (API, module, lib);
 		if (keys) return (keys);	/* Found it in this shared library, return the keys */
 	}
 	/* If we get here we did not found it.  Try to prefix module with gmt */
 	strncat (gmt_module, module, GMT_LEN32-4);		/* Concatenate gmt and module name to get function name */
 	for (lib = 0; lib < API->n_shared_libs; lib++) {	/* Look for gmt_module in any of the shared libs */
-		keys = gmt_get_module_keys (API, gmt_module, lib);
+		keys = gmtapi_get_module_keys (API, gmt_module, lib);
 		if (keys) {	/* Found it in this shared library, adjust module name and return the keys */
 			strncpy (module, gmt_module, strlen(gmt_module));	/* Rewrite module name to contain prefix of gmt */
 			return (keys);
@@ -10497,7 +10495,7 @@ struct GMT_RESOURCE *GMT_Encode_Options (void *V_API, const char *module_name, i
 		*n = UINT_MAX;
 		return NULL;
 	}
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	(void) gmt_current_name (module_name, module);
 	gmt_manage_workflow (API, GMT_USE_WORKFLOW, NULL);		/* Detect and set modern mode if modern mode session dir is found */
@@ -10919,7 +10917,7 @@ int GMT_Get_Common (void *V_API, unsigned int option, double par[]) {
 	struct GMT_CTRL *GMT = NULL;
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	GMT = API->GMT;
 
@@ -10999,7 +10997,7 @@ int GMT_Get_Default (void *V_API, const char *keyword, char *value) {
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	if (keyword == NULL) return_error (V_API, GMT_NO_PARAMETERS);
 	if (value == NULL) return_error (V_API, GMT_NO_PARAMETERS);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	/* First intercept any API Keywords */
 	if (!strncmp (keyword, "API_VERSION", 11U))	/* The API version */
 		sprintf (value, "%s", GMT_PACKAGE_VERSION);
@@ -11052,7 +11050,7 @@ int GMT_Set_Default (void *V_API, const char *keyword, const char *txt_val) {
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	if (keyword == NULL) return_error (V_API, GMT_NOT_A_VALID_PARAMETER);
 	if (txt_val == NULL) return_error (V_API, GMT_NO_PARAMETERS);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	value = strdup (txt_val);	/* Make local copy to be safe */
 	/* First intercept any API Keywords */
 	if (!strncmp (keyword, "API_PAD", 7U)) {	/* Change the grid padding setting */
@@ -11104,7 +11102,7 @@ int GMT_Option (void *V_API, const char *options) {
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	if (options == NULL) return_error (V_API, GMT_NO_PARAMETERS);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 
 	/* The following does the translation between the rules for the option string and the convoluted items gmtlib_explain_options expects. */
 	while (gmt_strtok (options, ",", &pos, p) && k < (GMT_LEN64-1)) {
@@ -11187,7 +11185,7 @@ int GMT_Message (void *V_API, unsigned int mode, const char *format, ...) {
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	if (format == NULL) return GMT_PTR_IS_NULL;	/* Format cannot be NULL */
-	API = api_get_api_ptr (V_API);	/* Get the typecast structure pointer to API */
+	API = gmtapi_get_api_ptr (V_API);	/* Get the typecast structure pointer to API */
 	API->message[0] = '\0';	/* Start fresh */
 	if (mode) stamp = gmtapi_tictoc_string (API, mode);	/* Pointer to a timestamp string */
 	if (mode % 4) sprintf (API->message, "%s | ", stamp);	/* Lead with the time stamp */
@@ -11222,7 +11220,7 @@ int GMT_Report (void *V_API, unsigned int level, const char *format, ...) {
 	va_list args;
 	/* GMT_Report may be called before GMT is set so take precautions */
 	if (V_API == NULL) return GMT_NOERROR;		/* Not a fatal issue here but we cannot report anything */
-	API = api_get_api_ptr (V_API);	/* Get the typecast structure pointer to API */
+	API = gmtapi_get_api_ptr (V_API);	/* Get the typecast structure pointer to API */
 	GMT = API->GMT;	/* Short-hand for the GMT sub-structure */
 	g_level = (GMT) ? GMT->current.setting.verbose : GMT_MSG_QUIET;
 	if (GMT) err = GMT->session.std[GMT_ERR];
@@ -11264,7 +11262,7 @@ int GMT_Report_ (unsigned int *level, const char *format, int len) {
 char * GMT_Error_Message (void *V_API) {
 	struct GMTAPI_CTRL *API = NULL;
 	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);	/* Get the typecast structure pointer to API */
+	API = gmtapi_get_api_ptr (V_API);	/* Get the typecast structure pointer to API */
 	return (API->error_msg);
 }
 
@@ -11283,7 +11281,7 @@ int GMT_Handle_Messages (void *V_API, unsigned int mode, unsigned int method, vo
 	int *fd = NULL;
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	switch (mode) {
 		case GMT_LOG_OFF:	/* Close log file and reset to stderr */
 			if (API->log_level == GMT_LOG_SET)
@@ -11359,7 +11357,7 @@ int GMT_Get_Values (void *V_API, const char *arg, double par[], int maxpar) {
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	if (arg == NULL || arg[0] == '\0') return_value (V_API, GMT_NO_PARAMETERS, GMT_NOTSET);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	GMT = API->GMT;
 	API->error = GMT_NOERROR;
 
@@ -11994,7 +11992,7 @@ void *GMT_Convert_Data (void *V_API, void *In, unsigned int family_in, void *Out
 	struct GMTAPI_CTRL *API = NULL;
 
 	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 
 	switch (family_in) {
@@ -12077,7 +12075,7 @@ void *GMT_Alloc_Segment (void *V_API, unsigned int mode, uint64_t n_rows, uint64
 	char *H = header;
 
 	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	if ((Snew = S) != NULL)	/* Existing segment given */
 		first = false;
@@ -12115,7 +12113,7 @@ int GMT_Set_Columns (void *V_API, unsigned int direction, unsigned int n_cols, u
 	if (!(direction == GMT_IN || direction == GMT_OUT)) return_error (V_API, GMT_NOT_A_VALID_DIRECTION);
 	if (direction == GMT_IN && !(mode == GMT_COL_FIX || mode == GMT_COL_VAR || mode == GMT_COL_FIX_NO_TEXT)) return_error (V_API, GMT_NOT_A_VALID_MODE);
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 
 	if (direction == GMT_OUT) {	/* Output */
@@ -12306,7 +12304,7 @@ int GMT_Change_Layout (void *V_API, unsigned int family, char *code, unsigned in
 	struct GMTAPI_CTRL *API = NULL;
 	int error;
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	switch (family) {
 		case GMT_IS_GRID:
@@ -12472,11 +12470,11 @@ int GMT_Put_Strings (void *V_API, unsigned int family, void *object, char **arra
 	if (object == NULL) return_error (V_API, GMT_PTR_IS_NULL);
 	if (!(family == GMT_IS_VECTOR || family == GMT_IS_MATRIX)) return_error (V_API, GMT_NOT_A_VALID_FAMILY);
 	if (family == GMT_IS_VECTOR) {
-		struct GMT_VECTOR *V = api_get_vector_data (object);
+		struct GMT_VECTOR *V = gmtapi_get_vector_data (object);
 		V->text = array;
 	}
 	else if (family == GMT_IS_MATRIX) {
-		struct GMT_MATRIX *M = api_get_matrix_data (object);
+		struct GMT_MATRIX *M = gmtapi_get_matrix_data (object);
 		M->text = array;
 	}
 	return (GMT_NOERROR);
@@ -12496,11 +12494,11 @@ char ** GMT_Get_Strings (void *V_API, unsigned int family, void *object) {
 	if (object == NULL) return_null (V_API, GMT_PTR_IS_NULL);
 	if (!(family == GMT_IS_VECTOR || family == GMT_IS_MATRIX)) return_null (V_API, GMT_NOT_A_VALID_FAMILY);
 	if (family == GMT_IS_VECTOR) {
-		struct GMT_VECTOR *V = api_get_vector_data (object);
+		struct GMT_VECTOR *V = gmtapi_get_vector_data (object);
 		array = V->text;
 	}
 	else if (family == GMT_IS_MATRIX) {
-		struct GMT_MATRIX *M = api_get_matrix_data (object);
+		struct GMT_MATRIX *M = gmtapi_get_matrix_data (object);
 		array = M->text;
 	}
 	if (array == NULL)
@@ -12581,7 +12579,7 @@ int GMT_Get_Family (void *V_API, unsigned int direction, struct GMT_OPTION *head
 	unsigned int n_kinds = 0, k, counter[GMT_N_FAMILIES];
 	char desired_option = (direction == GMT_IN) ? GMT_OPT_INFILE : GMT_OPT_OUTFILE;
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	gmt_M_memset (counter, GMT_N_FAMILIES, unsigned int);	/* Initialize counter */
 	API->error = GMT_NOERROR;	/* Reset in case it has some previous error */
 
@@ -12626,11 +12624,11 @@ int GMT_Set_AllocMode (void *V_API, unsigned int family, void *object) {
 
 	switch (family) {	/* grid, image, or matrix */
 		case GMT_IS_GRID:	/* GMT grid */
-			GH = gmt_get_G_hidden (api_get_grid_data (object));
+			GH = gmt_get_G_hidden (gmtapi_get_grid_data (object));
 			GH->alloc_mode = GMT_ALLOC_EXTERNALLY;
 			break;
 		case GMT_IS_IMAGE:	/* GMT image */
-			IH = gmt_get_I_hidden (api_get_image_data (object));
+			IH = gmt_get_I_hidden (gmtapi_get_image_data (object));
 			IH->alloc_mode = GMT_ALLOC_EXTERNALLY;
 			break;
 		case GMT_IS_DATASET:	/* GMT dataset */
@@ -12638,19 +12636,19 @@ int GMT_Set_AllocMode (void *V_API, unsigned int family, void *object) {
 			DH->alloc_mode = GMT_ALLOC_EXTERNALLY;
 			break;
 		case GMT_IS_PALETTE:	/* GMT CPT */
-			CH = gmt_get_C_hidden (api_get_palette_data (object));
+			CH = gmt_get_C_hidden (gmtapi_get_palette_data (object));
 			CH->alloc_mode = GMT_ALLOC_EXTERNALLY;
 			break;
 		case GMT_IS_POSTSCRIPT:		/* GMT PS */
-			PH = gmt_get_P_hidden (api_get_postscript_data (object));
+			PH = gmt_get_P_hidden (gmtapi_get_postscript_data (object));
 			PH->alloc_mode = GMT_ALLOC_EXTERNALLY;
 			break;
 		case GMT_IS_VECTOR:	/* GMT Vector*/
-			VH = gmt_get_V_hidden (api_get_vector_data (object));
+			VH = gmt_get_V_hidden (gmtapi_get_vector_data (object));
 			VH->alloc_mode = GMT_ALLOC_EXTERNALLY;
 			break;
 		case GMT_IS_MATRIX:	/* GMT Matrix */
-			MH = gmt_get_M_hidden (api_get_matrix_data (object));
+			MH = gmt_get_M_hidden (gmtapi_get_matrix_data (object));
 			MH->alloc_mode = GMT_ALLOC_EXTERNALLY;
 			break;
 		default:
@@ -12670,7 +12668,7 @@ int GMT_Set_AllocMode_ (unsigned int *family, void *object) {
 int GMT_Extract_Region (void *V_API, char *file, double wesn[]) {
 	FILE *fp = NULL;
 	bool found = false;
-	struct GMTAPI_CTRL *API = api_get_api_ptr (V_API);
+	struct GMTAPI_CTRL *API = gmtapi_get_api_ptr (V_API);
 	char xx1[GMT_LEN64] = {""}, xx2[GMT_LEN64] = {""}, yy1[GMT_LEN64] = {""}, yy2[GMT_LEN64] = {""}, line[GMT_LEN256] = {""};
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
@@ -12748,6 +12746,6 @@ void *GMT_Get_Ctrl (void *V_API) {
 	struct GMTAPI_CTRL *API = NULL;
 
 	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
-	API = api_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
 	return API->GMT;	/* Pass back the GMT ctrl pointer as void pointer */
 }

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -10145,7 +10145,7 @@ int GMT_Call_Module (void *V_API, const char *module, int mode, void *args) {
 
 		/* Here we list purpose of all the available modules in each shared library */
 		for (lib = 0; lib < API->n_shared_libs; lib++) {
-			snprintf (gmt_module, GMT_LEN64, "gmt_%s_module_%s_all", API->lib[lib].name, listfunc);
+			snprintf (gmt_module, GMT_LEN64, "gmtlib_%s_module_%s_all", API->lib[lib].name, listfunc);
 			*(void **) (&l_func) = gmtapi_get_module_func (API, gmt_module, lib);
 			if (l_func == NULL) continue;	/* Not found in this shared library */
 			(*l_func) (V_API);	/* Run this function */

--- a/src/gmt_core_module.c
+++ b/src/gmt_core_module.c
@@ -271,7 +271,7 @@ GMT_LOCAL int skip_modern_module (const char *name) {
 }
 
 /* Pretty print all GMT core module names and their purposes for gmt --help */
-void gmt_core_module_show_all (void *V_API) {
+void gmtlib_core_module_show_all (void *V_API) {
 	unsigned int module_id = 0;
 	char message[GMT_LEN256];
 	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);
@@ -293,7 +293,7 @@ void gmt_core_module_show_all (void *V_API) {
 }
 
 /* Produce single list on stdout of all GMT core module names for gmt --show-modules */
-void gmt_core_module_list_all (void *V_API) {
+void gmtlib_core_module_list_all (void *V_API) {
 	unsigned int module_id = 0;
 	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);
 	while (g_core_module[module_id].cname != NULL) {
@@ -304,7 +304,7 @@ void gmt_core_module_list_all (void *V_API) {
 }
 
 /* Produce single list on stdout of all GMT core module names for gmt --show-classic [i.e., classic mode names] */
-void gmt_core_module_classic_all (void *V_API) {
+void gmtlib_core_module_classic_all (void *V_API) {
 	unsigned int module_id = 0;
 	size_t n_modules = 0;
 	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);
@@ -323,7 +323,7 @@ void gmt_core_module_classic_all (void *V_API) {
 }
 
 /* Lookup module id by name, return option keys pointer (for external API developers) */
-const char *gmt_core_module_keys (void *API, char *candidate) {
+const char *gmtlib_core_module_keys (void *API, char *candidate) {
 	int module_id = 0;
 	gmt_M_unused(API);
 
@@ -337,7 +337,7 @@ const char *gmt_core_module_keys (void *API, char *candidate) {
 }
 
 /* Lookup module id by name, return group char name (for external API developers) */
-const char *gmt_core_module_group (void *API, char *candidate) {
+const char *gmtlib_core_module_group (void *API, char *candidate) {
 	int module_id = 0;
 	gmt_M_unused(API);
 
@@ -352,7 +352,7 @@ const char *gmt_core_module_group (void *API, char *candidate) {
 
 #ifndef BUILD_SHARED_LIBS
 /* Lookup static module id by name, return function pointer */
-void *gmt_core_module_lookup (void *API, const char *candidate) {
+void *gmtlib_core_module_lookup (void *API, const char *candidate) {
 	int module_id = 0;
 	size_t len = strlen (candidate);
 	gmt_M_unused(API);

--- a/src/gmt_core_module.h
+++ b/src/gmt_core_module.h
@@ -120,15 +120,15 @@ EXTERN_MSC int GMT_pswiggle (void *API, int mode, void *args);
 EXTERN_MSC int GMT_xyz2grd (void *API, int mode, void *args);
 
 /* Pretty print all modules in the GMT core library and their purposes */
-EXTERN_MSC void gmt_core_module_show_all (void *API);
+EXTERN_MSC void gmtlib_core_module_show_all (void *API);
 /* List all modern modules in the GMT core library to stdout */
-EXTERN_MSC void gmt_core_module_list_all (void *API);
+EXTERN_MSC void gmtlib_core_module_list_all (void *API);
 /* List all classic modules in the GMT core library to stdout */
-EXTERN_MSC void gmt_core_module_classic_all (void *API);
+EXTERN_MSC void gmtlib_core_module_classic_all (void *API);
 /* Function called by GMT_Encode_Options so developers can get information about a module */
-EXTERN_MSC const char * gmt_core_module_keys (void *API, char *candidate);
+EXTERN_MSC const char * gmtlib_core_module_keys (void *API, char *candidate);
 /* Function returns name of group that module belongs to (core, spotter, etc.) */
-EXTERN_MSC const char * gmt_core_module_group (void *API, char *candidate);
+EXTERN_MSC const char * gmtlib_core_module_group (void *API, char *candidate);
 
 #ifdef __cplusplus
 }

--- a/src/gmt_customio.c
+++ b/src/gmt_customio.c
@@ -975,7 +975,7 @@ int gmt_native_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, g
 		return (GMT_GRDIO_OPEN_FAILED);
 
 	type = GMT->session.grdformat[header->type][1];
-	size = gmt_grd_data_size (GMT, header->type, &header->nan_value);
+	size = gmtlib_grd_data_size (GMT, header->type, &header->nan_value);
 	check = !isnan (header->nan_value);
 
 	(void)gmtlib_init_complex (header, complex_mode, &imag_offset);	/* Set offset for imaginary complex component */
@@ -1092,7 +1092,7 @@ int gmt_native_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, 
 		return (GMT_GRDIO_CREATE_FAILED);
 
 	type = GMT->session.grdformat[header->type][1];
-	size = gmt_grd_data_size (GMT, header->type, &header->nan_value);
+	size = gmtlib_grd_data_size (GMT, header->type, &header->nan_value);
 	check = !isnan (header->nan_value);
 
 	gmt_M_err_pass (GMT, gmt_grd_prep_io (GMT, header, wesn, &width_out, &height_out, &first_col, &last_col, &first_row, &last_row, &k), HH->name);
@@ -1510,7 +1510,7 @@ int gmt_srf_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_
 		return (GMT_GRDIO_OPEN_FAILED);
 
 	type = GMT->session.grdformat[header->type][1];
-	size = gmt_grd_data_size (GMT, header->type, &header->nan_value);
+	size = gmtlib_grd_data_size (GMT, header->type, &header->nan_value);
 
 	gmt_M_err_pass (GMT, gmt_grd_prep_io (GMT, header, wesn, &width_in, &height_in, &first_col, &last_col, &first_row, &last_row, &k), HH->name);
 	(void)gmtlib_init_complex (header, complex_mode, &imag_offset);	/* Set offset for imaginary complex component */
@@ -1645,7 +1645,7 @@ int gmt_srf_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 		return (GMT_GRDIO_CREATE_FAILED);
 
 	type = GMT->session.grdformat[header->type][1];
-	size = gmt_grd_data_size (GMT, header->type, &header->nan_value);
+	size = gmtlib_grd_data_size (GMT, header->type, &header->nan_value);
 
 	gmt_M_err_pass (GMT, gmt_grd_prep_io (GMT, header, wesn, &width_out, &height_out, &first_col, &last_col, &first_row, &last_row, &k), HH->name);
 	(void)gmtlib_init_complex (header, complex_mode, &imag_offset);	/* Set offset for imaginary complex component */

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -46,7 +46,7 @@
  *  gmt_grd_pad_status      :
  *  gmt_grd_info_syntax
  *  gmtlib_get_grdtype         :
- *  gmt_grd_data_size       :
+ *  gmtlib_grd_data_size       :
  *  gmt_grd_set_ij_inc      :
  *  gmt_grd_format_decoder  :
  *  gmt_grd_prep_io         :
@@ -1511,7 +1511,7 @@ int gmtlib_write_grd (struct GMT_CTRL *GMT, char *file, struct GMT_GRID_HEADER *
 	return (err);
 }
 
-size_t gmt_grd_data_size (struct GMT_CTRL *GMT, unsigned int format, gmt_grdfloat *nan_value) {
+size_t gmtlib_grd_data_size (struct GMT_CTRL *GMT, unsigned int format, gmt_grdfloat *nan_value) {
 	/* Determine size of data type and set NaN value, if not yet done so (integers only) */
 
 	switch (GMT->session.grdformat[format][1]) {

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -63,7 +63,7 @@
  *	gmt_default_error
  *	gmt_check_region
  *	gmt_parse_R_option
- *	gmt_parse_index_range
+ *	gmtlib_parse_index_range
  *	gmt_parse_d_option
  *	gmt_parse_i_option
  *	gmt_parse_o_option
@@ -1381,7 +1381,7 @@ GMT_LOCAL int gmtinit_parse_f_option (struct GMT_CTRL *GMT, char *arg) {
 	}
 
 	while ((gmt_strtok (copy, ",", &pos, p))) {	/* While it is not empty, process it */
-		if ((inc = gmt_parse_index_range (GMT, p, &start, &stop)) == 0) return (GMT_PARSE_ERROR);
+		if ((inc = gmtlib_parse_index_range (GMT, p, &start, &stop)) == 0) return (GMT_PARSE_ERROR);
 		len = strlen (p);	/* Length of the string p */
 		ic = (int) p[len-1];	/* Last char in p is the potential code T, t, x, y, or f. */
 		switch (ic) {
@@ -1637,7 +1637,7 @@ GMT_LOCAL int gmtinit_parse_model1d (struct GMT_CTRL *GMT, char option, char *in
 			single = true;
 			gmtinit_count_x_terms (p, &xstart, &xstop);
 		}
-		else if ((step = gmt_parse_index_range (GMT, this_range, &xstart, &xstop)) != 1) {
+		else if ((step = gmtlib_parse_index_range (GMT, this_range, &xstart, &xstop)) != 1) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Bad basis function order (%s)\n", option, this_range);
 			gmt_M_str_free (arg);
 			return -1;
@@ -1851,7 +1851,7 @@ GMT_LOCAL int gmtinit_parse_model2d (struct GMT_CTRL *GMT, char option, char *in
 			single = true;
 			gmtinit_count_xy_terms (&p[1], &xstart, &xstop, &ystart, &ystop);
 		}
-		else if ((step = gmt_parse_index_range (GMT, this_range, &xstart, &xstop)) != 1) {
+		else if ((step = gmtlib_parse_index_range (GMT, this_range, &xstart, &xstop)) != 1) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Bad basis function order (%s)\n", option, this_range);
 			return -1;
 		}
@@ -2365,7 +2365,7 @@ GMT_LOCAL bool gmtinit_parse_s_option (struct GMT_CTRL *GMT, char *item) {
 	/* Here we have user-supplied column information */
 	for (i = 0; i < GMT_MAX_COLUMNS; i++) tmp[i] = -1;
 	while (!error && (gmt_strtok (item, ",", &pos, p))) {	/* While it is not empty, process it */
-		if ((inc = gmt_parse_index_range (GMT, p, &start, &stop)) == 0) return (true);
+		if ((inc = gmtlib_parse_index_range (GMT, p, &start, &stop)) == 0) return (true);
 
 		/* Now set the code for these columns */
 		for (i = start; i <= stop; i += inc) tmp[i] = true;
@@ -3900,7 +3900,7 @@ GMT_LOCAL int gmtinit_decode5_wesnz (struct GMT_CTRL *GMT, const char *in, bool 
 	return (error);
 }
 
-bool gmtinit_B_is_frame (struct GMT_CTRL *GMT, char *in) {
+bool gmtlib_B_is_frame (struct GMT_CTRL *GMT, char *in) {
 	gmt_M_unused (GMT);
 	if (strstr (in, "+b")) return true;	/* Found a +b so likely frame */
 	if (strstr (in, "+g")) return true;	/* Found a +g so likely frame */
@@ -3934,7 +3934,7 @@ GMT_LOCAL int gmtinit_parse5_B_frame_setting (struct GMT_CTRL *GMT, char *in) {
 
 	if (strchr ("pxy", in[0])) return (-1);	/* -B[p[xy] is definitively not the frame settings (-Bz and -Bs are tricker; see below) */
 	if (strchr ("afg", in[0])) return (-1);	/* -Ba|f|g is definitively not the frame settings; looks like axes settings */
-	if (!gmtinit_B_is_frame (GMT, in)) return (-1);		/* No, nothing matched */
+	if (!gmtlib_B_is_frame (GMT, in)) return (-1);		/* No, nothing matched */
 
 	/* OK, here we are pretty sure this is a frame -B statement */
 
@@ -8309,7 +8309,7 @@ int gmt_parse_R_option (struct GMT_CTRL *GMT, char *arg) {
 }
 
 //*! . */
-int64_t gmt_parse_index_range (struct GMT_CTRL *GMT, char *p, int64_t *start, int64_t *stop) {
+int64_t gmtlib_parse_index_range (struct GMT_CTRL *GMT, char *p, int64_t *start, int64_t *stop) {
 	/* Parse p looking for range or columns or individual columns.
 	 * If neither then we just increment both start and stop. */
 	int64_t inc = 1, r = 0;
@@ -8531,7 +8531,7 @@ int gmt_parse_i_option (struct GMT_CTRL *GMT, char *arg) {
 			}
 		}
 		else {	/* Now process column range */
-			if ((inc = gmt_parse_index_range (GMT, p, &start, &stop)) == 0) return (GMT_PARSE_ERROR);
+			if ((inc = gmtlib_parse_index_range (GMT, p, &start, &stop)) == 0) return (GMT_PARSE_ERROR);
 			if (stop == INTMAX_MAX) {	/* Gave an open interval, e.g., 3: or 4- to mean "until last column" */
 				GMT->common.i.end = true;
 				stop = GMT_MAX_COLUMNS - 1;	/* Set to last column */
@@ -8709,7 +8709,7 @@ int gmt_parse_o_option (struct GMT_CTRL *GMT, char *arg) {
 			}
 		}
 		else {
-			if ((inc = gmt_parse_index_range (GMT, p, &start, &stop)) == 0) return (GMT_PARSE_ERROR);
+			if ((inc = gmtlib_parse_index_range (GMT, p, &start, &stop)) == 0) return (GMT_PARSE_ERROR);
 			if (stop == INTMAX_MAX) {	/* Gave an open-ended interval, e.g., 3: or 3- to mean "from 3 until last column" */
 				GMT->common.o.end = true;
 				stop = GMT_MAX_COLUMNS - 1;	/* Set to last column */
@@ -8746,7 +8746,7 @@ GMT_LOCAL int gmtinit_parse_q_option_r (struct GMT_CTRL *GMT, unsigned int direc
 			return (GMT_PARSE_ERROR);
 		}
 		/* We can process A or A: or A- or A/ or A:B or A-B or A/B or :B or -B or /B */
-		if ((R[n].inc = gmt_parse_index_range (GMT, p, &R[n].first, &R[n].last)) == 0) return (GMT_PARSE_ERROR);
+		if ((R[n].inc = gmtlib_parse_index_range (GMT, p, &R[n].first, &R[n].last)) == 0) return (GMT_PARSE_ERROR);
 		R[n].first++;	/* Since the i/o machinery increments the current record number before we compare, we switch to 1 being the first row */
 		if (R[n].last != INTMAX_MAX) R[n].last++;	/* Same for last row unless infinite */
 		if ((++n) == GMT_MAX_RANGES) {

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -48,19 +48,17 @@ struct GMT_XINGS {
         unsigned int nx;	/* Number of intersections (1 or 2) */
 };
 
-EXTERN_MSC char *opt (struct GMTAPI_CTRL *API,char code);
-
+EXTERN_MSC size_t gmtlib_grd_data_size (struct GMT_CTRL *GMT, unsigned int format, gmt_grdfloat *nan_value);
 EXTERN_MSC double gmtlib_geo_centroid_area (struct GMT_CTRL *GMT, double *lon, double *lat, uint64_t n, double *centroid);
 EXTERN_MSC int gmtlib_set_current_item_file (struct GMT_CTRL *GMT, const char *item, char *file);
 EXTERN_MSC int gmtlib_polar_prepare_label (struct GMT_CTRL *GMT, double angle, unsigned int side, double *line_angle, double *text_angle, unsigned int *justify);
-EXTERN_MSC bool gmtinit_B_is_frame (struct GMT_CTRL *GMT, char *in);
-EXTERN_MSC int64_t gmt_parse_index_range (struct GMT_CTRL *GMT, char *p, int64_t *start, int64_t *stop);
+EXTERN_MSC bool gmtlib_B_is_frame (struct GMT_CTRL *GMT, char *in);
+EXTERN_MSC int64_t gmtlib_parse_index_range (struct GMT_CTRL *GMT, char *p, int64_t *start, int64_t *stop);
 EXTERN_MSC int gmtlib_ascii_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double *ptr, char *txt);
 EXTERN_MSC void gmtlib_reparse_i_option (struct GMT_CTRL *GMT, uint64_t n_columns);
 EXTERN_MSC void gmtlib_reparse_o_option (struct GMT_CTRL *GMT, uint64_t n_columns);
 EXTERN_MSC void gmtlib_get_graphics_item (struct GMTAPI_CTRL *API, int *fig, int *subplot, char *panel, int *inset);
 EXTERN_MSC unsigned int gmtlib_char_count (char *txt, char c);
-EXTERN_MSC void gmt_check_modern_oneliner (struct GMTAPI_CTRL *API, const char *module, struct GMT_OPTION *head);
 EXTERN_MSC void gmtlib_set_KOP_strings (struct GMTAPI_CTRL *API);
 EXTERN_MSC bool gmtlib_is_modern_name (struct GMTAPI_CTRL *API, const char *module);
 EXTERN_MSC const char * gmtlib_get_active_name (struct GMTAPI_CTRL *API, const char *module);
@@ -113,7 +111,7 @@ EXTERN_MSC int gmtlib_ogr_get_type (char *item);
 EXTERN_MSC void gmtlib_plot_C_format (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmtlib_clock_C_format (struct GMT_CTRL *GMT, char *form, struct GMT_CLOCK_IO *S, unsigned int mode);
 EXTERN_MSC void gmtlib_date_C_format (struct GMT_CTRL *GMT, char *form, struct GMT_DATE_IO *S, unsigned int mode);
-EXTERN_MSC void * gmtio_ascii_textinput (struct GMT_CTRL *GMT, FILE *fp, uint64_t *ncol, int *status);
+EXTERN_MSC void * gmtlib_ascii_textinput (struct GMT_CTRL *GMT, FILE *fp, uint64_t *ncol, int *status);
 EXTERN_MSC double gmtlib_get_map_interval (struct GMT_CTRL *GMT, struct GMT_PLOT_AXIS_ITEM *T);
 EXTERN_MSC unsigned int gmtlib_log_array (struct GMT_CTRL *GMT, double min, double max, double delta, double **array);
 EXTERN_MSC int gmtlib_nc_get_att_text (struct GMT_CTRL *GMT, int ncid, int varid, char *name, char *text, size_t textlen);
@@ -129,7 +127,6 @@ EXTERN_MSC int gmtlib_get_coordinate_label (struct GMT_CTRL *GMT, char *string, 
 EXTERN_MSC void gmtlib_get_time_label (struct GMT_CTRL *GMT, char *string, struct GMT_PLOT_CALCLOCK *P, struct GMT_PLOT_AXIS_ITEM *T, double t);
 EXTERN_MSC int gmtlib_getrgb_index (struct GMT_CTRL *GMT, double *rgb);
 EXTERN_MSC char * gmtlib_getuserpath (struct GMT_CTRL *GMT, const char *stem, char *path);	/* Look for user file */
-EXTERN_MSC size_t gmt_grd_data_size (struct GMT_CTRL *GMT, unsigned int format, gmt_grdfloat *nan_value);
 EXTERN_MSC void gmtlib_init_ellipsoid (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmtlib_init_geodesic (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmtlib_io_init (struct GMT_CTRL *GMT);			/* Initialize pointers */
@@ -171,7 +168,6 @@ EXTERN_MSC int gmtlib_get_grdtype (struct GMT_CTRL *GMT, unsigned int direction,
 EXTERN_MSC void gmtlib_grd_real_interleave (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_grdfloat *data);
 EXTERN_MSC void gmtlib_grd_get_units (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header);
 EXTERN_MSC void gmtlib_grd_set_units (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header);
-EXTERN_MSC int gmtinit_backwards_SQ_parsing (struct GMT_CTRL *GMT, char option, char *item);
 EXTERN_MSC int gmtlib_process_binary_input (struct GMT_CTRL *GMT, uint64_t n_read);
 EXTERN_MSC bool gmtlib_gap_detected (struct GMT_CTRL *GMT);
 EXTERN_MSC int gmtlib_set_gap (struct GMT_CTRL *GMT);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -66,7 +66,7 @@
  * gmt_set_cols
  * gmt_access
  * gmt_get_ogr_id
- * gmtio_ascii_textinput
+ * gmtlib_ascii_textinput
  * gmt_is_a_blank_line
  * gmtio_bin_colselect
  * gmt_skip_output
@@ -3565,7 +3565,7 @@ GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, 
 						GMT->current.io.record.text = NULL;
 					}
 					else if (n_cols_this_record == 0 && start_of_text) {	/* All text */
-						GMT->current.io.input = &gmtio_ascii_textinput;	/* Override and use ASCII text mode */
+						GMT->current.io.input = &gmtlib_ascii_textinput;	/* Override and use ASCII text mode */
 						strcpy (GMT->current.io.curr_trailing_text, line);
 						GMT->current.io.record.text = GMT->current.io.curr_trailing_text;
 						GMT->current.io.record.data = NULL;
@@ -5112,11 +5112,11 @@ int gmt_get_ogr_id (struct GMT_OGR *G, char *name) {
 }
 
 /*! . */
-void * gmtio_ascii_textinput (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, int *status) {
+void * gmtlib_ascii_textinput (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, int *status) {
 	bool more = true;
 	char line[GMT_BUFSIZ] = {""}, *p = NULL;
 
-	/* gmtio_ascii_textinput will read one text line and return it, setting
+	/* gmtlib_ascii_textinput will read one text line and return it, setting
 	 * header or segment flags in the process.
 	 */
 
@@ -7455,7 +7455,7 @@ struct GMT_DATATABLE * gmtlib_read_table (struct GMT_CTRL *GMT, void *source, un
 
 	if (ASCII && *geometry == GMT_IS_TEXT) {
 		psave = GMT->current.io.input;			/* Save the previous pointer since we need to change it back at the end */
-		GMT->current.io.input = &gmtio_ascii_textinput;	/* Override and use ASCII text mode */
+		GMT->current.io.input = &gmtlib_ascii_textinput;	/* Override and use ASCII text mode */
 		GMT->current.io.record_type[GMT_IN] = *data_type = GMT_READ_TEXT;
 	}
 

--- a/src/gmt_make_module_src.sh
+++ b/src/gmt_make_module_src.sh
@@ -128,15 +128,15 @@ gawk '{printf "EXTERN_MSC int GMT_%s (void *API, int mode, void *args);\n", $2;}
 cat << EOF >> ${FILE_GMT_MODULE_H}
 
 /* Pretty print all modules in the GMT ${L_TAG} library and their purposes */
-EXTERN_MSC void gmt_${L_TAG}_module_show_all (void *API);
+EXTERN_MSC void gmtlib_${L_TAG}_module_show_all (void *API);
 /* List all modern modules in the GMT ${L_TAG} library to stdout */
-EXTERN_MSC void gmt_${L_TAG}_module_list_all (void *API);
+EXTERN_MSC void gmtlib_${L_TAG}_module_list_all (void *API);
 /* List all classic modules in the GMT ${L_TAG} library to stdout */
-EXTERN_MSC void gmt_${L_TAG}_module_classic_all (void *API);
+EXTERN_MSC void gmtlib_${L_TAG}_module_classic_all (void *API);
 /* Function called by GMT_Encode_Options so developers can get information about a module */
-EXTERN_MSC const char * gmt_${L_TAG}_module_keys (void *API, char *candidate);
+EXTERN_MSC const char * gmtlib_${L_TAG}_module_keys (void *API, char *candidate);
 /* Function returns name of group that module belongs to (core, spotter, etc.) */
-EXTERN_MSC const char * gmt_${L_TAG}_module_group (void *API, char *candidate);
+EXTERN_MSC const char * gmtlib_${L_TAG}_module_group (void *API, char *candidate);
 
 #ifdef __cplusplus
 }
@@ -304,7 +304,7 @@ fi
 cat << EOF >> ${FILE_GMT_MODULE_C}
 
 /* Pretty print all GMT ${L_TAG} module names and their purposes for gmt --help */
-void gmt_${L_TAG}_module_show_all (void *V_API) {
+void gmtlib_${L_TAG}_module_show_all (void *V_API) {
 	unsigned int module_id = 0;
 	char message[GMT_LEN256];
 EOF
@@ -347,7 +347,7 @@ EOF
 
 cat << EOF >> ${FILE_GMT_MODULE_C}
 /* Produce single list on stdout of all GMT ${L_TAG} module names for gmt --show-modules */
-void gmt_${L_TAG}_module_list_all (void *V_API) {
+void gmtlib_${L_TAG}_module_list_all (void *V_API) {
 	unsigned int module_id = 0;
 EOF
 if [ "$U_TAG" = "CORE" ]; then
@@ -378,7 +378,7 @@ cat << EOF >> ${FILE_GMT_MODULE_C}
 }
 
 /* Produce single list on stdout of all GMT ${L_TAG} module names for gmt --show-classic [i.e., classic mode names] */
-void gmt_${L_TAG}_module_classic_all (void *V_API) {
+void gmtlib_${L_TAG}_module_classic_all (void *V_API) {
 	unsigned int module_id = 0;
 	size_t n_modules = 0;
 EOF
@@ -417,7 +417,7 @@ cat << EOF >> ${FILE_GMT_MODULE_C}
 }
 
 /* Lookup module id by name, return option keys pointer (for external API developers) */
-const char *gmt_${L_TAG}_module_keys (void *API, char *candidate) {
+const char *gmtlib_${L_TAG}_module_keys (void *API, char *candidate) {
 	int module_id = 0;
 	gmt_M_unused(API);
 
@@ -431,7 +431,7 @@ const char *gmt_${L_TAG}_module_keys (void *API, char *candidate) {
 }
 
 /* Lookup module id by name, return group char name (for external API developers) */
-const char *gmt_${L_TAG}_module_group (void *API, char *candidate) {
+const char *gmtlib_${L_TAG}_module_group (void *API, char *candidate) {
 	int module_id = 0;
 	gmt_M_unused(API);
 
@@ -450,7 +450,7 @@ if [ "$U_TAG" = "CORE" ]; then
 
 #ifndef BUILD_SHARED_LIBS
 /* Lookup static module id by name, return function pointer */
-void *gmt_${L_TAG}_module_lookup (void *API, const char *candidate) {
+void *gmtlib_${L_TAG}_module_lookup (void *API, const char *candidate) {
 	int module_id = 0;
 	size_t len = strlen (candidate);
 	gmt_M_unused(API);

--- a/src/gmt_parse.c
+++ b/src/gmt_parse.c
@@ -465,7 +465,7 @@ GMT_LOCAL void ensure_b_options_order (struct GMT_CTRL *GMT, struct GMT_OPTION *
 
 	for (opt = options; opt; opt = opt->next) {
 		if (opt->option != 'B') continue;	/* Only look at -B options here */
-		if (gmtinit_B_is_frame (GMT, opt->arg)) continue;	/* Don't care about the frame setting here */
+		if (gmtlib_B_is_frame (GMT, opt->arg)) continue;	/* Don't care about the frame setting here */
 		if ((c = gmt_first_modifier (GMT, opt->arg, "aflLpsSu"))) {	/* Option has axis modifier(s) */
 			c[0] = '\0';	/* Temporary chop them off */
 			k = 0;	/* Start of option string, then advance past any leading [p|s][x|y|z] */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -63,7 +63,6 @@ EXTERN_MSC int gmt_get_next_panel (struct GMTAPI_CTRL *API, int fig, int *row, i
 EXTERN_MSC int gmt_report_usage (struct GMTAPI_CTRL *API, struct GMT_OPTION *options, unsigned int special, int (*usage)(struct GMTAPI_CTRL *, int));
 EXTERN_MSC void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int justify);
 EXTERN_MSC struct GMT_SUBPLOT * gmt_subplot_info (struct GMTAPI_CTRL *API, int fig);
-EXTERN_MSC int get_V (char arg);
 EXTERN_MSC int gmt_get_V (char arg);
 EXTERN_MSC char gmt_set_V (int mode);
 EXTERN_MSC void gmt_conf_US (struct GMT_CTRL *GMT);
@@ -642,8 +641,9 @@ EXTERN_MSC void gmt_cart_to_polar (struct GMT_CTRL *GMT, double *r, double *thet
 EXTERN_MSC int gmt_copy (struct GMTAPI_CTRL *API, enum GMT_enum_family family, unsigned int direction, char *ifile, char *ofile);
 EXTERN_MSC struct GMTAPI_CTRL * gmt_get_api_ptr (struct GMTAPI_CTRL *ptr);
 EXTERN_MSC const char * gmt_show_name_and_purpose (void *API, const char *name, const char *component, const char *purpose);
-EXTERN_MSC bool gmtlib_is_an_object (struct GMT_CTRL *GMT, void *ptr);
+EXTERN_MSC bool gmt_is_an_object (struct GMT_CTRL *GMT, void *ptr);
 EXTERN_MSC unsigned int gmt_download_file_if_not_found (struct GMT_CTRL *GMT, const char * file_name, unsigned int mode);
+EXTERN_MSC const char *gmt_get_module_group (void *V_API, char *module);
 
 /* From gmt_stat.c */
 EXTERN_MSC double gmt_bei (struct GMT_CTRL *GMT, double x);

--- a/src/gmt_supplements_module.c
+++ b/src/gmt_supplements_module.c
@@ -102,7 +102,7 @@ static struct Gmt_moduleinfo g_supplements_module[] = {
 };
 
 /* Pretty print all GMT supplements module names and their purposes for gmt --help */
-void gmt_supplements_module_show_all (void *V_API) {
+void gmtlib_supplements_module_show_all (void *V_API) {
 	unsigned int module_id = 0;
 	char message[GMT_LEN256];
 	GMT_Message (V_API, GMT_TIME_NONE, "\n===  GMT suppl: The official supplements to the Generic Mapping Tools  ===\n");
@@ -121,7 +121,7 @@ void gmt_supplements_module_show_all (void *V_API) {
 }
 
 /* Produce single list on stdout of all GMT supplements module names for gmt --show-modules */
-void gmt_supplements_module_list_all (void *V_API) {
+void gmtlib_supplements_module_list_all (void *V_API) {
 	unsigned int module_id = 0;
 	gmt_M_unused(V_API);
 	while (g_supplements_module[module_id].cname != NULL) {
@@ -131,7 +131,7 @@ void gmt_supplements_module_list_all (void *V_API) {
 }
 
 /* Produce single list on stdout of all GMT supplements module names for gmt --show-classic [i.e., classic mode names] */
-void gmt_supplements_module_classic_all (void *V_API) {
+void gmtlib_supplements_module_classic_all (void *V_API) {
 	unsigned int module_id = 0;
 	size_t n_modules = 0;
 	gmt_M_unused(V_API);
@@ -149,7 +149,7 @@ void gmt_supplements_module_classic_all (void *V_API) {
 }
 
 /* Lookup module id by name, return option keys pointer (for external API developers) */
-const char *gmt_supplements_module_keys (void *API, char *candidate) {
+const char *gmtlib_supplements_module_keys (void *API, char *candidate) {
 	int module_id = 0;
 	gmt_M_unused(API);
 
@@ -163,7 +163,7 @@ const char *gmt_supplements_module_keys (void *API, char *candidate) {
 }
 
 /* Lookup module id by name, return group char name (for external API developers) */
-const char *gmt_supplements_module_group (void *API, char *candidate) {
+const char *gmtlib_supplements_module_group (void *API, char *candidate) {
 	int module_id = 0;
 	gmt_M_unused(API);
 

--- a/src/gmt_supplements_module.h
+++ b/src/gmt_supplements_module.h
@@ -74,15 +74,15 @@ EXTERN_MSC int GMT_x2sys_report (void *API, int mode, void *args);
 EXTERN_MSC int GMT_x2sys_solve (void *API, int mode, void *args);
 
 /* Pretty print all modules in the GMT supplements library and their purposes */
-EXTERN_MSC void gmt_supplements_module_show_all (void *API);
+EXTERN_MSC void gmtlib_supplements_module_show_all (void *API);
 /* List all modern modules in the GMT supplements library to stdout */
-EXTERN_MSC void gmt_supplements_module_list_all (void *API);
+EXTERN_MSC void gmtlib_supplements_module_list_all (void *API);
 /* List all classic modules in the GMT supplements library to stdout */
-EXTERN_MSC void gmt_supplements_module_classic_all (void *API);
+EXTERN_MSC void gmtlib_supplements_module_classic_all (void *API);
 /* Function called by GMT_Encode_Options so developers can get information about a module */
-EXTERN_MSC const char * gmt_supplements_module_keys (void *API, char *candidate);
+EXTERN_MSC const char * gmtlib_supplements_module_keys (void *API, char *candidate);
 /* Function returns name of group that module belongs to (core, spotter, etc.) */
-EXTERN_MSC const char * gmt_supplements_module_group (void *API, char *candidate);
+EXTERN_MSC const char * gmtlib_supplements_module_group (void *API, char *candidate);
 
 #ifdef __cplusplus
 }

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15191,7 +15191,7 @@ struct GMT_INT_SELECTION * gmt_set_int_selection (struct GMT_CTRL *GMT, char *it
 	for (k = n = 0; k < n_items; k++) {
 		pos = 0;	/* Reset since gmt_strtok changed it */
 		while ((gmt_strtok (list[k], ",", &pos, p))) {	/* While it is not empty or there are parsing errors, process next item */
-			if ((step = gmt_parse_index_range (GMT, p, &start, &stop)) == 0) {
+			if ((step = gmtlib_parse_index_range (GMT, p, &start, &stop)) == 0) {
 				gmt_free_int_selection (GMT, &select);
 				gmtlib_free_list (GMT, list, n_items);
 				return (NULL);

--- a/src/gmtmath.c
+++ b/src/gmtmath.c
@@ -5808,7 +5808,7 @@ GMT_LOCAL void gmtmath_free_stack (struct GMTAPI_CTRL *API, struct GMTMATH_STACK
 	struct GMT_DATASET_HIDDEN *DH = NULL;
 	for (k = 0; k < GMTMATH_STACK_SIZE; k++) {
 		if (stack[k]->D) {	/* Must free unless being passed back out */
-			is_object = gmtlib_is_an_object (API->GMT, &stack[k]->D);
+			is_object = gmt_is_an_object (API->GMT, &stack[k]->D);
 			if (is_object && (error = GMT_Destroy_Data (API, &stack[k]->D)) == GMT_NOERROR)
 				GMT_Report (API, GMT_MSG_DEBUG, "GMT_Destroy_Data freed stack item %d\n", k);
 			else if (!is_object || error == GMT_OBJECT_NOT_FOUND) {

--- a/src/mgd77/mgd77manage.c
+++ b/src/mgd77/mgd77manage.c
@@ -27,7 +27,7 @@
 #define THIS_MODULE_PURPOSE	"Manage the content of MGD77+ files"
 #define THIS_MODULE_KEYS	""
 #define THIS_MODULE_NEEDS	""
-#define THIS_MODULE_OPTIONS "-RVbjn"
+#define THIS_MODULE_OPTIONS "-RVbjn" GMT_OPT("Q")
 
 #define N_PAR		7
 #define COL_SCALE	0
@@ -58,8 +58,6 @@
 #define MODE_i		6
 #define MODE_n		7
 #define MODE_t		8
-
-EXTERN_MSC int gmtinit_backwards_SQ_parsing (struct GMT_CTRL *GMT, char option, char *item);
 
 struct MGD77MANAGE_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
@@ -471,12 +469,6 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct MGD77MANAGE_CTRL *Ctrl, struct
 				}
 				break;
 
-			case 'Q':	/* Backwards compatible.  Grid interpolation options are now be set with -n */
-				if (gmt_M_compat_check (GMT, 4))
-					n_errors += gmtinit_backwards_SQ_parsing (GMT, 'Q', opt->arg);
-				else
-					n_errors += gmt_default_error (GMT, opt->option);
-				break;
 			default:	/* Report bad options */
 				n_errors += gmt_default_error (GMT, opt->option);
 				break;


### PR DESCRIPTION
**Description of proposed changes**

Also, renamed badly named functions and removed some unused declarations.  Eliminated spurious extern declaration in some modules which duplicated entries in gmt_prototypes.h; same for externs listed in some gmt_*.c files that had entries in gmt_internals.h.  Also added missing entries for some functions to those two includes.

