### PR TITLE
Mixup in grid x/y array allocation

### DIFF
--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -620,7 +620,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 		/* Look for the x-coordinate vector */
 		if ((has_vector = !nc_get_var_double (ncid, ids[HH->xy_dim[0]], xy))) {
 			var_spacing = gmtnc_check_step (GMT, header->n_columns, xy, header->x_units, HH->name, save_xy_array);
-			if (save_xy_array) {
+			if (save_xy_array && var_spacing) {
 				if (GMT->current.io.nc_xarray) gmt_M_free (GMT, GMT->current.io.nc_xarray);
 				GMT->current.io.nc_xarray = gmt_M_memory (GMT, NULL, header->n_columns, double);
 				gmt_M_memcpy (GMT->current.io.nc_xarray, xy, header->n_columns, double);
@@ -708,7 +708,7 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 		/* Read the y-coordinate vector (if available), otherwise just look for range attributes */
 		if ((has_vector = !nc_get_var_double (ncid, ids[HH->xy_dim[1]], xy))) {
 			var_spacing = gmtnc_check_step (GMT, header->n_rows, xy, header->y_units, HH->name, save_xy_array);
-			if (save_xy_array) {
+			if (save_xy_array && var_spacing) {
 				if (GMT->current.io.nc_yarray) gmt_M_free (GMT, GMT->current.io.nc_yarray);
 				GMT->current.io.nc_yarray = gmt_M_memory (GMT, NULL, header->n_rows, double);
 				gmt_M_memcpy (GMT->current.io.nc_yarray, xy, header->n_rows, double);

--- a/src/grd2xyz.c
+++ b/src/grd2xyz.c
@@ -420,8 +420,8 @@ EXTERN_MSC int GMT_grd2xyz (void *V_API, int mode, void *args) {
 			if (H->var_spacing[GMT_X]) GMT_Report (API, GMT_MSG_WARNING, "Grid %s has non-equidistant x-coordinates (see grd2xyz docs for discussion)\n", opt->arg);
 			if (H->var_spacing[GMT_Y]) GMT_Report (API, GMT_MSG_WARNING, "Grid %s has non-equidistant y-coordinates (see grd2xyz docs for discussion)\n", opt->arg);
 
-			x = (H->var_spacing[GMT_X] && G->x) ? G->x : gmt_grd_coord (GMT, G->header, GMT_X);
-			y = (H->var_spacing[GMT_Y] && G->y) ? G->y : gmt_grd_coord (GMT, G->header, GMT_Y);
+			x = (G->x) ? G->x : gmt_grd_coord (GMT, G->header, GMT_X);
+			y = (G->y) ? G->y : gmt_grd_coord (GMT, G->header, GMT_Y);
 			Out = gmt_new_record (GMT, out, NULL);	/* Since we only need to worry about numerics in this module */
 			if (Ctrl->C.active) {	/* Replace x,y with col,row */
 				if (Ctrl->C.mode < 2) {


### PR DESCRIPTION
Unfortunately I made a mistake in implementing the variable x,y arrays.  If these are found we save the non-equidistant arrays in a special array, and then these are assigned as the grids x and y arrays.  However, if these are not found, gmt will create x and y arrays (equidistant) so we should not allocate new ones in grd2xyz.  The bug is harmless and only prompts things like

`gmt [WARNING]: Memory not freed first allocated in gmt_grdio.c:870(gmt_grd_coord) (ID = 35): 4.688 kb [4800 bytes]`

if compiled with MEM_DEBUG.
