### PR TITLE
Add a github action to automatically make a draft release after tagging

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -32,13 +32,15 @@ assignees: ''
 - [ ] create macOS bundle (@PaulWessel)
 - [ ] create Windows installers (win32 and win64) (@joa-quim)
 - [ ] check if the source tarballs, macOS bundle and Windows installers work well
-- [ ] make a tag and push it to github
+- [ ] upload source tarballs, macOS bundle, Windows installers to the GMT FTP (@PaulWessel)
+- [ ] make a tag and push it to github (**Must be done after uploading packages to the GMT FTP**)
     ```
     git tag x.x.x
     git push --tags
     ```
-- [ ] go to [GitHub Release](https://github.com/GenericMappingTools/gmt/releases) and make a release. Remember to attach the source tarballs, macOS bundle and Windows installers.
-- [ ] upload source tarballs, macOS bundle, Windows installers to the GMT FTP (@PaulWessel)
+- [ ] make a [GitHub Release](https://github.com/GenericMappingTools/gmt/releases).
+  **GitHub actions automatically create a draft release for us after pushing the tag.**
+  We need to check if everything is OK and then publish the release.
 - [ ] upload the tarball to zenodo (@PaulWessel)
 - [ ] update README and VERSION files on the GMT FTP (@PaulWessel)
 - [ ] make announcements in the [GMT forum](https://forum.generic-mapping-tools.org/)

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,127 @@
+# GitHub action to make a draft release
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags/x.x.x and refs/tags/x.x.xrcx
+    tags:
+      # Push events to matching versions, e.g., 6.1.0, 6.1.0rc1
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
+
+name: Create a Draft Release
+
+jobs:
+  draft-release:
+    name: Create a Draft Release
+    runs-on: macos-latest # Have to use macos because linux sometimes timeouts
+    steps:
+      # for debugging only
+      #- name: Set DEBUG_GITHUB_REF for debugging
+      #  run: echo "::set-env name=DEBUG_GITHUB_REF::refs/tags/6.0.0"
+
+      - name: Set GMT Version from tag name
+        # ${GITHUB_REF} is "refs/tags/6.0.0" for tags
+        # after this step, the GMT Version can be used by ${{ env.GMT_VERSION }}
+        run: echo "::set-env name=GMT_VERSION::${GITHUB_REF##*/}"
+        # Uncomment the following line for debugging only
+        # run: echo "::set-env name=GMT_VERSION::${DEBUG_GITHUB_REF##*/}"
+
+      - name: Download GMT tarballs and installers
+        run: |
+          curl -O ftp://ftp.soest.hawaii.edu/gmt/bin/gmt-${{ env.GMT_VERSION }}-darwin-x86_64.dmg
+          curl -O ftp://ftp.soest.hawaii.edu/gmt/gmt-${{ env.GMT_VERSION }}-src.tar.gz
+          curl -O ftp://ftp.soest.hawaii.edu/gmt/gmt-${{ env.GMT_VERSION }}-src.tar.xz
+          curl -O ftp://ftp.soest.hawaii.edu/gmt/bin/gmt-${{ env.GMT_VERSION }}-win32.exe
+          curl -O ftp://ftp.soest.hawaii.edu/gmt/bin/gmt-${{ env.GMT_VERSION }}-win64.exe
+
+      - name: Checksum
+        run: |
+          shasum -a 256 \
+                gmt-${{ env.GMT_VERSION }}-darwin-x86_64.dmg \
+                gmt-${{ env.GMT_VERSION }}-src.tar.gz \
+                gmt-${{ env.GMT_VERSION }}-src.tar.xz \
+                gmt-${{ env.GMT_VERSION }}-win32.exe \
+                gmt-${{ env.GMT_VERSION }}-win64.exe \
+                > gmt-${{ env.GMT_VERSION }}-checksums.txt
+          # Display the checksums
+          cat gmt-${{ env.GMT_VERSION }}-checksums.txt
+
+      - name: Create a Draft Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.GMT_VERSION }}
+          release_name: ${{ env.GMT_VERSION }}
+          body: |
+            | **File**                       | **Description**                         |
+            |--------------------------------|-----------------------------------------|
+            | gmt-${{ env.GMT_VERSION }}-checksums.txt     | sha256sum of source and binary packages |
+            | gmt-${{ env.GMT_VERSION }}-darwin-x86_64.dmg | macOS bundle                            |
+            | gmt-${{ env.GMT_VERSION }}-src.tar.gz        | Source code                             |
+            | gmt-${{ env.GMT_VERSION }}-src.tar.xz        | Source code                             |
+            | gmt-${{ env.GMT_VERSION }}-win32.exe         | Windows installer (32bit)               |
+            | gmt-${{ env.GMT_VERSION }}-win64.exe         | Windows installer (64bit)               |
+          draft: true
+          prerelease: false
+
+      - name: Upload Release Asset - gmt-${{ env.GMT_VERSION }}-checksums.txt
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: gmt-${{ env.GMT_VERSION }}-checksums.txt
+          asset_name: gmt-${{ env.GMT_VERSION }}-checksums.txt
+          asset_content_type: text/plain
+
+      - name: Upload Release Asset - gmt-${{ env.GMT_VERSION }}-darwin-x86_64.dmg
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: gmt-${{ env.GMT_VERSION }}-darwin-x86_64.dmg
+          asset_name: gmt-${{ env.GMT_VERSION }}-darwin-x86_64.dmg
+          asset_content_type: application/x-apple-diskimage
+
+      - name: Upload Release Asset - gmt-${{ env.GMT_VERSION }}-src.tar.gz
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: gmt-${{ env.GMT_VERSION }}-src.tar.gz
+          asset_name: gmt-${{ env.GMT_VERSION }}-src.tar.gz
+          asset_content_type: application/x-tar
+
+      - name: Upload Release Asset - gmt-${{ env.GMT_VERSION }}-src.tar.xz
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: gmt-${{ env.GMT_VERSION }}-src.tar.xz
+          asset_name: gmt-${{ env.GMT_VERSION }}-src.tar.xz
+          asset_content_type: application/x-tar
+
+      - name: Upload Release Asset - gmt-${{ env.GMT_VERSION }}-win32.exe
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: gmt-${{ env.GMT_VERSION }}-win32.exe
+          asset_name: gmt-${{ env.GMT_VERSION }}-win32.exe
+          asset_content_type: application/x-msdownload
+
+      - name: Upload Release Asset - gmt-${{ env.GMT_VERSION }}-win64.exe
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: gmt-${{ env.GMT_VERSION }}-win64.exe
+          asset_name: gmt-${{ env.GMT_VERSION }}-win64.exe
+          asset_content_type: application/x-msdownload


### PR DESCRIPTION
This PR adds a github action to automatically make a draft release for us.

Making a tag (e.g., 6.1.0) and pushing it to github will trigger the github action. It will:

- Download 5 packages (source tarballs, bundle and windows installers) from the GMT FTP
- Create the checksum file
- Make a draft release
- Attach the 5 packages and the checksum file as assets of the draft release

The whole process only takes ~2.5 minutes and is fully automatic. As a comparison, it usually took me >15 minutes to download files from FTP and upload them to github. We still need to review the draft release and publish it if everything looks good.

**NOTE**: Since the github action needs to download packages from the GMT FTP. We need to upload the packages before making a tag. The release checklist is also updated accordingly.