### PR TITLE
use n_bands when duplicating images

### DIFF
--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -3636,7 +3636,7 @@ The full definition of the ``GMT_GRID_HEADER`` structure.  Most of these members
 										                       grid, GMT_GRID_IS_COMPLEX_IMAG = imag part of complex grid */
        unsigned int mx, my;             /* Actual dimensions of the grid in memory, allowing for the padding */
        size_t       nm;                 /* Number of data items in this grid (n_columns * n_rows) [padding is excluded] */
-       size_t       size;               /* Actual number of items (not bytes) required to hold this grid (= mx * my) */
+       size_t       size;               /* Actual number of items (not bytes) required to hold this grid (= mx * my), per band */
        size_t       n_alloc;            /* Bytes allocated for this grid */
        unsigned int n_bands;            /* Number of bands [1]. Used with IMAGE containers and macros to get ij index from row,col, band */
        unsigned int pad[4];             /* Padding on west, east, south, north sides [2,2,2,2] */
@@ -3654,6 +3654,8 @@ An image is similar to a grid except it may have more than one layer (i.e., band
 It is represented by a :ref:`GMT_IMAGE <struct-image>` structure that consists of the
 :ref:`GMT_GRID_HEADER <struct-gridheader>` structure and an char array ``data`` that
 contains the image values.  The type of the array is determined by the value of ``type``.
+**Note**: The header *size* value reflects number of nodes per band, so the actual memory
+allocated will be *size * n_bands*.
 
 .. _struct-image:
 

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8062,6 +8062,10 @@ struct GMT_IMAGE *gmtlib_duplicate_image (struct GMT_CTRL *GMT, struct GMT_IMAGE
 	if ((mode & GMT_DUPLICATE_DATA) || (mode & GMT_DUPLICATE_ALLOC)) {	/* Also allocate and possibly duplicate data array */
 		Inew->data = gmt_M_memory_aligned (GMT, NULL, I->header->size * I->header->n_bands, char);
 		if (mode & GMT_DUPLICATE_DATA) gmt_M_memcpy (Inew->data, I->data, I->header->size * I->header->n_bands, char);
+		if (I->alpha) {	/* Also deal with the alpha layer */
+			Inew->alpha = gmt_M_memory_aligned (GMT, NULL, I->header->size, unsigned char);
+			if (mode & GMT_DUPLICATE_DATA) gmt_M_memcpy (Inew->alpha, I->alpha, I->header->size, unsigned char);
+		}
 		Inew->x = gmt_grd_coord (GMT, Inew->header, GMT_X);	/* Get array of x coordinates */
 		Inew->y = gmt_grd_coord (GMT, Inew->header, GMT_Y);	/* Get array of y coordinates */
 	}

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8060,8 +8060,8 @@ struct GMT_IMAGE *gmtlib_duplicate_image (struct GMT_CTRL *GMT, struct GMT_IMAGE
 	gmt_copy_gridheader (GMT, Inew->header, I->header);
 
 	if ((mode & GMT_DUPLICATE_DATA) || (mode & GMT_DUPLICATE_ALLOC)) {	/* Also allocate and possibly duplicate data array */
-		Inew->data = gmt_M_memory_aligned (GMT, NULL, I->header->size, char);
-		if (mode & GMT_DUPLICATE_DATA) gmt_M_memcpy (Inew->data, I->data, I->header->size, char);
+		Inew->data = gmt_M_memory_aligned (GMT, NULL, I->header->size * I->header->n_bands, char);
+		if (mode & GMT_DUPLICATE_DATA) gmt_M_memcpy (Inew->data, I->data, I->header->size * I->header->n_bands, char);
 		Inew->x = gmt_grd_coord (GMT, Inew->header, GMT_X);	/* Get array of x coordinates */
 		Inew->y = gmt_grd_coord (GMT, Inew->header, GMT_Y);	/* Get array of y coordinates */
 	}

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -402,7 +402,7 @@ struct GMT_GRID_HEADER {
 
 	/* Items not stored in the data file for grids but explicitly used in macros computing node numbers */
 	size_t nm;                       /* Number of data items in this grid (n_columns * n_rows) [padding is excluded] */
-	size_t size;                     /* Actual number of items (not bytes) required to hold this grid (= mx * my) */
+	size_t size;                     /* Actual number of items (not bytes) required to hold this grid (= mx * my), per band (for images) */
 	unsigned int bits;               /* Bits per data value (e.g., 32 for ints/floats; 8 for bytes) */
 	unsigned int complex_mode;       /* 0 = normal, GMT_GRID_IS_COMPLEX_REAL = real part of complex grid, GMT_GRID_IS_COMPLEX_IMAG = imag part of complex grid */
 	unsigned int type;               /* Grid format */


### PR DESCRIPTION
More previously unused/tested code related to images: _GMT_Duplicate_Data_ had a bug for images as it only allocated space for one band.  The _size_ parameters is the number of nodes (including padding) per band, so like in _GMT_Read_Data_ we must allocated _n_band_ as much memory than size.  Updated the docs as well.

