### PR TITLE
Let movie delete input scripts if selected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ share/dcw
 src/newsuppl*
 **/gmt.history
 .DS_Store
+doc/examples/**/*.mp4
+doc/examples/**/*.png
+doc/examples/**/*.gif

--- a/doc/examples/anim01/anim01.sh
+++ b/doc/examples/anim01/anim01.sh
@@ -34,5 +34,4 @@ gmt begin
 gmt end
 EOF
 # 3. Run the movie
-gmt movie main.sh -Sbpre.sh -C4ix2ix125 -Tsin_point.txt -Z -Nanim01 -D5 $opt
-rm -rf main.sh pre.sh
+gmt movie main.sh -Sbpre.sh -C4ix2ix125 -Tsin_point.txt -Zs -Nanim01 -D5 $opt

--- a/doc/examples/anim02/anim02.sh
+++ b/doc/examples/anim02/anim02.sh
@@ -30,5 +30,4 @@ gmt begin
 gmt end
 EOF
 # 3. Run the movie
-gmt movie main.sh -C3.5ix4.167ix72 -Nanim02 -Tangles.txt -Sbpre.sh -D6 -Z $opt
-rm -rf main.sh pre.sh
+gmt movie main.sh -C3.5ix4.167ix72 -Nanim02 -Tangles.txt -Sbpre.sh -D6 -Zs $opt

--- a/doc/examples/anim03/anim03.sh
+++ b/doc/examples/anim03/anim03.sh
@@ -28,5 +28,4 @@ gmt begin
 gmt end
 EOF
 # 3. Run the movie
-gmt movie main.sh -C4ix2.5ix100 -Nanim03 -Tangles.txt -Sbpre.sh -D10 -Pb -Z $opt
-rm -rf main.sh pre.sh
+gmt movie main.sh -C4ix2.5ix100 -Nanim03 -Tangles.txt -Sbpre.sh -D10 -Pb -Zs $opt

--- a/doc/examples/anim04/anim04.sh
+++ b/doc/examples/anim04/anim04.sh
@@ -31,5 +31,4 @@ gmt begin
 gmt end
 EOF
 # 3. Run the movie
-gmt movie main.sh -C7.2ix4.8ix100 -Nanim04 -Tflight_path.txt -Sbpre.sh -Z -H2 -Lf+o0.1i+f14p,Helvetica-Bold $opt
-rm -f main.sh pre.sh
+gmt movie main.sh -C7.2ix4.8ix100 -Nanim04 -Tflight_path.txt -Sbpre.sh -Zs -H2 -Lf+o0.1i+f14p,Helvetica-Bold $opt

--- a/doc/examples/anim05/anim05.sh
+++ b/doc/examples/anim05/anim05.sh
@@ -30,5 +30,4 @@ gmt begin
 gmt end
 EOF
 # 3. Run the movie
-gmt movie main.sh -C4.5ix5.0ix100 -Nanim05 -T@Table_5_11.txt -Sbpre.sh -D10 -Z $opt
-rm -rf main.sh pre.sh
+gmt movie main.sh -C4.5ix5.0ix100 -Nanim05 -T@Table_5_11.txt -Sbpre.sh -D10 -Zs $opt

--- a/doc/examples/anim06/anim06.sh
+++ b/doc/examples/anim06/anim06.sh
@@ -73,5 +73,4 @@ gmt begin
 gmt end
 EOF
 # 3. Run the movie
-gmt movie main.sh -Sbpre.sh -C7.2ix4.8ix100 -Iinit.sh -Tframe_times.txt -D$rate -Nanim06 -Z $opt
-rm -rf init.sh main.sh pre.sh
+gmt movie main.sh -Sbpre.sh -C7.2ix4.8ix100 -Iinit.sh -Tframe_times.txt -D$rate -Nanim06 -Zs $opt

--- a/doc/examples/anim07/anim07.sh
+++ b/doc/examples/anim07/anim07.sh
@@ -41,5 +41,4 @@ gmt begin
 gmt end
 EOF
 # 3. Run the movie
-gmt movie main.sh -Sbpre.sh -C6ix6ix100 -Tlongitudes.txt -Nanim07 -H2 -Pa -Z $opt
-rm -rf main.sh pre.sh
+gmt movie main.sh -Sbpre.sh -C6ix6ix100 -Tlongitudes.txt -Nanim07 -H2 -Pa -Zs $opt

--- a/doc/examples/anim08/anim08.sh
+++ b/doc/examples/anim08/anim08.sh
@@ -36,5 +36,4 @@ gmt begin
 gmt end
 EOF
 # 3. Run the movie
-gmt movie main.sh -Sbpre.sh -C6ix6ix100 -Ttimes.txt -Nanim08 -Gblack -H2 -Z -Lc0+f20p,Helvetica,white --FORMAT_CLOCK_MAP=- $opt
-rm -rf main.sh pre.sh
+gmt movie main.sh -Sbpre.sh -C6ix6ix100 -Ttimes.txt -Nanim08 -Gblack -H2 -Zs -Lc0+f20p,Helvetica,white --FORMAT_CLOCK_MAP=- $opt

--- a/doc/examples/movie01/movie01.sh
+++ b/doc/examples/movie01/movie01.sh
@@ -18,6 +18,7 @@
 # https://www.youtube.com/watch?v=LTxlR5LuJ8g
 # The movie took ~6 hours to render on a 24-core MacPro 2013.
 
+gmt set PROJ_LENGTH_UNIT inch FONT_TAG 20p,Helvetica,white
 cat << EOF > pre.sh
 #!/bin/bash
 # Pre-script: Runs once to produce files needed for all frames
@@ -26,7 +27,6 @@ gmt begin
 	gmt makecpt -Cgeo -H > MOR_topo.cpt
 gmt end
 EOF
-gmt set PROJ_LENGTH_UNIT inch FONT_TAG 20p,Helvetica,white
 cat << EOF > include.sh
 # A set of parameters needed by all frames
 ALTITUDE=1000
@@ -45,6 +45,5 @@ gmt begin
 gmt end
 EOF
 # 3. Run the movie
-gmt movie main.sh -Iinclude.sh -CHD -Sbpre.sh -TMOR_PAC_twist_path.txt -Nmovie01 -D24 -H4 -Fmp4 -K -M2000,png -Gblack -Le+jTR -Lf -V -W/tmp/MOR -Z
-# Clean up
-rm -f include.sh pre.sh main.sh gmt.conf
+gmt movie main.sh -Iinclude.sh -CHD -Sbpre.sh -TMOR_PAC_twist_path.txt -Nmovie01 -D24 -H4 -Fnone -K -M2000,png -Gblack -Le+jTR -Lf -V -W/tmp/MOR -Zs
+rm -f gmt.conf

--- a/doc/examples/movie01/movie01.sh
+++ b/doc/examples/movie01/movie01.sh
@@ -18,7 +18,6 @@
 # https://www.youtube.com/watch?v=LTxlR5LuJ8g
 # The movie took ~6 hours to render on a 24-core MacPro 2013.
 
-gmt set PROJ_LENGTH_UNIT inch FONT_TAG 20p,Helvetica,white
 cat << EOF > pre.sh
 #!/bin/bash
 # Pre-script: Runs once to produce files needed for all frames
@@ -45,5 +44,6 @@ gmt begin
 gmt end
 EOF
 # 3. Run the movie
+gmt set PROJ_LENGTH_UNIT inch FONT_TAG 20p,Helvetica,white
 gmt movie main.sh -Iinclude.sh -CHD -Sbpre.sh -TMOR_PAC_twist_path.txt -Nmovie01 -D24 -H4 -Fnone -K -M2000,png -Gblack -Le+jTR -Lf -V -W/tmp/MOR -Zs
 rm -f gmt.conf

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -31,7 +31,7 @@ Synopsis
 [ **-Sb**\ *background* ]
 [ **-Sf**\ *foreground* ]
 [ |SYN_OPT-V| ]
-[ |-Z| ]
+[ |-Z|\ [**s**] ]
 [ |-W|\ *workdir* ]
 [ |SYN_OPT-x| ]
 [ |SYN_OPT--| ]
@@ -265,9 +265,11 @@ Optional Arguments
 
 .. _-Z:
 
-**-Z**
+**-Z**\ [**s**]
     Erase the entire *prefix* directory after assembling the final movie [Default leaves directory with all images;
-    the script files, parameter files, and layer *PostScript* files are all removed (but see **-Q**)].
+    the temporary script files, parameter files, and layer *PostScript* files are all removed (but see **-Q**)].
+    If your *mainscript* and all input scripts via **-E**, **-I**, and **-S** should be deleted as well then
+    append **s**.
 
 .. _-cores:
 

--- a/src/movie.c
+++ b/src/movie.c
@@ -1209,6 +1209,31 @@ GMT_LOCAL bool movie_is_gmt_end_show (char *line) {
 	return false;	/* Not gmt end show */
 }
 
+GMT_LOCAL int movie_delete_scripts (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl) {
+	/* Delete the scripts since they apparently are temporary */
+	if (Ctrl->In.file && gmt_remove_file (GMT, Ctrl->In.file)) {	/* Delete the main script */
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to delete the main script %s.\n", Ctrl->In.file);
+		return (GMT_RUNTIME_ERROR);
+	}
+	if (Ctrl->E.file && gmt_remove_file (GMT, Ctrl->E.file)) {	/* Delete the title script */
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to delete the title script %s.\n", Ctrl->E.file);
+		return (GMT_RUNTIME_ERROR);
+	}
+	if (Ctrl->I.file && gmt_remove_file (GMT, Ctrl->I.file)) {	/* Delete the include script */
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to delete the include script %s.\n", Ctrl->I.file);
+		return (GMT_RUNTIME_ERROR);
+	}
+	if (Ctrl->S[MOVIE_PREFLIGHT].file && gmt_remove_file (GMT, Ctrl->S[MOVIE_PREFLIGHT].file)) {	/* Delete the background script */
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to delete the background script %s.\n", Ctrl->S[MOVIE_PREFLIGHT].file);
+		return (GMT_RUNTIME_ERROR);
+	}
+	if (Ctrl->S[MOVIE_POSTFLIGHT].file && gmt_remove_file (GMT, Ctrl->S[MOVIE_POSTFLIGHT].file)) {	/* Delete the foreground script */
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to delete the foreground script %s.\n", Ctrl->S[MOVIE_POSTFLIGHT].file);
+		return (GMT_RUNTIME_ERROR);
+	}
+	return (GMT_NOERROR);
+}
+
 #define bailout(code) {gmt_M_free_options (mode); return (code);}
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
@@ -2152,6 +2177,10 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 					Return (GMT_RUNTIME_ERROR);
 				}
 			}
+			if (Ctrl->Z.delete) {	/* Delete input scripts */
+				if ((error = movie_delete_scripts (GMT, Ctrl)))
+					Return (error);
+			}
 			Return (GMT_NOERROR);
 		}
 	}
@@ -2428,27 +2457,9 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		}
 	}
 
-	if (Ctrl->Z.delete) {	/* Delete the scripts since they apparently are temporary */
-		if (Ctrl->In.file && gmt_remove_file (GMT, Ctrl->In.file)) {	/* Delete the main script */
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to delete the main script %s.\n", Ctrl->In.file);
-			Return (GMT_RUNTIME_ERROR);
-		}
-		if (Ctrl->E.file && gmt_remove_file (GMT, Ctrl->E.file)) {	/* Delete the title script */
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to delete the title script %s.\n", Ctrl->E.file);
-			Return (GMT_RUNTIME_ERROR);
-		}
-		if (Ctrl->I.file && gmt_remove_file (GMT, Ctrl->I.file)) {	/* Delete the include script */
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to delete the include script %s.\n", Ctrl->I.file);
-			Return (GMT_RUNTIME_ERROR);
-		}
-		if (Ctrl->S[MOVIE_PREFLIGHT].file && gmt_remove_file (GMT, Ctrl->S[MOVIE_PREFLIGHT].file)) {	/* Delete the background script */
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to delete the background script %s.\n", Ctrl->S[MOVIE_PREFLIGHT].file);
-			Return (GMT_RUNTIME_ERROR);
-		}
-		if (Ctrl->S[MOVIE_POSTFLIGHT].file && gmt_remove_file (GMT, Ctrl->S[MOVIE_POSTFLIGHT].file)) {	/* Delete the foreground script */
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to delete the foreground script %s.\n", Ctrl->S[MOVIE_POSTFLIGHT].file);
-			Return (GMT_RUNTIME_ERROR);
-		}
+	if (Ctrl->Z.delete) {	/* Delete input scripts */
+		if ((error = movie_delete_scripts (GMT, Ctrl)))
+			Return (error);
 	}
 
 	/* Finally, delete the clean-up script separately since under DOS we got complaints when we had it delete itself (which works under *nix) */

--- a/src/movie.c
+++ b/src/movie.c
@@ -2429,7 +2429,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	}
 
 	if (Ctrl->Z.delete) {	/* Delete the scripts since they apparently are temporary */
-		if (gmt_remove_file (GMT, Ctrl->In.file)) {	/* Delete the main script */
+		if (Ctrl->In.file && gmt_remove_file (GMT, Ctrl->In.file)) {	/* Delete the main script */
 			GMT_Report (API, GMT_MSG_ERROR, "Unable to delete the main script %s.\n", Ctrl->In.file);
 			Return (GMT_RUNTIME_ERROR);
 		}
@@ -2437,7 +2437,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			GMT_Report (API, GMT_MSG_ERROR, "Unable to delete the title script %s.\n", Ctrl->E.file);
 			Return (GMT_RUNTIME_ERROR);
 		}
-		if (Ctrl->Ifile && gmt_remove_file (GMT, Ctrl->I.file)) {	/* Delete the include script */
+		if (Ctrl->I.file && gmt_remove_file (GMT, Ctrl->I.file)) {	/* Delete the include script */
 			GMT_Report (API, GMT_MSG_ERROR, "Unable to delete the include script %s.\n", Ctrl->I.file);
 			Return (GMT_RUNTIME_ERROR);
 		}


### PR DESCRIPTION
**Description of proposed changes**

Most/all of our GMT animations are scripts the simply build the required movie script parts on the fly, then feed these to the movie module, and then we have to manually delete all the parts.  This PR extends the **-Z** option with an optional s directive which will also delete the input scripts given (_mainscript_ plus any scripts given via **-E, -I, -S**).  All animation scripts have been updated with **-Zs** and removing the manual rm -f lines.
I also added 3 lines to .gitignore so that no MP4, PNG, GIF created in the movie directories are accidentally merged into the repo.  Closes #3241.

