### PR TITLE
List countries limited to a continent

### DIFF
--- a/doc/rst/source/coast_common.rst_
+++ b/doc/rst/source/coast_common.rst_
@@ -80,6 +80,8 @@ Optional Arguments
     NA (North America), or SA (South America).  Append **+l** to
     just list the countries and their codes [no data extraction or plotting takes place].
     Use **+L** to see states/territories for Argentina, Australia, Brazil, Canada, China, India, Russia and the US.
+    Finally, you can append **+l**\|\ **+L** to **-E**\ =*continent* to only list countries in that continent;
+    repeat if more than one continent is requested.
     Append **+p**\ *pen* to draw polygon outlines [no outline] and
     **+g**\ *fill* to fill them [no fill].  One of **+p**\|\ **g** must be
     specified unless **-M** is in effect, in which case only one **-E** option can be given.

--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -549,6 +549,7 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 unsigned int gmt_DCW_list (struct GMT_CTRL *GMT, struct GMT_DCW_SELECT *F) {
 	/* List available countries [and optionally states]; then make program exit */
 	unsigned int list_mode, i, j, k, kk, GMT_DCW_COUNTRIES = 0, GMT_DCW_STATES = 0, GMT_DCW_N_COUNTRIES_WITH_STATES = 0, n_bodies[3] = {0, 0, 0};
+	bool search = false;
 	struct GMT_DCW_COUNTRY *GMT_DCW_country = NULL;
 	struct GMT_DCW_STATE *GMT_DCW_state = NULL;
 	struct GMT_DCW_COUNTRY_STATE *GMT_DCW_country_with_state = NULL;
@@ -560,11 +561,15 @@ unsigned int gmt_DCW_list (struct GMT_CTRL *GMT, struct GMT_DCW_SELECT *F) {
 	GMT_DCW_STATES = n_bodies[1];
 	GMT_DCW_N_COUNTRIES_WITH_STATES = n_bodies[2];
 	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "List of ISO 3166-1 alpha-2 codes for DCW supported countries:\n\n");
+	for (k = 0; k < F->n_items; k++) {
+		if (!F->item[k]->codes || F->item[k]->codes[0] == '\0') continue;
+		search = true;	/* Gave some codes */
+	}
 	for (i = k = 0; i < GMT_DCW_COUNTRIES; i++) {
-		if (F->n_items) {	/* Listed continent(s) */
+		if (search) {	/* Listed continent(s) */
 			bool found = false;
 			for (kk = 0; kk < F->n_items; kk++) {
-				if (F->item[kk]->codes[0] == '=' && strstr (GMT_DCW_country[i].continent, &F->item[kk]->codes[1]))
+				if (F->item[kk]->codes[0] == '=' && strstr (F->item[kk]->codes, GMT_DCW_country[i].continent))
 					found = true;
 			}
 			if (!found) continue;

--- a/src/gmt_dcw.h
+++ b/src/gmt_dcw.h
@@ -57,7 +57,7 @@ struct GMT_DCW_SELECT {	/* -F<DWC-options> */
 	struct GMT_DCW_ITEM **item;	/* Pointer to array of n_items items */
 };
 
-EXTERN_MSC unsigned int gmt_DCW_list (struct GMT_CTRL *GMT, unsigned list_mode);
+EXTERN_MSC unsigned int gmt_DCW_list (struct GMT_CTRL *GMT, struct GMT_DCW_SELECT *F);
 EXTERN_MSC unsigned int gmt_DCW_parse (struct GMT_CTRL *GMT, char option, char *args, struct GMT_DCW_SELECT *F);
 EXTERN_MSC void gmt_DCW_option (struct GMTAPI_CTRL *API, char option, unsigned int plot);
 EXTERN_MSC struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SELECT *F, double wesn[], unsigned int mode);

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -1321,7 +1321,7 @@ EXTERN_MSC int GMT_coast (void *V_API, int mode, void *args) {
 		struct GMT_OPTION *opt = NULL, *options = GMT_Create_Options (API, mode, args);
 		bool list_items = false, dump_data = false;
 		if (API->error) return (API->error);	/* Set or get option list */
-		list_items = ((opt = GMT_Find_Option (API, 'E', options)) && opt->arg[0] == '+' && strchr ("lL", opt->arg[1]));
+		list_items = ((opt = GMT_Find_Option (API, 'E', options)) && (strstr (opt->arg, "+l") || strstr (opt->arg, "+L")));
 		dump_data = (GMT_Find_Option (API, 'M', options) != NULL);
 		gmt_M_free_options (mode);
 		if (!list_items && !dump_data) {

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -518,7 +518,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOAST_CTRL *Ctrl, struct GMT_OP
 		}
 	}
 
-	if (gmt_DCW_list (GMT, Ctrl->E.info.mode)) return 1;	/* If +l|L was given we list countries and return */
+	if (gmt_DCW_list (GMT, &(Ctrl->E.info))) return 1;	/* If +l|L was given we list countries and return */
 
 	if (!GMT->common.J.active) {	/* So without -J we can only do -M or report region only */
 		if (Ctrl->M.active) Ctrl->E.info.mode = GMT_DCW_DUMP;


### PR DESCRIPTION
It is useful to be able to list all the countries in a continent. Now, **-E**[=_continent_]**+l+L** will do that [Default is all countries, as before].
