### PR TITLE
Fix gdal_info to gdal_translate in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ GMT may be linked with these libraries (* means optional):
 [Linear Algebra Package (LAPACK*)](http://www.netlib.org/lapack/),
 [Basic Linear Algebra Subprograms (BLAS*)](http://www.netlib.org/blas/), and
 [ZLIB*](https://www.zlib.net). GMT may call these executables:
-GDAL (ogr2ogr, gdal_info), [Ghostscript](https://www.ghostscript.com),
+GDAL (ogr2ogr, gdal_translate), [Ghostscript](https://www.ghostscript.com),
 [FFmpeg](https://www.ffmpeg.org),
 [xdg-open](https://www.freedesktop.org/wiki/Software/xdg-utils/), and
 [GraphicsMagick](http://www.graphicsmagick.org).


### PR DESCRIPTION
GMT doesn't call `gdal_info`, but calls `gdal_translate`.