### PR TITLE
Warn if deprecated variable GMT_DATA_URL is used

### DIFF
--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -159,6 +159,7 @@ if (NOT GMT_INCLUDEDIR)
 endif(NOT GMT_INCLUDEDIR)
 
 if (GMT_DATA_URL) # Backwards compatibility with old ConfigUser.cmake files
+	message (WARNING "CMake variable GMT_DATA_URL is deprecated and will be removed in the futhure releases. Use GMT_DATA_SERVER instead.")
 	set (GMT_DATA_SERVER ${GMT_DATA_URL})
 endif (GMT_DATA_URL)
 


### PR DESCRIPTION
GMT_DATA_URL was renamed to GMT_DATA_SERVER but kept for backward compatibility.

We should warn users that GMT_DATA_URL is deprecated. If someone uses GMT_DATA_URL, he/she will see an warning:

```
CMake Warning at cmake/modules/ConfigCMake.cmake:162 (message):
  CMake variable GMT_DATA_URL is deprecated and will be removed in the
  futhure releases.  Use GMT_DATA_SERVER instead.
Call Stack (most recent call first):
  CMakeLists.txt:75 (include)
```