### PR TITLE
Movie improvements and animation test scripts

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -128,12 +128,14 @@ Optional Arguments
 .. _-E:
 
 **-E**\ *titlepage*\ [**+d**\ *duration*\ [**s**]][**+f**\ [**i**\|\ **o**]\ *fade*\ [**s**]]\ [**+g**\ *fill*]
-    Give *titlepage* script that creates a static title page for the movie [no title].
-    Alternatively, *titlepage* can be a *PostScript* plot layer of dimensions exactly matching the canvas size.
-    Control how long it should be displayed with **+d** in number of frames (append **s** for duration in seconds instead) [4s].
-    Optionally, supply **+f**\ *fade* **i**\ n and **o**\ ut durations [Default is both] (in frames or seconds [1s]) as well [no fading].
-    Fading affects the beginning and end of the title page *duration*. We fade from and to black by default;
-    append **+g**\ *fill* to use another terminal fade color.
+    Give a *titlepage* script that creates a static title page for the movie [no title].
+    Alternatively, *titlepage* can be a *PostScript* plot (file extension .ps) of dimensions exactly matching
+    the canvas size set in **-C**. You control the duration of the title sequence with **+d** and specify
+    the number of frames (or append **s** for a duration in seconds instead) [4s].
+    Optionally, supply the fade length via **+f**\ *fade* (in frames or seconds [1s]) as well [no fading];
+    Use **+fi** and/or **+fo** to specify one-sided fading or to give unequal fade intervals [Default is same
+    duration for both]. The fading affects the beginning and end of the title page *duration*. We fade from and
+    to black by default; append **+g**\ *fill* to use another terminal fade color.
 
 .. _-F:
 
@@ -176,10 +178,10 @@ Optional Arguments
 **-K**\ [**+f**\ [**i**\|\ **o**]\ *fade*\ [**s**]]\ [**+g**\ *fill*]\ [**+p**] ]
     Add fading in and out for the main animation sequence [no fading]. Append
     the length of the fading in number of frames (or seconds by appending **s**) [1s].
-    For different lengths of fading in and out you can repeat the **-K** option
-    by appending the **i** or **o** directives to **+f**.  Normally, fading will affect the
-    first and last animation frames.  Append **+p** to preserve these by instead
-    fading in and out on only the first and last (repeated) animation frames.
+    For different lengths of in and out fading you can repeat the **+f** modifier
+    by appending the **i** or **o** directives.  Normally, fading will be overlaid on the
+    first and last few seconds of the main animation frames.  Append **+p** to preserve
+    these frames by instead fading over only the first and last (repeated) animation frames.
     We fade from and to black by default; append **+g**\ *fill* to use another terminal fade color.
 
 .. _-L:
@@ -459,11 +461,11 @@ Title Sequence and Fading
    The fade-level (0 means black, 100 means normal visibility) for the complete movie, including
    an optional title sequence.
 
-The complete movie may have a leading title sequence (**-E**) of given *duration*. A short section
-at the beginning and end may be designated to fade in/out via black.  The main animation
-sequence may also have fade in/out (**-K**). Here, you can choose to fade in/out during the beginning and end section of
-the animation or you can "freeze" the first and last animation frame and only fade in/out using
-those static images (via modifier **+p** to preserve the whole animation sequence).
+The complete movie may have an optional leading title sequence (**-E**) of a given *duration*. A short section
+at the beginning and/or end of this duration may be designated to fade in/out via the designated fade
+color [black].  The main animation sequence may also have an optional fade in and/or out section (**-K**). Here, you
+can choose to fade on top of the animation or you can "freeze" the first and/or last animation frame and only fade over
+those static images (via modifier **+p**) in order to preserve the whole animation sequence.
 
 Examples
 --------

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -178,10 +178,11 @@ Optional Arguments
 **-K**\ [**+f**\ [**i**\|\ **o**]\ *fade*\ [**s**]]\ [**+g**\ *fill*]\ [**+p**] ]
     Add fading in and out for the main animation sequence [no fading]. Append
     the length of the fading in number of frames (or seconds by appending **s**) [1s].
-    For different lengths of in and out fading you can repeat the **+f** modifier
-    by appending the **i** or **o** directives.  Normally, fading will be overlaid on the
-    first and last few seconds of the main animation frames.  Append **+p** to preserve
-    these frames by instead fading over only the first and last (repeated) animation frames.
+    Use **+fi** and/or **+fo** to specify one-sided fading or to give unequal fade
+    intervals [Default is same duration for both].  Normally, fading will be overlaid on the
+    first and last *fade* frames of the main animation.  Append **+p** to *preserve*
+    these frames by fading over only the first and last (repeated) animation frames instead.
+    Append **i** or **o** to only preserve the frame involved during the fade in or fade out instead.
     We fade from and to black by default; append **+g**\ *fill* to use another terminal fade color.
 
 .. _-L:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ if (DO_TESTS)
 	# Automatically detect all subdirectories for testing
 	include (GmtHelperMacros)
 	get_subdir_list (GMT_TEST_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
+	list (REMOVE_ITEM GMT_TEST_DIRS animation)
 
 	if (NOT DO_API_TESTS)
 		list (REMOVE_ITEM GMT_TEST_DIRS api)

--- a/test/README.tests
+++ b/test/README.tests
@@ -6,6 +6,7 @@
 # scripts that tests one or more aspects of the program.
 # The script should report a PASS/FAIL grade so
 # that it is easy to tell which test failed.
+# The animation directory is exempt from these rules.
 # Scripts making plots should also have an original PS file
 # with the same file prefix as the script (stuff.sh -> stuff.ps).
 # In addition, each script that fails should add a single line

--- a/test/animation/title.sh
+++ b/test/animation/title.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Test movie options -E and -K
+# Total of 19 separate tests or combinations
+#
+# 1 Set up title
+cat << EOF > t.sh
+gmt begin
+	echo TITLE | gmt text -R0/5/0/5 -JX5i -B+glightpink -F+f24p+cCM -X0 -Y0
+gmt end
+EOF
+# 2. Set up the main frame script
+cat << EOF > m.sh
+gmt begin
+	gmt basemap -R0/5/0/5 -JX5i -Baf -B+glightgreen --MAP_FRAME_TYPE=inside -X0 -Y0
+gmt end
+EOF
+# A. Run the movie: title plus plot, no fading anywhere
+gmt movie m.sh -C5ix5ix100 -T48 -NA -D12 -Fmp4 -Et.sh+d24 -Lf -Z
+# B. Run the movie: title plus plot, 6 frames fade in on title
+gmt movie m.sh -C5ix5ix100 -T48 -NB -D12 -Fmp4 -Et.sh+d24+fi6 -Lf -Z
+# C. Run the movie: title plus plot, 6 frames fade out on title
+gmt movie m.sh -C5ix5ix100 -T48 -NC -D12 -Fmp4 -Et.sh+d24+fo6 -Lf -Z
+# D. Run the movie: title plus plot, 6 frames fade in and out on title
+gmt movie m.sh -C5ix5ix100 -T48 -ND -D12 -Fmp4 -Et.sh+d24+f6 -Lf -Z
+# E. Run the movie: title plus plot, 6 frames fade in, 3 frames out on title
+gmt movie m.sh -C5ix5ix100 -T48 -NE -D12 -Fmp4 -Et.sh+d24+fi6+fo3 -Lf -Z
+# F. Run the movie: title plus plot, fade in on plot
+gmt movie m.sh -C5ix5ix100 -T48 -NF -D12 -Fmp4 -Et.sh+d24 -K+fi6 -Lf -Z
+# G. Run the movie: title plus plot, fade out on plot
+gmt movie m.sh -C5ix5ix100 -T48 -NG -D12 -Fmp4 -Et.sh+d24 -K+fo6 -Lf -Z
+# H. Run the movie: title plus plot, fade in/out on plot
+gmt movie m.sh -C5ix5ix100 -T48 -NH -D12 -Fmp4 -Et.sh+d24 -K+f6 -Lf -Z
+# I. Run the movie: title plus plot, fade in/out on plot unequally
+gmt movie m.sh -C5ix5ix100 -T48 -NI -D12 -Fmp4 -Et.sh+d24 -K+fi6+fo12 -Lf -Z
+# J. Run the movie: title plus plot, fade in title, fade out on plot 
+gmt movie m.sh -C5ix5ix100 -T48 -NJ -D12 -Fmp4 -Et.sh+d24+fi6 -K+fo6 -Lf -Z
+# K. Run the movie: title plus plot, fade in title, fade out in/on plot 
+gmt movie m.sh -C5ix5ix100 -T48 -NK -D12 -Fmp4 -Et.sh+d24+fi6 -K+f6 -Lf -Z
+# L. Run the movie: title plus plot, fade in/out title, fade in/out plot 
+gmt movie m.sh -C5ix5ix100 -T48 -NL -D12 -Fmp4 -Et.sh+d24+f6 -K+f6 -Lf -Z
+# M. Run the movie: title plus plot, no title fade, fade in/out plot with preserve both ends
+gmt movie m.sh -C5ix5ix100 -T48 -NM -D12 -Fmp4 -Et.sh+d24 -K+f6+p -Lf -Z
+# N. Run the movie: title plus plot, no title fade, fade in/out plot with preserve in
+gmt movie m.sh -C5ix5ix100 -T48 -NN -D12 -Fmp4 -Et.sh+d24 -K+f6+pi -Lf -Z
+# O. Run the movie: title plus plot, no title fade, fade in/out plot with preserve out
+gmt movie m.sh -C5ix5ix100 -T48 -NO -D12 -Fmp4 -Et.sh+d24 -K+f6+po -Lf -Z
+rm -f t.sh m.sh


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a new animation directory under test which is excluded from the automatic checks.  Its use is for collecting various test scripts that examines aspects of movie.  Because movies take time to generate and because we don't want to compare these movies with a set of reference movies or large sets of frames (at least not yet).
The PR also improves the syntax and parsing of **-K** and **-E** and the first test script (title.sh) generates 19 different short movies exploring various combination of how fading options affect a simple title plus animation sequence.  Documentation is also updated.
