### PR TITLE
Ensure remote files have correct _g|p string in the name

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13499,6 +13499,13 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 	gmt_M_unused(this_module_kw);
 	#endif
 
+	/* First handle any half-hearted naming of remote datasets where _g or _p should be appended */
+
+	for (opt = *options; opt; opt = opt->next) {	/* Loop over all options */
+		if (opt->arg[0] != '@') continue;	/* No remote file argument given */
+		gmt_set_unspecified_remote_registration (API, &(opt->arg));	/* If argument is a remote file name then tis handles any missing registration _p|_g */
+	}
+
 	/* Making -R<country-codes> globally available means it must affect history, etc.  The simplest fix here is to
 	 * make sure pscoast -E, if passing old +r|R area settings via -E, is split into -R before GMT_Parse_Common is called */
 
@@ -13909,7 +13916,6 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 
 		for (opt = *options; opt; opt = opt->next) {	/* Loop over all options */
 			if (opt->arg[0] != '@') continue;	/* No remote file argument given */
-        	gmt_set_unspecified_remote_registration (API, &(opt->arg));	/* If argument is a remote file name then tis handles any missing registration _p|_g */
 			if ((k_data = gmt_remote_no_extension (API, opt->arg)) != GMT_NOTSET) {	/* Remote file without file extension */
 				char *file = malloc (strlen(opt->arg)+1+strlen (API->remote_info[k_data].ext));
 				sprintf (file, "%s", opt->arg);


### PR DESCRIPTION
This is the first thing we do in gmt_init_module as the file may be used for many things, such as finding -R.  We are then guaranteed to have the correct name for a remote grid or image.

gmt grdimage -JG0/0/3i @earth_day_01d -B -pdf map

thus becomes internally

gmt grdimage -JG0/0/3i @earth_day_01d_p -B -pdf map

PS. This gets the image and takes me where I want but I think I have found a bug in grdimage so I will sort that out in a separate branch.
