### PR TITLE
Let grdcontour -N support the oneliner syntax

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -811,6 +811,12 @@ GMT_LOCAL void gmtapi_check_for_modern_oneliner (struct GMTAPI_CTRL *API, const 
 	if ((opt = GMT_Find_Option (API, 'V', head)))	/* Remove -V here so that we can run gmt plot -? -Vd and still get modern mode usage plus debug info */
 		GMT_Delete_Option (API, opt, &head);
 
+	if (!strcmp (module, "grdcontour") && GMT_Find_Option (API, 'N', head)) {	/* Special case of two module calls cannot be oneliner here */
+		if (GMT_Destroy_Options (API, &head))	/* Done with these here */
+			GMT_Report (API, GMT_MSG_WARNING, "Unable to free options in gmtapi_check_for_modern_oneliner?\n");
+		return;
+	}
+
 	API->GMT->current.setting.use_modern_name = gmtlib_is_modern_name (API, module);
 
 	if (API->GMT->current.setting.use_modern_name) {	/* Make some checks needed to handle synopsis and usage messages in classic vs modern mode */


### PR DESCRIPTION
THe problem is that **grdcontour** **-N** calls **grdview** and then itself via _GMT_Call_Module_.  However, we have already flagged it as a oneliner but now there are several calls.  The solution was to not trigger the oneliner check for **grdcontour** **-N** and then detect it instead in the special **-N** branch in **grdcontour**.  We parse the options and discover if the command was a oneliner or not, and if it is we craft the **gmt begin** call needed and add the **gmt end** show call at the end.  Seems to work.
Addresses aspects of #3701 but not the external part.