### PR TITLE
Only make tiny adjustments to dx and dy if both need it

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -1293,22 +1293,23 @@ int gmtlib_get_grdtype (struct GMT_CTRL *GMT, unsigned int direction, struct GMT
 
 GMT_LOCAL void gmtgrdio_doctor_geo_increments (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header) {
 	/* Check for sloppy arc min/sec increments due to divisions by 60 or 3600 */
-	double round_inc, scale, inc, slop;
-	unsigned int side;
+	double round_inc[2], scale[2], inc, slop;
+	unsigned int side, n_fix = 0;
 	static char *type[2] = {"longitude", "latitude"};
 
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Call gmtgrdio_doctor_geo_increments on a geographic grid\n");
 	for (side = GMT_X; side <= GMT_Y; side++) {	/* Check both increments */
-		scale = (header->inc[side] < GMT_MIN2DEG) ? 3600.0 : 60.0;	/* Check for clean multiples of minutes or seconds */
-		inc = header->inc[side] * scale;
-		round_inc = rint (inc);
-		slop = fabs (inc - round_inc);
-		if (slop > 0 && slop < GMT_CONV4_LIMIT) {
-			inc = header->inc[side];
-			header->inc[side] = round_inc / scale;
-			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Round-off patrol changed geographic grid increment for %s from %.18g to %.18g\n",
-				type[side], inc, header->inc[side]);
-		}
+		scale[side] = (header->inc[side] < GMT_MIN2DEG) ? 3600.0 : 60.0;	/* Check for clean multiples of minutes or seconds */
+		inc = header->inc[side] * scale[side];
+		round_inc[side] = rint (inc);
+		slop = fabs (inc - round_inc[side]);
+		if (slop > 0 && slop < GMT_CONV4_LIMIT) n_fix++;
+	}
+	if (n_fix == 2) {
+		inc = header->inc[side];
+		header->inc[side] = round_inc[side] / scale[side];
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Round-off patrol changed geographic grid increment for %s from %.18g to %.18g\n",
+			type[side], inc, header->inc[side]);
 	}
 }
 
@@ -1381,7 +1382,8 @@ int gmtlib_read_grd_info (struct GMT_CTRL *GMT, char *file, struct GMT_GRID_HEAD
 		header->nan_value = invalid;
 
 	gmtlib_grd_get_units (GMT, header);
-	gmtgrdio_round_off_patrol (GMT, header);	/* Ensure limit/inc consistency */
+	if (strncmp (GMT->init.module_name, "grdedit", 7U))
+		gmtgrdio_round_off_patrol (GMT, header);	/* Ensure limit/inc consistency */
 	//gmtlib_clean_global_headers (GMT, header);
 
 	if (header->ProjRefPROJ4 && strstr (header->ProjRefPROJ4, "longlat"))	/* A geographic image perhaps */

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -1306,10 +1306,12 @@ GMT_LOCAL void gmtgrdio_doctor_geo_increments (struct GMT_CTRL *GMT, struct GMT_
 		if (slop > 0 && slop < GMT_CONV4_LIMIT) n_fix++;
 	}
 	if (n_fix == 2) {
-		inc = header->inc[side];
-		header->inc[side] = round_inc[side] / scale[side];
-		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Round-off patrol changed geographic grid increment for %s from %.18g to %.18g\n",
-			type[side], inc, header->inc[side]);
+		for (side = GMT_X; side <= GMT_Y; side++) {	/* Check both increments */
+			inc = header->inc[side];
+			header->inc[side] = round_inc[side] / scale[side];
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Round-off patrol changed geographic grid increment for %s from %.18g to %.18g\n",
+				type[side], inc, header->inc[side]);
+		}
 	}
 }
 


### PR DESCRIPTION
We have a roundoff-patrol checker that looks to see if an geographic grid increment is close to a multiple of integer seconds or minutes.  If it is close enough then we set it to be exact.  However, the [case](https://forum.generic-mapping-tools.org/t/grdedit-a-seems-not-to-work/636/13) that triggered this discussion was close enough to 3s in x but not in y.  I think we should at least require **both** increments to be adjusted or neither, and possibly tighten the decision when to do this.  This PR requires both increment to be flagged to be adjusted instead of just one, so it fixes the immediate problem, but we can discuss the check.  To be flagged, the increment and its nearest integer has to differ by less than 10^-4 (GMT_CONV4_LIMIT).  Unfortunately, all this code was of course added for the same reason: Someones grid made elsewhere with ugly increments and boundaries, so it is there for a purpose.  We could tighten it to 10-5 or -6 but it could have other consequences.  I also turn off the roundoff-patrol when **grdedit** is used since it interferes with options like **-A**.

So summary of changes:

1. Only adjust increment to nearest integer minute or second if **both** increments are flagged this way
2. Do not do the adjustment when **grdedit** is used
