### PR TITLE
Eliminate exit calls from gmt_sph.c

### DIFF
--- a/src/gmt_sph.c
+++ b/src/gmt_sph.c
@@ -92,7 +92,7 @@ int gmt_stripack_lists (struct GMT_CTRL *GMT, uint64_t n_in, double *x, double *
 		gmt_M_free (GMT, lptr);
 		gmt_M_free (GMT, list);
 		gmt_M_free (GMT, lend);
-		GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+		return GMT_RUNTIME_ERROR;
 	}
 
 	if (ierror > 0) {
@@ -100,7 +100,7 @@ int gmt_stripack_lists (struct GMT_CTRL *GMT, uint64_t n_in, double *x, double *
 		gmt_M_free (GMT, lptr);
 		gmt_M_free (GMT, list);
 		gmt_M_free (GMT, lend);
-		GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+		return GMT_RUNTIME_ERROR;
 	}
 
 	if (T->mode == INTERPOLATE) {	/* Pass back the three lists from trmesh_ */
@@ -122,7 +122,7 @@ int gmt_stripack_lists (struct GMT_CTRL *GMT, uint64_t n_in, double *x, double *
 	if (ierror) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "STRIPACK: Failure in TRLIST.\n");
 		gmt_M_free (GMT, list);		gmt_M_free (GMT, lend);		gmt_M_free (GMT, lptr);
-		GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+		return GMT_RUNTIME_ERROR;
 	}
 
 	if (T->mode == VORONOI) {	/* Construct the Voronoi diagram */
@@ -161,7 +161,7 @@ int gmt_stripack_lists (struct GMT_CTRL *GMT, uint64_t n_in, double *x, double *
 		if (0 < ierror) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "STRIPACK: Failure in CRLIST.  IERROR = %" PRId64 ".\n", ierror);
 			gmt_M_free (GMT, list);
-			GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+			return GMT_RUNTIME_ERROR;
 		}
 
 		/* Adjust Fortran to GMT indices */
@@ -202,7 +202,7 @@ int gmt_ssrfpack_grid (struct GMT_CTRL *GMT, double *x, double *y, double *z, do
 
 	gmt_M_memset (&P, 1, struct STRIPACK);
 	P.mode = INTERPOLATE;
-	gmt_stripack_lists (GMT, n, x, y, z, &P);
+	if (gmt_stripack_lists (GMT, n, x, y, z, &P)) return GMT_RUNTIME_ERROR;
 
 	/* Set out output nodes */
 
@@ -229,7 +229,7 @@ int gmt_ssrfpack_grid (struct GMT_CTRL *GMT, double *x, double *y, double *z, do
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in INTRC0: I = %d, J = %d, IER = %" PRId64 "\n", row, col, ierror);
 					gmt_M_free (GMT, plat);		gmt_M_free (GMT, plon);
 					gmt_M_free (GMT, sigma);	gmt_M_free (GMT, grad);
-					GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+					return GMT_RUNTIME_ERROR;
 				}
 			}
 		}
@@ -246,7 +246,7 @@ int gmt_ssrfpack_grid (struct GMT_CTRL *GMT, double *x, double *y, double *z, do
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in GRADL: K = %" PRId64 " IER = %" PRId64 "\n", k1, ierror);
 				gmt_M_free (GMT, plat);		gmt_M_free (GMT, plon);
 				gmt_M_free (GMT, sigma);	gmt_M_free (GMT, grad);
-				GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				return GMT_RUNTIME_ERROR;
 			}
 			sum += (double)ierror;
 		}
@@ -258,7 +258,7 @@ int gmt_ssrfpack_grid (struct GMT_CTRL *GMT, double *x, double *y, double *z, do
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in GETSIG: IER = %" PRId64 "\n", ierror);
 					gmt_M_free (GMT, plat);		gmt_M_free (GMT, plon);
 					gmt_M_free (GMT, sigma);	gmt_M_free (GMT, grad);
-					GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+					return GMT_RUNTIME_ERROR;
 				}
 				GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "GETSIG: %" PRId64 " tension factors altered;  Max change = %g\n", ierror, dsm);
 	        }
@@ -272,7 +272,7 @@ int gmt_ssrfpack_grid (struct GMT_CTRL *GMT, double *x, double *y, double *z, do
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in UNIF: IER = %" PRId64 "\n", ierror);
 			gmt_M_free (GMT, plat);		gmt_M_free (GMT, plon);
 			gmt_M_free (GMT, sigma);	gmt_M_free (GMT, grad);
-			GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+			return GMT_RUNTIME_ERROR;
 		}
 		GMT_Report (GMT->parent, GMT_MSG_INFORMATION,
 		            "UNIF: Number of evaluation points = %" PRId64 ", number of extrapolation points = %" PRId64 "\n", nm, ierror);
@@ -297,7 +297,7 @@ int gmt_ssrfpack_grid (struct GMT_CTRL *GMT, double *x, double *y, double *z, do
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in GRADG (iteration %" PRId64 "): IER = %" PRId64 "\n", iter, ierror);
 				gmt_M_free (GMT, plat);		gmt_M_free (GMT, plon);
 				gmt_M_free (GMT, sigma);	gmt_M_free (GMT, grad);
-				GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				return GMT_RUNTIME_ERROR;
 			}
 			GMT_Report (GMT->parent, GMT_MSG_INFORMATION,
 			            "GRADG (iteration %" PRId64 "): tolerance = %g max change = %g  maxit = %" PRId64 " no. iterations = %" PRId64 " ier = %" PRId64 "\n",
@@ -310,7 +310,7 @@ int gmt_ssrfpack_grid (struct GMT_CTRL *GMT, double *x, double *y, double *z, do
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in GETSIG (iteration %" PRId64 "): ier = %" PRId64 "\n", iter, ierror);
 					gmt_M_free (GMT, plat);		gmt_M_free (GMT, plon);
 					gmt_M_free (GMT, sigma);	gmt_M_free (GMT, grad);
-					GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+					return GMT_RUNTIME_ERROR;
 				}
 				GMT_Report (GMT->parent, GMT_MSG_INFORMATION,
 				            "GETSIG (iteration %" PRId64 "): %" PRId64 " tension factors altered;  Max change = %g\n", iter, ierror, dsm);
@@ -323,7 +323,7 @@ int gmt_ssrfpack_grid (struct GMT_CTRL *GMT, double *x, double *y, double *z, do
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in UNIF: IER = %" PRId64 "\n", ierror);
 			gmt_M_free (GMT, grad);		gmt_M_free (GMT, plat);
 			gmt_M_free (GMT, plon);		gmt_M_free (GMT, sigma);
-			GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+			return GMT_RUNTIME_ERROR;
 		}
 		GMT_Report (GMT->parent, GMT_MSG_INFORMATION,
 		            "UNIF: Number of evaluations = %" PRId64 ", number of extrapolations = %" PRId64 "\n", nm, ierror);
@@ -351,7 +351,7 @@ int gmt_ssrfpack_grid (struct GMT_CTRL *GMT, double *x, double *y, double *z, do
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in SMSURF (iteration %" PRId64 "): IER = %" PRId64 "\n", iter, ierror);
 				gmt_M_free (GMT, grad);		gmt_M_free (GMT, plat);		gmt_M_free (GMT, plon);
 				gmt_M_free (GMT, wt);		gmt_M_free (GMT, sigma);
-				GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+				return GMT_RUNTIME_ERROR;
 			}
 			if (ierror == 1)
 				GMT_Report (GMT->parent, GMT_MSG_INFORMATION,
@@ -362,7 +362,7 @@ int gmt_ssrfpack_grid (struct GMT_CTRL *GMT, double *x, double *y, double *z, do
 				if (ierror < 0) {
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in GETSIG (iteration %" PRId64 "): IER = %" PRId64 "\n", iter, ierror);
 					gmt_M_free (GMT, grad);		gmt_M_free (GMT, wt);
-					GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+					return GMT_RUNTIME_ERROR;
 				}
 				GMT_Report (GMT->parent, GMT_MSG_INFORMATION,
 				            "GETSIG (iteration %" PRId64 "): %" PRId64 " tension factors altered;  Max change = %g\n", iter, ierror, dsm);
@@ -373,7 +373,7 @@ int gmt_ssrfpack_grid (struct GMT_CTRL *GMT, double *x, double *y, double *z, do
 		gmt_M_free (GMT, wt);
 		if (ierror < 0) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in UNIF: ier = %" PRId64 "\n", ierror);
-			GMT_exit (GMT, GMT_RUNTIME_ERROR); return GMT_RUNTIME_ERROR;
+			return GMT_RUNTIME_ERROR;
 		}
 		GMT_Report (GMT->parent, GMT_MSG_INFORMATION,
 		            "UNIF: Number of evaluations = %" PRId64 ", number of extrapolations = %" PRId64 "\n", nm, ierror);

--- a/src/sphdistance.c
+++ b/src/sphdistance.c
@@ -452,7 +452,7 @@ EXTERN_MSC int GMT_sphdistance (void *V_API, int mode, void *args) {
 		GMT_Report (API, GMT_MSG_INFORMATION, "Do Voronoi construction using %" PRIu64 " points\n", n);
 
 		T.mode = VORONOI;
-		gmt_stripack_lists (GMT, n, xx, yy, zz, &T);	/* Do the basic triangulation */
+		if (gmt_stripack_lists (GMT, n, xx, yy, zz, &T)) Return (GMT_RUNTIME_ERROR);	/* Do the basic triangulation */
 		gmt_M_free (GMT, T.D.tri);	/* Don't need the triangulation */
 		if (Ctrl->C.active) {	/* Recompute lon,lat and set pointers */
 			gmt_n_cart_to_geo (GMT, n, xx, yy, zz, xx, yy);	/* Revert to lon, lat */

--- a/src/sphinterpolate.c
+++ b/src/sphinterpolate.c
@@ -353,7 +353,8 @@ EXTERN_MSC int GMT_sphinterpolate (void *V_API, int mode, void *args) {
 
 	/* Do the interpolation */
 
-	gmt_ssrfpack_grid (GMT, xx, yy, zz, ww, n, Ctrl->Q.mode, Ctrl->Q.value, Ctrl->T.active, Grid->header, surfd);
+	if (gmt_ssrfpack_grid (GMT, xx, yy, zz, ww, n, Ctrl->Q.mode, Ctrl->Q.value, Ctrl->T.active, Grid->header, surfd))
+		Return (GMT_RUNTIME_ERROR);
 
 	gmt_M_free (GMT, xx);	gmt_M_free (GMT, yy);
 	gmt_M_free (GMT, zz);	gmt_M_free (GMT, ww);

--- a/src/sphtriangulate.c
+++ b/src/sphtriangulate.c
@@ -657,7 +657,7 @@ EXTERN_MSC int GMT_sphtriangulate (void *V_API, int mode, void *args) {
 
 	gmt_M_memset (&T, 1, struct STRIPACK);
 	T.mode = Ctrl->Q.mode;
-	gmt_stripack_lists (GMT, n, xx, yy, zz, &T);	/* Do the basic triangulation */
+	if (gmt_stripack_lists (GMT, n, xx, yy, zz, &T)) Return (GMT_RUNTIME_ERROR);	/* Do the basic triangulation */
 	if (Ctrl->C.active) {	/* Must recover lon,lat and set pointers */
 		gmt_n_cart_to_geo (GMT, n, xx, yy, zz, xx, yy);	/* Revert to lon, lat */
 		lon = xx;


### PR DESCRIPTION
Easy, mostly needing to check return status in some modules.
