### PR TITLE
Improve ppm handing

### DIFF
--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -767,7 +767,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 			if ((Grid_orig[k] = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, Ctrl->In.file[k], NULL)) == NULL) {	/* Get header only */
 				Return (API->error);
 			}
-			if ((API->error = gmt_img_sanitycheck (GMT, Grid_orig[k]->header))) {	/* Used map projection on a Mercator (cartesian) grid */
+			if ((API->error = gmt_img_sanitycheck (GMT, Grid_orig[k]->header))) {	/* Used map projection on a Mercator (Cartesian) grid */
 				Return (API->error);
 			}
 		}


### PR DESCRIPTION
Do a more robust way of dealing with comments in PPM files, plus put back the last character read before parsing next record.  Also, if **-R** is set we use that as the image region since we have no other information.  Sorry, fixed typo in grdimage.