### PR TITLE
Cannot let pshistogram determine region from data

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12957,10 +12957,14 @@ GMT_LOCAL int gmtinit_get_region_from_data (struct GMTAPI_CTRL *API, int family,
 			if (GMT_Close_VirtualFile (API, virt_file) != GMT_NOERROR)
 				return (API->error);
 			/* Get the four values from the first and only output record */
-			wesn[XLO] = Out->table[0]->segment[0]->data[0][0];
-			wesn[XHI] = Out->table[0]->segment[0]->data[1][0];
-			wesn[YLO] = Out->table[0]->segment[0]->data[2][0];
-			wesn[YHI] = Out->table[0]->segment[0]->data[3][0];
+			if (Out->n_columns >= 2) {
+				wesn[XLO] = Out->table[0]->segment[0]->data[0][0];
+				wesn[XHI] = Out->table[0]->segment[0]->data[1][0];
+			}
+			if (Out->n_columns >= 4) {
+				wesn[YLO] = Out->table[0]->segment[0]->data[2][0];
+				wesn[YHI] = Out->table[0]->segment[0]->data[3][0];
+			}
 			if (GMT_Destroy_Data (API, &Out) != GMT_OK)
 				return (API->error);
 			geo = gmt_M_is_geographic (API->GMT, GMT_IN);

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12956,15 +12956,15 @@ GMT_LOCAL int gmtinit_get_region_from_data (struct GMTAPI_CTRL *API, int family,
 			/* Close the virtual files */
 			if (GMT_Close_VirtualFile (API, virt_file) != GMT_NOERROR)
 				return (API->error);
+			if (Out->n_columns > 4) {	/* No can do */
+				GMT_Report (API, GMT_MSG_ERROR, "gmtinit_get_region_from_data: Not enough data columns (%d) to determine region %s.\n", (unsigned int)Out->n_columns);
+				return (GMT_RUNTIME_ERROR);
+			}
 			/* Get the four values from the first and only output record */
-			if (Out->n_columns >= 2) {
-				wesn[XLO] = Out->table[0]->segment[0]->data[0][0];
-				wesn[XHI] = Out->table[0]->segment[0]->data[1][0];
-			}
-			if (Out->n_columns >= 4) {
-				wesn[YLO] = Out->table[0]->segment[0]->data[2][0];
-				wesn[YHI] = Out->table[0]->segment[0]->data[3][0];
-			}
+			wesn[XLO] = Out->table[0]->segment[0]->data[0][0];
+			wesn[XHI] = Out->table[0]->segment[0]->data[1][0];
+			wesn[YLO] = Out->table[0]->segment[0]->data[2][0];
+			wesn[YHI] = Out->table[0]->segment[0]->data[3][0];
 			if (GMT_Destroy_Data (API, &Out) != GMT_OK)
 				return (API->error);
 			geo = gmt_M_is_geographic (API->GMT, GMT_IN);

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -29,7 +29,7 @@
 #define THIS_MODULE_LIB		"core"
 #define THIS_MODULE_PURPOSE	"Calculate and plot histograms"
 #define THIS_MODULE_KEYS	"<D{,CC(,>X},>D),>DI@<D{,ID)"
-#define THIS_MODULE_NEEDS	"Jd"
+#define THIS_MODULE_NEEDS	"J"
 #define THIS_MODULE_OPTIONS "->BJKOPRUVXYbdefhipqstxy" GMT_OPT("Ec")
 
 struct PSHISTOGRAM_CTRL {


### PR DESCRIPTION
Modules reading (x,y) or (lon,lat) data can determine a region from the data set.  However, histogram cannot do that since only one columns is given.  It can determine its domain after doing the histogram counts.  For some reason, its **THIS_MODULE_NEEDS** included a **d** which mean scan the data file - causing the crash reported.
Closes #3098.