### PR TITLE
More error checking for events

### DIFF
--- a/doc/rst/source/events_common.rst_
+++ b/doc/rst/source/events_common.rst_
@@ -83,8 +83,9 @@ Optional Arguments
     duration of the rise phase, **+p** to set the duration of the plateau phase, **+d**
     to specify the duration of the decay phase, and **+f** to set the duration of the
     fade phase.  These are all optional [and default to zero], and can be set separately for symbols and texts.
-    If neither **s** or **t** is given then we set the time knots for both features. Note that **+l** is
+    If neither **s** or **t** is given then we set the time knots for both features. **Note**: The **+l** modifier is
     restricted to **-Et** and specifies an alternative duration (visibility) of the text [same duration as symbol].
+    Furthermore, the **+p** and **+d** periods do not apply to text labels.
 
 .. _-F:
 
@@ -231,13 +232,18 @@ Figure below illustrates how transparency may vary through time.
 
    Here we show how a symbol may go from being invisible to reaching full opaqueness
    at the event begin time, finally fading to a near-invisible stage after reaching
-   its length.
+   its length. For text labels, the plateau and decay periods do not apply.
 
 While shown in these examples, the rise, plateau, fade, and coda periods are all optional
 and can be selected or ignored as you wish via **-E**.  You can choose to specify any or none
 of the three time histories.  By default the symbol size is constant, there is no intensity
-variation, and all symbols are opaque.  If trailing text is plotted (requires **-Et**) then
-only a transparency time-function is used.
+variation, and all symbols are opaque.
+
+If trailing text is plotted (i.e., by selecting **-Et**) then only the transparency time-function
+is used and neither the plateau nor decay periods apply.  The appearance and disappearance of a
+label is thus dictated by an initial (and optional) rise time (during which the label slowly
+becomes fully visible), an normal period (where it remains visible), followed by the optional
+fade period (where the text fades out).
 
 Sorting the data
 ----------------

--- a/src/movie.c
+++ b/src/movie.c
@@ -1352,7 +1352,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	/* Determine pixel dimensions of individual images */
 	p_width =  urint (ceil (Ctrl->C.dim[GMT_X] * Ctrl->C.dim[GMT_Z]));
 	p_height = urint (ceil (Ctrl->C.dim[GMT_Y] * Ctrl->C.dim[GMT_Z]));
-	one_frame = (Ctrl->M.active && (!Ctrl->animate || Ctrl->M.exit));	/* true if we want to create a single master plot only */
+	one_frame = (Ctrl->M.active && Ctrl->M.exit);	/* true if we want to create a single master plot only (no frames nor animations) */
 	if (Ctrl->C.unit == 'c') Ctrl->C.dim[GMT_Z] *= 2.54;		/* Since gs requires dots per inch but we gave dots per cm */
 	else if (Ctrl->C.unit == 'p') Ctrl->C.dim[GMT_Z] *= 72.0;	/* Since gs requires dots per inch but we gave dots per point */
 	strcpy (frame_products, movie_raster_format[Ctrl->F.transparent]);	/* psconvert code for the desired PNG image type */


### PR DESCRIPTION
The events module has been updated to deal with a set of problems:

1. For text labels (**-Et**), the plateau (**+p**) and decay (**+d**) period settings do not apply, yet this was not explained, and no check would prevent these from being set.  Documentation was updated and error checks now prevent plateau and decay from being specified.
2. If no fading was set, we would offer no protection against doing a division by zero, which would lead to a nan transparency and Ghostscript crashing.

Finally, movie **-M** with no **-F** failed to create the PNG frames.
