### PR TITLE
Address failure to pick up current cpt

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7774,19 +7774,22 @@ char * gmt_cpt_default (struct GMTAPI_CTRL *API, char *cpt, char *file) {
 	 * the GMT default CPT given by GMT_DEFAULT_CPT_NAME */
 	int k_data;
 	static char *srtm_cpt = "srtm";
+	char *curr_cpt = NULL;
 
-	if (cpt) return cpt;	/* CPT was already specified */
+	if (cpt) return strdup (cpt);	/* CPT was already specified */
 	if (file == NULL) return NULL;	/* No file given, so there */
+	if (API->GMT->current.setting.run_mode == GMT_MODERN && (curr_cpt = gmt_get_current_item (API->GMT, "cpt", false))) return curr_cpt;	/* Use current CPT */
+
 	if ((k_data = gmt_remote_dataset_id (API, file)) == GMT_NOTSET) {
 		size_t LOX;
 		if ((k_data = gmt_get_tile_id (API, file)) == GMT_NOTSET)
 			return NULL;	/* Go with the default, whatever that is */
 		LOX = strlen (file) - 8;	/* Position of the L|O|X flag */
-		if (file[LOX] == 'L') return srtm_cpt;
+		if (file[LOX] == 'L') return strdup (srtm_cpt);
 	}
 	if (API->remote_info[k_data].CPT[0] == '-') return (NULL);
 	
-	return (API->remote_info[k_data].CPT);
+	return (strdup (API->remote_info[k_data].CPT));
 }
 
 bool gmt_is_cpt_master (struct GMT_CTRL *GMT, char *cpt) {

--- a/src/grd2kml.c
+++ b/src/grd2kml.c
@@ -673,6 +673,7 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 			GMT_Report (API, GMT_MSG_ERROR, "Failed to create a CPT\n");
 			Return (API->error);	/* Well, that did not go well... */
 		}
+		if (cpt) gmt_M_str_free (cpt);
 		sprintf (cptfile, "%s/grd2kml_%d.cpt", API->tmp_dir, uniq);
 		if (GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, 0, NULL, cptfile, P) != GMT_NOERROR) {
 			Return (API->error);

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1055,6 +1055,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 				GMT_Report (API, GMT_MSG_ERROR, "Failed to read CPT %s.\n", Ctrl->C.file);
 				Return (API->error);	/* Well, that did not go well... */
 			}
+			if (cpt) gmt_M_str_free (cpt);
 			gray_only = (P && P->is_gray);	/* Flag that we are doing a grayscale image below */
 		}
 		else

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -908,6 +908,7 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 		if (P->categorical && Ctrl->W.active) {
 			GMT_Report (API, GMT_MSG_ERROR, "Categorical data (as implied by CPT) do not have contours.  Check plot.\n");
 		}
+		if (cpt) gmt_M_str_free (cpt);
 	}
 	get_contours = (Ctrl->Q.mode == GRDVIEW_MESH && Ctrl->W.contour) || (Ctrl->Q.mode == GRDVIEW_SURF && P && P->n_colors > 1);
 


### PR DESCRIPTION
When makecpt etc sets a current cpt, the new _gmt_cpt_default_ function did not leap into action.  Now it does and I had to make it return an allocated string so we always free it if not NULL. Deals with the ex34 failure.