### PR TITLE
doc: Fix grdimage documentation

### DIFF
--- a/doc/rst/source/grdimage_common.rst_
+++ b/doc/rst/source/grdimage_common.rst_
@@ -57,7 +57,7 @@ Optional Arguments
     the image file name and extension. If the extension is one of .bmp, .gif, .jpg, .png, or .tif
     then no driver information is required. For other output formats you must append the required
     GDAL driver. The *driver* is the driver code name used by GDAL; see your GDAL installation's
-    documentation for available drivers. Append a +c<options> string where *options* is a list of
+    documentation for available drivers. Append a **+c**\ *options* string where *options* is a list of
     one or more concatenated number of GDAL -co options. For example, to write a GeoPDF with the
     TerraGo format use *=PDF+cGEO_ENCODING=OGC_BP*. Notes: (1) If a tiff file (.tif) is selected
     then we will write a GeoTiff image if the GMT projection syntax translates into a PROJ syntax,

--- a/doc/rst/source/grdimage_common.rst_
+++ b/doc/rst/source/grdimage_common.rst_
@@ -58,7 +58,7 @@ Optional Arguments
     then no driver information is required. For other output formats you must append the required
     GDAL driver. The *driver* is the driver code name used by GDAL; see your GDAL installation's
     documentation for available drivers. Append a **+c**\ *options* string where *options* is a list of
-    one or more concatenated number of GDAL -co options. For example, to write a GeoPDF with the
+    one or more concatenated number of GDAL **-co** options. For example, to write a GeoPDF with the
     TerraGo format use *=PDF+cGEO_ENCODING=OGC_BP*. Notes: (1) If a tiff file (.tif) is selected
     then we will write a GeoTiff image if the GMT projection syntax translates into a PROJ syntax,
     otherwise a plain tiff file is produced. (2) Any vector elements will be lost.


### PR DESCRIPTION
The documentation says:
```
Append a +c<options> string where options is a list of 
one or more concatenated number of GDAL -co options.
```

What does the "GDAL -co options" mean? Typo?