### PR TITLE
Fix the grdinfo crash for external grids

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -6382,6 +6382,7 @@ int gmtlib_validate_id (struct GMTAPI_CTRL *API, int family, int object_ID, int 
 	for (i = 0, item = GMT_NOTSET; item == GMT_NOTSET && i < API->n_objects; i++) {
 		S_obj = API->object[i];	/* Shorthand only */
 		if (!S_obj) continue;								/* Empty object */
+		if (direction != GMT_NOTSET && S_obj->direction != direction) continue;		/* Not the same direction */
 		if (direction == GMT_IN && S_obj->status != GMT_IS_UNUSED && object_ID == GMT_NOTSET) continue;		/* Already used this input object once */
 		if (!(family == GMT_NOTSET || (int)S_obj->family == family)) {		/* Not the required data type; check for exceptions... */
 			if (family == GMT_IS_DATASET && (S_obj->actual_family == GMT_IS_VECTOR || S_obj->actual_family == GMT_IS_MATRIX))

--- a/src/testapi_matrix_as_grid.c
+++ b/src/testapi_matrix_as_grid.c
@@ -23,11 +23,13 @@ int main () {
 	if ((M_g = GMT_Create_Data (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, range_g, inc, GMT_GRID_NODE_REG, 0, NULL)) == NULL) return (EXIT_FAILURE);
 	GMT_Put_Matrix (API, M_g, GMT_DOUBLE, 0, coord);
 	GMT_Open_VirtualFile (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, M_g, input_g);
-	//sprintf (args_g, "%s -R-1/3/-1/3 -JX6c -Baf -BWSen+tGridline -K -P > api_matrix_as_grid.ps", input_g);
-	//GMT_Call_Module (API, "grdimage", GMT_MODULE_CMD, args_g);
-
-	sprintf (args_g, "%s -C -Vd", input_g);
+	/* call grdinfo to make sure it doesn't crash
+	 * See https://github.com/GenericMappingTools/gmt/pull/3514 */
+	sprintf (args_g, "%s -C", input_g);
 	GMT_Call_Module (API, "grdinfo", GMT_MODULE_CMD, args_g);
+	/* call grdimage */
+	sprintf (args_g, "%s -R-1/3/-1/3 -JX6c -Baf -BWSen+tGridline -K -P > api_matrix_as_grid.ps", input_g);
+	GMT_Call_Module (API, "grdimage", GMT_MODULE_CMD, args_g);
 	GMT_Close_VirtualFile (API, input_g);
 
 	/* pass matrix as pixel-registered grid */

--- a/src/testapi_matrix_as_grid.c
+++ b/src/testapi_matrix_as_grid.c
@@ -37,6 +37,11 @@ int main () {
 	if ((M_p = GMT_Create_Data (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, range_p, inc, GMT_GRID_PIXEL_REG, 0, NULL)) == NULL) return (EXIT_FAILURE);
 	GMT_Put_Matrix (API, M_p, GMT_DOUBLE, 0, coord);
 	GMT_Open_VirtualFile (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, M_p, input_p);
+	/* call grdinfo to make sure it doesn't crash
+	 * See https://github.com/GenericMappingTools/gmt/pull/3514 */
+	sprintf (args_p, "%s -C", input_p);
+	GMT_Call_Module (API, "grdinfo", GMT_MODULE_CMD, args_p);
+	/* call grdimage */
 	sprintf (args_p, "%s -R-1/3/-1/3 -JX6c -Baf -BWSen+tPixel -O -X8c >> api_matrix_as_grid.ps", input_p);
 	GMT_Call_Module (API, "grdimage", GMT_MODULE_CMD, args_p);
 	GMT_Close_VirtualFile (API, input_p);

--- a/src/testapi_matrix_as_grid.c
+++ b/src/testapi_matrix_as_grid.c
@@ -23,8 +23,11 @@ int main () {
 	if ((M_g = GMT_Create_Data (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, range_g, inc, GMT_GRID_NODE_REG, 0, NULL)) == NULL) return (EXIT_FAILURE);
 	GMT_Put_Matrix (API, M_g, GMT_DOUBLE, 0, coord);
 	GMT_Open_VirtualFile (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, M_g, input_g);
-	sprintf (args_g, "%s -R-1/3/-1/3 -JX6c -Baf -BWSen+tGridline -K -P > api_matrix_as_grid.ps", input_g);
-	GMT_Call_Module (API, "grdimage", GMT_MODULE_CMD, args_g);
+	//sprintf (args_g, "%s -R-1/3/-1/3 -JX6c -Baf -BWSen+tGridline -K -P > api_matrix_as_grid.ps", input_g);
+	//GMT_Call_Module (API, "grdimage", GMT_MODULE_CMD, args_g);
+
+	sprintf (args_g, "%s -C -Vd", input_g);
+	GMT_Call_Module (API, "grdinfo", GMT_MODULE_CMD, args_g);
 	GMT_Close_VirtualFile (API, input_g);
 
 	/* pass matrix as pixel-registered grid */


### PR DESCRIPTION
@PaulWessel 

I changed the C code `testapi_matrix_as_grid.c` to pass an external grid to `grdinfo`. Now it crashes for me. 

Is it another API bug?