### PR TITLE
Add -Z option to grdconvert to enable scaling/translation services

### DIFF
--- a/doc/rst/source/grdconvert.rst
+++ b/doc/rst/source/grdconvert.rst
@@ -16,7 +16,7 @@ Synopsis
 [ |-N| ]
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]
-[ |-Z|\ [**+s**\ *factor*][**+o**\ *shift*] ]
+[ |-Z|\ [**+s**\ *factor*][**+o**\ *offset*] ]
 [ |SYN_OPT-f| ]
 [ |SYN_OPT--| ]
 
@@ -104,8 +104,8 @@ Optional Arguments
 
 .. _-Z:
 
-**-Z**\ [**+s**\ *factor*][**+o**\ *shift*]
-    Use to subtract *shift* from the data and then multiply the results by
+**-Z**\ [**+s**\ *factor*][**+o**\ *offset*]
+    Use to subtract *offset* from the data and then multiply the results by
     *factor* before writing the output file [1/0]. **Note**: This
     *changes* the values in the grid.  In contrast, while options to supply
     a scale and offset via the **+s** and **+o** modifiers in a file

--- a/doc/rst/source/grdconvert.rst
+++ b/doc/rst/source/grdconvert.rst
@@ -16,6 +16,7 @@ Synopsis
 [ |-N| ]
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]
+[ |-Z|\ [**+s**\ *factor*][**+o**\ *shift*] ]
 [ |SYN_OPT-f| ]
 [ |SYN_OPT--| ]
 
@@ -100,6 +101,18 @@ Optional Arguments
 
 .. |Add_-V| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-V.rst_
+
+.. _-Z:
+
+**-Z**\ [**+s**\ *factor*][**+o**\ *shift*]
+    Use to subtract *shift* from the data and then multiply the results by
+    *factor* before writing the output file [1/0]. **Note**: This
+    *changes* the values in the grid.  In contrast, while options to supply
+    a scale and offset via the **+s** and **+o** modifiers in a file
+    name also adjust the data accordingly they also set the scale and
+    offset in the metadata, so upon reading the new file you recover
+    the original range.  Typically, those options are used to enable
+    packing of data via the use of an integer format (see table).
 
 .. |Add_-f| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-f.rst_

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -181,7 +181,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t[-D<template>] [-F[l|r]] [%s] %s[-L<low>/<high>|n|N|P|p]\n", GMT_CONTG, API->K_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-N[<cpt>]] %s%s[-Q[<cut>][+z]] [%s]\n", API->O_OPT, API->P_OPT, GMT_Rgeoz_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-S<smooth>] [%s]\n", GMT_CONTT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [-W[a|c]<pen>[+c[l|f]]]\n\t[%s] [%s] [-Z[+s<fact>][+o<shift>][+p]\n",
+	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [-W[a|c]<pen>[+c[l|f]]]\n\t[%s] [%s] [-Z[+s<fact>][+o<shift>][+p]]\n",
 	                                 GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] %s[%s] [%s] [%s]\n", GMT_bo_OPT, API->c_OPT, GMT_do_OPT, GMT_ho_OPT, GMT_l_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [%s]\n\n", GMT_p_OPT, GMT_t_OPT, GMT_PAR_OPT);

--- a/src/grdconvert.c
+++ b/src/grdconvert.c
@@ -44,6 +44,10 @@ struct GRDCONVERT_CTRL {
 	struct GRDCONVERT_N {	/* -N */
 		bool active;
 	} N;
+	struct GRDCONVERT_Z {	/* -Z[+s<fact>][+o<shift>] */
+		bool active;
+		double scale, offset;
+	} Z;
 };
 
 static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
@@ -52,6 +56,8 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 	C = gmt_M_memory (GMT, NULL, 1, struct GRDCONVERT_CTRL);
 
 	/* Initialize values whose defaults are not 0/false/NULL */
+
+	C->Z.scale = 1.0;
 
 	return (C);
 }
@@ -69,7 +75,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s <ingrid>[=<id>][+s<scale>][+o<offset>][+n<nan>]\n\t-G<outgrid>[=<id>][+s<scale>][+o<offset>][+n<nan>][:<driver>[/<dataType>]] [-N]\n\t[%s] [%s] [%s] [%s]\n\n",
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s <ingrid>[=<id>][+s<scale>][+o<offset>][+n<nan>]\n\t-G<outgrid>[=<id>][+s<scale>][+o<offset>][+n<nan>][:<driver>[/<dataType>]]\n\t[-N] [%s] [%s]\n\t[-Z[+s<fact>][+o<shift>]] [%s] [%s]\n\n",
 		name, GMT_Rgeo_OPT, GMT_V_OPT, GMT_f_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -81,8 +87,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Do NOT write the header (for native grids only - ignored otherwise).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Useful when creating files to be used by external programs.\n");
-	GMT_Option (API, "R,V,f,.");
-
+	GMT_Option (API, "R,V");
+	GMT_Message (API, GMT_TIME_NONE, "\t-Z Subtract <shift> (via +o<shift> [0]) then multiply result by <fact>\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   (via +s<fact> [1]) before writing the output grid.\n");
+	GMT_Option (API, "f,.");
 	GMT_Message (API, GMT_TIME_NONE, "\nThe following grid file formats are supported:\n");
 	for (i = 1; i < GMT_N_GRD_FORMATS; ++i) {
 		if (!strstr (grdformats[i], "not supported"))
@@ -96,6 +104,30 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 #endif
 	return (GMT_MODULE_USAGE);
 }
+
+GMT_LOCAL unsigned int grdconvert_parse_Z_opt (struct GMT_CTRL *GMT, char *txt, struct GRDCONVERT_CTRL *Ctrl) {
+	/* Parse the -Z option: -Z[+s<scale>][+o<offset>] */
+	unsigned int uerr = 0;
+	if (!txt || txt[0] == '\0') {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR,
+    		"Option -Z: No arguments given\n");
+		return (GMT_PARSE_ERROR);
+	}
+	if (strstr (txt, "+s") || strstr (txt, "+o")) {
+		char p[GMT_LEN64] = {""};
+		unsigned int pos = 0;
+		while (gmt_getmodopt (GMT, 'Z', txt, "so", &pos, p, &uerr) && uerr == 0) {
+			switch (p[0]) {
+				case 's':	Ctrl->Z.scale = atof (&p[1]);	break;
+				case 'o':	Ctrl->Z.offset = atof (&p[1]);	break;
+				default: 	/* These are caught in gmt_getmodopt so break is just for Coverity */
+					break;
+			}
+		}
+	}
+	return (uerr ? GMT_PARSE_ERROR : GMT_NOERROR);
+}
+
 
 static int parse (struct GMT_CTRL *GMT, struct GRDCONVERT_CTRL *Ctrl, struct GMT_OPTION *options) {
 	/* This parses the options provided to grdconvert and sets parameters in CTRL.
@@ -152,6 +184,11 @@ static int parse (struct GMT_CTRL *GMT, struct GRDCONVERT_CTRL *Ctrl, struct GMT
 
 			case 'N':
 				Ctrl->N.active = true;
+				break;
+
+			case 'Z':	/* For scaling or phase data */
+				Ctrl->Z.active = true;
+				n_errors += grdconvert_parse_Z_opt (GMT, opt->arg, Ctrl);
 				break;
 
 			default:	/* Report bad options */
@@ -284,6 +321,12 @@ EXTERN_MSC int GMT_grdconvert (void *V_API, int mode, void *args) {
 		strcpy (Grid->header->x_units, "x_units");
 		strcpy (Grid->header->y_units, "y_units");
 	}
+	if (Ctrl->Z.active) {	/* Apply given scale/offset before writing */
+		/* Since gmt_scale_and_offset_f applies z' = z * scale + offset we must adjust Z.offset first: */
+		Ctrl->Z.offset *= Ctrl->Z.scale;
+		gmt_scale_and_offset_f (GMT, Grid->data, Grid->header->size, Ctrl->Z.scale, -Ctrl->Z.offset);
+	}
+
 	if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, hmode, NULL, Ctrl->G.file, Grid) != GMT_NOERROR)
 		Return (API->error);
 


### PR DESCRIPTION
We need to distinguish between what the **+s** and **+o** modifiers in a _filename_ do versus the ability to permanently change grid values (like what **grdmath** would do).  It is convenient to have a **-Z** option in **grdconvert** to avoid having to do separate **grdmath** calls for this simple task.

