### PR TITLE
Make sure we only try to download input files

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -2478,7 +2478,9 @@ GMT_LOCAL int gmtapi_next_io_source (struct GMTAPI_CTRL *API, unsigned int direc
 		case GMT_IS_FILE:	/* Filename given; we must open the file here */
 			assert (S_obj->filename != NULL);
 			if (S_obj->family == GMT_IS_GRID || S_obj->family == GMT_IS_IMAGE) return (gmtlib_report_error (API, GMT_NOT_A_VALID_FAMILY));	/* Grids or images not allowed here */
-			first = gmt_download_file_if_not_found (API->GMT, S_obj->filename, 0);	/* Deal with downloadable GMT data sets first */
+			if (direction == GMT_IN) {
+				first = gmt_download_file_if_not_found (API->GMT, S_obj->filename, 0);	/* Deal with downloadable GMT data sets first */
+			}
 			if (direction == GMT_OUT && S_obj->filename[0] == '>') {
 				mode = GMT->current.io.a_mode;	/* Must append to an existing file (we have already checked the file exists) */
 				first = 1;


### PR DESCRIPTION
In _gmtapi_next_io_source_ we call _gmt_download_file_if_not_found_ wihtout checking if it is an input file first.  Not sure if this is causing any problems but now isolated inside an if-test.  Addresses the issue in #3532.