### PR TITLE
Use temp grid if incoming grid does not have pad in gmt_grd_project

### DIFF
--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -7844,7 +7844,6 @@ int gmt_project_init (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, doub
 	return (GMT_NOERROR);
 }
 
-
 /*! . */
 int gmt_grd_project (struct GMT_CTRL *GMT, struct GMT_GRID *I, struct GMT_GRID *O, bool inverse) {
 	/* Generalized grid projection that deals with both interpolation and averaging effects.
@@ -7874,11 +7873,20 @@ int gmt_grd_project (struct GMT_CTRL *GMT, struct GMT_GRID *I, struct GMT_GRID *
 	double *x_in = NULL, *x_out = NULL, *x_in_proj = NULL, *x_out_proj = NULL;
 	double *y_in = NULL, *y_out = NULL, *y_in_proj = NULL, *y_out_proj = NULL;
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (I->header);
+	struct GMT_GRID *I2 = NULL;
 
-	/* Only input grid MUST have at least 2 rows/cols padding */
+	/* Only input grid MUST have at least 2 rows/cols padding - otherwise we must allocate a temp grid */
 	if (I->header->pad[XLO] < 2 || I->header->pad[XHI] < 2 || I->header->pad[YLO] < 2 || I->header->pad[YHI] < 2) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_grd_project: Input grid does not have sufficient (2) padding\n");
-		return GMT_RUNTIME_ERROR;
+		unsigned int pad2[4] = {2, 2, 2, 2};
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "gmt_grd_project: Input grid has no pad - create and work on a duplicate with pad\n");
+		if ((I2 = GMT_Duplicate_Data (GMT->parent, GMT_IS_GRID, GMT_DUPLICATE_DATA, I)) == NULL) {
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_grd_project: Unable to duplicate grid\n");
+			return GMT_RUNTIME_ERROR;
+		}	
+		gmt_grd_pad_on (GMT, I2, pad2);	/* Add pad */
+		gmt_BC_init (GMT, I2->header);	/* Initialize grid interpolation and boundary condition parameters */
+		gmt_grd_BC_set (GMT, I2, GMT_IN);	/* Set boundary conditions */
+		I = I2;	/* Use this input grid instead */
 	}
 
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "gmt_grd_project: In [%.12g/%.12g/%.12g/%.12g] and out [%.12g/%.12g/%.12g/%.12g]\n",
@@ -8050,6 +8058,10 @@ int gmt_grd_project (struct GMT_CTRL *GMT, struct GMT_GRID *I, struct GMT_GRID *
 	}
 	if (GMT->common.n.antialias) gmt_M_free (GMT, nz);
 
+	if (I2 && GMT_Destroy_Data (GMT->parent, &I2)) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_grd_project: Unable to free padded grid\n");
+		return GMT_RUNTIME_ERROR;		
+	}
 	return (GMT_NOERROR);
 }
 

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -8060,7 +8060,7 @@ int gmt_grd_project (struct GMT_CTRL *GMT, struct GMT_GRID *I, struct GMT_GRID *
 
 	if (I2 && GMT_Destroy_Data (GMT->parent, &I2)) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_grd_project: Unable to free padded grid\n");
-		return GMT_RUNTIME_ERROR;		
+		return GMT_RUNTIME_ERROR;
 	}
 	return (GMT_NOERROR);
 }

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -7878,7 +7878,7 @@ int gmt_grd_project (struct GMT_CTRL *GMT, struct GMT_GRID *I, struct GMT_GRID *
 	/* Only input grid MUST have at least 2 rows/cols padding - otherwise we must allocate a temp grid */
 	if (I->header->pad[XLO] < 2 || I->header->pad[XHI] < 2 || I->header->pad[YLO] < 2 || I->header->pad[YHI] < 2) {
 		unsigned int pad2[4] = {2, 2, 2, 2};
-		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "gmt_grd_project: Input grid has no pad - create and work on a duplicate with pad\n");
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "gmt_grd_project: Input grid has insufficient padding - create and work on a duplicate with r row/col pad\n");
 		if ((I2 = GMT_Duplicate_Data (GMT->parent, GMT_IS_GRID, GMT_DUPLICATE_DATA, I)) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_grd_project: Unable to duplicate grid\n");
 			return GMT_RUNTIME_ERROR;

--- a/src/testapi_matrix_plot.c
+++ b/src/testapi_matrix_plot.c
@@ -9,12 +9,12 @@ int main () {
 	char input[GMT_VF_LEN] = {""};	/* String to hold virtual input filename */
 	char args[128] = {""};         	/* String to hold module command arguments */
 	/* Initialize the GMT session */
-	API = GMT_Create_Session ("test", 2U, GMT_SESSION_EXTERNAL, NULL);
+	API = GMT_Create_Session ("test", 0U, GMT_SESSION_EXTERNAL, NULL);
 	M = GMT_Read_Data (API, GMT_IS_MATRIX, GMT_IS_FILE, GMT_IS_SURFACE, GMT_READ_NORMAL, NULL, "@matrix_grid.txt", NULL);
 	/* Associate our matrix with a virtual file */
-	GMT_Open_VirtualFile (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_IN, M, input);
+	GMT_Open_VirtualFile (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, M, input);
 	/* Prepare the module arguments */
-	sprintf (args, "%s -JX6i -P -Baf", input);
+	sprintf (args, "%s -JM6i -P -Baf -Ei -I+d", input);
 	/* Call the grdimage module */
 	GMT_Call_Module (API, "grdimage", GMT_MODULE_CMD, args);
 	/* Close the virtual file */

--- a/test/api/apimatgrd.ps
+++ b/test/api/apimatgrd.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_2c43c7c_2019.09.03 [64-bit] Document from grdimage
+%%Title: GMT v6.1.0_4aa1f4c-dirty_2020.06.27 [64-bit] Document from grdimage
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Tue Sep  3 16:41:10 2019
+%%CreationDate: Sat Jun 27 15:05:22 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -646,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -658,7 +659,8 @@ V 0.06 0.06 scale
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_plot_completion {} def
-/PSL_movie_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
@@ -667,201 +669,158 @@ O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: gmt grdimage @GMTAPI@-000000 -JX6i -P -Baf
-%@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
-%GMTBoundingBox: 72 72 432 432
+%@GMT: gmt grdimage @GMTAPI@-S-I-G-M-G-N-000000 -JM6i -P -Baf -Ei -I+d
+%@PROJ: merc 0.00000000 10.00000000 0.00000000 10.00000000 -556597.454 556597.454 -0.000 1111475.103 +proj=merc +lon_0=5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%GMTBoundingBox: 72 72 432 431.332591454
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 clipsave
 0 0 M
 7200 0 D
-0 7200 D
+0 7189 D
 -7200 0 D
 P
 PSL_clip N
-V N -360 -360 T 7920 7920 scale [/Indexed /DeviceRGB 42 <
-30123B455BCD3E9BFE18D6CB46F884A2FC3DE1DD37FEA632F05B12C426037A04034454C3448FFE20C7DF27EEA578FE5A
-BDF434EFCE3AFE972BEC540F424CB74682F82EB5F218DFBE94FF46CAED34F2C93A4146AB4775ED3AA2FC1DCCD920EAAC
-59FB739CFE403F3F9E4668DF3E3790477BF228BBEC3B3081392971362160341A4E>] setcolorspace
-<< /ImageType 1 /Decode [0 255] /Width 11 /Height 11 /BitsPerComponent 8
-   /ImageMatrix [11 0 0 -11 0 11] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+V N -360 -359 T 7920 7908 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Interpolate true /Decode [0 1 0 1 0 1] /Width 11 /Height 11 /BitsPerComponent 8
+   /ImageMatrix [11 0 0 -11 0 11] /DataSource currentfile /ASCII85Decode filter
 >> image
-G[<hT<<@gr!!U/.Qlm/Pa+>r/r=A+i1E_qP-r/2ALQI3>X1E"$BOa-\%qCf4R[80OIm]dBH"i]#q^TTO:ASTB0-^Ve%CKuL
-3%cTV.2Q2Bgqd^aB-Sjsq[/+JZlo.Vb,5Ka~>
+]U$aG]C<#Ts-3$=V#8-Urg3*@K`8o5oR]][4s,.V"h0Q3WNtiibl<acnqm+dXo=d<piZ2]B)\Sqlr=Y)+p,!(^S.ReUVZkf
+fD0CRfn'%#XoE@gmnE>o46M>B`CLB8I^k`5gmGGBLr]L&hWIf+^2Ek#Sc1mafI=h<,eS48SoV#mMp[ETmXMSB>K6=igsIP<
+UdsKOEmQ:o[i(a('pE4(IX&_TMVrB>p/Ish.(njZ`46T!M^#]24fol6T+ZfXQ#1$7AT#XnGiM8Fpb7Qe)j82NS#$F^K++/Y
+&X,=u7>+l<Pu(8W6r_&_=N`4!`una&(1sWXDjgrWM$8BQ?8HIh0m,Q2JMT'F.PmP;24baGS/")P&Nu<f6B2FDL.<Ce1E'"D
+**k*8B-eI6*Z/l4'lt!(F:T41%2s<r*-3eH4#%:11(HQ*$plcY6T#3=2$l]/#Y$]W7lCQA2?l\~>
 U
 PSL_cliprestore
 25 W
-2 setlinecap
-N 0 7200 M 0 -7200 D S
-/PSL_A0_y 83 def
-/PSL_A1_y 0 def
-8 W
-N 0 0 M -83 0 D S
-N 0 1440 M -83 0 D S
-N 0 2880 M -83 0 D S
-N 0 4320 M -83 0 D S
-N 0 5760 M -83 0 D S
-N 0 7200 M -83 0 D S
-/PSL_AH0 0
-/MM {neg exch M} def
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-(0) sw mx
-(2) sw mx
-(4) sw mx
-(6) sw mx
-(8) sw mx
-(10) sw mx
-def
-/PSL_A0_y PSL_A0_y 83 add def
-0 PSL_A0_y MM
-(0) mr Z
-1440 PSL_A0_y MM
-(2) mr Z
-2880 PSL_A0_y MM
-(4) mr Z
-4320 PSL_A0_y MM
-(6) mr Z
-5760 PSL_A0_y MM
-(8) mr Z
-7200 PSL_A0_y MM
-(10) mr Z
-/PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 0 720 M -42 0 D S
-N 0 2160 M -42 0 D S
-N 0 3600 M -42 0 D S
-N 0 5040 M -42 0 D S
-N 0 6480 M -42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-7200 0 T
-25 W
-N 0 7200 M 0 -7200 D S
-/PSL_A0_y 83 def
-/PSL_A1_y 0 def
-8 W
-N 0 0 M 83 0 D S
-N 0 1440 M 83 0 D S
-N 0 2880 M 83 0 D S
-N 0 4320 M 83 0 D S
-N 0 5760 M 83 0 D S
-N 0 7200 M 83 0 D S
-/PSL_AH0 0
-/MM {exch M} def
-(0) sw mx
-(2) sw mx
-(4) sw mx
-(6) sw mx
-(8) sw mx
-(10) sw mx
-def
-/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
-0 PSL_A0_y MM
-(0) mr Z
-1440 PSL_A0_y MM
-(2) mr Z
-2880 PSL_A0_y MM
-(4) mr Z
-4320 PSL_A0_y MM
-(6) mr Z
-5760 PSL_A0_y MM
-(8) mr Z
-7200 PSL_A0_y MM
-(10) mr Z
-N 0 720 M 42 0 D S
-N 0 2160 M 42 0 D S
-N 0 3600 M 42 0 D S
-N 0 5040 M 42 0 D S
-N 0 6480 M 42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--7200 0 T
-25 W
-N 0 0 M 7200 0 D S
-/PSL_A0_y 83 def
-/PSL_A1_y 0 def
 8 W
 N 0 0 M 0 -83 D S
+N 0 7189 M 0 83 D S
 N 1440 0 M 0 -83 D S
+N 1440 7189 M 0 83 D S
 N 2880 0 M 0 -83 D S
+N 2880 7189 M 0 83 D S
 N 4320 0 M 0 -83 D S
+N 4320 7189 M 0 83 D S
 N 5760 0 M 0 -83 D S
+N 5760 7189 M 0 83 D S
 N 7200 0 M 0 -83 D S
-/PSL_AH0 0
-/MM {neg M} def
-(0) sh mx
-(2) sh mx
-(4) sh mx
-(6) sh mx
-(8) sh mx
-(10) sh mx
-def
-/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
-0 PSL_A0_y MM
-(0) bc Z
-1440 PSL_A0_y MM
-(2) bc Z
-2880 PSL_A0_y MM
-(4) bc Z
-4320 PSL_A0_y MM
-(6) bc Z
-5760 PSL_A0_y MM
-(8) bc Z
-7200 PSL_A0_y MM
-(10) bc Z
-N 720 0 M 0 -42 D S
-N 2160 0 M 0 -42 D S
-N 3600 0 M 0 -42 D S
-N 5040 0 M 0 -42 D S
-N 6480 0 M 0 -42 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 7200 T
-25 W
-N 0 0 M 7200 0 D S
-/PSL_A0_y 83 def
-/PSL_A1_y 0 def
+N 7200 7189 M 0 83 D S
+N 0 0 M -83 0 D S
+N 7200 0 M 83 0 D S
+N 0 1431 M -83 0 D S
+N 7200 1431 M 83 0 D S
+N 0 2863 M -83 0 D S
+N 7200 2863 M 83 0 D S
+N 0 4299 M -83 0 D S
+N 7200 4299 M 83 0 D S
+N 0 5740 M -83 0 D S
+N 7200 5740 M 83 0 D S
+N 0 7189 M -83 0 D S
+N 7200 7189 M 83 0 D S
+83 W
+N -42 0 M 0 715 D S
+N 7242 0 M 0 715 D S
+1 A
+N -42 715 M 0 716 D S
+N 7242 715 M 0 716 D S
+0 A
+N -42 1431 M 0 716 D S
+N 7242 1431 M 0 716 D S
+1 A
+N -42 2147 M 0 716 D S
+N 7242 2147 M 0 716 D S
+0 A
+N -42 2863 M 0 718 D S
+N 7242 2863 M 0 718 D S
+1 A
+N -42 3581 M 0 718 D S
+N 7242 3581 M 0 718 D S
+0 A
+N -42 4299 M 0 720 D S
+N 7242 4299 M 0 720 D S
+1 A
+N -42 5019 M 0 721 D S
+N 7242 5019 M 0 721 D S
+0 A
+N -42 5740 M 0 724 D S
+N 7242 5740 M 0 724 D S
+1 A
+N -42 6464 M 0 725 D S
+N 7242 6464 M 0 725 D S
+0 A
+N 0 -42 M 720 0 D S
+N 0 7231 M 720 0 D S
+1 A
+N 720 -42 M 720 0 D S
+N 720 7231 M 720 0 D S
+0 A
+N 1440 -42 M 720 0 D S
+N 1440 7231 M 720 0 D S
+1 A
+N 2160 -42 M 720 0 D S
+N 2160 7231 M 720 0 D S
+0 A
+N 2880 -42 M 720 0 D S
+N 2880 7231 M 720 0 D S
+1 A
+N 3600 -42 M 720 0 D S
+N 3600 7231 M 720 0 D S
+0 A
+N 4320 -42 M 720 0 D S
+N 4320 7231 M 720 0 D S
+1 A
+N 5040 -42 M 720 0 D S
+N 5040 7231 M 720 0 D S
+0 A
+N 5760 -42 M 720 0 D S
+N 5760 7231 M 720 0 D S
+1 A
+N 6480 -42 M 720 0 D S
+N 6480 7231 M 720 0 D S
+0 A
 8 W
-N 0 0 M 0 83 D S
-N 1440 0 M 0 83 D S
-N 2880 0 M 0 83 D S
-N 4320 0 M 0 83 D S
-N 5760 0 M 0 83 D S
-N 7200 0 M 0 83 D S
-/PSL_AH0 0
-/MM {M} def
-(0) sh mx
-(2) sh mx
-(4) sh mx
-(6) sh mx
-(8) sh mx
-(10) sh mx
-def
-/PSL_A0_y PSL_A0_y 83 add def
-0 PSL_A0_y MM
-(0) bc Z
-1440 PSL_A0_y MM
-(2) bc Z
-2880 PSL_A0_y MM
-(4) bc Z
-4320 PSL_A0_y MM
-(6) bc Z
-5760 PSL_A0_y MM
-(8) bc Z
-7200 PSL_A0_y MM
-(10) bc Z
-/PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 720 0 M 0 42 D S
-N 2160 0 M 0 42 D S
-N 3600 0 M 0 42 D S
-N 5040 0 M 0 42 D S
-N 6480 0 M 0 42 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -7200 T
-0 setlinecap
+N -83 0 M 7366 0 D S
+N -83 -83 M 7366 0 D S
+N 7200 -83 M 0 7355 D S
+N 7283 -83 M 0 7355 D S
+N 7283 7189 M -7366 0 D S
+N 7283 7272 M -7366 0 D S
+N 0 7272 M 0 -7355 D S
+N -83 7272 M 0 -7355 D S
+0 -167 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0è) tc Z
+0 7356 M (0è) bc Z
+1440 -167 M (2è) tc Z
+1440 7356 M (2è) bc Z
+2880 -167 M (4è) tc Z
+2880 7356 M (4è) bc Z
+4320 -167 M (6è) tc Z
+4320 7356 M (6è) bc Z
+5760 -167 M (8è) tc Z
+5760 7356 M (8è) bc Z
+7200 -167 M (10è) tc Z
+7200 7356 M (10è) bc Z
+-167 0 M (0è) mr Z
+7367 0 M (0è) ml Z
+-167 1431 M (2è) mr Z
+7367 1431 M (2è) ml Z
+-167 2863 M (4è) mr Z
+7367 2863 M (4è) ml Z
+-167 4299 M (6è) mr Z
+7367 4299 M (6è) ml Z
+-167 5740 M (8è) mr Z
+7367 5740 M (8è) ml Z
+-167 7189 M (10è) mr Z
+7367 7189 M (10è) ml Z
 %%EndObject
 
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U


### PR DESCRIPTION
Rather than exiting we use a temp grid with padding and natural BCs on the edges.
Changed the teestapi_matrix_plot to set up a session with no pads then needing one in grdimage due to projection, hence PS update.