### PR TITLE
Use GMT_IS_REFERENCE for outputs in general

### DIFF
--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -1688,7 +1688,8 @@ compatible with the data type used by the modules then we could use your array d
 This *may* have the side-effect that your input array is modified by the module, especially
 if the module writes the results to a netCDF grid file.
 If that is a price you are willing to pay then you can add GMT_IS_REFERENCE to the ``direction``
-argument and we will pass the array internally to avoid duplicating memory.
+argument and we will pass the array internally to avoid duplicating memory. For output it is
+best to pass GMT_IS_REFERENCE as well.
 
 Import from a virtual file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/batch.c
+++ b/src/batch.c
@@ -622,7 +622,7 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 		else if (gmt_count_char (GMT, Ctrl->T.file, '/') == 2) {	/* Give a vector specification -Tmin/max/inc, call gmtmath to build the array */
 			char output[GMT_VF_LEN] = {""}, cmd[GMT_LEN128] = {""};
 			unsigned int V = GMT->current.setting.verbose;
-			if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_NONE, GMT_OUT, NULL, output) == GMT_NOTSET) {
+			if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_NONE, GMT_OUT|GMT_IS_REFERENCE, NULL, output) == GMT_NOTSET) {
 				Return (API->error);
 			}
 			if (GMT->common.f.active[GMT_IN])

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -5560,6 +5560,8 @@ GMT_LOCAL int gmtapi_export_grid (struct GMTAPI_CTRL *API, int object_ID, unsign
 			if (mode & GMT_CONTAINER_ONLY) return (gmtlib_report_error (API, GMT_NOT_A_VALID_MODE));
 			GMT_Report (API, GMT_MSG_INFORMATION, "Referencing grid data to GMT_GRID memory location\n");
 			gmt_grd_zminmax (GMT, G_obj->header, G_obj->data);	/* Must set zmin/zmax since we are not writing */
+			gmt_BC_init (GMT, G_obj->header);	/* Initialize grid interpolation and boundary condition parameters */
+			if (gmt_M_err_pass (GMT, gmt_grd_BC_set (GMT, G_obj, GMT_OUT), "Grid memory")) return (gmtlib_report_error (API, GMT_GRID_BC_ERROR));	/* Set boundary conditions */
 			S_obj->resource = G_obj;	/* Set resource pointer to the grid */
 			GH->alloc_level = S_obj->alloc_level;	/* Since we are passing it up to the caller */
 			break;
@@ -7390,10 +7392,6 @@ int GMT_Open_VirtualFile (void *V_API, unsigned int family, unsigned int geometr
 		readonly = true;
 		direction -= GMT_IS_REFERENCE;
 		the_mode = GMT_IS_REFERENCE;
-		if (direction == GMT_OUT) {
-			GMT_Report (API, GMT_MSG_ERROR, "GMT_Open_VirtualFile: GMT_IS_REFERENCE can only be added for inputs, not output files\n");
-			return_error (V_API, GMT_NOT_A_VALID_DIRECTION);
-		}
 	}
 	if (!(direction == GMT_IN || direction == GMT_OUT)) return GMT_NOT_A_VALID_DIRECTION;
 	if (direction == GMT_IN && data == NULL) return GMT_PTR_IS_NULL;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -878,7 +878,7 @@ GMT_LOCAL int gmtinit_rectR_to_geoR (struct GMT_CTRL *GMT, char unit, double rec
 	/* Register In as input virtual file and define an output virtual file */
 	if (GMT_Open_VirtualFile (GMT->parent, GMT_IS_DATASET, GMT_IS_POINT, GMT_IN|GMT_IS_REFERENCE, In, in_string) == GMT_NOTSET)
 		return (GMT->parent->error);
-	if (GMT_Open_VirtualFile (GMT->parent, GMT_IS_DATASET, GMT_IS_POINT, GMT_OUT, NULL, out_string) == GMT_NOTSET)
+	if (GMT_Open_VirtualFile (GMT->parent, GMT_IS_DATASET, GMT_IS_POINT, GMT_OUT|GMT_IS_REFERENCE, NULL, out_string) == GMT_NOTSET)
 		return (GMT->parent->error);
 
 	was_R = GMT->common.R.active[RSET];	was_J = GMT->common.J.active;
@@ -13066,7 +13066,7 @@ GMT_LOCAL int gmtinit_get_region_from_data (struct GMTAPI_CTRL *API, int family,
 				return API->error;	/* Failure to make new option -- or append to list */
 
 			/* Set up virtual file to hold the result of gmt info */
-			if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_POINT, GMT_OUT, NULL, virt_file) == GMT_NOTSET)
+			if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_POINT, GMT_OUT|GMT_IS_REFERENCE, NULL, virt_file) == GMT_NOTSET)
 				return (API->error);
 			if ((tmp = GMT_Make_Option (API, GMT_OPT_OUTFILE, virt_file)) == NULL || (head = GMT_Append_Option (API, tmp, head)) == NULL)
 		        return API->error;	/* Failure to make new output option or append to the list */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -2838,7 +2838,7 @@ GMT_LOCAL int gmtio_prep_ogr_output (struct GMT_CTRL *GMT, struct GMT_DATASET *D
 	if (GMT_Open_VirtualFile (GMT->parent, GMT_IS_DATASET, GMT_IS_POINT, GMT_IN|GMT_IS_REFERENCE, D, in_string) == GMT_NOTSET) {
 		return (GMT->parent->error);
 	}
-	if (GMT_Open_VirtualFile (GMT->parent, GMT_IS_DATASET, GMT_IS_POINT, GMT_OUT, NULL, out_string) == GMT_NOTSET) {
+	if (GMT_Open_VirtualFile (GMT->parent, GMT_IS_DATASET, GMT_IS_POINT, GMT_OUT|GMT_IS_REFERENCE, NULL, out_string) == GMT_NOTSET) {
 		return (GMT->parent->error);
 	}
 	snprintf (buffer, GMT_BUFSIZ, "-C -fg -<%s ->%s --GMT_HISTORY=false", in_string, out_string);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -1371,7 +1371,7 @@ struct GMT_GRID *gmtlib_assemble_tiles (struct GMTAPI_CTRL *API, double *region,
 		return NULL;
 	}
 
-	GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT, NULL, grid);
+	GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, grid);
 	/* Pass -N0 so that missing tiles (oceans) yield z = 0 and not NaN, and -Co+n to override using negative earth_relief_15s values */
 	snprintf (cmd, GMT_LEN256, "%s -R%.16g/%.16g/%.16g/%.16g -I%s -r%c -G%s -N0 -Co+n", file, wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI], API->remote_info[k_data].inc, API->remote_info[k_data].reg, grid);
 	if (GMT_Call_Module (API, "grdblend", GMT_MODULE_CMD, cmd) != GMT_NOERROR) {

--- a/src/grdfill.c
+++ b/src/grdfill.c
@@ -213,7 +213,7 @@ GMT_LOCAL int grdfill_do_splinefill (struct GMTAPI_CTRL *API, struct GMT_GRID *G
 		return (API->error);
 	}
 	/* Create a virtual file to hold the resampled grid */
-	if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT, NULL, output) == GMT_NOTSET) {
+	if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, output) == GMT_NOTSET) {
 		return (API->error);
 	}
 	/* Add up to 2 rows/cols around hole, but watch for grid edges */

--- a/src/grdfilter.c
+++ b/src/grdfilter.c
@@ -1343,7 +1343,7 @@ EXTERN_MSC int GMT_grdfilter (void *V_API, int mode, void *args) {
 				Return (API->error);
 			}
 			/* Create a virtual file to hold the resampled grid */
-			if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT, NULL, out_string) == GMT_NOTSET) {
+			if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, out_string) == GMT_NOTSET) {
 				Return (API->error);
 			}
 			sprintf (cmd, "%s -G%s -R%s -V%c", in_string, out_string, Ctrl->In.file, V_level[GMT->current.setting.verbose]);

--- a/src/grdfilter_mt.c
+++ b/src/grdfilter_mt.c
@@ -1014,7 +1014,7 @@ int GMT_grdfilter_mt (void *V_API, int mode, void *args)
 				Return (API->error);
 			}
 			/* Create a virtual file to hold the resampled grid */
-			if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT, NULL, out_string) == GMT_NOTSET) {
+			if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, out_string) == GMT_NOTSET) {
 				Return (API->error);
 			}
 			sprintf (cmd, "%s -G%s -R%s -V%d", in_string, out_string, Ctrl->In.file, GMT->current.setting.verbose);

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -846,7 +846,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 		char int_grd[GMT_VF_LEN] = {""};
 		GMT_Report (API, GMT_MSG_INFORMATION, "Derive intensity grid from data grid\n");
 		/* Create a virtual file to hold the intensity grid */
-		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT, NULL, int_grd))
+		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, int_grd))
 			Return (API->error);
 		/* Prepare the grdgradient arguments using selected -A -N and the data region in effect */
 		sprintf (cmd, "-G%s -A%s -N%s+a%s -R%.16g/%.16g/%.16g/%.16g --GMT_HISTORY=false ",
@@ -919,7 +919,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
     		/* Associate the intensity grid with an open virtual file - in_string will then hold the name of this input "file" */
     		GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, Intens_orig, in_string);
    			/* Create a virtual file to hold the resampled grid - out_string then holds the name of this output "file" */
-    		GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT, NULL, out_string);
+    		GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, out_string);
 			/* Create the command to do the resampling via the grdsample module */
 			sprintf (cmd, "%s -G%s -I%d+/%d+ --GMT_HISTORY=false", in_string, out_string, n_columns, n_rows);
 			GMT_Report (API, GMT_MSG_INFORMATION, "Calling grdsample with args %s\n", cmd);

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -538,7 +538,7 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 				sprintf (grid, "%s", Ctrl->In.file[k]);
 			else	/* Get the k'th layer from 3D cube */
 				sprintf (grid, "%s?%s[%" PRIu64 "]", Ctrl->In.file[0], cube_layer, k);
-			if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_POINT, GMT_OUT, NULL, o_file) == GMT_NOTSET) {
+			if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_POINT, GMT_OUT|GMT_IS_REFERENCE, NULL, o_file) == GMT_NOTSET) {
 				GMT_Report (API, GMT_MSG_ERROR, "Unable to create virtual dataset for time-series\n");
 				Return (API->error);
 			}
@@ -601,7 +601,7 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 				GMT_Report (API, GMT_MSG_ERROR, "Unable to create virtual dataset for sampled time-series\n");
 				Return (API->error);
 			}
-			if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_LINE, GMT_OUT, NULL, o_file) == GMT_NOTSET) {
+			if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_LINE, GMT_OUT|GMT_IS_REFERENCE, NULL, o_file) == GMT_NOTSET) {
 				GMT_Report (API, GMT_MSG_ERROR, "Unable to create virtual dataset for sampled time-series\n");
 				Return (API->error);
 			}

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -867,7 +867,7 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 		char int_grd[GMT_VF_LEN] = {""}, data_file[PATH_MAX] = {""}, cmd[GMT_LEN256] = {""};
 		GMT_Report (API, GMT_MSG_INFORMATION, "Derive intensity grid from data grid\n");
 		/* Create a virtual file to hold the intensity grid */
-		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT, NULL, int_grd))
+		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, int_grd))
 			Return (API->error);
 		if (Topo->data) {	/* If not NULL it means we have a tiled and blended grid, use as is */
 			if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, Topo, data_file))

--- a/src/img/img2grd.c
+++ b/src/img/img2grd.c
@@ -779,7 +779,7 @@ EXTERN_MSC int GMT_img2grd (void *V_API, int mode, void *args) {
 	/* b. If -E: Register a grid struct Geo to be the destination allocated and written to by GMT_grdproject, else write to -G<file> */
 	if (Ctrl->E.active) {	/* Since we will resample again, register a memory location for the result */
 		GMT_Report (API, GMT_MSG_DEBUG, "Register memory Grid container as grdproject output\n");
-		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT, NULL, output) != GMT_NOERROR) {
+		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, output) != GMT_NOERROR) {
 			Return (API->error);
 		}
 	}

--- a/src/movie.c
+++ b/src/movie.c
@@ -1492,7 +1492,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		else if (gmt_count_char (GMT, Ctrl->T.file, '/') == 2) {	/* Give a vector specification -Tmin/max/inc, call gmtmath */
 			char output[GMT_VF_LEN] = {""}, cmd[GMT_LEN128] = {""};
 			unsigned int V = GMT->current.setting.verbose;
-			if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_NONE, GMT_OUT, NULL, output) == GMT_NOTSET) {
+			if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_NONE, GMT_OUT|GMT_IS_REFERENCE, NULL, output) == GMT_NOTSET) {
 				Return (API->error);
 			}
 			if (GMT->common.f.active[GMT_IN])

--- a/src/surface.c
+++ b/src/surface.c
@@ -2104,7 +2104,7 @@ EXTERN_MSC int GMT_surface (void *V_API, int mode, void *args) {
 			Return (API->error);
 		}
 		/* Create a virtual file to hold the mask grid */
-		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT, NULL, mask) == GMT_NOTSET) {
+		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, mask) == GMT_NOTSET) {
 			Return (API->error);
 		}
 		sprintf (cmd, "%s -G%s -R%g/%g/%g/%g -I%g/%g -NNaN/1/1 -S%s -V%c --GMT_HISTORY=false",

--- a/src/surface_experimental.c
+++ b/src/surface_experimental.c
@@ -2454,7 +2454,7 @@ int GMT_surface_mt (void *V_API, int mode, void *args) {
 			Return (API->error);
 		}
 		/* Create a virtual file to hold the mask grid */
-		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT, NULL, mask) == GMT_NOTSET) {
+		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, mask) == GMT_NOTSET) {
 			Return (API->error);
 		}
 		sprintf (cmd, "%s -G%s -R%g/%g/%g/%g -I%g/%g -NNaN/1/1 -S%s -V%c --GMT_HISTORY=false", input, mask, wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI],

--- a/src/test_JL.c
+++ b/src/test_JL.c
@@ -19,7 +19,7 @@ int main () {
     /* Associate our data table with a virtual file */
     GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_PLP, GMT_IN, V[GMT_IN], input);
     /* Create a virtual file to hold the sampled points */
-    GMT_Open_VirtualFile (API, GMT_IS_VECTOR, GMT_IS_PLP, GMT_OUT, NULL, output);
+    GMT_Open_VirtualFile (API, GMT_IS_VECTOR, GMT_IS_PLP, GMT_OUT|GMT_IS_REFERENCE, NULL, output);
     /* Prepare the module arguments */
     sprintf (args, "-sa %s -Gtopo.nc ->%s", input, output);
     /* Call the grdtrack module */
@@ -37,7 +37,7 @@ int main () {
     /* Associate our data table with a virtual file */
     GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_PLP, GMT_IN, M[GMT_IN], input);
     /* Create a virtual file to hold the sampled points */
-    GMT_Open_VirtualFile (API, GMT_IS_MATRIX, GMT_IS_PLP, GMT_OUT, NULL, output);
+    GMT_Open_VirtualFile (API, GMT_IS_MATRIX, GMT_IS_PLP, GMT_OUT|GMT_IS_REFERENCE, NULL, output);
     /* Prepare the module arguments */
     sprintf (args, "-sa %s -Gtopo.nc ->%s", input, output);
     /* Call the grdtrack module */

--- a/src/test_example1.c
+++ b/src/test_example1.c
@@ -15,7 +15,7 @@ int main () {
     /* Associate our data table with a virtual file */
     GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_PLP, GMT_IN, D, input);
     /* Create a virtual file to hold the resulting grid */
-    GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT, NULL, output);
+    GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, output);
     /* Prepare the module arguments */
     sprintf (args, "-R0/7/0/7 -I0.2 -D1 -St0.3 %s -G%s", input, output);
     /* Call the greenspline module */

--- a/src/testapi_matrix.c
+++ b/src/testapi_matrix.c
@@ -15,7 +15,7 @@ int main () {
 	/* Associate our data table with a virtual file */
 	GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_MATRIX, GMT_IS_PLP, GMT_IN, M[GMT_IN], input);
 	/* Open a virtual file to hold the sampled points */
-	GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_IS_MATRIX, GMT_IS_PLP, GMT_OUT, NULL, output);
+	GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_IS_MATRIX, GMT_IS_PLP, GMT_OUT|GMT_IS_REFERENCE, NULL, output);
 	/* Prepare the module arguments */
 	sprintf (args, "-sa %s -Gtopo.nc ->%s", input, output);
 	/* Call the grdtrack module */

--- a/src/testapi_userdataset.c
+++ b/src/testapi_userdataset.c
@@ -198,7 +198,7 @@ int deploy_test (unsigned int intype, unsigned int outtype, int alloc_in_GMT, in
 	/* Associate our matrix container with a virtual dataset file to "read" from */
 	GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_MATRIX, GMT_IS_POINT, GMT_IN|GMT_IS_REFERENCE, M[GMT_IN], input);
 	if (alloc_in_GMT)	/* Request matrix container for output data to be allocated by GMT */
-	    GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_MATRIX, out_via, GMT_OUT, NULL, output);
+	    GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_MATRIX, out_via, GMT_OUT|GMT_IS_REFERENCE, NULL, output);
 	else {	/* Preallocate array space here in the app */
 		out_data = get_array (outtype, 0);	/* Make user space for output */
  		/* Create a blank matrix container that will hold our user out_data, but pass dimensions so we know */

--- a/src/testapi_usergrid.c
+++ b/src/testapi_usergrid.c
@@ -216,7 +216,7 @@ int deploy_test (unsigned int intype, unsigned int outtype, int alloc_in_GMT, in
 	/* Associate our matrix container with a virtual grid file to "read" from via duplication */
 	GMT_Open_VirtualFile (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_IN, M[GMT_IN], input);
 	if (alloc_in_GMT)	/* Request matrix container for output data to be allocated by GMT */
-	    GMT_Open_VirtualFile (API, GMT_IS_GRID|GMT_VIA_MATRIX, out_via, GMT_OUT, NULL, output);
+	    GMT_Open_VirtualFile (API, GMT_IS_GRID|GMT_VIA_MATRIX, out_via, GMT_OUT|GMT_IS_REFERENCE, NULL, output);
 	else {	/* Preallocate array space here in the app */
 		out_data = get_array (outtype, 0);	/* Make user space for output */
  		/* Create a blank matrix container that will hold our user out_data, but pass dim so it can set the dimensions */

--- a/src/testapi_uservectors.c
+++ b/src/testapi_uservectors.c
@@ -222,7 +222,7 @@ int deploy_test (unsigned int intype, unsigned int outtype, int alloc_in_GMT, in
 	/* Associate our vectors container with a virtual dataset file to "read" from */
 	GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_VECTOR, GMT_IS_POINT, GMT_IN|GMT_IS_REFERENCE, V[GMT_IN], input);
 	if (alloc_in_GMT)	/* Request vectors container for output data to be allocated by GMT */
-		GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_VECTOR, out_via, GMT_OUT, NULL, output);
+		GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_VECTOR, out_via, GMT_OUT|GMT_IS_REFERENCE, NULL, output);
 	else {	/* Preallocate array space here in the app */
 		out_data[GMT_X] = get_array (outtype, 0);	/* Make user space for output */
 		out_data[GMT_Y] = get_array (outtype, 0);	/* Make user space for output */

--- a/src/testapi_vector.c
+++ b/src/testapi_vector.c
@@ -18,7 +18,7 @@ int main () {
 	/* Associate our data table with a virtual file */
 	GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_VECTOR, GMT_IS_PLP, GMT_IN, V[GMT_IN], input);
 	/* Create a virtual file to hold the sampled points */
-	GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_VECTOR, GMT_IS_PLP, GMT_OUT, NULL, output);
+	GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_VECTOR, GMT_IS_PLP, GMT_OUT|GMT_IS_REFERENCE, NULL, output);
 	/* Prepare the module arguments */
 	sprintf (args, "-sa %s -Gtopo.nc ->%s", input, output);
 	/* Call the grdtrack module */

--- a/src/testpsl.c
+++ b/src/testpsl.c
@@ -37,7 +37,7 @@ int main () {
 	if ((API = GMT_Create_Session ("PSLTEST", GMT_NOTSET, GMT_SESSION_NORMAL, NULL)) == NULL) exit (EXIT_FAILURE);
 
 	/* 2. Create a virtual file to be the destination allocated and written to by pscoast */
-	if (GMT_Open_VirtualFile (API, GMT_IS_POSTSCRIPT, GMT_IS_NONE, GMT_OUT, NULL, string) != GMT_NOERROR) exit (EXIT_FAILURE);
+	if (GMT_Open_VirtualFile (API, GMT_IS_POSTSCRIPT, GMT_IS_NONE, GMT_OUT|GMT_IS_REFERENCE, NULL, string) != GMT_NOERROR) exit (EXIT_FAILURE);
 	sprintf (cmd, "-R0/20/0/20 -JM6i -P -Gred -K > %s", string);			/* Create command for pscoast */
 
 	/* 3. Run GMT cmd function, or give usage message if errors arise during parsing */


### PR DESCRIPTION
This is the other shoe dropping.  Earlier, after fixing the virtual file system and dealing properly with **GMT_IS_REFERENCE** and **GMT_IS_DUPLICATE**, we realized most/all places inside GMT should use **GMT_IN**|**GMT_IS_REFERENCE** when passing data to other modules.   We can do this since we control the information.  Of course, there are plenty of places where we expect to return data from those modules, and prior to the fixes the **GMT_OUT** simply gave us **GMT_IS_REFERENCE** by default.  Now it takes **GMT_OUT**|**GMT_IS_REFERENCE** to simply pass out the internally allocated item.

Looks like all tests still pass. May need to check if all is will in pyGMT for this as well, @seisman.