### PR TITLE
Let GMT_VECTOR have alloc_mode array

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -2092,9 +2092,9 @@ GMT_LOCAL int gmtapi_init_vector (struct GMTAPI_CTRL *API, uint64_t dim[], doubl
 			if (mode & GMT_WITH_STRINGS) {	/* Must allocate text pointer array */
 				if ((V->text = gmt_M_memory (API->GMT, NULL, V->n_rows, char *)) == NULL)
 					return (GMT_MEMORY_ERROR);
+				VH->alloc_mode_text = GMT_ALLOC_INTERNALLY;
 			}
 		}
-		VH->alloc_mode = GMT_ALLOC_INTERNALLY;
 	}
 
 	return (GMT_NOERROR);
@@ -12728,7 +12728,7 @@ int GMT_Put_Vector (void *API, struct GMT_VECTOR *V, unsigned int col, unsigned 
 			break;
 	}
 	VH = gmt_get_V_hidden (V);
-	VH->alloc_mode = GMT_ALLOC_EXTERNALLY;	/* Since it clearly is a user array */
+	VH->alloc_mode[col] = GMT_ALLOC_EXTERNALLY;	/* Since it clearly is a user array */
 	return GMT_NOERROR;
 }
 
@@ -12845,11 +12845,15 @@ int GMT_Put_Strings (void *V_API, unsigned int family, void *object, char **arra
 	if (!(family == GMT_IS_VECTOR || family == GMT_IS_MATRIX)) return_error (V_API, GMT_NOT_A_VALID_FAMILY);
 	if (family == GMT_IS_VECTOR) {
 		struct GMT_VECTOR *V = gmtapi_get_vector_data (object);
+		struct GMT_VECTOR_HIDDEN *VH = gmt_get_V_hidden (V);
 		V->text = array;
+		VH->alloc_mode_text = GMT_ALLOC_EXTERNALLY;
 	}
 	else if (family == GMT_IS_MATRIX) {
 		struct GMT_MATRIX *M = gmtapi_get_matrix_data (object);
+		struct GMT_MATRIX_HIDDEN *MH = gmt_get_M_hidden (M);
 		M->text = array;
+		MH->alloc_mode_text = GMT_ALLOC_EXTERNALLY;
 	}
 	return (GMT_NOERROR);
 }

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -4445,6 +4445,7 @@ GMT_LOCAL int gmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, uns
 				struct GMT_DATASEGMENT_HIDDEN *SH = gmt_get_DS_hidden (S);
 				if ((V_obj = gmt_create_vector (GMT, n_columns, GMT_OUT)) == NULL)
 					return (gmtlib_report_error (API, GMT_PTR_IS_NULL));
+				VH = gmt_get_V_hidden (V_obj);
 				for (col = 0; col < V_obj->n_columns; col++) {
 					V_obj->type[col] = S_obj->type;	/* Set same data type for all columns */
 					V_obj->data[col].f8 = S->data[col];	/* Set pointer only */
@@ -4455,7 +4456,6 @@ GMT_LOCAL int gmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, uns
 					VH->alloc_mode_text = GMT_ALLOC_EXTERNALLY;	/* Since not duplicated, just pointed to */
 				}
 				V_obj->n_rows = n_rows;
-				VH = gmt_get_V_hidden (V_obj);
 				VH->alloc_level = S_obj->alloc_level;	/* Otherwise D_obj will be freed before we get to use data */
 				S_obj->alloc_mode = DH->alloc_mode;	/* Otherwise D_obj will be freed before we get to use data */
 				SH->alloc_mode = GMT_ALLOC_EXTERNALLY;	/* To prevent freeing in D_obj */

--- a/src/gmt_hidden.h
+++ b/src/gmt_hidden.h
@@ -128,7 +128,8 @@ struct GMT_POSTSCRIPT_HIDDEN {	/* Supporting information hidden from the API */
 struct GMT_VECTOR_HIDDEN {	/* Supporting information hidden from the API */
 	uint64_t id;			/* The internal number of the data set */
 	unsigned int alloc_level;	/* The level it was allocated at */
-	enum GMT_enum_alloc alloc_mode;	/* Allocation mode [GMT_ALLOC_INTERNALLY] */
+	enum GMT_enum_alloc *alloc_mode;	/* Allocation mode per column [GMT_ALLOC_INTERNALLY] */
+	enum GMT_enum_alloc alloc_mode_text;	/* Allocation mode per text [GMT_ALLOC_INTERNALLY] */
 };
 
 struct GMT_MATRIX_HIDDEN {	/* Supporting information hidden from the API */
@@ -136,6 +137,7 @@ struct GMT_MATRIX_HIDDEN {	/* Supporting information hidden from the API */
 	int pad;			/* The internal number of the data set */
 	unsigned int alloc_level;	/* The level it was allocated at */
 	enum GMT_enum_alloc alloc_mode;	/* Allocation mode [GMT_ALLOC_INTERNALLY] */
+	enum GMT_enum_alloc alloc_mode_text;	/* Allocation mode per text [GMT_ALLOC_INTERNALLY] */
 };
 
 struct GMT_GRID_HEADER_HIDDEN {

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -213,8 +213,8 @@ EXTERN_MSC void gmtlib_inplace_transpose (gmt_grdfloat *A, unsigned int n_rows, 
 EXTERN_MSC void gmtlib_free_dataset_ptr (struct GMT_CTRL *GMT, struct GMT_DATASET *data);
 EXTERN_MSC void gmtlib_free_cpt_ptr (struct GMT_CTRL *GMT, struct GMT_PALETTE *P);
 EXTERN_MSC void gmtlib_free_ps_ptr (struct GMT_CTRL *GMT, struct GMT_POSTSCRIPT *P);
-EXTERN_MSC unsigned int gmtlib_free_matrix_ptr (struct GMT_CTRL *GMT, struct GMT_MATRIX *M, bool free_matrix);
-EXTERN_MSC unsigned int gmtlib_free_vector_ptr (struct GMT_CTRL *GMT, struct GMT_VECTOR *V, bool free_vector);
+EXTERN_MSC void gmtlib_free_matrix_ptr (struct GMT_CTRL *GMT, struct GMT_MATRIX *M, bool free_matrix);
+EXTERN_MSC void gmtlib_free_vector_ptr (struct GMT_CTRL *GMT, struct GMT_VECTOR *V, bool free_vector);
 EXTERN_MSC void gmtlib_union_transpose (struct GMT_CTRL *GMT, union GMT_UNIVECTOR *m, const uint64_t n_rows, const uint64_t n_columns, unsigned int type);
 EXTERN_MSC void gmtlib_free_image_ptr (struct GMT_CTRL *GMT, struct GMT_IMAGE *I, bool free_image);
 EXTERN_MSC struct GMT_IMAGE * gmtlib_duplicate_image (struct GMT_CTRL *GMT, struct GMT_IMAGE *I, unsigned int mode);


### PR DESCRIPTION
**Description of proposed changes**

We want the ability to give each vector in a **GMT_VECTOR** container its own allocation mode setting, since we may have a mix of user and GMT arrays.  This PR extends the hidden _alloc_mode_ variable to an array.  We also add a separate _alloc_mode_text_ variable to both the hidden structures for VECTOR and MATRIX.  Apart from updating the settings to be per-column, I fixed missing sections such as when we convert a data segment to a matrix or vector and the segment has trailing text; this did not get placed into the matrix or vector.  Still largely untested code but closer to being correct for sure.