### PR TITLE
Honor the colon switch for external data

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -3980,6 +3980,7 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 					GMT_Report (API, GMT_MSG_WARNING, "Row-selection via -qi is not implemented for GMT_IS_REFERENCE GMT_IS_DATASET external memory objects\n");
 				GMT_Report (API, GMT_MSG_INFORMATION, "Referencing data table from GMT_DATASET memory location\n");
 				if ((D_obj = S_obj->resource) == NULL) return_null (API, GMT_PTR_IS_NULL);
+				check_col_switch = true;
 				DH = gmt_get_DD_hidden (D_obj);
 				break;
 
@@ -4049,7 +4050,7 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 				DH = gmt_get_DD_hidden (D_obj);
 				DH->alloc_level = API->object[new_item]->alloc_level;	/* Since allocated here */
 				D_obj->geometry = S_obj->geometry;	/* Since provided when registered */
-				update = via = check_col_switch = true;
+				update = via = true;
 				break;
 
 	 		case GMT_IS_DUPLICATE|GMT_VIA_VECTOR:
@@ -4117,7 +4118,7 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 				DH = gmt_get_DD_hidden (D_obj);
 				DH->alloc_level = API->object[new_item]->alloc_level;	/* Since allocated here */
 				D_obj->geometry = S_obj->geometry;	/* Since provided when registered */
-				update = via = check_col_switch = true;
+				update = via = true;
 				break;
 
 		 	case GMT_IS_REFERENCE|GMT_VIA_VECTOR:

--- a/src/gmt_macros.h
+++ b/src/gmt_macros.h
@@ -116,6 +116,7 @@
 #define gmt_M_int_swap(x, y) {int int_tmp; int_tmp = x, x = y, y = int_tmp;}
 #define gmt_M_uint_swap(x, y) {unsigned int uint_tmp; uint_tmp = x, x = y, y = uint_tmp;}
 #define gmt_M_double_swap(x, y) {double double_tmp; double_tmp = x, x = y, y = double_tmp;}
+#define gmt_M_doublep_swap(x, y) {double *double_tmp; double_tmp = x, x = y, y = double_tmp;}
 #define gmt_M_float_swap(x, y) {float float_tmp; float_tmp = x, x = y, y = float_tmp;}
 
 /*! Macro to ensure proper value and sign of a change in longitude from lon1 to lon2 */


### PR DESCRIPTION
**Description of proposed changes**

When we use **-:** we basically set both **-:i** and **-:o**.  With file i/o this works fine.  With externals there were several issues (#3289 ):

1. When we read data from externals we either get a dataset, a matrix, or vectors.  We then build a dataset.  For these paths, there were no check on **-:i**.  I have added that.
2. When we write to externals from an internal dataset we either write a dataset, a matrix, or a vector.  Each of those cases needed a check for **-:o**.
3. Some modules do rec-by-rec i/o and go via a different path entirely.  I have similarly added **-:** checks on i/o for those pathways that did not check.

I think that corrects all these issues and closes #3289.