### PR TITLE
Let the auto-determined region be consistent

### DIFF
--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -345,7 +345,7 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 			    "Must specify -I if input grids have different increments\n");
 		if (!common_reg)
 			GMT_Report (GMT->parent, GMT_MSG_WARNING,
-			    "Must specify -I and -r if input grids have different increments and/or registrations\n");
+			    "Must specify -r if input grids have different registrations\n");
 		if (!common_inc || !common_reg)
 			return (-GMT_RUNTIME_ERROR);
 		/* While the inc may be fixed, our wesn may not be in phase, so since gmt_set_grddim

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -337,11 +337,18 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 	gmt_M_free (GMT, L);	/* Done with this now */
 
 	if (h == NULL) {	/* Must use the common region from the tiles */
+		uint64_t pp;
 		if (!common_inc) {
 			GMT_Report (GMT->parent, GMT_MSG_WARNING,
 			            "Must specify -I if input grids have different increments\n");
 			return (-GMT_RUNTIME_ERROR);
 		}
+		/* While the inc may be fixed, our wesn may not be in phase, so since gmt_set_grddim
+		 * will plow through and modify inc if it does not fit, we don't want that here. */
+		pp = (uint64_t)ceil ((wesn[XHI] - wesn[XLO])/B[0].G->header->inc[GMT_X] - GMT_CONV6_LIMIT);
+		wesn[XHI] = wesn[XLO] + pp * B[0].G->header->inc[GMT_X];
+		pp = (uint64_t)ceil ((wesn[YHI] - wesn[YLO])/B[0].G->header->inc[GMT_Y] - GMT_CONV6_LIMIT);
+		wesn[YHI] = wesn[YLO] + pp * B[0].G->header->inc[GMT_Y];
 		/* Create the h structure and initialize it */
 		h = gmt_get_header (GMT);
 		gmt_M_memcpy (h->wesn, wesn, 4, double);

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -362,6 +362,8 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 		gmt_M_grd_setpad (GMT, h, GMT->current.io.pad); /* Assign default pad */
 		gmt_set_grddim (GMT, h);	/* Update dimensions */
 		*h_ptr = h;			/* Pass out the updated settings */
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION,
+			"We determined the region %.12g/%.12g/%.12g/%.12g from the given grids", h->wesn[XLO], h->wesn[XHI], h->wesn[YLO], h->wesn[YHI]);
 	}
 
 	HH = gmt_get_H_hidden (h);

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -194,7 +194,7 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 	/* Returns how many blend files or a negative error value if something went wrong */
 	int type, status, not_supported = 0, t_data, k_data = GMT_NOTSET;
 	unsigned int one_or_zero, n = 0, nr, do_sample, n_download = 0, down = 0, srtm_res = 0;
-	bool srtm_job = false, common_inc = true;
+	bool srtm_job = false, common_inc = true, common_reg = true;
 	struct GRDBLEND_INFO *B = NULL;
 	struct GMT_GRID_HEADER *h = *h_ptr;	/* Input header may be NULL or preset */
 	struct GMT_GRID_HIDDEN *GH = NULL;
@@ -330,6 +330,8 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 					fabs((B[n].G->header->inc[GMT_Y] - B[0].G->header->inc[GMT_Y]) / B[0].G->header->inc[GMT_Y]) > 0.002)
 						common_inc = false;
 			}
+			if (B[n].G->header->registration != B[0].G->header->registration)
+				common_reg = false;
 		}
 		gmt_M_str_free (L[n].file);	/* Done with these now */
 		gmt_M_str_free (L[n].region);
@@ -338,9 +340,9 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 
 	if (h == NULL) {	/* Must use the common region from the tiles */
 		uint64_t pp;
-		if (!common_inc) {
+		if (!common_inc || !common_reg) {
 			GMT_Report (GMT->parent, GMT_MSG_WARNING,
-			            "Must specify -I if input grids have different increments\n");
+			    "Must specify -I and -r if input grids have different increments and/or registrations\n");
 			return (-GMT_RUNTIME_ERROR);
 		}
 		/* While the inc may be fixed, our wesn may not be in phase, so since gmt_set_grddim

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -340,11 +340,14 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 
 	if (h == NULL) {	/* Must use the common region from the tiles */
 		uint64_t pp;
-		if (!common_inc || !common_reg) {
+		if (!common_inc)
+			GMT_Report (GMT->parent, GMT_MSG_WARNING,
+			    "Must specify -I if input grids have different increments\n");
+		if (!common_reg)
 			GMT_Report (GMT->parent, GMT_MSG_WARNING,
 			    "Must specify -I and -r if input grids have different increments and/or registrations\n");
+		if (!common_inc || !common_reg)
 			return (-GMT_RUNTIME_ERROR);
-		}
 		/* While the inc may be fixed, our wesn may not be in phase, so since gmt_set_grddim
 		 * will plow through and modify inc if it does not fit, we don't want that here. */
 		pp = (uint64_t)ceil ((wesn[XHI] - wesn[XLO])/B[0].G->header->inc[GMT_X] - GMT_CONV6_LIMIT);


### PR DESCRIPTION
When no **-R -I -r** is given we determine the max extent wesn of all input grids, and if all grids have the same inc we can create a common output grid region and use that inc.  However, we had no defense against these different wesn being phase-shifted.  Now, we ensure that the region we select has an integer number of steps in dx, dy between min and max for both dimensions.  Also, there was no check to determine if all input grids have the same registration. To use the determined wesn we must have the same registration and increment, and we adjust wesn to be consistent.  Otherwise, the user has to provide that information.

This is just a part of the problem reported on the [forum](https://forum.generic-mapping-tools.org/t/grdblend-problem/564/3) but is not the cause of the crash.

