### PR TITLE
doc: Remove the subsection title in the gallery page

### DIFF
--- a/doc/rst/source/gallery.rst
+++ b/doc/rst/source/gallery.rst
@@ -3,9 +3,6 @@
 Example Gallery
 ===============
 
-The 51 Examples
-----------------
-
 In this section we will be giving numerous examples of typical usage of
 GMT programs. In general, we will start with a raw data set,
 manipulate the numbers in various ways, then display the results in


### PR DESCRIPTION
No need to update the number when adding new examples.