### PR TITLE
Let movie build transparent PNG images

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -359,6 +359,15 @@ making a HD movie using the US unit dimensions then a background pink layer woul
 Note the canvas selection via :term:`PS_MEDIA`, the matching region and projection, and
 the zero location of the origin.
 
+Transparent images
+------------------
+
+By default, **movie** will build opaque PNG images which can then be assembled into an animation.
+Use **-F** modifier **+t** to instead make transparent PNG images.  Currently, few video codecs support
+transparency.  It is claimed both H.265 (HECV) and VP9 (Webm) offers this capability.
+Animated GIFs are able to build an animation from transparent PNGs.  Experts may create the transparent
+PNGs and take things from there.
+
 Technical Details
 -----------------
 

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -363,10 +363,11 @@ Transparent images
 ------------------
 
 By default, **movie** will build opaque PNG images which can then be assembled into an animation.
-Use **-F** modifier **+t** to instead make transparent PNG images.  Currently, few video codecs support
-transparency.  It is claimed both H.265 (HECV) and VP9 (Webm) offers this capability.
-Animated GIFs are able to build an animation from transparent PNGs.  Experts may create the transparent
-PNGs and take things from there.
+Use **-F** experimental modifier **+t** to instead make transparent PNG images.  Currently, few video codecs support
+transparency.  It is claimed both H.265 (HECV) and VP9 (Webm) offers this capability; I have only been
+able to verify the latter by viewing the webm movie in Chrome.
+Animated GIFs can be built from transparent PNGs and here each frame accumulate in the final movie.
+Experts may create the transparent PNGs and take things from there.
 
 Technical Details
 -----------------

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -362,12 +362,13 @@ the zero location of the origin.
 Transparent images
 ------------------
 
-By default, **movie** will build opaque PNG images which can then be assembled into an animation.
-Use **-F** experimental modifier **+t** to instead make transparent PNG images.  Currently, few video codecs support
-transparency.  It is claimed both H.265 (HECV) and VP9 (Webm) offers this capability; I have only been
-able to verify the latter by viewing the webm movie in Chrome.
-Animated GIFs can be built from transparent PNGs and here each frame accumulate in the final movie.
-Experts may create the transparent PNGs and take things from there.
+By default, **movie** will build *opaque* PNG images which can then be assembled into an animation.
+The vast majority of movies is likely to be made that way. Use the **-F** option's experimental modifier
+**+t** to make *transparent* PNG images.  Currently, very few video codecs support
+transparency.  It is claimed both H.265 (HECV) and VP9 (Webm) offer this capability; we have only been
+able to verify the latter by viewing a transparent webm movie in Chrome. Animated GIFs can be built from
+transparent PNGs as well and here each additional frame accumulate in the final movie. Experts may create
+transparent PNGs and create movies in professional tools that support a movie alpha channel.
 
 Technical Details
 -----------------

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -19,7 +19,7 @@ Synopsis
 [ |-A|\ [**+l**\ [*n*]]\ [**+s**\ *stride*] ]
 [ |-D|\ *displayrate* ]
 [ |-E|\ *titlepage*\ [**+d**\ *duration*\ [**s**]][**+f**\ [**+i**\|\ **o**]\ *fade*\ [**s**]]\ [**+g**\ *fill*] ]
-[ |-F|\ *format*\ [**+o**\ *options*]]
+[ |-F|\ *format*\ [**+t**]\ [**+o**\ *options*]]
 [ |-G|\ [*fill*]\ [**+p**\ *pen*] ]
 [ |-H|\ *factor*]
 [ |-I|\ *includefile* ]
@@ -137,11 +137,11 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ *format*\ [**+o**\ *options*]
+**-F**\ *format*\ [**+t**]\ [**+o**\ *options*]
     Set the format of the final video product.  Repeatable.  Choose either **mp4** (MPEG-4 movie) or
     **webm** (WebM movie).  You may optionally add additional FFmpeg encoding settings for this format
     via the **+o** modifier (in quotes if more than one word). If **none** is chosen then no PNGs will
-    be created at all; this requires **-M**.
+    be created at all; this requires **-M**.  Choose **+t** to generate transparent PNG images [opaque].
 
 .. _-G:
 

--- a/src/movie.c
+++ b/src/movie.c
@@ -1929,7 +1929,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			movie_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_BACKGROUND", ",Mb../movie_background.ps");		/* Current frame tag (formatted frame number) */
 		else
 			movie_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_BACKGROUND", "");		/* Nothing */
-		if (Ctrl->F.transparent) place_background = false;	/* Only place background once if transparent images */
+		if (Ctrl->F.transparent && Ctrl->A.active) place_background = false;	/* Only place background once if transparent images */
 		movie_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_ITEM", state_tag);		/* Current frame tag (formatted frame number) */
 		for (col = 0; col < n_values; col++) {	/* Derive frame variables from <timefile> in each parameter file */
 			sprintf (string, "MOVIE_COL%u", col);
@@ -2448,6 +2448,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		GMT_Report (API, GMT_MSG_INFORMATION, "MP4 movie built: %s.mp4\n", Ctrl->N.prefix);
 	}
 	if (Ctrl->F.active[MOVIE_WEBM]) {
+		static char *vpx[2] = {"libvpx", "libvpx-vp9"}, *pix_fmt[2] = {"yuv420p", "yuva420p"};
 		/* Set up system call to FFmpeg (which we know exists) */
 		if (gmt_M_is_verbose (GMT, GMT_MSG_DEBUG))
 			sprintf (extra, "verbose");
@@ -2458,8 +2459,9 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		else
 			sprintf (extra, "quiet");
 		sprintf (png_file, "%%0%dd", precision);
-		sprintf (cmd, "ffmpeg -loglevel %s -f image2 -framerate %g -y -i \"%s%c%s_%s.%s\" -vcodec libvpx %s -pix_fmt yuv420p %s.webm",
-			extra, Ctrl->D.framerate, workdir, dir_sep, Ctrl->N.prefix, png_file, MOVIE_RASTER_EXTENSION, (Ctrl->F.options[MOVIE_WEBM]) ? Ctrl->F.options[MOVIE_WEBM] : "", Ctrl->N.prefix);
+		sprintf (cmd, "ffmpeg -loglevel %s -f image2 -framerate %g -y -i \"%s%c%s_%s.%s\" -vcodec %s %s -pix_fmt %s %s.webm",
+			extra, Ctrl->D.framerate, workdir, dir_sep, Ctrl->N.prefix, png_file, MOVIE_RASTER_EXTENSION, vpx[Ctrl->F.transparent],
+			(Ctrl->F.options[MOVIE_WEBM]) ? Ctrl->F.options[MOVIE_WEBM] : "", pix_fmt[Ctrl->F.transparent], Ctrl->N.prefix);
 		GMT_Report (API, GMT_MSG_INFORMATION, "Running: %s\n", cmd);
 		if ((error = system (cmd))) {
 			GMT_Report (API, GMT_MSG_ERROR, "Running FFmpeg conversion to webM returned error %d - exiting.\n", error);

--- a/src/movie.c
+++ b/src/movie.c
@@ -1333,6 +1333,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the movie main code ----------------------------*/
 
+	if (Ctrl->F.transparent) GMT_Report (API, GMT_MSG_WARNING, "Building transparent PNG images is an experimental feature\n");
 	/* Determine pixel dimensions of individual images */
 	p_width =  urint (ceil (Ctrl->C.dim[GMT_X] * Ctrl->C.dim[GMT_Z]));
 	p_height = urint (ceil (Ctrl->C.dim[GMT_Y] * Ctrl->C.dim[GMT_Z]));

--- a/src/movie.c
+++ b/src/movie.c
@@ -53,8 +53,7 @@
 
 #define MOVIE_WAIT_TO_CHECK	10000	/* In microseconds, so 0.01 seconds */
 
-#define MOVIE_RASTER_FORMAT	"png"	/* Lossless opaque raster format */
-#define MOVIE_RASTER_EXTENSION	"png"	/* Lossless transparent raster format */
+#define MOVIE_RASTER_EXTENSION	"png"	/* Fixed raster format */
 #define MOVIE_DEBUG_FORMAT	",ps"	/* Comma is intentional since we append to a list of formats */
 
 enum enum_script {BASH_MODE = 0,	/* Write Bash script */
@@ -129,8 +128,9 @@ struct MOVIE_CTRL {
 		unsigned int fade[2];	/* Duration of fade title in, fade title out [none]*/
 		FILE *fp;			/* Open file pointer to title script */
 	} E;
-	struct MOVIE_F {	/* -F<videoformat>[+o<options>] */
+	struct MOVIE_F {	/* -F<videoformat>[+o<options>][+t] */
 		bool active[MOVIE_N_FORMATS];
+		bool transparent;
 		char *format[MOVIE_N_FORMATS];
 		char *options[MOVIE_N_FORMATS];
 	} F;
@@ -424,7 +424,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s <mainscript> -C<canvas> -N<prefix> -T<nframes>|<min>/<max>/<inc>[+n]|<timefile>[+p<width>][+s<first>][+w]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-A[+l[<n>]][+s<stride>]] [-D<rate>] [-E<titlepage>[+d<duration>[s]][+f[i|o]<fade>[s]][+g<fill>]] [-F<format>[+o<opts>]] [-G[<fill>][+p<pen>]] [-H<factor>]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t[-A[+l[<n>]][+s<stride>]] [-D<rate>] [-E<titlepage>[+d<duration>[s]][+f[i|o]<fade>[s]][+g<fill>]] [-F<format>[+o<opts>][+t]] [-G[<fill>][+p<pen>]] [-H<factor>]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t[-I<includefile>] [-K[+f[i|o]<fade>[s]][+g<fill>][+p]] [-L<labelinfo>] [-M[<frame>,][<format>]] [-P<progress>] [-Q[s]] [-Sb<background>]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t[-Sf<foreground>] [%s] [-W<workdir>] [-Z[s]] [%s] [-x[[-]<n>]] [%s]\n\n", GMT_V_OPT, GMT_f_OPT, GMT_PAR_OPT);
 
@@ -474,6 +474,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     mp4:    Convert PNG frames into an MP4 movie.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     webm:   Convert PNG frames into an WebM movie.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     none:   Make no PNG frames - requires -M.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     By default we build opaque png images; append +t for transparent images.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Optionally, append +o<options> to add custom encoding options for mp4 or webm.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     [Default is no video products; just create the PNG frames].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Set the canvas background color [none].  Append +p<pen> to draw canvas outline [none]\n");
@@ -870,15 +871,24 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 				break;
 
 			case 'F':	/* Set movie format and optional FFmpeg options */
-				if ((c = strstr (opt->arg, "+o"))) {	/* Gave encoding options */
-					s = &c[2];	/* Retain start of encoding options for later */
-					c[0] = '\0';	/* Chop off options */
+				if ((c = gmt_first_modifier (GMT, opt->arg, "ot"))) {	/* Process any modifiers */
+					pos = 0;	/* Reset to start of new word */
+					while (gmt_getmodopt (GMT, 'F', c, "ot", &pos, p, &n_errors) && n_errors == 0) {
+						switch (p[0]) {
+							case 'o':	/* Duration of entire title/fade sequence */
+								s = strdup (&p[1]);	/* Retain start of encoding options for later */
+								break;
+							case 't':	/* Transparent images */
+								Ctrl->F.transparent = true;
+								break;
+							default:
+								break;	/* These are caught in gmt_getmodopt so break is just for Coverity */
+						}
+					}
+					c[0] = '\0';	/* Chop off modifiers */
 				}
-				else
-					s = NULL;	/* No encoding options given */
 				strncpy (arg, opt->arg, GMT_LEN64-1);	/* Get a copy of the args (minus encoding options)... */
 				gmt_str_tolower (arg);	/* ..so we can convert it to lower case for comparisons */
-				if (c) c[0] = '+';	/* Now we can restore the optional text we chopped off */
 				if (!strcmp (opt->arg, "none")) {	/* Do not make those PNGs at all, just a master plot */
 					Ctrl->M.exit = true;
 					break;
@@ -887,22 +897,25 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 					k = MOVIE_MP4;
 				else if (!strcmp (opt->arg, "webm"))	/* Make a WebM movie */
 					k = MOVIE_WEBM;
-				else {
+				else if (opt->arg[0]) {
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -F: Unrecognized format %s\n", opt->arg);
 					n_errors++;
 					break;
 				}
-				if (Ctrl->F.active[k]) {	/* Can only select a format once */
-					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -F: Format %s already selected\n", opt->arg);
-					n_errors++;
-					break;
+				if (opt->arg[0]) {	/* Gave an argument */
+					if (Ctrl->F.active[k]) {	/* Can only select a format once */
+						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -F: Format %s already selected\n", opt->arg);
+						n_errors++;
+						break;
+					}
+					/* Here we have a new video format selected */
+					Ctrl->F.active[k] = Ctrl->animate = true;
+					if (s) {	/* Gave specific encoding options */
+						if (Ctrl->F.options[k]) gmt_M_str_free (Ctrl->F.options[k]);	/* Free old setting first */
+						Ctrl->F.options[k] = s;
+					}
 				}
-				/* Here we have a new video format selected */
-				Ctrl->F.active[k] = Ctrl->animate = true;
-				if (s) {	/* Gave specific encoding options */
-					if (Ctrl->F.options[k]) gmt_M_str_free (Ctrl->F.options[k]);	/* Free old setting first */
-					Ctrl->F.options[k] = strdup (s);
-				}
+				if (c) c[0] = '+';	/* Now we can restore the optional text we chopped off */
 				break;
 
 			case 'G':	/* Canvas fill */
@@ -1278,8 +1291,9 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	unsigned int dd, hh, mm, ss, start, flavor[2] = {0, 0};
 
 	bool done = false, layers = false, one_frame = false, upper_case[2] = {false, false};
-	bool n_written = false, has_text = false, is_classic = false;
+	bool n_written = false, has_text = false, is_classic = false, place_background = false;
 
+	static char *movie_raster_format[2] = {"png", "PNG"}, *img_type[2] = {"opaque", "transparent"};
 	char *extension[3] = {"sh", "csh", "bat"}, *load[3] = {"source", "source", "call"}, *rmfile[3] = {"rm -f", "rm -f", "del"};
 	char *rmdir[3] = {"rm -rf", "rm -rf", "rd /s /q"}, *export[3] = {"export ", "setenv ", ""};
 	char *mvfile[3] = {"mv -f", "mv -f", "move"}, *sc_call[3] = {"bash ", "csh ", "start /B"};
@@ -1287,7 +1301,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	char init_file[PATH_MAX] = {""}, state_tag[GMT_LEN16] = {""}, state_prefix[GMT_LEN64] = {""}, param_file[PATH_MAX] = {""}, cwd[PATH_MAX] = {""};
 	char pre_file[PATH_MAX] = {""}, post_file[PATH_MAX] = {""}, main_file[PATH_MAX] = {""}, line[PATH_MAX] = {""}, version[GMT_LEN32] = {""};
 	char string[GMT_LEN128] = {""}, extra[GMT_LEN256] = {""}, cmd[GMT_LEN256] = {""}, cleanup_file[PATH_MAX] = {""}, L_txt[GMT_LEN128] = {""};
-	char png_file[PATH_MAX] = {""}, topdir[PATH_MAX] = {""}, workdir[PATH_MAX] = {""}, datadir[PATH_MAX] = {""}, frame_products[GMT_LEN32] = {MOVIE_RASTER_FORMAT};
+	char png_file[PATH_MAX] = {""}, topdir[PATH_MAX] = {""}, workdir[PATH_MAX] = {""}, datadir[PATH_MAX] = {""}, frame_products[GMT_LEN32] = {""};
 	char intro_file[PATH_MAX] = {""}, *script_file =  NULL, dir_sep = '/', which[2] = {"LP"};
 	static char *LP_name[2] = {"LABEL", "PROG_INDICATOR"};
 	double percent = 0.0, L_col = 0, sx, sy, fade_level = 0.0;
@@ -1325,6 +1339,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	one_frame = (Ctrl->M.active && (!Ctrl->animate || Ctrl->M.exit));	/* true if we want to create a single master plot only */
 	if (Ctrl->C.unit == 'c') Ctrl->C.dim[GMT_Z] *= 2.54;		/* Since gs requires dots per inch but we gave dots per cm */
 	else if (Ctrl->C.unit == 'p') Ctrl->C.dim[GMT_Z] *= 72.0;	/* Since gs requires dots per inch but we gave dots per point */
+	strcpy (frame_products, movie_raster_format[Ctrl->F.transparent]);	/* psconvert code for the desired PNG image type */
 
 	for (k = MOVIE_ITEM_IS_LABEL; k <= MOVIE_ITEM_IS_PROG_INDICATOR; k++) {
 		/* Compute auto label placement */
@@ -1388,6 +1403,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 
 	GMT_Report (API, GMT_MSG_INFORMATION, "Paper dimensions: Width = %g%c Height = %g%c\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
 	GMT_Report (API, GMT_MSG_INFORMATION, "Pixel dimensions: %u x %u\n", p_width, p_height);
+	GMT_Report (API, GMT_MSG_INFORMATION, "Building %s PNG images.\n", img_type[Ctrl->F.transparent]);
 
 	/* First try to read -T<timefile> in case it is prescribed directly (and before we change directory) */
 	if (!gmt_access (GMT, Ctrl->T.file, R_OK)) {	/* A file by that name exists and is readable */
@@ -1551,6 +1567,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 				Return (GMT_RUNTIME_ERROR);
 			}
 		}
+		place_background = (!access ("movie_background.ps", R_OK));	/* Need to place a background layer in the main frames */
 	}
 
 	/* Now we can complete the -T parsing since any given file has now been created by pre_file */
@@ -1908,6 +1925,12 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		movie_set_ivalue (fp, Ctrl->In.mode, false, "MOVIE_FRAME", data_frame);		/* Current frame number */
 		if (!n_written) movie_set_ivalue (fp, Ctrl->In.mode, false, "MOVIE_NFRAMES", n_data_frames);	/* Total frames (write here since n_frames was not yet known when init was written) */
 		movie_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_ITEM", state_tag);		/* Current frame tag (formatted frame number) */
+		if (place_background)	/* Need to place a background layer first (which is in parent dir when loop script is run) */
+			movie_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_BACKGROUND", ",Mb../movie_background.ps");		/* Current frame tag (formatted frame number) */
+		else
+			movie_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_BACKGROUND", "");		/* Nothing */
+		if (Ctrl->F.transparent) place_background = false;	/* Only place background once if transparent images */
+		movie_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_ITEM", state_tag);		/* Current frame tag (formatted frame number) */
 		for (col = 0; col < n_values; col++) {	/* Derive frame variables from <timefile> in each parameter file */
 			sprintf (string, "MOVIE_COL%u", col);
 			movie_set_value (GMT, fp, Ctrl->In.mode, col, string, D->table[0]->segment[0]->data[col][data_frame]);
@@ -2240,7 +2263,6 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		if (Ctrl->G.mode & 2) strcat (extra, "+g"), strcat (extra, Ctrl->G.fill);
 	}
 	if (!access ("movie_background.ps", R_OK)) {	/* Need to place a background layer first (which will be in parent dir when loop script is run) */
-		strcat (extra, ",Mb../movie_background.ps");
 		layers = true;
 	}
 	else if (Ctrl->S[MOVIE_PREFLIGHT].PS) {	/* Got a background PS layer directly */
@@ -2279,7 +2301,8 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
 			movie_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
 			fprintf (fp, "\tgmt figure ../%s %s", movie_place_var (Ctrl->In.mode, "MOVIE_NAME"), frame_products);
-			fprintf (fp, " E%s,%s\n", movie_place_var (Ctrl->In.mode, "MOVIE_DPU"), extra);
+			fprintf (fp, " E%s,%s", movie_place_var (Ctrl->In.mode, "MOVIE_DPU"), extra);
+			fprintf (fp, "%s\n", movie_place_var (Ctrl->In.mode, "MOVIE_BACKGROUND"));
 			fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c DIR_DATA %s GMT_MAX_CORES 1\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit, datadir);
 		}
 		else if (!strstr (line, "#!/")) {		/* Skip any leading shell incantation since already placed */


### PR DESCRIPTION
**Description of proposed changes**

As an experimental feature, a new **+t** modifier to **-F** will change the format of the PNG images being created from opaque to transparent.  At the moment, few video codecs support transparency; VP9 in WebM being one exception. Also, animated GIF (**-A**) can also accept transparent images and here each additional frame is added to the previous, creating an artistic effect.  Users with commercial tools can use the transparent images to build a transparent video.  The movie documentation discusses the experimental nature, but the **-F**_webm_**+t** setting currently works.  Results may depend on having a very recent FFmpeg tool.
Closes #3243.