### PR TITLE
Implement the proj4 construct "source +to destiny" in mapproject

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15541,6 +15541,13 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 				}
 				else {
 					size_t len, k = 3;
+
+					if (!strcmp(GMT->init.module_name, "grdproject")) {
+						GMT_Report(GMT->parent, GMT_MSG_ERROR, "Cannot use the PROJ +to construct here. Not implemented, try grdgdal instead.\n\n");
+						error = 1;
+						break;
+					}
+
 					len = strlen(pch);
 					pch[0] = '\0';
 					error  = gmtinit_parse_proj4 (GMT, item, source);
@@ -15551,7 +15558,12 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 						error = 1;
 						break;
 					}
+					if (GMT->current.proj.projection_GMT != GMT_LINEAR)
+						GMT->current.proj.proj4_is_cart[0] = true;		/* Need to know this in mapproject*/
+
 					error += gmtinit_parse_proj4 (GMT, &pch[k], dest);
+					if (GMT->current.proj.projection_GMT != GMT_LINEAR)
+						GMT->current.proj.proj4_is_cart[1] = true;
 				}
 				GMT->current.gdal_read_in.hCT_fwd = gmt_OGRCoordinateTransformation (GMT, source, dest);
 				GMT->current.gdal_read_in.hCT_inv = gmt_OGRCoordinateTransformation (GMT, dest, source);

--- a/src/gmt_project.h
+++ b/src/gmt_project.h
@@ -427,6 +427,7 @@ struct GMT_PROJ {
 	/* PROJ4 variables */
 	double proj4_x0, proj4_y0, proj4_scl;
 	bool is_proj4;
+	bool proj4_is_cart[2];	/* Fist is for origin ref sys and second (if requested) for destiny */
 };
 
 enum GMT_enum_frame {GMT_IS_PLAIN = 0,	/* Plain baseframe */

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -1115,6 +1115,13 @@ int GMT_mapproject (void *V_API, int mode, void *args) {
 		gmt_set_geographic (GMT, GMT_OUT);	/* Inverse projection expects x,y and gives lon, lat */
 		gmt_set_cartesian (GMT, GMT_IN);
 	}
+	else if (GMT->current.proj.proj4_is_cart[0]) {	/* Proj4 used and starting ref system is not geog */
+		gmt_set_cartesian(GMT, GMT_IN);
+		if (GMT->current.proj.proj4_is_cart[1])
+			gmt_set_cartesian(GMT, GMT_OUT);
+		else
+			gmt_set_geographic(GMT, GMT_OUT);
+	}
 	else if (datum_conv_only || Ctrl->N.active) {	/* Both in and out are geographic */
 		gmt_set_geographic (GMT, GMT_IN);
 		gmt_set_geographic (GMT, GMT_OUT);


### PR DESCRIPTION
And forbid it in grdproject. Quite hard to implement because it needs to know the intermediate -R and to initialize many function pointers that depend on the destiny projection.

Closes #3147