### PR TITLE
GMT_SUPPL_LIB_NAME was defined on Windows only

### DIFF
--- a/src/gmt_sharedlibs.h.in
+++ b/src/gmt_sharedlibs.h.in
@@ -17,10 +17,10 @@
 extern "C" {
 #endif
 
+#define GMT_SUPPL_LIB_NAME "@GMT_SUPPL_LIB_NAME@"
+
 #ifdef _WIN32
 #include <windows.h>
-
-#define GMT_SUPPL_LIB_NAME "@GMT_SUPPL_LIB_NAME@"
 
 /* Various functions declared in gmt_sharedlibs.c */
 EXTERN_MSC void *dlopen (const char *module_name, int mode);


### PR DESCRIPTION
GMT_SUPPL_LIB_NAME is defined in gmt_sharedlibs.h.in, but it's only defined on Windows.

This PR fixes the issue.