### PR TITLE
Try to refresh only when remote files are requested

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13585,7 +13585,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 	 * Modules like psxy has "d" so we can make a quick map without specifying -R.
 	 */
 
-	bool is_PS, is_psrose = false, is_D_module = false;
+	bool is_PS, is_psrose = false, is_D_module = false, remote_first = true;
 	char *required = (char *)in_required;
 	unsigned int k;
 	static char *D_module[4] = {"gmtlogo", "psimage", "pslegend", "psscale"};	/* These all may take -Dx etc */
@@ -13603,6 +13603,10 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 
 	for (opt = *options; opt; opt = opt->next) {	/* Loop over all options */
 		if (opt->arg[0] != '@') continue;	/* No remote file argument given */
+		if (remote_first) {
+			gmt_refresh_server (GMT);	/* Refresh hash and info tables as needed */
+			remote_first = false;
+		}
 		gmt_set_unspecified_remote_registration (API, &(opt->arg));	/* If argument is a remote file name then tis handles any missing registration _p|_g */
 	}
 
@@ -16485,8 +16489,6 @@ struct GMT_CTRL *gmt_begin (struct GMTAPI_CTRL *API, const char *session, unsign
 	gmtlib_fft_initialization (GMT);	/* Determine which FFT algos are available and set pointers */
 
 	gmtinit_set_today (GMT);	/* Determine today's rata die value */
-
-	gmtlib_refresh_server (GMT);	/* Refresh hash and info tables if needed */
 
 	return (GMT);
 }

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -55,7 +55,6 @@ EXTERN_MSC char *dlerror (void);
 EXTERN_MSC int gmtlib_file_is_jpeg2000_tile (struct GMTAPI_CTRL *API, char *file);
 EXTERN_MSC int gmtlib_download_remote_file (struct GMT_CTRL *GMT, const char* file_name, char *path, int k_data, unsigned int mode);
 EXTERN_MSC int gmtlib_get_serverfile_index (struct GMTAPI_CTRL *API, const char *file);
-EXTERN_MSC void gmtlib_refresh_server (struct GMT_CTRL *GMT);
 EXTERN_MSC bool gmtlib_module_may_get_R_from_RP (struct GMT_CTRL *GMT, const char *mod_name);
 EXTERN_MSC double gmtlib_distance_type (struct GMT_CTRL *GMT, double lonS, double latS, double lonE, double latE, unsigned int id);
 EXTERN_MSC bool gmtlib_genper_reset (struct GMT_CTRL *GMT, bool reset);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -170,6 +170,7 @@ EXTERN_MSC double gmt_fft_any_wave (uint64_t k, unsigned int mode, struct GMT_FF
 
 /* gmt_remote.c: */
 
+EXTERN_MSC void gmt_refresh_server (struct GMT_CTRL *GMT);
 EXTERN_MSC int gmt_download_file (struct GMT_CTRL *GMT, const char *name, char *url, char *localfile, bool mode);
 EXTERN_MSC int gmt_set_remote_and_local_filenames (struct GMT_CTRL *GMT, const char* file, char *local_path, char *remote_path, unsigned int mode);
 EXTERN_MSC int gmt_remote_dataset_id (struct GMTAPI_CTRL *API, const char *file);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -665,7 +665,7 @@ GMT_LOCAL int gmtremote_refresh (struct GMT_CTRL *GMT, unsigned int index) {
 	return GMT_NOERROR;
 }
 
-void gmtlib_refresh_server (struct GMT_CTRL *GMT) {
+void gmt_refresh_server (struct GMT_CTRL *GMT) {
 	/* Called once in gmt_begin from GMT_Create_Session,  The following actions take place:
 	 *
 	 * The data info table is refreshed if missing or older than 24 hours.

--- a/src/gmtget.c
+++ b/src/gmtget.c
@@ -212,6 +212,8 @@ EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 			double world[4] = {-180.0, +180.0, -90.0, +90.0};
 			struct GMT_RECORD *Out = NULL;
 
+			gmt_refresh_server (GMT);	/* Refresh hash and info tables as needed since we need to know what is there */
+
 			if (Ctrl->Q.active) {	/* Must activate data output machinery for a DATASET with no numerical columns */
 				Out = gmt_new_record (GMT, NULL, message);
 				if ((error = GMT_Set_Columns (API, GMT_OUT, 0, GMT_COL_FIX)) != GMT_NOERROR) Return (API->error);


### PR DESCRIPTION
**Description of proposed changes**

See #3609 for background.  This PR examines the option arguments in gmt_init_module, before any parsing happens, and if it finds an argument starting with @ or an argument containing a @ that is not inside quotes, it errs on the side of caution and refreshes the server (once).

All tests pass for me.  We consider this a but (excessive checking) so goes into 6.1.