### PR TITLE
cmake: Fix some comment lines in CMakeLists.txt

### DIFF
--- a/src/geodesy/CMakeLists.txt
+++ b/src/geodesy/CMakeLists.txt
@@ -17,8 +17,8 @@
 #
 # CMake settings for supplemental package:
 #
-# 	SUPPL_NAME:          name of the supplemental package
-#   SUPPL_HEADERS:       header files. Will be installed if BUILD_SUPPLEMENTS is TRUE
+#   SUPPL_NAME:          name of the supplemental package
+#   SUPPL_HEADERS:       header files. Will be installed if BUILD_DEVELOPER is TRUE
 #   SUPPL_PROGS_SRCS:    list of C source codes for supplemental modules
 #   SUPPL_LIB_SRCS:      list of C source codes for supplemental library
 #   SUPPL_EXAMPLE_FILES: README and other example files

--- a/src/gshhg/CMakeLists.txt
+++ b/src/gshhg/CMakeLists.txt
@@ -17,8 +17,8 @@
 #
 # CMake settings for supplemental package:
 #
-# 	SUPPL_NAME:          name of the supplemental package
-#   SUPPL_HEADERS:       header files. Will be installed if BUILD_SUPPLEMENTS is TRUE
+#   SUPPL_NAME:          name of the supplemental package
+#   SUPPL_HEADERS:       header files. Will be installed if BUILD_DEVELOPER is TRUE
 #   SUPPL_PROGS_SRCS:    list of C source codes for supplemental modules
 #   SUPPL_LIB_SRCS:      list of C source codes for supplemental library
 #   SUPPL_EXAMPLE_FILES: README and other example files

--- a/src/img/CMakeLists.txt
+++ b/src/img/CMakeLists.txt
@@ -17,8 +17,8 @@
 #
 # CMake settings for supplemental package:
 #
-# 	SUPPL_NAME:          name of the supplemental package
-#   SUPPL_HEADERS:       header files. Will be installed if BUILD_SUPPLEMENTS is TRUE
+#   SUPPL_NAME:          name of the supplemental package
+#   SUPPL_HEADERS:       header files. Will be installed if BUILD_DEVELOPER is TRUE
 #   SUPPL_PROGS_SRCS:    list of C source codes for supplemental modules
 #   SUPPL_LIB_SRCS:      list of C source codes for supplemental library
 #   SUPPL_EXAMPLE_FILES: README and other example files

--- a/src/mgd77/CMakeLists.txt
+++ b/src/mgd77/CMakeLists.txt
@@ -17,8 +17,8 @@
 #
 # CMake settings for supplemental package:
 #
-# 	SUPPL_NAME:          name of the supplemental package
-#   SUPPL_HEADERS:       header files. Will be installed if BUILD_SUPPLEMENTS is TRUE
+#   SUPPL_NAME:          name of the supplemental package
+#   SUPPL_HEADERS:       header files. Will be installed if BUILD_DEVELOPER is TRUE
 #   SUPPL_PROGS_SRCS:    list of C source codes for supplemental modules
 #   SUPPL_LIB_SRCS:      list of C source codes for supplemental library
 #   SUPPL_EXAMPLE_FILES: README and other example files

--- a/src/potential/CMakeLists.txt
+++ b/src/potential/CMakeLists.txt
@@ -17,8 +17,8 @@
 #
 # CMake settings for supplemental package:
 #
-# 	SUPPL_NAME:          name of the supplemental package
-#   SUPPL_HEADERS:       header files. Will be installed if BUILD_SUPPLEMENTS is TRUE
+#   SUPPL_NAME:          name of the supplemental package
+#   SUPPL_HEADERS:       header files. Will be installed if BUILD_DEVELOPER is TRUE
 #   SUPPL_PROGS_SRCS:    list of C source codes for supplemental modules
 #   SUPPL_LIB_SRCS:      list of C source codes for supplemental library
 #   SUPPL_EXAMPLE_FILES: README and other example files

--- a/src/segy/CMakeLists.txt
+++ b/src/segy/CMakeLists.txt
@@ -17,8 +17,8 @@
 #
 # CMake settings for supplemental package:
 #
-# 	SUPPL_NAME:          name of the supplemental package
-#   SUPPL_HEADERS:       header files. Will be installed if BUILD_SUPPLEMENTS is TRUE
+#   SUPPL_NAME:          name of the supplemental package
+#   SUPPL_HEADERS:       header files. Will be installed if BUILD_DEVELOPER is TRUE
 #   SUPPL_PROGS_SRCS:    list of C source codes for supplemental modules
 #   SUPPL_LIB_SRCS:      list of C source codes for supplemental library
 #   SUPPL_EXAMPLE_FILES: README and other example files

--- a/src/seis/CMakeLists.txt
+++ b/src/seis/CMakeLists.txt
@@ -17,8 +17,8 @@
 #
 # CMake settings for supplemental package:
 #
-# 	SUPPL_NAME:          name of the supplemental package
-#   SUPPL_HEADERS:       header files. Will be installed if BUILD_SUPPLEMENTS is TRUE
+#   SUPPL_NAME:          name of the supplemental package
+#   SUPPL_HEADERS:       header files. Will be installed if BUILD_DEVELOPER is TRUE
 #   SUPPL_PROGS_SRCS:    list of C source codes for supplemental modules
 #   SUPPL_LIB_SRCS:      list of C source codes for supplemental library
 #   SUPPL_EXAMPLE_FILES: README and other example files

--- a/src/spotter/CMakeLists.txt
+++ b/src/spotter/CMakeLists.txt
@@ -17,8 +17,8 @@
 #
 # CMake settings for supplemental package:
 #
-# 	SUPPL_NAME:          name of the supplemental package
-#   SUPPL_HEADERS:       header files. Will be installed if BUILD_SUPPLEMENTS is TRUE
+#   SUPPL_NAME:          name of the supplemental package
+#   SUPPL_HEADERS:       header files. Will be installed if BUILD_DEVELOPER is TRUE
 #   SUPPL_PROGS_SRCS:    list of C source codes for supplemental modules
 #   SUPPL_LIB_SRCS:      list of C source codes for supplemental library
 #   SUPPL_EXAMPLE_FILES: README and other example files

--- a/src/x2sys/CMakeLists.txt
+++ b/src/x2sys/CMakeLists.txt
@@ -17,8 +17,8 @@
 #
 # CMake settings for supplemental package:
 #
-# 	SUPPL_NAME:          name of the supplemental package
-#   SUPPL_HEADERS:       header files. Will be installed if BUILD_SUPPLEMENTS is TRUE
+#   SUPPL_NAME:          name of the supplemental package
+#   SUPPL_HEADERS:       header files. Will be installed if BUILD_DEVELOPER is TRUE
 #   SUPPL_PROGS_SRCS:    list of C source codes for supplemental modules
 #   SUPPL_LIB_SRCS:      list of C source codes for supplemental library
 #   SUPPL_EXAMPLE_FILES: README and other example files


### PR DESCRIPTION
Header files are installed if BUILD_DEVELOPER is TRUE.

Fix the typos in CMakeLists.txt.