### PR TITLE
Define UC_IP() for RISC-V and SuperH

### DIFF
--- a/src/common_sighandler.c
+++ b/src/common_sighandler.c
@@ -86,6 +86,8 @@ void backtrace_symbols_fd(void *const *buffer, int size, int fd) {
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.sc_iaoq[0])
 # elif defined(__m68k__)
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.gregs[R_PC])
+# elif defined(__riscv)
+#  define UC_IP(uc) ((void *) (uc)->uc_mcontext.__gregs[REG_PC])
 # elif defined(__s390__)
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.psw.addr)
 # elif defined(__sparc__)

--- a/src/common_sighandler.c
+++ b/src/common_sighandler.c
@@ -88,6 +88,8 @@ void backtrace_symbols_fd(void *const *buffer, int size, int fd) {
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.gregs[R_PC])
 # elif defined(__riscv)
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.__gregs[REG_PC])
+# elif defined(__sh__)
+#  define UC_IP(uc) ((void *) (uc)->uc_mcontext.pc)
 # elif defined(__s390__)
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.psw.addr)
 # elif defined(__sparc__)


### PR DESCRIPTION
These changes allow ```gmt``` to be built on RISC-V and SuperH by defining ```UC_IP()```.