### PR TITLE
Let all test programs be called test_*.c

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -396,7 +396,7 @@ set (GMT_LIB_SRCS block_subs.h common_byteswap.h common_math.h
 # source codes for testing API
 if (DO_API_TESTS)
 	set (GMT_DEMOS_SRCS testpsl.c testgmtshell.c testgmtio.c testgrdio.c
-		testapiconv.c example1.c testapi_matrix.c testapi_matrix_plot.c testapi_vector.c test_JL.c testapi_mixmatrix.c
+		testapiconv.c test_example1.c testapi_matrix.c testapi_matrix_plot.c testapi_vector.c test_JL.c testapi_mixmatrix.c
 		test_walter.c testapi_usergrid.c testapi_userdataset.c testapi_uservectors.c)
 endif (DO_API_TESTS)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -395,9 +395,8 @@ set (GMT_LIB_SRCS block_subs.h common_byteswap.h common_math.h
 
 # source codes for testing API
 if (DO_API_TESTS)
-	set (GMT_DEMOS_SRCS testpsl.c testgmtshell.c testgmtio.c testgrdio.c
-		testapiconv.c test_example1.c testapi_matrix.c testapi_matrix_plot.c testapi_vector.c test_JL.c testapi_mixmatrix.c
-		test_walter.c testapi_usergrid.c testapi_userdataset.c testapi_uservectors.c)
+	# Include all test*.c files
+	file (GLOB GMT_DEMOS_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/test*.c")
 endif (DO_API_TESTS)
 
 

--- a/src/test_example1.c
+++ b/src/test_example1.c
@@ -1,4 +1,5 @@
 #include "gmt.h"
+/* Demonstrate how to use the API to read a table and grid it with greenspline, then write a grid file */
 int main () {
     void *API;                        /* The API control structure */
     struct GMT_DATASET *D = NULL;     /* Structure to hold input dataset */


### PR DESCRIPTION
Most of them already did, but example1.c was the odd man out.  Perhaps @seisman can now simplify the CMakefile to look for all test_*.c files instead of a list?
