### PR TITLE
Handle font values with equal signs in them

### DIFF
--- a/doc/rst/source/gmtset.rst
+++ b/doc/rst/source/gmtset.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt set** [ |-C| \| |-D|\ [**s**\|\ **u**] \|
 |-G|\ *defaultsfile* ] [ **-**\ [**BJRXYp**]\ *value* ]
-PARAMETER1 [=] *value1* PARAMETER2 [=] *value2* PARAMETER3 [=] *value3*
+PARAMETER1 *value1* PARAMETER2 *value2* PARAMETER3  *value3*
 ...
 
 |No-spaces|

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9222,7 +9222,7 @@ unsigned int gmt_setdefaults (struct GMT_CTRL *GMT, struct GMT_OPTION *options) 
 	for (opt = options; opt; opt = opt->next) {
 		if (!(opt->option == '<' || opt->option == '#') || !opt->arg) continue;		/* Skip other and empty options */
 		if (!strcmp (opt->arg, "=")) continue;			/* User forgot and gave parameter = value (3 words) */
-		if (opt->arg[0] != '=' && strchr (opt->arg, '=') && param && !strstr (param, "FONT_")) {	/* User forgot and gave parameter=value (1 word) */
+		if (opt->arg[0] != '=' && strchr (opt->arg, '=') && !strstr (opt->arg, "FONT_")) {	/* User forgot and gave parameter=value (1 word); OK except for FONTS */
 			p = 0;
 			while (opt->arg[p] && opt->arg[p] != '=') p++;
 			opt->arg[p] = '\0';	/* Temporarily remove the equal sign */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9222,7 +9222,7 @@ unsigned int gmt_setdefaults (struct GMT_CTRL *GMT, struct GMT_OPTION *options) 
 	for (opt = options; opt; opt = opt->next) {
 		if (!(opt->option == '<' || opt->option == '#') || !opt->arg) continue;		/* Skip other and empty options */
 		if (!strcmp (opt->arg, "=")) continue;			/* User forgot and gave parameter = value (3 words) */
-		if (opt->arg[0] != '=' && strchr (opt->arg, '=') && !strstr (opt->arg, "FONT_")) {	/* User forgot and gave parameter=value (1 word); OK except for FONTS */
+		if (opt->arg[0] != '=' && strchr (opt->arg, '=') && (!param || !strstr (param, "FONT_"))) {	/* User forgot and gave parameter=value (1 word); OK except for FONTS */
 			p = 0;
 			while (opt->arg[p] && opt->arg[p] != '=') p++;
 			opt->arg[p] = '\0';	/* Temporarily remove the equal sign */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9222,7 +9222,7 @@ unsigned int gmt_setdefaults (struct GMT_CTRL *GMT, struct GMT_OPTION *options) 
 	for (opt = options; opt; opt = opt->next) {
 		if (!(opt->option == '<' || opt->option == '#') || !opt->arg) continue;		/* Skip other and empty options */
 		if (!strcmp (opt->arg, "=")) continue;			/* User forgot and gave parameter = value (3 words) */
-		if (opt->arg[0] != '=' && strchr (opt->arg, '=')) {	/* User forgot and gave parameter=value (1 word) */
+		if (opt->arg[0] != '=' && strchr (opt->arg, '=') && param && !strstr (param, "FONT_")) {	/* User forgot and gave parameter=value (1 word) */
 			p = 0;
 			while (opt->arg[p] && opt->arg[p] != '=') p++;
 			opt->arg[p] = '\0';	/* Temporarily remove the equal sign */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -6499,8 +6499,12 @@ char *gmt_putfont (struct GMT_CTRL *GMT, struct GMT_FONT *F) {
 
 	static char text[GMT_BUFSIZ];
 
-	if (F->form & 2)
-		snprintf (text, GMT_BUFSIZ, "%gp,%s,%s=%s", F->size, GMT->session.font[F->id].name, gmtlib_putfill (GMT, &F->fill), gmt_putpen (GMT, &F->pen));
+	if (F->form & 2) {
+		if (F->form & 8)
+			snprintf (text, GMT_BUFSIZ, "%gp,%s,%s=~%s", F->size, GMT->session.font[F->id].name, gmtlib_putfill (GMT, &F->fill), gmt_putpen (GMT, &F->pen));
+		else
+			snprintf (text, GMT_BUFSIZ, "%gp,%s,%s=%s", F->size, GMT->session.font[F->id].name, gmtlib_putfill (GMT, &F->fill), gmt_putpen (GMT, &F->pen));
+	}
 	else
 		snprintf (text, GMT_BUFSIZ, "%gp,%s,%s", F->size, GMT->session.font[F->id].name, gmtlib_putfill (GMT, &F->fill));
 	return (text);

--- a/src/gmtset.c
+++ b/src/gmtset.c
@@ -65,7 +65,7 @@ GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct GMTSET_CTRL *C) {	/* Deal
 GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [-C | -D[s|u] | -G<defaultsfile>] [-[" GMT_SHORTHAND_OPTIONS "]<value>] PARAMETER1 [=] value1 PARAMETER2 [=] value2 PARAMETER3 [=] value3 ...\n", name);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s [-C | -D[s|u] | -G<defaultsfile>] [-[" GMT_SHORTHAND_OPTIONS "]<value>] PARAMETER1 value1 PARAMETER2 value2 PARAMETER3 value3 ...\n", name);
 	GMT_Message (API, GMT_TIME_NONE, "\n\tFor available PARAMETERS, see gmt.conf man page.\n\n");
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);

--- a/test/psxy/variable_z.sh
+++ b/test/psxy/variable_z.sh
@@ -36,4 +36,3 @@ gmt psxy -R -J pol.txt -B0 -Ct.cpt -Zz.txt -W2p+z -O -K -X-8.5c -Y8.5c >> $ps
 echo "-Zz.txt -W2p+z" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i >> $ps
 gmt psxy -R -J pol.txt -B0 -Ct.cpt -Z3 -G+z -W2p -O -K -X8.5c >> $ps
 echo "-Z3 -G+z -W2p" | gmt pstext -R -J -O -F+f12p+cTL -Dj0.1i >> $ps
-gv $ps

--- a/test/psxyz/variable_z.sh
+++ b/test/psxyz/variable_z.sh
@@ -36,4 +36,3 @@ gmt psxy -R -J pol.txt -B0 -Ct.cpt -Zz.txt -W2p+z -O -K -X-8.5c -Y8.5c -p >> $ps
 echo "-Zz.txt -W2p+z" | gmt pstext -R -J -O -K -F+f12p+cTL -Dj0.1i -p >> $ps
 gmt psxy -R -J pol.txt -B0 -Ct.cpt -Z3 -G+z -W2p -O -K -X8.5c -p >> $ps
 echo "-Z3 -G+z -W2p" | gmt pstext -R -J -O -F+f12p+cTL -Dj0.1i -p >> $ps
-gv $ps


### PR DESCRIPTION
From the olden days, we have been allowing the deprecated syntax **PAR** = _value_ and even **PAR**=_value_ given to gmt set, despite the syntax being **PAR** _value_.  This caused trouble for fonts with outline pens which contains an equal sign.  While being bakwards compatible, I removed the [=] from the docs to discourage the use of that old syntax.  We still allow it, but not **PAR**=_value_  if **PAR** contains the text **FONT_**.  Closes #3190.
