### PR TITLE
Add auto-naming mode for working directory

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -32,7 +32,7 @@ Synopsis
 [ **-Sf**\ *foreground* ]
 [ |SYN_OPT-V| ]
 [ |-Z|\ [**s**] ]
-[ |-W|\ *workdir* ]
+[ |-W|\ [*workdir*] ]
 [ |SYN_OPT-x| ]
 [ |SYN_OPT--| ]
 
@@ -264,9 +264,12 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ *workdir*
-    By default, all temporary files and frame PNG file are built in the subdirectory *prefix* set via **-N**.
-    You can override that selection by giving another *workdir* as a relative or full directory path.
+**-W**\ [*workdir*]
+    By default, all temporary files and frame PNG file are created in the subdirectory *prefix* set via **-N**.
+    You can override that selection by giving another *workdir* as a relative or full directory path. If no
+    path is given then we create a working directory in the system temp folder named *prefix*.  The main benefit
+    of a working directory is to avoid endless syncing by agents like DropBox or TimeMachine, or to avoid
+    problems related to low space in the main directory.
 
 .. _-Z:
 


### PR DESCRIPTION
It is helpful to run big movie jobs in a temp directory, possibly in /tmp or similar, since these (a) may have more free space and (b) may not be monitored by backup and sync tools.  This PR makes this even simpler by allowing **-W** (no work directory given), which then defaults to /tmp/prefix (i.e., a subdir with the same name as the movie prefix (**-N**) but in the system temp folder.
