### PR TITLE
Allow new supplement testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ cmake/ConfigUser.cmake
 cmake/ConfigUserAdvanced.cmake
 share/coast
 share/dcw
+src/newsuppl*
 **/gmt.history
 .DS_Store

--- a/cmake/ConfigUserAdvancedTemplate.cmake
+++ b/cmake/ConfigUserAdvancedTemplate.cmake
@@ -194,7 +194,8 @@
 # List extra sub-dirs of 'src' with a CMakeList.txt to build non-module codes
 # that link against the full gmt libs (not just the API; for building codes
 # that only need the GMT API, see the gmt-custom project).
-#set (EXTRA_BUILD_DIRS newsuppl1 newsuppl2)
+# These supplemental modules end up in supplements.so like the GMT supplements.
+#set (EXTRA_BUILD_DIRS newsuppl1 newsuppl2 ...)
 
 # List extra new supplemental modules for testing without adding them to the module list
 #set (EXTRA_MODULES_SUPPL newsuppl1.c newsuppl2.c)

--- a/cmake/ConfigUserAdvancedTemplate.cmake
+++ b/cmake/ConfigUserAdvancedTemplate.cmake
@@ -194,7 +194,7 @@
 # List extra sub-dirs of 'src' with a CMakeList.txt to build non-module codes
 # that link against the full gmt libs (not just the API; for building codes
 # that only need the GMT API, see the gmt-custom project).
-#set (EXTRA_BUILD_DIRS apidemo)
+#set (EXTRA_BUILD_DIRS newsuppl1 newsuppl2)
 
 # List extra new supplemental modules for testing without adding them to the module list
 #set (EXTRA_MODULES_SUPPL newsuppl1.c newsuppl2.c)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -683,6 +683,14 @@ if (BUILD_SUPPLEMENTS)
 	# supplement library files
 	get_subdir_var_files (GMT_SUPPL_LIB_SRCS SUPPL_LIB_SRCS ${GMT_SUPPL_DIRS})
 
+	# supplement extra include files
+	get_subdir_var (GMT_EXTRA_INCLUDES SUPPL_EXTRA_INCLUDES ${GMT_SUPPL_DIRS})
+	include_directories (${GMT_EXTRA_INCLUDES})
+
+	# supplement extra library files
+	get_subdir_var (GMT_EXTRA_LIBRARIES SUPPL_EXTRA_LIBS ${GMT_SUPPL_DIRS})
+	list (APPEND GMT_OPTIONAL_LIBRARIES ${GMT_EXTRA_LIBRARIES})
+
 	# libgmtsuppl
 	if (WIN32)
 		add_library (supplib

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -680,10 +680,10 @@ if (BUILD_SUPPLEMENTS)
 		include_directories (${CMAKE_CURRENT_BINARY_DIR}/${_dir})
 	endforeach (_dir)
 
-	# supplement extra (non-GMT) library files
+	# supplement extra (non-GMT) library files, if any
 	get_subdir_var_files (GMT_SUPPL_LIB_SRCS SUPPL_LIB_SRCS ${GMT_SUPPL_DIRS})
 
-	# supplement extra (non-GMT) include files
+	# supplement extra (non-GMT) include files, if any
 	get_subdir_var (GMT_EXTRA_INCLUDES SUPPL_EXTRA_INCLUDES ${GMT_SUPPL_DIRS})
 	include_directories (${GMT_EXTRA_INCLUDES})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -680,16 +680,15 @@ if (BUILD_SUPPLEMENTS)
 		include_directories (${CMAKE_CURRENT_BINARY_DIR}/${_dir})
 	endforeach (_dir)
 
-	# supplement library files
+	# supplement extra (non-GMT) library files
 	get_subdir_var_files (GMT_SUPPL_LIB_SRCS SUPPL_LIB_SRCS ${GMT_SUPPL_DIRS})
 
-	# supplement extra include files
+	# supplement extra (non-GMT) include files
 	get_subdir_var (GMT_EXTRA_INCLUDES SUPPL_EXTRA_INCLUDES ${GMT_SUPPL_DIRS})
 	include_directories (${GMT_EXTRA_INCLUDES})
 
 	# supplement extra library files
 	get_subdir_var (GMT_EXTRA_LIBRARIES SUPPL_EXTRA_LIBS ${GMT_SUPPL_DIRS})
-	list (APPEND GMT_OPTIONAL_LIBRARIES ${GMT_EXTRA_LIBRARIES})
 
 	# libgmtsuppl
 	if (WIN32)
@@ -711,7 +710,8 @@ if (BUILD_SUPPLEMENTS)
 	# No SOVERSION & VERSION for a MODULE, only for SHARED libs
 	target_link_libraries (supplib
 		gmtlib
-		pslib)
+		pslib
+		${GMT_EXTRA_LIBRARIES})
 
 	# Include any extra files that are listed in EXTRA_MODULES_SUPPL defined in ConfigUserAdvanced.cmake
 	# This include(s) will add new modules to the official GMT supplements


### PR DESCRIPTION
Specifically, allow a supplement to have some specific include and library requirements not part of the supplement (e..g, system libs and includes). These are the changes:

1. Allow the CMakeLists.txt file in a supplement directory to specify extra include dirs and libraries, e.g.,

```
set (SUPPL_EXTRA_INCLUDES /Users/pwessel/GMTdev/mbsystem/include)
set (SUPPL_EXTRA_LIBS /Users/pwessel/GMTdev/mbsystem/lib/libmbio.dylib)
```

1. Let the src/CmakeLists.txt file harvest all such settings then include them in the main setup:

```
	# supplement extra include files
	get_subdir_var (GMT_EXTRA_INCLUDES SUPPL_EXTRA_INCLUDES ${GMT_SUPPL_DIRS})
	include_directories (${GMT_EXTRA_INCLUDES})

	# supplement extra library files
	get_subdir_var (GMT_EXTRA_LIBRARIES SUPPL_EXTRA_LIBS ${GMT_SUPPL_DIRS})
	list (APPEND GMT_OPTIONAL_LIBRARIES ${GMT_EXTRA_LIBRARIES})
```

However, these are executed too late, I think, as the CMakeLists.txt file already have said

```
target_link_libraries (gmtlib
	${NETCDF_LIBRARIES}
	${GMT_OPTIONAL_LIBRARIES}
	pslib)
```

before we get down to the `if (BUILD_SUPPLEMENTS)` section.  However, it looks like the include files are found this way; the errors I get is during linking and the given library is not found.

Perhaps there is another way to have these settings be activated inside the if BUILD_SUPPLEMENTS section?

