### PR TITLE
Add a weekly CI job checking if SCM has a new release

### DIFF
--- a/.github/workflows/scm-check.yml
+++ b/.github/workflows/scm-check.yml
@@ -1,0 +1,85 @@
+#
+# This workflow checks if Scientific Colour Maps has a new release.
+# If a new release if found, it will open a issue automatically.
+#
+# http://www.fabiocrameri.ch/colourmaps.php
+#
+name: SCM Check
+on:
+  schedule:
+    # weekly cron job
+    - cron: '0 0 * * 0'
+
+jobs:
+  scm-check:
+    name: SCM Check
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check the latest release
+        id: scm
+        run: |
+          scm_output=scm_version_string.txt
+          scm_version_in_gmt=6.0.4
+
+          # Crawl the version string for parsing
+          echo "Crawling the official site: http://www.fabiocrameri.ch/colourmaps.php"
+          curl -s http://www.fabiocrameri.ch/colourmaps.php | grep Version > ${scm_output}
+
+          # The number of lines in ${scm_output} must be 1
+          nlines=$(wc ${scm_output} | awk '{print $1}')
+          echo "Number of matched version strings: ${nlines}"
+          if [ "$nlines" != 1 ]; then
+            echo "${nlines} mactched version strings found. Will create a bug report!"
+            echo "::set-output name=error_code::1"
+          fi
+
+          # parse version string and date
+          scm_version=$(awk -F'Version <strong>' '{print $2}' scm_version_string.txt | awk -F'</strong>' '{print $1}')
+          scm_version_date=$(awk -F'(' '{print $2}' scm_version_string.txt | awk -F')' '{print $1}' | awk -F, '{print $1}')
+          echo "::set-output name=scm_version::${scm_version}"
+          echo "::set-output name=scm_version_date::${scm_version_date}"
+
+          echo "Find version ${scm_version} released on ${scm_version_date}"
+          if [ "${scm_version}" != ${scm_version_in_gmt} ]; then
+            echo "The latest SCM version ${scm_version} is different the one in GMT ${scm_version_in_gmt}!"
+            echo "Will create a update request!"
+            echo "::set-output name=error_code::2"
+          fi
+
+      - name: Create a bug report
+        if: ${{ steps.scm.outputs.error_code == 1 }}
+        uses: nashmaniac/create-issue-action@v1.1
+        with:
+          title: Error in checking ScientificColourMap release
+          token: ${{secrets.GITHUB_TOKEN}}
+          assignees: seisman
+          labels: bug
+          body: |
+            The ["SCM check"](.github/workflows/scm-check.yml) has an error in
+            parsing the version string of Scientific Colour Maps from
+            http://www.fabiocrameri.ch/colourmaps.php.
+
+            Please manually check it and fix the workflow.
+
+      - name: Create a update request
+        if: ${{ steps.scm.outputs.error_code == 2 }}
+        uses: nashmaniac/create-issue-action@v1.1
+        with:
+          title: New ScientificColourMaps release found
+          token: ${{secrets.GITHUB_TOKEN}}
+          body: |
+            New Scientific Colour Maps release found.
+
+            - website: http://www.fabiocrameri.ch/colourmaps.php
+            - version: ${{ steps.scm.outputs.scm_version }}
+            - date: ${{ steps.scm.outputs.scm_version_date }}
+
+            Todo list:
+
+            - [ ] Download the latest ScientificColourMaps release
+            - [ ] Run `admin/build_scientific_colors_cpt.sh` to update CPTs for the new release
+            - [ ] Copy the generated CPTs to `share/cpt` directory
+            - [ ] Update the version number in `admin/build_scientific_colors_cpt.sh`
+            - [ ] Update the version number in `.github/workflows/scm-check.yml`
+            - [ ] Commit all changes and open a PR


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a weekly CI job to check if ScientificColourMaps has a new release. If a new release is detected, it will automatically create a issue to remind us updating to the new release.

https://github.com/GenericMappingTools/gmt/issues/3653 is the automatic generated issue for testing purpose.

Fixes #3640.


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
