### PR TITLE
Fix inconsistencies in new -F option

### DIFF
--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt grdtrack** [ *xyfile* ] |-G|\ *grd1* |-G|\ *grd2* ...
+**gmt grdtrack** [ *trackfile* ] |-G|\ *grd1* |-G|\ *grd2* ...
 [ |-A|\ **f**\|\ **p**\|\ **m**\|\ **r**\|\ **R**\ [**+l**] ]
 [ |-C|\ *length*/\ *ds*\ [*/spacing*][**+a**\|\ **+v**][**l**\|\ **r**] ]
 [ |-D|\ *dfile* ]
@@ -82,7 +82,7 @@ Required Arguments
 Optional Arguments
 ------------------
 
-*xyfile*
+*trackfile*
     This is an ASCII (or binary, see **-bi**)
     file where the first 2 columns hold the (x,y) positions where the
     user wants to sample the 2-D data set.
@@ -169,20 +169,22 @@ Optional Arguments
 .. _-F:
 
 **-F**\ [**+b**][**+n**][**+z**\ *z0*]
-    Find critical points along each cross-profile.
-    Requires **-C** and a single input grid. We examine each cross-profile generated
-    and report (*lonc*, *latc*, *distc*, *azimuthc*, *zc*) at the center peak of
+    Find critical points along each cross-profile as a function of along-track distance.
+    Requires **-C** and a single input grid (*z*). We examine each cross-profile generated
+    and report (*dist*, *lonc*, *latc*, *distc*, *azimuthc*, *zc*) at the center peak of
     maximum *z* value, (*lonl*, *latl*, *distl*) and (*lonr*, *latr*, *distr*)
     at the first and last non-NaN point whose *z*-value exceeds *z0*, respectively,
-    and the *width* based on the two extreme points found. When searching for
-    the center peak and the extreme first and last values that exceed the threshold
-    we assume the profile is positive up.  If we instead are looking
-    for a trough then you must use **+n** to temporarily flip the profile to positive.
-    The threshold *z0* value is always given as >= 0; use **+z** to change it [0].
-    Alternatively, use **+b** to determine the balance point and standard deviation of the profile.
-    Note that we round the exact results to the nearest distance nodes.
-    We write 12 output columns per track with an identified center peak, with values
-    *lonc, latc, distc, azimuthc, zc, lonl, latl, distl, lonr, latr, distr, width*.
+    and the *width* based on the two extreme points found. Here, *dist* is the distance
+    along the original input *trackfile* and the other 12 output columns are a function
+    of that distance.  When searching for the center peak and the extreme first and last
+    values that exceed the threshold we assume the profile is positive up.  If we instead
+    are looking for a trough then you must use **+n** to temporarily flip the profile to
+    positive. The threshold *z0* value is always given as >= 0; use **+z** to change it [0].
+    Alternatively, use **+b** to determine the balance point and standard deviation of the
+    profile; this is the weighted mean and weighted standard deviation of the distances,
+    with *z* acting as the weight. **Note**: We round the exact results to the nearest
+    distance nodes along the cross-profiles.  We write 13 output columns per track:
+    *dist, lonc, latc, distc, azimuthc, zc, lonl, latl, distl, lonr, latr, distr, width*.
 
 .. _-N:
 

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -860,15 +860,8 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 			if (Ctrl->S.selected[STACK_ADD_RES]) n_cols += Ctrl->G.n_grids;	/* Make space for the stacked residuals(s) in each profile */
 		}
 		if ((Dout = gmt_crosstracks (GMT, Dtmp, Ctrl->C.length, Ctrl->C.ds, n_cols, Ctrl->C.mode)) == NULL) Return (API->error);
-#if 0
-		if (Ctrl->D.active) {
-			if (GMT_Destroy_Data (API, &Dtmp) != GMT_NOERROR) {
-				Return (API->error);
-			}
-		}
-		else	/* Never written */
-#endif
-		if (Ctrl->F.active) {	/* Keep a record of the along-track distances for -C */
+
+		if (Ctrl->F.active) {	/* Keep a record of the along-track distances produced in -C */
 			dist = gmt_M_memory (GMT, NULL, Dtmp->n_records, double);
 			for (tbl = prof = 0; tbl < Dtmp->n_tables; tbl++) {
 				T = Dtmp->table[tbl];
@@ -880,6 +873,7 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 				}
 			}
 		}
+
 		gmt_free_dataset (GMT, &Dtmp);
 
 		/* Sample the grids along all profiles in Dout */


### PR DESCRIPTION
The **-F** option scans all cross-profiles made via **-C** and report on some aspects of each profile as a function of the along-track (not cross) distance.  Thus, the first output column needs to be the along-track _distance_.  Furthermore, the initial implementation skipped output records if no values could be determined. Now we follow standard GMT practice of issuing NaN values if they cannot be determined.
