### PR TITLE
Rename module substructure to be unique, continued

### DIFF
--- a/src/gmt2kml.c
+++ b/src/gmt2kml.c
@@ -121,7 +121,7 @@ struct GMT2KML_CTRL {
 		double value[2];
 		double scale;
 	} Q;
-	struct R2 {	/* -R */
+	struct GMT2KML_R2 {	/* -R */
 		bool active;
 		bool automatic;
 	} R2;

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -106,7 +106,7 @@ struct GREENSPLINE_CTRL {
 		double az;
 		double dir[3];
 	} Q;
-	struct R3 {	/* -Rxmin/xmax[/ymin/ymax[/zmin/zmaz]] | -Ggridfile */
+	struct GREENSPLINE_R3 {	/* -Rxmin/xmax[/ymin/ymax[/zmin/zmaz]] | -Ggridfile */
 		bool active;
 		bool mode;		/* true if settings came from a grid file */
 		unsigned int dimension;	/* 1, 2, or 3 */

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -112,28 +112,28 @@ struct PSCOUPE_CTRL {
 		bool active;
 		char *file;
 	} Z;
-	struct A2 {	/* -Fa[size[/Psymbol[Tsymbol]]] */
+	struct PSCOUPE_A2 {	/* -Fa[size[/Psymbol[Tsymbol]]] */
 		bool active;
 		char P_symbol, T_symbol;
 		double size;
 	} A2;
-	struct E2 {	/* -Fe<fill> */
+	struct PSCOUPE_E2 {	/* -Fe<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} E2;
- 	struct G2 {	/* -Fg<fill> */
+ 	struct PSCOUPE_G2 {	/* -Fg<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} G2;
- 	struct P2 {	/* -Fp[<pen>] */
+ 	struct PSCOUPE_P2 {	/* -Fp[<pen>] */
 		bool active;
 		struct GMT_PEN pen;
 	} P2;
-	struct R2 {	/* -Fr[<fill>] */
+	struct PSCOUPE_R2 {	/* -Fr[<fill>] */
 		bool active;
 		struct GMT_FILL fill;
 	} R2;
- 	struct T2 {	/* -Ft[<pen>] */
+ 	struct PSCOUPE_T2 {	/* -Ft[<pen>] */
 		bool active;
 		struct GMT_PEN pen;
 	} T2;

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -101,35 +101,35 @@ struct PSMECA_CTRL {
 		bool active;
 		char *file;
 	} Z;
-	struct A2 {	/* -Fa[size[/Psymbol[Tsymbol]]] */
+	struct PSMECA_A2 {	/* -Fa[size[/Psymbol[Tsymbol]]] */
 		bool active;
 		char P_symbol, T_symbol;
 		double size;
 	} A2;
-	struct E2 {	/* -Fe<fill> */
+	struct PSMECA_E2 {	/* -Fe<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} E2;
-	struct G2 {	/* -Fg<fill> */
+	struct PSMECA_G2 {	/* -Fg<fill> */
 		bool active;
 		struct GMT_FILL fill;
 	} G2;
-	struct P2 {	/* -Fp[<pen>] */
+	struct PSMECA_P2 {	/* -Fp[<pen>] */
 		bool active;
 		struct GMT_PEN pen;
 	} P2;
-	struct R2 {	/* -Fr[<fill>] */
+	struct PSMECA_R2 {	/* -Fr[<fill>] */
 		bool active;
 		struct GMT_FILL fill;
 	} R2;
-	struct T2 {	/* -Ft[<pen>] */
+	struct PSMECA_T2 {	/* -Ft[<pen>] */
 		bool active;
 		struct GMT_PEN pen;
 	} T2;
-	struct O2 {	/* -Fo */
+	struct PSMECA_O2 {	/* -Fo */
 		bool active;
 	} O2;
-	struct Z2 {	/* -Fz[<pen>] */
+	struct PSMECA_Z2 {	/* -Fz[<pen>] */
 		bool active;
 		struct GMT_PEN pen;
 	} Z2;

--- a/src/seis/pspolar.c
+++ b/src/seis/pspolar.c
@@ -70,7 +70,7 @@ struct PSPOLAR_CTRL {
 	struct PSPOLAR_Q {	/* Repeatable: -Q<mode>[<args>] for various symbol parameters */
 		bool active;
 	} Q;
-	struct H2 {	/* -Qh for Hypo71 */
+	struct PSPOLAR_H2 {	/* -Qh for Hypo71 */
 		bool active;
 	} H2;
 	struct PSPOLAR_S {	/* -S<symbol><size>[c|i|p] */
@@ -79,7 +79,7 @@ struct PSPOLAR_CTRL {
 		double size;
 		struct GMT_FILL fill;
 	} S;
-	struct S2 {	/* -Qs<half-size>[+v<size>[+<specs>] */
+	struct PSPOLAR_S2 {	/* -Qs<half-size>[+v<size>[+<specs>] */
 		bool active;
 		bool scolor;
 		bool vector;

--- a/src/spotter/grdspotter.c
+++ b/src/spotter/grdspotter.c
@@ -161,7 +161,7 @@ struct GRDSPOTTER_CTRL {	/* All control options for this program (except common 
 		unsigned int id;
 		char *file;
 	} Q;
-	struct S2 {	/* -S2 */
+	struct GRDSPOTTER_S2 {	/* -S2 */
 		bool active;
 		double dist;
 	} S2;


### PR DESCRIPTION
Further work on module substructure renaming. 

Related to #3198.