### PR TITLE
Use list of keywords instead of bit-sum for MAP_ANNOT_OBLIQUE

### DIFF
--- a/doc/examples/ex02/ex02.bat
+++ b/doc/examples/ex02/ex02.bat
@@ -4,7 +4,7 @@ REM Purpose:	Make two color images based gridded data
 REM GMT modules:	set, grd2cpt, grdimage, makecpt, colorbar, subplot
 REM
 gmt begin ex02
-	gmt set MAP_ANNOT_OBLIQUE 0
+	gmt set MAP_ANNOT_OBLIQUE separate
 	gmt subplot begin 2x1 -A+JTL -Fs16c/9c -M0 -R160/20/220/30+r -JOc190/25.5/292/69/16c -B10 -T"H@#awaiian@# T@#opo and @#G@#eoid@#"
 		gmt subplot set 0,0 -Ce3c
 		gmt grd2cpt @HI_topo_02.nc -Crelief -Z

--- a/doc/examples/ex02/ex02.sh
+++ b/doc/examples/ex02/ex02.sh
@@ -5,7 +5,7 @@
 # GMT modules:	set, grd2cpt, grdimage, makecpt, colorbar, subplot
 #
 gmt begin ex02
-	gmt set MAP_ANNOT_OBLIQUE 0
+	gmt set MAP_ANNOT_OBLIQUE separate
 	gmt subplot begin 2x1 -A+JTL -Fs16c/9c -M0 -R160/20/220/30+r -JOc190/25.5/292/69/16c -B10 -T"H@#awaiian@# T@#opo and @#G@#eoid@#"
 		gmt subplot set 0,0 -Ce3c
 		gmt grd2cpt @HI_topo_02.nc -Crelief -Z

--- a/doc/examples/ex31/ex31.bat
+++ b/doc/examples/ex31/ex31.bat
@@ -20,7 +20,7 @@ gmt begin ex31
 	REM common settings
 	gmt set FORMAT_GEO_MAP ddd:mm:ssF MAP_DEGREE_SYMBOL colon MAP_TITLE_OFFSET 20p ^
 		MAP_GRID_CROSS_SIZE_PRIMARY 0.4c PS_LINE_JOIN round PS_CHAR_ENCODING ISO-8859-5 ^
-		FONT LinBiolinumO FONT_TITLE 24p,LinLibertineOB MAP_ANNOT_OBLIQUE 42
+		FONT LinBiolinumO FONT_TITLE 24p,LinLibertineOB MAP_ANNOT_OBLIQUE lon_horizontal,lat_parallel,tick_extend
 
 	REM map of countries
 	gmt coast -R-7/31/64/66+r -JL15/50/40/60/16c -Bx10g10 -By5g5 -B+t"Europe\072 Countries and Capital Cities" -A250 -Slightblue -Glightgreen -W0.25p -N1/1p,white

--- a/doc/examples/ex31/ex31.sh
+++ b/doc/examples/ex31/ex31.sh
@@ -27,7 +27,7 @@ gmt begin ex31
 	# common settings
 	gmt set FORMAT_GEO_MAP ddd:mm:ssF MAP_DEGREE_SYMBOL colon MAP_TITLE_OFFSET 20p \
 		MAP_GRID_CROSS_SIZE_PRIMARY 0.4c PS_LINE_JOIN round PS_CHAR_ENCODING ISO-8859-5 \
-		FONT LinBiolinumO FONT_TITLE 24p,LinLibertineOB MAP_ANNOT_OBLIQUE 42
+		FONT LinBiolinumO FONT_TITLE 24p,LinLibertineOB MAP_ANNOT_OBLIQUE lon_horizontal,lat_parallel,tick_extend
 
 	# map of countries
 	gmt coast -R-7/31/64/66+r -JL15/50/40/60/16c -Bx10g10 -By5g5 -B+t"Europe\072 Countries and Capital Cities" -A250 \

--- a/doc/rst/source/datasets/gshhg.rst
+++ b/doc/rst/source/datasets/gshhg.rst
@@ -200,7 +200,7 @@ total file size of the coastlines, rivers, and borders database is only
    Map using the crude resolution coastline data.
 
 
-Here, we use the :term:`MAP_ANNOT_OBLIQUE` bit flags to achieve horizontal
+Here, we use the :term:`MAP_ANNOT_OBLIQUE` words to achieve horizontal
 annotations and set :term:`MAP_ANNOT_MIN_SPACING` to suppress some
 longitudinal annotations near the S pole that otherwise would overprint.
 The square box indicates the outline of the next map.

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -572,20 +572,18 @@ MAP Parameters
         occur for certain oblique projections.) [0p]
 
     **MAP_ANNOT_OBLIQUE**
-        This integer is a sum of 6 bit flags (most of which only are
-        relevant for oblique projections): If bit 1 is set (1),
-        annotations will occur wherever a gridline crosses the map
-        boundaries, else longitudes will be annotated on the lower and upper
-        boundaries only, and latitudes will be annotated on the left and
-        right boundaries only. If bit 2 is set (2), then
-        longitude annotations will be plotted horizontally. If bit 3 is set
-        (4), then latitude annotations will be plotted
-        horizontally. If bit 4 is set (8), then oblique
-        tick-marks are extended to give a projection equal to the specified
-        tick length. If bit 5 is set (16), tick-marks will be drawn normal
-        to the border regardless of gridline angle. If bit 6 is set (32),
-        then latitude annotations will be plotted parallel to the border. To
-        set a combination of these, add up the values in parentheses. [1].
+        This argument is a comma-separated list of up to seven keywords:
+        **separate** means longitudes will be annotated on the lower and upper
+        boundaries only, and latitudes will be annotated on the left and right
+        boundaries only.
+        **anywhere** means annotations will occur wherever an imaginary gridline
+        crosses the map boundaries. **lon_horizontal** means longitude annotations
+        will be plotted horizontally. **lat_horizontal** means latitude annotations
+        will be plotted horizontally. **tick_extend** means tick-marks are extended
+        so the distance from the tip of the oblique tick to the map frame equals
+        the specified tick length. **tick_normal** means tick-marks will be drawn
+        normal to the border regardless of gridline angle. **lat_parallel** means
+        latitude annotations will be plotted parallel to the border. [anywhere].
 
     **MAP_ANNOT_OFFSET**
         Sets both :term:`MAP_ANNOT_OFFSET_PRIMARY` and :term:`MAP_ANNOT_OFFSET_SECONDARY` to the value specified.

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -575,14 +575,14 @@ MAP Parameters
         This argument is a comma-separated list of up to seven keywords:
         **separate** means longitudes will be annotated on the lower and upper
         boundaries only, and latitudes will be annotated on the left and right
-        boundaries only.
+        boundaries only;
         **anywhere** means annotations will occur wherever an imaginary gridline
-        crosses the map boundaries. **lon_horizontal** means longitude annotations
-        will be plotted horizontally. **lat_horizontal** means latitude annotations
-        will be plotted horizontally. **tick_extend** means tick-marks are extended
+        crosses the map boundaries; **lon_horizontal** means longitude annotations
+        will be plotted horizontally; **lat_horizontal** means latitude annotations
+        will be plotted horizontally; **tick_extend** means tick-marks are extended
         so the distance from the tip of the oblique tick to the map frame equals
-        the specified tick length. **tick_normal** means tick-marks will be drawn
-        normal to the border regardless of gridline angle. **lat_parallel** means
+        the specified tick length; **tick_normal** means tick-marks will be drawn
+        normal to the border regardless of gridline angle; **lat_parallel** means
         latitude annotations will be plotted parallel to the border. [anywhere].
 
     **MAP_ANNOT_OFFSET**

--- a/doc/scripts/GMT_App_K_1.sh
+++ b/doc/scripts/GMT_App_K_1.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 gmt begin GMT_App_K_1
-	gmt set MAP_GRID_CROSS_SIZE_PRIMARY 0 MAP_ANNOT_OBLIQUE 22 MAP_ANNOT_MIN_SPACING 0.3i
+	gmt set MAP_GRID_CROSS_SIZE_PRIMARY 0  MAP_ANNOT_MIN_SPACING 0.3i \
+	  MAP_ANNOT_OBLIQUE lon_horizontal,lat_horizontal,tick_normal
 	gmt coast -R-9000/9000/-9000/9000+uk -JE130.35/-0.2/3.5i -Dc \
 		-A500 -Gburlywood -Sazure -Wthinnest -N1/thinnest,- -B20g20 -BWSne
 	echo 130.35 -0.2 | gmt plot -SJ-4000 -Wthicker

--- a/doc/scripts/GMT_Defaults_1b.sh
+++ b/doc/scripts/GMT_Defaults_1b.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 gmt begin GMT_Defaults_1b
 	gmt set MAP_FRAME_TYPE plain FORMAT_GEO_MAP ddd:mm:ssF MAP_GRID_CROSS_SIZE_PRIMARY 0i \
-		FONT_ANNOT_PRIMARY +8p MAP_ANNOT_OBLIQUE 1
+		FONT_ANNOT_PRIMARY +8p MAP_ANNOT_OBLIQUE anywhere
 	gmt basemap -X1.5i -R-90/20/-55/25r -JOc-80/25.5/2/69/2.25i -Ba10f5g5
 	gmt text -R0/2.25/0/2 -Jx1i -N -F+f7p,Helvetica-Bold,blue+j << EOF
 -0.15 0.15  RB MAP_ORIGIN_X

--- a/doc/scripts/GMT_dir_rose.sh
+++ b/doc/scripts/GMT_dir_rose.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Showing map directional roses
 gmt begin GMT_dir_rose
-	gmt set FONT_LABEL 10p FONT_TITLE 12p MAP_ANNOT_OBLIQUE 34 MAP_TITLE_OFFSET 5p \
+	gmt set FONT_LABEL 10p FONT_TITLE 12p MAP_ANNOT_OBLIQUE lon_horizontal,lat_parallel MAP_TITLE_OFFSET 5p \
 		MAP_FRAME_WIDTH 3p FORMAT_GEO_MAP dddF FONT_ANNOT_PRIMARY 10p
 # left: Fancy kind = 1
 	gmt basemap -R-5/5/-5/5 -Jm0.15i -Ba5f -BWSne+gazure1 -Tdg0/0+w1i+jCM -X1i

--- a/doc/scripts/GMT_mag_rose.sh
+++ b/doc/scripts/GMT_mag_rose.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 gmt begin GMT_mag_rose
 # Magnetic rose with a specified declination
-	gmt basemap -R-10/-2/12.8812380332/0.661018975345+r -JOc0/0/50/60/7i -B -BWSne -X1.25i --MAP_ANNOT_OBLIQUE=34 --FONT_ANNOT_PRIMARY=12p
+	gmt basemap -R-10/-2/12.8812380332/0.661018975345+r -JOc0/0/50/60/7i -B -BWSne -X1.25i --MAP_ANNOT_OBLIQUE=lon_horizontal,lat_parallel --FONT_ANNOT_PRIMARY=12p
 	gmt basemap -Tmg-2/0.5+w2.5i+d-14.5+t45/10/5+i0.25p,blue+p0.25p,red+l+jCM \
 		--FONT_ANNOT_PRIMARY=9p,Helvetica,blue --FONT_ANNOT_SECONDARY=12p,Helvetica,red --FONT_LABEL=14p,Times-Italic,darkgreen --FONT_TITLE=24p \
 		--MAP_TITLE_OFFSET=7p --MAP_FRAME_WIDTH=10p --COLOR_BACKGROUND=green --MAP_DEFAULT_PEN=2p,darkgreen --COLOR_BACKGROUND=darkgreen \

--- a/doc/scripts/GMT_obl_baja.sh
+++ b/doc/scripts/GMT_obl_baja.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Oblique Mercator map for Baja California with oblique Equator along y-axis
 gmt begin GMT_obl_baja
-	gmt set MAP_ANNOT_OBLIQUE 14
+	gmt set MAP_ANNOT_OBLIQUE lon_horizontal,lat_horizontal,tick_extend
 	gmt coast -R122W/35N/107W/22N+r -JOa120W/25N/-30/6c+v -Gsienna -Ba5g5 -B+f -N1/1p -EUS+gburlywood -Smintcream -TdjBL+w0.5i+l
 gmt end show

--- a/doc/scripts/GMT_obl_nz.sh
+++ b/doc/scripts/GMT_obl_nz.sh
@@ -12,7 +12,7 @@ plat=40S
 w2=$(gmt math -Q $w 2 DIV =)
 h2=$(gmt math -Q $h 2 DIV =)
 R=-R-${w2}/$w2/-${h2}/${h2}+uk
-gmt coast $R -JOA$lon/$lat/$az/3i -Ba5f5g5 -Gred -Dh -TdjBR+w0.5i+l+o0.2i/-0.05i --FONT_TITLE=9p --MAP_ANNOT_OBLIQUE=34 --FORMAT_GEO_MAP=dddF
+gmt coast $R -JOA$lon/$lat/$az/3i -Ba5f5g5 -Gred -Dh -TdjBR+w0.5i+l+o0.2i/-0.05i --FONT_TITLE=9p --MAP_ANNOT_OBLIQUE=anywhere,lat_parallel --FORMAT_GEO_MAP=dddF
 echo $plon $plat | gmt plot -Sc0.2c -Gblue -W0.25p
 gmt plot -R0/3/0/1.5 -Jx1i -W0.25p,- << EOF
 >
@@ -33,7 +33,7 @@ gmt text -F+f12p,Times-Italic+j -Dj0.1i -Gwhite << EOF
 EOF
 #echo $plon $plat | gmt mapproject -JoA$lon/$lat/$az/1:1 -Fk -C
 az=215
-gmt coast $R -JOA$lon/$lat/$az/3i -Ba5f5g5 -Gred -Dh -X3.4i -TdjTL+w0.5i+l+o0.2i/-0.05i --FONT_TITLE=9p --MAP_ANNOT_OBLIQUE=34 --FORMAT_GEO_MAP=dddF
+gmt coast $R -JOA$lon/$lat/$az/3i -Ba5f5g5 -Gred -Dh -X3.4i -TdjTL+w0.5i+l+o0.2i/-0.05i --FONT_TITLE=9p --MAP_ANNOT_OBLIQUE=anywhere,lat_parallel --FORMAT_GEO_MAP=dddF
 echo $plon $plat | gmt plot -Sc0.2c -Gblue -W0.25p
 gmt plot -R0/3/0/1.5 -Jx1i -W0.25p,- << EOF
 >

--- a/doc/scripts/GMT_obl_nz.sh
+++ b/doc/scripts/GMT_obl_nz.sh
@@ -12,7 +12,7 @@ plat=40S
 w2=$(gmt math -Q $w 2 DIV =)
 h2=$(gmt math -Q $h 2 DIV =)
 R=-R-${w2}/$w2/-${h2}/${h2}+uk
-gmt coast $R -JOA$lon/$lat/$az/3i -Ba5f5g5 -Gred -Dh -TdjBR+w0.5i+l+o0.2i/-0.05i --FONT_TITLE=9p --MAP_ANNOT_OBLIQUE=anywhere,lat_parallel --FORMAT_GEO_MAP=dddF
+gmt coast $R -JOA$lon/$lat/$az/3i -Ba5f5g5 -Gred -Dh -TdjBR+w0.5i+l+o0.2i/-0.05i --FONT_TITLE=9p --MAP_ANNOT_OBLIQUE=separate,lon_horizontal,lat_parallel --FORMAT_GEO_MAP=dddF
 echo $plon $plat | gmt plot -Sc0.2c -Gblue -W0.25p
 gmt plot -R0/3/0/1.5 -Jx1i -W0.25p,- << EOF
 >
@@ -33,7 +33,7 @@ gmt text -F+f12p,Times-Italic+j -Dj0.1i -Gwhite << EOF
 EOF
 #echo $plon $plat | gmt mapproject -JoA$lon/$lat/$az/1:1 -Fk -C
 az=215
-gmt coast $R -JOA$lon/$lat/$az/3i -Ba5f5g5 -Gred -Dh -X3.4i -TdjTL+w0.5i+l+o0.2i/-0.05i --FONT_TITLE=9p --MAP_ANNOT_OBLIQUE=anywhere,lat_parallel --FORMAT_GEO_MAP=dddF
+gmt coast $R -JOA$lon/$lat/$az/3i -Ba5f5g5 -Gred -Dh -X3.4i -TdjTL+w0.5i+l+o0.2i/-0.05i --FONT_TITLE=9p --MAP_ANNOT_OBLIQUE=separate,lon_horizontal,lat_parallel --FORMAT_GEO_MAP=dddF
 echo $plon $plat | gmt plot -Sc0.2c -Gblue -W0.25p
 gmt plot -R0/3/0/1.5 -Jx1i -W0.25p,- << EOF
 >

--- a/doc/scripts/GMT_stereographic_general.sh
+++ b/doc/scripts/GMT_stereographic_general.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 gmt begin GMT_stereographic_general
-	gmt set MAP_ANNOT_OBLIQUE 0
+	gmt set MAP_ANNOT_OBLIQUE separate
 	gmt coast -R100/-42/160/-8+r -JS130/-30/12c -Bag -Dl -A500 -Ggreen -Slightblue -Wthinnest
 gmt end show

--- a/doc/scripts/GMT_stereographic_rect.sh
+++ b/doc/scripts/GMT_stereographic_rect.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 gmt begin GMT_stereographic_rect
-	gmt set MAP_ANNOT_OBLIQUE 30
+	gmt set MAP_ANNOT_OBLIQUE lon_horizontal,lat_horizontal,tick_extend,tick_normal
 	gmt coast -R-25/59/70/72+r -JS10/90/11c -B20g -Dl -A250 -Gdarkbrown -Wthinnest -Slightgray
 gmt end show

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9289,17 +9289,16 @@ GMT_LOCAL unsigned int gmtinit_parse_map_annot_oblique (struct GMT_CTRL *GMT, ch
 		if (found != UINT_MAX)
 			bits += (found == 0) ? 0 : urint (pow (2.0, found-1));
 		else
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "MAP_ANNOT_OBLIQUE: Unrecognized flag name %s - ignored\n", token);
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtinit_parse_map_annot_oblique: Unrecognized flag name %s - ignored\n", token);
 	}
 	gmt_M_str_free (tofree);
-	GMT_Report (GMT->parent, GMT_MSG_NOTICE, "Converted %s to %d\n", text, bits);
+	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "gmtinit_parse_map_annot_oblique: Converted %s to %d\n", text, bits);
 
 	return (bits);
 }
 
 GMT_LOCAL char * gmtinit_print_map_annot_oblique (struct GMT_CTRL *GMT, unsigned int val) {
-	/* Create text-equivalent using keywords for MAP_ANNOT_OBLIQUE
-	 */
+	/* Create text-equivalent using keywords for MAP_ANNOT_OBLIQUE */
 	char string[GMT_LEN128] = {""};
 	unsigned int bit, k, first = 1;
 
@@ -9311,6 +9310,7 @@ GMT_LOCAL char * gmtinit_print_map_annot_oblique (struct GMT_CTRL *GMT, unsigned
 			first = 0;
 		}
 	}
+	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "gmtinit_print_map_annot_oblique: Converted %d to %sn", val, string);
 	return (strdup (string));
 }
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9281,16 +9281,18 @@ GMT_LOCAL unsigned int gmtinit_parse_map_annot_oblique (struct GMT_CTRL *GMT, ch
 	unsigned int bits = 0, k, found;
 
 	if (isdigit (text[0])) return (atoi (text));	/* That was easy */
+
 	tofree = string = strdup (text);
 	while ((token = strsep (&string, ",")) != NULL) {
-		for (k = found = 0; !found && k < N_MAP_ANNOT_OBLIQUE_ITEMS; k++)
-			found = !strcmp (token, map_annot_oblique_item[k]);
-		if (found)
-			bits += (k == 0) ? 0 : urint (pow (2.0, k-1));
+		for (k = 0, found = UINT_MAX; found == UINT_MAX && k < N_MAP_ANNOT_OBLIQUE_ITEMS; k++)
+			if (!strcmp (token, map_annot_oblique_item[k])) found = k;
+		if (found != UINT_MAX)
+			bits += (found == 0) ? 0 : urint (pow (2.0, found-1));
 		else
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "MAP_ANNOT_OBLIQUE: Unrecognized flag name %s - ignored\n", token);
 	}
 	gmt_M_str_free (tofree);
+	GMT_Report (GMT->parent, GMT_MSG_NOTICE, "Converted %s to %d\n", text, bits);
 
 	return (bits);
 }

--- a/test/mapproject/oblmerc_down.sh
+++ b/test/mapproject/oblmerc_down.sh
@@ -3,7 +3,7 @@
 # Tests mapproject for oblique Mercator -R-20/40/-15/65r -Joa-30/60/-75/1:30000000
 # This should be upside down
 
-gmt set MAP_ANNOT_OBLIQUE 0 FORMAT_GEO_MAP dddF
+gmt set MAP_ANNOT_OBLIQUE separate FORMAT_GEO_MAP dddF
 ps=oblmerc_down.ps
 lon=-30
 lat=60

--- a/test/mapproject/oblmerc_up.sh
+++ b/test/mapproject/oblmerc_up.sh
@@ -2,7 +2,7 @@
 #
 # Tests mapproject for oblique Mercator -R-20/40/-15/65r -Joa-30/60/105/1:30000000
 
-gmt set MAP_ANNOT_OBLIQUE 0 FORMAT_GEO_MAP dddF
+gmt set MAP_ANNOT_OBLIQUE separate FORMAT_GEO_MAP dddF
 ps=oblmerc_up.ps
 lon=-30
 lat=60

--- a/test/psbasemap/oblique.sh
+++ b/test/psbasemap/oblique.sh
@@ -7,6 +7,6 @@
 
 ps=oblique.ps
 
-gmt set MAP_ANNOT_OBLIQUE 14 MAP_ANNOT_MIN_SPACING 0.5i
+gmt set MAP_ANNOT_OBLIQUE lon_horizontal,lat_horizontal,tick_extend MAP_ANNOT_MIN_SPACING 0.5i
 gmt psbasemap -R-100/100/-60/60 -JOa1/0/45/5.5i -B30g30 -P -K -Xc > $ps
 gmt psbasemap -R -JOa0/0.1/45/5.5i -B30g30 -O -Y5i >> $ps

--- a/test/psbasemap/rose_dir.sh
+++ b/test/psbasemap/rose_dir.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Testing map directional roses
 ps=rose_dir.ps
-gmt set FONT_LABEL 10p FONT_TITLE 14p MAP_ANNOT_OBLIQUE 34 MAP_TITLE_OFFSET 7p MAP_FRAME_WIDTH 3p
+gmt set FONT_LABEL 10p FONT_TITLE 14p MAP_ANNOT_OBLIQUE lon_horizontal,lat_parallel MAP_TITLE_OFFSET 7p MAP_FRAME_WIDTH 3p
 # 4th row left: Fancy kind = 1
 gmt psbasemap -R-7/7/-5/5 -JM2.75i -Baf -BWSne+gazure1 -Tdg0/0+w1i+f1+l+jCM -P -K -X1.25i > $ps
 # 4th row right: Fancy kind = 2

--- a/test/psbasemap/rose_mag2.sh
+++ b/test/psbasemap/rose_mag2.sh
@@ -2,7 +2,7 @@
 # Testing map directional roses for magnetics
 ps=rose_mag2.ps
 gmt set FONT_ANNOT_PRIMARY 9p FONT_ANNOT_SECONDARY 12p FONT_LABEL 14p FONT_TITLE 24p \
-	MAP_TITLE_OFFSET 7p MAP_ANNOT_OBLIQUE 34 MAP_FRAME_WIDTH 3p \
+	MAP_TITLE_OFFSET 7p MAP_ANNOT_OBLIQUE lon_horizontal,lat_parallel MAP_FRAME_WIDTH 3p \
 	MAP_VECTOR_SHAPE 0.5 MAP_TICK_PEN_SECONDARY thinner,red MAP_TICK_PEN_PRIMARY thinner,blue
 # 2nd row: Magnetic rose with a specified declination
 gmt psbasemap -R-10/-2.5/10/2.5r -JOc0/0/50/60/5.8i -Baf -BWSne -P -K -X1.25i --FONT_ANNOT_PRIMARY=12p > $ps

--- a/test/pscoast/oblCA.sh
+++ b/test/pscoast/oblCA.sh
@@ -26,4 +26,4 @@ gmt psxy -R -J -O -K -Sc0.1i -Gred << EOF >> $ps
 -120.01540	33.83507
 -120.76423	38.40270
 EOF
-gmt pscoast $PROJ1 -B1g1 -W.75p -Na/.5,80/80/80 -Slightblue -Df -Clightblue -Ir/.24p,lightblue -O -Y4.5i --MAP_ANNOT_OBLIQUE=0 >> $ps
+gmt pscoast $PROJ1 -B1g1 -W.75p -Na/.5,80/80/80 -Slightblue -Df -Clightblue -Ir/.24p,lightblue -O -Y4.5i --MAP_ANNOT_OBLIQUE=separate >> $ps

--- a/test/pscoast/vert_obl_merc.sh
+++ b/test/pscoast/vert_obl_merc.sh
@@ -5,7 +5,7 @@
 
 ps=vert_obl_merc.ps
 
-gmt set MAP_ANNOT_OBLIQUE 0 MAP_ANNOT_MIN_SPACING 0.5i
+gmt set MAP_ANNOT_OBLIQUE separate MAP_ANNOT_MIN_SPACING 0.5i
 gmt pscoast -Gred -R122W/35N/107W/22N+r -JOa120W/25N/150/12c -Bafg -P -K -X5c -Y1.5c > $ps
 gmt pscoast -Gred -R-1000/1000/-500/500+uk -JOa173:17:02E/41:16:15S/35/12c -Bafg -O -K -Y5.5c >> $ps
 gmt pscoast -Gred -R122W/35N/107W/22N+r -JOa120W/25N/150/12c+dh+v -Bafg -O -K -Y7c >> $ps

--- a/test/pscontour/thickness.sh
+++ b/test/pscontour/thickness.sh
@@ -15,4 +15,4 @@ cat << EOF > t.cpt
 3000 215 048 031   3500 215 048 031
 EOF
 gmt pscontour ice.bm -JS321/90/71/5i -P -R302/57/355/82.25r -Ct.cpt -I -W+ -K -Gl-45/81/-45/58 -Xc > $ps
-gmt pscoast -J -R -W -O -Bafg --MAP_ANNOT_OBLIQUE=2 >> $ps
+gmt pscoast -J -R -W -O -Bafg --MAP_ANNOT_OBLIQUE=lon_horizontal >> $ps

--- a/test/psxy/line_wraps.sh
+++ b/test/psxy/line_wraps.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Isolated part of issue submitted by Nicky Wright on May 25, 2017 at GSA meeting
 ps=line_wraps.ps
-gmt set MAP_ANNOT_OBLIQUE 2 MAP_FRAME_TYPE plain FORMAT_GEO_MAP dddF
+gmt set MAP_ANNOT_OBLIQUE lon_horizontal MAP_FRAME_TYPE plain FORMAT_GEO_MAP dddF
 gmt psxy -R110/-79/-25/70r -JN12c -Bafg -Xc -P -W1p,blue subduct.txt -K > $ps
 gmt psxy -Rg -JH120W/17c -Bafg -O -K -W1p,blue subduct.txt -X-1i -Y15c >> $ps
 gmt psbasemap -R110/-79/-25/70r -JN12c -A | gmt psxy -Rg -JH120W/16c -O -W0.25p,red >> $ps

--- a/test/psxy/quotedlinedash.sh
+++ b/test/psxy/quotedlinedash.sh
@@ -13,7 +13,7 @@ cat << EOF > p
 14.501667 80.028333
 16.563333 76.481667
 EOF
-gmt set MAP_ANNOT_OBLIQUE 0
+gmt set MAP_ANNOT_OBLIQUE separate
 gmt pscoast -Wfaint -R17/76.3/16/81+r -Slightblue -JS66/90/12c -P -K -Dh -Xc -Y2c > $ps
 gmt psxy p -Fr15.65/78.22 -O -R -J -Wthick,red,- -SqD40k:+gwhite+f4+LD+an+p+u"km" -K >> $ps
 gmt psxy p -Sc0.1c -Gblack -O -R -J -Bafg -K >> $ps


### PR DESCRIPTION
Since not even I can remember what the hell **MAP_ANNOT_OBLIQUE**=34 might mean without reading the settings web page every single time, I finally broke down and replaced this bit value with a comma-separated list of understandable keywords.  Old integer values are of course accepted via backwards compatibility.  All scripts using **MAP_ANNOT_OBLIQUE** have been updated to the new syntax (e.g., --**MAP_ANNOT_OBLIQUE**=**separate**,**lat_horizontal**).  The list of keyword arguments are (with corresponding integer bit value in brackets):

- **separate** [0], let longitudes be annotated only on NS axes and latitudes on WE axes.
- **anywhere** [1], let longitudes and latitudes be annotated wherever an invisible gridline crosses the map boundary [Default].
- **lon_horizontal** [2], let all longitudes be typeset horizontally.
- **lat_horizontal** [4], let all latitudes be typeset horizontally
- **tick_extend** [8], let oblique tick lengths be extended so the .tip's distance from the frame equals the requested tick length.
- **tick_normal** [16] let ticks be plotted normal to frame regardless of gridline angle.
- **lat_parallel** [32] let latitudes be annotated parallel to the frame (this is not the same as **lat_horizontal**).

All tests still pass after the changes.