### PR TITLE
Fix use and doc on invisible lines

### DIFF
--- a/doc/rst/source/explain_clabelinfo.rst_
+++ b/doc/rst/source/explain_clabelinfo.rst_
@@ -26,8 +26,8 @@
        Selects opaque text boxes [Default is transparent]; optionally
        specify the color [Default is :term:`PS_PAGE_COLOR`].
 
-    **+h**
-       Hide the lines [Default draws the lines]. This may be useful if all you want
+    **+i**
+       Invisible lines (i.e., hide the lines) [Default draws the lines]. This may be useful if all you want
        is to see annotations and labels and not the lines that guides them.
 
     **+j**\ *just*

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7159,7 +7159,6 @@ void gmt_label_syntax (struct GMT_CTRL *GMT, unsigned int indent, unsigned int k
 		gmt_message (GMT, "%s +g[<color>] paints text box [transparent]; append color [white].\n", pad);
 	else
 		gmt_message (GMT, "%s +g<fill> sets the fill for the symbol [transparent]\n", pad);
-	if (kind == 1) gmt_message (GMT, "%s +h hide the lines [Draw the lines].\n", pad);
 	if (kind) gmt_message (GMT, "%s +i makes the main line invisible [drawn using pen settings from -W].\n", pad);
 	if (kind < 2) gmt_message (GMT, "%s +j<just> sets %s justification [Default is MC].\n", pad, feature[kind]);
 	if (kind == 1) {

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -6584,14 +6584,17 @@ void gmt_contlabel_plot (struct GMT_CTRL *GMT, struct GMT_CONTOUR *G) {
 
 	if (!G->n_segments) return;	/* Northing to do here */
 
-	if (G->debug) gmtplot_contlabel_debug (GMT, PSL, G);		/* Debugging lines and points */
-
 	/* See if there are labels at all */
 	for (i = 0, no_labels = true; i < G->n_segments && no_labels; i++)
 		if (G->segment[i]->n_labels) no_labels = false;
 
+	if (!G->delay) PSL_command (GMT->PSL, "V\n");	/* Plotting something, so protect current graphics state */
+
+	if (G->debug) gmtplot_contlabel_debug (GMT, PSL, G);		/* Debugging lines and points */
+
 	if (no_labels) {	/* No labels, just draw lines; no clipping required */
 		gmtplot_contlabel_drawlines (GMT, PSL, G, 0);
+		PSL_command (GMT->PSL, "U\n");	/* Restore to where we were */
 		return;
 	}
 
@@ -6606,7 +6609,7 @@ void gmt_contlabel_plot (struct GMT_CTRL *GMT, struct GMT_CONTOUR *G) {
 		gmtplot_contlabel_plotlabels (GMT, PSL, G, mode);	/* Take the above actions */
 	}
 	else {	/* Opaque text boxes */
-		mode = PSL_TXT_INIT | PSL_TXT_DRAW;	/* Plot text */
+		mode = PSL_TXT_INIT;	/* Plot text */
 		if (G->draw) mode |= PSL_TXT_DRAW;	/* Draw lines */
 		gmtplot_contlabel_plotlabels (GMT, PSL, G, mode);	/* Place PSL variables and draw lines */
 		mode = PSL_TXT_SHOW;				/* Plot text */
@@ -6615,6 +6618,8 @@ void gmt_contlabel_plot (struct GMT_CTRL *GMT, struct GMT_CONTOUR *G) {
 	}
 	PSL_command (GMT->PSL, "[] 0 B\n");	/* Ensure no pen textures remain in effect */
 	PSL_settextmode (PSL, PSL_TXTMODE_HYPHEN);	/* Back to leave as is */
+
+	if (!G->delay) PSL_command (GMT->PSL, "U\n");	/* Restore to where we were */
 }
 
 #if 0        	// We have no current need for this anymore

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -197,7 +197,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     implied by the information provided in -C.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Alternatively prepend + to annotation interval to plot that as a single contour.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   <labelinfo> controls the specifics of the labels.  Choose from:\n");
-	gmt_label_syntax (API->GMT, 5, 0);
+	gmt_label_syntax (API->GMT, 5, 1);
 	GMT_Option (API, "B-");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Contours to be drawn can be specified in one of four ways:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   1. Fixed contour interval.\n");

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -409,7 +409,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Alternatively, give -An to disable all contour annotations\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     implied by the information provided in -C.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   <labelinfo> controls the specifics of the labels.  Choose from:\n");
-	gmt_label_syntax (API->GMT, 5, 0);
+	gmt_label_syntax (API->GMT, 5, 1);
 	GMT_Option (API, "B-");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Contours to be drawn can be specified in one of four ways:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   1. Fixed contour interval.\n");


### PR DESCRIPTION
See #3518 for context.  First, internally we had renamed that modifier **+i** but we do accept **+h** for backwards compatibility.  **+h** is generally used for header or other things so **+i** is better. However, this did not (1) make it into the documentation, (2) the usage message, or (3) actual code [which had a bug].  Closes #3518.
