### PR TITLE
No exit calls, part 1

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -482,7 +482,7 @@ GMT_LOCAL inline GMT_putfunction gmtapi_select_put_function (struct GMTAPI_CTRL 
 		case GMT_UCHAR:		return (gmtapi_put_val_uchar);	break;
 		case GMT_CHAR:		return (gmtapi_put_val_char);	break;
 		default:
-			GMT_Report (API, GMT_MSG_ERROR, "Internal error in gmtapi_select_put_function: Passed bad type (%d), Will probably crash\n", type);
+			GMT_Report (API, GMT_MSG_ERROR, "Internal error in gmtapi_select_put_function: Passed bad type (%d), Will be unable to place binary data\n", type);
 			return NULL;
 			break;
 	}
@@ -501,7 +501,7 @@ GMT_LOCAL inline GMT_getfunction gmtapi_select_get_function (struct GMTAPI_CTRL 
 		case GMT_UCHAR:		return (gmtapi_get_val_uchar);	break;
 		case GMT_CHAR:		return (gmtapi_get_val_char);	break;
 		default:
-			GMT_Report (API, GMT_MSG_ERROR, "Internal error in gmtapi_select_get_function: Passed bad type (%d), Must probably crash\n", type);
+			GMT_Report (API, GMT_MSG_ERROR, "Internal error in gmtapi_select_get_function: Passed bad type (%d), will be unable to convert binary data\n", type);
 			return NULL;
 			break;
 	}
@@ -3251,7 +3251,8 @@ GMT_LOCAL struct GMT_MATRIX * gmtapi_read_matrix (struct GMT_CTRL *GMT, void *so
 		if (close_file) fclose (fp);
 		return_null (GMT->parent, GMT_MEMORY_ERROR);
 	}
-	api_put_val = gmtapi_select_put_function (GMT->parent, M->type);	/* Get correct put function given data type */
+	if ((api_put_val = gmtapi_select_put_function (GMT->parent, M->type)) == NULL)	/* Get correct put function given data type */
+		return_null (GMT->parent, GMT_NOT_A_VALID_TYPE);
 	GMT_2D_to_index = gmtapi_get_2d_to_index (GMT->parent, M->shape, GMT_GRID_IS_REAL);	/* Get ij index function */
 	for (col = 0; col < M->n_columns; col++) {
 		for (row = 0; row < M->n_rows; row++) {
@@ -3393,7 +3394,9 @@ GMT_LOCAL int gmtapi_write_matrix (struct GMT_CTRL *GMT, void *dest, unsigned in
 
 	/* Set index and put-value functions */
 	GMT_2D_to_index = gmtapi_get_2d_to_index (GMT->parent, M->shape, GMT_GRID_IS_REAL);
-	api_get_val = gmtapi_select_get_function (GMT->parent, M->type);
+	if ((api_get_val = gmtapi_select_get_function (GMT->parent, M->type)) == NULL)
+		return (GMT_NOT_A_VALID_TYPE);
+	
 
 	/* Start writing Matrix to fp */
 
@@ -3532,8 +3535,10 @@ GMT_LOCAL int gmtapi_write_vector (struct GMT_CTRL *GMT, void *dest, unsigned in
 
 	/* Set get function per vector column */
 	api_get_val = gmt_M_memory (GMT, NULL, V->n_columns, GMT_getfunction);
-	for (col = 0; col < V->n_columns; col++)
-		api_get_val[col] = gmtapi_select_get_function (GMT->parent, V->type[col]);
+	for (col = 0; col < V->n_columns; col++) {
+		if ((api_get_val[col] = gmtapi_select_get_function (GMT->parent, V->type[col])) == NULL)
+			return (GMT_NOT_A_VALID_TYPE);
+	}
 
 	/* Start writing Vector to fp */
 
@@ -3690,7 +3695,8 @@ GMT_LOCAL struct GMT_VECTOR * gmtapi_read_vector (struct GMT_CTRL *GMT, void *so
 		return_null (GMT->parent, GMT_MEMORY_ERROR);
 	}
 	for (col = 0; col < V->n_columns; col++) {
-		api_put_val = gmtapi_select_put_function (GMT->parent, V->type[col]);
+		if ((api_put_val = gmtapi_select_put_function (GMT->parent, V->type[col])) == NULL)
+			return_null (GMT->parent, GMT_NOT_A_VALID_TYPE);
 		for (row = 0; row < V->n_rows; row++)
 			api_put_val (&(V->data[col]), row, GMT->hidden.mem_coord[col][row]);
 	}
@@ -3948,7 +3954,9 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 				D_obj->table[D_obj->n_tables]->segment = gmt_M_memory (GMT, NULL, s_alloc, struct GMT_DATASEGMENT *);
 				S = D_obj->table[D_obj->n_tables]->segment[0] = GMT_Alloc_Segment (API, smode, M_obj->n_rows, n_columns, NULL, NULL);
 				GMT_2D_to_index = gmtapi_get_2d_to_index (API, M_obj->shape, GMT_GRID_IS_REAL);
-				api_get_val = gmtapi_select_get_function (API, M_obj->type);
+				if ((api_get_val = gmtapi_select_get_function (API, M_obj->type)) == NULL)
+					return_null (API, GMT_NOT_A_VALID_TYPE);
+
 				n_use = gmtapi_n_cols_needed_for_gaps (GMT, M_obj->n_columns);	/* Number of input columns to process */
 				for (row = seg = n_records = 0; row < M_obj->n_rows; row++) {	/* This loop may include NaN-records and data records */
 					gmtapi_update_prev_rec (GMT, n_use);	/* Make last current record the previous record if it is required by gap checking */
@@ -4014,12 +4022,15 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 				D_obj->table[D_obj->n_tables]->segment = gmt_M_memory (GMT, NULL, s_alloc, struct GMT_DATASEGMENT *);
 				S = D_obj->table[D_obj->n_tables]->segment[0] = GMT_Alloc_Segment (API, smode, V_obj->n_rows, n_columns, NULL, NULL);
 				for (col = 1, diff_types = false; !diff_types && col < V_obj->n_columns; col++) if (V_obj->type[col] != V_obj->type[col-1]) diff_types = true;
-				if (!diff_types) api_get_val = gmtapi_select_get_function (API, V_obj->type[0]);
+				if (!diff_types && (api_get_val = gmtapi_select_get_function (API, V_obj->type[0])) == NULL)
+					return_null (API, GMT_NOT_A_VALID_TYPE);
+
 				for (row = seg = n_records = 0; row < V_obj->n_rows; row++) {	/* This loop may include NaN-records and data records */
 					n_use = gmtapi_n_cols_needed_for_gaps (GMT, V_obj->n_columns);
 					gmtapi_update_prev_rec (GMT, n_use);
 					for (col = 0; col < V_obj->n_columns; col++) {	/* Process a single record into curr_rec */
-						if (diff_types) api_get_val = gmtapi_select_get_function (API, V_obj->type[col]);
+						if (diff_types && (api_get_val = gmtapi_select_get_function (API, V_obj->type[col])) == NULL)
+							return_null (API, GMT_NOT_A_VALID_TYPE);
 						api_get_val (&(V_obj->data[col]), row, &(GMT->current.io.curr_rec[col]));
 					}
 					if ((status = gmtapi_bin_input_memory (GMT, V_obj->n_columns, n_use)) < 0) {	/* Segment header found, finish the one we had and add more */
@@ -4324,7 +4335,8 @@ GMT_LOCAL int gmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, uns
 
 			/* Set up index and put-value functions for this matrix */
 			GMT_2D_to_index = gmtapi_get_2d_to_index (API, M_obj->shape, GMT_GRID_IS_REAL);
-			api_put_val = gmtapi_select_put_function (API, M_obj->type);
+			if ((api_put_val = gmtapi_select_put_function (API, M_obj->type)) == NULL)
+				return (gmtlib_report_error (API, GMT_NOT_A_VALID_TYPE));
 
 			for (tbl = row_out = 0; tbl < D_obj->n_tables; tbl++) {	/* Loop over tables and segments */
 				for (seg = 0; seg < D_obj->table[tbl]->n_segments; seg++) {
@@ -4379,7 +4391,8 @@ GMT_LOCAL int gmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, uns
 			}
 
 			/* Set up put-value functions for this vector */
-			if (!diff_types) api_put_val = gmtapi_select_put_function (API, V_obj->type[0]);	/* Get function to write 1st column (possibly all columns) */
+			if (!diff_types && (api_put_val = gmtapi_select_put_function (API, V_obj->type[0])) == NULL)	/* Get function to write 1st column (possibly all columns) */
+				return (gmtlib_report_error (API, GMT_NOT_A_VALID_TYPE));
 			for (tbl = row_out = 0; tbl < D_obj->n_tables; tbl++) {	/* Loop over all tables and segments */
 				for (seg = 0; seg < D_obj->table[tbl]->n_segments; seg++) {
 					S = D_obj->table[tbl]->segment[seg];	/* Shorthand for this segment */
@@ -4390,7 +4403,8 @@ GMT_LOCAL int gmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, uns
 					}
 					for (row = 0; row < S->n_rows; row++, row_out++) {	/* Copy the data records */
 						for (col = 0; col < V_obj->n_columns; col++) {
-							if (diff_types) api_put_val = gmtapi_select_put_function (API, V_obj->type[col]);
+							if (diff_types && (api_put_val = gmtapi_select_put_function (API, V_obj->type[col])) == NULL)
+								return (gmtlib_report_error (API, GMT_NOT_A_VALID_TYPE));
 							value = gmtapi_select_dataset_value (GMT, S, (unsigned int)row, (unsigned int)col);
 							api_put_val (&(V_obj->data[col]), row_out, value);
 						}
@@ -4718,7 +4732,8 @@ GMT_LOCAL struct GMT_IMAGE * gmtapi_import_image (struct GMTAPI_CTRL *API, int o
 			gmt_set_grddim (GMT, I_obj->header);	/* Set all dimensions */
 			I_obj->data = gmt_M_memory (GMT, NULL, I_obj->header->size, unsigned char);
 			GMT_2D_to_index = gmtapi_get_2d_to_index (API, M_obj->shape, GMT_GRID_IS_REAL);
-			api_get_val = gmtapi_select_get_function (API, M_obj->type);
+			if ((api_get_val = gmtapi_select_get_function (API, M_obj->type)) == NULL)
+				return_null (API, GMT_NOT_A_VALID_TYPE);
 			gmt_M_grd_loop (GMT, I_obj, row, col, ij) {
 				ij_orig = GMT_2D_to_index (row, col, M_obj->dim);
 				api_get_val (&(M_obj->data), ij_orig, &d);
@@ -5138,7 +5153,8 @@ GMT_LOCAL struct GMT_GRID * gmtapi_import_grid (struct GMTAPI_CTRL *API, int obj
 					G_obj->header->z_min = +DBL_MAX;
 					G_obj->header->z_max = -DBL_MAX;
 					HH->has_NaNs = GMT_GRID_NO_NANS;	/* We are about to check for NaNs and if none are found we retain 1, else 2 */
-					api_get_val = gmtapi_select_get_function (API, M_obj->type);
+					if ((api_get_val = gmtapi_select_get_function (API, M_obj->type)) == NULL)
+						return_null (API, GMT_NOT_A_VALID_TYPE);
 					gmt_M_grd_loop (GMT, G_obj, row, col, ij) {
 						ij_orig = GMT_2D_to_index (row, col, M_obj->dim);
 						api_get_val (&(M_obj->data), ij_orig, &d);
@@ -5156,7 +5172,8 @@ GMT_LOCAL struct GMT_GRID * gmtapi_import_grid (struct GMTAPI_CTRL *API, int obj
 			GMT_Report (API, GMT_MSG_INFORMATION, "Importing grid data from user memory location\n");
 			G_obj->data = gmt_M_memory_aligned (GMT, NULL, G_obj->header->size, gmt_grdfloat);
 			GMT_2D_to_index = gmtapi_get_2d_to_index (API, M_obj->shape, GMT_GRID_IS_REAL);
-			api_get_val = gmtapi_select_get_function (API, M_obj->type);
+			if ((api_get_val = gmtapi_select_get_function (API, M_obj->type)) == NULL)
+				return_null (API, GMT_NOT_A_VALID_TYPE);
 			gmt_M_grd_loop (GMT, G_obj, row, col, ij) {
 				ij_orig = GMT_2D_to_index (row, col, M_obj->dim);
 				api_get_val (&(M_obj->data), ij_orig, &d);
@@ -5398,7 +5415,8 @@ GMT_LOCAL int gmtapi_export_grid (struct GMTAPI_CTRL *API, int object_ID, unsign
 				MH->alloc_mode = GMT_ALLOC_INTERNALLY;
 			}
 			GMT_2D_to_index = gmtapi_get_2d_to_index (API, M_obj->shape, GMT_GRID_IS_REAL);
-			api_put_val = gmtapi_select_put_function (API, M_obj->type);
+			if ((api_put_val = gmtapi_select_put_function (API, M_obj->type)) == NULL)
+				return (gmtlib_report_error (API, GMT_NOT_A_VALID_TYPE));
 			gmt_M_grd_loop (GMT, G_obj, row, col, ijp) {
 				ij = GMT_2D_to_index (row, col, M_obj->dim);
 				api_put_val (&(M_obj->data), ij, (double)G_obj->data[ijp]);
@@ -6919,6 +6937,7 @@ GMT_LOCAL int gmtapi_end_io_matrix (struct GMTAPI_CTRL *API, struct GMTAPI_DATA_
 	}
 	if (S->delay) {	/* Must place delayed NaN record(s) signifying segment header(s) */
 		GMT_putfunction api_put_val = gmtapi_select_put_function (API, M->type);
+		if (api_put_val == NULL) return_error (API, GMT_NOT_A_VALID_TYPE);
 		p_func_uint64_t GMT_2D_to_index = NULL;
 		uint64_t col, ij;
 		GMT_2D_to_index = gmtapi_get_2d_to_index (API, GMT_IS_ROW_FORMAT, GMT_GRID_IS_REAL);	/* Can only do row-format until end of this function */
@@ -7990,7 +8009,8 @@ struct GMT_RECORD *api_get_record_matrix (struct GMTAPI_CTRL *API, unsigned int 
 		API->current_get_M = gmtapi_get_matrix_data (S->resource);
 		API->current_get_n_columns = (GMT->common.i.select) ? GMT->common.i.n_cols : S->n_columns;
 		API->current_get_M_index = gmtapi_get_2d_to_index (API, API->current_get_M->shape, GMT_GRID_IS_REAL);
-		API->current_get_M_val = gmtapi_select_get_function (API, API->current_get_M->type);
+		if ((API->current_get_M_val = gmtapi_select_get_function (API, API->current_get_M->type)) == NULL)
+			return NULL;
 		record = NULL;
 	}
 	else {	/* Read from the current resource */
@@ -8605,7 +8625,8 @@ GMT_LOCAL int gmtapi_put_record_init (struct GMTAPI_CTRL *API, unsigned int mode
 			/* Place current matrix parameters in API */
 			API->current_put_M = M_obj;
 			API->current_put_M_index = gmtapi_get_2d_to_index (API, GMT_IS_ROW_FORMAT, GMT_GRID_IS_REAL);	/* Since we cannot do col_format without knowing dimension - see end_io_matrix */
-			API->current_put_M_val = gmtapi_select_put_function (API, M_obj->type);
+			if ((API->current_put_M_val = gmtapi_select_put_function (API, M_obj->type)) == NULL)
+				return GMT_NOT_A_VALID_TYPE;
 			API->api_put_record = gmtapi_put_record_matrix;
 			error = gmtapi_put_record_matrix (API, mode, record);
 			break;
@@ -8643,8 +8664,10 @@ GMT_LOCAL int gmtapi_put_record_init (struct GMTAPI_CTRL *API, unsigned int mode
 			/* Place current vector parameters in API */
 			API->current_put_V = V_obj;
 			API->current_put_V_val = gmt_M_memory (GMT, NULL, V_obj->n_columns, GMT_putfunction);	/* Array of functions */
-			for (col = 0; col < V_obj->n_columns; col++)	/* Assign the functions */
-				API->current_put_V_val[col] = gmtapi_select_put_function (API, V_obj->type[col]);
+			for (col = 0; col < V_obj->n_columns; col++) {	/* Assign the functions */
+				if ((API->current_put_V_val[col] = gmtapi_select_put_function (API, V_obj->type[col])) == NULL)
+					return GMT_NOT_A_VALID_TYPE;
+			}
 			API->api_put_record = gmtapi_put_record_vector;
 			error = gmtapi_put_record_vector (API, mode, record);
 			break;
@@ -12031,7 +12054,7 @@ GMT_LOCAL void * gmtapi_dataset2matrix (struct GMTAPI_CTRL *API, struct GMT_DATA
 		MH = gmt_get_M_hidden (Out);
 		MH->alloc_mode = GMT_ALLOC_INTERNALLY;
 	}
-	api_put_val = gmtapi_select_put_function (API, Out->type);
+	if ((api_put_val = gmtapi_select_put_function (API, Out->type)) == NULL) return (NULL);
 	GMT_2D_to_index = gmtapi_get_2d_to_index (API, Out->shape, GMT_GRID_IS_REAL);
 	for (tbl = row_out = 0; tbl < In->n_tables; tbl++) {
 		D = In->table[tbl];	/* Shorthand to current input data table */
@@ -12077,7 +12100,7 @@ GMT_LOCAL void * gmtapi_dataset2vector (struct GMTAPI_CTRL *API, struct GMT_DATA
 			return (NULL);
 		}
 	}
-	api_put_val = gmtapi_select_put_function (API, Out->type[0]);	/* Since all columns are of same type we get the pointer here */
+	if ((api_put_val = gmtapi_select_put_function (API, Out->type[0])) == NULL) return NULL;	/* Since all columns are of same type we get the pointer here */
 	for (tbl = row_out = 0; tbl < In->n_tables; tbl++) {
 		D = In->table[tbl];	/* Shorthand to current input data table */
 		for (seg = 0; seg < D->n_segments; seg++) {
@@ -12114,7 +12137,8 @@ GMT_LOCAL void * gmtapi_matrix2dataset (struct GMTAPI_CTRL *API, struct GMT_MATR
 	if (alloc && (Out = gmtlib_create_dataset (GMT, 1U, 1U, In->n_rows, In->n_columns, GMT_IS_POINT, mode, true)) == NULL)
 		return_null (API, GMT_MEMORY_ERROR);
 	SD = Out->table[0]->segment[0];	/* Shorthand to only segment in the dataset */
-	api_get_val = gmtapi_select_get_function (API, In->type);
+	if ((api_get_val = gmtapi_select_get_function (API, In->type)) == NULL)
+		return_null (API, GMT_NOT_A_VALID_TYPE);
 	GMT_2D_to_index = gmtapi_get_2d_to_index (API, In->shape, GMT_GRID_IS_REAL);
 	for (row = 0; row < In->n_rows; row++) {
 		for (col = 0; col < In->n_columns; col++) {
@@ -12152,8 +12176,10 @@ GMT_LOCAL void * gmtapi_matrix2vector (struct GMTAPI_CTRL *API, struct GMT_MATRI
 		}
 	}
 
-	api_get_val_m = gmtapi_select_get_function (API, In->type);
-	api_put_val_v = gmtapi_select_put_function (API, GMT->current.setting.export_type);	/* Since all columns are of same type we get the pointer here */
+	if ((api_get_val_m = gmtapi_select_get_function (API, In->type)) == NULL)
+		return_null (API, GMT_NOT_A_VALID_TYPE);
+	if ((api_put_val_v = gmtapi_select_put_function (API, GMT->current.setting.export_type)) == NULL)	/* Since all columns are of same type we get the pointer here */
+		return_null (API, GMT_NOT_A_VALID_TYPE);
 	GMT_2D_to_index = gmtapi_get_2d_to_index (API, In->shape, GMT_GRID_IS_REAL);
 	for (row = 0; row < In->n_rows; row++) {
 		for (col = 0; col < In->n_columns; col++) {
@@ -12183,7 +12209,8 @@ GMT_LOCAL void * gmtapi_vector2dataset (struct GMTAPI_CTRL *API, struct GMT_VECT
 		return_null (API, GMT_MEMORY_ERROR);
 	SD = Out->table[0]->segment[0];	/* Shorthand to only segment in the dataset */
 	for (col = 0; col < In->n_columns; col++) {
-		api_get_val = gmtapi_select_get_function (API, In->type[col]);
+		if ((api_get_val = gmtapi_select_get_function (API, In->type[col])) == NULL)
+			return_null (API, GMT_NOT_A_VALID_TYPE);
 		for (row = 0; row < In->n_rows; row++)
 			api_get_val (&(In->data[col]), row, &(SD->data[col][row]));
 	}
@@ -12223,9 +12250,13 @@ GMT_LOCAL void * gmtapi_vector2matrix (struct GMTAPI_CTRL *API, struct GMT_VECTO
 	}
 
 	GMT_2D_to_index = gmtapi_get_2d_to_index (API, Out->shape, GMT_GRID_IS_REAL);
-	api_put_val = gmtapi_select_put_function (API, Out->type);	/* Since all columns are of same type we get the pointer here */
+	if ((api_put_val = gmtapi_select_put_function (API, Out->type)) == NULL)	/* Since all columns are of same type we get the pointer here */
+		return (NULL);
 	for (col = 0; col < In->n_columns; col++) {
-		api_get_val = gmtapi_select_get_function (API, In->type[col]);
+		if ((api_get_val = gmtapi_select_get_function (API, In->type[col])) == NULL) {
+			gmt_M_free (GMT, Out);
+			return (NULL);
+		}
 		for (row = 0; row < In->n_rows; row++) {
 			api_get_val (&(In->data[col]), row, &value);
 			ij = GMT_2D_to_index (row, col, Out->dim);

--- a/src/gmt_fft.c
+++ b/src/gmt_fft.c
@@ -336,8 +336,8 @@ int gmt_fft_set_wave (struct GMT_CTRL *GMT, unsigned int mode, struct GMT_FFT_WA
 		case GMT_FFT_K_IS_KY: K->k_ptr = gmtfft_ky; break;
 		case GMT_FFT_K_IS_KR: K->k_ptr = gmtfft_kr; break;
 		default:
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad mode selected (%u) - exit\n", mode);
-			GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad mode passed to gmt_fft_set_wave (%u)!\n", mode);
+			return GMT_RUNTIME_ERROR;
 			break;
 	}
 	return GMT_OK;
@@ -502,10 +502,8 @@ GMT_LOCAL fftwf_plan gmtfft_gmt_fftwf_plan_dft(struct GMT_CTRL *GMT, unsigned n_
 			plan = fftwf_plan_dft_2d(n_rows, n_columns, cin, cout, sign, GMT->current.setting.fftw_plan);
 	}
 
-	if (plan == NULL) { /* There was a problem creating a plan */
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not create FFTW plan.\n");
-		GMT_exit (GMT, GMT_ARG_IS_NULL); return NULL;
-	}
+	if (plan == NULL) /* There was a problem creating a plan */
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not create FFTW plan!\n");
 
 	return plan;
 }

--- a/src/gmt_memory.c
+++ b/src/gmt_memory.c
@@ -81,7 +81,7 @@ GMT_LOCAL void gmtmemory_init_tmp_arrays (struct GMT_CTRL *GMT, int direction, s
 	GMT->hidden.mem_set = true;
 }
 
-GMT_LOCAL int gmtmemory_die_if_memfail (struct GMT_CTRL *GMT, size_t nelem, size_t size, const char *where) {
+GMT_LOCAL void gmtmemory_die_if_memfail (struct GMT_CTRL *GMT, size_t nelem, size_t size, const char *where) {
 	/* Handle reporting and aborting if memory allocation fails */
 	double mem = ((double)nelem) * ((double)size);
 	unsigned int k = 0;
@@ -91,7 +91,6 @@ GMT_LOCAL int gmtmemory_die_if_memfail (struct GMT_CTRL *GMT, size_t nelem, size
 #ifdef DEBUG
 	gmtlib_report_func (GMT, GMT_MSG_WARNING, where, "gmt_M_memory [realloc] called\n");
 #endif
-	GMT_exit (GMT, GMT_MEMORY_ERROR); return GMT_MEMORY_ERROR;
 }
 
 #ifdef MEMDEBUG
@@ -147,7 +146,7 @@ int gmt_memtrack_init (struct GMT_CTRL *GMT) {
 		snprintf (logfile, GMT_LEN32, "gmt_memtrack_%d.log", pid);
 		if ((M->fp = fopen (logfile, "w")) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not create log file gmt_memtrack_%d.log\n", pid);
-			GMT_exit (GMT, GMT_ERROR_ON_FOPEN); return GMT_ERROR_ON_FOPEN;
+			return GMT_ERROR_ON_FOPEN;
 		}
 	}
 	fprintf (M->fp, "# %s", ctime (&now));
@@ -500,7 +499,7 @@ void *gmt_memory_func (struct GMT_CTRL *GMT, void *prev_addr, size_t nelem, size
 #ifdef DEBUG
 		gmtlib_report_func (GMT, GMT_MSG_WARNING, where, "gmt_M_memory called\n");
 #endif
-		GMT_exit (GMT, GMT_MEMORY_ERROR); return NULL;
+		GMT->parent->error = GMT_MEMORY_ERROR; return NULL;
 	}
 
 #if defined(WIN32) && !defined(USE_MEM_ALIGNED)
@@ -527,8 +526,10 @@ void *gmt_memory_func (struct GMT_CTRL *GMT, void *prev_addr, size_t nelem, size
 		}
 		else
 			tmp = realloc ( prev_addr, nelem * size);
-		if (tmp == NULL)
+		if (tmp == NULL) {
 			gmtmemory_die_if_memfail (GMT, nelem, size, where);
+			return (NULL);
+		}
 	}
 	else {
 		if (nelem == 0) return (NULL); /* Take care of n == 0 */
@@ -549,8 +550,10 @@ void *gmt_memory_func (struct GMT_CTRL *GMT, void *prev_addr, size_t nelem, size
 		}
 		else
 			tmp = calloc (nelem, size);
-		if (tmp == NULL)
+		if (tmp == NULL) {
 			gmtmemory_die_if_memfail (GMT, nelem, size, where);
+			return (NULL);
+		}
 	}
 
 #ifdef MEMDEBUG

--- a/src/gmt_memory.c
+++ b/src/gmt_memory.c
@@ -146,6 +146,7 @@ int gmt_memtrack_init (struct GMT_CTRL *GMT) {
 		snprintf (logfile, GMT_LEN32, "gmt_memtrack_%d.log", pid);
 		if ((M->fp = fopen (logfile, "w")) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not create log file gmt_memtrack_%d.log\n", pid);
+			M->active = 0;
 			return GMT_ERROR_ON_FOPEN;
 		}
 	}

--- a/src/gmt_proj.c
+++ b/src/gmt_proj.c
@@ -410,8 +410,8 @@ GMT_LOCAL int gmtproj_genper_tolatlong (struct GMT_CTRL *GMT, double x, double y
 	}
 	if (set_exit == 1) gmt_message (GMT, "gmtproj_genper_tolatlong - 5\n");
 	if (set_exit || GMT->current.proj.g_debug > 1) {
-		gmt_message (GMT, "phi    %12.7f\n", phi*R2D);
-		GMT_exit (GMT, GMT_PROJECTION_ERROR); return GMT_PROJECTION_ERROR;
+		gmt_message (GMT, "gmtproj_genper_tolatlong phi    %12.7f\n", phi*R2D);
+		return GMT_PROJECTION_ERROR;
 	}
 	*lat = phi * R2D;
 	*lon = atan2d (Y, X) + GMT->current.proj.g_lon0;
@@ -2591,7 +2591,7 @@ double gmtproj_left_robinson (struct GMT_CTRL *GMT, double y) {
 	Y = fabs (y * GMT->current.proj.n_i_cy);
 	if (gmt_intpol (GMT, GMT->current.proj.n_Y, GMT->current.proj.n_X, GMT_N_ROBINSON, 1, &Y, &X, GMT->current.setting.interpolant)) {
 		gmt_message (GMT, "GMT Internal error in gmtproj_left_robinson!\n");
-		GMT_exit (GMT, GMT_PROJECTION_ERROR); return GMT->session.d_NaN;
+		return GMT->session.d_NaN;
 	}
 
 	x = GMT->current.proj.n_cx * X * (GMT->common.R.wesn[XLO] - GMT->current.proj.central_meridian);
@@ -2606,7 +2606,7 @@ double gmtproj_right_robinson (struct GMT_CTRL *GMT, double y) {
 	Y = fabs (y * GMT->current.proj.n_i_cy);
 	if (gmt_intpol (GMT, GMT->current.proj.n_Y, GMT->current.proj.n_X, GMT_N_ROBINSON, 1, &Y, &X, GMT->current.setting.interpolant)) {
 		gmt_message (GMT, "GMT Internal error in gmtproj_right_robinson!\n");
-		GMT_exit (GMT, GMT_PROJECTION_ERROR); return GMT->session.d_NaN;
+		return GMT->session.d_NaN;
 	}
 
 	x = GMT->current.proj.n_cx * X * (GMT->common.R.wesn[XHI] - GMT->current.proj.central_meridian);

--- a/src/gmt_regexp.c
+++ b/src/gmt_regexp.c
@@ -45,7 +45,8 @@
 #endif
 
 int gmtlib_regexp_match (struct GMT_CTRL *GMT, const char *subject, const char *pattern, bool caseless) {
-/* Match string against the extended regular expression in pattern. Return 1 for match, 0 for no match. */
+/* Match string against the extended regular expression in pattern. Return 1 for match, 0 for no match.
+ * Returns a negative value for fatal errors. */
 
 #ifdef HAVE_PCRE
 
@@ -77,7 +78,7 @@ int gmtlib_regexp_match (struct GMT_CTRL *GMT, const char *subject, const char *
 
 	if (re == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtlib_regexp_match: PCRE compilation failed at offset %d: %s.\n", erroffset, error);
-		GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+		return (-GMT_RUNTIME_ERROR);
 	}
 
 	/*************************************************************************
@@ -105,7 +106,7 @@ int gmtlib_regexp_match (struct GMT_CTRL *GMT, const char *subject, const char *
 			/* Handle other special cases if you like */
 			default:
 				 GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtlib_regexp_match: PCRE matching error %d.\n", rc);
-				 GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				 return (-GMT_RUNTIME_ERROR);
 				 break;
 		}
 		return (0);	/* Match failed */
@@ -146,7 +147,7 @@ int gmtlib_regexp_match (struct GMT_CTRL *GMT, const char *subject, const char *
 		PCRE2_UCHAR error[256];
 		pcre2_get_error_message(errornumber, error, sizeof(error));
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtlib_regexp_match: PCRE2 compilation failed at offset %d: %s.\n", erroffset, error);
-		GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+		return (-GMT_RUNTIME_ERROR);
 	}
 
 	/*************************************************************************
@@ -180,7 +181,7 @@ int gmtlib_regexp_match (struct GMT_CTRL *GMT, const char *subject, const char *
 			/* Handle other special cases if you like */
 			default:
 				 GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtlib_regexp_match: PCRE2 matching error %d.\n", rc);
-				 GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				 return (-GMT_RUNTIME_ERROR);
 				 break;
 		}
 		return (0);	/* Match failed */
@@ -204,7 +205,7 @@ int gmtlib_regexp_match (struct GMT_CTRL *GMT, const char *subject, const char *
 	if ( (status = regcomp(&re, pattern, cflags)) != 0) {
 		regerror(status, &re, err_msg, MAX_ERR_LENGTH);
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtlib_regexp_match: POSIX ERE compilation failed: %s\n", err_msg);
-		GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+		return (-GMT_RUNTIME_ERROR);
 	}
 
 	/* execute the RE against the subject string */
@@ -216,7 +217,7 @@ int gmtlib_regexp_match (struct GMT_CTRL *GMT, const char *subject, const char *
 		/* this is when errors have been encountered */
 		regerror(status, &re, err_msg, MAX_ERR_LENGTH);
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtlib_regexp_match: POSIX ERE matching error: %s\n", err_msg); /* Report error. */
-		GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+		return (-GMT_RUNTIME_ERROR;)
 	}
 	return (0); /* No match */
 
@@ -224,7 +225,7 @@ int gmtlib_regexp_match (struct GMT_CTRL *GMT, const char *subject, const char *
 
 	/* disable ERE support */
 	GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtlib_regexp_match: this GMT version was compiled without regular expression support.\n");
-	GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+	return (-GMT_RUNTIME_ERROR);
 
 #endif
 }

--- a/src/gmt_shore.c
+++ b/src/gmt_shore.c
@@ -408,18 +408,18 @@ int gmt_set_levels (struct GMT_CTRL *GMT, char *info, struct GMT_SHORE_SELECT *I
 				case 'S': I->antarctica_mode |= GSHHS_ANTARCTICA_SKIP_INV;	break;	/* Skip everything BUT Antarctica data south of 60S */
 				default:
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -A modifier +a: Invalid code %c\n", p[0]);
-					GMT_exit (GMT, GMT_PARSE_ERROR); return GMT_PARSE_ERROR;
+					return GMT_PARSE_ERROR;
 					break;
 			}
 			p++;	/* Go to next code */
 		}
 		if ((I->antarctica_mode & GSHHS_ANTARCTICA_GROUND) && (I->antarctica_mode & GSHHS_ANTARCTICA_ICE)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -A modifier +a: Cannot select both g and i\n");
-			GMT_exit (GMT, GMT_PARSE_ERROR); return GMT_PARSE_ERROR;
+			return GMT_PARSE_ERROR;
 		}
 		if ((I->antarctica_mode & GSHHS_ANTARCTICA_SKIP) && (I->antarctica_mode & GSHHS_ANTARCTICA_SKIP_INV)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -A modifier +a: Cannot select both s and S\n");
-			GMT_exit (GMT, GMT_PARSE_ERROR); return GMT_PARSE_ERROR;
+			return GMT_PARSE_ERROR;
 		}
 	}
 	if (strstr (info, "+l"))  I->flag = GSHHS_NO_RIVERLAKES;
@@ -431,7 +431,7 @@ int gmt_set_levels (struct GMT_CTRL *GMT, char *info, struct GMT_SHORE_SELECT *I
 	n = sscanf (info, "%lf/%d/%d", &I->area, &I->low, &I->high);
 	if (n == 0) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -A: No area given\n");
-		GMT_exit (GMT, GMT_PARSE_ERROR); return GMT_PARSE_ERROR;
+		return GMT_PARSE_ERROR;
 	}
 	if (n == 1) I->low = 0, I->high = GSHHS_MAX_LEVEL;
 	return (GMT_OK);

--- a/src/gmt_stat.c
+++ b/src/gmt_stat.c
@@ -1805,7 +1805,8 @@ int gmt_median (struct GMT_CTRL *GMT, double *x, uint64_t n, double xmin, double
 		}
 		else {	/* If we get here, I made a mistake!  */
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Internal goof in gmt_median; please report to developers!\n");
-			GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+			*med = GMT->session.d_NaN;
+			return -1;
 		}
 
 	} while (!finished);

--- a/src/gmtmath.c
+++ b/src/gmtmath.c
@@ -6693,7 +6693,8 @@ EXTERN_MSC int GMT_gmtmath (void *V_API, int mode, void *args) {
 				if (Ctrl->C.cols[j]) continue;
 				status = (*call_operator[op]) (GMT, &info, stack, nstack - 1, j);	/* Do it */
 				if (status == -1) {	/* Serious problem, need to bail */
-					GMT_exit (GMT, GMT_RUNTIME_ERROR); Return (GMT_RUNTIME_ERROR);
+					GMT_Report (API, GMT_MSG_ERROR, "Operand %s returned status = %d. Must give up.\n", operator[op], status);
+					Return (GMT_RUNTIME_ERROR);
 				}
 			}
 		}

--- a/src/gmtselect.c
+++ b/src/gmtselect.c
@@ -335,7 +335,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTSELECT_CTRL *Ctrl, struct GMT_
 
 			case 'A':	/* Limit GSHHS features */
 				Ctrl->A.active = true;
-				gmt_set_levels (GMT, opt->arg, &Ctrl->A.info);
+				n_errors += gmt_set_levels (GMT, opt->arg, &Ctrl->A.info);
 				break;
 			case 'C':	/* Near a point test  Syntax -C<pfile>+d<distance>  */
 				Ctrl->C.active = true;

--- a/src/grdlandmask.c
+++ b/src/grdlandmask.c
@@ -162,7 +162,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDLANDMASK_CTRL *Ctrl, struct GM
 
 			case 'A':	/* Restrict GSHHS features */
 				Ctrl->A.active = true;
-				gmt_set_levels (GMT, opt->arg, &Ctrl->A.info);
+				n_errors += gmt_set_levels (GMT, opt->arg, &Ctrl->A.info);
 				break;
 			case 'D':	/* Set GSHHS resolution */
 				Ctrl->D.active = true;

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -491,7 +491,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDMATH_CTRL *Ctrl, struct GMT_OP
 
 			case 'A':	/* Restrict GSHHS features */
 				Ctrl->A.active = true;
-				gmt_set_levels (GMT, opt->arg, &Ctrl->A.info);
+				n_errors += gmt_set_levels (GMT, opt->arg, &Ctrl->A.info);
 				break;
 			case 'D':	/* Set GSHHS resolution */
 				Ctrl->D.active = true;

--- a/src/img/img2grd.c
+++ b/src/img/img2grd.c
@@ -683,7 +683,7 @@ EXTERN_MSC int GMT_img2grd (void *V_API, int mode, void *args) {
 			GMT_Report (API, GMT_MSG_ERROR, "Read failure at jin = %d.\n", jin);
 			gmt_M_free (GMT, ix);	gmt_M_free (GMT, row);
 			fclose (fp);
-			GMT_exit (GMT, GMT_DATA_READ_ERROR); return GMT_DATA_READ_ERROR;
+			Return (GMT_DATA_READ_ERROR);
 		}
 
 #ifndef WORDS_BIGENDIAN

--- a/src/mgd77/mgd77manage.c
+++ b/src/mgd77/mgd77manage.c
@@ -702,7 +702,7 @@ EXTERN_MSC int GMT_mgd77manage (void *V_API, int mode, void *args) {
 				gmt_M_free (GMT, colvalue);
 				if (two_cols) gmt_M_free (GMT, coldnt);
 				if (strings) gmt_M_free (GMT, tmp_string);
-				GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				Return (GMT_RUNTIME_ERROR);
 			}
 
 			if (strings) {	/* number in col1, string in col2 */
@@ -763,7 +763,7 @@ EXTERN_MSC int GMT_mgd77manage (void *V_API, int mode, void *args) {
 
 		if (MGD77_Read_File (GMT, list[argno], &In, D)) {
 			GMT_Report (API, GMT_MSG_ERROR, "Failure while reading data set for cruise %s\n", list[argno]);
-			GMT_exit (GMT, GMT_DATA_READ_ERROR); return GMT_DATA_READ_ERROR;
+			Return (GMT_DATA_READ_ERROR);
 		}
 
 		/* Start reading data from file */
@@ -775,7 +775,7 @@ EXTERN_MSC int GMT_mgd77manage (void *V_API, int mode, void *args) {
 			if (set == MGD77_M77_SET && !Ctrl->F.active) {
 				GMT_Report (API, GMT_MSG_ERROR, "Column %s is part of the standard MGD77 set and cannot be removed unless you use -F!\n",
 				            Ctrl->I.c_abbrev);
-				GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				Return (GMT_RUNTIME_ERROR);
 			}
 			if (!Ctrl->A.replace) {
 				GMT_Report (API, GMT_MSG_ERROR, "A columned named %s is already present in %s.  use -A+ to overwrite [default is to skip]\n",
@@ -837,7 +837,7 @@ EXTERN_MSC int GMT_mgd77manage (void *V_API, int mode, void *args) {
 
 			sprintf (oldfile, "%s.old", In.path);
 			if (gmt_rename_file (GMT, In.path, oldfile, GMT_RENAME_FILE)) {
-				GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				Return (GMT_RUNTIME_ERROR);
 			}
 
 			/* Update header history */
@@ -851,14 +851,14 @@ EXTERN_MSC int GMT_mgd77manage (void *V_API, int mode, void *args) {
 
 			if (MGD77_Write_File (GMT, In.path, &In, D)) {	/* Create the new, slimmer file */
 				GMT_Report (API, GMT_MSG_ERROR, "Failure while writing slimmer version of %s\n", list[argno]);
-				GMT_exit (GMT, GMT_DATA_WRITE_ERROR); return GMT_DATA_WRITE_ERROR;
+				Return (GMT_DATA_WRITE_ERROR);
 			}
 
 			/* Now we can safely remove the old file */
 
 			if (gmt_remove_file (GMT, oldfile))	{
 				GMT_Report (API, GMT_MSG_ERROR, "Failure while removing the old version of %s\n", list[argno]);
-				GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				Return (GMT_RUNTIME_ERROR);
 			}
 
 			MGD77_Free_Dataset (GMT, &D);
@@ -870,7 +870,7 @@ EXTERN_MSC int GMT_mgd77manage (void *V_API, int mode, void *args) {
 			D = MGD77_Create_Dataset (GMT);
 			if (MGD77_Read_File (GMT, list[argno], &In, D)) {
 				GMT_Report (API, GMT_MSG_ERROR, "Failure while reading data set for cruise %s\n", list[argno]);
-				GMT_exit (GMT, GMT_DATA_READ_ERROR); return GMT_DATA_READ_ERROR;
+				Return (GMT_DATA_READ_ERROR);
 			}
 			if (reset_column)
 				column = MGD77_NOT_SET;
@@ -1011,7 +1011,7 @@ EXTERN_MSC int GMT_mgd77manage (void *V_API, int mode, void *args) {
 			if (n != D->H.n_records) {
 				GMT_Report (API, GMT_MSG_ERROR, "Extra column data records (%d) do not match # of cruise records (%d) for %s\n",
 				            n, D->H.n_records, list[argno]);
-				GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				Return (GMT_RUNTIME_ERROR);
 			}
 			GMT_Report (API, GMT_MSG_INFORMATION, "Appended column data for all %d records for cruise %s\n", D->H.n_records, list[argno]);
 		}
@@ -1038,7 +1038,7 @@ EXTERN_MSC int GMT_mgd77manage (void *V_API, int mode, void *args) {
 				result = gmt_intpol (GMT, coldnt, colvalue, n, D->H.n_records, x, y, GMT->current.setting.interpolant);
 				if (result != 0) {
 					GMT_Report (API, GMT_MSG_ERROR, "Failure in gmt_intpol near row %d!\n", result+1);
-					GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				Return (GMT_RUNTIME_ERROR);
 				}
 				gmt_M_memcpy (colvalue, y, D->H.n_records, double);
 				gmt_M_free (GMT, y);

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -295,7 +295,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOAST_CTRL *Ctrl, struct GMT_OP
 
 			case 'A':
 				Ctrl->A.active = true;
-				gmt_set_levels (GMT, opt->arg, &Ctrl->A.info);
+				n_errors += gmt_set_levels (GMT, opt->arg, &Ctrl->A.info);
 				break;
 			case 'C':	/* Lake colors */
 				Ctrl->C.active = true;

--- a/src/segy/pssegyz.c
+++ b/src/segy/pssegyz.c
@@ -653,11 +653,11 @@ EXTERN_MSC int GMT_pssegyz (void *V_API, int mode, void *args) {
 
 	if ((check = segy_get_reelhd (fpi, reelhead)) != true) {
 		fclose (fpi);
-		GMT_exit (GMT, GMT_RUNTIME_ERROR); Return(GMT_RUNTIME_ERROR);
+		Return (GMT_RUNTIME_ERROR);
 	}
 	if ((check = segy_get_binhd (fpi, &binhead)) != true) {
 		fclose (fpi);
-		GMT_exit (GMT, GMT_RUNTIME_ERROR); Return(GMT_RUNTIME_ERROR);
+		Return (GMT_RUNTIME_ERROR);
 	}
 
 	if (Ctrl->A.active) {
@@ -685,7 +685,6 @@ use a few of these*/
 
 	if (!Ctrl->L.value) { /* no number of samples still - a problem! */
 		GMT_Report (API, GMT_MSG_ERROR, "Number of samples per trace unknown\n");
-		GMT_exit (GMT, GMT_RUNTIME_ERROR);
 		if (fpi != stdin) fclose (fpi);
 		Return(GMT_RUNTIME_ERROR);
 	}
@@ -705,7 +704,7 @@ use a few of these*/
 	if (!Ctrl->Q.value[Y_ID]) { /* still no sample interval at this point is a problem! */
 		GMT_Report (API, GMT_MSG_ERROR, "No sample interval in reel header\n");
 		if (fpi != stdin) fclose (fpi);
-		GMT_exit (GMT, GMT_RUNTIME_ERROR); Return(GMT_RUNTIME_ERROR);
+		Return (GMT_RUNTIME_ERROR);
 	}
 
 	bitmap = gmt_M_memory (GMT, NULL, nm, unsigned char);

--- a/src/segy/segy2grd.c
+++ b/src/segy/segy2grd.c
@@ -344,14 +344,12 @@ EXTERN_MSC int GMT_segy2grd (void *V_API, int mode, void *args) {
 	if ((check = segy_get_reelhd (fpi, reelhead)) != true) {
 		if (fpi != stdin) fclose (fpi);
 		gmt_M_free (GMT, flag);
-		GMT_exit (GMT, GMT_RUNTIME_ERROR);
-		return GMT_RUNTIME_ERROR;
+		Return (GMT_RUNTIME_ERROR);
 	}
 	if ((check = segy_get_binhd (fpi, &binhead)) != true) {
 		if (fpi != stdin) fclose (fpi);
 		gmt_M_free (GMT, flag);
-		GMT_exit (GMT, GMT_RUNTIME_ERROR);
-		return GMT_RUNTIME_ERROR;
+		Return (GMT_RUNTIME_ERROR);
 	}
 
 	if (swap_bytes) {
@@ -400,7 +398,7 @@ EXTERN_MSC int GMT_segy2grd (void *V_API, int mode, void *args) {
 		GMT_Report (API, GMT_MSG_ERROR, "No sample interval in reel header\n");
 		if (fpi != stdin) fclose (fpi);
 		gmt_M_free (GMT, flag);
-		GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+		Return (GMT_RUNTIME_ERROR);
 	}
 	if (read_cont && (Ctrl->Q.value[Y_ID] != Grid->header->inc[GMT_Y])) {
 		GMT_Report (API, GMT_MSG_INFORMATION, "Grid spacing != sample interval, setting sample interval to grid spacing\n");

--- a/src/spectrum1d.c
+++ b/src/spectrum1d.c
@@ -765,7 +765,7 @@ EXTERN_MSC int GMT_spectrum1d (void *V_API, int mode, void *args) {
 
 			y = (C.y_given) ? S->data[GMT_Y] : NULL;
 			if (spectrum1d_compute_spectra (GMT, &C, S->data[GMT_X], y, S->n_rows, Ctrl->L.active, Ctrl->L.mode)) {
-				GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				Return (GMT_RUNTIME_ERROR);
 			}
 
 			if (!Ctrl->T.active) {

--- a/src/sphtriangulate.c
+++ b/src/sphtriangulate.c
@@ -106,7 +106,7 @@ GMT_LOCAL int sphtriangulate_delaunay_output (struct GMT_CTRL *GMT, double *lon,
 		dim[GMT_ROW] = 3;	/* All segments has 3 rows */
 		if ((Dout[0] = GMT_Create_Data (GMT->parent, GMT_IS_DATASET, GMT_IS_LINE, 0, dim, NULL, NULL, 0, 0, NULL)) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to create a data set for sphtriangulate\n");
-			GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+			return GMT_RUNTIME_ERROR;
 		}
 		if (nodes) {	/* Want Voronoi node and area information via Dout[1] */
 			dim[GMT_SEG] = 1;	/* Just one segment */
@@ -114,7 +114,7 @@ GMT_LOCAL int sphtriangulate_delaunay_output (struct GMT_CTRL *GMT, double *lon,
 			dim[GMT_ROW] = D->n;	/* One row per node */
 			if ((Dout[1] = GMT_Create_Data (GMT->parent, GMT_IS_DATASET, GMT_IS_POINT, 0, dim, NULL, NULL, 0, 0, NULL)) == NULL) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to create a data set for sphtriangulate nodes\n");
-				GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				return GMT_RUNTIME_ERROR;
 			}
 			S[1] = Dout[1]->table[0]->segment[0];
 		}
@@ -181,7 +181,7 @@ GMT_LOCAL int sphtriangulate_delaunay_output (struct GMT_CTRL *GMT, double *lon,
 		if ((Dout[0] = GMT_Create_Data (GMT->parent, GMT_IS_DATASET, GMT_IS_LINE, 0, dim, NULL, NULL, 0, 0, NULL)) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to create a data set for sphtriangulate arcs\n");
 			gmt_M_free (GMT, arc);
-			GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+			return GMT_RUNTIME_ERROR;
 		}
 		for (i = 0; i < n_arcs; i++) {
 			S[0] = Dout[0]->table[0]->segment[i];	/* Shorthand for this output segment */
@@ -239,7 +239,7 @@ GMT_LOCAL int sphtriangulate_voronoi_output (struct GMT_CTRL *GMT, uint64_t n, d
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to create a data set for sphtriangulate\n");
 		gmt_M_free (GMT, plon);		gmt_M_free (GMT, plat);
 		gmt_M_free (GMT, arc);
-		GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+		return GMT_RUNTIME_ERROR;
 	}
 	if (nodes) {	/* Want Voronoi node and area information via Dout[1] */
 		dim[GMT_SEG] = 1;	/* Only need one segment */
@@ -247,7 +247,7 @@ GMT_LOCAL int sphtriangulate_voronoi_output (struct GMT_CTRL *GMT, uint64_t n, d
 		dim[GMT_ROW] = n;	/* One row per node */
 		if ((Dout[1] = GMT_Create_Data (GMT->parent, GMT_IS_DATASET, GMT_IS_POINT, 0, dim, NULL, NULL, 0, 0, NULL)) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to create a data set for sphtriangulate nodes\n");
-			GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+			return GMT_RUNTIME_ERROR;
 		}
 		S[1] = Dout[1]->table[0]->segment[0];	/* Shorthand for this segment */
 	}
@@ -348,7 +348,7 @@ GMT_LOCAL int sphtriangulate_voronoi_output (struct GMT_CTRL *GMT, uint64_t n, d
 		if ((Dout[0] = GMT_Create_Data (GMT->parent, GMT_IS_DATASET, GMT_IS_LINE, 0, dim, NULL, NULL, 0, 0, NULL)) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to create a data set for sphtriangulate Voronoi nodes\n");
 			gmt_M_free (GMT, arc);
-			GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+			return GMT_RUNTIME_ERROR;
 		}
 		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Output %d unique Voronoi arcs\n", n_arcs);
 
@@ -666,13 +666,17 @@ EXTERN_MSC int GMT_sphtriangulate (void *V_API, int mode, void *args) {
 
 	GMT->current.setting.io_header[GMT_OUT] = true;	/* Turn on table headers on output */
 	if (Ctrl->Q.mode == VORONOI) {	/* Selected Voronoi polygons */
-		sphtriangulate_voronoi_output (GMT, n, lon, lat, &T.V, Ctrl->T.active, Ctrl->A.active + steradians, Ctrl->N.active, Dout);
+		if ((error = sphtriangulate_voronoi_output (GMT, n, lon, lat, &T.V, Ctrl->T.active, Ctrl->A.active + steradians, Ctrl->N.active, Dout))) {
+			Return (error);
+		}
 		gmt_M_free (GMT, T.V.lon);	gmt_M_free (GMT, T.V.lat);
 		gmt_M_free (GMT, T.V.lend);	gmt_M_free (GMT, T.V.listc);
 		gmt_M_free (GMT, T.V.lptr);
 	}
 	else {	/* Selected Delaunay triangles */
-		sphtriangulate_delaunay_output (GMT, lon, lat, &T.D, Ctrl->T.active, Ctrl->A.active + steradians, Ctrl->N.active, Dout);
+		if ((error = sphtriangulate_delaunay_output (GMT, lon, lat, &T.D, Ctrl->T.active, Ctrl->A.active + steradians, Ctrl->N.active, Dout))) {
+			Return (error);
+		}
 	}
 
 	Dout[0]->table[0]->header = gmt_M_memory (GMT, NULL, 1, char *);	/* One header record only */

--- a/src/spotter/grdspotter.c
+++ b/src/spotter/grdspotter.c
@@ -672,7 +672,7 @@ EXTERN_MSC int GMT_grdspotter (void *V_API, int mode, void *args) {
 
 			if ((fp = gmt_fopen (GMT, Ctrl->Q.file, "r")) == NULL) {	/* Oh, oh... */
 				GMT_Report (API, GMT_MSG_ERROR, "-Q info file unreadable/nonexistent\n");
-				GMT_exit (GMT, GMT_ERROR_ON_FOPEN); return GMT_ERROR_ON_FOPEN;
+				Return (GMT_ERROR_ON_FOPEN);
 			}
 			while (fgets (line, GMT_BUFSIZ, fp)) {
 				if (line[0] == '#' || line[0] == '\n') continue;

--- a/src/spotter/originater.c
+++ b/src/spotter/originater.c
@@ -401,10 +401,10 @@ EXTERN_MSC int GMT_originater (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the originater main code ----------------------------*/
 
-	ns = spotter_hotspot_init (GMT, Ctrl->F.file, true, &orig_hotspot);	/* Get geocentric hotspot locations */
-	if (ns < 0) {
-		GMT_exit (GMT, GMT_RUNTIME_ERROR); Return (GMT_RUNTIME_ERROR);		/* An error message was already issued by spotter_hotspot_init() */
+	if ((ns = spotter_hotspot_init (GMT, Ctrl->F.file, true, &orig_hotspot)) < 0) {	/* Get geocentric hotspot locations */
+		Return (GMT_RUNTIME_ERROR);		/* An error message was already issued by spotter_hotspot_init() */
 	}
+	
 	n_hotspots = (unsigned int)ns;
 	if (Ctrl->S.n > n_hotspots) {
 		GMT_Report (API, GMT_MSG_ERROR, "Option -S: Give value between 1 and %d\n", n_hotspots);

--- a/src/x2sys/x2sys_datalist.c
+++ b/src/x2sys/x2sys_datalist.c
@@ -274,7 +274,7 @@ EXTERN_MSC int GMT_x2sys_datalist (void *V_API, int mode, void *args) {
 	if (Ctrl->I.active && (k = x2sys_read_list (GMT, Ctrl->I.file, &ignore, &n_ignore)) != X2SYS_NOERROR) {
 		GMT_Report (API, GMT_MSG_ERROR, "Ignore file %s cannot be read - aborting\n", Ctrl->I.file);
 		x2sys_free_list (GMT, trk_name, n_tracks);
-		GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+		Return (GMT_RUNTIME_ERROR);
 	}
 
 	x2sys_err_fail (GMT, x2sys_set_system (GMT, Ctrl->T.TAG, &s, &B, &GMT->current.io), Ctrl->T.TAG);
@@ -322,7 +322,7 @@ EXTERN_MSC int GMT_x2sys_datalist (void *V_API, int mode, void *args) {
 				GMT_Report (API, GMT_MSG_ERROR, "Unit m for miles is not recognized\n");
 				x2sys_end (GMT, s);
 				x2sys_free_list (GMT, trk_name, n_tracks);
-				GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				Return (GMT_RUNTIME_ERROR);
 				break;
 			}
 			/* Intentionally fall through */
@@ -360,7 +360,7 @@ EXTERN_MSC int GMT_x2sys_datalist (void *V_API, int mode, void *args) {
 				GMT_Report (API, GMT_MSG_ERROR, "Unit m for miles is not recognized\n");
 				x2sys_end (GMT, s);
 				x2sys_free_list (GMT, trk_name, n_tracks);
-				GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				Return (GMT_RUNTIME_ERROR);
 				break;
 			}
 			/* Intentionally fall through */
@@ -385,7 +385,7 @@ EXTERN_MSC int GMT_x2sys_datalist (void *V_API, int mode, void *args) {
 			MGD77_Free_Correction (GMT, CORR, (unsigned int)n_tracks);
 			x2sys_end (GMT, s);
 			x2sys_free_list (GMT, trk_name, n_tracks);
-			GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+			Return (GMT_RUNTIME_ERROR);
 		}
 	}
 	/* Override default GMT->current.io.col_type[GMT_OUT] settings */


### PR DESCRIPTION
**Description of proposed changes**

This PR removes numerous gratuitous _GMT_exit_ calls from any module and from a bunch of the gmt_*.c files.  There is more, but this is a start, hence "part 1".

All tests continue to pass.  Most of these exit calls were not possible to trigger, I think, unless a developer passed a wrong argument to a function internally, and those who could be triggered would probably just crash the module instead.  In some places I pass the error cope up, if possible, and call Return (error) when I can.

This remains now:

```
./gmt_api.c:        2
./gmt_init.c:       29
./gmt_io.c:       22
./gmt_map.c:       17
./gmt_plot.c:       11
./gmt_sph.c:       14
./gmt_support.c:       35
./gmt_types.h:        2
./mgd77/mgd77.c:       25
./spotter/spotter.c:       14
./x2sys/x2sys.c:       16

```