### PR TITLE
Fix the message if ghostscript is not found in Windows registry

### DIFF
--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -2748,7 +2748,7 @@ GMT_LOCAL int psconvert_ghostbuster(struct GMTAPI_CTRL *API, struct PSCONVERT_CT
 #endif
 
 	if (RegO != ERROR_SUCCESS) {
-		GMT_Report (API, GMT_MSG_ERROR, "Failure while opening HKLM key\n");
+		GMT_Report (API, GMT_MSG_DEBUG, "Ghostscript not found in registry. Fallback to PATH.\n");
 		return (GMT_RUNTIME_ERROR);
 	}
 
@@ -2783,7 +2783,7 @@ GMT_LOCAL int psconvert_ghostbuster(struct GMTAPI_CTRL *API, struct PSCONVERT_CT
 		RegO = RegOpenKeyEx(HKEY_LOCAL_MACHINE, key, 0, KEY_QUERY_VALUE, &hkey);
 #endif
 	if (RegO != ERROR_SUCCESS) {
-		GMT_Report (API, GMT_MSG_ERROR, "Failure while opening HKLM key\n");
+		GMT_Report (API, GMT_MSG_DEBUG, "Ghostscript not found in registry. Fallback to PATH.\n");
 		return (GMT_RUNTIME_ERROR);
 	}
 


### PR DESCRIPTION
As mentioned in https://github.com/GenericMappingTools/pygmt/issues/478,
change the messages to debug level.

If ghostscript is not found in the Windows registry, then psconvert will
try to run `gswin64c` directory, which is equivalent to search for gs in
the GMT's bin directory and PATH.