### PR TITLE
Do not change GMT_USERDIR in cmake

### DIFF
--- a/doc/examples/CMakeLists.txt
+++ b/doc/examples/CMakeLists.txt
@@ -24,7 +24,6 @@ foreach (_ps ${_examples})
 	list (APPEND _examples_png ${RST_BINARY_DIR}/_images/${_png_fig})
 	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
 		COMMAND ${CMAKE_COMMAND} -E env
-		GMT_USERDIR=${GMT_BINARY_DIR}/share
 		GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
 		${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
 		-A -P -E150 -Tg -Qg4 -Qt4

--- a/doc/scripts/CMakeLists.txt
+++ b/doc/scripts/CMakeLists.txt
@@ -23,7 +23,6 @@ foreach (_fig ${_scripts_ps2png})
 	list (APPEND _scripts_png ${RST_BINARY_DIR}/_images/${_png_fig})
 	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
 		COMMAND ${CMAKE_COMMAND} -E env
-		GMT_USERDIR=${GMT_BINARY_DIR}/share
 		GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
 		${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
 		-A -P -E150 -Tg -Qg4 -Qt4
@@ -41,7 +40,6 @@ foreach (_fig ${_scripts_ps2pdf})
 	list (APPEND _scripts_pdf ${RST_BINARY_DIR}/_images/${_pdf_fig})
 	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_pdf_fig}
 		COMMAND ${CMAKE_COMMAND} -E env
-		GMT_USERDIR=${GMT_BINARY_DIR}/share
 		GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
 		${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert -A -P -Tf
 		-D${RST_BINARY_DIR}/_images


### PR DESCRIPTION
I think this goes back to a time when we needed **GMT_USERDIR** to temporarily equal the build/share dir to find certain files, but this is no longer true, at least not requiring GMT_USERDIR to be reset.  We may possibly still need **GMT_SHAREDIR** which is OK.  Running without these settings worked fine for me locally.
