### PR TITLE
Fix script for fronts since pens now listened too

### DIFF
--- a/test/pslegend/lines.ps
+++ b/test/pslegend/lines.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from pslegend
+%%Title: GMT v6.1.0_e3c40a4-dirty_2020.06.23 [64-bit] Document from pslegend
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:52:49 2018
+%%CreationDate: Wed Jun 24 13:30:24 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -336,9 +336,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +592,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +635,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -651,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -662,8 +658,9 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
-/PSL_movie_completion {} def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
@@ -673,12 +670,12 @@ O0
 
 % PostScript produced by:
 %@GMT: gmt pslegend -R0/10/0/7 -JM6i -Dx0.5i/0.5i+w5i+jBL+l1.75 -F+p1p -C0.1i/0.1i -B5f1 -P -Xc
-%@PROJ: merc 0.00000000 10.00000000 0.00000000 7.00000000 -556597.454 556597.454 -0.000 775978.504 +proj=merc +lon_0=5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
-%GMTBoundingBox: -216 72 432 301.136
+%@PROJ: merc 0.00000000 10.00000000 0.00000000 7.00000000 -556597.454 556597.454 -0.000 775978.504 +proj=merc +lon_0=5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%GMTBoundingBox: -216 72 432 301.135687475
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 25 W
 8 W
 N 0 0 M 0 -83 D S
@@ -763,6 +760,8 @@ N -83 5102 M 0 -5185 D S
 7367 0 M (0è) ml Z
 -167 3581 M (5è) mr Z
 7367 3581 M (5è) ml Z
+/PSL_legend_box_width 6000 def
+/PSL_legend_box_height 4090 def
 600 600 T
 17 W
 O1
@@ -773,18 +772,26 @@ O0
 -3600 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -R0/6/0/4.18244 -Jx1i -O -K -N -Sf0.1i @GMTAPI@-000001 --GMT_HISTORY=false
+%@GMT: gmt psxy -R0/6/0/4.18244 -Jx1i -O -K -N -Sf0.1i @GMTAPI@-S-I-D-D-L-N-000001 --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 6.00000000 0.00000000 4.18244000 0.000 6.000 0.000 4.182 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
+clipsave
+0 0 M
+7200 0 D
+0 5019 D
+-7200 0 D
+P
+PSL_clip N
 17 W
 480 3795 M
 2400 0 D
 S
 O1
+V
 480 3795 M
 0 -150 D
 S
@@ -797,10 +804,12 @@ S
 2880 3795 M
 0 -150 D
 S
+U
 33 W
 480 3445 M
 2400 0 D
 S
+V
 10 setmiterlimit
 17 W
 810 3528 M
@@ -827,11 +836,14 @@ S
 -300 0 D
 70 -26 D
 S
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
+U
+8 W
 480 3095 M
 2400 0 D
 S
 {1 0 0 C} FS
+V
 10 setmiterlimit
 -45 -78 -45 78 2 525 3095 SP
 -45 -78 -45 78 2 765 3095 SP
@@ -844,10 +856,12 @@ S
 -45 -78 -45 78 2 2445 3095 SP
 -45 -78 -45 78 2 2685 3095 SP
 -45 -78 -45 78 2 2925 3095 SP
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
+U
 480 2745 M
 2400 0 D
 S
+V
 10 setmiterlimit
 45 180 360 480 2745 Sw
 45 180 360 720 2745 Sw
@@ -860,13 +874,16 @@ S
 45 180 360 2400 2745 Sw
 45 180 360 2640 2745 Sw
 45 180 360 2880 2745 Sw
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
+U
+4 W
 0 1 0 C
 480 2395 M
 2400 0 D
 S
 {0 0 1 C} FS
 O0
+V
 10 setmiterlimit
 0 -45 -90 0 0 45 3 525 2395 SP
 0 -45 -90 0 0 45 3 765 2395 SP
@@ -879,13 +896,16 @@ O0
 0 -45 -90 0 0 45 3 2445 2395 SP
 0 -45 -90 0 0 45 3 2685 2395 SP
 0 -45 -90 0 0 45 3 2925 2395 SP
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
+U
+8 W
 0 A
 480 2045 M
 2400 0 D
 S
 {1 A} FS
 O1
+V
 10 setmiterlimit
 60 480 2045 Sc
 60 960 2045 Sc
@@ -893,12 +913,15 @@ O1
 60 1920 2045 Sc
 60 2400 2045 Sc
 60 2880 2045 Sc
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
+U
+17 W
 [17 67] 0 B
 480 1695 M
 2400 0 D
 S
 {0.745 A} FS
+V
 10 setmiterlimit
 4 W
 [] 0 B
@@ -908,7 +931,9 @@ S
 60 1680 1695 Sc
 60 2160 1695 Sc
 60 2640 1695 Sc
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
+U
+PSL_cliprestore
 %%EndObject
 0 A
 FQ
@@ -916,12 +941,23 @@ O0
 -3600 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psxy -R0/6/0/4.18244 -Jx1i -O -K -N -Sqn1 @GMTAPI@-000003 --GMT_HISTORY=false
+%@GMT: gmt psxy -R0/6/0/4.18244 -Jx1i -O -K -N -Sqn1 @GMTAPI@-S-I-D-D-L-N-000003 --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 6.00000000 0.00000000 4.18244000 0.000 6.000 0.000 4.182 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 5019 D
+-7200 0 D
+P
+PSL_clip N
+42 W
+1 0.647 0 C
+V
+0 A
 /PSL_setboxpen {4 W 0 A [] 0 B} def
 /PSL_setboxrgb {1 A} def
 /PSL_path_pen [
@@ -954,6 +990,9 @@ S
 PSL_cliprestore
 U
 [] 0 B
+U
+25 W
+V
 /PSL_setboxpen {4 W 0 A [] 0 B} def
 /PSL_setboxrgb {1 A} def
 /PSL_path_pen [
@@ -988,6 +1027,10 @@ S
 PSL_cliprestore
 U
 [] 0 B
+U
+1 0 0 C
+V
+0 A
 /PSL_setboxpen {4 W 0 A [] 0 B} def
 /PSL_setboxrgb {1 A} def
 /PSL_path_pen [
@@ -1034,6 +1077,11 @@ S
 PSL_cliprestore
 U
 [] 0 B
+U
+0.647 0.165 0.165 C
+PSL_cliprestore
+V
+0 A
 /PSL_setboxpen {4 W 0 A [] 0 B} def
 /PSL_setboxrgb {1 A} def
 /PSL_path_pen [
@@ -1068,6 +1116,7 @@ S
 PSL_cliprestore
 U
 [] 0 B
+U
 %%EndObject
 0 A
 FQ
@@ -1075,12 +1124,12 @@ O0
 -3600 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -R0/6/0/4.18244 -Jx1i -O -K -N -F+f+j @GMTAPI@-000002 --GMT_HISTORY=false
+%@GMT: gmt pstext -R0/6/0/4.18244 -Jx1i -O -K -N -F+f+j @GMTAPI@-S-I-D-D-N-N-000002 --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 6.00000000 0.00000000 4.18244000 0.000 6.000 0.000 4.182 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 3240 3725 M 200 F0
 (A simple fault symbol) bl Z
 3240 3375 M (Right lateral strike-slip) bl Z
@@ -1098,7 +1147,8 @@ O0
 %%EndObject
 
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U

--- a/test/pslegend/lines.sh
+++ b/test/pslegend/lines.sh
@@ -10,10 +10,10 @@ gmt pslegend -R0/10/0/7 -JM6i -Dx0.5i/0.5i+w5i+jBL+l1.75 -F+p1p -C0.1i/0.1i -B5f
 # Legend test for gmt pslegend
 S 1.3i f+r+f	2i/0.6i/0.25i	-	1.0p		2.6i	A simple fault symbol
 S 1.3i f+r+s+o0.4i+p1p	2i/0.6i/0.25i	-	2.0p		2.6i	Right lateral strike-slip
-S 1.3i f+l+t	2i/0.2i/0.075i	red	1.0p		2.6i	Subduction zone
-S 1.3i f+r+c	2i/0.2i/0.075i	red	1.0p		2.6i	Warm front to the south
-S 1.3i f+l+b+p	2i/0.2i/0.075i	blue	1.0p,green		2.6i	Demarcation line
-S 1.3i f+c	2i/0.4i/0.1i	white	1.0p		2.6i	Some path goes here
+S 1.3i f+l+t	2i/0.2i/0.075i	red	0.5p		2.6i	Subduction zone
+S 1.3i f+r+c	2i/0.2i/0.075i	red	0.5p		2.6i	Warm front to the south
+S 1.3i f+l+b+p	2i/0.2i/0.075i	blue	0.25p,green		2.6i	Demarcation line
+S 1.3i f+c	2i/0.4i/0.1i	white	0.5p		2.6i	Some path goes here
 S 1.3i f+c+o0.2i+p0.25p,yellow	2i/0.4i/0.1i	gray	1.0p,.		2.6i	Another path is offset
 S 1.3i qn1:+lPerimeter	2i 		-	2.5p,orange	2.6i	A boundary between things
 S 1.3i qn2:+l5m	2i		-	1.5p		2.6i	5-m contour line


### PR DESCRIPTION
A side-effect of #3533 is that one of the legend examples (lines.sh) now honors the changing pen thicknesses between items and hence I adjusted them a bit since the stated (and ignored) values were too fat.
