### PR TITLE
Recognize GDAL netCDF layers

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -13490,7 +13490,7 @@ int GMT_Extract_Region (void *V_API, char *file, double wesn[]) {
 }
 
 float GMT_Get_Version (void *API, unsigned int *major, unsigned int *minor, unsigned int *patch) {
-	/* Return the current lib version as a float, e.g. 6.0, and optionally its constituints.
+	/* Return the current lib version as a float, e.g. 6.0, and optionally its constituents.
 	 * Either one or all of in *major, *minor, *patch args can be NULL. If they are not, one
 	 * gets the corresponding version component. */
 	int major_loc, minor_loc, patch_loc;

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -902,7 +902,10 @@ not_local:	/* Get here if we failed to find a remote file already on disk */
 	is_url = (gmt_M_file_is_url (file));	/* A remote file or query given via an URL */
 	is_query = (gmt_M_file_is_query (file));	/* A remote file or query given via an URL */
 
-	if ((c = strchr (file, '?')) && !strchr (file, '=')) {	/* Must be a netCDF sliced URL file so chop off the layer/variable specifications */
+	if (strchr (file, '?') && (c = strstr (file, "=gd"))) {	/* Must be a netCDF sliced file to be read via GDAL so chop off the =gd?layer/variable specifications */
+		was = c[0]; c[0] = '\0';
+	}
+	else if ((c = strchr (file, '?')) && !strchr (file, '=')) {	/* Must be a netCDF sliced URL file so chop off the layer/variable specifications */
 		was = c[0]; c[0] = '\0';
 	}
 	else if (c == NULL && (c = strchr (file, '='))) {	/* If no ? then = means grid attributes (e.g., =bf) */


### PR DESCRIPTION
**Description of proposed changes**

The major rewrite of all things remote failed to detect the special case of a local netCDF file with a specific layer that we wish to pass to GDAL.  An example of such a file name is

`A2016152023000.L2_LAC_SST.nc=gd?HDF5:A2016152023000.L2_LAC_SST.nc://geophysical_data/sst`

This PR reinstate this capability.  With the resulting library (and separate updates to GMTMEX), all the GMT mex tests and examples work (again).
