### PR TITLE
Only set geographic column formatting if in geographic mode

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -731,7 +731,7 @@ EXTERN_MSC int GMT_project (void *V_API, int mode, void *args) {
 		gmt_set_column (GMT, GMT_OUT, GMT_Y, (Ctrl->N.active) ? GMT_IS_FLOAT : GMT_IS_LAT);
 		gmt_set_column (GMT, GMT_OUT, GMT_Z, GMT_IS_FLOAT);
 	}
-	else {	/* Decode and set the various output column types */
+	else if (!Ctrl->N.active) {	/* Decode and set the various output column types in the geographic case */
 		for (col = 0; col < P.n_outputs; col++) {
 			switch (P.output_choice[col]) {
 				case 0: case 4: gmt_set_column (GMT, GMT_OUT, (unsigned int)col, GMT_IS_LON);		break;
@@ -1042,11 +1042,13 @@ EXTERN_MSC int GMT_project (void *V_API, int mode, void *args) {
 						P.want_z_output = z_set_auto = false;
 						for (col = 3; col < P.n_outputs; col++) P.output_choice[col-1] = P.output_choice[col];	/* Shuffle pqrs to the left */
 						P.n_outputs--;
-						for (col = 0; col < P.n_outputs; col++) {
-							switch (P.output_choice[col]) {
-								case 0: case 4: gmt_set_column (GMT, GMT_OUT, (unsigned int)col, GMT_IS_LON);	break;
-								case 1: case 5: gmt_set_column (GMT, GMT_OUT, (unsigned int)col, GMT_IS_LAT);	break;
-								default: gmt_set_column (GMT, GMT_OUT, (unsigned int)col, GMT_IS_FLOAT);	break;
+						if (!Ctrl->N.active) {
+							for (col = 0; col < P.n_outputs; col++) {
+								switch (P.output_choice[col]) {
+									case 0: case 4: gmt_set_column (GMT, GMT_OUT, (unsigned int)col, GMT_IS_LON);	break;
+									case 1: case 5: gmt_set_column (GMT, GMT_OUT, (unsigned int)col, GMT_IS_LAT);	break;
+									default: gmt_set_column (GMT, GMT_OUT, (unsigned int)col, GMT_IS_FLOAT);	break;
+								}
 							}
 						}
 					}
@@ -1060,7 +1062,7 @@ EXTERN_MSC int GMT_project (void *V_API, int mode, void *args) {
 					gmt_M_free (GMT, p_data);
 					Return (GMT_RUNTIME_ERROR);
 				}
-				else {	/* Must update col types since # of z values will need to be considered */
+				else if (!Ctrl->N.active) {	/* Must update col types since # of z values will need to be considered */
 					unsigned int k, kk;
 					P.n_z = n_cols - 2;
 					for (col = kk = 0; col < P.n_outputs; col++, kk++) {


### PR DESCRIPTION
See issue #3695 for details.  The problem was that **-N** was not consulted when setting the output column types.  In Cartesian mode they are all regular floats, while in geographic mode we need to set special formatting for longitude and latitude.  This PR turns off these column operations when **-N** is set.  Closes #3695.
