### PR TITLE
Limit -J to x|X for histogram

### DIFF
--- a/doc/rst/source/histogram_common.rst_
+++ b/doc/rst/source/histogram_common.rst_
@@ -14,7 +14,8 @@ Required Arguments
 .. _-J:
 
 **-Jx**
-    *xscale[/yscale]* (Linear scale(s) in distance unit/data unit).
+    *xscale*\ [/*yscale*] (Linear scale(s) in distance unit/data unit), or
+    **-JX** with *width*\ [/*height*] dimensions.
 
 .. _-T:
 

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -472,7 +472,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
-	GMT_Option (API, "J");
+	GMT_Message (API, GMT_TIME_NONE, "\t-Jx|X<x-scl>|<width>[/<y-scl>|<height>] for Cartesian scaling.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-T Make evenly spaced bin boundaries from <min> to <max> by <inc>.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If <min>/<max> is not given then boundaries in -R is used.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +n to indicate <inc> is the number of bin boundaries to produce instead.\n");
@@ -784,6 +784,11 @@ int GMT_pshistogram (void *V_API, int mode, void *args) {
 	if ((error = parse (GMT, Ctrl, options)) != 0) Return (error);
 
 	/*---------------------------- This is the pshistogram main code ----------------------------*/
+
+	if (GMT->current.proj.projection != GMT_LINEAR) {
+		GMT_Report (API, GMT_MSG_ERROR, "Option -J: Only Cartesian scaling available in this module.\n");
+		Return (GMT_RUNTIME_ERROR);
+	}
 
 	GMT_Report (API, GMT_MSG_INFORMATION, "Processing input table data\n");
 	gmt_M_memset (&F, 1, struct PSHISTOGRAM_INFO);


### PR DESCRIPTION
It currently prints out all the map projections.  Closes #3140.