### PR TITLE
cmake: Allow renaming non-GMT supplement DLLs on Windows

### DIFF
--- a/cmake/ConfigUserAdvancedTemplate.cmake
+++ b/cmake/ConfigUserAdvancedTemplate.cmake
@@ -197,9 +197,6 @@
 # These supplemental modules end up in supplements.so like the GMT supplements.
 #set (EXTRA_BUILD_DIRS newsuppl1 newsuppl2 ...)
 
-# List extra new supplemental modules for testing without adding them to the module list
-#set (EXTRA_MODULES_SUPPL newsuppl1.c newsuppl2.c)
-
 # Directory in which to install the release sources per default
 # [${GMT_BINARY_DIR}/gmt-${GMT_PACKAGE_VERSION}]:
 #set (GMT_RELEASE_PREFIX "release-src-prefix")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -770,14 +770,6 @@ if (BUILD_SUPPLEMENTS)
 			COMPONENT Runtime)
 	endforeach (_suppl_lib_name ${GMT_SUPPL_LIBRARIES})
 
-	# Include any extra files that are listed in EXTRA_MODULES_SUPPL defined in ConfigUserAdvanced.cmake
-	# This include(s) will add new modules to the official GMT supplements
-	if (EXTRA_MODULES_SUPPL)
-		foreach (_f ${EXTRA_MODULES_SUPPL})
-			include (${_f})
-		endforeach(_f)
-	endif (EXTRA_MODULES_SUPPL)
-
 	# install more
 	foreach (_dir ${GMT_SUPPL_DIRS})
 		# get variables from subdirectory
@@ -809,14 +801,6 @@ if (BUILD_SUPPLEMENTS)
 		endif (BUILD_DEVELOPER)
 	endforeach (_dir)
 endif (BUILD_SUPPLEMENTS)
-
-# Include any extra files that are listed in EXTRA_INCLUDE_NEWSUPPL defined in ConfigUserAdvanced.cmake
-# This include(s) will create new pluggins
-if (EXTRA_INCLUDE_NEWSUPPL)
-	foreach (_f ${EXTRA_INCLUDE_NEWSUPPL})
-		include (${_f})
-	endforeach(_f)
-endif (EXTRA_INCLUDE_NEWSUPPL)
 
 
 ##

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -698,6 +698,9 @@ if (BUILD_SUPPLEMENTS)
 		# supplement extra libraries for each supplement library
 		get_subdir_var (_suppl_extra_libraries SUPPL_EXTRA_LIBS ${_dir})
 		list (APPEND SUPPL_${_suppl_lib_name}_EXTRA_LIBRARIES ${_suppl_extra_libraries})
+
+		# rename the supplement dll [Windows only]
+		get_subdir_var (SUPPL_${_suppl_lib_name}_DLL_RENAME SUPPL_DLL_RENAME ${_dir})
 	endforeach (_dir)
 
 	# remove duplicate supplement library names, so multiple supplement packages can be built into one single library
@@ -751,6 +754,11 @@ if (BUILD_SUPPLEMENTS)
 		if (WIN32 AND ${_suppl_lib_name} STREQUAL "supplements" AND SUPP_DLL_RENAME)
 			set_target_properties (${_suppl_lib_name} PROPERTIES RUNTIME_OUTPUT_NAME ${SUPP_DLL_RENAME})
 		endif (WIN32 AND ${_suppl_lib_name} STREQUAL "supplements" AND SUPP_DLL_RENAME)
+
+		# Rename non-GMT supplement DLLs
+		if (WIN32 AND SUPPL_${_suppl_lib_name}_DLL_RENAME)
+			set_target_properties (${_suppl_lib_name} PROPERTIES RUNTIME_OUTPUT_NAME ${SUPPL_${_suppl_lib_name}_DLL_RENAME})
+		endif (WIN32 AND SUPPL_${_suppl_lib_name}_DLL_RENAME)
 
 		# Testing
 		add_dependencies (check ${_suppl_lib_name})


### PR DESCRIPTION
Add the following line to `src/newsuppl/CMakeLists.txt` to rename DLLs on Windows:
```
set (SUPPL_DLL_RENAME "newsuppl_w64")
```

I aslo clean up two cmake variables EXTRA_MODULES_SUPPL and EXTRA_INCLUDE_NEWSUPPL,
since they are no longer used.


Address #2917 and #3090