### PR TITLE
Update example 47 and test regress_2

### DIFF
--- a/doc/examples/ex47/ex47.ps
+++ b/doc/examples/ex47/ex47.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 595 842
 %%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.1.0_4575a83_2020.05.01 [64-bit] Document from psxy
+%%Title: GMT v6.2.0_c981889_2020.07.10 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Fri May  1 10:52:39 2020
+%%CreationDate: Sat Jul 11 18:48:17 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -666,7 +666,7 @@ O0
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 %%EndObject
 PSL_plot_completion /PSL_plot_completion {} def
 0 A
@@ -679,7 +679,7 @@ O0
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {0.941 1 0.941 C} FS
 -2362 0 0 2362 2362 0 3 0 0 SP
 25 W
@@ -946,7 +946,7 @@ O0
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {1 0 0 C} FS
@@ -967,7 +967,7 @@ O0
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 O1
@@ -988,7 +988,7 @@ O0
 %%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 33 W
 clipsave
 0 0 M
@@ -1018,10 +1018,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -BWens+ghoneydew data.txt -Sc0.1c -Gblue -Bxafg '-Byafg+lLog light intensity' -Xa0i -Ya4.2148i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_6
+%%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {0.941 1 0.941 C} FS
 -2362 0 0 2362 2362 0 3 0 0 SP
 25 W
@@ -1279,10 +1279,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.1c -Gred -N -Xa0i -Ya4.2148i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_7
+%%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {1 0 0 C} FS
@@ -1300,10 +1300,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.25c -W0.25p -N -Xa0i -Ya4.2148i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_8
+%%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 O1
@@ -1321,10 +1321,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -W2p -Xa0i -Ya4.2148i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_9
+%%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 33 W
 clipsave
 0 0 M
@@ -1333,10 +1333,10 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-1158 -5 M
--2 5 D
--697 2362 D
--1 5 D S
+990 -2 M
+0 2 D
+-337 2362 D
+-1 3 D S
 PSL_cliprestore
 %%EndObject
 0 -5058 TM
@@ -1348,10 +1348,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -BWens+ghoneydew data.txt -Sc0.1c -Gblue -Bxafg '-Byafg+lLog light intensity' -Xa0i -Ya2.1074i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_10
+%%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {0.941 1 0.941 C} FS
 -2362 0 0 2362 2362 0 3 0 0 SP
 25 W
@@ -1609,10 +1609,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.1c -Gred -N -Xa0i -Ya2.1074i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_11
+%%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {1 0 0 C} FS
@@ -1630,10 +1630,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.25c -W0.25p -N -Xa0i -Ya2.1074i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_12
+%%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 O1
@@ -1651,10 +1651,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -W2p -Xa0i -Ya2.1074i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_13
+%%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 33 W
 clipsave
 0 0 M
@@ -1678,10 +1678,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -BWenS+ghoneydew data.txt -Sc0.1c -Gblue '-Bxafg+lLog temperature' '-Byafg+lLog light intensity' -Xa0i -Ya0i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_14
+%%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {0.941 1 0.941 C} FS
 -2362 0 0 2362 2362 0 3 0 0 SP
 25 W
@@ -1963,10 +1963,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.1c -Gred -N -Xa0i -Ya0i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_15
+%%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {1 0 0 C} FS
@@ -1984,10 +1984,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.25c -W0.25p -N -Xa0i -Ya0i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_16
+%%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 O1
@@ -2005,10 +2005,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -W2p -Xa0i -Ya0i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_17
+%%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 33 W
 clipsave
 0 0 M
@@ -2017,10 +2017,10 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-990 -2 M
-0 2 D
--337 2362 D
--1 3 D S
+1158 -5 M
+-2 5 D
+-697 2362 D
+-1 5 D S
 PSL_cliprestore
 %%EndObject
 0 0 TM
@@ -2032,10 +2032,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -Bwens+ghoneydew+tL@-2@- data.txt -Sc0.1c -Gblue -Bxafg -Byafg -Xa2.1074i -Ya6.3222i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_18
+%%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {0.941 1 0.941 C} FS
 -2362 0 0 2362 2362 0 3 0 0 SP
 25 W
@@ -2274,10 +2274,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.1c -Gred -N -Xa2.1074i -Ya6.3222i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_19
+%%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {1 0 0 C} FS
@@ -2295,10 +2295,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.25c -W0.25p -N -Xa2.1074i -Ya6.3222i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_20
+%%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 O1
@@ -2316,10 +2316,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -W2p -Xa2.1074i -Ya6.3222i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_21
+%%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 33 W
 clipsave
 0 0 M
@@ -2328,11 +2328,32 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-1486 -8 M
--4 8 D
--596 1172 D
--606 1190 D
--4 8 D S
+2362 1689 M
+-98 -41 D
+-99 -41 D
+-98 -41 D
+-98 -40 D
+-99 -41 D
+-98 -41 D
+-99 -40 D
+-98 -41 D
+-99 -41 D
+-98 -40 D
+-98 -41 D
+-99 -41 D
+-98 -40 D
+-99 -41 D
+-98 -41 D
+-99 -40 D
+-98 -41 D
+-98 -41 D
+-99 -40 D
+-98 -41 D
+-99 -41 D
+-98 -40 D
+-99 -41 D
+-98 -41 D
+S
 PSL_cliprestore
 %%EndObject
 -2529 -7587 TM
@@ -2344,10 +2365,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -Bwens+ghoneydew data.txt -Sc0.1c -Gblue -Bxafg -Byafg -Xa2.1074i -Ya4.2148i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_22
+%%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {0.941 1 0.941 C} FS
 -2362 0 0 2362 2362 0 3 0 0 SP
 25 W
@@ -2579,10 +2600,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.1c -Gred -N -Xa2.1074i -Ya4.2148i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_23
+%%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {1 0 0 C} FS
@@ -2600,10 +2621,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.25c -W0.25p -N -Xa2.1074i -Ya4.2148i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_24
+%%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 O1
@@ -2621,10 +2642,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -W2p -Xa2.1074i -Ya4.2148i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_25
+%%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 33 W
 clipsave
 0 0 M
@@ -2633,9 +2654,9 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-1105 2365 M
-0 -3 D
--335 -2362 D
+1061 2364 M
+0 -2 D
+-253 -2362 D
 0 -2 D S
 PSL_cliprestore
 %%EndObject
@@ -2648,10 +2669,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -Bwens+ghoneydew data.txt -Sc0.1c -Gblue -Bxafg -Byafg -Xa2.1074i -Ya2.1074i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_26
+%%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {0.941 1 0.941 C} FS
 -2362 0 0 2362 2362 0 3 0 0 SP
 25 W
@@ -2883,10 +2904,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.1c -Gred -N -Xa2.1074i -Ya2.1074i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_27
+%%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {1 0 0 C} FS
@@ -2904,10 +2925,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.25c -W0.25p -N -Xa2.1074i -Ya2.1074i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_28
+%%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 O1
@@ -2925,10 +2946,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -W2p -Xa2.1074i -Ya2.1074i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_29
+%%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 33 W
 clipsave
 0 0 M
@@ -2937,9 +2958,9 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-1061 2364 M
-0 -2 D
--253 -2362 D
+1105 2365 M
+0 -3 D
+-335 -2362 D
 0 -2 D S
 PSL_cliprestore
 %%EndObject
@@ -2952,10 +2973,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -BwenS+ghoneydew data.txt -Sc0.1c -Gblue '-Bxafg+lLog temperature' -Byafg -Xa2.1074i -Ya0i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_30
+%%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {0.941 1 0.941 C} FS
 -2362 0 0 2362 2362 0 3 0 0 SP
 25 W
@@ -3212,10 +3233,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.1c -Gred -N -Xa2.1074i -Ya0i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_31
+%%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {1 0 0 C} FS
@@ -3233,10 +3254,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.25c -W0.25p -N -Xa2.1074i -Ya0i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_32
+%%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 O1
@@ -3254,10 +3275,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -W2p -Xa2.1074i -Ya0i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_33
+%%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 33 W
 clipsave
 0 0 M
@@ -3266,32 +3287,11 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-2362 1689 M
--98 -41 D
--99 -41 D
--98 -41 D
--98 -40 D
--99 -41 D
--98 -41 D
--99 -40 D
--98 -41 D
--99 -41 D
--98 -40 D
--98 -41 D
--99 -41 D
--98 -40 D
--99 -41 D
--98 -41 D
--99 -40 D
--98 -41 D
--98 -41 D
--99 -40 D
--98 -41 D
--99 -41 D
--98 -40 D
--99 -41 D
--98 -41 D
-S
+1574 2370 M
+-3 -8 D
+-882 -1731 D
+-321 -631 D
+-4 -8 D S
 PSL_cliprestore
 %%EndObject
 -2529 0 TM
@@ -3303,10 +3303,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -Bwens+ghoneydew+tLMS data.txt -Sc0.1c -Gblue -Bxafg -Byafg -Xa4.2148i -Ya6.3222i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_34
+%%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {0.941 1 0.941 C} FS
 -2362 0 0 2362 2362 0 3 0 0 SP
 25 W
@@ -3543,10 +3543,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.1c -Gred -N -Xa4.2148i -Ya6.3222i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_35
+%%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {1 0 0 C} FS
@@ -3564,10 +3564,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.25c -W0.25p -N -Xa4.2148i -Ya6.3222i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_36
+%%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 O1
@@ -3585,10 +3585,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -W2p -Xa4.2148i -Ya6.3222i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_37
+%%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 33 W
 clipsave
 0 0 M
@@ -3597,10 +3597,10 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-1054 -3 M
--1 3 D
--468 2362 D
--1 3 D S
+1069 -4 M
+-1 4 D
+-591 2362 D
+-1 4 D S
 PSL_cliprestore
 %%EndObject
 -5058 -7587 TM
@@ -3611,10 +3611,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt pstext '-F+cRM+jTC+a90+tY ON X' -N -Dj15p -Xa4.2148i -Ya6.3222i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_38
+%%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 2612 1181 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V 90 R (Y ON X) tc Z U
@@ -3628,10 +3628,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -Bwens+ghoneydew data.txt -Sc0.1c -Gblue -Bxafg -Byafg -Xa4.2148i -Ya4.2148i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_39
+%%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {0.941 1 0.941 C} FS
 -2362 0 0 2362 2362 0 3 0 0 SP
 25 W
@@ -3863,10 +3863,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.1c -Gred -N -Xa4.2148i -Ya4.2148i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_40
+%%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {1 0 0 C} FS
@@ -3884,10 +3884,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.25c -W0.25p -N -Xa4.2148i -Ya4.2148i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_41
+%%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 O1
@@ -3905,10 +3905,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -W2p -Xa4.2148i -Ya4.2148i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_42
+%%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 33 W
 clipsave
 0 0 M
@@ -3917,9 +3917,9 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-1054 -3 M
--1 3 D
--468 2362 D
+1053 -3 M
+0 3 D
+-467 2362 D
 -1 3 D S
 PSL_cliprestore
 %%EndObject
@@ -3931,10 +3931,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt pstext '-F+cRM+jTC+a90+tX ON Y' -N -Dj15p -Xa4.2148i -Ya4.2148i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_43
+%%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 2612 1181 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V 90 R (X ON Y) tc Z U
@@ -3948,10 +3948,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -Bwens+ghoneydew data.txt -Sc0.1c -Gblue -Bxafg -Byafg -Xa4.2148i -Ya2.1074i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_44
+%%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {0.941 1 0.941 C} FS
 -2362 0 0 2362 2362 0 3 0 0 SP
 25 W
@@ -4183,10 +4183,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.1c -Gred -N -Xa4.2148i -Ya2.1074i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_45
+%%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {1 0 0 C} FS
@@ -4204,10 +4204,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.25c -W0.25p -N -Xa4.2148i -Ya2.1074i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_46
+%%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 O1
@@ -4225,10 +4225,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -W2p -Xa4.2148i -Ya2.1074i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_47
+%%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 33 W
 clipsave
 0 0 M
@@ -4237,9 +4237,9 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-1053 -3 M
-0 3 D
--467 2362 D
+1054 -3 M
+-1 3 D
+-468 2362 D
 -1 3 D S
 PSL_cliprestore
 %%EndObject
@@ -4251,10 +4251,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt pstext -F+cRM+jTC+a90+tORTHOGONAL -N -Dj15p -Xa4.2148i -Ya2.1074i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_48
+%%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 2612 1181 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V 90 R (ORTHOGONAL) tc Z U
@@ -4268,10 +4268,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -BwenS+ghoneydew data.txt -Sc0.1c -Gblue '-Bxafg+lLog temperature' -Byafg -Xa4.2148i -Ya0i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_49
+%%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {0.941 1 0.941 C} FS
 -2362 0 0 2362 2362 0 3 0 0 SP
 25 W
@@ -4528,10 +4528,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.1c -Gred -N -Xa4.2148i -Ya0i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_50
+%%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 {1 0 0 C} FS
@@ -4549,10 +4549,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy giants.txt -Sc0.25c -W0.25p -N -Xa4.2148i -Ya0i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_51
+%%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 4 W
 V
 O1
@@ -4570,10 +4570,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt psxy -W2p -Xa4.2148i -Ya0i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_52
+%%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 33 W
 clipsave
 0 0 M
@@ -4582,10 +4582,10 @@ clipsave
 -2362 0 D
 P
 PSL_clip N
-1069 -4 M
--1 4 D
--591 2362 D
--1 4 D S
+1054 -3 M
+-1 3 D
+-468 2362 D
+-1 3 D S
 PSL_cliprestore
 %%EndObject
 -5058 0 TM
@@ -4596,10 +4596,10 @@ O0
 % PostScript produced by:
 %@GMT: gmt pstext '-F+cRM+jTC+a90+tREDUCED MAJOR AXIS' -N -Dj15p -Xa4.2148i -Ya0i -R2.85/5.25/3.9/6.3 -JX-5c/5c
 %@PROJ: xy 2.85000000 5.25000000 3.90000000 6.30000000 5.250 2.850 3.900 6.300 +xy
-%%BeginObject PSL_Layer_53
+%%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 2612 1181 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V 90 R (REDUCED MAJOR AXIS) tc Z U

--- a/doc/examples/ex47/ex47.sh
+++ b/doc/examples/ex47/ex47.sh
@@ -32,7 +32,7 @@ gmt begin ex47
 	plot_one -Ey -N2 -c0,1 +tL@-2@-
 	plot_one -Ex -N2 -c1,1
 	plot_one -Eo -N2 -c2,1
-	plot_one -Er-N2 -c3,1
+	plot_one -Er -N2 -c3,1
 	#LMS regressions - also add labels on right side
 	plot_one -Ey -Nr -c0,2 +tLMS
 	gmt text -F+cRM+jTC+a90+t"Y ON X" -N -Dj15p

--- a/doc/examples/ex47/ex47.sh
+++ b/doc/examples/ex47/ex47.sh
@@ -25,22 +25,22 @@ gmt begin ex47
 	gmt subplot begin 4x3 -M0p -Fs5c -R2.85/5.25/3.9/6.3 -JX-5c/5c -SRl+l"Log light intensity" -SCb+l"Log temperature"+tc -Bwesn -Bafg
 	# L1 regressions
 	plot_one -Ey -N1 -c0,0 +tL@-1@-
-	plot_one -Er -N1 -c1,0
+	plot_one -Ex -N1 -c1,0
 	plot_one -Eo -N1 -c2,0
-	plot_one -Ex -N1 -c3,0
+	plot_one -Er -N1 -c3,0
 	#L2 regressions
-	plot_one -Er -N2 -c0,1 +tL@-2@-
-	plot_one -Eo -N2 -c1,1
-	plot_one -Ex -N2 -c2,1
-	plot_one -Ey -N2 -c3,1
+	plot_one -Ey -N2 -c0,1 +tL@-2@-
+	plot_one -Ex -N2 -c1,1
+	plot_one -Eo -N2 -c2,1
+	plot_one -Er-N2 -c3,1
 	#LMS regressions - also add labels on right side
-	plot_one -Er -Nr -c0,2 +tLMS
+	plot_one -Ey -Nr -c0,2 +tLMS
 	gmt text -F+cRM+jTC+a90+t"Y ON X" -N -Dj15p
-	plot_one -Eo -Nr -c1,2
+	plot_one -Ex -Nr -c1,2
 	gmt text -F+cRM+jTC+a90+t"X ON Y" -N -Dj15p
-	plot_one -Ex -Nr -c2,2
+	plot_one -Eo -Nr -c2,2
 	gmt text -F+cRM+jTC+a90+tORTHOGONAL -N -Dj15p
-	plot_one -Ey -Nr -c3,2
+	plot_one -Er -Nr -c3,2
 	gmt text -F+cRM+jTC+a90+t"REDUCED MAJOR AXIS" -N -Dj15p
 	gmt subplot end
 gmt end show

--- a/test/gmtregress/regress_2.ps
+++ b/test/gmtregress/regress_2.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.1.0_da1ff95_2020.05.26 [64-bit] Document from psxy
+%%Title: GMT v6.2.0_c981889_2020.07.10 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Tue May 26 19:43:00 2020
+%%CreationDate: Sat Jul 11 18:51:22 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -2249,10 +2249,10 @@ clipsave
 -2400 0 D
 P
 PSL_clip N
-1508 -4 M
--2 4 D
--1222 2400 D
--2 4 D S
+1598 2404 M
+-2 -4 D
+-1222 -2400 D
+-2 -4 D S
 PSL_cliprestore
 %%EndObject
 -3960 -1200 TM


### PR DESCRIPTION
**Description of proposed changes**

The underlying reason why these two failed had to do with a bug fix in gmtregress: Until recently, the slope for the RMA regression was always reported as positive, without checking the regression coefficient to see if the sign should be negative.  Both of these scripts involve a data set with a negative slope, so the RMA results were always wrong here.

Furthermore, ex47 derived from the earlier test (regress_2.sh) which was written in classic mode.  The translation to modern mode mixed up which rows we are doing, so the initial order (bottom to top in classic) was **r**|**o**|**x**|**y** while for the modern mode going down the rows it needs to be the reverse: **y**|**x**|**o**|**r**.  It was **r**|**o**|**x**|**y** except for the L1 column which was **y**|**r**|**o**|**x**.  So bug within a bug.