### PR TITLE
Help user avoid common movie/batch mistakes

### DIFF
--- a/src/batch.c
+++ b/src/batch.c
@@ -348,10 +348,10 @@ static int parse (struct GMT_CTRL *GMT, struct BATCH_CTRL *Ctrl, struct GMT_OPTI
 		/* Armed with script language we check that any back/fore-ground scripts are of the same kind */
 		for (k = BATCH_PREFLIGHT; !n_errors && k <= BATCH_POSTFLIGHT; k++) {
 			if (!Ctrl->S[k].active) continue;	/* Not provided */
-			n_errors += gmtlib_check_language (GMT, Ctrl->In.mode, Ctrl->S[k].file, k, NULL);
+			n_errors += gmt_check_language (GMT, Ctrl->In.mode, Ctrl->S[k].file, k, NULL);
 		}
 		if (!n_errors && Ctrl->I.active) {	/* Must also check the include file, and open it for reading */
-			n_errors += gmtlib_check_language (GMT, Ctrl->In.mode, Ctrl->I.file, 3, NULL);
+			n_errors += gmt_check_language (GMT, Ctrl->In.mode, Ctrl->I.file, 3, NULL);
 			if (n_errors == 0 && ((Ctrl->I.fp = fopen (Ctrl->I.file, "r")) == NULL)) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to open include script file %s\n", Ctrl->I.file);
 				n_errors++;
@@ -362,8 +362,12 @@ static int parse (struct GMT_CTRL *GMT, struct BATCH_CTRL *Ctrl, struct GMT_OPTI
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to open main script file %s\n", Ctrl->In.file);
 			n_errors++;
 		}
-		if (n_errors == 0 && gmtlib_script_is_classic (GMT, Ctrl->In.fp)) {
+		if (n_errors == 0 && gmt_script_is_classic (GMT, Ctrl->In.fp)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Your main script file %s is not in GMT modern mode\n", Ctrl->In.file);
+			n_errors++;
+		}
+		/* Make sure all BATCH_* variables are used with leading token ($, %) */
+		if (n_errors == 0 && gmt_token_check (GMT, Ctrl->In.fp, "BATCH_", Ctrl->In.mode)) {
 			n_errors++;
 		}
 	}
@@ -424,7 +428,7 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 	if (Ctrl->Q.scripts) {	/* No batch will be run, but scripts will be produced */
 		GMT_Report (API, GMT_MSG_INFORMATION, "Dry-run enabled - Processing scripts will be created and any pre/post-flight scripts will be executed.\n");
 		if (Ctrl->M.active) GMT_Report (API, GMT_MSG_INFORMATION, "A single script for job %d will be created and executed\n", Ctrl->M.job);
-		run_script = gmtlib_dry_run_only;	/* This prevents the main job loop from executing the script */
+		run_script = gmt_dry_run_only;	/* This prevents the main job loop from executing the script */
 	}
 	else	/* Will run scripts and may even need to make a batch */
 		run_script = system;	/* The standard system function will be used */
@@ -510,14 +514,14 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 	}
 
 	sprintf (string, "Static parameters set for processing sequence %s", Ctrl->N.prefix);
-	gmtlib_set_comment (fp, Ctrl->In.mode, string);
-	gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "BATCH_PREFIX", Ctrl->N.prefix);
-	if (n_written) gmtlib_set_ivalue (fp, Ctrl->In.mode, false, "BATCH_NJOBS", n_jobs);	/* Total jobs (write to init since known) */
+	gmt_set_comment (fp, Ctrl->In.mode, string);
+	gmt_set_tvalue (fp, Ctrl->In.mode, true, "BATCH_PREFIX", Ctrl->N.prefix);
+	if (n_written) gmt_set_ivalue (fp, Ctrl->In.mode, false, "BATCH_NJOBS", n_jobs);	/* Total jobs (write to init since known) */
 	if (Ctrl->I.active) {	/* Append contents of an include file */
-		gmtlib_set_comment (fp, Ctrl->In.mode, "Static parameters set via user include file");
+		gmt_set_comment (fp, Ctrl->In.mode, "Static parameters set via user include file");
 		while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->I.fp)) {	/* Read the include file and copy to init script with some exceptions */
-			if (gmtlib_is_gmt_module (line, "begin")) continue;		/* Skip gmt begin */
-			if (gmtlib_is_gmt_module (line, "end")) continue;		/* Skip gmt end */
+			if (gmt_is_gmtmodule (line, "begin")) continue;		/* Skip gmt begin */
+			if (gmt_is_gmtmodule (line, "end")) continue;		/* Skip gmt end */
 			if (strstr (line, "#!/")) continue;			/* Skip any leading shell incantation */
 			if (strchr (line, '\n') == NULL) strcat (line, "\n");	/* In case the last line misses a newline */
 			fprintf (fp, "%s", line);				/* Just copy the line as is */
@@ -530,7 +534,7 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 		/* The preflight script must be modern mode */
 		unsigned int rec = 0;
 		sprintf (pre_file, "batch_preflight.%s", extension[Ctrl->In.mode]);
-		is_classic = gmtlib_script_is_classic (GMT, Ctrl->S[BATCH_PREFLIGHT].fp);
+		is_classic = gmt_script_is_classic (GMT, Ctrl->S[BATCH_PREFLIGHT].fp);
 		if (is_classic) {
 			GMT_Report (API, GMT_MSG_ERROR, "Your preflight file %s is not in GMT modern node - exiting\n", pre_file);
 			fclose (Ctrl->In.fp);
@@ -542,23 +546,23 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 			fclose (Ctrl->In.fp);
 			Return (GMT_ERROR_ON_FOPEN);
 		}
-		gmtlib_set_script (fp, Ctrl->In.mode);			/* Write 1st line of a script */
-		gmtlib_set_comment (fp, Ctrl->In.mode, "Preflight script");
+		gmt_set_script (fp, Ctrl->In.mode);			/* Write 1st line of a script */
+		gmt_set_comment (fp, Ctrl->In.mode, "Preflight script");
 		fprintf (fp, "%s", export[Ctrl->In.mode]);		/* Hardwire a Session Name since sub-shells may mess things up */
 		if (Ctrl->In.mode == GMT_DOS_MODE)	/* Set GMT_SESSION_NAME under Windows to 1 since we run this separately first */
 			fprintf (fp, "set GMT_SESSION_NAME=1\n");
 		else	/* On UNIX we may use the calling terminal or script's PID as the GMT_SESSION_NAME */
-			gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
+			gmt_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
 		fprintf (fp, "%s", export[Ctrl->In.mode]);		/* Turn off auto-display of figures if scrip has gmt end show */
-		gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "GMT_END_SHOW", "off");
+		gmt_set_tvalue (fp, Ctrl->In.mode, true, "GMT_END_SHOW", "off");
 		fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 		while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->S[BATCH_PREFLIGHT].fp)) {	/* Read the preflight script and copy to the temporary preflight script with some exceptions */
-			if (gmtlib_is_gmt_module (line, "begin")) {	/* Need to insert the DIR_DATA statement */
+			if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert the DIR_DATA statement */
 				fprintf (fp, "%s", line);
 				fprintf (fp, "\tgmt set DIR_DATA %s\n", datadir);
 			}
-			else if (!strstr (line, "#!/"))	 {	/* Skip any leading shell incantation since already placed by gmtlib_set_script */
-				if (gmtlib_is_gmt_end_show (line)) sprintf (line, "gmt end\n");		/* Eliminate show from gmt end in this script since we are running these in batch */
+			else if (!strstr (line, "#!/"))	 {	/* Skip any leading shell incantation since already placed by gmt_set_script */
+				if (gmt_is_gmt_end_show (line)) sprintf (line, "gmt end\n");		/* Eliminate show from gmt end in this script since we are running these in batch */
 				else if (strchr (line, '\n') == NULL) strcat (line, "\n");	/* In case the last line misses a newline */
 				fprintf (fp, "%s", line);	/* Just copy the line as is */
 			}
@@ -645,7 +649,7 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 
 	if (Ctrl->S[BATCH_POSTFLIGHT].active) {	/* Prepare the temporary postflight script */
 		sprintf (post_file, "batch_postflight.%s", extension[Ctrl->In.mode]);
-		is_classic = gmtlib_script_is_classic (GMT, Ctrl->S[BATCH_POSTFLIGHT].fp);
+		is_classic = gmt_script_is_classic (GMT, Ctrl->S[BATCH_POSTFLIGHT].fp);
 		if (is_classic) {
 			GMT_Report (API, GMT_MSG_ERROR, "Your postflight file %s is not in GMT modern node - exiting\n", post_file);
 			fclose (Ctrl->In.fp);
@@ -657,22 +661,22 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 			fclose (Ctrl->In.fp);
 			Return (GMT_ERROR_ON_FOPEN);
 		}
-		gmtlib_set_script (fp, Ctrl->In.mode);					/* Write 1st line of a script */
-		gmtlib_set_comment (fp, Ctrl->In.mode, "Postflight script");
+		gmt_set_script (fp, Ctrl->In.mode);					/* Write 1st line of a script */
+		gmt_set_comment (fp, Ctrl->In.mode, "Postflight script");
 		fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 		fprintf (fp, "cd %s\n", topdir);		/* cd to the starting directory */
 		fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Hardwire a SESSION_NAME since sub-shells may mess things up */
 		if (Ctrl->In.mode == GMT_DOS_MODE)	/* Set GMT_SESSION_NAME under Windows to 1 since we run this separately */
 			fprintf (fp, "set GMT_SESSION_NAME=1\n");
 		else	/* On UNIX we may use the script's PID as GMT_SESSION_NAME */
-			gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
+			gmt_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
 		while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->S[BATCH_POSTFLIGHT].fp)) {	/* Read the postflight script and copy to the temporary postflight script with some exceptions */
-			if (gmtlib_is_gmt_module (line, "begin")) {
+			if (gmt_is_gmtmodule (line, "begin")) {
 				fprintf (fp, "%s", line);	/* Allow args since the script may make a plot */
 				fprintf (fp, "\tgmt set DIR_DATA %s\n", datadir);
 			}
 			else if (!strstr (line, "#!/"))	{	/* Skip any leading shell incantation since already placed */
-				if (gmtlib_is_gmt_end_show (line)) sprintf (line, "%s", line);		/* Allow show in gmt end here */
+				if (gmt_is_gmt_end_show (line)) sprintf (line, "%s", line);		/* Allow show in gmt end here */
 				else if (strchr (line, '\n') == NULL) strcat (line, "\n");	/* In case the last line misses a newline */
 				fprintf (fp, "%s", line);	/* Just copy the line as is */
 			}
@@ -705,18 +709,18 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 			Return (GMT_ERROR_ON_FOPEN);
 		}
 		sprintf (state_prefix, "Parameter file for job %s", state_tag);
-		gmtlib_set_comment (fp, Ctrl->In.mode, state_prefix);
+		gmt_set_comment (fp, Ctrl->In.mode, state_prefix);
 		sprintf (state_prefix, "%s_%s", Ctrl->N.prefix, state_tag);
-		gmtlib_set_tvalue (fp, Ctrl->In.mode, false, "BATCH_NAME", state_prefix);	/* Current job name prefix (e.g., my_job_0003) */
-		gmtlib_set_ivalue (fp, Ctrl->In.mode, false, "BATCH_JOB", data_job);		/* Current job number (e.g., 3) */
-		if (!n_written) gmtlib_set_ivalue (fp, Ctrl->In.mode, false, "BATCH_NJOBS", n_jobs);	/* Total jobs (write here since n_jobs was not yet known when init was written) */
-		gmtlib_set_tvalue (fp, Ctrl->In.mode, false, "BATCH_ITEM", state_tag);		/* Current job tag (formatted job number, e.g, 0003) */
+		gmt_set_tvalue (fp, Ctrl->In.mode, false, "BATCH_NAME", state_prefix);	/* Current job name prefix (e.g., my_job_0003) */
+		gmt_set_ivalue (fp, Ctrl->In.mode, false, "BATCH_JOB", data_job);		/* Current job number (e.g., 3) */
+		if (!n_written) gmt_set_ivalue (fp, Ctrl->In.mode, false, "BATCH_NJOBS", n_jobs);	/* Total jobs (write here since n_jobs was not yet known when init was written) */
+		gmt_set_tvalue (fp, Ctrl->In.mode, false, "BATCH_ITEM", state_tag);		/* Current job tag (formatted job number, e.g, 0003) */
 		for (col = 0; col < n_values; col++) {	/* Derive job variables from this row in <timefile> and copy to each parameter file  as script variables */
 			sprintf (string, "BATCH_COL%u", col);
-			gmtlib_set_value (GMT, fp, Ctrl->In.mode, col, string, D->table[0]->segment[0]->data[col][data_job]);
+			gmt_set_value (GMT, fp, Ctrl->In.mode, col, string, D->table[0]->segment[0]->data[col][data_job]);
 		}
 		if (has_text) {	/* Also place any string parameter as a single string variable */
-			gmtlib_set_tvalue (fp, Ctrl->In.mode, false, "BATCH_TEXT", D->table[0]->segment[0]->text[data_job]);
+			gmt_set_tvalue (fp, Ctrl->In.mode, false, "BATCH_TEXT", D->table[0]->segment[0]->text[data_job]);
 			if (Ctrl->T.split) {	/* Also split the string into individual words BATCH_WORD1, BATCH_WORD2, etc. */
 				char *word = NULL, *trail = NULL, *orig = strdup (D->table[0]->segment[0]->text[data_job]);
 				col = 0;
@@ -724,7 +728,7 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 				while ((word = strsep (&trail, " \t")) != NULL) {
 					if (*word != '\0') {	/* Skip empty strings */
 						sprintf (string, "BATCH_WORD%u", col++);
-						gmtlib_set_tvalue (fp, Ctrl->In.mode, false, string, word);
+						gmt_set_tvalue (fp, Ctrl->In.mode, false, string, word);
 					}
 				}
 				gmt_M_str_free (orig);
@@ -742,40 +746,40 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 		fclose (Ctrl->In.fp);
 		Return (GMT_ERROR_ON_FOPEN);
 	}
-	gmtlib_set_script (fp, Ctrl->In.mode);	/* Write 1st line of a script */
-	gmtlib_set_comment (fp, Ctrl->In.mode, "Main job loop script");
+	gmt_set_script (fp, Ctrl->In.mode);	/* Write 1st line of a script */
+	gmt_set_comment (fp, Ctrl->In.mode, "Main job loop script");
 	fprintf (fp, "%s", export[Ctrl->In.mode]);	/* Hardwire a GMT_SESSION_NAME since sub-shells may mess things up */
 	if (Ctrl->In.mode == GMT_DOS_MODE)	/* Set GMT_SESSION_NAME under Windows to be the job number */
 		fprintf (fp, "set GMT_SESSION_NAME=%c1\n", var_token[Ctrl->In.mode]);
 	else	/* On UNIX we use the script's PID as GMT_SESSION_NAME */
-		gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
+		gmt_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
 	fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Turn off auto-display of figures if script has gmt end show */
-	gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "GMT_END_SHOW", "off");
-	gmtlib_set_comment (fp, Ctrl->In.mode, "Include static and job-specific parameters");
+	gmt_set_tvalue (fp, Ctrl->In.mode, true, "GMT_END_SHOW", "off");
+	gmt_set_comment (fp, Ctrl->In.mode, "Include static and job-specific parameters");
 	fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 	fprintf (fp, "%s batch_params_%c1.%s\n", load[Ctrl->In.mode], var_token[Ctrl->In.mode], extension[Ctrl->In.mode]);	/* Include the job parameters */
-	fprintf (fp, "mkdir %s\n", gmtlib_place_var (Ctrl->In.mode, "BATCH_NAME"));	/* Make a temp directory for this job */
-	fprintf (fp, "cd %s\n", gmtlib_place_var (Ctrl->In.mode, "BATCH_NAME"));		/* cd to the temp directory */
+	fprintf (fp, "mkdir %s\n", gmt_place_var (Ctrl->In.mode, "BATCH_NAME"));	/* Make a temp directory for this job */
+	fprintf (fp, "cd %s\n", gmt_place_var (Ctrl->In.mode, "BATCH_NAME"));		/* cd to the temp directory */
 	while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->In.fp)) {	/* Read the main script and copy to loop script, with some exceptions */
-		if (gmtlib_is_gmt_module (line, "begin")) {	/* Must insert DIR_DATA setting */
+		if (gmt_is_gmtmodule (line, "begin")) {	/* Must insert DIR_DATA setting */
 			fprintf (fp, "%s", line);
 			fprintf (fp, "\tgmt set DIR_DATA %s\n", datadir);
 		}
 		else if (!strstr (line, "#!/")) {		/* Skip any leading shell incantation since already placed */
-			if (gmtlib_is_gmt_end_show (line)) sprintf (line, "gmt end\n");		/* Eliminate show from gmt end in this script */
+			if (gmt_is_gmt_end_show (line)) sprintf (line, "gmt end\n");		/* Eliminate show from gmt end in this script */
 			else if (strchr (line, '\n') == NULL) strcat (line, "\n");	/* In case the last line misses a newline */
 			fprintf (fp, "%s", line);	/* Just copy the line as is */
 		}
 	}
 	fclose (Ctrl->In.fp);	/* Done reading the main script */
 	/* Move job products up to main directory */
-	fprintf (fp, "%s %s.* %s\n", mvfile[Ctrl->In.mode], gmtlib_place_var (Ctrl->In.mode, "BATCH_NAME"), topdir);
+	fprintf (fp, "%s %s.* %s\n", mvfile[Ctrl->In.mode], gmt_place_var (Ctrl->In.mode, "BATCH_NAME"), topdir);
 	fprintf (fp, "cd ..\n");	/* cd up to parent dir */
 	/* Create completion file so batch knows this job is done */
-	fprintf (fp, "%s %s.___\n", createfile[Ctrl->In.mode], gmtlib_place_var (Ctrl->In.mode, "BATCH_NAME"));
+	fprintf (fp, "%s %s.___\n", createfile[Ctrl->In.mode], gmt_place_var (Ctrl->In.mode, "BATCH_NAME"));
 	if (!Ctrl->Q.active) {	/* Delete evidence; otherwise we want to leave debug evidence when doing a single job only */
-		gmtlib_set_comment (fp, Ctrl->In.mode, "Remove job directory and job parameter file");
-		fprintf (fp, "%s %s\n", rmdir[Ctrl->In.mode], gmtlib_place_var (Ctrl->In.mode, "BATCH_NAME"));	/* Remove the work dir and any files in it */
+		gmt_set_comment (fp, Ctrl->In.mode, "Remove job directory and job parameter file");
+		fprintf (fp, "%s %s\n", rmdir[Ctrl->In.mode], gmt_place_var (Ctrl->In.mode, "BATCH_NAME"));	/* Remove the work dir and any files in it */
 		fprintf (fp, "%s batch_params_%c1.%s\n", rmfile[Ctrl->In.mode], var_token[Ctrl->In.mode], extension[Ctrl->In.mode]);	/* Remove the parameter file for this job */
 	}
 	if (Ctrl->In.mode == GMT_DOS_MODE)	/* This is crucial to the "start /B ..." statement below to ensure the DOS process terminates */
@@ -797,9 +801,9 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 		GMT_Report (API, GMT_MSG_ERROR, "Unable to create cleanup file %s - exiting\n", cleanup_file);
 		Return (GMT_ERROR_ON_FOPEN);
 	}
-	gmtlib_set_script (fp, Ctrl->In.mode);		/* Write 1st line of a script */
+	gmt_set_script (fp, Ctrl->In.mode);		/* Write 1st line of a script */
 	if (Ctrl->W.active) {	/* Want to delete the entire work directory */
-		gmtlib_set_comment (fp, Ctrl->In.mode, "Cleanup script removes working directory with job files");
+		gmt_set_comment (fp, Ctrl->In.mode, "Cleanup script removes working directory with job files");
 		fprintf (fp, "%s %s\n", rmdir[Ctrl->In.mode], workdir);	/* Delete the entire working directory with batch jobs and tmp files */
 	}
 	else {	/* Just delete the remaining script files */
@@ -876,7 +880,7 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 			n_jobs_not_started--;		/* One less job remaining */
 			n_cores_unused--;		/* This core is now busy */
 		}
-		gmtlib_gmt_sleep (BATCH_WAIT_TO_CHECK);	/* Wait 0.01 second - then check for the completion file */
+		gmt_sleep (BATCH_WAIT_TO_CHECK);	/* Wait 0.01 second - then check for the completion file */
 		for (k = first_job; k < i_job; k++) {	/* Only loop over the range of jobs that we know are currently in play */
 			if (status[k].completed) continue;	/* Already finished with this job */
 			if (!status[k].started) continue;	/* Not started this job yet */

--- a/src/batch.c
+++ b/src/batch.c
@@ -650,14 +650,14 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 		}
 
 		sprintf (string, "Static parameters set for processing sequence %s", Ctrl->N.prefix);
-		gmtlib_set_comment (fp, Ctrl->In.mode, string);
-		gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "BATCH_PREFIX", Ctrl->N.prefix);
-		gmtlib_set_ivalue (fp, Ctrl->In.mode, false, "BATCH_NJOBS", n_jobs);	/* Total jobs (write to init since known) */
+		gmt_set_comment (fp, Ctrl->In.mode, string);
+		gmt_set_tvalue (fp, Ctrl->In.mode, true, "BATCH_PREFIX", Ctrl->N.prefix);
+		gmt_set_ivalue (fp, Ctrl->In.mode, false, "BATCH_NJOBS", n_jobs);	/* Total jobs (write to init since known) */
 		if (Ctrl->I.active) {	/* Append contents of an include file */
-			gmtlib_set_comment (fp, Ctrl->In.mode, "Static parameters set via user include file");
+			gmt_set_comment (fp, Ctrl->In.mode, "Static parameters set via user include file");
 			while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->I.fp)) {	/* Read the include file and copy to init script with some exceptions */
-				if (gmtlib_is_gmt_module (line, "begin")) continue;		/* Skip gmt begin */
-				if (gmtlib_is_gmt_module (line, "end")) continue;		/* Skip gmt end */
+				if (gmt_is_gmtmodule (line, "begin")) continue;		/* Skip gmt begin */
+				if (gmt_is_gmtmodule (line, "end")) continue;		/* Skip gmt end */
 				if (strstr (line, "#!/")) continue;			/* Skip any leading shell incantation */
 				if (strchr (line, '\n') == NULL) strcat (line, "\n");	/* In case the last line misses a newline */
 				fprintf (fp, "%s", line);				/* Just copy the line as is */
@@ -738,9 +738,9 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 		sprintf (state_prefix, "Parameter file for job %s", state_tag);
 		gmt_set_comment (fp, Ctrl->In.mode, state_prefix);
 		sprintf (state_prefix, "%s_%s", Ctrl->N.prefix, state_tag);
-		gmtlib_set_tvalue (fp, Ctrl->In.mode, false, "BATCH_NAME", state_prefix);	/* Current job name prefix (e.g., my_job_0003) */
-		gmtlib_set_ivalue (fp, Ctrl->In.mode, false, "BATCH_JOB", data_job);		/* Current job number (e.g., 3) */
-		gmtlib_set_tvalue (fp, Ctrl->In.mode, false, "BATCH_ITEM", state_tag);		/* Current job tag (formatted job number, e.g, 0003) */
+		gmt_set_tvalue (fp, Ctrl->In.mode, false, "BATCH_NAME", state_prefix);	/* Current job name prefix (e.g., my_job_0003) */
+		gmt_set_ivalue (fp, Ctrl->In.mode, false, "BATCH_JOB", data_job);		/* Current job number (e.g., 3) */
+		gmt_set_tvalue (fp, Ctrl->In.mode, false, "BATCH_ITEM", state_tag);		/* Current job tag (formatted job number, e.g, 0003) */
 		for (col = 0; col < n_values; col++) {	/* Derive job variables from this row in <timefile> and copy to each parameter file  as script variables */
 			sprintf (string, "BATCH_COL%u", col);
 			gmt_set_value (GMT, fp, Ctrl->In.mode, col, string, D->table[0]->segment[0]->data[col][data_job]);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -352,19 +352,20 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
-EXTERN_MSC bool gmtlib_is_gmt_module (char *line, char *module);
-EXTERN_MSC bool gmtlib_is_gmt_end_show (char *line);
-EXTERN_MSC int gmtlib_gmt_sleep (unsigned int microsec);
-EXTERN_MSC void gmtlib_set_value (struct GMT_CTRL *GMT, FILE *fp, int mode, int col, char *name, double value);
-EXTERN_MSC void gmtlib_set_ivalue (FILE *fp, int mode, bool env, char *name, int value);
-EXTERN_MSC void gmtlib_set_dvalue (FILE *fp, int mode, char *name, double value, char unit);
-EXTERN_MSC void gmtlib_set_tvalue (FILE *fp, int mode, bool env, char *name, char *value);
-EXTERN_MSC void gmtlib_set_script (FILE *fp, int mode);
-EXTERN_MSC void gmtlib_set_comment (FILE *fp, int mode, char *comment);
-EXTERN_MSC char *gmtlib_place_var (int mode, char *name);
-EXTERN_MSC int gmtlib_dry_run_only (const char *cmd);
-EXTERN_MSC unsigned int gmtlib_check_language (struct GMT_CTRL *GMT, unsigned int mode, char *file, unsigned int k, bool *PS);
-EXTERN_MSC bool gmtlib_script_is_classic (struct GMT_CTRL *GMT, FILE *fp);
+EXTERN_MSC int gmt_token_check (struct GMT_CTRL *GMT, FILE *fp, char *prefix, unsigned int mode);
+EXTERN_MSC bool gmt_is_gmtmodule (char *line, char *module);
+EXTERN_MSC bool gmt_is_gmt_end_show (char *line);
+EXTERN_MSC int gmt_sleep (unsigned int microsec);
+EXTERN_MSC void gmt_set_value (struct GMT_CTRL *GMT, FILE *fp, int mode, int col, char *name, double value);
+EXTERN_MSC void gmt_set_ivalue (FILE *fp, int mode, bool env, char *name, int value);
+EXTERN_MSC void gmt_set_dvalue (FILE *fp, int mode, char *name, double value, char unit);
+EXTERN_MSC void gmt_set_tvalue (FILE *fp, int mode, bool env, char *name, char *value);
+EXTERN_MSC void gmt_set_script (FILE *fp, int mode);
+EXTERN_MSC void gmt_set_comment (FILE *fp, int mode, char *comment);
+EXTERN_MSC char *gmt_place_var (int mode, char *name);
+EXTERN_MSC int gmt_dry_run_only (const char *cmd);
+EXTERN_MSC unsigned int gmt_check_language (struct GMT_CTRL *GMT, unsigned int mode, char *file, unsigned int k, bool *PS);
+EXTERN_MSC bool gmt_script_is_classic (struct GMT_CTRL *GMT, FILE *fp);
 EXTERN_MSC int gmt_write_glue_function (struct GMTAPI_CTRL *API, char* library);
 EXTERN_MSC unsigned int gmt_polygon_orientation (struct GMT_CTRL *GMT, double x[], double y[], uint64_t n, int geo);
 EXTERN_MSC struct GMT_CONTOUR_INFO * gmt_get_contours_from_table (struct GMT_CTRL *GMT, char *file, bool inner_ticks, unsigned int *type, unsigned int *n_contours);

--- a/src/movie.c
+++ b/src/movie.c
@@ -1028,17 +1028,17 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 		/* Armed with script language we check that any back/fore-ground scripts are of the same kind */
 		for (k = MOVIE_PREFLIGHT; !n_errors && k <= MOVIE_POSTFLIGHT; k++) {
 			if (!Ctrl->S[k].active) continue;	/* Not provided */
-			n_errors += gmtlib_check_language (GMT, Ctrl->In.mode, Ctrl->S[k].file, k, &Ctrl->S[k].PS);
+			n_errors += gmt_check_language (GMT, Ctrl->In.mode, Ctrl->S[k].file, k, &Ctrl->S[k].PS);
 		}
 		if (!n_errors && Ctrl->E.active) {	/* Must also check the include file, and open it for reading */
-			n_errors += gmtlib_check_language (GMT, Ctrl->In.mode, Ctrl->E.file, 2, &Ctrl->E.PS);
+			n_errors += gmt_check_language (GMT, Ctrl->In.mode, Ctrl->E.file, 2, &Ctrl->E.PS);
 			if (n_errors == 0 && ((Ctrl->E.fp = fopen (Ctrl->E.file, "r")) == NULL)) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to open title script file %s\n", Ctrl->E.file);
 				n_errors++;
 			}
 		}
 		if (!n_errors && Ctrl->I.active) {	/* Must also check the include file, and open it for reading */
-			n_errors += gmtlib_check_language (GMT, Ctrl->In.mode, Ctrl->I.file, 3, NULL);
+			n_errors += gmt_check_language (GMT, Ctrl->In.mode, Ctrl->I.file, 3, NULL);
 			if (n_errors == 0 && ((Ctrl->I.fp = fopen (Ctrl->I.file, "r")) == NULL)) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to open include script file %s\n", Ctrl->I.file);
 				n_errors++;
@@ -1049,8 +1049,12 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to open main script file %s\n", Ctrl->In.file);
 			n_errors++;
 		}
-		if (n_errors == 0 && gmtlib_script_is_classic (GMT, Ctrl->In.fp)) {
+		if (n_errors == 0 && gmt_script_is_classic (GMT, Ctrl->In.fp)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Your main script file %s is not in GMT modern mode\n", Ctrl->In.file);
+			n_errors++;
+		}
+		/* Make sure all MOVIE_* variables are used with leading token ($, %) */
+		if (n_errors == 0 && gmt_token_check (GMT, Ctrl->In.fp, "MOVIE_", Ctrl->In.mode)) {
 			n_errors++;
 		}
 	}
@@ -1182,7 +1186,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	if (Ctrl->Q.scripts) {	/* No movie, but scripts will be produced */
 		GMT_Report (API, GMT_MSG_INFORMATION, "Dry-run enabled - Movie scripts will be created and any pre/post scripts will be executed.\n");
 		if (Ctrl->M.active) GMT_Report (API, GMT_MSG_INFORMATION, "A single plot for frame %d will be create and named %s.%s\n", Ctrl->M.frame, Ctrl->N.prefix, Ctrl->M.format);
-		run_script = gmtlib_dry_run_only;	/* This prevents the main frame loop from executing the script */
+		run_script = gmt_dry_run_only;	/* This prevents the main frame loop from executing the script */
 	}
 	else {	/* Will run scripts and may even need to make a movie */
 		run_script = system;	/* The standard system function will be used */
@@ -1299,17 +1303,17 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	}
 
 	sprintf (string, "Static parameters set for animation sequence %s", Ctrl->N.prefix);
-	gmtlib_set_comment (fp, Ctrl->In.mode, string);
-	gmtlib_set_dvalue (fp, Ctrl->In.mode, "MOVIE_WIDTH",  Ctrl->C.dim[GMT_X], Ctrl->C.unit);
-	gmtlib_set_dvalue (fp, Ctrl->In.mode, "MOVIE_HEIGHT", Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
-	gmtlib_set_dvalue (fp, Ctrl->In.mode, "MOVIE_DPU",    Ctrl->C.dim[GMT_Z], 0);
-	gmtlib_set_dvalue (fp, Ctrl->In.mode, "MOVIE_RATE",   Ctrl->D.framerate, 0);
-	if (n_written) gmtlib_set_ivalue (fp, Ctrl->In.mode, false, "MOVIE_NFRAMES", n_data_frames);	/* Total frames (write to init since known) */
+	gmt_set_comment (fp, Ctrl->In.mode, string);
+	gmt_set_dvalue (fp, Ctrl->In.mode, "MOVIE_WIDTH",  Ctrl->C.dim[GMT_X], Ctrl->C.unit);
+	gmt_set_dvalue (fp, Ctrl->In.mode, "MOVIE_HEIGHT", Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
+	gmt_set_dvalue (fp, Ctrl->In.mode, "MOVIE_DPU",    Ctrl->C.dim[GMT_Z], 0);
+	gmt_set_dvalue (fp, Ctrl->In.mode, "MOVIE_RATE",   Ctrl->D.framerate, 0);
+	if (n_written) gmt_set_ivalue (fp, Ctrl->In.mode, false, "MOVIE_NFRAMES", n_data_frames);	/* Total frames (write to init since known) */
 	if (Ctrl->I.active) {	/* Append contents of an include file */
-		gmtlib_set_comment (fp, Ctrl->In.mode, "Static parameters set via user include file");
+		gmt_set_comment (fp, Ctrl->In.mode, "Static parameters set via user include file");
 		while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->I.fp)) {	/* Read the include file and copy to init script with some exceptions */
-			if (gmtlib_is_gmt_module (line, "begin")) continue;		/* Skip gmt begin */
-			if (gmtlib_is_gmt_module (line, "end")) continue;		/* Skip gmt end */
+			if (gmt_is_gmtmodule (line, "begin")) continue;		/* Skip gmt begin */
+			if (gmt_is_gmtmodule (line, "end")) continue;		/* Skip gmt end */
 			if (strstr (line, "#!/")) continue;			/* Skip any leading shell incantation */
 			if (strchr (line, '\n') == NULL) strcat (line, "\n");	/* In case the last line misses a newline */
 			fprintf (fp, "%s", line);				/* Just copy the line as is */
@@ -1325,7 +1329,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			fclose (Ctrl->S[MOVIE_PREFLIGHT].fp);
 		else {	/* Run the preflight script */
 			sprintf (pre_file, "movie_preflight.%s", extension[Ctrl->In.mode]);
-			is_classic = gmtlib_script_is_classic (GMT, Ctrl->S[MOVIE_PREFLIGHT].fp);
+			is_classic = gmt_script_is_classic (GMT, Ctrl->S[MOVIE_PREFLIGHT].fp);
 			if (is_classic) {
 				GMT_Report (API, GMT_MSG_ERROR, "Your preflight file %s is not in GMT modern node - exiting\n", pre_file);
 				fclose (Ctrl->In.fp);
@@ -1337,26 +1341,26 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 				fclose (Ctrl->In.fp);
 				Return (GMT_ERROR_ON_FOPEN);
 			}
-			gmtlib_set_script (fp, Ctrl->In.mode);			/* Write 1st line of a script */
-			gmtlib_set_comment (fp, Ctrl->In.mode, "Preflight script");
+			gmt_set_script (fp, Ctrl->In.mode);			/* Write 1st line of a script */
+			gmt_set_comment (fp, Ctrl->In.mode, "Preflight script");
 			fprintf (fp, "%s", export[Ctrl->In.mode]);		/* Hardwire a Session Name since sub-shells may mess things up */
 			if (Ctrl->In.mode == GMT_DOS_MODE)	/* Set GMT_SESSION_NAME under Windows to 1 since we run this separately first */
 				fprintf (fp, "set GMT_SESSION_NAME=1\n");
 			else	/* On UNIX we may use the calling terminal or script's PID as the GMT_SESSION_NAME */
-				gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
+				gmt_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
 			fprintf (fp, "%s", export[Ctrl->In.mode]);		/* Turn off auto-display of figures if scrip has gmt end show */
-			gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "GMT_END_SHOW", "off");
+			gmt_set_tvalue (fp, Ctrl->In.mode, true, "GMT_END_SHOW", "off");
 			fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 			while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->S[MOVIE_PREFLIGHT].fp)) {	/* Read the background script and copy to preflight script with some exceptions */
-				if (gmtlib_is_gmt_module (line, "begin")) {	/* Need to insert gmt figure after this line (or as first line) in case a background plot will be made */
+				if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert gmt figure after this line (or as first line) in case a background plot will be made */
 					fprintf (fp, "gmt begin\n");	/* To ensure there are no args here since we are using gmt figure instead */
-					gmtlib_set_comment (fp, Ctrl->In.mode, "\tSet fixed background output ps name");
+					gmt_set_comment (fp, Ctrl->In.mode, "\tSet fixed background output ps name");
 					fprintf (fp, "\tgmt figure movie_background ps\n");
 					fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
 					fprintf (fp, "\tgmt set DIR_DATA %s\n", datadir);
 				}
-				else if (!strstr (line, "#!/"))	 {	/* Skip any leading shell incantation since already placed by gmtlib_set_script */
-					if (gmtlib_is_gmt_end_show (line)) sprintf (line, "gmt end\n");		/* Eliminate show from gmt end in this script */
+				else if (!strstr (line, "#!/"))	 {	/* Skip any leading shell incantation since already placed by gmt_set_script */
+					if (gmt_is_gmt_end_show (line)) sprintf (line, "gmt end\n");		/* Eliminate show from gmt end in this script */
 					else if (strchr (line, '\n') == NULL) strcat (line, "\n");	/* In case the last line misses a newline */
 					fprintf (fp, "%s", line);	/* Just copy the line as is */
 				}
@@ -1478,7 +1482,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			fclose (Ctrl->S[MOVIE_POSTFLIGHT].fp);
 		else {	/* Must run postflight script */
 			sprintf (post_file, "movie_postflight.%s", extension[Ctrl->In.mode]);
-			is_classic = gmtlib_script_is_classic (GMT, Ctrl->S[MOVIE_POSTFLIGHT].fp);
+			is_classic = gmt_script_is_classic (GMT, Ctrl->S[MOVIE_POSTFLIGHT].fp);
 			if (is_classic) {
 				GMT_Report (API, GMT_MSG_ERROR, "Your postflight file %s is not in GMT modern node - exiting\n", post_file);
 				fclose (Ctrl->In.fp);
@@ -1490,26 +1494,26 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 				fclose (Ctrl->In.fp);
 				Return (GMT_ERROR_ON_FOPEN);
 			}
-			gmtlib_set_script (fp, Ctrl->In.mode);					/* Write 1st line of a script */
-			gmtlib_set_comment (fp, Ctrl->In.mode, "Postflight script");
+			gmt_set_script (fp, Ctrl->In.mode);					/* Write 1st line of a script */
+			gmt_set_comment (fp, Ctrl->In.mode, "Postflight script");
 			fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Hardwire a SESSION_NAME since sub-shells may mess things up */
 			if (Ctrl->In.mode == GMT_DOS_MODE)	/* Set GMT_SESSION_NAME under Windows to 1 since we run this separately */
 				fprintf (fp, "set GMT_SESSION_NAME=1\n");
 			else	/* On UNIX we may use the script's PID as GMT_SESSION_NAME */
-				gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
+				gmt_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
 			fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Turn off auto-display of figures if scrip has gmt end show */
-			gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "GMT_END_SHOW", "off");
+			gmt_set_tvalue (fp, Ctrl->In.mode, true, "GMT_END_SHOW", "off");
 			fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 			while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->S[MOVIE_POSTFLIGHT].fp)) {	/* Read the foreground script and copy to postflight script with some exceptions */
-				if (gmtlib_is_gmt_module (line, "begin")) {	/* Need to insert gmt figure after this line */
+				if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert gmt figure after this line */
 					fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
-					gmtlib_set_comment (fp, Ctrl->In.mode, "\tSet fixed foreground output ps name");
+					gmt_set_comment (fp, Ctrl->In.mode, "\tSet fixed foreground output ps name");
 					fprintf (fp, "\tgmt figure movie_foreground ps\n");
 					fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
 					fprintf (fp, "\tgmt set DIR_DATA %s\n", datadir);
 				}
 				else if (!strstr (line, "#!/"))	{	/* Skip any leading shell incantation since already placed */
-					if (gmtlib_is_gmt_end_show (line)) sprintf (line, "gmt end\n");		/* Eliminate show from gmt end in this script */
+					if (gmt_is_gmt_end_show (line)) sprintf (line, "gmt end\n");		/* Eliminate show from gmt end in this script */
 					else if (strchr (line, '\n') == NULL) strcat (line, "\n");	/* In case the last line misses a newline */
 					fprintf (fp, "%s", line);	/* Just copy the line as is */
 				}
@@ -1604,16 +1608,16 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 				Return (GMT_ERROR_ON_FOPEN);
 			}
 			sprintf (state_prefix, "Parameter file for pre-frame %s", state_tag);
-			gmtlib_set_comment (fp, Ctrl->In.mode, state_prefix);
+			gmt_set_comment (fp, Ctrl->In.mode, state_prefix);
 			sprintf (state_prefix, "%s_%s", Ctrl->N.prefix, state_tag);
-			gmtlib_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_NAME", state_prefix);	/* Current frame name prefix */
+			gmt_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_NAME", state_prefix);	/* Current frame name prefix */
 			if (i_frame < Ctrl->E.fade[GMT_IN])	/* During title fade-in */
 				fade_level = 50 * (1.0 + cos (M_PI * i_frame / Ctrl->E.fade[GMT_IN]));
 			else if (i_frame > (start = (Ctrl->E.duration -Ctrl->E.fade[GMT_OUT])))	/* During title fade-out */
 				fade_level = 50 * (1.0 - cos (M_PI * (i_frame - start) / Ctrl->E.fade[GMT_OUT]));
 			else /* No fading during main part of title */
 				fade_level = 0.0;
-			gmtlib_set_dvalue (fp, Ctrl->In.mode, "MOVIE_FADE", fade_level, 0);
+			gmt_set_dvalue (fp, Ctrl->In.mode, "MOVIE_FADE", fade_level, 0);
 			fclose (fp);	/* Done writing this parameter file */
 		}
 
@@ -1624,7 +1628,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			fclose (Ctrl->E.fp);
 			Return (GMT_ERROR_ON_FOPEN);
 		}
-		sprintf (extra, "A+n+r+f%s", gmtlib_place_var (Ctrl->In.mode, "MOVIE_FADE"));	/* No cropping, image size is fixed, possibly fading */
+		sprintf (extra, "A+n+r+f%s", gmt_place_var (Ctrl->In.mode, "MOVIE_FADE"));	/* No cropping, image size is fixed, possibly fading */
 		if (Ctrl->E.fill) {strcat (extra, "+g"); strcat (extra, Ctrl->E.fill);}	/* Chose another fade color than black */
 		if (Ctrl->E.PS) {	/* Need to place a background title first (which will be in parent dir when loop script is run) */
 			strcat (extra, ",Mb../../");
@@ -1635,41 +1639,41 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			sprintf (htxt, ",H%d", Ctrl->H.factor);
 			strcat (extra, htxt);
 		}
-		gmtlib_set_script (fp, Ctrl->In.mode);					/* Write 1st line of a script */
-		gmtlib_set_comment (fp, Ctrl->In.mode, "Movie intro frame loop script");
+		gmt_set_script (fp, Ctrl->In.mode);					/* Write 1st line of a script */
+		gmt_set_comment (fp, Ctrl->In.mode, "Movie intro frame loop script");
 		fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Hardwire a GMT_SESSION_NAME since sub-shells may mess things up */
 		if (Ctrl->In.mode == GMT_DOS_MODE)	/* Set GMT_SESSION_NAME under Windows to be the frame number */
 			fprintf (fp, "set GMT_SESSION_NAME=%c1\n", var_token[Ctrl->In.mode]);
 		else	/* On UNIX we use the script's PID as GMT_SESSION_NAME */
-			gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
+			gmt_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
 		fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Turn off auto-display of figures if scrip has gmt end show */
-		gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "GMT_END_SHOW", "off");
-		gmtlib_set_comment (fp, Ctrl->In.mode, "Include static and frame-specific parameters");
+		gmt_set_tvalue (fp, Ctrl->In.mode, true, "GMT_END_SHOW", "off");
+		gmt_set_comment (fp, Ctrl->In.mode, "Include static and frame-specific parameters");
 		fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 		fprintf (fp, "%s movie_params_%c1.%s\n", load[Ctrl->In.mode], var_token[Ctrl->In.mode], extension[Ctrl->In.mode]);	/* Include the frame parameters */
-		fprintf (fp, "mkdir %s\n", gmtlib_place_var (Ctrl->In.mode, "MOVIE_NAME"));	/* Make a temp directory for this frame */
-		fprintf (fp, "cd %s\n", gmtlib_place_var (Ctrl->In.mode, "MOVIE_NAME"));		/* cd to the temp directory */
+		fprintf (fp, "mkdir %s\n", gmt_place_var (Ctrl->In.mode, "MOVIE_NAME"));	/* Make a temp directory for this frame */
+		fprintf (fp, "cd %s\n", gmt_place_var (Ctrl->In.mode, "MOVIE_NAME"));		/* cd to the temp directory */
 		if (Ctrl->E.PS) {	/* There is no title script, just a PS, so we make a dummy script that plots nothing */
 			fclose (Ctrl->E.fp);
 			fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
-			gmtlib_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
+			gmt_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
 			fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c GMT_MAX_CORES 1\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
-			fprintf (fp, "\tgmt figure ../%s %s", gmtlib_place_var (Ctrl->In.mode, "MOVIE_NAME"), frame_products);
-			fprintf (fp, " E%s,%s\n", gmtlib_place_var (Ctrl->In.mode, "MOVIE_DPU"), extra);
+			fprintf (fp, "\tgmt figure ../%s %s", gmt_place_var (Ctrl->In.mode, "MOVIE_NAME"), frame_products);
+			fprintf (fp, " E%s,%s\n", gmt_place_var (Ctrl->In.mode, "MOVIE_DPU"), extra);
 			fprintf (fp, "\tgmt plot -R0/%g/0/%g -Jx1%c -X0 -Y0 -T\n", Ctrl->C.dim[GMT_X], Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
 			fprintf (fp, "gmt end\n");		/* Eliminate show from gmt end in this script */
 		}
 		else {	/* Read the title script */
 			while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->E.fp)) {	/* Read the main script and copy to loop script, with some exceptions */
-				if (gmtlib_is_gmt_module (line, "begin")) {	/* Need to insert a gmt figure call after this line */
+				if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert a gmt figure call after this line */
 					fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
-					gmtlib_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
+					gmt_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
 					fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
-					fprintf (fp, "\tgmt figure ../%s %s", gmtlib_place_var (Ctrl->In.mode, "MOVIE_NAME"), frame_products);
-					fprintf (fp, " E%s,%s\n", gmtlib_place_var (Ctrl->In.mode, "MOVIE_DPU"), extra);
+					fprintf (fp, "\tgmt figure ../%s %s", gmt_place_var (Ctrl->In.mode, "MOVIE_NAME"), frame_products);
+					fprintf (fp, " E%s,%s\n", gmt_place_var (Ctrl->In.mode, "MOVIE_DPU"), extra);
 				}
 				else if (!strstr (line, "#!/")) {		/* Skip any leading shell incantation since already placed */
-					if (gmtlib_is_gmt_end_show (line)) sprintf (line, "gmt end\n");		/* Eliminate show from gmt end in this script */
+					if (gmt_is_gmt_end_show (line)) sprintf (line, "gmt end\n");		/* Eliminate show from gmt end in this script */
 					else if (strchr (line, '\n') == NULL) strcat (line, "\n");	/* In case the last line misses a newline */
 					fprintf (fp, "%s", line);	/* Just copy the line as is */
 				}
@@ -1678,8 +1682,8 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		}
 		fprintf (fp, "cd ..\n");	/* cd up to parent dir */
 		if (!Ctrl->Q.active) {	/* Delete evidence; otherwise we want to leave debug evidence when doing a single frame only */
-			gmtlib_set_comment (fp, Ctrl->In.mode, "Remove frame directory and frame parameter file");
-			fprintf (fp, "%s %s\n", rmdir[Ctrl->In.mode], gmtlib_place_var (Ctrl->In.mode, "MOVIE_NAME"));	/* Remove the work dir and any files in it */
+			gmt_set_comment (fp, Ctrl->In.mode, "Remove frame directory and frame parameter file");
+			fprintf (fp, "%s %s\n", rmdir[Ctrl->In.mode], gmt_place_var (Ctrl->In.mode, "MOVIE_NAME"));	/* Remove the work dir and any files in it */
 			fprintf (fp, "%s movie_params_%c1.%s\n", rmfile[Ctrl->In.mode], var_token[Ctrl->In.mode], extension[Ctrl->In.mode]);	/* Remove the parameter file for this frame */
 		}
 		if (Ctrl->In.mode == GMT_DOS_MODE)	/* This is crucial to the "start /B ..." statement below to ensure the DOS process terminates */
@@ -1720,9 +1724,9 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			Return (GMT_ERROR_ON_FOPEN);
 		}
 		sprintf (state_prefix, "Parameter file for frame %s", state_tag);
-		gmtlib_set_comment (fp, Ctrl->In.mode, state_prefix);
+		gmt_set_comment (fp, Ctrl->In.mode, state_prefix);
 		sprintf (state_prefix, "%s_%s", Ctrl->N.prefix, state_tag);
-		gmtlib_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_NAME", state_prefix);	/* Current frame name prefix */
+		gmt_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_NAME", state_prefix);	/* Current frame name prefix */
 
 		if (Ctrl->K.active) {	/* Must stay on either first or last actual frame repeatedly to fade in/out the first/last true frame plot */
 			if (i_frame < Ctrl->K.fade[GMT_IN]) { /* Must keep fixed first data frame but change fading in */
@@ -1737,24 +1741,24 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 				fade_level = 0.0;	/* No fading */
 				if (Ctrl->K.preserve[GMT_IN]) data_frame = i_frame - Ctrl->K.fade[GMT_IN];
 			}
-			gmtlib_set_dvalue (fp, Ctrl->In.mode, "MOVIE_FADE", fade_level, 0);
+			gmt_set_dvalue (fp, Ctrl->In.mode, "MOVIE_FADE", fade_level, 0);
 		}
 		if (Ctrl->E.active) sprintf (state_tag, "%*.*d", precision, precision, data_frame);	/* Reset frame tag */
-		gmtlib_set_ivalue (fp, Ctrl->In.mode, false, "MOVIE_FRAME", data_frame);		/* Current frame number */
-		if (!n_written) gmtlib_set_ivalue (fp, Ctrl->In.mode, false, "MOVIE_NFRAMES", n_data_frames);	/* Total frames (write here since n_frames was not yet known when init was written) */
-		gmtlib_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_ITEM", state_tag);		/* Current frame tag (formatted frame number) */
+		gmt_set_ivalue (fp, Ctrl->In.mode, false, "MOVIE_FRAME", data_frame);		/* Current frame number */
+		if (!n_written) gmt_set_ivalue (fp, Ctrl->In.mode, false, "MOVIE_NFRAMES", n_data_frames);	/* Total frames (write here since n_frames was not yet known when init was written) */
+		gmt_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_ITEM", state_tag);		/* Current frame tag (formatted frame number) */
 		if (place_background)	/* Need to place a background layer first (which is in parent dir when loop script is run) */
-			gmtlib_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_BACKGROUND", ",Mb../movie_background.ps");		/* Current frame tag (formatted frame number) */
+			gmt_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_BACKGROUND", ",Mb../movie_background.ps");		/* Current frame tag (formatted frame number) */
 		else
-			gmtlib_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_BACKGROUND", "");		/* Nothing */
+			gmt_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_BACKGROUND", "");		/* Nothing */
 		if (Ctrl->F.transparent && Ctrl->A.active) place_background = false;	/* Only place background once if transparent images */
-		gmtlib_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_ITEM", state_tag);		/* Current frame tag (formatted frame number) */
+		gmt_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_ITEM", state_tag);		/* Current frame tag (formatted frame number) */
 		for (col = 0; col < n_values; col++) {	/* Derive frame variables from <timefile> in each parameter file */
 			sprintf (string, "MOVIE_COL%u", col);
-			gmtlib_set_value (GMT, fp, Ctrl->In.mode, col, string, D->table[0]->segment[0]->data[col][data_frame]);
+			gmt_set_value (GMT, fp, Ctrl->In.mode, col, string, D->table[0]->segment[0]->data[col][data_frame]);
 		}
 		if (has_text) {	/* Also place any string parameter as a single string variable */
-			gmtlib_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_TEXT", D->table[0]->segment[0]->text[data_frame]);
+			gmt_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_TEXT", D->table[0]->segment[0]->text[data_frame]);
 			if (Ctrl->T.split) {	/* Also split the string into individual words MOVIE_WORD1, MOVIE_WORD2, etc. */
 				char *word = NULL, *trail = NULL, *orig = strdup (D->table[0]->segment[0]->text[data_frame]);
 				col = 0;
@@ -1762,7 +1766,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 				while ((word = strsep (&trail, " \t")) != NULL) {
 					if (*word != '\0') {	/* Skip empty strings */
 						sprintf (string, "MOVIE_WORD%u", col++);
-						gmtlib_set_tvalue (fp, Ctrl->In.mode, false, string, word);
+						gmt_set_tvalue (fp, Ctrl->In.mode, false, string, word);
 					}
 				}
 				gmt_M_str_free (orig);
@@ -1779,7 +1783,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 				/* Note: All dimensions are written in inches and read as inches in gmt_plotinit */
 				fprintf (fp, "%s", export[Ctrl->In.mode]);
 				sprintf (name, "MOVIE_N_%sS", LP_name[k]);
-				gmtlib_set_ivalue (fp, Ctrl->In.mode, true, name, Ctrl->n_items[k]);
+				gmt_set_ivalue (fp, Ctrl->In.mode, true, name, Ctrl->n_items[k]);
 				for (T = 0; T < Ctrl->n_items[k]; T++) {
 					t = (frame + 1.0) / n_frames;
 					I = &Ctrl->item[k][T];	/* Shorthand for this item */
@@ -1875,7 +1879,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 					if (I->kind == 'F') strcat (label, "/0/1");
 					/* Set MOVIE_{LABEL|PROG_INDICATOR}_ARG# as exported environmental variable. gmt figure will check for this and if found create gmt.movie{label|prog_indicator}s in session directory */
 					fprintf (fp, "%s", export[Ctrl->In.mode]);
-					gmtlib_set_tvalue (fp, Ctrl->In.mode, true, name, label);
+					gmt_set_tvalue (fp, Ctrl->In.mode, true, name, label);
 				}
 			}
 			spacer = 'T';	/* For ISO time stamp as used in -R */
@@ -1901,10 +1905,10 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 				fade_level = 50 * (1.0 - cos (M_PI * (Ctrl->M.frame - start) / Ctrl->E.fade[GMT_OUT]));
 			else /* No fading during main part of title */
 				fade_level = 0.0;
-			gmtlib_set_dvalue (fp, Ctrl->In.mode, "MOVIE_FADE", fade_level, 0);
+			gmt_set_dvalue (fp, Ctrl->In.mode, "MOVIE_FADE", fade_level, 0);
 		}
 		else if (Ctrl->K.active) {
-			sprintf (extra, "A+n+r+f%s", gmtlib_place_var (Ctrl->In.mode, "MOVIE_FADE"));	/* No cropping, image size is fixed, but fading may be in effect for some frames */
+			sprintf (extra, "A+n+r+f%s", gmt_place_var (Ctrl->In.mode, "MOVIE_FADE"));	/* No cropping, image size is fixed, but fading may be in effect for some frames */
 			if (Ctrl->K.fill) {strcat (extra, "+g"); strcat (extra, Ctrl->K.fill);}	/* Chose another fade color than black */
 		}
 		else
@@ -1937,14 +1941,14 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			sprintf (line, ",H%d", Ctrl->H.factor);
 			strncat (extra, line, GMT_LEN128);
 		}
-		gmtlib_set_script (fp, Ctrl->In.mode);					/* Write 1st line of a script */
-		gmtlib_set_comment (fp, Ctrl->In.mode, "Master frame loop script");
+		gmt_set_script (fp, Ctrl->In.mode);					/* Write 1st line of a script */
+		gmt_set_comment (fp, Ctrl->In.mode, "Master frame loop script");
 		fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Hardwire a GMT_SESSION_NAME since sub-shells may mess things up */
 		if (Ctrl->In.mode == GMT_DOS_MODE)	/* Set GMT_SESSION_NAME under Windows to be the frame number */
 			fprintf (fp, "set GMT_SESSION_NAME=%c1\n", var_token[Ctrl->In.mode]);
 		else	/* On UNIX we use the script's PID as GMT_SESSION_NAME */
-			gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
-		gmtlib_set_comment (fp, Ctrl->In.mode, "Include static and frame-specific parameters");
+			gmt_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
+		gmt_set_comment (fp, Ctrl->In.mode, "Include static and frame-specific parameters");
 		fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 		fprintf (fp, "%s movie_params_%c1.%s\n", load[Ctrl->In.mode], var_token[Ctrl->In.mode], extension[Ctrl->In.mode]);	/* Include the frame parameters */
 		fprintf (fp, "mkdir master\n");	/* Make a temp directory for this frame */
@@ -1952,29 +1956,29 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		if (is_title) {	/* Process title page script or PS */
 			if (Ctrl->E.PS) {	/* There is no title script, just a PS, so we make a dummy script that plots nothing */
 				fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
-				gmtlib_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
+				gmt_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
 				fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
 				fprintf (fp, "\tgmt figure %s %s", Ctrl->N.prefix, Ctrl->M.format);
 				fprintf (fp, " %s", extra);
 				if (strstr (Ctrl->M.format, "pdf") || strstr (Ctrl->M.format, "eps") || strstr (Ctrl->M.format, "ps"))
 					fprintf (fp, "\n");	/* No dpu needed */
 				else
-					fprintf (fp, ",E%s\n", gmtlib_place_var (Ctrl->In.mode, "MOVIE_DPU"));
+					fprintf (fp, ",E%s\n", gmt_place_var (Ctrl->In.mode, "MOVIE_DPU"));
 				fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c DIR_DATA %s\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit, datadir);
 				fprintf (fp, "\tgmt plot -R0/%g/0/%g -Jx1%c -X0 -Y0 -T\n", Ctrl->C.dim[GMT_X], Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
 				fprintf (fp, "gmt end\n");		/* Eliminate show from gmt end in this script */
 			}
 			else {	/* Read the title script */
 				while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->E.fp)) {	/* Read the main script and copy to loop script, with some exceptions */
-					if (gmtlib_is_gmt_module (line, "begin")) {	/* Need to insert a gmt figure call after this line */
+					if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert a gmt figure call after this line */
 						fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
-						gmtlib_set_comment (fp, Ctrl->In.mode, "\tSet output name and plot conversion parameters");
+						gmt_set_comment (fp, Ctrl->In.mode, "\tSet output name and plot conversion parameters");
 						fprintf (fp, "\tgmt figure %s %s", Ctrl->N.prefix, Ctrl->M.format);
 						fprintf (fp, " %s", extra);
 						if (strstr (Ctrl->M.format, "pdf") || strstr (Ctrl->M.format, "eps") || strstr (Ctrl->M.format, "ps"))
 							fprintf (fp, "\n");	/* No dpu needed */
 						else
-							fprintf (fp, ",E%s\n", gmtlib_place_var (Ctrl->In.mode, "MOVIE_DPU"));
+							fprintf (fp, ",E%s\n", gmt_place_var (Ctrl->In.mode, "MOVIE_DPU"));
 						fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c DIR_DATA %s\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit, datadir);
 					}
 					else if (!strstr (line, "#!/")) {		/* Skip any leading shell incantation since already placed */
@@ -1987,15 +1991,15 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		}
 		else {	/* Process main script */
 			while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->In.fp)) {	/* Read the mainscript and copy to loop script, with some exceptions */
-				if (gmtlib_is_gmt_module (line, "begin")) {	/* Need to insert a gmt figure call after this line */
+				if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert a gmt figure call after this line */
 					fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
-					gmtlib_set_comment (fp, Ctrl->In.mode, "\tSet output name and plot conversion parameters");
+					gmt_set_comment (fp, Ctrl->In.mode, "\tSet output name and plot conversion parameters");
 					fprintf (fp, "\tgmt figure %s %s", Ctrl->N.prefix, Ctrl->M.format);
 					fprintf (fp, " %s", extra);
 					if (strstr (Ctrl->M.format, "pdf") || strstr (Ctrl->M.format, "eps") || strstr (Ctrl->M.format, "ps"))
 						fprintf (fp, "\n");	/* No dpu needed */
 					else
-						fprintf (fp, ",E%s\n", gmtlib_place_var (Ctrl->In.mode, "MOVIE_DPU"));
+						fprintf (fp, ",E%s\n", gmt_place_var (Ctrl->In.mode, "MOVIE_DPU"));
 					fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c DIR_DATA %s\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit, datadir);
 				}
 				else if (!strstr (line, "#!/"))	{	/* Skip any leading shell incantation since already placed */
@@ -2005,11 +2009,11 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			}
 			rewind (Ctrl->In.fp);	/* Get ready for main_frame reading */
 		}
-		gmtlib_set_comment (fp, Ctrl->In.mode, "Move master file up to top directory and cd up one level");
+		gmt_set_comment (fp, Ctrl->In.mode, "Move master file up to top directory and cd up one level");
 		fprintf (fp, "%s %s.%s %s\n", mvfile[Ctrl->In.mode], Ctrl->N.prefix, Ctrl->M.format, topdir);	/* Move master plot up to top dir */
 		fprintf (fp, "cd ..\n");	/* cd up to workdir */
 		if (!Ctrl->Q.active) {	/* Remove the work dir and any files in it */
-			gmtlib_set_comment (fp, Ctrl->In.mode, "Remove frame directory");
+			gmt_set_comment (fp, Ctrl->In.mode, "Remove frame directory");
 			fprintf (fp, "%s master\n", rmdir[Ctrl->In.mode]);
 		}
 		fclose (fp);	/* Done writing loop script */
@@ -2070,7 +2074,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		Return (GMT_ERROR_ON_FOPEN);
 	}
 	if (Ctrl->K.active) {
-		sprintf (extra, "A+n+r+f%s", gmtlib_place_var (Ctrl->In.mode, "MOVIE_FADE"));	/* No cropping, image size is fixed, but fading may be in effect for some frames */
+		sprintf (extra, "A+n+r+f%s", gmt_place_var (Ctrl->In.mode, "MOVIE_FADE"));	/* No cropping, image size is fixed, but fading may be in effect for some frames */
 		if (Ctrl->K.fill) {strcat (extra, "+g"); strcat (extra, Ctrl->K.fill);}	/* Chose another fade color than black */
 	}
 	else
@@ -2099,31 +2103,31 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		sprintf (htxt, ",H%d", Ctrl->H.factor);
 		strcat (extra, htxt);
 	}
-	gmtlib_set_script (fp, Ctrl->In.mode);					/* Write 1st line of a script */
-	gmtlib_set_comment (fp, Ctrl->In.mode, "Main frame loop script");
+	gmt_set_script (fp, Ctrl->In.mode);					/* Write 1st line of a script */
+	gmt_set_comment (fp, Ctrl->In.mode, "Main frame loop script");
 	fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Hardwire a GMT_SESSION_NAME since sub-shells may mess things up */
 	if (Ctrl->In.mode == GMT_DOS_MODE)	/* Set GMT_SESSION_NAME under Windows to be the frame number */
 		fprintf (fp, "set GMT_SESSION_NAME=%c1\n", var_token[Ctrl->In.mode]);
 	else	/* On UNIX we use the script's PID as GMT_SESSION_NAME */
-		gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
+		gmt_set_tvalue (fp, Ctrl->In.mode, true, "GMT_SESSION_NAME", "$$");
 	fprintf (fp, "%s", export[Ctrl->In.mode]);			/* Turn off auto-display of figures if script has gmt end show */
-	gmtlib_set_tvalue (fp, Ctrl->In.mode, true, "GMT_END_SHOW", "off");
-	gmtlib_set_comment (fp, Ctrl->In.mode, "Include static and frame-specific parameters");
+	gmt_set_tvalue (fp, Ctrl->In.mode, true, "GMT_END_SHOW", "off");
+	gmt_set_comment (fp, Ctrl->In.mode, "Include static and frame-specific parameters");
 	fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 	fprintf (fp, "%s movie_params_%c1.%s\n", load[Ctrl->In.mode], var_token[Ctrl->In.mode], extension[Ctrl->In.mode]);	/* Include the frame parameters */
-	fprintf (fp, "mkdir %s\n", gmtlib_place_var (Ctrl->In.mode, "MOVIE_NAME"));	/* Make a temp directory for this frame */
-	fprintf (fp, "cd %s\n", gmtlib_place_var (Ctrl->In.mode, "MOVIE_NAME"));		/* cd to the temp directory */
+	fprintf (fp, "mkdir %s\n", gmt_place_var (Ctrl->In.mode, "MOVIE_NAME"));	/* Make a temp directory for this frame */
+	fprintf (fp, "cd %s\n", gmt_place_var (Ctrl->In.mode, "MOVIE_NAME"));		/* cd to the temp directory */
 	while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->In.fp)) {	/* Read the main script and copy to loop script, with some exceptions */
-		if (gmtlib_is_gmt_module (line, "begin")) {	/* Need to insert a gmt figure call after this line */
+		if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert a gmt figure call after this line */
 			fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
-			gmtlib_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
-			fprintf (fp, "\tgmt figure ../%s %s", gmtlib_place_var (Ctrl->In.mode, "MOVIE_NAME"), frame_products);
-			fprintf (fp, " E%s,%s", gmtlib_place_var (Ctrl->In.mode, "MOVIE_DPU"), extra);
-			fprintf (fp, "%s\n", gmtlib_place_var (Ctrl->In.mode, "MOVIE_BACKGROUND"));
+			gmt_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
+			fprintf (fp, "\tgmt figure ../%s %s", gmt_place_var (Ctrl->In.mode, "MOVIE_NAME"), frame_products);
+			fprintf (fp, " E%s,%s", gmt_place_var (Ctrl->In.mode, "MOVIE_DPU"), extra);
+			fprintf (fp, "%s\n", gmt_place_var (Ctrl->In.mode, "MOVIE_BACKGROUND"));
 			fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c DIR_DATA %s GMT_MAX_CORES 1\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit, datadir);
 		}
 		else if (!strstr (line, "#!/")) {		/* Skip any leading shell incantation since already placed */
-			if (gmtlib_is_gmt_end_show (line)) sprintf (line, "gmt end\n");		/* Eliminate show from gmt end in this script */
+			if (gmt_is_gmt_end_show (line)) sprintf (line, "gmt end\n");		/* Eliminate show from gmt end in this script */
 			else if (strchr (line, '\n') == NULL) strcat (line, "\n");	/* In case the last line misses a newline */
 			fprintf (fp, "%s", line);	/* Just copy the line as is */
 		}
@@ -2131,8 +2135,8 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	fclose (Ctrl->In.fp);	/* Done reading the main script */
 	fprintf (fp, "cd ..\n");	/* cd up to parent dir */
 	if (!Ctrl->Q.active) {	/* Delete evidence; otherwise we want to leave debug evidence when doing a single frame only */
-		gmtlib_set_comment (fp, Ctrl->In.mode, "Remove frame directory and frame parameter file");
-		fprintf (fp, "%s %s\n", rmdir[Ctrl->In.mode], gmtlib_place_var (Ctrl->In.mode, "MOVIE_NAME"));	/* Remove the work dir and any files in it */
+		gmt_set_comment (fp, Ctrl->In.mode, "Remove frame directory and frame parameter file");
+		fprintf (fp, "%s %s\n", rmdir[Ctrl->In.mode], gmt_place_var (Ctrl->In.mode, "MOVIE_NAME"));	/* Remove the work dir and any files in it */
 		fprintf (fp, "%s movie_params_%c1.%s\n", rmfile[Ctrl->In.mode], var_token[Ctrl->In.mode], extension[Ctrl->In.mode]);	/* Remove the parameter file for this frame */
 	}
 	if (Ctrl->In.mode == GMT_DOS_MODE)	/* This is crucial to the "start /B ..." statement below to ensure the DOS process terminates */
@@ -2188,7 +2192,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			if (Ctrl->E.active && frame == Ctrl->E.duration)	/* Past the title intro, now point to main script */
 				script_file = main_file;
 		}
-		gmtlib_gmt_sleep (MOVIE_WAIT_TO_CHECK);	/* Wait 0.01 second - then check for completion of the PNG images */
+		gmt_sleep (MOVIE_WAIT_TO_CHECK);	/* Wait 0.01 second - then check for completion of the PNG images */
 		for (k = first_frame; k < i_frame; k++) {	/* Only loop over the range of frames that we know are currently in play */
 			if (status[k].completed) continue;	/* Already finished with this frame */
 			if (!status[k].started) continue;	/* Not started this frame yet */
@@ -2236,7 +2240,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 				strcat (files, "0");
 		}
 		sprintf (cmd, "gm convert -delay %u -loop %u +dither %s%c%s_%s.%s %s.gif", delay, Ctrl->A.loops, workdir, dir_sep, Ctrl->N.prefix, files, MOVIE_RASTER_EXTENSION, Ctrl->N.prefix);
-		gmtlib_gmt_sleep (MOVIE_PAUSE_A_SEC);	/* Wait 1 second to ensure all files are synced before building the movie */
+		gmt_sleep (MOVIE_PAUSE_A_SEC);	/* Wait 1 second to ensure all files are synced before building the movie */
 		GMT_Report (API, GMT_MSG_INFORMATION, "Running: %s\n", cmd);
 		if ((error = system (cmd))) {
 			GMT_Report (API, GMT_MSG_ERROR, "Running GIF conversion returned error %d - exiting.\n", error);
@@ -2258,7 +2262,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		sprintf (png_file, "%%0%dd", precision);
 		sprintf (cmd, "ffmpeg -loglevel %s -f image2 -framerate %g -y -i \"%s%c%s_%s.%s\" -vcodec libx264 %s -pix_fmt yuv420p %s.mp4",
 			extra, Ctrl->D.framerate, workdir, dir_sep, Ctrl->N.prefix, png_file, MOVIE_RASTER_EXTENSION, (Ctrl->F.options[MOVIE_MP4]) ? Ctrl->F.options[MOVIE_MP4] : "", Ctrl->N.prefix);
-		gmtlib_gmt_sleep (MOVIE_PAUSE_A_SEC);	/* Wait 1 second to ensure all files are synced before building the movie */
+		gmt_sleep (MOVIE_PAUSE_A_SEC);	/* Wait 1 second to ensure all files are synced before building the movie */
 		GMT_Report (API, GMT_MSG_INFORMATION, "Running: %s\n", cmd);
 		if ((error = system (cmd))) {
 			GMT_Report (API, GMT_MSG_ERROR, "Running FFmpeg conversion to MP4 returned error %d - exiting.\n", error);
@@ -2281,7 +2285,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		sprintf (cmd, "ffmpeg -loglevel %s -f image2 -framerate %g -y -i \"%s%c%s_%s.%s\" -vcodec %s %s -pix_fmt %s %s.webm",
 			extra, Ctrl->D.framerate, workdir, dir_sep, Ctrl->N.prefix, png_file, MOVIE_RASTER_EXTENSION, vpx[Ctrl->F.transparent],
 			(Ctrl->F.options[MOVIE_WEBM]) ? Ctrl->F.options[MOVIE_WEBM] : "", pix_fmt[Ctrl->F.transparent], Ctrl->N.prefix);
-		gmtlib_gmt_sleep (MOVIE_PAUSE_A_SEC);	/* Wait 1 second to ensure all files are synced before building the movie */
+		gmt_sleep (MOVIE_PAUSE_A_SEC);	/* Wait 1 second to ensure all files are synced before building the movie */
 		GMT_Report (API, GMT_MSG_INFORMATION, "Running: %s\n", cmd);
 		if ((error = system (cmd))) {
 			GMT_Report (API, GMT_MSG_ERROR, "Running FFmpeg conversion to webM returned error %d - exiting.\n", error);
@@ -2296,9 +2300,9 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		GMT_Report (API, GMT_MSG_ERROR, "Unable to create cleanup file %s - exiting\n", cleanup_file);
 		Return (GMT_ERROR_ON_FOPEN);
 	}
-	gmtlib_set_script (fp, Ctrl->In.mode);		/* Write 1st line of a script */
+	gmt_set_script (fp, Ctrl->In.mode);		/* Write 1st line of a script */
 	if (Ctrl->Z.active) {	/* Want to delete the entire frame directory */
-		gmtlib_set_comment (fp, Ctrl->In.mode, "Cleanup script removes working directory with frame files");
+		gmt_set_comment (fp, Ctrl->In.mode, "Cleanup script removes working directory with frame files");
 		fprintf (fp, "%s %s\n", rmdir[Ctrl->In.mode], workdir);	/* Delete the entire working directory with PNG frames and tmp files */
 	}
 	else {	/* Just delete the remaining scripts and PS files */


### PR DESCRIPTION
All the **MOVIE_*** or **BATCH_*** script variables must have a leading $ or % to actually give a value.  It is pretty simple to forget to do so, and then you just have a random text in your script.  Now, both batch and movie looks for that. We also recogonize the deprecated ways to do a sub-shell (`...`) and recommend $(...) instead.
Finally, the common functions used by both batch and move were incorrectly named _gmtlib_.  They need to be _gmt__* per our convention.
