### PR TITLE
cmake: Exclude .DS_Store when install directories

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -63,4 +63,5 @@ install (DIRECTORY examples
 	PATTERN "${_exclude_bat}" EXCLUDE
 	PATTERN "CMakeLists.txt" EXCLUDE
 	PATTERN "gmt.history" EXCLUDE
+	PATTERN ".DS_Store" EXCLUDE
 	REGEX "[.](cmake|in|ps)$" EXCLUDE)

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -25,6 +25,7 @@ install (DIRECTORY ${_gmt_share_dirs}
 	DESTINATION ${GMT_DATADIR}
 	COMPONENT Runtime
 	PATTERN "CMakeLists.txt" EXCLUDE
+	PATTERN ".DS_Store" EXCLUDE
 	REGEX "[.](cmake|in)$" EXCLUDE)
 
 # only attempt to install shorelines when requested and path is known


### PR DESCRIPTION
We don't want to install the hidden .DS_Store files.