### PR TITLE
Defang the GMT_M_free_options macro

### DIFF
--- a/src/gmt_macros.h
+++ b/src/gmt_macros.h
@@ -59,6 +59,9 @@
 #define gmt_nc_put_varm_grdfloat nc_put_varm_float
 #endif
 
+/* This macro is called via each modules "Return" macro so API and options are available */
+#define gmt_M_free_options(mode) {if (GMT_Destroy_Options (API, &options) != GMT_OK) return (GMT_MEMORY_ERROR);}
+
 /*! Safe math macros that check arguments */
 
 #define d_log2(C,x) ((x) <= 0.0f ? C->session.f_NaN : log2 (x))

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -639,10 +639,6 @@ EXTERN_MSC int gmt_solve_svd (struct GMT_CTRL *GMT, double *u, unsigned int m, u
 EXTERN_MSC void gmt_polar_to_cart (struct GMT_CTRL *GMT, double r, double theta, double *a, bool degrees);
 EXTERN_MSC void gmt_cart_to_polar (struct GMT_CTRL *GMT, double *r, double *theta, double *a, bool degrees);
 
-/* From gmt_parse.c */
-/* This macro is called via each modules Return macro so API and options are set */
-#define gmt_M_free_options(mode) {if (GMT_Destroy_Options (API, &options) != GMT_OK) exit (GMT_MEMORY_ERROR);}
-
 /* From gmt_api.c */
 EXTERN_MSC int gmt_copy (struct GMTAPI_CTRL *API, enum GMT_enum_family family, unsigned int direction, char *ifile, char *ofile);
 EXTERN_MSC struct GMTAPI_CTRL * gmt_get_api_ptr (struct GMTAPI_CTRL *ptr);


### PR DESCRIPTION
It needlessly called exit if freeing the memory could not be done.  Might as wel just return the error code since that is the context where it is called anyway (via the bailout macros in the module).  Also moving the macros to gmt_macros.h.
Closes #3315.