### PR TITLE
Set minimum length for line symbol in auto-legend

### DIFF
--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -720,7 +720,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 							x = gmt_M_to_inch (GMT, txt_b);
 							if (x > def_dx2) def_dx2 = x;
 						}
-						if (do_width && n_scan == 3 && strlen (text)) {
+						if (do_width && n_scan == 4 && strlen (text)) {
 							gmt_M_memcpy (&legend_item[n_item].font, &(GMT->current.setting.font_annot[GMT_PRIMARY]), 1, struct GMT_FONT);
 							legend_item[n_item++].text = strdup (text);
 						}

--- a/test/modern/onefiglegend.ps
+++ b/test/modern/onefiglegend.ps
@@ -1,17 +1,16 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_ae8e825_2019.10.15 [64-bit] Document from psxy
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.1.0_9e17e0c-dirty_2020.07.02 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Tue Oct 15 08:20:36 2019
+%%CreationDate: Thu Jul  2 14:58:02 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
 %%Pages: 1
 %%EndComments
-
 %%BeginProlog
 250 dict begin
 /! {bind def} bind def
@@ -643,39 +642,33 @@ end
 /PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
 /PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
 %%EndProlog
-
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
-PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
-PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
-
 %%Page: 1 1
-
 %%BeginPageSetup
 V 0.06 0.06 scale
 %%EndPageSetup
-
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_plot_completion {} def
-/PSL_movie_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
 FQ
 O0
 1200 1200 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy -R0/7/3/7 -Jx1i -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+hLEGEND+f16p+d
+%@GMT: gmt psxy -R0/7/3/7 -Jx1i -B /Users/pwessel/.gmt/cache/Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 7.000 3.000 7.000 +xy
-%GMTBoundingBox: 72 72 504 288
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 4800 M 0 -4800 D S
 /PSL_A0_y 83 def
@@ -686,8 +679,8 @@ N 0 1200 M -83 0 D S
 N 0 2400 M -83 0 D S
 N 0 3600 M -83 0 D S
 N 0 4800 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (3) sw mx
@@ -736,8 +729,8 @@ N 0 1200 M 83 0 D S
 N 0 2400 M 83 0 D S
 N 0 3600 M 83 0 D S
 N 0 4800 M 83 0 D S
-/PSL_AH0 0
 /MM {exch M} def
+/PSL_AH0 0
 (3) sw mx
 (4) sw mx
 (5) sw mx
@@ -786,8 +779,8 @@ N 4800 0 M 0 -83 D S
 N 6000 0 M 0 -83 D S
 N 7200 0 M 0 -83 D S
 N 8400 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (0) sh mx
 (1) sh mx
 (2) sh mx
@@ -857,8 +850,8 @@ N 4800 0 M 0 83 D S
 N 6000 0 M 0 83 D S
 N 7200 0 M 0 83 D S
 N 8400 0 M 0 83 D S
-/PSL_AH0 0
 /MM {M} def
+/PSL_AH0 0
 (0) sh mx
 (1) sh mx
 (2) sh mx
@@ -965,14 +958,13 @@ PSL_cliprestore
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy @Table_5_11.txt -W1.5p,gray '-lMy Lines' -R0/7/3/7 -Jx1i
+%@GMT: gmt psxy /Users/pwessel/.gmt/cache/Table_5_11.txt -W1.5p,gray '-lMy Lines' -R0/7/3/7 -Jx1i
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 7.000 3.000 7.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 25 W
 0.745 A
 clipsave
@@ -1021,14 +1013,13 @@ PSL_cliprestore
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy @Table_5_11.txt -St0.15i -Gorange -lOranges -R0/7/3/7 -Jx1i
+%@GMT: gmt psxy /Users/pwessel/.gmt/cache/Table_5_11.txt -St0.15i -Gorange -lOranges -R0/7/3/7 -Jx1i
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 7.000 3.000 7.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 clipsave
 0 0 M
 8400 0 D
@@ -1076,14 +1067,13 @@ PSL_cliprestore
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
 %@GMT: gmt pslegend -DjRT+w0i+o0.2c -F+p1p+gwhite -S1 -R0/7/3/7 -Jx1i
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 7.000 3.000 7.000 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 /PSL_legend_label_width 0 def
 /PSL_legend_string_width 0 def
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
@@ -1097,7 +1087,7 @@ PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
 (Oranges) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
-/PSL_tmp_w 270 def
+/PSL_tmp_w 354 def
 /PSL_legend_clear_x 133 def
 /PSL_tmp_w PSL_tmp_w PSL_legend_label_width add def
 /PSL_legend_box_width PSL_tmp_w PSL_legend_string_width gt { PSL_tmp_w } { PSL_legend_string_width} ifelse PSL_legend_clear_x add def
@@ -1122,60 +1112,56 @@ PSL_legend_box_width PSL_legend_hor_off sub 0 D S
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy -R0/7/0/4 -Jx1i -O -K -N -S @GMTAPI@-000001 --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=false
+%@GMT: gmt psxy -R0/7/0/4 -Jx1i -O -K -N -S @GMTAPI@-S-I-D-D-T-N-000001 --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 7.00000000 0.00000000 4.00000000 0.000 7.000 0.000 4.000 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {0.565 0.933 0.565 C} FS
 O1
 0 W
-90 157 617 Sc
+90 185 617 Sc
 FQ
 25 W
 0.745 A
-90 157 397 S-
+118 185 397 S-
 {1 0.647 0 C} FS
 O0
 4 W
 0 A
-90 157 177 St
+90 185 177 St
 U
 %%EndObject
 0 A
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt pstext -R0/7/0/4 -Jx1i -O -K -N -F+f+j @GMTAPI@-000002 --GMT_HISTORY=false
+%@GMT: gmt pstext -R0/7/0/4 -Jx1i -O -K -N -F+f+j @GMTAPI@-S-I-D-D-N-N-000002 --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 7.00000000 0.00000000 4.00000000 0.000 7.000 0.000 4.000 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
-337 547 M 200 F0
+3.32550952342 setmiterlimit
+421 547 M 200 F0
 (Apples) bl Z
-337 327 M (My Lines) bl Z
-337 107 M (Oranges) bl Z
+421 327 M (My Lines) bl Z
+421 107 M (Oranges) bl Z
 %%EndObject
 PSL_legend_box_width PSL_legend_box_height sub 2 2 div mul 0 translate
 -7109 -3509 T
 %%EndObject
-
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage
-
 %%Trailer
-
 end
 %%EOF

--- a/test/modern/twofiglegend.ps
+++ b/test/modern/twofiglegend.ps
@@ -1,17 +1,16 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_ae8e825_2019.10.15 [64-bit] Document from psxy
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.1.0_9e17e0c-dirty_2020.07.02 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Tue Oct 15 08:20:37 2019
+%%CreationDate: Thu Jul  2 14:58:03 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
 %%Pages: 1
 %%EndComments
-
 %%BeginProlog
 250 dict begin
 /! {bind def} bind def
@@ -643,39 +642,33 @@ end
 /PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
 /PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
 %%EndProlog
-
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
-PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
-PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
-
 %%Page: 1 1
-
 %%BeginPageSetup
 V 0.06 0.06 scale
 %%EndPageSetup
-
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_plot_completion {} def
-/PSL_movie_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
 FQ
 O0
 1200 1200 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy -R0/7/3/7 -Jx1i -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+hLEGEND+f16p+d+jTL
+%@GMT: gmt psxy -R0/7/3/7 -Jx1i -B /Users/pwessel/.gmt/cache/Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D+jTL
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 7.000 3.000 7.000 +xy
-%GMTBoundingBox: 72 72 504 288
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 4800 M 0 -4800 D S
 /PSL_A0_y 83 def
@@ -686,8 +679,8 @@ N 0 1200 M -83 0 D S
 N 0 2400 M -83 0 D S
 N 0 3600 M -83 0 D S
 N 0 4800 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (3) sw mx
@@ -736,8 +729,8 @@ N 0 1200 M 83 0 D S
 N 0 2400 M 83 0 D S
 N 0 3600 M 83 0 D S
 N 0 4800 M 83 0 D S
-/PSL_AH0 0
 /MM {exch M} def
+/PSL_AH0 0
 (3) sw mx
 (4) sw mx
 (5) sw mx
@@ -786,8 +779,8 @@ N 4800 0 M 0 -83 D S
 N 6000 0 M 0 -83 D S
 N 7200 0 M 0 -83 D S
 N 8400 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (0) sh mx
 (1) sh mx
 (2) sh mx
@@ -857,8 +850,8 @@ N 4800 0 M 0 83 D S
 N 6000 0 M 0 83 D S
 N 7200 0 M 0 83 D S
 N 8400 0 M 0 83 D S
-/PSL_AH0 0
 /MM {M} def
+/PSL_AH0 0
 (0) sh mx
 (1) sh mx
 (2) sh mx
@@ -965,14 +958,13 @@ PSL_cliprestore
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy @Table_5_11.txt -W1.5p,gray '-lMy Lines' -R0/7/3/7 -Jx1i
+%@GMT: gmt psxy /Users/pwessel/.gmt/cache/Table_5_11.txt -W1.5p,gray '-lMy Lines' -R0/7/3/7 -Jx1i
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 7.000 3.000 7.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 25 W
 0.745 A
 clipsave
@@ -1021,14 +1013,13 @@ PSL_cliprestore
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy @Table_5_11.txt -St0.15i -Gred -lRed -R0/7/3/7 -Jx1i
+%@GMT: gmt psxy /Users/pwessel/.gmt/cache/Table_5_11.txt -St0.15i -Gred -lRed -R0/7/3/7 -Jx1i
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 7.000 3.000 7.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 clipsave
 0 0 M
 8400 0 D
@@ -1076,14 +1067,13 @@ PSL_cliprestore
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
 %@GMT: gmt pslegend -DjLT+w0i+o0.2c -F+p1p+gwhite -S1 -R0/7/3/7 -Jx1i
 %@PROJ: xy 0.00000000 7.00000000 3.00000000 7.00000000 0.000 7.000 3.000 7.000 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 /PSL_legend_label_width 0 def
 /PSL_legend_string_width 0 def
 267 F0
@@ -1096,7 +1086,7 @@ PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
 (Red) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
-/PSL_tmp_w 270 def
+/PSL_tmp_w 354 def
 /PSL_legend_clear_x 133 def
 /PSL_tmp_w PSL_tmp_w PSL_legend_label_width add def
 /PSL_legend_box_width PSL_tmp_w PSL_legend_string_width gt { PSL_tmp_w } { PSL_legend_string_width} ifelse PSL_legend_clear_x add def
@@ -1121,60 +1111,56 @@ PSL_legend_box_width PSL_legend_hor_off sub 0 D S
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy -R0/7/0/4 -Jx1i -O -K -N -S @GMTAPI@-000004 --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=false
+%@GMT: gmt psxy -R0/7/0/4 -Jx1i -O -K -N -S @GMTAPI@-S-I-D-D-T-N-000004 --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 7.00000000 0.00000000 4.00000000 0.000 7.000 0.000 4.000 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {0.565 0.933 0.565 C} FS
 O1
 0 W
-90 157 617 Sc
+90 185 617 Sc
 FQ
 25 W
 0.745 A
-90 157 397 S-
+118 185 397 S-
 {1 0 0 C} FS
 O0
 4 W
 0 A
-90 157 177 St
+90 185 177 St
 U
 %%EndObject
 0 A
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt pstext -R0/7/0/4 -Jx1i -O -K -N -F+f+j @GMTAPI@-000005 --GMT_HISTORY=false
+%@GMT: gmt pstext -R0/7/0/4 -Jx1i -O -K -N -F+f+j @GMTAPI@-S-I-D-D-N-N-000005 --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 7.00000000 0.00000000 4.00000000 0.000 7.000 0.000 4.000 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
-337 547 M 200 F0
+3.32550952342 setmiterlimit
+421 547 M 200 F0
 (Apples) bl Z
-337 327 M (My Lines) bl Z
-337 107 M (Red) bl Z
+421 327 M (My Lines) bl Z
+421 107 M (Red) bl Z
 %%EndObject
 PSL_legend_box_width PSL_legend_box_height sub 0 2 div mul 0 translate
 -94 -3509 T
 %%EndObject
-
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage
-
 %%Trailer
-
 end
 %%EOF

--- a/test/pslegend/autolegend.ps
+++ b/test/pslegend/autolegend.ps
@@ -1,17 +1,16 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_ae8e825_2019.10.15 [64-bit] Document from psxy
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.1.0_9e17e0c-dirty_2020.07.02 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Tue Oct 15 08:20:54 2019
+%%CreationDate: Thu Jul  2 14:58:27 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
 %%Pages: 1
 %%EndComments
-
 %%BeginProlog
 250 dict begin
 /! {bind def} bind def
@@ -643,39 +642,33 @@ end
 /PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
 /PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
 %%EndProlog
-
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
-PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
-PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
-
 %%Page: 1 1
-
 %%BeginPageSetup
 V 0.06 0.06 scale
 %%EndPageSetup
-
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_plot_completion {} def
-/PSL_movie_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
 FQ
 O0
 1200 1200 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy -R0/7.2/3/7.2 -Jx1i -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+hLEGEND+f16p+d
+%@GMT: gmt psxy -R0/7.2/3/7.2 -Jx1i -B /Users/pwessel/.gmt/cache/Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D
 %@PROJ: xy 0.00000000 7.20000000 3.00000000 7.20000000 0.000 7.200 3.000 7.200 +xy
-%GMTBoundingBox: 72 72 518.4 302.4
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 5040 M 0 -5040 D S
 /PSL_A0_y 83 def
@@ -686,8 +679,8 @@ N 0 1200 M -83 0 D S
 N 0 2400 M -83 0 D S
 N 0 3600 M -83 0 D S
 N 0 4800 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (3) sw mx
@@ -737,8 +730,8 @@ N 0 1200 M 83 0 D S
 N 0 2400 M 83 0 D S
 N 0 3600 M 83 0 D S
 N 0 4800 M 83 0 D S
-/PSL_AH0 0
 /MM {exch M} def
+/PSL_AH0 0
 (3) sw mx
 (4) sw mx
 (5) sw mx
@@ -788,8 +781,8 @@ N 4800 0 M 0 -83 D S
 N 6000 0 M 0 -83 D S
 N 7200 0 M 0 -83 D S
 N 8400 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (0) sh mx
 (1) sh mx
 (2) sh mx
@@ -860,8 +853,8 @@ N 4800 0 M 0 83 D S
 N 6000 0 M 0 83 D S
 N 7200 0 M 0 83 D S
 N 8400 0 M 0 83 D S
-/PSL_AH0 0
 /MM {M} def
+/PSL_AH0 0
 (0) sh mx
 (1) sh mx
 (2) sh mx
@@ -969,14 +962,13 @@ PSL_cliprestore
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy @Table_5_11.txt -W1.5p,gray '-lMy Lines' -R0/7.2/3/7.2 -Jx1i
+%@GMT: gmt psxy /Users/pwessel/.gmt/cache/Table_5_11.txt -W1.5p,gray '-lMy Lines' -R0/7.2/3/7.2 -Jx1i
 %@PROJ: xy 0.00000000 7.20000000 3.00000000 7.20000000 0.000 7.200 3.000 7.200 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 25 W
 0.745 A
 clipsave
@@ -1025,14 +1017,13 @@ PSL_cliprestore
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy @Table_5_11.txt -St0.15i -Gorange -lOranges -R0/7.2/3/7.2 -Jx1i
+%@GMT: gmt psxy /Users/pwessel/.gmt/cache/Table_5_11.txt -St0.15i -Gorange -lOranges -R0/7.2/3/7.2 -Jx1i
 %@PROJ: xy 0.00000000 7.20000000 3.00000000 7.20000000 0.000 7.200 3.000 7.200 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 clipsave
 0 0 M
 8640 0 D
@@ -1080,14 +1071,13 @@ PSL_cliprestore
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
 %@GMT: gmt pslegend -DjTR+w1.15i+o0.1i -F+p1p -R0/7.2/3/7.2 -Jx1i
 %@PROJ: xy 0.00000000 7.20000000 3.00000000 7.20000000 0.000 7.200 3.000 7.200 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 /PSL_legend_box_width 1380 def
 /PSL_legend_box_height 1197 def
 7140 3723 T
@@ -1100,62 +1090,58 @@ O1
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy -R0/7.2/0/4.2 -Jx1i -O -K -N -S @GMTAPI@-000002 --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=false
+%@GMT: gmt psxy -R0/7.2/0/4.2 -Jx1i -O -K -N -S @GMTAPI@-S-I-D-D-T-N-000002 --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 7.20000000 0.00000000 4.20000000 0.000 7.200 0.000 4.200 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {0.565 0.933 0.565 C} FS
 O1
 0 W
-90 157 617 Sc
+90 185 617 Sc
 FQ
 25 W
 0.745 A
-90 157 397 S-
+118 185 397 S-
 {1 0.647 0 C} FS
 O0
 4 W
 0 A
-90 157 177 St
+90 185 177 St
 U
 %%EndObject
 0 A
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt pstext -R0/7.2/0/4.2 -Jx1i -O -K -N -F+f+j @GMTAPI@-000001 --GMT_HISTORY=false
+%@GMT: gmt pstext -R0/7.2/0/4.2 -Jx1i -O -K -N -F+f+j @GMTAPI@-S-I-D-D-N-N-000001 --GMT_HISTORY=false
 %@PROJ: xy 0.00000000 7.20000000 0.00000000 4.20000000 0.000 7.200 0.000 4.200 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 690 890 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 267 F0
 (LEGEND) bc Z
-337 547 M 200 F0
+421 547 M 200 F0
 (Apples) bl Z
-337 327 M (My Lines) bl Z
-337 107 M (Oranges) bl Z
+421 327 M (My Lines) bl Z
+421 107 M (Oranges) bl Z
 %%EndObject
 -7140 -3723 T
 %%EndObject
-
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage
-
 %%Trailer
-
 end
 %%EOF

--- a/test/sample1d/smooth.ps
+++ b/test/sample1d/smooth.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.1.0_101c4fc_2020.06.30 [64-bit] Document from psxy
+%%Title: GMT v6.1.0_9e17e0c-dirty_2020.07.02 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Wed Jul  1 16:08:40 2020
+%%CreationDate: Thu Jul  2 14:58:59 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -115,39 +115,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -674,7 +674,7 @@ FQ
 O0
 0 5767 TM
 % PostScript produced by:
-%@GMT: gmt psxy topo.txt -R300/500/-4500/-3000 -Sc0.1c -Gred -N -lData -BW -Bxaf -Byaf -Xa0i -Ya4.8056i -JX15c
+%@GMT: gmt psxy /Users/pwessel/.gmt/cache/topo_crossection.txt -R300/500/-4500/-3000 -Sc0.1c -Gred -N -lData -BW -Bxaf -Byaf -Xa0i -Ya4.8056i -JX15c
 %@PROJ: xy 300.00000000 500.00000000 -4500.00000000 -3000.00000000 300.000 500.000 -4500.000 -3000.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -683,7 +683,7 @@ O0
 /PSL_plot_completion {
 V
 0 5767 T
-0 A 67 5333 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 A 67 5333 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (No weights) tl Z
 U
@@ -699,24 +699,24 @@ N 0 0 M -83 0 D S
 N 0 1800 M -83 0 D S
 N 0 3600 M -83 0 D S
 N 0 5400 M -83 0 D S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /MM {neg exch M} def
 /PSL_AH0 0
 200 F0
-(-4500) sw mx
-(-4000) sw mx
-(-3500) sw mx
-(-3000) sw mx
+(”4500) sw mx
+(”4000) sw mx
+(”3500) sw mx
+(”3000) sw mx
 def
 /PSL_A0_y PSL_A0_y 83 add def
 0 PSL_A0_y MM
-(-4500) mr Z
+(”4500) mr Z
 1800 PSL_A0_y MM
-(-4000) mr Z
+(”4000) mr Z
 3600 PSL_A0_y MM
-(-3500) mr Z
+(”3500) mr Z
 5400 PSL_A0_y MM
-(-3000) mr Z
+(”3000) mr Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
 N 0 360 M -42 0 D S
 N 0 720 M -42 0 D S
@@ -2498,7 +2498,7 @@ O0
 3.32550952342 setmiterlimit
 /PSL_legend_label_width 0 def
 /PSL_legend_string_width 0 def
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (Data) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
@@ -2510,7 +2510,7 @@ PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
 (Smooth spline p = 0.0001) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
-/PSL_tmp_w 71 def
+/PSL_tmp_w 354 def
 /PSL_legend_clear_x 133 def
 /PSL_tmp_w PSL_tmp_w PSL_legend_label_width add def
 /PSL_legend_box_width PSL_tmp_w PSL_legend_string_width gt { PSL_tmp_w } { PSL_legend_string_width} ifelse PSL_legend_clear_x add def
@@ -2537,20 +2537,20 @@ O0
 4 W
 V
 {1 0 0 C} FS
-24 90 1057 Sc
+24 185 1057 Sc
 FQ
 O1
 0 W
 1 0 0 C
-24 90 837 S-
+118 185 837 S-
 4 W
 0 A
-24 90 617 S-
+118 185 617 S-
 8 W
-24 90 397 S-
+118 185 397 S-
 17 W
 0 0 1 C
-24 90 177 S-
+118 185 177 S-
 U
 %%EndObject
 0 0 TM
@@ -2565,11 +2565,11 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-138 987 M (Data) bl Z
-138 767 M (Smooth spline p = 1) bl Z
-138 547 M (Smooth spline p = 0.1) bl Z
-138 327 M (Smooth spline p = 0.001) bl Z
-138 107 M (Smooth spline p = 0.0001) bl Z
+421 987 M (Data) bl Z
+421 767 M (Smooth spline p = 1) bl Z
+421 547 M (Smooth spline p = 0.1) bl Z
+421 327 M (Smooth spline p = 0.001) bl Z
+421 107 M (Smooth spline p = 0.0001) bl Z
 %%EndObject
 0 0 TM
 PSL_legend_box_width PSL_legend_box_height sub 2 2 div mul 0 translate
@@ -2582,7 +2582,7 @@ FQ
 O0
 0 167 TM
 % PostScript produced by:
-%@GMT: gmt psxy topo.txt -R300/500/-4500/-3000 -Sc0.1c -Gred -Ey+w3p -N -lData -BWS -Bxaf -Byaf -Xa0i -Ya0.1389i -JX15c
+%@GMT: gmt psxy /Users/pwessel/.gmt/cache/topo_crossection.txt -R300/500/-4500/-3000 -Sc0.1c -Gred -Ey+w3p -N -lData -BWS -Bxaf -Byaf -Xa0i -Ya0.1389i -JX15c
 %@PROJ: xy 300.00000000 500.00000000 -4500.00000000 -3000.00000000 300.000 500.000 -4500.000 -3000.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -2591,7 +2591,7 @@ O0
 /PSL_plot_completion {
 V
 0 167 T
-0 A 67 5333 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 A 67 5333 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 V MU 0 0 M (Weights w = 1/) FP 333 F12 (s) FP 0 117 G 233 F0 (2) FP 0 -117 G pathbbox N 4 1 roll pop pop pop U neg 0 exch G
 (Weights w = 1/) Z
@@ -2610,24 +2610,24 @@ N 0 0 M -83 0 D S
 N 0 1800 M -83 0 D S
 N 0 3600 M -83 0 D S
 N 0 5400 M -83 0 D S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /MM {neg exch M} def
 /PSL_AH0 0
 200 F0
-(-4500) sw mx
-(-4000) sw mx
-(-3500) sw mx
-(-3000) sw mx
+(”4500) sw mx
+(”4000) sw mx
+(”3500) sw mx
+(”3000) sw mx
 def
 /PSL_A0_y PSL_A0_y 83 add def
 0 PSL_A0_y MM
-(-4500) mr Z
+(”4500) mr Z
 1800 PSL_A0_y MM
-(-4000) mr Z
+(”4000) mr Z
 3600 PSL_A0_y MM
-(-3500) mr Z
+(”3500) mr Z
 5400 PSL_A0_y MM
-(-3000) mr Z
+(”3000) mr Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
 N 0 360 M -42 0 D S
 N 0 720 M -42 0 D S
@@ -4766,7 +4766,7 @@ O0
 3.32550952342 setmiterlimit
 /PSL_legend_label_width 0 def
 /PSL_legend_string_width 0 def
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (Data) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
@@ -4778,7 +4778,7 @@ PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
 (Smooth spline p = 0.0001) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
-/PSL_tmp_w 71 def
+/PSL_tmp_w 354 def
 /PSL_legend_clear_x 133 def
 /PSL_tmp_w PSL_tmp_w PSL_legend_label_width add def
 /PSL_legend_box_width PSL_tmp_w PSL_legend_string_width gt { PSL_tmp_w } { PSL_legend_string_width} ifelse PSL_legend_clear_x add def
@@ -4805,20 +4805,20 @@ O0
 4 W
 V
 {1 0 0 C} FS
-24 90 1057 Sc
+24 185 1057 Sc
 FQ
 O1
 0 W
 1 0 0 C
-24 90 837 S-
+118 185 837 S-
 4 W
 0 A
-24 90 617 S-
+118 185 617 S-
 8 W
-24 90 397 S-
+118 185 397 S-
 17 W
 0 0 1 C
-24 90 177 S-
+118 185 177 S-
 U
 %%EndObject
 0 0 TM
@@ -4833,11 +4833,11 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-138 987 M (Data) bl Z
-138 767 M (Smooth spline p = 1) bl Z
-138 547 M (Smooth spline p = 0.1) bl Z
-138 327 M (Smooth spline p = 0.001) bl Z
-138 107 M (Smooth spline p = 0.0001) bl Z
+421 987 M (Data) bl Z
+421 767 M (Smooth spline p = 1) bl Z
+421 547 M (Smooth spline p = 0.1) bl Z
+421 327 M (Smooth spline p = 0.001) bl Z
+421 107 M (Smooth spline p = 0.0001) bl Z
 %%EndObject
 0 0 TM
 PSL_legend_box_width PSL_legend_box_height sub 2 2 div mul 0 translate


### PR DESCRIPTION
**Description of proposed changes**

When only lines are added to the auto-legend we got a minimum 5 mm length, but once a symbol was introduced we used that as the line length, resulting in ridiculously short line symbols.  This PR checks if line symbols were given without a specific length, and if so we set the default symbol size for those lines to 5 mm.  This affects a few PS, especially the recent smooth.ps.