### PR TITLE
Grdmix normalize io

### DIFF
--- a/doc/rst/source/grdmix.rst
+++ b/doc/rst/source/grdmix.rst
@@ -94,7 +94,7 @@ Optional Arguments
 .. _-I:
 
 **-I**\ *intensity*
-    A constant intensity or grid (-1/+1 range) to modify final output image colors.
+    A constant intensity or grid (-1 to +1 range) to modify final output image colors.
 
 .. _-M:
 

--- a/doc/rst/source/grdmix.rst
+++ b/doc/rst/source/grdmix.rst
@@ -20,7 +20,7 @@ Synopsis
 [ |-D| ]
 [ |-I|\ *intensity* ]
 [ |-M| ]
-[ |-N|\ [*factor*] ]
+[ |-N|\ [**i**\|\ **o**][*factor*] ]
 [ |-Q| ]
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]
@@ -75,7 +75,7 @@ Optional Arguments
 
 **-C**
     **C**\ onstruct an output image from one or three normalized input grids;
-    these grids must all have values in the 0-1 range only (see **-N** if they don't).
+    these grids must all have values in the 0-1 range only (see **-Ni** if they don't).
     Optionally, use **-A** to add transparency and **-I** to add intensity
     to the colors before writing the image. For three layers the input order must
     be red grid first, then the green grid, and finally the blue grid.
@@ -83,10 +83,10 @@ Optional Arguments
 .. _-D:
 
 **-D**
-    **D**\ econstruct a single image into one or three normalized output grids.
+    **D**\ econstruct a single image into one or three output grids.
     An extra grid will be written if the image contains an alpha (transparency layer).
-    All grids written will have values in the 0-1 range exclusively; however, you
-    can use **-N** to undo this implicit normalization.
+    All grids written will reflect the original image values in the 0-255 range exclusively;
+    however, you can use **-No** to normalize the values to the 0-1 range.
     The output names uses the name template given by **-G** which must contain the
     C-format string "%c".  This code is replaced by the codes R, G, B and A for color
     images and g, A for gray-scale images.
@@ -104,8 +104,9 @@ Optional Arguments
 
 .. _-N:
 
-**-N**\ [*factor*] 
-    Normalize all input grids from 0-255 to 0-1 [All input grids are assumed to be in 0-1 range].
+**-N**\ [**i**\|\ **o**][*factor*] 
+    Normalize all input grids from 0-255 to 0-1 and all output grids from 0-1 to 0-255.
+    To only turn on normalization for input *or* output, use **-Ni** or **-No** instead.
     To normalize by another factor than 255, append an optional *factor* value.
 
 .. _-Q:
@@ -163,7 +164,7 @@ To insert the values from the grid transparency.grd into the image gravity.tif a
 To break the color image layers.png into separate, normalized red, green, and blue grids (and possibly an alpha grid),
 we run::
 
-    gmt grdmix layers.png -D -Glayer_%c.grd
+    gmt grdmix layers.png -D -Glayer_%c.grd -No
 
 To recombine the three normalized grids red.grd, green.grd, and blue.grd into a TIFF file, but
 applying intensities from intens.grd and add transparency from transp.grd grids, try::

--- a/src/grdmix.c
+++ b/src/grdmix.c
@@ -439,7 +439,7 @@ EXTERN_MSC int GMT_grdmix (void *V_API, int mode, void *args) {
 			if (GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_DATA_ONLY, NULL, Ctrl->In.file[k], G_in[k]) == NULL) {	/* Get data only */
 				Return (API->error);
 			}
-			if (Ctrl->N.active[GMT_IN]) {	/* Normalize the grid */
+			if (k < 3 && Ctrl->N.active[GMT_IN]) {	/* Normalize the 1-3 input grid */
 				double factor = 1.0 / Ctrl->N.factor[GMT_IN];	/* To avoid division in the loop */
 				GMT_Report (API, GMT_MSG_INFORMATION, "Normalizing grid %s\n", Ctrl->In.file[k]);
 				gmt_M_grd_loop (GMT, G_in[k], row, col, node)

--- a/src/grdmix.c
+++ b/src/grdmix.c
@@ -110,8 +110,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s <raster1> [<raster2> [<raster3>]] -G<outraster> [-A<transp>] [-C] [-D]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-I<intens>] [-M] [-N[i|o][<factor>]] [-Q] [%s] [%s]\n", GMT_Rgeo_OPT, GMT_V_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-W<weight>] [%s] [%s]\n\n", GMT_f_OPT, GMT_PAR_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-I<intens>] [-M] [-N[i|o][<factor>]] [-Q] [%s]\n", GMT_Rgeo_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-W<weight>] [%s] [%s]\n\n", GMT_V_OPT, GMT_f_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -119,20 +119,23 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Specify file name for output %s file.\n", type[API->external]);
 	GMT_Message (API, GMT_TIME_NONE, "\t   With -D the name is a template and must contain %%c to hold the layer code.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-A Specify a transparency grid or image, or set a constant alpha value (0-1 range).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-A Specify a transparency grid or image, or set a constant alpha value [no transparency].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   An image must have 0-255 values, while a grid or constant must be in the 0-1 range).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Construct an image from 1 (gray) or 3 (r, g, b) input component grids.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   You may optionally supply transparency (-A) and/or intensity (-I).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-D Deconstruct an image into 1 or 3 output component grids, plus any transparency.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   We write the layers as is (0-255); use -N to normalize the layers.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-I Specify an intensity grid file, or set a constant intensity value (-1/+1 range).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-I Specify an intensity grid file, or set a constant intensity value [no intensity].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   The grid or constant must be in the -1 to +1 range).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-M Force a monochrome final image [same number of bands as the input].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-N Set normalization factor for (i)input or (o)output grids [Default sets both].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-N Set normalization factor for (i)nput or (o)utput grids [Default sets both].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   With -Ni (or -N), input grids will be divided by <factor> [255].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   With -No (or -N), output grids will be multiplied by <factor> [255].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append <factor> to use another factor than 255.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Q Make the final image opaque by removing any alpha layer.\n");
 	GMT_Option (API, "R,V");
-	GMT_Message (API, GMT_TIME_NONE, "\t-W Specify a blend weight grid or image, or set a constant weight (0-1 range).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-W Specify a blend weight grid or image, or set a constant weight [no blend weight].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   An image must have 0-255 values, while a grid or constant must be in the 0-1 range).\n");
 	GMT_Option (API, "f,.");
 
 	return (GMT_MODULE_USAGE);


### PR DESCRIPTION
**Description of proposed changes**

The grdmix module needs ability to normalize but input or output grids.  Since we can read a mix of grids and images it is best to have separate scales.  Thus **-N** now has optional directives **i** or **o** to set just the input or output scale.