### PR TITLE
Avoid confusion between srtm lists and netcdf files

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -5081,11 +5081,14 @@ int gmt_access (struct GMT_CTRL *GMT, const char* filename, int mode) {
 	if (gmt_M_file_is_memory (filename)) return (0);	/* Memory location always exists */
 	if (gmt_M_file_is_cache (filename))			/* Must be a cache file */
 		first = gmt_download_file_if_not_found (GMT, filename, 0);
-	file[0] = '\0';		/* 'Initialize' it so we can test if it's still 'empty' after the sscanf below */
-	sscanf (&filename[first], "%[^=?]", file);	/* Exclude netcdf 3-D grid extensions to make sure we get a valid file name */
-	if (file[0] == '\0')
-		return (-1);		/* It happens for example when parsing grdmath args and it finds an isolated  "=" */
-
+	if (strstr (filename, "/=srtm"))	/* Special list with SRTM tiles, use as is */
+		strncpy (file, filename, PATH_MAX-1);
+	else {
+		file[0] = '\0';		/* 'Initialize' it so we can test if it's still 'empty' after the sscanf below */
+		sscanf (&filename[first], "%[^=?]", file);	/* Exclude netcdf 3-D grid extensions to make sure we get a valid file name */
+		if (file[0] == '\0')
+			return (-1);		/* It happens for example when parsing grdmath args and it finds an isolated  "=" */
+	}
 	if ((c = gmtlib_file_unitscale (file))) c[0] = '\0';	/* Chop off any x/u unit specification */
 	else if ((c = strchr (file, '+')) && strchr ("hons", c[1])) c[0] = '\0';	/* Chop off any +h hinge setting or any z-scaling specification */
 	if (mode == W_OK)

--- a/test/grdimage/grdimage_img_tif.sh
+++ b/test/grdimage/grdimage_img_tif.sh
@@ -2,7 +2,7 @@
 # Test that proj info is well propagated into nc and gtiff files and that grdimage
 # produces well referenced geotiffs
 
-ps=grimage_img_tif.ps
+ps=grdimage_img_tif.ps
 
 gmt grdmath -R0/20/30/50 -I0.25 X Y MUL = lixo.grd
 gmt grdproject lixo.grd -J+proj=utm+zone=32 -Glixo_utm.grd
@@ -17,4 +17,3 @@ gmt grdimage lixo_utm.grd -I+d -Agrdimg.tiff
 
 gmt grdimage grdimg.tiff -JX8c -X-8.5c -Y8.5c -Ba -BWseN -O -K >> $ps
 echo 10 40 | gmt mapproject -J+proj=utm+zone=32 | gmt psxy -JX8c -Rgrdimg.tiff -Sc1c -Gwhite -O >> $ps
-


### PR DESCRIPTION
The equal sign at the start of the list confused gmt_access - probably due to a recent improvement with a side-effect.  Closes #3097.  @joa-quim, please check your new test grdimage_img_tif.sh which fails.  I renamed it (the "d") was missing but not sure why it is off the page.


