### PR TITLE
[Backport 6.1] Do not let the API object for the assembled grid live one (#3771)

### DIFF
--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -52,6 +52,7 @@ struct GMT_XINGS {
 EXTERN_MSC char *dlerror (void);
 #endif
 
+EXTERN_MSC int gmtlib_delete_virtualfile  (void *API, const char *string);
 EXTERN_MSC int gmtlib_file_is_jpeg2000_tile (struct GMTAPI_CTRL *API, char *file);
 EXTERN_MSC int gmtlib_download_remote_file (struct GMT_CTRL *GMT, const char* file_name, char *path, int k_data, unsigned int mode);
 EXTERN_MSC int gmtlib_get_serverfile_index (struct GMTAPI_CTRL *API, const char *file);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -217,7 +217,7 @@ GMT_LOCAL struct GMT_DATA_INFO *gmtremote_data_load (struct GMTAPI_CTRL *API, in
 		else
 			GMT_Report (API, GMT_MSG_ERROR, "Unable to parse \"%s\" to extract GMT version\n", line);
 		return NULL;
-	}	
+	}
 	if ((I = gmt_M_memory (GMT, NULL, *n, struct GMT_DATA_INFO)) == NULL) {
 		GMT_Report (API, GMT_MSG_ERROR, "Unable to allocated %d GMT_DATA_INFO structures!\n", *n);
 		return NULL;
@@ -748,7 +748,7 @@ GMT_LOCAL int gmtremote_refresh (struct GMTAPI_CTRL *API, unsigned int index) {
 			if (!access (old_indexpath, F_OK))
 				remove (old_indexpath);	/* Remove old index file if it exists */
 		}
-		else 
+		else
 			GMT->current.io.new_data_list = true;	/* Flag that we wish to delete datasets older than entries in this file */
 	}
 	else
@@ -1351,7 +1351,7 @@ char ** gmt_get_dataset_tiles (struct GMTAPI_CTRL *API, double wesn_in[], int k_
 			XS = (lon < 0) ? 'W' : 'E';
 			/* Write remote tile name to list */
 			if (n >= n_alloc) {
-				n_alloc <<= 1; 
+				n_alloc <<= 1;
 				if ((list = gmt_M_memory (API->GMT, list, n_alloc, char *)) == NULL) {
 					GMT_Report (API, GMT_MSG_ERROR, "gmt_get_dataset_tiles: Unable to reallocate memory.\n");
 					API->error = GMT_RUNTIME_ERROR;
@@ -1394,7 +1394,7 @@ char *gmtlib_get_tile_list (struct GMTAPI_CTRL *API, double wesn[], int k_data, 
 	if (strcmp (Ip->filler, "-") && srtm_flag == 0) {	/* Want background filler, except special case when srtm_relief is the given dataset name (srtm_flag == 1) */
 		if ((k_filler = gmt_remote_dataset_id (API, Ip->filler)) == GMT_NOTSET) {
 			GMT_Report (API, GMT_MSG_ERROR, "gmtlib_get_tile_list: Internal error - Filler grid %s is not a recognized remote data set.\n", Ip->filler);
-			return NULL;			
+			return NULL;
 		}
 		Is = &API->remote_info[k_filler];	/* Pointer to secondary tiled dataset */
 		ocean = (strcmp (Is->inc, "15s") == 0);
@@ -1507,6 +1507,11 @@ struct GMT_GRID *gmtlib_assemble_tiles (struct GMTAPI_CTRL *API, double *region,
 		GMT_Report (API, GMT_MSG_ERROR, "ERROR - Unable to receive blended grid from grdblend\n");
 		return NULL;
 	}
+	if (gmtlib_delete_virtualfile (API, grid)) {	/* Remove trace since passed upwards anyway */
+		GMT_Report (API, GMT_MSG_ERROR, "ERROR - Unable to destroy temporary object for assembled grid\n");
+		return NULL;
+	}
+
 	HH = gmt_get_H_hidden (G->header);
 	HH->orig_datatype = GMT_SHORT;	/* Since we know this */
 	return (G);


### PR DESCRIPTION
GMT_Read_Data assigns a new object number to what is read, but for tiles it calls gmt_assemble_grid which also creates an object to pass to grdblend.  However, once we get it back from grdblend we only want to keep the grid and discard the container since GMT_Read_Data already has a container for it.

Backport https://github.com/GenericMappingTools/gmt/pull/3771 to 6.1 branch.