### PR TITLE
doc: Add HD movies to the GMT gallery

### DIFF
--- a/doc/rst/_extensions/youtube.py
+++ b/doc/rst/_extensions/youtube.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#  Original code from https://github.com/sphinx-contrib/youtube with a few modifications.
+#
+
+from __future__ import division
+
+import re
+from docutils import nodes
+from docutils.parsers.rst import directives, Directive
+
+CONTROL_HEIGHT = 30
+
+def get_size(d, key):
+    if key not in d:
+        return None
+    m = re.match("(\d+)(|%|px)$", d[key])
+    if not m:
+        raise ValueError("invalid size %r" % d[key])
+    return int(m.group(1)), m.group(2) or "px"
+
+def css(d):
+    return "; ".join(sorted("%s: %s" % kv for kv in d.items()))
+
+class youtube(nodes.General, nodes.Element): pass
+
+def visit_youtube_node(self, node):
+    aspect = node["aspect"]
+    width = node["width"]
+    height = node["height"]
+
+    if aspect is None:
+        aspect = 16, 9
+
+    div_style = {}
+    if (height is None) and (width is not None) and (width[1] == "%"):
+        div_style = {
+            "padding-top": "%dpx" % CONTROL_HEIGHT,
+            "padding-bottom": "%f%%" % (width[0] * aspect[1] / aspect[0]),
+            "width": "%d%s" % width,
+            "position": "relative",
+        }
+        style = {
+            "position": "absolute",
+            "top": "0",
+            "left": "0",
+            "width": "100%",
+            "height": "100%",
+            "border": "0",
+        }
+        attrs = {
+            "src": "https://www.youtube.com/embed/%s?autoplay=1" % node["id"],
+            "style": css(style),
+        }
+    else:
+        if width is None:
+            if height is None:
+                width = 560, "px"
+            else:
+                width = height[0] * aspect[0] / aspect[1], "px"
+        if height is None:
+            height = width[0] * aspect[1] / aspect[0], "px"
+        style = {
+            "width": "%d%s" % width,
+            "height": "%d%s" % (height[0] + CONTROL_HEIGHT, height[1]),
+            "border": "0",
+        }
+        attrs = {
+            "src": "https://www.youtube.com/embed/%s?autoplay=1" % node["id"],
+            "style": css(style),
+        }
+    attrs["allowfullscreen"] = "true"
+    div_attrs = {
+        "CLASS": "youtube_wrapper",
+        "style": css(div_style),
+    }
+    self.body.append(self.starttag(node, "div", **div_attrs))
+    self.body.append(self.starttag(node, "iframe", **attrs))
+    self.body.append("</iframe></div>")
+
+def depart_youtube_node(self, node):
+    pass
+
+def visit_youtube_node_latex(self,node):
+    self.body.append(r'\begin{quote}\begin{center}\fbox{\url{https://youtu.be/%s}}\end{center}\end{quote}'%node['id'])
+
+
+class YouTube(Directive):
+    has_content = True
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = False
+    option_spec = {
+        "width": directives.unchanged,
+        "height": directives.unchanged,
+        "aspect": directives.unchanged,
+    }
+
+    def run(self):
+        if "aspect" in self.options:
+            aspect = self.options.get("aspect")
+            m = re.match("(\d+):(\d+)", aspect)
+            if m is None:
+                raise ValueError("invalid aspect ratio %r" % aspect)
+            aspect = tuple(int(x) for x in m.groups())
+        else:
+            aspect = None
+        width = get_size(self.options, "width")
+        height = get_size(self.options, "height")
+        return [youtube(id=self.arguments[0], aspect=aspect, width=width, height=height)]
+
+
+def unsupported_visit_youtube(self, node):
+    self.builder.warn('youtube: unsupported output format (node skipped)')
+    raise nodes.SkipNode
+
+
+_NODE_VISITORS = {
+    'html': (visit_youtube_node, depart_youtube_node),
+    'latex': (visit_youtube_node_latex, depart_youtube_node),
+    'man': (unsupported_visit_youtube, None),
+    'texinfo': (unsupported_visit_youtube, None),
+    'text': (unsupported_visit_youtube, None)
+}
+
+
+def setup(app):
+    app.add_node(youtube, **_NODE_VISITORS)
+    app.add_directive("youtube", YouTube)

--- a/doc/rst/_static/style.css
+++ b/doc/rst/_static/style.css
@@ -38,6 +38,14 @@
     margin-right: 15px;
 }
 
+/* style for gmt movies */
+.gmtmovie li {
+    list-style: none;
+    width: 45%;
+    display: inline-grid;
+    margin-right: 15px;
+}
+
 /* Set tab-width to 2 spaces */
 .highlight {
     tab-size: 2;

--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -8,7 +8,7 @@ sys.path.append(os.path.abspath('_extensions'))
 
 # -- General configuration -----------------------------------------------------
 needs_sphinx = '1.8'
-extensions = ['sphinx.ext.mathjax', 'jinja']
+extensions = ['sphinx.ext.mathjax', 'jinja', 'youtube']
 source_encoding = 'utf-8-sig'
 source_suffix = '.rst'
 master_doc = 'index'

--- a/doc/rst/source/gallery.rst
+++ b/doc/rst/source/gallery.rst
@@ -53,3 +53,19 @@ Animations
 
    gallery/anim-introduction.rst
    gallery/anim*
+
+HD movies
+---------
+
+.. cssclass:: gmtmovie
+
+- .. youtube:: LTxlR5LuJ8g
+     :width: 100%
+
+  :ref:`movie01`
+
+.. toctree::
+   :hidden:
+   :glob:
+
+   gallery/movie*

--- a/doc/rst/source/gallery/movie01.rst
+++ b/doc/rst/source/gallery/movie01.rst
@@ -1,0 +1,28 @@
+.. _movie01:
+
+(1) Flying over the Antarctic Ridge and the East Pacific Rise
+=============================================================
+
+Animation of a simulated fly-over of the Pacific basin mid-ocean ridge system.
+It uses a premade flight path that originally was derived from a data file
+of the world's ridges, then filtered and manipulated to give the equidistant
+path to simulate a constant velocity at the given altitude, with synthetic
+banking as we turn to follow the path.  We use the 30 arc second global relief
+grid and overlay a few labels for named features.
+
+- Grid:   @earth_relief_30s.grd
+- Path:   MOR_PAC_twist_path.txt
+- Labels: MOR_names.txt
+
+We create a global intensity grid using shading from East and a CPT file; these are
+created by the preflight script.
+We add a 1 second fade in and a 1 second fade out for the animation
+The resulting movie was presented at the Fall 2019 AGU meeting in an eLighting talk:
+P. Wessel, 2019, GMT science animations for the masses, Abstract IN21B-11.
+The movie took ~6 hours to render on a 24-core MacPro 2013.
+
+.. literalinclude:: /_verbatim/movie01.txt
+   :language: bash
+
+..  youtube:: LTxlR5LuJ8g
+    :width: 100%


### PR DESCRIPTION
HD movies are uploaded to YouTube. We can use the directive below to embed a YouTube video.

```
.. youtube: videoID
   :width: 100%
```

Screenshot of the gallery page:
![image](https://user-images.githubusercontent.com/3974108/80931110-d4e27880-8d85-11ea-8f5f-a05d1bc1b924.png)

Screenshot for the movie01 page:

![image](https://user-images.githubusercontent.com/3974108/80931121-e035a400-8d85-11ea-8a9f-09f988de4940.png)
