### PR TITLE
Adjust offset to work in grdconvert for tiles

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -715,9 +715,11 @@ GMT_LOCAL int gmtremote_convert_jp2_to_nc (struct GMTAPI_CTRL *API, char *localf
 	ncfile = gmt_strrep (localfile, GMT_TILE_EXTENSION_REMOTE, GMT_TILE_EXTENSION_LOCAL);
 	sprintf (cmd, "%s -G%s%s", localfile, ncfile, args);
 	if (!doubleAlmostEqual (API->remote_info[k_data].scale, 1.0) || !gmt_M_is_zero (API->remote_info[k_data].offset)) {
-		/* Integer is not the original data unit and/or has an offset - must scale/shift jp2 integers to units first */
+		/* Integer is not the original data unit and/or has an offset - must scale/shift jp2 integers to units first.
+		 * Because we are inverting the scaling and because grdconvert applies z' = z * scale + offset, we must
+		 * pre-scale the offset here to survive that translation */
 		char extra[GMT_LEN64] = {""};
-		sprintf (extra, " -Z+s%g+o%g", API->remote_info[k_data].scale, API->remote_info[k_data].offset);
+		sprintf (extra, " -Z+s%g+o%g", API->remote_info[k_data].scale, -API->remote_info[k_data].offset / API->remote_info[k_data].scale);
 		strcat (cmd, extra);
 	}
 	GMT_Report (API, GMT_MSG_INFORMATION, "Convert SRTM tile from JPEG2000 to netCDF grid [%s]\n", ncfile);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -726,6 +726,7 @@ GMT_LOCAL int gmtremote_convert_jp2_to_nc (struct GMTAPI_CTRL *API, char *localf
 	}
 	strcat (cmd, args);	/* Append the common arguments */
 	GMT_Report (API, GMT_MSG_INFORMATION, "Convert SRTM tile from JPEG2000 to netCDF grid [%s]\n", ncfile);
+	GMT_Report (API, GMT_MSG_DEBUG, "Running: grdconvert %sn", cmd);
 	if (GMT_Call_Module (API, "grdconvert", GMT_MODULE_CMD, cmd) != GMT_NOERROR) {
 		GMT_Report (API, GMT_MSG_ERROR, "ERROR - Unable to convert SRTM file %s to compressed netCDF format\n", localfile);
 		gmt_M_free (API->GMT, ncfile);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -960,8 +960,10 @@ int gmtlib_file_is_jpeg2000_tile (struct GMTAPI_CTRL *API, char *file) {
 	/* Detect if a file matches the name <path>/[N|S]yy[E|W]xxx.tag.jp2 (e.g., N22W160.earth_relief_01m_p.jp2) */
 	char *c, tmp[GMT_LEN64] = {""};
 	if (file == NULL || file[0] == '\0') return GMT_NOTSET;	/* Bad argument */
-	if ((c = strrchr (file, '/')) == NULL) return GMT_NOTSET;	/* Get place of the last slash */
-	sprintf (tmp, "@%s", &c[1]);	/* Now should have something like @N22W160.earth_relief_01m_p.jp2 */
+	if ((c = strrchr (file, '/')) == NULL)	/* Get place of the last slash */
+		sprintf (tmp, "@%s", file);	/* Now should have something like @N22W160.earth_relief_01m_p.jp2 */
+	else
+		sprintf (tmp, "@%s", &c[1]);	/* Now should have something like @N22W160.earth_relief_01m_p.jp2 */
 	return (gmt_file_is_a_tile (API, tmp, GMT_REMOTE_DIR));
 }
 

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -768,16 +768,15 @@ static int parse (struct GMT_CTRL *GMT, struct GRDBLEND_CTRL *Ctrl, struct GMT_O
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
 
-GMT_LOCAL bool grdblend_got_plot_domain (struct GMTAPI_CTRL *API, const char *file, bool *ocean) {
+GMT_LOCAL bool grdblend_got_plot_domain (struct GMTAPI_CTRL *API, const char *file, char *code) {
 	/* If given an =tiled_<ID>_[P|G][L|O|X].xxxxxx list then we return true if the region given when the list was assembled
 	 * was a plot domain (give to a PS producer) or a grid domain (given to a grid producer). */
-	char wet, region;
-	*ocean = false;
-	if (!gmt_file_is_tiled_list (API, file, NULL, &wet, &region)) return false;	/* Not a valid tiled list file */
+	char region;
+	*code = 0;
+	if (!gmt_file_is_tiled_list (API, file, NULL, code, &region)) return false;	/* Not a valid tiled list file */
 
 	if (region == 'P') {
 		GMT_Report (API, GMT_MSG_DEBUG, "Got tiled list determined from a plot region\n");
-		if (wet == 'O') *ocean = true;
 		return true;
 	}
 	return false;
@@ -789,13 +788,13 @@ GMT_LOCAL bool grdblend_got_plot_domain (struct GMTAPI_CTRL *API, const char *fi
 EXTERN_MSC int GMT_grdblend (void *V_API, int mode, void *args) {
 	unsigned int col, row, nx_360 = 0, k, kk, m, n_blend, nx_final, ny_final, out_case;
 	int status, pcol, err, error;
-	bool reformat, wrap_x, write_all_at_once = false, first_grid, delayed = true, ocean = false;
+	bool reformat, wrap_x, write_all_at_once = false, first_grid, delayed = true, not_nan;
 
 	uint64_t ij, n_fill, n_tot;
 	double wt_x, w, wt;
 	gmt_grdfloat *z = NULL, no_data_f;
 
-	char type;
+	char type, zcase;
 	char *outfile = NULL, outtemp[PATH_MAX];
 
 	struct GRDBLEND_INFO *blend = NULL;
@@ -837,9 +836,9 @@ EXTERN_MSC int GMT_grdblend (void *V_API, int mode, void *args) {
 
 	if (GMT->common.R.active[RSET] && GMT->common.R.active[ISET]) {	/* Set output grid via -R -I [-r] */
 		double *region = NULL, wesn[4];
-		if (Ctrl->In.n == 1 && grdblend_got_plot_domain (API, Ctrl->In.file[0], &ocean)) {	/* Must adjust -R to be exact multiple of desired grid inc */
+		if (Ctrl->In.n == 1 && grdblend_got_plot_domain (API, Ctrl->In.file[0], &zcase)) {	/* Must adjust -R to be exact multiple of desired grid inc */
 			double inc15[2] = {15.0 / 3600.0, 15.0/ 3600.0};
-			double *inc = (ocean) ? inc15 : GMT->common.R.inc;	/* Pointer to the grid increment */
+			double *inc = (zcase == 'O') ? inc15 : GMT->common.R.inc;	/* Pointer to the grid increment */
 			wesn[XLO] = floor ((GMT->common.R.wesn[XLO] / inc[GMT_X]) + GMT_CONV8_LIMIT) * inc[GMT_X];
 			wesn[XHI] = ceil  ((GMT->common.R.wesn[XHI] / inc[GMT_X]) - GMT_CONV8_LIMIT) * inc[GMT_X];
 			wesn[YLO] = floor ((GMT->common.R.wesn[YLO] / inc[GMT_Y]) + GMT_CONV8_LIMIT) * inc[GMT_Y];
@@ -954,6 +953,7 @@ EXTERN_MSC int GMT_grdblend (void *V_API, int mode, void *args) {
 
 			w = 0.0;	/* Reset weight */
 			first_grid = true;	/* Since some grids do not contain this (row,col) we want to know when we are processing the first grid inside */
+			not_nan = false;	/* Will be true once the first grid that has a non-NaN node is encountered for this (row,col); */
 			for (k = m = 0; k < n_blend; k++) {	/* Loop over every input grid; m will be the number of contributing grids to this node  */
 				if (blend[k].ignore) continue;					/* This grid is entirely outside the s/n range */
 				if (blend[k].outside) continue;					/* This grid is currently outside the s/n range */
@@ -968,6 +968,7 @@ EXTERN_MSC int GMT_grdblend (void *V_API, int mode, void *args) {
 				}
 				kk = pcol - blend[k].out_i0;					/* kk is the local column variable for this grid */
 				if (gmt_M_is_fnan (blend[k].z[kk])) continue;			/* NaNs do not contribute */
+				not_nan = true;	/* At least one non-NaN grid contributing */
 				if (Ctrl->C.active) {	/* Clobber; update z[col] according to selected mode */
 					switch (Ctrl->C.mode) {
 						case BLEND_FIRST: if (m) continue; break;	/* Already set */
@@ -1004,7 +1005,7 @@ EXTERN_MSC int GMT_grdblend (void *V_API, int mode, void *args) {
 				}
 			}
 
-			if (Ctrl->C.sign && m == 0) m = 1, w = 1.0;	/* Since we started off with the first grid and never set m,w at that time */
+			if (Ctrl->C.sign && m == 0 && not_nan) m = 1, w = 1.0;	/* Since we started off with the first grid and never set m,w at that time */
 
 			if (m) {	/* OK, at least one grid contributed to an output value */
 				switch (out_case) {


### PR DESCRIPTION
Because grdconvert always applies z' = z * scale + offset, but our definition in the recpie is z' = (z - offset) * scale, , it turns out we must pass -offset/scale to counter-act this shift.
@seisman, pls delete any *.nc tiles you got earlier so that after trying this branch you will get the JP2 again and this time use the update conversion.