### PR TITLE
CI: Cache GMT remote files for testings

### DIFF
--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -56,6 +56,14 @@ steps:
     cmake --build .
   displayName: Compile GMT
 
+# Cache the ${HOME}/.gmt directory, for docs and testing
+- task: Cache@2
+  inputs:
+    key: cachedata | 20200409
+    path: $(HOME)/.gmt
+    cacheHitVar: CACHE_CACHEDATA_RESTORED
+  displayName: Cache GMT remote data for testing
+
 - bash: |
     set -x -e
     cd build
@@ -83,14 +91,17 @@ steps:
     gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
   displayName: Check a few simple commands
 
-# Run the full tests
+# Download remote files, if not already cached
 - bash: |
     set -x -e
-    # Download cache files from remote server before testing, see see #939.
     $(gmt --show-sharedir)/tools/gmt_getremote.sh cache
-    # Download earth relief files used in testing
     gmt which -Gu @earth_relief_01m @earth_relief_02m @earth_relief_04m @earth_relief_05m @earth_relief_10m @earth_relief_15m
-    # run all jobs, and rerun failed jobs
+  displayName: Download remote data
+  condition: ne(variables['CACHE_CACHEDATA_RESTORED'], true)
+
+# Run the full tests, and rerun failed tests
+- bash: |
+    set -x -e
     cd build
     ctest ${CTEST_ARGS} || ctest ${CTEST_ARGS} --rerun-failed || ctest ${CTEST_ARGS} --rerun-failed
   displayName: Full tests

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -59,6 +59,14 @@ steps:
     cmake --build .
   displayName: Compile GMT
 
+# Cache the ${HOME}/.gmt directory, for docs and testing
+- task: Cache@2
+  inputs:
+    key: cachedata | 20200409
+    path: $(HOME)/.gmt
+    cacheHitVar: CACHE_CACHEDATA_RESTORED
+  displayName: Cache GMT remote data for testing
+
 - bash: |
     set -x -e
     cd build
@@ -86,14 +94,17 @@ steps:
     gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
   displayName: Check a few simple commands
 
-# Run the full tests
+# Download remote files, if not already cached
 - bash: |
     set -x -e
-    # Download cache files from remote server before testing, see see #939.
     $(gmt --show-sharedir)/tools/gmt_getremote.sh cache
-    # Download earth relief files used in testing
     gmt which -Gu @earth_relief_01m @earth_relief_02m @earth_relief_04m @earth_relief_05m @earth_relief_10m @earth_relief_15m
-    # run all jobs, and rerun failed jobs
+  displayName: Download remote data
+  condition: ne(variables['CACHE_CACHEDATA_RESTORED'], true)
+
+# Run the full tests, and rerun failed tests
+- bash: |
+    set -x -e
     cd build
     ctest ${CTEST_ARGS} || ctest ${CTEST_ARGS} --rerun-failed
   displayName: Full tests

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -102,6 +102,14 @@ steps:
     cmake --build .
   displayName: Compile GMT
 
+# Cache the ${HOME}/.gmt directory, for docs and testing
+- task: Cache@2
+  inputs:
+    key: cachedata | 20200409
+    path: $(HOME)/.gmt
+    cacheHitVar: CACHE_CACHEDATA_RESTORED
+  displayName: Cache GMT remote data for testing
+
 - bash: |
     set -x -e
     cd build
@@ -127,15 +135,19 @@ steps:
     gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
   displayName: Check a few simple commands
 
+# Download remote files, if not already cached
 - bash: |
     set -x -e
-    # Download cache files from remote server before testing, see see #939.
     $(gmt --show-sharedir)/tools/gmt_getremote.sh cache
-    # Download earth relief files used in testing
     gmt which -Gu @earth_relief_01m @earth_relief_02m @earth_relief_04m @earth_relief_05m @earth_relief_10m @earth_relief_15m
+  displayName: Download remote data
+  condition: ne(variables['CACHE_CACHEDATA_RESTORED'], true)
+
+# Run the full tests, and rerun failed tests
+- bash: |
+    set -x -e
     # disable MinGW's path conversion, see #1035.
     export MSYS_NO_PATHCONV=1
-    # run all jobs, and rerun failed jobs
     cd build
     ctest ${CTEST_ARGS} || ctest ${CTEST_ARGS} --rerun-failed || ctest ${CTEST_ARGS} --rerun-failed
   displayName: Full tests


### PR DESCRIPTION
Recently, the nightly CI jobs fail on Linux and Windows, but succeed on macOS.

The CI jobs fail because the Linux and Windows agents cann't connect to
any external websites, thus GMT can't download any remote files from the GMT server.
It's unclear if it's a temporary issue of Azure Pipelines.

Currently, the only workaround is using the cache mechanism of Azure Pipelines.
The macOS agents download remote files to ${HOME}/.gmt and save them to
the CI cache, then Linux and Windows agents can restore the cache when
needed.

The only problem is that the Azure Pipelines caches are immutable.
When the remote files are changed, we have to manually update the cache key (i.e. update the key 20200409 to a new date) to regenerate the caches.