### PR TITLE
Add testapi wrapper so that gmtest can find them on Windows

### DIFF
--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -82,7 +82,10 @@ for apiprog in \
     testapi_uservectors \
     testapi_vector \
     testapiconv \
-    testgrdio
+    testgrdio \
+    testapi_imageshading \
+    testapi_matrix_as_grid \
+    testapi_vector_strings
 do
     eval "${apiprog}() { valgrind_wrapper \"@GMT_BINARY_DIR@/src/${apiprog}\" \"\$@\"; }"
 done


### PR DESCRIPTION
Following tests fail on Windows:
```
	208 - api/apigrdpix.sh (Failed)
	211 - api/apimatimageplain.sh (Failed)
	212 - api/apimatimageshading.sh (Failed)
	216 - api/apiuserstrings.sh (Failed)
```
These tests can't find the testapi_* commands, because these new
testapi_* commands are not wrapped.