### PR TITLE
Remove a few empty statements

### DIFF
--- a/src/grd2kml.c
+++ b/src/grd2kml.c
@@ -382,7 +382,7 @@ GMT_LOCAL void grd2kml_halve_dimensions (double *inc, double *step) {
 
 GMT_LOCAL unsigned int grd2kml_max_level (struct GMT_CTRL *GMT, bool global, struct GMT_GRID_HEADER *H, unsigned int size, unsigned int extra) {
 	unsigned int level = 0;
-	if (global) {;
+	if (global) {
 		unsigned int n = 1, f = 1, go = 1;
 		double inc = 1.0, step = 360, range;
 		GMT_Report (GMT->parent, GMT_MSG_NOTICE, "Level = %2.2d tile size = %gd grid inc = %gm n_tiles = %d\n", level, step, 60*inc, n);

--- a/src/mgd77/mgd77.c
+++ b/src/mgd77/mgd77.c
@@ -5762,7 +5762,7 @@ unsigned int MGD77_Scan_Corrtable (struct GMT_CTRL *GMT, char *tablefile, char *
 					sscanf (p, "%[^-]-%[^)])", name, origin);
 				else			/* Just (value), origin == 0.0 */
 					sscanf (p, "%[^)])", name);
-				if ((id = MGD77_Match_List (GMT, name, n_list, list)) == MGD77_NOT_SET) {;	/* Not a recognized column */
+				if ((id = MGD77_Match_List (GMT, name, n_list, list)) == MGD77_NOT_SET) {	/* Not a recognized column */
 					list[n_list] = strdup (name);
 					n_list++;
 					if (n_list == n_alloc) {
@@ -5920,7 +5920,7 @@ int MGD77_Parse_Corrtable (struct GMT_CTRL *GMT, char *tablefile, char **cruises
 					sscanf (p, "%[^)])", name);
 					c->origin = 0.0;
 				}
-				if ((c->id = MGD77_Match_List (GMT, name, n_fields, field_names)) == MGD77_NOT_SET) {;	/* Not a recognized column */
+				if ((c->id = MGD77_Match_List (GMT, name, n_fields, field_names)) == MGD77_NOT_SET) {	/* Not a recognized column */
 					for (i = 0; i < n_aux; i++) if (!strcmp (name, aux_names[i])) c->id = i;	/* check auxiliaries */
 					if (c->id == MGD77_NOT_SET) { /* Not an auxiliary column either */
 						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Column %s not found - requested by the correction table %s!\n", name, tablefile);


### PR DESCRIPTION
```
if (a) {;
  c = d + e;
}
```

`{;` adds a empty statement at the beginning of the code block. These empty statements are useless.
I believe they're just typos.