### PR TITLE
grdseamount must write grids even if no change for a time-step

### DIFF
--- a/doc/rst/source/supplements/potential/grdseamount.rst
+++ b/doc/rst/source/supplements/potential/grdseamount.rst
@@ -150,9 +150,8 @@ Optional Arguments
     give start time *t0*. Default *unit* is years; append **k** for kyr and **M** for Myr.
     For a logarithmic time scale, append **+l** and specify *n* steps instead of *dt*.
     Alternatively, give a file with the desired times in the first column (these times
-    may have individual units appended, otherwise we assume year).  Note that the grid
-    for *t0* (if a range is given) is not written as it is zero and marks the start of
-    the building history.
+    may have individual units appended, otherwise we assume year).  Note that a grid
+    will be written for all time-steps even if there is no loads or no changes.
 
 .. _-Z:
 

--- a/doc/rst/source/supplements/potential/grdseamount.rst
+++ b/doc/rst/source/supplements/potential/grdseamount.rst
@@ -151,7 +151,7 @@ Optional Arguments
     For a logarithmic time scale, append **+l** and specify *n* steps instead of *dt*.
     Alternatively, give a file with the desired times in the first column (these times
     may have individual units appended, otherwise we assume year).  Note that a grid
-    will be written for all time-steps even if there is no loads or no changes.
+    will be written for all time-steps even if there are no loads or no changes.
 
 .. _-Z:
 

--- a/src/potential/grdseamount.c
+++ b/src/potential/grdseamount.c
@@ -861,9 +861,8 @@ EXTERN_MSC int GMT_grdseamount (void *V_API, int mode, void *args) {
 			prev_user_time = this_user_time;	/* Make this the previous time */
 		}
 		if (empty) {
-			GMT_Report (API, GMT_MSG_INFORMATION, "No contribution made for time %g %s\n",
+			GMT_Report (API, GMT_MSG_WARNING, "No contribution made for time %g %s\n",
 			            Ctrl->T.time[t].value * Ctrl->T.time[t].scale, gmt_modeltime_unit (Ctrl->T.time[t].u));
-			continue;
 		}
 
 		/* Time to write the grid */


### PR DESCRIPTION
The **-T** range may include times when there is no seamounts being grown or there is no change. Instead of warning of no input for a time, it actually skipped writing an empty (incremental) or unchanged (cumulative) grid, which breaks workflows that makes movies or computes flexure.  Now we just warn, and clarify in man page.
