### PR TITLE
cmake: Bump the minimum required CMake version to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ if (${srcdir} STREQUAL ${bindir})
 endif (${srcdir} STREQUAL ${bindir})
 
 # Define minimum CMake version required
-cmake_minimum_required (VERSION 2.8.7)
+cmake_minimum_required (VERSION 2.8.12)
 
 # Use NEW behavior with newer CMake releases
 foreach (p


### PR DESCRIPTION
CMake 2.8.12 (released in 2013) is the final version for CMake 2.x.

It's reasonable to assume Windows and macOS users are using CMake 3.x.
Although most of the currenly supported Linux distros provide CMake 3.x,
Ubuntu 14.04, CentOS 6 and CentOS 7 still provide CMake 2.8.12 by default.

Here we bump the minimum required CMake version to 2.8.12.
After the three distros are no longer officially supported, we can bump
it to CMake 3.x.