### PR TITLE
Ensure hoels of polygons have correct handedness

### DIFF
--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -257,6 +257,11 @@ enum GMT_enum_inside {
 	GMT_ONEDGE,
 	GMT_INSIDE};
 
+/*! Return codes from gmt_polygon_orientation */
+enum GMT_enum_polorient {
+	GMT_POL_IS_CCW = 0,
+	GMT_POL_IS_CW  = 1};
+
 /*! Codes for -q selections */
 enum GMT_enum_skiprows {
 	GMT_RANGE_ROW_IN   = 1,

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -351,6 +351,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC unsigned int gmt_polygon_orientation (struct GMT_CTRL *GMT, double x[], double y[], uint64_t n, int geo);
 EXTERN_MSC struct GMT_CONTOUR_INFO * gmt_get_contours_from_table (struct GMT_CTRL *GMT, char *file, bool inner_ticks, unsigned int *type, unsigned int *n_contours);
 EXTERN_MSC int gmt_signum (double x);
 EXTERN_MSC void gmt_get_rgb_lookup (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, int index, double value, double *rgb);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15717,6 +15717,17 @@ double gmt_centroid_area (struct GMT_CTRL *GMT, double x[], double y[], uint64_t
 	return (area);
 }
 
+unsigned int gmt_polygon_orientation (struct GMT_CTRL *GMT, double x[], double y[], uint64_t n, int geo) {
+	/* Estimate area of a polygon.  geo is 1 if geographic data. Input data remains unchanged.
+	 * Since area will be +ve if polygon is CW, negative if CCW we return */
+	double area, dummy[2];
+	if (geo)	/* Spherical centroid and area */
+		area = gmtlib_geo_centroid_area (GMT, x, y, n, dummy);
+	else	/* Cartesian centroid and area */
+		area = gmtsupport_cart_centroid_area (GMT, x, y, n, dummy);
+	return ((area < 0.0) ? GMT_POL_IS_CCW : GMT_POL_IS_CW);
+}
+
 /*! . */
 void gmt_mean_point (struct GMT_CTRL *GMT, double x[], double y[], uint64_t n, int geo, double *pos) {
 	/* Estimate mean position.  geo is 1 if geographic data (requiring vector mean).  Input data remains unchanged. */

--- a/src/gmtspatial.c
+++ b/src/gmtspatial.c
@@ -33,9 +33,6 @@
 #define THIS_MODULE_NEEDS	""
 #define THIS_MODULE_OPTIONS "-:RVabdefghijoqs" GMT_OPT("HMm")
 
-#define POL_IS_CW	1
-#define POL_IS_CCW	0
-
 #define GMT_W	3
 
 #define POL_UNION		1
@@ -187,7 +184,7 @@ GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct GMTSPATIAL_CTRL *C) {	/* 
 GMT_LOCAL unsigned int gmtspatial_area_size (struct GMT_CTRL *GMT, double x[], double y[], uint64_t n, double *out, int geo) {
 	double size = gmt_centroid_area (GMT, x, y, n, geo, out);
  	out[GMT_Z] = fabs (size);
-	return ((size < 0.0) ? POL_IS_CCW : POL_IS_CW);
+	return ((size < 0.0) ? GMT_POL_IS_CCW : GMT_POL_IS_CW);
 }
 
 #if 0
@@ -243,7 +240,7 @@ GMT_LOCAL unsigned int gmtspatial_gmtspatial_area_size_old (struct GMT_CTRL *GMT
 	gmt_M_free (GMT, yp);
 	if (geo) size *= (GMT->current.map.dist[GMT_MAP_DIST].scale * GMT->current.map.dist[GMT_MAP_DIST].scale);
 	out[GMT_Z] = fabs (size);
-	return ((size < 0.0) ? POL_IS_CCW : POL_IS_CW);
+	return ((size < 0.0) ? GMT_POL_IS_CCW : GMT_POL_IS_CW);
 }
 #endif
 
@@ -914,9 +911,9 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMTSPATIAL_CTRL *Ctrl, struct 
 			case 'E':	/* Orient polygons -E+n|p  (old -E-|+) */
 			 	Ctrl->E.active = true;
 				if (opt->arg[0] == '-' || strstr (opt->arg, "+n"))
-					Ctrl->E.mode = POL_IS_CW;
+					Ctrl->E.mode = GMT_POL_IS_CW;
 				else if (opt->arg[0] == '+' || strstr (opt->arg, "+p"))
-					Ctrl->E.mode = POL_IS_CCW;
+					Ctrl->E.mode = GMT_POL_IS_CCW;
 				else
 					n_errors++;
 				break;

--- a/test/psxy/polyholes.ps
+++ b/test/psxy/polyholes.ps
@@ -1,0 +1,1606 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.1.0_dcc5679-dirty_2020.04.20 [64-bit] Document from psxy
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Mon Apr 20 19:31:48 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt psxy quads.dat -JX10c -Ba2f1 -BWSen -R-0.5/10.5/-0.5/10.5 -Gred -W1p
+%@PROJ: xy -0.50000000 10.50000000 -0.50000000 10.50000000 -0.500 10.500 -0.500 10.500 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 215 M -83 0 D S
+N 0 1074 M -83 0 D S
+N 0 1933 M -83 0 D S
+N 0 2792 M -83 0 D S
+N 0 3651 M -83 0 D S
+N 0 4510 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+(10) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+215 PSL_A0_y MM
+(0) mr Z
+1074 PSL_A0_y MM
+(2) mr Z
+1933 PSL_A0_y MM
+(4) mr Z
+2792 PSL_A0_y MM
+(6) mr Z
+3651 PSL_A0_y MM
+(8) mr Z
+4510 PSL_A0_y MM
+(10) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 644 M -42 0 D S
+N 0 1503 M -42 0 D S
+N 0 2362 M -42 0 D S
+N 0 3221 M -42 0 D S
+N 0 4080 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+4724 0 T
+25 W
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 215 M 83 0 D S
+N 0 1074 M 83 0 D S
+N 0 1933 M 83 0 D S
+N 0 2792 M 83 0 D S
+N 0 3651 M 83 0 D S
+N 0 4510 M 83 0 D S
+N 0 644 M 42 0 D S
+N 0 1503 M 42 0 D S
+N 0 2362 M 42 0 D S
+N 0 3221 M 42 0 D S
+N 0 4080 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-4724 0 T
+25 W
+N 0 0 M 4724 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 215 0 M 0 -83 D S
+N 1074 0 M 0 -83 D S
+N 1933 0 M 0 -83 D S
+N 2792 0 M 0 -83 D S
+N 3651 0 M 0 -83 D S
+N 4510 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+215 PSL_A0_y MM
+(0) bc Z
+1074 PSL_A0_y MM
+(2) bc Z
+1933 PSL_A0_y MM
+(4) bc Z
+2792 PSL_A0_y MM
+(6) bc Z
+3651 PSL_A0_y MM
+(8) bc Z
+4510 PSL_A0_y MM
+(10) bc Z
+N 644 0 M 0 -42 D S
+N 1503 0 M 0 -42 D S
+N 2362 0 M 0 -42 D S
+N 3221 0 M 0 -42 D S
+N 4080 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 4724 T
+25 W
+N 0 0 M 4724 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 215 0 M 0 83 D S
+N 1074 0 M 0 83 D S
+N 1933 0 M 0 83 D S
+N 2792 0 M 0 83 D S
+N 3651 0 M 0 83 D S
+N 4510 0 M 0 83 D S
+N 644 0 M 0 42 D S
+N 1503 0 M 0 42 D S
+N 2362 0 M 0 42 D S
+N 3221 0 M 0 42 D S
+N 4080 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -4724 T
+0 setlinecap
+17 W
+clipsave
+0 0 M
+4724 0 D
+0 4724 D
+-4724 0 D
+P
+PSL_clip N
+{1 0 0 C} FS
+O1
+O0
+/FO {P}!
+-2147 0 0 4295 2147 0 3 215 215 SP
+0 -859 859 0 0 859 3 1074 644 SP
+0 -859 859 0 0 859 3 1074 1933 SP
+-859 0 0 -859 859 0 3 1074 4080 SP
+/FO {fs os}!
+FO
+O1
+215 215 M
+2147 0 D
+0 4295 D
+-2147 0 D
+P S
+1074 644 M
+0 859 D
+859 0 D
+0 -859 D
+P S
+1074 1933 M
+0 859 D
+859 0 D
+0 -859 D
+P S
+1074 4080 M
+859 0 D
+0 -859 D
+-859 0 D
+P S
+{0 0 1 C} FS
+O0
+/FO {P}!
+0 -4295 2148 0 0 4295 3 2362 215 SP
+-859 0 0 859 859 0 3 3221 644 SP
+-859 0 0 859 859 0 3 3221 1933 SP
+/FO {fs os}!
+FO
+O1
+2362 215 M
+0 4295 D
+2148 0 D
+0 -4295 D
+P S
+3221 644 M
+859 0 D
+0 859 D
+-859 0 D
+P S
+3221 1933 M
+859 0 D
+0 859 D
+-859 0 D
+P S
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 5669 TM
+% PostScript produced by:
+%@GMT: gmt psxy quads.dat -JM10c -Ba2f1 -BWSen -Gred -W1p -Y12c -R-0.5/10.5/-0.5/10.5
+%@PROJ: merc -0.50000000 10.50000000 -0.50000000 10.50000000 -612257.199 612257.199 -55287.849 1167670.999 +proj=merc +lon_0=5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+8 W
+N 215 0 M 0 -83 D S
+N 215 4718 M 0 84 D S
+N 1074 0 M 0 -83 D S
+N 1074 4718 M 0 84 D S
+N 1933 0 M 0 -83 D S
+N 1933 4718 M 0 84 D S
+N 2792 0 M 0 -83 D S
+N 2792 4718 M 0 84 D S
+N 3651 0 M 0 -83 D S
+N 3651 4718 M 0 84 D S
+N 4510 0 M 0 -83 D S
+N 4510 4718 M 0 84 D S
+N 0 213 M -83 0 D S
+N 4724 213 M 84 0 D S
+N 0 1067 M -83 0 D S
+N 4724 1067 M 84 0 D S
+N 0 1921 M -83 0 D S
+N 4724 1921 M 84 0 D S
+N 0 2778 M -83 0 D S
+N 4724 2778 M 84 0 D S
+N 0 3638 M -83 0 D S
+N 4724 3638 M 84 0 D S
+N 0 4502 M -83 0 D S
+N 4724 4502 M 84 0 D S
+83 W
+1 A
+N -42 0 M 0 213 D S
+N 4766 0 M 0 213 D S
+0 A
+N -42 213 M 0 427 D S
+N 4766 213 M 0 427 D S
+1 A
+N -42 640 M 0 427 D S
+N 4766 640 M 0 427 D S
+0 A
+N -42 1067 M 0 427 D S
+N 4766 1067 M 0 427 D S
+1 A
+N -42 1494 M 0 427 D S
+N 4766 1494 M 0 427 D S
+0 A
+N -42 1921 M 0 428 D S
+N 4766 1921 M 0 428 D S
+1 A
+N -42 2349 M 0 429 D S
+N 4766 2349 M 0 429 D S
+0 A
+N -42 2778 M 0 429 D S
+N 4766 2778 M 0 429 D S
+1 A
+N -42 3207 M 0 431 D S
+N 4766 3207 M 0 431 D S
+0 A
+N -42 3638 M 0 431 D S
+N 4766 3638 M 0 431 D S
+1 A
+N -42 4069 M 0 433 D S
+N 4766 4069 M 0 433 D S
+0 A
+N -42 4502 M 0 216 D S
+N 4766 4502 M 0 216 D S
+1 A
+N 0 -42 M 215 0 D S
+N 0 4760 M 215 0 D S
+0 A
+N 215 -42 M 429 0 D S
+N 215 4760 M 429 0 D S
+1 A
+N 644 -42 M 430 0 D S
+N 644 4760 M 430 0 D S
+0 A
+N 1074 -42 M 429 0 D S
+N 1074 4760 M 429 0 D S
+1 A
+N 1503 -42 M 430 0 D S
+N 1503 4760 M 430 0 D S
+0 A
+N 1933 -42 M 429 0 D S
+N 1933 4760 M 429 0 D S
+1 A
+N 2362 -42 M 430 0 D S
+N 2362 4760 M 430 0 D S
+0 A
+N 2792 -42 M 429 0 D S
+N 2792 4760 M 429 0 D S
+1 A
+N 3221 -42 M 430 0 D S
+N 3221 4760 M 430 0 D S
+0 A
+N 3651 -42 M 429 0 D S
+N 3651 4760 M 429 0 D S
+1 A
+N 4080 -42 M 430 0 D S
+N 4080 4760 M 430 0 D S
+0 A
+N 4510 -42 M 214 0 D S
+N 4510 4760 M 214 0 D S
+8 W
+N -83 0 M 4891 0 D S
+N -83 -83 M 4891 0 D S
+N 4724 -83 M 0 4885 D S
+N 4808 -83 M 0 4885 D S
+N 4808 4718 M -4891 0 D S
+N 4808 4802 M -4891 0 D S
+N 0 4802 M 0 -4885 D S
+N -83 4802 M 0 -4885 D S
+215 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0°) tc Z
+1074 -167 M (2°) tc Z
+1933 -167 M (4°) tc Z
+2792 -167 M (6°) tc Z
+3651 -167 M (8°) tc Z
+4510 -167 M (10°) tc Z
+-167 213 M (0°) mr Z
+-167 1067 M (2°) mr Z
+-167 1921 M (4°) mr Z
+-167 2778 M (6°) mr Z
+-167 3638 M (8°) mr Z
+-167 4502 M (10°) mr Z
+17 W
+clipsave
+0 0 M
+4724 0 D
+0 4718 D
+-4724 0 D
+P
+PSL_clip N
+{1 0 0 C} FS
+O1
+O0
+/FO {P}!
+215 213 M
+2147 0 D
+0 4289 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-572 3 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-420 1 D
+-12 -1 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 -1 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 -1 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 -1 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+P
+FO
+0 -854 859 0 0 854 3 1074 640 SP
+0 -857 859 0 0 857 3 1074 1921 SP
+-859 0 0 -862 859 0 3 1074 4069 SP
+/FO {fs os}!
+FO
+O1
+215 213 M
+2147 0 D
+0 4289 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-572 3 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-420 1 D
+-12 -1 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 -1 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 -1 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 -1 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+P S
+1074 640 M
+0 854 D
+859 0 D
+0 -854 D
+P S
+1074 1921 M
+0 857 D
+859 0 D
+0 -857 D
+P S
+1074 4069 M
+859 0 D
+0 -862 D
+-859 0 D
+P S
+{0 0 1 C} FS
+O0
+/FO {P}!
+2362 213 M
+0 4289 D
+750 3 D
+521 1 D
+737 -3 D
+140 -1 D
+0 -4289 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+P
+FO
+-859 0 0 854 859 0 3 3221 640 SP
+-859 0 0 857 859 0 3 3221 1921 SP
+/FO {fs os}!
+FO
+O1
+2362 213 M
+0 4289 D
+750 3 D
+521 1 D
+737 -3 D
+140 -1 D
+0 -4289 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+P S
+3221 640 M
+859 0 D
+0 854 D
+-859 0 D
+P S
+3221 1921 M
+859 0 D
+0 857 D
+-859 0 D
+P S
+PSL_cliprestore
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psxy/polyholes.sh
+++ b/test/psxy/polyholes.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Test that polygons with holes plot correctly regardless of handedness
+# for both geo and Cartesian plots
+cat << EOF > quads.dat
+> -Gred CCW
+0  0
+5  0
+5  10
+0  10
+0  0
+> -Ph  CW
+2  1
+2  3
+4  3
+4  1
+2  1
+> -Ph  CCW
+2  4
+4  4
+4  6
+2  6
+2  4
+> -Ph CCW origin TopLeft
+2  9
+2  7
+4  7
+4  9
+2  9
+> CW -Gblue
+5  0
+5  10
+10 10
+10 0
+5  0
+> -Ph  CW
+7  1
+7  3
+9  3
+9  1
+7  1
+> -Ph  CCW
+7  4
+9  4
+9  6
+7  6
+7  4
+EOF
+gmt begin polyholes ps
+	gmt plot quads.dat -JX10c -Ba2f1 -BWSen -R-0.5/10.5/-0.5/10.5 -Gred -W1p
+	gmt plot quads.dat -JM10c -Ba2f1 -BWSen -Gred -W1p -Y12c
+gmt end show


### PR DESCRIPTION
Do not trust the incoming data.  For polygons with holes that need to be filled, we ensure the holes have a different handedness than the parent, reversing the child if needed.  Closes #3135.
