### PR TITLE
Failure of Cartesian clipping in plot -L+d

### DIFF
--- a/doc/examples/ex43/ex43.ps
+++ b/doc/examples/ex43/ex43.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 595 842
 %%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.2.0_2bc92d0_2020.07.12 [64-bit] Document from psbasemap
+%%Title: GMT v6.2.0_da5eaa4_2020.07.13 [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Jul 12 15:49:44 2020
+%%CreationDate: Mon Jul 13 19:26:27 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -1098,9 +1098,7 @@ clipsave
 P
 PSL_clip N
 {0.933 0.867 0.51 C} FS
-7087 7087 M
--7087 0 D
-0 -6651 D
+0 436 M
 354 355 D
 89 88 D
 88 89 D
@@ -1131,7 +1129,13 @@ PSL_clip N
 89 88 D
 177 178 D
 89 88 D
-621 623 D
+708 710 D
+89 88 D
+88 89 D
+178 177 D
+0 -441 D
+-7087 0 D
+P
 FO
 PSL_cliprestore
 %%EndObject
@@ -1184,25 +1188,7 @@ PSL_clip N
 [33 17] 0 B
 {1 0.973 0.863 C} FS
 O1
-6229 7087 M
--825 -916 D
--709 -780 D
--354 -388 D
--443 -478 D
--355 -377 D
--265 -277 D
--266 -271 D
--177 -177 D
--355 -346 D
--265 -252 D
--89 -84 D
--354 -329 D
--620 -565 D
--443 -399 D
--355 -317 D
--265 -238 D
--89 -79 D
-0 -756 D
+0 58 M
 266 294 D
 265 295 D
 709 780 D
@@ -1220,7 +1206,26 @@ O1
 974 870 D
 355 315 D
 443 393 D
-0 72 D
+0 1026 D
+-1152 -1281 D
+-531 -589 D
+-709 -780 D
+-354 -388 D
+-443 -478 D
+-355 -377 D
+-265 -277 D
+-266 -271 D
+-177 -177 D
+-355 -346 D
+-265 -252 D
+-89 -84 D
+-354 -329 D
+-620 -565 D
+-443 -399 D
+-355 -317 D
+-265 -238 D
+-89 -79 D
+P
 FO
 [] 0 B
 PSL_cliprestore

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -7657,6 +7657,21 @@ GMT_LOCAL bool gmtmap_accept_the_jump (struct GMT_CTRL *GMT, double lon1, double
 }
 
 /*! . */
+uint64_t gmt_cart_to_xy_line (struct GMT_CTRL *GMT, double *x, double *y, uint64_t n) {
+	/* Cartesian data has no wrapping but may go outside in a benign way  */
+	uint64_t k;
+
+	while (n > GMT->current.plot.n_alloc) gmt_get_plot_array (GMT);
+
+	for (k = 0; k < n; k++) {
+		gmt_geo_to_xy (GMT, x[k], y[k], &GMT->current.plot.x[k], &GMT->current.plot.y[k]);
+		GMT->current.plot.pen[k] = PSL_DRAW;
+	}
+	GMT->current.plot.pen[0] = PSL_MOVE;
+	return (n);
+}
+
+/*! . */
 uint64_t gmt_geo_to_xy_line (struct GMT_CTRL *GMT, double *lon, double *lat, uint64_t n) {
 	/* Traces the lon/lat array and returns x,y plus appropriate pen moves
 	 * Pen moves are caused by breakthroughs of the map boundary or when

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -527,6 +527,7 @@ EXTERN_MSC double gmt_azim_to_angle (struct GMT_CTRL *GMT, double lon, double la
 EXTERN_MSC uint64_t gmt_clip_to_map (struct GMT_CTRL *GMT, double *lon, double *lat, uint64_t np, double **x, double **y);
 EXTERN_MSC uint64_t gmt_compact_line (struct GMT_CTRL *GMT, double *x, double *y, uint64_t n, int pen_flag, int *pen);
 EXTERN_MSC uint64_t gmt_geo_to_xy_line (struct GMT_CTRL *GMT, double *lon, double *lat, uint64_t n);
+EXTERN_MSC uint64_t gmt_cart_to_xy_line (struct GMT_CTRL *GMT, double *x, double *y, uint64_t n);
 EXTERN_MSC uint64_t gmt_graticule_path (struct GMT_CTRL *GMT, double **x, double **y, int dir, bool check, double w, double e, double s, double n);
 EXTERN_MSC int gmt_grd_project (struct GMT_CTRL *GMT, struct GMT_GRID *I, struct GMT_GRID *O, bool inverse);
 EXTERN_MSC int gmt_img_project (struct GMT_CTRL *GMT, struct GMT_IMAGE *I, struct GMT_IMAGE *O, bool inverse);

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -2224,7 +2224,11 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 							end += 3;
 						}
 						/* Project and get ready */
-						if ((GMT->current.plot.n = gmt_geo_to_xy_line (GMT, GMT->hidden.mem_coord[GMT_X], GMT->hidden.mem_coord[GMT_Y], end)) == 0) continue;
+						if (gmt_M_is_geographic (GMT, GMT_IN)) {
+							if ((GMT->current.plot.n = gmt_geo_to_xy_line (GMT, GMT->hidden.mem_coord[GMT_X], GMT->hidden.mem_coord[GMT_Y], end)) == 0) continue;
+						}
+						else
+							GMT->current.plot.n = gmt_cart_to_xy_line (GMT,  GMT->hidden.mem_coord[GMT_X], GMT->hidden.mem_coord[GMT_Y], end);
 						if (Ctrl->L.outline) gmt_setpen (GMT, &Ctrl->L.pen);	/* Select separate pen for polygon outline */
 						if (Ctrl->G.active)	/* Specify the fill, possibly set outline */
 							gmt_setfill (GMT, &current_fill, Ctrl->L.outline);


### PR DESCRIPTION
**Description of proposed changes**

The confidence band around a line created via **-L+d i**s a Cartesian polygon, but it got the same treatment as any geographic polygon that possibly might wrap in longitude.  Especially if one side of the polygon was below or above the frame we ran into trouble.  This PR treats Cartesian polygons differently than geographic.  Below is the before (top) and after (below) showing the issue:

![o](https://user-images.githubusercontent.com/26473567/87388956-826dc700-c541-11ea-807b-262cc756f031.png)

![n](https://user-images.githubusercontent.com/26473567/87388972-8a2d6b80-c541-11ea-96b9-a160385f9e27.png)

The change also made ex43 fail due to tiny differences in the two polygons, so that PS is updated here as well.