### PR TITLE
Make sure grdsample is careful about input and output regions

### DIFF
--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -395,12 +395,16 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 			unsigned int k;
 			k = (unsigned int)rint ((MAX (h->wesn[XLO], B[n].G->header->wesn[XLO]) - h->wesn[XLO]) / h->inc[GMT_X] - h->xy_off);
 			wesn[XLO] = gmt_M_grd_col_to_x (GMT, k, h);
+			while (wesn[XLO] < B[n].G->header->wesn[XLO]) wesn[XLO] += h->inc[GMT_X];	/* Make sure we are not outside this grid */
 			k = (unsigned int)rint  ((MIN (h->wesn[XHI], B[n].G->header->wesn[XHI]) - h->wesn[XLO]) / h->inc[GMT_X] - h->xy_off);
 			wesn[XHI] = gmt_M_grd_col_to_x (GMT, k, h);
+			while (wesn[XHI] > B[n].G->header->wesn[XHI]) wesn[XHI] -= h->inc[GMT_X];	/* Make sure we are not outside this grid */
 			k = h->n_rows - 1 - (unsigned int)rint ((MAX (h->wesn[YLO], B[n].G->header->wesn[YLO]) - h->wesn[YLO]) / h->inc[GMT_Y] - h->xy_off);
 			wesn[YLO] = gmt_M_grd_row_to_y (GMT, k, h);
+			while (wesn[YLO] < B[n].G->header->wesn[YLO]) wesn[YLO] += h->inc[GMT_Y];	/* Make sure we are not outside this grid */
 			k = h->n_rows - 1 - (unsigned int)rint  ((MIN (h->wesn[YHI], B[n].G->header->wesn[YHI]) - h->wesn[YLO]) / h->inc[GMT_Y] - h->xy_off);
 			wesn[YHI] = gmt_M_grd_row_to_y (GMT, k, h);
+			while (wesn[YHI] > B[n].G->header->wesn[YHI]) wesn[YHI] -= h->inc[GMT_Y];	/* Make sure we are not outside this grid */
 			sprintf (Rargs, "-R%.12g/%.12g/%.12g/%.12g", wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI]);
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "File %s coordinates are phase-shifted w.r.t. the output grid - must resample\n", B[n].file);
 			do_sample |= 1;

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -408,7 +408,7 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 			double wesn[4];	/* Make sure wesn is equal to or larger than B[n].G->header->wesn so all points are included */
 			unsigned int k;
 			/* The goal below is to come up with a wesn that a proper subset of the output grid while still not
-			 * exceeding the bounds of the current tile grid. Th wesn below will be compatible with the output grid
+			 * exceeding the bounds of the current tile grid. The wesn below will be compatible with the output grid
 			 * but is not compatible with the input grid.  grdsample will make the adjustment */
 			k = (unsigned int)rint ((MAX (h->wesn[XLO], t->wesn[XLO]) - h->wesn[XLO]) / h->inc[GMT_X] - h->xy_off);
 			wesn[XLO] = h->wesn[XLO] + k * h->inc[GMT_X];

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -341,11 +341,9 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 	if (h == NULL) {	/* Must use the common region from the tiles */
 		uint64_t pp;
 		if (!common_inc)
-			GMT_Report (GMT->parent, GMT_MSG_WARNING,
-			    "Must specify -I if input grids have different increments\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Must specify -I if input grids have different increments\n");
 		if (!common_reg)
-			GMT_Report (GMT->parent, GMT_MSG_WARNING,
-			    "Must specify -r if input grids have different registrations\n");
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Must specify -r if input grids have different registrations\n");
 		if (!common_inc || !common_reg)
 			return (-GMT_RUNTIME_ERROR);
 		/* While the inc may be fixed, our wesn may not be in phase, so since gmt_set_grddim
@@ -363,13 +361,15 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 		gmt_set_grddim (GMT, h);	/* Update dimensions */
 		*h_ptr = h;			/* Pass out the updated settings */
 		GMT_Report (GMT->parent, GMT_MSG_INFORMATION,
-			"We determined the region %.12g/%.12g/%.12g/%.12g from the given grids", h->wesn[XLO], h->wesn[XHI], h->wesn[YLO], h->wesn[YHI]);
+			"We determined the region %.12g/%.12g/%.12g/%.12g from the given grids\n", h->wesn[XLO], h->wesn[XHI], h->wesn[YLO], h->wesn[YHI]);
 	}
 
 	HH = gmt_get_H_hidden (h);
 	one_or_zero = !h->registration;
 
 	for (n = 0; n < n_files; n++) {	/* Process each input grid */
+		struct GMT_GRID_HEADER *t = B[n].G->header;	/* Shortcut for this tile header */
+
 		/* Skip the file if its outer region does not lie within the final grid region */
 		if (h->wesn[YLO] > B[n].wesn[YHI] || h->wesn[YHI] < B[n].wesn[YLO]) {
 			GMT_Report (GMT->parent, GMT_MSG_WARNING,
@@ -397,28 +397,31 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 			            "File %s not supported via row-by-row read - must reformat first\n", B[n].file);
 			do_sample |= 2;
 		}
-		if (fabs((B[n].G->header->inc[GMT_X] - h->inc[GMT_X]) / h->inc[GMT_X]) > 0.002 ||
-			fabs((B[n].G->header->inc[GMT_Y] - h->inc[GMT_Y]) / h->inc[GMT_Y]) > 0.002) {
+		if (fabs((t->inc[GMT_X] - h->inc[GMT_X]) / h->inc[GMT_X]) > 0.002 ||
+			fabs((t->inc[GMT_Y] - h->inc[GMT_Y]) / h->inc[GMT_Y]) > 0.002) {
 			sprintf (Iargs, "-I%.12g/%.12g", h->inc[GMT_X], h->inc[GMT_Y]);
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "File %s has different increments (%.12g/%.12g) than the output grid (%.12g/%.12g) - must resample\n",
-				B[n].file, B[n].G->header->inc[GMT_X], B[n].G->header->inc[GMT_Y], h->inc[GMT_X], h->inc[GMT_Y]);
+				B[n].file, t->inc[GMT_X], t->inc[GMT_Y], h->inc[GMT_X], h->inc[GMT_Y]);
 			do_sample |= 1;
 		}
-		if (grdblend_out_of_phase (B[n].G->header, h)) {	/* Set explicit -R for resampling that is multiple of desired increments AND inside both original grid and desired grid */
+		if (grdblend_out_of_phase (t, h)) {	/* Set explicit -R for resampling that is multiple of desired increments AND inside both original grid and desired grid */
 			double wesn[4];	/* Make sure wesn is equal to or larger than B[n].G->header->wesn so all points are included */
 			unsigned int k;
-			k = (unsigned int)rint ((MAX (h->wesn[XLO], B[n].G->header->wesn[XLO]) - h->wesn[XLO]) / h->inc[GMT_X] - h->xy_off);
-			wesn[XLO] = gmt_M_grd_col_to_x (GMT, k, h);
-			while (wesn[XLO] < B[n].G->header->wesn[XLO]) wesn[XLO] += h->inc[GMT_X];	/* Make sure we are not outside this grid */
-			k = (unsigned int)rint  ((MIN (h->wesn[XHI], B[n].G->header->wesn[XHI]) - h->wesn[XLO]) / h->inc[GMT_X] - h->xy_off);
-			wesn[XHI] = gmt_M_grd_col_to_x (GMT, k, h);
-			while (wesn[XHI] > B[n].G->header->wesn[XHI]) wesn[XHI] -= h->inc[GMT_X];	/* Make sure we are not outside this grid */
-			k = h->n_rows - 1 - (unsigned int)rint ((MAX (h->wesn[YLO], B[n].G->header->wesn[YLO]) - h->wesn[YLO]) / h->inc[GMT_Y] - h->xy_off);
-			wesn[YLO] = gmt_M_grd_row_to_y (GMT, k, h);
-			while (wesn[YLO] < B[n].G->header->wesn[YLO]) wesn[YLO] += h->inc[GMT_Y];	/* Make sure we are not outside this grid */
-			k = h->n_rows - 1 - (unsigned int)rint  ((MIN (h->wesn[YHI], B[n].G->header->wesn[YHI]) - h->wesn[YLO]) / h->inc[GMT_Y] - h->xy_off);
-			wesn[YHI] = gmt_M_grd_row_to_y (GMT, k, h);
-			while (wesn[YHI] > B[n].G->header->wesn[YHI]) wesn[YHI] -= h->inc[GMT_Y];	/* Make sure we are not outside this grid */
+			/* The goal below is to come up with a wesn that a proper subset of the output grid while still not
+			 * exceeding the bounds of the current tile grid. Th wesn below will be compatible with the output grid
+			 * but is not compatible with the input grid.  grdsample will make the adjustment */
+			k = (unsigned int)rint ((MAX (h->wesn[XLO], t->wesn[XLO]) - h->wesn[XLO]) / h->inc[GMT_X] - h->xy_off);
+			wesn[XLO] = h->wesn[XLO] + k * h->inc[GMT_X];
+			while (wesn[XLO] < t->wesn[XLO]) wesn[XLO] += t->inc[GMT_X];	/* Make sure we are not outside this grid */
+			k = (unsigned int)rint ((MIN (h->wesn[XHI], t->wesn[XHI]) - h->wesn[XLO]) / h->inc[GMT_X] - h->xy_off);
+			wesn[XHI] = h->wesn[XLO] + k * h->inc[GMT_X];
+			while (wesn[XHI] > t->wesn[XHI]) wesn[XHI] -= t->inc[GMT_X];	/* Make sure we are not outside this grid */
+			k = (unsigned int)rint ((MAX (h->wesn[YLO], t->wesn[YLO]) - h->wesn[YLO]) / h->inc[GMT_Y] - h->xy_off);
+			wesn[YLO] = h->wesn[YLO] + k * h->inc[GMT_Y];
+			while (wesn[YLO] < t->wesn[YLO]) wesn[YLO] += t->inc[GMT_Y];	/* Make sure we are not outside this grid */
+			k = (unsigned int)rint  ((MIN (h->wesn[YHI], t->wesn[YHI]) - h->wesn[YLO]) / h->inc[GMT_Y] - h->xy_off);
+			wesn[YHI] = h->wesn[YLO] + k * h->inc[GMT_Y];
+			while (wesn[YHI] > t->wesn[YHI]) wesn[YHI] -= t->inc[GMT_Y];	/* Make sure we are not outside this grid */
 			sprintf (Rargs, "-R%.12g/%.12g/%.12g/%.12g", wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI]);
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "File %s coordinates are phase-shifted w.r.t. the output grid - must resample\n", B[n].file);
 			do_sample |= 1;
@@ -426,10 +429,10 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 		else if (do_sample) {	/* Set explicit -R to handle possible subsetting */
 			double wesn[4];
 			gmt_M_memcpy (wesn, h->wesn, 4, double);
-			if (wesn[XLO] < B[n].G->header->wesn[XLO]) wesn[XLO] = B[n].G->header->wesn[XLO];
-			if (wesn[XHI] > B[n].G->header->wesn[XHI]) wesn[XHI] = B[n].G->header->wesn[XHI];
-			if (wesn[YLO] < B[n].G->header->wesn[YLO]) wesn[YLO] = B[n].G->header->wesn[YLO];
-			if (wesn[YHI] > B[n].G->header->wesn[YHI]) wesn[YHI] = B[n].G->header->wesn[YHI];
+			if (wesn[XLO] < t->wesn[XLO]) wesn[XLO] = t->wesn[XLO];
+			if (wesn[XHI] > t->wesn[XHI]) wesn[XHI] = t->wesn[XHI];
+			if (wesn[YLO] < t->wesn[YLO]) wesn[YLO] = t->wesn[YLO];
+			if (wesn[YHI] > t->wesn[YHI]) wesn[YHI] = t->wesn[YHI];
 			sprintf (Rargs, "-R%.12g/%.12g/%.12g/%.12g", wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI]);
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "File %s is sampled using region %s\n", B[n].file, Rargs);
 		}
@@ -471,9 +474,11 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 			B[n].delete = true;		/* Flag to delete this temporary file when done */
 			if (GMT_Destroy_Data (GMT->parent, &B[n].G))
 				return (-GMT_RUNTIME_ERROR);
+			t = NULL;	/* To remind us that this is now gone */
 			if ((B[n].G = GMT_Read_Data (GMT->parent, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_ONLY|GMT_GRID_ROW_BY_ROW, NULL, B[n].file, NULL)) == NULL) {
 				return (-GMT_DATA_READ_ERROR);
 			}
+			t = B[n].G->header;	/* Since it got reallocated */
 			if (grdblend_overlap_check (GMT, &B[n], h, 0)) continue;	/* In case grdconvert changed the region */
 		}
 		if (B[n].weight < 0.0) {	/* Negative weight means invert sense of taper */
@@ -491,24 +496,24 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 		/* The following works for both pixel and grid-registered grids since we are here using the i,j to measure the width of the
 		 * taper zone in units of dx, dy. */
 
-		B[n].out_i0 = irint ((B[n].G->header->wesn[XLO] - h->wesn[XLO]) * HH->r_inc[GMT_X]);
+		B[n].out_i0 = irint ((t->wesn[XLO] - h->wesn[XLO]) * HH->r_inc[GMT_X]);
 		B[n].in_i0  = irint ((B[n].wesn[XLO] - h->wesn[XLO]) * HH->r_inc[GMT_X]) - 1;
 		B[n].in_i1  = irint ((B[n].wesn[XHI] - h->wesn[XLO]) * HH->r_inc[GMT_X]) + one_or_zero;
-		B[n].out_i1 = irint ((B[n].G->header->wesn[XHI] - h->wesn[XLO]) * HH->r_inc[GMT_X]) - B[n].G->header->registration;
-		B[n].out_j0 = irint ((h->wesn[YHI] - B[n].G->header->wesn[YHI]) * HH->r_inc[GMT_Y]);
+		B[n].out_i1 = irint ((t->wesn[XHI] - h->wesn[XLO]) * HH->r_inc[GMT_X]) - t->registration;
+		B[n].out_j0 = irint ((h->wesn[YHI] - t->wesn[YHI]) * HH->r_inc[GMT_Y]);
 		B[n].in_j0  = irint ((h->wesn[YHI] - B[n].wesn[YHI]) * HH->r_inc[GMT_Y]) - 1;
 		B[n].in_j1  = irint ((h->wesn[YHI] - B[n].wesn[YLO]) * HH->r_inc[GMT_Y]) + one_or_zero;
-		B[n].out_j1 = irint ((h->wesn[YHI] - B[n].G->header->wesn[YLO]) * HH->r_inc[GMT_Y]) - B[n].G->header->registration;
+		B[n].out_j1 = irint ((h->wesn[YHI] - t->wesn[YLO]) * HH->r_inc[GMT_Y]) - t->registration;
 
-		B[n].wxl = M_PI * h->inc[GMT_X] / (B[n].wesn[XLO] - B[n].G->header->wesn[XLO]);
-		B[n].wxr = M_PI * h->inc[GMT_X] / (B[n].G->header->wesn[XHI] - B[n].wesn[XHI]);
-		B[n].wyu = M_PI * h->inc[GMT_Y] / (B[n].G->header->wesn[YHI] - B[n].wesn[YHI]);
-		B[n].wyd = M_PI * h->inc[GMT_Y] / (B[n].wesn[YLO] - B[n].G->header->wesn[YLO]);
+		B[n].wxl = M_PI * h->inc[GMT_X] / (B[n].wesn[XLO] - t->wesn[XLO]);
+		B[n].wxr = M_PI * h->inc[GMT_X] / (t->wesn[XHI] - B[n].wesn[XHI]);
+		B[n].wyu = M_PI * h->inc[GMT_Y] / (t->wesn[YHI] - B[n].wesn[YHI]);
+		B[n].wyd = M_PI * h->inc[GMT_Y] / (B[n].wesn[YLO] - t->wesn[YLO]);
 
 		if (B[n].out_j0 < 0) {	/* Must skip to first row inside the present -R */
-			type = GMT->session.grdformat[B[n].G->header->type][0];
+			type = GMT->session.grdformat[t->type][0];
 			if (type == 'c')	/* Old-style, 1-D netcdf grid */
-				B[n].offset = B[n].G->header->n_columns * abs (B[n].out_j0);
+				B[n].offset = t->n_columns * abs (B[n].out_j0);
 			else if (type == 'n')	/* New, 2-D netcdf grid */
 				B[n].offset = B[n].out_j0;
 			else
@@ -519,10 +524,10 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 
 		/* Allocate space for one entire row for this grid */
 
-		B[n].z = gmt_M_memory (GMT, NULL, B[n].G->header->n_columns, gmt_grdfloat);
-		HHG = gmt_get_H_hidden (B[n].G->header);
+		B[n].z = gmt_M_memory (GMT, NULL, t->n_columns, gmt_grdfloat);
+		HHG = gmt_get_H_hidden (t);
 
-		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Blend file %s in %g/%g/%g/%g with %s weight %g [%d-%d]\n",
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Blend file %s in %.12g/%.12g/%.12g/%.12g with %s weight %g [%d-%d]\n",
 			HHG->name, B[n].wesn[XLO], B[n].wesn[XHI], B[n].wesn[YLO], B[n].wesn[YHI], sense[B[n].invert], B[n].weight, B[n].out_j0, B[n].out_j1);
 
 		if (!B[n].memory && GMT_Destroy_Data (GMT->parent, &B[n].G)) return (-GMT_RUNTIME_ERROR);	/* Free grid unless it is a memory grid */
@@ -757,11 +762,9 @@ static int parse (struct GMT_CTRL *GMT, struct GRDBLEND_CTRL *Ctrl, struct GMT_O
 		}
 	}
 
-#if 0
-	n_errors += gmt_M_check_condition (GMT, !GMT->common.R.active[RSET], "Option -R: Must specify region\n");
-	n_errors += gmt_M_check_condition (GMT, GMT->common.R.inc[GMT_X] <= 0.0 || GMT->common.R.inc[GMT_Y] <= 0.0,
-	                                   "Option -I: Must specify positive dx, dy\n");
-#endif
+	n_errors += gmt_M_check_condition (GMT, GMT->common.R.active[ISET] && (GMT->common.R.inc[GMT_X] <= 0.0 || GMT->common.R.inc[GMT_Y] <= 0.0),
+	            "Option -I: Must specify positive increments\n");
+
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
 

--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -219,13 +219,13 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 	/* There are two separate regions that we need to worry about and ensure they are consistent when a user
 	 * selects a subset. This is because the grid region and the desired region may not only be different, but
 	 * may be phase-shifted. That means a single w/e/s/n cannot be used both to specify a subset for READING and
-	 * also as a OUTPUT region.  Thus, below we create two regions:
+	 * also as an OUTPUT region.  Thus, below we create two regions:
 	 * wesn_i: This is initially the input grid's domain.  If no -R is given then that is what we will read.
 	 * wesn_o: This is the region given by -R.  If no -R then it is the same as wesn_i.
 	 * If no -R is given then wesn_i == wesn_o and (presumably) there is only differences in inc and registration.
 	 * If there is a -R, then we adjust wesn_i and wesn_o thus:
-	 *   wesn_i: We move the boundaries inwards by the grid spacing until the bounds are equal to or inside the -R.
-	 *   wesn_o: We move the boundaries inwards by the -Iinc spacing until the bounds are eqaul to or inside the input grid.
+	 *   wesn_i: We move the boundaries inwards by the grid's own increments until the bounds are equal to or inside the -R.
+	 *   wesn_o: We move the boundaries inwards by the -Iinc spacing until the bounds are equal to or inside the input grid.
 	 */
 
 	gmt_M_memcpy (wesn_i, Gin->header->wesn, 4, double);	/* wesn_i is eventually the subset we will read from this grid */

--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -68,57 +68,6 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GRDSAMPLE_CTRL *C) {	/* Deal
 	gmt_M_free (GMT, C);
 }
 
-GMT_LOCAL void grdsample_adjust_R (struct GMTAPI_CTRL *API, struct GRDSAMPLE_CTRL *Ctrl, struct GMT_GRID *Gin, double *wesn) {
-	/* Check that the grid limis provided do not extend further than that of the to-be-resampled grid.
-	   If any of the WESN 'overflows', trim it to the maximum extent allowed by the sampling grid.
-	*/
-	int    n;
-	double x, y, d;
-	if (wesn[YLO] < (Gin->header->wesn[YLO] - Gin->header->inc[GMT_Y]) || wesn[YHI] > (Gin->header->wesn[YHI] + Gin->header->inc[GMT_Y])) {
-		GMT_Report (API, GMT_MSG_WARNING,
-		            "Selected region exceeds the Y-boundaries of the grid file by more than one y-increment! Adjusting it.\n");
-		if (wesn[YHI] > (Gin->header->wesn[YHI] + Gin->header->inc[GMT_Y]))  {
-			n = gmt_M_x_to_col(Gin->header->wesn[YHI], wesn[YLO], API->GMT->common.R.inc[GMT_Y], 0, 0);	/* First 0 is ref grid's xy_off. So it could != 0 */
-			y = wesn[YLO] + n * API->GMT->common.R.inc[GMT_Y];
-			d = y - Gin->header->wesn[YLO];
-			wesn[YHI] = d >= 0 ? y : wesn[YLO] + (n - 1) * API->GMT->common.R.inc[GMT_Y];
-		}
-
-		if (wesn[YLO] < (Gin->header->wesn[YLO] - Gin->header->inc[GMT_Y])) {
-			n = gmt_M_x_to_col(Gin->header->wesn[YLO], wesn[YLO], API->GMT->common.R.inc[GMT_Y], 0, 0);	/* First 0 is ref grid's xy_off. So it could != 0 */
-			y = wesn[YLO] + n * API->GMT->common.R.inc[GMT_Y];
-			d = Gin->header->wesn[YLO] - y;
-			wesn[YLO] = d > 0 ? wesn[YLO] + (n + 1) * API->GMT->common.R.inc[GMT_Y] : y;
-		}
-	}
-	if (gmt_M_is_geographic (API->GMT, GMT_IN)) {	/* Must carefully check the longitude overlap */
-		int shift = 0;
-		if (Gin->header->wesn[XHI] < wesn[XLO]) shift += 360;
-		if (Gin->header->wesn[XLO] > wesn[XHI]) shift -= 360;
-		if (shift) {	/* Must modify header */
-			Gin->header->wesn[XLO] += shift, Gin->header->wesn[XHI] += shift;
-			GMT_Report (API, GMT_MSG_INFORMATION, "File %s region needed longitude adjustment to fit final grid region\n", Ctrl->In.file);
-		}
-	}
-	if (wesn[XLO] < (Gin->header->wesn[XLO] - Gin->header->inc[GMT_X]) || wesn[XHI] > (Gin->header->wesn[XHI] + Gin->header->inc[GMT_X])) {
-		GMT_Report (API, GMT_MSG_WARNING,
-		            "Selected region exceeds the X-boundaries of the grid file by more than one x-increment! Adjusting it.\n");
-		if (wesn[XHI] > (Gin->header->wesn[XHI] + Gin->header->inc[GMT_X]))  {
-			n = gmt_M_x_to_col(Gin->header->wesn[XHI], wesn[XLO], API->GMT->common.R.inc[GMT_X], 0, 0);	/* First 0 is ref grid's xy_off. So it could != 0 */
-			x = wesn[XLO] + n * API->GMT->common.R.inc[GMT_X];
-			d = x - Gin->header->wesn[XHI];
-			wesn[XHI] = d >= 0 ? x : wesn[XLO] + (n - 1) * API->GMT->common.R.inc[GMT_X];
-		}
-
-		if (wesn[XLO] < (Gin->header->wesn[XLO] - Gin->header->inc[GMT_X])) {
-			n = gmt_M_x_to_col(Gin->header->wesn[XLO], wesn[XLO], API->GMT->common.R.inc[GMT_X], 0, 0);	/* First 0 is ref grid's xy_off. So it could != 0 */
-			x = wesn[XLO] + n * API->GMT->common.R.inc[GMT_X];
-			d = Gin->header->wesn[XLO] - x;
-			wesn[XLO] = d > 0 ? wesn[XLO] + (n + 1) * API->GMT->common.R.inc[GMT_X] : x;
-		}
-	}
-}
-
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
@@ -232,7 +181,7 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 
 	char format[GMT_BUFSIZ];
 
-	double *lon = NULL, lat, wesn[4], inc[2];
+	double *lon = NULL, lat, wesn_i[4], wesn_o[4], inc[2];
 
 	struct GRDSAMPLE_CTRL *Ctrl = NULL;
 	struct GMT_GRID *Gin = NULL, *Gout = NULL;
@@ -267,9 +216,23 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 		Return (API->error);
 	}
 
-	gmt_M_memcpy (wesn, (GMT->common.R.active[RSET] ? GMT->common.R.wesn : Gin->header->wesn), 4, double);
-	gmt_M_memcpy (inc, (GMT->common.R.active[ISET] ? GMT->common.R.inc : Gin->header->inc), 2, double);
+	/* There are two separate regions that we need to worry about and ensure they are consistent when a user
+	 * selects a subset. This is because the grid region and the desired region may not only be different, but
+	 * may be phase-shifted. That means a single w/e/s/n cannot be used both to specify a subset for READING and
+	 * also as a OUTPUT region.  Thus, below we create two regions:
+	 * wesn_i: This is initially the input grid's domain.  If no -R is given then that is what we will read.
+	 * wesn_o: This is the region given by -R.  If no -R then it is the same as wesn_i.
+	 * If no -R is given then wesn_i == wesn_o and (presumably) there is only differences in inc and registration.
+	 * If there is a -R, then we adjust wesn_i and wesn_o thus:
+	 *   wesn_i: We move the boundaries inwards by the grid spacing until the bounds are equal to or inside the -R.
+	 *   wesn_o: We move the boundaries inwards by the -Iinc spacing until the bounds are eqaul to or inside the input grid.
+	 */
 
+	gmt_M_memcpy (wesn_i, Gin->header->wesn, 4, double);	/* wesn_i is eventually the subset we will read from this grid */
+	gmt_M_memcpy (wesn_o, (GMT->common.R.active[RSET] ? GMT->common.R.wesn : Gin->header->wesn), 4, double);	/* wesn_o is the region we want for the output [Same as input] */
+	gmt_M_memcpy (inc, (GMT->common.R.active[ISET] ? GMT->common.R.inc : Gin->header->inc), 2, double);	/* Either a new increment is given or we use the one from the input grid */
+
+	/* Set the registration for the output via -R, -r or default input grid */
 	if (Ctrl->T.active)
 		registration = !Gin->header->registration;
 	else if (GMT->common.R.active[GSET])
@@ -277,39 +240,47 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 	else
 		registration = Gin->header->registration;
 
-	if (GMT->common.R.active[RSET]) {		/* Make sure input grid and output -R has an overlap */
-		if ((wesn[YLO] < (Gin->header->wesn[YLO] - Gin->header->inc[GMT_Y]) ||
-		     wesn[YHI] > (Gin->header->wesn[YHI] + Gin->header->inc[GMT_Y]) ||
-		     wesn[XLO] < (Gin->header->wesn[XLO] - Gin->header->inc[GMT_X]) ||
-		     wesn[XHI] > (Gin->header->wesn[XHI] + Gin->header->inc[GMT_X])) && GMT->common.R.active[FSET]) {
-			/* If the limits were specified via -R<grid> adjust those limits to maximum allowed by resampling grid */
-			grdsample_adjust_R (API, Ctrl, Gin, wesn);
-		}
-		else {
-			bool geo = gmt_M_360_range (Gin->header->wesn[XLO], Gin->header->wesn[XHI]);
-			if (wesn[YLO] < (Gin->header->wesn[YLO] - Gin->header->inc[GMT_Y]) || wesn[YHI] > (Gin->header->wesn[YHI] + Gin->header->inc[GMT_Y])) {
-				GMT_Report (API, GMT_MSG_ERROR, "Selected region exceeds the Y-boundaries of the grid file by more than one y-increment!\n");
-				Return (GMT_RUNTIME_ERROR);
-			}
-			if (gmt_M_is_geographic (GMT, GMT_IN)) {	/* Must carefully check the longitude overlap */
-				int shift = 0;
-				if (Gin->header->wesn[XHI] < wesn[XLO]) shift += 360;
-				else if (Gin->header->wesn[XLO] > wesn[XHI]) shift -= 360;
-				else if (geo && wesn[XHI] > Gin->header->wesn[XHI]) shift += 360;
-				else if (geo && wesn[XLO] < Gin->header->wesn[XLO]) shift -= 360;
-				if (shift) {	/* Must modify header */
-					Gin->header->wesn[XLO] += shift, Gin->header->wesn[XHI] += shift;
-					GMT_Report (API, GMT_MSG_INFORMATION, "File %s region needed longitude adjustment to fit final grid region\n", Ctrl->In.file);
-				}
-			}
-			if (!geo && (wesn[XLO] < (Gin->header->wesn[XLO] - Gin->header->inc[GMT_X]) || wesn[XHI] > (Gin->header->wesn[XHI] + Gin->header->inc[GMT_X]))) {
-				GMT_Report (API, GMT_MSG_ERROR, "Selected region exceeds the X-boundaries of the grid file by more than one x-increment!\n");
-				return (GMT_RUNTIME_ERROR);
+	if (GMT->common.R.active[RSET]) {		/* Gave -R */
+		bool geo = gmt_M_360_range (Gin->header->wesn[XLO], Gin->header->wesn[XHI]);
+		/* Adjust wesn used to READ subset */
+		while (wesn_i[YLO] < wesn_o[YLO]) wesn_i[YLO] += Gin->header->inc[GMT_Y];	/* Now on or inside boundary */
+		while (wesn_i[YHI] > Gin->header->wesn[YHI]) wesn_i[YHI] -= Gin->header->inc[GMT_Y];	/* Now on or inside boundary */
+		if (gmt_M_is_geographic (GMT, GMT_IN)) {	/* Must carefully check the longitude overlap */
+			int shift = 0;
+			if (Gin->header->wesn[XHI] < wesn_i[XLO]) shift += 360;
+			else if (Gin->header->wesn[XLO] > wesn_i[XHI]) shift -= 360;
+			else if (geo && wesn_i[XHI] > Gin->header->wesn[XHI]) shift += 360;
+			else if (geo && wesn_i[XLO] < Gin->header->wesn[XLO]) shift -= 360;
+			if (shift) {	/* Must modify header to match -R */
+				Gin->header->wesn[XLO] += shift, Gin->header->wesn[XHI] += shift;
+				GMT_Report (API, GMT_MSG_INFORMATION, "File %s region needed a %g longitude adjustment to fit final grid region\n", Ctrl->In.file, shift);
 			}
 		}
+		while (wesn_i[XLO] < Gin->header->wesn[XLO]) wesn_i[XLO] += Gin->header->inc[GMT_X];	/* Now on or inside boundary */
+		while (wesn_i[XHI] > Gin->header->wesn[XHI]) wesn_i[XHI] -= Gin->header->inc[GMT_X];	/* Now on or inside boundary */
+
+		/* Adjust wesn_o used to CREATE the output grid */
+		while (wesn_o[YLO] < Gin->header->wesn[YLO]) wesn_o[YLO] += inc[GMT_Y];	/* Now on or inside boundary */
+		while (wesn_o[YHI] > Gin->header->wesn[YHI]) wesn_o[YHI] -= inc[GMT_Y];	/* Now on or inside boundary */
+		if (gmt_M_is_geographic (GMT, GMT_IN)) {	/* Must carefully check the longitude overlap */
+			int shift = 0;
+			if (Gin->header->wesn[XHI] < wesn_o[XLO]) shift += 360;
+			else if (Gin->header->wesn[XLO] > wesn_o[XHI]) shift -= 360;
+			else if (geo && wesn_o[XHI] > Gin->header->wesn[XHI]) shift += 360;
+			else if (geo && wesn_o[XLO] < Gin->header->wesn[XLO]) shift -= 360;
+			if (shift) {	/* Must modify header */
+				Gin->header->wesn[XLO] += shift, Gin->header->wesn[XHI] += shift;
+				GMT_Report (API, GMT_MSG_INFORMATION, "File %s region needed a %g longitude adjustment to fit final grid region\n", Ctrl->In.file, shift);
+			}
+		}
+		while (wesn_o[XLO] < Gin->header->wesn[XLO]) wesn_o[XLO] += inc[GMT_X];	/* Now on or inside boundary */
+		while (wesn_o[XHI] > Gin->header->wesn[XHI]) wesn_o[XHI] -= inc[GMT_X];	/* Now on or inside boundary */
 	}
 
-	if ((Gout = GMT_Create_Data (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, wesn, inc, \
+	/* Here, wesn_i is compatible with the INPUT grid so we can read the subset from which we will resample.
+	 * Here, wesn_o is the region we wish to use when creating the output grid */
+
+	if ((Gout = GMT_Create_Data (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, wesn_o, inc, \
 		registration, GMT_NOTSET, NULL)) == NULL) Return (API->error);
 
 	sprintf (format, "Input  grid (%s/%s/%s/%s) n_columns = %%d n_rows = %%d dx = %s dy = %s registration = %%d\n",
@@ -326,7 +297,7 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 		Gout->header->wesn[YLO], Gout->header->wesn[YHI], Gout->header->n_columns, Gout->header->n_rows,
 		Gout->header->inc[GMT_X], Gout->header->inc[GMT_Y], Gout->header->registration);
 
-	if (GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_DATA_ONLY, wesn, Ctrl->In.file, Gin) == NULL) {	/* Get subset */
+	if (GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_DATA_ONLY, wesn_i, Ctrl->In.file, Gin) == NULL) {	/* Get subset */
 		Return (API->error);
 	}
 
@@ -335,7 +306,7 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 	if (Gout->header->inc[GMT_Y] > Gin->header->inc[GMT_Y])
 		GMT_Report (API, GMT_MSG_WARNING, "Output sampling interval in y exceeds input interval and may lead to aliasing.\n");
 
-	/* Precalculate longitudes */
+	/* Precalculate longitudes from the output grid layout */
 
 	HH = gmt_get_H_hidden (Gin->header);
 	lon = gmt_M_memory (GMT, NULL, Gout->header->n_columns, double);


### PR DESCRIPTION
**Description of proposed changes**

The **grdsample** module is unusual in that we will request output from a region (**-R**) further defined by an increment (**-I**) and registration (**-r**).  The resulting output grid may be completely shifted from the nodes in the input grid, depending you options.    Yet, we have used the input region to select a subset from the input grid.  However, as you can imagine, the subset region may not be compatible with the input grid registration, spacing, phase, etc.  This caused much grief when **grdblend** would need to resample a grid due to phase shifts, as it would pass the desired regions (and possibly increments, registration) and **grdsample** would give nasty messages about w/e/s/n not being multiples of grid spacings.

This revision maintains two separate regions.  The given input region **-R** is used to derive two regions: One that can be used to extract the subset when reading the input grid, and another that is the actual desired region.  Both may be adjusted if they exceed the input grid domain.  This PR stops the crash reported on the [forum](https://forum.generic-mapping-tools.org/t/grdblend-problem/564/8).
