### PR TITLE
Failed to requiest more memory in stair-step function

### DIFF
--- a/src/gmt_vector.c
+++ b/src/gmt_vector.c
@@ -316,6 +316,7 @@ GMT_LOCAL uint64_t gmtvector_fix_up_path_cartonly (struct GMT_CTRL *GMT, double 
 	GMT->hidden.mem_coord[GMT_X][0] = x[0];	GMT->hidden.mem_coord[GMT_Y][0] = y[0];
 
 	for (i = k = 1; i < n; i++) {	/* For remaining points we must insert an intermediate node */
+		gmt_prep_tmp_arrays (GMT, GMT_NOTSET, k+1, 2);	/* Init or reallocate two tmp vectors */
 		if (mode == GMT_STAIRS_X) {	/* First follow x, then y */
 			GMT->hidden.mem_coord[GMT_X][k] = x[i];
 			GMT->hidden.mem_coord[GMT_Y][k] = y[i-1];
@@ -326,6 +327,7 @@ GMT_LOCAL uint64_t gmtvector_fix_up_path_cartonly (struct GMT_CTRL *GMT, double 
 		}
 		k++;
 		/* Then add original point */
+		gmt_prep_tmp_arrays (GMT, GMT_NOTSET, k+1, 2);	/* Init or reallocate two tmp vectors */
 		GMT->hidden.mem_coord[GMT_X][k] = x[i];	GMT->hidden.mem_coord[GMT_Y][k] = y[i];
 		k++;
 	}


### PR DESCRIPTION
The function _gmtvector_fix_up_path_cartonly_ builds a stair-step curve from an array by adding the extra horizontal or vertical steps, thus lengthening the array.  Yet, there was no check to allocate more memory once we passed the initial **GMT_INITIAL_MEM_ROW_ALLOC** points.  So it took a large file to exceed that and then crash, reveling the bug.

