### PR TITLE
Fix crash for grdimage from MATLAB and silly -O warning

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -7656,7 +7656,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 	}
 	else if ((Out = GMT_Find_Option (GMT->parent, '>', options))) {	/* Want to use a specific output file */
 		k = (Out->arg[0] == '>') ? 1 : 0;	/* Are we appending (k = 1) or starting a new file (k = 0) */
-		if (O_active && k == 0) {
+		if (O_active && k == 0 && !gmt_M_file_is_memory (Out->arg)) {
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "-O given but append-mode not selected for file %s\n", &(Out->arg[k]));
 		}
 		if (gmt_M_file_is_memory (&(Out->arg[k]))) {

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1414,16 +1414,16 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 	}
 
 	for (k = 0; k < n_grids; k++) {	/* If memory grids are passed in we must restore the headers */
-		if (mem_G[k] && Grid_orig[k]) {
+		if (mem_G[k] && Grid_orig[k] && header_G[k]) {
 			gmt_copy_gridheader (GMT, Grid_orig[k]->header, header_G[k]);
 			gmt_free_header (API->GMT, &header_G[k]);
 		}
 	}
-	if (mem_I && Intens_orig) {
+	if (mem_I && Intens_orig && header_I) {
 		gmt_copy_gridheader (GMT, Intens_orig->header, header_I);
 		gmt_free_header (API->GMT, &header_I);
 	}
-	if (mem_D && I) {
+	if (mem_D && I && header_D) {
 		gmt_copy_gridheader (GMT, I->header, header_D);
 		gmt_free_header (API->GMT, &header_D);
 	}


### PR DESCRIPTION
Two problems crashing grdimage calls and unwanted warnings from GMT?MEX:

1. We passed NULL as a header to _gmt_copy_gridheader_ at the end of **grdimage**, leading to crash.  Now checking that all the items are available. 
2. Also, if output _PostScript_ file is a memory file then it won't have a leading '>' letter like regular append files, so prevent those types of warnings.

With these fixes I think most Mex examples are running - on to the next.  All mex_test_?.m are working.