### PR TITLE
Change geographic grid to Cartesian

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -1891,6 +1891,22 @@ int gmt_decode_grd_h_info (struct GMT_CTRL *GMT, char *input, struct GMT_GRID_HE
 	return (int)uerr;
 }
 
+void gmt_grd_set_cartesian (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h, unsigned int direction) {
+	/* When we need to turn a geographic grid into a Cartesian grid type.
+	 * direction is 0 for input, 1 for output, and 2 for both */
+	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (h);
+	if (direction == GMT_IO) {	/* Set Cartesian for both directions */
+		gmt_set_cartesian (GMT, GMT_IN);
+		gmt_set_cartesian (GMT, GMT_OUT);
+	}
+	else
+		gmt_set_cartesian (GMT, direction);
+	/* Reset the units from degree_longitude/latitude to plain x/y */
+	strcpy (h->x_units, "x");
+	strcpy (h->y_units, "y");
+	HH->grdtype = GMT_GRID_CARTESIAN;	/* Set hidden type to Cartesian */
+}
+
 void gmt_grd_info_syntax (struct GMT_CTRL *GMT, char option) {
 	/* Display the option for setting grid metadata in grdedit etc. */
 	GMT_Message (GMT->parent, GMT_TIME_NONE, "\t-%c Append grid header information as one string composed of one or\n", option);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -172,6 +172,7 @@ EXTERN_MSC bool gmt_file_is_srtmtile (struct GMTAPI_CTRL *API, const char *file,
 
 /* gmt_grdio.c: */
 
+EXTERN_MSC void gmt_grd_set_cartesian (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h, unsigned int direction);
 EXTERN_MSC int gmt_img_sanitycheck (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h);
 EXTERN_MSC void gmt_grd_flip_vertical (void *gridp, const unsigned n_cols, const unsigned n_rows, const unsigned n_stride, size_t cell_size);
 EXTERN_MSC int gmt_raster_type (struct GMT_CTRL *GMT, char *file);


### PR DESCRIPTION
When a geographic grid has its region extended in grdcut and elsewhere, we must change it to Cartesian if it exceeds valid limits on longitude or latitude.
The immediate need is in grd2kml where the quadtree algorithm requires me to extend the global grid to -180/180/-180/180 for a square grid.  It then needs to loose its geographicity so that other modules dont go crazy and complain about latitudes out of range.  This happens via a call to GMT_grdcut, hence the change is in that module where -N can adjust the grid region and fill in NaNs.