### PR TITLE
Outward rounding grd

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -2257,7 +2257,9 @@ int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_
 			snprintf (format, GMT_LEN256, "w reset from %s to %s\n",
 			          GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, format, wesn[XLO], val);
-			wesn[XLO] = val;
+			//wesn[XLO] = val;
+			wesn[XLO] = val - header->inc[GMT_X];
+			if (wesn[XLO] < header->wesn[XLO]) val += header->inc[GMT_X];
 		}
 
 		val = header->wesn[XLO] + lrint ((wesn[XHI] - header->wesn[XLO]) * HH->r_inc[GMT_X]) * header->inc[GMT_X];
@@ -2269,7 +2271,9 @@ int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_
 			snprintf (format, GMT_LEN256, "e reset from %s to %s\n",
 			          GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, format, wesn[XHI], val);
-			wesn[XHI] = val;
+			//wesn[XHI] = val;
+			wesn[XHI] = val + header->inc[GMT_X];
+			if (wesn[XHI] > header->wesn[XHI]) val -= header->inc[GMT_X];
 		}
 	}
 
@@ -2283,7 +2287,9 @@ int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_
 		snprintf (format, GMT_LEN256, "s reset from %s to %s\n",
 		          GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, format, wesn[YLO], val);
-		wesn[YLO] = val;
+		//wesn[YLO] = val;
+		wesn[YLO] = val - header->inc[GMT_Y];
+		if (wesn[YLO] < header->wesn[YLO]) val += header->inc[GMT_Y];
 	}
 
 	val = header->wesn[YLO] + lrint ((wesn[YHI] - header->wesn[YLO]) * HH->r_inc[GMT_Y]) * header->inc[GMT_Y];
@@ -2293,7 +2299,9 @@ int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_
 		snprintf (format, GMT_LEN256, "n reset from %s to %s\n",
 		          GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, format, wesn[YHI], val);
-		wesn[YHI] = val;
+		//wesn[YHI] = val;
+		wesn[YHI] = val + header->inc[GMT_Y];
+		if (wesn[YHI] > header->wesn[YHI]) val -= header->inc[GMT_Y];
 	}
 	return (GMT_NOERROR);
 }

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -2245,6 +2245,9 @@ int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_
 	if (error)
 		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Region exceeds grid domain. Region reduced to grid domain.\n");
 
+	/* If new region is not an exact match with grid increment we ensure we extend the region outwards to cover the desired
+	 * region.  However, if that takes us outside the grid's region then we backtrack back in */
+
 	if (!(gmt_M_x_is_lon (GMT, GMT_IN) && gmt_M_360_range (wesn[XLO], wesn[XHI]) && global)) {    /* Do this unless a 360 longitude wrap */
 		small = GMT_CONV4_LIMIT * header->inc[GMT_X];
 
@@ -2257,7 +2260,6 @@ int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_
 			snprintf (format, GMT_LEN256, "w reset from %s to %s\n",
 			          GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, format, wesn[XLO], val);
-			//wesn[XLO] = val;
 			wesn[XLO] = val - header->inc[GMT_X];
 			if (wesn[XLO] < header->wesn[XLO]) val += header->inc[GMT_X];
 		}
@@ -2271,7 +2273,6 @@ int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_
 			snprintf (format, GMT_LEN256, "e reset from %s to %s\n",
 			          GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, format, wesn[XHI], val);
-			//wesn[XHI] = val;
 			wesn[XHI] = val + header->inc[GMT_X];
 			if (wesn[XHI] > header->wesn[XHI]) val -= header->inc[GMT_X];
 		}
@@ -2287,7 +2288,6 @@ int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_
 		snprintf (format, GMT_LEN256, "s reset from %s to %s\n",
 		          GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, format, wesn[YLO], val);
-		//wesn[YLO] = val;
 		wesn[YLO] = val - header->inc[GMT_Y];
 		if (wesn[YLO] < header->wesn[YLO]) val += header->inc[GMT_Y];
 	}
@@ -2299,7 +2299,6 @@ int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_
 		snprintf (format, GMT_LEN256, "n reset from %s to %s\n",
 		          GMT->current.setting.format_float_out, GMT->current.setting.format_float_out);
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, format, wesn[YHI], val);
-		//wesn[YHI] = val;
 		wesn[YHI] = val + header->inc[GMT_Y];
 		if (wesn[YHI] > header->wesn[YHI]) val -= header->inc[GMT_Y];
 	}


### PR DESCRIPTION
**Description of proposed changes**

When we request a subset of a grid via **-R** we check to see if the new bounds are multiples of the grid spacing.  If not we adjust the requested region.  However, we did this by shrinking the domain inwards.  That meant a plot of the subset with the originally requested region would have thin slivers of unpainted areas where the subset did not cover. This was highlighted by #3206 which actually has two problems of which the first will be fixed by this PR.  Now, we extend the region to the next increment outwards.  Of course, if that exceeds the grids bounds then we retract to the actual grid boundary.  The corrections are all done in function _gmt_adjust_loose_wesn_.
All tests still pass and it fixes the gap in #3206.