### PR TITLE
Delete local versions of remote files and tile-directories older than creation date

### DIFF
--- a/src/gmt_io.h
+++ b/src/gmt_io.h
@@ -256,6 +256,7 @@ struct GMT_IO {				/* Used to process input data records */
 	bool first_rec;			/* true when reading very first data record in a dataset */
 	bool trailing_text[2];	/* Default is to process training text unless turned off via -i, -o */
 	bool refreshed[2];		/* true after calling the hash_refresh function the first time, for hash and info, respectively */
+	bool new_data_list;		/* true after when a server refresh yields an updated gmt_data_server.txt */
 	bool internet_error;		/* true after failing to get hash table due to time-out */
 	bool grid_padding;		/* If true we try to read two extra rows/cols from grids for BC purposes */
 	bool leave_as_jp2;		/* If true we do not convert downloaded JP2 grids to NC right away, but as needed */


### PR DESCRIPTION
Since we anticipate that we will update some of the data sets on the server as new versions of SRTM15+ or age grids arrive, we check if the _date_ in the server data listing is more recent than the creation date of any copy found in the user's server directory.  Any files older that the server date will unceremoniously be removed, so that the next time the user accesses that file it will be downloaded from the server.
This check is only run if the _gmt_data_server.txt_ file has just been updated (by the current module) which only happens once a day, assuming the user runs GMT that often.  I am using the same scheme as **gmt clear** for (possibly populated) directories: Let the operating system delete the directory for us.  Single files we delete via C functions.