### PR TITLE
Check Antarctica node level before changing levels due to -Alimit

### DIFF
--- a/src/gmt_shore.c
+++ b/src/gmt_shore.c
@@ -692,12 +692,17 @@ int gmt_init_shore (struct GMT_CTRL *GMT, char res, struct GMT_SHORE *c, double 
 
 	/* Allocate space for arrays of bin information */
 
+	c->bin_info_g    = gmt_M_memory (GMT, NULL, nb, short);
 	c->bin_info      = gmt_M_memory (GMT, NULL, nb, short);
 	c->bin_nseg      = gmt_M_memory (GMT, NULL, nb, short);
 	c->bin_firstseg  = gmt_M_memory (GMT, NULL, nb, int);
 
 	count[0] = c->n_bin;
 	stmp = gmt_M_memory (GMT, NULL, c->n_bin, short);
+
+	/* Keep the node levels for when the grounding line polygon is in effect */
+	err = nc_get_vara_short (c->cdfid, c->bin_info_id_ANT, start, count, stmp);
+	for (i = 0; i < c->nb; i++) c->bin_info_g[i] = stmp[c->bins[i]];
 
 	if (c->ant_mode & GSHHS_ANTARCTICA_ICE) {	/* Get node levels relevant for ice-shelf */
 		err = nc_get_vara_short (c->cdfid, c->bin_info_id, start, count, stmp);
@@ -749,6 +754,8 @@ int gmt_get_shore_bin (struct GMT_CTRL *GMT, unsigned int b, struct GMT_SHORE *c
 	for (k = 0; k < 4; k++) {	/* Extract node corner levels */
 		corner[k] = ((unsigned short)c->bin_info[b] >> bitshift[k]) & 7;
 		c->node_level[k] = (unsigned char)MIN (corner[k], c->max_level);
+		corner[k] = ((unsigned short)c->bin_info_g[b] >> bitshift[k]) & 7;
+		c->node_level_g[k] = (unsigned char)MIN (corner[k], c->max_level);
 	}
 	dx = c->bin_size / 60.0;
 	c->lon_sw = (c->bins[b] % c->bin_nx) * dx;
@@ -789,9 +796,10 @@ int gmt_get_shore_bin (struct GMT_CTRL *GMT, unsigned int b, struct GMT_SHORE *c
 		for (k = 0; k < 4; k++) {	/* Visit all four nodes defining this bin, going counter-clockwise from lower-left bin */
 			node = ll_node + inc[k];	/* Current node index */
 			ID = c->GSHHS_node[node];	/* GSHHS Id of the polygon that determined the level of the current node */
-			while (c->node_level[k] && c->GSHHS_area[ID] < c->min_area) {	/* Polygon must be skipped and node level reset */
+			while (ID >= 0 && c->node_level[k] && c->GSHHS_area[ID] < c->min_area) {	/* Polygon must be skipped and node level reset */
 				ID = c->GSHHS_parent[ID];	/* Pick the parent polygon since that is the next polygon up */
-				c->node_level[k]--;		/* ...and drop down one level to that of the parent polygon */
+				if (c->node_level[k] != c->node_level_g[k])
+					c->node_level[k]--;		/* ...and drop down one level to that of the parent polygon */
 			}	/* Keep doing this until the polygon containing the node is "too big to fail" or we are in the ocean */
 		}
 	}
@@ -1462,6 +1470,7 @@ void gmt_free_br (struct GMT_CTRL *GMT, struct GMT_BR *c) {
 void gmt_shore_cleanup (struct GMT_CTRL *GMT, struct GMT_SHORE *c) {
 	gmt_M_free (GMT, c->bins);
 	gmt_M_free (GMT, c->bin_info);
+	gmt_M_free (GMT, c->bin_info_g);
 	gmt_M_free (GMT, c->bin_nseg);
 	gmt_M_free (GMT, c->bin_firstseg);
 	gmt_M_free (GMT, c->GSHHS_area);

--- a/src/gmt_shore.h
+++ b/src/gmt_shore.h
@@ -93,6 +93,7 @@ struct GMT_SHORE {	/* Struct used by pscoast and others */
 
 	int ns;			/* Number of segments to use in current bin */
 	unsigned char node_level[4];
+	unsigned char node_level_g[4];	/* Levels if gronding line Antarctica is used */
 	struct GMT_SHORE_SEGMENT *seg;	/* Array of these segments */
 	struct GSHHS_SIDE *side[4];	/* Has position & id for each side exit/entry */
 	int nside[4];		/* Number of entries per side, including corner */
@@ -121,6 +122,7 @@ struct GMT_SHORE {	/* Struct used by pscoast and others */
 	int *GSHHS_node;	/* Array with ids of the polygon that enclose each node */
 	int *bin_firstseg;	/* Array with ids of first segment per bin */
 	short int *bin_info;	/* Array with levels of all 4 nodes per bin */
+	short int *bin_info_g;	/* Array with levels of all 4 nodes per bin for the other Antarctica choice [or NULL] */
 	short int *bin_nseg;	/* Array with number of segments per bin */
 
 	int *GSHHS_parent;		/* Array with ids of the parent polygon for each GSHHS polygon (-1 for all level 1 polygons) */

--- a/test/pscoast/gshhs_A.ps
+++ b/test/pscoast/gshhs_A.ps
@@ -1,0 +1,5794 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.1.0_743f935-dirty_2020.06.04 [64-bit] Document from psxy
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Fri Jun  5 21:59:33 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 472 TM
+% PostScript produced by:
+%@GMT: gmt psxy -R0/4.72441/0/10.0576 -Jx1i -T -Xr1i -Yr0.393701i --GMT_HISTORY=false
+%@PROJ: xy 0.00000000 4.72441000 0.00000000 10.05760000 0.000 4.724 0.000 10.058 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+909 6400 TM
+% PostScript produced by:
+%@GMT: gmt pscoast -Df -A+ai -Gazure3 -Wfaint -BWeNs -Bxa1fg1 -Bya1fg1 -Xa0i -Ya5.3332i -R-42/-39/-82:10/-77:45 -JQ15c+
+%@PROJ: eqc -42.00000000 -39.00000000 -82.16666667 -77.75000000 -166792.578 166792.578 -9136526.771 -8645415.291 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=-40.5 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 W
+clipsave
+0 0 M
+3851 0 D
+0 5669 D
+-3851 0 D
+P
+PSL_clip N
+1284 5349 M
+-3 0 D
+-6 0 D
+-4 -1 D
+-5 1 D
+-4 -1 D
+22 0 D
+P
+{0.757 0.804 0.804 C} FS
+FO
+1284 5349 M
+-3 0 D
+-6 0 D
+-4 -1 D
+-5 1 D
+-4 -1 D
+S
+1291 5348 M
+-6 2 D
+-1 -2 D
+P
+FO
+1302 5348 M
+-2 1 D
+-1 -1 D
+P
+FO
+1302 5348 M
+-2 1 D
+-1 -1 D
+S
+1291 5348 M
+-6 2 D
+-1 -1 D
+S
+1262 5348 M
+-19 -4 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-14 -4 D
+10 -2 D
+-13 -3 D
+-5 -1 D
+-5 1 D
+-9 -2 D
+-7 1 D
+-3 -1 D
+-6 1 D
+-14 -4 D
+5 -1 D
+-5 -1 D
+-5 1 D
+-14 -1 D
+-5 1 D
+-14 -1 D
+-28 -7 D
+-6 1 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 0 D
+-5 -1 D
+-6 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-5 1 D
+-18 -5 D
+5 -1 D
+-14 -3 D
+11 -2 D
+-4 -1 D
+10 -2 D
+-5 -1 D
+17 -3 D
+-6 -1 D
+16 -3 D
+-4 -1 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-14 -3 D
+-5 0 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-12 2 D
+-4 -1 D
+-96 17 D
+-4 -1 D
+-16 3 D
+-4 -1 D
+-12 2 D
+-4 -1 D
+-15 3 D
+-5 -1 D
+-22 4 D
+-4 -1 D
+-10 1 D
+-5 -1 D
+-16 1 D
+-5 -1 D
+-10 2 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-10 0 D
+-6 -1 D
+7 -1 D
+-5 -2 D
+15 -2 D
+-4 -1 D
+5 -1 D
+-5 -2 D
+5 0 D
+-9 -3 D
+6 -1 D
+-9 -2 D
+5 -1 D
+-5 -1 D
+1 -4 D
+-4 -1 D
+5 -1 D
+-5 -1 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-5 -1 D
+7 -1 D
+-6 -2 D
+6 0 D
+-9 -3 D
+5 -1 D
+-5 -1 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-14 -3 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-9 -3 D
+0 -2 D
+-23 -5 D
+-5 1 D
+5 1 D
+-6 1 D
+5 1 D
+-5 1 D
+9 4 D
+-5 1 D
+8 2 D
+-5 1 D
+14 4 D
+-5 1 D
+9 2 D
+-5 1 D
+9 2 D
+-5 1 D
+9 2 D
+4 3 D
+-5 1 D
+5 1 D
+-5 1 D
+4 1 D
+-11 2 D
+5 1 D
+-6 3 D
+5 2 D
+-6 3 D
+5 1 D
+-5 1 D
+4 1 D
+-11 2 D
+5 1 D
+-5 1 D
+4 1 D
+-10 2 D
+5 1 D
+-10 2 D
+4 1 D
+-5 1 D
+5 1 D
+-17 3 D
+5 1 D
+-10 2 D
+-5 -1 D
+-25 1 D
+-5 -2 D
+-5 1 D
+-9 -2 D
+-6 1 D
+-9 -2 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-9 -2 D
+-5 1 D
+-5 -1 D
+-5 0 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-4 -2 D
+-6 1 D
+-4 -1 D
+-20 2 D
+-6 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-15 1 D
+-5 -1 D
+-5 1 D
+-4 -2 D
+-7 1 D
+-4 -1 D
+-5 1 D
+-10 -2 D
+-5 1 D
+-9 -2 D
+-5 1 D
+-5 -1 D
+-6 1 D
+-8 -2 D
+-6 1 D
+-5 -2 D
+-5 1 D
+-5 -1 D
+-35 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-21 1 D
+-9 -2 D
+-6 1 D
+-4 -1 D
+-5 1 D
+-19 -4 D
+5 -1 D
+-5 -1 D
+1 -2 D
+-14 -4 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-19 -4 D
+5 -1 D
+-104 -24 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-19 -4 D
+5 -1 D
+-9 -3 D
+5 0 D
+-5 -2 D
+7 -1 D
+-8 -1 D
+0 -1 D
+3 -1 D
+-3 0 D
+0 -1178 D
+1284 0 D
+0 1283 D
+P
+FO
+1262 5348 M
+-19 -4 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-14 -4 D
+10 -2 D
+-13 -3 D
+-5 -1 D
+-5 1 D
+-9 -2 D
+-7 1 D
+-3 -1 D
+-6 1 D
+-14 -4 D
+5 -1 D
+-5 -1 D
+-5 1 D
+-14 -1 D
+-5 1 D
+-14 -1 D
+-28 -7 D
+-6 1 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 0 D
+-5 -1 D
+-6 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-5 1 D
+-18 -5 D
+5 -1 D
+-14 -3 D
+11 -2 D
+-4 -1 D
+10 -2 D
+-5 -1 D
+17 -3 D
+-6 -1 D
+16 -3 D
+-4 -1 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-14 -3 D
+-5 0 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-12 2 D
+-4 -1 D
+-96 17 D
+-4 -1 D
+-16 3 D
+-4 -1 D
+-12 2 D
+-4 -1 D
+-15 3 D
+-5 -1 D
+-22 4 D
+-4 -1 D
+-10 1 D
+-5 -1 D
+-16 1 D
+-5 -1 D
+-10 2 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-10 0 D
+-6 -1 D
+7 -1 D
+-5 -2 D
+15 -2 D
+-4 -1 D
+5 -1 D
+-5 -2 D
+5 0 D
+-9 -3 D
+6 -1 D
+-9 -2 D
+5 -1 D
+-5 -1 D
+1 -4 D
+-4 -1 D
+5 -1 D
+-5 -1 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-5 -1 D
+7 -1 D
+-6 -2 D
+6 0 D
+-9 -3 D
+5 -1 D
+-5 -1 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-14 -3 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-9 -3 D
+0 -2 D
+-23 -5 D
+-5 1 D
+5 1 D
+-6 1 D
+5 1 D
+-5 1 D
+9 4 D
+-5 1 D
+8 2 D
+-5 1 D
+14 4 D
+-5 1 D
+9 2 D
+-5 1 D
+9 2 D
+-5 1 D
+9 2 D
+4 3 D
+-5 1 D
+5 1 D
+-5 1 D
+4 1 D
+-11 2 D
+5 1 D
+-6 3 D
+5 2 D
+-6 3 D
+5 1 D
+-5 1 D
+4 1 D
+-11 2 D
+5 1 D
+-5 1 D
+4 1 D
+-10 2 D
+5 1 D
+-10 2 D
+4 1 D
+-5 1 D
+5 1 D
+-17 3 D
+5 1 D
+-10 2 D
+-5 -1 D
+-25 1 D
+-5 -2 D
+-5 1 D
+-9 -2 D
+-6 1 D
+-9 -2 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-9 -2 D
+-5 1 D
+-5 -1 D
+-5 0 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-4 -2 D
+-6 1 D
+-4 -1 D
+-20 2 D
+-6 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-15 1 D
+-5 -1 D
+-5 1 D
+-4 -2 D
+-7 1 D
+-4 -1 D
+-5 1 D
+-10 -2 D
+-5 1 D
+-9 -2 D
+-5 1 D
+-5 -1 D
+-6 1 D
+-8 -2 D
+-6 1 D
+-5 -2 D
+-5 1 D
+-5 -1 D
+-35 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-21 1 D
+-9 -2 D
+-6 1 D
+-4 -1 D
+-5 1 D
+-19 -4 D
+5 -1 D
+-5 -1 D
+1 -2 D
+-14 -4 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-19 -4 D
+5 -1 D
+-104 -24 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-19 -4 D
+5 -1 D
+-9 -3 D
+5 0 D
+-5 -2 D
+7 -1 D
+-8 -1 D
+S
+0 5244 M
+3 -1 D
+-3 0 D
+S
+2567 5185 M
+-18 3 D
+-5 -1 D
+-20 1 D
+-17 3 D
+-4 -1 D
+-17 3 D
+-5 -1 D
+-15 2 D
+-5 -1 D
+-38 7 D
+-5 -1 D
+-21 4 D
+-4 -1 D
+-17 2 D
+-5 -1 D
+-16 3 D
+-10 0 D
+-17 3 D
+-3 -1 D
+-22 3 D
+-5 -1 D
+-59 11 D
+-6 -2 D
+-26 5 D
+-4 -1 D
+-22 4 D
+-5 -1 D
+-91 16 D
+-2 2 D
+-10 2 D
+4 1 D
+-27 5 D
+0 2 D
+-27 4 D
+4 2 D
+-54 9 D
+-4 -1 D
+-11 2 D
+-4 -1 D
+-17 3 D
+-4 -2 D
+-11 2 D
+-4 -1 D
+-38 7 D
+-5 -1 D
+-86 15 D
+5 1 D
+-16 3 D
+5 1 D
+-5 1 D
+4 1 D
+-11 2 D
+4 1 D
+-15 3 D
+5 1 D
+-12 2 D
+6 1 D
+-12 4 D
+4 1 D
+-10 2 D
+5 1 D
+-17 3 D
+0 2 D
+-59 11 D
+-10 -1 D
+-11 2 D
+-5 -1 D
+-15 1 D
+-53 10 D
+-5 -2 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-10 2 D
+-6 -1 D
+-5 1 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-21 3 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-10 2 D
+-6 -1 D
+-5 1 D
+-9 -2 D
+-5 1 D
+-10 -3 D
+-5 1 D
+-4 -1 D
+-12 2 D
+-3 -1 D
+-12 2 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-6 0 D
+-3 -1 D
+-5 1 D
+-6 -1 D
+-10 2 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-27 1 D
+0 -1283 D
+1283 0 D
+P
+FO
+2567 5185 M
+-18 3 D
+-5 -1 D
+-20 1 D
+-17 3 D
+-4 -1 D
+-17 3 D
+-5 -1 D
+-15 2 D
+-5 -1 D
+-38 7 D
+-5 -1 D
+-21 4 D
+-4 -1 D
+-17 2 D
+-5 -1 D
+-16 3 D
+-10 0 D
+-17 3 D
+-3 -1 D
+-22 3 D
+-5 -1 D
+-59 11 D
+-6 -2 D
+-26 5 D
+-4 -1 D
+-22 4 D
+-5 -1 D
+-91 16 D
+-2 2 D
+-10 2 D
+4 1 D
+-27 5 D
+0 2 D
+-27 4 D
+4 2 D
+-54 9 D
+-4 -1 D
+-11 2 D
+-4 -1 D
+-17 3 D
+-4 -2 D
+-11 2 D
+-4 -1 D
+-38 7 D
+-5 -1 D
+-86 15 D
+5 1 D
+-16 3 D
+5 1 D
+-5 1 D
+4 1 D
+-11 2 D
+4 1 D
+-15 3 D
+5 1 D
+-12 2 D
+6 1 D
+-12 4 D
+4 1 D
+-10 2 D
+5 1 D
+-17 3 D
+0 2 D
+-59 11 D
+-10 -1 D
+-11 2 D
+-5 -1 D
+-15 1 D
+-53 10 D
+-5 -2 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-10 2 D
+-6 -1 D
+-5 1 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-21 3 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-10 2 D
+-6 -1 D
+-5 1 D
+-9 -2 D
+-5 1 D
+-10 -3 D
+-5 1 D
+-4 -1 D
+-12 2 D
+-3 -1 D
+-12 2 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-6 0 D
+-3 -1 D
+-5 1 D
+-6 -1 D
+-10 2 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-9 1 D
+S
+1299 5348 M
+-4 0 D
+-4 0 D
+S
+3851 5154 M
+-8 -2 D
+-5 1 D
+-27 -7 D
+5 -1 D
+-9 -2 D
+7 -1 D
+-23 -6 D
+-6 1 D
+-9 -2 D
+-6 1 D
+-4 -1 D
+-20 -1 D
+-6 1 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-22 4 D
+-4 -2 D
+-11 2 D
+-4 -1 D
+-12 2 D
+-5 -1 D
+-33 5 D
+-4 -1 D
+-72 12 D
+5 1 D
+-38 7 D
+4 1 D
+-27 5 D
+-2 2 D
+-33 5 D
+-4 -1 D
+-12 2 D
+-3 -1 D
+-7 1 D
+-4 -1 D
+-5 1 D
+-9 -3 D
+-6 1 D
+-22 -5 D
+5 -1 D
+-4 -1 D
+49 -9 D
+-4 -1 D
+39 -7 D
+-5 -1 D
+83 -14 D
+9 1 D
+17 -3 D
+-9 -2 D
+-5 1 D
+-9 -3 D
+-6 1 D
+-5 -1 D
+-11 2 D
+-4 -1 D
+-31 1 D
+-11 2 D
+-4 -1 D
+-12 2 D
+-4 -1 D
+-11 2 D
+-5 -2 D
+-11 2 D
+-20 0 D
+-10 2 D
+-6 -1 D
+-10 2 D
+-10 -1 D
+-12 2 D
+-4 -1 D
+-11 2 D
+-4 -1 D
+-11 2 D
+-6 -2 D
+-15 3 D
+-5 -1 D
+-16 1 D
+-16 3 D
+-4 -2 D
+-67 12 D
+-4 -1 D
+-6 0 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 0 D
+-4 -1 D
+-12 2 D
+-3 -1 D
+-7 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-10 1 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-20 2 D
+-5 -1 D
+-11 2 D
+-5 -2 D
+-5 1 D
+-5 -1 D
+-10 2 D
+-6 -1 D
+-10 2 D
+-5 -1 D
+-10 2 D
+-5 -2 D
+-17 3 D
+-4 -1 D
+-11 2 D
+-36 2 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-10 2 D
+-6 -1 D
+-5 0 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-10 2 D
+-5 -2 D
+-21 2 D
+-5 -1 D
+-10 2 D
+-6 -1 D
+-30 3 D
+-5 -1 D
+-12 2 D
+-4 -1 D
+-17 3 D
+-25 2 D
+-5 -1 D
+-17 3 D
+-4 -1 D
+-27 5 D
+-5 -2 D
+-10 2 D
+-5 -1 D
+-25 3 D
+0 -1120 D
+1284 0 D
+P
+FO
+3851 5154 M
+-8 -2 D
+-5 1 D
+-27 -7 D
+5 -1 D
+-9 -2 D
+7 -1 D
+-23 -6 D
+-6 1 D
+-9 -2 D
+-6 1 D
+-4 -1 D
+-20 -1 D
+-6 1 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-22 4 D
+-4 -2 D
+-11 2 D
+-4 -1 D
+-12 2 D
+-5 -1 D
+-33 5 D
+-4 -1 D
+-72 12 D
+5 1 D
+-38 7 D
+4 1 D
+-27 5 D
+-2 2 D
+-33 5 D
+-4 -1 D
+-12 2 D
+-3 -1 D
+-7 1 D
+-4 -1 D
+-5 1 D
+-9 -3 D
+-6 1 D
+-22 -5 D
+5 -1 D
+-4 -1 D
+49 -9 D
+-4 -1 D
+39 -7 D
+-5 -1 D
+83 -14 D
+9 1 D
+17 -3 D
+-9 -2 D
+-5 1 D
+-9 -3 D
+-6 1 D
+-5 -1 D
+-11 2 D
+-4 -1 D
+-31 1 D
+-11 2 D
+-4 -1 D
+-12 2 D
+-4 -1 D
+-11 2 D
+-5 -2 D
+-11 2 D
+-20 0 D
+-10 2 D
+-6 -1 D
+-10 2 D
+-10 -1 D
+-12 2 D
+-4 -1 D
+-11 2 D
+-4 -1 D
+-11 2 D
+-6 -2 D
+-15 3 D
+-5 -1 D
+-16 1 D
+-16 3 D
+-4 -2 D
+-67 12 D
+-4 -1 D
+-6 0 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 0 D
+-4 -1 D
+-12 2 D
+-3 -1 D
+-7 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-10 1 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-20 2 D
+-5 -1 D
+-11 2 D
+-5 -2 D
+-5 1 D
+-5 -1 D
+-10 2 D
+-6 -1 D
+-10 2 D
+-5 -1 D
+-10 2 D
+-5 -2 D
+-17 3 D
+-4 -1 D
+-11 2 D
+-36 2 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-10 2 D
+-6 -1 D
+-5 0 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-10 2 D
+-5 -2 D
+-21 2 D
+-5 -1 D
+-10 2 D
+-6 -1 D
+-30 3 D
+-5 -1 D
+-12 2 D
+-4 -1 D
+-17 3 D
+-25 2 D
+-5 -1 D
+-17 3 D
+-4 -1 D
+-27 5 D
+-5 -2 D
+-10 2 D
+-5 -1 D
+-25 3 D
+S
+0 2781 M
+1284 0 D
+0 1284 D
+-1284 0 D
+P
+FO
+1284 2781 M
+1283 0 D
+0 1284 D
+-1283 0 D
+P
+FO
+2567 2781 M
+1284 0 D
+0 1284 D
+-1284 0 D
+P
+FO
+0 1498 M
+1284 0 D
+0 1283 D
+-1284 0 D
+P
+FO
+1284 1498 M
+1283 0 D
+0 1283 D
+-1283 0 D
+P
+FO
+2567 1498 M
+1284 0 D
+0 1283 D
+-1284 0 D
+P
+FO
+0 214 M
+1284 0 D
+0 1284 D
+-1284 0 D
+P
+FO
+1284 214 M
+1283 0 D
+0 1284 D
+-1283 0 D
+P
+FO
+2567 214 M
+1284 0 D
+0 1284 D
+-1284 0 D
+P
+FO
+1284 0 M
+0 214 D
+-1284 0 D
+0 -214 D
+P
+FO
+2567 0 M
+0 214 D
+-1283 0 D
+0 -214 D
+P
+FO
+3851 0 M
+0 214 D
+-1284 0 D
+0 -214 D
+P
+FO
+PSL_cliprestore
+25 W
+4 W
+0 0 M
+0 5669 D
+S
+1284 0 M
+0 5669 D
+S
+2567 0 M
+0 5669 D
+S
+3851 0 M
+0 5669 D
+S
+0 214 M
+3851 0 D
+S
+0 1498 M
+3851 0 D
+S
+0 2781 M
+3851 0 D
+S
+0 4065 M
+3851 0 D
+S
+0 5348 M
+3851 0 D
+S
+8 W
+N 0 0 M 0 -83 D S
+N 0 5669 M 0 84 D S
+N 1284 0 M 0 -83 D S
+N 1284 5669 M 0 84 D S
+N 2567 0 M 0 -83 D S
+N 2567 5669 M 0 84 D S
+N 3851 0 M 0 -83 D S
+N 3851 5669 M 0 84 D S
+N 0 214 M -83 0 D S
+N 3851 214 M 83 0 D S
+N 0 1498 M -83 0 D S
+N 3851 1498 M 83 0 D S
+N 0 2781 M -83 0 D S
+N 3851 2781 M 83 0 D S
+N 0 4065 M -83 0 D S
+N 3851 4065 M 83 0 D S
+N 0 5348 M -83 0 D S
+N 3851 5348 M 83 0 D S
+83 W
+1 A
+N -42 0 M 0 214 D S
+N 3892 0 M 0 214 D S
+0 A
+N -42 214 M 0 321 D S
+N 3892 214 M 0 321 D S
+1 A
+N -42 535 M 0 321 D S
+N 3892 535 M 0 321 D S
+0 A
+N -42 856 M 0 321 D S
+N 3892 856 M 0 321 D S
+1 A
+N -42 1177 M 0 321 D S
+N 3892 1177 M 0 321 D S
+0 A
+N -42 1498 M 0 320 D S
+N 3892 1498 M 0 320 D S
+1 A
+N -42 1818 M 0 321 D S
+N 3892 1818 M 0 321 D S
+0 A
+N -42 2139 M 0 321 D S
+N 3892 2139 M 0 321 D S
+1 A
+N -42 2460 M 0 321 D S
+N 3892 2460 M 0 321 D S
+0 A
+N -42 2781 M 0 321 D S
+N 3892 2781 M 0 321 D S
+1 A
+N -42 3102 M 0 321 D S
+N 3892 3102 M 0 321 D S
+0 A
+N -42 3423 M 0 321 D S
+N 3892 3423 M 0 321 D S
+1 A
+N -42 3744 M 0 321 D S
+N 3892 3744 M 0 321 D S
+0 A
+N -42 4065 M 0 321 D S
+N 3892 4065 M 0 321 D S
+1 A
+N -42 4386 M 0 321 D S
+N 3892 4386 M 0 321 D S
+0 A
+N -42 4707 M 0 320 D S
+N 3892 4707 M 0 320 D S
+1 A
+N -42 5027 M 0 321 D S
+N 3892 5027 M 0 321 D S
+0 A
+N -42 5348 M 0 321 D S
+N 3892 5348 M 0 321 D S
+N 0 -42 M 321 0 D S
+N 0 5711 M 321 0 D S
+1 A
+N 321 -42 M 321 0 D S
+N 321 5711 M 321 0 D S
+0 A
+N 642 -42 M 321 0 D S
+N 642 5711 M 321 0 D S
+1 A
+N 963 -42 M 321 0 D S
+N 963 5711 M 321 0 D S
+0 A
+N 1284 -42 M 321 0 D S
+N 1284 5711 M 321 0 D S
+1 A
+N 1605 -42 M 320 0 D S
+N 1605 5711 M 320 0 D S
+0 A
+N 1925 -42 M 321 0 D S
+N 1925 5711 M 321 0 D S
+1 A
+N 2246 -42 M 321 0 D S
+N 2246 5711 M 321 0 D S
+0 A
+N 2567 -42 M 321 0 D S
+N 2567 5711 M 321 0 D S
+1 A
+N 2888 -42 M 321 0 D S
+N 2888 5711 M 321 0 D S
+0 A
+N 3209 -42 M 321 0 D S
+N 3209 5711 M 321 0 D S
+1 A
+N 3530 -42 M 321 0 D S
+N 3530 5711 M 321 0 D S
+0 A
+8 W
+N -83 0 M 4017 0 D S
+N -83 -83 M 4017 0 D S
+N 3851 -83 M 0 5836 D S
+N 3934 -83 M 0 5836 D S
+N 3934 5669 M -4017 0 D S
+N 3934 5753 M -4017 0 D S
+N 0 5753 M 0 -5836 D S
+N -83 5753 M 0 -5836 D S
+0 5836 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-42°) bc Z
+1284 5836 M (-41°) bc Z
+2567 5836 M (-40°) bc Z
+3851 5836 M (-39°) bc Z
+-167 214 M (-82°) mr Z
+-167 1498 M (-81°) mr Z
+-167 2781 M (-80°) mr Z
+-167 4065 M (-79°) mr Z
+-167 5348 M (-78°) mr Z
+%%EndObject
+-909 -6400 TM
+0 A
+FQ
+O0
+909 6400 TM
+% PostScript produced by:
+%@GMT: gmt pscoast -Df -A+ag -Glightpink -Wfaint -Xa0i -Ya5.3332i -R-42/-39/-82:10/-77:45 -JQ15c+
+%@PROJ: eqc -42.00000000 -39.00000000 -82.16666667 -77.75000000 -166792.578 166792.578 -9136526.771 -8645415.291 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=-40.5 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 W
+clipsave
+0 0 M
+3851 0 D
+0 5669 D
+-3851 0 D
+P
+PSL_clip N
+2567 1505 M
+-34 -7 D
+-8 1 D
+-6 -1 D
+-7 1 D
+-8 -1 D
+63 0 D
+P
+{1 0.714 0.757 C} FS
+FO
+2567 1505 M
+-34 -7 D
+-8 1 D
+-6 -1 D
+-7 1 D
+-8 -1 D
+S
+2614 1498 M
+11 2 D
+7 -1 D
+30 5 D
+-7 1 D
+42 8 D
+7 -1 D
+31 6 D
+-8 1 D
+6 1 D
+-28 4 D
+-18 -4 D
+-8 1 D
+-18 -3 D
+-7 1 D
+-72 -14 D
+-13 0 D
+-2 0 D
+0 -7 D
+P
+FO
+3851 1592 M
+-19 -3 D
+-33 -2 D
+-20 -4 D
+4 0 D
+-5 -2 D
+10 -1 D
+-4 0 D
+-18 -2 D
+-14 0 D
+-49 -5 D
+-4 1 D
+-20 -4 D
+-44 -4 D
+-45 -9 D
+-34 -3 D
+-21 -4 D
+-6 1 D
+-61 -10 D
+-18 -3 D
+-4 1 D
+-35 -7 D
+-4 0 D
+4 1 D
+-21 0 D
+-21 -3 D
+-19 -2 D
+-4 1 D
+-24 -4 D
+-4 1 D
+-31 -4 D
+-13 0 D
+-84 -15 D
+-28 4 D
+-33 -3 D
+-44 -8 D
+7 -1 D
+-3 -1 D
+762 0 D
+P
+FO
+3851 1598 M
+-8 -1 D
+8 -2 D
+P
+FO
+3851 1603 M
+-5 -1 D
+4 0 D
+-7 -2 D
+8 -1 D
+P
+FO
+3851 1592 M
+-19 -3 D
+-33 -2 D
+-20 -4 D
+4 0 D
+-5 -2 D
+10 -1 D
+-4 0 D
+-18 -2 D
+-14 0 D
+-49 -5 D
+-4 1 D
+-20 -4 D
+-44 -4 D
+-45 -9 D
+-34 -3 D
+-21 -4 D
+-6 1 D
+-61 -10 D
+-18 -3 D
+-4 1 D
+-35 -7 D
+-4 0 D
+4 1 D
+-21 0 D
+-21 -3 D
+-19 -2 D
+-4 1 D
+-24 -4 D
+-4 1 D
+-31 -4 D
+-13 0 D
+-84 -15 D
+-28 4 D
+-33 -3 D
+-44 -8 D
+7 -1 D
+-3 -1 D
+S
+2614 1498 M
+11 2 D
+7 -1 D
+30 5 D
+-7 1 D
+42 8 D
+7 -1 D
+31 6 D
+-8 1 D
+6 1 D
+-28 4 D
+-18 -4 D
+-8 1 D
+-18 -3 D
+-7 1 D
+-72 -14 D
+-13 0 D
+-2 0 D
+S
+3851 1603 M
+-5 -1 D
+4 0 D
+-7 -2 D
+8 -1 D
+S
+3851 1598 M
+-8 -1 D
+8 -2 D
+S
+1284 1275 M
+-66 -11 D
+-20 -5 D
+3 -1 D
+-9 -2 D
+-5 -7 D
+-9 -2 D
+8 -2 D
+-11 -5 D
+3 -1 D
+-7 -4 D
+4 0 D
+-9 -3 D
+7 -2 D
+-18 -7 D
+4 -1 D
+-11 -4 D
+1 -3 D
+-7 -2 D
+6 -2 D
+-4 -1 D
+7 0 D
+-54 -10 D
+-14 0 D
+-54 -9 D
+4 -1 D
+-9 -3 D
+4 0 D
+-22 -6 D
+4 -1 D
+-47 -9 D
+7 -1 D
+-19 -4 D
+4 -1 D
+-22 -4 D
+8 -1 D
+-17 -2 D
+4 -1 D
+-22 -5 D
+8 -1 D
+-17 -2 D
+4 -1 D
+-38 -7 D
+-13 -3 D
+4 0 D
+-13 -2 D
+1 -1 D
+-13 -3 D
+4 0 D
+-42 -8 D
+1 -1 D
+-17 -3 D
+2 -1 D
+-45 -8 D
+2 0 D
+-28 -5 D
+4 -1 D
+-19 -3 D
+2 -1 D
+-26 -4 D
+4 -1 D
+-9 -1 D
+0 -2 D
+-9 -2 D
+4 0 D
+-10 -2 D
+1 -2 D
+-10 -2 D
+4 0 D
+-7 -2 D
+-19 -4 D
+-24 -6 D
+-36 -6 D
+4 -1 D
+-43 -7 D
+4 0 D
+-13 -3 D
+2 -2 D
+-22 -5 D
+6 -1 D
+-9 -4 D
+1 -2 D
+-34 -7 D
+-7 -2 D
+4 -1 D
+-10 -1 D
+-10 -2 D
+4 -1 D
+-18 -7 D
+3 -1 D
+-11 -4 D
+4 0 D
+-8 -2 D
+1 -2 D
+-6 -1 D
+4 0 D
+-19 -6 D
+3 -1 D
+-6 -1 D
+1 -2 D
+8 -2 D
+-5 -4 D
+-10 -2 D
+1 -2 D
+-17 -4 D
+8 -1 D
+-7 -1 D
+8 -1 D
+-10 -3 D
+4 0 D
+-32 -7 D
+-29 1 D
+-16 -3 D
+-11 -8 D
+4 -3 D
+-6 -1 D
+5 -1 D
+-5 -8 D
+9 -3 D
+-1 -6 D
+15 -3 D
+-6 -1 D
+7 -4 D
+-6 -2 D
+4 -1 D
+-20 -4 D
+-29 3 D
+-7 -1 D
+-10 1 D
+-23 -4 D
+5 -6 D
+27 -5 D
+-10 -3 D
+5 -1 D
+-10 -2 D
+1 -2 D
+-8 -1 D
+8 -1 D
+1 -2 D
+-6 -1 D
+8 -2 D
+-11 -2 D
+2 -4 D
+-7 -1 D
+2 -2 D
+-8 -2 D
+1 -2 D
+-17 -2 D
+2 -2 D
+-14 -3 D
+1 -2 D
+-13 -2 D
+4 0 D
+-8 -1 D
+4 -1 D
+-9 -2 D
+0 -2 D
+-6 -1 D
+3 0 D
+-6 -1 D
+8 -2 D
+-11 -2 D
+6 -4 D
+-7 -1 D
+4 -2 D
+-5 -3 D
+8 -2 D
+-4 -2 D
+11 -2 D
+-14 -8 D
+1 -6 D
+-8 -2 D
+3 -1 D
+-10 -1 D
+4 -1 D
+-10 -1 D
+7 -2 D
+-12 -3 D
+7 -1 D
+-16 -6 D
+7 -1 D
+-13 -3 D
+2 -2 D
+-11 -1 D
+4 -1 D
+-10 -2 D
+8 -1 D
+-7 -1 D
+4 0 D
+-8 -1 D
+2 -2 D
+-14 -3 D
+7 -1 D
+-22 -6 D
+27 -5 D
+-3 0 D
+19 -6 D
+-7 -2 D
+35 -5 D
+-4 -1 D
+5 -4 D
+-6 -1 D
+4 -1 D
+-7 -4 D
+6 -2 D
+-7 -1 D
+8 -1 D
+-8 -1 D
+12 -3 D
+-7 -1 D
+5 -6 D
+-9 -3 D
+2 -3 D
+-7 -2 D
+4 -1 D
+-6 -1 D
+1 -3 D
+-10 -2 D
+4 0 D
+-7 -1 D
+1 -4 D
+-7 -1 D
+5 -1 D
+-8 -1 D
+5 -2 D
+-10 -2 D
+8 -1 D
+-8 -2 D
+8 -1 D
+-9 -3 D
+7 -1 D
+-6 -2 D
+4 -2 D
+-34 -5 D
+-3 0 D
+-11 -2 D
+-3 1 D
+-17 -2 D
+-22 1 D
+0 -487 D
+1284 0 D
+P
+FO
+1284 1275 M
+-66 -11 D
+-20 -5 D
+3 -1 D
+-9 -2 D
+-5 -7 D
+-9 -2 D
+8 -2 D
+-11 -5 D
+3 -1 D
+-7 -4 D
+4 0 D
+-9 -3 D
+7 -2 D
+-18 -7 D
+4 -1 D
+-11 -4 D
+1 -3 D
+-7 -2 D
+6 -2 D
+-4 -1 D
+7 0 D
+-54 -10 D
+-14 0 D
+-54 -9 D
+4 -1 D
+-9 -3 D
+4 0 D
+-22 -6 D
+4 -1 D
+-47 -9 D
+7 -1 D
+-19 -4 D
+4 -1 D
+-22 -4 D
+8 -1 D
+-17 -2 D
+4 -1 D
+-22 -5 D
+8 -1 D
+-17 -2 D
+4 -1 D
+-38 -7 D
+-13 -3 D
+4 0 D
+-13 -2 D
+1 -1 D
+-13 -3 D
+4 0 D
+-42 -8 D
+1 -1 D
+-17 -3 D
+2 -1 D
+-45 -8 D
+2 0 D
+-28 -5 D
+4 -1 D
+-19 -3 D
+2 -1 D
+-26 -4 D
+4 -1 D
+-9 -1 D
+0 -2 D
+-9 -2 D
+4 0 D
+-10 -2 D
+1 -2 D
+-10 -2 D
+4 0 D
+-7 -2 D
+-19 -4 D
+-24 -6 D
+-36 -6 D
+4 -1 D
+-43 -7 D
+4 0 D
+-13 -3 D
+2 -2 D
+-22 -5 D
+6 -1 D
+-9 -4 D
+1 -2 D
+-34 -7 D
+-7 -2 D
+4 -1 D
+-10 -1 D
+-10 -2 D
+4 -1 D
+-18 -7 D
+3 -1 D
+-11 -4 D
+4 0 D
+-8 -2 D
+1 -2 D
+-6 -1 D
+4 0 D
+-19 -6 D
+3 -1 D
+-6 -1 D
+1 -2 D
+8 -2 D
+-5 -4 D
+-10 -2 D
+1 -2 D
+-17 -4 D
+8 -1 D
+-7 -1 D
+8 -1 D
+-10 -3 D
+4 0 D
+-32 -7 D
+-29 1 D
+-16 -3 D
+-11 -8 D
+4 -3 D
+-6 -1 D
+5 -1 D
+-5 -8 D
+9 -3 D
+-1 -6 D
+15 -3 D
+-6 -1 D
+7 -4 D
+-6 -2 D
+4 -1 D
+-20 -4 D
+-29 3 D
+-7 -1 D
+-10 1 D
+-23 -4 D
+5 -6 D
+27 -5 D
+-10 -3 D
+5 -1 D
+-10 -2 D
+1 -2 D
+-8 -1 D
+8 -1 D
+1 -2 D
+-6 -1 D
+8 -2 D
+-11 -2 D
+2 -4 D
+-7 -1 D
+2 -2 D
+-8 -2 D
+1 -2 D
+-17 -2 D
+2 -2 D
+-14 -3 D
+1 -2 D
+-13 -2 D
+4 0 D
+-8 -1 D
+4 -1 D
+-9 -2 D
+0 -2 D
+-6 -1 D
+3 0 D
+-6 -1 D
+8 -2 D
+-11 -2 D
+6 -4 D
+-7 -1 D
+4 -2 D
+-5 -3 D
+8 -2 D
+-4 -2 D
+11 -2 D
+-14 -8 D
+1 -6 D
+-8 -2 D
+3 -1 D
+-10 -1 D
+4 -1 D
+-10 -1 D
+7 -2 D
+-12 -3 D
+7 -1 D
+-16 -6 D
+7 -1 D
+-13 -3 D
+2 -2 D
+-11 -1 D
+4 -1 D
+-10 -2 D
+8 -1 D
+-7 -1 D
+4 0 D
+-8 -1 D
+2 -2 D
+-14 -3 D
+7 -1 D
+-22 -6 D
+27 -5 D
+-3 0 D
+19 -6 D
+-7 -2 D
+35 -5 D
+-4 -1 D
+5 -4 D
+-6 -1 D
+4 -1 D
+-7 -4 D
+6 -2 D
+-7 -1 D
+8 -1 D
+-8 -1 D
+12 -3 D
+-7 -1 D
+5 -6 D
+-9 -3 D
+2 -3 D
+-7 -2 D
+4 -1 D
+-6 -1 D
+1 -3 D
+-10 -2 D
+4 0 D
+-7 -1 D
+1 -4 D
+-7 -1 D
+5 -1 D
+-8 -1 D
+5 -2 D
+-10 -2 D
+8 -1 D
+-8 -2 D
+8 -1 D
+-9 -3 D
+7 -1 D
+-6 -2 D
+4 -2 D
+-34 -5 D
+-3 0 D
+-11 -2 D
+-3 1 D
+-17 -2 D
+-22 1 D
+S
+2567 1380 M
+-7 -1 D
+-35 -5 D
+4 -1 D
+-12 -2 D
+3 -1 D
+-21 -4 D
+-6 0 D
+-16 -2 D
+-25 -4 D
+11 3 D
+-22 -2 D
+-73 -14 D
+2 -2 D
+-20 -3 D
+9 -2 D
+-50 -8 D
+-37 -6 D
+1 -3 D
+-6 -1 D
+5 -3 D
+8 -1 D
+-4 0 D
+4 -2 D
+-9 -1 D
+4 -1 D
+-77 -14 D
+3 0 D
+-9 -2 D
+6 -5 D
+-15 -4 D
+-24 2 D
+-10 -1 D
+-8 1 D
+-6 -1 D
+-7 1 D
+-6 -1 D
+-18 1 D
+-7 -1 D
+-10 0 D
+-5 -1 D
+-8 0 D
+-59 -10 D
+-2 0 D
+-7 -1 D
+-7 1 D
+-7 -1 D
+-10 0 D
+-23 -1 D
+-26 4 D
+3 1 D
+-8 1 D
+4 1 D
+-12 2 D
+-1 2 D
+-44 7 D
+-3 -1 D
+-33 4 D
+-6 -1 D
+-6 1 D
+-7 -1 D
+-8 0 D
+-6 -1 D
+-27 2 D
+-17 -1 D
+-18 1 D
+-37 -7 D
+-2 -1 D
+7 -1 D
+-34 -6 D
+-31 1 D
+-35 -7 D
+4 0 D
+-9 -2 D
+4 0 D
+-10 -2 D
+-3 1 D
+-17 -2 D
+-36 -4 D
+-12 0 D
+-7 -1 D
+-4 0 D
+-21 -3 D
+-15 0 D
+-6 -1 D
+-6 1 D
+-7 -1 D
+-8 1 D
+-87 -16 D
+-13 -1 D
+-32 3 D
+-6 13 D
+4 0 D
+-9 4 D
+31 6 D
+3 -1 D
+98 17 D
+-4 0 D
+10 2 D
+-7 1 D
+2 1 D
+-28 3 D
+-9 -2 D
+-8 0 D
+-72 -12 D
+-6 0 D
+-35 -7 D
+-4 1 D
+-3 -1 D
+0 -1061 D
+1283 0 D
+P
+FO
+2504 1498 M
+-22 -5 D
+-7 1 D
+-6 -1 D
+-13 0 D
+-13 -2 D
+-7 1 D
+-12 -3 D
+-7 1 D
+-18 -3 D
+-7 1 D
+-31 -6 D
+-7 1 D
+-18 -3 D
+-7 1 D
+-67 -12 D
+22 -3 D
+6 1 D
+7 -1 D
+6 1 D
+7 -1 D
+6 1 D
+7 -1 D
+6 1 D
+8 -1 D
+12 3 D
+7 -1 D
+6 1 D
+7 -1 D
+18 3 D
+-1 2 D
+7 -1 D
+7 2 D
+19 1 D
+-1 2 D
+7 -1 D
+49 7 D
+8 -1 D
+18 3 D
+7 -1 D
+12 3 D
+7 -1 D
+24 4 D
+8 -1 D
+9 2 D
+0 7 D
+P
+FO
+2198 1414 M
+12 2 D
+-7 1 D
+24 4 D
+7 -1 D
+13 3 D
+7 -1 D
+61 11 D
+-1 2 D
+12 2 D
+-7 1 D
+6 1 D
+-15 2 D
+-6 -1 D
+-7 1 D
+-6 -1 D
+-7 1 D
+-67 -13 D
+-8 1 D
+-30 -5 D
+-7 1 D
+-80 -15 D
+7 -1 D
+-23 -6 D
+7 -1 D
+-12 -2 D
+22 -3 D
+6 1 D
+7 -1 D
+12 2 D
+7 -1 D
+6 1 D
+8 -1 D
+6 1 D
+7 -1 D
+19 2 D
+8 -1 D
+12 2 D
+7 -1 D
+33 2 D
+18 3 D
+7 -1 D
+31 6 D
+7 -1 D
+19 3 D
+7 -1 D
+103 19 D
+-7 1 D
+12 2 D
+-29 4 D
+-6 -1 D
+-7 1 D
+-6 -1 D
+-7 1 D
+-122 -23 D
+-7 1 D
+-12 -2 D
+-8 1 D
+-6 -1 D
+P
+FO
+1984 1399 M
+30 6 D
+-7 1 D
+6 1 D
+-7 1 D
+6 1 D
+-14 2 D
+-6 -1 D
+-15 2 D
+-6 -1 D
+-7 1 D
+-12 -3 D
+-7 1 D
+-68 -12 D
+7 -1 D
+-6 -1 D
+29 -4 D
+6 1 D
+14 -2 D
+13 3 D
+7 -1 D
+12 2 D
+7 -1 D
+13 2 D
+P
+FO
+2567 1380 M
+-7 -1 D
+-35 -5 D
+4 -1 D
+-12 -2 D
+3 -1 D
+-21 -4 D
+-6 0 D
+-16 -2 D
+-25 -4 D
+11 3 D
+-22 -2 D
+-73 -14 D
+2 -2 D
+-20 -3 D
+9 -2 D
+-50 -8 D
+-37 -6 D
+1 -3 D
+-6 -1 D
+5 -3 D
+8 -1 D
+-4 0 D
+4 -2 D
+-9 -1 D
+4 -1 D
+-77 -14 D
+3 0 D
+-9 -2 D
+6 -5 D
+-15 -4 D
+-24 2 D
+-10 -1 D
+-8 1 D
+-6 -1 D
+-7 1 D
+-6 -1 D
+-18 1 D
+-7 -1 D
+-10 0 D
+-5 -1 D
+-8 0 D
+-59 -10 D
+-2 0 D
+-7 -1 D
+-7 1 D
+-7 -1 D
+-10 0 D
+-23 -1 D
+-26 4 D
+3 1 D
+-8 1 D
+4 1 D
+-12 2 D
+-1 2 D
+-44 7 D
+-3 -1 D
+-33 4 D
+-6 -1 D
+-6 1 D
+-7 -1 D
+-8 0 D
+-6 -1 D
+-27 2 D
+-17 -1 D
+-18 1 D
+-37 -7 D
+-2 -1 D
+7 -1 D
+-34 -6 D
+-31 1 D
+-35 -7 D
+4 0 D
+-9 -2 D
+4 0 D
+-10 -2 D
+-3 1 D
+-17 -2 D
+-36 -4 D
+-12 0 D
+-7 -1 D
+-4 0 D
+-21 -3 D
+-15 0 D
+-6 -1 D
+-6 1 D
+-7 -1 D
+-8 1 D
+-87 -16 D
+-13 -1 D
+-32 3 D
+-6 13 D
+4 0 D
+-9 4 D
+31 6 D
+3 -1 D
+98 17 D
+-4 0 D
+10 2 D
+-7 1 D
+2 1 D
+-28 3 D
+-9 -2 D
+-8 0 D
+-72 -12 D
+-6 0 D
+-35 -7 D
+-4 1 D
+-3 -1 D
+S
+2198 1414 M
+12 2 D
+-7 1 D
+24 4 D
+7 -1 D
+13 3 D
+7 -1 D
+61 11 D
+-1 2 D
+12 2 D
+-7 1 D
+6 1 D
+-15 2 D
+-6 -1 D
+-7 1 D
+-6 -1 D
+-7 1 D
+-67 -13 D
+-8 1 D
+-30 -5 D
+-7 1 D
+-80 -15 D
+7 -1 D
+-23 -6 D
+7 -1 D
+-12 -2 D
+22 -3 D
+6 1 D
+7 -1 D
+12 2 D
+7 -1 D
+6 1 D
+8 -1 D
+6 1 D
+7 -1 D
+19 2 D
+8 -1 D
+12 2 D
+7 -1 D
+33 2 D
+18 3 D
+7 -1 D
+31 6 D
+7 -1 D
+19 3 D
+7 -1 D
+103 19 D
+-7 1 D
+12 2 D
+-29 4 D
+-6 -1 D
+-7 1 D
+-6 -1 D
+-7 1 D
+-122 -23 D
+-7 1 D
+-12 -2 D
+-8 1 D
+-6 -1 D
+P S
+2504 1498 M
+-22 -5 D
+-7 1 D
+-6 -1 D
+-13 0 D
+-13 -2 D
+-7 1 D
+-12 -3 D
+-7 1 D
+-18 -3 D
+-7 1 D
+-31 -6 D
+-7 1 D
+-18 -3 D
+-7 1 D
+-67 -12 D
+22 -3 D
+6 1 D
+7 -1 D
+6 1 D
+7 -1 D
+6 1 D
+7 -1 D
+6 1 D
+8 -1 D
+12 3 D
+7 -1 D
+6 1 D
+7 -1 D
+18 3 D
+-1 2 D
+7 -1 D
+7 2 D
+19 1 D
+-1 2 D
+7 -1 D
+49 7 D
+8 -1 D
+18 3 D
+7 -1 D
+12 3 D
+7 -1 D
+24 4 D
+8 -1 D
+9 2 D
+S
+1984 1399 M
+30 6 D
+-7 1 D
+6 1 D
+-7 1 D
+6 1 D
+-14 2 D
+-6 -1 D
+-15 2 D
+-6 -1 D
+-7 1 D
+-12 -3 D
+-7 1 D
+-68 -12 D
+7 -1 D
+-6 -1 D
+29 -4 D
+6 1 D
+14 -2 D
+13 3 D
+7 -1 D
+12 2 D
+7 -1 D
+13 2 D
+P S
+3089 1498 M
+-4 -3 D
+3 -2 D
+-36 -7 D
+12 -2 D
+-3 0 D
+15 -3 D
+-3 -2 D
+12 -1 D
+-6 -3 D
+-20 -4 D
+-36 -2 D
+-9 -2 D
+-6 1 D
+-3 3 D
+-28 4 D
+-30 -1 D
+-24 -5 D
+7 -1 D
+-33 -7 D
+1 -1 D
+-57 -11 D
+-16 -1 D
+-10 0 D
+-9 -2 D
+-10 1 D
+-31 -6 D
+1 -1 D
+-9 -2 D
+4 0 D
+-5 -3 D
+8 -2 D
+-8 -5 D
+5 -2 D
+-3 -2 D
+12 -2 D
+-6 -1 D
+1 -3 D
+-50 -11 D
+1 -2 D
+-9 -2 D
+-31 -6 D
+-6 1 D
+-7 -2 D
+6 -2 D
+-7 -1 D
+4 -1 D
+-15 -3 D
+3 -1 D
+-17 -3 D
+-13 0 D
+-7 -1 D
+-4 0 D
+-6 -1 D
+-4 1 D
+-14 -3 D
+-10 0 D
+-12 -1 D
+0 -1166 D
+1284 0 D
+0 1284 D
+P
+FO
+2567 1491 M
+21 4 D
+7 -1 D
+19 4 D
+-47 0 D
+P
+FO
+3089 1498 M
+-4 -3 D
+3 -2 D
+-36 -7 D
+12 -2 D
+-3 0 D
+15 -3 D
+-3 -2 D
+12 -1 D
+-6 -3 D
+-20 -4 D
+-36 -2 D
+-9 -2 D
+-6 1 D
+-3 3 D
+-28 4 D
+-30 -1 D
+-24 -5 D
+7 -1 D
+-33 -7 D
+1 -1 D
+-57 -11 D
+-16 -1 D
+-10 0 D
+-9 -2 D
+-10 1 D
+-31 -6 D
+1 -1 D
+-9 -2 D
+4 0 D
+-5 -3 D
+8 -2 D
+-8 -5 D
+5 -2 D
+-3 -2 D
+12 -2 D
+-6 -1 D
+1 -3 D
+-50 -11 D
+1 -2 D
+-9 -2 D
+-31 -6 D
+-6 1 D
+-7 -2 D
+6 -2 D
+-7 -1 D
+4 -1 D
+-15 -3 D
+3 -1 D
+-17 -3 D
+-13 0 D
+-7 -1 D
+-4 0 D
+-6 -1 D
+-4 1 D
+-14 -3 D
+-10 0 D
+-12 -1 D
+S
+2567 1491 M
+21 4 D
+7 -1 D
+19 4 D
+S
+1284 0 M
+0 214 D
+-1284 0 D
+0 -214 D
+P
+FO
+2567 0 M
+0 214 D
+-1283 0 D
+0 -214 D
+P
+FO
+3851 0 M
+0 214 D
+-1284 0 D
+0 -214 D
+P
+FO
+PSL_cliprestore
+%%EndObject
+-909 -6400 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+909 0 TM
+% PostScript produced by:
+%@GMT: gmt pscoast -Df -A7+ai -Gazure3 -Wfaint -BWeNs -Bxa1fg1 -Bya1fg1 -Xa0i -Ya0i -R-42/-39/-82:10/-77:45 -JQ15c+
+%@PROJ: eqc -42.00000000 -39.00000000 -82.16666667 -77.75000000 -166792.578 166792.578 -9136526.771 -8645415.291 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=-40.5 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 W
+clipsave
+0 0 M
+3851 0 D
+0 5669 D
+-3851 0 D
+P
+PSL_clip N
+1284 5349 M
+-3 0 D
+-6 0 D
+-4 -1 D
+-5 1 D
+-4 -1 D
+22 0 D
+P
+{0.757 0.804 0.804 C} FS
+FO
+1284 5349 M
+-3 0 D
+-6 0 D
+-4 -1 D
+-5 1 D
+-4 -1 D
+S
+1291 5348 M
+-6 2 D
+-1 -2 D
+P
+FO
+1302 5348 M
+-2 1 D
+-1 -1 D
+P
+FO
+1302 5348 M
+-2 1 D
+-1 -1 D
+S
+1291 5348 M
+-6 2 D
+-1 -1 D
+S
+1262 5348 M
+-19 -4 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-14 -4 D
+10 -2 D
+-13 -3 D
+-5 -1 D
+-5 1 D
+-9 -2 D
+-7 1 D
+-3 -1 D
+-6 1 D
+-14 -4 D
+5 -1 D
+-5 -1 D
+-5 1 D
+-14 -1 D
+-5 1 D
+-14 -1 D
+-28 -7 D
+-6 1 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 0 D
+-5 -1 D
+-6 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-5 1 D
+-18 -5 D
+5 -1 D
+-14 -3 D
+11 -2 D
+-4 -1 D
+10 -2 D
+-5 -1 D
+17 -3 D
+-6 -1 D
+16 -3 D
+-4 -1 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-14 -3 D
+-5 0 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-12 2 D
+-4 -1 D
+-96 17 D
+-4 -1 D
+-16 3 D
+-4 -1 D
+-12 2 D
+-4 -1 D
+-15 3 D
+-5 -1 D
+-22 4 D
+-4 -1 D
+-10 1 D
+-5 -1 D
+-16 1 D
+-5 -1 D
+-10 2 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-10 0 D
+-6 -1 D
+7 -1 D
+-5 -2 D
+15 -2 D
+-4 -1 D
+5 -1 D
+-5 -2 D
+5 0 D
+-9 -3 D
+6 -1 D
+-9 -2 D
+5 -1 D
+-5 -1 D
+1 -4 D
+-4 -1 D
+5 -1 D
+-5 -1 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-5 -1 D
+7 -1 D
+-6 -2 D
+6 0 D
+-9 -3 D
+5 -1 D
+-5 -1 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-14 -3 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-9 -3 D
+0 -2 D
+-23 -5 D
+-5 1 D
+5 1 D
+-6 1 D
+5 1 D
+-5 1 D
+9 4 D
+-5 1 D
+8 2 D
+-5 1 D
+14 4 D
+-5 1 D
+9 2 D
+-5 1 D
+9 2 D
+-5 1 D
+9 2 D
+4 3 D
+-5 1 D
+5 1 D
+-5 1 D
+4 1 D
+-11 2 D
+5 1 D
+-6 3 D
+5 2 D
+-6 3 D
+5 1 D
+-5 1 D
+4 1 D
+-11 2 D
+5 1 D
+-5 1 D
+4 1 D
+-10 2 D
+5 1 D
+-10 2 D
+4 1 D
+-5 1 D
+5 1 D
+-17 3 D
+5 1 D
+-10 2 D
+-5 -1 D
+-25 1 D
+-5 -2 D
+-5 1 D
+-9 -2 D
+-6 1 D
+-9 -2 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-9 -2 D
+-5 1 D
+-5 -1 D
+-5 0 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-4 -2 D
+-6 1 D
+-4 -1 D
+-20 2 D
+-6 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-15 1 D
+-5 -1 D
+-5 1 D
+-4 -2 D
+-7 1 D
+-4 -1 D
+-5 1 D
+-10 -2 D
+-5 1 D
+-9 -2 D
+-5 1 D
+-5 -1 D
+-6 1 D
+-8 -2 D
+-6 1 D
+-5 -2 D
+-5 1 D
+-5 -1 D
+-35 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-21 1 D
+-9 -2 D
+-6 1 D
+-4 -1 D
+-5 1 D
+-19 -4 D
+5 -1 D
+-5 -1 D
+1 -2 D
+-14 -4 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-19 -4 D
+5 -1 D
+-104 -24 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-19 -4 D
+5 -1 D
+-9 -3 D
+5 0 D
+-5 -2 D
+7 -1 D
+-8 -1 D
+0 -1 D
+3 -1 D
+-3 0 D
+0 -1178 D
+1284 0 D
+0 1283 D
+P
+FO
+1262 5348 M
+-19 -4 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-14 -4 D
+10 -2 D
+-13 -3 D
+-5 -1 D
+-5 1 D
+-9 -2 D
+-7 1 D
+-3 -1 D
+-6 1 D
+-14 -4 D
+5 -1 D
+-5 -1 D
+-5 1 D
+-14 -1 D
+-5 1 D
+-14 -1 D
+-28 -7 D
+-6 1 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 0 D
+-5 -1 D
+-6 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-5 1 D
+-18 -5 D
+5 -1 D
+-14 -3 D
+11 -2 D
+-4 -1 D
+10 -2 D
+-5 -1 D
+17 -3 D
+-6 -1 D
+16 -3 D
+-4 -1 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-14 -3 D
+-5 0 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-12 2 D
+-4 -1 D
+-96 17 D
+-4 -1 D
+-16 3 D
+-4 -1 D
+-12 2 D
+-4 -1 D
+-15 3 D
+-5 -1 D
+-22 4 D
+-4 -1 D
+-10 1 D
+-5 -1 D
+-16 1 D
+-5 -1 D
+-10 2 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-10 0 D
+-6 -1 D
+7 -1 D
+-5 -2 D
+15 -2 D
+-4 -1 D
+5 -1 D
+-5 -2 D
+5 0 D
+-9 -3 D
+6 -1 D
+-9 -2 D
+5 -1 D
+-5 -1 D
+1 -4 D
+-4 -1 D
+5 -1 D
+-5 -1 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-5 -1 D
+7 -1 D
+-6 -2 D
+6 0 D
+-9 -3 D
+5 -1 D
+-5 -1 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-14 -3 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-9 -3 D
+0 -2 D
+-23 -5 D
+-5 1 D
+5 1 D
+-6 1 D
+5 1 D
+-5 1 D
+9 4 D
+-5 1 D
+8 2 D
+-5 1 D
+14 4 D
+-5 1 D
+9 2 D
+-5 1 D
+9 2 D
+-5 1 D
+9 2 D
+4 3 D
+-5 1 D
+5 1 D
+-5 1 D
+4 1 D
+-11 2 D
+5 1 D
+-6 3 D
+5 2 D
+-6 3 D
+5 1 D
+-5 1 D
+4 1 D
+-11 2 D
+5 1 D
+-5 1 D
+4 1 D
+-10 2 D
+5 1 D
+-10 2 D
+4 1 D
+-5 1 D
+5 1 D
+-17 3 D
+5 1 D
+-10 2 D
+-5 -1 D
+-25 1 D
+-5 -2 D
+-5 1 D
+-9 -2 D
+-6 1 D
+-9 -2 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-9 -2 D
+-5 1 D
+-5 -1 D
+-5 0 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-4 -2 D
+-6 1 D
+-4 -1 D
+-20 2 D
+-6 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-15 1 D
+-5 -1 D
+-5 1 D
+-4 -2 D
+-7 1 D
+-4 -1 D
+-5 1 D
+-10 -2 D
+-5 1 D
+-9 -2 D
+-5 1 D
+-5 -1 D
+-6 1 D
+-8 -2 D
+-6 1 D
+-5 -2 D
+-5 1 D
+-5 -1 D
+-35 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-21 1 D
+-9 -2 D
+-6 1 D
+-4 -1 D
+-5 1 D
+-19 -4 D
+5 -1 D
+-5 -1 D
+1 -2 D
+-14 -4 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-19 -4 D
+5 -1 D
+-104 -24 D
+5 -1 D
+-9 -2 D
+5 -1 D
+-19 -4 D
+5 -1 D
+-9 -3 D
+5 0 D
+-5 -2 D
+7 -1 D
+-8 -1 D
+S
+0 5244 M
+3 -1 D
+-3 0 D
+S
+2567 5185 M
+-18 3 D
+-5 -1 D
+-20 1 D
+-17 3 D
+-4 -1 D
+-17 3 D
+-5 -1 D
+-15 2 D
+-5 -1 D
+-38 7 D
+-5 -1 D
+-21 4 D
+-4 -1 D
+-17 2 D
+-5 -1 D
+-16 3 D
+-10 0 D
+-17 3 D
+-3 -1 D
+-22 3 D
+-5 -1 D
+-59 11 D
+-6 -2 D
+-26 5 D
+-4 -1 D
+-22 4 D
+-5 -1 D
+-91 16 D
+-2 2 D
+-10 2 D
+4 1 D
+-27 5 D
+0 2 D
+-27 4 D
+4 2 D
+-54 9 D
+-4 -1 D
+-11 2 D
+-4 -1 D
+-17 3 D
+-4 -2 D
+-11 2 D
+-4 -1 D
+-38 7 D
+-5 -1 D
+-86 15 D
+5 1 D
+-16 3 D
+5 1 D
+-5 1 D
+4 1 D
+-11 2 D
+4 1 D
+-15 3 D
+5 1 D
+-12 2 D
+6 1 D
+-12 4 D
+4 1 D
+-10 2 D
+5 1 D
+-17 3 D
+0 2 D
+-59 11 D
+-10 -1 D
+-11 2 D
+-5 -1 D
+-15 1 D
+-53 10 D
+-5 -2 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-10 2 D
+-6 -1 D
+-5 1 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-21 3 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-10 2 D
+-6 -1 D
+-5 1 D
+-9 -2 D
+-5 1 D
+-10 -3 D
+-5 1 D
+-4 -1 D
+-12 2 D
+-3 -1 D
+-12 2 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-6 0 D
+-3 -1 D
+-5 1 D
+-6 -1 D
+-10 2 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-27 1 D
+0 -1283 D
+1283 0 D
+P
+FO
+2567 5185 M
+-18 3 D
+-5 -1 D
+-20 1 D
+-17 3 D
+-4 -1 D
+-17 3 D
+-5 -1 D
+-15 2 D
+-5 -1 D
+-38 7 D
+-5 -1 D
+-21 4 D
+-4 -1 D
+-17 2 D
+-5 -1 D
+-16 3 D
+-10 0 D
+-17 3 D
+-3 -1 D
+-22 3 D
+-5 -1 D
+-59 11 D
+-6 -2 D
+-26 5 D
+-4 -1 D
+-22 4 D
+-5 -1 D
+-91 16 D
+-2 2 D
+-10 2 D
+4 1 D
+-27 5 D
+0 2 D
+-27 4 D
+4 2 D
+-54 9 D
+-4 -1 D
+-11 2 D
+-4 -1 D
+-17 3 D
+-4 -2 D
+-11 2 D
+-4 -1 D
+-38 7 D
+-5 -1 D
+-86 15 D
+5 1 D
+-16 3 D
+5 1 D
+-5 1 D
+4 1 D
+-11 2 D
+4 1 D
+-15 3 D
+5 1 D
+-12 2 D
+6 1 D
+-12 4 D
+4 1 D
+-10 2 D
+5 1 D
+-17 3 D
+0 2 D
+-59 11 D
+-10 -1 D
+-11 2 D
+-5 -1 D
+-15 1 D
+-53 10 D
+-5 -2 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-10 2 D
+-6 -1 D
+-5 1 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-21 3 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 1 D
+-4 -1 D
+-10 2 D
+-6 -1 D
+-5 1 D
+-9 -2 D
+-5 1 D
+-10 -3 D
+-5 1 D
+-4 -1 D
+-12 2 D
+-3 -1 D
+-12 2 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-6 0 D
+-3 -1 D
+-5 1 D
+-6 -1 D
+-10 2 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-9 1 D
+S
+1299 5348 M
+-4 0 D
+-4 0 D
+S
+3851 5154 M
+-8 -2 D
+-5 1 D
+-27 -7 D
+5 -1 D
+-9 -2 D
+7 -1 D
+-23 -6 D
+-6 1 D
+-9 -2 D
+-6 1 D
+-4 -1 D
+-20 -1 D
+-6 1 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-22 4 D
+-4 -2 D
+-11 2 D
+-4 -1 D
+-12 2 D
+-5 -1 D
+-33 5 D
+-4 -1 D
+-72 12 D
+5 1 D
+-38 7 D
+4 1 D
+-27 5 D
+-2 2 D
+-33 5 D
+-4 -1 D
+-12 2 D
+-3 -1 D
+-7 1 D
+-4 -1 D
+-5 1 D
+-9 -3 D
+-6 1 D
+-22 -5 D
+5 -1 D
+-4 -1 D
+49 -9 D
+-4 -1 D
+39 -7 D
+-5 -1 D
+83 -14 D
+9 1 D
+17 -3 D
+-9 -2 D
+-5 1 D
+-9 -3 D
+-6 1 D
+-5 -1 D
+-11 2 D
+-4 -1 D
+-31 1 D
+-11 2 D
+-4 -1 D
+-12 2 D
+-4 -1 D
+-11 2 D
+-5 -2 D
+-11 2 D
+-20 0 D
+-10 2 D
+-6 -1 D
+-10 2 D
+-10 -1 D
+-12 2 D
+-4 -1 D
+-11 2 D
+-4 -1 D
+-11 2 D
+-6 -2 D
+-15 3 D
+-5 -1 D
+-16 1 D
+-16 3 D
+-4 -2 D
+-67 12 D
+-4 -1 D
+-6 0 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 0 D
+-4 -1 D
+-12 2 D
+-3 -1 D
+-7 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-10 1 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-20 2 D
+-5 -1 D
+-11 2 D
+-5 -2 D
+-5 1 D
+-5 -1 D
+-10 2 D
+-6 -1 D
+-10 2 D
+-5 -1 D
+-10 2 D
+-5 -2 D
+-17 3 D
+-4 -1 D
+-11 2 D
+-36 2 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-10 2 D
+-6 -1 D
+-5 0 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-10 2 D
+-5 -2 D
+-21 2 D
+-5 -1 D
+-10 2 D
+-6 -1 D
+-30 3 D
+-5 -1 D
+-12 2 D
+-4 -1 D
+-17 3 D
+-25 2 D
+-5 -1 D
+-17 3 D
+-4 -1 D
+-27 5 D
+-5 -2 D
+-10 2 D
+-5 -1 D
+-25 3 D
+0 -1120 D
+1284 0 D
+P
+FO
+3851 5154 M
+-8 -2 D
+-5 1 D
+-27 -7 D
+5 -1 D
+-9 -2 D
+7 -1 D
+-23 -6 D
+-6 1 D
+-9 -2 D
+-6 1 D
+-4 -1 D
+-20 -1 D
+-6 1 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-22 4 D
+-4 -2 D
+-11 2 D
+-4 -1 D
+-12 2 D
+-5 -1 D
+-33 5 D
+-4 -1 D
+-72 12 D
+5 1 D
+-38 7 D
+4 1 D
+-27 5 D
+-2 2 D
+-33 5 D
+-4 -1 D
+-12 2 D
+-3 -1 D
+-7 1 D
+-4 -1 D
+-5 1 D
+-9 -3 D
+-6 1 D
+-22 -5 D
+5 -1 D
+-4 -1 D
+49 -9 D
+-4 -1 D
+39 -7 D
+-5 -1 D
+83 -14 D
+9 1 D
+17 -3 D
+-9 -2 D
+-5 1 D
+-9 -3 D
+-6 1 D
+-5 -1 D
+-11 2 D
+-4 -1 D
+-31 1 D
+-11 2 D
+-4 -1 D
+-12 2 D
+-4 -1 D
+-11 2 D
+-5 -2 D
+-11 2 D
+-20 0 D
+-10 2 D
+-6 -1 D
+-10 2 D
+-10 -1 D
+-12 2 D
+-4 -1 D
+-11 2 D
+-4 -1 D
+-11 2 D
+-6 -2 D
+-15 3 D
+-5 -1 D
+-16 1 D
+-16 3 D
+-4 -2 D
+-67 12 D
+-4 -1 D
+-6 0 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-6 -1 D
+-5 1 D
+-5 -1 D
+-5 1 D
+-4 -1 D
+-6 0 D
+-4 -1 D
+-12 2 D
+-3 -1 D
+-7 1 D
+-4 -1 D
+-5 1 D
+-5 -1 D
+-10 1 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-20 2 D
+-5 -1 D
+-11 2 D
+-5 -2 D
+-5 1 D
+-5 -1 D
+-10 2 D
+-6 -1 D
+-10 2 D
+-5 -1 D
+-10 2 D
+-5 -2 D
+-17 3 D
+-4 -1 D
+-11 2 D
+-36 2 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-5 1 D
+-5 -1 D
+-10 2 D
+-6 -1 D
+-5 0 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-11 2 D
+-5 -1 D
+-10 2 D
+-5 -1 D
+-10 2 D
+-5 -2 D
+-21 2 D
+-5 -1 D
+-10 2 D
+-6 -1 D
+-30 3 D
+-5 -1 D
+-12 2 D
+-4 -1 D
+-17 3 D
+-25 2 D
+-5 -1 D
+-17 3 D
+-4 -1 D
+-27 5 D
+-5 -2 D
+-10 2 D
+-5 -1 D
+-25 3 D
+S
+0 2781 M
+1284 0 D
+0 1284 D
+-1284 0 D
+P
+FO
+1284 2781 M
+1283 0 D
+0 1284 D
+-1283 0 D
+P
+FO
+2567 2781 M
+1284 0 D
+0 1284 D
+-1284 0 D
+P
+FO
+0 1498 M
+1284 0 D
+0 1283 D
+-1284 0 D
+P
+FO
+1284 1498 M
+1283 0 D
+0 1283 D
+-1283 0 D
+P
+FO
+2567 1498 M
+1284 0 D
+0 1283 D
+-1284 0 D
+P
+FO
+0 214 M
+1284 0 D
+0 1284 D
+-1284 0 D
+P
+FO
+1284 214 M
+1283 0 D
+0 1284 D
+-1283 0 D
+P
+FO
+2567 214 M
+1284 0 D
+0 1284 D
+-1284 0 D
+P
+FO
+1284 0 M
+0 214 D
+-1284 0 D
+0 -214 D
+P
+FO
+2567 0 M
+0 214 D
+-1283 0 D
+0 -214 D
+P
+FO
+3851 0 M
+0 214 D
+-1284 0 D
+0 -214 D
+P
+FO
+PSL_cliprestore
+25 W
+4 W
+0 0 M
+0 5669 D
+S
+1284 0 M
+0 5669 D
+S
+2567 0 M
+0 5669 D
+S
+3851 0 M
+0 5669 D
+S
+0 214 M
+3851 0 D
+S
+0 1498 M
+3851 0 D
+S
+0 2781 M
+3851 0 D
+S
+0 4065 M
+3851 0 D
+S
+0 5348 M
+3851 0 D
+S
+8 W
+N 0 0 M 0 -83 D S
+N 0 5669 M 0 84 D S
+N 1284 0 M 0 -83 D S
+N 1284 5669 M 0 84 D S
+N 2567 0 M 0 -83 D S
+N 2567 5669 M 0 84 D S
+N 3851 0 M 0 -83 D S
+N 3851 5669 M 0 84 D S
+N 0 214 M -83 0 D S
+N 3851 214 M 83 0 D S
+N 0 1498 M -83 0 D S
+N 3851 1498 M 83 0 D S
+N 0 2781 M -83 0 D S
+N 3851 2781 M 83 0 D S
+N 0 4065 M -83 0 D S
+N 3851 4065 M 83 0 D S
+N 0 5348 M -83 0 D S
+N 3851 5348 M 83 0 D S
+83 W
+1 A
+N -42 0 M 0 214 D S
+N 3892 0 M 0 214 D S
+0 A
+N -42 214 M 0 321 D S
+N 3892 214 M 0 321 D S
+1 A
+N -42 535 M 0 321 D S
+N 3892 535 M 0 321 D S
+0 A
+N -42 856 M 0 321 D S
+N 3892 856 M 0 321 D S
+1 A
+N -42 1177 M 0 321 D S
+N 3892 1177 M 0 321 D S
+0 A
+N -42 1498 M 0 320 D S
+N 3892 1498 M 0 320 D S
+1 A
+N -42 1818 M 0 321 D S
+N 3892 1818 M 0 321 D S
+0 A
+N -42 2139 M 0 321 D S
+N 3892 2139 M 0 321 D S
+1 A
+N -42 2460 M 0 321 D S
+N 3892 2460 M 0 321 D S
+0 A
+N -42 2781 M 0 321 D S
+N 3892 2781 M 0 321 D S
+1 A
+N -42 3102 M 0 321 D S
+N 3892 3102 M 0 321 D S
+0 A
+N -42 3423 M 0 321 D S
+N 3892 3423 M 0 321 D S
+1 A
+N -42 3744 M 0 321 D S
+N 3892 3744 M 0 321 D S
+0 A
+N -42 4065 M 0 321 D S
+N 3892 4065 M 0 321 D S
+1 A
+N -42 4386 M 0 321 D S
+N 3892 4386 M 0 321 D S
+0 A
+N -42 4707 M 0 320 D S
+N 3892 4707 M 0 320 D S
+1 A
+N -42 5027 M 0 321 D S
+N 3892 5027 M 0 321 D S
+0 A
+N -42 5348 M 0 321 D S
+N 3892 5348 M 0 321 D S
+N 0 -42 M 321 0 D S
+N 0 5711 M 321 0 D S
+1 A
+N 321 -42 M 321 0 D S
+N 321 5711 M 321 0 D S
+0 A
+N 642 -42 M 321 0 D S
+N 642 5711 M 321 0 D S
+1 A
+N 963 -42 M 321 0 D S
+N 963 5711 M 321 0 D S
+0 A
+N 1284 -42 M 321 0 D S
+N 1284 5711 M 321 0 D S
+1 A
+N 1605 -42 M 320 0 D S
+N 1605 5711 M 320 0 D S
+0 A
+N 1925 -42 M 321 0 D S
+N 1925 5711 M 321 0 D S
+1 A
+N 2246 -42 M 321 0 D S
+N 2246 5711 M 321 0 D S
+0 A
+N 2567 -42 M 321 0 D S
+N 2567 5711 M 321 0 D S
+1 A
+N 2888 -42 M 321 0 D S
+N 2888 5711 M 321 0 D S
+0 A
+N 3209 -42 M 321 0 D S
+N 3209 5711 M 321 0 D S
+1 A
+N 3530 -42 M 321 0 D S
+N 3530 5711 M 321 0 D S
+0 A
+8 W
+N -83 0 M 4017 0 D S
+N -83 -83 M 4017 0 D S
+N 3851 -83 M 0 5836 D S
+N 3934 -83 M 0 5836 D S
+N 3934 5669 M -4017 0 D S
+N 3934 5753 M -4017 0 D S
+N 0 5753 M 0 -5836 D S
+N -83 5753 M 0 -5836 D S
+0 5836 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-42°) bc Z
+1284 5836 M (-41°) bc Z
+2567 5836 M (-40°) bc Z
+3851 5836 M (-39°) bc Z
+-167 214 M (-82°) mr Z
+-167 1498 M (-81°) mr Z
+-167 2781 M (-80°) mr Z
+-167 4065 M (-79°) mr Z
+-167 5348 M (-78°) mr Z
+%%EndObject
+-909 0 TM
+0 A
+FQ
+O0
+909 0 TM
+% PostScript produced by:
+%@GMT: gmt pscoast -Df -A7+ag -Glightpink -Wfaint -Xa0i -Ya0i -R-42/-39/-82:10/-77:45 -JQ15c+
+%@PROJ: eqc -42.00000000 -39.00000000 -82.16666667 -77.75000000 -166792.578 166792.578 -9136526.771 -8645415.291 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=-40.5 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 W
+clipsave
+0 0 M
+3851 0 D
+0 5669 D
+-3851 0 D
+P
+PSL_clip N
+3851 1592 M
+-19 -3 D
+-33 -2 D
+-20 -4 D
+4 0 D
+-5 -2 D
+10 -1 D
+-4 0 D
+-18 -2 D
+-14 0 D
+-49 -5 D
+-4 1 D
+-20 -4 D
+-44 -4 D
+-45 -9 D
+-34 -3 D
+-21 -4 D
+-6 1 D
+-61 -10 D
+-18 -3 D
+-4 1 D
+-35 -7 D
+-4 0 D
+4 1 D
+-21 0 D
+-21 -3 D
+-19 -2 D
+-4 1 D
+-24 -4 D
+-4 1 D
+-31 -4 D
+-13 0 D
+-84 -15 D
+-28 4 D
+-33 -3 D
+-44 -8 D
+7 -1 D
+-3 -1 D
+762 0 D
+P
+{1 0.714 0.757 C} FS
+FO
+3851 1598 M
+-8 -1 D
+8 -2 D
+P
+FO
+3851 1603 M
+-5 -1 D
+4 0 D
+-7 -2 D
+8 -1 D
+P
+FO
+3851 1592 M
+-19 -3 D
+-33 -2 D
+-20 -4 D
+4 0 D
+-5 -2 D
+10 -1 D
+-4 0 D
+-18 -2 D
+-14 0 D
+-49 -5 D
+-4 1 D
+-20 -4 D
+-44 -4 D
+-45 -9 D
+-34 -3 D
+-21 -4 D
+-6 1 D
+-61 -10 D
+-18 -3 D
+-4 1 D
+-35 -7 D
+-4 0 D
+4 1 D
+-21 0 D
+-21 -3 D
+-19 -2 D
+-4 1 D
+-24 -4 D
+-4 1 D
+-31 -4 D
+-13 0 D
+-84 -15 D
+-28 4 D
+-33 -3 D
+-44 -8 D
+7 -1 D
+-3 -1 D
+S
+3851 1603 M
+-5 -1 D
+4 0 D
+-7 -2 D
+8 -1 D
+S
+3851 1598 M
+-8 -1 D
+8 -2 D
+S
+1284 1275 M
+-66 -11 D
+-20 -5 D
+3 -1 D
+-9 -2 D
+-5 -7 D
+-9 -2 D
+8 -2 D
+-11 -5 D
+3 -1 D
+-7 -4 D
+4 0 D
+-9 -3 D
+7 -2 D
+-18 -7 D
+4 -1 D
+-11 -4 D
+1 -3 D
+-7 -2 D
+6 -2 D
+-4 -1 D
+7 0 D
+-54 -10 D
+-14 0 D
+-54 -9 D
+4 -1 D
+-9 -3 D
+4 0 D
+-22 -6 D
+4 -1 D
+-47 -9 D
+7 -1 D
+-19 -4 D
+4 -1 D
+-22 -4 D
+8 -1 D
+-17 -2 D
+4 -1 D
+-22 -5 D
+8 -1 D
+-17 -2 D
+4 -1 D
+-38 -7 D
+-13 -3 D
+4 0 D
+-13 -2 D
+1 -1 D
+-13 -3 D
+4 0 D
+-42 -8 D
+1 -1 D
+-17 -3 D
+2 -1 D
+-45 -8 D
+2 0 D
+-28 -5 D
+4 -1 D
+-19 -3 D
+2 -1 D
+-26 -4 D
+4 -1 D
+-9 -1 D
+0 -2 D
+-9 -2 D
+4 0 D
+-10 -2 D
+1 -2 D
+-10 -2 D
+4 0 D
+-7 -2 D
+-19 -4 D
+-24 -6 D
+-36 -6 D
+4 -1 D
+-43 -7 D
+4 0 D
+-13 -3 D
+2 -2 D
+-22 -5 D
+6 -1 D
+-9 -4 D
+1 -2 D
+-34 -7 D
+-7 -2 D
+4 -1 D
+-10 -1 D
+-10 -2 D
+4 -1 D
+-18 -7 D
+3 -1 D
+-11 -4 D
+4 0 D
+-8 -2 D
+1 -2 D
+-6 -1 D
+4 0 D
+-19 -6 D
+3 -1 D
+-6 -1 D
+1 -2 D
+8 -2 D
+-5 -4 D
+-10 -2 D
+1 -2 D
+-17 -4 D
+8 -1 D
+-7 -1 D
+8 -1 D
+-10 -3 D
+4 0 D
+-32 -7 D
+-29 1 D
+-16 -3 D
+-11 -8 D
+4 -3 D
+-6 -1 D
+5 -1 D
+-5 -8 D
+9 -3 D
+-1 -6 D
+15 -3 D
+-6 -1 D
+7 -4 D
+-6 -2 D
+4 -1 D
+-20 -4 D
+-29 3 D
+-7 -1 D
+-10 1 D
+-23 -4 D
+5 -6 D
+27 -5 D
+-10 -3 D
+5 -1 D
+-10 -2 D
+1 -2 D
+-8 -1 D
+8 -1 D
+1 -2 D
+-6 -1 D
+8 -2 D
+-11 -2 D
+2 -4 D
+-7 -1 D
+2 -2 D
+-8 -2 D
+1 -2 D
+-17 -2 D
+2 -2 D
+-14 -3 D
+1 -2 D
+-13 -2 D
+4 0 D
+-8 -1 D
+4 -1 D
+-9 -2 D
+0 -2 D
+-6 -1 D
+3 0 D
+-6 -1 D
+8 -2 D
+-11 -2 D
+6 -4 D
+-7 -1 D
+4 -2 D
+-5 -3 D
+8 -2 D
+-4 -2 D
+11 -2 D
+-14 -8 D
+1 -6 D
+-8 -2 D
+3 -1 D
+-10 -1 D
+4 -1 D
+-10 -1 D
+7 -2 D
+-12 -3 D
+7 -1 D
+-16 -6 D
+7 -1 D
+-13 -3 D
+2 -2 D
+-11 -1 D
+4 -1 D
+-10 -2 D
+8 -1 D
+-7 -1 D
+4 0 D
+-8 -1 D
+2 -2 D
+-14 -3 D
+7 -1 D
+-22 -6 D
+27 -5 D
+-3 0 D
+19 -6 D
+-7 -2 D
+35 -5 D
+-4 -1 D
+5 -4 D
+-6 -1 D
+4 -1 D
+-7 -4 D
+6 -2 D
+-7 -1 D
+8 -1 D
+-8 -1 D
+12 -3 D
+-7 -1 D
+5 -6 D
+-9 -3 D
+2 -3 D
+-7 -2 D
+4 -1 D
+-6 -1 D
+1 -3 D
+-10 -2 D
+4 0 D
+-7 -1 D
+1 -4 D
+-7 -1 D
+5 -1 D
+-8 -1 D
+5 -2 D
+-10 -2 D
+8 -1 D
+-8 -2 D
+8 -1 D
+-9 -3 D
+7 -1 D
+-6 -2 D
+4 -2 D
+-34 -5 D
+-3 0 D
+-11 -2 D
+-3 1 D
+-17 -2 D
+-22 1 D
+0 -487 D
+1284 0 D
+P
+FO
+1284 1275 M
+-66 -11 D
+-20 -5 D
+3 -1 D
+-9 -2 D
+-5 -7 D
+-9 -2 D
+8 -2 D
+-11 -5 D
+3 -1 D
+-7 -4 D
+4 0 D
+-9 -3 D
+7 -2 D
+-18 -7 D
+4 -1 D
+-11 -4 D
+1 -3 D
+-7 -2 D
+6 -2 D
+-4 -1 D
+7 0 D
+-54 -10 D
+-14 0 D
+-54 -9 D
+4 -1 D
+-9 -3 D
+4 0 D
+-22 -6 D
+4 -1 D
+-47 -9 D
+7 -1 D
+-19 -4 D
+4 -1 D
+-22 -4 D
+8 -1 D
+-17 -2 D
+4 -1 D
+-22 -5 D
+8 -1 D
+-17 -2 D
+4 -1 D
+-38 -7 D
+-13 -3 D
+4 0 D
+-13 -2 D
+1 -1 D
+-13 -3 D
+4 0 D
+-42 -8 D
+1 -1 D
+-17 -3 D
+2 -1 D
+-45 -8 D
+2 0 D
+-28 -5 D
+4 -1 D
+-19 -3 D
+2 -1 D
+-26 -4 D
+4 -1 D
+-9 -1 D
+0 -2 D
+-9 -2 D
+4 0 D
+-10 -2 D
+1 -2 D
+-10 -2 D
+4 0 D
+-7 -2 D
+-19 -4 D
+-24 -6 D
+-36 -6 D
+4 -1 D
+-43 -7 D
+4 0 D
+-13 -3 D
+2 -2 D
+-22 -5 D
+6 -1 D
+-9 -4 D
+1 -2 D
+-34 -7 D
+-7 -2 D
+4 -1 D
+-10 -1 D
+-10 -2 D
+4 -1 D
+-18 -7 D
+3 -1 D
+-11 -4 D
+4 0 D
+-8 -2 D
+1 -2 D
+-6 -1 D
+4 0 D
+-19 -6 D
+3 -1 D
+-6 -1 D
+1 -2 D
+8 -2 D
+-5 -4 D
+-10 -2 D
+1 -2 D
+-17 -4 D
+8 -1 D
+-7 -1 D
+8 -1 D
+-10 -3 D
+4 0 D
+-32 -7 D
+-29 1 D
+-16 -3 D
+-11 -8 D
+4 -3 D
+-6 -1 D
+5 -1 D
+-5 -8 D
+9 -3 D
+-1 -6 D
+15 -3 D
+-6 -1 D
+7 -4 D
+-6 -2 D
+4 -1 D
+-20 -4 D
+-29 3 D
+-7 -1 D
+-10 1 D
+-23 -4 D
+5 -6 D
+27 -5 D
+-10 -3 D
+5 -1 D
+-10 -2 D
+1 -2 D
+-8 -1 D
+8 -1 D
+1 -2 D
+-6 -1 D
+8 -2 D
+-11 -2 D
+2 -4 D
+-7 -1 D
+2 -2 D
+-8 -2 D
+1 -2 D
+-17 -2 D
+2 -2 D
+-14 -3 D
+1 -2 D
+-13 -2 D
+4 0 D
+-8 -1 D
+4 -1 D
+-9 -2 D
+0 -2 D
+-6 -1 D
+3 0 D
+-6 -1 D
+8 -2 D
+-11 -2 D
+6 -4 D
+-7 -1 D
+4 -2 D
+-5 -3 D
+8 -2 D
+-4 -2 D
+11 -2 D
+-14 -8 D
+1 -6 D
+-8 -2 D
+3 -1 D
+-10 -1 D
+4 -1 D
+-10 -1 D
+7 -2 D
+-12 -3 D
+7 -1 D
+-16 -6 D
+7 -1 D
+-13 -3 D
+2 -2 D
+-11 -1 D
+4 -1 D
+-10 -2 D
+8 -1 D
+-7 -1 D
+4 0 D
+-8 -1 D
+2 -2 D
+-14 -3 D
+7 -1 D
+-22 -6 D
+27 -5 D
+-3 0 D
+19 -6 D
+-7 -2 D
+35 -5 D
+-4 -1 D
+5 -4 D
+-6 -1 D
+4 -1 D
+-7 -4 D
+6 -2 D
+-7 -1 D
+8 -1 D
+-8 -1 D
+12 -3 D
+-7 -1 D
+5 -6 D
+-9 -3 D
+2 -3 D
+-7 -2 D
+4 -1 D
+-6 -1 D
+1 -3 D
+-10 -2 D
+4 0 D
+-7 -1 D
+1 -4 D
+-7 -1 D
+5 -1 D
+-8 -1 D
+5 -2 D
+-10 -2 D
+8 -1 D
+-8 -2 D
+8 -1 D
+-9 -3 D
+7 -1 D
+-6 -2 D
+4 -2 D
+-34 -5 D
+-3 0 D
+-11 -2 D
+-3 1 D
+-17 -2 D
+-22 1 D
+S
+2567 1380 M
+-7 -1 D
+-35 -5 D
+4 -1 D
+-12 -2 D
+3 -1 D
+-21 -4 D
+-6 0 D
+-16 -2 D
+-25 -4 D
+11 3 D
+-22 -2 D
+-73 -14 D
+2 -2 D
+-20 -3 D
+9 -2 D
+-50 -8 D
+-37 -6 D
+1 -3 D
+-6 -1 D
+5 -3 D
+8 -1 D
+-4 0 D
+4 -2 D
+-9 -1 D
+4 -1 D
+-77 -14 D
+3 0 D
+-9 -2 D
+6 -5 D
+-15 -4 D
+-24 2 D
+-10 -1 D
+-8 1 D
+-6 -1 D
+-7 1 D
+-6 -1 D
+-18 1 D
+-7 -1 D
+-10 0 D
+-5 -1 D
+-8 0 D
+-59 -10 D
+-2 0 D
+-7 -1 D
+-7 1 D
+-7 -1 D
+-10 0 D
+-23 -1 D
+-26 4 D
+3 1 D
+-8 1 D
+4 1 D
+-12 2 D
+-1 2 D
+-44 7 D
+-3 -1 D
+-33 4 D
+-6 -1 D
+-6 1 D
+-7 -1 D
+-8 0 D
+-6 -1 D
+-27 2 D
+-17 -1 D
+-18 1 D
+-37 -7 D
+-2 -1 D
+7 -1 D
+-34 -6 D
+-31 1 D
+-35 -7 D
+4 0 D
+-9 -2 D
+4 0 D
+-10 -2 D
+-3 1 D
+-17 -2 D
+-36 -4 D
+-12 0 D
+-7 -1 D
+-4 0 D
+-21 -3 D
+-15 0 D
+-6 -1 D
+-6 1 D
+-7 -1 D
+-8 1 D
+-87 -16 D
+-13 -1 D
+-32 3 D
+-6 13 D
+4 0 D
+-9 4 D
+31 6 D
+3 -1 D
+98 17 D
+-4 0 D
+10 2 D
+-7 1 D
+2 1 D
+-28 3 D
+-9 -2 D
+-8 0 D
+-72 -12 D
+-6 0 D
+-35 -7 D
+-4 1 D
+-3 -1 D
+0 -1061 D
+1283 0 D
+P
+FO
+2198 1414 M
+12 2 D
+-7 1 D
+24 4 D
+7 -1 D
+13 3 D
+7 -1 D
+61 11 D
+-1 2 D
+12 2 D
+-7 1 D
+6 1 D
+-15 2 D
+-6 -1 D
+-7 1 D
+-6 -1 D
+-7 1 D
+-67 -13 D
+-8 1 D
+-30 -5 D
+-7 1 D
+-80 -15 D
+7 -1 D
+-23 -6 D
+7 -1 D
+-12 -2 D
+22 -3 D
+6 1 D
+7 -1 D
+12 2 D
+7 -1 D
+6 1 D
+8 -1 D
+6 1 D
+7 -1 D
+19 2 D
+8 -1 D
+12 2 D
+7 -1 D
+33 2 D
+18 3 D
+7 -1 D
+31 6 D
+7 -1 D
+19 3 D
+7 -1 D
+103 19 D
+-7 1 D
+12 2 D
+-29 4 D
+-6 -1 D
+-7 1 D
+-6 -1 D
+-7 1 D
+-122 -23 D
+-7 1 D
+-12 -2 D
+-8 1 D
+-6 -1 D
+P
+FO
+2567 1380 M
+-7 -1 D
+-35 -5 D
+4 -1 D
+-12 -2 D
+3 -1 D
+-21 -4 D
+-6 0 D
+-16 -2 D
+-25 -4 D
+11 3 D
+-22 -2 D
+-73 -14 D
+2 -2 D
+-20 -3 D
+9 -2 D
+-50 -8 D
+-37 -6 D
+1 -3 D
+-6 -1 D
+5 -3 D
+8 -1 D
+-4 0 D
+4 -2 D
+-9 -1 D
+4 -1 D
+-77 -14 D
+3 0 D
+-9 -2 D
+6 -5 D
+-15 -4 D
+-24 2 D
+-10 -1 D
+-8 1 D
+-6 -1 D
+-7 1 D
+-6 -1 D
+-18 1 D
+-7 -1 D
+-10 0 D
+-5 -1 D
+-8 0 D
+-59 -10 D
+-2 0 D
+-7 -1 D
+-7 1 D
+-7 -1 D
+-10 0 D
+-23 -1 D
+-26 4 D
+3 1 D
+-8 1 D
+4 1 D
+-12 2 D
+-1 2 D
+-44 7 D
+-3 -1 D
+-33 4 D
+-6 -1 D
+-6 1 D
+-7 -1 D
+-8 0 D
+-6 -1 D
+-27 2 D
+-17 -1 D
+-18 1 D
+-37 -7 D
+-2 -1 D
+7 -1 D
+-34 -6 D
+-31 1 D
+-35 -7 D
+4 0 D
+-9 -2 D
+4 0 D
+-10 -2 D
+-3 1 D
+-17 -2 D
+-36 -4 D
+-12 0 D
+-7 -1 D
+-4 0 D
+-21 -3 D
+-15 0 D
+-6 -1 D
+-6 1 D
+-7 -1 D
+-8 1 D
+-87 -16 D
+-13 -1 D
+-32 3 D
+-6 13 D
+4 0 D
+-9 4 D
+31 6 D
+3 -1 D
+98 17 D
+-4 0 D
+10 2 D
+-7 1 D
+2 1 D
+-28 3 D
+-9 -2 D
+-8 0 D
+-72 -12 D
+-6 0 D
+-35 -7 D
+-4 1 D
+-3 -1 D
+S
+2198 1414 M
+12 2 D
+-7 1 D
+24 4 D
+7 -1 D
+13 3 D
+7 -1 D
+61 11 D
+-1 2 D
+12 2 D
+-7 1 D
+6 1 D
+-15 2 D
+-6 -1 D
+-7 1 D
+-6 -1 D
+-7 1 D
+-67 -13 D
+-8 1 D
+-30 -5 D
+-7 1 D
+-80 -15 D
+7 -1 D
+-23 -6 D
+7 -1 D
+-12 -2 D
+22 -3 D
+6 1 D
+7 -1 D
+12 2 D
+7 -1 D
+6 1 D
+8 -1 D
+6 1 D
+7 -1 D
+19 2 D
+8 -1 D
+12 2 D
+7 -1 D
+33 2 D
+18 3 D
+7 -1 D
+31 6 D
+7 -1 D
+19 3 D
+7 -1 D
+103 19 D
+-7 1 D
+12 2 D
+-29 4 D
+-6 -1 D
+-7 1 D
+-6 -1 D
+-7 1 D
+-122 -23 D
+-7 1 D
+-12 -2 D
+-8 1 D
+-6 -1 D
+P S
+3089 1498 M
+-4 -3 D
+3 -2 D
+-36 -7 D
+12 -2 D
+-3 0 D
+15 -3 D
+-3 -2 D
+12 -1 D
+-6 -3 D
+-20 -4 D
+-36 -2 D
+-9 -2 D
+-6 1 D
+-3 3 D
+-28 4 D
+-30 -1 D
+-24 -5 D
+7 -1 D
+-33 -7 D
+1 -1 D
+-57 -11 D
+-16 -1 D
+-10 0 D
+-9 -2 D
+-10 1 D
+-31 -6 D
+1 -1 D
+-9 -2 D
+4 0 D
+-5 -3 D
+8 -2 D
+-8 -5 D
+5 -2 D
+-3 -2 D
+12 -2 D
+-6 -1 D
+1 -3 D
+-50 -11 D
+1 -2 D
+-9 -2 D
+-31 -6 D
+-6 1 D
+-7 -2 D
+6 -2 D
+-7 -1 D
+4 -1 D
+-15 -3 D
+3 -1 D
+-17 -3 D
+-13 0 D
+-7 -1 D
+-4 0 D
+-6 -1 D
+-4 1 D
+-14 -3 D
+-10 0 D
+-12 -1 D
+0 -1166 D
+1284 0 D
+0 1284 D
+P
+FO
+3089 1498 M
+-4 -3 D
+3 -2 D
+-36 -7 D
+12 -2 D
+-3 0 D
+15 -3 D
+-3 -2 D
+12 -1 D
+-6 -3 D
+-20 -4 D
+-36 -2 D
+-9 -2 D
+-6 1 D
+-3 3 D
+-28 4 D
+-30 -1 D
+-24 -5 D
+7 -1 D
+-33 -7 D
+1 -1 D
+-57 -11 D
+-16 -1 D
+-10 0 D
+-9 -2 D
+-10 1 D
+-31 -6 D
+1 -1 D
+-9 -2 D
+4 0 D
+-5 -3 D
+8 -2 D
+-8 -5 D
+5 -2 D
+-3 -2 D
+12 -2 D
+-6 -1 D
+1 -3 D
+-50 -11 D
+1 -2 D
+-9 -2 D
+-31 -6 D
+-6 1 D
+-7 -2 D
+6 -2 D
+-7 -1 D
+4 -1 D
+-15 -3 D
+3 -1 D
+-17 -3 D
+-13 0 D
+-7 -1 D
+-4 0 D
+-6 -1 D
+-4 1 D
+-14 -3 D
+-10 0 D
+-12 -1 D
+S
+1284 0 M
+0 214 D
+-1284 0 D
+0 -214 D
+P
+FO
+2567 0 M
+0 214 D
+-1283 0 D
+0 -214 D
+P
+FO
+3851 0 M
+0 214 D
+-1284 0 D
+0 -214 D
+P
+FO
+PSL_cliprestore
+%%EndObject
+-909 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/pscoast/gshhs_A.sh
+++ b/test/pscoast/gshhs_A.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Test a that -A with Antarctica works again
+# https://github.com/GenericMappingTools/gmt/issues/1295
+
+gmt begin gshhs_A ps
+  gmt subplot begin 2x1 -Fs12c -M10p -R-42/-39/-82:10/-77:45 -Ba1fg1 -BWsNe -Y1c
+  gmt coast -Df  -A+ai -Gazure3 -Wfaint -c
+  gmt coast -Df -A+ag -Glightpink -Wfaint
+  gmt coast -Df -A7+ai -Gazure3 -Wfaint -c
+  gmt coast -Df -A7+ag -Glightpink -Wfaint
+  gmt subplot end
+gmt end show


### PR DESCRIPTION
See #1295 for background and apparent solution. When a polygon is removed because its size is smaller than the **-A**_limit_ setting then we must be careful resetting the level of any node enclosed by the removed polygon.  if we are inside the Antarctica grounding line polygon but are using the icefront as coastline then we are still on land, not in the ocean.
