### PR TITLE
Warn if transparency and gs is 9.51052

### DIFF
--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -2329,8 +2329,12 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 		fclose (fpo);	fpo = NULL;
 		fclose (fp);	fp  = NULL;
 
-		if (transparency && Ctrl->T.device != GS_DEV_PDF)	/* Must reset to PDF settings since we have transparency */
-			gs_params = (gsVersion.major >= 9 && gsVersion.minor >= 21) ? gs_params_pdfnew : gs_params_pdfold;
+		if (transparency) {
+			if (gsVersion.major == 9 && (gsVersion.minor == 51 || gsVersion.minor == 52))
+				GMT_Report (API, GMT_MSG_WARNING, "The file %s specifies transparency but your gs version 9.%d has a bug preventing it - please downgrade to 9.50\n", ps_file, gsVersion.minor);
+			if (Ctrl->T.device != GS_DEV_PDF)	/* Must reset to PDF settings since we have transparency */
+				gs_params = (gsVersion.major >= 9 && gsVersion.minor >= 21) ? gs_params_pdfnew : gs_params_pdfold;
+		}
 
 		/* Build the converting Ghostscript command and execute it */
 


### PR DESCRIPTION
Do that because that GS version is screwed.  Not tested though.