### PR TITLE
Rename module substructure to be unique

### DIFF
--- a/src/dimfilter.c
+++ b/src/dimfilter.c
@@ -79,47 +79,47 @@ struct DIMFILTER_INFO {
 };
 
 struct DIMFILTER_CTRL {
-	struct In {
+	struct DIMFILTER_In {
 		bool active;
 		char *file;
 	} In;
-	struct C {	/* -C */
+	struct DIMFILTER_C {	/* -C */
 		bool active;
 	} C;
-	struct D {	/* -D<distflag> */
+	struct DIMFILTER_D {	/* -D<distflag> */
 		bool active;
 		int mode;
 	} D;
-	struct E {	/* -E */
+	struct DIMFILTER_E {	/* -E */
 		bool active;
 	} E;
-	struct F {	/* <type><filter_width>*/
+	struct DIMFILTER_F {	/* <type><filter_width>*/
 		bool active;
 		int filter;	/* Id for the filter */
 		double width;
 		int mode;
 	} F;
-	struct G {	/* -G<file> */
+	struct DIMFILTER_G {	/* -G<file> */
 		bool active;
 		char *file;
 	} G;
-	struct L {	/* -L */
+	struct DIMFILTER_L {	/* -L */
 		bool active;
 	} L;
-	struct N {	/* -N */
+	struct DIMFILTER_N {	/* -N */
 		bool active;
 		unsigned int n_sectors;
 		int filter;	/* Id for the filter */
 		int mode;
 	} N;
-	struct Q {	/* -Q */
+	struct DIMFILTER_Q {	/* -Q */
 		bool active;
 	} Q;
-	struct S {	/* -S<file> */
+	struct DIMFILTER_S {	/* -S<file> */
 		bool active;
 		char *file;
 	} S;
-	struct T {	/* -T */
+	struct DIMFILTER_T {	/* -T */
 		bool active;
 	} T;
 };

--- a/src/filter1d.c
+++ b/src/filter1d.c
@@ -50,14 +50,14 @@
 /* Control structure for filter1d */
 
 struct FILTER1D_CTRL {
-	struct D {	/* -D<inc> */
+	struct FILTER1D_D {	/* -D<inc> */
 		bool active;
 		double inc;
 	} D;
-	struct E {	/* -E */
+	struct FILTER1D_E {	/* -E */
 		bool active;
 	} E;
-	struct F {	/* -F<type><width>[<mode>] */
+	struct FILTER1D_F {	/* -F<type><width>[<mode>] */
 		bool active;
 		bool highpass;
 		char filter;	/* Character codes for the filter */
@@ -65,11 +65,11 @@ struct FILTER1D_CTRL {
 		int mode;	/* -1/0/+1 */
 		char *file;	/* Character codes for the filter */
 	} F;
-	struct L {	/* -L<lackwidth> */
+	struct FILTER1D_L {	/* -L<lackwidth> */
 		bool active;
 		double value;
 	} L;
-	struct N {	/* -N<t_col> or -Nc|<unit>[+a] */
+	struct FILTER1D_N {	/* -N<t_col> or -Nc|<unit>[+a] */
 		bool active;
 		bool add_col;
 		char unit;
@@ -77,15 +77,15 @@ struct FILTER1D_CTRL {
 		unsigned int spatial;
 		int col;
 	} N;
-	struct Q {	/* -Q<factor> */
+	struct FILTER1D_Q {	/* -Q<factor> */
 		bool active;
 		double value;
 	} Q;
-	struct S {	/* -S<symmetry> */
+	struct FILTER1D_S {	/* -S<symmetry> */
 		bool active;
 		double value;
 	} S;
-	struct T {	/* -T<tmin/tmax/tinc>[+a|n] */
+	struct FILTER1D_T {	/* -T<tmin/tmax/tinc>[+a|n] */
 		bool active;
 		struct GMT_ARRAY T;
 	} T;

--- a/src/fitcircle.c
+++ b/src/fitcircle.c
@@ -83,15 +83,15 @@
 
 struct FITCIRCLE_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct F {	/* -F[f|m|n|s|c] */
+	struct FITCIRCLE_F {	/* -F[f|m|n|s|c] */
 		bool active;
 		unsigned int mode;	/* f = 1, m = 2, n = 4, s = 8, c = 16 [31] */
 	} F;
-	struct L {	/* -L[<n>] */
+	struct FITCIRCLE_L {	/* -L[<n>] */
 		bool active;
 		unsigned int norm;	/* 1, 2, or 3 (both) */
 	} L;
-	struct S {	/* -S[<lat] */
+	struct FITCIRCLE_S {	/* -S[<lat] */
 		bool active;
 		unsigned int mode;	/* 0 = find latitude, 1 = use specified latitude */
 		double lat;	/* 0 for great circle */

--- a/src/geodesy/psvelo.c
+++ b/src/geodesy/psvelo.c
@@ -54,29 +54,29 @@ PostScript code is written to stdout.
 /* Control structure for psvelo */
 
 struct PSVELO_CTRL {
-	struct A {	/* -A */
+	struct PSVELO_A {	/* -A */
 		bool active;
 		struct GMT_SYMBOL S;
 	} A;
-	struct D {	/* -D */
+	struct PSVELO_D {	/* -D */
 		bool active;
 		double scale;
 	} D;
- 	struct E {	/* -E<fill> */
+ 	struct PSVELO_E {	/* -E<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} E;
- 	struct G {	/* -G<fill> */
+ 	struct PSVELO_G {	/* -G<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} G;
-	struct L {	/* -L */
+	struct PSVELO_L {	/* -L */
 		bool active;
 	} L;
-	struct N {	/* -N */
+	struct PSVELO_N {	/* -N */
 		bool active;
 	} N;
-	struct S {	/* -r<fill> */
+	struct PSVELO_S {	/* -r<fill> */
 		bool active;
 		int symbol;
 		unsigned int readmode;
@@ -86,7 +86,7 @@ struct PSVELO_CTRL {
 		struct GMT_FILL fill;
 		struct GMT_FONT font;
 	} S;
-	struct W {	/* -W<pen> */
+	struct PSVELO_W {	/* -W<pen> */
 		bool active;
 		struct GMT_PEN pen;
 	} W;

--- a/src/gmt2kml.c
+++ b/src/gmt2kml.c
@@ -66,55 +66,55 @@
 
 struct GMT2KML_CTRL {
 	double t_transp;
-	struct In {
+	struct GMT2KML_In {
 		bool active;
 		char *file;
 	} In;
-	struct A {	/* -A */
+	struct GMT2KML_A {	/* -A */
 		bool active;
 		bool get_alt;
 		unsigned int mode;
 		double scale;
 		double altitude;
 	} A;
-	struct C {	/* -C<cpt> */
+	struct GMT2KML_C {	/* -C<cpt> */
 		bool active;
 		char *file;
 	} C;
-	struct D {	/* -D<descriptfile> */
+	struct GMT2KML_D {	/* -D<descriptfile> */
 		bool active;
 		char *file;
 	} D;
-	struct E {	/* -E[+e][+s] */
+	struct GMT2KML_E {	/* -E[+e][+s] */
 		bool active;
 		bool extrude;
 		bool tessellate;
 	} E;
-	struct F {	/* -F */
+	struct GMT2KML_F {	/* -F */
 		bool active;
 		unsigned int mode;
 		unsigned int geometry;
 	} F;
-	struct G {	/* -G<fill>+f|n */
+	struct GMT2KML_G {	/* -G<fill>+f|n */
 		bool active[2];
 		struct GMT_FILL fill[2];
 	} G;
-	struct I {	/* -I<icon> */
+	struct GMT2KML_I {	/* -I<icon> */
 		bool active;
 		char *file;
 	} I;
-	struct L {	/* -L */
+	struct GMT2KML_L {	/* -L */
 		bool active;
 		unsigned int n_cols;
 		char **name;
 	} L;
-	struct N {	/* -N */
+	struct GMT2KML_N {	/* -N */
 		bool active;
 		unsigned int col;
 		unsigned int mode;
 		char *fmt;
 	} N;
-	struct Q {	/* -Qi|a<az> and -Qs<scale> */
+	struct GMT2KML_Q {	/* -Qi|a<az> and -Qs<scale> */
 		bool active;
 		unsigned int mode, dmode;
 		char unit;
@@ -125,20 +125,20 @@ struct GMT2KML_CTRL {
 		bool active;
 		bool automatic;
 	} R2;
-	struct S {	/* -S */
+	struct GMT2KML_S {	/* -S */
 		bool active;
 		double scale[2];
 	} S;
-	struct T {	/* -T */
+	struct GMT2KML_T {	/* -T */
 		bool active;
 		char *title;
 		char *folder;
 	} T;
-	struct W {	/* -W<pen>[+c[l|f]] */
+	struct GMT2KML_W {	/* -W<pen>[+c[l|f]] */
 		bool active;
 		struct GMT_PEN pen;
 	} W;
-	struct Z {	/* -Z */
+	struct GMT2KML_Z {	/* -Z */
 		bool active;
 		bool invisible;
 		bool open;
@@ -146,7 +146,7 @@ struct GMT2KML_CTRL {
 	} Z;
 };
 
-struct KML {
+struct GMT2KML_KML {
 	double *lon, *lat, *z;	/* Points defining the data for the wiggle */
 	double *flon, *flat;	/* The fake lon, lat of the wiggle on the Earth */
 	uint64_t n_in;	/* Poinst making the wiggle data */
@@ -705,9 +705,9 @@ GMT_LOCAL bool gmt2kml_crossed_dateline (double this_x, double last_x) {
 	return (false);
 }
 
-GMT_LOCAL struct KML * gmt2kml_alloc (struct GMT_CTRL *GMT, struct GMT_DATASET *D) {
+GMT_LOCAL struct GMT2KML_KML * gmt2kml_alloc (struct GMT_CTRL *GMT, struct GMT_DATASET *D) {
 	uint64_t tbl, seg, max = 0;
-	struct KML *kml = gmt_M_memory (GMT, NULL, 1, struct KML);
+	struct GMT2KML_KML *kml = gmt_M_memory (GMT, NULL, 1, struct GMT2KML_KML);
 	for (tbl = 0; tbl < D->n_tables; tbl++) for (seg = 0; seg < D->table[tbl]->n_segments; seg++) if (D->table[tbl]->segment[seg]->n_rows > max) max = D->table[tbl]->segment[seg]->n_rows;
 	kml->n_alloc = 3 * max;
 	kml->lon  = gmt_M_memory (GMT, NULL, kml->n_alloc, double);
@@ -718,7 +718,7 @@ GMT_LOCAL struct KML * gmt2kml_alloc (struct GMT_CTRL *GMT, struct GMT_DATASET *
 	return (kml);
 }
 
-GMT_LOCAL void gmt2kml_free (struct GMT_CTRL *GMT, struct KML ** kml) {
+GMT_LOCAL void gmt2kml_free (struct GMT_CTRL *GMT, struct GMT2KML_KML ** kml) {
 	gmt_M_free (GMT, (*kml)->lon);
 	gmt_M_free (GMT, (*kml)->lat);
 	gmt_M_free (GMT, (*kml)->z);
@@ -759,7 +759,7 @@ GMT_LOCAL void gmt2kml_plot_object (struct GMTAPI_CTRL *API, struct GMT_RECORD *
 	gmt2kml_print (API, Out, --N, "</Placemark>");
 }
 
-GMT_LOCAL void gmt2kml_plot_wiggle (struct GMT_CTRL *GMT, struct GMT_RECORD *Out, struct KML *kml, double zscale, int mode, double azim[], int fill, int outline, int process_id, int amode, int N, double altitude) {
+GMT_LOCAL void gmt2kml_plot_wiggle (struct GMT_CTRL *GMT, struct GMT_RECORD *Out, struct GMT2KML_KML *kml, double zscale, int mode, double azim[], int fill, int outline, int process_id, int amode, int N, double altitude) {
 	int64_t i, np = 0;
 	double lon_len, lat_len, az = 0.0, s = 0.0, c = 0.0, lon_inc, lat_inc;
 	double start_az = 0, stop_az = 0, daz;
@@ -836,7 +836,7 @@ EXTERN_MSC int GMT_gmt2kml (void *V_API, int mode, void *args) {
 
 	double rgb[4], out[5], last_x = 0;
 
-	struct KML *kml = NULL;
+	struct GMT2KML_KML *kml = NULL;
 	struct GMT_OPTION *options = NULL;
 	struct GMT_PALETTE *P = NULL;
 	struct GMT_DATASET *D = NULL;

--- a/src/gmtconnect.c
+++ b/src/gmtconnect.c
@@ -39,27 +39,27 @@
 /* Control structure for gmtconnect */
 
 struct GMTCONNECT_CTRL {
-	struct Out {	/* -> */
+	struct GMTCONNECT_Out {	/* -> */
 		bool active;
 		char *file;
 	} Out;
-	struct C {	/* -C[<file>] */
+	struct GMTCONNECT_C {	/* -C[<file>] */
 		bool active;
 		char *file;	/* File for storing closed polygons */
 	} C;
-	struct D {	/* -D[<file>] */
+	struct GMTCONNECT_D {	/* -D[<file>] */
 		bool active;
 		char *format;
 	} D;
-	struct L {	/* -L[<file>] */
+	struct GMTCONNECT_L {	/* -L[<file>] */
 		bool active;
 		char *file;
 	} L;
-	struct Q {	/* -Q[<file>] */
+	struct GMTCONNECT_Q {	/* -Q[<file>] */
 		bool active;
 		char *file;
 	} Q;
-	struct T {	/* -T[<cutoff>[+s<sdist>]] */
+	struct GMTCONNECT_T {	/* -T[<cutoff>[+s<sdist>]] */
 		bool active[2];
 		int mode;
 		double dist[2];
@@ -75,14 +75,14 @@ struct GMTCONNECT_CTRL {
 #define CLOSED	0
 #define OPEN	1
 
-struct NEAREST {	/* Holds information about the nearest segment to one of the two end of a segment */
+struct GMTCONNECT_NEAREST {	/* Holds information about the nearest segment to one of the two end of a segment */
 	uint64_t id;		/* Running number ID starting at 0 for open segments only */
 	uint64_t orig_id;	/* The original ID before expelling duplicates and closed segments */
 	unsigned int end_order;	/* Index of line-end-point (0 = beginning and 1 = end) that is closest to another line */
 	double dist, next_dist;	/* The nearest and next nearest distance to another segment */
 };
 
-struct LINK {	/* Information on linking segments together basd on end point properties */
+struct GMTCONNECT_LINK {	/* Information on linking segments together basd on end point properties */
 	uint64_t id;		/* Running number ID starting at 0 for open segments only */
 	uint64_t orig_id;	/* The original ID before expelling duplicates and closed segments */
 	uint64_t seg;		/* Original segment number in table */
@@ -91,7 +91,7 @@ struct LINK {	/* Information on linking segments together basd on end point prop
 	bool used;		/* True when we have connected this segment into a longer chain */
 	double x_end[2];	/* The x-coordinates of the two line end-points (0 = beginning and 1 = end) */
 	double y_end[2];	/* The y-coordinates of the two line end-points (0 = beginning and 1 = end) */
-	struct NEAREST nearest[2];	/* The nearest line segment to the two end-points  (0 = beginning and 1 = end) */
+	struct GMTCONNECT_NEAREST nearest[2];	/* The nearest line segment to the two end-points  (0 = beginning and 1 = end) */
 };
 
 GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
@@ -236,7 +236,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMTCONNECT_CTRL *Ctrl, struct 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
 
-GMT_LOCAL int gmtconnect_found_a_near_segment (struct LINK *S, uint64_t id, int order, double threshold, bool nn_check, double sdist) {
+GMT_LOCAL int gmtconnect_found_a_near_segment (struct GMTCONNECT_LINK *S, uint64_t id, int order, double threshold, bool nn_check, double sdist) {
 	/* Checks if OK to connect this segment to its nearest neighbor and returns true if OK */
 
 	if (S[S[id].nearest[order].id].used) return (false);		/* Segment has been conncted already */
@@ -285,7 +285,7 @@ EXTERN_MSC int GMT_gmtconnect (void *V_API, int mode, void *args) {
 
 	char *buffer = NULL, msg[GMT_BUFSIZ] = {""}, text[GMT_LEN64] = {""}, *BE = "BE", *ofile = NULL;
 
-	struct LINK *segment = NULL;
+	struct GMTCONNECT_LINK *segment = NULL;
 	struct GMT_DATASET *D[2] = {NULL, NULL}, *C = NULL;
 	struct GMT_DATASET *Q = NULL;
 	struct GMT_DATASEGMENT **T[2] = {NULL, NULL}, *S = NULL;
@@ -383,7 +383,7 @@ EXTERN_MSC int GMT_gmtconnect (void *V_API, int mode, void *args) {
 		Return (GMT_RUNTIME_ERROR);
 	}
 	/* Surely we don't need any more segment space than the number of input segments */
-	segment = gmt_M_memory (GMT, NULL, D[GMT_IN]->n_segments, struct LINK);
+	segment = gmt_M_memory (GMT, NULL, D[GMT_IN]->n_segments, struct GMTCONNECT_LINK);
 	id = ns = out_seg = 0;
 	GMT_Report (API, GMT_MSG_INFORMATION, "Check for already-closed polygons\n");
 
@@ -523,7 +523,7 @@ EXTERN_MSC int GMT_gmtconnect (void *V_API, int mode, void *args) {
 	 * Here we need to do the connecting work.  We already have n_closed polygons stored n D[GMT_OUT] at this point */
 
 	ns = id;	/* Number of open segments remaining, adjust necessary memory */
-	if (ns < D[GMT_IN]->n_segments) segment = gmt_M_memory (GMT, segment, ns, struct LINK);	/* Trim the fat */
+	if (ns < D[GMT_IN]->n_segments) segment = gmt_M_memory (GMT, segment, ns, struct GMTCONNECT_LINK);	/* Trim the fat */
 	skip = gmt_M_memory (GMT, NULL, ns, bool);	/* Used when looking for duplicate segments only */
 
 	GMT_Report (API, GMT_MSG_INFORMATION, "Found %" PRIu64 " closed individual polygons\n", n_closed_orig);

--- a/src/gmtconvert.c
+++ b/src/gmtconvert.c
@@ -44,61 +44,61 @@
 /* Control structure for gmtconvert */
 
 struct GMTCONVERT_CTRL {
-	struct Out {	/* -> */
+	struct GMTCONVERT_Out {	/* -> */
 		bool active;
 		char *file;
 	} Out;
-	struct A {	/* -A */
+	struct GMTCONVERT_A {	/* -A */
 		bool active;
 	} A;
-	struct C {	/* -C[+l<min>+u<max>+i>] */
+	struct GMTCONVERT_C {	/* -C[+l<min>+u<max>+i>] */
 		bool active, invert;
 		uint64_t min, max;
 	} C;
-	struct D {	/* -D[<template>][+o<orig>] */
+	struct GMTCONVERT_D {	/* -D[<template>][+o<orig>] */
 		bool active;
 		bool origin;
 		unsigned int mode;
 		unsigned int t_orig, s_orig;
 		char *name;
 	} D;
-	struct E {	/* -E */
+	struct GMTCONVERT_E {	/* -E */
 		bool active;
 		bool end;
 		int mode;	/* -3, -1, -1, 0, or increment stride */
 	} E;
-	struct F {	/* -F<mode> */
+	struct GMTCONVERT_F {	/* -F<mode> */
 		bool active;
 		struct GMT_SEGMENTIZE S;
 	} F;
-	struct I {	/* -I[ast] */
+	struct GMTCONVERT_I {	/* -I[ast] */
 		bool active;
 		unsigned int mode;
 	} I;
-	struct L {	/* -L */
+	struct GMTCONVERT_L {	/* -L */
 		bool active;
 	} L;
-	struct N {	/* -N<col>[+a|d] sorting */
+	struct GMTCONVERT_N {	/* -N<col>[+a|d] sorting */
 		bool active;
 		int dir;	/* +1 ascending [default], -1 descending */
 		uint64_t col;
 	} N;
-	struct Q {	/* -Q<selections> */
+	struct GMTCONVERT_Q {	/* -Q<selections> */
 		bool active;
 		struct GMT_INT_SELECTION *select;
 	} Q;
-	struct S {	/* -S[~]\"search string\" */
+	struct GMTCONVERT_S {	/* -S[~]\"search string\" */
 		bool active;
 		struct GMT_TEXT_SELECTION *select;
 	} S;
-	struct T {	/* -T[sd] */
+	struct GMTCONVERT_T {	/* -T[sd] */
 		bool active[2];
 	} T;
-	struct W {	/* -W[+n] */
+	struct GMTCONVERT_W {	/* -W[+n] */
 		bool active;
 		unsigned int mode;
 	} W;
-	struct Z {	/* -Z[<first>]:[<last>] [DEPRECATED - use -q instead]*/
+	struct GMTCONVERT_Z {	/* -Z[<first>]:[<last>] [DEPRECATED - use -q instead]*/
 		bool active;
 		int64_t first, last;
 	} Z;

--- a/src/gmtdefaults.c
+++ b/src/gmtdefaults.c
@@ -37,7 +37,7 @@
 /* Control structure for gmtdefaults */
 
 struct GMTDEFAULTS_CTRL {
-	struct D {	/* -D[s|u] */
+	struct GMTDEFAULTS_D {	/* -D[s|u] */
 		bool active;
 		char mode;
 	} D;

--- a/src/gmtget.c
+++ b/src/gmtget.c
@@ -36,10 +36,10 @@
 /* Control structure for gmtget */
 
 struct GMTGET_CTRL {
-	struct L {	/* -L */
+	struct GMTGET_L {	/* -L */
 		bool active;
 	} L;
-	struct G {	/* -Gfilename */
+	struct GMTGET_G {	/* -Gfilename */
 		bool active;
 		char *file;
 	} G;

--- a/src/gmtinfo.c
+++ b/src/gmtinfo.c
@@ -52,30 +52,30 @@ EXTERN_MSC unsigned int gmtlib_log_array (struct GMT_CTRL *GMT, double min, doub
 struct MINMAX_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
 	unsigned int n_files;
-	struct A {	/* -A */
+	struct GMTINFO_A {	/* -A */
 		bool active;
 		unsigned int mode;	/* 0 reports range for all tables, 1 is per table, 2 is per segment */
 	} A;
-	struct C {	/* -C */
+	struct GMTINFO_C {	/* -C */
 		bool active;
 	} C;
-	struct D {	/* -D[dx[/dy[/<dz>..]]] */
+	struct GMTINFO_D {	/* -D[dx[/dy[/<dz>..]]] */
 		bool active;
 		unsigned int ncol;
 		unsigned int mode;	/* 0 means center, 1 means use dx granularity */
 		double inc[GMT_MAX_COLUMNS];
 	} D;
-	struct E {	/* -E<L|l|H|h>[<col>] */
+	struct GMTINFO_E {	/* -E<L|l|H|h>[<col>] */
 		bool active;
 		bool abs;
 		int mode;	/* -1, 0, +1 */
 		uint64_t col;
 	} E;
-	struct F {	/* -F<i|d|t> */
+	struct GMTINFO_F {	/* -F<i|d|t> */
 		bool active;
 		int mode;	/*  */
 	} F;
-	struct I {	/* -I[b|e|f|p|s]dx[/dy[/<dz>..]][[+e|r|R<incs>]] */
+	struct GMTINFO_I {	/* -I[b|e|f|p|s]dx[/dy[/<dz>..]][[+e|r|R<incs>]] */
 		bool active;
 		unsigned int extend;
 		unsigned int ncol;
@@ -83,14 +83,14 @@ struct MINMAX_CTRL {	/* All control options for this program (except common args
 		double inc[GMT_MAX_COLUMNS];
 		double delta[4];
 	} I;
-	struct L {	/* -L */
+	struct GMTINFO_L {	/* -L */
 		bool active;
 	} L;
-	struct S {	/* -S[x|y] */
+	struct GMTINFO_S {	/* -S[x|y] */
 		bool active;
 		bool xbar, ybar;
 	} S;
-	struct T {	/* -T<dz>[/<col>] */
+	struct GMTINFO_T {	/* -T<dz>[/<col>] */
 		bool active;
 		double inc;
 		unsigned int col;

--- a/src/gmtlogo.c
+++ b/src/gmtlogo.c
@@ -165,18 +165,18 @@ static float gmt_letters[GMT_N_LETTERS][2] = {	/* The G, M, T polygons */
 /* Control structure for gmtlogo */
 
 struct GMTLOGO_CTRL {
-	struct D {	/* -D[g|j|n|x]<refpoint>+w<width>[+j<justify>][+o<dx>[/<dy>]] */
+	struct GMTLOGO_D {	/* -D[g|j|n|x]<refpoint>+w<width>[+j<justify>][+o<dx>[/<dy>]] */
 		bool active;
 		struct GMT_REFPOINT *refpoint;
 		double off[2];
 		double width;
 		int justify;
 	} D;
-	struct F {	/* -F[+c<clearance>][+g<fill>][+i[<off>/][<pen>]][+p[<pen>]][+r[<radius>]][+s[<dx>/<dy>/][<shade>]][+d] */
+	struct GMTLOGO_F {	/* -F[+c<clearance>][+g<fill>][+i[<off>/][<pen>]][+p[<pen>]][+r[<radius>]][+s[<dx>/<dy>/][<shade>]][+d] */
 		bool active;
 		struct GMT_MAP_PANEL *panel;
 	} F;
-	struct S {	/* -S means only plot logo and not title below */
+	struct GMTLOGO_S {	/* -S means only plot logo and not title below */
 		bool active;
 		unsigned int mode;	/* 0 = draw label, 1 draw URL, 2 no label */
 	} S;

--- a/src/gmtmath.c
+++ b/src/gmtmath.c
@@ -82,43 +82,43 @@
 
 struct GMTMATH_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct Out {	/* = <filename> */
+	struct GMTMATH_Out {	/* = <filename> */
 		bool active;
 		char *file;
 	} Out;
-	struct A {	/* -A[-]<t_f(t).d>[+e][+w|s] */
+	struct GMTMATH_A {	/* -A[-]<t_f(t).d>[+e][+w|s] */
 		bool active;
 		bool null;
 		unsigned int e_mode;	/* 0 save coefficients, 1 save predictions and residuals */
 		unsigned int w_mode;	/* 0 no weights, 1 = got weights, 2 = got sigmas */
 		char *file;
 	} A;
-	struct C {	/* -C<cols> */
+	struct GMTMATH_C {	/* -C<cols> */
 		bool active;
 		bool *cols;
 	} C;
-	struct E {	/* -E<min_eigenvalue> */
+	struct GMTMATH_E {	/* -E<min_eigenvalue> */
 		bool active;
 		double eigen;
 	} E;
-	struct I {	/* -I */
+	struct GMTMATH_I {	/* -I */
 		bool active;
 	} I;
-	struct L {	/* -L */
+	struct GMTMATH_L {	/* -L */
 		bool active;
 	} L;
-	struct N {	/* -N<n_col>/<t_col> */
+	struct GMTMATH_N {	/* -N<n_col>/<t_col> */
 		bool active;
 		uint64_t ncol, tcol;
 	} N;
-	struct Q {	/* -Q */
+	struct GMTMATH_Q {	/* -Q */
 		bool active;
 	} Q;
-	struct S {	/* -S[f|l] */
+	struct GMTMATH_S {	/* -S[f|l] */
 		bool active;
 		int mode;	/* -1 or +1 */
 	} S;
-	struct T {	/* -T[<tmin/tmax/t_inc>[+]] | -T<file> */
+	struct GMTMATH_T {	/* -T[<tmin/tmax/t_inc>[+]] | -T<file> */
 		bool active;
 		bool notime;
 		struct GMT_ARRAY T;

--- a/src/gmtregress.c
+++ b/src/gmtregress.c
@@ -66,43 +66,43 @@ enum GMT_enum_regress {
 /* Control structure for gmtregress */
 
 struct GMTREGRESS_CTRL {
-	struct Out {	/* ->[<outfile>] */
+	struct GMTREGRESS_Out {	/* ->[<outfile>] */
 		bool active;
 		char *file;
 	} Out;
-	struct A {	/* 	-A<min>/<max>/<inc> */
+	struct GMTREGRESS_A {	/* 	-A<min>/<max>/<inc> */
 		bool active;
 		double min, max, inc;
 	} A;
-	struct C {	/* 	-C<confidence> */
+	struct GMTREGRESS_C {	/* 	-C<confidence> */
 		bool active;
 		double value;
 	} C;
-	struct E {	/* 	-Ex|y|o|r */
+	struct GMTREGRESS_E {	/* 	-Ex|y|o|r */
 		bool active;
 		unsigned int mode;
 	} E;
-	struct F {	/* 	-Fxymrcsw */
+	struct GMTREGRESS_F {	/* 	-Fxymrcsw */
 		bool active;
 		bool band;	/* True if c was given */
 		bool param;	/* True if only -Fp was given */
 		unsigned int n_cols;
 		char col[GMTREGRESS_N_FARGS];	/* Character codes for desired output in the right order */
 	} F;
-	struct N {	/* 	-N1|2|r|w */
+	struct GMTREGRESS_N {	/* 	-N1|2|r|w */
 		bool active;
 		unsigned int mode;
 	} N;
-	struct S {	/* 	-S[r] */
+	struct GMTREGRESS_S {	/* 	-S[r] */
 		bool active;
 		unsigned int mode;
 	} S;
-	struct T {	/* 	-T[<min>/<max>/]<inc>[+n] */
+	struct GMTREGRESS_T {	/* 	-T[<min>/<max>/]<inc>[+n] */
 		bool active;
 		bool no_eval;
 		struct GMT_ARRAY T;
 	} T;
-	struct W {	/* 	-W[s]x|y|r */
+	struct GMTREGRESS_W {	/* 	-W[s]x|y|r */
 		bool active;
 		unsigned int type;	/* 0 for weights, 1 if sigmas */
 		unsigned int n_weights;	/* 1-3 if any weights are selected */

--- a/src/gmtset.c
+++ b/src/gmtset.c
@@ -36,14 +36,14 @@
 /* Control structure for gmtset */
 
 struct GMTSET_CTRL {
-	struct C {	/* -C */
+	struct GMTSET_C {	/* -C */
 		bool active;
 	} C;
-	struct D {	/* -D[s|u] */
+	struct GMTSET_D {	/* -D[s|u] */
 		bool active;
 		char mode;
 	} D;
-	struct G {	/* -Gfilename */
+	struct GMTSET_G {	/* -Gfilename */
 		bool active;
 		char *file;
 	} G;

--- a/src/gmtsimplify.c
+++ b/src/gmtsimplify.c
@@ -50,11 +50,11 @@
 /* Control structure for gmtsimplify */
 
 struct GMTSIMPLIFY_CTRL {
-	struct Out {	/* ->[<outfile>] */
+	struct GMTSIMPLIFY_Out {	/* ->[<outfile>] */
 		bool active;
 		char *file;
 	} Out;
-	struct T {	/* 	-T[-|=|+]<tolerance>[d|s|m|e|f|k|M|n] */
+	struct GMTSIMPLIFY_T {	/* 	-T[-|=|+]<tolerance>[d|s|m|e|f|k|M|n] */
 		bool active;
 		int mode;	/* Can be negative */
 		double tolerance;

--- a/src/gmtspatial.c
+++ b/src/gmtspatial.c
@@ -48,7 +48,7 @@
 #define MIN_CLOSENESS		0.01	/* If two close segments has an mean separation exceeding 1% of segment length, then they are not the same feature */
 #define MIN_SUBSET		2.0	/* If two close segments deemed approximate fits has lengths that differ by this factor then they are sub/super sets of each other */
 
-struct DUP {	/* Holds information on which single segment is closest to the current test segment */
+struct GMTSPATIAL_DUP {	/* Holds information on which single segment is closest to the current test segment */
 	uint64_t point;
 	uint64_t segment;
 	unsigned int table;
@@ -73,52 +73,52 @@ struct DUP_INFO {
 };
 
 struct GMTSPATIAL_CTRL {
-	struct Out {	/* -> */
+	struct GMTSPATIAL_Out {	/* -> */
 		bool active;
 		char *file;
 	} Out;
-	struct A {	/* -Aa<min_dist>, -A */
+	struct GMTSPATIAL_A {	/* -Aa<min_dist>, -A */
 		bool active;
 		unsigned int mode;
 		int smode;
 		double min_dist;
 		char unit;
 	} A;
-	struct C {	/* -C */
+	struct GMTSPATIAL_C {	/* -C */
 		bool active;
 	} C;
-	struct D {	/* -D[pol] */
+	struct GMTSPATIAL_D {	/* -D[pol] */
 		bool active;
 		int mode;
 		char unit;
 		char *file;
-		struct DUP I;
+		struct GMTSPATIAL_DUP I;
 	} D;
-	struct E {	/* -E+n|p */
+	struct GMTSPATIAL_E {	/* -E+n|p */
 		bool active;
 		unsigned int mode;
 	} E;
-	struct F {	/* -F */
+	struct GMTSPATIAL_F {	/* -F */
 		bool active;
 		unsigned int geometry;
 	} F;
-	struct I {	/* -I[i|e] */
+	struct GMTSPATIAL_I {	/* -I[i|e] */
 		bool active;
 		unsigned int mode;
 	} I;
-	struct L {	/* -L */
+	struct GMTSPATIAL_L {	/* -L */
 		bool active;
 		char unit;
 		double s_cutoff, path_noise, box_offset;
 	} L;
-	struct N {	/* -N<file>[+a][+p>ID>][+r][+z] */
+	struct GMTSPATIAL_N {	/* -N<file>[+a][+p>ID>][+r][+z] */
 		bool active;
 		bool all;	/* All points in lines and polygons must be inside a polygon for us to report ID */
 		unsigned int mode;	/* 0 for reporting ID in -Z<ID> header, 1 via data column, 2 just as a report */
 		unsigned int ID;	/* If 1 we use running numbers */
 		char *file;
 	} N;
-	struct Q {	/* -Q[+c<min>/<max>][+h][+l][+p][+s[a|d]] */
+	struct GMTSPATIAL_Q {	/* -Q[+c<min>/<max>][+h][+l][+p][+s[a|d]] */
 		bool active;
 		bool header;	/* Place dimension and centroid in segment headers */
 		bool area;		/* Apply range test on dimension */
@@ -129,17 +129,17 @@ struct GMTSPATIAL_CTRL {
 		double limit[2];	/* Min and max area or length for output segments */
 		char unit;
 	} Q;
-	struct S {	/* -S[u|i|c|j|h] */
+	struct GMTSPATIAL_S {	/* -S[u|i|c|j|h] */
 		bool active;
 		unsigned int mode;
 	} S;
-	struct T {	/* -T[pol] */
+	struct GMTSPATIAL_T {	/* -T[pol] */
 		bool active;
 		char *file;
 	} T;
 };
 
-struct PAIR {
+struct GMTSPATIAL_PAIR {
 	double node;
 	uint64_t pos;
 };
@@ -268,7 +268,7 @@ GMT_LOCAL void gmtspatial_length_size (struct GMT_CTRL *GMT, double x[], double 
 }
 
 GMT_LOCAL int gmtspatial_comp_pairs (const void *a, const void *b) {
-	const struct PAIR *xa = a, *xb = b;
+	const struct GMTSPATIAL_PAIR *xa = a, *xb = b;
 	/* Sort on node value */
 	if (xa->node < xb->node) return (-1);
 	if (xa->node > xb->node) return (+1);
@@ -284,7 +284,7 @@ GMT_LOCAL void gmtspatial_write_record (struct GMT_CTRL *GMT, double **R, uint64
 	GMT_Put_Record (GMT->parent, GMT_WRITE_DATA, &Out);
 }
 
-GMT_LOCAL int gmtspatial_is_duplicate (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S, struct GMT_DATASET *D, struct DUP *I, struct DUP_INFO **L) {
+GMT_LOCAL int gmtspatial_is_duplicate (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S, struct GMT_DATASET *D, struct GMTSPATIAL_DUP *I, struct DUP_INFO **L) {
 	/* Given single line segment S and a dataset of many line segments in D, determine the closest neighbor
 	 * to S in D (call it S'), and if "really close" it might be a duplicate or slight revision to S.
 	 * There might be several features S' in D close to S so we return how many near or exact matches we
@@ -1591,14 +1591,14 @@ EXTERN_MSC int GMT_gmtspatial (void *V_API, int mode, void *args) {
 								uint64_t row0;
 								bool go, first;
 								double *xx = NULL, *yy = NULL, *kk = NULL;
-								struct PAIR *pair = NULL;
+								struct GMTSPATIAL_PAIR *pair = NULL;
 
-								pair = gmt_M_memory (GMT, NULL, nx, struct PAIR);
+								pair = gmt_M_memory (GMT, NULL, nx, struct GMTSPATIAL_PAIR);
 								xx = gmt_M_memory (GMT, NULL, nx, double);
 								yy = gmt_M_memory (GMT, NULL, nx, double);
 								kk = gmt_M_memory (GMT, NULL, nx, double);
 								for (px = 0; px < nx; px++) pair[px].node = XC.xnode[1][px], pair[px].pos = px;
-								qsort (pair, nx, sizeof (struct PAIR), gmtspatial_comp_pairs);
+								qsort (pair, nx, sizeof (struct GMTSPATIAL_PAIR), gmtspatial_comp_pairs);
 								for (px = 0; px < nx; px++) {
 									xx[px] = XC.x[pair[px].pos];
 									yy[px] = XC.y[pair[px].pos];

--- a/src/gmtvector.c
+++ b/src/gmtvector.c
@@ -49,35 +49,35 @@ enum gmtvector_method {	/* The available methods */
 	DO_BISECTOR};
 
 struct GMTVECTOR_CTRL {
-	struct Out {	/* -> */
+	struct GMTVECTOR_Out {	/* -> */
 		bool active;
 		char *file;
 	} Out;
-	struct In {	/* infile */
+	struct GMTVECTOR_In {	/* infile */
 		bool active;
 		unsigned int n_args;
 		char *arg;
 	} In;
-	struct A {	/* -A[m[<conf>]|<vec>] */
+	struct GMTVECTOR_A {	/* -A[m[<conf>]|<vec>] */
 		bool active;
 		unsigned int mode;
 		double conf;
 		char *arg;
 	} A;
-	struct C {	/* -C[i|o] */
+	struct GMTVECTOR_C {	/* -C[i|o] */
 		bool active[2];
 	} C;
-	struct E {	/* -E */
+	struct GMTVECTOR_E {	/* -E */
 		bool active;
 	} E;
-	struct N {	/* -N */
+	struct GMTVECTOR_N {	/* -N */
 		bool active;
 	} N;
-	struct S {	/* -S[vec] */
+	struct GMTVECTOR_S {	/* -S[vec] */
 		bool active;
 		char *arg;
 	} S;
-	struct T {	/* -T[operator] */
+	struct GMTVECTOR_T {	/* -T[operator] */
 		bool active;
 		bool degree;
 		enum gmtvector_method mode;

--- a/src/gmtwhich.c
+++ b/src/gmtwhich.c
@@ -35,16 +35,16 @@
 
 struct GMTWHICH_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct A {	/* -A */
+	struct GMTWHICH_A {	/* -A */
 		bool active;
 	} A;
-	struct C {	/* -C */
+	struct GMTWHICH_C {	/* -C */
 		bool active;
 	} C;
-	struct D {	/* -D */
+	struct GMTWHICH_D {	/* -D */
 		bool active;
 	} D;
-	struct G {	/* -G[c|l|u] */
+	struct GMTWHICH_G {	/* -G[c|l|u] */
 		bool active;
 		unsigned int mode;
 	} G;

--- a/src/gmtwrite.c
+++ b/src/gmtwrite.c
@@ -36,11 +36,11 @@
 /* Control structure for gmtwrite */
 
 struct GMTWRITE_CTRL {
-	struct IO {	/* Need two args with filenames */
+	struct GMTWRITE_IO {	/* Need two args with filenames */
 		bool active[2];
 		char *file[2];
 	} IO;
-	struct T {	/* -T sets data type */
+	struct GMTWRITE_T {	/* -T sets data type */
 		bool active;
 		enum GMT_enum_family mode;
 	} T;

--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -45,61 +45,61 @@
 #define GRD2CPT_N_LEVELS	11	/* The default number of levels if nothing is specified */
 
 struct GRD2CPT_CTRL {
-	struct In {
+	struct GRD2CPT_In {
 		bool active;
 	} In;
-	struct Out {	/* -> */
+	struct GRD2CPT_Out {	/* -> */
 		bool active;
 		char *file;
 	} Out;
-	struct A {	/* -A<transp>[+a] */
+	struct GRD2CPT_A {	/* -A<transp>[+a] */
 		bool active;
 		unsigned int mode;
 		double value;
 	} A;
-	struct C {	/* -C<cpt> or -C<color1>,<color2>[,<color3>,...] */
+	struct GRD2CPT_C {	/* -C<cpt> or -C<color1>,<color2>[,<color3>,...] */
 		bool active;
 		char *file;
 	} C;
-	struct D {	/* -D[i|o] */
+	struct GRD2CPT_D {	/* -D[i|o] */
 		bool active;
 		unsigned int mode;
 	} D;
-	struct E {	/* -E<nlevels> */
+	struct GRD2CPT_E {	/* -E<nlevels> */
 		bool active;
 		unsigned int levels;
 	} E;
-	struct F {	/* -F[r|R|h|c][+c] */
+	struct GRD2CPT_F {	/* -F[r|R|h|c][+c] */
 		bool active;
 		bool cat;
 		unsigned int model;
 	} F;
-	struct G {	/* -Glow/high for input CPT truncation */
+	struct GRD2CPT_G {	/* -Glow/high for input CPT truncation */
 		bool active;
 		double z_low, z_high;
 	} G;
-	struct H {	/* -H */
+	struct GRD2CPT_H {	/* -H */
 		bool active;
 	} H;
-	struct I {	/* -I[z][c] */
+	struct GRD2CPT_I {	/* -I[z][c] */
 		bool active;
 		unsigned int mode;
 	} I;
-	struct L {	/* -L<min_limit>/<max_limit> */
+	struct GRD2CPT_L {	/* -L<min_limit>/<max_limit> */
 		bool active;
 		double min, max;
 	} L;
-	struct M {	/* -M */
+	struct GRD2CPT_M {	/* -M */
 		bool active;
 	} M;
-	struct N {	/* -N */
+	struct GRD2CPT_N {	/* -N */
 		bool active;
 	} N;
-	struct Q {	/* -Q[i|o] */
+	struct GRD2CPT_Q {	/* -Q[i|o] */
 		bool active;
 		unsigned int mode;
 	} Q;
-	struct T {	/* -T<start>/<stop>/<inc> or -T<n_levels> */
+	struct GRD2CPT_T {	/* -T<start>/<stop>/<inc> or -T<n_levels> */
 		bool active;
 		bool interpolate;
 		unsigned int mode;	/* 0 or 1 (-Tn) */
@@ -107,15 +107,15 @@ struct GRD2CPT_CTRL {
 		double low, high, inc;
 		char *file;
 	} T;
-	struct S {	/* -S<kind> */
+	struct GRD2CPT_S {	/* -S<kind> */
 		bool active;
 		int kind; /* -1 symmetric +-zmin, +1 +-zmax, -2 = +-Minx(|zmin|,|zmax|), +2 = +-Max(|zmin|,|zmax|), 0 = min to max [Default] */
 	} S;
-	struct W {	/* -W[w] */
+	struct GRD2CPT_W {	/* -W[w] */
 		bool active;
 		bool wrap;
 	} W;
-	struct Z {	/* -Z */
+	struct GRD2CPT_Z {	/* -Z */
 		bool active;
 	} Z;
 };

--- a/src/grdclip.c
+++ b/src/grdclip.c
@@ -52,15 +52,15 @@ struct GRDCLIP_RECLASSIFY {
 };
 
 struct GRDCLIP_CTRL {
-	struct In {
+	struct GRDCLIP_In {
 		bool active;
 		char *file;
 	} In;
-	struct G {	/* -G<output_grdfile> */
+	struct GRDCLIP_G {	/* -G<output_grdfile> */
 		bool active;
 		char *file;
 	} G;
-	struct S {	/* -Sa<high/above>, -Sb<low/below>, -Si<low/high/between>, -Sr<old>/<new> */
+	struct GRDCLIP_S {	/* -Sa<high/above>, -Sb<low/below>, -Si<low/high/between>, -Sr<old>/<new> */
 		bool active;
 		unsigned int mode;
 		unsigned int n_class;

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -124,7 +124,7 @@ enum grdcontour_contour_type {cont_is_not_closed = 0,	/* Not a closed contour of
 	cont_is_closed_straddles_equator_south = -4,	/* Closed contour crossing equator that encloses the south pole */
 	cont_is_closed_straddles_equator_north = +4};	/* Closed contour crossing equator that encloses the north pole */
 
-struct SAVE {
+struct GRDCONTOUR_SAVE {
 	double *x, *y;
 	double *xp, *yp;
 	double cval;
@@ -654,7 +654,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDCONTOUR_CTRL *Ctrl, struct 
 
 /* Three sub functions used by GMT_grdcontour */
 
-GMT_LOCAL void grdcontour_sort_and_plot_ticks (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, struct SAVE *save, size_t n, struct GMT_GRID *G, double tick_gap, double tick_length, bool tick_low, bool tick_high, bool tick_label, bool all, char *in_lbl[], unsigned int mode, struct GMT_DATASET *T) {
+GMT_LOCAL void grdcontour_sort_and_plot_ticks (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, struct GRDCONTOUR_SAVE *save, size_t n, struct GMT_GRID *G, double tick_gap, double tick_length, bool tick_low, bool tick_high, bool tick_label, bool all, char *in_lbl[], unsigned int mode, struct GMT_DATASET *T) {
 	/* Labeling and ticking of inner-most contours cannot happen until all contours are found and we can determine
 	   which are the innermost ones. Here, all the n candidate contours are passed via the save array.
 	   We need to do several types of testing here:
@@ -1010,7 +1010,7 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 	struct GMT_CLOCK_IO Clock;
 	struct GMT_DATE_IO Date;
 	struct GMT_CONTOUR_INFO *cont = NULL;
-	struct SAVE *save = NULL;
+	struct GRDCONTOUR_SAVE *save = NULL;
 	struct GMT_GRID *G = NULL, *G_orig = NULL;
 	struct GMT_PALETTE *P = NULL;
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;
@@ -1627,10 +1627,10 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 				if (make_plot && cont[c].do_tick && is_closed) {	/* Must store the entire contour for later processing */
 					/* These are original coordinates that have not yet been projected */
 					int extra;
-					if (n_save == n_save_alloc) save = gmt_M_malloc (GMT, save, n_save, &n_save_alloc, struct SAVE);
+					if (n_save == n_save_alloc) save = gmt_M_malloc (GMT, save, n_save, &n_save_alloc, struct GRDCONTOUR_SAVE);
 					extra = (abs (closed) == 2);	/* Need extra slot to temporarily close half-polygons */
 					n_alloc = 0;
-					gmt_M_memset (&save[n_save], 1, struct SAVE);
+					gmt_M_memset (&save[n_save], 1, struct GRDCONTOUR_SAVE);
 					gmt_M_malloc2 (GMT, save[n_save].x, save[n_save].y, n + extra, &n_alloc, double);
 					gmt_M_memcpy (save[n_save].x, x, n, double);
 					gmt_M_memcpy (save[n_save].y, y, n, double);
@@ -1703,7 +1703,7 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 	if (make_plot) PSL_setdash (PSL, NULL, 0.0);
 
 	if (Ctrl->T.active && n_save) {	/* Finally sort and plot ticked innermost contours and plot/save L|H labels */
-		save = gmt_M_memory (GMT, save, n_save, struct SAVE);
+		save = gmt_M_memory (GMT, save, n_save, struct GRDCONTOUR_SAVE);
 
 		grdcontour_sort_and_plot_ticks (GMT, PSL, save, n_save, G_orig, Ctrl->T.dim[GMT_X], Ctrl->T.dim[GMT_Y], Ctrl->T.low, Ctrl->T.high, Ctrl->T.label, Ctrl->T.all, Ctrl->T.txt, label_mode, Ctrl->contour.Out);
 		for (i = 0; i < n_save; i++) {

--- a/src/grdconvert.c
+++ b/src/grdconvert.c
@@ -33,15 +33,15 @@
 #define THIS_MODULE_OPTIONS "-RVf"
 
 struct GRDCONVERT_CTRL {
-	struct In {
+	struct GRDCONVERT_In {
 		bool active;
 		char *file;
 	} In;
-	struct G {	/* -G<outgrid> */
+	struct GRDCONVERT_G {	/* -G<outgrid> */
 		bool active;
 		char *file;
 	} G;
-	struct N {	/* -N */
+	struct GRDCONVERT_N {	/* -N */
 		bool active;
 	} N;
 };

--- a/src/grdedit.c
+++ b/src/grdedit.c
@@ -42,41 +42,41 @@
 #define THIS_MODULE_OPTIONS "-:JRVbdefhi" GMT_OPT("H")
 
 struct GRDEDIT_CTRL {
-	struct In {
+	struct GRDEDIT_In {
 		bool active;
 		char *file;
 	} In;
-	struct A {	/* -A */
+	struct GRDEDIT_A {	/* -A */
 		bool active;
 	} A;
-	struct C {	/* -C */
+	struct GRDEDIT_C {	/* -C */
 		bool active;
 	} C;
-	struct D {	/* -D[+x<xname>][+yyname>][+z<zname>][+s<scale>][+ooffset>][+n<invalid>][+t<title>][+r<remark>] */
+	struct GRDEDIT_D {	/* -D[+x<xname>][+yyname>][+z<zname>][+s<scale>][+ooffset>][+n<invalid>][+t<title>][+r<remark>] */
 		bool active;
 		char *information;
 	} D;
-	struct E {	/* -E[a|h|l|r|t|v] */
+	struct GRDEDIT_E {	/* -E[a|h|l|r|t|v] */
 		bool active;
 		char mode;	/* l rotate 90 degrees left (CCW), t = transpose, r = rotate 90 degrees right (CW) */
 				/* a rotate around (180), h flip grid horizontally (FLIPLR), v flip grid vertically (FLIPUD) */
 	} E;
-	struct G {
+	struct GRDEDIT_G {
 		bool active;
 		char *file;
 	} G;
-	struct L {	/* -L[+n|p] */
+	struct GRDEDIT_L {	/* -L[+n|p] */
 		bool active;
 		int mode;
 	} L;
-	struct N {	/* N<xyzfile> */
+	struct GRDEDIT_N {	/* N<xyzfile> */
 		bool active;
 		char *file;
 	} N;
-	struct S {	/* -S */
+	struct GRDEDIT_S {	/* -S */
 		bool active;
 	} S;
-	struct T {	/* -T */
+	struct GRDEDIT_T {	/* -T */
 		bool active;
 	} T;
 };

--- a/src/grdfill.c
+++ b/src/grdfill.c
@@ -41,20 +41,20 @@ enum GRDFILL_mode {
 };
 
 struct GRDFILL_CTRL {
-	struct In {
+	struct GRDFILL_In {
 		bool active;
 		char *file;
 	} In;
-	struct A {	/* -A<algo>[<options>] */
+	struct GRDFILL_A {	/* -A<algo>[<options>] */
 		bool active;
 		unsigned int mode;
 		double value;
 	} A;
-	struct G {	/* -G<outgrid> */
+	struct GRDFILL_G {	/* -G<outgrid> */
 		bool active;
 		char *file;
 	} G;
-	struct L {	/* -L[p] */
+	struct GRDFILL_L {	/* -L[p] */
 		bool active;
 		unsigned int mode;	/* 0 = region, 1 = polygons */
 	} L;

--- a/src/grdfilter.c
+++ b/src/grdfilter.c
@@ -57,22 +57,22 @@ Use option -x to set the number of threads. e.g. -x2, -x4, ... or -xa to use all
 #define THIS_MODULE_OPTIONS "-RVfr" GMT_ADD_x_OPT
 
 struct GRDFILTER_CTRL {
-	struct GRDFILT_In {
+	struct GRDFILTER_In {
 		bool active;
 		char *file;
 	} In;
-	struct GRDFILT_A {	/* -A<a|r|w|c>row/col */
+	struct GRDFILTER_A {	/* -A<a|r|w|c>row/col */
 		bool active;
 		char mode;
 		unsigned int ROW, COL;
 		double x, y;
 		char *file;
 	} A;
-	struct GRDFILT_D {	/* -D<distflag> */
+	struct GRDFILTER_D {	/* -D<distflag> */
 		bool active;
 		int mode;	/* -1 to 5 */
 	} D;
-	struct GRDFILT_F {	/* <type>[-]<filter_width>[/<width2>][<mode>] */
+	struct GRDFILTER_F {	/* <type>[-]<filter_width>[/<width2>][<mode>] */
 		bool active;
 		bool highpass;
 		bool custom;
@@ -86,18 +86,18 @@ struct GRDFILTER_CTRL {
 		int mode;	/*-1 0 +1 */
 		struct GMT_GRID *W;
 	} F;
-	struct GRDFILT_G {	/* -G<file> */
+	struct GRDFILTER_G {	/* -G<file> */
 		bool active;
 		char *file;
 	} G;
-	struct GRDFILT_N {	/* -Np|i|r */
+	struct GRDFILTER_N {	/* -Np|i|r */
 		bool active;
 		unsigned int mode;	/* 0 is default (i), 1 is replace (r), 2 is preserve (p) */
 	} N;
-	struct GRDFILT_T {	/* -T */
+	struct GRDFILTER_T {	/* -T */
 		bool active;
 	} T;
-	struct GRDFILT_z {	/* -z */
+	struct GRDFILTER_z {	/* -z */
 		bool active;
 		int n_threads;
 	} z;

--- a/src/grdgradient.c
+++ b/src/grdgradient.c
@@ -44,43 +44,43 @@ enum grdgradient_mode {
 	GRDGRADIENT_VAR = 2};
 
 struct GRDGRADIENT_CTRL {
-	struct In {
+	struct GRDGRADIENT_In {
 		bool active;
 		char *file;
 	} In;
-	struct A {	/* -A<azim>[/<azim2>] | -A<file>*/
+	struct GRDGRADIENT_A {	/* -A<azim>[/<azim2>] | -A<file>*/
 		bool active;
 		bool two;
 		double azimuth[2];
 		unsigned int mode;
 		char *file;
 	} A;
-	struct D {	/* -D[a][c][o][n] */
+	struct GRDGRADIENT_D {	/* -D[a][c][o][n] */
 		bool active;
 		unsigned int mode;
 	} D;
-	struct E {	/* -E[s|p]<azim>/<elev[+a<ambient>][+d<diffuse>][+p<specular>][+<shine>] */
+	struct GRDGRADIENT_E {	/* -E[s|p]<azim>/<elev[+a<ambient>][+d<diffuse>][+p<specular>][+<shine>] */
 		bool active;
 		unsigned int mode;
 		double azimuth, elevation;
 		double ambient, diffuse, specular, shine;
 	} E;
-	struct G {	/* -G<file> */
+	struct GRDGRADIENT_G {	/* -G<file> */
 		bool active;
 		char *file;
 	} G;
-	struct N {	/* -N[t_or_e][<amp>][+<ambient>][+o<offset>][+s<sigma>] */
+	struct GRDGRADIENT_N {	/* -N[t_or_e][<amp>][+<ambient>][+o<offset>][+s<sigma>] */
 		bool active;
 		unsigned int set[3];	/* 1 if values are specified for amp, offset and sigma, 2 means we want last-run values */
 		unsigned int mode;	/* 1 = atan, 2 = exp */
 		double norm, sigma, offset, ambient;
 	} N;
-	struct Q {	/* -Qc|r|R */
+	struct GRDGRADIENT_Q {	/* -Qc|r|R */
 		/* Note: If -Qc is set with -N then -G is not required. GMT_Encode_Options turns off the primary output */
 		bool active;
 		unsigned int mode;
 	} Q;
-	struct S {	/* -S<slopefile> */
+	struct GRDGRADIENT_S {	/* -S<slopefile> */
 		bool active;
 		char *file;
 	} S;

--- a/src/grdhisteq.c
+++ b/src/grdhisteq.c
@@ -34,27 +34,27 @@
 #define THIS_MODULE_OPTIONS "-RVh"
 
 struct GRDHISTEQ_CTRL {
-	struct In {
+	struct GRDHISTEQ_In {
 		bool active;
 		char *file;
 	} In;
-	struct C {	/* -C<n_cells>*/
+	struct GRDHISTEQ_C {	/* -C<n_cells>*/
 		bool active;
 		unsigned int value;
 	} C;
-	struct D {	/* -D[<file>] */
+	struct GRDHISTEQ_D {	/* -D[<file>] */
 		bool active;
 		char *file;
 	} D;
-	struct G {	/* -G<file> */
+	struct GRDHISTEQ_G {	/* -G<file> */
 		bool active;
 		char *file;
 	} G;
-	struct N {	/* -N[<norm>] */
+	struct GRDHISTEQ_N {	/* -N[<norm>] */
 		bool active;
 		double norm;
 	} N;
-	struct Q {	/* -Q */
+	struct GRDHISTEQ_Q {	/* -Q */
 		bool active;
 	} Q;
 };
@@ -64,7 +64,7 @@ struct INDEXED_DATA {
 	uint64_t i;
 };
 
-struct CELL {
+struct GRDHISTEQ_CELL {
 	gmt_grdfloat low;
 	gmt_grdfloat high;
 };
@@ -176,7 +176,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDHISTEQ_CTRL *Ctrl, struct G
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
 
-GMT_LOCAL gmt_grdfloat grdhisteq_get_cell (gmt_grdfloat x, struct CELL *cell, unsigned int n_cells_m1, unsigned int last_cell) {
+GMT_LOCAL gmt_grdfloat grdhisteq_get_cell (gmt_grdfloat x, struct GRDHISTEQ_CELL *cell, unsigned int n_cells_m1, unsigned int last_cell) {
 	unsigned int low, high, i;
 
 	low = 0;
@@ -210,11 +210,11 @@ GMT_LOCAL int grdhisteq_do_hist_equalization_cart (struct GMT_CTRL *GMT, struct 
 	uint64_t i, j, nxy;
 	unsigned int n_cells_m1 = 0, current_cell, pad[4];
 	double delta_cell, target, out[3];
-	struct CELL *cell = NULL;
+	struct GRDHISTEQ_CELL *cell = NULL;
 	struct GMT_GRID *Orig = NULL;
 	struct GMT_RECORD *Out = NULL;
 
-	cell = gmt_M_memory (GMT, NULL, n_cells, struct CELL);
+	cell = gmt_M_memory (GMT, NULL, n_cells, struct GRDHISTEQ_CELL);
 
 	/* Sort the data and find the division points */
 
@@ -285,7 +285,7 @@ GMT_LOCAL int grdhisteq_do_hist_equalization_geo (struct GMT_CTRL *GMT, struct G
 	uint64_t i, j, node, nxy = 0;
 	unsigned int n_cells_m1 = 0, current_cell, row, col;
 	double cell_w, delta_w, target_w, wsum = 0.0, out[3];
-	struct CELL *cell = gmt_M_memory (GMT, NULL, n_cells, struct CELL);
+	struct GRDHISTEQ_CELL *cell = gmt_M_memory (GMT, NULL, n_cells, struct GRDHISTEQ_CELL);
 	struct GMT_GRID *W = gmt_duplicate_grid (GMT, Grid, GMT_DUPLICATE_ALLOC);
 	struct GMT_OBSERVATION *pair = gmt_M_memory (GMT, NULL, Grid->header->nm, struct GMT_OBSERVATION);
 	struct GMT_RECORD *Out = NULL;

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -43,40 +43,40 @@ static char *gdal_ext[N_IMG_EXTENSIONS] = {"tiff", "tif", "gif", "png", "jpg", "
 /* Control structure for grdimage */
 
 struct GRDIMAGE_CTRL {
-	struct GRDIMG_In {
+	struct GRDIMAGE_In {
 		bool active;
 		bool do_rgb;
 		char *file[3];
 	} In;
-	struct GRDIMG_Out {
+	struct GRDIMAGE_Out {
 		bool active;
 		char *file;
 	} Out;
-	struct GRDIMG_C {	/* -C<cpt> or -C<color1>,<color2>[,<color3>,...][+i<dz>] */
+	struct GRDIMAGE_C {	/* -C<cpt> or -C<color1>,<color2>[,<color3>,...][+i<dz>] */
 		bool active;
 		double dz;
 		char *file;
 	} C;
-	struct GRDIMG_D {	/* -D to read image instead of grid */
+	struct GRDIMAGE_D {	/* -D to read image instead of grid */
 		bool active;
 		bool mode;	/* Use info of -R option to reference image */
 	} D;
-	struct GRDIMG_A {	/* -A to write a raster file or return image to API */
+	struct GRDIMAGE_A {	/* -A to write a raster file or return image to API */
 		bool active;
 		bool return_image;
 		unsigned int way;
 		char *file;
 	} A;
-	struct GRDIMG_E {	/* -Ei|<dpi> */
+	struct GRDIMAGE_E {	/* -Ei|<dpi> */
 		bool active;
 		bool device_dpi;
 		unsigned int dpi;
 	} E;
-	struct GRDIMG_G {	/* -G<rgb>[+b|f] */
+	struct GRDIMAGE_G {	/* -G<rgb>[+b|f] */
 		bool active;
 		double rgb[2][4];
 	} G;
-	struct GRDIMG_I {	/* -I[<intensfile>|<value>|<modifiers>] */
+	struct GRDIMAGE_I {	/* -I[<intensfile>|<value>|<modifiers>] */
 		bool active;
 		bool constant;
 		bool derive;
@@ -86,16 +86,16 @@ struct GRDIMAGE_CTRL {
 		char *method;	/* Default scaling method */
 		char *ambient;	/* Default ambient offset */
 	} I;
-	struct GRDIMG_M {	/* -M */
+	struct GRDIMAGE_M {	/* -M */
 		bool active;
 	} M;
-	struct GRDIMG_N {	/* -N */
+	struct GRDIMAGE_N {	/* -N */
 		bool active;
 	} N;
-	struct GRDIMG_Q {	/* -Q */
+	struct GRDIMAGE_Q {	/* -Q */
 		bool active;
 	} Q;
-	struct GRDIMG_W {	/* -W */
+	struct GRDIMAGE_W {	/* -W */
 		bool active;
 	} W;
 };

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -40,40 +40,40 @@
 #define THIS_MODULE_OPTIONS	"->RVfn"
 
 struct GRDINTERPOLATE_CTRL {
-	struct In {
+	struct GRDINTERPOLATE_In {
 		bool active;
 		char **file;
 		unsigned int n_files;
 	} In;
-	struct E {	/* -E<file>|<line1>[,<line2>,...][+a<az>][+c][+g][+i<step>][+l<length>][+n<np][+o<az>][+p][+r<radius>][+x] */
+	struct GRDINTERPOLATE_E {	/* -E<file>|<line1>[,<line2>,...][+a<az>][+c][+g][+i<step>][+l<length>][+n<np][+o<az>][+p][+r<radius>][+x] */
 		bool active;
 		unsigned int mode;
 		char *lines;
 		double step;
 		char unit;
 	} E;
-	struct F {	/* -Fl|a|c[1|2] */
+	struct GRDINTERPOLATE_F {	/* -Fl|a|c[1|2] */
 		bool active;
 		unsigned int mode;
 		unsigned int type;
 		char spline[GMT_LEN8];
 	} F;
-	struct G {	/* -G<output_grdfile>  */
+	struct GRDINTERPOLATE_G {	/* -G<output_grdfile>  */
 		bool active;
 		char *file;
 	} G;
-	struct S {	/* -S<x>/<y>|<pointfile>[+h<header>] */
+	struct GRDINTERPOLATE_S {	/* -S<x>/<y>|<pointfile>[+h<header>] */
 		bool active;
 		double x, y;
 		char *file;
 		char *header;
 	} S;
-	struct T {	/* -T<start>/<stop>/<inc> or -T<value> */
+	struct GRDINTERPOLATE_T {	/* -T<start>/<stop>/<inc> or -T<value> */
 		bool active;
 		struct GMT_ARRAY T;
 		char *string;
 	} T;
-	struct Z {	/* -Z<min>/<max>/<inc>, -Z<file>, or -Z<list> */
+	struct GRDINTERPOLATE_Z {	/* -Z<min>/<max>/<inc>, -Z<file>, or -Z<list> */
 		bool active[2];
 		struct GMT_ARRAY T;
 	} Z;

--- a/src/grdlandmask.c
+++ b/src/grdlandmask.c
@@ -70,12 +70,12 @@ struct GRDLANDMASK_CTRL {	/* All control options for this program (except common
 	} N;
 };
 
-struct BINCROSS {
+struct GRDLANDMASK_BINCROSS {
 	double x, y, d;
 };
 
 GMT_LOCAL int grdlandmask_comp_bincross (const void *p1, const void *p2) {
-	const struct BINCROSS *a = p1, *b = p2;
+	const struct GRDLANDMASK_BINCROSS *a = p1, *b = p2;
 
 	if (a->d < b->d) return (-1);
 	if (a->d > b->d) return (+1);
@@ -281,7 +281,7 @@ EXTERN_MSC int GMT_grdlandmask (void *V_API, int mode, void *args) {
 	struct GMT_GRID_HEADER *C = NULL;
 	struct GMT_GRID_HEADER_HIDDEN *HH = NULL;
 	struct GMT_GSHHS_POL *p = NULL;
-	struct BINCROSS *X = NULL;
+	struct GRDLANDMASK_BINCROSS *X = NULL;
 	struct GRDLANDMASK_CTRL *Ctrl = NULL;
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;
 	struct GMT_OPTION *options = NULL;
@@ -380,7 +380,7 @@ EXTERN_MSC int GMT_grdlandmask (void *V_API, int mode, void *args) {
 	x = gmt_M_memory (GMT, NULL, Grid->header->n_columns, double);
 	y = gmt_M_memory (GMT, NULL, Grid->header->n_rows, double);
 	if (Ctrl->E.linetrace)
-		X = gmt_M_memory (GMT, X, nx_alloc, struct BINCROSS);
+		X = gmt_M_memory (GMT, X, nx_alloc, struct GRDLANDMASK_BINCROSS);
 
 	nx1 = Grid->header->n_columns - 1;	ny1 = Grid->header->n_rows - 1;
 
@@ -539,7 +539,7 @@ EXTERN_MSC int GMT_grdlandmask (void *V_API, int mode, void *args) {
 								nx++;
 								if (nx == nx_alloc) {
 									nx_alloc <<= 1;
-									X = gmt_M_memory (GMT, X, nx_alloc, struct BINCROSS);
+									X = gmt_M_memory (GMT, X, nx_alloc, struct GRDLANDMASK_BINCROSS);
 								}
 							}
 							for (bcol = start_col; bcol <= end_col; bcol++) {	/* If we go in here we think dx is non-zero (we do a last-ditch dx check just in case) */
@@ -553,12 +553,12 @@ EXTERN_MSC int GMT_grdlandmask (void *V_API, int mode, void *args) {
 								nx++;
 								if (nx == nx_alloc) {
 									nx_alloc <<= 1;
-									X = gmt_M_memory (GMT, X, nx_alloc, struct BINCROSS);
+									X = gmt_M_memory (GMT, X, nx_alloc, struct GRDLANDMASK_BINCROSS);
 								}
 							}
 
 							if (nx) {	/* Here we have intersections */
-								qsort (X, nx, sizeof (struct BINCROSS), grdlandmask_comp_bincross);	/* Sort on distances along the line segment */
+								qsort (X, nx, sizeof (struct GRDLANDMASK_BINCROSS), grdlandmask_comp_bincross);	/* Sort on distances along the line segment */
 								grdlandmask_assign_node (GMT, Grid, C, X[0].x, X[0].y, f_level, &ij);	/* Possibly assign f_level to nearest node */
 								for (curr_x_pt = 1, prev_x_pt = 0; curr_x_pt < nx; curr_x_pt++, prev_x_pt++) {	/* Process the intervals, getting mid-points and using that to get bin */
 									grdlandmask_assign_node (GMT, Grid, C, X[curr_x_pt].x, X[curr_x_pt].y, f_level, &ij);	/* Possibly assign f_level to nearest node */

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -102,22 +102,22 @@
 
 struct GRDMATH_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct Out {	/* = <filename> */
+	struct GRDMATH_Out {	/* = <filename> */
 		bool active;
 	} Out;
-	struct A {	/* -A<min_area>[/<min_level>/<max_level>][+ag|i|s][+r|l][+p<percent>] */
+	struct GRDMATH_A {	/* -A<min_area>[/<min_level>/<max_level>][+ag|i|s][+r|l][+p<percent>] */
 		bool active;
 		struct GMT_SHORE_SELECT info;
 	} A;
-	struct D {	/* -D<resolution>[+f] */
+	struct GRDMATH_D {	/* -D<resolution>[+f] */
 		bool active;
 		bool force;	/* if true, select next highest level if current set is not available */
 		char set;	/* One of f, h, i, l, c, or auto */
 	} D;
-	struct M {	/* -M */
+	struct GRDMATH_M {	/* -M */
 		bool active;
 	} M;
-	struct N {	/* -N */
+	struct GRDMATH_N {	/* -N */
 		bool active;
 	} N;
 };

--- a/src/grdpaste.c
+++ b/src/grdpaste.c
@@ -34,11 +34,11 @@
 #define THIS_MODULE_OPTIONS "-Vf"
 
 struct GRDPASTE_CTRL {
-	struct In {
+	struct GRDPASTE_In {
 		bool active;
 		char *file[2];
 	} In;
-	struct G {	/* -G<output_grdfile> */
+	struct GRDPASTE_G {	/* -G<output_grdfile> */
 		bool active;
 		char *file;
 	} G;

--- a/src/grdproject.c
+++ b/src/grdproject.c
@@ -36,30 +36,30 @@
 #define THIS_MODULE_OPTIONS "-JRVnr" GMT_OPT("S")
 
 struct GRDPROJECT_CTRL {
-	struct GRDPRJ_In {	/* Input grid */
+	struct GRDPROJECT_In {	/* Input grid */
 		bool active;
 		char *file;
 	} In;
-	struct GRDPRJ_C {	/* -C[<dx/dy>] */
+	struct GRDPROJECT_C {	/* -C[<dx/dy>] */
 		bool active;
 		double easting, northing;
 	} C;
-	struct GRDPRJ_E {	/* -E<dpi> */
+	struct GRDPROJECT_E {	/* -E<dpi> */
 		bool active;
 		int dpi;
 	} E;
-	struct GRDPRJ_F {	/* -F[k|m|n|i|c|p] */
+	struct GRDPROJECT_F {	/* -F[k|m|n|i|c|p] */
 		bool active;
 		char unit;
 	} F;
-	struct GRDPRJ_G {	/* -G */
+	struct GRDPROJECT_G {	/* -G */
 		bool active;
 		char *file;
 	} G;
-	struct GRDPRJ_I {	/* -I */
+	struct GRDPROJECT_I {	/* -I */
 		bool active;
 	} I;
-	struct GRDPRJ_M {	/* -Mc|i|m */
+	struct GRDPROJECT_M {	/* -Mc|i|m */
 		bool active;
 		char unit;
 	} M;

--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -39,15 +39,15 @@
 #define THIS_MODULE_OPTIONS "-RVfnr" GMT_ADD_x_OPT GMT_OPT("FQ")
 
 struct GRDSAMPLE_CTRL {
-	struct In {
+	struct GRDSAMPLE_In {
 		bool active;
 		char *file;
 	} In;
-	struct G {	/* -G<grdfile> */
+	struct GRDSAMPLE_G {	/* -G<grdfile> */
 		bool active;
 		char *file;
 	} G;
-	struct T {	/* -T */
+	struct GRDSAMPLE_T {	/* -T */
 		bool active;
 	} T;
 };

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -35,49 +35,49 @@
 #define THIS_MODULE_OPTIONS "->BJKOPRUVXYfptxy" GMT_OPT("c")
 
 struct GRDVECTOR_CTRL {
-	struct In {
+	struct GRDVECTOR_In {
 		bool active;
 		char *file[2];
 	} In;
-	struct A {	/* -A */
+	struct GRDVECTOR_A {	/* -A */
 		bool active;
 	} A;
-	struct C {	/* -C<cpt>[+i<dz>] */
+	struct GRDVECTOR_C {	/* -C<cpt>[+i<dz>] */
 		bool active;
 		double dz;
 		char *file;
 	} C;
-	struct G {	/* -G<fill> */
+	struct GRDVECTOR_G {	/* -G<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} G;
-	struct I {	/* -I[x]<dx>[/<dy>] */
+	struct GRDVECTOR_I {	/* -I[x]<dx>[/<dy>] */
 		bool active;
 		unsigned int mode;
 	} I;
-	struct N {	/* -N */
+	struct GRDVECTOR_N {	/* -N */
 		bool active;
 	} N;
-	struct Q {	/* -Q<size>[+<mods>] */
+	struct GRDVECTOR_Q {	/* -Q<size>[+<mods>] */
 		bool active;
 		struct GMT_SYMBOL S;
 	} Q;
-	struct S {	/* -S[l|i]<length|scale>[<unit>] */
+	struct GRDVECTOR_S {	/* -S[l|i]<length|scale>[<unit>] */
 		bool active;
 		bool constant;
 		bool invert;
 		char unit;
 		double factor;
 	} S;
-	struct T {	/* -T */
+	struct GRDVECTOR_T {	/* -T */
 		bool active;
 	} T;
-	struct W {	/* -W<pen> */
+	struct GRDVECTOR_W {	/* -W<pen> */
 		bool active;
 		bool cpt_effect;
 		struct GMT_PEN pen;
 	} W;
-	struct Z {	/* -Z */
+	struct GRDVECTOR_Z {	/* -Z */
 		bool active;
 	} Z;
 };

--- a/src/grdvolume.c
+++ b/src/grdvolume.c
@@ -36,31 +36,31 @@
 #define THIS_MODULE_OPTIONS "-RVfho"
 
 struct GRDVOLUME_CTRL {
-	struct In {
+	struct GRDVOLUME_In {
 		bool active;
 		char *file;
 	} In;
-	struct C {	/* -C */
+	struct GRDVOLUME_C {	/* -C */
 		bool active;
 		bool reverse, reverse_min;
 		double low, high, inc;
 	} C;
-	struct D {	/* -D */
+	struct GRDVOLUME_D {	/* -D */
 		bool active;
 	} D;
-	struct L {	/* -L<base> */
+	struct GRDVOLUME_L {	/* -L<base> */
 		bool active;
 		double value;
 	} L;
-	struct S {	/* -S */
+	struct GRDVOLUME_S {	/* -S */
 		bool active;
 		char unit;
 	} S;
-	struct T {	/* -T[c|z] */
+	struct GRDVOLUME_T {	/* -T[c|z] */
 		bool active;
 		unsigned int mode;
 	} T;
-	struct Z {	/* Z<fact>[/<shift>] */
+	struct GRDVOLUME_Z {	/* Z<fact>[/<shift>] */
 		bool active;
 		double scale, offset;
 	} Z;

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -60,48 +60,48 @@ EXTERN_MSC int gmtlib_cspline (struct GMT_CTRL *GMT, double *x, double *y, uint6
 /* Control structure for greenspline */
 
 struct GREENSPLINE_CTRL {
-	struct A {	/* -A<gradientfile> */
+	struct GREENSPLINE_A {	/* -A<gradientfile> */
 		bool active;
 		unsigned int mode;	/* 0 = azimuths, 1 = directions, 2 = dx,dy components, 3 = dx, dy, dz components */
 		char *file;
 	} A	;
-	struct C {	/* -C[n]<cutoff>[+f<file>] */
+	struct GREENSPLINE_C {	/* -C[n]<cutoff>[+f<file>] */
 		bool active;
 		unsigned int movie;	/* Undocumented and not-yet-working movie mode +m incremental grids, +M total grids vs eigenvalue */
 		unsigned int mode;
 		double value;
 		char *file;
 	} C;
-	struct D {	/* -D<distflag> */
+	struct GREENSPLINE_D {	/* -D<distflag> */
 		bool active;
 		int mode;	/* Can be negative */
 	} D;
-	struct E {	/* -E[<file>] */
+	struct GREENSPLINE_E {	/* -E[<file>] */
 		bool active;
 		unsigned int mode;
 		char *file;
 	} E;
-	struct G {	/* -G<output_grdfile> */
+	struct GREENSPLINE_G {	/* -G<output_grdfile> */
 		bool active;
 		char *file;
 	} G;
-	struct I {	/* -Idx[/dy[/dz]] */
+	struct GREENSPLINE_I {	/* -Idx[/dy[/dz]] */
 		bool active;
 		double inc[3];
 	} I;
-	struct L {	/* -L */
+	struct GREENSPLINE_L {	/* -L */
 		bool active;
 	} L;
-	struct M {	/* -M<gfuncfile> */
+	struct GREENSPLINE_M {	/* -M<gfuncfile> */
 		bool active;
 		unsigned int mode;	/* GMT_IN or GMT_OUT */
 		char *file;
 	} M;
-	struct N {	/* -N<outputnode_file> */
+	struct GREENSPLINE_N {	/* -N<outputnode_file> */
 		bool active;
 		char *file;
 	} N;
-	struct Q {	/* -Qdaz */
+	struct GREENSPLINE_Q {	/* -Qdaz */
 		bool active;
 		double az;
 		double dir[3];
@@ -114,22 +114,22 @@ struct GREENSPLINE_CTRL {
 		double range[6];	/* Min/max for each dimension */
 		double inc[2];		/* xinc/yinc when -Rgridfile was given*/
 	} R3;
-	struct S {	/* -S<mode>[<tension][+<mod>[args]] */
+	struct GREENSPLINE_S {	/* -S<mode>[<tension][+<mod>[args]] */
 		bool active;
 		unsigned int mode;
 		double value[4];
 		double rval[2];
 		char *arg;
 	} S;
-	struct T {	/* -T<mask_grdfile> */
+	struct GREENSPLINE_T {	/* -T<mask_grdfile> */
 		bool active;
 		char *file;
 	} T;
-	struct W {	/* -W[w] */
+	struct GREENSPLINE_W {	/* -W[w] */
 		bool active;
 		unsigned int mode;	/* 0 = got sigmas, 1 = got weights */
 	} W;
-	struct Z {	/* -Z undocumented debugging option */
+	struct GREENSPLINE_Z {	/* -Z undocumented debugging option */
 		bool active;
 	} Z;
 };
@@ -192,7 +192,7 @@ struct GREENSPLINE_LOOKUP {	/* Used to spline interpolation of precalculated fun
 	double *A, *B, *C;	/* power/ratios of order l terms */
 };
 
-struct ZGRID {
+struct GREENSPLINE_ZGRID {
 	unsigned int nz;
 	double z_min, z_max, z_inc;
 };
@@ -1457,7 +1457,7 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 	double (*dGdr) (struct GMT_CTRL *, double, double *, struct GREENSPLINE_LOOKUP *) = NULL;	/* Pointer to chosen gradient of Green's function */
 
 	struct GMT_GRID *Grid = NULL, *Out = NULL;
-	struct ZGRID Z;
+	struct GREENSPLINE_ZGRID Z;
 	struct GREENSPLINE_LOOKUP *Lz = NULL, *Lg = NULL;
 	struct GMT_DATATABLE *T = NULL;
 	struct GMT_DATASET *Nin = NULL;
@@ -1490,7 +1490,7 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 	gmt_M_memset (par,   N_PARAMS, double);
 	gmt_M_memset (norm,  GSP_LENGTH, double);
 	gmt_M_memset (&info, 1, struct GMT_GRID_INFO);
-	gmt_M_memset (&Z,    1, struct ZGRID);
+	gmt_M_memset (&Z,    1, struct GREENSPLINE_ZGRID);
 
 	if (Ctrl->S.mode == SANDWELL_1987_1D || Ctrl->S.mode == WESSEL_BERCOVICI_1998_1D) Ctrl->S.mode += (dimension - 1);
 	if (Ctrl->S.mode == LINEAR_1D) Ctrl->S.mode += (dimension - 1);

--- a/src/gshhg/gshhg.c
+++ b/src/gshhg/gshhg.c
@@ -33,34 +33,34 @@
 #define THIS_MODULE_OPTIONS "-:Vbdo"
 
 struct GSHHG_CTRL {
-	struct In {	/* <file> */
+	struct GSHHG_In {	/* <file> */
 		bool active;
 		char *file;
 	} In;
-	struct Out {	/* > <file> */
+	struct GSHHG_Out {	/* > <file> */
 		bool active;
 		char *file;
 	} Out;
-	struct A {	/* -A */
+	struct GSHHG_A {	/* -A */
 		bool active;
 		double min;	/* Cutoff area in km^2 */
 	} A;
-	struct L {	/* -L */
+	struct GSHHG_L {	/* -L */
 		bool active;
 	} L;
-	struct G {	/* -G */
+	struct GSHHG_G {	/* -G */
 		bool active;
 	} G;
-	struct I {	/* -I[<id>|c] */
+	struct GSHHG_I {	/* -I[<id>|c] */
 		bool active;
 		unsigned int mode;
 		unsigned int id;
 	} I;
-	struct N {	/* -N<level> */
+	struct GSHHG_N {	/* -N<level> */
 		bool active;
 		unsigned int level;
 	} N;
-	struct Q {	/* -Qe|i */
+	struct GSHHG_Q {	/* -Qe|i */
 		bool active;
 		unsigned int mode;
 	} Q;

--- a/src/img/img2grd.c
+++ b/src/img/img2grd.c
@@ -106,45 +106,45 @@ struct GMT_IMG_COORD {
 };
 
 struct IMG2GRD_CTRL {
-	struct In {	/* Input file name */
+	struct IMG2GRD_In {	/* Input file name */
 		bool active;
 		char *file;	/* Input file name */
 	} In;
-	struct D {	/* -D[<minlat>/<maxlat>] */
+	struct IMG2GRD_D {	/* -D[<minlat>/<maxlat>] */
 		bool active;
 		double min, max;
 	} D;
-	struct E {	/* -E */
+	struct IMG2GRD_E {	/* -E */
 		bool active;
 	} E;
-	struct F {	/* -F */
+	struct IMG2GRD_F {	/* -F */
 		bool active;
 	} F;
-	struct G {	/* -G<output_grdfile> */
+	struct IMG2GRD_G {	/* -G<output_grdfile> */
 		bool active;
 		char *file;
 	} G;
-	struct I {	/* -I<minutes> */
+	struct IMG2GRD_I {	/* -I<minutes> */
 		bool active;
 		double value;
 	} I;
-	struct M {	/* -M */
+	struct IMG2GRD_M {	/* -M */
 		bool active;
 	} M;
-	struct N {	/* -N<ave> */
+	struct IMG2GRD_N {	/* -N<ave> */
 		bool active;
 		int value;
 	} N;
-	struct S {	/* -S<scale> */
+	struct IMG2GRD_S {	/* -S<scale> */
 		bool active;
 		unsigned int mode;
 		double value;
 	} S;
-	struct T {	/* -T<type> */
+	struct IMG2GRD_T {	/* -T<type> */
 		bool active;
 		int value;
 	} T;
-	struct W {	/* -W<maxlon> */
+	struct IMG2GRD_W {	/* -W<maxlon> */
 		bool active;
 		double value;
 	} W;

--- a/src/inset.c
+++ b/src/inset.c
@@ -45,23 +45,23 @@
 #define INSET_END		0
 
 struct INSET_CTRL {
-	struct In {	/* begin | end */
+	struct INSET_In {	/* begin | end */
 		bool active;
 		unsigned int mode;	/* INSET_BEGIN|END*/
 	} In;
-	struct D {	/* -D[g|j|n|x]<refpoint>+w<width>[/<height>][+j<justify>[+o<dx>[/<dy>]][+t] or <xmin>/<xmax>/<ymin>/<ymax>[+r][+t][+u] */
+	struct INSET_D {	/* -D[g|j|n|x]<refpoint>+w<width>[/<height>][+j<justify>[+o<dx>[/<dy>]][+t] or <xmin>/<xmax>/<ymin>/<ymax>[+r][+t][+u] */
 		bool active;
 		struct GMT_MAP_INSET inset;
 	} D;
-	struct F {	/* -F[+c<clearance>][+g<fill>][+i[<off>/][<pen>]][+p[<pen>]][+r[<radius>]][+s[<dx>/<dy>/][<shade>]][+d] */
+	struct INSET_F {	/* -F[+c<clearance>][+g<fill>][+i[<off>/][<pen>]][+p[<pen>]][+r[<radius>]][+s[<dx>/<dy>/][<shade>]][+d] */
 		bool active;
 		/* The panel is a member of GMT_MAP_INSET */
 	} F;
-	struct M {	/* -M<margin> | <xmargin>/<ymargin>  | <wmargin>/<emargin>/<smargin>/<nmargin>  */
+	struct INSET_M {	/* -M<margin> | <xmargin>/<ymargin>  | <wmargin>/<emargin>/<smargin>/<nmargin>  */
 		bool active;
 		double margin[4];
 	} M;
-	struct N {	/* -N  (no clip) */
+	struct INSET_N {	/* -N  (no clip) */
 		bool active;
 	} N;
 };

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -50,70 +50,70 @@ enum makecpt_enum_mode {DO_RANGE = 0,		/* Use actual data range in -T */
 /* Control structure for makecpt */
 
 struct MAKECPT_CTRL {
-	struct Out {	/* -> */
+	struct MAKECPT_Out {	/* -> */
 		bool active;
 		char *file;
 	} Out;
-	struct A {	/* -A<transp>[+a] */
+	struct MAKECPT_A {	/* -A<transp>[+a] */
 		bool active;
 		unsigned int mode;
 		double value;
 	} A;
-	struct C {	/* -C<cpt> or -C<color1>,<color2>[,<color3>,...] */
+	struct MAKECPT_C {	/* -C<cpt> or -C<color1>,<color2>[,<color3>,...] */
 		bool active;
 		char *file;
 	} C;
-	struct D {	/* -D[i|o] */
+	struct MAKECPT_D {	/* -D[i|o] */
 		bool active;
 		unsigned int mode;
 	} D;
-	struct E {	/* -E<nlevels> */
+	struct MAKECPT_E {	/* -E<nlevels> */
 		bool active;
 		unsigned int levels;
 	} E;
-	struct F {	/* -F[r|R|h|c][+c] */
+	struct MAKECPT_F {	/* -F[r|R|h|c][+c] */
 		bool active;
 		bool cat;
 		unsigned int model;
 	} F;
-	struct G {	/* -Glow/high for input CPT truncation */
+	struct MAKECPT_G {	/* -Glow/high for input CPT truncation */
 		bool active;
 		double z_low, z_high;
 	} G;
-	struct H {	/* -H */
+	struct MAKECPT_H {	/* -H */
 		bool active;
 	} H;
-	struct I {	/* -I[z][c] */
+	struct MAKECPT_I {	/* -I[z][c] */
 		bool active;
 		unsigned int mode;
 	} I;
-	struct M {	/* -M */
+	struct MAKECPT_M {	/* -M */
 		bool active;
 	} M;
-	struct N {	/* -N */
+	struct MAKECPT_N {	/* -N */
 		bool active;
 	} N;
-	struct S {	/* -S */
+	struct MAKECPT_S {	/* -S */
 		bool active;
 		bool discrete;
 		unsigned int mode;
 		double scale;
 		double q[2];
 	} S;
-	struct T {	/* -T<min/max[/inc>[+n]]|<file>|<z0,z1,...,zn> */
+	struct MAKECPT_T {	/* -T<min/max[/inc>[+n]]|<file>|<z0,z1,...,zn> */
 		bool active;
 		bool interpolate;
 		struct GMT_ARRAY T;
 	} T;
-	struct Q {	/* -Q[i|o] */
+	struct MAKECPT_Q {	/* -Q[i|o] */
 		bool active;
 		unsigned int mode;
 	} Q;
-	struct W {	/* -W[w] */
+	struct MAKECPT_W {	/* -W[w] */
 		bool active;
 		bool wrap;
 	} W;
-	struct Z {	/* -Z */
+	struct MAKECPT_Z {	/* -Z */
 		bool active;
 	} Z;
 };

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -88,7 +88,7 @@ enum GMT_mp_cols {	/* Index into the extra and ecol_type arrays */
 struct MAPPROJECT_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
 	bool used[8];	/* Used to keep track of which items are used by -A,G,L,Z */
-	struct MAPPRJ_A {	/* -Ab|B|f|Fb|B|o|O<lon0>/<lat0> */
+	struct MAPPROJECT_A {	/* -Ab|B|f|Fb|B|o|O<lon0>/<lat0> */
 		bool active;
 		bool azims;
 		bool orient;	/* true if we want orientations, not azimuths */
@@ -97,63 +97,63 @@ struct MAPPROJECT_CTRL {	/* All control options for this program (except common 
 		unsigned int mode;
 		double lon, lat;	/* Fixed point of reference */
 	} A;
-	struct MAPPRJ_C {	/* -C[<false_easting>/<false_northing>] */
+	struct MAPPROJECT_C {	/* -C[<false_easting>/<false_northing>] */
 		bool active;
 		bool shift;
 		double easting, northing;	/* Shifts */
 	} C;
-	struct MAPPRJ_D {	/* -D<c|i|p> */
+	struct MAPPROJECT_D {	/* -D<c|i|p> */
 		bool active;
 		char unit;
 	} D;
-	struct MAPPRJ_E {	/* -E[<datum>] */
+	struct MAPPROJECT_E {	/* -E[<datum>] */
 		bool active;
 		struct GMT_DATUM datum;	/* Contains a, f, xyz[3] */
 	} E;
-	struct MAPPRJ_F {	/* -F[k|m|n|i|c|p] */
+	struct MAPPROJECT_F {	/* -F[k|m|n|i|c|p] */
 		bool active;
 		char unit;
 	} F;
-	struct MAPPRJ_G {	/* -G<lon0>/<lat0>[+a][+i][+u[+|-]d|e|f|k|m|M|n|s|c|C][+v] */
+	struct MAPPROJECT_G {	/* -G<lon0>/<lat0>[+a][+i][+u[+|-]d|e|f|k|m|M|n|s|c|C][+v] */
 		bool active;
 		unsigned int mode;	/* 1 = distance to fixed point, 2 = cumulative distances, 3 = incremental distances, 4 = 2nd point in cols 3/4 */
 		unsigned int sph;	/* 0 = Flat Earth, 1 = spherical [Default], 2 = ellipsoidal */
 		double lon, lat;	/* Fixed point of reference */
 		char unit;
 	} G;
-	struct MAPPRJ_I {	/* -I */
+	struct MAPPROJECT_I {	/* -I */
 		bool active;
 	} I;
-	struct MAPPRJ_L {	/* -L<line.xy>[/<d|e|f|k|m|M|n|s|c|C>] */
+	struct MAPPROJECT_L {	/* -L<line.xy>[/<d|e|f|k|m|M|n|s|c|C>] */
 		bool active;
 		unsigned int mode;	/* 0 = dist to nearest point, 1 = also get the point, 2 = instead get seg#, pt# */
 		unsigned int sph;	/* 0 = Flat Earth, 1 = spherical [Default], 2 = ellipsoidal */
 		char *file;	/* Name of file with lines */
 		char unit;
 	} L;
-	struct MAPPRJ_N {	/* -N */
+	struct MAPPROJECT_N {	/* -N */
 		bool active;
 		unsigned int mode;
 	} N;
-	struct MAPPRJ_Q {	/* -Q[e|d] */
+	struct MAPPROJECT_Q {	/* -Q[e|d] */
 		bool active;
 		unsigned int mode;	/* 1 = print =Qe, 2 print -Qd, 3 print both */
 	} Q;
-	struct MAPPRJ_S {	/* -S */
+	struct MAPPROJECT_S {	/* -S */
 		bool active;
 	} S;
-	struct MAPPRJ_T {	/* -T[h]<from>[/<to>] */
+	struct MAPPROJECT_T {	/* -T[h]<from>[/<to>] */
 		bool active;
 		bool heights;	/* True if we have heights */
 		struct GMT_DATUM from;	/* Contains a, f, xyz[3] */
 		struct GMT_DATUM to;	/* Contains a, f, xyz[3] */
 	} T;
-	struct MAPPRJ_W {	/* -W[w|h|j<code>|n<rx/ry>|g<lon/lat>|x<x/y>] */
+	struct MAPPROJECT_W {	/* -W[w|h|j<code>|n<rx/ry>|g<lon/lat>|x<x/y>] */
 		bool active;
 		unsigned int mode;	/* See GMT_mp_Wcodes above */
 		struct GMT_REFPOINT *refpoint;
 	} W;
-	struct MAPPRJ_Z {	/* -Z[<speed>][+c][+f][+i][+t<epoch>] */
+	struct MAPPROJECT_Z {	/* -Z[<speed>][+c][+f][+i][+t<epoch>] */
 		bool active;
 		bool formatted;		/* Format duration per ISO 8601 specification */
 		unsigned int mode;	/* 1 = incremental time, 2 absolute time since epoch, 3 = both */

--- a/src/mgd77/mgd77convert.c
+++ b/src/mgd77/mgd77convert.c
@@ -35,23 +35,23 @@ EXTERN_MSC void MGD77_select_high_resolution (struct GMT_CTRL *GMT);
 
 struct MGD77CONVERT_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct C {	/* -C */
+	struct MGD77CONVERT_C {	/* -C */
 		bool active;
 	} C;
-	struct D {	/* -D */
+	struct MGD77CONVERT_D {	/* -D */
 		bool active;
 	} D;
-	struct L {	/* -L */
+	struct MGD77CONVERT_L {	/* -L */
 		bool active;
 		unsigned int mode;
 		unsigned int dest;
 	} L;
-	struct F {	/* -F */
+	struct MGD77CONVERT_F {	/* -F */
 		bool active;
 		unsigned int mode;
 		int format;
 	} F;
-	struct T {	/* -T */
+	struct MGD77CONVERT_T {	/* -T */
 		bool active;
 		unsigned int mode;
 		int format;

--- a/src/mgd77/mgd77header.c
+++ b/src/mgd77/mgd77header.c
@@ -40,11 +40,11 @@ EXTERN_MSC int MGD77_Read_File_nohdr (struct GMT_CTRL *GMT, char *file, struct M
 
 struct MGD77HEADER_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct H {	/* -H<file> */
+	struct MGD77HEADER_H {	/* -H<file> */
 		bool active;
 		char *file;
 	} H;
-	struct M {	/* -Mf[<item>|r|t] */
+	struct MGD77HEADER_M {	/* -Mf[<item>|r|t] */
 		bool active;
 		unsigned int mode;
 		unsigned int flag;

--- a/src/mgd77/mgd77info.c
+++ b/src/mgd77/mgd77info.c
@@ -39,24 +39,24 @@
 
 struct MGD77INFO_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct C {	/* -C */
+	struct MGD77INFO_C {	/* -C */
 		bool active;
 		unsigned int mode;
 	} C;
-	struct E {	/* -E */
+	struct MGD77INFO_E {	/* -E */
 		bool active;
 		unsigned int mode;
 	} E;
-	struct I {	/* -I */
+	struct MGD77INFO_I {	/* -I */
 		bool active;
 		unsigned int n;
 		char code[3];
 	} I;
-	struct L {	/* -L */
+	struct MGD77INFO_L {	/* -L */
 		bool active;
 		unsigned int mode;
 	} L;
-	struct M {	/* -M */
+	struct MGD77INFO_M {	/* -M */
 		bool active;
 		unsigned int mode;
 		unsigned int flag;

--- a/src/mgd77/mgd77list.c
+++ b/src/mgd77/mgd77list.c
@@ -140,7 +140,7 @@ struct MGD77LIST_CTRL {	/* All control options for this program (except common a
 		double start;	/* Start dist */
 		double stop;	/* Stop dist */
 	} S;
-	struct T {	/* -T */
+	struct MGD77LIST_T {	/* -T */
 		bool active;
 		int mode;	/* May be -1 */
 	} T;

--- a/src/mgd77/mgd77manage.c
+++ b/src/mgd77/mgd77manage.c
@@ -61,7 +61,7 @@
 
 struct MGD77MANAGE_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct A {	/* -A */
+	struct MGD77MANAGE_A {	/* -A */
 		bool active;
 		bool replace;
 		bool interpolate;

--- a/src/mgd77/mgd77path.c
+++ b/src/mgd77/mgd77path.c
@@ -27,14 +27,14 @@
 
 struct MGD77PATH_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct A {	/* -A */
+	struct MGD77PATH_A {	/* -A */
 		bool active;
 		bool mode;
 	} A;
-	struct D {	/* -D */
+	struct MGD77PATH_D {	/* -D */
 		bool active;
 	} D;
-	struct I {	/* -I */
+	struct MGD77PATH_I {	/* -I */
 		bool active;
 		unsigned int n;
 		char code[3];

--- a/src/mgd77/mgd77track.c
+++ b/src/mgd77/mgd77track.c
@@ -65,47 +65,47 @@ struct MGD77TRACK_MARKER {
 
 struct MGD77TRACK_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct A {	/* -A */
+	struct MGD77TRACK_A {	/* -A */
 		bool active;
 		int mode;	/* May be negative */
 		double size;
 		struct MGD77TRACK_ANNOT info;
 	} A;
-	struct D {	/* -D */
+	struct MGD77TRACK_D {	/* -D */
 		bool active;
 		double start;	/* Start time */
 		double stop;	/* Stop time */
 	} D;
-	struct F {	/* -F */
+	struct MGD77TRACK_F {	/* -F */
 		bool active;
 		int mode;
 	} F;
-	struct G {	/* -G */
+	struct MGD77TRACK_G {	/* -G */
 		bool active[3];
 		unsigned int value[3];
 	} G;
-	struct I {	/* -I */
+	struct MGD77TRACK_I {	/* -I */
 		bool active;
 		unsigned int n;
 		char code[3];
 	} I;
-	struct L {	/* -L */
+	struct MGD77TRACK_L {	/* -L */
 		bool active;
 		struct MGD77TRACK_ANNOT info;
 	} L;
-	struct N {	/* -N */
+	struct MGD77TRACK_N {	/* -N */
 		bool active;
 	} N;
-	struct S {	/* -S */
+	struct MGD77TRACK_S {	/* -S */
 		bool active;
 		double start;	/* Start dist */
 		double stop;	/* Stop dist */
 	} S;
-	struct T {	/* -T */
+	struct MGD77TRACK_T {	/* -T */
 		bool active;
 		struct MGD77TRACK_MARKER marker[3];
 	} T;
-	struct W {	/* -W<pen> */
+	struct MGD77TRACK_W {	/* -W<pen> */
 		bool active;
 		struct GMT_PEN pen;
 	} W;

--- a/src/nearneighbor.c
+++ b/src/nearneighbor.c
@@ -44,26 +44,26 @@
 
 struct NEARNEIGHBOR_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct E {	/* -E<empty> */
+	struct NEARNEIGHBOR_E {	/* -E<empty> */
 		bool active;
 		double value;
 	} E;
-	struct G {	/* -G<grdfile> */
+	struct NEARNEIGHBOR_G {	/* -G<grdfile> */
 		bool active;
 		char *file;
 	} G;
-	struct N {	/* -N<sectors>[+m<min_sectors>] | -Nn */
+	struct NEARNEIGHBOR_N {	/* -N<sectors>[+m<min_sectors>] | -Nn */
 		bool active;
 		unsigned int sectors, min_sectors;
 		unsigned int mode;
 	} N;
-	struct S {	/* -S[-|=|+]<radius>[d|e|f|k|m|M|n] */
+	struct NEARNEIGHBOR_S {	/* -S[-|=|+]<radius>[d|e|f|k|m|M|n] */
 		bool active;
 		int mode;	/* May be negative */
 		double radius;
 		char unit;
 	} S;
-	struct W {	/* -W */
+	struct NEARNEIGHBOR_W {	/* -W */
 		bool active;
 	} W;
 };

--- a/src/potential/gmtflexure.c
+++ b/src/potential/gmtflexure.c
@@ -58,57 +58,57 @@
  */
 
 struct GMTFLEXURE_CTRL {
-	struct Out {	/* -> */
+	struct GMTFLEXURE_Out {	/* -> */
 		bool active;
 		char *file;
 	} Out;
-	struct A {	/* -A[l|r]<bc>[<args>] */
+	struct GMTFLEXURE_A {	/* -A[l|r]<bc>[<args>] */
 		bool active;
 		unsigned int bc[2];	/* Left and Right BC code */
 		double deflection[2], moment[2], force[2];	/* Left and Right arguments */
 	} A;
-	struct C {	/* -Cy<E> or -Cp<poisson> */
+	struct GMTFLEXURE_C {	/* -Cy<E> or -Cp<poisson> */
 		bool active[2];
 		double E, nu;
 	} C;
-	struct D {	/* -D<rhom/rhol[/rhoi]/rhow> */
+	struct GMTFLEXURE_D {	/* -D<rhom/rhol[/rhoi]/rhow> */
 		bool active;
 		double rhom, rhol, rhoi, rhow;
 	} D;
-	struct E {	/* -E<te|D|>file> */
+	struct GMTFLEXURE_E {	/* -E<te|D|>file> */
 		bool active;
 		double te;
 		char *file;
 	} E;
-	struct F {	/* -F<force> */
+	struct GMTFLEXURE_F {	/* -F<force> */
 		bool active;
 		double force;
 	} F;
-	struct L {	/* Use variable restoring force [constant] */
+	struct GMTFLEXURE_L {	/* Use variable restoring force [constant] */
 		bool active;
 	} L;
-	struct M {	/* -Mx|z  */
+	struct GMTFLEXURE_M {	/* -Mx|z  */
 		bool active[2];	/* True if km, else m */
 	} M;
-	struct Q {	/* Load specifier -Qn|q|t[/args] */
+	struct GMTFLEXURE_Q {	/* Load specifier -Qn|q|t[/args] */
 		bool active;
 		bool set_x;
 		unsigned int mode;
 		struct GMT_ARRAY T;
 		char *file;
 	} Q;
-	struct S {	/* Compute second derivatives (curvatures) */
+	struct GMTFLEXURE_S {	/* Compute second derivatives (curvatures) */
 		bool active;
 	} S;
-	struct T {	/* Pre-existing deformation */
+	struct GMTFLEXURE_T {	/* Pre-existing deformation */
 		bool active;
 		char *file;
 	} T;
-	struct W {	/* Water depth */
+	struct GMTFLEXURE_W {	/* Water depth */
 		bool active;
 		double water_depth;	/* Reference water depth [0] */
 	} W;
-	struct Z {	/* Moho depth */
+	struct GMTFLEXURE_Z {	/* Moho depth */
 		bool active;
 		double zm;	/* Reference depth to flexed surface [0] */
 	} Z;

--- a/src/potential/gmtgravmag3d.c
+++ b/src/potential/gmtgravmag3d.c
@@ -122,7 +122,7 @@ static struct MAG_VAR4 {
 } *okabe_mag_var4;
 
 static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
-	C = gmt_M_memory (GMT, NULL, 1, struct GMTGRAVMAG3D_CTRL);
+	struct GMTGRAVMAG3D_CTRL *C = gmt_M_memory (GMT, NULL, 1, struct GMTGRAVMAG3D_CTRL);
 
 	/* Initialize values whose defaults are not 0/false/NULL */
 	C->L.zobs = 0;

--- a/src/potential/gmtgravmag3d.c
+++ b/src/potential/gmtgravmag3d.c
@@ -36,47 +36,47 @@
 #define THIS_MODULE_NEEDS	"R"
 #define THIS_MODULE_OPTIONS "-:RVf"
 
-struct XYZOKB_CTRL {
-	struct XYZOKB_C {	/* -C */
+struct GMTGRAVMAG3D_CTRL {
+	struct GMTGRAVMAG3D_C {	/* -C */
 		bool active;
 		double rho;
 	} C;
-	struct XYZOKB_D {	/* -D */
+	struct GMTGRAVMAG3D_D {	/* -D */
 		bool active;
 		double dir;
 	} D;
-	struct XYZOKB_I {	/* -Idx[/dy] */
+	struct GMTGRAVMAG3D_I {	/* -Idx[/dy] */
 		bool active;
 		double inc[2];
 	} I;
-	struct XYZOKB_F {	/* -F<grdfile> */
+	struct GMTGRAVMAG3D_F {	/* -F<grdfile> */
 		bool active;
 		char *file;
 	} F;
-	struct XYZOKB_G {	/* -G<grdfile> */
+	struct GMTGRAVMAG3D_G {	/* -G<grdfile> */
 		bool active;
 		char *file;
 	} G;
-	struct XYZOKB_H {	/* -H */
+	struct GMTGRAVMAG3D_H {	/* -H */
 		bool active;
 		double	t_dec, t_dip, m_int, m_dec, m_dip;
 	} H;
-	struct XYZOKB_L {	/* -L */
+	struct GMTGRAVMAG3D_L {	/* -L */
 		bool active;
 		double zobs;
 	} L;
-	struct XYZOKB_E {	/* -T */
+	struct GMTGRAVMAG3D_E {	/* -T */
 		bool active;
 		double dz;
 	} E;
-	struct XYZOKB_S {	/* -S */
+	struct GMTGRAVMAG3D_S {	/* -S */
 		bool active;
 		double radius;
 	} S;
-	struct XYZOKB_Z {	/* -Z */
+	struct GMTGRAVMAG3D_Z {	/* -Z */
 		double z0;
 	} Z;
-	struct XYZOKB_T {	/* -T */
+	struct GMTGRAVMAG3D_T {	/* -T */
 		bool active;
 		bool triangulate;
 		bool raw;
@@ -87,13 +87,13 @@ struct XYZOKB_CTRL {
 		char *raw_file;
 		char *stl_file;
 	} T;
-	struct XYZOKB_box {	/* No option, just a container */
+	struct GMTGRAVMAG3D_box {	/* No option, just a container */
 		bool is_geog;
 		double	d_to_m, *mag_int, lon_0, lat_0;
 	} box;
 };
 
-static struct TRIANG {
+static struct GMTGRAVMAG3D_TRIANG {
 	double  x, y, z;
 } *triang;
 
@@ -105,7 +105,7 @@ static struct  TRI_CENTER {
 	double  x, y, z;
 } *t_center;
 
-static struct RAW {
+static struct GMTGRAVMAG3D_RAW {
 	double  t1[3], t2[3], t3[3];
 } *raw_mesh;
 
@@ -122,9 +122,9 @@ static struct MAG_VAR4 {
 } *okabe_mag_var4;
 
 GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
-	struct XYZOKB_CTRL *C;
+	struct GMTGRAVMAG3D_CTRL *C;
 
-	C = gmt_M_memory (GMT, NULL, 1, struct XYZOKB_CTRL);
+	C = gmt_M_memory (GMT, NULL, 1, struct GMTGRAVMAG3D_CTRL);
 
 	/* Initialize values whose defaults are not 0/false/NULL */
 	C->L.zobs = 0;
@@ -133,7 +133,7 @@ GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a n
 	return (C);
 }
 
-GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct XYZOKB_CTRL *C) {	/* Deallocate control structure */
+GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct GMTGRAVMAG3D_CTRL *C) {	/* Deallocate control structure */
 	if (!C) return;
 	gmt_M_str_free (C->F.file);
 	gmt_M_str_free (C->G.file);
@@ -148,10 +148,10 @@ GMT_LOCAL int gmtgravmag3d_read_t (struct GMT_CTRL *GMT, char *fname);
 GMT_LOCAL int gmtgravmag3d_read_raw (struct GMT_CTRL *GMT, char *fname, double z_dir);
 GMT_LOCAL int gmtgravmag3d_read_stl (struct GMT_CTRL *GMT, char *fname, double z_dir);
 GMT_LOCAL void gmtgravmag3d_set_center (unsigned int n_triang);
-GMT_LOCAL int gmtgravmag3d_facet_triangulate (struct XYZOKB_CTRL *Ctrl, struct BODY_VERTS *body_verts, unsigned int i, bool bat);
-GMT_LOCAL int gmtgravmag3d_facet_raw (struct XYZOKB_CTRL *Ctrl, struct BODY_VERTS *body_verts, unsigned int i, bool geo);
+GMT_LOCAL int gmtgravmag3d_facet_triangulate (struct GMTGRAVMAG3D_CTRL *Ctrl, struct BODY_VERTS *body_verts, unsigned int i, bool bat);
+GMT_LOCAL int gmtgravmag3d_facet_raw (struct GMTGRAVMAG3D_CTRL *Ctrl, struct BODY_VERTS *body_verts, unsigned int i, bool geo);
 GMT_LOCAL int gmtgravmag3d_check_triang_cw (unsigned int n, unsigned int type);
-GMT_LOCAL int gmtgravmag3d_read_xyz (struct GMT_CTRL *GMT, struct XYZOKB_CTRL *Ctrl, char *fname, double *lon_0, double *lat_0);
+GMT_LOCAL int gmtgravmag3d_read_xyz (struct GMT_CTRL *GMT, struct GMTGRAVMAG3D_CTRL *Ctrl, char *fname, double *lon_0, double *lat_0);
 
 GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
@@ -190,7 +190,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
-GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct XYZOKB_CTRL *Ctrl, struct GMT_OPTION *options) {
+GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMTGRAVMAG3D_CTRL *Ctrl, struct GMT_OPTION *options) {
 
 	/* This parses the options provided to gmtgravmag3d and sets parameters in Ctrl.
 	 * Note Ctrl has already been initialized and non-zero default values set.
@@ -398,7 +398,7 @@ EXTERN_MSC int GMT_gmtgravmag3d (void *V_API, int mode, void *args) {
 	struct	LOC_OR *loc_or = NULL;
 	struct	BODY_VERTS *body_verts = NULL;
 	struct	BODY_DESC body_desc;
-	struct	XYZOKB_CTRL *Ctrl = NULL;
+	struct	GMTGRAVMAG3D_CTRL *Ctrl = NULL;
 	struct	GMT_GRID *Gout = NULL;
 	struct  GMT_DATASET *Cin = NULL;
 	struct  GMT_DATATABLE *point = NULL;
@@ -776,7 +776,7 @@ END:
 }
 
 /* -------------------------------------------------------------------------*/
-GMT_LOCAL int gmtgravmag3d_read_xyz (struct GMT_CTRL *GMT, struct XYZOKB_CTRL *Ctrl, char *fname, double *lon_0, double *lat_0) {
+GMT_LOCAL int gmtgravmag3d_read_xyz (struct GMT_CTRL *GMT, struct GMTGRAVMAG3D_CTRL *Ctrl, char *fname, double *lon_0, double *lat_0) {
 	/* read xyz[m] file with point data coordinates */
 
 	unsigned int ndata_xyz;
@@ -791,7 +791,7 @@ GMT_LOCAL int gmtgravmag3d_read_xyz (struct GMT_CTRL *GMT, struct XYZOKB_CTRL *C
        	n_alloc = GMT_CHUNK;
 	ndata_xyz = 0;
 	*lon_0 = 0.;	*lat_0 = 0.;
-        triang = gmt_M_memory (GMT, NULL, n_alloc, struct TRIANG);
+        triang = gmt_M_memory (GMT, NULL, n_alloc, struct GMTGRAVMAG3D_TRIANG);
 	if (Ctrl->T.m_var1)
         	Ctrl->box.mag_int = gmt_M_memory (GMT, NULL, n_alloc, double);
 	else if (Ctrl->T.m_var2)
@@ -836,7 +836,7 @@ GMT_LOCAL int gmtgravmag3d_read_xyz (struct GMT_CTRL *GMT, struct XYZOKB_CTRL *C
 		}
 		if (ndata_xyz == n_alloc) {
 			n_alloc <<= 1;
-			triang = gmt_M_memory (GMT, triang, n_alloc, struct TRIANG);
+			triang = gmt_M_memory (GMT, triang, n_alloc, struct GMTGRAVMAG3D_TRIANG);
 			if (Ctrl->T.m_var1)
 				Ctrl->box.mag_int = gmt_M_memory (GMT, Ctrl->box.mag_int, n_alloc, double);
 			else if (Ctrl->T.m_var2)
@@ -921,7 +921,7 @@ GMT_LOCAL int gmtgravmag3d_read_raw (struct GMT_CTRL *GMT, char *fname, double z
 
 	n_alloc = GMT_CHUNK;
 	ndata_r = 0;
-	raw_mesh = gmt_M_memory (GMT, NULL, n_alloc, struct RAW);
+	raw_mesh = gmt_M_memory (GMT, NULL, n_alloc, struct GMTGRAVMAG3D_RAW);
 
 	while (fgets (line, GMT_LEN256, fp)) {
 		if(sscanf (line, "%lg %lg %lg %lg %lg %lg %lg %lg %lg",
@@ -929,7 +929,7 @@ GMT_LOCAL int gmtgravmag3d_read_raw (struct GMT_CTRL *GMT, char *fname, double z
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "ERROR deciphering line %d of %s\n", ndata_r+1, fname);
               	if (ndata_r == n_alloc) {
 			n_alloc <<= 1;
-			raw_mesh = gmt_M_memory (GMT, raw_mesh, n_alloc, struct RAW);
+			raw_mesh = gmt_M_memory (GMT, raw_mesh, n_alloc, struct GMTGRAVMAG3D_RAW);
 		}
 		raw_mesh[ndata_r].t1[0] = in[0];
 		raw_mesh[ndata_r].t1[1] = -in[1];
@@ -959,7 +959,7 @@ GMT_LOCAL int gmtgravmag3d_read_stl (struct GMT_CTRL *GMT, char *fname, double z
 
 	n_alloc = GMT_CHUNK;
 	ndata_s = 0;
-	raw_mesh = gmt_M_memory (GMT, NULL, n_alloc, struct RAW);
+	raw_mesh = gmt_M_memory (GMT, NULL, n_alloc, struct GMTGRAVMAG3D_RAW);
 
 	while (fgets (line, GMT_LEN256, fp)) {
 		sscanf (line, "%s", text);
@@ -988,7 +988,7 @@ GMT_LOCAL int gmtgravmag3d_read_stl (struct GMT_CTRL *GMT, char *fname, double z
 			ndata_s++;
               		if (ndata_s == n_alloc) { /* with bad luck we have a flaw here */
 				n_alloc <<= 1;
-				raw_mesh = gmt_M_memory (GMT, raw_mesh, n_alloc, struct RAW);
+				raw_mesh = gmt_M_memory (GMT, raw_mesh, n_alloc, struct GMTGRAVMAG3D_RAW);
 			}
 		}
 		else
@@ -999,7 +999,7 @@ GMT_LOCAL int gmtgravmag3d_read_stl (struct GMT_CTRL *GMT, char *fname, double z
 }
 
 /* -----------------------------------------------------------------*/
-GMT_LOCAL int gmtgravmag3d_facet_triangulate (struct XYZOKB_CTRL *Ctrl, struct BODY_VERTS *body_verts, unsigned int i, bool bat) {
+GMT_LOCAL int gmtgravmag3d_facet_triangulate (struct GMTGRAVMAG3D_CTRL *Ctrl, struct BODY_VERTS *body_verts, unsigned int i, bool bat) {
 	/* Sets coordinates for the facet whose effect is being calculated */
 	double x_a, x_b, x_c, y_a, y_b, y_c, z_a, z_b, z_c;
 	gmt_M_unused (bat);
@@ -1078,7 +1078,7 @@ GMT_LOCAL int gmtgravmag3d_facet_triangulate (struct XYZOKB_CTRL *Ctrl, struct B
 }
 
 /* -----------------------------------------------------------------*/
-GMT_LOCAL int gmtgravmag3d_facet_raw (struct XYZOKB_CTRL *Ctrl, struct BODY_VERTS *body_verts, unsigned int i, bool geo) {
+GMT_LOCAL int gmtgravmag3d_facet_raw (struct GMTGRAVMAG3D_CTRL *Ctrl, struct BODY_VERTS *body_verts, unsigned int i, bool geo) {
 	/* Sets coordinates for the facet in the RAW format */
 	double cos_a, cos_b, cos_c, x_a, x_b, x_c, y_a, y_b, y_c, z_a, z_b, z_c;
 

--- a/src/potential/gravfft.c
+++ b/src/potential/gravfft.c
@@ -55,66 +55,66 @@ struct GRAVFFT_CTRL {
 	unsigned int n_par;
 	double *par;
 
-	struct GRVF_In {
+	struct GRAVFFT_In {
 		bool active;
 		unsigned int n_grids;	/* 1 or 2 */
 		char *file[2];
 	} In;
-	struct GRVF_C {	/* -C<zlevel> */
+	struct GRAVFFT_C {	/* -C<zlevel> */
 		bool active;
 		unsigned int n_pt;
 		double theor_inc;
 	} C;
-	struct GRVF_D {	/* -D[<rho>|<rhofile>] */
+	struct GRAVFFT_D {	/* -D[<rho>|<rhofile>] */
 		bool active;
 		bool variable;
 		char *file;
 	} D;
-	struct GRVF_E {	/* -E */
+	struct GRAVFFT_E {	/* -E */
 		bool active;
 		unsigned int n_terms;
 	} E;
-	struct GRVF_F {	/* -F[f[+s]|b|g|e|n|v] */
+	struct GRAVFFT_F {	/* -F[f[+s]|b|g|e|n|v] */
 		bool active;
 		bool slab;
 		bool bouger;
 		unsigned int mode;
 	} F;
-	struct GRVF_G {	/* -G<outfile> */
+	struct GRAVFFT_G {	/* -G<outfile> */
 		bool active;
 		char *file;
 	} G;
-	struct GRVF_I {	/* -I[<scale>|g] */
+	struct GRAVFFT_I {	/* -I[<scale>|g] */
 		bool active;
 		double value;
 	} I;
-	struct GRVF_N {	/* -N[f|q|s<n_columns>/<n_rows>][+e|m|n][+t<width>][+w[<suffix>]][+z[p]]  */
+	struct GRAVFFT_N {	/* -N[f|q|s<n_columns>/<n_rows>][+e|m|n][+t<width>][+w[<suffix>]][+z[p]]  */
 		bool active;
 		struct GMT_FFT_INFO *info;
 	} N;
-	struct GRVF_Q {
+	struct GRAVFFT_Q {
 		bool active;
 	} Q;
-	struct GRVF_S {	/* -S<scale> */
+	struct GRAVFFT_S {	/* -S<scale> */
 		bool active;
 	} S;
-	struct GRVF_T {	/* -T<te/rl/rm/rw[/ri>][+m] */
+	struct GRAVFFT_T {	/* -T<te/rl/rm/rw[/ri>][+m] */
 		bool active, moho, approx;
 		double te, rhol, rhom, rhow, rhoi;
 		double rho_cw;		/* crust-water density contrast */
 		double rho_mc;		/* mantle-crust density contrast */
 		double rho_mw;		/* mantle-water density contrast */
 	} T;
-	struct GRVF_W {	/* Water depth/observation level */
+	struct GRAVFFT_W {	/* Water depth/observation level */
 		bool active;
 		double water_depth;	/* Reference water depth [0] */
 	} W;
-	struct GRVF_Z {
+	struct GRAVFFT_Z {
 		bool active;
 		double zm;		/* mean Moho depth (given by user) */
 		double zl;		/* mean depth of swell compensation (user given) */
 	} Z;
-	struct GRVF_misc {	/* -T */
+	struct GRAVFFT_misc {	/* -T */
 		bool coherence;
 		bool give_wavelength;
 		bool give_km;

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -49,70 +49,70 @@ struct GMT_MODELTIME {	/* Hold info about time */
 };
 
 struct GRDFLEXURE_CTRL {
-	struct In {	/* Input load file, template, or =flist */
+	struct GRDFLEXURE_In {	/* Input load file, template, or =flist */
 		bool active, many, list;
 		char *file;
 	} In;
-	struct A {	/* -A<Nx/Ny/Nxy> In-plane forces */
+	struct GRDFLEXURE_A {	/* -A<Nx/Ny/Nxy> In-plane forces */
 		bool active;
 		double Nx, Ny, Nxy;
 	} A;
-	struct C {	/* -Cy<E> or -Cp<poisson> */
+	struct GRDFLEXURE_C {	/* -Cy<E> or -Cp<poisson> */
 		bool active[2];
 		double E, nu;
 	} C;
-	struct D {	/* -D<rhom/rhol[/rhoi]/rhow> */
+	struct GRDFLEXURE_D {	/* -D<rhom/rhol[/rhoi]/rhow> */
 		bool active, approx;
 		unsigned int mode;
 		double rhom, rhol, rhoi, rhow;
 	} D;
-	struct E {	/* -E<te> */
+	struct GRDFLEXURE_E {	/* -E<te> */
 		bool active;
 		double te;
 	} E;
-	struct F {	/* -F<nu> or -F<nu_a>/<h_a>/<nu_m> */
+	struct GRDFLEXURE_F {	/* -F<nu> or -F<nu_a>/<h_a>/<nu_m> */
 		bool active;
 		unsigned int mode;
 		double nu_a, nu_m, h_a;
 	} F;
-	struct G {	/* -G<outfile> */
+	struct GRDFLEXURE_G {	/* -G<outfile> */
 		bool active;
 		char *file;
 	} G;
-	struct L {	/* -L<outlist> */
+	struct GRDFLEXURE_L {	/* -L<outlist> */
 		bool active;
 		char *file;
 	} L;
-	struct M {	/* -M<maxwell_t>  */
+	struct GRDFLEXURE_M {	/* -M<maxwell_t>  */
 		bool active;
 		double maxwell_t;	/* Maxwell time */
 		double scale;		/* scale for time */
 		char unit;		/* Unit of time */
 	} M;
-	struct N {	/* -N[f|q|s<n_columns>/<n_rows>][+e|m|n][+t<width>][+w[<suffix>]][+z[p]]  */
+	struct GRDFLEXURE_N {	/* -N[f|q|s<n_columns>/<n_rows>][+e|m|n][+t<width>][+w[<suffix>]][+z[p]]  */
 		bool active;
 		struct GMT_FFT_INFO *info;
 	} N;
-	struct S {	/* Starved moat */
+	struct GRDFLEXURE_S {	/* Starved moat */
 		bool active;
 		double beta;	/* Fraction of moat w(x) filled in [1] */
 	} S;
-	struct T {	/* -T[l]<t0>/<t1>/<d0>|n  */
+	struct GRDFLEXURE_T {	/* -T[l]<t0>/<t1>/<d0>|n  */
 		bool active, log;
 		unsigned int n_eval_times;
 		struct GMT_MODELTIME *time;	/* The current sequence of times */
 	} T;
-	struct W {	/* Water depth */
+	struct GRDFLEXURE_W {	/* Water depth */
 		bool active;
 		double water_depth;	/* Reference water depth [0] */
 	} W;
-	struct Z {	/* Moho depth */
+	struct GRDFLEXURE_Z {	/* Moho depth */
 		bool active;
 		double zm;	/* Reference depth to flexed surface [0] */
 	} Z;
 };
 
-struct RHEOLOGY {	/* Used to pass parameters in/out of functions */
+struct GRDFLEXURE_RHEOLOGY {	/* Used to pass parameters in/out of functions */
 	double eval_time_yr;	/* Time in years of evaluation or relative time since loading */
 	double load_time_yr;	/* Time in years of loading, or zero */
 	double t0;		/* Time in seconds since loading */
@@ -128,9 +128,9 @@ struct RHEOLOGY {	/* Used to pass parameters in/out of functions */
 	double dens_ratio;	/* (Ctrl->D.rhom - Ctrl->D.rhoi) / Ctrl->D.rhom */
 	bool relative;		/* eval_time_yr is relative to load time [at 0] */
 	bool isotropic;		/* true when no inplane forces are set (no -A) */
-	double (*transfer) (double *, struct RHEOLOGY *);	/* pointer to function returning isostatic response for given k and R */
-	double (*tr_elastic_sub) (double *, struct RHEOLOGY *);	/* pointer to sub-function returning elastic isostatic response for given k and R */
-	void (*setup) (struct GMT_CTRL *, struct GRDFLEXURE_CTRL *, struct GMT_FFT_WAVENUMBER *, struct RHEOLOGY *);	/* Init function */
+	double (*transfer) (double *, struct GRDFLEXURE_RHEOLOGY *);	/* pointer to function returning isostatic response for given k and R */
+	double (*tr_elastic_sub) (double *, struct GRDFLEXURE_RHEOLOGY *);	/* pointer to sub-function returning elastic isostatic response for given k and R */
+	void (*setup) (struct GMT_CTRL *, struct GRDFLEXURE_CTRL *, struct GMT_FFT_WAVENUMBER *, struct GRDFLEXURE_RHEOLOGY *);	/* Init function */
 };
 
 struct FLX_GRID {
@@ -303,25 +303,25 @@ void gmt_modeltime_name (struct GMT_CTRL *GMT, char *file, char *format, struct 
 		sprintf (file, format, T->value);
 }
 
-GMT_LOCAL double grdflexure_transfer_elastic_sub_iso (double *k, struct RHEOLOGY *R) {
+GMT_LOCAL double grdflexure_transfer_elastic_sub_iso (double *k, struct GRDFLEXURE_RHEOLOGY *R) {
 	/* Elastic transfer function (isotropic) */
 	double grdflexure_transfer_fn = 1.0 / (R->ce * pow (k[GMT_FFT_K_IS_KR], 4.0) + 1.0);
 	return (grdflexure_transfer_fn);
 }
 
-GMT_LOCAL double grdflexure_transfer_elastic_sub (double *k, struct RHEOLOGY *R) {
+GMT_LOCAL double grdflexure_transfer_elastic_sub (double *k, struct GRDFLEXURE_RHEOLOGY *R) {
 	/* Elastic transfer function (general) */
 	double grdflexure_transfer_fn = 1.0 / (R->ce * pow (k[GMT_FFT_K_IS_KR], 4.0) + R->Nx_e * k[GMT_FFT_K_IS_KX] * k[GMT_FFT_K_IS_KX] + R->Ny_e * k[GMT_FFT_K_IS_KY] * k[GMT_FFT_K_IS_KY] + R->Nxy_e * k[GMT_FFT_K_IS_KX] * k[GMT_FFT_K_IS_KY] + 1.0);
 	return (grdflexure_transfer_fn);
 }
 
-GMT_LOCAL double grdflexure_transfer_elastic (double *k, struct RHEOLOGY *R) {
+GMT_LOCAL double grdflexure_transfer_elastic (double *k, struct GRDFLEXURE_RHEOLOGY *R) {
 	/* Elastic transfer function */
 	double grdflexure_transfer_fn = R->scale * R->tr_elastic_sub (k, R);
 	return (grdflexure_transfer_fn);
 }
 
-GMT_LOCAL void grdflexure_grdflexure_setup_elastic (struct GMT_CTRL *GMT, struct GRDFLEXURE_CTRL *Ctrl, struct GMT_FFT_WAVENUMBER *K, struct RHEOLOGY *R) {
+GMT_LOCAL void grdflexure_grdflexure_setup_elastic (struct GMT_CTRL *GMT, struct GRDFLEXURE_CTRL *Ctrl, struct GMT_FFT_WAVENUMBER *K, struct GRDFLEXURE_RHEOLOGY *R) {
 	/* Do the isostatic response function convolution in the Freq domain.
 	   All units assumed to be in SI (that is kx, ky, modk wavenumbers in m**-1,
 	   densities in kg/m**3, Te in m, etc.
@@ -371,7 +371,7 @@ GMT_LOCAL void grdflexure_grdflexure_setup_elastic (struct GMT_CTRL *GMT, struct
 		R->scale, rigidity_d, R->ce, R->Nx_e, R->Ny_e, R->Nxy_e);
 }
 
-GMT_LOCAL double grdflexure_relax_time_2 (double k, struct RHEOLOGY *R) {
+GMT_LOCAL double grdflexure_relax_time_2 (double k, struct GRDFLEXURE_RHEOLOGY *R) {
 	/*  grdflexure_relax_time_2 evalues relaxation time(k) of 2-layer viscous mantle
 	 *
 	 *     k	= wavenumber in 1/m
@@ -391,7 +391,7 @@ GMT_LOCAL double grdflexure_relax_time_2 (double k, struct RHEOLOGY *R) {
 	return (tau);
 }
 
-GMT_LOCAL void grdflexure_setup_fv2 (struct GMT_CTRL *GMT, struct GRDFLEXURE_CTRL *Ctrl, struct GMT_FFT_WAVENUMBER *K, struct RHEOLOGY *R) {
+GMT_LOCAL void grdflexure_setup_fv2 (struct GMT_CTRL *GMT, struct GRDFLEXURE_CTRL *Ctrl, struct GMT_FFT_WAVENUMBER *K, struct GRDFLEXURE_RHEOLOGY *R) {
 	/* Setup function for 2-layer viscous mantle beneath elastic plate */
 	grdflexure_grdflexure_setup_elastic (GMT, Ctrl, K, R);	/* Both firmoviscous setups rely on the elastic setup */
 	R->t0 = (R->relative) ?  R->eval_time_yr : R->load_time_yr - R->eval_time_yr;	/* Either relative to load time or both are absolute times */
@@ -407,7 +407,7 @@ GMT_LOCAL void grdflexure_setup_fv2 (struct GMT_CTRL *GMT, struct GRDFLEXURE_CTR
 		R->t0, R->dens_ratio, R->nu_ratio, R->nu_ratio1, R->cv);
 }
 
-GMT_LOCAL double grdflexure_transfer_fv2 (double *k, struct RHEOLOGY *R) {
+GMT_LOCAL double grdflexure_transfer_fv2 (double *k, struct GRDFLEXURE_RHEOLOGY *R) {
 	/* Transfer function for 2-layer viscous mantle */
 	double phi_e, phi_fv2, tau;
 	phi_e = R->tr_elastic_sub (k, R);
@@ -416,7 +416,7 @@ GMT_LOCAL double grdflexure_transfer_fv2 (double *k, struct RHEOLOGY *R) {
 	return (R->scale * phi_fv2);
 }
 
-GMT_LOCAL void grdflexure_setup_fv (struct GMT_CTRL *GMT, struct GRDFLEXURE_CTRL *Ctrl, struct GMT_FFT_WAVENUMBER *K, struct RHEOLOGY *R) {
+GMT_LOCAL void grdflexure_setup_fv (struct GMT_CTRL *GMT, struct GRDFLEXURE_CTRL *Ctrl, struct GMT_FFT_WAVENUMBER *K, struct GRDFLEXURE_RHEOLOGY *R) {
 	/* Setup function for 1-layer viscous mantle beneath elastic plate */
 	grdflexure_grdflexure_setup_elastic (GMT, Ctrl, K, R);	/* Both firmoviscous setups rely on the elastic setup */
 	R->t0 = (R->relative) ?  R->eval_time_yr : R->load_time_yr - R->eval_time_yr;	/* Either relative to load time or both are absolute times */
@@ -428,7 +428,7 @@ GMT_LOCAL void grdflexure_setup_fv (struct GMT_CTRL *GMT, struct GRDFLEXURE_CTRL
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "FV Setup: R->t0 = %g R->dens_ratio = %g R->cv = %g\n", R->t0, R->dens_ratio, R->cv);
 }
 
-GMT_LOCAL double grdflexure_transfer_fv (double *k, struct RHEOLOGY *R) {
+GMT_LOCAL double grdflexure_transfer_fv (double *k, struct GRDFLEXURE_RHEOLOGY *R) {
 /*	Firmoviscous response function for elastic plate over
  *	viscous half-space.  Give:
  *
@@ -449,13 +449,13 @@ GMT_LOCAL double grdflexure_transfer_fv (double *k, struct RHEOLOGY *R) {
 	return (R->scale * phi_fv);
 }
 
-GMT_LOCAL void grdflexure_setup_ve (struct GMT_CTRL *GMT, struct GRDFLEXURE_CTRL *Ctrl, struct GMT_FFT_WAVENUMBER *K, struct RHEOLOGY *R) {
+GMT_LOCAL void grdflexure_setup_ve (struct GMT_CTRL *GMT, struct GRDFLEXURE_CTRL *Ctrl, struct GMT_FFT_WAVENUMBER *K, struct GRDFLEXURE_RHEOLOGY *R) {
 	grdflexure_grdflexure_setup_elastic (GMT, Ctrl, K, R);	/* Both firmoviscous setups rely on the elastic setup */
 	R->cv = 1.0 / (Ctrl->M.maxwell_t * (86400*365.25));	/* Convert to seconds */
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "VE Setup: R->cv = %g, t_maxwell = %g%c\n", R->cv, Ctrl->M.maxwell_t * Ctrl->M.scale, Ctrl->M.unit);
 }
 
-GMT_LOCAL double grdflexure_transfer_ve (double *k, struct RHEOLOGY *R) {
+GMT_LOCAL double grdflexure_transfer_ve (double *k, struct GRDFLEXURE_RHEOLOGY *R) {
 /*	Viscoelastic response function for VE plate.  Give:
  *
  *	k	- wavenumbers (1/m)
@@ -472,7 +472,7 @@ GMT_LOCAL double grdflexure_transfer_ve (double *k, struct RHEOLOGY *R) {
 	return (R->scale * phi_ve);
 }
 
-GMT_LOCAL void grdflexure_apply_grdflexure_transfer_function (struct GMT_CTRL *GMT, struct GMT_GRID *Grid, struct GRDFLEXURE_CTRL *Ctrl, struct GMT_FFT_WAVENUMBER *K, struct RHEOLOGY *R) {
+GMT_LOCAL void grdflexure_apply_grdflexure_transfer_function (struct GMT_CTRL *GMT, struct GMT_GRID *Grid, struct GRDFLEXURE_CTRL *Ctrl, struct GMT_FFT_WAVENUMBER *K, struct GRDFLEXURE_RHEOLOGY *R) {
 	/* Do the spectral convolution for isostatic response in the Freq domain. */
 	uint64_t k;
 	double  mk[3], grdflexure_transfer_fn;
@@ -741,9 +741,9 @@ GMT_LOCAL struct FLX_GRID *grdflexure_prepare_load (struct GMT_CTRL *GMT, struct
 	return (G);
 }
 
-GMT_LOCAL struct RHEOLOGY *grdflexure_select_rheology (struct GMT_CTRL *GMT, struct GRDFLEXURE_CTRL *Ctrl) {
+GMT_LOCAL struct GRDFLEXURE_RHEOLOGY *grdflexure_select_rheology (struct GMT_CTRL *GMT, struct GRDFLEXURE_CTRL *Ctrl) {
 	unsigned int fmode = 0;
-	struct RHEOLOGY *R = NULL;
+	struct GRDFLEXURE_RHEOLOGY *R = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
 	/* Select the transfer function to use */
@@ -754,7 +754,7 @@ GMT_LOCAL struct RHEOLOGY *grdflexure_select_rheology (struct GMT_CTRL *GMT, str
 	else				/* Elastic */
 		fmode = FLX_E;
 
-	R = gmt_M_memory (GMT, NULL, 1, struct RHEOLOGY);	/* Allocate rheology structure */
+	R = gmt_M_memory (GMT, NULL, 1, struct GRDFLEXURE_RHEOLOGY);	/* Allocate rheology structure */
 
 	switch (fmode) {	/* Set function pointers */
 		case FLX_E:
@@ -796,7 +796,7 @@ EXTERN_MSC int GMT_grdflexure (void *V_API, int mode, void *args) {
 	char file[PATH_MAX] = {""}, time_fmt[GMT_LEN64] = {""};
 
 	struct GMT_FFT_WAVENUMBER *K = NULL;
-	struct RHEOLOGY *R = NULL;
+	struct GRDFLEXURE_RHEOLOGY *R = NULL;
 	struct FLX_GRID **Load = NULL, *This_Load = NULL;
 	struct GMT_GRID *Out = NULL;
 	struct GMT_DATASET *L = NULL;

--- a/src/potential/grdgravmag3d.c
+++ b/src/potential/grdgravmag3d.c
@@ -47,38 +47,38 @@
 typedef void (*PFV) ();		/* pointer to a function returning void */
 typedef double (*PFD) ();		/* pointer to a function returning double */
 
-struct GRDOKB_CTRL {
+struct GRDGRAVMAG3D_CTRL {
 
-	struct GRDOKB_In {
+	struct GRDGRAVMAG3D_In {
 		bool active;
 		char *file[3];
 	} In;
 
-	struct GRDOKB_C {	/* -C */
+	struct GRDGRAVMAG3D_C {	/* -C */
 		bool active;
 		double rho;
 	} C;
-	struct GRDOKB_D {	/* -D */
+	struct GRDGRAVMAG3D_D {	/* -D */
 		bool active;
 		gmt_grdfloat z_dir;
 	} D;
-	struct GRDOKB_E {	/* -E */
+	struct GRDGRAVMAG3D_E {	/* -E */
 		bool active;
 		double thickness;
 	} E;
-	struct GRDOKB_I {	/* -Idx[/dy] */
+	struct GRDGRAVMAG3D_I {	/* -Idx[/dy] */
 		bool active;
 		double inc[2];
 	} I;
-	struct GRDOKB_F {	/* -F<xyfile> */
+	struct GRDGRAVMAG3D_F {	/* -F<xyfile> */
 		bool active;
 		char *file;
 	} F;
-	struct GRDOKB_G {	/* -G<grdfile> */
+	struct GRDGRAVMAG3D_G {	/* -G<grdfile> */
 		bool active;
 		char *file;
 	} G;
-	struct GRDOKB_H {	/* -H */
+	struct GRDGRAVMAG3D_H {	/* -H */
 		bool active;
 		bool bhatta;
 		bool pirtt;
@@ -87,27 +87,27 @@ struct GRDOKB_CTRL {
 		char *incfile, *decfile, *magfile;
 		double	t_dec, t_dip, m_int, m_dec, m_dip, koningsberg;
 	} H;
-	struct GRDOKB_L {	/* -L */
+	struct GRDGRAVMAG3D_L {	/* -L */
 		double zobs;
 	} L;
-	struct GRDOKB_Q {	/* -Q */
+	struct GRDGRAVMAG3D_Q {	/* -Q */
 		bool active;
 		unsigned int n_pad;
 		char region[GMT_BUFSIZ];	/* gmt_parse_R_option has this!!!! */
 		double pad_dist;
 	} Q;
-	struct GRDOKB_S {	/* -S */
+	struct GRDGRAVMAG3D_S {	/* -S */
 		bool active;
 		double radius;
 	} S;
-	struct GRDOKB_T {	/* -T<grdfile> */
+	struct GRDGRAVMAG3D_T {	/* -T<grdfile> */
 		double	year;
 	} T;
-	struct GRDOKB_Z {	/* -Z */
+	struct GRDGRAVMAG3D_Z {	/* -Z */
 		bool top, bot;
 		double z0;
 	} Z;
-	struct GRDOKB_box {	/* No option, just a container */
+	struct GRDGRAVMAG3D_box {	/* No option, just a container */
 		bool is_geog;
 		double	d_to_m, *mag_int, lon_0, lat_0;
 	} box;
@@ -121,24 +121,24 @@ struct THREAD_STRUCT {
 	struct LOC_OR *loc_or;
 	struct BODY_DESC *body_desc;
 	struct BODY_VERTS *body_verts;
-	struct GRDOKB_CTRL *Ctrl;
+	struct GRDGRAVMAG3D_CTRL *Ctrl;
 	struct GMT_GRID *Grid;
 	struct GMT_GRID *Gout;
 	struct GMT_GRID *Gsource;
 	struct GMT_CTRL *GMT;
 };
 
-GMT_LOCAL int grdgravmag3d_body_set_tri (struct GMT_CTRL *GMT, struct GRDOKB_CTRL *Ctrl, struct GMT_GRID *Grid,
+GMT_LOCAL int grdgravmag3d_body_set_tri (struct GMT_CTRL *GMT, struct GRDGRAVMAG3D_CTRL *Ctrl, struct GMT_GRID *Grid,
 	struct BODY_DESC *body_desc, struct BODY_VERTS *body_verts, double *x, double *y,
 	double *cos_vec, unsigned int j, unsigned int i, unsigned int inc_j, unsigned int inc_i);
-GMT_LOCAL int grdgravmag3d_body_set_prism(struct GMT_CTRL *GMT, struct GRDOKB_CTRL *Ctrl, struct GMT_GRID *Grid,
+GMT_LOCAL int grdgravmag3d_body_set_prism(struct GMT_CTRL *GMT, struct GRDGRAVMAG3D_CTRL *Ctrl, struct GMT_GRID *Grid,
 	struct BODY_DESC *body_desc, struct BODY_VERTS *body_verts, double *x, double *y,
 	double *cos_vec, unsigned int j, unsigned int i, unsigned int inc_j, unsigned int inc_i);
-GMT_LOCAL int grdgravmag3d_body_desc_tri(struct GMT_CTRL *GMT, struct GRDOKB_CTRL *Ctrl, struct BODY_DESC *body_desc,
+GMT_LOCAL int grdgravmag3d_body_desc_tri(struct GMT_CTRL *GMT, struct GRDGRAVMAG3D_CTRL *Ctrl, struct BODY_DESC *body_desc,
 	struct BODY_VERTS **body_verts, unsigned int face);
-GMT_LOCAL int grdgravmag3d_body_desc_prism(struct GMT_CTRL *GMT, struct GRDOKB_CTRL *Ctrl, struct BODY_DESC *body_desc,
+GMT_LOCAL int grdgravmag3d_body_desc_prism(struct GMT_CTRL *GMT, struct GRDGRAVMAG3D_CTRL *Ctrl, struct BODY_DESC *body_desc,
 	struct BODY_VERTS **body_verts, unsigned int face);
-GMT_LOCAL void grdgravmag3d_calc_surf (struct GMT_CTRL *GMT, struct GRDOKB_CTRL *Ctrl, struct GMT_GRID *Grid, struct GMT_GRID *Gout,
+GMT_LOCAL void grdgravmag3d_calc_surf (struct GMT_CTRL *GMT, struct GRDGRAVMAG3D_CTRL *Ctrl, struct GMT_GRID *Grid, struct GMT_GRID *Gout,
 	struct GMT_GRID *Gsource, double *g, unsigned int n_pts, double *x_grd, double *y_grd, double *x_grd_geo, double *y_grd_geo,
 	double *x_obs, double *y_obs, double *cos_vec, struct MAG_PARAM *okabe_mag_param, struct MAG_VAR *okabe_mag_var, struct LOC_OR *loc_or,
 	struct BODY_DESC *body_desc, struct BODY_VERTS *body_verts);
@@ -163,9 +163,9 @@ GMT_LOCAL double grdgravmag3d_fast_atan(double x) {
 #define FATAN(x) (fabs(x) > 1) ? atan(x) : (M_PI_4*x - x*(fabs(x) - 1)*(0.2447 + 0.0663*fabs(x)))
 
 GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
-	struct GRDOKB_CTRL *C;
+	struct GRDGRAVMAG3D_CTRL *C;
 
-	C = gmt_M_memory (GMT, NULL, 1, struct GRDOKB_CTRL);
+	C = gmt_M_memory (GMT, NULL, 1, struct GRDGRAVMAG3D_CTRL);
 
 	/* Initialize values whose defaults are not 0/false/NULL */
 	C->E.thickness = 500;
@@ -176,7 +176,7 @@ GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a n
 	return (C);
 }
 
-GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct GRDOKB_CTRL *C) {	/* Deallocate control structure */
+GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct GRDGRAVMAG3D_CTRL *C) {	/* Deallocate control structure */
 	if (!C) return;
 	gmt_M_str_free (C->In.file[0]);
 	gmt_M_str_free (C->In.file[1]);
@@ -245,7 +245,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
-GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDOKB_CTRL *Ctrl, struct GMT_OPTION *options) {
+GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDGRAVMAG3D_CTRL *Ctrl, struct GMT_OPTION *options) {
 
 	/* This parses the options provided to grdgravmag3d and sets parameters in Ctrl.
 	 * Note Ctrl has already been initialized and non-zero default values set.
@@ -459,7 +459,7 @@ EXTERN_MSC int GMT_grdgravmag3d (void *V_API, int mode, void *args) {
 	struct  LOC_OR *loc_or = NULL;
 	struct  BODY_VERTS *body_verts = NULL;
 	struct  BODY_DESC body_desc;
-	struct  GRDOKB_CTRL *Ctrl = NULL;
+	struct  GRDGRAVMAG3D_CTRL *Ctrl = NULL;
 	struct  GMT_DATASET *Cin = NULL;
 	struct  GMT_DATATABLE *point = NULL;
 	struct  GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;
@@ -1006,7 +1006,7 @@ L1:
 
 
 /* -----------------------------------------------------------------*/
-GMT_LOCAL int grdgravmag3d_body_desc_tri(struct GMT_CTRL *GMT, struct GRDOKB_CTRL *Ctrl, struct BODY_DESC *body_desc,
+GMT_LOCAL int grdgravmag3d_body_desc_tri(struct GMT_CTRL *GMT, struct GRDGRAVMAG3D_CTRL *Ctrl, struct BODY_DESC *body_desc,
                                          struct BODY_VERTS **body_verts, unsigned int face) {
 	gmt_M_unused(Ctrl);
 /*
@@ -1054,7 +1054,7 @@ GMT_LOCAL int grdgravmag3d_body_desc_tri(struct GMT_CTRL *GMT, struct GRDOKB_CTR
 }
 
 /* -----------------------------------------------------------------------------------*/
-GMT_LOCAL int grdgravmag3d_body_desc_prism(struct GMT_CTRL *GMT, struct GRDOKB_CTRL *Ctrl, struct BODY_DESC *body_desc,
+GMT_LOCAL int grdgravmag3d_body_desc_prism(struct GMT_CTRL *GMT, struct GRDGRAVMAG3D_CTRL *Ctrl, struct BODY_DESC *body_desc,
                                            struct BODY_VERTS **body_verts, unsigned int face) {
 	gmt_M_unused(Ctrl);
 	if (face != 0 && face != 5) return(0);
@@ -1073,7 +1073,7 @@ GMT_LOCAL int grdgravmag3d_body_desc_prism(struct GMT_CTRL *GMT, struct GRDOKB_C
 }
 
 /* -----------------------------------------------------------------------------------*/
-GMT_LOCAL int grdgravmag3d_body_set_tri(struct GMT_CTRL *GMT, struct GRDOKB_CTRL *Ctrl, struct GMT_GRID *Grid,
+GMT_LOCAL int grdgravmag3d_body_set_tri(struct GMT_CTRL *GMT, struct GRDGRAVMAG3D_CTRL *Ctrl, struct GMT_GRID *Grid,
 		struct BODY_DESC *body_desc, struct BODY_VERTS *body_verts, double *x, double *y,
 		double *cos_vec, unsigned int j, unsigned int i, unsigned int inc_j, unsigned int inc_i) {
 
@@ -1122,7 +1122,7 @@ GMT_LOCAL int grdgravmag3d_body_set_tri(struct GMT_CTRL *GMT, struct GRDOKB_CTRL
 }
 
 /* -----------------------------------------------------------------------------------*/
-GMT_LOCAL int grdgravmag3d_body_set_prism(struct GMT_CTRL *GMT, struct GRDOKB_CTRL *Ctrl, struct GMT_GRID *Grid,
+GMT_LOCAL int grdgravmag3d_body_set_prism(struct GMT_CTRL *GMT, struct GRDGRAVMAG3D_CTRL *Ctrl, struct GMT_GRID *Grid,
 		struct BODY_DESC *body_desc, struct BODY_VERTS *body_verts, double *x, double *y,
 		double *cos_vec, unsigned int j, unsigned int i, unsigned int inc_j, unsigned int inc_i) {
 
@@ -1170,7 +1170,7 @@ GMT_LOCAL void grdgravmag3d_calc_surf_ (struct THREAD_STRUCT *t) {
 	struct BODY_VERTS *body_verts = NULL;
 
     struct GMT_CTRL *GMT        = t->GMT;
-    struct GRDOKB_CTRL *Ctrl    = t->Ctrl;
+    struct GRDGRAVMAG3D_CTRL *Ctrl    = t->Ctrl;
     struct GMT_GRID *Grid       = t->Grid;
     struct GMT_GRID *Gout       = t->Gout;
     struct GMT_GRID *Gsource    = t->Gsource;
@@ -1188,7 +1188,7 @@ GMT_LOCAL void grdgravmag3d_calc_surf_ (struct THREAD_STRUCT *t) {
     unsigned int r_start        = t->r_start;
     unsigned int r_stop         = t->r_stop;
 
-	int (*v_func[3])(struct GMT_CTRL *, struct GRDOKB_CTRL *, struct GMT_GRID *, struct BODY_DESC *, struct BODY_VERTS *,
+	int (*v_func[3])(struct GMT_CTRL *, struct GRDGRAVMAG3D_CTRL *, struct GMT_GRID *, struct BODY_DESC *, struct BODY_VERTS *,
 	      double *, double *, double *, unsigned int, unsigned int, unsigned int, unsigned int);
 	double (*d_func[3])(struct GMT_CTRL *, double, double, double, double, bool, struct BODY_DESC, struct BODY_VERTS *,
 	        unsigned int, unsigned int, struct LOC_OR *, struct MAG_PARAM *, struct MAG_VAR *);
@@ -1293,7 +1293,7 @@ GMT_LOCAL void grdgravmag3d_calc_surf_ (struct THREAD_STRUCT *t) {
 }
 
 /* -----------------------------------------------------------------------------------*/
-GMT_LOCAL void grdgravmag3d_calc_surf (struct GMT_CTRL *GMT, struct GRDOKB_CTRL *Ctrl, struct GMT_GRID *Grid, struct GMT_GRID *Gout,
+GMT_LOCAL void grdgravmag3d_calc_surf (struct GMT_CTRL *GMT, struct GRDGRAVMAG3D_CTRL *Ctrl, struct GMT_GRID *Grid, struct GMT_GRID *Gout,
 		struct GMT_GRID *Gsource, double *g, unsigned int n_pts, double *x_grd, double *y_grd, double *x_grd_geo, double *y_grd_geo,
 		double *x_obs, double *y_obs, double *cos_vec, struct MAG_PARAM *okabe_mag_param, struct MAG_VAR *okabe_mag_var, struct LOC_OR *loc_or,
 		struct BODY_DESC *body_desc, struct BODY_VERTS *body_verts) {

--- a/src/potential/grdredpol.c
+++ b/src/potential/grdredpol.c
@@ -40,53 +40,53 @@
 #define THIS_MODULE_NEEDS	"g"
 #define THIS_MODULE_OPTIONS "-RVn"
 
-struct REDPOL_CTRL {
-	struct In {
+struct GRDREDPOL_CTRL {
+	struct GRDREDPOL_In {
 		bool active;
 		char *file;
 	} In;
-	struct C {	/* -C */
+	struct GRDREDPOL_C {	/* -C */
 		bool use_igrf;
 		bool const_f;
 		double	dec;
 		double	dip;
 	} C;
-	struct E {	/* -E */
+	struct GRDREDPOL_E {	/* -E */
 		bool active;
 		bool dip_grd_only;
 		bool dip_dec_grd;
 		char *decfile;
 		char *dipfile;
 	} E;
-	struct F {	/* -F */
+	struct GRDREDPOL_F {	/* -F */
 		bool active;
 		unsigned int	ncoef_row;
 		unsigned int	ncoef_col;
 		unsigned int	compute_n;	/* Compute ncoef_col */
 		double	width;
 	} F;
-	struct G {	/* -G<file> */
+	struct GRDREDPOL_G {	/* -G<file> */
 		bool active;
 		char	*file;
 	} G;
-	struct M {	/* -M */
+	struct GRDREDPOL_M {	/* -M */
 		bool pad_zero;
 		bool mirror;
 	} M;
-	struct N {	/* -N */
+	struct GRDREDPOL_N {	/* -N */
 		bool active;
 	} N;
-	struct S {	/* -S, size of working grid */
+	struct GRDREDPOL_S {	/* -S, size of working grid */
 		unsigned int	n_columns;
 		unsigned int	n_rows;
 	} S;
-	struct T {	/* -T */
+	struct GRDREDPOL_T {	/* -T */
 		double	year;
 	} T;
-	struct W {	/* -W */
+	struct GRDREDPOL_W {	/* -W */
 		double	wid;
 	} W;
-	struct Z {	/* -Z */
+	struct GRDREDPOL_Z {	/* -Z */
 		bool active;
 		char	*file;
 	} Z;
@@ -97,9 +97,9 @@ struct REDPOL_CTRL {
 #define ij_mn(Ctrl,i,j) (Ctrl->F.ncoef_row*(j)+(i))
 
 GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
-	struct REDPOL_CTRL *C;
+	struct GRDREDPOL_CTRL *C;
 
-	C = gmt_M_memory (GMT, NULL, 1, struct REDPOL_CTRL);
+	C = gmt_M_memory (GMT, NULL, 1, struct GRDREDPOL_CTRL);
 
 	/* Initialize values whose defaults are not 0/false/NULL */
 	C->C.use_igrf = true;
@@ -112,7 +112,7 @@ GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a n
 	return (C);
 }
 
-GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct REDPOL_CTRL *C) {	/* Deallocate control structure */
+GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct GRDREDPOL_CTRL *C) {	/* Deallocate control structure */
 	if (!C) return;
 	gmt_M_str_free (C->In.file);
 	gmt_M_str_free (C->G.file);
@@ -124,7 +124,7 @@ GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct REDPOL_CTRL *C) {	/* Deal
 
 GMT_LOCAL void grdgravmag3d_rtp_filt_colinear (int i, int j, int n21, double *gxr,double *gxi, double *gxar,
 		double *gxai, double *gxbr, double *gxbi, double *gxgr, double *gxgi, double u,
-		double v, double alfa, double beta, double gama, struct REDPOL_CTRL *Ctrl) {
+		double v, double alfa, double beta, double gama, struct GRDREDPOL_CTRL *Ctrl) {
 
 	uint64_t ij = ij_mn(Ctrl,i,j-n21+1);
 	double ro, ro2, ro3, ro4, ro5, alfa_u, beta_v, gama_ro, gama_ro_2;
@@ -160,7 +160,7 @@ GMT_LOCAL void grdgravmag3d_rtp_filt_colinear (int i, int j, int n21, double *gx
 GMT_LOCAL void grdgravmag3d_rtp_filt_not_colinear (int i, int j, int n21, double *gxr, double *gxi, double *gxar,
 		double *gxai, double *gxbr, double *gxbi, double *gxgr, double *gxgi, double *gxtr,
 		double *gxti, double *gxmr, double *gxmi, double *gxnr, double *gxni, double u, double v, double alfa,
-		double beta, double gama, double tau, double mu, double nu, struct REDPOL_CTRL *Ctrl) {
+		double beta, double gama, double tau, double mu, double nu, struct GRDREDPOL_CTRL *Ctrl) {
 
 	uint64_t ij = ij_mn(Ctrl,i,j-n21+1);
 	double ro, ro2, ro3, ro4, ro5, alfa_u, beta_v, gama_ro, gama_ro_2;
@@ -211,7 +211,7 @@ GMT_LOCAL void grdgravmag3d_rtp_filt_not_colinear (int i, int j, int n21, double
 	}
 }
 
-GMT_LOCAL void grdgravmag3d_mirror_edges (gmt_grdfloat *grid, int nc, int i_data_start, int j_data_start, struct REDPOL_CTRL *Ctrl) {
+GMT_LOCAL void grdgravmag3d_mirror_edges (gmt_grdfloat *grid, int nc, int i_data_start, int j_data_start, struct GRDREDPOL_CTRL *Ctrl) {
 	/* This routine mirrors or replicates the West and East borders j_data_start times
 	   and the South and North borders by i_data_start times.
 	   nc	is the total number of columns by which the grid is extended
@@ -415,11 +415,11 @@ GMT_LOCAL int grdgravmag3d_igrf10syn (struct GMT_CTRL *C, int isv, double date, 
   *	Updated for IGRF 11th generation
   */
 
-	struct IGRF {
+	struct GRDREDPOL_IGRF {
 		double e_1[3450];
 	};
      /* Initialized data */
-     static struct IGRF equiv_22 = {
+     static struct GRDREDPOL_IGRF equiv_22 = {
        {-31543.,-2298., 5922., -677., 2905.,-1061.,  924., 1121., /* g0 (1900) */
          1022.,-1469., -330., 1256.,    3.,  572.,  523.,  876.,
           628.,  195.,  660.,  -69., -361., -210.,  134.,  -75.,
@@ -1050,7 +1050,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
-GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct REDPOL_CTRL *Ctrl, struct GMT_OPTION *options) {
+GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDREDPOL_CTRL *Ctrl, struct GMT_OPTION *options) {
 	/* This parses the options provided to grdredpol and sets parameters in Ctrl.
 	 * Note Ctrl has already been initialized and non-zero default values set.
 	 * Any GMT common options will override values set previously by other commands.
@@ -1197,7 +1197,7 @@ EXTERN_MSC int GMT_grdredpol (void *V_API, int mode, void *args) {
 	double	dec_m, dip_m, tau1, mu1, nu1, dt = 0, dm = 0, dn = 0, tau = 0, mu = 0, nu = 0;
 	double	wesn_new[4], out_igrf[7];
 
-	struct	REDPOL_CTRL *Ctrl = NULL;
+	struct	GRDREDPOL_CTRL *Ctrl = NULL;
 	struct	GMT_GRID *Gin = NULL, *Gout = NULL, *Gdip = NULL, *Gdec = NULL, *Gfilt = NULL;
 	struct	GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;
 	struct	GMT_OPTION *options = NULL;

--- a/src/potential/grdseamount.c
+++ b/src/potential/grdseamount.c
@@ -60,58 +60,58 @@ struct GMT_MODELTIME {	/* Hold info about modeling time */
 };
 
 struct GRDSEAMOUNT_CTRL {
-	struct A {	/* -A[<out>/<in>] */
+	struct GRDSEAMOUNT_A {	/* -A[<out>/<in>] */
 		bool active;
 		gmt_grdfloat value[2];	/* Inside and outside value for mask */
 	} A;
-	struct C {	/* -C<shape> */
+	struct GRDSEAMOUNT_C {	/* -C<shape> */
 		bool active;
 		unsigned int mode;	/* 0 = Gaussian, 1 = parabola, 2 = cone, 3 = disc */
 	} C;
-	struct D {	/* -De|f|k|M|n|u */
+	struct GRDSEAMOUNT_D {	/* -De|f|k|M|n|u */
 		bool active;
 		char unit;
 	} D;
-	struct E {	/* -E */
+	struct GRDSEAMOUNT_E {	/* -E */
 		bool active;
 	} E;
-	struct F {	/* -F[<flattening>] */
+	struct GRDSEAMOUNT_F {	/* -F[<flattening>] */
 		bool active;
 		unsigned int mode;
 		double value;
 	} F;
-	struct G {	/* -G<output_grdfile> */
+	struct GRDSEAMOUNT_G {	/* -G<output_grdfile> */
 		bool active;
 		char *file;
 	} G;
-	struct L {	/* -L[<hcut>] */
+	struct GRDSEAMOUNT_L {	/* -L[<hcut>] */
 		bool active;
 		unsigned int mode;
 		double value;
 	} L;
-	struct M {	/* -M<outlist> */
+	struct GRDSEAMOUNT_M {	/* -M<outlist> */
 		bool active;
 		char *file;
 	} M;
-	struct N {	/* -N<norm> */
+	struct GRDSEAMOUNT_N {	/* -N<norm> */
 		bool active;
 		double value;
 	} N;
-	struct Q {	/* -Qc|i/g|l */
+	struct GRDSEAMOUNT_Q {	/* -Qc|i/g|l */
 		bool active;
 		unsigned int bmode;
 		unsigned int fmode;
 	} Q;
-	struct S {	/* -S<r_scale> */
+	struct GRDSEAMOUNT_S {	/* -S<r_scale> */
 		bool active;
 		double value;
 	} S;
-	struct T {	/* -T[l]<t0>/<t1>/<d0>|n  */
+	struct GRDSEAMOUNT_T {	/* -T[l]<t0>/<t1>/<d0>|n  */
 		bool active, log;
 		unsigned int n_times;
 		struct GMT_MODELTIME *time;	/* The current sequence of times */
 	} T;
-	struct Z {	/* -Z<base> */
+	struct GRDSEAMOUNT_Z {	/* -Z<base> */
 		bool active;
 		double value;
 	} Z;

--- a/src/potential/talwani2d.c
+++ b/src/potential/talwani2d.c
@@ -52,34 +52,34 @@
 #define THIS_MODULE_OPTIONS "-Vdehio" GMT_ADD_x_OPT
 
 struct TALWANI2D_CTRL {
-	struct Out {	/* -> */
+	struct TALWANI2D_Out {	/* -> */
 		bool active;
 		char *file;
 	} Out;
-	struct A {	/* -A positive up  */
+	struct TALWANI2D_A {	/* -A positive up  */
 		bool active;
 	} A;
-	struct D {	/* -D<rho> fixed density to override model files */
+	struct TALWANI2D_D {	/* -D<rho> fixed density to override model files */
 		bool active;
 		double rho;
 	} D;
-	struct F {	/* -F[f|n[<lat>]|v] */
+	struct TALWANI2D_F {	/* -F[f|n[<lat>]|v] */
 		bool active;
 		unsigned int mode;
 		double lat;
 	} F;
-	struct M {	/* -Mh|z  */
+	struct TALWANI2D_M {	/* -Mh|z  */
 		bool active[2];	/* True if km, else m */
 	} M;
-	struct N {	/* Output points with optional obs-z values*/
+	struct TALWANI2D_N {	/* Output points with optional obs-z values*/
 		bool active;
 		char *file;
 	} N;
-	struct T {	/* -T<min/max/inc>[+n] | -T<file> */
+	struct TALWANI2D_T {	/* -T<min/max/inc>[+n] | -T<file> */
 		bool active;
 		struct GMT_ARRAY T;
 	} T;
-	struct Z {	/* Observation level constant */
+	struct TALWANI2D_Z {	/* Observation level constant */
 		bool active;
 		double level;
 		double ymin, ymax;
@@ -87,7 +87,7 @@ struct TALWANI2D_CTRL {
 	} Z;
 };
 
-struct BODY2D {
+struct TALWANI2D_BODY2D {
 	int n;
 	double rho;
 	double *x, *z;
@@ -486,7 +486,7 @@ GMT_LOCAL double talwani2d_get_geoid2d (struct GMT_CTRL *GMT, double y[], double
 	return (N);
 }
 
-GMT_LOCAL double talwani2d_get_one_output (struct GMT_CTRL *GMT, double x_obs, double z_obs, struct BODY2D *body, unsigned int n_bodies, unsigned int mode, double ymin, double ymax, double G0) {
+GMT_LOCAL double talwani2d_get_one_output (struct GMT_CTRL *GMT, double x_obs, double z_obs, struct TALWANI2D_BODY2D *body, unsigned int n_bodies, unsigned int mode, double ymin, double ymax, double G0) {
 	/* Evaluate output at a single observation point (x,z) */
 	/* Work array vtry must have at least of length ndepths */
 	unsigned int k;
@@ -523,7 +523,7 @@ EXTERN_MSC int GMT_talwani2d (void *V_API, int mode, void *args) {
 	char *uname[2] = {"meter", "km"}, *kind[4] = {"FAA", "VGG", "GEOID", "FAA(2.5-D)"};
 	double *x = NULL, *z = NULL, *in = NULL;
 
-	struct BODY2D *body = NULL;
+	struct TALWANI2D_BODY2D *body = NULL;
 	struct TALWANI2D_CTRL *Ctrl = NULL;
 	struct GMT_DATASET *Out = NULL;
 	struct GMT_DATASEGMENT *S = NULL;
@@ -592,7 +592,7 @@ EXTERN_MSC int GMT_talwani2d (void *V_API, int mode, void *args) {
 	/* Set up cake slice array and pointers */
 
 	n_alloc1 = GMT_CHUNK;
-	body = gmt_M_memory (GMT, NULL, n_alloc1, struct BODY2D);
+	body = gmt_M_memory (GMT, NULL, n_alloc1, struct TALWANI2D_BODY2D);
 	n_bodies = 0;
 	/* Read polygon information from multiple segment file */
 	GMT_Report (API, GMT_MSG_INFORMATION, "All x-values are assumed to be given in %s\n", uname[Ctrl->M.active[TALWANI2D_HOR]]);
@@ -640,7 +640,7 @@ EXTERN_MSC int GMT_talwani2d (void *V_API, int mode, void *args) {
 				n = 0;
 				if (n_bodies == n_alloc1) {
 					n_alloc1 <<= 1;
-					body = gmt_M_memory (GMT, body, n_alloc1, struct BODY2D);
+					body = gmt_M_memory (GMT, body, n_alloc1, struct TALWANI2D_BODY2D);
 				}
 				continue;
 			}
@@ -668,7 +668,7 @@ EXTERN_MSC int GMT_talwani2d (void *V_API, int mode, void *args) {
 				n = 0;
 				if (n_bodies == n_alloc1) {
 					n_alloc1 <<= 1;
-					body = gmt_M_memory (GMT, body, n_alloc1, struct BODY2D);
+					body = gmt_M_memory (GMT, body, n_alloc1, struct TALWANI2D_BODY2D);
 				}
 			}
 			x[n] = in[GMT_X];	z[n] = in[GMT_Y];
@@ -693,7 +693,7 @@ EXTERN_MSC int GMT_talwani2d (void *V_API, int mode, void *args) {
 
 	/* Finish allocation */
 
-	body = gmt_M_memory (GMT, body, n_bodies, struct BODY2D);
+	body = gmt_M_memory (GMT, body, n_bodies, struct TALWANI2D_BODY2D);
 
 	if (n_duplicate) GMT_Report (API, GMT_MSG_WARNING, "Ignored %u duplicate vertices\n", n_duplicate);
 

--- a/src/project.c
+++ b/src/project.c
@@ -39,23 +39,23 @@
 
 struct PROJECT_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct A {	/* -A<azimuth> */
+	struct PROJECT_A {	/* -A<azimuth> */
 		bool active;
 		double azimuth;
 	} A;
-	struct C {	/* -C<ox>/<oy> */
+	struct PROJECT_C {	/* -C<ox>/<oy> */
 		bool active;
 		double x, y;
 	} C;
-	struct E {	/* -E<bx>/<by> */
+	struct PROJECT_E {	/* -E<bx>/<by> */
 		bool active;
 		double x, y;
 	} E;
-	struct F {	/* -F<flags> */
+	struct PROJECT_F {	/* -F<flags> */
 		bool active;
 		char col[PROJECT_N_FARGS];	/* Character codes for desired output in the right order */
 	} F;
-	struct G {	/* -G<inc>[/<colat>][+h] */
+	struct PROJECT_G {	/* -G<inc>[/<colat>][+h] */
 		bool active;
 		bool header;
 		bool through_C;
@@ -63,29 +63,29 @@ struct PROJECT_CTRL {	/* All control options for this program (except common arg
 		double inc;
 		double colat;
 	} G;
-	struct L {	/* -L[w][<l_min>/<l_max>] */
+	struct PROJECT_L {	/* -L[w][<l_min>/<l_max>] */
 		bool active;
 		bool constrain;
 		double min, max;
 	} L;
-	struct N {	/* -N */
+	struct PROJECT_N {	/* -N */
 		bool active;
 	} N;
-	struct Q {	/* -Q */
+	struct PROJECT_Q {	/* -Q */
 		bool active;
 	} Q;
-	struct S {	/* -S */
+	struct PROJECT_S {	/* -S */
 		bool active;
 	} S;
-	struct T {	/* -T<px>/<py> */
+	struct PROJECT_T {	/* -T<px>/<py> */
 		bool active;
 		double x, y;
 	} T;
-	struct W {	/* -W<w_min>/<w_max> */
+	struct PROJECT_W {	/* -W<w_min>/<w_max> */
 		bool active;
 		double min, max;
 	} W;
-	struct Z {	/* -Z<major/minor/azimuth>[+e] */
+	struct PROJECT_Z {	/* -Z<major/minor/azimuth>[+e] */
 		bool active;
 		bool exact;
 		double major, minor, azimuth;

--- a/src/psbasemap.c
+++ b/src/psbasemap.c
@@ -38,23 +38,23 @@
 /* Control structure for psbasemap */
 
 struct PSBASEMAP_CTRL {
-	struct A {	/* -A */
+	struct PSBASEMAP_A {	/* -A */
 		bool active;
 		char *file;
 	} A;
-	struct D {	/* -D[g|j|n|x]<refpoint>+w<width>[/<height>][+j<justify>[+o<dx>[/<dy>]][+s<file>][+t] or <xmin>/<xmax>/<ymin>/<ymax>[+r][+s<file>][+t][+u<unit>] */
+	struct PSBASEMAP_D {	/* -D[g|j|n|x]<refpoint>+w<width>[/<height>][+j<justify>[+o<dx>[/<dy>]][+s<file>][+t] or <xmin>/<xmax>/<ymin>/<ymax>[+r][+s<file>][+t][+u<unit>] */
 		bool active;
 		struct GMT_MAP_INSET inset;
 	} D;
-	struct F {	/* -F[d|f|l][+c<clearance>][+g<fill>][+i[<off>/][<pen>]][+p[<pen>]][+r[<radius>]][+s[<dx>/<dy>/][<shade>]][+d] */
+	struct PSBASEMAP_F {	/* -F[d|f|l][+c<clearance>][+g<fill>][+i[<off>/][<pen>]][+p[<pen>]][+r[<radius>]][+s[<dx>/<dy>/][<shade>]][+d] */
 		bool active;
 		/* The panels are members of GMT_MAP_SCALE, GMT_MAP_ROSE, and GMT_MAP_INSET */
 	} F;
-	struct L {	/* -L[g|j|n|x]<refpoint>+c[<slon>/]<slat>+w<length>[e|f|M|n|k|u][+a<align>][+f][+l[<label>]][+u] */
+	struct PSBASEMAP_L {	/* -L[g|j|n|x]<refpoint>+c[<slon>/]<slat>+w<length>[e|f|M|n|k|u][+a<align>][+f][+l[<label>]][+u] */
 		bool active;
 		struct GMT_MAP_SCALE scale;
 	} L;
-	struct T {	/* -Td|m<params> */
+	struct PSBASEMAP_T {	/* -Td|m<params> */
 		bool active;
 		struct GMT_MAP_ROSE rose;
 	} T;

--- a/src/psclip.c
+++ b/src/psclip.c
@@ -36,22 +36,22 @@
 #define THIS_MODULE_OPTIONS "-:>BJKOPRUVXYbdefghipqstxy" GMT_OPT("EZMmc")
 
 struct PSCLIP_CTRL {
-	struct A {	/* -A[m|p|step] */
+	struct PSCLIP_A {	/* -A[m|p|step] */
 		bool active;
 		unsigned int mode;
 		double step;
 	} A;
-	struct C {	/* -C */
+	struct PSCLIP_C {	/* -C */
 		bool active;
 		int n;	/* Number of levels to undo [1] */
 	} C;
-	struct N {	/* -N */
+	struct PSCLIP_N {	/* -N */
 		bool active;
 	} N;
-	struct T {	/* -T */
+	struct PSCLIP_T {	/* -T */
 		bool active;
 	} T;
-	struct W {	/* -W<pen> */
+	struct PSCLIP_W {	/* -W<pen> */
 		bool active;
 		struct GMT_PEN pen;
 	} W;

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -68,73 +68,73 @@
 /* Control structure for pscoast */
 
 struct PSCOAST_CTRL {
-	struct A {	/* -A<min_area>[/<min_level>/<max_level>][+ag|i|s][+r|l][+p<percent>] */
+	struct PSCOAST_A {	/* -A<min_area>[/<min_level>/<max_level>][+ag|i|s][+r|l][+p<percent>] */
 		bool active;
 		struct GMT_SHORE_SELECT info;
 	} A;
-	struct C {	/* -C<fill>[+l|r] */
+	struct PSCOAST_C {	/* -C<fill>[+l|r] */
 		bool active;
 		struct GMT_FILL fill[2];	/* lake and riverlake fill */
 	} C;
-	struct D {	/* -D<resolution>[+f] */
+	struct PSCOAST_D {	/* -D<resolution>[+f] */
 		bool active;
 		bool force;	/* if true, select next highest level if current set is not available */
 		char set;	/* One of f, h, i, l, c, or a for auto */
 	} D;
-	struct E {	/* -E<DWC-options> */
+	struct PSCOAST_E {	/* -E<DWC-options> */
 		bool active;
 		struct GMT_DCW_SELECT info;
 	} E;
-	struct F {	/* -F[l|t][+c<clearance>][+g<fill>][+i[<off>/][<pen>]][+p[<pen>]][+r[<radius>]][+s[<dx>/<dy>/][<shade>]][+d] */
+	struct PSCOAST_F {	/* -F[l|t][+c<clearance>][+g<fill>][+i[<off>/][<pen>]][+p[<pen>]][+r[<radius>]][+s[<dx>/<dy>/][<shade>]][+d] */
 		bool active;
 		/* The panels are members of GMT_MAP_SCALE and GMT_MAP_ROSE */
 	} F;
-	struct G {	/* -G[<fill>] */
+	struct PSCOAST_G {	/* -G[<fill>] */
 		bool active;
 		bool clip;
 		struct GMT_FILL fill;
 	} G;
-	struct I {	/* -I<feature>[/<pen>] */
+	struct PSCOAST_I {	/* -I<feature>[/<pen>] */
 		bool active;
 		unsigned int use[GSHHS_N_RLEVELS];
 		unsigned int list[GSHHS_N_RLEVELS];
 		unsigned int n_rlevels;
 		struct GMT_PEN pen[GSHHS_N_RLEVELS];
 	} I;
-	struct L {	/* -L[g|j|n|x]<refpoint>+c[<slon>/]<slat>+w<length>[e|f|M|n|k|u][+a<align>][+f][+l[<label>]][+u] */
+	struct PSCOAST_L {	/* -L[g|j|n|x]<refpoint>+c[<slon>/]<slat>+w<length>[e|f|M|n|k|u][+a<align>][+f][+l[<label>]][+u] */
 		bool active;
 		struct GMT_MAP_SCALE scale;
 	} L;
-	struct M {	/* -M */
+	struct PSCOAST_M {	/* -M */
 		bool active;
 		bool single;
 	} M;
-	struct N {	/* -N<feature>[/<pen>] */
+	struct PSCOAST_N {	/* -N<feature>[/<pen>] */
 		bool active;
 		unsigned int use[GSHHS_N_BLEVELS];
 		unsigned int list[GSHHS_N_BLEVELS];
 		unsigned int n_blevels;
 		struct GMT_PEN pen[GSHHS_N_BLEVELS];
 	} N;
-	struct Q {	/* -Q */
+	struct PSCOAST_Q {	/* -Q */
 		bool active;
 	} Q;
-	struct S {	/* -S[<fill>] */
+	struct PSCOAST_S {	/* -S[<fill>] */
 		bool active;
 		bool clip;
 		struct GMT_FILL fill;
 	} S;
-	struct T {	/* -Td|m<params> */
+	struct PSCOAST_T {	/* -Td|m<params> */
 		bool active;
 		struct GMT_MAP_ROSE rose;
 	} T;
-	struct W {	/* -W[<feature>/]<pen> */
+	struct PSCOAST_W {	/* -W[<feature>/]<pen> */
 		bool active;
 		bool use[GSHHS_MAX_LEVEL];
 		struct GMT_PEN pen[GSHHS_MAX_LEVEL];
 	} W;
 #ifdef DEBUG
-	struct DBG {	/* -+<bin> */
+	struct PSCOAST_DBG {	/* -+<bin> */
 		bool active;
 		int bin;
 	} debug;

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -36,46 +36,46 @@
 
 struct PSCONTOUR_CTRL {
 	struct GMT_CONTOUR contour;
-	struct PSCONT_A {	/* -A[n|<int>][labelinfo] */
+	struct PSCONTOUR_A {	/* -A[n|<int>][labelinfo] */
 		bool active;
 		char *file;
 		unsigned int mode;	/* 1 turns off all labels */
 		double interval;
 		double single_cont;
 	} A;
-	struct PSCONT_C {	/* -C<cpt> */
+	struct PSCONTOUR_C {	/* -C<cpt> */
 		bool active;
 		bool cpt;
 		char *file;
 		double interval;
 		double single_cont;
 	} C;
-	struct PSCONT_D {	/* -D<dumpfile> */
+	struct PSCONTOUR_D {	/* -D<dumpfile> */
 		bool active;
 		char *file;
 	} D;
-	struct PSCONT_E {	/* -E<indexfile> */
+	struct PSCONTOUR_E {	/* -E<indexfile> */
 		bool active;
 		char *file;
 	} E;
-	struct PSCONT_G {	/* -G[d|f|n|l|L|x|X]<params> */
+	struct PSCONTOUR_G {	/* -G[d|f|n|l|L|x|X]<params> */
 		bool active;
 	} G;
-	struct PSCONT_I {	/* -I */
+	struct PSCONTOUR_I {	/* -I */
 		bool active;
 	} I;
-	struct PSCONT_L {	/* -L<pen> */
+	struct PSCONTOUR_L {	/* -L<pen> */
 		bool active;
 		struct GMT_PEN pen;
 	} L;
-	struct PSCONT_N {	/* -N */
+	struct PSCONTOUR_N {	/* -N */
 		bool active;
 	} N;
-	struct PSCONT_S {	/* -S[p|t] */
+	struct PSCONTOUR_S {	/* -S[p|t] */
 		bool active;
 		unsigned int mode;	/* 0 skip points; 1 skip triangles */
 	} S;
-	struct PSCONT_T {	/* -T[h|l][+a][+d<gap>[c|i|p][/<length>[c|i|p]]][+lLH|"low,high"] */
+	struct PSCONTOUR_T {	/* -T[h|l][+a][+d<gap>[c|i|p][/<length>[c|i|p]]][+lLH|"low,high"] */
 		bool active;
 		bool label;
 		bool all;
@@ -83,7 +83,7 @@ struct PSCONTOUR_CTRL {
 		double dim[2];	/* spacing, length */
 		char *txt[2];	/* Low and high label */
 	} T;
-	struct PSCONT_Q {	/* -Q[<cut>][+z] */
+	struct PSCONTOUR_Q {	/* -Q[<cut>][+z] */
 		bool active;
 		bool zero;	/* True if we should skip zero-contour */
 		bool project;	/* True if we need distances in plot units */
@@ -92,7 +92,7 @@ struct PSCONTOUR_CTRL {
 		unsigned int min;
 		char unit;
 	} Q;
-	struct PSCONT_W {	/* -W[a|c]<pen>[+c[l|f]] */
+	struct PSCONTOUR_W {	/* -W[a|c]<pen>[+c[l|f]] */
 		bool active;
 		bool cpt_effect;
 		unsigned int cptmode;	/* Apply to both a&c */
@@ -106,7 +106,7 @@ struct PSCONTOUR_CTRL {
 #define PEN_CONT	0
 #define PEN_ANNOT	1
 
-struct SAVE {
+struct PSCONTOUR_SAVE {
 	double *x, *y;
 	double cval;
 	unsigned int n;
@@ -284,7 +284,7 @@ GMT_LOCAL void pscontour_paint_it (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, s
 	PSL_plotpolygon (PSL, x, y, n);
 }
 
-GMT_LOCAL void pscontour_sort_and_plot_ticks (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, struct SAVE *save, size_t n, double *x, double *y, double *z, unsigned int nn, double tick_gap, double tick_length, bool tick_low, bool tick_high, bool tick_label, bool all, char *in_lbl[], unsigned int mode, struct GMT_DATASET *T) {
+GMT_LOCAL void pscontour_sort_and_plot_ticks (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, struct PSCONTOUR_SAVE *save, size_t n, double *x, double *y, double *z, unsigned int nn, double tick_gap, double tick_length, bool tick_low, bool tick_high, bool tick_label, bool all, char *in_lbl[], unsigned int mode, struct GMT_DATASET *T) {
 	/* Labeling and ticking of inner-most contours cannot happen until all contours are found and we can determine
 	which are the innermost ones.
 
@@ -826,7 +826,7 @@ EXTERN_MSC int GMT_pscontour (void *V_API, int mode, void *args) {
 	struct GMT_DATASEGMENT_HIDDEN *SH = NULL;
 	struct GMT_PALETTE *P = NULL;
 	struct GMT_RECORD *In = NULL;
-	struct SAVE *save = NULL;
+	struct PSCONTOUR_SAVE *save = NULL;
 	struct PSCONTOUR_CTRL *Ctrl = NULL;
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;		/* General GMT internal parameters */
 	struct GMT_OPTION *options = NULL, *opt = NULL;
@@ -1615,9 +1615,9 @@ EXTERN_MSC int GMT_pscontour (void *V_API, int mode, void *args) {
 
 				if (make_plot) {
 					if (cont[c].do_tick && is_closed) {	/* Must store the entire contour for later processing */
-						if (n_save == n_save_alloc) save = gmt_M_malloc (GMT, save, n_save, &n_save_alloc, struct SAVE);
+						if (n_save == n_save_alloc) save = gmt_M_malloc (GMT, save, n_save, &n_save_alloc, struct PSCONTOUR_SAVE);
 						n_alloc = 0;
-						gmt_M_memset (&save[n_save], 1, struct SAVE);
+						gmt_M_memset (&save[n_save], 1, struct PSCONTOUR_SAVE);
 						gmt_M_malloc2 (GMT, save[n_save].x, save[n_save].y, m, &n_alloc, double);
 						gmt_M_memcpy (save[n_save].x, xp, m, double);
 						gmt_M_memcpy (save[n_save].y, yp, m, double);
@@ -1648,7 +1648,7 @@ EXTERN_MSC int GMT_pscontour (void *V_API, int mode, void *args) {
 		}
 		if (Ctrl->T.active && n_save) {	/* Finally sort and plot ticked innermost contours and plot/save L|H labels */
 			size_t kk;
-			save = gmt_M_malloc (GMT, save, 0, &n_save, struct SAVE);
+			save = gmt_M_malloc (GMT, save, 0, &n_save, struct PSCONTOUR_SAVE);
 
 			pscontour_sort_and_plot_ticks (GMT, PSL, save, n_save, x, y, z, n, Ctrl->T.dim[GMT_X], Ctrl->T.dim[GMT_Y], Ctrl->T.low, Ctrl->T.high, Ctrl->T.label, Ctrl->T.all, Ctrl->T.txt, label_mode, Ctrl->contour.Out);
 			for (kk = 0; kk < n_save; kk++) {

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -116,11 +116,11 @@ enum psconv_alias {
 #define add_to_list(list,item) { if (list[0]) strcat (list, " "); strcat (list, item); }
 #define add_to_qlist(list,item) { if (list[0]) strcat (list, " "); strcat (list, squote);  strcat (list, item); strcat (list, squote); }
 
-struct PS2RASTER_CTRL {
-	struct PS2R_In {	/* Input file info */
+struct PSCONVERT_CTRL {
+	struct PSCONVERT_In {	/* Input file info */
 		unsigned int n_files;
 	} In;
-	struct PS2R_A {             /* -A[+f<fade>][+g<fill>][+m<margins>][+n][+p<pen>][+r][+s|S[m]<width>[/<height>]][+u] */
+	struct PSCONVERT_A {             /* -A[+f<fade>][+g<fill>][+m<margins>][+n][+p<pen>][+r][+s|S[m]<width>[/<height>]][+u] */
 		bool active;
 		bool max;          /* Only scale if dim exceeds the given size */
 		bool round;        /* Round HiRes BB instead of ceil (+r) */
@@ -139,59 +139,59 @@ struct PS2RASTER_CTRL {
 		struct GMT_PEN pen;
 		struct GMT_FILL fill;
 	} A;
-	struct PS2R_C {	/* -C<option> */
+	struct PSCONVERT_C {	/* -C<option> */
 		bool active;
 		char arg[GMT_LEN256];
 	} C;
-	struct PS2R_D {	/* -D<dir> */
+	struct PSCONVERT_D {	/* -D<dir> */
 		bool active;
 		char *dir;
 	} D;
-	struct PS2R_E {	/* -E<resolution> */
+	struct PSCONVERT_E {	/* -E<resolution> */
 		bool active;
 		double dpi;
 	} E;
-	struct PS2R_F {	/* -F<out_name> */
+	struct PSCONVERT_F {	/* -F<out_name> */
 		bool active;
 		char *file;
 	} F;
-	struct PS2R_G {	/* -G<GSpath> */
+	struct PSCONVERT_G {	/* -G<GSpath> */
 		bool active;
 		char *file;
 	} G;
-	struct PS2R_H {	/* -H<factor> */
+	struct PSCONVERT_H {	/* -H<factor> */
 		bool active;
 		int factor;
 	} H;
-	struct PS2R_I {	/* -I */
+	struct PSCONVERT_I {	/* -I */
 		bool active;
 	} I;
-	struct PS2R_L {	/* -L<listfile> */
+	struct PSCONVERT_L {	/* -L<listfile> */
 		bool active;
 		char *file;
 	} L;
-	struct PS2R_M {	/* -Mb|f<PSfile> */
+	struct PSCONVERT_M {	/* -Mb|f<PSfile> */
 		bool active;
 		char *file;
 	} M[2];
-	struct PS2R_P {	/* -P */
+	struct PSCONVERT_P {	/* -P */
 		bool active;
 	} P;
-	struct PS2R_Q {	/* -Q[g|t]<bits> -Qp */
+	struct PSCONVERT_Q {	/* -Q[g|t]<bits> -Qp */
 		bool active;
 		bool on[3];	/* [0] for graphics, [1] for text antialiasing, [2] for pdfmark GeoPDF */
 		unsigned int bits[2];
 	} Q;
-	struct PS2R_S {	/* -S */
+	struct PSCONVERT_S {	/* -S */
 		bool active;
 	} S;
-	struct PS2R_T {	/* -T */
+	struct PSCONVERT_T {	/* -T */
 		bool active;
 		int eps;	/* 1 if we want to make EPS, -1 with setpagedevice (possibly in addition to another format) */
 		int ps;		/* 1 if we want to save the final PS under "modern" setting */
 		int device;	/* May be negative */
 	} T;
-	struct PS2R_W {	/* -W -- for world file production */
+	struct PSCONVERT_W {	/* -W -- for world file production */
 		bool active;
 		bool folder;
 		bool warp;
@@ -205,13 +205,13 @@ struct PS2RASTER_CTRL {
 		char *foldername;	/* Name of KML folder */
 		double altitude;
 	} W;
-	struct PS2R_Z { /* -Z */
+	struct PSCONVERT_Z { /* -Z */
 		bool active;
 	} Z;
 };
 
 #ifdef WIN32	/* Special for Windows */
-	GMT_LOCAL int psconvert_ghostbuster(struct GMTAPI_CTRL *API, struct PS2RASTER_CTRL *C);
+	GMT_LOCAL int psconvert_ghostbuster(struct GMTAPI_CTRL *API, struct PSCONVERT_CTRL *C);
 #else
 	/* Abstraction to get popen to do bidirectional read/write */
 GMT_LOCAL struct popen2 * psconvert_popen2 (const char *cmdline) {
@@ -266,7 +266,7 @@ GMT_LOCAL void psconvert_pclose2 (struct popen2 **Faddr, int dir) {
 }
 #endif
 
-GMT_LOCAL int psconvert_parse_A_settings (struct GMT_CTRL *GMT, char *arg, struct PS2RASTER_CTRL *Ctrl) {
+GMT_LOCAL int psconvert_parse_A_settings (struct GMT_CTRL *GMT, char *arg, struct PSCONVERT_CTRL *Ctrl) {
 	/* Syntax:
 	 * New : -A[+f<fade>][+g<fill>][+m<margins>][+n][+p<pen>][+r][+s|S[m]<width>[/<height>]][+u]
 	 * Old : -A[-][u][<margins>][+g<fill>][+p<pen>][+r][+s|S[m]<width>[/<height>]]
@@ -412,7 +412,7 @@ GMT_LOCAL int psconvert_parse_A_settings (struct GMT_CTRL *GMT, char *arg, struc
 	return (error);
 }
 
-GMT_LOCAL int psconvert_parse_GE_settings (struct GMT_CTRL *GMT, char *arg, struct PS2RASTER_CTRL *C) {
+GMT_LOCAL int psconvert_parse_GE_settings (struct GMT_CTRL *GMT, char *arg, struct PSCONVERT_CTRL *C) {
 	/* Syntax: -W[+g][+k][+t<doctitle>][+n<layername>][+a<altmode>][+l<lodmin>/<lodmax>] */
 
 	unsigned int pos = 0, error = 0;
@@ -487,9 +487,9 @@ GMT_LOCAL int psconvert_parse_GE_settings (struct GMT_CTRL *GMT, char *arg, stru
 }
 
 GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
-	struct PS2RASTER_CTRL *C;
+	struct PSCONVERT_CTRL *C;
 
-	C = gmt_M_memory (GMT, NULL, 1, struct PS2RASTER_CTRL);
+	C = gmt_M_memory (GMT, NULL, 1, struct PSCONVERT_CTRL);
 
 	/* Initialize values whose defaults are not 0/false/NULL */
 #ifdef WIN32
@@ -507,7 +507,7 @@ GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a n
 	return (C);
 }
 
-GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct PS2RASTER_CTRL *C) {	/* Deallocate control structure */
+GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *C) {	/* Deallocate control structure */
 	if (!C) return;
 	gmt_M_str_free (C->D.dir);
 	gmt_M_str_free (C->F.file);
@@ -676,7 +676,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
-GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PS2RASTER_CTRL *Ctrl, struct GMT_OPTION *options) {
+GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *Ctrl, struct GMT_OPTION *options) {
 	/* This parses the options provided to psconvert and sets parameters in CTRL.
 	 * Any GMT common options will override values set previously by other commands.
 	 * It also replaces any file names specified as input or output with the data ID
@@ -963,7 +963,7 @@ GMT_LOCAL void psconvert_file_rewind (FILE *fp, uint64_t *notused) {	/* Rewinds 
 #define bailout(code) {gmt_M_free_options (mode); return (code);}
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
-GMT_LOCAL inline char *psconvert_alpha_bits (struct PS2RASTER_CTRL *Ctrl) {
+GMT_LOCAL inline char *psconvert_alpha_bits (struct PSCONVERT_CTRL *Ctrl) {
 	/* return alpha bits which are valid for the selected driver */
 	static char alpha[48];
 	char *c = alpha;
@@ -989,7 +989,7 @@ GMT_LOCAL inline char *psconvert_alpha_bits (struct PS2RASTER_CTRL *Ctrl) {
 	return alpha;
 }
 
-GMT_LOCAL void psconvert_possibly_fill_or_outline_BB (struct GMT_CTRL *GMT, struct PS2R_A *A, FILE *fp) {
+GMT_LOCAL void psconvert_possibly_fill_or_outline_BB (struct GMT_CTRL *GMT, struct PSCONVERT_A *A, FILE *fp) {
 	/* Check if user wanted to paint or outline the BoundingBox - otherwise do nothing */
 	char *ptr = NULL;
 	GMT->PSL->internal.dpp = PSL_DOTS_PER_INCH / 72.0;	/* Dots pr. point resolution of output device, set here since no PSL initialization */
@@ -1009,7 +1009,7 @@ GMT_LOCAL void psconvert_possibly_fill_or_outline_BB (struct GMT_CTRL *GMT, stru
 }
 
 /* ---------------------------------------------------------------------------------------------- */
-GMT_LOCAL int psconvert_pipe_HR_BB(struct GMTAPI_CTRL *API, struct PS2RASTER_CTRL *Ctrl, char *gs_BB, double margin, double *w, double *h) {
+GMT_LOCAL int psconvert_pipe_HR_BB(struct GMTAPI_CTRL *API, struct PSCONVERT_CTRL *Ctrl, char *gs_BB, double margin, double *w, double *h) {
 	/* Do what we do in the main code for the -A (if used here) option but on an in-memory PS 'file' */
 	char      cmd[GMT_LEN512] = {""}, buf[GMT_LEN128] = {""}, t[32] = {""}, *pch, c;
 	int       fh, r, c_begin = 0;
@@ -1165,7 +1165,7 @@ GMT_LOCAL int psconvert_pipe_HR_BB(struct GMTAPI_CTRL *API, struct PS2RASTER_CTR
 }
 /* ---------------------------------------------------------------------------------------------- */
 
-GMT_LOCAL int psconvert_pipe_ghost (struct GMTAPI_CTRL *API, struct PS2RASTER_CTRL *Ctrl, char *gs_params, double w, double h, char *out_file) {
+GMT_LOCAL int psconvert_pipe_ghost (struct GMTAPI_CTRL *API, struct PSCONVERT_CTRL *Ctrl, char *gs_params, double w, double h, char *out_file) {
 	/* Run the command that converts the PostScript into a raster format, but using an in-memory PS as source.
 	   For that we use the popen function to run the GS command. The biggest problem, however, is that popen only
 	   access one pipe and we need two. One for the PS input and the other for the raster output. There are popen
@@ -1339,7 +1339,7 @@ GMT_LOCAL int psconvert_pipe_ghost (struct GMTAPI_CTRL *API, struct PS2RASTER_CT
 }
 
 /* ---------------------------------------------------------------------------------------------- */
-GMT_LOCAL int psconvert_in_mem_PS(struct GMTAPI_CTRL *API, struct PS2RASTER_CTRL *Ctrl, char **ps_names, char *gs_BB, char *gs_params, char *device[], char *device_options[], char *ext[]) {
+GMT_LOCAL int psconvert_in_mem_PS(struct GMTAPI_CTRL *API, struct PSCONVERT_CTRL *Ctrl, char **ps_names, char *gs_BB, char *gs_params, char *device[], char *device_options[], char *ext[]) {
 	char out_file[PATH_MAX] = {""};
 	int    error = 0;
 	double margin = 0, w = 0, h = 0;	/* Width and height in pixels of the final raster cropped of the outer white spaces */
@@ -1518,7 +1518,7 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 	FILE *fp = NULL, *fpo = NULL, *fpb = NULL, *fp2 = NULL, *fpw = NULL;
 
 	struct GMT_OPTION *opt = NULL;
-	struct PS2RASTER_CTRL *Ctrl = NULL;
+	struct PSCONVERT_CTRL *Ctrl = NULL;
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;
 	struct GMT_OPTION *options = NULL;
 	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);	/* Cast from void to GMTAPI_CTRL pointer */
@@ -2724,7 +2724,7 @@ EXTERN_MSC int GMT_ps2raster (void *V_API, int mode, void *args) {
 }
 
 #ifdef WIN32
-GMT_LOCAL int psconvert_ghostbuster(struct GMTAPI_CTRL *API, struct PS2RASTER_CTRL *C) {
+GMT_LOCAL int psconvert_ghostbuster(struct GMTAPI_CTRL *API, struct PSCONVERT_CTRL *C) {
 	/* Search the Windows registry for the directory containing the gswinXXc.exe
 	   We do this by finding the GS_DLL that is a value of the HKLM\SOFTWARE\GPL Ghostscript\X.XX\ key
 	   Things are further complicated because Win64 has TWO registries: one 32 and the other 64 bits.

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -33,60 +33,60 @@
 #define THIS_MODULE_OPTIONS "->BJKOPRUVXYbdefhipqstxy" GMT_OPT("Ec")
 
 struct PSHISTOGRAM_CTRL {
-	struct Out {	/* -> */
+	struct PSHISTOGRAM_Out {	/* -> */
 		bool active;
 		char *file;
 	} Out;
-	struct A {	/* -A */
+	struct PSHISTOGRAM_A {	/* -A */
 		bool active;
 	} A;
-	struct C {	/* -C<cpt> */
+	struct PSHISTOGRAM_C {	/* -C<cpt> */
 		bool active;
 		char *file;
 	} C;
-	struct D {	/* -D[+r][+f<font>][+o<off>][+b] */
+	struct PSHISTOGRAM_D {	/* -D[+r][+f<font>][+o<off>][+b] */
 		bool active;
 		unsigned int mode;	/* 0 for horizontal, 1 for vertical */
 		unsigned int just;	/* 0 for top of bar, 1 for below */
 		struct GMT_FONT font;
 		double offset;
 	} D;
-	struct F {	/* -F */
+	struct PSHISTOGRAM_F {	/* -F */
 		bool active;
 	} F;
-	struct G {	/* -Gfill */
+	struct PSHISTOGRAM_G {	/* -Gfill */
 		bool active;
 		struct GMT_FILL fill;
 	} G;
-	struct I {	/* -I[o] */
+	struct PSHISTOGRAM_I {	/* -I[o] */
 		bool active;
 		unsigned int mode;
 	} I;
-	struct L {	/* -Ll|h|b */
+	struct PSHISTOGRAM_L {	/* -Ll|h|b */
 		bool active;
 		unsigned int mode;
 	} L;
-	struct N {	/* -N[<kind>]+p<pen>, <kind = 0,1,2 */
+	struct PSHISTOGRAM_N {	/* -N[<kind>]+p<pen>, <kind = 0,1,2 */
 		bool active;
 		bool selected[3];
 		struct GMT_PEN pen[3];
 	} N;
-	struct Q {	/* -Q[r] */
+	struct PSHISTOGRAM_Q {	/* -Q[r] */
 		bool active;
 		int mode;
 	} Q;
-	struct S {	/* -S */
+	struct PSHISTOGRAM_S {	/* -S */
 		bool active;
 	} S;
-	struct T {	/* -T<tmin/tmax/tinc>[+n] | -Tfile|list  */
+	struct PSHISTOGRAM_T {	/* -T<tmin/tmax/tinc>[+n] | -Tfile|list  */
 		bool active;
 		struct GMT_ARRAY T;
 	} T;
-	struct W {	/* -W<pen> */
+	struct PSHISTOGRAM_W {	/* -W<pen> */
 		bool active;
 		struct GMT_PEN pen;
 	} W;
-	struct Z {	/* -Z<type>[+w] */
+	struct PSHISTOGRAM_Z {	/* -Z<type>[+w] */
 		bool active;
 		bool weights;
 		unsigned int mode;
@@ -247,7 +247,7 @@ GMT_LOCAL int pshistogram_fill_boxes (struct GMT_CTRL *GMT, struct PSHISTOGRAM_I
 	return (0);
 }
 
-GMT_LOCAL double pshistogram_plot_boxes (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, struct GMT_PALETTE *P, struct PSHISTOGRAM_INFO *F, bool stairs, bool flip_to_y, bool draw_outline, struct GMT_PEN *pen, struct GMT_FILL *fill, bool cpt, struct D *D) {
+GMT_LOCAL double pshistogram_plot_boxes (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, struct GMT_PALETTE *P, struct PSHISTOGRAM_INFO *F, bool stairs, bool flip_to_y, bool draw_outline, struct GMT_PEN *pen, struct GMT_FILL *fill, bool cpt, struct PSHISTOGRAM_D *D) {
 	int i, index, fmode = 0, label_justify;
 	uint64_t ibox;
 	char label[GMT_LEN64] = {""};

--- a/src/psimage.c
+++ b/src/psimage.c
@@ -34,11 +34,11 @@
 #define THIS_MODULE_OPTIONS "->BJKOPRUVXYptxy" GMT_OPT("c")
 
 struct PSIMAGE_CTRL {
-	struct PSIMG_In {
+	struct PSIMAGE_In {
 		bool active;
 		char *file;
 	} In;
-	struct PSIMG_D {	/* -D[g|j|n|x]<refpoint>+w[-]<width>[/<height>][+j<justify>][+n<n_columns>[/<n_rows>]][+o<dx>[/<dy>]][+r<dpi>] */
+	struct PSIMAGE_D {	/* -D[g|j|n|x]<refpoint>+w[-]<width>[/<height>][+j<justify>][+n<n_columns>[/<n_rows>]][+o<dx>[/<dy>]][+r<dpi>] */
 		bool active;
 		struct GMT_REFPOINT *refpoint;
 		double off[2];
@@ -48,25 +48,25 @@ struct PSIMAGE_CTRL {
 		double dpi;
 		unsigned int n_columns, n_rows;
 	} D;
-	struct PSIMG_F {	/* -F[+c<clearance>][+g<fill>][+i[<off>/][<pen>]][+p[<pen>]][+r[<radius>]][+s[<dx>/<dy>/][<shade>]][+d] */
+	struct PSIMAGE_F {	/* -F[+c<clearance>][+g<fill>][+i[<off>/][<pen>]][+p[<pen>]][+r[<radius>]][+s[<dx>/<dy>/][<shade>]][+d] */
 		bool active;
 		struct GMT_MAP_PANEL *panel;
 	} F;
-	struct PSIMG_G {	/* -G<rgb>[+b|f|t] */
+	struct PSIMAGE_G {	/* -G<rgb>[+b|f|t] */
 		bool active;
 		double rgb[3][4];
 	} G;
-	struct PSIMG_I {	/* -I */
+	struct PSIMAGE_I {	/* -I */
 		bool active;
 	} I;
-	struct PSIMG_M {	/* -M */
+	struct PSIMAGE_M {	/* -M */
 		bool active;
 	} M;
 };
 
-#define PSIMG_BGD	0
-#define PSIMG_FGD	1
-#define PSIMG_TRA	2
+#define PSIMAGE_BGD	0
+#define PSIMAGE_FGD	1
+#define PSIMAGE_TRA	2
 
 GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
 	struct PSIMAGE_CTRL *C;
@@ -74,7 +74,7 @@ GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a n
 	C = gmt_M_memory (GMT, NULL, 1, struct PSIMAGE_CTRL);
 
 	/* Initialize values whose defaults are not 0/false/NULL */
-	C->G.rgb[PSIMG_FGD][0] = C->G.rgb[PSIMG_BGD][0] = C->G.rgb[PSIMG_TRA][0] = -2;	/* All turned off */
+	C->G.rgb[PSIMAGE_FGD][0] = C->G.rgb[PSIMAGE_BGD][0] = C->G.rgb[PSIMAGE_TRA][0] = -2;	/* All turned off */
 	C->D.n_columns = C->D.n_rows = 1;
 	return (C);
 }
@@ -132,7 +132,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSIMAGE_CTRL *Ctrl, struct GMT
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int n_errors = 0, n_files = 0, ind = PSIMG_FGD, k = 0;
+	unsigned int n_errors = 0, n_files = 0, ind = PSIMAGE_FGD, k = 0;
 	int n;
 	bool p_fail = false;
 	char string[GMT_LEN256] = {""}, *p = NULL;
@@ -215,28 +215,28 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSIMAGE_CTRL *Ctrl, struct GMT
 			case 'G':	/* Background/foreground color for 1-bit images */
 				Ctrl->G.active = true;
 				if ((p = strstr (opt->arg, "+b")))	/* Background color (or transparency) selected */
-					ind = PSIMG_BGD, k = 0, p[0] = '\0';
+					ind = PSIMAGE_BGD, k = 0, p[0] = '\0';
 				else if ((p = strstr (opt->arg, "+f")))	/* Foreground color (or transparency) selected */
-					ind = PSIMG_FGD, k = 0, p[0] = '\0';
+					ind = PSIMAGE_FGD, k = 0, p[0] = '\0';
 				else if ((p = strstr (opt->arg, "+t"))) {	/* Transparency color specified */
-					ind = PSIMG_TRA;	k = 0; p[0] = '\0';
+					ind = PSIMAGE_TRA;	k = 0; p[0] = '\0';
 					if (opt->arg[0] == '\0') {
 						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -G: Must specify a color when +t is used\n");
 						n_errors++;
 					}
 				}
 				else if (gmt_M_compat_check (GMT, 5)) {	/* Must check old-style arguments */
-					if (opt->arg[0] == '-' || gmt_colorname2index (GMT, opt->arg) >= 0 || !gmt_getrgb (GMT, opt->arg, Ctrl->G.rgb[PSIMG_FGD]))	/* Foreground color selected as default */
-						ind = PSIMG_FGD, k = 0;
+					if (opt->arg[0] == '-' || gmt_colorname2index (GMT, opt->arg) >= 0 || !gmt_getrgb (GMT, opt->arg, Ctrl->G.rgb[PSIMAGE_FGD]))	/* Foreground color selected as default */
+						ind = PSIMAGE_FGD, k = 0;
 					else if (opt->arg[0] == 'f')	/* Foreground color selected */
-						ind = PSIMG_FGD, k = 1;
+						ind = PSIMAGE_FGD, k = 1;
 					else if (opt->arg[0] == 'b')	/* Background color (or transparency) selected */
-						ind = PSIMG_BGD, k = 1;
+						ind = PSIMAGE_BGD, k = 1;
 					else if (opt->arg[0] == 't')	/* Transparency color specified */
-						ind = PSIMG_TRA, k = 1;
+						ind = PSIMAGE_TRA, k = 1;
 				}
 				else	/* Just -G[<color>] for foreground */
-					ind = PSIMG_FGD, k = 0;
+					ind = PSIMAGE_FGD, k = 0;
 				if (opt->arg[k] == '\0')	/* No color given means set transparency */
 					Ctrl->G.rgb[ind][0] = -1;
 				else if (opt->arg[k] == '-') {	/* - means set transparency but only in GMT 5 and earlier */
@@ -297,7 +297,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSIMAGE_CTRL *Ctrl, struct GMT
 	n_errors += gmt_M_check_condition (GMT, !p_fail && Ctrl->D.dim[GMT_X] <= 0.0 && Ctrl->D.dpi <= 0.0, "Option -D: Must specify image width (+w) or dpi (+r)\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->D.n_columns < 1 || Ctrl->D.n_rows < 1,
 			"Option -D: Must specify positive values for replication with +n\n");
-	n_errors += gmt_M_check_condition (GMT, Ctrl->G.rgb[PSIMG_FGD][0] == -1 && Ctrl->G.rgb[PSIMG_BGD][0] == -1,
+	n_errors += gmt_M_check_condition (GMT, Ctrl->G.rgb[PSIMAGE_FGD][0] == -1 && Ctrl->G.rgb[PSIMAGE_BGD][0] == -1,
 			"Option -G: Only one of fore/back-ground can be transparent for 1-bit images\n");
 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
@@ -473,10 +473,10 @@ EXTERN_MSC int GMT_psimage (void *V_API, int mode, void *args) {
 			for (n = 0; n < (size_t)(4 * I->n_indexed_colors) && I->colormap[n] >= 0; n++) colormap[n] = (unsigned char)I->colormap[n];
 			n /= 4;
 			if (n == 2 && Ctrl->G.active) {	/* Replace back or fore-ground color with color given in -G, or catch selection for transparency */
-				if (Ctrl->G.rgb[PSIMG_TRA][0] != -2) {
+				if (Ctrl->G.rgb[PSIMAGE_TRA][0] != -2) {
 					GMT_Report (API, GMT_MSG_WARNING, "Your -G<color>+t is ignored for 1-bit images; see +b/+f modifiers instead\n");
 				}
-				for (unsigned int k = PSIMG_BGD; k <= PSIMG_FGD; k++) {
+				for (unsigned int k = PSIMAGE_BGD; k <= PSIMAGE_FGD; k++) {
 					if (Ctrl->G.rgb[k][0] == -1) {	/* Want this color to be transparent */
 						has_trans = 1; r = colormap[4*k]; g = colormap[1+4*k]; b = colormap[2+4*k];
 					}
@@ -512,9 +512,9 @@ EXTERN_MSC int GMT_psimage (void *V_API, int mode, void *args) {
 
 		/* If a transparent color was found, we replace it with a unique one */
 		if (has_trans) {
-			Ctrl->G.rgb[PSIMG_TRA][0] = gmt_M_is255(r);
-			Ctrl->G.rgb[PSIMG_TRA][1] = gmt_M_is255(g);
-			Ctrl->G.rgb[PSIMG_TRA][2] = gmt_M_is255(b);
+			Ctrl->G.rgb[PSIMAGE_TRA][0] = gmt_M_is255(r);
+			Ctrl->G.rgb[PSIMAGE_TRA][1] = gmt_M_is255(g);
+			Ctrl->G.rgb[PSIMAGE_TRA][2] = gmt_M_is255(b);
 		}
 
 		picture = (unsigned char *)I->data;
@@ -548,14 +548,14 @@ EXTERN_MSC int GMT_psimage (void *V_API, int mode, void *args) {
 	}
 
 	/* Add transparent color at beginning, if requested */
-	if (Ctrl->G.rgb[PSIMG_TRA][0] < 0)
+	if (Ctrl->G.rgb[PSIMAGE_TRA][0] < 0)
 		PS_transparent = 1;
 	else if (header.depth >= 8) {
 		PS_transparent = -1;
 		j = header.depth / 8;
 		n = j * (header.width * header.height + 1);
 		buffer = gmt_M_memory (GMT, NULL, n, unsigned char);
-		for (i = 0; i < j; i++) buffer[i] = (unsigned char)rint(255 * Ctrl->G.rgb[PSIMG_TRA][i]);
+		for (i = 0; i < j; i++) buffer[i] = (unsigned char)rint(255 * Ctrl->G.rgb[PSIMAGE_TRA][i]);
 		gmt_M_memcpy (&(buffer[j]), picture, n - j, unsigned char);
 #ifdef HAVE_GDAL
 		if (GMT_Destroy_Data (API, &I) != GMT_NOERROR) {	/* If I is NULL then nothing is done */
@@ -655,10 +655,10 @@ EXTERN_MSC int GMT_psimage (void *V_API, int mode, void *args) {
 				/* Invert is opposite from what is expected. This is to match the behavior of -Gp */
 				if (Ctrl->I.active)
 					PSL_plotbitimage (PSL, x, y, Ctrl->D.dim[GMT_X], Ctrl->D.dim[GMT_Y], PSL_BL, picture,
-							header.width, header.height, Ctrl->G.rgb[PSIMG_FGD], Ctrl->G.rgb[PSIMG_BGD]);
+							header.width, header.height, Ctrl->G.rgb[PSIMAGE_FGD], Ctrl->G.rgb[PSIMAGE_BGD]);
 				else
 					PSL_plotbitimage (PSL, x, y, Ctrl->D.dim[GMT_X], Ctrl->D.dim[GMT_Y], PSL_BL, picture,
-							header.width, header.height, Ctrl->G.rgb[PSIMG_BGD], Ctrl->G.rgb[PSIMG_FGD]);
+							header.width, header.height, Ctrl->G.rgb[PSIMAGE_BGD], Ctrl->G.rgb[PSIMAGE_FGD]);
 			}
 			else
 				 PSL_plotcolorimage (PSL, x, y, Ctrl->D.dim[GMT_X], Ctrl->D.dim[GMT_Y], PSL_BL, picture,

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -35,32 +35,32 @@
 #define THIS_MODULE_OPTIONS "->BJKOPRUVXYpqt" GMT_OPT("c")
 
 struct PSLEGEND_CTRL {
-	struct PSLEGND_C {	/* -C<dx>[/<dy>] */
+	struct PSLEGEND_C {	/* -C<dx>[/<dy>] */
 		bool active;
 		double off[2];
 	} C;
-	struct PSLEGND_D {	/* -D[g|j|n|x]<refpoint>+w<width>[/<height>][+j<justify>][+l<spacing>][+o<dx>[/<dy>]] */
+	struct PSLEGEND_D {	/* -D[g|j|n|x]<refpoint>+w<width>[/<height>][+j<justify>][+l<spacing>][+o<dx>[/<dy>]] */
 		bool active;
 		struct GMT_REFPOINT *refpoint;
 		double dim[2], off[2];
 		double spacing;
 		int justify;
 	} D;
-	struct PSLEGND_F {	/* -F[+r[<radius>]][+g<fill>][+p[<pen>]][+i[<off>/][<pen>]][+s[<dx>/<dy>/][<shade>]][+d] */
+	struct PSLEGEND_F {	/* -F[+r[<radius>]][+g<fill>][+p[<pen>]][+i[<off>/][<pen>]][+s[<dx>/<dy>/][<shade>]][+d] */
 		bool active;
 		bool debug;			/* If true we draw guide lines */
 		struct GMT_MAP_PANEL *panel;
 	} F;
-	struct PSLEGND_S {	/* -S<scale> */
+	struct PSLEGEND_S {	/* -S<scale> */
 		bool active;
 		double scale;
 	} S;
-	struct PSLEGND_T {	/* -T<legendfile> */
+	struct PSLEGEND_T {	/* -T<legendfile> */
 		bool active;
 		char *file;
 	} T;
 #ifdef DEBUG
-	struct PSLEGND_DEBUG {	/* -+ */
+	struct PSLEGEND_DEBUG {	/* -+ */
 		bool active;
 	} DBG;
 #endif

--- a/src/psmask.c
+++ b/src/psmask.c
@@ -52,40 +52,40 @@ enum Mask_Modes {
 };
 
 struct PSMASK_CTRL {
-	struct C {	/* -C */
+	struct PSMASK_C {	/* -C */
 		bool active;
 	} C;
-	struct D {	/* -D<dumpfile> */
+	struct PSMASK_D {	/* -D<dumpfile> */
 		bool active;
 		char *file;
 	} D;
-	struct F {	/* -F<way> */
+	struct PSMASK_F {	/* -F<way> */
 		bool active;
 		int value;
 	} F;
-	struct G {	/* -G<fill> */
+	struct PSMASK_G {	/* -G<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} G;
-	struct L {	/* -L<file>[+i|o] */
+	struct PSMASK_L {	/* -L<file>[+i|o] */
 		bool active;
 		int mode;	/* -1 = set inside node to NaN (+i), 0 as is, +1 set outside node to NaN (+o) */
 		char *file;
 	} L;
-	struct N {	/* -N */
+	struct PSMASK_N {	/* -N */
 		bool active;
 	} N;
-	struct Q {	/* -Q<cut> */
+	struct PSMASK_Q {	/* -Q<cut> */
 		bool active;
 		unsigned int min;
 	} Q;
-	struct S {	/* -S[-|=|+]<radius>[d|e|f|k|m|M|n|s] */
+	struct PSMASK_S {	/* -S[-|=|+]<radius>[d|e|f|k|m|M|n|s] */
 		bool active;
 		int mode;	/* May be negative */
 		double radius;
 		char unit;
 	} S;
-	struct T {	/* -T */
+	struct PSMASK_T {	/* -T */
 		bool active;
 	} T;
 };

--- a/src/psrose.c
+++ b/src/psrose.c
@@ -53,62 +53,62 @@
 
 struct PSROSE_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct A {	/* -A<sector_angle>[+r] */
+	struct PSROSE_A {	/* -A<sector_angle>[+r] */
 		bool active;
 		bool rose;
 		double inc;
 	} A;
-	struct C {	/* -C<cpt> */
+	struct PSROSE_C {	/* -C<cpt> */
 		bool active;
 		char *file;
 	} C;
-	struct D {	/* -D */
+	struct PSROSE_D {	/* -D */
 		bool active;
 	} D;
-	struct E {	/* -Em|[+w]<modefile> */
+	struct PSROSE_E {	/* -Em|[+w]<modefile> */
 		bool active;
 		bool mode;
 		bool mean;
 		char *file;
 	} E;
-	struct F {	/* -F */
+	struct PSROSE_F {	/* -F */
 		bool active;
 	} F;
-	struct G {	/* -G<fill> */
+	struct PSROSE_G {	/* -G<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} G;
-	struct I {	/* -I */
+	struct PSROSE_I {	/* -I */
 		bool active;
 	} I;
-	struct L {	/* -L */
+	struct PSROSE_L {	/* -L */
 		bool active;
 		char *w, *e, *s, *n;
 	} L;
-	struct M {	/* -M[<size>][<modifiers>] */
+	struct PSROSE_M {	/* -M[<size>][<modifiers>] */
 		bool active;
 		struct GMT_SYMBOL S;
 	} M;
-	struct N {	/* -N */
+	struct PSROSE_N {	/* -N */
 		bool active;
 	} N;
-	struct Q {	/* -Q<alpha> */
+	struct PSROSE_Q {	/* -Q<alpha> */
 		bool active;
 		double value;
 	} Q;
-	struct S {	/* -S */
+	struct PSROSE_S {	/* -S */
 		bool active;
 		bool normalize;
 		double scale;	/* Get this via -JX */
 	} S;
-	struct T {	/* -T */
+	struct PSROSE_T {	/* -T */
 		bool active;
 	} T;
-	struct W {	/* -W[v]<pen> */
+	struct PSROSE_W {	/* -W[v]<pen> */
 		bool active[2];
 		struct GMT_PEN pen[2];
 	} W;
-	struct Z {	/* -Zu|<scale> */
+	struct PSROSE_Z {	/* -Zu|<scale> */
 		bool active;
 		unsigned int mode;
 		double scale;

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -60,11 +60,11 @@ enum psscale_shift {
 /* Control structure for psscale */
 
 struct PSSCALE_CTRL {
-	struct C {	/* -C<cpt> */
+	struct PSSCALE_C {	/* -C<cpt> */
 		bool active;
 		char *file;
 	} C;
-	struct D {	/* -D[g|j|n|x]<refpoint>+w<length>/<width>[+m<move>][+h][+j<justify>][+o<dx>[/<dy>]]+e[b|f][<length>][+n[<text>]] */
+	struct PSSCALE_D {	/* -D[g|j|n|x]<refpoint>+w<length>/<width>[+m<move>][+h][+j<justify>][+o<dx>[/<dy>]]+e[b|f][<length>][+n[<text>]] */
 		bool active;
 		bool horizontal;
 		bool move;
@@ -79,42 +79,42 @@ struct PSSCALE_CTRL {
 		char *etext;
 		char *opt;
 	} D;
-	struct F {	/* -F[+c<clearance>][+g<fill>][+i[<off>/][<pen>]][+p[<pen>]][+r[<radius>]][+s[<dx>/<dy>/][<shade>]][+d] */
+	struct PSSCALE_F {	/* -F[+c<clearance>][+g<fill>][+i[<off>/][<pen>]][+p[<pen>]][+r[<radius>]][+s[<dx>/<dy>/][<shade>]][+d] */
 		bool active;
 		struct GMT_MAP_PANEL *panel;
 	} F;
-	struct G {	/* -Glow/high for input CPT truncation */
+	struct PSSCALE_G {	/* -Glow/high for input CPT truncation */
 		bool active;
 		double z_low, z_high;
 	} G;
-	struct I {	/* -I[<intens>|<min_i>/<max_i>] */
+	struct PSSCALE_I {	/* -I[<intens>|<min_i>/<max_i>] */
 		bool active;
 		double min, max;
 	} I;
-	struct M {	/* -M */
+	struct PSSCALE_M {	/* -M */
 		bool active;
 	} M;
-	struct N {	/* -N<dpi>|p */
+	struct PSSCALE_N {	/* -N<dpi>|p */
 		bool active;
 		unsigned int mode;
 		double dpi;
 	} N;
-	struct L {	/* -L[i][<gap>] */
+	struct PSSCALE_L {	/* -L[i][<gap>] */
 		bool active;
 		bool interval;
 		double spacing;
 	} L;
-	struct Q {	/* -Q */
+	struct PSSCALE_Q {	/* -Q */
 		bool active;
 	} Q;
-	struct S {	/* -S */
+	struct PSSCALE_S {	/* -S */
 		bool active;
 	} S;
-	struct W {	/* -W<scale> */
+	struct PSSCALE_W {	/* -W<scale> */
 		bool active;
 		double scale;
 	} W;
-	struct Z {	/* -Z<zfile> */
+	struct PSSCALE_Z {	/* -Z<zfile> */
 		bool active;
 		char *file;
 	} Z;

--- a/src/pssolar.c
+++ b/src/pssolar.c
@@ -47,28 +47,28 @@ struct SUN_PARAMS {
 };
 
 struct PSSOLAR_CTRL {
-	struct PSSOL_C {		/* -C */
+	struct PSSOLAR_C {		/* -C */
 		bool active;
 	} C;
-	struct PSSOL_G {		/* -G<fill> */
+	struct PSSOLAR_G {		/* -G<fill> */
 		bool active;
 		bool clip;
 		struct GMT_FILL fill;
 	} G;
-	struct PSSOL_I {		/* -I info about solar stuff */
+	struct PSSOLAR_I {		/* -I info about solar stuff */
 		bool   active;
 		bool   position;
 		int    TZ;			/* Time Zone */
 		double lon, lat;
 		struct GMT_GCAL calendar;
 	} I;
-	struct PSSOL_M {		/* -M dumps the terminators data instead of plotting them */
+	struct PSSOLAR_M {		/* -M dumps the terminators data instead of plotting them */
 		bool active;
 	} M;
-	struct PSSOL_N {		/* -N */
+	struct PSSOLAR_N {		/* -N */
 		bool active;
 	} N;
-	struct PSSOL_T {		/* -T terminator options */
+	struct PSSOLAR_T {		/* -T terminator options */
 		bool   active;
 		bool   night, civil, nautical, astronomical;
 		unsigned int n_terminators;
@@ -77,7 +77,7 @@ struct PSSOLAR_CTRL {
 		double radius[4];
 		struct GMT_GCAL calendar;
 	} T;
-	struct PSSOL_W {		/* -W<pen> */
+	struct PSSOLAR_W {		/* -W<pen> */
 		bool active;
 		struct GMT_PEN pen;
 	} W;

--- a/src/pswiggle.c
+++ b/src/pswiggle.c
@@ -44,45 +44,45 @@
 #define PSWIGGLE_NEG	1
 
 struct PSWIGGLE_CTRL {
-	struct A {	/* -A[<azimuth>] */
+	struct PSWIGGLE_A {	/* -A[<azimuth>] */
 		bool active;
 		unsigned int mode;
 		double value;
 	} A;
-	struct C {	/* -C<center> */
+	struct PSWIGGLE_C {	/* -C<center> */
 		bool active;
 		double value;
 	} C;
-	struct D {	/* -D[g|j|J|n|x]<refpoint>+w<length>[+a][+j<justify>][+o<dx>[/<dy>]][+l<label>] */
+	struct PSWIGGLE_D {	/* -D[g|j|J|n|x]<refpoint>+w<length>[+a][+j<justify>][+o<dx>[/<dy>]][+l<label>] */
 		bool active;
 		struct GMT_MAP_SCALE scale;
 	} D;
-	struct F {	/* -F[+c<clearance>][+g<fill>][+i[<off>/][<pen>]][+p[<pen>]][+r[<radius>]][+s[<dx>/<dy>/][<shade>]][+d] */
+	struct PSWIGGLE_F {	/* -F[+c<clearance>][+g<fill>][+i[<off>/][<pen>]][+p[<pen>]][+r[<radius>]][+s[<dx>/<dy>/][<shade>]][+d] */
 		bool active;	/* Panel inside GMT_MAP_SCALE in -D */
 	} F;
-	struct G {	/* -G<fill>[+n][+p] */
+	struct PSWIGGLE_G {	/* -G<fill>[+n][+p] */
 		bool active[2];
 		struct GMT_FILL fill[2];
 	} G;
-	struct I {	/* -I<azimuth> */
+	struct PSWIGGLE_I {	/* -I<azimuth> */
 		bool active;
 		double value;
 	} I;
-	struct S {	/* -S[x]<lon0>/<lat0>/<length>/<units> [Backwards compatibility with GMT 5] */
+	struct PSWIGGLE_S {	/* -S[x]<lon0>/<lat0>/<length>/<units> [Backwards compatibility with GMT 5] */
 		bool active;
 		bool cartesian;
 		double lon, lat, length;
 		char *label;
 	} S;
-	struct T {	/* -T<pen> */
+	struct PSWIGGLE_T {	/* -T<pen> */
 		bool active;
 		struct GMT_PEN pen;
 	} T;
-	struct W {	/* -W<pen> */
+	struct PSWIGGLE_W {	/* -W<pen> */
 		bool active;
 		struct GMT_PEN pen;
 	} W;
-	struct Z {	/* -Z<scale> */
+	struct PSWIGGLE_Z {	/* -Z<scale> */
 		bool active;
 		double scale;
 		char unit;

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -36,30 +36,30 @@
 /* Control structure for psxyz */
 
 struct PSXYZ_CTRL {
-	struct A {	/* -A[m|y|p|x|step] */
+	struct PSXYZ_A {	/* -A[m|y|p|x|step] */
 		bool active;
 		unsigned int mode;
 		double step;
 	} A;
-	struct C {	/* -C<cpt> or -C<color1>,<color2>[,<color3>,...] */
+	struct PSXYZ_C {	/* -C<cpt> or -C<color1>,<color2>[,<color3>,...] */
 		bool active;
 		char *file;
 	} C;
-	struct D {	/* -D<dx>/<dy>[/<dz>] */
+	struct PSXYZ_D {	/* -D<dx>/<dy>[/<dz>] */
 		bool active;
 		double dx, dy, dz;
 	} D;
-	struct G {	/* -G<fill>|+z */
+	struct PSXYZ_G {	/* -G<fill>|+z */
 		bool active;
 		bool set_color;
 		struct GMT_FILL fill;
 	} G;
-	struct I {	/* -I[<intensity>] */
+	struct PSXYZ_I {	/* -I[<intensity>] */
 		bool active;
 		unsigned int mode;	/* 0 if constant, 1 if read from file (symbols only) */
 		double value;
 	} I;
-	struct L {	/* -L[+xl|r|x0][+yb|t|y0][+e|E][+p<pen>] */
+	struct PSXYZ_L {	/* -L[+xl|r|x0][+yb|t|y0][+e|E][+p<pen>] */
 		bool active;
 		bool polygon;		/* true when just -L is given */
 		int outline;		/* 1 when +p<pen> is given */
@@ -68,27 +68,27 @@ struct PSXYZ_CTRL {
 		double value;
 		struct GMT_PEN pen;
 	} L;
-	struct N {	/* -N[r|c] */
+	struct PSXYZ_N {	/* -N[r|c] */
 		bool active;
 		unsigned int mode;
 	} N;
-	struct Q {	/* -Q */
+	struct PSXYZ_Q {	/* -Q */
 		bool active;
 	} Q;
-	struct S {	/* -S */
+	struct PSXYZ_S {	/* -S */
 		bool active;
 		char *arg;
 	} S;
-	struct T {	/* -T */
+	struct PSXYZ_T {	/* -T */
 		bool active;
 	} T;
-	struct W {	/* -W<pen>[+c[l|f]][+o<offset>][+s][+v[b|e]<size><vecargs>][+z] */
+	struct PSXYZ_W {	/* -W<pen>[+c[l|f]][+o<offset>][+s][+v[b|e]<size><vecargs>][+z] */
 		bool active;
 		bool cpt_effect;
 		bool set_color;
 		struct GMT_PEN pen;
 	} W;
-	struct Z {	/* -Z<value> */
+	struct PSXYZ_Z {	/* -Z<value> */
 		bool active;
 		double value;
 		char *file;

--- a/src/sample1d.c
+++ b/src/sample1d.c
@@ -42,24 +42,24 @@
 #define INT_2D_GEO	2	/* Spherical 2-D path interpolation */
 
 struct SAMPLE1D_CTRL {
-	struct SAMP1D_Out {	/* -> */
+	struct SAMPLE1D_Out {	/* -> */
 		bool active;
 		char *file;
 	} Out;
-	struct SAMP1D_A {	/* -A[f|m|p|r|R|l][+l] */
+	struct SAMPLE1D_A {	/* -A[f|m|p|r|R|l][+l] */
 		bool active, loxo;
 		enum GMT_enum_track mode;
 	} A;
-	struct SAMP1D_F {	/* -Fl|a|c[1|2] */
+	struct SAMPLE1D_F {	/* -Fl|a|c[1|2] */
 		bool active;
 		unsigned int mode;
 		unsigned int type;
 	} F;
-	struct SAMP1D_N {	/* -N<time_col> */
+	struct SAMPLE1D_N {	/* -N<time_col> */
 		bool active;
 		unsigned int col;
 	} N;
-	struct SAMP1D_T {	/* -T<tmin/tmax/tinc>[+a|n] */
+	struct SAMPLE1D_T {	/* -T<tmin/tmax/tinc>[+a|n] */
 		bool active;
 		struct GMT_ARRAY T;
 	} T;

--- a/src/segy/pssegy.c
+++ b/src/segy/pssegy.c
@@ -50,60 +50,60 @@
 #define PLOT_OFFSET	2
 
 struct PSSEGY_CTRL {
-	struct In {	/* -In */
+	struct PSSEGY_In {	/* -In */
 		bool active;
 		char *file;
 	} In;
-	struct A {	/* -A */
+	struct PSSEGY_A {	/* -A */
 		bool active;
 	} A;
-	struct C {	/* -C<cpt> */
+	struct PSSEGY_C {	/* -C<cpt> */
 		bool active;
 		double value;
 	} C;
-	struct D {	/* -D */
+	struct PSSEGY_D {	/* -D */
 		bool active;
 		double value;
 	} D;
-	struct E {	/* -E */
+	struct PSSEGY_E {	/* -E */
 		bool active;
 		double value;
 	} E;
-	struct F {	/* -F<fill> */
+	struct PSSEGY_F {	/* -F<fill> */
 		bool active;
 		double rgb[4];
 	} F;
-	struct I {	/* -I */
+	struct PSSEGY_I {	/* -I */
 		bool active;
 	} I;
-	struct L {	/* -L */
+	struct PSSEGY_L {	/* -L */
 		bool active;
 		uint32_t value;
 	} L;
-	struct M {	/* -M */
+	struct PSSEGY_M {	/* -M */
 		bool active;
 		uint32_t value;
 	} M;
-	struct N {	/* -N */
+	struct PSSEGY_N {	/* -N */
 		bool active;
 	} N;
-	struct Q {	/* -Qb|i|u|x|y */
+	struct PSSEGY_Q {	/* -Qb|i|u|x|y */
 		bool active[5];
 		double value[5];
 	} Q;
-	struct S {	/* -S */
+	struct PSSEGY_S {	/* -S */
 		bool active;
 		unsigned int mode;
 		int value;
 	} S;
-	struct T {	/* -T */
+	struct PSSEGY_T {	/* -T */
 		bool active;
 		char *file;
 	} T;
-	struct W {	/* -W */
+	struct PSSEGY_W {	/* -W */
 		bool active;
 	} W;
-	struct Z {	/* -Z */
+	struct PSSEGY_Z {	/* -Z */
 		bool active;
 	} Z;
 };

--- a/src/segy/pssegyz.c
+++ b/src/segy/pssegyz.c
@@ -53,62 +53,62 @@
 #define PLOT_OFFSET	2
 
 struct PSSEGYZ_CTRL {
-	struct In {	/* -In */
+	struct PSSEGYZ_In {	/* -In */
 		bool active;
 		char *file;
 	} In;
-	struct A {	/* -A */
+	struct PSSEGYZ_A {	/* -A */
 		bool active;
 	} A;
-	struct C {	/* -C<cpt> */
+	struct PSSEGYZ_C {	/* -C<cpt> */
 		bool active;
 		double value;
 	} C;
-	struct D {	/* -D */
+	struct PSSEGYZ_D {	/* -D */
 		bool active;
 		double value[2];
 	} D;
-	struct E {	/* -E */
+	struct PSSEGYZ_E {	/* -E */
 		bool active;
 		double value;
 	} E;
-	struct F {	/* -F<fill> */
+	struct PSSEGYZ_F {	/* -F<fill> */
 		bool active;
 		double rgb[4];
 	} F;
-	struct I {	/* -I */
+	struct PSSEGYZ_I {	/* -I */
 		bool active;
 	} I;
-	struct L {	/* -L */
+	struct PSSEGYZ_L {	/* -L */
 		bool active;
 		int value;
 	} L;
-	struct M {	/* -M */
+	struct PSSEGYZ_M {	/* -M */
 		bool active;
 		int value;
 	} M;
-	struct N {	/* -N */
+	struct PSSEGYZ_N {	/* -N */
 		bool active;
 	} N;
-	struct Q {	/* -Qb|i|u|x|y */
+	struct PSSEGYZ_Q {	/* -Qb|i|u|x|y */
 		bool active[5];
 		double value[5];	/* b is bias, i is dpi, u is redval, x/y are trace and sample interval */
 	} Q;
-	struct S {	/* -S */
+	struct PSSEGYZ_S {	/* -S */
 		bool active;
 		bool fixed[2];
 		unsigned int mode[2];
 		int value[2];
 		double orig[2];
 	} S;
-	struct T {	/* -T */
+	struct PSSEGYZ_T {	/* -T */
 		bool active;
 		char *file;
 	} T;
-	struct W {	/* -W */
+	struct PSSEGYZ_W {	/* -W */
 		bool active;
 	} W;
-	struct Z {	/* -Z */
+	struct PSSEGYZ_Z {	/* -Z */
 		bool active;
 	} Z;
 };

--- a/src/segy/segy2grd.c
+++ b/src/segy/segy2grd.c
@@ -45,48 +45,48 @@
 #define PLOT_OFFSET	2
 
 struct SEGY2GRD_CTRL {
-	struct In {	/* -In */
+	struct SEGY2GRD_In {	/* -In */
 		bool active;
 		char *file;
 	} In;
-	struct A {	/* -A */
+	struct SEGY2GRD_A {	/* -A */
 		bool active;
 		int mode;
 	} A;
-	struct C {	/* -C<cpt> */
+	struct SEGY2GRD_C {	/* -C<cpt> */
 		bool active;
 		double value;
 	} C;
-	struct D {	/* -D */
+	struct SEGY2GRD_D {	/* -D */
 		bool active;
 		char *text;
 	} D;
-	struct G {	/* -G */
+	struct SEGY2GRD_G {	/* -G */
 		bool active;
 		char *file;
 	} G;
-	struct I {	/* -Idx[/dy] */
+	struct SEGY2GRD_I {	/* -Idx[/dy] */
 		bool active;
 		double inc[2];
 	} I;
-	struct L {	/* -L */
+	struct SEGY2GRD_L {	/* -L */
 		bool active;
 		int value;
 	} L;
-	struct M {	/* -M */
+	struct SEGY2GRD_M {	/* -M */
 		bool active;
 		unsigned int value;
 	} M;
-	struct N {	/* -N */
+	struct SEGY2GRD_N {	/* -N */
 		bool active;
 		double d_value;
 		float f_value;
 	} N;
-	struct Q {	/* -Qx|y */
+	struct SEGY2GRD_Q {	/* -Qx|y */
 		bool active[2];
 		double value[2];
 	} Q;
-	struct S {	/* -S */
+	struct SEGY2GRD_S {	/* -S */
 		bool active;
 		unsigned int mode;
 		int value;

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -49,7 +49,7 @@ PostScript code is written to stdout.
 /* Control structure for pscoupe */
 
 struct PSCOUPE_CTRL {
-	struct A {	/* -A[<params>] */
+	struct PSCOUPE_A {	/* -A[<params>] */
 		bool active, frame, polygon;
 		int fuseau;
 		char proj_type;
@@ -59,31 +59,31 @@ struct PSCOUPE_CTRL {
 		struct nodal_plane PREF;
 		char newfile[PATH_MAX], extfile[PATH_MAX];
 	} A;
- 	struct E {	/* -E<fill> */
+ 	struct PSCOUPE_E {	/* -E<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} E;
-	struct F {	/* Repeatable -F<mode>[<args>] */
+	struct PSCOUPE_F {	/* Repeatable -F<mode>[<args>] */
 		bool active;
 	} F;
- 	struct G {	/* -G<fill> */
+ 	struct PSCOUPE_G {	/* -G<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} G;
-	struct L {	/* -L<pen> */
+	struct PSCOUPE_L {	/* -L<pen> */
 		bool active;
 		struct GMT_PEN pen;
 	} L;
-	struct M {	/* -M */
+	struct PSCOUPE_M {	/* -M */
 		bool active;
 	} M;
-	struct N {	/* -N */
+	struct PSCOUPE_N {	/* -N */
 		bool active;
 	} N;
-	struct Q {	/* -Q */
+	struct PSCOUPE_Q {	/* -Q */
 		bool active;
 	} Q;
-	struct S {	/* -S<format><scale>[+a<angle>][+f<font>][+j<justify>][+o<dx>[/<dy>]] and -Fs */
+	struct PSCOUPE_S {	/* -S<format><scale>[+a<angle>][+f<font>][+j<justify>][+o<dx>[/<dy>]] and -Fs */
 		bool active;
 		bool zerotrace;
 		bool no_label;
@@ -99,16 +99,16 @@ struct PSCOUPE_CTRL {
 		struct GMT_FILL fill;
 		struct GMT_FONT font;
 	} S;
-	struct T {	/* -Tnplane[/<pen>] */
+	struct PSCOUPE_T {	/* -Tnplane[/<pen>] */
 		bool active;
 		unsigned int n_plane;
 		struct GMT_PEN pen;
 	} T;
-	struct W {	/* -W<pen> */
+	struct PSCOUPE_W {	/* -W<pen> */
 		bool active;
 		struct GMT_PEN pen;
 	} W;
-	struct Z {	/* -Z<cpt> */
+	struct PSCOUPE_Z {	/* -Z<cpt> */
 		bool active;
 		char *file;
 	} Z;

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -46,37 +46,37 @@ PostScript code is written to stdout.
 
 /* Control structure for psmeca */
 struct PSMECA_CTRL {
-	struct C {	/* -C[<pen>][+s<size>] */
+	struct PSMECA_C {	/* -C[<pen>][+s<size>] */
 		bool active;
 		double size;
 		struct GMT_PEN pen;
 	} C;
-	struct D {	/* -D<min/max> */
+	struct PSMECA_D {	/* -D<min/max> */
 		bool active;
 		double depmin, depmax;
 	} D;
-	struct E {	/* -E<fill> */
+	struct PSMECA_E {	/* -E<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} E;
-	struct F {	/* Repeatable -F<mode>[<args>] */
+	struct PSMECA_F {	/* Repeatable -F<mode>[<args>] */
 		bool active;
 	} F;
-	struct G {	/* -G<fill> */
+	struct PSMECA_G {	/* -G<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} G;
-	struct L {	/* -L<pen> */
+	struct PSMECA_L {	/* -L<pen> */
 		bool active;
 		struct GMT_PEN pen;
 	} L;
-	struct M {	/* -M */
+	struct PSMECA_M {	/* -M */
 		bool active;
 	} M;
-	struct N {	/* -N */
+	struct PSMECA_N {	/* -N */
 		bool active;
 	} N;
-	struct S {	/* -S<format><scale>[+a<angle>][+f<font>][+j<justify>][+o<dx>[/<dy>]] */
+	struct PSMECA_S {	/* -S<format><scale>[+a<angle>][+f<font>][+j<justify>][+o<dx>[/<dy>]] */
 		bool active;
 		bool no_label;
 		unsigned int readmode;
@@ -88,16 +88,16 @@ struct PSMECA_CTRL {
 		double offset[2];
 		struct GMT_FONT font;
 	} S;
-	struct T {	/* -Tnplane[/<pen>] */
+	struct PSMECA_T {	/* -Tnplane[/<pen>] */
 		bool active;
 		unsigned int n_plane;
 		struct GMT_PEN pen;
 	} T;
-	struct W {	/* -W<pen> */
+	struct PSMECA_W {	/* -W<pen> */
 		bool active;
 		struct GMT_PEN pen;
 	} W;
-	struct Z {	/* -Z<cpt> */
+	struct PSMECA_Z {	/* -Z<cpt> */
 		bool active;
 		char *file;
 	} Z;

--- a/src/seis/pspolar.c
+++ b/src/seis/pspolar.c
@@ -36,44 +36,44 @@
 /* Control structure for pspolar */
 
 struct PSPOLAR_CTRL {
-	struct C {	/* -C */
+	struct PSPOLAR_C {	/* -C */
 		bool active;
 		double lon, lat, size;
 		struct GMT_PEN pen;
 	} C;
-	struct D {	/* -D */
+	struct PSPOLAR_D {	/* -D */
 		bool active;
 		double lon, lat;
 	} D;
- 	struct E {	/* -E<fill> */
+ 	struct PSPOLAR_E {	/* -E<fill> */
 		bool active;
 		struct GMT_FILL fill;
 		struct GMT_PEN pen;
 	} E;
-	struct F {	/* -F<fill> */
+	struct PSPOLAR_F {	/* -F<fill> */
 		bool active;
 		struct GMT_FILL fill;
 		struct GMT_PEN pen;
 	} F;
- 	struct G {	/* -G<fill> */
+ 	struct PSPOLAR_G {	/* -G<fill> */
 		bool active;
 		struct GMT_FILL fill;
 		struct GMT_PEN pen;
 	} G;
-	struct M {	/* -M<scale>[+m<magnitude>] */
+	struct PSPOLAR_M {	/* -M<scale>[+m<magnitude>] */
 		bool active;
 		double ech;
 	} M;
-	struct N {	/* -N */
+	struct PSPOLAR_N {	/* -N */
 		bool active;
 	} N;
-	struct Q {	/* Repeatable: -Q<mode>[<args>] for various symbol parameters */
+	struct PSPOLAR_Q {	/* Repeatable: -Q<mode>[<args>] for various symbol parameters */
 		bool active;
 	} Q;
 	struct H2 {	/* -Qh for Hypo71 */
 		bool active;
 	} H2;
-	struct S {	/* -S<symbol><size>[c|i|p] */
+	struct PSPOLAR_S {	/* -S<symbol><size>[c|i|p] */
 		bool active;
 		int symbol;
 		double size;
@@ -92,7 +92,7 @@ struct PSPOLAR_CTRL {
 		struct GMT_FILL fill;
 		struct GMT_SYMBOL S;
 	} S2;
-	struct T { /* New syntax: -T+a<angle>+j<justify>+o<dx>/<dy>+f<font> */
+	struct PSPOLAR_T { /* New syntax: -T+a<angle>+j<justify>+o<dx>/<dy>+f<font> */
 		bool active;
 		double angle;
 		int justify;
@@ -100,7 +100,7 @@ struct PSPOLAR_CTRL {
 		struct GMT_FONT font;
 		int form; /* for back-compatibility only */
  	} T;
-	struct W {	/* -W<pen> */
+	struct PSPOLAR_W {	/* -W<pen> */
 		bool active;
 		struct GMT_PEN pen;
 	} W;

--- a/src/spectrum1d.c
+++ b/src/spectrum1d.c
@@ -87,7 +87,7 @@ struct SPECTRUM1D_INFO {	/* Control structure for spectrum1d */
 	int n_spec, window, window_2;
 	gmt_grdfloat *datac;
 	double dt, x_variance, y_variance, d_n_windows, y_pow;
-	struct SPEC {
+	struct SPECTRUM1D_SPEC {
 		double xpow;	/* PSD in X(t)  */
 		double ypow;	/* PSD in Y(t)  */
 		double gain;	/* Amplitude increase X->Y in Optimal Response Function  */
@@ -101,7 +101,7 @@ GMT_LOCAL void spectrum1d_alloc_arrays (struct GMT_CTRL *GMT, struct SPECTRUM1D_
 	C->n_spec = C->window/2;	/* This means we skip zero frequency; data are detrended  */
 	C->window_2 = 2 * C->window;		/* This is for complex array stuff  */
 
-	C->spec = gmt_M_memory (GMT, NULL, C->n_spec, struct SPEC);
+	C->spec = gmt_M_memory (GMT, NULL, C->n_spec, struct SPECTRUM1D_SPEC);
 	C->datac = gmt_M_memory (GMT, NULL, C->window_2, gmt_grdfloat);
 }
 

--- a/src/sph2grd.c
+++ b/src/sph2grd.c
@@ -42,28 +42,28 @@ enum Sph2grd_fmode {
 
 struct SPH2GRD_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct D {	/* -D */
+	struct SPH2GRD_D {	/* -D */
 		bool active;
 		char mode;
 	} D;
-	struct E {	/* -E */
+	struct SPH2GRD_E {	/* -E */
 		bool active;
 	} E;
-	struct G {	/* -G<grdfile> */
+	struct SPH2GRD_G {	/* -G<grdfile> */
 		bool active;
 		char *file;
 	} G;
-	struct F {	/* -F[k]<lc>/<lp>/<hp>/<hc> or -F[k]<lo>/<hi> */
+	struct SPH2GRD_F {	/* -F[k]<lc>/<lp>/<hp>/<hc> or -F[k]<lo>/<hi> */
 		bool active;
 		bool km;	/* True if filter was specified in km instead of harmonic degree */
 		int mode;
 		double lc, lp, hp, hc;
 	} F;
-	struct N {	/* -Ng|m|s */
+	struct SPH2GRD_N {	/* -Ng|m|s */
 		bool active;
 		char mode;
 	} N;
-	struct Q {	/* -Q */
+	struct SPH2GRD_Q {	/* -Q */
 		bool active;
 	} Q;
 };

--- a/src/sphdistance.c
+++ b/src/sphdistance.c
@@ -51,32 +51,32 @@ enum sphdist_modes {
 	SPHD_VALUES = 2};
 
 struct SPHDISTANCE_CTRL {
-	struct A {	/* -A[m|p|x|y|step] */
+	struct SPHDISTANCE_A {	/* -A[m|p|x|y|step] */
 		bool active;
 		unsigned int mode;
 		double step;
 	} A;
-	struct C {	/* -C */
+	struct SPHDISTANCE_C {	/* -C */
 		bool active;
 	} C;
-	struct E {	/* -Ed|n|z[<dist>] */
+	struct SPHDISTANCE_E {	/* -Ed|n|z[<dist>] */
 		bool active;
 		unsigned int mode;
 		double dist;
 	} E;
-	struct G {	/* -G<maskfile> */
+	struct SPHDISTANCE_G {	/* -G<maskfile> */
 		bool active;
 		char *file;
 	} G;
-	struct L {	/* -L<unit>] */
+	struct SPHDISTANCE_L {	/* -L<unit>] */
 		bool active;
 		char unit;
 	} L;
-	struct N {	/* -N */
+	struct SPHDISTANCE_N {	/* -N */
 		bool active;
 		char *file;
 	} N;
-	struct Q {	/* -Q */
+	struct SPHDISTANCE_Q {	/* -Q */
 		bool active;
 		char *file;
 	} Q;

--- a/src/sphinterpolate.c
+++ b/src/sphinterpolate.c
@@ -44,19 +44,19 @@
 #define THIS_MODULE_OPTIONS "-:RVbdehiqrs" GMT_OPT("F")
 
 struct SPHINTERPOLATE_CTRL {
-	struct G {	/* -G<grdfile> */
+	struct SPHINTERPOLATE_G {	/* -G<grdfile> */
 		bool active;
 		char *file;
 	} G;
-	struct Q {	/* -Q<interpolation> */
+	struct SPHINTERPOLATE_Q {	/* -Q<interpolation> */
 		bool active;
 		unsigned int mode;
 		double value[3];
 	} Q;
-	struct T {	/* -T for variable tension */
+	struct SPHINTERPOLATE_T {	/* -T for variable tension */
 		bool active;
 	} T;
-	struct Z {	/* -Z to scale data */
+	struct SPHINTERPOLATE_Z {	/* -Z to scale data */
 		bool active;
 	} Z;
 };

--- a/src/spotter/backtracker.c
+++ b/src/spotter/backtracker.c
@@ -88,50 +88,50 @@
 
 struct BACKTRACKER_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct A {	/* -A[young/old] */
+	struct BACKTRACKER_A {	/* -A[young/old] */
 		bool active;
 		unsigned int mode;	/* 1 specific limits for all input points, 2 if limits are in cols 4 + 5  */
 		double t_low, t_high;
 	} A;
-	struct D {	/* -Df|b */
+	struct BACKTRACKER_D {	/* -Df|b */
 		bool active;
 		unsigned int mode;		/* 1 we go FROM hotspot to seamount, 0 is reverse */
 	} D;
-	struct E {	/* -Erotfile[+i], -E<ID1>-<ID2>[+i], or -E<lon/lat/angle> */
+	struct BACKTRACKER_E {	/* -Erotfile[+i], -E<ID1>-<ID2>[+i], or -E<lon/lat/angle> */
 		bool active;
 		struct SPOTTER_ROT rot;
 	} E;
-	struct F {	/* -Fdriftfile */
+	struct BACKTRACKER_F {	/* -Fdriftfile */
 		bool active;
 		char *file;
 	} F;
-	struct L {	/* -L */
+	struct BACKTRACKER_L {	/* -L */
 		bool active;
 		unsigned int mode;	/* 0 = hotspot tracks, 1 = flowlines */
 		bool stage_id;	/* 1 returns stage id instead of ages */
 		double d_km;	/* Resampling spacing */
 	} L;
-	struct M {	/* -M[<value>] */
+	struct BACKTRACKER_M {	/* -M[<value>] */
 		bool active;
 		double value;
 	} M;
-	struct N {	/* -N */
+	struct BACKTRACKER_N {	/* -N */
 		bool active;
 		double t_upper;
 	} N;
-	struct Q {	/* -Q<tfix> */
+	struct BACKTRACKER_Q {	/* -Q<tfix> */
 		bool active;
 		double t_fix;	/* Set fixed age*/
 	} Q;
-	struct S {	/* -S */
+	struct BACKTRACKER_S {	/* -S */
 		bool active;
 		char *file;
 	} S;
-	struct T {	/* -T<tzero> */
+	struct BACKTRACKER_T {	/* -T<tzero> */
 		bool active;
 		double t_zero;	/* Set zero age*/
 	} T;
-	struct W {	/* -W<flag> */
+	struct BACKTRACKER_W {	/* -W<flag> */
 		bool active;
 		char mode;
 	} W;

--- a/src/spotter/gmtpmodeler.c
+++ b/src/spotter/gmtpmodeler.c
@@ -47,28 +47,28 @@
 
 struct GMTPMODELER_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct In {
+	struct GMTPMODELER_In {
 		bool active;
 		char *file;
 	} In;
-	struct E {	/* -E[+]rotfile, -E[+]<ID1>-<ID2>, or -E<lon/lat/angle> */
+	struct GMTPMODELER_E {	/* -E[+]rotfile, -E[+]<ID1>-<ID2>, or -E<lon/lat/angle> */
 		bool active;
 		struct SPOTTER_ROT rot;
 	} E;
-	struct F {	/* -Fpolfile */
+	struct GMTPMODELER_F {	/* -Fpolfile */
 		bool active;
 		char *file;
 	} F;
-	struct N {	/* -N */
+	struct GMTPMODELER_N {	/* -N */
 		bool active;
 		double t_upper;
 	} N;
-	struct S {	/* -Sa|d|s|v|w|x|y|X|Y */
+	struct GMTPMODELER_S {	/* -Sa|d|s|v|w|x|y|X|Y */
 		bool active, center;
 		unsigned int mode[N_PM_ITEMS];
 		unsigned int n_items;
 	} S;
-	struct T {	/* -T<fixtime> */
+	struct GMTPMODELER_T {	/* -T<fixtime> */
 		bool active;
 		double value;
 	} T;

--- a/src/spotter/grdpmodeler.c
+++ b/src/spotter/grdpmodeler.c
@@ -47,32 +47,32 @@
 
 struct GRDROTATER_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct In {
+	struct GRDPMODELER_In {
 		bool active;
 		char *file;
 	} In;
-	struct E {	/* -E[+]rotfile, -E[+]<ID1>-<ID2>, or -E<lon/lat/angle> */
+	struct GRDPMODELER_E {	/* -E[+]rotfile, -E[+]<ID1>-<ID2>, or -E<lon/lat/angle> */
 		bool active;
 		struct SPOTTER_ROT rot;
 	} E;
-	struct F {	/* -Fpolfile */
+	struct GRDPMODELER_F {	/* -Fpolfile */
 		bool active;
 		char *file;
 	} F;
-	struct G {	/* -Goutfile */
+	struct GRDPMODELER_G {	/* -Goutfile */
 		bool active;
 		char *file;
 	} G;
-	struct N {	/* -N */
+	struct GRDPMODELER_N {	/* -N */
 		bool active;
 		double t_upper;
 	} N;
-	struct S {	/* -Sa|d|s|v|w|x|y|X|Y */
+	struct GRDPMODELER_S {	/* -Sa|d|s|v|w|x|y|X|Y */
 		bool active, center;
 		unsigned int mode[N_PM_ITEMS];
 		unsigned int n_items;
 	} S;
-	struct T {	/* -T<fixtime> */
+	struct GRDPMODELER_T {	/* -T<fixtime> */
 		bool active;
 		double value;
 	} T;

--- a/src/spotter/grdrotater.c
+++ b/src/spotter/grdrotater.c
@@ -37,37 +37,37 @@
 
 struct GRDROTATER_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct In {
+	struct GRDROTATER_In {
 		bool active;
 		char *file;
 	} In;
-	struct A {	/* -Aw/e/s/n */
+	struct GRDROTATER_A {	/* -Aw/e/s/n */
 		bool active;
 		double wesn[4];
 	} A;
-	struct D {	/* -Drotpolfile or -Dtemplate */
+	struct GRDROTATER_D {	/* -Drotpolfile or -Dtemplate */
 		bool active;
 		char *file;
 	} D;
-	struct E {	/* -E[+]rotfile, -E[+]<ID1>-<ID2>, or -E<lon/lat/angle> */
+	struct GRDROTATER_E {	/* -E[+]rotfile, -E[+]<ID1>-<ID2>, or -E<lon/lat/angle> */
 		bool active;
 		struct SPOTTER_ROT rot;
 	} E;
-	struct F {	/* -Fpolfile */
+	struct GRDROTATER_F {	/* -Fpolfile */
 		bool active;
 		char *file;
 	} F;
-	struct G {	/* -Goutfile or -Gtemplate*/
+	struct GRDROTATER_G {	/* -Goutfile or -Gtemplate*/
 		bool active;
 		char *file;
 	} G;
-	struct N {	/* -N */
+	struct GRDROTATER_N {	/* -N */
 		bool active;
 	} N;
-	struct S {	/* -S */
+	struct GRDROTATER_S {	/* -S */
 		bool active;
 	} S;
-	struct T {	/* -T<time>, -T<start/stop/inc> or -T<tfile.txt> */
+	struct GRDROTATER_T {	/* -T<time>, -T<start/stop/inc> or -T<tfile.txt> */
 		bool active;
 		unsigned int n_times;	/* Number of reconstruction times */
 		double *value;	/* Array with one or more reconstruction times */

--- a/src/spotter/grdspotter.c
+++ b/src/spotter/grdspotter.c
@@ -119,43 +119,43 @@
 
 struct GRDSPOTTER_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct In {
+	struct GRDSPOTTER_In {
 		bool active;
 		char *file;
 	} In;
-	struct A {	/* -A<file> */
+	struct GRDSPOTTER_A {	/* -A<file> */
 		bool active;
 		char *file;
 	} A;
-	struct D {	/* -Di<file> */
+	struct GRDSPOTTER_D {	/* -Di<file> */
 		bool active;
 		char *file;
 	} D;
-	struct E {	/* -E[+rotfile */
+	struct GRDSPOTTER_E {	/* -E[+rotfile */
 		bool active;
 		bool mode;
 		char *file;
 	} E;
-	struct G {	/* -Ggrdfile */
+	struct GRDSPOTTER_G {	/* -Ggrdfile */
 		bool active;	/* Pixel registration */
 		char *file;
 	} G;
-	struct L {	/* -Lfile */
+	struct GRDSPOTTER_L {	/* -Lfile */
 		bool active;
 		char *file;
 	} L;
-	struct M {	/* -M */
+	struct GRDSPOTTER_M {	/* -M */
 		bool active;
 	} M;
-	struct N {	/* -N */
+	struct GRDSPOTTER_N {	/* -N */
 		bool active;
 		double t_upper;
 	} N;
-	struct PA {	/* -Dp<file> */
+	struct GRDSPOTTER_PA {	/* -Dp<file> */
 		bool active;
 		char *file;
 	} PA;
-	struct Q {	/* -Q */
+	struct GRDSPOTTER_Q {	/* -Q */
 		bool active;
 		unsigned int mode;
 		unsigned int id;
@@ -165,18 +165,18 @@ struct GRDSPOTTER_CTRL {	/* All control options for this program (except common 
 		bool active;
 		double dist;
 	} S2;
-	struct S {	/* -S */
+	struct GRDSPOTTER_S {	/* -S */
 		bool active;
 	} S;
-	struct T {	/* -T */
+	struct GRDSPOTTER_T {	/* -T */
 		bool active[2];
 		double t_fix;	/* Set fixed age*/
 	} T;
-	struct W {	/* -W */
+	struct GRDSPOTTER_W {	/* -W */
 		bool active;
 		unsigned int n_try;
 	} W;
-	struct Z {	/* -Z */
+	struct GRDSPOTTER_Z {	/* -Z */
 		bool active;
 		bool mode;
 		double min, max, inc;
@@ -537,7 +537,7 @@ EXTERN_MSC int GMT_grdspotter (void *V_API, int mode, void *args) {
 
 	struct FLOWLINE *flowline = NULL;	/* Array with flowline structures */
 
-	struct ID {			/* Information regarding one chain ID */
+	struct GRDSPOTTER_ID {			/* Information regarding one chain ID */
 		double wesn[4];		/* Do not calculate flowlines outside this box */
 		bool ok;		/* true if we want to calculate this CVA */
 		bool check_region;	/* true if w, e, s, n is more restrictive than command line -R */
@@ -660,7 +660,7 @@ EXTERN_MSC int GMT_grdspotter (void *V_API, int mode, void *args) {
 		ID = gmt_M_memory (GMT, NULL, L->header->size, int);
 		for (ij = 0; ij < L->header->size; ij++) ID[ij] = irint ((double)L->data[ij]);
 		if (GH->alloc_mode == GMT_ALLOC_INTERNALLY) gmt_M_free_aligned (GMT, L->data);	/* Just free the array since we use ID; Grid struct is destroyed at end */
-		ID_info = gmt_M_memory (GMT, NULL, lrint (L->header->z_max) + 1, struct ID);
+		ID_info = gmt_M_memory (GMT, NULL, lrint (L->header->z_max) + 1, struct GRDSPOTTER_ID);
 		if (Ctrl->Q.mode == 1) {	/* Only doing one CVA with no extra restrictions */
 			ID_info[Ctrl->Q.id].ok = true;	/* Every other info in struct array is NULL or 0 */
 		}

--- a/src/spotter/hotspotter.c
+++ b/src/spotter/hotspotter.c
@@ -135,28 +135,28 @@
 
 struct HOTSPOTTER_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct D {	/* -D<factor> */
+	struct HOTSPOTTER_D {	/* -D<factor> */
 		bool active;
 		double value;	/* Resampling factor */
 	} D;
-	struct E {	/* -E[+]rotfile */
+	struct HOTSPOTTER_E {	/* -E[+]rotfile */
 		bool active;
 		bool mode;
 		char *file;
 	} E;
-	struct G {	/* -Goutfile */
+	struct HOTSPOTTER_G {	/* -Goutfile */
 		bool active;
 		char *file;
 	} G;
-	struct N {	/* -N */
+	struct HOTSPOTTER_N {	/* -N */
 		bool active;
 		double t_upper;
 	} N;
-	struct S {	/* -S */
+	struct HOTSPOTTER_S {	/* -S */
 		bool active;
 		char *file;
 	} S;
-	struct T {	/* -T<tzero> */
+	struct HOTSPOTTER_T {	/* -T<tzero> */
 		bool active;
 		double t_zero;	/* Set zero age*/
 	} T;

--- a/src/spotter/originater.c
+++ b/src/spotter/originater.c
@@ -134,45 +134,45 @@ struct HOTSPOT_ORIGINATOR {
 
 struct ORIGINATOR_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct D {	/* -D<factor */
+	struct ORIGINATER_D {	/* -D<factor */
 		bool active;
 		double value;
 	} D;
-	struct E {	/* -Erotfile[+i] */
+	struct ORIGINATER_E {	/* -Erotfile[+i] */
 		bool active;
 		bool mode;
 		char *file;
 	} E;
-	struct F {	/* -Fhotspotfile[+d] */
+	struct ORIGINATER_F {	/* -Fhotspotfile[+d] */
 		bool active;
 		bool mode;
 		char *file;
 	} F;
-	struct L {	/* -L */
+	struct ORIGINATER_L {	/* -L */
 		bool active;
 		unsigned int mode;
 		bool degree;	/* Report degrees */
 	} L;
-	struct N {	/* -N */
+	struct ORIGINATER_N {	/* -N */
 		bool active;
 		double t_upper;
 	} N;
-	struct Q {	/* -Q<tfix> */
+	struct ORIGINATER_Q {	/* -Q<tfix> */
 		bool active;
 		double t_fix, r_fix;
 	} Q;
-	struct S {	/* -S */
+	struct ORIGINATER_S {	/* -S */
 		bool active;
 		unsigned int n;
 	} S;
-	struct T {	/* -T */
+	struct ORIGINATER_T {	/* -T */
 		bool active;
 	} T;
-	struct W {	/* -W<max_dist> */
+	struct ORIGINATER_W {	/* -W<max_dist> */
 		bool active;
 		double dist;
 	} W;
-	struct Z {	/* -Z */
+	struct ORIGINATER_Z {	/* -Z */
 		bool active;
 	} Z;
 };

--- a/src/spotter/polespotter.c
+++ b/src/spotter/polespotter.c
@@ -31,31 +31,31 @@
 
 struct POLESPOTTER_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct A {	/* -A<abyssalhilefile> */
+	struct POLESPOTTER_A {	/* -A<abyssalhilefile> */
 		bool active;
 		char *file;
 		double weight;
 	} A;
-	struct D {	/* -D<spacing> */
+	struct POLESPOTTER_D {	/* -D<spacing> */
 		bool active;
 		double length;
 	} D;
-	struct E {	/* -Ea|f<sigma> */
+	struct POLESPOTTER_E {	/* -Ea|f<sigma> */
 		bool active;
 	} E;
-	struct F {	/* -F<fzfile> */
+	struct POLESPOTTER_F {	/* -F<fzfile> */
 		bool active;
 		char *file;
 		double weight;
 	} F;
-	struct G {	/* -Goutfile */
+	struct POLESPOTTER_G {	/* -Goutfile */
 		bool active;
 		char *file;
 	} G;
-	struct N {	/* -N */
+	struct POLESPOTTER_N {	/* -N */
 		bool active;
 	} N;
-	struct S {	/* -Ss|l|p[<modifiers>] */
+	struct POLESPOTTER_S {	/* -Ss|l|p[<modifiers>] */
 		bool active;
 		bool dump_lines;
 		bool dump_crossings;

--- a/src/spotter/rotconverter.c
+++ b/src/spotter/rotconverter.c
@@ -74,33 +74,33 @@
 
 struct ROTCONVERTER_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct A {	/* -A */
+	struct ROTCONVERTER_A {	/* -A */
 		bool active;
 	} A;
-	struct D {	/* -D */
+	struct ROTCONVERTER_D {	/* -D */
 		bool active;
 	} D;
-	struct F {	/* -F */
+	struct ROTCONVERTER_F {	/* -F */
 		bool active;
 		bool mode;	/* out mode (true if total reconstruction rotations) */
 	} F;
-	struct G {	/* -G */
+	struct ROTCONVERTER_G {	/* -G */
 		bool active;
 	} G;
-	struct M {	/* -M[<value>] */
+	struct ROTCONVERTER_M {	/* -M[<value>] */
 		bool active;
 		double value;
 	} M;
-	struct N {	/* -N */
+	struct ROTCONVERTER_N {	/* -N */
 		bool active;
 	} N;
-	struct S {	/* -S */
+	struct ROTCONVERTER_S {	/* -S */
 		bool active;
 	} S;
-	struct T {	/* -T */
+	struct ROTCONVERTER_T {	/* -T */
 		bool active;
 	} T;
-	struct W {	/* -W */
+	struct ROTCONVERTER_W {	/* -W */
 		bool active;
 	} W;
 };

--- a/src/spotter/rotsmoother.c
+++ b/src/spotter/rotsmoother.c
@@ -45,27 +45,27 @@
 
 struct ROTSMOOTHER_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
-	struct A {	/* -A */
+	struct ROTSMOOTHER_A {	/* -A */
 		bool active;
 	} A;
-	struct C {	/* -C */
+	struct ROTSMOOTHER_C {	/* -C */
 		bool active;
 	} C;
-	struct N {	/* -N */
+	struct ROTSMOOTHER_N {	/* -N */
 		bool active;
 	} N;
-	struct S {	/* -S */
+	struct ROTSMOOTHER_S {	/* -S */
 		bool active;
 	} S;
-	struct T {	/* -T<time>, -T<start/stop/inc> or -T<tfile.txt> */
+	struct ROTSMOOTHER_T {	/* -T<time>, -T<start/stop/inc> or -T<tfile.txt> */
 		bool active;
 		unsigned int n_times;	/* Number of reconstruction times */
 		double *value;	/* Array with one or more reconstruction times */
 	} T;
-	struct W {	/* -W */
+	struct ROTSMOOTHER_W {	/* -W */
 		bool active;
 	} W;
-	struct Z {	/* -Z */
+	struct ROTSMOOTHER_Z {	/* -Z */
 		bool active;
 	} Z;
 };
@@ -77,7 +77,7 @@ struct ROTSMOOTHER_CTRL {	/* All control options for this program (except common
 #define K_WEIGHT	4
 #define N_ITEMS		5
 
-struct AGEROT {
+struct ROTSMOOTHER_AGEROT {
 	double wxyasn[N_ITEMS];
 	double P[3];	/* For Cartesian components */
 	double Q[4];	/* For quaternion components */
@@ -236,10 +236,10 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct ROTSMOOTHER_CTRL *Ctrl, struct
 }
 
 GMT_LOCAL int rotsmoother_compare_ages (const void *point_1v, const void *point_2v) {
-	struct AGEROT *point_1, *point_2;
+	struct ROTSMOOTHER_AGEROT *point_1, *point_2;
 
-	point_1 = (struct AGEROT *)point_1v;
-	point_2 = (struct AGEROT *)point_2v;
+	point_1 = (struct ROTSMOOTHER_AGEROT *)point_1v;
+	point_2 = (struct ROTSMOOTHER_AGEROT *)point_2v;
 	if (point_1->wxyasn[K_AGE] < point_2->wxyasn[K_AGE]) return (-1);
 	if (point_1->wxyasn[K_AGE] > point_2->wxyasn[K_AGE]) return (+1);
 	return (0);
@@ -262,7 +262,7 @@ EXTERN_MSC int GMT_rotsmoother (void *V_API, int mode, void *args) {
 	double x_in_plane[3], y_in_plane[3], C[9], EigenValue[3], EigenVector[9], work1[3], work2[3];
 	double R[3][3], DR[3][3], Ri[3][3], E[3], this_h[3], xyz_mean_pole[3], xyz_mean_quat[4], z_unit_vector[3];
 	double mean_rot_age, std_rot_age, *H[3], mean_H[3], Ccopy[9], *mangle = NULL, this_lon, this_lat;
-	struct AGEROT *D = NULL;
+	struct ROTSMOOTHER_AGEROT *D = NULL;
 	struct GMT_RECORD *In = NULL, *Out = NULL;
 	struct ROTSMOOTHER_CTRL *Ctrl = NULL;
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;
@@ -310,7 +310,7 @@ EXTERN_MSC int GMT_rotsmoother (void *V_API, int mode, void *args) {
 	}
 	t_col = (Ctrl->A.active) ? GMT_Z : 3;	/* If no time we use angle as proxy for time */
 	w_col = t_col + 1;
-	D = (struct AGEROT *) gmt_M_memory (GMT, NULL, n_alloc, struct AGEROT);
+	D = (struct ROTSMOOTHER_AGEROT *) gmt_M_memory (GMT, NULL, n_alloc, struct ROTSMOOTHER_AGEROT);
 	Out = gmt_new_record (GMT, out, NULL);	/* Since we only need to worry about numerics in this module */
 
 	do {	/* Keep returning records until we reach EOF */
@@ -341,11 +341,11 @@ EXTERN_MSC int GMT_rotsmoother (void *V_API, int mode, void *args) {
 		n_read++;
 		if (n_read == n_alloc) {	/* Need larger arrays */
 			n_alloc <<= 1;
-			D = gmt_M_memory (GMT, D, n_alloc, struct AGEROT);
+			D = gmt_M_memory (GMT, D, n_alloc, struct ROTSMOOTHER_AGEROT);
 		}
 	} while (true);
 
-	if (n_read < n_alloc) D = gmt_M_memory (GMT, D, n_read, struct AGEROT);
+	if (n_read < n_alloc) D = gmt_M_memory (GMT, D, n_read, struct ROTSMOOTHER_AGEROT);
 
 	if (GMT_End_IO (API, GMT_IN,  0) != GMT_NOERROR) {	/* Disables further data input */
 		gmt_M_free (GMT, D);
@@ -383,7 +383,7 @@ EXTERN_MSC int GMT_rotsmoother (void *V_API, int mode, void *args) {
 
 	/* Sort the entire dataset on increasing ages */
 
-	qsort (D, n_read, sizeof (struct AGEROT), rotsmoother_compare_ages);
+	qsort (D, n_read, sizeof (struct ROTSMOOTHER_AGEROT), rotsmoother_compare_ages);
 
 	if (GMT->common.h.add_colnames) {	/* Create meaningful column header */
 		static char *short_header = "lon\tlat\ttime\tangle";

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -68,14 +68,14 @@
 #define SUBPLOT_PLACE_AT_BOTH	3
 
 struct SUBPLOT_CTRL {
-	struct In {	/* begin | end | set */
+	struct SUBPLOT_In {	/* begin | end | set */
 		bool active;
 		bool next;
 		bool no_B;
 		unsigned int mode;	/* SUBPLOT_BEGIN|SUBPLOT_SET|SUBPLOT_END*/
 		int row, col;		/* Current (row,col) subplot */
 	} In;
-	struct A {	/* -A[<letter>|<number>][+c<clearance>][+g<fill>][+j|J<pos>][+o<offset>][+p<pen>][+r|R][+v] */
+	struct SUBPLOT_A {	/* -A[<letter>|<number>][+c<clearance>][+g<fill>][+j|J<pos>][+o<offset>][+p<pen>][+r|R][+v] */
 		bool active;			/* Want to plot subplot tags */
 		char format[GMT_LEN128];	/* Format for plotting tag (or constant string when done via subplot set) */
 		char fill[GMT_LEN64];		/* Color fill for optional rectangle behind the tag [none] */
@@ -90,11 +90,11 @@ struct SUBPLOT_CTRL {
 		double off[2];			/* Offset from placement location [20% of font size] */
 		double clearance[2];		/* Padding around text for rectangle behind the tag [15%] */
 	} A;
-	struct C {	/* -C[side]<clearance>  */
+	struct SUBPLOT_C {	/* -C[side]<clearance>  */
 		bool active;
 		double gap[4];	/* Internal margins (in inches) on the 4 sides [0/0/0/0] */
 	} C;
-	struct F {	/* -F[f|s][<width>/<height>][+f<wfracs/hfracs>][+p<pen>][+g<fill>][+c<clearance>][+d][+w<pen>] */
+	struct SUBPLOT_F {	/* -F[f|s][<width>/<height>][+f<wfracs/hfracs>][+p<pen>][+g<fill>][+c<clearance>][+d][+w<pen>] */
 		bool active;
 		bool lines;
 		bool debug;		/* Draw red faint lines to illustrate the result of space partitioning */
@@ -107,7 +107,7 @@ struct SUBPLOT_CTRL {
 		char pen[GMT_LEN64];	/* Pen outline for the entire figure canvas */
 		char Lpen[GMT_LEN64];	/* Pen to draw midlines */
 	} F;
-	struct S {	/* -S[C|R]<layout> */
+	struct SUBPLOT_S {	/* -S[C|R]<layout> */
 		bool active;
 		bool has_label;		/* True if we want y labels */
 		char axes[4];		/* W|e|w|e|l|r for -SR,  S|s|N|n|b|t for -SC [Default is MAP_FRAME_AXES] */
@@ -119,16 +119,16 @@ struct SUBPLOT_CTRL {
 		unsigned tick;		/* 1 if only l|r or t|b, 0 for both */
 		unsigned parallel;	/* 1 if we want axis parallel annotations */
 	} S[2];
-	struct M {	/* -M<margin> | <xmargin>/<ymargin>  | <wmargin>/<emargin>/<smargin>/<nmargin>  */
+	struct SUBPLOT_M {	/* -M<margin> | <xmargin>/<ymargin>  | <wmargin>/<emargin>/<smargin>/<nmargin>  */
 		bool active;
 		double margin[4];
 	} M;
-	struct N {	/* NrowsxNcolumns (is not used as -N<> but without the option which is just internal) */
+	struct SUBPLOT_N {	/* NrowsxNcolumns (is not used as -N<> but without the option which is just internal) */
 		bool active;
 		unsigned int dim[2];		/* nrows, rcols */
 		unsigned int n_subplots;	/* The product of the two dims */
 	} N;
-	struct T {	/* -T<figuretitle> */
+	struct SUBPLOT_T {	/* -T<figuretitle> */
 		bool active;
 		char *title;	/* Title above the entire set of subplots */
 	} T;

--- a/src/surface.c
+++ b/src/surface.c
@@ -52,62 +52,62 @@
 #define THIS_MODULE_OPTIONS "-:RVabdefhiqrs" GMT_ADD_x_OPT GMT_OPT("FH")
 
 struct SURFACE_CTRL {
-	struct SRF_A {	/* -A<aspect_ratio> */
+	struct SURFACE_A {	/* -A<aspect_ratio> */
 		bool active;
 		unsigned int mode;	/* 1 if given as fraction */
 		double value;
 	} A;
-	struct SRF_C {	/* -C<converge_limit> */
+	struct SURFACE_C {	/* -C<converge_limit> */
 		bool active;
 		unsigned int mode;	/* 1 if given as fraction */
 		double value;
 	} C;
-	struct SRF_D {	/* -D<line.xyz>[+d][+z[<zval>]] */
+	struct SURFACE_D {	/* -D<line.xyz>[+d][+z[<zval>]] */
 		bool active;
 		bool debug;
 		bool fix_z;
 		double z;
 		char *file;	/* Name of file with breaklines */
 	} D;
-	struct SRF_G {	/* -G<file> */
+	struct SURFACE_G {	/* -G<file> */
 		bool active;
 		char *file;
 	} G;
-	struct SRF_J {	/* -G<file> */
+	struct SURFACE_J {	/* -G<file> */
 		bool active;
 		char *projstring;
 	} J;
-	struct SRF_L {	/* -Ll|u<limit> */
+	struct SURFACE_L {	/* -Ll|u<limit> */
 		bool active;
 		char *file[2];
 		double limit[2];
 		unsigned int mode[2];
 	} L;
-	struct SRF_M {	/* -M<radius> */
+	struct SURFACE_M {	/* -M<radius> */
 		bool active;
 		char *arg;
 	} M;
-	struct SRF_N {	/* -N<max_iterations> */
+	struct SURFACE_N {	/* -N<max_iterations> */
 		bool active;
 		unsigned int value;
 	} N;
-	struct SRF_Q {	/* -Q */
+	struct SURFACE_Q {	/* -Q */
 		bool active;
 	} Q;
-	struct SRF_S {	/* -S<radius>[m|s] */
+	struct SURFACE_S {	/* -S<radius>[m|s] */
 		bool active;
 		double radius;
 		char unit;
 	} S;
-	struct SRF_T {	/* -T<tension>[i][b] */
+	struct SURFACE_T {	/* -T<tension>[i][b] */
 		bool active;
 		double b_tension, i_tension;
 	} T;
-	struct SRF_W {	/* -W[<logfile>] */
+	struct SURFACE_W {	/* -W[<logfile>] */
 		bool active;
 		char *file;
 	} W;
-	struct SRF_Z {	/* -Z<over_relaxation_parameter> */
+	struct SURFACE_Z {	/* -Z<over_relaxation_parameter> */
 		bool active;
 		double value;
 	} Z;

--- a/src/surface_experimental.c
+++ b/src/surface_experimental.c
@@ -53,63 +53,63 @@
 #define THIS_MODULE_OPTIONS "-:RVabdefhirs" GMT_ADD_x_OPT GMT_OPT("FH")
 
 struct SURFACE_CTRL {
-	struct A {	/* -A<aspect_ratio> */
+	struct SURFACE_EXPERIMENTAL_A {	/* -A<aspect_ratio> */
 		bool active;
 		unsigned int mode;	/* 1 if given as fraction */
 		double value;
 	} A;
-	struct C {	/* -C<converge_limit> */
+	struct SURFACE_EXPERIMENTAL_C {	/* -C<converge_limit> */
 		bool active;
 		unsigned int mode;	/* 1 if given as fraction */
 		double value;
 	} C;
-	struct D {	/* -D<line.xyz>[+d] */
+	struct SURFACE_EXPERIMENTAL_D {	/* -D<line.xyz>[+d] */
 		bool active;
 		bool debug;
 		char *file;	/* Name of file with breaklines */
 	} D;
 #ifdef DEBUG_SURF
-	struct E {	/* -E[+o|p|m+1+a+s][<name>] */
+	struct SURFACE_EXPERIMENTAL_E {	/* -E[+o|p|m+1+a+s][<name>] */
 		bool active;
 		bool once;
 		bool save;
 	} E;
 #endif
-	struct G {	/* -G<file> */
+	struct SURFACE_EXPERIMENTAL_G {	/* -G<file> */
 		bool active;
 		char *file;
 	} G;
-	struct L {	/* -Ll|u<limit> */
+	struct SURFACE_EXPERIMENTAL_L {	/* -Ll|u<limit> */
 		bool active;
 		char *file[2];
 		double limit[2];
 		unsigned int mode[2];
 	} L;
-	struct M {	/* -M<radius> */
+	struct SURFACE_EXPERIMENTAL_M {	/* -M<radius> */
 		bool active;
 		char *arg;
 	} M;
-	struct N {	/* -N<max_iterations> */
+	struct SURFACE_EXPERIMENTAL_N {	/* -N<max_iterations> */
 		bool active;
 		unsigned int value;
 	} N;
-	struct Q {	/* -Q */
+	struct SURFACE_EXPERIMENTAL_Q {	/* -Q */
 		bool active;
 	} Q;
-	struct S {	/* -S<radius>[m|s] */
+	struct SURFACE_EXPERIMENTAL_S {	/* -S<radius>[m|s] */
 		bool active;
 		double radius;
 		char unit;
 	} S;
-	struct T {	/* -T<tension>[i][b] */
+	struct SURFACE_EXPERIMENTAL_T {	/* -T<tension>[i][b] */
 		bool active;
 		double b_tension, i_tension;
 	} T;
-	struct W {	/* -W[<logfile>] */
+	struct SURFACE_EXPERIMENTAL_W {	/* -W[<logfile>] */
 		bool active;
 		char *file;
 	} W;
-	struct Z {	/* -Z<over_relaxation_parameter> */
+	struct SURFACE_EXPERIMENTAL_Z {	/* -Z<over_relaxation_parameter> */
 		bool active;
 		double value;
 	} Z;

--- a/src/surface_old.c
+++ b/src/surface_old.c
@@ -49,47 +49,47 @@
 #define THIS_MODULE_OPTIONS "-:RVabdefhirs" GMT_OPT("FH")
 
 struct SURFACE_CTRL {
-	struct A {	/* -A<aspect_ratio>|m */
+	struct SURFACE_OLD_A {	/* -A<aspect_ratio>|m */
 		bool active;
 		unsigned int mode;	/* 1 if we want cos(mid_latitude) */
 		double value;
 	} A;
-	struct C {	/* -C<converge_limit> */
+	struct SURFACE_OLD_C {	/* -C<converge_limit> */
 		bool active;
 		unsigned int mode;	/* 1 if given as fraction */
 		double value;
 	} C;
-	struct D {	/* -D<line.xyz> */
+	struct SURFACE_OLD_D {	/* -D<line.xyz> */
 		bool active;
 		char *file;	/* Name of file with breaklines */
 	} D;
-	struct G {	/* -G<file> */
+	struct SURFACE_OLD_G {	/* -G<file> */
 		bool active;
 		char *file;
 	} G;
-	struct L {	/* -Ll|u<limit> */
+	struct SURFACE_OLD_L {	/* -Ll|u<limit> */
 		bool active;
 		char *low, *high;
 		double min, max;
 		unsigned int lmode, hmode;
 	} L;
-	struct N {	/* -N<max_iterations> */
+	struct SURFACE_OLD_N {	/* -N<max_iterations> */
 		bool active;
 		unsigned int value;
 	} N;
-	struct Q {	/* -Q */
+	struct SURFACE_OLD_Q {	/* -Q */
 		bool active;
 	} Q;
-	struct S {	/* -S<radius>[m|s] */
+	struct SURFACE_OLD_S {	/* -S<radius>[m|s] */
 		bool active;
 		double radius;
 		char unit;
 	} S;
-	struct T {	/* -T<tension>[i][b] */
+	struct SURFACE_OLD_T {	/* -T<tension>[i][b] */
 		bool active;
 		double b_tension, i_tension;
 	} T;
-	struct Z {	/* -Z<over_relaxation_parameter> */
+	struct SURFACE_OLD_Z {	/* -Z<over_relaxation_parameter> */
 		bool active;
 		double value;
 	} Z;

--- a/src/trend1d.c
+++ b/src/trend1d.c
@@ -99,23 +99,23 @@ struct TREND1D_CTRL {
 	unsigned int n_outputs;
 	bool weighted_output;
 	unsigned int model_parameters;	/* 0 = no output, 1 = polynomial output (users), 2 = polynomial output (normalized), 3 = Chebyshev (normalized) */
-	struct C {	/* -C<condition_#> */
+	struct TREND1D_C {	/* -C<condition_#> */
 		bool active;
 		double value;
 	} C;
-	struct F {	/* -F<xymrw> */
+	struct TREND1D_F {	/* -F<xymrw> */
 		bool active;
 		char col[TREND1D_N_OUTPUT_CHOICES];	/* Character codes for desired output in the right order */
 	} F;
-	struct I {	/* -I[<confidence>] */
+	struct TREND1D_I {	/* -I[<confidence>] */
 		bool active;
 		double value;
 	} I;
-	struct N {	/*  -N[p|P|f|F|c|C|s|S|x|X]<list-of-terms>[,...][+l<length>][+o<origin>][+r] */
+	struct TREND1D_N {	/*  -N[p|P|f|F|c|C|s|S|x|X]<list-of-terms>[,...][+l<length>][+o<origin>][+r] */
 		bool active;
 		struct GMT_MODEL M;
 	} N;
-	struct W {	/* -W[+s] */
+	struct TREND1D_W {	/* -W[+s] */
 		bool active;
 		unsigned int mode;
 	} W;

--- a/src/trend2d.c
+++ b/src/trend2d.c
@@ -46,25 +46,25 @@
 struct TREND2D_CTRL {
 	unsigned int n_outputs;
 	bool weighted_output;
-	struct C {	/* -C<condition_#> */
+	struct TREND2D_C {	/* -C<condition_#> */
 		bool active;
 		double value;
 	} C;
-	struct F {	/* -F<xymrw>|p */
+	struct TREND2D_F {	/* -F<xymrw>|p */
 		bool active;
 		bool report;
 		char col[TREND2D_N_OUTPUT_CHOICES];	/* Character codes for desired output in the right order */
 	} F;
-	struct I {	/* -I[<confidence>] */
+	struct TREND2D_I {	/* -I[<confidence>] */
 		bool active;
 		double value;
 	} I;
-	struct N {	/* -N<n_model>[r] */
+	struct TREND2D_N {	/* -N<n_model>[r] */
 		bool active;
 		bool robust;
 		unsigned int value;
 	} N;
-	struct W {	/* -W[+s] */
+	struct TREND2D_W {	/* -W[+s] */
 		bool active;
 		unsigned int mode;
 	} W;

--- a/src/triangulate.c
+++ b/src/triangulate.c
@@ -42,48 +42,48 @@
 #define THIS_MODULE_OPTIONS "-:>JRVbdefhiqrs" GMT_OPT("Hm")
 
 struct TRIANGULATE_CTRL {
-	struct Out {	/* -> */
+	struct TRIANGULATE_Out {	/* -> */
 		bool active;
 		char *file;
 	} Out;
-	struct C {	/* -C<input_slope_grid> */
+	struct TRIANGULATE_C {	/* -C<input_slope_grid> */
 		bool active;
 		char *file;
 	} C;
-	struct D {	/* -Dx|y */
+	struct TRIANGULATE_D {	/* -Dx|y */
 		bool active;
 		unsigned int dir;
 	} D;
-	struct E {	/* -E<value> */
+	struct TRIANGULATE_E {	/* -E<value> */
 		bool active;
 		double value;
 	} E;
-	struct F {	/* -F<pregrid>[+d] */
+	struct TRIANGULATE_F {	/* -F<pregrid>[+d] */
 		bool active;
 		char *file;
 		unsigned int mode;
 	} F;
-	struct G {	/* -G<output_grdfile> */
+	struct TRIANGULATE_G {	/* -G<output_grdfile> */
 		bool active;
 		char *file;
 	} G;
-	struct M {	/* -M */
+	struct TRIANGULATE_M {	/* -M */
 		bool active;
 	} M;
-	struct N {	/* -N */
+	struct TRIANGULATE_N {	/* -N */
 		bool active;
 	} N;
-	struct Q {	/* -Q[n] */
+	struct TRIANGULATE_Q {	/* -Q[n] */
 		bool active;
 		unsigned int mode;
 	} Q;
-	struct S {	/* -S */
+	struct TRIANGULATE_S {	/* -S */
 		bool active;
 	} S;
-	struct T {	/* -T */
+	struct TRIANGULATE_T {	/* -T */
 		bool active;
 	} T;
-	struct Z {	/* -Z */
+	struct TRIANGULATE_Z {	/* -Z */
 		bool active;
 	} Z;
 };

--- a/src/x2sys/x2sys_binlist.c
+++ b/src/x2sys/x2sys_binlist.c
@@ -42,19 +42,19 @@
 /* Control structure for x2sys_binlist */
 
 struct X2SYS_BINLIST_CTRL {
-	struct D {	/* -D */
+	struct X2SYS_BINLIST_D {	/* -D */
 		bool active;
 	} D;
-	struct E {	/* -E */
+	struct X2SYS_BINLIST_E {	/* -E */
 		bool active;
 	} E;
-	struct T {	/* -T */
+	struct X2SYS_BINLIST_T {	/* -T */
 		bool active;
 		char *TAG;
 	} T;
 };
 
-struct BINCROSS {
+struct X2SYS_BINLIST_BINCROSS {
 	double x, y, d;
 };
 
@@ -163,7 +163,7 @@ GMT_LOCAL unsigned int x2sysbinlist_get_data_flag (double *data[], uint64_t j, s
 }
 
 GMT_LOCAL int x2sysbinlist_comp_bincross (const void *p1, const void *p2) {
-	const struct BINCROSS *a = p1, *b = p2;
+	const struct X2SYS_BINLIST_BINCROSS *a = p1, *b = p2;
 
 	if (a->d < b->d) return (-1);
 	if (a->d > b->d) return (+1);
@@ -196,7 +196,7 @@ EXTERN_MSC int GMT_x2sys_binlist (void *V_API, int mode, void *args) {
 	struct X2SYS_INFO *s = NULL;
 	struct X2SYS_FILE_INFO p;		/* File information */
 	struct X2SYS_BIX B;
-	struct BINCROSS *X = NULL;
+	struct X2SYS_BINLIST_BINCROSS *X = NULL;
 	struct X2SYS_BINLIST_CTRL *Ctrl = NULL;
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;
 	struct GMT_OPTION *options = NULL;
@@ -281,7 +281,7 @@ EXTERN_MSC int GMT_x2sys_binlist (void *V_API, int mode, void *args) {
 	jump_180 = irint (180.0 / B.inc[GMT_X]);
 	jump_360 = irint (360.0 / B.inc[GMT_X]);
 
-	X = gmt_M_memory (GMT, NULL, nx_alloc, struct BINCROSS);
+	X = gmt_M_memory (GMT, NULL, nx_alloc, struct X2SYS_BINLIST_BINCROSS);
 
 	if (Ctrl->D.active) {
 		gmt_init_distaz (GMT, s->unit[X2SYS_DIST_SELECTION][0], s->dist_flag, GMT_MAP_DIST);
@@ -425,7 +425,7 @@ EXTERN_MSC int GMT_x2sys_binlist (void *V_API, int mode, void *args) {
 					nx++;
 					if (nx == nx_alloc) {
 						nx_alloc <<= 1;
-						X = gmt_M_memory (GMT, X, nx_alloc, struct BINCROSS);
+						X = gmt_M_memory (GMT, X, nx_alloc, struct X2SYS_BINLIST_BINCROSS);
 					}
 				}
 				for (bcol = start_col; bcol <= end_col; bcol++) {	/* If we go in here we think dx is non-zero (we do a last-ditch dx check just in case) */
@@ -442,13 +442,13 @@ EXTERN_MSC int GMT_x2sys_binlist (void *V_API, int mode, void *args) {
 					nx++;
 					if (nx == nx_alloc) {
 						nx_alloc <<= 1;
-						X = gmt_M_memory (GMT, X, nx_alloc, struct BINCROSS);
+						X = gmt_M_memory (GMT, X, nx_alloc, struct X2SYS_BINLIST_BINCROSS);
 					}
 				}
 
 				/* Here we have 1 or more intersections */
 
-				qsort (X, nx, sizeof (struct BINCROSS), x2sysbinlist_comp_bincross);
+				qsort (X, nx, sizeof (struct X2SYS_BINLIST_BINCROSS), x2sysbinlist_comp_bincross);
 
 				for (curr_x_pt = 1, prev_x_pt = 0; curr_x_pt < nx; curr_x_pt++, prev_x_pt++) {	/* Process the intervals, getting mid-points and using that to get bin */
 					dx = X[curr_x_pt].x - X[prev_x_pt].x;

--- a/src/x2sys/x2sys_cross.c
+++ b/src/x2sys/x2sys_cross.c
@@ -88,7 +88,7 @@ struct X2SYS_CROSS_CTRL {
 	} Z;
 };
 
-struct PAIR {				/* Used with -Kkombinations.lis option */
+struct X2SYS_CROSS_PAIR {				/* Used with -Kkombinations.lis option */
 	char *id1, *id2;
 };
 
@@ -279,7 +279,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct X2SYS_CROSS_CTRL *Ctrl, struct
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
 
-GMT_LOCAL int x2syscross_combo_ok (char *name_1, char *name_2, struct PAIR *pair, uint64_t n_pairs) {
+GMT_LOCAL int x2syscross_combo_ok (char *name_1, char *name_2, struct X2SYS_CROSS_PAIR *pair, uint64_t n_pairs) {
 	uint64_t i;
 
 	/* Return true if this particular combination is found in the list of pairs */
@@ -291,10 +291,10 @@ GMT_LOCAL int x2syscross_combo_ok (char *name_1, char *name_2, struct PAIR *pair
 	return (false);
 }
 
-GMT_LOCAL void x2syscross_free_pairs (struct GMT_CTRL *GMT, struct PAIR **pair, uint64_t n_pairs) {
+GMT_LOCAL void x2syscross_free_pairs (struct GMT_CTRL *GMT, struct X2SYS_CROSS_PAIR **pair, uint64_t n_pairs) {
 	/* Free the array of pairs */
 	uint64_t k;
-	struct PAIR *P = *pair;
+	struct X2SYS_CROSS_PAIR *P = *pair;
 	for (k = 0; k < n_pairs; k++) {
 		gmt_M_str_free (P[k].id1);
 		gmt_M_str_free (P[k].id2);
@@ -403,7 +403,7 @@ EXTERN_MSC int GMT_x2sys_cross (void *V_API, int mode, void *args) {
 	struct GMT_XOVER XC;				/* Structure with resulting crossovers */
 	struct X2SYS_FILE_INFO data_set[2];		/* File information */
 	struct X2SYS_BIX Bix;
-	struct PAIR *pair = NULL;			/* Used with -Akombinations.lis option */
+	struct X2SYS_CROSS_PAIR *pair = NULL;			/* Used with -Akombinations.lis option */
 	FILE *fp = NULL, *fpC = NULL;
 	struct GMT_RECORD *Out = NULL;
 	struct X2SYS_CROSS_CTRL *Ctrl = NULL;
@@ -484,7 +484,7 @@ EXTERN_MSC int GMT_x2sys_cross (void *V_API, int mode, void *args) {
 		}
 
 		n_alloc = add_chunk = GMT_CHUNK;
-		pair = gmt_M_memory (GMT, NULL, n_alloc, struct PAIR);
+		pair = gmt_M_memory (GMT, NULL, n_alloc, struct X2SYS_CROSS_PAIR);
 
 		while (fgets (line, GMT_BUFSIZ, fp)) {
 
@@ -503,8 +503,8 @@ EXTERN_MSC int GMT_x2sys_cross (void *V_API, int mode, void *args) {
 				size_t old_n_alloc = n_alloc;
 				add_chunk *= 2;
 				n_alloc += add_chunk;
-				pair = gmt_M_memory (GMT, pair, n_alloc, struct PAIR);
-				gmt_M_memset (&(pair[old_n_alloc]), n_alloc - old_n_alloc, struct PAIR);
+				pair = gmt_M_memory (GMT, pair, n_alloc, struct X2SYS_CROSS_PAIR);
+				gmt_M_memset (&(pair[old_n_alloc]), n_alloc - old_n_alloc, struct X2SYS_CROSS_PAIR);
 			}
 		}
 		fclose (fp);
@@ -513,7 +513,7 @@ EXTERN_MSC int GMT_x2sys_cross (void *V_API, int mode, void *args) {
 			GMT_Report (API, GMT_MSG_ERROR, "No combinations found in file %s!\n", Ctrl->A.file);
 			Crashout (GMT_RUNTIME_ERROR);
 		}
-		if (n_pairs < n_alloc) pair = gmt_M_memory (GMT, pair, n_pairs, struct PAIR);
+		if (n_pairs < n_alloc) pair = gmt_M_memory (GMT, pair, n_pairs, struct X2SYS_CROSS_PAIR);
 		GMT_Report (API, GMT_MSG_INFORMATION, "%" PRIu64 "\n", n_pairs);
 	}
 

--- a/src/x2sys/x2sys_datalist.c
+++ b/src/x2sys/x2sys_datalist.c
@@ -38,28 +38,28 @@
 #define THIS_MODULE_OPTIONS "->RVbd"
 
 struct X2SYS_DATALIST_CTRL {
-	struct A {	/* -A */
+	struct X2SYS_DATALIST_A {	/* -A */
 		bool active;
 	} A;
-	struct E {	/* -E */
+	struct X2SYS_DATALIST_E {	/* -E */
 		bool active;
 	} E;
-	struct F {	/* -F */
+	struct X2SYS_DATALIST_F {	/* -F */
 		bool active;
 		char *flags;
 	} F;
-	struct I {	/* -I */
+	struct X2SYS_DATALIST_I {	/* -I */
 		bool active;
 		char *file;
 	} I;
-	struct L {	/* -L */
+	struct X2SYS_DATALIST_L {	/* -L */
 		bool active;
 		char *file;
 	} L;
-	struct S {	/* -S */
+	struct X2SYS_DATALIST_S {	/* -S */
 		bool active;
 	} S;
-	struct T {	/* -T */
+	struct X2SYS_DATALIST_T {	/* -T */
 		bool active;
 		char *TAG;
 	} T;

--- a/src/x2sys/x2sys_init.c
+++ b/src/x2sys/x2sys_init.c
@@ -41,39 +41,39 @@
 EXTERN_MSC void x2sys_set_home (struct GMT_CTRL *GMT);
 
 struct X2SYS_INIT_CTRL {
-	struct In {	/*  */
+	struct X2SYS_INIT_In {	/*  */
 		bool active;
 		char *TAG;
 	} In;
-	struct C {	/* -C [Deprecated, now use -j] */
+	struct X2SYS_INIT_C {	/* -C [Deprecated, now use -j] */
 		bool active;
 		char *string;
 	} C;
-	struct D {	/* -D */
+	struct X2SYS_INIT_D {	/* -D */
 		bool active;
 		char *file;
 	} D;
-	struct E {	/* -E */
+	struct X2SYS_INIT_E {	/* -E */
 		bool active;
 		char *string;
 	} E;
-	struct F {	/* -F */
+	struct X2SYS_INIT_F {	/* -F */
 		bool active;
 	} F;
-	struct G {	/* -G */
+	struct X2SYS_INIT_G {	/* -G */
 		bool active;
 		char *string;
 	} G;
-	struct I {	/* -I */
+	struct X2SYS_INIT_I {	/* -I */
 		bool active;
 		double inc[2];
 		char *string;
 	} I;
-	struct N {	/* -N */
+	struct X2SYS_INIT_N {	/* -N */
 		bool active[2];
 		char *string[2];
 	} N;
-	struct W {	/* -W */
+	struct X2SYS_INIT_W {	/* -W */
 		bool active[2];
 		char *string[2];
 	} W;

--- a/src/x2sys/x2sys_merge.c
+++ b/src/x2sys/x2sys_merge.c
@@ -35,11 +35,11 @@
 #define THIS_MODULE_OPTIONS "->V"
 
 struct X2SYS_MERGE_CTRL {
-	struct A {	/* -A */
+	struct X2SYS_MERGE_A {	/* -A */
 		bool active;
 		char *file;
 	} A;
-	struct M {	/* -M */
+	struct X2SYS_MERGE_M {	/* -M */
 		bool active;
 		char *file;
 	} M;

--- a/src/x2sys/x2sys_put.c
+++ b/src/x2sys/x2sys_put.c
@@ -41,20 +41,20 @@
 #define THIS_MODULE_OPTIONS "->V"
 
 struct X2SYS_PUT_CTRL {
-	struct In {	/* -In */
+	struct X2SYS_PUT_In {	/* -In */
 		bool active;
 		char *file;
 	} In;
-	struct D {	/* -D */
+	struct X2SYS_PUT_D {	/* -D */
 		bool active;
 	} D;
-	struct F {	/* -F */
+	struct X2SYS_PUT_F {	/* -F */
 		bool active;
 	} F;
-	struct S {	/* -S */
+	struct X2SYS_PUT_S {	/* -S */
 		bool active;
 	} S;
-	struct T {	/* -T */
+	struct X2SYS_PUT_T {	/* -T */
 		bool active;
 		char *TAG;
 	} T;

--- a/src/x2sys/x2sys_report.c
+++ b/src/x2sys/x2sys_report.c
@@ -40,38 +40,38 @@
 #define XREPORT_INTERNAL	2
 
 struct X2SYS_REPORT_CTRL {
-	struct In {
+	struct X2SYS_REPORT_In {
 		bool active;
 		char *file;
 	} In;
-	struct A {	/* -A */
+	struct X2SYS_REPORT_A {	/* -A */
 		bool active;
 	} A;
-	struct C {	/* -C */
+	struct X2SYS_REPORT_C {	/* -C */
 		bool active;
 		char *col;
 	} C;
-	struct I {	/* -I */
+	struct X2SYS_REPORT_I {	/* -I */
 		bool active;
 		char *file;
 	} I;
-	struct L {	/* -L */
+	struct X2SYS_REPORT_L {	/* -L */
 		bool active;
 		char *file;
 	} L;
-	struct N {	/* -N */
+	struct X2SYS_REPORT_N {	/* -N */
 		bool active;
 		uint64_t min;
 	} N;
-	struct Q {	/* -Q */
+	struct X2SYS_REPORT_Q {	/* -Q */
 		bool active;
 		int mode;
 	} Q;
-	struct S {	/* -S */
+	struct X2SYS_REPORT_S {	/* -S */
 		bool active;
 		char *file;
 	} S;
-	struct T {	/* -T */
+	struct X2SYS_REPORT_T {	/* -T */
 		bool active;
 		char *TAG;
 	} T;

--- a/src/xyz2grd.c
+++ b/src/xyz2grd.c
@@ -35,28 +35,28 @@
 #define THIS_MODULE_OPTIONS "-:JRVbdefhiqrs" GMT_OPT("FH")
 
 struct XYZ2GRD_CTRL {
-	struct In {
+	struct XYZ2GRD_In {
 		bool active;
 		char *file;
 	} In;
-	struct A {	/* -A[f|l|n|m|r|s|u|z] */
+	struct XYZ2GRD_A {	/* -A[f|l|n|m|r|s|u|z] */
 		bool active;
 		char mode;
 	} A;
-	struct D {	/* -D[+x<xname>][+yyname>][+z<zname>][+s<scale>][+ooffset>][+n<invalid>][+t<title>][+r<remark>] */
+	struct XYZ2GRD_D {	/* -D[+x<xname>][+yyname>][+z<zname>][+s<scale>][+ooffset>][+n<invalid>][+t<title>][+r<remark>] */
 		bool active;
 		char *information;
 	} D;
-	struct E {	/* -E[<nodata>] */
+	struct XYZ2GRD_E {	/* -E[<nodata>] */
 		bool active;
 		bool set;
 		double nodata;
 	} E;
-	struct G {	/* -G<output_grdfile> */
+	struct XYZ2GRD_G {	/* -G<output_grdfile> */
 		bool active;
 		char *file;
 	} G;
-	struct S {	/* -S */
+	struct XYZ2GRD_S {	/* -S */
 		bool active;
 		char *file;
 	} S;


### PR DESCRIPTION
I.e., use struct PSXY_A instead of struct A.  That way it is unique across the modules.  Closes #3198.

It is possible a few more needs work since some where already renamed but did not use the full name, e.g. SRF_A instead of SURFACE_A.  If anyone wants to hunt down the ones I miss please do.