### PR TITLE
Update functions in mbsystem_module

### DIFF
--- a/src/gmt_mbsystem_module.c
+++ b/src/gmt_mbsystem_module.c
@@ -43,7 +43,7 @@ static struct Gmt_moduleinfo g_mbsystem_module[] = {
 };
 
 /* Pretty print all GMT mbsystem module names and their purposes for gmt --help */
-void gmt_mbsystem_module_show_all (void *V_API) {
+void gmtlib_mbsystem_module_show_all (void *V_API) {
 	unsigned int module_id = 0;
 	char message[256] = {""};
 	GMT_Message (V_API, GMT_TIME_NONE, "\n===  mbsystem modules accessible from gmt  ===\n");
@@ -62,7 +62,7 @@ void gmt_mbsystem_module_show_all (void *V_API) {
 }
 
 /* Produce single list on stdout of all GMT mbsystem module names for gmt --show-modules */
-void gmt_mbsystem_module_list_all (void *API) {
+void gmtlib_mbsystem_module_list_all (void *API) {
 	unsigned int module_id = 0;
 	gmt_M_unused(API);
 	while (g_mbsystem_module[module_id].name != NULL) {
@@ -72,7 +72,7 @@ void gmt_mbsystem_module_list_all (void *API) {
 }
 
 /* Lookup module id by name, return option keys pointer (for external API developers) */
-const char *gmt_mbsystem_module_keys (void *API, char *candidate) {
+const char *gmtlib_mbsystem_module_keys (void *API, char *candidate) {
 	int module_id = 0;
 	gmt_M_unused(API);
 
@@ -86,7 +86,7 @@ const char *gmt_mbsystem_module_keys (void *API, char *candidate) {
 }
 
 /* Lookup module id by name, return group char name (for external API developers) */
-const char *gmt_mbsystem_module_group (void *API, char *candidate) {
+const char *gmtlib_mbsystem_module_group (void *API, char *candidate) {
 	int module_id = 0;
 	gmt_M_unused(API);
 

--- a/src/gmt_mbsystem_module.h
+++ b/src/gmt_mbsystem_module.h
@@ -27,11 +27,11 @@ EXTERN_MSC int GMT_mbgrdtiff (void *API, int mode, void *args);
 EXTERN_MSC int GMT_mbswath (void *API, int mode, void *args);
 
 /* Pretty print all modules in the GMT mbsystem library and their purposes */
-EXTERN_MSC void gmt_mbsystem_module_show_all (void *API);
+EXTERN_MSC void gmtlib_mbsystem_module_show_all (void *API);
 /* List all modules in the GMT mbsystem library to stdout */
-EXTERN_MSC void gmt_mbsystem_module_list_all (void *API);
+EXTERN_MSC void gmtlib_mbsystem_module_list_all (void *API);
 /* Function called by GMT_Encode_Options so developers can get information about a module */
-EXTERN_MSC const char * gmt_mbsystem_module_info (void *API, char *candidate);
+EXTERN_MSC const char * gmtlib_mbsystem_module_info (void *API, char *candidate);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Since these are library functions and now are called gmtlib_* we must make the same changes to this glue file.
