### PR TITLE
New color scheme

### DIFF
--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -20,7 +20,7 @@ Synopsis
 [ |-D|\ *dx*/*dy* ]
 [ |-E|\ [**x**\|\ **y**\|\ **X**\|\ **Y**][**+a**][**+cl**\|\ **f**][**+n**][**+w**\ *cap*][**+p**\ *pen*] ]
 [ |-F|\ [**c**\|\ **n**\|\ **r**][**a**\|\ **f**\|\ **s**\|\ **r**\|\ *refpoint*] ]
-[ |-G|\ *fill* ]
+[ |-G|\ *fill*\|\ **+z** ]
 [ |-I|\ [*intens*] ]
 [ |-L|\ [**+b**\|\ **d**\|\ **D**][**+xl**\|\ **r**\|\ *x0*][**+yl**\|\ **r**\|\ *y0*][**+p**\ *pen*] ]
 [ |-N|\ [**c**\|\ **r**] ]
@@ -30,7 +30,7 @@ Synopsis
 [ |-W|\ [*pen*][*attr*] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
-[ |-Z|\ *value*\|\ *file*\ [**+f**\|\ **l**]]
+[ |-Z|\ *value*\|\ *file*]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-bi| ]
 [ |SYN_OPT-di| ]
@@ -78,11 +78,11 @@ sides 0.25 inch on the left side of the line, spaced every 0.8 inch, use
 
     gmt plot trench.txt -R150/200/20/50 -Jm0.15i -Sf0.8i/0.1i+l+t -Gwhite -W -B10 -pdf map
 
-To plot a point with color dictated by the *t.cpt* file for the *z*-value 65, try
+To plot a circle with color dictated by the *t.cpt* file for the *z*-value 65, try
 
    ::
 
-    echo 175 30 | gmt plot -R150/200/20/50 -JM15c -Sc0.5c -Zf65 -Ct.cpt -pdf map
+    echo 175 30 | gmt plot -R150/200/20/50 -JM15c -B -Sc0.5c -Z65 -Ct.cpt -G+z -pdf map
 
 To plot the data in the file misc.txt as symbols determined by the code in
 the last column, and with size given by the magnitude in the 4th column,

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -19,7 +19,7 @@ Synopsis
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
 [ |-D|\ *dx*/*dy*\ [/*dz*] ]
-[ |-G|\ *fill* ]
+[ |-G|\ *fill*\|\ **+z** ]
 [ |-I|\ [*intens*] ]
 [ |-L|\ [**+b**\|\ **d**\|\ **D**][**+xl**\|\ **r**\|\ *x0*][**+yl**\|\ **r**\|\ *y0*][**+p**\ *pen*] ]
 [ |-N| ]
@@ -30,7 +30,7 @@ Synopsis
 [ |-W|\ [*pen*][*attr*] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
-[ |-Z|\ *value*\|\ *file*\ [**+f**\|\ **l**]]
+[ |-Z|\ *value*\|\ *file*]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-bi| ]
 [ |SYN_OPT-di| ]
@@ -71,7 +71,7 @@ To plot a point with color and outline dictated by the *t.cpt* file for the *lev
 
    ::
 
-    echo 175 30 0 | gmt plot3d -R150/200/20/50 -JM15c -Sc0.5c -Z65 -Ct.cpt -pdf map
+    echo 175 30 0 | gmt plot3d -R150/200/20/50 -JM15c -B -Sc0.5c -Z65 -G+z -Ct.cpt -pdf map
 
 .. include:: plot3d_notes.rst_
 

--- a/doc/rst/source/plot3d_common.rst_
+++ b/doc/rst/source/plot3d_common.rst_
@@ -87,6 +87,8 @@ Optional Arguments
     Select color or pattern for filling of symbols or polygons [Default is no fill].
     Note that the module will search for **-G** and **-W** strings in all the
     segment headers and let any values thus found over-ride the command line settings.
+    If **-Z** is set, use **-G+z** to assign fill color via **-C**\ *cpt* and the
+    *z*-values obtained.
 
 .. _-I:
 
@@ -149,6 +151,8 @@ Optional Arguments
     is appended then the color of the line are taken from the CPT (see
     **-C**). If instead modifier **+cf** is appended then the color from the cpt
     file is applied to symbol fill.  Use just **+c** for both effects.
+    If **-Z** is set, then append **+z** to **-W** to assign pen color via **-C**\ *cpt* and the
+    *z*-values obtained.
 
 .. _-X:
 
@@ -156,11 +160,11 @@ Optional Arguments
 
 .. _-Z:
 
-**-Z**\ *value*\|\ *file*\ [**+f**\|\ **l**]
+**-Z**\ *value*\|\ *file*
     Instead of specifying a symbol or polygon fill and outline color via **-G** and **-W**,
     give both a *value* via **-Z** and a color lookup table via **-C**.  Alternatively,
     give the name of a *file* with one z-value (read from the last column) for each polygon in the input data.
-    To just set the fill or outline, append **+f** or **+l**, respectively [both]. 
+    To apply the color obtain to a fill, use **-G+z**; to apply it to the pen color, append **+z** to **-W**.
 
 .. include:: explain_-aspatial.rst_
 

--- a/doc/rst/source/plot_common.rst_
+++ b/doc/rst/source/plot_common.rst_
@@ -119,10 +119,12 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
+**-G**\ *fill*\|\ **+z** :ref:`(more ...) <-Gfill_attrib>`
     Select color or pattern for filling of symbols or polygons [Default is no fill].
     Note that this module will search for **-G** and **-W** strings in all the
     segment headers and let any values thus found over-ride the command line settings.
+    If **-Z** is set, use **-G+z** to assign fill color via **-C**\ *cpt* and the
+    *z*-values obtained.
 
 .. _-I:
 
@@ -188,6 +190,8 @@ Optional Arguments
     Because **+v** may take additional modifiers it must necessarily be given
     at the end of the pen specification.
     See the `Vector Attributes`_ for more information.
+    If **-Z** is set, then append **+z** to **-W** to assign pen color via **-C**\ *cpt* and the
+    *z*-values obtained.
 
 .. _-X:
 
@@ -195,11 +199,11 @@ Optional Arguments
 
 .. _-Z:
 
-**-Z**\ *value*\|\ *file*\ [**+f**\|\ **l**]
+**-Z**\ *value*\|\ *file*
     Instead of specifying a symbol or polygon fill and outline color via **-G** and **-W**,
     give both a *value* via **-Z** and a color lookup table via **-C**.  Alternatively,
     give the name of a *file* with one z-value (read from the last column) for each polygon in the input data.
-    To just set the fill or outline, append **+f** or **+l**, respectively [both]. 
+    To apply the color obtain to a fill, use **-G+z**; to apply it to the pen color, append **+z** to **-W**.
 
 .. |Add_-bi| replace:: [Default is the required number of columns given the chosen settings].
 .. include:: explain_-bi.rst_

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -742,7 +742,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OP
 				break;
 			case 'G':		/* Set fill for symbols or polygon */
 				Ctrl->G.active = true;
-				if (strcmp (opt->arg, "+z", 2U) == 0)
+				if (strncmp (opt->arg, "+z", 2U) == 0)
 					Ctrl->G.set_color = true;
 				else if (!opt->arg[0] || gmt_getfill (GMT, opt->arg, &Ctrl->G.fill)) {
 					gmt_fill_syntax (GMT, 'G', NULL, " "); n_errors++;
@@ -857,7 +857,6 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OP
 
 	if (Ctrl->T.active && n_files) GMT_Report (API, GMT_MSG_WARNING, "Option -T ignores all input files\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active && !Ctrl->C.active, "Option -Z: No CPT given via -C\n");
-	n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active && Ctrl->G.active, "Option -Z: Not compatible with -G\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && (Ctrl->C.file == NULL || Ctrl->C.file[0] == '\0'), "Option -C: No CPT given\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && gmt_parse_symbol_option (GMT, Ctrl->S.arg, S, 0, true), "Option -S: Parsing failure\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->E.active && (S->symbol == PSL_VECTOR || S->symbol == GMT_SYMBOL_GEOVECTOR || S->symbol == PSL_MARC \

--- a/test/psxy/variable_z.ps
+++ b/test/psxy/variable_z.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.1.0_5032eae_2020.03.02 [64-bit] Document from psxy
+%%Title: GMT v6.1.0_6a98b3e-dirty_2020.04.26 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Mar  2 14:27:58 2020
+%%CreationDate: Sun Apr 26 22:11:58 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -666,58 +666,56 @@ gsave
 0 A
 FQ
 O0
-1890 709 TM
+1200 709 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -R-2/5/-1/3 -Jx2c pol.txt -Zz.txt -B0 -Ct.cpt -W1p -P -K -X4c -Y1.5c
-%@PROJ: xy -2.00000000 5.00000000 -1.00000000 3.00000000 -2.000 5.000 -1.000 3.000 +xy
-%GMTBoundingBox: 113.386 42.5197 396.85 226.772
+%@GMT: gmt psxy -R-1/3/-1/3 -Jx2c pol.txt -B0 -Ct.cpt -Zz.txt -G+z -P -K -Y1.5c
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%GMTBoundingBox: 72 42.5197 226.772 226.772
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 3780 M 0 -3780 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-6614 0 T
+3780 0 T
 N 0 3780 M 0 -3780 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--6614 0 T
-N 0 0 M 6614 0 D S
+-3780 0 T
+N 0 0 M 3780 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 3780 T
-N 0 0 M 6614 0 D S
+N 0 0 M 3780 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 -3780 T
 0 setlinecap
-17 W
+4 W
 clipsave
 0 0 M
-6614 0 D
+3780 0 D
 0 3780 D
--6614 0 D
+-3780 0 D
 P
 PSL_clip N
-0.533 0 0 C
 {0.533 0 0 C} FS
-O1
 /FO {P}!
-0 -662 945 0 0 945 3 1890 945 SP
+0 -662 945 0 0 945 3 945 945 SP
 /FO {fs os}!
 FO
-1 1 0.2 C
 {1 1 0.2 C} FS
 /FO {P}!
-0 -945 945 0 0 945 3 2835 1890 SP
+0 -945 945 0 0 945 3 1890 1890 SP
 /FO {fs os}!
 FO
 PSL_cliprestore
@@ -725,114 +723,433 @@ PSL_cliprestore
 0 A
 FQ
 O0
-0 4016 TM
+0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -R-2/5/-1/3 -Jx2c pol.txt -Zz.txt -B0 -Ct.cpt -W1p -O -K -Y8.5c
-%@PROJ: xy -2.00000000 5.00000000 -1.00000000 3.00000000 -2.000 5.000 -1.000 3.000 +xy
+%@GMT: gmt pstext -R-1/3/-1/3 -Jx2c -O -K -F+f12p+cTL -Dj0.1i
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-25 W
-2 setlinecap
-N 0 3780 M 0 -3780 D S
-/PSL_A0_y 0 def
-/PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-6614 0 T
-N 0 3780 M 0 -3780 D S
-/PSL_A0_y 0 def
-/PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--6614 0 T
-N 0 0 M 6614 0 D S
-/PSL_A0_y 0 def
-/PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 3780 T
-N 0 0 M 6614 0 D S
-/PSL_A0_y 0 def
-/PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -3780 T
-0 setlinecap
-17 W
 clipsave
 0 0 M
-6614 0 D
+3780 0 D
 0 3780 D
--6614 0 D
+-3780 0 D
 P
 PSL_clip N
-{0.533 0 0 C} FS
-O1
-/FO {P}!
-0 -662 945 0 0 945 3 1890 945 SP
-/FO {fs os}!
-FO
-{1 1 0.2 C} FS
-/FO {P}!
-0 -945 945 0 0 945 3 2835 1890 SP
-/FO {fs os}!
-FO
+120 3660 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(­Zz.txt ­G+z) tl Z
 PSL_cliprestore
 %%EndObject
 0 A
 FQ
 O0
-0 4016 TM
+4016 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -R-2/5/-1/3 -Jx2c pol.txt -Zz.txt -B0 -Ct.cpt -W1p -O -Y8.5c
-%@PROJ: xy -2.00000000 5.00000000 -1.00000000 3.00000000 -2.000 5.000 -1.000 3.000 +xy
+%@GMT: gmt psxy -R-1/3/-1/3 -Jx2c pol.txt -B0 -Ct.cpt -Zz.txt -G+z -W2p -O -K -X8.5c
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 3780 M 0 -3780 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-6614 0 T
+3780 0 T
 N 0 3780 M 0 -3780 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--6614 0 T
-N 0 0 M 6614 0 D S
+-3780 0 T
+N 0 0 M 3780 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 3780 T
-N 0 0 M 6614 0 D S
+N 0 0 M 3780 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 -3780 T
 0 setlinecap
-17 W
+33 W
 clipsave
 0 0 M
-6614 0 D
+3780 0 D
 0 3780 D
--6614 0 D
+-3780 0 D
+P
+PSL_clip N
+{0.533 0 0 C} FS
+O1
+/FO {P}!
+0 -662 945 0 0 945 3 945 945 SP
+/FO {fs os}!
+FO
+{1 1 0.2 C} FS
+/FO {P}!
+0 -945 945 0 0 945 3 1890 1890 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R-1/3/-1/3 -Jx2c -O -K -F+f12p+cTL -Dj0.1i
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+120 3660 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(­Zz.txt ­G+z ­W2p) tl Z
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+-4016 4016 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R-1/3/-1/3 -Jx2c pol.txt -B0 -Ct.cpt -Zz.txt -G+z -W2p+z -O -K -X-8.5c -Y8.5c
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+33 W
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
 P
 PSL_clip N
 0.533 0 0 C
-1890 945 M
+{0.533 0 0 C} FS
+O1
+/FO {P}!
+0 -662 945 0 0 945 3 945 945 SP
+/FO {fs os}!
+FO
+1 1 0.2 C
+{1 1 0.2 C} FS
+/FO {P}!
+0 -945 945 0 0 945 3 1890 1890 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R-1/3/-1/3 -Jx2c -O -K -F+f12p+cTL -Dj0.1i
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+120 3660 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(­Zz.tx ­G+z ­W2p+z) tl Z
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+4016 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R-1/3/-1/3 -Jx2c pol.txt -B0 -Ct.cpt -Zz.txt -Gcyan -W2p+z -O -K -X8.5c
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+33 W
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+0.533 0 0 C
+{0 1 1 C} FS
+O1
+/FO {P}!
+0 -662 945 0 0 945 3 945 945 SP
+/FO {fs os}!
+FO
+1 1 0.2 C
+/FO {P}!
+0 -945 945 0 0 945 3 1890 1890 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R-1/3/-1/3 -Jx2c -O -K -F+f12p+cTL -Dj0.1i
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_8
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+120 3660 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(­Zz.txt ­Gcyan ­W2p+z) tl Z
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+-4016 4016 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R-1/3/-1/3 -Jx2c pol.txt -B0 -Ct.cpt -Zz.txt -W2p+z -O -K -X-8.5c -Y8.5c
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_9
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+33 W
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+0.533 0 0 C
+945 945 M
 0 945 D
 945 0 D
 0 -662 D
 P S
 1 1 0.2 C
-2835 1890 M
+1890 1890 M
 0 945 D
 945 0 D
 0 -945 D
 P S
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R-1/3/-1/3 -Jx2c -O -K -F+f12p+cTL -Dj0.1i
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_10
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+120 3660 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(­Zz.txt ­W2p+z) tl Z
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+4016 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R-1/3/-1/3 -Jx2c pol.txt -B0 -Ct.cpt -Z3 -G+z -W2p -O -K -X8.5c
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_11
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+33 W
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+{1 0.6 0 C} FS
+O1
+/FO {P}!
+0 -662 945 0 0 945 3 945 945 SP
+/FO {fs os}!
+FO
+/FO {P}!
+0 -945 945 0 0 945 3 1890 1890 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R-1/3/-1/3 -Jx2c -O -F+f12p+cTL -Dj0.1i
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_12
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+120 3660 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(­Z3 ­G+z ­W2p) tl Z
 PSL_cliprestore
 %%EndObject
 

--- a/test/psxy/variable_z.ps
+++ b/test/psxy/variable_z.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.1.0_6a98b3e-dirty_2020.04.26 [64-bit] Document from psxy
+%%Title: GMT v6.1.0_8dc21ec-dirty_2020.04.26 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Apr 26 22:11:58 2020
+%%CreationDate: Sun Apr 26 22:27:44 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -905,7 +905,7 @@ P
 PSL_clip N
 120 3660 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(­Zz.tx ­G+z ­W2p+z) tl Z
+(­Zz.txt ­G+z ­W2p+z) tl Z
 PSL_cliprestore
 %%EndObject
 0 A

--- a/test/psxy/variable_z.sh
+++ b/test/psxy/variable_z.sh
@@ -24,6 +24,16 @@ cat << EOF > z.txt
 EOF
 gmt makecpt -Chot -T0/5 > t.cpt
 
-gmt psxy -R-2/5/-1/3 -Jx2c pol.txt -Zz.txt -B0 -Ct.cpt -W1p -P -K -X4c -Y1.5c > $ps
-gmt psxy -R -J pol.txt -Zz.txt+f -B0 -Ct.cpt -W1p -O -K -Y8.5c >> $ps
-gmt psxy -R -J pol.txt -Zz.txt+l -B0 -Ct.cpt -W1p -O -Y8.5c >> $ps
+gmt psxy -R-1/3/-1/3 -Jx2c pol.txt -B0 -Ct.cpt -Zz.txt -G+z -P -K -Y1.5c > $ps
+echo "-Zz.txt -G+z" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i >> $ps
+gmt psxy -R -J pol.txt -B0 -Ct.cpt -Zz.txt -G+z -W2p -O -K -X8.5c >> $ps
+echo "-Zz.txt -G+z -W2p" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i >> $ps
+gmt psxy -R -J pol.txt -B0 -Ct.cpt -Zz.txt -G+z -W2p+z -O -K -X-8.5c -Y8.5c >> $ps
+echo "-Zz.tx -G+z -W2p+z" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i >> $ps
+gmt psxy -R -J pol.txt -B0 -Ct.cpt -Zz.txt -Gcyan -W2p+z -O -K -X8.5c >> $ps
+echo "-Zz.txt -Gcyan -W2p+z" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i >> $ps
+gmt psxy -R -J pol.txt -B0 -Ct.cpt -Zz.txt -W2p+z -O -K -X-8.5c -Y8.5c >> $ps
+echo "-Zz.txt -W2p+z" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i >> $ps
+gmt psxy -R -J pol.txt -B0 -Ct.cpt -Z3 -G+z -W2p -O -K -X8.5c >> $ps
+echo "-Z3 -G+z -W2p" | gmt pstext -R -J -O -F+f12p+cTL -Dj0.1i >> $ps
+gv $ps

--- a/test/psxy/variable_z.sh
+++ b/test/psxy/variable_z.sh
@@ -29,7 +29,7 @@ echo "-Zz.txt -G+z" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i >> $ps
 gmt psxy -R -J pol.txt -B0 -Ct.cpt -Zz.txt -G+z -W2p -O -K -X8.5c >> $ps
 echo "-Zz.txt -G+z -W2p" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i >> $ps
 gmt psxy -R -J pol.txt -B0 -Ct.cpt -Zz.txt -G+z -W2p+z -O -K -X-8.5c -Y8.5c >> $ps
-echo "-Zz.tx -G+z -W2p+z" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i >> $ps
+echo "-Zz.txt -G+z -W2p+z" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i >> $ps
 gmt psxy -R -J pol.txt -B0 -Ct.cpt -Zz.txt -Gcyan -W2p+z -O -K -X8.5c >> $ps
 echo "-Zz.txt -Gcyan -W2p+z" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i >> $ps
 gmt psxy -R -J pol.txt -B0 -Ct.cpt -Zz.txt -W2p+z -O -K -X-8.5c -Y8.5c >> $ps

--- a/test/psxyz/variable_z.ps
+++ b/test/psxyz/variable_z.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.1.0_5032eae_2020.03.02 [64-bit] Document from psxyz
+%%Title: GMT v6.1.0_6a98b3e-dirty_2020.04.26 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Mar  2 14:30:23 2020
+%%CreationDate: Sun Apr 26 22:15:16 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -666,166 +666,562 @@ gsave
 0 A
 FQ
 O0
-1890 709 TM
+945 709 TM
 
 % PostScript produced by:
-%@GMT: gmt psxyz -R-2/5/-1/3/0/1 -Jx2c -Jz1c pol.txt -Zz.txt -B0 -Ct.cpt -W1p -P -K -X4c -Y1.5c -p135/35
-%@PROJ: xy -2.00000000 5.00000000 -1.00000000 3.00000000 -2.000 5.000 -1.000 3.000 +xy
-%GMTBoundingBox: 113.386 42.5197 396.85 226.772
+%@GMT: gmt psxy -R-1/3/-1/3 -Jx2c -Jz1c pol.txt -B0 -Ct.cpt -Zz.txt -G+z -P -K -p165/35 -X2c -Y1.5c
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%GMTBoundingBox: 56.6929 42.5197 226.772 226.772
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-/PSL_GPP matrix currentmatrix def [0.707107 -0.40558 0.707107 0.40558 -0 2682.57] concat
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
 25 W
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0 0.819152 0 561.08] concat
+N 0 0 M 0 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 3780 M 0 -3780 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-6614 0 T
+3780 0 T
 N 0 3780 M 0 -3780 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--6614 0 T
-N 0 0 M 6614 0 D S
+-3780 0 T
+N 0 0 M 3780 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 3780 T
-N 0 0 M 6614 0 D S
+N 0 0 M 3780 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 -3780 T
 0 setlinecap
-17 W
-0.533 0 0 C
+4 W
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
 {0.533 0 0 C} FS
-O1
-PSL_GPP setmatrix
--468 -268 668 -384 669 384 3 2004 2299 SP
-1 1 0.2 C
+/FO {P}!
+0 -662 945 0 0 945 3 945 945 SP
+/FO {fs os}!
+FO
 {1 1 0.2 C} FS
--668 -383 668 -384 668 384 3 3341 2299 SP
-/PSL_GPP matrix currentmatrix def [0.707107 -0.40558 0 0.819152 0 2682.57] concat
-25 W
-0 A
-N 0 472 M 0 -472 D S
-/PSL_A0_y 0 def
-/PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/FO {P}!
+0 -945 945 0 0 945 3 1890 1890 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
 PSL_GPP setmatrix
 %%EndObject
 0 A
 FQ
 O0
-0 3780 TM
+0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxyz -R-2/5/-1/3/0/1 -Jx2c -Jz1c pol.txt -Zz.txt -B0 -Ct.cpt -W1p -p135/35 -O -K -Y8c
-%@PROJ: xy -2.00000000 5.00000000 -1.00000000 3.00000000 -2.000 5.000 -1.000 3.000 +xy
+%@GMT: gmt pstext -R-1/3/-1/3 -Jx2c -O -K -F+f12p+cTL -Dj0.1i -p165/35
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-/PSL_GPP matrix currentmatrix def [0.707107 -0.40558 0.707107 0.40558 -0 2682.57] concat
-25 W
-2 setlinecap
-N 0 3780 M 0 -3780 D S
-/PSL_A0_y 0 def
-/PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-6614 0 T
-N 0 3780 M 0 -3780 D S
-/PSL_A0_y 0 def
-/PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--6614 0 T
-N 0 0 M 6614 0 D S
-/PSL_A0_y 0 def
-/PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 3780 T
-N 0 0 M 6614 0 D S
-/PSL_A0_y 0 def
-/PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -3780 T
-0 setlinecap
-17 W
-{0.533 0 0 C} FS
-O1
-PSL_GPP setmatrix
--468 -268 668 -384 669 384 3 2004 2299 SP
-{1 1 0.2 C} FS
--668 -383 668 -384 668 384 3 3341 2299 SP
-/PSL_GPP matrix currentmatrix def [0.707107 -0.40558 0 0.819152 0 2682.57] concat
-25 W
-N 0 472 M 0 -472 D S
-/PSL_A0_y 0 def
-/PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+120 3660 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(­Zz.txt ­G+z) tl Z
+PSL_cliprestore
 PSL_GPP setmatrix
 %%EndObject
 0 A
 FQ
 O0
-0 3780 TM
+4016 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxyz -R-2/5/-1/3/0/1 -Jx2c -Jz1c pol.txt -Zz.txt -B0 -Ct.cpt -W1p -p135/35 -O -Y8c
-%@PROJ: xy -2.00000000 5.00000000 -1.00000000 3.00000000 -2.000 5.000 -1.000 3.000 +xy
+%@GMT: gmt psxy -R-1/3/-1/3 -Jx2c pol.txt -B0 -Ct.cpt -Zz.txt -G+z -W2p -O -K -X8.5c -p165/35
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
 3.32551 setmiterlimit
-/PSL_GPP matrix currentmatrix def [0.707107 -0.40558 0.707107 0.40558 -0 2682.57] concat
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
 25 W
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0 0.819152 0 561.08] concat
+N 0 0 M 0 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 3780 M 0 -3780 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-6614 0 T
+3780 0 T
 N 0 3780 M 0 -3780 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--6614 0 T
-N 0 0 M 6614 0 D S
+-3780 0 T
+N 0 0 M 3780 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 3780 T
-N 0 0 M 6614 0 D S
+N 0 0 M 3780 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 -3780 T
 0 setlinecap
-17 W
-0.533 0 0 C
+33 W
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+{0.533 0 0 C} FS
+O1
+/FO {P}!
+0 -662 945 0 0 945 3 945 945 SP
+/FO {fs os}!
+FO
+{1 1 0.2 C} FS
+/FO {P}!
+0 -945 945 0 0 945 3 1890 1890 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
 PSL_GPP setmatrix
-2004 2299 M
-669 384 D
-668 -384 D
--468 -268 D
-P S
-1 1 0.2 C
-3341 2299 M
-668 384 D
-668 -384 D
--668 -383 D
-P S
-/PSL_GPP matrix currentmatrix def [0.707107 -0.40558 0 0.819152 0 2682.57] concat
-25 W
+%%EndObject
 0 A
-N 0 472 M 0 -472 D S
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R-1/3/-1/3 -Jx2c -O -K -F+f12p+cTL -Dj0.1i -p165/35
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+120 3660 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(­Zz.txt ­G+z ­W2p) tl Z
+PSL_cliprestore
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+-4016 4016 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R-1/3/-1/3 -Jx2c pol.txt -B0 -Ct.cpt -Zz.txt -G+z -W2p+z -O -K -X-8.5c -Y8.5c -p165/35
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+25 W
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0 0.819152 0 561.08] concat
+N 0 0 M 0 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+33 W
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+0.533 0 0 C
+{0.533 0 0 C} FS
+O1
+/FO {P}!
+0 -662 945 0 0 945 3 945 945 SP
+/FO {fs os}!
+FO
+1 1 0.2 C
+{1 1 0.2 C} FS
+/FO {P}!
+0 -945 945 0 0 945 3 1890 1890 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R-1/3/-1/3 -Jx2c -O -K -F+f12p+cTL -Dj0.1i -p165/35
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+120 3660 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(­Zz.tx ­G+z ­W2p+z) tl Z
+PSL_cliprestore
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+4016 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R-1/3/-1/3 -Jx2c pol.txt -B0 -Ct.cpt -Zz.txt -Gcyan -W2p+z -O -K -X8.5c -p165/35
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+25 W
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0 0.819152 0 561.08] concat
+N 0 0 M 0 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+33 W
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+0.533 0 0 C
+{0 1 1 C} FS
+O1
+/FO {P}!
+0 -662 945 0 0 945 3 945 945 SP
+/FO {fs os}!
+FO
+1 1 0.2 C
+/FO {P}!
+0 -945 945 0 0 945 3 1890 1890 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R-1/3/-1/3 -Jx2c -O -K -F+f12p+cTL -Dj0.1i -p165/35
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_8
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+120 3660 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(­Zz.txt ­Gcyan ­W2p+z) tl Z
+PSL_cliprestore
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+-4016 4016 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R-1/3/-1/3 -Jx2c pol.txt -B0 -Ct.cpt -Zz.txt -W2p+z -O -K -X-8.5c -Y8.5c -p165/35
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_9
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+25 W
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0 0.819152 0 561.08] concat
+N 0 0 M 0 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+33 W
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+0.533 0 0 C
+945 945 M
+0 945 D
+945 0 D
+0 -662 D
+P S
+1 1 0.2 C
+1890 1890 M
+0 945 D
+945 0 D
+0 -945 D
+P S
+PSL_cliprestore
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R-1/3/-1/3 -Jx2c -O -K -F+f12p+cTL -Dj0.1i -p165/35
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_10
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+120 3660 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(­Zz.txt ­W2p+z) tl Z
+PSL_cliprestore
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+4016 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R-1/3/-1/3 -Jx2c pol.txt -B0 -Ct.cpt -Z3 -G+z -W2p -O -K -X8.5c -p165/35
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_11
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+25 W
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0 0.819152 0 561.08] concat
+N 0 0 M 0 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+33 W
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+{1 0.6 0 C} FS
+O1
+/FO {P}!
+0 -662 945 0 0 945 3 945 945 SP
+/FO {fs os}!
+FO
+/FO {P}!
+0 -945 945 0 0 945 3 1890 1890 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R-1/3/-1/3 -Jx2c -O -F+f12p+cTL -Dj0.1i -p165/35
+%@PROJ: xy -1.00000000 3.00000000 -1.00000000 3.00000000 -1.000 3.000 -1.000 3.000 +xy
+%%BeginObject PSL_Layer_12
+0 setlinecap
+0 setlinejoin
+3.32551 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.965926 -0.148453 0.258819 0.554032 -0 561.08] concat
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+120 3660 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(­Z3 ­G+z ­W2p) tl Z
+PSL_cliprestore
 PSL_GPP setmatrix
 %%EndObject
 

--- a/test/psxyz/variable_z.sh
+++ b/test/psxyz/variable_z.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test psxyz -Zfile for coloring
+# Test psxy -Zfile for coloring
 
 ps=variable_z.ps
 
@@ -24,6 +24,16 @@ cat << EOF > z.txt
 EOF
 gmt makecpt -Chot -T0/5 > t.cpt
 
-gmt psxyz -R-2/5/-1/3/0/1 -Jx2c -Jz1c pol.txt -Zz.txt -B0 -Ct.cpt -W1p -P -K -X4c -Y1.5c -p135/35 > $ps
-gmt psxyz -R -J -Jz pol.txt -Zz.txt+f -B0 -Ct.cpt -W1p -p -O -K -Y8c >> $ps
-gmt psxyz -R -J -Jz pol.txt -Zz.txt+l -B0 -Ct.cpt -W1p -p -O -Y8c >> $ps
+gmt psxy -R-1/3/-1/3 -Jx2c -Jz1c pol.txt -B0 -Ct.cpt -Zz.txt -G+z -P -K -p165/35 -X2c -Y1.5c > $ps
+echo "-Zz.txt -G+z" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i -p >> $ps
+gmt psxy -R -J pol.txt -B0 -Ct.cpt -Zz.txt -G+z -W2p -O -K -X8.5c -p >> $ps
+echo "-Zz.txt -G+z -W2p" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i -p >> $ps
+gmt psxy -R -J pol.txt -B0 -Ct.cpt -Zz.txt -G+z -W2p+z -O -K -X-8.5c -Y8.5c -p >> $ps
+echo "-Zz.tx -G+z -W2p+z" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i -p >> $ps
+gmt psxy -R -J pol.txt -B0 -Ct.cpt -Zz.txt -Gcyan -W2p+z -O -K -X8.5c -p >> $ps
+echo "-Zz.txt -Gcyan -W2p+z" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i -p >> $ps
+gmt psxy -R -J pol.txt -B0 -Ct.cpt -Zz.txt -W2p+z -O -K -X-8.5c -Y8.5c -p >> $ps
+echo "-Zz.txt -W2p+z" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i -p >> $ps
+gmt psxy -R -J pol.txt -B0 -Ct.cpt -Z3 -G+z -W2p -O -K -X8.5c -p >> $ps
+echo "-Z3 -G+z -W2p" | gmt pstext -R -J -O -F+f12p+cTL -Dj0.1i -p >> $ps
+gv $ps


### PR DESCRIPTION
**Description of proposed changes**

See #3131 for context and longer explanation.  This PR implements those suggestions, specifically the **-G+z** to let z-values from **-Z** be assigned via **-C**_cpt_ to fill and **-W**_pen_**+z** to let z-values from **-Z** be assigned via **-C**_cpt_ to pen (both can be set as well).

Note: **-G+z** is not needed for symbol fill when **-C**_cpt_ is given as we expect *z* to be delivered via the third input column.

Below is a revised test/psxy/variable_z.sh output:

![variable_z](https://user-images.githubusercontent.com/26473567/80351090-6fced600-880d-11ea-9ca6-852e5e72811a.png)

Closes #3131.
