### PR TITLE
Better key verification

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -328,12 +328,12 @@ int gmt_remote_dataset_id (struct GMTAPI_CTRL *API, const char *file) {
 	/* Exclude leading directory for local saved versions of the file */
 	if (pos == 0) pos = gmtremote_wind_to_file (file);	/* Skip any leading directories */
 	key = bsearch (&file[pos], API->remote_info, API->n_remote_info, sizeof (struct GMT_DATA_INFO), gmtremote_compare_key);
-	if (key) {	/* Make sure we actually got a real hit since "earth" will find a key starting with "earth****" */
-		char *c = strrchr (key->file, '.');	/* Find location of the start of the file extension */
+	if (key) {	/* Make sure we actually got a real hit since file = "earth" will find a key starting with "earth****" */
+		char *c = strrchr (key->file, '.');	/* Find location of the start of the file extension (or NULL if no extension) */
 		size_t L = strlen (&file[pos]);	/* Length of input file without leading @ */
-		size_t Lkey = (size_t)(c - key->file);	/* Length of key file name */
-		if (Lkey > L && key->file[Lkey-2] == '_' && strchr ("gp", key->file[Lkey-1])) Lkey -= 2;	/* Remove the length of _g or _p from Lkey */
-		if (L != Lkey)	/* Not a match */
+		size_t Lkey = (c) ? (size_t)(c - key->file) : strlen (key->file);	/* Length of key file name without extension */
+		if (Lkey > L && Lkey > 2 && key->file[Lkey-2] == '_' && strchr ("gp", key->file[Lkey-1])) Lkey -= 2;	/* Remove the length of _g or _p from Lkey */
+		if (L != Lkey)	/* Not an exact match (apart from trailing _p|g) */
 			key = NULL;
 	}
 	return ((key == NULL) ? GMT_NOTSET : key->id);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -333,6 +333,7 @@ int gmt_remote_dataset_id (struct GMTAPI_CTRL *API, const char *file) {
 		char *cfile = strrchr (&file[pos], '.');	/* Find location of the start of the input file extension (or NULL if no extension) */
 		size_t Lfile = (cfile) ? (size_t)(cfile - &file[pos]) : strlen (&file[pos]);	/* Length of key file name without extension */
 		size_t Lkey  = (ckey)  ? (size_t)(ckey  - key->file)  : strlen (key->file);		/* Length of key file name without extension */
+		if (ckey == NULL && Lkey > 1 && key->file[Lkey-1] == '/') Lkey--;	/* Skip trailing dir flag */
 		if (Lkey > Lfile && Lkey > 2 && key->file[Lkey-2] == '_' && strchr ("gp", key->file[Lkey-1])) Lkey -= 2;	/* Remove the length of _g or _p from Lkey */
 		if (Lfile != Lkey)	/* Not an exact match (apart from trailing _p|g) */
 			key = NULL;

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -320,7 +320,13 @@ int gmtremote_wind_to_file (const char *file) {
 }
 
 int gmt_remote_dataset_id (struct GMTAPI_CTRL *API, const char *file) {
-	/* Return the entry in the remote file table of file is found, else -1 */
+	/* Return the entry in the remote file table of file is found, else -1.
+	 * Complications to consider before finding a match:
+	 * Input file may or may not have leading @
+	 * Input file may or may not have _g or _p for registration
+	 * Input file may or many not have an extension
+	 * Key file may be a tiled data set and thus ends with '/'
+	 */
 	int pos = 0;
 	struct GMT_DATA_INFO *key = NULL;
 	if (file == NULL || file[0] == '\0') return GMT_NOTSET;	/* No file name given */

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -328,6 +328,14 @@ int gmt_remote_dataset_id (struct GMTAPI_CTRL *API, const char *file) {
 	/* Exclude leading directory for local saved versions of the file */
 	if (pos == 0) pos = gmtremote_wind_to_file (file);	/* Skip any leading directories */
 	key = bsearch (&file[pos], API->remote_info, API->n_remote_info, sizeof (struct GMT_DATA_INFO), gmtremote_compare_key);
+	if (key) {	/* Make sure we actually got a real hit since "earth" will find a key starting with "earth****" */
+		char *c = strrchr (key->file, '.');	/* Find location of the start of the file extension */
+		size_t L = strlen (&file[pos]);	/* Length of input file without leading @ */
+		size_t Lkey = (size_t)(c - key->file);	/* Length of key file name */
+		if (Lkey > L && key->file[Lkey-2] == '_' && strchr ("gp", key->file[Lkey-1])) Lkey -= 2;	/* Remove the length of _g or _p from Lkey */
+		if (L != Lkey)	/* Not a match */
+			key = NULL;
+	}
 	return ((key == NULL) ? GMT_NOTSET : key->id);
 }
 

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -329,11 +329,12 @@ int gmt_remote_dataset_id (struct GMTAPI_CTRL *API, const char *file) {
 	if (pos == 0) pos = gmtremote_wind_to_file (file);	/* Skip any leading directories */
 	key = bsearch (&file[pos], API->remote_info, API->n_remote_info, sizeof (struct GMT_DATA_INFO), gmtremote_compare_key);
 	if (key) {	/* Make sure we actually got a real hit since file = "earth" will find a key starting with "earth****" */
-		char *c = strrchr (key->file, '.');	/* Find location of the start of the file extension (or NULL if no extension) */
-		size_t L = strlen (&file[pos]);	/* Length of input file without leading @ */
-		size_t Lkey = (c) ? (size_t)(c - key->file) : strlen (key->file);	/* Length of key file name without extension */
-		if (Lkey > L && Lkey > 2 && key->file[Lkey-2] == '_' && strchr ("gp", key->file[Lkey-1])) Lkey -= 2;	/* Remove the length of _g or _p from Lkey */
-		if (L != Lkey)	/* Not an exact match (apart from trailing _p|g) */
+		char *ckey = strrchr (key->file, '.');		/* Find location of the start of the key file extension (or NULL if no extension) */
+		char *cfile = strrchr (&file[pos], '.');	/* Find location of the start of the input file extension (or NULL if no extension) */
+		size_t Lfile = (cfile) ? (size_t)(cfile - &file[pos]) : strlen (&file[pos]);	/* Length of key file name without extension */
+		size_t Lkey  = (ckey)  ? (size_t)(ckey  - key->file)  : strlen (key->file);		/* Length of key file name without extension */
+		if (Lkey > Lfile && Lkey > 2 && key->file[Lkey-2] == '_' && strchr ("gp", key->file[Lkey-1])) Lkey -= 2;	/* Remove the length of _g or _p from Lkey */
+		if (Lfile != Lkey)	/* Not an exact match (apart from trailing _p|g) */
 			key = NULL;
 	}
 	return ((key == NULL) ? GMT_NOTSET : key->id);


### PR DESCRIPTION
Only return a remote file ID when it truly is a remote file (and not files like "earth").
