### PR TITLE
Finalize auto-legend -l modifiers

### DIFF
--- a/doc/examples/ex07/ex07.sh
+++ b/doc/examples/ex07/ex07.sh
@@ -7,7 +7,7 @@
 gmt begin ex07
 	gmt coast -R-50/0/-10/20 -JM24c -Slightblue -GP26+r300+ftan+bdarkbrown -Dl -Wthinnest -B --FORMAT_GEO_MAP=dddF
 	gmt plot @fz_07.txt -Wthinner,-
-	gmt plot @quakes_07.txt -h1 -Scc -i0,1,2+s0.025 -Gred -Wthinnest -l"ISC Earthquakes"+s0.2c
+	gmt plot @quakes_07.txt -h1 -Scc -i0,1,2+s0.025 -Gred -Wthinnest -l"ISC Earthquakes"+S0.2c
 	gmt plot @isochron_07.txt -Wthin,blue
 	gmt plot @ridge_07.txt -Wthicker,orange
 	gmt legend -DjTR+o0.5c -F+pthick+ithinner+gwhite --FONT_ANNOT_PRIMARY=18p,Times-Italic

--- a/doc/rst/source/auto_legend_info.rst_
+++ b/doc/rst/source/auto_legend_info.rst_
@@ -5,5 +5,4 @@ This module allows you to use the **-l** option to specify an automatic legend e
 This option is available for lines or symbols only.  If there is no size specified
 (which is always true for lines) or if the symbol size is computed from other information
 (which may be true for some symbols deriving size from other input columns), then you need
-to supply a legend size (i.e., length of a line symbol) via the **+s** modifier.
-
+to supply a legend size (i.e., length of a line symbol) via the **+S** modifier.

--- a/doc/rst/source/explain_-l.rst_
+++ b/doc/rst/source/explain_-l.rst_
@@ -1,2 +1,2 @@
-**-l**\ [*label*]\ [**+d**\ *pen*][**+f**\ *font*][**+g**\ *gap*][**+h**\ *header*][**+j**\ *just*][**+l**\ [*code*/]\ *txt*][**+n**\ *cols*][**+s**\ *size*][**+v**\ [*pen*]][**+w**\ *width*][**+x**\ *scale*] :ref:`(more ...) <-l_full>`
+**-l**\ [*label*]\ [**+D**\ *pen*][**+G**\ *gap*][**+H**\ *header*][**+L**\ [*code*/]\ *txt*][**+N**\ *cols*][**+S**\ *size*][**+V**\ [*pen*]][**+f**\ *font*][**+g**\ *fill*][**+j**\ *just*][**+o**\ *off*][**+p**\ *pen*][**+s**\ *scale*][**+w**\ *width*] :ref:`(more ...) <-l_full>`
     Add a legend entry for the symbol or line being plotted. |Add_-l|

--- a/doc/rst/source/explain_-l_full.rst_
+++ b/doc/rst/source/explain_-l_full.rst_
@@ -7,7 +7,7 @@
     when :doc:`legend` is called): Use **+D** to draw a horizontal line before the
     legend entry is placed [no line], **+G** to add some vertical space [0],
     **+H** to add a legend header [no header], **+L** to set a line text; prepend
-    a horizontal justification code **L**, **C**, or **R** [**C**], **+B**
+    a horizontal justification code **L**, **C**, or **R** [**C**], **+N**
     to change the number of columns used to set the following legend items [1],
     **+S** to override the size of the current symbol for the legend or set a
     length if plotting a line or contour [same as plotted], and

--- a/doc/rst/source/explain_-l_full.rst_
+++ b/doc/rst/source/explain_-l_full.rst_
@@ -1,24 +1,31 @@
 .. _-l_full:
 
-**-l**\ [*label*]\ [**+d**\ *pen*][**+f**\ *font*][**+g**\ *gap*][**+h**\ *header*][**+j**\ *just*][**+l**\ [*code*/]\ *txt*][**+n**\ *cols*][**+s**\ *size*][**+v**\ [*pen*]][**+w**\ *width*][**+x**\ *scale*]
+**-l**\ [*label*]\ [**+D**\ *pen*][**+G**\ *gap*][**+H**\ *header*][**+L**\ [*code*/]\ *txt*][**+N**\ *cols*][**+S**\ *size*][**+V**\ [*pen*]][**+f**\ *font*][**+g**\ *fill*][**+j**\ *just*][**+o**\ *off*][**+p**\ *pen*][**+s**\ *scale*][**+w**\ *width*]
     Add a map legend entry to the session legend information file for the
     current plot.  Optionally append a text *label* to describe the entry.
     Several modifiers allow further changes to the legend (to be built
-    when :doc:`legend` is called): Use **+d** to draw a horizontal line before the
-    legend entry is placed [no line], **+f** to set the font used for the legend header [:term:`FONT_TITLE`],
-    **+g** to add some vertical space [0], **+h** to add a legend header [no header],
-    **+j** to set placement of the legend [TR], **+l** to set a line text; prepend
-    a horizontal justification code **L**, **C**, or **R** [**C**], **+n** to change the number of columns used to
-    set the following legend items [1], **+s** to override the size of the
-    current symbol for the legend or set a length if plotting a line or contour [same as plotted],
-    **+v** to start and **+v**\ *pen* to stop drawing vertical line from
-    previous to current horizontal line [no vertical line], **+w** to set legend width [auto],
-    and **+x**\ *scale* to resize all symbol and length sizes in the legend.  Default pen is
-    given by :term:`MAP_DEFAULT_PEN`.  Note that **+h**, **+j**, **+w**, and **+x**
-    will only take effect if appended to the very first **-l** option for a plot.  The **+n** modifier,
+    when :doc:`legend` is called): Use **+D** to draw a horizontal line before the
+    legend entry is placed [no line], **+G** to add some vertical space [0],
+    **+H** to add a legend header [no header], **+L** to set a line text; prepend
+    a horizontal justification code **L**, **C**, or **R** [**C**], **+B**
+    to change the number of columns used to set the following legend items [1],
+    **+S** to override the size of the current symbol for the legend or set a
+    length if plotting a line or contour [same as plotted], and
+    **+V** to start and **+v**\ *pen* to stop drawing vertical line from
+    previous to current horizontal line [no vertical line].  In addition, several
+    lower-case modifiers can be set to affect the legend: Use
+    **+f** to set the font used for the legend header [:term:`FONT_TITLE`],
+    **+g** to set the fill used for the legend frame [white],
+    **+j** to set placement of the legend [TR],
+    **+o** to set the offset from legend frame to anchor point [0.2c],
+    **+p** to set the pen used for the legend frame [1p],
+    **+s**\ *scale* to resize all symbol and length sizes in the legend, and
+    **+w**\ *width* to set legend frame width [auto].
+    Default pen is given by :term:`MAP_DEFAULT_PEN`.
+    Note that **+H**, **+g**, **+j**, **+o**, **+p**, **+w**, and **+s**
+    will only take effect if appended to the very first **-l** option for a plot.  The **+N** modifier,
     if appended to the first **-l** option, affects the legend width (unless set via **+w**); otherwise it
     just subdivides the available width among the specified columns.
-    The automatic legend has a fixed white background with a solid black pen outline and offset 0.2 cm from the map frame.
-    The modifiers largely reflect legend codes described in :doc:`legend`, which provide more details and
+    The upper-case modifiers reflect legend codes described in :doc:`legend`, which provide more details and
     customization.  If **legend** is not called explicitly we will call it implicitly when finishing the plot
     via :doc:`end`.

--- a/doc/scripts/GMT_autolegend.sh
+++ b/doc/scripts/GMT_autolegend.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 gmt begin GMT_autolegend
-	gmt plot -R0/7.2/3/7.2 -Jx2c @Table_5_11.txt -Sc0.35c -Glightgreen -Wfaint -lApples+h"LEGEND"+f16p+d
+	gmt plot -R0/7.2/3/7.2 -Jx2c @Table_5_11.txt -Sc0.35c -Glightgreen -Wfaint -lApples+H"LEGEND"+f16p+D
 	gmt plot @Table_5_11.txt -St0.35c -Gorange -B -BWStr -lOranges
 	gmt legend -DjTR+w3c+o0.25c -F+p1p+ggray95+s
 gmt end show

--- a/src/gmt_common.h
+++ b/src/gmt_common.h
@@ -59,8 +59,10 @@ struct GMT_LEGEND_ITEM {	/* Information about one item in a legend */
 	char header[GMT_LEN128];	/* Header for the whole legend H */
 	char subheader[GMT_LEN128];	/* Subheader, i.e., line label L*/
 	char font[GMT_LEN32];		/* Fontsize to use for current H or L */
+	char fill[GMT_LEN32];		/* Fill of the canvas behind the legend */
 	char gap[GMT_LEN32];		/* Move this much down before placing symbol entry */
-	char pen[2][GMT_LEN32];		/* Pens to use with +d and +v */
+	char off[GMT_LEN32];		/* Offset of anchor point for frame */
+	char pen[3][GMT_LEN32];		/* Pens to use with +d and +v and +p */
 	int draw;			/* 0 no draw, 1 draw horizontal +d, 2 draw vertical +v */
 	int just;			/* Legend placement [TR] */
 	char code;			/* Label justification code (L|C|R) [L] */

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -311,7 +311,7 @@ enum GMT_enum_download {
 
 /*! Various mode for auto-legend pens */
 enum GMT_enum_autolegend {
-	GMT_LEGEND_PEN_D  = 0, GMT_LEGEND_PEN_V  = 1,, GMT_LEGEND_PEN_P  = 2,
+	GMT_LEGEND_PEN_D  = 0, GMT_LEGEND_PEN_V  = 1, GMT_LEGEND_PEN_P  = 2,
 	GMT_LEGEND_DRAW_D = 1, GMT_LEGEND_DRAW_V = 2};
 
 /*! Various mode for custom symbols */

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -311,7 +311,7 @@ enum GMT_enum_download {
 
 /*! Various mode for auto-legend pens */
 enum GMT_enum_autolegend {
-	GMT_LEGEND_PEN_D  = 0, GMT_LEGEND_PEN_V  = 1,
+	GMT_LEGEND_PEN_D  = 0, GMT_LEGEND_PEN_V  = 1,, GMT_LEGEND_PEN_P  = 2,
 	GMT_LEGEND_DRAW_D = 1, GMT_LEGEND_DRAW_V = 2};
 
 /*! Various mode for custom symbols */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -17062,8 +17062,8 @@ void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do
 	 * +j -Dj?? as to where to place legend
 	 * +o sets the frame offset [0.2c].
 	 * +p sets the frame pen [1p].
-	 * +w specifies the legend width, as in -D+w<width>.
 	 * +s specifies an overall symbol scaling factor, as in -S<factor> [1].
+	 * +w specifies the legend width, as in -D+w<width>.
 	 *
 	 * S can be given as NULL for lines but then item->size must be set (+size).
 	 */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -17088,7 +17088,7 @@ void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do
 		fprintf (fp, "# LEGEND_JUSTIFICATION: %s\n", justcode);
 		fprintf (fp, "# LEGEND_SCALING: %g\n", item->scale);
 		fprintf (fp, "# LEGEND_FRAME: ");
-		if (item->pen[GMT_LEGEND_PEN_P]) 
+		if (item->pen[GMT_LEGEND_PEN_P][0]) 
 			fprintf (fp, " %s", item->pen[GMT_LEGEND_PEN_P]);
 		else
 			fprintf (fp, " 1p");
@@ -17121,7 +17121,7 @@ void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do
 			return;
 		}
 		if (item->scale > 0.0)
-			GMT_Report (API, GMT_MSG_WARNING, "Your -l+x<scale> is ignored - only applicable to the first instance of -l.\n");
+			GMT_Report (API, GMT_MSG_WARNING, "Your -l+s<scale> is ignored - only applicable to the first instance of -l.\n");
 		if (item->just)
 			GMT_Report (API, GMT_MSG_WARNING, "Your -l+j<just> is ignored - only applicable to the first instance of -l.\n");
 		if (item->width)
@@ -17196,7 +17196,7 @@ bool gmt_get_legend_info (struct GMTAPI_CTRL *API, double *width, double *scale,
 		else if (strstr (file, "# LEGEND_SCALING:"))	/* Need to override the default justification */
 			sscanf (&file[2], "%*s %lf\n", scale);
 		else if (strstr (file, "# LEGEND_FRAME:"))	/* Need to override the default frame settings */
-			sscanf (&file[2], "%s %s %s\n", pen, fill, off);
+			sscanf (&file[2], "%*s %s %s %s\n", pen, fill, off);
 		else if (strstr (file, "# LEGEND_WIDTH:")) {	/* Need to explicitly set legend width */
 			sscanf (&file[2], "%*s %s\n", dim);
 			*width = gmt_M_to_inch (API->GMT, dim);

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8629,6 +8629,7 @@ GMT_LOCAL int gmtinit_parse_l_option (struct GMT_CTRL *GMT, char *arg) {
 				case 'f': strncpy (GMT->common.l.item.font, &txt[1], GMT_LEN32-1);		break;	/* Font to use for this -l entry */
 				case 'g': /* Frame fill */
 					if (&txt[1]) strncpy (GMT->common.l.item.fill, &txt[1], GMT_LEN32-1);
+					break;
 				case 'j': GMT->common.l.item.just = gmt_just_decode (GMT, &txt[1], PSL_TR);	break;	/* legend placement */
 				case 'o': /* Frame offset */
 					if (&txt[1]) strncpy (GMT->common.l.item.off, &txt[1], GMT_LEN32-1);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -394,7 +394,7 @@ EXTERN_MSC double * gmt_list_to_array (struct GMT_CTRL *GMT, char *list, unsigne
 EXTERN_MSC int gmt_getfonttype (struct GMT_CTRL *GMT, char *name);
 EXTERN_MSC int gmt_legend_file (struct GMTAPI_CTRL *API, char *file);
 EXTERN_MSC void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do_fill, struct GMT_FILL *fill, bool do_line, struct GMT_PEN *pen, struct GMT_LEGEND_ITEM *item);
-EXTERN_MSC bool gmt_get_legend_info (struct GMTAPI_CTRL *API, double *width, double *scale, char justification[]);
+EXTERN_MSC bool gmt_get_legend_info (struct GMTAPI_CTRL *API, double *width, double *scale, char justification[], char pen[], char fill[], char off[]);
 EXTERN_MSC unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument, struct GMT_ARRAY *T, unsigned int flags, unsigned int tcol);
 EXTERN_MSC unsigned int gmt_create_array (struct GMT_CTRL *GMT, char option, struct GMT_ARRAY *T, double *min, double *max);
 EXTERN_MSC void gmt_free_array (struct GMT_CTRL *GMT, struct GMT_ARRAY *T);

--- a/src/inset.c
+++ b/src/inset.c
@@ -314,13 +314,13 @@ EXTERN_MSC int GMT_inset (void *V_API, int mode, void *args) {
 		/* Here we need to finish the inset with a grestore and restate the original -R -J in the history file,
 		 * and finally remove the inset information file */
 
-		char tag[GMT_LEN16] = {""}, legend_justification[4] = {""};
+		char tag[GMT_LEN16] = {""}, legend_justification[4] = {""}, pen[GMT_LEN32] = {""}, fill[GMT_LEN32] = {""}, off[GMT_LEN32] = {""};
 		double legend_width = 0.0, legend_scale = 1.0;
 
-		if (gmt_get_legend_info (API, &legend_width, &legend_scale, legend_justification)) {	/* Unplaced legend file */
+		if (gmt_get_legend_info (API, &legend_width, &legend_scale, legend_justification, pen, fill, off)) {	/* Unplaced legend file */
 			char cmd[GMT_LEN64] = {""};
 			/* Default to white legend with 1p frame offset 0.2 cm from selected justification point [TR] */
-			snprintf (cmd, GMT_LEN64, "-Dj%s+w%gi+o0.2c -F+p1p+gwhite -S%g", legend_justification, legend_width, legend_scale);
+			snprintf (cmd, GMT_LEN64, "-Dj%s+w%gi+o%s -F+p%s+g%s -S%g", legend_justification, legend_width, off, pen, fill, legend_scale);
 			if ((error = GMT_Call_Module (API, "legend", GMT_MODULE_CMD, cmd))) {
 				GMT_Report (API, GMT_MSG_ERROR, "Failed to place legend on current inset figure\n");
 				Return (error);

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -1220,17 +1220,17 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 		gmt_M_free (GMT, Ly);
 	}
 	else if (Ctrl->In.mode == SUBPLOT_SET) {	/* SUBPLOT_SET */
-		char legend_justification[4] = {""};
+		char legend_justification[4] = {""}, pen[GMT_LEN32] = {""}, fill[GMT_LEN32] = {""}, off[GMT_LEN32] = {""};
 		double gap[4], legend_width = 0.0, legend_scale = 1.0;
 
-		if (gmt_get_legend_info (API, &legend_width, &legend_scale, legend_justification)) {	/* Unplaced legend file */
+		if (gmt_get_legend_info (API, &legend_width, &legend_scale, legend_justification, pen, fill, off)) {	/* Unplaced legend file */
 			char cmd[GMT_LEN128] = {""};
 			if ((P = gmt_subplot_info (API, fig)) == NULL) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "No subplot information file!\n");
 				Return (GMT_ERROR_ON_FOPEN);
 			}
 			/* Default to white legend with 1p frame offset 0.2 cm from selected justification point [TR] */
-			snprintf (cmd, GMT_LEN128, "-Dj%s+w%gi+o0.2c -F+p1p+gwhite -S%g -Xa%gi -Ya%gi", legend_justification, legend_width, legend_scale, P->origin[GMT_X] + P->x, P->origin[GMT_Y] + P->y);
+			snprintf (cmd, GMT_LEN128, "-Dj%s+w%gi+o%s -F+p%s+g%s -S%g -Xa%gi -Ya%gi", legend_justification, legend_width, off, pen, fill, legend_scale, P->origin[GMT_X] + P->x, P->origin[GMT_Y] + P->y);
 			if ((error = GMT_Call_Module (API, "legend", GMT_MODULE_CMD, cmd))) {
 				GMT_Report (API, GMT_MSG_ERROR, "Failed to place legend on current subplot figure\n");
 				Return (error);
@@ -1249,7 +1249,7 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 	else {	/* SUBPLOT_END */
 		int k, id;
 		char *wmode[2] = {"w","a"}, vfile[GMT_VF_LEN] = {""}, Rtxt[GMT_LEN64] = {""}, tag[GMT_LEN16] = {""};
-		char legend_justification[4] = {""}, Jstr[3] = {"J"};
+		char legend_justification[4] = {""}, Jstr[3] = {"J"}, pen[GMT_LEN32] = {""}, fill[GMT_LEN32] = {""}, off[GMT_LEN32] = {""};
 		double legend_width = 0.0, legend_scale = 1.0;
 		FILE *fp = NULL;
 
@@ -1258,10 +1258,10 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 			Return (GMT_ERROR_ON_FOPEN);
 		}
 
-		if (gmt_get_legend_info (API, &legend_width, &legend_scale, legend_justification)) {	/* Unplaced legend file */
+		if (gmt_get_legend_info (API, &legend_width, &legend_scale, legend_justification, pen, fill, off)) {	/* Unplaced legend file */
 			char cmd[GMT_LEN128] = {""};
 			/* Default to white legend with 1p frame offset 0.2 cm from selected justification point [TR] */
-			snprintf (cmd, GMT_LEN128, "-Dj%s+w%gi+o0.2c -F+p1p+gwhite -S%g -Xa%gi -Ya%gi", legend_justification, legend_width, legend_scale, P->origin[GMT_X] + P->x, P->origin[GMT_Y] + P->y);
+			snprintf (cmd, GMT_LEN128, "-Dj%s+w%gi+o%s -F+p%s+g%s -S%g -Xa%gi -Ya%gi", legend_justification, legend_width, off, pen, fill, legend_scale, P->origin[GMT_X] + P->x, P->origin[GMT_Y] + P->y);
 			if ((error = GMT_Call_Module (API, "legend", GMT_MODULE_CMD, cmd))) {
 				GMT_Report (API, GMT_MSG_ERROR, "Failed to place legend on current subplot figure\n");
 				Return (error);

--- a/test/grdcontour/contourlegend.sh
+++ b/test/grdcontour/contourlegend.sh
@@ -2,5 +2,5 @@
 # Test automated contour legend
 
 gmt begin contourlegend ps
-	gmt grdcontour @earth_relief_20m -R0/20/0/30 -JM6i -A1000 -C500 -Baf -Wc1p,red -Wa1p,blue -l"Annotated Contour"/"Regular Contour"+h"LEGEND"+d
+	gmt grdcontour @earth_relief_20m -R0/20/0/30 -JM6i -A1000 -C500 -Baf -Wc1p,red -Wa1p,blue -l"Annotated Contour"/"Regular Contour"+H"LEGEND"+D
 gmt end show

--- a/test/modern/insetlegend.ps
+++ b/test/modern/insetlegend.ps
@@ -1,17 +1,16 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_ae8e825_2019.10.15 [64-bit] Document from psbasemap
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.1.0_009f6ab_2020.05.20 [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Tue Oct 15 09:51:51 2019
+%%CreationDate: Wed May 20 11:27:55 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
 %%Pages: 1
 %%EndComments
-
 %%BeginProlog
 250 dict begin
 /! {bind def} bind def
@@ -643,39 +642,33 @@ end
 /PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
 /PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
 %%EndProlog
-
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
-PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
-PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
-
 %%Page: 1 1
-
 %%BeginPageSetup
 V 0.06 0.06 scale
 %%EndPageSetup
-
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_plot_completion {} def
-/PSL_movie_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
 FQ
 O0
 -4200 PSL_xorig sub PSL_page_xsize 2 div add 1200 TM
-
 % PostScript produced by:
 %@GMT: gmt psbasemap -R0/7/3/7 -Jx1i -B0 '-B+tInset with plot and legend' -Xc
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 7.000 3.000 7.000 +xy
-%GMTBoundingBox: -252 72 504 288
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 4800 M 0 -4800 D S
 /PSL_A0_y 0 def
@@ -699,7 +692,7 @@ N 0 0 M 8400 0 D S
 0 -4800 T
 0 setlinecap
 /PSL_H_y PSL_L_y PSL_LH add 233 add def
-4200 4800 PSL_H_y add M
+4200 4800 PSL_H_y add PSL_slant_y add M
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 (Inset with plot and legend) bc Z
@@ -708,14 +701,13 @@ PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencod
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
 %@GMT: gmt inset begin -DjTR+w4i/2.5i+o0.1i -M1c -F+p1p,red -R0/7/3/7 -Jx1i
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 7.000 3.000 7.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 V % Begin inset
 17 W
 1 0 0 C
@@ -736,15 +728,15 @@ clip N
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy -R0/7/3/7 -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+hLEGEND+f16p+d+jTL+x0.5 -JX15c
+%@GMT: gmt psxy -R0/7/3/7 -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D+jTL+s0.5+glightblue+p2p+o0.3c -JX15c
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 7.000 3.000 7.000 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 2055 M 0 -2055 D S
 /PSL_A0_y 83 def
@@ -755,8 +747,8 @@ N 0 514 M -83 0 D S
 N 0 1028 M -83 0 D S
 N 0 1541 M -83 0 D S
 N 0 2055 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (3) sw mx
@@ -805,8 +797,8 @@ N 0 514 M 83 0 D S
 N 0 1028 M 83 0 D S
 N 0 1541 M 83 0 D S
 N 0 2055 M 83 0 D S
-/PSL_AH0 0
 /MM {exch M} def
+/PSL_AH0 0
 (3) sw mx
 (4) sw mx
 (5) sw mx
@@ -851,8 +843,8 @@ N 0 0 M 0 -83 D S
 N 1101 0 M 0 -83 D S
 N 2203 0 M 0 -83 D S
 N 3304 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (0) sh mx
 (2) sh mx
 (4) sh mx
@@ -882,8 +874,8 @@ N 0 0 M 0 83 D S
 N 1101 0 M 0 83 D S
 N 2203 0 M 0 83 D S
 N 3304 0 M 0 83 D S
-/PSL_AH0 0
 /MM {M} def
+/PSL_AH0 0
 (0) sh mx
 (2) sh mx
 (4) sh mx
@@ -954,14 +946,13 @@ PSL_cliprestore
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy @Table_5_11.txt -W1.5p,gray '-lMy Lines+s1c' -R0/7/3/7 -JX15c
+%@GMT: gmt psxy @Table_5_11.txt -W1.5p,gray '-lMy Lines+S1c' -R0/7/3/7 -JX15c
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 7.000 3.000 7.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 25 W
 0.745 A
 clipsave
@@ -1010,14 +1001,13 @@ PSL_cliprestore
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
 %@GMT: gmt psxy @Table_5_11.txt -St0.15i -Gorange -lOranges -R0/7/3/7 -JX15c
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 7.000 3.000 7.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 clipsave
 0 0 M
 3855 0 D
@@ -1065,26 +1055,24 @@ PSL_cliprestore
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
 %@GMT: gmt inset end -R0/7/3/7 -JX15c
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 0.000 0.000 0.000 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 0 A
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt pslegend -DjLT+w0i+o0.2c -F+p1p+gwhite -S0.5 -R0/7/3/7 -JX15c
+%@GMT: gmt pslegend -DjLT+w0i+o0.3c -F+p2p+glightblue -S0.5 -R0/7/3/7 -JX15c
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 7.000 3.000 7.000 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 /PSL_legend_label_width 0 def
 /PSL_legend_string_width 0 def
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
@@ -1103,11 +1091,11 @@ PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
 /PSL_tmp_w PSL_tmp_w PSL_legend_label_width add def
 /PSL_legend_box_width PSL_tmp_w PSL_legend_string_width gt { PSL_tmp_w } { PSL_legend_string_width} ifelse PSL_legend_clear_x add def
 /PSL_legend_box_height 1197 def
-94 764 T
+142 717 T
 PSL_legend_box_width PSL_legend_box_height sub 0 2 div mul neg 0 translate
 V
-17 W
-{1 A} FS
+33 W
+{0.678 0.847 0.902 C} FS
 O1
 0 0 M PSL_legend_box_width 0 D 0 PSL_legend_box_height D PSL_legend_box_width neg 0 D P FO N
 U
@@ -1123,14 +1111,13 @@ PSL_legend_box_width PSL_legend_hor_off sub 0 D S
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy -R0/3.2126/0/1.7126 -Jx1i -O -K -N -S @GMTAPI@-000001 --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=false
+%@GMT: gmt psxy -R0/3.2126/0/1.7126 -Jx1i -O -K -N -S @GMTAPI@-S-I-D-D-T-N-000001 --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 3.21260000 0.00000000 1.71260000 0.000 3.213 0.000 1.713 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {0.565 0.933 0.565 C} FS
@@ -1152,34 +1139,31 @@ U
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt pstext -R0/3.2126/0/1.7126 -Jx1i -O -K -N -F+f+j @GMTAPI@-000002 --GMT_HISTORY=false
+%@GMT: gmt pstext -R0/3.2126/0/1.7126 -Jx1i -O -K -N -F+f+j @GMTAPI@-S-I-D-D-N-N-000002 --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 3.21260000 0.00000000 1.71260000 0.000 3.213 0.000 1.713 +xy
 %%BeginObject PSL_Layer_7
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 421 547 M 200 F0
 (Apples) bl Z
 421 327 M (My Lines) bl Z
 421 107 M (Oranges) bl Z
 %%EndObject
 PSL_legend_box_width PSL_legend_box_height sub 0 2 div mul 0 translate
--94 -764 T
+-142 -717 T
 %%EndObject
 PSL_inset_clip 1 eq {cliprestore /PSL_inset_clip 0 def} if
 U % End inset
 %%EndObject
-
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage
-
 %%Trailer
-
 end
 %%EOF

--- a/test/modern/insetlegend.sh
+++ b/test/modern/insetlegend.sh
@@ -4,7 +4,7 @@ gmt begin insetlegend ps
   gmt psbasemap -R0/7/3/7 -Jx1i -B0 -B+t"Inset with plot and legend" -Xc
   gmt inset begin -DjTR+w4i/2.5i+o0.1i -M1c -F+p1p,red
     gmt plot -R0/7/3/7 -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D+jTL+s0.5
-    gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"+s1c
+    gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"+S1c
     gmt plot @Table_5_11.txt -St0.15i -Gorange -lOranges
   gmt inset end
 gmt end show

--- a/test/modern/insetlegend.sh
+++ b/test/modern/insetlegend.sh
@@ -3,7 +3,7 @@
 gmt begin insetlegend ps
   gmt psbasemap -R0/7/3/7 -Jx1i -B0 -B+t"Inset with plot and legend" -Xc
   gmt inset begin -DjTR+w4i/2.5i+o0.1i -M1c -F+p1p,red
-    gmt plot -R0/7/3/7 -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+hLEGEND+f16p+d+jTL+x0.5
+    gmt plot -R0/7/3/7 -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D+jTL+s0.5
     gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"+s1c
     gmt plot @Table_5_11.txt -St0.15i -Gorange -lOranges
   gmt inset end

--- a/test/modern/insetlegend.sh
+++ b/test/modern/insetlegend.sh
@@ -3,7 +3,7 @@
 gmt begin insetlegend ps
   gmt psbasemap -R0/7/3/7 -Jx1i -B0 -B+t"Inset with plot and legend" -Xc
   gmt inset begin -DjTR+w4i/2.5i+o0.1i -M1c -F+p1p,red
-    gmt plot -R0/7/3/7 -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D+jTL+s0.5
+    gmt plot -R0/7/3/7 -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D+jTL+s0.5+glightblue+p2p+o0.3c
     gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"+S1c
     gmt plot @Table_5_11.txt -St0.15i -Gorange -lOranges
   gmt inset end

--- a/test/modern/sublegend.sh
+++ b/test/modern/sublegend.sh
@@ -2,11 +2,11 @@
 # Test that the auto-legend works in subplots
 gmt begin sublegend ps
   gmt subplot begin 2x1 -Fs7i/3i -T"Subplots with legends" -X0.7i
-    gmt plot -R0/7/3/7 @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+hLEGEND+f16p+d -c0
-    gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"+s0.2i
+    gmt plot -R0/7/3/7 @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D -c0
+    gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"+S0.2i
     gmt plot @Table_5_11.txt -St0.15i -Gorange -lOranges
-    gmt plot -R0/7/3/7 @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+hLEGEND+f16p+d+jTL -c1
-    gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"+s0.2i
+    gmt plot -R0/7/3/7 @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D+jTL -c1
+    gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"+S0.2i
     gmt plot @Table_5_11.txt -St0.15i -Gred -lRed
   gmt subplot end
 gmt end show

--- a/test/modern/twofiglegend.sh
+++ b/test/modern/twofiglegend.sh
@@ -2,11 +2,11 @@
 # Test that the auto-legend works in a map inset
 gmt begin
   gmt figure onefiglegend ps
-    gmt plot -R0/7/3/7 -Jx1i -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+hLEGEND+f16p+d
+    gmt plot -R0/7/3/7 -Jx1i -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D
     gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"
     gmt plot @Table_5_11.txt -St0.15i -Gorange -lOranges
   gmt figure twofiglegend ps
-    gmt plot -R0/7/3/7 -Jx1i -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+hLEGEND+f16p+d+jTL
+    gmt plot -R0/7/3/7 -Jx1i -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D+jTL
     gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"
     gmt plot @Table_5_11.txt -St0.15i -Gred -lRed
 gmt end show

--- a/test/pslegend/autolegend.sh
+++ b/test/pslegend/autolegend.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 gmt begin autolegend ps
-  gmt plot -R0/7.2/3/7.2 -Jx1i -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+h"LEGEND"+f16p+d
+  gmt plot -R0/7.2/3/7.2 -Jx1i -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+H"LEGEND"+f16p+D
   gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"
   gmt plot @Table_5_11.txt -St0.15i -Gorange -lOranges
   gmt legend -DjTR+w1.15i+o0.1i -F+p1p


### PR DESCRIPTION
**Description of proposed changes**

As outlined in #3362, I have been bothered by the **-l** syntax and its limitations.  This is a new 6.1 feature so now is the time to make any final changes.  In struggling with making room for **+g**_fill_ despite also having **+g**_gap_ (and not really liking **+a**_gap_) I have decided to do this:
 

1. Let the **legend** macro code that have modifier equivalents be upper case.
2. Let other **legend** options that have modifier equivalents be lower case.

Thus, setting the gap (**G** in legend) means **+G**, and same for **+D**, **+N**, **+H**, **+L**, **+S**, **+V**.  That frees up the lowercase modifiers and now standard like **+g**_fill_, **+p**_pen_ and **+o**_offset_ have readily been added, and the oddly named **+x**_scale_ is now **+s**_scale_ (i.e., **-S** in legend).

I updated the handful of scripts that needed updated modifiers.  All tests pass, and documentation has been updated.

I think this concludes the changes to **-l** and it is ready to be frozen.