### PR TITLE
doc: Update conda install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -276,9 +276,6 @@ You can use the [conda package manager](https://conda.io/) that comes with the
    conda install gmt -c conda-forge
    ```
 
-   NOTE: Currently conda-forge doesn't provide graphicsmagick on win-64 platform.
-   Windows users need to download and install graphicsmagick separately.
-
 3. If you want to install GMT 5, use:
 
    ```


### PR DESCRIPTION
conda now provides graphicsmagick for win64, and the gmt package was
just rebuilt with graphicsmagick as a runtime dependency.