### PR TITLE
Rename static functions in a series of gmt_*.c files

### DIFF
--- a/src/gmt_agc_io.c
+++ b/src/gmt_agc_io.c
@@ -57,7 +57,7 @@ int gmt_agc_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 
 /* Local runctions used by the public functions: */
 
-GMT_LOCAL int agc_read_record (FILE *fpi, gmt_grdfloat z[ZBLOCKWIDTH][ZBLOCKHEIGHT]) {
+GMT_LOCAL int gmtagcio_read_record (FILE *fpi, gmt_grdfloat z[ZBLOCKWIDTH][ZBLOCKHEIGHT]) {
 	/* Reads one block of data, including pre- and post-headers */
 	size_t nitems;
 	gmt_grdfloat garbage[PREHEADSIZE];
@@ -73,7 +73,7 @@ GMT_LOCAL int agc_read_record (FILE *fpi, gmt_grdfloat z[ZBLOCKWIDTH][ZBLOCKHEIG
 	return (GMT_NOERROR);
 }
 
-GMT_LOCAL int agc_write_record (FILE *file, gmt_grdfloat rec[ZBLOCKWIDTH][ZBLOCKHEIGHT], gmt_grdfloat *prerec, gmt_grdfloat *postrec) {
+GMT_LOCAL int gmtagcio_write_record (FILE *file, gmt_grdfloat rec[ZBLOCKWIDTH][ZBLOCKHEIGHT], gmt_grdfloat *prerec, gmt_grdfloat *postrec) {
 	/* Writes one block of data, including pre- and post-headers */
 	if (gmt_M_fwrite (prerec, sizeof(gmt_grdfloat), PREHEADSIZE, file) < PREHEADSIZE)
 		return (GMT_GRDIO_WRITE_FAILED);
@@ -84,7 +84,7 @@ GMT_LOCAL int agc_write_record (FILE *file, gmt_grdfloat rec[ZBLOCKWIDTH][ZBLOCK
 	return (GMT_NOERROR);
 }
 
-GMT_LOCAL void agc_pack_header (gmt_grdfloat *prez, gmt_grdfloat *postz, struct GMT_GRID_HEADER *header) {
+GMT_LOCAL void gmtagcio_pack_header (gmt_grdfloat *prez, gmt_grdfloat *postz, struct GMT_GRID_HEADER *header) {
 	/* Places grd header info in the AGC header array */
 	gmt_M_memset (prez,  PREHEADSIZE,  gmt_grdfloat);
 	gmt_M_memset (postz, POSTHEADSIZE, gmt_grdfloat);
@@ -97,7 +97,7 @@ GMT_LOCAL void agc_pack_header (gmt_grdfloat *prez, gmt_grdfloat *postz, struct 
 	prez[PREHEADSIZE-1] = (gmt_grdfloat)RECORDLENGTH;
 }
 
-GMT_LOCAL void agc_save_header (char *remark, gmt_grdfloat *agchead) {
+GMT_LOCAL void gmtagcio_save_header (char *remark, gmt_grdfloat *agchead) {
 	/* Place AGC header data in remark string */
 	char floatvalue[PARAMSIZE+1];	/* Allow space for final \0 */
 	unsigned int i;
@@ -209,7 +209,7 @@ int gmt_agc_read_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header)
 	for (i = 6; i < PREHEADSIZE; i++) agchead[i-6] = recdata[i];
 	agchead[BUFFHEADSIZE-2] = recdata[RECORDLENGTH-2];
 	agchead[BUFFHEADSIZE-1] = recdata[RECORDLENGTH-1];
-	agc_save_header (header->remark, agchead);
+	gmtagcio_save_header (header->remark, agchead);
 
 	gmt_fclose (GMT, fp);
 
@@ -231,7 +231,7 @@ int gmt_agc_write_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header
 	else if ((fp = gmt_fopen (GMT, HH->name, "rb+")) == NULL && (fp = gmt_fopen (GMT, HH->name, "wb")) == NULL)
 		return (GMT_GRDIO_CREATE_FAILED);
 
-	agc_pack_header (prez, postz, header);	/* Stuff header info into the AGC arrays */
+	gmtagcio_pack_header (prez, postz, header);	/* Stuff header info into the AGC arrays */
 
 	if (gmt_M_fwrite (prez, sizeof(gmt_grdfloat), PREHEADSIZE, fp) < PREHEADSIZE) {
 		gmt_fclose (GMT, fp);
@@ -297,7 +297,7 @@ int gmt_agc_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_
 	n_blocks = n_blocks_x * n_blocks_y;
 	datablockcol = datablockrow = 0;
 	for (block = 0; block < n_blocks; block++) {
-		if (agc_read_record (fp, z)) {
+		if (gmtagcio_read_record (fp, z)) {
 			gmt_M_free (GMT, k);
 			gmt_fclose (GMT, fp);
 			return (GMT_GRDIO_READ_FAILED);
@@ -407,9 +407,9 @@ int gmt_agc_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "AGC grid region in file %s reset to %g/%g/%g/%g\n", HH->name, header->wesn[XLO], header->wesn[XHI], header->wesn[YLO], header->wesn[YHI]);
 	}
 
-	agc_pack_header (prez, postz, header);	/* Stuff header info into the AGC arrays */
+	gmtagcio_pack_header (prez, postz, header);	/* Stuff header info into the AGC arrays */
 
-	gmt_M_memset (outz, ZBLOCKWIDTH * ZBLOCKHEIGHT, gmt_grdfloat); /* or agc_write_record (fp, outz, prez, postz); points to uninitialised buffer */
+	gmt_M_memset (outz, ZBLOCKWIDTH * ZBLOCKHEIGHT, gmt_grdfloat); /* or gmtagcio_write_record (fp, outz, prez, postz); points to uninitialised buffer */
 
 	n_blocks_y = urint (ceil ((double)header->n_rows / (double)ZBLOCKHEIGHT));
 	n_blocks_x = urint (ceil ((double)header->n_columns / (double)ZBLOCKWIDTH));
@@ -430,7 +430,7 @@ int gmt_agc_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 			}
 		}
 
-		if (agc_write_record (fp, outz, prez, postz)) {
+		if (gmtagcio_write_record (fp, outz, prez, postz)) {
 			gmt_M_free (GMT, k);
 			gmt_fclose (GMT, fp);
 			return (GMT_GRDIO_WRITE_FAILED);

--- a/src/gmt_calclock.c
+++ b/src/gmt_calclock.c
@@ -55,13 +55,13 @@
 #include "gmt_internals.h"
 
 /* Private functions to this file:
-   int calclock_kday_on_or_before (int date, int kday);
-   int calclock_kday_after (int date, int kday);
-   int calclock_kday_before (int date, int kday);
-   int calclock_nth_kday (int n, int kday, int date);
-   int calclock_cal_imod (int x, int y);
-   int calclock_gyear_from_rd (int date);
-   void calclock_small_moment_interval (struct GMT_CTRL *GMT, struct GMT_MOMENT_INTERVAL *p, int step_secs, int init);  Aux to gmtlib_moment_interval
+   int gmtcalclock_kday_on_or_before (int date, int kday);
+   int gmtcalclock_kday_after (int date, int kday);
+   int gmtcalclock_kday_before (int date, int kday);
+   int gmtcalclock_nth_kday (int n, int kday, int date);
+   int gmtcalclock_cal_imod (int x, int y);
+   int gmtcalclock_gyear_from_rd (int date);
+   void gmtcalclock_small_moment_interval (struct GMT_CTRL *GMT, struct GMT_MOMENT_INTERVAL *p, int step_secs, int init);  Aux to gmtlib_moment_interval
 */
 
 /* Modulo functions.  The C operation "x%y" and the POSIX
@@ -75,7 +75,7 @@
 	print a domain error and return something anyway.
 */
 
-GMT_LOCAL int calclock_cal_imod (int64_t x, int y) {
+GMT_LOCAL int gmtcalclock_cal_imod (int64_t x, int y) {
 	assert (y != 0);
 	return ((int)(x - y * lrint (floor ((double)x / (double)y))));
 }
@@ -85,40 +85,40 @@ GMT_LOCAL int calclock_cal_imod (int64_t x, int y) {
    1 = Mon, etc. through 6 = Sat.  (Note that ISO day of
    the week is the same for all of these except ISO Sunday
    is 7.)  Since rata die 1 is a Monday, we have kday from
-   rd is simply calclock_cal_imod(rd, 7).  The various functions
+   rd is simply gmtcalclock_cal_imod(rd, 7).  The various functions
    below take an rd and find another rd related to the first
    through the fact that the related day falls on a given
    kday of the week.  */
 
-GMT_LOCAL int64_t calclock_kday_on_or_before (int64_t date, int kday) {
+GMT_LOCAL int64_t gmtcalclock_kday_on_or_before (int64_t date, int kday) {
 	/* Given date and kday, return the date of the nearest kday
 	   on or before the given date. */
-	return (date - calclock_cal_imod (date-kday, 7));
+	return (date - gmtcalclock_cal_imod (date-kday, 7));
 }
 
-GMT_LOCAL int64_t calclock_kday_after (int64_t date, int kday) {
+GMT_LOCAL int64_t gmtcalclock_kday_after (int64_t date, int kday) {
 	/* Given date and kday, return the date of the nearest kday
 	   after the given date. */
-	return (calclock_kday_on_or_before (date+7, kday));
+	return (gmtcalclock_kday_on_or_before (date+7, kday));
 }
 
-GMT_LOCAL int64_t calclock_kday_before (int64_t date, int kday) {
+GMT_LOCAL int64_t gmtcalclock_kday_before (int64_t date, int kday) {
 	/* Given date and kday, return the date of the nearest kday
 	   before the given date. */
-	return (calclock_kday_on_or_before (date-1, kday));
+	return (gmtcalclock_kday_on_or_before (date-1, kday));
 }
 
-GMT_LOCAL int64_t calclock_nth_kday (int n, int kday, int64_t date) {
+GMT_LOCAL int64_t gmtcalclock_nth_kday (int n, int kday, int64_t date) {
 	/* Given date, kday, and n, return the date of the n'th
 	   kday before or after the given date, according to the
 	   sign of n. */
 	if (n > 0)
-		return (7*n + calclock_kday_before (date, kday));
+		return (7*n + gmtcalclock_kday_before (date, kday));
 	else
-		return (7*n + calclock_kday_after (date, kday));
+		return (7*n + gmtcalclock_kday_after (date, kday));
 }
 
-GMT_LOCAL int calclock_gyear_from_rd (int64_t date) {
+GMT_LOCAL int gmtcalclock_gyear_from_rd (int64_t date) {
 	/* Given rata die integer day number, return proleptic Gregorian year  */
 
 	int64_t d0, d1, d2, d3;
@@ -126,13 +126,13 @@ GMT_LOCAL int calclock_gyear_from_rd (int64_t date) {
 
 	d0 = date - 1;
 	n400 = irint (floor (d0 / 146097.0));
-	d1 = calclock_cal_imod (d0, 146097);
+	d1 = gmtcalclock_cal_imod (d0, 146097);
 	n100 = irint (floor (d1 / 36524.0));
-	d2 = calclock_cal_imod (d1, 36524);
+	d2 = gmtcalclock_cal_imod (d1, 36524);
 	n4 = irint (floor (d2 / 1461.0));
-	d3 = calclock_cal_imod (d2, 1461);
+	d3 = gmtcalclock_cal_imod (d2, 1461);
 	n1 = irint (floor (d3 / 365.0));
-	/* d4 = calclock_cal_imod (d3, 365) + 1; NOT USED (removed) */
+	/* d4 = gmtcalclock_cal_imod (d3, 365) + 1; NOT USED (removed) */
 	year = 400*n400 + 100*n100 + 4*n4 + n1;
 
 	if (n100 != 4 && n1 != 4) year++;
@@ -140,7 +140,7 @@ GMT_LOCAL int calclock_gyear_from_rd (int64_t date) {
 	return (year);
 }
 
-GMT_LOCAL void calclock_small_moment_interval (struct GMT_CTRL *GMT, struct GMT_MOMENT_INTERVAL *p, int step_secs, bool init) {
+GMT_LOCAL void gmtcalclock_small_moment_interval (struct GMT_CTRL *GMT, struct GMT_MOMENT_INTERVAL *p, int step_secs, bool init) {
 
 	/* Called by gmtlib_moment_interval ().  Get here when p->stuff[0] is initialized and
 	   0 < step_secs <= GMT_DAY2SEC_I.  If init, stuff[0] may need to be truncated.  */
@@ -257,11 +257,11 @@ bool gmtlib_is_gleap (int gyear) {
 
 	int y400;
 
-	if (calclock_cal_imod (gyear, 4) != 0) return (false);
+	if (gmtcalclock_cal_imod (gyear, 4) != 0) return (false);
 
-	y400 = calclock_cal_imod (gyear, 400);
+	y400 = gmtcalclock_cal_imod (gyear, 400);
 	if (y400 == 0) return (true);
-	if (calclock_cal_imod (y400, 100) == 0) return (false);
+	if (gmtcalclock_cal_imod (y400, 100) == 0) return (false);
 
 	return (true);
 }
@@ -302,7 +302,7 @@ int64_t gmtlib_rd_from_iywd (struct GMT_CTRL *GMT, int iy, int iw, int id) {
 
 	/* Add id to the iw'th Sunday after Dec 28 iy-1:  */
 	rdtemp = gmt_rd_from_gymd (GMT, iy-1, 12, 28);
-	return (id + calclock_nth_kday (iw, 0, rdtemp));
+	return (id + gmtcalclock_nth_kday (iw, 0, rdtemp));
 }
 
 /* Set calendar struct data from fixed date:  */
@@ -316,11 +316,11 @@ void gmt_gcal_from_rd (struct GMT_CTRL *GMT, int64_t date, struct GMT_GCAL *gcal
 
 	/* Day of the week in 0 through 6:  */
 
-	gcal->day_w = calclock_cal_imod (date, 7);
+	gcal->day_w = gmtcalclock_cal_imod (date, 7);
 
 	/* proleptic Gregorian operations:  */
 
-	gcal->year = calclock_gyear_from_rd (date);
+	gcal->year = gmtcalclock_gyear_from_rd (date);
 	prior_days = date - gmt_rd_from_gymd (GMT, gcal->year, 1, 1);
 	gcal->day_y = (unsigned int)prior_days + 1;
 
@@ -603,7 +603,7 @@ void gmtlib_moment_interval (struct GMT_CTRL *GMT, struct GMT_MOMENT_INTERVAL *p
 			if (gmt_M_compat_check (GMT, 4)) {
 				GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Unit c for seconds is deprecated; use s.\n");
 				k = p->step;
-				calclock_small_moment_interval (GMT, p, k, init);
+				gmtcalclock_small_moment_interval (GMT, p, k, init);
 			}
 			else {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "GMT_LOGIC_BUG:  Bad unit in GMT_init_moment_interval()\n");
@@ -613,17 +613,17 @@ void gmtlib_moment_interval (struct GMT_CTRL *GMT, struct GMT_MOMENT_INTERVAL *p
 		case 'S':
 
 			k = p->step;
-			calclock_small_moment_interval (GMT, p, k, init);
+			gmtcalclock_small_moment_interval (GMT, p, k, init);
 			break;
 		case 'm':
 		case 'M':
 			k = GMT_MIN2SEC_I * p->step;
-			calclock_small_moment_interval (GMT, p, k, init);
+			gmtcalclock_small_moment_interval (GMT, p, k, init);
 			break;
 		case 'h':
 		case 'H':
 			k = GMT_HR2SEC_I * p->step;
-			calclock_small_moment_interval (GMT, p, k, init);
+			gmtcalclock_small_moment_interval (GMT, p, k, init);
 			break;
 		case 'd':
 		case 'D':
@@ -631,7 +631,7 @@ void gmtlib_moment_interval (struct GMT_CTRL *GMT, struct GMT_MOMENT_INTERVAL *p
 				/* Here we want every day (of the Gregorian month or year)
 					so the stepping is easy.  */
 				k = GMT_DAY2SEC_I;
-				calclock_small_moment_interval (GMT, p, k, init);
+				gmtcalclock_small_moment_interval (GMT, p, k, init);
 			}
 			else if (GMT->current.plot.calclock.date.day_of_year) {
 				/* Select every n'th day of the Gregorian year  */
@@ -741,7 +741,7 @@ void gmtlib_moment_interval (struct GMT_CTRL *GMT, struct GMT_MOMENT_INTERVAL *p
 				/* Floor to the first day of the week start.  */
 				k = p->cc[0].day_w - GMT->current.setting.time_week_start;
 				if (k) {
-					p->rd[0] -= calclock_cal_imod(k, 7);
+					p->rd[0] -= gmtcalclock_cal_imod(k, 7);
  					gmt_gcal_from_rd (GMT, p->rd[0], &(p->cc[0]) );
  				}
 				p->sd[0] = 0.0;
@@ -825,12 +825,12 @@ void gmtlib_moment_interval (struct GMT_CTRL *GMT, struct GMT_MOMENT_INTERVAL *p
 				/* Floor to the step'th year, either ISO or Gregorian, depending on... */
 				if (GMT->current.plot.calclock.date.iso_calendar) {
 					p->sd[0] = 0.0;
-					if (p->step > 1) p->cc[0].iso_y -= calclock_cal_imod (p->cc[0].iso_y, p->step);
+					if (p->step > 1) p->cc[0].iso_y -= gmtcalclock_cal_imod (p->cc[0].iso_y, p->step);
 					p->rd[0] = gmtlib_rd_from_iywd (GMT, p->cc[0].iso_y, 1, 1);
 				}
 				else {
 					p->sd[0] = 0.0;
-					if (p->step > 1) p->cc[0].year -= calclock_cal_imod (p->cc[0].year, p->step);
+					if (p->step > 1) p->cc[0].year -= gmtcalclock_cal_imod (p->cc[0].year, p->step);
 					p->rd[0] = gmt_rd_from_gymd (GMT, p->cc[0].year, 1, 1);
 				}
 				gmt_gcal_from_rd (GMT, p->rd[0], &(p->cc[0]) );

--- a/src/gmt_customio.c
+++ b/src/gmt_customio.c
@@ -116,7 +116,7 @@ int gmt_dummy_grd_read (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gm
 
 #define	RAS_MAGIC	0x59a66a95
 
-GMT_LOCAL int customio_read_rasheader (FILE *fp, struct rasterfile *h) {
+GMT_LOCAL int gmtcustomio_read_rasheader (FILE *fp, struct rasterfile *h) {
 	/* Reads the header of a Sun rasterfile byte by byte
 	   since the format is defined as the byte order on the
 	   PDP-11.
@@ -149,7 +149,7 @@ GMT_LOCAL int customio_read_rasheader (FILE *fp, struct rasterfile *h) {
 	return (GMT_NOERROR);
 }
 
-GMT_LOCAL int customio_write_rasheader (FILE *fp, struct rasterfile *h) {
+GMT_LOCAL int gmtcustomio_write_rasheader (FILE *fp, struct rasterfile *h) {
 	/* Writes the header of a Sun rasterfile byte by byte
 	   since the format is defined as the byte order on the
 	   PDP-11.
@@ -198,7 +198,7 @@ int gmt_is_ras_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header) {
 	if ((fp = gmt_fopen (GMT, HH->name, "rb")) == NULL)
 		return (GMT_GRDIO_OPEN_FAILED);
 	gmt_M_memset (&h, 1, struct rasterfile);
-	if (customio_read_rasheader (fp, &h)) {
+	if (gmtcustomio_read_rasheader (fp, &h)) {
 		gmt_fclose (GMT, fp);
 		return (GMT_GRDIO_READ_FAILED);
 	}
@@ -232,7 +232,7 @@ int gmt_ras_read_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header)
 		return (GMT_GRDIO_OPEN_FAILED);
 
 	gmt_M_memset (&h, 1, struct rasterfile);
-	if (customio_read_rasheader (fp, &h)) {
+	if (gmtcustomio_read_rasheader (fp, &h)) {
 		gmt_fclose (GMT, fp);
 		return (GMT_GRDIO_READ_FAILED);
 	}
@@ -288,7 +288,7 @@ int gmt_ras_write_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header
 	h.type = 1;
 	h.maptype = h.maplength = 0;
 
-	if (customio_write_rasheader (fp, &h))  {
+	if (gmtcustomio_write_rasheader (fp, &h))  {
 		gmt_fclose (GMT, fp);
 		return (GMT_GRDIO_WRITE_FAILED);
 	}
@@ -326,7 +326,7 @@ int gmt_ras_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_
 		piping = true;
 	}
 	else if ((fp = gmt_fopen (GMT, HH->name, "rb")) != NULL) {	/* Skip header */
-		if (customio_read_rasheader (fp, &h)) {
+		if (gmtcustomio_read_rasheader (fp, &h)) {
 			gmt_fclose (GMT, fp);
 			return (GMT_GRDIO_READ_FAILED);
 		}
@@ -470,7 +470,7 @@ int gmt_ras_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 
 	/* store header information and array */
 
-	if (customio_write_rasheader (fp, &h)) {
+	if (gmtcustomio_write_rasheader (fp, &h)) {
 		gmt_fclose (GMT, fp);
 		gmt_M_free (GMT, actual_col);
 		gmt_M_free (GMT, tmp);
@@ -526,7 +526,7 @@ int gmt_ras_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 /* sizeof the complete native header */
 #define SIZEOF_NATIVE_GRD_HDR  892 /* SIZEOF_NATIVE_GRD_HDR1 + SIZEOF_NATIVE_GRD_HD */
 
-GMT_LOCAL int customio_native_read_grd_header (FILE *fp, struct GMT_GRID_HEADER *header) {
+GMT_LOCAL int gmtcustomio_native_read_grd_header (FILE *fp, struct GMT_GRID_HEADER *header) {
 	int err = GMT_NOERROR;
 	/* Because GMT_GRID_HEADER is not 64-bit aligned we must read it in parts */
 	if (gmt_M_fread (&header->n_columns, SIZEOF_NATIVE_GRD_HDR1, 1U, fp) != 1 ||
@@ -552,7 +552,7 @@ int gmt_native_read_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 	else if ((fp = gmt_fopen (GMT, HH->name, "rb")) == NULL)
 		return (GMT_GRDIO_OPEN_FAILED);
 
-	status = customio_native_read_grd_header (fp, header);
+	status = gmtcustomio_native_read_grd_header (fp, header);
 	gmt_fclose (GMT, fp);
 	return status;
 }
@@ -646,7 +646,7 @@ int gmt_is_native_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header) {
 	free_and_return (GMT_NOERROR);
 }
 
-GMT_LOCAL int customio_native_write_grd_header (FILE *fp, struct GMT_GRID_HEADER *header) {
+GMT_LOCAL int gmtcustomio_native_write_grd_header (FILE *fp, struct GMT_GRID_HEADER *header) {
 	int err = GMT_NOERROR;
 	/* Because GMT_GRID_HEADER is not 64-bit aligned we must write it in parts */
 
@@ -656,7 +656,7 @@ GMT_LOCAL int customio_native_write_grd_header (FILE *fp, struct GMT_GRID_HEADER
 	return (err);
 }
 
-GMT_LOCAL int customio_native_skip_grd_header (FILE *fp, struct GMT_GRID_HEADER *header) {
+GMT_LOCAL int gmtcustomio_native_skip_grd_header (FILE *fp, struct GMT_GRID_HEADER *header) {
 	int err = GMT_NOERROR;
 	gmt_M_unused(header);
 	/* Because GMT_GRID_HEADER is not 64-bit aligned we must estimate the # of bytes in parts */
@@ -693,7 +693,7 @@ int gmt_bit_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_
 		piping = true;
 	}
 	else if ((fp = gmt_fopen (GMT, HH->name, "rb")) != NULL) {	/* Skip header */
-		gmt_M_err_trap (customio_native_skip_grd_header (fp, header));
+		gmt_M_err_trap (gmtcustomio_native_skip_grd_header (fp, header));
 	}
 	else
 		return (GMT_GRDIO_OPEN_FAILED);
@@ -838,7 +838,7 @@ int gmt_bit_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 	/* Store header information and array */
 
 	if (do_header) {
-		if ((err = customio_native_write_grd_header (fp, header))) {
+		if ((err = gmtcustomio_native_write_grd_header (fp, header))) {
 			gmt_fclose (GMT, fp);
 			gmt_M_free (GMT, actual_col);
 			return err;
@@ -926,7 +926,7 @@ int gmt_native_write_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *hea
 	else if ((fp = gmt_fopen (GMT, HH->name, "rb+")) == NULL && (fp = gmt_fopen (GMT, HH->name, "wb")) == NULL)
 		return (GMT_GRDIO_CREATE_FAILED);
 
-	err = customio_native_write_grd_header (fp, header);
+	err = gmtcustomio_native_write_grd_header (fp, header);
 	gmt_fclose (GMT, fp);
 
 	if (err)
@@ -969,7 +969,7 @@ int gmt_native_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, g
 		piping = true;
 	}
 	else if ((fp = gmt_fopen (GMT, HH->name, "rb")) != NULL)	{	/* Skip header */
-		gmt_M_err_trap (customio_native_skip_grd_header (fp, header));
+		gmt_M_err_trap (gmtcustomio_native_skip_grd_header (fp, header));
 	}
 	else
 		return (GMT_GRDIO_OPEN_FAILED);
@@ -1132,7 +1132,7 @@ int gmt_native_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, 
 	/* Store header information and array */
 
 	if (do_header) {
-		if ((err = customio_native_write_grd_header (fp, header)) != 0) {
+		if ((err = gmtcustomio_native_write_grd_header (fp, header)) != 0) {
 			gmt_M_free (GMT, k);	gmt_fclose (GMT, fp);
 			return err;
 		}
@@ -1259,7 +1259,7 @@ struct srf_header6 {	/* Surfer 6 file header structure */
    grid format we are dealing with, I removed them from the header definition (and jump
    12 bytes before reading the header). As a result the header has now one 4 byte char +
    trhee 4-bytes ints followed by 8-bytes doubles. With this organization the header is
-   read correctly by customio_read_srfheader7. Needless to say that I don't understand why the
+   read correctly by gmtcustomio_read_srfheader7. Needless to say that I don't understand why the
    even number of 4-bytes variables before the 8-bytes caused that the doubles we incorrectly read.
 
    Joaquim Luis 08-2005. */
@@ -1306,7 +1306,7 @@ int gmt_is_srf_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header) {
 	return GMT_NOERROR;
 }
 
-GMT_LOCAL int customio_read_srfheader6 (FILE *fp, struct srf_header6 *h) {
+GMT_LOCAL int gmtcustomio_read_srfheader6 (FILE *fp, struct srf_header6 *h) {
 	/* Reads the header of a Surfer 6 gridfile */
 	/* if (gmt_M_fread (h, sizeof (struct srf_header6), 1U, fp) < 1U) return (GMT_GRDIO_READ_FAILED); */
 
@@ -1323,7 +1323,7 @@ GMT_LOCAL int customio_read_srfheader6 (FILE *fp, struct srf_header6 *h) {
 	return GMT_NOERROR;
 }
 
-GMT_LOCAL int customio_read_srfheader7 (FILE *fp, struct srf_header7 *h) {
+GMT_LOCAL int gmtcustomio_read_srfheader7 (FILE *fp, struct srf_header7 *h) {
 	/* Reads the header of a Surfer 7 gridfile */
 
 	if (fseek (fp, (off_t)(3*sizeof(int)), SEEK_SET))
@@ -1345,7 +1345,7 @@ GMT_LOCAL int customio_read_srfheader7 (FILE *fp, struct srf_header7 *h) {
 	return GMT_NOERROR;
 }
 
-GMT_LOCAL int customio_write_srfheader (FILE *fp, struct srf_header6 *h) {
+GMT_LOCAL int gmtcustomio_write_srfheader (FILE *fp, struct srf_header6 *h) {
 	/* if (gmt_M_fwrite (h, sizeof (struct srf_header6), 1U, fp) < 1U) return (GMT_GRDIO_WRITE_FAILED); */
 	/* UPDATE: Because srf_header6 is not 64-bit aligned we must write it in parts */
 	if (gmt_M_fwrite (h->id, 4*sizeof (char), 1U, fp) != 1)
@@ -1391,12 +1391,12 @@ int gmt_srf_read_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header)
 	gmt_M_memset (&h6, 1, struct srf_header6);
 	gmt_M_memset (&h7, 1, struct srf_header7);
 	if (!strncmp (id, "DSBB", 4U)) {		/* Version 6 format */
-		if (customio_read_srfheader6 (fp, &h6)) return (GMT_GRDIO_READ_FAILED);
+		if (gmtcustomio_read_srfheader6 (fp, &h6)) return (GMT_GRDIO_READ_FAILED);
 		header->type = GMT_GRID_IS_SF;
 		HH->orig_datatype = GMT_FLOAT;
 	}
 	else {					/* Version 7 format */
-		if (customio_read_srfheader7 (fp, &h7))  return (GMT_GRDIO_READ_FAILED);
+		if (gmtcustomio_read_srfheader7 (fp, &h7))  return (GMT_GRDIO_READ_FAILED);
 		if (h7.len_d != h7.n_columns * h7.n_rows * 8 || !strcmp (h7.id2, "GRID")) return (GMT_GRDIO_SURF7_UNSUPPORTED);
 		header->type = GMT_GRID_IS_SD;
 		HH->orig_datatype = GMT_DOUBLE;
@@ -1454,7 +1454,7 @@ int gmt_srf_write_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header
 		gmt_M_memcpy (h.wesn, header->wesn, 4, double);
 	h.z_min = header->z_min;	 h.z_max = header->z_max;
 
-	if (customio_write_srfheader (fp, &h)) {
+	if (gmtcustomio_write_srfheader (fp, &h)) {
 		gmt_fclose (GMT, fp);
 		return (GMT_GRDIO_WRITE_FAILED);
 	}
@@ -2453,7 +2453,7 @@ void gmt_grdio_init (struct GMT_CTRL *GMT) {
 }
 
 /* Comparator for qsort in gmt_grdformats_sorted() */
-GMT_LOCAL int customio_compare_grd_fmt_strings (const void* a, const void* b) {
+GMT_LOCAL int gmtcustomio_compare_grd_fmt_strings (const void* a, const void* b) {
 	const char **ia = (const char **)a;
 	const char **ib = (const char **)b;
 	return strncmp(*ia, *ib, 2);
@@ -2470,7 +2470,7 @@ char ** gmt_grdformats_sorted (struct GMT_CTRL *Ctrl) {
 	/* copy array with char pointers to type id strings: */
 	memcpy (formats_sorted, Ctrl->session.grdformat, GMT_N_GRD_FORMATS * sizeof(char*));
 	/* sort pointers beginning from the 2nd element: */
-	qsort (formats_sorted + 1, GMT_N_GRD_FORMATS - 1, sizeof(char*), &customio_compare_grd_fmt_strings);
+	qsort (formats_sorted + 1, GMT_N_GRD_FORMATS - 1, sizeof(char*), &gmtcustomio_compare_grd_fmt_strings);
 	sorted = true;
 
 	return formats_sorted;

--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -68,7 +68,7 @@ static char *GMT_DCW_continents[GMT_DCW_N_CONTINENTS] = {"Africa", "Antarctica",
 
 /* Local functions only visible inside this file */
 
-GMT_LOCAL bool dcw_get_path (struct GMT_CTRL *GMT, char *name, char *suffix, char *path) {
+GMT_LOCAL bool gmtdcw_get_path (struct GMT_CTRL *GMT, char *name, char *suffix, char *path) {
 	bool found = false;
 
 	/* This is the order of checking:
@@ -97,7 +97,7 @@ GMT_LOCAL bool dcw_get_path (struct GMT_CTRL *GMT, char *name, char *suffix, cha
 	return (found);
 }
 
-GMT_LOCAL int dcw_load_lists (struct GMT_CTRL *GMT, struct GMT_DCW_COUNTRY **C, struct GMT_DCW_STATE **S, struct GMT_DCW_COUNTRY_STATE **CS, unsigned int dim[]) {
+GMT_LOCAL int gmtdcw_load_lists (struct GMT_CTRL *GMT, struct GMT_DCW_COUNTRY **C, struct GMT_DCW_STATE **S, struct GMT_DCW_COUNTRY_STATE **CS, unsigned int dim[]) {
 	/* Open and read list of countries and states and return via two struct and one char arrays plus dimensions in dim */
 	size_t n_alloc = 300;
 	unsigned int k, n;
@@ -107,7 +107,7 @@ GMT_LOCAL int dcw_load_lists (struct GMT_CTRL *GMT, struct GMT_DCW_COUNTRY **C, 
 	struct GMT_DCW_STATE *State = NULL;
 	struct GMT_DCW_COUNTRY_STATE *Country_State = NULL;
 
-	if (!dcw_get_path (GMT, "dcw-countries", ".txt", path)) return -1;
+	if (!gmtdcw_get_path (GMT, "dcw-countries", ".txt", path)) return -1;
 
 	/* Get countries first */
 	if ((fp = fopen (path, "r")) == NULL) {
@@ -130,7 +130,7 @@ GMT_LOCAL int dcw_load_lists (struct GMT_CTRL *GMT, struct GMT_DCW_COUNTRY **C, 
 	Country = gmt_M_memory (GMT, Country, k, struct GMT_DCW_COUNTRY);
 
 	/* Get states */
-	if (!dcw_get_path (GMT, "dcw-states", ".txt", path)) {
+	if (!gmtdcw_get_path (GMT, "dcw-states", ".txt", path)) {
 		gmt_M_free (GMT, Country);
 		return -1;
 	}
@@ -174,14 +174,14 @@ GMT_LOCAL int dcw_load_lists (struct GMT_CTRL *GMT, struct GMT_DCW_COUNTRY **C, 
 	return 0;
 }
 
-GMT_LOCAL int dcw_comp_countries (const void *p1, const void *p2) {
+GMT_LOCAL int gmtdcw_comp_countries (const void *p1, const void *p2) {
 	/* Used to sort countries alphabetically */
 	struct GMT_DCW_COUNTRY *A = (struct GMT_DCW_COUNTRY *)p1;
 	struct GMT_DCW_COUNTRY *B = (struct GMT_DCW_COUNTRY *)p2;
 	return (strcmp (A->code, B->code));
 }
 
-GMT_LOCAL int dcw_find_country (char *code, struct GMT_DCW_COUNTRY *list, int n) {
+GMT_LOCAL int gmtdcw_find_country (char *code, struct GMT_DCW_COUNTRY *list, int n) {
 	/* Basic binary search for country with given code and an alphabetically sorted list */
 	int low = 0, high = n, mid, last = -1, way;
 
@@ -197,7 +197,7 @@ GMT_LOCAL int dcw_find_country (char *code, struct GMT_DCW_COUNTRY *list, int n)
 	return (low);
 }
 
-GMT_LOCAL int dcw_find_state (char *scode, char *ccode, struct GMT_DCW_STATE *slist, int ns) {
+GMT_LOCAL int gmtdcw_find_state (char *scode, char *ccode, struct GMT_DCW_STATE *slist, int ns) {
 	/* Return state id given country and state codes using a linear search */
 	int i;
 
@@ -205,7 +205,7 @@ GMT_LOCAL int dcw_find_state (char *scode, char *ccode, struct GMT_DCW_STATE *sl
 	return (-1);
 }
 
-GMT_LOCAL bool gmt_dcw_country_has_states (char *code, struct GMT_DCW_COUNTRY_STATE *st_country, unsigned int n) {
+GMT_LOCAL bool gmtdcw_country_has_states (char *code, struct GMT_DCW_COUNTRY_STATE *st_country, unsigned int n) {
 	/* Return true if this country has interior state boundaries */
 	unsigned int i;
 	for (i = 0; i < n; i++) if (!strcmp (code, st_country[i].country)) return (true);
@@ -259,13 +259,13 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 		wesn[YLO] = +9999.0;	wesn[YHI] = -9999.0;	/* Initialize so we can shrink it below */
 	}
 
-	if (dcw_load_lists (GMT, &GMT_DCW_country, &GMT_DCW_state, NULL, n_bodies))	/* Something went wrong */
+	if (gmtdcw_load_lists (GMT, &GMT_DCW_country, &GMT_DCW_state, NULL, n_bodies))	/* Something went wrong */
 		return NULL;
 
 	GMT_DCW_COUNTRIES = n_bodies[0];
 	GMT_DCW_STATES = n_bodies[1];
 
-	qsort ((void *)GMT_DCW_country, (size_t)GMT_DCW_COUNTRIES, sizeof (struct GMT_DCW_COUNTRY), dcw_comp_countries);	/* Sort on country code */
+	qsort ((void *)GMT_DCW_country, (size_t)GMT_DCW_COUNTRIES, sizeof (struct GMT_DCW_COUNTRY), gmtdcw_comp_countries);	/* Sort on country code */
 
 	n_alloc = n_bodies[0] + n_bodies[1];	/* Presumably max items considered */
 	order = gmt_M_memory (GMT, NULL, n_alloc, unsigned int);
@@ -303,7 +303,7 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 		return NULL;
 	}
 
-	if (!dcw_get_path (GMT, "dcw-gmt", ".nc", path)) {
+	if (!gmtdcw_get_path (GMT, "dcw-gmt", ".nc", path)) {
 		gmt_M_free (GMT, order);
 		return NULL;
 	}
@@ -373,14 +373,14 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 			code[2] = '\0';
 			want_state = true;
 		}
-		ks = dcw_find_country (code, GMT_DCW_country, GMT_DCW_COUNTRIES);
+		ks = gmtdcw_find_country (code, GMT_DCW_country, GMT_DCW_COUNTRIES);
 		if (ks == -1) {
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "No country code matching %s (skipped)\n", code);
 			continue;
 		}
 		k = ks;
 		if (want_state) {
-			if ((item = dcw_find_state (state, code, GMT_DCW_state, GMT_DCW_STATES)) == -1) {
+			if ((item = gmtdcw_find_state (state, code, GMT_DCW_state, GMT_DCW_STATES)) == -1) {
 				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Country %s does not have states (skipped)\n", code);
 				continue;
 			}
@@ -553,7 +553,7 @@ unsigned int gmt_DCW_list (struct GMT_CTRL *GMT, unsigned list_mode) {
 	struct GMT_DCW_STATE *GMT_DCW_state = NULL;
 	struct GMT_DCW_COUNTRY_STATE *GMT_DCW_country_with_state = NULL;
 	if ((list_mode & GMT_DCW_LIST) == 0) return 0;
-	if (dcw_load_lists (GMT, &GMT_DCW_country, &GMT_DCW_state, &GMT_DCW_country_with_state, n_bodies)) return 0;	/* Something went wrong */
+	if (gmtdcw_load_lists (GMT, &GMT_DCW_country, &GMT_DCW_state, &GMT_DCW_country_with_state, n_bodies)) return 0;	/* Something went wrong */
 	GMT_DCW_COUNTRIES = n_bodies[0];
 	GMT_DCW_STATES = n_bodies[1];
 	GMT_DCW_N_COUNTRIES_WITH_STATES = n_bodies[2];
@@ -562,7 +562,7 @@ unsigned int gmt_DCW_list (struct GMT_CTRL *GMT, unsigned list_mode) {
 		if (i == 0 || strcmp (GMT_DCW_country[i].continent, GMT_DCW_country[i-1].continent) )
 			printf ("%s [%s]:\n", GMT_DCW_continents[k++], GMT_DCW_country[i].continent);
 		printf ("  %s\t%s\n", GMT_DCW_country[i].code, GMT_DCW_country[i].name);
-		if ((list_mode & 2) && gmt_dcw_country_has_states (GMT_DCW_country[i].code, GMT_DCW_country_with_state, GMT_DCW_N_COUNTRIES_WITH_STATES)) {
+		if ((list_mode & 2) && gmtdcw_country_has_states (GMT_DCW_country[i].code, GMT_DCW_country_with_state, GMT_DCW_N_COUNTRIES_WITH_STATES)) {
 			for (j = 0; j < GMT_DCW_STATES; j++) {
 				if (!strcmp (GMT_DCW_country[i].code, GMT_DCW_state[j].country)) printf ("\t\t%s.%s\t%s\n", GMT_DCW_country[i].code, GMT_DCW_state[j].code, GMT_DCW_state[j].name);
 			}

--- a/src/gmt_esri_io.c
+++ b/src/gmt_esri_io.c
@@ -32,7 +32,7 @@
 
 /* Private function visible only in this file */
 
-GMT_LOCAL int esri_write_info (struct GMT_CTRL *GMT, FILE *fp, struct GMT_GRID_HEADER *header) {
+GMT_LOCAL int gmtesriio_write_info (struct GMT_CTRL *GMT, FILE *fp, struct GMT_GRID_HEADER *header) {
 	/* Note: fp is an open file pointer passed in; it will be closed upstream and not here */
 	char record[GMT_BUFSIZ] = {""}, item[GMT_LEN64] = {""};
 
@@ -72,7 +72,7 @@ GMT_LOCAL int esri_write_info (struct GMT_CTRL *GMT, FILE *fp, struct GMT_GRID_H
 	return (GMT_NOERROR);
 }
 
-GMT_LOCAL int esri_read_info_hdr (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header) {
+GMT_LOCAL int gmtesriio_read_info_hdr (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header) {
 	/* Parse the contents of a .HDR file */
 	int nB;
 	char record[GMT_BUFSIZ];
@@ -172,7 +172,7 @@ GMT_LOCAL int esri_read_info_hdr (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *
 	return (GMT_NOERROR);
 }
 
-GMT_LOCAL int esri_read_info (struct GMT_CTRL *GMT, FILE *fp, struct GMT_GRID_HEADER *header) {
+GMT_LOCAL int gmtesriio_read_info (struct GMT_CTRL *GMT, FILE *fp, struct GMT_GRID_HEADER *header) {
 	/* Note: fp is an open file pointer passed in; it will be closed upstream and not here */
 	int c;
 	char record[GMT_BUFSIZ];
@@ -185,7 +185,7 @@ GMT_LOCAL int esri_read_info (struct GMT_CTRL *GMT, FILE *fp, struct GMT_GRID_HE
 
 	if (HH->flags[0] == 'M' || HH->flags[0] == 'I') {	/* We are dealing with a ESRI .hdr file */
 		int error;
-		if ((error = esri_read_info_hdr (GMT, header)) != 0) 		/* Continue the work someplace else */
+		if ((error = gmtesriio_read_info_hdr (GMT, header)) != 0) 		/* Continue the work someplace else */
 			return (error);
 		else
 			return (GMT_NOERROR);
@@ -432,7 +432,7 @@ int gmt_is_esri_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header) {
 				HH->orig_datatype = GMT_SHORT;
 			}
 			else if (name_len > 3 && !(strncmp (&HH->name[name_len-4], ".hgt", 4) && strncmp (&HH->name[name_len-4], ".HGT", 4))) {
-				/* Probably a SRTM1|3 file. In esri_read_info we'll check further if it is a 1 or 3 sec */
+				/* Probably a SRTM1|3 file. In gmtesriio_read_info we'll check further if it is a 1 or 3 sec */
 				if ((file[len-4] == 'E' || file[len-4] == 'e' || file[len-4] == 'W' || file[len-4] == 'w') &&
 					(file[len-7] == 'N' || file[len-7] == 'n' || file[len-7] == 'S' || file[len-7] == 's')) {
 					HH->flags[0] = 'B';	/* SRTM1|3 are Big Endians */
@@ -465,7 +465,7 @@ int gmt_esri_read_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header
 	else if ((fp = gmt_fopen (GMT, HH->name, "r")) == NULL)
 		return (GMT_GRDIO_OPEN_FAILED);
 
-	if ((error = esri_read_info (GMT, fp, header)) != 0) {
+	if ((error = gmtesriio_read_info (GMT, fp, header)) != 0) {
 		gmt_fclose (GMT, fp);
 		return (error);
 	}
@@ -484,7 +484,7 @@ int gmt_esri_write_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *heade
 	else if ((fp = gmt_fopen (GMT, HH->name, "w")) == NULL)
 		return (GMT_GRDIO_CREATE_FAILED);
 
-	esri_write_info (GMT, fp, header);
+	gmtesriio_write_info (GMT, fp, header);
 
 	gmt_fclose (GMT, fp);
 
@@ -520,7 +520,7 @@ int gmt_esri_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 	if (!strcmp (HH->name, "="))	/* Read from pipe */
 		fp = GMT->session.std[GMT_IN];
 	else if ((fp = gmt_fopen (GMT, HH->name, r_mode)) != NULL) {
-		if ((error = esri_read_info (GMT, fp, header)) != 0) {
+		if ((error = gmtesriio_read_info (GMT, fp, header)) != 0) {
 			gmt_fclose (GMT, fp);
 			return (error);
 		}
@@ -677,7 +677,7 @@ int gmt_esri_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gm
 	else if ((fp = gmt_fopen (GMT, HH->name, GMT->current.io.w_mode)) == NULL)
 		return (GMT_GRDIO_CREATE_FAILED);
 	else
-		esri_write_info (GMT, fp, header);
+		gmtesriio_write_info (GMT, fp, header);
 
 	gmt_M_err_pass (GMT, gmt_grd_prep_io (GMT, header, wesn, &width_out, &height_out, &first_col, &last_col, &first_row, &last_row, &actual_col), HH->name);
 	(void)gmtlib_init_complex (header, complex_mode, &imag_offset);	/* Set offset for imaginary complex component */

--- a/src/gmt_fft.c
+++ b/src/gmt_fft.c
@@ -60,14 +60,14 @@ static char *GMT_fft_algo[] = {
  * grdfft.c and potential/gravfft.c as examples.
  */
 
-static inline uint64_t propose_radix2 (uint64_t n) {
+static inline uint64_t gmtfft_propose_radix2 (uint64_t n) {
 	/* Returns the smallest base 2 exponent, log2n, that satisfies: 2^log2n >= n */
 	uint64_t log2n = 1;
 	while ( 1ULL<<log2n < n ) ++log2n; /* log2n = 1<<(unsigned)ceil(log2(n)); */
 	return log2n;
 }
 
-static inline uint64_t radix2 (uint64_t n) {
+static inline uint64_t gmtfft_radix2 (uint64_t n) {
 	/* Returns the base 2 exponent that represents 'n' if 'n' is a power of 2,
 	 * 0 otherwise */
 	uint64_t log2n = 1ULL;
@@ -77,10 +77,10 @@ static inline uint64_t radix2 (uint64_t n) {
 	return 0ULL;
 }
 
-static inline struct GMT_FFT_WAVENUMBER * fft_get_fftwave_ptr (struct GMT_FFT_WAVENUMBER *ptr) {return (ptr);}
-static inline struct GMTAPI_CTRL * fft_get_api_ptr (struct GMTAPI_CTRL *ptr)  {return (ptr);}
+static inline struct GMT_FFT_WAVENUMBER * gmtfft_get_fftwave_ptr (struct GMT_FFT_WAVENUMBER *ptr) {return (ptr);}
+static inline struct GMTAPI_CTRL * gmtfft_get_api_ptr (struct GMTAPI_CTRL *ptr)  {return (ptr);}
 
-GMT_LOCAL uint64_t fft_get_non_symmetric_f (unsigned int *f, unsigned int n) {
+GMT_LOCAL uint64_t gmtfft_get_non_symmetric_f (unsigned int *f, unsigned int n) {
 	/* Return the product of the non-symmetric factors in f[]  */
 	unsigned int i = 0, j = 1, retval = 1;
 
@@ -144,9 +144,9 @@ void gmtfft_fourt_stats (struct GMT_CTRL *GMT, unsigned int n_columns, unsigned 
 
 	/* Find workspace needed.  First find non_symmetric factors in n_columns, n_rows  */
 	n_factors = gmt_get_prime_factors (GMT, n_columns, f);
-	nonsymx = fft_get_non_symmetric_f (f, n_factors);
+	nonsymx = gmtfft_get_non_symmetric_f (f, n_factors);
 	n_factors = gmt_get_prime_factors (GMT, n_rows, f);
-	nonsymy = fft_get_non_symmetric_f (f, n_factors);
+	nonsymy = gmtfft_get_non_symmetric_f (f, n_factors);
 	nonsym = MAX (nonsymx, nonsymy);
 
 	/* Now get factors of ntotal  */
@@ -278,7 +278,7 @@ void gmtlib_suggest_fft_dim (struct GMT_CTRL *GMT, unsigned int n_columns, unsig
 	return;
 }
 
-GMT_LOCAL double fft_kx (uint64_t k, struct GMT_FFT_WAVENUMBER *K) {
+GMT_LOCAL double gmtfft_kx (uint64_t k, struct GMT_FFT_WAVENUMBER *K) {
 	/* Return the value of kx given k,
 	 * where kx = 2 pi / lambda x,
 	 * and k refers to the position
@@ -289,7 +289,7 @@ GMT_LOCAL double fft_kx (uint64_t k, struct GMT_FFT_WAVENUMBER *K) {
 	return (ii * K->delta_kx);
 }
 
-GMT_LOCAL double fft_ky (uint64_t k, struct GMT_FFT_WAVENUMBER *K) {
+GMT_LOCAL double gmtfft_ky (uint64_t k, struct GMT_FFT_WAVENUMBER *K) {
 	/* Return the value of ky given k,
 	 * where ky = 2 pi / lambda y,
 	 * and k refers to the position
@@ -300,12 +300,12 @@ GMT_LOCAL double fft_ky (uint64_t k, struct GMT_FFT_WAVENUMBER *K) {
 	return (jj * K->delta_ky);
 }
 
-GMT_LOCAL double fft_kr (uint64_t k, struct GMT_FFT_WAVENUMBER *K) {
+GMT_LOCAL double gmtfft_kr (uint64_t k, struct GMT_FFT_WAVENUMBER *K) {
 	/* Return the value of sqrt(kx*kx + ky*ky),
 	 * where k refers to the position
 	 * in the complex data array Grid->data[k].  */
 
-	return (hypot (fft_kx (k, K), fft_ky (k, K)));
+	return (hypot (gmtfft_kx (k, K), gmtfft_ky (k, K)));
 }
 
 double gmt_fft_get_wave (uint64_t k, struct GMT_FFT_WAVENUMBER *K) {
@@ -322,9 +322,9 @@ double gmt_fft_any_wave (uint64_t k, unsigned int mode, struct GMT_FFT_WAVENUMBE
 	double wave = 0.0;
 
 	switch (mode) {	/* Select which wavenumber we need */
-		case GMT_FFT_K_IS_KX: wave = fft_kx (k, K); break;
-		case GMT_FFT_K_IS_KY: wave = fft_ky (k, K); break;
-		case GMT_FFT_K_IS_KR: wave = fft_kr (k, K); break;
+		case GMT_FFT_K_IS_KX: wave = gmtfft_kx (k, K); break;
+		case GMT_FFT_K_IS_KY: wave = gmtfft_ky (k, K); break;
+		case GMT_FFT_K_IS_KR: wave = gmtfft_kr (k, K); break;
 	}
 	return (wave);
 }
@@ -332,9 +332,9 @@ double gmt_fft_any_wave (uint64_t k, unsigned int mode, struct GMT_FFT_WAVENUMBE
 int gmt_fft_set_wave (struct GMT_CTRL *GMT, unsigned int mode, struct GMT_FFT_WAVENUMBER *K) {
 	/* Change wavenumber selection */
 	switch (mode) {	/* Select which wavenumber we need */
-		case GMT_FFT_K_IS_KX: K->k_ptr = fft_kx; break;
-		case GMT_FFT_K_IS_KY: K->k_ptr = fft_ky; break;
-		case GMT_FFT_K_IS_KR: K->k_ptr = fft_kr; break;
+		case GMT_FFT_K_IS_KX: K->k_ptr = gmtfft_kx; break;
+		case GMT_FFT_K_IS_KY: K->k_ptr = gmtfft_ky; break;
+		case GMT_FFT_K_IS_KR: K->k_ptr = gmtfft_kr; break;
 		default:
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad mode selected (%u) - exit\n", mode);
 			GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
@@ -346,10 +346,10 @@ int gmt_fft_set_wave (struct GMT_CTRL *GMT, unsigned int mode, struct GMT_FFT_WA
 /*! . */
 double GMT_FFT_Wavenumber (void *V_API, uint64_t k, unsigned int mode, void *v_K) {
 	/* Lets you specify which 1-D or 2-D wavenumber you want */
-	struct GMT_FFT_WAVENUMBER *K = fft_get_fftwave_ptr (v_K);
+	struct GMT_FFT_WAVENUMBER *K = gmtfft_get_fftwave_ptr (v_K);
 	gmt_M_unused(V_API);
 	if (K->dim == 2) return (gmt_fft_any_wave (k, mode, K));
-	else return (fft_kx (k, K));
+	else return (gmtfft_kx (k, K));
 }
 
 #ifdef HAVE_FFTW3F
@@ -361,7 +361,7 @@ double GMT_FFT_Wavenumber (void *V_API, uint64_t k, unsigned int mode, void *v_K
 
 #define FFTWF_WISDOM_FILENAME "fftwf_wisdom"
 
-GMT_LOCAL char *fft_fftwf_wisdom_filename (struct GMT_CTRL *GMT) {
+GMT_LOCAL char *gmtfft_fftwf_wisdom_filename (struct GMT_CTRL *GMT) {
 	static char wisdom_file[PATH_MAX+256] = "\0";
 	char hostname[257];
 	if (*wisdom_file == '\0') { /* wisdom_file has not been set yet */
@@ -382,7 +382,7 @@ GMT_LOCAL char *fft_fftwf_wisdom_filename (struct GMT_CTRL *GMT) {
 }
 
 /* Wrapper around fftwf_import_wisdom_from_filename */
-GMT_LOCAL void fft_fftwf_import_wisdom_from_filename (struct GMT_CTRL *GMT) {
+GMT_LOCAL void gmtfft_fftwf_import_wisdom_from_filename (struct GMT_CTRL *GMT) {
 	static bool already_imported = false;
 	char *filenames[3], **filename = filenames;
 	int status;
@@ -394,7 +394,7 @@ GMT_LOCAL void fft_fftwf_import_wisdom_from_filename (struct GMT_CTRL *GMT) {
 
 	/* Initialize filenames */
 	filenames[0] = FFTWF_WISDOM_FILENAME; /* 1st try importing wisdom from file in current dir */
-	filenames[1] = fft_fftwf_wisdom_filename(GMT); /* 2nd try wisdom file in CACHEDIR */
+	filenames[1] = gmtfft_fftwf_wisdom_filename(GMT); /* 2nd try wisdom file in CACHEDIR */
 	filenames[2] = NULL; /* end of array */
 
 	while (*filename != NULL) {
@@ -412,8 +412,8 @@ GMT_LOCAL void fft_fftwf_import_wisdom_from_filename (struct GMT_CTRL *GMT) {
 }
 
 /* Wrapper around fftwf_export_wisdom_to_filename */
-GMT_LOCAL void fft_fftwf_export_wisdom_to_filename (struct GMT_CTRL *GMT) {
-	char *filename = fft_fftwf_wisdom_filename(GMT);
+GMT_LOCAL void gmtfft_fftwf_export_wisdom_to_filename (struct GMT_CTRL *GMT) {
+	char *filename = gmtfft_fftwf_wisdom_filename(GMT);
 	int status;
 
 	if (filename == NULL)
@@ -427,7 +427,7 @@ GMT_LOCAL void fft_fftwf_export_wisdom_to_filename (struct GMT_CTRL *GMT) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Exporting FFTW Wisdom to file failed: %s\n", filename);
 }
 
-GMT_LOCAL fftwf_plan gmt_fftwf_plan_dft(struct GMT_CTRL *GMT, unsigned n_rows, unsigned n_columns, fftwf_complex *data, int direction) {
+GMT_LOCAL fftwf_plan gmtfft_gmt_fftwf_plan_dft(struct GMT_CTRL *GMT, unsigned n_rows, unsigned n_columns, fftwf_complex *data, int direction) {
 	/* The first two arguments, n0 and n1, are the size of the two-dimensional
 	 * transform you are trying to compute. The size n can be any positive
 	 * integer, but sizes that are products of small factors are transformed
@@ -469,7 +469,7 @@ GMT_LOCAL fftwf_plan gmt_fftwf_plan_dft(struct GMT_CTRL *GMT, unsigned n_rows, u
 	cout = cin; /* in-place transform */
 
 	if (GMT->current.setting.fftw_plan != FFTW_ESTIMATE) {
-		fft_fftwf_import_wisdom_from_filename (GMT);
+		gmtfft_fftwf_import_wisdom_from_filename (GMT);
 		if (n_rows == 0) /* 1d DFT */
 			plan = fftwf_plan_dft_1d(n_columns, cin, cout, sign, FFTW_WISDOM_ONLY | GMT->current.setting.fftw_plan);
 		else /* 2d DFT */
@@ -487,7 +487,7 @@ GMT_LOCAL fftwf_plan gmt_fftwf_plan_dft(struct GMT_CTRL *GMT, unsigned n_rows, u
 			plan = NULL;
 			fftwf_free (in_place_tmp);
 			/* Save new Wisdom */
-			fft_fftwf_export_wisdom_to_filename (GMT);
+			gmtfft_fftwf_export_wisdom_to_filename (GMT);
 		}
 		else
 			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Using preexisting FFTW Wisdom.\n");
@@ -510,24 +510,24 @@ GMT_LOCAL fftwf_plan gmt_fftwf_plan_dft(struct GMT_CTRL *GMT, unsigned n_rows, u
 	return plan;
 }
 
-GMT_LOCAL int fft_1d_fftwf (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n, int direction, unsigned int mode) {
+GMT_LOCAL int gmtfft_1d_fftwf (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n, int direction, unsigned int mode) {
 	fftwf_plan plan = NULL;
 	gmt_M_unused(mode);
 
 	/* Generate FFTW plan for complex 1d DFT */
-	plan = gmt_fftwf_plan_dft(GMT, 0, n, (fftwf_complex*)data, direction);
+	plan = gmtfft_gmt_fftwf_plan_dft(GMT, 0, n, (fftwf_complex*)data, direction);
 	fftwf_execute(plan);      /* do transform */
 	fftwf_destroy_plan(plan); /* deallocate plan */
 
 	return GMT_NOERROR;
 }
 
-GMT_LOCAL int fft_2d_fftwf (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n_columns, unsigned int n_rows, int direction, unsigned int mode) {
+GMT_LOCAL int gmtfft_2d_fftwf (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n_columns, unsigned int n_rows, int direction, unsigned int mode) {
 	fftwf_plan plan = NULL;
 	gmt_M_unused(mode);
 
 	/* Generate FFTW plan for complex 2d DFT */
-	plan = gmt_fftwf_plan_dft(GMT, n_rows, n_columns, (fftwf_complex*)data, direction);
+	plan = gmtfft_gmt_fftwf_plan_dft(GMT, n_rows, n_columns, (fftwf_complex*)data, direction);
 	fftwf_execute(plan);      /* do transform */
 	fftwf_destroy_plan(plan); /* deallocate plan */
 
@@ -538,7 +538,7 @@ GMT_LOCAL int fft_2d_fftwf (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned i
 
 #ifdef __APPLE__ /* Accelerate framework */
 
-GMT_LOCAL void fft_1d_vDSP_reset (struct GMT_FFT_HIDDEN *Z) {
+GMT_LOCAL void gmtfft_gmtfft_1d_vDSP_reset (struct GMT_FFT_HIDDEN *Z) {
 	if (Z->setup_1d) {	/* Free single-precision FFT data structure and arrays */
 		vDSP_destroy_fftsetup (Z->setup_1d);
 		gmt_M_str_free (Z->dsp_split_complex_1d.realp);
@@ -546,25 +546,25 @@ GMT_LOCAL void fft_1d_vDSP_reset (struct GMT_FFT_HIDDEN *Z) {
 	}
 }
 
-GMT_LOCAL int fft_1d_vDSP (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n, int direction, unsigned int mode) {
+GMT_LOCAL int gmtfft_1d_vDSP (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n, int direction, unsigned int mode) {
 	FFTDirection fft_direction = direction == GMT_FFT_FWD ?
 			kFFTDirection_Forward : kFFTDirection_Inverse;
 	DSPComplex *dsp_complex = (DSPComplex *)data;
 
 	/* Base 2 exponent that specifies the largest power of
 	 * two that can be processed by fft: */
-	vDSP_Length log2n = radix2 (n);
+	vDSP_Length log2n = gmtfft_radix2 (n);
 	gmt_M_unused(mode);
 
 	if (log2n == 0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Need Radix-2 input try: %u [n]\n", 1U<<propose_radix2 (n));
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Need Radix-2 input try: %u [n]\n", 1U<<gmtfft_propose_radix2 (n));
 		return -1;
 	}
 
 	if (GMT->current.fft.n_1d != n) {	/* Must update the FFT setup arrays */
 		/* Build data structure that contains precalculated data for use by
 		 * single-precision FFT functions: */
-		fft_1d_vDSP_reset (&GMT->current.fft);
+		gmtfft_gmtfft_1d_vDSP_reset (&GMT->current.fft);
 		GMT->current.fft.setup_1d = vDSP_create_fftsetup (log2n, kFFTRadix2);
 		GMT->current.fft.dsp_split_complex_1d.realp = calloc (n, sizeof(gmt_grdfloat));
 		GMT->current.fft.dsp_split_complex_1d.imagp = calloc (n, sizeof(gmt_grdfloat));
@@ -583,7 +583,7 @@ GMT_LOCAL int fft_1d_vDSP (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned in
 	return GMT_NOERROR;
 }
 
-GMT_LOCAL void fft_2d_vDSP_reset (struct GMT_FFT_HIDDEN *Z) {
+GMT_LOCAL void gmtfft_gmtfft_2d_vDSP_reset (struct GMT_FFT_HIDDEN *Z) {
 	if (Z->setup_2d) {	/* Free single-precision 2D FFT data structure and arrays */
 		vDSP_destroy_fftsetup (Z->setup_2d);
 		gmt_M_str_free (Z->dsp_split_complex_2d.realp);
@@ -591,28 +591,28 @@ GMT_LOCAL void fft_2d_vDSP_reset (struct GMT_FFT_HIDDEN *Z) {
 	}
 }
 
-GMT_LOCAL int fft_2d_vDSP (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n_columns, unsigned int n_rows, int direction, unsigned int mode) {
+GMT_LOCAL int gmtfft_2d_vDSP (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n_columns, unsigned int n_rows, int direction, unsigned int mode) {
 	FFTDirection fft_direction = direction == GMT_FFT_FWD ?
 			kFFTDirection_Forward : kFFTDirection_Inverse;
 	DSPComplex *dsp_complex = (DSPComplex *)data;
 
 	/* Base 2 exponent that specifies the largest power of
 	 * two that can be processed by fft: */
-	vDSP_Length log2nx = radix2 (n_columns);
-	vDSP_Length log2ny = radix2 (n_rows);
+	vDSP_Length log2nx = gmtfft_radix2 (n_columns);
+	vDSP_Length log2ny = gmtfft_radix2 (n_rows);
 	unsigned int n_xy = n_columns * n_rows;
 	gmt_M_unused(mode);
 
 	if (log2nx == 0 || log2ny == 0) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Need Radix-2 input try: %u/%u [n_columns/n_rows]\n",
-				1U<<propose_radix2 (n_columns), 1U<<propose_radix2 (n_rows));
+				1U<<gmtfft_propose_radix2 (n_columns), 1U<<gmtfft_propose_radix2 (n_rows));
 		return -1;
 	}
 
 	if (GMT->current.fft.n_2d != n_xy) {	/* Must update the 2-D FFT setup arrays */
 		/* Build data structure that contains precalculated data for use by
 	 	* single-precision FFT functions: */
-		fft_2d_vDSP_reset (&GMT->current.fft);
+		gmtfft_gmtfft_2d_vDSP_reset (&GMT->current.fft);
 		GMT->current.fft.setup_2d = vDSP_create_fftsetup (MAX (log2nx, log2ny), kFFTRadix2);
 		GMT->current.fft.dsp_split_complex_2d.realp = calloc (n_xy, sizeof(gmt_grdfloat));
 		GMT->current.fft.dsp_split_complex_2d.imagp = calloc (n_xy, sizeof(gmt_grdfloat));
@@ -641,7 +641,7 @@ GMT_LOCAL int fft_2d_vDSP (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned in
 
 #include "kiss_fft/kiss_fftnd.h"
 
-GMT_LOCAL int fft_1d_kiss (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n, int direction, unsigned int mode) {
+GMT_LOCAL int gmtfft_1d_kiss (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n, int direction, unsigned int mode) {
 	kiss_fft_cpx *fin, *fout;
 	kiss_fft_cfg config;
 	gmt_M_unused(GMT); gmt_M_unused(mode);
@@ -655,7 +655,7 @@ GMT_LOCAL int fft_1d_kiss (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned in
 	return GMT_NOERROR;
 }
 
-GMT_LOCAL int fft_2d_kiss (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n_columns, unsigned int n_rows, int direction, unsigned int mode) {
+GMT_LOCAL int gmtfft_2d_kiss (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n_columns, unsigned int n_rows, int direction, unsigned int mode) {
 	const int dim[2] = {n_rows, n_columns}; /* dimensions of fft */
 	const int dimcount = 2;      /* number of dimensions */
 	kiss_fft_cpx *fin, *fout;
@@ -673,7 +673,7 @@ GMT_LOCAL int fft_2d_kiss (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned in
 }
 
 
-GMT_LOCAL int fft_brenner_fourt_f (gmt_grdfloat *data, int *nn, int *ndim, int *ksign, int *iform, gmt_grdfloat *work) {
+GMT_LOCAL int gmtfft_brenner_fourt_f (gmt_grdfloat *data, int *nn, int *ndim, int *ksign, int *iform, gmt_grdfloat *work) {
 
     /* System generated locals */
     int i__1, i__2, i__3, i__4, i__5, i__6, i__7, i__8, i__9, i__10, i__11, i__12;
@@ -1523,7 +1523,7 @@ L920:
     return 0;
 } /* fourt_ */
 
-GMT_LOCAL size_t fft_brenner_worksize (struct GMT_CTRL *GMT, unsigned int n_columns, unsigned int n_rows) {
+GMT_LOCAL size_t gmtfft_brenner_worksize (struct GMT_CTRL *GMT, unsigned int n_columns, unsigned int n_rows) {
         /* Find the size of the workspace that will be needed by the transform.
          * To use this routine for a 1-D transform, set n_rows = 1.
          *
@@ -1544,9 +1544,9 @@ GMT_LOCAL size_t fft_brenner_worksize (struct GMT_CTRL *GMT, unsigned int n_colu
 
         /* Find workspace needed.  First find non_symmetric factors in n_columns, n_rows  */
         n_factors = gmt_get_prime_factors (GMT, n_columns, f);
-        nonsymx = (unsigned int)fft_get_non_symmetric_f (f, n_factors);
+        nonsymx = (unsigned int)gmtfft_get_non_symmetric_f (f, n_factors);
         n_factors = gmt_get_prime_factors (GMT, n_rows, f);
-        nonsymy = (unsigned int)fft_get_non_symmetric_f (f, n_factors);
+        nonsymy = (unsigned int)gmtfft_get_non_symmetric_f (f, n_factors);
         nonsym = MAX (nonsymx, nonsymy);
 
         /* Now get factors of ntotal  */
@@ -1559,8 +1559,8 @@ GMT_LOCAL size_t fft_brenner_worksize (struct GMT_CTRL *GMT, unsigned int n_colu
         return (2 * storage);
 }
 
-/* C-callable wrapper for fft_brenner_fourt_f */
-GMT_LOCAL int fft_1d_brenner (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n, int direction, unsigned int mode) {
+/* C-callable wrapper for gmtfft_brenner_fourt_f */
+GMT_LOCAL int gmtfft_1d_brenner (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n, int direction, unsigned int mode) {
         /* void GMT_fourt (struct GMT_CTRL *GMT, gmt_grdfloat *data, int *nn, int ndim, int ksign, int iform, gmt_grdfloat *work) */
         /* Data array */
         /* Dimension array */
@@ -1574,13 +1574,13 @@ GMT_LOCAL int fft_1d_brenner (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned
         gmt_grdfloat *work = NULL;
 
         ksign = (direction == GMT_FFT_INV) ? +1 : -1;
-        if ((work_size = fft_brenner_worksize (GMT, n, 1))) work = gmt_M_memory (GMT, NULL, work_size, gmt_grdfloat);
-        (void) fft_brenner_fourt_f (data, &n_signed, &ndim, &ksign, &kmode, work);
+        if ((work_size = gmtfft_brenner_worksize (GMT, n, 1))) work = gmt_M_memory (GMT, NULL, work_size, gmt_grdfloat);
+        (void) gmtfft_brenner_fourt_f (data, &n_signed, &ndim, &ksign, &kmode, work);
         gmt_M_free (GMT, work);
         return (GMT_OK);
 }
 
-GMT_LOCAL int fft_2d_brenner (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n_columns, unsigned int n_rows, int direction, unsigned int mode) {
+GMT_LOCAL int gmtfft_2d_brenner (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned int n_columns, unsigned int n_rows, int direction, unsigned int mode) {
         /* Data array */
         /* Dimension array */
         /* Number of dimensions */
@@ -1593,14 +1593,14 @@ GMT_LOCAL int fft_2d_brenner (struct GMT_CTRL *GMT, gmt_grdfloat *data, unsigned
         gmt_grdfloat *work = NULL;
 
         ksign = (direction == GMT_FFT_INV) ? +1 : -1;
-        if ((work_size = fft_brenner_worksize (GMT, n_columns, n_rows))) work = gmt_M_memory (GMT, NULL, work_size, gmt_grdfloat);
+        if ((work_size = gmtfft_brenner_worksize (GMT, n_columns, n_rows))) work = gmt_M_memory (GMT, NULL, work_size, gmt_grdfloat);
         GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Brenner_fourt_ work size = %" PRIuS "\n", work_size);
-        (void) fft_brenner_fourt_f (data, nn, &ndim, &ksign, &kmode, work);
+        (void) gmtfft_brenner_fourt_f (data, nn, &ndim, &ksign, &kmode, work);
         gmt_M_free (GMT, work);
         return (GMT_OK);
 }
 
-GMT_LOCAL int fft_1d_selection (struct GMT_CTRL *GMT, uint64_t n) {
+GMT_LOCAL int gmtfft_1d_selection (struct GMT_CTRL *GMT, uint64_t n) {
 	/* Returns the most suitable 1-D FFT for the job - or the one requested via GMT_FFT */
 	if (GMT->current.setting.fft != k_fft_auto) {
 		/* Specific selection requested */
@@ -1609,14 +1609,14 @@ GMT_LOCAL int fft_1d_selection (struct GMT_CTRL *GMT, uint64_t n) {
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Desired FFT Algorithm (%s) not configured - choosing suitable alternative.\n", GMT_fft_algo[GMT->current.setting.fft]);
 	}
 	/* Here we want automatic selection from available candidates */
-	if (GMT->session.fft1d[k_fft_accelerate] && radix2 (n))
+	if (GMT->session.fft1d[k_fft_accelerate] && gmtfft_radix2 (n))
 		return k_fft_accelerate; /* Use if Radix-2 under OS/X */
 	if (GMT->session.fft1d[k_fft_fftw])
 		return k_fft_fftw;
 	return k_fft_kiss; /* Default/fallback general-purpose FFT */
 }
 
-GMT_LOCAL int fft_2d_selection (struct GMT_CTRL *GMT, unsigned int n_columns, unsigned int n_rows) {
+GMT_LOCAL int gmtfft_2d_selection (struct GMT_CTRL *GMT, unsigned int n_columns, unsigned int n_rows) {
 	/* Returns the most suitable 2-D FFT for the job - or the one requested via GMT_FFT */
 	if (GMT->current.setting.fft != k_fft_auto) {
 		/* Specific selection requested */
@@ -1625,7 +1625,7 @@ GMT_LOCAL int fft_2d_selection (struct GMT_CTRL *GMT, unsigned int n_columns, un
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Desired FFT Algorithm (%s) not configured - choosing suitable alternative.\n", GMT_fft_algo[GMT->current.setting.fft]);
 	}
 	/* Here we want automatic selection from available candidates */
-	if (GMT->session.fft2d[k_fft_accelerate] && radix2 (n_columns) && radix2 (n_rows))
+	if (GMT->session.fft2d[k_fft_accelerate] && gmtfft_radix2 (n_columns) && gmtfft_radix2 (n_rows))
 		return k_fft_accelerate; /* Use if Radix-2 under OS/X */
 	if (GMT->session.fft2d[k_fft_fftw])
 		return k_fft_fftw;
@@ -1639,10 +1639,10 @@ int GMT_FFT_1D (void *V_API, gmt_grdfloat *data, uint64_t n, int direction, unsi
 	 * mode is either GMT_FFT_REAL or GMT_FFT_COMPLEX
 	 */
 	int status, use;
-	struct GMTAPI_CTRL *API = fft_get_api_ptr (V_API);
+	struct GMTAPI_CTRL *API = gmtfft_get_api_ptr (V_API);
 	struct GMT_CTRL *GMT = API->GMT;
 	assert (mode == GMT_FFT_COMPLEX); /* GMT_FFT_REAL not implemented yet */
-	use = fft_1d_selection (GMT, n);
+	use = gmtfft_1d_selection (GMT, n);
 	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "1-D FFT using %s\n", GMT_fft_algo[use]);
 	status = GMT->session.fft1d[use] (GMT, data, (unsigned int)n, direction, mode);
 	if (direction == GMT_FFT_INV) {	/* Undo the 2/nm factor */
@@ -1659,10 +1659,10 @@ int GMT_FFT_2D (void *V_API, gmt_grdfloat *data, unsigned int n_columns, unsigne
 	 * mode is either GMT_FFT_REAL or GMT_FFT_COMPLEX
 	 */
 	int status, use;
-	struct GMTAPI_CTRL *API = fft_get_api_ptr (V_API);
+	struct GMTAPI_CTRL *API = gmtfft_get_api_ptr (V_API);
 	struct GMT_CTRL *GMT = API->GMT;
 	assert (mode == GMT_FFT_COMPLEX); /* GMT_FFT_REAL not implemented yet */
-	use = fft_2d_selection (GMT, n_columns, n_rows);
+	use = gmtfft_2d_selection (GMT, n_columns, n_rows);
 
 	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "2-D FFT using %s\n", GMT_fft_algo[use]);
 	status = GMT->session.fft2d[use] (GMT, data, n_columns, n_rows, direction, mode);
@@ -1699,20 +1699,20 @@ void gmt_fft_initialization (struct GMT_CTRL *GMT) {
 
 #ifdef __APPLE__
 	/* OS X Accelerate Framework */
-	GMT->session.fft1d[k_fft_accelerate] = &fft_1d_vDSP;
-	GMT->session.fft2d[k_fft_accelerate] = &fft_2d_vDSP;
+	GMT->session.fft1d[k_fft_accelerate] = &gmtfft_1d_vDSP;
+	GMT->session.fft2d[k_fft_accelerate] = &gmtfft_2d_vDSP;
 #endif
 #ifdef HAVE_FFTW3F
 	/* single precision FFTW3 */
-	GMT->session.fft1d[k_fft_fftw] = &fft_1d_fftwf;
-	GMT->session.fft2d[k_fft_fftw] = &fft_2d_fftwf;
+	GMT->session.fft1d[k_fft_fftw] = &gmtfft_1d_fftwf;
+	GMT->session.fft2d[k_fft_fftw] = &gmtfft_2d_fftwf;
 #endif /* HAVE_FFTW3F */
 	/* Kiss FFT is the integrated fallback */
-	GMT->session.fft1d[k_fft_kiss] = &fft_1d_kiss;
-	GMT->session.fft2d[k_fft_kiss] = &fft_2d_kiss;
+	GMT->session.fft1d[k_fft_kiss] = &gmtfft_1d_kiss;
+	GMT->session.fft2d[k_fft_kiss] = &gmtfft_2d_kiss;
 	/* Brenner FFT is the legacy fallback */
-	GMT->session.fft1d[k_fft_brenner] = &fft_1d_brenner;
-	GMT->session.fft2d[k_fft_brenner] = &fft_2d_brenner;
+	GMT->session.fft1d[k_fft_brenner] = &gmtfft_1d_brenner;
+	GMT->session.fft2d[k_fft_brenner] = &gmtfft_2d_brenner;
 }
 
 void gmt_fft_cleanup (struct GMT_CTRL *GMT) {
@@ -1724,7 +1724,7 @@ void gmt_fft_cleanup (struct GMT_CTRL *GMT) {
 	fftwf_cleanup_threads(); /* clean resources allocated internally by FFTW */
 #endif
 #ifdef __APPLE__ /* Accelerate framework */
-	fft_1d_vDSP_reset (&GMT->current.fft);
-	fft_2d_vDSP_reset (&GMT->current.fft);
+	gmtfft_gmtfft_1d_vDSP_reset (&GMT->current.fft);
+	gmtfft_gmtfft_2d_vDSP_reset (&GMT->current.fft);
 #endif
 }

--- a/src/gmt_mgg_header2.c
+++ b/src/gmt_mgg_header2.c
@@ -25,14 +25,14 @@
 
 /* Local functions */
 
-GMT_LOCAL void grd98_swap_word (void* ptr) {
+GMT_LOCAL void gmtmggheader2_swap_word (void* ptr) {
 	unsigned char *tmp = ptr;
 	unsigned char a = tmp[0];
 	tmp[0] = tmp[1];
 	tmp[1] = a;
 }
 
-GMT_LOCAL void grd98_swap_long (void *ptr) {
+GMT_LOCAL void gmtmggheader2_swap_long (void *ptr) {
 	unsigned char *tmp = ptr;
 	unsigned char a = tmp[0];
 	tmp[0] = tmp[3];
@@ -42,41 +42,41 @@ GMT_LOCAL void grd98_swap_long (void *ptr) {
 	tmp[2] = a;
 }
 
-GMT_LOCAL int grd98_swap_mgg_header (MGG_GRID_HEADER_2 *header) {
+GMT_LOCAL int gmtmggheader2_swap_mgg_header (MGG_GRID_HEADER_2 *header) {
 	int i, version;
 	/* Determine if swapping is needed */
 	if (header->version == (GRD98_MAGIC_NUM + GRD98_VERSION)) return (0);	/* Version matches, No need to swap */
 	version = header->version;
-	grd98_swap_long (&version);
+	gmtmggheader2_swap_long (&version);
 	if (version != (GRD98_MAGIC_NUM + GRD98_VERSION)) return (-1);		/* Cannot make sense of header */
 	/* Here we come when we do need to swap */
-	grd98_swap_long (&header->version);
-	grd98_swap_long (&header->length);
-	grd98_swap_long (&header->dataType);
-	grd98_swap_long (&header->latDeg);
-	grd98_swap_long (&header->latMin);
-	grd98_swap_long (&header->latSec);
-	grd98_swap_long (&header->latSpacing);
-	grd98_swap_long (&header->latNumCells);
-	grd98_swap_long (&header->lonDeg);
-	grd98_swap_long (&header->lonMin);
-	grd98_swap_long (&header->lonSec);
-	grd98_swap_long (&header->lonSpacing);
-	grd98_swap_long (&header->lonNumCells);
-	grd98_swap_long (&header->minValue);
-	grd98_swap_long (&header->maxValue);
-	grd98_swap_long (&header->gridRadius);
-	grd98_swap_long (&header->precision);
-	grd98_swap_long (&header->nanValue);
-	grd98_swap_long (&header->numType);
-	grd98_swap_long (&header->waterDatum);
-	grd98_swap_long (&header->dataLimit);
-	grd98_swap_long (&header->cellRegistration);
-	for (i = 0; i < GRD98_N_UNUSED; i++) grd98_swap_long (&header->unused[i]);
+	gmtmggheader2_swap_long (&header->version);
+	gmtmggheader2_swap_long (&header->length);
+	gmtmggheader2_swap_long (&header->dataType);
+	gmtmggheader2_swap_long (&header->latDeg);
+	gmtmggheader2_swap_long (&header->latMin);
+	gmtmggheader2_swap_long (&header->latSec);
+	gmtmggheader2_swap_long (&header->latSpacing);
+	gmtmggheader2_swap_long (&header->latNumCells);
+	gmtmggheader2_swap_long (&header->lonDeg);
+	gmtmggheader2_swap_long (&header->lonMin);
+	gmtmggheader2_swap_long (&header->lonSec);
+	gmtmggheader2_swap_long (&header->lonSpacing);
+	gmtmggheader2_swap_long (&header->lonNumCells);
+	gmtmggheader2_swap_long (&header->minValue);
+	gmtmggheader2_swap_long (&header->maxValue);
+	gmtmggheader2_swap_long (&header->gridRadius);
+	gmtmggheader2_swap_long (&header->precision);
+	gmtmggheader2_swap_long (&header->nanValue);
+	gmtmggheader2_swap_long (&header->numType);
+	gmtmggheader2_swap_long (&header->waterDatum);
+	gmtmggheader2_swap_long (&header->dataLimit);
+	gmtmggheader2_swap_long (&header->cellRegistration);
+	for (i = 0; i < GRD98_N_UNUSED; i++) gmtmggheader2_swap_long (&header->unused[i]);
 	return (1);	/* Signal we need to swap the data also */
 }
 
-GMT_LOCAL double grd98_dms2degrees (int deg, int min, int sec) {
+GMT_LOCAL double gmtmggheader2_dms2degrees (int deg, int min, int sec) {
 	double decDeg = (double)deg;
 
 	decDeg += (double)min * GMT_MIN2DEG;
@@ -85,7 +85,7 @@ GMT_LOCAL double grd98_dms2degrees (int deg, int min, int sec) {
     return decDeg;
 }
 
-GMT_LOCAL void grd98_degrees2dms (double degrees, int *deg, int *min, int *sec) {
+GMT_LOCAL void gmtmggheader2_degrees2dms (double degrees, int *deg, int *min, int *sec) {
 	/* Round off to the nearest half second */
 	if (degrees < 0) degrees -= (0.5 * GMT_SEC2DEG);
 
@@ -99,7 +99,7 @@ GMT_LOCAL void grd98_degrees2dms (double degrees, int *deg, int *min, int *sec) 
 	*sec = (int)(degrees * GMT_MIN2SEC_F);
 }
 
-GMT_LOCAL int grd98_GMTtoMGG2 (struct GMT_GRID_HEADER *gmt, MGG_GRID_HEADER_2 *mgg) {
+GMT_LOCAL int gmtmggheader2_GMTtoMGG2 (struct GMT_GRID_HEADER *gmt, MGG_GRID_HEADER_2 *mgg) {
 	double f;
 	gmt_M_memset (mgg, 1, MGG_GRID_HEADER_2);
 
@@ -112,13 +112,13 @@ GMT_LOCAL int grd98_GMTtoMGG2 (struct GMT_GRID_HEADER *gmt, MGG_GRID_HEADER_2 *m
 	f  = gmt->inc[GMT_X] * GMT_DEG2SEC_F;
 	mgg->lonSpacing  = irint(f);
 	if (fabs (f - (double)mgg->lonSpacing) > GMT_CONV8_LIMIT) return (GMT_GRDIO_GRD98_XINC);
-	grd98_degrees2dms(gmt->wesn[XLO], &mgg->lonDeg, &mgg->lonMin, &mgg->lonSec);
+	gmtmggheader2_degrees2dms(gmt->wesn[XLO], &mgg->lonDeg, &mgg->lonMin, &mgg->lonSec);
 
 	mgg->latNumCells = gmt->n_rows;
 	f  = gmt->inc[GMT_Y] * GMT_DEG2SEC_F;
 	mgg->latSpacing  = irint(gmt->inc[GMT_Y] * GMT_DEG2SEC_F);
 	if (fabs (f - (double)mgg->latSpacing) > GMT_CONV8_LIMIT) return (GMT_GRDIO_GRD98_YINC);
-	grd98_degrees2dms(gmt->wesn[YHI], &mgg->latDeg, &mgg->latMin, &mgg->latSec);
+	gmtmggheader2_degrees2dms(gmt->wesn[YHI], &mgg->latDeg, &mgg->latMin, &mgg->latSec);
 
 	/* Default values */
 	mgg->gridRadius  = -1;
@@ -146,7 +146,7 @@ GMT_LOCAL int grd98_GMTtoMGG2 (struct GMT_GRID_HEADER *gmt, MGG_GRID_HEADER_2 *m
 	return (GMT_NOERROR);
 }
 
-GMT_LOCAL void grd98_MGG2toGMT (MGG_GRID_HEADER_2 *mgg, struct GMT_GRID_HEADER *gmt) {
+GMT_LOCAL void gmtmggheader2_MGG2toGMT (MGG_GRID_HEADER_2 *mgg, struct GMT_GRID_HEADER *gmt) {
 	int one_or_zero;
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (gmt);
 
@@ -156,13 +156,13 @@ GMT_LOCAL void grd98_MGG2toGMT (MGG_GRID_HEADER_2 *mgg, struct GMT_GRID_HEADER *
 	gmt->registration = mgg->cellRegistration;
 	one_or_zero = 1 - gmt->registration;
 	gmt->n_columns = mgg->lonNumCells;
-	gmt->wesn[XLO] = grd98_dms2degrees(mgg->lonDeg, mgg->lonMin, mgg->lonSec);
-	gmt->inc[GMT_X] = grd98_dms2degrees(0, 0, mgg->lonSpacing);
+	gmt->wesn[XLO] = gmtmggheader2_dms2degrees(mgg->lonDeg, mgg->lonMin, mgg->lonSec);
+	gmt->inc[GMT_X] = gmtmggheader2_dms2degrees(0, 0, mgg->lonSpacing);
 	gmt->wesn[XHI] = gmt->wesn[XLO] + (gmt->inc[GMT_X] * (gmt->n_columns - one_or_zero));
 
 	gmt->n_rows = mgg->latNumCells;
-	gmt->wesn[YHI] = grd98_dms2degrees(mgg->latDeg, mgg->latMin, mgg->latSec);
-	gmt->inc[GMT_Y] = grd98_dms2degrees(0, 0, mgg->latSpacing);
+	gmt->wesn[YHI] = gmtmggheader2_dms2degrees(mgg->latDeg, mgg->latMin, mgg->latSec);
+	gmt->inc[GMT_Y] = gmtmggheader2_dms2degrees(0, 0, mgg->latSpacing);
 	gmt->wesn[YLO] = gmt->wesn[YHI] - (gmt->inc[GMT_Y] * (gmt->n_rows - one_or_zero));
 
 	gmt->z_min = (double)mgg->minValue / (double)mgg->precision;
@@ -202,7 +202,7 @@ int gmt_is_mgg2_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header) {
 	}
 
 	/* Swap header bytes if necessary; ok is 0|1 if successful and -1 if bad file */
-	ok = grd98_swap_mgg_header (&mggHeader);
+	ok = gmtmggheader2_swap_mgg_header (&mggHeader);
 
 	/* Check the magic number and size of header */
 	if (ok == -1) {
@@ -232,7 +232,7 @@ int gmt_mgg2_read_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header
 	}
 
 	/* Swap header bytes if necessary; ok is 0|1 if successful and -1 if bad file */
-	ok = grd98_swap_mgg_header (&mggHeader);
+	ok = gmtmggheader2_swap_mgg_header (&mggHeader);
 
 	/* Check the magic number and size of header */
 	if (ok == -1) {
@@ -251,7 +251,7 @@ int gmt_mgg2_read_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header
 
 	gmt_fclose (GMT, fp);
 
-	grd98_MGG2toGMT (&mggHeader, header);
+	gmtmggheader2_MGG2toGMT (&mggHeader, header);
 
 	return (GMT_NOERROR);
 }
@@ -267,7 +267,7 @@ int gmt_mgg2_write_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *heade
 	else if ((fp = gmt_fopen (GMT, HH->name, GMT->current.io.w_mode)) == NULL)
 		return (GMT_GRDIO_CREATE_FAILED);
 
-	if ((err = grd98_GMTtoMGG2 (header, &mggHeader)) != 0) {
+	if ((err = gmtmggheader2_GMTtoMGG2 (header, &mggHeader)) != 0) {
 		gmt_fclose (GMT, fp);
 		return (err);
 	}
@@ -309,7 +309,7 @@ int gmt_mgg2_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 			gmt_fclose (GMT, fp);
 			return (GMT_GRDIO_READ_FAILED);
 		}
-		swap_all = grd98_swap_mgg_header (&mggHeader);
+		swap_all = gmtmggheader2_swap_mgg_header (&mggHeader);
 		if (swap_all == -1) {
 			gmt_fclose (GMT, fp);
 			return (GMT_GRDIO_GRD98_BADMAGIC);
@@ -361,18 +361,18 @@ int gmt_mgg2_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 		for (i = 0; i < width_in; i++) {
 			kk = ij + i;
 			if (mggHeader.numType == sizeof (int)) {
-				if (swap_all) grd98_swap_long (&tLong[actual_col[i]]);
+				if (swap_all) gmtmggheader2_swap_long (&tLong[actual_col[i]]);
 				if (tLong[actual_col[i]] == mggHeader.nanValue) grid[kk] = GMT->session.f_NaN;
 				else grid[kk] = (gmt_grdfloat) tLong[actual_col[i]] / (gmt_grdfloat) mggHeader.precision;
 			}
 			else if (is_float) {
-				if (swap_all) grd98_swap_long (&tLong[actual_col[i]]);
+				if (swap_all) gmtmggheader2_swap_long (&tLong[actual_col[i]]);
 				if (tLong[actual_col[i]] == mggHeader.nanValue) grid[kk] = GMT->session.f_NaN;
 				else grid[kk] = tFloat[actual_col[i]];
 			}
 
 			else if (mggHeader.numType == sizeof (short)) {
-				if (swap_all) grd98_swap_word(&tShort[actual_col[i]]);
+				if (swap_all) gmtmggheader2_swap_word(&tShort[actual_col[i]]);
 				if (tShort[actual_col[i]] == mggHeader.nanValue) grid[kk] = GMT->session.f_NaN;
 				else grid[kk] = (gmt_grdfloat) tShort[actual_col[i]] / (gmt_grdfloat) mggHeader.precision;
 			}
@@ -474,7 +474,7 @@ int gmt_mgg2_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gm
 		header->z_min = header->z_max = NAN;
 
 	/* store header information and array */
-	if ((err = grd98_GMTtoMGG2(header, &mggHeader)) != 0) {
+	if ((err = gmtmggheader2_GMTtoMGG2(header, &mggHeader)) != 0) {
 		gmt_fclose (GMT, fp);
 		gmt_M_free (GMT, actual_col);
 		return (err);

--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -102,7 +102,7 @@ enum Netcdf_io_mode {
 };
 
 /* Wrapper around gmt_nc_put_vara_grdfloat and gmt_nc_get_vara_grdfloat */
-static inline int io_nc_vara_grdfloat (int ncid, int varid, const size_t *startp, const size_t *countp, gmt_grdfloat *fp, unsigned io_mode) {
+static inline int gmtnc_vara_grdfloat (int ncid, int varid, const size_t *startp, const size_t *countp, gmt_grdfloat *fp, unsigned io_mode) {
 	if (io_mode == k_put_netcdf)	/* write netcdf */
 		return gmt_nc_put_vara_grdfloat (ncid, varid, startp, countp, fp);
 	/* read netcdf */
@@ -110,7 +110,7 @@ static inline int io_nc_vara_grdfloat (int ncid, int varid, const size_t *startp
 }
 
 /* Wrapper around gmt_nc_put_varm_grdfloat and gmt_nc_get_varm_grdfloat */
-static inline int io_nc_varm_grdfloat (int ncid, int varid, const size_t *startp, const size_t *countp, const ptrdiff_t *stridep, const ptrdiff_t *imapp, gmt_grdfloat *fp, unsigned io_mode) {
+static inline int gmtnc_varm_grdfloat (int ncid, int varid, const size_t *startp, const size_t *countp, const ptrdiff_t *stridep, const ptrdiff_t *imapp, gmt_grdfloat *fp, unsigned io_mode) {
 	if (io_mode == k_put_netcdf)	/* write netcdf */
 		return gmt_nc_put_varm_grdfloat (ncid, varid, startp, countp, stridep, imapp, fp);
 	/* read netcdf */
@@ -221,9 +221,9 @@ GMT_LOCAL int gmtnc_io_nc_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *he
 #endif
 			/* get/put chunked rows */
 			if (stride)
-				status = io_nc_varm_grdfloat (HH->ncid, HH->z_id, start, count, onestride, imap, grid, io_mode);
+				status = gmtnc_varm_grdfloat (HH->ncid, HH->z_id, start, count, onestride, imap, grid, io_mode);
 			else
-				status = io_nc_vara_grdfloat (HH->ncid, HH->z_id, start, count, grid, io_mode);
+				status = gmtnc_vara_grdfloat (HH->ncid, HH->z_id, start, count, grid, io_mode);
 
 			/* advance grid location and set new origin */
 			grid += count[yx_dim[0]] * ((stride == 0 ? width_t : stride));
@@ -242,9 +242,9 @@ GMT_LOCAL int gmtnc_io_nc_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *he
 					++row_num, start[yx_dim[0]], count[yx_dim[0]]);
 #endif
 			if (stride)
-				status = io_nc_varm_grdfloat (HH->ncid, HH->z_id, start, count, onestride, imap, grid, io_mode);
+				status = gmtnc_varm_grdfloat (HH->ncid, HH->z_id, start, count, onestride, imap, grid, io_mode);
 			else
-				status = io_nc_vara_grdfloat (HH->ncid, HH->z_id, start, count, grid, io_mode);
+				status = gmtnc_vara_grdfloat (HH->ncid, HH->z_id, start, count, grid, io_mode);
 		}
 	}
 	else {
@@ -252,9 +252,9 @@ GMT_LOCAL int gmtnc_io_nc_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *he
 		count[yx_dim[0]] = height_t;
 		count[yx_dim[1]] = width_t;
 		if (stride)
-			status = io_nc_varm_grdfloat (HH->ncid, HH->z_id, start, count, onestride, imap, grid, io_mode);
+			status = gmtnc_varm_grdfloat (HH->ncid, HH->z_id, start, count, onestride, imap, grid, io_mode);
 		else
-			status = io_nc_vara_grdfloat (HH->ncid, HH->z_id, start, count, grid, io_mode);
+			status = gmtnc_vara_grdfloat (HH->ncid, HH->z_id, start, count, grid, io_mode);
 	}
 	return status;
 }
@@ -375,14 +375,14 @@ GMT_LOCAL void gmtnc_set_optimal_chunksize (struct GMT_CTRL *GMT, struct GMT_GRI
 	GMT->current.setting.io_nc4_chunksize[1] = (size_t) ceil (header->n_columns / floor (header->n_columns / chunksize[1]));
 }
 
-GMT_LOCAL bool not_obviously_global (double *we) {
+GMT_LOCAL bool gmtnc_not_obviously_global (double *we) {
 	/* If range is not 360 and boundaries are not 0, 180, 360 then we pass */
 	if (!gmt_M_360_range (we[0], we[1])) return true;
 	if (!(doubleAlmostEqualZero (we[0], 0.0) || doubleAlmostEqual (we[0], -180.0))) return true;
 	return false;
 }
 
-GMT_LOCAL bool not_obviously_polar (double *se) {
+GMT_LOCAL bool gmtnc_not_obviously_polar (double *se) {
 	/* If range is not 180 and boundaries are not -90/90 then we pass */
 	if (!gmt_M_180_range (se[0], se[1])) return true;
 	if (!(doubleAlmostEqual (se[0], -90.0) && doubleAlmostEqual (se[1], 90.0))) return true;
@@ -627,7 +627,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 
 		if (has_vector && has_range) {	/* Has both so we can do a basic sanity check */
 			if (fabs (dummy[0] - xy[0]) > ((0.5+GMT_CONV5_LIMIT) * dx) || fabs (dummy[1] - xy[header->n_columns-1]) > ((0.5+GMT_CONV5_LIMIT) * dx)) {
-				if (not_obviously_global (dummy)) {
+				if (gmtnc_not_obviously_global (dummy)) {
 					GMT_Report (GMT->parent, GMT_MSG_WARNING, "The x-coordinates and range attribute are in conflict; must rely on coordinates only\n");
 					dummy[0] = xy[0], dummy[1] = xy[header->n_columns-1];
 					has_range = false;	/* Since useless information */
@@ -708,7 +708,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 
 		if (has_vector && has_range) {	/* Has both so we can do a basic sanity check */
 			if (fabs (dummy[0] - xy[0]) > ((0.5+GMT_CONV5_LIMIT) * dy) || fabs (dummy[1] - xy[header->n_rows-1]) > ((0.5+GMT_CONV5_LIMIT) * dy)) {
-				if (not_obviously_polar (dummy)) {
+				if (gmtnc_not_obviously_polar (dummy)) {
 					GMT_Report (GMT->parent, GMT_MSG_WARNING, "The y-coordinates and range attribute are in conflict; must rely on coordinates only\n");
 					dummy[0] = xy[0], dummy[1] = xy[header->n_rows-1];
 					has_range = false;	/* Since useless information */

--- a/src/gmt_sph.c
+++ b/src/gmt_sph.c
@@ -390,7 +390,7 @@ int gmt_ssrfpack_grid (struct GMT_CTRL *GMT, double *x, double *y, double *z, do
 }
 
 /* Determine if spherical triangle is oriented clockwise or counter-clockwise */
-GMT_LOCAL int orientation (struct GMT_CTRL *GMT, double A[], double B[], double C[]) {
+GMT_LOCAL int gmtsph_orientation (struct GMT_CTRL *GMT, double A[], double B[], double C[]) {
 	double X[3];
 	gmt_cross3v (GMT, A, B, X);
 	return (gmt_dot3v (GMT, X, C) < 0.0 ? -1 : +1);
@@ -413,7 +413,7 @@ double gmtlib_geo_centroid_area (struct GMT_CTRL *GMT, double *lon, double *lat,
 		gmt_geo_to_cart (GMT, clat, lon[1], P0, true);	/* get x/y/z for 2nd point*/
 		clat = gmt_lat_swap (GMT, lat[2], GMT_LATSWAP_G2O);	/* Get geocentric latitude */
 		gmt_geo_to_cart (GMT, clat, lon[2], P1, true);	/* get x/y/z for 3rd point*/
-		sgn = orientation (GMT, N, P0, P1);
+		sgn = gmtsph_orientation (GMT, N, P0, P1);
 		pol_area = areas_ (N, P0, P1);	/* Absolute area of this spherical triangle N-P0-P1 */
 		if (gmt_M_is_verbose (GMT, GMT_MSG_DEBUG)) {
 			kind = (sgn == -1) ? 0 : 1;
@@ -444,7 +444,7 @@ double gmtlib_geo_centroid_area (struct GMT_CTRL *GMT, double *lon, double *lat,
 		clat = gmt_lat_swap (GMT, lat[p], GMT_LATSWAP_G2O);	/* Get geocentric latitude */
 		gmt_geo_to_cart (GMT, clat, lon[p], P1, true);	/* Get x/y/z for next point P1 */
 		tri_area = areas_ (N, P0, P1);	/* Absolute area of this spherical triangle N-P0-P1 */
-		sgn = orientation (GMT, N, P0, P1);	/* Sign of this area */
+		sgn = gmtsph_orientation (GMT, N, P0, P1);	/* Sign of this area */
 		if (gmt_M_is_verbose (GMT, GMT_MSG_DEBUG)) {
 			kind = (sgn == -1) ? 0 : 1;
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Spherical triangle %.4lg/%.4lg via %.4lg/%.4lg to %.4lg/%.4lg : Unit area %7.5lg oriented %3s\n", center[0], center[1], lon[p-1], lat[p-1], lon[p], lat[p], tri_area, way[kind]);

--- a/src/gmt_stat.c
+++ b/src/gmt_stat.c
@@ -1576,7 +1576,7 @@ double gmt_Fcrit (struct GMT_CTRL *GMT, double alpha, double nu1, double nu2) {
 	return (F_mid);
 }
 
-static inline uint64_t mix64 (uint64_t a, uint64_t b, uint64_t c) {
+static inline uint64_t gmtstat_mix64 (uint64_t a, uint64_t b, uint64_t c) {
 	/* Mix 3 64-bit values, from lookup8.c by Bob Jenkins
 	 * (http://burtleburtle.net/bob/index.html) */
 	a -= b; a -= c; a ^= (c>>43);
@@ -1603,7 +1603,7 @@ double gmt_rand (struct GMT_CTRL *GMT) {
 	while (seed == 0) { /* repeat in case of unsigned overflow */
 		/* Initialize random seed, idea from Jonathan
 		 * Wright (http://stackoverflow.com/q/322938) */
-		seed = (unsigned) mix64 (clock(), time(NULL), getpid());
+		seed = (unsigned) gmtstat_mix64 (clock(), time(NULL), getpid());
 		srand (seed);
 	}
 
@@ -2737,7 +2737,7 @@ double gmt_grd_lmsscl (struct GMT_CTRL *GMT, struct GMT_GRID *G, struct GMT_GRID
 	return lmsscl;
 }
 
-GMT_LOCAL void get_geo_cellarea (struct GMT_CTRL *GMT, struct GMT_GRID *G) {
+GMT_LOCAL void gmtstat_get_geo_cellarea (struct GMT_CTRL *GMT, struct GMT_GRID *G) {
 	/* Calculate geographic SPHERICAL area in km^2 and place in grid G.
 	 * Integrating the area between two parallels +/- yinc/2 to either side of latitude y on a sphere
 	 * and partition it amount all cells in longitude yields the exact area (angles in radians)
@@ -2788,7 +2788,7 @@ GMT_LOCAL void get_geo_cellarea (struct GMT_CTRL *GMT, struct GMT_GRID *G) {
 	}
 }
 
-GMT_LOCAL void get_cart_cellarea (struct GMT_CTRL *GMT, struct GMT_GRID *G) {
+GMT_LOCAL void gmtstat_get_cart_cellarea (struct GMT_CTRL *GMT, struct GMT_GRID *G) {
 	/* Calculate Cartesian cell areas in user units */
 	uint64_t node;
 	unsigned int row, col, last_row = G->header->n_rows - 1, last_col = G->header->n_columns - 1;
@@ -2806,7 +2806,7 @@ GMT_LOCAL void get_cart_cellarea (struct GMT_CTRL *GMT, struct GMT_GRID *G) {
 void gmt_get_cellarea (struct GMT_CTRL *GMT, struct GMT_GRID *G) {
 	/* Calculate geographic spherical in km^2 or plain Cartesian area in suer_unit^2 and place in grid G. */
 	if (gmt_M_is_geographic (GMT, GMT_IN))
-		get_geo_cellarea (GMT, G);
+		gmtstat_get_geo_cellarea (GMT, G);
 	else
-		get_cart_cellarea (GMT, G);
+		gmtstat_get_cart_cellarea (GMT, G);
 }

--- a/src/gmt_vector.c
+++ b/src/gmt_vector.c
@@ -33,7 +33,7 @@ struct GMT_SINGULAR_VALUE {	/* Used for sorting of eigenvalues in the SVD functi
 
 /* Local functions */
 
-GMT_LOCAL void vector_switchrows (double *a, double *b, unsigned int n1, unsigned int n2, unsigned int n) {
+GMT_LOCAL void gmtvector_switchrows (double *a, double *b, unsigned int n1, unsigned int n2, unsigned int n) {
 	double *oa = (double *)malloc (sizeof(double)*n);
 
 	memcpy(oa, a+n*n1, sizeof(double)*n);
@@ -59,7 +59,7 @@ GMT_LOCAL void vector_switchrows (double *a, double *b, unsigned int n1, unsigne
 
 #ifndef HAVE_LAPACK
 /* Use version provided by DJ 2015-07-06 [SDSC] */
-GMT_LOCAL int vector_svdcmp_nr (struct GMT_CTRL *GMT, double *a, unsigned int m_in, unsigned int n_in, double *w, double *v) {
+GMT_LOCAL int gmtvector_svdcmp_nr (struct GMT_CTRL *GMT, double *a, unsigned int m_in, unsigned int n_in, double *w, double *v) {
 	/* void svdcmp(double *a,int m,int n,double *w,double *v) */
 
 	int flag,i,its,j,jj,k,l=0,nm = 0, n = n_in, m = m_in;
@@ -280,7 +280,7 @@ GMT_LOCAL int vector_svdcmp_nr (struct GMT_CTRL *GMT, double *a, unsigned int m_
 }
 #endif
 
-GMT_LOCAL int vector_compare_singular_values (const void *point_1v, const void *point_2v) {
+GMT_LOCAL int gmtvector_compare_singular_values (const void *point_1v, const void *point_2v) {
 	/*  Routine for qsort to sort struct GMT_SINGULAR_VALUE on decreasing eigenvalues
 	 * keeping track of the original order before sorting.
 	 */
@@ -297,7 +297,7 @@ GMT_LOCAL int vector_compare_singular_values (const void *point_1v, const void *
 	return (0);
 }
 
-GMT_LOCAL uint64_t vector_fix_up_path_cartonly (struct GMT_CTRL *GMT, double **a_x, double **a_y, uint64_t n, unsigned int mode) {
+GMT_LOCAL uint64_t gmtvector_fix_up_path_cartonly (struct GMT_CTRL *GMT, double **a_x, double **a_y, uint64_t n, unsigned int mode) {
 	/* Takes pointers to a list of <n> Cartesian x/y pairs and adds
 	 * auxiliary points to build a staircase curve.
 	 * If mode=1: staircase; first follows y, then x
@@ -338,7 +338,7 @@ GMT_LOCAL uint64_t vector_fix_up_path_cartonly (struct GMT_CTRL *GMT, double **a
 	return (n_new);
 }
 
-GMT_LOCAL uint64_t vector_fix_up_path_cartesian (struct GMT_CTRL *GMT, double **a_x, double **a_y, uint64_t n, double step, unsigned int mode) {
+GMT_LOCAL uint64_t gmtvector_fix_up_path_cartesian (struct GMT_CTRL *GMT, double **a_x, double **a_y, uint64_t n, double step, unsigned int mode) {
 	/* Takes pointers to a list of <n> x/y pairs (in user units) and adds
 	 * auxiliary points if the distance between two given points exceeds
 	 * <step> units.
@@ -419,7 +419,7 @@ GMT_LOCAL uint64_t vector_fix_up_path_cartesian (struct GMT_CTRL *GMT, double **
 	return (n_new);
 }
 
-GMT_LOCAL uint64_t vector_resample_path_spherical (struct GMT_CTRL *GMT, double **lon, double **lat, uint64_t n_in, double step_out, enum GMT_enum_track mode) {
+GMT_LOCAL uint64_t gmtvector_resample_path_spherical (struct GMT_CTRL *GMT, double **lon, double **lat, uint64_t n_in, double step_out, enum GMT_enum_track mode) {
 	/* See gmt_resample_path below for details. */
 
 	bool meridian, new_pair;
@@ -430,11 +430,11 @@ GMT_LOCAL uint64_t vector_resample_path_spherical (struct GMT_CTRL *GMT, double 
 	double *dist_in = NULL, *lon_out = NULL, *lat_out = NULL, *lon_in = *lon, *lat_in = *lat;
 
 	if (step_out < 0.0) {	/* Safety valve */
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Internal error: vector_resample_path_spherical given negative step-size\n");
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Internal error: gmtvector_resample_path_spherical given negative step-size\n");
 		return (GMT_RUNTIME_ERROR);
 	}
 	if (mode > GMT_TRACK_SAMPLE_ADJ) {	/* Bad mode*/
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Internal error: vector_resample_path_spherical given bad mode %d\n", mode);
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Internal error: gmtvector_resample_path_spherical given bad mode %d\n", mode);
 		return (GMT_RUNTIME_ERROR);
 	}
 
@@ -527,7 +527,7 @@ GMT_LOCAL uint64_t vector_resample_path_spherical (struct GMT_CTRL *GMT, double 
 	return (n_out);
 }
 
-GMT_LOCAL uint64_t vector_resample_path_cartesian (struct GMT_CTRL *GMT, double **x, double **y, uint64_t n_in, double step_out, enum GMT_enum_track mode) {
+GMT_LOCAL uint64_t gmtvector_resample_path_cartesian (struct GMT_CTRL *GMT, double **x, double **y, uint64_t n_in, double step_out, enum GMT_enum_track mode) {
 	/* See gmt_resample_path below for details. */
 
 	uint64_t last_row_in = 0, row_in, row_out, n_out;
@@ -536,15 +536,15 @@ GMT_LOCAL uint64_t vector_resample_path_cartesian (struct GMT_CTRL *GMT, double 
 	double *dist_in = NULL, *x_out = NULL, *y_out = NULL, *x_in = *x, *y_in = *y;
 
 	if (step_out < 0.0) {	/* Safety valve */
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Internal error: vector_resample_path_cartesian given negative step-size\n");
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Internal error: gmtvector_resample_path_cartesian given negative step-size\n");
 		return (GMT_RUNTIME_ERROR);
 	}
 	if (mode > GMT_TRACK_SAMPLE_ADJ) {	/* Bad mode*/
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Internal error: vector_resample_path_cartesian given bad mode %d\n", mode);
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Internal error: gmtvector_resample_path_cartesian given bad mode %d\n", mode);
 		return (GMT_RUNTIME_ERROR);
 	}
 
-	if (mode < GMT_TRACK_SAMPLE_FIX) return (vector_fix_up_path_cartesian (GMT, x, y, n_in, step_out, mode));	/* Insert extra points only */
+	if (mode < GMT_TRACK_SAMPLE_FIX) return (gmtvector_fix_up_path_cartesian (GMT, x, y, n_in, step_out, mode));	/* Insert extra points only */
 
 	dist_in = gmt_dist_array (GMT, x_in, y_in, n_in, true);	/* Compute cumulative distances along line */
 	if (step_out == 0.0) step_out = (dist_in[n_in-1] - dist_in[0])/100.0;	/* If nothing is selected we get 101 points */
@@ -972,7 +972,7 @@ int gmt_gaussjordan (struct GMT_CTRL *GMT, double *a, unsigned int nu, double *b
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_gaussjordan given a singular matrix\n");
 			bad++;
 		}
-		vector_switchrows (a, b, j, k, n);	/* Pivot rows */
+		gmtvector_switchrows (a, b, j, k, n);	/* Pivot rows */
 #ifdef _OPENMP
 #pragma omp parallel for private(i,k,c) shared(GMT,a,b,j,n)
 #endif
@@ -1025,7 +1025,7 @@ int gmt_svdcmp (struct GMT_CTRL *GMT, double *a, unsigned int m_in, unsigned int
 	return (GMT_NOERROR);
 #else
 	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "gmt_svdcmp: Using GMT's NR-based SVD\n");
-	return vector_svdcmp_nr (GMT, a, m_in, n_in, w, v);
+	return gmtvector_svdcmp_nr (GMT, a, m_in, n_in, w, v);
 #endif
 }
 
@@ -1081,7 +1081,7 @@ int gmt_solve_svd (struct GMT_CTRL *GMT, double *u, unsigned int m, unsigned int
 			eigen[i].value = fabs (w[i]);
 			eigen[i].order = i;
 		}
-		qsort (eigen, n, sizeof (struct GMT_SINGULAR_VALUE), vector_compare_singular_values);
+		qsort (eigen, n, sizeof (struct GMT_SINGULAR_VALUE), gmtvector_compare_singular_values);
 
 		n_eigen = (unsigned int)lrint (cutoff);	/* Desired number of eigenvalues to use instead */
 		for (i = 0; i < n; i++) {	/* Visit all singular values in decreasing magnitude */
@@ -1397,7 +1397,7 @@ uint64_t gmt_fix_up_path (struct GMT_CTRL *GMT, double **a_lon, double **a_lat, 
 	double c, d, fraction, theta, minlon, maxlon;
 	double dlon, lon_i, boost, f_lat_a, f_lat_b;
 
-	if (gmt_M_is_cartesian (GMT, GMT_IN)) return (vector_fix_up_path_cartonly (GMT, a_lon, a_lat, n, mode));	/* Stair case only */
+	if (gmt_M_is_cartesian (GMT, GMT_IN)) return (gmtvector_fix_up_path_cartonly (GMT, a_lon, a_lat, n, mode));	/* Stair case only */
 
 	lon = *a_lon;	lat = *a_lat;	/* Input arrays */
 
@@ -1599,9 +1599,9 @@ uint64_t gmt_resample_path (struct GMT_CTRL *GMT, double **x, double **y, uint64
 	 */
 	uint64_t n_out;
 	if (gmt_M_is_geographic (GMT, GMT_IN))
-		n_out = vector_resample_path_spherical (GMT, x, y, n_in, step_out, mode);
+		n_out = gmtvector_resample_path_spherical (GMT, x, y, n_in, step_out, mode);
 	else
-		n_out = vector_resample_path_cartesian (GMT, x, y, n_in, step_out, mode);
+		n_out = gmtvector_resample_path_cartesian (GMT, x, y, n_in, step_out, mode);
 	return (n_out);
 }
 


### PR DESCRIPTION
This includes gmt_agc_io.c, gmt_calclock.c, gmt_customio.c, gmt_dcw.c, gmt_esri_io.c, gmt_fft.c, gmt_mgg_header2.c, gmt_nc.c, gmt_sph.c, gmt_stat.c, and gmt_vector.c
