### PR TITLE
Dealing with images

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -605,19 +605,24 @@ GMT_LOCAL int gmtapi_alloc_grid_xy (struct GMTAPI_CTRL *API, struct GMT_GRID *G)
 }
 
 /*! . */
-GMT_LOCAL int gmtapi_alloc_image (struct GMT_CTRL *GMT, uint64_t *dim, struct GMT_IMAGE *I) {
+GMT_LOCAL int gmtapi_alloc_image (struct GMT_CTRL *GMT, uint64_t *dim, unsigned int mode, struct GMT_IMAGE *I) {
 	/* Use information in Image header to allocate the image data.
 	 * We assume gmtapi_init_grdheader has been called.
-	 * If dim given and is 2 or 4 then we have 1 or 3 bands plus alpha channel */
+	 * If dim given and is 2 or 4 then we have 1 or 3 bands plus alpha channel
+	 * Depending on mode, the alpha layer is part of image or separate array. */
+	unsigned int n_bands = I->header->n_bands;
 
 	if (I == NULL) return (GMT_PTR_IS_NULL);
 	if (I->data) return (GMT_PTR_NOT_NULL);
 	if (I->header->size == 0U) return (GMT_SIZE_IS_ZERO);
-	if (dim && (dim[GMT_Z] == 2 || dim[GMT_Z] == 4)) {
-		if ((I->alpha = gmt_M_memory_aligned (GMT, NULL, I->header->size, unsigned char)) == NULL) return (GMT_MEMORY_ERROR);
-		I->header->n_bands--;	/* transparency is in a separate alpha array, not in the image data */
+	if (dim && (dim[GMT_Z] == 2 || dim[GMT_Z] == 4)) {	/* Transparency layer is requested */
+		if ((mode & GMT_IMAGE_ALPHA_LAYER) == 0) {	/* Use a separate alpha array */
+			if ((I->alpha = gmt_M_memory_aligned (GMT, NULL, I->header->size, unsigned char)) == NULL) return (GMT_MEMORY_ERROR);
+			n_bands--;	/* One less layer to allocate */
+		}
 	}
-	if ((I->data = gmt_M_memory_aligned (GMT, NULL, I->header->size * I->header->n_bands, unsigned char)) == NULL) return (GMT_MEMORY_ERROR);
+	if ((I->data = gmt_M_memory_aligned (GMT, NULL, I->header->size * n_bands, unsigned char)) == NULL) return (GMT_MEMORY_ERROR);
+	I->header->n_bands = n_bands;	/* Update as needed */
 	return (GMT_NOERROR);
 }
 
@@ -9298,7 +9303,7 @@ void * GMT_Create_Data (void *V_API, unsigned int family, unsigned int geometry,
 
 	int error = GMT_NOERROR;
 	int def_direction = GMT_IN;	/* Default direction is GMT_IN  */
-	unsigned int module_input, actual_family;
+	unsigned int module_input, actual_family, i_mode;
 	uint64_t n_layers = 0, zero_dim[4] = {0, 0, 0, 0}, *this_dim = dim;
 	int64_t n_cols = 0;
 	bool already_registered = false, has_ID = false;
@@ -9309,6 +9314,8 @@ void * GMT_Create_Data (void *V_API, unsigned int family, unsigned int geometry,
 	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 
+	i_mode = (family & GMT_IMAGE_ALPHA_LAYER);
+	family -= i_mode;
 	module_input = (family & GMT_VIA_MODULE_INPUT);	/* Are we creating a resource that is a module input? */
 	family -= module_input;
 	actual_family = gmtapi_separate_families (&family);
@@ -9367,7 +9374,7 @@ void * GMT_Create_Data (void *V_API, unsigned int family, unsigned int geometry,
 				already_registered = true;
 			}
 			if (def_direction == GMT_IN && (mode & GMT_CONTAINER_ONLY) == 0) {	/* Allocate the image array unless we asked for header only */
-				if ((error = gmtapi_alloc_image (API->GMT, dim, new_obj)) != GMT_NOERROR)
+				if ((error = gmtapi_alloc_image (API->GMT, dim, i_mode, new_obj)) != GMT_NOERROR)
 					return_null (API, error);	/* Allocation error */
 					/* Also allocate and populate the image x,y vectors */
 				if ((error = gmtapi_alloc_image_xy (API, new_obj)) != GMT_NOERROR)

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -613,10 +613,11 @@ GMT_LOCAL int gmtapi_alloc_image (struct GMT_CTRL *GMT, uint64_t *dim, struct GM
 	if (I == NULL) return (GMT_PTR_IS_NULL);
 	if (I->data) return (GMT_PTR_NOT_NULL);
 	if (I->header->size == 0U) return (GMT_SIZE_IS_ZERO);
-	if ((I->data = gmt_M_memory_aligned (GMT, NULL, I->header->size * I->header->n_bands, unsigned char)) == NULL) return (GMT_MEMORY_ERROR);
 	if (dim && (dim[GMT_Z] == 2 || dim[GMT_Z] == 4)) {
 		if ((I->alpha = gmt_M_memory_aligned (GMT, NULL, I->header->size, unsigned char)) == NULL) return (GMT_MEMORY_ERROR);
+		I->header->n_bands--;	/* transparency is in a separate alpha array, not in the image data */
 	}
+	if ((I->data = gmt_M_memory_aligned (GMT, NULL, I->header->size * I->header->n_bands, unsigned char)) == NULL) return (GMT_MEMORY_ERROR);
 	return (GMT_NOERROR);
 }
 

--- a/src/gmt_enum_dict.h
+++ b/src/gmt_enum_dict.h
@@ -28,7 +28,7 @@ struct GMT_API_DICT {
 	int value;
 };
 
-#define GMT_N_API_ENUMS 241
+#define GMT_N_API_ENUMS 242
 
 static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_ADD_DEFAULT", 6},
@@ -111,6 +111,7 @@ static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_HEADER_OFF", 0},
 	{"GMT_HEADER_ON", 1},
 	{"GMT_HSV", 2},
+	{"GMT_IMAGE_ALPHA_LAYER", 8192},
 	{"GMT_IMAGE_NO_INDEX", 4096},
 	{"GMT_IN", 0},
 	{"GMT_INT", 4},

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14160,6 +14160,10 @@ void gmt_end_module (struct GMT_CTRL *GMT, struct GMT_CTRL *Ccopy) {
 	gmtlib_free_custom_symbols (GMT);	/* Free linked list of custom psxy[z] symbols, if any */
 	gmtinit_free_user_media (GMT);	/* Free user-specified media formats */
 
+	/* Reset frame fill painting */
+	Ccopy->current.map.frame.paint = GMT->current.map.frame.paint;
+	gmt_M_memcpy (Ccopy->current.map.frame.fill.rgb, GMT->current.map.frame.fill.rgb, 3, double);
+
 	/* GMT_IO */
 
 	gmtlib_free_ogr (GMT, &(GMT->current.io.OGR), 1);	/* Free up the GMT/OGR structure, if used */
@@ -14222,10 +14226,6 @@ void gmt_end_module (struct GMT_CTRL *GMT, struct GMT_CTRL *Ccopy) {
 	gmt_M_memset (&GMT->current.gdal_read_in,  1, struct GMT_GDALREAD_IN_CTRL);
 	gmt_M_memset (&GMT->current.gdal_read_out, 1, struct GMT_GDALREAD_OUT_CTRL);
 	gmt_M_memset (&GMT->current.gdal_write,    1, struct GMT_GDALWRITE_CTRL);
-
-	/* Reset frame fill painting */
-	GMT->current.map.frame.paint = false;
-	GMT->current.map.frame.fill.rgb[0] = GMT->current.map.frame.fill.rgb[1] = GMT->current.map.frame.fill.rgb[2] = 1.0;
 
 	gmt_M_str_free (Ccopy);	/* Good riddance */
 }

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -358,7 +358,8 @@ enum GMT_enum_gridio {
 	GMT_GRID_XY		   = 128U,  /* Allocate and initialize x,y vectors */
 	GMT_GRID_IS_GEO		   = 256U,  /* Grid is a geographic grid, not Cartesian */
 	GMT_GRID_IS_IMAGE	   = 512U,   /* Grid may be an image, only allowed with GMT_CONTAINER_ONLY */
-	GMT_IMAGE_NO_INDEX	   = 4096	/* IF reading an indexed grid, convert to rgb so we can interpolate */
+	GMT_IMAGE_NO_INDEX	   = 4096,	/* If reading an indexed grid, convert to rgb so we can interpolate */
+	GMT_IMAGE_ALPHA_LAYER  = 8192	/* Place any alpha layer in the image band, not alpha array */
 };
 
 #define GMT_GRID_ALL		0U   /* Backwards compatibility for < 5.3.3; See GMT_CONTAINER_AND_DATA */

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1377,6 +1377,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 						if (gmt_M_is_fnan (Grid_proj[0]->data[kk + col])) Out->alpha[node] = 0;
 					}
 				}
+				if (Out->header->n_bands == 4) Out->header->n_bands = 3;
 			}
 			GMT_Report (API, GMT_MSG_INFORMATION, "Creating 24-bit color image %s\n", way[Ctrl->A.way]);
 			if (GMT_Write_Data (API, GMT_IS_IMAGE, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, Ctrl->Out.file, Out) != GMT_NOERROR)

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1377,7 +1377,6 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 						if (gmt_M_is_fnan (Grid_proj[0]->data[kk + col])) Out->alpha[node] = 0;
 					}
 				}
-				if (Out->header->n_bands == 4) Out->header->n_bands = 3;
 			}
 			GMT_Report (API, GMT_MSG_INFORMATION, "Creating 24-bit color image %s\n", way[Ctrl->A.way]);
 			if (GMT_Write_Data (API, GMT_IS_IMAGE, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, Ctrl->Out.file, Out) != GMT_NOERROR)

--- a/src/psbasemap.c
+++ b/src/psbasemap.c
@@ -300,7 +300,7 @@ EXTERN_MSC int GMT_psbasemap (void *V_API, int mode, void *args) {
 		Return (GMT_NOERROR);
 	}
 
-	/* Regular plot behaviour */
+	/* Regular plot behavior */
 
 	if ((PSL = gmt_plotinit (GMT, options)) == NULL) Return (GMT_RUNTIME_ERROR);
 


### PR DESCRIPTION
This PR is in response to #3481 and the failures it caused.  I have implemented a few things in this PR:

1. The missing canvas painting for the movie example was addressed by hiding the current setting until the movie-indicator code in _gmt_plotinit_ had been executed, then resetting the canvas fill variables.
2. Implemented the **GMT_IMAGE_ALPHA_LAYER** mode to be added to GMT+IS_IMAGE when calling _GMT_Create_Data_.  This controls whether we add a 4th image layer or just do a separate alpha array.

With these the failures in **grd2kml** are gone, the **movie** test passes, and hopefully @joa-quim can test how this impacts his Julia example and deal with that.

Closes #3479 and #3481.