### PR TITLE
doc: Fail the CI job if sphinx reports any warnings

### DIFF
--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -73,7 +73,11 @@ steps:
     cmake --build . --target optimize_images
     cmake --build . --target animation
     cmake --build . --target docs_html
+    # if html.log isn't empty (i.e., sphinx raise warnings), return 1
+    ! [ -s doc/rst/html.log ]
     cmake --build . --target docs_man
+    # if man.log isn't empty (i.e., sphinx raise warnings), return 1
+    ! [ -s doc/rst/man.log ]
   displayName: Build documentations
   condition: eq(variables['BUILD_DOCS'], true)
 

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -74,7 +74,11 @@ steps:
     cmake --build . --target optimize_images
     cmake --build . --target animation
     cmake --build . --target docs_html
+    # if html.log isn't empty (i.e., sphinx raise warnings), return 1
+    ! [ -s doc/rst/html.log ]
     cmake --build . --target docs_man
+    # if man.log isn't empty (i.e., sphinx raise warnings), return 1
+    ! [ -s doc/rst/man.log ]
   displayName: Build documentations
   condition: eq(variables['BUILD_DOCS'], true)
 

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -116,7 +116,11 @@ steps:
     cmake --build . --target docs_depends
     cmake --build . --target optimize_images
     cmake --build . --target docs_html
+    # if html.log isn't empty (i.e., sphinx raise warnings), return 1
+    ! [ -s doc/rst/html.log ]
     cmake --build . --target docs_man
+    # if man.log isn't empty (i.e., sphinx raise warnings), return 1
+    ! [ -s doc/rst/man.log ]
   displayName: Build documentations
   condition: eq(variables['BUILD_DOCS'], true)
 


### PR DESCRIPTION
Currently, sphinx doesn't report any errors and warnings (e.g., wrong reST syntax,
include a non-existent file, missing references) when building the GMT documentation.
That means our documentation is in good shape and we should keep it warnings free.

When we make a non-fatal mistake in the documentation, sphinx will report a
warning, but the exit code is still 0. Then the CI job will think the sphinx build is
sucessful, and we won't be aware of the mistake unless we check the CI report
or build the documentation locally.

This PR fixes the issue by checking if the warning log file "html.log" is empty.
A non-empty html.log file means sphinx reports some warnings, then the CI job fails.