### PR TITLE
Fix the histogram NEEDS settings

### DIFF
--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -32,6 +32,11 @@
 #define THIS_MODULE_NEEDS	"JR"
 #define THIS_MODULE_OPTIONS "->BJKOPRUVXYbdefhipqstxy" GMT_OPT("Ec")
 
+/* Note: The NEEDS must be JR.  Although pshistogram can create a region from data, it
+ * does so indirectly by building the histogram and setting the ymin/ymax that way, NOT by
+ * reading y data (which is what a NEEDS of d or r would do).
+ */
+
 struct PSHISTOGRAM_CTRL {
 	struct PSHISTOGRAM_Out {	/* -> */
 		bool active;

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -29,7 +29,7 @@
 #define THIS_MODULE_LIB		"core"
 #define THIS_MODULE_PURPOSE	"Calculate and plot histograms"
 #define THIS_MODULE_KEYS	"<D{,CC(,>X},>D),>DI@<D{,ID)"
-#define THIS_MODULE_NEEDS	"J"
+#define THIS_MODULE_NEEDS	"JR"
 #define THIS_MODULE_OPTIONS "->BJKOPRUVXYbdefhipqstxy" GMT_OPT("Ec")
 
 struct PSHISTOGRAM_CTRL {


### PR DESCRIPTION
This PR closes #3197.  Problem was confusion as to what **THIS_MODULE_NEEDS** should be.  Normally, if the module can read data it can determine a region from that data (flag **r** or **d**), but here we do not read y-data, only x-data, and then compute y-data (a function of bin widths, etc).  Thus, the **THIS_MODULE_NEEDS** must be **JR**, but histogram has a special handling of missing **-R** which means use the calculated region instead.  I added some comments near the settings of **THIS_MODULE_NEEDS** to make this clear for the future.