### PR TITLE
Simplify contour arg parsing

### DIFF
--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -244,6 +244,9 @@ enum GMT_enum_script {GMT_BASH_MODE = 0,	/* Write Bash script */
 /* Allowable refpoint codes */
 #define GMT_REFPOINT_CODES "gjJnx"
 
+/* Modifiers for contour -A option */
+#define GMT_CONTSPEC_MODS "acdefghijklLnNoprstuvwxX="
+
 /*! Codes for grdtrack */
 enum GMT_enum_tracklayout {
 	GMT_LEFT_RIGHT = 1,

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -370,6 +370,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 EXTERN_MSC unsigned int gmt_contour_first_pos (struct GMT_CTRL *GMT, char *arg);
 EXTERN_MSC unsigned int gmt_contour_A_arg_parsing (struct GMT_CTRL *GMT, char *arg, struct CONTOUR_ARGS *A);
 EXTERN_MSC unsigned int gmt_contour_C_arg_parsing (struct GMT_CTRL *GMT, char *arg, struct CONTOUR_ARGS *A);
+EXTERN_MSC unsigned int gmt_contour_T_arg_parsing (struct GMT_CTRL *GMT, char *arg, struct CONTOUR_CLOSED *A);
 EXTERN_MSC unsigned int gmt_char_count (char *txt, char c);
 EXTERN_MSC void gmt_free_list (struct GMT_CTRL *GMT, char **list, uint64_t n);
 EXTERN_MSC uint64_t gmt_read_list (struct GMT_CTRL *GMT, char *file, char ***list);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -367,6 +367,9 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC unsigned int gmt_contour_first_pos (struct GMT_CTRL *GMT, char *arg);
+EXTERN_MSC unsigned int gmt_contour_A_arg_parsing (struct GMT_CTRL *GMT, char *arg, struct CONTOUR_ARGS *A);
+EXTERN_MSC unsigned int gmt_contour_C_arg_parsing (struct GMT_CTRL *GMT, char *arg, struct CONTOUR_ARGS *A);
 EXTERN_MSC unsigned int gmt_char_count (char *txt, char c);
 EXTERN_MSC void gmt_free_list (struct GMT_CTRL *GMT, char **list, uint64_t n);
 EXTERN_MSC uint64_t gmt_read_list (struct GMT_CTRL *GMT, char *file, char ***list);

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -36,6 +36,16 @@
  * GMT TYPE DEFINITIONS
  *--------------------------------------------------------------------*/
 
+/*! Definition of CONTOUR_ARGS used by grdcontour and pscontour */
+struct CONTOUR_ARGS {
+	bool cpt;		/* true of we were given a CPT file */
+	bool check;		/* true if in modern mode and no CPT was given */
+	unsigned int mode;	/* Module specific action, usually to indicate no annotations desired */
+	char *file;		/* File with cpt or contours, or list of contours */
+	double interval;	/* Constant interval */
+	double single_cont;	/* Single specified contour */
+};
+
 /*! Definition of GMT_MATH_MACRO used by grdmath and gmtmath */
 struct GMT_MATH_MACRO {
 	unsigned int n_arg;	/* How many commands this macro represents */

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -46,6 +46,15 @@ struct CONTOUR_ARGS {
 	double single_cont;	/* Single specified contour */
 };
 
+/*! Definition of CONTOUR_CLOSED used by grdcontour and pscontour */
+struct CONTOUR_CLOSED {
+	bool label;
+	bool all;
+	bool low, high;	/* true to tick low and high locals */
+	double dim[2];	/* spacing, length */
+	char *txt[2];	/* Low and high label [-+] */
+};
+
 /*! Definition of GMT_MATH_MACRO used by grdmath and gmtmath */
 struct GMT_MATH_MACRO {
 	unsigned int n_arg;	/* How many commands this macro represents */

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -44,17 +44,11 @@ struct GRDCONTOUR_CTRL {
 	struct GMT_CONTOUR contour;
 	struct GRDCONTOUR_A {	/* -A[n|[+]<int>][labelinfo] */
 		bool active;
-		char *file;
-		unsigned int mode;	/* 1 turns off all labels */
-		double interval;
-		double single_cont;
+		struct CONTOUR_ARGS info;
 	} A;
 	struct GRDCONTOUR_C {	/* -C<cont_int> */
 		bool active;
-		bool cpt;
-		char *file;
-		double interval;
-		double single_cont;
+		struct CONTOUR_ARGS info;
 	} C;
 	struct GRDCONTOUR_D {	/* -D<dumpfile> */
 		bool active;
@@ -146,8 +140,8 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 	/* Initialize values whose defaults are not 0/false/NULL */
 
 	gmt_contlabel_init (GMT, &C->contour, 1);
-	C->A.single_cont = GMT->session.d_NaN;
-	C->C.single_cont = GMT->session.d_NaN;
+	C->A.info.single_cont = GMT->session.d_NaN;
+	C->C.info.single_cont = GMT->session.d_NaN;
 	C->L.low = -DBL_MAX;
 	C->L.high = DBL_MAX;
 	C->T.dim[GMT_X] = TICKED_SPACING * GMT->session.u2u[GMT_PT][GMT_INCH];	/* 14p */
@@ -162,8 +156,8 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 static void Free_Ctrl (struct GMT_CTRL *GMT, struct GRDCONTOUR_CTRL *C) {	/* Deallocate control structure */
 	if (!C) return;
 	gmt_M_str_free (C->In.file);
-	gmt_M_str_free (C->A.file);
-	gmt_M_str_free (C->C.file);
+	gmt_M_str_free (C->A.info.file);
+	gmt_M_str_free (C->C.info.file);
 	gmt_M_str_free (C->D.file);
 	gmt_M_str_free (C->T.txt[0]);
 	gmt_M_str_free (C->T.txt[1]);
@@ -346,8 +340,6 @@ static int parse (struct GMT_CTRL *GMT, struct GRDCONTOUR_CTRL *Ctrl, struct GMT
 
 	unsigned int n_errors = 0, n_files = 0, id, reset = 0;
 	int j, k, n;
-	size_t L;
-	bool c_check = false;
 	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, string[GMT_LEN256] = {""}, *c = NULL;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
@@ -367,29 +359,16 @@ static int parse (struct GMT_CTRL *GMT, struct GRDCONTOUR_CTRL *Ctrl, struct GMT
 
 			case 'A':	/* Annotation control */
 				Ctrl->A.active = true;
-				if (gmt_contlabel_specs (GMT, opt->arg, &Ctrl->contour)) {
-					GMT_Report (API, GMT_MSG_ERROR, "Option -A: Expected\n\t-A[n|[+]<aint>][+a<angle>|n|p[u|d]][+c<dx>[/<dy>]][+d][+e][+f<font>][+g<fill>][+j<just>][+l<label>][+n|N<dx>[/<dy>]][+o][+p<pen>][+r<min_rc>][+t[<file>]][+u<unit>][+v][+w<width>][+=<prefix>]\n");
-					n_errors ++;
+				k = gmt_contour_first_pos (GMT, opt->arg);	/* Do deal with backwards compatibility */
+				if ((c = gmt_first_modifier (GMT, &opt->arg[k], GMT_CONTSPEC_MODS))) {	/* Process any modifiers */
+					if (gmt_contlabel_specs (GMT, c, &Ctrl->contour)) {
+						GMT_Report (API, GMT_MSG_ERROR, "Option -A: Expected\n\t-A[n|[+]<aint>][+a<angle>|n|p[u|d]][+c<dx>[/<dy>]][+d][+e][+f<font>][+g<fill>][+j<just>][+l<label>][+n|N<dx>[/<dy>]][+o][+p<pen>][+r<min_rc>][+t[<file>]][+u<unit>][+v][+w<width>][+=<prefix>]\n");
+						n_errors ++;
+					}
+					c[0] = '\0';	/* Chop off modifiers since parsed by gmt_contlabel_specs */
 				}
-				c = NULL;
-				if (opt->arg[0] != '+') c = strchr (opt->arg, '+');	/* Find start of modifiers */
-				if (c) c[0] = '\0';	/* Chop off modifiers since parsed by gmt_contlabel_specs */
-				if (opt->arg[0] == 'n' && opt->arg[1] == '\0')	/* -An turns off all labels */
-					Ctrl->A.mode = 1;	/* Turn off all labels */
-				else if (opt->arg[0] == '+' && (isdigit(opt->arg[1]) || strchr ("-+.", opt->arg[1]))) {
-					Ctrl->A.single_cont = atof (&opt->arg[1]);
-					Ctrl->contour.annot = true;
-				}
-				else if (strchr (opt->arg, ',')) {
-					gmt_M_str_free (Ctrl->A.file);
-					Ctrl->A.file = strdup (opt->arg);
-				}
-				else if (opt->arg[0] == '-' && opt->arg[1] == '\0')	/* -A- is deprecated */
-					Ctrl->A.mode = 1;	/* Turn off all labels */
-				else {
-					Ctrl->A.interval = atof (opt->arg);
-					Ctrl->contour.annot = true;
-				}
+				n_errors += gmt_contour_A_arg_parsing (GMT, opt->arg, &Ctrl->A.info);
+				if (Ctrl->A.info.mode == 0) Ctrl->contour.annot = true;
 				if (c) c[0] = '+';	/* Restore modifiers */
 				break;
 			case 'C':	/* Contour interval/cpt */
@@ -399,51 +378,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDCONTOUR_CTRL *Ctrl, struct GMT
 					break;
 				}
 				Ctrl->C.active = true;
-				L = strlen (opt->arg);
-				if (L >= 4) Ctrl->C.cpt = (!strncmp (&opt->arg[L-4], ".cpt", 4U)) ? true : false;
-				if (GMT->current.setting.run_mode == GMT_MODERN && gmt_M_no_cpt_given (opt->arg))
-					c_check = true;
-				else if (gmt_M_file_is_memory (opt->arg)) {	/* Passed a memory reference from a module */
-					enum GMT_enum_family family = GMT_Inquire_VirtualFile (API, opt->arg);
-					Ctrl->C.interval = 1.0;
-					Ctrl->C.cpt = (family == GMT_IS_PALETTE);
-					gmt_M_str_free (Ctrl->C.file);
-					Ctrl->C.file = strdup (opt->arg);
-				}
-				else if (Ctrl->C.cpt) {	/* Passed a cpt file, it must exist */
-					if (!gmt_file_is_cache (API, opt->arg) && gmt_access (GMT, opt->arg, R_OK)) {
-						GMT_Report (API, GMT_MSG_ERROR, "Option -C: CPT file %s not found\n", opt->arg);
-						n_errors++;
-					}
-					else {	/* Found it or a cache file */
-						Ctrl->C.interval = 1.0;
-						gmt_M_str_free (Ctrl->C.file);
-						Ctrl->C.file = strdup (opt->arg);
-					}
-				}
-				else if (gmt_file_is_cache (API, opt->arg) || !gmt_access (GMT, opt->arg, R_OK)) {	/* Gave a readable table file */
-					Ctrl->C.interval = 1.0;
-					gmt_M_str_free (Ctrl->C.file);
-					Ctrl->C.file = strdup (opt->arg);
-				}
-				else if (strchr (opt->arg, ',')) {	/* Gave a comma-separated list of contours */
-					Ctrl->C.interval = 1.0;
-					gmt_M_str_free (Ctrl->C.file);
-					Ctrl->C.file = strdup (opt->arg);
-				}
-				else if (opt->arg[0] == '+' && (isdigit(opt->arg[1]) || strchr ("-+.", opt->arg[1])))
-					Ctrl->C.single_cont = atof (&opt->arg[1]);
-				else if (opt->arg[0] != '-') {
-					Ctrl->C.interval = atof (opt->arg);
-					if (gmt_M_is_zero (Ctrl->C.interval)) {
-						GMT_Report (API, GMT_MSG_ERROR, "Option -C: Contour interval cannot be zero\n");
-						n_errors++;
-					}
-				}
-				else {
-					GMT_Report (API, GMT_MSG_ERROR, "Option -C: Contour interval cannot be negative (%s)\n", opt->arg);
-					n_errors++;
-				}
+				n_errors += gmt_contour_C_arg_parsing (GMT, opt->arg, &Ctrl->C.info);
 				break;
 			case 'D':	/* Dump file name */
 				Ctrl->D.active = true;
@@ -629,17 +564,17 @@ static int parse (struct GMT_CTRL *GMT, struct GRDCONTOUR_CTRL *Ctrl, struct GMT
 		}
 	}
 
-	if (c_check && gmt_consider_current_cpt (API, &Ctrl->C.active, &(Ctrl->C.file)))
-		Ctrl->C.cpt = true;
+	if (Ctrl->C.info.check && gmt_consider_current_cpt (API, &Ctrl->C.active, &(Ctrl->C.info.file)))
+		Ctrl->C.info.cpt = true;
 
-	if (Ctrl->A.interval > 0.0 && (!Ctrl->C.file && Ctrl->C.interval == 0.0)) Ctrl->C.interval = Ctrl->A.interval;
+	if (Ctrl->A.info.interval > 0.0 && (!Ctrl->C.info.file && Ctrl->C.info.interval == 0.0)) Ctrl->C.info.interval = Ctrl->A.info.interval;
 
 	n_errors += gmt_M_check_condition (GMT, n_files != 1, "Must specify a single grid file\n");
 	n_errors += gmt_M_check_condition (GMT, !GMT->common.J.active && !Ctrl->D.active,
 	                                 "Must specify a map projection with the -J option\n");
 #if 0
-	n_errors += gmt_M_check_condition (GMT, !Ctrl->C.file && Ctrl->C.interval <= 0.0 &&
-			gmt_M_is_dnan (Ctrl->C.single_cont) && gmt_M_is_dnan (Ctrl->A.single_cont),
+	n_errors += gmt_M_check_condition (GMT, !Ctrl->C.info.file && Ctrl->C.info.interval <= 0.0 &&
+			gmt_M_is_dnan (Ctrl->C.single_cont) && gmt_M_is_dnan (Ctrl->A.info.single_cont),
 	                     "Option -C: Must specify contour interval, file name with levels, or CPT\n");
 #endif
 	n_errors += gmt_M_check_condition (GMT, Ctrl->L.low > Ctrl->L.high, "Option -L: lower limit > upper!\n");
@@ -647,7 +582,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDCONTOUR_CTRL *Ctrl, struct GMT
 	n_errors += gmt_M_check_condition (GMT, Ctrl->contour.label_dist_spacing <= 0.0 || Ctrl->contour.half_width <= 0,
 	                                 "Option -G: Correct syntax:\n\t-G<annot_dist>/<npoints>, both values must be > 0\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Z.scale == 0.0, "Option -Z: factor must be nonzero\n");
-	n_errors += gmt_M_check_condition (GMT, Ctrl->W.cptmode && !Ctrl->C.cpt,
+	n_errors += gmt_M_check_condition (GMT, Ctrl->W.cptmode && !Ctrl->C.info.cpt,
 	                                 "Option -W: Modifier +c only valid if -C sets a CPT\n");
 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
@@ -1244,8 +1179,8 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 		Return (GMT_NOERROR);
 	}
 
-	if (Ctrl->C.cpt) {	/* Presumably got a CPT */
-		if ((P = GMT_Read_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, Ctrl->C.file, NULL)) == NULL) {
+	if (Ctrl->C.info.cpt) {	/* Presumably got a CPT */
+		if ((P = GMT_Read_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, Ctrl->C.info.file, NULL)) == NULL) {
 			Return (API->error);
 		}
 		if (P->categorical)
@@ -1276,7 +1211,7 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 		tmp = GMT->current.setting.time_system.epoch_t0; GMT->current.setting.time_system.epoch_t0 = 0.0;	/* Save */
 		t_epoch_unit = gmt_rdc2dt (GMT, GMT->current.setting.time_system.rata_die, tmp * GMT_DAY2SEC_F);	/* Epoch in user units */
 		GMT->current.setting.time_system.epoch_t0 = tmp;	/* Restore */
-		t_epoch_unit_even = floor (t_epoch_unit / Ctrl->A.interval) * Ctrl->A.interval;	/* Offset to grid values in user units reuired to align contours on even epoch */
+		t_epoch_unit_even = floor (t_epoch_unit / Ctrl->A.info.interval) * Ctrl->A.info.interval;	/* Offset to grid values in user units reuired to align contours on even epoch */
 		t_offset = t_epoch_unit - t_epoch_unit_even;	/* Offset to grid values in user units to align on even epoch */
 		use_t_offset = !doubleAlmostEqualZero (t_epoch_unit, t_epoch_unit_even);
 		if (use_t_offset) {	/* Must temporarily add t_offset to grid, quietly */
@@ -1312,7 +1247,7 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 		}
 		Return (GMT_NOERROR);
 	}
-	if (!Ctrl->C.active && (!Ctrl->A.active || Ctrl->A.interval == 0.0)) {	/* Want automatic annotations */
+	if (!Ctrl->C.active && (!Ctrl->A.active || Ctrl->A.info.interval == 0.0)) {	/* Want automatic annotations */
 		double x, range = G->header->z_max - G->header->z_min;
 		int nx;
 		x = pow (10, floor (log10 (range)) - 1.0);
@@ -1321,31 +1256,31 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 			x *= 5;
 		else if (nx > 20)
 			x *= 2;
-		Ctrl->C.interval = x;
-		Ctrl->A.interval = 2.0 * x;
+		Ctrl->C.info.interval = x;
+		Ctrl->A.info.interval = 2.0 * x;
 		Ctrl->C.active  = Ctrl->A.active = Ctrl->contour.annot = true;
-		GMT_Report (API, GMT_MSG_INFORMATION, "Auto-determined contour interval = %g and annotation interval = %g\n", Ctrl->C.interval, Ctrl->A.interval);
+		GMT_Report (API, GMT_MSG_INFORMATION, "Auto-determined contour interval = %g and annotation interval = %g\n", Ctrl->C.info.interval, Ctrl->A.info.interval);
 	}
 
 	if (!strcmp (Ctrl->contour.unit, "z")) strncpy (Ctrl->contour.unit, G->header->z_units, GMT_LEN64-1);
-	if (Ctrl->A.interval == 0.0) Ctrl->A.interval = Ctrl->C.interval;
+	if (Ctrl->A.info.interval == 0.0) Ctrl->A.info.interval = Ctrl->C.info.interval;
 
 	if (Ctrl->contour.annot) {	/* Want annotated contours */
 		/* Determine the first annotated contour level */
-		aval = floor (G->header->z_min / Ctrl->A.interval) * Ctrl->A.interval;
-		if (aval < G->header->z_min) aval += Ctrl->A.interval;
+		aval = floor (G->header->z_min / Ctrl->A.info.interval) * Ctrl->A.info.interval;
+		if (aval < G->header->z_min) aval += Ctrl->A.info.interval;
 	}
 	else	/* No annotations, set aval outside range */
 		aval = G->header->z_max + 1.0;
 
-	if (Ctrl->C.cpt) {	/* Got a CPT */
+	if (Ctrl->C.info.cpt) {	/* Got a CPT */
 		/* Set up which contours to draw based on the CPT slices and their attributes */
 		n_contours = P->n_colors + 1;	/* Since n_colors refer to slices */
 		cont = gmt_M_memory (GMT, NULL, n_contours, struct GMT_CONTOUR_INFO);
 		for (i = c = 0; i < P->n_colors; i++) {
 			if (P->data[i].skip) continue;
 			cont[c].val = P->data[i].z_low;
-			if (Ctrl->A.mode)
+			if (Ctrl->A.info.mode)
 				cont[c].type = 'C';
 			else if (P->data[i].annot)
 				cont[c].type = 'A';
@@ -1356,7 +1291,7 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 			c++;
 		}
 		cont[c].val = P->data[P->n_colors-1].z_high;
-		if (Ctrl->A.mode)
+		if (Ctrl->A.info.mode)
 			cont[c].type = 'C';
 		else if (P->data[P->n_colors-1].annot & 2)
 			cont[c].type = 'A';
@@ -1366,15 +1301,15 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 		cont[c].do_tick = (char)Ctrl->T.active;
 		n_contours = c + 1;
 	}
-	else if ((Ctrl->A.file && strchr (Ctrl->A.file, ',')) || (Ctrl->C.file && strchr (Ctrl->C.file, ','))) {	/* Got a comma-separated list of contours */
+	else if ((Ctrl->A.info.file && strchr (Ctrl->A.info.file, ',')) || (Ctrl->C.info.file && strchr (Ctrl->C.info.file, ','))) {	/* Got a comma-separated list of contours */
 		uint64_t na = 0, nc = 0;
 		double *za = NULL, *zc = NULL;
-		if (Ctrl->A.file && strchr (Ctrl->A.file, ',') && (za = gmt_list_to_array (GMT, Ctrl->A.file, gmt_M_type (GMT, GMT_IN, GMT_Z), &na)) == NULL) {
-			GMT_Report (API, GMT_MSG_ERROR, "Failure while parsing annotated contours from list %s\n", Ctrl->A.file);
+		if (Ctrl->A.info.file && strchr (Ctrl->A.info.file, ',') && (za = gmt_list_to_array (GMT, Ctrl->A.info.file, gmt_M_type (GMT, GMT_IN, GMT_Z), &na)) == NULL) {
+			GMT_Report (API, GMT_MSG_ERROR, "Failure while parsing annotated contours from list %s\n", Ctrl->A.info.file);
 			Return (GMT_RUNTIME_ERROR);
 		}
-		if (Ctrl->C.file && strchr (Ctrl->C.file, ',') && (zc = gmt_list_to_array (GMT, Ctrl->C.file, gmt_M_type (GMT, GMT_IN, GMT_Z), &nc)) == NULL) {
-			GMT_Report (API, GMT_MSG_ERROR, "Failure while parsing regular contours from list %s\n", Ctrl->C.file);
+		if (Ctrl->C.info.file && strchr (Ctrl->C.info.file, ',') && (zc = gmt_list_to_array (GMT, Ctrl->C.info.file, gmt_M_type (GMT, GMT_IN, GMT_Z), &nc)) == NULL) {
+			GMT_Report (API, GMT_MSG_ERROR, "Failure while parsing regular contours from list %s\n", Ctrl->C.info.file);
 			if (za) gmt_M_free (GMT, za);
 			Return (GMT_RUNTIME_ERROR);
 		}
@@ -1395,43 +1330,43 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 		if (za) gmt_M_free (GMT, za);
 		if (zc) gmt_M_free (GMT, zc);
 	}
-	else if (Ctrl->C.file) {	/* Read contour info from file with cval [angle] C|A [pen]] records */
-		if ((cont = gmt_get_contours_from_table (GMT, Ctrl->C.file, Ctrl->T.active, &Ctrl->contour.angle_type, &n_contours)) == NULL) Return (GMT_RUNTIME_ERROR);
+	else if (Ctrl->C.info.file) {	/* Read contour info from file with cval [angle] C|A [pen]] records */
+		if ((cont = gmt_get_contours_from_table (GMT, Ctrl->C.info.file, Ctrl->T.active, &Ctrl->contour.angle_type, &n_contours)) == NULL) Return (GMT_RUNTIME_ERROR);
 	}
-	else if (!gmt_M_is_dnan (Ctrl->C.single_cont) || !gmt_M_is_dnan (Ctrl->A.single_cont)) {	/* Plot one or two contours only  */
+	else if (!gmt_M_is_dnan (Ctrl->C.info.single_cont) || !gmt_M_is_dnan (Ctrl->A.info.single_cont)) {	/* Plot one or two contours only  */
 		n_contours = 0;
 		cont = gmt_M_memory (GMT, cont, 2, struct GMT_CONTOUR_INFO);
-		if (!gmt_M_is_dnan (Ctrl->C.single_cont)) {
+		if (!gmt_M_is_dnan (Ctrl->C.info.single_cont)) {
 			cont[n_contours].type = 'C';
-			cont[n_contours++].val = Ctrl->C.single_cont;
+			cont[n_contours++].val = Ctrl->C.info.single_cont;
 		}
-		if (!gmt_M_is_dnan (Ctrl->A.single_cont)) {
+		if (!gmt_M_is_dnan (Ctrl->A.info.single_cont)) {
 			cont[n_contours].type = 'A';
-			cont[n_contours].val = Ctrl->A.single_cont;
+			cont[n_contours].val = Ctrl->A.info.single_cont;
 			cont[n_contours].do_tick = Ctrl->T.active ? 1 : 0;
 			cont[n_contours].angle = (Ctrl->contour.angle_type == 2) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
 			n_contours++;
 		}
 	}
-	else {	/* Set up contour intervals automatically from Ctrl->C.interval and Ctrl->A.interval */
-		double min, max, noise = GMT_CONV4_LIMIT * Ctrl->C.interval;
-		min = floor (G->header->z_min / Ctrl->C.interval) * Ctrl->C.interval;
-		if (!GMT->current.map.z_periodic && min < G->header->z_min) min += Ctrl->C.interval;
-		max = ceil (G->header->z_max / Ctrl->C.interval) * Ctrl->C.interval;
-		if (max > G->header->z_max) max -= Ctrl->C.interval;
-		if (Ctrl->A.interval > Ctrl->C.interval && fabs ((Ctrl->A.interval/Ctrl->C.interval) - irint (Ctrl->A.interval/Ctrl->C.interval)) > GMT_CONV4_LIMIT)
+	else {	/* Set up contour intervals automatically from Ctrl->C.info.interval and Ctrl->A.info.interval */
+		double min, max, noise = GMT_CONV4_LIMIT * Ctrl->C.info.interval;
+		min = floor (G->header->z_min / Ctrl->C.info.interval) * Ctrl->C.info.interval;
+		if (!GMT->current.map.z_periodic && min < G->header->z_min) min += Ctrl->C.info.interval;
+		max = ceil (G->header->z_max / Ctrl->C.info.interval) * Ctrl->C.info.interval;
+		if (max > G->header->z_max) max -= Ctrl->C.info.interval;
+		if (Ctrl->A.info.interval > Ctrl->C.info.interval && fabs ((Ctrl->A.info.interval/Ctrl->C.info.interval) - irint (Ctrl->A.info.interval/Ctrl->C.info.interval)) > GMT_CONV4_LIMIT)
 			GMT_Report (API, GMT_MSG_WARNING, "Annotation interval is not a multiple of contour interval - no annotated contours will be drawn.\n");
-		else if (Ctrl->contour.annot && Ctrl->A.interval < Ctrl->C.interval)
+		else if (Ctrl->contour.annot && Ctrl->A.info.interval < Ctrl->C.info.interval)
 			GMT_Report (API, GMT_MSG_WARNING, "Annotation interval < contour interval - some/all annotated contours will not be drawn.\n");
-		for (c = irint (min/Ctrl->C.interval), n_contours = 0; c <= irint (max/Ctrl->C.interval); c++, n_contours++) {
+		for (c = irint (min/Ctrl->C.info.interval), n_contours = 0; c <= irint (max/Ctrl->C.info.interval); c++, n_contours++) {
 			if (n_contours == n_alloc) {
 				n_alloc += 32;
 				cont = gmt_M_memory (GMT, cont, n_alloc, struct GMT_CONTOUR_INFO);
 			}
 			gmt_M_memset (&cont[n_contours], 1, struct GMT_CONTOUR_INFO);	/* Cause the pen structure needs to be empty */
-			cont[n_contours].val = c * Ctrl->C.interval;
-			if (Ctrl->contour.annot && (cont[n_contours].val - aval) > noise) aval += Ctrl->A.interval;
-			if (Ctrl->A.mode)	/* No labels */
+			cont[n_contours].val = c * Ctrl->C.info.interval;
+			if (Ctrl->contour.annot && (cont[n_contours].val - aval) > noise) aval += Ctrl->A.info.interval;
+			if (Ctrl->A.info.mode)	/* No labels */
 				cont[n_contours].type = 'C';
 			else
 				cont[n_contours].type = (fabs (cont[n_contours].val - aval) < noise) ? 'A' : 'C';
@@ -1459,7 +1394,7 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 		if (GMT_Destroy_Data (API, &G) != GMT_NOERROR) {
 			Return (API->error);
 		}
-		if (Ctrl->C.cpt && GMT_Destroy_Data (API, &P) != GMT_NOERROR) {
+		if (Ctrl->C.info.cpt && GMT_Destroy_Data (API, &P) != GMT_NOERROR) {
 			Return (API->error);
 		}
 		Return (GMT_NOERROR);
@@ -1468,10 +1403,10 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 	/* OK, now we know we have contouring to do */
 
 	z_range = G->header->z_max - G->header->z_min;
-	if (Ctrl->C.interval == 0.0)
+	if (Ctrl->C.info.interval == 0.0)
 		small = z_range * 1.0e-6;	/* Our gmt_grdfloat noise threshold */
 	else
-		small = MIN (Ctrl->C.interval, z_range) * 1.0e-6;	/* Our gmt_grdfloat noise threshold */
+		small = MIN (Ctrl->C.info.interval, z_range) * 1.0e-6;	/* Our gmt_grdfloat noise threshold */
 	cont = gmt_M_memory (GMT, cont, n_contours, struct GMT_CONTOUR_INFO);
 
 	if (Ctrl->L.mode) {	/* Set negative or positive range only */

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -362,7 +362,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDCONTOUR_CTRL *Ctrl, struct GMT
 				k = gmt_contour_first_pos (GMT, opt->arg);	/* Do deal with backwards compatibility */
 				if ((c = gmt_first_modifier (GMT, &opt->arg[k], GMT_CONTSPEC_MODS))) {	/* Process any modifiers */
 					if (gmt_contlabel_specs (GMT, c, &Ctrl->contour)) {
-						GMT_Report (API, GMT_MSG_ERROR, "Option -A: Expected\n\t-A[n|[+]<aint>][+a<angle>|n|p[u|d]][+c<dx>[/<dy>]][+d][+e][+f<font>][+g<fill>][+j<just>][+l<label>][+n|N<dx>[/<dy>]][+o][+p<pen>][+r<min_rc>][+t[<file>]][+u<unit>][+v][+w<width>][+=<prefix>]\n");
+						GMT_Report (API, GMT_MSG_ERROR, "Option -A: Expected\n\t-A[n|<contours>][+a<angle>|n|p[u|d]][+c<dx>[/<dy>]][+d][+e][+f<font>][+g<fill>][+i][+j<just>][+l<label>][+n|N<dx>[/<dy>]][+o][+p<pen>][+r<min_rc>][+t[<file>]][+u<unit>][+v][+w<width>][+=<prefix>]\n");
 						n_errors ++;
 					}
 					c[0] = '\0';	/* Chop off modifiers since parsed by gmt_contlabel_specs */

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -534,7 +534,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONTOUR_CTRL *Ctrl, struct GMT_
 				k = gmt_contour_first_pos (GMT, opt->arg);	/* Do deal with backwards compatibility */
 				if ((c = gmt_first_modifier (GMT, &opt->arg[k], GMT_CONTSPEC_MODS))) {	/* Process any modifiers */
 					if (gmt_contlabel_specs (GMT, c, &Ctrl->contour)) {
-						GMT_Report (API, GMT_MSG_ERROR, "Option -A: Expected\n\t-A[n|[+]<aint>][+a<angle>|n|p[u|d]][+c<dx>[/<dy>]][+d][+e][+f<font>][+g<fill>][+j<just>][+l<label>][+n|N<dx>[/<dy>]][+o][+p<pen>][+r<min_rc>][+t[<file>]][+u<unit>][+v][+w<width>][+=<prefix>]\n");
+						GMT_Report (API, GMT_MSG_ERROR, "Option -A: Expected\n\t-A[n|<contours>][+a<angle>|n|p[u|d]][+c<dx>[/<dy>]][+d][+e][+f<font>][+g<fill>][+i][+j<just>][+l<label>][+n|N<dx>[/<dy>]][+o][+p<pen>][+r<min_rc>][+t[<file>]][+u<unit>][+v][+w<width>][+=<prefix>]\n");
 						n_errors ++;
 					}
 					c[0] = '\0';	/* Chop off modifiers since parsed by gmt_contlabel_specs */

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -71,11 +71,7 @@ struct PSCONTOUR_CTRL {
 	} S;
 	struct PSCONTOUR_T {	/* -T[h|l][+a][+d<gap>[c|i|p][/<length>[c|i|p]]][+lLH|"low,high"] */
 		bool active;
-		bool label;
-		bool all;
-		bool low, high;	/* true to tick low and high locals */
-		double dim[2];	/* spacing, length */
-		char *txt[2];	/* Low and high label */
+		struct CONTOUR_CLOSED info;
 	} T;
 	struct PSCONTOUR_Q {	/* -Q[<cut>][+z] */
 		bool active;
@@ -145,8 +141,8 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 	C->A.info.single_cont = GMT->session.d_NaN;
 	C->C.info.single_cont = GMT->session.d_NaN;
 	C->L.pen = GMT->current.setting.map_default_pen;
-	C->T.dim[GMT_X] = TICKED_SPACING * GMT->session.u2u[GMT_PT][GMT_INCH];	/* 14p */
-	C->T.dim[GMT_Y] = TICKED_LENGTH  * GMT->session.u2u[GMT_PT][GMT_INCH];	/* 3p */
+	C->T.info.dim[GMT_X] = TICKED_SPACING * GMT->session.u2u[GMT_PT][GMT_INCH];	/* 14p */
+	C->T.info.dim[GMT_Y] = TICKED_LENGTH  * GMT->session.u2u[GMT_PT][GMT_INCH];	/* 3p */
 	C->W.pen[PEN_CONT] = C->W.pen[PEN_ANNOT] = GMT->current.setting.map_default_pen;
 	C->W.pen[PEN_ANNOT].width *= 3.0;
 
@@ -158,8 +154,8 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct PSCONTOUR_CTRL *C) {	/* Deal
 	gmt_M_str_free (C->C.info.file);
 	gmt_M_str_free (C->D.file);
 	gmt_M_str_free (C->E.file);
-	gmt_M_str_free (C->T.txt[0]);
-	gmt_M_str_free (C->T.txt[1]);
+	gmt_M_str_free (C->T.info.txt[0]);
+	gmt_M_str_free (C->T.info.txt[1]);
 	gmt_M_free (GMT, C);
 }
 
@@ -400,6 +396,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Option (API, "<");
 	GMT_Message (API, GMT_TIME_NONE, "\t-A Annotation label information. [Default is no annotated contours].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Give annotation interval or comma-separated list of contours.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     (for single contour append comma to be seen as list).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Alternatively, give -An to disable all contour annotations\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     implied by the information provided in -C.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   <labelinfo> controls the specifics of the labels.  Choose from:\n");
@@ -469,42 +466,6 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
-GMT_LOCAL unsigned int pscontour_old_T_parser (struct GMT_CTRL *GMT, char *arg, struct PSCONTOUR_CTRL *Ctrl) {
-	/* The backwards compatible parser for old-style -T option: */
-	/* -T[+|-][<gap>[c|i|p]/<length>[c|i|p]][:LH] (also handle -Th|l<...> )*/
-	int n, j;
-	unsigned int n_errors = 0;
-	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""};
-	if (strchr (arg, '/')) {	/* Gave gap/length */
-		n = sscanf (arg, "%[^/]/%[^:]", txt_a, txt_b);
-		if (n == 2) {
-			Ctrl->T.dim[GMT_X] = gmt_M_to_inch (GMT, txt_a);
-			Ctrl->T.dim[GMT_Y] = gmt_M_to_inch (GMT, txt_b);
-		}
-	}
-	for (j = 0; arg[j] && arg[j] != ':'; j++);
-	if (arg[j] == ':') Ctrl->T.label = true, j++;
-	if (arg[j]) {	/* Override high/low markers */
-		if (strlen (&(arg[j])) == 2) {	/* Standard :LH syntax */
-			txt_a[0] = arg[j++];	txt_a[1] = '\0';
-			txt_b[0] = arg[j++];	txt_b[1] = '\0';
-		}
-		else if (strchr (&(arg[j]), ',')) {	/* Found :<labellow>,<labelhigh> */
-			(void)sscanf (&(arg[j]), "%[^,],%s", txt_a, txt_b);
-		}
-		else {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -T: Give low and high labels either as +lLH or +l<low>,<high>.\n");
-			Ctrl->T.label = false;
-			n_errors++;
-		}
-		if (Ctrl->T.label) {	/* Replace defaults */
-			Ctrl->T.txt[0] = strdup (txt_a);
-			Ctrl->T.txt[1] = strdup (txt_b);
-		}
-	}
-	return (n_errors);
-}
-
 static int parse (struct GMT_CTRL *GMT, struct PSCONTOUR_CTRL *Ctrl, struct GMT_OPTION *options) {
 	/* This parses the options provided to pscontour and sets parameters in Ctrl.
 	 * Note Ctrl has already been initialized and non-zero default values set.
@@ -515,7 +476,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONTOUR_CTRL *Ctrl, struct GMT_
 
 	unsigned int n_errors = 0, id, reset = 0;
 	int k, j, n;
-	char txt_a[GMT_LEN64] = {""}, txt_b[GMT_LEN64] = {""}, string[GMT_LEN64] = {""}, *c = NULL;
+	char txt_a[GMT_LEN256] = {""}, *c = NULL;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
@@ -622,52 +583,8 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONTOUR_CTRL *Ctrl, struct GMT_
 					Ctrl->E.active = true;
 					break;
 				}
-				Ctrl->T.active = Ctrl->T.high = Ctrl->T.low = true;	/* Default if just -T is given */
-				if (opt->arg[0]) {	/* But here we gave more options */
-					if (opt->arg[0] == 'h'  || (opt->arg[0] == '+' && !strchr ("adl", opt->arg[1])))	/* Only tick local highs */
-						Ctrl->T.low = false, j = 1;
-					else if (opt->arg[0] == 'l' || opt->arg[0] == '-')		/* Only tick local lows */
-						Ctrl->T.high = false, j = 1;
-					else
-						j = 0;
-					if (strstr (opt->arg, "+a") || strstr (opt->arg, "+d") || strstr (opt->arg, "+l")) {	/* New parser */
-						if (gmt_get_modifier (opt->arg, 'a', string))
-							Ctrl->T.all = true;
-						if (gmt_get_modifier (opt->arg, 'd', string))
-							if ((n = gmt_get_pair (GMT, string, GMT_PAIR_DIM_NODUP, Ctrl->T.dim)) < 1) n_errors++;
-						if (gmt_get_modifier (opt->arg, 'l', string)) {	/* Want to label innermost contours */
-							Ctrl->T.label = true;
-							if (string[0] == 0)
-								;	/* Use default labels */
-							else if (strlen (string) == 2) {	/* Standard +lLH syntax */
-								char A[2] = {0, 0};
-								A[0] = string[0];	Ctrl->T.txt[0] = strdup (A);
-								A[0] = string[1];	Ctrl->T.txt[1] = strdup (A);
-							}
-							else if (strchr (string, ',') && (n = sscanf (string, "%[^,],%s", txt_a, txt_b)) == 2) {	/* Found :<labellow>,<labelhigh> */
-								Ctrl->T.txt[0] = strdup (txt_a);
-								Ctrl->T.txt[1] = strdup (txt_b);
-							}
-							else {
-								GMT_Report (API, GMT_MSG_ERROR, "Option -T: Give low and high labels either as +lLH or +l<low>,<high>.\n");
-								n_errors++;
-							}
-						}
-					}
-					else {
-						if (gmt_M_compat_check (API->GMT, 4))  {
-							GMT_Report (API, GMT_MSG_COMPAT, "Your format for -T is deprecated (but accepted); use -T[h|l][+d<tick_gap>[%s][/<tick_length>[%s]]][+lLH] instead\n",
-								GMT_DIM_UNITS_DISPLAY, GMT_DIM_UNITS_DISPLAY);
-							n_errors += pscontour_old_T_parser (GMT, &opt->arg[j], Ctrl);
-						}
-						else {
-							GMT_Report (API, GMT_MSG_COMPAT, "Option -T: Your format for -T is deprecated; use -T[h|l][+d<tick_gap>[%s][/<tick_length>[%s]]][+lLH] instead\n",
-								GMT_DIM_UNITS_DISPLAY, GMT_DIM_UNITS_DISPLAY);
-							n_errors++;
-						}
-					}
-					n_errors += gmt_M_check_condition (GMT, Ctrl->T.dim[GMT_X] <= 0.0 || Ctrl->T.dim[GMT_Y] == 0.0, "Option -T: Expected\n\t-T[h|l][+d<tick_gap>[%s][/<tick_length>[%s]]][+lLH], <tick_gap> must be > 0\n", GMT_DIM_UNITS_DISPLAY, GMT_DIM_UNITS_DISPLAY);
-				}
+				Ctrl->T.active = true;
+				n_errors += gmt_contour_T_arg_parsing (GMT, opt->arg, &Ctrl->T.info);
 				break;
 			case 'W':	/* Sets pen attributes */
 				Ctrl->W.active = true;
@@ -1615,7 +1532,7 @@ EXTERN_MSC int GMT_pscontour (void *V_API, int mode, void *args) {
 			size_t kk;
 			save = gmt_M_malloc (GMT, save, 0, &n_save, struct PSCONTOUR_SAVE);
 
-			pscontour_sort_and_plot_ticks (GMT, PSL, save, n_save, x, y, z, n, Ctrl->T.dim[GMT_X], Ctrl->T.dim[GMT_Y], Ctrl->T.low, Ctrl->T.high, Ctrl->T.label, Ctrl->T.all, Ctrl->T.txt, label_mode, Ctrl->contour.Out);
+			pscontour_sort_and_plot_ticks (GMT, PSL, save, n_save, x, y, z, n, Ctrl->T.info.dim[GMT_X], Ctrl->T.info.dim[GMT_Y], Ctrl->T.info.low, Ctrl->T.info.high, Ctrl->T.info.label, Ctrl->T.info.all, Ctrl->T.info.txt, label_mode, Ctrl->contour.Out);
 			for (kk = 0; kk < n_save; kk++) {
 				gmt_M_free (GMT, save[kk].x);
 				gmt_M_free (GMT, save[kk].y);

--- a/test/trend2d/trend.sh
+++ b/test/trend2d/trend.sh
@@ -6,7 +6,7 @@ ps=trend.ps
 gmt makecpt -Crainbow -T690/960/10 > z.cpt
 gmt makecpt -Cjet -T-60/120/10 > r.cpt
 gmt makecpt -Chot -T0.7/1/0.02 > w.cpt
-gmt pscontour -R0/6.5/0/6.5 @Table_5_11.txt -C25 -A50 -JX3i -Y6.5i -Baf -B+tData -K -X1i -I -Cz.cpt -P > $ps
+gmt pscontour -R0/6.5/0/6.5 @Table_5_11.txt -JX3i -Y6.5i -Baf -B+tData -K -X1i -I -Cz.cpt -P > $ps
 gmt triangulate -M @Table_5_11.txt | gmt psxy -R -J -O -K -W0.25p,- >> $ps
 gmt psxy -R -J -O -K @Table_5_11.txt -Sc0.1c -Gblack >> $ps
 gmt psscale -Cz.cpt -Dx1.5i/-0.5i+w3i/0.1i+h+jTC -O -K -Ba >> $ps


### PR DESCRIPTION
**Description of proposed changes**

The two contouring modules **grdcontour** and **pscontour** are parsing some of the same arguments, here **-A**, **-C**, **-T**, and they are mostly identical except the coding was a bit sloppy.  So not exactly the same parsing (an error in one module may go unnoticed in another), but lots of near-duplicate code in the two modules.

This PR starts the process towards fixing #3730 (the part that -C1 does not yield unit contours in the presence of -A-2,0,2,5) by first simplifying all the parsing.  All tests passes, one test script had a bug that went unnoticed but now yielded an error (trend.sh), and a few more error checks were added to the common parsing functions now stored in gmt_support.c.  The contour parameters are now gathered into new structures that are used across these two modules and the library.  We backport since the coming PR that will unify the building of the contour structure array will rely on these changes, and it is that step that will fix the bug that started this PR.
