### PR TITLE
grdinfo -C now also includes registration

### DIFF
--- a/doc/rst/source/grdinfo.rst
+++ b/doc/rst/source/grdinfo.rst
@@ -59,7 +59,8 @@ Optional Arguments
     output only if the corresponding options **-M**, **-L1**, **-L2**,
     and **-M** are used, respectively. Use **-Ct** to place file *name*
     at the end of the output record or **-Cn** to only output numerical
-    columns.  If the **-I** option is used, the
+    columns.  The *registration* is either 0 (gridline) or 1 (pixel).
+    If the **-I** option is used, the
     output format is instead *NF w e s n z0 z1*, where *NF* is the total
     number of grids read and *w e s n* are rounded off (see **-I**).
 

--- a/doc/rst/source/grdinfo.rst
+++ b/doc/rst/source/grdinfo.rst
@@ -55,7 +55,7 @@ Optional Arguments
 **-C**\ [**n**\|\ **t**\]
     Formats the report using tab-separated fields on a single line. The
     output is *name w e s n z0 z1 dx dy nx ny*\ [ *x0 y0 x1 y1* ] [ *med
-    scale* ] [*mean std rms*] [*n\_nan*]. The data in brackets are
+    scale* ] [*mean std rms*] [*n\_nan*] *registration*. The data in brackets are
     output only if the corresponding options **-M**, **-L1**, **-L2**,
     and **-M** are used, respectively. Use **-Ct** to place file *name*
     at the end of the output record or **-Cn** to only output numerical

--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -114,7 +114,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t<grid> may be one or more grid files.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Format report in fields on a single line using the format\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   <file w e s n z0 z1 dx dy n_columns n_rows [x0 y0 x1 y1] [med L1scale] [mean std rms] [n_nan] [mode LMSscale]>,\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   <file w e s n z0 z1 dx dy n_columns n_rows [x0 y0 x1 y1] [med L1scale] [mean std rms] [n_nan] [mode LMSscale] registration>,\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   where -M adds [x0 y0 x1 y1] and [n_nan], -L1 adds [median L1scale], -L2 adds [mean std rms],\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   and -Lp adds [mode LMSscale]).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use -Ct to place <file> at the end of the output record, or -Cn to write only numerical columns.\n");
@@ -478,7 +478,7 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 
 	double x_min = 0.0, y_min = 0.0, z_min = 0.0, x_max = 0.0, y_max = 0.0, z_max = 0.0, wesn[4];
 	double global_xmin, global_xmax, global_ymin, global_ymax, global_zmin, global_zmax;
-	double z_mean = 0.0, z_median = 0.0, z_mode = 0.0, z_stdev = 0.0, z_scale = 0.0, z_lmsscl = 0.0, z_rms = 0.0, out[22];
+	double z_mean = 0.0, z_median = 0.0, z_mode = 0.0, z_stdev = 0.0, z_scale = 0.0, z_lmsscl = 0.0, z_rms = 0.0, out[23];
 
 	char format[GMT_BUFSIZ] = {""}, text[GMT_LEN512] = {""}, record[GMT_BUFSIZ] = {""}, grdfile[PATH_MAX] = {""};
 	char *type[2] = { "Gridline", "Pixel"}, *sep = NULL, *projStr = NULL, *answer[2] = {"", " no"};
@@ -533,6 +533,7 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 			if (Ctrl->L.norm & 1) n_cols += 2;	/* Add median scale */
 			if (Ctrl->L.norm & 2) n_cols += 3;	/* Add mean stdev rms */
 			if (Ctrl->L.norm & 4) n_cols += 2;	/* Add mode lmsscale */
+			n_cols ++;		/* Add registration */
 		}
 		if (Ctrl->C.mode == GRDINFO_NUMERICAL) cmode = GMT_COL_FIX_NO_TEXT;
 		geometry = GMT_IS_NONE;
@@ -789,6 +790,7 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 				if (Ctrl->L.norm & 4) {
 					out[col++] = z_mode;	out[col++] = z_lmsscl;
 				}
+				out[col++] = G->header->registration;
 				if (Ctrl->C.mode == GRDINFO_TRAILING)
 					sprintf (record, "%s", HH->name);
 				GMT_Put_Record (API, GMT_WRITE_DATA, Out);
@@ -840,6 +842,7 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 					strcat (record, sep);	gmt_ascii_format_col (GMT, text, z_mode,   GMT_OUT, GMT_Z);	strcat (record, text);
 					strcat (record, sep);	gmt_ascii_format_col (GMT, text, z_lmsscl, GMT_OUT, GMT_Z);	strcat (record, text);
 				}
+				strcat (record, sep);	gmt_ascii_format_col (GMT, text, (double)G->header->registration, GMT_OUT, GMT_Z);	strcat (record, text);
 				if (Ctrl->C.mode == GRDINFO_TRAILING) { sprintf (text, "%s%s", sep, HH->name);	strcat (record, text); }
 				GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 			}


### PR DESCRIPTION
For whatever reason, while `grdinfo t.grd` reports a line about the node registration, there was no such item when we asked for a numerical record via **-C**.  So no way of easily determining if a grid is pixel or gridline in a script, other than grepping on the text output.  Because the order of outputs was set a long time ago, this PR just adds the missing registration (0 = gridline, 1 = pixel) as the very last item of the record.
