### PR TITLE
Fix syntax error in gmt_regexp.c

### DIFF
--- a/src/gmt_regexp.c
+++ b/src/gmt_regexp.c
@@ -217,7 +217,7 @@ int gmtlib_regexp_match (struct GMT_CTRL *GMT, const char *subject, const char *
 		/* this is when errors have been encountered */
 		regerror(status, &re, err_msg, MAX_ERR_LENGTH);
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtlib_regexp_match: POSIX ERE matching error: %s\n", err_msg); /* Report error. */
-		return (-GMT_RUNTIME_ERROR;)
+		return (-GMT_RUNTIME_ERROR);
 	}
 	return (0); /* No match */
 


### PR DESCRIPTION
I tried building GMT 6.1.0 with AppleClang 11.0.3 on macOS 10.15.5, but compilation fails with the following error:
```
/private/var/folders/21/hwq39zyj4g36x6zjfyl5l8080000gn/T/Adam/spack-stage/spack-stage-gmt-6.1.0-kvj2zi5nvdutba2zsdu5onzusknh3how/spack-src/src/gmt_regexp.c:220:29: error: unexpected ';' before ')'
                    return (-GMT_RUNTIME_ERROR;)
                                              ^
```
This PR fixes the syntax error, and 6.1.0 compiles fine with this patch.

Let me know if I should also submit a PR to the master branch.

@PaulWessel it looks like this bug was introduced in #3389