### PR TITLE
Highlight the problems with toggling the grid registration

### DIFF
--- a/doc/rst/source/grdsample.rst
+++ b/doc/rst/source/grdsample.rst
@@ -83,7 +83,7 @@ Optional Arguments
    Intermediate wavelengths will experience attenuated amplitudes as well. b) Transfer function for
    resampling data from a pixel-registered to a gridline-registered grid format illustrates the loss
    of amplitude that will occur.  There is also a linear change in phase from 0 to 90 degrees as a
-   function of :math:`k_j` [Marks and Smith, 2007].
+   function of wavenumber :math:`k_j` [Marks and Smith, 2007].
 
 .. _-V:
 

--- a/doc/rst/source/grdsample.rst
+++ b/doc/rst/source/grdsample.rst
@@ -72,6 +72,19 @@ Optional Arguments
     Translate between grid and pixel registration; if the input is
     grid-registered, the output will be pixel-registered and vice-versa.
 
+.. figure:: /_images/GMT_grid2pix.*
+   :width: 500 px
+   :align: center
+
+   a) Cross-section of a grid along the *x*-axis for a constant value of *y*, showing just the Nyquist
+   *x*-component (heavy line) at its grid nodes (red circles).  Resampling this component half-way
+   between nodes (vertical lines) will always give zero (red triangles), hence this signal is lost,
+   unlike long wavelength components (thin line), which can be interpolated (blue triangles).
+   Intermediate wavelengths will experience attenuated amplitudes as well. b) Transfer function for
+   resampling data from a pixel-registered to a gridline-registered grid format illustrates the loss
+   of amplitude that will occur.  There is also a linear change in phase from 0 to 90 degrees as a
+   function of :math:`k_j` [Marks and Smith, 2007].
+
 .. _-V:
 
 .. |Add_-V| unicode:: 0x20 .. just an invisible code
@@ -147,3 +160,11 @@ See Also
 :doc:`grdfilter`,
 :doc:`greenspline`,
 :doc:`surface`
+
+
+References
+----------
+
+Marks, K. M., and W. H. F. Smith, 2007, Some remarks on resolving seamounts in satellite gravity,
+*Geophys. Res. Lett., 34 (L03307)*, http://doi.org/10.1029/2006GL028857.
+

--- a/doc/scripts/GMT_grid2pix.ps
+++ b/doc/scripts/GMT_grid2pix.ps
@@ -1,0 +1,1338 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.2.0_092c688_2020.07.29 [64-bit] Document from psxy
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Wed Jul 29 12:29:44 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt psxy -R0/6/0/2.5 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 2.50000000 0.000 6.000 0.000 2.500 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 1864 TM
+% PostScript produced by:
+%@GMT: gmt psxy -R0/6.7/-1.5/1.7 -W2p -Bx1 -By0g10 -BWS --MAP_FRAME_TYPE=graph --MAP_GRID_PEN_PRIMARY=0.25p,- -Xa0i -Ya1.5532i -JX15c
+%@PROJ: xy 0.00000000 6.70000000 -1.50000000 1.70000000 0.000 6.700 -1.500 1.700 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 1864 T
+0 A 7440 1136 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(a\)) tr Z
+U
+}!
+25 W
+4 W
+[33 17] 0 B
+0 533 M
+7200 0 D
+S
+[] 0 B
+/PSL_slant_y 0 def
+2 setlinecap
+25 W
+N 0 1136 M 0 -1136 D S
+{0 A} FS
+/PSL_vecheadpen {25 W 0 A [] 0 B} def
+V 0 1136 T 90 R
+U
+V 0 1221 T 90 R
+PSL_vecheadpen
+25 W
+0 0 M
+-250 62 D
+0 -124 D
+P clip fs N 
+U
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+N 0 0 M 7200 0 D S
+/PSL_vecheadpen {25 W 0 A [] 0 B} def
+V 7200 0 T N 0 0 M 290 0 D S
+U
+V 7740 0 T PSL_vecheadpen
+25 W
+0 0 M
+-250 62 D
+0 -124 D
+P clip fs N 
+U
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 1075 0 M 0 -83 D S
+N 2149 0 M 0 -83 D S
+N 3224 0 M 0 -83 D S
+N 4299 0 M 0 -83 D S
+N 5373 0 M 0 -83 D S
+N 6448 0 M 0 -83 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg M} def
+/PSL_AH0 0
+200 F0
+(0) sh mx
+(1) sh mx
+(2) sh mx
+(3) sh mx
+(4) sh mx
+(5) sh mx
+(6) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+1075 PSL_A0_y MM
+(1) bc Z
+2149 PSL_A0_y MM
+(2) bc Z
+3224 PSL_A0_y MM
+(3) bc Z
+4299 PSL_A0_y MM
+(4) bc Z
+5373 PSL_A0_y MM
+(5) bc Z
+6448 PSL_A0_y MM
+(6) bc Z
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 setlinecap
+33 W
+clipsave
+0 0 M
+7200 0 D
+0 1136 D
+-7200 0 D
+P
+PSL_clip N
+0 888 M
+43 -3 D
+43 -9 D
+43 -13 D
+43 -19 D
+43 -24 D
+64 -44 D
+65 -53 D
+43 -39 D
+86 -85 D
+150 -155 D
+65 -63 D
+64 -57 D
+43 -34 D
+43 -31 D
+43 -26 D
+43 -22 D
+43 -16 D
+43 -11 D
+43 -6 D
+43 0 D
+22 2 D
+43 9 D
+43 13 D
+43 19 D
+43 24 D
+43 29 D
+43 32 D
+43 36 D
+64 60 D
+43 42 D
+172 177 D
+64 63 D
+43 39 D
+65 53 D
+64 44 D
+43 24 D
+43 19 D
+43 13 D
+43 9 D
+43 3 D
+43 -3 D
+43 -9 D
+43 -13 D
+43 -19 D
+43 -24 D
+65 -44 D
+64 -53 D
+43 -39 D
+65 -63 D
+86 -88 D
+64 -67 D
+86 -85 D
+64 -57 D
+43 -34 D
+43 -31 D
+43 -26 D
+43 -22 D
+43 -16 D
+43 -11 D
+43 -6 D
+43 0 D
+22 2 D
+43 9 D
+43 13 D
+43 19 D
+43 24 D
+43 29 D
+43 32 D
+43 36 D
+43 39 D
+86 85 D
+150 155 D
+86 83 D
+65 55 D
+21 17 D
+65 44 D
+43 24 D
+43 19 D
+43 13 D
+43 9 D
+43 3 D
+42 -3 D
+43 -9 D
+43 -13 D
+43 -19 D
+43 -24 D
+65 -44 D
+64 -53 D
+43 -39 D
+65 -63 D
+86 -88 D
+64 -67 D
+86 -85 D
+43 -39 D
+43 -36 D
+65 -47 D
+21 -14 D
+43 -24 D
+43 -19 D
+43 -13 D
+43 -9 D
+43 -2 D
+22 0 D
+43 6 D
+43 11 D
+43 16 D
+43 22 D
+43 26 D
+64 47 D
+43 36 D
+43 39 D
+86 85 D
+150 155 D
+86 83 D
+65 55 D
+21 17 D
+65 44 D
+43 24 D
+43 19 D
+43 13 D
+43 9 D
+43 3 D
+43 -3 D
+43 -9 D
+43 -13 D
+43 -19 D
+43 -24 D
+64 -44 D
+65 -53 D
+43 -39 D
+86 -85 D
+150 -155 D
+65 -63 D
+64 -57 D
+11 -9 D S
+PSL_cliprestore
+%%EndObject
+0 -1864 TM
+0 A
+FQ
+O0
+0 1864 TM
+% PostScript produced by:
+%@GMT: gmt psbasemap -Bx0g1+0.5 -By0 -BS -Xa0i -Ya1.5532i -R0/6.7/-1.5/1.7 -JX15c
+%@PROJ: xy 0.00000000 6.70000000 -1.50000000 1.70000000 0.000 6.700 -1.500 1.700 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+4 W
+537 0 M
+0 1136 D
+S
+1612 0 M
+0 1136 D
+S
+2687 0 M
+0 1136 D
+S
+3761 0 M
+0 1136 D
+S
+4836 0 M
+0 1136 D
+S
+5910 0 M
+0 1136 D
+S
+6985 0 M
+0 1136 D
+S
+/PSL_slant_y 0 def
+2 setlinecap
+25 W
+N 0 0 M 7200 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 setlinecap
+%%EndObject
+0 -1864 TM
+0 A
+FQ
+O0
+0 1864 TM
+% PostScript produced by:
+%@GMT: gmt psxy -W0.25p -Xa0i -Ya1.5532i -R0/6.7/-1.5/1.7 -JX15c
+%@PROJ: xy 0.00000000 6.70000000 -1.50000000 1.70000000 0.000 6.700 -1.500 1.700 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+clipsave
+0 0 M
+7200 0 D
+0 1136 D
+-7200 0 D
+P
+PSL_clip N
+0 310 M
+107 22 D
+237 53 D
+301 74 D
+580 150 D
+236 58 D
+129 31 D
+258 56 D
+172 33 D
+194 32 D
+107 16 D
+194 23 D
+193 17 D
+193 10 D
+194 3 D
+150 -3 D
+108 -4 D
+193 -14 D
+172 -17 D
+215 -29 D
+237 -40 D
+171 -34 D
+237 -52 D
+215 -51 D
+537 -138 D
+344 -87 D
+322 -76 D
+215 -44 D
+86 -17 D
+215 -36 D
+237 -32 D
+193 -19 D
+172 -11 D
+86 -4 D
+0 0 D S
+PSL_cliprestore
+%%EndObject
+0 -1864 TM
+0 A
+FQ
+O0
+0 1864 TM
+% PostScript produced by:
+%@GMT: gmt psxy -Sc0.1i -Gred -W0.25p -N -Xa0i -Ya1.5532i -R0/6.7/-1.5/1.7 -JX15c
+%@PROJ: xy 0.00000000 6.70000000 -1.50000000 1.70000000 0.000 6.700 -1.500 1.700 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+V
+{1 0 0 C} FS
+O1
+60 0 888 Sc
+60 1075 178 Sc
+60 2149 888 Sc
+60 3224 178 Sc
+60 4299 888 Sc
+60 5373 178 Sc
+60 6448 888 Sc
+U
+%%EndObject
+0 -1864 TM
+0 A
+FQ
+O0
+0 1864 TM
+% PostScript produced by:
+%@GMT: gmt psxy -St0.1i -Gred -W0.25p -N -Xa0i -Ya1.5532i -R0/6.7/-1.5/1.7 -JX15c
+%@PROJ: xy 0.00000000 6.70000000 -1.50000000 1.70000000 0.000 6.700 -1.500 1.700 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+V
+{1 0 0 C} FS
+O1
+60 537 533 St
+60 1612 533 St
+60 2687 533 St
+60 3761 533 St
+60 4836 533 St
+60 5910 533 St
+60 6985 533 St
+U
+%%EndObject
+0 -1864 TM
+0 A
+FQ
+O0
+0 1864 TM
+% PostScript produced by:
+%@GMT: gmt psxy -Sc0.1i -Gblue -W0.25p -N -Xa0i -Ya1.5532i -R0/6.7/-1.5/1.7 -JX15c
+%@PROJ: xy 0.00000000 6.70000000 -1.50000000 1.70000000 0.000 6.700 -1.500 1.700 +xy
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+V
+{0 0 1 C} FS
+O1
+60 0 310 Sc
+60 1075 570 Sc
+60 2149 809 Sc
+60 3224 886 Sc
+60 4299 756 Sc
+60 5373 495 Sc
+60 6448 256 Sc
+U
+%%EndObject
+0 -1864 TM
+0 A
+FQ
+O0
+0 1864 TM
+% PostScript produced by:
+%@GMT: gmt psxy -St0.1i -Gblue -W0.25p -N -Xa0i -Ya1.5532i -R0/6.7/-1.5/1.7 -JX15c
+%@PROJ: xy 0.00000000 6.70000000 -1.50000000 1.70000000 0.000 6.700 -1.500 1.700 +xy
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+V
+{0 0 1 C} FS
+O1
+60 537 432 St
+60 1612 702 St
+60 2687 873 St
+60 3761 844 St
+60 4836 633 St
+60 5910 363 St
+60 6985 192 St
+U
+%%EndObject
+0 -1864 TM
+0 A
+FQ
+O0
+0 1864 TM
+% PostScript produced by:
+%@GMT: gmt pstext -N -F+f+j -Xa0i -Ya1.5532i -R0/6.7/-1.5/1.7 -JX15c
+%@PROJ: xy 0.00000000 6.70000000 -1.50000000 1.70000000 0.000 6.700 -1.500 1.700 +xy
+%%BeginObject PSL_Layer_8
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+PSL_font_encode 6 get 0 eq {ISOLatin1+_Encoding /Times-Italic /Times-Italic PSL_reencode PSL_font_encode 6 1 put} if
+7415 -71 M 300 F6
+(x) tr Z
+-215 1101 M (z) tr Z
+-215 888 M 267 F6
+V MU 0 0 M (a) FP 0 -67 G 187 F6 (n/2) FP 0 67 G pathbbox N 4 1 roll exch pop add exch U -2 div exch neg exch G
+(a) Z
+0 -67 G 187 F6 (n/2) Z
+0 67 G PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-215 533 M 233 F0
+(0) mr Z
+%%EndObject
+0 -1864 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt psxy -R0/0.5/0/1.2 -W2p '-Bx1f+lWavenumber, @%6%k@%%' -By1f+l|@%6%T(k@-j@-)@%%| -BWS --MAP_FRAME_TYPE=graph --MAP_GRID_PEN_PRIMARY=0.25p,- -Xa0i -Ya0i -JX15c
+%@PROJ: xy 0.00000000 0.50000000 0.00000000 1.20000000 0.000 0.500 0.000 1.200 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 A 7440 1136 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(b\)) tr Z
+U
+}!
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 1136 M 0 -1136 D S
+{0 A} FS
+/PSL_vecheadpen {25 W 0 A [] 0 B} def
+V 0 1136 T 90 R
+U
+V 0 1221 T 90 R
+PSL_vecheadpen
+25 W
+0 0 M
+-250 62 D
+0 -124 D
+P clip fs N 
+U
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 947 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+233 F0
+(0) sw mx
+(1) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+947 PSL_A0_y MM
+(1) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 95 M -42 0 D S
+N 0 189 M -42 0 D S
+N 0 284 M -42 0 D S
+N 0 379 M -42 0 D S
+N 0 473 M -42 0 D S
+N 0 568 M -42 0 D S
+N 0 663 M -42 0 D S
+N 0 757 M -42 0 D S
+N 0 852 M -42 0 D S
+N 0 1041 M -42 0 D S
+N 0 1136 M -42 0 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 0 add def
+568 PSL_L_y MM
+PSL_font_encode 6 get 0 eq {ISOLatin1+_Encoding /Times-Italic /Times-Italic PSL_reencode PSL_font_encode 6 1 put} if
+V 90 R V MU 0 0 M (|) FP 267 F6 (T\(k) FP 0 -67 G 187 F6 (j) FP 0 67 G 267 F6 (\)) FP 267 F0 (|) FP pathbbox N pop exch pop add U -2 div 0 G
+(|) Z
+267 F6 (T\(k) Z
+0 -67 G 187 F6 (j) Z
+0 67 G 267 F6 (\)) Z
+267 F0 (|) Z
+U
+25 W
+N 0 0 M 7200 0 D S
+/PSL_vecheadpen {25 W 0 A [] 0 B} def
+V 7200 0 T N 0 0 M 290 0 D S
+U
+V 7740 0 T PSL_vecheadpen
+25 W
+0 0 M
+-250 62 D
+0 -124 D
+P clip fs N 
+U
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+233 F0
+(0) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+N 0 0 M 0 -42 D S
+N 288 0 M 0 -42 D S
+N 576 0 M 0 -42 D S
+N 864 0 M 0 -42 D S
+N 1152 0 M 0 -42 D S
+N 1440 0 M 0 -42 D S
+N 1728 0 M 0 -42 D S
+N 2016 0 M 0 -42 D S
+N 2304 0 M 0 -42 D S
+N 2592 0 M 0 -42 D S
+N 2880 0 M 0 -42 D S
+N 3168 0 M 0 -42 D S
+N 3456 0 M 0 -42 D S
+N 3744 0 M 0 -42 D S
+N 4032 0 M 0 -42 D S
+N 4320 0 M 0 -42 D S
+N 4608 0 M 0 -42 D S
+N 4896 0 M 0 -42 D S
+N 5184 0 M 0 -42 D S
+N 5472 0 M 0 -42 D S
+N 5760 0 M 0 -42 D S
+N 6048 0 M 0 -42 D S
+N 6336 0 M 0 -42 D S
+N 6624 0 M 0 -42 D S
+N 6912 0 M 0 -42 D S
+N 7200 0 M 0 -42 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 0 add PSL_LH add def
+3600 PSL_L_y MM
+V MU 0 0 M (Wavenumber, ) FP 267 F6 (k) FP pathbbox N pop exch pop add U -2 div 0 G
+(Wavenumber, ) Z
+267 F6 (k) Z
+0 setlinecap
+33 W
+clipsave
+0 0 M
+7200 0 D
+0 1136 D
+-7200 0 D
+P
+PSL_clip N
+0 947 M
+317 -2 D
+345 -8 D
+303 -11 D
+259 -13 D
+187 -11 D
+274 -18 D
+273 -22 D
+346 -32 D
+346 -37 D
+302 -36 D
+317 -41 D
+317 -44 D
+388 -59 D
+375 -61 D
+403 -70 D
+432 -79 D
+331 -63 D
+303 -59 D
+504 -101 D
+244 -50 D
+116 -23 D
+244 -51 D
+116 -23 D
+158 -33 D
+S
+PSL_cliprestore
+%%EndObject
+0 0 TM
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt pstext -N -F+f+j -Xa0i -Ya0i -R0/0.5/0/1.2 -JX15c
+%@PROJ: xy 0.00000000 0.50000000 0.00000000 1.20000000 0.000 0.500 0.000 1.200 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+PSL_font_encode 6 get 0 eq {ISOLatin1+_Encoding /Times-Italic /Times-Italic PSL_reencode PSL_font_encode 6 1 put} if
+7200 -95 M 233 F6
+V MU 0 0 M (k) FP 0 -58 G 163 F6 (n/2) FP 0 58 G pathbbox N 4 1 roll exch pop add exch U neg exch -2 div exch G
+(k) Z
+0 -58 G 163 F6 (n/2) Z
+0 58 G %%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/doc/scripts/GMT_grid2pix.sh
+++ b/doc/scripts/GMT_grid2pix.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Illustrate the problem with grdsample -T
+gmt begin GMT_grid2pix ps
+	gmt subplot begin 2x1 -F6i/2.5i -M3p -A+jTR+o-0.2i/0
+		gmt subplot set 0
+		gmt math -T0/7/0.02 T PI MUL COS = | gmt plot -R0/6.7/-1.5/1.7 -W2p -Bx1 -By0g10 -BWS --MAP_FRAME_TYPE=graph --MAP_GRID_PEN_PRIMARY=0.25p,-
+		gmt basemap -Bx0g1+0.5 -By0 -BS
+		gmt math -T0/7/0.02 T PI MUL 4 DIV 2.25 SUB COS = | gmt plot -W0.25p
+		gmt math -T0/6/1 T PI MUL COS = | gmt plot -Sc0.1i -Gred -W0.25p -N
+		gmt math -T0.5/6.5/1 T 0 MUL = | gmt plot -St0.1i -Gred -W0.25p -N
+		gmt math -T0/6/1 T PI MUL 4 DIV 2.25 SUB COS = | gmt plot -Sc0.1i -Gblue -W0.25p -N
+		gmt math -T0.5/6.5/1 T PI MUL 4 DIV 2.25 SUB COS = | gmt plot -St0.1i -Gblue -W0.25p -N
+		gmt text -N -F+f+j <<- EOF
+		6.9 -1.7 18p,Times-Italic RT x
+		-0.2 1.6 18p,Times-Italic RT z
+		-0.2 1.0 16p,Times-Italic RM a@-n/2@-
+		-0.2 0.0 14p,Helvetica RM 0
+		EOF
+		gmt subplot set 1
+		gmt set PS_SCALE_X 0.6 PS_SCALE_Y 0.6 FONT_ANNOT_PRIMARY 14p FONT_LABEL 16p MAP_LABEL_OFFSET 0
+		gmt math -T0/0.5/0.001 T PI MUL COS = | gmt plot -R0/0.5/0/1.2 -W2p -Bx1f+l"Wavenumber, @%6%k@%%" -By1f+l"|@%6%T(k@-j@-)@%%|" -BWS --MAP_FRAME_TYPE=graph --MAP_GRID_PEN_PRIMARY=0.25p,-
+		gmt text -N -F+f+j <<- EOF
+		0.5 -0.1 14p,Times-Italic TC k@-n/2@-
+		EOF
+	gmt subplot end
+gmt end show


### PR DESCRIPTION
Unsophisticated users see no problems in switching between node-registrations, so I am highlighting the danger of this practice (and the reason why we serve both registrations for remote download).  @WalterHFSmith will appreciate that.  Under the **grdsample -T** explanation we have this bit:

![toggle](https://user-images.githubusercontent.com/26473567/88861392-8df3fb80-d199-11ea-8052-9e666c94360b.png)
