### PR TITLE
Rename glue

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -740,7 +740,7 @@ if (BUILD_SUPPLEMENTS)
 		# generate gmt_${SHARED_LIB_NAME}_glue.c
 		configure_file (gmt_glue.c.in gmt_${SHARED_LIB_NAME}_glue.c)
 		# Needed in supplement libraries
-		set (GMT_SUPPL_SRCS gmt_modern.c ${CMAKE_CURRENT_BINARY_DIR}/gmt_${SHARED_LIB_NAME}_glue.c)
+		set (GMT_SUPPL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/gmt_${SHARED_LIB_NAME}_glue.c)
 
 		# generate gmt_${SHARED_LIB_NAME}_moduleinfo.h
 		add_custom_command (OUTPUT gmt_${SHARED_LIB_NAME}_moduleinfo.h

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -10258,7 +10258,7 @@ int GMT_Call_Module (void *V_API, const char *module, int mode, void *args) {
 
 		/* Here we list purpose of all the available modules in each shared library */
 		for (lib = 0; lib < API->n_shared_libs; lib++) {
-			snprintf (gmt_module, GMT_LEN64, "gmtlib_%s_module_%s_all", API->lib[lib].name, listfunc);
+			snprintf (gmt_module, GMT_LEN64, "%s_module_%s_all", API->lib[lib].name, listfunc);
 			*(void **) (&l_func) = gmtapi_get_module_func (API, gmt_module, lib);
 			if (l_func == NULL) continue;	/* Not found in this shared library */
 			(*l_func) (V_API);	/* Run this function */
@@ -10310,7 +10310,7 @@ GMT_LOCAL const char * gmtapi_get_shared_module_keys (struct GMTAPI_CTRL *API, c
 		API->lib[lib_no].skip = true;	/* Not bother the next time... */
 		return (NULL);			/* ...and obviously no keys would be found */
 	}
-	snprintf (function, GMT_LEN64, "gmtlib_%s_module_keys", API->lib[lib_no].name);
+	snprintf (function, GMT_LEN64, "%s_module_keys", API->lib[lib_no].name);
 	/* Here the library handle is available; try to get pointer to specified module */
 	*(void **) (&func) = dlsym (API->lib[lib_no].handle, function);
 	if (func) keys = (*func) (API, module);
@@ -10330,7 +10330,7 @@ GMT_LOCAL const char * gmtapi_get_shared_module_group (struct GMTAPI_CTRL *API, 
 		API->lib[lib_no].skip = true;	/* Not bother the next time... */
 		return (NULL);			/* ...and obviously no keys would be found */
 	}
-	snprintf (function, GMT_LEN64, "gmtlib_%s_module_group", API->lib[lib_no].name);
+	snprintf (function, GMT_LEN64, "%s_module_group", API->lib[lib_no].name);
 	/* Here the library handle is available; try to get pointer to specified module */
 	*(void **) (&func) = dlsym (API->lib[lib_no].handle, function);
 	if (func) group = (*func) (API, module);

--- a/src/gmt_glue.c.in
+++ b/src/gmt_glue.c.in
@@ -8,8 +8,8 @@
  * This file also contains the following convenience functions to
  * display all module purposes, list their names, or return keys or group:
  *
- *   void @SHARED_LIB_NAME@_module_show_all (struct GMTAPI_CTRL *API);
- *   void @SHARED_LIB_NAME@_module_list_all (void *API);
+ *   void @SHARED_LIB_NAME@_module_show_all    (void *API);
+ *   void @SHARED_LIB_NAME@_module_list_all    (void *API);
  *   void @SHARED_LIB_NAME@_module_classic_all (void *API);
  *
  * These functions may be called by gmt --help and gmt --show-modules
@@ -18,8 +18,8 @@
  * function indirectly via GMT_Encode_Options to retrieve option keys
  * needed for module arg processing:
  *
- *   const char *@SHARED_LIB_NAME@_module_keys (void *API, char *candidate);
- *   const char *@SHARED_LIB_NAME@_module_group  (void *API, char *candidate);
+ *   const char *@SHARED_LIB_NAME@_module_keys  (void *API, char *candidate);
+ *   const char *@SHARED_LIB_NAME@_module_group (void *API, char *candidate);
  *
  * All functions are exported by the shared library so that gmt can call these
  * functions by name to learn about the library.

--- a/src/gmt_glue.c.in
+++ b/src/gmt_glue.c.in
@@ -8,9 +8,9 @@
  * This file also contains the following convenience functions to
  * display all module purposes, list their names, or return keys or group:
  *
- *   void gmt_@SHARED_LIB_NAME@_module_show_all (struct GMTAPI_CTRL *API);
- *   void gmt_@SHARED_LIB_NAME@_module_list_all (void *API);
- *   void gmt_@SHARED_LIB_NAME@_module_classic_all (void *API);
+ *   void @SHARED_LIB_NAME@_module_show_all (struct GMTAPI_CTRL *API);
+ *   void @SHARED_LIB_NAME@_module_list_all (void *API);
+ *   void @SHARED_LIB_NAME@_module_classic_all (void *API);
  *
  * These functions may be called by gmt --help and gmt --show-modules
  *
@@ -18,8 +18,8 @@
  * function indirectly via GMT_Encode_Options to retrieve option keys
  * needed for module arg processing:
  *
- *   const char *gmtlib_@SHARED_LIB_NAME@_module_keys (void *API, char *candidate);
- *   const char *gmtlib_@SHARED_LIB_NAME@_module_group  (void *API, char *candidate);
+ *   const char *@SHARED_LIB_NAME@_module_keys (void *API, char *candidate);
+ *   const char *@SHARED_LIB_NAME@_module_group  (void *API, char *candidate);
  *
  * All functions are exported by the shared library so that gmt can call these
  * functions by name to learn about the library.
@@ -36,26 +36,26 @@ static struct GMT_MODULEINFO modules[] = {
 };
 
 /* Pretty print all shared module names and their purposes for gmt --help */
-EXTERN_MSC void gmtlib_@SHARED_LIB_NAME@_module_show_all (void *API) {
+EXTERN_MSC void @SHARED_LIB_NAME@_module_show_all (void *API) {
 	gmtlib_module_show_all (API, modules, "@SHARED_LIB_PURPOSE@");
 }
 
 /* Produce single list on stdout of all shared module names for gmt --show-modules */
-EXTERN_MSC void gmtlib_@SHARED_LIB_NAME@_module_list_all (void *API) {
+EXTERN_MSC void @SHARED_LIB_NAME@_module_list_all (void *API) {
 	gmtlib_module_list_all (API, modules);
 }
 
 /* Produce single list on stdout of all shared module names for gmt --show-classic [i.e., classic mode names] */
-EXTERN_MSC void gmtlib_@SHARED_LIB_NAME@_module_classic_all (void *API) {
+EXTERN_MSC void @SHARED_LIB_NAME@_module_classic_all (void *API) {
 	gmtlib_module_classic_all (API, modules);
 }
 
 /* Lookup module id by name, return option keys pointer (for external API developers) */
-EXTERN_MSC const char *gmtlib_@SHARED_LIB_NAME@_module_keys (void *API, char *candidate) {
+EXTERN_MSC const char *@SHARED_LIB_NAME@_module_keys (void *API, char *candidate) {
 	return (gmtlib_module_keys (API, modules, candidate));
 }
 
 /* Lookup module id by name, return group char name (for external API developers) */
-EXTERN_MSC const char *gmtlib_@SHARED_LIB_NAME@_module_group (void *API, char *candidate) {
+EXTERN_MSC const char *@SHARED_LIB_NAME@_module_group (void *API, char *candidate) {
 	return (gmtlib_module_group (API, modules, candidate));
 }


### PR DESCRIPTION
**Description of proposed changes**

1. Strip from the glue functions names the leading **gmtlib_** prefix.
2. Remove _gmt_modern.c_ from being linked into supplemental shared libs
