### PR TITLE
Restore initial offsets in PSL

### DIFF
--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -4306,6 +4306,9 @@ int PSL_endplot (struct PSL_CTRL *PSL, int lastpage) {
 			PSL->internal.fp = NULL;
 		}
 	}
+	PSL->internal.offset[0] = PSL->internal.prev_offset[0];
+	PSL->internal.offset[1] = PSL->internal.prev_offset[1];
+
 	PSL->internal.call_level--;	/* Done with this module call */
 	return (PSL_NO_ERROR);
 }
@@ -4386,6 +4389,8 @@ int PSL_beginplot (struct PSL_CTRL *PSL, FILE *fp, int orientation, int overlay,
 
 	right_now = time ((time_t *)0);
 	PSL->internal.landscape = !(overlay || orientation);	/* Only rotate if not overlay and not Portrait */
+	PSL->internal.prev_offset[0] = PSL->internal.offset[0];
+	PSL->internal.prev_offset[1] = PSL->internal.offset[1];
 	PSL->internal.offset[0] = offset[0];
 	PSL->internal.offset[1] = offset[1];
 

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -314,6 +314,7 @@ struct PSL_CTRL {
 		char *user_image[PSL_N_PATTERNS];	/* Name of user patterns		*/
 		char origin[2];			/* 'r', 'a', 'f', 'c' depending on reference for new origin x and y coordinate */
 		double offset[2];		/* Origin offset [1/1]				*/
+		double prev_offset[2];		/* Previous Origin offset [1/1]				*/
 		double p_width;			/* Paper width in points, set in PSL_beginplot();	*/
 		double p_height;		/* Paper height in points, set in PSL_beginplot();	*/
 		double dpu;			/* PS dots per unit.  Must be set through PSL_beginplot();		*/


### PR DESCRIPTION
See #3365 for background.  The problem was that psxy plots decorated lines by drawing the line first, then call it self to plot the symbols.  In the second call we do a straight overlay so the x/y offsets passed to gmt_plotinit (and into PSL) are zero.  Yet, when we return back to the original psxy call, we want to undo any translated done by that command.  Alas, those values were wiped when 0,0 was given.  The solution is to let PSL remember the origin value before the update, and then restore the values when we call gmt_plotend.  Fixes this issue and all tests pass.
