### PR TITLE
Add -Q to gmtget to simply list aviailble datasets

### DIFF
--- a/doc/rst/source/gmtget.rst
+++ b/doc/rst/source/gmtget.rst
@@ -85,7 +85,7 @@ PARAMETER
     Can be used in conjunction with **-D** (and **-I**) to provide a listing of
     available datasets (no downloading takes place)  The output is one record per
     dataset giving the information as *planet group dataset size remark*.  For datasets
-    that are tiled, the *size* is set to N/A (tile sizes various but are usually just
+    that are tiled, the *size* is set to N/A (tile sizes vary but are usually just
     a few Mb each).
 
 .. _-V:

--- a/doc/rst/source/gmtget.rst
+++ b/doc/rst/source/gmtget.rst
@@ -84,7 +84,9 @@ PARAMETER
 **-Q**
     Can be used in conjunction with **-D** (and **-I**) to provide a listing of
     available datasets (no downloading takes place)  The output is one record per
-    dataset giving the information as *planet group dataset size remark*.
+    dataset giving the information as *planet group dataset size remark*.  For datasets
+    that are tiled, the *size* is set to N/A (tile sizes various but are usually just
+    a few Mb each).
 
 .. _-V:
 

--- a/doc/rst/source/gmtget.rst
+++ b/doc/rst/source/gmtget.rst
@@ -19,6 +19,7 @@ Synopsis
 [ |-I|\ *inc*\ [**m**\|\ **s**] ]
 [ |-L| ]
 [ |-N| ]
+[ |-Q| ]
 [ |SYN_OPT-V| ]
 
 |No-spaces|
@@ -77,6 +78,13 @@ PARAMETER
     of downloaded compressed JP2000 tiles to locally (compressed) netCDF grids.
     This speeds up the total data request and defers the conversion to when the
     tile is requested by a module.
+
+.. _-Q:
+
+**-Q**
+    Can be used in conjunction with **-D** (and **-I**) to provide a listing of
+    available datasets (no downloading takes place)  The output is one record per
+    dataset giving the information as *planet group dataset size remark*.
 
 .. _-V:
 

--- a/doc/rst/source/gmtget.rst
+++ b/doc/rst/source/gmtget.rst
@@ -83,7 +83,7 @@ PARAMETER
 
 **-Q**
     Can be used in conjunction with **-D** (and **-I**) to provide a listing of
-    available datasets (no downloading takes place)  The output is one record per
+    available datasets (no downloading takes place). The output is one record per
     dataset giving the information as *planet group dataset size remark*.  For datasets
     that are tiled, the *size* is set to N/A (tile sizes vary but are usually just
     a few Mb each).

--- a/doc/rst/source/gmtget.rst
+++ b/doc/rst/source/gmtget.rst
@@ -84,9 +84,9 @@ PARAMETER
 **-Q**
     Can be used in conjunction with **-D** (and **-I**) to provide a listing of
     available datasets (no downloading takes place). The output is one record per
-    dataset giving the information as *planet group dataset size remark*.  For datasets
+    dataset giving the information as *planet group dataset size nitems remark*.  For datasets
     that are tiled, the *size* is set to N/A (tile sizes vary but are usually just
-    a few Mb each).
+    a few Mb each) and *nitems* indicates the number of tiles.
 
 .. _-V:
 

--- a/src/gmtget.c
+++ b/src/gmtget.c
@@ -160,6 +160,8 @@ static int parse (struct GMT_CTRL *GMT, struct GMTGET_CTRL *Ctrl, struct GMT_OPT
 	                                 "Option -D: Requires a selection\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.active && !Ctrl->D.active,
 	                                 "Option -Q: Requires -D\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.active && Ctrl->N.active,
+	                                 "Option -Q: -N will be ignored\n");
 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
@@ -206,7 +208,7 @@ EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 			double world[4] = {-180.0, +180.0, -90.0, +90.0};
 			struct GMT_RECORD *Out = NULL;
 
-			if (Ctrl->Q.active) {
+			if (Ctrl->Q.active) {	/* Must activate data output machinery for a DATASET with no numerical columns */
 				Out = gmt_new_record (GMT, NULL, message);
 				if ((error = GMT_Set_Columns (API, GMT_OUT, 0, GMT_COL_FIX)) != GMT_NOERROR) Return (API->error);
 				if (GMT_Init_IO (API, GMT_IS_DATASET, GMT_IS_NONE, GMT_OUT, GMT_ADD_DEFAULT, 0, options) != GMT_NOERROR) {
@@ -268,7 +270,7 @@ EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 				}
 			}
 			if (list) gmt_free_list (GMT, list, n_items);
-			if (Ctrl->Q.active) {
+			if (Ctrl->Q.active) {	/* Terminate i/o */
 				gmt_M_free (GMT, Out);
 				if (GMT_End_IO (API, GMT_OUT, 0) != GMT_NOERROR) {
 					Return (API->error);

--- a/src/gmtget.c
+++ b/src/gmtget.c
@@ -54,6 +54,9 @@ struct GMTGET_CTRL {
 	struct GMTGET_N {	/* -N */
 		bool active;
 	} N;
+	struct GMTGET_Q {	/* -Q */
+		bool active;
+	} Q;
 };
 
 static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
@@ -72,7 +75,7 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GMTGET_CTRL *C) {	/* Dealloc
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [-D<download>] [-G<defaultsfile>] [-I<inc>] [-L] [-N] [PARAMETER1 PARAMETER2 PARAMETER3 ...] [%s]\n", name, GMT_V_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s [-D<download>] [-G<defaultsfile>] [-I<inc>] [-L] [-N] [-Q] [PARAMETER1 PARAMETER2 PARAMETER3 ...] [%s]\n", name, GMT_V_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\n\tFor available PARAMETERS, see %s man page\n", GMT_SETTINGS_FILE);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -92,6 +95,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Limit the download of data sets to grid spacings of <inc> or larger [0].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-L Write one parameter value per line [Default writes all on one line].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Do NOT convert grids downloaded with -D to netCDF but leave as JP2.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-Q In conjunction with -D, will list but not download the selected data.\n");
 	GMT_Option (API, "V,.");
 
 	return (GMT_MODULE_USAGE);
@@ -137,6 +141,9 @@ static int parse (struct GMT_CTRL *GMT, struct GMTGET_CTRL *Ctrl, struct GMT_OPT
 			case 'N':	/* Leave JP2 as is */
 				Ctrl->N.active = true;
 				break;
+			case 'Q':	/* Report data sets available */
+				Ctrl->Q.active = true;
+				break;
 
 
 			default:	/* Report bad options */
@@ -151,6 +158,8 @@ static int parse (struct GMT_CTRL *GMT, struct GMTGET_CTRL *Ctrl, struct GMT_OPT
 	                                 "Option -D: Cannot be used with -L\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->D.active && Ctrl->D.dir == NULL,
 	                                 "Option -D: Requires a selection\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.active && !Ctrl->D.active,
+	                                 "Option -Q: Requires -D\n");
 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
@@ -193,7 +202,23 @@ EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 			bool found;
 			unsigned int n_tiles, k, d = 0, t, n_items = 0;
 			char **list = NULL, *string = NULL, *token = NULL, *tofree = NULL;
+			char planet[GMT_LEN32] = {""}, group[GMT_LEN32] = {""}, dataset[GMT_LEN64] = {""}, size[GMT_LEN32] = {""}, message[GMT_LEN256] = {""};
 			double world[4] = {-180.0, +180.0, -90.0, +90.0};
+			struct GMT_RECORD *Out = NULL;
+
+			if (Ctrl->Q.active) {
+				Out = gmt_new_record (GMT, NULL, message);
+				if ((error = GMT_Set_Columns (API, GMT_OUT, 0, GMT_COL_FIX)) != GMT_NOERROR) Return (API->error);
+				if (GMT_Init_IO (API, GMT_IS_DATASET, GMT_IS_NONE, GMT_OUT, GMT_ADD_DEFAULT, 0, options) != GMT_NOERROR) {
+					Return (API->error);
+				}
+				if (GMT_Begin_IO (API, GMT_IS_DATASET, GMT_OUT, GMT_HEADER_OFF) != GMT_NOERROR) {
+					Return (API->error);
+				}
+				if (GMT_Set_Geometry (API, GMT_OUT, GMT_IS_NONE) != GMT_NOERROR) {	/* Sets output geometry */
+					Return (API->error);
+				}
+			}
 
 			if (Ctrl->N.active) GMT->current.io.leave_as_jp2 = true;	/* Do not convert to netCDF right away */
 			if ((c = strchr (Ctrl->D.dir, '=')) && (datasets = &c[1])) {	/* But only one or more specific planets or datasets */
@@ -212,18 +237,43 @@ EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 					if (!found) continue;	/* Not this planet or dataset */
 				}
 				if (Ctrl->I.active && Ctrl->I.inc > API->remote_info[k].d_inc) continue;	/* Skip this resolution */
-				if (API->remote_info[k].tile_size > 0.0) {	/* Must obtain all tiles */
-					char **list = gmt_get_dataset_tiles (API, world, k, &n_tiles);
-					for (t = 0; t < n_tiles; t++)
-						gmt_download_file_if_not_found (GMT, list[t], GMT_AUTO_DIR);
-					gmt_free_list (GMT, list, n_tiles);
+				if (Ctrl->Q.active) {	/* Reporting only */
+					strcpy (message, API->remote_info[k].dir);
+					gmt_strrepc (message, '/', ' ');	/* Turn slashes to spaces */
+					sscanf (message, "%*s %s %s", planet, group);
+					strcpy (dataset, API->remote_info[k].file);
+					if (dataset[strlen(dataset)-1] == '/') {	/* Tiles */
+						dataset[strlen(dataset)-1] = '\0';	/* Chop off slash */
+						strcpy (size, "N/A");
+					}
+					else {
+						(void) gmt_chop_ext (dataset);
+						strcpy (size, API->remote_info[k].size);
+					}
+					message[0] = '\0';
+					sprintf (message, "%s\t%s\t%s\t%s\t%s", planet, group, dataset, size, API->remote_info[k].remark);
+					GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 				}
 				else {
-					sprintf (file, "@%s", API->remote_info[k].file);
-					gmt_download_file_if_not_found (GMT, file, GMT_AUTO_DIR);
+					if (API->remote_info[k].tile_size > 0.0) {	/* Must obtain all tiles */
+						char **list = gmt_get_dataset_tiles (API, world, k, &n_tiles);
+						for (t = 0; t < n_tiles; t++)
+							gmt_download_file_if_not_found (GMT, list[t], GMT_AUTO_DIR);
+						gmt_free_list (GMT, list, n_tiles);
+					}
+					else {
+						sprintf (file, "@%s", API->remote_info[k].file);
+						gmt_download_file_if_not_found (GMT, file, GMT_AUTO_DIR);
+					}
 				}
 			}
 			if (list) gmt_free_list (GMT, list, n_items);
+			if (Ctrl->Q.active) {
+				gmt_M_free (GMT, Out);
+				if (GMT_End_IO (API, GMT_OUT, 0) != GMT_NOERROR) {
+					Return (API->error);
+				}
+			}
 		}
 		if (!strncmp (Ctrl->D.dir, "all", 3U) || !strncmp (Ctrl->D.dir, "cache", 5U)) {	/* Want cache */
 			char line[GMT_LEN256] = {""}, hashpath[PATH_MAX] = {""};
@@ -245,7 +295,6 @@ EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 			}
 			fclose (fp);
 		}
-
 		Return (GMT_NOERROR);
 	}
 

--- a/src/gmtget.c
+++ b/src/gmtget.c
@@ -202,7 +202,7 @@ EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 	if (Ctrl->D.active) {	/* Data download */
 		if (!strncmp (Ctrl->D.dir, "all", 3U) || !strncmp (Ctrl->D.dir, "data", 4U)) {	/* Want data */
 			bool found;
-			unsigned int n_tiles, k, d = 0, t, n_items = 0;
+			unsigned int n_tiles, k, d = 0, t, n_items = 0, n;
 			char **list = NULL, *string = NULL, *token = NULL, *tofree = NULL;
 			char planet[GMT_LEN32] = {""}, group[GMT_LEN32] = {""}, dataset[GMT_LEN64] = {""}, size[GMT_LEN32] = {""}, message[GMT_LEN256] = {""};
 			double world[4] = {-180.0, +180.0, -90.0, +90.0};
@@ -247,13 +247,15 @@ EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 					if (dataset[strlen(dataset)-1] == '/') {	/* Tiles */
 						dataset[strlen(dataset)-1] = '\0';	/* Chop off slash */
 						strcpy (size, "N/A");
+						n = (API->remote_info[k].inc[2] == 's' && strchr ("13", API->remote_info[k].inc[1])) ? 14297 : urint (360.0 * 180.0 / (API->remote_info[k].tile_size * API->remote_info[k].tile_size));
 					}
 					else {
 						(void) gmt_chop_ext (dataset);
 						strcpy (size, API->remote_info[k].size);
+						n = 1;
 					}
 					message[0] = '\0';
-					sprintf (message, "%s\t%s\t%s\t%s\t%s", planet, group, dataset, size, API->remote_info[k].remark);
+					sprintf (message, "%s\t%s\t%s\t%s\t%u\t%s", planet, group, dataset, size, n, API->remote_info[k].remark);
 					GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 				}
 				else {


### PR DESCRIPTION
With **-Q**, no downloading takes place when **-D**  is given, and **-D** and **-I** can be used to limit what is shown.  We return one record with information about each dataset that passes the selection criteria.  Advanced users can use this option to script particular download requests via gmt which or gmt get.