### PR TITLE
doc: Add the missing MAP_GRID_PEN to gmt.conf manpage

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -674,6 +674,10 @@ MAP Parameters
         draw ticks away from Equator and Greenwich, while a positive size will
         draw symmetric ticks [0p].
 
+    **MAP_GRID_PEN**
+        Sets both :term:`MAP_GRID_PEN_PRIMARY` and `MAP_GRID_PEN_PRIMARY` to
+        the value specified. This setting is not include in the **gmt.conf** file.
+
     **MAP_GRID_PEN_PRIMARY**
         Pen attributes used to draw primary grid lines in dpi units or
         points (append p) [default,black].

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -675,7 +675,7 @@ MAP Parameters
         draw symmetric ticks [0p].
 
     **MAP_GRID_PEN**
-        Sets both :term:`MAP_GRID_PEN_PRIMARY` and `MAP_GRID_PEN_SECONDARY` to
+        Sets both :term:`MAP_GRID_PEN_PRIMARY` and :term:`MAP_GRID_PEN_SECONDARY` to
         the value specified. This setting is not include in the **gmt.conf** file.
 
     **MAP_GRID_PEN_PRIMARY**

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -675,7 +675,7 @@ MAP Parameters
         draw symmetric ticks [0p].
 
     **MAP_GRID_PEN**
-        Sets both :term:`MAP_GRID_PEN_PRIMARY` and `MAP_GRID_PEN_PRIMARY` to
+        Sets both :term:`MAP_GRID_PEN_PRIMARY` and `MAP_GRID_PEN_SECONDARY` to
         the value specified. This setting is not include in the **gmt.conf** file.
 
     **MAP_GRID_PEN_PRIMARY**


### PR DESCRIPTION
MAP_GRID_PEN sets both MAP_GRID_PEN_PRIMARY and MAP_GRID_PEN_SECONDARY,
but it's undocumented.