### PR TITLE
Forgot to update the theme in gmtinit_conf_modern_override

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6110,6 +6110,9 @@ GMT_LOCAL void gmtinit_conf_modern_override (struct GMT_CTRL *GMT) {
 	strcpy (GMT->current.setting.format_geo_map, "ddd:mm:ssF");
 	gmtlib_plot_C_format (GMT);	/* Update format statements */
 
+	/* GMT_THEME */
+	strcpy (GMT->current.setting.theme, "modern");
+
 	/* MAP group */
 
 	/* MAP_ANNOT_MIN_SPACING */


### PR DESCRIPTION
This function is called when modern theme is selected in classic or always in modern.  But it failed to actually set the **GMT_THEME** variable so in classic mode it reverted to classic before writing out the theme.
