### PR TITLE
Set backwards nx,ny to n_cols, n_rows in 6.1

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -5450,6 +5450,11 @@ GMT_LOCAL struct GMT_GRID * gmtapi_import_grid (struct GMTAPI_CTRL *API, int obj
 	if (done) S_obj->status = GMT_IS_USED;	/* Mark as read (unless we just got the header) */
 
 	return (G_obj);	/* Pass back out what we have so far */
+
+#ifdef GMT_BACKWARDS_API
+	G_obj->header->nx = G_obj->header->n_columns;
+	G_obj->header->ny = G_obj->header->n_rows;
+#endif
 }
 
 /*! Writes out a single grid to destination */

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -1412,6 +1412,10 @@ int gmtlib_read_grd_info (struct GMT_CTRL *GMT, char *file, struct GMT_GRID_HEAD
 	/* unpack z-range: */
 	header->z_min = header->z_min * header->z_scale_factor + header->z_add_offset;
 	header->z_max = header->z_max * header->z_scale_factor + header->z_add_offset;
+#ifdef GMT_BACKWARDS_API
+	header->nx = header->n_columns;
+	header->ny = header->n_rows;
+#endif
 
 	return (GMT_NOERROR);
 }
@@ -1944,6 +1948,10 @@ void gmt_set_grddim (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h) {
 	h->size = gmtgrdio_grd_get_size (h);	/* Sets the number of items (not bytes!) needed to hold this array, which includes the padding (size >= nm) */
 	h->xy_off = 0.5 * h->registration;
 	gmt_set_grdinc (GMT, h);
+#ifdef GMT_BACKWARDS_API
+	h->nx = h->n_columns;
+	h->ny = h->n_rows;
+#endif
 }
 
 void gmt_grd_init (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, struct GMT_OPTION *options, bool update) {

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -33,6 +33,8 @@
 #ifndef GMT_RESOURCES_H
 #define GMT_RESOURCES_H
 
+#define GMT_BACKWARDS_API	/* Try to be backwards compatible with API naming for now */
+
 #ifdef DOUBLE_PRECISION_GRID
 /* Build GMT using double-precicion for grids.  Untested and caveat emptor */
 typedef double gmt_grdfloat;
@@ -425,6 +427,10 @@ struct GMT_GRID_HEADER {
 	char *ProjRefWKT;               /* To store a referencing system string in WKT format */
 	int ProjRefEPSG;                /* To store a referencing system EPSG code */
 	void *hidden;                    /* Lower-level information for GMT use only */
+#ifdef GMT_BACKWARDS_API
+	uint32_t nx;
+	uint32_t ny;
+#endif
 };
 
 /* grd is stored in rows going from west (xmin) to east (xmax)


### PR DESCRIPTION
Because of the ubuntus of the world, people are failing to build GMT and GMTSAR since we removed the backward nx,ny settings.  This reinstate those settings just for GRIDs since that is the only thing GMTSAR uses.  I figure we can eventually remove that when ubuntu 16 dies or the people using it dies or stop using GMTSAR.  This will help in the short term and will be in 6.1
