### PR TITLE
Also search in sharedir in addition to its given subdir

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -5071,7 +5071,6 @@ char *gmt_getsharepath (struct GMT_CTRL *GMT, const char *subdir, const char *st
 	sprintf (path, "%s/%s%s", GMT->session.SHAREDIR, stem, suffix);
 	if (!access (path, R_OK)) return (path);
 
-
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "GMT: 6. gmt_getsharepath failed\n");
 	return (NULL);	/* No file found, give up */
 }

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -5022,12 +5022,12 @@ char *gmt_getdatapath (struct GMT_CTRL *GMT, const char *stem, char *path, int m
 
 /*! . */
 char *gmt_getsharepath (struct GMT_CTRL *GMT, const char *subdir, const char *stem, const char *suffix, char *path, int mode) {
-	/* stem is the prefix of the file, e.g., gmt_cpt for gmt_cpt.conf
+	/* stem is the prefix of the file, e.g., mysymbol for mysymbol.def
 	 * subdir is an optional subdirectory name in the $GMT_SHAREDIR directory.
 	 * suffix is an optional suffix to append to name
 	 * path is the full path to the file in question
 	 * Returns full pathname if a workable path was found
-	 * Looks for file stem in current directory, $GMT_USERDIR (default ~/.gmt) and $GMT_SHAREDIR/subdir
+	 * Looks for file stem in current directory, $GMT_USERDIR (default ~/.gmt), $GMT_SHAREDIR/subdir and $GMT_SHAREDIR.
 	 */
 
 	/* First look in the current working directory */
@@ -5065,7 +5065,14 @@ char *gmt_getsharepath (struct GMT_CTRL *GMT, const char *subdir, const char *st
 		if (!access (path, R_OK)) return (path);
 	}
 
-	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "GMT: 5. gmt_getsharepath failed\n");
+	/* Lastly try to get file from $GMT_SHAREDIR */
+
+	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "GMT: 5. gmt_getsharepath trying SHAREDIR %s\n", GMT->session.SHAREDIR);
+	sprintf (path, "%s/%s%s", GMT->session.SHAREDIR, stem, suffix);
+	if (!access (path, R_OK)) return (path);
+
+
+	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "GMT: 6. gmt_getsharepath failed\n");
 	return (NULL);	/* No file found, give up */
 }
 

--- a/test/psxy/line_geo.sh
+++ b/test/psxy/line_geo.sh
@@ -18,3 +18,4 @@ awk '{printf "@~a@~ = %s@.\n", $3}' q1.txt | gmt pstext -R -J -O -K -F+f10p+cBL 
 gmt psxy -R -J -Skgeo-lineation/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q2.txt -K -Y-10c >> $ps
 awk '{printf "@~a@~ = %s@.\n", $3}' q2.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -O -T >> $ps
+rm -f geo-lineation.def

--- a/test/psxy/line_geo.sh
+++ b/test/psxy/line_geo.sh
@@ -3,7 +3,7 @@
 # This version is a Mercator plot and azimuths are given.
 ps=line_geo.ps
 # Must copy the specific symbol file from the documentation to here.
-DIR=`gmt --show-sharedir`/../doc/rst/source/users-contrib-symbols/geology
+DIR=$(gmt --show-sharedir)/../doc/rst/source/users-contrib-symbols/geology
 cp -f ${DIR}/geo-lineation.def .
 echo "0 0  60 30" > q1.txt
 echo "0 0 150 30" > q2.txt

--- a/test/psxy/line_geo.sh
+++ b/test/psxy/line_geo.sh
@@ -2,8 +2,9 @@
 # Test strike/dip symbol from Jose for consistency across quadrants
 # This version is a Mercator plot and azimuths are given.
 ps=line_geo.ps
-# Must temporarily change GMT_USERDIR to the gallery documentation dir
-export GMT_USERDIR=`gmt --show-sharedir`/../doc/rst/source/users-contrib-symbols/geology
+# Must copy the specific symbol file from the documentation to here.
+DIR=`gmt --show-sharedir`/../doc/rst/source/users-contrib-symbols/geology
+cp -f ${DIR}/geo-lineation.def .
 echo "0 0  60 30" > q1.txt
 echo "0 0 150 30" > q2.txt
 echo "0 0 240 30" > q3.txt

--- a/test/psxy/struct_geo.sh
+++ b/test/psxy/struct_geo.sh
@@ -4,7 +4,7 @@ ps=struct_geo.ps
 reg=-R0/10/0/10
 # Must copy the specific symbol files from the documentation to here.
 DIR=$(gmt --show-sharedir)/../doc/rst/source/users-contrib-symbols/geology
-cp -f ${DIR}/*.def .
+cp -f ${DIR}/geo-*.def .
 gmt psxy $reg -JM12c -T -K -P > $ps
 
 echo 1 9 60 40 | gmt psxy -R -J -Skgeo-plane/24p -Wthin -O -K >> $ps
@@ -69,3 +69,4 @@ gmt pstext -R -J -F+f7p,29+jLT -M -O -N >> $ps << END
 > 0.5 4.3 6p 10.6c j
 1 - Strike and dip of beds. 2 - Horizontal beds. 3 - Strike of vertical beds. 4 - Strike and dip of overturned beds. 5 - Strike and dip of bed with rake of lineation. 6 - Strike and dip direction of gently dipping beds. 7 - Strike and dip direction of moderatly dipping beds. 8 - Strike and dip direction of steeply dipping beds. 9 - Strike and dip of crenulated or undulated beds. 10 - Strike and dip of foliation. 11 - Horizontal foliation. 12 - Strike of vertical foliation. 13. Strike and dip of cleavage. 14 - Horizontal cleavage. 15 - Strike of vertical cleavage. 16 - Strike and dip of foliation 2. 17 - Strike and dip of foliation 3. 18 - Strike and dip of joints. 19 - Horizontal joints. 20 - Strike of vertical joints. 21 - Trend and plunge of lineation. 22 - Vertical lineation. 23 - Horizontal lineation. 24 - Trend and plunge of lineation 2. 25 - Trend and plunge of lineation 3.
 END
+rm -f geo-*.def

--- a/test/psxy/struct_geo.sh
+++ b/test/psxy/struct_geo.sh
@@ -3,7 +3,7 @@
 ps=struct_geo.ps
 reg=-R0/10/0/10
 # Must copy the specific symbol files from the documentation to here.
-DIR=`gmt --show-sharedir`/../doc/rst/source/users-contrib-symbols/geology
+DIR=$(gmt --show-sharedir)/../doc/rst/source/users-contrib-symbols/geology
 cp -f ${DIR}/*.def .
 gmt psxy $reg -JM12c -T -K -P > $ps
 

--- a/test/psxy/struct_geo.sh
+++ b/test/psxy/struct_geo.sh
@@ -2,9 +2,9 @@
 # Test all structural geology symbols from Jose
 ps=struct_geo.ps
 reg=-R0/10/0/10
-# Must temporarily change GMT_USERDIR to the gallery documentation dir
-export GMT_USERDIR=`gmt --show-sharedir`/../doc/rst/source/users-contrib-symbols/geology
-
+# Must copy the specific symbol files from the documentation to here.
+DIR=`gmt --show-sharedir`/../doc/rst/source/users-contrib-symbols/geology
+cp -f ${DIR}/*.def .
 gmt psxy $reg -JM12c -T -K -P > $ps
 
 echo 1 9 60 40 | gmt psxy -R -J -Skgeo-plane/24p -Wthin -O -K >> $ps


### PR DESCRIPTION
This PR will helps users who temporarily want to change where **GMT_SHAREDIR** points to: Because GMT only looks in _subdir_ under **GMT_SHAREDIR** it is more awkward to use when you just want to point to a temporary directory.  Now, we will also look in **GMT_SHAREDIR** itself  if **GMT_SHAREDIR**/_subdir_ fails to find the file.

Also, the two test that temporarily reset **GMT_USERDIR** have been changed to use the files directly without changing the environment as that negatively affects other jobs running in parallel.
