### PR TITLE
Enforce that no grid header inquiry passes a subset

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -5102,6 +5102,10 @@ GMT_LOCAL struct GMT_GRID * gmtapi_import_grid (struct GMTAPI_CTRL *API, int obj
 		GMT_Report (API, GMT_MSG_ERROR, "Can only use method GMT_IS_FILE when row-by-row reading of grid is selected\n");
 		return_null (API, GMT_NOT_A_VALID_METHOD);
 	}
+	if ((mode & GMT_CONTAINER_ONLY) && S_obj->region) {
+		GMT_Report (API, GMT_MSG_ERROR, "Cannot request a subset when just inquiring about the grid header\n");
+		return_null (API, GMT_SUBSET_NOT_ALLOWED);		
+	}
 
 	if (S_obj->region && grid) {	/* See if this is really a subset or just the same region as the grid */
 		if (grid->header->wesn[XLO] == S_obj->wesn[XLO] && grid->header->wesn[XHI] == S_obj->wesn[XHI] && grid->header->wesn[YLO] == S_obj->wesn[YLO] && grid->header->wesn[YHI] == S_obj->wesn[YHI]) S_obj->region = false;

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -6750,7 +6750,7 @@ EXTERN_MSC int GMT_grdmath (void *V_API, int mode, void *args) {
 			else if (op == GRDMATH_ARG_IS_FILE) {		/* Filename given */
 				if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) GMT_Message (API, GMT_TIME_NONE, "%s ", opt->arg);
 				/* Passing GMT_VIA_MODULE_INPUT since these are command line file arguments but processed here instead of by GMT_Init_IO */
-				if ((stack[nstack]->G = GMT_Read_Data (API, GMT_IS_GRID|GMT_VIA_MODULE_INPUT, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, wesn, opt->arg, NULL)) == NULL) {	/* Get header only */
+				if ((stack[nstack]->G = GMT_Read_Data (API, GMT_IS_GRID|GMT_VIA_MODULE_INPUT, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, opt->arg, NULL)) == NULL) {	/* Get header only */
 					Return (API->error);
 				}
 				if (!subset && !gmt_M_grd_same_shape (GMT, stack[nstack]->G, info.G)) {


### PR DESCRIPTION
When _GMT_Read_Data_ uses **GMT_CONTAINER_ONLY** as mode, we return the full header of the grid.  Hence, it makes no sense to pass a subset wesn argument other than NULL.  To discourage such confusing behavior we now issue an error if that happens.  In GMT, only one instance (in **grdmath**) called _GMT_Read_Data_ in that way, now fixed.  Al tests pass. Any externals will need to fix their calls if they ever abused the function.
