### PR TITLE
Optional use of -Z in DCW header dumps

### DIFF
--- a/doc/rst/source/coast_common.rst_
+++ b/doc/rst/source/coast_common.rst_
@@ -68,7 +68,7 @@ Optional Arguments
 
 .. _-E:
 
-**-E**\ *code1,code2,...*\ [**+l**\|\ **L**][**+g**\ *fill*][**+p**\ *pen*]
+**-E**\ *code1,code2,...*\ [**+l**\|\ **L**][**+g**\ *fill*][**+p**\ *pen*][**+z**]
     Select painting or dumping country polygons from the Digital Chart of the World.
     This is another dataset independent of GSHHG and hence the **-A** and **-D** options do not apply.
     Append one or more comma-separated countries using the
@@ -84,7 +84,8 @@ Optional Arguments
     repeat if more than one continent is requested.
     Append **+p**\ *pen* to draw polygon outlines [no outline] and
     **+g**\ *fill* to fill them [no fill].  One of **+p**\|\ **g** must be
-    specified unless **-M** is in effect, in which case only one **-E** option can be given.
+    specified unless **-M** is in effect, in which case only one **-E** option can be given;
+    append **+z** to place the country code in the segment headers via **-Z**\ *code* settings.
     Otherwise, you may repeat **-E** to give different groups of items their own pen/fill settings.
     If neither **-J** nor **-M** are set then we just print the **-R**\ *wesn* string.
 

--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -43,10 +43,8 @@
 
 #define DCW_GET_COUNTRY			1	/* Extract countries only */
 #define DCW_GET_COUNTRY_AND_STATE	2	/* Extract countries and states */
-#define DCW_ADD_ZCOUNTRY		4	/* Report -Z<countrycode> in segment header if -M */
 #define DCW_DO_OUTLINE			1	/* Draw outline of polygons */
-#define DCW_DO_FILL			2	/* Fill the polygons */
-#define DCW_DO_FILL			2	/* Fill the polygons */
+#define DCW_DO_FILL				2	/* Fill the polygons */
 
 struct GMT_DCW_COUNTRY {	/* Information per country */
 	char continent[4];	/* 2-char continent code (EU, NA, SA, AF, AU, AN) */

--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -234,7 +234,7 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 	bool done, new_set, want_state, outline, fill = false, is_Antarctica = false;
 	char TAG[GMT_LEN16] = {""}, dim[GMT_LEN16] = {""}, xname[GMT_LEN16] = {""};
 	char yname[GMT_LEN16] = {""}, code[GMT_LEN16] = {""}, state[GMT_LEN16] = {""};
-	char msg[GMT_BUFSIZ] = {""}, segment[GMT_LEN32] = {""}, path[PATH_MAX] = {""}, list[GMT_BUFSIZ] = {""};
+	char msg[GMT_BUFSIZ] = {""}, path[PATH_MAX] = {""}, list[GMT_BUFSIZ] = {""};
 	double west, east, south, north, xscl, yscl, out[2], *lon = NULL, *lat = NULL;
 	struct GMT_RANGE *Z = NULL;
 	struct GMT_DATASET *D = NULL;
@@ -385,11 +385,17 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 				continue;
 			}
 			snprintf (TAG, GMT_LEN16, "%s%s", GMT_DCW_country[k].code, GMT_DCW_state[item].code);
-			snprintf (msg, GMT_BUFSIZ, "-Z%s %s (%s)\n", TAG, GMT_DCW_state[item].name, GMT_DCW_country[k].name);
+			if (F->mode & GMT_DCW_ZHEADER)
+				snprintf (msg, GMT_BUFSIZ, "-Z%s %s (%s)\n", TAG, GMT_DCW_state[item].name, GMT_DCW_country[k].name);
+			else
+				snprintf (msg, GMT_BUFSIZ, "%s (%s)\n", GMT_DCW_state[item].name, GMT_DCW_country[k].name);
 		}
 		else {
 			snprintf (TAG, GMT_LEN16, "%s", GMT_DCW_country[k].code);
-			snprintf (msg, GMT_BUFSIZ, "-Z%s %s\n", TAG, GMT_DCW_country[k].name);
+			if (F->mode & GMT_DCW_ZHEADER)
+				snprintf (msg, GMT_BUFSIZ, "-Z%s %s\n", TAG, GMT_DCW_country[k].name);
+			else
+				snprintf (msg, GMT_BUFSIZ, "%s\n", GMT_DCW_country[k].name);
 		}
 		if (!strncmp (GMT_DCW_country[k].code, "AQ", 2U)) is_Antarctica = true;
 
@@ -478,14 +484,7 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 			P->data[GMT_X] = &lon[first];
 			P->data[GMT_Y] = &lat[first];
 			if (mode & GMT_DCW_DUMP) {	/* Dump the coordinates to stdout */
-				snprintf (segment, GMT_LEN32, "Segment %" PRIu64, seg);
-				if (F->mode & GMT_DCW_ZHEADER) {
-					strcpy (GMT->current.io.segment_header, msg);
-					strcat (GMT->current.io.segment_header, " ");
-					strcat (GMT->current.io.segment_header, segment);
-				}
-				else
-					strcpy (GMT->current.io.segment_header, segment);
+				snprintf (GMT->current.io.segment_header, GMT_BUFSIZ-1, "%s Segment %" PRIu64, msg, seg);
 				GMT_Put_Record (GMT->parent, GMT_WRITE_SEGMENT_HEADER, NULL);
 				for (kk = 0; kk < P->n_rows; kk++) {
 					out[GMT_X] = P->data[GMT_X][kk];

--- a/src/gmt_dcw.h
+++ b/src/gmt_dcw.h
@@ -31,14 +31,15 @@
 #ifndef GMT_DCW_H
 #define GMT_DCW_H
 
-#define DCW_OPT "<code1,code2,...>[+l|L][+g<fill>][+p<pen>]"
+#define DCW_OPT "<code1,code2,...>[+l|L][+g<fill>][+p<pen>][+z]"
 
 enum GMT_DCW_modes {
 	GMT_DCW_REGION	= 1,
 	GMT_DCW_PLOT	= 2,
 	GMT_DCW_DUMP	= 4,
 	GMT_DCW_EXTRACT	= 8,
-	GMT_DCW_LIST	= 16
+	GMT_DCW_LIST	= 16,
+	GMT_DCW_ZHEADER	= 32
 };
 
 struct GMT_DCW_ITEM {	/* One set of codes with their color/fill */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13104,7 +13104,7 @@ GMT_LOCAL unsigned int gmtinit_strip_R_from_E_in_pscoast (struct GMT_CTRL *GMT, 
 		if (c) {	/* Now process the modifiers */
 			c[0] = '+';	/* Unhide the modifiers */
 			pos = 0;	/* Initialize position counter for this string */
-			while (gmt_getmodopt (GMT, 'E', c, "lLgprRw", &pos, p, &n_errors) && n_errors == 0) {
+			while (gmt_getmodopt (GMT, 'E', c, "lLgprRwz", &pos, p, &n_errors) && n_errors == 0) {
 				switch (p[0]) {
 					case 'r': case 'R':
 						if (r_opt[0] == 0) {	/* Only set this once */

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -178,7 +178,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s %s [%s] [%s]\n", name, GMT_J_OPT, GMT_A_OPT, GMT_B_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-C<fill>[+l|r]]\n\t[-D<resolution>][+f] [-E%s][-G[<fill>]]\n", GMT_Rgeoz_OPT, DCW_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-C<fill>[+l|r]]\n\t[-D<resolution>][+f] [-E%s] [-G[<fill>]]\n", GMT_Rgeoz_OPT, DCW_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-F%s]\n", GMT_PANEL);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-I<feature>[/<pen>]] %s\n", API->K_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-L%s]\n", GMT_SCALE);

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -521,7 +521,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOAST_CTRL *Ctrl, struct GMT_OP
 	if (gmt_DCW_list (GMT, &(Ctrl->E.info))) return 1;	/* If +l|L was given we list countries and return */
 
 	if (!GMT->common.J.active) {	/* So without -J we can only do -M or report region only */
-		if (Ctrl->M.active) Ctrl->E.info.mode = GMT_DCW_DUMP;
+		if (Ctrl->M.active) Ctrl->E.info.mode |= GMT_DCW_DUMP;
 		else if (GMT->common.B.active[GMT_PRIMARY] || GMT->common.B.active[GMT_SECONDARY] || Ctrl->C.active || Ctrl->G.active || Ctrl->I.active || Ctrl->N.active || GMT->common.P.active || Ctrl->S.active || Ctrl->W.active)
 			n_errors++;	/* Tried to make a plot but forgot -J */
 		else if (!Ctrl->Q.active && Ctrl->E.active)
@@ -1150,7 +1150,7 @@ EXTERN_MSC int GMT_pscoast (void *V_API, int mode, void *args) {
 		GMT->current.map.coastline = false;
 	}
 
-	if (Ctrl->E.info.mode > GMT_DCW_REGION)
+	if ((Ctrl->E.info.mode & (GMT_DCW_LIST-1)) > GMT_DCW_REGION)	/* Avoid having GMT_DCW_ZHEADER be included in check */
 		(void)gmt_DCW_operation (GMT, &Ctrl->E.info, NULL, Ctrl->M.active ? GMT_DCW_DUMP : GMT_DCW_PLOT);
 
 	if (clipping) PSL_beginclipping (PSL, xtmp, ytmp, 0, GMT->session.no_rgb, 2);	/* End clippath */


### PR DESCRIPTION
**Description of proposed changes**

When gmt coast **-M -E** is used to write polygons to stdout, the segment headers now has the settings **-Z**_code_.  This is not always appropriate.  Hence, this PR adds the modifier **+z** for **-E** which is required to get the country codes written via **-Z** in the headers.
