### PR TITLE
Fix GMT_LIBDIR_RELATIVE for Windows

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -33,7 +33,11 @@
 
 /* path to executables/libs */
 #define GMT_BINDIR_RELATIVE "@GMT_BINDIR@"
-#define GMT_LIBDIR_RELATIVE "@GMT_LIBDIR@"
+#ifndef WIN32
+    #define GMT_LIBDIR_RELATIVE "@GMT_LIBDIR@"
+#else
+    #define GMT_LIBDIR_RELATIVE "@GMT_BINDIR@"
+#endif
 
 /* path to shared files */
 #define GMT_SHARE_DIR "@CMAKE_INSTALL_PREFIX@/@GMT_DATADIR@"


### PR DESCRIPTION
On Windows, the gmt.dll is located in the `bin` directory, instead of
the usual `lib` directory. Thus, for windows, we need to set
`GMT_LIBDIR_RELATIVE` to `bin`.

Closes #3353.