### PR TITLE
Do not let PostScriptLight call exit

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -16185,7 +16185,10 @@ struct GMT_CTRL *gmt_begin (struct GMTAPI_CTRL *API, const char *session, unsign
 
 	GMT->PSL->init.unit = PSL_INCH;					/* We use inches internally in PSL */
 	GMT_Report (API, GMT_MSG_DEBUG, "Enter: PSL_beginsession\n");
-	PSL_beginsession (GMT->PSL, API->external, GMT->session.SHAREDIR, GMT->session.USERDIR);	/* Initializes the session and sets a few defaults */
+	if (PSL_beginsession (GMT->PSL, API->external, GMT->session.SHAREDIR, GMT->session.USERDIR)) {	/* Initializes the session and sets a few defaults */
+		gmtinit_free_GMT_ctrl (GMT);	/* Deallocate control structure */
+		return NULL;
+	}
 	GMT_Report (API, GMT_MSG_DEBUG, "Exit : PSL_beginsession\n");
 	/* Reset session defaults to the chosen GMT settings; these are fixed for the entire PSL session */
 	GMT_Report (API, GMT_MSG_DEBUG, "Enter: PSL_setdefaults\n");

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5636,6 +5636,10 @@ void gmt_setfill (struct GMT_CTRL *GMT, struct GMT_FILL *fill, int outline) {
 		/* Fill with a pattern */
 		double rgb[4] = {-3.0, -3.0, -3.0, 0.0};
 		rgb[1] = (double)PSL_setimage (PSL, fill->pattern_no, fill->pattern, fill->image, fill->dpi, fill->dim, fill->f_rgb, fill->b_rgb);
+		if (rgb[1] < 0.0) {	/* Error in PSL_setimage */
+			gmt_M_memset (rgb, 4, double);
+			PSL_comment (GMT->PSL, "PSL_setimage failed: Setting fill to black\n");
+		}
 		PSL_setfill (PSL, rgb, outline);
 	}
 	else	/* Fill with a color */

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -1757,13 +1757,15 @@ static char *psl_getsharepath (struct PSL_CTRL *PSL, const char *subdir, const c
 
 static int psl_place_encoding (struct PSL_CTRL *PSL, const char *encoding) {
 	/* Write the specified encoding string to file */
-	int k = 0, match = 0;
+	int k = 0, match = 0, err = 0;
 	while (PSL_ISO_name[k] && (match = strcmp (encoding, PSL_ISO_name[k])) != 0) k++;
 	if (match == 0)
 		PSL_command (PSL, "%s", PSL_ISO_encoding[k]);
-	else
+	else {
 		PSL_message (PSL, PSL_MSG_ERROR, "Fatal Error: Could not find ISO encoding %s\n", encoding);
-	return 0;
+		err = -1;
+	}
+	return err;
 }
 
 /* psl_bulkcopy copies the given long static string (defined in PSL_strings.h)

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -200,13 +200,6 @@ static inline uint32_t inline_bswap32 (uint32_t x) {
 #	define bswap32 inline_bswap32
 #endif /* HAVE___BUILTIN_BSWAP32 */
 
-/* Macro for exit since this should be returned when called from Matlab */
-#ifdef DO_NOT_EXIT
-#define PSL_exit(code) return(code)
-#else
-#define PSL_exit(code) exit(code)
-#endif
-
 #define PSL_M_unused(x) (void)(x)
 
 /* ISO Font encodings.  Ensure that the order of PSL_ISO_names matches order of includes below */
@@ -1768,10 +1761,8 @@ static int psl_place_encoding (struct PSL_CTRL *PSL, const char *encoding) {
 	while (PSL_ISO_name[k] && (match = strcmp (encoding, PSL_ISO_name[k])) != 0) k++;
 	if (match == 0)
 		PSL_command (PSL, "%s", PSL_ISO_encoding[k]);
-	else {
+	else
 		PSL_message (PSL, PSL_MSG_ERROR, "Fatal Error: Could not find ISO encoding %s\n", encoding);
-		PSL_exit (EXIT_FAILURE);
-	}
 	return 0;
 }
 
@@ -2474,13 +2465,13 @@ static int psl_pattern_init (struct PSL_CTRL *PSL, int image_no, char *imagefile
 	else {	/* User image, check to see if already used */
 		if (imagefile == NULL) {
 			PSL_message (PSL, PSL_MSG_ERROR, "Error: Gave NULL as imagefile name\n");
-			PSL_exit (EXIT_FAILURE);
+			return (-1);
 		}
 		i = psl_search_userimages (PSL, imagefile);	/* i = 0 is the first user image */
 		if (i >= 0) return (PSL_N_PATTERNS + i + 1);	/* Already registered, just return number */
 		if (PSL->internal.n_userimages > (PSL_N_PATTERNS-1)) {
 			PSL_message (PSL, PSL_MSG_ERROR, "Error: Already maintaining %d user images and cannot accept any more\n", PSL->internal.n_userimages+1);
-			PSL_exit (EXIT_FAILURE);
+			return (-1);
 		}
 		/* Must initialize a previously unused image */
 		PSL->internal.user_image[PSL->internal.n_userimages] = PSL_memory (PSL, NULL, strlen (imagefile)+1, char);
@@ -3174,7 +3165,7 @@ static int psl_init_fonts (struct PSL_CTRL *PSL) {
 		if ((in = fopen (fullname, "r")) == NULL) {	/* File exist but opening fails? WTF! */
 			PSL_message (PSL, PSL_MSG_ERROR, "Fatal Error: ");
 			perror (fullname);
-			PSL_exit (EXIT_FAILURE);
+			return (EXIT_FAILURE);
 		}
 
 		while (fgets (buf, PSL_BUFSIZ, in)) {
@@ -3459,12 +3450,12 @@ int PSL_beginsession (struct PSL_CTRL *PSL, unsigned int flags, char *sharedir, 
 		psl_dos_path_fix (PSL->internal.SHAREDIR);
 		if (access(PSL->internal.SHAREDIR, R_OK)) {
 			PSL_message (PSL, PSL_MSG_ERROR, "Error: Could not access PSL_SHAREDIR %s.\n", PSL->internal.SHAREDIR);
-			PSL_exit (EXIT_FAILURE);
+			return (EXIT_FAILURE);
 		}
 	}
 	else {	/* No sharedir found */
 		PSL_message (PSL, PSL_MSG_ERROR, "Error: Could not locate PSL_SHAREDIR.\n");
-		PSL_exit (EXIT_FAILURE);
+		return (EXIT_FAILURE);
 	}
 
 	/* Determine USERDIR (directory containing user replacements contents in SHAREDIR) */
@@ -4007,14 +3998,16 @@ int PSL_setimage (struct PSL_CTRL *PSL, int image_no, char *imagefile, unsigned 
 
 	/* Determine if image was used before */
 
-	if ((image_no > 0 && image_no <= PSL_N_PATTERNS) && !PSL->internal.pattern[image_no-1].status)	/* Unused predefined */
-		image_no = psl_pattern_init (PSL, image_no, NULL, NULL, 64, 64, 1);
+	if ((image_no > 0 && image_no <= PSL_N_PATTERNS) && !PSL->internal.pattern[image_no-1].status) {	/* Unused predefined */
+		if ((image_no = psl_pattern_init (PSL, image_no, NULL, NULL, 64, 64, 1)) < 0) return -1;	/* Error in psl_pattern_init */
+	}
 	else if (image_no < 0) {	/* User image, check if already used */
 		int i = psl_search_userimages (PSL, imagefile);	/* i = 0 is the first user image */
 		if (i == -1)	/* Not found or no previous user images loaded */
 			image_no = psl_pattern_init (PSL, -1, imagefile, image, dim[0], dim[1], dim[2]);
 		else
 			image_no = PSL_N_PATTERNS + i + 1;
+		if (image_no < 0) return -1;	/* Error in psl_pattern_init */
 	}
 	k = image_no - 1;	/* Image array index */
 	nx = PSL->internal.pattern[k].nx;


### PR DESCRIPTION
The externals (Julia, MATLAB, Python) cannot have liibpostscriptlight call _exit_.  Passing errors up to caller instead so it can decide to quit etc.
