### PR TITLE
Must update dimensions of produced datasets

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14916,6 +14916,7 @@ struct GMT_DATASET * gmt_resample_data (struct GMT_CTRL *GMT, struct GMT_DATASET
 		D = gmtsupport_resample_data_spherical (GMT, Din, along_ds, mode, ex_cols, smode);
 	else
 		D = gmtsupport_resample_data_cartesian (GMT, Din, along_ds, mode, ex_cols, smode);
+	gmt_set_dataset_minmax (GMT, D);	/* Determine min/max for each column */
 	return (D);
 }
 
@@ -14927,6 +14928,7 @@ struct GMT_DATASET * gmt_crosstracks (struct GMT_CTRL *GMT, struct GMT_DATASET *
 		D = gmtsupport_crosstracks_spherical (GMT, Din, cross_length, across_ds, n_cols, mode);
 	else
 		D = gmtsupport_crosstracks_cartesian (GMT, Din, cross_length, across_ds, n_cols, mode);
+	gmt_set_dataset_minmax (GMT, D);	/* Determine min/max for each column */
 	return (D);
 }
 

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -868,7 +868,7 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 				for (seg = 0; seg < T->n_segments; seg++) {
 					S = T->segment[seg];
 					for (row = 0; row < S->n_rows; row++, prof++) {
-						dist[prof] = S->data[2][row];
+						dist[prof] = S->data[GMT_Z][row];
 					}
 				}
 			}
@@ -1078,7 +1078,7 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 							out[9] = out[10] = out[11] = GMT->session.d_NaN;
 						else {
 							out[9]  = T->segment[seg]->data[GMT_X][kr];	/* Right longitude */
-							out[10]  = T->segment[seg]->data[GMT_Y][kr];	/* Right latitude */
+							out[10] = T->segment[seg]->data[GMT_Y][kr];	/* Right latitude */
 							out[11] = T->segment[seg]->data[GMT_Z][kr];	/* Right distance */
 						}
 						out[12] = out[11] - out[8];	/* Width = distance between left and right point */


### PR DESCRIPTION
Both the _gmt_resample_data_ and _gmt_crosstracks_ functions failed to update the datasets they created, leaving the wrong info in the headers (e.g., input, not output record counts).  This caused **grdtrack** to fail for a new feature in **-F** that actually used those counters to allocate an array (which then was too short and boom).
