### PR TITLE
Let developers export all gmtlib functions

### DIFF
--- a/cmake/ConfigUserAdvancedTemplate.cmake
+++ b/cmake/ConfigUserAdvancedTemplate.cmake
@@ -226,6 +226,8 @@
 #add_definitions(-DMEMDEBUG) # Turn on memory tracking see gmt_support.c for extra info
 #add_definitions(-DUSE_COMMON_LONG_OPTIONS) 	# Turn on testing of upcoming long-option syntax for common GMT options
 #add_definitions(-DUSE_MODULE_LONG_OPTIONS) 	# Turn on testing of upcoming long-option syntax for module options
+#add_definitions(-DEXPORT_GMTLIB)				# Turn on to access normally un-exported or static gmtlib functions from external tools
+
 #set (CMAKE_C_FLAGS "-Wall -Wdeclaration-after-statement ${CMAKE_C_FLAGS}") # recommended even for release build
 #set (CMAKE_C_FLAGS "-Wextra ${CMAKE_C_FLAGS}")            # extra warnings
 #set (CMAKE_C_FLAGS_DEBUG -ggdb3)                          # gdb debugging symbols

--- a/src/begin.c
+++ b/src/begin.c
@@ -34,7 +34,7 @@
 
 #include "gmt_gsformats.h"
 
-GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
+static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<prefix>] [<format(s)>] [<psconvertoptions] [%s]\n\n", name, GMT_V_OPT);
@@ -64,7 +64,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
-GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
+static int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
 
 	/* This parses the options provided to begin */
 
@@ -90,7 +90,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
 
-GMT_LOCAL char * begin_get_session_name_and_format (struct GMTAPI_CTRL *API, struct GMT_OPTION *opt, int *error) {
+static char * begin_get_session_name_and_format (struct GMTAPI_CTRL *API, struct GMT_OPTION *opt, int *error) {
 	/* Extract session arguments (including optional graphics format) from options:
 	 * gmt begin [<sessionname>] [<formats>] [<psconvertopts>] [-V<arg>]  */
 	char buffer[GMT_LEN256] = {""};

--- a/src/block_subs.h
+++ b/src/block_subs.h
@@ -87,7 +87,7 @@ struct BLOCK_CTRL {
 	} W;
 };
 
-GMT_LOCAL struct GMT_KEYWORD_DICTIONARY module_kw[] = { /* Local options for all the block* modules */
+static struct GMT_KEYWORD_DICTIONARY module_kw[] = { /* Local options for all the block* modules */
 	/* separator, short-option, long-option, short-directives, long-directives, short-modifiers, long-modifiers */
 	{ 0, 'A', "fields", "", "", "", "" },
 	{ 0, 'C', "center", "", "", "", "" },
@@ -202,7 +202,7 @@ struct BLK_DATA {
 /* Declaring the standard functions to allocate and free the program Ctrl structure */
 
 /*! Allocate and initialize a new control structure */
-GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {
+static void *New_Ctrl (struct GMT_CTRL *GMT) {
 	struct BLOCK_CTRL *C;
 
 	C = gmt_M_memory (GMT, NULL, 1, struct  BLOCK_CTRL);
@@ -218,7 +218,7 @@ GMT_LOCAL void *New_Ctrl (struct GMT_CTRL *GMT) {
 }
 
 /*! Deallocate control structure */
-GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct  BLOCK_CTRL *C) {
+static void Free_Ctrl (struct GMT_CTRL *GMT, struct  BLOCK_CTRL *C) {
 	unsigned int k;
 	if (!C) return;
 	for (k = 0; k < C->G.n; k++)
@@ -226,7 +226,7 @@ GMT_LOCAL void Free_Ctrl (struct GMT_CTRL *GMT, struct  BLOCK_CTRL *C) {
 	gmt_M_free (GMT, C);
 }
 
-GMT_LOCAL void strip_commas (const char *in, char out[]) {
+static void strip_commas (const char *in, char out[]) {
 	/* Remove the commas in the input and return the remaining characters via out */
 	size_t i, o = 0;
 	for (i = 0; in[i]; i++)
@@ -246,7 +246,7 @@ enum GMT_enum_blockcases {BLK_CASE_X = 0,
 	BLK_CASE_Z	= 2};
 
 /*! Sort on index, then the specified item a[0,1,2] = x, y, z */
-GMT_LOCAL int BLK_compare_sub (const void *point_1, const void *point_2, int item) {
+static int BLK_compare_sub (const void *point_1, const void *point_2, int item) {
 	const struct BLK_DATA *p1 = point_1, *p2 = point_2;
 
 	/* First sort on bin index ij */
@@ -260,17 +260,17 @@ GMT_LOCAL int BLK_compare_sub (const void *point_1, const void *point_2, int ite
 }
 
 /*! Sort on index, then x */
-GMT_LOCAL int BLK_compare_x (const void *point_1, const void *point_2) {
+static int BLK_compare_x (const void *point_1, const void *point_2) {
 	return (BLK_compare_sub (point_1, point_2, BLK_CASE_X));
 }
 
 /* Sort on index, then y */
-GMT_LOCAL int BLK_compare_y (const void *point_1, const void *point_2) {
+static int BLK_compare_y (const void *point_1, const void *point_2) {
 	return (BLK_compare_sub (point_1, point_2, BLK_CASE_Y));
 }
 
 /*! Sort on index, then z */
-GMT_LOCAL int BLK_compare_index_z (const void *point_1, const void *point_2) {
+static int BLK_compare_index_z (const void *point_1, const void *point_2) {
 	return (BLK_compare_sub (point_1, point_2, BLK_CASE_Z));
 }
 

--- a/src/blockmean.c
+++ b/src/blockmean.c
@@ -58,7 +58,7 @@ enum S_Modes {
  * is required for external calls to make grids, even if just z is requested.  This differs from the command line where
  * -Az is the default and -G is required to set file name format.  */
 
-GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
+static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] %s %s\n", name, GMT_I_OPT, GMT_Rgeo_OPT);
@@ -106,7 +106,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
-GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct BLOCKMEAN_CTRL *Ctrl, struct GMT_OPTION *options) {
+static int parse (struct GMT_CTRL *GMT, struct BLOCKMEAN_CTRL *Ctrl, struct GMT_OPTION *options) {
 	/* This parses the options provided to blockmean and sets parameters in CTRL.
 	 * Any GMT common options will override values set previously by other commands.
 	 * It also replaces any file names specified as input or output with the data ID

--- a/src/blockmedian.c
+++ b/src/blockmedian.c
@@ -44,7 +44,7 @@
  * is required for external calls to make grids, even if just z is requested.  This differs from the command line where
  * -Az is the default and -G is required to set file name format.  */
 
-GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
+static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] %s %s\n", name, GMT_I_OPT, GMT_Rgeo_OPT);
@@ -92,7 +92,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
-GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct BLOCKMEDIAN_CTRL *Ctrl, struct GMT_OPTION *options) {
+static int parse (struct GMT_CTRL *GMT, struct BLOCKMEDIAN_CTRL *Ctrl, struct GMT_OPTION *options) {
 	/* This parses the options provided to blockmedian and sets parameters in CTRL.
 	 * Any GMT common options will override values set previously by other commands.
 	 * It also replaces any file names specified as input or output with the data ID

--- a/src/blockmode.c
+++ b/src/blockmode.c
@@ -55,7 +55,7 @@ struct BIN_MODE_INFO {	/* Used for histogram binning */
  * is required for external calls to make grids, even if just z is requested.  This differs from the command line where
  * -Az is the default and -G is required to set file name format.  */
 
-GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
+static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] %s %s\n", name, GMT_I_OPT, GMT_Rgeo_OPT);
@@ -106,7 +106,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
-GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct BLOCKMODE_CTRL *Ctrl, struct GMT_OPTION *options) {
+static int parse (struct GMT_CTRL *GMT, struct BLOCKMODE_CTRL *Ctrl, struct GMT_OPTION *options) {
 	/* This parses the options provided to blockmode and sets parameters in CTRL.
 	 * Any GMT common options will override values set previously by other commands.
 	 * It also replaces any file names specified as input or output with the data ID

--- a/src/clear.c
+++ b/src/clear.c
@@ -24,6 +24,7 @@
  */
 
 #include "gmt_dev.h"
+#include "gmt_internals.h"
 
 #define THIS_MODULE_CLASSIC_NAME	"clear"
 #define THIS_MODULE_MODERN_NAME	"clear"
@@ -33,10 +34,7 @@
 #define THIS_MODULE_NEEDS	""
 #define THIS_MODULE_OPTIONS	"V"
 
-EXTERN_MSC uint64_t gmtlib_glob_list (struct GMT_CTRL *GMT, const char *pattern, char ***list);
-EXTERN_MSC void gmtlib_free_list (struct GMT_CTRL *GMT, char **list, uint64_t n);
-
-GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
+static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s all|cache|data|sessions|settings [%s]\n\n", name, GMT_V_OPT);
@@ -55,7 +53,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
-GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
+static int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
 
 	/* This parses the options provided to clear.
 	 */
@@ -70,13 +68,13 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
 
-GMT_LOCAL int clear_cache (struct GMTAPI_CTRL *API) {
+static int clear_cache (struct GMTAPI_CTRL *API) {
 	if (gmt_remove_dir (API, API->GMT->session.CACHEDIR, false))
 		return GMT_RUNTIME_ERROR;
 	return GMT_NOERROR;
 }
 
-GMT_LOCAL int clear_defaults (struct GMTAPI_CTRL *API) {
+static int clear_defaults (struct GMTAPI_CTRL *API) {
 	char file[PATH_MAX] = {""};
 	sprintf (file, "%s/gmt.conf", API->gwf_dir);
 	if (gmt_remove_file (API->GMT, file))
@@ -84,7 +82,7 @@ GMT_LOCAL int clear_defaults (struct GMTAPI_CTRL *API) {
 	return GMT_NOERROR;
 }
 
-GMT_LOCAL int clear_data (struct GMTAPI_CTRL *API) {
+static int clear_data (struct GMTAPI_CTRL *API) {
 	char dir[PATH_MAX] = {""};
 	sprintf (dir, "%s/server/srtm1", API->GMT->session.USERDIR);
 	if (access (dir, F_OK) == 0 && gmt_remove_dir (API, dir, false))
@@ -98,7 +96,7 @@ GMT_LOCAL int clear_data (struct GMTAPI_CTRL *API) {
 	return GMT_NOERROR;
 }
 
-GMT_LOCAL int clear_sessions (struct GMTAPI_CTRL *API) {
+static int clear_sessions (struct GMTAPI_CTRL *API) {
 	unsigned int n_dirs, k;
 	char **dirlist = NULL, *here = NULL;
 	if (access (API->session_dir, F_OK)) {

--- a/src/docs.c
+++ b/src/docs.c
@@ -38,7 +38,7 @@
 #define THIS_MODULE_NEEDS	""
 #define THIS_MODULE_OPTIONS	"V"
 
-GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
+static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [-Q] [-S] [%s] <module-name> [<-option>]\n\n", name, GMT_V_OPT);

--- a/src/end.c
+++ b/src/end.c
@@ -33,7 +33,7 @@
 #define THIS_MODULE_NEEDS	""
 #define THIS_MODULE_OPTIONS	"V"
 
-GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
+static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [show] [%s]\n\n", name, GMT_V_OPT);
@@ -47,7 +47,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
-GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options, bool *show) {
+static int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options, bool *show) {
 
 	/* This parses the options provided to end and sets parameters in CTRL.
 	 * Any GMT common options will override values set previously by other commands.

--- a/src/figure.c
+++ b/src/figure.c
@@ -35,7 +35,7 @@
 
 #include "gmt_gsformats.h"
 
-GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
+static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s <prefix> [<formats>] [<psconvertoptions] [%s]\n\n", name, GMT_V_OPT);
@@ -68,7 +68,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 #define GMT_IS_FMT	0
 #define GMT_IS_OPT	1
 
-GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
+static int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
 
 	/* This parses the options provided to grdcut and sets parameters in CTRL.
 	 * Any GMT common options will override values set previously by other commands.

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -8880,8 +8880,8 @@ int GMT_Destroy_Data_ (void *object) {
 }
 #endif
 
-GMT_LOCAL int gmtapi_destroy_grids (struct GMTAPI_CTRL *API, struct GMT_GRID ***obj, unsigned int n_items)
-{	/* Used to destroy a group of grids read via GMT_Read_Group */
+GMT_LOCAL int gmtapi_destroy_grids (struct GMTAPI_CTRL *API, struct GMT_GRID ***obj, unsigned int n_items) {
+	/* Used to destroy a group of grids read via GMT_Read_Group */
 	unsigned int k;
 	int error;
 	struct GMT_GRID **G = *obj;
@@ -8890,8 +8890,8 @@ GMT_LOCAL int gmtapi_destroy_grids (struct GMTAPI_CTRL *API, struct GMT_GRID ***
 	return_error (API, GMT_NOERROR);
 }
 
-GMT_LOCAL int gmtapi_destroy_datasets (struct GMTAPI_CTRL *API, struct GMT_DATASET ***obj, unsigned int n_items)
-{	/* Used to destroy a group of datasets read via GMT_Read_Group */
+GMT_LOCAL int gmtapi_destroy_datasets (struct GMTAPI_CTRL *API, struct GMT_DATASET ***obj, unsigned int n_items) {
+	/* Used to destroy a group of datasets read via GMT_Read_Group */
 	unsigned int k;
 	int error;
 	struct GMT_DATASET **D = *obj;
@@ -8900,8 +8900,8 @@ GMT_LOCAL int gmtapi_destroy_datasets (struct GMTAPI_CTRL *API, struct GMT_DATAS
 	return_error (API, GMT_NOERROR);
 }
 
-GMT_LOCAL int gmtapi_destroy_images (struct GMTAPI_CTRL *API, struct GMT_IMAGE ***obj, unsigned int n_items)
-{	/* Used to destroy a group of images read via GMT_Read_Group */
+GMT_LOCAL int gmtapi_destroy_images (struct GMTAPI_CTRL *API, struct GMT_IMAGE ***obj, unsigned int n_items) {
+	/* Used to destroy a group of images read via GMT_Read_Group */
 	unsigned int k;
 	int error;
 	struct GMT_IMAGE **I = *obj;
@@ -8910,8 +8910,7 @@ GMT_LOCAL int gmtapi_destroy_images (struct GMTAPI_CTRL *API, struct GMT_IMAGE *
 	return_error (API, GMT_NOERROR);
 }
 
-GMT_LOCAL int gmtapi_destroy_palettes (struct GMTAPI_CTRL *API, struct GMT_PALETTE ***obj, unsigned int n_items)
-{
+GMT_LOCAL int gmtapi_destroy_palettes (struct GMTAPI_CTRL *API, struct GMT_PALETTE ***obj, unsigned int n_items) {
 	unsigned int k;
 	int error;
 	struct GMT_PALETTE **C = *obj;
@@ -8920,8 +8919,8 @@ GMT_LOCAL int gmtapi_destroy_palettes (struct GMTAPI_CTRL *API, struct GMT_PALET
 	return_error (API, GMT_NOERROR);
 }
 
-GMT_LOCAL int gmtapi_destroy_postscripts (struct GMTAPI_CTRL *API, struct GMT_POSTSCRIPT ***obj, unsigned int n_items)
-{	/* Used to destroy a group of palettes read via GMT_Read_Group */
+GMT_LOCAL int gmtapi_destroy_postscripts (struct GMTAPI_CTRL *API, struct GMT_POSTSCRIPT ***obj, unsigned int n_items) {
+	/* Used to destroy a group of palettes read via GMT_Read_Group */
 	unsigned int k;
 	int error;
 	struct GMT_POSTSCRIPT **P = *obj;
@@ -8930,8 +8929,8 @@ GMT_LOCAL int gmtapi_destroy_postscripts (struct GMTAPI_CTRL *API, struct GMT_PO
 	return_error (API, GMT_NOERROR);
 }
 
-GMT_LOCAL int gmtapi_destroy_matrices (struct GMTAPI_CTRL *API, struct GMT_MATRIX ***obj, unsigned int n_items)
-{	/* Used to destroy a group of matrices read via GMT_Read_Group */
+GMT_LOCAL int gmtapi_destroy_matrices (struct GMTAPI_CTRL *API, struct GMT_MATRIX ***obj, unsigned int n_items) {
+	/* Used to destroy a group of matrices read via GMT_Read_Group */
 	unsigned int k;
 	int error;
 	struct GMT_MATRIX **M = *obj;
@@ -8940,8 +8939,8 @@ GMT_LOCAL int gmtapi_destroy_matrices (struct GMTAPI_CTRL *API, struct GMT_MATRI
 	return_error (API, GMT_NOERROR);
 }
 
-GMT_LOCAL int gmtapi_destroy_vectors (struct GMTAPI_CTRL *API, struct GMT_VECTOR ***obj, unsigned int n_items)
-{	/* Used to destroy a group of vectors read via GMT_Read_Group */
+GMT_LOCAL int gmtapi_destroy_vectors (struct GMTAPI_CTRL *API, struct GMT_VECTOR ***obj, unsigned int n_items) {
+	/* Used to destroy a group of vectors read via GMT_Read_Group */
 	unsigned int k;
 	int error;
 	struct GMT_VECTOR **V = *obj;

--- a/src/gmt_dev.h
+++ b/src/gmt_dev.h
@@ -83,9 +83,6 @@ extern "C" {
 #	pragma warning( disable : 4244 )	/* conversion from 'uint64_t' to '::size_t', possible loss of data */
 #endif
 
-/* Used to restrict the scope of a function to the file it was declared in */
-#define GMT_LOCAL static
-
 /* CMake definitions: This must be first! */
 #include "gmt_config.h"
 
@@ -114,6 +111,14 @@ extern "C" {
 #include <errno.h>
 
 #include <time.h>
+
+#ifdef EXPORT_GMTLIB
+/* Used to export everything so external enviroments can do unit tests */
+#	define GMT_LOCAL EXTERN_MSC
+#	else
+/* Used to restrict the scope of a function to the file it was declared in */
+#	define GMT_LOCAL static
+#endif
 
 #include "gmt_common_math.h" /* Shared math functions */
 #include "gmt.h"             /* All GMT high-level API */

--- a/src/gmt_dev.h
+++ b/src/gmt_dev.h
@@ -115,7 +115,7 @@ extern "C" {
 #ifdef EXPORT_GMTLIB
 /* Used to export everything so external enviroments can do unit tests */
 #	define GMT_LOCAL EXTERN_MSC
-#	else
+#else
 /* Used to restrict the scope of a function to the file it was declared in */
 #	define GMT_LOCAL static
 #endif

--- a/src/gmt_enum_dict.h
+++ b/src/gmt_enum_dict.h
@@ -30,7 +30,7 @@ struct GMT_API_DICT {
 
 #define GMT_N_API_ENUMS 237
 
-GMT_LOCAL struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
+static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_ADD_DEFAULT", 6},
 	{"GMT_ADD_EXISTING", 16},
 	{"GMT_ADD_FILES_ALWAYS", 2},

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -519,8 +519,7 @@ GMT_LOCAL int gmtgrdio_padspace (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h
 	return (true);	/* Return true so the calling function can take appropriate action */
 }
 
-GMT_LOCAL void gmtgrdio_handle_pole_averaging (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_grdfloat *grid, gmt_grdfloat f_value, int pole)
-{
+GMT_LOCAL void gmtgrdio_handle_pole_averaging (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_grdfloat *grid, gmt_grdfloat f_value, int pole) {
 	uint64_t node;
 	unsigned int col = 0;
 	char *name[3] = {"south", "", "north"};

--- a/src/gmt_hidden.h
+++ b/src/gmt_hidden.h
@@ -32,16 +32,16 @@
 #ifndef GMT_HIDDEN_H
 #define GMT_HIDDEN_H
 
-GMT_LOCAL inline struct GMT_DATASET_HIDDEN     * gmt_get_DD_hidden (struct GMT_DATASET *p)     {return (p->hidden);}
-GMT_LOCAL inline struct GMT_DATATABLE_HIDDEN   * gmt_get_DT_hidden (struct GMT_DATATABLE *p)   {return (p->hidden);}
-GMT_LOCAL inline struct GMT_DATASEGMENT_HIDDEN * gmt_get_DS_hidden (struct GMT_DATASEGMENT *p) {return (p->hidden);}
-GMT_LOCAL inline struct GMT_PALETTE_HIDDEN     * gmt_get_C_hidden (struct GMT_PALETTE *p)      {return (p->hidden);}
-GMT_LOCAL inline struct GMT_POSTSCRIPT_HIDDEN  * gmt_get_P_hidden (struct GMT_POSTSCRIPT *p)   {return (p->hidden);}
-GMT_LOCAL inline struct GMT_VECTOR_HIDDEN      * gmt_get_V_hidden (struct GMT_VECTOR *p)       {return (p->hidden);}
-GMT_LOCAL inline struct GMT_MATRIX_HIDDEN      * gmt_get_M_hidden (struct GMT_MATRIX *p)       {return (p->hidden);}
-GMT_LOCAL inline struct GMT_GRID_HIDDEN        * gmt_get_G_hidden (struct GMT_GRID *p)         {return (p->hidden);}
-GMT_LOCAL inline struct GMT_IMAGE_HIDDEN       * gmt_get_I_hidden (struct GMT_IMAGE *p)        {return (p->hidden);}
-GMT_LOCAL inline struct GMT_GRID_HEADER_HIDDEN * gmt_get_H_hidden (struct GMT_GRID_HEADER *p)  {return (p->hidden);}
+static inline struct GMT_DATASET_HIDDEN     * gmt_get_DD_hidden (struct GMT_DATASET *p)     {return (p->hidden);}
+static inline struct GMT_DATATABLE_HIDDEN   * gmt_get_DT_hidden (struct GMT_DATATABLE *p)   {return (p->hidden);}
+static inline struct GMT_DATASEGMENT_HIDDEN * gmt_get_DS_hidden (struct GMT_DATASEGMENT *p) {return (p->hidden);}
+static inline struct GMT_PALETTE_HIDDEN     * gmt_get_C_hidden (struct GMT_PALETTE *p)      {return (p->hidden);}
+static inline struct GMT_POSTSCRIPT_HIDDEN  * gmt_get_P_hidden (struct GMT_POSTSCRIPT *p)   {return (p->hidden);}
+static inline struct GMT_VECTOR_HIDDEN      * gmt_get_V_hidden (struct GMT_VECTOR *p)       {return (p->hidden);}
+static inline struct GMT_MATRIX_HIDDEN      * gmt_get_M_hidden (struct GMT_MATRIX *p)       {return (p->hidden);}
+static inline struct GMT_GRID_HIDDEN        * gmt_get_G_hidden (struct GMT_GRID *p)         {return (p->hidden);}
+static inline struct GMT_IMAGE_HIDDEN       * gmt_get_I_hidden (struct GMT_IMAGE *p)        {return (p->hidden);}
+static inline struct GMT_GRID_HEADER_HIDDEN * gmt_get_H_hidden (struct GMT_GRID_HEADER *p)  {return (p->hidden);}
 
 /* Here are the GMT data types used for tables */
 
@@ -200,6 +200,6 @@ struct GMT_IMAGE_HIDDEN {	/* Supporting information hidden from the API */
 };
 
 /* Get the segments next segment (for holes in perimeters */
-GMT_LOCAL inline struct GMT_DATASEGMENT * gmt_get_next_S (struct GMT_DATASEGMENT *S) {struct GMT_DATASEGMENT_HIDDEN *SH = gmt_get_DS_hidden (S); return (SH->next);}
+static inline struct GMT_DATASEGMENT * gmt_get_next_S (struct GMT_DATASEGMENT *S) {struct GMT_DATASEGMENT_HIDDEN *SH = gmt_get_DS_hidden (S); return (SH->next);}
 
 #endif /* GMT_HIDDEN_H */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -365,7 +365,7 @@ static struct GMT_FONTSPEC GMT_standard_fonts[GMT_N_STANDARD_FONTS] = {
  * common options without the module options, you cannot do the reverse.
   */
 
-GMT_LOCAL struct GMT_KEYWORD_DICTIONARY gmt_common_kw[] = {
+static struct GMT_KEYWORD_DICTIONARY gmt_common_kw[] = {
 	/* separator, short-option, long-option, short-directives, long-directives, short-modifiers, long-modifiers */
 	{   0, 'B', "frame",         "",        "",                                         "b,g,n,o,t",				"box,fill,noframe,oblique-pole,title" },
 	{   0, 'B', "axis",          "x,y,z",   "x,y,z",                                    "a,f,l,L,p,s,S,u",			"angle,fancy,label,Label,prefix,second-label,Second-label,unit" },

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -207,8 +207,8 @@ GMT_LOCAL bool gmtio_is_a_NaN_line (struct GMT_CTRL *GMT, char *line) {
 }
 
 /*! . */
-GMT_LOCAL unsigned int gmtio_is_segment_header (struct GMT_CTRL *GMT, char *line)
-{	/* Returns 1 if this record is a GMT segment header;
+GMT_LOCAL unsigned int gmtio_is_segment_header (struct GMT_CTRL *GMT, char *line) {
+	/* Returns 1 if this record is a GMT segment header;
 	 * Returns 2 if this record is a segment breaker;
 	 * Otherwise returns 0 */
 	if (GMT->current.setting.io_blankline[GMT_IN] && gmt_is_a_blank_line (line)) return (2);	/* Treat blank line as segment break */
@@ -3841,8 +3841,8 @@ GMT_LOCAL int gmtio_write_table (struct GMT_CTRL *GMT, void *dest, unsigned int 
 }
 
 /*! . */
-GMT_LOCAL void * gmtio_nc_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, int *retval)
-{	/* netCDF tables contain information about the number of records, so we can use a
+GMT_LOCAL void * gmtio_nc_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, int *retval) {
+	/* netCDF tables contain information about the number of records, so we can use a
 	 * faster strategy: When file is opened, determine number of rows and columns and
 	 * preallocate all the column vectors.  Then, when we ask for the first data record
 	 * we read the entire data set.  We then simply return the values corresponding to
@@ -4085,8 +4085,8 @@ GMT_LOCAL FILE *gmtio_nc_fopen (struct GMT_CTRL *GMT, const char *filename, cons
 }
 
 /*! . */
-GMT_LOCAL bool gmtio_file_is_readable (struct GMT_CTRL *GMT, char *path)
-{	/* Returns true if readable, otherwise give error and return false */
+GMT_LOCAL bool gmtio_file_is_readable (struct GMT_CTRL *GMT, char *path) {
+	/* Returns true if readable, otherwise give error and return false */
 	if (!access (path, R_OK)) return (true);	/* Readable */
 	/* Get here when found, but not readable */
 	GMT_Report (GMT->parent, GMT_MSG_WARNING, "Unable to read %s (permissions?)\n", path);

--- a/src/gmt_make_enum_dicts.sh
+++ b/src/gmt_make_enum_dicts.sh
@@ -55,7 +55,7 @@ struct GMT_API_DICT {
 
 #define GMT_N_API_ENUMS $n
 
-GMT_LOCAL struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
+static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 EOF
 
 sort -k 1 ${TMPDIR}/junk2.txt | awk '{printf "\t{\"%s\", %d},\n", $1, $2}' >> gmt_enum_dict.h

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -1892,7 +1892,7 @@ GMT_LOCAL uint64_t gmtmap_radial_boundary_arc (struct GMT_CTRL *GMT, int this_wa
 
 #ifdef DEBUG
 /* If we need to dump out clipped polygon then set clip_dump = 1 during execution */
-GMT_LOCAL int clip_dump = 0, clip_id = 0;
+static int clip_dump = 0, clip_id = 0;
 GMT_LOCAL void gmtmap_dumppol (uint64_t n, double *x, double *y, int *id) {
 	uint64_t i;
 	FILE *fp = NULL;
@@ -3910,14 +3910,13 @@ GMT_LOCAL bool gmtmap_init_ortho (struct GMT_CTRL *GMT) {
 }
 
 /*! . */
-GMT_LOCAL double gmtmap_left_genper (struct GMT_CTRL *GMT, double y)
-{	/* Windowed genper may need to consider the inner of circle and rectangle */
+GMT_LOCAL double gmtmap_left_genper (struct GMT_CTRL *GMT, double y) {
+	/* Windowed genper may need to consider the inner of circle and rectangle */
 	return (MAX (0.0, gmtmap_left_circle (GMT, y)));
 }
 
 /*! . */
-GMT_LOCAL double gmtmap_right_genper (struct GMT_CTRL *GMT, double y)
-{
+GMT_LOCAL double gmtmap_right_genper (struct GMT_CTRL *GMT, double y) {
 	return (MIN (GMT->current.map.width, gmtmap_right_circle (GMT, y)));
 }
 
@@ -9483,8 +9482,7 @@ struct GMT_DATASEGMENT * gmt_get_smallcircle (struct GMT_CTRL *GMT, double plon,
 	return (S);	/* Pass out the results */
 }
 
-GMT_LOCAL void gmtmap_ellipse_point (struct GMT_CTRL *GMT, double lon, double lat, double center, double sinp, double cosp, double major, double minor, double cos_azimuth, double sin_azimuth, double angle, double *plon, double *plat)
-{
+GMT_LOCAL void gmtmap_ellipse_point (struct GMT_CTRL *GMT, double lon, double lat, double center, double sinp, double cosp, double major, double minor, double cos_azimuth, double sin_azimuth, double angle, double *plon, double *plat) {
 	/* Lon, lat is center of ellipse, our point is making an angle with the major axis. */
 	double x, y, x_prime, y_prime, rho, c, sin_c, cos_c;
 	sincos (angle, &y, &x);

--- a/src/gmt_remote.h
+++ b/src/gmt_remote.h
@@ -42,7 +42,7 @@ struct GMT_DATA_HASH {	/* Holds file hashes (probably SHA256) */
 
 /* When making edits below, make sure string does not exceed 127 characters as indicated by the bars below:
  *                  |                                                                                                                              | */
-GMT_LOCAL struct GMT_DATA_INFO gmt_data_info[GMT_N_DATA_INFO_ITEMS] = {
+static struct GMT_DATA_INFO gmt_data_info[GMT_N_DATA_INFO_ITEMS] = {
 	{"60m", "106K", "Earth Relief at 60x60 arc minutes from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]"},
 	{"01d", "106K", "Earth Relief at 1x1 arc degrees from Gaussian Cartesian filtering (111 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]"},
 	{"30m", "363K", "Earth Relief at 30x30 arc minutes from Gaussian Cartesian filtering (55 km fullwidth) of SRTM15+V2.1 [Tozer et al., 2019]"},

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -5769,8 +5769,7 @@ void gmtlib_free_list (struct GMT_CTRL *GMT, char **list, uint64_t n) {
 
 #ifndef WIN32
 /*! . */
-GMT_LOCAL int gmtsupport_globerr (const char *path, int eerrno)
-{
+GMT_LOCAL int gmtsupport_globerr (const char *path, int eerrno) {
 	fprintf (stderr, "gmtlib_glob_list: %s: %s\n", path, strerror(eerrno));
 	return 0;	/* let glob() keep going */
 }

--- a/src/gmtmath.c
+++ b/src/gmtmath.c
@@ -5599,8 +5599,7 @@ GMT_LOCAL int gmtmath_ROOTS (struct GMT_CTRL *GMT, struct GMTMATH_INFO *info, st
 
 #define GMTMATH_N_OPERATORS 197
 
-GMT_LOCAL void gmtmath_init (int (*ops[])(struct GMT_CTRL *, struct GMTMATH_INFO *, struct GMTMATH_STACK **S, unsigned int, unsigned int), unsigned int n_args[], unsigned int n_out[])
-{
+GMT_LOCAL void gmtmath_init (int (*ops[])(struct GMT_CTRL *, struct GMTMATH_INFO *, struct GMTMATH_STACK **S, unsigned int, unsigned int), unsigned int n_args[], unsigned int n_out[]) {
 	/* Operator function	# of operands	# of outputs */
 
 	ops[0] = gmtmath_ABS;	n_args[0] = 1;	n_out[0] = 1;
@@ -5934,8 +5933,8 @@ GMT_LOCAL char *gmtmath_setlabel (struct GMT_CTRL *GMT, char *arg) {
 	return (label);
 }
 
-GMT_LOCAL void gmtmath_backwards_fixing (struct GMT_CTRL *GMT, char **arg)
-{	/* Handle backwards compatible operator names */
+GMT_LOCAL void gmtmath_backwards_fixing (struct GMT_CTRL *GMT, char **arg) {
+	/* Handle backwards compatible operator names */
 	char *t = NULL, old[GMT_LEN16] = {""};
 	if (!gmt_M_compat_check (GMT, 6)) return;	/* No checking so we may fail later */
 	if (!strcmp (*arg, "CHIDIST"))      {strncpy (old, *arg, GMT_LEN16-1); gmt_M_str_free (*arg); *arg = t = strdup ("CHI2CDF");  }

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -688,8 +688,7 @@ GMT_LOCAL double grdmath_stack_collapse_xor (struct GMT_CTRL *GMT, double *array
  *              Definitions of all operator functions
  * -----------------------------------------------------------------*/
 
-GMT_LOCAL int grdmath_collapse_stack (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last, char *OP)
-{
+GMT_LOCAL int grdmath_collapse_stack (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, struct GRDMATH_STACK *stack[], unsigned int last, char *OP) {
 	/* Collapse stack will apply the given operator to all items on the stack, per node.
 	 * E.g., you may have 7 grids on the stack and you want to return the mean value per node
 	 * for all 7 grids, to be replaced by a single grid with those means.  You would do
@@ -5827,8 +5826,8 @@ static void grdmath_init (void (*ops[]) (struct GMT_CTRL *, struct GRDMATH_INFO 
 #define Return1(code) {GMT_Destroy_Options (API, &list); Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 #define Return(code) {GMT_Destroy_Options (API, &list); Free_Ctrl (GMT, Ctrl); grdmath_free (GMT, stack, recall, &info); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
-GMT_LOCAL void grdmath_backwards_fixing (struct GMT_CTRL *GMT, char **arg)
-{	/* Handle backwards compatible operator names */
+GMT_LOCAL void grdmath_backwards_fixing (struct GMT_CTRL *GMT, char **arg) {
+	/* Handle backwards compatible operator names */
 	char *t = NULL, old[GMT_LEN16] = {""};
 	if (!gmt_M_compat_check (GMT, 6)) return;	/* No checking so we may fail later */
 	if (!strcmp (*arg, "CHIDIST"))      {strncpy (old, *arg, GMT_LEN16-1); gmt_M_str_free (*arg); *arg = t = strdup ("CHI2CDF");  }

--- a/src/mgd77/mgd77.c
+++ b/src/mgd77/mgd77.c
@@ -2947,8 +2947,8 @@ int MGD77_Write_Header_Record (struct GMT_CTRL *GMT, char *file, struct MGD77_CO
 	return (error);
 }
 
-GMT_LOCAL int mgd77_read_header_record_m77_nohdr (struct GMT_CTRL *GMT, char *file, struct MGD77_CONTROL *F, struct MGD77_HEADER *H)
-{	/* Applies to MGD77 files */
+GMT_LOCAL int mgd77_read_header_record_m77_nohdr (struct GMT_CTRL *GMT, char *file, struct MGD77_CONTROL *F, struct MGD77_HEADER *H) {
+	/* Applies to MGD77 files */
 	char *MGD77_header[MGD77_N_HEADER_RECORDS], line[BUFSIZ], *not_used = NULL;
 	int i, sequence, err, n_eols, c, n;
 	struct stat buf;
@@ -3012,8 +3012,8 @@ GMT_LOCAL int mgd77_read_header_record_m77_nohdr (struct GMT_CTRL *GMT, char *fi
 	return (MGD77_NO_ERROR);	/* Success, it seems */
 }
 
-GMT_LOCAL int mgd77_read_header_record_m77t_nohdr (struct GMT_CTRL *GMT, char *file, struct MGD77_CONTROL *F, struct MGD77_HEADER *H)
-{	/* Applies to MGD77T files */
+GMT_LOCAL int mgd77_read_header_record_m77t_nohdr (struct GMT_CTRL *GMT, char *file, struct MGD77_CONTROL *F, struct MGD77_HEADER *H) {
+	/* Applies to MGD77T files */
 	char *MGD77_header, line[BUFSIZ], *not_used = NULL;
 	int i, err;
 	gmt_M_unused(file);
@@ -3046,8 +3046,8 @@ GMT_LOCAL int mgd77_read_header_record_m77t_nohdr (struct GMT_CTRL *GMT, char *f
 	return (MGD77_NO_ERROR);	/* Success, it seems */
 }
 
-GMT_LOCAL int mgd77_read_header_record_nohdr (struct GMT_CTRL *GMT, char *file, struct MGD77_CONTROL *F, struct MGD77_HEADER *H)
-{	/* Reads the header structure form a MGD77[+] file */
+GMT_LOCAL int mgd77_read_header_record_nohdr (struct GMT_CTRL *GMT, char *file, struct MGD77_CONTROL *F, struct MGD77_HEADER *H) {
+	/* Reads the header structure form a MGD77[+] file */
 	int error;
 
 	switch (F->format) {
@@ -3073,8 +3073,7 @@ GMT_LOCAL int mgd77_read_header_record_nohdr (struct GMT_CTRL *GMT, char *file, 
 	return (error);
 }
 
-GMT_LOCAL int mgd77_read_file_cdf_nohdr (struct GMT_CTRL *GMT, char *file, struct MGD77_CONTROL *F, struct MGD77_DATASET *S)
-{
+GMT_LOCAL int mgd77_read_file_cdf_nohdr (struct GMT_CTRL *GMT, char *file, struct MGD77_CONTROL *F, struct MGD77_DATASET *S) {
 	int err;
 
 	MGD77_Select_All_Columns (GMT, F, &S->H);
@@ -3090,8 +3089,8 @@ GMT_LOCAL int mgd77_read_file_cdf_nohdr (struct GMT_CTRL *GMT, char *file, struc
 	return (MGD77_NO_ERROR);
 }
 
-GMT_LOCAL int mgd77_read_file_asc_nohdr (struct GMT_CTRL *GMT, char *file, struct MGD77_CONTROL *F, struct MGD77_DATASET *S)	  /* Will read all MGD77 records in current file */
-{
+GMT_LOCAL int mgd77_read_file_asc_nohdr (struct GMT_CTRL *GMT, char *file, struct MGD77_CONTROL *F, struct MGD77_DATASET *S) {
+	/* Will read all MGD77 records in current file */
 	int err;
 
 	err = MGD77_Open_File (GMT, file, F, MGD77_READ_MODE);
@@ -3110,8 +3109,7 @@ GMT_LOCAL int mgd77_read_file_asc_nohdr (struct GMT_CTRL *GMT, char *file, struc
 	return (MGD77_NO_ERROR);
 }
 
-int MGD77_Read_File_nohdr (struct GMT_CTRL *GMT, char *file, struct MGD77_CONTROL *F, struct MGD77_DATASET *S)
-{
+int MGD77_Read_File_nohdr (struct GMT_CTRL *GMT, char *file, struct MGD77_CONTROL *F, struct MGD77_DATASET *S) {
 	int err = 0;
 
 	switch (F->format) {

--- a/src/potential/talwani.h
+++ b/src/potential/talwani.h
@@ -32,7 +32,7 @@
 
 #include "../mgd77/mgd77_IGF_coeffs.h"	/* Normal gravity coefficients */
 
-GMT_LOCAL double g_normal (double lat) {
+static double g_normal (double lat) {
 	/* IAG 1980 model */
 	double slat2 = sind (lat);
 	slat2 *= slat2;


### PR DESCRIPTION
See #3199.  This redefines **GMT_LOCAL** to mean **MSC_EXPORT** when **-DEXPORT_GMTLIB** is added to the CFLAGS. No duplicate symbols found (compiles and links fine) and all tests pass on macOS. Various structs and some remaining parse, usage functions set to static. Oh, and some minor function formatting cleaning.  Closes #3199.
