### PR TITLE
Let gdal_open know about and apply cache dir

### DIFF
--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -143,6 +143,7 @@ struct GMTAPI_CTRL {
 	bool usage;				/* Flag when 1-liner modern mode modules just want usage */
 	bool allow_reuse;				/* Flag when get_region_from_data can read a file and not flag it as "used" */
 	bool is_file;					/* True if current rec-by-rec i/o is from a physical file */
+	bool cache;					/* true if we want to read a cache file via GDAL */
 	size_t n_objects_alloc;			/* Allocation counter for data objects */
 	int error;				/* Error code from latest API call [GMT_OK] */
 	int last_error;				/* Error code from previous API call [GMT_OK] */

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -835,7 +835,15 @@ int gmt_set_remote_and_local_filenames (struct GMT_CTRL *GMT, const char * file,
 		else {	/* Must be cache file */
 			if (GMT->session.CACHEDIR == NULL) goto not_local;	/* Cannot have cache data if no cache directory created yet */
 			snprintf (local_path, PATH_MAX, "%s/%s", GMT->session.CACHEDIR, &file[1]);	/* This is where all cache files live */
-			if (access (local_path, R_OK)) goto not_local;	/* No such file yet */
+			if ((c = strchr (local_path, '=')) || (c = strchr (local_path, '?'))) {
+				was = c[0];	c[0] = '\0';
+			}
+			GMT->parent->cache = true;
+			if (access (local_path, R_OK)) {
+				if (c) c[0] = was;
+				goto not_local;	/* No such file yet */
+			}
+			if (c) c[0] = was;
 		}
 		GMT_Report (API, GMT_MSG_DEBUG, "Remote file %s exists locally as %s\n", file, local_path);
 		remote_path[0] = '\0';	/* No need to get from elsewhere */

--- a/test/gmtmex/WL_example_3.sh
+++ b/test/gmtmex/WL_example_3.sh
@@ -8,11 +8,11 @@ gmt begin WL_example_3 ps
   # Speed up processing by using native binary intermediary files
   file="A2016152023000.L2_LAC_SST.nc"
   args="=gd?HDF5:A2016152023000.L2_LAC_SST.nc"
-  gmt which -G @${file}
-  gmt grd2xyz ${file}${args}://geophysical_data/qual_sst -ZTLf > qual_sst.b
-  gmt grd2xyz ${file}${args}://geophysical_data/sst -ZTLf > sst.b
-  gmt grd2xyz ${file}${args}://navigation_data/longitude -ZTLf > lon.b
-  gmt grd2xyz ${file}${args}://navigation_data/latitude -ZTLf > lat.b
+  gmt which -Gc @${file}
+  gmt grd2xyz @${file}${args}://geophysical_data/qual_sst -ZTLf > qual_sst.b
+  gmt grd2xyz @${file}${args}://geophysical_data/sst -ZTLf > sst.b
+  gmt grd2xyz @${file}${args}://navigation_data/longitude -ZTLf > lon.b
+  gmt grd2xyz @${file}${args}://navigation_data/latitude -ZTLf > lat.b
   # Merge columns and skip record whose sst_qual > 0
   gmt convert -A lon.b lat.b sst.b qual_sst.b -bi1f -bo4d | gmt select -Z-/0+c3 -bi4d -bo3d -o0-2 > input.b
   # Perform nearest neighbor gridding


### PR DESCRIPTION
Since some files passed to GDAL has a leading driver: we need to insert the cach dir in-between the driver and the filename.  This is unique to files that must be read via GDAL this way. This allows a remote file to be used in test WL_example_3.sh.

WIP for now since only being merged after tag and creation of a 6.1 branch.