### PR TITLE
Fix incorrect use of gmt_M_grd_x_to_col/gmt_M_grd_y_to_row

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -4773,6 +4773,7 @@ GMT_LOCAL struct GMT_IMAGE * gmtapi_import_image (struct GMTAPI_CTRL *API, int o
 			GMT_Report (API, GMT_MSG_INFORMATION, "Extracting subset image data from GMT_IMAGE memory location\n");
 			/* Here we need to do more work: Either extract subset or add/change padding, or both. */
 			/* Get start/stop row/cols for subset (or the entire domain) */
+			/* dx,dy are needed when the image is pixel-registered as the w/e/s/n bounds are off by 0.5 {dx,dy} relative to node coordinates */
 			dx = I_obj->header->inc[GMT_X] * I_obj->header->xy_off;	dy = I_obj->header->inc[GMT_Y] * I_obj->header->xy_off;
 			j1 = (uint64_t) gmt_M_grd_y_to_row (GMT, I_obj->header->wesn[YLO]+dy, I_orig->header);
 			j0 = (uint64_t) gmt_M_grd_y_to_row (GMT, I_obj->header->wesn[YHI]-dy, I_orig->header);
@@ -5174,6 +5175,7 @@ GMT_LOCAL struct GMT_GRID * gmtapi_import_grid (struct GMTAPI_CTRL *API, int obj
 			}
 			/* Here we need to do more work: Either extract subset or add/change padding, or both. */
 			/* Get start/stop row/cols for subset (or the entire domain) */
+			/* dx,dy are needed when the grid is pixel-registered as the w/e/s/n bounds are off by 0.5 {dx,dy} relative to node coordinates */
 			dx = G_obj->header->inc[GMT_X] * G_obj->header->xy_off;	dy = G_obj->header->inc[GMT_Y] * G_obj->header->xy_off;
 			j1 = (unsigned int)gmt_M_grd_y_to_row (GMT, G_obj->header->wesn[YLO]+dy, G_orig->header);
 			j0 = (unsigned int)gmt_M_grd_y_to_row (GMT, G_obj->header->wesn[YHI]-dy, G_orig->header);
@@ -5471,6 +5473,7 @@ GMT_LOCAL int gmtapi_export_grid (struct GMTAPI_CTRL *API, int object_ID, unsign
 			GH2->alloc_level = S_obj->alloc_level;	/* Since we are passing it up to the caller */
 			gmt_copy_gridheader (GMT, G_copy->header, G_obj->header);
 			gmt_M_memcpy (G_copy->header->wesn, S_obj->wesn, 4, double);
+			/* dx,dy are needed when the grid is pixel-registered as the w/e/s/n bounds are off by 0.5 {dx,dy} relative to node coordinates */
 			dx = G_obj->header->inc[GMT_X] * G_obj->header->xy_off;	dy = G_obj->header->inc[GMT_Y] * G_obj->header->xy_off;
 			j1 = (unsigned int) gmt_M_grd_y_to_row (GMT, G_obj->header->wesn[YLO]+dy, G_obj->header);
 			j0 = (unsigned int) gmt_M_grd_y_to_row (GMT, G_obj->header->wesn[YHI]-dy, G_obj->header);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -1165,6 +1165,8 @@ char ** gmt_get_dataset_tiles (struct GMTAPI_CTRL *API, double wesn[], int k_dat
 	}
 
 	/* Get nearest whole multiple of tile size wesn boundary.  This ASSUMES all global grids are -Rd  */
+	/* Also, the srtm_tiles.nc grid is gridline-registered and we check if the node corresponding to
+	 * the lon/lat of the SW corner of a tile is 1 or 0 */
 	iw = (int)(-180 + floor ((wesn[XLO] + 180) / I->tile_size) * I->tile_size);
 	ie = (int)(-180 + ceil  ((wesn[XHI] + 180) / I->tile_size) * I->tile_size);
 	is = (int)( -90 + floor ((wesn[YLO] +  90) / I->tile_size) * I->tile_size);

--- a/src/grdcut.c
+++ b/src/grdcut.c
@@ -465,6 +465,8 @@ EXTERN_MSC int GMT_grdcut (void *V_API, int mode, void *args) {
 		add_mode = GMT_IO_RESET;	/* Pass this to allow reading the data again. */
 	}
 	else if (Ctrl->S.active) {	/* Must determine new region via -S, so only need header */
+		/* Note: The use of g and gmt_M_grd_row_to_y is correct since lon and lat args are not
+		 * coordinates computed from west or south in whole increments of dx dy. */
 		int row, col;
 		bool wrap;
 
@@ -497,6 +499,7 @@ EXTERN_MSC int GMT_grdcut (void *V_API, int mode, void *args) {
 				distance = gmt_distance (GMT, Ctrl->S.lon, Ctrl->S.lat, Ctrl->S.lon, lat);
 			}
 			wesn_new[YLO] = lat + (1.0 - G->header->xy_off) * G->header->inc[GMT_Y];	/* Go one back since last row was outside */
+			/* The (1-xy_off) adjust since grid boundaries for pixel grids do not coincide with pixel node coordinates - they are a half off */
 			if (wesn_new[YLO] <= G->header->wesn[YLO]) wesn_new[YLO] = G->header->wesn[YLO];
 		}
 		wesn_new[YHI] += radius;	/* Approximate north limit in degrees */
@@ -512,6 +515,7 @@ EXTERN_MSC int GMT_grdcut (void *V_API, int mode, void *args) {
 				distance = gmt_distance (GMT, Ctrl->S.lon, Ctrl->S.lat, Ctrl->S.lon, lat);
 			}
 			wesn_new[YHI] = lat - (1.0 - G->header->xy_off) * G->header->inc[GMT_Y];	/* Go one back since last row was outside */
+			/* The (1-xy_off) adjust since grid boundaries for pixel grids do not coincide with pixel node coordinates - they are a half off */
 			if (wesn_new[YHI] >= G->header->wesn[YHI]) wesn_new[YHI] = G->header->wesn[YHI];
 		}
 		if (doubleAlmostEqual (wesn_new[YLO], -90.0) || doubleAlmostEqual (wesn_new[YHI], 90.0)) {	/* Need all longitudes when a pole is included */
@@ -520,9 +524,9 @@ EXTERN_MSC int GMT_grdcut (void *V_API, int mode, void *args) {
 		}
 		else {	/* Determine longitude limits */
 			wrap = gmt_M_360_range (G->header->wesn[XLO], G->header->wesn[XHI]);	/* true if grid is 360 global */
-			radius /= cosd (Ctrl->S.lat);					/* Approximate e-w width in degrees longitude */
-			wesn_new[XLO] -= radius;					/* Approximate west limit in degrees */
-			if (!wrap && wesn_new[XLO] < G->header->wesn[XLO]) {		/* Outside non-periodic grid range */
+			radius /= cosd (Ctrl->S.lat);	/* Approximate e-w width in degrees longitude at center point */
+			wesn_new[XLO] -= radius;	/* Approximate west limit in degrees */
+			if (!wrap && wesn_new[XLO] < G->header->wesn[XLO]) {	/* Outside non-periodic grid range */
 				wesn_new[XLO] = G->header->wesn[XLO];
 			}
 			else {
@@ -678,6 +682,7 @@ EXTERN_MSC int GMT_grdcut (void *V_API, int mode, void *args) {
 	}
 	if (Ctrl->N.active && extend) {	/* Now shrink pad back to default and simultaneously extend region and apply nodata values */
 		unsigned int xlo, xhi, ylo, yhi, row, col, n_zero, n_zero_e;
+		double dx, dy;
 		n_zero = 0;	/* Count zeros in the grid before extension */
 		gmt_M_grd_loop (GMT, G, row, col, node) {
 			if (G->data[node] == 0.0) n_zero++;
@@ -687,10 +692,13 @@ EXTERN_MSC int GMT_grdcut (void *V_API, int mode, void *args) {
 		gmt_M_grd_setpad (GMT, G->header, GMT->current.io.pad);	/* Set the default pad */
 		gmt_set_grddim (GMT, G->header);			/* Update dimensions given the change of wesn and pad */
 		gmt_M_memcpy (wesn_new, wesn_requested, 4, double);	/* So reporting below is accurate */
-		xlo = outside[XLO] ? (unsigned int)gmt_M_grd_x_to_col (GMT, wesn_old[XLO], G->header) : 0;
-		xhi = outside[XHI] ? (unsigned int)gmt_M_grd_x_to_col (GMT, wesn_old[XHI], G->header) : G->header->n_columns - 1;
-		ylo = outside[YLO] ? (unsigned int)gmt_M_grd_y_to_row (GMT, wesn_old[YLO], G->header) : G->header->n_rows - 1;
-		yhi = outside[YHI] ? (unsigned int)gmt_M_grd_y_to_row (GMT, wesn_old[YHI], G->header) : 0;
+		/* dx,dy are needed when the grid is pixel-registered as the w/e/s/n bounds are off by 0.5 {dx,dy} relative to node coordinates */
+		dx = G->header->inc[GMT_X] * G->header->xy_off;	dy = G->header->inc[GMT_Y] * G->header->xy_off;
+
+		xlo = outside[XLO] ? (unsigned int)gmt_M_grd_x_to_col (GMT, wesn_old[XLO] + dx, G->header) : 0;
+		xhi = outside[XHI] ? (unsigned int)gmt_M_grd_x_to_col (GMT, wesn_old[XHI] - dx, G->header) : G->header->n_columns - 1;
+		ylo = outside[YLO] ? (unsigned int)gmt_M_grd_y_to_row (GMT, wesn_old[YLO] + dy, G->header) : G->header->n_rows - 1;
+		yhi = outside[YHI] ? (unsigned int)gmt_M_grd_y_to_row (GMT, wesn_old[YHI] - dy, G->header) : 0;
 		if (outside[XLO]) {
 			for (row = 0; row < G->header->n_rows; row++)
 				for (col = 0; col < xlo; col++) G->data[gmt_M_ijp(G->header,row,col)] = Ctrl->N.value;


### PR DESCRIPTION
These macros return the nearest node in a pixel or gridline grid.  However, when used to convert an actual node coordinate to a node column or row, you must make sure you pass the correct coordinates.  We had several places were we passed the equivalent of west +k * inc but that is only a node coordinate for gridline grids; pixel grids are off by 0.5*inc.
Closes #3492.