### PR TITLE
Use common FFT in tests

### DIFF
--- a/test/potential/flex_inplane.sh
+++ b/test/potential/flex_inplane.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test the output of gmt grdflexure for single circular Gaussian seamount on elastic plate with inplane forces
+# Test the output of gmt grdflexure for single circular Gaussian seamount on elastic plate with in-plane forces
 ps=flex_inplane.ps
 m=g
 f=0.2

--- a/test/potential/flexure_e.ps
+++ b/test/potential/flexure_e.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from grdcontour
+%%Title: GMT v6.1.0_7cb8618_2020.06.07 [64-bit] Document from grdcontour
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:51:21 2018
+%%CreationDate: Sun Jun  7 19:38:31 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -336,9 +336,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +592,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +635,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -651,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -662,8 +658,9 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
-/PSL_movie_completion {} def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
@@ -678,7 +675,7 @@ O0
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 clipsave
 0 0 M
 7200 0 D
@@ -1127,6 +1124,7 @@ S
 0 4800 M
 7200 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 4800 M 0 -4800 D S
@@ -1138,8 +1136,8 @@ N 0 1200 M -83 0 D S
 N 0 2400 M -83 0 D S
 N 0 3600 M -83 0 D S
 N 0 4800 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 200 F0
 (0) sw mx
 (100) sw mx
@@ -1187,8 +1185,8 @@ N 0 1200 M 83 0 D S
 N 0 2400 M 83 0 D S
 N 0 3600 M 83 0 D S
 N 0 4800 M 83 0 D S
-/PSL_AH0 0
 /MM {exch M} def
+/PSL_AH0 0
 (0) sw mx
 (100) sw mx
 (200) sw mx
@@ -1236,8 +1234,8 @@ N 3600 0 M 0 -83 D S
 N 4800 0 M 0 -83 D S
 N 6000 0 M 0 -83 D S
 N 7200 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (0) sh mx
 (100) sh mx
 (200) sh mx
@@ -1299,8 +1297,8 @@ N 3600 0 M 0 83 D S
 N 4800 0 M 0 83 D S
 N 6000 0 M 0 83 D S
 N 7200 0 M 0 83 D S
-/PSL_AH0 0
 /MM {M} def
+/PSL_AH0 0
 (0) sh mx
 (100) sh mx
 (200) sh mx
@@ -1364,7 +1362,7 @@ O0
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 clipsave
 0 0 M
 7200 0 D
@@ -1421,7 +1419,7 @@ PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencod
 ] def
 /PSL_gap_x 22 def
 /PSL_gap_y 22 def
-/PSL_label_angle [ 76.28 76.28 77.45 77.45 77.04 77.04 86.76 86.42 85.04 85.04 
+/PSL_label_angle [ 76.28 76.28 77.45 77.45 77.04 77.04 86.81 86.53 85.04 85.04 
 	78.36 78.36 ] def
 /PSL_label_str [
 	(”3)
@@ -2894,93 +2892,121 @@ PSL_path_pen 17 get cvx exec
 84 13 D
 P S
 PSL_path_pen 18 get cvx exec
-662 0 M
--51 60 D
+663 0 M
+-9 12 D
+-30 31 D
+-13 17 D
+-11 12 D
+-8 12 D
 -12 12 D
--23 29 D
--42 55 D
 -8 12 D
+-22 24 D
+-17 24 D
+-19 24 D
 -10 14 D
--12 8 D
--12 23 D
--24 29 D
--24 34 D
--12 15 D
--36 58 D
--17 23 D
--7 13 D
--17 23 D
--22 36 D
--9 18 D
--21 30 D
--20 36 D
+-16 22 D
+-29 36 D
+-27 41 D
+-24 33 D
+-69 106 D
+-15 24 D
+-5 12 D
+-10 12 D
+-5 12 D
+-9 12 D
+-7 15 D
+-12 21 D
+-5 12 D
+-10 12 D
+-21 43 D
+-23 41 D
+-14 36 D
+-12 24 D
+-11 28 D
+-12 27 D
+-13 29 D
+-2 12 D
+-5 12 D
 -8 12 D
--24 48 D
--11 18 D
--24 47 D
--12 34 D
--17 33 D
--11 24 D
--22 48 D
--34 96 D
--18 48 D
--21 72 D
--31 108 D
--40 168 D
--10 52 D
+-8 24 D
+-6 12 D
+-6 27 D
+-8 21 D
+-4 14 D
+-13 34 D
+-11 41 D
+-8 19 D
+-4 17 D
+-3 7 D
+-9 39 D
+-12 43 D
+-3 14 D
+-5 12 D
+-1 12 D
+-5 24 D
+-5 12 D
+-5 24 D
+-4 12 D
+-3 24 D
+-8 36 D
+-4 12 D
+-5 27 D
 S
 PSL_path_pen 19 get cvx exec
 2140 0 M
--68 36 D
--92 54 D
--60 37 D
--108 73 D
+-67 36 D
+-84 48 D
+-95 60 D
+-82 56 D
 -86 64 D
 -61 48 D
 -84 72 D
 -78 72 D
 -51 50 D
--77 82 D
--55 63 D
--60 74 D
--68 91 D
--57 84 D
--43 68 D
--58 100 D
--61 120 D
--38 84 D
--44 108 D
--39 111 D
--35 117 D
--32 132 D
--25 132 D
--17 132 D
+-66 70 D
+-54 61 D
+-60 73 D
+-63 82 D
+-58 84 D
+-47 72 D
+-48 81 D
+-53 99 D
+-47 96 D
+-56 133 D
+-39 107 D
+-27 84 D
+-23 84 D
+-26 108 D
+-17 88 D
+-15 92 D
+-11 96 D
 -7 72 D
--6 132 D
--1 96 D
-3 84 D
-7 108 D
-12 108 D
-23 144 D
-30 136 D
-24 92 D
-41 132 D
-35 96 D
-54 132 D
-50 106 D
-38 74 D
-47 84 D
-50 84 D
+-6 156 D
+2 132 D
+9 132 D
+13 108 D
+21 132 D
+18 85 D
+33 131 D
+27 91 D
+34 101 D
+38 99 D
+45 105 D
+52 108 D
+59 109 D
+63 107 D
 71 108 D
-61 84 D
-57 75 D
-78 93 D
-54 61 D
-72 76 D
-72 71 D
-108 98 D
-109 90 D
-119 89 D
+46 64 D
+51 68 D
+57 71 D
+63 73 D
+57 63 D
+72 74 D
+60 58 D
+72 66 D
+84 71 D
+84 67 D
+84 62 D
 84 58 D
 96 62 D
 94 55 D
@@ -2990,40 +3016,38 @@ S
 PSL_path_pen 20 get cvx exec
 4799 0 M
 109 55 D
-60 33 D
-76 44 D
-78 48 D
+108 60 D
+106 65 D
 90 60 D
-92 66 D
-72 55 D
+80 57 D
+84 64 D
 115 95 D
-77 70 D
-65 62 D
-67 68 D
+89 81 D
+65 63 D
+55 56 D
 80 88 D
-61 72 D
-51 64 D
-69 92 D
-87 130 D
-60 99 D
-65 119 D
-47 96 D
-37 84 D
-39 96 D
-22 60 D
-25 72 D
-39 132 D
-32 132 D
+88 105 D
+66 87 D
+66 93 D
+60 92 D
+68 115 D
+64 122 D
+55 118 D
+49 120 D
+39 108 D
+30 96 D
+23 84 D
+26 108 D
 20 108 D
 15 96 D
-14 132 D
-7 132 D
-1 108 D
--6 132 D
--4 60 D
--11 96 D
--14 96 D
--21 108 D
+13 120 D
+7 120 D
+2 120 D
+-3 96 D
+-7 108 D
+-17 138 D
+-12 74 D
+-17 88 D
 -35 144 D
 -37 120 D
 -34 96 D
@@ -3040,129 +3064,179 @@ PSL_path_pen 20 get cvx exec
 -84 78 D
 -64 56 D
 -74 60 D
--80 60 D
--70 49 D
--71 47 D
--97 59 D
--72 40 D
--40 21 D
+-90 67 D
+-60 42 D
+-96 63 D
+-95 56 D
+-85 46 D
+-4 2 D
 S
 PSL_path_pen 21 get cvx exec
 6343 0 M
-17 15 D
-24 27 D
-19 18 D
-34 36 D
-31 36 D
-12 12 D
-31 36 D
-5 7 D
+13 12 D
+16 17 D
 12 11 D
-24 30 D
-12 17 D
-16 19 D
+48 51 D
+38 41 D
+10 12 D
+12 12 D
+49 60 D
+11 12 D
 8 12 D
-36 42 D
+12 12 D
+75 96 D
+13 19 D
 12 18 D
-37 48 D
-25 36 D
-50 72 D
-39 60 D
-23 36 D
-8 12 D
-50 84 D
-13 24 D
-8 12 D
-11 24 D
-13 24 D
-11 18 D
-37 78 D
-16 36 D
-23 48 D
-44 108 D
-31 84 D
-46 144 D
-7 19 D
-28 101 D
-17 60 D
-20 84 D
-7 36 D
+26 35 D
+10 14 D
+12 17 D
+28 41 D
+9 12 D
+31 48 D
+16 26 D
+22 34 D
+6 12 D
+24 36 D
+8 18 D
+12 20 D
+7 10 D
+5 12 D
+14 24 D
+10 21 D
+12 22 D
+32 65 D
+28 60 D
+12 28 D
+3 8 D
+7 12 D
+3 12 D
+7 12 D
+4 13 D
+6 11 D
+8 24 D
+6 12 D
+21 60 D
+6 12 D
+13 41 D
+34 103 D
+18 60 D
+27 96 D
+10 36 D
+2 12 D
+5 18 D
+24 98 D
 S
 PSL_path_pen 22 get cvx exec
 7200 3464 M
--12 65 D
--60 240 D
--12 27 D
--16 56 D
--9 24 D
--18 60 D
--19 48 D
--34 78 D
--16 42 D
--32 64 D
--15 32 D
--21 38 D
--12 24 D
--15 22 D
--21 39 D
--24 39 D
--24 31 D
--18 35 D
+-3 16 D
+-4 12 D
+-5 32 D
+-6 28 D
+-4 12 D
+-11 48 D
+-8 36 D
+-5 12 D
+-2 12 D
+-4 12 D
+-8 40 D
+-14 44 D
+-3 12 D
+-5 12 D
+-11 36 D
+-3 15 D
+-4 9 D
+-3 12 D
+-7 12 D
+-5 24 D
+-11 36 D
+-17 36 D
+-4 12 D
+-9 21 D
+-6 15 D
+-6 19 D
+-15 29 D
+-3 12 D
+-11 24 D
+-7 18 D
+-24 47 D
+-24 45 D
+-2 10 D
+-10 14 D
+-5 10 D
 -8 12 D
+-13 24 D
+-5 12 D
 -10 12 D
--31 48 D
--18 24 D
--35 53 D
--45 55 D
--36 48 D
--39 49 D
--12 9 D
--12 20 D
--17 18 D
--19 24 D
+-3 12 D
+-10 12 D
+-18 30 D
+-5 6 D
+-29 48 D
+-40 60 D
+-7 12 D
+-12 12 D
+-15 25 D
+-25 35 D
+-11 13 D
+-25 35 D
+-23 29 D
+-13 19 D
+-31 36 D
+-8 12 D
+-20 22 D
+-12 17 D
+-12 13 D
+-17 20 D
+-23 24 D
 S
 PSL_path_pen 23 get cvx exec
-857 4800 M
--17 -16 D
--18 -20 D
--30 -29 D
--48 -52 D
--45 -51 D
--27 -31 D
--12 -18 D
--12 -13 D
--37 -46 D
+856 4800 M
+-40 -39 D
+-64 -69 D
+-10 -12 D
+-12 -12 D
+-34 -40 D
+-8 -8 D
+-19 -24 D
+-32 -36 D
+-17 -24 D
 -11 -12 D
--12 -17 D
--36 -46 D
--43 -57 D
--9 -12 D
--8 -15 D
--16 -21 D
+-69 -91 D
+-40 -53 D
+-20 -31 D
+-28 -41 D
 -8 -14 D
--12 -15 D
--12 -20 D
--17 -23 D
+-9 -10 D
+-27 -44 D
+-41 -64 D
+-20 -36 D
+-16 -24 D
+-7 -15 D
+-6 -9 D
+-6 -13 D
+-14 -23 D
+-10 -21 D
+-33 -63 D
+-39 -85 D
+-12 -27 D
+-54 -128 D
+-6 -24 D
+-19 -48 D
+-11 -36 D
+-6 -17 D
+-26 -79 D
+-7 -24 D
 -7 -12 D
--12 -17 D
--12 -23 D
--14 -20 D
--10 -19 D
--27 -41 D
--26 -48 D
--21 -36 D
--11 -24 D
--14 -24 D
--16 -36 D
--37 -72 D
--4 -6 D
--12 -39 D
--23 -51 D
--26 -60 D
--54 -156 D
--30 -96 D
--37 -132 D
--34 -140 D
+0 -12 D
+-17 -60 D
+-7 -12 D
+0 -12 D
+-13 -48 D
+-2 -12 D
+-5 -14 D
+-16 -70 D
+-4 -12 D
+-4 -20 D
 S
 PSL_path_pen 24 get cvx exec
 3576 4177 M
@@ -3199,9 +3273,9 @@ PSL_path_pen 24 get cvx exec
 13 -84 D
 10 -108 D
 2 -60 D
-1 -36 D
--4 -108 D
--8 -84 D
+1 -48 D
+-5 -108 D
+-7 -72 D
 -12 -84 D
 -17 -84 D
 -14 -60 D
@@ -3210,14 +3284,13 @@ PSL_path_pen 24 get cvx exec
 -33 -80 D
 -35 -76 D
 -37 -71 D
--57 -97 D
--39 -60 D
--60 -83 D
--39 -49 D
--33 -40 D
--48 -54 D
--71 -74 D
--13 -12 D
+-60 -102 D
+-53 -79 D
+-53 -72 D
+-58 -72 D
+-76 -84 D
+-48 -49 D
+-12 -11 D
 -48 -46 D
 -43 -38 D
 -29 -24 D
@@ -3356,9 +3429,9 @@ PSL_path_pen 24 get cvx exec
 -13 84 D
 -10 108 D
 -2 60 D
--1 36 D
-4 108 D
-8 84 D
+-1 48 D
+5 108 D
+7 72 D
 12 84 D
 17 84 D
 14 60 D
@@ -3580,6 +3653,7 @@ S
 0 4800 M
 7200 0 D
 S
+/PSL_slant_y 0 def
 2 setlinecap
 25 W
 N 0 4800 M 0 -4800 D S
@@ -3591,8 +3665,8 @@ N 0 1200 M -83 0 D S
 N 0 2400 M -83 0 D S
 N 0 3600 M -83 0 D S
 N 0 4800 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 200 F0
 (0) sw mx
 (100) sw mx
@@ -3640,8 +3714,8 @@ N 0 1200 M 83 0 D S
 N 0 2400 M 83 0 D S
 N 0 3600 M 83 0 D S
 N 0 4800 M 83 0 D S
-/PSL_AH0 0
 /MM {exch M} def
+/PSL_AH0 0
 (0) sw mx
 (100) sw mx
 (200) sw mx
@@ -3727,8 +3801,8 @@ N 3600 0 M 0 83 D S
 N 4800 0 M 0 83 D S
 N 6000 0 M 0 83 D S
 N 7200 0 M 0 83 D S
-/PSL_AH0 0
 /MM {M} def
+/PSL_AH0 0
 (0) sh mx
 (100) sh mx
 (200) sh mx
@@ -3781,7 +3855,7 @@ N 6960 0 M 0 42 D S
 0 -4800 T
 0 setlinecap
 /PSL_H_y PSL_L_y PSL_LH add 233 add def
-3600 4800 PSL_H_y add M
+3600 4800 PSL_H_y add PSL_slant_y add M
 400 F0
 V MU 0 0 M (Elastic Plate Flexure, T) FP 0 -100 G 280 F0 (e) FP 0 100 G 400 F0 ( = 5 km) FP pathbbox N pop exch pop add U -2 div 0 G
 (Elastic Plate Flexure, T) Z
@@ -3794,16 +3868,17 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -Rk0/600/0/400 -Jx0.01i -O -T
+%@GMT: gmt psxy -R0/600/0/400+uk -Jx0.01i -O -T
 %@PROJ: xy 0.00000000 600000.00000000 0.00000000 400000.00000000 0.000 600000.000 0.000 400000.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 %%EndObject
 
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U

--- a/test/potential/flexure_e.sh
+++ b/test/potential/flexure_e.sh
@@ -4,7 +4,7 @@
 ps=flexure_e.ps
 m=g
 f=0.2
-gmt set MAP_FRAME_TYPE plain
+gmt set MAP_FRAME_TYPE plain GMT_FFT kiss
 cat << EOF > t.txt
 #lon lat azimuth, semi-major, semi-minor, height
 300	200	70	70	30	5000

--- a/test/potential/flexure_en.ps
+++ b/test/potential/flexure_en.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.1.0_fd744e5-dirty_2020.05.16 [64-bit] Document from grdcontour
+%%Title: GMT v6.1.0_7cb8618_2020.06.07 [64-bit] Document from grdcontour
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun May 17 21:14:20 2020
+%%CreationDate: Sun Jun  7 19:38:32 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -686,7 +686,7 @@ PSL_clip N
 /PSL_setboxpen {4 W 0 A [] 0 B} def
 /PSL_setboxrgb {1 A} def
 /PSL_path_pen [
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 	(12 W 0 A \[\] 0 B)
 	(12 W 0 A \[\] 0 B)
 	(12 W 0 A \[\] 0 B)
@@ -1323,7 +1323,7 @@ PSL_clip N
 /PSL_setboxpen {4 W 0 A [] 0 B} def
 /PSL_setboxrgb {1 A} def
 /PSL_path_pen [
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 	(4 W 0 A \[\] 0 B)
 	(4 W 0 A \[\] 0 B)
 	(12 W 0 A \[\] 0 B)
@@ -1379,17 +1379,17 @@ PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reenco
 ] def
 /PSL_gap_x 22 def
 /PSL_gap_y 22 def
-/PSL_label_angle [ 30.44 30.44 82.45 82.45 84.44 84.44 82.02 82.02 75.59 75.38 
-	79.60 79.54 75.08 75.08 74.47 74.47 ] def
+/PSL_label_angle [ 30.44 30.44 82.45 82.45 84.44 84.44 82.02 82.02 75.59 75.37 
+	79.70 79.47 75.08 75.08 74.47 74.47 ] def
 /PSL_label_str [
-	(-4)
-	(-4)
-	(-3)
-	(-3)
-	(-2)
-	(-2)
-	(-1)
-	(-1)
+	(”4)
+	(”4)
+	(”3)
+	(”3)
+	(”2)
+	(”2)
+	(”1)
+	(”1)
 	(0)
 	(0)
 	(0)
@@ -1406,7 +1406,7 @@ PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reenco
 /PSL_n_paths 32 def
 /PSL_n_labels 16 def
 /PSL_txt_x [ 3763 3437 3894 3306 4012 3188 4155 3045 937 6263 
-	7132 69 5360 1840 4459 2741 ] def
+	7132 68 5360 1840 4459 2741 ] def
 /PSL_txt_y [ 2400 2400 2400 2400 2400 2400 2400 2400 2400 2400 
 	2400 2400 2400 2400 2400 2400 ] def
 /PSL_txt_n [ 16 ] def
@@ -3045,62 +3045,60 @@ PSL_path_pen 21 get cvx exec
 P S
 PSL_path_pen 22 get cvx exec
 82 0 M
-14 16 D
-12 9 D
-12 -5 D
-12 33 D
-12 10 D
-12 22 D
-12 -10 D
-12 5 D
-12 19 D
-12 -5 D
-12 16 D
-12 -12 D
-12 -6 D
-12 10 D
-12 -13 D
-12 1 D
-12 -14 D
-8 -28 D
-4 -20 D
-12 2 D
-12 -12 D
-6 -18 D
+20 12 D
+3 12 D
+20 12 D
+-5 12 D
+27 12 D
+33 20 D
+11 4 D
+7 12 D
+30 1 D
+4 -1 D
+14 -12 D
+18 -8 D
+44 -28 D
+-2 -12 D
+17 -12 D
+-4 -12 D
+16 -12 D
 S
 PSL_path_pen 23 get cvx exec
 1579 0 M
--37 48 D
--90 102 D
--104 114 D
--73 84 D
--67 84 D
--61 84 D
--55 86 D
--48 84 D
--24 47 D
--43 95 D
--24 60 D
--37 108 D
--28 106 D
--21 98 D
--17 108 D
--10 95 D
--6 85 D
+-8 12 D
+-60 72 D
+-191 211 D
+-72 86 D
+-40 51 D
+-32 43 D
+-48 70 D
+-49 79 D
+-34 60 D
+-49 100 D
+-43 104 D
+-33 96 D
+-30 108 D
+-18 84 D
+-20 119 D
+-10 85 D
+-8 108 D
 -3 120 D
 2 108 D
-7 112 D
+7 113 D
 12 121 D
-16 115 D
-25 144 D
-35 156 D
-35 132 D
-37 120 D
-23 72 D
-57 156 D
-64 156 D
-72 156 D
-73 144 D
+16 114 D
+3 24 D
+27 144 D
+19 84 D
+26 108 D
+41 142 D
+31 98 D
+5 13 D
+42 119 D
+47 120 D
+51 120 D
+64 136 D
+65 128 D
 73 132 D
 57 96 D
 84 132 D
@@ -3150,136 +3148,178 @@ PSL_path_pen 24 get cvx exec
 19 122 D
 13 120 D
 10 132 D
-3 132 D
--2 96 D
--5 84 D
--9 96 D
+3 120 D
+-1 84 D
+-5 96 D
+-10 108 D
 -12 84 D
--17 92 D
--20 88 D
--24 84 D
--33 96 D
--43 104 D
--36 75 D
--40 73 D
--36 60 D
--44 67 D
--56 77 D
--57 72 D
--55 65 D
--169 187 D
--12 12 D
--51 60 D
--28 36 D
+-15 84 D
+-22 96 D
+-32 108 D
+-25 72 D
+-34 84 D
+-40 84 D
+-41 77 D
+-40 67 D
+-39 60 D
+-61 84 D
+-52 66 D
+-46 54 D
+-62 70 D
+-143 158 D
+-49 59 D
+-19 25 D
 S
 PSL_path_pen 25 get cvx exec
 5857 0 M
 96 108 D
 111 132 D
-58 72 D
-70 90 D
-93 126 D
-75 107 D
-104 157 D
-88 143 D
-84 145 D
-72 134 D
-72 143 D
-48 102 D
-50 113 D
-59 144 D
-48 132 D
-29 84 D
-47 156 D
-50 204 D
-29 156 D
-17 108 D
-16 132 D
-13 132 D
-12 132 D
-2 33 D
+92 116 D
+72 94 D
+96 133 D
+93 137 D
+77 120 D
+94 156 D
+84 150 D
+78 150 D
+66 137 D
+41 91 D
+61 144 D
+54 143 D
+38 109 D
+34 111 D
+32 117 D
+23 96 D
+5 18 D
+3 18 D
+4 12 D
+5 21 D
+1 15 D
+19 96 D
+5 24 D
+2 24 D
+3 12 D
+3 24 D
+4 12 D
+0 12 D
+3 12 D
+5 48 D
+7 48 D
+0 12 D
+10 72 D
+5 48 D
+0 12 D
+9 96 D
+0 12 D
+4 36 D
+0 12 D
+3 24 D
+1 27 D
 S
 PSL_path_pen 26 get cvx exec
 6929 0 M
-26 36 D
-19 24 D
-34 50 D
-18 22 D
-8 12 D
-26 36 D
-20 31 D
-24 31 D
-39 58 D
-25 36 D
-32 45 D
+44 60 D
+11 15 D
+8 9 D
+7 12 D
+60 84 D
+9 12 D
+12 19 D
+60 87 D
+28 38 D
+15 24 D
+17 22 D
 S
 PSL_path_pen 27 get cvx exec
-7114 4800 M
--10 -13 D
--12 -4 D
--12 -19 D
--12 -31 D
--12 2 D
--12 -14 D
--12 -1 D
--12 -14 D
--12 0 D
--12 -1 D
--12 3 D
--12 -9 D
--12 2 D
--12 18 D
--7 -3 D
--5 -2 D
--12 16 D
--12 2 D
--24 25 D
--12 22 D
--9 21 D
+7105 4800 M
+-4 -12 D
+-6 -12 D
+-15 -12 D
+-15 -12 D
+-10 -12 D
+-2 -12 D
+-21 -10 D
+-12 -6 D
+-12 -5 D
+-12 -3 D
+-8 0 D
+-4 0 D
+-12 1 D
+-24 6 D
+-24 13 D
+-4 4 D
+-3 12 D
+-17 17 D
+-21 31 D
+1 12 D
 S
 PSL_path_pen 28 get cvx exec
 1343 4800 M
 -96 -108 D
 -111 -132 D
--80 -100 D
--96 -126 D
--104 -146 D
--89 -132 D
--98 -156 D
--81 -138 D
--63 -114 D
--57 -108 D
--72 -147 D
--48 -105 D
+-92 -116 D
+-72 -94 D
+-60 -83 D
+-72 -102 D
+-104 -157 D
+-88 -143 D
+-84 -145 D
+-72 -134 D
+-72 -143 D
+-67 -143 D
 -71 -168 D
--41 -108 D
--42 -120 D
--41 -132 D
--29 -108 D
--32 -132 D
--32 -168 D
--17 -108 D
--16 -132 D
--11 -108 D
--16 -193 D
+-54 -143 D
+-24 -69 D
+-33 -100 D
+-27 -91 D
+-20 -77 D
+-5 -12 D
+-1 -12 D
+-4 -12 D
+-21 -96 D
+-4 -12 D
+-11 -60 D
+-7 -24 D
+0 -12 D
+-12 -60 D
+-12 -84 D
+-3 -12 D
+-8 -66 D
+-1 -18 D
+-3 -12 D
+-8 -66 D
+-4 -54 D
+-3 -12 D
+-1 -24 D
+-4 -29 D
+-2 -7 D
+1 -24 D
+-2 -12 D
+0 -12 D
+-5 -48 D
+-1 -24 D
+-2 -12 D
+-1 -22 D
 S
 PSL_path_pen 29 get cvx exec
-270 4800 M
--9 -12 D
--10 -12 D
--23 -36 D
--28 -36 D
--25 -36 D
+269 4800 M
 -7 -12 D
+-10 -13 D
+-24 -35 D
 -12 -15 D
 -25 -33 D
--15 -24 D
--9 -12 D
--11 -18 D
--31 -42 D
--17 -24 D
--24 -37 D
--24 -33 D
+-11 -19 D
+-24 -32 D
+-5 -9 D
+-31 -43 D
+-12 -18 D
+-18 -23 D
+-7 -12 D
+-35 -51 D
+-8 -9 D
+-6 -12 D
+-11 -12 D
+-23 -35 D
 S
 PSL_path_pen 30 get cvx exec
 4068 4404 M
@@ -3365,8 +3405,8 @@ PSL_path_pen 30 get cvx exec
 -11 -5 D
 -13 -6 D
 -12 -6 D
--12 -6 D
 -12 -5 D
+-12 -6 D
 -12 -5 D
 -12 -6 D
 -12 -5 D
@@ -3427,7 +3467,8 @@ PSL_path_pen 30 get cvx exec
 -12 -1 D
 -12 0 D
 -12 0 D
--12 0 D
+-1 0 D
+-11 0 D
 -10 0 D
 -2 0 D
 -12 0 D
@@ -3878,10 +3919,10 @@ N 6960 0 M 0 42 D S
 /PSL_H_y PSL_L_y PSL_LH add 233 add def
 3600 4800 PSL_H_y add PSL_slant_y add M
 400 F0
-V MU 0 0 M (Elastic Plate Flexure, T) FP 0 -100 G 280 F0 (e) FP 0 100 G 400 F0 ( = 5 km, N = \(­4/2/­10\)e12 Pa) FP pathbbox N pop exch pop add U -2 div 0 G
+V MU 0 0 M (Elastic Plate Flexure, T) FP 0 -100 G 280 F0 (e) FP 0 100 G 400 F0 ( = 5 km, N = \(-4/2/-10\)e12 Pa) FP pathbbox N pop exch pop add U -2 div 0 G
 (Elastic Plate Flexure, T) Z
 0 -100 G 280 F0 (e) Z
-0 100 G 400 F0 ( = 5 km, N = \(­4/2/­10\)e12 Pa) Z
+0 100 G 400 F0 ( = 5 km, N = \(-4/2/-10\)e12 Pa) Z
 %%EndObject
 
 grestore

--- a/test/potential/flexure_en.sh
+++ b/test/potential/flexure_en.sh
@@ -5,7 +5,7 @@
 ps=flexure_en.ps
 m=g
 f=0.2
-gmt set MAP_FRAME_TYPE plain
+gmt set MAP_FRAME_TYPE plain GMT_FFT kiss
 cat << EOF > t.txt
 #lon lat azimuth, semi-major, semi-minor, height
 300	200	0	50	50	5000

--- a/test/potential/flexure_gl.sh
+++ b/test/potential/flexure_gl.sh
@@ -5,7 +5,7 @@
 ps=flexure_gl.ps
 m=g
 f=0.2
-gmt set MAP_FRAME_TYPE plain
+gmt set MAP_FRAME_TYPE plain GMT_FFT kiss
 cat << EOF > t.txt
 #lon lat azimuth, semi-major, semi-minor, height
 300	200	0	50	50	5000

--- a/test/potential/flexure_ve.sh
+++ b/test/potential/flexure_ve.sh
@@ -5,7 +5,7 @@
 ps=flexure_ve.ps
 m=g
 f=0.2
-gmt set MAP_FRAME_TYPE plain
+gmt set MAP_FRAME_TYPE plain GMT_FFT kiss
 cat << EOF > t.txt
 #lon lat azimuth, semi-major, semi-minor, height
 300	200	0	50	50	5000

--- a/test/potential/grdgravmag3D_grav_sph.sh
+++ b/test/potential/grdgravmag3D_grav_sph.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Computes the gravity anomaly over a sphere with radius r = 15 m and center at -15 m.
-# The sphere is aproximated by two hemi-spheres
+# The sphere is approximated by two hemispheres
 # Compare with analytical expressions
 
 ps=grdgravmag3D_grav_sph.ps

--- a/test/potential/grdokb_grav.sh
+++ b/test/potential/grdokb_grav.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Compute the gravity anomaly of the whater layer above the Gorringe bank
+# Compute the gravity anomaly of the water layer above the Gorringe bank
 
 ps=grdokb_grav.ps
 

--- a/test/potential/spheres.sh
+++ b/test/potential/spheres.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Computes the gravity anomaly of a sphere both analytical and descrete triangles
+# Computes the gravity anomaly of a sphere both analytical and discrete triangles
 
 ps=spheres.ps
 


### PR DESCRIPTION
**Description of proposed changes**

All tests using modules needing FFTs should set GMT_FFT kiss so that all test CIs and OS return the same results.