### PR TITLE
CI: Remove gmt_make_module_src.sh from CI testing

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,8 +27,6 @@ jobs:
       cd src
       bash gmt_make_PSL_strings.sh
       bash gmt_make_pattern_include.sh
-      bash gmt_make_module_src.sh core
-      bash gmt_make_module_src.sh supplements
       bash gmt_make_enum_dicts.sh
       # check if any files are changed
       if [ $(git ls-files -m) ]; then


### PR DESCRIPTION
gmt_make_module_src.sh is no longer used and was removed in branch new-api-lookup.