### PR TITLE
Fixing miscellaneous issues in gmtregress

### DIFF
--- a/doc/examples/ex43/ex43.ps
+++ b/doc/examples/ex43/ex43.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 595 842
 %%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.1.0_9ee9cff_2020.02.16 [64-bit] Document from psbasemap
+%%Title: GMT v6.1.0_4575a83_2020.05.01 [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Feb 16 18:07:31 2020
+%%CreationDate: Fri May  1 10:52:40 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -670,6 +670,7 @@ O0
 {0.678 0.847 0.902 C} FS
 -7087 0 0 7087 7087 0 3 0 0 SP
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 7087 M 0 -7087 D S
 /PSL_A0_y 83 def
@@ -682,8 +683,8 @@ N 0 3543 M -83 0 D S
 N 0 4724 M -83 0 D S
 N 0 5906 M -83 0 D S
 N 0 7087 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V MU 0 0 M (10) FP 0 70 G 140 F0 (-1) FP 0 -70 G pathbbox N pop exch pop add U mx
@@ -864,8 +865,8 @@ N 4429 0 M 0 -83 D S
 N 5315 0 M 0 -83 D S
 N 6201 0 M 0 -83 D S
 N 7087 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 200 F0
 V MU 0 0 M (10) FP 0 70 G 140 F0 (-2) FP 0 -70 G pathbbox N 4 1 roll pop pop pop U mx
 V MU 0 0 M (10) FP 0 70 G 140 F0 (-1) FP 0 -70 G pathbbox N 4 1 roll pop pop pop U mx
@@ -1437,6 +1438,7 @@ PSL_clip N
 3794 3845 M (28) mc Z
 PSL_cliprestore
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 7087 M 0 -7087 D S
 /PSL_A0_y 0 def
@@ -1488,7 +1490,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt pstext -R0/5.90551/0/5.90551 -Jx1i -O -K -N -F+f+j @GMTAPI@-000001 --GMT_HISTORY=false
+%@GMT: gmt pstext -R0/5.90551/0/5.90551 -Jx1i -O -K -N -F+f+j @GMTAPI@-S-I-D-D-N-N-000001 --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 5.90551000 0.00000000 5.90551000 0.000 5.906 0.000 5.906 +xy
 %%BeginObject PSL_Layer_10
 0 setlinecap
@@ -1572,6 +1574,7 @@ O0
 {0.933 0.867 0.51 C} FS
 -7087 0 0 2362 7087 0 3 0 0 SP
 25 W
+/PSL_slant_y 0 def
 %%EndObject
 0 A
 FQ
@@ -1629,41 +1632,41 @@ PSL_clip N
 V
 {0 1 0 C} FS
 O1
--14 253 0 1687 Sb
--144 253 253 1687 Sb
+-16 253 0 1687 Sb
+-143 253 253 1687 Sb
 47 253 506 1687 Sb
 96 253 759 1687 Sb
--69 253 1012 1687 Sb
+-71 253 1012 1687 Sb
 {1 0.502 0.502 C} FS
--1470 254 1265 1687 Sb
+-1472 254 1265 1687 Sb
 {0 1 0 C} FS
-177 253 1519 1687 Sb
-53 253 1772 1687 Sb
--42 253 2025 1687 Sb
-318 253 2278 1687 Sb
-136 253 2531 1687 Sb
--34 253 2784 1687 Sb
+180 253 1519 1687 Sb
+54 253 1772 1687 Sb
+-41 253 2025 1687 Sb
+319 253 2278 1687 Sb
+135 253 2531 1687 Sb
+-33 253 2784 1687 Sb
 22 253 3037 1687 Sb
 {1 0.502 0.502 C} FS
-628 253 3290 1687 Sb
+630 253 3290 1687 Sb
 {0 1 0 C} FS
-30 253 3543 1687 Sb
+32 253 3543 1687 Sb
 {1 0.502 0.502 C} FS
--1324 253 3796 1687 Sb
-531 254 4049 1687 Sb
+-1326 253 3796 1687 Sb
+532 254 4049 1687 Sb
 {0 1 0 C} FS
--165 253 4303 1687 Sb
--92 253 4556 1687 Sb
-4 253 4809 1687 Sb
--32 253 5062 1687 Sb
-65 253 5315 1687 Sb
+-166 253 4303 1687 Sb
+-95 253 4556 1687 Sb
+0 253 4809 1687 Sb
+-34 253 5062 1687 Sb
+66 253 5315 1687 Sb
 -95 253 5568 1687 Sb
-347 253 5821 1687 Sb
+348 253 5821 1687 Sb
 {1 0.502 0.502 C} FS
--1582 253 6074 1687 Sb
+-1583 253 6074 1687 Sb
 {0 1 0 C} FS
--91 253 6327 1687 Sb
-224 254 6580 1687 Sb
+-94 253 6327 1687 Sb
+222 254 6580 1687 Sb
 -198 253 6834 1687 Sb
 U
 PSL_cliprestore
@@ -1684,6 +1687,7 @@ O0
 0 1687 M
 7087 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2362 M 0 -2362 D S
@@ -1693,8 +1697,8 @@ N 0 2362 M 0 -2362 D S
 N 0 0 M -83 0 D S
 N 0 844 M -83 0 D S
 N 0 1687 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (-10) sw mx
@@ -1759,8 +1763,8 @@ N 2404 0 M 0 -83 D S
 N 3670 0 M 0 -83 D S
 N 4935 0 M 0 -83 D S
 N 6201 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 200 F0
 (5) sh mx
 (10) sh mx

--- a/doc/examples/ex47/ex47.ps
+++ b/doc/examples/ex47/ex47.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 595 842
 %%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.1.0_9ee9cff_2020.02.16 [64-bit] Document from psxy
+%%Title: GMT v6.1.0_4575a83_2020.05.01 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Feb 16 18:07:36 2020
+%%CreationDate: Fri May  1 10:52:39 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -714,6 +714,7 @@ S
 2362 2067 M
 -2362 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2362 M 0 -2362 D S
@@ -725,8 +726,8 @@ N 0 591 M -83 0 D S
 N 0 1083 M -83 0 D S
 N 0 1575 M -83 0 D S
 N 0 2067 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (4.0) sw mx
@@ -869,7 +870,7 @@ N 49 0 M 0 42 D S
 0 -2362 T
 0 setlinecap
 /PSL_H_y PSL_L_y PSL_LH add 233 add def
-1181 2362 PSL_H_y add M
+1181 2362 PSL_H_y add PSL_slant_y add M
 400 F0
 V MU 0 0 M (L) FP 0 -100 G 280 F0 (1) FP 0 100 G pathbbox N pop exch pop add U -2 div 0 G
 (L) Z
@@ -996,15 +997,15 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-2362 2210 M
--295 -199 D
--295 -199 D
--296 -200 D
--295 -199 D
--295 -199 D
--295 -199 D
--296 -199 D
--295 -199 D
+2362 2237 M
+-295 -204 D
+-295 -205 D
+-296 -204 D
+-295 -205 D
+-295 -205 D
+-295 -204 D
+-296 -205 D
+-295 -204 D
 S
 PSL_cliprestore
 %%EndObject
@@ -1055,6 +1056,7 @@ S
 2362 2067 M
 -2362 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2362 M 0 -2362 D S
@@ -1066,8 +1068,8 @@ N 0 591 M -83 0 D S
 N 0 1083 M -83 0 D S
 N 0 1575 M -83 0 D S
 N 0 2067 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (4.0) sw mx
@@ -1331,9 +1333,9 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-1156 -5 M
--1 5 D
--690 2362 D
+1158 -5 M
+-2 5 D
+-697 2362 D
 -1 5 D S
 PSL_cliprestore
 %%EndObject
@@ -1384,6 +1386,7 @@ S
 2362 2067 M
 -2362 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2362 M 0 -2362 D S
@@ -1395,8 +1398,8 @@ N 0 591 M -83 0 D S
 N 0 1083 M -83 0 D S
 N 0 1575 M -83 0 D S
 N 0 2067 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (4.0) sw mx
@@ -1661,8 +1664,8 @@ clipsave
 P
 PSL_clip N
 998 -2 M
-0 2 D
--352 2362 D
+-1 2 D
+-350 2362 D
 0 3 D S
 PSL_cliprestore
 %%EndObject
@@ -1713,6 +1716,7 @@ S
 2362 2067 M
 -2362 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2362 M 0 -2362 D S
@@ -1724,8 +1728,8 @@ N 0 591 M -83 0 D S
 N 0 1083 M -83 0 D S
 N 0 1575 M -83 0 D S
 N 0 2067 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (4.0) sw mx
@@ -1814,8 +1818,8 @@ N 1722 0 M 0 -83 D S
 N 1230 0 M 0 -83 D S
 N 738 0 M 0 -83 D S
 N 246 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 200 F0
 (3.0) sh mx
 (3.5) sh mx
@@ -2013,10 +2017,10 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-989 -2 M
+990 -2 M
 0 2 D
--332 2362 D
-0 3 D S
+-337 2362 D
+-1 3 D S
 PSL_cliprestore
 %%EndObject
 0 0 TM
@@ -2066,6 +2070,7 @@ S
 2362 2067 M
 -2362 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2362 M 0 -2362 D S
@@ -2195,7 +2200,7 @@ N 49 0 M 0 42 D S
 0 -2362 T
 0 setlinecap
 /PSL_H_y PSL_L_y PSL_LH add 233 add def
-1181 2362 PSL_H_y add M
+1181 2362 PSL_H_y add PSL_slant_y add M
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 V MU 0 0 M (L) FP 0 -100 G 280 F0 (2) FP 0 100 G pathbbox N pop exch pop add U -2 div 0 G
@@ -2377,6 +2382,7 @@ S
 2362 2067 M
 -2362 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2362 M 0 -2362 D S
@@ -2680,6 +2686,7 @@ S
 2362 2067 M
 -2362 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2362 M 0 -2362 D S
@@ -2983,6 +2990,7 @@ S
 2362 2067 M
 -2362 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2362 M 0 -2362 D S
@@ -3058,8 +3066,8 @@ N 1722 0 M 0 -83 D S
 N 1230 0 M 0 -83 D S
 N 738 0 M 0 -83 D S
 N 246 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (3.0) sh mx
@@ -3333,6 +3341,7 @@ S
 2362 2067 M
 -2362 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2362 M 0 -2362 D S
@@ -3462,7 +3471,7 @@ N 49 0 M 0 42 D S
 0 -2362 T
 0 setlinecap
 /PSL_H_y PSL_L_y PSL_LH add 233 add def
-1181 2362 PSL_H_y add M
+1181 2362 PSL_H_y add PSL_slant_y add M
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 (LMS) bc Z
@@ -3657,6 +3666,7 @@ S
 2362 2067 M
 -2362 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2362 M 0 -2362 D S
@@ -3907,9 +3917,9 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-1051 -3 M
-0 3 D
--459 2362 D
+1054 -3 M
+-1 3 D
+-468 2362 D
 -1 3 D S
 PSL_cliprestore
 %%EndObject
@@ -3976,6 +3986,7 @@ S
 2362 2067 M
 -2362 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2362 M 0 -2362 D S
@@ -4226,9 +4237,9 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-1051 -3 M
+1053 -3 M
 0 3 D
--459 2362 D
+-467 2362 D
 -1 3 D S
 PSL_cliprestore
 %%EndObject
@@ -4295,6 +4306,7 @@ S
 2362 2067 M
 -2362 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2362 M 0 -2362 D S
@@ -4370,8 +4382,8 @@ N 1722 0 M 0 -83 D S
 N 1230 0 M 0 -83 D S
 N 738 0 M 0 -83 D S
 N 246 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (3.0) sh mx
@@ -4570,9 +4582,9 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-1068 -4 M
+1069 -4 M
 -1 4 D
--589 2362 D
+-591 2362 D
 -1 4 D S
 PSL_cliprestore
 %%EndObject

--- a/doc/rst/source/gmtregress.rst
+++ b/doc/rst/source/gmtregress.rst
@@ -179,9 +179,10 @@ Note:
 -----
 
 The output segment header will contain all the various statistics we compute for each segment.
-These are in order: N (number of points), x0 (weighted mean x), y0 (weighted mean y),
-angle (of line), E (misfit), slope, intercept, sigma_slope, sigma_intercept, correlation (r),
-coefficient of determination (R).
+These are in order: *N* (number of points), *x0* (weighted mean x), *y0* (weighted mean y),
+*angle* (of line), *E* (misfit), *slope*, *intercept*, *sigma_slope*, and *sigma_intercept*.  More the
+standard regression (**-Ey**) we also report the Pearsonian correlation (*r*) and
+coefficient of determination (*R*).
 
 Examples
 --------

--- a/src/gmtregress.c
+++ b/src/gmtregress.c
@@ -1047,10 +1047,9 @@ GMT_LOCAL double * gmtregress_do_regression (struct GMT_CTRL *GMT, double *x_in,
 		}
 		(void) gmtregress_do_regression (GMT, x_in, y_in, www, n, regression, GMTREGRESS_NORM_L2, par, 1);
 	}
-	if (regression == GMTREGRESS_Y) {	/* Can only do this for standard regression */
-		gmtregress_get_correlation (GMT, x_in, y_in, w, n, par);	/* Evaluate r */
+	gmtregress_get_correlation (GMT, x_in, y_in, w, n, par);	/* Evaluate r */
+	if (regression == GMTREGRESS_Y)	/* Can only do this for standard regression */
 		gmtregress_get_coeffR (GMT, x_in, y_in, w, n, regression, par);	/* Evaluate R */
-	}
 	if (reweighted_ls) {	/* Free weights */
 		for (col = first_col; col <= GMT_Y; col++)	/* Free any arrays we allocated */
 			if (made[col]) gmt_M_free (GMT, www[col]);
@@ -1247,8 +1246,8 @@ EXTERN_MSC int GMT_gmtregress (void *V_API, int mode, void *args) {
 						snprintf (buffer, GMT_LEN256, "Best regression: N: %" PRIu64 " x0: %g y0: %g angle: %g E: %g slope: %g icept: %g sig_slope: %g sig_icept: %g corr: %g R: %g", S->n_rows, par[GMTREGRESS_XMEAN], par[GMTREGRESS_YMEAN],
 							par[GMTREGRESS_ANGLE], par[GMTREGRESS_MISFT], par[GMTREGRESS_SLOPE], par[GMTREGRESS_ICEPT], par[GMTREGRESS_SIGSL], par[GMTREGRESS_SIGIC], par[GMTREGRESS_CORR], par[GMTREGRESS_R]);
 					else
-							snprintf (buffer, GMT_LEN256, "Best regression: N: %" PRIu64 " x0: %g y0: %g angle: %g E: %g slope: %g icept: %g sig_slope: %g sig_icept: %g", S->n_rows, par[GMTREGRESS_XMEAN], par[GMTREGRESS_YMEAN],
-						par[GMTREGRESS_ANGLE], par[GMTREGRESS_MISFT], par[GMTREGRESS_SLOPE], par[GMTREGRESS_ICEPT], par[GMTREGRESS_SIGSL], par[GMTREGRESS_SIGIC]);
+							snprintf (buffer, GMT_LEN256, "Best regression: N: %" PRIu64 " x0: %g y0: %g angle: %g E: %g slope: %g icept: %g sig_slope: %g sig_icept: %g corr: %g", S->n_rows, par[GMTREGRESS_XMEAN], par[GMTREGRESS_YMEAN],
+						par[GMTREGRESS_ANGLE], par[GMTREGRESS_MISFT], par[GMTREGRESS_SLOPE], par[GMTREGRESS_ICEPT], par[GMTREGRESS_SIGSL], par[GMTREGRESS_SIGIC], par[GMTREGRESS_CORR]);
 					GMT_Report (API, GMT_MSG_INFORMATION, "%s\n", buffer);	/* Report results if verbose */
 					GMT_Put_Record (API, GMT_WRITE_SEGMENT_HEADER, buffer);	/* Also include in segment header */
 

--- a/src/gmtregress.c
+++ b/src/gmtregress.c
@@ -1243,7 +1243,7 @@ EXTERN_MSC int GMT_gmtregress (void *V_API, int mode, void *args) {
 				}
 				else {
 					/* Make segment header with the findings for best regression */
-					if (Ctrl->E.mode != GMTREGRESS_Y)	/* Can include Pearsonian orrelation and R */
+					if (Ctrl->E.mode == GMTREGRESS_Y)	/* Can include Pearsonian orrelation and R */
 						snprintf (buffer, GMT_LEN256, "Best regression: N: %" PRIu64 " x0: %g y0: %g angle: %g E: %g slope: %g icept: %g sig_slope: %g sig_icept: %g corr: %g R: %g", S->n_rows, par[GMTREGRESS_XMEAN], par[GMTREGRESS_YMEAN],
 							par[GMTREGRESS_ANGLE], par[GMTREGRESS_MISFT], par[GMTREGRESS_SLOPE], par[GMTREGRESS_ICEPT], par[GMTREGRESS_SIGSL], par[GMTREGRESS_SIGIC], par[GMTREGRESS_CORR], par[GMTREGRESS_R]);
 					else

--- a/src/gmtregress.c
+++ b/src/gmtregress.c
@@ -832,8 +832,8 @@ GMT_LOCAL double gmtregress_regress1D (struct GMT_CTRL *GMT, double *x, double *
 			if (tpar[GMTREGRESS_MISFT] < par[GMTREGRESS_MISFT])
 				gmt_M_memcpy (par, tpar, GMTREGRESS_NPAR, double);	/* Update best fit so far without stepping on the means and sigmas */
 		}
-		if (d_a < 0.1 && par[GMTREGRESS_MISFT] <= last_E && (f = (last_E - par[GMTREGRESS_MISFT])/par[GMTREGRESS_MISFT]) < GMT_CONV15_LIMIT)
-			done = true;	/* Change is tiny so we are done */
+		if (d_a < 0.05 && par[GMTREGRESS_MISFT] <= last_E && (f = (last_E - par[GMTREGRESS_MISFT])/par[GMTREGRESS_MISFT]) < GMT_CONV15_LIMIT)
+			done = true;	/* Change is tiny so we are done, or d_a is too big to make a decision for yet */
 		else {	/* Gradually zoom in on the angles with smallest misfit but allow some slack */
 			a_min = MAX (-90.0, par[GMTREGRESS_ANGLE] - 0.25 * r_a);	/* Get a range that is ~-/+ 25% of previous range */
 			a_max = MIN (+90.0, par[GMTREGRESS_ANGLE] + 0.25 * r_a);	/* Get a range that is ~-/+ 25% of previous range */
@@ -1047,8 +1047,10 @@ GMT_LOCAL double * gmtregress_do_regression (struct GMT_CTRL *GMT, double *x_in,
 		}
 		(void) gmtregress_do_regression (GMT, x_in, y_in, www, n, regression, GMTREGRESS_NORM_L2, par, 1);
 	}
-	gmtregress_get_correlation (GMT, x_in, y_in, w, n, par);	/* Evaluate r */
-	gmtregress_get_coeffR (GMT, x_in, y_in, w, n, regression, par);	/* Evaluate R */
+	if (regression == GMTREGRESS_Y) {	/* Can only do this for standard regression */
+		gmtregress_get_correlation (GMT, x_in, y_in, w, n, par);	/* Evaluate r */
+		gmtregress_get_coeffR (GMT, x_in, y_in, w, n, regression, par);	/* Evaluate R */
+	}
 	if (reweighted_ls) {	/* Free weights */
 		for (col = first_col; col <= GMT_Y; col++)	/* Free any arrays we allocated */
 			if (made[col]) gmt_M_free (GMT, www[col]);

--- a/test/gmtregress/regress_2.ps
+++ b/test/gmtregress/regress_2.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_831abca_2019.06.27 [64-bit] Document from psxy
+%%Title: GMT v6.1.0_4575a83_2020.05.01 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Jun 27 12:16:19 2019
+%%CreationDate: Fri May  1 10:52:39 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -646,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -657,8 +658,9 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
-/PSL_movie_completion {} def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
@@ -720,6 +722,7 @@ S
 2400 2100 M
 -2400 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2400 M 0 -2400 D S
@@ -731,8 +734,8 @@ N 0 600 M -83 0 D S
 N 0 1100 M -83 0 D S
 N 0 1600 M -83 0 D S
 N 0 2100 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (4.0) sw mx
@@ -817,8 +820,8 @@ N 1750 0 M 0 -83 D S
 N 1250 0 M 0 -83 D S
 N 750 0 M 0 -83 D S
 N 250 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (3.0) sh mx
 (3.5) sh mx
 (4.0) sh mx
@@ -994,9 +997,9 @@ clipsave
 -2400 0 D
 P
 PSL_clip N
-1174 -2 M
--1 2 D
--700 2400 D
+1175 -2 M
+0 2 D
+-708 2400 D
 -1 2 D S
 PSL_cliprestore
 %%EndObject
@@ -1045,6 +1048,7 @@ S
 2400 2100 M
 -2400 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2400 M 0 -2400 D S
@@ -1056,8 +1060,8 @@ N 0 600 M -83 0 D S
 N 0 1100 M -83 0 D S
 N 0 1600 M -83 0 D S
 N 0 2100 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (4.0) sw mx
@@ -1301,8 +1305,8 @@ clipsave
 P
 PSL_clip N
 1014 -1 M
-0 1 D
--358 2400 D
+-1 1 D
+-356 2400 D
 0 1 D S
 PSL_cliprestore
 %%EndObject
@@ -1351,6 +1355,7 @@ S
 2400 2100 M
 -2400 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2400 M 0 -2400 D S
@@ -1362,8 +1367,8 @@ N 0 600 M -83 0 D S
 N 0 1100 M -83 0 D S
 N 0 1600 M -83 0 D S
 N 0 2100 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (4.0) sw mx
@@ -1606,9 +1611,9 @@ clipsave
 -2400 0 D
 P
 PSL_clip N
-1005 -1 M
+1006 -1 M
 0 1 D
--337 2400 D
+-343 2400 D
 0 1 D S
 PSL_cliprestore
 %%EndObject
@@ -1657,6 +1662,7 @@ S
 2400 2100 M
 -2400 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2400 M 0 -2400 D S
@@ -1668,8 +1674,8 @@ N 0 600 M -83 0 D S
 N 0 1100 M -83 0 D S
 N 0 1600 M -83 0 D S
 N 0 2100 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (4.0) sw mx
@@ -1785,8 +1791,8 @@ N 1750 0 M 0 83 D S
 N 1250 0 M 0 83 D S
 N 750 0 M 0 83 D S
 N 250 0 M 0 83 D S
-/PSL_AH0 0
 /MM {M} def
+/PSL_AH0 0
 (3.0) sh mx
 (3.5) sh mx
 (4.0) sh mx
@@ -1828,7 +1834,7 @@ N 50 0 M 0 42 D S
 0 -2400 T
 0 setlinecap
 /PSL_H_y PSL_L_y PSL_LH add 233 add def
-1200 2400 PSL_H_y add M
+1200 2400 PSL_H_y add PSL_slant_y add M
 400 F0
 (L1) bc Z
 clipsave
@@ -1936,15 +1942,15 @@ clipsave
 -2400 0 D
 P
 PSL_clip N
-2400 2245 M
--300 -202 D
--300 -202 D
--300 -203 D
--300 -202 D
--300 -203 D
--300 -202 D
--300 -202 D
--300 -203 D
+2400 2273 M
+-300 -208 D
+-300 -208 D
+-300 -207 D
+-300 -208 D
+-300 -208 D
+-300 -208 D
+-300 -208 D
+-300 -208 D
 S
 PSL_cliprestore
 %%EndObject
@@ -1993,6 +1999,7 @@ S
 2400 2100 M
 -2400 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2400 M 0 -2400 D S
@@ -2068,8 +2075,8 @@ N 1750 0 M 0 -83 D S
 N 1250 0 M 0 -83 D S
 N 750 0 M 0 -83 D S
 N 250 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (3.0) sh mx
@@ -2298,6 +2305,7 @@ S
 2400 2100 M
 -2400 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2400 M 0 -2400 D S
@@ -2582,6 +2590,7 @@ S
 2400 2100 M
 -2400 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2400 M 0 -2400 D S
@@ -2866,6 +2875,7 @@ S
 2400 2100 M
 -2400 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2400 M 0 -2400 D S
@@ -2972,8 +2982,8 @@ N 1750 0 M 0 83 D S
 N 1250 0 M 0 83 D S
 N 750 0 M 0 83 D S
 N 250 0 M 0 83 D S
-/PSL_AH0 0
 /MM {M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (3.0) sh mx
@@ -3017,7 +3027,7 @@ N 50 0 M 0 42 D S
 0 -2400 T
 0 setlinecap
 /PSL_H_y PSL_L_y PSL_LH add 233 add def
-1200 2400 PSL_H_y add M
+1200 2400 PSL_H_y add PSL_slant_y add M
 400 F0
 (L2) bc Z
 clipsave
@@ -3198,6 +3208,7 @@ S
 2400 2100 M
 -2400 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2400 M 0 -2400 D S
@@ -3273,8 +3284,8 @@ N 1750 0 M 0 -83 D S
 N 1250 0 M 0 -83 D S
 N 750 0 M 0 -83 D S
 N 250 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (3.0) sh mx
@@ -3503,6 +3514,7 @@ S
 2400 2100 M
 -2400 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2400 M 0 -2400 D S
@@ -3736,9 +3748,9 @@ clipsave
 -2400 0 D
 P
 PSL_clip N
-1068 -2 M
+1070 -2 M
 0 2 D
--467 2400 D
+-476 2400 D
 0 2 D S
 PSL_cliprestore
 %%EndObject
@@ -3787,6 +3799,7 @@ S
 2400 2100 M
 -2400 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2400 M 0 -2400 D S
@@ -4020,9 +4033,9 @@ clipsave
 -2400 0 D
 P
 PSL_clip N
-1068 -2 M
+1070 -2 M
 0 2 D
--467 2400 D
+-475 2400 D
 0 2 D S
 PSL_cliprestore
 %%EndObject
@@ -4071,6 +4084,7 @@ S
 2400 2100 M
 -2400 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 2400 M 0 -2400 D S
@@ -4177,8 +4191,8 @@ N 1750 0 M 0 83 D S
 N 1250 0 M 0 83 D S
 N 750 0 M 0 83 D S
 N 250 0 M 0 83 D S
-/PSL_AH0 0
 /MM {M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (3.0) sh mx
@@ -4222,7 +4236,7 @@ N 50 0 M 0 42 D S
 0 -2400 T
 0 setlinecap
 /PSL_H_y PSL_L_y PSL_LH add 233 add def
-1200 2400 PSL_H_y add M
+1200 2400 PSL_H_y add PSL_slant_y add M
 400 F0
 (LMS) bc Z
 clipsave
@@ -4330,9 +4344,9 @@ clipsave
 -2400 0 D
 P
 PSL_clip N
-1085 -2 M
+1086 -2 M
 -1 2 D
--598 2400 D
+-600 2400 D
 -1 2 D S
 PSL_cliprestore
 %%EndObject
@@ -4420,7 +4434,8 @@ O0
 %%EndObject
 
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U


### PR DESCRIPTION
**Description of proposed changes**

Some issues have come to light via [this forum post](https://forum.generic-mapping-tools.org/t/issues-with-interpreting-the-correlation-r-and-coefficient-of-determination-r-in-gmt-regress/435) that required some changes:

1. Except for regular regression with misfit measured vertically (**-Ey**), the Pearsonian correlation coefficient _r_ and coefficient of determination _R_ are not defined (perhaps they are, but not by the same equations; my Google search could not find equivalent expressions for RMA and Ortho regressions - let me know if you can).  The output for the userʻs case gave wild _r_ and _R_.  I now only output these for **-Ey**.
2. The RLS algorithm of dividing the search angle range by 2 etc. could stop the search too early if the second iteration visited the same (crude) angle step and that happened to be the smallest misfit yet.  Then there would be no drop in best misfit and iterations would stop.  I know ensure that this cannot happen until the angle step in the search is at least < 0.05 degrees.
3. The latter change refined the fits in minor ways for three examples and hence their PS files have been updated.