### PR TITLE
GMT_Read_Data for image data only failed

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -4703,7 +4703,7 @@ GMT_LOCAL struct GMT_IMAGE * gmtapi_import_image (struct GMTAPI_CTRL *API, int o
 	if (done) S_obj->status = GMT_IS_USED;	/* Mark as read (unless we just got the header) */
 	if (!via) S_obj->resource = I_obj;	/* Retain pointer to the allocated data so we use garbage collection later */
 
-	return ((mode & GMT_DATA_ONLY) ? NULL : I_obj);	/* Pass back out what we have so far */
+	return (I_obj);	/* Pass back out what we have so far */
 }
 
 GMT_LOCAL int gmtapi_export_ppm (struct GMT_CTRL *GMT, char *fname, struct GMT_IMAGE *I) {


### PR DESCRIPTION
It oddly wanted to return NULL when we came back for seconds to get the data, so any if (... == NULL) would print error and exit.  Unlike GRIDs.

I assume this bug has survived just because lack of testing.  Heads up to @joa-quim if he is doing anything strange with GMT_Read_Data for GMT_IS_IMAGE since the behavior will change slightly to the correct result.
