### PR TITLE
Setup a GitHub Action to automatically do the backports

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,6 @@ Fixes #
 
 **Reminders**
 
-- [ ] Correct base branch selected? `master` for new features, `6.1` for bug fixes
 - [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
 - [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
 - [ ] Describe changes to function behavior and arguments in a comment below the function declaration.

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,20 @@
+#
+# Backport a PR lablled by "backport 6.1" into 6.1 branch
+#
+
+name: Backport
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    name: Backport
+    steps:
+      - name: Backport
+        uses: tibdex/backport@v1.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,4 +1,9 @@
-# GitHub action to make a draft release
+#
+# Make a draft release when tagging
+#
+# The release assets are automatically downloaded from the GMT FTP server
+# and uploaded to GitHub.
+#
 
 on:
   push:
@@ -19,9 +24,9 @@ jobs:
       #- name: Set DEBUG_GITHUB_REF for debugging
       #  run: echo "::set-env name=DEBUG_GITHUB_REF::refs/tags/6.0.0"
 
-      - name: Set GMT Version from tag name
+      - name: Set GMT version from tag name
         # ${GITHUB_REF} is "refs/tags/6.0.0" for tags
-        # after this step, the GMT Version can be used by ${{ env.GMT_VERSION }}
+        # after this step, the GMT version can be used as ${{ env.GMT_VERSION }}
         run: echo "::set-env name=GMT_VERSION::${GITHUB_REF##*/}"
         # Uncomment the following line for debugging only
         # run: echo "::set-env name=GMT_VERSION::${DEBUG_GITHUB_REF##*/}"


### PR DESCRIPTION
**Description of proposed changes**

Following the [new workflow](https://github.com/GenericMappingTools/gmt/issues/3612#issuecomment-655115921), we will merge all commits into master branch, and backport critical fixes into 6.1 branch. 

This PR setup the backport action to make backporting automatically.

If you open a PR for master branch, and want to backport it to the 6.1 branch, the only thing you need to do is adding [the "backport 6.1" label](https://github.com/GenericMappingTools/gmt/labels/backport%206.1) to this PR. When this PR is merged, it will **automatically** create a backport PR for the 6.1 branch.


