### PR TITLE
Just use a system call to wipe the entire sessions dir

### DIFF
--- a/src/clear.c
+++ b/src/clear.c
@@ -157,7 +157,7 @@ static int clear_sessions (struct GMTAPI_CTRL *API) {
 		GMT_Report (API, GMT_MSG_INFORMATION, "No directory named %s\n", API->session_dir);
 		return GMT_FILE_NOT_FOUND;
 	}
-#ifdef WIN32
+#ifdef _WIN32
 	sprintf (del_cmd, "rmdir /s /q %s", API->session_dir);
 #else
 	sprintf (del_cmd, "rm -rf %s", API->session_dir);


### PR DESCRIPTION
No safety issues since this directory was created by GMT. See #3476 for discussion. It does not matter if the user has set their **USER_DIR** to any area, since we _only_ delete the subdirectory _sessions_ inside that directory.  GMT created it, so GMT can delete it.  Closes #3476.