### PR TITLE
Add gmt_remote.h to the developer headers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -659,7 +659,7 @@ if (BUILD_DEVELOPER)
 		gmt_dcw.h gmt_decorate.h gmt_defaults.h gmt_error.h gmt_error_codes.h gmt_fft.h gmt_gdalread.h gmt_grd.h
 		gmt_grdio.h gmt_hash.h gmt_io.h gmt_macros.h gmt_memory.h gmt_modern.h gmt_nan.h gmt_notposix.h gmt_plot.h
 		gmt_private.h gmt_project.h gmt_prototypes.h gmt_psl.h gmt_shore.h gmt_symbol.h gmt_synopsis.h
-		gmt_texture.h gmt_time.h gmt_types.h gmt_dev.h gmt_customio.h gmt_hidden.h gmt_mb.h
+		gmt_texture.h gmt_time.h gmt_types.h gmt_dev.h gmt_customio.h gmt_hidden.h gmt_mb.h gmt_remote.h
 		DESTINATION ${GMT_INCLUDEDIR}
 		COMPONENT Runtime)
 	install (FILES compat/qsort.h

--- a/src/gmt_dev.h
+++ b/src/gmt_dev.h
@@ -161,7 +161,7 @@ struct GMT_CTRL; /* forward declaration of GMT_CTRL */
 #include "gmt_plot.h"           /* extern functions defined in gmt_plot.c */
 #include "gmt_memory.h"         /* extern functions defined in gmt_M_memory.c */
 #include "gmt_types.h"          /* GMT type declarations */
-#include "gmt_remote.h"          /* GMT type declarations */
+#include "gmt_remote.h"         /* GMT remote dataset structure */
 
 #ifdef _OPENMP                  /* Using open MP parallelization */
 #include <omp.h>


### PR DESCRIPTION
We forgot to add gmt_remote.h to the developer include files in the CmakeLists.txt file in src. Closes #3449.
