### PR TITLE
Fix #include

### DIFF
--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -62,7 +62,7 @@
 
 #include "gmt_dev.h"
 #include "gmt_internals.h"
-#include "netcdf.h"
+#include <netcdf.h>
 
 /* Declaration modifier for netcdf DLL support
  * annoying: why can't netcdf.h do this on its own? */

--- a/src/gmt_ogrproj.c
+++ b/src/gmt_ogrproj.c
@@ -21,8 +21,8 @@
  * Date:	17-Aug-2017
  */
 
-#include "gdal.h"
-#include "ogr_srs_api.h"
+#include <gdal.h>
+#include <ogr_srs_api.h>
 
 OGRCoordinateTransformationH gmt_OGRCoordinateTransformation(struct GMT_CTRL *GMT, const char *pSrcSRS, const char *pDstSRS) {
     /* pSrcSRS and pDstSRS are pointers to strings defining the Source and Destination Referencing

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -72,7 +72,7 @@ char *file_to_delete_if_ctrl_C;
 #endif
 
 static char *all_grid_files[GMT_N_DATASETS]= {
-#include <gmt_datasets.h>
+#include "gmt_datasets.h"
 };
 
 GMT_LOCAL void gmtremote_delete_file_then_exit (int sig_no) {
@@ -474,7 +474,7 @@ unsigned int gmt_download_file_if_not_found (struct GMT_CTRL *GMT, const char* f
 
 	if (GMT->current.setting.auto_download == GMT_NO_DOWNLOAD && (gmt_M_file_is_remotedata (file_name) || gmt_M_file_is_cache (file_name) || gmt_M_file_is_url (file_name))) {  /* Not allowed to use remote copying */
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Remote download is currently deactivated\n");
-		return 0; 
+		return 0;
 	}
 	if (GMT->current.io.internet_error) return 0;   			/* Not able to use remote copying in this session */
 

--- a/src/gmt_shore.h
+++ b/src/gmt_shore.h
@@ -36,7 +36,7 @@
 #define DLL_NETCDF
 #endif
 
-#include "netcdf.h"
+#include <netcdf.h>
 
 enum gmt_enum_gshhs {GSHHS_MAX_DELTA = 65535,	/* Largest value to store in a unsigned short, used as largest dx or dy in bin  */
 	GSHHS_MAX_LEVEL			= 4,	/* Highest hierarchical level of coastlines */


### PR DESCRIPTION
Use `#include <xxx.h>` to include external header files, and
`#include "xxx.h"` to include GMT's own heade files.