### PR TITLE
gmtregress update to limit angles considered

### DIFF
--- a/doc/rst/source/gmtregress.rst
+++ b/doc/rst/source/gmtregress.rst
@@ -188,7 +188,7 @@ standard regression (**-Ey**) we also report the Pearsonian correlation (*r*) an
 coefficient of determination (*R*).
 
 .. figure:: /_images/GMT_slopes.*
-   :width: 400 px
+   :width: 500 px
    :align: center
 
    Scanning slopes (**-A**) to see how the misfit for an fully orthogonal regression using the LMS (-Nr) criterion

--- a/doc/rst/source/gmtregress.rst
+++ b/doc/rst/source/gmtregress.rst
@@ -187,6 +187,14 @@ These are in order: *N* (number of points), *x0* (weighted mean x), *y0* (weight
 standard regression (**-Ey**) we also report the Pearsonian correlation (*r*) and
 coefficient of determination (*R*).
 
+.. figure:: /_images/GMT_slopes.*
+   :width: 400 px
+   :align: center
+
+   Scanning slopes (**-A**) to see how the misfit for an fully orthogonal regression using the LMS (-Nr) criterion
+   varies with the line angle.  Here we see the best solution gives a line angle of -78.3 degrees
+   but there is another local minimum for an angle of 78.6 degrees that is almost as good.
+
 Examples
 --------
 

--- a/doc/rst/source/gmtregress.rst
+++ b/doc/rst/source/gmtregress.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt regress** [ *table* ] [ |-A|\ *min*\ /*max*\ /*inc* ]
+**gmt regress** [ *table* ] [ |-A|\ [*min*\ /*max*\ /*inc*][**+f**\ [**n**\|\ **p**]] ]
 [ |-C|\ *level* ]
 [ |-E|\ **x**\|\ **y**\|\ **o**\|\ **r** ]
 [ |-F|\ *flags* ]
@@ -63,14 +63,17 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ *min*\ /*max*\ /*inc*
-    Instead of determining a best-fit regression we explore the full range of regressions.
-    Examine all possible regression lines with slope angles between *min* and *max*,
-    using steps of *inc* degrees [-90/+90/1].  For each slope the optimum intercept
-    is determined based on your regression type (**-E**) and misfit norm (**-N**) settings.
-    For each segment we report the four columns *angle*, *E*, *slope*, *intercept*, for
-    the range of specified angles. The best model parameters within this range
+**-A**\ [*min*\ /*max*\ /*inc*][**+f**\ [**n**\|\ **p**]]
+    There are two uses for this setting: (1) Instead of determining a best-fit regression
+    we explore the full range of regressions. Examine all possible regression lines with slope
+    angles between *min* and *max*, using steps of *inc* degrees [-90/+90/1].  For each slope,
+    the optimum intercept is determined based on your regression type (**-E**) and misfit norm
+    (**-N**) settings. For each data segment we report the four columns *angle*, *E*, *slope*,
+    *intercept*, for the range of specified angles. The best model parameters within this range
     are written into the segment header and reported in verbose information mode (**-Vi**).
+    (2) Except for **-N2**, append **+f** to force the best regression to
+    only consider the given restricted range of angles [all angles].  As shortcuts for negative
+    or positive slopes, just use **+fn** or **+fp**, respectively.
 
 .. _-C:
 
@@ -228,6 +231,12 @@ in steps of 0.2 degrees for the same file, try
    ::
 
     gmt regress points.txt -A0/90/0.2 -Eo -Nr > points_analysis.txt
+
+To force an orthogonal LMS to pick the best solution with a positive slope, try
+
+   ::
+
+    gmt regress points.txt -A+fp -Eo -Nr > best_pos_slope.txt
 
 
 References

--- a/doc/scripts/GMT_slopes.ps
+++ b/doc/scripts/GMT_slopes.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.1.0_9ec2b60-dirty_2020.06.17 [64-bit] Document from psxy
+%%Title: GMT v6.1.0_fb5fdfb_2020.06.18 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Jun 18 11:42:54 2020
+%%CreationDate: Thu Jun 18 12:18:24 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -669,7 +669,7 @@ O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy tmp.txt -R-90/90/0/35 -JX15c/5c '-Bxa30+u@.+lRegression line angle, @~a@~' '-Byaf+lMisfit, E(@~a@~)' -BWSrt -P -K
+%@GMT: gmt psxy tmp.txt -R-90/90/0/35 -JX15c/5c '-Bxa30+u@.+lRegression line angle, @~a@~' '-Byaf+lMisfit, E(@~a@~)' -BWSrt -P -K -W0.75p
 %@PROJ: xy -90.00000000 90.00000000 0.00000000 35.00000000 -90.000 90.000 0.000 35.000 +xy
 %GMTBoundingBox: 72 72 425.196850394 141.732283465
 %%BeginObject PSL_Layer_1
@@ -782,7 +782,7 @@ V MU 0 0 M (Regression line angle, ) FP 267 F12 (a) FP pathbbox N pop exch pop a
 N 0 0 M 7087 0 D S
 0 -2362 T
 0 setlinecap
-4 W
+12 W
 clipsave
 0 0 M
 7087 0 D

--- a/doc/scripts/GMT_slopes.ps
+++ b/doc/scripts/GMT_slopes.ps
@@ -1,0 +1,1110 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.1.0_9ec2b60-dirty_2020.06.17 [64-bit] Document from psxy
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Thu Jun 18 11:42:54 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy tmp.txt -R-90/90/0/35 -JX15c/5c '-Bxa30+u@.+lRegression line angle, @~a@~' '-Byaf+lMisfit, E(@~a@~)' -BWSrt -P -K
+%@PROJ: xy -90.00000000 90.00000000 0.00000000 35.00000000 -90.000 90.000 0.000 35.000 +xy
+%GMTBoundingBox: 72 72 425.196850394 141.732283465
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 2362 M 0 -2362 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 675 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 0 2025 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) sw mx
+(10) sw mx
+(20) sw mx
+(30) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+675 PSL_A0_y MM
+(10) mr Z
+1350 PSL_A0_y MM
+(20) mr Z
+2025 PSL_A0_y MM
+(30) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 135 M -42 0 D S
+N 0 270 M -42 0 D S
+N 0 405 M -42 0 D S
+N 0 540 M -42 0 D S
+N 0 810 M -42 0 D S
+N 0 945 M -42 0 D S
+N 0 1080 M -42 0 D S
+N 0 1215 M -42 0 D S
+N 0 1485 M -42 0 D S
+N 0 1620 M -42 0 D S
+N 0 1755 M -42 0 D S
+N 0 1890 M -42 0 D S
+N 0 2160 M -42 0 D S
+N 0 2295 M -42 0 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
+1181 PSL_L_y MM
+V 90 R V MU 0 0 M (Misfit, E\() FP 267 F12 (a) FP 267 F0 (\)) FP pathbbox N pop exch pop add U -2 div 0 G
+(Misfit, E\() Z
+267 F12 (a) Z
+267 F0 (\)) Z
+U
+7087 0 T
+25 W
+N 0 2362 M 0 -2362 D S
+-7087 0 T
+N 0 0 M 7087 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 1181 0 M 0 -83 D S
+N 2362 0 M 0 -83 D S
+N 3543 0 M 0 -83 D S
+N 4724 0 M 0 -83 D S
+N 5906 0 M 0 -83 D S
+N 7087 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+200 F0
+(-90\260) sh mx
+(-60\260) sh mx
+(-30\260) sh mx
+(0\260) sh mx
+(30\260) sh mx
+(60\260) sh mx
+(90\260) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(-90\260) bc Z
+1181 PSL_A0_y MM
+(-60\260) bc Z
+2362 PSL_A0_y MM
+(-30\260) bc Z
+3543 PSL_A0_y MM
+(0\260) bc Z
+4724 PSL_A0_y MM
+(30\260) bc Z
+5906 PSL_A0_y MM
+(60\260) bc Z
+7087 PSL_A0_y MM
+(90\260) bc Z
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
+3543 PSL_L_y MM
+V MU 0 0 M (Regression line angle, ) FP 267 F12 (a) FP pathbbox N pop exch pop add U -2 div 0 G
+(Regression line angle, ) Z
+267 F12 (a) Z
+0 2362 T
+25 W
+N 0 0 M 7087 0 D S
+0 -2362 T
+0 setlinecap
+4 W
+clipsave
+0 0 M
+7087 0 D
+0 2362 D
+-7087 0 D
+P
+PSL_clip N
+0 622 M
+94 -45 D
+4 -2 D
+8 1 D
+4 -2 D
+4 -6 D
+55 -27 D
+91 -60 D
+20 -12 D
+11 -8 D
+52 -32 D
+11 -8 D
+55 -33 D
+52 -31 D
+181 45 D
+102 23 D
+36 25 D
+74 54 D
+75 57 D
+16 18 D
+83 107 D
+7 11 D
+4 5 D
+52 114 D
+7 5 D
+40 21 D
+12 15 D
+27 41 D
+16 23 D
+4 4 D
+20 -16 D
+66 -53 D
+99 -79 D
+4 -3 D
+4 -1 D
+27 19 D
+44 37 D
+4 -3 D
+7 4 D
+59 -28 D
+4 0 D
+56 54 D
+15 16 D
+48 90 D
+23 47 D
+8 10 D
+32 26 D
+3 4 D
+60 49 D
+3 4 D
+63 52 D
+99 81 D
+27 22 D
+52 41 D
+4 3 D
+3 4 D
+60 59 D
+15 16 D
+48 47 D
+11 12 D
+52 50 D
+11 12 D
+12 11 D
+40 -33 D
+59 -50 D
+4 -2 D
+27 20 D
+36 24 D
+35 24 D
+35 23 D
+63 40 D
+79 47 D
+36 20 D
+7 5 D
+56 30 D
+94 47 D
+79 35 D
+71 28 D
+27 10 D
+8 13 D
+39 76 D
+87 20 D
+79 13 D
+12 1 D
+70 113 D
+60 95 D
+63 99 D
+7 13 D
+44 67 D
+4 3 D
+47 8 D
+71 7 D
+67 3 D
+67 -1 D
+43 -3 D
+24 -20 D
+3 -4 D
+32 -29 D
+28 -39 D
+19 -29 D
+44 -62 D
+27 -41 D
+95 -139 D
+47 -71 D
+75 -112 D
+7 -8 D
+52 -47 D
+8 -7 D
+7 -8 D
+44 -41 D
+12 -11 D
+7 -8 D
+56 -53 D
+31 -32 D
+24 -23 D
+55 -13 D
+16 15 D
+3 4 D
+63 60 D
+63 59 D
+56 50 D
+3 4 D
+60 52 D
+3 4 D
+44 37 D
+4 0 D
+15 -13 D
+24 -21 D
+12 -19 D
+24 -44 D
+7 -15 D
+63 -116 D
+59 7 D
+75 5 D
+47 2 D
+28 -76 D
+4 -2 D
+114 1 D
+20 -1 D
+16 -31 D
+4 2 D
+35 -71 D
+4 -1 D
+27 13 D
+4 -7 D
+28 -128 D
+28 -52 D
+11 -23 D
+91 -166 D
+59 -104 D
+16 -25 D
+23 14 D
+4 2 D
+12 -23 D
+4 -2 D
+28 21 D
+3 4 D
+87 66 D
+36 -69 D
+3 0 D
+12 16 D
+4 -4 D
+67 -164 D
+24 -54 D
+4 -5 D
+126 -87 D
+43 -29 D
+4 -1 D
+31 49 D
+8 -15 D
+40 -89 D
+4 -3 D
+78 -27 D
+52 -18 D
+59 -21 D
+4 0 D
+74 55 D
+52 38 D
+3 0 D
+32 -32 D
+4 1 D
+23 24 D
+79 -100 D
+24 -29 D
+4 -1 D
+79 63 D
+63 110 D
+63 121 D
+59 123 D
+7 -5 D
+20 30 D
+4 3 D
+39 -72 D
+40 -70 D
+12 -15 D
+15 -17 D
+36 -67 D
+4 -5 D
+8 -4 D
+S
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R-90/90/0/35 -JX15c/5c -O -K -Sv12p+s -W0.25p,dashed
+%@PROJ: xy -90.00000000 90.00000000 0.00000000 35.00000000 -90.000 90.000 0.000 35.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7087 0 D
+0 2362 D
+-7087 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {4 W 0 A [33 17] 0 B} def
+4 W
+[33 17] 0 B
+V
+O1
+4 W
+V 0 357 T N 0 0 M 7087 0 D S
+U
+U
+PSL_cliprestore
+[] 0 B
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R-90/90/0/35 -JX15c/5c -O -K -Sv12p+b -Gblack -W0.5p --MAP_VECTOR_SHAPE=0.5
+%@PROJ: xy -90.00000000 90.00000000 0.00000000 35.00000000 -90.000 90.000 0.000 35.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7087 0 D
+0 2362 D
+-7087 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {8 W 0 A [] 0 B} def
+8 W
+V
+{0 A} FS
+O1
+8 W
+V 6638 427 T 90 R
+N 150 0 M 1078 0 D S
+PSL_vecheadpen
+8 W
+0 0 M
+200 -54 D
+-50 54 D
+50 54 D
+P clip fs P S U
+8 W
+V 461 358 T 90 R
+N 150 0 M 1126 0 D S
+PSL_vecheadpen
+8 W
+0 0 M
+200 -54 D
+-50 54 D
+50 54 D
+P clip fs P S U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R-90/90/0/35 -JX15c/5c -O -F+f12p+jCB -Dj0/0.1c
+%@PROJ: xy -90.00000000 90.00000000 0.00000000 35.00000000 -90.000 90.000 0.000 35.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7087 0 D
+0 2362 D
+-7087 0 D
+P
+PSL_clip N
+6638 1735 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(78.6\260) bc Z
+461 1735 M (­78.3\260) bc Z
+PSL_cliprestore
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/doc/scripts/GMT_slopes.sh
+++ b/doc/scripts/GMT_slopes.sh
@@ -23,7 +23,7 @@ cat << EOF > data
 EOF
 
 gmt regress data -A-90/90/0.1 -Eo -Nr > tmp.txt
-gmt psxy tmp.txt -R-90/90/0/35 -JX15c/5c -Bxa30+u@.+l"Regression line angle, @~a@~" -Byaf+l"Misfit, E(@~a@~)" -BWSrt -P -K > $ps
+gmt psxy tmp.txt -R-90/90/0/35 -JX15c/5c -Bxa30+u@.+l"Regression line angle, @~a@~" -Byaf+l"Misfit, E(@~a@~)" -BWSrt -P -K -W0.75p > $ps
 echo -90 5.29462 90 5.29462 | gmt psxy -R -J -O -K -Sv12p+s -W0.25p,dashed >> $ps
 gmt psxy -R -J -O -K -Sv12p+b -Gblack -W0.5p --MAP_VECTOR_SHAPE=0.5 << EOF >> $ps
 78.6 6.32 90 2.6c

--- a/doc/scripts/GMT_slopes.sh
+++ b/doc/scripts/GMT_slopes.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Show gmtregress -A option in effect
+ps=GMT_slopes.ps
+cat << EOF > data
+5.2957	-19.5631
+7.087	-36.0337
+4.7318	-22.9612
+10.7389	-43.3934
+13.2405	-12.6665
+10.8035	-28.1462
+17.9197	-13.7448
+5.0468	-30.0907
+6.6409	-20.6262
+2.0459	-38.0396
+0.0963	-45.2655
+15.1622	-25.3824
+14.108	-30.4538
+15.1111	-32.6112
+5.07	-26.6111
+8.81	-25.579
+5.89	-31.2512
+11.28	-37.4959
+EOF
+
+gmt regress data -A-90/90/0.1 -Eo -Nr > tmp.txt
+gmt psxy tmp.txt -R-90/90/0/35 -JX15c/5c -Bxa30+u@.+l"Regression line angle, @~a@~" -Byaf+l"Misfit, E(@~a@~)" -BWSrt -P -K > $ps
+echo -90 5.29462 90 5.29462 | gmt psxy -R -J -O -K -Sv12p+s -W0.25p,dashed >> $ps
+gmt psxy -R -J -O -K -Sv12p+b -Gblack -W0.5p --MAP_VECTOR_SHAPE=0.5 << EOF >> $ps
+78.6 6.32 90 2.6c
+-78.3 5.3 90 2.7c
+EOF
+gmt pstext -R -J -O -F+f12p+jCB -Dj0/0.1c << EOF >> $ps
+78.6 25 78.6@.
+-78.3 25 -78.3@.
+EOF
+rm -f data tmp.txt

--- a/src/gmtregress.c
+++ b/src/gmtregress.c
@@ -621,7 +621,8 @@ GMT_LOCAL double gmtregress_demeaning (struct GMT_CTRL *GMT, double *X, double *
 		if (beta && alpha) {	/* Compute beta (as alpha above) which is needed for weighted orthogonal regression */
 			for (i = 0; i < n; i++) {
 				if (w[GMT_Z]) corr_i = w[GMT_Z][i];
-				beta[i] = (corr_i > 0.0) ? W[i] * (U[i] / w[GMT_Y][i] + par[GMTREGRESS_SLOPE] * V[i] / w[GMT_X][i] - (par[GMTREGRESS_SLOPE] * U[i] + V[i]) * corr_i / alpha[i]) : 0.0;
+				beta[i] = W[i] * (U[i] / w[GMT_Y][i] + par[GMTREGRESS_SLOPE] * V[i] / w[GMT_X][i] - (par[GMTREGRESS_SLOPE] * U[i] + V[i]) * corr_i / alpha[i]);
+				if (gmt_M_is_dnan (beta[i])) beta[i] = 0.0;	/* Prevent division by zero */
 			}
 		}
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Computed single weights from separate x- and y-weights %s\n",

--- a/src/gmtregress.c
+++ b/src/gmtregress.c
@@ -70,7 +70,7 @@ struct GMTREGRESS_CTRL {
 		bool active;
 		char *file;
 	} Out;
-	struct GMTREGRESS_A {	/* 	-A[<min>/<max>/<inc>][+f] */
+	struct GMTREGRESS_A {	/* 	-A[<min>/<max>/<inc>][+f[n|p]] */
 		bool active;
 		bool force;
 		double min, max, inc;

--- a/src/gmtregress.c
+++ b/src/gmtregress.c
@@ -318,6 +318,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTREGRESS_CTRL *Ctrl, struct GMT
 				break;
 		}
 	}
+	n_errors += gmt_M_check_condition (GMT, Ctrl->A.force && Ctrl->N.mode == GMTREGRESS_NORM_L2, "Option -A: Cannot force limited angle range for -N2 norm.\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && Ctrl->T.active, "Option -S: Cannot simultaneously specify -T.\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->E.mode == GMTREGRESS_XY && Ctrl->W.n_weights == 1, "Option -Eo: Needs errors in both x,y or neither.\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->E.mode == GMTREGRESS_RMA && Ctrl->W.n_weights == 1, "Option -Er: Needs errors in both x,y or neither.\n");


### PR DESCRIPTION
**Description of proposed changes**

Letting **-A** have power to limit which angles are used in determining the best regression.  This is helpful when you know from other information that a slope must be positive, yet outliers may trick it to find a negative solution that is not physically meaningful.  Using **-A+fp** forces a positive angle, for instance (**+fn** does the same for negative slopes), while a full -A30/66/1+f forces us to only use the given range.  This feature was requested by Dietmar Müller and I agree it is a useful addition.  So now **-A** has two different roles:

1. Scan all angles given and return misfit as function of angle
2. Limit angles used for robust determinations of slope

I added a new figure in doc that is now included in gmtregress.rst to show the purpose of the **-A** scanning feature. 

This PR also fixed a problem with the LS orthogonal solution when weights were either 0 or 1.  Now, if that is the case, I simply collect all the points with weight one and do a non-weighted orthogonal regression on those points instead.