### PR TITLE
Let CI deploy documentations in master and 6.x branches

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -76,7 +76,8 @@ jobs:
 ########################################################################################
 - job:
   displayName: 'Linux | Build docs + Deploy docs + Package'
-  condition: eq(variables['Build.SourceBranchName'], 'master')
+  # Deploy documentation in master and 6.x branches
+  condition: in(variables['Build.SourceBranchName'], 'master', '6.1', '6.2', '6.3', '6.4', '6.5')
 
   pool:
     vmImage: 'ubuntu-18.04'


### PR DESCRIPTION
The gh-pages branch still don't have the documentation for GMT 6.1, simply because the job for building documentations is only triggered in master branch.

This PR allow the job run in master and 6.x branches.