### PR TITLE
Numerous bugs fixed in psrose

### DIFF
--- a/doc/rst/source/psrose.rst
+++ b/doc/rst/source/psrose.rst
@@ -24,7 +24,7 @@ Synopsis
 [ |-M|\ *parameters* ]
 [ |-O| ] [ |-P| ]
 [ |-Q|\ *alpha* ]
-[ |-R|\ *r0*/*r1*/*az_0*/*az_1* ]
+[ |-R|\ *r0*/*r1*/*az0*/*az1* ]
 [ |-S| ]
 [ |-T| ]
 [ |SYN_OPT-U| ]

--- a/doc/rst/source/rose.rst
+++ b/doc/rst/source/rose.rst
@@ -23,7 +23,7 @@ Synopsis
 [ |-L|\ [*wlabel*\ ,\ *elabel*\ ,\ *slabel*\ ,\ *nlabel*] ]
 [ |-M|\ *parameters* ]
 [ |-Q|\ *alpha* ]
-[ |-R|\ *r0*/*r1*/*az_0*/*az_1* ]
+[ |-R|\ *r0*/*r1*/*az0*/*az1* ]
 [ |-S| ]
 [ |-T| ]
 [ |SYN_OPT-U| ]

--- a/doc/rst/source/rose_common.rst_
+++ b/doc/rst/source/rose_common.rst_
@@ -117,7 +117,7 @@ Optional Arguments
 .. _-R:
 
 **-R**\ *r0*/*r1*/*az0*/*az1*
-    Specifies the 'region' of interest in (*r*\ ,*azimuth*) space. Here, *r0* is 0, *r1*
+    Specifies the 'region' of interest in (*r*\ ,\ *azimuth*) space. Here, *r0* is 0, *r1*
     is max length in units. For azimuth, specify either -90/90 or 0/180
     for half circle plot or 0/360 for full circle.
 

--- a/doc/rst/source/rose_common.rst_
+++ b/doc/rst/source/rose_common.rst_
@@ -64,7 +64,7 @@ Optional Arguments
 .. _-F:
 
 **-F**
-    Do not draw the scale length bar [Default plots scale in lower right corner]
+    Do not draw the scale length bar [Default plots scale in lower right corner provided **-B** is used]
 
 .. _-G:
 

--- a/doc/rst/source/rose_common.rst_
+++ b/doc/rst/source/rose_common.rst_
@@ -34,14 +34,12 @@ Optional Arguments
 
 .. include:: explain_-B.rst_
 |
-|   Remember that "x" here is
-|   radial distance and "y" is azimuth. The ylabel may be used to plot a figure caption.
-|   The scale bar length is determined by the radial gridline spacing.
+|   Remember that "x" here is radial distance and "y" is azimuth. The ylabel may be used to plot a figure caption. The scale bar length is determined by the radial gridline spacing.
 
 .. _-C:
 
 **-C**\ *cpt*
-    Give a CPT. The r-value for each sector is used to
+    Give a CPT. The *r*-value for each sector is used to
     look-up the sector color.  Cannot be used with a rose diagram.
     If modern mode and no argument is given then we select the current CPT.
 
@@ -94,7 +92,7 @@ Optional Arguments
     full-circle plot the default is WEST,EAST,SOUTH,NORTH and for
     half-circle the default is 90W,90E,-,0. A - in any entry disables
     that label. Use **-L** with no argument to disable all four labels.
-    Note that the GMT_LANGUAGE setting will affect the words used.
+    Note that the :term:`GMT_LANGUAGE` setting will affect the words used.
 
 .. _-M:
 
@@ -118,8 +116,8 @@ Optional Arguments
 
 .. _-R:
 
-**-R**\ *r0*/*r1*/*az\_0*/*az\_1*
-    Specifies the 'region' of interest in (r,azimuth) space. r0 is 0, r1
+**-R**\ *r0*/*r1*/*az0*/*az1*
+    Specifies the 'region' of interest in (*r*\ ,*azimuth*) space. Here, *r0* is 0, *r1*
     is max length in units. For azimuth, specify either -90/90 or 0/180
     for half circle plot or 0/360 for full circle.
 
@@ -166,8 +164,8 @@ Optional Arguments
     scaling].
 
 **-:**
-    Input file has (azimuth,radius) pairs rather than the expected
-    (radius,azimuth).
+    Input file has (*azimuth,radius*) pairs rather than the expected
+    (*radius,azimuth*).
 
 .. |Add_-bi| replace:: [Default is 2 input columns].
 .. include:: explain_-bi.rst_

--- a/src/psrose.c
+++ b/src/psrose.c
@@ -400,7 +400,6 @@ static int parse (struct GMT_CTRL *GMT, struct PSROSE_CTRL *Ctrl, struct GMT_OPT
 
 	/* Check that the options selected are mutually consistent */
 
-	GMT->common.R.wesn[XLO] = 0.0;
 	range = GMT->common.R.wesn[YHI] - GMT->common.R.wesn[YLO];
 	if (doubleAlmostEqual (range, 180.0) && Ctrl->T.active) {
 		GMT_Report (API, GMT_MSG_WARNING, "-T only needed for 0-360 range data (ignored)");
@@ -425,6 +424,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSROSE_CTRL *Ctrl, struct GMT_OPT
 			|| (GMT->common.R.wesn[YLO] == 0.0 && GMT->common.R.wesn[YHI] == 180.0)
 			|| (GMT->common.R.wesn[YLO] == 0.0 && GMT->common.R.wesn[YHI] == 360.0)),
 				"Option -R: theta0/theta1 must be either -90/90, 0/180 or 0/360\n");
+		n_errors += gmt_M_check_condition (GMT, GMT->common.R.wesn[XLO] != 0.0, "Option -R: r0/r1 must have r0 == 0 and r1 must be positive\n");
 	}
 	n_errors += gmt_check_binary_io (GMT, 2);
 

--- a/src/psrose.c
+++ b/src/psrose.c
@@ -735,7 +735,7 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 	}
 
 	//if (GMT->current.map.frame.draw && !GMT->current.map.frame.no_frame && gmt_M_is_zero (GMT->current.map.frame.axis[GMT_Y].item[GMT_ANNOT_UPPER].interval)) GMT->current.map.frame.axis[GMT_Y].item[GMT_ANNOT_UPPER].interval = GMT->current.map.frame.axis[GMT_Y].item[GMT_GRID_UPPER].interval = 30.0;
-	if (GMT->current.map.frame.draw && !GMT->current.map.frame.no_frame && gmt_M_is_zero (GMT->current.map.frame.axis[GMT_Y].item[GMT_ANNOT_UPPER].interval && gmt_M_is_zero (GMT->current.map.frame.axis[GMT_Y].item[GMT_GRID_UPPER].interval)) do_labels = false;
+	if (GMT->current.map.frame.draw && !GMT->current.map.frame.no_frame && gmt_M_is_zero (GMT->current.map.frame.axis[GMT_Y].item[GMT_ANNOT_UPPER].interval) && gmt_M_is_zero (GMT->current.map.frame.axis[GMT_Y].item[GMT_GRID_UPPER].interval)) do_labels = false;
 
 	/* Ready to plot.  So set up GMT projections (not used by psrose), we set region to actual plot width and scale to 1 */
 

--- a/test/psrose/gallery.ps
+++ b/test/psrose/gallery.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_47d22d6_2019.09.01 [64-bit] Document from psxy
+%%Title: GMT v6.1.1_69c7fc6-dirty_2020.07.06 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Sep  1 18:14:00 2019
+%%CreationDate: Mon Jul  6 20:42:12 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -646,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -658,7 +659,8 @@ V 0.06 0.06 scale
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_plot_completion {} def
-/PSL_movie_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
@@ -669,11 +671,11 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -R0/5/0/5 -Jx1c -P -K -T
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 5.00000000 0.000 5.000 0.000 5.000 +xy
-%GMTBoundingBox: 72 72 141.732 141.732
+%GMTBoundingBox: 72 72 141.732283465 141.732283465
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 %%EndObject
 0 A
 FQ
@@ -686,7 +688,7 @@ O0
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 -236 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (Sector Diagrams) tc Z
@@ -702,7 +704,7 @@ O0
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 -236 1181 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V 90 R (-R0/360/...) bc Z U
@@ -713,12 +715,12 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/0/360 -Bxg25 -Byg90 -BWESN -O -K -A5
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/0/360 -Bxg25 -Byg90 -BWESN -O -K -A5
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 1181 T
 25 W
 O1
@@ -799,17 +801,9 @@ O0
 824 -265 -260 0 0 Sw
 880 -270 -265 0 0 Sw
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
-N 0 0 M -1023 -591 D S
-N 0 0 M -591 -1023 D S
 N 0 0 M 0 -1181 D S
-N 0 0 M 591 -1023 D S
-N 0 0 M 1023 -591 D S
 N 0 0 M 1181 0 D S
 N 0 0 197 0 360 arc S
 N 0 0 394 0 360 arc S
@@ -838,7 +832,7 @@ O0
 %%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 -236 1181 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V 90 R (-R0/360/... -T) bc Z U
@@ -849,12 +843,12 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/0/360 -Bxg25 -Byg90 -BWESN -O -K -A5 -T
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/0/360 -Bxg25 -Byg90 -BWESN -O -K -A5 -T
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 1181 T
 25 W
 O1
@@ -935,17 +929,9 @@ O0
 824 -265 -260 0 0 Sw
 880 -270 -265 0 0 Sw
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
-N 0 0 M -1023 -591 D S
-N 0 0 M -591 -1023 D S
 N 0 0 M 0 -1181 D S
-N 0 0 M 591 -1023 D S
-N 0 0 M 1023 -591 D S
 N 0 0 M 1181 0 D S
 N 0 0 197 0 360 arc S
 N 0 0 394 0 360 arc S
@@ -974,7 +960,7 @@ O0
 %%BeginObject PSL_Layer_7
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 -236 1181 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V 90 R (-R0/360/... -Zu -T) bc Z U
@@ -985,12 +971,12 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/1200/0/360 -Bxg200 -Byg90 -BWESN -O -K -A5 -Zu -T
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/1200/0/360 -Bxg200 -Byg90 -BWESN -O -K -A5 -Zu -T
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_8
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 1181 T
 25 W
 O1
@@ -1071,17 +1057,9 @@ O0
 155 -265 -260 0 0 Sw
 144 -270 -265 0 0 Sw
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
-N 0 0 M -1023 -591 D S
-N 0 0 M -591 -1023 D S
 N 0 0 M 0 -1181 D S
-N 0 0 M 591 -1023 D S
-N 0 0 M 1023 -591 D S
 N 0 0 M 1181 0 D S
 N 0 0 197 0 360 arc S
 N 0 0 394 0 360 arc S
@@ -1110,7 +1088,7 @@ O0
 %%BeginObject PSL_Layer_9
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 -236 0 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V 90 R (-R-90/90/...) bl Z U
@@ -1121,12 +1099,12 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/-90/90 -Bxg25 -Byg90 -BWESN -O -K -A5
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/-90/90 -Bxg25 -Byg90 -BWESN -O -K -A5
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_10
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 0 T
 25 W
 O1
@@ -1171,11 +1149,7 @@ O0
 391 5 10 0 0 Sw
 382 0 5 0 0 Sw
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
 N 0 0 197 0 180 arc S
 N 0 0 394 0 180 arc S
@@ -1186,8 +1160,6 @@ N 0 0 1181 0 180 arc S
 0 1881 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 () bc Z
-0 -83 M 200 F0
-(0) tc Z
 1348 0 M 267 F0
 () ml Z
 -1348 0 M () mr Z
@@ -1205,7 +1177,7 @@ O0
 %%BeginObject PSL_Layer_11
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 -236 0 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V 90 R (-R0/180/...) bl Z U
@@ -1216,12 +1188,12 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/0/180 -Bxg25 -Byg90 -BWESN -O -K -A5
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/0/180 -Bxg25 -Byg90 -BWESN -O -K -A5
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_12
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 0 T
 25 W
 O1
@@ -1266,11 +1238,7 @@ O0
 824 5 10 0 0 Sw
 880 0 5 0 0 Sw
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
 N 0 0 197 0 180 arc S
 N 0 0 394 0 180 arc S
@@ -1281,8 +1249,6 @@ N 0 0 1181 0 180 arc S
 0 1881 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 () bc Z
-0 -83 M 200 F0
-(0) tc Z
 1348 0 M 267 F0
 () ml Z
 -1348 0 M () mr Z
@@ -1300,7 +1266,7 @@ O0
 %%BeginObject PSL_Layer_13
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 -236 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (Rose Diagrams) tc Z
@@ -1311,12 +1277,12 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/0/360 -Bxg25 -Byg90 -BWESN -O -K -A5r
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/0/360 -Bxg25 -Byg90 -BWESN -O -K -A5r
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_14
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 1181 T
 25 W
 O1
@@ -1375,17 +1341,9 @@ O0
 70 62 D
 FO
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
-N 0 0 M -1023 -591 D S
-N 0 0 M -591 -1023 D S
 N 0 0 M 0 -1181 D S
-N 0 0 M 591 -1023 D S
-N 0 0 M 1023 -591 D S
 N 0 0 M 1181 0 D S
 N 0 0 197 0 360 arc S
 N 0 0 394 0 360 arc S
@@ -1409,12 +1367,12 @@ O0
 0 2598 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/0/360 -Bxg25 -Byg90 -BWESN -O -K -A5r -T -Y5.5c
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/0/360 -Bxg25 -Byg90 -BWESN -O -K -A5r -T -Y5.5c
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_15
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 1181 T
 25 W
 O1
@@ -1494,17 +1452,9 @@ O0
 70 62 D
 FO
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
-N 0 0 M -1023 -591 D S
-N 0 0 M -591 -1023 D S
 N 0 0 M 0 -1181 D S
-N 0 0 M 591 -1023 D S
-N 0 0 M 1023 -591 D S
 N 0 0 M 1181 0 D S
 N 0 0 197 0 360 arc S
 N 0 0 394 0 360 arc S
@@ -1528,12 +1478,12 @@ O0
 0 2598 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/1200/0/360 -Bxg200 -Byg90 -BWESN -O -K -A5r -Zu -T -Y5.5c
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/1200/0/360 -Bxg200 -Byg90 -BWESN -O -K -A5r -Zu -T -Y5.5c
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_16
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 1181 T
 25 W
 O1
@@ -1613,17 +1563,9 @@ O0
 14 -9 D
 FO
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
-N 0 0 M -1023 -591 D S
-N 0 0 M -591 -1023 D S
 N 0 0 M 0 -1181 D S
-N 0 0 M 591 -1023 D S
-N 0 0 M 1023 -591 D S
 N 0 0 M 1181 0 D S
 N 0 0 197 0 360 arc S
 N 0 0 394 0 360 arc S
@@ -1647,12 +1589,12 @@ O0
 0 2835 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/-90/90 -Bxg25 -Byg90 -BWESN -O -K -A5r -Y6c
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/-90/90 -Bxg25 -Byg90 -BWESN -O -K -A5r -Y6c
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_17
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 0 T
 25 W
 O1
@@ -1699,11 +1641,7 @@ O0
 -876 0 D
 FO
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
 N 0 0 197 0 180 arc S
 N 0 0 394 0 180 arc S
@@ -1714,8 +1652,6 @@ N 0 0 1181 0 180 arc S
 0 1881 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 () bc Z
-0 -83 M 200 F0
-(0) tc Z
 1348 0 M 267 F0
 () ml Z
 -1348 0 M () mr Z
@@ -1728,12 +1664,12 @@ O0
 0 1654 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/0/180 -Bxg25 -Byg90 -BWESN -O -K -A5r -Y3.5c
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/150/0/180 -Bxg25 -Byg90 -BWESN -O -K -A5r -Y3.5c
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_18
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 0 T
 25 W
 O1
@@ -1780,11 +1716,7 @@ O0
 -1924 0 D
 FO
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
 N 0 0 197 0 180 arc S
 N 0 0 394 0 180 arc S
@@ -1795,8 +1727,6 @@ N 0 0 1181 0 180 arc S
 0 1881 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 () bc Z
-0 -83 M 200 F0
-(0) tc Z
 1348 0 M 267 F0
 () ml Z
 -1348 0 M () mr Z
@@ -1814,7 +1744,7 @@ O0
 %%BeginObject PSL_Layer_19
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 -236 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (Windrose Diagrams) tc Z
@@ -1825,12 +1755,12 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -R0/5/0/360 -Bxg1 -Byg190 -BWESN -O -K
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -R0/5/0/360 -Bxg1 -Byg90 -BWESN -O -K
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_20
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 1181 T
 25 W
 O1
@@ -9815,17 +9745,9 @@ N 0 0 M -10 33 D S
 N 0 0 M 5 5 D S
 N 0 0 M -183 5 D S
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
-N 0 0 M -1023 -591 D S
-N 0 0 M -591 -1023 D S
 N 0 0 M 0 -1181 D S
-N 0 0 M 591 -1023 D S
-N 0 0 M 1023 -591 D S
 N 0 0 M 1181 0 D S
 N 0 0 236 0 360 arc S
 N 0 0 472 0 360 arc S
@@ -9848,12 +9770,12 @@ O0
 0 2598 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -R0/5/0/360 -Bxg1 -Byg190 -BWESN -O -K -T -Y5.5c
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -R0/5/0/360 -Bxg1 -Byg90 -BWESN -O -K -T -Y5.5c
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_21
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 1181 T
 25 W
 O1
@@ -17838,17 +17760,9 @@ N -10 33 M 20 -66 D S
 N -5 -5 M 10 10 D S
 N -183 5 M 366 -10 D S
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
-N 0 0 M -1023 -591 D S
-N 0 0 M -591 -1023 D S
 N 0 0 M 0 -1181 D S
-N 0 0 M 591 -1023 D S
-N 0 0 M 1023 -591 D S
 N 0 0 M 1181 0 D S
 N 0 0 236 0 360 arc S
 N 0 0 472 0 360 arc S
@@ -17871,12 +17785,12 @@ O0
 0 2598 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -R0/1/0/360 -Bxg0.2 -Byg190 -BWESN -O -K -Zu -T -Y5.5c
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -R0/1/0/360 -Bxg0.2 -Byg90 -BWESN -O -K -Zu -T -Y5.5c
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_22
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 1181 T
 25 W
 O1
@@ -25861,17 +25775,9 @@ N -332 1133 M 664 -2266 D S
 N -846 -824 M 1692 1648 D S
 N -1181 30 M 2362 -60 D S
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
-N 0 0 M -1023 -591 D S
-N 0 0 M -591 -1023 D S
 N 0 0 M 0 -1181 D S
-N 0 0 M 591 -1023 D S
-N 0 0 M 1023 -591 D S
 N 0 0 M 1181 0 D S
 N 0 0 236 0 360 arc S
 N 0 0 472 0 360 arc S
@@ -25894,12 +25800,12 @@ O0
 0 2835 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/5/-90/90 -Bxg1 -Byg90 -BWESN -O -K -Y6c
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/5/-90/90 -Bxg1 -Byg90 -BWESN -O -K -Y6c
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_23
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 0 T
 25 W
 O1
@@ -33884,11 +33790,7 @@ N 0 0 M -10 33 D S
 N 0 0 M 5 5 D S
 N 0 0 M -183 5 D S
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
 N 0 0 236 0 180 arc S
 N 0 0 472 0 180 arc S
@@ -33898,8 +33800,6 @@ N 0 0 1181 0 180 arc S
 0 1881 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 () bc Z
-0 -83 M 200 F0
-(0) tc Z
 1348 0 M 267 F0
 () ml Z
 -1348 0 M () mr Z
@@ -33912,12 +33812,12 @@ O0
 0 1654 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose @azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/5/0/180 -Bxg1 -Byg90 -BWESN -O -K -Y3.5c
+%@GMT: gmt psrose /Users/pwessel/.gmt/cache/azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/5/0/180 -Bxg1 -Byg90 -BWESN -O -K -Y3.5c
 %@PROJ: xy -0.98425197 0.98425197 -0.98425197 0.98425197 -0.984 0.984 -0.984 0.984 +xy
 %%BeginObject PSL_Layer_24
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1181 0 T
 25 W
 O1
@@ -41902,11 +41802,7 @@ N 0 0 M 33 10 D S
 N 0 0 M -5 5 D S
 N 0 0 M 5 183 D S
 N 0 0 M 1181 0 D S
-N 0 0 M 1023 591 D S
-N 0 0 M 591 1023 D S
 N 0 0 M 0 1181 D S
-N 0 0 M -591 1023 D S
-N 0 0 M -1023 591 D S
 N 0 0 M -1181 0 D S
 N 0 0 236 0 180 arc S
 N 0 0 472 0 180 arc S
@@ -41916,8 +41812,6 @@ N 0 0 1181 0 180 arc S
 0 1881 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 () bc Z
-0 -83 M 200 F0
-(0) tc Z
 1348 0 M 267 F0
 () ml Z
 -1348 0 M () mr Z
@@ -41935,11 +41829,12 @@ O0
 %%BeginObject PSL_Layer_25
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 %%EndObject
 
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U

--- a/test/psrose/gallery.sh
+++ b/test/psrose/gallery.sh
@@ -8,8 +8,8 @@ common0n="@azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/5/-90/90 -Bxg1 -Byg90 -
 common1n="@azimuth_lengths.txt -: -JX5c -F -L -Ggray -R0/5/0/180 -Bxg1 -Byg90 -BWESN -O -K"
 common="@azimuth_lengths.txt   -: -JX5c -F -L -Ggray -R0/150/0/360 -Bxg25 -Byg90 -BWESN -O -K"
 commonn="@azimuth_lengths.txt  -: -JX5c -F -L -Ggray -R0/1200/0/360 -Bxg200 -Byg90 -BWESN -O -K"
-commonu="@azimuth_lengths.txt  -: -JX5c -F -L -R0/5/0/360 -Bxg1 -Byg190 -BWESN -O -K"
-commonun="@azimuth_lengths.txt -: -JX5c -F -L -R0/1/0/360 -Bxg0.2 -Byg190 -BWESN -O -K"
+commonu="@azimuth_lengths.txt  -: -JX5c -F -L -R0/5/0/360 -Bxg1 -Byg90 -BWESN -O -K"
+commonun="@azimuth_lengths.txt -: -JX5c -F -L -R0/1/0/360 -Bxg0.2 -Byg90 -BWESN -O -K"
 # Set up blank plot
 gmt psxy -R0/5/0/5 -Jx1c -P -K -T > $ps
 echo "2.5 -0.5 Sector Diagrams" | gmt pstext -R -J -O -K -N -F+jCT+f12p >> $ps

--- a/test/psrose/oldrose.ps
+++ b/test/psrose/oldrose.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612 792             
-%%Title: GMT v5.3.4_r17901M [64-bit] Document from psrose
-%%Creator: GMT5
-%%For: pwessel
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.1.1_69c7fc6-dirty_2020.07.06 [64-bit] Document from psrose
+%%Creator: GMT6
+%%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Apr 10 08:51:54 2017
+%%CreationDate: Mon Jul  6 20:42:12 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -646,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -657,18 +658,24 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
 0 A
 FQ
 O0
 -2400 PSL_xorig sub PSL_page_xsize 2 div add 1200 TM
 
 % PostScript produced by:
-%@GMT: psrose a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -B+glightgreen -A5r -Glightblue -W1p -: -S2in -P -K -Xc -Cm -M0.3i+e+gred -Wv2p,red --MAP_VECTOR_SHAPE=0.5
+%@GMT: gmt psrose /Users/pwessel/GMTdev/gmt-dev/test/psrose/a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -B+glightgreen -A5r -Glightblue -W1p -: -Sn -JX4i -P -K -Xc -Cm -M0.3i+e+gred -Wv2p,red --MAP_VECTOR_SHAPE=0.5
 %@PROJ: xy -2.00000000 2.00000000 -2.00000000 2.00000000 -2.000 2.000 -2.000 2.000 +xy
+%GMTBoundingBox: -144 72 288 288
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 2400 2400 T
 {0.565 0.933 0.565 C} FS
 2400 0 0 Sc
@@ -677,6 +684,7 @@ FQ
 O1
 2400 0 0 Sc
 17 W
+/PSL_vecheadpen {17 W 1 0 0 C [] 0 B} def
 {0.678 0.847 0.902 C} FS
 44 999 M
 165 587 D
@@ -705,11 +713,14 @@ FO
 33 W
 1 0 0 C
 {1 0 0 C} FS
+/PSL_vecheadpen {17 W 1 0 0 C [] 0 B} def
 33 W
-V 0 0 T 62.8891 R
+V 0 0 T 62.8891148382 R
 N 0 0 M 1924 0 D S
 U
-V 1000 1953 T 62.8891 R
+V 1000 1953 T 62.8891148382 R
+PSL_vecheadpen
+33 W
 0 0 M
 -360 96 D
 90 -96 D
@@ -719,24 +730,18 @@ U
 4 W
 0 A
 N 0 0 M 2400 0 D S
-N 0 0 M 2078 1200 D S
 N 0 0 M 1200 2078 D S
-N 0 0 M 0 2400 D S
 N 0 0 M -1200 2078 D S
-N 0 0 M -2078 1200 D S
 N 0 0 M -2400 0 D S
-N 0 0 M -2078 -1200 D S
 N 0 0 M -1200 -2078 D S
-N 0 0 M 0 -2400 D S
 N 0 0 M 1200 -2078 D S
-N 0 0 M 2078 -1200 D S
 N 0 0 M 2400 0 D S
 N 0 0 480 0 360 arc S
 N 0 0 960 0 360 arc S
 N 0 0 1440 0 360 arc S
 N 0 0 1920 0 360 arc S
 N 0 0 2400 0 360 arc S
-0 3100 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 3100 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 () bc Z
 0 -2567 M 267 F0
@@ -758,17 +763,18 @@ O0
 0 6000 TM
 
 % PostScript produced by:
-%@GMT: psrose a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -A5 -Glightblue -W1p -: -S2in -O -Y5i -Cm -M0.1c/0.3i/0.1i/255/0/0 --MAP_VECTOR_SHAPE=0.5
+%@GMT: gmt psrose /Users/pwessel/GMTdev/gmt-dev/test/psrose/a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -A5 -Glightblue -W1p -: -Sn -JX4i -O -Y5i -Cm -M0.1c/0.3i/0.1i/255/0/0 --MAP_VECTOR_SHAPE=0.5
 %@PROJ: xy -2.00000000 2.00000000 -2.00000000 2.00000000 -2.000 2.000 -2.000 2.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 2400 2400 T
 25 W
 O1
 2400 0 0 Sc
 17 W
+/PSL_vecheadpen {2 W 0 A [] 0 B} def
 {0.678 0.847 0.902 C} FS
 O0
 1000 85 90 0 0 Sw
@@ -920,26 +926,20 @@ O0
 4 W
 {1 0 0 C} FS
 O1
-V 0 0 T 62.8891 R -1924 90 -96 -360 120 360 120 -90 -96 1924 -24 SV U
+V 0 0 T 62.8891148382 R -1924 90 -96 -360 120 360 120 -90 -96 1924 -24 SV U
 N 0 0 M 2400 0 D S
-N 0 0 M 2078 1200 D S
 N 0 0 M 1200 2078 D S
-N 0 0 M 0 2400 D S
 N 0 0 M -1200 2078 D S
-N 0 0 M -2078 1200 D S
 N 0 0 M -2400 0 D S
-N 0 0 M -2078 -1200 D S
 N 0 0 M -1200 -2078 D S
-N 0 0 M 0 -2400 D S
 N 0 0 M 1200 -2078 D S
-N 0 0 M 2078 -1200 D S
 N 0 0 M 2400 0 D S
 N 0 0 480 0 360 arc S
 N 0 0 960 0 360 arc S
 N 0 0 1440 0 360 arc S
 N 0 0 1920 0 360 arc S
 N 0 0 2400 0 360 arc S
-0 3100 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 3100 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 () bc Z
 0 -2567 M 267 F0
@@ -955,6 +955,11 @@ N 1920 -2400 M 0 83 D S
 0 2567 M (North) bc Z
 -2400 -2400 T
 %%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage

--- a/test/psrose/rose.ps
+++ b/test/psrose/rose.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612 792
-%%Title: GMT v5.2.0_r13154M [64-bit] Document from psrose
-%%Creator: GMT5
-%%For: remko
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.1.1_69c7fc6-dirty_2020.07.06 [64-bit] Document from psrose
+%%Creator: GMT6
+%%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sat May 17 15:20:38 2014
+%%CreationDate: Mon Jul  6 20:42:12 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -193,6 +193,7 @@
 /PSL_pathtextdict 26 dict def
 /PSL_pathtext
   {PSL_pathtextdict begin
+    /ydepth exch def
     /textheight exch def
     /just exch def
     /offset exch def
@@ -200,7 +201,7 @@
     /pathdist 0 def
     /setdist offset def
     /charcount 0 def
-    /justy just 4 idiv textheight mul 2 div neg def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
     V flattenpath
 	{movetoproc} {linetoproc}
 	{curvetoproc} {closepathproc}
@@ -259,24 +260,54 @@ PSL_pathtextdict begin
     U /setdist setdist charwidth add def
   } def
 end
-/PSL_curved_text_labels
-{ /bits exch def
-  /PSL_clippath bits 1 and 1 eq def
-  /PSL_placetext bits 2 and 0 eq def
-  /PSL_strokeline bits 4 and 4 eq def
-  /PSL_firstcall bits 32 and 32 eq def
-  /PSL_lastcall bits 64 and 64 eq def
-  /PSL_fillbox bits 128 and 128 eq def
-  /PSL_drawbox bits 256 and 256 eq def
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
   /PSL_n1 PSL_n 1 sub def
   /PSL_m1 PSL_m 1 sub def
-  /PSL_usebox PSL_fillbox PSL_drawbox or def
   PSL_CT_calcstringwidth
   PSL_CT_calclinedist
+  PSL_CT_excludelabels
   PSL_CT_addcutpoints
-  PSL_clippath PSL_firstcall and
-  {clipsave N clippath} if
-  PSL_setlinepen
   /PSL_nn1 PSL_nn 1 sub def
   /n 0 def
   /k 0 def
@@ -303,23 +334,20 @@ end
     } if
   } for
   n 0 eq {PSL_CT_drawline} if
-  PSL_lastcall
-  {PSL_clippath
-    {PSL_clip} if N
-  } if
 } def
 /PSL_CT_textline
-{PSL_placetext
-  {PSL_clippath
-    {PSL_CT_clippath} {PSL_CT_placelabel} ifelse
-  } if
-  /n 0 def /k k 1 add def PSL_setlinepen
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
 } def
 /PSL_CT_calcstringwidth
-{ /PSL_width PSL_m array def
+{ /PSL_width_tmp PSL_m array def
   0 1 PSL_m1
   { /i exch def
-    PSL_width i PSL_str i get stringwidth pop put
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
   } for
 } def
 /PSL_CT_calclinedist
@@ -339,6 +367,33 @@ end
     /dist dist dx dx mul dy dy mul add sqrt add def
     PSL_dist i dist put
   } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
 } def
 /PSL_CT_addcutpoints
 { /k 0 def
@@ -403,14 +458,18 @@ end
 } def
 /PSL_CT_placelabel
 {
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
   PSL_usebox
   {PSL_CT_clippath
     PSL_fillbox
     {V PSL_setboxrgb fill U} if
     PSL_drawbox
-    {PSL_setboxpen S} if N
+    {V PSL_setboxpen S U} if N
   } if
-  PSL_settxtrgb PSL_CT_placeline PSL_str k get PSL_gap_x PSL_just PSL_height PSL_pathtext
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
 } def
 /PSL_CT_clippath
 {
@@ -434,7 +493,7 @@ end
       /dx x x1 sub def
       /dy y y1 sub def
     } ifelse
-    dx 0.0 ne dy 0.0 ne and
+    dx 0.0 eq dy 0.0 eq and not
     { /angle dy dx atan 90 add def} if
     /sina angle sin def
     /cosa angle cos def
@@ -455,7 +514,7 @@ end
 {
   /str 20 string def
   PSL_strokeline
-  {PSL_CT_placeline PSL_setlinepen S} if
+  {PSL_CT_placeline S} if
   /PSL_seg PSL_seg 1 add def
   /n 1 def
 } def
@@ -463,93 +522,121 @@ end
 {PSL_xp 0 get PSL_yp 0 get M
   1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
 } def
-/PSL_straight_text_labels
+/PSL_draw_path_lines
 {
-  /bits exch def
-  /PSL_clippath bits 1 and 0 eq def
-  /PSL_rounded bits 16 and 16 eq def
-  /PSL_fillbox bits 128 and 128 eq def
-  /PSL_drawbox bits 256 and 256 eq def
-  /PSL_m1 PSL_m 1 sub def
-  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
-  /PSL_justy PSL_just 4 idiv PSL_height mul 2 div neg def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
   /PSL_usebox PSL_fillbox PSL_drawbox or def
-  PSL_clippath
-  {PSL_ST_clippath}
-  {PSL_usebox {PSL_ST_clippath} if
-    PSL_ST_placelabel
-  } ifelse
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
 } def
-/PSL_ST_placelabel
-{PSL_settxtrgb
-  0 1 PSL_m1
-  { /k exch def
-    /xp PSL_txt_x k get def
-    /yp PSL_txt_y k get def
-    V PSL_txt_x k get PSL_txt_y k get T
-    PSL_angle k get R
-    /BoxW PSL_str k get stringwidth pop def
-    BoxW PSL_justx mul PSL_justy M
-    PSL_str k get show
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
     U
-  } for
-} def
-/PSL_ST_clippath
-{N
-  PSL_usebox not {clipsave clippath} if
-  PSL_rounded {PSL_ST_clippath_round} {PSL_ST_clippath_rect} ifelse
-  PSL_usebox
-  {PSL_fillbox
-    {V PSL_setboxrgb fill U} if
-    PSL_drawbox
-    {PSL_setboxpen S} if N
-  }
-  {PSL_clip
-  } ifelse
-  N
-} def
-/PSL_ST_clippath_rect
-{
-  /BoxH PSL_height PSL_gap_y 2 mul add def
-  /DelY BoxH BoxH 0 3 array astore def
-  0 1 PSL_m1
-  { /k exch def
-    /xp PSL_txt_x k get def
-    /yp PSL_txt_y k get def
-    /MAT PSL_angle k get matrix R def
-    /BoxW PSL_str k get stringwidth pop PSL_gap_x 2 mul add def
-    /x0 0 BoxW PSL_justx mul add def
-    /y0 0 PSL_justy add PSL_gap_y sub def
-    /DelX 0 BoxW BoxW 3 array astore def
-    x0 y0 MAT transform
-    /dy exch def /dx exch def
-    xp dx add yp dy add M
-    0 1 2
-    {
-      /ii exch def
-      x0 DelX ii get add y0 DelY ii get add MAT transform
-      /dy exch def /dx exch def
-      xp dx add yp dy add L
-    } for P
-  } for
-} def
-/PSL_ST_clippath_round
-{
-  /PSL_justy2 PSL_just 4 idiv 2 div neg def
-  /BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
-  /BoxH PSL_height PSL_gap_y 2 mul add def
-  /y0 PSL_height PSL_gap_y 2 mul add PSL_justy2 mul def
-  0 1 PSL_m1
-  { /k exch def
-    /xp PSL_txt_x k get def
-    /yp PSL_txt_y k get def
-    /BoxW PSL_str k get stringwidth pop PSL_gap_x 2 mul add def
-    /x0 BoxW PSL_justx mul def
-    xp yp T PSL_angle k get R x0 y0 T
-    BoxR 0 M
-    BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct P
-    x0 neg y0 neg T PSL_angle k get neg R xp neg yp neg T
-  } for
 } def
 /PSL_nclip 0 def
 /PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
@@ -559,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -570,18 +658,24 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
 0 A
 FQ
 O0
 -2400 PSL_xorig sub PSL_page_xsize 2 div add 1200 TM
 
 % PostScript produced by:
-%%GMT: psrose a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -B+glightgreen -A5r -Glightblue -W1p -: -S2in -P -K -Xc -C
-%%PROJ: xy -2.00000000 2.00000000 -2.00000000 2.00000000 -2.000 2.000 -2.000 2.000 +xy +a=6378137.000 +b=6356752.314245
+%@GMT: gmt psrose /Users/pwessel/GMTdev/gmt-dev/test/psrose/a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -B+glightgreen -A5r -Glightblue -W1p -: -Sn -JX4i -P -K -Xc -Cm
+%@PROJ: xy -2.00000000 2.00000000 -2.00000000 2.00000000 -2.000 2.000 -2.000 2.000 +xy
+%GMTBoundingBox: -144 72 288 288
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 2400 2400 T
 {0.565 0.933 0.565 C} FS
 2400 0 0 Sc
@@ -616,29 +710,27 @@ O1
 0 401 D
 FO
 {0 A} FS
+/PSL_vecheadpen {33 W 0 A [] 0 B} def
 17 W
-V 0 0 T 62.8891 R
-0 0 M 2044 0 D S
+V 0 0 T 62.8891148382 R
+N 0 0 M 2044 0 D S
 U
-V 1000 1953 T 62.8891 R
+V 1000 1953 T 62.8891148382 R
+PSL_vecheadpen
+67 W
 0 0 M
 -150 40 D
 0 -80 D
-P clip fs P S U
+P clip fs P S 
+U
 4 W
-0 0 M 2400 0 D S
-0 0 M 2078 1200 D S
-0 0 M 1200 2078 D S
-0 0 M 0 2400 D S
-0 0 M -1200 2078 D S
-0 0 M -2078 1200 D S
-0 0 M -2400 0 D S
-0 0 M -2078 -1200 D S
-0 0 M -1200 -2078 D S
-0 0 M 0 -2400 D S
-0 0 M 1200 -2078 D S
-0 0 M 2078 -1200 D S
-0 0 M 2400 0 D S
+N 0 0 M 2400 0 D S
+N 0 0 M 1200 2078 D S
+N 0 0 M -1200 2078 D S
+N 0 0 M -2400 0 D S
+N 0 0 M -1200 -2078 D S
+N 0 0 M 1200 -2078 D S
+N 0 0 M 2400 0 D S
 N 0 0 480 0 360 arc S
 N 0 0 960 0 360 arc S
 N 0 0 1440 0 360 arc S
@@ -649,9 +741,9 @@ N 0 0 2400 0 360 arc S
 () bc Z
 0 -2567 M 267 F0
 (South) tc Z
-2400 -2400 M -480 0 D S
-2400 -2400 M 0 83 D S
-1920 -2400 M 0 83 D S
+N 2400 -2400 M -480 0 D S
+N 2400 -2400 M 0 83 D S
+N 1920 -2400 M 0 83 D S
 2160 -2483 M 200 F0
 (0.2) tc Z
 2567 0 M 267 F0
@@ -666,12 +758,12 @@ O0
 0 6000 TM
 
 % PostScript produced by:
-%%GMT: psrose a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -A5 -Glightblue -W1p -: -S2in -O -Y5i -C
-%%PROJ: xy -2.00000000 2.00000000 -2.00000000 2.00000000 -2.000 2.000 -2.000 2.000 +xy +a=6378137.000 +b=6356752.314245
+%@GMT: gmt psrose /Users/pwessel/GMTdev/gmt-dev/test/psrose/a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -A5 -Glightblue -W1p -: -Sn -JX4i -O -Y5i -Cm
+%@PROJ: xy -2.00000000 2.00000000 -2.00000000 2.00000000 -2.000 2.000 -2.000 2.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 2400 2400 T
 25 W
 O1
@@ -827,29 +919,27 @@ O0
 0 0 1000 85 90 arc S
 {0 A} FS
 O1
+/PSL_vecheadpen {33 W 0 A [] 0 B} def
 17 W
-V 0 0 T 62.8891 R
-0 0 M 2044 0 D S
+V 0 0 T 62.8891148382 R
+N 0 0 M 2044 0 D S
 U
-V 1000 1953 T 62.8891 R
+V 1000 1953 T 62.8891148382 R
+PSL_vecheadpen
+67 W
 0 0 M
 -150 40 D
 0 -80 D
-P clip fs P S U
+P clip fs P S 
+U
 4 W
-0 0 M 2400 0 D S
-0 0 M 2078 1200 D S
-0 0 M 1200 2078 D S
-0 0 M 0 2400 D S
-0 0 M -1200 2078 D S
-0 0 M -2078 1200 D S
-0 0 M -2400 0 D S
-0 0 M -2078 -1200 D S
-0 0 M -1200 -2078 D S
-0 0 M 0 -2400 D S
-0 0 M 1200 -2078 D S
-0 0 M 2078 -1200 D S
-0 0 M 2400 0 D S
+N 0 0 M 2400 0 D S
+N 0 0 M 1200 2078 D S
+N 0 0 M -1200 2078 D S
+N 0 0 M -2400 0 D S
+N 0 0 M -1200 -2078 D S
+N 0 0 M 1200 -2078 D S
+N 0 0 M 2400 0 D S
 N 0 0 480 0 360 arc S
 N 0 0 960 0 360 arc S
 N 0 0 1440 0 360 arc S
@@ -860,9 +950,9 @@ N 0 0 2400 0 360 arc S
 () bc Z
 0 -2567 M 267 F0
 (South) tc Z
-2400 -2400 M -480 0 D S
-2400 -2400 M 0 83 D S
-1920 -2400 M 0 83 D S
+N 2400 -2400 M -480 0 D S
+N 2400 -2400 M 0 83 D S
+N 1920 -2400 M 0 83 D S
 2160 -2483 M 200 F0
 (0.2) tc Z
 2567 0 M 267 F0
@@ -871,6 +961,11 @@ N 0 0 2400 0 360 arc S
 0 2567 M (North) bc Z
 -2400 -2400 T
 %%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage

--- a/test/psrose/sector.ps
+++ b/test/psrose/sector.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612 792             
-%%Title: GMT v6.0.0_r19515 [64-bit] Document from psrose
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.1.1_69c7fc6-dirty_2020.07.06 [64-bit] Document from psrose
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Tue Dec 19 20:40:19 2017
+%%CreationDate: Mon Jul  6 20:42:12 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -646,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -657,20 +658,24 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
 0 A
 FQ
 O0
 -2400 PSL_xorig sub PSL_page_xsize 2 div add 1200 TM
 
 % PostScript produced by:
-%@GMT: psrose a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -B+glightgreen -A5 -Glightblue -W1p -: -Sn -JX4i -P -K -Xc -Em
+%@GMT: gmt psrose /Users/pwessel/GMTdev/gmt-dev/test/psrose/a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -B+glightgreen -A5 -Glightblue -W1p -: -Sn -JX4i -P -K -Xc -Em
 %@PROJ: xy -2.00000000 2.00000000 -2.00000000 2.00000000 -2.000 2.000 -2.000 2.000 +xy
 %GMTBoundingBox: -144 72 288 288
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 2400 2400 T
 {0.565 0.933 0.565 C} FS
 2400 0 0 Sc
@@ -829,11 +834,14 @@ O0
 0 0 1000 85 90 arc S
 {0 A} FS
 O1
+/PSL_vecheadpen {33 W 0 A [] 0 B} def
 17 W
-V 0 0 T 62.8891 R
+V 0 0 T 62.8891148382 R
 N 0 0 M 2044 0 D S
 U
-V 1000 1953 T 62.8891 R
+V 1000 1953 T 62.8891148382 R
+PSL_vecheadpen
+67 W
 0 0 M
 -150 40 D
 0 -80 D
@@ -841,24 +849,18 @@ P clip fs P S
 U
 4 W
 N 0 0 M 2400 0 D S
-N 0 0 M 2078 1200 D S
 N 0 0 M 1200 2078 D S
-N 0 0 M 0 2400 D S
 N 0 0 M -1200 2078 D S
-N 0 0 M -2078 1200 D S
 N 0 0 M -2400 0 D S
-N 0 0 M -2078 -1200 D S
 N 0 0 M -1200 -2078 D S
-N 0 0 M 0 -2400 D S
 N 0 0 M 1200 -2078 D S
-N 0 0 M 2078 -1200 D S
 N 0 0 M 2400 0 D S
 N 0 0 480 0 360 arc S
 N 0 0 960 0 360 arc S
 N 0 0 1440 0 360 arc S
 N 0 0 1920 0 360 arc S
 N 0 0 2400 0 360 arc S
-0 3100 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 3100 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 () bc Z
 0 -2567 M 267 F0
@@ -880,12 +882,12 @@ O0
 0 5700 TM
 
 % PostScript produced by:
-%@GMT: psrose a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -B+glightgreen -A5 -Ct.cpt -W1p -: -Sn -JX4i -O -Y4.75i -Em
+%@GMT: gmt psrose /Users/pwessel/GMTdev/gmt-dev/test/psrose/a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -B+glightgreen -A5 -Ct.cpt -W1p -: -Sn -JX4i -O -Y4.75i -Em
 %@PROJ: xy -2.00000000 2.00000000 -2.00000000 2.00000000 -2.000 2.000 -2.000 2.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 2400 2400 T
 {0.565 0.933 0.565 C} FS
 2400 0 0 Sc
@@ -1064,11 +1066,14 @@ O0
 0 0 1000 85 90 arc S
 {0 A} FS
 O1
+/PSL_vecheadpen {33 W 0 A [] 0 B} def
 17 W
-V 0 0 T 62.8891 R
+V 0 0 T 62.8891148382 R
 N 0 0 M 2044 0 D S
 U
-V 1000 1953 T 62.8891 R
+V 1000 1953 T 62.8891148382 R
+PSL_vecheadpen
+67 W
 0 0 M
 -150 40 D
 0 -80 D
@@ -1076,24 +1081,18 @@ P clip fs P S
 U
 4 W
 N 0 0 M 2400 0 D S
-N 0 0 M 2078 1200 D S
 N 0 0 M 1200 2078 D S
-N 0 0 M 0 2400 D S
 N 0 0 M -1200 2078 D S
-N 0 0 M -2078 1200 D S
 N 0 0 M -2400 0 D S
-N 0 0 M -2078 -1200 D S
 N 0 0 M -1200 -2078 D S
-N 0 0 M 0 -2400 D S
 N 0 0 M 1200 -2078 D S
-N 0 0 M 2078 -1200 D S
 N 0 0 M 2400 0 D S
 N 0 0 480 0 360 arc S
 N 0 0 960 0 360 arc S
 N 0 0 1440 0 360 arc S
 N 0 0 1920 0 360 arc S
 N 0 0 2400 0 360 arc S
-0 3100 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 3100 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 () bc Z
 0 -2567 M 267 F0
@@ -1109,6 +1108,11 @@ N 1920 -2400 M 0 83 D S
 0 2567 M (North) bc Z
 -2400 -2400 T
 %%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage

--- a/test/psrose/vectors.ps
+++ b/test/psrose/vectors.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0 [64-bit] Document from psxy
+%%Title: GMT v6.1.1_69c7fc6-dirty_2020.07.06 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Feb 10 09:42:17 2019
+%%CreationDate: Mon Jul  6 20:42:12 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -336,9 +336,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +592,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +635,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -651,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -662,8 +658,9 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
-/PSL_movie_completion {} def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
@@ -674,11 +671,11 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -R0/5/0/5 -Jx1c -P -K -T
 %@PROJ: xy 0.00000000 5.00000000 0.00000000 5.00000000 0.000 5.000 0.000 5.000 +xy
-%GMTBoundingBox: 72 72 141.732 141.732
+%GMTBoundingBox: 72 72 141.732283465 141.732283465
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 %%EndObject
 0 A
 FQ
@@ -686,12 +683,12 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose subset.txt -: -JX7c -F -L -R0/3/0/360 -Bxg1 -Byg190 -BWESN -O -K
+%@GMT: gmt psrose subset.txt -: -JX7c -F -L -R0/3/0/360 -Bxg1 -Byg90 -BWESN -O -K
 %@PROJ: xy -1.37795276 1.37795276 -1.37795276 1.37795276 -1.378 1.378 -1.378 1.378 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1654 1654 T
 25 W
 O1
@@ -857,17 +854,9 @@ N 0 0 M 6 5 D S
 N 0 0 M 433 587 D S
 N 0 0 M -239 5 D S
 N 0 0 M 1654 0 D S
-N 0 0 M 1432 827 D S
-N 0 0 M 827 1432 D S
 N 0 0 M 0 1654 D S
-N 0 0 M -827 1432 D S
-N 0 0 M -1432 827 D S
 N 0 0 M -1654 0 D S
-N 0 0 M -1432 -827 D S
-N 0 0 M -827 -1432 D S
 N 0 0 M 0 -1654 D S
-N 0 0 M 827 -1432 D S
-N 0 0 M 1432 -827 D S
 N 0 0 M 1654 0 D S
 N 0 0 551 0 360 arc S
 N 0 0 1102 0 360 arc S
@@ -888,12 +877,12 @@ O0
 0 3543 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose subset.txt -: -JX7c -F -L -R0/3/0/360 -Bxg1 -Byg190 -BWESN -O -K -T -Y7.5c
+%@GMT: gmt psrose subset.txt -: -JX7c -F -L -R0/3/0/360 -Bxg1 -Byg90 -BWESN -O -K -T -Y7.5c
 %@PROJ: xy -1.37795276 1.37795276 -1.37795276 1.37795276 -1.378 1.378 -1.378 1.378 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1654 1654 T
 25 W
 O1
@@ -1059,17 +1048,9 @@ N -6 -5 M 12 10 D S
 N -433 -587 M 866 1174 D S
 N -239 5 M 478 -10 D S
 N 0 0 M 1654 0 D S
-N 0 0 M 1432 827 D S
-N 0 0 M 827 1432 D S
 N 0 0 M 0 1654 D S
-N 0 0 M -827 1432 D S
-N 0 0 M -1432 827 D S
 N 0 0 M -1654 0 D S
-N 0 0 M -1432 -827 D S
-N 0 0 M -827 -1432 D S
 N 0 0 M 0 -1654 D S
-N 0 0 M 827 -1432 D S
-N 0 0 M 1432 -827 D S
 N 0 0 M 1654 0 D S
 N 0 0 551 0 360 arc S
 N 0 0 1102 0 360 arc S
@@ -1095,7 +1076,7 @@ O0
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1654 0 T
 25 W
 O1
@@ -1261,11 +1242,7 @@ N 0 0 M 6 5 D S
 N 0 0 M 433 587 D S
 N 0 0 M -239 5 D S
 N 0 0 M 1654 0 D S
-N 0 0 M 1432 827 D S
-N 0 0 M 827 1432 D S
 N 0 0 M 0 1654 D S
-N 0 0 M -827 1432 D S
-N 0 0 M -1432 827 D S
 N 0 0 M -1654 0 D S
 N 0 0 551 0 180 arc S
 N 0 0 1102 0 180 arc S
@@ -1273,8 +1250,6 @@ N 0 0 1654 0 180 arc S
 0 2354 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 () bc Z
-0 -83 M 200 F0
-(0) tc Z
 1820 0 M 267 F0
 () ml Z
 -1820 0 M () mr Z
@@ -1292,7 +1267,7 @@ O0
 %%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1654 0 T
 25 W
 O1
@@ -1458,11 +1433,7 @@ N 0 0 M -5 6 D S
 N 0 0 M -587 433 D S
 N 0 0 M 5 239 D S
 N 0 0 M 1654 0 D S
-N 0 0 M 1432 827 D S
-N 0 0 M 827 1432 D S
 N 0 0 M 0 1654 D S
-N 0 0 M -827 1432 D S
-N 0 0 M -1432 827 D S
 N 0 0 M -1654 0 D S
 N 0 0 551 0 180 arc S
 N 0 0 1102 0 180 arc S
@@ -1470,8 +1441,6 @@ N 0 0 1654 0 180 arc S
 0 2354 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 () bc Z
-0 -83 M 200 F0
-(0) tc Z
 1820 0 M 267 F0
 () ml Z
 -1820 0 M () mr Z
@@ -1484,12 +1453,12 @@ O0
 4252 -9449 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose subset.txt -: -JX7c -F -L -R0/3/0/360 -Bxg1 -Byg190 -BWESN -O -K -M0.5c+e+gorange+n1i+h0.5 -Y-20c -X9c
+%@GMT: gmt psrose subset.txt -: -JX7c -F -L -R0/3/0/360 -Bxg1 -Byg90 -BWESN -O -K -M0.5c+e+gorange+n1i+h0.5 -Y-20c -X9c
 %@PROJ: xy -1.37795276 1.37795276 -1.37795276 1.37795276 -1.378 1.378 -1.378 1.378 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1654 1654 T
 25 W
 O1
@@ -1509,10 +1478,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 83.4981 R
+V 0 0 T 83.4981110367 R
 N 0 0 M 213 0 D S
 U
-V 28 248 T 83.4981 R
+V 28 248 T 83.4981110367 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1522,10 +1491,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 53.5537 R
+V 0 0 T 53.5536643959 R
 N 0 0 M 145 0 D S
 U
-V 101 137 T 53.5537 R
+V 101 137 T 53.5536643959 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1535,10 +1504,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1559,10 +1528,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1572,10 +1541,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1585,10 +1554,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 21.3045 R
+V 0 0 T 21.3044852105 R
 N 0 0 M 76 0 D S
 U
-V 83 33 T 21.3045 R
+V 83 33 T 21.3044852105 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1598,10 +1567,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 31.2815 R
+V 0 0 T 31.2814741346 R
 N 0 0 M 384 0 D S
 U
-V 385 234 T 31.2815 R
+V 385 234 T 31.2814741346 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1611,10 +1580,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 74.3715 R
+V 0 0 T 74.3714607294 R
 N 0 0 M 107 0 D S
 U
-V 34 121 T 74.3715 R
+V 34 121 T 74.3714607294 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1635,10 +1604,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 97.2317 R
+V 0 0 T 97.231709821 R
 N 0 0 M 460 0 D S
 U
-V -68 535 T 97.2317 R
+V -68 535 T 97.231709821 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1659,10 +1628,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 133.817 R
+V 0 0 T 133.817075415 R
 N 0 0 M 400 0 D S
 U
-V -325 339 T 133.817 R
+V -325 339 T 133.817075415 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1683,10 +1652,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 98.3363 R
+V 0 0 T 98.3363226 R
 N 0 0 M 33 0 D S
 U
-V -6 39 T 98.3363 R
+V -6 39 T 98.3363226 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1751,10 +1720,10 @@ V 55 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1764,10 +1733,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V 0 0 T 97.1108 R
+V 0 0 T 97.110842666 R
 N 0 0 M 702 0 D S
 U
-V -102 817 T 97.1108 R
+V -102 817 T 97.110842666 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1801,10 +1770,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 143.294 R
+V 0 0 T 143.294120171 R
 N 0 0 M 202 0 D S
 U
-V -190 142 T 143.294 R
+V -190 142 T 143.294120171 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1814,10 +1783,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 54.0944 R
+V 0 0 T 54.0943788918 R
 N 0 0 M 98 0 D S
 U
-V 67 93 T 54.0944 R
+V 67 93 T 54.0943788918 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1827,10 +1796,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 71.8287 R
+V 0 0 T 71.8287392661 R
 N 0 0 M 494 0 D S
 U
-V 181 551 T 71.8287 R
+V 181 551 T 71.8287392661 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1851,10 +1820,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 61.3191 R
+V 0 0 T 61.319071179 R
 N 0 0 M 80 0 D S
 U
-V 45 82 T 61.3191 R
+V 45 82 T 61.319071179 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1864,10 +1833,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 116.16 R
+V 0 0 T 116.159616615 R
 N 0 0 M 371 0 D S
 U
-V -192 390 T 116.16 R
+V -192 390 T 116.159616615 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1877,10 +1846,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 98.4275 R
+V 0 0 T 98.427517488 R
 N 0 0 M 428 0 D S
 U
-V -74 497 T 98.4275 R
+V -74 497 T 98.427517488 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1890,10 +1859,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 111.747 R
+V 0 0 T 111.74664169 R
 N 0 0 M 91 0 D S
 U
-V -40 99 T 111.747 R
+V -40 99 T 111.74664169 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1903,10 +1872,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 111.655 R
+V 0 0 T 111.655456694 R
 N 0 0 M 157 0 D S
 U
-V -68 171 T 111.655 R
+V -68 171 T 111.655456694 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1916,10 +1885,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 85.8829 R
+V 0 0 T 85.882926875 R
 N 0 0 M 538 0 D S
 U
-V 45 629 T 85.8829 R
+V 45 629 T 85.882926875 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1929,10 +1898,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1942,10 +1911,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727433613 R
 N 0 0 M 20 0 D S
 U
-V -17 16 T 135.727 R
+V -17 16 T 135.727433613 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1955,10 +1924,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1968,10 +1937,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 60.774 R
+V 0 0 T 60.7739941664 R
 N 0 0 M 118 0 D S
 U
-V 68 121 T 60.774 R
+V 68 121 T 60.7739941664 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1981,10 +1950,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 108.876 R
+V 0 0 T 108.875766467 R
 N 0 0 M 268 0 D S
 U
-V -102 298 T 108.876 R
+V -102 298 T 108.875766467 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -1994,10 +1963,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2007,10 +1976,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2020,10 +1989,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2033,10 +2002,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2046,10 +2015,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2059,10 +2028,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 136.666 R
+V 0 0 T 136.665667736 R
 N 0 0 M 203 0 D S
 U
-V -174 164 T 136.666 R
+V -174 164 T 136.665667736 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2072,10 +2041,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2085,10 +2054,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 128.007 R
+V 0 0 T 128.007424435 R
 N 0 0 M 124 0 D S
 U
-V -90 115 T 128.007 R
+V -90 115 T 128.007424435 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2098,10 +2067,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 73.2671 R
+V 0 0 T 73.2671396726 R
 N 0 0 M 569 0 D S
 U
-V 192 639 T 73.2671 R
+V 192 639 T 73.2671396726 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2111,10 +2080,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 99.9727 R
+V 0 0 T 99.972694283 R
 N 0 0 M 334 0 D S
 U
-V -68 386 T 99.9727 R
+V -68 386 T 99.972694283 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2124,10 +2093,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T -15.3336 R
+V 0 0 T -15.333640212 R
 N 0 0 M 157 0 D S
 U
-V 178 -49 T -15.3336 R
+V 178 -49 T -15.333640212 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2148,10 +2117,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2161,10 +2130,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2174,10 +2143,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 86.5472 R
+V 0 0 T 86.5471576761 R
 N 0 0 M 240 0 D S
 U
-V 17 282 T 86.5472 R
+V 17 282 T 86.5471576761 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2198,10 +2167,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 152.423 R
+V 0 0 T 152.422590305 R
 N 0 0 M 450 0 D S
 U
-V -468 244 T 152.423 R
+V -468 244 T 152.422590305 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2233,10 +2202,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 102.138 R
+V 0 0 T 102.137603117 R
 N 0 0 M 298 0 D S
 U
-V -74 342 T 102.138 R
+V -74 342 T 102.137603117 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2246,10 +2215,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 34.8526 R
+V 0 0 T 34.8525550265 R
 N 0 0 M 365 0 D S
 U
-V 352 245 T 34.8526 R
+V 352 245 T 34.8525550265 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2259,10 +2228,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 56.2609 R
+V 0 0 T 56.2608798258 R
 N 0 0 M 242 0 D S
 U
-V 158 236 T 56.2609 R
+V 158 236 T 56.2608798258 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2272,10 +2241,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 163.347 R
+V 0 0 T 163.346654225 R
 N 0 0 M 435 0 D S
 U
-V -489 146 T 163.347 R
+V -489 146 T 163.346654225 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2285,10 +2254,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 118.681 R
+V 0 0 T 118.680682398 R
 N 0 0 M 320 0 D S
 U
-V -180 330 T 118.681 R
+V -180 330 T 118.680682398 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2298,10 +2267,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.728 R
+V 0 0 T 135.727527232 R
 N 0 0 M 13 0 D S
 U
-V -11 11 T 135.728 R
+V -11 11 T 135.727527232 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2322,10 +2291,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 64.8451 R
+V 0 0 T 64.8450901702 R
 N 0 0 M 430 0 D S
 U
-V 214 457 T 64.8451 R
+V 214 457 T 64.8450901702 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2335,10 +2304,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 41.7868 R
+V 0 0 T 41.7868110984 R
 N 0 0 M 307 0 D S
 U
-V 269 240 T 41.7868 R
+V 269 240 T 41.7868110984 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2359,10 +2328,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V 0 0 T 97.9623 R
+V 0 0 T 97.96229628 R
 N 0 0 M 627 0 D S
 U
-V -102 729 T 97.9623 R
+V -102 729 T 97.96229628 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2384,10 +2353,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V 0 0 T 43.3394 R
+V 0 0 T 43.3393795183 R
 N 0 0 M 1263 0 D S
 U
-V 1047 988 T 43.3394 R
+V 1047 988 T 43.3393795183 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2397,10 +2366,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 146.978 R
+V 0 0 T 146.978109328 R
 N 0 0 M 34 0 D S
 U
-V -33 22 T 146.978 R
+V -33 22 T 146.978109328 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2421,10 +2390,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 85.309 R
+V 0 0 T 85.3089528426 R
 N 0 0 M 118 0 D S
 U
-V 11 138 T 85.309 R
+V 11 138 T 85.3089528426 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2445,10 +2414,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 161.997 R
+V 0 0 T 161.997027527 R
 N 0 0 M 15 0 D S
 U
-V -17 5 T 161.997 R
+V -17 5 T 161.997027527 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2457,10 +2426,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 98.3363 R
+V 0 0 T 98.336311085 R
 N 0 0 M 200 0 D S
 U
-V -34 232 T 98.3363 R
+V -34 232 T 98.336311085 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2481,10 +2450,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 125.19 R
+V 0 0 T 125.190471614 R
 N 0 0 M 92 0 D S
 U
-V -62 88 T 125.19 R
+V -62 88 T 125.190471614 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2505,10 +2474,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 106.334 R
+V 0 0 T 106.333678442 R
 N 0 0 M 171 0 D S
 U
-V -57 193 T 106.334 R
+V -57 193 T 106.333678442 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2518,10 +2487,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 6.94817 R
+V 0 0 T 6.9481674333 R
 N 0 0 M 114 0 D S
 U
-V 133 16 T 6.94817 R
+V 133 16 T 6.9481674333 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2542,10 +2511,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V 0 0 T 39.5693 R
+V 0 0 T 39.5693373414 R
 N 0 0 M 1346 0 D S
 U
-V 1174 971 T 39.5693 R
+V 1174 971 T 39.5693373414 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2555,10 +2524,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T -29.1224 R
+V 0 0 T -29.122367302 R
 N 0 0 M 381 0 D S
 U
-V 390 -217 T -29.1224 R
+V 390 -217 T -29.122367302 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2568,10 +2537,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 128.582 R
+V 0 0 T 128.582027402 R
 N 0 0 M 269 0 D S
 U
-V -197 246 T 128.582 R
+V -197 246 T 128.582027402 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2592,10 +2561,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 80.0272 R
+V 0 0 T 80.0271811365 R
 N 0 0 M 167 0 D S
 U
-V 34 193 T 80.0272 R
+V 34 193 T 80.0271811365 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2616,10 +2585,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V 0 0 T 29.7322 R
+V 0 0 T 29.7322200721 R
 N 0 0 M 1543 0 D S
 U
-V 1494 853 T 29.7322 R
+V 1494 853 T 29.7322200721 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2640,10 +2609,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 46.3951 R
+V 0 0 T 46.3951286195 R
 N 0 0 M 180 0 D S
 U
-V 146 153 T 46.3951 R
+V 146 153 T 46.3951286195 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2653,10 +2622,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 143.42 R
+V 0 0 T 143.420404711 R
 N 0 0 M 397 0 D S
 U
-V -374 278 T 143.42 R
+V -374 278 T 143.420404711 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2677,10 +2646,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 23.688 R
+V 0 0 T 23.6879987656 R
 N 0 0 M 104 0 D S
 U
-V 111 49 T 23.688 R
+V 111 49 T 23.6879987656 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2690,10 +2659,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 68.9612 R
+V 0 0 T 68.961237036 R
 N 0 0 M 161 0 D S
 U
-V 68 176 T 68.9612 R
+V 68 176 T 68.961237036 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2736,10 +2705,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 128.274 R
+V 0 0 T 128.273589102 R
 N 0 0 M 77 0 D S
 U
-V -56 71 T 128.274 R
+V -56 71 T 128.273589102 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2749,10 +2718,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2762,10 +2731,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 126.229 R
+V 0 0 T 126.228690606 R
 N 0 0 M 41 0 D S
 U
-V -28 38 T 126.229 R
+V -28 38 T 126.228690606 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2775,10 +2744,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 93.6681 R
+V 0 0 T 93.668072336 R
 N 0 0 M 377 0 D S
 U
-V -28 442 T 93.6681 R
+V -28 442 T 93.668072336 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2788,10 +2757,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V 0 0 T 109.329 R
+V 0 0 T 109.328900609 R
 N 0 0 M 961 0 D S
 U
-V -373 1063 T 109.329 R
+V -373 1063 T 109.328900609 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2814,10 +2783,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2827,10 +2796,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 76.6829 R
+V 0 0 T 76.6829133315 R
 N 0 0 M 63 0 D S
 U
-V 17 72 T 76.6829 R
+V 17 72 T 76.6829133315 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2840,10 +2809,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 23.9006 R
+V 0 0 T 23.9005791371 R
 N 0 0 M 571 0 D S
 U
-V 612 271 T 23.9006 R
+V 612 271 T 23.9005791371 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2853,10 +2822,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 142.338 R
+V 0 0 T 142.338327548 R
 N 0 0 M 144 0 D S
 U
-V -134 104 T 142.338 R
+V -134 104 T 142.338327548 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2888,10 +2857,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2901,10 +2870,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 129.077 R
+V 0 0 T 129.077372409 R
 N 0 0 M 577 0 D S
 U
-V -427 526 T 129.077 R
+V -427 526 T 129.077372409 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2925,10 +2894,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 80.1844 R
+V 0 0 T 80.1843508983 R
 N 0 0 M 396 0 D S
 U
-V 79 458 T 80.1844 R
+V 79 458 T 80.1843508983 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2938,10 +2907,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V 0 0 T 79.9286 R
+V 0 0 T 79.9285740348 R
 N 0 0 M 1118 0 D S
 U
-V 226 1275 T 79.9286 R
+V 226 1275 T 79.9285740348 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2951,10 +2920,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 57.9195 R
+V 0 0 T 57.9194872699 R
 N 0 0 M 199 0 D S
 U
-V 124 198 T 57.9195 R
+V 124 198 T 57.9194872699 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2975,10 +2944,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -2988,10 +2957,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T -5.25498 R
+V 0 0 T -5.2549782407 R
 N 0 0 M 252 0 D S
 U
-V 294 -27 T -5.25498 R
+V 294 -27 T -5.2549782407 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3001,10 +2970,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 57.586 R
+V 0 0 T 57.5859741375 R
 N 0 0 M 116 0 D S
 U
-V 73 115 T 57.586 R
+V 73 115 T 57.5859741375 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3014,10 +2983,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3027,10 +2996,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V 0 0 T 98.7468 R
+V 0 0 T 98.746783411 R
 N 0 0 M 857 0 D S
 U
-V -153 994 T 98.7468 R
+V -153 994 T 98.746783411 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3052,10 +3021,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 108.676 R
+V 0 0 T 108.676181316 R
 N 0 0 M 436 0 D S
 U
-V -164 485 T 108.676 R
+V -164 485 T 108.676181316 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3065,10 +3034,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3078,10 +3047,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3091,10 +3060,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3104,10 +3073,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 107.01 R
+V 0 0 T 107.009604732 R
 N 0 0 M 280 0 D S
 U
-V -96 314 T 107.01 R
+V -96 314 T 107.009604732 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3117,10 +3086,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 108.247 R
+V 0 0 T 108.247084285 R
 N 0 0 M 415 0 D S
 U
-V -153 463 T 108.247 R
+V -153 463 T 108.247084285 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3130,10 +3099,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 65.0035 R
+V 0 0 T 65.003506947 R
 N 0 0 M 455 0 D S
 U
-V 226 484 T 65.0035 R
+V 226 484 T 65.003506947 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3143,10 +3112,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3156,10 +3125,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3169,10 +3138,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 62.4421 R
+V 0 0 T 62.4420840663 R
 N 0 0 M 301 0 D S
 U
-V 164 313 T 62.4421 R
+V 164 313 T 62.4420840663 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3182,10 +3151,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V 0 0 T 65.254 R
+V 0 0 T 65.2540215489 R
 N 0 0 M 816 0 D S
 U
-V 401 869 T 65.254 R
+V 401 869 T 65.2540215489 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3195,10 +3164,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3219,10 +3188,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 141.616 R
+V 0 0 T 141.616087615 R
 N 0 0 M 97 0 D S
 U
-V -89 71 T 141.616 R
+V -89 71 T 141.616087615 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3232,10 +3201,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3245,10 +3214,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V 0 0 T 42.3002 R
+V 0 0 T 42.30021154 R
 N 0 0 M 1072 0 D S
 U
-V 924 841 T 42.3002 R
+V 924 841 T 42.30021154 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3258,10 +3227,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V 0 0 T 82.8498 R
+V 0 0 T 82.8497823969 R
 N 0 0 M 659 0 D S
 U
-V 96 767 T 82.8498 R
+V 96 767 T 82.8497823969 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3271,10 +3240,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3284,10 +3253,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 29.9461 R
+V 0 0 T 29.94608629 R
 N 0 0 M 603 0 D S
 U
-V 613 353 T 29.9461 R
+V 613 353 T 29.94608629 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3297,10 +3266,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3310,10 +3279,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3334,10 +3303,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 142.048 R
+V 0 0 T 142.047722808 R
 N 0 0 M 121 0 D S
 U
-V -112 87 T 142.048 R
+V -112 87 T 142.047722808 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3347,10 +3316,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727251741 R
 N 0 0 M 140 0 D S
 U
-V -118 115 T 135.727 R
+V -118 115 T 135.727251741 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3360,10 +3329,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3373,10 +3342,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 58.1928 R
+V 0 0 T 58.1928227994 R
 N 0 0 M 237 0 D S
 U
-V 146 236 T 58.1928 R
+V 146 236 T 58.1928227994 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3386,10 +3355,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3399,10 +3368,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3412,10 +3381,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3436,10 +3405,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3449,10 +3418,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3462,10 +3431,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V 0 0 T 53.5679 R
+V 0 0 T 53.5678656709 R
 N 0 0 M 621 0 D S
 U
-V 433 587 T 53.5679 R
+V 433 587 T 53.5678656709 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3475,10 +3444,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 178.701 R
+V 0 0 T 178.701156525 R
 N 0 0 M 203 0 D S
 U
-V -239 5 T 178.701 R
+V -239 5 T 178.701156525 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3488,17 +3457,9 @@ PSL_vecheadpen
 P clip fs P S 
 U
 N 0 0 M 1654 0 D S
-N 0 0 M 1432 827 D S
-N 0 0 M 827 1432 D S
 N 0 0 M 0 1654 D S
-N 0 0 M -827 1432 D S
-N 0 0 M -1432 827 D S
 N 0 0 M -1654 0 D S
-N 0 0 M -1432 -827 D S
-N 0 0 M -827 -1432 D S
 N 0 0 M 0 -1654 D S
-N 0 0 M 827 -1432 D S
-N 0 0 M 1432 -827 D S
 N 0 0 M 1654 0 D S
 N 0 0 551 0 360 arc S
 N 0 0 1102 0 360 arc S
@@ -3519,12 +3480,12 @@ O0
 0 3543 TM
 
 % PostScript produced by:
-%@GMT: gmt psrose subset.txt -: -JX7c -F -L -R0/3/0/360 -Bxg1 -Byg190 -BWESN -O -K -T -Y7.5c -M0.5c+b+e+gorange+n1i+h0.5
+%@GMT: gmt psrose subset.txt -: -JX7c -F -L -R0/3/0/360 -Bxg1 -Byg90 -BWESN -O -K -T -Y7.5c -M0.5c+b+e+gorange+n1i+h0.5
 %@PROJ: xy -1.37795276 1.37795276 -1.37795276 1.37795276 -1.378 1.378 -1.378 1.378 +xy
 %%BeginObject PSL_Layer_7
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1654 1654 T
 25 W
 O1
@@ -3546,7 +3507,7 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -28 -248 T 83.4981 R
+V -28 -248 T 83.4981110367 R
 N 37 0 M 426 0 D S
 PSL_vecheadpen
 4 W
@@ -3555,7 +3516,7 @@ PSL_vecheadpen
 -12 13 D
 12 13 D
 P clip fs P S U
-V 28 248 T 83.4981 R
+V 28 248 T 83.4981110367 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3565,7 +3526,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -101 -137 T 53.5537 R
+V -101 -137 T 53.5536643959 R
 N 25 0 M 290 0 D S
 PSL_vecheadpen
 4 W
@@ -3574,7 +3535,7 @@ PSL_vecheadpen
 -9 9 D
 9 9 D
 P clip fs P S U
-V 101 137 T 53.5537 R
+V 101 137 T 53.5536643959 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3584,7 +3545,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -3593,7 +3554,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3618,7 +3579,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -3627,7 +3588,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3637,7 +3598,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -3646,7 +3607,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3656,7 +3617,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -83 -33 T 21.3045 R
+V -83 -33 T 21.3044852105 R
 N 13 0 M 153 0 D S
 PSL_vecheadpen
 4 W
@@ -3665,7 +3626,7 @@ PSL_vecheadpen
 -5 5 D
 5 5 D
 P clip fs P S U
-V 83 33 T 21.3045 R
+V 83 33 T 21.3044852105 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3675,7 +3636,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -385 -234 T 31.2815 R
+V -385 -234 T 31.2814741346 R
 N 66 0 M 768 0 D S
 PSL_vecheadpen
 4 W
@@ -3684,7 +3645,7 @@ PSL_vecheadpen
 -23 24 D
 23 24 D
 P clip fs P S U
-V 385 234 T 31.2815 R
+V 385 234 T 31.2814741346 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3694,7 +3655,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -34 -121 T 74.3715 R
+V -34 -121 T 74.3714607294 R
 N 19 0 M 214 0 D S
 PSL_vecheadpen
 4 W
@@ -3703,7 +3664,7 @@ PSL_vecheadpen
 -6 7 D
 6 7 D
 P clip fs P S U
-V 34 121 T 74.3715 R
+V 34 121 T 74.3714607294 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3726,7 +3687,7 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -68 535 T -82.7683 R
+V -68 535 T -82.768290179 R
 N 80 0 M 920 0 D S
 PSL_vecheadpen
 4 W
@@ -3735,7 +3696,7 @@ PSL_vecheadpen
 -26 28 D
 26 28 D
 P clip fs P S U
-V 68 -535 T -82.7683 R
+V 68 -535 T -82.768290179 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3758,7 +3719,7 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -325 339 T -46.1829 R
+V -325 339 T -46.182924585 R
 N 69 0 M 801 0 D S
 PSL_vecheadpen
 4 W
@@ -3767,7 +3728,7 @@ PSL_vecheadpen
 -23 25 D
 23 25 D
 P clip fs P S U
-V 325 -339 T -46.1829 R
+V 325 -339 T -46.182924585 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3792,7 +3753,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 39 T -81.6637 R
+V -6 39 T -81.6636774 R
 N 6 0 M 66 0 D S
 PSL_vecheadpen
 4 W
@@ -3801,7 +3762,7 @@ PSL_vecheadpen
 -2 2 D
 2 2 D
 P clip fs P S U
-V 6 -39 T -81.6637 R
+V 6 -39 T -81.6636774 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3886,7 +3847,7 @@ V 55 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -3895,7 +3856,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3905,7 +3866,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V -102 817 T -82.8892 R
+V -102 817 T -82.889157334 R
 N 122 0 M 1403 0 D S
 PSL_vecheadpen
 4 W
@@ -3914,7 +3875,7 @@ PSL_vecheadpen
 -40 43 D
 40 43 D
 P clip fs P S U
-V 102 -817 T -82.8892 R
+V 102 -817 T -82.889157334 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3958,7 +3919,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -190 142 T -36.7059 R
+V -190 142 T -36.705879829 R
 N 35 0 M 404 0 D S
 PSL_vecheadpen
 4 W
@@ -3967,7 +3928,7 @@ PSL_vecheadpen
 -12 12 D
 12 12 D
 P clip fs P S U
-V 190 -142 T -36.7059 R
+V 190 -142 T -36.705879829 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3977,7 +3938,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -67 -93 T 54.0944 R
+V -67 -93 T 54.0943788918 R
 N 17 0 M 196 0 D S
 PSL_vecheadpen
 4 W
@@ -3986,7 +3947,7 @@ PSL_vecheadpen
 -6 6 D
 6 6 D
 P clip fs P S U
-V 67 93 T 54.0944 R
+V 67 93 T 54.0943788918 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -3996,7 +3957,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -181 -551 T 71.8287 R
+V -181 -551 T 71.8287392661 R
 N 86 0 M 988 0 D S
 PSL_vecheadpen
 4 W
@@ -4005,7 +3966,7 @@ PSL_vecheadpen
 -28 31 D
 28 31 D
 P clip fs P S U
-V 181 551 T 71.8287 R
+V 181 551 T 71.8287392661 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4028,7 +3989,7 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -45 -82 T 61.3191 R
+V -45 -82 T 61.319071179 R
 N 14 0 M 160 0 D S
 PSL_vecheadpen
 4 W
@@ -4037,7 +3998,7 @@ PSL_vecheadpen
 -4 5 D
 4 5 D
 P clip fs P S U
-V 45 82 T 61.3191 R
+V 45 82 T 61.319071179 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4047,7 +4008,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -192 390 T -63.8404 R
+V -192 390 T -63.840383385 R
 N 64 0 M 742 0 D S
 PSL_vecheadpen
 4 W
@@ -4056,7 +4017,7 @@ PSL_vecheadpen
 -22 23 D
 22 23 D
 P clip fs P S U
-V 192 -390 T -63.8404 R
+V 192 -390 T -63.840383385 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4066,7 +4027,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -74 497 T -81.5725 R
+V -74 497 T -81.572482512 R
 N 74 0 M 856 0 D S
 PSL_vecheadpen
 4 W
@@ -4075,7 +4036,7 @@ PSL_vecheadpen
 -25 26 D
 25 26 D
 P clip fs P S U
-V 74 -497 T -81.5725 R
+V 74 -497 T -81.572482512 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4085,7 +4046,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -40 99 T -68.2534 R
+V -40 99 T -68.25335831 R
 N 16 0 M 182 0 D S
 PSL_vecheadpen
 4 W
@@ -4094,7 +4055,7 @@ PSL_vecheadpen
 -5 6 D
 5 6 D
 P clip fs P S U
-V 40 -99 T -68.2534 R
+V 40 -99 T -68.25335831 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4104,7 +4065,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -68 171 T -68.3445 R
+V -68 171 T -68.344543306 R
 N 27 0 M 313 0 D S
 PSL_vecheadpen
 4 W
@@ -4113,7 +4074,7 @@ PSL_vecheadpen
 -9 10 D
 9 10 D
 P clip fs P S U
-V 68 -171 T -68.3445 R
+V 68 -171 T -68.344543306 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4123,7 +4084,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -45 -629 T 85.8829 R
+V -45 -629 T 85.882926875 R
 N 93 0 M 1076 0 D S
 PSL_vecheadpen
 4 W
@@ -4132,7 +4093,7 @@ PSL_vecheadpen
 -31 33 D
 31 33 D
 P clip fs P S U
-V 45 629 T 85.8829 R
+V 45 629 T 85.882926875 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4142,7 +4103,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -4151,7 +4112,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4161,7 +4122,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -17 16 T -44.2726 R
+V -17 16 T -44.272566387 R
 N 3 0 M 40 0 D S
 PSL_vecheadpen
 4 W
@@ -4170,7 +4131,7 @@ PSL_vecheadpen
 -2 1 D
 2 1 D
 P clip fs P S U
-V 17 -16 T -44.2726 R
+V 17 -16 T -44.272566387 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4180,7 +4141,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -4189,7 +4150,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4199,7 +4160,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -68 -121 T 60.774 R
+V -68 -121 T 60.7739941664 R
 N 20 0 M 237 0 D S
 PSL_vecheadpen
 4 W
@@ -4208,7 +4169,7 @@ PSL_vecheadpen
 -7 7 D
 7 7 D
 P clip fs P S U
-V 68 121 T 60.774 R
+V 68 121 T 60.7739941664 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4218,7 +4179,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -102 298 T -71.1242 R
+V -102 298 T -71.124233533 R
 N 46 0 M 536 0 D S
 PSL_vecheadpen
 4 W
@@ -4227,7 +4188,7 @@ PSL_vecheadpen
 -16 17 D
 16 17 D
 P clip fs P S U
-V 102 -298 T -71.1242 R
+V 102 -298 T -71.124233533 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4237,7 +4198,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -4246,7 +4207,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4256,7 +4217,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -4265,7 +4226,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4275,7 +4236,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -4284,7 +4245,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4294,7 +4255,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -4303,7 +4264,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4313,7 +4274,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -4322,7 +4283,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4332,7 +4293,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -174 164 T -43.3343 R
+V -174 164 T -43.334332264 R
 N 35 0 M 407 0 D S
 PSL_vecheadpen
 4 W
@@ -4341,7 +4302,7 @@ PSL_vecheadpen
 -12 13 D
 12 13 D
 P clip fs P S U
-V 174 -164 T -43.3343 R
+V 174 -164 T -43.334332264 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4351,7 +4312,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -4360,7 +4321,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4370,7 +4331,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -90 115 T -51.9926 R
+V -90 115 T -51.992575565 R
 N 22 0 M 248 0 D S
 PSL_vecheadpen
 4 W
@@ -4379,7 +4340,7 @@ PSL_vecheadpen
 -7 8 D
 7 8 D
 P clip fs P S U
-V 90 -115 T -51.9926 R
+V 90 -115 T -51.992575565 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4389,7 +4350,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -192 -639 T 73.2671 R
+V -192 -639 T 73.2671396726 R
 N 99 0 M 1138 0 D S
 PSL_vecheadpen
 4 W
@@ -4398,7 +4359,7 @@ PSL_vecheadpen
 -32 35 D
 32 35 D
 P clip fs P S U
-V 192 639 T 73.2671 R
+V 192 639 T 73.2671396726 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4408,7 +4369,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -68 386 T -80.0273 R
+V -68 386 T -80.027305717 R
 N 58 0 M 669 0 D S
 PSL_vecheadpen
 4 W
@@ -4417,7 +4378,7 @@ PSL_vecheadpen
 -19 21 D
 19 21 D
 P clip fs P S U
-V 68 -386 T -80.0273 R
+V 68 -386 T -80.027305717 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4427,7 +4388,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -178 49 T -15.3336 R
+V -178 49 T -15.333640212 R
 N 27 0 M 314 0 D S
 PSL_vecheadpen
 4 W
@@ -4436,7 +4397,7 @@ PSL_vecheadpen
 -9 10 D
 9 10 D
 P clip fs P S U
-V 178 -49 T -15.3336 R
+V 178 -49 T -15.333640212 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4461,7 +4422,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -4470,7 +4431,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4480,7 +4441,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -4489,7 +4450,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4499,7 +4460,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -17 -282 T 86.5472 R
+V -17 -282 T 86.5471576761 R
 N 42 0 M 481 0 D S
 PSL_vecheadpen
 4 W
@@ -4508,7 +4469,7 @@ PSL_vecheadpen
 -14 15 D
 14 15 D
 P clip fs P S U
-V 17 282 T 86.5472 R
+V 17 282 T 86.5471576761 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4531,7 +4492,7 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -468 244 T -27.5774 R
+V -468 244 T -27.577409695 R
 N 78 0 M 900 0 D S
 PSL_vecheadpen
 4 W
@@ -4540,7 +4501,7 @@ PSL_vecheadpen
 -26 28 D
 26 28 D
 P clip fs P S U
-V 468 -244 T -27.5774 R
+V 468 -244 T -27.577409695 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4578,7 +4539,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -74 342 T -77.8624 R
+V -74 342 T -77.862396883 R
 N 52 0 M 596 0 D S
 PSL_vecheadpen
 4 W
@@ -4587,7 +4548,7 @@ PSL_vecheadpen
 -17 18 D
 17 18 D
 P clip fs P S U
-V 74 -342 T -77.8624 R
+V 74 -342 T -77.862396883 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4597,7 +4558,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -352 -245 T 34.8526 R
+V -352 -245 T 34.8525550265 R
 N 63 0 M 731 0 D S
 PSL_vecheadpen
 4 W
@@ -4606,7 +4567,7 @@ PSL_vecheadpen
 -21 23 D
 21 23 D
 P clip fs P S U
-V 352 245 T 34.8526 R
+V 352 245 T 34.8525550265 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4616,7 +4577,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -158 -236 T 56.2609 R
+V -158 -236 T 56.2608798258 R
 N 42 0 M 483 0 D S
 PSL_vecheadpen
 4 W
@@ -4625,7 +4586,7 @@ PSL_vecheadpen
 -14 15 D
 14 15 D
 P clip fs P S U
-V 158 236 T 56.2609 R
+V 158 236 T 56.2608798258 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4635,7 +4596,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -489 146 T -16.6533 R
+V -489 146 T -16.653345775 R
 N 75 0 M 870 0 D S
 PSL_vecheadpen
 4 W
@@ -4644,7 +4605,7 @@ PSL_vecheadpen
 -25 27 D
 25 27 D
 P clip fs P S U
-V 489 -146 T -16.6533 R
+V 489 -146 T -16.653345775 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4654,7 +4615,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -180 330 T -61.3193 R
+V -180 330 T -61.319317602 R
 N 55 0 M 641 0 D S
 PSL_vecheadpen
 4 W
@@ -4663,7 +4624,7 @@ PSL_vecheadpen
 -19 20 D
 19 20 D
 P clip fs P S U
-V 180 -330 T -61.3193 R
+V 180 -330 T -61.319317602 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4673,7 +4634,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -11 11 T -44.2725 R
+V -11 11 T -44.272472768 R
 N 2 0 M 27 0 D S
 PSL_vecheadpen
 4 W
@@ -4682,7 +4643,7 @@ PSL_vecheadpen
 -1 1 D
 1 1 D
 P clip fs P S U
-V 11 -11 T -44.2725 R
+V 11 -11 T -44.272472768 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4707,7 +4668,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -214 -457 T 64.8451 R
+V -214 -457 T 64.8450901702 R
 N 74 0 M 860 0 D S
 PSL_vecheadpen
 4 W
@@ -4716,7 +4677,7 @@ PSL_vecheadpen
 -25 27 D
 25 27 D
 P clip fs P S U
-V 214 457 T 64.8451 R
+V 214 457 T 64.8450901702 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4726,7 +4687,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -269 -240 T 41.7868 R
+V -269 -240 T 41.7868110984 R
 N 53 0 M 614 0 D S
 PSL_vecheadpen
 4 W
@@ -4735,7 +4696,7 @@ PSL_vecheadpen
 -18 19 D
 18 19 D
 P clip fs P S U
-V 269 240 T 41.7868 R
+V 269 240 T 41.7868110984 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4760,7 +4721,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V -102 729 T -82.0377 R
+V -102 729 T -82.03770372 R
 N 109 0 M 1254 0 D S
 PSL_vecheadpen
 4 W
@@ -4769,7 +4730,7 @@ PSL_vecheadpen
 -36 39 D
 36 39 D
 P clip fs P S U
-V 102 -729 T -82.0377 R
+V 102 -729 T -82.03770372 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4796,7 +4757,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V -1047 -988 T 43.3394 R
+V -1047 -988 T 43.3393795183 R
 N 177 0 M 2526 0 D S
 PSL_vecheadpen
 4 W
@@ -4805,7 +4766,7 @@ PSL_vecheadpen
 -59 63 D
 59 63 D
 P clip fs P S U
-V 1047 988 T 43.3394 R
+V 1047 988 T 43.3393795183 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4815,7 +4776,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -33 22 T -33.0219 R
+V -33 22 T -33.021890672 R
 N 6 0 M 68 0 D S
 PSL_vecheadpen
 4 W
@@ -4824,7 +4785,7 @@ PSL_vecheadpen
 -2 2 D
 2 2 D
 P clip fs P S U
-V 33 -22 T -33.0219 R
+V 33 -22 T -33.021890672 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4847,7 +4808,7 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -11 -138 T 85.309 R
+V -11 -138 T 85.3089528426 R
 N 20 0 M 237 0 D S
 PSL_vecheadpen
 4 W
@@ -4856,7 +4817,7 @@ PSL_vecheadpen
 -7 7 D
 7 7 D
 P clip fs P S U
-V 11 138 T 85.309 R
+V 11 138 T 85.3089528426 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4879,7 +4840,7 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -17 5 T -18.003 R
+V -17 5 T -18.002972473 R
 N 3 0 M 29 0 D S
 PSL_vecheadpen
 4 W
@@ -4887,7 +4848,7 @@ PSL_vecheadpen
 3 -1 D
 0 2 D
 P clip fs P S U
-V 17 -5 T -18.003 R
+V 17 -5 T -18.002972473 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4896,7 +4857,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -34 232 T -81.6637 R
+V -34 232 T -81.663688915 R
 N 35 0 M 399 0 D S
 PSL_vecheadpen
 4 W
@@ -4905,7 +4866,7 @@ PSL_vecheadpen
 -11 12 D
 11 12 D
 P clip fs P S U
-V 34 -232 T -81.6637 R
+V 34 -232 T -81.663688915 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4930,7 +4891,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -62 88 T -54.8095 R
+V -62 88 T -54.809528386 R
 N 16 0 M 183 0 D S
 PSL_vecheadpen
 4 W
@@ -4939,7 +4900,7 @@ PSL_vecheadpen
 -5 6 D
 5 6 D
 P clip fs P S U
-V 62 -88 T -54.8095 R
+V 62 -88 T -54.809528386 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4964,7 +4925,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -57 193 T -73.6663 R
+V -57 193 T -73.666321558 R
 N 30 0 M 342 0 D S
 PSL_vecheadpen
 4 W
@@ -4973,7 +4934,7 @@ PSL_vecheadpen
 -10 11 D
 10 11 D
 P clip fs P S U
-V 57 -193 T -73.6663 R
+V 57 -193 T -73.666321558 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -4983,7 +4944,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -133 -16 T 6.94817 R
+V -133 -16 T 6.9481674333 R
 N 20 0 M 228 0 D S
 PSL_vecheadpen
 4 W
@@ -4992,7 +4953,7 @@ PSL_vecheadpen
 -6 7 D
 6 7 D
 P clip fs P S U
-V 133 16 T 6.94817 R
+V 133 16 T 6.9481674333 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5017,7 +4978,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V -1174 -971 T 39.5693 R
+V -1174 -971 T 39.5693373414 R
 N 177 0 M 2693 0 D S
 PSL_vecheadpen
 4 W
@@ -5026,7 +4987,7 @@ PSL_vecheadpen
 -59 63 D
 59 63 D
 P clip fs P S U
-V 1174 971 T 39.5693 R
+V 1174 971 T 39.5693373414 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5036,7 +4997,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -390 217 T -29.1224 R
+V -390 217 T -29.122367302 R
 N 66 0 M 761 0 D S
 PSL_vecheadpen
 4 W
@@ -5045,7 +5006,7 @@ PSL_vecheadpen
 -22 24 D
 22 24 D
 P clip fs P S U
-V 390 -217 T -29.1224 R
+V 390 -217 T -29.122367302 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5055,7 +5016,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -197 246 T -51.418 R
+V -197 246 T -51.417972598 R
 N 47 0 M 537 0 D S
 PSL_vecheadpen
 4 W
@@ -5064,7 +5025,7 @@ PSL_vecheadpen
 -15 17 D
 15 17 D
 P clip fs P S U
-V 197 -246 T -51.418 R
+V 197 -246 T -51.417972598 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5089,7 +5050,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -34 -193 T 80.0272 R
+V -34 -193 T 80.0271811365 R
 N 29 0 M 334 0 D S
 PSL_vecheadpen
 4 W
@@ -5098,7 +5059,7 @@ PSL_vecheadpen
 -10 10 D
 10 10 D
 P clip fs P S U
-V 34 193 T 80.0272 R
+V 34 193 T 80.0271811365 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5121,7 +5082,7 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V -1494 -853 T 29.7322 R
+V -1494 -853 T 29.7322200721 R
 N 177 0 M 3086 0 D S
 PSL_vecheadpen
 4 W
@@ -5130,7 +5091,7 @@ PSL_vecheadpen
 -59 63 D
 59 63 D
 P clip fs P S U
-V 1494 853 T 29.7322 R
+V 1494 853 T 29.7322200721 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5155,7 +5116,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -146 -153 T 46.3951 R
+V -146 -153 T 46.3951286195 R
 N 31 0 M 361 0 D S
 PSL_vecheadpen
 4 W
@@ -5164,7 +5125,7 @@ PSL_vecheadpen
 -11 11 D
 11 11 D
 P clip fs P S U
-V 146 153 T 46.3951 R
+V 146 153 T 46.3951286195 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5174,7 +5135,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -374 278 T -36.5796 R
+V -374 278 T -36.579595289 R
 N 69 0 M 794 0 D S
 PSL_vecheadpen
 4 W
@@ -5183,7 +5144,7 @@ PSL_vecheadpen
 -23 25 D
 23 25 D
 P clip fs P S U
-V 374 -278 T -36.5796 R
+V 374 -278 T -36.579595289 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5206,7 +5167,7 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -111 -49 T 23.688 R
+V -111 -49 T 23.6879987656 R
 N 18 0 M 207 0 D S
 PSL_vecheadpen
 4 W
@@ -5215,7 +5176,7 @@ PSL_vecheadpen
 -6 6 D
 6 6 D
 P clip fs P S U
-V 111 49 T 23.688 R
+V 111 49 T 23.6879987656 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5225,7 +5186,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -68 -176 T 68.9612 R
+V -68 -176 T 68.961237036 R
 N 28 0 M 322 0 D S
 PSL_vecheadpen
 4 W
@@ -5234,7 +5195,7 @@ PSL_vecheadpen
 -9 10 D
 9 10 D
 P clip fs P S U
-V 68 176 T 68.9612 R
+V 68 176 T 68.961237036 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5287,7 +5248,7 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -56 71 T -51.7264 R
+V -56 71 T -51.726410898 R
 N 13 0 M 155 0 D S
 PSL_vecheadpen
 4 W
@@ -5296,7 +5257,7 @@ PSL_vecheadpen
 -5 5 D
 5 5 D
 P clip fs P S U
-V 56 -71 T -51.7264 R
+V 56 -71 T -51.726410898 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5306,7 +5267,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -5315,7 +5276,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5325,7 +5286,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -28 38 T -53.7713 R
+V -28 38 T -53.771309394 R
 N 7 0 M 81 0 D S
 PSL_vecheadpen
 4 W
@@ -5334,7 +5295,7 @@ PSL_vecheadpen
 -2 3 D
 2 3 D
 P clip fs P S U
-V 28 -38 T -53.7713 R
+V 28 -38 T -53.771309394 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5344,7 +5305,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -28 442 T -86.3319 R
+V -28 442 T -86.331927664 R
 N 65 0 M 755 0 D S
 PSL_vecheadpen
 4 W
@@ -5353,7 +5314,7 @@ PSL_vecheadpen
 -22 23 D
 22 23 D
 P clip fs P S U
-V 28 -442 T -86.3319 R
+V 28 -442 T -86.331927664 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5363,7 +5324,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V -373 1063 T -70.6711 R
+V -373 1063 T -70.671099391 R
 N 166 0 M 1921 0 D S
 PSL_vecheadpen
 4 W
@@ -5372,7 +5333,7 @@ PSL_vecheadpen
 -56 59 D
 56 59 D
 P clip fs P S U
-V 373 -1063 T -70.6711 R
+V 373 -1063 T -70.671099391 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5401,7 +5362,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -5410,7 +5371,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5420,7 +5381,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -17 -72 T 76.6829 R
+V -17 -72 T 76.6829133315 R
 N 11 0 M 126 0 D S
 PSL_vecheadpen
 4 W
@@ -5429,7 +5390,7 @@ PSL_vecheadpen
 -4 4 D
 4 4 D
 P clip fs P S U
-V 17 72 T 76.6829 R
+V 17 72 T 76.6829133315 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5439,7 +5400,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -612 -271 T 23.9006 R
+V -612 -271 T 23.9005791371 R
 N 99 0 M 1141 0 D S
 PSL_vecheadpen
 4 W
@@ -5448,7 +5409,7 @@ PSL_vecheadpen
 -33 35 D
 33 35 D
 P clip fs P S U
-V 612 271 T 23.9006 R
+V 612 271 T 23.9005791371 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5458,7 +5419,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -134 104 T -37.6617 R
+V -134 104 T -37.661672452 R
 N 25 0 M 289 0 D S
 PSL_vecheadpen
 4 W
@@ -5467,7 +5428,7 @@ PSL_vecheadpen
 -8 9 D
 8 9 D
 P clip fs P S U
-V 134 -104 T -37.6617 R
+V 134 -104 T -37.661672452 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5503,7 +5464,7 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -5512,7 +5473,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5522,7 +5483,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -427 526 T -50.9226 R
+V -427 526 T -50.922627591 R
 N 100 0 M 1154 0 D S
 PSL_vecheadpen
 4 W
@@ -5531,7 +5492,7 @@ PSL_vecheadpen
 -33 36 D
 33 36 D
 P clip fs P S U
-V 427 -526 T -50.9226 R
+V 427 -526 T -50.922627591 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5554,7 +5515,7 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -79 -458 T 80.1844 R
+V -79 -458 T 80.1843508983 R
 N 69 0 M 792 0 D S
 PSL_vecheadpen
 4 W
@@ -5563,7 +5524,7 @@ PSL_vecheadpen
 -23 25 D
 23 25 D
 P clip fs P S U
-V 79 458 T 80.1844 R
+V 79 458 T 80.1843508983 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5573,7 +5534,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V -226 -1275 T 79.9286 R
+V -226 -1275 T 79.9285740348 R
 N 177 0 M 2236 0 D S
 PSL_vecheadpen
 4 W
@@ -5582,7 +5543,7 @@ PSL_vecheadpen
 -59 63 D
 59 63 D
 P clip fs P S U
-V 226 1275 T 79.9286 R
+V 226 1275 T 79.9285740348 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5592,7 +5553,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -124 -198 T 57.9195 R
+V -124 -198 T 57.9194872699 R
 N 34 0 M 398 0 D S
 PSL_vecheadpen
 4 W
@@ -5601,7 +5562,7 @@ PSL_vecheadpen
 -12 12 D
 12 12 D
 P clip fs P S U
-V 124 198 T 57.9195 R
+V 124 198 T 57.9194872699 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5626,7 +5587,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -5635,7 +5596,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5645,7 +5606,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -294 27 T -5.25498 R
+V -294 27 T -5.2549782407 R
 N 44 0 M 503 0 D S
 PSL_vecheadpen
 4 W
@@ -5654,7 +5615,7 @@ PSL_vecheadpen
 -14 16 D
 14 16 D
 P clip fs P S U
-V 294 -27 T -5.25498 R
+V 294 -27 T -5.2549782407 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5664,7 +5625,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -73 -115 T 57.586 R
+V -73 -115 T 57.5859741375 R
 N 20 0 M 233 0 D S
 PSL_vecheadpen
 4 W
@@ -5673,7 +5634,7 @@ PSL_vecheadpen
 -7 7 D
 7 7 D
 P clip fs P S U
-V 73 115 T 57.586 R
+V 73 115 T 57.5859741375 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5683,7 +5644,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -5692,7 +5653,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5702,7 +5663,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V -153 994 T -81.2532 R
+V -153 994 T -81.253216589 R
 N 148 0 M 1714 0 D S
 PSL_vecheadpen
 4 W
@@ -5711,7 +5672,7 @@ PSL_vecheadpen
 -50 53 D
 50 53 D
 P clip fs P S U
-V 153 -994 T -81.2532 R
+V 153 -994 T -81.253216589 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5738,7 +5699,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -164 485 T -71.3238 R
+V -164 485 T -71.323818684 R
 N 76 0 M 872 0 D S
 PSL_vecheadpen
 4 W
@@ -5747,7 +5708,7 @@ PSL_vecheadpen
 -25 27 D
 25 27 D
 P clip fs P S U
-V 164 -485 T -71.3238 R
+V 164 -485 T -71.323818684 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5757,7 +5718,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -5766,7 +5727,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5776,7 +5737,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -5785,7 +5746,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5795,7 +5756,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -5804,7 +5765,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5814,7 +5775,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -96 314 T -72.9904 R
+V -96 314 T -72.990395268 R
 N 49 0 M 560 0 D S
 PSL_vecheadpen
 4 W
@@ -5823,7 +5784,7 @@ PSL_vecheadpen
 -16 17 D
 16 17 D
 P clip fs P S U
-V 96 -314 T -72.9904 R
+V 96 -314 T -72.990395268 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5833,7 +5794,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -153 463 T -71.7529 R
+V -153 463 T -71.752915715 R
 N 72 0 M 831 0 D S
 PSL_vecheadpen
 4 W
@@ -5842,7 +5803,7 @@ PSL_vecheadpen
 -24 26 D
 24 26 D
 P clip fs P S U
-V 153 -463 T -71.7529 R
+V 153 -463 T -71.752915715 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5852,7 +5813,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -226 -484 T 65.0035 R
+V -226 -484 T 65.003506947 R
 N 79 0 M 911 0 D S
 PSL_vecheadpen
 4 W
@@ -5861,7 +5822,7 @@ PSL_vecheadpen
 -26 28 D
 26 28 D
 P clip fs P S U
-V 226 484 T 65.0035 R
+V 226 484 T 65.003506947 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5871,7 +5832,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -5880,7 +5841,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5890,7 +5851,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -5899,7 +5860,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5909,7 +5870,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -164 -313 T 62.4421 R
+V -164 -313 T 62.4420840663 R
 N 52 0 M 603 0 D S
 PSL_vecheadpen
 4 W
@@ -5918,7 +5879,7 @@ PSL_vecheadpen
 -18 19 D
 18 19 D
 P clip fs P S U
-V 164 313 T 62.4421 R
+V 164 313 T 62.4420840663 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5928,7 +5889,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V -401 -869 T 65.254 R
+V -401 -869 T 65.2540215489 R
 N 141 0 M 1632 0 D S
 PSL_vecheadpen
 4 W
@@ -5937,7 +5898,7 @@ PSL_vecheadpen
 -47 50 D
 47 50 D
 P clip fs P S U
-V 401 869 T 65.254 R
+V 401 869 T 65.2540215489 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5947,7 +5908,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -5956,7 +5917,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -5981,7 +5942,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -89 71 T -38.3839 R
+V -89 71 T -38.383912385 R
 N 17 0 M 194 0 D S
 PSL_vecheadpen
 4 W
@@ -5990,7 +5951,7 @@ PSL_vecheadpen
 -5 6 D
 5 6 D
 P clip fs P S U
-V 89 -71 T -38.3839 R
+V 89 -71 T -38.383912385 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6000,7 +5961,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -6009,7 +5970,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6019,7 +5980,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V -924 -841 T 42.3002 R
+V -924 -841 T 42.30021154 R
 N 177 0 M 2144 0 D S
 PSL_vecheadpen
 4 W
@@ -6028,7 +5989,7 @@ PSL_vecheadpen
 -59 63 D
 59 63 D
 P clip fs P S U
-V 924 841 T 42.3002 R
+V 924 841 T 42.30021154 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6038,7 +5999,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V -96 -767 T 82.8498 R
+V -96 -767 T 82.8497823969 R
 N 114 0 M 1319 0 D S
 PSL_vecheadpen
 4 W
@@ -6047,7 +6008,7 @@ PSL_vecheadpen
 -38 41 D
 38 41 D
 P clip fs P S U
-V 96 767 T 82.8498 R
+V 96 767 T 82.8497823969 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6057,7 +6018,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -6066,7 +6027,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6076,7 +6037,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V -613 -353 T 29.9461 R
+V -613 -353 T 29.94608629 R
 N 105 0 M 1206 0 D S
 PSL_vecheadpen
 4 W
@@ -6085,7 +6046,7 @@ PSL_vecheadpen
 -34 37 D
 34 37 D
 P clip fs P S U
-V 613 353 T 29.9461 R
+V 613 353 T 29.94608629 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6095,7 +6056,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -6104,7 +6065,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6114,7 +6075,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -6123,7 +6084,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6148,7 +6109,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -112 87 T -37.9523 R
+V -112 87 T -37.952277192 R
 N 21 0 M 242 0 D S
 PSL_vecheadpen
 4 W
@@ -6157,7 +6118,7 @@ PSL_vecheadpen
 -7 7 D
 7 7 D
 P clip fs P S U
-V 112 -87 T -37.9523 R
+V 112 -87 T -37.952277192 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6167,7 +6128,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -118 115 T -44.2727 R
+V -118 115 T -44.272748259 R
 N 24 0 M 280 0 D S
 PSL_vecheadpen
 4 W
@@ -6176,7 +6137,7 @@ PSL_vecheadpen
 -8 9 D
 8 9 D
 P clip fs P S U
-V 118 -115 T -44.2727 R
+V 118 -115 T -44.272748259 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6186,7 +6147,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -6195,7 +6156,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6205,7 +6166,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -146 -236 T 58.1928 R
+V -146 -236 T 58.1928227994 R
 N 41 0 M 474 0 D S
 PSL_vecheadpen
 4 W
@@ -6214,7 +6175,7 @@ PSL_vecheadpen
 -14 15 D
 14 15 D
 P clip fs P S U
-V 146 236 T 58.1928 R
+V 146 236 T 58.1928227994 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6224,7 +6185,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -6233,7 +6194,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6243,7 +6204,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -6252,7 +6213,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6262,7 +6223,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 5 T -44.2728 R
+V -6 5 T -44.272753623 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -6271,7 +6232,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 -5 T -44.2728 R
+V 6 -5 T -44.272753623 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6294,7 +6255,7 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -6303,7 +6264,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6313,7 +6274,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V -6 -5 T 44.2728 R
+V -6 -5 T 44.2727536233 R
 N 1 0 M 13 0 D S
 PSL_vecheadpen
 4 W
@@ -6322,7 +6283,7 @@ PSL_vecheadpen
 -1 0 D
 1 0 D
 P clip fs P S U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6332,7 +6293,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V -433 -587 T 53.5679 R
+V -433 -587 T 53.5678656709 R
 N 108 0 M 1243 0 D S
 PSL_vecheadpen
 4 W
@@ -6341,7 +6302,7 @@ PSL_vecheadpen
 -36 38 D
 36 38 D
 P clip fs P S U
-V 433 587 T 53.5679 R
+V 433 587 T 53.5678656709 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6351,7 +6312,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V -239 5 T -1.29884 R
+V -239 5 T -1.298843475 R
 N 35 0 M 407 0 D S
 PSL_vecheadpen
 4 W
@@ -6360,7 +6321,7 @@ PSL_vecheadpen
 -12 13 D
 12 13 D
 P clip fs P S U
-V 239 -5 T -1.29884 R
+V 239 -5 T -1.298843475 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6370,17 +6331,9 @@ PSL_vecheadpen
 P clip fs P S 
 U
 N 0 0 M 1654 0 D S
-N 0 0 M 1432 827 D S
-N 0 0 M 827 1432 D S
 N 0 0 M 0 1654 D S
-N 0 0 M -827 1432 D S
-N 0 0 M -1432 827 D S
 N 0 0 M -1654 0 D S
-N 0 0 M -1432 -827 D S
-N 0 0 M -827 -1432 D S
 N 0 0 M 0 -1654 D S
-N 0 0 M 827 -1432 D S
-N 0 0 M 1432 -827 D S
 N 0 0 M 1654 0 D S
 N 0 0 551 0 360 arc S
 N 0 0 1102 0 360 arc S
@@ -6406,7 +6359,7 @@ O0
 %%BeginObject PSL_Layer_8
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1654 0 T
 25 W
 O1
@@ -6424,10 +6377,10 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 83.4981 R
+V 0 0 T 83.4981110367 R
 N 0 0 M 213 0 D S
 U
-V 28 248 T 83.4981 R
+V 28 248 T 83.4981110367 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6437,10 +6390,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 53.5537 R
+V 0 0 T 53.5536643959 R
 N 0 0 M 145 0 D S
 U
-V 101 137 T 53.5537 R
+V 101 137 T 53.5536643959 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6450,10 +6403,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6474,10 +6427,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6487,10 +6440,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6500,10 +6453,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 21.3045 R
+V 0 0 T 21.3044852105 R
 N 0 0 M 76 0 D S
 U
-V 83 33 T 21.3045 R
+V 83 33 T 21.3044852105 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6513,10 +6466,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 31.2815 R
+V 0 0 T 31.2814741346 R
 N 0 0 M 384 0 D S
 U
-V 385 234 T 31.2815 R
+V 385 234 T 31.2814741346 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6526,10 +6479,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 74.3715 R
+V 0 0 T 74.3714607294 R
 N 0 0 M 107 0 D S
 U
-V 34 121 T 74.3715 R
+V 34 121 T 74.3714607294 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6548,10 +6501,10 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 97.2317 R
+V 0 0 T 97.231709821 R
 N 0 0 M 460 0 D S
 U
-V -68 535 T 97.2317 R
+V -68 535 T 97.231709821 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6570,10 +6523,10 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 133.817 R
+V 0 0 T 133.817075415 R
 N 0 0 M 400 0 D S
 U
-V -325 339 T 133.817 R
+V -325 339 T 133.817075415 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6594,10 +6547,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 98.3363 R
+V 0 0 T 98.3363226 R
 N 0 0 M 33 0 D S
 U
-V -6 39 T 98.3363 R
+V -6 39 T 98.3363226 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6660,10 +6613,10 @@ V 55 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6673,10 +6626,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V 0 0 T 97.1108 R
+V 0 0 T 97.110842666 R
 N 0 0 M 702 0 D S
 U
-V -102 817 T 97.1108 R
+V -102 817 T 97.110842666 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6710,10 +6663,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 143.294 R
+V 0 0 T 143.294120171 R
 N 0 0 M 202 0 D S
 U
-V -190 142 T 143.294 R
+V -190 142 T 143.294120171 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6723,10 +6676,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 54.0944 R
+V 0 0 T 54.0943788918 R
 N 0 0 M 98 0 D S
 U
-V 67 93 T 54.0944 R
+V 67 93 T 54.0943788918 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6736,10 +6689,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 71.8287 R
+V 0 0 T 71.8287392661 R
 N 0 0 M 494 0 D S
 U
-V 181 551 T 71.8287 R
+V 181 551 T 71.8287392661 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6758,10 +6711,10 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 61.3191 R
+V 0 0 T 61.319071179 R
 N 0 0 M 80 0 D S
 U
-V 45 82 T 61.3191 R
+V 45 82 T 61.319071179 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6771,10 +6724,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 116.16 R
+V 0 0 T 116.159616615 R
 N 0 0 M 371 0 D S
 U
-V -192 390 T 116.16 R
+V -192 390 T 116.159616615 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6784,10 +6737,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 98.4275 R
+V 0 0 T 98.427517488 R
 N 0 0 M 428 0 D S
 U
-V -74 497 T 98.4275 R
+V -74 497 T 98.427517488 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6797,10 +6750,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 111.747 R
+V 0 0 T 111.74664169 R
 N 0 0 M 91 0 D S
 U
-V -40 99 T 111.747 R
+V -40 99 T 111.74664169 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6810,10 +6763,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 111.655 R
+V 0 0 T 111.655456694 R
 N 0 0 M 157 0 D S
 U
-V -68 171 T 111.655 R
+V -68 171 T 111.655456694 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6823,10 +6776,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 85.8829 R
+V 0 0 T 85.882926875 R
 N 0 0 M 538 0 D S
 U
-V 45 629 T 85.8829 R
+V 45 629 T 85.882926875 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6836,10 +6789,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6849,10 +6802,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727433613 R
 N 0 0 M 20 0 D S
 U
-V -17 16 T 135.727 R
+V -17 16 T 135.727433613 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6862,10 +6815,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6875,10 +6828,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 60.774 R
+V 0 0 T 60.7739941664 R
 N 0 0 M 118 0 D S
 U
-V 68 121 T 60.774 R
+V 68 121 T 60.7739941664 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6888,10 +6841,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 108.876 R
+V 0 0 T 108.875766467 R
 N 0 0 M 268 0 D S
 U
-V -102 298 T 108.876 R
+V -102 298 T 108.875766467 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6901,10 +6854,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6914,10 +6867,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6927,10 +6880,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6940,10 +6893,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6953,10 +6906,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6966,10 +6919,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 136.666 R
+V 0 0 T 136.665667736 R
 N 0 0 M 203 0 D S
 U
-V -174 164 T 136.666 R
+V -174 164 T 136.665667736 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6979,10 +6932,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -6992,10 +6945,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 128.007 R
+V 0 0 T 128.007424435 R
 N 0 0 M 124 0 D S
 U
-V -90 115 T 128.007 R
+V -90 115 T 128.007424435 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7005,10 +6958,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 73.2671 R
+V 0 0 T 73.2671396726 R
 N 0 0 M 569 0 D S
 U
-V 192 639 T 73.2671 R
+V 192 639 T 73.2671396726 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7018,10 +6971,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 99.9727 R
+V 0 0 T 99.972694283 R
 N 0 0 M 334 0 D S
 U
-V -68 386 T 99.9727 R
+V -68 386 T 99.972694283 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7031,10 +6984,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 164.666 R
+V 0 0 T 164.666359788 R
 N 0 0 M 157 0 D S
 U
-V -178 49 T 164.666 R
+V -178 49 T 164.666359788 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7055,10 +7008,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7068,10 +7021,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7081,10 +7034,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 86.5472 R
+V 0 0 T 86.5471576761 R
 N 0 0 M 240 0 D S
 U
-V 17 282 T 86.5472 R
+V 17 282 T 86.5471576761 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7103,10 +7056,10 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 152.423 R
+V 0 0 T 152.422590305 R
 N 0 0 M 450 0 D S
 U
-V -468 244 T 152.423 R
+V -468 244 T 152.422590305 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7136,10 +7089,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 102.138 R
+V 0 0 T 102.137603117 R
 N 0 0 M 298 0 D S
 U
-V -74 342 T 102.138 R
+V -74 342 T 102.137603117 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7149,10 +7102,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 34.8526 R
+V 0 0 T 34.8525550265 R
 N 0 0 M 365 0 D S
 U
-V 352 245 T 34.8526 R
+V 352 245 T 34.8525550265 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7162,10 +7115,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 56.2609 R
+V 0 0 T 56.2608798258 R
 N 0 0 M 242 0 D S
 U
-V 158 236 T 56.2609 R
+V 158 236 T 56.2608798258 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7175,10 +7128,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 163.347 R
+V 0 0 T 163.346654225 R
 N 0 0 M 435 0 D S
 U
-V -489 146 T 163.347 R
+V -489 146 T 163.346654225 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7188,10 +7141,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 118.681 R
+V 0 0 T 118.680682398 R
 N 0 0 M 320 0 D S
 U
-V -180 330 T 118.681 R
+V -180 330 T 118.680682398 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7201,10 +7154,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.728 R
+V 0 0 T 135.727527232 R
 N 0 0 M 13 0 D S
 U
-V -11 11 T 135.728 R
+V -11 11 T 135.727527232 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7225,10 +7178,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 64.8451 R
+V 0 0 T 64.8450901702 R
 N 0 0 M 430 0 D S
 U
-V 214 457 T 64.8451 R
+V 214 457 T 64.8450901702 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7238,10 +7191,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 41.7868 R
+V 0 0 T 41.7868110984 R
 N 0 0 M 307 0 D S
 U
-V 269 240 T 41.7868 R
+V 269 240 T 41.7868110984 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7262,10 +7215,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V 0 0 T 97.9623 R
+V 0 0 T 97.96229628 R
 N 0 0 M 627 0 D S
 U
-V -102 729 T 97.9623 R
+V -102 729 T 97.96229628 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7287,10 +7240,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V 0 0 T 43.3394 R
+V 0 0 T 43.3393795183 R
 N 0 0 M 1263 0 D S
 U
-V 1047 988 T 43.3394 R
+V 1047 988 T 43.3393795183 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7300,10 +7253,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 146.978 R
+V 0 0 T 146.978109328 R
 N 0 0 M 34 0 D S
 U
-V -33 22 T 146.978 R
+V -33 22 T 146.978109328 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7322,10 +7275,10 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 85.309 R
+V 0 0 T 85.3089528426 R
 N 0 0 M 118 0 D S
 U
-V 11 138 T 85.309 R
+V 11 138 T 85.3089528426 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7344,10 +7297,10 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 161.997 R
+V 0 0 T 161.997027527 R
 N 0 0 M 15 0 D S
 U
-V -17 5 T 161.997 R
+V -17 5 T 161.997027527 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7356,10 +7309,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 98.3363 R
+V 0 0 T 98.336311085 R
 N 0 0 M 200 0 D S
 U
-V -34 232 T 98.3363 R
+V -34 232 T 98.336311085 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7380,10 +7333,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 125.19 R
+V 0 0 T 125.190471614 R
 N 0 0 M 92 0 D S
 U
-V -62 88 T 125.19 R
+V -62 88 T 125.190471614 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7404,10 +7357,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 106.334 R
+V 0 0 T 106.333678442 R
 N 0 0 M 171 0 D S
 U
-V -57 193 T 106.334 R
+V -57 193 T 106.333678442 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7417,10 +7370,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 6.94817 R
+V 0 0 T 6.9481674333 R
 N 0 0 M 114 0 D S
 U
-V 133 16 T 6.94817 R
+V 133 16 T 6.9481674333 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7441,10 +7394,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V 0 0 T 39.5693 R
+V 0 0 T 39.5693373414 R
 N 0 0 M 1346 0 D S
 U
-V 1174 971 T 39.5693 R
+V 1174 971 T 39.5693373414 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7454,10 +7407,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 150.878 R
+V 0 0 T 150.877632698 R
 N 0 0 M 381 0 D S
 U
-V -390 217 T 150.878 R
+V -390 217 T 150.877632698 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7467,10 +7420,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 128.582 R
+V 0 0 T 128.582027402 R
 N 0 0 M 269 0 D S
 U
-V -197 246 T 128.582 R
+V -197 246 T 128.582027402 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7491,10 +7444,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 80.0272 R
+V 0 0 T 80.0271811365 R
 N 0 0 M 167 0 D S
 U
-V 34 193 T 80.0272 R
+V 34 193 T 80.0271811365 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7513,10 +7466,10 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V 0 0 T 29.7322 R
+V 0 0 T 29.7322200721 R
 N 0 0 M 1543 0 D S
 U
-V 1494 853 T 29.7322 R
+V 1494 853 T 29.7322200721 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7537,10 +7490,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 46.3951 R
+V 0 0 T 46.3951286195 R
 N 0 0 M 180 0 D S
 U
-V 146 153 T 46.3951 R
+V 146 153 T 46.3951286195 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7550,10 +7503,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 143.42 R
+V 0 0 T 143.420404711 R
 N 0 0 M 397 0 D S
 U
-V -374 278 T 143.42 R
+V -374 278 T 143.420404711 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7572,10 +7525,10 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 23.688 R
+V 0 0 T 23.6879987656 R
 N 0 0 M 104 0 D S
 U
-V 111 49 T 23.688 R
+V 111 49 T 23.6879987656 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7585,10 +7538,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 68.9612 R
+V 0 0 T 68.961237036 R
 N 0 0 M 161 0 D S
 U
-V 68 176 T 68.9612 R
+V 68 176 T 68.961237036 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7627,10 +7580,10 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 128.274 R
+V 0 0 T 128.273589102 R
 N 0 0 M 77 0 D S
 U
-V -56 71 T 128.274 R
+V -56 71 T 128.273589102 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7640,10 +7593,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7653,10 +7606,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 126.229 R
+V 0 0 T 126.228690606 R
 N 0 0 M 41 0 D S
 U
-V -28 38 T 126.229 R
+V -28 38 T 126.228690606 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7666,10 +7619,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 93.6681 R
+V 0 0 T 93.668072336 R
 N 0 0 M 377 0 D S
 U
-V -28 442 T 93.6681 R
+V -28 442 T 93.668072336 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7679,10 +7632,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V 0 0 T 109.329 R
+V 0 0 T 109.328900609 R
 N 0 0 M 961 0 D S
 U
-V -373 1063 T 109.329 R
+V -373 1063 T 109.328900609 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7705,10 +7658,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7718,10 +7671,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 76.6829 R
+V 0 0 T 76.6829133315 R
 N 0 0 M 63 0 D S
 U
-V 17 72 T 76.6829 R
+V 17 72 T 76.6829133315 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7731,10 +7684,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 23.9006 R
+V 0 0 T 23.9005791371 R
 N 0 0 M 571 0 D S
 U
-V 612 271 T 23.9006 R
+V 612 271 T 23.9005791371 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7744,10 +7697,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 142.338 R
+V 0 0 T 142.338327548 R
 N 0 0 M 144 0 D S
 U
-V -134 104 T 142.338 R
+V -134 104 T 142.338327548 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7775,10 +7728,10 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7788,10 +7741,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 129.077 R
+V 0 0 T 129.077372409 R
 N 0 0 M 577 0 D S
 U
-V -427 526 T 129.077 R
+V -427 526 T 129.077372409 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7810,10 +7763,10 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 80.1844 R
+V 0 0 T 80.1843508983 R
 N 0 0 M 396 0 D S
 U
-V 79 458 T 80.1844 R
+V 79 458 T 80.1843508983 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7823,10 +7776,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V 0 0 T 79.9286 R
+V 0 0 T 79.9285740348 R
 N 0 0 M 1118 0 D S
 U
-V 226 1275 T 79.9286 R
+V 226 1275 T 79.9285740348 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7836,10 +7789,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 57.9195 R
+V 0 0 T 57.9194872699 R
 N 0 0 M 199 0 D S
 U
-V 124 198 T 57.9195 R
+V 124 198 T 57.9194872699 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7860,10 +7813,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7873,10 +7826,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 174.745 R
+V 0 0 T 174.745021759 R
 N 0 0 M 252 0 D S
 U
-V -294 27 T 174.745 R
+V -294 27 T 174.745021759 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7886,10 +7839,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 57.586 R
+V 0 0 T 57.5859741375 R
 N 0 0 M 116 0 D S
 U
-V 73 115 T 57.586 R
+V 73 115 T 57.5859741375 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7899,10 +7852,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7912,10 +7865,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V 0 0 T 98.7468 R
+V 0 0 T 98.746783411 R
 N 0 0 M 857 0 D S
 U
-V -153 994 T 98.7468 R
+V -153 994 T 98.746783411 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7937,10 +7890,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 108.676 R
+V 0 0 T 108.676181316 R
 N 0 0 M 436 0 D S
 U
-V -164 485 T 108.676 R
+V -164 485 T 108.676181316 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7950,10 +7903,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7963,10 +7916,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7976,10 +7929,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -7989,10 +7942,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 107.01 R
+V 0 0 T 107.009604732 R
 N 0 0 M 280 0 D S
 U
-V -96 314 T 107.01 R
+V -96 314 T 107.009604732 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8002,10 +7955,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 108.247 R
+V 0 0 T 108.247084285 R
 N 0 0 M 415 0 D S
 U
-V -153 463 T 108.247 R
+V -153 463 T 108.247084285 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8015,10 +7968,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 65.0035 R
+V 0 0 T 65.003506947 R
 N 0 0 M 455 0 D S
 U
-V 226 484 T 65.0035 R
+V 226 484 T 65.003506947 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8028,10 +7981,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8041,10 +7994,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8054,10 +8007,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 62.4421 R
+V 0 0 T 62.4420840663 R
 N 0 0 M 301 0 D S
 U
-V 164 313 T 62.4421 R
+V 164 313 T 62.4420840663 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8067,10 +8020,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V 0 0 T 65.254 R
+V 0 0 T 65.2540215489 R
 N 0 0 M 816 0 D S
 U
-V 401 869 T 65.254 R
+V 401 869 T 65.2540215489 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8080,10 +8033,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8104,10 +8057,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 141.616 R
+V 0 0 T 141.616087615 R
 N 0 0 M 97 0 D S
 U
-V -89 71 T 141.616 R
+V -89 71 T 141.616087615 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8117,10 +8070,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8130,10 +8083,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 4 W
-V 0 0 T 42.3002 R
+V 0 0 T 42.30021154 R
 N 0 0 M 1072 0 D S
 U
-V 924 841 T 42.3002 R
+V 924 841 T 42.30021154 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8143,10 +8096,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V 0 0 T 82.8498 R
+V 0 0 T 82.8497823969 R
 N 0 0 M 659 0 D S
 U
-V 96 767 T 82.8498 R
+V 96 767 T 82.8497823969 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8156,10 +8109,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8169,10 +8122,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 2 W
-V 0 0 T 29.9461 R
+V 0 0 T 29.94608629 R
 N 0 0 M 603 0 D S
 U
-V 613 353 T 29.9461 R
+V 613 353 T 29.94608629 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8182,10 +8135,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8195,10 +8148,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8219,10 +8172,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 142.048 R
+V 0 0 T 142.047722808 R
 N 0 0 M 121 0 D S
 U
-V -112 87 T 142.048 R
+V -112 87 T 142.047722808 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8232,10 +8185,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727251741 R
 N 0 0 M 140 0 D S
 U
-V -118 115 T 135.727 R
+V -118 115 T 135.727251741 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8245,10 +8198,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8258,10 +8211,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 58.1928 R
+V 0 0 T 58.1928227994 R
 N 0 0 M 237 0 D S
 U
-V 146 236 T 58.1928 R
+V 146 236 T 58.1928227994 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8271,10 +8224,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8284,10 +8237,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8297,10 +8250,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 135.727 R
+V 0 0 T 135.727246377 R
 N 0 0 M 7 0 D S
 U
-V -6 5 T 135.727 R
+V -6 5 T 135.727246377 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8319,10 +8272,10 @@ V 6 0 T PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8332,10 +8285,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 0 W
-V 0 0 T 44.2728 R
+V 0 0 T 44.2727536233 R
 N 0 0 M 7 0 D S
 U
-V 6 5 T 44.2728 R
+V 6 5 T 44.2727536233 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8345,10 +8298,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 3 W
-V 0 0 T 53.5679 R
+V 0 0 T 53.5678656709 R
 N 0 0 M 621 0 D S
 U
-V 433 587 T 53.5679 R
+V 433 587 T 53.5678656709 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8358,10 +8311,10 @@ PSL_vecheadpen
 P clip fs P S 
 U
 1 W
-V 0 0 T 178.701 R
+V 0 0 T 178.701156525 R
 N 0 0 M 203 0 D S
 U
-V -239 5 T 178.701 R
+V -239 5 T 178.701156525 R
 PSL_vecheadpen
 4 W
 0 0 M
@@ -8371,11 +8324,7 @@ PSL_vecheadpen
 P clip fs P S 
 U
 N 0 0 M 1654 0 D S
-N 0 0 M 1432 827 D S
-N 0 0 M 827 1432 D S
 N 0 0 M 0 1654 D S
-N 0 0 M -827 1432 D S
-N 0 0 M -1432 827 D S
 N 0 0 M -1654 0 D S
 N 0 0 551 0 180 arc S
 N 0 0 1102 0 180 arc S
@@ -8383,8 +8332,6 @@ N 0 0 1654 0 180 arc S
 0 2354 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 () bc Z
-0 -83 M 200 F0
-(0) tc Z
 1820 0 M 267 F0
 () ml Z
 -1820 0 M () mr Z
@@ -8402,7 +8349,7 @@ O0
 %%BeginObject PSL_Layer_9
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1654 0 T
 25 W
 O1
@@ -8413,49 +8360,49 @@ O1
 V 0 0 T 90 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 173.498 R
+V 0 0 T 173.498111037 R
 N 0 0 M 250 0 D S
 U
-V 0 0 T 143.554 R
+V 0 0 T 143.553664396 R
 N 0 0 M 170 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 111.304 R
+V 0 0 T 111.304485211 R
 N 0 0 M 89 0 D S
 U
-V 0 0 T 121.281 R
+V 0 0 T 121.281474135 R
 N 0 0 M 450 0 D S
 U
-V 0 0 T 164.371 R
+V 0 0 T 164.371460729 R
 N 0 0 M 126 0 D S
 U
 V 0 0 T 90 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 7.23171 R
+V 0 0 T 7.231709821 R
 N 0 0 M 540 0 D S
 U
 V 0 0 T 90 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 43.8171 R
+V 0 0 T 43.817075415 R
 N 0 0 M 470 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 8.33632 R
+V 0 0 T 8.3363226 R
 N 0 0 M 39 0 D S
 U
 V 0 0 T 90 R
@@ -8473,10 +8420,10 @@ U
 V 0 0 T 90 R
 N 0 0 M 55 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 7.11084 R
+V 0 0 T 7.110842666 R
 N 0 0 M 823 0 D S
 U
 V 0 0 T 180 R
@@ -8485,100 +8432,100 @@ U
 V 0 0 T 180 R
 N 0 0 M 55 0 D S
 U
-V 0 0 T 53.2941 R
+V 0 0 T 53.294120171 R
 N 0 0 M 237 0 D S
 U
-V 0 0 T 144.094 R
+V 0 0 T 144.094378892 R
 N 0 0 M 115 0 D S
 U
-V 0 0 T 161.829 R
+V 0 0 T 161.828739266 R
 N 0 0 M 580 0 D S
 U
 V 0 0 T 90 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 151.319 R
+V 0 0 T 151.319071179 R
 N 0 0 M 94 0 D S
 U
-V 0 0 T 26.1596 R
+V 0 0 T 26.159616615 R
 N 0 0 M 435 0 D S
 U
-V 0 0 T 8.42752 R
+V 0 0 T 8.427517488 R
 N 0 0 M 502 0 D S
 U
-V 0 0 T 21.7466 R
+V 0 0 T 21.74664169 R
 N 0 0 M 107 0 D S
 U
-V 0 0 T 21.6555 R
+V 0 0 T 21.655456694 R
 N 0 0 M 184 0 D S
 U
-V 0 0 T 175.883 R
+V 0 0 T 175.882926875 R
 N 0 0 M 631 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 45.7274 R
+V 0 0 T 45.727433613 R
 N 0 0 M 23 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 150.774 R
+V 0 0 T 150.773994166 R
 N 0 0 M 138 0 D S
 U
-V 0 0 T 18.8758 R
+V 0 0 T 18.875766467 R
 N 0 0 M 314 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 46.6657 R
+V 0 0 T 46.665667736 R
 N 0 0 M 239 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 38.0074 R
+V 0 0 T 38.007424435 R
 N 0 0 M 146 0 D S
 U
-V 0 0 T 163.267 R
+V 0 0 T 163.267139673 R
 N 0 0 M 668 0 D S
 U
-V 0 0 T 9.97269 R
+V 0 0 T 9.972694283 R
 N 0 0 M 392 0 D S
 U
-V 0 0 T 74.6664 R
+V 0 0 T 74.666359788 R
 N 0 0 M 184 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 176.547 R
+V 0 0 T 176.547157676 R
 N 0 0 M 282 0 D S
 U
 V 0 0 T 90 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 62.4226 R
+V 0 0 T 62.422590305 R
 N 0 0 M 528 0 D S
 U
 V 0 0 T 90 R
@@ -8587,118 +8534,118 @@ U
 V 0 0 T 180 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 12.1376 R
+V 0 0 T 12.137603117 R
 N 0 0 M 350 0 D S
 U
-V 0 0 T 124.853 R
+V 0 0 T 124.852555026 R
 N 0 0 M 429 0 D S
 U
-V 0 0 T 146.261 R
+V 0 0 T 146.260879826 R
 N 0 0 M 284 0 D S
 U
-V 0 0 T 73.3467 R
+V 0 0 T 73.346654225 R
 N 0 0 M 510 0 D S
 U
-V 0 0 T 28.6807 R
+V 0 0 T 28.680682398 R
 N 0 0 M 376 0 D S
 U
-V 0 0 T 45.7275 R
+V 0 0 T 45.727527232 R
 N 0 0 M 16 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 154.845 R
+V 0 0 T 154.84509017 R
 N 0 0 M 504 0 D S
 U
-V 0 0 T 131.787 R
+V 0 0 T 131.786811098 R
 N 0 0 M 360 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 7.9623 R
+V 0 0 T 7.96229628 R
 N 0 0 M 736 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 11 0 D S
 U
-V 0 0 T 133.339 R
+V 0 0 T 133.339379518 R
 N 0 0 M 1440 0 D S
 U
-V 0 0 T 56.9781 R
+V 0 0 T 56.978109328 R
 N 0 0 M 40 0 D S
 U
 V 0 0 T 90 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 175.309 R
+V 0 0 T 175.308952843 R
 N 0 0 M 139 0 D S
 U
 V 0 0 T 90 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 71.997 R
+V 0 0 T 71.997027527 R
 N 0 0 M 18 0 D S
 U
-V 0 0 T 8.33631 R
+V 0 0 T 8.336311085 R
 N 0 0 M 234 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 35.1905 R
+V 0 0 T 35.190471614 R
 N 0 0 M 107 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 16.3337 R
+V 0 0 T 16.333678442 R
 N 0 0 M 201 0 D S
 U
-V 0 0 T 96.9482 R
+V 0 0 T 96.9481674333 R
 N 0 0 M 134 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 129.569 R
+V 0 0 T 129.569337341 R
 N 0 0 M 1524 0 D S
 U
-V 0 0 T 60.8776 R
+V 0 0 T 60.877632698 R
 N 0 0 M 447 0 D S
 U
-V 0 0 T 38.582 R
+V 0 0 T 38.582027402 R
 N 0 0 M 315 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 170.027 R
+V 0 0 T 170.027181136 R
 N 0 0 M 196 0 D S
 U
 V 0 0 T 90 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 119.732 R
+V 0 0 T 119.732220072 R
 N 0 0 M 1720 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 136.395 R
+V 0 0 T 136.395128619 R
 N 0 0 M 211 0 D S
 U
-V 0 0 T 53.4204 R
+V 0 0 T 53.420404711 R
 N 0 0 M 466 0 D S
 U
 V 0 0 T 90 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 113.688 R
+V 0 0 T 113.687998766 R
 N 0 0 M 122 0 D S
 U
-V 0 0 T 158.961 R
+V 0 0 T 158.961237036 R
 N 0 0 M 189 0 D S
 U
 V 0 0 T 90 R
@@ -8710,34 +8657,34 @@ U
 V 0 0 T 90 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 38.2736 R
+V 0 0 T 38.273589102 R
 N 0 0 M 91 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 36.2287 R
+V 0 0 T 36.228690606 R
 N 0 0 M 48 0 D S
 U
-V 0 0 T 3.66807 R
+V 0 0 T 3.668072336 R
 N 0 0 M 443 0 D S
 U
-V 0 0 T 19.3289 R
+V 0 0 T 19.328900609 R
 N 0 0 M 1127 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 149 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 166.683 R
+V 0 0 T 166.682913332 R
 N 0 0 M 74 0 D S
 U
-V 0 0 T 113.901 R
+V 0 0 T 113.900579137 R
 N 0 0 M 670 0 D S
 U
-V 0 0 T 52.3383 R
+V 0 0 T 52.338327548 R
 N 0 0 M 169 0 D S
 U
 V 0 0 T 90 R
@@ -8746,154 +8693,150 @@ U
 V 0 0 T 90 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 39.0774 R
+V 0 0 T 39.077372409 R
 N 0 0 M 677 0 D S
 U
 V 0 0 T 90 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 170.184 R
+V 0 0 T 170.184350898 R
 N 0 0 M 465 0 D S
 U
-V 0 0 T 169.929 R
+V 0 0 T 169.928574035 R
 N 0 0 M 1295 0 D S
 U
-V 0 0 T 147.919 R
+V 0 0 T 147.91948727 R
 N 0 0 M 233 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 84.745 R
+V 0 0 T 84.7450217593 R
 N 0 0 M 295 0 D S
 U
-V 0 0 T 147.586 R
+V 0 0 T 147.585974137 R
 N 0 0 M 137 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 8.74678 R
+V 0 0 T 8.746783411 R
 N 0 0 M 1005 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 11 0 D S
 U
-V 0 0 T 18.6762 R
+V 0 0 T 18.676181316 R
 N 0 0 M 512 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 17.0096 R
+V 0 0 T 17.009604732 R
 N 0 0 M 329 0 D S
 U
-V 0 0 T 18.2471 R
+V 0 0 T 18.247084285 R
 N 0 0 M 487 0 D S
 U
-V 0 0 T 155.004 R
+V 0 0 T 155.003506947 R
 N 0 0 M 534 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 152.442 R
+V 0 0 T 152.442084066 R
 N 0 0 M 353 0 D S
 U
-V 0 0 T 155.254 R
+V 0 0 T 155.254021549 R
 N 0 0 M 957 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 51.6161 R
+V 0 0 T 51.616087615 R
 N 0 0 M 114 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 132.3 R
+V 0 0 T 132.30021154 R
 N 0 0 M 1249 0 D S
 U
-V 0 0 T 172.85 R
+V 0 0 T 172.849782397 R
 N 0 0 M 773 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 119.946 R
+V 0 0 T 119.94608629 R
 N 0 0 M 708 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
 V 0 0 T 180 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 52.0477 R
+V 0 0 T 52.047722808 R
 N 0 0 M 142 0 D S
 U
-V 0 0 T 45.7273 R
+V 0 0 T 45.727251741 R
 N 0 0 M 164 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 148.193 R
+V 0 0 T 148.192822799 R
 N 0 0 M 278 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 45.7272 R
+V 0 0 T 45.727246377 R
 N 0 0 M 8 0 D S
 U
 V 0 0 T 90 R
 N 0 0 M 6 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 134.273 R
+V 0 0 T 134.272753623 R
 N 0 0 M 8 0 D S
 U
-V 0 0 T 143.568 R
+V 0 0 T 143.567865671 R
 N 0 0 M 729 0 D S
 U
-V 0 0 T 88.7012 R
+V 0 0 T 88.701156525 R
 N 0 0 M 239 0 D S
 U
 4 W
 N 0 0 M 1654 0 D S
-N 0 0 M 1432 827 D S
-N 0 0 M 827 1432 D S
 N 0 0 M 0 1654 D S
-N 0 0 M -827 1432 D S
-N 0 0 M -1432 827 D S
 N 0 0 M -1654 0 D S
 N 0 0 551 0 180 arc S
 N 0 0 1102 0 180 arc S
@@ -8901,8 +8844,6 @@ N 0 0 1654 0 180 arc S
 0 2354 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 () bc Z
-0 -83 M 200 F0
-(0) tc Z
 1820 0 M 267 F0
 () ml Z
 -1820 0 M () mr Z
@@ -8920,11 +8861,12 @@ O0
 %%BeginObject PSL_Layer_10
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 %%EndObject
 
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U

--- a/test/psrose/vectors.sh
+++ b/test/psrose/vectors.sh
@@ -7,7 +7,7 @@ awk '{if ((NR%50) == 0) print $0}' $data > subset.txt
 common0n="subset.txt -: -JX7c -F -L -Ggray -R0/3/-90/90 -Bxg1 -Byg90 -BWESN -O -K"
 common1n="subset.txt -: -JX7c -F -L -Ggray -R0/3/0/180 -Bxg1 -Byg90 -BWESN -O -K"
 commonn="subset.txt  -: -JX7c -F -L -Ggray -R0/750/0/360 -Bxg200 -Byg90 -BWESN -O -K"
-commonu="subset.txt  -: -JX7c -F -L -R0/3/0/360 -Bxg1 -Byg190 -BWESN -O -K"
+commonu="subset.txt  -: -JX7c -F -L -R0/3/0/360 -Bxg1 -Byg90 -BWESN -O -K"
 # Set up blank plot
 gmt psxy -R0/5/0/5 -Jx1c -P -K -T > $ps
 gmt set MAP_VECTOR_SHAPE 0.5


### PR DESCRIPTION
**Description of proposed changes**

This PR started out by addressing #3615 which was an easy fix.  However, it became clear that **psrose -B** was violating most rules about base frames:


1. With no **-B** there should be no frame
2. With **-Bafg** or any of them, we should automatically estimate an interval.
3. The w/e/s/n labels should become -90/90 or 0/180 if half-circle.

Now, giving no **-B**, or **-B+n**, results in no frame, like all other modules with **-B**.  However, the -Bauto was interesting.  We had a hard-wired setting in **rose** that make this setting 30 degrees for all plot, no matter what size. This happen even if you actually specified a separate grid-interval like **-Bg**90.  Several tests used **-Bg**90 but were overruled to basically do **-Bg**30.  Once this hard-wired case was removed it became clear that the auto-interval was garbage. This is because internally, the polar projection switches to a square Cartesian one and hence the 0/360 angles are gone, yielding silly auto-intervals for azimuth.  OK, so we clearly had to overrule those in the module if auto-intervals were set. After that, I tried **-R**-90/90 with annotations and that actually crashed with SEGV, because we were trying to printf to Ctrl-L.w which once upon a time was a string but is now a pointer, and it was NULL.  So fixing that, and clarifying the man pages in several pages.  Some of the test scripts needed updates as there were typos in **-By** that not cause problems due to the other bugs.  A handful of PS originals had to be updated.  However, now **psrose -B** should behave like we expect.
