### PR TITLE
Return if input data has no numerical data

### DIFF
--- a/src/blockmean.c
+++ b/src/blockmean.c
@@ -388,6 +388,11 @@ EXTERN_MSC int GMT_blockmean (void *V_API, int mode, void *args) {
 				break;
 			continue;							/* Go back and read the next record */
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		in = In->data;	/* Only need to process numerical part here */
 		if (gmt_M_is_dnan (in[GMT_Z])) 		/* Skip if z = NaN */
 			continue;

--- a/src/blockmedian.c
+++ b/src/blockmedian.c
@@ -485,6 +485,11 @@ EXTERN_MSC int GMT_blockmedian (void *V_API, int mode, void *args) {
 				break;
 			continue;							/* Go back and read the next record */
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		in = In->data;	/* Only need to process numerical part here */
 
 		if (gmt_M_is_dnan (in[GMT_Z])) 		/* Skip if z = NaN */

--- a/src/blockmode.c
+++ b/src/blockmode.c
@@ -598,6 +598,11 @@ EXTERN_MSC int GMT_blockmode (void *V_API, int mode, void *args) {
 				break;
 			continue;							/* Go back and read the next record */
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		in = In->data;	/* Only need to process numerical part here */
 
 		if (gmt_M_is_dnan (in[GMT_Z])) 		/* Skip if z = NaN */

--- a/src/fitcircle.c
+++ b/src/fitcircle.c
@@ -412,6 +412,11 @@ EXTERN_MSC int GMT_fitcircle (void *V_API, int mode, void *args) {
 				break;
 			continue;	/* Go back and read the next record */
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		in = In->data;	/* Only need to process numerical part here */
 		if (in == NULL) {
 			GMT_Report (API, GMT_MSG_WARNING, "No data columns found; no output can be produced");

--- a/src/geodesy/gpsgridder.c
+++ b/src/geodesy/gpsgridder.c
@@ -612,6 +612,10 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 			if (gmt_M_rec_is_eof (GMT)) 		/* Reached end of file */
 				break;
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
 
 		/* Data record to process */
 		in = In->data;	/* Only need to process numerical part here */

--- a/src/geodesy/psvelo.c
+++ b/src/geodesy/psvelo.c
@@ -893,6 +893,10 @@ EXTERN_MSC int GMT_psvelo (void *V_API, int mode, void *args) {
 				break;
 			assert (In->text != NULL);						/* Should never get here */
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
 
 		in = In->data;
 		station_name = In->text;

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8775,3 +8775,9 @@ int gmt_mkdir (const char *path)
 
 	return 0;
 }
+
+void gmt_quit_bad_record (struct GMTAPI_CTRL *API, struct GMT_RECORD *In) {
+	GMT_Report (API, GMT_MSG_ERROR, "No data columns to work with - exiting\n");
+	if (In->text) GMT_Report (API, GMT_MSG_ERROR, "Data file only has trailing text. GMT expects numerical columns followed by optional trailing text\n");
+	API->error = GMT_DIM_TOO_SMALL;
+}

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -256,6 +256,7 @@ EXTERN_MSC int gmt_set_psfilename (struct GMT_CTRL *GMT);
 
 /* gmt_io.c: */
 
+EXTERN_MSC void gmt_quit_bad_record (struct GMTAPI_CTRL *API, struct GMT_RECORD *In);
 EXTERN_MSC int gmt_get_ogr_id (struct GMT_OGR *G, char *name);
 EXTERN_MSC bool gmt_is_float (struct GMT_CTRL *GMT, char *text);
 EXTERN_MSC void gmt_replace_backslash_in_path (char *dir);

--- a/src/gmtinfo.c
+++ b/src/gmtinfo.c
@@ -765,10 +765,13 @@ EXTERN_MSC int GMT_gmtinfo (void *V_API, int mode, void *args) {
 		if (gmt_M_rec_is_file_break (GMT)) continue;
 
 		/* We get here once we have read a data record */
-		if ((in = In->data) == NULL) {	/* Only need to process numerical part here */
-			GMT_Report (API, GMT_MSG_ERROR, "No data columns to work with - exiting\n");
-			Return (GMT_DIM_TOO_SMALL);
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
 		}
+
+		in = In->data;
+
 		if (first_data_record) {	/* First time we read data, we must allocate arrays based on the number of columns */
 
 			if (Ctrl->C.active) {	/* Must set output column types since each input col will produce two output cols. */

--- a/src/gmtselect.c
+++ b/src/gmtselect.c
@@ -796,6 +796,12 @@ EXTERN_MSC int GMT_gmtselect (void *V_API, int mode, void *args) {
 
 		/* Data record to process */
 
+		/* We get here once we have read a data record */
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		if (n_output == 0) {
 			GMT_Set_Columns (API, GMT_OUT, (unsigned int)gmt_get_cols (GMT, GMT_IN), (In->text) ? GMT_COL_FIX : GMT_COL_FIX_NO_TEXT);
 			n_output = gmt_get_cols (GMT, GMT_OUT);

--- a/src/grdedit.c
+++ b/src/grdedit.c
@@ -396,6 +396,11 @@ EXTERN_MSC int GMT_grdedit (void *V_API, int mode, void *args) {
 					break;
 				continue;	/* Go back and read the next record */
 			}
+			if (In->data == NULL) {
+				gmt_quit_bad_record (API, In);
+				Return (API->error);
+			}
+			
 			in = In->data;	/* Only need to process numerical part here */
 
 			/* Data record to process */

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -1178,12 +1178,13 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 					break;
 				continue;	/* Go back and read the next record */
 			}
+			if (In->data == NULL) {
+				gmt_quit_bad_record (API, In);
+				Return (API->error);
+			}
 
 			/* Data record to process */
-			if ((in = In->data) == NULL) {	/* Only need to process numerical part here */
-				GMT_Report (API, GMT_MSG_ERROR, "Record %" PRIu64 " did not have two coordinates - skipped.\n", n_read);
-				continue;
-			}
+			in = In->data;
 			if (n_out == 0) {	/* First time we need to determine # of columns and allocate output vector */
 				n_lead = (unsigned int)gmt_get_cols (GMT, GMT_IN);	/* Get total # of input cols */
 				n_out = n_lead + Ctrl->G.n_grids;	/* Get total # of output cols */

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -1571,6 +1571,10 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 				break;
 			continue;							/* Go back and read the next record */
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
 
 		/* Data record to process */
 		in = In->data;	/* Only need to process numerical part here */

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -1207,6 +1207,10 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 			GMT_Report (API, GMT_MSG_ERROR, "Input pointer is NULL where it should not be, aborting\n");
 			Return (GMT_PTR_IS_NULL);
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
 		if (first) {
 			unsigned int n_in_cols = (unsigned int)gmt_get_cols (GMT, GMT_IN);
 			if ((error = GMT_Set_Columns (API, GMT_OUT, n_in_cols, gmt_M_colmode (In->text))) != GMT_NOERROR) {

--- a/src/nearneighbor.c
+++ b/src/nearneighbor.c
@@ -400,6 +400,11 @@ EXTERN_MSC int GMT_nearneighbor (void *V_API, int mode, void *args) {
 				break;
 			continue;	/* Go back and read the next record */
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		in = In->data;	/* Only need to process numerical part here */
 
 		if (gmt_M_is_dnan (in[GMT_Z])) continue;					/* Skip if z = NaN */

--- a/src/potential/talwani2d.c
+++ b/src/potential/talwani2d.c
@@ -645,6 +645,11 @@ EXTERN_MSC int GMT_talwani2d (void *V_API, int mode, void *args) {
 				continue;
 			}
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		/* Clean data record to process.  Add point unless duplicate */
 		in = In->data;	/* Only need to process numerical part here */
 		if (Ctrl->A.active) in[GMT_Y] = -in[GMT_Y];

--- a/src/potential/talwani3d.c
+++ b/src/potential/talwani3d.c
@@ -859,6 +859,10 @@ EXTERN_MSC int GMT_talwani3d (void *V_API, int mode, void *args) {
 			gmt_M_free (GMT, cake);
 			Return (API->error);
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
 
 		/* Clean data record to process */
 

--- a/src/project.c
+++ b/src/project.c
@@ -1027,6 +1027,10 @@ EXTERN_MSC int GMT_project (void *V_API, int mode, void *args) {
 					break;
 				continue;							/* Go back and read the next record */
 			}
+			if (In->data == NULL) {
+				gmt_quit_bad_record (API, In);
+				Return (API->error);
+			}
 
 			/* Data record to process */
 			in = In->data;	/* Only need to process numerical part here */

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -910,6 +910,10 @@ EXTERN_MSC int GMT_pscontour (void *V_API, int mode, void *args) {
 				break;
 			continue;	/* Go back and read the next record */
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
 
 		/* Data record to process */
 		in = In->data;	/* Only need to process numerical part here */

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -473,6 +473,10 @@ EXTERN_MSC int GMT_psevents (void *V_API, int mode, void *args) {
 			}
 			continue;	/* Go back and read the next record */
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
 
 		/* Data record to process */
 

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -836,6 +836,11 @@ EXTERN_MSC int GMT_pshistogram (void *V_API, int mode, void *args) {
 			continue;	/* Go back and read the next record */
 		}
 
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		/* Data record to process */
 		in = In->data;	/* Only need to process numerical part here */
 

--- a/src/psmask.c
+++ b/src/psmask.c
@@ -754,6 +754,11 @@ EXTERN_MSC int GMT_psmask (void *V_API, int mode, void *args) {
 				if (gmt_M_rec_is_eof (GMT)) 		/* Reached end of file */
 					break;
 			}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 			in = In->data;	/* Only need to process numerical part here */
 
 			if (gmt_M_y_is_outside (GMT, in[GMT_Y], Grid->header->wesn[YLO], Grid->header->wesn[YHI])) continue;	/* Outside y-range */

--- a/src/psrose.c
+++ b/src/psrose.c
@@ -558,6 +558,11 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 			continue;	/* Go back and read the next record */
 		}
 
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		/* Data record to process */
 		in = In->data;	/* Only need to process numerical part here */
 

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1263,6 +1263,11 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 			}
 			outline_setting = (outline_active) ? 1 : 0;
 
+			if (In->data == NULL) {
+				gmt_quit_bad_record (API, In);
+				Return (API->error);
+			}
+
 			/* Data record to process */
 
 			in = In->data;

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -959,6 +959,11 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 				continue;							/* Go back and read the next record */
 			}
 
+			if (In->data == NULL) {
+				gmt_quit_bad_record (API, In);
+				Return (API->error);
+			}
+
 			/* Data record to process */
 
 			in = In->data;

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -941,6 +941,11 @@ EXTERN_MSC int GMT_pscoupe (void *V_API, int mode, void *args) {
 				break;
 		}
 
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		/* Data record to process */
 
 		in = In->data;

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -596,6 +596,11 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 			assert (In->text != NULL);						/* Should never get here */
 		}
 
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		/* Data record to process */
 		in = In->data;
 

--- a/src/sphdistance.c
+++ b/src/sphdistance.c
@@ -403,6 +403,11 @@ EXTERN_MSC int GMT_sphdistance (void *V_API, int mode, void *args) {
 				continue;	/* Go back and read the next record */
 			}
 
+			if (In->data == NULL) {
+				gmt_quit_bad_record (API, In);
+				Return (API->error);
+			}
+
 			/* Data record to process - avoid duplicate points as gmt_stripack_lists cannot handle that */
 			in = In->data;	/* Only need to process numerical part here */
 

--- a/src/sphinterpolate.c
+++ b/src/sphinterpolate.c
@@ -277,6 +277,11 @@ EXTERN_MSC int GMT_sphinterpolate (void *V_API, int mode, void *args) {
 			continue;	/* Go back and read the next record */
 		}
 
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		/* Data record to process */
 		in = In->data;	/* Only need to process numerical part here */
 

--- a/src/sphtriangulate.c
+++ b/src/sphtriangulate.c
@@ -609,6 +609,11 @@ EXTERN_MSC int GMT_sphtriangulate (void *V_API, int mode, void *args) {
 			continue;	/* Go back and read the next record */
 		}
 
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		/* Data record to process */
 		in = In->data;	/* Only need to process numerical part here */
 

--- a/src/spotter/backtracker.c
+++ b/src/spotter/backtracker.c
@@ -548,6 +548,11 @@ EXTERN_MSC int GMT_backtracker (void *V_API, int mode, void *args) {
 			}
 		}
 
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		/* Data record to process */
 		in = In->data;	/* Only need to process numerical part here */
 		in[GMT_Y] = gmt_lat_swap (GMT, in[GMT_Y], GMT_LATSWAP_G2O);	/* Convert to geocentric latitude */

--- a/src/spotter/gmtpmodeler.c
+++ b/src/spotter/gmtpmodeler.c
@@ -354,6 +354,11 @@ EXTERN_MSC int GMT_gmtpmodeler (void *V_API, int mode, void *args) {
 			}
 		}
 
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		/* Data record to process */
 		in = In->data;
 		Out->text = In->text;

--- a/src/spotter/hotspotter.c
+++ b/src/spotter/hotspotter.c
@@ -429,6 +429,11 @@ EXTERN_MSC int GMT_hotspotter (void *V_API, int mode, void *args) {
 				break;
 		}
 
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		/* Data record to process */
 		in = In->data;	/* Only need to process numerical part here */
 

--- a/src/spotter/originater.c
+++ b/src/spotter/originater.c
@@ -502,6 +502,11 @@ EXTERN_MSC int GMT_originater (void *V_API, int mode, void *args) {
 				break;
 		}
 
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		/* Data record to process */
 		in = In->data;	/* Only need to process numerical part here */
 		Out->text = In->text;

--- a/src/spotter/rotsmoother.c
+++ b/src/spotter/rotsmoother.c
@@ -330,6 +330,11 @@ EXTERN_MSC int GMT_rotsmoother (void *V_API, int mode, void *args) {
 				continue;
 			}
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		in = In->data;	/* Only need to process numerical part here */
 
 		/* Convert to geocentric, load parameters  */

--- a/src/surface.c
+++ b/src/surface.c
@@ -749,6 +749,11 @@ GMT_LOCAL int surface_read_data (struct GMT_CTRL *GMT, struct SURFACE_INFO *C, s
 			continue;	/* Go back and read the next record */
 		}
 
+		if (In->data == NULL) {
+			gmt_quit_bad_record (GMT->parent, In);
+			return (GMT->parent->error);
+		}
+
 		/* Data record to process */
 		in = In->data;	/* Only need to process numerical part here */
 

--- a/src/triangulate.c
+++ b/src/triangulate.c
@@ -446,6 +446,11 @@ EXTERN_MSC int GMT_triangulate (void *V_API, int mode, void *args) {
 			continue;	/* Go back and read the next record */
 		}
 
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		/* Data record to process */
 		in = In->data;	/* Only need to process numerical part here */
 

--- a/src/x2sys/x2sys_solve.c
+++ b/src/x2sys/x2sys_solve.c
@@ -475,6 +475,11 @@ EXTERN_MSC int GMT_x2sys_solve (void *V_API, int mode, void *args) {
 				break;
 			continue;
 		}
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
+		}
+
 		in = In->data;
 		if (In->text) {
 			if ((ks = sscanf (In->text, "%s %s", trk[0], trk[1])) != 2) {

--- a/src/xyz2grd.c
+++ b/src/xyz2grd.c
@@ -404,6 +404,11 @@ EXTERN_MSC int GMT_xyz2grd (void *V_API, int mode, void *args) {
 				assert (false);						/* Should never get here */
 			}
 
+			if (In->data == NULL) {
+				gmt_quit_bad_record (API, In);
+				Return (API->error);
+			}
+
 			/* Data record to process */
 
 			GMT_Put_Record (API, GMT_WRITE_DATA, In);
@@ -605,6 +610,11 @@ EXTERN_MSC int GMT_xyz2grd (void *V_API, int mode, void *args) {
 			else if (gmt_M_rec_is_eof (GMT)) 		/* Reached end of file */
 				break;
 			continue;	/* Go back and read the next record */
+		}
+
+		if (In->data == NULL) {
+			gmt_quit_bad_record (API, In);
+			Return (API->error);
 		}
 
 		/* Data record to process */


### PR DESCRIPTION
For programs that expect numerical data records, we had very few checks, and would get SEGV as in #3261.  This PR adds a check and if no data columns we print errors, maybe suggesting that the record is malformed (if there is trailing text), and return.  Closes #3261.
