### PR TITLE
Correct grdvector scalings and documentation

### DIFF
--- a/doc/examples/ex13/ex13.ps
+++ b/doc/examples/ex13/ex13.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 595 842
 %%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.1.0_9ee9cff_2020.02.16 [64-bit] Document from pstext
+%%Title: GMT v6.1.0_6488207_2020.04.11 [64-bit] Document from pstext
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Feb 16 18:07:10 2020
+%%CreationDate: Sat Apr 11 17:11:59 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -661,7 +661,7 @@ FQ
 O0
 1200 1200 TM
 % PostScript produced by:
-%@GMT: gmt pstext -R0/5.90551/0/5.90551 -Jx1i -N -F+jBC+f40p,Times-Italic,black @GMTAPI@-000000 -Xr1i -Yr1i --GMT_HISTORY=false
+%@GMT: gmt pstext -R0/5.90551/0/5.90551 -Jx1i -N -F+jBC+f40p,Times-Italic,black @GMTAPI@-S-I-D-D-N-N-000000 -Xr1i -Yr1i --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 5.90551000 0.00000000 5.90551000 0.000 5.906 0.000 5.906 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -2020,6 +2020,7 @@ U
 [] 0 B
 PSL_cliprestore
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 3297 M 0 -3297 D S
 /PSL_A0_y 83 def
@@ -2030,8 +2031,8 @@ N 0 824 M -83 0 D S
 N 0 1649 M -83 0 D S
 N 0 2473 M -83 0 D S
 N 0 3297 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 200 F0
 (-2) sw mx
 (-1) sw mx
@@ -2107,8 +2108,8 @@ N 824 0 M 0 -83 D S
 N 1649 0 M 0 -83 D S
 N 2473 0 M 0 -83 D S
 N 3297 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (-2) sh mx
 (-1) sh mx
 (0) sh mx
@@ -3409,6 +3410,7 @@ P S
 P S
 PSL_cliprestore
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 3297 M 0 -3297 D S
 /PSL_A0_y 83 def
@@ -3419,8 +3421,8 @@ N 0 824 M -83 0 D S
 N 0 1649 M -83 0 D S
 N 0 2473 M -83 0 D S
 N 0 3297 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (-2) sw mx
@@ -3497,8 +3499,8 @@ N 824 0 M 0 -83 D S
 N 1649 0 M 0 -83 D S
 N 2473 0 M 0 -83 D S
 N 3297 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (-2) sh mx
 (-1) sh mx
 (0) sh mx
@@ -3570,7 +3572,7 @@ FQ
 O0
 3789 3789 TM
 % PostScript produced by:
-%@GMT: gmt grdvector dzdx.nc dzdy.nc -I0.2 -Q0.25c+e+n0.25i+h0.5 -Gblack -W1p -S12c -Xa3.1576i -Ya3.1576i -R-2/2/-2/2 -JX15c
+%@GMT: gmt grdvector dzdx.nc dzdy.nc -I0.2 -Q0.25c+e+n0.25i+h0.5 -Gblack -W1p -S2c -Xa3.1576i -Ya3.1576i -R-2/2/-2/2 -JX15c
 %@PROJ: xy -2.00000000 2.00000000 -2.00000000 2.00000000 -2.000 2.000 -2.000 2.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -3629,29 +3631,28 @@ V 493 3302 T 113.494 R
 PSL_vecheadpen
 0 W
 0 0 M
--2 1 D
-1 -1 D
--1 -1 D
+-2 0 D
+1 0 D
+-1 0 D
 P clip fs P S 
 U
 0 W
 V 659 3297 T 108.003 R
-N 0 0 M 5 0 D S
+N 0 0 M 4 0 D S
 U
-V 657 3304 T 108.003 R
+V 658 3303 T 108.003 R
 PSL_vecheadpen
 0 W
 0 0 M
--3 1 D
-1 -1 D
--1 -1 D
+-2 1 D
+0 -2 D
 P clip fs P S 
 U
 0 W
 V 824 3297 T 101.65 R
-N 0 0 M 6 0 D S
+N 0 0 M 5 0 D S
 U
-V 823 3306 T 101.65 R
+V 823 3305 T 101.65 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -3660,37 +3661,35 @@ PSL_vecheadpen
 -1 -1 D
 P clip fs P S 
 U
-1 W
+0 W
 V 989 3297 T 94.0463 R
-N 0 0 M 7 0 D S
+N 0 0 M 6 0 D S
 U
-V 989 3307 T 94.0463 R
+V 989 3306 T 94.0463 R
 PSL_vecheadpen
-1 W
+0 W
 0 0 M
--4 1 D
-1 -1 D
--1 -1 D
+-3 1 D
+0 -2 D
 P clip fs P S 
 U
-1 W
+0 W
 V 1154 3297 T 84.3598 R
-N 0 0 M 7 0 D S
+N 0 0 M 6 0 D S
 U
-V 1155 3307 T 84.3598 R
+V 1155 3306 T 84.3598 R
 PSL_vecheadpen
-1 W
+0 W
 0 0 M
--4 1 D
-1 -1 D
--1 -1 D
+-3 1 D
+0 -2 D
 P clip fs P S 
 U
 0 W
 V 1319 3297 T 70.4884 R
-N 0 0 M 6 0 D S
+N 0 0 M 5 0 D S
 U
-V 1322 3305 T 70.4884 R
+V 1321 3305 T 70.4884 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -3703,7 +3702,7 @@ U
 V 1484 3297 T 46.3003 R
 N 0 0 M 4 0 D S
 U
-V 1488 3302 T 46.3003 R
+V 1488 3301 T 46.3003 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -3726,7 +3725,7 @@ U
 V 1814 3297 T -46.3003 R
 N 0 0 M 4 0 D S
 U
-V 1818 3293 T -46.3003 R
+V 1817 3294 T -46.3003 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -3736,7 +3735,7 @@ P clip fs P S
 U
 0 W
 V 1978 3297 T -70.4884 R
-N 0 0 M 6 0 D S
+N 0 0 M 5 0 D S
 U
 V 1981 3290 T -70.4884 R
 PSL_vecheadpen
@@ -3747,37 +3746,35 @@ PSL_vecheadpen
 -1 -1 D
 P clip fs P S 
 U
-1 W
+0 W
 V 2143 3297 T -84.3598 R
-N 0 0 M 7 0 D S
+N 0 0 M 6 0 D S
 U
-V 2144 3288 T -84.3598 R
+V 2144 3289 T -84.3598 R
 PSL_vecheadpen
-1 W
+0 W
 0 0 M
--4 1 D
-1 -1 D
--1 -1 D
+-3 1 D
+0 -2 D
 P clip fs P S 
 U
-1 W
+0 W
 V 2308 3297 T -94.0463 R
-N 0 0 M 7 0 D S
+N 0 0 M 6 0 D S
 U
-V 2308 3288 T -94.0463 R
+V 2308 3289 T -94.0463 R
 PSL_vecheadpen
-1 W
+0 W
 0 0 M
--4 1 D
-1 -1 D
--1 -1 D
+-3 1 D
+0 -2 D
 P clip fs P S 
 U
 0 W
 V 2473 3297 T -101.65 R
-N 0 0 M 6 0 D S
+N 0 0 M 5 0 D S
 U
-V 2471 3289 T -101.65 R
+V 2472 3290 T -101.65 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -3788,15 +3785,14 @@ P clip fs P S
 U
 0 W
 V 2638 3297 T -108.003 R
-N 0 0 M 5 0 D S
+N 0 0 M 4 0 D S
 U
-V 2636 3291 T -108.003 R
+V 2636 3292 T -108.003 R
 PSL_vecheadpen
 0 W
 0 0 M
--3 1 D
-1 -1 D
--1 -1 D
+-2 1 D
+0 -2 D
 P clip fs P S 
 U
 0 W
@@ -3807,9 +3803,9 @@ V 2801 3293 T -113.494 R
 PSL_vecheadpen
 0 W
 0 0 M
--2 1 D
-1 -1 D
--1 -1 D
+-2 0 D
+1 0 D
+-1 0 D
 P clip fs P S 
 U
 0 W
@@ -3881,9 +3877,9 @@ P clip fs P S
 U
 0 W
 V 495 3133 T 119.656 R
-N 0 0 M 6 0 D S
+N 0 0 M 5 0 D S
 U
-V 491 3140 T 119.656 R
+V 491 3139 T 119.656 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -3894,9 +3890,9 @@ P clip fs P S
 U
 1 W
 V 659 3133 T 113.057 R
-N 0 0 M 8 0 D S
+N 0 0 M 7 0 D S
 U
-V 655 3143 T 113.057 R
+V 655 3142 T 113.057 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -3907,9 +3903,9 @@ P clip fs P S
 U
 1 W
 V 824 3133 T 105.112 R
-N 0 0 M 10 0 D S
+N 0 0 M 9 0 D S
 U
-V 821 3146 T 105.112 R
+V 821 3145 T 105.112 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -3920,35 +3916,35 @@ P clip fs P S
 U
 1 W
 V 989 3133 T 95.2935 R
-N 0 0 M 11 0 D S
+N 0 0 M 10 0 D S
 U
-V 988 3148 T 95.2935 R
+V 988 3147 T 95.2935 R
 PSL_vecheadpen
 1 W
 0 0 M
 -6 2 D
-1 -2 D
--1 -2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 1154 3133 T 82.6295 R
-N 0 0 M 11 0 D S
+N 0 0 M 10 0 D S
 U
-V 1156 3148 T 82.6295 R
+V 1156 3147 T 82.6295 R
 PSL_vecheadpen
 1 W
 0 0 M
 -6 2 D
-1 -2 D
--1 -2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 1319 3133 T 65.1031 R
-N 0 0 M 10 0 D S
+N 0 0 M 9 0 D S
 U
-V 1325 3145 T 65.1031 R
+V 1324 3144 T 65.1031 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -3959,9 +3955,9 @@ P clip fs P S
 U
 1 W
 V 1484 3133 T 38.623 R
-N 0 0 M 8 0 D S
+N 0 0 M 7 0 D S
 U
-V 1493 3140 T 38.623 R
+V 1492 3139 T 38.623 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -3971,9 +3967,9 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 1649 3133 T N 0 0 M 7 0 D S
+V 1649 3133 T N 0 0 M 6 0 D S
 U
-V 1659 3133 T PSL_vecheadpen
+V 1658 3133 T PSL_vecheadpen
 1 W
 0 0 M
 -4 1 D
@@ -3983,7 +3979,7 @@ P clip fs P S
 U
 1 W
 V 1814 3133 T -38.623 R
-N 0 0 M 8 0 D S
+N 0 0 M 7 0 D S
 U
 V 1822 3126 T -38.623 R
 PSL_vecheadpen
@@ -3996,9 +3992,9 @@ P clip fs P S
 U
 1 W
 V 1978 3133 T -65.1031 R
-N 0 0 M 10 0 D S
+N 0 0 M 9 0 D S
 U
-V 1984 3120 T -65.1031 R
+V 1984 3121 T -65.1031 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -4009,35 +4005,35 @@ P clip fs P S
 U
 1 W
 V 2143 3133 T -82.6295 R
-N 0 0 M 11 0 D S
+N 0 0 M 10 0 D S
 U
-V 2145 3117 T -82.6295 R
+V 2145 3119 T -82.6295 R
 PSL_vecheadpen
 1 W
 0 0 M
 -6 2 D
-1 -2 D
--1 -2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 2308 3133 T -95.2935 R
-N 0 0 M 11 0 D S
+N 0 0 M 10 0 D S
 U
-V 2307 3117 T -95.2935 R
+V 2307 3118 T -95.2935 R
 PSL_vecheadpen
 1 W
 0 0 M
 -6 2 D
-1 -2 D
--1 -2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 2473 3133 T -105.112 R
-N 0 0 M 10 0 D S
+N 0 0 M 9 0 D S
 U
-V 2470 3119 T -105.112 R
+V 2470 3120 T -105.112 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -4048,9 +4044,9 @@ P clip fs P S
 U
 1 W
 V 2638 3133 T -113.057 R
-N 0 0 M 8 0 D S
+N 0 0 M 7 0 D S
 U
-V 2634 3122 T -113.057 R
+V 2634 3123 T -113.057 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -4061,9 +4057,9 @@ P clip fs P S
 U
 0 W
 V 2803 3133 T -119.656 R
-N 0 0 M 6 0 D S
+N 0 0 M 5 0 D S
 U
-V 2799 3125 T -119.656 R
+V 2799 3126 T -119.656 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -4088,7 +4084,7 @@ U
 V 3133 3133 T -129.999 R
 N 0 0 M 2 0 D S
 U
-V 3130 3130 T -129.999 R
+V 3131 3130 T -129.999 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -4108,7 +4104,7 @@ P clip fs P S
 U
 0 W
 V 0 2968 T 141.362 R
-N 0 0 M 3 0 D S
+N 0 0 M 2 0 D S
 U
 V -3 2970 T 141.362 R
 PSL_vecheadpen
@@ -4133,7 +4129,7 @@ U
 V 330 2968 T 128.592 R
 N 0 0 M 7 0 D S
 U
-V 324 2976 T 128.592 R
+V 324 2975 T 128.592 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -4146,72 +4142,59 @@ U
 V 495 2968 T 122.758 R
 N 0 0 M 10 0 D S
 U
-V 487 2980 T 122.758 R
+V 487 2979 T 122.758 R
 PSL_vecheadpen
 1 W
 0 0 M
--6 2 D
-2 -2 D
--2 -2 D
+-5 1 D
+1 -1 D
+-1 -1 D
 P clip fs P S 
 U
 1 W
 V 659 2968 T 115.688 R
-N 0 0 M 14 0 D S
+N 0 0 M 13 0 D S
 U
-V 651 2986 T 115.688 R
+V 651 2984 T 115.688 R
 PSL_vecheadpen
 1 W
 0 0 M
--8 2 D
+-7 2 D
 2 -2 D
 -2 -2 D
 P clip fs P S 
 U
 1 W
 V 824 2968 T 106.971 R
-N 0 0 M 17 0 D S
+N 0 0 M 16 0 D S
 U
-V 817 2991 T 106.971 R
+V 818 2989 T 106.971 R
 PSL_vecheadpen
 1 W
 0 0 M
--10 3 D
-3 -3 D
--3 -3 D
+-9 2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 989 2968 T 95.9773 R
-N 0 0 M 19 0 D S
+N 0 0 M 18 0 D S
 U
-V 986 2994 T 95.9773 R
+V 987 2993 T 95.9773 R
 PSL_vecheadpen
 1 W
 0 0 M
--11 3 D
+-10 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 1 W
 V 1154 2968 T 81.6834 R
-N 0 0 M 19 0 D S
+N 0 0 M 18 0 D S
 U
-V 1158 2994 T 81.6834 R
-PSL_vecheadpen
-1 W
-0 0 M
--11 3 D
-3 -3 D
--3 -3 D
-P clip fs P S 
-U
-1 W
-V 1319 2968 T 62.3236 R
-N 0 0 M 17 0 D S
-U
-V 1330 2989 T 62.3236 R
+V 1158 2992 T 81.6834 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -4221,10 +4204,23 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 1484 2968 T 35.2598 R
-N 0 0 M 15 0 D S
+V 1319 2968 T 62.3236 R
+N 0 0 M 16 0 D S
 U
-V 1501 2980 T 35.2598 R
+V 1330 2988 T 62.3236 R
+PSL_vecheadpen
+1 W
+0 0 M
+-9 2 D
+2 -2 D
+-2 -2 D
+P clip fs P S 
+U
+1 W
+V 1484 2968 T 35.2598 R
+N 0 0 M 14 0 D S
+U
+V 1500 2979 T 35.2598 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -4234,21 +4230,21 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 1649 2968 T N 0 0 M 14 0 D S
+V 1649 2968 T N 0 0 M 13 0 D S
 U
-V 1668 2968 T PSL_vecheadpen
+V 1667 2968 T PSL_vecheadpen
 1 W
 0 0 M
--8 2 D
+-7 2 D
 2 -2 D
 -2 -2 D
 P clip fs P S 
 U
 1 W
 V 1814 2968 T -35.2598 R
-N 0 0 M 15 0 D S
+N 0 0 M 14 0 D S
 U
-V 1831 2956 T -35.2598 R
+V 1830 2956 T -35.2598 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -4259,48 +4255,35 @@ P clip fs P S
 U
 1 W
 V 1978 2968 T -62.3236 R
-N 0 0 M 17 0 D S
+N 0 0 M 16 0 D S
 U
-V 1990 2946 T -62.3236 R
+V 1989 2948 T -62.3236 R
 PSL_vecheadpen
 1 W
 0 0 M
--10 3 D
-3 -3 D
--3 -3 D
+-9 2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 2143 2968 T -81.6834 R
-N 0 0 M 19 0 D S
+N 0 0 M 18 0 D S
 U
-V 2147 2941 T -81.6834 R
+V 2147 2943 T -81.6834 R
 PSL_vecheadpen
 1 W
 0 0 M
--11 3 D
+-10 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 1 W
 V 2308 2968 T -95.9773 R
-N 0 0 M 19 0 D S
+N 0 0 M 18 0 D S
 U
-V 2305 2941 T -95.9773 R
-PSL_vecheadpen
-1 W
-0 0 M
--11 3 D
-3 -3 D
--3 -3 D
-P clip fs P S 
-U
-1 W
-V 2473 2968 T -106.971 R
-N 0 0 M 17 0 D S
-U
-V 2466 2944 T -106.971 R
+V 2306 2943 T -95.9773 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -4310,14 +4293,27 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 2638 2968 T -115.688 R
-N 0 0 M 14 0 D S
+V 2473 2968 T -106.971 R
+N 0 0 M 16 0 D S
 U
-V 2629 2950 T -115.688 R
+V 2467 2946 T -106.971 R
 PSL_vecheadpen
 1 W
 0 0 M
--8 2 D
+-9 2 D
+2 -2 D
+-2 -2 D
+P clip fs P S 
+U
+1 W
+V 2638 2968 T -115.688 R
+N 0 0 M 13 0 D S
+U
+V 2630 2951 T -115.688 R
+PSL_vecheadpen
+1 W
+0 0 M
+-7 2 D
 2 -2 D
 -2 -2 D
 P clip fs P S 
@@ -4326,20 +4322,20 @@ U
 V 2803 2968 T -122.758 R
 N 0 0 M 10 0 D S
 U
-V 2795 2955 T -122.758 R
+V 2795 2956 T -122.758 R
 PSL_vecheadpen
 1 W
 0 0 M
--6 2 D
-2 -2 D
--2 -2 D
+-5 1 D
+1 -1 D
+-1 -1 D
 P clip fs P S 
 U
 1 W
 V 2968 2968 T -128.592 R
 N 0 0 M 7 0 D S
 U
-V 2961 2960 T -128.592 R
+V 2962 2960 T -128.592 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -4352,7 +4348,7 @@ U
 V 3133 2968 T -133.477 R
 N 0 0 M 4 0 D S
 U
-V 3128 2963 T -133.477 R
+V 3129 2964 T -133.477 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -4362,9 +4358,9 @@ P clip fs P S
 U
 0 W
 V 3297 2968 T -141.362 R
-N 0 0 M 3 0 D S
+N 0 0 M 2 0 D S
 U
-V 3295 2965 T -141.362 R
+V 3295 2966 T -141.362 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -4373,22 +4369,21 @@ P clip fs P S
 U
 0 W
 V 0 2803 T 145.136 R
-N 0 0 M 5 0 D S
+N 0 0 M 4 0 D S
 U
-V -5 2807 T 145.136 R
+V -5 2806 T 145.136 R
 PSL_vecheadpen
 0 W
 0 0 M
--3 1 D
-1 -1 D
--1 -1 D
+-2 1 D
+0 -2 D
 P clip fs P S 
 U
 1 W
 V 165 2803 T 137.413 R
 N 0 0 M 7 0 D S
 U
-V 157 2810 T 137.413 R
+V 158 2809 T 137.413 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -4399,190 +4394,112 @@ P clip fs P S
 U
 1 W
 V 330 2803 T 132.481 R
-N 0 0 M 12 0 D S
+N 0 0 M 11 0 D S
 U
-V 318 2815 T 132.481 R
+V 319 2814 T 132.481 R
 PSL_vecheadpen
 1 W
 0 0 M
--7 2 D
-2 -2 D
--2 -2 D
+-6 2 D
+1 -2 D
+-1 -2 D
 P clip fs P S 
 U
 1 W
 V 495 2803 T 126.437 R
-N 0 0 M 17 0 D S
+N 0 0 M 16 0 D S
 U
-V 480 2823 T 126.437 R
+V 481 2821 T 126.437 R
 PSL_vecheadpen
 1 W
 0 0 M
--10 3 D
-3 -3 D
--3 -3 D
+-9 2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 2 W
 V 659 2803 T 118.895 R
-N 0 0 M 23 0 D S
+N 0 0 M 21 0 D S
 U
-V 644 2831 T 118.895 R
+V 645 2829 T 118.895 R
 PSL_vecheadpen
 2 W
 0 0 M
--13 3 D
+-12 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 2 W
 V 824 2803 T 109.298 R
-N 0 0 M 28 0 D S
+N 0 0 M 26 0 D S
 U
-V 811 2840 T 109.298 R
+V 812 2837 T 109.298 R
 PSL_vecheadpen
 2 W
 0 0 M
--15 4 D
+-14 4 D
 3 -4 D
 -3 -4 D
 P clip fs P S 
 U
 2 W
 V 989 2803 T 96.8506 R
-N 0 0 M 30 0 D S
+N 0 0 M 28 0 D S
 U
-V 984 2845 T 96.8506 R
+V 985 2842 T 96.8506 R
 PSL_vecheadpen
 2 W
 0 0 M
--17 5 D
-4 -5 D
--4 -5 D
+-16 4 D
+4 -4 D
+-4 -4 D
 P clip fs P S 
 U
 2 W
 V 1154 2803 T 80.4785 R
-N 0 0 M 30 0 D S
+N 0 0 M 28 0 D S
 U
-V 1161 2845 T 80.4785 R
+V 1161 2842 T 80.4785 R
 PSL_vecheadpen
 2 W
 0 0 M
--17 4 D
+-16 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
 2 W
 V 1319 2803 T 58.9604 R
-N 0 0 M 28 0 D S
+N 0 0 M 26 0 D S
 U
-V 1340 2837 T 58.9604 R
+V 1338 2835 T 58.9604 R
 PSL_vecheadpen
 2 W
 0 0 M
--16 4 D
+-15 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
 2 W
 V 1484 2803 T 31.6397 R
-N 0 0 M 26 0 D S
+N 0 0 M 24 0 D S
 U
-V 1515 2822 T 31.6397 R
+V 1513 2821 T 31.6397 R
 PSL_vecheadpen
 2 W
 0 0 M
--14 4 D
+-13 4 D
 3 -4 D
 -3 -4 D
 P clip fs P S 
 U
 2 W
-V 1649 2803 T N 0 0 M 25 0 D S
+V 1649 2803 T N 0 0 M 23 0 D S
 U
-V 1684 2803 T PSL_vecheadpen
-2 W
-0 0 M
--14 4 D
-4 -4 D
--4 -4 D
-P clip fs P S 
-U
-2 W
-V 1814 2803 T -31.6397 R
-N 0 0 M 26 0 D S
-U
-V 1845 2784 T -31.6397 R
-PSL_vecheadpen
-2 W
-0 0 M
--14 4 D
-3 -4 D
--3 -4 D
-P clip fs P S 
-U
-2 W
-V 1978 2803 T -58.9604 R
-N 0 0 M 28 0 D S
-U
-V 1999 2769 T -58.9604 R
-PSL_vecheadpen
-2 W
-0 0 M
--16 4 D
-4 -4 D
--4 -4 D
-P clip fs P S 
-U
-2 W
-V 2143 2803 T -80.4785 R
-N 0 0 M 30 0 D S
-U
-V 2150 2761 T -80.4785 R
-PSL_vecheadpen
-2 W
-0 0 M
--17 4 D
-4 -4 D
--4 -4 D
-P clip fs P S 
-U
-2 W
-V 2308 2803 T -96.8506 R
-N 0 0 M 30 0 D S
-U
-V 2303 2760 T -96.8506 R
-PSL_vecheadpen
-2 W
-0 0 M
--17 5 D
-4 -5 D
--4 -5 D
-P clip fs P S 
-U
-2 W
-V 2473 2803 T -109.298 R
-N 0 0 M 28 0 D S
-U
-V 2460 2766 T -109.298 R
-PSL_vecheadpen
-2 W
-0 0 M
--15 4 D
-3 -4 D
--3 -4 D
-P clip fs P S 
-U
-2 W
-V 2638 2803 T -118.895 R
-N 0 0 M 23 0 D S
-U
-V 2622 2774 T -118.895 R
-PSL_vecheadpen
+V 1682 2803 T PSL_vecheadpen
 2 W
 0 0 M
 -13 3 D
@@ -4590,30 +4507,108 @@ PSL_vecheadpen
 -3 -3 D
 P clip fs P S 
 U
-1 W
-V 2803 2803 T -126.437 R
-N 0 0 M 17 0 D S
+2 W
+V 1814 2803 T -31.6397 R
+N 0 0 M 24 0 D S
 U
-V 2788 2783 T -126.437 R
+V 1843 2785 T -31.6397 R
 PSL_vecheadpen
-1 W
+2 W
 0 0 M
--10 3 D
+-13 4 D
+3 -4 D
+-3 -4 D
+P clip fs P S 
+U
+2 W
+V 1978 2803 T -58.9604 R
+N 0 0 M 26 0 D S
+U
+V 1998 2771 T -58.9604 R
+PSL_vecheadpen
+2 W
+0 0 M
+-15 4 D
+4 -4 D
+-4 -4 D
+P clip fs P S 
+U
+2 W
+V 2143 2803 T -80.4785 R
+N 0 0 M 28 0 D S
+U
+V 2150 2764 T -80.4785 R
+PSL_vecheadpen
+2 W
+0 0 M
+-16 4 D
+4 -4 D
+-4 -4 D
+P clip fs P S 
+U
+2 W
+V 2308 2803 T -96.8506 R
+N 0 0 M 28 0 D S
+U
+V 2304 2763 T -96.8506 R
+PSL_vecheadpen
+2 W
+0 0 M
+-16 4 D
+4 -4 D
+-4 -4 D
+P clip fs P S 
+U
+2 W
+V 2473 2803 T -109.298 R
+N 0 0 M 26 0 D S
+U
+V 2461 2768 T -109.298 R
+PSL_vecheadpen
+2 W
+0 0 M
+-14 4 D
+3 -4 D
+-3 -4 D
+P clip fs P S 
+U
+2 W
+V 2638 2803 T -118.895 R
+N 0 0 M 21 0 D S
+U
+V 2623 2776 T -118.895 R
+PSL_vecheadpen
+2 W
+0 0 M
+-12 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 1 W
-V 2968 2803 T -132.481 R
-N 0 0 M 12 0 D S
+V 2803 2803 T -126.437 R
+N 0 0 M 16 0 D S
 U
-V 2956 2790 T -132.481 R
+V 2789 2784 T -126.437 R
 PSL_vecheadpen
 1 W
 0 0 M
--7 2 D
+-9 2 D
 2 -2 D
 -2 -2 D
+P clip fs P S 
+U
+1 W
+V 2968 2803 T -132.481 R
+N 0 0 M 11 0 D S
+U
+V 2957 2791 T -132.481 R
+PSL_vecheadpen
+1 W
+0 0 M
+-6 2 D
+1 -2 D
+-1 -2 D
 P clip fs P S 
 U
 1 W
@@ -4631,22 +4626,21 @@ P clip fs P S
 U
 0 W
 V 3297 2803 T -145.136 R
-N 0 0 M 5 0 D S
+N 0 0 M 4 0 D S
 U
-V 3292 2799 T -145.136 R
+V 3293 2799 T -145.136 R
 PSL_vecheadpen
 0 W
 0 0 M
--3 1 D
-1 -1 D
--1 -1 D
+-2 1 D
+0 -2 D
 P clip fs P S 
 U
 1 W
 V 0 2638 T 149.244 R
 N 0 0 M 7 0 D S
 U
-V -9 2643 T 149.244 R
+V -8 2643 T 149.244 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -4657,9 +4651,9 @@ P clip fs P S
 U
 1 W
 V 165 2638 T 141.864 R
-N 0 0 M 12 0 D S
+N 0 0 M 11 0 D S
 U
-V 152 2648 T 141.864 R
+V 153 2647 T 141.864 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -4670,176 +4664,163 @@ P clip fs P S
 U
 1 W
 V 330 2638 T 136.991 R
-N 0 0 M 18 0 D S
+N 0 0 M 17 0 D S
 U
-V 311 2656 T 136.991 R
+V 312 2655 T 136.991 R
 PSL_vecheadpen
 1 W
 0 0 M
 -10 3 D
-2 -3 D
--2 -3 D
+3 -3 D
+-3 -3 D
 P clip fs P S 
 U
 2 W
 V 495 2638 T 130.836 R
-N 0 0 M 27 0 D S
+N 0 0 M 25 0 D S
 U
-V 470 2666 T 130.836 R
+V 472 2664 T 130.836 R
 PSL_vecheadpen
 2 W
 0 0 M
--15 4 D
+-14 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
 3 W
 V 659 2638 T 122.868 R
-N 0 0 M 34 0 D S
+N 0 0 M 32 0 D S
 U
-V 633 2679 T 122.868 R
+V 635 2676 T 122.868 R
 PSL_vecheadpen
 3 W
 0 0 M
--19 5 D
+-18 5 D
 5 -5 D
 -5 -5 D
 P clip fs P S 
 U
 3 W
 V 824 2638 T 112.29 R
-N 0 0 M 40 0 D S
+N 0 0 M 38 0 D S
 U
-V 803 2691 T 112.29 R
+V 804 2687 T 112.29 R
 PSL_vecheadpen
 3 W
 0 0 M
--23 6 D
-6 -6 D
--6 -6 D
+-21 6 D
+5 -6 D
+-5 -6 D
 P clip fs P S 
 U
 3 W
 V 989 2638 T 98.0059 R
-N 0 0 M 43 0 D S
+N 0 0 M 40 0 D S
 U
-V 981 2699 T 98.0059 R
+V 981 2695 T 98.0059 R
 PSL_vecheadpen
 3 W
 0 0 M
--24 6 D
+-23 6 D
 6 -6 D
 -6 -6 D
 P clip fs P S 
 U
 3 W
 V 1154 2638 T 78.8908 R
-N 0 0 M 43 0 D S
+N 0 0 M 40 0 D S
 U
-V 1166 2698 T 78.8908 R
+V 1165 2694 T 78.8908 R
 PSL_vecheadpen
 3 W
 0 0 M
--24 6 D
+-23 6 D
 6 -6 D
 -6 -6 D
 P clip fs P S 
 U
 3 W
 V 1319 2638 T 54.8342 R
-N 0 0 M 42 0 D S
+N 0 0 M 39 0 D S
 U
-V 1354 2687 T 54.8342 R
+V 1351 2684 T 54.8342 R
 PSL_vecheadpen
 3 W
 0 0 M
--24 6 D
-6 -6 D
--6 -6 D
+-22 6 D
+5 -6 D
+-5 -6 D
 P clip fs P S 
 U
 3 W
 V 1484 2638 T 27.7586 R
-N 0 0 M 42 0 D S
+N 0 0 M 39 0 D S
 U
-V 1537 2666 T 27.7586 R
+V 1533 2664 T 27.7586 R
 PSL_vecheadpen
 3 W
 0 0 M
--23 6 D
-5 -6 D
--5 -6 D
-P clip fs P S 
-U
-3 W
-V 1649 2638 T N 0 0 M 42 0 D S
-U
-V 1708 2638 T PSL_vecheadpen
-3 W
-0 0 M
--23 6 D
-5 -6 D
--5 -6 D
-P clip fs P S 
-U
-3 W
-V 1814 2638 T -27.7586 R
-N 0 0 M 42 0 D S
-U
-V 1866 2610 T -27.7586 R
-PSL_vecheadpen
-3 W
-0 0 M
--23 6 D
-5 -6 D
--5 -6 D
-P clip fs P S 
-U
-3 W
-V 1978 2638 T -54.8342 R
-N 0 0 M 42 0 D S
-U
-V 2013 2589 T -54.8342 R
-PSL_vecheadpen
-3 W
-0 0 M
--24 6 D
+-22 6 D
 6 -6 D
 -6 -6 D
 P clip fs P S 
 U
 3 W
-V 2143 2638 T -78.8908 R
-N 0 0 M 43 0 D S
+V 1649 2638 T N 0 0 M 39 0 D S
 U
-V 2155 2578 T -78.8908 R
+V 1704 2638 T PSL_vecheadpen
+3 W
+0 0 M
+-22 6 D
+6 -6 D
+-6 -6 D
+P clip fs P S 
+U
+3 W
+V 1814 2638 T -27.7586 R
+N 0 0 M 39 0 D S
+U
+V 1863 2612 T -27.7586 R
 PSL_vecheadpen
 3 W
 0 0 M
--24 6 D
+-22 6 D
+6 -6 D
+-6 -6 D
+P clip fs P S 
+U
+3 W
+V 1978 2638 T -54.8342 R
+N 0 0 M 39 0 D S
+U
+V 2011 2592 T -54.8342 R
+PSL_vecheadpen
+3 W
+0 0 M
+-22 6 D
+5 -6 D
+-5 -6 D
+P clip fs P S 
+U
+3 W
+V 2143 2638 T -78.8908 R
+N 0 0 M 40 0 D S
+U
+V 2154 2582 T -78.8908 R
+PSL_vecheadpen
+3 W
+0 0 M
+-23 6 D
 6 -6 D
 -6 -6 D
 P clip fs P S 
 U
 3 W
 V 2308 2638 T -98.0059 R
-N 0 0 M 43 0 D S
-U
-V 2300 2577 T -98.0059 R
-PSL_vecheadpen
-3 W
-0 0 M
--24 6 D
-6 -6 D
--6 -6 D
-P clip fs P S 
-U
-3 W
-V 2473 2638 T -112.29 R
 N 0 0 M 40 0 D S
 U
-V 2451 2585 T -112.29 R
+V 2300 2581 T -98.0059 R
 PSL_vecheadpen
 3 W
 0 0 M
@@ -4849,49 +4830,62 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V 2638 2638 T -122.868 R
-N 0 0 M 34 0 D S
+V 2473 2638 T -112.29 R
+N 0 0 M 38 0 D S
 U
-V 2611 2597 T -122.868 R
+V 2453 2589 T -112.29 R
 PSL_vecheadpen
 3 W
 0 0 M
--19 5 D
+-21 6 D
+5 -6 D
+-5 -6 D
+P clip fs P S 
+U
+3 W
+V 2638 2638 T -122.868 R
+N 0 0 M 32 0 D S
+U
+V 2613 2600 T -122.868 R
+PSL_vecheadpen
+3 W
+0 0 M
+-18 5 D
 5 -5 D
 -5 -5 D
 P clip fs P S 
 U
 2 W
 V 2803 2638 T -130.836 R
-N 0 0 M 27 0 D S
+N 0 0 M 25 0 D S
 U
-V 2778 2610 T -130.836 R
+V 2780 2612 T -130.836 R
 PSL_vecheadpen
 2 W
 0 0 M
--15 4 D
+-14 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
 1 W
 V 2968 2638 T -136.991 R
-N 0 0 M 18 0 D S
+N 0 0 M 17 0 D S
 U
-V 2949 2620 T -136.991 R
+V 2950 2621 T -136.991 R
 PSL_vecheadpen
 1 W
 0 0 M
 -10 3 D
-2 -3 D
--2 -3 D
+3 -3 D
+-3 -3 D
 P clip fs P S 
 U
 1 W
 V 3133 2638 T -141.864 R
-N 0 0 M 12 0 D S
+N 0 0 M 11 0 D S
 U
-V 3120 2628 T -141.864 R
+V 3121 2629 T -141.864 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -4915,202 +4909,163 @@ P clip fs P S
 U
 1 W
 V 0 2473 T 153.689 R
-N 0 0 M 11 0 D S
+N 0 0 M 10 0 D S
 U
-V -14 2480 T 153.689 R
+V -13 2479 T 153.689 R
 PSL_vecheadpen
 1 W
 0 0 M
 -6 2 D
-1 -2 D
--1 -2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 165 2473 T 146.882 R
-N 0 0 M 17 0 D S
+N 0 0 M 16 0 D S
 U
-V 145 2486 T 146.882 R
+V 146 2485 T 146.882 R
 PSL_vecheadpen
 1 W
 0 0 M
--9 3 D
-2 -3 D
--2 -3 D
+-9 2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 2 W
 V 330 2473 T 142.221 R
-N 0 0 M 27 0 D S
+N 0 0 M 25 0 D S
 U
-V 300 2496 T 142.221 R
+V 302 2495 T 142.221 R
 PSL_vecheadpen
 2 W
 0 0 M
--15 4 D
+-14 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
 3 W
 V 495 2473 T 136.128 R
-N 0 0 M 37 0 D S
+N 0 0 M 35 0 D S
 U
-V 456 2510 T 136.128 R
+V 459 2507 T 136.128 R
 PSL_vecheadpen
 3 W
 0 0 M
--21 6 D
-5 -6 D
--5 -6 D
+-19 5 D
+4 -5 D
+-4 -5 D
 P clip fs P S 
 U
-4 W
+3 W
 V 659 2473 T 127.87 R
-N 0 0 M 47 0 D S
+N 0 0 M 44 0 D S
 U
-V 618 2526 T 127.87 R
+V 621 2522 T 127.87 R
 PSL_vecheadpen
-4 W
+3 W
 0 0 M
--26 7 D
-6 -7 D
--6 -7 D
+-25 7 D
+7 -7 D
+-7 -7 D
 P clip fs P S 
 U
 4 W
 V 824 2473 T 116.259 R
-N 0 0 M 54 0 D S
+N 0 0 M 50 0 D S
 U
-V 791 2542 T 116.259 R
+V 793 2537 T 116.259 R
 PSL_vecheadpen
 4 W
 0 0 M
--30 8 D
-7 -8 D
--7 -8 D
+-28 7 D
+7 -7 D
+-7 -7 D
 P clip fs P S 
 U
 4 W
 V 989 2473 T 99.6074 R
-N 0 0 M 56 0 D S
+N 0 0 M 52 0 D S
 U
-V 976 2552 T 99.6074 R
+V 977 2546 T 99.6074 R
 PSL_vecheadpen
 4 W
 0 0 M
--31 8 D
+-29 8 D
 7 -8 D
 -7 -8 D
 P clip fs P S 
 U
 4 W
 V 1154 2473 T 76.7038 R
-N 0 0 M 56 0 D S
+N 0 0 M 53 0 D S
 U
-V 1173 2551 T 76.7038 R
+V 1171 2546 T 76.7038 R
 PSL_vecheadpen
 4 W
 0 0 M
--32 8 D
-8 -8 D
--8 -8 D
-P clip fs P S 
-U
-5 W
-V 1319 2473 T 49.705 R
-N 0 0 M 59 0 D S
-U
-V 1373 2537 T 49.705 R
-PSL_vecheadpen
-5 W
-0 0 M
--33 9 D
-8 -9 D
--8 -9 D
-P clip fs P S 
-U
-5 W
-V 1484 2473 T 23.6206 R
-N 0 0 M 63 0 D S
-U
-V 1566 2509 T 23.6206 R
-PSL_vecheadpen
-5 W
-0 0 M
--35 9 D
-9 -9 D
--9 -9 D
-P clip fs P S 
-U
-5 W
-V 1649 2473 T N 0 0 M 65 0 D S
-U
-V 1741 2473 T PSL_vecheadpen
-5 W
-0 0 M
--36 10 D
-9 -10 D
--9 -10 D
-P clip fs P S 
-U
-5 W
-V 1814 2473 T -23.6206 R
-N 0 0 M 63 0 D S
-U
-V 1895 2437 T -23.6206 R
-PSL_vecheadpen
-5 W
-0 0 M
--35 9 D
-9 -9 D
--9 -9 D
-P clip fs P S 
-U
-5 W
-V 1978 2473 T -49.705 R
-N 0 0 M 59 0 D S
-U
-V 2032 2410 T -49.705 R
-PSL_vecheadpen
-5 W
-0 0 M
--33 9 D
-8 -9 D
--8 -9 D
-P clip fs P S 
-U
-4 W
-V 2143 2473 T -76.7038 R
-N 0 0 M 56 0 D S
-U
-V 2162 2395 T -76.7038 R
-PSL_vecheadpen
-4 W
-0 0 M
--32 8 D
-8 -8 D
--8 -8 D
-P clip fs P S 
-U
-4 W
-V 2308 2473 T -99.6074 R
-N 0 0 M 56 0 D S
-U
-V 2295 2395 T -99.6074 R
-PSL_vecheadpen
-4 W
-0 0 M
--31 8 D
+-29 8 D
 7 -8 D
 -7 -8 D
 P clip fs P S 
 U
 4 W
-V 2473 2473 T -116.259 R
-N 0 0 M 54 0 D S
+V 1319 2473 T 49.705 R
+N 0 0 M 55 0 D S
 U
-V 2439 2405 T -116.259 R
+V 1369 2532 T 49.705 R
+PSL_vecheadpen
+4 W
+0 0 M
+-30 8 D
+7 -8 D
+-7 -8 D
+P clip fs P S 
+U
+5 W
+V 1484 2473 T 23.6206 R
+N 0 0 M 59 0 D S
+U
+V 1560 2506 T 23.6206 R
+PSL_vecheadpen
+5 W
+0 0 M
+-33 9 D
+8 -9 D
+-8 -9 D
+P clip fs P S 
+U
+5 W
+V 1649 2473 T N 0 0 M 61 0 D S
+U
+V 1735 2473 T PSL_vecheadpen
+5 W
+0 0 M
+-34 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+5 W
+V 1814 2473 T -23.6206 R
+N 0 0 M 59 0 D S
+U
+V 1890 2440 T -23.6206 R
+PSL_vecheadpen
+5 W
+0 0 M
+-33 9 D
+8 -9 D
+-8 -9 D
+P clip fs P S 
+U
+4 W
+V 1978 2473 T -49.705 R
+N 0 0 M 55 0 D S
+U
+V 2029 2414 T -49.705 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5120,75 +5075,114 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V 2638 2473 T -127.87 R
-N 0 0 M 47 0 D S
+V 2143 2473 T -76.7038 R
+N 0 0 M 53 0 D S
 U
-V 2597 2420 T -127.87 R
+V 2160 2401 T -76.7038 R
 PSL_vecheadpen
 4 W
 0 0 M
--26 7 D
-6 -7 D
--6 -7 D
+-29 8 D
+7 -8 D
+-7 -8 D
+P clip fs P S 
+U
+4 W
+V 2308 2473 T -99.6074 R
+N 0 0 M 52 0 D S
+U
+V 2296 2400 T -99.6074 R
+PSL_vecheadpen
+4 W
+0 0 M
+-29 8 D
+7 -8 D
+-7 -8 D
+P clip fs P S 
+U
+4 W
+V 2473 2473 T -116.259 R
+N 0 0 M 50 0 D S
+U
+V 2442 2409 T -116.259 R
+PSL_vecheadpen
+4 W
+0 0 M
+-28 7 D
+7 -7 D
+-7 -7 D
+P clip fs P S 
+U
+3 W
+V 2638 2473 T -127.87 R
+N 0 0 M 44 0 D S
+U
+V 2600 2424 T -127.87 R
+PSL_vecheadpen
+3 W
+0 0 M
+-25 7 D
+7 -7 D
+-7 -7 D
 P clip fs P S 
 U
 3 W
 V 2803 2473 T -136.128 R
-N 0 0 M 37 0 D S
+N 0 0 M 35 0 D S
 U
-V 2765 2436 T -136.128 R
+V 2767 2439 T -136.128 R
 PSL_vecheadpen
 3 W
 0 0 M
--21 6 D
-5 -6 D
--5 -6 D
+-19 5 D
+4 -5 D
+-4 -5 D
 P clip fs P S 
 U
 2 W
 V 2968 2473 T -142.221 R
-N 0 0 M 27 0 D S
+N 0 0 M 25 0 D S
 U
-V 2938 2450 T -142.221 R
+V 2940 2452 T -142.221 R
 PSL_vecheadpen
 2 W
 0 0 M
--15 4 D
+-14 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
 1 W
 V 3133 2473 T -146.882 R
-N 0 0 M 17 0 D S
+N 0 0 M 16 0 D S
 U
-V 3112 2460 T -146.882 R
+V 3114 2461 T -146.882 R
 PSL_vecheadpen
 1 W
 0 0 M
--9 3 D
-2 -3 D
--2 -3 D
+-9 2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 3297 2473 T -153.689 R
-N 0 0 M 11 0 D S
+N 0 0 M 10 0 D S
 U
-V 3284 2466 T -153.689 R
+V 3285 2467 T -153.689 R
 PSL_vecheadpen
 1 W
 0 0 M
 -6 2 D
-1 -2 D
--1 -2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 0 2308 T 158.465 R
-N 0 0 M 15 0 D S
+N 0 0 M 14 0 D S
 U
-V -20 2316 T 158.465 R
+V -18 2315 T 158.465 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -5199,254 +5193,254 @@ P clip fs P S
 U
 2 W
 V 165 2308 T 152.497 R
-N 0 0 M 23 0 D S
+N 0 0 M 21 0 D S
 U
-V 136 2323 T 152.497 R
+V 138 2322 T 152.497 R
 PSL_vecheadpen
 2 W
 0 0 M
--13 3 D
+-12 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 3 W
 V 330 2308 T 148.26 R
-N 0 0 M 35 0 D S
+N 0 0 M 33 0 D S
 U
-V 287 2335 T 148.26 R
+V 290 2333 T 148.26 R
 PSL_vecheadpen
 3 W
 0 0 M
--20 5 D
-5 -5 D
--5 -5 D
+-18 5 D
+4 -5 D
+-4 -5 D
 P clip fs P S 
 U
 4 W
 V 495 2308 T 142.503 R
-N 0 0 M 49 0 D S
+N 0 0 M 45 0 D S
 U
-V 440 2350 T 142.503 R
+V 444 2347 T 142.503 R
 PSL_vecheadpen
 4 W
 0 0 M
--27 7 D
-7 -7 D
--7 -7 D
+-25 7 D
+6 -7 D
+-6 -7 D
 P clip fs P S 
 U
-5 W
+4 W
 V 659 2308 T 134.256 R
-N 0 0 M 60 0 D S
+N 0 0 M 55 0 D S
 U
-V 600 2369 T 134.256 R
+V 605 2365 T 134.256 R
 PSL_vecheadpen
-5 W
+4 W
 0 0 M
--33 9 D
-8 -9 D
--8 -9 D
+-31 8 D
+8 -8 D
+-8 -8 D
 P clip fs P S 
 U
 5 W
 V 824 2308 T 121.723 R
-N 0 0 M 65 0 D S
+N 0 0 M 60 0 D S
 U
-V 776 2387 T 121.723 R
+V 779 2381 T 121.723 R
 PSL_vecheadpen
 5 W
 0 0 M
--36 10 D
-9 -10 D
--9 -10 D
+-34 9 D
+9 -9 D
+-9 -9 D
 P clip fs P S 
 U
 5 W
 V 989 2308 T 101.975 R
-N 0 0 M 65 0 D S
+N 0 0 M 60 0 D S
 U
-V 970 2398 T 101.975 R
+V 972 2392 T 101.975 R
 PSL_vecheadpen
 5 W
 0 0 M
--36 10 D
-9 -10 D
--9 -10 D
+-34 9 D
+9 -9 D
+-9 -9 D
 P clip fs P S 
 U
 5 W
 V 1154 2308 T 73.5055 R
-N 0 0 M 66 0 D S
+N 0 0 M 61 0 D S
 U
-V 1181 2397 T 73.5055 R
+V 1179 2391 T 73.5055 R
 PSL_vecheadpen
 5 W
 0 0 M
--37 10 D
-10 -10 D
--10 -10 D
-P clip fs P S 
-U
-6 W
-V 1319 2308 T 43.2662 R
-N 0 0 M 75 0 D S
-U
-V 1396 2381 T 43.2662 R
-PSL_vecheadpen
-6 W
-0 0 M
--42 11 D
-11 -11 D
--11 -11 D
-P clip fs P S 
-U
-7 W
-V 1484 2308 T 19.2398 R
-N 0 0 M 88 0 D S
-U
-V 1601 2349 T 19.2398 R
-PSL_vecheadpen
-7 W
-0 0 M
--49 13 D
-12 -13 D
--12 -13 D
-P clip fs P S 
-U
-7 W
-V 1649 2308 T N 0 0 M 93 0 D S
-U
-V 1781 2308 T PSL_vecheadpen
-7 W
-0 0 M
--52 14 D
-13 -14 D
--13 -14 D
-P clip fs P S 
-U
-7 W
-V 1814 2308 T -19.2398 R
-N 0 0 M 88 0 D S
-U
-V 1931 2267 T -19.2398 R
-PSL_vecheadpen
-7 W
-0 0 M
--49 13 D
-12 -13 D
--12 -13 D
-P clip fs P S 
-U
-6 W
-V 1978 2308 T -43.2662 R
-N 0 0 M 75 0 D S
-U
-V 2056 2236 T -43.2662 R
-PSL_vecheadpen
-6 W
-0 0 M
--42 11 D
-11 -11 D
--11 -11 D
-P clip fs P S 
-U
-5 W
-V 2143 2308 T -73.5055 R
-N 0 0 M 66 0 D S
-U
-V 2170 2219 T -73.5055 R
-PSL_vecheadpen
-5 W
-0 0 M
--37 10 D
-10 -10 D
--10 -10 D
-P clip fs P S 
-U
-5 W
-V 2308 2308 T -101.975 R
-N 0 0 M 65 0 D S
-U
-V 2289 2218 T -101.975 R
-PSL_vecheadpen
-5 W
-0 0 M
--36 10 D
-9 -10 D
--9 -10 D
-P clip fs P S 
-U
-5 W
-V 2473 2308 T -121.723 R
-N 0 0 M 65 0 D S
-U
-V 2425 2230 T -121.723 R
-PSL_vecheadpen
-5 W
-0 0 M
--36 10 D
-9 -10 D
--9 -10 D
-P clip fs P S 
-U
-5 W
-V 2638 2308 T -134.256 R
-N 0 0 M 60 0 D S
-U
-V 2579 2248 T -134.256 R
-PSL_vecheadpen
-5 W
-0 0 M
--33 9 D
+-34 9 D
 8 -9 D
 -8 -9 D
 P clip fs P S 
 U
-4 W
-V 2803 2308 T -142.503 R
-N 0 0 M 49 0 D S
+5 W
+V 1319 2308 T 43.2662 R
+N 0 0 M 69 0 D S
 U
-V 2748 2266 T -142.503 R
+V 1391 2376 T 43.2662 R
+PSL_vecheadpen
+5 W
+0 0 M
+-39 10 D
+10 -10 D
+-10 -10 D
+P clip fs P S 
+U
+6 W
+V 1484 2308 T 19.2398 R
+N 0 0 M 81 0 D S
+U
+V 1593 2346 T 19.2398 R
+PSL_vecheadpen
+6 W
+0 0 M
+-45 12 D
+11 -12 D
+-11 -12 D
+P clip fs P S 
+U
+7 W
+V 1649 2308 T N 0 0 M 87 0 D S
+U
+V 1772 2308 T PSL_vecheadpen
+7 W
+0 0 M
+-49 13 D
+13 -13 D
+-13 -13 D
+P clip fs P S 
+U
+6 W
+V 1814 2308 T -19.2398 R
+N 0 0 M 81 0 D S
+U
+V 1923 2270 T -19.2398 R
+PSL_vecheadpen
+6 W
+0 0 M
+-45 12 D
+11 -12 D
+-11 -12 D
+P clip fs P S 
+U
+5 W
+V 1978 2308 T -43.2662 R
+N 0 0 M 69 0 D S
+U
+V 2050 2241 T -43.2662 R
+PSL_vecheadpen
+5 W
+0 0 M
+-39 10 D
+10 -10 D
+-10 -10 D
+P clip fs P S 
+U
+5 W
+V 2143 2308 T -73.5055 R
+N 0 0 M 61 0 D S
+U
+V 2168 2225 T -73.5055 R
+PSL_vecheadpen
+5 W
+0 0 M
+-34 9 D
+8 -9 D
+-8 -9 D
+P clip fs P S 
+U
+5 W
+V 2308 2308 T -101.975 R
+N 0 0 M 60 0 D S
+U
+V 2291 2225 T -101.975 R
+PSL_vecheadpen
+5 W
+0 0 M
+-34 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+5 W
+V 2473 2308 T -121.723 R
+N 0 0 M 60 0 D S
+U
+V 2428 2235 T -121.723 R
+PSL_vecheadpen
+5 W
+0 0 M
+-34 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+4 W
+V 2638 2308 T -134.256 R
+N 0 0 M 55 0 D S
+U
+V 2583 2252 T -134.256 R
 PSL_vecheadpen
 4 W
 0 0 M
--27 7 D
-7 -7 D
--7 -7 D
+-31 8 D
+8 -8 D
+-8 -8 D
+P clip fs P S 
+U
+4 W
+V 2803 2308 T -142.503 R
+N 0 0 M 45 0 D S
+U
+V 2752 2269 T -142.503 R
+PSL_vecheadpen
+4 W
+0 0 M
+-25 7 D
+6 -7 D
+-6 -7 D
 P clip fs P S 
 U
 3 W
 V 2968 2308 T -148.26 R
-N 0 0 M 35 0 D S
+N 0 0 M 33 0 D S
 U
-V 2925 2282 T -148.26 R
+V 2928 2284 T -148.26 R
 PSL_vecheadpen
 3 W
 0 0 M
--20 5 D
-5 -5 D
--5 -5 D
+-18 5 D
+4 -5 D
+-4 -5 D
 P clip fs P S 
 U
 2 W
 V 3133 2308 T -152.497 R
-N 0 0 M 23 0 D S
+N 0 0 M 21 0 D S
 U
-V 3104 2293 T -152.497 R
+V 3106 2294 T -152.497 R
 PSL_vecheadpen
 2 W
 0 0 M
--13 3 D
+-12 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 1 W
 V 3297 2308 T -158.465 R
-N 0 0 M 15 0 D S
+N 0 0 M 14 0 D S
 U
-V 3278 2300 T -158.465 R
+V 3279 2301 T -158.465 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -5455,178 +5449,204 @@ PSL_vecheadpen
 -2 -2 D
 P clip fs P S 
 U
-2 W
+1 W
 V 0 2143 T 163.542 R
-N 0 0 M 19 0 D S
+N 0 0 M 18 0 D S
 U
-V -26 2151 T 163.542 R
+V -24 2151 T 163.542 R
 PSL_vecheadpen
-2 W
+1 W
 0 0 M
--11 3 D
+-10 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 2 W
 V 165 2143 T 158.707 R
-N 0 0 M 29 0 D S
+N 0 0 M 27 0 D S
 U
-V 127 2158 T 158.707 R
+V 129 2157 T 158.707 R
 PSL_vecheadpen
 2 W
 0 0 M
--16 4 D
+-15 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
 3 W
 V 330 2143 T 155.153 R
-N 0 0 M 44 0 D S
+N 0 0 M 41 0 D S
 U
-V 273 2169 T 155.153 R
+V 277 2168 T 155.153 R
 PSL_vecheadpen
 3 W
 0 0 M
--24 7 D
-6 -7 D
--6 -7 D
+-23 6 D
+6 -6 D
+-6 -6 D
 P clip fs P S 
 U
-5 W
+4 W
 V 495 2143 T 150.128 R
-N 0 0 M 59 0 D S
+N 0 0 M 55 0 D S
 U
-V 422 2185 T 150.128 R
+V 427 2182 T 150.128 R
 PSL_vecheadpen
-5 W
+4 W
 0 0 M
--33 9 D
-8 -9 D
--8 -9 D
+-31 8 D
+8 -8 D
+-8 -8 D
 P clip fs P S 
 U
 5 W
 V 659 2143 T 142.465 R
-N 0 0 M 69 0 D S
+N 0 0 M 65 0 D S
 U
-V 581 2203 T 142.465 R
+V 587 2199 T 142.465 R
 PSL_vecheadpen
 5 W
 0 0 M
--39 10 D
-10 -10 D
--10 -10 D
+-36 10 D
+9 -10 D
+-9 -10 D
 P clip fs P S 
 U
-6 W
+5 W
 V 824 2143 T 129.549 R
-N 0 0 M 71 0 D S
+N 0 0 M 66 0 D S
 U
-V 760 2221 T 129.549 R
+V 765 2216 T 129.549 R
 PSL_vecheadpen
-6 W
+5 W
 0 0 M
--40 11 D
-10 -11 D
--10 -11 D
+-37 10 D
+9 -10 D
+-9 -10 D
 P clip fs P S 
 U
 5 W
 V 989 2143 T 105.819 R
-N 0 0 M 65 0 D S
+N 0 0 M 61 0 D S
 U
-V 964 2232 T 105.819 R
+V 966 2226 T 105.819 R
 PSL_vecheadpen
 5 W
 0 0 M
--36 10 D
-9 -10 D
--9 -10 D
+-34 9 D
+9 -9 D
+-9 -9 D
 P clip fs P S 
 U
 5 W
 V 1154 2143 T 68.4188 R
-N 0 0 M 67 0 D S
+N 0 0 M 62 0 D S
 U
-V 1189 2232 T 68.4188 R
+V 1187 2226 T 68.4188 R
 PSL_vecheadpen
 5 W
 0 0 M
--37 10 D
-9 -10 D
--9 -10 D
+-35 9 D
+9 -9 D
+-9 -9 D
 P clip fs P S 
 U
-7 W
+6 W
 V 1319 2143 T 35.1691 R
-N 0 0 M 88 0 D S
+N 0 0 M 82 0 D S
 U
-V 1421 2215 T 35.1691 R
+V 1414 2210 T 35.1691 R
 PSL_vecheadpen
-7 W
+6 W
 0 0 M
--49 13 D
-12 -13 D
--12 -13 D
+-46 12 D
+12 -12 D
+-12 -12 D
 P clip fs P S 
 U
-9 W
+8 W
 V 1484 2143 T 14.6426 R
-N 0 0 M 113 0 D S
+N 0 0 M 105 0 D S
 U
-V 1639 2184 T 14.6426 R
+V 1628 2181 T 14.6426 R
 PSL_vecheadpen
+8 W
+0 0 M
+-59 16 D
+15 -16 D
+-15 -16 D
+P clip fs P S 
+U
+9 W
+V 1649 2143 T N 0 0 M 115 0 D S
+U
+V 1812 2143 T PSL_vecheadpen
 9 W
 0 0 M
--63 17 D
+-64 17 D
 16 -17 D
 -16 -17 D
 P clip fs P S 
 U
-10 W
-V 1649 2143 T N 0 0 M 124 0 D S
-U
-V 1824 2143 T PSL_vecheadpen
-10 W
-0 0 M
--69 19 D
-17 -19 D
--17 -19 D
-P clip fs P S 
-U
-9 W
+8 W
 V 1814 2143 T -14.6426 R
-N 0 0 M 113 0 D S
+N 0 0 M 105 0 D S
 U
-V 1969 2103 T -14.6426 R
+V 1958 2106 T -14.6426 R
 PSL_vecheadpen
-9 W
+8 W
 0 0 M
--63 17 D
-16 -17 D
--16 -17 D
+-59 16 D
+15 -16 D
+-15 -16 D
 P clip fs P S 
 U
-7 W
+6 W
 V 1978 2143 T -35.1691 R
-N 0 0 M 88 0 D S
+N 0 0 M 82 0 D S
 U
-V 2081 2071 T -35.1691 R
+V 2073 2076 T -35.1691 R
 PSL_vecheadpen
-7 W
+6 W
 0 0 M
--49 13 D
-12 -13 D
--12 -13 D
+-46 12 D
+12 -12 D
+-12 -12 D
 P clip fs P S 
 U
 5 W
 V 2143 2143 T -68.4188 R
-N 0 0 M 67 0 D S
+N 0 0 M 62 0 D S
 U
-V 2178 2055 T -68.4188 R
+V 2176 2061 T -68.4188 R
+PSL_vecheadpen
+5 W
+0 0 M
+-35 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+5 W
+V 2308 2143 T -105.819 R
+N 0 0 M 61 0 D S
+U
+V 2285 2061 T -105.819 R
+PSL_vecheadpen
+5 W
+0 0 M
+-34 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+5 W
+V 2473 2143 T -129.549 R
+N 0 0 M 66 0 D S
+U
+V 2413 2071 T -129.549 R
 PSL_vecheadpen
 5 W
 0 0 M
@@ -5636,10 +5656,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 5 W
-V 2308 2143 T -105.819 R
+V 2638 2143 T -142.465 R
 N 0 0 M 65 0 D S
 U
-V 2283 2054 T -105.819 R
+V 2565 2088 T -142.465 R
 PSL_vecheadpen
 5 W
 0 0 M
@@ -5648,128 +5668,256 @@ PSL_vecheadpen
 -9 -10 D
 P clip fs P S 
 U
-6 W
-V 2473 2143 T -129.549 R
-N 0 0 M 71 0 D S
-U
-V 2409 2066 T -129.549 R
-PSL_vecheadpen
-6 W
-0 0 M
--40 11 D
-10 -11 D
--10 -11 D
-P clip fs P S 
-U
-5 W
-V 2638 2143 T -142.465 R
-N 0 0 M 69 0 D S
-U
-V 2560 2083 T -142.465 R
-PSL_vecheadpen
-5 W
-0 0 M
--39 10 D
-10 -10 D
--10 -10 D
-P clip fs P S 
-U
-5 W
+4 W
 V 2803 2143 T -150.128 R
-N 0 0 M 59 0 D S
+N 0 0 M 55 0 D S
 U
-V 2730 2102 T -150.128 R
+V 2735 2105 T -150.128 R
 PSL_vecheadpen
-5 W
+4 W
 0 0 M
--33 9 D
-8 -9 D
--8 -9 D
+-31 8 D
+8 -8 D
+-8 -8 D
 P clip fs P S 
 U
 3 W
 V 2968 2143 T -155.153 R
-N 0 0 M 44 0 D S
+N 0 0 M 41 0 D S
 U
-V 2911 2117 T -155.153 R
+V 2915 2119 T -155.153 R
 PSL_vecheadpen
 3 W
 0 0 M
--24 7 D
-6 -7 D
--6 -7 D
+-23 6 D
+6 -6 D
+-6 -6 D
 P clip fs P S 
 U
 2 W
 V 3133 2143 T -158.707 R
-N 0 0 M 29 0 D S
+N 0 0 M 27 0 D S
 U
-V 3094 2128 T -158.707 R
+V 3097 2130 T -158.707 R
 PSL_vecheadpen
 2 W
 0 0 M
--16 4 D
+-15 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
-2 W
+1 W
 V 3297 2143 T -163.542 R
-N 0 0 M 19 0 D S
+N 0 0 M 18 0 D S
 U
-V 3271 2136 T -163.542 R
+V 3273 2136 T -163.542 R
 PSL_vecheadpen
-2 W
+1 W
 0 0 M
--11 3 D
+-10 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 2 W
 V 0 1978 T 168.873 R
-N 0 0 M 23 0 D S
+N 0 0 M 21 0 D S
 U
-V -32 1985 T 168.873 R
+V -30 1984 T 168.873 R
 PSL_vecheadpen
 2 W
 0 0 M
--13 3 D
+-12 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
-3 W
+2 W
 V 165 1978 T 165.453 R
-N 0 0 M 34 0 D S
+N 0 0 M 32 0 D S
 U
-V 118 1991 T 165.453 R
+V 122 1990 T 165.453 R
 PSL_vecheadpen
-3 W
+2 W
 0 0 M
--19 5 D
+-18 5 D
 5 -5 D
 -5 -5 D
 P clip fs P S 
 U
 4 W
 V 330 1978 T 162.865 R
-N 0 0 M 51 0 D S
+N 0 0 M 47 0 D S
 U
-V 261 2000 T 162.865 R
+V 266 1998 T 162.865 R
 PSL_vecheadpen
 4 W
 0 0 M
--28 8 D
+-26 7 D
+6 -7 D
+-6 -7 D
+P clip fs P S 
+U
+5 W
+V 495 1978 T 159.073 R
+N 0 0 M 62 0 D S
+U
+V 412 2010 T 159.073 R
+PSL_vecheadpen
+5 W
+0 0 M
+-35 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+6 W
+V 659 1978 T 152.91 R
+N 0 0 M 70 0 D S
+U
+V 571 2024 T 152.91 R
+PSL_vecheadpen
+6 W
+0 0 M
+-39 11 D
+10 -11 D
+-10 -11 D
+P clip fs P S 
+U
+5 W
+V 824 1978 T 141.122 R
+N 0 0 M 66 0 D S
+U
+V 752 2037 T 141.122 R
+PSL_vecheadpen
+5 W
+0 0 M
+-37 10 D
+9 -10 D
+-9 -10 D
+P clip fs P S 
+U
+4 W
+V 989 1978 T 113.052 R
+N 0 0 M 52 0 D S
+U
+V 961 2046 T 113.052 R
+PSL_vecheadpen
+4 W
+0 0 M
+-29 8 D
+7 -8 D
+-7 -8 D
+P clip fs P S 
+U
+4 W
+V 1154 1978 T 59.2848 R
+N 0 0 M 55 0 D S
+U
+V 1194 2045 T 59.2848 R
+PSL_vecheadpen
+4 W
+0 0 M
+-31 8 D
+8 -8 D
+-8 -8 D
+P clip fs P S 
+U
+7 W
+V 1319 1978 T 25.1321 R
+N 0 0 M 90 0 D S
+U
+V 1435 2033 T 25.1321 R
+PSL_vecheadpen
+7 W
+0 0 M
+-50 14 D
+12 -14 D
+-12 -14 D
+P clip fs P S 
+U
+10 W
+V 1484 1978 T 9.86794 R
+N 0 0 M 126 0 D S
+U
+V 1660 2009 T 9.86794 R
+PSL_vecheadpen
+10 W
+0 0 M
+-70 19 D
+17 -19 D
+-17 -19 D
+P clip fs P S 
+U
+11 W
+V 1649 1978 T N 0 0 M 140 0 D S
+U
+V 1848 1978 T PSL_vecheadpen
+11 W
+0 0 M
+-78 21 D
+19 -21 D
+-19 -21 D
+P clip fs P S 
+U
+10 W
+V 1814 1978 T -9.86794 R
+N 0 0 M 126 0 D S
+U
+V 1990 1948 T -9.86794 R
+PSL_vecheadpen
+10 W
+0 0 M
+-70 19 D
+17 -19 D
+-17 -19 D
+P clip fs P S 
+U
+7 W
+V 1978 1978 T -25.1321 R
+N 0 0 M 90 0 D S
+U
+V 2094 1924 T -25.1321 R
+PSL_vecheadpen
+7 W
+0 0 M
+-50 14 D
+12 -14 D
+-12 -14 D
+P clip fs P S 
+U
+4 W
+V 2143 1978 T -59.2848 R
+N 0 0 M 55 0 D S
+U
+V 2183 1912 T -59.2848 R
+PSL_vecheadpen
+4 W
+0 0 M
+-31 8 D
+8 -8 D
+-8 -8 D
+P clip fs P S 
+U
+4 W
+V 2308 1978 T -113.052 R
+N 0 0 M 52 0 D S
+U
+V 2280 1911 T -113.052 R
+PSL_vecheadpen
+4 W
+0 0 M
+-29 8 D
 7 -8 D
 -7 -8 D
 P clip fs P S 
 U
 5 W
-V 495 1978 T 159.073 R
-N 0 0 M 67 0 D S
+V 2473 1978 T -141.122 R
+N 0 0 M 66 0 D S
 U
-V 406 2012 T 159.073 R
+V 2400 1920 T -141.122 R
 PSL_vecheadpen
 5 W
 0 0 M
@@ -5779,422 +5927,294 @@ PSL_vecheadpen
 P clip fs P S 
 U
 6 W
-V 659 1978 T 152.91 R
-N 0 0 M 76 0 D S
-U
-V 564 2027 T 152.91 R
-PSL_vecheadpen
-6 W
-0 0 M
--42 11 D
-10 -11 D
--10 -11 D
-P clip fs P S 
-U
-6 W
-V 824 1978 T 141.122 R
-N 0 0 M 71 0 D S
-U
-V 746 2042 T 141.122 R
-PSL_vecheadpen
-6 W
-0 0 M
--40 11 D
-10 -11 D
--10 -11 D
-P clip fs P S 
-U
-4 W
-V 989 1978 T 113.052 R
-N 0 0 M 55 0 D S
-U
-V 958 2051 T 113.052 R
-PSL_vecheadpen
-4 W
-0 0 M
--31 8 D
-8 -8 D
--8 -8 D
-P clip fs P S 
-U
-5 W
-V 1154 1978 T 59.2848 R
-N 0 0 M 59 0 D S
-U
-V 1197 2050 T 59.2848 R
-PSL_vecheadpen
-5 W
-0 0 M
--33 9 D
-8 -9 D
--8 -9 D
-P clip fs P S 
-U
-8 W
-V 1319 1978 T 25.1321 R
-N 0 0 M 97 0 D S
-U
-V 1444 2037 T 25.1321 R
-PSL_vecheadpen
-8 W
-0 0 M
--54 15 D
-13 -15 D
--13 -15 D
-P clip fs P S 
-U
-11 W
-V 1484 1978 T 9.86794 R
-N 0 0 M 136 0 D S
-U
-V 1673 2011 T 9.86794 R
-PSL_vecheadpen
-11 W
-0 0 M
--76 20 D
-19 -20 D
--19 -20 D
-P clip fs P S 
-U
-12 W
-V 1649 1978 T N 0 0 M 151 0 D S
-U
-V 1863 1978 T PSL_vecheadpen
-12 W
-0 0 M
--84 23 D
-21 -23 D
--21 -23 D
-P clip fs P S 
-U
-11 W
-V 1814 1978 T -9.86794 R
-N 0 0 M 136 0 D S
-U
-V 2003 1946 T -9.86794 R
-PSL_vecheadpen
-11 W
-0 0 M
--76 20 D
-19 -20 D
--19 -20 D
-P clip fs P S 
-U
-8 W
-V 1978 1978 T -25.1321 R
-N 0 0 M 97 0 D S
-U
-V 2103 1920 T -25.1321 R
-PSL_vecheadpen
-8 W
-0 0 M
--54 15 D
-13 -15 D
--13 -15 D
-P clip fs P S 
-U
-5 W
-V 2143 1978 T -59.2848 R
-N 0 0 M 59 0 D S
-U
-V 2186 1907 T -59.2848 R
-PSL_vecheadpen
-5 W
-0 0 M
--33 9 D
-8 -9 D
--8 -9 D
-P clip fs P S 
-U
-4 W
-V 2308 1978 T -113.052 R
-N 0 0 M 55 0 D S
-U
-V 2277 1906 T -113.052 R
-PSL_vecheadpen
-4 W
-0 0 M
--31 8 D
-8 -8 D
--8 -8 D
-P clip fs P S 
-U
-6 W
-V 2473 1978 T -141.122 R
-N 0 0 M 71 0 D S
-U
-V 2395 1915 T -141.122 R
-PSL_vecheadpen
-6 W
-0 0 M
--40 11 D
-10 -11 D
--10 -11 D
-P clip fs P S 
-U
-6 W
 V 2638 1978 T -152.91 R
-N 0 0 M 76 0 D S
+N 0 0 M 70 0 D S
 U
-V 2543 1930 T -152.91 R
+V 2549 1933 T -152.91 R
 PSL_vecheadpen
 6 W
 0 0 M
--42 11 D
+-39 11 D
 10 -11 D
 -10 -11 D
 P clip fs P S 
 U
 5 W
 V 2803 1978 T -159.073 R
-N 0 0 M 67 0 D S
+N 0 0 M 62 0 D S
 U
-V 2714 1945 T -159.073 R
+V 2721 1947 T -159.073 R
 PSL_vecheadpen
 5 W
 0 0 M
--37 10 D
-9 -10 D
--9 -10 D
+-35 9 D
+9 -9 D
+-9 -9 D
 P clip fs P S 
 U
 4 W
 V 2968 1978 T -162.865 R
-N 0 0 M 51 0 D S
+N 0 0 M 47 0 D S
 U
-V 2899 1957 T -162.865 R
+V 2904 1959 T -162.865 R
 PSL_vecheadpen
 4 W
 0 0 M
--28 8 D
-7 -8 D
--7 -8 D
+-26 7 D
+6 -7 D
+-6 -7 D
 P clip fs P S 
 U
-3 W
+2 W
 V 3133 1978 T -165.453 R
-N 0 0 M 34 0 D S
+N 0 0 M 32 0 D S
 U
-V 3086 1966 T -165.453 R
+V 3089 1967 T -165.453 R
 PSL_vecheadpen
-3 W
+2 W
 0 0 M
--19 5 D
+-18 5 D
 5 -5 D
 -5 -5 D
 P clip fs P S 
 U
 2 W
 V 3297 1978 T -168.873 R
-N 0 0 M 23 0 D S
+N 0 0 M 21 0 D S
 U
-V 3266 1972 T -168.873 R
+V 3268 1973 T -168.873 R
 PSL_vecheadpen
 2 W
 0 0 M
--13 3 D
+-12 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 2 W
 V 0 1814 T 174.388 R
-N 0 0 M 26 0 D S
+N 0 0 M 24 0 D S
 U
-V -36 1817 T 174.388 R
+V -34 1817 T 174.388 R
 PSL_vecheadpen
 2 W
 0 0 M
--14 4 D
+-13 4 D
 3 -4 D
 -3 -4 D
 P clip fs P S 
 U
 3 W
 V 165 1814 T 172.613 R
-N 0 0 M 37 0 D S
+N 0 0 M 35 0 D S
 U
-V 112 1820 T 172.613 R
+V 116 1820 T 172.613 R
 PSL_vecheadpen
 3 W
 0 0 M
--21 6 D
-5 -6 D
--5 -6 D
+-19 5 D
+4 -5 D
+-4 -5 D
 P clip fs P S 
 U
 4 W
 V 330 1814 T 171.244 R
-N 0 0 M 55 0 D S
+N 0 0 M 51 0 D S
 U
-V 252 1826 T 171.244 R
+V 258 1825 T 171.244 R
 PSL_vecheadpen
 4 W
 0 0 M
--31 8 D
-8 -8 D
--8 -8 D
+-29 8 D
+7 -8 D
+-7 -8 D
 P clip fs P S 
 U
-6 W
+5 W
 V 495 1814 T 169.184 R
-N 0 0 M 72 0 D S
+N 0 0 M 67 0 D S
 U
-V 395 1833 T 169.184 R
+V 402 1831 T 169.184 R
 PSL_vecheadpen
-6 W
+5 W
 0 0 M
--40 11 D
-10 -11 D
--10 -11 D
+-37 10 D
+9 -10 D
+-9 -10 D
 P clip fs P S 
 U
 6 W
 V 659 1814 T 165.665 R
-N 0 0 M 78 0 D S
+N 0 0 M 73 0 D S
 U
-V 552 1841 T 165.665 R
+V 559 1839 T 165.665 R
 PSL_vecheadpen
 6 W
 0 0 M
--44 12 D
-11 -12 D
--11 -12 D
+-41 11 D
+11 -11 D
+-11 -11 D
 P clip fs P S 
 U
 5 W
 V 824 1814 T 158.06 R
-N 0 0 M 67 0 D S
+N 0 0 M 62 0 D S
 U
-V 736 1849 T 158.06 R
+V 742 1847 T 158.06 R
 PSL_vecheadpen
 5 W
 0 0 M
--37 10 D
-9 -10 D
--9 -10 D
+-35 9 D
+9 -9 D
+-9 -9 D
 P clip fs P S 
 U
 3 W
 V 989 1814 T 130.424 R
-N 0 0 M 38 0 D S
+N 0 0 M 35 0 D S
 U
-V 955 1854 T 130.424 R
+V 957 1852 T 130.424 R
 PSL_vecheadpen
 3 W
 0 0 M
--21 6 D
-5 -6 D
--5 -6 D
+-20 5 D
+5 -5 D
+-5 -5 D
 P clip fs P S 
 U
 3 W
 V 1154 1814 T 40.061 R
-N 0 0 M 44 0 D S
+N 0 0 M 41 0 D S
 U
-V 1202 1854 T 40.061 R
+V 1199 1851 T 40.061 R
 PSL_vecheadpen
 3 W
 0 0 M
--25 7 D
-6 -7 D
--6 -7 D
+-23 6 D
+6 -6 D
+-6 -6 D
 P clip fs P S 
 U
-8 W
+7 W
 V 1319 1814 T 13.1904 R
-N 0 0 M 102 0 D S
+N 0 0 M 95 0 D S
 U
-V 1460 1847 T 13.1904 R
+V 1450 1844 T 13.1904 R
 PSL_vecheadpen
-8 W
+7 W
 0 0 M
--57 15 D
-14 -15 D
--14 -15 D
+-53 14 D
+13 -14 D
+-13 -14 D
 P clip fs P S 
 U
-12 W
+11 W
 V 1484 1814 T 4.96687 R
-N 0 0 M 151 0 D S
+N 0 0 M 141 0 D S
 U
-V 1698 1832 T 4.96687 R
+V 1683 1831 T 4.96687 R
 PSL_vecheadpen
-12 W
+11 W
 0 0 M
--84 23 D
-21 -23 D
--21 -23 D
-P clip fs P S 
-U
-13 W
-V 1649 1814 T N 0 0 M 170 0 D S
-U
-V 1890 1814 T PSL_vecheadpen
-13 W
-0 0 M
--95 25 D
-24 -25 D
--24 -25 D
+-79 21 D
+20 -21 D
+-20 -21 D
 P clip fs P S 
 U
 12 W
+V 1649 1814 T N 0 0 M 158 0 D S
+U
+V 1873 1814 T PSL_vecheadpen
+12 W
+0 0 M
+-88 24 D
+22 -24 D
+-22 -24 D
+P clip fs P S 
+U
+11 W
 V 1814 1814 T -4.96687 R
-N 0 0 M 151 0 D S
+N 0 0 M 141 0 D S
 U
-V 2027 1795 T -4.96687 R
+V 2012 1796 T -4.96687 R
 PSL_vecheadpen
-12 W
+11 W
 0 0 M
--84 23 D
-21 -23 D
--21 -23 D
+-79 21 D
+20 -21 D
+-20 -21 D
 P clip fs P S 
 U
-8 W
+7 W
 V 1978 1814 T -13.1904 R
-N 0 0 M 102 0 D S
+N 0 0 M 95 0 D S
 U
-V 2119 1781 T -13.1904 R
+V 2109 1783 T -13.1904 R
 PSL_vecheadpen
-8 W
+7 W
 0 0 M
--57 15 D
-14 -15 D
--14 -15 D
+-53 14 D
+13 -14 D
+-13 -14 D
 P clip fs P S 
 U
 3 W
 V 2143 1814 T -40.061 R
-N 0 0 M 44 0 D S
+N 0 0 M 41 0 D S
 U
-V 2191 1773 T -40.061 R
+V 2188 1776 T -40.061 R
 PSL_vecheadpen
 3 W
 0 0 M
--25 7 D
-6 -7 D
--6 -7 D
+-23 6 D
+6 -6 D
+-6 -6 D
 P clip fs P S 
 U
 3 W
 V 2308 1814 T -130.424 R
-N 0 0 M 38 0 D S
+N 0 0 M 35 0 D S
 U
-V 2274 1773 T -130.424 R
+V 2276 1776 T -130.424 R
 PSL_vecheadpen
 3 W
 0 0 M
--21 6 D
-5 -6 D
--5 -6 D
+-20 5 D
+5 -5 D
+-5 -5 D
 P clip fs P S 
 U
 5 W
 V 2473 1814 T -158.06 R
+N 0 0 M 62 0 D S
+U
+V 2391 1781 T -158.06 R
+PSL_vecheadpen
+5 W
+0 0 M
+-35 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+6 W
+V 2638 1814 T -165.665 R
+N 0 0 M 73 0 D S
+U
+V 2538 1788 T -165.665 R
+PSL_vecheadpen
+6 W
+0 0 M
+-41 11 D
+11 -11 D
+-11 -11 D
+P clip fs P S 
+U
+5 W
+V 2803 1814 T -169.184 R
 N 0 0 M 67 0 D S
 U
-V 2385 1778 T -158.06 R
+V 2710 1796 T -169.184 R
 PSL_vecheadpen
 5 W
 0 0 M
@@ -6203,115 +6223,102 @@ PSL_vecheadpen
 -9 -10 D
 P clip fs P S 
 U
-6 W
-V 2638 1814 T -165.665 R
-N 0 0 M 78 0 D S
-U
-V 2530 1786 T -165.665 R
-PSL_vecheadpen
-6 W
-0 0 M
--44 12 D
-11 -12 D
--11 -12 D
-P clip fs P S 
-U
-6 W
-V 2803 1814 T -169.184 R
-N 0 0 M 72 0 D S
-U
-V 2703 1795 T -169.184 R
-PSL_vecheadpen
-6 W
-0 0 M
--40 11 D
-10 -11 D
--10 -11 D
-P clip fs P S 
-U
 4 W
 V 2968 1814 T -171.244 R
-N 0 0 M 55 0 D S
+N 0 0 M 51 0 D S
 U
-V 2890 1802 T -171.244 R
+V 2896 1802 T -171.244 R
 PSL_vecheadpen
 4 W
 0 0 M
--31 8 D
-8 -8 D
--8 -8 D
+-29 8 D
+7 -8 D
+-7 -8 D
 P clip fs P S 
 U
 3 W
 V 3133 1814 T -172.613 R
-N 0 0 M 37 0 D S
+N 0 0 M 35 0 D S
 U
-V 3080 1807 T -172.613 R
+V 3084 1807 T -172.613 R
 PSL_vecheadpen
 3 W
 0 0 M
--21 6 D
-5 -6 D
--5 -6 D
+-19 5 D
+4 -5 D
+-4 -5 D
 P clip fs P S 
 U
 2 W
 V 3297 1814 T -174.388 R
-N 0 0 M 26 0 D S
+N 0 0 M 24 0 D S
 U
-V 3261 1810 T -174.388 R
+V 3264 1810 T -174.388 R
 PSL_vecheadpen
 2 W
 0 0 M
--14 4 D
+-13 4 D
 3 -4 D
 -3 -4 D
 P clip fs P S 
 U
 2 W
 V 0 1649 T 180 R
-N 0 0 M 26 0 D S
+N 0 0 M 25 0 D S
 U
-V -38 1649 T 180 R
+V -35 1649 T 180 R
 PSL_vecheadpen
 2 W
 0 0 M
--15 4 D
+-14 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
 3 W
 V 165 1649 T 180 R
-N 0 0 M 39 0 D S
+N 0 0 M 36 0 D S
 U
-V 110 1649 T 180 R
+V 114 1649 T 180 R
 PSL_vecheadpen
 3 W
 0 0 M
--22 6 D
-6 -6 D
--6 -6 D
+-20 5 D
+5 -5 D
+-5 -5 D
 P clip fs P S 
 U
 4 W
 V 330 1649 T 180 R
-N 0 0 M 57 0 D S
+N 0 0 M 53 0 D S
 U
-V 249 1649 T 180 R
+V 255 1649 T 180 R
 PSL_vecheadpen
 4 W
 0 0 M
--32 9 D
-8 -9 D
--8 -9 D
+-30 8 D
+8 -8 D
+-8 -8 D
+P clip fs P S 
+U
+5 W
+V 495 1649 T 180 R
+N 0 0 M 68 0 D S
+U
+V 398 1649 T 180 R
+PSL_vecheadpen
+5 W
+0 0 M
+-38 10 D
+9 -10 D
+-9 -10 D
 P clip fs P S 
 U
 6 W
-V 495 1649 T 180 R
+V 659 1649 T 180 R
 N 0 0 M 73 0 D S
 U
-V 391 1649 T 180 R
+V 555 1649 T 180 R
 PSL_vecheadpen
 6 W
 0 0 M
@@ -6320,166 +6327,140 @@ PSL_vecheadpen
 -10 -11 D
 P clip fs P S 
 U
-6 W
-V 659 1649 T 180 R
-N 0 0 M 79 0 D S
-U
-V 548 1649 T 180 R
-PSL_vecheadpen
-6 W
-0 0 M
--44 12 D
-11 -12 D
--11 -12 D
-P clip fs P S 
-U
 5 W
 V 824 1649 T 180 R
-N 0 0 M 65 0 D S
+N 0 0 M 60 0 D S
 U
-V 732 1649 T 180 R
+V 739 1649 T 180 R
 PSL_vecheadpen
 5 W
 0 0 M
--36 10 D
-9 -10 D
--9 -10 D
+-34 9 D
+9 -9 D
+-9 -9 D
 P clip fs P S 
 U
 2 W
 V 989 1649 T 180 R
-N 0 0 M 25 0 D S
+N 0 0 M 24 0 D S
 U
-V 953 1649 T 180 R
+V 956 1649 T 180 R
 PSL_vecheadpen
 2 W
 0 0 M
--14 4 D
+-13 4 D
 3 -4 D
 -3 -4 D
 P clip fs P S 
 U
 3 W
-V 1154 1649 T N 0 0 M 35 0 D S
+V 1154 1649 T N 0 0 M 33 0 D S
 U
-V 1204 1649 T PSL_vecheadpen
+V 1201 1649 T PSL_vecheadpen
 3 W
 0 0 M
--20 5 D
-5 -5 D
--5 -5 D
+-18 5 D
+4 -5 D
+-4 -5 D
 P clip fs P S 
 U
 8 W
-V 1319 1649 T N 0 0 M 103 0 D S
+V 1319 1649 T N 0 0 M 96 0 D S
 U
-V 1465 1649 T PSL_vecheadpen
+V 1455 1649 T PSL_vecheadpen
 8 W
 0 0 M
--58 15 D
-15 -15 D
--15 -15 D
+-54 14 D
+14 -14 D
+-14 -14 D
 P clip fs P S 
 U
-12 W
-V 1484 1649 T N 0 0 M 157 0 D S
+11 W
+V 1484 1649 T N 0 0 M 146 0 D S
 U
-V 1706 1649 T PSL_vecheadpen
-12 W
+V 1691 1649 T PSL_vecheadpen
+11 W
 0 0 M
--88 23 D
-22 -23 D
--22 -23 D
+-81 22 D
+20 -22 D
+-20 -22 D
 P clip fs P S 
 U
-14 W
-V 1649 1649 T N 0 0 M 177 0 D S
+13 W
+V 1649 1649 T N 0 0 M 165 0 D S
 U
-V 1900 1649 T PSL_vecheadpen
-14 W
+V 1883 1649 T PSL_vecheadpen
+13 W
 0 0 M
--99 27 D
-25 -27 D
--25 -27 D
+-92 25 D
+23 -25 D
+-23 -25 D
 P clip fs P S 
 U
-12 W
-V 1814 1649 T N 0 0 M 157 0 D S
+11 W
+V 1814 1649 T N 0 0 M 146 0 D S
 U
-V 2036 1649 T PSL_vecheadpen
-12 W
+V 2021 1649 T PSL_vecheadpen
+11 W
 0 0 M
--88 23 D
-22 -23 D
--22 -23 D
+-81 22 D
+20 -22 D
+-20 -22 D
 P clip fs P S 
 U
 8 W
-V 1978 1649 T N 0 0 M 103 0 D S
+V 1978 1649 T N 0 0 M 96 0 D S
 U
-V 2125 1649 T PSL_vecheadpen
+V 2115 1649 T PSL_vecheadpen
 8 W
 0 0 M
--58 15 D
-15 -15 D
--15 -15 D
+-54 14 D
+14 -14 D
+-14 -14 D
 P clip fs P S 
 U
 3 W
-V 2143 1649 T N 0 0 M 35 0 D S
+V 2143 1649 T N 0 0 M 33 0 D S
 U
-V 2193 1649 T PSL_vecheadpen
+V 2190 1649 T PSL_vecheadpen
 3 W
 0 0 M
--20 5 D
-5 -5 D
--5 -5 D
+-18 5 D
+4 -5 D
+-4 -5 D
 P clip fs P S 
 U
 2 W
 V 2308 1649 T 180 R
-N 0 0 M 25 0 D S
+N 0 0 M 24 0 D S
 U
-V 2272 1649 T 180 R
+V 2275 1649 T 180 R
 PSL_vecheadpen
 2 W
 0 0 M
--14 4 D
+-13 4 D
 3 -4 D
 -3 -4 D
 P clip fs P S 
 U
 5 W
 V 2473 1649 T 180 R
-N 0 0 M 65 0 D S
+N 0 0 M 60 0 D S
 U
-V 2381 1649 T 180 R
+V 2388 1649 T 180 R
 PSL_vecheadpen
 5 W
 0 0 M
--36 10 D
-9 -10 D
--9 -10 D
+-34 9 D
+9 -9 D
+-9 -9 D
 P clip fs P S 
 U
 6 W
 V 2638 1649 T 180 R
-N 0 0 M 79 0 D S
-U
-V 2526 1649 T 180 R
-PSL_vecheadpen
-6 W
-0 0 M
--44 12 D
-11 -12 D
--11 -12 D
-P clip fs P S 
-U
-6 W
-V 2803 1649 T 180 R
 N 0 0 M 73 0 D S
 U
-V 2699 1649 T 180 R
+V 2534 1649 T 180 R
 PSL_vecheadpen
 6 W
 0 0 M
@@ -6488,37 +6469,618 @@ PSL_vecheadpen
 -10 -11 D
 P clip fs P S 
 U
+5 W
+V 2803 1649 T 180 R
+N 0 0 M 68 0 D S
+U
+V 2706 1649 T 180 R
+PSL_vecheadpen
+5 W
+0 0 M
+-38 10 D
+9 -10 D
+-9 -10 D
+P clip fs P S 
+U
 4 W
 V 2968 1649 T 180 R
-N 0 0 M 57 0 D S
+N 0 0 M 53 0 D S
 U
-V 2887 1649 T 180 R
+V 2893 1649 T 180 R
 PSL_vecheadpen
 4 W
 0 0 M
--32 9 D
-8 -9 D
--8 -9 D
+-30 8 D
+8 -8 D
+-8 -8 D
 P clip fs P S 
 U
 3 W
 V 3133 1649 T 180 R
-N 0 0 M 39 0 D S
+N 0 0 M 36 0 D S
 U
-V 3078 1649 T 180 R
+V 3082 1649 T 180 R
 PSL_vecheadpen
 3 W
 0 0 M
--22 6 D
-6 -6 D
--6 -6 D
+-20 5 D
+5 -5 D
+-5 -5 D
 P clip fs P S 
 U
 2 W
 V 3297 1649 T 180 R
-N 0 0 M 26 0 D S
+N 0 0 M 25 0 D S
 U
-V 3260 1649 T 180 R
+V 3263 1649 T 180 R
+PSL_vecheadpen
+2 W
+0 0 M
+-14 4 D
+4 -4 D
+-4 -4 D
+P clip fs P S 
+U
+2 W
+V 0 1484 T -174.388 R
+N 0 0 M 24 0 D S
+U
+V -34 1481 T -174.388 R
+PSL_vecheadpen
+2 W
+0 0 M
+-13 4 D
+3 -4 D
+-3 -4 D
+P clip fs P S 
+U
+3 W
+V 165 1484 T -172.613 R
+N 0 0 M 35 0 D S
+U
+V 116 1478 T -172.613 R
+PSL_vecheadpen
+3 W
+0 0 M
+-19 5 D
+4 -5 D
+-4 -5 D
+P clip fs P S 
+U
+4 W
+V 330 1484 T -171.244 R
+N 0 0 M 51 0 D S
+U
+V 258 1473 T -171.244 R
+PSL_vecheadpen
+4 W
+0 0 M
+-29 8 D
+7 -8 D
+-7 -8 D
+P clip fs P S 
+U
+5 W
+V 495 1484 T -169.184 R
+N 0 0 M 67 0 D S
+U
+V 402 1466 T -169.184 R
+PSL_vecheadpen
+5 W
+0 0 M
+-37 10 D
+9 -10 D
+-9 -10 D
+P clip fs P S 
+U
+6 W
+V 659 1484 T -165.665 R
+N 0 0 M 73 0 D S
+U
+V 559 1458 T -165.665 R
+PSL_vecheadpen
+6 W
+0 0 M
+-41 11 D
+11 -11 D
+-11 -11 D
+P clip fs P S 
+U
+5 W
+V 824 1484 T -158.06 R
+N 0 0 M 62 0 D S
+U
+V 742 1451 T -158.06 R
+PSL_vecheadpen
+5 W
+0 0 M
+-35 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+3 W
+V 989 1484 T -130.424 R
+N 0 0 M 35 0 D S
+U
+V 957 1446 T -130.424 R
+PSL_vecheadpen
+3 W
+0 0 M
+-20 5 D
+5 -5 D
+-5 -5 D
+P clip fs P S 
+U
+3 W
+V 1154 1484 T -40.061 R
+N 0 0 M 41 0 D S
+U
+V 1199 1446 T -40.061 R
+PSL_vecheadpen
+3 W
+0 0 M
+-23 6 D
+6 -6 D
+-6 -6 D
+P clip fs P S 
+U
+7 W
+V 1319 1484 T -13.1904 R
+N 0 0 M 95 0 D S
+U
+V 1450 1453 T -13.1904 R
+PSL_vecheadpen
+7 W
+0 0 M
+-53 14 D
+13 -14 D
+-13 -14 D
+P clip fs P S 
+U
+11 W
+V 1484 1484 T -4.96687 R
+N 0 0 M 141 0 D S
+U
+V 1683 1467 T -4.96687 R
+PSL_vecheadpen
+11 W
+0 0 M
+-79 21 D
+20 -21 D
+-20 -21 D
+P clip fs P S 
+U
+12 W
+V 1649 1484 T N 0 0 M 158 0 D S
+U
+V 1873 1484 T PSL_vecheadpen
+12 W
+0 0 M
+-88 24 D
+22 -24 D
+-22 -24 D
+P clip fs P S 
+U
+11 W
+V 1814 1484 T 4.96687 R
+N 0 0 M 141 0 D S
+U
+V 2012 1501 T 4.96687 R
+PSL_vecheadpen
+11 W
+0 0 M
+-79 21 D
+20 -21 D
+-20 -21 D
+P clip fs P S 
+U
+7 W
+V 1978 1484 T 13.1904 R
+N 0 0 M 95 0 D S
+U
+V 2109 1515 T 13.1904 R
+PSL_vecheadpen
+7 W
+0 0 M
+-53 14 D
+13 -14 D
+-13 -14 D
+P clip fs P S 
+U
+3 W
+V 2143 1484 T 40.061 R
+N 0 0 M 41 0 D S
+U
+V 2188 1522 T 40.061 R
+PSL_vecheadpen
+3 W
+0 0 M
+-23 6 D
+6 -6 D
+-6 -6 D
+P clip fs P S 
+U
+3 W
+V 2308 1484 T 130.424 R
+N 0 0 M 35 0 D S
+U
+V 2276 1522 T 130.424 R
+PSL_vecheadpen
+3 W
+0 0 M
+-20 5 D
+5 -5 D
+-5 -5 D
+P clip fs P S 
+U
+5 W
+V 2473 1484 T 158.06 R
+N 0 0 M 62 0 D S
+U
+V 2391 1517 T 158.06 R
+PSL_vecheadpen
+5 W
+0 0 M
+-35 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+6 W
+V 2638 1484 T 165.665 R
+N 0 0 M 73 0 D S
+U
+V 2538 1509 T 165.665 R
+PSL_vecheadpen
+6 W
+0 0 M
+-41 11 D
+11 -11 D
+-11 -11 D
+P clip fs P S 
+U
+5 W
+V 2803 1484 T 169.184 R
+N 0 0 M 67 0 D S
+U
+V 2710 1502 T 169.184 R
+PSL_vecheadpen
+5 W
+0 0 M
+-37 10 D
+9 -10 D
+-9 -10 D
+P clip fs P S 
+U
+4 W
+V 2968 1484 T 171.244 R
+N 0 0 M 51 0 D S
+U
+V 2896 1495 T 171.244 R
+PSL_vecheadpen
+4 W
+0 0 M
+-29 8 D
+7 -8 D
+-7 -8 D
+P clip fs P S 
+U
+3 W
+V 3133 1484 T 172.613 R
+N 0 0 M 35 0 D S
+U
+V 3084 1490 T 172.613 R
+PSL_vecheadpen
+3 W
+0 0 M
+-19 5 D
+4 -5 D
+-4 -5 D
+P clip fs P S 
+U
+2 W
+V 3297 1484 T 174.388 R
+N 0 0 M 24 0 D S
+U
+V 3264 1487 T 174.388 R
+PSL_vecheadpen
+2 W
+0 0 M
+-13 4 D
+3 -4 D
+-3 -4 D
+P clip fs P S 
+U
+2 W
+V 0 1319 T -168.873 R
+N 0 0 M 21 0 D S
+U
+V -30 1313 T -168.873 R
+PSL_vecheadpen
+2 W
+0 0 M
+-12 3 D
+3 -3 D
+-3 -3 D
+P clip fs P S 
+U
+2 W
+V 165 1319 T -165.453 R
+N 0 0 M 32 0 D S
+U
+V 122 1308 T -165.453 R
+PSL_vecheadpen
+2 W
+0 0 M
+-18 5 D
+5 -5 D
+-5 -5 D
+P clip fs P S 
+U
+4 W
+V 330 1319 T -162.865 R
+N 0 0 M 47 0 D S
+U
+V 266 1299 T -162.865 R
+PSL_vecheadpen
+4 W
+0 0 M
+-26 7 D
+6 -7 D
+-6 -7 D
+P clip fs P S 
+U
+5 W
+V 495 1319 T -159.073 R
+N 0 0 M 62 0 D S
+U
+V 412 1288 T -159.073 R
+PSL_vecheadpen
+5 W
+0 0 M
+-35 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+6 W
+V 659 1319 T -152.91 R
+N 0 0 M 70 0 D S
+U
+V 571 1274 T -152.91 R
+PSL_vecheadpen
+6 W
+0 0 M
+-39 11 D
+10 -11 D
+-10 -11 D
+P clip fs P S 
+U
+5 W
+V 824 1319 T -141.122 R
+N 0 0 M 66 0 D S
+U
+V 752 1260 T -141.122 R
+PSL_vecheadpen
+5 W
+0 0 M
+-37 10 D
+9 -10 D
+-9 -10 D
+P clip fs P S 
+U
+4 W
+V 989 1319 T -113.052 R
+N 0 0 M 52 0 D S
+U
+V 961 1252 T -113.052 R
+PSL_vecheadpen
+4 W
+0 0 M
+-29 8 D
+7 -8 D
+-7 -8 D
+P clip fs P S 
+U
+4 W
+V 1154 1319 T -59.2848 R
+N 0 0 M 55 0 D S
+U
+V 1194 1252 T -59.2848 R
+PSL_vecheadpen
+4 W
+0 0 M
+-31 8 D
+8 -8 D
+-8 -8 D
+P clip fs P S 
+U
+7 W
+V 1319 1319 T -25.1321 R
+N 0 0 M 90 0 D S
+U
+V 1435 1265 T -25.1321 R
+PSL_vecheadpen
+7 W
+0 0 M
+-50 14 D
+12 -14 D
+-12 -14 D
+P clip fs P S 
+U
+10 W
+V 1484 1319 T -9.86794 R
+N 0 0 M 126 0 D S
+U
+V 1660 1288 T -9.86794 R
+PSL_vecheadpen
+10 W
+0 0 M
+-70 19 D
+17 -19 D
+-17 -19 D
+P clip fs P S 
+U
+11 W
+V 1649 1319 T N 0 0 M 140 0 D S
+U
+V 1848 1319 T PSL_vecheadpen
+11 W
+0 0 M
+-78 21 D
+19 -21 D
+-19 -21 D
+P clip fs P S 
+U
+10 W
+V 1814 1319 T 9.86794 R
+N 0 0 M 126 0 D S
+U
+V 1990 1350 T 9.86794 R
+PSL_vecheadpen
+10 W
+0 0 M
+-70 19 D
+17 -19 D
+-17 -19 D
+P clip fs P S 
+U
+7 W
+V 1978 1319 T 25.1321 R
+N 0 0 M 90 0 D S
+U
+V 2094 1373 T 25.1321 R
+PSL_vecheadpen
+7 W
+0 0 M
+-50 14 D
+12 -14 D
+-12 -14 D
+P clip fs P S 
+U
+4 W
+V 2143 1319 T 59.2848 R
+N 0 0 M 55 0 D S
+U
+V 2183 1386 T 59.2848 R
+PSL_vecheadpen
+4 W
+0 0 M
+-31 8 D
+8 -8 D
+-8 -8 D
+P clip fs P S 
+U
+4 W
+V 2308 1319 T 113.052 R
+N 0 0 M 52 0 D S
+U
+V 2280 1386 T 113.052 R
+PSL_vecheadpen
+4 W
+0 0 M
+-29 8 D
+7 -8 D
+-7 -8 D
+P clip fs P S 
+U
+5 W
+V 2473 1319 T 141.122 R
+N 0 0 M 66 0 D S
+U
+V 2400 1378 T 141.122 R
+PSL_vecheadpen
+5 W
+0 0 M
+-37 10 D
+9 -10 D
+-9 -10 D
+P clip fs P S 
+U
+6 W
+V 2638 1319 T 152.91 R
+N 0 0 M 70 0 D S
+U
+V 2549 1364 T 152.91 R
+PSL_vecheadpen
+6 W
+0 0 M
+-39 11 D
+10 -11 D
+-10 -11 D
+P clip fs P S 
+U
+5 W
+V 2803 1319 T 159.073 R
+N 0 0 M 62 0 D S
+U
+V 2721 1350 T 159.073 R
+PSL_vecheadpen
+5 W
+0 0 M
+-35 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+4 W
+V 2968 1319 T 162.865 R
+N 0 0 M 47 0 D S
+U
+V 2904 1339 T 162.865 R
+PSL_vecheadpen
+4 W
+0 0 M
+-26 7 D
+6 -7 D
+-6 -7 D
+P clip fs P S 
+U
+2 W
+V 3133 1319 T 165.453 R
+N 0 0 M 32 0 D S
+U
+V 3089 1330 T 165.453 R
+PSL_vecheadpen
+2 W
+0 0 M
+-18 5 D
+5 -5 D
+-5 -5 D
+P clip fs P S 
+U
+2 W
+V 3297 1319 T 168.873 R
+N 0 0 M 21 0 D S
+U
+V 3268 1325 T 168.873 R
+PSL_vecheadpen
+2 W
+0 0 M
+-12 3 D
+3 -3 D
+-3 -3 D
+P clip fs P S 
+U
+1 W
+V 0 1154 T -163.542 R
+N 0 0 M 18 0 D S
+U
+V -24 1147 T -163.542 R
+PSL_vecheadpen
+1 W
+0 0 M
+-10 3 D
+3 -3 D
+-3 -3 D
+P clip fs P S 
+U
+2 W
+V 165 1154 T -158.707 R
+N 0 0 M 27 0 D S
+U
+V 129 1140 T -158.707 R
 PSL_vecheadpen
 2 W
 0 0 M
@@ -6527,720 +7089,178 @@ PSL_vecheadpen
 -4 -4 D
 P clip fs P S 
 U
-2 W
-V 0 1484 T -174.388 R
-N 0 0 M 26 0 D S
-U
-V -36 1480 T -174.388 R
-PSL_vecheadpen
-2 W
-0 0 M
--14 4 D
-3 -4 D
--3 -4 D
-P clip fs P S 
-U
-3 W
-V 165 1484 T -172.613 R
-N 0 0 M 37 0 D S
-U
-V 112 1477 T -172.613 R
-PSL_vecheadpen
-3 W
-0 0 M
--21 6 D
-5 -6 D
--5 -6 D
-P clip fs P S 
-U
-4 W
-V 330 1484 T -171.244 R
-N 0 0 M 55 0 D S
-U
-V 252 1472 T -171.244 R
-PSL_vecheadpen
-4 W
-0 0 M
--31 8 D
-8 -8 D
--8 -8 D
-P clip fs P S 
-U
-6 W
-V 495 1484 T -169.184 R
-N 0 0 M 72 0 D S
-U
-V 395 1465 T -169.184 R
-PSL_vecheadpen
-6 W
-0 0 M
--40 11 D
-10 -11 D
--10 -11 D
-P clip fs P S 
-U
-6 W
-V 659 1484 T -165.665 R
-N 0 0 M 78 0 D S
-U
-V 552 1456 T -165.665 R
-PSL_vecheadpen
-6 W
-0 0 M
--44 12 D
-11 -12 D
--11 -12 D
-P clip fs P S 
-U
-5 W
-V 824 1484 T -158.06 R
-N 0 0 M 67 0 D S
-U
-V 736 1448 T -158.06 R
-PSL_vecheadpen
-5 W
-0 0 M
--37 10 D
-9 -10 D
--9 -10 D
-P clip fs P S 
-U
-3 W
-V 989 1484 T -130.424 R
-N 0 0 M 38 0 D S
-U
-V 955 1443 T -130.424 R
-PSL_vecheadpen
-3 W
-0 0 M
--21 6 D
-5 -6 D
--5 -6 D
-P clip fs P S 
-U
-3 W
-V 1154 1484 T -40.061 R
-N 0 0 M 44 0 D S
-U
-V 1202 1443 T -40.061 R
-PSL_vecheadpen
-3 W
-0 0 M
--25 7 D
-6 -7 D
--6 -7 D
-P clip fs P S 
-U
-8 W
-V 1319 1484 T -13.1904 R
-N 0 0 M 102 0 D S
-U
-V 1460 1451 T -13.1904 R
-PSL_vecheadpen
-8 W
-0 0 M
--57 15 D
-14 -15 D
--14 -15 D
-P clip fs P S 
-U
-12 W
-V 1484 1484 T -4.96687 R
-N 0 0 M 151 0 D S
-U
-V 1698 1465 T -4.96687 R
-PSL_vecheadpen
-12 W
-0 0 M
--84 23 D
-21 -23 D
--21 -23 D
-P clip fs P S 
-U
-13 W
-V 1649 1484 T N 0 0 M 170 0 D S
-U
-V 1890 1484 T PSL_vecheadpen
-13 W
-0 0 M
--95 25 D
-24 -25 D
--24 -25 D
-P clip fs P S 
-U
-12 W
-V 1814 1484 T 4.96687 R
-N 0 0 M 151 0 D S
-U
-V 2027 1502 T 4.96687 R
-PSL_vecheadpen
-12 W
-0 0 M
--84 23 D
-21 -23 D
--21 -23 D
-P clip fs P S 
-U
-8 W
-V 1978 1484 T 13.1904 R
-N 0 0 M 102 0 D S
-U
-V 2119 1517 T 13.1904 R
-PSL_vecheadpen
-8 W
-0 0 M
--57 15 D
-14 -15 D
--14 -15 D
-P clip fs P S 
-U
-3 W
-V 2143 1484 T 40.061 R
-N 0 0 M 44 0 D S
-U
-V 2191 1524 T 40.061 R
-PSL_vecheadpen
-3 W
-0 0 M
--25 7 D
-6 -7 D
--6 -7 D
-P clip fs P S 
-U
-3 W
-V 2308 1484 T 130.424 R
-N 0 0 M 38 0 D S
-U
-V 2274 1525 T 130.424 R
-PSL_vecheadpen
-3 W
-0 0 M
--21 6 D
-5 -6 D
--5 -6 D
-P clip fs P S 
-U
-5 W
-V 2473 1484 T 158.06 R
-N 0 0 M 67 0 D S
-U
-V 2385 1519 T 158.06 R
-PSL_vecheadpen
-5 W
-0 0 M
--37 10 D
-9 -10 D
--9 -10 D
-P clip fs P S 
-U
-6 W
-V 2638 1484 T 165.665 R
-N 0 0 M 78 0 D S
-U
-V 2530 1511 T 165.665 R
-PSL_vecheadpen
-6 W
-0 0 M
--44 12 D
-11 -12 D
--11 -12 D
-P clip fs P S 
-U
-6 W
-V 2803 1484 T 169.184 R
-N 0 0 M 72 0 D S
-U
-V 2703 1503 T 169.184 R
-PSL_vecheadpen
-6 W
-0 0 M
--40 11 D
-10 -11 D
--10 -11 D
-P clip fs P S 
-U
-4 W
-V 2968 1484 T 171.244 R
-N 0 0 M 55 0 D S
-U
-V 2890 1496 T 171.244 R
-PSL_vecheadpen
-4 W
-0 0 M
--31 8 D
-8 -8 D
--8 -8 D
-P clip fs P S 
-U
-3 W
-V 3133 1484 T 172.613 R
-N 0 0 M 37 0 D S
-U
-V 3080 1491 T 172.613 R
-PSL_vecheadpen
-3 W
-0 0 M
--21 6 D
-5 -6 D
--5 -6 D
-P clip fs P S 
-U
-2 W
-V 3297 1484 T 174.388 R
-N 0 0 M 26 0 D S
-U
-V 3261 1487 T 174.388 R
-PSL_vecheadpen
-2 W
-0 0 M
--14 4 D
-3 -4 D
--3 -4 D
-P clip fs P S 
-U
-2 W
-V 0 1319 T -168.873 R
-N 0 0 M 23 0 D S
-U
-V -32 1313 T -168.873 R
-PSL_vecheadpen
-2 W
-0 0 M
--13 3 D
-3 -3 D
--3 -3 D
-P clip fs P S 
-U
-3 W
-V 165 1319 T -165.453 R
-N 0 0 M 34 0 D S
-U
-V 118 1307 T -165.453 R
-PSL_vecheadpen
-3 W
-0 0 M
--19 5 D
-5 -5 D
--5 -5 D
-P clip fs P S 
-U
-4 W
-V 330 1319 T -162.865 R
-N 0 0 M 51 0 D S
-U
-V 261 1298 T -162.865 R
-PSL_vecheadpen
-4 W
-0 0 M
--28 8 D
-7 -8 D
--7 -8 D
-P clip fs P S 
-U
-5 W
-V 495 1319 T -159.073 R
-N 0 0 M 67 0 D S
-U
-V 406 1285 T -159.073 R
-PSL_vecheadpen
-5 W
-0 0 M
--37 10 D
-9 -10 D
--9 -10 D
-P clip fs P S 
-U
-6 W
-V 659 1319 T -152.91 R
-N 0 0 M 76 0 D S
-U
-V 564 1270 T -152.91 R
-PSL_vecheadpen
-6 W
-0 0 M
--42 11 D
-10 -11 D
--10 -11 D
-P clip fs P S 
-U
-6 W
-V 824 1319 T -141.122 R
-N 0 0 M 71 0 D S
-U
-V 746 1256 T -141.122 R
-PSL_vecheadpen
-6 W
-0 0 M
--40 11 D
-10 -11 D
--10 -11 D
-P clip fs P S 
-U
-4 W
-V 989 1319 T -113.052 R
-N 0 0 M 55 0 D S
-U
-V 958 1247 T -113.052 R
-PSL_vecheadpen
-4 W
-0 0 M
--31 8 D
-8 -8 D
--8 -8 D
-P clip fs P S 
-U
-5 W
-V 1154 1319 T -59.2848 R
-N 0 0 M 59 0 D S
-U
-V 1197 1247 T -59.2848 R
-PSL_vecheadpen
-5 W
-0 0 M
--33 9 D
-8 -9 D
--8 -9 D
-P clip fs P S 
-U
-8 W
-V 1319 1319 T -25.1321 R
-N 0 0 M 97 0 D S
-U
-V 1444 1260 T -25.1321 R
-PSL_vecheadpen
-8 W
-0 0 M
--54 15 D
-13 -15 D
--13 -15 D
-P clip fs P S 
-U
-11 W
-V 1484 1319 T -9.86794 R
-N 0 0 M 136 0 D S
-U
-V 1673 1286 T -9.86794 R
-PSL_vecheadpen
-11 W
-0 0 M
--76 20 D
-19 -20 D
--19 -20 D
-P clip fs P S 
-U
-12 W
-V 1649 1319 T N 0 0 M 151 0 D S
-U
-V 1863 1319 T PSL_vecheadpen
-12 W
-0 0 M
--84 23 D
-21 -23 D
--21 -23 D
-P clip fs P S 
-U
-11 W
-V 1814 1319 T 9.86794 R
-N 0 0 M 136 0 D S
-U
-V 2003 1352 T 9.86794 R
-PSL_vecheadpen
-11 W
-0 0 M
--76 20 D
-19 -20 D
--19 -20 D
-P clip fs P S 
-U
-8 W
-V 1978 1319 T 25.1321 R
-N 0 0 M 97 0 D S
-U
-V 2103 1377 T 25.1321 R
-PSL_vecheadpen
-8 W
-0 0 M
--54 15 D
-13 -15 D
--13 -15 D
-P clip fs P S 
-U
-5 W
-V 2143 1319 T 59.2848 R
-N 0 0 M 59 0 D S
-U
-V 2186 1391 T 59.2848 R
-PSL_vecheadpen
-5 W
-0 0 M
--33 9 D
-8 -9 D
--8 -9 D
-P clip fs P S 
-U
-4 W
-V 2308 1319 T 113.052 R
-N 0 0 M 55 0 D S
-U
-V 2277 1391 T 113.052 R
-PSL_vecheadpen
-4 W
-0 0 M
--31 8 D
-8 -8 D
--8 -8 D
-P clip fs P S 
-U
-6 W
-V 2473 1319 T 141.122 R
-N 0 0 M 71 0 D S
-U
-V 2395 1382 T 141.122 R
-PSL_vecheadpen
-6 W
-0 0 M
--40 11 D
-10 -11 D
--10 -11 D
-P clip fs P S 
-U
-6 W
-V 2638 1319 T 152.91 R
-N 0 0 M 76 0 D S
-U
-V 2543 1368 T 152.91 R
-PSL_vecheadpen
-6 W
-0 0 M
--42 11 D
-10 -11 D
--10 -11 D
-P clip fs P S 
-U
-5 W
-V 2803 1319 T 159.073 R
-N 0 0 M 67 0 D S
-U
-V 2714 1353 T 159.073 R
-PSL_vecheadpen
-5 W
-0 0 M
--37 10 D
-9 -10 D
--9 -10 D
-P clip fs P S 
-U
-4 W
-V 2968 1319 T 162.865 R
-N 0 0 M 51 0 D S
-U
-V 2899 1340 T 162.865 R
-PSL_vecheadpen
-4 W
-0 0 M
--28 8 D
-7 -8 D
--7 -8 D
-P clip fs P S 
-U
-3 W
-V 3133 1319 T 165.453 R
-N 0 0 M 34 0 D S
-U
-V 3086 1331 T 165.453 R
-PSL_vecheadpen
-3 W
-0 0 M
--19 5 D
-5 -5 D
--5 -5 D
-P clip fs P S 
-U
-2 W
-V 3297 1319 T 168.873 R
-N 0 0 M 23 0 D S
-U
-V 3266 1325 T 168.873 R
-PSL_vecheadpen
-2 W
-0 0 M
--13 3 D
-3 -3 D
--3 -3 D
-P clip fs P S 
-U
-2 W
-V 0 1154 T -163.542 R
-N 0 0 M 19 0 D S
-U
-V -26 1146 T -163.542 R
-PSL_vecheadpen
-2 W
-0 0 M
--11 3 D
-3 -3 D
--3 -3 D
-P clip fs P S 
-U
-2 W
-V 165 1154 T -158.707 R
-N 0 0 M 29 0 D S
-U
-V 127 1139 T -158.707 R
-PSL_vecheadpen
-2 W
-0 0 M
--16 4 D
-4 -4 D
--4 -4 D
-P clip fs P S 
-U
 3 W
 V 330 1154 T -155.153 R
-N 0 0 M 44 0 D S
+N 0 0 M 41 0 D S
 U
-V 273 1128 T -155.153 R
+V 277 1130 T -155.153 R
 PSL_vecheadpen
 3 W
 0 0 M
--24 7 D
-6 -7 D
--6 -7 D
+-23 6 D
+6 -6 D
+-6 -6 D
 P clip fs P S 
 U
-5 W
+4 W
 V 495 1154 T -150.128 R
-N 0 0 M 59 0 D S
+N 0 0 M 55 0 D S
 U
-V 422 1113 T -150.128 R
+V 427 1115 T -150.128 R
 PSL_vecheadpen
-5 W
+4 W
 0 0 M
--33 9 D
-8 -9 D
--8 -9 D
+-31 8 D
+8 -8 D
+-8 -8 D
 P clip fs P S 
 U
 5 W
 V 659 1154 T -142.465 R
-N 0 0 M 69 0 D S
+N 0 0 M 65 0 D S
 U
-V 581 1094 T -142.465 R
+V 587 1098 T -142.465 R
 PSL_vecheadpen
 5 W
 0 0 M
--39 10 D
-10 -10 D
--10 -10 D
+-36 10 D
+9 -10 D
+-9 -10 D
 P clip fs P S 
 U
-6 W
+5 W
 V 824 1154 T -129.549 R
-N 0 0 M 71 0 D S
+N 0 0 M 66 0 D S
 U
-V 760 1076 T -129.549 R
+V 765 1082 T -129.549 R
 PSL_vecheadpen
-6 W
+5 W
 0 0 M
--40 11 D
-10 -11 D
--10 -11 D
+-37 10 D
+9 -10 D
+-9 -10 D
 P clip fs P S 
 U
 5 W
 V 989 1154 T -105.819 R
-N 0 0 M 65 0 D S
+N 0 0 M 61 0 D S
 U
-V 964 1065 T -105.819 R
+V 966 1071 T -105.819 R
 PSL_vecheadpen
 5 W
 0 0 M
--36 10 D
-9 -10 D
--9 -10 D
+-34 9 D
+9 -9 D
+-9 -9 D
 P clip fs P S 
 U
 5 W
 V 1154 1154 T -68.4188 R
-N 0 0 M 67 0 D S
+N 0 0 M 62 0 D S
 U
-V 1189 1066 T -68.4188 R
+V 1187 1072 T -68.4188 R
 PSL_vecheadpen
 5 W
 0 0 M
--37 10 D
-9 -10 D
--9 -10 D
+-35 9 D
+9 -9 D
+-9 -9 D
 P clip fs P S 
 U
-7 W
+6 W
 V 1319 1154 T -35.1691 R
-N 0 0 M 88 0 D S
+N 0 0 M 82 0 D S
 U
-V 1421 1082 T -35.1691 R
+V 1414 1087 T -35.1691 R
 PSL_vecheadpen
-7 W
+6 W
 0 0 M
--49 13 D
-12 -13 D
--12 -13 D
+-46 12 D
+12 -12 D
+-12 -12 D
 P clip fs P S 
 U
-9 W
+8 W
 V 1484 1154 T -14.6426 R
-N 0 0 M 113 0 D S
+N 0 0 M 105 0 D S
 U
-V 1639 1114 T -14.6426 R
+V 1628 1116 T -14.6426 R
 PSL_vecheadpen
+8 W
+0 0 M
+-59 16 D
+15 -16 D
+-15 -16 D
+P clip fs P S 
+U
+9 W
+V 1649 1154 T N 0 0 M 115 0 D S
+U
+V 1812 1154 T PSL_vecheadpen
 9 W
 0 0 M
--63 17 D
+-64 17 D
 16 -17 D
 -16 -17 D
 P clip fs P S 
 U
-10 W
-V 1649 1154 T N 0 0 M 124 0 D S
-U
-V 1824 1154 T PSL_vecheadpen
-10 W
-0 0 M
--69 19 D
-17 -19 D
--17 -19 D
-P clip fs P S 
-U
-9 W
+8 W
 V 1814 1154 T 14.6426 R
-N 0 0 M 113 0 D S
+N 0 0 M 105 0 D S
 U
-V 1969 1195 T 14.6426 R
+V 1958 1192 T 14.6426 R
 PSL_vecheadpen
-9 W
+8 W
 0 0 M
--63 17 D
-16 -17 D
--16 -17 D
+-59 16 D
+15 -16 D
+-15 -16 D
 P clip fs P S 
 U
-7 W
+6 W
 V 1978 1154 T 35.1691 R
-N 0 0 M 88 0 D S
+N 0 0 M 82 0 D S
 U
-V 2081 1226 T 35.1691 R
+V 2073 1221 T 35.1691 R
 PSL_vecheadpen
-7 W
+6 W
 0 0 M
--49 13 D
-12 -13 D
--12 -13 D
+-46 12 D
+12 -12 D
+-12 -12 D
 P clip fs P S 
 U
 5 W
 V 2143 1154 T 68.4188 R
-N 0 0 M 67 0 D S
+N 0 0 M 62 0 D S
 U
-V 2178 1242 T 68.4188 R
+V 2176 1236 T 68.4188 R
+PSL_vecheadpen
+5 W
+0 0 M
+-35 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+5 W
+V 2308 1154 T 105.819 R
+N 0 0 M 61 0 D S
+U
+V 2285 1237 T 105.819 R
+PSL_vecheadpen
+5 W
+0 0 M
+-34 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+5 W
+V 2473 1154 T 129.549 R
+N 0 0 M 66 0 D S
+U
+V 2413 1226 T 129.549 R
 PSL_vecheadpen
 5 W
 0 0 M
@@ -7250,10 +7270,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 5 W
-V 2308 1154 T 105.819 R
+V 2638 1154 T 142.465 R
 N 0 0 M 65 0 D S
 U
-V 2283 1243 T 105.819 R
+V 2565 1210 T 142.465 R
 PSL_vecheadpen
 5 W
 0 0 M
@@ -7262,89 +7282,63 @@ PSL_vecheadpen
 -9 -10 D
 P clip fs P S 
 U
-6 W
-V 2473 1154 T 129.549 R
-N 0 0 M 71 0 D S
-U
-V 2409 1232 T 129.549 R
-PSL_vecheadpen
-6 W
-0 0 M
--40 11 D
-10 -11 D
--10 -11 D
-P clip fs P S 
-U
-5 W
-V 2638 1154 T 142.465 R
-N 0 0 M 69 0 D S
-U
-V 2560 1214 T 142.465 R
-PSL_vecheadpen
-5 W
-0 0 M
--39 10 D
-10 -10 D
--10 -10 D
-P clip fs P S 
-U
-5 W
+4 W
 V 2803 1154 T 150.128 R
-N 0 0 M 59 0 D S
+N 0 0 M 55 0 D S
 U
-V 2730 1196 T 150.128 R
+V 2735 1193 T 150.128 R
 PSL_vecheadpen
-5 W
+4 W
 0 0 M
--33 9 D
-8 -9 D
--8 -9 D
+-31 8 D
+8 -8 D
+-8 -8 D
 P clip fs P S 
 U
 3 W
 V 2968 1154 T 155.153 R
-N 0 0 M 44 0 D S
+N 0 0 M 41 0 D S
 U
-V 2911 1180 T 155.153 R
+V 2915 1178 T 155.153 R
 PSL_vecheadpen
 3 W
 0 0 M
--24 7 D
-6 -7 D
--6 -7 D
+-23 6 D
+6 -6 D
+-6 -6 D
 P clip fs P S 
 U
 2 W
 V 3133 1154 T 158.707 R
-N 0 0 M 29 0 D S
+N 0 0 M 27 0 D S
 U
-V 3094 1169 T 158.707 R
+V 3097 1168 T 158.707 R
 PSL_vecheadpen
 2 W
 0 0 M
--16 4 D
+-15 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
-2 W
+1 W
 V 3297 1154 T 163.542 R
-N 0 0 M 19 0 D S
+N 0 0 M 18 0 D S
 U
-V 3271 1162 T 163.542 R
+V 3273 1161 T 163.542 R
 PSL_vecheadpen
-2 W
+1 W
 0 0 M
--11 3 D
+-10 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 1 W
 V 0 989 T -158.465 R
-N 0 0 M 15 0 D S
+N 0 0 M 14 0 D S
 U
-V -20 981 T -158.465 R
+V -18 982 T -158.465 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -7355,254 +7349,254 @@ P clip fs P S
 U
 2 W
 V 165 989 T -152.497 R
-N 0 0 M 23 0 D S
+N 0 0 M 21 0 D S
 U
-V 136 974 T -152.497 R
+V 138 975 T -152.497 R
 PSL_vecheadpen
 2 W
 0 0 M
--13 3 D
+-12 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 3 W
 V 330 989 T -148.26 R
-N 0 0 M 35 0 D S
+N 0 0 M 33 0 D S
 U
-V 287 963 T -148.26 R
+V 290 965 T -148.26 R
 PSL_vecheadpen
 3 W
 0 0 M
--20 5 D
-5 -5 D
--5 -5 D
+-18 5 D
+4 -5 D
+-4 -5 D
 P clip fs P S 
 U
 4 W
 V 495 989 T -142.503 R
-N 0 0 M 49 0 D S
+N 0 0 M 45 0 D S
 U
-V 440 947 T -142.503 R
+V 444 950 T -142.503 R
 PSL_vecheadpen
 4 W
 0 0 M
--27 7 D
-7 -7 D
--7 -7 D
+-25 7 D
+6 -7 D
+-6 -7 D
 P clip fs P S 
 U
-5 W
+4 W
 V 659 989 T -134.256 R
-N 0 0 M 60 0 D S
+N 0 0 M 55 0 D S
 U
-V 600 929 T -134.256 R
+V 605 933 T -134.256 R
 PSL_vecheadpen
-5 W
+4 W
 0 0 M
--33 9 D
-8 -9 D
--8 -9 D
+-31 8 D
+8 -8 D
+-8 -8 D
 P clip fs P S 
 U
 5 W
 V 824 989 T -121.723 R
-N 0 0 M 65 0 D S
+N 0 0 M 60 0 D S
 U
-V 776 911 T -121.723 R
+V 779 916 T -121.723 R
 PSL_vecheadpen
 5 W
 0 0 M
--36 10 D
-9 -10 D
--9 -10 D
+-34 9 D
+9 -9 D
+-9 -9 D
 P clip fs P S 
 U
 5 W
 V 989 989 T -101.975 R
-N 0 0 M 65 0 D S
+N 0 0 M 60 0 D S
 U
-V 970 899 T -101.975 R
+V 972 906 T -101.975 R
 PSL_vecheadpen
 5 W
 0 0 M
--36 10 D
-9 -10 D
--9 -10 D
+-34 9 D
+9 -9 D
+-9 -9 D
 P clip fs P S 
 U
 5 W
 V 1154 989 T -73.5055 R
-N 0 0 M 66 0 D S
+N 0 0 M 61 0 D S
 U
-V 1181 900 T -73.5055 R
+V 1179 906 T -73.5055 R
 PSL_vecheadpen
 5 W
 0 0 M
--37 10 D
-10 -10 D
--10 -10 D
-P clip fs P S 
-U
-6 W
-V 1319 989 T -43.2662 R
-N 0 0 M 75 0 D S
-U
-V 1396 917 T -43.2662 R
-PSL_vecheadpen
-6 W
-0 0 M
--42 11 D
-11 -11 D
--11 -11 D
-P clip fs P S 
-U
-7 W
-V 1484 989 T -19.2398 R
-N 0 0 M 88 0 D S
-U
-V 1601 948 T -19.2398 R
-PSL_vecheadpen
-7 W
-0 0 M
--49 13 D
-12 -13 D
--12 -13 D
-P clip fs P S 
-U
-7 W
-V 1649 989 T N 0 0 M 93 0 D S
-U
-V 1781 989 T PSL_vecheadpen
-7 W
-0 0 M
--52 14 D
-13 -14 D
--13 -14 D
-P clip fs P S 
-U
-7 W
-V 1814 989 T 19.2398 R
-N 0 0 M 88 0 D S
-U
-V 1931 1030 T 19.2398 R
-PSL_vecheadpen
-7 W
-0 0 M
--49 13 D
-12 -13 D
--12 -13 D
-P clip fs P S 
-U
-6 W
-V 1978 989 T 43.2662 R
-N 0 0 M 75 0 D S
-U
-V 2056 1062 T 43.2662 R
-PSL_vecheadpen
-6 W
-0 0 M
--42 11 D
-11 -11 D
--11 -11 D
-P clip fs P S 
-U
-5 W
-V 2143 989 T 73.5055 R
-N 0 0 M 66 0 D S
-U
-V 2170 1078 T 73.5055 R
-PSL_vecheadpen
-5 W
-0 0 M
--37 10 D
-10 -10 D
--10 -10 D
-P clip fs P S 
-U
-5 W
-V 2308 989 T 101.975 R
-N 0 0 M 65 0 D S
-U
-V 2289 1079 T 101.975 R
-PSL_vecheadpen
-5 W
-0 0 M
--36 10 D
-9 -10 D
--9 -10 D
-P clip fs P S 
-U
-5 W
-V 2473 989 T 121.723 R
-N 0 0 M 65 0 D S
-U
-V 2425 1068 T 121.723 R
-PSL_vecheadpen
-5 W
-0 0 M
--36 10 D
-9 -10 D
--9 -10 D
-P clip fs P S 
-U
-5 W
-V 2638 989 T 134.256 R
-N 0 0 M 60 0 D S
-U
-V 2579 1050 T 134.256 R
-PSL_vecheadpen
-5 W
-0 0 M
--33 9 D
+-34 9 D
 8 -9 D
 -8 -9 D
 P clip fs P S 
 U
-4 W
-V 2803 989 T 142.503 R
-N 0 0 M 49 0 D S
+5 W
+V 1319 989 T -43.2662 R
+N 0 0 M 69 0 D S
 U
-V 2748 1031 T 142.503 R
+V 1391 922 T -43.2662 R
+PSL_vecheadpen
+5 W
+0 0 M
+-39 10 D
+10 -10 D
+-10 -10 D
+P clip fs P S 
+U
+6 W
+V 1484 989 T -19.2398 R
+N 0 0 M 81 0 D S
+U
+V 1593 951 T -19.2398 R
+PSL_vecheadpen
+6 W
+0 0 M
+-45 12 D
+11 -12 D
+-11 -12 D
+P clip fs P S 
+U
+7 W
+V 1649 989 T N 0 0 M 87 0 D S
+U
+V 1772 989 T PSL_vecheadpen
+7 W
+0 0 M
+-49 13 D
+13 -13 D
+-13 -13 D
+P clip fs P S 
+U
+6 W
+V 1814 989 T 19.2398 R
+N 0 0 M 81 0 D S
+U
+V 1923 1027 T 19.2398 R
+PSL_vecheadpen
+6 W
+0 0 M
+-45 12 D
+11 -12 D
+-11 -12 D
+P clip fs P S 
+U
+5 W
+V 1978 989 T 43.2662 R
+N 0 0 M 69 0 D S
+U
+V 2050 1057 T 43.2662 R
+PSL_vecheadpen
+5 W
+0 0 M
+-39 10 D
+10 -10 D
+-10 -10 D
+P clip fs P S 
+U
+5 W
+V 2143 989 T 73.5055 R
+N 0 0 M 61 0 D S
+U
+V 2168 1072 T 73.5055 R
+PSL_vecheadpen
+5 W
+0 0 M
+-34 9 D
+8 -9 D
+-8 -9 D
+P clip fs P S 
+U
+5 W
+V 2308 989 T 101.975 R
+N 0 0 M 60 0 D S
+U
+V 2291 1073 T 101.975 R
+PSL_vecheadpen
+5 W
+0 0 M
+-34 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+5 W
+V 2473 989 T 121.723 R
+N 0 0 M 60 0 D S
+U
+V 2428 1062 T 121.723 R
+PSL_vecheadpen
+5 W
+0 0 M
+-34 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+4 W
+V 2638 989 T 134.256 R
+N 0 0 M 55 0 D S
+U
+V 2583 1046 T 134.256 R
 PSL_vecheadpen
 4 W
 0 0 M
--27 7 D
-7 -7 D
--7 -7 D
+-31 8 D
+8 -8 D
+-8 -8 D
+P clip fs P S 
+U
+4 W
+V 2803 989 T 142.503 R
+N 0 0 M 45 0 D S
+U
+V 2752 1028 T 142.503 R
+PSL_vecheadpen
+4 W
+0 0 M
+-25 7 D
+6 -7 D
+-6 -7 D
 P clip fs P S 
 U
 3 W
 V 2968 989 T 148.26 R
-N 0 0 M 35 0 D S
+N 0 0 M 33 0 D S
 U
-V 2925 1016 T 148.26 R
+V 2928 1014 T 148.26 R
 PSL_vecheadpen
 3 W
 0 0 M
--20 5 D
-5 -5 D
--5 -5 D
+-18 5 D
+4 -5 D
+-4 -5 D
 P clip fs P S 
 U
 2 W
 V 3133 989 T 152.497 R
-N 0 0 M 23 0 D S
+N 0 0 M 21 0 D S
 U
-V 3104 1004 T 152.497 R
+V 3106 1003 T 152.497 R
 PSL_vecheadpen
 2 W
 0 0 M
--13 3 D
+-12 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 1 W
 V 3297 989 T 158.465 R
-N 0 0 M 15 0 D S
+N 0 0 M 14 0 D S
 U
-V 3278 997 T 158.465 R
+V 3279 997 T 158.465 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -7613,202 +7607,163 @@ P clip fs P S
 U
 1 W
 V 0 824 T -153.689 R
-N 0 0 M 11 0 D S
+N 0 0 M 10 0 D S
 U
-V -14 818 T -153.689 R
+V -13 818 T -153.689 R
 PSL_vecheadpen
 1 W
 0 0 M
 -6 2 D
-1 -2 D
--1 -2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 165 824 T -146.882 R
-N 0 0 M 17 0 D S
+N 0 0 M 16 0 D S
 U
-V 145 811 T -146.882 R
+V 146 812 T -146.882 R
 PSL_vecheadpen
 1 W
 0 0 M
--9 3 D
-2 -3 D
--2 -3 D
+-9 2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 2 W
 V 330 824 T -142.221 R
-N 0 0 M 27 0 D S
+N 0 0 M 25 0 D S
 U
-V 300 801 T -142.221 R
+V 302 803 T -142.221 R
 PSL_vecheadpen
 2 W
 0 0 M
--15 4 D
+-14 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
 3 W
 V 495 824 T -136.128 R
-N 0 0 M 37 0 D S
+N 0 0 M 35 0 D S
 U
-V 456 788 T -136.128 R
+V 459 790 T -136.128 R
 PSL_vecheadpen
 3 W
 0 0 M
--21 6 D
-5 -6 D
--5 -6 D
+-19 5 D
+4 -5 D
+-4 -5 D
 P clip fs P S 
 U
-4 W
+3 W
 V 659 824 T -127.87 R
-N 0 0 M 47 0 D S
+N 0 0 M 44 0 D S
 U
-V 618 771 T -127.87 R
+V 621 775 T -127.87 R
 PSL_vecheadpen
-4 W
+3 W
 0 0 M
--26 7 D
-6 -7 D
--6 -7 D
+-25 7 D
+7 -7 D
+-7 -7 D
 P clip fs P S 
 U
 4 W
 V 824 824 T -116.259 R
-N 0 0 M 54 0 D S
+N 0 0 M 50 0 D S
 U
-V 791 756 T -116.259 R
+V 793 761 T -116.259 R
 PSL_vecheadpen
 4 W
 0 0 M
--30 8 D
-7 -8 D
--7 -8 D
+-28 7 D
+7 -7 D
+-7 -7 D
 P clip fs P S 
 U
 4 W
 V 989 824 T -99.6074 R
-N 0 0 M 56 0 D S
+N 0 0 M 52 0 D S
 U
-V 976 746 T -99.6074 R
+V 977 751 T -99.6074 R
 PSL_vecheadpen
 4 W
 0 0 M
--31 8 D
+-29 8 D
 7 -8 D
 -7 -8 D
 P clip fs P S 
 U
 4 W
 V 1154 824 T -76.7038 R
-N 0 0 M 56 0 D S
+N 0 0 M 53 0 D S
 U
-V 1173 746 T -76.7038 R
+V 1171 752 T -76.7038 R
 PSL_vecheadpen
 4 W
 0 0 M
--32 8 D
-8 -8 D
--8 -8 D
-P clip fs P S 
-U
-5 W
-V 1319 824 T -49.705 R
-N 0 0 M 59 0 D S
-U
-V 1373 761 T -49.705 R
-PSL_vecheadpen
-5 W
-0 0 M
--33 9 D
-8 -9 D
--8 -9 D
-P clip fs P S 
-U
-5 W
-V 1484 824 T -23.6206 R
-N 0 0 M 63 0 D S
-U
-V 1566 789 T -23.6206 R
-PSL_vecheadpen
-5 W
-0 0 M
--35 9 D
-9 -9 D
--9 -9 D
-P clip fs P S 
-U
-5 W
-V 1649 824 T N 0 0 M 65 0 D S
-U
-V 1741 824 T PSL_vecheadpen
-5 W
-0 0 M
--36 10 D
-9 -10 D
--9 -10 D
-P clip fs P S 
-U
-5 W
-V 1814 824 T 23.6206 R
-N 0 0 M 63 0 D S
-U
-V 1895 860 T 23.6206 R
-PSL_vecheadpen
-5 W
-0 0 M
--35 9 D
-9 -9 D
--9 -9 D
-P clip fs P S 
-U
-5 W
-V 1978 824 T 49.705 R
-N 0 0 M 59 0 D S
-U
-V 2032 888 T 49.705 R
-PSL_vecheadpen
-5 W
-0 0 M
--33 9 D
-8 -9 D
--8 -9 D
-P clip fs P S 
-U
-4 W
-V 2143 824 T 76.7038 R
-N 0 0 M 56 0 D S
-U
-V 2162 902 T 76.7038 R
-PSL_vecheadpen
-4 W
-0 0 M
--32 8 D
-8 -8 D
--8 -8 D
-P clip fs P S 
-U
-4 W
-V 2308 824 T 99.6074 R
-N 0 0 M 56 0 D S
-U
-V 2295 903 T 99.6074 R
-PSL_vecheadpen
-4 W
-0 0 M
--31 8 D
+-29 8 D
 7 -8 D
 -7 -8 D
 P clip fs P S 
 U
 4 W
-V 2473 824 T 116.259 R
-N 0 0 M 54 0 D S
+V 1319 824 T -49.705 R
+N 0 0 M 55 0 D S
 U
-V 2439 893 T 116.259 R
+V 1369 765 T -49.705 R
+PSL_vecheadpen
+4 W
+0 0 M
+-30 8 D
+7 -8 D
+-7 -8 D
+P clip fs P S 
+U
+5 W
+V 1484 824 T -23.6206 R
+N 0 0 M 59 0 D S
+U
+V 1560 791 T -23.6206 R
+PSL_vecheadpen
+5 W
+0 0 M
+-33 9 D
+8 -9 D
+-8 -9 D
+P clip fs P S 
+U
+5 W
+V 1649 824 T N 0 0 M 61 0 D S
+U
+V 1735 824 T PSL_vecheadpen
+5 W
+0 0 M
+-34 9 D
+9 -9 D
+-9 -9 D
+P clip fs P S 
+U
+5 W
+V 1814 824 T 23.6206 R
+N 0 0 M 59 0 D S
+U
+V 1890 858 T 23.6206 R
+PSL_vecheadpen
+5 W
+0 0 M
+-33 9 D
+8 -9 D
+-8 -9 D
+P clip fs P S 
+U
+4 W
+V 1978 824 T 49.705 R
+N 0 0 M 55 0 D S
+U
+V 2029 883 T 49.705 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7818,75 +7773,114 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V 2638 824 T 127.87 R
-N 0 0 M 47 0 D S
+V 2143 824 T 76.7038 R
+N 0 0 M 53 0 D S
 U
-V 2597 877 T 127.87 R
+V 2160 897 T 76.7038 R
 PSL_vecheadpen
 4 W
 0 0 M
--26 7 D
-6 -7 D
--6 -7 D
+-29 8 D
+7 -8 D
+-7 -8 D
+P clip fs P S 
+U
+4 W
+V 2308 824 T 99.6074 R
+N 0 0 M 52 0 D S
+U
+V 2296 897 T 99.6074 R
+PSL_vecheadpen
+4 W
+0 0 M
+-29 8 D
+7 -8 D
+-7 -8 D
+P clip fs P S 
+U
+4 W
+V 2473 824 T 116.259 R
+N 0 0 M 50 0 D S
+U
+V 2442 888 T 116.259 R
+PSL_vecheadpen
+4 W
+0 0 M
+-28 7 D
+7 -7 D
+-7 -7 D
+P clip fs P S 
+U
+3 W
+V 2638 824 T 127.87 R
+N 0 0 M 44 0 D S
+U
+V 2600 874 T 127.87 R
+PSL_vecheadpen
+3 W
+0 0 M
+-25 7 D
+7 -7 D
+-7 -7 D
 P clip fs P S 
 U
 3 W
 V 2803 824 T 136.128 R
-N 0 0 M 37 0 D S
+N 0 0 M 35 0 D S
 U
-V 2765 861 T 136.128 R
+V 2767 859 T 136.128 R
 PSL_vecheadpen
 3 W
 0 0 M
--21 6 D
-5 -6 D
--5 -6 D
+-19 5 D
+4 -5 D
+-4 -5 D
 P clip fs P S 
 U
 2 W
 V 2968 824 T 142.221 R
-N 0 0 M 27 0 D S
+N 0 0 M 25 0 D S
 U
-V 2938 847 T 142.221 R
+V 2940 846 T 142.221 R
 PSL_vecheadpen
 2 W
 0 0 M
--15 4 D
+-14 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
 1 W
 V 3133 824 T 146.882 R
-N 0 0 M 17 0 D S
+N 0 0 M 16 0 D S
 U
-V 3112 838 T 146.882 R
+V 3114 837 T 146.882 R
 PSL_vecheadpen
 1 W
 0 0 M
--9 3 D
-2 -3 D
--2 -3 D
+-9 2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 3297 824 T 153.689 R
-N 0 0 M 11 0 D S
+N 0 0 M 10 0 D S
 U
-V 3284 831 T 153.689 R
+V 3285 831 T 153.689 R
 PSL_vecheadpen
 1 W
 0 0 M
 -6 2 D
-1 -2 D
--1 -2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 0 659 T -149.244 R
 N 0 0 M 7 0 D S
 U
-V -9 654 T -149.244 R
+V -8 655 T -149.244 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -7897,9 +7891,9 @@ P clip fs P S
 U
 1 W
 V 165 659 T -141.864 R
-N 0 0 M 12 0 D S
+N 0 0 M 11 0 D S
 U
-V 152 649 T -141.864 R
+V 153 650 T -141.864 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -7910,176 +7904,163 @@ P clip fs P S
 U
 1 W
 V 330 659 T -136.991 R
-N 0 0 M 18 0 D S
+N 0 0 M 17 0 D S
 U
-V 311 642 T -136.991 R
+V 312 643 T -136.991 R
 PSL_vecheadpen
 1 W
 0 0 M
 -10 3 D
-2 -3 D
--2 -3 D
+3 -3 D
+-3 -3 D
 P clip fs P S 
 U
 2 W
 V 495 659 T -130.836 R
-N 0 0 M 27 0 D S
+N 0 0 M 25 0 D S
 U
-V 470 631 T -130.836 R
+V 472 633 T -130.836 R
 PSL_vecheadpen
 2 W
 0 0 M
--15 4 D
+-14 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
 3 W
 V 659 659 T -122.868 R
-N 0 0 M 34 0 D S
+N 0 0 M 32 0 D S
 U
-V 633 618 T -122.868 R
+V 635 621 T -122.868 R
 PSL_vecheadpen
 3 W
 0 0 M
--19 5 D
+-18 5 D
 5 -5 D
 -5 -5 D
 P clip fs P S 
 U
 3 W
 V 824 659 T -112.29 R
-N 0 0 M 40 0 D S
+N 0 0 M 38 0 D S
 U
-V 803 606 T -112.29 R
+V 804 610 T -112.29 R
 PSL_vecheadpen
 3 W
 0 0 M
--23 6 D
-6 -6 D
--6 -6 D
+-21 6 D
+5 -6 D
+-5 -6 D
 P clip fs P S 
 U
 3 W
 V 989 659 T -98.0059 R
-N 0 0 M 43 0 D S
+N 0 0 M 40 0 D S
 U
-V 981 599 T -98.0059 R
+V 981 603 T -98.0059 R
 PSL_vecheadpen
 3 W
 0 0 M
--24 6 D
+-23 6 D
 6 -6 D
 -6 -6 D
 P clip fs P S 
 U
 3 W
 V 1154 659 T -78.8908 R
-N 0 0 M 43 0 D S
+N 0 0 M 40 0 D S
 U
-V 1166 599 T -78.8908 R
+V 1165 603 T -78.8908 R
 PSL_vecheadpen
 3 W
 0 0 M
--24 6 D
+-23 6 D
 6 -6 D
 -6 -6 D
 P clip fs P S 
 U
 3 W
 V 1319 659 T -54.8342 R
-N 0 0 M 42 0 D S
+N 0 0 M 39 0 D S
 U
-V 1354 610 T -54.8342 R
+V 1351 614 T -54.8342 R
 PSL_vecheadpen
 3 W
 0 0 M
--24 6 D
-6 -6 D
--6 -6 D
+-22 6 D
+5 -6 D
+-5 -6 D
 P clip fs P S 
 U
 3 W
 V 1484 659 T -27.7586 R
-N 0 0 M 42 0 D S
+N 0 0 M 39 0 D S
 U
-V 1537 632 T -27.7586 R
+V 1533 634 T -27.7586 R
 PSL_vecheadpen
 3 W
 0 0 M
--23 6 D
-5 -6 D
--5 -6 D
-P clip fs P S 
-U
-3 W
-V 1649 659 T N 0 0 M 42 0 D S
-U
-V 1708 659 T PSL_vecheadpen
-3 W
-0 0 M
--23 6 D
-5 -6 D
--5 -6 D
-P clip fs P S 
-U
-3 W
-V 1814 659 T 27.7586 R
-N 0 0 M 42 0 D S
-U
-V 1866 687 T 27.7586 R
-PSL_vecheadpen
-3 W
-0 0 M
--23 6 D
-5 -6 D
--5 -6 D
-P clip fs P S 
-U
-3 W
-V 1978 659 T 54.8342 R
-N 0 0 M 42 0 D S
-U
-V 2013 709 T 54.8342 R
-PSL_vecheadpen
-3 W
-0 0 M
--24 6 D
+-22 6 D
 6 -6 D
 -6 -6 D
 P clip fs P S 
 U
 3 W
-V 2143 659 T 78.8908 R
-N 0 0 M 43 0 D S
+V 1649 659 T N 0 0 M 39 0 D S
 U
-V 2155 720 T 78.8908 R
+V 1704 659 T PSL_vecheadpen
+3 W
+0 0 M
+-22 6 D
+6 -6 D
+-6 -6 D
+P clip fs P S 
+U
+3 W
+V 1814 659 T 27.7586 R
+N 0 0 M 39 0 D S
+U
+V 1863 685 T 27.7586 R
 PSL_vecheadpen
 3 W
 0 0 M
--24 6 D
+-22 6 D
+6 -6 D
+-6 -6 D
+P clip fs P S 
+U
+3 W
+V 1978 659 T 54.8342 R
+N 0 0 M 39 0 D S
+U
+V 2011 705 T 54.8342 R
+PSL_vecheadpen
+3 W
+0 0 M
+-22 6 D
+5 -6 D
+-5 -6 D
+P clip fs P S 
+U
+3 W
+V 2143 659 T 78.8908 R
+N 0 0 M 40 0 D S
+U
+V 2154 716 T 78.8908 R
+PSL_vecheadpen
+3 W
+0 0 M
+-23 6 D
 6 -6 D
 -6 -6 D
 P clip fs P S 
 U
 3 W
 V 2308 659 T 98.0059 R
-N 0 0 M 43 0 D S
-U
-V 2300 720 T 98.0059 R
-PSL_vecheadpen
-3 W
-0 0 M
--24 6 D
-6 -6 D
--6 -6 D
-P clip fs P S 
-U
-3 W
-V 2473 659 T 112.29 R
 N 0 0 M 40 0 D S
 U
-V 2451 713 T 112.29 R
+V 2300 716 T 98.0059 R
 PSL_vecheadpen
 3 W
 0 0 M
@@ -8089,49 +8070,62 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V 2638 659 T 122.868 R
-N 0 0 M 34 0 D S
+V 2473 659 T 112.29 R
+N 0 0 M 38 0 D S
 U
-V 2611 701 T 122.868 R
+V 2453 709 T 112.29 R
 PSL_vecheadpen
 3 W
 0 0 M
--19 5 D
+-21 6 D
+5 -6 D
+-5 -6 D
+P clip fs P S 
+U
+3 W
+V 2638 659 T 122.868 R
+N 0 0 M 32 0 D S
+U
+V 2613 698 T 122.868 R
+PSL_vecheadpen
+3 W
+0 0 M
+-18 5 D
 5 -5 D
 -5 -5 D
 P clip fs P S 
 U
 2 W
 V 2803 659 T 130.836 R
-N 0 0 M 27 0 D S
+N 0 0 M 25 0 D S
 U
-V 2778 688 T 130.836 R
+V 2780 686 T 130.836 R
 PSL_vecheadpen
 2 W
 0 0 M
--15 4 D
+-14 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
 1 W
 V 2968 659 T 136.991 R
-N 0 0 M 18 0 D S
+N 0 0 M 17 0 D S
 U
-V 2949 677 T 136.991 R
+V 2950 676 T 136.991 R
 PSL_vecheadpen
 1 W
 0 0 M
 -10 3 D
-2 -3 D
--2 -3 D
+3 -3 D
+-3 -3 D
 P clip fs P S 
 U
 1 W
 V 3133 659 T 141.864 R
-N 0 0 M 12 0 D S
+N 0 0 M 11 0 D S
 U
-V 3120 670 T 141.864 R
+V 3121 669 T 141.864 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8144,7 +8138,7 @@ U
 V 3297 659 T 149.244 R
 N 0 0 M 7 0 D S
 U
-V 3289 665 T 149.244 R
+V 3289 664 T 149.244 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8155,22 +8149,21 @@ P clip fs P S
 U
 0 W
 V 0 495 T -145.136 R
-N 0 0 M 5 0 D S
+N 0 0 M 4 0 D S
 U
 V -5 491 T -145.136 R
 PSL_vecheadpen
 0 W
 0 0 M
--3 1 D
-1 -1 D
--1 -1 D
+-2 1 D
+0 -2 D
 P clip fs P S 
 U
 1 W
 V 165 495 T -137.413 R
 N 0 0 M 7 0 D S
 U
-V 157 488 T -137.413 R
+V 158 488 T -137.413 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8181,190 +8174,112 @@ P clip fs P S
 U
 1 W
 V 330 495 T -132.481 R
-N 0 0 M 12 0 D S
+N 0 0 M 11 0 D S
 U
-V 318 482 T -132.481 R
+V 319 483 T -132.481 R
 PSL_vecheadpen
 1 W
 0 0 M
--7 2 D
-2 -2 D
--2 -2 D
+-6 2 D
+1 -2 D
+-1 -2 D
 P clip fs P S 
 U
 1 W
 V 495 495 T -126.437 R
-N 0 0 M 17 0 D S
+N 0 0 M 16 0 D S
 U
-V 480 475 T -126.437 R
+V 481 476 T -126.437 R
 PSL_vecheadpen
 1 W
 0 0 M
--10 3 D
-3 -3 D
--3 -3 D
+-9 2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 2 W
 V 659 495 T -118.895 R
-N 0 0 M 23 0 D S
+N 0 0 M 21 0 D S
 U
-V 644 466 T -118.895 R
+V 645 468 T -118.895 R
 PSL_vecheadpen
 2 W
 0 0 M
--13 3 D
+-12 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 2 W
 V 824 495 T -109.298 R
-N 0 0 M 28 0 D S
+N 0 0 M 26 0 D S
 U
-V 811 458 T -109.298 R
+V 812 460 T -109.298 R
 PSL_vecheadpen
 2 W
 0 0 M
--15 4 D
+-14 4 D
 3 -4 D
 -3 -4 D
 P clip fs P S 
 U
 2 W
 V 989 495 T -96.8506 R
-N 0 0 M 30 0 D S
+N 0 0 M 28 0 D S
 U
-V 984 452 T -96.8506 R
+V 985 455 T -96.8506 R
 PSL_vecheadpen
 2 W
 0 0 M
--17 5 D
-4 -5 D
--4 -5 D
+-16 4 D
+4 -4 D
+-4 -4 D
 P clip fs P S 
 U
 2 W
 V 1154 495 T -80.4785 R
-N 0 0 M 30 0 D S
+N 0 0 M 28 0 D S
 U
-V 1161 453 T -80.4785 R
+V 1161 456 T -80.4785 R
 PSL_vecheadpen
 2 W
 0 0 M
--17 4 D
+-16 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
 2 W
 V 1319 495 T -58.9604 R
-N 0 0 M 28 0 D S
+N 0 0 M 26 0 D S
 U
-V 1340 460 T -58.9604 R
+V 1338 463 T -58.9604 R
 PSL_vecheadpen
 2 W
 0 0 M
--16 4 D
+-15 4 D
 4 -4 D
 -4 -4 D
 P clip fs P S 
 U
 2 W
 V 1484 495 T -31.6397 R
-N 0 0 M 26 0 D S
+N 0 0 M 24 0 D S
 U
-V 1515 475 T -31.6397 R
+V 1513 477 T -31.6397 R
 PSL_vecheadpen
 2 W
 0 0 M
--14 4 D
+-13 4 D
 3 -4 D
 -3 -4 D
 P clip fs P S 
 U
 2 W
-V 1649 495 T N 0 0 M 25 0 D S
+V 1649 495 T N 0 0 M 23 0 D S
 U
-V 1684 495 T PSL_vecheadpen
-2 W
-0 0 M
--14 4 D
-4 -4 D
--4 -4 D
-P clip fs P S 
-U
-2 W
-V 1814 495 T 31.6397 R
-N 0 0 M 26 0 D S
-U
-V 1845 514 T 31.6397 R
-PSL_vecheadpen
-2 W
-0 0 M
--14 4 D
-3 -4 D
--3 -4 D
-P clip fs P S 
-U
-2 W
-V 1978 495 T 58.9604 R
-N 0 0 M 28 0 D S
-U
-V 1999 529 T 58.9604 R
-PSL_vecheadpen
-2 W
-0 0 M
--16 4 D
-4 -4 D
--4 -4 D
-P clip fs P S 
-U
-2 W
-V 2143 495 T 80.4785 R
-N 0 0 M 30 0 D S
-U
-V 2150 537 T 80.4785 R
-PSL_vecheadpen
-2 W
-0 0 M
--17 4 D
-4 -4 D
--4 -4 D
-P clip fs P S 
-U
-2 W
-V 2308 495 T 96.8506 R
-N 0 0 M 30 0 D S
-U
-V 2303 537 T 96.8506 R
-PSL_vecheadpen
-2 W
-0 0 M
--17 5 D
-4 -5 D
--4 -5 D
-P clip fs P S 
-U
-2 W
-V 2473 495 T 109.298 R
-N 0 0 M 28 0 D S
-U
-V 2460 532 T 109.298 R
-PSL_vecheadpen
-2 W
-0 0 M
--15 4 D
-3 -4 D
--3 -4 D
-P clip fs P S 
-U
-2 W
-V 2638 495 T 118.895 R
-N 0 0 M 23 0 D S
-U
-V 2622 523 T 118.895 R
-PSL_vecheadpen
+V 1682 495 T PSL_vecheadpen
 2 W
 0 0 M
 -13 3 D
@@ -8372,37 +8287,115 @@ PSL_vecheadpen
 -3 -3 D
 P clip fs P S 
 U
-1 W
-V 2803 495 T 126.437 R
-N 0 0 M 17 0 D S
+2 W
+V 1814 495 T 31.6397 R
+N 0 0 M 24 0 D S
 U
-V 2788 514 T 126.437 R
+V 1843 513 T 31.6397 R
 PSL_vecheadpen
-1 W
+2 W
 0 0 M
--10 3 D
+-13 4 D
+3 -4 D
+-3 -4 D
+P clip fs P S 
+U
+2 W
+V 1978 495 T 58.9604 R
+N 0 0 M 26 0 D S
+U
+V 1998 526 T 58.9604 R
+PSL_vecheadpen
+2 W
+0 0 M
+-15 4 D
+4 -4 D
+-4 -4 D
+P clip fs P S 
+U
+2 W
+V 2143 495 T 80.4785 R
+N 0 0 M 28 0 D S
+U
+V 2150 534 T 80.4785 R
+PSL_vecheadpen
+2 W
+0 0 M
+-16 4 D
+4 -4 D
+-4 -4 D
+P clip fs P S 
+U
+2 W
+V 2308 495 T 96.8506 R
+N 0 0 M 28 0 D S
+U
+V 2304 534 T 96.8506 R
+PSL_vecheadpen
+2 W
+0 0 M
+-16 4 D
+4 -4 D
+-4 -4 D
+P clip fs P S 
+U
+2 W
+V 2473 495 T 109.298 R
+N 0 0 M 26 0 D S
+U
+V 2461 529 T 109.298 R
+PSL_vecheadpen
+2 W
+0 0 M
+-14 4 D
+3 -4 D
+-3 -4 D
+P clip fs P S 
+U
+2 W
+V 2638 495 T 118.895 R
+N 0 0 M 21 0 D S
+U
+V 2623 521 T 118.895 R
+PSL_vecheadpen
+2 W
+0 0 M
+-12 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 1 W
-V 2968 495 T 132.481 R
-N 0 0 M 12 0 D S
+V 2803 495 T 126.437 R
+N 0 0 M 16 0 D S
 U
-V 2956 507 T 132.481 R
+V 2789 513 T 126.437 R
 PSL_vecheadpen
 1 W
 0 0 M
--7 2 D
+-9 2 D
 2 -2 D
 -2 -2 D
+P clip fs P S 
+U
+1 W
+V 2968 495 T 132.481 R
+N 0 0 M 11 0 D S
+U
+V 2957 506 T 132.481 R
+PSL_vecheadpen
+1 W
+0 0 M
+-6 2 D
+1 -2 D
+-1 -2 D
 P clip fs P S 
 U
 1 W
 V 3133 495 T 137.413 R
 N 0 0 M 7 0 D S
 U
-V 3125 502 T 137.413 R
+V 3125 501 T 137.413 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8413,22 +8406,21 @@ P clip fs P S
 U
 0 W
 V 3297 495 T 145.136 R
-N 0 0 M 5 0 D S
+N 0 0 M 4 0 D S
 U
-V 3292 498 T 145.136 R
+V 3293 498 T 145.136 R
 PSL_vecheadpen
 0 W
 0 0 M
--3 1 D
-1 -1 D
--1 -1 D
+-2 1 D
+0 -2 D
 P clip fs P S 
 U
 0 W
 V 0 330 T -141.362 R
-N 0 0 M 3 0 D S
+N 0 0 M 2 0 D S
 U
-V -3 327 T -141.362 R
+V -3 328 T -141.362 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -8439,7 +8431,7 @@ U
 V 165 330 T -133.477 R
 N 0 0 M 4 0 D S
 U
-V 161 325 T -133.477 R
+V 161 326 T -133.477 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -8464,72 +8456,59 @@ U
 V 495 330 T -122.758 R
 N 0 0 M 10 0 D S
 U
-V 487 317 T -122.758 R
+V 487 318 T -122.758 R
 PSL_vecheadpen
 1 W
 0 0 M
--6 2 D
-2 -2 D
--2 -2 D
+-5 1 D
+1 -1 D
+-1 -1 D
 P clip fs P S 
 U
 1 W
 V 659 330 T -115.688 R
-N 0 0 M 14 0 D S
+N 0 0 M 13 0 D S
 U
-V 651 312 T -115.688 R
+V 651 313 T -115.688 R
 PSL_vecheadpen
 1 W
 0 0 M
--8 2 D
+-7 2 D
 2 -2 D
 -2 -2 D
 P clip fs P S 
 U
 1 W
 V 824 330 T -106.971 R
-N 0 0 M 17 0 D S
+N 0 0 M 16 0 D S
 U
-V 817 306 T -106.971 R
+V 818 308 T -106.971 R
 PSL_vecheadpen
 1 W
 0 0 M
--10 3 D
-3 -3 D
--3 -3 D
+-9 2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 989 330 T -95.9773 R
-N 0 0 M 19 0 D S
+N 0 0 M 18 0 D S
 U
-V 986 303 T -95.9773 R
+V 987 305 T -95.9773 R
 PSL_vecheadpen
 1 W
 0 0 M
--11 3 D
+-10 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 1 W
 V 1154 330 T -81.6834 R
-N 0 0 M 19 0 D S
+N 0 0 M 18 0 D S
 U
-V 1158 303 T -81.6834 R
-PSL_vecheadpen
-1 W
-0 0 M
--11 3 D
-3 -3 D
--3 -3 D
-P clip fs P S 
-U
-1 W
-V 1319 330 T -62.3236 R
-N 0 0 M 17 0 D S
-U
-V 1330 308 T -62.3236 R
+V 1158 305 T -81.6834 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8539,10 +8518,23 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 1484 330 T -35.2598 R
-N 0 0 M 15 0 D S
+V 1319 330 T -62.3236 R
+N 0 0 M 16 0 D S
 U
-V 1501 318 T -35.2598 R
+V 1330 310 T -62.3236 R
+PSL_vecheadpen
+1 W
+0 0 M
+-9 2 D
+2 -2 D
+-2 -2 D
+P clip fs P S 
+U
+1 W
+V 1484 330 T -35.2598 R
+N 0 0 M 14 0 D S
+U
+V 1500 318 T -35.2598 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8552,21 +8544,21 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 1649 330 T N 0 0 M 14 0 D S
+V 1649 330 T N 0 0 M 13 0 D S
 U
-V 1668 330 T PSL_vecheadpen
+V 1667 330 T PSL_vecheadpen
 1 W
 0 0 M
--8 2 D
+-7 2 D
 2 -2 D
 -2 -2 D
 P clip fs P S 
 U
 1 W
 V 1814 330 T 35.2598 R
-N 0 0 M 15 0 D S
+N 0 0 M 14 0 D S
 U
-V 1831 342 T 35.2598 R
+V 1830 341 T 35.2598 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8577,48 +8569,35 @@ P clip fs P S
 U
 1 W
 V 1978 330 T 62.3236 R
-N 0 0 M 17 0 D S
+N 0 0 M 16 0 D S
 U
-V 1990 351 T 62.3236 R
+V 1989 350 T 62.3236 R
 PSL_vecheadpen
 1 W
 0 0 M
--10 3 D
-3 -3 D
--3 -3 D
+-9 2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 2143 330 T 81.6834 R
-N 0 0 M 19 0 D S
+N 0 0 M 18 0 D S
 U
-V 2147 356 T 81.6834 R
+V 2147 354 T 81.6834 R
 PSL_vecheadpen
 1 W
 0 0 M
--11 3 D
+-10 3 D
 3 -3 D
 -3 -3 D
 P clip fs P S 
 U
 1 W
 V 2308 330 T 95.9773 R
-N 0 0 M 19 0 D S
+N 0 0 M 18 0 D S
 U
-V 2305 356 T 95.9773 R
-PSL_vecheadpen
-1 W
-0 0 M
--11 3 D
-3 -3 D
--3 -3 D
-P clip fs P S 
-U
-1 W
-V 2473 330 T 106.971 R
-N 0 0 M 17 0 D S
-U
-V 2466 353 T 106.971 R
+V 2306 355 T 95.9773 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8628,14 +8607,27 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 2638 330 T 115.688 R
-N 0 0 M 14 0 D S
+V 2473 330 T 106.971 R
+N 0 0 M 16 0 D S
 U
-V 2629 348 T 115.688 R
+V 2467 351 T 106.971 R
 PSL_vecheadpen
 1 W
 0 0 M
--8 2 D
+-9 2 D
+2 -2 D
+-2 -2 D
+P clip fs P S 
+U
+1 W
+V 2638 330 T 115.688 R
+N 0 0 M 13 0 D S
+U
+V 2630 346 T 115.688 R
+PSL_vecheadpen
+1 W
+0 0 M
+-7 2 D
 2 -2 D
 -2 -2 D
 P clip fs P S 
@@ -8644,20 +8636,20 @@ U
 V 2803 330 T 122.758 R
 N 0 0 M 10 0 D S
 U
-V 2795 342 T 122.758 R
+V 2795 341 T 122.758 R
 PSL_vecheadpen
 1 W
 0 0 M
--6 2 D
-2 -2 D
--2 -2 D
+-5 1 D
+1 -1 D
+-1 -1 D
 P clip fs P S 
 U
 1 W
 V 2968 330 T 128.592 R
 N 0 0 M 7 0 D S
 U
-V 2961 338 T 128.592 R
+V 2962 337 T 128.592 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8670,7 +8662,7 @@ U
 V 3133 330 T 133.477 R
 N 0 0 M 4 0 D S
 U
-V 3128 334 T 133.477 R
+V 3129 334 T 133.477 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -8680,7 +8672,7 @@ P clip fs P S
 U
 0 W
 V 3297 330 T 141.362 R
-N 0 0 M 3 0 D S
+N 0 0 M 2 0 D S
 U
 V 3295 332 T 141.362 R
 PSL_vecheadpen
@@ -8715,7 +8707,7 @@ U
 V 330 165 T -125.23 R
 N 0 0 M 4 0 D S
 U
-V 327 160 T -125.23 R
+V 327 161 T -125.23 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -8725,7 +8717,7 @@ P clip fs P S
 U
 0 W
 V 495 165 T -119.656 R
-N 0 0 M 6 0 D S
+N 0 0 M 5 0 D S
 U
 V 491 158 T -119.656 R
 PSL_vecheadpen
@@ -8738,7 +8730,7 @@ P clip fs P S
 U
 1 W
 V 659 165 T -113.057 R
-N 0 0 M 8 0 D S
+N 0 0 M 7 0 D S
 U
 V 655 155 T -113.057 R
 PSL_vecheadpen
@@ -8751,7 +8743,7 @@ P clip fs P S
 U
 1 W
 V 824 165 T -105.112 R
-N 0 0 M 10 0 D S
+N 0 0 M 9 0 D S
 U
 V 821 152 T -105.112 R
 PSL_vecheadpen
@@ -8764,35 +8756,35 @@ P clip fs P S
 U
 1 W
 V 989 165 T -95.2935 R
-N 0 0 M 11 0 D S
+N 0 0 M 10 0 D S
 U
-V 988 150 T -95.2935 R
+V 988 151 T -95.2935 R
 PSL_vecheadpen
 1 W
 0 0 M
 -6 2 D
-1 -2 D
--1 -2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 1154 165 T -82.6295 R
-N 0 0 M 11 0 D S
+N 0 0 M 10 0 D S
 U
-V 1156 150 T -82.6295 R
+V 1156 151 T -82.6295 R
 PSL_vecheadpen
 1 W
 0 0 M
 -6 2 D
-1 -2 D
--1 -2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 1319 165 T -65.1031 R
-N 0 0 M 10 0 D S
+N 0 0 M 9 0 D S
 U
-V 1325 153 T -65.1031 R
+V 1324 153 T -65.1031 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8803,9 +8795,9 @@ P clip fs P S
 U
 1 W
 V 1484 165 T -38.623 R
-N 0 0 M 8 0 D S
+N 0 0 M 7 0 D S
 U
-V 1493 158 T -38.623 R
+V 1492 158 T -38.623 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8815,9 +8807,9 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 1649 165 T N 0 0 M 7 0 D S
+V 1649 165 T N 0 0 M 6 0 D S
 U
-V 1659 165 T PSL_vecheadpen
+V 1658 165 T PSL_vecheadpen
 1 W
 0 0 M
 -4 1 D
@@ -8827,9 +8819,9 @@ P clip fs P S
 U
 1 W
 V 1814 165 T 38.623 R
-N 0 0 M 8 0 D S
+N 0 0 M 7 0 D S
 U
-V 1822 172 T 38.623 R
+V 1822 171 T 38.623 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8840,9 +8832,9 @@ P clip fs P S
 U
 1 W
 V 1978 165 T 65.1031 R
-N 0 0 M 10 0 D S
+N 0 0 M 9 0 D S
 U
-V 1984 177 T 65.1031 R
+V 1984 176 T 65.1031 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8853,35 +8845,35 @@ P clip fs P S
 U
 1 W
 V 2143 165 T 82.6295 R
-N 0 0 M 11 0 D S
+N 0 0 M 10 0 D S
 U
-V 2145 180 T 82.6295 R
+V 2145 179 T 82.6295 R
 PSL_vecheadpen
 1 W
 0 0 M
 -6 2 D
-1 -2 D
--1 -2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 2308 165 T 95.2935 R
-N 0 0 M 11 0 D S
+N 0 0 M 10 0 D S
 U
-V 2307 180 T 95.2935 R
+V 2307 179 T 95.2935 R
 PSL_vecheadpen
 1 W
 0 0 M
 -6 2 D
-1 -2 D
--1 -2 D
+2 -2 D
+-2 -2 D
 P clip fs P S 
 U
 1 W
 V 2473 165 T 105.112 R
-N 0 0 M 10 0 D S
+N 0 0 M 9 0 D S
 U
-V 2470 178 T 105.112 R
+V 2470 177 T 105.112 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8892,9 +8884,9 @@ P clip fs P S
 U
 1 W
 V 2638 165 T 113.057 R
-N 0 0 M 8 0 D S
+N 0 0 M 7 0 D S
 U
-V 2634 175 T 113.057 R
+V 2634 174 T 113.057 R
 PSL_vecheadpen
 1 W
 0 0 M
@@ -8905,7 +8897,7 @@ P clip fs P S
 U
 0 W
 V 2803 165 T 119.656 R
-N 0 0 M 6 0 D S
+N 0 0 M 5 0 D S
 U
 V 2799 172 T 119.656 R
 PSL_vecheadpen
@@ -8932,7 +8924,7 @@ U
 V 3133 165 T 129.999 R
 N 0 0 M 2 0 D S
 U
-V 3130 167 T 129.999 R
+V 3131 167 T 129.999 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -8965,7 +8957,7 @@ U
 V 165 0 T -122.644 R
 N 0 0 M 1 0 D S
 U
-V 164 -2 T -122.644 R
+V 164 -1 T -122.644 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -8991,27 +8983,26 @@ V 493 -4 T -113.494 R
 PSL_vecheadpen
 0 W
 0 0 M
--2 1 D
-1 -1 D
--1 -1 D
+-2 0 D
+1 0 D
+-1 0 D
 P clip fs P S 
 U
 0 W
 V 659 0 T -108.003 R
-N 0 0 M 5 0 D S
+N 0 0 M 4 0 D S
 U
-V 657 -6 T -108.003 R
+V 658 -6 T -108.003 R
 PSL_vecheadpen
 0 W
 0 0 M
--3 1 D
-1 -1 D
--1 -1 D
+-2 1 D
+0 -2 D
 P clip fs P S 
 U
 0 W
 V 824 0 T -101.65 R
-N 0 0 M 6 0 D S
+N 0 0 M 5 0 D S
 U
 V 823 -8 T -101.65 R
 PSL_vecheadpen
@@ -9022,37 +9013,35 @@ PSL_vecheadpen
 -1 -1 D
 P clip fs P S 
 U
-1 W
+0 W
 V 989 0 T -94.0463 R
-N 0 0 M 7 0 D S
+N 0 0 M 6 0 D S
 U
 V 989 -9 T -94.0463 R
 PSL_vecheadpen
-1 W
+0 W
 0 0 M
--4 1 D
-1 -1 D
--1 -1 D
+-3 1 D
+0 -2 D
 P clip fs P S 
 U
-1 W
+0 W
 V 1154 0 T -84.3598 R
-N 0 0 M 7 0 D S
+N 0 0 M 6 0 D S
 U
 V 1155 -9 T -84.3598 R
 PSL_vecheadpen
-1 W
+0 W
 0 0 M
--4 1 D
-1 -1 D
--1 -1 D
+-3 1 D
+0 -2 D
 P clip fs P S 
 U
 0 W
 V 1319 0 T -70.4884 R
-N 0 0 M 6 0 D S
+N 0 0 M 5 0 D S
 U
-V 1322 -8 T -70.4884 R
+V 1321 -7 T -70.4884 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -9088,7 +9077,7 @@ U
 V 1814 0 T 46.3003 R
 N 0 0 M 4 0 D S
 U
-V 1818 4 T 46.3003 R
+V 1817 4 T 46.3003 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -9098,9 +9087,9 @@ P clip fs P S
 U
 0 W
 V 1978 0 T 70.4884 R
-N 0 0 M 6 0 D S
+N 0 0 M 5 0 D S
 U
-V 1981 8 T 70.4884 R
+V 1981 7 T 70.4884 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -9109,37 +9098,35 @@ PSL_vecheadpen
 -1 -1 D
 P clip fs P S 
 U
-1 W
+0 W
 V 2143 0 T 84.3598 R
-N 0 0 M 7 0 D S
+N 0 0 M 6 0 D S
 U
 V 2144 9 T 84.3598 R
 PSL_vecheadpen
-1 W
+0 W
 0 0 M
--4 1 D
-1 -1 D
--1 -1 D
+-3 1 D
+0 -2 D
 P clip fs P S 
 U
-1 W
+0 W
 V 2308 0 T 94.0463 R
-N 0 0 M 7 0 D S
+N 0 0 M 6 0 D S
 U
 V 2308 9 T 94.0463 R
 PSL_vecheadpen
-1 W
+0 W
 0 0 M
--4 1 D
-1 -1 D
--1 -1 D
+-3 1 D
+0 -2 D
 P clip fs P S 
 U
 0 W
 V 2473 0 T 101.65 R
-N 0 0 M 6 0 D S
+N 0 0 M 5 0 D S
 U
-V 2471 8 T 101.65 R
+V 2472 8 T 101.65 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -9150,15 +9137,14 @@ P clip fs P S
 U
 0 W
 V 2638 0 T 108.003 R
-N 0 0 M 5 0 D S
+N 0 0 M 4 0 D S
 U
 V 2636 6 T 108.003 R
 PSL_vecheadpen
 0 W
 0 0 M
--3 1 D
-1 -1 D
--1 -1 D
+-2 1 D
+0 -2 D
 P clip fs P S 
 U
 0 W
@@ -9169,9 +9155,9 @@ V 2801 4 T 113.494 R
 PSL_vecheadpen
 0 W
 0 0 M
--2 1 D
-1 -1 D
--1 -1 D
+-2 0 D
+1 0 D
+-1 0 D
 P clip fs P S 
 U
 0 W
@@ -9189,7 +9175,7 @@ U
 V 3133 0 T 122.644 R
 N 0 0 M 1 0 D S
 U
-V 3132 2 T 122.644 R
+V 3132 1 T 122.644 R
 PSL_vecheadpen
 0 W
 0 0 M
@@ -10436,6 +10422,7 @@ U
 [] 0 B
 PSL_cliprestore
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 3297 M 0 -3297 D S
 /PSL_A0_y 83 def
@@ -10446,8 +10433,8 @@ N 0 824 M -83 0 D S
 N 0 1649 M -83 0 D S
 N 0 2473 M -83 0 D S
 N 0 3297 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 200 F0
 (-2) sw mx
 (-1) sw mx
@@ -10523,8 +10510,8 @@ N 824 0 M 0 -83 D S
 N 1649 0 M 0 -83 D S
 N 2473 0 M 0 -83 D S
 N 3297 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (-2) sh mx
 (-1) sh mx
 (0) sh mx
@@ -12927,6 +12914,7 @@ U
 [] 0 B
 PSL_cliprestore
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 3297 M 0 -3297 D S
 /PSL_A0_y 83 def
@@ -12937,8 +12925,8 @@ N 0 824 M -83 0 D S
 N 0 1649 M -83 0 D S
 N 0 2473 M -83 0 D S
 N 0 3297 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 200 F0
 (-2) sw mx
 (-1) sw mx
@@ -13014,8 +13002,8 @@ N 824 0 M 0 -83 D S
 N 1649 0 M 0 -83 D S
 N 2473 0 M 0 -83 D S
 N 3297 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (-2) sh mx
 (-1) sh mx
 (0) sh mx

--- a/doc/examples/ex13/ex13.sh
+++ b/doc/examples/ex13/ex13.sh
@@ -13,7 +13,7 @@ gmt begin ex13
 	gmt subplot begin 2x2 -M0.1c -Ff15c -BWSne -T"z(x,y) = x@~\327@~exp(-x@+2@+-y@+2@+)"
 		gmt grdcontour z.nc -C0.05 -A0.1 -Gd5c -S4 -T+d8p/2p -c0,0
 		gmt grdcontour z.nc -C0.05 -Gd5c -S4 -c0,1
-		gmt grdvector dzdx.nc dzdy.nc -I0.2 -Q0.25c+e+n0.25i+h0.5 -Gblack -W1p -S12c
+		gmt grdvector dzdx.nc dzdy.nc -I0.2 -Q0.25c+e+n0.25i+h0.5 -Gblack -W1p -S2c
 		gmt grdcontour dzdx.nc -C0.10 -A0.5 -Gd5c -S4 -T+d8p/2p -c1,0
 		gmt grdcontour dzdy.nc -C0.05 -A0.2 -Gd5c -S4 -T+d8p/2p -c1,1
 	gmt subplot end

--- a/doc/rst/source/grdvector_common.rst_
+++ b/doc/rst/source/grdvector_common.rst_
@@ -72,20 +72,21 @@ Optional Arguments
 .. _-S:
 
 **-S**\ [**i**\|\ **l**]\ *scale*
-    Sets scale for vector plot length in data units per plot distance measurement
-    unit [1]. Append **c**, **i**, or **p** to indicate the measurement
+    Sets scale for vector plot lengths in data units per plot distance measurement unit. 
+    Append **c**, **i**, or **p** to indicate the desired plot distance measurement
     unit (cm, inch, or point); if no unit is given we use the default value that
-    is controlled by :term:`PROJ_LENGTH_UNIT`. Alternatively,
-    use **-Sl**\ *length* to set a fixed plot length for all vectors.  Vectors given
-    via plot unit scaling will plot as straight vectors and their lengths are not
+    is controlled by :term:`PROJ_LENGTH_UNIT`.  Vector lengths converted via plot unit
+    scaling will plot as straight Cartesian vectors and their lengths are not
     affected by map projection and coordinate locations.
-    For geographic data you may alternatively give *scale* in data units per
-    map distance unit (see `Units`_). Then, your user units are scaled to map distances in the given unit
-    which are projected to plot dimensions.  These are geo-vectors that follow
-    great circle paths and their lengths are affected by the map projection and their
-    coordinates.  Finally, use **-Si** if it is simpler to give the reciprocal scale in
-    measurement unit per data unit or km per data unit.  To report the minimum, maximum,
-    and mean scaled vector length, use **-Vi**.
+    For geographic data you may alternatively give *scale* in data units per map distance
+    unit (see `Units`_). Then, your vector magnitudes (in data units) are scaled to map
+    *distances* in the given distance unit, and finally projected onto the Earth to give
+    *plot* dimensions.  These are geo-vectors that follow great circle paths and their
+    lengths may be affected by the map projection and their coordinates.  Finally, use
+    **-Si** if it is simpler to give the reciprocal scale in plot length or distance units
+    per data unit.  To report the minimum, maximum, and mean plot vector lengths of those
+    plotted, use **-V**.  Alternatively, use **-Sl**\ *length* to set a fixed plot length
+    for all vectors. 
 
 .. _-T:
 

--- a/doc/rst/source/grdvector_common.rst_
+++ b/doc/rst/source/grdvector_common.rst_
@@ -84,9 +84,9 @@ Optional Arguments
     *plot* dimensions.  These are geo-vectors that follow great circle paths and their
     lengths may be affected by the map projection and their coordinates.  Finally, use
     **-Si** if it is simpler to give the reciprocal scale in plot length or distance units
-    per data unit.  To report the minimum, maximum, and mean plot vector lengths of those
-    plotted, use **-V**.  Alternatively, use **-Sl**\ *length* to set a fixed plot length
-    for all vectors. 
+    per data unit.  To report the minimum, maximum, and mean data and plot vector lengths
+    of all vectors plotted, use **-V**.  Alternatively, use **-Sl**\ *length* to set a fixed
+    plot length for all vectors.
 
 .. _-T:
 

--- a/doc/rst/source/grdvector_notes.rst_
+++ b/doc/rst/source/grdvector_notes.rst_
@@ -4,7 +4,7 @@ Vector scaling and unit effects
 The scale given via **-S** may require some consideration. As explained in **-S**,
 it is specified in data-units per plot or distance unit. The plot or distance unit
 chosen will affect the type of vector you select. In all cases, we first compute
-the magnitude of the user's data vectors at each selected node from the *x* and *y*
+the magnitude *r* of the user's data vectors at each selected node from the *x* and *y*
 components (unless you are passing *r*, *theta* grids directly with **-A**).  These
 magnitudes are given in whatever data units they come with.  Let us pretend our data
 grids record secular changes in the Earth's magnetic horizontal vector field in units
@@ -15,9 +15,9 @@ then you are selecting *Cartesian* vectors. Let us further pretend that you sele
 1 cm plot length. Internally, we convert this scale to a plot scale of 1/10  = 0.1 cm
 per nTesla/year. Given our vector magnitude of 28 nTesla/year, we multiply it by our
 plot scale and finally obtain a vector length of 2.8 cm, which is then plotted.
-The user's data units do not enter of course, i.e., they always cancel.  Likewise, if
-we had used -S25i (25 nTesla/year per inch) the plot scale would be (1/25) = 0.04
-inch/(nTesla/year) and the vector plot lengths would be 28 * 0.04 inch = 1.12 inch).
+The user's data units do not enter of course, i.e., they always cancel [Likewise, if
+we had used **-S**\ 25i (25 nTesla/year per inch) the plot scale would be (1/25) = 0.04
+inch per nTesla/year and the vector plot lengths would be 28 * 0.04 inch = 1.12 inch].
 If we now wished to plot a 10 nTesla/year reference vector in the map legend we would
 plot one that is 10 times 0.1 cm = 1 cm long since the scale length is *constant*
 regardless of map projection and location. A 10 nTesla/year vector will be 1 cm anywhere.
@@ -27,20 +27,20 @@ instead, say **-S**\ 0.5k (0.5 nTesla/year per km). Internally, this becomes a m
 2 km per nTesta/year. Given our node magnitude of 28 nTesla/year, the vector length will
 be 28 x 2 km = 56 km. Again, the user's data unit do not enter. Now, that vector length
 of 56 km must be projected onto the Earth, and because of map distortions, a 56 km vector
-will be mapped to a length on the plot that is a function of the users map projection,
+will be mapped to a length on the plot that is a function of the user's map projection,
 the map scale, and possibly the location on the map. E.g., a 56 km vector due east at
-Equator on a Mercator map would seem to equal ~0.5 degree longitudes but at 60 north it
-would be more like ~1 degrees longitude. A consequence of this effect is that a user
-who wants to add a 10 nTesla/year scale vector to a legend face the same problem we do
+Equator on a Mercator map would seem to equal ~0.5 degree longitude but at 60 north it
+would be more like ~1 degree longitude. A consequence of this effect is that a user
+who wants to add a 10 nTesla/year reference vector to a legend faces the same problem we do
 when we wish to draw a 100 km map scale on a map: the plotted length usually will depend
 on latitude and hence that reference scale is only useful around that latitude.
 
 This brings us to the inverse scale option, **-Si**\ *length*.  This variant is useful
-if perhaps giving the inverse of a scale is simpler. In the Cartesian case above, we
+when providing the inverse of the scale is simpler. In the Cartesian case above, we
 could instead give **-Si**\ 0.1c which would directly imply a plot scale of 0.1 cm per
 nTesla/year. Likewise, for geographic distances we could give **-Si**\ 2k for 2 km per
-nTesla/year As the **-Si** argument increases, the plotted vector length increases as
-well, while for plain **-S** the plot length decreases with increasing scale.
+nTesla/year scale as well. As the **-Si** argument increases, the plotted vector length
+increases as well, while for plain **-S** the plot length decreases with increasing scale.
 
 Notes
 -----

--- a/doc/rst/source/grdvector_notes.rst_
+++ b/doc/rst/source/grdvector_notes.rst_
@@ -1,3 +1,47 @@
+Vector scaling and unit effects
+-------------------------------
+
+The scale given via **-S** may require some consideration. As explained in **-S**,
+it is specified in data-units per plot or distance unit. The plot or distance unit
+chosen will affect the type of vector you select. In all cases, we first compute
+the magnitude of the user's data vectors at each selected node from the *x* and *y*
+components (unless you are passing *r*, *theta* grids directly with **-A**).  These
+magnitudes are given in whatever data units they come with.  Let us pretend our data
+grids record secular changes in the Earth's magnetic horizontal vector field in units
+of nTesla/year, and that at a particular node the magnitude is 28 nTesla/year (in some
+direction). If you specify the scale using plot distance units (**c**\|\ **i**\|\ **p**)
+then you are selecting *Cartesian* vectors. Let us further pretend that you selected
+**-S**\ 10c as your scale option.  That means you want 10 nTesla/year to equate to a
+1 cm plot length. Internally, we convert this scale to a plot scale of 1/10  = 0.1 cm
+per nTesla/year. Given our vector magnitude of 28 nTesla/year, we multiply it by our
+plot scale and finally obtain a vector length of 2.8 cm, which is then plotted.
+The user's data units do not enter of course, i.e., they always cancel.  Likewise, if
+we had used -S25i (25 nTesla/year per inch) the plot scale would be (1/25) = 0.04
+inch/(nTesla/year) and the vector plot lengths would be 28 * 0.04 inch = 1.12 inch).
+If we now wished to plot a 10 nTesla/year reference vector in the map legend we would
+plot one that is 10 times 0.1 cm = 1 cm long since the scale length is *constant*
+regardless of map projection and location. A 10 nTesla/year vector will be 1 cm anywhere.
+
+Let us contrast this behavior with what happens if we use a geographic distance unit
+instead, say **-S**\ 0.5k (0.5 nTesla/year per km). Internally, this becomes a map scale of
+2 km per nTesta/year. Given our node magnitude of 28 nTesla/year, the vector length will
+be 28 x 2 km = 56 km. Again, the user's data unit do not enter. Now, that vector length
+of 56 km must be projected onto the Earth, and because of map distortions, a 56 km vector
+will be mapped to a length on the plot that is a function of the users map projection,
+the map scale, and possibly the location on the map. E.g., a 56 km vector due east at
+Equator on a Mercator map would seem to equal ~0.5 degree longitudes but at 60 north it
+would be more like ~1 degrees longitude. A consequence of this effect is that a user
+who wants to add a 10 nTesla/year scale vector to a legend face the same problem we do
+when we wish to draw a 100 km map scale on a map: the plotted length usually will depend
+on latitude and hence that reference scale is only useful around that latitude.
+
+This brings us to the inverse scale option, **-Si**\ *length*.  This variant is useful
+if perhaps giving the inverse of a scale is simpler. In the Cartesian case above, we
+could instead give **-Si**\ 0.1c which would directly imply a plot scale of 0.1 cm per
+nTesla/year. Likewise, for geographic distances we could give **-Si**\ 2k for 2 km per
+nTesla/year As the **-Si** argument increases, the plotted vector length increases as
+well, while for plain **-S** the plot length decreases with increasing scale.
+
 Notes
 -----
 

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -476,7 +476,7 @@ int GMT_grdvector (void *V_API, int mode, void *args) {
 			Ctrl->S.factor *= (GMT->current.proj.KM_PR_DEG / GMT_DEG2SEC_F);
 			break;
 		case 'e':
-			Ctrl->S.factor /= METERS_IN_A_KM;
+			Ctrl->S.factor *= (1 / METERS_IN_A_KM);	/* 1 is "meters in a meter" ... */
 			break;
 		case 'f':
 			Ctrl->S.factor *= (METERS_IN_A_FOOT / METERS_IN_A_KM);
@@ -485,10 +485,10 @@ int GMT_grdvector (void *V_API, int mode, void *args) {
 			/* Already in km */
 			break;
 		case 'M':
-			Ctrl->S.factor /= (METERS_IN_A_MILE / METERS_IN_A_KM);
+			Ctrl->S.factor *= (METERS_IN_A_MILE / METERS_IN_A_KM);
 			break;
 		case 'n':
-			Ctrl->S.factor /= (METERS_IN_A_NAUTICAL_MILE / METERS_IN_A_KM);
+			Ctrl->S.factor *= (METERS_IN_A_NAUTICAL_MILE / METERS_IN_A_KM);
 			break;
 		case 'u':
 			Ctrl->S.factor *= (METERS_IN_A_SURVEY_FOOT / METERS_IN_A_KM);

--- a/test/grdvector/vec_scales.ps
+++ b/test/grdvector/vec_scales.ps
@@ -1,0 +1,1446 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.1.0_9139867_2020.04.10 [64-bit] Document from psxy
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sat Apr 11 15:30:39 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt psxy -R0/5.6507/0/8.9392 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 5.65070000 0.00000000 8.93920000 0.000 5.651 0.000 8.939 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 7892 TM
+% PostScript produced by:
+%@GMT: gmt grdvector r.nc a.nc -A -S1i -Q1c+e -Wthickest,black -Gred -BWN -Bxafg1 -Byafg1 -Xa0i -Ya6.577i -R-3/3/-3/3 -JX6c
+%@PROJ: xy -3.00000000 3.00000000 -3.00000000 3.00000000 -3.000 3.000 -3.000 3.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_plot_completion {
+V
+0 7892 T
+0 A 17 W
+{1 A} FS
+O1
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+V
+(­S1i) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 50 def
+/PSL_dy 50 def
+2598 236 T PSL_dim_w neg 0 T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+2598 236 M (­S1i) br Z
+U
+}!
+33 W
+{1 0 0 C} FS
+clipsave
+0 0 M
+2835 0 D
+0 2835 D
+-2835 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A [] 0 B} def
+V
+33 W
+V 1417 1417 T 90 R
+N 0 0 M 728 0 D S
+U
+V 1417 2617 T 90 R
+PSL_vecheadpen
+33 W
+0 0 M
+-472 127 D
+0 -254 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+25 W
+4 W
+0 0 M
+0 2835 D
+S
+472 0 M
+0 2835 D
+S
+945 0 M
+0 2835 D
+S
+1417 0 M
+0 2835 D
+S
+1890 0 M
+0 2835 D
+S
+2362 0 M
+0 2835 D
+S
+2835 0 M
+0 2835 D
+S
+0 0 M
+2835 0 D
+S
+0 472 M
+2835 0 D
+S
+0 945 M
+2835 0 D
+S
+0 1417 M
+2835 0 D
+S
+0 1890 M
+2835 0 D
+S
+0 2362 M
+2835 0 D
+S
+0 2835 M
+2835 0 D
+S
+/PSL_slant_y 0 def
+2 setlinecap
+25 W
+N 0 2835 M 0 -2835 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 472 M -83 0 D S
+N 0 1417 M -83 0 D S
+N 0 2362 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(-2) sw mx
+(0) sw mx
+(2) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+472 PSL_A0_y MM
+(-2) mr Z
+1417 PSL_A0_y MM
+(0) mr Z
+2362 PSL_A0_y MM
+(2) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -42 0 D S
+N 0 945 M -42 0 D S
+N 0 1890 M -42 0 D S
+N 0 2835 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 2835 T
+25 W
+N 0 0 M 2835 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 472 0 M 0 83 D S
+N 1417 0 M 0 83 D S
+N 2362 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+(-2) sh mx
+(0) sh mx
+(2) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+472 PSL_A0_y MM
+(-2) bc Z
+1417 PSL_A0_y MM
+(0) bc Z
+2362 PSL_A0_y MM
+(2) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M 0 42 D S
+N 945 0 M 0 42 D S
+N 1890 0 M 0 42 D S
+N 2835 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -2835 T
+0 setlinecap
+%%EndObject
+0 -7892 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3780 7892 TM
+% PostScript produced by:
+%@GMT: gmt grdvector r.nc a.nc -A -Si1i -Q1c+e -Wthickest,black -Gred -BN -Bxafg1 -Byafg1 -Xa3.1496i -Ya6.577i -R-3/3/-3/3 -JX6c
+%@PROJ: xy -3.00000000 3.00000000 -3.00000000 3.00000000 -3.000 3.000 -3.000 3.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_plot_completion {
+V
+3780 7892 T
+0 A 17 W
+{1 A} FS
+O1
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+V
+(­Si1i) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 50 def
+/PSL_dy 50 def
+2598 236 T PSL_dim_w neg 0 T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+2598 236 M (­Si1i) br Z
+U
+}!
+33 W
+{1 0 0 C} FS
+clipsave
+0 0 M
+2835 0 D
+0 2835 D
+-2835 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A [] 0 B} def
+V
+33 W
+V 1417 1417 T 90 R
+N 0 0 M 728 0 D S
+U
+V 1417 2617 T 90 R
+PSL_vecheadpen
+33 W
+0 0 M
+-472 127 D
+0 -254 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+25 W
+4 W
+0 0 M
+0 2835 D
+S
+472 0 M
+0 2835 D
+S
+945 0 M
+0 2835 D
+S
+1417 0 M
+0 2835 D
+S
+1890 0 M
+0 2835 D
+S
+2362 0 M
+0 2835 D
+S
+2835 0 M
+0 2835 D
+S
+0 0 M
+2835 0 D
+S
+0 472 M
+2835 0 D
+S
+0 945 M
+2835 0 D
+S
+0 1417 M
+2835 0 D
+S
+0 1890 M
+2835 0 D
+S
+0 2362 M
+2835 0 D
+S
+0 2835 M
+2835 0 D
+S
+/PSL_slant_y 0 def
+2 setlinecap
+0 2835 T
+25 W
+N 0 0 M 2835 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 472 0 M 0 83 D S
+N 1417 0 M 0 83 D S
+N 2362 0 M 0 83 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {M} def
+/PSL_AH0 0
+200 F0
+(-2) sh mx
+(0) sh mx
+(2) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+472 PSL_A0_y MM
+(-2) bc Z
+1417 PSL_A0_y MM
+(0) bc Z
+2362 PSL_A0_y MM
+(2) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M 0 42 D S
+N 945 0 M 0 42 D S
+N 1890 0 M 0 42 D S
+N 2835 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -2835 T
+0 setlinecap
+%%EndObject
+-3780 -7892 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 4113 TM
+% PostScript produced by:
+%@GMT: gmt grdvector r.nc a.nc -A -S0.4c -Q1c+e -Wthickest,black -Gred -BW -Bxafg1 -Byafg1 -Xa0i -Ya3.4274i -R-3/3/-3/3 -JX6c
+%@PROJ: xy -3.00000000 3.00000000 -3.00000000 3.00000000 -3.000 3.000 -3.000 3.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_plot_completion {
+V
+0 4113 T
+0 A 17 W
+{1 A} FS
+O1
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+V
+(­S0.4c) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 50 def
+/PSL_dy 50 def
+2598 236 T PSL_dim_w neg 0 T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+2598 236 M (­S0.4c) br Z
+U
+}!
+33 W
+{1 0 0 C} FS
+clipsave
+0 0 M
+2835 0 D
+0 2835 D
+-2835 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A [] 0 B} def
+V
+33 W
+V 1417 1417 T 90 R
+N 0 0 M 709 0 D S
+U
+V 1417 2598 T 90 R
+PSL_vecheadpen
+33 W
+0 0 M
+-472 127 D
+0 -254 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+25 W
+4 W
+0 0 M
+0 2835 D
+S
+472 0 M
+0 2835 D
+S
+945 0 M
+0 2835 D
+S
+1417 0 M
+0 2835 D
+S
+1890 0 M
+0 2835 D
+S
+2362 0 M
+0 2835 D
+S
+2835 0 M
+0 2835 D
+S
+0 0 M
+2835 0 D
+S
+0 472 M
+2835 0 D
+S
+0 945 M
+2835 0 D
+S
+0 1417 M
+2835 0 D
+S
+0 1890 M
+2835 0 D
+S
+0 2362 M
+2835 0 D
+S
+0 2835 M
+2835 0 D
+S
+/PSL_slant_y 0 def
+2 setlinecap
+25 W
+N 0 2835 M 0 -2835 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 472 M -83 0 D S
+N 0 1417 M -83 0 D S
+N 0 2362 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(-2) sw mx
+(0) sw mx
+(2) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+472 PSL_A0_y MM
+(-2) mr Z
+1417 PSL_A0_y MM
+(0) mr Z
+2362 PSL_A0_y MM
+(2) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -42 0 D S
+N 0 945 M -42 0 D S
+N 0 1890 M -42 0 D S
+N 0 2835 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 setlinecap
+%%EndObject
+0 -4113 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3780 4113 TM
+% PostScript produced by:
+%@GMT: gmt grdvector r.nc a.nc -A -Si2.5c -Q1c+e -Wthickest,black -Gred -B+n -Bxafg1 -Byafg1 -Xa3.1496i -Ya3.4274i -R-3/3/-3/3 -JX6c
+%@PROJ: xy -3.00000000 3.00000000 -3.00000000 3.00000000 -3.000 3.000 -3.000 3.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_plot_completion {
+V
+3780 4113 T
+0 A 17 W
+{1 A} FS
+O1
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+V
+(­Si2.5c) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 50 def
+/PSL_dy 50 def
+2598 236 T PSL_dim_w neg 0 T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+2598 236 M (­Si2.5c) br Z
+U
+}!
+33 W
+{1 0 0 C} FS
+clipsave
+0 0 M
+2835 0 D
+0 2835 D
+-2835 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A [] 0 B} def
+V
+33 W
+V 1417 1417 T 90 R
+N 0 0 M 709 0 D S
+U
+V 1417 2598 T 90 R
+PSL_vecheadpen
+33 W
+0 0 M
+-472 127 D
+0 -254 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+25 W
+4 W
+0 0 M
+0 2835 D
+S
+472 0 M
+0 2835 D
+S
+945 0 M
+0 2835 D
+S
+1417 0 M
+0 2835 D
+S
+1890 0 M
+0 2835 D
+S
+2362 0 M
+0 2835 D
+S
+2835 0 M
+0 2835 D
+S
+0 0 M
+2835 0 D
+S
+0 472 M
+2835 0 D
+S
+0 945 M
+2835 0 D
+S
+0 1417 M
+2835 0 D
+S
+0 1890 M
+2835 0 D
+S
+0 2362 M
+2835 0 D
+S
+0 2835 M
+2835 0 D
+S
+%%EndObject
+-3780 -4113 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 333 TM
+% PostScript produced by:
+%@GMT: gmt grdvector r.nc a.nc -A -S0.01388p -Q1c+e -Wthickest,black -Gred -BW -Bxafg1 -Byafg1 -Xa0i -Ya0.2778i -R-3/3/-3/3 -JX6c
+%@PROJ: xy -3.00000000 3.00000000 -3.00000000 3.00000000 -3.000 3.000 -3.000 3.000 +xy
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_plot_completion {
+V
+0 333 T
+0 A 17 W
+{1 A} FS
+O1
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+V
+(­S0.01388p) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 50 def
+/PSL_dy 50 def
+2598 236 T PSL_dim_w neg 0 T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+2598 236 M (­S0.01388p) br Z
+U
+}!
+33 W
+{1 0 0 C} FS
+clipsave
+0 0 M
+2835 0 D
+0 2835 D
+-2835 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A [] 0 B} def
+V
+33 W
+V 1417 1417 T 90 R
+N 0 0 M 728 0 D S
+U
+V 1417 2618 T 90 R
+PSL_vecheadpen
+33 W
+0 0 M
+-472 127 D
+0 -254 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+25 W
+4 W
+0 0 M
+0 2835 D
+S
+472 0 M
+0 2835 D
+S
+945 0 M
+0 2835 D
+S
+1417 0 M
+0 2835 D
+S
+1890 0 M
+0 2835 D
+S
+2362 0 M
+0 2835 D
+S
+2835 0 M
+0 2835 D
+S
+0 0 M
+2835 0 D
+S
+0 472 M
+2835 0 D
+S
+0 945 M
+2835 0 D
+S
+0 1417 M
+2835 0 D
+S
+0 1890 M
+2835 0 D
+S
+0 2362 M
+2835 0 D
+S
+0 2835 M
+2835 0 D
+S
+/PSL_slant_y 0 def
+2 setlinecap
+25 W
+N 0 2835 M 0 -2835 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 472 M -83 0 D S
+N 0 1417 M -83 0 D S
+N 0 2362 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(-2) sw mx
+(0) sw mx
+(2) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+472 PSL_A0_y MM
+(-2) mr Z
+1417 PSL_A0_y MM
+(0) mr Z
+2362 PSL_A0_y MM
+(2) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -42 0 D S
+N 0 945 M -42 0 D S
+N 0 1890 M -42 0 D S
+N 0 2835 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 setlinecap
+%%EndObject
+0 -333 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3780 333 TM
+% PostScript produced by:
+%@GMT: gmt grdvector r.nc a.nc -A -Si72p -Q1c+e -Wthickest,black -Gred -B+n -Bxafg1 -Byafg1 -Xa3.1496i -Ya0.2778i -R-3/3/-3/3 -JX6c
+%@PROJ: xy -3.00000000 3.00000000 -3.00000000 3.00000000 -3.000 3.000 -3.000 3.000 +xy
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_plot_completion {
+V
+3780 333 T
+0 A 17 W
+{1 A} FS
+O1
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+V
+(­S72p) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 50 def
+/PSL_dy 50 def
+2598 236 T PSL_dim_w neg 0 T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+2598 236 M (­S72p) br Z
+U
+}!
+33 W
+{1 0 0 C} FS
+clipsave
+0 0 M
+2835 0 D
+0 2835 D
+-2835 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A [] 0 B} def
+V
+33 W
+V 1417 1417 T 90 R
+N 0 0 M 728 0 D S
+U
+V 1417 2617 T 90 R
+PSL_vecheadpen
+33 W
+0 0 M
+-472 127 D
+0 -254 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+25 W
+4 W
+0 0 M
+0 2835 D
+S
+472 0 M
+0 2835 D
+S
+945 0 M
+0 2835 D
+S
+1417 0 M
+0 2835 D
+S
+1890 0 M
+0 2835 D
+S
+2362 0 M
+0 2835 D
+S
+2835 0 M
+0 2835 D
+S
+0 0 M
+2835 0 D
+S
+0 472 M
+2835 0 D
+S
+0 945 M
+2835 0 D
+S
+0 1417 M
+2835 0 D
+S
+0 1890 M
+2835 0 D
+S
+0 2362 M
+2835 0 D
+S
+0 2835 M
+2835 0 D
+S
+%%EndObject
+-3780 -333 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/grdvector/vec_scales.sh
+++ b/test/grdvector/vec_scales.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Test that scales and inverse scales given to grdvector work the same for all units
+# Create a data set with a unit vector data length and then plot that to give the
+# plot lengths of 1 inch, 2.5 cm, or 72 points via direct or inverse scales.  These
+# should all be about 2.5-2.54 cm long regardless of how we specified the scales.
+arg="-Q1c+e -Wthickest,black -Gred"
+gmt begin vec_scales ps
+  gmt set MAP_FRAME_TYPE plain
+  echo 0 0 90 | gmt xyz2grd -R-3/3/-3/3 -I3 -Ga.nc
+  echo 0 0 1  | gmt xyz2grd -R-3/3/-3/3 -I3 -Gr.nc
+  gmt subplot begin 3x2 -Fs6c -SCt -SRl -Bafg1 -M1c -R-3/3/-3/3 -JX6c -A+jBR+o0.5c+gwhite+p1p
+    gmt subplot set 0 -A"-S1i"					# 1 data unit per inch = 1 inch per data unit = 1 inch length
+    gmt grdvector r.nc a.nc -A -S1i $arg
+    gmt subplot set 1 -A"-Si1i"					# 1 inch per data unit = 1 inch length
+    gmt grdvector r.nc a.nc -A -Si1i $arg
+    gmt subplot set 2 -A"-S0.4c"				# 0.4 data unit per cm = 2.5 cm per data unit ~ 1 inch length
+    gmt grdvector r.nc a.nc -A -S0.4c $arg
+    gmt subplot set 3 -A"-Si2.5c"				# 2.5 cm per data unit ~ 1 inch length
+    gmt grdvector r.nc a.nc -A -Si2.5c $arg
+    gmt subplot set 4 -A"-S0.01388p"			# 0.01388 data unit per point = 72 points per data unit = 1 inch length
+    gmt grdvector r.nc a.nc -A -S0.01388p $arg
+    gmt subplot set 5  -A"-S72p"				# 72 points per data unit = 1 inch length
+    gmt grdvector r.nc a.nc -A -Si72p $arg
+ gmt subplot end
+gmt end show


### PR DESCRIPTION
**Description of proposed changes**

See #3088 for background.  I have made sure this now both works correctly, and works as the documentation states.  We had a bug that affected scalings using the units **M** (statute miles) and **n** (nautical mines) in **-S**.  Also, the description of **-S** was backwards and confusion.  I have update both the usage and doc for **-S** and added a long section regarding the vector scale and how the unit selection triggers Cartesian or geovectors.  I have added one more test script (vec_scales.sh) to grdvector's test directory.
