### PR TITLE
doc: Add reST math instructions to the reST cheatsheet

### DIFF
--- a/doc/rst/source/rst-cheatsheet.rst_
+++ b/doc/rst/source/rst-cheatsheet.rst_
@@ -140,7 +140,7 @@ Math
 
 reST also supports LaTeX-style math.
 
-This is a inline math :math:`x^2+y^2=z^2`.
+This is an inline math :math:`x^2+y^2=z^2`.
 
 For long equations, use the ``math`` directive:
 

--- a/doc/rst/source/rst-cheatsheet.rst_
+++ b/doc/rst/source/rst-cheatsheet.rst_
@@ -113,6 +113,7 @@ Link to a GMT parameter :term:`FONT_TITLE`.
 
 
 
+
 Codes
 =====
 
@@ -131,3 +132,18 @@ Use the ``figure`` directive to include images:
    :width: 90%
 
    Figure caption
+
+
+
+Math
+====
+
+reST also supports LaTeX-style math.
+
+This is a inline math :math:`x^2+y^2=z^2`.
+
+For long equations, use the ``math`` directive:
+
+.. math::
+
+   \gamma = \sqrt{(\alpha^2 + \beta^2)}


### PR DESCRIPTION
reST cheatsheet for adding math into the documentation.

screenshot:

![image](https://user-images.githubusercontent.com/3974108/82271817-d8116300-9946-11ea-97ad-b1211acc64b5.png)
