### PR TITLE
Refresh GMT install instructions for Ubuntu 20.04/Debian 11

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -209,7 +209,7 @@ by the official GMT repository. You can uninstall the older packages by:
 GMT 6.0 packages are available for Ubuntu 20.04 (Focal Fossa) and Debian 11 (Bullseye/Testing).
 Install it via
 
-    sudo apt-get install gmt gmt-dcw gmt-gshhg-data
+    sudo apt-get install gmt gmt-dcw gmt-gshhg
 
 **Note** that the above command will install GMT 5.4 for older Ubuntu/Debian versions,
 e.g. Ubuntu 18.04 Bionic Beaver and Debian 10 Buster/Stable.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -206,15 +206,15 @@ by the official GMT repository. You can uninstall the older packages by:
 
 ### Ubuntu/Debian
 
-**Note:** Ubuntu/Debian are way behind in packing a recent GMT version.
-Typically you may find they offer 5.2.1 from 2015 while the rest of us have
-moved on to 2019. Your best bet then is to
+GMT 6.0 packages are available for Ubuntu 20.04 (Focal Fossa) and Debian 11 (Bullseye/Testing).
+Install it via
+
+    sudo apt-get install gmt gmt-dcw gmt-gshhg-data
+
+**Note** that the above command will install GMT 5.4 for older Ubuntu/Debian versions,
+e.g. Ubuntu 18.04 Bionic Beaver and Debian 10 Buster/Stable.
+If you want the latest GMT 6.0 release, your best bet then is to
 [build the latest release from source](BUILDING.md).
-Otherwise, installing from the distros goes like this:
-
-Install GMT5 via
-
-    sudo apt-get install gmt gmt-dcw gmt-gshhg
 
 Install other GMT dependencies (some are optional) via:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -215,6 +215,10 @@ Install it via
 e.g. Ubuntu 18.04 Bionic Beaver and Debian 10 Buster/Stable.
 If you want the latest GMT 6.0 release, your best bet then is to
 [build the latest release from source](BUILDING.md).
+Keep in mind that Ubuntu 16.04 LTS for mysterious reasons does not
+include the [supplemental modules](https://docs.generic-mapping-tools.org/latest/modules.html#supplemental-modules),
+but you can obtain them by [building from source](BUILDING.md) or upgrading to Ubuntu 18.04 LTS (or newer).
+
 
 Install other GMT dependencies (some are optional) via:
 
@@ -222,10 +226,6 @@ Install other GMT dependencies (some are optional) via:
     sudo apt-get install ghostscript
     # optional
     sudo apt-get install gdal-bin
-
-**Note:** The Ubuntu package under 16.04 LTS for mysterious reasons does not
-include the supplements. If you need them you will need to
-[build from source](BUILDING.md) or upgrade to 18.04 LTS.
 
 ### ArchLinux
 


### PR DESCRIPTION
**Description of proposed changes**

Ubuntu LTS 20.04 [Focal Fossa](https://wiki.ubuntu.com/FocalFossa/ReleaseNotes) was just released on 23 March 2020, and GMT 6.0.0 is actually available in the repository at https://packages.ubuntu.com/focal/gmt. The package has [just made it](https://tracker.debian.org/news/1121125/gmt-600dfsg-2-migrated-to-testing/) into Debian 11 Bullseye/Testing too on the same date at https://packages.debian.org/bullseye/gmt.

Thanks by the way to @sebastic for maintaining these Debian/Ubuntu packages!

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

I've removed the note that Ubuntu/Debian is 'way behind', but am still instructing users using older Ubuntu/Debian stable versions to build from source to get GMT6. Let me know if I should change the wording of this a bit more.

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Correct base branch selected? `master` for new features, `6.1` for bug fixes
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
