### PR TITLE
Wait with deleting font files until gmt end has completed

### DIFF
--- a/doc/examples/ex31/ex31.bat
+++ b/doc/examples/ex31/ex31.bat
@@ -54,5 +54,6 @@ gmt begin ex31
 	REM plot legend
 	gmt legend -DjTR+o0.1c+w8.0c+l1.2 -C0.3c/0.4c -F+p+gwhite legend.txt
 
-	del PSL_custom_fonts.txt legend.txt ex31CropNoLogo.eps europe-capitals-ru.csv
+	del legend.txt ex31CropNoLogo.eps europe-capitals-ru.csv
 gmt end show
+del PSL_custom_fonts.txt

--- a/doc/examples/ex31/ex31.sh
+++ b/doc/examples/ex31/ex31.sh
@@ -65,5 +65,6 @@ gmt begin ex31
 	# plot legend
 	gmt legend -DjTR+o0.1c+w8.0c+l1.2 -C0.3c/0.4c -F+p+gwhite legend.txt
 
-	rm -f PSL_custom_fonts.txt legend.txt ex31CropNoLogo.eps europe-capitals-ru.csv
+	rm -f legend.txt ex31CropNoLogo.eps europe-capitals-ru.csv
 gmt end show
+rm -f PSL_custom_fonts.txt


### PR DESCRIPTION
We got lots of error messages like this in ex31.sh

`gmt [WARNING]: Representation of font type not recognized. Using default.`

from **gmt end** because we deleted the PSL_custom_fonts.txt before the session ended.

This PR moves those delete statements outside the session.  This explains those errors form you too @KristofKoch.

