### PR TITLE
Properly set parameters for cyclic CPT symbol that scale with bar size

### DIFF
--- a/doc/scripts/GMT_cyclic.ps
+++ b/doc/scripts/GMT_cyclic.ps
@@ -1,17 +1,16 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from psbasemap
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.2.0_b34bf88_2020.07.14 [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:52:26 2018
+%%CreationDate: Tue Jul 14 18:50:11 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
 %%Pages: 1
 %%EndComments
-
 %%BeginProlog
 250 dict begin
 /! {bind def} bind def
@@ -336,9 +335,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +591,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +634,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -648,37 +642,31 @@ end
 /PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
 /PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
 %%EndProlog
-
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
-PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
-
 %%Page: 1 1
-
 %%BeginPageSetup
 V 0.06 0.06 scale
 %%EndPageSetup
-
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
-/PSL_movie_completion {} def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
 FQ
 O0
 1200 1200 TM
-
 % PostScript produced by:
-%@GMT: gmt psbasemap -R0/20/0/1 -JM5i -BWse -Baf
-%@PROJ: merc 0.00000000 20.00000000 0.00000000 1.00000000 -1113194.908 1113194.908 -0.000 110579.965 +proj=merc +lon_0=10 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
-%GMTBoundingBox: 72 72 360 17.8804
+%@GMT: gmt psbasemap -R0/20/0/1 -JM5i -BWse -B
+%@PROJ: merc 0.00000000 20.00000000 0.00000000 1.00000000 -1113194.908 1113194.908 -0.000 110579.965 +proj=merc +lon_0=10 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 25 W
 8 W
 N 0 0 M 0 -83 D S
@@ -746,14 +734,13 @@ N -83 381 M 0 -464 D S
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt psscale -Ct.cpt -Baf -DJBC
-%@PROJ: merc 0.00000000 20.00000000 0.00000000 1.00000000 -1113194.908 1113194.908 -0.000 110579.965 +proj=merc +lon_0=10 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt psscale -C -B -DJBC -R0/20/0/1 -JM5i
+%@PROJ: merc 0.00000000 20.00000000 0.00000000 1.00000000 -1113194.908 1113194.908 -0.000 110579.965 +proj=merc +lon_0=10 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 600 -409 T
 25 W
 V N 0 0 T 4800 192 scale /DeviceRGB setcolorspace
@@ -805,8 +792,8 @@ N 1920 0 M 0 -83 D S
 N 2880 0 M 0 -83 D S
 N 3840 0 M 0 -83 D S
 N 4800 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sh mx
@@ -836,36 +823,40 @@ N 3360 0 M 0 -42 D S
 N 4320 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 {0 A} FS
-6 W
-V 4970 96 T
-N 0 0 78 50 181.352 arc S
+12 W
+/PSL_vecheadpen {0 W 0 A [] 0 B} def
+V 4983 96 T
+N 0 0 86 50 172.5 arc S
 O1
+PSL_vecheadpen
+0 W
 V
-N -9 12 78 -138.769 -188.832 arcn
-8 -26 D
-7 -15 78 -204.984 -161.892 arc
+N -14 18 86 -134.514210415 -204.142186961 arcn
+7 -42 D
+9 -23 86 -220.38254784 -166.700983493 arc
 P clip fs N U
 U 
-V 4970 96 T
-N 0 0 78 230 361.352 arc S
+V 4983 96 T
+12 W
+N 0 0 86 230 352.5 arc S
+PSL_vecheadpen
+0 W
 V
-N 9 -12 78 41.2306 -8.83179 arcn
--8 26 D
--7 15 78 -24.9835 18.1079 arc
+N 14 -18 86 45.4857895853 -24.1421869612 arcn
+-7 42 D
+-9 23 86 -40.38254784 13.2990165068 arc
 P clip fs N U
 U 
 0 setlinecap
 -600 409 T
 %%EndObject
-
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage
-
 %%Trailer
-
 end
 %%EOF

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -614,7 +614,7 @@ GMT_LOCAL void psscale_fix_format (char *unit, char *format) {
 
 GMT_LOCAL void psscale_plot_cycle (struct GMT_CTRL *GMT, double x, double y, double width) {
 	/* Use the color of MAP_FRAME_PEN to draw the symbol stem and head fill.
-	 * Use the symbol width to estimate pen width as 0.5p times (width/0.1) [in inches]  */
+	 * Use the symbol width to estimate pen width as 0.5p times (width/0.05) [in inches]  */
 	double vdim[PSL_MAX_DIMS], s = width / 0.05, p_width, circum;
 	struct GMT_SYMBOL S;
 	struct GMT_FILL head;

--- a/test/psbasemap/radians.ps
+++ b/test/psbasemap/radians.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from psbasemap
+%%Title: GMT v6.2.0_b34bf88_2020.07.14 [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:52:18 2018
+%%CreationDate: Tue Jul 14 18:50:19 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -336,9 +336,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +592,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +635,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -651,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -662,8 +658,9 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
-/PSL_movie_completion {} def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
@@ -678,8 +675,9 @@ O0
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 8400 M 0 -8400 D S
 /PSL_A0_y 83 def
@@ -691,8 +689,8 @@ N 0 3360 M -83 0 D S
 N 0 5040 M -83 0 D S
 N 0 6720 M -83 0 D S
 N 0 8400 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sw mx
@@ -734,8 +732,8 @@ N 0 3360 M 83 0 D S
 N 0 5040 M 83 0 D S
 N 0 6720 M 83 0 D S
 N 0 8400 M 83 0 D S
-/PSL_AH0 0
 /MM {exch M} def
+/PSL_AH0 0
 (0) sw mx
 (20) sw mx
 (40) sw mx
@@ -775,8 +773,8 @@ N 3600 0 M 0 -83 D S
 N 4800 0 M 0 -83 D S
 N 6000 0 M 0 -83 D S
 N 7200 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 V MU 0 0 M (”12) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
 V MU 0 0 M (”8) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
 V MU 0 0 M (”4) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
@@ -831,8 +829,8 @@ N 3600 0 M 0 83 D S
 N 4800 0 M 0 83 D S
 N 6000 0 M 0 83 D S
 N 7200 0 M 0 83 D S
-/PSL_AH0 0
 /MM {M} def
+/PSL_AH0 0
 200 F0
 V MU 0 0 M (”12) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
 V MU 0 0 M (”8) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
@@ -890,8 +888,15 @@ O0
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 33 W
+clipsave
+0 0 M
+7200 0 D
+0 8400 D
+-7200 0 D
+P
+PSL_clip N
 0 420 M
 36 8 D
 36 22 D
@@ -1049,6 +1054,7 @@ O0
 36 -22 D
 36 -8 D
 S
+PSL_cliprestore
 %%EndObject
 0 A
 FQ
@@ -1061,7 +1067,7 @@ O0
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 6360 1800 T
 25 W
 240 0 T
@@ -1096,8 +1102,8 @@ N 0 4800 M 0 -4800 D S
 N 0 0 M -83 0 D S
 N 0 2400 M -83 0 D S
 N 0 4800 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V MU 0 0 M (”) FP 200 F12 (p) FP pathbbox N pop exch pop add U mx
@@ -1121,22 +1127,28 @@ V MU 0 0 M (+) FP 200 F12 (p) FP pathbbox N 4 1 roll exch pop add exch U -2 div 
 240 0 T
 90 R
 {0 A} FS
-8 W
-V 4991 120 T
-N 0 0 97 50 174.19 arc S
+15 W
+/PSL_vecheadpen {0 W 0 A [] 0 B} def
+V 5008 120 T
+N 0 0 108 50 172.5 arc S
 O1
+PSL_vecheadpen
+0 W
 V
-N -12 16 97 -138.022 -201.913 arcn
-5 -43 D
-9 -20 97 -215.33 -162.732 arc
+N -18 23 108 -134.514210415 -204.142186961 arcn
+9 -53 D
+12 -29 108 -220.38254784 -166.700983493 arc
 P clip fs N U
 U 
-V 4991 120 T
-N 0 0 97 230 354.19 arc S
+V 5008 120 T
+15 W
+N 0 0 108 230 352.5 arc S
+PSL_vecheadpen
+0 W
 V
-N 12 -16 97 41.9777 -21.913 arcn
--5 43 D
--9 20 97 -35.3303 17.2679 arc
+N 18 -23 108 45.4857895853 -24.1421869612 arcn
+-9 53 D
+-12 29 108 -40.38254784 13.2990165068 arc
 P clip fs N U
 U 
 -90 R
@@ -1155,7 +1167,7 @@ O0
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 600 -840 T
 25 W
 V N 0 0 T 6000 240 scale /DeviceRGB setcolorspace
@@ -1188,8 +1200,8 @@ N 1500 0 M 0 -83 D S
 N 3000 0 M 0 -83 D S
 N 4500 0 M 0 -83 D S
 N 6000 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V MU 0 0 M (”) FP 200 F12 (p) FP pathbbox N 4 1 roll pop pop pop U mx
@@ -1224,22 +1236,28 @@ V MU 0 0 M (+) FP 200 F12 (p) FP pathbbox N pop exch pop add U -2 div 0 G
 200 F12 (p) Z
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 {0 A} FS
-8 W
-V 6191 120 T
-N 0 0 97 50 174.19 arc S
+15 W
+/PSL_vecheadpen {0 W 0 A [] 0 B} def
+V 6208 120 T
+N 0 0 108 50 172.5 arc S
 O1
+PSL_vecheadpen
+0 W
 V
-N -12 16 97 -138.022 -201.913 arcn
-5 -43 D
-9 -20 97 -215.33 -162.732 arc
+N -18 23 108 -134.514210415 -204.142186961 arcn
+9 -53 D
+12 -29 108 -220.38254784 -166.700983493 arc
 P clip fs N U
 U 
-V 6191 120 T
-N 0 0 97 230 354.19 arc S
+V 6208 120 T
+15 W
+N 0 0 108 230 352.5 arc S
+PSL_vecheadpen
+0 W
 V
-N 12 -16 97 41.9777 -21.913 arcn
--5 43 D
--9 20 97 -35.3303 17.2679 arc
+N 18 -23 108 45.4857895853 -24.1421869612 arcn
+-9 53 D
+-12 29 108 -40.38254784 13.2990165068 arc
 P clip fs N U
 U 
 0 setlinecap
@@ -1247,7 +1265,8 @@ U
 %%EndObject
 
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U

--- a/test/psscale/cyclecpt.ps
+++ b/test/psscale/cyclecpt.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.1.0_07d3b13-dirty_2020.03.19 [64-bit] Document from psscale
+%%Title: GMT v6.2.0_b34bf88_2020.07.14 [64-bit] Document from psscale
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 19 12:12:10 2020
+%%CreationDate: Tue Jul 14 18:50:19 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -671,11 +671,11 @@ O0
 % PostScript produced by:
 %@GMT: gmt psscale -P -K -Ctemp_cpt.cpt -Dx3c/5c+w10c/0.618c+n -By+lm '-Bxa+lCyclic CPT with NaN and unit' -X1i
 %@PROJ: xy 0.00000000 180.00000000 0.00000000 0.24330709 0.000 180.000 0.000 0.243 +xy
-%GMTBoundingBox: 72 72 283.465 17.5181
+%GMTBoundingBox: 72 72 283.46472 17.518104
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1417 2362 T
 25 W
 292 0 T
@@ -730,8 +730,8 @@ N 0 0 M 83 0 D S
 N 0 1312 M 83 0 D S
 N 0 2625 M 83 0 D S
 N 0 3937 M 83 0 D S
-/PSL_AH0 0
 /MM {exch M} def
+/PSL_AH0 0
 (0) sw mx
 (50) sw mx
 (100) sw mx
@@ -756,28 +756,28 @@ V 90 R (Cyclic CPT with NaN and unit) bc Z U
 V -90 R (m) bc Z U
 {0 A} FS
 O0
-9 W
+18 W
 /PSL_vecheadpen {0 W 0 A [] 0 B} def
-V 2362 146 T
-N 0 0 118 50 166.436 arc S
+V 2383 146 T
+N 0 0 131 50 172.5 arc S
 O1
 PSL_vecheadpen
 0 W
 V
-N -16 22 118 -136.827 -216.585 arcn
--4 -65 D
-11 -26 118 -226.067 -163.905 arc
+N -22 28 131 -134.514210415 -204.142186961 arcn
+11 -65 D
+14 -35 131 -220.38254784 -166.700983493 arc
 P clip fs N U
 U 
-V 2362 146 T
-9 W
-N 0 0 118 230 346.436 arc S
+V 2383 146 T
+18 W
+N 0 0 131 230 352.5 arc S
 PSL_vecheadpen
 0 W
 V
-N 16 -22 118 43.1731 -36.5853 arcn
-4 65 D
--11 26 118 -46.0667 16.0947 arc
+N 22 -28 131 45.4857895853 -24.1421869612 arcn
+-11 65 D
+-14 35 131 -40.38254784 13.2990165068 arc
 P clip fs N U
 U 
 -90 R
@@ -796,7 +796,7 @@ O0
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 1417 2362 T
 25 W
 292 0 T
@@ -851,8 +851,8 @@ N 0 0 M 83 0 D S
 N 0 1312 M 83 0 D S
 N 0 2625 M 83 0 D S
 N 0 3937 M 83 0 D S
-/PSL_AH0 0
 /MM {exch M} def
+/PSL_AH0 0
 (0) sw mx
 (50) sw mx
 (100) sw mx
@@ -875,28 +875,28 @@ V 90 R (Cyclic CPT with NaN) bc Z U
 90 R
 {0 A} FS
 O0
-9 W
+18 W
 /PSL_vecheadpen {0 W 0 A [] 0 B} def
-V 4939 146 T
-N 0 0 118 50 166.436 arc S
+V 4960 146 T
+N 0 0 131 50 172.5 arc S
 O1
 PSL_vecheadpen
 0 W
 V
-N -16 22 118 -136.827 -216.585 arcn
--4 -65 D
-11 -26 118 -226.067 -163.905 arc
+N -22 28 131 -134.514210415 -204.142186961 arcn
+11 -65 D
+14 -35 131 -220.38254784 -166.700983493 arc
 P clip fs N U
 U 
-V 4939 146 T
-9 W
-N 0 0 118 230 346.436 arc S
+V 4960 146 T
+18 W
+N 0 0 131 230 352.5 arc S
 PSL_vecheadpen
 0 W
 V
-N 16 -22 118 43.1731 -36.5853 arcn
-4 65 D
--11 26 118 -46.0667 16.0947 arc
+N 22 -28 131 45.4857895853 -24.1421869612 arcn
+-11 65 D
+-14 35 131 -40.38254784 13.2990165068 arc
 P clip fs N U
 U 
 -90 R
@@ -915,7 +915,7 @@ O0
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 2362 2362 T
 25 W
 V N 0 0 T 4724 292 scale /DeviceRGB setcolorspace
@@ -967,8 +967,8 @@ N 0 0 M 0 -83 D S
 N 1312 0 M 0 -83 D S
 N 2625 0 M 0 -83 D S
 N 3937 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (0) sh mx
 (50) sh mx
 (100) sh mx
@@ -990,28 +990,28 @@ def
 (m) ml Z
 {0 A} FS
 O0
-9 W
+18 W
 /PSL_vecheadpen {0 W 0 A [] 0 B} def
-V 2362 146 T
-N 0 0 118 50 166.436 arc S
+V 2383 146 T
+N 0 0 131 50 172.5 arc S
 O1
 PSL_vecheadpen
 0 W
 V
-N -16 22 118 -136.827 -216.585 arcn
--4 -65 D
-11 -26 118 -226.067 -163.905 arc
+N -22 28 131 -134.514210415 -204.142186961 arcn
+11 -65 D
+14 -35 131 -220.38254784 -166.700983493 arc
 P clip fs N U
 U 
-V 2362 146 T
-9 W
-N 0 0 118 230 346.436 arc S
+V 2383 146 T
+18 W
+N 0 0 131 230 352.5 arc S
 PSL_vecheadpen
 0 W
 V
-N 16 -22 118 43.1731 -36.5853 arcn
-4 65 D
--11 26 118 -46.0667 16.0947 arc
+N 22 -28 131 45.4857895853 -24.1421869612 arcn
+-11 65 D
+-14 35 131 -40.38254784 13.2990165068 arc
 P clip fs N U
 U 
 0 setlinecap
@@ -1028,7 +1028,7 @@ O0
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 2362 2362 T
 25 W
 V N 0 0 T 4724 292 scale /DeviceRGB setcolorspace
@@ -1080,8 +1080,8 @@ N 0 0 M 0 -83 D S
 N 1312 0 M 0 -83 D S
 N 2625 0 M 0 -83 D S
 N 3937 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (0) sh mx
 (50) sh mx
 (100) sh mx
@@ -1101,28 +1101,28 @@ def
 (Cyclic CPT with NaN) tc Z
 {0 A} FS
 O0
-9 W
+18 W
 /PSL_vecheadpen {0 W 0 A [] 0 B} def
-V 4939 146 T
-N 0 0 118 50 166.436 arc S
+V 4960 146 T
+N 0 0 131 50 172.5 arc S
 O1
 PSL_vecheadpen
 0 W
 V
-N -16 22 118 -136.827 -216.585 arcn
--4 -65 D
-11 -26 118 -226.067 -163.905 arc
+N -22 28 131 -134.514210415 -204.142186961 arcn
+11 -65 D
+14 -35 131 -220.38254784 -166.700983493 arc
 P clip fs N U
 U 
-V 4939 146 T
-9 W
-N 0 0 118 230 346.436 arc S
+V 4960 146 T
+18 W
+N 0 0 131 230 352.5 arc S
 PSL_vecheadpen
 0 W
 V
-N 16 -22 118 43.1731 -36.5853 arcn
-4 65 D
--11 26 118 -46.0667 16.0947 arc
+N 22 -28 131 45.4857895853 -24.1421869612 arcn
+-11 65 D
+-14 35 131 -40.38254784 13.2990165068 arc
 P clip fs N U
 U 
 0 setlinecap


### PR DESCRIPTION
The derived parameters of the CPT cyclic symbol did not scale correctly with bar thickness and only worked reasonably well for moderately thin bars such as the test examples in **psscale**.  Select a wider bar and we either got ugly symbols or even a crash.  Also, the symbol was always black and invisible if we wanted to plot white on black.  This PR accomplishes both of these:

1. We now use the color of **MAP_FRAME_PEN** to determine the color to use.
2. We define the length and width of the circular arrow head as fixed fractions of the circumference (and hence the radius or bar thickness).
3. We adjust position so that the gap between the bar and the symbol is controlled by **MAP_ANNOT_OFFSET**.
4. We increased the reference pen thickness to make the symbol clearer.

Three _PostScript_ originals needed to be updated as well.  Below we show a thin and a thick color bar with dark and light settings.

![dark](https://user-images.githubusercontent.com/26473567/87505296-3a63a880-c604-11ea-8864-26498e8e9b42.png)

Here  is a narrower scale on white background:

![white](https://user-images.githubusercontent.com/26473567/87505322-4c454b80-c604-11ea-8618-c0c20de85dfb.png)
