### PR TITLE
pssac: Fix a bug when reading a SAC data in a partial time window

### DIFF
--- a/src/seis/pssac.c
+++ b/src/seis/pssac.c
@@ -785,8 +785,7 @@ EXTERN_MSC int GMT_pssac (void *V_API, int mode, void *args) {	/* High-level fun
 		else {
 			unsigned int user = 0; /* default using user0 */
 			/* determine X0 */
-			if (!Ctrl->C.active) x0 = hd.b - tref;
-			else                 x0 = Ctrl->C.t0;
+			x0 = hd.b - tref;	/* the new begin time may not exactly match t1 */
 
 			/* determine Y0 */
 			if (Ctrl->E.active) {

--- a/src/seis/sacio.c
+++ b/src/seis/sacio.c
@@ -368,8 +368,8 @@ float *read_sac_pdw(const char *name, SACHEAD *hd, int tmark, float t1, float t2
 	nt2 = nt1 + nn;
 	npts = hd->npts;
 	hd->npts = nn;
-	hd->b   = t1;
-	hd->e   = t1 + nn * hd->delta;
+	hd->b = hd->b + hd->delta * nt1;  /* the new begin time may not exactly match t1 */
+	hd->e = hd->b + (nn - 1) * hd->delta;
 
 	if (nt1 > npts || nt2 < 0) {
 		fclose(strm);

--- a/test/pssac/pssac_C.ps
+++ b/test/pssac/pssac_C.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from pssac
+%%Title: GMT v6.1.0_90e1d13_2020.05.16 [64-bit] Document from pssac
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:53:06 2018
+%%CreationDate: Sat May 16 12:31:47 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -336,9 +336,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +592,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +635,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -651,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -662,8 +658,9 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
-/PSL_movie_completion {} def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
@@ -674,11 +671,11 @@ O0
 % PostScript produced by:
 %@GMT: gmt pssac ntkl.z onkl.z -JX15c/4c -R200/1600/22/27 -Bx100 -By1 -BWSen -Ed -M1.5c -K -P
 %@PROJ: xy 200.00000000 1600.00000000 22.00000000 27.00000000 200.000 1600.000 22.000 27.000 +xy
-%GMTBoundingBox: 72 72 425.197 113.386
+%GMTBoundingBox: 72 72 425.196850394 113.385826772
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 0 543 M
 587 1 D
@@ -1434,7 +1431,7 @@ O0
 10 17 D
 5 6 D
 6 3 D
-S
+0 -1 D S
 0 1277 M
 69 1 D
 71 -1 D
@@ -2082,8 +2079,9 @@ S
 5 2 D
 5 -1 D
 28 -19 D
-S
+0 0 D S
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 1890 M 0 -1890 D S
 /PSL_A0_y 83 def
@@ -2095,8 +2093,8 @@ N 0 756 M -83 0 D S
 N 0 1134 M -83 0 D S
 N 0 1512 M -83 0 D S
 N 0 1890 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (22) sw mx
@@ -2155,8 +2153,8 @@ N 5568 0 M 0 -83 D S
 N 6074 0 M 0 -83 D S
 N 6580 0 M 0 -83 D S
 N 7087 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (200) sh mx
 (300) sh mx
 (400) sh mx
@@ -2241,38 +2239,38 @@ O0
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
-1519 527 M
+1518 527 M
 5 1 D
-5 3 D
-20 19 D
+11 8 D
+15 14 D
 5 4 D
 5 2 D
 10 0 D
 10 -7 D
 15 -17 D
-6 -3 D
+5 -3 D
 5 0 D
-10 5 D
+11 5 D
 10 7 D
 40 15 D
-16 1 D
-10 -3 D
-15 -8 D
-20 -6 D
+15 1 D
+16 -6 D
+15 -7 D
+15 -4 D
 10 -7 D
 10 -9 D
 5 -3 D
 5 -1 D
-6 1 D
-15 10 D
-25 20 D
+5 1 D
+21 14 D
+20 16 D
 15 7 D
 10 1 D
 10 -3 D
-16 -12 D
-5 -3 D
+10 -9 D
+11 -6 D
 5 0 D
 15 10 D
 5 2 D
@@ -2281,9 +2279,9 @@ O0
 10 -17 D
 10 -22 D
 5 -7 D
-6 0 D
+5 0 D
 5 8 D
-25 83 D
+26 83 D
 5 11 D
 5 7 D
 5 3 D
@@ -2292,28 +2290,27 @@ O0
 5 -10 D
 5 -17 D
 10 -64 D
-11 -82 D
-5 -30 D
+15 -112 D
 5 -17 D
-5 -3 D
+6 -3 D
 5 9 D
 10 38 D
 10 60 D
 25 226 D
 5 30 D
 5 14 D
-6 -3 D
+5 -3 D
 5 -21 D
-10 -81 D
+11 -81 D
 20 -203 D
 5 -35 D
 5 -23 D
 5 -7 D
 5 7 D
 10 47 D
-10 61 D
-16 63 D
-10 23 D
+15 86 D
+10 38 D
+11 23 D
 5 5 D
 5 0 D
 5 -8 D
@@ -2322,8 +2319,8 @@ O0
 5 -11 D
 5 -3 D
 5 7 D
-6 14 D
-20 78 D
+10 33 D
+16 59 D
 5 13 D
 5 7 D
 5 0 D
@@ -2332,11 +2329,10 @@ O0
 5 -4 D
 5 0 D
 5 4 D
-10 16 D
-6 6 D
+15 22 D
 5 3 D
 5 -4 D
-5 -10 D
+6 -10 D
 20 -65 D
 5 -7 D
 5 0 D
@@ -2344,10 +2340,10 @@ O0
 15 28 D
 5 5 D
 5 3 D
-6 1 D
+5 1 D
 5 -1 D
 10 -7 D
-5 -6 D
+6 -6 D
 10 -23 D
 10 -28 D
 5 -10 D
@@ -2356,96 +2352,96 @@ O0
 15 35 D
 5 8 D
 5 3 D
-16 4 D
-10 9 D
-5 3 D
+15 4 D
+16 12 D
 5 -1 D
 5 -5 D
 15 -27 D
 5 -2 D
 5 5 D
 5 10 D
-16 51 D
-20 102 D
+15 51 D
+21 102 D
 10 45 D
 5 10 D
 5 -1 D
 5 -14 D
 15 -80 D
 15 -82 D
-11 -29 D
+5 -18 D
+5 -11 D
 5 -4 D
-10 -2 D
+11 -2 D
 5 -3 D
 5 -7 D
 10 -28 D
 15 -67 D
 15 -78 D
 5 -19 D
-6 -10 D
+5 -10 D
 5 0 D
 5 9 D
-10 42 D
-25 163 D
-20 180 D
-10 100 D
-11 75 D
+6 18 D
+15 84 D
+20 142 D
+30 284 D
+5 32 D
 5 20 D
-5 5 D
+6 5 D
 5 -10 D
 5 -26 D
 10 -91 D
 30 -415 D
 10 -102 D
 5 -35 D
-6 -22 D
+5 -22 D
 5 -8 D
 5 9 D
-5 26 D
+6 26 D
 10 99 D
 25 334 D
 10 87 D
 10 52 D
 5 13 D
-6 6 D
+5 6 D
 5 -4 D
 5 -12 D
-10 -54 D
-10 -99 D
-25 -351 D
+6 -22 D
+10 -75 D
+15 -197 D
+15 -210 D
 5 -44 D
 5 -24 D
 5 -2 D
 5 19 D
-6 37 D
-15 177 D
-25 355 D
+10 87 D
+16 200 D
+20 282 D
 5 40 D
 5 13 D
 5 -18 D
 5 -49 D
-21 -358 D
-5 -70 D
+25 -428 D
 5 -43 D
-5 -12 D
+6 -12 D
 5 14 D
 25 179 D
 15 82 D
 15 100 D
-6 15 D
+5 15 D
 5 -9 D
-5 -35 D
-20 -276 D
+11 -96 D
+15 -215 D
 5 -29 D
 5 10 D
 5 47 D
 15 211 D
 5 34 D
 5 1 D
-11 -72 D
-10 -82 D
+5 -28 D
+15 -126 D
 5 -20 D
-5 -5 D
+6 -5 D
 5 5 D
 15 36 D
 10 41 D
@@ -2453,9 +2449,9 @@ O0
 5 19 D
 5 0 D
 5 -26 D
-6 -50 D
-15 -208 D
-5 -37 D
+10 -119 D
+5 -76 D
+11 -100 D
 5 0 D
 5 36 D
 15 190 D
@@ -2465,9 +2461,8 @@ O0
 5 -17 D
 5 -10 D
 5 6 D
-6 20 D
-10 52 D
-5 8 D
+15 72 D
+6 8 D
 5 -15 D
 5 -41 D
 20 -291 D
@@ -2475,19 +2470,19 @@ O0
 5 -8 D
 5 33 D
 10 179 D
-16 330 D
+15 330 D
 5 48 D
-5 -4 D
+6 -4 D
 5 -52 D
 20 -375 D
 5 -55 D
 5 -24 D
 5 3 D
 5 27 D
-15 146 D
-11 64 D
+20 186 D
+5 24 D
 5 5 D
-5 -9 D
+6 -9 D
 5 -14 D
 5 -9 D
 5 2 D
@@ -2497,19 +2492,20 @@ O0
 5 -17 D
 15 -79 D
 5 -12 D
-6 -1 D
+5 -1 D
 5 7 D
-30 74 D
+21 49 D
+10 25 D
 5 8 D
 5 1 D
 5 -7 D
 20 -57 D
 5 -9 D
-6 -6 D
+5 -6 D
 5 -3 D
 5 0 D
 5 6 D
-5 13 D
+6 13 D
 15 70 D
 5 13 D
 5 -2 D
@@ -2518,19 +2514,19 @@ O0
 5 -17 D
 5 2 D
 5 23 D
-11 70 D
+10 70 D
 5 23 D
 5 3 D
-5 -20 D
+6 -20 D
 20 -173 D
 5 -22 D
 5 -1 D
 5 22 D
 20 203 D
 5 31 D
-6 11 D
+5 11 D
 5 -10 D
-10 -66 D
+11 -66 D
 15 -133 D
 5 -22 D
 5 -2 D
@@ -2538,9 +2534,9 @@ O0
 15 86 D
 5 14 D
 5 5 D
-11 4 D
-10 17 D
-5 10 D
+5 1 D
+5 3 D
+16 27 D
 5 4 D
 5 -3 D
 5 -11 D
@@ -2548,10 +2544,10 @@ O0
 15 -89 D
 5 -8 D
 5 15 D
-16 131 D
+15 131 D
 5 29 D
 5 1 D
-5 -26 D
+6 -26 D
 10 -85 D
 5 -28 D
 5 -4 D
@@ -2560,11 +2556,11 @@ O0
 5 25 D
 5 6 D
 5 -17 D
-10 -80 D
-6 -35 D
+15 -115 D
 5 -14 D
 5 18 D
-15 160 D
+6 45 D
+10 115 D
 5 34 D
 5 1 D
 5 -30 D
@@ -2572,10 +2568,10 @@ O0
 5 -30 D
 5 -6 D
 5 15 D
-10 62 D
-11 43 D
+15 89 D
+5 16 D
 5 3 D
-10 -13 D
+11 -13 D
 5 -2 D
 5 6 D
 10 22 D
@@ -2584,9 +2580,9 @@ O0
 15 -80 D
 5 -15 D
 5 3 D
-6 18 D
-15 93 D
 5 18 D
+10 64 D
+11 47 D
 5 3 D
 5 -14 D
 15 -89 D
@@ -2595,10 +2591,10 @@ O0
 5 12 D
 10 41 D
 5 14 D
-6 4 D
+5 4 D
 5 -4 D
 5 -9 D
-5 -5 D
+6 -5 D
 5 3 D
 10 37 D
 5 20 D
@@ -2607,15 +2603,15 @@ O0
 15 -107 D
 5 -19 D
 5 2 D
-11 48 D
-5 29 D
+5 19 D
+10 58 D
 S
-1519 1276 M
+1517 1276 M
 15 2 D
 20 2 D
 25 7 D
-10 -1 D
-16 -7 D
+11 -1 D
+15 -7 D
 15 -10 D
 10 -3 D
 10 1 D
@@ -2640,9 +2636,9 @@ S
 15 -13 D
 5 -2 D
 15 2 D
-5 -1 D
+6 -1 D
 5 -4 D
-16 -21 D
+15 -21 D
 10 -7 D
 5 -2 D
 5 0 D
@@ -2650,8 +2646,9 @@ S
 5 6 D
 5 10 D
 15 57 D
-15 58 D
-6 9 D
+10 41 D
+6 17 D
+5 9 D
 5 0 D
 5 -11 D
 10 -53 D
@@ -2660,9 +2657,7 @@ S
 5 -9 D
 5 -1 D
 5 8 D
-15 51 D
-11 35 D
-5 13 D
+31 99 D
 5 7 D
 5 -1 D
 5 -8 D
@@ -2670,14 +2665,16 @@ S
 5 -4 D
 5 3 D
 5 10 D
-20 67 D
-6 11 D
+15 52 D
+11 26 D
 5 5 D
 5 0 D
 5 -5 D
 25 -40 D
 20 -22 D
-26 -19 D
+10 -8 D
+11 -7 D
+5 -4 D
 5 -1 D
 5 2 D
 5 5 D
@@ -2686,17 +2683,16 @@ S
 5 4 D
 5 1 D
 5 -2 D
-5 -6 D
-11 -21 D
-15 -40 D
-10 -17 D
+11 -15 D
+25 -62 D
+5 -7 D
 5 -4 D
 5 1 D
 5 4 D
 25 47 D
 5 4 D
-5 1 D
-16 -3 D
+6 1 D
+15 -3 D
 5 1 D
 10 7 D
 10 11 D
@@ -2710,21 +2706,21 @@ S
 5 -3 D
 5 -1 D
 5 1 D
-20 18 D
-11 2 D
-10 -1 D
+15 14 D
+11 6 D
+15 -1 D
 20 3 D
 10 -4 D
 15 -18 D
 5 -7 D
 5 -4 D
-5 -1 D
-6 3 D
+6 -1 D
+5 3 D
 10 12 D
 25 40 D
 25 30 D
-15 24 D
-11 12 D
+21 31 D
+5 5 D
 10 3 D
 10 -3 D
 10 -6 D
@@ -2738,21 +2734,20 @@ S
 10 0 D
 5 2 D
 5 6 D
-10 29 D
-21 100 D
-30 154 D
+11 29 D
+50 254 D
 10 36 D
 5 11 D
 5 5 D
 5 0 D
-5 -7 D
-11 -34 D
+6 -7 D
+10 -34 D
 30 -161 D
 20 -116 D
 5 -17 D
 10 -17 D
-10 -10 D
-6 -3 D
+11 -10 D
+5 -3 D
 5 0 D
 5 7 D
 5 14 D
@@ -2767,8 +2762,8 @@ S
 15 -170 D
 25 -307 D
 10 -73 D
-5 -15 D
-6 1 D
+6 -15 D
+5 1 D
 5 17 D
 10 81 D
 35 473 D
@@ -2780,14 +2775,12 @@ S
 25 -513 D
 5 -12 D
 25 0 D
-5 66 D
-11 256 D
-15 366 D
+6 66 D
+25 622 D
 5 21 D
 25 0 D
 10 -146 D
-20 -426 D
-6 -98 D
+26 -524 D
 5 -39 D
 25 0 D
 5 52 D
@@ -2799,8 +2792,8 @@ S
 20 -562 D
 5 -52 D
 15 0 D
-25 637 D
-6 72 D
+20 523 D
+11 186 D
 10 0 D
 10 -213 D
 15 -370 D
@@ -2809,8 +2802,8 @@ S
 5 22 D
 10 151 D
 10 187 D
-5 65 D
-6 36 D
+6 65 D
+5 36 D
 5 10 D
 5 -8 D
 20 -46 D
@@ -2820,7 +2813,8 @@ S
 5 -30 D
 5 -3 D
 5 28 D
-21 255 D
+6 54 D
+15 201 D
 5 35 D
 5 2 D
 5 -32 D
@@ -2828,8 +2822,9 @@ S
 5 -22 D
 5 15 D
 10 117 D
-10 126 D
-6 26 D
+5 71 D
+6 55 D
+5 26 D
 5 -7 D
 10 -81 D
 10 -85 D
@@ -2838,8 +2833,8 @@ S
 5 6 D
 15 34 D
 15 20 D
-10 27 D
-11 38 D
+6 11 D
+15 54 D
 5 12 D
 5 0 D
 5 -14 D
@@ -2848,8 +2843,9 @@ S
 5 -1 D
 5 7 D
 10 36 D
-10 40 D
-6 10 D
+5 22 D
+6 18 D
+5 10 D
 5 -2 D
 15 -40 D
 5 -2 D
@@ -2860,9 +2856,8 @@ S
 5 -17 D
 10 -53 D
 5 -15 D
-5 2 D
-6 15 D
-5 18 D
+6 2 D
+10 33 D
 5 9 D
 5 -7 D
 10 -42 D
@@ -2872,8 +2867,8 @@ S
 5 9 D
 5 -4 D
 10 -26 D
-5 -9 D
-6 -1 D
+6 -9 D
+5 -1 D
 10 5 D
 5 -1 D
 10 -9 D
@@ -2883,8 +2878,9 @@ S
 5 9 D
 5 -4 D
 5 -17 D
-15 -85 D
-6 -6 D
+10 -61 D
+6 -24 D
+5 -6 D
 5 16 D
 15 119 D
 5 25 D
@@ -2894,11 +2890,12 @@ S
 5 -12 D
 5 1 D
 10 21 D
-5 6 D
-6 -5 D
+6 6 D
+5 -5 D
 5 -16 D
 S
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 1890 M 0 -1890 D S
 /PSL_A0_y 83 def
@@ -2910,8 +2907,8 @@ N 0 756 M -83 0 D S
 N 0 1134 M -83 0 D S
 N 0 1512 M -83 0 D S
 N 0 1890 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (22) sw mx
@@ -2970,8 +2967,8 @@ N 5568 0 M 0 -83 D S
 N 6074 0 M 0 -83 D S
 N 6580 0 M 0 -83 D S
 N 7087 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (200) sh mx
 (300) sh mx
 (400) sh mx
@@ -3056,7 +3053,7 @@ O0
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 0 543 M
 244 1 D
@@ -4459,6 +4456,7 @@ S
 5 -2 D
 S
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 1890 M 0 -1890 D S
 /PSL_A0_y 83 def
@@ -4470,8 +4468,8 @@ N 0 756 M -83 0 D S
 N 0 1134 M -83 0 D S
 N 0 1512 M -83 0 D S
 N 0 1890 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (22) sw mx
@@ -4530,8 +4528,8 @@ N 5568 0 M 0 -83 D S
 N 6074 0 M 0 -83 D S
 N 6580 0 M 0 -83 D S
 N 7087 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (”300) sh mx
 (”200) sh mx
 (”100) sh mx
@@ -4616,12 +4614,11 @@ O0
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
-1012 545 M
-5 0 D
-11 -5 D
-10 -7 D
+1008 545 M
+11 -2 D
+15 -10 D
 5 -2 D
 5 0 D
 10 7 D
@@ -4637,8 +4634,8 @@ O0
 15 -10 D
 15 -13 D
 5 -3 D
-10 1 D
-6 3 D
+11 1 D
+5 3 D
 20 19 D
 5 4 D
 5 2 D
@@ -4646,8 +4643,9 @@ O0
 10 -7 D
 15 -17 D
 5 -3 D
-11 2 D
-15 10 D
+6 0 D
+10 5 D
+10 7 D
 40 15 D
 15 1 D
 11 -3 D
@@ -4657,9 +4655,8 @@ O0
 10 -9 D
 5 -3 D
 5 -1 D
-5 1 D
-16 10 D
-25 20 D
+11 4 D
+35 27 D
 15 7 D
 10 1 D
 10 -3 D
@@ -4675,8 +4672,8 @@ O0
 5 -7 D
 5 0 D
 5 8 D
-16 51 D
-10 32 D
+6 14 D
+20 69 D
 5 11 D
 5 7 D
 5 3 D
@@ -4685,8 +4682,9 @@ O0
 5 -10 D
 5 -17 D
 10 -64 D
-15 -112 D
-6 -17 D
+10 -82 D
+6 -30 D
+5 -17 D
 5 -3 D
 5 9 D
 10 38 D
@@ -4695,16 +4693,16 @@ O0
 5 30 D
 5 14 D
 5 -3 D
-11 -56 D
-25 -249 D
+6 -21 D
+10 -81 D
+20 -203 D
 5 -35 D
 5 -23 D
 5 -7 D
 5 7 D
 10 47 D
 15 86 D
-5 21 D
-11 30 D
+16 51 D
 5 10 D
 5 5 D
 5 0 D
@@ -4726,8 +4724,8 @@ O0
 5 4 D
 15 22 D
 5 3 D
-5 -4 D
-6 -10 D
+6 -4 D
+5 -10 D
 20 -65 D
 5 -7 D
 5 0 D
@@ -4736,8 +4734,8 @@ O0
 5 5 D
 5 3 D
 5 1 D
-5 -1 D
-11 -7 D
+11 -4 D
+5 -4 D
 5 -6 D
 10 -23 D
 10 -28 D
@@ -4756,9 +4754,8 @@ O0
 5 -2 D
 5 5 D
 5 10 D
-15 51 D
-16 73 D
-10 55 D
+21 72 D
+20 107 D
 5 19 D
 5 10 D
 5 -1 D
@@ -4766,8 +4763,8 @@ O0
 15 -80 D
 15 -82 D
 5 -18 D
-5 -11 D
-6 -4 D
+6 -11 D
+5 -4 D
 10 -2 D
 5 -3 D
 5 -7 D
@@ -4777,14 +4774,14 @@ O0
 5 -19 D
 5 -10 D
 5 0 D
-5 9 D
-6 18 D
-15 84 D
-20 142 D
-30 284 D
+6 9 D
+10 42 D
+25 163 D
+20 180 D
+15 143 D
 5 32 D
-5 20 D
-6 5 D
+6 20 D
+5 5 D
 5 -10 D
 5 -26 D
 10 -91 D
@@ -4792,8 +4789,8 @@ O0
 10 -102 D
 5 -35 D
 5 -22 D
-5 -8 D
-6 9 D
+6 -8 D
+5 9 D
 5 26 D
 10 99 D
 25 334 D
@@ -4801,8 +4798,8 @@ O0
 10 52 D
 5 13 D
 5 6 D
-5 -4 D
-6 -12 D
+6 -4 D
+5 -12 D
 10 -54 D
 10 -99 D
 25 -351 D
@@ -4810,14 +4807,14 @@ O0
 5 -24 D
 5 -2 D
 5 19 D
-16 147 D
-30 422 D
+11 87 D
+35 482 D
 5 40 D
 5 13 D
 5 -18 D
 5 -49 D
-25 -428 D
-6 -43 D
+20 -358 D
+11 -113 D
 5 -12 D
 5 14 D
 25 179 D
@@ -4825,8 +4822,8 @@ O0
 15 100 D
 5 15 D
 5 -9 D
-11 -96 D
-15 -215 D
+6 -35 D
+20 -276 D
 5 -29 D
 5 10 D
 5 47 D
@@ -4834,8 +4831,9 @@ O0
 5 34 D
 5 1 D
 5 -28 D
-15 -126 D
-6 -20 D
+10 -90 D
+6 -36 D
+5 -20 D
 5 -5 D
 5 5 D
 15 36 D
@@ -4844,7 +4842,8 @@ O0
 5 19 D
 5 0 D
 5 -26 D
-21 -258 D
+11 -119 D
+10 -139 D
 5 -37 D
 5 0 D
 5 36 D
@@ -4864,8 +4863,9 @@ O0
 5 -8 D
 5 33 D
 10 179 D
-15 330 D
-6 48 D
+10 238 D
+6 92 D
+5 48 D
 5 -4 D
 5 -52 D
 20 -375 D
@@ -4887,9 +4887,8 @@ O0
 15 -79 D
 5 -12 D
 5 -1 D
-5 7 D
-21 49 D
-10 25 D
+11 18 D
+25 63 D
 5 8 D
 5 1 D
 5 -7 D
@@ -4897,8 +4896,8 @@ O0
 5 -9 D
 5 -6 D
 5 -3 D
-5 0 D
-6 6 D
+6 0 D
+5 6 D
 5 13 D
 15 70 D
 5 13 D
@@ -4909,8 +4908,8 @@ O0
 5 2 D
 5 23 D
 10 70 D
-5 23 D
-6 3 D
+6 23 D
+5 3 D
 5 -20 D
 20 -173 D
 5 -22 D
@@ -4919,9 +4918,9 @@ O0
 20 203 D
 5 31 D
 5 11 D
-5 -10 D
-6 -27 D
-20 -172 D
+6 -10 D
+10 -66 D
+15 -133 D
 5 -22 D
 5 -2 D
 5 18 D
@@ -4930,7 +4929,8 @@ O0
 5 5 D
 5 1 D
 5 3 D
-16 27 D
+6 7 D
+10 20 D
 5 4 D
 5 -3 D
 5 -11 D
@@ -4940,8 +4940,8 @@ O0
 5 15 D
 15 131 D
 5 29 D
-5 1 D
-6 -26 D
+6 1 D
+5 -26 D
 10 -85 D
 5 -28 D
 5 -4 D
@@ -4952,9 +4952,8 @@ O0
 5 -17 D
 15 -115 D
 5 -14 D
-5 18 D
-6 45 D
-10 115 D
+6 18 D
+15 160 D
 5 34 D
 5 1 D
 5 -30 D
@@ -4963,8 +4962,8 @@ O0
 5 -6 D
 5 15 D
 15 89 D
-5 16 D
-6 3 D
+6 16 D
+5 3 D
 10 -13 D
 5 -2 D
 5 6 D
@@ -4977,293 +4976,292 @@ O0
 5 18 D
 S
 1012 1276 M
-41 4 D
-25 7 D
+40 4 D
+26 7 D
 10 -1 D
-21 -10 D
-10 -7 D
+15 -7 D
+15 -10 D
 10 -3 D
 10 1 D
-25 12 D
+26 12 D
 20 3 D
-26 -1 D
-30 -7 D
+25 -1 D
+31 -7 D
 15 1 D
-31 2 D
+25 2 D
+20 1 D
+31 4 D
+15 -1 D
+25 -8 D
+31 -1 D
+35 10 D
 15 1 D
-25 4 D
-20 -1 D
-26 -8 D
-30 -1 D
-31 9 D
-20 2 D
-30 -9 D
+31 -9 D
 15 1 D
-16 4 D
+15 4 D
 15 9 D
 5 1 D
 5 -1 D
 15 -13 D
 5 -2 D
-15 2 D
+16 2 D
 5 -1 D
 5 -4 D
-16 -21 D
+15 -21 D
 10 -7 D
 5 -2 D
 5 0 D
 5 2 D
 5 6 D
 5 10 D
-15 57 D
-15 58 D
+11 35 D
+20 80 D
 5 9 D
 5 0 D
-6 -11 D
+5 -11 D
 10 -53 D
 15 -97 D
 5 -20 D
 5 -9 D
 5 -1 D
-5 8 D
+6 8 D
 15 51 D
 15 48 D
-6 7 D
+5 7 D
 5 -1 D
 5 -8 D
 20 -58 D
 5 -4 D
 5 3 D
-5 10 D
+6 10 D
 20 67 D
 5 11 D
 5 5 D
-6 0 D
+5 0 D
 5 -5 D
 25 -40 D
-20 -22 D
-25 -19 D
-6 -1 D
+15 -17 D
+31 -24 D
+5 -1 D
 5 2 D
 5 5 D
 25 57 D
 5 8 D
 5 4 D
-5 1 D
+6 1 D
 5 -2 D
 5 -6 D
 10 -21 D
-21 -50 D
-5 -7 D
+15 -40 D
+10 -17 D
 5 -4 D
 5 1 D
 5 4 D
-25 47 D
+15 30 D
+11 17 D
 5 4 D
 5 1 D
 15 -3 D
-6 1 D
+5 1 D
 10 7 D
 10 11 D
 10 7 D
 10 -3 D
-20 -22 D
+6 -5 D
+15 -17 D
 15 -10 D
-16 -5 D
+15 -5 D
 10 -6 D
 10 -9 D
 5 -3 D
 5 -1 D
-5 1 D
+6 1 D
 20 18 D
 5 2 D
-16 -1 D
+15 -1 D
 20 3 D
 10 -4 D
-15 -18 D
-5 -7 D
+21 -25 D
 5 -4 D
 5 -1 D
 5 3 D
-11 12 D
+10 12 D
 25 40 D
-25 30 D
+26 30 D
 20 31 D
 5 5 D
-11 3 D
+10 3 D
 10 -3 D
 10 -6 D
 10 -14 D
-10 -22 D
-20 -72 D
-10 -39 D
-26 -64 D
+16 -38 D
+30 -110 D
+20 -49 D
 5 -8 D
 5 -5 D
 5 -3 D
 10 0 D
-5 2 D
+6 2 D
 5 6 D
 10 29 D
-41 204 D
-15 70 D
-10 27 D
+50 254 D
+10 36 D
+6 11 D
 5 5 D
 5 0 D
 5 -7 D
 10 -34 D
-31 -161 D
+30 -161 D
 20 -116 D
-5 -17 D
-10 -17 D
-10 -10 D
+11 -27 D
+10 -12 D
+5 -5 D
 5 -3 D
 5 0 D
-6 7 D
+5 7 D
 5 14 D
 15 75 D
-20 141 D
-20 139 D
+41 280 D
 10 50 D
 5 16 D
-6 3 D
+5 3 D
 5 -13 D
 5 -31 D
 15 -170 D
-25 -307 D
-10 -73 D
+15 -196 D
+16 -153 D
+5 -31 D
 5 -15 D
 5 1 D
 5 17 D
-6 34 D
-15 174 D
-25 346 D
-10 100 D
+10 81 D
+35 473 D
+5 55 D
+6 45 D
 5 18 D
 15 0 D
-11 -104 D
-15 -283 D
-15 -310 D
+5 -41 D
+10 -143 D
+25 -513 D
 5 -12 D
-25 0 D
+26 0 D
 5 66 D
-21 516 D
-5 106 D
+25 622 D
 5 21 D
 25 0 D
-10 -146 D
+11 -146 D
 25 -524 D
 5 -39 D
-26 0 D
+25 0 D
 5 52 D
-20 543 D
-5 107 D
+15 416 D
+11 234 D
 5 7 D
 20 0 D
-6 -95 D
+5 -95 D
 20 -562 D
 5 -52 D
 15 0 D
-25 637 D
+6 108 D
+20 529 D
 5 72 D
-11 0 D
+10 0 D
 10 -213 D
 15 -370 D
 5 -71 D
 5 -25 D
 5 22 D
-10 151 D
-10 187 D
+6 63 D
+15 275 D
 5 65 D
 5 36 D
 5 10 D
-6 -8 D
+5 -8 D
 20 -46 D
 5 -22 D
 10 -85 D
 10 -103 D
-5 -30 D
+6 -30 D
 5 -3 D
 5 28 D
-15 195 D
-11 95 D
+20 255 D
+5 35 D
 5 2 D
 5 -32 D
 20 -267 D
 5 -22 D
 5 15 D
-10 117 D
-10 126 D
+6 48 D
+15 195 D
 5 26 D
 5 -7 D
-6 -34 D
-15 -132 D
+10 -81 D
+10 -85 D
 5 -21 D
 5 -5 D
 5 6 D
 15 34 D
-15 20 D
+16 20 D
 10 27 D
 10 38 D
-6 12 D
+5 12 D
 5 0 D
 5 -14 D
 20 -109 D
 5 -13 D
 5 -1 D
-5 7 D
+6 7 D
 10 36 D
 10 40 D
 5 10 D
 5 -2 D
-6 -11 D
-10 -29 D
+15 -40 D
 5 -2 D
 5 12 D
 10 46 D
 5 15 D
 5 1 D
-5 -17 D
+6 -17 D
 10 -53 D
 5 -15 D
 5 2 D
 10 33 D
-6 9 D
+5 9 D
 5 -7 D
 10 -42 D
 5 -14 D
 5 4 D
 15 70 D
-5 9 D
+6 9 D
 5 -4 D
 10 -26 D
 5 -9 D
 5 -1 D
-11 5 D
+10 5 D
 5 -1 D
 10 -9 D
 5 -1 D
 5 6 D
 10 25 D
 5 9 D
-5 -4 D
+6 -4 D
 5 -17 D
 15 -85 D
 5 -6 D
 5 16 D
-6 35 D
-10 84 D
+15 119 D
 5 25 D
 5 6 D
 5 -13 D
 15 -74 D
 5 -12 D
-5 1 D
+6 1 D
 10 21 D
 5 6 D
 5 -5 D
 S
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 1890 M 0 -1890 D S
 /PSL_A0_y 83 def
@@ -5275,8 +5273,8 @@ N 0 756 M -83 0 D S
 N 0 1134 M -83 0 D S
 N 0 1512 M -83 0 D S
 N 0 1890 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (22) sw mx
@@ -5335,8 +5333,8 @@ N 5568 0 M 0 -83 D S
 N 6074 0 M 0 -83 D S
 N 6580 0 M 0 -83 D S
 N 7087 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (”300) sh mx
 (”200) sh mx
 (”100) sh mx
@@ -5421,11 +5419,12 @@ O0
 %%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 %%EndObject
 
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U


### PR DESCRIPTION
When reading a SAC file in a time window from t1 to t2, the timings of
the data points may not exactly match t1 or t2, thus we must be
very careful with the begin time of the new data segment.

The old code always uses t1 as the begin time of the new data, which may
cause a tiny time error < dt (dt is the time interval of the data).

The error is usually tiny and ignored, but for studies that require
high-precision data timings, it's very important to keep the data
timings.

Also fix a failing test due to the tiny time shift.