### PR TITLE
Fix bug in grdvolume

### DIFF
--- a/doc/examples/ex18/ex18.ps
+++ b/doc/examples/ex18/ex18.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 595 842
 %%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.1.0_9ee9cff_2020.02.16 [64-bit] Document from psxy
+%%Title: GMT v6.1.0_6a98b3e-dirty_2020.04.26 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Feb 16 19:24:55 2020
+%%CreationDate: Sun Apr 26 18:41:17 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -4442,8 +4442,8 @@ N 0 0 M 5291 0 D S
 N 441 0 M 0 -83 D S
 N 2646 0 M 0 -83 D S
 N 4850 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (-50) sh mx
@@ -16565,17 +16565,17 @@ PSL_clip N
 V
 {1 0 0 C} FS
 O1
-24 2734 2813 Sc
-24 3368 2685 Sc
-24 2930 2400 Sc
-24 4081 2094 Sc
-24 2792 1965 Sc
-24 3007 3688 Sc
-24 2810 3181 Sc
-24 1499 3148 Sc
-24 1765 3085 Sc
-24 3001 3036 Sc
-24 2203 2867 Sc
+24 2738 2809 Sc
+24 3366 2686 Sc
+24 2931 2401 Sc
+24 4084 2093 Sc
+24 2789 1966 Sc
+24 3006 3688 Sc
+24 2811 3178 Sc
+24 1502 3150 Sc
+24 1768 3084 Sc
+24 3003 3035 Sc
+24 2199 2864 Sc
 U
 PSL_cliprestore
 %%EndObject
@@ -16860,7 +16860,7 @@ O1
 /PSL_UL 0 def
 /PSL_show {ashow} def
 /PSL_word
-(Volumes:) (191401) (mGal\267km) (2) () (Areas:) (4610.48) (km) (2)
+(Volumes:) (190797) (mGal\267km) (2) () (Areas:) (4610.48) (km) (2)
 9 array astore def
 /PSL_fnt
 0 0 0 0 0 0 0 0 0

--- a/src/grdvolume.c
+++ b/src/grdvolume.c
@@ -63,6 +63,10 @@ struct GRDVOLUME_CTRL {
 	} Z;
 };
 
+/* For equations underlying the math here, see the explanation in
+ * https://github.com/GenericMappingTools/sandbox/blob/master/gurudocs/grdvolume_integration.pdf
+  */
+
 /* This function returns the volume bounded by a trapezoid based on two vertical
  * lines x0 and x1 and two horizontal lines y0 = ax +b and y1 = cx + d
  */

--- a/src/grdvolume.c
+++ b/src/grdvolume.c
@@ -146,7 +146,7 @@ GMT_LOCAL void grdvolume_NE_triangle (struct GMT_GRID *G, uint64_t ij, bool tria
 	y1_1 = y1 - 1.0;
 	if (x0_1 != 0.0) {
 		a = y1_1 / x0_1;
-		frac = grdvolume_vol_prism_frac_x (G, ij, x0, 1.0, a, 1.0 - a * x0, 0.0, 0.0);
+		frac = grdvolume_vol_prism_frac_x (G, ij, x0, 1.0, a, 1.0 - a * x0, 0.0, 1.0);
 	}
 	if (triangle) {
 		*dv += frac;

--- a/test/grdvolume/sphere_volume.ps
+++ b/test/grdvolume/sphere_volume.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from grdview
+%%Title: GMT v6.1.0_6a98b3e-dirty_2020.04.26 [64-bit] Document from grdview
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:52:25 2018
+%%CreationDate: Sun Apr 26 18:41:30 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -336,9 +336,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +592,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +635,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -651,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -662,8 +658,9 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
-/PSL_movie_completion {} def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
@@ -681,6 +678,7 @@ O0
 3.32551 setmiterlimit
 /PSL_GPP matrix currentmatrix def [0.573576 -0.469846 0.819152 0.32899 -0 2277.81] concat
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 4848 M 0 -4848 D S
 /PSL_A0_y 83 def
@@ -719,8 +717,8 @@ N 0 1224 M 83 0 D S
 N 0 2424 M 83 0 D S
 N 0 3624 M 83 0 D S
 N 0 4824 M 83 0 D S
-/PSL_AH0 0
 /MM {exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (”10) sw mx
@@ -768,8 +766,8 @@ N 1224 0 M 0 -83 D S
 N 2424 0 M 0 -83 D S
 N 3624 0 M 0 -83 D S
 N 4824 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (”10) sh mx
 (”5) sh mx
 (0) sh mx
@@ -2865,7 +2863,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -R-10.1/10.1/-10.1/10.1 -Jx0.2i -Jz0.2i -O -K -p125/35 -F+f18p+cBC+jTC -Dj0/0.4i -N
+%@GMT: gmt pstext -R-10.1/10.1/-10.1/10.1 -Jx0.2i -Jz0.2i -O -K -p125/35 '-F+f18p+cBC+jTC+tArea = 316.800 Volume = 2094.254' -Dj0/0.4i -N
 %@PROJ: xy -10.10000000 10.10000000 -10.10000000 10.10000000 -10.100 10.100 -10.100 10.100 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -2874,7 +2872,7 @@ O0
 /PSL_GPP matrix currentmatrix def [0.573576 -0.469846 0.819152 0.32899 -0 2277.81] concat
 2424 -480 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
-(Area = 316.800 Volume = 2094.160) tc Z
+(Area = 316.800 Volume = 2094.254) tc Z
 PSL_GPP setmatrix
 %%EndObject
 0 A
@@ -2891,6 +2889,7 @@ O0
 3.32551 setmiterlimit
 /PSL_GPP matrix currentmatrix def [0.573576 -0.469846 0.819152 0.32899 -0 2277.81] concat
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 4848 M 0 -4848 D S
 /PSL_A0_y 83 def
@@ -2929,8 +2928,8 @@ N 0 1224 M 83 0 D S
 N 0 2424 M 83 0 D S
 N 0 3624 M 83 0 D S
 N 0 4824 M 83 0 D S
-/PSL_AH0 0
 /MM {exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (”10) sw mx
@@ -2978,8 +2977,8 @@ N 1224 0 M 0 -83 D S
 N 2424 0 M 0 -83 D S
 N 3624 0 M 0 -83 D S
 N 4824 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (”10) sh mx
 (”5) sh mx
 (0) sh mx
@@ -4993,7 +4992,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -R-10.1/10.1/-10.1/10.1 -Jx0.2i -Jz0.2i -O -K -p125/35 -F+f18p+cBC+jTC -Dj0/0.4i -N
+%@GMT: gmt pstext -R-10.1/10.1/-10.1/10.1 -Jx0.2i -Jz0.2i -O -K -p125/35 '-F+f18p+cBC+jTC+tArea = 316.800 Volume = 2094.254' -Dj0/0.4i -N
 %@PROJ: xy -10.10000000 10.10000000 -10.10000000 10.10000000 -10.100 10.100 -10.100 10.100 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -5002,7 +5001,7 @@ O0
 /PSL_GPP matrix currentmatrix def [0.573576 -0.469846 0.819152 0.32899 -0 2277.81] concat
 2424 -480 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 300 F0
-(Area = 316.800 Volume = 2094.160) tc Z
+(Area = 316.800 Volume = 2094.254) tc Z
 PSL_GPP setmatrix
 %%EndObject
 0 A
@@ -5020,7 +5019,8 @@ O0
 %%EndObject
 
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U


### PR DESCRIPTION
And update two PS files. We had wrong parameters being passed into the local function _grdvolume_NE_triangle_.  Here, we pass two lines y0(x) = ax +b and y1(x) = cx + d.  For a NE triangle the a and b are computed from a sloping line, but y1 is the top of the square, so c = 0 and d = 1.  Unfortunately, we passed c = d = 0 and hence all NE triangles were wrong.  Because this error only affects a small part of the volume near a contour where we have a NE triangle it is not easy to notice.  However, I created a grid with a bilinear surface so the analytical volume is known, and then I added a new **-D** option (another PR) that computed incremental slice volumes.  I noticed that near some contours the slice volume was negative, which cannot happen.  Detailed debugging lead to the discovery of this but.  Now the results are correct (the integrals were checked and are all correct).  The bug affected two scripts whose volumes were slightly off.