### PR TITLE
CI: Always build and deploy docs in master branch

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -75,7 +75,7 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Linux | Build docs + Deploy docs + Package'
-  condition: eq(variables['Build.Reason'], 'Schedule')
+  condition: eq(variables['Build.SourceBranchName'], 'master')
 
   pool:
     vmImage: 'ubuntu-18.04'


### PR DESCRIPTION
We update the GMT documentation frequently, but have to wait for the nightly CI job
to build and view the documentation online.

The CI job for the documentation building takes ~22 minutes. After we migrate all
the animations to YouTube, the time could be decreased to ~10 minutes.

This PR changes the CI settings to rebuild the documentation when the
master branch changes, so that we can view the latest dev documentation
after ~20 minutes, not one night.