### PR TITLE
Allow remote grids to be auto-derived into intensities

### DIFF
--- a/doc/rst/source/grdimage_common.rst_
+++ b/doc/rst/source/grdimage_common.rst_
@@ -110,6 +110,7 @@ Optional Arguments
     for that module, or just give **+d** to select the
     default arguments (**+a**\ -45\ **+nt**\ 1\ **+m**\ 0). If you want a more
     specific intensity scenario then run :doc:`grdgradient` separately first.
+    If we should derive intensities from another file than *grd_z*, specify the file.
     [Default is no illumination].
 
 .. _-M:

--- a/doc/rst/source/grdimage_common.rst_
+++ b/doc/rst/source/grdimage_common.rst_
@@ -110,7 +110,7 @@ Optional Arguments
     for that module, or just give **+d** to select the
     default arguments (**+a**\ -45\ **+nt**\ 1\ **+m**\ 0). If you want a more
     specific intensity scenario then run :doc:`grdgradient` separately first.
-    If we should derive intensities from another file than *grd_z*, specify the file.
+    If we should derive intensities from another file than *grd_z*, specify the file
     [Default is no illumination].
 
 .. _-M:

--- a/doc/rst/source/grdview_common.rst_
+++ b/doc/rst/source/grdview_common.rst_
@@ -60,7 +60,7 @@ Optional Arguments
     for that module, or just give **+d** to select the
     default arguments (**+a**\ -45\ **+nt**\ 1\ **+m**\ 0). If you want a more
     specific intensity scenario then run :doc:`grdgradient` separately first.
-    If we should derive intensities from another file than *reliefgrid*, specify the file.
+    If we should derive intensities from another file than *reliefgrid*, specify the file
     [Default is no illumination].
 
 .. _-N:

--- a/doc/rst/source/grdview_common.rst_
+++ b/doc/rst/source/grdview_common.rst_
@@ -61,7 +61,7 @@ Optional Arguments
     default arguments (**+a**\ -45\ **+nt**\ 1\ **+m**\ 0). If you want a more
     specific intensity scenario then run :doc:`grdgradient` separately first.
     If we should derive intensities from another file than *reliefgrid*, specify the file.
-   [Default is no illumination].
+    [Default is no illumination].
 
 .. _-N:
 

--- a/doc/rst/source/grdview_common.rst_
+++ b/doc/rst/source/grdview_common.rst_
@@ -60,7 +60,8 @@ Optional Arguments
     for that module, or just give **+d** to select the
     default arguments (**+a**\ -45\ **+nt**\ 1\ **+m**\ 0). If you want a more
     specific intensity scenario then run :doc:`grdgradient` separately first.
-    [Default is no illumination].
+    If we should derive intensities from another file than *reliefgrid*, specify the file.
+   [Default is no illumination].
 
 .. _-N:
 

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -274,11 +274,13 @@ void gmt_set_unspecified_remote_registration (struct GMTAPI_CTRL *API, char **fi
 	 * There are a few different scenarios where this can happen:
 	 * 1. Users of GMT <= 6.0.0 are used to say earth_relief_01m. These will now get p.
 	 * 2. Users who do not care about registration.  If so, they get p if available. */
-	char newfile[GMT_LEN256] = {""}, reg[2] = {'p', 'g'}, *file = NULL, *infile = NULL, *ext = NULL;
+	char newfile[GMT_LEN256] = {""}, reg[2] = {'p', 'g'}, *file = NULL, *infile = NULL, *ext = NULL, *c = NULL;
 	int k_data, k;
 	if (file_ptr == NULL || (file = *file_ptr) == NULL || file[0] == '\0') return;
 	if (file[0] != '@') return;
 	infile = strdup (file);
+	if ((c = strchr (infile, '+')))	/* Got modifiers, probably from grdimage or similar, chop off for now */
+		c[0] = '\0';
 	/* Deal with any extension the user may have added */
 	ext = gmt_chop_ext (infile);
 	/* If the remote file is found then there is nothing to do */
@@ -289,6 +291,10 @@ void gmt_set_unspecified_remote_registration (struct GMTAPI_CTRL *API, char **fi
 		sprintf (newfile, "%s_%c", infile, reg[k]);
 		if ((k_data = gmt_remote_dataset_id (API, newfile)) != GMT_NOTSET) {
 			/* Found, replace given file name with this */
+			if (c) {	/* Restore the modifiers */
+				c[0] = '+';
+				strcat (newfile, c);
+			}
 			gmt_M_str_free (*file_ptr);
 			*file_ptr = strdup (newfile);
 			goto clean_up;

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -200,6 +200,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   For a constant intensity (i.e., change the ambient light), append a value.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   To derive intensities from <grd_z> instead, append +a<azim> [-45], +n<method> [t1], and +m<ambient> [0]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   or use -I+d to accept the default values (see grdgradient for details).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   To derive from another grid than <grd_z>, give a filename as well.\n");
 	GMT_Option (API, "K");
 	GMT_Message (API, GMT_TIME_NONE, "\t-M Force monochrome image.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Do not clip image at the map boundary.\n");

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -859,13 +859,11 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, int_grd))
 			Return (API->error);
 		if (Ctrl->I.file) {	/* Gave a file to derive from */
-			//if (gmt_file_is_tiled_list (API, Ctrl->I.file, NULL, NULL, NULL)) {	/* Must read and stitch the tiles first */
-				if ((I_data = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, API->tile_wesn, Ctrl->I.file, NULL)) == NULL)	/* Get srtm grid data */
-					Return (API->error);
-				if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, I_data, int4_grd))
-					Return (API->error);
-				got_int4_grid = true;
-			//}
+			if ((I_data = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, API->tile_wesn, Ctrl->I.file, NULL)) == NULL)	/* Get srtm grid data */
+				Return (API->error);
+			if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, I_data, int4_grd))
+				Return (API->error);
+			got_int4_grid = true;
 		}
 		/* Prepare the grdgradient arguments using selected -A -N and the data region in effect */
 		sprintf (cmd, "-G%s -A%s -N%s+a%s -R%.16g/%.16g/%.16g/%.16g --GMT_HISTORY=false ",

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -859,7 +859,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, int_grd))
 			Return (API->error);
 		if (Ctrl->I.file) {	/* Gave a file to derive from */
-			if ((I_data = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, API->tile_wesn, Ctrl->I.file, NULL)) == NULL)	/* Get srtm grid data */
+			if ((I_data = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, wesn, Ctrl->I.file, NULL)) == NULL)	/* Get srtm grid data */
 				Return (API->error);
 			if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, I_data, int4_grd))
 				Return (API->error);

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -352,8 +352,10 @@ static int parse (struct GMT_CTRL *GMT, struct GRDIMAGE_CTRL *Ctrl, struct GMT_O
 				break;
 			case 'I':	/* Use intensity from grid or constant or auto-compute it */
 				Ctrl->I.active = true;
-				if (!strcmp (opt->arg, "+d"))	/* Gave +d only, so derive intensities from input grid using default settings */
+				if ((c = strstr (opt->arg, "+d"))) {	/* Gave +d, so derive intensities from the input grid using default settings */
 					Ctrl->I.derive = true;
+					c[0] = '\0';	/* Chop off modifier */
+				}
 				else if ((c = gmt_first_modifier (GMT, opt->arg, "amn"))) {	/* Want to control how grdgradient is run */
 					unsigned int pos = 0;
 					char p[GMT_BUFSIZ] = {""};
@@ -368,20 +370,25 @@ static int parse (struct GMT_CTRL *GMT, struct GRDIMAGE_CTRL *Ctrl, struct GMT_O
 					}
 					c[0] = '\0';	/* Chop off all modifiers so range can be determined */
 				}
-				else if (!opt->arg[0] || strstr (opt->arg, "+"))	/* No argument or just +, so derive intensities from input grid using default settings */
-					Ctrl->I.derive = true;	/* Need to have -I+ since otherwise, -I in mex would try to attach a grid */
-				else if (!gmt_access (GMT, opt->arg, R_OK))	/* Got a file */
-					Ctrl->I.file = strdup (opt->arg);
-				else if (gmt_M_file_is_remote (opt->arg))	/* Got a remote file */
-					Ctrl->I.file = strdup (opt->arg);
-				else if (opt->arg[0] && gmt_is_float (GMT, opt->arg)) {	/* Looks like a constant value */
-					Ctrl->I.value = atof (opt->arg);
-					Ctrl->I.constant = true;
+				else if (!opt->arg[0] || !strcmp (opt->arg, "+")) {	/* Gave deprecated option to derive intensities from the input grid using default settings */
+					Ctrl->I.derive = true;
+					if (opt->arg[0]) opt->arg[0] = '\0';	/* Remove the single + */
 				}
-				else {
+				if (opt->arg[0]) {	/* Gave an argument in addition to or instead of a modifier */
+					if (!gmt_access (GMT, opt->arg, R_OK))	/* Got a file */
+						Ctrl->I.file = strdup (opt->arg);
+					else if (gmt_M_file_is_remote (opt->arg))	/* Got a remote file */
+						Ctrl->I.file = strdup (opt->arg);
+					else if (opt->arg[0] && gmt_is_float (GMT, opt->arg)) {	/* Looks like a constant value */
+						Ctrl->I.value = atof (opt->arg);
+						Ctrl->I.constant = true;
+					}
+				}
+				else if (!Ctrl->I.active) {
 					GMT_Report (API, GMT_MSG_ERROR, "Option -I: Requires a valid grid file or a constant\n");
 					n_errors++;
 				}
+				if (c) c[0] = '+';	/* Restore the plus */
 				break;
 			case 'M':	/* Monochrome image */
 				Ctrl->M.active = true;
@@ -668,8 +675,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 			 * force all tiles to be downloaded, converted, and stitched into a single grid per -R. This must
 			 * happen _before_ we auto-derive intensities via grdgradient so that there is an input data grid */
 
-			if (gmt_file_is_tiled_list (API, Ctrl->In.file[0], NULL, NULL, NULL)) {	/* Must read and stitch the tiles first */
-				//if ((Grid_orig[0] = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, GMT->common.R.wesn, Ctrl->In.file[0], NULL)) == NULL)	/* Get srtm grid data */
+			if (Ctrl->I.file == NULL && gmt_file_is_tiled_list (API, Ctrl->In.file[0], NULL, NULL, NULL)) {	/* Must read and stitch the tiles first */
 				if ((Grid_orig[0] = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, API->tile_wesn, Ctrl->In.file[0], NULL)) == NULL)	/* Get srtm grid data */
 					Return (API->error);
 				if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, Grid_orig[0], data_grd))
@@ -843,16 +849,32 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 	 * auto-derived intensities we may create below */
 
 	if (Ctrl->I.derive) {	/* Auto-create intensity grid from data grid using the now determined data region */
-		char int_grd[GMT_VF_LEN] = {""};
+		bool got_int4_grid = false;
+		char int_grd[GMT_VF_LEN] = {""}, int4_grd[GMT_VF_LEN] = {""};
+		struct GMT_GRID *I_data = NULL;
+
 		GMT_Report (API, GMT_MSG_INFORMATION, "Derive intensity grid from data grid\n");
 		/* Create a virtual file to hold the intensity grid */
 		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, int_grd))
 			Return (API->error);
+		if (Ctrl->I.file) {	/* Gave a file to derive from */
+			if (gmt_file_is_tiled_list (API, Ctrl->I.file, NULL, NULL, NULL)) {	/* Must read and stitch the tiles first */
+				if ((I_data = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, API->tile_wesn, Ctrl->I.file, NULL)) == NULL)	/* Get srtm grid data */
+					Return (API->error);
+				if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, I_data, int4_grd))
+					Return (API->error);
+				got_int4_grid = true;
+			}
+		}
 		/* Prepare the grdgradient arguments using selected -A -N and the data region in effect */
 		sprintf (cmd, "-G%s -A%s -N%s+a%s -R%.16g/%.16g/%.16g/%.16g --GMT_HISTORY=false ",
 			int_grd, Ctrl->I.azimuth, Ctrl->I.method, Ctrl->I.ambient, wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI]);
 		if (got_data_grid)	/* Use the virtual file we made earlier */
 			strcat (cmd, data_grd);
+		else if (got_int4_grid)	/* Use the virtual file we made earlier */
+			strcat (cmd, int4_grd);
+		else if (Ctrl->I.file)
+			strcat (cmd, Ctrl->I.file);
 		else
 			strcat (cmd, Ctrl->In.file[0]);
 		/* Call the grdgradient module */
@@ -864,6 +886,8 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 			Return (API->error);
 		if (got_data_grid)
 			GMT_Close_VirtualFile (API, data_grd);
+		else if (got_int4_grid)	/* Use the virtual file we made earlier */
+			GMT_Close_VirtualFile (API, int4_grd);
 	}
 
 	if (n_grids) {	/* Get grid dimensions */

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -859,13 +859,13 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, int_grd))
 			Return (API->error);
 		if (Ctrl->I.file) {	/* Gave a file to derive from */
-			if (gmt_file_is_tiled_list (API, Ctrl->I.file, NULL, NULL, NULL)) {	/* Must read and stitch the tiles first */
+			//if (gmt_file_is_tiled_list (API, Ctrl->I.file, NULL, NULL, NULL)) {	/* Must read and stitch the tiles first */
 				if ((I_data = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, API->tile_wesn, Ctrl->I.file, NULL)) == NULL)	/* Get srtm grid data */
 					Return (API->error);
 				if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, I_data, int4_grd))
 					Return (API->error);
 				got_int4_grid = true;
-			}
+			//}
 		}
 		/* Prepare the grdgradient arguments using selected -A -N and the data region in effect */
 		sprintf (cmd, "-G%s -A%s -N%s+a%s -R%.16g/%.16g/%.16g/%.16g --GMT_HISTORY=false ",

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -439,8 +439,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t          2) The -G option requires the -Qi[<dpi>] option.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Apply directional illumination. Append name of intensity grid file.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   For a constant intensity (i.e., change the ambient light), append a value.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   To derive intensities from <grd_z> instead, append +a<azim> [-45], +n<method> [t1], and +m<ambient> [0]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   To derive intensities from <topogrid> instead, append +a<azim> [-45], +n<method> [t1], and +m<ambient> [0]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   or use -I+d to accept the default values (see grdgradient for details).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   To derive from another grid than <topogrid>, give a filename as well.\n");
 	GMT_Option (API, "K");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Draw a horizontal plane at z = <level>. For rectangular projections, append +g<fill>\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   to paint the facade between the plane and the data perimeter.\n");
@@ -845,7 +846,7 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 		}
 	}
 
-	if (!Ctrl->C.active && Ctrl->Q.cpt)
+	if (!Ctrl->C.active && Ctrl->Q.cpt && Ctrl->G.n == 1)
 		Ctrl->C.active = true;	/* Use default CPT (GMT_DEFAULT_CPT_NAME) and autostretch or under modern reuse current CPT */
 
 	/* Determine what wesn to pass to map_setup */

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -895,7 +895,7 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 
 		if (Ctrl->I.file) {	/* Gave a file to derive from */
 			if (gmt_file_is_tiled_list (API, Ctrl->I.file, NULL, NULL, NULL)) {	/* Must read and stitch the tiles first */
-				if ((I_data = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, API->tile_wesn, Ctrl->I.file, NULL)) == NULL)	/* Get srtm grid data */
+				if ((I_data = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, wesn, Ctrl->I.file, NULL)) == NULL)	/* Get srtm grid data */
 					Return (API->error);
 				if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, I_data, data_file))
 					Return (API->error);

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -98,6 +98,7 @@ struct GRDVIEW_CTRL {
 		bool active, special;
 		bool mask;
 		bool monochrome;
+		bool cpt;
 		int outline;
 		unsigned int mode;	/* GRDVIEW_MESH, GRDVIEW_SURF, GRDVIEW_IMAGE */
 		unsigned int dpi;
@@ -535,8 +536,10 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT_OP
 				break;
 			case 'I':	/* Use intensity from grid or constant or auto-compute it */
 				Ctrl->I.active = true;
-				if (!strcmp (opt->arg, "+d"))	/* Gave +d only, so derive intensities from input grid using default settings */
+				if ((c = strstr (opt->arg, "+d"))) {	/* Gave +d, so derive intensities from the input grid using default settings */
 					Ctrl->I.derive = true;
+					c[0] = '\0';	/* Chop off modifier */
+				}
 				else if ((c = gmt_first_modifier (GMT, opt->arg, "amn"))) {	/* Want to control how grdgradient is run */
 					unsigned int pos = 0;
 					char p[GMT_BUFSIZ] = {""};
@@ -551,20 +554,25 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT_OP
 					}
 					c[0] = '\0';	/* Chop off all modifiers so range can be determined */
 				}
-				else if (!opt->arg[0] || strstr (opt->arg, "+"))	/* No argument or just +, so derive intensities from input grid using default settings */
-					Ctrl->I.derive = true;	/* Need to have -I+ since otherwise, -I in mex would try to attach a grid */
-				else if (!gmt_access (GMT, opt->arg, R_OK))	/* Got a file */
-					Ctrl->I.file = strdup (opt->arg);
-				else if (gmt_M_file_is_remote (opt->arg))	/* Got a remote file */
-					Ctrl->I.file = strdup (opt->arg);
-				else if (opt->arg[0] && gmt_is_float (GMT, opt->arg)) {	/* Looks like a constant value */
-					Ctrl->I.value = atof (opt->arg);
-					Ctrl->I.constant = true;
+				else if (!opt->arg[0] || !strcmp (opt->arg, "+")) {	/* Gave deprecated option to derive intensities from the input grid using default settings */
+					Ctrl->I.derive = true;
+					if (opt->arg[0]) opt->arg[0] = '\0';	/* Remove the single + */
 				}
-				else {
+				if (opt->arg[0]) {	/* Gave an argument in addition to or instead of a modifier */
+					if (!gmt_access (GMT, opt->arg, R_OK))	/* Got a file */
+						Ctrl->I.file = strdup (opt->arg);
+					else if (gmt_M_file_is_remote (opt->arg))	/* Got a remote file */
+						Ctrl->I.file = strdup (opt->arg);
+					else if (opt->arg[0] && gmt_is_float (GMT, opt->arg)) {	/* Looks like a constant value */
+						Ctrl->I.value = atof (opt->arg);
+						Ctrl->I.constant = true;
+					}
+				}
+				else if (!Ctrl->I.active) {
 					GMT_Report (API, GMT_MSG_ERROR, "Option -I: Requires a valid grid file or a constant\n");
 					n_errors++;
 				}
+				if (c) c[0] = '+';	/* Restore the plus */
 				break;
 			case 'L':	/* GMT4 BCs */
 				if (gmt_M_compat_check (GMT, 4)) {
@@ -620,10 +628,12 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT_OP
 						break;
 					case 't':	/* Image without color interpolation */
 						Ctrl->Q.special = true;
+						Ctrl->Q.cpt = true;	/* Will need a CPT */
 						/* Intentionally fall through - to 'i' */
 					case 'i':	/* Image with clipmask */
 						Ctrl->Q.mode = GRDVIEW_IMAGE;
 						if (opt->arg[1] && isdigit ((int)opt->arg[1])) Ctrl->Q.dpi = atoi (&opt->arg[1]);
+						Ctrl->Q.cpt = true;	/* Will need a CPT */
 						break;
 					case 'm':	/* Mesh plot */
 						n = 0;
@@ -649,6 +659,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT_OP
 					case 's':	/* Color without contours */
 						Ctrl->Q.mode = GRDVIEW_SURF;
 						if (opt->arg[1] == 'm') Ctrl->Q.outline = 1;
+						Ctrl->Q.cpt = true;	/* Will need a CPT */
 						break;
 					default:
 						GMT_Report (API, GMT_MSG_ERROR, "Option -Q: Unrecognized qualifier (%c)\n", opt->arg[0]);
@@ -752,7 +763,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT_OP
 	n_errors += gmt_M_check_condition (GMT, Ctrl->I.active && !Ctrl->I.constant && !Ctrl->I.file && !Ctrl->I.derive,
 	                                   "Option -I: Must specify intensity file, value, or modifiers\n");
 	n_errors += gmt_M_check_condition (GMT, (Ctrl->Q.mode == GRDVIEW_SURF || Ctrl->Q.mode == GRDVIEW_IMAGE || Ctrl->W.contour) &&
-	                                   !Ctrl->C.file && Ctrl->G.n != 3 && !no_cpt, "Must specify color palette table\n");
+	                                   !Ctrl->C.file && Ctrl->G.n != 3 && !no_cpt && GMT->current.setting.run_mode == GMT_CLASSIC, "Must specify color palette table\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.mode == GRDVIEW_IMAGE && Ctrl->Q.dpi <= 0,
 	                                 "Option -Qi: Must specify positive dpi\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->T.active && GMT->current.proj.JZ_set,
@@ -834,6 +845,9 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 		}
 	}
 
+	if (!Ctrl->C.active && Ctrl->Q.cpt)
+		Ctrl->C.active = true;	/* Use default CPT (GMT_DEFAULT_CPT_NAME) and autostretch or under modern reuse current CPT */
+
 	/* Determine what wesn to pass to map_setup */
 
 	if (!GMT->common.R.active[RSET])	/* No -R, use grid region */
@@ -871,11 +885,24 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 
 	if (Ctrl->I.derive) {	/* Auto-create intensity grid from data grid */
 		char int_grd[GMT_VF_LEN] = {""}, data_file[PATH_MAX] = {""}, cmd[GMT_LEN256] = {""};
+		struct GMT_GRID *I_data = NULL;
+
 		GMT_Report (API, GMT_MSG_INFORMATION, "Derive intensity grid from data grid\n");
 		/* Create a virtual file to hold the intensity grid */
 		if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, int_grd))
 			Return (API->error);
-		if (Topo->data) {	/* If not NULL it means we have a tiled and blended grid, use as is */
+
+		if (Ctrl->I.file) {	/* Gave a file to derive from */
+			if (gmt_file_is_tiled_list (API, Ctrl->I.file, NULL, NULL, NULL)) {	/* Must read and stitch the tiles first */
+				if ((I_data = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, API->tile_wesn, Ctrl->I.file, NULL)) == NULL)	/* Get srtm grid data */
+					Return (API->error);
+				if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, I_data, data_file))
+					Return (API->error);
+			}
+			else
+				strcpy (data_file, Ctrl->I.file);
+		}
+		else if (Topo->data) {	/* If not NULL it means we have a tiled and blended grid, use as is */
 			if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, Topo, data_file))
 				Return (API->error);
 		}


### PR DESCRIPTION
**Description of proposed changes**

See #3589 for background.  This PR implements that feature.  I have tested various examples that work for me:

Data sets not tiled:

```
gmt grdimage @earth_age_30m -B -png map -C@age.cpt -I@earth_relief_30m+d
gmt grdimage @earth_age_30m -B -png map -C@age.cpt -I@earth_relief_30m+d -Rg
gmt grdimage @earth_age_30m -B -png map -C@age.cpt -I@earth_relief_30m+d -R-45/22/-35/25
gmt grdview @earth_age_30m -B -png map -C@age.cpt -I@earth_relief_30m+d -Qi100
gmt grdview @earth_age_30m -B -png map -C@age.cpt -I@earth_relief_30m+d -Qi100 -Rg
gmt grdview @earth_age_30m -B -png map -C@age.cpt -I@earth_relief_30m+d -Qi100 -R-45/22/-35/25

```
Tiled data:
```
gmt grdimage @earth_age_05m -B -png map -Cage.cpt -I@earth_relief_05m+d
gmt grdimage @earth_age_05m -B -png map -Cage.cpt -I@earth_relief_05m+d -Rg
gmt grdimage @earth_age_05m -B -png map -Cage.cpt -I@earth_relief_05m+d -R-45/22/-35/25
gmt grdview @earth_age_05m -B -png map -Cage.cpt -I@earth_relief_05m+d -Qi300
gmt grdview @earth_age_05m -B -png map -Cage.cpt -I@earth_relief_05m+d -Qi300 -Rg
gmt grdview @earth_age_05m -B -png map -Cage.cpt -I@earth_relief_05m+d -Qi300 -R-45/22/-35/25

```
High res (no _p yet so specifying the resolution).

`gmt grdimage @earth_age_01m_g -B -png map -Cage.cpt -I@earth_relief_01m_g+d -R-10/5/-10/5`
