### PR TITLE
Incomplete fix of grdsample required more work

### DIFF
--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -225,8 +225,8 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 	 * If no -R is given then wesn_i == wesn_o and (presumably) there is only differences in inc and registration.
 	 * If there is a -R, then we adjust wesn_i and wesn_o thus:
 	 *   wesn_i: We move the boundaries inwards by the grid's own increments until the bounds are equal to or inside the -R.
-	 *			 Then, if we are inside and we are able to move one step back we do so to ensure we cover the output range.
-	 *   wesn_o: We move the boundaries inwards by the -Iinc spacing until the bounds are equal to or inside the input grid.
+	 *			 Then, if we are inside and we are able to move one step outwards we do so to ensure we cover the output range.
+	 *   wesn_o: We move the boundaries inwards by the -Iinc spacing as long as we are outside the input grid.
 	 */
 
 	gmt_M_memcpy (wesn_i, Gin->header->wesn, 4, double);	/* wesn_i is eventually the subset we will read from this grid */


### PR DESCRIPTION
As documented on the [forum](https://forum.generic-mapping-tools.org/t/grdsample-problem-in-gmt-6-0/552/5), **grdsample** still failed to set the proper read area for input grids.  This time I hopefully paid more attention to details.  The two regions (the _wesn_i_ subset needed to be read and the desired new output region _wesn_o_) are now carefully compared to the input grid to ensure that we include all the nodes needed to do a full interpolation.  The user's case passes for me, several other cases I checked (including 360-regions and smaller ones with shifts of longitudes) passes plus the regular test suite.
