### PR TITLE
Add operator DAYNIGHT to grdmath

### DIFF
--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -151,7 +151,7 @@ Optional Arguments
 Operators
 ---------
 
-Choose among the following 223 operators. "args" are the number of input
+Choose among the following 224 operators. "args" are the number of input
 and output arguments.
 
 +---------------+-------+--------------------------------------------------------------------------------------------------------+
@@ -256,6 +256,8 @@ and output arguments.
 | **D2R**       | 1 1   | Converts Degrees to Radians                                                                            |
 +---------------+-------+--------------------------------------------------------------------------------------------------------+
 | **DDX**       | 1 1   | d(A)/dx Central 1st derivative                                                                         |
++---------------+-------+--------------------------------------------------------------------------------------------------------+
+| **DAYNIGHT**  | 3 1   | 1 where sun at (A, B) shines and 0 elsewhere, with C transition width                                  |
 +---------------+-------+--------------------------------------------------------------------------------------------------------+
 | **DDY**       | 1 1   | d(A)/dy Central 1st derivative                                                                         |
 +---------------+-------+--------------------------------------------------------------------------------------------------------+
@@ -730,6 +732,12 @@ Notes On Operators
 #. The color-triplet conversion functions (**RGB2HSV**, etc.) includes not
    only r,g,b and h,s,v triplet conversions, but also l,a,b (CIE L a b ) and
    sRGB (x, y, z) conversions between all four color spaces.
+
+#. The DAYNIGHT operator returns a grid with ones on the side facing the given
+   sun location at (A,B).  If the transition width (C) is zero then we get
+   either 1 or 0, but if C is nonzero then we approximate the step function
+   using an atan-approximation instead.  Thus, the values are never exactly
+   0 or 1, but close, and the smaller C the closer we get.
 
 .. include:: explain_float.rst_
 

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -1861,7 +1861,7 @@ GMT_LOCAL void grdmath_DAYNIGHT (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info
 	else {
 		if (stack[last]->constant) iw = 1.0 / stack[last]->factor;	/* To avoid division */
 #ifdef _OPENMP
-#pragma omp parallel for private(row,col,node,d,w) shared(info,stack,prev2,last,GMT,x0,y0)
+#pragma omp parallel for private(row,col,node,d,iw) shared(info,stack,prev2,last,GMT,x0,y0)
 #endif
 		for (row = 0; row < info->G->header->my; row++) {
 			node = row * info->G->header->mx;

--- a/test/grdmath/daynight.ps
+++ b/test/grdmath/daynight.ps
@@ -1,0 +1,2657 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.1.0_d0ac7b1-dirty_2020.05.11 [64-bit] Document from grdimage
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Mon May 11 22:01:52 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt grdimage a.grd -Ct.cpt -Baf '-B+tTransition = 0' -P -K -JQ6.5i
+%@PROJ: eqc -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.356 20015109.356 -10007554.678 10007554.678 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%GMTBoundingBox: 72 72 468 234
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7800 0 D
+0 3900 D
+-7800 0 D
+P
+PSL_clip N
+V N -11 -11 T 7973 3922 scale [/Indexed /DeviceGray 1 <00FF>] setcolorspace
+<< /ImageType 1 /Decode [0 1] /Width 368 /Height 181 /BitsPerComponent 1
+   /ImageMatrix [368 0 0 -181 0 181] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[Bdg95_]k$jBJ-%Q`qh=:.]RV6L`#^bCCsf5HJ]+&X!H3f&RM-mJAmPfMge]C,NF<QscbS<_<2\WQ`jCqe)Rge[n,CR6LL
+='rO3WqsTUMlHQibqm^iKHCfiiDka9g5P[TBK+;;dI./X)Z;S@VU7%PhHN/<bcT?#e@F%/e?RJC;aRDDVO1,:ZS0!->IaE2
+CuL,U(N`.##s'5H"W`k3)G`V%)NR0f(f/Oo@@0.-_D!pVp8lPSm9#q/g9Nc>2'8llepIa_>-fA'HHep&f5!:MgB?m]IJfG5
+duMgiK!pVub;Ha=@CbNda%Xk(ns&g9=g`[kAeoH7K(c"c;m[clH@iT$N_e$o@YQ>#?HhGOV'[#M=NdP0>g-\0Q'tscA'rkB
+:Zu$oFkREg:"#?SEK[2b-VVt<3n-Nn-3@N6XjohTCV7'DLhmO%>'m(:H)B($kp0r#FI]4J#_SdiXNiW';,GQ*W&4q))&#?3
+d@Z&h[-r)@7p*Au-W/Vn7oB$@$)6k."-*ZC2&rumdTm5H"%hl!%2qcPfB>'<D,\;:[nVE$P\tLF1.CNk1Z:jPg&`:M)U&H3
+L='BmE&O4MY7`MPg6JN[S?=N+m:/U)lINUs+n!24YKK?+N7V%b)V;*2h&=leo`rN?5Oe~>
+U
+PSL_cliprestore
+25 W
+8 W
+N 0 0 M 0 -83 D S
+N 0 3900 M 0 83 D S
+N 1300 0 M 0 -83 D S
+N 1300 3900 M 0 83 D S
+N 2600 0 M 0 -83 D S
+N 2600 3900 M 0 83 D S
+N 3900 0 M 0 -83 D S
+N 3900 3900 M 0 83 D S
+N 5200 0 M 0 -83 D S
+N 5200 3900 M 0 83 D S
+N 6500 0 M 0 -83 D S
+N 6500 3900 M 0 83 D S
+N 7800 0 M 0 -83 D S
+N 7800 3900 M 0 83 D S
+N 7800 650 M 83 0 D S
+N 0 650 M -83 0 D S
+N 7800 650 M 83 0 D S
+N 0 650 M -83 0 D S
+N 7800 1950 M 83 0 D S
+N 0 1950 M -83 0 D S
+N 7800 1950 M 83 0 D S
+N 0 1950 M -83 0 D S
+N 7800 3250 M 83 0 D S
+N 0 3250 M -83 0 D S
+N 7800 3250 M 83 0 D S
+N 0 3250 M -83 0 D S
+83 W
+N -42 0 M 0 325 D S
+N 7842 0 M 0 325 D S
+1 A
+N -42 325 M 0 325 D S
+N 7842 325 M 0 325 D S
+0 A
+N -42 650 M 0 325 D S
+N 7842 650 M 0 325 D S
+1 A
+N -42 975 M 0 325 D S
+N 7842 975 M 0 325 D S
+0 A
+N -42 1300 M 0 325 D S
+N 7842 1300 M 0 325 D S
+1 A
+N -42 1625 M 0 325 D S
+N 7842 1625 M 0 325 D S
+0 A
+N -42 1950 M 0 325 D S
+N 7842 1950 M 0 325 D S
+1 A
+N -42 2275 M 0 325 D S
+N 7842 2275 M 0 325 D S
+0 A
+N -42 2600 M 0 325 D S
+N 7842 2600 M 0 325 D S
+1 A
+N -42 2925 M 0 325 D S
+N 7842 2925 M 0 325 D S
+0 A
+N -42 3250 M 0 325 D S
+N 7842 3250 M 0 325 D S
+1 A
+N -42 3575 M 0 325 D S
+N 7842 3575 M 0 325 D S
+0 A
+N 0 -42 M 325 0 D S
+N 0 3942 M 325 0 D S
+1 A
+N 325 -42 M 325 0 D S
+N 325 3942 M 325 0 D S
+0 A
+N 650 -42 M 325 0 D S
+N 650 3942 M 325 0 D S
+1 A
+N 975 -42 M 325 0 D S
+N 975 3942 M 325 0 D S
+0 A
+N 1300 -42 M 325 0 D S
+N 1300 3942 M 325 0 D S
+1 A
+N 1625 -42 M 325 0 D S
+N 1625 3942 M 325 0 D S
+0 A
+N 1950 -42 M 325 0 D S
+N 1950 3942 M 325 0 D S
+1 A
+N 2275 -42 M 325 0 D S
+N 2275 3942 M 325 0 D S
+0 A
+N 2600 -42 M 325 0 D S
+N 2600 3942 M 325 0 D S
+1 A
+N 2925 -42 M 325 0 D S
+N 2925 3942 M 325 0 D S
+0 A
+N 3250 -42 M 325 0 D S
+N 3250 3942 M 325 0 D S
+1 A
+N 3575 -42 M 325 0 D S
+N 3575 3942 M 325 0 D S
+0 A
+N 3900 -42 M 325 0 D S
+N 3900 3942 M 325 0 D S
+1 A
+N 4225 -42 M 325 0 D S
+N 4225 3942 M 325 0 D S
+0 A
+N 4550 -42 M 325 0 D S
+N 4550 3942 M 325 0 D S
+1 A
+N 4875 -42 M 325 0 D S
+N 4875 3942 M 325 0 D S
+0 A
+N 5200 -42 M 325 0 D S
+N 5200 3942 M 325 0 D S
+1 A
+N 5525 -42 M 325 0 D S
+N 5525 3942 M 325 0 D S
+0 A
+N 5850 -42 M 325 0 D S
+N 5850 3942 M 325 0 D S
+1 A
+N 6175 -42 M 325 0 D S
+N 6175 3942 M 325 0 D S
+0 A
+N 6500 -42 M 325 0 D S
+N 6500 3942 M 325 0 D S
+1 A
+N 6825 -42 M 325 0 D S
+N 6825 3942 M 325 0 D S
+0 A
+N 7150 -42 M 325 0 D S
+N 7150 3942 M 325 0 D S
+1 A
+N 7475 -42 M 325 0 D S
+N 7475 3942 M 325 0 D S
+0 A
+8 W
+N -83 0 M 7966 0 D S
+N -83 -83 M 7966 0 D S
+N 7800 -83 M 0 4066 D S
+N 7883 -83 M 0 4066 D S
+N 7883 3900 M -7966 0 D S
+N 7883 3983 M -7966 0 D S
+N 0 3983 M 0 -4066 D S
+N -83 3983 M 0 -4066 D S
+/PSL_H_y 400 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(100°) sh add def
+3900 3900 PSL_H_y add M
+400 F0
+(Transition = 0) bc Z
+0 -167 M 200 F0
+(-180°) tc Z
+0 4067 M (-180°) bc Z
+1300 -167 M (-120°) tc Z
+1300 4067 M (-120°) bc Z
+2600 -167 M (-60°) tc Z
+2600 4067 M (-60°) bc Z
+3900 -167 M (0°) tc Z
+3900 4067 M (0°) bc Z
+5200 -167 M (60°) tc Z
+5200 4067 M (60°) bc Z
+6500 -167 M (120°) tc Z
+6500 4067 M (120°) bc Z
+7800 -167 M (180°) tc Z
+7800 4067 M (180°) bc Z
+-167 650 M (-60°) mr Z
+7967 650 M (-60°) ml Z
+-167 1950 M (0°) mr Z
+7967 1950 M (0°) ml Z
+-167 3250 M (60°) mr Z
+7967 3250 M (60°) ml Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -Rd -JQ6.5i -O -K -Sk@sunglasses/1.5c
+%@PROJ: eqc -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.356 20015109.356 -10007554.678 10007554.678 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7800 0 D
+0 3900 D
+-7800 0 D
+P
+PSL_clip N
+4 W
+V
+O1
+/Sk_sunglasses {
+PSL_eps_begin
+0.25399961 dup scale
+1200 72 div dup scale
+%%BeginDocument: sunglasses.eps
+-10.711 -12.201 translate
+% Recalculate translation and scale to obtain a resized image
+5.80456 6.61202 translate
+gsave 0.458074 0.458074 scale
+newpath
+278.68 633.29 moveto
+275.12 630.04 275.65 624.62 273.44 620.58 curveto
+268.94 611.85 261.56 604.76 253.07 599.91 curveto
+242.69 593.40 232.11 587.13 222.58 579.39 curveto
+219.58 576.72 217.04 573.59 214.38 570.60 curveto
+208.70 564.47 206.00 556.35 203.46 548.58 curveto
+199.26 534.65 200.12 519.56 205.11 505.96 curveto
+200.44 508.17 196.08 510.96 191.74 513.74 curveto
+186.53 517.18 183.14 522.55 179.37 527.39 curveto
+172.86 536.98 171.19 548.68 169.65 559.90 curveto
+168.17 570.30 164.70 581.42 156.01 588.05 curveto
+151.59 591.25 146.70 595.24 140.84 593.93 curveto
+140.20 588.39 142.27 582.94 141.41 577.41 curveto
+140.30 569.57 136.32 562.51 132.01 556.01 curveto
+126.09 548.00 119.86 540.21 113.79 532.31 curveto
+105.00 519.64 100.87 503.41 104.24 488.22 curveto
+107.90 475.49 113.44 463.11 121.70 452.68 curveto
+126.98 445.86 134.63 441.52 140.81 435.63 curveto
+123.82 428.66 103.16 431.38 88.59 442.58 curveto
+82.15 447.43 75.90 452.52 69.81 457.80 curveto
+65.51 461.65 59.92 463.46 54.72 465.74 curveto
+46.01 469.49 35.93 469.97 26.90 467.16 curveto
+23.92 466.41 23.04 462.23 25.19 460.16 curveto
+29.78 454.52 35.03 448.81 36.52 441.44 curveto
+39.39 428.75 36.15 415.79 36.86 402.98 curveto
+37.96 390.64 39.86 378.17 44.87 366.75 curveto
+48.95 358.08 55.55 350.95 62.24 344.23 curveto
+66.86 339.49 72.92 336.68 78.74 333.76 curveto
+84.71 330.86 91.30 329.71 97.57 327.65 curveto
+87.78 316.13 79.68 303.21 73.50 289.40 curveto
+68.69 280.50 65.12 270.93 59.49 262.50 curveto
+55.36 257.02 50.30 252.27 44.85 248.13 curveto
+38.09 243.71 29.98 239.67 21.69 241.79 curveto
+18.55 242.92 15.35 243.99 11.96 243.84 curveto
+10.72 236.72 15.05 230.42 18.83 224.82 curveto
+32.74 205.07 55.70 193.25 79.08 189.01 curveto
+92.39 187.41 105.48 193.16 115.82 201.17 curveto
+122.12 205.22 126.73 211.26 132.72 215.70 curveto
+131.13 209.06 128.00 202.80 127.49 195.91 curveto
+126.85 186.65 126.80 177.36 126.53 168.09 curveto
+125.62 163.61 124.23 159.23 123.50 154.69 curveto
+120.50 143.35 110.61 135.54 100.61 130.37 curveto
+95.77 127.55 90.12 126.97 84.70 126.13 curveto
+82.08 126.11 80.90 122.49 82.75 120.78 curveto
+94.06 106.48 109.61 95.54 126.96 89.87 curveto
+137.42 86.67 148.57 87.30 159.30 88.49 curveto
+167.95 90.10 176.07 94.51 182.31 100.69 curveto
+193.63 111.77 200.67 126.18 207.88 140.06 curveto
+210.07 143.89 211.66 148.32 215.38 150.99 curveto
+214.84 146.20 212.94 141.71 212.21 136.96 curveto
+211.88 132.35 212.04 127.69 212.28 123.07 curveto
+213.71 109.66 220.48 97.33 229.32 87.36 curveto
+239.06 77.10 249.62 67.63 258.93 56.97 curveto
+265.06 48.29 271.35 37.92 269.14 26.84 curveto
+268.59 22.18 263.13 18.59 265.64 13.63 curveto
+284.57 12.21 303.19 22.77 313.72 38.25 curveto
+317.75 44.44 321.88 51.01 322.60 58.53 curveto
+323.59 67.19 323.86 76.01 322.83 84.68 curveto
+321.03 92.76 318.19 100.57 315.72 108.46 curveto
+314.53 114.21 315.09 120.22 316.22 125.94 curveto
+317.92 125.31 318.16 123.33 318.89 121.89 curveto
+321.26 115.31 325.37 109.19 331.26 105.29 curveto
+337.66 101.13 344.30 97.26 351.45 94.51 curveto
+369.29 86.88 387.17 76.51 397.43 59.42 curveto
+400.60 52.97 401.32 45.69 402.46 38.68 curveto
+402.76 37.38 402.74 35.83 403.74 34.80 curveto
+405.65 33.97 407.87 34.22 409.58 35.40 curveto
+414.23 38.37 419.40 40.68 423.23 44.76 curveto
+429.04 50.65 434.63 56.83 439.30 63.68 curveto
+444.57 72.31 446.47 82.45 447.70 92.35 curveto
+448.15 103.87 445.79 115.42 440.93 125.87 curveto
+438.21 134.04 431.86 140.05 426.58 146.57 curveto
+422.33 151.76 417.48 156.83 415.52 163.42 curveto
+430.67 158.52 446.87 154.84 459.48 144.52 curveto
+465.85 140.30 469.30 133.29 472.75 126.73 curveto
+477.06 118.78 477.60 109.47 481.29 101.28 curveto
+483.79 96.34 486.12 91.10 490.20 87.20 curveto
+492.05 85.30 495.29 84.71 497.44 86.50 curveto
+498.63 89.40 499.44 92.43 500.69 95.31 curveto
+503.00 101.23 507.31 106.03 510.52 111.44 curveto
+517.29 122.71 522.91 134.75 526.53 147.41 curveto
+528.08 154.16 528.06 161.19 527.93 168.08 curveto
+526.06 182.37 518.05 195.02 508.54 205.53 curveto
+499.25 215.52 488.86 224.82 476.50 230.83 curveto
+476.62 231.20 476.86 231.94 476.98 232.31 curveto
+481.41 232.37 485.76 231.42 489.92 229.94 curveto
+503.39 224.82 513.93 214.57 526.11 207.21 curveto
+541.44 199.52 559.20 195.28 576.27 198.64 curveto
+588.86 201.88 600.75 208.77 608.80 219.12 curveto
+612.01 224.10 614.48 229.51 617.15 234.79 curveto
+618.22 236.58 617.89 238.93 616.25 240.26 curveto
+611.93 243.99 605.90 244.34 600.96 246.87 curveto
+595.43 249.86 589.91 252.99 585.24 257.24 curveto
+572.08 268.24 562.92 282.92 551.76 295.76 curveto
+546.20 302.87 538.34 307.57 531.89 313.77 curveto
+537.58 314.96 543.34 315.75 549.01 317.01 curveto
+563.12 320.22 576.29 326.71 588.19 334.83 curveto
+594.64 339.26 600.45 344.65 605.11 350.95 curveto
+609.37 356.72 614.21 362.14 617.44 368.60 curveto
+621.43 375.60 623.66 383.40 626.05 391.05 curveto
+629.27 407.51 629.52 425.00 623.78 440.96 curveto
+622.94 443.82 620.15 444.94 617.40 444.96 curveto
+614.48 439.78 612.26 434.17 608.65 429.40 curveto
+605.10 424.99 599.78 422.63 594.78 420.27 curveto
+590.69 418.64 586.50 416.90 582.03 416.81 curveto
+574.13 416.55 566.14 416.62 558.40 418.39 curveto
+547.10 420.76 536.35 425.19 525.01 427.36 curveto
+518.37 428.20 511.64 428.43 504.95 428.06 curveto
+498.88 427.81 493.44 424.87 487.70 423.27 curveto
+495.95 443.01 514.36 455.35 528.71 470.31 curveto
+537.58 480.47 543.39 493.39 544.55 506.88 curveto
+545.27 514.80 546.03 523.00 543.79 530.76 curveto
+542.33 537.53 539.05 543.70 535.65 549.67 curveto
+530.25 558.91 523.09 567.52 513.52 572.62 curveto
+511.14 573.90 509.33 576.03 506.91 577.23 curveto
+505.04 577.62 502.47 576.87 502.30 574.64 curveto
+501.71 570.18 503.19 565.70 502.43 561.24 curveto
+501.05 553.11 497.07 545.53 491.53 539.46 curveto
+482.15 528.94 468.07 524.49 454.73 521.45 curveto
+439.66 518.75 424.30 516.29 410.36 509.62 curveto
+405.19 507.29 400.62 503.92 395.80 500.98 curveto
+396.95 512.20 403.69 521.83 411.14 529.89 curveto
+419.07 538.89 429.68 545.79 435.25 556.69 curveto
+442.00 573.77 441.46 594.46 430.87 609.88 curveto
+423.06 619.72 411.73 625.84 400.13 630.11 curveto
+397.86 630.88 395.00 631.57 393.02 629.74 curveto
+392.93 626.12 395.68 622.89 394.69 619.22 curveto
+393.30 611.93 388.09 605.94 382.01 601.98 curveto
+366.77 591.61 348.26 587.81 332.45 578.53 curveto
+324.99 573.47 318.50 567.02 313.33 559.64 curveto
+305.40 548.27 300.97 534.83 298.87 521.22 curveto
+294.14 525.91 291.59 532.23 289.47 538.41 curveto
+287.31 544.58 287.21 551.28 288.33 557.66 curveto
+290.94 570.70 298.47 581.99 302.32 594.60 curveto
+304.32 601.09 303.97 607.98 303.75 614.67 curveto
+303.39 622.27 299.05 629.78 292.08 633.07 curveto
+287.80 634.26 282.89 634.89 278.68 633.29 curveto
+closepath
+1.000 1.000 1.000 setrgbcolor
+fill
+newpath
+278.68 633.29 moveto
+282.89 634.89 287.80 634.26 292.08 633.07 curveto
+299.05 629.78 303.39 622.27 303.75 614.67 curveto
+303.97 607.98 304.32 601.09 302.32 594.60 curveto
+298.47 581.99 290.94 570.70 288.33 557.66 curveto
+287.21 551.28 287.31 544.58 289.47 538.41 curveto
+291.59 532.23 294.14 525.91 298.87 521.22 curveto
+300.97 534.83 305.40 548.27 313.33 559.64 curveto
+318.50 567.02 324.99 573.47 332.45 578.53 curveto
+348.26 587.81 366.77 591.61 382.01 601.98 curveto
+388.09 605.94 393.30 611.93 394.69 619.22 curveto
+395.68 622.89 392.93 626.12 393.02 629.74 curveto
+395.00 631.57 397.86 630.88 400.13 630.11 curveto
+411.73 625.84 423.06 619.72 430.87 609.88 curveto
+441.46 594.46 442.00 573.77 435.25 556.69 curveto
+429.68 545.79 419.07 538.89 411.14 529.89 curveto
+403.69 521.83 396.95 512.20 395.80 500.98 curveto
+400.62 503.92 405.19 507.29 410.36 509.62 curveto
+424.30 516.29 439.66 518.75 454.73 521.45 curveto
+468.07 524.49 482.15 528.94 491.53 539.46 curveto
+497.07 545.53 501.05 553.11 502.43 561.24 curveto
+503.19 565.70 501.71 570.18 502.30 574.64 curveto
+502.47 576.87 505.04 577.62 506.91 577.23 curveto
+509.33 576.03 511.14 573.90 513.52 572.62 curveto
+523.09 567.52 530.25 558.91 535.65 549.67 curveto
+539.05 543.70 542.33 537.53 543.79 530.76 curveto
+546.03 523.00 545.27 514.80 544.55 506.88 curveto
+543.39 493.39 537.58 480.47 528.71 470.31 curveto
+514.36 455.35 495.95 443.01 487.70 423.27 curveto
+493.44 424.87 498.88 427.81 504.95 428.06 curveto
+511.64 428.43 518.37 428.20 525.01 427.36 curveto
+536.35 425.19 547.10 420.76 558.40 418.39 curveto
+566.14 416.62 574.13 416.55 582.03 416.81 curveto
+586.50 416.90 590.69 418.64 594.78 420.27 curveto
+599.78 422.63 605.10 424.99 608.65 429.40 curveto
+612.26 434.17 614.48 439.78 617.40 444.96 curveto
+620.15 444.94 622.94 443.82 623.78 440.96 curveto
+629.52 425.00 629.27 407.51 626.05 391.05 curveto
+623.66 383.40 621.43 375.60 617.44 368.60 curveto
+614.21 362.14 609.37 356.72 605.11 350.95 curveto
+600.45 344.65 594.64 339.26 588.19 334.83 curveto
+576.29 326.71 563.12 320.22 549.01 317.01 curveto
+543.34 315.75 537.58 314.96 531.89 313.77 curveto
+538.34 307.57 546.20 302.87 551.76 295.76 curveto
+562.92 282.92 572.08 268.24 585.24 257.24 curveto
+589.91 252.99 595.43 249.86 600.96 246.87 curveto
+605.90 244.34 611.93 243.99 616.25 240.26 curveto
+617.89 238.93 618.22 236.58 617.15 234.79 curveto
+614.48 229.51 612.01 224.10 608.80 219.12 curveto
+600.75 208.77 588.86 201.88 576.27 198.64 curveto
+559.20 195.28 541.44 199.52 526.11 207.21 curveto
+513.93 214.57 503.39 224.82 489.92 229.94 curveto
+485.76 231.42 481.41 232.37 476.98 232.31 curveto
+478.21 238.11 480.75 243.47 483.14 248.85 curveto
+489.80 265.47 495.34 282.71 497.43 300.56 curveto
+499.49 322.11 498.32 344.03 493.13 365.08 curveto
+487.91 390.76 476.29 414.84 460.94 435.97 curveto
+452.79 448.22 441.84 458.21 430.78 467.77 curveto
+415.97 481.19 398.47 491.36 380.16 499.20 curveto
+362.52 506.19 343.87 510.33 325.16 513.21 curveto
+315.30 514.42 305.30 514.16 295.40 513.57 curveto
+276.83 511.36 258.22 508.07 240.71 501.29 curveto
+231.08 497.79 222.00 493.00 213.19 487.81 curveto
+206.15 483.61 198.95 479.61 192.57 474.42 curveto
+181.13 465.31 169.79 455.79 160.86 444.12 curveto
+157.37 439.62 153.43 435.46 150.32 430.67 curveto
+140.99 415.64 132.15 400.09 126.76 383.15 curveto
+126.03 380.70 125.74 378.15 125.54 375.61 curveto
+122.68 372.31 119.87 368.76 118.65 364.50 curveto
+116.42 357.02 116.84 349.07 117.68 341.40 curveto
+114.58 309.48 120.18 276.96 132.59 247.46 curveto
+143.27 225.14 157.22 204.27 174.72 186.71 curveto
+182.53 178.37 191.84 171.66 201.20 165.19 curveto
+208.48 160.35 215.82 155.51 223.75 151.78 curveto
+232.26 147.68 241.16 144.50 249.95 141.09 curveto
+265.95 136.53 282.34 132.99 299.01 132.27 curveto
+325.24 130.47 351.46 136.09 376.01 145.02 curveto
+386.65 148.69 396.31 154.53 406.17 159.86 curveto
+411.11 162.60 416.51 164.53 421.10 167.89 curveto
+443.67 184.73 462.41 206.50 476.50 230.83 curveto
+488.86 224.82 499.25 215.52 508.54 205.53 curveto
+518.05 195.02 526.06 182.37 527.93 168.08 curveto
+528.06 161.19 528.08 154.16 526.53 147.41 curveto
+522.91 134.75 517.29 122.71 510.52 111.44 curveto
+507.31 106.03 503.00 101.23 500.69 95.31 curveto
+499.44 92.43 498.63 89.40 497.44 86.50 curveto
+495.29 84.71 492.05 85.30 490.20 87.20 curveto
+486.12 91.10 483.79 96.34 481.29 101.28 curveto
+477.60 109.47 477.06 118.78 472.75 126.73 curveto
+469.30 133.29 465.85 140.30 459.48 144.52 curveto
+446.87 154.84 430.67 158.52 415.52 163.42 curveto
+417.48 156.83 422.33 151.76 426.58 146.57 curveto
+431.86 140.05 438.21 134.04 440.93 125.87 curveto
+445.79 115.42 448.15 103.87 447.70 92.35 curveto
+446.47 82.45 444.57 72.31 439.30 63.68 curveto
+434.63 56.83 429.04 50.65 423.23 44.76 curveto
+419.40 40.68 414.23 38.37 409.58 35.40 curveto
+407.87 34.22 405.65 33.97 403.74 34.80 curveto
+402.74 35.83 402.76 37.38 402.46 38.68 curveto
+401.32 45.69 400.60 52.97 397.43 59.42 curveto
+387.17 76.51 369.29 86.88 351.45 94.51 curveto
+344.30 97.26 337.66 101.13 331.26 105.29 curveto
+325.37 109.19 321.26 115.31 318.89 121.89 curveto
+318.16 123.33 317.92 125.31 316.22 125.94 curveto
+315.09 120.22 314.53 114.21 315.72 108.46 curveto
+318.19 100.57 321.03 92.76 322.83 84.68 curveto
+323.86 76.01 323.59 67.19 322.60 58.53 curveto
+321.88 51.01 317.75 44.44 313.72 38.25 curveto
+303.19 22.77 284.57 12.21 265.64 13.63 curveto
+263.13 18.59 268.59 22.18 269.14 26.84 curveto
+271.35 37.92 265.06 48.29 258.93 56.97 curveto
+249.62 67.63 239.06 77.10 229.32 87.36 curveto
+220.48 97.33 213.71 109.66 212.28 123.07 curveto
+212.04 127.69 211.88 132.35 212.21 136.96 curveto
+212.94 141.71 214.84 146.20 215.38 150.99 curveto
+211.66 148.32 210.07 143.89 207.88 140.06 curveto
+200.67 126.18 193.63 111.77 182.31 100.69 curveto
+176.07 94.51 167.95 90.10 159.30 88.49 curveto
+148.57 87.30 137.42 86.67 126.96 89.87 curveto
+109.61 95.54 94.06 106.48 82.75 120.78 curveto
+80.90 122.49 82.08 126.11 84.70 126.13 curveto
+90.12 126.97 95.77 127.55 100.61 130.37 curveto
+110.61 135.54 120.50 143.35 123.50 154.69 curveto
+124.23 159.23 125.62 163.61 126.53 168.09 curveto
+126.80 177.36 126.85 186.65 127.49 195.91 curveto
+128.00 202.80 131.13 209.06 132.72 215.70 curveto
+126.73 211.26 122.12 205.22 115.82 201.17 curveto
+105.48 193.16 92.39 187.41 79.08 189.01 curveto
+55.70 193.25 32.74 205.07 18.83 224.82 curveto
+15.05 230.42 10.72 236.72 11.96 243.84 curveto
+15.35 243.99 18.55 242.92 21.69 241.79 curveto
+29.98 239.67 38.09 243.71 44.85 248.13 curveto
+50.30 252.27 55.36 257.02 59.49 262.50 curveto
+65.12 270.93 68.69 280.50 73.50 289.40 curveto
+79.68 303.21 87.78 316.13 97.57 327.65 curveto
+91.30 329.71 84.71 330.86 78.74 333.76 curveto
+72.92 336.68 66.86 339.49 62.24 344.23 curveto
+55.55 350.95 48.95 358.08 44.87 366.75 curveto
+39.86 378.17 37.96 390.64 36.86 402.98 curveto
+36.15 415.79 39.39 428.75 36.52 441.44 curveto
+35.03 448.81 29.78 454.52 25.19 460.16 curveto
+23.04 462.23 23.92 466.41 26.90 467.16 curveto
+35.93 469.97 46.01 469.49 54.72 465.74 curveto
+59.92 463.46 65.51 461.65 69.81 457.80 curveto
+75.90 452.52 82.15 447.43 88.59 442.58 curveto
+103.16 431.38 123.82 428.66 140.81 435.63 curveto
+134.63 441.52 126.98 445.86 121.70 452.68 curveto
+113.44 463.11 107.90 475.49 104.24 488.22 curveto
+100.87 503.41 105.00 519.64 113.79 532.31 curveto
+119.86 540.21 126.09 548.00 132.01 556.01 curveto
+136.32 562.51 140.30 569.57 141.41 577.41 curveto
+142.27 582.94 140.20 588.39 140.84 593.93 curveto
+146.70 595.24 151.59 591.25 156.01 588.05 curveto
+164.70 581.42 168.17 570.30 169.65 559.90 curveto
+171.19 548.68 172.86 536.98 179.37 527.39 curveto
+183.14 522.55 186.53 517.18 191.74 513.74 curveto
+196.08 510.96 200.44 508.17 205.11 505.96 curveto
+200.12 519.56 199.26 534.65 203.46 548.58 curveto
+206.00 556.35 208.70 564.47 214.38 570.60 curveto
+217.04 573.59 219.58 576.72 222.58 579.39 curveto
+232.11 587.13 242.69 593.40 253.07 599.91 curveto
+261.56 604.76 268.94 611.85 273.44 620.58 curveto
+275.65 624.62 275.12 630.04 278.68 633.29 curveto
+248.08 211.12 moveto
+251.21 212.54 254.55 213.79 258.04 213.54 curveto
+260.62 213.78 262.25 211.45 264.11 210.06 curveto
+263.73 208.56 263.35 207.06 263.00 205.54 curveto
+268.77 208.91 275.11 212.12 282.03 211.40 curveto
+290.61 210.56 299.17 206.64 305.03 200.25 curveto
+296.36 192.80 284.50 189.18 273.19 191.23 curveto
+262.54 193.95 253.57 201.75 248.08 211.12 curveto
+closepath
+0.973 0.580 0.004 setrgbcolor
+fill
+newpath
+295.40 513.57 moveto
+305.30 514.16 315.30 514.42 325.16 513.21 curveto
+343.87 510.33 362.52 506.19 380.16 499.20 curveto
+398.47 491.36 415.97 481.19 430.78 467.77 curveto
+441.84 458.21 452.79 448.22 460.94 435.97 curveto
+476.29 414.84 487.91 390.76 493.13 365.08 curveto
+498.32 344.03 499.49 322.11 497.43 300.56 curveto
+495.34 282.71 489.80 265.47 483.14 248.85 curveto
+480.75 243.47 478.21 238.11 476.98 232.31 curveto
+476.86 231.94 476.62 231.20 476.50 230.83 curveto
+462.41 206.50 443.67 184.73 421.10 167.89 curveto
+416.51 164.53 411.11 162.60 406.17 159.86 curveto
+396.31 154.53 386.65 148.69 376.01 145.02 curveto
+351.46 136.09 325.24 130.47 299.01 132.27 curveto
+282.34 132.99 265.95 136.53 249.95 141.09 curveto
+241.16 144.50 232.26 147.68 223.75 151.78 curveto
+215.82 155.51 208.48 160.35 201.20 165.19 curveto
+191.84 171.66 182.53 178.37 174.72 186.71 curveto
+157.22 204.27 143.27 225.14 132.59 247.46 curveto
+120.18 276.96 114.58 309.48 117.68 341.40 curveto
+118.93 337.55 119.78 332.85 123.66 330.70 curveto
+126.77 328.53 131.47 327.78 134.45 330.60 curveto
+139.09 334.27 138.75 340.72 139.15 346.04 curveto
+139.40 353.43 141.07 361.88 147.59 366.33 curveto
+152.74 369.54 158.47 371.78 164.36 373.21 curveto
+164.98 359.11 169.57 344.80 179.28 334.30 curveto
+188.51 323.69 201.37 317.25 214.27 312.25 curveto
+222.10 309.03 230.83 308.82 239.12 309.93 curveto
+254.11 312.19 267.70 322.45 273.59 336.46 curveto
+278.41 350.46 278.48 365.62 283.45 379.58 curveto
+285.40 385.04 288.47 390.29 293.06 393.93 curveto
+298.13 397.92 305.46 396.83 310.71 393.78 curveto
+316.16 389.69 319.00 382.76 319.20 376.06 curveto
+319.63 364.93 315.86 354.15 316.19 343.02 curveto
+315.50 330.71 320.36 318.50 328.04 309.03 curveto
+335.42 302.23 343.04 295.37 352.25 291.12 curveto
+357.84 287.93 364.24 286.84 370.40 285.29 curveto
+379.29 282.79 388.76 284.16 397.50 286.64 curveto
+406.33 289.50 414.15 294.85 420.96 301.07 curveto
+426.08 305.72 429.69 311.68 433.73 317.23 curveto
+437.29 322.12 439.13 327.92 441.65 333.35 curveto
+443.59 337.56 444.57 342.10 446.01 346.48 curveto
+450.75 343.13 455.07 339.24 459.35 335.34 curveto
+463.51 331.49 467.07 326.65 468.13 320.97 curveto
+470.03 313.01 464.26 305.10 467.21 297.23 curveto
+467.96 294.61 470.42 292.98 473.04 292.68 curveto
+476.67 291.89 479.38 295.03 481.94 297.07 curveto
+488.71 302.99 490.57 312.41 490.79 321.00 curveto
+491.05 325.01 488.86 328.57 486.77 331.79 curveto
+480.92 340.49 472.44 346.86 464.48 353.50 curveto
+458.34 358.42 452.20 363.45 445.32 367.31 curveto
+439.44 370.68 434.04 374.79 428.19 378.20 curveto
+403.09 392.47 375.94 402.93 348.04 410.22 curveto
+333.24 413.79 318.28 417.31 303.01 417.89 curveto
+291.02 418.69 279.02 419.41 267.01 419.34 curveto
+245.19 418.99 223.39 416.19 202.27 410.69 curveto
+188.41 407.11 175.16 401.57 162.01 395.98 curveto
+149.37 390.19 135.83 385.31 125.54 375.61 curveto
+125.74 378.15 126.03 380.70 126.76 383.15 curveto
+132.15 400.09 140.99 415.64 150.32 430.67 curveto
+153.43 435.46 157.37 439.62 160.86 444.12 curveto
+169.79 455.79 181.13 465.31 192.57 474.42 curveto
+198.95 479.61 206.15 483.61 213.19 487.81 curveto
+222.00 493.00 231.08 497.79 240.71 501.29 curveto
+258.22 508.07 276.83 511.36 295.40 513.57 curveto
+209.44 451.56 moveto
+203.23 444.58 199.95 435.21 200.03 425.90 curveto
+204.76 430.57 208.43 436.50 214.49 439.62 curveto
+219.85 443.08 226.63 442.61 232.62 441.48 curveto
+242.23 439.38 249.79 432.47 259.13 429.73 curveto
+256.88 445.56 241.79 457.98 226.00 458.29 curveto
+219.91 458.35 213.54 456.22 209.44 451.56 curveto
+368.04 443.97 moveto
+361.46 440.70 355.66 436.06 349.07 432.82 curveto
+345.14 430.87 340.83 429.89 336.64 428.69 curveto
+340.28 423.95 346.59 423.72 352.04 423.23 curveto
+360.61 422.36 368.78 425.66 377.15 426.87 curveto
+384.52 428.54 392.59 428.15 399.21 424.20 curveto
+405.14 421.17 408.74 415.34 413.93 411.37 curveto
+415.73 421.71 410.18 431.99 402.18 438.23 curveto
+396.62 442.30 390.19 446.15 383.04 445.80 curveto
+378.03 445.67 372.64 446.39 368.04 443.97 curveto
+205.30 288.67 moveto
+200.90 285.83 197.02 281.65 195.60 276.50 curveto
+198.88 279.93 201.33 284.29 205.82 286.37 curveto
+209.94 271.92 222.03 262.15 230.11 250.05 curveto
+234.12 242.32 236.26 233.79 238.23 225.35 curveto
+242.33 209.48 254.45 196.18 269.17 189.32 curveto
+281.28 185.93 295.06 189.24 304.63 197.35 curveto
+310.19 200.80 313.41 206.63 317.37 211.62 curveto
+321.00 216.34 324.31 221.31 328.12 225.89 curveto
+331.34 228.69 335.75 229.52 339.45 231.54 curveto
+349.36 236.11 357.92 243.27 364.56 251.89 curveto
+369.47 250.14 371.31 245.07 373.66 240.90 curveto
+373.16 244.70 372.89 249.06 369.69 251.69 curveto
+364.75 256.95 357.21 259.14 350.18 257.68 curveto
+350.26 257.19 350.42 256.20 350.50 255.71 curveto
+354.53 255.28 358.56 254.71 362.49 253.67 curveto
+359.14 247.56 353.60 243.05 348.23 238.79 curveto
+335.20 230.91 320.43 224.82 304.99 224.76 curveto
+289.84 224.90 274.52 228.04 260.92 234.82 curveto
+250.55 240.84 239.82 246.70 231.39 255.39 curveto
+221.92 264.79 211.95 274.94 208.29 288.16 curveto
+212.06 288.19 215.85 287.91 219.60 288.37 curveto
+215.82 292.20 209.51 291.32 205.30 288.67 curveto
+253.73 182.39 moveto
+259.27 175.16 268.40 168.16 278.03 170.92 curveto
+282.12 171.68 286.96 173.50 287.41 178.32 curveto
+282.88 176.78 279.11 172.72 274.00 173.33 curveto
+267.51 173.44 262.65 178.13 257.86 181.87 curveto
+256.73 183.02 255.12 182.56 253.73 182.39 curveto
+closepath
+1.000 0.937 0.012 setrgbcolor
+fill
+newpath
+209.44 451.56 moveto
+213.54 456.22 219.91 458.35 226.00 458.29 curveto
+241.79 457.98 256.88 445.56 259.13 429.73 curveto
+249.79 432.47 242.23 439.38 232.62 441.48 curveto
+226.63 442.61 219.85 443.08 214.49 439.62 curveto
+208.43 436.50 204.76 430.57 200.03 425.90 curveto
+199.95 435.21 203.23 444.58 209.44 451.56 curveto
+368.04 443.97 moveto
+372.64 446.39 378.03 445.67 383.04 445.80 curveto
+390.19 446.15 396.62 442.30 402.18 438.23 curveto
+410.18 431.99 415.73 421.71 413.93 411.37 curveto
+408.74 415.34 405.14 421.17 399.21 424.20 curveto
+392.59 428.15 384.52 428.54 377.15 426.87 curveto
+368.78 425.66 360.61 422.36 352.04 423.23 curveto
+346.59 423.72 340.28 423.95 336.64 428.69 curveto
+340.83 429.89 345.14 430.87 349.07 432.82 curveto
+355.66 436.06 361.46 440.70 368.04 443.97 curveto
+235.52 246.70 moveto
+240.99 243.99 245.90 240.35 251.09 237.15 curveto
+262.87 229.73 276.28 225.21 289.99 223.08 curveto
+295.98 222.67 301.98 222.40 307.98 222.48 curveto
+313.25 222.48 318.26 224.35 323.45 224.92 curveto
+321.58 219.77 318.10 215.47 315.07 210.97 curveto
+313.06 208.33 311.21 205.21 308.06 203.81 curveto
+303.68 205.57 300.15 208.90 295.81 210.74 curveto
+287.63 214.12 278.19 215.21 269.75 212.11 curveto
+266.42 210.29 263.95 213.78 261.17 215.07 curveto
+256.29 217.80 250.79 214.87 246.03 213.28 curveto
+240.66 223.71 237.84 235.27 235.52 246.70 curveto
+253.73 182.39 moveto
+255.12 182.56 256.73 183.02 257.86 181.87 curveto
+262.65 178.13 267.51 173.44 274.00 173.33 curveto
+279.11 172.72 282.88 176.78 287.41 178.32 curveto
+286.96 173.50 282.12 171.68 278.03 170.92 curveto
+268.40 168.16 259.27 175.16 253.73 182.39 curveto
+closepath
+0.941 0.353 0.075 setrgbcolor
+fill
+newpath
+202.27 410.69 moveto
+223.39 416.19 245.19 418.99 267.01 419.34 curveto
+279.02 419.41 291.02 418.69 303.01 417.89 curveto
+318.28 417.31 333.24 413.79 348.04 410.22 curveto
+375.94 402.93 403.09 392.47 428.19 378.20 curveto
+434.04 374.79 439.44 370.68 445.32 367.31 curveto
+452.20 363.45 458.34 358.42 464.48 353.50 curveto
+472.44 346.86 480.92 340.49 486.77 331.79 curveto
+488.86 328.57 491.05 325.01 490.79 321.00 curveto
+490.57 312.41 488.71 302.99 481.94 297.07 curveto
+479.38 295.03 476.67 291.89 473.04 292.68 curveto
+470.42 292.98 467.96 294.61 467.21 297.23 curveto
+464.26 305.10 470.03 313.01 468.13 320.97 curveto
+467.07 326.65 463.51 331.49 459.35 335.34 curveto
+455.07 339.24 450.75 343.13 446.01 346.48 curveto
+444.57 342.10 443.59 337.56 441.65 333.35 curveto
+439.13 327.92 437.29 322.12 433.73 317.23 curveto
+429.69 311.68 426.08 305.72 420.96 301.07 curveto
+414.15 294.85 406.33 289.50 397.50 286.64 curveto
+388.76 284.16 379.29 282.79 370.40 285.29 curveto
+364.24 286.84 357.84 287.93 352.25 291.12 curveto
+343.04 295.37 335.42 302.23 328.04 309.03 curveto
+320.36 318.50 315.50 330.71 316.19 343.02 curveto
+315.86 354.15 319.63 364.93 319.20 376.06 curveto
+319.00 382.76 316.16 389.69 310.71 393.78 curveto
+305.46 396.83 298.13 397.92 293.06 393.93 curveto
+288.47 390.29 285.40 385.04 283.45 379.58 curveto
+278.48 365.62 278.41 350.46 273.59 336.46 curveto
+267.70 322.45 254.11 312.19 239.12 309.93 curveto
+230.83 308.82 222.10 309.03 214.27 312.25 curveto
+201.37 317.25 188.51 323.69 179.28 334.30 curveto
+169.57 344.80 164.98 359.11 164.36 373.21 curveto
+158.47 371.78 152.74 369.54 147.59 366.33 curveto
+141.07 361.88 139.40 353.43 139.15 346.04 curveto
+138.75 340.72 139.09 334.27 134.45 330.60 curveto
+131.47 327.78 126.77 328.53 123.66 330.70 curveto
+119.78 332.85 118.93 337.55 117.68 341.40 curveto
+116.84 349.07 116.42 357.02 118.65 364.50 curveto
+119.87 368.76 122.68 372.31 125.54 375.61 curveto
+135.83 385.31 149.37 390.19 162.01 395.98 curveto
+175.16 401.57 188.41 407.11 202.27 410.69 curveto
+206.01 381.98 moveto
+202.05 379.14 197.90 376.50 194.54 372.92 curveto
+200.98 373.32 207.00 375.84 213.29 377.07 curveto
+207.29 366.51 198.63 357.71 192.65 347.12 curveto
+199.67 349.50 206.10 353.37 213.24 355.45 curveto
+209.69 347.57 204.26 340.70 200.81 332.77 curveto
+210.47 337.65 218.77 344.86 228.56 349.50 curveto
+224.47 340.79 218.88 332.86 214.86 324.10 curveto
+222.86 328.27 229.86 334.09 237.88 338.23 curveto
+236.95 333.09 235.88 327.95 235.71 322.71 curveto
+241.31 328.35 245.97 334.81 251.28 340.69 curveto
+257.87 347.63 260.88 356.93 264.82 365.44 curveto
+261.19 363.69 257.55 361.94 253.77 360.51 curveto
+255.55 365.52 258.62 369.95 260.21 375.03 curveto
+255.25 372.20 251.25 367.92 245.98 365.58 curveto
+249.31 373.45 255.33 379.71 259.38 387.16 curveto
+249.73 382.97 241.34 376.41 231.79 372.00 curveto
+234.81 378.72 239.58 384.51 242.26 391.39 curveto
+236.75 388.75 232.30 384.45 226.91 381.62 curveto
+228.39 388.27 231.35 394.46 232.95 401.08 curveto
+223.65 395.18 215.01 388.31 206.01 381.98 curveto
+362.14 367.87 moveto
+356.06 363.34 349.61 359.28 343.96 354.20 curveto
+350.45 354.47 356.59 356.67 362.88 358.05 curveto
+355.97 348.12 348.13 338.83 341.73 328.55 curveto
+349.46 329.82 355.81 334.72 363.05 337.35 curveto
+359.05 329.28 353.96 321.81 349.70 313.88 curveto
+359.65 318.87 368.20 326.24 378.17 331.20 curveto
+374.13 322.36 368.34 314.46 364.12 305.71 curveto
+372.21 309.56 379.06 315.51 387.11 319.42 curveto
+386.53 314.19 385.28 309.06 384.89 303.80 curveto
+390.60 311.38 395.29 319.64 400.52 327.55 curveto
+404.09 333.42 408.29 338.92 411.28 345.14 curveto
+408.43 344.04 405.66 342.77 402.82 341.65 curveto
+404.80 346.36 407.40 350.79 409.22 355.57 curveto
+404.43 353.37 400.38 349.92 395.71 347.50 curveto
+399.43 354.68 404.81 360.85 408.27 368.17 curveto
+398.64 363.86 390.18 357.41 380.70 352.82 curveto
+383.71 359.57 388.25 365.51 391.09 372.34 curveto
+385.76 369.53 381.23 365.48 375.90 362.67 curveto
+377.17 369.01 379.97 374.90 381.26 381.24 curveto
+374.58 377.23 368.54 372.29 362.14 367.87 curveto
+205.30 288.67 moveto
+209.51 291.32 215.82 292.20 219.60 288.37 curveto
+215.85 287.91 212.06 288.19 208.29 288.16 curveto
+211.95 274.94 221.92 264.79 231.39 255.39 curveto
+239.82 246.70 250.55 240.84 260.92 234.82 curveto
+274.52 228.04 289.84 224.90 304.99 224.76 curveto
+320.43 224.82 335.20 230.91 348.23 238.79 curveto
+353.60 243.05 359.14 247.56 362.49 253.67 curveto
+358.56 254.71 354.53 255.28 350.50 255.71 curveto
+350.42 256.20 350.26 257.19 350.18 257.68 curveto
+357.21 259.14 364.75 256.95 369.69 251.69 curveto
+372.89 249.06 373.16 244.70 373.66 240.90 curveto
+371.31 245.07 369.47 250.14 364.56 251.89 curveto
+357.92 243.27 349.36 236.11 339.45 231.54 curveto
+335.75 229.52 331.34 228.69 328.12 225.89 curveto
+324.31 221.31 321.00 216.34 317.37 211.62 curveto
+313.41 206.63 310.19 200.80 304.63 197.35 curveto
+295.06 189.24 281.28 185.93 269.17 189.32 curveto
+254.45 196.18 242.33 209.48 238.23 225.35 curveto
+236.26 233.79 234.12 242.32 230.11 250.05 curveto
+222.03 262.15 209.94 271.92 205.82 286.37 curveto
+201.33 284.29 198.88 279.93 195.60 276.50 curveto
+197.02 281.65 200.90 285.83 205.30 288.67 curveto
+235.52 246.70 moveto
+237.84 235.27 240.66 223.71 246.03 213.28 curveto
+250.79 214.87 256.29 217.80 261.17 215.07 curveto
+263.95 213.78 266.42 210.29 269.75 212.11 curveto
+278.19 215.21 287.63 214.12 295.81 210.74 curveto
+300.15 208.90 303.68 205.57 308.06 203.81 curveto
+311.21 205.21 313.06 208.33 315.07 210.97 curveto
+318.10 215.47 321.58 219.77 323.45 224.92 curveto
+318.26 224.35 313.25 222.48 307.98 222.48 curveto
+301.98 222.40 295.98 222.67 289.99 223.08 curveto
+276.28 225.21 262.87 229.73 251.09 237.15 curveto
+245.90 240.35 240.99 243.99 235.52 246.70 curveto
+248.08 211.12 moveto
+253.57 201.75 262.54 193.95 273.19 191.23 curveto
+284.50 189.18 296.36 192.80 305.03 200.25 curveto
+299.17 206.64 290.61 210.56 282.03 211.40 curveto
+275.11 212.12 268.77 208.91 263.00 205.54 curveto
+263.35 207.06 263.73 208.56 264.11 210.06 curveto
+262.25 211.45 260.62 213.78 258.04 213.54 curveto
+254.55 213.79 251.21 212.54 248.08 211.12 curveto
+closepath
+0.000 0.000 0.000 setrgbcolor
+fill
+newpath
+206.01 381.98 moveto
+215.01 388.31 223.65 395.18 232.95 401.08 curveto
+231.35 394.46 228.39 388.27 226.91 381.62 curveto
+232.30 384.45 236.75 388.75 242.26 391.39 curveto
+239.58 384.51 234.81 378.72 231.79 372.00 curveto
+241.34 376.41 249.73 382.97 259.38 387.16 curveto
+255.33 379.71 249.31 373.45 245.98 365.58 curveto
+251.25 367.92 255.25 372.20 260.21 375.03 curveto
+258.62 369.95 255.55 365.52 253.77 360.51 curveto
+257.55 361.94 261.19 363.69 264.82 365.44 curveto
+260.88 356.93 257.87 347.63 251.28 340.69 curveto
+245.97 334.81 241.31 328.35 235.71 322.71 curveto
+235.88 327.95 236.95 333.09 237.88 338.23 curveto
+229.86 334.09 222.86 328.27 214.86 324.10 curveto
+218.88 332.86 224.47 340.79 228.56 349.50 curveto
+218.77 344.86 210.47 337.65 200.81 332.77 curveto
+204.26 340.70 209.69 347.57 213.24 355.45 curveto
+206.10 353.37 199.67 349.50 192.65 347.12 curveto
+198.63 357.71 207.29 366.51 213.29 377.07 curveto
+207.00 375.84 200.98 373.32 194.54 372.92 curveto
+197.90 376.50 202.05 379.14 206.01 381.98 curveto
+362.14 367.87 moveto
+368.54 372.29 374.58 377.23 381.26 381.24 curveto
+379.97 374.90 377.17 369.01 375.90 362.67 curveto
+381.23 365.48 385.76 369.53 391.09 372.34 curveto
+388.25 365.51 383.71 359.57 380.70 352.82 curveto
+390.18 357.41 398.64 363.86 408.27 368.17 curveto
+404.81 360.85 399.43 354.68 395.71 347.50 curveto
+400.38 349.92 404.43 353.37 409.22 355.57 curveto
+407.40 350.79 404.80 346.36 402.82 341.65 curveto
+405.66 342.77 408.43 344.04 411.28 345.14 curveto
+408.29 338.92 404.09 333.42 400.52 327.55 curveto
+395.29 319.64 390.60 311.38 384.89 303.80 curveto
+385.28 309.06 386.53 314.19 387.11 319.42 curveto
+379.06 315.51 372.21 309.56 364.12 305.71 curveto
+368.34 314.46 374.13 322.36 378.17 331.20 curveto
+368.20 326.24 359.65 318.87 349.70 313.88 curveto
+353.96 321.81 359.05 329.28 363.05 337.35 curveto
+355.81 334.72 349.46 329.82 341.73 328.55 curveto
+348.13 338.83 355.97 348.12 362.88 358.05 curveto
+356.59 356.67 350.45 354.47 343.96 354.20 curveto
+349.61 359.28 356.06 363.34 362.14 367.87 curveto
+closepath
+0.388 0.388 0.388 setrgbcolor
+fill
+grestore
+
+%%EndDocument
+PSL_eps_end } def
+V 4196 2027 T
+0.590551181102 dup scale Sk_sunglasses U
+V -3604 2027 T
+0.590551181102 dup scale Sk_sunglasses U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 6000 TM
+
+% PostScript produced by:
+%@GMT: gmt grdimage b.grd -Ct.cpt -Baf '-B+tTransition = 5' -JQ6.5i -O -K -Y5i
+%@PROJ: eqc -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.356 20015109.356 -10007554.678 10007554.678 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7800 0 D
+0 3900 D
+-7800 0 D
+P
+PSL_clip N
+V N -11 -11 T 7822 3922 scale /DeviceGray setcolorspace
+<< /ImageType 1 /Decode [0 1] /Width 361 /Height 181 /BitsPerComponent 8
+   /ImageMatrix [361 0 0 -181 0 181] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[BdnBg>bQI5gXsBq)P&-HdZK-^c6NaZ+8eNXL`C+M2Ha#cJ#b/>@_I+ta/,LuO$-+tgq\+tbEu/-<+,..5jV1RVdB1f)Ra
+Bfg2'4AX_EH@EVMcFrtBHd?!5RA;M4H]^Vn$h3DihfJ3-rqHEc\,S76OSRd@d+EbPlhRGCf%>C\ememSO.Y$+I1[IbDp]%[
+R=G3``pV"uA,T-VrQ'T:5C>*DQsT@NRf/=k=PE\2e_!#e)maHNnib0F1oZ$qoG_6<hJRce+%pfNC;Z)Y8$K@jrlDjA*OQWd
+:-qJJ^SX11rs+X;Ro!<.S,%Fir@rXkCMa_s.54Q6$2p<^^N21."+DhQ2gQFEV9[Z/G(-'3p92K@H\d@2bZa"B+?&e*49YC[
+h#,THpq,hU7<)1/B5N;[7@*..8>e5+B/IRc6HbW_@25,i0Co(D18!9]H=)5p([&;RCmhZXg"b53mbb+cic4,7VUC&PO3A4-
+^05mrmh]M`Y089a;/`@VkM.q7Q!;_gXEeOmg;n))Caj-_f%``0&_b%%+`#(In1W<+K+rD*):$9=5*CnG,Is^!YF%+a?<a\c
+;&c5%bbiAqJH%5@Mu/uYl`#lj&nV;M0kS9pM@k`VIL,NGRJ5CIViC6rH3_)5P@s%->N=;=H#&8De6/efP`j0mO#=Ct>*,%0
+l]`9m5YV'+KUC2>k.<>9^q<D(R5ji&GVe39g/E&:::q<Z*h-=hC-gPRX^a7X[aT=PVV!qE.5^M;R")7).26<HR'[!UnH\Lq
+>HiMOoZ<:EO's*g4;<Qu%W@$t4FKi_#s*s=2rdAE%@^J#e1B*=B\qFXCeO[f-R4&8'O.BqU]kE`c3c@)er\:H&S$nW`_TGJ
+@37VAJ,eB=H["r8]`U&>%Xnb&J_TYNJ+*Hsd2^6bI[bR<D@IPe8ZkXd<GJ)3"t_f-Pk@XlZmK:6XeY$S<G9c_@4#D0=[ls;
+R1Wq'5`hU%7:*3hS@j:If#5N%ps#9eDql1^):\rkH/f+a1-RlVEU3=8J-U0=7r[reDQ9gHCY!7#p!NoKbh5D;cI0Or=IVnR
+coPg*AklJpVT).88VS?PQiu;dZlL/)*Zc4>]RG:%^V@OeYO@o<n1XRl_"I#GK1!Po,GV2$%cS%An-3d19s>eoBMENl;j1%Y
+dN#V0BK<C.o)E\bP/g.r"_od?)RSMJiiFo!/>FsGR35GgLCYNL:_<sq"Lrm3H@*68\up4"FBiNuDej-(`G$Lq$ias[^XCNW
+H*s]R];PC,+.s,Vn=/IZX_8Aac'lS>V`%'Rcr+LtA34&<Qt)UXo?_erNgYW)<@5eE0glnB4P&EAgB5)ig=oda?b1KUq0^Z%
+`l>=o%JBDeF`cQ:L5*$oNTZbU2da(>l#LQDq\:7Bl0[fO4ubAS9!nu6Adup.M)A#8:>,]M"knY*\W+!OYnj=X8F)p;B:<E@
+1G!sC1-qeWUE`-YfD@Y`!VjP-VT,t8F_>GaSNKbt]W/93U:gEVYqeA\Ng5r4<)cm=Y<Hss<6^iBqQl/Uk:Zg[HUh^McaEb'
+_;UM2`.heiYW6KfC7p;XCXOKV>'C7'(7_5FEkVKg2Y+Ia;<t"q[+ZKFd&Jn?R?kk=53A(Qb)g.%*ZGt<*9b/ge(*,kr`hhH
+RF<OaX")<98rjrQ=E:'Z?Vs[/6%4:^?97RQ6"*X<^>]5@#7hh(/M"$+W]k_)9O5Ori,38p\D#cn#M>.)#m`H62,B51Tp+U`
+D1pJ#>:H$Clc7.O-7sf"!\HB!CN.KSb7NbA82;=^ola^0BPW/IT<,1H5C2Be8T@U9IbpZd>s!7Hce>fZ1F",-4cN3_H:CBd
+[V]1%GO4+MZR7E@Yc,(md#k*bQ.76tC)\);?bG0;"gIm-%mdEIDVr!K+(J$D5?.I]l[qd8o&-3Qc:6r1'(]UF/Q*O`3G;S9
+MDM[sD2f&Do:q*8n(e$+Z&taGrIB9lmIJ6fN=E9Q-P%4G0$MYdfpSCrR@]_5Z?]Ah;IX*%r.YZ#EH1;ai4g3h`$ZfW-7*Ta
+S<B>,SsbkW1FG,rYkZ#-dUSQmVp<coG"[0p=)[!hU!Xh>[kQBt=q.kdbsg=dD02("gNct_-+-KO#H\/uGG]AWbS]JHj#9G_
+Y4qU4FgeaZErDD)eWn0I&+/&8SX$H;ATMli_M5SQQuu8Af;t!kN!Kq)?_n0Y*"a(!HHk0BFYU.@)\S<s2lCK:aNEAIB5_5K
+_'<NVeYd3/2I3iJh?g_6*/7RreBf:2qGSlGQ%pZmhUu62s2i:A^+sG0g)O9J%c[C8F,&7BR3BelK953?p<+8@cISSiXt2YT
+YdeZ@Sul4[PN(V3USHC.7]Zr$\KZ-@88qC%?sl5b^bRt?;.*d.:iOMHckS(K<^fEZM2I=QMbct%!no_Vnd>+5/1j)8Wj\Vc
+@`t%;4akq;7gV%poeYeB%(.M.Fb^Q4k%r!f"kJ_JC;$tq>&=bs)<2.-nI3!s0TQ]Nn*@N1V<)/b6g^l5jeW4V(ZsiGJ1Sa[
+XBQV]*k!7L,WIJcRD5AtO12TbQ`'"E(_7Va^sgcUbM1dlf?\qL5[\P%k_cV6aL1>CiY".e:<gl6\L2l6$!Pq<2IC@flmC5k
+#W2oGeq_Zp>^6V%Z9T@rVhM42\[<PsLpRB2(C078g<L7B_L.7qGB^K$DJlOCjcY&fHZj"4Ui,%V&/Pqe@X2qN14K;tnm(J=
+^1?cn7>osV(;dT0_%5AW(+i_&G_s&Q;GSqGpKn[Q]R3.M`9Jbd:>V/BD9&7Gie'`O:Rl-4]%#;^e77OJmbE/>U"6#Zn%hLt
+!c?oo*6?9i:s5][TJ=f8^S*VSS0-OuF)-.3R60+T2)Uma;0heAEW2OMgX<MU-cEtlXc<YonFuVL6=Jqt?*I_NMp&bYoB,&V
+_''o:B3\^(03I.ijQQ!mmHYi*'EZp&eub"j\0W_BB5Z[Z,N[H5oh?7W3d^]-7rCSA5Z9nb2,TJ_jZt)mQF%7XhUrCg@[p$U
+Tp:M4JYpCPS8f9k#42i$EFWO`YG\_o@T.\LFnq.%Kt0:Od^EtN?b^IfKK1=!gXF&gnKKnn!!_:?F(WaIl`F<rB)Rt>S*[oZ
+RCD%A4WE$>I/X1K[mc524Zj&Ens/17f<%h>:<CT&aY,i*m!)7Bq+L*VHO#;F`c'`Xog,B<@FA7!I&'bU1!hso#Km(?+1"%$
+W-N)@dMfJ.BNcC_T>?rF`gtlE@m^@3=5,C!Dl>[Flu6rn:3K*!El.ZqX2A!k-Xg?J[LeG]c9Yj"IIiFWB$QqB'0<>3r]9o^
+553&9Dh:'&"#jmHF<fFebKtQ0FBmhf[&i)1J\&GTCiddbD@#o0W"5X[7bRptg0"Ji&@V8?QSsICJ^unMD;9e(G@,&u5$Lqp
+b^4PHV/8tdMdD%YbPXnukI[DW//1S2f3b.)A&`:<5NW28!M;l*!!hsqW/]GfQCr@cE+i?aeG=hm>I/M9mls]iUA!B]2@/t0
+e-?[F8q6UJmddkY4+XhQ[R!s6T%Xd`(22LT5sM.9K6pE6_[u">Ms"hN<#jS`^H65sVM+V>O^Xs"!N<YA&VQPp^Oa</%&gAD
+qW]RjJ"mJK2gh3YK/[ba6*]U`:hq0Q^lXfnCL\#9V/=O-3,l7iFMmp?Nh1]u%piFuZk7V!c??e1RBj1@=pQtR%(4L?e'W3M
+iH3Vt!sL^>dl&MjY)QO$''SdOQ!NOsR>o:$N5A!W7kd.a%Xsk6UGpRIfZ`&t.E"8X"]B86cd"+'<">V9eDA_73')Nc/kX%<
+K._t%4f"3PgC=m1^%6;"j-W[7dP>LIkthEj.j81(@D@B=GAiP'%eb%Q?\18(+"GFX:>_#S.mbB&9AQ!kKGhA\2.fO4IfT'q
+SaY$9s2#]\37E<cRtOqjGBI-LiT2!YWK(/SP`iR-+$s7Sp0q7X23`hh__.#"1`'l.3t0J`TV]qWUo%WFX[UqDXYbeOBN!3]
+YCes4o<ka0Me?fJcM>(-;j,^%6(.n']f_Uj\^%+qDuA[=82;uu^e">cAR9]I-1tce*4^na8N*i&$i51#gL<Ji()ae/3A!=:
+hr0Gk%F)"VWUrP-:!80t1tNagBO.:%1&iUAMgJ!jooYP-@rl$FZf3+Q&#o0Nf&h]c'o2PFAu?qnLlMlgb_t9m_#!d@;2-d>
+U*<OpQZ2rX399\\>K*JUL(8c:;eg6c^u_WJ`$V?tgKf'.r+%sST"Oge$.^r!#E(E^LB,TM6@Eo7FT,)3aR3dm/T_5'%0^G!
+*+UA6ict4b-P)oCWH8$[nq2Y.\"t@iY$&.pd*J1:6^XR8Bk8^6PSd!lMU$FR@@pE0;4D!(Y%asdooc.8bCWeb7`TGifU6)E
+G,"Ce8rl\?hL>Y9,*iIn[*fs=Zm=!fB;:t'Z8o@qZl3Wf>&=`^BIF?m#TqlpS/=WVo5uG'9(I1<Cl4:6>T(2uBB^&ObeadZ
+nY72+aGcM-I`FFJ37VWn1tOs@9qc`9jR2+K\3,.Ugr?_f]_t@$M=f0I`1?ddT9Acl,#,\e)76r\NA;MYBfg"93EVrZ31`=J
+IqN5,LcAHXh4L%)[P;Z:q!p[W0D@o<$8Y]]d1:`r1/TC<RdddtUNmMiAdu<5W*rh6\/7OQ'"0,F.<TtiPO9C$E=92rc`fNN
+4lj5m%,-iM*ABF4V+mXdF-)XuM?=X2]=2YdoeGXbmAW[^CViC\cANLU'$)e;B70aV<1+V&dMM#?GnY#=>,-g`ObDFABLQH*
+@S0[=0h=74FnH:&]T"eNM_s$+4L?9Y-I-eC]!7J8,L&OGc+sW'$i9SAiVp!gAoKBJbt:QdM-LYR8)aqM+NI/;6WI0D^L];Q
+[pZ=8cZjjboZ+W?DG**?"%+<-'0pmDd1c0hg:ISZ`j)Du&L&fZ(7RZ5kiZ?nO\55-k.AM6RK`O./ElVdJaW4>od:m.=Xa[)
+&YXciSkIl$c\'f9q>(M[):PZ0F2m+%O/PdWM)E5?;8WkH69Wp(lQ]e_pc9U)G-^)dQ!RQ(mlkuJlQM7p;UT1(dQg$pZ_b%&
+4*8iVU6S!]NoRr]=9s8W>\lB&7\&(a0+YkPE1)W(T(/8dN+'^_/':!E2e9gI/(Qarljj@Zeq]%T1*XCpmm-^5`ljq)L2Pe\
+#EaIr6sAsf[A9YG\j/J51QFk,+))$<WG(!*,g`b.5.Yt8`mD-=bDiFC&*.RTcHEj`YVn2\cl+,"GJBn&Mo8s=8*&6(X4/]M
+:`g&Zl.#(5#:jPX>.aX94E*HZOk.+](>?%bIu,DbPGto8[*fpNd's]tEV+I_2UtbHgmak73%og9?uabb^J!!KPW@g.>E+G5
+XAs!]e6!g!k:U^p8*T6UXZHk"=4K1;pKSfPFViZI%rj63Ok.*r6@WSLD=.7.nr__V-uB1e)1ttZ!sAK0$oG&=GAiIHmqH^C
+X#aLi@r#O13kN!UQoc7&6]JF7R5]T2Cj9e!oh-sC:h+o=;9pW<&MZjk]8B3V1gK=U2KVlW['grX6(8&3WNqAg!Lf31LK9a.
+-."T+Y'!ua3)Nkd.kN1sJiM)3HH+ZHEJ>c9AU[KUekj+.N_Wf_-IgDm/C[K<:t/H*+>bi33?tHsf]dH/>m$i8GEbY!h*F\;
+J@5jXPaH%3%O0.`o+__Z_#f$t@W\9DjkT*1`AngXZ&t^\e/@TJeQ7tpZR(^0=](Im9>)'UN`tf\X:IbR_^Aj2lF>)AGpS``
+c0`2s\/mgY)\8c,`0,9H4]Q)61MJpaZ(f?<Lg,mP\.T;F[Puf=QK2UoNa'1@^rJfb`kuZ$2>GVHPVpjll:6o[X9ga"#T%5U
+)HK7u^m/]q;mHdk<&\(Ill-hWo=toO)eb^+gC^bHJJP&`TQPg7E+aQoYObXZooXjmPk_X:"+=Pt<1WhEPF[HLCdou7Q;Fna
+Z_E1#O\.;"$XU4n0l;,Sg$,Bbmd"@6dUYAfQaAR4kqM/=V4BlP'hsu\(?i$hh5sDLbDLMA-*CGem'i3?j"dR_L)O].c@RfA
+qA!uYfSVOVNM2+'@+)P/c?!:XkoUNMPFS%F;H\4;j4Z1V)@d;BEi>;2**V&9drdR22KX]_RT21M$K7Wh"$M%6j$I$_8T&-\
+9LO]Ok@3%g\.19,;B$n,)Y;PqAM[dE[q`$A/"n<_6)8Mh0mfMX'!Gl?X5gX!(R1M-D!Af-_oC^=V*!1i<]AGRd*b26dHX1*
+r?%o`au3G&BVd^3d#Tp.>qM$`9+/&7`2sMTk-`-MhX$kth>h1h)bQWsbSJ:B=AZ'kTh<XN=m58e(`!;:Z+p31o+d5V_l)t9
+:R=GOUeRO7!c80X(n%bF464a\F5YpCSYluQcrZ[^PjaCeL^FO^EF7ob7rY?5+Y^[(.Vk?".3C^]5g@o9.fIAg3V0MQ_dek=
+m6+^&p+f,6raWAV.c!B`HHOTXXHJu41fr)O*-<WWHliH=q/#`_^"\][_Qfcsc^FG1n#Y)p3O9$t*a>;'9&ndg-b(9Op4W"h
+OLfMjZ't88dUYAVmP(euEbP.Gdqte.:Ifl/"St@,TuFF$2?tde/C<QqNpYSh\cI]+F"o;#5G@r`\[,0PEoau37ZK&ue+sWO
+?\,!B2eUH@kjBH.[Os!RpYbQG/^d78d#p;gL*k9ucG(/cEY"#6&_aH)6:EELT`r$dpqbaEUig*shX1d7c$g=d]3c/@[Cq=9
+//&f>?nDgFPQ!b2L74_&[aZrU@f;VZU9`5bl&!$5fQ*p6LK`-P"9!T,Hk+M<7FUD7^"qKN%.reiU?jJt,=;<o]$6"^VU"(#
+S0`1+0q0:)YU.eN1`dn@bpuoF:``rd<if"dhc!F,OhNQ,41pW'`c]<YTH,`0W2C)!RKJnn-P%PB@%aPmp7s(;?*VT]M?=7_
+Q+t/q6(P>GcH_N:O\m'niQ-^(LeuPs*^2mKZ(&0<*ed/ZND.,RMqT32C1m^o"k&gF6(3-)-dZTsX3CYM.ha.U&EomCgGd*+
+#JlF1*\HRtrW%sWABn6"Ir65^C8j$Q7T@Q@d8L"k2=YB@--$s.\d*/:jcFS>]"oU;c##Q/TUe,J86\IAVF.=r]"+T\!DDCr
+_=!VDj!?^"nS:JiEQ>nQK,tPl3ZF;0a:`<O=tWNa)U$$@M0ImX(l39:9lii)kUfmH=a(]UH90Cgc?a3fd(5+3blLJrXjR-.
+k*e%2FNgaMmj5,=*8Ek/ERs.9"BcTK[2Nd,r?@HFR`=ocm/lV4o$o#6B3T_;`c4$:n71[B^LQ*iI*e2)3pGlpj'goE5QCLG
+>RJN,H<SXX5d+K(/"t.&=r_?%<;%9pC`6qJ@lB@D8PMQtbaJY"@:31o7f(>_c@N7TA3"2V_+K#Gd":)<TJ^Frd%mC=F-*6f
+p=MXnKejS0kcd<S$0TNaiZJDAk:BX4Z@8V#`qiN-nS"GXa(qm=HK[X=^#rdG@pAEk`'(Dkk.?7Q%G;>O;eR+_ZUd`_l1#+q
+(37ZNS*524_nBoHeHbi15^VE]#WiN"*;$aFFOo&u-*dq`:G#,<2,25GXG8X\fgY#1QXGS=QUB1AibHPQ48qdtlDB2<$Ya[D
+V%E?DQYO^%Z>#uR9#qeR'XZ_"b%urO`-*>!G93s&TgUq)p[H;%.t+WAC>E<(dXOMqX,9rH".$g<.nqB%kGBb\VCS?<*"JP,
+Pf_!5Xcle$)Tm]6LG[G[@Q*['Y,K+j9pS/p*TZ.?^*Z!KBKPA6MpbOV`n-s<@3O;l_c#-8\\=e_a(EtEO?h9[OR/WC5oZAm
+_i,fH[4;-,.]ns@DXg8nf-Fnn/NqnubMhLa8U()VK/PX.K1T/PRnoC=bt(r(!f^DG^,VMO$Pq#KbWcc]KN]jB-kEW&,E\#B
+ZKo<rZYdB#\/^C^Tj&!+R*b];:h^DE$:fEsc5o3SCJ-2b1tgSSMo3cl$<`6<:eRWVH*BicTTK^iS$];jm**F$3'--36RulW
+D9!G%/_bBG(!ST@*#3X&4B#:b/ST&M%J1&EBN?*bc4X_&AYZY<R]gFB4es[s*>BQ]RWIs$/r-oqh-h_r574d#U;c9)ND&5e
+K/ooNiBc>-U%st805,-694^/MdcuF_Pm:G&+k!Ub=R*Y1?1R]`MY`X1+cGcMPk6%!g9dUMjr!AtWNR`(T"Jrps&.WmO?g.;
+O;8)1&F,d``/LIh2Fsn1+\$do&te+'%I&..E&iTRZrqU?YD-Ba[%sGrh5iVE'9,ZDOhC;qOhj4S()R*)(5J<aSM)p^Um:MD
+OiG)AgX9YAd@5@JYA.mc2L6=Nd^2+*i(uKBGI/:ZEq[qu]k)aQY(c022a&_1k($1umEo]dNE,k"DN532[a^<'Tt*Fh`F8!^
+oDDNJZC@qk[ISk@ODOI:8Ge.C8^&_6X1a0jBsg#r2gCrn8^!Xk.pC]_.F!F5kY&<p"dt3_6@?1+j46t.$+5A.k5;-sE?oBA
+BpV8m_crb%F6M]\NrBu]8p?YhoR@6^;UM:#-?&O#S3M9I-ZqT=m2!7b#27@*U+EQ-9'aVe=V$e2oZWrQFbLiBeAgnQ.N2K;
+7rIkQ+kbd6?4H:tL&7<*lZUZJ7J"cDCS\GITjlpQNDZphF.N3WRE?RS=:)t+&=aai)m.A]FmC2?qNW/;NX%/m5nU=@QI`iP
+)@jYVGPq#5Oq"!g8P^Y\[a'24h<+-,^Eh&)LYo=mXso($0EUulZep0/a00H5elG*Bc8Nm+2UZ&[n<':s'+S33/mB4,H.RW4
+F'&4Y-6GGMI(Eep^L8i+Zu'kHI5j7<J)sr.JR+b?="]-=h5m##`'?tQj#NW(V%#<,7iDjJ@6&]KGBg>3DC[9ACZu]pmuAjb
+Ud#B'PKfZF*5aokFle>3?n'%-*?9LBJd7!WTVVg/E4-E\a';eT*[K1DQR8n/_fFu')&U):l^l"lS$-/5C!n#^2L(7Ym@?s1
+GIlqHH2VLLl,.kVXq)'8FG$EO]FOm'ZK:!HXY5_!453<lejK.g#Mn@`F`mG2UVe+VQ#<LTiL`ni3;mn#dm2YF#<i!&LJ@CN
+3%FQALS[i#gSoai(Pgl#c;lm4dV>RbI.99LdVLoPNf;<*0<;eA1H]['fH$!5_OX8f386=2B?')D2_j*/\[F%R,<dlM/VPb&
+h][>[1!ij<rY'`sV01lCNO5u2L;g%J<k@o!br_!Ya"5^,%MNR4IAG/3bs@Ck*o4AP]b<?P.C!=:;CDp[Uc;&=s26lqOOcj(
+gYn:Vd!,:hfLf5:`PZZC*C$0&GM)pqR/RTXJ[TBTT<m[ieonJ72UQ<,qi[dPgtPs9g;I-g/@-+c^FY;MH?_u(G]YrNjFph&
+]gpDa@JIdSa3OE"p<k.miE!LqZTSQ-E7]O&bgF,6M'b`HYS=*a4*j^O$+-ipS1tt]SOAq$iN_K`TnbjMV+XQ?FU['@QiAAf
+Tg*./(hjsGjo;Uo[+Wh62@$tWIq,.HksPhqUA[4jW_;;Xl'fLFd*A1&8]r=&08F'gSQ,fJiR^QKmSI4?S^MEdV:)7$4O@ha
+OB4tUF,X@V_sa<NZAI_16Ba[h386.IQqCRQ>$DJV.il)VpBWbfL[KEej%n1mpoW*4*VOt]C,OeAbb;Gr3I\"ea!VtD&'[BM
+^Q7GnNPeJtku&o;["?4`gEDb8K/Q,$Z5hk^V.;*iBdYnLQb7uanI)J^Og]9g/;6];#VXuliV1VlA.q[D+I+U6NWO&fbf3Q7
+(hmhI,VPIHXn:n3beirI(@i(Zq:-YgHPYB(R"huqfs3X;8Snt.b<kd:>t]Tk@:mAkZABn]ORc&</C;`//<_t[g:5&\\moHi
+WqE?1(k1H/+FEokr]AikR72GEd[&00d'BJZRtJH95Bui&*.Ffg?PTfpfGoXZSMAL?EOM06,HWPQg'\sD/+)a@)?koTa5J_"
+be_L&`f136m6mDX])XF#3@nM-++qK"j)Fc6($atbDPHrn3OGVZ)X-EGo?n,[iu<`T[!*'A%'RRdE1<3om3?I@/_nr=ct4rd
+iSeu$3W'BX2Jf*^Q9l6u)<[@MaDR/6M]32EE_*Xe1M=s4%`;("9+SqB,!?BL#L56B/0p#.c)6fDn%#c:MOS9f.?n^11bL$F
+QhYP+/W6uU.rB;DDXf)Igj1B82Q%>Z-9C`KTueB)aUc/JS*4PiqFg[)-7rL5q5q%%0V!$Wc2V<G(29>He67><os%PK(7.@n
+M3]33Rr>#Q!c>t/Tlpu]>RlbL_%+@m[O?piVTYYcdWX&"CZEYTc=VR[W;PH[3W._H,<brOc/EUjFPs6e2NP5e<gl)Y-bn&$
+,)>-ghhM/``Lfcgb<mIj3BCfR5`:+N6\"u=Pa+XcLLiUG2I-ZfkA2V2V=+*jlOGl_:P6Q(ZB]lLnJAj(dSljj*b=DLneZM2
+a<hf8^XM-1Rl,u_iO@:u0Qkr<9;1aaj(7p'/J%jrd;TqOr#BUNl#N_L_1R[<k94^,X:)DD[j+NhDPGGtLVrTE(&f9@G??Lo
+X#Z\24-=]nmsr;pT9.T[R0CXP<Z7;l4?DPIGkuUoR7TK8k3fEs(';aq5Nl20W">:^gdE57a@ohZij7;0KtAcma6*G>f,Z[)
+Rcig)%`<9:D>_:L0%0UeR%C[AZ_TRfG8?'c6@.o.3W/SmS+i6)$[3)M_pV\PQ9soL6\!>NZMN<p3"4+c`iV(%%YYppBmE7F
+mATimb++1F&GL?i.E"r&EAfiT2JE["dE;&=LXSd%-#M'NjL=*PQ,`Q$^iK5,7q/9:l_.0ZTJj7pm\N$FiiK88>bF<-&-&.%
+hbA*4YOT*ZP*c*;2i!C!K1J)h%e:6=(iH1NcUm#,+Y=3TBrSN.*_'dPECet]ENU3=d:'<sm_5@VG[>(VQt;;Y3uiu&AJLNK
+E[\TH6@%=ZluZ:ZdQG#*-FpH\*9u+8CcR/m;d?IU0?d%?_f,73^Z@*Vc(TEoWBmT54LF>Wmp"dYdbnOnCo%Z7C5/M$8]+bu
+%?ZrJ9;tWTI>lD'1sca\iMa!Ve7$utj5IKBG;J-FroVLdq+I$9Q9^?I4Mr8,DV>-7@4QaB5)hE!/pmoP:8tW+=?.l^+[(Ah
+%J4UX.kHB92TbrOeB&(jWmTu8D06Q<QaHTQMq&+Oq+'E-OM2,&6U&qGGt=a/7]g;]3qFkq''KkjHgK^in7[8?_J8Vs'UHM!
+r>[<@+gdr=L#:9mn$@gEfj.M3fT&$U6_q]M4'G20=S$a$33*4b59h".h9<sJp;ZB\h'oVWG>hWB''g&7D=T&IUc[]k,k&(\
+.QgaY$/\>OOI_Vj^#EHK%th5SD.YBT7sUcQR4f'D.L/&k%%]\_lVd,T_CY7q$@Ks&hAih.It-G(ZCSA841p1j2Jh2jLc_l[
+caZN89?X:DfXb8jB"9]6kauiBNB":Xl\:4'Di<asZ5.o*d)HNdg)Y(&\/],L_\5\i8:U-6jP6t?dX#[";'-s((5d_Kq?%XL
+4DDaJCg7=h+.qkfA(n[LZr?tP[%Z`V8q6`M>^,+,H;-^qhN:b"8YjJ-_mK)5XD+6t'WH6!U9dnIg.J<6&?P?Cq,9fSn>$Z#
+M<:7Z]s1E52l$qVmA5M`:CULo%e[aQ482hAcA#s_%piE]C3s^_Xr=Y'=Y('^%!S!6GB,'ji1&cA"#Rd[@&oup47HPNTkfiI
+o1Mk<GL/lr-\o*rk,9l9q)`S92L":Yp'QB=BKf^jT:*&EPeP2pclDoV#Q=H?$!OVQikZf&%f.gULq(sj#HF"Z^S@=f=?BTq
+:>1q9Jh>i\B,7&CT`7kPn+fHq]V>V@lG2i;\-VpPHdWleoC&s9s-^W3BKKqucIU@^P,90\[6%V/_/d&'@ogEC)X2U0T=p"a
+4T>!QK!Z;.Kj&,+3m-9.a2_>)<f7'hG4.S@I#eL.BL14hFg)Q4Em^=Cs3<s93Lp&-dSumIVf2jBPVbIS#?_O(+ua>_.3XgS
+:;b8?LBD6<eEVI!S^m>Tj%4AbTM'=6DMS]E9;-BL%\&?!#!I[tYY5_!FU(!N=?ou11.I_&L0$OEoIm`_4>CP;I;%,rf\F.s
+B!jN2B;M9O$RS!Ib>,'AOHge+(8.0/N,Oa>KQd::fr74EX!-j?mVI+ndWfA<rque.dQBC*/]6^hrgh,Hilmt6T:I8hB<1G/
+G;&p&\/%,\Ft@LqC]gfAL<9^]T&=V>g]d%$]Fa>)G5dX?./inO.n^5t12;a+RH;_)#L+k^`\'s4h?8CA-e2Kf2UU68WkN'A
+*_q&qB7E/k$+)RsDupPnN]%\4G%Tt@Q1^KH%`!B]00H%:9?SGpUpe6CmjBe.Sa!PdfVO4<N=K4,<*sp$SL'_q<0s,-eEZZG
+7VGG/)7AEeguG:<Xe&)tcReGs"Hh!P00OT`XU!EE[60CL9=:EN`THS3@2>EUF\Z(Z^e38.G4&mTIMN&Ia@A<b[.0)_cNS0Y
+QJ?!8d%mK%##@BBllo5ao[_jq.r$_Zi)RrA4s<u-<Yn/HmidFS;=i@j\*ikfXtfNf<q[Kf6AUtAHAL/mlaTbqZ%)LK%(,1A
+iFK.aUq2::<B5SqrcPU0ha^>1-.'N;iu?c&g;s)Mhk904?cB1'e'^*-Fpfrs.pO]l84u:O>3iHdUYP7o6tRaj]JD-Q.#tQ`
+Xql1LRoT)Crbj2t0/fE.nLNnpM@A2kdWQjdrj"PkYSo"ITgbDU%u4E\&?k(b/pV+W/YP)Af'XY7bFR>*$?=*@f\=]SBVPab
+GZNW:?I5=EMM%KmUb.=NYX<*,Ut)g"ZUdT)bfi4P<Hk^C&$HN<QsQ^sOoC>`rG\?s=``5mo5C)'`m!`D+5%CqR55O6?JDTc
+j'l<E_;*7odB!$M;]*gR3b@NS9$<b#k-0C8[X,)u>RopJ^e!MYi<m^"i<Db!a<c?sl+\Uo(=\Z&l@!3eo[94\o94rRa]2(T
+:R2cZCV)m*(X1hjR.+DC]]Z0=<o#K!C#P2[5`="eC8c:\/r-sS_aoQb92*[b?X@ffNF$Gs.7eq^Ug``.f*=f?XYjns2g<H[
+WlceI<uY\b!R;d>o2Bs\jL4Y;jnj,I'A%qHTQ+m/j&PV;rpmBRo$A_GSr0o)g!C^:BWaFG`%F.TO^9(H].#6@b2^>RH=^9#
+V04>jeH\mp>P$Leq,^F]B3&c"3@i]]+7-[]!K&*TCK#'1EXXe<FO6)E-^Y^DV;7i3G"O>M8:<BdctZ.%:Uuc,7bSfb9UiVg
+&2.hTff+;B8q0,#*ku1WJY=u"/(QInmAA2TbV[Vhq%ohcM"Al"]UJ2Dd_[$(GVrWB%((%,XRC-D4U('68a@EBFgcs8h=384
+j<;2lD0U/#H;8J5WQ(7)rPLQAn#Om/&nruJN1.*8YU/n/TM1c]3"tIN<Tj7C2i%:6[PXR*/'^^^M@QOcP@YO\ACn]p[Onk'
+U`E:t+!;*$$sHdC%?[6kOBaG]rMFFW,o&:3X^1lMj/V`!^\F$([6RHf'l9YSG/M'Caum!Gk>-TtM<[2edbiU/<)ZYW[r'T?
+Eg>+-o*g1Nf0ZC^&nu,r_n?N)`jLn`k"8gfBGk-qe'5ch-k%bESU[T<p3^*=!0tR;a2agVU8CXZW"%=j[VjabJhgoWG%UFF
+aiCpKT[!YqD<G]8%cu_^W5F474l#PlS*EG_F;:oEb?%&HBiAfh4gcXm&$uICkmf#fjC6<kd>;R!$]c:2CMkNJpDuJCqq_!d
+8Q8#nTOui6[XA'W6.RhBEQ2SZrHI.Jo&q-7DJu[>I\^pq>%2S5]f\%X[!3<K1MF*cs4O$eXnC?;3uOS`Ta`<M?7qL2g>+h5
+1bpsLA,!^clM:l:%4gGU-dP$rl@Xh[ULr(>[aA=X]RihB2.dWeT7$jfc^m7PFV()se5r")gRXHH)]9RPmB-XsCC[&4XeC#S
+P>jU];eKlZ[6*m+P3S=dI=kS'M;+9*VtfH^7JcG)a3UugePHooSMeCK\G9RBrDoht0k6`YStA/pE*%$CEO9sdk,,XG.t`6"
+l`/FW6CM/&9EHf4SfTch"No3aJMr-]\q=6>Q#&QjMs%[idk>rG<;`&`h#1eP\psLpXZI&dW*-(leBF@q/):!sX^]M=ouo8<
+:sT[?gq#5q:RoW%k@SRfO'3:bkIJMG[WZ3)+hQ%!'Nu=;kEiVrecK[ibq4_3$G^T)`U[->4FCF$b'"ubgt("71c@(6+6iqp
+%8G*Gag+I=))eZM)9%se;e>0)L&'a>1!WQ9hOg;T)sZa(CF7?];\IZ8040IQJ_*C=JQA+(F(f9`Fja3b(*9M?V]jE'G@q-)
+,)tpIJjg_E!ML+QM5f8$5e?B2ld]d'UZ5Gu(i&CJQ!1C=fSnQEoYu@lPW@le5/9-fD2aMc?G"p;^(-\)[\kHA7t_*AGV!$k
+>ehB_D$p5A!EpRZ^%>:&`<Y\!NQn.^F!WD+)V.7lf>UC2"'7n1J9:5YUXcbHQTKKtYWhJ>KVmn1H#(>Fg5<@WkY8f8aIG$+
+%.3u^51[_=:WMRog?PGpkL@G;a;'9?9,G4Oi(D&qR]gB*g<^iUdLNDP&$g.4LXnojc*uiZ?b"&'2i($AQWBYk][Yfo2ag"2
+kQsb=Z"DR;NS9&TGmj3_7L[:e9U.?V*:o@a,gJc*h<gOIcW$/F1ZolfcQrt^c[h?X%(%=fF(nioir]_8[a;*;kRJ-td^U?-
+9uDQRUf4R>M@N^XDJ3qTm"J839\r^H5@h%=>V"I*9t1r.hl+8R(l]9k^\sCNq*Tl3hW+gX\[SoQ\`%YLiM)jD']KN/+Vlo;
+KXcf7HTSJmm%A3ks3)0]G$"(Abad?i-pVS(5pD<MJMliWmY0*:$!T0/(E>P\U9<bOQ0uB&Odig.p"SrLpHDL(>Vg3C-JZOD
+2nu6.@&tKG1,?WEhRd])k$'c7#5c!8>]-Q'EU7)Lm`[6hdHKrYmY1n)`PD_H2MV:7XG5<SB%1oRJD$;N9*-\3PO;h@-KQst
+%P3E03du.icFs*JX(op<[s%E9%ujJ%=;G&@1"Rm5iC7`He<\C`#dK8G=_;)s-'0mC%e]R<Zo4PYW@H`=GA"qXGifDBiLF&H
+3*;i]k0Tbq+t](g_6t9MBiJ_/ckau#G<hsD4f$LY<&ui[C.!$qp,tj"b"pNY]@b\+W$`q\_QjHP7dCRuYaICg;fH?oF9sW6
+;e$a-%uBe_-a3a1SX^hHSS]1heXe0R<4$:b>4REHLf!C'6Cl4j8-;SU_\-,hBjR6K:OU//coI$/+[R\*9tCEc*je%Arq%ep
+HD#@fB_^<S8L^(>o(SJOSuQ_?e986tIrOJgq!C0;*\cpS+P7sm6lWWB\:3qr5A.ud$rMJ7.6k=dkP"\1Ohq$gX)42ll;(EG
+ma'dUR?Fq+D0T_:3l?^4Xe3n7`IV5'V)`3XbFk\o2FpW/g4WUJQ9t3!TgTgB")AgNTr1&%"%'k*a2DnJ:`#E;XZDHkSNVDQ
+LW=:-0^GVNRqMm_GQ[^g`*=2Nn"6<C`ubn'MYr\f:YZp/^>9*/#3OB77nX14cC<g'<elA3pj,7kUGET@.h3lP>'$&s)l/JC
+Nj0%SF5UkbAs$]k+YUN>WR%m.'bO:SlAQao70h"rT<:D&Z*g@-(Lg+@mmCFqCsYXhn-3huXpog]55tWrK/#fDo\_o5L+r@F
+FgPI;=+C'kftjE<*>oFOW/)2)bC#U.iLSXoW!:rU4WWc?gL<es@:3]mG0kW48PKl_GmbB?p@.b`>eXrqoS2GVD*.@_*A"6P
+<S,lN\\5?Hg&P<;hjQt"LSt[;kRHGm:?DYS,m0cd(PRDWN?9A8jK3E$*k9eWfm^KBZ0kRkfti)^41D%5Dhq`5C3cJE\&[K^
+YR[B`.;1H_%\OPN>A>ogKZRoRB'O1>X[ZKUT"f4Ve-CXfHu2Q)nlDD9.OhJZ;,_u4646uk?QUKE[jUX=2K1m0K&Ft*SBO(]
+^[N*@Ie">3dJ3.jD1Xll]cWMD/tAuG3DiXW;?Y3JPN-0(L-qK)2ARm7Dfhk-2M\`'7VXGk]A]>QAJUg35]b:eGL6$PA\'"Y
+oUE1!cZO5]qLDCtXGhsm9h8%(gp*bbs5C8`P@kfZ?+A\@EOCR0O5@B,5&kpio$6'<!"S!!+5o?%+WnO5*WY]C]6>SLDbl>L
+]J3$?H`hP!?+t9\iQTEDZGZPIp?]jo9hpM(MHC_tEJE1dFdY=<esjVR<TZsWXY^7n/Oinsbu6.L;]kNYbaf3i6DR1u.+5?o
+!,3kHKo=bMIJa26LIJ;(NSg+d^3t33d=EO_W_V-p2kIe:!nc>BI08)VL.=_Rd/2CrgIMfqQO\HM]XMh86K,2sOl<#""+@l=
+JD>28Ht.TLaf8i@%M\$lhO^=E0g9bt7+h&qIihI1W"#(Ri!fJl`L.Eq(ha5_6g:RZlQ<2lZ&,e9Zr.s81oV!e\&BCp8A-cf
+9lsY"k,k')3I?Yo*%n:j5'7(603i7/n$q*%e(`J=E.&;57n-"h`brTI`5)u(`^WHg!-n#05_!-Z:Y4-Wp=;kQ!;Xj<lADmb
+#E&6;A7of9S/<'U-=S8VH[./cF!\613@i'W"`5P;UNVH1Ga.ot$8Z`]"Iau*,>H=5p@O<qB4?9#l6V*EAAtS!;6fX_BY?L:
+TXa&R=iKop273mQ:!FJ-\$fT,ke,X"h:$`<>$kWdJ,]Khpo(Cbg9oe/m]NU]*EUru04/O5C2BiN3I/93lps]f61/Vi:5Y*l
+>.nZ>#[q%+R'AP]^-72CZVhcHTQt3RU_RU(>&I'S))*';Zbb;pbt"4h-:NofL8H<ISj%T(_95o7Y?;[R+_akiHIe,4Gm4'T
+*%D-Z';oS[ld%IIS\K.6dcHeGf!b;Gp++;$a).r\/XJ+r]PtTanSEVjc)D@a>^GVL^4O#R40m:52^N<s?+2/.jmq=059E\<
+%.-aJN:e__F+KWB9;S1V3um\!1hOSW!h(VMV*.Y$#-Ndioj[Zl?G?Di_4`Bs=%C6J-#DA,R_CA#f:KX,UAZBn9?YI.X/\sc
+3aGZg='+9up2"5Kj#J+Sn(G#VolYDb25a6@W33-O0.T1jZG3=\DpPTQD<\$h2^ZJ^7'-r+)&aLYn*@C2IBgp'X5FEKquc5c
+'o+ZR6(4_NMa*glpg4;:@+IF*Tin0_H#V38d&*\ioB%].\-QR2mHY:n?Ekth%:I4(-#Z@LceQ6E=&*(N5uI0'P!b"c*%a6q
+XLt:%ZEf?_AS";!q6=F@7unWR<-"YAW$";XB@i12RH^\TP*=l+Gtl5W'p*!V?Z-5AU4j!;c_J^kSR2u!YrK,Qcp:=#9rQUI
+P?#Zm8F;7VbXQ4d=t:+-NI)0ne<G:)4H)."0D4o+>8@Ls@1fQlY)?F)T=AmiQIN;6bcL.O]6<B(akN;W?Vjj(<4%\rHrO40
+T>*=':X8B640l1Je'h4(Ctb6n^HQ8cg=6dDJ/l)Ccc9fM-tAX<RjkZVB=?]jc<?kuBW8@l>&I'S3A;?=3E9\-=U(ur=t^>Y
+k,E!%XBcUO/mPd9*J+aQ!C7m&/&T4Kf)U#2gkLL#NQI[!Unhm&9@(]#bhTWYMpAbJR@+p1l"O@#;mpL;hO'\7+YFOdf0k@K
+XUGXF$34UmZMWWM$XFRY@$kTsbd<s1B/S%VBY?5uD.2gRr_aRrZeei9(*fqQPPS,PK<rR&07[F4p/3P^?U+R@^u1=$'e<@>
+7f[e`]',O6ol4sjio:[b&eaHE8+H*gio8P0`^I"g!oSn(<@_.(L'._cq"sl56]qK'c#j'3ZDt"5#,r'W=Vk`d=s>Pr#41T;
+s.sV_kLVFeB/S%^BUptoC78mr[:VRg?n\>0SmL8;^Ac:W!eZ(lQA5Ne=P0YCn;)mV8=\5kJ)ObniN'i4J2_Rq88qC5^bUCH
++)`f.C:oWNcde77bV[S?Sb:8tBJ%Y+g.8?Pf#A2dN9"tciC<WX7V;bU+O*iK!o^40[]5>B9>I$IqtU$`q#bq.5[[u-O>cS]
+ptRWSIm6/)*s)kf99<75VT>8_.h.NlkU]'DV)`:3m&:KpS=6b)9V'_ri1O(a&o+#,`0sdqLJVfaNSNG$nTJ+>i_/(_4ZlO]
+`_.9K-eN`i\@XBphaMDo@Lu"<Ak\>\0o.Rm1WN2KX?#n!>'DZ7"1;P8'aA5:Bf9>GNV5dTAtu[4Xd:B.-IeKlMTrL72gQ_D
+4;T8M!9au8#eE"j.C]P!#@<aB#`QWRQl2sGS2+MRi[d-Kcr+S<>-o'bNg>XrOkeEdapKrnX?l0J<GI\3&o1sY@DA[Y'5n#G
+7EE:be`S-h0][;"j(uRoMZBNV6MqaW9U&,9Pr(:/]e]mF8upIS[0?8'kGuII9cK4_G8?lLRY=qAVUc_Fd8mcn)o+`Za9ao+
+j3/-kIe$3bMnIsU^`]]i'4VN?.Vm6ZcGWij/P$h[7;U+0?2(N@LANa+ZGOhUp!A;t6HuTWClKCI!?B(@*6fooR@2bWT;$Os
+6$^9_JO*Ba(6P#j_CR_eTbV:,R^^jVbJp6W3aWOjrMh?RkY.[mdY+'u<j5Gjj$mr2:<aBAb\OL]DL@`6&mlj,&YlU_/1;0D
+]eb;l95E%/295+"h/pACQl!80^B]HqETWso[#USW'5U[<E2,?,VrgZYPrF_L42!_(.!_,F'k5^\+;8<L1NaJ,'krYrZSlJi
+Ar<nZ]HGGM\P^'ceX8]ZBqCbs;f#3uE&2G_cHJ.ib>I`O*rC@#Qk=DZ'U^EYbfj4D<i%fk&_dW$ds8bh?PhiDg?>)MdY]p"
+B%iJR!GCCA\j10lr*@jn^Vg.'`6=SlIn0=C6t_ppBW]l5,GgS&?UB''@D8n:Dt*?mD:EK,OZ$=Bg8_V3Y+b1FX[[Pgp-e1e
+X'\U"qDr35=b@Kgp"0Ie)8FWT4>iUHki\H5I#FI1[J@6hlAqukoAk4Ba.mtcrlMQ$aaG8dGK53^_G=\:=j9c,^G1+-1>gU-
+\&<PhQu<B(*HAeDT>.ZNPK2pZ?2W.1\#&tn%6p'S8%7WC,F[E@Hjnm?Rr92-7EKp]2W+=X8,>)Rhi-WC2Z*%2=Is<P^8QK+
+h_-poT9(-DbO^bM(Ua7.m=&GSVT(HPZ2QZK`X^r8(qX_.HG348ru&lKrrLV!k[=~>
+U
+PSL_cliprestore
+25 W
+8 W
+N 0 0 M 0 -83 D S
+N 0 3900 M 0 83 D S
+N 1300 0 M 0 -83 D S
+N 1300 3900 M 0 83 D S
+N 2600 0 M 0 -83 D S
+N 2600 3900 M 0 83 D S
+N 3900 0 M 0 -83 D S
+N 3900 3900 M 0 83 D S
+N 5200 0 M 0 -83 D S
+N 5200 3900 M 0 83 D S
+N 6500 0 M 0 -83 D S
+N 6500 3900 M 0 83 D S
+N 7800 0 M 0 -83 D S
+N 7800 3900 M 0 83 D S
+N 7800 650 M 83 0 D S
+N 0 650 M -83 0 D S
+N 7800 650 M 83 0 D S
+N 0 650 M -83 0 D S
+N 7800 1950 M 83 0 D S
+N 0 1950 M -83 0 D S
+N 7800 1950 M 83 0 D S
+N 0 1950 M -83 0 D S
+N 7800 3250 M 83 0 D S
+N 0 3250 M -83 0 D S
+N 7800 3250 M 83 0 D S
+N 0 3250 M -83 0 D S
+83 W
+N -42 0 M 0 325 D S
+N 7842 0 M 0 325 D S
+1 A
+N -42 325 M 0 325 D S
+N 7842 325 M 0 325 D S
+0 A
+N -42 650 M 0 325 D S
+N 7842 650 M 0 325 D S
+1 A
+N -42 975 M 0 325 D S
+N 7842 975 M 0 325 D S
+0 A
+N -42 1300 M 0 325 D S
+N 7842 1300 M 0 325 D S
+1 A
+N -42 1625 M 0 325 D S
+N 7842 1625 M 0 325 D S
+0 A
+N -42 1950 M 0 325 D S
+N 7842 1950 M 0 325 D S
+1 A
+N -42 2275 M 0 325 D S
+N 7842 2275 M 0 325 D S
+0 A
+N -42 2600 M 0 325 D S
+N 7842 2600 M 0 325 D S
+1 A
+N -42 2925 M 0 325 D S
+N 7842 2925 M 0 325 D S
+0 A
+N -42 3250 M 0 325 D S
+N 7842 3250 M 0 325 D S
+1 A
+N -42 3575 M 0 325 D S
+N 7842 3575 M 0 325 D S
+0 A
+N 0 -42 M 325 0 D S
+N 0 3942 M 325 0 D S
+1 A
+N 325 -42 M 325 0 D S
+N 325 3942 M 325 0 D S
+0 A
+N 650 -42 M 325 0 D S
+N 650 3942 M 325 0 D S
+1 A
+N 975 -42 M 325 0 D S
+N 975 3942 M 325 0 D S
+0 A
+N 1300 -42 M 325 0 D S
+N 1300 3942 M 325 0 D S
+1 A
+N 1625 -42 M 325 0 D S
+N 1625 3942 M 325 0 D S
+0 A
+N 1950 -42 M 325 0 D S
+N 1950 3942 M 325 0 D S
+1 A
+N 2275 -42 M 325 0 D S
+N 2275 3942 M 325 0 D S
+0 A
+N 2600 -42 M 325 0 D S
+N 2600 3942 M 325 0 D S
+1 A
+N 2925 -42 M 325 0 D S
+N 2925 3942 M 325 0 D S
+0 A
+N 3250 -42 M 325 0 D S
+N 3250 3942 M 325 0 D S
+1 A
+N 3575 -42 M 325 0 D S
+N 3575 3942 M 325 0 D S
+0 A
+N 3900 -42 M 325 0 D S
+N 3900 3942 M 325 0 D S
+1 A
+N 4225 -42 M 325 0 D S
+N 4225 3942 M 325 0 D S
+0 A
+N 4550 -42 M 325 0 D S
+N 4550 3942 M 325 0 D S
+1 A
+N 4875 -42 M 325 0 D S
+N 4875 3942 M 325 0 D S
+0 A
+N 5200 -42 M 325 0 D S
+N 5200 3942 M 325 0 D S
+1 A
+N 5525 -42 M 325 0 D S
+N 5525 3942 M 325 0 D S
+0 A
+N 5850 -42 M 325 0 D S
+N 5850 3942 M 325 0 D S
+1 A
+N 6175 -42 M 325 0 D S
+N 6175 3942 M 325 0 D S
+0 A
+N 6500 -42 M 325 0 D S
+N 6500 3942 M 325 0 D S
+1 A
+N 6825 -42 M 325 0 D S
+N 6825 3942 M 325 0 D S
+0 A
+N 7150 -42 M 325 0 D S
+N 7150 3942 M 325 0 D S
+1 A
+N 7475 -42 M 325 0 D S
+N 7475 3942 M 325 0 D S
+0 A
+8 W
+N -83 0 M 7966 0 D S
+N -83 -83 M 7966 0 D S
+N 7800 -83 M 0 4066 D S
+N 7883 -83 M 0 4066 D S
+N 7883 3900 M -7966 0 D S
+N 7883 3983 M -7966 0 D S
+N 0 3983 M 0 -4066 D S
+N -83 3983 M 0 -4066 D S
+/PSL_H_y 400 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(100°) sh add def
+3900 3900 PSL_H_y add M
+400 F0
+(Transition = 5) bc Z
+0 -167 M 200 F0
+(-180°) tc Z
+0 4067 M (-180°) bc Z
+1300 -167 M (-120°) tc Z
+1300 4067 M (-120°) bc Z
+2600 -167 M (-60°) tc Z
+2600 4067 M (-60°) bc Z
+3900 -167 M (0°) tc Z
+3900 4067 M (0°) bc Z
+5200 -167 M (60°) tc Z
+5200 4067 M (60°) bc Z
+6500 -167 M (120°) tc Z
+6500 4067 M (120°) bc Z
+7800 -167 M (180°) tc Z
+7800 4067 M (180°) bc Z
+-167 650 M (-60°) mr Z
+7967 650 M (-60°) ml Z
+-167 1950 M (0°) mr Z
+7967 1950 M (0°) ml Z
+-167 3250 M (60°) mr Z
+7967 3250 M (60°) ml Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -Rd -JQ6.5i -O -Sc0.25c -Sk@sunglasses/1.5c
+%@PROJ: eqc -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.356 20015109.356 -10007554.678 10007554.678 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7800 0 D
+0 3900 D
+-7800 0 D
+P
+PSL_clip N
+4 W
+V
+O1
+/Sk_sunglasses {
+PSL_eps_begin
+0.25399961 dup scale
+1200 72 div dup scale
+%%BeginDocument: sunglasses.eps
+-10.711 -12.201 translate
+% Recalculate translation and scale to obtain a resized image
+5.80456 6.61202 translate
+gsave 0.458074 0.458074 scale
+newpath
+278.68 633.29 moveto
+275.12 630.04 275.65 624.62 273.44 620.58 curveto
+268.94 611.85 261.56 604.76 253.07 599.91 curveto
+242.69 593.40 232.11 587.13 222.58 579.39 curveto
+219.58 576.72 217.04 573.59 214.38 570.60 curveto
+208.70 564.47 206.00 556.35 203.46 548.58 curveto
+199.26 534.65 200.12 519.56 205.11 505.96 curveto
+200.44 508.17 196.08 510.96 191.74 513.74 curveto
+186.53 517.18 183.14 522.55 179.37 527.39 curveto
+172.86 536.98 171.19 548.68 169.65 559.90 curveto
+168.17 570.30 164.70 581.42 156.01 588.05 curveto
+151.59 591.25 146.70 595.24 140.84 593.93 curveto
+140.20 588.39 142.27 582.94 141.41 577.41 curveto
+140.30 569.57 136.32 562.51 132.01 556.01 curveto
+126.09 548.00 119.86 540.21 113.79 532.31 curveto
+105.00 519.64 100.87 503.41 104.24 488.22 curveto
+107.90 475.49 113.44 463.11 121.70 452.68 curveto
+126.98 445.86 134.63 441.52 140.81 435.63 curveto
+123.82 428.66 103.16 431.38 88.59 442.58 curveto
+82.15 447.43 75.90 452.52 69.81 457.80 curveto
+65.51 461.65 59.92 463.46 54.72 465.74 curveto
+46.01 469.49 35.93 469.97 26.90 467.16 curveto
+23.92 466.41 23.04 462.23 25.19 460.16 curveto
+29.78 454.52 35.03 448.81 36.52 441.44 curveto
+39.39 428.75 36.15 415.79 36.86 402.98 curveto
+37.96 390.64 39.86 378.17 44.87 366.75 curveto
+48.95 358.08 55.55 350.95 62.24 344.23 curveto
+66.86 339.49 72.92 336.68 78.74 333.76 curveto
+84.71 330.86 91.30 329.71 97.57 327.65 curveto
+87.78 316.13 79.68 303.21 73.50 289.40 curveto
+68.69 280.50 65.12 270.93 59.49 262.50 curveto
+55.36 257.02 50.30 252.27 44.85 248.13 curveto
+38.09 243.71 29.98 239.67 21.69 241.79 curveto
+18.55 242.92 15.35 243.99 11.96 243.84 curveto
+10.72 236.72 15.05 230.42 18.83 224.82 curveto
+32.74 205.07 55.70 193.25 79.08 189.01 curveto
+92.39 187.41 105.48 193.16 115.82 201.17 curveto
+122.12 205.22 126.73 211.26 132.72 215.70 curveto
+131.13 209.06 128.00 202.80 127.49 195.91 curveto
+126.85 186.65 126.80 177.36 126.53 168.09 curveto
+125.62 163.61 124.23 159.23 123.50 154.69 curveto
+120.50 143.35 110.61 135.54 100.61 130.37 curveto
+95.77 127.55 90.12 126.97 84.70 126.13 curveto
+82.08 126.11 80.90 122.49 82.75 120.78 curveto
+94.06 106.48 109.61 95.54 126.96 89.87 curveto
+137.42 86.67 148.57 87.30 159.30 88.49 curveto
+167.95 90.10 176.07 94.51 182.31 100.69 curveto
+193.63 111.77 200.67 126.18 207.88 140.06 curveto
+210.07 143.89 211.66 148.32 215.38 150.99 curveto
+214.84 146.20 212.94 141.71 212.21 136.96 curveto
+211.88 132.35 212.04 127.69 212.28 123.07 curveto
+213.71 109.66 220.48 97.33 229.32 87.36 curveto
+239.06 77.10 249.62 67.63 258.93 56.97 curveto
+265.06 48.29 271.35 37.92 269.14 26.84 curveto
+268.59 22.18 263.13 18.59 265.64 13.63 curveto
+284.57 12.21 303.19 22.77 313.72 38.25 curveto
+317.75 44.44 321.88 51.01 322.60 58.53 curveto
+323.59 67.19 323.86 76.01 322.83 84.68 curveto
+321.03 92.76 318.19 100.57 315.72 108.46 curveto
+314.53 114.21 315.09 120.22 316.22 125.94 curveto
+317.92 125.31 318.16 123.33 318.89 121.89 curveto
+321.26 115.31 325.37 109.19 331.26 105.29 curveto
+337.66 101.13 344.30 97.26 351.45 94.51 curveto
+369.29 86.88 387.17 76.51 397.43 59.42 curveto
+400.60 52.97 401.32 45.69 402.46 38.68 curveto
+402.76 37.38 402.74 35.83 403.74 34.80 curveto
+405.65 33.97 407.87 34.22 409.58 35.40 curveto
+414.23 38.37 419.40 40.68 423.23 44.76 curveto
+429.04 50.65 434.63 56.83 439.30 63.68 curveto
+444.57 72.31 446.47 82.45 447.70 92.35 curveto
+448.15 103.87 445.79 115.42 440.93 125.87 curveto
+438.21 134.04 431.86 140.05 426.58 146.57 curveto
+422.33 151.76 417.48 156.83 415.52 163.42 curveto
+430.67 158.52 446.87 154.84 459.48 144.52 curveto
+465.85 140.30 469.30 133.29 472.75 126.73 curveto
+477.06 118.78 477.60 109.47 481.29 101.28 curveto
+483.79 96.34 486.12 91.10 490.20 87.20 curveto
+492.05 85.30 495.29 84.71 497.44 86.50 curveto
+498.63 89.40 499.44 92.43 500.69 95.31 curveto
+503.00 101.23 507.31 106.03 510.52 111.44 curveto
+517.29 122.71 522.91 134.75 526.53 147.41 curveto
+528.08 154.16 528.06 161.19 527.93 168.08 curveto
+526.06 182.37 518.05 195.02 508.54 205.53 curveto
+499.25 215.52 488.86 224.82 476.50 230.83 curveto
+476.62 231.20 476.86 231.94 476.98 232.31 curveto
+481.41 232.37 485.76 231.42 489.92 229.94 curveto
+503.39 224.82 513.93 214.57 526.11 207.21 curveto
+541.44 199.52 559.20 195.28 576.27 198.64 curveto
+588.86 201.88 600.75 208.77 608.80 219.12 curveto
+612.01 224.10 614.48 229.51 617.15 234.79 curveto
+618.22 236.58 617.89 238.93 616.25 240.26 curveto
+611.93 243.99 605.90 244.34 600.96 246.87 curveto
+595.43 249.86 589.91 252.99 585.24 257.24 curveto
+572.08 268.24 562.92 282.92 551.76 295.76 curveto
+546.20 302.87 538.34 307.57 531.89 313.77 curveto
+537.58 314.96 543.34 315.75 549.01 317.01 curveto
+563.12 320.22 576.29 326.71 588.19 334.83 curveto
+594.64 339.26 600.45 344.65 605.11 350.95 curveto
+609.37 356.72 614.21 362.14 617.44 368.60 curveto
+621.43 375.60 623.66 383.40 626.05 391.05 curveto
+629.27 407.51 629.52 425.00 623.78 440.96 curveto
+622.94 443.82 620.15 444.94 617.40 444.96 curveto
+614.48 439.78 612.26 434.17 608.65 429.40 curveto
+605.10 424.99 599.78 422.63 594.78 420.27 curveto
+590.69 418.64 586.50 416.90 582.03 416.81 curveto
+574.13 416.55 566.14 416.62 558.40 418.39 curveto
+547.10 420.76 536.35 425.19 525.01 427.36 curveto
+518.37 428.20 511.64 428.43 504.95 428.06 curveto
+498.88 427.81 493.44 424.87 487.70 423.27 curveto
+495.95 443.01 514.36 455.35 528.71 470.31 curveto
+537.58 480.47 543.39 493.39 544.55 506.88 curveto
+545.27 514.80 546.03 523.00 543.79 530.76 curveto
+542.33 537.53 539.05 543.70 535.65 549.67 curveto
+530.25 558.91 523.09 567.52 513.52 572.62 curveto
+511.14 573.90 509.33 576.03 506.91 577.23 curveto
+505.04 577.62 502.47 576.87 502.30 574.64 curveto
+501.71 570.18 503.19 565.70 502.43 561.24 curveto
+501.05 553.11 497.07 545.53 491.53 539.46 curveto
+482.15 528.94 468.07 524.49 454.73 521.45 curveto
+439.66 518.75 424.30 516.29 410.36 509.62 curveto
+405.19 507.29 400.62 503.92 395.80 500.98 curveto
+396.95 512.20 403.69 521.83 411.14 529.89 curveto
+419.07 538.89 429.68 545.79 435.25 556.69 curveto
+442.00 573.77 441.46 594.46 430.87 609.88 curveto
+423.06 619.72 411.73 625.84 400.13 630.11 curveto
+397.86 630.88 395.00 631.57 393.02 629.74 curveto
+392.93 626.12 395.68 622.89 394.69 619.22 curveto
+393.30 611.93 388.09 605.94 382.01 601.98 curveto
+366.77 591.61 348.26 587.81 332.45 578.53 curveto
+324.99 573.47 318.50 567.02 313.33 559.64 curveto
+305.40 548.27 300.97 534.83 298.87 521.22 curveto
+294.14 525.91 291.59 532.23 289.47 538.41 curveto
+287.31 544.58 287.21 551.28 288.33 557.66 curveto
+290.94 570.70 298.47 581.99 302.32 594.60 curveto
+304.32 601.09 303.97 607.98 303.75 614.67 curveto
+303.39 622.27 299.05 629.78 292.08 633.07 curveto
+287.80 634.26 282.89 634.89 278.68 633.29 curveto
+closepath
+1.000 1.000 1.000 setrgbcolor
+fill
+newpath
+278.68 633.29 moveto
+282.89 634.89 287.80 634.26 292.08 633.07 curveto
+299.05 629.78 303.39 622.27 303.75 614.67 curveto
+303.97 607.98 304.32 601.09 302.32 594.60 curveto
+298.47 581.99 290.94 570.70 288.33 557.66 curveto
+287.21 551.28 287.31 544.58 289.47 538.41 curveto
+291.59 532.23 294.14 525.91 298.87 521.22 curveto
+300.97 534.83 305.40 548.27 313.33 559.64 curveto
+318.50 567.02 324.99 573.47 332.45 578.53 curveto
+348.26 587.81 366.77 591.61 382.01 601.98 curveto
+388.09 605.94 393.30 611.93 394.69 619.22 curveto
+395.68 622.89 392.93 626.12 393.02 629.74 curveto
+395.00 631.57 397.86 630.88 400.13 630.11 curveto
+411.73 625.84 423.06 619.72 430.87 609.88 curveto
+441.46 594.46 442.00 573.77 435.25 556.69 curveto
+429.68 545.79 419.07 538.89 411.14 529.89 curveto
+403.69 521.83 396.95 512.20 395.80 500.98 curveto
+400.62 503.92 405.19 507.29 410.36 509.62 curveto
+424.30 516.29 439.66 518.75 454.73 521.45 curveto
+468.07 524.49 482.15 528.94 491.53 539.46 curveto
+497.07 545.53 501.05 553.11 502.43 561.24 curveto
+503.19 565.70 501.71 570.18 502.30 574.64 curveto
+502.47 576.87 505.04 577.62 506.91 577.23 curveto
+509.33 576.03 511.14 573.90 513.52 572.62 curveto
+523.09 567.52 530.25 558.91 535.65 549.67 curveto
+539.05 543.70 542.33 537.53 543.79 530.76 curveto
+546.03 523.00 545.27 514.80 544.55 506.88 curveto
+543.39 493.39 537.58 480.47 528.71 470.31 curveto
+514.36 455.35 495.95 443.01 487.70 423.27 curveto
+493.44 424.87 498.88 427.81 504.95 428.06 curveto
+511.64 428.43 518.37 428.20 525.01 427.36 curveto
+536.35 425.19 547.10 420.76 558.40 418.39 curveto
+566.14 416.62 574.13 416.55 582.03 416.81 curveto
+586.50 416.90 590.69 418.64 594.78 420.27 curveto
+599.78 422.63 605.10 424.99 608.65 429.40 curveto
+612.26 434.17 614.48 439.78 617.40 444.96 curveto
+620.15 444.94 622.94 443.82 623.78 440.96 curveto
+629.52 425.00 629.27 407.51 626.05 391.05 curveto
+623.66 383.40 621.43 375.60 617.44 368.60 curveto
+614.21 362.14 609.37 356.72 605.11 350.95 curveto
+600.45 344.65 594.64 339.26 588.19 334.83 curveto
+576.29 326.71 563.12 320.22 549.01 317.01 curveto
+543.34 315.75 537.58 314.96 531.89 313.77 curveto
+538.34 307.57 546.20 302.87 551.76 295.76 curveto
+562.92 282.92 572.08 268.24 585.24 257.24 curveto
+589.91 252.99 595.43 249.86 600.96 246.87 curveto
+605.90 244.34 611.93 243.99 616.25 240.26 curveto
+617.89 238.93 618.22 236.58 617.15 234.79 curveto
+614.48 229.51 612.01 224.10 608.80 219.12 curveto
+600.75 208.77 588.86 201.88 576.27 198.64 curveto
+559.20 195.28 541.44 199.52 526.11 207.21 curveto
+513.93 214.57 503.39 224.82 489.92 229.94 curveto
+485.76 231.42 481.41 232.37 476.98 232.31 curveto
+478.21 238.11 480.75 243.47 483.14 248.85 curveto
+489.80 265.47 495.34 282.71 497.43 300.56 curveto
+499.49 322.11 498.32 344.03 493.13 365.08 curveto
+487.91 390.76 476.29 414.84 460.94 435.97 curveto
+452.79 448.22 441.84 458.21 430.78 467.77 curveto
+415.97 481.19 398.47 491.36 380.16 499.20 curveto
+362.52 506.19 343.87 510.33 325.16 513.21 curveto
+315.30 514.42 305.30 514.16 295.40 513.57 curveto
+276.83 511.36 258.22 508.07 240.71 501.29 curveto
+231.08 497.79 222.00 493.00 213.19 487.81 curveto
+206.15 483.61 198.95 479.61 192.57 474.42 curveto
+181.13 465.31 169.79 455.79 160.86 444.12 curveto
+157.37 439.62 153.43 435.46 150.32 430.67 curveto
+140.99 415.64 132.15 400.09 126.76 383.15 curveto
+126.03 380.70 125.74 378.15 125.54 375.61 curveto
+122.68 372.31 119.87 368.76 118.65 364.50 curveto
+116.42 357.02 116.84 349.07 117.68 341.40 curveto
+114.58 309.48 120.18 276.96 132.59 247.46 curveto
+143.27 225.14 157.22 204.27 174.72 186.71 curveto
+182.53 178.37 191.84 171.66 201.20 165.19 curveto
+208.48 160.35 215.82 155.51 223.75 151.78 curveto
+232.26 147.68 241.16 144.50 249.95 141.09 curveto
+265.95 136.53 282.34 132.99 299.01 132.27 curveto
+325.24 130.47 351.46 136.09 376.01 145.02 curveto
+386.65 148.69 396.31 154.53 406.17 159.86 curveto
+411.11 162.60 416.51 164.53 421.10 167.89 curveto
+443.67 184.73 462.41 206.50 476.50 230.83 curveto
+488.86 224.82 499.25 215.52 508.54 205.53 curveto
+518.05 195.02 526.06 182.37 527.93 168.08 curveto
+528.06 161.19 528.08 154.16 526.53 147.41 curveto
+522.91 134.75 517.29 122.71 510.52 111.44 curveto
+507.31 106.03 503.00 101.23 500.69 95.31 curveto
+499.44 92.43 498.63 89.40 497.44 86.50 curveto
+495.29 84.71 492.05 85.30 490.20 87.20 curveto
+486.12 91.10 483.79 96.34 481.29 101.28 curveto
+477.60 109.47 477.06 118.78 472.75 126.73 curveto
+469.30 133.29 465.85 140.30 459.48 144.52 curveto
+446.87 154.84 430.67 158.52 415.52 163.42 curveto
+417.48 156.83 422.33 151.76 426.58 146.57 curveto
+431.86 140.05 438.21 134.04 440.93 125.87 curveto
+445.79 115.42 448.15 103.87 447.70 92.35 curveto
+446.47 82.45 444.57 72.31 439.30 63.68 curveto
+434.63 56.83 429.04 50.65 423.23 44.76 curveto
+419.40 40.68 414.23 38.37 409.58 35.40 curveto
+407.87 34.22 405.65 33.97 403.74 34.80 curveto
+402.74 35.83 402.76 37.38 402.46 38.68 curveto
+401.32 45.69 400.60 52.97 397.43 59.42 curveto
+387.17 76.51 369.29 86.88 351.45 94.51 curveto
+344.30 97.26 337.66 101.13 331.26 105.29 curveto
+325.37 109.19 321.26 115.31 318.89 121.89 curveto
+318.16 123.33 317.92 125.31 316.22 125.94 curveto
+315.09 120.22 314.53 114.21 315.72 108.46 curveto
+318.19 100.57 321.03 92.76 322.83 84.68 curveto
+323.86 76.01 323.59 67.19 322.60 58.53 curveto
+321.88 51.01 317.75 44.44 313.72 38.25 curveto
+303.19 22.77 284.57 12.21 265.64 13.63 curveto
+263.13 18.59 268.59 22.18 269.14 26.84 curveto
+271.35 37.92 265.06 48.29 258.93 56.97 curveto
+249.62 67.63 239.06 77.10 229.32 87.36 curveto
+220.48 97.33 213.71 109.66 212.28 123.07 curveto
+212.04 127.69 211.88 132.35 212.21 136.96 curveto
+212.94 141.71 214.84 146.20 215.38 150.99 curveto
+211.66 148.32 210.07 143.89 207.88 140.06 curveto
+200.67 126.18 193.63 111.77 182.31 100.69 curveto
+176.07 94.51 167.95 90.10 159.30 88.49 curveto
+148.57 87.30 137.42 86.67 126.96 89.87 curveto
+109.61 95.54 94.06 106.48 82.75 120.78 curveto
+80.90 122.49 82.08 126.11 84.70 126.13 curveto
+90.12 126.97 95.77 127.55 100.61 130.37 curveto
+110.61 135.54 120.50 143.35 123.50 154.69 curveto
+124.23 159.23 125.62 163.61 126.53 168.09 curveto
+126.80 177.36 126.85 186.65 127.49 195.91 curveto
+128.00 202.80 131.13 209.06 132.72 215.70 curveto
+126.73 211.26 122.12 205.22 115.82 201.17 curveto
+105.48 193.16 92.39 187.41 79.08 189.01 curveto
+55.70 193.25 32.74 205.07 18.83 224.82 curveto
+15.05 230.42 10.72 236.72 11.96 243.84 curveto
+15.35 243.99 18.55 242.92 21.69 241.79 curveto
+29.98 239.67 38.09 243.71 44.85 248.13 curveto
+50.30 252.27 55.36 257.02 59.49 262.50 curveto
+65.12 270.93 68.69 280.50 73.50 289.40 curveto
+79.68 303.21 87.78 316.13 97.57 327.65 curveto
+91.30 329.71 84.71 330.86 78.74 333.76 curveto
+72.92 336.68 66.86 339.49 62.24 344.23 curveto
+55.55 350.95 48.95 358.08 44.87 366.75 curveto
+39.86 378.17 37.96 390.64 36.86 402.98 curveto
+36.15 415.79 39.39 428.75 36.52 441.44 curveto
+35.03 448.81 29.78 454.52 25.19 460.16 curveto
+23.04 462.23 23.92 466.41 26.90 467.16 curveto
+35.93 469.97 46.01 469.49 54.72 465.74 curveto
+59.92 463.46 65.51 461.65 69.81 457.80 curveto
+75.90 452.52 82.15 447.43 88.59 442.58 curveto
+103.16 431.38 123.82 428.66 140.81 435.63 curveto
+134.63 441.52 126.98 445.86 121.70 452.68 curveto
+113.44 463.11 107.90 475.49 104.24 488.22 curveto
+100.87 503.41 105.00 519.64 113.79 532.31 curveto
+119.86 540.21 126.09 548.00 132.01 556.01 curveto
+136.32 562.51 140.30 569.57 141.41 577.41 curveto
+142.27 582.94 140.20 588.39 140.84 593.93 curveto
+146.70 595.24 151.59 591.25 156.01 588.05 curveto
+164.70 581.42 168.17 570.30 169.65 559.90 curveto
+171.19 548.68 172.86 536.98 179.37 527.39 curveto
+183.14 522.55 186.53 517.18 191.74 513.74 curveto
+196.08 510.96 200.44 508.17 205.11 505.96 curveto
+200.12 519.56 199.26 534.65 203.46 548.58 curveto
+206.00 556.35 208.70 564.47 214.38 570.60 curveto
+217.04 573.59 219.58 576.72 222.58 579.39 curveto
+232.11 587.13 242.69 593.40 253.07 599.91 curveto
+261.56 604.76 268.94 611.85 273.44 620.58 curveto
+275.65 624.62 275.12 630.04 278.68 633.29 curveto
+248.08 211.12 moveto
+251.21 212.54 254.55 213.79 258.04 213.54 curveto
+260.62 213.78 262.25 211.45 264.11 210.06 curveto
+263.73 208.56 263.35 207.06 263.00 205.54 curveto
+268.77 208.91 275.11 212.12 282.03 211.40 curveto
+290.61 210.56 299.17 206.64 305.03 200.25 curveto
+296.36 192.80 284.50 189.18 273.19 191.23 curveto
+262.54 193.95 253.57 201.75 248.08 211.12 curveto
+closepath
+0.973 0.580 0.004 setrgbcolor
+fill
+newpath
+295.40 513.57 moveto
+305.30 514.16 315.30 514.42 325.16 513.21 curveto
+343.87 510.33 362.52 506.19 380.16 499.20 curveto
+398.47 491.36 415.97 481.19 430.78 467.77 curveto
+441.84 458.21 452.79 448.22 460.94 435.97 curveto
+476.29 414.84 487.91 390.76 493.13 365.08 curveto
+498.32 344.03 499.49 322.11 497.43 300.56 curveto
+495.34 282.71 489.80 265.47 483.14 248.85 curveto
+480.75 243.47 478.21 238.11 476.98 232.31 curveto
+476.86 231.94 476.62 231.20 476.50 230.83 curveto
+462.41 206.50 443.67 184.73 421.10 167.89 curveto
+416.51 164.53 411.11 162.60 406.17 159.86 curveto
+396.31 154.53 386.65 148.69 376.01 145.02 curveto
+351.46 136.09 325.24 130.47 299.01 132.27 curveto
+282.34 132.99 265.95 136.53 249.95 141.09 curveto
+241.16 144.50 232.26 147.68 223.75 151.78 curveto
+215.82 155.51 208.48 160.35 201.20 165.19 curveto
+191.84 171.66 182.53 178.37 174.72 186.71 curveto
+157.22 204.27 143.27 225.14 132.59 247.46 curveto
+120.18 276.96 114.58 309.48 117.68 341.40 curveto
+118.93 337.55 119.78 332.85 123.66 330.70 curveto
+126.77 328.53 131.47 327.78 134.45 330.60 curveto
+139.09 334.27 138.75 340.72 139.15 346.04 curveto
+139.40 353.43 141.07 361.88 147.59 366.33 curveto
+152.74 369.54 158.47 371.78 164.36 373.21 curveto
+164.98 359.11 169.57 344.80 179.28 334.30 curveto
+188.51 323.69 201.37 317.25 214.27 312.25 curveto
+222.10 309.03 230.83 308.82 239.12 309.93 curveto
+254.11 312.19 267.70 322.45 273.59 336.46 curveto
+278.41 350.46 278.48 365.62 283.45 379.58 curveto
+285.40 385.04 288.47 390.29 293.06 393.93 curveto
+298.13 397.92 305.46 396.83 310.71 393.78 curveto
+316.16 389.69 319.00 382.76 319.20 376.06 curveto
+319.63 364.93 315.86 354.15 316.19 343.02 curveto
+315.50 330.71 320.36 318.50 328.04 309.03 curveto
+335.42 302.23 343.04 295.37 352.25 291.12 curveto
+357.84 287.93 364.24 286.84 370.40 285.29 curveto
+379.29 282.79 388.76 284.16 397.50 286.64 curveto
+406.33 289.50 414.15 294.85 420.96 301.07 curveto
+426.08 305.72 429.69 311.68 433.73 317.23 curveto
+437.29 322.12 439.13 327.92 441.65 333.35 curveto
+443.59 337.56 444.57 342.10 446.01 346.48 curveto
+450.75 343.13 455.07 339.24 459.35 335.34 curveto
+463.51 331.49 467.07 326.65 468.13 320.97 curveto
+470.03 313.01 464.26 305.10 467.21 297.23 curveto
+467.96 294.61 470.42 292.98 473.04 292.68 curveto
+476.67 291.89 479.38 295.03 481.94 297.07 curveto
+488.71 302.99 490.57 312.41 490.79 321.00 curveto
+491.05 325.01 488.86 328.57 486.77 331.79 curveto
+480.92 340.49 472.44 346.86 464.48 353.50 curveto
+458.34 358.42 452.20 363.45 445.32 367.31 curveto
+439.44 370.68 434.04 374.79 428.19 378.20 curveto
+403.09 392.47 375.94 402.93 348.04 410.22 curveto
+333.24 413.79 318.28 417.31 303.01 417.89 curveto
+291.02 418.69 279.02 419.41 267.01 419.34 curveto
+245.19 418.99 223.39 416.19 202.27 410.69 curveto
+188.41 407.11 175.16 401.57 162.01 395.98 curveto
+149.37 390.19 135.83 385.31 125.54 375.61 curveto
+125.74 378.15 126.03 380.70 126.76 383.15 curveto
+132.15 400.09 140.99 415.64 150.32 430.67 curveto
+153.43 435.46 157.37 439.62 160.86 444.12 curveto
+169.79 455.79 181.13 465.31 192.57 474.42 curveto
+198.95 479.61 206.15 483.61 213.19 487.81 curveto
+222.00 493.00 231.08 497.79 240.71 501.29 curveto
+258.22 508.07 276.83 511.36 295.40 513.57 curveto
+209.44 451.56 moveto
+203.23 444.58 199.95 435.21 200.03 425.90 curveto
+204.76 430.57 208.43 436.50 214.49 439.62 curveto
+219.85 443.08 226.63 442.61 232.62 441.48 curveto
+242.23 439.38 249.79 432.47 259.13 429.73 curveto
+256.88 445.56 241.79 457.98 226.00 458.29 curveto
+219.91 458.35 213.54 456.22 209.44 451.56 curveto
+368.04 443.97 moveto
+361.46 440.70 355.66 436.06 349.07 432.82 curveto
+345.14 430.87 340.83 429.89 336.64 428.69 curveto
+340.28 423.95 346.59 423.72 352.04 423.23 curveto
+360.61 422.36 368.78 425.66 377.15 426.87 curveto
+384.52 428.54 392.59 428.15 399.21 424.20 curveto
+405.14 421.17 408.74 415.34 413.93 411.37 curveto
+415.73 421.71 410.18 431.99 402.18 438.23 curveto
+396.62 442.30 390.19 446.15 383.04 445.80 curveto
+378.03 445.67 372.64 446.39 368.04 443.97 curveto
+205.30 288.67 moveto
+200.90 285.83 197.02 281.65 195.60 276.50 curveto
+198.88 279.93 201.33 284.29 205.82 286.37 curveto
+209.94 271.92 222.03 262.15 230.11 250.05 curveto
+234.12 242.32 236.26 233.79 238.23 225.35 curveto
+242.33 209.48 254.45 196.18 269.17 189.32 curveto
+281.28 185.93 295.06 189.24 304.63 197.35 curveto
+310.19 200.80 313.41 206.63 317.37 211.62 curveto
+321.00 216.34 324.31 221.31 328.12 225.89 curveto
+331.34 228.69 335.75 229.52 339.45 231.54 curveto
+349.36 236.11 357.92 243.27 364.56 251.89 curveto
+369.47 250.14 371.31 245.07 373.66 240.90 curveto
+373.16 244.70 372.89 249.06 369.69 251.69 curveto
+364.75 256.95 357.21 259.14 350.18 257.68 curveto
+350.26 257.19 350.42 256.20 350.50 255.71 curveto
+354.53 255.28 358.56 254.71 362.49 253.67 curveto
+359.14 247.56 353.60 243.05 348.23 238.79 curveto
+335.20 230.91 320.43 224.82 304.99 224.76 curveto
+289.84 224.90 274.52 228.04 260.92 234.82 curveto
+250.55 240.84 239.82 246.70 231.39 255.39 curveto
+221.92 264.79 211.95 274.94 208.29 288.16 curveto
+212.06 288.19 215.85 287.91 219.60 288.37 curveto
+215.82 292.20 209.51 291.32 205.30 288.67 curveto
+253.73 182.39 moveto
+259.27 175.16 268.40 168.16 278.03 170.92 curveto
+282.12 171.68 286.96 173.50 287.41 178.32 curveto
+282.88 176.78 279.11 172.72 274.00 173.33 curveto
+267.51 173.44 262.65 178.13 257.86 181.87 curveto
+256.73 183.02 255.12 182.56 253.73 182.39 curveto
+closepath
+1.000 0.937 0.012 setrgbcolor
+fill
+newpath
+209.44 451.56 moveto
+213.54 456.22 219.91 458.35 226.00 458.29 curveto
+241.79 457.98 256.88 445.56 259.13 429.73 curveto
+249.79 432.47 242.23 439.38 232.62 441.48 curveto
+226.63 442.61 219.85 443.08 214.49 439.62 curveto
+208.43 436.50 204.76 430.57 200.03 425.90 curveto
+199.95 435.21 203.23 444.58 209.44 451.56 curveto
+368.04 443.97 moveto
+372.64 446.39 378.03 445.67 383.04 445.80 curveto
+390.19 446.15 396.62 442.30 402.18 438.23 curveto
+410.18 431.99 415.73 421.71 413.93 411.37 curveto
+408.74 415.34 405.14 421.17 399.21 424.20 curveto
+392.59 428.15 384.52 428.54 377.15 426.87 curveto
+368.78 425.66 360.61 422.36 352.04 423.23 curveto
+346.59 423.72 340.28 423.95 336.64 428.69 curveto
+340.83 429.89 345.14 430.87 349.07 432.82 curveto
+355.66 436.06 361.46 440.70 368.04 443.97 curveto
+235.52 246.70 moveto
+240.99 243.99 245.90 240.35 251.09 237.15 curveto
+262.87 229.73 276.28 225.21 289.99 223.08 curveto
+295.98 222.67 301.98 222.40 307.98 222.48 curveto
+313.25 222.48 318.26 224.35 323.45 224.92 curveto
+321.58 219.77 318.10 215.47 315.07 210.97 curveto
+313.06 208.33 311.21 205.21 308.06 203.81 curveto
+303.68 205.57 300.15 208.90 295.81 210.74 curveto
+287.63 214.12 278.19 215.21 269.75 212.11 curveto
+266.42 210.29 263.95 213.78 261.17 215.07 curveto
+256.29 217.80 250.79 214.87 246.03 213.28 curveto
+240.66 223.71 237.84 235.27 235.52 246.70 curveto
+253.73 182.39 moveto
+255.12 182.56 256.73 183.02 257.86 181.87 curveto
+262.65 178.13 267.51 173.44 274.00 173.33 curveto
+279.11 172.72 282.88 176.78 287.41 178.32 curveto
+286.96 173.50 282.12 171.68 278.03 170.92 curveto
+268.40 168.16 259.27 175.16 253.73 182.39 curveto
+closepath
+0.941 0.353 0.075 setrgbcolor
+fill
+newpath
+202.27 410.69 moveto
+223.39 416.19 245.19 418.99 267.01 419.34 curveto
+279.02 419.41 291.02 418.69 303.01 417.89 curveto
+318.28 417.31 333.24 413.79 348.04 410.22 curveto
+375.94 402.93 403.09 392.47 428.19 378.20 curveto
+434.04 374.79 439.44 370.68 445.32 367.31 curveto
+452.20 363.45 458.34 358.42 464.48 353.50 curveto
+472.44 346.86 480.92 340.49 486.77 331.79 curveto
+488.86 328.57 491.05 325.01 490.79 321.00 curveto
+490.57 312.41 488.71 302.99 481.94 297.07 curveto
+479.38 295.03 476.67 291.89 473.04 292.68 curveto
+470.42 292.98 467.96 294.61 467.21 297.23 curveto
+464.26 305.10 470.03 313.01 468.13 320.97 curveto
+467.07 326.65 463.51 331.49 459.35 335.34 curveto
+455.07 339.24 450.75 343.13 446.01 346.48 curveto
+444.57 342.10 443.59 337.56 441.65 333.35 curveto
+439.13 327.92 437.29 322.12 433.73 317.23 curveto
+429.69 311.68 426.08 305.72 420.96 301.07 curveto
+414.15 294.85 406.33 289.50 397.50 286.64 curveto
+388.76 284.16 379.29 282.79 370.40 285.29 curveto
+364.24 286.84 357.84 287.93 352.25 291.12 curveto
+343.04 295.37 335.42 302.23 328.04 309.03 curveto
+320.36 318.50 315.50 330.71 316.19 343.02 curveto
+315.86 354.15 319.63 364.93 319.20 376.06 curveto
+319.00 382.76 316.16 389.69 310.71 393.78 curveto
+305.46 396.83 298.13 397.92 293.06 393.93 curveto
+288.47 390.29 285.40 385.04 283.45 379.58 curveto
+278.48 365.62 278.41 350.46 273.59 336.46 curveto
+267.70 322.45 254.11 312.19 239.12 309.93 curveto
+230.83 308.82 222.10 309.03 214.27 312.25 curveto
+201.37 317.25 188.51 323.69 179.28 334.30 curveto
+169.57 344.80 164.98 359.11 164.36 373.21 curveto
+158.47 371.78 152.74 369.54 147.59 366.33 curveto
+141.07 361.88 139.40 353.43 139.15 346.04 curveto
+138.75 340.72 139.09 334.27 134.45 330.60 curveto
+131.47 327.78 126.77 328.53 123.66 330.70 curveto
+119.78 332.85 118.93 337.55 117.68 341.40 curveto
+116.84 349.07 116.42 357.02 118.65 364.50 curveto
+119.87 368.76 122.68 372.31 125.54 375.61 curveto
+135.83 385.31 149.37 390.19 162.01 395.98 curveto
+175.16 401.57 188.41 407.11 202.27 410.69 curveto
+206.01 381.98 moveto
+202.05 379.14 197.90 376.50 194.54 372.92 curveto
+200.98 373.32 207.00 375.84 213.29 377.07 curveto
+207.29 366.51 198.63 357.71 192.65 347.12 curveto
+199.67 349.50 206.10 353.37 213.24 355.45 curveto
+209.69 347.57 204.26 340.70 200.81 332.77 curveto
+210.47 337.65 218.77 344.86 228.56 349.50 curveto
+224.47 340.79 218.88 332.86 214.86 324.10 curveto
+222.86 328.27 229.86 334.09 237.88 338.23 curveto
+236.95 333.09 235.88 327.95 235.71 322.71 curveto
+241.31 328.35 245.97 334.81 251.28 340.69 curveto
+257.87 347.63 260.88 356.93 264.82 365.44 curveto
+261.19 363.69 257.55 361.94 253.77 360.51 curveto
+255.55 365.52 258.62 369.95 260.21 375.03 curveto
+255.25 372.20 251.25 367.92 245.98 365.58 curveto
+249.31 373.45 255.33 379.71 259.38 387.16 curveto
+249.73 382.97 241.34 376.41 231.79 372.00 curveto
+234.81 378.72 239.58 384.51 242.26 391.39 curveto
+236.75 388.75 232.30 384.45 226.91 381.62 curveto
+228.39 388.27 231.35 394.46 232.95 401.08 curveto
+223.65 395.18 215.01 388.31 206.01 381.98 curveto
+362.14 367.87 moveto
+356.06 363.34 349.61 359.28 343.96 354.20 curveto
+350.45 354.47 356.59 356.67 362.88 358.05 curveto
+355.97 348.12 348.13 338.83 341.73 328.55 curveto
+349.46 329.82 355.81 334.72 363.05 337.35 curveto
+359.05 329.28 353.96 321.81 349.70 313.88 curveto
+359.65 318.87 368.20 326.24 378.17 331.20 curveto
+374.13 322.36 368.34 314.46 364.12 305.71 curveto
+372.21 309.56 379.06 315.51 387.11 319.42 curveto
+386.53 314.19 385.28 309.06 384.89 303.80 curveto
+390.60 311.38 395.29 319.64 400.52 327.55 curveto
+404.09 333.42 408.29 338.92 411.28 345.14 curveto
+408.43 344.04 405.66 342.77 402.82 341.65 curveto
+404.80 346.36 407.40 350.79 409.22 355.57 curveto
+404.43 353.37 400.38 349.92 395.71 347.50 curveto
+399.43 354.68 404.81 360.85 408.27 368.17 curveto
+398.64 363.86 390.18 357.41 380.70 352.82 curveto
+383.71 359.57 388.25 365.51 391.09 372.34 curveto
+385.76 369.53 381.23 365.48 375.90 362.67 curveto
+377.17 369.01 379.97 374.90 381.26 381.24 curveto
+374.58 377.23 368.54 372.29 362.14 367.87 curveto
+205.30 288.67 moveto
+209.51 291.32 215.82 292.20 219.60 288.37 curveto
+215.85 287.91 212.06 288.19 208.29 288.16 curveto
+211.95 274.94 221.92 264.79 231.39 255.39 curveto
+239.82 246.70 250.55 240.84 260.92 234.82 curveto
+274.52 228.04 289.84 224.90 304.99 224.76 curveto
+320.43 224.82 335.20 230.91 348.23 238.79 curveto
+353.60 243.05 359.14 247.56 362.49 253.67 curveto
+358.56 254.71 354.53 255.28 350.50 255.71 curveto
+350.42 256.20 350.26 257.19 350.18 257.68 curveto
+357.21 259.14 364.75 256.95 369.69 251.69 curveto
+372.89 249.06 373.16 244.70 373.66 240.90 curveto
+371.31 245.07 369.47 250.14 364.56 251.89 curveto
+357.92 243.27 349.36 236.11 339.45 231.54 curveto
+335.75 229.52 331.34 228.69 328.12 225.89 curveto
+324.31 221.31 321.00 216.34 317.37 211.62 curveto
+313.41 206.63 310.19 200.80 304.63 197.35 curveto
+295.06 189.24 281.28 185.93 269.17 189.32 curveto
+254.45 196.18 242.33 209.48 238.23 225.35 curveto
+236.26 233.79 234.12 242.32 230.11 250.05 curveto
+222.03 262.15 209.94 271.92 205.82 286.37 curveto
+201.33 284.29 198.88 279.93 195.60 276.50 curveto
+197.02 281.65 200.90 285.83 205.30 288.67 curveto
+235.52 246.70 moveto
+237.84 235.27 240.66 223.71 246.03 213.28 curveto
+250.79 214.87 256.29 217.80 261.17 215.07 curveto
+263.95 213.78 266.42 210.29 269.75 212.11 curveto
+278.19 215.21 287.63 214.12 295.81 210.74 curveto
+300.15 208.90 303.68 205.57 308.06 203.81 curveto
+311.21 205.21 313.06 208.33 315.07 210.97 curveto
+318.10 215.47 321.58 219.77 323.45 224.92 curveto
+318.26 224.35 313.25 222.48 307.98 222.48 curveto
+301.98 222.40 295.98 222.67 289.99 223.08 curveto
+276.28 225.21 262.87 229.73 251.09 237.15 curveto
+245.90 240.35 240.99 243.99 235.52 246.70 curveto
+248.08 211.12 moveto
+253.57 201.75 262.54 193.95 273.19 191.23 curveto
+284.50 189.18 296.36 192.80 305.03 200.25 curveto
+299.17 206.64 290.61 210.56 282.03 211.40 curveto
+275.11 212.12 268.77 208.91 263.00 205.54 curveto
+263.35 207.06 263.73 208.56 264.11 210.06 curveto
+262.25 211.45 260.62 213.78 258.04 213.54 curveto
+254.55 213.79 251.21 212.54 248.08 211.12 curveto
+closepath
+0.000 0.000 0.000 setrgbcolor
+fill
+newpath
+206.01 381.98 moveto
+215.01 388.31 223.65 395.18 232.95 401.08 curveto
+231.35 394.46 228.39 388.27 226.91 381.62 curveto
+232.30 384.45 236.75 388.75 242.26 391.39 curveto
+239.58 384.51 234.81 378.72 231.79 372.00 curveto
+241.34 376.41 249.73 382.97 259.38 387.16 curveto
+255.33 379.71 249.31 373.45 245.98 365.58 curveto
+251.25 367.92 255.25 372.20 260.21 375.03 curveto
+258.62 369.95 255.55 365.52 253.77 360.51 curveto
+257.55 361.94 261.19 363.69 264.82 365.44 curveto
+260.88 356.93 257.87 347.63 251.28 340.69 curveto
+245.97 334.81 241.31 328.35 235.71 322.71 curveto
+235.88 327.95 236.95 333.09 237.88 338.23 curveto
+229.86 334.09 222.86 328.27 214.86 324.10 curveto
+218.88 332.86 224.47 340.79 228.56 349.50 curveto
+218.77 344.86 210.47 337.65 200.81 332.77 curveto
+204.26 340.70 209.69 347.57 213.24 355.45 curveto
+206.10 353.37 199.67 349.50 192.65 347.12 curveto
+198.63 357.71 207.29 366.51 213.29 377.07 curveto
+207.00 375.84 200.98 373.32 194.54 372.92 curveto
+197.90 376.50 202.05 379.14 206.01 381.98 curveto
+362.14 367.87 moveto
+368.54 372.29 374.58 377.23 381.26 381.24 curveto
+379.97 374.90 377.17 369.01 375.90 362.67 curveto
+381.23 365.48 385.76 369.53 391.09 372.34 curveto
+388.25 365.51 383.71 359.57 380.70 352.82 curveto
+390.18 357.41 398.64 363.86 408.27 368.17 curveto
+404.81 360.85 399.43 354.68 395.71 347.50 curveto
+400.38 349.92 404.43 353.37 409.22 355.57 curveto
+407.40 350.79 404.80 346.36 402.82 341.65 curveto
+405.66 342.77 408.43 344.04 411.28 345.14 curveto
+408.29 338.92 404.09 333.42 400.52 327.55 curveto
+395.29 319.64 390.60 311.38 384.89 303.80 curveto
+385.28 309.06 386.53 314.19 387.11 319.42 curveto
+379.06 315.51 372.21 309.56 364.12 305.71 curveto
+368.34 314.46 374.13 322.36 378.17 331.20 curveto
+368.20 326.24 359.65 318.87 349.70 313.88 curveto
+353.96 321.81 359.05 329.28 363.05 337.35 curveto
+355.81 334.72 349.46 329.82 341.73 328.55 curveto
+348.13 338.83 355.97 348.12 362.88 358.05 curveto
+356.59 356.67 350.45 354.47 343.96 354.20 curveto
+349.61 359.28 356.06 363.34 362.14 367.87 curveto
+closepath
+0.388 0.388 0.388 setrgbcolor
+fill
+grestore
+
+%%EndDocument
+PSL_eps_end } def
+V 4196 2027 T
+0.590551181102 dup scale Sk_sunglasses U
+V -3604 2027 T
+0.590551181102 dup scale Sk_sunglasses U
+U
+PSL_cliprestore
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/grdmath/daynight.sh
+++ b/test/grdmath/daynight.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+ps=daynight.ps
+gmt grdmath -Rd -I1 30 20 0 DAYMASK = a.grd
+gmt grdmath -Rd -I1 30 20 5 DAYMASK = b.grd
+echo "0 black 1 white" > t.cpt
+gmt grdimage a.grd -Ct.cpt -Baf -P -K -JQ6i > $ps
+echo 30 20 | gmt psxy -R -J -O -K -Sc0.25c -Gred >> $ps
+gmt grdimage b.grd -Ct.cpt -Baf -O -K -Y4i >> $ps
+echo 30 20 | gmt psxy -R -J -O -K -Sc0.25c -Gred >> $ps

--- a/test/grdmath/daynight.sh
+++ b/test/grdmath/daynight.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
+# Test the DAYNIGHT operator
+
 ps=daynight.ps
-gmt grdmath -Rd -I1 30 20 0 DAYMASK = a.grd
-gmt grdmath -Rd -I1 30 20 5 DAYMASK = b.grd
+gmt grdmath -Rd -I1 30 20 0 DAYNIGHT = a.grd
+gmt grdmath -Rd -I1 30 20 5 DAYNIGHT = b.grd
 echo "0 black 1 white" > t.cpt
-gmt grdimage a.grd -Ct.cpt -Baf -P -K -JQ6i > $ps
-echo 30 20 | gmt psxy -R -J -O -K -Sc0.25c -Gred >> $ps
-gmt grdimage b.grd -Ct.cpt -Baf -O -K -Y4i >> $ps
-echo 30 20 | gmt psxy -R -J -O -K -Sc0.25c -Gred >> $ps
+gmt grdimage a.grd -Ct.cpt -Baf -B+t"Transition = 0" -P -K -JQ6.5i > $ps
+echo 30 20 | gmt psxy -R -J -O -K -Sk@sunglasses/1.5c >> $ps
+gmt grdimage b.grd -Ct.cpt -Baf -B+t"Transition = 5" -J -O -K -Y5i >> $ps
+echo 30 20 | gmt psxy -R -J -O -Sc0.25c -Sk@sunglasses/1.5c >> $ps


### PR DESCRIPTION
**Description of proposed changes**

This operator takes a _longitude_ and _latitude_ position (assumed to be the sun) and a transition _width_ and computes a day/night mask grid that is one on the side facing the sun and zero on the side facing away.  If the transition width is zero then we get an exact 0/1 mask, but if the width is finite then we approximate the 0/1 Heaviside step function by a scaled _atan_ function and depending on the transition width the values will be > 0 and < 1.  A new test (daynight.sh) has been added showing the two types of results.  The Sun is specified at (30, 20) with transition widths of 0 and 5 degrees.

![daynight](https://user-images.githubusercontent.com/26473567/81657665-c1618e00-93d3-11ea-93be-add43c5cd500.png)
