### PR TITLE
Make sure all test scripts have a set GMT_SESSION_NAME

### DIFF
--- a/doc/examples/gmtest.in
+++ b/doc/examples/gmtest.in
@@ -195,10 +195,11 @@ export GS_FONTPATH="@CMAKE_CURRENT_SOURCE_DIR@/ex31/fonts"
 export GMT_END_SHOW=off
 # Start with proper GMT defaults
 gmt set -Ds FORMAT_TIME_STAMP "Version 6" GMT_GRAPHICS_FORMAT ps
-# Modern mode needs a stable PPID but ctest messes that up when pipes are used
+export GMT_SESSION_NAME=\$\$
+echo "Set GMT_SESSION_NAME = \$GMT_SESSION_NAME"
+# Modern mode needs a stable PPID but ctest messes that up when pipes are used.
+# Because classic scripts also look to see what mode they are we set this for all.
 if [ ${modern} -gt 0 ]; then
-	export GMT_SESSION_NAME=\$\$
-	echo "Set GMT_SESSION_NAME = \$GMT_SESSION_NAME"
 	script_mode=M
 fi
 # Now run the script

--- a/doc/scripts/gmtest.in
+++ b/doc/scripts/gmtest.in
@@ -185,10 +185,11 @@ export GMT_END_SHOW=off
 gmt set -Du PS_CHAR_ENCODING ISOLatin1+ GMT_GRAPHICS_FORMAT ps
 # Tentative PS file name
 ps="${script_name%.sh}.ps"
-# Modern mode needs a stable PPID but ctest messes that up when pipes are used
+# Modern mode needs a stable PPID but ctest messes that up when pipes are used.
+# Because classic scripts also look to see what mode they are we set this for all.
+export GMT_SESSION_NAME=\$\$
+echo "Set GMT_SESSION_NAME = \$GMT_SESSION_NAME"
 if [ ${modern} -gt 0 ]; then
-	export GMT_SESSION_NAME=\$\$
-	echo "Set GMT_SESSION_NAME = \$GMT_SESSION_NAME"
 	script_mode=M
 fi
 # Now run the script

--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -240,10 +240,11 @@ export HAVE_GLIB_GTHREAD="@HAVE_GLIB_GTHREAD@"
 export GMT_END_SHOW=off
 # Start with proper GMT defaults
 gmt set -Du
-# Modern mode needs a stable PPID but ctest messes that up when pipes are used
+# Modern mode needs a stable PPID but ctest messes that up when pipes are used.
+# Because classic scripts also look to see what mode they are we set this for all.
+export GMT_SESSION_NAME=\$\$
+echo "Set GMT_SESSION_NAME = \$GMT_SESSION_NAME"
 if [ ${modern} -gt 0 ]; then
-	export GMT_SESSION_NAME=\$\$
-	echo "Set GMT_SESSION_NAME = \$GMT_SESSION_NAME"
 	script_mode=M
 fi
 # Now run the script


### PR DESCRIPTION
While required for modern mode script, the fact is that any GMT command starts its day by checking if it is run within a modern mode environment.  It learns taht it is by finding the special temporary directory created by gmt begin.   Hence, if ctest runs tons of tests and the classic ones do not have **GMT_SESSION_NAME** and default to **$$**, we may inadvertently have to scripts that share the same session name.  This seems to happen because some tests fail when run in parallel by claiming they are modern when in fact they are classic.  This PR sets the **GMT_SESSION_NAME** for any script run as a precaution, and so far it seems to have fixed my problems (running 24 tests in parallel).  Closes #3761 