### PR TITLE
Fix line[GMT_BUFSIZ] to line[BUFSIZ] to in gmt_write_glue_function

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16676,7 +16676,7 @@ int gmt_write_glue_function (struct GMTAPI_CTRL *API, char* library) {
 	 */
 
 	char **C = NULL, *lib_purpose = NULL;
-	char line[GMT_BUFSIZ] = {""}, argument[GMT_LEN256] = {""};
+	char line[BUFSIZ] = {""}, argument[GMT_LEN256] = {""};
 	bool first, first_purpose = true;
 	int error = GMT_NOERROR, k = 0, n_alloc = 0, n = -1;	/* Advance to 0 for first item */
 	FILE *fp = NULL;
@@ -16693,7 +16693,7 @@ int gmt_write_glue_function (struct GMTAPI_CTRL *API, char* library) {
 			goto CROAK;
 		}
 		first = true;	/* Reset for each new C file */
-		while (fgets (line, GMT_BUFSIZ, fp)) {	/* This leaves the trailing linefeed intact */
+		while (fgets (line, BUFSIZ, fp)) {	/* This leaves the trailing linefeed intact */
 			if (strncmp (line, "#define THIS_MODULE_", 20U)) continue;	/* Not found our lines yet */
 			if (first) {	/* First time we passed the above if-test */
 				n++, first = false;

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16693,7 +16693,7 @@ int gmt_write_glue_function (struct GMTAPI_CTRL *API, char* library) {
 			goto CROAK;
 		}
 		first = true;	/* Reset for each new C file */
-		while (fgets (line, BUFSIZ, fp)) {	/* This leaves the trailing linefeed intact */
+		while (fgets (line, GMT_BUFSIZ, fp)) {	/* This leaves the trailing linefeed intact */
 			if (strncmp (line, "#define THIS_MODULE_", 20U)) continue;	/* Not found our lines yet */
 			if (first) {	/* First time we passed the above if-test */
 				n++, first = false;


### PR DESCRIPTION
Fix the compiler warning:
```
In file included from /usr/include/stdio.h:862:0,
                 from ../src/postscriptlight.h:46,
                 from ../src/gmt_dev.h:101,
                 from ../src/gmt_support.c:83:
In function ‘fgets’,
    inlined from ‘gmt_write_glue_function’ at ../src/gmt_support.c:16696:10:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:260:9: warning: call to ‘__fgets_chk_warn’ declared with attribute warning: fgets called with bigger size than length of destination buffer
  return __fgets_chk_warn (__s, __bos (__s), __n, __stream);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```