### PR TITLE
Reduce the UNIX-centric phrasing of the docs

### DIFF
--- a/doc/rst/source/cookbook/introduction.rst
+++ b/doc/rst/source/cookbook/introduction.rst
@@ -80,10 +80,11 @@ cookbook which explains the purpose of the package and its many
 features, and provides numerous examples to help new users quickly
 become familiar with the operation and philosophy of the system. The
 cookbook contains the shell scripts that were used for each example;
-PostScript files of each illustration are also provided. All programs
-have individual manual pages which can be installed as part of the
-on-line documentation under the UNIX **man** utility or as web
-pages. In addition, the programs offer friendly help messages which make
+PostScript files of each illustration are also provided. The extensive online 
+GMT Documentation is also home to the detailed technical reference for all programs. 
+All programs also have individual manual pages which can be installed as part of the
+on-line documentation under the UNIX **man** utility. 
+In addition, the programs offer friendly help messages which make
 them essentially self-teaching – if a user enters invalid or ambiguous
 command arguments, the program will print a warning to the screen with a
 synopsis of the valid arguments. All the documentation is available for

--- a/doc/rst/source/cookbook/introduction.rst
+++ b/doc/rst/source/cookbook/introduction.rst
@@ -80,9 +80,9 @@ cookbook which explains the purpose of the package and its many
 features, and provides numerous examples to help new users quickly
 become familiar with the operation and philosophy of the system. The
 cookbook contains the shell scripts that were used for each example;
-PostScript files of each illustration are also provided. The extensive online 
-GMT Documentation is also home to the detailed technical reference for all programs. 
-All programs also have individual manual pages which can be installed as part of the
+PostScript files of each illustration are also provided. The online 
+GMT Documentation is also home to the extensive technical reference for all programs. 
+The programs also have individual manual pages which can be installed as part of the
 on-line documentation under the UNIX **man** utility. 
 In addition, the programs offer friendly help messages which make
 them essentially self-teaching – if a user enters invalid or ambiguous

--- a/doc/rst/source/cookbook/introduction.rst
+++ b/doc/rst/source/cookbook/introduction.rst
@@ -79,8 +79,7 @@ GMT is thoroughly documented and comes with a technical reference and
 cookbook which explains the purpose of the package and its many
 features, and provides numerous examples to help new users quickly
 become familiar with the operation and philosophy of the system. The
-cookbook contains the shell scripts that were used for each example;
-PostScript files of each illustration are also provided. The online 
+cookbook contains the shell scripts that were used for each example. The online 
 GMT Documentation is also home to the extensive technical reference for all programs. 
 The programs also have individual manual pages which can be installed as part of the
 on-line documentation under the UNIX **man** utility. 

--- a/doc/rst/source/cookbook/introduction.rst
+++ b/doc/rst/source/cookbook/introduction.rst
@@ -24,7 +24,7 @@ Line drawings, bitmapped images, and text can be easily combined in one
 illustration. PostScript plot files are device-independent: The same
 file can be printed at 300 dots per inch (dpi) on a cheap
 printer or converted to a high-resolution PNG image for online usage.
-GMT software is written as a set of UNIX tools [3]_ and is
+GMT software is written as a set of command-line tools [3]_ and is
 totally self-contained and fully documented. The system is offered free
 of charge and is distributed over the Internet
 [*Wessel and Smith, 1991; 1995; 1998*; *Wessel et al., 2013*; *Wessel et al., 2019*].
@@ -249,7 +249,7 @@ Footnotes
    for terms on redistribution and modifications.
 
 .. [3]
-   The tools can also be installed on other platforms (see Chapter :doc:`non-unix-platforms`).
+   The tools can be installed on a variety of platforms - UNIX and non-UNIX alike (see Chapter :doc:`non-unix-platforms`).
 
 .. [4]
    One public-domain RIP is ghostscript, available from `<https://www.ghostscript.com/>`_.

--- a/doc/rst/source/cookbook/options.rst
+++ b/doc/rst/source/cookbook/options.rst
@@ -759,7 +759,7 @@ annotations on the *x*-axis and irregular annotations on the *y*-axis.
 Timestamps on plots: The **-U** option
 --------------------------------------
 
-The **-U** option draws the GMT UNIX System time stamp on the plot.
+The **-U** option draws the GMT system time stamp on the plot.
 By appending **+j**\ *just* and/or **+o**\ *dx/dy*, the user may
 specify the justification of the stamp and where the stamp should fall
 on the page relative to lower left corner of the plot.

--- a/doc/rst/source/explain_-U_full.rst_
+++ b/doc/rst/source/explain_-U_full.rst_
@@ -1,7 +1,7 @@
 .. _-U_full:
 
 **-U**\ [*label*][**+c**][**+j**\ *just*][**+o**\ *dx*/*dy*]
-    Draw the GMT Unix System time stamp on the plot.
+    Draw the GMT system time stamp on the plot.
     By appending **+j**\ *just* [BL] and/or **+o**\ *dx/dy* [-54p/-54p], the
     user may specify the justification of the stamp and where the stamp
     should fall on the page relative to lower left corner of the plot.

--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -11,7 +11,7 @@ gmt
 Introduction
 ------------
 
-GMT is a collection of command-line tools in the public-domain that allows you to
+GMT is a collection of freely available command-line tools under the GNU LGPL that allows you to
 manipulate x,y and x,y,z data sets (filtering, trend fitting, gridding,
 projecting, etc.) and produce illustrations ranging from
 simple x-y plots, via contour maps, to artificially illuminated surfaces

--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -11,7 +11,7 @@ gmt
 Introduction
 ------------
 
-GMT is a collection of public-domain Unix tools that allows you to
+GMT is a collection of command-line tools in the public-domain that allows you to
 manipulate x,y and x,y,z data sets (filtering, trend fitting, gridding,
 projecting, etc.) and produce illustrations ranging from
 simple x-y plots, via contour maps, to artificially illuminated surfaces


### PR DESCRIPTION
**Description of proposed changes**

The docs are very UNIX centric despite GMT installs on a variety of platforms. This PR reduces that. I have some difficulties with rephrasing line 83ff in `./cookbook/introduction.rst` maybe someone has a better idea? See #3369 for more context.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #3369 


**Reminders**

- [ ] Correct base branch selected? `master` for new features, `6.1` for bug fixes
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
