### PR TITLE
Extract +i from CPT names, set interval, and leave the rest of the name

### DIFF
--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -352,6 +352,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC void gmt_cpt_interval_modifier (struct GMT_CTRL *GMT, char **arg, double *interval);
 EXTERN_MSC int gmt_token_check (struct GMT_CTRL *GMT, FILE *fp, char *prefix, unsigned int mode);
 EXTERN_MSC bool gmt_is_gmtmodule (char *line, char *module);
 EXTERN_MSC bool gmt_is_gmt_end_show (char *line);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16804,6 +16804,23 @@ CROAK:	/* We are done or premature return due to error */
 	return (error);
 }
 
+void gmt_cpt_interval_modifier (struct GMT_CTRL *GMT, char **arg, double *interval) {
+	/* CPT files in some programs (grdimage, grdview) may have a +i<dz> modifier,
+	 * but it may be just one of several modifiers.  Here, we wish to remove this
+	 * modifier, set the corresponding interval, and update *file to only have the
+	 * remaining text items. */
+	char *file = NULL, *c = NULL, new_arg[PATH_MAX] = {""};
+	if (arg == NULL || (file = *arg) == NULL || file[0] == '\0') return;
+	if ((c = strstr (file, "+i")) == NULL) return;
+	/* Here we have a +i<dz> string in c */
+	*interval = atof (&c[2]);
+	c[0] = '\0';	c++;	/* Chop off and move one char to the right */
+	strcpy (new_arg, file);	/* Everything up to start of +i */
+	while (*c && *c != '+') c++;	/* Wind to next modifier or reach end of string */
+	if (*c) strcat (new_arg, c);	/* Append other modifiers given after +i */
+	gmt_M_str_free (*arg);
+	*arg = strdup (new_arg);
+}
 
 /* This set of 14 functions are used by both movie.c and batch.c to deal with understanding
  * input script types and to write shell commands in various syntax variants.

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16805,7 +16805,7 @@ CROAK:	/* We are done or premature return due to error */
 }
 
 void gmt_cpt_interval_modifier (struct GMT_CTRL *GMT, char **arg, double *interval) {
-	/* CPT files in some programs (grdimage, grdview) may have a +i<dz> modifier,
+	/* CPT files in some programs (grd2kml, grdimage, grdvector, grdview) may have a +i<dz> modifier,
 	 * but it may be just one of several modifiers.  Here, we wish to remove this
 	 * modifier, set the corresponding interval, and update *file to only have the
 	 * remaining text items. */

--- a/src/grd2kml.c
+++ b/src/grd2kml.c
@@ -230,13 +230,9 @@ static int parse (struct GMT_CTRL *GMT, struct GRD2KML_CTRL *Ctrl, struct GMT_OP
 				break;
 			case 'C':	/* CPT */
 				Ctrl->C.active = true;
-				if ((c = strstr (opt->arg, "+i"))) {	/* Gave auto-interval */
-					Ctrl->C.dz = atof (&c[2]);
-					c[0] = '\0';	/* Temporarily chop off the modifier */
-				}
 				gmt_M_str_free (Ctrl->C.file);
-				Ctrl->C.file = strdup (opt->arg);
-				if (c) c[0] = '+';	/* Restore */
+				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
+				gmt_cpt_interval_modifier (GMT, &(Ctrl->C.file), &(Ctrl->C.dz));
 				break;
 			case 'D':	/* Debug options - may fade away when happy with the performance */
 				Ctrl->D.active = true;

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -305,13 +305,9 @@ static int parse (struct GMT_CTRL *GMT, struct GRDIMAGE_CTRL *Ctrl, struct GMT_O
 
 			case 'C':	/* CPT */
 				Ctrl->C.active = true;
-				if ((c = strstr (opt->arg, "+i"))) {	/* Gave auto-interval */
-					Ctrl->C.dz = atof (&c[2]);
-					c[0] = '\0';	/* Temporarily chop off the modifier */
-				}
 				gmt_M_str_free (Ctrl->C.file);
 				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
-				if (c) c[0] = '+';	/* Restore */
+				gmt_cpt_interval_modifier (GMT, &(Ctrl->C.file), &(Ctrl->C.dz));
 				break;
 #ifdef HAVE_GDAL
 			case 'D':	/* Get an image via GDAL */

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -167,7 +167,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVECTOR_CTRL *Ctrl, struct GMT_
 	unsigned int n_errors = 0, n_files = 0;
 	int j;
 	size_t len;
-	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""}, symbol, *c = NULL;
+	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""}, symbol;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
@@ -192,13 +192,9 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVECTOR_CTRL *Ctrl, struct GMT_
 				break;
 			case 'C':	/* Vary symbol color with z */
 				Ctrl->C.active = true;
-				if ((c = strstr (opt->arg, "+i"))) {	/* Gave auto-interval */
-					Ctrl->C.dz = atof (&c[2]);
-					c[0] = '\0';	/* Temporarily chop off the modifier */
-				}
 				gmt_M_str_free (Ctrl->C.file);
 				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
-				if (c) c[0] = '+';	/* Restore */
+				gmt_cpt_interval_modifier (GMT, &(Ctrl->C.file), &(Ctrl->C.dz));
 				break;
 			case 'E':	/* Center vectors [OBSOLETE; use modifier +jc in -Q ] */
 				if (gmt_M_compat_check (GMT, 4)) {

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -504,13 +504,9 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT_OP
 
 			case 'C':	/* Cpt file */
 				Ctrl->C.active = true;
-				if ((c = strstr (opt->arg, "+i"))) {	/* Gave auto-interval */
-					Ctrl->C.dz = atof (&c[2]);
-					c[0] = '\0';	/* Temporarily chop off the modifier */
-				}
 				gmt_M_str_free (Ctrl->C.file);
 				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
-				if (c) c[0] = '+';	/* Restore */
+				gmt_cpt_interval_modifier (GMT, &(Ctrl->C.file), &(Ctrl->C.dz));
 				break;
 			case 'G':	/* One grid or image or three separate r,g,b grids */
 				Ctrl->G.active = true;


### PR DESCRIPTION
As discussed in #3383, this PR fixed the problem that other modifiers after **+i** in cpt names are chopped off too.
