### PR TITLE
Check if a map projection is given when guessing resolution

### DIFF
--- a/src/gmt_shore.c
+++ b/src/gmt_shore.c
@@ -451,7 +451,7 @@ int gmt_set_resolution (struct GMT_CTRL *GMT, char *res, char opt) {
 
 	switch (*res) {
 		case 'a':	/* Automatic selection via -J or -R, if possible */
-			if (GMT->common.J.active) {	/* Use map scale xxxx as in 1:xxxx */
+			if (GMT->common.J.active && !gmt_M_is_linear (GMT)) {	/* Use map scale xxxx as in 1:xxxx */
 				double i_scale = 1.0 / (0.0254 * GMT->current.proj.scale[GMT_X]);
 				if (i_scale > GMT_CRUDE_THRESHOLD)
 					base = 4;	/* crude */


### PR DESCRIPTION
We used map scale to guess a reasonable coastline resolution but that algorihtm assumed a map projection.  Now we skip this if just **-Jx** is given and use area instead.  Closes #3388.
