### PR TITLE
doc: Automatically determine the number of examples in the gallery page

### DIFF
--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -4,6 +4,7 @@
 # Refer to http://www.sphinx-doc.org/en/master/usage/configuration.html for details.
 #
 import sys, os
+import glob
 sys.path.append(os.path.abspath('_extensions'))
 
 # -- General configuration -----------------------------------------------------
@@ -80,6 +81,15 @@ from sphinx.builders.html import StandaloneHTMLBuilder
 StandaloneHTMLBuilder.supported_image_types = [
   'image/gif', 'image/jpeg', 'image/png', 'image/svg+xml'
 ]
+
+# context for the jinja extension
+## Count number of examples (.rst) in the source/gallery directory
+no_of_examples = len(glob.glob("source/gallery/ex*.rst"))
+jinja_contexts = {
+    'jinja_ctx': {
+        'no_of_examples': no_of_examples,
+    }
+}
 
 # -- Options for manual page output --------------------------------------------
 # One entry per manual page. List of tuples

--- a/doc/rst/source/gallery.rst
+++ b/doc/rst/source/gallery.rst
@@ -15,9 +15,9 @@ complex illustration.
 
 .. cssclass:: gmtgallary
 
-.. jinja::
+.. jinja:: jinja_ctx
 
-   {% for i in range(1, 51) %}
+   {% for i in range(1, no_of_examples + 1) %}
    {% set i = '%02d' % i %}
    -  .. figure:: /_images/ex{{i}}.*
          :target: ./gallery/ex{{i}}.html


### PR DESCRIPTION
In the GMT gallery page (`source/gallery.rst`), we include all examples using a for loop:
```
{% for i in range(1, 51) %}
```
The total number of examples is hard-coded here. We have to increase the number
when new examples are added.

In this PR, the total number of examples are automatically determined by counting the number
of `ex*.rst` files in the `doc/rst/source/gallery` directory. Thus, we no longer
need to manually increase the number.