### PR TITLE
CI: Set up dockers for building GMT on other Linux distros

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -217,3 +217,37 @@ jobs:
 
   steps:
   - template: ci/azure-pipelines-windows.yml
+
+# Docker
+########################################################################################
+- job:
+  displayName: 'Docker | '
+  condition: ne(variables['Build.Reason'], 'Schedule')
+
+  variables:
+    BUILD_DOCS: false
+    DEPLOY_DOCS: false
+    PACKAGE: false
+    TEST: false
+
+  strategy:
+    matrix:
+      Ubuntu1404:   # CMake 2.8.12 + GNU 4.8.4
+        containerImage: ubuntu:14.04
+      Ubuntu1604:   # CMake 3.5.1 + GNU 5.4.0
+        containerImage: ubuntu:16.04
+      Ubuntu1804:   # CMake 3.10.2 + GNU 7.4.0
+        containerImage: ubuntu:18.04
+
+  container:
+    image: $[ variables['containerImage'] ]
+    # See https://github.com/microsoft/azure-pipelines-agent/issues/2043#issuecomment-500451567
+    # for docker sudo workaround
+    options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
+
+  steps:
+  - script: |
+      /tmp/docker exec -t -u 0 ci-container \
+      sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
+    displayName: Set up sudo
+  - template: ci/azure-pipelines-linux.yml

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -222,7 +222,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Docker | '
-  condition: ne(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.Reason'], 'Schedule')
 
   variables:
     BUILD_DOCS: false

--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -6,8 +6,10 @@ steps:
     set -x -e
     sudo apt-get update
     sudo apt-get install -y --no-install-recommends --no-install-suggests \
-        cmake ninja-build libcurl4-gnutls-dev libnetcdf-dev libgdal-dev \
-        libfftw3-dev libpcre3-dev liblapack-dev ghostscript curl
+        build-essential cmake ninja-build \
+        libcurl4-gnutls-dev libnetcdf-dev libgdal-dev \
+        libfftw3-dev libpcre3-dev liblapack-dev libglib2.0-dev \
+        ghostscript curl git
   displayName: Install dependencies
 
 - bash: |


### PR DESCRIPTION
This PR enables dockers support on Azure Pipelines CI to check if GMT can be successfully built on other Linux distros. 

The normal Linux CI jobs are running on Ubuntu 18.04. This Ubuntu version provides CMake 3.10, but the CI logs show that the actual CMake version is 3.16. Perhaps Azure Pipelines install the newer CMake version to their Ubuntu agent.

In this PR, I set up dockers and enable building GMT on following distros:

- Ubuntu 14.04 (CMake 2.8.12 + GNU 4.8.4) 
- Ubuntu 16.04 (CMake 3.5.1 + GNU 5.4.0)
- Ubuntu 18.04 (CMake 3.10.2  + GNU 7.5.0)

Currently, Ubuntu 20.04 (CMake 3.16.3 + GNU 10.x) is not supported yet, due to the slow speed to download and install the Ubuntu packages. I don't know why it's so slow for Ubuntu 20.04. Perhaps it's because Ubuntu 20.04 was released a few weeks ago and there aren't many mirrors.

FYI, the docker jobs take ~5 minutes to build GMT and will be run as cron jobs nightly.

Closes #3235.