### PR TITLE
Improve SRTM blending in grdblend

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13796,7 +13796,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 		if (gmtlib_file_is_srtmrequest (API, opt->arg, &srtm_res, &ocean)) {
 			unsigned int level = GMT->hidden.func_level;	/* Since we will need to increment prematurely since gmtinit_begin_module_sub has not been reached yet */
 			char *list = NULL;
-			double sgn, res[4] = {0.0, 1.0/3600.0, 0.0, 3.0/3600.0};	/* Only access 1 or 3 here */
+			double res[4] = {0.0, 1.0/3600.0, 0.0, 3.0/3600.0};	/* Only access 1 or 3 here */
 			struct GMT_OPTION *opt_J = GMT_Find_Option (API, 'J', *options);
 			opt_R = GMT_Find_Option (API, 'R', *options);
 			if (opt_R == NULL) {
@@ -13812,17 +13812,21 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 			API->GMT->hidden.func_level++;	/* Must do this here in case gmt_parse_R_option calls mapproject */
 			gmt_parse_R_option (GMT, opt_R->arg);
 			API->GMT->hidden.func_level = level;	/* Reset to what it should be */
-			/* Enforce multiple of 1s or 3s in wesn so region is in phase with tiles */
-			sgn = (GMT->common.R.wesn[XLO] < 0.0) ? -1.0 : +1.0;
-			GMT->common.R.wesn[XLO] = sgn * ceil (fabs (GMT->common.R.wesn[XLO]) / res[srtm_res]) * res[srtm_res];
-			sgn = (GMT->common.R.wesn[XHI] < 0.0) ? -1.0 : +1.0;
-			GMT->common.R.wesn[XHI] = sgn * ceil  (fabs (GMT->common.R.wesn[XHI]) / res[srtm_res]) * res[srtm_res];
-			sgn = (GMT->common.R.wesn[YLO] < 0.0) ? -1.0 : +1.0;
-			GMT->common.R.wesn[YLO] = sgn * ceil (fabs (GMT->common.R.wesn[YLO]) / res[srtm_res]) * res[srtm_res];
-			sgn = (GMT->common.R.wesn[YHI] < 0.0) ? -1.0 : +1.0;
-			GMT->common.R.wesn[YHI] = sgn * ceil  (fabs (GMT->common.R.wesn[YHI]) / res[srtm_res]) * res[srtm_res];
+			/* Enforce multiple of 1s or 3s in wesn so requested region is in phase with tiles and at least covers the given region  */
+//			sgn = (GMT->common.R.wesn[XLO] < 0.0) ? -1.0 : +1.0;
+//			GMT->common.R.wesn[XLO] = sgn * ceil (fabs (GMT->common.R.wesn[XLO]) / res[srtm_res]) * res[srtm_res];
+//			sgn = (GMT->common.R.wesn[XHI] < 0.0) ? -1.0 : +1.0;
+//			GMT->common.R.wesn[XHI] = sgn * ceil  (fabs (GMT->common.R.wesn[XHI]) / res[srtm_res]) * res[srtm_res];
+//			sgn = (GMT->common.R.wesn[YLO] < 0.0) ? -1.0 : +1.0;
+//			GMT->common.R.wesn[YLO] = sgn * ceil (fabs (GMT->common.R.wesn[YLO]) / res[srtm_res]) * res[srtm_res];
+//			sgn = (GMT->common.R.wesn[YHI] < 0.0) ? -1.0 : +1.0;
+//			GMT->common.R.wesn[YHI] = sgn * ceil  (fabs (GMT->common.R.wesn[YHI]) / res[srtm_res]) * res[srtm_res];
+			GMT->common.R.wesn[XLO] = floor ((GMT->common.R.wesn[XLO] / res[srtm_res]) + GMT_CONV8_LIMIT) * res[srtm_res];
+			GMT->common.R.wesn[XHI] = ceil  ((GMT->common.R.wesn[XHI] / res[srtm_res]) - GMT_CONV8_LIMIT) * res[srtm_res];
+			GMT->common.R.wesn[YLO] = floor ((GMT->common.R.wesn[YLO] / res[srtm_res]) + GMT_CONV8_LIMIT) * res[srtm_res];
+			GMT->common.R.wesn[YHI] = ceil  ((GMT->common.R.wesn[YHI] / res[srtm_res]) - GMT_CONV8_LIMIT) * res[srtm_res];
 			/* Get a file with a list of all needed srtm tiles */
-			list = gmtlib_get_srtmlist (API, GMT->common.R.wesn, srtm_res, ocean);
+			list = gmtlib_get_srtmlist (API, GMT->common.R.wesn, srtm_res, ocean, GMT->current.ps.active);
 			/* Replace the @[earth|srtm]_relief_0[1|3s file name with this local list */
 			gmt_M_str_free (opt->arg);
 			opt->arg = list;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13814,7 +13814,8 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 			gmt_parse_R_option (GMT, opt_R->arg);
 			API->GMT->hidden.func_level = level;	/* Reset to what it should be */
 			/* Enforce multiple of 1s or 3s in wesn so requested region is in phase with tiles and at least covers the given region.
-			 * When ocean is true we instead round to nearest 15s since earth_relief_15s will be used */
+			 * When ocean is true we instead round to nearest 15s since earth_relief_15s will be used.
+			 * the GMT_CONV8_LIMIT is there to ensure we dont round an almost exact x/dx */
 			k = (ocean) ? 0 : srtm_res;	/* Select 15s, 1s, or 3s increments */
 			GMT->common.R.wesn[XLO] = floor ((GMT->common.R.wesn[XLO] / res[k]) + GMT_CONV8_LIMIT) * res[k];
 			GMT->common.R.wesn[XHI] = ceil  ((GMT->common.R.wesn[XHI] / res[k]) - GMT_CONV8_LIMIT) * res[k];

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13795,8 +13795,9 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 		bool ocean;
 		if (gmtlib_file_is_srtmrequest (API, opt->arg, &srtm_res, &ocean)) {
 			unsigned int level = GMT->hidden.func_level;	/* Since we will need to increment prematurely since gmtinit_begin_module_sub has not been reached yet */
+			unsigned int k;
 			char *list = NULL;
-			double res[4] = {0.0, 1.0/3600.0, 0.0, 3.0/3600.0};	/* Only access 1 or 3 here */
+			double res[4] = {15.0/3600.0, 1.0/3600.0, 0.0, 3.0/3600.0};	/* Only access 1 or 3 here */
 			struct GMT_OPTION *opt_J = GMT_Find_Option (API, 'J', *options);
 			opt_R = GMT_Find_Option (API, 'R', *options);
 			if (opt_R == NULL) {
@@ -13812,19 +13813,13 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 			API->GMT->hidden.func_level++;	/* Must do this here in case gmt_parse_R_option calls mapproject */
 			gmt_parse_R_option (GMT, opt_R->arg);
 			API->GMT->hidden.func_level = level;	/* Reset to what it should be */
-			/* Enforce multiple of 1s or 3s in wesn so requested region is in phase with tiles and at least covers the given region  */
-//			sgn = (GMT->common.R.wesn[XLO] < 0.0) ? -1.0 : +1.0;
-//			GMT->common.R.wesn[XLO] = sgn * ceil (fabs (GMT->common.R.wesn[XLO]) / res[srtm_res]) * res[srtm_res];
-//			sgn = (GMT->common.R.wesn[XHI] < 0.0) ? -1.0 : +1.0;
-//			GMT->common.R.wesn[XHI] = sgn * ceil  (fabs (GMT->common.R.wesn[XHI]) / res[srtm_res]) * res[srtm_res];
-//			sgn = (GMT->common.R.wesn[YLO] < 0.0) ? -1.0 : +1.0;
-//			GMT->common.R.wesn[YLO] = sgn * ceil (fabs (GMT->common.R.wesn[YLO]) / res[srtm_res]) * res[srtm_res];
-//			sgn = (GMT->common.R.wesn[YHI] < 0.0) ? -1.0 : +1.0;
-//			GMT->common.R.wesn[YHI] = sgn * ceil  (fabs (GMT->common.R.wesn[YHI]) / res[srtm_res]) * res[srtm_res];
-			GMT->common.R.wesn[XLO] = floor ((GMT->common.R.wesn[XLO] / res[srtm_res]) + GMT_CONV8_LIMIT) * res[srtm_res];
-			GMT->common.R.wesn[XHI] = ceil  ((GMT->common.R.wesn[XHI] / res[srtm_res]) - GMT_CONV8_LIMIT) * res[srtm_res];
-			GMT->common.R.wesn[YLO] = floor ((GMT->common.R.wesn[YLO] / res[srtm_res]) + GMT_CONV8_LIMIT) * res[srtm_res];
-			GMT->common.R.wesn[YHI] = ceil  ((GMT->common.R.wesn[YHI] / res[srtm_res]) - GMT_CONV8_LIMIT) * res[srtm_res];
+			/* Enforce multiple of 1s or 3s in wesn so requested region is in phase with tiles and at least covers the given region.
+			 * When ocean is true we instead round to nearest 15s since earth_relief_15s will be used */
+			k = (ocean) ? 0 : srtm_res;	/* Select 15s, 1s, or 3s increments */
+			GMT->common.R.wesn[XLO] = floor ((GMT->common.R.wesn[XLO] / res[k]) + GMT_CONV8_LIMIT) * res[k];
+			GMT->common.R.wesn[XHI] = ceil  ((GMT->common.R.wesn[XHI] / res[k]) - GMT_CONV8_LIMIT) * res[k];
+			GMT->common.R.wesn[YLO] = floor ((GMT->common.R.wesn[YLO] / res[k]) + GMT_CONV8_LIMIT) * res[k];
+			GMT->common.R.wesn[YHI] = ceil  ((GMT->common.R.wesn[YHI] / res[k]) - GMT_CONV8_LIMIT) * res[k];
 			/* Get a file with a list of all needed srtm tiles */
 			list = gmtlib_get_srtmlist (API, GMT->common.R.wesn, srtm_res, ocean, GMT->current.ps.active);
 			/* Replace the @[earth|srtm]_relief_0[1|3s file name with this local list */

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -103,7 +103,7 @@ EXTERN_MSC void gmtlib_update_outcol_type (struct GMT_CTRL *GMT, uint64_t n);
 EXTERN_MSC void gmtlib_reset_input (struct GMT_CTRL *GMT);
 EXTERN_MSC bool gmtlib_file_is_srtmrequest (struct GMTAPI_CTRL *API, const char *file, unsigned int *res, bool *ocean);
 EXTERN_MSC bool gmtlib_file_is_srtmlist (struct GMTAPI_CTRL *API, const char *file);
-EXTERN_MSC char * gmtlib_get_srtmlist  (struct GMTAPI_CTRL *API, double wesn[], unsigned int res, bool ocean);
+EXTERN_MSC char * gmtlib_get_srtmlist  (struct GMTAPI_CTRL *API, double wesn[], unsigned int res, bool ocean, bool plot_region);
 EXTERN_MSC struct GMT_GRID * gmtlib_assemble_srtm (struct GMTAPI_CTRL *API, double *region, char *file);
 EXTERN_MSC bool gmtlib_fig_is_ps (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmtlib_refpoint_to_panel_xy (struct GMT_CTRL *GMT, int refpoint, struct GMT_SUBPLOT *P, double *x, double *y);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -738,7 +738,7 @@ bool gmtlib_file_is_srtmrequest (struct GMTAPI_CTRL *API, const char *file, unsi
 	return true;
 }
 
-#define GMT_REMOTE_SRTM_POS 14	/* start of =srtm string in file if a srtm list */
+#define GMT_REMOTE_SRTM_POS 15	/* start of =srtm string counting from end in file if a srtm list */
 
 bool gmtlib_file_is_srtmlist (struct GMTAPI_CTRL *API, const char *file) {
 	size_t len = strlen(file);
@@ -762,7 +762,7 @@ char *gmtlib_get_srtmlist (struct GMTAPI_CTRL *API, double wesn[], unsigned int 
 	 * Uses the srtm_tiles.nc grid on the cache to know if a 1x1 degree has a tile. */
 	int x, lon, lat, iw, ie, is, in, n_tiles = 0;
 	uint64_t node;
-	char srtmlist[PATH_MAX] = {""}, YS, XS, *file = NULL, regtype[2] = {'G', 'P'};
+	char srtmlist[PATH_MAX] = {""}, YS, XS, *file = NULL, datatype[2] = {'L', 'O'}, regtype[2] = {'G', 'P'};
 	FILE *fp = NULL;
 	struct GMT_GRID *SRTM = NULL;
 
@@ -770,7 +770,7 @@ char *gmtlib_get_srtmlist (struct GMTAPI_CTRL *API, double wesn[], unsigned int 
 	iw = (int)floor (wesn[XLO]);	ie = (int)ceil (wesn[XHI]);
 	is = (int)floor (wesn[YLO]);	in = (int)ceil (wesn[YHI]);
 	if (API->GMT->current.setting.run_mode == GMT_MODERN) {	/* Isolation mode is baked in */
-		snprintf (srtmlist, PATH_MAX, "%s/=srtm%d%c.000000", API->GMT->parent->gwf_dir, res, regtype[plot_region]);
+		snprintf (srtmlist, PATH_MAX, "%s/=srtm%d%c%c.000000", API->GMT->parent->gwf_dir, res, datatype[ocean], regtype[plot_region]);
 		file = srtmlist;
 		if ((fp = fopen (file, "w")) == NULL) {
 			GMT_Report (API, GMT_MSG_ERROR, "ERROR - Unable to create job file %s\n", file);
@@ -784,7 +784,7 @@ char *gmtlib_get_srtmlist (struct GMTAPI_CTRL *API, double wesn[], unsigned int 
 #endif
 		if (API->tmp_dir)			/* Have a recognized temp directory */
 			snprintf (srtmlist, PATH_MAX, "%s/", API->tmp_dir);
-		snprintf (name, GMT_LEN16, "=srtm%d%c.XXXXXX", res, regtype[plot_region]);
+		snprintf (name, GMT_LEN16, "=srtm%d%c%c.XXXXXX", res, datatype[ocean], regtype[plot_region]);
 		strcat (srtmlist, name);
 #ifdef _WIN32
 		if ((file = mktemp (srtmlist)) == NULL) {
@@ -924,7 +924,7 @@ char *gmtlib_get_srtmlist (struct GMTAPI_CTRL *API, double wesn[], unsigned int 
 	return (strdup (file));
 }
 
-#define GMT_REMOTE_RES_POS 9	/* Position from the end where the SRTM resolution is placed */
+#define GMT_REMOTE_RES_POS 10	/* Position from the end where the SRTM resolution is placed */
 
 struct GMT_GRID *gmtlib_assemble_srtm (struct GMTAPI_CTRL *API, double *region, char *file) {
 	/* Get here if file is a =srtm?.xxxxxx file.  Need to do:

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -738,11 +738,13 @@ bool gmtlib_file_is_srtmrequest (struct GMTAPI_CTRL *API, const char *file, unsi
 	return true;
 }
 
+#define GMT_REMOTE_SRTM_POS 14	/* start of =srtm string in file if a srtm list */
+
 bool gmtlib_file_is_srtmlist (struct GMTAPI_CTRL *API, const char *file) {
 	size_t len = strlen(file);
 	gmt_M_unused (API);
-	if (len < 13) return false;	/* Too short a filename */
-	if (strncmp (&file[len-13], "=srtm", 5U)) return false;	/* Not that kind of file */
+	if (len < GMT_REMOTE_SRTM_POS) return false;	/* Too short a filename */
+	if (strncmp (&file[len-GMT_REMOTE_SRTM_POS], "=srtm", 5U)) return false;	/* Not that kind of file */
 	return true;	/* We got one */
 }
 
@@ -755,12 +757,12 @@ bool gmt_file_is_srtmtile (struct GMTAPI_CTRL *API, const char *file, unsigned i
 	return true;	/* Found it */
 }
 
-char *gmtlib_get_srtmlist (struct GMTAPI_CTRL *API, double wesn[], unsigned int res, bool ocean) {
+char *gmtlib_get_srtmlist (struct GMTAPI_CTRL *API, double wesn[], unsigned int res, bool ocean, bool plot_region) {
 	/* Builds a list of SRTM tile to download for the chosen region and resolution.
 	 * Uses the srtm_tiles.nc grid on the cache to know if a 1x1 degree has a tile. */
 	int x, lon, lat, iw, ie, is, in, n_tiles = 0;
 	uint64_t node;
-	char srtmlist[PATH_MAX] = {""}, YS, XS, *file = NULL;
+	char srtmlist[PATH_MAX] = {""}, YS, XS, *file = NULL, regtype[2] = {'G', 'P'};
 	FILE *fp = NULL;
 	struct GMT_GRID *SRTM = NULL;
 
@@ -768,7 +770,7 @@ char *gmtlib_get_srtmlist (struct GMTAPI_CTRL *API, double wesn[], unsigned int 
 	iw = (int)floor (wesn[XLO]);	ie = (int)ceil (wesn[XHI]);
 	is = (int)floor (wesn[YLO]);	in = (int)ceil (wesn[YHI]);
 	if (API->GMT->current.setting.run_mode == GMT_MODERN) {	/* Isolation mode is baked in */
-		snprintf (srtmlist, PATH_MAX, "%s/=srtm%d.000000", API->GMT->parent->gwf_dir, res);
+		snprintf (srtmlist, PATH_MAX, "%s/=srtm%d%c.000000", API->GMT->parent->gwf_dir, res, regtype[plot_region]);
 		file = srtmlist;
 		if ((fp = fopen (file, "w")) == NULL) {
 			GMT_Report (API, GMT_MSG_ERROR, "ERROR - Unable to create job file %s\n", file);
@@ -782,7 +784,7 @@ char *gmtlib_get_srtmlist (struct GMTAPI_CTRL *API, double wesn[], unsigned int 
 #endif
 		if (API->tmp_dir)			/* Have a recognized temp directory */
 			snprintf (srtmlist, PATH_MAX, "%s/", API->tmp_dir);
-		snprintf (name, GMT_LEN16, "=srtm%d.XXXXXX", res);
+		snprintf (name, GMT_LEN16, "=srtm%d%c.XXXXXX", res, regtype[plot_region]);
 		strcat (srtmlist, name);
 #ifdef _WIN32
 		if ((file = mktemp (srtmlist)) == NULL) {
@@ -922,11 +924,13 @@ char *gmtlib_get_srtmlist (struct GMTAPI_CTRL *API, double wesn[], unsigned int 
 	return (strdup (file));
 }
 
+#define GMT_REMOTE_RES_POS 9	/* Position from the end where the SRTM resolution is placed */
+
 struct GMT_GRID *gmtlib_assemble_srtm (struct GMTAPI_CTRL *API, double *region, char *file) {
 	/* Get here if file is a =srtm?.xxxxxx file.  Need to do:
 	 * Set up a grdblend command and return the assembled grid
 	 */
-	char res = file[strlen(file)-8];
+	char res = file[strlen(file)-GMT_REMOTE_RES_POS];
 	struct GMT_GRID *G = NULL;
 	double *wesn = (region) ? region : API->GMT->common.R.wesn;	/* Default to -R */
 	char grid[GMT_VF_LEN] = {""}, cmd[GMT_LEN256] = {""}, tag[4] = {"01s"};


### PR DESCRIPTION
**Description of proposed changes**

See #3206 for background.  There were a few issues:

1. We had no way of distinguishing between a plot region and a grid region when grdblend is called.  For instance, in #3206 a plot region is given, but that **-R** is not suitable as is to define a grid since the bounds are not multiples of the SRTM increments.
2. After fixing that, another issue was that the earth_relief_15s is used to fill in, but of course it needs to round to nearest 15s, not 1s.
3. FInally, grdblend would fail to probably pass -r? to request pixel or gridline-registered grdsample calls so the output match the desired registration.

With these changes the case that started it (#3206) works, so this closes #3206.
