### PR TITLE
Remove fink as it is no longer officially supported

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -73,7 +73,6 @@ assignees: ''
 
 - [ ] update [conda-forge feedstock](https://github.com/conda-forge/gmt-feedstock) (@leouieda, @seisman)
 - [ ] update [homebrew formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/gmt.rb) (@claudiodsf, @seisman)
-- [ ] update [fink package](https://github.com/fink/fink-distributions/blob/master/10.9-libcxx/stable/main/finkinfo/sci/) (@remkos)
 - [ ] update [macports ports](https://github.com/macports/macports-ports/blob/master/science/gmt5/Portfile) (@remkos, @seisman)
 - [ ] update [the RPM repository](https://copr.fedorainfracloud.org/coprs/genericmappingtools/gmt/) (@seisman)
 - [ ] update the [try-gmt](https://github.com/GenericMappingTools/try-gmt) Jupyter lab (@seisman)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,6 @@ for compiling GMT source package (either stable release or development version).
   * [Application Bundle](#application-bundle)
   * [Install via Homebrew](#install-via-homebrew)
   * [Install via Macports](#install-via-macports)
-  * [Install via fink](#install-via-fink)
 - [Linux](#linux)
   * [Fedora](#fedora)
   * [RHEL/CentOS](#rhelcentos)
@@ -108,29 +107,6 @@ For the legacy GMT 4 or GMT 5 versions, use:
 or:
 
     sudo port install gmt5
-
-### Install via fink
-
-Installation of GMT through [Fink](http://www.finkproject.org/) is quite easy.
-All required packages will also be installed.
-
-For the latest GMT 6 version, use:
-
-    sudo fink install gmt6
-
-You also need to install other GMT run-time dependencies separately:
-
-    sudo fink install graphicsmagick ffmpeg
-
-For legacy GMT 5 version, use:
-
-    sudo fink install gmt5
-
-For legacy GMT 4 version, use:
-
-    sudo fink install gmt
-
-These three GMT versions cannot live side by side.
 
 ## Linux
 


### PR DESCRIPTION
We stop support fink since
(a) nobody is using it that we know and
(b) nobody we know is willing to maintain the recipe.