### PR TITLE
cmake: Show the current CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ endif (${srcdir} STREQUAL ${bindir})
 
 # Define minimum CMake version required
 cmake_minimum_required (VERSION 2.8.12)
+message ("CMake version: ${CMAKE_VERSION}")
 
 # Use NEW behavior with newer CMake releases
 foreach (p


### PR DESCRIPTION
Sometimes we want to know the CMake version we're using.

The variable CMAKE_VERSION was defined since 2.6.3.