### PR TITLE
Avoid data-padding for grids if not needed by module

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -483,6 +483,7 @@ GMT_LOCAL int gmtgrdio_padspace (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h
 		return (false);	/* Subset equals whole area */
 	gmt_M_memcpy (P->wesn, wesn, 4, double);					/* Copy the subset boundaries */
 	if (pad[XLO] == 0 && pad[XHI] == 0 && pad[YLO] == 0 && pad[YHI] == 0) return (false);	/* No padding requested */
+	if (!GMT->current.io.grid_padding) return (false);	/* Not requested */
 
 	/* Determine if data exist for a pad on all four sides.  If not we give up */
 	wrap = gmt_grd_is_global (GMT, header);	/* If global wrap then we cannot be outside */
@@ -517,6 +518,12 @@ GMT_LOCAL int gmtgrdio_padspace (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h
 	}
 
 	return (true);	/* Return true so the calling function can take appropriate action */
+}
+
+void gmt_grd_set_datapadding (struct GMT_CTRL *GMT, bool set) {
+	/* Changes the value of GMT->current.io.grid_padding.
+	 * If set = true we turn padding on, else off. */
+	GMT->current.io.grid_padding = set;
 }
 
 GMT_LOCAL void gmtgrdio_handle_pole_averaging (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_grdfloat *grid, gmt_grdfloat f_value, int pole) {

--- a/src/gmt_io.h
+++ b/src/gmt_io.h
@@ -257,6 +257,7 @@ struct GMT_IO {				/* Used to process input data records */
 	bool trailing_text[2];	/* Default is to process training text unless turned off via -i, -o */
 	bool hash_refreshed;		/* true after calling the hash_refresh function the first time */
 	bool internet_error;		/* true after failing to get hash table due to time-out */
+	bool grid_padding;		/* If true we try to read two extra rows/cols from grids for BC purposes */
 	uint64_t seg_no;		/* Number of current multi-segment in entire data set */
 	uint64_t seg_in_tbl_no;		/* Number of current multi-segment in current table */
 	uint64_t n_clean_rec;		/* Number of clean records read (not including skipped records or comments or blanks) */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -172,6 +172,7 @@ EXTERN_MSC bool gmt_file_is_srtmtile (struct GMTAPI_CTRL *API, const char *file,
 
 /* gmt_grdio.c: */
 
+EXTERN_MSC void gmt_grd_set_datapadding (struct GMT_CTRL *GMT, bool set);
 EXTERN_MSC void gmt_grd_set_cartesian (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h, unsigned int direction);
 EXTERN_MSC int gmt_img_sanitycheck (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h);
 EXTERN_MSC void gmt_grd_flip_vertical (void *gridp, const unsigned n_cols, const unsigned n_rows, const unsigned n_stride, size_t cell_size);

--- a/src/grd2kml.c
+++ b/src/grd2kml.c
@@ -519,6 +519,8 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the grd2kml main code ----------------------------*/
 
+	gmt_grd_set_datapadding (GMT, true);	/* Turn on gridpadding when reading a subset */
+
 	uniq = (int)getpid();	/* Unique number for temporary files  */
 
 	/* Read grid header only to determine dimensions and required levels for the Pyramid */

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -800,6 +800,8 @@ EXTERN_MSC int GMT_grdblend (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the grdblend main code ----------------------------*/
 
+	gmt_grd_set_datapadding (GMT, true);	/* Turn on gridpadding when reading a subset */
+
 	if (Ctrl->In.n <= 1) {	/* Got a blend file (or stdin) */
 		if (GMT_Init_IO (API, GMT_IS_DATASET, GMT_IS_TEXT, GMT_IN, GMT_ADD_DEFAULT, 0, options) != GMT_NOERROR) {	/* Register data input */
 			Return (API->error);

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -1166,6 +1166,8 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the grdcontour main code ----------------------------*/
 
+	gmt_grd_set_datapadding (GMT, true);	/* Turn on gridpadding when reading a subset */
+
 	GMT_Report (API, GMT_MSG_INFORMATION, "Processing input grid\n");
 	if (Ctrl->D.active) {
 		GMT_Report (API, GMT_MSG_INFORMATION, "With -D, no plotting will take place\n");

--- a/src/grdgradient.c
+++ b/src/grdgradient.c
@@ -440,6 +440,8 @@ EXTERN_MSC int GMT_grdgradient (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the grdgradient main code ----------------------------*/
 
+	gmt_grd_set_datapadding (GMT, true);	/* Turn on gridpadding when reading a subset */
+
 	if (Ctrl->Q.mode & 1) {	/* Read in previous statistics */
 		char sfile[PATH_MAX] = {""};
 		FILE *fp = NULL;

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -642,6 +642,8 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the grdimage main code ----------------------------*/
 
+	gmt_grd_set_datapadding (GMT, true);	/* Turn on gridpadding when reading a subset */
+
 	use_intensity_grid = (Ctrl->I.active && !Ctrl->I.constant);	/* We want to use an intensity grid */
 	n_grids = (Ctrl->In.do_rgb) ? 3 : 1;	/* Either reading 3 grids (r, g, b) or a z-data grid */
 	if (Ctrl->A.file) {

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -346,6 +346,8 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the grdinterpolate main code ----------------------------*/
 
+	gmt_grd_set_datapadding (GMT, true);	/* Turn on gridpadding when reading a subset */
+
 	if (Ctrl->Z.active[GMT_IN]) {	/* Create the input level array */
 		if (gmt_create_array (GMT, 'Z', &(Ctrl->Z.T), NULL, NULL)) {
 			GMT_Report (API, GMT_MSG_ERROR, "Option -Zi: Unable to set up input level array\n");

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -6384,6 +6384,8 @@ EXTERN_MSC int GMT_grdmath (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the grdmath main code ----------------------------*/
 
+	gmt_grd_set_datapadding (GMT, true);	/* Turn on gridpadding when reading a subset */
+
 	gmt_enable_threads (GMT);	/* Set number of active threads, if supported */
 	GMT_Report (API, GMT_MSG_INFORMATION, "Perform reverse Polish notation calculations on grids\n");
 	gmt_M_memset (&info, 1, struct GRDMATH_INFO);		/* Initialize here to not crash when Return gets called */

--- a/src/grdproject.c
+++ b/src/grdproject.c
@@ -258,6 +258,8 @@ EXTERN_MSC int GMT_grdproject (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the grdproject main code ----------------------------*/
 
+	gmt_grd_set_datapadding (GMT, true);	/* Turn on gridpadding when reading a subset */
+
 	GMT_Report (API, GMT_MSG_INFORMATION, "Processing input grid\n");
 	gmt_set_pad (GMT, 2U);	/* Ensure space for BCs in case an API passed pad == 0 */
 	if ((GMT->common.R.active[ISET] + Ctrl->E.active) == 0) set_n = true;

--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -260,6 +260,8 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the grdsample main code ----------------------------*/
 
+	gmt_grd_set_datapadding (GMT, true);	/* Turn on gridpadding when reading a subset */
+
 	gmt_enable_threads (GMT);	/* Set number of active threads, if supported */
 	GMT_Report (API, GMT_MSG_INFORMATION, "Processing input grid\n");
 	gmt_set_pad (GMT, 2U);	/* Ensure space for BCs in case an API passed pad == 0 */

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -713,6 +713,8 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the grdtrack main code ----------------------------*/
 
+	gmt_grd_set_datapadding (GMT, true);	/* Turn on gridpadding when reading a subset */
+
 	cmd = GMT_Create_Cmd (API, options);
 	sprintf (run_cmd, "# %s %s", GMT->init.module_name, cmd);	/* Build command line argument string */
 	gmt_M_free (GMT, cmd);

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -815,6 +815,8 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the grdview main code ----------------------------*/
 
+	gmt_grd_set_datapadding (GMT, true);	/* Turn on gridpadding when reading a subset */
+
 	GMT->current.plot.mode_3D = 1;	/* Only do background axis first; do foreground at end */
 	use_intensity_grid = (Ctrl->I.active && !Ctrl->I.constant);	/* We want to use the intensity grid */
 


### PR DESCRIPTION
Since it adds extra work and in some cases causes netcdf slowness (#2402), we only turn on data padding in modules that require it.
