### PR TITLE
Allow -Vd to debug modern usage

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -642,6 +642,8 @@ GMT_LOCAL void gmtapi_check_for_modern_oneliner (struct GMTAPI_CTRL *API, const 
 	}
 
 	head = GMT_Create_Options (API, mode, args);	/* Get option list */
+	if ((opt = GMT_Find_Option (API, 'V', head)))	/* Remove -V here so that we can run gmt plot -? -Vd and still get modern mode usage plus debug info */
+		GMT_Delete_Option (API, opt, &head);
 
 	API->GMT->current.setting.use_modern_name = gmtlib_is_modern_name (API, module);
 

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -654,7 +654,7 @@ GMT_LOCAL void gmtapi_check_for_modern_oneliner (struct GMTAPI_CTRL *API, const 
 			return;
 		}
 		if (head->next == NULL) {	/* Gave a single argument */
-			if (head->option == GMT_OPT_USAGE || head->option == GMT_OPT_SYNOPSIS) modern = 1;
+			if (head->option == GMT_OPT_USAGE || head->option == GMT_OPT_SYNOPSIS || (head->option == '+' && !head->arg[0])) modern = 1;
 			if (modern) usage = true;
 		}
 	}

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -17419,10 +17419,12 @@ int gmt_report_usage (struct GMTAPI_CTRL *API, struct GMT_OPTION *options, unsig
 	int code = GMT_NOERROR;	/* Default is no usage message was requested and we move on to parsing the arguments */
 	if (API->GMT->current.setting.run_mode == GMT_MODERN) {	/* Under modern mode we always require an option like -? or -^ to call usage */
 		if (options) {	/* Modern mode will only print the usage if one of the usage-options are given (but see exception for one-liners) */
-			if (options->option == GMT_OPT_USAGE)	/* Return the usage message */
+			if (options->option == GMT_OPT_USAGE)	/* -? Return the usage message */
 				code = GMT_OPT_USAGE;
-			if (options->option == GMT_OPT_SYNOPSIS)	/* Return the synopsis message */
+			else if (options->option == GMT_OPT_SYNOPSIS)	/* -^ or - Return the synopsis message */
 				code = GMT_SYNOPSIS;
+			else if (options->option == '+' && !options->arg[0])	/* -+ Return the extended synopsis message */
+				code = GMT_OPT_USAGE, API->GMT->common.synopsis.extended = true;
 		}
 		else if (API->usage)	/* One-liner modern mode with no args must give usage */
 			code = GMT_OPT_USAGE;


### PR DESCRIPTION
Commands like `gmt plot -? -Vd` would refuse to show the moderm mode syntax since the **-Vd** messed up the option count.  I now deal with this so that developers can run the synopsis cases with full debug.  However, I cannot get `gmt plot -Vd `to not complain, but this is not a likely command; developers can run `gmt plot -? -Vd` to test that case.
