### PR TITLE
Fix grdimage -A for PPM rasters

### DIFF
--- a/doc/rst/source/grdimage_common.rst_
+++ b/doc/rst/source/grdimage_common.rst_
@@ -52,7 +52,8 @@ Optional Arguments
 
 **-A**\ *out_img*\ [**=**\ *driver*]
     Save an image in a raster format instead of PostScript. Use extension .ppm for a Portable
-    Pixel Map format. For GDAL-aware versions there are more choices: Append *out_img* to select
+    Pixel Map format which is the only raster format GMT can natively write. For GMT installations
+    configured with GDAL support there are more choices: Append *out_img* to select
     the image file name and extension. If the extension is one of .bmp, .gif, .jpg, .png, or .tif
     then no driver information is required. For other output formats you must append the required
     GDAL driver. The *driver* is the driver code name used by GDAL; see your GDAL installation's

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -4492,7 +4492,7 @@ GMT_LOCAL int gmtapi_export_ppm (struct GMT_CTRL *GMT, char *fname, struct GMT_I
 	snprintf (dim, GMT_LEN32, "%d %d\n255\n", I->header->n_rows, I->header->n_columns);
 	fwrite (dim, sizeof (char), strlen (dim), fp);	/* Write dimensions and max color value + linefeeds */
 	/* Now dump the image in scaneline order, with each pixel as (R, G, B) */
-	if (strncmp (I->header->mem_layout, "TRP", 3U)) /* Easy street! */
+	if (!strncmp (I->header->mem_layout, "TRP", 3U)) /* Easy street! */
 		fwrite (I->data, sizeof(char), I->header->nm * I->header->n_bands, fp);
 #if 0
 	else

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1120,14 +1120,14 @@ int GMT_grdimage (void *V_API, int mode, void *args) {
 		else
 #endif
 			gmt_strncpy (mem_layout, "TRPa", 4);					/* Don't let it be empty (may it screw?) */
-		GMT_Set_Default (API, "API_IMAGE_LAYOUT", "TRPa");
+		GMT_Set_Default (API, "API_IMAGE_LAYOUT", "TRPa");			/* Set grdimage's image memory layout */
 
 		if ((Out = GMT_Create_Data (API, GMT_IS_IMAGE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, dim, img_wesn, img_inc, 1, 0, NULL)) == NULL) {
 			if (Ctrl->Q.active) gmt_M_free (GMT, rgb_used);
 			Return(API->error);	/* Well, no luck with that allocation */
 		}
 
-		GMT_Set_Default (API, "API_IMAGE_LAYOUT", mem_layout);		/* Reset to previous mem layout */
+		GMT_Set_Default (API, "API_IMAGE_LAYOUT", mem_layout);		/* Reset to previous memory layout */
 
 		HH = gmt_get_H_hidden (Out->header);
 		if ((pch = strstr(Ctrl->Out.file, "+c")) != NULL) {			/* Check if we have +c<options> */

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1326,7 +1326,7 @@ int GMT_grdimage (void *V_API, int mode, void *args) {
 		for (kk = 0, P->is_bw = true; P->is_bw && kk < header_work->nm; kk++)
 			if (!(bitimage_8[kk] == 0 || bitimage_8[kk] == 255)) P->is_bw = false;
 
-	if (P && P->is_bw && !Ctrl->A.active) {	/* Can get away with a 1-bit image, but we must pack the original byte to 8 image bits */
+	if (P && P->is_bw && !Ctrl->A.active) {	/* Can get away with a 1-bit image, but we must pack the original byte to 8 image bits, unless we are returning the image (8 or 24 bit only allowed) */
 		int nx8, shift, b_or_w, nx_pixels;
 		uint64_t imsize, k8;
 		unsigned char *bit = NULL;

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -64,6 +64,7 @@ struct GRDIMAGE_CTRL {
 	struct GRDIMG_A {	/* -A to write a raster file or return image to API */
 		bool active;
 		bool return_image;
+		unsigned int way;
 		char *file;
 	} A;
 	struct GRDIMG_E {	/* -Ei|<dpi> */
@@ -255,6 +256,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDIMAGE_CTRL *Ctrl, struct GM
 						n_errors++;
 					}
 					Ctrl->A.return_image = true;
+					Ctrl->A.way = 1;	/* Building image directly, use TRPa layout, no call to GDAL */
 				}
 				else if ((n = strlen (opt->arg)) == 0) {
 					GMT_Report (API, GMT_MSG_ERROR, "Option -A: No output name provided\n");
@@ -262,6 +264,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDIMAGE_CTRL *Ctrl, struct GM
 				}
 				else if (!strcmp (gmt_get_ext (opt->arg), "ppm")) {	/* Want a ppm image which we can do without GDAL */
 					Ctrl->A.file = strdup (opt->arg);
+					Ctrl->A.way = 1;	/* Building image directly, use TRP layout, no call to GDAL, writing a PPM file */
 				}
 #ifdef HAVE_GDAL
 				else {	/* Must give file and GDAL driver and this requires GDAL support */
@@ -1117,14 +1120,14 @@ int GMT_grdimage (void *V_API, int mode, void *args) {
 		else
 #endif
 			gmt_strncpy (mem_layout, "TRPa", 4);					/* Don't let it be empty (may it screw?) */
-		GMT_Set_Default (API, "API_IMAGE_LAYOUT", "TRPa");			/* This is the grdimage's mem layout */
+		GMT_Set_Default (API, "API_IMAGE_LAYOUT", "TRPa");
 
 		if ((Out = GMT_Create_Data (API, GMT_IS_IMAGE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, dim, img_wesn, img_inc, 1, 0, NULL)) == NULL) {
 			if (Ctrl->Q.active) gmt_M_free (GMT, rgb_used);
 			Return(API->error);	/* Well, no luck with that allocation */
 		}
 
-		GMT_Set_Default (API, "API_IMAGE_LAYOUT", mem_layout);		/* Reset previous mem layout */
+		GMT_Set_Default (API, "API_IMAGE_LAYOUT", mem_layout);		/* Reset to previous mem layout */
 
 		HH = gmt_get_H_hidden (Out->header);
 		if ((pch = strstr(Ctrl->Out.file, "+c")) != NULL) {			/* Check if we have +c<options> */
@@ -1368,7 +1371,7 @@ int GMT_grdimage (void *V_API, int mode, void *args) {
 	}
 	else if ((P && gray_only) || Ctrl->M.active) {	/* Here we have a 1-layer 8 bit grayscale image */
 		if (Ctrl->A.active) {	/* Creating a raster image, not PostScript */
-			GMT_Report (API, GMT_MSG_INFORMATION, "Creating 8-bit grayshade image %s\n", way[Ctrl->A.return_image]);
+			GMT_Report (API, GMT_MSG_INFORMATION, "Creating 8-bit grayshade image %s\n", way[Ctrl->A.way]);
 			if (GMT_Write_Data (API, GMT_IS_IMAGE, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, Ctrl->Out.file, Out) != GMT_NOERROR)
 				Return (API->error);
 		}
@@ -1388,7 +1391,7 @@ int GMT_grdimage (void *V_API, int mode, void *args) {
 					}
 				}
 			}
-			GMT_Report (API, GMT_MSG_INFORMATION, "Creating 24-bit color image %s\n", way[Ctrl->A.return_image]);
+			GMT_Report (API, GMT_MSG_INFORMATION, "Creating 24-bit color image %s\n", way[Ctrl->A.way]);
 			if (GMT_Write_Data (API, GMT_IS_IMAGE, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, Ctrl->Out.file, Out) != GMT_NOERROR)
 				Return (API->error);
 		}


### PR DESCRIPTION
The _gmtapi_export_image_ function in GMT which writes PPM grids had a bug in the test for image layout, resulting in nothing being written except for a small header.  Also fixes a wrong information message from **grdimage** that implied writing via GDAL when PPM was selected.  Clarify the documentation on PPM and GDAL.
