### PR TITLE
Disable GDAL-created auxilliary files

### DIFF
--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -648,7 +648,17 @@ int GMT_grdimage (void *V_API, int mode, void *args) {
 
 	use_intensity_grid = (Ctrl->I.active && !Ctrl->I.constant);	/* We want to use an intensity grid */
 	n_grids = (Ctrl->In.do_rgb) ? 3 : 1;	/* Either reading 3 grids (r, g, b) or a z-data grid */
-	if (Ctrl->A.file) {Ctrl->Out.file = Ctrl->A.file; Ctrl->A.file = NULL;}	/* Only use Out.file for writing */
+	if (Ctrl->A.file) {
+		Ctrl->Out.file = Ctrl->A.file; Ctrl->A.file = NULL;	/* Only use Out.file for writing */
+		if (strcmp (gmt_get_ext (Ctrl->Out.file), "ppm")) {	/* Turn off the automatic creation of aux files by GDAL */
+#ifdef WIN32
+			if (_putenv ("GDAL_PAM_ENABLED=NO"))
+#else
+			if (setenv ("GDAL_PAM_ENABLED", "NO", 0))
+#endif
+				GMT_Report (API, GMT_MSG_WARNING, "Unable to set GDAL_PAM_ENABLED to prevent writing our auxiliary files\n");
+		}
+	}
 
 	/* Read the illumination grid header right away so we can use its region to set that of an image (if requested) */
 	if (use_intensity_grid) {	/* Illumination grid desired */


### PR DESCRIPTION
WHen GDAL creates rasters that cannot hold geographic metadata it defaults to writing *.xml files.  We don't want that in **grdimage**, hence this PR. @joa-quim should test it on Windows as I am assuming _putenv is available.
