### PR TITLE
doc: Remove ex51 from testing

### DIFF
--- a/doc/examples/CMakeLists.txt
+++ b/doc/examples/CMakeLists.txt
@@ -98,6 +98,8 @@ endif (UNIX AND DO_ANIMATIONS)
 
 # run examples (test)
 file (GLOB _examples RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/ex*/*.sh")
+# Remove a few known failed examples from tests
+list (REMOVE_ITEM _examples "ex51/ex51.sh")
 file (GLOB _anims RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/anim0[1-5]/*.sh")
 if (DO_EXAMPLES AND BASH)
 	# this file takes care of setting up the test environment


### PR DESCRIPTION
ex51 is known to fail since we don't include the osm data in the repository.
This PR excludes ex51 from GMT tests.