### PR TITLE
Update gmt_mb.h

### DIFF
--- a/src/gmt_mb.h
+++ b/src/gmt_mb.h
@@ -20,7 +20,7 @@
  * the MB-system programs mbcontour.c, mbgrdtiff.c, and mbswath.c.
  *
  * Author:      Paul Wessel
- * Date:        11-Mar-2018
+ * Date:        4-Jul-2020
  * Version:     6 API
  */
 
@@ -28,10 +28,8 @@
 #ifndef GMT_MB_H
 #define GMT_MB_H
 
-#if GMT_MAJOR_VERSION == 6
-#define gmt_get_cpt(GMT,file,flag,min,max) gmt_get_palette(GMT,file,flag,min,max,0.0,0)
+#define gmt_get_cpt(GMT,file,flag,min,max) gmt_get_palette(GMT,file,flag,min,max,0.0)
 #define gmt_M_grd_is_global gmt_grd_is_global
 #define GMT_c_OPT	"-c<ncopies>"	/* OBSOLETE */
-#endif
 
 #endif /* GMT_MB_H */


### PR DESCRIPTION
The gmt function _gmt_get_cpt_ dropped its 7th argument for 6.1 and that affects the _gmt_get_cpt_ macro used in MB-System.

Oddly, the previous version of this include file had #ifdef checks on the GMT version, but that is pointless since the GMT version is what it is.  Any check would need to be for MB version.