### PR TITLE
Improve docs and always write out the ffmpe command

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -537,7 +537,7 @@ Remaking Movie with Existing PNG Frames
 
 Perhaps you made your movie and then decided you want to change the frame rate or adjust something else in
 how the movie is put together from all the still images.  If you kept all the frame images then
-iyou do not have to rerun the whole render process.  Assuming you want a MP4 movie and that you
+you do not have to rerun the whole render process.  Assuming you want a MP4 movie and that you
 want to rerun just the ffmpeg command, here is an example::
 
     ffmpeg -loglevel warning -f image2 -framerate 24 -y -i "mydir/myimages_%04d.png" -vcodec libx264 -pix_fmt yuv420p mymovie.mp4

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -527,10 +527,24 @@ Other Movie Formats
 
 As configured, **movie** only offers the MP4 and WebM formats for movies.  The conversion is performed by the
 tool `FFmpeg <https://www.ffmpeg.org/>`_, which has more codecs and processing options than there are children in China.
-If you wish to run FFmpeg with other options, select mp4 and run **movie** with verbose information on (**-Vi**).
+If you wish to run FFmpeg with other options, run **movie** with one of the two video formats.
 At the end it will print the FFmpeg command used.  You can copy, paste, and modify this command to
 select other codecs, bit-rates, and arguments.  You can also use the PNG sequence as input to tools such
 as QuickTime Player, iMovie, MovieMaker, and other commercial programs to make a movie that way.
+
+Remaking Movie with Existing PNG Frames
+---------------------------------------
+
+Perhaps you made your movie and then decided you want to change the frame rate or adjust something else in
+how the movie is put together from all the still images.  If you kept all the frame images then
+iyou do not have to rerun the whole render process.  Assuming you want a MP4 movie and that you
+want to rerun just the ffmpeg command, here is an example::
+
+    ffmpeg -loglevel warning -f image2 -framerate 24 -y -i "mydir/myimages_%04d.png" -vcodec libx264 -pix_fmt yuv420p mymovie.mp4
+
+This command is also written out when movie performs this step.
+For other movie formats you will need to consult the `FFmpeg <https://www.ffmpeg.org/>`_ documentation.
+**Note**: On Windows, the percentage character is special (like the dollar sign under shells) so you will need to enter two (%%).
 
 Manipulating Multiple Movies
 ----------------------------

--- a/src/movie.c
+++ b/src/movie.c
@@ -2241,7 +2241,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		}
 		sprintf (cmd, "gm convert -delay %u -loop %u +dither %s%c%s_%s.%s %s.gif", delay, Ctrl->A.loops, workdir, dir_sep, Ctrl->N.prefix, files, MOVIE_RASTER_EXTENSION, Ctrl->N.prefix);
 		gmt_sleep (MOVIE_PAUSE_A_SEC);	/* Wait 1 second to ensure all files are synced before building the movie */
-		GMT_Report (API, GMT_MSG_INFORMATION, "Running: %s\n", cmd);
+		GMT_Report (API, GMT_MSG_NOTICE, "Running: %s\n", cmd);
 		if ((error = system (cmd))) {
 			GMT_Report (API, GMT_MSG_ERROR, "Running GIF conversion returned error %d - exiting.\n", error);
 			Return (GMT_RUNTIME_ERROR);
@@ -2263,7 +2263,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		sprintf (cmd, "ffmpeg -loglevel %s -f image2 -framerate %g -y -i \"%s%c%s_%s.%s\" -vcodec libx264 %s -pix_fmt yuv420p %s.mp4",
 			extra, Ctrl->D.framerate, workdir, dir_sep, Ctrl->N.prefix, png_file, MOVIE_RASTER_EXTENSION, (Ctrl->F.options[MOVIE_MP4]) ? Ctrl->F.options[MOVIE_MP4] : "", Ctrl->N.prefix);
 		gmt_sleep (MOVIE_PAUSE_A_SEC);	/* Wait 1 second to ensure all files are synced before building the movie */
-		GMT_Report (API, GMT_MSG_INFORMATION, "Running: %s\n", cmd);
+		GMT_Report (API, GMT_MSG_NOTICE, "Running: %s\n", cmd);
 		if ((error = system (cmd))) {
 			GMT_Report (API, GMT_MSG_ERROR, "Running FFmpeg conversion to MP4 returned error %d - exiting.\n", error);
 			Return (GMT_RUNTIME_ERROR);
@@ -2286,7 +2286,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			extra, Ctrl->D.framerate, workdir, dir_sep, Ctrl->N.prefix, png_file, MOVIE_RASTER_EXTENSION, vpx[Ctrl->F.transparent],
 			(Ctrl->F.options[MOVIE_WEBM]) ? Ctrl->F.options[MOVIE_WEBM] : "", pix_fmt[Ctrl->F.transparent], Ctrl->N.prefix);
 		gmt_sleep (MOVIE_PAUSE_A_SEC);	/* Wait 1 second to ensure all files are synced before building the movie */
-		GMT_Report (API, GMT_MSG_INFORMATION, "Running: %s\n", cmd);
+		GMT_Report (API, GMT_MSG_NOTICE, "Running: %s\n", cmd);
 		if ((error = system (cmd))) {
 			GMT_Report (API, GMT_MSG_ERROR, "Running FFmpeg conversion to webM returned error %d - exiting.\n", error);
 			Return (GMT_RUNTIME_ERROR);


### PR DESCRIPTION
**Description of proposed changes**

Now we let the ffmpeg or gm call that assembles the movie always be displayed.  In addition, the documentation now addresses the case of rerunning the ffmpeg command without having to recreate all the frame images since you already have them,