### PR TITLE
Implementing headers/trailing text for GMT_MATRIX i/o

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -3323,7 +3323,7 @@ GMT_LOCAL struct GMT_MATRIX * gmtapi_read_matrix (struct GMT_CTRL *GMT, void *so
 	M->inc[GMT_X] = M->inc[GMT_Y] = 1.0;
 
 	if (text) {	/* Attach the trailing text to the vector */
-		struct GMT_MATRIX_HIDDEN *MH = gmt_get_V_hidden (M);
+		struct GMT_MATRIX_HIDDEN *MH = gmt_get_M_hidden (M);
 		if (nt_alloc > row) text = gmt_M_memory (GMT, text, row, char **);
 		GMT_Put_Strings (GMT->parent, GMT_IS_MATRIX, M, text);
 		MH->alloc_mode_text = GMT_ALLOC_INTERNALLY;	/* Override since it is allocated internally in GMT */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -3220,12 +3220,12 @@ GMT_LOCAL struct GMT_MATRIX * gmtapi_read_matrix (struct GMT_CTRL *GMT, void *so
 	 * Notes: mode is not used yet.  We only do ascii file for now - later need to deal with -b, if needed.
 	 */
 
-	bool close_file = false, first = true, add_first_segheader = false;
+	bool close_file = false, first = true, add_first_segheader = false, in_header_section = true;
 	unsigned int pos;
 	int error = 0;
-	uint64_t row = 0, col, ij, dim[4] = {0, 0, 0, GMT->current.setting.export_type};
-	char M_file[PATH_MAX] = {""};
-	char line[GMT_BUFSIZ] = {""};
+	uint64_t row = 0, col, ij, nt_alloc = 0, nh_alloc = 0, n_headers = 0, dim[4] = {0, 0, 0, GMT->current.setting.export_type};
+	char M_file[PATH_MAX] = {""}, line[GMT_BUFSIZ] = {""};
+	char **text = NULL, **header = NULL;
 	FILE *fp = NULL;
 	struct GMT_MATRIX *M = NULL;
 	GMT_putfunction api_put_val = NULL;
@@ -3270,7 +3270,15 @@ GMT_LOCAL struct GMT_MATRIX * gmtapi_read_matrix (struct GMT_CTRL *GMT, void *so
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Read Matrix from %s\n", M_file);
 
 	while (!error && fgets (line, GMT_BUFSIZ, fp)) {
-		if (strchr (GMT->current.setting.io_head_marker_in, line[0])) continue;	/* Just skip headers */
+		gmt_chop (line);	/* Remove linefeeds */
+		if (strchr (GMT->current.setting.io_head_marker_in, line[0])) {
+			if (in_header_section) {
+				if (nh_alloc <= n_headers) header = gmt_M_memory (GMT, NULL, nh_alloc += GMT_TINY_CHUNK, char *);
+				header[n_headers++] = strdup (line);
+			}
+			continue;
+		}
+		in_header_section = false;
 		if (line[0] == '>') {
 			if (first) {	/* Have not allocated yet so just skip that row for now and deal with it later */
 				first = false;
@@ -3282,10 +3290,13 @@ GMT_LOCAL struct GMT_MATRIX * gmtapi_read_matrix (struct GMT_CTRL *GMT, void *so
 			}
 		}
 		else {	/* Regular data record */
-			gmt_chop (line);	/* Remove linefeeds */
 			dim[0] = gmtlib_conv_text2datarec (GMT, line, GMT_BUFSIZ, GMT->current.io.curr_rec, &pos);
 			gmt_prep_tmp_arrays (GMT, GMT_IN, row, dim[0]);	/* Init or reallocate tmp vectors */
 			for (col = 0; col < dim[0]; col++) GMT->hidden.mem_coord[col][row] = GMT->current.io.curr_rec[col];
+			if (line[pos]) {	/* Deal with trailing text */
+				if (nt_alloc <= row) text = gmt_M_memory (GMT, NULL, nt_alloc += GMT_INITIAL_MEM_ROW_ALLOC, char **);
+				text[row] = strdup (&line[pos]);
+			}
 		}
 		row++;
 	}
@@ -3310,6 +3321,18 @@ GMT_LOCAL struct GMT_MATRIX * gmtapi_read_matrix (struct GMT_CTRL *GMT, void *so
 	M->range[XHI] = dim[GMT_X] - 1.0;
 	M->range[YHI] = dim[GMT_Y] - 1.0;
 	M->inc[GMT_X] = M->inc[GMT_Y] = 1.0;
+
+	if (text) {	/* Attach the trailing text to the vector */
+		struct GMT_MATRIX_HIDDEN *MH = gmt_get_V_hidden (M);
+		if (nt_alloc > row) text = gmt_M_memory (GMT, text, row, char **);
+		GMT_Put_Strings (GMT->parent, GMT_IS_MATRIX, M, text);
+		MH->alloc_mode_text = GMT_ALLOC_INTERNALLY;	/* Override since it is allocated internally in GMT */
+	}
+	if (n_headers) {	/* Pass out the header records as well */
+		if (nh_alloc > n_headers) header = gmt_M_memory (GMT, header, n_headers, char *);
+		M->header = header;
+		M->n_headers = n_headers;
+	}
 
 	if (close_file) gmt_fclose (GMT, fp);
 	return (M);
@@ -3388,7 +3411,7 @@ GMT_LOCAL int gmtapi_write_matrix (struct GMT_CTRL *GMT, void *dest, unsigned in
 	 * mode is not used yet.
 	 */
 
-	bool close_file = false, append = false;
+	bool close_file = false, append = false, was;
 	uint64_t row, col, ij;
 	unsigned int hdr;
 	char M_file[PATH_MAX] = {""};
@@ -3445,6 +3468,10 @@ GMT_LOCAL int gmtapi_write_matrix (struct GMT_CTRL *GMT, void *dest, unsigned in
 
 	/* Start writing Matrix to fp */
 
+	if (M->n_headers) {	/* Make sure we enable header records to be written */
+		was = GMT->current.setting.io_header[GMT_OUT];
+		GMT->current.setting.io_header[GMT_OUT] = true;
+	}
 	for (hdr = 0; hdr < M->n_headers; hdr++)
 		gmtlib_write_tableheader (GMT, fp, M->header[hdr]);
 
@@ -3466,6 +3493,7 @@ GMT_LOCAL int gmtapi_write_matrix (struct GMT_CTRL *GMT, void *dest, unsigned in
 			fprintf (fp, "\n");
 		}
 	}
+	GMT->current.setting.io_header[GMT_OUT] = was;
 
 	if (close_file) fclose (fp);
 	return (GMT_NOERROR);

--- a/src/testapi_matrix_io.c
+++ b/src/testapi_matrix_io.c
@@ -1,0 +1,18 @@
+#include "gmt.h"
+/*
+ * Testing the reading and writing of GMT_MATRIX from/to ASCII files.
+ * The test script api/apimat_io.sh will run this and make a plot.
+ */
+int main () {
+	void *API = NULL;                 /* The API control structure */
+	struct GMT_MATRIX *M = NULL;     /* Structure to hold input/output dataset as vectors */
+
+	/* Initialize the GMT session */
+	API = GMT_Create_Session ("test", 2U, GMT_SESSION_EXTERNAL, NULL);
+	/* Read in our data table to memory as a matrix */
+	M = GMT_Read_Data (API, GMT_IS_MATRIX, GMT_IS_FILE, GMT_IS_POINT, GMT_READ_NORMAL, NULL, "@hotspots.txt", NULL);
+	/* Write the matrix out to a table */
+	GMT_Write_Data (API, GMT_IS_MATRIX, GMT_IS_FILE, GMT_IS_POINT, GMT_WRITE_NORMAL, NULL, "test_hotspots.txt", M);
+	/* Destroy the GMT session */
+	if (GMT_Destroy_Session (API)) return EXIT_FAILURE;
+};

--- a/src/testapi_vector_io.c
+++ b/src/testapi_vector_io.c
@@ -11,7 +11,7 @@ int main () {
 	API = GMT_Create_Session ("test", 2U, GMT_SESSION_EXTERNAL, NULL);
 	/* Read in our data table to memory */
 	V = GMT_Read_Data (API, GMT_IS_VECTOR, GMT_IS_FILE, GMT_IS_POINT, GMT_READ_NORMAL, NULL, "@hotspots.txt", NULL);
-	/* Associate our data table with a virtual file */
+	/* Write the vector out to a table */
 	GMT_Write_Data (API, GMT_IS_VECTOR, GMT_IS_FILE, GMT_IS_POINT, GMT_WRITE_NORMAL, NULL, "test_hotspots.txt", V);
 	/* Destroy the GMT session */
 	if (GMT_Destroy_Session (API)) return EXIT_FAILURE;

--- a/test/api/apimat_io.ps
+++ b/test/api/apimat_io.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.2.0_e42c833-dirty_2020.07.30 [64-bit] Document from pscoast
+%%Title: GMT v6.2.0_4b839ec_2020.07.30 [64-bit] Document from pscoast
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Jul 30 16:24:56 2020
+%%CreationDate: Thu Jul 30 16:37:40 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -90462,23 +90462,23 @@ N 8587 4252 M -8670 0 D S
 N 8587 4335 M -8670 0 D S
 N 0 4335 M 0 -4418 D S
 N -83 4335 M 0 -4418 D S
-/PSL_H_y 400 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/PSL_H_y 400 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(100∞) sh add def
+(100è) sh add def
 4252 4252 PSL_H_y add M
 400 F0
 (Testing Matrix i/o) bc Z
 0 -167 M 200 F0
-(-180∞) tc Z
-1417 -167 M (-120∞) tc Z
-2835 -167 M (-60∞) tc Z
-4252 -167 M (0∞) tc Z
-5669 -167 M (60∞) tc Z
-7087 -167 M (120∞) tc Z
-8504 -167 M (180∞) tc Z
--167 709 M (-60∞) mr Z
--167 2126 M (0∞) mr Z
--167 3543 M (60∞) mr Z
+(î180è) tc Z
+1417 -167 M (î120è) tc Z
+2835 -167 M (î60è) tc Z
+4252 -167 M (0è) tc Z
+5669 -167 M (60è) tc Z
+7087 -167 M (120è) tc Z
+8504 -167 M (180è) tc Z
+-167 709 M (î60è) mr Z
+-167 2126 M (0è) mr Z
+-167 3543 M (60è) mr Z
 %%EndObject
 0 A
 FQ
@@ -90634,46 +90634,63 @@ clipsave
 -8504 0 D
 P
 PSL_clip N
-5311 2476 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+5311 2476 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 100 F0
-(EHTIOPIA) bl Z
-3728 1791 M (SEAMOUNT) bl Z
-1012 1499 M (ISLANDS HOTSPOT) bl Z
-1649 2830 M (CALIFORNIA, GUADAL) bl Z
-1115 3456 M (SEAMOUNT, KODIAC SEAMOUNTS) bl Z
-3917 2854 M (ISLANDS) bl Z
-3752 2547 M (VERDE) bl Z
-4173 1886 M (SEAMOUNT) bl Z
-8240 2311 M (ISLANDS) bl Z
-5358 1909 M (ISLANDS) bl Z
-790 1536 M (ISLAND) bl Z
-4484 3374 M (BELGIUM) bl Z
-2169 2193 M (ISLANDS) bl Z
-4460 2736 M (MOUNTAINS, ALGER) bl Z
-4886 2500 M (MARRA, SUDAN) bl Z
-1295 3279 M (DE FUCA, COBB SEAM) bl Z
-2452 1390 M (FERNANDEZ) bl Z
-5169 2122 M (VICTORIA, EAST AFRICA) bl Z
-1562 1571 M (ISLANDS) bl Z
-1056 990 M (HOTSPOT) bl Z
-1489 1508 M (SEAMOUNT) bl Z
-5209 1087 M (ISLAND) bl Z
-1071 2015 M (ISLANDS) bl Z
-693 1697 M (ISLANDS) bl Z
-4531 2287 M (CAMEROON) bl Z
-8264 350 M (EREBUS) bl Z
-1477 1956 M (HOTSPOT) bl Z
-1245 1623 M (ISLAND) bl Z
-1862 3067 M (NEW MEXICO) bl Z
-6149 1278 M (PAUL ISLAND) bl Z
-1744 1555 M (Y GOMEZ) bl Z
-2429 1555 M (FELIX) bl Z
-823 1765 M (ISLANDS) bl Z
-4720 2689 M (CHAD) bl Z
-4035 1319 M (DA CUNHA) bl Z
-4697 1437 M (SEAMOUNT) bl Z
-3645 2886 M (SEAMOUNT S OF GREENLAND) bl Z
-5462 931 M (SEAMOUNT EAST OF LENA SEAMOUNT ON CONRAD RISE) bl Z
+(AFAR, EHTIOPIA) bl Z
+3728 1791 M (ARNOLD SEAMOUNT) bl Z
+3988 2004 M (ASCENSION) bl Z
+1012 1499 M (AUSTRAL-COOK ISLANDS HOTSPOT) bl Z
+3657 3090 M (AZORES) bl Z
+1649 2830 M (BAJA CALIFORNIA, GUADAL) bl Z
+8209 601 M (BALLENY) bl Z
+2901 2901 M (BERMUDA) bl Z
+4413 917 M (BOUVET) bl Z
+1115 3456 M (BOWIE SEAMOUNT, KODIAC SEAMOUNTS) bl Z
+3917 2854 M (CANARY ISLANDS) bl Z
+3752 2547 M (CAPE VERDE) bl Z
+4173 1886 M (CARDNO SEAMOUNT) bl Z
+8240 2311 M (CAROLINE ISLANDS) bl Z
+5358 1909 M (COMORES ISLANDS) bl Z
+5382 1100 M (CROZET) bl Z
+790 1536 M (EASTER ISLAND) bl Z
+4484 3374 M (EIFEL, BELGIUM) bl Z
+3563 2098 M (FERNANDO) bl Z
+2169 2193 M (GALAPAGOS ISLANDS) bl Z
+657 2665 M (HAWAII) bl Z
+4460 2736 M (HOGGAR MOUNTAINS, ALGER) bl Z
+3846 3704 M (ICELAND) bl Z
+4886 2500 M (JEBEL MARRA, SUDAN) bl Z
+1295 3279 M (JUAN DE FUCA, COBB SEAM) bl Z
+2452 1390 M (JUAN FERNANDEZ) bl Z
+5807 1035 M (KERGUELEN) bl Z
+5169 2122 M (LAKE VICTORIA, EAST AFRICA) bl Z
+1562 1571 M (LINE ISLANDS) bl Z
+1056 990 M (LOUISVILLE HOTSPOT) bl Z
+1489 1508 M (MACDONALD SEAMOUNT) bl Z
+3917 2972 M (MADEIRA) bl Z
+5209 1087 M (MARION ISLAND) bl Z
+1071 2015 M (MARQUESAS ISLANDS) bl Z
+693 1697 M (MARSHALL-GILBERT ISLANDS) bl Z
+4531 2287 M (MOUNT CAMEROON) bl Z
+8264 350 M (MOUNT EREBUS) bl Z
+1477 1956 M (MUSICIANS HOTSPOT) bl Z
+1245 1623 M (PITCAIRN ISLAND) bl Z
+1862 3067 M (RATON, NEW MEXICO) bl Z
+5630 1697 M (REUNION) bl Z
+6149 1278 M (ST. PAUL ISLAND) bl Z
+1744 1555 M (SALA Y GOMEZ) bl Z
+312 1857 M (SAMOA) bl Z
+2429 1555 M (SAN FELIX) bl Z
+823 1765 M (SOCIETY ISLANDS) bl Z
+787 1777 M (TAHITI) bl Z
+8011 1236 M (TASMANTID) bl Z
+4720 2689 M (TIBESTI, CHAD) bl Z
+3634 1720 M (TRINDADE) bl Z
+4035 1319 M (TRISTAN DA CUNHA) bl Z
+4697 1437 M (VEMA SEAMOUNT) bl Z
+1697 3256 M (YELLOWSTONE) bl Z
+3645 2886 M (ACTIVE SEAMOUNT S OF GREENLAND) bl Z
+5462 931 M (UNNAMED SEAMOUNT EAST OF LENA SEAMOUNT ON CONRAD RISE) bl Z
 PSL_cliprestore
 %%EndObject
 

--- a/test/api/apimat_io.ps
+++ b/test/api/apimat_io.ps
@@ -1,0 +1,90691 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.2.0_e42c833-dirty_2020.07.30 [64-bit] Document from pscoast
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Thu Jul 30 16:24:56 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt pscoast -Rg -JQ0/18c -Glightgreen -Baf '-BWSne+tTesting Matrix i/o' -K -P
+%@PROJ: eqc -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.356 20015109.356 -10007554.678 10007554.678 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%GMTBoundingBox: 72 72 510.236220472 255.118110236
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4640 4016 M
+-4 1 D
+-4 -1 D
+P
+{0.565 0.933 0.565 C} FS
+FO
+4693 4016 M
+-1 0 D
+-1 0 D
+P
+FO
+4724 4025 M
+-8 3 D
+4 -7 D
+-19 3 D
+13 -5 D
+-7 -1 D
+-13 3 D
+-23 -2 D
+13 -3 D
+15 1 D
+-1 -1 D
+26 0 D
+P
+FO
+4724 4028 M
+-1 -1 D
+P
+FO
+4679 4022 M
+8 -1 D
+8 2 D
+-11 1 D
+-5 -1 D
+P
+FO
+4777 4016 M
+-4 2 D
+-11 0 D
+5 4 D
+-22 -2 D
+-11 5 D
+-8 0 D
+-2 0 D
+0 -9 D
+P
+FO
+4889 4016 M
+-4 3 D
+-26 0 D
+-9 3 D
+-13 -1 D
+2 3 D
+-10 -2 D
+4 1 D
+-11 1 D
+5 -2 D
+-14 0 D
+-2 -3 D
+-6 1 D
+-8 -2 D
+6 8 D
+-13 2 D
+0 -5 D
+-4 3 D
+-7 -1 D
+-1 -9 D
+P
+FO
+4724 4028 M
+P
+FO
+4821 4025 M
+3 1 D
+P
+FO
+4902 4019 M
+9 0 D
+P
+FO
+4736 4031 M
+7 -1 D
+P
+FO
+4750 4032 M
+7 0 D
+P
+FO
+5008 4018 M
+38 3 D
+-51 -3 D
+P
+FO
+5126 4019 M
+-7 1 D
+P
+FO
+5412 4016 M
+P
+FO
+5433 4021 M
+-11 -2 D
+11 -2 D
+P
+FO
+5433 4038 M
+-24 -4 D
+16 -2 D
+-11 -4 D
+-11 -1 D
+-9 2 D
+-21 -2 D
+19 -1 D
+-16 -1 D
+10 -2 D
+-16 0 D
+-3 2 D
+-11 -2 D
+6 -3 D
+22 2 D
+5 -2 D
+-11 -3 D
+11 2 D
+5 -2 D
+2 3 D
+16 0 D
+-14 3 D
+5 2 D
+20 -1 D
+2 3 D
+8 1 D
+P
+FO
+5314 4030 M
+14 -2 D
+12 1 D
+4 -3 D
+8 3 D
+20 1 D
+5 4 D
+12 -3 D
+15 0 D
+-7 4 D
+-25 1 D
+-12 -3 D
+P
+FO
+5416 4017 M
+10 0 D
+P
+FO
+5461 4016 M
+-4 2 D
+-10 -2 D
+P
+FO
+5663 4016 M
+2 1 D
+-19 0 D
+0 -1 D
+P
+FO
+5669 4035 M
+-7 -1 D
+-8 -7 D
+7 -2 D
+8 0 D
+P
+FO
+5669 4039 M
+P
+FO
+5433 4028 M
+24 1 D
+19 4 D
+-14 2 D
+-24 -2 D
+18 3 D
+-3 2 D
+-18 -2 D
+8 2 D
+-7 0 D
+-3 0 D
+P
+FO
+5433 4017 M
+9 3 D
+-9 1 D
+P
+FO
+5551 4038 M
+39 -4 D
+10 -3 D
+18 3 D
+-39 6 D
+-16 -1 D
+-19 3 D
+-6 -3 D
+P
+FO
+5598 4026 M
+8 -7 D
+12 -1 D
+4 2 D
+10 -1 D
+-5 3 D
+26 1 D
+-23 4 D
+P
+FO
+5598 4048 M
+-15 1 D
+6 -4 D
+-27 2 D
+2 -3 D
+22 -1 D
+35 3 D
+P
+FO
+5598 4038 M
+17 -3 D
+15 2 D
+-18 3 D
+-34 2 D
+P
+FO
+5622 4051 M
+-14 2 D
+-14 -3 D
+32 -2 D
+9 2 D
+P
+FO
+5574 4030 M
+22 0 D
+0 2 D
+-12 2 D
+-25 -2 D
+P
+FO
+5551 4033 M
+21 1 D
+-19 2 D
+-22 0 D
+-3 -1 D
+P
+FO
+5504 4019 M
+11 0 D
+11 2 D
+-14 4 D
+-26 -3 D
+P
+FO
+5527 4026 M
+12 1 D
+-14 3 D
+P
+FO
+5574 4018 M
+25 -1 D
+0 7 D
+-26 -1 D
+P
+FO
+5646 4057 M
+6 3 D
+-33 -1 D
+6 -3 D
+P
+FO
+5622 4035 M
+12 -2 D
+12 2 D
+-8 1 D
+P
+FO
+5623 4039 M
+11 -1 D
+5 2 D
+-14 2 D
+P
+FO
+5646 4049 M
+-12 -1 D
+11 -2 D
+8 1 D
+P
+FO
+5457 4042 M
+-12 2 D
+-2 -4 D
+P
+FO
+5574 4024 M
+7 1 D
+-9 1 D
+P
+FO
+5506 4030 M
+9 -3 D
+-2 3 D
+P
+FO
+5530 4022 M
+2 -2 D
+6 2 D
+P
+FO
+5537 4025 M
+9 0 D
+-2 2 D
+P
+FO
+5622 4029 M
+2 2 D
+-20 -2 D
+8 -1 D
+P
+FO
+5634 4029 M
+9 1 D
+P
+FO
+5597 4043 M
+19 -1 D
+6 2 D
+P
+FO
+5625 4042 M
+11 0 D
+P
+FO
+5532 4048 M
+8 -2 D
+P
+FO
+5551 4021 M
+11 2 D
+-12 -2 D
+P
+FO
+5646 4044 M
+18 -1 D
+P
+FO
+5628 4053 M
+10 1 D
+P
+FO
+5551 4025 M
+6 1 D
+P
+FO
+5633 4041 M
+7 0 D
+-7 1 D
+P
+FO
+5486 4024 M
+10 -1 D
+P
+FO
+5669 4039 M
+24 -2 D
+15 5 D
+-13 0 D
+-26 -3 D
+P
+FO
+5669 4025 M
+8 1 D
+18 -2 D
+26 7 D
+-4 5 D
+-48 -1 D
+P
+FO
+5740 4032 M
+10 -2 D
+17 1 D
+25 5 D
+5 4 D
+-9 3 D
+-15 1 D
+-7 -5 D
+-18 -1 D
+-16 -2 D
+P
+FO
+5740 4053 M
+18 1 D
+-4 2 D
+-34 1 D
+P
+FO
+5669 4047 M
+14 -1 D
+P
+FO
+5717 4053 M
+2 -1 D
+P
+FO
+6142 4038 M
+-17 0 D
+-4 -3 D
+21 0 D
+P
+FO
+6142 4035 M
+9 3 D
+-9 0 D
+P
+FO
+6453 4016 M
+-52 1 D
+P
+FO
+6466 4016 M
+20 3 D
+65 2 D
+-4 8 D
+24 2 D
+-32 7 D
+-5 3 D
+-11 0 D
+9 1 D
+-19 2 D
+8 1 D
+-9 1 D
+-13 -1 D
+9 -1 D
+-46 -5 D
+12 -1 D
+-22 0 D
+-14 -5 D
+21 1 D
+-14 -4 D
+2 -3 D
+-22 -1 D
+18 -2 D
+-24 0 D
+-7 -2 D
+21 0 D
+16 -3 D
+-16 1 D
+-4 -1 D
+P
+FO
+6478 4016 M
+3 1 D
+-7 -1 D
+P
+FO
+6568 4016 M
+3 1 D
+-12 3 D
+-42 -2 D
+-9 1 D
+-5 -2 D
+-7 1 D
+-6 -2 D
+P
+FO
+6602 4016 M
+-1 0 D
+-7 0 D
+5 1 D
+-14 0 D
+-2 -1 D
+P
+FO
+6402 4045 M
+-20 -1 D
+-1 -3 D
+29 0 D
+2 2 D
+P
+FO
+1890 4016 M
+P
+FO
+1918 4016 M
+0 2 D
+-23 1 D
+-5 -3 D
+P
+FO
+2016 4016 M
+-48 3 D
+1 -2 D
+8 0 D
+-4 -1 D
+P
+FO
+2126 4027 M
+-18 2 D
+5 2 D
+-30 12 D
+-40 5 D
+0 -1 D
+-16 1 D
+-4 -3 D
+28 -1 D
+2 -3 D
+-27 1 D
+10 -2 D
+-13 -2 D
+-12 3 D
+-15 -6 D
+39 -3 D
+-18 -1 D
+20 -3 D
+-52 2 D
+-2 -3 D
+19 -2 D
+-32 -1 D
+16 -4 D
+17 2 D
+-12 -2 D
+9 -1 D
+18 2 D
+12 -1 D
+-17 -2 D
+7 -2 D
+106 0 D
+P
+FO
+2126 4044 M
+-6 0 D
+6 -2 D
+P
+FO
+2126 4053 M
+-19 -3 D
+9 -2 D
+10 1 D
+P
+FO
+2126 4061 M
+-14 -1 D
+-31 -5 D
+12 -4 D
+16 4 D
+12 -1 D
+2 2 D
+3 -2 D
+P
+FO
+2126 4062 M
+-12 0 D
+P
+FO
+1984 4031 M
+25 0 D
+-6 1 D
+P
+FO
+2194 4016 M
+-3 2 D
+-15 -1 D
+-9 2 D
+17 1 D
+-2 5 D
+-17 1 D
+-6 -1 D
+6 -7 D
+-18 3 D
+1 6 D
+-12 2 D
+-3 -2 D
+-7 0 D
+0 -11 D
+P
+FO
+2298 4016 M
+-25 6 D
+-64 1 D
+0 -7 D
+P
+FO
+2362 4028 M
+-4 0 D
+-71 -5 D
+21 -6 D
+54 -1 D
+P
+FO
+2362 4085 M
+-43 -3 D
+-12 -3 D
+-7 -8 D
+52 -7 D
+-112 10 D
+-39 -4 D
+18 -1 D
+-10 0 D
+10 -1 D
+-19 0 D
+6 -2 D
+43 -3 D
+7 -3 D
+-9 3 D
+3 -3 D
+-10 3 D
+-12 0 D
+7 -4 D
+-15 4 D
+-19 1 D
+-8 -2 D
+-19 4 D
+-25 -3 D
+4 -4 D
+-9 3 D
+0 -4 D
+-9 3 D
+-9 0 D
+0 -7 D
+12 0 D
+-12 -1 D
+0 -4 D
+41 4 D
+25 -2 D
+-33 1 D
+-31 -5 D
+25 -2 D
+-27 -1 D
+0 -2 D
+7 -2 D
+55 1 D
+65 5 D
+-27 -5 D
+-86 -4 D
+45 -7 D
+44 10 D
+79 4 D
+-80 -5 D
+-24 -9 D
+15 -2 D
+12 2 D
+-5 -2 D
+47 1 D
+0 4 D
+13 3 D
+-3 -4 D
+38 3 D
+-31 -4 D
+-1 -2 D
+51 2 D
+22 3 D
+P
+FO
+2126 4062 M
+14 0 D
+9 2 D
+-22 -2 D
+-1 0 D
+P
+FO
+2584 4016 M
+4 2 D
+-43 -1 D
+10 1 D
+-12 3 D
+17 -3 D
+38 3 D
+0 1 D
+-10 2 D
+-8 5 D
+13 -5 D
+5 0 D
+0 20 D
+-4 0 D
+4 0 D
+0 16 D
+-41 -4 D
+-27 -1 D
+14 3 D
+54 3 D
+0 28 D
+-60 2 D
+-63 0 D
+-42 -1 D
+-26 -5 D
+2 -3 D
+-10 2 D
+8 1 D
+-19 1 D
+-4 -2 D
+-7 2 D
+-15 -1 D
+0 -51 D
+13 2 D
+10 5 D
+-10 3 D
+20 -2 D
+8 4 D
+34 4 D
+-38 -7 D
+-12 -6 D
+59 -1 D
+-41 -1 D
+-43 -5 D
+45 -1 D
+-45 -1 D
+0 -12 D
+P
+FO
+2835 4060 M
+-17 1 D
+-27 -3 D
+12 -7 D
+-12 -3 D
+12 -6 D
+-11 -3 D
+-22 5 D
+-17 0 D
+-8 -1 D
+16 -10 D
+-23 9 D
+-20 -3 D
+-9 -5 D
+-12 -2 D
+5 -1 D
+-10 1 D
+-34 -8 D
+11 -7 D
+14 1 D
+14 -2 D
+13 3 D
+18 -1 D
+5 5 D
+11 -4 D
+-29 -3 D
+120 0 D
+P
+FO
+2835 4064 M
+-3 0 D
+3 -1 D
+P
+FO
+2598 4061 M
+23 1 D
+-23 -2 D
+0 -16 D
+80 8 D
+-12 1 D
+-39 -1 D
+10 0 D
+-22 4 D
+24 -3 D
+58 1 D
+13 2 D
+-18 0 D
+17 1 D
+23 -1 D
+1 2 D
+11 0 D
+63 10 D
+1 3 D
+-27 4 D
+-27 -2 D
+11 4 D
+-24 3 D
+9 3 D
+-20 -2 D
+-11 3 D
+-6 -3 D
+-13 2 D
+-23 -3 D
+-45 -2 D
+52 7 D
+-62 2 D
+-17 -1 D
+2 3 D
+-9 0 D
+P
+FO
+2598 4041 M
+10 3 D
+-10 0 D
+P
+FO
+2598 4024 M
+12 0 D
+45 14 D
+71 11 D
+-1 3 D
+-110 -8 D
+-17 -3 D
+P
+FO
+2598 4021 M
+3 1 D
+-3 0 D
+P
+FO
+2670 4031 M
+9 -1 D
+-9 2 D
+P
+FO
+2682 4053 M
+-10 0 D
+11 0 D
+P
+FO
+2717 4055 M
+3 1 D
+-4 -1 D
+P
+FO
+3071 4075 M
+-1 0 D
+-40 0 D
+9 -8 D
+31 -6 D
+-10 -1 D
+-29 2 D
+32 -8 D
+-38 7 D
+-43 2 D
+-5 -6 D
+-20 -3 D
+9 11 D
+-18 6 D
+-27 -2 D
+8 -1 D
+-20 0 D
+-5 -2 D
+-6 2 D
+-63 -4 D
+0 -1 D
+65 -16 D
+-50 8 D
+-10 5 D
+-5 0 D
+0 -44 D
+236 0 D
+P
+FO
+3024 4062 M
+-13 4 D
+-33 4 D
+-3 -5 D
+P
+FO
+3004 4070 M
+7 -2 D
+P
+FO
+2865 4054 M
+6 0 D
+P
+FO
+3307 4082 M
+-13 4 D
+-26 0 D
+-25 4 D
+-8 -2 D
+6 3 D
+-35 2 D
+8 -2 D
+-24 0 D
+25 -2 D
+-35 2 D
+-6 -2 D
+-11 2 D
+-9 -1 D
+51 -5 D
+-37 0 D
+9 -2 D
+58 0 D
+44 -3 D
+7 -8 D
+-9 4 D
+-29 4 D
+-10 0 D
+5 -6 D
+-8 7 D
+-83 0 D
+43 -10 D
+35 -2 D
+-10 -1 D
+-34 2 D
+-12 -1 D
+8 -12 D
+-36 5 D
+-10 4 D
+-26 1 D
+-39 8 D
+0 -59 D
+236 0 D
+P
+3144 4057 M
+14 -2 D
+-10 -3 D
+-5 5 D
+P
+3143 4062 M
+32 -5 D
+-7 -2 D
+-26 7 D
+P
+3109 4062 M
+17 -5 D
+-18 5 D
+P
+FO
+3307 4087 M
+-4 0 D
+4 -2 D
+P
+FO
+3307 4091 M
+-38 4 D
+-3 -2 D
+41 -4 D
+P
+FO
+3307 4097 M
+-2 0 D
+1 -4 D
+1 0 D
+P
+FO
+3142 4086 M
+4 -1 D
+-21 1 D
+18 -3 D
+29 0 D
+-27 6 D
+-17 -2 D
+P
+FO
+3107 4078 M
+19 -6 D
+48 -7 D
+-7 3 D
+15 4 D
+-39 7 D
+-35 -1 D
+P
+FO
+3283 4090 M
+-15 1 D
+25 -4 D
+5 2 D
+P
+FO
+3278 4086 M
+3 2 D
+-33 3 D
+P
+FO
+3093 4076 M
+-13 -1 D
+14 -3 D
+P
+FO
+3092 4084 M
+2 -3 D
+19 1 D
+P
+FO
+3298 4094 M
+-4 2 D
+2 -2 D
+P
+FO
+3115 4085 M
+22 -2 D
+P
+FO
+3259 4092 M
+-15 1 D
+P
+FO
+3226 4092 M
+9 1 D
+-9 0 D
+P
+FO
+3543 4063 M
+-15 -1 D
+-5 -2 D
+-4 1 D
+-42 -2 D
+-31 -4 D
+-4 4 D
+68 6 D
+-33 2 D
+35 -1 D
+31 1 D
+0 22 D
+-37 1 D
+-35 -5 D
+-7 2 D
+-37 -1 D
+-6 -6 D
+1 4 D
+-24 1 D
+-17 -5 D
+1 5 D
+69 3 D
+-22 3 D
+34 -3 D
+39 3 D
+41 -1 D
+0 7 D
+-4 1 D
+4 0 D
+-41 3 D
+-72 0 D
+-13 -1 D
+5 -2 D
+-12 3 D
+-2 -1 D
+-5 1 D
+-13 -1 D
+-25 0 D
+-14 -1 D
+13 -3 D
+-30 3 D
+-4 -4 D
+-23 2 D
+0 -4 D
+46 -3 D
+-44 -2 D
+40 -1 D
+-42 0 D
+0 -2 D
+6 -4 D
+-6 1 D
+0 -66 D
+236 0 D
+P
+3462 4069 M
+13 -1 D
+-70 1 D
+P
+FO
+3307 4089 M
+2 2 D
+-2 0 D
+P
+FO
+3315 4090 M
+11 1 D
+P
+FO
+3767 4016 M
+4 2 D
+-6 0 D
+15 4 D
+0 9 D
+-20 -4 D
+2 2 D
+-13 0 D
+31 3 D
+0 7 D
+-17 -4 D
+17 5 D
+0 11 D
+-12 -2 D
+7 6 D
+-21 -2 D
+-87 -25 D
+38 18 D
+-10 -1 D
+16 2 D
+8 5 D
+-9 13 D
+-43 -2 D
+0 -7 D
+-19 -1 D
+-53 -6 D
+-16 2 D
+54 6 D
+1 6 D
+-82 0 D
+-9 0 D
+0 -47 D
+P
+3733 4020 M
+-23 -1 D
+24 1 D
+P
+FO
+3780 4016 M
+-1 0 D
+P
+FO
+3780 4018 M
+-2 -1 D
+2 0 D
+P
+FO
+3543 4098 M
+7 1 D
+-7 -1 D
+P
+FO
+3543 4090 M
+42 0 D
+30 2 D
+4 3 D
+-53 3 D
+-18 -2 D
+-5 1 D
+P
+FO
+3543 4067 M
+100 0 D
+30 3 D
+31 1 D
+30 7 D
+-54 5 D
+-14 -2 D
+-1 4 D
+-49 -4 D
+30 6 D
+-14 4 D
+-75 -3 D
+-14 1 D
+P
+FO
+3774 4063 M
+-18 4 D
+-5 -3 D
+23 -4 D
+1 2 D
+P
+FO
+3756 4056 M
+-8 0 D
+1 -2 D
+18 1 D
+P
+FO
+3835 4016 M
+-4 3 D
+-35 -1 D
+-16 -2 D
+P
+FO
+3780 4040 M
+9 3 D
+29 3 D
+-26 -3 D
+4 -1 D
+-16 -3 D
+0 -7 D
+32 -1 D
+17 4 D
+6 -2 D
+38 0 D
+4 2 D
+26 2 D
+-6 5 D
+23 1 D
+45 10 D
+-17 4 D
+-45 4 D
+-47 0 D
+-6 -2 D
+-16 0 D
+8 -3 D
+-15 1 D
+-3 -3 D
+9 -1 D
+-15 0 D
+-1 -3 D
+-30 3 D
+-7 -2 D
+P
+FO
+3780 4022 M
+4 1 D
+32 -2 D
+32 1 D
+23 6 D
+-28 3 D
+-30 -2 D
+-33 2 D
+P
+FO
+3780 4017 M
+22 3 D
+-16 2 D
+-6 -4 D
+P
+FO
+3803 4055 M
+12 0 D
+-18 3 D
+-6 -1 D
+P
+FO
+3789 4065 M
+-3 3 D
+3 -2 D
+P
+FO
+4694 3780 M
+5 2 D
+-3 -1 D
+-2 1 D
+P
+FO
+4709 3780 M
+-4 2 D
+-6 -2 D
+P
+FO
+4716 3780 M
+-4 1 D
+-2 -1 D
+P
+FO
+4719 3780 M
+P
+FO
+4724 3782 M
+-9 4 D
+3 -5 D
+6 0 D
+P
+FO
+4724 3992 M
+-1 0 D
+-3 4 D
+-21 0 D
+-8 2 D
+7 4 D
+-14 5 D
+-15 -6 D
+-2 4 D
+11 4 D
+-15 5 D
+-9 1 D
+-7 -2 D
+-7 3 D
+-8 0 D
+-4 -1 D
+5 -3 D
+-10 1 D
+-2 -2 D
+21 -21 D
+-16 6 D
+-4 -2 D
+-9 12 D
+-13 5 D
+-21 -6 D
+5 -7 D
+-12 5 D
+-8 0 D
+6 3 D
+-21 -2 D
+-5 2 D
+16 2 D
+16 0 D
+2 5 D
+-28 -3 D
+-10 2 D
+3 -5 D
+-16 5 D
+-4 -2 D
+-7 0 D
+8 -3 D
+-12 0 D
+-4 -1 D
+9 -1 D
+-13 0 D
+12 -10 D
+12 1 D
+-3 4 D
+6 -3 D
+9 2 D
+0 -2 D
+-12 -3 D
+9 -3 D
+9 1 D
+3 -2 D
+-29 1 D
+15 -3 D
+-12 -2 D
+22 -5 D
+22 1 D
+-23 -2 D
+13 -3 D
+2 -4 D
+19 0 D
+5 3 D
+2 -2 D
+3 4 D
+14 -1 D
+-13 3 D
+8 1 D
+-5 4 D
+8 1 D
+6 -3 D
+8 6 D
+4 -5 D
+-9 -1 D
+7 -4 D
+20 2 D
+7 4 D
+9 -1 D
+-15 -5 D
+13 -1 D
+13 1 D
+-13 -3 D
+-26 0 D
+0 -2 D
+-10 0 D
+-8 -3 D
+-18 0 D
+2 -3 D
+-8 3 D
+-9 -1 D
+8 -8 D
+38 4 D
+9 -2 D
+25 3 D
+-5 -1 D
+9 -3 D
+-19 1 D
+-38 -4 D
+29 -2 D
+3 -2 D
+-25 2 D
+-8 -2 D
+-5 2 D
+-13 -1 D
+12 -8 D
+15 -1 D
+9 -3 D
+14 1 D
+8 -1 D
+-21 -3 D
+19 -4 D
+0 -4 D
+16 1 D
+4 3 D
+-6 2 D
+9 3 D
+8 13 D
+16 1 D
+2 12 D
+16 2 D
+-1 7 D
+19 0 D
+-6 5 D
+10 0 D
+P
+FO
+4724 3998 M
+P
+FO
+4724 4001 M
+-9 0 D
+9 -1 D
+P
+FO
+4724 4006 M
+-7 1 D
+7 -3 D
+P
+FO
+4698 4016 M
+-1 -1 D
+-6 1 D
+-12 -3 D
+16 -4 D
+29 1 D
+0 6 D
+P
+FO
+4512 3981 M
+28 -8 D
+-6 6 D
+-16 2 D
+-5 7 D
+-13 2 D
+P
+FO
+4701 3883 M
+6 1 D
+-4 2 D
+-8 -1 D
+P
+FO
+4700 3783 M
+5 -1 D
+1 4 D
+-5 -3 D
+P
+FO
+4512 4009 M
+-6 0 D
+1 -2 D
+P
+FO
+4680 4014 M
+5 1 D
+P
+FO
+4642 3933 M
+2 -1 D
+P
+FO
+4512 4010 M
+-8 0 D
+P
+FO
+4596 3962 M
+5 -1 D
+P
+FO
+4696 3783 M
+1 -2 D
+P
+FO
+4709 3782 M
+5 0 D
+-5 1 D
+P
+FO
+4747 3780 M
+-6 0 D
+P
+FO
+4759 3780 M
+-1 0 D
+-4 0 D
+P
+FO
+4764 3780 M
+-1 1 D
+P
+FO
+4798 3780 M
+-3 3 D
+-4 -1 D
+3 2 D
+-14 2 D
+-1 -3 D
+6 -1 D
+-8 1 D
+2 3 D
+-5 -1 D
+-4 2 D
+-2 -4 D
+-7 4 D
+-1 -3 D
+-2 2 D
+-6 -2 D
+13 -3 D
+8 1 D
+-7 -2 D
+8 0 D
+-1 0 D
+P
+FO
+4947 3780 M
+-18 2 D
+2 1 D
+30 -2 D
+0 15 D
+-7 -2 D
+0 3 D
+-11 -2 D
+4 3 D
+-11 2 D
+-10 -3 D
+0 -7 D
+-3 1 D
+-4 -2 D
+0 3 D
+-5 -3 D
+3 3 D
+-7 -2 D
+11 6 D
+-16 -2 D
+12 3 D
+-10 1 D
+12 0 D
+7 4 D
+-8 0 D
+1 3 D
+-10 -1 D
+-4 2 D
+-3 -4 D
+-6 2 D
+2 -2 D
+-6 0 D
+7 -1 D
+7 -3 D
+-10 1 D
+1 -2 D
+-5 0 D
+4 -4 D
+-7 0 D
+3 -3 D
+-8 1 D
+-6 -3 D
+3 7 D
+-7 0 D
+8 2 D
+0 5 D
+-29 -14 D
+3 -1 D
+-10 -6 D
+-1 2 D
+-2 -2 D
+-3 1 D
+10 9 D
+-6 0 D
+4 1 D
+-4 -1 D
+20 9 D
+-7 1 D
+-4 -2 D
+3 2 D
+-6 2 D
+-2 -5 D
+-2 3 D
+-6 -1 D
+3 2 D
+-5 -1 D
+-4 2 D
+0 -5 D
+-7 2 D
+-2 -2 D
+7 -1 D
+4 -3 D
+-10 2 D
+-5 -4 D
+6 -2 D
+-12 1 D
+-9 -4 D
+3 -1 D
+-8 -1 D
+6 0 D
+-8 0 D
+5 -3 D
+-6 0 D
+7 -2 D
+P
+FO
+4778 4016 M
+0 -1 D
+-54 1 D
+0 -6 D
+41 1 D
+-5 -3 D
+-25 0 D
+16 -3 D
+-27 1 D
+0 -2 D
+23 -4 D
+44 1 D
+0 -3 D
+20 -2 D
+12 1 D
+13 4 D
+10 -1 D
+14 2 D
+0 5 D
+30 5 D
+-1 4 D
+P
+FO
+4724 4000 M
+4 -1 D
+-4 2 D
+P
+FO
+4724 3998 M
+1 -1 D
+P
+FO
+4724 3983 M
+13 0 D
+6 2 D
+14 -1 D
+4 2 D
+-1 2 D
+-36 4 D
+P
+FO
+4724 3781 M
+3 1 D
+-3 0 D
+P
+FO
+4772 3793 M
+7 1 D
+-4 -3 D
+4 1 D
+0 -1 D
+8 2 D
+1 -2 D
+6 1 D
+13 6 D
+-4 2 D
+-1 -2 D
+-2 1 D
+-4 -1 D
+4 -1 D
+-5 -2 D
+-5 3 D
+-2 -4 D
+-8 3 D
+1 -3 D
+-10 1 D
+0 -2 D
+P
+FO
+4819 3960 M
+8 4 D
+-17 1 D
+-18 9 D
+-48 -3 D
+17 -5 D
+-16 -11 D
+38 4 D
+7 -3 D
+-2 -6 D
+26 8 D
+8 0 D
+P
+FO
+4795 3788 M
+3 1 D
+2 -3 D
+10 4 D
+-1 4 D
+-5 0 D
+4 -2 D
+-7 0 D
+0 -1 D
+-2 2 D
+-7 -3 D
+P
+FO
+4748 3973 M
+27 2 D
+0 5 D
+-11 3 D
+-5 -1 D
+-6 1 D
+-4 -1 D
+-21 -2 D
+10 -1 D
+-1 -3 D
+P
+FO
+4866 3802 M
+6 2 D
+-8 -1 D
+2 3 D
+-11 1 D
+5 -2 D
+-11 0 D
+7 -3 D
+P
+FO
+4913 3988 M
+2 -1 D
+17 3 D
+13 -2 D
+8 2 D
+-30 1 D
+-11 -3 D
+P
+FO
+4819 3803 M
+0 -2 D
+5 1 D
+-5 2 D
+-4 -1 D
+P
+FO
+4819 3796 M
+-8 1 D
+3 -5 D
+8 2 D
+P
+FO
+4795 3786 M
+-5 3 D
+-10 -2 D
+P
+FO
+4726 3993 M
+7 -1 D
+11 1 D
+-18 2 D
+P
+FO
+4890 3985 M
+-12 3 D
+5 -5 D
+P
+FO
+4842 3934 M
+-1 -2 D
+13 6 D
+-11 -4 D
+P
+FO
+4833 3805 M
+4 -1 D
+2 2 D
+P
+FO
+4743 3781 M
+-1 4 D
+-8 -1 D
+-1 -2 D
+P
+FO
+4824 3800 M
+2 0 D
+P
+FO
+4836 3803 M
+-4 0 D
+P
+FO
+4764 3786 M
+1 3 D
+P
+FO
+4728 3787 M
+2 -2 D
+P
+FO
+4842 3803 M
+0 1 D
+P
+FO
+4848 3785 M
+2 2 D
+P
+FO
+4961 3781 M
+4 0 D
+8 4 D
+13 1 D
+-1 3 D
+-7 1 D
+-3 3 D
+-14 -1 D
+8 2 D
+-8 2 D
+P
+FO
+4963 3992 M
+6 0 D
+P
+FO
+4986 3789 M
+1 -1 D
+P
+FO
+5433 4015 M
+-6 0 D
+P
+FO
+5412 4016 M
+6 -1 D
+P
+FO
+5669 3782 M
+-22 9 D
+-7 -1 D
+-7 -3 D
+8 -3 D
+-10 1 D
+8 -5 D
+30 0 D
+P
+FO
+5669 3920 M
+-26 -2 D
+-4 -3 D
+-16 -2 D
+6 -2 D
+-16 -2 D
+6 -4 D
+-22 1 D
+-4 -1 D
+4 -2 D
+-11 -4 D
+-3 2 D
+-8 1 D
+-3 -5 D
+13 1 D
+-2 -3 D
+11 1 D
+-23 -4 D
+17 1 D
+1 -3 D
+9 0 D
+-28 0 D
+-5 -3 D
+16 -2 D
+-21 -1 D
+-2 -2 D
+13 -2 D
+-13 1 D
+-4 -2 D
+30 -5 D
+-32 4 D
+-11 -4 D
+11 -2 D
+-9 1 D
+-16 -4 D
+-7 0 D
+12 -5 D
+28 5 D
+-6 -2 D
+17 -1 D
+-5 -1 D
+-21 1 D
+-16 -7 D
+5 -1 D
+16 3 D
+23 -3 D
+-1 3 D
+5 -4 D
+14 -1 D
+0 3 D
+4 -1 D
+8 4 D
+-19 6 D
+19 -4 D
+10 1 D
+-7 5 D
+-17 1 D
+19 -1 D
+6 -3 D
+5 1 D
+-8 8 D
+-8 0 D
+9 0 D
+-2 3 D
+6 -4 D
+12 -1 D
+-3 3 D
+5 -1 D
+5 1 D
+-6 2 D
+5 -2 D
+1 2 D
+5 0 D
+-4 6 D
+-9 2 D
+22 -3 D
+3 5 D
+-5 2 D
+17 -4 D
+1 3 D
+-4 1 D
+8 0 D
+P
+FO
+5669 3922 M
+-1 0 D
+P
+FO
+5669 3924 M
+P
+FO
+5646 4016 M
+0 -1 D
+15 -1 D
+2 2 D
+P
+FO
+5447 4016 M
+-14 -1 D
+32 -1 D
+-4 2 D
+P
+FO
+5528 3797 M
+7 1 D
+3 -1 D
+2 2 D
+15 -7 D
+3 4 D
+5 -1 D
+-5 1 D
+3 1 D
+14 -4 D
+-5 2 D
+20 -2 D
+-5 2 D
+-5 -1 D
+0 3 D
+8 0 D
+1 -3 D
+17 -2 D
+-13 3 D
+16 -2 D
+-1 4 D
+5 -1 D
+-33 12 D
+-12 8 D
+-5 8 D
+-7 0 D
+6 1 D
+-3 3 D
+6 3 D
+-7 2 D
+4 4 D
+-8 0 D
+10 1 D
+-11 2 D
+12 -1 D
+1 4 D
+7 -1 D
+-11 4 D
+15 -1 D
+3 4 D
+-17 0 D
+21 2 D
+-15 1 D
+18 2 D
+-4 2 D
+-10 0 D
+-4 2 D
+-20 3 D
+-11 -2 D
+2 -2 D
+-16 0 D
+-15 -3 D
+4 -3 D
+-7 0 D
+0 -2 D
+12 -1 D
+-16 0 D
+-13 -4 D
+10 -2 D
+20 0 D
+-23 -1 D
+6 -1 D
+-5 -2 D
+3 -1 D
+-2 -3 D
+-5 1 D
+2 -3 D
+-4 1 D
+0 -5 D
+-16 2 D
+-9 -7 D
+5 -7 D
+7 -2 D
+9 0 D
+0 3 D
+4 -3 D
+2 5 D
+10 -7 D
+1 3 D
+4 -2 D
+8 3 D
+-5 -2 D
+6 -6 D
+7 -2 D
+-1 2 D
+4 -1 D
+3 1 D
+6 -2 D
+-7 1 D
+3 -2 D
+-9 1 D
+3 -2 D
+-10 1 D
+5 -6 D
+-6 2 D
+2 -1 D
+-5 0 D
+P
+FO
+5505 3803 M
+3 -1 D
+-3 2 D
+4 5 D
+-4 0 D
+-8 4 D
+1 -2 D
+-4 1 D
+-6 -1 D
+-2 -2 D
+10 -1 D
+P
+FO
+5515 3806 M
+4 -1 D
+-2 2 D
+1 -1 D
+P
+FO
+5646 3919 M
+-4 0 D
+10 1 D
+P
+FO
+5598 3793 M
+-4 0 D
+10 -2 D
+P
+FO
+5627 4014 M
+16 -1 D
+-6 2 D
+P
+FO
+5513 3809 M
+1 -1 D
+P
+FO
+5606 3792 M
+4 0 D
+P
+FO
+5528 3860 M
+-1 0 D
+4 1 D
+P
+FO
+5583 3793 M
+7 0 D
+P
+FO
+5508 3812 M
+5 -2 D
+P
+FO
+5575 3794 M
+4 -1 D
+P
+FO
+5651 3884 M
+2 -1 D
+P
+FO
+5508 3813 M
+3 -2 D
+P
+FO
+5653 3922 M
+4 0 D
+P
+FO
+5657 3921 M
+5 1 D
+-5 0 D
+P
+FO
+5676 3780 M
+-7 2 D
+0 -2 D
+P
+FO
+5835 3780 M
+0 1 D
+-3 -1 D
+P
+FO
+5906 3847 M
+-9 0 D
+4 2 D
+-10 0 D
+-29 -31 D
+4 -1 D
+-4 1 D
+-14 -5 D
+3 -1 D
+-18 -3 D
+-5 -3 D
+6 -1 D
+-9 -5 D
+2 -3 D
+12 2 D
+6 -4 D
+-5 -3 D
+3 -4 D
+-4 0 D
+-2 -3 D
+6 -4 D
+-5 -1 D
+68 0 D
+P
+FO
+5906 3854 M
+-1 -3 D
+1 0 D
+P
+FO
+5669 3924 M
+12 1 D
+-12 -1 D
+P
+FO
+5669 3922 M
+8 -1 D
+-8 -1 D
+0 -29 D
+8 1 D
+-3 2 D
+9 0 D
+2 2 D
+-15 1 D
+10 1 D
+3 2 D
+5 -2 D
+12 7 D
+4 -2 D
+6 3 D
+1 -1 D
+5 3 D
+19 1 D
+5 3 D
+8 -1 D
+8 3 D
+2 -2 D
+98 14 D
+12 0 D
+18 11 D
+-13 7 D
+-23 1 D
+-19 -2 D
+-24 -6 D
+3 -4 D
+-9 1 D
+-8 -2 D
+-6 0 D
+-5 -3 D
+-25 0 D
+-20 -3 D
+-3 2 D
+-6 -3 D
+-2 2 D
+-30 1 D
+-5 -3 D
+5 -2 D
+-8 -2 D
+-8 0 D
+8 3 D
+-14 0 D
+-5 -2 D
+P
+FO
+5829 3803 M
+-1 2 D
+-7 -6 D
+P
+FO
+5820 3796 M
+5 -5 D
+-4 8 D
+P
+FO
+5825 3791 M
+7 -3 D
+-4 4 D
+P
+FO
+5822 3799 M
+4 -1 D
+P
+FO
+5698 3928 M
+6 0 D
+P
+FO
+5913 3780 M
+-5 1 D
+2 2 D
+8 -2 D
+-4 -1 D
+10 0 D
+-1 1 D
+5 2 D
+2 -3 D
+35 0 D
+-1 0 D
+3 4 D
+-5 2 D
+9 3 D
+1 11 D
+-6 6 D
+-18 8 D
+13 6 D
+12 13 D
+-4 5 D
+5 5 D
+-30 5 D
+-38 -1 D
+0 -67 D
+P
+5967 3791 M
+1 -1 D
+P
+5933 3793 M
+2 -1 D
+P
+5913 3784 M
+13 0 D
+-6 -2 D
+P
+FO
+6142 3833 M
+-12 2 D
+-25 1 D
+3 -2 D
+-11 1 D
+-10 -4 D
+-5 1 D
+-1 -4 D
+12 1 D
+6 -2 D
+-5 -4 D
+-8 -1 D
+-18 6 D
+-22 -4 D
+7 -7 D
+34 -8 D
+8 3 D
+-2 -3 D
+9 0 D
+5 -8 D
+-14 2 D
+-6 4 D
+-38 1 D
+1 -1 D
+-16 3 D
+-5 3 D
+7 2 D
+-6 8 D
+11 10 D
+-5 6 D
+4 0 D
+-8 4 D
+3 2 D
+-11 3 D
+-4 -2 D
+4 -15 D
+-35 -9 D
+-1 -4 D
+-11 -5 D
+13 -5 D
+18 -15 D
+-15 -11 D
+1 -2 D
+148 0 D
+P
+6114 3812 M
+1 2 D
+7 -2 D
+-3 -1 D
+P
+6124 3810 M
+8 -2 D
+-8 -2 D
+P
+6135 3815 M
+2 -1 D
+P
+6036 3782 M
+3 -1 D
+-3 0 D
+P
+6130 3796 M
+5 1 D
+P
+6040 3798 M
+6 -1 D
+P
+6135 3804 M
+5 -1 D
+P
+FO
+5906 3851 M
+3 0 D
+-1 1 D
+8 -1 D
+29 3 D
+-6 4 D
+-2 -1 D
+-1 4 D
+-11 1 D
+-19 -2 D
+P
+FO
+6071 3836 M
+-1 -3 D
+20 0 D
+13 5 D
+-17 3 D
+P
+FO
+6047 3862 M
+-9 0 D
+-5 -3 D
+4 3 D
+5 -2 D
+P
+FO
+6132 3888 M
+-7 1 D
+-2 -2 D
+8 -1 D
+P
+FO
+6118 3850 M
+-8 -4 D
+21 -2 D
+-5 9 D
+P
+FO
+6003 3850 M
+12 -3 D
+2 5 D
+-8 1 D
+P
+FO
+6071 4006 M
+-21 1 D
+16 -4 D
+19 1 D
+P
+FO
+6127 3855 M
+-7 1 D
+-7 -1 D
+5 1 D
+P
+FO
+6068 3832 M
+2 -2 D
+P
+FO
+6050 3855 M
+14 -1 D
+P
+FO
+6048 3862 M
+17 -2 D
+P
+FO
+5973 3842 M
+3 -2 D
+-3 3 D
+P
+FO
+6047 3855 M
+0 -1 D
+P
+FO
+6221 3780 M
+-22 4 D
+6 -1 D
+6 5 D
+-3 1 D
+3 -1 D
+2 2 D
+3 9 D
+-7 3 D
+-10 -7 D
+5 -4 D
+-6 3 D
+-4 -5 D
+-5 4 D
+9 4 D
+-3 12 D
+18 4 D
+-1 3 D
+7 4 D
+-9 2 D
+-34 -2 D
+-14 9 D
+-20 4 D
+0 -53 D
+P
+6152 3809 M
+3 -1 D
+P
+6143 3804 M
+10 1 D
+-7 -3 D
+P
+6146 3811 M
+4 0 D
+P
+FO
+6320 3780 M
+4 2 D
+7 -1 D
+-4 -1 D
+51 0 D
+0 11 D
+0 -1 D
+-1 0 D
+1 120 D
+-5 -2 D
+-8 0 D
+-4 2 D
+5 0 D
+-5 0 D
+-12 -3 D
+7 0 D
+-11 -2 D
+3 -2 D
+-5 1 D
+-8 -1 D
+4 -2 D
+-5 -1 D
+-27 1 D
+0 -2 D
+20 -1 D
+-6 -2 D
+-3 2 D
+-6 -1 D
+5 -1 D
+-7 -2 D
+0 -3 D
+-5 1 D
+-3 -1 D
+5 -3 D
+-25 6 D
+6 -2 D
+-8 -1 D
+-1 -3 D
+25 -1 D
+-6 -1 D
+5 -2 D
+8 1 D
+-2 -4 D
+-1 1 D
+-6 -1 D
+6 3 D
+-10 1 D
+-12 -1 D
+6 -2 D
+-5 1 D
+-5 -1 D
+18 -2 D
+6 -5 D
+13 0 D
+-12 0 D
+6 -5 D
+-13 2 D
+-25 -2 D
+-8 -3 D
+-13 2 D
+-29 -3 D
+-71 -2 D
+3 -4 D
+-7 -3 D
+8 -2 D
+-9 -1 D
+7 -1 D
+-3 -1 D
+9 -3 D
+-4 -5 D
+4 -7 D
+25 -2 D
+6 -2 D
+1 1 D
+0 -5 D
+10 -5 D
+17 -1 D
+7 -5 D
+-12 -9 D
+15 -19 D
+-6 -3 D
+-13 0 D
+4 -6 D
+P
+6305 3867 M
+-4 -3 D
+-8 0 D
+P
+6345 3825 M
+6 0 D
+-4 -2 D
+P
+6349 3849 M
+0 2 D
+6 -2 D
+P
+6345 3823 M
+4 0 D
+-5 -2 D
+P
+6355 3847 M
+-3 1 D
+8 -1 D
+P
+6338 3844 M
+3 1 D
+-2 -2 D
+P
+6311 3866 M
+-5 -1 D
+P
+6326 3784 M
+-6 -1 D
+1 2 D
+P
+6327 3845 M
+-5 -1 D
+P
+6312 3869 M
+-8 -4 D
+8 5 D
+P
+6302 3867 M
+5 1 D
+-4 -1 D
+P
+FO
+6307 3894 M
+-6 1 D
+9 0 D
+-2 3 D
+-7 -2 D
+-5 1 D
+4 -2 D
+-10 1 D
+3 -2 D
+12 -1 D
+P
+FO
+6189 3902 M
+2 3 D
+7 0 D
+-7 5 D
+-2 -4 D
+-6 1 D
+-3 -2 D
+6 -4 D
+-2 3 D
+4 1 D
+P
+FO
+6283 3887 M
+7 -1 D
+-11 2 D
+-1 -3 D
+7 0 D
+-2 1 D
+P
+FO
+6264 3886 M
+5 -2 D
+7 3 D
+-9 1 D
+P
+FO
+6269 3878 M
+6 0 D
+-3 -1 D
+6 0 D
+P
+FO
+6213 3920 M
+-10 1 D
+-6 -1 D
+21 -1 D
+P
+FO
+6217 3796 M
+3 -1 D
+3 1 D
+-2 3 D
+P
+FO
+6247 3884 M
+9 -1 D
+-5 2 D
+9 1 D
+P
+FO
+6236 3874 M
+9 -1 D
+2 2 D
+-14 0 D
+P
+FO
+6360 3951 M
+3 -3 D
+5 1 D
+3 3 D
+P
+FO
+6295 3893 M
+3 -1 D
+6 1 D
+P
+FO
+6208 3784 M
+2 -1 D
+-1 2 D
+P
+FO
+6283 3893 M
+-4 2 D
+-1 -2 D
+P
+FO
+6221 3792 M
+4 -1 D
+1 2 D
+P
+FO
+6189 3918 M
+9 0 D
+-15 2 D
+P
+FO
+6215 3792 M
+5 2 D
+-3 2 D
+P
+FO
+6212 3784 M
+-2 1 D
+4 -3 D
+-1 2 D
+P
+FO
+6213 3802 M
+4 -3 D
+1 3 D
+P
+FO
+6214 3789 M
+6 2 D
+-2 1 D
+P
+FO
+6262 3892 M
+15 -1 D
+-5 2 D
+P
+FO
+6201 3803 M
+0 -2 D
+4 2 D
+P
+FO
+6189 3900 M
+4 -1 D
+0 2 D
+P
+FO
+6191 3792 M
+4 1 D
+P
+FO
+6212 3876 M
+15 0 D
+-7 1 D
+P
+FO
+6208 3876 M
+-5 2 D
+-5 -2 D
+P
+FO
+6197 3801 M
+2 -1 D
+2 2 D
+P
+FO
+6200 3798 M
+7 4 D
+P
+FO
+6351 3945 M
+4 3 D
+-6 -1 D
+P
+FO
+6222 3789 M
+5 3 D
+P
+FO
+6222 3788 M
+5 2 D
+P
+FO
+6194 3794 M
+2 1 D
+P
+FO
+6265 3884 M
+10 0 D
+P
+FO
+6194 3957 M
+11 -1 D
+P
+FO
+6147 3862 M
+5 1 D
+P
+FO
+6194 3792 M
+3 2 D
+P
+FO
+6296 3873 M
+8 0 D
+P
+FO
+6213 3801 M
+-1 2 D
+0 -2 D
+P
+FO
+6217 3797 M
+1 2 D
+P
+FO
+6206 3784 M
+3 -1 D
+P
+FO
+6307 3874 M
+-3 1 D
+P
+FO
+6298 3876 M
+5 0 D
+P
+FO
+6261 3881 M
+5 0 D
+P
+FO
+6366 3911 M
+5 -1 D
+P
+FO
+6192 3904 M
+1 -1 D
+P
+FO
+6272 3895 M
+5 0 D
+P
+FO
+6614 3818 M
+-13 -2 D
+3 -2 D
+-4 2 D
+14 3 D
+0 46 D
+-4 0 D
+4 0 D
+0 16 D
+-5 0 D
+-1 2 D
+-15 1 D
+21 -1 D
+0 49 D
+-5 -1 D
+-21 2 D
+5 -4 D
+12 -2 D
+6 -5 D
+-3 2 D
+-7 -1 D
+4 2 D
+-8 -1 D
+2 2 D
+-13 0 D
+0 1 D
+-20 -3 D
+7 -1 D
+-17 -1 D
+8 -2 D
+-10 1 D
+-7 -2 D
+4 3 D
+-22 -5 D
+7 4 D
+-7 1 D
+-16 -5 D
+-4 1 D
+14 6 D
+-16 1 D
+-9 -2 D
+-11 2 D
+5 -1 D
+-8 -1 D
+-18 1 D
+8 -2 D
+-14 -1 D
+-5 3 D
+-1 -2 D
+-7 0 D
+-2 -4 D
+11 3 D
+3 -3 D
+3 2 D
+2 -2 D
+11 2 D
+0 -1 D
+-49 -5 D
+-8 1 D
+0 -3 D
+-11 0 D
+1 2 D
+-6 -2 D
+-2 2 D
+-18 -2 D
+-4 -2 D
+0 -119 D
+1 1 D
+-1 -12 D
+236 0 D
+P
+6594 3835 M
+9 2 D
+9 -1 D
+2 -3 D
+-16 -3 D
+0 2 D
+4 0 D
+-9 3 D
+P
+6586 3833 M
+2 1 D
+5 -2 D
+-5 -2 D
+P
+6557 3867 M
+5 0 D
+-7 -1 D
+P
+6606 3875 M
+4 5 D
+4 -7 D
+P
+6415 3815 M
+0 -1 D
+-1 1 D
+P
+6385 3839 M
+-2 -1 D
+P
+6430 3872 M
+-6 -3 D
+2 2 D
+P
+6529 3833 M
+-8 -1 D
+P
+6503 3826 M
+-4 0 D
+P
+6382 3834 M
+4 1 D
+P
+6611 3921 M
+-2 -2 D
+P
+6594 3831 M
+-1 -1 D
+P
+6379 3839 M
+1 1 D
+P
+FO
+6614 3976 M
+-15 -7 D
+5 -2 D
+10 1 D
+P
+FO
+6614 3990 M
+-1 4 D
+-18 5 D
+10 -2 D
+5 1 D
+4 8 D
+0 6 D
+-12 4 D
+-19 0 D
+-5 -5 D
+-19 1 D
+9 4 D
+-78 0 D
+-11 -1 D
+10 -4 D
+-17 -1 D
+-16 -5 D
+-10 0 D
+13 -2 D
+11 4 D
+-5 -4 D
+16 0 D
+7 -9 D
+10 -2 D
+13 2 D
+8 -2 D
+22 0 D
+15 -5 D
+21 -1 D
+26 1 D
+P
+6559 4001 M
+7 0 D
+-11 -1 D
+-5 3 D
+P
+6534 4010 M
+12 0 D
+P
+FO
+6614 4002 M
+0 -1 D
+P
+FO
+6614 4006 M
+P
+FO
+6474 4016 M
+-4 -1 D
+8 1 D
+-1 0 D
+1 0 D
+P
+FO
+6466 4016 M
+P
+FO
+6402 4016 M
+3 -4 D
+28 -2 D
+-9 -2 D
+-18 2 D
+1 -2 D
+11 -1 D
+31 1 D
+19 6 D
+-15 2 D
+P
+FO
+6520 3928 M
+-11 -2 D
+-5 2 D
+-1 -2 D
+25 -2 D
+3 4 D
+3 -3 D
+2 2 D
+-8 2 D
+-5 -2 D
+P
+FO
+6517 3945 M
+-5 -2 D
+18 3 D
+2 3 D
+-30 -5 D
+P
+FO
+6496 3936 M
+9 0 D
+-6 2 D
+-8 -2 D
+P
+FO
+6543 3921 M
+9 3 D
+-16 -3 D
+P
+FO
+6520 3935 M
+5 -1 D
+5 3 D
+-11 -2 D
+P
+FO
+6537 3926 M
+9 2 D
+-6 2 D
+-5 -4 D
+P
+FO
+6449 4001 M
+-8 2 D
+-21 -1 D
+P
+FO
+6547 3939 M
+7 -1 D
+5 2 D
+P
+FO
+6496 3925 M
+6 0 D
+-2 1 D
+P
+FO
+6402 4005 M
+-1 0 D
+-10 0 D
+30 -3 D
+P
+FO
+6560 3941 M
+4 -2 D
+1 2 D
+P
+FO
+6550 3937 M
+1 -2 D
+3 3 D
+P
+FO
+6482 3938 M
+3 -1 D
+P
+FO
+6483 3926 M
+11 -1 D
+2 2 D
+P
+FO
+6518 3943 M
+12 0 D
+P
+FO
+6506 3936 M
+10 0 D
+-10 1 D
+P
+FO
+6472 3934 M
+11 0 D
+P
+FO
+6425 3960 M
+1 -1 D
+0 1 D
+P
+FO
+6528 3929 M
+10 0 D
+P
+FO
+6520 3937 M
+-1 1 D
+P
+FO
+6430 3995 M
+16 -1 D
+P
+FO
+6520 3943 M
+-6 0 D
+P
+FO
+6511 3938 M
+4 -1 D
+P
+FO
+6479 3936 M
+6 0 D
+P
+FO
+6496 3931 M
+3 1 D
+P
+FO
+6486 3936 M
+5 0 D
+P
+FO
+6850 3862 M
+-5 -1 D
+-13 3 D
+5 -4 D
+-4 2 D
+0 -2 D
+-24 -3 D
+3 -2 D
+-36 -2 D
+-12 2 D
+-2 -6 D
+-18 -5 D
+-6 1 D
+11 3 D
+10 9 D
+16 1 D
+9 5 D
+-4 2 D
+26 0 D
+21 9 D
+22 5 D
+1 2 D
+-10 0 D
+10 1 D
+0 55 D
+-13 2 D
+-7 -1 D
+-26 1 D
+-8 -6 D
+-28 0 D
+-2 2 D
+6 -1 D
+3 4 D
+17 5 D
+-15 3 D
+-1 -1 D
+-15 1 D
+-18 -1 D
+9 1 D
+3 2 D
+-20 -2 D
+-22 1 D
+29 3 D
+11 3 D
+-6 0 D
+17 1 D
+-9 4 D
+-13 0 D
+-13 3 D
+-11 -1 D
+-6 2 D
+-7 -3 D
+-11 1 D
+-48 -13 D
+-10 -5 D
+9 -4 D
+-8 -4 D
+4 -2 D
+-4 2 D
+-23 -2 D
+0 -49 D
+14 5 D
+-5 5 D
+-8 2 D
+10 1 D
+2 3 D
+-12 0 D
+0 2 D
+13 -2 D
+-4 -4 D
+4 -3 D
+18 -3 D
+40 0 D
+19 4 D
+8 0 D
+6 2 D
+-10 -1 D
+-5 2 D
+9 5 D
+8 -1 D
+5 -4 D
+25 -2 D
+-43 -3 D
+0 -2 D
+-30 -2 D
+2 -2 D
+-20 1 D
+6 -6 D
+-5 -1 D
+-16 4 D
+1 3 D
+-18 -2 D
+13 0 D
+10 -10 D
+0 -4 D
+-15 0 D
+5 5 D
+-8 6 D
+-19 0 D
+0 -62 D
+35 3 D
+22 5 D
+15 9 D
+25 2 D
+2 3 D
+21 4 D
+-19 -4 D
+-4 -3 D
+-23 -2 D
+-15 -9 D
+-8 -2 D
+1 -3 D
+19 -6 D
+-10 2 D
+-13 6 D
+-15 -3 D
+-29 -2 D
+-4 -1 D
+0 -38 D
+236 0 D
+P
+6785 3886 M
+-7 1 D
+1 3 D
+14 -3 D
+P
+6634 3850 M
+2 2 D
+6 0 D
+-1 -3 D
+P
+6779 3876 M
+-11 2 D
+16 2 D
+4 -4 D
+P
+6727 3887 M
+4 1 D
+-3 -2 D
+P
+6744 3885 M
+10 2 D
+-2 -2 D
+P
+6624 3855 M
+-3 1 D
+8 -1 D
+P
+6718 3885 M
+0 1 D
+1 -3 D
+P
+6701 3883 M
+3 -1 D
+-6 0 D
+P
+6722 3890 M
+5 -1 D
+P
+6693 3869 M
+4 -1 D
+-5 1 D
+P
+6726 3877 M
+3 -1 D
+-4 1 D
+P
+6845 3853 M
+0 -2 D
+P
+6779 3882 M
+-1 -1 D
+P
+6638 3866 M
+0 -2 D
+P
+6843 3847 M
+-3 0 D
+P
+6739 3886 M
+-5 0 D
+P
+6842 3852 M
+-1 -3 D
+-5 1 D
+P
+6618 3835 M
+1 -2 D
+P
+6796 3886 M
+4 -2 D
+-4 -1 D
+P
+6706 3870 M
+-7 0 D
+2 1 D
+P
+6698 3867 M
+4 -1 D
+-5 1 D
+P
+FO
+6850 3874 M
+-10 -4 D
+3 -4 D
+7 0 D
+P
+FO
+6614 4006 M
+3 5 D
+-3 1 D
+P
+FO
+6614 4006 M
+9 2 D
+-6 1 D
+P
+FO
+6614 4001 M
+1 1 D
+-1 0 D
+P
+FO
+6614 3990 M
+P
+FO
+6614 3968 M
+8 0 D
+29 6 D
+14 -2 D
+14 1 D
+3 -1 D
+6 2 D
+42 1 D
+13 5 D
+-3 7 D
+-9 2 D
+-6 -3 D
+-19 10 D
+-17 -4 D
+-4 1 D
+-5 -5 D
+-8 0 D
+18 11 D
+-17 3 D
+-4 -6 D
+-11 5 D
+-13 -4 D
+3 -2 D
+-9 -2 D
+14 -2 D
+-15 1 D
+-5 -4 D
+10 -2 D
+-14 1 D
+-7 -4 D
+6 0 D
+-14 -7 D
+P
+FO
+6779 3970 M
+15 0 D
+-2 -1 D
+6 3 D
+-29 -1 D
+P
+FO
+6785 3950 M
+12 1 D
+0 2 D
+-7 0 D
+P
+FO
+6759 3973 M
+16 1 D
+1 2 D
+P
+FO
+6750 3848 M
+3 1 D
+P
+FO
+6713 3992 M
+5 1 D
+P
+FO
+6780 3955 M
+-11 -1 D
+P
+FO
+6783 3865 M
+5 0 D
+P
+FO
+6749 3848 M
+4 1 D
+P
+FO
+7087 3851 M
+-3 0 D
+-1 -2 D
+-6 3 D
+-28 4 D
+0 4 D
+13 1 D
+-2 2 D
+-75 4 D
+-51 -5 D
+15 -4 D
+-9 0 D
+-7 -3 D
+2 3 D
+-9 3 D
+6 5 D
+-14 8 D
+3 -6 D
+-16 -1 D
+-23 4 D
+-2 3 D
+8 1 D
+-9 0 D
+-4 -3 D
+-25 2 D
+0 -8 D
+8 0 D
+9 3 D
+8 -2 D
+-13 -2 D
+-12 -3 D
+0 -82 D
+237 0 D
+P
+7052 3841 M
+4 -1 D
+-9 0 D
+P
+7044 3861 M
+2 1 D
+P
+6936 3851 M
+4 1 D
+-3 -1 D
+P
+FO
+7087 3851 M
+-1 0 D
+P
+FO
+7087 3854 M
+-5 -2 D
+5 1 D
+P
+FO
+6850 3882 M
+5 0 D
+4 4 D
+17 1 D
+9 3 D
+9 -1 D
+8 5 D
+14 2 D
+19 7 D
+4 6 D
+-9 1 D
+-2 3 D
+-11 -3 D
+2 5 D
+-13 2 D
+17 -2 D
+-1 -2 D
+13 0 D
+0 -3 D
+8 7 D
+-3 3 D
+-7 -2 D
+-5 10 D
+-8 -1 D
+9 -3 D
+-6 1 D
+-3 -3 D
+-7 1 D
+6 1 D
+-2 2 D
+-6 0 D
+6 3 D
+-11 3 D
+-9 -2 D
+6 2 D
+-14 4 D
+-5 -1 D
+6 2 D
+-14 0 D
+0 2 D
+-20 0 D
+-3 -2 D
+-3 0 D
+P
+6910 3904 M
+6 -1 D
+P
+FO
+6897 3882 M
+-9 0 D
+0 -2 D
+30 -4 D
+15 7 D
+-7 3 D
+-27 1 D
+-1 -5 D
+P
+FO
+6925 3930 M
+7 0 D
+-5 2 D
+P
+FO
+6897 3935 M
+15 -4 D
+-2 5 D
+P
+FO
+6876 3881 M
+3 -1 D
+P
+FO
+7055 3858 M
+4 1 D
+P
+FO
+7076 3854 M
+3 1 D
+P
+FO
+7080 3853 M
+3 -1 D
+P
+FO
+6937 3859 M
+4 -1 D
+P
+FO
+6992 3882 M
+0 -1 D
+P
+FO
+6921 3932 M
+5 0 D
+P
+FO
+7077 3853 M
+3 -2 D
+P
+FO
+7213 3780 M
+15 4 D
+-6 6 D
+5 2 D
+22 0 D
+16 7 D
+-8 8 D
+2 6 D
+7 -14 D
+-15 -7 D
+-21 0 D
+-5 -2 D
+7 -4 D
+-10 -6 D
+101 0 D
+0 25 D
+-7 0 D
+1 3 D
+-7 2 D
+-6 7 D
+-7 0 D
+0 2 D
+11 2 D
+5 -1 D
+-11 7 D
+3 -5 D
+-8 -2 D
+-14 9 D
+5 2 D
+9 -3 D
+11 1 D
+-7 1 D
+11 2 D
+-10 0 D
+10 2 D
+-3 3 D
+-23 2 D
+6 2 D
+9 -1 D
+0 2 D
+6 -1 D
+3 1 D
+-10 2 D
+9 1 D
+-6 1 D
+5 1 D
+-11 2 D
+5 2 D
+-11 0 D
+2 2 D
+-6 -1 D
+8 3 D
+-7 0 D
+5 1 D
+-5 0 D
+-11 -1 D
+6 2 D
+-7 0 D
+4 2 D
+-7 -2 D
+3 3 D
+-18 -3 D
+2 2 D
+-2 2 D
+-2 -3 D
+-1 3 D
+-1 -3 D
+-5 2 D
+4 -3 D
+-4 0 D
+-2 4 D
+-12 -4 D
+1 2 D
+-6 1 D
+6 1 D
+2 -1 D
+-2 3 D
+-7 -2 D
+-2 2 D
+-3 -3 D
+-8 4 D
+-7 -2 D
+-1 5 D
+-3 -2 D
+0 2 D
+-2 -1 D
+0 1 D
+-11 0 D
+-1 2 D
+-10 -5 D
+-9 1 D
+2 2 D
+-4 -2 D
+-3 1 D
+-2 -4 D
+4 -2 D
+-3 1 D
+-3 -1 D
+7 -1 D
+-3 -2 D
+8 -2 D
+-7 -1 D
+8 -1 D
+-3 -1 D
+-3 1 D
+-1 -2 D
+-1 2 D
+-5 -5 D
+-16 3 D
+7 -4 D
+-13 3 D
+-5 -1 D
+2 -1 D
+-10 2 D
+-15 -1 D
+-26 2 D
+0 -71 D
+P
+7100 3848 M
+12 -3 D
+11 1 D
+9 -5 D
+43 -12 D
+-3 -5 D
+5 -3 D
+-28 -10 D
+-4 -7 D
+2 6 D
+28 11 D
+-4 3 D
+3 4 D
+-42 12 D
+-10 5 D
+-12 0 D
+-10 2 D
+P
+7220 3855 M
+-3 -1 D
+P
+7246 3833 M
+0 2 D
+P
+7179 3845 M
+4 -1 D
+P
+7198 3842 M
+-3 0 D
+P
+7244 3831 M
+-2 4 D
+P
+7255 3825 M
+0 -1 D
+-5 3 D
+P
+FO
+7087 3853 M
+6 1 D
+-6 0 D
+P
+FO
+7087 3851 M
+8 1 D
+0 1 D
+-8 -2 D
+P
+FO
+7220 3863 M
+5 -1 D
+1 4 D
+-6 -2 D
+P
+FO
+7299 3853 M
+-3 -2 D
+7 1 D
+P
+FO
+7174 3868 M
+2 -1 D
+2 1 D
+P
+FO
+7189 3871 M
+5 -1 D
+6 2 D
+P
+FO
+7252 3860 M
+2 2 D
+P
+FO
+7175 3865 M
+3 2 D
+P
+FO
+7279 3855 M
+7 1 D
+P
+FO
+7261 3860 M
+2 -1 D
+P
+FO
+7279 3857 M
+5 2 D
+P
+FO
+7296 3827 M
+-4 0 D
+P
+FO
+7241 3859 M
+2 2 D
+-2 -1 D
+P
+FO
+7147 3849 M
+3 0 D
+P
+FO
+7291 3829 M
+4 -1 D
+P
+FO
+7291 3840 M
+4 0 D
+P
+FO
+7276 3859 M
+3 1 D
+-4 -1 D
+P
+FO
+7181 3869 M
+3 0 D
+P
+FO
+7164 3858 M
+2 -3 D
+P
+FO
+7289 3830 M
+3 0 D
+P
+FO
+7289 3826 M
+5 -1 D
+P
+FO
+7305 3849 M
+4 0 D
+P
+FO
+7306 3839 M
+4 -1 D
+P
+FO
+7291 3840 M
+3 -1 D
+P
+FO
+7270 3859 M
+3 1 D
+-4 -1 D
+P
+FO
+7236 3858 M
+2 1 D
+P
+FO
+7163 3865 M
+3 2 D
+P
+FO
+7307 3849 M
+5 0 D
+P
+FO
+7270 3860 M
+3 1 D
+P
+FO
+7293 3853 M
+4 0 D
+P
+FO
+7300 3840 M
+5 0 D
+P
+FO
+7252 3860 M
+2 -1 D
+P
+FO
+7292 3830 M
+4 -1 D
+P
+FO
+7292 3839 M
+3 0 D
+P
+FO
+7302 3851 M
+4 0 D
+P
+FO
+7162 3860 M
+2 -2 D
+P
+FO
+7160 3871 M
+3 1 D
+P
+FO
+7302 3841 M
+3 0 D
+P
+FO
+7308 3823 M
+1 0 D
+-1 1 D
+P
+FO
+7299 3840 M
+-3 0 D
+P
+FO
+7168 3867 M
+2 1 D
+P
+FO
+7292 3851 M
+5 2 D
+P
+FO
+7264 3859 M
+7 2 D
+-7 -1 D
+P
+FO
+7289 3827 M
+6 -2 D
+P
+FO
+7305 3830 M
+7 0 D
+P
+FO
+7143 3852 M
+-2 -2 D
+P
+FO
+7181 3868 M
+0 -2 D
+P
+FO
+7291 3827 M
+6 -1 D
+P
+FO
+5 1 1 7218 3780 SP
+-1 1 0 1 2 7230 3785 SP
+7559 3814 M
+-14 1 D
+-5 -2 D
+-2 4 D
+-7 1 D
+-8 -3 D
+-2 2 D
+-6 0 D
+-8 -5 D
+12 -3 D
+-7 -1 D
+-4 1 D
+-1 -1 D
+8 -2 D
+-6 0 D
+-3 4 D
+-6 -1 D
+1 3 D
+-6 -1 D
+-11 5 D
+-5 -2 D
+0 1 D
+-5 0 D
+3 1 D
+-12 2 D
+-25 -3 D
+-3 -4 D
+-24 2 D
+-25 8 D
+1 4 D
+7 1 D
+6 -3 D
+-5 3 D
+-8 0 D
+-12 -7 D
+-9 -10 D
+6 -1 D
+-9 -1 D
+5 0 D
+-6 -1 D
+-7 -10 D
+-9 0 D
+-6 6 D
+-5 -3 D
+-9 3 D
+-2 3 D
+-3 0 D
+0 -25 D
+236 0 D
+P
+7516 3801 M
+4 0 D
+2 -2 D
+-7 2 D
+P
+7525 3813 M
+1 1 D
+2 -2 D
+P
+7506 3797 M
+0 -2 D
+P
+7523 3806 M
+-1 -2 D
+P
+7523 3815 M
+0 -1 D
+P
+7545 3806 M
+0 -1 D
+-1 2 D
+P
+7521 3814 M
+1 -1 D
+P
+7507 3802 M
+0 -2 D
+P
+7516 3802 M
+4 0 D
+P
+7490 3792 M
+-1 0 D
+3 1 D
+P
+7509 3805 M
+4 0 D
+P
+7508 3800 M
+-13 -1 D
+P
+7509 3804 M
+-10 1 D
+P
+FO
+7559 3823 M
+-7 0 D
+0 -4 D
+7 -4 D
+P
+FO
+7559 3831 M
+-2 0 D
+-7 -6 D
+-7 0 D
+16 -1 D
+P
+FO
+7559 3834 M
+-14 1 D
+-7 -2 D
+7 -3 D
+14 3 D
+P
+FO
+7559 3838 M
+-10 0 D
+-5 -2 D
+15 0 D
+P
+FO
+7559 3860 M
+-5 0 D
+5 -2 D
+P
+FO
+7559 3918 M
+-4 0 D
+4 2 D
+-17 3 D
+-2 3 D
+-10 0 D
+-5 -4 D
+-1 3 D
+-13 -4 D
+5 2 D
+0 -2 D
+-15 -1 D
+-1 -5 D
+3 1 D
+3 -1 D
+-12 1 D
+-6 -5 D
+5 -1 D
+-4 2 D
+6 0 D
+-2 -5 D
+7 -1 D
+-12 0 D
+-1 -2 D
+29 -12 D
+23 -3 D
+13 5 D
+-5 2 D
+5 2 D
+7 -5 D
+P
+FO
+7465 3907 M
+7 5 D
+-11 6 D
+-6 -11 D
+P
+FO
+7489 3815 M
+16 -2 D
+7 2 D
+-13 2 D
+-10 -1 D
+P
+FO
+7521 3819 M
+6 -1 D
+4 2 D
+P
+FO
+7469 3874 M
+-17 6 D
+17 -9 D
+P
+FO
+7519 3823 M
+6 0 D
+P
+FO
+7492 3814 M
+6 -1 D
+P
+FO
+7490 3814 M
+4 -1 D
+P
+FO
+7446 3817 M
+3 0 D
+P
+FO
+7323 3817 M
+0 -2 D
+P
+FO
+7736 3780 M
+-6 2 D
+4 1 D
+0 5 D
+12 6 D
+18 2 D
+2 3 D
+17 2 D
+12 7 D
+0 11 D
+-27 0 D
+6 2 D
+-4 1 D
+6 0 D
+5 2 D
+8 -3 D
+6 3 D
+0 2 D
+-11 5 D
+-12 2 D
+-3 -1 D
+2 1 D
+-14 2 D
+-30 -1 D
+-23 -12 D
+-18 -3 D
+-1 -3 D
+0 3 D
+-9 -1 D
+-1 3 D
+8 2 D
+-5 3 D
+7 -2 D
+12 1 D
+-5 4 D
+4 3 D
+-7 1 D
+9 -1 D
+-1 -2 D
+5 2 D
+-2 -4 D
+1 3 D
+7 -1 D
+-8 -2 D
+0 -4 D
+23 10 D
+-41 -1 D
+-16 -3 D
+-7 3 D
+6 -1 D
+7 4 D
+12 1 D
+2 -2 D
+35 0 D
+-60 7 D
+-56 2 D
+-25 3 D
+-3 -2 D
+13 -4 D
+-18 -3 D
+-13 0 D
+0 -2 D
+6 -1 D
+-4 -1 D
+-2 0 D
+0 -1 D
+5 0 D
+-3 -1 D
+5 -1 D
+-7 0 D
+0 -7 D
+2 -1 D
+-2 0 D
+0 -8 D
+3 -2 D
+-3 1 D
+0 -34 D
+P
+7770 3827 M
+1 3 D
+4 1 D
+5 -4 D
+-5 -3 D
+P
+7599 3839 M
+-3 2 D
+14 -1 D
+-7 -3 D
+P
+7631 3822 M
+8 -2 D
+-2 -2 D
+-7 2 D
+P
+7780 3826 M
+3 2 D
+3 -2 D
+-8 -1 D
+P
+7787 3815 M
+-2 -2 D
+-2 2 D
+P
+7724 3804 M
+6 1 D
+0 -2 D
+P
+7712 3802 M
+2 2 D
+2 -2 D
+P
+7716 3808 M
+-1 -2 D
+-3 0 D
+P
+7735 3803 M
+4 0 D
+-4 -2 D
+P
+7667 3797 M
+-1 -2 D
+-4 1 D
+P
+7609 3801 M
+0 -1 D
+-4 1 D
+P
+7743 3802 M
+-2 -1 D
+P
+7665 3821 M
+-1 -2 D
+P
+7729 3810 M
+4 0 D
+P
+7734 3808 M
+4 0 D
+P
+7617 3804 M
+2 -2 D
+P
+7658 3819 M
+2 -2 D
+P
+7741 3813 M
+0 -2 D
+P
+7597 3814 M
+3 1 D
+-3 -2 D
+P
+7638 3815 M
+-3 -1 D
+P
+7761 3807 M
+4 -1 D
+P
+7721 3806 M
+0 -2 D
+P
+7647 3805 M
+-4 1 D
+P
+7709 3790 M
+2 -1 D
+P
+7688 3836 M
+0 2 D
+P
+7709 3805 M
+-2 -2 D
+1 2 D
+P
+7713 3833 M
+4 -1 D
+P
+7711 3832 M
+-4 0 D
+P
+7781 3817 M
+1 1 D
+P
+7674 3797 M
+-3 1 D
+P
+7763 3812 M
+-1 -1 D
+P
+7633 3806 M
+-3 -1 D
+P
+7681 3792 M
+-3 -1 D
+P
+7750 3802 M
+2 -1 D
+-3 1 D
+P
+7708 3786 M
+-2 -1 D
+P
+7700 3801 M
+2 1 D
+P
+7717 3805 M
+2 -2 D
+P
+7681 3805 M
+-2 -1 D
+P
+7710 3802 M
+-2 -1 D
+P
+7781 3815 M
+1 1 D
+P
+7642 3819 M
+3 1 D
+P
+7635 3810 M
+-2 -1 D
+P
+7624 3836 M
+2 -1 D
+P
+7708 3788 M
+2 -1 D
+P
+FO
+7795 3808 M
+-11 -8 D
+-17 -1 D
+-2 -3 D
+-19 -2 D
+-11 -9 D
+3 -5 D
+57 0 D
+P
+FO
+7795 3822 M
+-3 -1 D
+3 0 D
+P
+FO
+7795 3903 M
+-14 1 D
+-17 -2 D
+-5 1 D
+2 4 D
+-22 1 D
+-16 -3 D
+-11 6 D
+-8 -8 D
+51 -11 D
+40 1 D
+P
+FO
+7559 3920 M
+P
+FO
+7559 3893 M
+53 5 D
+3 -2 D
+-12 0 D
+13 -3 D
+8 2 D
+20 0 D
+0 3 D
+-20 1 D
+-12 5 D
+-1 8 D
+-5 0 D
+7 1 D
+-7 0 D
+10 0 D
+0 2 D
+15 -2 D
+-12 -7 D
+20 -7 D
+24 0 D
+14 5 D
+-2 5 D
+12 0 D
+-37 8 D
+-26 0 D
+-32 8 D
+8 -4 D
+-17 1 D
+-3 -7 D
+6 -2 D
+-13 -1 D
+-1 4 D
+-13 2 D
+P
+7605 3913 M
+-6 -1 D
+P
+FO
+7559 3858 M
+17 2 D
+21 -3 D
+33 -2 D
+14 1 D
+-2 5 D
+-21 9 D
+-13 2 D
+-23 -2 D
+-5 -6 D
+-13 -3 D
+-8 -1 D
+P
+FO
+7583 3874 M
+1 6 D
+-18 0 D
+2 -8 D
+P
+FO
+7771 3937 M
+7 -1 D
+5 3 D
+-23 -3 D
+P
+FO
+7711 3828 M
+3 1 D
+P
+FO
+7596 3896 M
+7 0 D
+P
+FO
+7731 3835 M
+5 0 D
+P
+FO
+7572 3914 M
+6 -1 D
+P
+FO
+7728 3835 M
+4 0 D
+P
+FO
+7588 3923 M
+3 0 D
+P
+FO
+8028 3780 M
+3 2 D
+-7 0 D
+7 1 D
+0 7 D
+-9 6 D
+-23 6 D
+-6 -2 D
+3 2 D
+-44 3 D
+0 -2 D
+-2 2 D
+-15 0 D
+-54 -6 D
+-26 0 D
+-21 4 D
+11 0 D
+-8 2 D
+5 0 D
+-9 6 D
+-12 2 D
+-11 -3 D
+1 5 D
+-14 0 D
+5 1 D
+-6 0 D
+1 2 D
+-2 1 D
+0 -11 D
+1 0 D
+-1 0 D
+0 -28 D
+P
+8008 3791 M
+-3 0 D
+-3 2 D
+6 0 D
+P
+8003 3780 M
+-6 3 D
+10 -1 D
+P
+7832 3800 M
+-1 1 D
+P
+7880 3794 M
+4 -1 D
+P
+8028 3784 M
+-5 -1 D
+P
+8015 3783 M
+-2 1 D
+P
+7819 3811 M
+0 -2 D
+P
+8011 3791 M
+2 2 D
+P
+8007 3789 M
+5 0 D
+P
+7816 3809 M
+-1 2 D
+P
+8006 3784 M
+-2 1 D
+3 -1 D
+P
+8019 3791 M
+4 0 D
+P
+7873 3798 M
+4 -1 D
+P
+7830 3798 M
+4 -1 D
+P
+8000 3795 M
+2 1 D
+P
+7841 3796 M
+0 -1 D
+-1 1 D
+P
+8001 3789 M
+-2 2 D
+P
+7810 3796 M
+2 -1 D
+P
+FO
+7795 3893 M
+15 2 D
+9 6 D
+-11 -1 D
+-13 3 D
+P
+FO
+7795 3824 M
+2 1 D
+-2 1 D
+P
+FO
+7795 3821 M
+0 1 D
+P
+FO
+7855 3924 M
+6 -1 D
+3 3 D
+P
+FO
+7806 3816 M
+3 0 D
+P
+FO
+7811 3813 M
+5 0 D
+P
+FO
+7822 3812 M
+7 0 D
+-7 1 D
+P
+FO
+7811 3815 M
+1 -1 D
+P
+FO
+8031 3783 M
+3 2 D
+-3 5 D
+P
+FO
+8042 3801 M
+2 -2 D
+6 -1 D
+P
+FO
+8067 3798 M
+5 -2 D
+0 2 D
+P
+FO
+8085 3795 M
+6 0 D
+P
+FO
+8065 3801 M
+4 -1 D
+P
+FO
+8322 3780 M
+-41 2 D
+0 -2 D
+P
+FO
+8504 3815 M
+-11 -2 D
+-21 -8 D
+4 -7 D
+28 4 D
+P
+FO
+0 3802 M
+2 1 D
+10 -3 D
+38 4 D
+11 5 D
+-29 8 D
+-25 0 D
+-7 -2 D
+P
+FO
+47 3814 M
+-4 1 D
+8 -3 D
+P
+FO
+98 3813 M
+6 -1 D
+P
+FO
+15 3817 M
+7 0 D
+P
+FO
+24 3817 M
+-6 1 D
+P
+FO
+410 3780 M
+3 1 D
+-3 -1 D
+P
+FO
+472 3788 M
+-4 0 D
+4 2 D
+0 1 D
+-4 -1 D
+4 1 D
+0 2 D
+-3 1 D
+-20 -7 D
+2 -1 D
+-3 1 D
+-24 -4 D
+8 1 D
+-4 1 D
+5 0 D
+-6 1 D
+-9 -4 D
+1 -2 D
+-5 1 D
+-2 -1 D
+60 0 D
+P
+FO
+472 3795 M
+-2 -1 D
+2 0 D
+P
+FO
+442 3786 M
+5 1 D
+-5 0 D
+P
+FO
+413 3782 M
+10 4 D
+P
+FO
+426 3787 M
+16 -1 D
+P
+FO
+709 3790 M
+-7 -1 D
+-2 2 D
+-10 0 D
+-7 -2 D
+-2 1 D
+-1 -2 D
+-5 2 D
+-13 0 D
+6 3 D
+-21 -1 D
+13 1 D
+-12 1 D
+7 5 D
+-10 1 D
+0 -2 D
+-2 2 D
+-11 1 D
+-16 -1 D
+-6 -2 D
+-14 2 D
+5 3 D
+-9 3 D
+-2 -2 D
+-1 2 D
+0 -1 D
+-2 1 D
+-3 -1 D
+2 -2 D
+-8 -1 D
+5 -4 D
+-5 2 D
+-11 -3 D
+2 2 D
+-6 0 D
+5 2 D
+-6 0 D
+11 2 D
+4 4 D
+-8 1 D
+-4 -1 D
+0 2 D
+-13 2 D
+6 1 D
+-3 0 D
+-12 -5 D
+1 -1 D
+-3 1 D
+-17 -7 D
+-19 -2 D
+-11 1 D
+3 -1 D
+-7 -1 D
+-2 2 D
+5 0 D
+-5 1 D
+-7 -2 D
+-9 -3 D
+0 -1 D
+7 -3 D
+-2 0 D
+-1 -4 D
+-4 1 D
+0 -8 D
+237 0 D
+P
+624 3790 M
+-10 2 D
+-6 4 D
+15 1 D
+16 -3 D
+-14 -4 D
+P
+616 3795 M
+-3 -1 D
+4 -1 D
+P
+593 3801 M
+-2 2 D
+P
+607 3792 M
+-2 2 D
+P
+563 3797 M
+0 1 D
+P
+559 3786 M
+0 2 D
+P
+634 3797 M
+1 2 D
+P
+547 3798 M
+0 1 D
+P
+609 3783 M
+-1 1 D
+P
+570 3805 M
+1 1 D
+P
+637 3796 M
+-1 1 D
+P
+584 3800 M
+1 1 D
+P
+642 3795 M
+-1 1 D
+P
+538 3801 M
+0 1 D
+1 -1 D
+P
+638 3798 M
+1 1 D
+0 -1 D
+P
+493 3785 M
+0 1 D
+1 -1 D
+P
+551 3790 M
+-2 2 D
+P
+554 3793 M
+-1 2 D
+P
+550 3803 M
+0 2 D
+1 -2 D
+P
+573 3806 M
+-1 1 D
+2 -1 D
+P
+576 3782 M
+0 2 D
+P
+545 3804 M
+0 -1 D
+-1 2 D
+P
+567 3804 M
+0 1 D
+P
+484 3784 M
+0 1 D
+1 -1 D
+P
+557 3786 M
+0 -1 D
+-2 2 D
+P
+541 3802 M
+0 1 D
+P
+554 3804 M
+1 3 D
+P
+595 3802 M
+-2 3 D
+P
+624 3799 M
+-3 1 D
+P
+564 3804 M
+-1 2 D
+P
+558 3801 M
+6 2 D
+-5 -2 D
+P
+628 3798 M
+1 2 D
+P
+645 3795 M
+-1 1 D
+P
+FO
+472 3791 M
+3 1 D
+-3 1 D
+P
+FO
+472 3790 M
+3 1 D
+-3 0 D
+P
+FO
+496 3800 M
+5 1 D
+P
+FO
+576 3801 M
+0 1 D
+P
+FO
+576 3808 M
+4 0 D
+P
+FO
+819 3780 M
+-6 0 D
+-7 3 D
+0 -1 D
+-15 2 D
+-13 -1 D
+-17 2 D
+0 1 D
+-4 0 D
+-4 2 D
+-9 -1 D
+-2 2 D
+-21 3 D
+-12 -2 D
+0 -10 D
+P
+FO
+881 3780 M
+-13 2 D
+-30 -2 D
+P
+FO
+856 3782 M
+5 1 D
+P
+FO
+717 3793 M
+6 -1 D
+P
+FO
+850 3782 M
+6 0 D
+P
+FO
+732 3791 M
+5 0 D
+P
+FO
+727 3792 M
+4 -1 D
+P
+FO
+808 3783 M
+4 -1 D
+P
+FO
+711 3793 M
+3 0 D
+P
+FO
+1181 3781 M
+-3 1 D
+-2 -2 D
+1 2 D
+-4 -1 D
+-1 2 D
+-1 -1 D
+-6 1 D
+0 -2 D
+-1 1 D
+-6 -1 D
+-2 -1 D
+25 0 D
+P
+FO
+1182 3780 M
+1 1 D
+-1 -1 D
+13 0 D
+-6 6 D
+-5 -5 D
+-3 0 D
+0 -1 D
+P
+FO
+1254 3780 M
+-9 7 D
+-18 6 D
+-3 -5 D
+1 1 D
+0 -1 D
+5 0 D
+-5 0 D
+2 -2 D
+12 -1 D
+-14 -2 D
+-5 -1 D
+2 -2 D
+P
+FO
+1298 3780 M
+17 1 D
+-1 2 D
+-7 0 D
+3 1 D
+-5 0 D
+0 -2 D
+8 -2 D
+-19 0 D
+P
+FO
+1417 3881 M
+-34 6 D
+-78 -5 D
+13 -11 D
+11 -3 D
+-27 -15 D
+10 -4 D
+-16 -2 D
+5 -7 D
+-10 -2 D
+-10 -8 D
+2 -2 D
+-7 -2 D
+17 0 D
+31 -7 D
+20 -14 D
+7 0 D
+27 9 D
+7 -2 D
+17 3 D
+7 5 D
+0 7 D
+5 4 D
+-2 2 D
+5 0 D
+P
+FO
+1417 3944 M
+-9 -4 D
+-19 -2 D
+-7 -6 D
+-20 -1 D
+-7 -2 D
+-9 -6 D
+12 2 D
+-5 -1 D
+7 0 D
+-7 -2 D
+3 -2 D
+18 2 D
+13 -3 D
+5 2 D
+4 -1 D
+1 6 D
+5 -5 D
+6 0 D
+-2 -4 D
+8 2 D
+3 -1 D
+P
+FO
+1223 3793 M
+-1 1 D
+4 -1 D
+-4 2 D
+-2 -4 D
+P
+FO
+1394 3915 M
+3 5 D
+-10 -4 D
+P
+FO
+1360 3919 M
+-6 0 D
+9 -1 D
+P
+FO
+1315 3864 M
+6 0 D
+-6 2 D
+P
+FO
+1299 3783 M
+-4 0 D
+P
+FO
+1393 3939 M
+-4 0 D
+5 0 D
+P
+FO
+1654 3837 M
+-9 3 D
+-3 -1 D
+5 -2 D
+-10 3 D
+-9 -4 D
+2 -3 D
+-8 2 D
+3 3 D
+-9 -2 D
+3 -2 D
+-5 -1 D
+0 2 D
+-9 -2 D
+15 5 D
+6 6 D
+-46 7 D
+-6 -2 D
+-6 -4 D
+5 -2 D
+-26 -3 D
+8 3 D
+-4 2 D
+10 1 D
+-1 8 D
+-12 5 D
+-67 -10 D
+-28 -10 D
+-1 -3 D
+10 -1 D
+0 -3 D
+-11 -1 D
+-13 -10 D
+6 -4 D
+1 2 D
+8 0 D
+2 -2 D
+16 2 D
+-5 -2 D
+7 -1 D
+-13 -1 D
+-1 -3 D
+17 0 D
+-1 3 D
+5 -1 D
+-1 -2 D
+40 4 D
+6 -1 D
+10 1 D
+-8 -2 D
+-9 1 D
+-11 -2 D
+11 -1 D
+-12 0 D
+-49 -8 D
+-1 -2 D
+17 -6 D
+-1 -2 D
+7 -1 D
+30 2 D
+-1 -1 D
+6 -1 D
+-3 -1 D
+14 1 D
+-2 1 D
+40 2 D
+23 -4 D
+17 0 D
+4 -3 D
+12 -1 D
+-6 -1 D
+6 -1 D
+-19 1 D
+4 -1 D
+-10 -2 D
+-46 3 D
+-39 -2 D
+-29 -5 D
+174 0 D
+P
+1606 3803 M
+-2 -3 D
+-8 2 D
+6 2 D
+P
+1650 3801 M
+-4 -2 D
+-6 1 D
+P
+1480 3798 M
+-2 -3 D
+-2 3 D
+P
+1560 3815 M
+-1 -2 D
+-2 2 D
+P
+1538 3814 M
+7 -1 D
+-14 0 D
+P
+1525 3819 M
+-6 -1 D
+1 2 D
+6 -1 D
+P
+1617 3830 M
+-3 -1 D
+-2 2 D
+P
+1620 3832 M
+-1 1 D
+2 -1 D
+P
+1501 3807 M
+-8 1 D
+P
+FO
+1654 3839 M
+-6 1 D
+6 -2 D
+P
+FO
+1654 3843 M
+-2 1 D
+-5 -1 D
+7 -2 D
+P
+FO
+1654 3850 M
+-14 1 D
+-4 -1 D
+13 -4 D
+-1 -2 D
+6 0 D
+P
+FO
+1654 3911 M
+-11 0 D
+-18 -1 D
+-9 7 D
+4 1 D
+-19 -1 D
+13 2 D
+-17 3 D
+0 4 D
+-14 2 D
+-24 -2 D
+-4 7 D
+-17 1 D
+-14 -2 D
+-10 -4 D
+30 -3 D
+-37 1 D
+-10 -2 D
+4 -3 D
+-6 -2 D
+46 0 D
+-48 -2 D
+-10 -6 D
+27 0 D
+25 3 D
+-23 -5 D
+-30 0 D
+-9 -5 D
+22 -4 D
+12 3 D
+-2 -3 D
+7 1 D
+-6 -2 D
+16 -2 D
+-2 4 D
+6 -1 D
+4 2 D
+3 -5 D
+15 2 D
+5 3 D
+-8 2 D
+10 -1 D
+3 6 D
+4 -2 D
+14 1 D
+-12 -3 D
+-3 -3 D
+7 0 D
+-7 -3 D
+27 2 D
+3 3 D
+3 -2 D
+4 2 D
+2 -1 D
+-3 -2 D
+15 1 D
+5 -1 D
+12 3 D
+3 -1 D
+-16 -5 D
+-32 -1 D
+-6 -3 D
+-29 -4 D
+21 -6 D
+28 0 D
+37 6 D
+10 4 D
+9 0 D
+P
+FO
+1654 3919 M
+-2 0 D
+P
+FO
+1654 3932 M
+-9 -1 D
+-1 -1 D
+10 -2 D
+P
+FO
+1654 3971 M
+-8 0 D
+-67 -4 D
+-1 -10 D
+27 -4 D
+45 4 D
+3 6 D
+-17 0 D
+-4 2 D
+22 2 D
+P
+FO
+1654 3985 M
+-17 1 D
+-17 -3 D
+-43 -5 D
+5 -3 D
+20 2 D
+17 -2 D
+7 3 D
+28 -3 D
+P
+FO
+1417 3918 M
+6 0 D
+7 4 D
+-8 2 D
+6 0 D
+-4 5 D
+6 1 D
+10 -7 D
+2 5 D
+10 1 D
+-9 5 D
+14 0 D
+-3 4 D
+14 3 D
+-5 -10 D
+13 -3 D
+11 0 D
+0 6 D
+18 1 D
+10 3 D
+-12 5 D
+16 1 D
+-17 5 D
+25 3 D
+-25 6 D
+-11 0 D
+-3 -3 D
+9 -1 D
+-3 -2 D
+-9 2 D
+3 -2 D
+-20 2 D
+-32 -2 D
+-19 -8 D
+P
+FO
+1417 3833 M
+5 -1 D
+12 3 D
+5 7 D
+57 14 D
+21 2 D
+11 5 D
+-55 17 D
+-12 1 D
+-14 -2 D
+-9 -5 D
+1 5 D
+-9 0 D
+-8 -2 D
+3 3 D
+-8 1 D
+P
+1449 3851 M
+-3 -1 D
+-1 2 D
+-5 -1 D
+-2 2 D
+P
+1472 3852 M
+-11 0 D
+-2 -2 D
+-4 2 D
+11 2 D
+7 -2 D
+P
+FO
+1465 3915 M
+12 7 D
+-4 2 D
+-25 -5 D
+-17 -7 D
+20 -3 D
+P
+FO
+1559 3962 M
+11 2 D
+-19 6 D
+-18 -3 D
+17 -5 D
+P
+FO
+1559 3942 M
+-15 0 D
+-5 -3 D
+30 -1 D
+3 3 D
+P
+FO
+1606 3788 M
+-7 0 D
+15 -1 D
+P
+FO
+1498 3793 M
+-5 -1 D
+12 0 D
+P
+FO
+1488 3792 M
+4 1 D
+-11 0 D
+P
+FO
+1495 3791 M
+4 0 D
+P
+FO
+1506 3792 M
+3 0 D
+P
+FO
+1565 3947 M
+-1 2 D
+0 -2 D
+P
+FO
+1582 3787 M
+-4 0 D
+5 0 D
+P
+FO
+1615 3919 M
+-6 -1 D
+7 1 D
+P
+FO
+1681 3780 M
+-8 2 D
+15 -2 D
+7 1 D
+-6 -1 D
+31 0 D
+-22 1 D
+7 1 D
+21 -1 D
+-4 -1 D
+145 0 D
+0 4 D
+-5 -1 D
+-5 1 D
+-3 -2 D
+0 4 D
+-4 1 D
+-5 -1 D
+-22 6 D
+-4 4 D
+-3 -3 D
+6 -2 D
+-10 3 D
+-6 -1 D
+-11 5 D
+-1 3 D
+-13 5 D
+5 1 D
+-2 4 D
+5 1 D
+-1 5 D
+-11 6 D
+-12 15 D
+-5 10 D
+5 -2 D
+-41 12 D
+0 -4 D
+-23 5 D
+-3 -2 D
+6 -2 D
+-9 -1 D
+11 -23 D
+9 -6 D
+5 0 D
+-7 -1 D
+6 -2 D
+-14 -2 D
+2 -3 D
+-12 3 D
+2 6 D
+-4 -1 D
+-7 10 D
+1 5 D
+-5 1 D
+-5 -1 D
+-1 4 D
+-7 0 D
+-15 6 D
+0 -6 D
+6 0 D
+-2 -2 D
+-4 1 D
+0 -2 D
+2 0 D
+3 -3 D
+-5 1 D
+0 -1 D
+6 -1 D
+-5 1 D
+-1 -58 D
+P
+1738 3807 M
+-2 -3 D
+7 -5 D
+-12 3 D
+4 1 D
+-1 6 D
+4 1 D
+0 -2 D
+10 -1 D
+P
+1691 3809 M
+3 -3 D
+-2 1 D
+-5 -1 D
+P
+1664 3783 M
+0 -2 D
+-5 1 D
+P
+1728 3806 M
+-1 -2 D
+-4 1 D
+P
+1750 3830 M
+3 -3 D
+-6 2 D
+P
+1731 3809 M
+-3 -2 D
+-3 2 D
+P
+1715 3805 M
+-5 -2 D
+-2 3 D
+P
+1708 3815 M
+-6 -2 D
+-1 1 D
+P
+1754 3794 M
+5 -1 D
+-16 2 D
+P
+1717 3803 M
+0 -2 D
+-4 0 D
+P
+1696 3800 M
+0 -3 D
+-9 0 D
+P
+1736 3787 M
+8 -2 D
+-8 0 D
+-1 3 D
+P
+1740 3830 M
+-5 -4 D
+0 4 D
+P
+1767 3784 M
+-10 1 D
+P
+1686 3817 M
+-4 -2 D
+P
+1725 3845 M
+1 -2 D
+-2 2 D
+P
+1668 3794 M
+-4 -1 D
+P
+1748 3817 M
+1 -2 D
+-2 2 D
+P
+1728 3840 M
+0 -2 D
+-1 2 D
+P
+1838 3781 M
+-2 -1 D
+P
+FO
+1890 3845 M
+-3 1 D
+3 0 D
+0 9 D
+-9 2 D
+-4 -1 D
+1 -4 D
+6 2 D
+5 -5 D
+-6 -1 D
+0 3 D
+-4 0 D
+7 -6 D
+-10 -1 D
+-6 1 D
+0 -2 D
+-10 1 D
+-6 5 D
+-17 4 D
+-7 -2 D
+-4 -8 D
+19 -5 D
+3 -4 D
+7 0 D
+1 -2 D
+5 3 D
+7 -4 D
+1 1 D
+7 -1 D
+14 -8 D
+P
+1872 3843 M
+2 -2 D
+P
+1861 3838 M
+0 1 D
+2 -2 D
+P
+1866 3840 M
+3 -1 D
+P
+FO
+1890 3869 M
+-13 2 D
+-8 -1 D
+-6 -2 D
+5 -3 D
+9 0 D
+3 -5 D
+-11 5 D
+-18 -3 D
+16 -5 D
+15 1 D
+-1 2 D
+9 -3 D
+P
+FO
+1890 3872 M
+-7 0 D
+3 -2 D
+4 1 D
+P
+FO
+1890 3903 M
+-13 -1 D
+4 -4 D
+9 -1 D
+P
+FO
+1890 3909 M
+-17 -1 D
+7 -1 D
+-9 -1 D
+19 -3 D
+P
+FO
+1890 3910 M
+-7 0 D
+P
+FO
+1890 3911 M
+-1 0 D
+P
+FO
+1890 3919 M
+-14 4 D
+5 1 D
+-8 -1 D
+2 2 D
+-12 2 D
+-4 4 D
+-14 1 D
+-7 -5 D
+20 0 D
+-13 -4 D
+5 -2 D
+9 1 D
+-7 -2 D
+6 -4 D
+10 1 D
+-9 -2 D
+-13 4 D
+-7 -1 D
+-5 -2 D
+6 0 D
+1 -2 D
+-7 1 D
+-6 -3 D
+-6 0 D
+6 -3 D
+62 4 D
+P
+FO
+1890 3925 M
+-6 -1 D
+6 -3 D
+P
+FO
+1890 3928 M
+-5 1 D
+4 -1 D
+-10 0 D
+0 -2 D
+11 0 D
+P
+FO
+1890 3936 M
+-7 0 D
+-17 -3 D
+7 -3 D
+15 1 D
+2 -1 D
+P
+FO
+1890 3938 M
+0 1 D
+P
+FO
+1890 3983 M
+-1 1 D
+1 0 D
+0 2 D
+-9 2 D
+-13 -1 D
+-7 0 D
+6 4 D
+-21 3 D
+-13 -1 D
+-4 -4 D
+-7 9 D
+-20 3 D
+-41 -1 D
+-4 -7 D
+22 0 D
+-7 -6 D
+21 5 D
+6 -2 D
+-8 -3 D
+11 1 D
+-2 -2 D
+8 1 D
+4 -1 D
+-17 -3 D
+15 0 D
+-4 -3 D
+-28 2 D
+-6 -1 D
+13 -6 D
+12 -1 D
+27 4 D
+4 -4 D
+11 1 D
+27 -2 D
+17 -9 D
+7 0 D
+P
+FO
+1890 4016 M
+-4 -3 D
+4 0 D
+P
+FO
+1654 3975 M
+14 1 D
+4 4 D
+-18 5 D
+P
+FO
+1654 3967 M
+10 3 D
+-10 1 D
+P
+FO
+1654 3928 M
+17 -4 D
+1 -2 D
+-18 -3 D
+28 -5 D
+-1 -3 D
+-5 0 D
+4 -2 D
+-26 2 D
+0 -17 D
+11 0 D
+17 5 D
+8 -2 D
+-8 0 D
+20 -1 D
+5 4 D
+2 -3 D
+11 -1 D
+28 3 D
+9 7 D
+-2 3 D
+8 4 D
+-1 5 D
+-12 4 D
+-15 1 D
+-8 -2 D
+0 -4 D
+8 0 D
+-7 -1 D
+0 -3 D
+-4 6 D
+-17 0 D
+-6 -3 D
+9 5 D
+-6 2 D
+-15 -1 D
+11 6 D
+-13 3 D
+-3 5 D
+8 2 D
+-7 3 D
+-10 0 D
+-16 -8 D
+-5 -1 D
+P
+FO
+1771 3850 M
+12 8 D
+0 6 D
+-18 5 D
+-30 -2 D
+-11 -5 D
+22 -5 D
+18 -10 D
+0 2 D
+P
+FO
+1795 3937 M
+-15 -2 D
+4 -4 D
+10 -1 D
+-8 -1 D
+21 0 D
+12 3 D
+-19 4 D
+-5 -1 D
+P
+FO
+1772 3955 M
+-5 5 D
+-18 3 D
+12 -13 D
+17 -2 D
+9 3 D
+-9 4 D
+P
+FO
+1795 3899 M
+10 3 D
+-5 4 D
+-10 2 D
+-6 -1 D
+-10 -6 D
+11 -3 D
+P
+FO
+1795 3923 M
+15 -1 D
+17 2 D
+0 4 D
+-38 -1 D
+-5 -3 D
+P
+FO
+1866 3963 M
+-17 3 D
+-18 -1 D
+10 -4 D
+27 1 D
+P
+FO
+1843 3920 M
+-4 1 D
+-17 -1 D
+-12 -4 D
+19 0 D
+P
+FO
+1875 3796 M
+-1 -3 D
+10 -2 D
+-3 2 D
+5 0 D
+P
+FO
+1819 3920 M
+16 3 D
+-39 -3 D
+7 -1 D
+P
+FO
+1866 3938 M
+-16 -3 D
+8 -1 D
+26 5 D
+P
+FO
+1853 3973 M
+-4 1 D
+-3 -2 D
+P
+FO
+1819 3975 M
+-4 -4 D
+9 3 D
+P
+FO
+1885 3912 M
+-19 -1 D
+16 1 D
+-3 -1 D
+P
+FO
+1882 3909 M
+-5 0 D
+P
+FO
+1809 3797 M
+2 -1 D
+P
+FO
+1875 3846 M
+5 -1 D
+P
+FO
+1886 3790 M
+0 -2 D
+P
+FO
+1808 3794 M
+0 2 D
+P
+FO
+1859 3993 M
+-5 1 D
+P
+FO
+1701 3864 M
+10 0 D
+P
+FO
+1795 3949 M
+-9 -2 D
+P
+FO
+1799 3918 M
+12 0 D
+P
+FO
+1870 3787 M
+3 -2 D
+P
+FO
+1699 3827 M
+-1 2 D
+P
+FO
+1816 3795 M
+-3 1 D
+P
+FO
+1860 3910 M
+-6 0 D
+P
+FO
+1670 3943 M
+6 -1 D
+P
+FO
+2053 3780 M
+-2 1 D
+P
+FO
+2062 3780 M
+2 0 D
+-1 0 D
+17 0 D
+-5 2 D
+-10 -1 D
+5 2 D
+-4 1 D
+6 0 D
+-2 1 D
+9 -3 D
+11 2 D
+-4 0 D
+-1 4 D
+-4 0 D
+-1 -3 D
+-3 2 D
+3 1 D
+-8 3 D
+3 3 D
+-3 1 D
+0 -2 D
+-17 6 D
+4 1 D
+-3 11 D
+-19 7 D
+2 3 D
+-12 1 D
+-5 -3 D
+2 3 D
+-7 -1 D
+3 6 D
+-16 -1 D
+-1 -3 D
+15 1 D
+-15 -1 D
+0 -3 D
+-16 -3 D
+2 -2 D
+15 1 D
+-8 -2 D
+-1 -4 D
+-11 3 D
+-11 -3 D
+3 -3 D
+-4 -1 D
+4 -1 D
+-6 -6 D
+11 -5 D
+2 1 D
+7 -3 D
+-11 1 D
+-7 -6 D
+1 -5 D
+6 -2 D
+P
+2017 3819 M
+5 -2 D
+-4 1 D
+-3 -1 D
+1 2 D
+P
+2030 3818 M
+3 -4 D
+-6 1 D
+P
+2026 3813 M
+6 -1 D
+P
+FO
+2126 3828 M
+-1 0 D
+-2 -3 D
+3 -1 D
+P
+FO
+2126 3875 M
+-5 0 D
+5 -1 D
+P
+FO
+2126 3921 M
+-13 -2 D
+3 2 D
+-9 0 D
+-9 -4 D
+6 4 D
+-5 1 D
+22 1 D
+-16 0 D
+5 1 D
+-18 1 D
+4 1 D
+-8 2 D
+35 -4 D
+-8 1 D
+11 0 D
+0 5 D
+-35 2 D
+1 2 D
+23 -2 D
+-12 5 D
+-12 1 D
+-21 -3 D
+-18 1 D
+-10 -6 D
+9 9 D
+-12 4 D
+-15 -1 D
+-7 3 D
+-26 2 D
+-16 -1 D
+4 -1 D
+-6 -1 D
+-8 0 D
+0 -2 D
+12 -3 D
+-14 2 D
+-1 -3 D
+11 0 D
+10 -4 D
+10 2 D
+-4 -3 D
+-7 0 D
+30 -4 D
+-13 0 D
+-1 -2 D
+9 -1 D
+8 3 D
+25 -2 D
+-3 2 D
+16 1 D
+10 -9 D
+13 -3 D
+3 -6 D
+-10 -4 D
+-2 -5 D
+11 -3 D
+-5 -1 D
+2 -1 D
+6 -7 D
+6 0 D
+4 -2 D
+4 2 D
+5 -2 D
+-3 2 D
+11 4 D
+-6 -4 D
+7 0 D
+2 -2 D
+15 -1 D
+P
+FO
+2126 3941 M
+-14 -2 D
+13 -7 D
+P
+FO
+2126 3958 M
+-21 2 D
+-9 -2 D
+2 -4 D
+20 -4 D
+8 1 D
+P
+FO
+2126 3979 M
+-1 1 D
+1 36 D
+-106 0 D
+2 -1 D
+-49 1 D
+-3 -1 D
+11 -1 D
+-12 -1 D
+21 -6 D
+23 1 D
+11 2 D
+-6 -3 D
+-28 -2 D
+0 -3 D
+12 0 D
+2 -3 D
+18 3 D
+13 0 D
+-10 -4 D
+9 0 D
+13 5 D
+-1 -3 D
+9 1 D
+-3 3 D
+6 -2 D
+15 1 D
+-9 -2 D
+11 -1 D
+24 1 D
+-34 -2 D
+7 -2 D
+46 1 D
+-43 -2 D
+-29 0 D
+-6 -3 D
+-13 -1 D
+7 -4 D
+21 -1 D
+-19 0 D
+12 -5 D
+11 1 D
+28 -1 D
+-32 -2 D
+12 -4 D
+8 0 D
+2 -3 D
+41 -1 D
+1 3 D
+-11 1 D
+18 -1 D
+P
+FO
+1890 4013 M
+11 0 D
+17 -5 D
+0 8 D
+-28 0 D
+P
+FO
+1890 3984 M
+3 1 D
+-3 1 D
+P
+FO
+1890 3964 M
+3 -1 D
+21 3 D
+-1 0 D
+2 4 D
+-20 6 D
+7 6 D
+-12 1 D
+P
+FO
+1890 3938 M
+14 0 D
+-14 0 D
+P
+FO
+1890 3930 M
+4 -2 D
+-4 0 D
+0 -2 D
+14 -1 D
+-14 0 D
+0 -4 D
+3 -1 D
+10 1 D
+-11 -3 D
+-2 1 D
+0 -6 D
+9 1 D
+-6 -2 D
+5 0 D
+-8 -1 D
+4 0 D
+-4 -1 D
+8 0 D
+-8 -1 D
+0 -6 D
+1 0 D
+-1 0 D
+0 -6 D
+14 0 D
+1 3 D
+0 -3 D
+11 2 D
+6 -2 D
+16 1 D
+-3 5 D
+6 -3 D
+6 1 D
+-10 3 D
+3 1 D
+-6 0 D
+6 1 D
+-4 2 D
+6 0 D
+-6 1 D
+7 0 D
+1 2 D
+10 -4 D
+-2 7 D
+-13 1 D
+9 3 D
+-3 15 D
+-16 2 D
+5 0 D
+-17 2 D
+9 0 D
+-2 -2 D
+-12 0 D
+5 -4 D
+-7 1 D
+2 -1 D
+-14 5 D
+-8 0 D
+P
+FO
+1890 3871 M
+4 0 D
+-4 -2 D
+0 -12 D
+5 -2 D
+-5 0 D
+0 -9 D
+2 -1 D
+2 2 D
+2 -3 D
+-6 1 D
+0 -22 D
+8 -2 D
+10 -10 D
+7 1 D
+6 -2 D
+12 3 D
+3 3 D
+-11 4 D
+7 4 D
+-4 -3 D
+5 -3 D
+16 0 D
+24 6 D
+-6 1 D
+6 3 D
+-9 0 D
+9 1 D
+-1 4 D
+-8 1 D
+14 3 D
+-6 8 D
+-15 -4 D
+4 3 D
+-10 3 D
+3 3 D
+-18 1 D
+-9 -4 D
+-2 4 D
+20 7 D
+12 1 D
+-1 3 D
+-10 -1 D
+-2 2 D
+12 1 D
+6 4 D
+-6 3 D
+-15 0 D
+2 1 D
+-10 -2 D
+-23 -2 D
+-1 -1 D
+-15 6 D
+-4 -1 D
+P
+1916 3843 M
+12 -1 D
+5 -3 D
+-4 0 D
+-1 2 D
+-10 0 D
+-3 2 D
+P
+1907 3830 M
+4 0 D
+1 -4 D
+-6 3 D
+P
+1902 3828 M
+1 -1 D
+-2 2 D
+P
+1937 3833 M
+0 -4 D
+P
+1911 3832 M
+1 -2 D
+P
+1891 3829 M
+3 -1 D
+P
+FO
+2008 3826 M
+16 2 D
+6 -1 D
+1 1 D
+-5 0 D
+18 9 D
+-7 7 D
+-12 0 D
+0 1 D
+23 1 D
+28 -2 D
+18 11 D
+-7 1 D
+9 1 D
+7 6 D
+5 1 D
+14 8 D
+-32 3 D
+-19 -2 D
+-6 4 D
+-21 1 D
+-8 -1 D
+2 -1 D
+-16 1 D
+-21 -3 D
+0 -3 D
+16 -5 D
+-16 3 D
+-10 -2 D
+5 -13 D
+-4 -1 D
+0 -7 D
+13 -8 D
+-1 -8 D
+10 1 D
+-11 -2 D
+1 -3 D
+P
+FO
+1984 3966 M
+22 1 D
+4 4 D
+-12 3 D
+13 4 D
+-16 3 D
+-18 0 D
+3 2 D
+-9 2 D
+-38 3 D
+-5 -2 D
+8 -5 D
+-9 -1 D
+11 -6 D
+15 0 D
+11 -3 D
+-22 -2 D
+18 -2 D
+-2 -3 D
+13 2 D
+P
+FO
+1975 3898 M
+4 -2 D
+4 2 D
+4 -4 D
+9 -1 D
+-1 -1 D
+6 1 D
+5 -3 D
+10 -1 D
+28 1 D
+0 14 D
+-24 8 D
+-19 0 D
+-12 -2 D
+2 -3 D
+-10 1 D
+7 -1 D
+-8 -3 D
+6 1 D
+-12 -2 D
+-4 -5 D
+P
+FO
+2031 3962 M
+-16 2 D
+-16 -2 D
+-2 2 D
+-19 -3 D
+-2 -2 D
+12 -3 D
+54 -1 D
+11 6 D
+-13 2 D
+-8 -1 D
+P
+FO
+1984 3910 M
+1 2 D
+-10 1 D
+0 -2 D
+-15 -1 D
+2 -3 D
+8 0 D
+5 4 D
+4 -2 D
+P
+FO
+1943 3874 M
+0 3 D
+-40 -5 D
+16 -2 D
+0 1 D
+9 0 D
+P
+FO
+1959 3850 M
+4 -1 D
+7 1 D
+-5 5 D
+-7 -2 D
+P
+FO
+2021 3915 M
+4 1 D
+-5 5 D
+-9 -2 D
+2 -3 D
+P
+FO
+2102 3948 M
+7 2 D
+-10 1 D
+-4 -1 D
+P
+FO
+1989 3889 M
+3 -2 D
+10 -1 D
+-6 3 D
+P
+FO
+1998 3821 M
+3 0 D
+0 2 D
+P
+FO
+2019 3973 M
+4 -1 D
+-5 3 D
+P
+FO
+1997 3951 M
+-4 -1 D
+9 -1 D
+P
+FO
+2007 3922 M
+4 3 D
+-7 -1 D
+P
+FO
+1972 3810 M
+-3 -1 D
+5 -1 D
+P
+FO
+1968 3845 M
+-1 3 D
+-6 -3 D
+P
+FO
+1951 3889 M
+-6 -4 D
+7 1 D
+P
+FO
+1926 3881 M
+-9 0 D
+P
+FO
+1951 3945 M
+7 0 D
+-8 0 D
+P
+FO
+1988 3853 M
+3 -1 D
+P
+FO
+1990 3850 M
+-1 -2 D
+P
+FO
+1961 3856 M
+0 1 D
+-1 -1 D
+P
+FO
+1962 3913 M
+6 0 D
+P
+FO
+1961 3820 M
+3 1 D
+-4 -1 D
+P
+FO
+1990 3847 M
+1 -2 D
+P
+FO
+1913 3811 M
+2 1 D
+P
+FO
+1988 3919 M
+1 2 D
+P
+FO
+1959 3940 M
+-3 2 D
+P
+FO
+1957 3903 M
+-3 3 D
+P
+FO
+1937 3934 M
+5 0 D
+P
+FO
+1934 3892 M
+-5 0 D
+P
+FO
+1960 3944 M
+3 1 D
+P
+FO
+2014 3922 M
+-2 1 D
+P
+FO
+1956 3932 M
+2 2 D
+P
+FO
+1956 3935 M
+1 1 D
+P
+FO
+1975 3935 M
+1 1 D
+P
+FO
+1947 3909 M
+1 -1 D
+P
+FO
+2209 3780 M
+-3 2 D
+-12 1 D
+-6 -1 D
+6 -2 D
+P
+FO
+2237 3780 M
+-13 1 D
+2 1 D
+20 -1 D
+3 1 D
+0 -2 D
+68 0 D
+-26 7 D
+32 -7 D
+8 0 D
+-10 3 D
+41 -3 D
+0 5 D
+-3 1 D
+3 0 D
+0 8 D
+-3 1 D
+-7 -2 D
+-2 2 D
+-7 0 D
+-2 -1 D
+-3 3 D
+5 -1 D
+10 1 D
+-2 -1 D
+5 -1 D
+6 1 D
+0 10 D
+-4 1 D
+4 0 D
+0 25 D
+-5 2 D
+0 -3 D
+-6 0 D
+3 -3 D
+-15 -4 D
+5 3 D
+-7 1 D
+1 1 D
+12 -1 D
+-11 4 D
+11 4 D
+0 3 D
+-21 -7 D
+28 12 D
+-10 5 D
+1 5 D
+-14 3 D
+0 6 D
+-8 4 D
+-31 1 D
+-4 -2 D
+-15 -2 D
+-9 -2 D
+9 -1 D
+1 -4 D
+-3 3 D
+-10 2 D
+-11 -2 D
+7 -4 D
+-10 4 D
+-6 -1 D
+-3 -4 D
+34 -4 D
+-36 3 D
+2 -2 D
+-6 2 D
+-4 -3 D
+11 0 D
+27 -7 D
+-33 6 D
+-8 -2 D
+4 -10 D
+9 -3 D
+8 3 D
+-2 -3 D
+11 1 D
+-13 -2 D
+9 -2 D
+-4 0 D
+14 -5 D
+-1 -2 D
+-7 4 D
+-17 4 D
+-7 0 D
+0 -5 D
+-12 -1 D
+14 -5 D
+-4 0 D
+7 -3 D
+19 -1 D
+-3 0 D
+2 -4 D
+-6 -2 D
+0 -10 D
+-4 -1 D
+1 4 D
+-5 0 D
+6 0 D
+-3 3 D
+-3 -2 D
+-6 2 D
+-9 -2 D
+-17 -3 D
+-19 0 D
+-2 -1 D
+-51 3 D
+9 -3 D
+-6 -1 D
+1 -2 D
+14 -8 D
+20 -3 D
+-8 -1 D
+10 -2 D
+5 1 D
+-3 1 D
+18 -1 D
+0 2 D
+-6 1 D
+6 2 D
+1 -2 D
+5 0 D
+-3 -2 D
+5 0 D
+6 5 D
+-4 -7 D
+18 -5 D
+P
+2344 3803 M
+8 -1 D
+-8 -3 D
+-4 3 D
+P
+2244 3798 M
+-11 -4 D
+-10 0 D
+P
+2320 3799 M
+5 -2 D
+-6 2 D
+P
+2188 3788 M
+3 0 D
+-4 0 D
+P
+2341 3785 M
+-1 0 D
+16 -3 D
+P
+FO
+2362 3836 M
+-4 -2 D
+4 -1 D
+P
+FO
+2362 3868 M
+-1 0 D
+-18 0 D
+-1 -5 D
+4 -1 D
+-4 0 D
+-1 -4 D
+18 -2 D
+0 -6 D
+3 -3 D
+P
+FO
+2362 3897 M
+-7 -1 D
+-2 2 D
+9 2 D
+0 8 D
+-9 0 D
+9 2 D
+0 1 D
+-30 2 D
+4 3 D
+-29 1 D
+-19 -2 D
+-21 2 D
+-7 -3 D
+-9 0 D
+4 -2 D
+-12 1 D
+-5 -2 D
+-7 1 D
+-14 -2 D
+14 -3 D
+-24 -1 D
+5 2 D
+-21 4 D
+-7 -4 D
+-4 3 D
+-13 -2 D
+-12 5 D
+-4 -6 D
+-6 3 D
+-12 0 D
+11 1 D
+2 4 D
+-10 2 D
+-5 -2 D
+3 3 D
+-8 2 D
+0 -34 D
+19 1 D
+2 6 D
+6 -4 D
+7 5 D
+6 -3 D
+-6 -6 D
+15 -1 D
+4 1 D
+1 -1 D
+10 2 D
+0 -2 D
+16 0 D
+-4 4 D
+8 -4 D
+6 3 D
+1 -3 D
+13 1 D
+1 4 D
+7 -4 D
+6 4 D
+2 -4 D
+31 1 D
+7 5 D
+-5 3 D
+11 -2 D
+4 -6 D
+8 -1 D
+1 2 D
+1 -2 D
+17 -1 D
+14 3 D
+22 0 D
+-4 8 D
+9 -3 D
+P
+FO
+2362 3949 M
+-9 -2 D
+7 3 D
+-20 1 D
+-20 -2 D
+-10 3 D
+25 1 D
+-15 2 D
+-4 6 D
+28 -8 D
+18 -1 D
+0 56 D
+-14 -3 D
+-20 2 D
+-7 -1 D
+-8 6 D
+-15 4 D
+-84 0 D
+25 -2 D
+-28 1 D
+-1 -5 D
+31 -3 D
+19 -10 D
+10 0 D
+-2 -2 D
+15 -2 D
+-13 0 D
+-14 3 D
+-5 -3 D
+51 -3 D
+25 3 D
+-5 -4 D
+-37 -1 D
+10 -2 D
+15 0 D
+-9 -1 D
+6 -3 D
+-32 6 D
+-33 2 D
+-42 -4 D
+-6 -4 D
+7 -1 D
+-8 0 D
+-8 -3 D
+0 -4 D
+10 -1 D
+-10 -2 D
+19 0 D
+21 7 D
+-11 -8 D
+19 1 D
+21 12 D
+-7 -6 D
+7 0 D
+-9 -3 D
+23 -1 D
+-24 0 D
+4 -3 D
+13 0 D
+-20 0 D
+-13 -3 D
+5 -2 D
+27 1 D
+-26 -1 D
+3 -1 D
+8 1 D
+-8 -3 D
+8 -3 D
+12 4 D
+-8 -6 D
+26 0 D
+22 12 D
+11 1 D
+-22 -12 D
+-15 -2 D
+9 -3 D
+-26 1 D
+3 -2 D
+-26 4 D
+-6 -1 D
+-4 7 D
+-11 3 D
+-20 1 D
+-22 -1 D
+0 -5 D
+14 -4 D
+-2 -3 D
+20 1 D
+-9 -2 D
+9 -1 D
+-9 -1 D
+15 -1 D
+-6 -1 D
+-10 1 D
+-30 -2 D
+-23 -6 D
+4 -3 D
+-7 -3 D
+18 -4 D
+5 4 D
+2 -4 D
+-2 7 D
+5 3 D
+1 -10 D
+13 -1 D
+2 1 D
+4 -2 D
+5 1 D
+-3 6 D
+2 -4 D
+18 -3 D
+1 3 D
+9 2 D
+-8 2 D
+10 -2 D
+-5 -4 D
+27 -2 D
+21 1 D
+-14 2 D
+-3 3 D
+20 -2 D
+-2 5 D
+14 -6 D
+13 0 D
+-5 8 D
+8 -8 D
+19 0 D
+3 4 D
+-4 1 D
+12 2 D
+-7 -5 D
+14 -1 D
+6 2 D
+11 -3 D
+-7 -7 D
+25 3 D
+P
+FO
+2318 4016 M
+11 -1 D
+-3 -6 D
+18 -2 D
+18 1 D
+0 8 D
+P
+FO
+2126 3982 M
+1 1 D
+26 -11 D
+7 6 D
+-6 5 D
+15 -4 D
+7 3 D
+-3 2 D
+-9 0 D
+7 1 D
+-2 7 D
+10 2 D
+-6 -6 D
+9 -4 D
+16 5 D
+-1 4 D
+7 -2 D
+5 2 D
+38 5 D
+-20 9 D
+-7 -5 D
+-8 6 D
+-10 -1 D
+0 -2 D
+-4 1 D
+-11 -1 D
+11 9 D
+-13 -2 D
+12 2 D
+-3 2 D
+-68 0 D
+P
+FO
+2126 3975 M
+12 -3 D
+-12 7 D
+P
+FO
+2126 3951 M
+8 1 D
+-8 6 D
+P
+FO
+2126 3933 M
+8 0 D
+-8 8 D
+P
+FO
+2126 3925 M
+19 2 D
+-19 3 D
+P
+FO
+2126 3874 M
+2 1 D
+-2 0 D
+P
+FO
+2126 3824 M
+5 -3 D
+-5 -7 D
+8 -4 D
+37 -2 D
+6 1 D
+2 -3 D
+18 -3 D
+18 2 D
+12 3 D
+8 0 D
+-2 1 D
+7 1 D
+-3 0 D
+11 0 D
+-2 3 D
+-13 2 D
+-21 11 D
+-2 6 D
+5 5 D
+-12 7 D
+19 15 D
+26 9 D
+-9 2 D
+-32 1 D
+-34 -5 D
+-20 -8 D
+6 -1 D
+-8 0 D
+2 -1 D
+-7 -1 D
+-6 -9 D
+4 -1 D
+-8 1 D
+3 -4 D
+-7 -1 D
+-4 -4 D
+0 -6 D
+8 0 D
+-10 -3 D
+P
+FO
+2214 3992 M
+-5 -2 D
+31 3 D
+-14 1 D
+P
+FO
+2244 3959 M
+-13 -1 D
+10 -2 D
+8 1 D
+P
+FO
+2362 3838 M
+-3 1 D
+3 -2 D
+P
+FO
+2268 3933 M
+-5 0 D
+6 -2 D
+P
+FO
+2185 3804 M
+-3 0 D
+P
+FO
+2220 3834 M
+3 -2 D
+P
+FO
+2244 3835 M
+4 0 D
+P
+FO
+2141 3932 M
+-7 0 D
+P
+FO
+2247 3813 M
+1 -2 D
+P
+FO
+2169 3979 M
+-4 -5 D
+5 5 D
+P
+FO
+2349 3831 M
+0 -1 D
+P
+FO
+2393 3780 M
+-6 7 D
+-15 1 D
+5 3 D
+5 -1 D
+4 4 D
+-4 0 D
+3 2 D
+4 -1 D
+4 -3 D
+-5 2 D
+-4 -3 D
+5 -2 D
+0 2 D
+7 -4 D
+4 2 D
+1 -1 D
+-5 -1 D
+4 -3 D
+15 2 D
+2 -2 D
+1 -4 D
+180 0 D
+0 1 D
+-4 -1 D
+4 2 D
+0 8 D
+-6 -1 D
+-9 -4 D
+10 5 D
+5 0 D
+0 3 D
+-1 0 D
+0 2 D
+-8 -1 D
+3 -3 D
+-8 -1 D
+5 2 D
+-1 2 D
+10 4 D
+0 2 D
+-23 -6 D
+-13 -14 D
+9 12 D
+-8 1 D
+-8 -6 D
+3 3 D
+-6 -1 D
+5 1 D
+4 4 D
+9 -1 D
+10 4 D
+6 4 D
+-2 4 D
+-5 1 D
+-9 -2 D
+1 -4 D
+-9 0 D
+-15 -2 D
+-9 -4 D
+9 5 D
+-14 0 D
+10 1 D
+6 5 D
+15 0 D
+7 5 D
+-9 5 D
+-24 4 D
+-19 -16 D
+3 6 D
+5 0 D
+-7 2 D
+-13 -7 D
+12 8 D
+-4 2 D
+-2 -2 D
+1 5 D
+-7 -1 D
+-8 -8 D
+4 6 D
+-6 -1 D
+8 1 D
+-2 2 D
+9 4 D
+-1 2 D
+-6 -1 D
+-6 -4 D
+3 4 D
+-10 -2 D
+-6 -3 D
+3 -4 D
+-10 -5 D
+9 5 D
+-6 2 D
+2 1 D
+-7 -1 D
+12 5 D
+-18 -4 D
+11 4 D
+-10 0 D
+26 4 D
+1 5 D
+-21 1 D
+-10 -3 D
+-9 -6 D
+-5 0 D
+7 1 D
+5 6 D
+9 2 D
+-14 0 D
+-14 -6 D
+8 5 D
+10 2 D
+10 -1 D
+5 2 D
+-3 7 D
+-16 3 D
+-6 -3 D
+-1 3 D
+-13 1 D
+-2 2 D
+-20 1 D
+-19 -4 D
+-4 -4 D
+37 -7 D
+-14 1 D
+-1 -2 D
+0 3 D
+-18 3 D
+0 -4 D
+-5 4 D
+-6 -3 D
+28 -10 D
+-1 -1 D
+-10 5 D
+-3 -1 D
+10 -4 D
+-8 2 D
+-7 6 D
+-9 2 D
+-2 -4 D
+10 -3 D
+-16 2 D
+6 7 D
+-9 3 D
+-5 -2 D
+0 -1 D
+-5 -1 D
+4 3 D
+-5 4 D
+-5 -3 D
+0 -3 D
+8 -3 D
+-8 2 D
+0 -25 D
+2 0 D
+2 -2 D
+-4 1 D
+0 -10 D
+12 -5 D
+-12 3 D
+0 -8 D
+8 0 D
+-3 -4 D
+-5 3 D
+0 -5 D
+P
+2386 3808 M
+10 -2 D
+-18 -1 D
+-1 3 D
+P
+2436 3821 M
+5 1 D
+3 -2 D
+P
+2377 3801 M
+5 -2 D
+-10 0 D
+P
+2414 3826 M
+8 0 D
+-6 -1 D
+P
+FO
+2410 3780 M
+1 0 D
+-1 0 D
+P
+FO
+2598 3932 M
+-4 -1 D
+4 0 D
+P
+FO
+2598 3935 M
+P
+FO
+2598 3941 M
+-1 0 D
+1 -1 D
+P
+FO
+2598 3950 M
+-4 1 D
+-18 -2 D
+6 -1 D
+-16 -2 D
+7 -3 D
+10 0 D
+-7 -1 D
+8 -2 D
+14 4 D
+P
+FO
+2598 3954 M
+-28 1 D
+P
+FO
+2598 3960 M
+-6 -2 D
+6 0 D
+P
+FO
+2598 3965 M
+-15 -4 D
+15 0 D
+P
+FO
+2598 3988 M
+-4 0 D
+-17 -3 D
+-2 -2 D
+-10 0 D
+-23 -2 D
+-11 -4 D
+3 -4 D
+-8 0 D
+18 -3 D
+9 -4 D
+18 0 D
+-2 -3 D
+29 2 D
+P
+FO
+2362 4008 M
+7 1 D
+-7 -1 D
+0 -56 D
+19 0 D
+10 2 D
+1 -2 D
+25 7 D
+-17 7 D
+5 2 D
+29 -2 D
+17 3 D
+9 -1 D
+7 4 D
+-31 2 D
+29 -1 D
+15 3 D
+-9 3 D
+-29 2 D
+27 -1 D
+21 2 D
+-8 7 D
+-35 -1 D
+16 3 D
+-23 2 D
+-21 -1 D
+-14 -5 D
+12 6 D
+-28 1 D
+33 -2 D
+33 2 D
+-12 2 D
+-39 0 D
+53 1 D
+6 -3 D
+31 -1 D
+-9 3 D
+7 2 D
+-53 1 D
+-20 -1 D
+7 0 D
+-18 2 D
+21 0 D
+-5 3 D
+6 0 D
+6 -3 D
+25 0 D
+-30 5 D
+46 -4 D
+7 1 D
+-6 2 D
+21 -2 D
+6 3 D
+18 -1 D
+-3 6 D
+-37 2 D
+15 1 D
+9 -2 D
+23 0 D
+5 -3 D
+29 1 D
+14 4 D
+-13 1 D
+19 2 D
+-222 0 D
+P
+FO
+2362 3927 M
+17 1 D
+11 7 D
+10 -3 D
+14 5 D
+-5 8 D
+-9 0 D
+-8 -4 D
+-3 2 D
+-13 0 D
+10 4 D
+-7 3 D
+-10 1 D
+-7 -2 D
+P
+FO
+2362 3910 M
+2 0 D
+-2 1 D
+P
+FO
+2362 3900 M
+12 3 D
+-2 5 D
+-10 0 D
+P
+FO
+2362 3893 M
+16 2 D
+-6 3 D
+-10 -1 D
+P
+FO
+2362 3847 M
+16 -3 D
+26 4 D
+41 -2 D
+10 1 D
+-6 3 D
+2 3 D
+-9 1 D
+-2 4 D
+-6 0 D
+-11 5 D
+-17 3 D
+-32 -1 D
+-12 3 D
+P
+FO
+2386 3919 M
+-4 1 D
+8 2 D
+-3 2 D
+-19 -6 D
+9 -2 D
+2 2 D
+10 -1 D
+P
+FO
+2528 3811 M
+4 3 D
+-4 2 D
+-4 -3 D
+0 4 D
+-6 -2 D
+3 -3 D
+P
+FO
+2551 3799 M
+14 2 D
+1 3 D
+-14 1 D
+-7 -4 D
+P
+FO
+2551 3955 M
+-12 -1 D
+12 -2 D
+16 1 D
+P
+FO
+2376 3836 M
+-4 2 D
+0 -3 D
+P
+FO
+2528 3818 M
+5 -2 D
+1 3 D
+P
+FO
+2494 3985 M
+7 1 D
+-12 1 D
+P
+FO
+2386 3835 M
+6 1 D
+-6 1 D
+-1 -2 D
+P
+FO
+2521 3819 M
+-2 -3 D
+5 3 D
+P
+FO
+2386 3835 M
+2 -2 D
+P
+FO
+2411 3964 M
+9 1 D
+P
+FO
+2568 3805 M
+5 2 D
+P
+FO
+2487 3831 M
+-6 0 D
+P
+FO
+2392 3944 M
+-1 -1 D
+P
+FO
+2602 3780 M
+-4 1 D
+0 -1 D
+P
+FO
+2624 3780 M
+2 0 D
+4 4 D
+-23 -1 D
+-3 -3 D
+P
+FO
+2662 3780 M
+-11 6 D
+-9 1 D
+-5 -3 D
+3 -2 D
+-8 -1 D
+-1 -1 D
+P
+FO
+2718 4016 M
+21 -3 D
+-25 -1 D
+8 -7 D
+-29 -10 D
+-23 0 D
+2 1 D
+-5 -2 D
+-5 2 D
+-14 -3 D
+-10 1 D
+-17 -1 D
+-9 -2 D
+11 -3 D
+-10 2 D
+-5 -2 D
+-10 0 D
+0 -23 D
+2 0 D
+-2 0 D
+0 -4 D
+14 2 D
+-14 -3 D
+0 -2 D
+16 -2 D
+18 1 D
+-3 4 D
+9 -4 D
+20 0 D
+19 5 D
+12 -3 D
+3 -3 D
+-14 -1 D
+11 -4 D
+-29 3 D
+-23 0 D
+-18 -3 D
+53 -3 D
+17 2 D
+-5 -3 D
+-86 3 D
+0 -6 D
+12 1 D
+-12 -4 D
+0 -1 D
+30 -3 D
+20 0 D
+-2 -2 D
+-17 0 D
+-21 -4 D
+19 -6 D
+8 0 D
+-2 -2 D
+49 -4 D
+-19 6 D
+10 3 D
+10 -5 D
+6 5 D
+15 -1 D
+-8 -3 D
+11 -2 D
+2 3 D
+17 -1 D
+-2 3 D
+7 -1 D
+0 4 D
+6 -1 D
+1 -4 D
+8 0 D
+8 5 D
+14 -1 D
+2 -3 D
+12 2 D
+13 -3 D
+18 0 D
+5 -4 D
+6 2 D
+11 -3 D
+0 96 D
+P
+FO
+2598 3954 M
+1 0 D
+-1 0 D
+P
+FO
+2598 3935 M
+7 -1 D
+7 1 D
+-14 0 D
+P
+FO
+2598 3931 M
+2 -1 D
+-2 2 D
+P
+FO
+2598 3798 M
+5 1 D
+-5 1 D
+P
+FO
+2598 3790 M
+9 1 D
+-9 -1 D
+0 -8 D
+15 4 D
+16 1 D
+4 4 D
+2 -3 D
+4 4 D
+-28 6 D
+-13 -5 D
+P
+FO
+2740 3924 M
+0 -2 D
+7 2 D
+P
+FO
+2758 3928 M
+2 1 D
+P
+FO
+2678 3956 M
+7 0 D
+P
+FO
+2772 3927 M
+2 -1 D
+P
+FO
+2794 3924 M
+5 1 D
+P
+FO
+2716 3923 M
+-1 -2 D
+2 2 D
+P
+FO
+2675 3957 M
+14 0 D
+P
+FO
+2671 3959 M
+8 1 D
+P
+FO
+2634 3784 M
+1 -1 D
+P
+FO
+2693 3922 M
+0 1 D
+P
+FO
+2789 3925 M
+1 1 D
+P
+FO
+2787 3923 M
+0 1 D
+P
+FO
+3003 3780 M
+-10 4 D
+-25 3 D
+-11 -2 D
+1 -4 D
+P
+FO
+3039 3780 M
+6 1 D
+5 -1 D
+-5 1 D
+-1 -1 D
+21 1 D
+0 -1 D
+6 0 D
+0 236 D
+-236 0 D
+0 -97 D
+8 1 D
+-3 -4 D
+15 2 D
+2 -4 D
+16 0 D
+-5 -1 D
+7 0 D
+-3 -2 D
+7 -2 D
+-13 -3 D
+11 1 D
+-5 -2 D
+12 -3 D
+-5 -2 D
+19 -5 D
+7 1 D
+6 -3 D
+-10 -1 D
+4 -2 D
+5 1 D
+10 -4 D
+6 0 D
+0 -2 D
+-16 0 D
+15 -1 D
+-2 -2 D
+-11 0 D
+11 -1 D
+-25 -5 D
+19 2 D
+10 3 D
+-5 -4 D
+5 -1 D
+-8 0 D
+12 -1 D
+-4 -2 D
+12 -2 D
+-8 0 D
+2 -2 D
+8 -1 D
+-10 1 D
+-2 -2 D
+5 -1 D
+-6 0 D
+24 -7 D
+-5 1 D
+-5 -3 D
+9 -2 D
+-8 0 D
+-7 -3 D
+14 -1 D
+3 1 D
+-1 -2 D
+7 0 D
+4 -4 D
+-8 -1 D
+11 0 D
+-8 -1 D
+6 -1 D
+-8 -1 D
+6 -1 D
+-4 0 D
+0 -2 D
+12 -1 D
+-28 1 D
+-4 -2 D
+7 -1 D
+1 2 D
+2 -3 D
+5 3 D
+7 -3 D
+-5 0 D
+1 -2 D
+-13 -4 D
+3 -1 D
+-7 -1 D
+8 -2 D
+14 2 D
+6 5 D
+-6 -5 D
+-16 -3 D
+2 -3 D
+-4 1 D
+-11 -3 D
+8 -1 D
+0 -4 D
+10 -1 D
+-3 2 D
+10 -3 D
+22 2 D
+0 3 D
+-6 1 D
+4 2 D
+4 -2 D
+-3 3 D
+7 0 D
+6 2 D
+-13 11 D
+8 1 D
+-6 -1 D
+10 -7 D
+1 -5 D
+16 5 D
+-14 -7 D
+27 -2 D
+11 3 D
+-4 -4 D
+-15 -1 D
+-12 -3 D
+13 -1 D
+26 3 D
+-22 -3 D
+-6 -5 D
+20 5 D
+4 -2 D
+-17 -4 D
+24 1 D
+-7 -2 D
+14 -1 D
+-6 -2 D
+-15 3 D
+-4 -1 D
+19 -4 D
+7 0 D
+5 -4 D
+-15 3 D
+-4 -2 D
+6 -1 D
+4 2 D
+-2 -3 D
+11 0 D
+-6 0 D
+4 -3 D
+-4 1 D
+0 -2 D
+-6 3 D
+-4 -1 D
+9 -4 D
+10 3 D
+-4 -3 D
+4 -2 D
+-24 3 D
+-32 8 D
+-29 1 D
+-11 -4 D
+17 -6 D
+25 -3 D
+11 -5 D
+P
+2967 3836 M
+1 -3 D
+P
+FO
+2929 3871 M
+-14 1 D
+-3 -1 D
+3 -2 D
+8 1 D
+-1 -1 D
+8 0 D
+P
+FO
+3000 3812 M
+-4 -1 D
+1 -3 D
+11 -1 D
+6 3 D
+0 1 D
+P
+FO
+2952 3846 M
+-14 -1 D
+-5 -4 D
+6 1 D
+1 -2 D
+5 1 D
+8 5 D
+P
+FO
+3000 3819 M
+-11 0 D
+0 -2 D
+8 -1 D
+8 3 D
+P
+FO
+2929 3843 M
+3 1 D
+3 -1 D
+2 2 D
+-12 -1 D
+P
+FO
+2952 3835 M
+-13 -1 D
+4 -1 D
+-6 -2 D
+7 0 D
+P
+FO
+2905 3885 M
+14 1 D
+-7 1 D
+-19 -1 D
+P
+FO
+2976 3806 M
+7 -2 D
+7 1 D
+-5 6 D
+P
+FO
+2916 3864 M
+5 -1 D
+4 3 D
+P
+FO
+2944 3840 M
+8 -1 D
+0 2 D
+P
+FO
+2948 3850 M
+-2 -1 D
+6 0 D
+P
+FO
+2953 3842 M
+-5 1 D
+-1 -2 D
+P
+FO
+2953 3843 M
+5 1 D
+-4 1 D
+P
+FO
+2953 3840 M
+4 -1 D
+0 2 D
+P
+FO
+3024 3803 M
+-5 -2 D
+15 -1 D
+P
+FO
+2953 3791 M
+1 -2 D
+6 0 D
+P
+FO
+2934 3824 M
+6 -1 D
+4 2 D
+P
+FO
+3025 3795 M
+12 0 D
+-9 2 D
+P
+FO
+2907 3866 M
+8 -1 D
+7 2 D
+P
+FO
+2931 3862 M
+8 -3 D
+3 2 D
+P
+FO
+2929 3859 M
+-2 -2 D
+7 2 D
+P
+FO
+2938 3850 M
+4 -1 D
+3 2 D
+P
+FO
+2934 3858 M
+0 -1 D
+5 0 D
+-5 2 D
+P
+FO
+3000 3815 M
+3 1 D
+-7 -2 D
+P
+FO
+3031 3793 M
+10 -2 D
+P
+FO
+2929 3861 M
+6 0 D
+P
+FO
+2930 3840 M
+8 1 D
+P
+FO
+2930 3829 M
+6 1 D
+P
+FO
+2905 3888 M
+4 -1 D
+P
+FO
+2939 3859 M
+6 1 D
+P
+FO
+2897 3884 M
+4 0 D
+P
+FO
+2909 3872 M
+5 0 D
+P
+FO
+2929 3856 M
+5 0 D
+P
+FO
+2939 3846 M
+6 1 D
+P
+FO
+2929 3854 M
+0 1 D
+P
+FO
+2889 3891 M
+7 0 D
+P
+FO
+2929 3863 M
+4 0 D
+P
+FO
+2922 3855 M
+4 0 D
+P
+FO
+2919 3869 M
+6 -2 D
+P
+FO
+2931 3850 M
+6 2 D
+-6 -1 D
+P
+FO
+2929 3845 M
+5 1 D
+P
+FO
+2909 3869 M
+5 0 D
+P
+FO
+2919 3857 M
+4 0 D
+P
+FO
+2900 3888 M
+4 1 D
+P
+FO
+2934 3839 M
+4 0 D
+P
+FO
+2924 3845 M
+4 0 D
+P
+FO
+3030 3792 M
+6 -1 D
+P
+FO
+2938 3848 M
+4 -1 D
+P
+FO
+2909 3863 M
+5 0 D
+P
+FO
+2924 3869 M
+5 0 D
+P
+FO
+2929 3872 M
+-4 1 D
+P
+FO
+2925 3846 M
+4 1 D
+P
+FO
+3019 3796 M
+1 -1 D
+P
+FO
+2930 3833 M
+1 -1 D
+P
+FO
+2867 3912 M
+5 1 D
+P
+FO
+2914 3863 M
+5 0 D
+P
+FO
+3016 3801 M
+2 1 D
+-2 0 D
+P
+FO
+2929 3852 M
+5 0 D
+P
+FO
+2918 3885 M
+4 0 D
+P
+FO
+2953 3847 M
+5 0 D
+P
+FO
+2914 3874 M
+4 0 D
+P
+FO
+2911 3875 M
+2 1 D
+P
+FO
+3071 3780 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+3307 3780 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+3603 3780 M
+-1 1 D
+-11 -1 D
+-15 2 D
+10 1 D
+7 -1 D
+21 5 D
+13 0 D
+3 2 D
+-5 2 D
+-40 -3 D
+-2 4 D
+-20 -3 D
+-2 1 D
+19 2 D
+6 2 D
+7 6 D
+-12 3 D
+18 -1 D
+-7 5 D
+10 -5 D
+17 0 D
+27 5 D
+-3 2 D
+6 -1 D
+2 2 D
+-11 5 D
+-27 1 D
+-4 -2 D
+1 3 D
+-10 1 D
+-20 -2 D
+25 2 D
+1 2 D
+-16 4 D
+4 0 D
+-14 1 D
+2 2 D
+11 0 D
+25 -11 D
+10 2 D
+19 -2 D
+12 -6 D
+11 1 D
+-2 -1 D
+12 -6 D
+4 -9 D
+16 -5 D
+17 0 D
+4 10 D
+1 -9 D
+9 1 D
+2 -3 D
+11 3 D
+-7 1 D
+5 3 D
+-5 1 D
+6 -1 D
+-6 1 D
+4 1 D
+-8 1 D
+6 0 D
+3 3 D
+-10 1 D
+8 0 D
+0 2 D
+-16 -1 D
+15 2 D
+-4 2 D
+5 -1 D
+-1 2 D
+-5 0 D
+7 2 D
+-5 0 D
+2 4 D
+-11 -1 D
+-4 -5 D
+-4 5 D
+15 7 D
+-8 0 D
+-10 -5 D
+6 6 D
+-17 -4 D
+15 7 D
+-26 5 D
+-5 -1 D
+1 4 D
+-20 4 D
+-14 -2 D
+-7 -6 D
+6 7 D
+-25 0 D
+41 2 D
+-6 2 D
+3 3 D
+-13 3 D
+-7 0 D
+-15 -2 D
+-10 -5 D
+7 5 D
+-12 0 D
+10 1 D
+-8 2 D
+-17 0 D
+19 0 D
+12 -2 D
+11 3 D
+13 1 D
+1 3 D
+-31 3 D
+-6 -2 D
+-14 0 D
+-5 -4 D
+2 4 D
+-8 0 D
+11 2 D
+12 -1 D
+9 2 D
+-17 3 D
+-6 3 D
+13 -4 D
+8 1 D
+11 -3 D
+13 3 D
+1 2 D
+17 1 D
+-22 7 D
+-4 4 D
+20 -8 D
+11 -2 D
+-1 4 D
+9 2 D
+31 -6 D
+14 2 D
+-13 -2 D
+-20 4 D
+-11 -1 D
+16 -6 D
+24 -4 D
+19 3 D
+0 3 D
+28 0 D
+-3 5 D
+6 4 D
+-20 1 D
+-14 4 D
+-5 -3 D
+2 -7 D
+-2 5 D
+-13 4 D
+7 1 D
+-5 2 D
+8 3 D
+-9 0 D
+12 1 D
+3 2 D
+-7 4 D
+10 -3 D
+30 0 D
+4 -4 D
+6 -1 D
+0 9 D
+-5 1 D
+-21 -1 D
+11 2 D
+0 8 D
+-13 1 D
+-14 -3 D
+-16 5 D
+16 -5 D
+14 3 D
+16 1 D
+-22 7 D
+-26 3 D
+26 -3 D
+-16 5 D
+33 -8 D
+13 0 D
+4 -3 D
+0 10 D
+-13 2 D
+13 -2 D
+0 8 D
+-45 0 D
+-1 2 D
+36 -1 D
+10 1 D
+0 5 D
+-12 -1 D
+-15 2 D
+9 -2 D
+-10 2 D
+-16 -2 D
+5 5 D
+-22 1 D
+5 1 D
+10 -1 D
+6 1 D
+-9 -1 D
+8 2 D
+-12 0 D
+9 1 D
+-21 3 D
+10 1 D
+3 3 D
+12 -6 D
+9 4 D
+12 1 D
+-21 1 D
+27 0 D
+-18 1 D
+5 1 D
+26 -1 D
+0 11 D
+-20 1 D
+19 1 D
+-26 2 D
+15 -1 D
+-8 1 D
+14 0 D
+-17 2 D
+5 3 D
+7 -2 D
+11 1 D
+0 3 D
+-17 2 D
+-4 2 D
+-13 -8 D
+-13 0 D
+14 10 D
+-11 1 D
+11 0 D
+11 11 D
+-12 1 D
+12 1 D
+-7 0 D
+0 3 D
+12 0 D
+0 2 D
+15 -1 D
+-2 5 D
+4 0 D
+0 18 D
+-10 -2 D
+-1 3 D
+-9 -1 D
+7 4 D
+-224 0 D
+0 -236 D
+P
+3774 3946 M
+0 -1 D
+-19 3 D
+-22 -1 D
+23 1 D
+P
+3724 4006 M
+-8 -1 D
+-11 2 D
+25 -1 D
+P
+3724 3981 M
+-12 0 D
+0 1 D
+P
+3760 3995 M
+-5 0 D
+P
+3744 3956 M
+17 -7 D
+-18 7 D
+P
+FO
+3723 3780 M
+7 2 D
+-1 1 D
+-15 -1 D
+-26 1 D
+-28 5 D
+-6 -2 D
+1 3 D
+-25 -5 D
+-14 2 D
+-9 -6 D
+P
+FO
+3780 3895 M
+-5 1 D
+4 2 D
+-9 1 D
+-5 -5 D
+9 -3 D
+6 1 D
+P
+FO
+3780 3967 M
+-12 1 D
+12 -3 D
+P
+FO
+3779 4016 M
+-5 -4 D
+6 0 D
+0 4 D
+P
+FO
+3685 3838 M
+18 -3 D
+13 -4 D
+3 1 D
+1 -2 D
+9 0 D
+3 3 D
+-7 0 D
+-11 4 D
+19 -1 D
+1 2 D
+-7 0 D
+-22 8 D
+-32 1 D
+4 -6 D
+P
+FO
+3591 3790 M
+41 3 D
+4 -1 D
+18 3 D
+-4 3 D
+2 4 D
+-8 1 D
+0 2 D
+-18 -4 D
+-14 0 D
+-14 -6 D
+-6 0 D
+-5 -4 D
+P
+FO
+3685 3848 M
+25 -1 D
+8 -4 D
+17 1 D
+-7 2 D
+6 3 D
+-32 3 D
+-30 -2 D
+1 -2 D
+P
+FO
+3709 3853 M
+3 1 D
+-47 3 D
+39 -1 D
+-33 5 D
+-16 -1 D
+-12 -5 D
+32 -4 D
+P
+FO
+3732 3880 M
+17 -4 D
+28 2 D
+-10 6 D
+-14 0 D
+-12 0 D
+P
+FO
+3627 3792 M
+5 -2 D
+4 2 D
+-4 1 D
+2 -1 D
+-6 0 D
+P
+FO
+3762 3929 M
+8 -2 D
+-2 2 D
+6 0 D
+P
+FO
+3756 3933 M
+-5 -1 D
+6 -2 D
+5 3 D
+P
+FO
+3742 3936 M
+10 -2 D
+1 2 D
+P
+FO
+3596 3800 M
+2 -3 D
+10 4 D
+P
+FO
+3661 3845 M
+5 3 D
+-13 -1 D
+P
+FO
+3650 3805 M
+4 -2 D
+P
+FO
+3752 3968 M
+-6 -2 D
+P
+FO
+3769 3960 M
+10 -1 D
+-3 2 D
+P
+FO
+3760 3973 M
+11 1 D
+P
+FO
+3762 3930 M
+14 0 D
+P
+FO
+3745 3853 M
+7 1 D
+P
+FO
+3756 3933 M
+8 2 D
+P
+FO
+3743 3933 M
+7 0 D
+-6 0 D
+P
+FO
+3651 3807 M
+4 -1 D
+P
+FO
+3769 3940 M
+5 1 D
+P
+FO
+3766 3932 M
+6 1 D
+P
+FO
+3760 3874 M
+-3 1 D
+P
+FO
+3745 3937 M
+6 0 D
+P
+FO
+3764 3969 M
+6 1 D
+P
+FO
+3646 3805 M
+2 -1 D
+P
+FO
+3737 3810 M
+4 -1 D
+P
+FO
+3763 3961 M
+3 -1 D
+P
+FO
+3759 3987 M
+4 1 D
+P
+FO
+3647 3806 M
+4 0 D
+P
+FO
+3648 3805 M
+2 -1 D
+P
+FO
+3744 3796 M
+3 -1 D
+P
+FO
+3780 4012 M
+3 0 D
+-3 0 D
+0 -18 D
+9 1 D
+5 4 D
+1 -3 D
+5 1 D
+2 2 D
+-13 1 D
+-7 -4 D
+5 12 D
+9 3 D
+26 -1 D
+13 6 D
+-55 0 D
+P
+FO
+3780 3965 M
+18 -1 D
+-4 2 D
+-14 1 D
+P
+FO
+3780 3962 M
+16 -3 D
+7 1 D
+-4 2 D
+-19 3 D
+P
+FO
+3780 3943 M
+34 -5 D
+6 3 D
+-3 12 D
+-14 1 D
+1 -4 D
+-11 1 D
+-13 3 D
+P
+FO
+3780 3922 M
+5 0 D
+0 3 D
+-5 2 D
+P
+FO
+3780 3912 M
+0 -10 D
+9 -1 D
+6 7 D
+-5 7 D
+5 0 D
+-15 5 D
+P
+FO
+3780 3892 M
+6 2 D
+-6 1 D
+P
+FO
+3780 3880 M
+8 0 D
+16 5 D
+-10 2 D
+0 3 D
+-8 -2 D
+-6 1 D
+P
+FO
+3808 3898 M
+21 0 D
+7 -2 D
+6 2 D
+-1 3 D
+-9 -1 D
+-6 3 D
+-4 0 D
+9 2 D
+-5 3 D
+-6 -4 D
+-5 3 D
+-11 -1 D
+P
+FO
+3816 3921 M
+-6 15 D
+-9 2 D
+7 -3 D
+-7 0 D
+-2 -2 D
+17 -13 D
+P
+FO
+3785 3987 M
+8 -1 D
+6 1 D
+-10 0 D
+10 0 D
+-6 0 D
+5 4 D
+P
+FO
+3803 3887 M
+6 0 D
+-3 3 D
+-8 -2 D
+P
+FO
+3803 3975 M
+-8 1 D
+2 -2 D
+P
+FO
+3827 3961 M
+9 4 D
+-3 2 D
+-13 -6 D
+P
+FO
+3785 3976 M
+6 0 D
+-4 2 D
+P
+FO
+3827 3993 M
+9 1 D
+-4 4 D
+P
+FO
+3812 3891 M
+6 -2 D
+1 2 D
+P
+FO
+3818 3988 M
+1 -2 D
+2 3 D
+P
+FO
+3793 3977 M
+4 -1 D
+3 1 D
+P
+FO
+3809 3983 M
+9 2 D
+P
+FO
+3807 3938 M
+3 -1 D
+P
+FO
+3809 3937 M
+4 -1 D
+P
+FO
+3786 3968 M
+4 -2 D
+P
+FO
+3780 3969 M
+5 0 D
+P
+FO
+3803 3972 M
+-2 -2 D
+P
+FO
+3793 3995 M
+1 3 D
+-3 -2 D
+P
+FO
+3782 3939 M
+4 2 D
+P
+FO
+3780 3958 M
+3 -1 D
+P
+FO
+3781 3938 M
+6 -1 D
+P
+FO
+3803 3980 M
+-6 -1 D
+P
+FO
+3793 3972 M
+2 1 D
+P
+FO
+3788 3974 M
+4 1 D
+-4 0 D
+P
+FO
+3798 3973 M
+5 1 D
+P
+FO
+4059 3806 M
+-21 -7 D
+25 5 D
+2 3 D
+P
+FO
+4376 3543 M
+-1 3 D
+P
+FO
+4379 3543 M
+0 2 D
+P
+FO
+4386 3543 M
+1 1 D
+3 -1 D
+4 7 D
+4 0 D
+-1 2 D
+14 4 D
+-1 -3 D
+8 4 D
+-3 -2 D
+6 0 D
+-8 0 D
+-3 -3 D
+-3 -7 D
+3 8 D
+-8 -1 D
+-6 -4 D
+1 -2 D
+4 0 D
+-6 -1 D
+-1 -2 D
+94 0 D
+0 79 D
+-4 0 D
+4 3 D
+-6 4 D
+-6 -1 D
+2 -1 D
+-2 1 D
+-2 -2 D
+0 1 D
+-6 -1 D
+9 0 D
+-8 -2 D
+1 -1 D
+6 1 D
+-9 -3 D
+2 2 D
+-4 2 D
+0 -1 D
+-9 0 D
+5 -2 D
+-5 0 D
+1 1 D
+-4 0 D
+2 -4 D
+9 0 D
+-11 -1 D
+3 -2 D
+-11 1 D
+2 -2 D
+6 0 D
+-3 -2 D
+6 1 D
+-5 -1 D
+6 -3 D
+-6 2 D
+2 -2 D
+-5 1 D
+1 2 D
+-5 4 D
+-6 -3 D
+3 1 D
+13 -9 D
+-10 4 D
+-2 3 D
+-8 -1 D
+2 1 D
+-8 -1 D
+-4 3 D
+-7 -2 D
+0 -3 D
+6 0 D
+-6 0 D
+0 -2 D
+16 1 D
+-8 -2 D
+17 2 D
+2 -2 D
+-4 1 D
+-11 -2 D
+1 -2 D
+-3 1 D
+9 -1 D
+-5 -2 D
+-10 3 D
+0 -2 D
+-2 3 D
+-4 0 D
+0 -2 D
+-3 2 D
+-4 -2 D
+-1 1 D
+-7 -1 D
+0 -1 D
+11 -1 D
+-11 -1 D
+13 1 D
+4 -4 D
+10 -1 D
+-9 0 D
+-2 -4 D
+6 0 D
+-8 0 D
+4 4 D
+-7 4 D
+-4 -1 D
+1 -2 D
+-5 2 D
+6 -5 D
+-2 -2 D
+-5 6 D
+-9 -2 D
+3 -2 D
+-4 1 D
+9 -4 D
+-6 0 D
+-2 2 D
+-3 -3 D
+2 4 D
+-6 0 D
+1 -2 D
+-5 2 D
+-2 -1 D
+5 -2 D
+-4 -1 D
+-3 3 D
+-6 1 D
+1 -2 D
+7 -2 D
+-5 -2 D
+-1 1 D
+0 -2 D
+7 1 D
+12 -1 D
+-6 0 D
+2 -1 D
+25 1 D
+-9 -2 D
+-9 1 D
+2 -2 D
+-4 2 D
+-2 -3 D
+1 3 D
+-8 -1 D
+2 2 D
+-12 0 D
+4 -1 D
+-6 -2 D
+4 0 D
+-3 -1 D
+-4 0 D
+0 -2 D
+10 0 D
+-10 -1 D
+11 -1 D
+-6 1 D
+5 -1 D
+-6 -1 D
+16 -1 D
+-14 0 D
+-6 -1 D
+4 0 D
+-3 -1 D
+1 -1 D
+14 1 D
+-16 -2 D
+0 -2 D
+7 -1 D
+-5 1 D
+4 -3 D
+19 3 D
+0 -2 D
+4 1 D
+6 -1 D
+1 3 D
+3 1 D
+-1 -2 D
+9 -1 D
+4 2 D
+-5 -3 D
+9 1 D
+-1 5 D
+7 3 D
+-6 -5 D
+2 -2 D
+7 0 D
+-8 -2 D
+3 -1 D
+-6 1 D
+-5 -1 D
+4 -4 D
+-2 -1 D
+-1 3 D
+-5 -2 D
+4 4 D
+-9 2 D
+-6 -4 D
+1 2 D
+-4 -1 D
+1 1 D
+-8 1 D
+-11 -2 D
+-1 -1 D
+-7 2 D
+-3 -1 D
+4 -2 D
+-2 -2 D
+-3 2 D
+2 -3 D
+4 -1 D
+6 3 D
+2 -1 D
+-5 -1 D
+-3 -2 D
+5 -3 D
+-12 4 D
+7 -4 D
+-3 1 D
+4 -3 D
+10 5 D
+-1 -1 D
+3 1 D
+-2 -7 D
+-6 -1 D
+-4 3 D
+1 -4 D
+-4 0 D
+4 -1 D
+-3 -1 D
+6 -4 D
+7 7 D
+-3 -4 D
+3 0 D
+-4 -2 D
+4 1 D
+0 -3 D
+-5 0 D
+-4 -2 D
+P
+4450 3576 M
+20 -1 D
+-8 -1 D
+-14 2 D
+P
+4441 3562 M
+4 -2 D
+-5 1 D
+P
+4432 3548 M
+4 -1 D
+-6 0 D
+P
+4454 3554 M
+7 -1 D
+1 -2 D
+P
+4404 3589 M
+-8 -1 D
+P
+4403 3582 M
+-3 3 D
+P
+4446 3547 M
+2 -2 D
+P
+4452 3588 M
+15 0 D
+P
+FO
+4488 3628 M
+-1 -2 D
+1 0 D
+P
+FO
+4488 3632 M
+-4 -2 D
+1 -2 D
+3 0 D
+P
+FO
+4488 3635 M
+-7 -1 D
+-3 -2 D
+6 0 D
+-8 -3 D
+12 3 D
+P
+FO
+4488 3636 M
+-1 0 D
+P
+FO
+4488 3639 M
+-1 -3 D
+P
+FO
+4465 3629 M
+-4 -1 D
+0 2 D
+-14 -4 D
+6 -2 D
+13 2 D
+3 2 D
+-5 0 D
+P
+FO
+4394 3598 M
+2 1 D
+-5 2 D
+-1 -4 D
+-7 1 D
+2 -2 D
+-2 0 D
+5 -1 D
+P
+FO
+4378 3556 M
+9 -2 D
+0 6 D
+-2 0 D
+-3 -4 D
+P
+FO
+4429 3613 M
+5 1 D
+-1 3 D
+-2 -3 D
+-5 2 D
+0 -2 D
+P
+FO
+4370 3587 M
+-2 -2 D
+8 2 D
+-7 1 D
+-3 -1 D
+P
+FO
+4441 3619 M
+-2 -2 D
+6 1 D
+-1 2 D
+P
+FO
+4441 3621 M
+5 2 D
+-2 2 D
+-9 -1 D
+P
+FO
+4370 3548 M
+4 0 D
+0 4 D
+-4 2 D
+P
+FO
+4369 3570 M
+-2 2 D
+-2 -5 D
+5 2 D
+0 2 D
+P
+FO
+4447 3620 M
+2 -2 D
+6 0 D
+-3 3 D
+P
+FO
+4370 3590 M
+3 -1 D
+0 2 D
+P
+FO
+4394 3604 M
+3 -1 D
+0 1 D
+P
+FO
+4370 3557 M
+6 -2 D
+-2 2 D
+P
+FO
+4459 3630 M
+3 2 D
+-3 1 D
+-12 -3 D
+P
+FO
+4412 3610 M
+3 -1 D
+2 2 D
+P
+FO
+4370 3560 M
+-3 1 D
+8 -4 D
+P
+FO
+4370 3556 M
+2 -2 D
+4 -1 D
+P
+FO
+4363 3574 M
+2 0 D
+P
+FO
+4409 3607 M
+7 1 D
+P
+FO
+4368 3565 M
+1 -1 D
+P
+FO
+4371 3580 M
+3 0 D
+P
+FO
+4396 3601 M
+4 1 D
+P
+FO
+4373 3547 M
+1 -2 D
+P
+FO
+4370 3589 M
+3 -1 D
+P
+FO
+4436 3614 M
+2 0 D
+P
+FO
+4443 3621 M
+3 1 D
+P
+FO
+4434 3617 M
+2 0 D
+P
+FO
+4366 3556 M
+1 1 D
+P
+FO
+4441 3621 M
+3 0 D
+P
+FO
+4368 3559 M
+2 -1 D
+P
+FO
+4365 3580 M
+3 0 D
+P
+FO
+4455 3632 M
+3 1 D
+P
+FO
+4371 3560 M
+3 -1 D
+P
+FO
+4399 3601 M
+-4 0 D
+7 -1 D
+P
+FO
+4394 3547 M
+-1 -2 D
+P
+FO
+4445 3619 M
+4 -1 D
+P
+FO
+4363 3567 M
+0 2 D
+P
+FO
+4365 3565 M
+4 -2 D
+P
+FO
+4370 3566 M
+1 -3 D
+P
+FO
+4370 3561 M
+-2 2 D
+-2 -1 D
+P
+FO
+4465 3629 M
+4 0 D
+P
+FO
+4384 3598 M
+4 1 D
+P
+FO
+4365 3557 M
+0 2 D
+P
+FO
+4370 3566 M
+-2 1 D
+P
+FO
+4365 3586 M
+3 -1 D
+P
+FO
+4406 3606 M
+3 1 D
+P
+FO
+4366 3583 M
+2 -1 D
+P
+FO
+4371 3571 M
+1 -1 D
+P
+FO
+4382 3599 M
+2 0 D
+P
+FO
+4399 3607 M
+3 -1 D
+P
+FO
+4449 3621 M
+3 1 D
+-3 0 D
+P
+FO
+4435 3617 M
+3 0 D
+P
+FO
+4403 3609 M
+2 -1 D
+P
+FO
+4398 3606 M
+2 -1 D
+P
+FO
+4368 3581 M
+-2 1 D
+-1 -1 D
+P
+FO
+4397 3605 M
+2 0 D
+-2 1 D
+P
+FO
+4379 3597 M
+3 -1 D
+P
+FO
+4371 3578 M
+3 0 D
+P
+FO
+4489 3543 M
+3 3 D
+1 -2 D
+3 2 D
+0 -3 D
+65 0 D
+-2 3 D
+1 0 D
+1 -3 D
+137 0 D
+-1 3 D
+-2 -2 D
+-4 3 D
+0 -2 D
+-6 6 D
+7 -2 D
+-5 1 D
+1 1 D
+-5 0 D
+-6 7 D
+-6 -3 D
+-3 4 D
+-10 0 D
+4 2 D
+-3 1 D
+2 2 D
+-4 2 D
+2 1 D
+-2 0 D
+2 6 D
+-3 1 D
+4 0 D
+-3 0 D
+3 0 D
+-4 3 D
+3 0 D
+-4 3 D
+4 0 D
+-5 1 D
+5 0 D
+-3 1 D
+4 0 D
+-4 2 D
+9 -2 D
+-4 7 D
+4 7 D
+4 0 D
+-6 2 D
+-2 4 D
+3 1 D
+7 -3 D
+-2 2 D
+5 0 D
+0 4 D
+3 0 D
+-7 8 D
+3 0 D
+2 -4 D
+3 1 D
+2 -2 D
+4 1 D
+-2 2 D
+3 -2 D
+4 2 D
+-2 2 D
+3 -1 D
+-8 1 D
+5 1 D
+-1 1 D
+2 -1 D
+1 3 D
+5 0 D
+-1 2 D
+2 -2 D
+3 1 D
+-4 2 D
+4 0 D
+4 -2 D
+7 7 D
+4 -2 D
+-2 4 D
+5 -4 D
+8 6 D
+0 107 D
+-28 3 D
+-5 4 D
+15 -4 D
+15 0 D
+-7 -2 D
+10 -1 D
+0 26 D
+-2 -1 D
+2 2 D
+0 6 D
+-6 0 D
+-2 -4 D
+-4 -1 D
+5 2 D
+1 8 D
+-12 -1 D
+-7 -3 D
+1 -2 D
+7 -1 D
+-4 1 D
+-3 -2 D
+4 -2 D
+5 0 D
+5 -4 D
+-7 0 D
+2 3 D
+-9 1 D
+-3 4 D
+-9 -1 D
+0 -2 D
+13 -3 D
+-8 1 D
+1 -2 D
+-4 2 D
+-1 -2 D
+-3 5 D
+-5 0 D
+-5 -6 D
+6 -2 D
+-13 -1 D
+-4 -2 D
+-1 -3 D
+6 1 D
+4 -1 D
+-4 1 D
+-5 -2 D
+8 -2 D
+-8 2 D
+-5 -2 D
+10 -2 D
+-10 2 D
+-3 -2 D
+-4 1 D
+-8 -1 D
+0 -3 D
+-4 -1 D
+1 -1 D
+12 2 D
+1 -2 D
+12 2 D
+-2 -2 D
+10 -1 D
+-14 0 D
+0 -5 D
+-3 5 D
+-8 -2 D
+-2 2 D
+-11 -1 D
+12 -5 D
+-15 4 D
+5 -2 D
+-4 -1 D
+6 1 D
+3 -1 D
+-4 0 D
+-2 -2 D
+3 0 D
+-3 -2 D
+4 -2 D
+-5 2 D
+4 -3 D
+-7 3 D
+1 -3 D
+7 -2 D
+-7 2 D
+-5 9 D
+-8 -5 D
+-1 3 D
+-8 -3 D
+3 -2 D
+3 3 D
+9 -2 D
+-1 -3 D
+-4 2 D
+-12 -3 D
+1 1 D
+-9 -1 D
+6 0 D
+-7 0 D
+0 -2 D
+7 0 D
+-8 -1 D
+0 -2 D
+9 2 D
+5 3 D
+11 -4 D
+-12 1 D
+-4 -2 D
+7 -1 D
+-5 0 D
+-1 -1 D
+8 -1 D
+8 1 D
+-8 -2 D
+1 -2 D
+3 1 D
+-3 -2 D
+-3 3 D
+-7 -1 D
+2 2 D
+-7 -1 D
+1 2 D
+-8 -2 D
+10 -1 D
+-5 -1 D
+-5 1 D
+-8 -4 D
+10 1 D
+0 -2 D
+10 2 D
+-3 -1 D
+11 -1 D
+-3 0 D
+1 -1 D
+-7 1 D
+-3 -2 D
+1 2 D
+-5 0 D
+-11 -1 D
+-3 -2 D
+5 0 D
+-5 0 D
+-2 -3 D
+-2 3 D
+-1 -3 D
+-1 2 D
+-4 -2 D
+-7 0 D
+4 -3 D
+7 -1 D
+-11 0 D
+6 -1 D
+-7 0 D
+10 -1 D
+-4 0 D
+-12 0 D
+8 -2 D
+-8 1 D
+5 -1 D
+-5 -2 D
+12 1 D
+-6 -1 D
+5 -1 D
+-10 1 D
+3 -2 D
+-3 0 D
+-3 2 D
+-4 0 D
+5 -2 D
+-4 -3 D
+13 -1 D
+-9 0 D
+-4 -3 D
+28 4 D
+-9 -3 D
+0 1 D
+-5 -1 D
+6 -2 D
+-7 0 D
+-1 2 D
+-20 -3 D
+9 0 D
+-3 -3 D
+5 0 D
+2 -3 D
+-8 3 D
+-5 -1 D
+1 -3 D
+-4 -1 D
+6 -3 D
+-7 3 D
+-3 -3 D
+1 -2 D
+3 1 D
+0 -2 D
+1 2 D
+1 -3 D
+4 0 D
+-4 0 D
+2 -2 D
+-6 2 D
+2 -1 D
+-6 4 D
+-2 -3 D
+4 0 D
+-8 -6 D
+11 4 D
+-6 -3 D
+5 1 D
+-3 -1 D
+4 -1 D
+-3 -1 D
+14 4 D
+-12 -6 D
+-6 3 D
+-17 -6 D
+2 -1 D
+-3 1 D
+-3 -1 D
+10 0 D
+-11 -1 D
+-2 -2 D
+6 1 D
+-5 -2 D
+22 5 D
+-8 -2 D
+-4 -1 D
+5 0 D
+-11 -3 D
+3 -3 D
+7 1 D
+-7 -1 D
+-2 -2 D
+10 -1 D
+-11 0 D
+-4 -3 D
+3 3 D
+-4 0 D
+-5 4 D
+0 -2 D
+-7 -1 D
+4 -2 D
+-8 1 D
+4 -2 D
+-5 0 D
+1 -1 D
+-5 -2 D
+2 -1 D
+-4 1 D
+-2 -2 D
+3 -1 D
+-6 0 D
+0 -3 D
+4 0 D
+-4 -1 D
+5 1 D
+1 -1 D
+-6 -1 D
+0 -3 D
+3 1 D
+-3 -1 D
+0 -6 D
+23 6 D
+2 3 D
+-11 -2 D
+19 7 D
+-4 -1 D
+6 -1 D
+-10 -4 D
+6 1 D
+4 -2 D
+-12 -2 D
+-8 -4 D
+7 2 D
+-4 -3 D
+5 -1 D
+-18 0 D
+-3 -2 D
+4 -1 D
+-6 0 D
+0 -79 D
+P
+4679 3679 M
+-2 3 D
+-3 1 D
+-3 -2 D
+0 3 D
+-6 2 D
+-2 -1 D
+-2 3 D
+6 -2 D
+-1 2 D
+3 -2 D
+5 1 D
+-21 7 D
+1 2 D
+25 -9 D
+-4 -1 D
+0 -3 D
+15 -6 D
+-8 1 D
+-1 -3 D
+P
+4579 3653 M
+12 -6 D
+15 -1 D
+6 -4 D
+-5 4 D
+5 0 D
+3 -7 D
+11 -7 D
+-4 2 D
+-3 -2 D
+0 3 D
+-7 1 D
+1 1 D
+3 -2 D
+1 2 D
+-9 7 D
+-17 3 D
+-15 6 D
+P
+4587 3622 M
+6 -2 D
+1 1 D
+7 -5 D
+-8 2 D
+0 -9 D
+-2 8 D
+-10 4 D
+5 -2 D
+-3 3 D
+P
+4593 3619 M
+4 0 D
+-3 0 D
+P
+4499 3569 M
+7 -7 D
+5 -1 D
+-2 3 D
+5 -2 D
+1 -4 D
+3 -1 D
+-1 -4 D
+-1 3 D
+-11 6 D
+P
+4511 3561 M
+1 -1 D
+P
+4643 3716 M
+-6 2 D
+5 0 D
+-3 2 D
+12 1 D
+-6 1 D
+13 0 D
+-17 -3 D
+7 -2 D
+P
+4598 3566 M
+6 -3 D
+5 1 D
+-3 -4 D
+-2 3 D
+-4 -2 D
+-5 3 D
+0 3 D
+P
+4719 3709 M
+-11 2 D
+-13 7 D
+-37 7 D
+4 0 D
+-7 2 D
+41 -9 D
+P
+4612 3602 M
+5 -1 D
+-8 -1 D
+1 -4 D
+-5 5 D
+5 -1 D
+2 2 D
+2 -1 D
+P
+4584 3677 M
+-7 1 D
+4 0 D
+-3 3 D
+4 -1 D
+11 3 D
+-6 -2 D
+P
+4663 3555 M
+-5 -4 D
+-8 -1 D
+-1 -3 D
+-7 0 D
+6 1 D
+0 2 D
+P
+4565 3631 M
+1 -1 D
+-7 0 D
+4 -1 D
+-3 -1 D
+8 -4 D
+-12 6 D
+P
+4596 3633 M
+-6 4 D
+-5 0 D
+3 1 D
+-9 4 D
+21 -9 D
+P
+4708 3701 M
+-18 5 D
+-12 -1 D
+-7 2 D
+30 -2 D
+11 -4 D
+-3 0 D
+P
+4714 3699 M
+-3 1 D
+7 0 D
+-4 2 D
+6 -2 D
+P
+4621 3643 M
+7 -2 D
+-2 -4 D
+-1 4 D
+-8 3 D
+P
+4645 3695 M
+-6 2 D
+-2 3 D
+3 -3 D
+9 -2 D
+-3 0 D
+P
+4692 3692 M
+-4 2 D
+-6 0 D
+-6 2 D
+14 -1 D
+P
+4611 3663 M
+6 -2 D
+-15 2 D
+8 -1 D
+P
+4628 3660 M
+17 -7 D
+3 -4 D
+-18 8 D
+P
+4576 3654 M
+-7 4 D
+1 2 D
+4 -1 D
+P
+4617 3673 M
+-8 4 D
+9 -4 D
+7 0 D
+P
+4607 3685 M
+-11 3 D
+6 0 D
+7 -3 D
+-2 -1 D
+P
+4674 3693 M
+-11 3 D
+9 -2 D
+-1 3 D
+P
+4695 3700 M
+-11 3 D
+12 -1 D
+P
+4619 3674 M
+-6 4 D
+5 -1 D
+3 -4 D
+P
+4720 3655 M
+-3 3 D
+5 -2 D
+-3 1 D
+P
+4640 3606 M
+0 -1 D
+-3 1 D
+P
+4493 3562 M
+6 -9 D
+-1 -4 D
+P
+4621 3571 M
+3 -3 D
+-8 4 D
+P
+4723 3726 M
+-21 2 D
+9 1 D
+P
+4690 3709 M
+-11 1 D
+9 1 D
+P
+4651 3558 M
+0 -2 D
+-7 1 D
+P
+4609 3613 M
+7 -5 D
+-9 3 D
+P
+4637 3705 M
+-5 1 D
+19 -1 D
+P
+4514 3621 M
+-3 -2 D
+-11 1 D
+P
+4667 3729 M
+-8 5 D
+6 -2 D
+P
+4534 3655 M
+-6 -2 D
+-5 1 D
+12 1 D
+P
+4647 3589 M
+3 -3 D
+-7 2 D
+P
+4651 3573 M
+3 -1 D
+-10 0 D
+P
+4534 3600 M
+-1 -11 D
+-4 4 D
+P
+4641 3608 M
+7 -3 D
+-11 4 D
+P
+4700 3718 M
+-12 3 D
+16 -3 D
+-3 0 D
+P
+4550 3622 M
+-1 -2 D
+-3 1 D
+P
+4651 3633 M
+1 -2 D
+-5 2 D
+P
+4550 3630 M
+1 -2 D
+-6 2 D
+P
+4543 3600 M
+4 -3 D
+-6 1 D
+1 2 D
+P
+4527 3553 M
+2 -3 D
+-5 2 D
+P
+4655 3663 M
+-19 9 D
+23 -9 D
+P
+4585 3658 M
+4 -1 D
+-2 -2 D
+P
+4529 3607 M
+2 -2 D
+-8 2 D
+P
+4645 3587 M
+4 -2 D
+-5 1 D
+P
+4571 3661 M
+-1 2 D
+8 -1 D
+-6 -2 D
+P
+4567 3619 M
+4 -1 D
+-9 1 D
+5 1 D
+P
+4556 3639 M
+0 3 D
+1 -5 D
+P
+4546 3632 M
+8 -2 D
+-8 1 D
+P
+4629 3592 M
+2 -2 D
+-5 0 D
+P
+4607 3548 M
+3 -1 D
+-5 1 D
+1 1 D
+P
+4587 3701 M
+-3 1 D
+3 1 D
+P
+4638 3583 M
+1 -4 D
+-5 4 D
+P
+4608 3671 M
+-2 0 D
+8 0 D
+-5 0 D
+P
+4583 3693 M
+-4 2 D
+10 -1 D
+P
+4617 3567 M
+2 -1 D
+-6 0 D
+P
+4536 3617 M
+0 -2 D
+-3 2 D
+P
+4549 3567 M
+-1 -2 D
+-1 2 D
+P
+4532 3627 M
+-2 1 D
+4 0 D
+P
+4563 3610 M
+1 -1 D
+-4 0 D
+P
+4525 3639 M
+1 2 D
+18 3 D
+P
+4563 3653 M
+5 4 D
+6 -3 D
+-10 -1 D
+P
+4643 3659 M
+-11 7 D
+16 -8 D
+P
+4558 3637 M
+2 -5 D
+-7 5 D
+P
+4598 3614 M
+2 -8 D
+-5 6 D
+P
+4722 3741 M
+-21 6 D
+18 -3 D
+P
+4525 3590 M
+3 -2 D
+P
+4525 3634 M
+1 2 D
+P
+4581 3566 M
+5 -3 D
+P
+4632 3704 M
+-2 2 D
+P
+4517 3583 M
+3 -7 D
+P
+4640 3547 M
+-3 -1 D
+P
+4653 3616 M
+4 -2 D
+P
+4627 3631 M
+6 -3 D
+P
+4659 3703 M
+-4 2 D
+P
+4632 3671 M
+1 0 D
+-5 1 D
+P
+4664 3675 M
+-14 5 D
+13 -3 D
+P
+4716 3755 M
+-3 2 D
+P
+4530 3574 M
+5 -4 D
+P
+4651 3561 M
+-1 -2 D
+P
+4611 3571 M
+1 -1 D
+P
+4663 3547 M
+-4 0 D
+5 0 D
+P
+4550 3603 M
+7 -3 D
+P
+4647 3706 M
+-9 3 D
+10 -3 D
+P
+4558 3620 M
+-1 0 D
+4 -1 D
+P
+4514 3553 M
+0 -3 D
+P
+4547 3554 M
+2 -1 D
+P
+4607 3668 M
+1 -3 D
+P
+4488 3556 M
+2 -4 D
+P
+4627 3573 M
+-2 -2 D
+P
+4565 3582 M
+11 -5 D
+P
+4624 3557 M
+-5 -2 D
+P
+4539 3613 M
+5 -2 D
+P
+4597 3570 M
+-1 -3 D
+0 3 D
+P
+4602 3615 M
+3 -3 D
+P
+4581 3629 M
+8 -2 D
+P
+4714 3742 M
+1 0 D
+-8 2 D
+P
+4652 3709 M
+-3 0 D
+P
+4606 3581 M
+1 -1 D
+P
+4674 3696 M
+-12 7 D
+P
+4565 3593 M
+5 -1 D
+P
+4581 3562 M
+-2 -2 D
+P
+4617 3547 M
+2 -2 D
+P
+4565 3665 M
+1 2 D
+P
+4558 3566 M
+2 -2 D
+-3 2 D
+P
+FO
+4492 3543 M
+-1 0 D
+P
+FO
+4724 3547 M
+-1 1 D
+1 0 D
+0 4 D
+-5 1 D
+3 -2 D
+-2 -3 D
+0 3 D
+-4 -1 D
+2 -4 D
+4 -1 D
+1 1 D
+0 -2 D
+P
+FO
+4724 3775 M
+-5 -3 D
+5 -1 D
+P
+FO
+4719 3780 M
+0 -1 D
+-8 -3 D
+7 0 D
+P
+FO
+4710 3780 M
+-1 -1 D
+0 1 D
+-10 0 D
+-5 -2 D
+12 -3 D
+11 4 D
+0 1 D
+-1 0 D
+P
+FO
+4694 3780 M
+0 -1 D
+P
+FO
+4606 3739 M
+13 5 D
+-5 -3 D
+7 -2 D
+4 4 D
+2 -2 D
+3 1 D
+2 3 D
+10 1 D
+2 6 D
+-8 2 D
+2 -2 D
+-6 0 D
+4 -2 D
+-4 0 D
+0 -3 D
+-2 1 D
+-6 -3 D
+6 6 D
+-5 -1 D
+3 5 D
+-7 0 D
+1 -3 D
+-5 -2 D
+6 -1 D
+-6 0 D
+4 -2 D
+-10 -1 D
+5 -3 D
+-5 0 D
+-5 -3 D
+P
+FO
+4676 3768 M
+-3 -1 D
+1 3 D
+-2 -2 D
+-4 2 D
+1 -3 D
+-4 3 D
+5 -3 D
+-9 2 D
+1 -2 D
+3 -1 D
+-5 0 D
+3 -2 D
+-4 2 D
+-9 -1 D
+8 -1 D
+-7 -1 D
+7 0 D
+-7 -2 D
+7 0 D
+-10 -4 D
+9 1 D
+0 -2 D
+8 5 D
+0 -2 D
+12 1 D
+-3 1 D
+4 4 D
+P
+FO
+4606 3746 M
+10 3 D
+-6 7 D
+-4 -1 D
+4 -3 D
+-6 0 D
+0 -2 D
+-6 2 D
+0 -2 D
+-2 2 D
+-3 -2 D
+3 0 D
+-5 -1 D
+4 -3 D
+4 3 D
+2 -1 D
+9 2 D
+0 -1 D
+-9 -2 D
+P
+FO
+4701 3773 M
+-1 2 D
+-7 2 D
+1 -5 D
+-2 3 D
+-3 -2 D
+-3 2 D
+-1 -2 D
+7 -1 D
+-10 1 D
+5 -2 D
+-10 -2 D
+17 0 D
+1 3 D
+P
+FO
+4606 3741 M
+5 3 D
+-10 -3 D
+0 2 D
+-9 -1 D
+2 -2 D
+-4 0 D
+-2 -4 D
+10 2 D
+2 3 D
+0 -2 D
+P
+FO
+4583 3739 M
+-1 2 D
+-9 -2 D
+-2 -5 D
+2 2 D
+3 -2 D
+4 3 D
+5 0 D
+1 2 D
+P
+FO
+4617 3756 M
+1 -3 D
+1 3 D
+8 1 D
+5 3 D
+1 4 D
+P
+FO
+4713 3547 M
+2 0 D
+0 2 D
+2 -2 D
+-2 4 D
+P
+FO
+4563 3733 M
+5 0 D
+2 3 D
+-3 0 D
+0 -2 D
+P
+FO
+4559 3731 M
+5 1 D
+-2 3 D
+-7 -7 D
+P
+FO
+4653 3750 M
+5 1 D
+-4 2 D
+-5 -3 D
+P
+FO
+4520 3651 M
+4 0 D
+-3 2 D
+P
+FO
+4686 3555 M
+1 -3 D
+4 -2 D
+P
+FO
+4512 3661 M
+-7 -3 D
+11 3 D
+P
+FO
+4552 3691 M
+3 -1 D
+1 2 D
+P
+FO
+4512 3659 M
+-4 -1 D
+9 2 D
+P
+FO
+4524 3663 M
+4 -1 D
+2 2 D
+P
+FO
+4606 3732 M
+-1 -2 D
+9 1 D
+P
+FO
+4632 3742 M
+9 0 D
+-2 3 D
+P
+FO
+4548 3685 M
+-3 -3 D
+12 4 D
+P
+FO
+4512 3652 M
+9 -3 D
+-3 3 D
+P
+FO
+4543 3685 M
+8 2 D
+-2 3 D
+-6 -4 D
+P
+FO
+4535 3664 M
+0 1 D
+-5 -3 D
+P
+FO
+4610 3732 M
+3 0 D
+-1 1 D
+P
+FO
+4636 3755 M
+9 -2 D
+-1 2 D
+P
+FO
+4606 3745 M
+-9 1 D
+3 -2 D
+P
+FO
+4656 3754 M
+3 -3 D
+6 2 D
+P
+FO
+4532 3678 M
+-3 -2 D
+6 1 D
+P
+FO
+4584 3711 M
+3 -2 D
+2 4 D
+P
+FO
+4543 3677 M
+3 2 D
+P
+FO
+4549 3699 M
+2 -1 D
+P
+FO
+4692 3615 M
+2 1 D
+P
+FO
+4640 3756 M
+4 0 D
+P
+FO
+4544 3679 M
+3 1 D
+P
+FO
+4541 3681 M
+3 3 D
+P
+FO
+4577 3710 M
+3 0 D
+P
+FO
+4545 3681 M
+2 1 D
+P
+FO
+4503 3650 M
+3 0 D
+P
+FO
+4631 3740 M
+3 0 D
+P
+FO
+4537 3672 M
+2 2 D
+P
+FO
+4516 3649 M
+2 0 D
+P
+FO
+4662 3580 M
+3 0 D
+P
+FO
+4689 3615 M
+2 1 D
+P
+FO
+4677 3606 M
+3 0 D
+P
+FO
+4688 3549 M
+2 -1 D
+P
+FO
+4543 3665 M
+3 -1 D
+P
+FO
+4607 3724 M
+2 0 D
+P
+FO
+4538 3675 M
+1 2 D
+P
+FO
+4542 3688 M
+2 1 D
+P
+FO
+4548 3680 M
+1 1 D
+P
+FO
+4546 3682 M
+2 0 D
+P
+FO
+4631 3751 M
+3 -1 D
+P
+FO
+4537 3720 M
+2 1 D
+P
+FO
+4548 3692 M
+2 1 D
+P
+FO
+4513 3658 M
+6 1 D
+P
+FO
+4662 3602 M
+4 -3 D
+P
+FO
+4677 3607 M
+4 1 D
+P
+FO
+4515 3653 M
+4 -1 D
+1 2 D
+P
+FO
+4667 3758 M
+-4 0 D
+1 -2 D
+P
+FO
+4584 3740 M
+5 -1 D
+P
+FO
+4557 3693 M
+1 3 D
+-4 -2 D
+P
+FO
+4602 3738 M
+3 2 D
+P
+FO
+4559 3691 M
+4 1 D
+P
+FO
+4606 3753 M
+-3 1 D
+P
+FO
+4588 3718 M
+4 1 D
+P
+FO
+4591 3714 M
+6 0 D
+P
+FO
+4512 3632 M
+5 1 D
+P
+FO
+4505 3661 M
+6 0 D
+P
+FO
+4694 3548 M
+2 -1 D
+P
+FO
+4565 3703 M
+5 0 D
+P
+FO
+4559 3694 M
+3 1 D
+P
+FO
+4634 3734 M
+4 0 D
+P
+FO
+4701 3772 M
+-2 -1 D
+P
+FO
+4687 3776 M
+4 0 D
+P
+FO
+4555 3689 M
+3 1 D
+P
+FO
+4551 3689 M
+4 0 D
+P
+FO
+4536 3671 M
+3 2 D
+P
+FO
+4549 3724 M
+4 1 D
+P
+FO
+4730 3543 M
+1 4 D
+-5 -2 D
+-2 2 D
+3 -4 D
+P
+FO
+4733 3543 M
+2 0 D
+-3 0 D
+P
+FO
+4786 3543 M
+2 1 D
+-2 -1 D
+P
+FO
+4792 3543 M
+-1 1 D
+0 -1 D
+P
+FO
+4797 3543 M
+4 1 D
+-2 -1 D
+6 0 D
+3 3 D
+-2 -3 D
+11 0 D
+10 3 D
+-1 -3 D
+4 2 D
+-1 -2 D
+5 3 D
+-2 1 D
+4 -1 D
+3 2 D
+3 -1 D
+0 2 D
+2 -2 D
+6 3 D
+4 -1 D
+4 3 D
+0 -2 D
+5 0 D
+-3 1 D
+4 -2 D
+-2 4 D
+4 -1 D
+-1 -2 D
+4 1 D
+-4 4 D
+6 -3 D
+1 2 D
+7 -3 D
+-3 2 D
+1 2 D
+5 -2 D
+3 2 D
+4 -1 D
+1 2 D
+4 0 D
+0 1 D
+7 -3 D
+0 1 D
+6 0 D
+0 2 D
+3 -2 D
+9 0 D
+2 3 D
+7 1 D
+1 2 D
+3 -2 D
+-3 0 D
+1 -5 D
+-6 2 D
+4 -4 D
+5 0 D
+5 -4 D
+20 -1 D
+3 -4 D
+0 22 D
+-4 3 D
+4 0 D
+0 1 D
+-5 3 D
+5 -1 D
+-4 2 D
+1 1 D
+3 -1 D
+0 12 D
+-2 -1 D
+-2 1 D
+4 3 D
+0 1 D
+-8 4 D
+3 0 D
+5 -3 D
+0 9 D
+-2 1 D
+2 -1 D
+0 15 D
+-5 3 D
+0 1 D
+-4 -1 D
+-1 2 D
+-7 0 D
+-8 7 D
+5 -1 D
+-3 3 D
+13 -6 D
+5 -1 D
+2 1 D
+3 -1 D
+0 21 D
+-2 0 D
+0 2 D
+2 0 D
+0 6 D
+-3 -3 D
+-1 2 D
+4 1 D
+0 32 D
+-7 0 D
+7 0 D
+0 84 D
+-2 0 D
+2 0 D
+0 6 D
+-2 1 D
+2 1 D
+-12 -3 D
+6 6 D
+-10 0 D
+7 2 D
+-147 1 D
+1 -1 D
+-10 -1 D
+3 1 D
+-26 1 D
+0 -2 D
+-2 1 D
+-3 -1 D
+6 -5 D
+-15 7 D
+-5 0 D
+2 -3 D
+-5 -2 D
+2 2 D
+-4 0 D
+-1 -3 D
+-4 2 D
+5 3 D
+-14 -5 D
+1 -3 D
+8 -3 D
+-10 2 D
+-3 -5 D
+-7 -2 D
+0 -26 D
+2 0 D
+4 -4 D
+4 -2 D
+0 1 D
+3 -3 D
+6 0 D
+0 -2 D
+-7 2 D
+-12 7 D
+0 -106 D
+6 0 D
+1 2 D
+1 -2 D
+0 3 D
+2 -3 D
+2 4 D
+1 -2 D
+3 1 D
+7 9 D
+16 6 D
+-5 2 D
+3 0 D
+-11 4 D
+5 -1 D
+0 3 D
+-7 2 D
+4 -1 D
+10 8 D
+-3 3 D
+-5 1 D
+2 1 D
+10 -4 D
+-1 3 D
+-6 2 D
+5 -2 D
+-3 3 D
+9 -1 D
+3 1 D
+-5 2 D
+8 0 D
+-4 1 D
+9 -1 D
+-4 3 D
+1 1 D
+2 -1 D
+-1 4 D
+9 -2 D
+-1 4 D
+11 -5 D
+3 2 D
+-4 2 D
+5 -2 D
+2 1 D
+1 -2 D
+1 2 D
+3 -1 D
+4 1 D
+2 -2 D
+8 3 D
+0 -1 D
+6 -1 D
+4 1 D
+1 -4 D
+10 0 D
+7 -5 D
+-2 -2 D
+5 -1 D
+-6 0 D
+4 -3 D
+-4 -2 D
+7 -2 D
+-2 -2 D
+-6 2 D
+5 -4 D
+-7 2 D
+-13 -3 D
+0 -2 D
+-7 -5 D
+1 -2 D
+-5 0 D
+-3 -4 D
+-6 -1 D
+-2 -4 D
+-5 1 D
+0 -4 D
+-8 0 D
+-1 -3 D
+-5 3 D
+2 -2 D
+-6 -1 D
+6 0 D
+1 -2 D
+-3 -2 D
+-5 2 D
+-4 -3 D
+0 -3 D
+-3 3 D
+2 -3 D
+-4 0 D
+3 -4 D
+-8 -1 D
+0 -2 D
+-1 2 D
+-7 -1 D
+-2 2 D
+-2 -3 D
+4 -3 D
+-5 1 D
+-1 -5 D
+-4 1 D
+-3 -3 D
+-1 -4 D
+4 0 D
+-3 -3 D
+3 -1 D
+-1 -2 D
+2 1 D
+2 -1 D
+-1 -3 D
+1 1 D
+1 -1 D
+-3 -6 D
+12 -11 D
+-8 2 D
+4 -2 D
+-4 0 D
+3 -2 D
+-3 0 D
+4 -5 D
+-5 -1 D
+2 -2 D
+-5 0 D
+4 -4 D
+-4 2 D
+1 -2 D
+-3 0 D
+6 -1 D
+-4 0 D
+4 -3 D
+-3 -1 D
+6 -5 D
+6 3 D
+-2 -3 D
+3 1 D
+10 -4 D
+8 1 D
+-5 -3 D
+5 0 D
+-3 -2 D
+13 4 D
+-5 -5 D
+5 -1 D
+0 -2 D
+-2 0 D
+0 -1 D
+P
+4909 3570 M
+3 2 D
+7 -1 D
+-5 2 D
+-9 0 D
+1 -1 D
+-7 1 D
+2 0 D
+-3 2 D
+-2 -1 D
+2 3 D
+-2 2 D
+5 -1 D
+-5 1 D
+0 4 D
+3 -1 D
+-2 -3 D
+5 0 D
+-1 3 D
+2 -2 D
+6 3 D
+-4 3 D
+4 -1 D
+6 -7 D
+4 6 D
+7 1 D
+-1 2 D
+9 -1 D
+-6 3 D
+3 0 D
+-10 3 D
+4 -1 D
+-15 3 D
+3 0 D
+-5 8 D
+-1 -3 D
+-4 2 D
+0 -1 D
+-4 3 D
+1 -1 D
+-4 -1 D
+-3 4 D
+4 -3 D
+1 2 D
+2 -1 D
+3 1 D
+4 -4 D
+-5 5 D
+3 -1 D
+1 8 D
+-4 -2 D
+-8 6 D
+0 10 D
+-4 1 D
+0 -1 D
+-3 2 D
+6 -1 D
+3 -4 D
+2 0 D
+1 -5 D
+-4 0 D
+5 -4 D
+4 -1 D
+-1 2 D
+5 -3 D
+-2 4 D
+4 1 D
+1 -3 D
+11 1 D
+-6 -2 D
+3 -7 D
+17 -6 D
+-12 2 D
+4 0 D
+-6 2 D
+-3 -4 D
+-4 1 D
+1 5 D
+-4 3 D
+-5 -3 D
+3 -1 D
+-3 0 D
+4 -4 D
+4 -1 D
+-3 -3 D
+8 -1 D
+1 2 D
+5 -3 D
+5 3 D
+-2 2 D
+7 -5 D
+-4 1 D
+3 -2 D
+-5 1 D
+2 -2 D
+10 1 D
+-3 1 D
+6 -1 D
+2 2 D
+-3 0 D
+0 9 D
+9 -5 D
+-1 5 D
+7 -4 D
+-5 -2 D
+3 -1 D
+-7 -1 D
+10 -4 D
+-11 2 D
+0 -3 D
+-2 1 D
+9 -4 D
+-2 -3 D
+-7 -1 D
+-4 -4 D
+-5 0 D
+2 -1 D
+-10 3 D
+-2 -2 D
+7 0 D
+-5 0 D
+0 -3 D
+-4 1 D
+1 -2 D
+-7 -2 D
+4 -1 D
+5 2 D
+5 -4 D
+-17 -4 D
+-4 1 D
+-1 -1 D
+P
+4946 3593 M
+-3 1 D
+1 -4 D
+-3 4 D
+-12 -2 D
+8 -7 D
+5 0 D
+3 5 D
+4 -1 D
+P
+4938 3590 M
+1 -1 D
+P
+4935 3590 M
+3 -1 D
+P
+4937 3592 M
+2 -1 D
+-2 2 D
+P
+4905 3576 M
+-8 0 D
+6 -1 D
+-3 0 D
+7 -2 D
+P
+4914 3608 M
+3 0 D
+-3 1 D
+1 4 D
+-5 0 D
+0 -3 D
+P
+4903 3578 M
+4 -2 D
+6 2 D
+-6 2 D
+1 -3 D
+P
+4925 3584 M
+-2 -2 D
+-3 2 D
+0 -3 D
+6 1 D
+P
+4924 3579 M
+-6 -1 D
+1 -2 D
+7 1 D
+P
+4951 3599 M
+-4 0 D
+2 -1 D
+3 1 D
+P
+4903 3579 M
+3 0 D
+0 1 D
+P
+4930 3574 M
+-3 1 D
+3 -3 D
+P
+4943 3584 M
+-4 0 D
+3 -1 D
+P
+4924 3580 M
+-5 -1 D
+P
+4926 3593 M
+-2 1 D
+P
+4938 3584 M
+1 -2 D
+P
+4927 3580 M
+-2 -1 D
+P
+4919 3594 M
+-2 1 D
+P
+4915 3571 M
+-4 -1 D
+P
+4921 3574 M
+-5 0 D
+P
+4947 3598 M
+2 -1 D
+P
+4920 3570 M
+-1 -1 D
+P
+4931 3596 M
+-2 1 D
+P
+4914 3576 M
+0 1 D
+P
+4908 3602 M
+-3 2 D
+P
+4947 3602 M
+1 -2 D
+P
+4908 3582 M
+2 1 D
+P
+4926 3574 M
+1 -1 D
+0 1 D
+P
+4864 3616 M
+6 -3 D
+-5 0 D
+11 -6 D
+-9 3 D
+-2 -3 D
+4 -2 D
+-5 1 D
+-1 -2 D
+-3 0 D
+6 -4 D
+2 3 D
+-1 -3 D
+4 -1 D
+-1 4 D
+5 3 D
+4 -1 D
+-5 7 D
+12 -7 D
+1 2 D
+-10 6 D
+8 -4 D
+-3 5 D
+4 -2 D
+-4 2 D
+4 -1 D
+5 2 D
+0 -3 D
+-3 2 D
+1 -2 D
+-3 0 D
+8 -2 D
+-4 1 D
+0 -2 D
+-5 1 D
+6 -4 D
+-3 1 D
+3 -3 D
+-5 2 D
+-1 -3 D
+4 -2 D
+-4 1 D
+-3 -1 D
+0 4 D
+-6 -7 D
+-1 3 D
+3 -1 D
+2 3 D
+-6 2 D
+-3 -2 D
+2 -5 D
+-6 2 D
+4 -3 D
+-2 0 D
+-3 3 D
+0 -7 D
+-3 3 D
+-2 -4 D
+3 -2 D
+-3 1 D
+-1 -2 D
+-3 1 D
+0 -2 D
+3 0 D
+-4 -3 D
+4 1 D
+-3 -3 D
+4 -2 D
+-5 0 D
+-1 -3 D
+5 -1 D
+-6 1 D
+1 -4 D
+8 0 D
+5 -3 D
+3 3 D
+1 -2 D
+-2 1 D
+3 -4 D
+-5 -4 D
+2 4 D
+-6 3 D
+-2 -2 D
+-4 4 D
+2 -2 D
+-6 -2 D
+3 -3 D
+-3 2 D
+-4 -1 D
+5 3 D
+0 2 D
+-3 0 D
+0 2 D
+-2 -1 D
+-4 4 D
+0 2 D
+6 0 D
+1 2 D
+-6 4 D
+4 -1 D
+2 3 D
+-5 -1 D
+4 1 D
+-2 1 D
+4 -1 D
+1 3 D
+5 0 D
+-7 3 D
+6 0 D
+1 2 D
+5 2 D
+-3 5 D
+-6 1 D
+5 2 D
+0 2 D
+3 -1 D
+-2 5 D
+4 0 D
+-6 4 D
+-5 1 D
+-1 -4 D
+-3 2 D
+3 0 D
+-2 2 D
+5 3 D
+2 -3 D
+6 0 D
+P
+4851 3578 M
+1 -2 D
+P
+4857 3584 M
+-2 0 D
+2 -1 D
+P
+4812 3596 M
+-1 -2 D
+5 0 D
+2 2 D
+0 -2 D
+6 1 D
+-3 -3 D
+3 -1 D
+2 2 D
+0 -2 D
+7 0 D
+-7 4 D
+7 -3 D
+0 5 D
+2 0 D
+0 -2 D
+2 1 D
+-4 -5 D
+3 -3 D
+-4 3 D
+-11 0 D
+2 -2 D
+-10 -4 D
+-1 -3 D
+5 0 D
+-4 0 D
+1 -3 D
+-7 -3 D
+5 -1 D
+0 -2 D
+-9 3 D
+9 3 D
+-4 4 D
+4 1 D
+1 3 D
+-3 1 D
+5 -1 D
+0 2 D
+6 1 D
+-3 3 D
+-7 0 D
+P
+4891 3754 M
+20 6 D
+3 -1 D
+6 1 D
+-5 0 D
+-2 2 D
+4 1 D
+-1 -2 D
+5 2 D
+-4 -1 D
+10 3 D
+-5 -3 D
+11 4 D
+-10 -4 D
+6 0 D
+-6 -2 D
+1 -3 D
+-4 1 D
+-4 -1 D
+6 -5 D
+-11 1 D
+0 -1 D
+5 -1 D
+-7 -2 D
+0 3 D
+-4 -3 D
+-5 2 D
+-3 -2 D
+0 2 D
+6 0 D
+-2 2 D
+0 -2 D
+-3 3 D
+-2 -1 D
+P
+4912 3753 M
+3 1 D
+-3 0 D
+P
+4903 3752 M
+0 1 D
+P
+4903 3728 M
+-8 2 D
+4 2 D
+-2 2 D
+-6 1 D
+-5 -1 D
+3 -2 D
+-5 0 D
+-8 3 D
+-7 -1 D
+5 1 D
+-3 1 D
+15 -2 D
+4 2 D
+7 -2 D
+5 1 D
+-1 -3 D
+6 0 D
+-1 2 D
+4 0 D
+-1 -2 D
+6 2 D
+2 -2 D
+-6 0 D
+-2 -4 D
+P
+4889 3643 M
+-5 4 D
+4 0 D
+-3 4 D
+5 -2 D
+6 1 D
+-2 -3 D
+5 -2 D
+5 2 D
+9 0 D
+-4 -1 D
+4 -1 D
+-6 0 D
+-1 -1 D
+5 0 D
+0 -2 D
+7 -1 D
+-11 1 D
+3 0 D
+-7 2 D
+-8 -2 D
+1 -2 D
+-2 3 D
+-3 -1 D
+P
+4890 3644 M
+4 2 D
+-1 1 D
+-3 -2 D
+P
+4890 3643 M
+3 0 D
+P
+4837 3584 M
+-8 -3 D
+4 -2 D
+-8 0 D
+-4 -5 D
+2 0 D
+-4 -2 D
+9 -1 D
+1 -4 D
+-3 3 D
+-1 -2 D
+-11 4 D
+-1 3 D
+5 -4 D
+0 6 D
+9 3 D
+0 2 D
+2 -1 D
+1 2 D
+P
+4955 3639 M
+-9 2 D
+4 1 D
+-3 2 D
+4 -1 D
+-4 1 D
+5 3 D
+2 -3 D
+-3 1 D
+-1 -1 D
+7 -1 D
+-4 -1 D
+1 -1 D
+-5 0 D
+9 -3 D
+P
+4866 3580 M
+-3 3 D
+2 3 D
+5 -2 D
+1 3 D
+2 -3 D
+2 -1 D
+2 2 D
+3 -3 D
+-4 -1 D
+-5 4 D
+-4 -2 D
+3 0 D
+0 -4 D
+P
+4922 3638 M
+-2 3 D
+2 1 D
+13 -2 D
+5 2 D
+7 -2 D
+-3 0 D
+-3 -2 D
+-3 2 D
+-15 1 D
+2 -2 D
+-2 1 D
+P
+4877 3590 M
+-2 -3 D
+4 3 D
+6 -3 D
+-6 5 D
+7 -3 D
+1 -4 D
+4 -2 D
+-9 1 D
+5 -1 D
+0 -3 D
+-14 7 D
+1 2 D
+P
+4931 3613 M
+-3 -2 D
+4 0 D
+1 -2 D
+-4 -2 D
+9 -4 D
+-8 1 D
+-7 5 D
+7 0 D
+-6 3 D
+3 0 D
+0 2 D
+4 0 D
+P
+4912 3688 M
+4 0 D
+2 -2 D
+15 4 D
+-3 3 D
+11 -1 D
+-11 -4 D
+-8 -1 D
+8 0 D
+-5 -1 D
+-11 0 D
+P
+4883 3569 M
+-3 4 D
+4 1 D
+-4 3 D
+1 3 D
+1 -3 D
+7 -1 D
+-8 1 D
+8 -7 D
+-3 -1 D
+-2 2 D
+P
+4900 3701 M
+2 -1 D
+-3 3 D
+7 -2 D
+-2 -1 D
+4 -2 D
+5 2 D
+-3 -3 D
+-8 2 D
+-4 -3 D
+-2 1 D
+P
+4835 3577 M
+5 -6 D
+-4 3 D
+-3 -2 D
+3 -1 D
+-4 0 D
+-1 -1 D
+-4 3 D
+5 -1 D
+P
+4855 3608 M
+0 -3 D
+-6 1 D
+5 -1 D
+-1 2 D
+-9 -1 D
+-1 1 D
+8 0 D
+1 2 D
+P
+4880 3613 M
+-9 8 D
+5 -3 D
+5 0 D
+-6 4 D
+3 1 D
+6 -3 D
+-5 -4 D
+P
+4910 3691 M
+4 1 D
+-7 2 D
+7 -1 D
+1 2 D
+4 -3 D
+-4 -1 D
+3 -1 D
+P
+4878 3568 M
+2 -2 D
+-3 1 D
+0 -3 D
+-4 1 D
+3 1 D
+-2 2 D
+P
+4942 3684 M
+5 -1 D
+3 2 D
+5 0 D
+-4 -1 D
+9 -2 D
+-15 0 D
+-4 2 D
+P
+4828 3697 M
+0 6 D
+4 -3 D
+3 2 D
+3 -2 D
+-4 -1 D
+-5 1 D
+P
+4897 3567 M
+2 1 D
+1 -2 D
+6 0 D
+1 3 D
+3 -2 D
+-8 -2 D
+P
+4863 3627 M
+-2 2 D
+3 -1 D
+1 3 D
+2 -5 D
+-6 1 D
+P
+4844 3579 M
+1 -1 D
+-6 0 D
+7 -2 D
+-3 -1 D
+-6 3 D
+P
+4935 3658 M
+5 8 D
+3 -3 D
+-3 -1 D
+-2 -4 D
+4 -1 D
+P
+4914 3619 M
+-5 5 D
+12 -6 D
+0 1 D
+2 0 D
+-1 -3 D
+P
+4892 3593 M
+4 -6 D
+-8 3 D
+3 0 D
+-4 4 D
+6 -4 D
+P
+4846 3596 M
+0 -4 D
+-4 -1 D
+4 -3 D
+-5 3 D
+5 2 D
+P
+4892 3684 M
+-1 3 D
+-4 -1 D
+-1 4 D
+10 -4 D
+0 -2 D
+P
+4846 3611 M
+-3 12 D
+5 -4 D
+-1 -5 D
+4 -1 D
+P
+4945 3609 M
+1 -3 D
+2 2 D
+2 -2 D
+-9 0 D
+P
+4822 3552 M
+3 -1 D
+1 2 D
+0 -2 D
+-5 -1 D
+1 3 D
+P
+4953 3607 M
+-6 4 D
+5 -1 D
+-3 5 D
+8 -6 D
+P
+4819 3610 M
+5 -8 D
+-5 0 D
+-4 -2 D
+1 2 D
+6 1 D
+P
+4820 3551 M
+-2 -3 D
+-5 -1 D
+1 3 D
+P
+4816 3548 M
+-2 0 D
+P
+4810 3620 M
+3 -3 D
+-3 -2 D
+-2 3 D
+P
+4907 3631 M
+2 2 D
+4 -3 D
+-5 2 D
+P
+4878 3574 M
+-4 2 D
+6 0 D
+P
+4950 3671 M
+0 3 D
+5 -1 D
+-5 0 D
+P
+4815 3599 M
+-3 -3 D
+-2 3 D
+2 -1 D
+P
+4884 3755 M
+8 3 D
+-6 -3 D
+3 0 D
+P
+4891 3573 M
+3 1 D
+1 -1 D
+-2 -2 D
+P
+4836 3626 M
+-1 2 D
+4 -2 D
+P
+4913 3650 M
+0 2 D
+6 -3 D
+P
+4907 3593 M
+-4 3 D
+6 -2 D
+P
+4952 3582 M
+-1 -3 D
+-2 2 D
+P
+4933 3603 M
+2 -2 D
+-4 1 D
+P
+4766 3586 M
+4 -3 D
+-4 1 D
+-1 2 D
+P
+4859 3712 M
+-2 1 D
+4 0 D
+P
+4922 3680 M
+1 2 D
+3 -3 D
+P
+4776 3569 M
+4 -5 D
+-5 3 D
+P
+4909 3626 M
+-2 2 D
+2 0 D
+P
+4900 3594 M
+1 2 D
+3 -2 D
+P
+4877 3752 M
+5 2 D
+5 -1 D
+P
+4880 3569 M
+1 2 D
+1 -3 D
+P
+4862 3619 M
+-5 4 D
+10 -4 D
+-6 2 D
+P
+4871 3625 M
+2 1 D
+1 -2 D
+P
+4780 3577 M
+2 -1 D
+-4 -1 D
+P
+4803 3578 M
+-18 -6 D
+13 6 D
+P
+4945 3557 M
+1 -2 D
+-3 2 D
+P
+4930 3659 M
+-2 1 D
+4 0 D
+P
+4821 3729 M
+-2 2 D
+5 -2 D
+P
+4875 3592 M
+1 1 D
+2 -1 D
+P
+4795 3586 M
+7 -3 D
+-3 0 D
+-5 3 D
+P
+4935 3668 M
+0 1 D
+5 -1 D
+-4 0 D
+P
+4937 3642 M
+-1 1 D
+7 4 D
+P
+4935 3675 M
+8 3 D
+0 -2 D
+P
+4824 3770 M
+-2 3 D
+5 -1 D
+P
+4837 3611 M
+1 -5 D
+-4 5 D
+P
+4878 3609 M
+-2 3 D
+6 -4 D
+P
+4948 3580 M
+-2 -2 D
+-1 2 D
+P
+4826 3577 M
+5 -2 D
+-6 0 D
+P
+4934 3675 M
+3 1 D
+P
+4853 3622 M
+-5 5 D
+6 -5 D
+P
+4944 3681 M
+10 0 D
+P
+4735 3647 M
+1 3 D
+P
+4905 3765 M
+9 3 D
+P
+4951 3653 M
+-10 3 D
+P
+4927 3672 M
+8 1 D
+P
+4746 3755 M
+-6 2 D
+P
+4738 3749 M
+-7 3 D
+8 -3 D
+P
+4900 3647 M
+-1 2 D
+P
+4785 3581 M
+-6 0 D
+P
+4908 3667 M
+5 2 D
+P
+4842 3585 M
+4 -3 D
+-6 2 D
+P
+4937 3598 M
+5 -3 D
+-6 3 D
+P
+4827 3606 M
+-4 -2 D
+P
+4875 3571 M
+2 -2 D
+P
+4792 3757 M
+1 0 D
+-5 3 D
+P
+4903 3650 M
+-1 2 D
+P
+4805 3611 M
+2 -2 D
+P
+4919 3589 M
+-5 2 D
+P
+4949 3686 M
+6 0 D
+P
+4891 3598 M
+2 1 D
+P
+4938 3578 M
+5 -2 D
+P
+4921 3623 M
+-2 2 D
+P
+4896 3667 M
+-1 2 D
+P
+4958 3646 M
+-3 2 D
+P
+4825 3600 M
+-1 -2 D
+P
+4898 3590 M
+-1 2 D
+P
+4903 3598 M
+0 -1 D
+-4 2 D
+P
+4866 3675 M
+-3 2 D
+P
+4878 3578 M
+1 1 D
+P
+4915 3589 M
+-3 1 D
+P
+4827 3695 M
+1 0 D
+-6 0 D
+P
+4821 3726 M
+1 3 D
+P
+4924 3647 M
+-2 2 D
+P
+4885 3564 M
+3 2 D
+P
+4903 3591 M
+-1 2 D
+P
+4878 3632 M
+-3 2 D
+P
+4928 3669 M
+1 2 D
+0 -2 D
+P
+4882 3565 M
+3 0 D
+P
+4867 3590 M
+-2 -2 D
+P
+4861 3699 M
+-2 2 D
+P
+4854 3721 M
+1 1 D
+P
+4832 3616 M
+2 -2 D
+P
+4801 3594 M
+-3 -1 D
+P
+4813 3562 M
+-2 -1 D
+P
+4960 3635 M
+0 2 D
+P
+4917 3683 M
+4 0 D
+-3 0 D
+P
+4960 3633 M
+-2 1 D
+P
+4944 3679 M
+1 1 D
+0 -1 D
+P
+4893 3594 M
+1 2 D
+P
+4836 3600 M
+3 -1 D
+P
+4852 3602 M
+-3 -1 D
+P
+4941 3602 M
+-2 -1 D
+P
+4852 3598 M
+-2 -1 D
+P
+4941 3635 M
+-3 2 D
+P
+4938 3703 M
+1 1 D
+P
+4801 3581 M
+1 -2 D
+P
+4912 3584 M
+2 2 D
+P
+4887 3622 M
+1 2 D
+P
+4756 3646 M
+1 2 D
+P
+4920 3590 M
+-1 1 D
+P
+4779 3570 M
+1 -2 D
+P
+4800 3607 M
+1 -1 D
+P
+4955 3583 M
+-1 0 D
+2 -1 D
+P
+FO
+4911 3543 M
+-2 1 D
+P
+FO
+4955 3543 M
+-3 1 D
+P
+FO
+4961 3620 M
+-2 0 D
+2 -4 D
+P
+FO
+4961 3776 M
+-5 1 D
+-2 -3 D
+7 1 D
+P
+FO
+4764 3780 M
+0 -1 D
+P
+FO
+4742 3780 M
+2 -2 D
+4 1 D
+P
+FO
+4724 3771 M
+4 -1 D
+-4 0 D
+0 -6 D
+9 7 D
+-2 8 D
+-7 -4 D
+P
+FO
+4724 3548 M
+2 1 D
+2 -2 D
+3 3 D
+-7 2 D
+P
+FO
+4780 3545 M
+1 -2 D
+5 2 D
+4 -2 D
+5 7 D
+-11 -2 D
+-1 1 D
+-1 -2 D
+4 0 D
+P
+FO
+4750 3621 M
+4 -3 D
+5 1 D
+-2 2 D
+-4 -1 D
+1 2 D
+P
+FO
+4833 3661 M
+5 -1 D
+0 3 D
+6 0 D
+-10 0 D
+P
+FO
+4772 3552 M
+-4 3 D
+-1 -2 D
+3 -1 D
+-2 0 D
+P
+FO
+4737 3776 M
+2 -1 D
+3 2 D
+P
+FO
+4753 3558 M
+3 -1 D
+0 2 D
+-3 0 D
+P
+FO
+4774 3550 M
+3 -1 D
+3 2 D
+P
+FO
+4764 3546 M
+6 2 D
+-4 0 D
+-2 -1 D
+P
+FO
+4755 3557 M
+4 -2 D
+1 1 D
+P
+FO
+4760 3546 M
+4 0 D
+0 2 D
+P
+FO
+4773 3621 M
+4 0 D
+0 1 D
+P
+FO
+4792 3545 M
+0 -2 D
+2 2 D
+P
+FO
+4754 3622 M
+3 -1 D
+1 2 D
+P
+FO
+4772 3548 M
+0 -1 D
+2 1 D
+P
+FO
+4772 3623 M
+-1 -1 D
+3 1 D
+P
+FO
+4788 3632 M
+2 -1 D
+1 2 D
+P
+FO
+4789 3679 M
+2 -1 D
+-2 2 D
+P
+FO
+4856 3550 M
+1 -2 D
+0 3 D
+P
+FO
+4756 3615 M
+2 -1 D
+1 2 D
+P
+FO
+4778 3547 M
+3 1 D
+P
+FO
+4775 3552 M
+4 0 D
+P
+FO
+4923 3552 M
+3 -2 D
+P
+FO
+4926 3557 M
+3 0 D
+-3 1 D
+P
+FO
+4769 3551 M
+2 0 D
+P
+FO
+4775 3672 M
+2 -1 D
+P
+FO
+4924 3554 M
+2 -2 D
+P
+FO
+4927 3555 M
+3 -1 D
+-3 2 D
+P
+FO
+4763 3671 M
+5 -1 D
+P
+FO
+4761 3549 M
+1 1 D
+P
+FO
+4784 3675 M
+3 0 D
+P
+FO
+4778 3672 M
+4 0 D
+P
+FO
+4763 3621 M
+1 -1 D
+P
+FO
+4742 3551 M
+1 1 D
+P
+FO
+4735 3544 M
+2 1 D
+P
+FO
+4766 3668 M
+2 -1 D
+P
+FO
+4733 3544 M
+3 1 D
+P
+FO
+4764 3622 M
+2 -1 D
+P
+FO
+4756 3571 M
+2 0 D
+-2 1 D
+P
+FO
+4774 3552 M
+3 0 D
+P
+FO
+4831 3677 M
+3 1 D
+P
+FO
+4758 3573 M
+2 -1 D
+P
+FO
+4861 3548 M
+3 1 D
+P
+FO
+4752 3564 M
+3 0 D
+P
+FO
+4766 3667 M
+2 -1 D
+P
+FO
+4782 3552 M
+2 0 D
+P
+FO
+4870 3551 M
+2 0 D
+P
+FO
+4730 3548 M
+2 1 D
+P
+FO
+4752 3564 M
+3 -1 D
+P
+FO
+4800 3679 M
+3 -1 D
+P
+FO
+4762 3553 M
+1 1 D
+P
+FO
+4736 3546 M
+2 0 D
+P
+FO
+4867 3550 M
+2 0 D
+P
+FO
+4752 3599 M
+1 2 D
+P
+FO
+4736 3546 M
+3 -1 D
+P
+FO
+4789 3675 M
+2 -1 D
+P
+FO
+4766 3778 M
+2 -1 D
+P
+FO
+4759 3618 M
+2 -1 D
+P
+FO
+4755 3594 M
+0 -1 D
+P
+FO
+4926 3551 M
+4 -2 D
+P
+FO
+4776 3548 M
+3 2 D
+P
+FO
+4753 3557 M
+3 -2 D
+P
+FO
+4732 3550 M
+1 -2 D
+P
+FO
+4755 3548 M
+4 0 D
+P
+FO
+4772 3553 M
+-2 2 D
+P
+FO
+4764 3554 M
+3 2 D
+P
+FO
+4742 3549 M
+2 0 D
+-2 1 D
+P
+FO
+4776 3674 M
+4 -1 D
+P
+FO
+4736 3544 M
+3 0 D
+P
+FO
+4792 3679 M
+3 -2 D
+P
+FO
+4744 3632 M
+3 1 D
+-3 0 D
+P
+FO
+4791 3545 M
+3 1 D
+P
+FO
+4745 3630 M
+2 3 D
+P
+FO
+4890 3544 M
+-1 2 D
+P
+FO
+4878 3553 M
+4 0 D
+P
+FO
+4752 3614 M
+0 -1 D
+P
+FO
+4811 3678 M
+3 1 D
+-3 0 D
+P
+FO
+-1 2 1 4943 3623 SP
+1 1 1 4946 3621 SP
+4986 3543 M
+1 3 D
+-10 11 D
+-4 1 D
+0 5 D
+-12 6 D
+1 -2 D
+-1 -24 D
+P
+4967 3564 M
+1 -2 D
+-4 1 D
+P
+FO
+5126 3543 M
+-2 1 D
+73 -1 D
+0 109 D
+-4 1 D
+-7 -2 D
+-26 6 D
+1 -2 D
+-8 0 D
+0 -1 D
+-3 2 D
+8 0 D
+0 2 D
+-11 1 D
+-5 3 D
+-12 3 D
+-8 0 D
+-1 -5 D
+-8 0 D
+2 -5 D
+5 -1 D
+10 -7 D
+11 -1 D
+4 2 D
+6 -3 D
+-4 -2 D
+4 -7 D
+-9 -1 D
+-6 -2 D
+-6 2 D
+-20 1 D
+-2 5 D
+-5 2 D
+-1 -1 D
+-4 4 D
+-5 1 D
+0 -2 D
+-7 0 D
+-8 3 D
+1 2 D
+-5 0 D
+5 2 D
+-4 2 D
+4 1 D
+-6 0 D
+5 3 D
+-8 2 D
+4 1 D
+0 2 D
+-8 6 D
+-5 1 D
+10 2 D
+3 3 D
+-4 5 D
+8 -3 D
+-2 4 D
+-1 -1 D
+0 2 D
+-4 0 D
+1 3 D
+-14 5 D
+-14 2 D
+-13 -1 D
+16 2 D
+-4 1 D
+5 1 D
+-18 2 D
+6 1 D
+-9 1 D
+12 1 D
+-15 3 D
+6 -1 D
+-13 4 D
+3 3 D
+-15 3 D
+5 -1 D
+6 2 D
+15 -2 D
+-4 -1 D
+1 -2 D
+16 -6 D
+2 3 D
+8 -4 D
+5 3 D
+-2 -3 D
+7 1 D
+2 -4 D
+10 1 D
+16 -5 D
+37 -3 D
+19 -4 D
+28 0 D
+21 4 D
+0 42 D
+-5 3 D
+2 -3 D
+-5 1 D
+1 -2 D
+-25 9 D
+-4 -1 D
+7 -2 D
+-8 2 D
+0 -1 D
+-21 10 D
+-41 11 D
+-1 -3 D
+1 3 D
+-16 2 D
+4 -1 D
+-4 -2 D
+0 2 D
+-5 -1 D
+1 1 D
+-15 2 D
+-18 0 D
+0 -4 D
+-12 -2 D
+-1 -4 D
+1 4 D
+10 3 D
+-5 1 D
+4 1 D
+-6 0 D
+7 3 D
+-11 0 D
+-3 -3 D
+4 5 D
+-6 -2 D
+2 2 D
+-4 0 D
+-13 -1 D
+8 2 D
+-8 2 D
+-4 -1 D
+2 4 D
+3 -2 D
+15 -2 D
+7 4 D
+-13 1 D
+-12 4 D
+-4 -1 D
+4 -3 D
+-7 2 D
+1 -5 D
+-8 1 D
+-6 -3 D
+4 4 D
+-21 2 D
+-4 -3 D
+-1 5 D
+-4 -1 D
+-1 -4 D
+-2 0 D
+0 -6 D
+4 1 D
+-1 -2 D
+-3 1 D
+1 -123 D
+-1 -22 D
+1 -1 D
+-1 0 D
+0 -4 D
+9 -7 D
+-4 1 D
+-4 -3 D
+3 5 D
+-4 2 D
+0 -15 D
+2 -2 D
+-2 2 D
+0 -9 D
+3 -2 D
+-2 -5 D
+0 3 D
+-1 -13 D
+1 -1 D
+1 2 D
+4 0 D
+-3 1 D
+5 2 D
+-3 2 D
+6 -1 D
+7 6 D
+4 0 D
+4 -3 D
+6 1 D
+7 -6 D
+-2 2 D
+22 -8 D
+10 -11 D
+-4 -5 D
+-4 2 D
+2 -3 D
+-3 -5 D
+-7 -2 D
+-2 2 D
+-10 1 D
+-4 -2 D
+0 -4 D
+P
+5070 3611 M
+18 -5 D
+3 -2 D
+0 1 D
+7 -4 D
+-4 -9 D
+5 -3 D
+-1 -2 D
+10 -9 D
+5 -2 D
+-3 -3 D
+3 -2 D
+-15 -6 D
+3 0 D
+-2 -2 D
+-7 2 D
+-4 3 D
+-7 -1 D
+1 1 D
+-6 1 D
+-1 -2 D
+0 5 D
+10 -1 D
+-5 0 D
+3 -3 D
+3 1 D
+5 -2 D
+4 3 D
+-5 6 D
+-18 5 D
+-9 5 D
+-1 2 D
+6 -3 D
+2 3 D
+-8 5 D
+-4 7 D
+-3 -1 D
+-1 4 D
+10 -6 D
+-2 -2 D
+10 -4 D
+-6 11 D
+8 -6 D
+-8 9 D
+14 -13 D
+3 1 D
+-4 4 D
+8 -4 D
+6 3 D
+-6 8 D
+-1 -1 D
+-11 3 D
+5 -5 D
+-8 5 D
+0 -1 D
+-6 7 D
+P
+5086 3592 M
+-3 -3 D
+1 -2 D
+P
+5081 3591 M
+0 -2 D
+P
+5037 3740 M
+3 -8 D
+-3 -8 D
+-4 -1 D
+7 -1 D
+-5 0 D
+-1 -2 D
+-7 2 D
+-6 -4 D
+-6 4 D
+10 0 D
+1 2 D
+6 -1 D
+-3 2 D
+4 0 D
+0 3 D
+-6 0 D
+8 0 D
+-5 3 D
+5 -1 D
+3 2 D
+0 5 D
+-4 1 D
+4 2 D
+P
+5066 3634 M
+2 -1 D
+3 1 D
+-1 -2 D
+5 0 D
+3 -6 D
+10 0 D
+2 -2 D
+-7 0 D
+-2 -1 D
+-7 3 D
+4 -8 D
+-3 -7 D
+2 5 D
+-3 8 D
+-9 1 D
+3 2 D
+-5 4 D
+-4 -3 D
+2 6 D
+P
+5072 3626 M
+-3 -1 D
+3 0 D
+P
+4983 3666 M
+15 -1 D
+9 -7 D
+-16 7 D
+-3 -1 D
+1 -1 D
+-8 0 D
+-1 -3 D
+-7 -1 D
+5 3 D
+-7 1 D
+-2 3 D
+8 -3 D
+9 1 D
+-7 1 D
+P
+5006 3683 M
+7 -1 D
+-8 -1 D
+9 0 D
+-4 -1 D
+6 -2 D
+2 -2 D
+-4 -1 D
+10 -2 D
+0 -3 D
+-1 2 D
+-16 2 D
+0 2 D
+-9 2 D
+-2 3 D
+P
+5004 3706 M
+10 -1 D
+-3 -3 D
+6 -1 D
+-6 -2 D
+6 -4 D
+-14 2 D
+9 0 D
+-6 5 D
+-9 1 D
+1 2 D
+7 -1 D
+-7 1 D
+P
+5047 3626 M
+0 -2 D
+8 0 D
+-2 -2 D
+6 -4 D
+-19 2 D
+-3 3 D
+5 -2 D
+-1 2 D
+-5 1 D
+P
+4980 3636 M
+10 -3 D
+-6 0 D
+4 -2 D
+-2 -1 D
+2 -2 D
+-7 2 D
+0 3 D
+-5 0 D
+4 1 D
+P
+4973 3610 M
+4 1 D
+-4 2 D
+8 2 D
+-1 -4 D
+-5 -1 D
+2 -2 D
+-2 2 D
+-5 -1 D
+P
+5174 3560 M
+4 -2 D
+-2 -6 D
+-3 1 D
+2 3 D
+-4 2 D
+-1 -2 D
+-1 4 D
+3 2 D
+P
+5023 3724 M
+-12 1 D
+1 -3 D
+-7 3 D
+-2 -1 D
+7 -2 D
+-13 3 D
+P
+5029 3686 M
+-1 -1 D
+6 -1 D
+0 -3 D
+-9 -2 D
+-1 3 D
+6 0 D
+-5 1 D
+P
+5030 3681 M
+-4 0 D
+P
+5004 3651 M
+5 -2 D
+-1 -2 D
+-16 2 D
+0 1 D
+12 -1 D
+-2 2 D
+P
+4987 3691 M
+5 -9 D
+-17 4 D
+4 2 D
+-3 2 D
+5 2 D
+P
+4983 3687 M
+-2 -1 D
+P
+5155 3592 M
+7 1 D
+-7 -3 D
+-3 2 D
+3 2 D
+-3 -1 D
+4 1 D
+P
+5154 3735 M
+0 -1 D
+-4 2 D
+-2 -2 D
+-5 0 D
+9 3 D
+P
+5063 3729 M
+6 -6 D
+-3 -2 D
+-4 1 D
+-3 8 D
+P
+5013 3616 M
+6 -4 D
+-8 2 D
+-1 2 D
+2 -1 D
+P
+5040 3713 M
+5 -4 D
+-9 2 D
+4 1 D
+-3 2 D
+P
+4966 3648 M
+3 1 D
+0 -2 D
+-4 0 D
+-2 3 D
+5 1 D
+P
+5079 3707 M
+4 -1 D
+2 -3 D
+-6 3 D
+-4 -1 D
+P
+5071 3738 M
+0 -2 D
+-4 1 D
+-5 -1 D
+3 2 D
+P
+5009 3693 M
+-1 -3 D
+-10 1 D
+1 3 D
+7 -2 D
+P
+5000 3747 M
+-10 0 D
+-4 -4 D
+-8 -3 D
+9 7 D
+P
+5171 3577 M
+0 -5 D
+-5 -1 D
+-1 5 D
+7 2 D
+P
+5032 3648 M
+6 -2 D
+-5 1 D
+1 -2 D
+P
+5150 3545 M
+-10 0 D
+-8 2 D
+4 4 D
+11 0 D
+P
+5125 3602 M
+3 -6 D
+-5 -2 D
+-2 6 D
+P
+5033 3592 M
+8 -3 D
+-4 -2 D
+-6 2 D
+1 3 D
+P
+5039 3635 M
+7 -4 D
+-4 -1 D
+-8 5 D
+P
+5018 3719 M
+-7 -1 D
+-6 4 D
+9 -1 D
+P
+5012 3721 M
+-3 0 D
+4 -2 D
+P
+4980 3593 M
+4 -1 D
+1 -3 D
+-4 0 D
+P
+4973 3627 M
+-4 3 D
+7 -2 D
+1 -3 D
+-4 1 D
+P
+4986 3698 M
+-6 -2 D
+3 2 D
+-3 0 D
+7 0 D
+P
+4986 3605 M
+-1 2 D
+3 1 D
+2 -3 D
+-3 0 D
+P
+5051 3606 M
+1 -3 D
+-4 -1 D
+P
+5057 3606 M
+2 -3 D
+-4 1 D
+P
+5063 3716 M
+2 -2 D
+-3 0 D
+P
+5032 3586 M
+2 -1 D
+-5 1 D
+P
+5030 3671 M
+1 -2 D
+-4 1 D
+P
+5032 3626 M
+2 -2 D
+-7 3 D
+P
+5134 3566 M
+2 -3 D
+-5 0 D
+P
+5088 3633 M
+3 -2 D
+-6 2 D
+P
+5025 3581 M
+3 -1 D
+-6 0 D
+P
+5055 3650 M
+1 -2 D
+-5 2 D
+P
+5155 3696 M
+4 -3 D
+-4 0 D
+P
+5153 3584 M
+1 -1 D
+-4 1 D
+P
+5034 3674 M
+5 0 D
+0 -2 D
+-7 2 D
+P
+5044 3637 M
+0 -3 D
+-3 2 D
+P
+5144 3738 M
+3 -1 D
+-4 -2 D
+1 4 D
+P
+5086 3734 M
+-5 -9 D
+-1 7 D
+P
+4965 3643 M
+-2 1 D
+4 1 D
+P
+5043 3598 M
+-1 -2 D
+-2 2 D
+P
+5026 3736 M
+3 -4 D
+P
+5042 3680 M
+11 0 D
+-18 -3 D
+P
+5125 3704 M
+-9 -1 D
+P
+5152 3618 M
+3 -3 D
+-7 4 D
+P
+5056 3712 M
+4 -5 D
+P
+4979 3707 M
+13 -2 D
+P
+5011 3597 M
+3 -3 D
+-4 1 D
+P
+5167 3605 M
+1 2 D
+5 -1 D
+P
+4989 3627 M
+2 -3 D
+-3 3 D
+P
+5035 3620 M
+0 -3 D
+P
+5052 3601 M
+0 -3 D
+-1 3 D
+P
+5035 3630 M
+6 -3 D
+P
+4967 3622 M
+-5 2 D
+6 -2 D
+P
+5000 3723 M
+-8 2 D
+P
+4974 3675 M
+-1 -2 D
+P
+5168 3645 M
+-3 -2 D
+P
+4982 3607 M
+-2 3 D
+P
+5057 3593 M
+3 -3 D
+-4 3 D
+P
+5128 3612 M
+0 -2 D
+P
+5066 3624 M
+-3 -1 D
+P
+5112 3579 M
+-3 0 D
+P
+4961 3592 M
+1 -2 D
+P
+5072 3615 M
+2 -1 D
+P
+5050 3598 M
+-3 -1 D
+P
+5060 3636 M
+-2 -1 D
+P
+5115 3594 M
+1 -2 D
+P
+5038 3585 M
+-2 -1 D
+P
+4971 3595 M
+-4 0 D
+P
+5138 3654 M
+1 -2 D
+P
+4985 3657 M
+-1 -1 D
+P
+5035 3626 M
+2 -1 D
+P
+5010 3612 M
+2 -1 D
+P
+4971 3661 M
+-2 -1 D
+P
+4985 3703 M
+-5 -2 D
+P
+4972 3634 M
+0 -2 D
+P
+5030 3675 M
+-4 0 D
+P
+4979 3695 M
+-3 0 D
+P
+4980 3674 M
+-2 -2 D
+P
+5139 3655 M
+-2 0 D
+P
+5119 3590 M
+-2 -1 D
+P
+5057 3591 M
+2 -2 D
+P
+5166 3613 M
+-1 -2 D
+P
+5004 3687 M
+-3 0 D
+4 0 D
+P
+5072 3710 M
+2 -1 D
+P
+4989 3659 M
+-3 -2 D
+P
+FO
+5197 3654 M
+-5 0 D
+5 -1 D
+P
+FO
+5197 3677 M
+-5 -2 D
+-2 -3 D
+0 -3 D
+7 -3 D
+P
+FO
+4961 3775 M
+2 1 D
+-2 0 D
+P
+FO
+4961 3774 M
+P
+FO
+4961 3588 M
+0 1 D
+P
+FO
+4961 3571 M
+0 -1 D
+P
+FO
+5095 3661 M
+5 0 D
+-3 5 D
+-6 -2 D
+5 -3 D
+P
+FO
+5102 3666 M
+1 -2 D
+6 1 D
+P
+FO
+5102 3646 M
+-3 1 D
+3 -2 D
+P
+FO
+5039 3699 M
+-6 -1 D
+11 -1 D
+P
+FO
+5055 3764 M
+9 0 D
+-6 1 D
+P
+FO
+5054 3691 M
+-4 1 D
+P
+FO
+5102 3662 M
+-3 0 D
+P
+FO
+5031 3765 M
+4 1 D
+P
+FO
+5079 3679 M
+-2 1 D
+P
+FO
+3 -1 -2 -1 2 4979 3583 SP
+0 -2 1 4982 3584 SP
+-3 0 1 4984 3576 SP
+1 -2 1 4998 3576 SP
+1 -1 1 4962 3587 SP
+5433 3732 M
+-1 0 D
+1 2 D
+-23 -6 D
+-10 2 D
+4 -2 D
+-1 -3 D
+8 -2 D
+-9 2 D
+-20 -3 D
+2 -3 D
+-9 -13 D
+-36 -2 D
+-7 2 D
+-3 6 D
+-16 4 D
+0 3 D
+13 7 D
+29 2 D
+-6 7 D
+2 0 D
+-14 5 D
+2 3 D
+-46 2 D
+-19 3 D
+23 -9 D
+-2 -9 D
+4 0 D
+-5 -1 D
+2 -4 D
+-10 -11 D
+13 -4 D
+5 -4 D
+-4 -3 D
+5 -2 D
+-11 -9 D
+0 -8 D
+-7 6 D
+-13 -3 D
+10 4 D
+-10 4 D
+-18 -1 D
+2 2 D
+-9 1 D
+-16 -9 D
+-19 -3 D
+-7 -5 D
+-10 -3 D
+0 -11 D
+7 -4 D
+-1 -4 D
+3 2 D
+-1 -3 D
+8 -3 D
+-5 -4 D
+-11 2 D
+0 -109 D
+236 0 D
+P
+5315 3595 M
+-8 3 D
+-17 2 D
+-7 4 D
+-24 8 D
+-1 2 D
+-13 2 D
+-4 12 D
+-8 1 D
+-3 3 D
+4 3 D
+6 9 D
+-19 2 D
+-11 5 D
+13 -4 D
+18 -3 D
+1 -3 D
+-3 0 D
+0 -3 D
+-8 -6 D
+11 -4 D
+4 -11 D
+11 -2 D
+3 -3 D
+23 -7 D
+7 -5 D
+18 -1 D
+8 -4 D
+2 -4 D
+P
+5386 3687 M
+-1 -2 D
+-3 2 D
+5 0 D
+P
+5245 3656 M
+-2 -1 D
+P
+FO
+5433 3754 M
+P
+FO
+5433 3763 M
+-18 5 D
+-15 -2 D
+-9 -8 D
+1 -5 D
+8 -4 D
+-4 0 D
+13 0 D
+18 4 D
+6 3 D
+P
+FO
+5197 3691 M
+12 4 D
+17 10 D
+4 6 D
+-8 4 D
+-2 10 D
+-8 3 D
+-5 -1 D
+-4 2 D
+3 1 D
+-9 3 D
+P
+FO
+5197 3653 M
+11 -3 D
+-6 5 D
+-5 -1 D
+P
+FO
+5209 3653 M
+0 -2 D
+3 3 D
+-3 0 D
+P
+FO
+5409 3748 M
+-6 1 D
+10 -1 D
+P
+FO
+5260 3702 M
+-6 1 D
+P
+FO
+5421 3751 M
+3 1 D
+P
+FO
+5669 3749 M
+-5 -2 D
+4 -4 D
+-4 -3 D
+-15 2 D
+0 6 D
+9 2 D
+-13 4 D
+8 1 D
+-7 1 D
+-24 -4 D
+-1 -2 D
+-1 1 D
+-16 -2 D
+12 1 D
+-10 -5 D
+-30 2 D
+-16 -2 D
+-12 -5 D
+0 -4 D
+-9 3 D
+-8 -4 D
+-1 3 D
+-5 -1 D
+-9 1 D
+-7 -1 D
+2 3 D
+4 1 D
+4 -1 D
+-2 2 D
+6 -2 D
+3 2 D
+-5 4 D
+7 6 D
+-10 1 D
+23 2 D
+-16 0 D
+-38 -9 D
+6 1 D
+5 -4 D
+-10 -4 D
+-4 2 D
+4 2 D
+-7 1 D
+4 2 D
+-26 -6 D
+-7 1 D
+-19 -9 D
+0 -189 D
+236 0 D
+P
+5599 3671 M
+0 3 D
+-8 5 D
+4 5 D
+-10 8 D
+-6 1 D
+-9 -1 D
+-14 -4 D
+-2 -5 D
+-20 -11 D
+-33 -3 D
+-18 3 D
+3 9 D
+7 4 D
+-2 15 D
+-4 2 D
+2 9 D
+-6 4 D
+3 4 D
+-3 3 D
+11 3 D
+13 0 D
+5 4 D
+12 3 D
+7 4 D
+-2 -3 D
+-16 -4 D
+-6 -4 D
+-13 0 D
+-11 -3 D
+4 -3 D
+-1 -5 D
+5 -3 D
+-2 -9 D
+4 -2 D
+2 -15 D
+-9 -6 D
+-1 -7 D
+27 -2 D
+22 3 D
+6 5 D
+7 1 D
+7 4 D
+1 5 D
+15 5 D
+15 -1 D
+11 -8 D
+-5 -5 D
+9 -5 D
+P
+5501 3748 M
+6 3 D
+1 -3 D
+-4 1 D
+5 -2 D
+P
+5643 3750 M
+0 2 D
+4 -1 D
+P
+5513 3750 M
+3 1 D
+P
+5632 3748 M
+4 0 D
+P
+5440 3662 M
+-3 0 D
+P
+5625 3748 M
+4 2 D
+P
+FO
+5639 3780 M
+8 -4 D
+-3 2 D
+16 -2 D
+-1 -3 D
+10 -1 D
+0 8 D
+P
+FO
+5433 3756 M
+5 3 D
+-2 -4 D
+5 3 D
+-4 4 D
+-4 1 D
+P
+5436 3762 M
+0 -2 D
+P
+FO
+5433 3754 M
+3 1 D
+-3 -1 D
+P
+FO
+5433 3733 M
+1 1 D
+-1 0 D
+P
+FO
+5646 3763 M
+7 -4 D
+-2 3 D
+-12 3 D
+P
+FO
+5524 3740 M
+2 -1 D
+1 2 D
+P
+FO
+5457 3743 M
+-5 -2 D
+17 3 D
+P
+FO
+5532 3752 M
+5 -1 D
+P
+FO
+5532 3738 M
+4 2 D
+-4 -1 D
+P
+FO
+5560 3754 M
+7 -2 D
+P
+FO
+5541 3754 M
+3 1 D
+-3 0 D
+P
+FO
+5654 3757 M
+3 0 D
+-3 1 D
+P
+FO
+5814 3543 M
+-2 1 D
+5 0 D
+-1 -1 D
+87 0 D
+0 1 D
+-6 2 D
+5 3 D
+-2 4 D
+2 6 D
+-5 0 D
+-5 6 D
+-27 6 D
+1 6 D
+-18 6 D
+-9 11 D
+-16 3 D
+-4 3 D
+-10 2 D
+-21 12 D
+5 6 D
+6 3 D
+-2 2 D
+8 2 D
+-2 5 D
+4 1 D
+-2 6 D
+7 2 D
+-11 10 D
+4 2 D
+-7 2 D
+4 7 D
+-10 1 D
+15 19 D
+-1 4 D
+-3 2 D
+12 5 D
+8 7 D
+14 -2 D
+7 3 D
+16 -3 D
+11 3 D
+-6 0 D
+3 2 D
+13 1 D
+-21 -7 D
+-16 3 D
+-7 -3 D
+-14 3 D
+-5 -7 D
+-12 -4 D
+2 -7 D
+-14 -19 D
+10 -1 D
+-5 -7 D
+7 -2 D
+-3 -2 D
+4 -2 D
+6 -8 D
+-7 -2 D
+2 -6 D
+-4 -1 D
+3 -5 D
+-8 -2 D
+2 -2 D
+-7 -3 D
+-4 -6 D
+19 -12 D
+11 -1 D
+4 -4 D
+15 -2 D
+11 -12 D
+11 -2 D
+6 -4 D
+-1 -4 D
+5 -3 D
+6 -1 D
+4 3 D
+7 0 D
+5 2 D
+13 -1 D
+0 121 D
+-21 6 D
+1 3 D
+4 -1 D
+5 1 D
+-3 1 D
+12 1 D
+2 -1 D
+0 47 D
+-1 0 D
+1 0 D
+0 25 D
+-1 0 D
+1 0 D
+0 4 D
+-68 0 D
+-3 -2 D
+0 2 D
+-3 0 D
+-2 -11 D
+2 -1 D
+-1 2 D
+4 2 D
+23 -5 D
+3 1 D
+-3 -5 D
+10 -7 D
+9 -3 D
+11 1 D
+-7 -1 D
+4 -1 D
+-14 -12 D
+2 -2 D
+-9 -3 D
+-2 6 D
+-23 8 D
+0 3 D
+-39 7 D
+15 -1 D
+-26 4 D
+-9 -4 D
+0 4 D
+5 1 D
+-17 5 D
+-27 4 D
+-52 4 D
+-4 -4 D
+-8 0 D
+-3 -3 D
+23 -18 D
+-7 2 D
+-8 -4 D
+-13 0 D
+0 -206 D
+P
+5810 3596 M
+-2 1 D
+-3 -2 D
+0 2 D
+-3 -1 D
+0 2 D
+7 1 D
+P
+5887 3557 M
+-2 1 D
+4 2 D
+-8 -1 D
+0 2 D
+12 0 D
+P
+5840 3580 M
+-3 0 D
+2 2 D
+-7 1 D
+8 0 D
+1 -3 D
+P
+5844 3690 M
+3 2 D
+3 -2 D
+P
+5883 3706 M
+1 1 D
+6 -1 D
+-10 0 D
+P
+5787 3557 M
+-3 2 D
+2 1 D
+3 -2 D
+P
+5877 3759 M
+6 1 D
+-4 -2 D
+P
+5787 3684 M
+6 3 D
+2 -4 D
+P
+5882 3552 M
+14 6 D
+-1 -3 D
+P
+5791 3603 M
+-3 3 D
+6 1 D
+P
+5761 3556 M
+0 2 D
+5 -3 D
+-5 0 D
+P
+5810 3680 M
+10 -1 D
+P
+5842 3703 M
+5 2 D
+-1 -3 D
+P
+5854 3561 M
+5 1 D
+P
+5820 3592 M
+2 2 D
+4 -1 D
+-6 -2 D
+P
+5813 3632 M
+-3 3 D
+4 -1 D
+P
+5851 3557 M
+1 2 D
+7 -1 D
+P
+5719 3544 M
+-5 2 D
+6 -1 D
+P
+5762 3687 M
+4 1 D
+-4 -2 D
+P
+5828 3694 M
+-1 2 D
+5 -2 D
+P
+5836 3699 M
+-1 2 D
+5 -1 D
+-4 0 D
+P
+5832 3704 M
+1 1 D
+2 -2 D
+-4 1 D
+P
+5771 3678 M
+7 -1 D
+P
+5883 3576 M
+-1 -3 D
+P
+5882 3769 M
+7 -2 D
+-10 2 D
+P
+5887 3764 M
+4 -1 D
+P
+5767 3552 M
+3 -1 D
+-7 -1 D
+P
+5822 3687 M
+5 0 D
+P
+5895 3554 M
+2 1 D
+P
+5795 3563 M
+-4 1 D
+P
+5849 3561 M
+4 0 D
+-3 -1 D
+P
+5866 3548 M
+2 1 D
+-2 -2 D
+P
+5791 3561 M
+3 1 D
+P
+5861 3552 M
+2 1 D
+P
+5809 3662 M
+-3 -1 D
+P
+5890 3745 M
+2 -1 D
+P
+5902 3749 M
+2 2 D
+P
+5822 3557 M
+0 2 D
+P
+5862 3702 M
+4 0 D
+P
+5833 3702 M
+5 0 D
+P
+5811 3563 M
+-1 1 D
+P
+5881 3773 M
+4 -1 D
+-4 0 D
+P
+5862 3550 M
+2 0 D
+P
+5881 3736 M
+3 0 D
+-2 0 D
+P
+5876 3773 M
+2 -1 D
+-3 1 D
+P
+5901 3737 M
+2 0 D
+P
+5742 3544 M
+-2 3 D
+P
+5892 3559 M
+2 1 D
+P
+5892 3550 M
+1 2 D
+P
+FO
+5906 3572 M
+-13 2 D
+-4 -3 D
+-8 0 D
+1 -3 D
+11 -2 D
+5 -6 D
+5 -1 D
+-3 -5 D
+3 -5 D
+-5 -3 D
+6 -2 D
+0 -1 D
+2 0 D
+P
+FO
+5906 3699 M
+-12 4 D
+3 -4 D
+9 -1 D
+P
+FO
+5906 3701 M
+-10 2 D
+10 -4 D
+P
+FO
+5906 3702 M
+-5 1 D
+P
+FO
+5669 3773 M
+5 -1 D
+7 1 D
+-1 5 D
+-4 2 D
+-7 0 D
+P
+FO
+5835 3765 M
+3 -1 D
+4 2 D
+-9 1 D
+1 -2 D
+P
+FO
+5835 3767 M
+7 3 D
+P
+FO
+5890 3701 M
+2 -1 D
+P
+FO
+5889 3701 M
+3 -1 D
+P
+FO
+5896 3699 M
+2 -2 D
+P
+FO
+5895 3704 M
+4 -1 D
+P
+FO
+5899 3704 M
+3 0 D
+P
+FO
+-3 1 1 5860 3580 SP
+6117 3543 M
+1 1 D
+-12 4 D
+-1 2 D
+-3 -1 D
+0 4 D
+-8 0 D
+-10 6 D
+-4 -1 D
+-9 2 D
+-10 5 D
+-5 -1 D
+-12 4 D
+-5 -2 D
+-10 4 D
+-18 2 D
+-1 -2 D
+-3 2 D
+-5 -1 D
+-6 1 D
+-4 -1 D
+-25 1 D
+-7 2 D
+-24 -3 D
+-8 3 D
+-19 -2 D
+-3 0 D
+0 -29 D
+P
+FO
+5994 3780 M
+0 -2 D
+-5 -5 D
+9 -8 D
+-4 -5 D
+4 -3 D
+9 2 D
+12 -1 D
+17 4 D
+10 0 D
+40 -9 D
+4 -9 D
+4 0 D
+5 -6 D
+-15 -3 D
+-2 -9 D
+12 -1 D
+-1 -1 D
+11 -1 D
+1 2 D
+8 -1 D
+0 -4 D
+-12 2 D
+-10 -1 D
+-18 6 D
+5 2 D
+-3 3 D
+4 6 D
+-5 1 D
+4 5 D
+-18 6 D
+4 2 D
+-3 3 D
+-10 0 D
+-35 -5 D
+-5 -2 D
+-4 -7 D
+13 -8 D
+-2 -8 D
+-20 -10 D
+-1 -6 D
+-21 -7 D
+0 -2 D
+-12 -1 D
+-4 -2 D
+3 -4 D
+-7 -3 D
+-16 3 D
+-34 1 D
+0 -121 D
+3 -1 D
+7 2 D
+12 0 D
+7 -2 D
+25 2 D
+7 -2 D
+22 1 D
+3 -2 D
+4 2 D
+6 -2 D
+5 1 D
+3 -1 D
+1 1 D
+24 -2 D
+4 -3 D
+5 1 D
+13 -4 D
+5 1 D
+17 -6 D
+5 1 D
+5 -4 D
+7 -3 D
+7 0 D
+-1 -3 D
+3 0 D
+1 -2 D
+10 -2 D
+-1 -1 D
+4 -1 D
+-1 -1 D
+24 0 D
+0 237 D
+P
+6126 3570 M
+-3 2 D
+6 2 D
+P
+5989 3585 M
+-2 -3 D
+-5 2 D
+P
+6122 3648 M
+-5 3 D
+7 -2 D
+P
+6065 3569 M
+-1 2 D
+3 -1 D
+P
+6121 3641 M
+-6 0 D
+5 1 D
+P
+5976 3592 M
+-3 0 D
+1 1 D
+P
+5988 3587 M
+-4 0 D
+1 1 D
+P
+6042 3617 M
+-4 0 D
+P
+6133 3573 M
+4 3 D
+P
+5980 3590 M
+-3 0 D
+4 0 D
+P
+6066 3587 M
+2 2 D
+P
+5998 3628 M
+-1 1 D
+2 -1 D
+P
+5978 3591 M
+-3 0 D
+3 1 D
+P
+5971 3596 M
+-2 1 D
+P
+5943 3587 M
+-2 -1 D
+3 1 D
+P
+5939 3588 M
+-3 -1 D
+P
+5971 3593 M
+-3 2 D
+P
+5964 3594 M
+-3 1 D
+P
+5942 3627 M
+-5 -1 D
+P
+5937 3589 M
+-3 1 D
+P
+FO
+5930 3780 M
+0 -1 D
+-16 1 D
+0 -1 D
+-8 1 D
+0 -4 D
+5 0 D
+-4 -1 D
+-1 1 D
+0 -25 D
+2 -1 D
+-2 1 D
+0 -47 D
+3 -2 D
+31 4 D
+-1 2 D
+8 -2 D
+7 4 D
+-2 2 D
+5 1 D
+-3 3 D
+9 1 D
+2 6 D
+12 3 D
+1 -1 D
+0 12 D
+11 6 D
+2 -1 D
+-3 4 D
+-23 9 D
+2 8 D
+-4 3 D
+3 -1 D
+3 9 D
+-4 6 D
+P
+5939 3731 M
+5 2 D
+4 -1 D
+-4 -3 D
+-9 0 D
+P
+5927 3734 M
+4 1 D
+8 -3 D
+-8 0 D
+P
+5909 3774 M
+4 -2 D
+-4 -1 D
+-3 2 D
+P
+5914 3776 M
+7 1 D
+-3 -2 D
+P
+5925 3774 M
+3 1 D
+3 -1 D
+P
+5955 3762 M
+5 1 D
+-1 -2 D
+P
+5907 3760 M
+2 1 D
+1 -2 D
+P
+5931 3731 M
+4 0 D
+0 -1 D
+P
+5935 3774 M
+5 -1 D
+-5 0 D
+P
+5913 3749 M
+3 -1 D
+P
+5918 3762 M
+5 1 D
+P
+5912 3762 M
+3 0 D
+-4 0 D
+P
+5938 3735 M
+1 1 D
+P
+5938 3765 M
+4 0 D
+P
+5915 3773 M
+3 -1 D
+P
+5947 3737 M
+2 -1 D
+P
+5928 3739 M
+6 0 D
+P
+5932 3777 M
+3 0 D
+P
+5925 3737 M
+3 -1 D
+P
+FO
+5906 3702 M
+2 0 D
+-2 0 D
+P
+FO
+5906 3699 M
+1 0 D
+-1 2 D
+P
+FO
+5906 3698 M
+0 1 D
+P
+FO
+5929 3700 M
+5 -1 D
+9 1 D
+-2 5 D
+-14 -1 D
+-4 -2 D
+4 0 D
+-4 0 D
+P
+FO
+5929 3698 M
+-9 3 D
+-7 -1 D
+9 -3 D
+P
+FO
+5929 3700 M
+-9 1 D
+11 -2 D
+P
+FO
+5906 3697 M
+3 0 D
+P
+FO
+5906 3701 M
+4 -1 D
+P
+FO
+5910 3702 M
+10 -1 D
+P
+FO
+5906 3698 M
+4 0 D
+P
+FO
+5912 3702 M
+3 0 D
+P
+FO
+5906 3699 M
+3 -1 D
+P
+FO
+6106 3723 M
+4 0 D
+P
+FO
+5960 3692 M
+2 1 D
+P
+FO
+6091 3724 M
+3 1 D
+P
+FO
+5929 3699 M
+4 -1 D
+P
+FO
+6378 3663 M
+-1 13 D
+-22 8 D
+-5 -1 D
+-19 -3 D
+-4 -23 D
+-7 -9 D
+2 -10 D
+-9 -15 D
+21 -7 D
+21 -17 D
+-24 17 D
+-19 7 D
+3 8 D
+6 6 D
+-3 13 D
+7 8 D
+6 20 D
+-6 2 D
+-2 3 D
+6 1 D
+-1 3 D
+-16 2 D
+0 2 D
+6 3 D
+-14 5 D
+-11 -1 D
+-5 1 D
+12 5 D
+-4 14 D
+-8 5 D
+8 7 D
+-6 3 D
+7 5 D
+-7 4 D
+-3 6 D
+-8 5 D
+6 5 D
+-8 5 D
+8 3 D
+-19 7 D
+-8 1 D
+-14 -5 D
+-8 5 D
+11 -3 D
+8 4 D
+15 0 D
+18 -8 D
+-6 -5 D
+5 -3 D
+-4 -6 D
+15 -15 D
+-4 -4 D
+4 -5 D
+-8 -6 D
+3 -3 D
+7 -1 D
+2 -15 D
+-11 -5 D
+13 1 D
+16 -6 D
+1 -2 D
+-6 -3 D
+15 -2 D
+-2 -7 D
+27 4 D
+23 -7 D
+0 -5 D
+0 65 D
+-5 1 D
+-1 2 D
+-7 -2 D
+-4 3 D
+17 -1 D
+0 9 D
+-12 2 D
+12 1 D
+0 10 D
+-10 1 D
+3 1 D
+7 -1 D
+0 5 D
+-17 -5 D
+-12 0 D
+22 4 D
+7 3 D
+0 10 D
+-51 0 D
+-5 -2 D
+8 -5 D
+0 -4 D
+5 -2 D
+-3 -1 D
+-8 1 D
+-1 7 D
+-8 2 D
+5 4 D
+-94 0 D
+10 -5 D
+-1 -2 D
+-8 0 D
+-10 4 D
+7 -1 D
+-3 4 D
+-79 0 D
+0 -237 D
+236 0 D
+P
+6157 3640 M
+-8 0 D
+-3 2 D
+13 0 D
+P
+6164 3641 M
+-4 0 D
+4 1 D
+P
+6339 3698 M
+4 3 D
+-4 -5 D
+P
+6163 3568 M
+-3 1 D
+2 1 D
+P
+6318 3770 M
+2 1 D
+P
+FO
+6224 3775 M
+9 -1 D
+-7 2 D
+P
+FO
+6 2 -1 -1 2 6314 3691 SP
+1 1 1 6282 3763 SP
+2 -7 1 6298 3717 SP
+-2 -2 1 2 2 6326 3682 SP
+4 1 1 6291 3700 SP
+-1 -3 1 6321 3652 SP
+-1 -1 1 6282 3755 SP
+8 -3 1 6268 3774 SP
+6378 3770 M
+17 -3 D
+17 0 D
+3 -2 D
+-20 1 D
+-5 2 D
+-9 0 D
+-3 0 D
+0 -5 D
+15 -2 D
+-15 1 D
+0 -10 D
+9 -3 D
+32 3 D
+-6 -2 D
+-31 -2 D
+-4 1 D
+0 -9 D
+17 2 D
+2 -2 D
+7 3 D
+16 -1 D
+8 3 D
+-1 -3 D
+8 0 D
+-27 -1 D
+-7 -2 D
+-21 -2 D
+-2 0 D
+0 -73 D
+10 -7 D
+9 -2 D
+11 -5 D
+19 -3 D
+-19 2 D
+-12 6 D
+-9 1 D
+-9 7 D
+0 -120 D
+236 0 D
+0 237 D
+-236 0 D
+P
+6443 3715 M
+7 4 D
+2 -3 D
+-6 -2 D
+1 -2 D
+-6 -3 D
+4 3 D
+P
+6420 3726 M
+1 3 D
+18 6 D
+11 8 D
+17 -1 D
+-16 1 D
+-10 -8 D
+P
+6431 3716 M
+3 1 D
+7 -1 D
+-7 1 D
+-13 -3 D
+P
+6478 3694 M
+-12 10 D
+5 8 D
+-3 -8 D
+P
+6476 3755 M
+-14 9 D
+15 -7 D
+6 -1 D
+P
+6498 3702 M
+0 -1 D
+2 -1 D
+-8 8 D
+P
+6431 3709 M
+8 0 D
+-14 0 D
+P
+6423 3759 M
+-22 -3 D
+-2 2 D
+12 -1 D
+P
+6397 3754 M
+9 2 D
+-16 -3 D
+P
+6410 3729 M
+7 0 D
+P
+6407 3729 M
+-9 1 D
+P
+6458 3707 M
+4 4 D
+P
+FO
+6614 3543 M
+236 0 D
+0 237 D
+-236 0 D
+P
+6700 3719 M
+2 -1 D
+P
+FO
+6937 3543 M
+6 4 D
+7 2 D
+8 9 D
+10 2 D
+16 0 D
+12 -4 D
+16 -3 D
+8 -8 D
+7 -2 D
+38 0 D
+8 6 D
+14 -1 D
+0 79 D
+-3 1 D
+-21 -3 D
+21 3 D
+3 -1 D
+0 153 D
+-237 0 D
+0 -237 D
+P
+FO
+7024 3543 M
+-6 2 D
+-7 8 D
+-16 3 D
+-12 4 D
+-15 0 D
+-10 -3 D
+-7 -8 D
+-7 -2 D
+-5 -4 D
+P
+FO
+7087 3547 M
+-14 1 D
+-7 -5 D
+21 0 D
+P
+FO
+7323 3595 M
+-10 -12 D
+-20 -10 D
+-7 -1 D
+-8 1 D
+-21 -4 D
+-23 -1 D
+-18 -6 D
+-32 -5 D
+-56 0 D
+-11 2 D
+-14 -6 D
+1 -3 D
+3 2 D
+6 -2 D
+3 -3 D
+-3 -2 D
+2 2 D
+-5 4 D
+-6 -2 D
+-3 3 D
+-9 -1 D
+-5 -4 D
+0 -4 D
+236 0 D
+P
+FO
+7323 3602 M
+-11 14 D
+2 4 D
+-7 5 D
+-22 1 D
+-9 5 D
+-14 3 D
+-23 13 D
+0 -3 D
+-10 -7 D
+-18 -3 D
+-16 3 D
+0 1 D
+-22 2 D
+-12 -5 D
+-29 0 D
+-7 -2 D
+-11 0 D
+-2 -2 D
+-4 1 D
+-4 -3 D
+-6 0 D
+-1 -4 D
+-10 2 D
+0 -79 D
+6 4 D
+8 1 D
+3 3 D
+12 3 D
+12 -2 D
+56 0 D
+33 6 D
+14 5 D
+28 2 D
+23 4 D
+8 0 D
+23 10 D
+10 15 D
+P
+FO
+7323 3624 M
+-13 1 D
+5 -5 D
+-1 -4 D
+9 -12 D
+P
+FO
+7222 3780 M
+-14 -3 D
+-7 -11 D
+-17 -8 D
+-6 -17 D
+-17 -11 D
+-3 -9 D
+12 -10 D
+1 -11 D
+18 -19 D
+2 -12 D
+12 -8 D
+13 -4 D
+2 -4 D
+20 -5 D
+25 -12 D
+14 -4 D
+5 -4 D
+12 -2 D
+7 2 D
+22 -4 D
+0 156 D
+P
+FO
+7087 3627 M
+9 -2 D
+1 5 D
+7 0 D
+4 2 D
+4 -1 D
+2 2 D
+10 0 D
+9 2 D
+28 1 D
+12 4 D
+22 -1 D
+1 -2 D
+14 -2 D
+15 2 D
+12 6 D
+0 4 D
+-21 5 D
+-4 5 D
+-13 3 D
+-9 5 D
+-5 8 D
+2 7 D
+-12 9 D
+-18 32 D
+3 13 D
+16 8 D
+4 15 D
+17 8 D
+10 12 D
+6 3 D
+-126 0 D
+P
+FO
+-1 -1 1 7218 3780 SP
+-6 3 5 0 2 7192 3665 SP
+-2 2 1 7179 3690 SP
+7 0 1 7298 3626 SP
+-4 2 1 7269 3633 SP
+-4 2 1 7265 3634 SP
+4 1 1 7296 3626 SP
+0 2 1 7169 3703 SP
+-3 2 1 7259 3636 SP
+2 2 1 7198 3766 SP
+3 0 1 7301 3627 SP
+4 1 1 7213 3778 SP
+4 -3 0 -1 2 7181 3686 SP
+2 -5 -4 2 2 7170 3710 SP
+11 0 1 7280 3573 SP
+-7 3 1 7201 3661 SP
+-3 3 1 7178 3692 SP
+8 3 1 7164 3735 SP
+7323 3624 M
+21 -3 D
+10 3 D
+21 -3 D
+24 3 D
+-2 -6 D
+3 -2 D
+17 2 D
+-1 -3 D
+7 -1 D
+-1 -3 D
+14 -5 D
+10 -1 D
+8 1 D
+8 -9 D
+-5 -2 D
+2 -3 D
+-5 -3 D
+0 -3 D
+-8 -2 D
+3 -2 D
+5 0 D
+-5 -5 D
+5 -1 D
+-2 -2 D
+2 -4 D
+-5 -6 D
+-9 -4 D
+4 -8 D
+-14 2 D
+5 1 D
+7 -2 D
+0 2 D
+-4 5 D
+10 4 D
+5 6 D
+-2 4 D
+2 2 D
+-5 1 D
+5 4 D
+-8 3 D
+8 2 D
+-1 3 D
+6 3 D
+-2 3 D
+5 2 D
+-8 9 D
+-7 -2 D
+-11 2 D
+-14 5 D
+1 2 D
+-6 1 D
+0 4 D
+-16 -3 D
+-4 3 D
+2 5 D
+-24 -2 D
+-19 3 D
+-7 -3 D
+-25 3 D
+0 -20 D
+2 -2 D
+0 -4 D
+-2 -3 D
+0 -52 D
+236 0 D
+0 237 D
+-236 0 D
+P
+FO
+7323 3599 M
+1 1 D
+-1 2 D
+P
+FO
+7795 3698 M
+0 82 D
+-57 0 D
+-4 -9 D
+7 -5 D
+-7 -2 D
+3 -4 D
+-2 -4 D
+-2 8 D
+7 1 D
+-7 6 D
+4 8 D
+-178 1 D
+0 -237 D
+236 0 D
+P
+7657 3742 M
+3 -1 D
+-4 0 D
+P
+7784 3741 M
+6 -1 D
+-4 -1 D
+P
+7673 3742 M
+4 -1 D
+-7 1 D
+P
+7717 3763 M
+4 -2 D
+-9 0 D
+P
+7644 3604 M
+1 -3 D
+P
+7792 3698 M
+1 -2 D
+P
+7676 3744 M
+4 -2 D
+P
+7683 3760 M
+6 1 D
+0 -2 D
+P
+7667 3734 M
+4 0 D
+P
+7677 3741 M
+6 0 D
+P
+7791 3742 M
+4 -1 D
+P
+7662 3734 M
+3 0 D
+P
+7793 3696 M
+2 -1 D
+P
+7663 3742 M
+3 1 D
+3 -1 D
+P
+7680 3743 M
+3 1 D
+P
+FO
+7899 3543 M
+0 2 D
+4 1 D
+-1 -3 D
+1 0 D
+5 7 D
+24 10 D
+3 0 D
+1 6 D
+16 6 D
+1 7 D
+16 4 D
+3 3 D
+14 -2 D
+5 2 D
+13 0 D
+4 3 D
+9 -1 D
+2 -3 D
+3 1 D
+0 -4 D
+2 2 D
+5 0 D
+2 2 D
+0 159 D
+-23 3 D
+4 2 D
+-11 -1 D
+-4 2 D
+-13 -4 D
+2 -3 D
+-9 -5 D
+-1 -4 D
+-23 -5 D
+-13 1 D
+1 -2 D
+6 -2 D
+-3 -3 D
+-14 -2 D
+-12 2 D
+-31 -4 D
+5 2 D
+27 2 D
+11 -1 D
+12 1 D
+4 2 D
+-7 2 D
+0 3 D
+14 0 D
+22 4 D
+1 4 D
+8 5 D
+-3 4 D
+15 3 D
+5 -1 D
+12 1 D
+-3 -3 D
+21 -3 D
+0 8 D
+-2 0 D
+2 0 D
+0 10 D
+-5 1 D
+5 0 D
+0 9 D
+-3 1 D
+-2 -1 D
+-2 4 D
+4 3 D
+-233 0 D
+0 -82 D
+2 0 D
+-2 0 D
+0 -155 D
+P
+7916 3741 M
+-3 1 D
+5 1 D
+2 -2 D
+P
+7837 3744 M
+5 0 D
+-5 -2 D
+-3 0 D
+P
+7847 3747 M
+4 0 D
+-4 -2 D
+P
+7937 3766 M
+-1 2 D
+5 -1 D
+P
+7826 3750 M
+1 1 D
+3 -1 D
+P
+7926 3766 M
+6 2 D
+-1 -3 D
+P
+7899 3726 M
+5 1 D
+1 -2 D
+P
+7846 3749 M
+1 -1 D
+-4 1 D
+P
+8023 3774 M
+-1 -1 D
+-3 1 D
+P
+7921 3744 M
+-5 1 D
+4 1 D
+2 -1 D
+P
+7942 3745 M
+-1 1 D
+6 -1 D
+-4 -1 D
+P
+7945 3777 M
+3 1 D
+1 -2 D
+P
+7818 3738 M
+-1 2 D
+5 -1 D
+P
+8001 3772 M
+-4 1 D
+P
+7922 3748 M
+1 2 D
+P
+8021 3776 M
+-2 -1 D
+P
+7928 3770 M
+2 1 D
+P
+7807 3733 M
+-2 2 D
+2 -1 D
+P
+7906 3757 M
+1 1 D
+P
+7849 3741 M
+-1 -1 D
+P
+7968 3752 M
+1 1 D
+P
+7911 3736 M
+-3 0 D
+P
+7911 3742 M
+-3 1 D
+P
+7972 3775 M
+-3 1 D
+4 -1 D
+P
+7912 3741 M
+-3 0 D
+4 0 D
+P
+7880 3750 M
+-2 1 D
+P
+7827 3747 M
+3 0 D
+P
+7824 3736 M
+2 0 D
+-3 0 D
+P
+7856 3759 M
+3 1 D
+P
+7832 3746 M
+3 1 D
+P
+7922 3734 M
+-5 0 D
+P
+8006 3761 M
+0 1 D
+1 -1 D
+P
+7836 3751 M
+2 0 D
+P
+7824 3760 M
+-1 -1 D
+P
+7877 3722 M
+4 0 D
+P
+7814 3740 M
+0 -1 D
+P
+7853 3741 M
+-1 -2 D
+P
+7831 3708 M
+3 1 D
+P
+7943 3738 M
+3 1 D
+P
+8030 3765 M
+-3 1 D
+P
+7803 3755 M
+3 -1 D
+-3 0 D
+P
+7827 3744 M
+-3 0 D
+4 0 D
+P
+7896 3745 M
+3 -1 D
+P
+7931 3730 M
+5 0 D
+-5 -1 D
+P
+7911 3750 M
+5 1 D
+P
+7837 3730 M
+5 -1 D
+-6 -1 D
+P
+7913 3736 M
+-3 2 D
+P
+7946 3767 M
+5 0 D
+P
+7905 3746 M
+-4 -1 D
+P
+7910 3744 M
+2 2 D
+P
+7858 3759 M
+5 0 D
+P
+7863 3771 M
+-3 -1 D
+P
+7824 3740 M
+4 0 D
+P
+7935 3741 M
+3 1 D
+P
+7832 3720 M
+2 1 D
+P
+7909 3748 M
+3 0 D
+P
+8028 3768 M
+-4 0 D
+P
+7837 3746 M
+-1 0 D
+4 -1 D
+P
+7901 3730 M
+3 1 D
+P
+7915 3739 M
+4 1 D
+P
+8019 3775 M
+-4 -2 D
+P
+7834 3741 M
+-2 -1 D
+2 2 D
+P
+7869 3746 M
+1 1 D
+P
+7907 3725 M
+2 0 D
+P
+7855 3718 M
+2 1 D
+P
+7814 3759 M
+2 -2 D
+P
+8008 3760 M
+-4 -1 D
+P
+7917 3736 M
+2 1 D
+P
+7965 3751 M
+2 -1 D
+P
+7837 3741 M
+0 -1 D
+P
+FO
+8031 3569 M
+-4 -4 D
+4 1 D
+P
+FO
+8031 3574 M
+-5 -1 D
+4 0 D
+1 -3 D
+P
+FO
+8031 3576 M
+-2 -2 D
+2 0 D
+P
+FO
+8132 3543 M
+5 3 D
+6 -3 D
+12 0 D
+-4 3 D
+4 -1 D
+6 3 D
+-1 1 D
+1 -1 D
+10 3 D
+2 2 D
+7 1 D
+2 -1 D
+-3 0 D
+2 -5 D
+-3 -5 D
+9 0 D
+9 7 D
+-2 0 D
+5 0 D
+-2 3 D
+5 -2 D
+4 1 D
+-1 2 D
+5 -1 D
+6 1 D
+0 2 D
+16 1 D
+17 -1 D
+-4 1 D
+4 -1 D
+1 2 D
+4 -2 D
+-3 0 D
+9 -2 D
+3 -5 D
+5 0 D
+0 202 D
+-10 0 D
+-6 7 D
+-24 3 D
+0 8 D
+-12 5 D
+-22 -7 D
+-54 3 D
+-12 4 D
+-10 -2 D
+-31 0 D
+-21 -8 D
+-1 4 D
+-7 -1 D
+0 -7 D
+-6 11 D
+-12 0 D
+-9 2 D
+0 -9 D
+11 -1 D
+0 -2 D
+-11 2 D
+0 -10 D
+1 0 D
+-1 0 D
+0 -8 D
+12 -1 D
+6 2 D
+1 -1 D
+-7 -1 D
+-12 1 D
+0 -159 D
+10 3 D
+-3 -9 D
+-7 -4 D
+0 -2 D
+1 0 D
+-1 0 D
+1 -5 D
+-1 0 D
+0 -3 D
+11 2 D
+-1 -3 D
+-5 -2 D
+1 -6 D
+5 4 D
+-1 -1 D
+7 1 D
+2 -1 D
+3 4 D
+21 12 D
+2 -1 D
+0 2 D
+3 -1 D
+9 7 D
+9 -2 D
+-4 2 D
+5 1 D
+5 -5 D
+7 4 D
+-8 3 D
+5 6 D
+-3 4 D
+7 2 D
+-5 2 D
+3 3 D
+31 4 D
+4 -3 D
+13 -2 D
+-5 -1 D
+2 -1 D
+-15 1 D
+-9 -4 D
+-2 -14 D
+-5 -1 D
+-3 -4 D
+7 -3 D
+-13 -8 D
+7 -2 D
+-2 -1 D
+2 -1 D
+-4 1 D
+-7 -4 D
+0 2 D
+-9 -1 D
+-5 -3 D
+-19 -5 D
+0 -5 D
+-11 -4 D
+-1 -1 D
+P
+8035 3766 M
+3 -2 D
+-6 1 D
+1 4 D
+9 -3 D
+P
+8235 3720 M
+-5 1 D
+P
+8047 3759 M
+-4 1 D
+P
+8036 3760 M
+-2 1 D
+P
+8057 3758 M
+0 1 D
+P
+8140 3573 M
+3 3 D
+P
+8226 3717 M
+-1 0 D
+5 1 D
+P
+8044 3754 M
+-4 0 D
+P
+8032 3755 M
+2 -1 D
+P
+FO
+8268 3549 M
+-3 -1 D
+2 -3 D
+1 0 D
+P
+FO
+8244 3769 M
+6 0 D
+5 7 D
+-19 3 D
+-12 0 D
+-8 -4 D
+P
+FO
+8064 3769 M
+3 -3 D
+3 3 D
+-4 1 D
+P
+FO
+8072 3769 M
+4 0 D
+0 2 D
+P
+FO
+8072 3770 M
+2 1 D
+P
+FO
+8091 3580 M
+3 0 D
+P
+FO
+8067 3766 M
+3 1 D
+P
+FO
+8249 3778 M
+2 0 D
+P
+FO
+8276 3543 M
+4 6 D
+4 2 D
+-5 1 D
+4 0 D
+-2 1 D
+4 0 D
+2 3 D
+3 -1 D
+11 3 D
+7 5 D
+7 1 D
+2 -1 D
+3 3 D
+-4 3 D
+9 -2 D
+1 2 D
+-5 1 D
+4 0 D
+-2 2 D
+7 -1 D
+4 3 D
+3 -1 D
+0 2 D
+-5 1 D
+4 2 D
+4 -2 D
+5 1 D
+1 3 D
+5 0 D
+0 5 D
+7 -3 D
+7 3 D
+-2 2 D
+5 -1 D
+-3 -1 D
+6 2 D
+5 -1 D
+4 2 D
+-3 2 D
+5 -1 D
+-2 -1 D
+11 3 D
+1 2 D
+4 0 D
+-3 -1 D
+43 11 D
+23 0 D
+25 -6 D
+0 4 D
+6 1 D
+5 6 D
+-8 5 D
+4 4 D
+-15 5 D
+2 1 D
+4 -2 D
+-6 7 D
+2 -4 D
+-3 0 D
+-3 2 D
+4 0 D
+-7 2 D
+2 1 D
+4 -1 D
+-3 2 D
+4 -2 D
+-1 5 D
+-3 5 D
+1 -2 D
+-6 2 D
+-5 -1 D
+7 2 D
+3 -1 D
+-10 10 D
+3 -3 D
+-6 -2 D
+4 -1 D
+-10 1 D
+-8 4 D
+0 8 D
+-10 0 D
+-8 -5 D
+-6 4 D
+-10 -6 D
+3 4 D
+6 2 D
+-6 4 D
+-4 1 D
+-8 -4 D
+-13 0 D
+14 1 D
+8 4 D
+9 -3 D
+6 1 D
+9 -2 D
+6 1 D
+-1 2 D
+5 1 D
+-2 -3 D
+7 -3 D
+27 -1 D
+6 3 D
+10 1 D
+11 4 D
+0 8 D
+-3 0 D
+3 2 D
+0 85 D
+-17 6 D
+-8 0 D
+0 2 D
+4 -1 D
+-8 3 D
+-43 5 D
+-21 6 D
+-18 -2 D
+-4 1 D
+7 0 D
+-34 1 D
+-6 -2 D
+-7 3 D
+-3 -1 D
+5 -2 D
+-7 -1 D
+2 1 D
+-13 4 D
+-52 1 D
+1 -6 D
+-8 -1 D
+-2 -3 D
+11 -1 D
+8 -12 D
+5 0 D
+-6 0 D
+-7 -3 D
+2 -2 D
+-3 2 D
+-6 -2 D
+3 -2 D
+-3 2 D
+-8 -1 D
+0 -202 D
+1 0 D
+-1 0 D
+0 -4 D
+3 -2 D
+P
+8314 3720 M
+-1 1 D
+5 1 D
+1 -2 D
+P
+8411 3774 M
+-9 2 D
+8 0 D
+P
+8480 3604 M
+3 -1 D
+-2 -1 D
+P
+8425 3605 M
+4 0 D
+P
+8448 3606 M
+-1 -1 D
+P
+8272 3546 M
+3 -1 D
+P
+8487 3607 M
+3 -1 D
+P
+8399 3633 M
+0 -2 D
+P
+8484 3614 M
+2 1 D
+P
+FO
+8268 3773 M
+7 1 D
+P
+FO
+236 3625 M
+-2 4 D
+-6 2 D
+-13 -3 D
+-14 0 D
+3 1 D
+-9 4 D
+-3 -7 D
+3 -3 D
+7 -2 D
+8 3 D
+16 -2 D
+3 -3 D
+7 -1 D
+P
+198 3629 M
+2 1 D
+P
+FO
+236 3689 M
+-2 0 D
+-3 3 D
+-21 6 D
+-6 5 D
+-7 2 D
+0 2 D
+-47 4 D
+-23 -1 D
+15 -2 D
+2 -7 D
+-8 -2 D
+10 -3 D
+-3 -8 D
+-3 3 D
+2 5 D
+-5 0 D
+-5 -4 D
+-1 6 D
+-11 1 D
+-1 2 D
+6 1 D
+-5 9 D
+4 5 D
+-12 8 D
+-30 8 D
+9 -2 D
+-18 1 D
+4 1 D
+-6 4 D
+-4 -2 D
+-2 3 D
+3 -1 D
+-4 2 D
+-6 -1 D
+-3 3 D
+-17 2 D
+-8 3 D
+-2 4 D
+8 -3 D
+-23 8 D
+-4 -1 D
+-9 3 D
+0 -85 D
+6 1 D
+-5 -1 D
+1 -2 D
+-2 0 D
+0 -8 D
+8 4 D
+9 9 D
+0 2 D
+-9 3 D
+-3 4 D
+3 6 D
+3 -1 D
+7 1 D
+-3 4 D
+5 -2 D
+2 3 D
+-1 -3 D
+5 -2 D
+11 5 D
+-2 -6 D
+-6 -3 D
+-4 1 D
+7 -7 D
+5 0 D
+0 -7 D
+24 0 D
+10 4 D
+26 -5 D
+-1 -2 D
+-2 2 D
+7 -6 D
+-4 -4 D
+13 -3 D
+-2 -2 D
+10 0 D
+22 -5 D
+2 -3 D
+8 -3 D
+9 3 D
+-1 4 D
+4 -4 D
+-5 -3 D
+5 -2 D
+7 2 D
+1 3 D
+-6 0 D
+6 2 D
+5 -3 D
+8 0 D
+-4 4 D
+-9 1 D
+-4 -1 D
+3 2 D
+-6 0 D
+8 3 D
+-4 1 D
+-7 -1 D
+26 7 D
+-3 4 D
+4 6 D
+-5 -2 D
+-6 5 D
+-11 2 D
+13 0 D
+5 -4 D
+13 0 D
+-9 -1 D
+19 1 D
+5 -2 D
+2 3 D
+-11 6 D
+7 -3 D
+14 -2 D
+0 6 D
+3 2 D
+10 2 D
+P
+125 3698 M
+4 -1 D
+-5 1 D
+P
+FO
+165 3555 M
+10 -4 D
+9 0 D
+-13 3 D
+-4 4 D
+-3 -2 D
+P
+FO
+162 3559 M
+2 -1 D
+0 2 D
+P
+FO
+173 3654 M
+14 2 D
+-8 2 D
+-5 -4 D
+P
+FO
+47 3743 M
+-11 3 D
+19 -6 D
+P
+FO
+124 3714 M
+2 -2 D
+P
+FO
+124 3711 M
+1 -2 D
+P
+FO
+173 3658 M
+4 1 D
+-3 -1 D
+P
+FO
+172 3653 M
+6 -1 D
+P
+FO
+339 3543 M
+-1 7 D
+-9 1 D
+-2 3 D
+0 -2 D
+-13 -1 D
+-3 -3 D
+-15 0 D
+3 -3 D
+6 -2 D
+P
+FO
+400 3543 M
+1 1 D
+-1 -1 D
+13 0 D
+2 5 D
+-6 1 D
+4 1 D
+4 -1 D
+1 -3 D
+1 2 D
+2 -1 D
+-1 -3 D
+52 -1 D
+0 32 D
+-3 1 D
+3 0 D
+0 14 D
+-29 -3 D
+-4 -5 D
+-13 -2 D
+-2 5 D
+-4 3 D
+-6 0 D
+0 2 D
+-5 -2 D
+-4 1 D
+-3 -1 D
+-8 3 D
+-13 2 D
+-3 2 D
+2 5 D
+-1 4 D
+-12 5 D
+7 -1 D
+7 -4 D
+-1 -10 D
+16 -3 D
+3 -2 D
+6 1 D
+3 -1 D
+6 2 D
+2 -2 D
+5 1 D
+6 -9 D
+12 2 D
+3 5 D
+10 2 D
+17 0 D
+3 2 D
+0 5 D
+-5 10 D
+5 5 D
+0 84 D
+-3 2 D
+3 0 D
+0 82 D
+-60 0 D
+-11 -6 D
+-4 -11 D
+-2 -1 D
+3 4 D
+-19 -10 D
+-33 -3 D
+-21 0 D
+-2 -10 D
+-12 -3 D
+15 -1 D
+48 -16 D
+11 -12 D
+20 -3 D
+-2 2 D
+9 -1 D
+3 1 D
+0 -2 D
+18 1 D
+4 -2 D
+-5 0 D
+-4 -5 D
+9 -5 D
+13 4 D
+10 -2 D
+6 1 D
+1 -6 D
+-8 -1 D
+-14 5 D
+-10 -3 D
+-11 5 D
+1 4 D
+-11 4 D
+-4 -3 D
+18 -8 D
+-1 -4 D
+5 1 D
+13 -1 D
+4 -3 D
+-2 -2 D
+0 2 D
+-10 1 D
+-9 -7 D
+1 2 D
+-7 1 D
+-13 -2 D
+-1 2 D
+-24 -1 D
+-4 4 D
+-7 -1 D
+9 2 D
+2 7 D
+-16 1 D
+-7 -1 D
+-7 -4 D
+-3 1 D
+-15 -2 D
+-2 -3 D
+9 -2 D
+-7 -1 D
+-12 2 D
+-17 -5 D
+3 -1 D
+-4 -1 D
+-5 1 D
+-7 -2 D
+0 -3 D
+-11 -2 D
+5 3 D
+-7 -1 D
+1 -3 D
+14 -4 D
+33 -4 D
+-7 1 D
+-4 -4 D
+-9 1 D
+1 3 D
+-2 -3 D
+13 -6 D
+-2 -4 D
+7 -4 D
+28 -3 D
+6 1 D
+-4 -1 D
+0 2 D
+1 -1 D
+14 2 D
+-3 0 D
+18 0 D
+12 -4 D
+3 3 D
+-10 2 D
+7 1 D
+7 -4 D
+1 -4 D
+6 5 D
+21 6 D
+-2 2 D
+5 -3 D
+14 6 D
+-3 -2 D
+7 -4 D
+-6 -5 D
+-8 0 D
+-4 -2 D
+8 0 D
+11 -13 D
+-10 -9 D
+-24 -2 D
+4 2 D
+-7 1 D
+-6 -6 D
+-18 -7 D
+-4 3 D
+-3 -1 D
+-4 3 D
+-7 1 D
+-8 -1 D
+-4 -2 D
+3 -2 D
+-6 0 D
+-3 -5 D
+3 -5 D
+-2 -2 D
+-7 0 D
+-14 -10 D
+-1 -4 D
+5 -2 D
+-14 -1 D
+9 -3 D
+-9 -1 D
+-1 2 D
+1 -5 D
+4 1 D
+4 -1 D
+1 -2 D
+-3 0 D
+-1 -2 D
+7 -1 D
+1 -5 D
+5 0 D
+0 3 D
+3 -2 D
+2 3 D
+2 -1 D
+-3 -2 D
+4 0 D
+-1 -2 D
+6 2 D
+0 -2 D
+-4 1 D
+1 -2 D
+-6 0 D
+1 -2 D
+10 1 D
+4 -3 D
+19 0 D
+8 -3 D
+-9 -3 D
+0 4 D
+-3 1 D
+-14 -6 D
+2 -1 D
+-3 -1 D
+-3 -5 D
+13 -6 D
+P
+392 3553 M
+-4 0 D
+1 -4 D
+-5 -2 D
+-3 2 D
+3 2 D
+-10 -1 D
+9 2 D
+-4 0 D
+2 2 D
+2 -2 D
+2 2 D
+8 -1 D
+P
+415 3569 M
+0 -2 D
+-4 -1 D
+-1 1 D
+3 1 D
+-2 1 D
+P
+378 3568 M
+1 -3 D
+-3 -1 D
+-2 2 D
+4 0 D
+-3 1 D
+P
+389 3572 M
+-7 -2 D
+2 0 D
+-3 -2 D
+-1 3 D
+P
+381 3582 M
+5 -2 D
+0 -2 D
+-8 4 D
+P
+372 3551 M
+-4 -1 D
+1 3 D
+P
+364 3592 M
+-2 -1 D
+-2 2 D
+5 -1 D
+P
+391 3607 M
+-2 -3 D
+-2 3 D
+P
+325 3740 M
+2 -2 D
+-7 2 D
+P
+414 3562 M
+-3 -1 D
+-4 2 D
+P
+417 3567 M
+3 -5 D
+-4 1 D
+P
+375 3555 M
+1 -1 D
+-5 1 D
+P
+345 3666 M
+-6 -3 D
+-7 2 D
+P
+400 3675 M
+-5 0 D
+0 2 D
+P
+392 3547 M
+-3 0 D
+P
+355 3659 M
+-3 0 D
+P
+360 3577 M
+-4 0 D
+P
+408 3568 M
+-8 1 D
+P
+365 3580 M
+-5 -2 D
+P
+466 3582 M
+-5 -1 D
+P
+397 3568 M
+-4 0 D
+P
+381 3547 M
+-4 -1 D
+P
+433 3555 M
+-3 0 D
+P
+392 3563 M
+-4 1 D
+P
+426 3551 M
+-4 0 D
+P
+377 3556 M
+-3 0 D
+P
+374 3553 M
+-3 1 D
+4 -1 D
+P
+427 3554 M
+-4 0 D
+P
+460 3582 M
+-2 0 D
+P
+371 3566 M
+-3 -1 D
+P
+422 3596 M
+-4 0 D
+4 1 D
+P
+404 3671 M
+1 0 D
+-4 1 D
+P
+457 3583 M
+-3 1 D
+P
+351 3594 M
+-4 0 D
+P
+376 3552 M
+-2 -1 D
+2 2 D
+P
+367 3695 M
+-2 -1 D
+P
+377 3551 M
+-3 0 D
+P
+429 3556 M
+-2 0 D
+3 1 D
+P
+353 3593 M
+-3 0 D
+P
+372 3725 M
+-4 0 D
+P
+364 3578 M
+-3 -1 D
+P
+436 3576 M
+-2 0 D
+P
+379 3547 M
+-3 0 D
+3 1 D
+P
+410 3558 M
+0 -1 D
+P
+346 3593 M
+-3 0 D
+P
+429 3773 M
+0 1 D
+P
+378 3559 M
+-3 -1 D
+P
+388 3599 M
+-2 0 D
+P
+372 3556 M
+-2 0 D
+P
+374 3568 M
+-3 0 D
+P
+387 3611 M
+-2 1 D
+P
+357 3595 M
+-2 1 D
+3 -1 D
+P
+FO
+472 3611 M
+-3 -7 D
+3 -5 D
+P
+FO
+410 3780 M
+-3 -2 D
+P
+FO
+236 3686 M
+7 -1 D
+1 3 D
+-8 1 D
+P
+FO
+236 3618 M
+6 -5 D
+5 1 D
+4 4 D
+12 0 D
+4 3 D
+-31 4 D
+P
+FO
+354 3552 M
+7 -2 D
+5 6 D
+7 3 D
+-1 3 D
+-10 1 D
+0 2 D
+-4 -1 D
+-2 1 D
+-1 -5 D
+-11 -4 D
+4 -1 D
+7 1 D
+-4 -2 D
+P
+FO
+354 3563 M
+1 0 D
+0 1 D
+-1 0 D
+P
+FO
+331 3589 M
+0 -1 D
+1 2 D
+P
+FO
+398 3768 M
+0 -1 D
+1 5 D
+P
+FO
+354 3697 M
+-11 -2 D
+18 3 D
+P
+FO
+408 3628 M
+4 -1 D
+1 2 D
+P
+FO
+307 3685 M
+-6 -2 D
+10 3 D
+P
+FO
+333 3577 M
+0 -1 D
+P
+FO
+328 3585 M
+0 -1 D
+P
+FO
+365 3726 M
+-3 1 D
+P
+FO
+325 3690 M
+-10 -3 D
+P
+FO
+260 3680 M
+-2 -1 D
+P
+FO
+294 3681 M
+-4 -2 D
+P
+FO
+399 3772 M
+6 5 D
+P
+FO
+331 3592 M
+1 -1 D
+P
+FO
+368 3651 M
+-8 -2 D
+P
+FO
+289 3680 M
+1 0 D
+-3 -1 D
+P
+FO
+504 3543 M
+3 1 D
+95 -1 D
+2 1 D
+-2 -1 D
+44 0 D
+2 2 D
+-10 5 D
+9 -2 D
+5 2 D
+8 9 D
+5 2 D
+3 -1 D
+-1 5 D
+14 3 D
+5 4 D
+9 2 D
+0 1 D
+2 -2 D
+12 0 D
+0 207 D
+-237 0 D
+0 -82 D
+9 -2 D
+-8 -1 D
+-1 1 D
+0 -84 D
+14 13 D
+-2 2 D
+4 5 D
+13 7 D
+2 7 D
+18 12 D
+-18 -12 D
+3 -5 D
+-18 -9 D
+-3 -6 D
+2 -3 D
+-4 -1 D
+-10 -11 D
+-1 0 D
+0 -12 D
+7 -4 D
+-7 -5 D
+0 -14 D
+2 -1 D
+-2 0 D
+0 -32 D
+P
+494 3549 M
+6 1 D
+-2 -1 D
+4 0 D
+0 -2 D
+-9 1 D
+P
+623 3553 M
+-27 -9 D
+7 4 D
+-2 0 D
+23 6 D
+P
+657 3636 M
+2 -1 D
+-5 -1 D
+P
+670 3577 M
+4 0 D
+-5 -1 D
+P
+479 3701 M
+-2 -1 D
+-1 1 D
+P
+613 3548 M
+4 -1 D
+-9 1 D
+P
+574 3707 M
+1 1 D
+P
+590 3547 M
+-3 0 D
+P
+566 3678 M
+-2 0 D
+P
+638 3553 M
+3 -1 D
+P
+679 3647 M
+-2 -1 D
+P
+672 3590 M
+1 -1 D
+P
+501 3695 M
+-2 0 D
+P
+609 3770 M
+2 1 D
+P
+573 3705 M
+1 1 D
+P
+492 3544 M
+14 1 D
+P
+496 3552 M
+5 -1 D
+P
+606 3711 M
+-6 3 D
+P
+595 3566 M
+-4 0 D
+P
+643 3737 M
+4 2 D
+P
+613 3545 M
+-5 -1 D
+P
+574 3572 M
+-2 0 D
+2 1 D
+P
+606 3704 M
+-1 1 D
+P
+524 3648 M
+2 2 D
+P
+620 3559 M
+-4 -1 D
+P
+487 3552 M
+2 -1 D
+P
+616 3562 M
+-2 0 D
+P
+FO
+709 3566 M
+-5 -1 D
+-5 3 D
+-24 -8 D
+5 -4 D
+-2 -4 D
+-8 -9 D
+39 0 D
+P
+684 3550 M
+10 -4 D
+-1 -2 D
+-9 5 D
+-3 0 D
+P
+697 3554 M
+8 -1 D
+-5 -1 D
+P
+FO
+709 3572 M
+-2 -1 D
+2 -1 D
+P
+FO
+472 3592 M
+4 1 D
+2 2 D
+-6 2 D
+P
+FO
+661 3552 M
+4 3 D
+-2 0 D
+P
+FO
+-2 -2 1 505 3642 SP
+723 3543 M
+-1 3 D
+2 -3 D
+5 0 D
+3 3 D
+-1 -3 D
+12 1 D
+3 -1 D
+2 5 D
+2 -2 D
+4 2 D
+-3 -1 D
+-1 2 D
+-5 -1 D
+2 2 D
+1 -1 D
+2 3 D
+2 -1 D
+0 2 D
+5 1 D
+-3 0 D
+3 1 D
+-3 2 D
+-5 -3 D
+-4 2 D
+1 1 D
+2 -1 D
+3 2 D
+0 3 D
+-5 -3 D
+1 3 D
+-3 0 D
+-4 -2 D
+5 3 D
+-6 0 D
+9 0 D
+-2 1 D
+3 0 D
+3 6 D
+-5 -2 D
+-1 1 D
+6 2 D
+2 -3 D
+8 6 D
+-8 -8 D
+8 -2 D
+0 3 D
+3 -3 D
+-2 3 D
+4 5 D
+0 -6 D
+3 2 D
+0 -3 D
+4 3 D
+2 -2 D
+5 3 D
+-1 -3 D
+9 5 D
+9 -1 D
+-10 0 D
+4 -2 D
+-5 1 D
+-1 -2 D
+4 -1 D
+-5 1 D
+3 -3 D
+3 1 D
+-1 -2 D
+8 2 D
+4 -1 D
+-15 -2 D
+1 -2 D
+4 0 D
+5 3 D
+-1 -2 D
+3 0 D
+3 2 D
+2 -1 D
+-7 -3 D
+8 2 D
+-2 -2 D
+3 2 D
+0 -2 D
+6 1 D
+-8 -5 D
+13 0 D
+-2 -1 D
+4 -2 D
+7 3 D
+1 -1 D
+3 1 D
+-2 -4 D
+7 0 D
+1 -2 D
+-2 0 D
+12 0 D
+-2 -1 D
+7 -3 D
+-7 0 D
+12 -1 D
+23 3 D
+17 -3 D
+17 1 D
+-1 3 D
+2 -4 D
+31 0 D
+0 227 D
+-31 2 D
+-2 -1 D
+-31 9 D
+-43 0 D
+-10 -1 D
+-119 1 D
+0 -207 D
+7 5 D
+13 1 D
+-13 -3 D
+-7 -4 D
+0 -2 D
+7 -3 D
+12 -1 D
+5 -4 D
+-24 4 D
+0 -23 D
+P
+789 3601 M
+2 -4 D
+-4 5 D
+P
+881 3618 M
+-3 -2 D
+P
+804 3600 M
+-1 -2 D
+P
+939 3735 M
+-1 2 D
+P
+938 3734 M
+1 1 D
+-1 -2 D
+P
+740 3720 M
+4 2 D
+P
+738 3659 M
+-4 -1 D
+3 2 D
+P
+809 3601 M
+-2 -1 D
+P
+840 3633 M
+-5 0 D
+P
+795 3700 M
+4 0 D
+-4 -1 D
+P
+854 3717 M
+-1 1 D
+P
+781 3692 M
+-5 0 D
+P
+833 3638 M
+-1 -1 D
+P
+944 3731 M
+0 1 D
+1 -1 D
+P
+863 3710 M
+0 1 D
+1 -1 D
+P
+710 3580 M
+2 -1 D
+-3 1 D
+P
+943 3735 M
+-1 1 D
+P
+929 3734 M
+1 2 D
+P
+723 3720 M
+-2 1 D
+3 -1 D
+P
+943 3718 M
+2 1 D
+P
+743 3692 M
+-3 0 D
+P
+807 3697 M
+-1 1 D
+2 -1 D
+P
+797 3591 M
+-5 -6 D
+-2 4 D
+P
+858 3546 M
+8 0 D
+-7 -1 D
+P
+FO
+754 3543 M
+5 3 D
+-3 1 D
+-3 -4 D
+P
+FO
+757 3543 M
+3 2 D
+-3 -2 D
+P
+FO
+771 3543 M
+11 7 D
+-5 -1 D
+3 2 D
+-4 0 D
+1 1 D
+-12 -9 D
+P
+FO
+842 3543 M
+-1 2 D
+P
+FO
+789 3552 M
+3 0 D
+-5 -2 D
+1 -1 D
+13 4 D
+-7 0 D
+1 2 D
+-6 0 D
+-3 -3 D
+P
+FO
+758 3549 M
+3 0 D
+1 -2 D
+3 5 D
+-3 0 D
+3 1 D
+-2 2 D
+-4 -4 D
+3 0 D
+P
+FO
+756 3562 M
+1 2 D
+-3 1 D
+-2 -3 D
+P
+FO
+756 3560 M
+2 -1 D
+2 1 D
+-3 1 D
+P
+FO
+752 3558 M
+2 1 D
+-2 2 D
+-1 -1 D
+P
+FO
+784 3563 M
+2 0 D
+-1 1 D
+P
+FO
+803 3555 M
+6 3 D
+-14 -4 D
+P
+FO
+752 3544 M
+3 4 D
+-6 -3 D
+P
+FO
+910 3773 M
+3 -1 D
+P
+FO
+756 3552 M
+-3 -2 D
+P
+FO
+768 3559 M
+4 0 D
+P
+FO
+767 3549 M
+4 1 D
+P
+FO
+820 3551 M
+3 1 D
+P
+FO
+765 3556 M
+1 1 D
+P
+FO
+823 3551 M
+2 2 D
+P
+FO
+764 3556 M
+1 -1 D
+P
+FO
+841 3547 M
+1 -2 D
+P
+FO
+768 3561 M
+3 0 D
+P
+FO
+827 3549 M
+2 -1 D
+P
+FO
+910 3773 M
+-10 3 D
+P
+FO
+818 3550 M
+3 -1 D
+P
+FO
+825 3551 M
+1 1 D
+P
+FO
+812 3552 M
+4 -1 D
+P
+FO
+770 3556 M
+2 0 D
+P
+FO
+822 3549 M
+2 0 D
+P
+FO
+955 3543 M
+1 2 D
+2 -2 D
+107 0 D
+1 2 D
+-7 -1 D
+10 4 D
+9 -1 D
+2 5 D
+-5 4 D
+2 0 D
+5 -4 D
+-1 -5 D
+2 -4 D
+8 0 D
+0 1 D
+32 -1 D
+-11 5 D
+-6 5 D
+7 -5 D
+9 -2 D
+2 -3 D
+57 0 D
+0 161 D
+-3 0 D
+-5 10 D
+-14 5 D
+-14 0 D
+-30 -6 D
+-35 11 D
+1 4 D
+-4 1 D
+-3 5 D
+2 5 D
+8 3 D
+-3 7 D
+6 -5 D
+-5 -4 D
+-4 -1 D
+3 -1 D
+-4 -1 D
+0 -4 D
+16 -13 D
+4 0 D
+17 -6 D
+30 6 D
+13 0 D
+6 -3 D
+10 -1 D
+8 -12 D
+0 65 D
+-3 2 D
+3 0 D
+0 2 D
+-8 -1 D
+-13 -9 D
+-1 7 D
+22 7 D
+0 3 D
+-25 0 D
+-3 -5 D
+-4 4 D
+-15 -7 D
+-12 1 D
+-3 -1 D
+4 0 D
+-11 -1 D
+-2 -7 D
+-1 3 D
+0 -1 D
+-4 -1 D
+-11 0 D
+0 -2 D
+-1 1 D
+-11 -2 D
+11 6 D
+-2 2 D
+-1 -2 D
+-7 0 D
+0 3 D
+-8 2 D
+-1 -7 D
+-7 1 D
+1 -1 D
+-8 1 D
+-5 -2 D
+-4 0 D
+7 -3 D
+-8 2 D
+-1 -3 D
+-2 2 D
+0 -1 D
+-4 1 D
+7 -4 D
+-8 3 D
+-3 -1 D
+2 -3 D
+5 -2 D
+7 1 D
+-1 -3 D
+5 0 D
+-9 -1 D
+7 -1 D
+-4 0 D
+9 -4 D
+-4 0 D
+0 -1 D
+-20 6 D
+1 -1 D
+-10 2 D
+-2 -2 D
+-37 7 D
+-5 4 D
+-2 -2 D
+-3 0 D
+-12 7 D
+-21 2 D
+0 -227 D
+P
+1037 3557 M
+0 -3 D
+-5 -2 D
+7 -4 D
+-4 -3 D
+3 3 D
+-8 4 D
+6 2 D
+P
+977 3582 M
+-1 -8 D
+6 -3 D
+0 -4 D
+-15 10 D
+1 1 D
+6 -3 D
+P
+1019 3556 M
+-4 -4 D
+0 3 D
+7 1 D
+P
+1137 3724 M
+-1 2 D
+5 1 D
+1 -2 D
+P
+1113 3743 M
+3 6 D
+7 -3 D
+-6 -4 D
+P
+951 3600 M
+0 -2 D
+-4 0 D
+P
+1058 3575 M
+4 -10 D
+-6 10 D
+2 1 D
+P
+1006 3581 M
+8 -4 D
+2 -6 D
+-11 10 D
+P
+1068 3596 M
+11 -1 D
+-16 0 D
+P
+1093 3754 M
+3 2 D
+1 -2 D
+-3 0 D
+P
+1111 3732 M
+0 1 D
+7 -1 D
+-6 -1 D
+P
+1160 3774 M
+2 1 D
+1 -2 D
+-3 0 D
+P
+1133 3766 M
+-1 0 D
+3 0 D
+P
+1098 3736 M
+6 3 D
+P
+1151 3714 M
+3 1 D
+-3 -2 D
+P
+1095 3744 M
+2 2 D
+-1 -2 D
+P
+958 3731 M
+-1 1 D
+2 -1 D
+P
+1059 3765 M
+3 0 D
+P
+1123 3725 M
+4 -1 D
+P
+960 3733 M
+0 1 D
+P
+1120 3752 M
+3 1 D
+P
+1168 3763 M
+2 0 D
+P
+1167 3704 M
+-1 0 D
+3 2 D
+P
+1072 3764 M
+3 1 D
+P
+1118 3768 M
+3 0 D
+P
+1071 3760 M
+2 1 D
+P
+1160 3700 M
+-2 1 D
+P
+1169 3775 M
+-1 1 D
+P
+1180 3777 M
+1 2 D
+P
+946 3731 M
+3 1 D
+-2 -1 D
+P
+1125 3765 M
+3 0 D
+P
+1105 3720 M
+0 1 D
+P
+1115 3765 M
+1 1 D
+P
+1133 3762 M
+1 1 D
+P
+1100 3758 M
+1 1 D
+P
+FO
+1072 3543 M
+2 3 D
+-5 1 D
+-3 -4 D
+P
+FO
+1080 3543 M
+0 4 D
+-4 0 D
+-4 -4 D
+P
+FO
+969 3769 M
+3 0 D
+-7 2 D
+-4 -2 D
+5 -1 D
+P
+FO
+1039 3755 M
+6 -1 D
+-9 2 D
+P
+FO
+1052 3756 M
+-8 -1 D
+6 -1 D
+P
+FO
+1166 3770 M
+-3 1 D
+0 -2 D
+P
+FO
+1055 3768 M
+3 -1 D
+P
+FO
+1053 3767 M
+-2 -1 D
+P
+FO
+1033 3759 M
+4 -1 D
+P
+FO
+1052 3771 M
+-2 -2 D
+P
+FO
+1040 3755 M
+7 -2 D
+P
+FO
+1087 3769 M
+4 1 D
+P
+FO
+1040 3756 M
+3 0 D
+P
+FO
+1045 3768 M
+4 -2 D
+P
+FO
+1036 3757 M
+2 -1 D
+P
+FO
+1033 3760 M
+4 -1 D
+P
+FO
+1039 3754 M
+6 -1 D
+P
+FO
+1067 3772 M
+-3 0 D
+P
+FO
+1140 3776 M
+-4 -1 D
+P
+FO
+0 1 1 1081 3725 SP
+-2 -1 2 2 2 1075 3733 SP
+1417 3638 M
+-6 3 D
+6 -2 D
+0 28 D
+-24 -7 D
+-3 -3 D
+-5 0 D
+-3 3 D
+10 1 D
+2 3 D
+15 7 D
+-1 4 D
+-9 1 D
+-18 -5 D
+-1 -8 D
+-11 -3 D
+-34 5 D
+15 3 D
+3 2 D
+-5 3 D
+14 3 D
+5 4 D
+-9 4 D
+-6 0 D
+10 1 D
+21 -2 D
+5 4 D
+-8 0 D
+-8 4 D
+-26 0 D
+-2 -5 D
+-4 3 D
+-14 -2 D
+-8 2 D
+-9 0 D
+1 -4 D
+-5 1 D
+-1 -3 D
+-8 5 D
+4 4 D
+12 -1 D
+4 3 D
+7 -2 D
+20 6 D
+1 -2 D
+5 2 D
+10 0 D
+-1 1 D
+4 -1 D
+21 4 D
+7 3 D
+27 4 D
+0 55 D
+-32 10 D
+-38 2 D
+-10 -10 D
+-7 -2 D
+-7 1 D
+0 -1 D
+-2 1 D
+-7 -1 D
+-4 2 D
+12 6 D
+-11 1 D
+3 3 D
+-4 2 D
+3 2 D
+-12 0 D
+7 -1 D
+-6 0 D
+-5 -5 D
+-2 2 D
+-3 -1 D
+12 -2 D
+-3 -2 D
+-3 2 D
+-8 -1 D
+-2 -2 D
+5 0 D
+3 -3 D
+-8 1 D
+-4 -2 D
+12 0 D
+-8 -1 D
+3 0 D
+-3 -2 D
+-20 6 D
+-14 11 D
+-32 0 D
+1 -2 D
+-9 -2 D
+-9 -3 D
+1 -2 D
+-5 1 D
+0 3 D
+6 1 D
+-1 3 D
+-4 -3 D
+-21 -3 D
+0 -2 D
+3 0 D
+-3 -2 D
+0 -65 D
+12 -2 D
+20 -8 D
+1 -3 D
+-11 -4 D
+2 -4 D
+7 -4 D
+-2 -1 D
+26 -4 D
+8 -4 D
+26 -6 D
+6 -4 D
+20 -2 D
+2 -3 D
+4 -1 D
+2 -6 D
+-5 4 D
+3 2 D
+-5 0 D
+-4 4 D
+-17 2 D
+-10 5 D
+-18 3 D
+-21 7 D
+-16 1 D
+-10 11 D
+12 5 D
+-23 10 D
+-9 2 D
+0 -161 D
+236 0 D
+P
+1389 3587 M
+7 0 D
+-9 0 D
+2 -1 D
+-18 5 D
+-26 3 D
+-8 3 D
+4 16 D
+2 -8 D
+-5 -8 D
+12 -3 D
+12 0 D
+P
+1263 3715 M
+1 4 D
+-8 3 D
+7 1 D
+8 -5 D
+-4 -1 D
+7 -1 D
+-8 -2 D
+P
+1271 3710 M
+-2 4 D
+14 2 D
+-4 -6 D
+P
+1349 3634 M
+-10 2 D
+7 6 D
+-1 -5 D
+P
+1300 3717 M
+-5 3 D
+4 3 D
+9 -2 D
+P
+1287 3704 M
+5 5 D
+12 -8 D
+P
+1386 3634 M
+-11 0 D
+6 6 D
+P
+1268 3703 M
+0 6 D
+5 -3 D
+P
+1295 3671 M
+-7 2 D
+-2 3 D
+10 -5 D
+P
+1353 3720 M
+12 2 D
+0 -3 D
+-12 0 D
+P
+1361 3618 M
+-11 -1 D
+9 3 D
+3 -2 D
+P
+1402 3609 M
+-5 -1 D
+1 3 D
+P
+1376 3653 M
+7 0 D
+-2 -2 D
+-6 2 D
+P
+1271 3747 M
+5 1 D
+0 -2 D
+P
+1217 3705 M
+2 4 D
+P
+1402 3750 M
+-2 -2 D
+-2 2 D
+P
+1381 3565 M
+-5 0 D
+4 1 D
+P
+1261 3733 M
+0 5 D
+P
+1291 3738 M
+-1 2 D
+2 -2 D
+P
+1213 3714 M
+-3 3 D
+P
+1307 3757 M
+6 1 D
+P
+1288 3741 M
+-2 1 D
+2 -2 D
+P
+1183 3766 M
+2 1 D
+P
+1309 3707 M
+0 1 D
+P
+1278 3668 M
+-18 8 D
+P
+FO
+1417 3677 M
+-2 -1 D
+2 -1 D
+P
+FO
+1417 3701 M
+-3 0 D
+-7 -7 D
+7 1 D
+3 -1 D
+P
+FO
+1294 3780 M
+0 -2 D
+4 2 D
+P
+FO
+1182 3780 M
+-1 0 D
+0 -3 D
+10 3 D
+P
+FO
+1205 3772 M
+-1 1 D
+P
+FO
+5 1 1 1357 3692 SP
+3 -1 1 1234 3674 SP
+-1 1 1 1414 3674 SP
+2 -1 1 1272 3662 SP
+1654 3568 M
+-2 -2 D
+-7 0 D
+1 2 D
+4 -1 D
+4 4 D
+0 32 D
+-12 -3 D
+5 -1 D
+-19 1 D
+-15 -8 D
+6 0 D
+-18 -11 D
+-17 -5 D
+-4 2 D
+-13 -4 D
+-2 -3 D
+3 -2 D
+-3 -2 D
+-7 -1 D
+-4 1 D
+-19 -3 D
+-22 -1 D
+-14 5 D
+-16 1 D
+-11 5 D
+14 -4 D
+9 2 D
+-1 3 D
+19 -4 D
+-2 1 D
+4 2 D
+-5 2 D
+9 1 D
+-2 2 D
+6 6 D
+11 -1 D
+10 3 D
+-10 6 D
+0 2 D
+-6 1 D
+1 6 D
+-10 0 D
+0 2 D
+-8 3 D
+1 2 D
+7 -2 D
+-2 -1 D
+12 -1 D
+13 -6 D
+11 1 D
+0 -2 D
+12 -4 D
+0 -1 D
+10 -3 D
+21 2 D
+17 8 D
+6 7 D
+18 5 D
+17 0 D
+0 17 D
+-4 -1 D
+0 1 D
+4 0 D
+0 12 D
+-4 -1 D
+-6 -5 D
+-18 -3 D
+5 3 D
+-3 1 D
+-13 -6 D
+-7 1 D
+7 1 D
+-1 2 D
+6 4 D
+16 -4 D
+8 2 D
+0 3 D
+7 4 D
+3 0 D
+0 8 D
+-6 -2 D
+1 -1 D
+-10 0 D
+-4 -2 D
+-3 0 D
+5 1 D
+0 2 D
+-12 3 D
+7 0 D
+7 -2 D
+-1 1 D
+4 2 D
+2 -3 D
+8 1 D
+-4 4 D
+6 -3 D
+0 16 D
+-12 4 D
+4 -7 D
+-7 1 D
+4 1 D
+-2 2 D
+-7 2 D
+5 -1 D
+2 3 D
+-4 4 D
+-11 0 D
+3 1 D
+-6 3 D
+-4 -2 D
+-4 1 D
+4 0 D
+-1 2 D
+3 -1 D
+-2 3 D
+3 2 D
+0 -3 D
+7 -1 D
+1 -3 D
+8 2 D
+-3 -3 D
+6 -1 D
+1 -2 D
+4 1 D
+-2 -2 D
+6 -1 D
+-2 -2 D
+6 -2 D
+-1 64 D
+-24 -6 D
+-4 0 D
+0 2 D
+-5 -3 D
+-11 1 D
+0 -3 D
+-2 2 D
+-24 -1 D
+-50 3 D
+-3 2 D
+-11 0 D
+14 2 D
+-3 5 D
+12 0 D
+-7 2 D
+24 -1 D
+3 4 D
+-4 -1 D
+-3 5 D
+-19 7 D
+-22 3 D
+2 -2 D
+-12 1 D
+8 -4 D
+-9 2 D
+-6 -1 D
+-8 3 D
+-2 -2 D
+-23 3 D
+-16 5 D
+-31 3 D
+0 -55 D
+5 1 D
+1 -2 D
+8 1 D
+-2 -2 D
+13 -1 D
+-25 -5 D
+0 -7 D
+3 -1 D
+6 1 D
+-4 -1 D
+4 -1 D
+25 1 D
+11 3 D
+-4 -1 D
+5 4 D
+11 2 D
+-7 -6 D
+8 2 D
+2 -2 D
+-8 -6 D
+3 0 D
+-8 -2 D
+6 -1 D
+-8 -1 D
+-4 -3 D
+4 -2 D
+8 2 D
+-5 -2 D
+4 -1 D
+-17 -2 D
+0 -1 D
+-9 4 D
+-18 0 D
+-2 -1 D
+4 -1 D
+-10 -1 D
+0 -2 D
+11 -3 D
+2 -3 D
+-10 0 D
+-3 -2 D
+0 -28 D
+6 -2 D
+-1 -1 D
+-5 2 D
+0 -95 D
+237 0 D
+P
+1550 3677 M
+5 -1 D
+-4 0 D
+0 -3 D
+3 1 D
+-1 -1 D
+11 -1 D
+-4 -2 D
+9 1 D
+4 -1 D
+3 1 D
+7 -1 D
+-10 -2 D
+18 -2 D
+11 1 D
+-5 -3 D
+4 -1 D
+-1 -3 D
+-4 5 D
+-8 0 D
+-6 2 D
+1 -2 D
+-4 2 D
+-8 1 D
+-6 -1 D
+-3 2 D
+-6 1 D
+1 2 D
+-10 0 D
+2 5 D
+P
+1567 3670 M
+-4 -1 D
+1 -1 D
+7 1 D
+P
+1454 3668 M
+5 -2 D
+-2 -1 D
+3 0 D
+-3 -2 D
+3 -1 D
+-4 -1 D
+4 0 D
+-5 -3 D
+1 -1 D
+5 1 D
+-3 -1 D
+4 -1 D
+-10 2 D
+-4 6 D
+-4 2 D
+10 3 D
+P
+1454 3662 M
+-2 -2 D
+P
+1507 3610 M
+-3 6 D
+8 -5 D
+4 3 D
+-3 0 D
+3 3 D
+-8 2 D
+4 1 D
+5 -4 D
+3 3 D
+2 -2 D
+-5 -5 D
+-6 -1 D
+0 -2 D
+P
+1586 3697 M
+3 -3 D
+-5 -9 D
+-4 4 D
+-12 1 D
+1 2 D
+3 -2 D
+-2 3 D
+12 -1 D
+1 -6 D
+1 6 D
+-13 4 D
+15 2 D
+P
+1481 3617 M
+-7 -1 D
+-8 1 D
+-1 2 D
+-6 1 D
+3 1 D
+-5 -1 D
+-8 2 D
+2 3 D
+13 3 D
+2 -3 D
+13 -4 D
+3 -4 D
+P
+1620 3663 M
+5 -1 D
+-1 -2 D
+5 0 D
+-2 -2 D
+-6 2 D
+-7 -3 D
+1 4 D
+5 1 D
+-2 2 D
+P
+1430 3747 M
+-5 -4 D
+4 -3 D
+-8 -2 D
+-2 7 D
+5 2 D
+-3 0 D
+3 3 D
+4 -1 D
+-3 -2 D
+5 1 D
+P
+1471 3655 M
+5 0 D
+-5 -2 D
+0 -2 D
+7 -1 D
+-6 -4 D
+3 4 D
+-5 -2 D
+-7 3 D
+6 0 D
+P
+1472 3575 M
+-11 2 D
+-17 -5 D
+-14 0 D
+-13 3 D
+23 -2 D
+15 2 D
+4 5 D
+P
+1483 3631 M
+3 3 D
+-9 0 D
+2 3 D
+-4 0 D
+8 3 D
+0 -2 D
+4 0 D
+2 -3 D
+P
+1585 3598 M
+-2 -3 D
+-4 1 D
+1 1 D
+-4 -1 D
+4 4 D
+2 -4 D
+1 3 D
+P
+1462 3616 M
+-6 -2 D
+1 2 D
+-4 0 D
+-1 2 D
+6 0 D
+-3 -1 D
+6 1 D
+P
+1593 3674 M
+-4 -2 D
+-7 0 D
+-3 3 D
+2 1 D
+4 -3 D
+3 2 D
+P
+1611 3663 M
+1 -2 D
+-3 1 D
+-2 -2 D
+4 0 D
+-6 -3 D
+1 5 D
+P
+1469 3672 M
+1 -2 D
+-8 -2 D
+6 1 D
+-3 1 D
+2 3 D
+P
+1633 3640 M
+-31 1 D
+16 1 D
+-4 4 D
+8 -4 D
+11 -1 D
+P
+1538 3646 M
+-12 -6 D
+3 3 D
+-5 1 D
+11 0 D
+2 3 D
+P
+1518 3632 M
+-4 -3 D
+-3 4 D
+3 1 D
+0 -2 D
+P
+1477 3721 M
+10 -2 D
+11 -5 D
+-16 6 D
+-9 0 D
+P
+1486 3645 M
+-2 -4 D
+-7 -2 D
+1 3 D
+-5 -1 D
+P
+1483 3642 M
+-2 -2 D
+P
+1596 3712 M
+-9 -5 D
+-2 1 D
+5 1 D
+7 4 D
+0 -1 D
+P
+1472 3658 M
+3 -1 D
+-7 -1 D
+4 1 D
+-4 1 D
+P
+1599 3684 M
+5 -3 D
+-5 -1 D
+-6 3 D
+P
+1478 3559 M
+4 -2 D
+-2 -4 D
+-16 1 D
+P
+1487 3650 M
+-1 -2 D
+-4 0 D
+-1 2 D
+7 0 D
+P
+1477 3563 M
+-5 0 D
+-8 4 D
+13 -1 D
+P
+1577 3648 M
+-18 -6 D
+-20 0 D
+18 0 D
+P
+1483 3672 M
+3 0 D
+-3 -2 D
+-4 1 D
+P
+1580 3616 M
+-4 -4 D
+-2 1 D
+7 7 D
+P
+1521 3686 M
+9 -3 D
+-3 -1 D
+0 2 D
+P
+1646 3631 M
+-2 3 D
+8 0 D
+1 -2 D
+P
+1492 3740 M
+8 -1 D
+-2 -3 D
+-6 1 D
+P
+1595 3670 M
+2 -2 D
+-7 0 D
+P
+1534 3551 M
+-6 -6 D
+-15 3 D
+P
+1637 3633 M
+-17 -7 D
+4 4 D
+14 3 D
+P
+1634 3577 M
+-1 5 D
+5 3 D
+P
+1447 3594 M
+-11 -1 D
+-3 3 D
+P
+1599 3659 M
+11 -6 D
+-4 0 D
+1 2 D
+P
+1512 3646 M
+-6 -6 D
+1 5 D
+P
+1644 3624 M
+-7 -4 D
+3 6 D
+P
+1606 3578 M
+9 4 D
+-3 -5 D
+P
+1611 3556 M
+-4 6 D
+4 -3 D
+P
+1579 3717 M
+-2 -4 D
+-2 4 D
+P
+1500 3660 M
+3 -4 D
+-6 2 D
+P
+1649 3581 M
+-1 -2 D
+3 0 D
+-5 -3 D
+P
+1565 3612 M
+-6 -3 D
+2 4 D
+P
+1544 3548 M
+-4 2 D
+7 -1 D
+-2 -2 D
+P
+1580 3707 M
+-4 -3 D
+-1 2 D
+P
+1511 3578 M
+-8 0 D
+6 1 D
+P
+1487 3646 M
+-8 -2 D
+5 3 D
+4 -1 D
+P
+1587 3705 M
+-3 -2 D
+-6 0 D
+P
+1515 3628 M
+0 -3 D
+-4 1 D
+P
+1433 3597 M
+-6 2 D
+6 0 D
+1 -2 D
+P
+1593 3565 M
+1 3 D
+2 -2 D
+-2 -1 D
+P
+1609 3573 M
+0 3 D
+3 -2 D
+P
+1492 3626 M
+-3 -1 D
+0 3 D
+P
+1490 3630 M
+-3 -1 D
+0 2 D
+3 0 D
+P
+1455 3610 M
+-5 2 D
+P
+1520 3600 M
+-4 -1 D
+P
+1506 3574 M
+-4 0 D
+P
+1618 3687 M
+-8 -1 D
+P
+1581 3561 M
+-4 2 D
+P
+1435 3639 M
+-5 1 D
+P
+1603 3544 M
+-2 2 D
+3 -2 D
+P
+1420 3592 M
+0 2 D
+1 -2 D
+P
+1433 3638 M
+-4 1 D
+P
+1445 3619 M
+-6 0 D
+7 0 D
+P
+1621 3593 M
+12 3 D
+P
+1640 3562 M
+2 7 D
+P
+1510 3674 M
+-4 -2 D
+P
+1440 3550 M
+-3 1 D
+P
+1603 3717 M
+-4 -2 D
+P
+FO
+1654 3604 M
+-19 -1 D
+3 -1 D
+8 1 D
+-8 -2 D
+16 2 D
+P
+FO
+1654 3608 M
+-9 0 D
+-1 -1 D
+10 -1 D
+P
+FO
+1654 3610 M
+-16 0 D
+-2 -1 D
+4 0 D
+-19 -4 D
+-7 -6 D
+9 6 D
+19 1 D
+0 3 D
+12 -1 D
+P
+FO
+1654 3735 M
+-7 -1 D
+P
+FO
+1480 3780 M
+2 -5 D
+10 -4 D
+0 -1 D
+6 -1 D
+2 -3 D
+24 -4 D
+37 0 D
+13 -2 D
+-8 0 D
+4 -4 D
+-3 -4 D
+8 -6 D
+7 -1 D
+-4 -2 D
+48 2 D
+-5 1 D
+12 1 D
+-2 -2 D
+12 3 D
+3 -2 D
+8 1 D
+0 33 D
+P
+1650 3757 M
+0 -1 D
+-9 0 D
+-7 2 D
+10 -1 D
+4 2 D
+1 -2 D
+P
+1592 3779 M
+6 -1 D
+-7 -1 D
+6 -1 D
+-10 0 D
+1 3 D
+P
+1640 3762 M
+-4 -3 D
+-14 1 D
+P
+1614 3754 M
+6 -1 D
+-15 0 D
+P
+1633 3767 M
+6 -2 D
+-8 1 D
+P
+1642 3754 M
+4 -1 D
+-10 2 D
+P
+1648 3770 M
+3 -1 D
+-8 2 D
+P
+1522 3767 M
+5 -1 D
+-5 -1 D
+-1 3 D
+P
+1628 3753 M
+3 -1 D
+-4 1 D
+P
+1645 3752 M
+3 -2 D
+-4 2 D
+P
+1621 3769 M
+0 -1 D
+P
+1544 3770 M
+1 -1 D
+P
+1616 3749 M
+7 -2 D
+-8 2 D
+P
+1607 3768 M
+4 -2 D
+P
+1572 3771 M
+3 -1 D
+P
+FO
+1630 3745 M
+1 -2 D
+7 1 D
+-3 2 D
+P
+FO
+1630 3730 M
+-2 -1 D
+7 2 D
+P
+FO
+1583 3730 M
+3 1 D
+-7 -1 D
+P
+FO
+1635 3746 M
+7 -1 D
+P
+FO
+1559 3747 M
+-5 1 D
+P
+FO
+1647 3733 M
+-4 0 D
+P
+FO
+1564 3731 M
+-5 0 D
+P
+FO
+1617 3740 M
+-4 -2 D
+P
+FO
+1554 3731 M
+3 1 D
+P
+FO
+1644 3746 M
+-4 1 D
+P
+FO
+1550 3753 M
+-3 1 D
+P
+FO
+1587 3731 M
+1 0 D
+-3 0 D
+P
+FO
+1559 3729 M
+-6 1 D
+P
+FO
+1576 3731 M
+-7 -1 D
+P
+FO
+1560 3747 M
+5 -1 D
+P
+FO
+16 2 -1 -2 -15 -3 6 3 -6 -1 5 1604 3592 SP
+2 1 9 -1 -6 -1 3 1496 3571 SP
+6 1 -6 -3 2 1616 3598 SP
+8 1 -1 -1 2 1431 3706 SP
+4 2 -3 1 9 2 3 1590 3580 SP
+10 1 -23 -6 2 1607 3590 SP
+-8 0 1 1581 3589 SP
+-5 -2 -4 1 2 1461 3680 SP
+6 1 -2 -2 2 1591 3585 SP
+5 2 1 1466 3692 SP
+-10 -4 1 1611 3590 SP
+-5 0 1 1588 3584 SP
+-4 0 1 1588 3582 SP
+3 1 1 1464 3698 SP
+-8 -2 1 1614 3593 SP
+1742 3543 M
+-4 1 D
+4 2 D
+1 -3 D
+3 5 D
+7 1 D
+0 -2 D
+4 2 D
+-4 -3 D
+-6 1 D
+-2 -3 D
+7 0 D
+-3 -1 D
+29 0 D
+5 4 D
+-3 1 D
+3 3 D
+-2 -3 D
+7 0 D
+0 -5 D
+52 0 D
+-6 7 D
+-7 -2 D
+2 3 D
+2 -1 D
+4 2 D
+-4 4 D
+3 3 D
+3 0 D
+2 -5 D
+5 -2 D
+3 -4 D
+-1 -5 D
+44 0 D
+0 31 D
+-1 0 D
+1 0 D
+0 1 D
+-3 2 D
+0 2 D
+3 -1 D
+0 16 D
+-7 2 D
+0 1 D
+-5 -1 D
+-2 3 D
+4 2 D
+-2 2 D
+6 3 D
+3 -3 D
+-8 -4 D
+11 -1 D
+0 55 D
+-6 -2 D
+-13 1 D
+12 2 D
+-3 -2 D
+3 -1 D
+2 3 D
+5 0 D
+-1 29 D
+-10 -3 D
+-10 2 D
+-6 -2 D
+-1 2 D
+-6 0 D
+-3 -1 D
+1 2 D
+-6 1 D
+11 0 D
+-1 -1 D
+5 -1 D
+-2 3 D
+3 -3 D
+15 0 D
+0 7 D
+6 -6 D
+5 2 D
+0 44 D
+-10 0 D
+-4 -2 D
+-2 2 D
+-7 -3 D
+-3 1 D
+-5 -2 D
+-2 1 D
+-3 -2 D
+-10 4 D
+-7 -4 D
+-4 3 D
+-22 5 D
+-1 4 D
+-10 -3 D
+-16 0 D
+-3 5 D
+-8 0 D
+1 3 D
+-4 -1 D
+3 -2 D
+-8 4 D
+-6 0 D
+6 1 D
+-6 6 D
+2 1 D
+-17 5 D
+-26 -6 D
+-23 -2 D
+-13 -8 D
+6 -1 D
+3 2 D
+1 -5 D
+6 2 D
+13 -1 D
+-7 2 D
+1 3 D
+13 -1 D
+1 -2 D
+7 4 D
+-1 -1 D
+4 1 D
+7 -3 D
+1 3 D
+-4 1 D
+6 1 D
+-4 1 D
+22 2 D
+-3 -5 D
+-1 1 D
+-10 -3 D
+1 2 D
+-6 -2 D
+-2 -2 D
+4 -1 D
+-6 1 D
+-1 -2 D
+-4 2 D
+2 -3 D
+-10 -1 D
+0 2 D
+-4 -2 D
+-9 0 D
+1 -3 D
+-9 -4 D
+11 -7 D
+-3 -2 D
+4 -4 D
+4 -2 D
+7 0 D
+-8 -1 D
+2 -2 D
+-3 1 D
+9 -6 D
+-9 4 D
+1 -4 D
+-4 1 D
+-3 3 D
+6 -1 D
+-4 4 D
+0 -3 D
+-3 1 D
+-1 -1 D
+3 -5 D
+-3 0 D
+14 -10 D
+-16 10 D
+0 -2 D
+-7 7 D
+-9 2 D
+-1 2 D
+10 -3 D
+1 2 D
+6 -1 D
+-2 5 D
+-7 3 D
+-2 -2 D
+-1 3 D
+-2 -2 D
+-5 7 D
+-4 -7 D
+-4 9 D
+-9 1 D
+-3 -2 D
+-4 1 D
+1 2 D
+-5 2 D
+-3 -1 D
+0 2 D
+0 -62 D
+6 -1 D
+-1 -1 D
+4 -3 D
+6 1 D
+0 -2 D
+-7 1 D
+0 -2 D
+4 -1 D
+-7 0 D
+-2 -2 D
+4 -2 D
+-7 2 D
+6 5 D
+-2 3 D
+-4 1 D
+0 -16 D
+8 1 D
+-8 -2 D
+0 -8 D
+5 -2 D
+-5 0 D
+0 -12 D
+9 2 D
+-5 -5 D
+0 4 D
+-4 -2 D
+0 1 D
+0 -17 D
+24 -2 D
+-4 -2 D
+6 1 D
+-10 -5 D
+2 3 D
+-18 3 D
+0 -2 D
+6 0 D
+-6 0 D
+0 -2 D
+7 0 D
+-7 -2 D
+0 -1 D
+3 1 D
+-3 -1 D
+0 -32 D
+4 4 D
+-4 -7 D
+0 -25 D
+P
+1840 3615 M
+4 1 D
+-5 0 D
+-1 2 D
+16 5 D
+-2 2 D
+6 -2 D
+1 3 D
+5 -3 D
+0 3 D
+2 -2 D
+3 3 D
+2 -1 D
+0 2 D
+3 -1 D
+0 -5 D
+-4 0 D
+0 -1 D
+-5 1 D
+-2 -4 D
+1 -3 D
+6 -1 D
+-7 -3 D
+4 -2 D
+-4 -2 D
+-7 -1 D
+3 4 D
+-3 3 D
+-3 -7 D
+0 3 D
+-5 0 D
+-2 2 D
+-3 0 D
+P
+1869 3623 M
+1 2 D
+P
+1872 3624 M
+1 1 D
+P
+1723 3636 M
+-5 -2 D
+1 -3 D
+-7 2 D
+-4 3 D
+4 1 D
+-6 1 D
+-1 -2 D
+-1 3 D
+-10 -1 D
+-3 -2 D
+-8 3 D
+-21 0 D
+25 3 D
+-1 4 D
+4 2 D
+1 -5 D
+4 2 D
+-4 -3 D
+2 -1 D
+4 1 D
+10 -3 D
+11 2 D
+-2 -3 D
+4 0 D
+-5 -1 D
+4 -2 D
+P
+1713 3634 M
+5 1 D
+-4 1 D
+P
+1714 3638 M
+0 2 D
+-3 -1 D
+3 0 D
+P
+1688 3638 M
+3 1 D
+-4 0 D
+P
+1790 3551 M
+4 5 D
+-6 1 D
+-2 3 D
+-5 -1 D
+8 6 D
+-3 0 D
+-3 -3 D
+-3 1 D
+3 0 D
+1 4 D
+3 1 D
+0 -2 D
+3 0 D
+0 -4 D
+5 1 D
+-6 -3 D
+13 3 D
+-1 3 D
+3 -2 D
+-13 -5 D
+0 -1 D
+7 0 D
+3 2 D
+2 -2 D
+-7 -3 D
+0 -2 D
+P
+1656 3583 M
+4 5 D
+0 -2 D
+8 6 D
+14 5 D
+-9 -3 D
+-12 -9 D
+4 0 D
+-1 -1 D
+6 1 D
+1 4 D
+7 -3 D
+-9 -2 D
+0 -5 D
+-4 -2 D
+3 6 D
+-7 -1 D
+-1 2 D
+-4 -2 D
+P
+1723 3604 M
+6 2 D
+-6 3 D
+10 1 D
+-1 -3 D
+7 1 D
+-9 -2 D
+-2 -3 D
+7 -1 D
+10 1 D
+-4 -3 D
+12 -2 D
+-6 -3 D
+3 -1 D
+-6 0 D
+-1 2 D
+5 2 D
+-9 0 D
+0 2 D
+-17 4 D
+P
+1816 3704 M
+1 -2 D
+6 0 D
+4 -5 D
+1 2 D
+3 -3 D
+-3 -1 D
+6 -1 D
+2 1 D
+2 -1 D
+-10 -2 D
+-2 4 D
+-8 2 D
+-1 3 D
+-6 1 D
+P
+1848 3560 M
+2 2 D
+9 1 D
+0 2 D
+-5 0 D
+0 6 D
+3 -4 D
+5 1 D
+-3 -2 D
+2 -1 D
+1 2 D
+1 -2 D
+5 8 D
+-2 -9 D
+P
+1755 3573 M
+3 5 D
+-5 1 D
+-1 3 D
+9 -1 D
+9 3 D
+-2 2 D
+3 3 D
+0 -5 D
+7 0 D
+2 -2 D
+-10 1 D
+-7 -2 D
+P
+1759 3580 M
+-3 1 D
+0 -2 D
+P
+1696 3624 M
+-8 -2 D
+1 1 D
+-5 0 D
+-3 2 D
+8 1 D
+-11 1 D
+3 2 D
+-3 2 D
+5 0 D
+4 -4 D
+10 -3 D
+P
+1778 3573 M
+5 4 D
+-8 1 D
+17 4 D
+-9 -3 D
+2 -3 D
+6 1 D
+-3 -2 D
+2 -1 D
+-7 0 D
+-2 -3 D
+-3 1 D
+P
+1731 3646 M
+3 -1 D
+-3 -2 D
+-2 2 D
+-2 -1 D
+-4 3 D
+3 -1 D
+5 2 D
+-3 -2 D
+P
+1815 3587 M
+3 5 D
+7 3 D
+-5 1 D
+-5 -3 D
+-2 1 D
+8 4 D
+7 -3 D
+P
+1742 3617 M
+4 2 D
+-7 2 D
+-1 2 D
+8 0 D
+-3 -3 D
+5 1 D
+-3 -4 D
+P
+1751 3616 M
+1 4 D
+3 -4 D
+6 4 D
+0 -3 D
+4 3 D
+3 -1 D
+-9 -4 D
+-8 0 D
+P
+1842 3593 M
+5 3 D
+-4 6 D
+4 1 D
+2 -5 D
+8 3 D
+-2 -6 D
+-3 2 D
+P
+1814 3552 M
+3 8 D
+10 5 D
+-3 -7 D
+-5 -1 D
+2 -5 D
+-5 -1 D
+P
+1789 3597 M
+10 1 D
+-1 -1 D
+4 -3 D
+-6 0 D
+1 2 D
+P
+1680 3653 M
+1 -2 D
+-4 2 D
+-3 -2 D
+1 3 D
+2 -1 D
+-2 2 D
+P
+1833 3584 M
+-4 3 D
+5 -1 D
+6 1 D
+-2 -7 D
+-1 3 D
+P
+1743 3569 M
+-1 2 D
+4 2 D
+7 -3 D
+-3 -1 D
+-4 2 D
+P
+1833 3573 M
+0 3 D
+8 1 D
+-1 -2 D
+-5 0 D
+2 -5 D
+P
+1823 3578 M
+2 3 D
+3 0 D
+1 -2 D
+5 2 D
+-7 -6 D
+P
+1692 3612 M
+11 7 D
+5 6 D
+4 0 D
+-5 -8 D
+-17 -6 D
+P
+1858 3598 M
+3 3 D
+11 -2 D
+-5 -1 D
+-3 1 D
+-1 -2 D
+P
+1826 3600 M
+2 4 D
+-5 3 D
+4 1 D
+4 -7 D
+-6 -1 D
+P
+1803 3598 M
+4 4 D
+2 -2 D
+-4 -3 D
+P
+1834 3596 M
+-1 3 D
+8 1 D
+-2 -4 D
+P
+1806 3604 M
+8 4 D
+1 -6 D
+-4 -1 D
+P
+1766 3550 M
+9 2 D
+-2 -5 D
+0 3 D
+P
+1680 3672 M
+5 -2 D
+-11 0 D
+-1 2 D
+7 1 D
+P
+1776 3616 M
+3 5 D
+2 -4 D
+-3 -1 D
+-3 0 D
+P
+1837 3664 M
+-3 -2 D
+-2 3 D
+6 1 D
+P
+1678 3656 M
+2 -2 D
+-7 3 D
+2 1 D
+P
+1813 3548 M
+2 2 D
+4 0 D
+-3 -3 D
+P
+1814 3665 M
+3 -2 D
+-7 1 D
+P
+1813 3696 M
+-7 -2 D
+2 3 D
+P
+1666 3631 M
+4 5 D
+5 -1 D
+P
+1711 3627 M
+6 4 D
+-2 -6 D
+0 2 D
+P
+1785 3609 M
+3 3 D
+0 -5 D
+P
+1824 3662 M
+-11 -1 D
+4 2 D
+P
+1821 3613 M
+3 3 D
+3 -2 D
+P
+1671 3656 M
+1 -6 D
+-4 4 D
+P
+1677 3663 M
+-3 -2 D
+-2 2 D
+P
+1716 3620 M
+2 3 D
+5 -1 D
+P
+1871 3698 M
+0 -4 D
+-4 3 D
+4 2 D
+P
+1853 3649 M
+-6 -1 D
+-3 1 D
+10 0 D
+P
+1742 3739 M
+-3 -1 D
+1 2 D
+P
+1686 3661 M
+-3 -2 D
+-1 2 D
+P
+1719 3618 M
+9 3 D
+8 0 D
+P
+1808 3576 M
+6 7 D
+2 -2 D
+P
+1728 3626 M
+1 3 D
+2 -4 D
+-4 1 D
+P
+1735 3611 M
+12 0 D
+-5 -2 D
+P
+1719 3692 M
+3 -3 D
+-7 5 D
+P
+1827 3719 M
+-2 -3 D
+-2 3 D
+P
+1669 3644 M
+3 4 D
+P
+1785 3554 M
+2 3 D
+P
+1722 3585 M
+0 -2 D
+-5 1 D
+P
+1870 3659 M
+0 1 D
+P
+1850 3692 M
+1 -2 D
+P
+1682 3662 M
+-3 -2 D
+P
+1682 3618 M
+0 3 D
+3 0 D
+P
+1878 3629 M
+2 3 D
+P
+1665 3604 M
+5 2 D
+P
+1676 3646 M
+-2 -2 D
+P
+1677 3659 M
+-1 -1 D
+0 2 D
+P
+1864 3657 M
+-2 -1 D
+2 2 D
+P
+1700 3655 M
+-2 0 D
+2 1 D
+P
+FO
+1844 3543 M
+-1 1 D
+0 -1 D
+P
+FO
+1890 3756 M
+-3 4 D
+-2 -4 D
+5 -1 D
+P
+FO
+1722 3780 M
+-1 -1 D
+-32 1 D
+-5 -1 D
+-30 1 D
+0 -33 D
+23 2 D
+12 4 D
+-3 2 D
+30 1 D
+18 12 D
+7 -3 D
+-2 -5 D
+16 0 D
+6 -2 D
+13 0 D
+-8 -3 D
+3 -2 D
+14 0 D
+4 2 D
+5 -2 D
+17 -2 D
+7 1 D
+5 -1 D
+4 3 D
+5 -1 D
+3 2 D
+15 1 D
+1 4 D
+-4 2 D
+-4 -2 D
+-4 1 D
+1 2 D
+4 -1 D
+3 4 D
+-9 2 D
+-5 -2 D
+-8 -1 D
+-8 -7 D
+4 10 D
+-2 1 D
+-1 -3 D
+-1 4 D
+-7 0 D
+-1 3 D
+5 0 D
+12 -5 D
+5 1 D
+2 3 D
+-4 2 D
+7 1 D
+1 -1 D
+2 4 D
+3 -3 D
+2 3 D
+2 -5 D
+7 -1 D
+5 6 D
+3 -6 D
+8 0 D
+0 8 D
+P
+1787 3767 M
+-11 -4 D
+-5 2 D
+-24 -1 D
+-6 1 D
+8 2 D
+26 -1 D
+P
+1783 3766 M
+-3 0 D
+P
+1787 3775 M
+-3 -2 D
+-5 0 D
+-5 3 D
+11 0 D
+-4 -2 D
+P
+1722 3773 M
+-4 -2 D
+6 -3 D
+-12 5 D
+2 2 D
+P
+1817 3775 M
+2 -2 D
+-7 0 D
+-3 3 D
+P
+1682 3772 M
+-11 -1 D
+-12 5 D
+12 -4 D
+P
+1756 3763 M
+4 -2 D
+-3 -1 D
+-6 2 D
+P
+1688 3764 M
+5 -3 D
+-9 1 D
+-1 2 D
+P
+1694 3776 M
+4 -2 D
+-11 0 D
+P
+1703 3775 M
+8 -3 D
+-11 3 D
+P
+1764 3775 M
+6 -1 D
+-10 1 D
+P
+1800 3773 M
+-5 -3 D
+-1 2 D
+P
+1706 3771 M
+0 -1 D
+-15 1 D
+P
+1827 3777 M
+-3 0 D
+3 1 D
+P
+1776 3760 M
+-6 0 D
+P
+1685 3775 M
+-6 0 D
+P
+1752 3777 M
+-6 -1 D
+P
+1839 3765 M
+0 -2 D
+P
+FO
+1686 3780 M
+1 -1 D
+1 1 D
+P
+FO
+1654 3735 M
+P
+FO
+1876 3756 M
+0 -6 D
+4 1 D
+2 -2 D
+5 5 D
+-5 3 D
+P
+FO
+1843 3747 M
+4 -1 D
+3 2 D
+0 3 D
+-5 1 D
+-10 -3 D
+P
+FO
+1772 3744 M
+10 -2 D
+4 1 D
+-10 3 D
+-6 -1 D
+P
+FO
+1701 3717 M
+2 -1 D
+0 4 D
+-2 -2 D
+-3 1 D
+P
+FO
+1667 3732 M
+3 0 D
+1 2 D
+-5 1 D
+P
+FO
+1703 3732 M
+3 -1 D
+2 2 D
+-3 2 D
+P
+FO
+1701 3724 M
+-2 -4 D
+4 2 D
+P
+FO
+1696 3731 M
+3 -2 D
+1 2 D
+P
+FO
+1662 3737 M
+3 1 D
+-7 -2 D
+P
+FO
+1677 3732 M
+-4 0 D
+7 -3 D
+P
+FO
+1705 3711 M
+0 2 D
+-1 -4 D
+P
+FO
+1871 3742 M
+3 0 D
+-2 1 D
+P
+FO
+1866 3768 M
+-8 2 D
+3 -5 D
+P
+FO
+1711 3714 M
+2 -3 D
+4 0 D
+P
+FO
+1886 3740 M
+3 -1 D
+0 2 D
+P
+FO
+1854 3759 M
+-3 2 D
+-1 -3 D
+P
+FO
+1691 3720 M
+3 2 D
+-5 0 D
+P
+FO
+1783 3736 M
+1 -2 D
+3 3 D
+P
+FO
+1839 3774 M
+1 -3 D
+P
+FO
+1701 3706 M
+-3 3 D
+P
+FO
+1705 3709 M
+-3 -4 D
+4 4 D
+P
+FO
+1690 3724 M
+4 -1 D
+P
+FO
+1724 3740 M
+2 -2 D
+P
+FO
+1687 3730 M
+6 0 D
+P
+FO
+1676 3728 M
+-3 -1 D
+P
+FO
+1768 3745 M
+1 0 D
+-4 1 D
+P
+FO
+1692 3735 M
+1 -2 D
+P
+FO
+1705 3732 M
+-1 -2 D
+P
+FO
+1743 3743 M
+3 0 D
+P
+FO
+1822 3768 M
+0 -1 D
+P
+FO
+-1 -1 -2 0 2 1786 3546 SP
+1890 3543 M
+8 8 D
+-4 6 D
+7 -2 D
+5 6 D
+14 3 D
+0 -2 D
+-9 -1 D
+-6 -2 D
+5 -5 D
+-5 1 D
+-4 -4 D
+6 0 D
+4 -5 D
+-5 -1 D
+-3 3 D
+-6 1 D
+4 -3 D
+-2 -1 D
+0 -2 D
+113 0 D
+4 9 D
+-2 3 D
+4 1 D
+10 12 D
+4 1 D
+-3 1 D
+3 0 D
+-3 1 D
+2 0 D
+-1 3 D
+6 1 D
+-4 1 D
+0 2 D
+16 6 D
+-9 1 D
+10 -1 D
+-10 4 D
+5 0 D
+-4 1 D
+7 -1 D
+-1 1 D
+4 0 D
+-5 3 D
+6 -2 D
+0 2 D
+5 1 D
+-7 2 D
+7 -1 D
+-2 1 D
+4 1 D
+2 -1 D
+1 1 D
+-7 2 D
+7 0 D
+5 -4 D
+0 4 D
+-6 1 D
+3 1 D
+-2 2 D
+5 -1 D
+-1 -1 D
+11 -1 D
+1 1 D
+-11 1 D
+-1 4 D
+4 -2 D
+3 2 D
+8 -2 D
+2 1 D
+-1 2 D
+-9 1 D
+-3 3 D
+7 -1 D
+0 2 D
+17 -2 D
+9 4 D
+6 -1 D
+3 6 D
+-1 5 D
+-6 0 D
+4 0 D
+-6 2 D
+-9 0 D
+-8 6 D
+-17 -5 D
+2 3 D
+7 1 D
+-4 2 D
+-3 -1 D
+-3 2 D
+-3 -1 D
+-17 5 D
+-2 -2 D
+6 -2 D
+-11 1 D
+-2 3 D
+-5 -1 D
+3 2 D
+7 0 D
+-7 5 D
+11 -6 D
+23 -5 D
+23 -1 D
+18 -6 D
+-2 2 D
+-4 1 D
+8 0 D
+0 1 D
+8 -1 D
+5 4 D
+0 2 D
+-5 3 D
+5 0 D
+0 43 D
+-22 3 D
+17 0 D
+-5 -1 D
+10 -1 D
+0 60 D
+-3 -1 D
+-3 -3 D
+-1 4 D
+-6 -1 D
+6 1 D
+-7 2 D
+4 9 D
+-4 -1 D
+4 2 D
+-5 1 D
+0 4 D
+-19 6 D
+7 -1 D
+5 1 D
+-4 -1 D
+6 -1 D
+6 4 D
+-3 1 D
+9 0 D
+-7 2 D
+-3 -2 D
+2 2 D
+-5 -3 D
+2 2 D
+-4 -1 D
+2 1 D
+-6 1 D
+-11 -1 D
+9 2 D
+-4 2 D
+-9 -5 D
+-11 5 D
+-15 0 D
+21 8 D
+-16 0 D
+-13 -5 D
+4 4 D
+8 1 D
+-9 0 D
+-74 0 D
+4 -2 D
+-3 -2 D
+10 -3 D
+3 2 D
+19 -6 D
+6 4 D
+7 -7 D
+9 0 D
+9 2 D
+-1 -4 D
+5 1 D
+-11 -5 D
+-1 2 D
+7 4 D
+-17 -2 D
+-1 -4 D
+7 -1 D
+-9 -4 D
+-4 0 D
+-1 -5 D
+13 0 D
+6 3 D
+-6 -1 D
+6 4 D
+6 -3 D
+-5 -6 D
+9 0 D
+-15 -4 D
+-4 -4 D
+-13 -6 D
+-17 1 D
+-5 -8 D
+9 -5 D
+-2 -1 D
+6 -5 D
+-4 -2 D
+-4 -1 D
+-4 2 D
+-5 -2 D
+7 6 D
+-13 -4 D
+0 1 D
+-3 -1 D
+4 6 D
+-4 -1 D
+-3 2 D
+-2 -1 D
+3 5 D
+4 -1 D
+-1 4 D
+7 11 D
+-19 -7 D
+-3 2 D
+4 0 D
+7 6 D
+-5 -3 D
+-2 2 D
+-9 0 D
+2 2 D
+-9 3 D
+-6 0 D
+3 -2 D
+-11 4 D
+5 -5 D
+-8 0 D
+-3 -2 D
+-7 3 D
+0 -2 D
+-5 2 D
+5 -5 D
+4 0 D
+-1 -3 D
+-2 3 D
+-3 -1 D
+11 -8 D
+3 4 D
+1 -1 D
+7 2 D
+6 -4 D
+4 2 D
+0 -6 D
+4 2 D
+0 -2 D
+-9 -3 D
+2 -1 D
+-2 1 D
+5 2 D
+-10 -1 D
+-7 2 D
+-15 10 D
+-4 -4 D
+10 -4 D
+-9 1 D
+-5 -3 D
+-26 4 D
+1 -45 D
+9 -1 D
+14 7 D
+4 -4 D
+2 2 D
+0 -2 D
+3 0 D
+-1 -3 D
+-1 2 D
+-3 -1 D
+-6 3 D
+-4 -4 D
+-15 -2 D
+0 -2 D
+-3 3 D
+0 -28 D
+5 -2 D
+14 0 D
+7 -2 D
+10 2 D
+-1 2 D
+4 1 D
+3 -1 D
+16 3 D
+7 -2 D
+0 2 D
+4 -2 D
+0 -4 D
+-9 4 D
+2 -2 D
+-13 1 D
+-1 -2 D
+-3 2 D
+-5 -1 D
+-2 -3 D
+8 -2 D
+-7 0 D
+-6 2 D
+2 -4 D
+-12 1 D
+-3 4 D
+-4 -2 D
+-16 4 D
+1 -57 D
+3 2 D
+4 0 D
+-4 1 D
+0 2 D
+7 -3 D
+-4 -2 D
+0 -3 D
+-3 0 D
+-4 1 D
+1 -17 D
+-1 2 D
+5 0 D
+-3 -3 D
+5 -2 D
+-2 -2 D
+-5 2 D
+P
+1954 3700 M
+-1 -6 D
+6 0 D
+2 3 D
+1 -5 D
+-7 2 D
+-4 -2 D
+-2 3 D
+-6 -5 D
+-3 3 D
+5 1 D
+1 -1 D
+-1 4 D
+3 -1 D
+P
+1990 3605 M
+-5 6 D
+1 2 D
+6 1 D
+-3 2 D
+6 3 D
+4 -1 D
+-4 -2 D
+0 -3 D
+-7 -1 D
+6 -2 D
+-3 -3 D
+2 -2 D
+-2 0 D
+P
+2000 3592 M
+0 6 D
+6 0 D
+-5 -1 D
+0 -2 D
+4 0 D
+3 3 D
+7 2 D
+-2 -5 D
+-5 0 D
+0 -3 D
+-7 2 D
+3 -2 D
+-4 -1 D
+P
+1930 3606 M
+-5 4 D
+19 0 D
+2 4 D
+0 -8 D
+8 -4 D
+-3 -2 D
+-8 3 D
+-4 -2 D
+-4 2 D
+3 1 D
+-2 2 D
+P
+1941 3604 M
+3 0 D
+0 3 D
+P
+1998 3660 M
+-2 -4 D
+-10 3 D
+2 -2 D
+-6 2 D
+6 3 D
+5 -1 D
+4 1 D
+-6 0 D
+3 1 D
+10 -1 D
+P
+1959 3569 M
+-13 11 D
+4 3 D
+-8 -2 D
+-1 5 D
+7 0 D
+-1 -2 D
+7 -3 D
+1 -8 D
+4 -3 D
+4 0 D
+P
+1891 3635 M
+1 6 D
+4 0 D
+0 -1 D
+3 1 D
+0 -2 D
+1 2 D
+2 -4 D
+-4 -1 D
+-1 2 D
+-3 -4 D
+P
+1893 3635 M
+1 3 D
+P
+1932 3641 M
+-3 -3 D
+1 -2 D
+2 1 D
+4 -1 D
+-3 -4 D
+-2 3 D
+-4 -1 D
+-5 3 D
+1 4 D
+7 -1 D
+P
+2023 3619 M
+0 -2 D
+6 -1 D
+-5 0 D
+1 -2 D
+-3 0 D
+0 2 D
+-4 0 D
+3 1 D
+-5 2 D
+P
+2026 3640 M
+0 -4 D
+-17 5 D
+-20 -2 D
+-12 5 D
+5 -1 D
+-4 2 D
+21 0 D
+28 -5 D
+P
+2021 3640 M
+-4 0 D
+4 -1 D
+P
+2077 3615 M
+1 -2 D
+-15 4 D
+-3 -2 D
+6 -3 D
+-7 1 D
+-4 7 D
+10 -3 D
+4 1 D
+P
+1976 3636 M
+-7 -3 D
+-2 2 D
+3 1 D
+-6 3 D
+5 1 D
+1 -2 D
+6 0 D
+-5 0 D
+P
+1909 3629 M
+-2 4 D
+8 -1 D
+-3 3 D
+7 0 D
+1 -6 D
+-3 0 D
+-2 2 D
+P
+1912 3631 M
+2 0 D
+P
+2011 3575 M
+-10 7 D
+-2 6 D
+6 -2 D
+-5 0 D
+4 -1 D
+0 -4 D
+10 -4 D
+P
+1958 3638 M
+-9 -2 D
+0 -4 D
+-9 5 D
+-5 1 D
+4 2 D
+P
+1945 3637 M
+-3 -1 D
+4 1 D
+P
+1901 3571 M
+4 3 D
+-1 -1 D
+3 0 D
+-4 -3 D
+1 -2 D
+-4 1 D
+P
+1986 3589 M
+3 1 D
+5 -4 D
+2 1 D
+0 -2 D
+-8 2 D
+-1 -1 D
+P
+1950 3619 M
+4 7 D
+4 -2 D
+-4 -1 D
+4 -4 D
+-4 2 D
+-4 -3 D
+P
+2054 3770 M
+7 0 D
+0 -2 D
+-6 0 D
+1 -2 D
+-7 1 D
+P
+2058 3659 M
+1 -2 D
+-10 1 D
+1 1 D
+3 -1 D
+-1 2 D
+P
+1895 3610 M
+12 9 D
+-2 -4 D
+6 -3 D
+-8 -3 D
+P
+2050 3766 M
+10 -1 D
+-7 -8 D
+-1 2 D
+-4 0 D
+P
+1933 3717 M
+-5 -5 D
+-5 3 D
+2 4 D
+4 -3 D
+P
+1944 3676 M
+0 -3 D
+-4 2 D
+0 3 D
+2 -3 D
+P
+1944 3594 M
+3 0 D
+-1 2 D
+4 -1 D
+0 -2 D
+P
+2071 3728 M
+-2 -2 D
+-4 2 D
+-7 -1 D
+7 2 D
+P
+1899 3668 M
+1 -2 D
+-2 1 D
+-2 -2 D
+-1 4 D
+P
+1998 3667 M
+7 -3 D
+-8 1 D
+-4 2 D
+P
+2073 3753 M
+3 0 D
+-4 -2 D
+-3 1 D
+P
+1928 3614 M
+4 1 D
+-1 2 D
+5 -3 D
+P
+1960 3613 M
+3 3 D
+4 -6 D
+-5 1 D
+P
+2110 3703 M
+2 -4 D
+-7 5 D
+6 0 D
+P
+1942 3567 M
+6 0 D
+1 -4 D
+-7 0 D
+-1 4 D
+P
+1957 3550 M
+-9 4 D
+2 1 D
+9 -3 D
+-2 -3 D
+P
+1986 3652 M
+0 -3 D
+-7 3 D
+5 1 D
+P
+2039 3776 M
+2 -3 D
+-6 -2 D
+P
+2018 3600 M
+11 -1 D
+-9 -1 D
+-3 2 D
+P
+1919 3681 M
+5 -2 D
+-1 -3 D
+-4 1 D
+P
+1972 3566 M
+6 -2 D
+-3 -2 D
+P
+1989 3593 M
+5 1 D
+1 -4 D
+P
+1950 3645 M
+-1 -2 D
+-6 1 D
+3 2 D
+P
+1909 3676 M
+-2 -5 D
+-2 4 D
+P
+1941 3590 M
+5 2 D
+2 -2 D
+P
+1986 3671 M
+3 -5 D
+-7 1 D
+P
+1963 3646 M
+5 -3 D
+-1 -1 D
+-5 4 D
+P
+1936 3571 M
+4 0 D
+2 -3 D
+P
+1977 3586 M
+-2 3 D
+5 -4 D
+P
+1974 3568 M
+4 1 D
+4 -3 D
+-9 2 D
+P
+1937 3616 M
+1 1 D
+3 -3 D
+-4 1 D
+P
+1936 3563 M
+4 1 D
+-2 -2 D
+-3 1 D
+P
+2044 3770 M
+6 2 D
+3 -1 D
+P
+2000 3557 M
+1 2 D
+3 -1 D
+-5 -1 D
+P
+1925 3618 M
+2 1 D
+0 -3 D
+P
+2023 3774 M
+5 1 D
+3 -1 D
+-9 0 D
+P
+2000 3602 M
+-2 1 D
+7 -2 D
+P
+2044 3762 M
+4 0 D
+-4 -1 D
+P
+2032 3776 M
+3 1 D
+-1 -3 D
+P
+1980 3550 M
+3 2 D
+-1 -3 D
+P
+2053 3774 M
+4 1 D
+0 -2 D
+-4 0 D
+P
+1987 3629 M
+-17 -1 D
+-8 1 D
+25 1 D
+P
+1931 3632 M
+6 -2 D
+P
+1953 3707 M
+-3 -3 D
+P
+2091 3767 M
+1 -2 D
+-2 2 D
+P
+2081 3761 M
+3 1 D
+-4 -1 D
+P
+2029 3757 M
+4 1 D
+P
+1964 3731 M
+1 -1 D
+P
+2029 3758 M
+2 1 D
+P
+2076 3765 M
+-7 -3 D
+6 4 D
+P
+1972 3613 M
+7 -1 D
+-8 1 D
+P
+1971 3559 M
+3 1 D
+P
+1912 3644 M
+-9 -5 D
+0 4 D
+P
+1983 3602 M
+2 -2 D
+P
+1963 3716 M
+3 -3 D
+P
+1942 3670 M
+-2 -2 D
+P
+1988 3545 M
+3 -1 D
+P
+2040 3778 M
+4 -1 D
+-5 0 D
+P
+2080 3753 M
+3 -2 D
+P
+1960 3688 M
+-4 -6 D
+-2 3 D
+P
+1978 3735 M
+1 -2 D
+P
+2027 3773 M
+1 -2 D
+P
+FO
+2126 3751 M
+P
+FO
+2126 3755 M
+P
+FO
+1890 3755 M
+1 0 D
+-1 1 D
+P
+FO
+1890 3574 M
+3 0 D
+-3 1 D
+P
+FO
+1913 3754 M
+1 1 D
+4 -1 D
+-1 -2 D
+9 -2 D
+2 3 D
+4 -1 D
+1 -3 D
+11 -1 D
+5 -3 D
+9 -1 D
+1 2 D
+12 -3 D
+7 0 D
+7 4 D
+3 0 D
+2 3 D
+5 0 D
+1 -2 D
+8 5 D
+-16 0 D
+-3 8 D
+-4 -4 D
+-3 7 D
+-14 3 D
+-9 6 D
+-3 -3 D
+0 4 D
+-14 3 D
+-9 -7 D
+9 -4 D
+-14 4 D
+4 -3 D
+-5 -1 D
+6 -3 D
+-7 0 D
+-2 -3 D
+-12 0 D
+1 -3 D
+-2 3 D
+-6 -2 D
+3 -5 D
+5 -1 D
+4 1 D
+-5 2 D
+P
+1926 3760 M
+0 -1 D
+-3 2 D
+P
+1948 3767 M
+-6 -1 D
+P
+1931 3766 M
+1 -2 D
+P
+1968 3753 M
+1 0 D
+-3 -3 D
+P
+FO
+1986 3767 M
+-1 -2 D
+4 -1 D
+0 5 D
+3 0 D
+2 -4 D
+-3 -1 D
+4 -1 D
+5 5 D
+-11 3 D
+P
+FO
+1971 3769 M
+-3 1 D
+14 -6 D
+-1 6 D
+-3 -2 D
+P
+FO
+2119 3766 M
+-5 -2 D
+5 -2 D
+4 3 D
+P
+FO
+2112 3765 M
+-1 -1 D
+2 -3 D
+3 1 D
+P
+FO
+2055 3588 M
+-6 0 D
+5 -2 D
+P
+FO
+2123 3759 M
+-3 0 D
+3 -2 D
+P
+FO
+2084 3776 M
+-1 -1 D
+5 1 D
+P
+FO
+1948 3724 M
+4 0 D
+1 2 D
+P
+FO
+2088 3775 M
+-3 0 D
+7 -1 D
+P
+FO
+2001 3714 M
+-6 0 D
+4 -1 D
+P
+FO
+1964 3770 M
+3 -1 D
+P
+FO
+2099 3626 M
+-3 1 D
+P
+FO
+2093 3776 M
+-2 -1 D
+P
+FO
+2109 3769 M
+-1 -1 D
+2 1 D
+P
+FO
+1922 3738 M
+1 -2 D
+P
+FO
+2102 3625 M
+-2 1 D
+P
+FO
+2118 3770 M
+0 -2 D
+P
+FO
+1913 3742 M
+-3 1 D
+P
+FO
+1940 3742 M
+3 -1 D
+P
+FO
+2043 3587 M
+4 -1 D
+P
+FO
+2094 3776 M
+0 -1 D
+P
+FO
+1982 3724 M
+0 1 D
+P
+FO
+1942 3727 M
+-1 1 D
+P
+FO
+2035 3579 M
+2 -2 D
+P
+FO
+1985 3715 M
+2 1 D
+P
+FO
+2119 3767 M
+-2 -1 D
+P
+FO
+2087 3606 M
+2 -1 D
+P
+FO
+2041 3587 M
+2 0 D
+P
+FO
+2089 3628 M
+6 -1 D
+-6 2 D
+P
+FO
+2102 3606 M
+-6 1 D
+P
+FO
+1950 3778 M
+3 -1 D
+-3 2 D
+P
+FO
+1914 3732 M
+1 2 D
+P
+FO
+1984 3729 M
+-3 -2 D
+P
+FO
+2088 3773 M
+4 1 D
+P
+FO
+1941 3729 M
+-3 1 D
+P
+FO
+2124 3760 M
+-2 1 D
+P
+FO
+2110 3626 M
+3 0 D
+P
+FO
+2100 3772 M
+1 -1 D
+P
+FO
+1981 3723 M
+-3 1 D
+P
+FO
+-1 2 3 0 2 1894 3546 SP
+2362 3598 M
+-5 -4 D
+-1 -6 D
+6 -4 D
+P
+FO
+2362 3770 M
+-1 1 D
+1 0 D
+0 2 D
+-10 2 D
+1 -3 D
+-6 2 D
+-4 -1 D
+8 -1 D
+4 -3 D
+2 2 D
+-1 -2 D
+6 -2 D
+P
+FO
+2362 3779 M
+-1 -1 D
+1 0 D
+P
+FO
+2352 3780 M
+2 -1 D
+3 1 D
+P
+FO
+2323 3780 M
+17 -7 D
+4 2 D
+-13 5 D
+P
+FO
+2291 3780 M
+9 -3 D
+8 0 D
+0 -2 D
+4 0 D
+2 2 D
+7 0 D
+0 1 D
+-4 2 D
+P
+FO
+2257 3780 M
+4 -1 D
+13 1 D
+P
+FO
+2230 3780 M
+9 -1 D
+P
+FO
+2194 3780 M
+15 -1 D
+0 1 D
+P
+FO
+2126 3755 M
+3 -1 D
+-1 2 D
+-2 -1 D
+P
+FO
+2126 3751 M
+1 -3 D
+4 3 D
+-3 1 D
+-2 -1 D
+P
+FO
+2126 3681 M
+6 0 D
+-6 3 D
+7 -1 D
+-3 2 D
+20 -7 D
+14 -2 D
+-11 1 D
+20 -7 D
+16 -1 D
+6 2 D
+2 3 D
+11 3 D
+3 6 D
+11 3 D
+2 3 D
+-19 4 D
+-3 5 D
+13 0 D
+7 -2 D
+12 3 D
+5 -8 D
+2 2 D
+19 -4 D
+-7 4 D
+4 2 D
+2 -3 D
+6 0 D
+4 -2 D
+4 0 D
+-1 -2 D
+4 2 D
+-13 9 D
+2 2 D
+-7 1 D
+2 1 D
+-8 2 D
+4 0 D
+-6 1 D
+4 1 D
+-9 0 D
+3 -1 D
+-5 -1 D
+-3 2 D
+14 1 D
+9 -3 D
+-5 -1 D
+7 -2 D
+5 5 D
+-1 -8 D
+8 -2 D
+1 -4 D
+6 1 D
+-1 -1 D
+8 5 D
+10 0 D
+6 4 D
+5 0 D
+6 6 D
+10 1 D
+6 10 D
+-21 11 D
+-2 5 D
+5 2 D
+-7 -2 D
+0 4 D
+-6 1 D
+12 0 D
+-15 3 D
+4 0 D
+-2 2 D
+8 -2 D
+-1 2 D
+7 -3 D
+4 3 D
+5 -1 D
+8 3 D
+-3 6 D
+-4 -1 D
+-2 2 D
+-10 -1 D
+19 5 D
+-2 3 D
+-22 1 D
+3 1 D
+-6 2 D
+4 0 D
+-25 4 D
+20 -1 D
+-7 1 D
+4 1 D
+-2 1 D
+10 0 D
+-32 1 D
+-21 4 D
+-10 0 D
+-3 -2 D
+-13 2 D
+-1 -1 D
+10 -1 D
+-8 0 D
+4 -5 D
+-4 -2 D
+5 -1 D
+-4 0 D
+4 -3 D
+-4 1 D
+0 -2 D
+7 -2 D
+-2 -1 D
+7 1 D
+-4 -1 D
+15 -3 D
+-11 0 D
+4 -2 D
+-8 1 D
+4 -2 D
+-5 -1 D
+8 0 D
+3 -3 D
+-13 1 D
+2 -1 D
+-7 2 D
+-4 -1 D
+-5 -17 D
+-6 0 D
+-9 -8 D
+-1 -8 D
+-2 1 D
+0 -1 D
+-6 1 D
+-2 -2 D
+-3 0 D
+5 -4 D
+-4 3 D
+-5 -4 D
+-2 2 D
+-4 -2 D
+-1 2 D
+5 2 D
+-3 -1 D
+-1 3 D
+-15 8 D
+-6 7 D
+0 7 D
+5 2 D
+0 -3 D
+6 -1 D
+3 3 D
+-3 9 D
+-7 5 D
+-18 8 D
+-8 0 D
+-10 -7 D
+-3 -14 D
+-3 0 D
+P
+2314 3750 M
+1 -3 D
+-5 0 D
+-2 -2 D
+-6 2 D
+-2 -2 D
+0 5 D
+5 -1 D
+6 1 D
+-4 4 D
+5 -3 D
+2 1 D
+P
+2171 3699 M
+-7 2 D
+-8 -3 D
+3 5 D
+1 -2 D
+4 1 D
+P
+2151 3704 M
+-7 -1 D
+-3 -5 D
+2 3 D
+-2 3 D
+P
+2175 3697 M
+2 -2 D
+-6 1 D
+1 3 D
+3 -1 D
+P
+2155 3699 M
+-8 -3 D
+3 3 D
+5 1 D
+P
+2162 3692 M
+-1 -2 D
+-4 2 D
+P
+2197 3702 M
+-1 -2 D
+-9 6 D
+P
+2171 3704 M
+2 -2 D
+P
+2146 3760 M
+2 -2 D
+P
+2144 3738 M
+4 0 D
+P
+2158 3746 M
+1 -2 D
+P
+2152 3749 M
+2 -2 D
+P
+2154 3705 M
+-1 -4 D
+P
+2161 3708 M
+-5 -1 D
+P
+2135 3743 M
+5 -3 D
+P
+2178 3703 M
+-2 -1 D
+P
+FO
+2126 3637 M
+4 -1 D
+-4 6 D
+11 -5 D
+-1 3 D
+4 -1 D
+4 -3 D
+0 2 D
+4 -1 D
+-4 3 D
+11 -3 D
+7 2 D
+-1 1 D
+10 1 D
+7 9 D
+6 1 D
+1 5 D
+1 -2 D
+4 1 D
+9 10 D
+-2 2 D
+-7 1 D
+-17 -1 D
+-24 2 D
+-23 11 D
+P
+FO
+2126 3632 M
+1 1 D
+-1 1 D
+P
+FO
+2339 3625 M
+12 6 D
+8 1 D
+-14 4 D
+6 -1 D
+-1 2 D
+-5 1 D
+-5 3 D
+0 -4 D
+-11 3 D
+-14 -3 D
+1 2 D
+9 2 D
+-6 10 D
+-12 5 D
+-4 -1 D
+-16 5 D
+-5 5 D
+-17 1 D
+-1 3 D
+-8 4 D
+-7 -7 D
+-3 0 D
+-2 5 D
+-6 3 D
+6 2 D
+-4 4 D
+-7 0 D
+-3 3 D
+-9 -5 D
+-4 -18 D
+-6 -8 D
+5 -12 D
+-18 -5 D
+-6 -4 D
+1 -3 D
+6 -1 D
+9 3 D
+6 -1 D
+14 2 D
+2 -13 D
+3 -2 D
+21 5 D
+7 8 D
+5 -1 D
+7 4 D
+4 0 D
+-1 6 D
+3 2 D
+12 2 D
+-3 -5 D
+14 0 D
+4 -2 D
+-3 -5 D
+10 0 D
+25 -6 D
+P
+2231 3675 M
+-9 -2 D
+5 6 D
+P
+FO
+2291 3611 M
+-6 2 D
+-5 -2 D
+-2 -4 D
+-9 -5 D
+5 -8 D
+7 2 D
+7 -1 D
+8 2 D
+20 10 D
+2 5 D
+-9 2 D
+P
+2298 3604 M
+-7 -1 D
+3 3 D
+P
+FO
+2268 3679 M
+8 0 D
+-4 -2 D
+5 1 D
+7 -2 D
+3 2 D
+-8 0 D
+-6 2 D
+2 3 D
+-18 5 D
+P
+FO
+2201 3732 M
+-1 -4 D
+7 -2 D
+5 5 D
+-1 6 D
+-6 2 D
+-8 -4 D
+P
+FO
+2291 3690 M
+4 1 D
+-5 0 D
+-5 3 D
+0 -3 D
+P
+FO
+2319 3766 M
+8 -2 D
+-1 2 D
+-8 0 D
+0 -2 D
+P
+FO
+2247 3685 M
+-7 0 D
+1 -5 D
+10 -6 D
+4 3 D
+P
+FO
+2275 3774 M
+4 1 D
+-8 0 D
+5 -2 D
+P
+FO
+2283 3682 M
+-5 0 D
+7 -1 D
+P
+FO
+2315 3767 M
+-8 1 D
+8 -2 D
+P
+FO
+2307 3769 M
+-3 -1 D
+6 0 D
+P
+FO
+2187 3713 M
+3 1 D
+P
+FO
+2296 3775 M
+8 -2 D
+P
+FO
+2299 3777 M
+6 -3 D
+P
+FO
+2326 3642 M
+3 1 D
+P
+FO
+2326 3767 M
+-5 1 D
+P
+FO
+2291 3774 M
+1 0 D
+-8 0 D
+P
+FO
+2357 3766 M
+2 -2 D
+-1 2 D
+P
+FO
+2268 3702 M
+0 2 D
+P
+FO
+2308 3767 M
+-3 1 D
+P
+FO
+2278 3687 M
+-1 -1 D
+P
+FO
+2309 3766 M
+-6 1 D
+P
+FO
+2468 3543 M
+-2 1 D
+3 1 D
+-3 2 D
+8 2 D
+3 -6 D
+31 0 D
+-4 2 D
+4 -1 D
+9 3 D
+0 -2 D
+4 -1 D
+-5 0 D
+0 -1 D
+66 0 D
+-4 1 D
+20 -1 D
+0 20 D
+-3 1 D
+0 5 D
+-6 0 D
+0 -2 D
+-8 2 D
+0 -2 D
+-6 3 D
+-11 0 D
+0 2 D
+-4 -1 D
+1 2 D
+-5 0 D
+4 2 D
+-7 1 D
+8 0 D
+-7 1 D
+4 1 D
+-3 2 D
+7 0 D
+0 2 D
+-9 2 D
+-1 -3 D
+-7 -1 D
+7 3 D
+-7 2 D
+4 1 D
+-12 3 D
+0 -3 D
+-1 2 D
+-4 -2 D
+5 4 D
+0 3 D
+-8 0 D
+-6 5 D
+-9 2 D
+-3 2 D
+-15 -5 D
+-9 0 D
+4 -4 D
+-19 5 D
+-1 -1 D
+-2 1 D
+-10 -4 D
+8 3 D
+-26 4 D
+-3 2 D
+-15 1 D
+-16 -5 D
+-2 -2 D
+1 1 D
+3 -14 D
+13 -4 D
+-6 0 D
+4 -2 D
+-4 -1 D
+-2 1 D
+2 -7 D
+-12 -9 D
+8 -1 D
+9 2 D
+-6 -2 D
+4 0 D
+-6 -3 D
+6 -2 D
+-4 -4 D
+8 -6 D
+-5 -1 D
+10 -1 D
+-2 -1 D
+P
+2515 3561 M
+-3 -5 D
+3 1 D
+1 -2 D
+4 0 D
+-2 -2 D
+-5 2 D
+-34 3 D
+4 2 D
+13 -4 D
+8 2 D
+5 -2 D
+3 5 D
+P
+2462 3570 M
+0 -4 D
+2 1 D
+-1 -2 D
+3 0 D
+-4 -3 D
+-3 4 D
+2 -1 D
+-1 4 D
+-3 -2 D
+P
+2493 3568 M
+6 -2 D
+4 2 D
+13 -2 D
+-7 0 D
+0 -1 D
+-4 1 D
+-6 -2 D
+-6 5 D
+P
+2450 3569 M
+0 -5 D
+-4 -1 D
+2 4 D
+-2 0 D
+P
+2587 3554 M
+2 -2 D
+5 -1 D
+-7 0 D
+-1 3 D
+P
+2438 3546 M
+0 -1 D
+-11 1 D
+P
+2474 3555 M
+-1 -5 D
+-5 4 D
+6 2 D
+P
+2472 3555 M
+-3 -1 D
+P
+FO
+2475 3543 M
+-2 2 D
+-3 -2 D
+P
+FO
+2515 3543 M
+0 1 D
+-1 -1 D
+P
+FO
+2598 3566 M
+P
+FO
+2598 3695 M
+-1 0 D
+1 0 D
+0 74 D
+-1 0 D
+1 0 D
+0 9 D
+-11 -2 D
+11 3 D
+0 1 D
+-180 0 D
+0 -6 D
+5 1 D
+-5 0 D
+15 4 D
+-7 -3 D
+14 0 D
+-5 -1 D
+2 -3 D
+-8 -1 D
+9 0 D
+2 -2 D
+3 4 D
+9 -1 D
+0 -3 D
+-6 3 D
+-5 -3 D
+6 -3 D
+5 0 D
+14 -5 D
+0 -3 D
+-9 -2 D
+-14 1 D
+-2 -8 D
+8 0 D
+17 4 D
+3 4 D
+7 -4 D
+7 2 D
+-4 -1 D
+9 0 D
+0 -1 D
+-7 -1 D
+5 -2 D
+2 2 D
+5 0 D
+-6 -2 D
+11 -5 D
+8 0 D
+-7 5 D
+13 -2 D
+-7 -6 D
+10 -2 D
+-2 -2 D
+14 0 D
+2 -6 D
+4 -1 D
+-4 0 D
+8 -4 D
+5 -11 D
+6 -1 D
+-5 -4 D
+-11 -2 D
+-5 -6 D
+23 -2 D
+-24 1 D
+-33 -13 D
+11 -8 D
+8 -3 D
+4 -6 D
+-15 2 D
+-10 -5 D
+-4 3 D
+-4 -2 D
+-5 1 D
+-1 -4 D
+-19 2 D
+3 -2 D
+-37 6 D
+2 -3 D
+-4 0 D
+-1 -1 D
+5 -3 D
+-20 -6 D
+2 -3 D
+-6 -3 D
+4 0 D
+3 -6 D
+3 0 D
+3 -2 D
+3 1 D
+4 -1 D
+-2 -1 D
+3 1 D
+1 -3 D
+6 2 D
+11 -3 D
+-1 3 D
+10 -1 D
+3 1 D
+-5 1 D
+9 1 D
+7 -1 D
+-4 3 D
+6 -1 D
+-6 4 D
+16 -4 D
+0 1 D
+10 -2 D
+3 1 D
+4 -1 D
+-6 3 D
+7 1 D
+-13 5 D
+6 0 D
+3 3 D
+-2 -4 D
+7 -4 D
+-1 3 D
+5 -3 D
+2 4 D
+2 0 D
+0 -3 D
+-3 -1 D
+5 -1 D
+-4 1 D
+3 -4 D
+-2 0 D
+-1 -1 D
+3 -1 D
+2 5 D
+4 -1 D
+-1 -1 D
+3 1 D
+-6 3 D
+4 -2 D
+2 3 D
+2 -2 D
+3 1 D
+1 -1 D
+-7 0 D
+3 -6 D
+1 5 D
+6 1 D
+0 2 D
+3 -2 D
+-8 -4 D
+4 0 D
+-1 -3 D
+4 2 D
+3 -4 D
+5 0 D
+-2 -3 D
+6 -2 D
+3 1 D
+-2 -4 D
+2 1 D
+5 -2 D
+1 5 D
+1 -8 D
+2 2 D
+3 -2 D
+3 1 D
+1 -2 D
+-1 6 D
+7 -6 D
+0 2 D
+3 0 D
+-1 -3 D
+4 1 D
+1 -2 D
+3 1 D
+-2 -2 D
+-4 1 D
+3 -1 D
+-6 -2 D
+-13 1 D
+7 -2 D
+3 1 D
+1 -2 D
+-4 0 D
+1 -2 D
+4 0 D
+-3 0 D
+3 -3 D
+5 -1 D
+2 2 D
+-2 -3 D
+5 -1 D
+1 2 D
+4 0 D
+3 2 D
+-6 -4 D
+7 2 D
+-4 -3 D
+7 -1 D
+-3 0 D
+8 -1 D
+11 -3 D
+P
+2589 3651 M
+-9 2 D
+4 1 D
+-6 3 D
+-7 -4 D
+-9 -1 D
+-7 2 D
+-4 6 D
+6 0 D
+-4 -2 D
+6 -1 D
+-3 2 D
+10 0 D
+-7 2 D
+3 2 D
+-5 9 D
+25 -10 D
+8 -8 D
+-4 -1 D
+P
+2549 3650 M
+-6 -1 D
+0 4 D
+7 2 D
+P
+2588 3702 M
+2 -2 D
+-1 1 D
+-3 -1 D
+P
+2471 3772 M
+-1 -4 D
+5 1 D
+-14 -3 D
+P
+2552 3672 M
+-3 1 D
+5 3 D
+-1 -4 D
+P
+2553 3677 M
+-4 -1 D
+3 3 D
+2 -2 D
+P
+2500 3659 M
+-4 -1 D
+2 3 D
+P
+2470 3653 M
+-4 -1 D
+0 2 D
+P
+2455 3663 M
+-8 2 D
+P
+2561 3632 M
+2 -1 D
+P
+2466 3662 M
+-4 1 D
+P
+2496 3752 M
+-1 0 D
+17 -1 D
+P
+2445 3665 M
+-8 2 D
+9 -2 D
+P
+FO
+2410 3780 M
+-1 -1 D
+P
+FO
+2363 3780 M
+-1 -2 D
+3 1 D
+5 -3 D
+21 1 D
+2 3 D
+P
+FO
+2362 3771 M
+9 -1 D
+6 2 D
+-2 3 D
+-12 -2 D
+-1 0 D
+P
+FO
+2362 3769 M
+0 1 D
+P
+FO
+2362 3584 M
+4 -4 D
+3 1 D
+10 10 D
+0 6 D
+-7 3 D
+-8 0 D
+-2 -2 D
+P
+FO
+2433 3624 M
+7 -1 D
+4 2 D
+-5 -1 D
+3 2 D
+-4 3 D
+-13 1 D
+-2 -1 D
+4 0 D
+-3 -1 D
+P
+FO
+2379 3756 M
+-3 -2 D
+4 -2 D
+10 2 D
+8 7 D
+6 2 D
+-1 2 D
+-11 -1 D
+3 -2 D
+P
+FO
+2478 3732 M
+-1 6 D
+-18 2 D
+-18 -2 D
+-15 -12 D
+7 -12 D
+26 0 D
+12 3 D
+8 6 D
+-2 9 D
+P
+FO
+2509 3732 M
+-11 2 D
+-2 3 D
+-2 -3 D
+-7 0 D
+-2 -2 D
+9 -5 D
+23 0 D
+1 5 D
+P
+FO
+2575 3610 M
+6 -1 D
+-4 -1 D
+4 -4 D
+13 0 D
+-8 5 D
+-16 3 D
+P
+FO
+2480 3748 M
+-6 1 D
+-3 -4 D
+14 -5 D
+1 2 D
+-4 0 D
+4 2 D
+P
+FO
+2433 3766 M
+-8 0 D
+-1 -4 D
+3 -3 D
+9 0 D
+-1 2 D
+7 4 D
+P
+FO
+2409 3773 M
+-4 1 D
+-1 -2 D
+-4 0 D
+-10 -5 D
+18 3 D
+2 3 D
+P
+FO
+2387 3745 M
+5 -2 D
+6 4 D
+-9 1 D
+5 -2 D
+P
+FO
+2409 3617 M
+12 2 D
+-3 5 D
+-13 2 D
+-8 -2 D
+P
+FO
+2489 3747 M
+-4 1 D
+-1 -2 D
+8 0 D
+P
+FO
+2504 3606 M
+-15 1 D
+16 -2 D
+P
+FO
+2386 3741 M
+-5 -1 D
+3 -4 D
+6 3 D
+P
+FO
+2501 3739 M
+1 1 D
+-7 3 D
+2 -4 D
+P
+FO
+2520 3643 M
+0 -2 D
+2 1 D
+P
+FO
+2496 3650 M
+-1 -2 D
+5 0 D
+P
+FO
+2409 3604 M
+4 0 D
+-6 0 D
+P
+FO
+2508 3646 M
+3 -2 D
+-1 3 D
+P
+FO
+2402 3561 M
+1 2 D
+-10 -2 D
+P
+FO
+2410 3638 M
+6 -2 D
+5 2 D
+P
+FO
+2557 3630 M
+-2 1 D
+0 -2 D
+P
+FO
+2499 3651 M
+-3 0 D
+3 -2 D
+P
+FO
+2504 3645 M
+3 -1 D
+P
+FO
+2414 3604 M
+4 0 D
+P
+FO
+2399 3626 M
+-2 -1 D
+P
+FO
+2506 3647 M
+1 -2 D
+P
+FO
+2537 3632 M
+-2 -1 D
+P
+FO
+2575 3612 M
+4 -1 D
+P
+FO
+2394 3738 M
+3 1 D
+P
+FO
+2527 3641 M
+-1 -1 D
+2 1 D
+P
+FO
+2444 3643 M
+1 -1 D
+P
+FO
+2477 3750 M
+3 -1 D
+P
+FO
+2420 3638 M
+-1 -1 D
+P
+FO
+2515 3645 M
+2 -1 D
+P
+FO
+2546 3629 M
+-4 0 D
+P
+FO
+2543 3629 M
+-4 0 D
+P
+FO
+2560 3629 M
+-2 -1 D
+P
+FO
+2551 3587 M
+-3 1 D
+P
+FO
+2533 3632 M
+-2 0 D
+P
+FO
+2500 3650 M
+2 -2 D
+P
+FO
+2444 3642 M
+-4 0 D
+P
+FO
+2407 3776 M
+0 2 D
+P
+FO
+2543 3591 M
+-3 0 D
+P
+FO
+2571 3610 M
+3 0 D
+P
+FO
+2566 3615 M
+-3 0 D
+P
+FO
+2548 3628 M
+-3 0 D
+3 -1 D
+P
+FO
+2409 3637 M
+0 1 D
+P
+FO
+2539 3634 M
+-3 -1 D
+P
+FO
+2489 3650 M
+2 0 D
+P
+FO
+2520 3640 M
+3 -1 D
+P
+FO
+2551 3629 M
+2 -1 D
+P
+FO
+2416 3548 M
+2 0 D
+P
+FO
+2476 3648 M
+1 -1 D
+P
+FO
+2540 3631 M
+-7 -1 D
+P
+FO
+4 3 1 2512 3543 SP
+2604 3543 M
+-1 2 D
+4 0 D
+1 4 D
+-4 2 D
+2 1 D
+-3 3 D
+4 2 D
+-1 3 D
+8 3 D
+-4 6 D
+-4 -2 D
+1 -3 D
+-3 1 D
+-3 -3 D
+-3 1 D
+0 -20 D
+P
+FO
+2728 3543 M
+-1 0 D
+4 1 D
+1 2 D
+-8 -2 D
+8 3 D
+-1 2 D
+-4 -2 D
+3 2 D
+-7 1 D
+8 -1 D
+-11 3 D
+2 -2 D
+-5 -1 D
+3 0 D
+-4 -2 D
+1 -2 D
+-1 1 D
+0 -2 D
+-3 1 D
+1 -2 D
+P
+FO
+2735 3543 M
+1 1 D
+-3 1 D
+P
+FO
+2631 3780 M
+-2 -2 D
+-9 0 D
+-8 -4 D
+-8 1 D
+-6 -4 D
+0 -2 D
+17 -1 D
+14 3 D
+9 0 D
+10 3 D
+16 -1 D
+-2 7 D
+P
+FO
+2604 3780 M
+-6 -2 D
+0 -7 D
+5 5 D
+9 -1 D
+12 5 D
+P
+FO
+2598 3779 M
+5 0 D
+-5 1 D
+P
+FO
+2598 3695 M
+3 0 D
+-3 0 D
+0 -87 D
+1 0 D
+3 4 D
+-2 -3 D
+4 -1 D
+-1 2 D
+3 -2 D
+7 1 D
+-5 -3 D
+4 -3 D
+0 2 D
+2 -2 D
+2 3 D
+1 -5 D
+9 -2 D
+1 3 D
+0 -3 D
+3 -1 D
+-1 2 D
+4 -4 D
+8 0 D
+-2 2 D
+4 -3 D
+9 1 D
+0 -2 D
+5 1 D
+6 -1 D
+-1 -2 D
+2 1 D
+4 -2 D
+6 1 D
+12 -5 D
+8 1 D
+-5 5 D
+4 -1 D
+-2 1 D
+4 2 D
+-4 1 D
+-3 3 D
+-3 0 D
+0 -2 D
+-4 2 D
+4 2 D
+-4 -1 D
+1 2 D
+-6 4 D
+-7 0 D
+3 1 D
+-4 0 D
+1 2 D
+-5 1 D
+1 1 D
+-4 0 D
+3 0 D
+-4 2 D
+-6 -1 D
+3 3 D
+-5 -2 D
+3 3 D
+-7 1 D
+-2 -2 D
+2 2 D
+-7 2 D
+-5 6 D
+-11 4 D
+-3 3 D
+14 -1 D
+3 -2 D
+1 1 D
+1 -2 D
+2 1 D
+10 -6 D
+-5 9 D
+3 -3 D
+4 1 D
+-1 -3 D
+6 -3 D
+0 1 D
+5 -5 D
+1 2 D
+4 -1 D
+-1 -1 D
+5 -2 D
+0 3 D
+3 -6 D
+3 -1 D
+-5 7 D
+4 3 D
+-3 -3 D
+6 -6 D
+10 -2 D
+-5 7 D
+3 -5 D
+5 -1 D
+-1 1 D
+3 0 D
+-3 -2 D
+5 -2 D
+1 4 D
+-1 -2 D
+3 -1 D
+2 -3 D
+5 4 D
+0 -4 D
+3 0 D
+-4 -2 D
+3 0 D
+1 -3 D
+7 1 D
+-9 10 D
+11 -5 D
+5 2 D
+-6 1 D
+2 3 D
+-5 0 D
+5 1 D
+-7 1 D
+3 1 D
+-3 3 D
+4 -2 D
+-1 3 D
+-5 1 D
+3 0 D
+-3 0 D
+3 1 D
+-2 3 D
+2 1 D
+-7 4 D
+4 0 D
+9 -11 D
+6 -2 D
+-3 2 D
+3 -1 D
+1 2 D
+-6 0 D
+6 1 D
+-5 7 D
+4 -3 D
+0 2 D
+-11 3 D
+3 3 D
+6 1 D
+-2 2 D
+-7 -2 D
+2 1 D
+-6 0 D
+3 1 D
+-3 0 D
+0 2 D
+-6 0 D
+4 2 D
+-10 2 D
+11 0 D
+-1 3 D
+5 0 D
+-2 2 D
+-3 -1 D
+1 2 D
+-4 -3 D
+1 2 D
+-9 -1 D
+-1 3 D
+5 3 D
+-3 1 D
+-1 -2 D
+0 4 D
+-2 -1 D
+0 1 D
+-4 0 D
+4 -5 D
+-4 3 D
+-1 -3 D
+0 5 D
+-3 -2 D
+-1 -2 D
+-1 1 D
+1 1 D
+-4 0 D
+-2 -1 D
+2 -3 D
+-2 3 D
+6 1 D
+1 2 D
+-5 0 D
+-3 3 D
+-2 -1 D
+1 2 D
+-4 0 D
+-1 -7 D
+-1 8 D
+-3 -2 D
+-1 2 D
+4 3 D
+-4 -3 D
+-5 0 D
+5 4 D
+-8 -1 D
+4 3 D
+-8 1 D
+9 1 D
+-10 2 D
+4 1 D
+-5 0 D
+6 0 D
+-1 3 D
+-10 -1 D
+-1 0 D
+5 -1 D
+-6 1 D
+-5 -3 D
+2 2 D
+-3 0 D
+5 2 D
+-3 1 D
+5 2 D
+-2 1 D
+-10 -2 D
+6 2 D
+-2 3 D
+-5 -1 D
+4 1 D
+-5 3 D
+13 -5 D
+1 3 D
+7 -3 D
+1 2 D
+6 -1 D
+1 2 D
+-16 6 D
+3 1 D
+-7 5 D
+7 -2 D
+-1 2 D
+11 -6 D
+4 1 D
+-8 3 D
+7 -1 D
+0 1 D
+-5 3 D
+-4 0 D
+0 3 D
+9 -4 D
+0 1 D
+7 0 D
+-8 3 D
+10 -2 D
+-2 -1 D
+4 -2 D
+-2 -2 D
+8 1 D
+-3 -4 D
+3 -1 D
+1 1 D
+9 -3 D
+10 3 D
+2 3 D
+-1 -3 D
+-10 -5 D
+2 -2 D
+22 3 D
+6 5 D
+8 1 D
+-9 -3 D
+-2 -6 D
+-4 1 D
+-9 -2 D
+-3 -4 D
+2 1 D
+1 -3 D
+13 1 D
+-12 -2 D
+0 -1 D
+5 -1 D
+9 3 D
+0 -2 D
+-10 -2 D
+1 -2 D
+16 2 D
+-12 -3 D
+6 -1 D
+-6 -1 D
+7 -1 D
+-3 -1 D
+4 -2 D
+9 8 D
+-4 -6 D
+6 1 D
+-4 -3 D
+5 -2 D
+0 3 D
+3 -2 D
+4 3 D
+-2 -4 D
+5 0 D
+-4 -1 D
+5 0 D
+-1 -2 D
+3 -1 D
+-1 4 D
+3 -1 D
+-1 2 D
+4 0 D
+-4 1 D
+4 1 D
+-5 1 D
+5 0 D
+-4 1 D
+4 0 D
+-6 3 D
+4 1 D
+-8 2 D
+11 -2 D
+-10 4 D
+8 -1 D
+0 2 D
+-9 1 D
+10 0 D
+-5 6 D
+7 -7 D
+6 -1 D
+2 4 D
+1 -3 D
+3 -1 D
+1 1 D
+0 -1 D
+2 2 D
+-6 2 D
+7 0 D
+-7 4 D
+5 -3 D
+9 0 D
+-5 3 D
+2 1 D
+-10 1 D
+-3 4 D
+4 -3 D
+11 -2 D
+9 1 D
+-13 5 D
+-6 -1 D
+-4 4 D
+5 -3 D
+9 2 D
+-3 2 D
+-6 0 D
+14 1 D
+-3 -2 D
+7 -2 D
+9 2 D
+0 2 D
+-11 -1 D
+11 2 D
+-6 3 D
+-9 1 D
+4 1 D
+14 -4 D
+3 4 D
+-5 3 D
+-7 0 D
+4 2 D
+-9 -1 D
+7 2 D
+-4 1 D
+-4 -2 D
+1 4 D
+-6 0 D
+1 -3 D
+-5 0 D
+3 -5 D
+-6 6 D
+-5 -1 D
+1 -6 D
+-4 -1 D
+2 8 D
+-13 -2 D
+-1 -4 D
+-1 4 D
+-3 -2 D
+-5 0 D
+13 4 D
+-1 3 D
+8 3 D
+-4 3 D
+-16 -11 D
+-3 3 D
+9 2 D
+1 3 D
+-25 -2 D
+-4 -3 D
+2 3 D
+16 3 D
+-20 -2 D
+14 3 D
+-14 1 D
+20 0 D
+-2 2 D
+-5 0 D
+4 3 D
+-5 1 D
+0 3 D
+-8 -2 D
+7 2 D
+-5 0 D
+1 2 D
+-6 0 D
+-1 -3 D
+-3 2 D
+-7 -3 D
+5 4 D
+-6 -2 D
+8 4 D
+-4 0 D
+9 2 D
+-9 1 D
+-8 -3 D
+-3 -3 D
+5 -4 D
+-6 4 D
+4 5 D
+-8 0 D
+-6 -9 D
+3 6 D
+-2 2 D
+-4 -1 D
+5 3 D
+-7 -2 D
+-3 -4 D
+-9 2 D
+9 0 D
+4 4 D
+-8 1 D
+5 1 D
+-7 1 D
+-3 -5 D
+2 5 D
+-9 -4 D
+7 6 D
+-9 1 D
+-5 -2 D
+2 2 D
+6 1 D
+-9 1 D
+-4 -3 D
+-3 0 D
+4 2 D
+-9 -1 D
+11 3 D
+10 -1 D
+8 2 D
+-11 1 D
+1 -2 D
+-6 0 D
+2 2 D
+-7 0 D
+1 1 D
+-4 1 D
+-4 -1 D
+-2 -3 D
+0 4 D
+-19 0 D
+6 1 D
+-3 0 D
+13 1 D
+-32 4 D
+6 0 D
+-6 1 D
+9 0 D
+13 -2 D
+-3 1 D
+20 -1 D
+-17 3 D
+12 -1 D
+-2 2 D
+-12 0 D
+20 1 D
+-17 4 D
+-9 -2 D
+-4 -3 D
+2 3 D
+-4 1 D
+14 2 D
+-12 0 D
+22 0 D
+-20 3 D
+-8 -2 D
+5 2 D
+20 -1 D
+13 -3 D
+22 0 D
+-1 4 D
+-11 3 D
+-18 0 D
+-18 3 D
+-11 -2 D
+-19 1 D
+P
+2649 3690 M
+-9 4 D
+8 -1 D
+P
+2604 3695 M
+3 -1 D
+-5 0 D
+P
+2603 3700 M
+1 -3 D
+P
+2683 3709 M
+-14 3 D
+P
+2609 3698 M
+-1 -1 D
+0 1 D
+P
+2607 3693 M
+2 -1 D
+P
+2602 3697 M
+2 -1 D
+P
+FO
+2598 3566 M
+2 2 D
+P
+FO
+2717 3576 M
+3 -2 D
+5 5 D
+-3 0 D
+3 2 D
+-3 0 D
+1 1 D
+-17 0 D
+0 -2 D
+P
+FO
+2709 3652 M
+3 1 D
+-3 0 D
+1 2 D
+-3 -3 D
+1 4 D
+-7 -6 D
+4 0 D
+-1 1 D
+P
+FO
+2776 3678 M
+3 -3 D
+2 2 D
+0 -1 D
+3 0 D
+-3 3 D
+P
+FO
+2718 3602 M
+9 -3 D
+5 3 D
+-3 0 D
+3 0 D
+-9 2 D
+P
+FO
+2718 3633 M
+13 -3 D
+-1 3 D
+-1 -2 D
+-4 2 D
+2 3 D
+-9 -2 D
+P
+FO
+2646 3772 M
+-8 -2 D
+9 -2 D
+5 3 D
+-4 2 D
+1 -2 D
+P
+FO
+2646 3550 M
+4 5 D
+-4 2 D
+-6 0 D
+-4 -9 D
+P
+FO
+2744 3715 M
+11 1 D
+-3 1 D
+-3 -2 D
+1 2 D
+P
+FO
+2719 3553 M
+12 -3 D
+-1 3 D
+-3 -1 D
+-3 3 D
+P
+FO
+2717 3626 M
+-2 1 D
+5 -4 D
+-3 5 D
+P
+FO
+2716 3603 M
+5 1 D
+-4 1 D
+-4 -2 D
+P
+FO
+2655 3768 M
+7 1 D
+-5 1 D
+-6 -1 D
+P
+FO
+2728 3628 M
+4 -5 D
+7 -2 D
+-7 9 D
+P
+FO
+2717 3584 M
+5 1 D
+-10 4 D
+0 -3 D
+P
+FO
+2718 3647 M
+2 -2 D
+2 1 D
+P
+FO
+2769 3709 M
+9 4 D
+-11 -3 D
+P
+FO
+2669 3685 M
+-2 0 D
+4 -1 D
+P
+FO
+2697 3587 M
+2 -2 D
+0 2 D
+P
+FO
+2709 3732 M
+-3 -1 D
+5 1 D
+P
+FO
+2781 3683 M
+3 -2 D
+0 2 D
+P
+FO
+2646 3620 M
+2 -1 D
+-5 3 D
+P
+FO
+2716 3639 M
+4 1 D
+-3 1 D
+P
+FO
+2671 3741 M
+4 -1 D
+-3 2 D
+P
+FO
+2682 3612 M
+-3 0 D
+5 -1 D
+P
+FO
+2694 3585 M
+4 0 D
+-2 2 D
+P
+FO
+2740 3720 M
+7 1 D
+-5 3 D
+P
+FO
+2686 3736 M
+1 3 D
+-10 -2 D
+P
+FO
+2646 3750 M
+-12 1 D
+19 -2 D
+P
+FO
+2716 3642 M
+3 2 D
+-2 2 D
+P
+FO
+2673 3695 M
+-3 0 D
+9 -3 D
+P
+FO
+2731 3634 M
+5 -1 D
+0 2 D
+P
+FO
+2778 3690 M
+6 0 D
+-3 1 D
+P
+FO
+2735 3631 M
+5 -1 D
+-2 2 D
+P
+FO
+2646 3623 M
+2 0 D
+P
+FO
+2735 3629 M
+3 -3 D
+P
+FO
+2712 3642 M
+4 0 D
+P
+FO
+2652 3678 M
+6 1 D
+P
+FO
+2731 3633 M
+2 -2 D
+P
+FO
+2701 3681 M
+4 2 D
+-4 -1 D
+P
+FO
+2694 3594 M
+3 -1 D
+P
+FO
+2701 3736 M
+0 -2 D
+P
+FO
+2780 3711 M
+6 0 D
+P
+FO
+2726 3641 M
+5 0 D
+P
+FO
+2756 3668 M
+3 0 D
+P
+FO
+2766 3675 M
+2 -1 D
+P
+FO
+2695 3735 M
+0 -2 D
+P
+FO
+2711 3651 M
+4 0 D
+-3 0 D
+P
+FO
+2646 3747 M
+6 0 D
+P
+FO
+2669 3695 M
+4 -2 D
+P
+FO
+2754 3661 M
+4 -2 D
+P
+FO
+2718 3670 M
+2 1 D
+P
+FO
+2674 3666 M
+-1 -1 D
+P
+FO
+2672 3668 M
+0 -1 D
+P
+FO
+2648 3621 M
+2 -1 D
+P
+FO
+2669 3607 M
+1 1 D
+P
+FO
+2673 3668 M
+0 -1 D
+P
+FO
+2651 3617 M
+2 0 D
+P
+FO
+2672 3672 M
+0 -1 D
+P
+FO
+2640 3622 M
+2 -1 D
+P
+FO
+2669 3671 M
+-1 -1 D
+P
+FO
+2738 3629 M
+1 -1 D
+P
+FO
+2722 3558 M
+2 1 D
+P
+FO
+2649 3620 M
+3 -2 D
+P
+FO
+2761 3708 M
+3 0 D
+-3 1 D
+P
+FO
+2652 3627 M
+-1 2 D
+P
+FO
+2688 3659 M
+2 0 D
+-2 1 D
+P
+FO
+2706 3734 M
+1 -1 D
+P
+FO
+2669 3697 M
+3 -1 D
+P
+FO
+2673 3614 M
+-5 3 D
+P
+FO
+2725 3644 M
+4 -1 D
+P
+FO
+2723 3557 M
+3 2 D
+P
+FO
+2722 3620 M
+2 -1 D
+P
+FO
+2646 3682 M
+2 -1 D
+P
+FO
+2776 3708 M
+3 0 D
+P
+FO
+2759 3711 M
+4 0 D
+P
+FO
+2674 3736 M
+2 1 D
+P
+FO
+2652 3680 M
+3 0 D
+P
+FO
+2671 3697 M
+2 -1 D
+P
+FO
+2722 3558 M
+3 1 D
+P
+FO
+2720 3643 M
+3 0 D
+P
+FO
+2646 3619 M
+-3 2 D
+P
+FO
+2721 3574 M
+2 2 D
+P
+FO
+2656 3752 M
+-3 -1 D
+P
+FO
+2648 3753 M
+0 2 D
+P
+FO
+2672 3739 M
+-2 1 D
+P
+FO
+2732 3603 M
+1 0 D
+P
+FO
+2775 3675 M
+0 -1 D
+P
+FO
+2753 3670 M
+3 -1 D
+P
+FO
+2646 3625 M
+-1 2 D
+P
+FO
+2664 3675 M
+0 -1 D
+P
+FO
+2722 3644 M
+3 -1 D
+P
+FO
+2657 3593 M
+-2 1 D
+P
+FO
+2734 3604 M
+4 -1 D
+P
+FO
+2734 3636 M
+3 0 D
+P
+FO
+2742 3717 M
+1 -1 D
+-1 2 D
+P
+FO
+2757 3674 M
+3 0 D
+P
+FO
+2720 3730 M
+4 0 D
+P
+FO
+2740 3662 M
+0 1 D
+P
+FO
+2784 3692 M
+2 -1 D
+P
+FO
+2707 3583 M
+2 1 D
+P
+FO
+2629 3630 M
+1 -1 D
+P
+FO
+2660 3621 M
+-2 1 D
+P
+FO
+2736 3634 M
+2 -1 D
+P
+FO
+2656 3679 M
+-2 0 D
+P
+FO
+2685 3690 M
+0 -1 D
+P
+FO
+2773 3713 M
+3 1 D
+P
+FO
+2741 3719 M
+2 -1 D
+P
+FO
+2661 3679 M
+-3 1 D
+P
+FO
+3071 3598 M
+P
+FO
+3071 3609 M
+-5 -3 D
+-3 -4 D
+8 -4 D
+P
+FO
+3071 3614 M
+-4 -1 D
+-3 -6 D
+2 2 D
+5 1 D
+P
+FO
+3071 3634 M
+-7 -1 D
+7 1 D
+0 14 D
+-4 1 D
+-4 4 D
+-9 1 D
+5 -1 D
+-2 -1 D
+-7 0 D
+-1 -1 D
+6 0 D
+0 -1 D
+5 1 D
+-4 -3 D
+9 1 D
+1 -1 D
+-5 -1 D
+-7 1 D
+3 -1 D
+-8 0 D
+-3 -3 D
+4 0 D
+-21 -2 D
+8 0 D
+-5 -1 D
+5 -2 D
+25 7 D
+-5 -4 D
+10 2 D
+2 -3 D
+-5 2 D
+-26 -4 D
+2 -1 D
+-7 1 D
+6 -2 D
+-2 -4 D
+12 3 D
+-11 -3 D
+3 -1 D
+-6 0 D
+-1 -2 D
+5 1 D
+-5 -1 D
+5 -2 D
+3 1 D
+-4 -2 D
+5 -1 D
+2 4 D
+14 0 D
+-2 -2 D
+1 1 D
+-9 -1 D
+-4 0 D
+0 -2 D
+8 0 D
+-11 -2 D
+2 -1 D
+2 2 D
+0 -2 D
+7 1 D
+-1 -1 D
+15 0 D
+-22 -1 D
+0 -2 D
+3 0 D
+-1 -3 D
+5 3 D
+-3 -3 D
+3 2 D
+18 0 D
+-14 -3 D
+3 -2 D
+-2 -1 D
+10 1 D
+-5 -3 D
+0 -2 D
+5 4 D
+4 1 D
+P
+3054 3637 M
+15 2 D
+P
+FO
+3071 3657 M
+-6 -3 D
+5 0 D
+-3 -1 D
+1 -3 D
+3 -1 D
+P
+FO
+3071 3663 M
+-6 -1 D
+2 4 D
+4 -1 D
+0 95 D
+-12 -2 D
+-5 1 D
+6 -2 D
+5 1 D
+0 -2 D
+4 0 D
+-4 -1 D
+0 2 D
+-3 -1 D
+-2 0 D
+2 -3 D
+-7 5 D
+-8 -1 D
+6 2 D
+-8 0 D
+-3 -6 D
+6 1 D
+-8 -4 D
+15 2 D
+-8 -3 D
+3 -2 D
+5 0 D
+-4 0 D
+4 -1 D
+0 -2 D
+-9 5 D
+0 -3 D
+-19 -2 D
+-4 1 D
+5 2 D
+-10 1 D
+-5 -2 D
+11 0 D
+-16 -1 D
+6 -1 D
+-9 -2 D
+1 -1 D
+-17 -1 D
+22 1 D
+-10 -3 D
+12 2 D
+0 -4 D
+26 3 D
+-7 3 D
+20 2 D
+-15 -6 D
+12 -2 D
+-12 1 D
+9 -1 D
+-2 -2 D
+5 1 D
+-3 -1 D
+17 -4 D
+-7 0 D
+-13 4 D
+-19 -1 D
+-14 4 D
+-7 -1 D
+14 -2 D
+-25 3 D
+-4 -1 D
+9 0 D
+-1 -1 D
+8 -3 D
+18 -1 D
+-27 2 D
+-1 -1 D
+8 0 D
+-9 -1 D
+0 -2 D
+5 0 D
+-6 -1 D
+-3 2 D
+4 -3 D
+-4 0 D
+-1 2 D
+-5 -2 D
+4 -2 D
+-6 -3 D
+3 -2 D
+16 7 D
+33 5 D
+1 -1 D
+-19 -3 D
+15 -3 D
+10 3 D
+-7 3 D
+13 1 D
+2 -3 D
+-10 0 D
+5 -3 D
+13 2 D
+-7 1 D
+4 1 D
+12 -1 D
+-18 -3 D
+-7 0 D
+10 -2 D
+-3 0 D
+6 -2 D
+-14 3 D
+-11 -2 D
+-16 4 D
+-9 -1 D
+8 0 D
+-4 -1 D
+-7 1 D
+-3 -2 D
+5 1 D
+-9 -3 D
+5 0 D
+-17 -4 D
+0 -5 D
+15 4 D
+-1 -2 D
+25 3 D
+17 -1 D
+-17 1 D
+-41 -6 D
+-1 -2 D
+14 1 D
+-11 -1 D
+0 -1 D
+14 0 D
+-14 0 D
+3 -2 D
+21 -1 D
+9 2 D
+-2 -2 D
+5 0 D
+-5 0 D
+6 -1 D
+-19 0 D
+-2 -2 D
+11 1 D
+-12 -2 D
+13 0 D
+-21 -2 D
+6 -2 D
+11 1 D
+9 -2 D
+-28 0 D
+-1 -6 D
+13 1 D
+-11 -1 D
+-3 -3 D
+5 1 D
+-5 -1 D
+8 -1 D
+28 10 D
+4 4 D
+31 8 D
+-7 -3 D
+15 -1 D
+-22 0 D
+-6 -2 D
+2 -1 D
+-11 -2 D
+-4 -3 D
+3 0 D
+-10 -2 D
+-26 -9 D
+3 -1 D
+-2 -2 D
+13 3 D
+-10 -3 D
+3 -2 D
+14 5 D
+1 -3 D
+5 -1 D
+3 3 D
+10 2 D
+-2 -2 D
+3 -2 D
+-6 2 D
+-5 -1 D
+-3 -3 D
+-8 3 D
+-13 -5 D
+7 2 D
+-8 -4 D
+10 0 D
+3 4 D
+-2 -5 D
+6 1 D
+-6 -3 D
+2 -1 D
+6 4 D
+-4 -4 D
+2 -1 D
+4 3 D
+-3 -5 D
+14 4 D
+2 3 D
+14 4 D
+18 -4 D
+-13 2 D
+-15 -1 D
+-4 -2 D
+3 -1 D
+-21 -6 D
+3 -2 D
+-1 -1 D
+4 3 D
+0 -1 D
+4 0 D
+-3 -2 D
+7 3 D
+-6 -4 D
+6 1 D
+-7 -3 D
+7 -2 D
+-6 -2 D
+2 -1 D
+-1 -1 D
+3 3 D
+5 -1 D
+-6 -3 D
+10 2 D
+-3 1 D
+2 3 D
+4 -1 D
+-3 -3 D
+6 2 D
+-2 1 D
+2 -1 D
+4 1 D
+-4 -1 D
+2 -1 D
+-12 -2 D
+-7 -3 D
+4 -12 D
+7 3 D
+11 11 D
+5 0 D
+-3 -4 D
+11 3 D
+-8 12 D
+3 -2 D
+6 2 D
+-5 -3 D
+6 -9 D
+14 2 D
+P
+3049 3670 M
+-1 1 D
+5 0 D
+P
+3061 3675 M
+2 1 D
+4 -2 D
+P
+3004 3724 M
+12 -1 D
+-13 0 D
+P
+3061 3665 M
+3 3 D
+1 -3 D
+P
+3032 3665 M
+4 3 D
+4 -1 D
+-9 -2 D
+P
+2989 3725 M
+14 4 D
+-15 -4 D
+P
+2994 3713 M
+11 -3 D
+-12 3 D
+P
+3027 3680 M
+6 1 D
+P
+3053 3673 M
+5 0 D
+-6 -1 D
+P
+3029 3730 M
+4 -1 D
+-4 0 D
+P
+3040 3732 M
+3 0 D
+P
+FO
+3065 3780 M
+0 -1 D
+-9 -1 D
+10 -4 D
+-10 0 D
+-5 -1 D
+10 -3 D
+-10 1 D
+-2 -3 D
+16 0 D
+-7 -1 D
+2 -1 D
+-7 2 D
+-4 -1 D
+0 -5 D
+-5 -1 D
+10 0 D
+7 3 D
+-2 -4 D
+8 2 D
+4 -2 D
+0 20 D
+P
+FO
+3044 3780 M
+0 -1 D
+9 1 D
+P
+FO
+3035 3780 M
+1 -1 D
+3 1 D
+P
+FO
+2962 3780 M
+9 -2 D
+-15 0 D
+-2 -3 D
+14 -3 D
+-13 2 D
+2 -4 D
+18 -1 D
+2 1 D
+-1 -2 D
+6 0 D
+-1 -1 D
+11 3 D
+-6 -3 D
+5 -1 D
+-21 0 D
+10 -4 D
+7 -1 D
+37 8 D
+3 2 D
+-3 4 D
+-18 3 D
+-3 2 D
+P
+FO
+3047 3769 M
+1 4 D
+7 3 D
+-13 2 D
+-4 -2 D
+9 1 D
+-9 -4 D
+3 -5 D
+P
+FO
+3024 3737 M
+-9 -1 D
+9 1 D
+-6 -2 D
+8 0 D
+10 3 D
+P
+FO
+3000 3746 M
+15 1 D
+5 2 D
+-16 -1 D
+-8 -2 D
+P
+FO
+3053 3618 M
+3 0 D
+0 -2 D
+3 1 D
+-1 2 D
+P
+FO
+3000 3741 M
+3 2 D
+-3 1 D
+1 -1 D
+-7 -1 D
+P
+FO
+3033 3644 M
+7 1 D
+-3 1 D
+P
+FO
+3035 3647 M
+6 0 D
+3 4 D
+-4 0 D
+P
+FO
+3000 3706 M
+-9 0 D
+-3 -2 D
+14 2 D
+P
+FO
+2990 3732 M
+4 1 D
+-3 2 D
+-4 -2 D
+P
+FO
+3047 3647 M
+4 3 D
+-4 1 D
+-7 -8 D
+P
+FO
+3000 3674 M
+4 2 D
+-10 0 D
+P
+FO
+3024 3642 M
+-1 -1 D
+3 0 D
+P
+FO
+3053 3615 M
+2 -1 D
+1 2 D
+P
+FO
+3020 3644 M
+3 -2 D
+-2 3 D
+P
+FO
+3024 3734 M
+18 1 D
+-5 1 D
+P
+FO
+3050 3617 M
+4 -1 D
+-2 2 D
+P
+FO
+3000 3673 M
+2 -2 D
+1 2 D
+P
+FO
+2981 3726 M
+4 -1 D
+0 1 D
+P
+FO
+2984 3687 M
+3 -1 D
+3 1 D
+P
+FO
+3056 3776 M
+2 -1 D
+2 1 D
+P
+FO
+3000 3750 M
+4 0 D
+P
+FO
+2989 3702 M
+9 2 D
+P
+FO
+3007 3745 M
+6 1 D
+P
+FO
+3038 3625 M
+5 1 D
+P
+FO
+3035 3629 M
+2 -2 D
+P
+FO
+3014 3664 M
+4 2 D
+P
+FO
+2968 3768 M
+6 0 D
+P
+FO
+3005 3743 M
+4 1 D
+P
+FO
+3067 3607 M
+1 2 D
+P
+FO
+3002 3749 M
+5 0 D
+P
+FO
+3047 3617 M
+1 1 D
+P
+FO
+3012 3750 M
+4 0 D
+P
+FO
+3029 3636 M
+1 1 D
+P
+FO
+2988 3739 M
+2 1 D
+P
+FO
+2994 3734 M
+3 0 D
+P
+FO
+3065 3607 M
+2 1 D
+P
+FO
+3020 3653 M
+0 -1 D
+P
+FO
+3012 3662 M
+2 0 D
+P
+FO
+2988 3737 M
+3 1 D
+P
+FO
+2986 3741 M
+4 0 D
+P
+FO
+3015 3661 M
+-1 -1 D
+P
+FO
+3007 3749 M
+6 0 D
+P
+FO
+2988 3744 M
+3 0 D
+P
+FO
+3002 3745 M
+4 -1 D
+P
+FO
+3036 3778 M
+6 0 D
+P
+FO
+3000 3745 M
+-3 -1 D
+P
+FO
+2985 3706 M
+5 0 D
+P
+FO
+3058 3612 M
+2 1 D
+P
+FO
+3009 3738 M
+3 0 D
+P
+FO
+3031 3635 M
+2 0 D
+P
+FO
+3060 3607 M
+3 0 D
+-3 1 D
+P
+FO
+2992 3739 M
+4 0 D
+P
+FO
+3193 3543 M
+-3 2 D
+P
+FO
+3196 3543 M
+1 3 D
+1 -3 D
+1 0 D
+3 4 D
+4 0 D
+0 4 D
+2 -3 D
+2 4 D
+3 -2 D
+-4 -3 D
+13 -1 D
+11 -1 D
+-5 3 D
+5 0 D
+-2 1 D
+2 1 D
+-7 1 D
+-4 -1 D
+6 3 D
+-11 2 D
+-1 -2 D
+0 3 D
+-9 0 D
+1 2 D
+13 -2 D
+-2 4 D
+3 -5 D
+10 -1 D
+-4 2 D
+6 -2 D
+-2 2 D
+7 0 D
+-8 1 D
+8 0 D
+2 2 D
+-3 -2 D
+-9 2 D
+7 -1 D
+4 2 D
+-16 2 D
+16 -1 D
+-16 4 D
+13 -2 D
+5 2 D
+-2 2 D
+3 -1 D
+0 2 D
+-7 0 D
+1 1 D
+-16 1 D
+24 -1 D
+-13 3 D
+14 -1 D
+-2 2 D
+-6 -1 D
+4 1 D
+-12 2 D
+15 -1 D
+5 2 D
+0 2 D
+-2 -1 D
+-1 2 D
+-10 0 D
+-3 2 D
+15 -1 D
+0 2 D
+4 0 D
+-3 1 D
+4 0 D
+-15 2 D
+3 1 D
+4 -2 D
+6 1 D
+3 2 D
+-5 1 D
+5 0 D
+2 3 D
+-10 -2 D
+3 2 D
+-2 0 D
+5 2 D
+1 4 D
+-9 1 D
+-9 5 D
+20 -4 D
+-9 2 D
+2 0 D
+-2 2 D
+5 -2 D
+-1 3 D
+-18 3 D
+0 1 D
+10 -2 D
+0 3 D
+1 -3 D
+1 2 D
+3 -1 D
+-2 3 D
+2 -1 D
+2 1 D
+-5 1 D
+7 2 D
+-1 -4 D
+14 1 D
+0 2 D
+3 0 D
+1 2 D
+-14 0 D
+4 1 D
+-5 1 D
+1 3 D
+5 -4 D
+2 1 D
+9 -1 D
+-14 5 D
+16 -3 D
+-2 -2 D
+5 0 D
+-7 6 D
+-4 0 D
+2 1 D
+-5 3 D
+4 2 D
+6 -2 D
+0 2 D
+6 -4 D
+-4 4 D
+6 -4 D
+3 1 D
+-7 3 D
+7 -1 D
+0 1 D
+6 -1 D
+0 2 D
+-21 4 D
+3 2 D
+12 -4 D
+12 0 D
+-3 6 D
+-5 0 D
+6 1 D
+0 3 D
+-7 2 D
+-3 -3 D
+-13 5 D
+5 2 D
+7 -1 D
+10 2 D
+2 -2 D
+5 1 D
+-7 3 D
+1 4 D
+-14 7 D
+6 0 D
+-5 5 D
+8 -2 D
+1 1 D
+2 -2 D
+2 3 D
+9 -4 D
+5 2 D
+-1 2 D
+1 0 D
+0 7 D
+-2 1 D
+2 0 D
+0 107 D
+-236 0 D
+0 -20 D
+1 0 D
+-1 0 D
+1 -96 D
+4 2 D
+-5 -3 D
+0 -14 D
+8 -3 D
+-8 2 D
+0 -14 D
+1 0 D
+-1 0 D
+0 -20 D
+7 1 D
+-7 -1 D
+0 -4 D
+3 2 D
+0 -2 D
+-3 -1 D
+0 -11 D
+6 2 D
+4 -1 D
+-7 0 D
+0 -3 D
+8 2 D
+-1 -2 D
+7 1 D
+-10 -3 D
+10 1 D
+-4 -2 D
+3 -1 D
+-9 1 D
+6 -1 D
+-6 -2 D
+7 2 D
+1 -1 D
+-3 -1 D
+8 1 D
+3 4 D
+-2 -3 D
+3 2 D
+-1 -2 D
+4 0 D
+-15 -3 D
+3 0 D
+-3 -3 D
+6 2 D
+-4 -3 D
+4 -2 D
+0 4 D
+9 3 D
+-8 -7 D
+7 2 D
+-5 -4 D
+12 1 D
+-16 -1 D
+4 -1 D
+-4 0 D
+9 0 D
+-5 -1 D
+2 -2 D
+15 4 D
+-3 -2 D
+6 0 D
+-20 -3 D
+4 0 D
+-1 -1 D
+4 2 D
+0 -1 D
+4 1 D
+-1 -1 D
+9 0 D
+-5 -2 D
+4 0 D
+-6 -1 D
+-1 -1 D
+4 1 D
+-2 -1 D
+2 -1 D
+5 1 D
+0 -1 D
+3 3 D
+5 0 D
+-7 -3 D
+2 -1 D
+3 2 D
+-2 -3 D
+8 2 D
+-4 -4 D
+7 0 D
+-7 -2 D
+-1 -2 D
+7 -1 D
+8 2 D
+-6 0 D
+2 3 D
+1 -2 D
+5 1 D
+-1 -2 D
+6 2 D
+-1 -1 D
+9 -1 D
+-2 2 D
+3 -2 D
+1 2 D
+1 -2 D
+-2 2 D
+3 -1 D
+-1 2 D
+4 0 D
+0 2 D
+5 -3 D
+1 1 D
+-3 2 D
+5 -1 D
+6 2 D
+-7 3 D
+4 -1 D
+4 3 D
+-3 -3 D
+6 -2 D
+-11 -4 D
+2 -2 D
+12 5 D
+0 4 D
+3 -4 D
+4 3 D
+-7 -5 D
+-11 -3 D
+-6 -2 D
+9 2 D
+-9 -3 D
+5 -1 D
+2 3 D
+6 0 D
+-5 -2 D
+4 0 D
+8 6 D
+0 -2 D
+4 0 D
+-5 -1 D
+-5 -2 D
+5 1 D
+-10 -4 D
+7 1 D
+-10 -3 D
+3 -2 D
+1 3 D
+4 0 D
+-2 -1 D
+3 0 D
+-2 -2 D
+3 -1 D
+8 7 D
+-2 -2 D
+4 0 D
+-9 -5 D
+10 4 D
+-3 -5 D
+14 7 D
+-13 -14 D
+7 2 D
+10 8 D
+-7 -6 D
+5 -1 D
+-5 0 D
+-1 -2 D
+-6 0 D
+-2 -2 D
+6 1 D
+1 -3 D
+P
+3075 3624 M
+-4 2 D
+7 -1 D
+P
+3079 3603 M
+8 -1 D
+-9 1 D
+P
+3080 3653 M
+3 1 D
+P
+3075 3658 M
+4 0 D
+P
+3075 3619 M
+5 0 D
+P
+3077 3609 M
+5 1 D
+P
+FO
+3201 3543 M
+3 2 D
+0 -2 D
+4 1 D
+-6 2 D
+P
+FO
+3210 3543 M
+-1 0 D
+P
+FO
+3224 3543 M
+-3 2 D
+8 -2 D
+1 1 D
+1 -1 D
+1 1 D
+-21 3 D
+3 -3 D
+6 1 D
+-4 -2 D
+P
+FO
+3071 3598 M
+2 0 D
+-2 0 D
+P
+FO
+3287 3659 M
+9 -8 D
+-1 -2 D
+8 -1 D
+-2 2 D
+-5 2 D
+3 0 D
+-5 2 D
+3 0 D
+-1 3 D
+-6 3 D
+P
+FO
+3142 3563 M
+3 1 D
+-3 -1 D
+4 0 D
+-3 -1 D
+6 2 D
+-6 1 D
+P
+FO
+3260 3608 M
+3 0 D
+-9 1 D
+-5 -1 D
+1 -2 D
+3 1 D
+5 -1 D
+1 2 D
+P
+FO
+3262 3625 M
+11 -6 D
+2 2 D
+3 -2 D
+-1 2 D
+-9 4 D
+P
+FO
+3118 3563 M
+-6 -1 D
+4 -2 D
+2 2 D
+0 -2 D
+8 1 D
+P
+FO
+3273 3618 M
+6 -1 D
+-4 1 D
+3 -1 D
+-2 2 D
+P
+FO
+3252 3604 M
+2 -2 D
+3 0 D
+-1 2 D
+P
+FO
+3180 3547 M
+6 2 D
+0 3 D
+-5 0 D
+P
+FO
+3283 3642 M
+8 0 D
+0 3 D
+-7 -1 D
+P
+FO
+3165 3559 M
+3 1 D
+-8 -1 D
+P
+FO
+3189 3552 M
+1 1 D
+-3 -3 D
+P
+FO
+3260 3610 M
+5 -1 D
+P
+FO
+3089 3582 M
+3 -1 D
+0 2 D
+P
+FO
+3186 3553 M
+1 -2 D
+2 2 D
+P
+FO
+3293 3662 M
+4 0 D
+-4 1 D
+P
+FO
+3252 3585 M
+5 0 D
+1 2 D
+P
+FO
+3228 3552 M
+4 -1 D
+0 1 D
+P
+FO
+3077 3589 M
+5 -2 D
+2 1 D
+P
+FO
+3149 3562 M
+8 1 D
+4 2 D
+P
+FO
+3171 3555 M
+2 0 D
+P
+FO
+3119 3565 M
+-7 -2 D
+P
+FO
+3098 3575 M
+8 0 D
+P
+FO
+3206 3546 M
+6 -2 D
+P
+FO
+3279 3643 M
+3 -1 D
+P
+FO
+3156 3566 M
+3 1 D
+P
+FO
+3283 3625 M
+3 0 D
+-3 1 D
+P
+FO
+3245 3600 M
+3 -1 D
+P
+FO
+3134 3562 M
+3 -1 D
+P
+FO
+3256 3597 M
+2 -1 D
+P
+FO
+3119 3565 M
+3 1 D
+P
+FO
+3077 3584 M
+2 1 D
+P
+FO
+3079 3589 M
+3 0 D
+P
+FO
+3181 3555 M
+1 0 D
+P
+FO
+3253 3581 M
+3 1 D
+P
+FO
+3073 3596 M
+3 0 D
+P
+FO
+3126 3562 M
+2 0 D
+P
+FO
+3113 3569 M
+2 0 D
+P
+FO
+3162 3564 M
+2 0 D
+P
+FO
+3142 3562 M
+2 0 D
+P
+FO
+3159 3562 M
+2 0 D
+P
+FO
+3304 3661 M
+1 -1 D
+P
+FO
+3230 3555 M
+2 0 D
+P
+FO
+3113 3568 M
+2 0 D
+P
+FO
+3109 3569 M
+8 -1 D
+P
+FO
+3236 3563 M
+8 1 D
+P
+FO
+3269 3612 M
+3 2 D
+P
+FO
+3274 3644 M
+6 0 D
+P
+FO
+3108 3570 M
+5 0 D
+P
+FO
+3081 3584 M
+5 0 D
+P
+FO
+3165 3558 M
+5 1 D
+P
+FO
+3076 3595 M
+4 0 D
+P
+FO
+3154 3560 M
+5 1 D
+P
+FO
+3096 3573 M
+5 1 D
+P
+FO
+3286 3629 M
+5 0 D
+-4 0 D
+P
+FO
+3153 3567 M
+1 -2 D
+P
+FO
+3230 3548 M
+3 -2 D
+P
+FO
+3153 3560 M
+4 -1 D
+P
+FO
+3150 3561 M
+3 0 D
+P
+FO
+3182 3546 M
+3 1 D
+P
+FO
+3145 3561 M
+4 0 D
+P
+FO
+3246 3606 M
+4 -1 D
+P
+FO
+3155 3562 M
+4 0 D
+P
+FO
+3252 3606 M
+5 0 D
+P
+FO
+3137 3563 M
+3 1 D
+P
+FO
+3179 3553 M
+2 1 D
+P
+FO
+3297 3645 M
+3 1 D
+P
+FO
+3166 3561 M
+2 1 D
+-2 0 D
+P
+FO
+3280 3623 M
+3 -1 D
+P
+FO
+3103 3568 M
+3 0 D
+P
+FO
+3286 3645 M
+6 0 D
+P
+FO
+3137 3564 M
+3 1 D
+P
+FO
+3254 3593 M
+3 -1 D
+P
+FO
+3543 3738 M
+0 -2 D
+P
+FO
+3307 3673 M
+3 0 D
+-1 2 D
+5 -2 D
+3 4 D
+4 0 D
+1 -3 D
+3 2 D
+0 -2 D
+0 2 D
+3 -1 D
+-3 4 D
+9 -6 D
+2 3 D
+6 -1 D
+-4 3 D
+5 -2 D
+0 2 D
+3 -1 D
+-2 -2 D
+2 2 D
+4 -1 D
+3 4 D
+-5 0 D
+-4 4 D
+4 -2 D
+4 1 D
+-2 1 D
+4 -2 D
+2 5 D
+-5 0 D
+4 0 D
+3 2 D
+-2 1 D
+3 1 D
+0 -2 D
+3 2 D
+-12 2 D
+7 0 D
+0 2 D
+6 -3 D
+11 0 D
+-14 -6 D
+0 -2 D
+3 0 D
+-4 -2 D
+3 1 D
+11 -4 D
+-2 2 D
+4 -1 D
+1 1 D
+-9 4 D
+9 -3 D
+-4 5 D
+3 -3 D
+2 3 D
+1 -5 D
+12 2 D
+-3 3 D
+7 0 D
+-1 -3 D
+3 1 D
+-1 -1 D
+4 -1 D
+4 4 D
+5 0 D
+-6 0 D
+7 1 D
+-2 2 D
+4 -2 D
+-3 2 D
+4 1 D
+-6 0 D
+3 2 D
+-5 3 D
+7 -4 D
+3 1 D
+9 -2 D
+-5 1 D
+3 2 D
+3 -2 D
+6 1 D
+8 5 D
+-5 2 D
+5 2 D
+1 -3 D
+3 2 D
+-2 -3 D
+7 4 D
+-2 2 D
+5 -1 D
+-4 3 D
+5 2 D
+-4 1 D
+7 -1 D
+-4 1 D
+10 3 D
+-5 2 D
+9 1 D
+-6 2 D
+8 1 D
+-3 4 D
+7 2 D
+-3 1 D
+6 0 D
+10 4 D
+9 0 D
+-1 2 D
+4 0 D
+-3 2 D
+4 3 D
+-12 1 D
+9 0 D
+-14 8 D
+3 3 D
+5 -5 D
+4 1 D
+4 -5 D
+12 -1 D
+-6 -1 D
+4 -3 D
+6 2 D
+-2 -1 D
+12 -1 D
+-5 3 D
+6 -3 D
+9 0 D
+-6 5 D
+9 -1 D
+0 -3 D
+8 1 D
+-7 3 D
+8 -1 D
+0 42 D
+-236 0 D
+P
+FO
+3307 3665 M
+3 0 D
+1 2 D
+4 0 D
+-5 3 D
+4 1 D
+-7 1 D
+P
+FO
+3307 3663 M
+2 0 D
+-2 1 D
+P
+FO
+3355 3676 M
+6 -1 D
+1 2 D
+2 -2 D
+7 2 D
+-4 1 D
+0 2 D
+6 -1 D
+-10 4 D
+-7 -3 D
+P
+FO
+3378 3677 M
+-2 1 D
+-4 -1 D
+6 -2 D
+P
+FO
+3464 3717 M
+2 -1 D
+0 2 D
+P
+FO
+3333 3673 M
+5 0 D
+-1 2 D
+P
+FO
+3351 3682 M
+3 -1 D
+P
+FO
+3449 3704 M
+3 0 D
+-4 1 D
+P
+FO
+3384 3682 M
+3 -2 D
+3 4 D
+P
+FO
+3378 3680 M
+4 -2 D
+2 4 D
+P
+FO
+3496 3737 M
+5 0 D
+0 1 D
+P
+FO
+3393 3681 M
+4 1 D
+-2 1 D
+P
+FO
+3394 3680 M
+3 -1 D
+-2 2 D
+P
+FO
+3379 3679 M
+2 -1 D
+P
+FO
+3312 3665 M
+4 0 D
+P
+FO
+3315 3672 M
+4 -2 D
+P
+FO
+3459 3711 M
+3 0 D
+-3 1 D
+P
+FO
+3313 3669 M
+2 -1 D
+P
+FO
+3474 3723 M
+2 1 D
+P
+FO
+3410 3685 M
+0 1 D
+P
+FO
+3313 3669 M
+8 -1 D
+P
+FO
+3372 3675 M
+5 -1 D
+P
+FO
+3411 3689 M
+4 2 D
+P
+FO
+3460 3712 M
+4 2 D
+-4 -1 D
+P
+FO
+3378 3679 M
+1 -1 D
+P
+FO
+3323 3673 M
+4 0 D
+P
+FO
+3311 3661 M
+3 0 D
+P
+FO
+3310 3663 M
+4 0 D
+P
+FO
+3378 3675 M
+3 0 D
+P
+FO
+3381 3677 M
+1 -2 D
+P
+FO
+3455 3711 M
+3 -1 D
+P
+FO
+3780 3640 M
+-4 -1 D
+4 1 D
+0 34 D
+-3 0 D
+3 0 D
+0 12 D
+-3 2 D
+-7 -1 D
+3 -10 D
+-8 -1 D
+4 -1 D
+-1 -2 D
+-2 2 D
+-2 -1 D
+0 4 D
+-6 -3 D
+0 -5 D
+-4 2 D
+0 -7 D
+-3 7 D
+-2 1 D
+-4 -1 D
+4 3 D
+-4 0 D
+2 1 D
+-6 1 D
+-4 3 D
+5 -2 D
+6 1 D
+-3 1 D
+4 1 D
+0 2 D
+-7 1 D
+6 1 D
+-4 0 D
+-1 2 D
+-3 -2 D
+-1 4 D
+-7 1 D
+2 1 D
+-4 1 D
+-3 -1 D
+-5 5 D
+-17 -1 D
+4 -1 D
+-5 -1 D
+4 -1 D
+10 2 D
+-2 -2 D
+4 1 D
+-1 -2 D
+5 0 D
+-4 -1 D
+-11 0 D
+13 -3 D
+0 -6 D
+-3 -1 D
+3 3 D
+-2 2 D
+-3 -4 D
+-1 5 D
+-4 -4 D
+1 3 D
+-4 -2 D
+3 3 D
+-5 -2 D
+2 3 D
+-4 -1 D
+0 2 D
+-7 2 D
+-4 -2 D
+6 -1 D
+-7 1 D
+7 -3 D
+-9 2 D
+-2 -2 D
+15 -4 D
+-16 1 D
+4 -2 D
+12 0 D
+-8 -2 D
+7 -1 D
+-7 -1 D
+-2 2 D
+-11 2 D
+1 -2 D
+6 -2 D
+-7 0 D
+7 -2 D
+-12 3 D
+-5 -4 D
+18 -2 D
+8 3 D
+5 -1 D
+1 2 D
+7 0 D
+0 1 D
+0 -2 D
+3 -1 D
+-1 3 D
+3 -2 D
+2 3 D
+2 -4 D
+9 3 D
+-7 -3 D
+2 -1 D
+5 2 D
+3 -2 D
+7 0 D
+-22 -6 D
+13 -2 D
+7 2 D
+-1 -4 D
+-17 1 D
+-1 -2 D
+-4 2 D
+-7 -2 D
+0 -1 D
+-4 2 D
+-1 -2 D
+-3 1 D
+-6 -2 D
+-10 0 D
+6 -4 D
+10 2 D
+16 -1 D
+0 1 D
+1 -1 D
+6 1 D
+-1 -3 D
+3 0 D
+-3 -1 D
+2 -2 D
+3 1 D
+0 -3 D
+12 3 D
+-8 -5 D
+5 0 D
+-6 -2 D
+17 2 D
+-11 -2 D
+-2 -2 D
+5 -1 D
+-8 0 D
+4 -1 D
+-15 -4 D
+-4 3 D
+0 -7 D
+35 2 D
+-1 1 D
+5 0 D
+-4 -1 D
+10 -3 D
+2 3 D
+2 -3 D
+-4 0 D
+5 -2 D
+1 2 D
+8 -5 D
+5 -1 D
+P
+3754 3644 M
+1 -3 D
+-3 0 D
+P
+3772 3638 M
+-7 -2 D
+7 3 D
+P
+3743 3651 M
+6 -2 D
+P
+3734 3637 M
+-2 -1 D
+P
+FO
+3607 3780 M
+-2 -2 D
+-2 2 D
+-60 0 D
+0 -39 D
+1 2 D
+13 -6 D
+3 3 D
+4 -1 D
+-1 3 D
+8 -2 D
+7 3 D
+6 -1 D
+-1 2 D
+7 -1 D
+1 3 D
+8 -2 D
+-3 1 D
+5 1 D
+8 -1 D
+-2 2 D
+6 -1 D
+8 3 D
+0 -1 D
+8 0 D
+2 3 D
+8 0 D
+2 2 D
+6 0 D
+-3 2 D
+7 0 D
+-6 1 D
+3 1 D
+-2 1 D
+8 -2 D
+-1 3 D
+8 0 D
+0 2 D
+-6 0 D
+15 1 D
+-3 4 D
+7 -2 D
+2 3 D
+7 -1 D
+0 2 D
+-6 2 D
+12 -2 D
+4 1 D
+0 3 D
+-6 2 D
+16 0 D
+-3 2 D
+8 -2 D
+3 1 D
+-10 1 D
+7 1 D
+0 1 D
+6 -1 D
+-4 1 D
+8 0 D
+5 2 D
+P
+FO
+3543 3736 M
+5 0 D
+-5 2 D
+P
+FO
+3694 3773 M
+5 -2 D
+5 1 D
+P
+FO
+3772 3625 M
+1 -1 D
+P
+FO
+3780 3674 M
+0 -1 D
+0 1 D
+0 -34 D
+1 0 D
+-1 0 D
+0 -14 D
+29 -3 D
+14 2 D
+-3 0 D
+-2 2 D
+3 -1 D
+10 3 D
+-4 0 D
+5 1 D
+-5 0 D
+4 2 D
+19 1 D
+3 2 D
+3 -2 D
+0 1 D
+7 2 D
+-1 -1 D
+13 6 D
+18 2 D
+-5 1 D
+1 1 D
+10 -2 D
+1 3 D
+0 -1 D
+5 3 D
+3 -1 D
+2 1 D
+3 4 D
+-5 -1 D
+4 1 D
+-2 1 D
+5 0 D
+-6 3 D
+10 -2 D
+1 3 D
+7 1 D
+-7 2 D
+9 -1 D
+-13 3 D
+5 1 D
+8 -2 D
+4 2 D
+0 2 D
+-3 -2 D
+0 3 D
+-9 0 D
+10 2 D
+-10 0 D
+7 1 D
+-3 1 D
+5 1 D
+1 3 D
+-5 0 D
+-2 2 D
+-11 1 D
+1 3 D
+-12 -2 D
+5 7 D
+-14 3 D
+6 2 D
+-2 1 D
+12 3 D
+-10 0 D
+-9 -3 D
+-2 -2 D
+-7 1 D
+0 4 D
+-12 4 D
+-8 -1 D
+3 -5 D
+-7 -3 D
+3 -2 D
+-3 2 D
+-5 -1 D
+-5 2 D
+-6 -5 D
+-5 0 D
+-8 4 D
+-8 0 D
+6 -12 D
+-4 5 D
+-14 8 D
+-6 -1 D
+0 -3 D
+-9 0 D
+1 -8 D
+-6 1 D
+-8 7 D
+P
+3871 3671 M
+3 -2 D
+-5 -3 D
+4 3 D
+P
+3868 3677 M
+3 -4 D
+-6 8 D
+P
+3912 3672 M
+0 -2 D
+0 3 D
+P
+3806 3644 M
+-2 -1 D
+3 3 D
+P
+3912 3670 M
+-10 -7 D
+P
+3839 3681 M
+-2 -3 D
+P
+3800 3647 M
+8 3 D
+P
+3844 3634 M
+-1 -1 D
+1 2 D
+P
+3848 3636 M
+-1 -2 D
+P
+3821 3641 M
+-2 0 D
+P
+3852 3676 M
+-3 -1 D
+3 2 D
+P
+FO
+3827 3627 M
+3 1 D
+-8 -3 D
+P
+FO
+3860 3634 M
+1 1 D
+P
+FO
+3853 3635 M
+1 -1 D
+P
+FO
+3843 3633 M
+3 0 D
+P
+FO
+3856 3633 M
+3 0 D
+P
+FO
+3850 3633 M
+-2 0 D
+P
+FO
+3852 3633 M
+3 0 D
+P
+FO
+3831 3630 M
+2 1 D
+-2 0 D
+P
+FO
+4224 3543 M
+1 4 D
+-2 2 D
+3 0 D
+-2 3 D
+3 2 D
+-5 -1 D
+1 2 D
+-4 -2 D
+2 5 D
+-4 -2 D
+-4 -1 D
+5 0 D
+-1 -3 D
+5 0 D
+-2 -2 D
+-3 1 D
+0 -1 D
+-5 0 D
+5 -3 D
+1 2 D
+3 0 D
+-1 -6 D
+P
+FO
+4087 3599 M
+-3 -1 D
+10 -6 D
+0 2 D
+2 0 D
+-4 1 D
+3 0 D
+-5 3 D
+-2 -2 D
+P
+FO
+4228 3560 M
+-3 1 D
+-2 -3 D
+2 -3 D
+3 0 D
+P
+FO
+4229 3560 M
+3 -1 D
+2 4 D
+-3 0 D
+P
+FO
+4076 3594 M
+5 -3 D
+4 1 D
+-4 2 D
+P
+FO
+4092 3591 M
+-11 7 D
+-1 -3 D
+13 -6 D
+P
+FO
+4095 3596 M
+5 -1 D
+-4 4 D
+P
+FO
+4087 3582 M
+4 -4 D
+3 0 D
+P
+FO
+4088 3588 M
+7 -3 D
+0 2 D
+P
+FO
+4230 3558 M
+1 -1 D
+3 1 D
+P
+FO
+4100 3597 M
+3 0 D
+P
+FO
+4091 3599 M
+3 -3 D
+P
+FO
+4225 3547 M
+2 -1 D
+P
+FO
+4096 3600 M
+4 -3 D
+P
+FO
+4228 3552 M
+3 0 D
+P
+FO
+4071 3593 M
+3 0 D
+P
+FO
+4088 3590 M
+2 -1 D
+P
+FO
+4488 3413 M
+-3 0 D
+3 1 D
+-1 6 D
+-8 2 D
+-4 -1 D
+4 3 D
+3 -3 D
+1 2 D
+-4 3 D
+-4 0 D
+7 5 D
+-4 0 D
+2 1 D
+-1 3 D
+2 1 D
+-5 1 D
+6 0 D
+3 3 D
+-7 2 D
+10 0 D
+0 3 D
+-3 0 D
+3 0 D
+0 42 D
+-14 -11 D
+-19 -1 D
+-8 -8 D
+7 -5 D
+-6 0 D
+-2 4 D
+-2 -4 D
+1 -19 D
+-2 -5 D
+5 -2 D
+0 3 D
+9 -6 D
+-1 -10 D
+-6 0 D
+0 3 D
+-3 -7 D
+2 3 D
+6 0 D
+3 -4 D
+-5 -2 D
+11 -2 D
+-4 -1 D
+5 0 D
+-9 -2 D
+-1 -2 D
+9 0 D
+-4 -3 D
+5 -2 D
+0 -2 D
+-4 0 D
+1 -2 D
+7 0 D
+9 -7 D
+6 -2 D
+-7 1 D
+-6 6 D
+-14 1 D
+-5 -5 D
+3 -3 D
+-2 -4 D
+1 4 D
+-7 1 D
+1 -3 D
+-2 -2 D
+-3 2 D
+2 2 D
+-5 4 D
+-16 -1 D
+-4 -2 D
+-2 -6 D
+7 0 D
+2 -3 D
+-2 2 D
+-5 -1 D
+-7 5 D
+-15 -2 D
+3 -1 D
+-10 1 D
+-11 -4 D
+-2 -3 D
+1 -5 D
+8 -1 D
+-3 -4 D
+6 -2 D
+-9 -1 D
+-8 -4 D
+3 -1 D
+-8 1 D
+5 2 D
+-2 0 D
+0 4 D
+4 0 D
+2 3 D
+-4 0 D
+-2 5 D
+-4 -2 D
+-3 2 D
+-3 -11 D
+-11 -13 D
+-3 0 D
+1 -3 D
+14 -2 D
+-13 -2 D
+2 -2 D
+-5 1 D
+6 -2 D
+0 -2 D
+-9 4 D
+-10 -2 D
+9 -3 D
+4 2 D
+6 -3 D
+-6 1 D
+-4 -1 D
+-7 1 D
+-24 -7 D
+-22 -5 D
+-1 -14 D
+3 -3 D
+-3 1 D
+-7 -5 D
+207 0 D
+P
+4454 3463 M
+1 2 D
+-4 0 D
+1 2 D
+8 5 D
+7 1 D
+-2 2 D
+5 -3 D
+13 3 D
+4 -2 D
+-6 0 D
+-3 -2 D
+0 1 D
+-4 0 D
+-5 -2 D
+0 -6 D
+2 1 D
+3 -4 D
+-6 3 D
+-2 -2 D
+0 6 D
+-9 -5 D
+1 -3 D
+-4 2 D
+P
+4462 3470 M
+-6 -1 D
+-3 -3 D
+6 -1 D
+P
+4444 3458 M
+2 0 D
+2 -2 D
+-1 -1 D
+-3 2 D
+P
+4362 3348 M
+3 2 D
+-2 -2 D
+3 0 D
+P
+4445 3451 M
+5 -5 D
+-4 -2 D
+P
+4372 3359 M
+-1 -1 D
+P
+4474 3366 M
+-3 -1 D
+P
+4482 3413 M
+-4 1 D
+P
+4390 3376 M
+-2 -1 D
+P
+4486 3416 M
+1 0 D
+-5 -2 D
+P
+4446 3453 M
+0 -1 D
+P
+4364 3360 M
+-1 0 D
+P
+4385 3377 M
+-4 -1 D
+P
+4396 3371 M
+-2 -1 D
+P
+4443 3342 M
+2 0 D
+P
+4394 3369 M
+-3 0 D
+P
+FO
+4488 3425 M
+-8 2 D
+5 -3 D
+-2 1 D
+0 -2 D
+5 -1 D
+P
+FO
+4488 3438 M
+-7 -1 D
+3 -1 D
+-2 0 D
+6 -8 D
+P
+FO
+4488 3522 M
+-3 2 D
+3 -2 D
+0 12 D
+-4 2 D
+4 -2 D
+0 9 D
+-94 0 D
+-8 -3 D
+5 -2 D
+2 2 D
+1 -3 D
+8 3 D
+-6 -3 D
+-4 1 D
+-3 -4 D
+-5 2 D
+-3 -5 D
+1 6 D
+-2 -4 D
+-1 2 D
+-4 -3 D
+3 -6 D
+1 4 D
+1 -3 D
+1 2 D
+2 -3 D
+2 4 D
+-4 0 D
+4 2 D
+0 -6 D
+6 2 D
+-1 2 D
+-4 -1 D
+4 3 D
+6 -1 D
+-4 -1 D
+1 -2 D
+8 7 D
+-1 -3 D
+8 1 D
+-8 -1 D
+-6 -4 D
+5 -1 D
+0 2 D
+2 -2 D
+-4 0 D
+0 -1 D
+10 1 D
+-9 -1 D
+-4 -3 D
+4 0 D
+-7 -1 D
+5 -3 D
+-2 0 D
+1 -1 D
+14 3 D
+-13 -3 D
+4 -2 D
+-9 3 D
+-3 -3 D
+0 4 D
+-4 0 D
+2 -2 D
+-2 1 D
+-2 -5 D
+4 -5 D
+18 -7 D
+5 0 D
+0 1 D
+2 -2 D
+5 2 D
+-9 -4 D
+6 -2 D
+1 4 D
+1 -2 D
+3 0 D
+-4 -1 D
+2 1 D
+0 -2 D
+3 2 D
+-2 -2 D
+3 1 D
+-2 -2 D
+4 1 D
+9 -1 D
+9 2 D
+2 4 D
+0 -3 D
+4 0 D
+1 2 D
+3 0 D
+9 6 D
+4 0 D
+0 4 D
+2 -2 D
+4 3 D
+1 2 D
+-4 -1 D
+9 2 D
+-3 2 D
+4 0 D
+0 1 D
+6 1 D
+-5 4 D
+3 -2 D
+3 1 D
+1 -3 D
+4 1 D
+P
+4440 3543 M
+8 -4 D
+-5 1 D
+3 -2 D
+-5 1 D
+P
+4470 3528 M
+6 -4 D
+-7 4 D
+P
+4435 3538 M
+7 -3 D
+-8 3 D
+P
+4452 3527 M
+0 -7 D
+P
+4442 3530 M
+9 -2 D
+P
+4459 3543 M
+6 -6 D
+P
+4435 3516 M
+1 -6 D
+-2 6 D
+P
+4469 3521 M
+4 -2 D
+P
+4461 3515 M
+-4 -1 D
+P
+4410 3512 M
+-1 -6 D
+P
+4407 3506 M
+-1 -2 D
+P
+4463 3527 M
+-6 0 D
+P
+4428 3541 M
+2 -2 D
+P
+4442 3524 M
+5 -4 D
+P
+FO
+4388 3543 M
+2 0 D
+P
+FO
+4379 3543 M
+7 -2 D
+0 2 D
+P
+FO
+4379 3543 M
+P
+FO
+4376 3543 M
+P
+FO
+4252 3392 M
+3 -1 D
+-3 5 D
+P
+FO
+4252 3375 M
+8 7 D
+-4 7 D
+-4 2 D
+P
+FO
+4252 3326 M
+6 -2 D
+12 5 D
+5 0 D
+2 3 D
+8 2 D
+1 6 D
+-13 -1 D
+-3 1 D
+3 -1 D
+0 2 D
+-3 0 D
+-2 -1 D
+-4 0 D
+4 2 D
+-10 0 D
+16 3 D
+-2 0 D
+2 3 D
+-6 0 D
+7 1 D
+0 2 D
+2 -2 D
+4 1 D
+1 3 D
+-5 0 D
+5 0 D
+-2 2 D
+3 -2 D
+6 3 D
+5 10 D
+-2 6 D
+-9 4 D
+-18 1 D
+-4 -4 D
+-8 3 D
+P
+FO
+4346 3345 M
+3 1 D
+-7 2 D
+2 1 D
+5 -2 D
+7 0 D
+-9 4 D
+-8 -4 D
+P
+FO
+4373 3538 M
+3 0 D
+1 -2 D
+2 0 D
+-5 4 D
+P
+FO
+4378 3538 M
+4 0 D
+-1 4 D
+-3 1 D
+-1 -2 D
+P
+FO
+4365 3378 M
+3 2 D
+-1 2 D
+-4 -2 D
+P
+FO
+4394 3527 M
+-2 -2 D
+4 1 D
+P
+FO
+4374 3524 M
+3 -1 D
+-1 6 D
+P
+FO
+4452 3428 M
+2 -1 D
+1 3 D
+P
+FO
+4385 3539 M
+3 -2 D
+2 1 D
+P
+FO
+4370 3385 M
+-3 -2 D
+5 2 D
+P
+FO
+4448 3417 M
+2 -1 D
+-1 2 D
+P
+FO
+4379 3524 M
+2 -1 D
+-1 2 D
+P
+FO
+4417 3394 M
+3 0 D
+-6 0 D
+P
+FO
+4384 3388 M
+9 1 D
+-9 0 D
+P
+FO
+4437 3397 M
+3 -1 D
+P
+FO
+4375 3541 M
+1 -1 D
+P
+FO
+4426 3395 M
+2 0 D
+P
+FO
+4477 3517 M
+2 1 D
+P
+FO
+4386 3521 M
+2 0 D
+P
+FO
+4477 3516 M
+2 1 D
+P
+FO
+4449 3436 M
+3 -3 D
+P
+FO
+4384 3523 M
+5 -1 D
+P
+FO
+4450 3418 M
+5 1 D
+-5 0 D
+P
+FO
+4397 3389 M
+5 1 D
+P
+FO
+4455 3414 M
+3 1 D
+P
+FO
+4374 3387 M
+10 2 D
+P
+FO
+4409 3392 M
+4 0 D
+P
+FO
+4388 3523 M
+3 1 D
+P
+FO
+4373 3543 M
+2 0 D
+P
+FO
+4421 3395 M
+5 0 D
+P
+FO
+4406 3502 M
+3 -1 D
+P
+FO
+4428 3395 M
+4 1 D
+P
+FO
+4394 3525 M
+2 0 D
+P
+FO
+4433 3396 M
+4 0 D
+P
+FO
+4384 3522 M
+3 -1 D
+P
+FO
+4475 3516 M
+3 0 D
+P
+FO
+4385 3537 M
+2 -1 D
+P
+FO
+4444 3395 M
+1 0 D
+P
+FO
+4381 3526 M
+1 -1 D
+P
+FO
+4724 3395 M
+0 1 D
+0 -1 D
+0 20 D
+-14 -8 D
+0 1 D
+-3 0 D
+-1 2 D
+9 2 D
+7 5 D
+-9 -6 D
+-17 -1 D
+-5 2 D
+-4 8 D
+9 -4 D
+0 1 D
+-11 4 D
+-9 0 D
+-34 -7 D
+-9 -6 D
+-33 -6 D
+1 -2 D
+-6 -5 D
+2 -3 D
+-7 3 D
+-2 -1 D
+1 2 D
+-11 2 D
+3 2 D
+-4 2 D
+-1 3 D
+-6 -1 D
+-8 4 D
+-2 4 D
+-6 -2 D
+-2 1 D
+-7 -4 D
+1 4 D
+12 1 D
+-10 1 D
+-10 -7 D
+1 -2 D
+-2 2 D
+-9 -1 D
+-4 -2 D
+2 1 D
+-3 -5 D
+-7 3 D
+-7 -1 D
+-3 2 D
+8 3 D
+1 5 D
+-10 -2 D
+-9 3 D
+-4 -3 D
+0 4 D
+-4 0 D
+0 -106 D
+236 0 D
+P
+4714 3393 M
+2 1 D
+-3 2 D
+3 1 D
+1 -1 D
+-3 -4 D
+P
+4552 3389 M
+2 -2 D
+-2 -1 D
+-3 2 D
+P
+4511 3393 M
+-1 -2 D
+-1 2 D
+P
+4499 3405 M
+-1 -1 D
+-2 1 D
+P
+4675 3400 M
+-1 2 D
+3 0 D
+P
+4663 3418 M
+-2 0 D
+5 1 D
+-3 -2 D
+P
+4524 3396 M
+0 -4 D
+-2 3 D
+P
+4543 3393 M
+-1 -1 D
+P
+4599 3390 M
+-1 -3 D
+P
+4543 3390 M
+0 -3 D
+P
+4603 3383 M
+2 3 D
+P
+4557 3398 M
+-2 -2 D
+P
+4581 3360 M
+-1 -1 D
+P
+4557 3364 M
+1 -1 D
+P
+4544 3391 M
+0 -1 D
+P
+4580 3383 M
+-1 -1 D
+P
+4643 3392 M
+-2 0 D
+P
+4623 3377 M
+-2 0 D
+P
+4570 3386 M
+-1 -1 D
+P
+4675 3365 M
+-1 -1 D
+P
+4609 3381 M
+-2 1 D
+P
+4628 3360 M
+-1 -1 D
+P
+4658 3396 M
+0 1 D
+1 -2 D
+P
+4558 3363 M
+-1 -1 D
+P
+4603 3377 M
+0 -1 D
+P
+4720 3394 M
+2 0 D
+P
+4672 3408 M
+0 1 D
+P
+4547 3309 M
+-2 -1 D
+P
+4670 3406 M
+1 1 D
+P
+4497 3401 M
+2 0 D
+P
+4668 3408 M
+0 1 D
+P
+4637 3393 M
+2 0 D
+P
+4655 3417 M
+3 0 D
+P
+4500 3409 M
+-3 0 D
+P
+4565 3391 M
+-2 -2 D
+P
+4548 3390 M
+2 -1 D
+P
+4547 3364 M
+-2 0 D
+P
+4680 3325 M
+2 -1 D
+-2 0 D
+P
+4656 3318 M
+1 0 D
+P
+4588 3357 M
+-1 -2 D
+P
+4510 3400 M
+1 0 D
+-5 -1 D
+P
+4635 3391 M
+-1 2 D
+P
+4506 3396 M
+0 -2 D
+P
+4564 3366 M
+-2 -2 D
+P
+4551 3395 M
+-2 -1 D
+P
+4665 3395 M
+0 2 D
+P
+4724 3399 M
+0 2 D
+P
+4686 3370 M
+0 -3 D
+P
+4629 3388 M
+-3 1 D
+P
+4679 3419 M
+-1 1 D
+P
+4582 3377 M
+1 0 D
+0 -1 D
+P
+4547 3390 M
+-1 -1 D
+P
+4720 3397 M
+-1 2 D
+P
+4579 3385 M
+0 -1 D
+P
+4576 3377 M
+1 0 D
+-3 -1 D
+P
+4630 3352 M
+1 -1 D
+P
+4677 3365 M
+-1 -2 D
+P
+4676 3407 M
+3 2 D
+P
+4712 3403 M
+-1 1 D
+P
+4584 3361 M
+-1 -2 D
+P
+4593 3346 M
+-1 -1 D
+P
+4645 3398 M
+2 0 D
+P
+FO
+4724 3423 M
+-1 0 D
+-1 -6 D
+2 2 D
+P
+FO
+4561 3543 M
+1 -3 D
+-1 3 D
+-65 0 D
+-1 -2 D
+-4 2 D
+-3 0 D
+0 -9 D
+2 -1 D
+-2 1 D
+1 -13 D
+-1 1 D
+0 -2 D
+1 1 D
+4 -1 D
+1 3 D
+1 -2 D
+3 5 D
+0 -5 D
+2 9 D
+-6 3 D
+3 -1 D
+1 2 D
+1 -2 D
+4 1 D
+-4 6 D
+7 2 D
+0 -3 D
+-2 2 D
+-2 -2 D
+2 -6 D
+-2 -2 D
+2 -3 D
+3 0 D
+1 -3 D
+2 1 D
+4 -2 D
+2 1 D
+2 -2 D
+-4 -3 D
+5 -9 D
+-2 -2 D
+3 0 D
+-3 -4 D
+6 3 D
+-3 -3 D
+3 1 D
+-1 -3 D
+3 5 D
+3 -1 D
+-7 -5 D
+1 -4 D
+6 1 D
+-5 -1 D
+2 -3 D
+4 2 D
+-1 2 D
+4 4 D
+-4 1 D
+-5 -2 D
+5 3 D
+5 0 D
+-5 -12 D
+4 -1 D
+-4 -2 D
+6 0 D
+-2 -1 D
+3 -4 D
+-2 -2 D
+3 -2 D
+2 3 D
+0 -5 D
+2 0 D
+4 -7 D
+6 -3 D
+3 -4 D
+5 -1 D
+-2 -4 D
+-6 0 D
+4 -5 D
+-8 2 D
+15 -15 D
+-4 -2 D
+1 -3 D
+-3 -2 D
+13 -1 D
+12 2 D
+7 -1 D
+4 4 D
+-3 4 D
+0 3 D
+7 5 D
+6 -1 D
+-2 4 D
+16 -1 D
+5 2 D
+0 -2 D
+6 1 D
+0 -2 D
+10 13 D
+3 0 D
+-1 3 D
+3 0 D
+-2 0 D
+1 6 D
+1 -1 D
+2 1 D
+-2 1 D
+3 0 D
+-3 5 D
+6 4 D
+-1 2 D
+-4 1 D
+1 1 D
+3 -1 D
+-2 3 D
+3 -1 D
+0 1 D
+-7 4 D
+7 -3 D
+-6 4 D
+8 -1 D
+0 3 D
+-2 -1 D
+-2 1 D
+4 1 D
+-3 3 D
+4 -1 D
+-4 3 D
+3 1 D
+-4 1 D
+4 1 D
+-9 2 D
+7 -1 D
+5 1 D
+-4 3 D
+-14 1 D
+18 -1 D
+3 1 D
+-3 1 D
+6 0 D
+-4 1 D
+2 1 D
+1 -1 D
+9 2 D
+-2 2 D
+3 -1 D
+-1 1 D
+2 0 D
+1 7 D
+1 -3 D
+2 1 D
+-1 -4 D
+4 -3 D
+2 5 D
+11 4 D
+-5 2 D
+3 0 D
+-2 2 D
+5 -3 D
+3 1 D
+-5 1 D
+3 -1 D
+3 1 D
+-3 1 D
+2 0 D
+-4 2 D
+0 -3 D
+-2 1 D
+-7 -1 D
+0 3 D
+6 -1 D
+-2 2 D
+20 6 D
+-9 0 D
+5 3 D
+-1 2 D
+4 -3 D
+1 1 D
+-5 3 D
+P
+4630 3532 M
+7 -2 D
+6 2 D
+0 2 D
+5 -2 D
+1 2 D
+7 -2 D
+-1 2 D
+8 -4 D
+0 5 D
+3 -4 D
+5 -1 D
+2 2 D
+-8 3 D
+1 2 D
+-3 0 D
+5 1 D
+-1 -3 D
+4 -1 D
+0 1 D
+3 -2 D
+-2 -4 D
+5 -1 D
+-3 -3 D
+-6 1 D
+0 -1 D
+-5 2 D
+0 -1 D
+-5 0 D
+3 2 D
+-6 0 D
+-5 3 D
+-18 -1 D
+P
+4659 3530 M
+-4 1 D
+5 -2 D
+P
+4671 3529 M
+-3 1 D
+4 -3 D
+P
+4654 3532 M
+-2 -1 D
+3 -2 D
+P
+4667 3530 M
+1 -3 D
+5 -1 D
+P
+4665 3529 M
+1 -1 D
+P
+4673 3528 M
+1 -1 D
+P
+4651 3533 M
+0 -1 D
+P
+4584 3527 M
+-3 -5 D
+3 -1 D
+0 1 D
+1 -1 D
+-6 -8 D
+-11 -2 D
+-3 -3 D
+-3 0 D
+1 2 D
+-4 0 D
+-10 -6 D
+1 3 D
+-7 -2 D
+7 6 D
+-5 4 D
+3 0 D
+-2 4 D
+3 -4 D
+3 6 D
+4 1 D
+9 -5 D
+-4 9 D
+2 2 D
+2 -1 D
+10 2 D
+2 -2 D
+P
+4562 3512 M
+-2 -1 D
+4 0 D
+P
+4572 3527 M
+-3 0 D
+2 -1 D
+P
+4579 3515 M
+-3 1 D
+0 -2 D
+P
+4532 3531 M
+1 -2 D
+3 0 D
+-3 -3 D
+7 -4 D
+0 -3 D
+-8 8 D
+2 -10 D
+-5 11 D
+2 -1 D
+P
+4605 3515 M
+-2 -5 D
+3 -2 D
+-8 -3 D
+-11 -14 D
+-2 4 D
+4 8 D
+6 8 D
+9 6 D
+P
+4592 3498 M
+-3 -2 D
+P
+4620 3527 M
+5 -1 D
+1 1 D
+6 -1 D
+8 1 D
+-17 -4 D
+-4 3 D
+-7 0 D
+P
+4607 3499 M
+1 -2 D
+7 0 D
+0 -4 D
+-3 3 D
+-1 -2 D
+-3 2 D
+P
+4609 3497 M
+1 -2 D
+P
+4597 3467 M
+1 -3 D
+2 2 D
+2 -2 D
+0 -3 D
+-5 2 D
+P
+4654 3521 M
+2 -2 D
+-2 1 D
+-3 -1 D
+-1 3 D
+P
+4539 3528 M
+1 -4 D
+4 2 D
+-1 -4 D
+-5 3 D
+P
+4647 3518 M
+5 -2 D
+-4 -1 D
+-1 3 D
+-6 1 D
+P
+4509 3530 M
+1 -2 D
+-4 1 D
+0 2 D
+2 -2 D
+P
+4579 3473 M
+-5 -6 D
+-1 4 D
+3 3 D
+P
+4577 3472 M
+-1 -2 D
+P
+4557 3535 M
+4 -6 D
+-7 5 D
+2 -1 D
+P
+4601 3473 M
+1 -3 D
+-2 0 D
+-1 2 D
+P
+4590 3512 M
+3 -4 D
+-3 3 D
+-3 -1 D
+P
+4588 3464 M
+-2 -2 D
+0 3 D
+P
+4575 3532 M
+1 -1 D
+-3 1 D
+2 1 D
+P
+4610 3467 M
+-1 -2 D
+-2 2 D
+P
+4630 3542 M
+0 -1 D
+-3 1 D
+P
+4599 3535 M
+-1 -3 D
+-2 3 D
+P
+4619 3521 M
+1 -1 D
+-5 0 D
+P
+4659 3520 M
+1 -2 D
+-3 0 D
+1 2 D
+P
+4547 3535 M
+5 -2 D
+3 -5 D
+-9 7 D
+P
+4591 3521 M
+-2 -4 D
+-4 2 D
+P
+4595 3516 M
+-1 -4 D
+-3 3 D
+P
+4621 3509 M
+8 -1 D
+-9 -1 D
+P
+4639 3503 M
+2 -1 D
+-6 1 D
+P
+4629 3512 M
+3 -2 D
+-5 0 D
+P
+4595 3452 M
+-3 -2 D
+-2 2 D
+P
+4615 3530 M
+0 -1 D
+-2 1 D
+P
+4627 3520 M
+4 -2 D
+-5 0 D
+0 2 D
+P
+4547 3494 M
+-4 -2 D
+2 3 D
+P
+4643 3517 M
+4 -2 D
+-6 2 D
+P
+4514 3542 M
+3 -7 D
+P
+4563 3539 M
+3 -7 D
+-4 7 D
+P
+4626 3494 M
+-2 2 D
+4 1 D
+P
+4584 3476 M
+-2 -4 D
+P
+4613 3509 M
+-5 0 D
+P
+4517 3531 M
+-4 -4 D
+P
+4545 3532 M
+2 -2 D
+P
+4568 3537 M
+0 -3 D
+P
+4546 3485 M
+-6 -2 D
+P
+4586 3475 M
+-2 -4 D
+P
+4604 3505 M
+-4 -1 D
+P
+4590 3538 M
+0 -2 D
+P
+4591 3479 M
+0 -2 D
+0 3 D
+P
+4606 3477 M
+1 -3 D
+P
+4693 3540 M
+-4 0 D
+P
+4572 3470 M
+1 1 D
+-1 -2 D
+P
+4587 3449 M
+1 -1 D
+P
+4598 3522 M
+-3 -1 D
+P
+4592 3456 M
+-3 -2 D
+P
+4633 3489 M
+0 -1 D
+P
+4632 3523 M
+-3 0 D
+P
+4611 3520 M
+-3 0 D
+P
+4557 3541 M
+2 -2 D
+P
+4589 3531 M
+-1 -2 D
+1 3 D
+P
+4572 3446 M
+-1 -1 D
+P
+4568 3491 M
+-2 -2 D
+P
+4604 3459 M
+-2 -1 D
+P
+4594 3462 M
+-3 -1 D
+3 2 D
+P
+4603 3486 M
+0 -2 D
+P
+4582 3537 M
+-1 -2 D
+P
+4596 3527 M
+-3 -1 D
+P
+4596 3469 M
+0 -2 D
+0 3 D
+P
+4555 3525 M
+2 -2 D
+P
+4605 3473 M
+0 -1 D
+P
+4548 3497 M
+-2 -1 D
+3 1 D
+P
+4566 3488 M
+-1 -1 D
+P
+4582 3513 M
+-1 -2 D
+P
+4616 3467 M
+-3 -1 D
+P
+4596 3537 M
+1 -1 D
+P
+4543 3520 M
+-1 -1 D
+P
+4545 3500 M
+-2 -2 D
+P
+FO
+4488 3543 M
+1 0 D
+-1 0 D
+P
+FO
+4488 3445 M
+5 0 D
+1 8 D
+5 3 D
+-2 -3 D
+3 0 D
+1 -2 D
+2 3 D
+2 -2 D
+6 7 D
+-3 2 D
+-14 1 D
+2 3 D
+-5 1 D
+5 0 D
+-2 6 D
+2 0 D
+5 6 D
+-3 8 D
+6 4 D
+-16 -3 D
+P
+FO
+4488 3442 M
+1 0 D
+0 3 D
+-1 0 D
+P
+FO
+4488 3430 M
+4 -2 D
+-2 -1 D
+16 0 D
+0 5 D
+2 0 D
+-4 4 D
+-3 0 D
+5 1 D
+-3 3 D
+0 -3 D
+-4 -1 D
+0 2 D
+2 -1 D
+-5 3 D
+-8 -2 D
+P
+FO
+4488 3422 M
+2 0 D
+-2 3 D
+P
+FO
+4488 3414 M
+1 1 D
+-1 2 D
+P
+FO
+4534 3425 M
+5 0 D
+1 3 D
+-4 1 D
+10 3 D
+-6 4 D
+1 2 D
+7 2 D
+0 -1 D
+4 0 D
+-2 3 D
+-2 -2 D
+0 7 D
+2 3 D
+-7 2 D
+-11 -4 D
+4 0 D
+1 -7 D
+-2 1 D
+-1 -1 D
+3 2 D
+-3 4 D
+-2 -6 D
+-5 1 D
+3 1 D
+-4 1 D
+3 0 D
+-1 3 D
+2 1 D
+-3 -1 D
+-9 2 D
+6 -2 D
+0 -2 D
+-4 0 D
+-2 -3 D
+-9 1 D
+5 -2 D
+-4 0 D
+5 -2 D
+-1 -2 D
+3 -2 D
+-3 -2 D
+4 -3 D
+13 -1 D
+-2 -1 D
+2 -2 D
+-5 1 D
+7 -2 D
+-5 -1 D
+7 -9 D
+0 3 D
+4 3 D
+-6 2 D
+P
+4538 3449 M
+0 -2 D
+-1 2 D
+P
+FO
+4562 3409 M
+6 -2 D
+3 3 D
+4 0 D
+-2 -1 D
+3 -1 D
+1 2 D
+-4 3 D
+2 2 D
+-5 1 D
+-1 2 D
+-4 -1 D
+-2 -2 D
+3 2 D
+-1 -2 D
+3 1 D
+3 -1 D
+1 -3 D
+-5 2 D
+1 1 D
+-2 -1 D
+-4 0 D
+3 -1 D
+-2 -1 D
+2 -1 D
+-3 -1 D
+P
+FO
+4682 3472 M
+-2 -2 D
+7 2 D
+0 4 D
+6 2 D
+0 2 D
+6 2 D
+-4 2 D
+1 6 D
+3 -1 D
+4 3 D
+-2 2 D
+-4 0 D
+-1 -2 D
+-2 2 D
+-14 -9 D
+2 -3 D
+-3 -3 D
+3 -5 D
+2 1 D
+P
+FO
+4583 3398 M
+8 -1 D
+-2 3 D
+-12 6 D
+0 -4 D
+5 1 D
+2 -2 D
+-2 -1 D
+-2 1 D
+1 -1 D
+-2 -2 D
+P
+FO
+4512 3421 M
+0 -1 D
+12 -4 D
+8 2 D
+-5 5 D
+-1 -2 D
+-10 3 D
+-4 -1 D
+3 -2 D
+P
+FO
+4548 3425 M
+-6 2 D
+2 -2 D
+-5 0 D
+-1 -2 D
+10 1 D
+P
+FO
+4649 3472 M
+-10 -9 D
+0 -10 D
+17 28 D
+-3 -2 D
+P
+FO
+4606 3425 M
+3 0 D
+1 3 D
+-9 4 D
+-2 -5 D
+P
+FO
+4702 3494 M
+2 -2 D
+0 2 D
+5 1 D
+-4 1 D
+P
+FO
+4509 3425 M
+1 4 D
+-8 -8 D
+3 -2 D
+P
+FO
+4512 3412 M
+7 -1 D
+-3 3 D
+-3 0 D
+P
+FO
+4501 3449 M
+0 -5 D
+2 -1 D
+1 3 D
+-2 3 D
+P
+FO
+4512 3480 M
+-3 -1 D
+2 -1 D
+6 2 D
+P
+FO
+4503 3425 M
+0 2 D
+-3 -2 D
+1 -1 D
+P
+FO
+4689 3531 M
+1 -1 D
+5 3 D
+P
+FO
+4705 3505 M
+1 -1 D
+2 1 D
+P
+FO
+4669 3520 M
+1 -3 D
+-1 4 D
+P
+FO
+4701 3538 M
+-1 2 D
+-2 -2 D
+P
+FO
+4493 3424 M
+5 -3 D
+3 1 D
+P
+FO
+4589 3400 M
+8 -3 D
+3 5 D
+P
+FO
+4512 3521 M
+0 -1 D
+2 2 D
+P
+FO
+4681 3520 M
+-3 -1 D
+5 1 D
+P
+FO
+4693 3528 M
+0 -1 D
+2 0 D
+-3 1 D
+P
+FO
+4693 3523 M
+2 1 D
+P
+FO
+4685 3520 M
+4 3 D
+P
+FO
+4523 3402 M
+-2 -1 D
+P
+FO
+4679 3529 M
+4 -1 D
+P
+FO
+4682 3518 M
+4 1 D
+P
+FO
+4648 3505 M
+4 -1 D
+P
+FO
+4697 3533 M
+3 2 D
+-3 -1 D
+P
+FO
+4524 3466 M
+3 0 D
+P
+FO
+4509 3524 M
+1 -1 D
+P
+FO
+4560 3413 M
+2 3 D
+P
+FO
+4695 3533 M
+5 2 D
+P
+FO
+4621 3451 M
+3 1 D
+P
+FO
+4508 3522 M
+2 0 D
+P
+FO
+4694 3526 M
+3 1 D
+P
+FO
+4520 3424 M
+3 0 D
+P
+FO
+4525 3493 M
+2 0 D
+P
+FO
+4512 3518 M
+1 -2 D
+P
+FO
+4514 3447 M
+3 -2 D
+P
+FO
+4494 3443 M
+2 1 D
+P
+FO
+4535 3423 M
+3 0 D
+P
+FO
+4646 3492 M
+3 -1 D
+P
+FO
+4692 3530 M
+3 1 D
+P
+FO
+4694 3531 M
+3 0 D
+P
+FO
+4692 3529 M
+2 0 D
+P
+FO
+4685 3530 M
+3 -1 D
+P
+FO
+4667 3516 M
+3 -1 D
+P
+FO
+4677 3518 M
+1 1 D
+P
+FO
+4529 3487 M
+2 1 D
+P
+FO
+4521 3430 M
+2 0 D
+P
+FO
+4494 3426 M
+2 -1 D
+P
+FO
+4697 3527 M
+2 1 D
+P
+FO
+4681 3517 M
+1 1 D
+P
+FO
+4501 3537 M
+1 -1 D
+P
+FO
+4685 3529 M
+2 -1 D
+P
+FO
+4497 3425 M
+2 -1 D
+P
+FO
+4527 3429 M
+2 0 D
+P
+FO
+4961 3434 M
+-1 0 D
+1 0 D
+-1 12 D
+1 -1 D
+0 95 D
+-21 3 D
+-4 -4 D
+-5 -1 D
+-6 1 D
+-3 -4 D
+-6 3 D
+-1 -7 D
+-4 -2 D
+-22 1 D
+-8 3 D
+-16 2 D
+-3 -2 D
+-3 3 D
+0 -3 D
+-5 2 D
+2 -2 D
+-3 -2 D
+-7 2 D
+0 -2 D
+-5 0 D
+-3 2 D
+0 -3 D
+-11 1 D
+-4 -2 D
+2 -1 D
+-5 1 D
+1 -3 D
+-14 -1 D
+1 -4 D
+-3 -1 D
+6 -1 D
+-6 -1 D
+3 -3 D
+-2 -1 D
+8 0 D
+-7 -2 D
+6 -8 D
+6 0 D
+3 -2 D
+4 3 D
+7 -1 D
+-6 -12 D
+1 -14 D
+-10 -6 D
+-8 0 D
+-9 3 D
+-3 6 D
+-12 6 D
+0 3 D
+-21 -4 D
+-7 -7 D
+-1 -6 D
+-8 -4 D
+-1 -8 D
+2 -20 D
+4 -4 D
+-1 -4 D
+2 -1 D
+-3 -2 D
+2 -6 D
+-6 -1 D
+-11 1 D
+13 9 D
+0 4 D
+-10 -10 D
+-6 -3 D
+-10 -1 D
+0 -4 D
+2 -2 D
+8 1 D
+-10 -3 D
+0 -20 D
+2 -1 D
+-2 1 D
+0 -88 D
+237 0 D
+P
+4907 3518 M
+3 -11 D
+-8 -5 D
+2 -3 D
+8 1 D
+5 -4 D
+0 -4 D
+-5 1 D
+-5 4 D
+-3 -2 D
+-4 10 D
+-5 1 D
+0 4 D
+-6 5 D
+4 4 D
+10 1 D
+P
+4919 3527 M
+6 0 D
+-6 0 D
+-4 -4 D
+1 3 D
+-4 0 D
+-2 -3 D
+1 3 D
+5 1 D
+-2 1 D
+P
+4761 3394 M
+1 3 D
+7 0 D
+-4 -2 D
+1 -1 D
+-3 0 D
+0 2 D
+P
+4822 3420 M
+1 1 D
+-4 1 D
+2 1 D
+4 -2 D
+P
+4869 3505 M
+-1 -7 D
+-4 6 D
+2 2 D
+P
+4890 3439 M
+-1 1 D
+3 -1 D
+P
+4862 3443 M
+-2 2 D
+3 0 D
+P
+4878 3440 M
+3 1 D
+1 -2 D
+P
+4917 3449 M
+-2 1 D
+2 1 D
+1 -2 D
+P
+4760 3392 M
+1 1 D
+3 -2 D
+P
+4762 3404 M
+3 2 D
+0 -4 D
+P
+4796 3402 M
+2 1 D
+0 -1 D
+P
+4884 3421 M
+-1 2 D
+3 -1 D
+P
+4900 3456 M
+0 2 D
+2 -2 D
+P
+4885 3434 M
+-1 2 D
+2 -2 D
+P
+4858 3439 M
+1 1 D
+P
+4934 3429 M
+-1 2 D
+P
+4939 3452 M
+1 1 D
+P
+4923 3450 M
+0 1 D
+P
+4745 3398 M
+0 1 D
+P
+4903 3452 M
+2 1 D
+P
+4854 3429 M
+3 0 D
+P
+4834 3418 M
+1 2 D
+P
+4746 3392 M
+0 2 D
+P
+4896 3448 M
+2 0 D
+P
+4777 3400 M
+2 0 D
+-2 -1 D
+P
+4934 3429 M
+2 -1 D
+P
+4736 3392 M
+0 1 D
+P
+4861 3436 M
+4 -1 D
+P
+4930 3448 M
+2 0 D
+P
+4734 3391 M
+0 2 D
+P
+4955 3465 M
+3 0 D
+P
+4856 3431 M
+2 0 D
+P
+4929 3423 M
+1 1 D
+P
+4815 3344 M
+1 -1 D
+-2 1 D
+P
+4929 3452 M
+0 1 D
+P
+4958 3432 M
+-2 1 D
+3 -1 D
+P
+4956 3425 M
+-1 2 D
+P
+4841 3416 M
+1 1 D
+P
+4809 3412 M
+2 1 D
+P
+4781 3443 M
+0 1 D
+1 -1 D
+P
+4892 3441 M
+1 0 D
+-1 -1 D
+P
+4854 3455 M
+-2 0 D
+P
+4779 3441 M
+0 1 D
+P
+4775 3451 M
+0 1 D
+P
+4855 3430 M
+3 0 D
+P
+4764 3399 M
+2 1 D
+P
+4950 3442 M
+2 1 D
+P
+4909 3461 M
+-2 1 D
+P
+4950 3456 M
+-2 1 D
+P
+4902 3451 M
+3 0 D
+P
+4910 3458 M
+2 1 D
+P
+4726 3388 M
+-1 1 D
+P
+4853 3430 M
+2 1 D
+P
+4911 3430 M
+3 0 D
+P
+4924 3454 M
+1 2 D
+P
+4884 3466 M
+5 2 D
+P
+4890 3441 M
+1 3 D
+P
+4913 3364 M
+2 -1 D
+-3 0 D
+P
+4799 3477 M
+-2 3 D
+P
+4776 3475 M
+0 3 D
+P
+4850 3489 M
+-4 2 D
+P
+4933 3519 M
+-3 0 D
+P
+4938 3416 M
+1 2 D
+P
+4816 3343 M
+-3 -1 D
+P
+4938 3445 M
+1 3 D
+P
+4867 3432 M
+1 2 D
+P
+4878 3420 M
+-2 2 D
+P
+4924 3452 M
+0 2 D
+P
+4890 3453 M
+2 0 D
+P
+4766 3400 M
+0 2 D
+P
+4761 3397 M
+0 3 D
+P
+4767 3393 M
+4 1 D
+P
+4872 3436 M
+4 1 D
+P
+4898 3401 M
+2 1 D
+P
+4811 3408 M
+0 1 D
+1 -1 D
+P
+4865 3370 M
+-1 1 D
+P
+4940 3413 M
+1 3 D
+P
+4848 3365 M
+0 1 D
+P
+4896 3439 M
+4 0 D
+P
+4787 3395 M
+0 2 D
+P
+4915 3337 M
+0 -1 D
+P
+4811 3470 M
+4 1 D
+P
+4822 3395 M
+1 2 D
+P
+4925 3454 M
+1 2 D
+P
+4789 3411 M
+-1 1 D
+2 -1 D
+P
+4948 3468 M
+1 2 D
+0 -2 D
+P
+4896 3449 M
+3 0 D
+P
+4749 3452 M
+0 2 D
+P
+4958 3448 M
+0 1 D
+P
+4828 3409 M
+-1 1 D
+P
+4886 3423 M
+0 1 D
+P
+4868 3442 M
+-1 2 D
+P
+4783 3397 M
+-2 0 D
+P
+4813 3344 M
+-1 -1 D
+P
+4870 3439 M
+2 -1 D
+P
+4814 3408 M
+-1 1 D
+P
+4953 3455 M
+-2 1 D
+P
+4768 3449 M
+-1 1 D
+P
+FO
+4955 3543 M
+P
+FO
+4911 3543 M
+P
+FO
+4829 3543 M
+-1 0 D
+2 0 D
+P
+FO
+4806 3543 M
+-1 -1 D
+12 1 D
+P
+FO
+4799 3543 M
+-1 -1 D
+2 1 D
+0 -2 D
+-7 -2 D
+7 1 D
+5 3 D
+P
+FO
+4795 3543 M
+-3 0 D
+-1 0 D
+2 -2 D
+3 0 D
+0 2 D
+1 0 D
+P
+FO
+4786 3543 M
+P
+FO
+4732 3543 M
+1 0 D
+P
+FO
+4727 3543 M
+3 0 D
+P
+FO
+4772 3495 M
+1 -1 D
+3 2 D
+2 5 D
+6 1 D
+5 -1 D
+-1 2 D
+14 4 D
+-8 4 D
+-7 -1 D
+-2 1 D
+-7 -1 D
+1 -2 D
+-3 1 D
+-2 -3 D
+-2 2 D
+-4 0 D
+4 -3 D
+-4 -2 D
+9 -4 D
+-6 -4 D
+P
+FO
+4783 3520 M
+-2 -2 D
+-8 0 D
+8 -1 D
+2 -4 D
+4 0 D
+2 2 D
+4 -1 D
+-3 1 D
+7 1 D
+-3 3 D
+-6 1 D
+-1 2 D
+P
+FO
+4797 3510 M
+4 -2 D
+4 1 D
+-5 3 D
+P
+FO
+4799 3520 M
+6 0 D
+-5 1 D
+P
+FO
+4804 3541 M
+8 1 D
+-4 0 D
+-4 0 D
+P
+FO
+4805 3541 M
+3 0 D
+P
+FO
+4761 3539 M
+2 0 D
+P
+FO
+4819 3527 M
+-1 1 D
+P
+FO
+4816 3528 M
+2 -1 D
+P
+FO
+4817 3472 M
+3 2 D
+P
+FO
+4748 3542 M
+-2 0 D
+P
+FO
+4781 3542 M
+1 1 D
+P
+FO
+4815 3542 M
+2 0 D
+P
+FO
+4781 3540 M
+3 0 D
+P
+FO
+4767 3505 M
+3 0 D
+P
+FO
+4819 3543 M
+-3 0 D
+P
+FO
+4830 3533 M
+2 -1 D
+P
+FO
+4819 3500 M
+-1 -2 D
+P
+FO
+5126 3543 M
+4 0 D
+-4 0 D
+-128 0 D
+0 -1 D
+-4 -1 D
+-9 1 D
+1 1 D
+-25 0 D
+8 -1 D
+-4 -2 D
+-4 0 D
+0 -95 D
+1 0 D
+-1 0 D
+0 -11 D
+1 0 D
+-1 0 D
+0 -127 D
+236 0 D
+0 236 D
+P
+5153 3518 M
+14 -9 D
+8 -1 D
+-3 -2 D
+3 -2 D
+-4 0 D
+-2 -2 D
+1 -4 D
+-7 4 D
+3 -3 D
+-7 0 D
+1 -3 D
+-4 1 D
+-1 5 D
+-8 0 D
+-10 8 D
+-9 2 D
+3 1 D
+-2 4 D
+5 -4 D
+3 1 D
+-2 -2 D
+4 -2 D
+0 -1 D
+3 0 D
+-1 2 D
+11 -3 D
+0 3 D
+-4 2 D
+3 0 D
+-1 4 D
+-2 -1 D
+-9 2 D
+0 -2 D
+-3 1 D
+1 2 D
+6 1 D
+-4 4 D
+8 -1 D
+4 2 D
+-3 -2 D
+5 -1 D
+-1 3 D
+6 -2 D
+3 2 D
+-4 -4 D
+-13 1 D
+P
+4992 3507 M
+5 -3 D
+3 1 D
+1 -5 D
+-4 2 D
+-3 -3 D
+-14 2 D
+9 3 D
+2 4 D
+P
+5177 3540 M
+11 -6 D
+5 1 D
+-4 -1 D
+3 -2 D
+-2 -1 D
+-14 7 D
+P
+4973 3336 M
+0 -15 D
+-3 3 D
+1 7 D
+-4 0 D
+5 2 D
+P
+5034 3480 M
+3 -3 D
+-5 -2 D
+0 3 D
+-7 1 D
+P
+5033 3479 M
+0 -1 D
+P
+5155 3403 M
+2 3 D
+2 -1 D
+P
+5167 3466 M
+2 1 D
+1 -1 D
+-2 0 D
+P
+5141 3450 M
+0 2 D
+4 -2 D
+-3 0 D
+P
+4990 3453 M
+-2 2 D
+4 0 D
+P
+5082 3508 M
+4 -1 D
+-4 -2 D
+P
+5052 3500 M
+4 -1 D
+P
+5032 3485 M
+0 -4 D
+P
+4991 3450 M
+-4 2 D
+P
+5067 3487 M
+-1 -2 D
+0 2 D
+P
+5115 3472 M
+-2 1 D
+4 1 D
+P
+5033 3490 M
+-1 -2 D
+P
+5040 3489 M
+1 0 D
+-1 -2 D
+P
+4967 3521 M
+-1 -2 D
+P
+5001 3459 M
+-1 2 D
+P
+5013 3472 M
+-2 0 D
+P
+4999 3459 M
+0 1 D
+P
+4970 3476 M
+1 2 D
+P
+5035 3475 M
+1 -2 D
+P
+4962 3451 M
+3 1 D
+P
+5038 3497 M
+1 -1 D
+P
+5016 3467 M
+4 1 D
+P
+5013 3442 M
+-4 0 D
+P
+5003 3461 M
+-2 0 D
+P
+5009 3470 M
+-1 1 D
+P
+5044 3460 M
+-2 1 D
+P
+5007 3468 M
+-1 1 D
+2 -1 D
+P
+4997 3424 M
+2 1 D
+P
+4988 3446 M
+-3 1 D
+P
+FO
+4966 3542 M
+2 0 D
+P
+FO
+5324 3307 M
+1 2 D
+10 8 D
+-5 7 D
+10 4 D
+-2 4 D
+-4 2 D
+0 5 D
+9 5 D
+1 5 D
+6 0 D
+2 3 D
+1 -2 D
+-2 -1 D
+5 -1 D
+7 3 D
+-7 -4 D
+-6 2 D
+-4 -1 D
+-1 -2 D
+1 0 D
+-7 -4 D
+-4 -8 D
+5 -2 D
+-1 -7 D
+-7 -1 D
+0 -2 D
+5 -5 D
+-2 -3 D
+5 1 D
+5 -2 D
+4 3 D
+-3 -3 D
+2 -1 D
+-2 -1 D
+-3 3 D
+-6 -1 D
+-11 -4 D
+-1 -2 D
+108 0 D
+0 126 D
+-2 0 D
+-7 -5 D
+-4 0 D
+-1 -3 D
+-11 0 D
+0 -5 D
+5 0 D
+-2 0 D
+-2 -2 D
+4 -1 D
+-6 0 D
+0 -6 D
+-3 2 D
+-7 -3 D
+3 -4 D
+5 -1 D
+2 -4 D
+3 -1 D
+16 7 D
+3 -2 D
+-6 1 D
+-4 -5 D
+-4 -1 D
+4 -5 D
+-7 2 D
+-2 -6 D
+22 -3 D
+-11 0 D
+-5 -1 D
+-2 -3 D
+-8 0 D
+-5 3 D
+6 -3 D
+7 1 D
+1 2 D
+-7 2 D
+2 0 D
+-4 4 D
+0 7 D
+-12 6 D
+2 10 D
+9 1 D
+1 8 D
+10 4 D
+-6 6 D
+1 1 D
+5 -5 D
+3 1 D
+-2 5 D
+2 2 D
+1 -5 D
+6 1 D
+4 -2 D
+3 2 D
+0 108 D
+-236 0 D
+0 -236 D
+P
+5285 3459 M
+9 -2 D
+3 -4 D
+10 -3 D
+14 3 D
+4 -2 D
+10 3 D
+3 -1 D
+14 5 D
+9 -5 D
+23 0 D
+2 -5 D
+6 -1 D
+2 -2 D
+17 -1 D
+0 -7 D
+-3 6 D
+-5 0 D
+-7 -3 D
+5 4 D
+-13 2 D
+-6 6 D
+-5 0 D
+-1 -2 D
+-2 2 D
+-13 0 D
+-9 5 D
+-14 -5 D
+-3 2 D
+-10 -3 D
+-4 1 D
+-15 -2 D
+-10 3 D
+-1 2 D
+-11 4 D
+-6 5 D
+P
+5264 3485 M
+1 -3 D
+6 0 D
+2 5 D
+1 -5 D
+2 2 D
+-5 -8 D
+6 -5 D
+-2 -1 D
+3 -5 D
+-9 -2 D
+5 2 D
+-5 1 D
+5 1 D
+-2 3 D
+-4 1 D
+4 1 D
+-7 4 D
+5 5 D
+-5 0 D
+-5 -2 D
+3 3 D
+-5 0 D
+P
+5381 3356 M
+7 6 D
+4 8 D
+8 5 D
+-11 -12 D
+0 -3 D
+4 0 D
+-5 0 D
+-8 -4 D
+P
+5229 3484 M
+11 -1 D
+3 2 D
+15 -3 D
+-14 2 D
+-6 -3 D
+0 2 D
+P
+5259 3515 M
+-2 -1 D
+P
+5253 3507 M
+-1 -2 D
+-4 0 D
+P
+FO
+1 2 1 5333 3312 SP
+2 0 1 5346 3348 SP
+5433 3435 M
+3 1 D
+5 -1 D
+4 2 D
+3 -2 D
+5 2 D
+14 -1 D
+1 10 D
+0 -7 D
+7 3 D
+5 0 D
+-6 -1 D
+-1 -3 D
+-4 1 D
+-2 -3 D
+-7 0 D
+2 -1 D
+-1 -2 D
+-1 3 D
+-7 0 D
+-5 -2 D
+-15 -1 D
+0 -126 D
+236 0 D
+0 236 D
+-236 0 D
+P
+5581 3526 M
+5 2 D
+-2 1 D
+4 -1 D
+3 1 D
+-3 9 D
+-5 3 D
+8 -4 D
+1 -11 D
+-11 -1 D
+2 -2 D
+-4 -2 D
+5 0 D
+-2 -4 D
+9 1 D
+0 -2 D
+-7 1 D
+1 -4 D
+-3 1 D
+-5 -4 D
+9 -4 D
+-2 -2 D
+-3 0 D
+2 -4 D
+6 -1 D
+6 5 D
+0 -4 D
+6 0 D
+-2 -1 D
+-5 0 D
+-1 4 D
+-3 -4 D
+4 -2 D
+-1 -2 D
+-3 0 D
+3 -1 D
+2 -6 D
+-5 7 D
+3 1 D
+-8 4 D
+-3 -3 D
+0 5 D
+-2 2 D
+5 1 D
+-6 2 D
+1 1 D
+-6 0 D
+1 3 D
+-15 -2 D
+18 5 D
+-3 1 D
+5 0 D
+-2 3 D
+-13 1 D
+15 0 D
+-3 3 D
+P
+5530 3468 M
+0 3 D
+9 4 D
+6 -1 D
+5 1 D
+0 6 D
+13 0 D
+-3 2 D
+3 3 D
+-4 1 D
+1 2 D
+-5 3 D
+2 1 D
+5 -3 D
+-1 -3 D
+4 -1 D
+0 -8 D
+-3 2 D
+-8 0 D
+-2 -5 D
+-19 -4 D
+P
+5642 3359 M
+-1 -9 D
+9 -1 D
+-9 0 D
+0 -2 D
+-4 0 D
+2 2 D
+-3 3 D
+4 -2 D
+P
+5471 3318 M
+0 3 D
+3 1 D
+0 -4 D
+P
+FO
+5766 3307 M
+1 2 D
+-2 1 D
+3 2 D
+-2 -5 D
+120 0 D
+0 1 D
+3 -1 D
+-1 0 D
+18 0 D
+0 12 D
+-1 -2 D
+-5 4 D
+5 -4 D
+1 86 D
+-1 1 D
+-5 -3 D
+0 3 D
+4 2 D
+2 -2 D
+-1 25 D
+1 0 D
+-1 4 D
+1 0 D
+0 110 D
+-2 0 D
+0 -4 D
+-3 0 D
+-1 -2 D
+-5 0 D
+-6 -4 D
+-5 0 D
+-1 -3 D
+-3 0 D
+0 -10 D
+-4 0 D
+3 -2 D
+-4 -2 D
+1 -2 D
+-3 0 D
+0 -6 D
+-5 0 D
+-2 -4 D
+-4 0 D
+2 -4 D
+-3 4 D
+4 1 D
+2 3 D
+6 0 D
+-2 7 D
+4 -1 D
+0 3 D
+4 1 D
+-4 2 D
+4 0 D
+-1 6 D
+1 4 D
+4 1 D
+1 2 D
+5 0 D
+6 5 D
+5 0 D
+0 2 D
+4 -1 D
+-1 4 D
+-87 0 D
+-1 0 D
+-1 0 D
+-145 0 D
+0 -236 D
+P
+5875 3315 M
+3 5 D
+7 0 D
+4 4 D
+7 -1 D
+-2 -2 D
+-5 0 D
+4 2 D
+-3 0 D
+-8 -6 D
+2 -3 D
+4 1 D
+0 -2 D
+-3 0 D
+-4 -2 D
+-7 2 D
+P
+5883 3314 M
+0 1 D
+P
+5885 3314 M
+3 0 D
+P
+5766 3314 M
+-1 3 D
+2 0 D
+0 -1 D
+2 2 D
+1 -3 D
+-3 -3 D
+1 3 D
+-2 -2 D
+P
+5843 3446 M
+4 -3 D
+4 1 D
+-7 -2 D
+-3 1 D
+P
+5708 3331 M
+0 -2 D
+-3 0 D
+0 2 D
+P
+5817 3534 M
+0 2 D
+3 0 D
+0 -2 D
+P
+5775 3339 M
+-2 2 D
+3 2 D
+1 -3 D
+P
+5787 3376 M
+-2 -6 D
+-10 -4 D
+P
+5847 3441 M
+1 -1 D
+-3 -1 D
+1 2 D
+P
+5864 3492 M
+1 -1 D
+-3 0 D
+P
+5777 3407 M
+0 -4 D
+-2 1 D
+P
+5890 3407 M
+-4 -2 D
+2 3 D
+P
+5677 3432 M
+0 4 D
+3 -2 D
+P
+5729 3420 M
+-1 -2 D
+-2 2 D
+P
+5682 3437 M
+-3 0 D
+0 2 D
+P
+5716 3374 M
+-1 -1 D
+0 2 D
+P
+5830 3517 M
+4 2 D
+0 -2 D
+P
+5868 3311 M
+0 -2 D
+-2 1 D
+P
+5723 3338 M
+-2 -3 D
+0 2 D
+P
+5835 3527 M
+-2 1 D
+2 1 D
+1 -2 D
+P
+5804 3535 M
+-16 3 D
+17 -2 D
+0 -1 D
+P
+5885 3330 M
+4 -1 D
+-4 -1 D
+P
+5866 3420 M
+1 -1 D
+-2 0 D
+P
+5876 3311 M
+-1 -2 D
+-2 1 D
+P
+5839 3537 M
+0 2 D
+3 -1 D
+-2 -1 D
+P
+5686 3444 M
+-3 -1 D
+3 3 D
+P
+5853 3502 M
+-2 2 D
+3 0 D
+0 -2 D
+P
+5868 3382 M
+-2 1 D
+4 0 D
+P
+5860 3431 M
+-2 -2 D
+-1 1 D
+P
+5776 3348 M
+0 -4 D
+-3 0 D
+P
+5807 3473 M
+-1 1 D
+4 0 D
+P
+5688 3325 M
+4 1 D
+-1 -2 D
+P
+5779 3348 M
+-2 -2 D
+P
+5681 3452 M
+1 1 D
+P
+5886 3439 M
+1 -2 D
+P
+5741 3361 M
+-2 -1 D
+P
+5705 3452 M
+0 1 D
+P
+5809 3382 M
+0 -1 D
+P
+5708 3436 M
+1 2 D
+P
+5812 3369 M
+-2 -1 D
+P
+5678 3472 M
+1 1 D
+0 -1 D
+P
+5671 3428 M
+-2 1 D
+P
+5881 3434 M
+0 -2 D
+P
+5851 3511 M
+2 1 D
+P
+5734 3365 M
+-2 -1 D
+P
+5677 3424 M
+-2 0 D
+P
+5810 3371 M
+0 -2 D
+P
+5733 3338 M
+-2 1 D
+2 0 D
+P
+5718 3361 M
+0 -1 D
+P
+5708 3397 M
+-2 -1 D
+P
+5726 3538 M
+-1 1 D
+P
+5687 3451 M
+-1 1 D
+P
+5801 3368 M
+2 3 D
+P
+5697 3319 M
+-2 -3 D
+1 3 D
+P
+5775 3331 M
+0 -3 D
+0 4 D
+P
+5850 3435 M
+-3 -2 D
+P
+5865 3378 M
+-2 1 D
+P
+5866 3404 M
+1 -3 D
+P
+5847 3364 M
+0 2 D
+1 -2 D
+P
+5706 3443 M
+1 2 D
+P
+5872 3493 M
+-1 -2 D
+P
+5785 3538 M
+-5 3 D
+P
+5816 3392 M
+1 -2 D
+P
+5876 3436 M
+0 -2 D
+P
+5840 3447 M
+0 -2 D
+P
+5856 3444 M
+0 -2 D
+P
+5719 3416 M
+-2 -1 D
+P
+5830 3397 M
+1 -2 D
+P
+5686 3447 M
+1 3 D
+P
+5715 3341 M
+-3 -2 D
+P
+5806 3370 M
+2 2 D
+1 -2 D
+P
+5690 3331 M
+1 2 D
+P
+5897 3317 M
+0 3 D
+P
+5863 3368 M
+-1 2 D
+P
+5799 3373 M
+-3 -1 D
+P
+5889 3450 M
+0 -2 D
+P
+5712 3443 M
+0 2 D
+P
+5681 3479 M
+1 2 D
+P
+5856 3415 M
+1 -2 D
+P
+5898 3337 M
+1 -3 D
+P
+5807 3406 M
+2 -2 D
+-3 2 D
+P
+5678 3429 M
+-4 0 D
+P
+5736 3364 M
+-2 -1 D
+P
+5802 3387 M
+1 -2 D
+P
+5730 3364 M
+0 -2 D
+P
+5707 3454 M
+1 2 D
+P
+5844 3448 M
+0 -1 D
+P
+5713 3449 M
+1 1 D
+P
+FO
+6142 3435 M
+-4 0 D
+-1 0 D
+0 1 D
+5 2 D
+0 91 D
+-9 0 D
+-3 3 D
+-5 0 D
+-9 10 D
+1 1 D
+-211 0 D
+0 -110 D
+3 1 D
+-3 -2 D
+1 -29 D
+-1 0 D
+0 -96 D
+236 0 D
+P
+6078 3424 M
+8 3 D
+10 -3 D
+-12 -5 D
+2 1 D
+4 -3 D
+-5 -1 D
+0 1 D
+-7 1 D
+2 1 D
+-16 -1 D
+3 5 D
+8 1 D
+-2 -1 D
+4 -3 D
+P
+6088 3423 M
+3 0 D
+-1 1 D
+P
+5984 3381 M
+-7 5 D
+-3 -2 D
+2 3 D
+10 -1 D
+1 -6 D
+P
+5953 3454 M
+-2 -3 D
+-3 1 D
+-3 -2 D
+-1 3 D
+P
+5950 3398 M
+-1 3 D
+2 2 D
+3 -2 D
+-4 0 D
+P
+6105 3425 M
+3 1 D
+4 -1 D
+-5 -2 D
+-3 1 D
+P
+5919 3486 M
+2 -1 D
+-8 -1 D
+0 2 D
+P
+6135 3370 M
+0 2 D
+3 0 D
+1 -2 D
+P
+6128 3376 M
+2 5 D
+6 -1 D
+-1 -6 D
+-8 2 D
+P
+5919 3398 M
+1 2 D
+3 0 D
+-2 -3 D
+P
+5977 3396 M
+-5 2 D
+3 2 D
+3 -3 D
+P
+5995 3387 M
+-3 0 D
+3 3 D
+3 -1 D
+P
+6042 3359 M
+1 5 D
+1 -5 D
+P
+6090 3415 M
+8 2 D
+-3 -4 D
+P
+6093 3384 M
+2 3 D
+1 -3 D
+P
+5947 3418 M
+0 -2 D
+-2 1 D
+P
+6095 3429 M
+2 -2 D
+-4 1 D
+2 2 D
+P
+5937 3401 M
+-1 2 D
+3 1 D
+P
+5954 3397 M
+1 4 D
+2 -3 D
+P
+6002 3374 M
+0 3 D
+3 -4 D
+P
+6104 3414 M
+2 2 D
+3 -2 D
+P
+6108 3374 M
+1 2 D
+2 -2 D
+P
+5944 3451 M
+-4 -2 D
+1 2 D
+P
+6000 3366 M
+2 -1 D
+-2 0 D
+P
+6088 3361 M
+1 2 D
+1 -2 D
+P
+6057 3418 M
+2 -3 D
+-3 2 D
+P
+6040 3353 M
+-1 1 D
+3 -1 D
+P
+6108 3392 M
+0 -2 D
+-2 2 D
+P
+5933 3312 M
+-1 -2 D
+-1 2 D
+P
+5911 3315 M
+2 1 D
+0 -1 D
+P
+6051 3450 M
+0 -1 D
+-3 0 D
+P
+5975 3480 M
+2 -1 D
+-4 0 D
+P
+5928 3395 M
+-1 2 D
+P
+5979 3377 M
+1 2 D
+P
+5957 3483 M
+0 -1 D
+-1 1 D
+P
+6081 3373 M
+2 -1 D
+P
+6081 3372 M
+2 -1 D
+P
+5975 3310 M
+4 -1 D
+-4 0 D
+P
+6039 3414 M
+1 -2 D
+P
+5977 3479 M
+0 -1 D
+P
+5985 3348 M
+3 0 D
+-1 -1 D
+P
+6084 3333 M
+-3 0 D
+P
+6122 3380 M
+-1 -1 D
+P
+5935 3367 M
+-1 0 D
+0 1 D
+P
+6048 3351 M
+-2 -1 D
+2 2 D
+P
+5947 3378 M
+2 2 D
+P
+5941 3331 M
+-1 -1 D
+P
+6002 3432 M
+2 -2 D
+P
+6132 3355 M
+-3 0 D
+P
+5992 3320 M
+0 1 D
+P
+6108 3387 M
+2 0 D
+P
+6079 3384 M
+2 2 D
+2 -3 D
+P
+6063 3334 M
+-1 -1 D
+P
+6104 3382 M
+0 -1 D
+P
+6064 3331 M
+-1 0 D
+1 1 D
+P
+5941 3372 M
+2 -1 D
+P
+6129 3360 M
+0 -1 D
+P
+6039 3370 M
+1 1 D
+P
+6000 3401 M
+1 -1 D
+P
+5954 3335 M
+2 -1 D
+P
+6005 3376 M
+1 -2 D
+P
+6111 3389 M
+-1 -1 D
+P
+5932 3362 M
+1 2 D
+P
+FO
+6118 3543 M
+-1 -1 D
+9 -10 D
+4 0 D
+4 -3 D
+8 1 D
+0 13 D
+P
+FO
+6142 3530 M
+2 0 D
+4 -4 D
+6 2 D
+2 -4 D
+6 -2 D
+9 1 D
+10 -8 D
+-3 -1 D
+3 -2 D
+2 2 D
+4 -4 D
+6 0 D
+7 -5 D
+13 -2 D
+0 -3 D
+5 -1 D
+6 -9 D
+9 0 D
+-2 -3 D
+4 -6 D
+10 -3 D
+0 -2 D
+3 -1 D
+-2 -8 D
+-8 -6 D
+-1 -6 D
+1 6 D
+8 7 D
+1 7 D
+-3 1 D
+1 2 D
+-9 1 D
+-5 8 D
+1 2 D
+-10 1 D
+-5 8 D
+-7 3 D
+1 2 D
+-12 1 D
+-1 2 D
+-11 4 D
+-4 3 D
+-2 -1 D
+-4 1 D
+3 2 D
+-9 7 D
+-10 -1 D
+-5 2 D
+-3 4 D
+-6 -1 D
+-5 3 D
+0 -91 D
+8 0 D
+-5 -3 D
+-3 0 D
+0 -128 D
+236 0 D
+0 236 D
+-236 0 D
+P
+6171 3400 M
+12 9 D
+9 2 D
+15 9 D
+6 2 D
+6 -4 D
+-5 2 D
+-1 -2 D
+-30 -10 D
+-3 -4 D
+-6 -2 D
+-1 -3 D
+-1 2 D
+-1 -2 D
+P
+6324 3341 M
+-2 7 D
+-6 1 D
+8 1 D
+-1 -6 D
+4 -5 D
+P
+6374 3314 M
+-2 2 D
+4 0 D
+P
+6368 3438 M
+-2 3 D
+3 -3 D
+P
+6162 3380 M
+2 -1 D
+-4 1 D
+P
+6172 3360 M
+5 3 D
+P
+6168 3363 M
+10 6 D
+P
+6181 3371 M
+3 2 D
+P
+6360 3431 M
+2 -1 D
+P
+6159 3346 M
+2 2 D
+P
+6150 3434 M
+-4 -1 D
+P
+6370 3318 M
+2 0 D
+P
+6176 3370 M
+-2 -2 D
+P
+6165 3326 M
+-1 -2 D
+P
+6364 3417 M
+1 1 D
+P
+6166 3375 M
+-1 -1 D
+P
+6170 3357 M
+-2 -2 D
+P
+6160 3335 M
+2 0 D
+P
+6145 3339 M
+0 -1 D
+P
+6171 3389 M
+-3 0 D
+P
+6175 3389 M
+-4 -1 D
+P
+6162 3350 M
+2 2 D
+-2 -3 D
+P
+FO
+6439 3307 M
+-6 4 D
+-2 6 D
+16 6 D
+2 -5 D
+9 -4 D
+-7 -1 D
+-5 -5 D
+-5 -1 D
+173 0 D
+0 236 D
+-236 0 D
+0 -236 D
+P
+6399 3419 M
+4 7 D
+23 4 D
+9 7 D
+-1 -3 D
+6 -2 D
+-7 1 D
+-3 -3 D
+-14 -4 D
+-11 0 D
+-4 -3 D
+0 -6 D
+7 -3 D
+2 -4 D
+9 0 D
+-8 0 D
+4 -4 D
+-1 -5 D
+6 1 D
+1 -2 D
+-7 0 D
+0 -5 D
+-3 4 D
+3 5 D
+-7 5 D
+0 4 D
+-9 4 D
+P
+6380 3418 M
+3 -1 D
+0 2 D
+2 -1 D
+-4 -2 D
+P
+6497 3309 M
+3 0 D
+-4 -2 D
+-3 1 D
+4 0 D
+P
+6530 3364 M
+4 1 D
+-4 -2 D
+P
+6401 3312 M
+3 0 D
+0 -3 D
+-6 1 D
+P
+6602 3342 M
+-3 -5 D
+-1 3 D
+P
+6542 3372 M
+5 1 D
+4 -3 D
+P
+6382 3414 M
+3 -1 D
+P
+6553 3323 M
+-1 -2 D
+P
+6489 3332 M
+1 -2 D
+P
+6485 3339 M
+2 0 D
+-3 0 D
+P
+FO
+6614 3307 M
+236 0 D
+0 236 D
+-236 0 D
+P
+6667 3454 M
+0 1 D
+6 0 D
+0 2 D
+3 0 D
+-1 -3 D
+4 0 D
+2 2 D
+3 -3 D
+2 1 D
+-1 -7 D
+6 -5 D
+2 -14 D
+-6 -8 D
+5 -3 D
+-1 -5 D
+6 -7 D
+-6 6 D
+-6 -6 D
+11 -12 D
+5 -1 D
+2 1 D
+0 -4 D
+-6 3 D
+-3 -2 D
+0 -10 D
+-1 14 D
+-12 2 D
+10 0 D
+-7 9 D
+5 5 D
+-3 2 D
+5 0 D
+-1 5 D
+-4 4 D
+7 7 D
+-9 22 D
+-10 3 D
+-2 -1 D
+2 -1 D
+-5 1 D
+-5 -2 D
+1 -1 D
+-2 1 D
+-3 -1 D
+2 -2 D
+-4 -4 D
+7 -2 D
+-5 0 D
+4 -2 D
+6 0 D
+-2 -7 D
+4 0 D
+-9 -6 D
+5 4 D
+0 1 D
+3 1 D
+-4 0 D
+2 6 D
+-12 -3 D
+-3 2 D
+4 -1 D
+6 2 D
+-6 1 D
+-3 6 D
+-5 1 D
+-1 2 D
+-3 -2 D
+-4 3 D
+7 0 D
+4 -2 D
+0 2 D
+2 -2 D
+-1 3 D
+3 0 D
+-5 1 D
+3 2 D
+-1 2 D
+3 1 D
+1 -2 D
+4 1 D
+-6 -3 D
+2 -1 D
+P
+6838 3442 M
+8 1 D
+-5 1 D
+5 0 D
+4 -3 D
+-4 -3 D
+2 -2 D
+-6 -18 D
+-3 -2 D
+1 -11 D
+-9 -8 D
+0 -4 D
+-5 0 D
+3 4 D
+-4 1 D
+-9 -8 D
+8 2 D
+2 -6 D
+-5 -2 D
+-3 1 D
+-16 -12 D
+-19 -5 D
+-8 -6 D
+-6 1 D
+-5 -1 D
+-4 -9 D
+-6 -5 D
+-27 -6 D
+-12 1 D
+-12 3 D
+-1 2 D
+22 1 D
+2 2 D
+12 1 D
+8 5 D
+9 9 D
+14 5 D
+9 7 D
+-5 0 D
+19 10 D
+3 5 D
+13 7 D
+15 18 D
+1 6 D
+5 2 D
+2 12 D
+P
+6795 3385 M
+-16 -5 D
+-1 -2 D
+11 2 D
+8 4 D
+0 3 D
+P
+6624 3343 M
+4 2 D
+5 -4 D
+-1 -9 D
+-8 -8 D
+1 -4 D
+-6 0 D
+-1 -2 D
+4 16 D
+-2 4 D
+4 1 D
+P
+6718 3360 M
+10 -8 D
+-7 5 D
+-2 -2 D
+P
+6634 3434 M
+12 -1 D
+-13 0 D
+-1 -2 D
+P
+6763 3334 M
+5 3 D
+-3 -3 D
+P
+6805 3373 M
+3 2 D
+P
+6828 3392 M
+2 -1 D
+-2 0 D
+P
+6846 3446 M
+2 0 D
+P
+FO
+7066 3543 M
+-21 -8 D
+-21 8 D
+-85 0 D
+-8 -5 D
+-12 -4 D
+-7 -3 D
+4 -2 D
+-4 1 D
+-6 -5 D
+6 8 D
+18 5 D
+7 5 D
+-87 0 D
+0 -236 D
+237 0 D
+0 236 D
+P
+6919 3430 M
+5 2 D
+-1 -3 D
+-5 0 D
+P
+6902 3421 M
+4 1 D
+-1 -2 D
+P
+6914 3358 M
+6 2 D
+P
+6933 3433 M
+3 1 D
+-4 -1 D
+P
+6896 3376 M
+2 0 D
+P
+6893 3374 M
+2 1 D
+P
+6909 3354 M
+2 0 D
+P
+6886 3367 M
+2 0 D
+P
+6891 3433 M
+2 -1 D
+P
+6923 3361 M
+2 1 D
+P
+6884 3369 M
+3 1 D
+-1 -2 D
+P
+6890 3370 M
+0 -1 D
+-2 1 D
+P
+FO
+7027 3543 M
+20 -6 D
+17 6 D
+1 0 D
+P
+FO
+7087 3307 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+7483 3307 M
+2 4 D
+5 3 D
+-3 5 D
+8 4 D
+7 0 D
+8 3 D
+11 7 D
+11 4 D
+2 3 D
+10 0 D
+3 3 D
+9 2 D
+3 2 D
+0 11 D
+-4 -1 D
+-3 -5 D
+-1 4 D
+8 3 D
+0 15 D
+-7 3 D
+5 6 D
+2 0 D
+0 4 D
+-1 0 D
+1 17 D
+-5 2 D
+-1 3 D
+-10 -3 D
+-16 2 D
+0 -5 D
+3 1 D
+0 -3 D
+-7 -11 D
+-6 -1 D
+9 8 D
+0 4 D
+-6 -2 D
+-1 -4 D
+-8 -3 D
+-15 -1 D
+-3 1 D
+7 2 D
+3 4 D
+6 3 D
+-7 0 D
+-7 2 D
+2 2 D
+2 -1 D
+7 5 D
+-8 0 D
+-5 -2 D
+-3 -2 D
+2 -3 D
+3 0 D
+-2 -4 D
+-6 0 D
+-4 -2 D
+-2 4 D
+3 5 D
+-2 6 D
+2 1 D
+0 5 D
+-3 -1 D
+-1 2 D
+-4 -3 D
+-17 0 D
+-2 2 D
+-10 2 D
+-1 4 D
+22 9 D
+7 6 D
+8 2 D
+12 8 D
+3 0 D
+0 2 D
+7 2 D
+8 7 D
+4 0 D
+-3 3 D
+4 1 D
+4 6 D
+3 0 D
+0 -2 D
+1 4 D
+7 2 D
+1 3 D
+20 8 D
+5 5 D
+0 54 D
+-236 0 D
+0 -236 D
+P
+7552 3390 M
+6 1 D
+-3 -3 D
+0 -2 D
+-4 1 D
+0 3 D
+P
+7475 3344 M
+4 -2 D
+-2 -2 D
+P
+7481 3357 M
+2 -3 D
+-7 -3 D
+-2 3 D
+P
+7538 3382 M
+6 -3 D
+-5 0 D
+P
+7537 3406 M
+3 0 D
+P
+7544 3373 M
+2 1 D
+P
+7550 3386 M
+2 -1 D
+P
+7545 3379 M
+1 1 D
+P
+7544 3345 M
+1 -1 D
+P
+FO
+7559 3346 M
+-12 -3 D
+-1 -3 D
+-6 -2 D
+-6 2 D
+-1 -4 D
+-11 -4 D
+-13 -9 D
+-15 -1 D
+-4 -4 D
+1 -3 D
+8 1 D
+-2 -2 D
+2 -2 D
+-8 2 D
+0 -2 D
+-5 -2 D
+-1 -3 D
+74 0 D
+P
+FO
+7559 3383 M
+-2 0 D
+-4 -6 D
+6 -3 D
+P
+FO
+7512 3422 M
+5 4 D
+-14 4 D
+-9 -10 D
+6 2 D
+5 -6 D
+P
+FO
+7488 3423 M
+5 5 D
+-4 0 D
+-9 -5 D
+6 1 D
+P
+FO
+7501 3411 M
+3 0 D
+-1 4 D
+P
+FO
+7471 3418 M
+4 -2 D
+P
+FO
+7540 3415 M
+2 1 D
+P
+FO
+7520 3427 M
+2 0 D
+P
+FO
+7505 3410 M
+5 3 D
+P
+FO
+-4 -3 1 7490 3314 SP
+-3 0 1 7542 3339 SP
+7572 3307 M
+3 2 D
+-3 1 D
+0 -1 D
+-3 15 D
+6 6 D
+0 8 D
+5 3 D
+-4 1 D
+4 0 D
+0 4 D
+5 1 D
+2 4 D
+5 1 D
+-1 5 D
+5 1 D
+-1 2 D
+-3 0 D
+-7 4 D
+4 4 D
+-2 5 D
+1 2 D
+-4 0 D
+-3 4 D
+-7 2 D
+13 -3 D
+6 4 D
+-2 1 D
+2 2 D
+-13 3 D
+1 2 D
+5 -1 D
+-14 4 D
+-6 5 D
+1 3 D
+-8 3 D
+0 -16 D
+6 2 D
+-4 -3 D
+-2 0 D
+0 -4 D
+6 0 D
+10 -3 D
+-6 0 D
+-4 3 D
+-6 0 D
+0 -9 D
+2 -1 D
+1 -4 D
+5 -1 D
+4 -5 D
+-8 -8 D
+2 -5 D
+-5 -4 D
+3 0 D
+0 2 D
+4 1 D
+1 6 D
+1 -4 D
+5 0 D
+-5 0 D
+-5 -4 D
+4 -2 D
+7 2 D
+2 -2 D
+-3 1 D
+-4 -2 D
+-5 1 D
+-2 -2 D
+1 3 D
+-3 0 D
+-2 0 D
+0 -39 D
+P
+FO
+7653 3307 M
+-5 9 D
+-6 20 D
+-3 3 D
+3 -1 D
+-4 10 D
+0 -5 D
+-3 0 D
+3 4 D
+-4 6 D
+1 -3 D
+-3 3 D
+0 9 D
+5 8 D
+-3 -8 D
+2 2 D
+1 13 D
+-1 -3 D
+-6 11 D
+4 1 D
+-1 -3 D
+3 -2 D
+-10 16 D
+2 0 D
+-2 2 D
+4 5 D
+-7 8 D
+-4 -5 D
+2 2 D
+-9 0 D
+11 -9 D
+-3 -6 D
+3 4 D
+2 -3 D
+-3 -2 D
+-4 1 D
+0 -3 D
+2 1 D
+2 -2 D
+-2 0 D
+-4 -3 D
+-4 0 D
+0 4 D
+-11 -4 D
+4 -8 D
+-3 -12 D
+-5 -5 D
+0 -10 D
+5 -4 D
+-3 0 D
+9 -6 D
+4 -8 D
+-5 -14 D
+4 -10 D
+-1 -3 D
+P
+FO
+7559 3489 M
+8 1 D
+4 3 D
+6 10 D
+19 7 D
+12 10 D
+9 4 D
+19 5 D
+-2 -1 D
+7 -1 D
+10 2 D
+24 -1 D
+19 2 D
+2 -2 D
+4 1 D
+-3 -4 D
+5 -2 D
+7 1 D
+-1 5 D
+5 2 D
+24 -6 D
+2 2 D
+4 -1 D
+2 3 D
+12 0 D
+1 -3 D
+12 -1 D
+2 3 D
+-6 0 D
+-1 2 D
+4 3 D
+1 -3 D
+7 1 D
+-4 4 D
+9 3 D
+13 -1 D
+0 6 D
+-236 0 D
+P
+7652 3531 M
+-2 -1 D
+P
+FO
+7559 3359 M
+3 -1 D
+-3 0 D
+0 -11 D
+5 3 D
+-2 4 D
+4 4 D
+3 6 D
+-3 4 D
+-4 0 D
+-3 6 D
+P
+7559 3355 M
+2 0 D
+-1 -2 D
+P
+FO
+7633 3358 M
+0 -1 D
+1 6 D
+P
+FO
+7772 3523 M
+-1 -1 D
+4 3 D
+P
+FO
+7634 3354 M
+-1 3 D
+P
+FO
+7613 3390 M
+4 2 D
+-4 -1 D
+P
+FO
+7590 3386 M
+4 -1 D
+P
+FO
+7585 3389 M
+6 -2 D
+P
+FO
+8031 3384 M
+-1 -1 D
+1 3 D
+-5 4 D
+5 0 D
+-1 4 D
+-2 0 D
+1 -3 D
+-2 3 D
+4 11 D
+0 -1 D
+0 120 D
+-5 -3 D
+-1 -5 D
+-33 -20 D
+-1 1 D
+-8 -2 D
+-6 1 D
+-6 -5 D
+-6 0 D
+-4 2 D
+-6 -4 D
+6 -5 D
+-7 -10 D
+-4 1 D
+-1 -3 D
+-12 -7 D
+-8 -17 D
+-2 -19 D
+14 -55 D
+4 -8 D
+3 0 D
+-2 -1 D
+3 -10 D
+0 -17 D
+4 -2 D
+2 -3 D
+-2 -6 D
+19 12 D
+3 4 D
+7 3 D
+9 7 D
+2 7 D
+4 1 D
+0 3 D
+-3 0 D
+3 3 D
+-4 3 D
+4 -1 D
+1 2 D
+-3 2 D
+4 3 D
+-5 -1 D
+0 3 D
+4 1 D
+3 -4 D
+9 5 D
+17 4 D
+-1 -1 D
+5 -3 D
+P
+FO
+7902 3543 M
+-1 -1 D
+2 1 D
+P
+FO
+7795 3537 M
+14 -5 D
+4 1 D
+-6 -2 D
+6 0 D
+0 -1 D
+4 0 D
+0 3 D
+12 1 D
+7 -7 D
+11 0 D
+3 -2 D
+-5 -2 D
+-16 1 D
+-8 -2 D
+6 -6 D
+17 1 D
+8 3 D
+-1 1 D
+5 -3 D
+8 -1 D
+2 4 D
+8 1 D
+-1 1 D
+4 2 D
+5 -1 D
+2 1 D
+-2 -1 D
+9 -3 D
+7 1 D
+0 2 D
+3 1 D
+8 -2 D
+0 1 D
+9 0 D
+1 4 D
+-6 3 D
+-3 -1 D
+-10 3 D
+2 -3 D
+-3 2 D
+-2 -2 D
+-4 0 D
+2 5 D
+4 -2 D
+-4 7 D
+4 -1 D
+0 4 D
+-104 0 D
+P
+7839 3533 M
+-2 -1 D
+-1 1 D
+P
+FO
+7937 3316 M
+4 3 D
+0 6 D
+-3 0 D
+-9 -9 D
+-11 -2 D
+1 -6 D
+4 -1 D
+3 3 D
+8 3 D
+P
+FO
+7924 3328 M
+2 -2 D
+3 0 D
+0 3 D
+P
+FO
+7810 3520 M
+4 2 D
+-2 1 D
+-6 -3 D
+P
+FO
+7941 3324 M
+6 -2 D
+2 6 D
+P
+FO
+7926 3527 M
+2 1 D
+P
+FO
+8178 3543 M
+-3 -4 D
+5 0 D
+7 4 D
+P
+FO
+8143 3543 M
+3 -5 D
+9 5 D
+P
+FO
+8065 3543 M
+-13 -9 D
+-9 -1 D
+-2 -4 D
+-10 -5 D
+0 -120 D
+20 11 D
+8 0 D
+3 -2 D
+10 0 D
+10 6 D
+-9 15 D
+8 17 D
+11 4 D
+-2 -1 D
+4 0 D
+4 -4 D
+5 -1 D
+8 4 D
+-3 13 D
+-7 -1 D
+-4 2 D
+2 6 D
+-2 8 D
+-2 -1 D
+10 4 D
+5 6 D
+-3 2 D
+-12 3 D
+-3 -1 D
+-1 -4 D
+-4 -2 D
+3 3 D
+-9 1 D
+-3 5 D
+-2 -1 D
+4 8 D
+5 5 D
+-2 1 D
+3 0 D
+7 4 D
+-2 0 D
+7 2 D
+-3 0 D
+8 3 D
+-3 3 D
+3 2 D
+5 -3 D
+-4 4 D
+6 2 D
+0 1 D
+-5 3 D
+7 3 D
+1 6 D
+6 0 D
+3 3 D
+-5 0 D
+14 0 D
+-4 -2 D
+4 -1 D
+-2 2 D
+3 1 D
+P
+8033 3419 M
+6 4 D
+0 -4 D
+P
+8072 3453 M
+4 0 D
+-3 -1 D
+P
+8081 3490 M
+-1 2 D
+P
+8051 3463 M
+2 -2 D
+P
+8053 3459 M
+-1 -2 D
+P
+8091 3463 M
+2 2 D
+P
+FO
+8031 3380 M
+2 0 D
+-1 4 D
+-1 0 D
+P
+FO
+8124 3519 M
+-8 -9 D
+-4 -1 D
+2 -2 D
+2 3 D
+14 5 D
+11 2 D
+2 4 D
+-3 4 D
+-21 -5 D
+P
+FO
+8182 3425 M
+-3 8 D
+-7 1 D
+-5 -2 D
+5 -2 D
+5 -6 D
+12 -6 D
+0 4 D
+P
+8176 3432 M
+1 -1 D
+P
+FO
+8205 3422 M
+15 -8 D
+-3 4 D
+P
+FO
+8271 3543 M
+4 -1 D
+1 1 D
+P
+FO
+8332 3378 M
+-7 -2 D
+9 -1 D
+-2 -2 D
+4 -1 D
+4 2 D
+1 -1 D
+3 2 D
+5 -1 D
+-4 1 D
+-1 2 D
+-2 -1 D
+-1 2 D
+P
+FO
+8446 3354 M
+3 2 D
+-2 2 D
+-2 -4 D
+-7 -3 D
+3 -1 D
+1 3 D
+5 0 D
+P
+FO
+8480 3343 M
+6 -4 D
+5 1 D
+-4 0 D
+-9 5 D
+-7 1 D
+P
+FO
+8497 3354 M
+-3 1 D
+-2 -2 D
+4 -2 D
+3 2 D
+P
+FO
+8467 3353 M
+2 -1 D
+2 1 D
+P
+FO
+8347 3364 M
+9 -1 D
+1 3 D
+P
+FO
+8359 3373 M
+2 -1 D
+P
+FO
+8461 3354 M
+-2 1 D
+P
+FO
+8462 3350 M
+4 -1 D
+P
+FO
+8406 3363 M
+3 0 D
+P
+FO
+8364 3371 M
+2 0 D
+P
+FO
+236 3374 M
+P
+FO
+118 3355 M
+21 2 D
+-2 3 D
+3 0 D
+2 3 D
+-4 1 D
+-4 -1 D
+-3 -1 D
+2 -1 D
+2 1 D
+1 -2 D
+-8 -1 D
+2 -2 D
+-3 -1 D
+-7 1 D
+-3 -2 D
+P
+FO
+81 3354 M
+-5 -1 D
+2 -4 D
+-5 1 D
+2 -2 D
+-4 -3 D
+4 3 D
+0 -3 D
+9 3 D
+0 3 D
+-5 0 D
+P
+FO
+47 3348 M
+-3 -1 D
+5 -2 D
+3 4 D
+4 2 D
+-5 -1 D
+-3 2 D
+-5 0 D
+-1 -1 D
+6 -2 D
+P
+FO
+142 3357 M
+12 -2 D
+12 2 D
+-13 0 D
+0 1 D
+-7 -2 D
+-6 1 D
+P
+FO
+54 3347 M
+2 -1 D
+6 2 D
+5 -1 D
+3 5 D
+-4 1 D
+-1 -3 D
+P
+FO
+84 3351 M
+1 -3 D
+3 0 D
+0 3 D
+P
+FO
+94 3350 M
+-5 1 D
+2 -2 D
+0 1 D
+4 0 D
+P
+FO
+174 3361 M
+5 0 D
+3 2 D
+-4 0 D
+P
+FO
+216 3368 M
+7 2 D
+-4 0 D
+P
+FO
+91 3354 M
+4 1 D
+-4 2 D
+P
+FO
+27 3349 M
+3 0 D
+-2 2 D
+P
+FO
+226 3476 M
+4 -1 D
+4 3 D
+P
+FO
+232 3371 M
+3 2 D
+-3 0 D
+P
+FO
+94 3352 M
+-2 0 D
+3 -1 D
+0 1 D
+P
+FO
+20 3337 M
+0 -1 D
+2 1 D
+P
+FO
+24 3340 M
+0 -2 D
+2 1 D
+P
+FO
+236 3375 M
+-3 1 D
+P
+FO
+100 3353 M
+3 1 D
+P
+FO
+31 3345 M
+2 0 D
+P
+FO
+95 3354 M
+4 0 D
+P
+FO
+97 3353 M
+3 -1 D
+P
+FO
+205 3366 M
+3 0 D
+P
+FO
+27 3344 M
+3 0 D
+P
+FO
+472 3429 M
+-1 1 D
+1 -2 D
+-2 1 D
+1 -2 D
+-3 1 D
+1 -3 D
+-2 -3 D
+5 5 D
+P
+FO
+472 3460 M
+-7 -4 D
+-6 -9 D
+8 -2 D
+-1 -2 D
+-12 3 D
+3 -3 D
+-3 -1 D
+-6 4 D
+4 1 D
+0 2 D
+-22 -3 D
+-19 -10 D
+2 0 D
+2 -4 D
+-5 2 D
+-6 -2 D
+1 -2 D
+-5 -1 D
+2 2 D
+-9 -3 D
+3 -4 D
+-3 0 D
+2 -1 D
+-2 -2 D
+8 3 D
+-5 2 D
+1 2 D
+7 -4 D
+5 1 D
+3 -1 D
+-1 4 D
+-3 2 D
+2 2 D
+7 -4 D
+-4 0 D
+2 -2 D
+3 1 D
+2 -1 D
+3 3 D
+-1 -1 D
+4 0 D
+-2 3 D
+4 -1 D
+7 10 D
+10 -2 D
+-5 1 D
+-3 -2 D
+0 -3 D
+6 0 D
+8 4 D
+6 -2 D
+-3 2 D
+4 2 D
+3 -4 D
+3 4 D
+-2 1 D
+7 0 D
+0 2 D
+2 -1 D
+P
+FO
+421 3543 M
+11 -12 D
+-6 -2 D
+0 -3 D
+-1 1 D
+-1 -1 D
+1 -2 D
+4 -3 D
+0 1 D
+8 0 D
+-8 -1 D
+2 -7 D
+1 1 D
+1 -1 D
+-5 -2 D
+-6 -1 D
+9 -1 D
+0 -1 D
+19 8 D
+3 -2 D
+11 7 D
+1 -4 D
+7 -1 D
+0 26 D
+P
+FO
+400 3543 M
+-2 0 D
+2 0 D
+-25 0 D
+1 0 D
+-3 -1 D
+2 -3 D
+16 0 D
+21 4 D
+1 0 D
+P
+392 3541 M
+2 -1 D
+-5 0 D
+P
+383 3541 M
+-2 -1 D
+P
+397 3542 M
+-4 0 D
+P
+391 3542 M
+-3 0 D
+P
+FO
+305 3543 M
+21 -6 D
+3 1 D
+-5 2 D
+17 1 D
+-2 2 D
+P
+FO
+236 3374 M
+7 -1 D
+1 2 D
+-8 -1 D
+P
+FO
+307 3389 M
+0 -1 D
+3 2 D
+3 -2 D
+-1 3 D
+3 -2 D
+0 3 D
+2 -2 D
+1 3 D
+6 1 D
+-1 3 D
+-4 -3 D
+-3 1 D
+9 4 D
+-1 2 D
+-2 -1 D
+0 2 D
+-6 -4 D
+0 4 D
+-9 -1 D
+-4 -3 D
+11 -3 D
+-3 0 D
+1 -2 D
+-3 2 D
+-3 0 D
+1 -2 D
+-4 -1 D
+5 -2 D
+-5 0 D
+2 -1 D
+-5 0 D
+-1 -1 D
+-3 1 D
+-2 -1 D
+2 -1 D
+-5 0 D
+-4 -2 D
+8 -1 D
+P
+FO
+378 3416 M
+10 0 D
+5 3 D
+7 -1 D
+-7 2 D
+-4 6 D
+2 0 D
+-8 1 D
+-12 -4 D
+-5 0 D
+-10 -9 D
+2 -3 D
+5 0 D
+P
+FO
+266 3376 M
+11 8 D
+10 3 D
+1 3 D
+-7 1 D
+-6 -2 D
+-2 -3 D
+2 -2 D
+-8 -1 D
+-4 -6 D
+-6 -3 D
+P
+FO
+452 3433 M
+1 -5 D
+3 2 D
+4 -2 D
+0 6 D
+-3 -2 D
+-2 3 D
+P
+FO
+449 3513 M
+-2 -2 D
+-2 1 D
+2 -3 D
+5 1 D
+4 5 D
+P
+FO
+338 3407 M
+2 0 D
+0 -3 D
+5 2 D
+-4 1 D
+2 2 D
+P
+FO
+429 3428 M
+2 -1 D
+3 1 D
+-6 1 D
+P
+FO
+331 3403 M
+8 2 D
+-8 2 D
+-3 -3 D
+P
+FO
+434 3430 M
+2 1 D
+-3 0 D
+P
+FO
+415 3423 M
+4 -2 D
+0 4 D
+-4 -1 D
+P
+FO
+405 3412 M
+8 -1 D
+P
+FO
+327 3395 M
+1 3 D
+-5 -1 D
+P
+FO
+354 3405 M
+-5 -1 D
+6 -1 D
+P
+FO
+241 3463 M
+5 -2 D
+3 2 D
+P
+FO
+464 3435 M
+5 -1 D
+0 2 D
+P
+FO
+244 3378 M
+-2 1 D
+0 -2 D
+P
+FO
+466 3512 M
+-1 1 D
+1 -2 D
+P
+FO
+343 3403 M
+6 0 D
+P
+FO
+439 3429 M
+2 1 D
+P
+FO
+326 3401 M
+3 0 D
+P
+FO
+414 3411 M
+3 0 D
+P
+FO
+357 3406 M
+3 1 D
+P
+FO
+409 3435 M
+-5 -2 D
+P
+FO
+405 3412 M
+2 -2 D
+P
+FO
+392 3427 M
+-1 0 D
+P
+FO
+470 3433 M
+2 -1 D
+P
+FO
+463 3513 M
+-1 -1 D
+P
+FO
+434 3428 M
+2 -1 D
+P
+FO
+341 3403 M
+2 0 D
+P
+FO
+709 3537 M
+-1 2 D
+1 -1 D
+0 5 D
+-39 0 D
+-5 -5 D
+10 -4 D
+0 1 D
+12 3 D
+-7 -3 D
+0 -2 D
+-6 -1 D
+4 -3 D
+-10 2 D
+1 -2 D
+-5 1 D
+3 -3 D
+-4 1 D
+-1 -2 D
+6 -1 D
+-1 -2 D
+7 1 D
+-2 1 D
+3 1 D
+7 -1 D
+-5 2 D
+6 -1 D
+1 1 D
+2 -3 D
+0 3 D
+8 3 D
+-1 2 D
+2 2 D
+2 -4 D
+6 7 D
+-3 -6 D
+7 2 D
+-2 3 D
+3 -2 D
+P
+FO
+602 3543 M
+-1 0 D
+1 0 D
+-92 0 D
+5 -1 D
+-9 1 D
+-13 -2 D
+-1 2 D
+5 -2 D
+7 2 D
+-32 0 D
+0 -26 D
+2 -3 D
+8 4 D
+-1 -2 D
+4 -1 D
+9 -9 D
+5 -1 D
+4 3 D
+-4 6 D
+2 -1 D
+1 5 D
+1 -1 D
+7 4 D
+-3 2 D
+12 -5 D
+0 -1 D
+-8 4 D
+-5 -5 D
+9 -5 D
+26 6 D
+6 4 D
+-5 -7 D
+4 -1 D
+-7 -1 D
+-8 -7 D
+2 -4 D
+3 1 D
+3 -1 D
+-8 0 D
+-4 -14 D
+3 -3 D
+4 0 D
+-6 -1 D
+-2 3 D
+-9 -5 D
+2 -1 D
+-8 -1 D
+-8 -7 D
+2 -5 D
+-8 2 D
+-6 -4 D
+-14 -3 D
+-5 -2 D
+0 -16 D
+5 1 D
+5 -1 D
+-3 -3 D
+2 -1 D
+-3 -1 D
+4 -1 D
+2 8 D
+2 -2 D
+1 2 D
+11 1 D
+2 2 D
+4 -1 D
+-1 4 D
+2 0 D
+0 2 D
+4 -1 D
+-4 -3 D
+5 -1 D
+-2 3 D
+2 -2 D
+1 3 D
+0 -1 D
+6 3 D
+-5 -2 D
+-2 2 D
+5 1 D
+-3 -1 D
+1 1 D
+-4 0 D
+0 1 D
+-2 -2 D
+-3 0 D
+6 5 D
+7 0 D
+-1 1 D
+7 -1 D
+0 2 D
+-6 0 D
+8 3 D
+2 -2 D
+5 1 D
+-3 2 D
+5 1 D
+-1 2 D
+6 -2 D
+5 5 D
+3 -2 D
+2 3 D
+5 -1 D
+-2 2 D
+6 2 D
+1 3 D
+-5 1 D
+9 4 D
+3 -1 D
+0 3 D
+7 -1 D
+-1 3 D
+5 0 D
+-1 3 D
+7 -1 D
+0 2 D
+6 1 D
+1 4 D
+11 0 D
+-1 2 D
+4 -1 D
+-1 3 D
+3 -3 D
+0 2 D
+3 -1 D
+-2 2 D
+3 0 D
+-2 1 D
+4 1 D
+-6 0 D
+8 2 D
+-2 2 D
+4 1 D
+0 2 D
+8 1 D
+8 5 D
+-11 5 D
+-8 0 D
+-3 -1 D
+-2 3 D
+8 5 D
+-5 1 D
+10 1 D
+-3 3 D
+6 0 D
+-3 2 D
+3 1 D
+3 -1 D
+0 4 D
+3 -2 D
+-2 -2 D
+9 1 D
+1 3 D
+-7 0 D
+11 1 D
+4 3 D
+P
+616 3538 M
+-17 -4 D
+2 -2 D
+-4 0 D
+5 -1 D
+-16 -1 D
+-9 -3 D
+-8 1 D
+0 3 D
+6 4 D
+17 0 D
+4 3 D
+21 0 D
+P
+563 3513 M
+2 -2 D
+2 2 D
+14 -1 D
+-2 -2 D
+-7 1 D
+10 -2 D
+-6 -1 D
+-5 2 D
+-12 0 D
+-3 2 D
+P
+554 3498 M
+14 -4 D
+0 -2 D
+-4 0 D
+4 -1 D
+-5 -4 D
+2 4 D
+-19 4 D
+1 3 D
+P
+554 3491 M
+-7 -9 D
+-6 4 D
+7 0 D
+0 3 D
+P
+493 3535 M
+3 -2 D
+12 0 D
+-12 0 D
+10 -4 D
+-9 2 D
+P
+575 3515 M
+14 -5 D
+-13 3 D
+-2 2 D
+P
+498 3530 M
+7 -4 D
+-10 5 D
+P
+570 3509 M
+2 0 D
+-6 -2 D
+P
+491 3523 M
+2 -1 D
+-4 -1 D
+P
+578 3521 M
+10 -2 D
+-10 0 D
+-1 2 D
+P
+591 3522 M
+4 -2 D
+P
+497 3537 M
+12 -3 D
+P
+495 3528 M
+4 -5 D
+P
+497 3539 M
+10 -1 D
+-11 1 D
+P
+495 3460 M
+2 -1 D
+P
+483 3536 M
+-4 -4 D
+4 5 D
+P
+487 3523 M
+-3 -2 D
+P
+613 3532 M
+-7 -2 D
+7 3 D
+P
+589 3519 M
+6 -2 D
+P
+535 3478 M
+2 -1 D
+-3 1 D
+P
+544 3499 M
+2 -1 D
+P
+FO
+472 3427 M
+4 1 D
+-1 4 D
+-2 -3 D
+-1 0 D
+P
+FO
+611 3472 M
+9 4 D
+-5 -5 D
+3 2 D
+0 -1 D
+2 0 D
+-9 -5 D
+4 -1 D
+7 3 D
+-2 0 D
+2 3 D
+3 0 D
+-4 2 D
+5 0 D
+-1 3 D
+2 -2 D
+2 2 D
+10 1 D
+-6 2 D
+1 1 D
+1 -1 D
+6 1 D
+1 -2 D
+4 1 D
+1 2 D
+-10 1 D
+3 1 D
+-1 1 D
+15 -2 D
+4 4 D
+-7 0 D
+1 2 D
+-3 -1 D
+2 2 D
+-3 -1 D
+6 3 D
+-7 2 D
+0 -2 D
+-1 2 D
+-2 -2 D
+-2 0 D
+0 2 D
+-11 2 D
+6 -4 D
+-5 2 D
+1 -3 D
+-7 1 D
+4 -3 D
+-4 2 D
+0 -4 D
+-3 6 D
+-5 0 D
+-2 -4 D
+8 -2 D
+-7 1 D
+5 -3 D
+-4 1 D
+5 -7 D
+-7 6 D
+-4 0 D
+3 1 D
+-1 2 D
+-12 -2 D
+-7 -7 D
+5 -1 D
+2 -6 D
+6 -1 D
+-1 -2 D
+5 6 D
+-7 -1 D
+-2 1 D
+12 0 D
+P
+612 3483 M
+2 -4 D
+P
+FO
+641 3496 M
+3 0 D
+-1 2 D
+4 0 D
+1 3 D
+1 -3 D
+6 1 D
+-2 2 D
+2 1 D
+4 -2 D
+3 4 D
+-4 -3 D
+0 4 D
+-2 -1 D
+-3 2 D
+-2 -3 D
+-1 4 D
+-9 -1 D
+3 -4 D
+-7 1 D
+-2 -1 D
+6 -2 D
+-7 1 D
+-1 -1 D
+P
+FO
+631 3472 M
+3 3 D
+7 1 D
+-4 1 D
+-1 -1 D
+0 1 D
+-3 -1 D
+1 1 D
+-3 0 D
+-3 -3 D
+3 1 D
+-2 -1 D
+P
+FO
+646 3509 M
+2 1 D
+-2 -2 D
+4 -1 D
+4 4 D
+-3 -2 D
+0 2 D
+P
+FO
+598 3459 M
+7 4 D
+-7 -2 D
+-3 -2 D
+P
+FO
+638 3496 M
+2 0 D
+-9 4 D
+-3 -3 D
+4 0 D
+-1 1 D
+P
+FO
+486 3425 M
+-1 -1 D
+3 1 D
+0 2 D
+-3 0 D
+P
+FO
+612 3463 M
+-3 0 D
+-3 -2 D
+5 0 D
+P
+FO
+500 3444 M
+0 2 D
+3 -1 D
+-2 1 D
+P
+FO
+484 3431 M
+-3 -5 D
+4 0 D
+P
+FO
+630 3529 M
+-2 1 D
+-3 -2 D
+P
+FO
+543 3461 M
+-6 2 D
+-2 -1 D
+P
+FO
+614 3461 M
+3 1 D
+-6 -1 D
+P
+FO
+650 3495 M
+-1 -1 D
+5 0 D
+P
+FO
+628 3495 M
+-3 -1 D
+7 -2 D
+P
+FO
+577 3447 M
+-3 -3 D
+3 -1 D
+P
+FO
+488 3423 M
+3 0 D
+P
+FO
+691 3527 M
+3 2 D
+P
+FO
+666 3502 M
+-1 -2 D
+P
+FO
+643 3496 M
+0 -2 D
+P
+FO
+482 3421 M
+2 -2 D
+P
+FO
+653 3518 M
+5 0 D
+P
+FO
+639 3504 M
+4 -1 D
+P
+FO
+524 3458 M
+0 -2 D
+P
+FO
+493 3446 M
+-1 -1 D
+P
+FO
+614 3465 M
+-3 1 D
+P
+FO
+477 3421 M
+3 0 D
+P
+FO
+550 3450 M
+0 -1 D
+P
+FO
+548 3452 M
+1 2 D
+P
+FO
+673 3523 M
+2 -1 D
+P
+FO
+487 3442 M
+1 1 D
+-2 -1 D
+P
+FO
+655 3491 M
+-1 -1 D
+2 1 D
+P
+FO
+914 3543 M
+1 -1 D
+-4 -2 D
+13 -3 D
+13 -1 D
+8 2 D
+0 5 D
+P
+944 3539 M
+-5 -1 D
+P
+FO
+896 3543 M
+9 -1 D
+5 1 D
+P
+FO
+850 3543 M
+6 0 D
+P
+FO
+842 3543 M
+P
+FO
+765 3543 M
+-7 -5 D
+11 2 D
+2 3 D
+P
+FO
+757 3543 M
+-1 -1 D
+P
+FO
+753 3543 M
+1 0 D
+P
+FO
+744 3543 M
+2 -1 D
+0 1 D
+P
+FO
+731 3543 M
+-1 -1 D
+8 1 D
+3 -2 D
+1 2 D
+P
+FO
+724 3543 M
+1 -3 D
+4 3 D
+P
+FO
+709 3538 M
+6 -3 D
+-3 5 D
+3 -1 D
+0 3 D
+5 -6 D
+-2 3 D
+5 4 D
+-14 0 D
+P
+FO
+709 3535 M
+1 0 D
+-1 2 D
+P
+FO
+714 3534 M
+-2 2 D
+P
+FO
+795 3529 M
+1 2 D
+P
+FO
+846 3543 M
+-10 -4 D
+P
+FO
+1181 3389 M
+-13 4 D
+13 -10 D
+P
+FO
+1181 3393 M
+-1 -1 D
+1 0 D
+P
+FO
+1181 3396 M
+-5 4 D
+-2 -3 D
+3 0 D
+-1 -2 D
+3 0 D
+0 -2 D
+2 0 D
+P
+FO
+1181 3405 M
+-1 0 D
+-2 -5 D
+3 -2 D
+P
+FO
+1181 3409 M
+-10 8 D
+1 -4 D
+-2 -3 D
+2 -1 D
+3 2 D
+1 -3 D
+2 0 D
+-4 -2 D
+4 -1 D
+3 1 D
+P
+FO
+1181 3413 M
+-2 -2 D
+2 -2 D
+P
+FO
+1181 3424 M
+0 1 D
+-4 -3 D
+3 1 D
+-4 -4 D
+1 -1 D
+-4 0 D
+0 -2 D
+-2 1 D
+7 -6 D
+3 2 D
+P
+FO
+1181 3426 M
+0 -1 D
+P
+FO
+1181 3430 M
+-4 -3 D
+2 -2 D
+2 2 D
+P
+FO
+1181 3446 M
+-3 -3 D
+3 -7 D
+P
+FO
+1124 3543 M
+8 -9 D
+-2 -1 D
+-7 10 D
+-31 0 D
+1 -9 D
+4 -4 D
+-1 -2 D
+-5 0 D
+0 -6 D
+-4 2 D
+1 2 D
+-5 0 D
+9 7 D
+-3 7 D
+2 3 D
+-8 0 D
+2 -2 D
+-4 0 D
+0 -7 D
+9 2 D
+0 -1 D
+-8 -1 D
+-1 -4 D
+-5 -1 D
+4 1 D
+1 5 D
+-1 8 D
+-8 0 D
+-1 0 D
+1 0 D
+-6 0 D
+-3 -3 D
+2 3 D
+-107 0 D
+4 -3 D
+9 -1 D
+-10 0 D
+0 -6 D
+0 7 D
+-4 3 D
+-4 -3 D
+4 -4 D
+-4 -3 D
+-5 -1 D
+13 -4 D
+2 1 D
+2 -2 D
+-2 0 D
+14 -4 D
+-1 1 D
+6 0 D
+-5 -1 D
+12 -3 D
+11 -9 D
+4 1 D
+-4 -2 D
+13 -5 D
+5 0 D
+0 -1 D
+2 2 D
+-1 -2 D
+4 -1 D
+0 -2 D
+3 1 D
+-1 3 D
+6 -2 D
+-1 2 D
+-3 -1 D
+-2 1 D
+3 0 D
+-1 2 D
+5 -2 D
+0 1 D
+1 -2 D
+5 1 D
+-6 7 D
+-1 -2 D
+-5 0 D
+5 2 D
+-4 2 D
+2 -2 D
+-3 1 D
+-2 3 D
+-8 1 D
+-4 -1 D
+6 2 D
+-3 3 D
+9 -4 D
+-1 3 D
+2 -2 D
+3 1 D
+0 -3 D
+5 0 D
+-3 -1 D
+4 -1 D
+3 2 D
+-1 2 D
+-2 0 D
+1 3 D
+3 -5 D
+2 2 D
+5 -1 D
+-8 -1 D
+6 -6 D
+-2 -5 D
+7 1 D
+4 -1 D
+-1 3 D
+5 -6 D
+5 0 D
+-7 20 D
+-6 4 D
+8 -4 D
+-8 6 D
+6 -2 D
+1 5 D
+0 -6 D
+6 1 D
+-5 -2 D
+6 -11 D
+3 6 D
+0 -7 D
+-2 0 D
+5 -7 D
+15 -4 D
+1 5 D
+9 3 D
+-5 -2 D
+-2 -1 D
+-1 -8 D
+4 -3 D
+6 5 D
+-3 -3 D
+2 -3 D
+-2 2 D
+-2 -1 D
+4 -4 D
+3 3 D
+10 -1 D
+-10 1 D
+-1 -3 D
+10 -4 D
+2 2 D
+-2 -2 D
+7 -3 D
+-18 5 D
+1 -3 D
+6 0 D
+-4 -1 D
+0 -2 D
+4 0 D
+-3 -2 D
+10 0 D
+-5 -2 D
+1 -1 D
+-7 1 D
+-1 -2 D
+6 -2 D
+4 2 D
+-1 -2 D
+4 -2 D
+4 2 D
+1 -3 D
+-4 0 D
+10 -6 D
+4 2 D
+-4 -3 D
+5 -1 D
+6 2 D
+-7 -3 D
+5 -5 D
+5 0 D
+1 -4 D
+10 0 D
+-3 -1 D
+-9 0 D
+1 -5 D
+-3 -3 D
+2 -1 D
+-7 -1 D
+2 -4 D
+6 -2 D
+-2 4 D
+3 -2 D
+2 2 D
+-1 2 D
+2 2 D
+-3 1 D
+4 0 D
+-2 1 D
+2 -1 D
+5 3 D
+-2 -2 D
+2 0 D
+2 2 D
+2 -1 D
+8 3 D
+-5 -3 D
+7 -3 D
+1 -3 D
+4 1 D
+-4 -1 D
+0 -4 D
+5 2 D
+0 -2 D
+-5 0 D
+0 -4 D
+4 -2 D
+3 3 D
+-1 -3 D
+-7 0 D
+-4 -2 D
+3 -3 D
+4 3 D
+1 -3 D
+7 6 D
+-5 -4 D
+4 0 D
+-5 -1 D
+1 -2 D
+-4 2 D
+-3 -1 D
+-1 -2 D
+4 -1 D
+-3 -1 D
+3 -3 D
+3 1 D
+-1 3 D
+1 -4 D
+2 4 D
+0 -3 D
+4 3 D
+0 -3 D
+11 11 D
+-4 11 D
+4 3 D
+0 97 D
+P
+986 3527 M
+1 -2 D
+P
+1179 3488 M
+-3 -3 D
+P
+990 3525 M
+-3 -1 D
+P
+993 3530 M
+-3 0 D
+P
+FO
+945 3538 M
+4 1 D
+6 4 D
+-10 0 D
+P
+FO
+1134 3375 M
+2 1 D
+-3 3 D
+10 0 D
+-5 5 D
+-6 -3 D
+-5 0 D
+4 1 D
+-5 1 D
+9 1 D
+2 12 D
+5 10 D
+-6 -3 D
+-7 0 D
+3 -4 D
+-3 -3 D
+2 -2 D
+-5 0 D
+1 -1 D
+-5 -2 D
+3 3 D
+-7 0 D
+12 4 D
+0 4 D
+-3 2 D
+-3 0 D
+-6 -4 D
+2 4 D
+-12 2 D
+-1 -10 D
+3 0 D
+2 -2 D
+-2 0 D
+5 -2 D
+-5 -1 D
+4 -1 D
+-1 -1 D
+3 1 D
+-1 -1 D
+3 1 D
+0 -2 D
+6 -2 D
+-7 1 D
+-1 -1 D
+5 0 D
+-4 -2 D
+5 1 D
+-2 -3 D
+3 1 D
+-1 -2 D
+3 0 D
+-5 -1 D
+11 -2 D
+0 -2 D
+-6 1 D
+5 -3 D
+-2 1 D
+0 -2 D
+3 -1 D
+1 3 D
+3 -2 D
+1 -2 D
+-3 2 D
+1 -2 D
+-3 0 D
+14 -7 D
+-1 -2 D
+5 -3 D
+0 2 D
+2 -4 D
+0 3 D
+2 -3 D
+1 2 D
+2 -1 D
+1 2 D
+-4 0 D
+2 1 D
+-5 0 D
+-4 5 D
+-5 1 D
+-1 4 D
+-3 0 D
+0 1 D
+5 1 D
+P
+FO
+1124 3425 M
+0 2 D
+2 -7 D
+2 1 D
+-1 -3 D
+1 2 D
+2 -2 D
+0 1 D
+3 -1 D
+2 2 D
+-3 1 D
+3 0 D
+-4 2 D
+4 0 D
+-1 2 D
+-2 -1 D
+2 2 D
+-5 -3 D
+1 2 D
+-4 0 D
+6 1 D
+-2 2 D
+4 0 D
+-3 0 D
+3 3 D
+-4 -1 D
+-3 1 D
+-2 -3 D
+2 3 D
+-4 0 D
+9 1 D
+-5 3 D
+-2 -2 D
+-2 2 D
+0 -2 D
+0 2 D
+4 1 D
+-6 1 D
+-5 -3 D
+5 6 D
+9 -4 D
+-5 5 D
+-2 -1 D
+-3 2 D
+3 -1 D
+0 3 D
+-7 4 D
+-8 2 D
+1 3 D
+-3 4 D
+-4 -2 D
+1 2 D
+-7 0 D
+-1 -3 D
+9 -2 D
+0 -5 D
+3 -1 D
+-6 -3 D
+0 -3 D
+11 0 D
+-4 0 D
+-1 -4 D
+6 -2 D
+-8 0 D
+-1 -2 D
+8 0 D
+-2 -2 D
+4 2 D
+4 -4 D
+0 4 D
+3 0 D
+-3 0 D
+1 -5 D
+2 1 D
+2 -2 D
+-4 -2 D
+4 1 D
+-2 -2 D
+3 0 D
+P
+1110 3437 M
+2 0 D
+P
+FO
+1063 3467 M
+-3 -4 D
+3 3 D
+1 -3 D
+-2 -2 D
+2 -2 D
+1 1 D
+1 -4 D
+2 2 D
+-1 -2 D
+4 -3 D
+1 4 D
+-3 -1 D
+3 2 D
+-3 1 D
+3 1 D
+-3 2 D
+2 0 D
+0 2 D
+1 -2 D
+0 4 D
+-3 0 D
+3 0 D
+-4 3 D
+2 0 D
+-3 9 D
+-3 2 D
+-1 -1 D
+1 1 D
+-3 0 D
+4 0 D
+-6 3 D
+-1 -1 D
+0 2 D
+-4 -1 D
+2 2 D
+-3 1 D
+-5 -4 D
+4 -1 D
+-5 0 D
+3 -3 D
+5 1 D
+-2 -3 D
+3 0 D
+-3 -1 D
+7 -3 D
+-3 1 D
+-1 -1 D
+2 -1 D
+-4 0 D
+2 -1 D
+4 1 D
+-5 -2 D
+-1 1 D
+2 -3 D
+4 1 D
+-3 -2 D
+5 2 D
+-4 -3 D
+P
+FO
+1063 3485 M
+4 -1 D
+-2 6 D
+-13 0 D
+3 0 D
+-3 1 D
+2 0 D
+-5 1 D
+2 1 D
+-9 3 D
+19 -5 D
+3 1 D
+-6 3 D
+6 -3 D
+0 5 D
+-11 3 D
+-6 -5 D
+-4 1 D
+5 0 D
+-4 1 D
+6 1 D
+-1 3 D
+-5 2 D
+-4 -3 D
+-5 1 D
+2 -3 D
+-6 3 D
+2 -3 D
+-2 2 D
+-2 -2 D
+10 -6 D
+-8 4 D
+2 -2 D
+-2 0 D
+-2 -2 D
+6 -1 D
+1 -4 D
+4 0 D
+-2 -1 D
+3 0 D
+-2 -1 D
+5 -2 D
+-5 2 D
+4 -3 D
+4 -1 D
+3 3 D
+-3 1 D
+3 1 D
+-6 2 D
+2 0 D
+-3 3 D
+18 -8 D
+5 0 D
+P
+FO
+1087 3464 M
+1 4 D
+-8 3 D
+4 -2 D
+-6 1 D
+2 -2 D
+-3 1 D
+0 -3 D
+5 -1 D
+-2 -1 D
+5 0 D
+-6 -2 D
+7 -1 D
+-1 -4 D
+-3 2 D
+-2 -3 D
+3 1 D
+-3 -2 D
+3 -6 D
+-1 4 D
+2 0 D
+1 3 D
+2 -5 D
+2 3 D
+-2 1 D
+0 2 D
+3 -2 D
+1 1 D
+-3 3 D
+2 1 D
+-3 1 D
+3 1 D
+-2 1 D
+4 -1 D
+2 1 D
+-1 4 D
+-4 1 D
+P
+FO
+1087 3482 M
+-3 2 D
+4 -1 D
+0 2 D
+2 -2 D
+-9 10 D
+-2 -1 D
+0 6 D
+12 -11 D
+-9 13 D
+-12 0 D
+-6 6 D
+4 -8 D
+1 2 D
+-2 -3 D
+6 -13 D
+6 2 D
+-2 -2 D
+-4 0 D
+6 -4 D
+-6 2 D
+3 -2 D
+-5 -2 D
+1 -5 D
+8 3 D
+0 2 D
+1 -2 D
+3 2 D
+-2 4 D
+2 -2 D
+0 1 D
+3 -1 D
+2 1 D
+0 2 D
+P
+FO
+1157 3434 M
+2 5 D
+-3 6 D
+-5 3 D
+-6 -1 D
+2 -2 D
+-6 0 D
+5 -1 D
+-6 -1 D
+3 -1 D
+-3 -2 D
+3 -1 D
+-5 -3 D
+7 -4 D
+1 5 D
+0 -4 D
+2 0 D
+1 8 D
+2 -5 D
+-5 -4 D
+4 0 D
+2 3 D
+-2 -4 D
+4 -1 D
+P
+FO
+1087 3472 M
+6 -2 D
+-4 0 D
+5 -1 D
+1 -10 D
+5 1 D
+0 1 D
+7 -1 D
+1 3 D
+-4 1 D
+-3 5 D
+2 -1 D
+-1 2 D
+8 -7 D
+0 8 D
+-7 2 D
+1 -2 D
+-2 2 D
+-13 2 D
+-3 -1 D
+P
+FO
+1129 3449 M
+-1 3 D
+3 -1 D
+-6 3 D
+-3 -1 D
+3 3 D
+-4 1 D
+-4 -3 D
+1 -4 D
+3 0 D
+-1 3 D
+2 -3 D
+1 3 D
+0 -5 D
+5 -1 D
+P
+FO
+1110 3421 M
+2 1 D
+2 -4 D
+4 -1 D
+-7 7 D
+0 2 D
+-3 0 D
+0 2 D
+3 -1 D
+-4 4 D
+-2 -1 D
+3 -2 D
+-3 -1 D
+P
+FO
+1045 3472 M
+3 1 D
+2 3 D
+-5 5 D
+-3 -3 D
+2 0 D
+-1 -2 D
+3 0 D
+-3 -2 D
+P
+FO
+1166 3398 M
+0 2 D
+4 -1 D
+1 2 D
+2 0 D
+-4 -2 D
+3 -2 D
+4 3 D
+-5 4 D
+-6 -3 D
+P
+FO
+1134 3453 M
+2 1 D
+-3 3 D
+-3 0 D
+-5 3 D
+1 -6 D
+6 -2 D
+0 2 D
+P
+FO
+1092 3449 M
+1 -3 D
+8 4 D
+0 -4 D
+2 6 D
+-8 0 D
+3 -1 D
+-4 0 D
+P
+FO
+1137 3434 M
+3 -6 D
+-1 3 D
+2 0 D
+0 2 D
+2 -1 D
+-5 3 D
+P
+FO
+1099 3442 M
+-2 2 D
+3 -1 D
+3 1 D
+-8 1 D
+0 -3 D
+P
+FO
+1111 3468 M
+4 -5 D
+-4 1 D
+0 -3 D
+10 2 D
+-7 5 D
+P
+FO
+1100 3432 M
+-1 -2 D
+3 0 D
+3 2 D
+-3 0 D
+0 1 D
+P
+FO
+1140 3371 M
+3 -3 D
+0 2 D
+4 -1 D
+-1 3 D
+P
+FO
+1115 3423 M
+4 -4 D
+-3 3 D
+3 -1 D
+0 2 D
+P
+FO
+1096 3435 M
+-2 -2 D
+2 -2 D
+0 3 D
+3 0 D
+P
+FO
+1157 3354 M
+-1 2 D
+3 1 D
+-4 1 D
+P
+FO
+1110 3459 M
+-1 -2 D
+4 -3 D
+5 1 D
+0 4 D
+P
+FO
+1143 3425 M
+1 2 D
+2 -2 D
+3 1 D
+-1 4 D
+-4 2 D
+P
+FO
+1177 3425 M
+-7 -3 D
+1 -2 D
+-1 1 D
+1 -1 D
+P
+FO
+1151 3425 M
+-5 -1 D
+3 -2 D
+4 1 D
+P
+FO
+1135 3378 M
+3 -3 D
+5 1 D
+-1 2 D
+-6 0 D
+P
+FO
+1158 3413 M
+3 0 D
+2 3 D
+-4 0 D
+P
+FO
+1116 3425 M
+2 3 D
+-4 2 D
+-1 -4 D
+P
+FO
+1027 3496 M
+2 -4 D
+2 5 D
+-3 2 D
+P
+FO
+1120 3464 M
+4 -1 D
+2 1 D
+-5 1 D
+P
+FO
+1166 3420 M
+3 -2 D
+2 1 D
+-1 2 D
+P
+FO
+1080 3446 M
+0 -1 D
+4 2 D
+-5 0 D
+P
+FO
+1173 3408 M
+2 0 D
+0 1 D
+P
+FO
+1171 3394 M
+8 -3 D
+-4 6 D
+P
+FO
+1071 3503 M
+9 -2 D
+P
+FO
+1096 3438 M
+-3 0 D
+-2 -3 D
+5 2 D
+P
+FO
+1103 3437 M
+-3 1 D
+2 -2 D
+P
+FO
+1161 3405 M
+7 -2 D
+-6 4 D
+P
+FO
+1063 3482 M
+4 -2 D
+0 2 D
+P
+FO
+1099 3436 M
+-1 2 D
+-2 -2 D
+3 -1 D
+P
+FO
+1103 3444 M
+2 1 D
+-2 2 D
+P
+FO
+1149 3364 M
+2 -2 D
+1 3 D
+P
+FO
+1120 3458 M
+4 0 D
+-2 1 D
+P
+FO
+1174 3405 M
+2 -1 D
+1 1 D
+P
+FO
+1090 3446 M
+-2 1 D
+1 -2 D
+P
+FO
+1130 3449 M
+-1 1 D
+1 -3 D
+P
+FO
+1051 3478 M
+2 -1 D
+1 1 D
+P
+FO
+1127 3378 M
+-2 0 D
+4 -1 D
+P
+FO
+1050 3476 M
+2 0 D
+-2 2 D
+P
+FO
+1033 3489 M
+2 -1 D
+P
+FO
+1161 3412 M
+3 0 D
+-1 1 D
+P
+FO
+1046 3505 M
+4 -1 D
+P
+FO
+1110 3454 M
+2 0 D
+P
+FO
+1131 3383 M
+2 0 D
+P
+FO
+1057 3465 M
+1 1 D
+P
+FO
+1161 3412 M
+1 1 D
+P
+FO
+1118 3460 M
+2 -1 D
+P
+FO
+1155 3415 M
+1 1 D
+P
+FO
+1036 3510 M
+1 -1 D
+P
+FO
+1107 3439 M
+0 -1 D
+P
+FO
+1019 3518 M
+2 -1 D
+P
+FO
+1139 3372 M
+1 -1 D
+P
+FO
+949 3534 M
+3 1 D
+P
+FO
+1090 3460 M
+2 0 D
+P
+FO
+1088 3471 M
+2 -1 D
+P
+FO
+1173 3403 M
+1 -1 D
+P
+FO
+1172 3418 M
+4 2 D
+P
+FO
+1178 3402 M
+-1 1 D
+P
+FO
+1170 3409 M
+2 -2 D
+P
+FO
+1133 3449 M
+0 2 D
+P
+FO
+1166 3397 M
+3 0 D
+P
+FO
+1047 3480 M
+3 -2 D
+P
+FO
+1110 3406 M
+-1 2 D
+P
+FO
+1024 3516 M
+3 -2 D
+P
+FO
+1036 3503 M
+3 1 D
+P
+FO
+1167 3420 M
+2 2 D
+P
+FO
+1099 3448 M
+1 -1 D
+P
+FO
+1162 3410 M
+2 1 D
+-2 0 D
+P
+FO
+1140 3372 M
+3 0 D
+-3 1 D
+P
+FO
+1065 3507 M
+2 -2 D
+P
+FO
+1081 3493 M
+3 -2 D
+-3 3 D
+P
+FO
+1141 3446 M
+3 0 D
+P
+FO
+1046 3489 M
+3 -1 D
+P
+FO
+1080 3495 M
+2 -1 D
+P
+FO
+1152 3427 M
+1 1 D
+P
+FO
+1147 3368 M
+2 -1 D
+P
+FO
+1170 3396 M
+2 1 D
+P
+FO
+1138 3437 M
+1 1 D
+P
+FO
+1159 3433 M
+0 1 D
+P
+FO
+1164 3419 M
+2 0 D
+P
+FO
+6 1 -5 -4 2 1093 3532 SP
+1245 3307 M
+2 1 D
+-3 -1 D
+P
+FO
+1285 3307 M
+4 1 D
+5 -1 D
+-4 3 D
+-1 5 D
+-34 5 D
+-24 8 D
+-13 -2 D
+9 -8 D
+1 2 D
+1 -2 D
+10 2 D
+-11 3 D
+14 -2 D
+-4 -1 D
+4 -5 D
+-4 4 D
+-8 -1 D
+-1 -3 D
+6 -1 D
+-3 0 D
+3 -1 D
+-5 -3 D
+3 -1 D
+4 3 D
+1 -2 D
+4 2 D
+-2 -2 D
+2 0 D
+-1 -1 D
+3 -1 D
+1 4 D
+2 -3 D
+3 2 D
+-3 -3 D
+3 0 D
+-2 -1 D
+P
+FO
+1290 3307 M
+-3 0 D
+P
+FO
+1295 3307 M
+-1 3 D
+2 2 D
+-3 2 D
+-3 0 D
+3 -1 D
+-3 0 D
+1 -3 D
+P
+FO
+1306 3307 M
+-3 2 D
+1 -2 D
+P
+FO
+1323 3307 M
+5 2 D
+-5 3 D
+6 -3 D
+-5 -2 D
+93 0 D
+0 236 D
+-236 0 D
+0 -97 D
+2 2 D
+-2 -2 D
+0 -10 D
+2 -4 D
+-2 -2 D
+0 -3 D
+2 1 D
+-2 -3 D
+8 0 D
+-8 -2 D
+0 1 D
+0 -18 D
+11 1 D
+-10 -1 D
+3 -4 D
+-4 3 D
+0 -7 D
+16 -11 D
+2 2 D
+-2 4 D
+7 3 D
+-1 2 D
+2 -2 D
+-1 3 D
+2 -3 D
+6 6 D
+-1 -3 D
+6 -2 D
+-5 1 D
+-2 -2 D
+0 -5 D
+5 -3 D
+5 2 D
+5 0 D
+3 -4 D
+-3 0 D
+0 3 D
+-5 0 D
+-4 -1 D
+1 -2 D
+-8 5 D
+-4 0 D
+1 -3 D
+2 1 D
+0 -5 D
+5 -2 D
+-1 2 D
+3 -3 D
+2 0 D
+-2 -1 D
+3 0 D
+-3 0 D
+1 -4 D
+3 1 D
+-3 -1 D
+2 -2 D
+5 -1 D
+2 3 D
+3 0 D
+-3 -4 D
+7 0 D
+-6 0 D
+-2 -6 D
+-5 -5 D
+3 0 D
+5 9 D
+1 -8 D
+1 4 D
+0 -4 D
+2 4 D
+-1 -1 D
+1 -6 D
+4 4 D
+-1 -2 D
+8 3 D
+-5 5 D
+7 -5 D
+2 4 D
+6 2 D
+-6 -4 D
+1 -3 D
+5 -1 D
+-4 0 D
+-7 -3 D
+2 -2 D
+-6 -2 D
+4 2 D
+-3 0 D
+-2 -4 D
+-5 -1 D
+1 -6 D
+4 -1 D
+-3 0 D
+0 -2 D
+4 0 D
+-1 -1 D
+5 5 D
+-5 0 D
+5 0 D
+2 4 D
+-2 -5 D
+5 1 D
+-6 -2 D
+-1 -3 D
+7 -2 D
+-7 0 D
+2 1 D
+-3 1 D
+-5 -4 D
+10 2 D
+-4 -2 D
+12 1 D
+-10 -2 D
+-3 0 D
+5 1 D
+-5 0 D
+-4 -1 D
+-1 -2 D
+7 -2 D
+-3 1 D
+9 2 D
+-3 -1 D
+-1 -1 D
+12 -1 D
+-15 1 D
+8 -1 D
+-6 0 D
+3 -1 D
+13 1 D
+3 2 D
+-3 -3 D
+-13 -1 D
+-4 2 D
+-1 -2 D
+12 -5 D
+3 2 D
+-7 1 D
+7 -1 D
+3 3 D
+0 -2 D
+4 0 D
+-5 0 D
+4 -1 D
+3 3 D
+8 -2 D
+-6 -1 D
+-1 1 D
+-2 -2 D
+9 1 D
+0 -2 D
+4 0 D
+-4 -3 D
+11 1 D
+5 7 D
+-5 -8 D
+-13 -1 D
+2 -1 D
+6 1 D
+-8 -3 D
+8 1 D
+-3 -1 D
+2 -1 D
+6 2 D
+-2 -1 D
+3 0 D
+0 -2 D
+5 7 D
+-3 -6 D
+4 0 D
+2 2 D
+1 -2 D
+1 1 D
+1 -2 D
+2 0 D
+5 5 D
+-1 4 D
+3 3 D
+-2 -3 D
+1 -5 D
+-4 -3 D
+-1 -3 D
+3 1 D
+-1 2 D
+1 -3 D
+3 -1 D
+4 3 D
+8 2 D
+-10 -4 D
+4 -2 D
+-5 -4 D
+2 0 D
+1 -2 D
+P
+1305 3466 M
+13 -12 D
+5 2 D
+-2 -4 D
+3 -2 D
+18 -2 D
+2 3 D
+13 2 D
+9 -3 D
+-9 2 D
+-4 -2 D
+-7 0 D
+-4 -2 D
+-14 1 D
+3 -6 D
+6 -3 D
+4 -6 D
+2 1 D
+1 -6 D
+-8 10 D
+-11 7 D
+2 -4 D
+-5 4 D
+0 3 D
+-11 2 D
+6 -2 D
+3 2 D
+-6 3 D
+-11 13 D
+P
+1240 3394 M
+28 4 D
+27 -10 D
+9 3 D
+-6 -3 D
+-11 -2 D
+8 2 D
+-18 7 D
+-12 2 D
+-7 -6 D
+-12 -4 D
+11 5 D
+2 3 D
+-23 -2 D
+P
+1262 3432 M
+1 -5 D
+5 -1 D
+1 2 D
+1 -4 D
+0 2 D
+14 -12 D
+11 -1 D
+-7 -1 D
+-5 1 D
+-15 13 D
+-5 1 D
+P
+1278 3385 M
+-9 -2 D
+-10 1 D
+-5 -2 D
+2 4 D
+-7 -2 D
+5 4 D
+1 -2 D
+13 -3 D
+16 3 D
+P
+1409 3368 M
+-9 -2 D
+-16 -1 D
+-1 1 D
+9 1 D
+6 6 D
+-4 -6 D
+15 2 D
+P
+1295 3418 M
+11 -1 D
+11 -6 D
+-5 1 D
+-10 5 D
+-4 -1 D
+-4 2 D
+P
+1270 3442 M
+17 -16 D
+-12 5 D
+0 2 D
+7 -4 D
+P
+1318 3344 M
+5 -8 D
+-1 -4 D
+-1 4 D
+-2 0 D
+2 1 D
+P
+1389 3523 M
+4 -1 D
+-1 -2 D
+-4 1 D
+P
+1290 3360 M
+4 -2 D
+-7 1 D
+P
+1304 3404 M
+5 -1 D
+-7 0 D
+P
+1341 3540 M
+-3 0 D
+P
+1300 3422 M
+-11 -2 D
+12 2 D
+P
+1241 3403 M
+-9 -6 D
+P
+1187 3436 M
+0 -2 D
+P
+1378 3445 M
+-5 0 D
+6 0 D
+P
+1299 3401 M
+-36 0 D
+16 2 D
+P
+FO
+1181 3393 M
+2 0 D
+-2 0 D
+0 -1 D
+3 0 D
+1 -5 D
+6 -2 D
+-3 0 D
+5 -2 D
+1 4 D
+1 -2 D
+2 2 D
+-16 9 D
+P
+FO
+1181 3383 M
+6 -1 D
+-4 6 D
+-2 1 D
+P
+FO
+1205 3371 M
+5 -1 D
+3 7 D
+-3 -7 D
+3 -1 D
+-4 -3 D
+8 -1 D
+-2 5 D
+0 -2 D
+-2 2 D
+3 6 D
+-1 4 D
+-11 5 D
+-1 -2 D
+4 -1 D
+-5 0 D
+-2 -5 D
+3 -1 D
+4 3 D
+-5 -4 D
+2 0 D
+-3 0 D
+P
+FO
+1231 3354 M
+0 -1 D
+4 1 D
+2 4 D
+10 4 D
+0 2 D
+-5 -1 D
+-4 -3 D
+-4 0 D
+-2 -3 D
+2 0 D
+-3 0 D
+P
+FO
+1218 3372 M
+2 -2 D
+-2 0 D
+0 -3 D
+3 0 D
+0 4 D
+1 -3 D
+3 6 D
+-5 -2 D
+-1 1 D
+P
+FO
+1300 3312 M
+3 -1 D
+-2 0 D
+2 -1 D
+2 1 D
+-1 3 D
+-3 0 D
+P
+FO
+1230 3354 M
+-1 2 D
+-4 -1 D
+0 -2 D
+-3 -1 D
+4 0 D
+0 -3 D
+P
+FO
+1218 3359 M
+0 -2 D
+2 1 D
+1 -2 D
+2 3 D
+-5 1 D
+-1 -1 D
+P
+FO
+1254 3327 M
+3 -2 D
+6 1 D
+-4 1 D
+-2 -1 D
+P
+FO
+1299 3311 M
+-2 -1 D
+2 -3 D
+3 2 D
+-3 4 D
+P
+FO
+1205 3391 M
+2 0 D
+2 4 D
+-9 -2 D
+1 -6 D
+P
+FO
+1228 3342 M
+3 -1 D
+0 3 D
+-5 3 D
+-1 -2 D
+P
+FO
+1196 3382 M
+2 -2 D
+3 1 D
+-3 5 D
+P
+FO
+1260 3320 M
+6 -1 D
+5 2 D
+-2 1 D
+P
+FO
+1261 3323 M
+7 -1 D
+4 3 D
+-4 2 D
+P
+FO
+1290 3314 M
+6 1 D
+-3 3 D
+-1 -3 D
+P
+FO
+1210 3364 M
+2 -3 D
+2 4 D
+-4 1 D
+P
+FO
+1228 3358 M
+3 1 D
+-2 3 D
+-3 -3 D
+P
+FO
+1308 3313 M
+-3 1 D
+1 0 D
+0 -3 D
+2 1 D
+P
+FO
+1215 3371 M
+1 -2 D
+0 6 D
+P
+FO
+1205 3395 M
+-2 -1 D
+5 2 D
+P
+FO
+1276 3317 M
+6 0 D
+-2 1 D
+P
+FO
+1232 3328 M
+5 -1 D
+-2 2 D
+P
+FO
+1294 3314 M
+3 -1 D
+-1 2 D
+P
+FO
+1218 3367 M
+0 -2 D
+4 1 D
+P
+FO
+1181 3390 M
+1 -1 D
+2 2 D
+P
+FO
+1205 3365 M
+1 4 D
+-8 5 D
+0 -3 D
+P
+FO
+1205 3390 M
+-3 -5 D
+4 1 D
+P
+FO
+1195 3378 M
+3 -1 D
+-6 5 D
+P
+FO
+1189 3378 M
+3 -1 D
+-5 4 D
+P
+FO
+1223 3354 M
+2 2 D
+-1 3 D
+P
+FO
+1228 3356 M
+3 3 D
+-6 -1 D
+P
+FO
+1286 3316 M
+4 0 D
+2 2 D
+P
+FO
+1217 3364 M
+2 -1 D
+3 3 D
+P
+FO
+1223 3361 M
+4 1 D
+-1 3 D
+P
+FO
+1252 3323 M
+-4 -1 D
+8 0 D
+P
+FO
+1237 3332 M
+3 1 D
+P
+FO
+1281 3316 M
+6 1 D
+-6 0 D
+P
+FO
+1298 3312 M
+-1 2 D
+-1 -3 D
+P
+FO
+1262 3321 M
+5 1 D
+P
+FO
+1228 3348 M
+1 -2 D
+P
+FO
+1224 3360 M
+4 1 D
+P
+FO
+1254 3327 M
+4 0 D
+P
+FO
+1228 3329 M
+4 -1 D
+P
+FO
+1218 3354 M
+-1 -1 D
+P
+FO
+1228 3349 M
+-1 0 D
+P
+FO
+1296 3316 M
+1 0 D
+-1 1 D
+P
+FO
+1299 3314 M
+0 1 D
+P
+FO
+1197 3374 M
+-1 1 D
+1 -2 D
+P
+FO
+1257 3321 M
+2 -1 D
+P
+FO
+1225 3349 M
+0 -1 D
+P
+FO
+1261 3325 M
+3 0 D
+P
+FO
+1259 3325 M
+2 0 D
+P
+FO
+1234 3342 M
+2 1 D
+P
+FO
+1208 3396 M
+-1 -1 D
+P
+FO
+1196 3384 M
+1 1 D
+P
+FO
+1255 3329 M
+2 0 D
+P
+FO
+1262 3322 M
+2 0 D
+P
+FO
+1236 3319 M
+2 0 D
+P
+FO
+1428 3307 M
+1 5 D
+4 3 D
+-3 -4 D
+0 -4 D
+47 0 D
+1 2 D
+1 -2 D
+11 0 D
+0 4 D
+0 -4 D
+164 0 D
+0 105 D
+-5 1 D
+1 3 D
+4 0 D
+0 4 D
+-1 0 D
+1 37 D
+-2 -2 D
+2 2 D
+0 62 D
+-11 -5 D
+2 -3 D
+-10 0 D
+-1 -4 D
+0 4 D
+-3 0 D
+-3 -3 D
+0 3 D
+-5 1 D
+0 3 D
+4 -1 D
+-1 -1 D
+8 3 D
+6 6 D
+14 5 D
+0 16 D
+-237 0 D
+0 -236 D
+P
+1604 3504 M
+-5 3 D
+3 2 D
+-6 1 D
+-1 2 D
+9 4 D
+3 -1 D
+-6 -1 D
+3 -1 D
+6 1 D
+3 -2 D
+-5 -5 D
+5 -4 D
+P
+1440 3332 M
+1 -1 D
+2 3 D
+-2 -7 D
+-8 -4 D
+0 2 D
+6 1 D
+1 4 D
+-12 -2 D
+11 2 D
+P
+1540 3432 M
+-14 4 D
+-4 -3 D
+-5 2 D
+-2 -1 D
+-9 5 D
+5 -2 D
+25 1 D
+5 -6 D
+P
+1472 3325 M
+-4 -3 D
+-1 -7 D
+3 -3 D
+-3 -3 D
+-1 13 D
+P
+1603 3423 M
+1 -1 D
+4 1 D
+2 -3 D
+-11 2 D
+P
+1439 3371 M
+15 -13 D
+6 1 D
+0 -2 D
+-8 0 D
+0 3 D
+-13 12 D
+P
+1643 3462 M
+2 -3 D
+-5 2 D
+3 0 D
+-2 1 D
+2 1 D
+P
+1527 3447 M
+4 0 D
+-6 -3 D
+-4 3 D
+P
+1542 3465 M
+5 -2 D
+-1 -2 D
+P
+1642 3438 M
+2 -3 D
+-5 1 D
+P
+1595 3390 M
+1 -2 D
+-3 -1 D
+P
+1556 3380 M
+3 -3 D
+-4 2 D
+P
+1543 3391 M
+6 -1 D
+-3 -1 D
+-4 2 D
+P
+1616 3514 M
+-3 -1 D
+-2 2 D
+P
+1453 3535 M
+-16 3 D
+12 2 D
+5 -5 D
+P
+1639 3406 M
+0 -2 D
+-4 0 D
+P
+1595 3485 M
+-1 -1 D
+-1 4 D
+P
+1550 3395 M
+0 -1 D
+-4 1 D
+P
+1648 3417 M
+-1 -2 D
+-2 2 D
+P
+1495 3441 M
+-1 -2 D
+-2 2 D
+P
+1565 3511 M
+-2 0 D
+1 2 D
+P
+1592 3483 M
+-3 -2 D
+-1 1 D
+P
+1624 3509 M
+-10 1 D
+4 3 D
+P
+1469 3351 M
+6 -2 D
+1 -3 D
+P
+1577 3432 M
+-1 -3 D
+-3 3 D
+P
+1617 3539 M
+0 -1 D
+P
+1561 3448 M
+-1 2 D
+2 2 D
+P
+1530 3518 M
+-8 2 D
+P
+1564 3448 M
+4 -2 D
+P
+1473 3455 M
+-5 -1 D
+P
+1646 3401 M
+0 -3 D
+P
+1440 3514 M
+-2 -1 D
+P
+1515 3314 M
+0 -3 D
+P
+1574 3445 M
+-1 -1 D
+0 1 D
+P
+1509 3478 M
+-2 -2 D
+P
+1490 3444 M
+0 -2 D
+P
+1577 3445 M
+-1 -2 D
+P
+1544 3453 M
+-1 -1 D
+P
+FO
+1749 3307 M
+-6 3 D
+8 1 D
+1 -4 D
+-2 0 D
+140 0 D
+0 41 D
+-4 4 D
+0 9 D
+4 6 D
+-1 6 D
+-5 3 D
+-3 -3 D
+3 -1 D
+0 -3 D
+-4 3 D
+0 5 D
+-7 0 D
+3 -2 D
+-2 -3 D
+-4 0 D
+1 2 D
+-4 -1 D
+-2 8 D
+5 -1 D
+6 2 D
+14 -3 D
+0 1 D
+-7 2 D
+-3 3 D
+-2 -1 D
+-10 4 D
+2 2 D
+6 -1 D
+-2 3 D
+9 0 D
+-4 5 D
+7 3 D
+-7 -2 D
+-2 2 D
+7 0 D
+-3 6 D
+1 1 D
+2 -1 D
+3 2 D
+3 -3 D
+0 36 D
+-6 3 D
+-4 0 D
+-2 -4 D
+0 2 D
+-6 1 D
+7 3 D
+-1 6 D
+1 0 D
+2 -7 D
+5 0 D
+2 -2 D
+2 0 D
+0 72 D
+-4 1 D
+4 0 D
+0 3 D
+-1 0 D
+-1 2 D
+2 0 D
+0 8 D
+-1 -1 D
+0 2 D
+-3 0 D
+3 4 D
+1 -2 D
+0 5 D
+-1 -3 D
+-5 4 D
+4 -1 D
+-1 3 D
+3 3 D
+-44 0 D
+-1 -1 D
+-2 1 D
+-2 -1 D
+-53 1 D
+0 -1 D
+3 -2 D
+-2 1 D
+-2 -2 D
+0 4 D
+-7 0 D
+-6 -3 D
+4 3 D
+-19 0 D
+-1 -5 D
+-4 -1 D
+3 3 D
+-3 2 D
+5 1 D
+-10 0 D
+-3 0 D
+1 -4 D
+-4 -1 D
+0 4 D
+-1 -3 D
+-3 0 D
+3 4 D
+-88 0 D
+0 -16 D
+4 1 D
+7 6 D
+7 0 D
+4 -3 D
+6 1 D
+-3 -4 D
+18 3 D
+22 -4 D
+29 -1 D
+-16 -1 D
+-25 3 D
+-2 -4 D
+-8 -1 D
+-22 -1 D
+-5 1 D
+-16 -4 D
+0 -98 D
+4 4 D
+6 1 D
+-1 -4 D
+-6 0 D
+-3 -2 D
+0 -4 D
+3 -1 D
+-3 -3 D
+0 -105 D
+P
+1812 3456 M
+3 4 D
+-3 0 D
+-1 2 D
+2 1 D
+2 -1 D
+1 8 D
+0 -10 D
+4 1 D
+5 7 D
+-3 -5 D
+5 2 D
+-1 2 D
+3 0 D
+0 7 D
+-5 0 D
+3 4 D
+-4 2 D
+-4 -1 D
+1 4 D
+6 2 D
+-1 4 D
+4 -1 D
+4 4 D
+6 3 D
+1 3 D
+4 1 D
+-3 -4 D
+2 0 D
+5 5 D
+0 -5 D
+-4 -4 D
+4 1 D
+2 2 D
+1 -1 D
+3 1 D
+0 -2 D
+-6 -5 D
+-8 -3 D
+-1 -3 D
+8 -2 D
+-6 -2 D
+3 -5 D
+-12 -5 D
+5 0 D
+-5 -2 D
+1 -2 D
+-10 -2 D
+-4 -4 D
+-3 2 D
+-4 -4 D
+P
+1836 3470 M
+3 1 D
+-1 4 D
+P
+1827 3482 M
+3 0 D
+2 2 D
+P
+1847 3495 M
+-5 -2 D
+P
+1828 3482 M
+-2 -1 D
+P
+1839 3483 M
+-2 -1 D
+P
+1839 3492 M
+-1 -3 D
+P
+1827 3484 M
+-4 -2 D
+P
+1683 3468 M
+3 0 D
+1 -3 D
+3 1 D
+2 -8 D
+2 2 D
+6 -1 D
+-1 -4 D
+-4 0 D
+3 -5 D
+-4 -5 D
+-4 0 D
+-4 -4 D
+0 -4 D
+-2 10 D
+-7 0 D
+-5 4 D
+8 1 D
+7 -5 D
+-1 -2 D
+3 1 D
+1 5 D
+5 2 D
+-2 3 D
+0 -1 D
+-2 2 D
+-4 -1 D
+3 7 D
+-2 -3 D
+-3 0 D
+0 5 D
+-6 0 D
+P
+1696 3458 M
+-1 -2 D
+P
+1691 3459 M
+2 -2 D
+P
+1699 3458 M
+-1 -2 D
+P
+1686 3464 M
+1 -3 D
+P
+1820 3508 M
+5 -3 D
+-6 -3 D
+-1 -1 D
+3 0 D
+-8 -3 D
+1 -7 D
+-5 -3 D
+4 3 D
+-7 3 D
+-8 -4 D
+6 4 D
+-5 1 D
+8 4 D
+-7 -2 D
+6 6 D
+-4 -1 D
+2 3 D
+9 2 D
+2 3 D
+0 -2 D
+5 1 D
+P
+1805 3496 M
+4 0 D
+0 2 D
+P
+1808 3494 M
+3 2 D
+P
+1782 3432 M
+-1 -2 D
+5 2 D
+1 -3 D
+-4 -1 D
+-3 1 D
+-4 -5 D
+-10 0 D
+-1 3 D
+2 2 D
+-2 1 D
+3 2 D
+3 0 D
+-2 -2 D
+10 3 D
+-1 -2 D
+P
+1742 3489 M
+5 -1 D
+-3 -2 D
+3 -1 D
+-1 -3 D
+-2 1 D
+-2 -2 D
+-11 -1 D
+1 2 D
+-3 0 D
+-7 -5 D
+-1 1 D
+4 1 D
+-5 1 D
+5 2 D
+-3 2 D
+4 -2 D
+15 8 D
+P
+1741 3488 M
+-3 -2 D
+3 1 D
+P
+1741 3483 M
+-3 -1 D
+P
+1730 3483 M
+7 2 D
+P
+1729 3337 M
+9 -7 D
+-5 2 D
+-5 -1 D
+-4 -7 D
+-3 0 D
+-9 -2 D
+-11 0 D
+2 2 D
+9 -2 D
+12 3 D
+4 7 D
+4 1 D
+-5 4 D
+P
+1816 3422 M
+-3 -1 D
+-2 2 D
+-3 -1 D
+2 -2 D
+-4 -2 D
+4 -1 D
+-3 -2 D
+-4 1 D
+1 3 D
+-3 1 D
+5 -1 D
+3 6 D
+8 -3 D
+P
+1816 3436 M
+-5 -2 D
+1 -2 D
+9 -3 D
+7 1 D
+-4 -1 D
+1 -4 D
+-3 4 D
+-5 -3 D
+2 3 D
+-6 1 D
+-5 4 D
+P
+1707 3447 M
+2 -5 D
+-2 -7 D
+-2 -1 D
+1 -4 D
+-6 7 D
+3 -1 D
+-6 4 D
+9 -3 D
+-4 6 D
+4 -3 D
+P
+1873 3454 M
+-5 2 D
+0 2 D
+7 -3 D
+-1 2 D
+4 -1 D
+4 4 D
+3 -1 D
+4 1 D
+-10 -5 D
+2 -2 D
+P
+1769 3526 M
+5 -1 D
+-15 -3 D
+-5 -2 D
+0 -2 D
+-3 0 D
+2 3 D
+12 5 D
+P
+1761 3524 M
+3 1 D
+P
+1787 3502 M
+3 -1 D
+-3 -3 D
+2 0 D
+-5 -2 D
+1 4 D
+-2 0 D
+P
+1816 3528 M
+-3 -3 D
+2 -2 D
+3 1 D
+-2 -3 D
+-5 3 D
+2 4 D
+P
+1873 3368 M
+3 -4 D
+-3 -1 D
+0 2 D
+-2 0 D
+-2 3 D
+3 1 D
+P
+1673 3489 M
+-3 -1 D
+4 0 D
+-1 -2 D
+-4 0 D
+2 1 D
+-2 1 D
+P
+1737 3439 M
+1 -5 D
+-2 3 D
+-2 -4 D
+-3 0 D
+-1 2 D
+5 4 D
+P
+1780 3440 M
+4 -2 D
+3 1 D
+-5 -4 D
+1 3 D
+-4 2 D
+P
+1716 3430 M
+3 -1 D
+0 -3 D
+-4 0 D
+0 3 D
+-2 0 D
+P
+1809 3393 M
+-2 -3 D
+-2 2 D
+-2 -2 D
+-5 -1 D
+4 4 D
+P
+1841 3418 M
+-2 -6 D
+-3 0 D
+-3 2 D
+1 3 D
+3 3 D
+P
+1840 3418 M
+-3 0 D
+-1 -1 D
+P
+1716 3423 M
+9 -4 D
+-11 -3 D
+1 2 D
+-3 -1 D
+-1 2 D
+P
+1672 3541 M
+10 -2 D
+2 -2 D
+-13 0 D
+-5 3 D
+P
+1862 3432 M
+-3 -5 D
+-2 2 D
+-2 -3 D
+-2 4 D
+P
+1768 3340 M
+-1 -7 D
+7 -8 D
+-3 1 D
+-6 7 D
+2 7 D
+P
+1856 3416 M
+-6 -3 D
+-4 1 D
+5 4 D
+0 -2 D
+P
+1663 3462 M
+4 -2 D
+-2 -3 D
+0 4 D
+-4 -1 D
+1 2 D
+P
+1859 3457 M
+-5 -1 D
+-1 -6 D
+-2 3 D
+2 3 D
+P
+1863 3417 M
+2 -2 D
+-5 -3 D
+2 3 D
+-4 0 D
+P
+1807 3524 M
+-3 -3 D
+-4 2 D
+4 2 D
+-1 -2 D
+P
+1861 3533 M
+-1 2 D
+3 -2 D
+2 2 D
+-1 -3 D
+P
+1678 3482 M
+4 -2 D
+-6 0 D
+2 1 D
+-4 0 D
+P
+1767 3434 M
+0 -2 D
+-8 -1 D
+1 2 D
+P
+1877 3407 M
+-6 -3 D
+-6 3 D
+3 2 D
+P
+1733 3522 M
+8 0 D
+-5 1 D
+5 1 D
+3 -2 D
+P
+1729 3523 M
+-10 -1 D
+-1 2 D
+3 1 D
+P
+1846 3458 M
+-1 -3 D
+-4 -1 D
+1 3 D
+P
+1830 3515 M
+9 3 D
+-5 -4 D
+P
+1861 3377 M
+0 -2 D
+-7 1 D
+2 3 D
+5 -1 D
+P
+1804 3512 M
+-1 -3 D
+-4 1 D
+1 2 D
+P
+1851 3443 M
+-9 -3 D
+-2 1 D
+9 4 D
+3 -2 D
+P
+1885 3477 M
+-1 -3 D
+3 -2 D
+0 -4 D
+-6 4 D
+P
+1698 3430 M
+1 -1 D
+-6 -1 D
+0 3 D
+P
+1867 3405 M
+2 -3 D
+-7 -1 D
+-1 3 D
+P
+1787 3354 M
+3 -4 D
+-2 -1 D
+-4 1 D
+P
+1732 3419 M
+-2 -3 D
+-4 -1 D
+0 3 D
+P
+1821 3473 M
+-7 -3 D
+1 3 D
+3 -1 D
+P
+1856 3413 M
+1 -1 D
+-7 -1 D
+-1 1 D
+P
+1822 3425 M
+1 -2 D
+-5 -1 D
+2 3 D
+P
+1758 3412 M
+-4 -9 D
+-2 4 D
+2 6 D
+4 0 D
+P
+1741 3443 M
+-2 -1 D
+1 -2 D
+-5 1 D
+P
+1768 3507 M
+-2 -3 D
+-5 -2 D
+1 4 D
+P
+1848 3511 M
+2 6 D
+0 -5 D
+7 -3 D
+-9 1 D
+P
+1872 3512 M
+1 2 D
+5 1 D
+-5 -5 D
+0 2 D
+P
+1837 3405 M
+2 -4 D
+-7 0 D
+2 4 D
+P
+1753 3436 M
+-6 -3 D
+-6 0 D
+7 4 D
+P
+1883 3417 M
+-2 -2 D
+-7 1 D
+4 3 D
+6 -2 D
+P
+1843 3446 M
+4 0 D
+-7 -3 D
+P
+1699 3424 M
+0 -3 D
+-3 2 D
+P
+1887 3435 M
+-4 -2 D
+-2 2 D
+P
+1723 3415 M
+-3 -3 D
+-2 2 D
+P
+1878 3402 M
+-5 -1 D
+1 2 D
+4 0 D
+P
+1790 3424 M
+-10 -2 D
+-4 2 D
+P
+1792 3434 M
+-8 1 D
+5 1 D
+P
+1691 3414 M
+3 -2 D
+-5 0 D
+P
+1709 3448 M
+2 -3 D
+-2 0 D
+0 4 D
+P
+1774 3368 M
+-2 -4 D
+-1 3 D
+P
+1756 3517 M
+2 -2 D
+-6 1 D
+P
+1690 3428 M
+1 -1 D
+-4 0 D
+3 2 D
+P
+1845 3405 M
+-4 -2 D
+1 2 D
+P
+1878 3516 M
+3 2 D
+1 -1 D
+P
+1711 3389 M
+2 -2 D
+-3 0 D
+P
+1722 3371 M
+-3 -2 D
+0 2 D
+P
+1885 3464 M
+-2 -2 D
+0 2 D
+P
+1883 3424 M
+-3 -2 D
+0 2 D
+P
+1886 3452 M
+-2 -1 D
+0 2 D
+P
+1721 3406 M
+6 -8 D
+-6 5 D
+P
+1739 3404 M
+-1 -1 D
+-2 1 D
+P
+1819 3515 M
+3 2 D
+1 -2 D
+P
+1843 3398 M
+-7 -3 D
+2 4 D
+P
+1831 3410 M
+-10 0 D
+3 1 D
+P
+1811 3473 M
+2 -2 D
+-6 -4 D
+1 4 D
+P
+1883 3368 M
+0 -5 D
+-2 1 D
+P
+1761 3428 M
+1 -2 D
+-5 0 D
+P
+1708 3472 M
+1 -4 D
+-6 1 D
+P
+1765 3399 M
+3 -3 D
+-6 2 D
+P
+1748 3443 M
+-3 -2 D
+0 2 D
+P
+1739 3402 M
+7 -3 D
+P
+1797 3352 M
+-3 -1 D
+-3 2 D
+P
+1857 3406 M
+-6 -3 D
+1 3 D
+P
+1662 3373 M
+0 -3 D
+-4 3 D
+P
+1698 3518 M
+-6 -3 D
+2 3 D
+P
+1746 3405 M
+-1 -3 D
+-3 0 D
+P
+1715 3414 M
+3 -2 D
+-5 -1 D
+P
+1694 3440 M
+-2 -3 D
+-1 2 D
+P
+1697 3473 M
+3 -2 D
+-6 1 D
+P
+1731 3411 M
+-9 -2 D
+8 3 D
+P
+1681 3392 M
+-1 -1 D
+P
+1728 3447 M
+-6 -3 D
+P
+1748 3412 M
+-1 2 D
+2 -1 D
+P
+1669 3536 M
+-7 2 D
+P
+1703 3457 M
+-1 -3 D
+P
+1806 3434 M
+-7 0 D
+P
+1795 3410 M
+-2 1 D
+0 2 D
+P
+1687 3394 M
+-2 -4 D
+P
+1815 3446 M
+-2 2 D
+4 0 D
+P
+1722 3495 M
+-4 -2 D
+4 3 D
+P
+1669 3413 M
+-4 -2 D
+P
+1877 3433 M
+-3 -2 D
+P
+1729 3496 M
+-5 -3 D
+P
+1767 3369 M
+-2 -1 D
+P
+1858 3404 M
+-1 -2 D
+P
+1827 3345 M
+1 -2 D
+P
+1692 3405 M
+3 -1 D
+P
+1869 3516 M
+4 2 D
+P
+1693 3426 M
+-2 -1 D
+2 2 D
+P
+1832 3407 M
+-2 -1 D
+P
+1674 3483 M
+-1 -1 D
+P
+1662 3414 M
+-3 0 D
+P
+1856 3411 M
+-2 -1 D
+P
+1727 3413 M
+0 -1 D
+-1 1 D
+P
+1723 3333 M
+-2 -1 D
+P
+1671 3460 M
+1 -2 D
+P
+FO
+1890 3395 M
+-6 -2 D
+6 -2 D
+P
+FO
+1890 3404 M
+-6 -2 D
+5 -2 D
+-3 -1 D
+1 -2 D
+3 1 D
+P
+FO
+-1 -1 1 1877 3380 SP
+2080 3307 M
+-2 1 D
+2 2 D
+4 -3 D
+42 0 D
+0 87 D
+-9 2 D
+1 2 D
+4 -1 D
+4 2 D
+0 74 D
+-19 7 D
+-37 -9 D
+4 3 D
+-6 0 D
+-8 -4 D
+6 5 D
+3 6 D
+-19 34 D
+-5 -2 D
+-3 2 D
+-15 0 D
+-2 -9 D
+2 9 D
+-6 -2 D
+-4 5 D
+-5 3 D
+-3 0 D
+4 1 D
+0 4 D
+3 2 D
+-4 7 D
+2 3 D
+-2 5 D
+-113 0 D
+-1 -4 D
+6 0 D
+-2 -5 D
+-3 0 D
+2 4 D
+-10 2 D
+-1 -9 D
+4 3 D
+2 -2 D
+-6 -3 D
+0 -8 D
+6 1 D
+-6 -3 D
+0 -3 D
+6 1 D
+2 -1 D
+-8 -1 D
+0 -72 D
+1 0 D
+-1 -38 D
+5 1 D
+-5 -2 D
+0 -6 D
+8 5 D
+2 -1 D
+-4 -6 D
+-3 2 D
+-1 -3 D
+-2 0 D
+0 -4 D
+2 -3 D
+-2 -2 D
+3 -3 D
+3 2 D
+9 1 D
+-1 -7 D
+-4 0 D
+-1 4 D
+0 -2 D
+-4 1 D
+-3 -2 D
+-2 0 D
+0 -1 D
+6 -2 D
+-1 -2 D
+3 1 D
+-2 -2 D
+2 -7 D
+-5 -6 D
+3 -6 D
+-2 -7 D
+2 0 D
+1 3 D
+2 -1 D
+0 -5 D
+-3 -1 D
+-5 3 D
+0 8 D
+-1 -48 D
+P
+1927 3379 M
+-14 0 D
+-6 3 D
+1 4 D
+8 13 D
+13 -1 D
+11 -3 D
+-10 6 D
+7 10 D
+2 -1 D
+-2 -1 D
+5 0 D
+-8 -3 D
+-2 -4 D
+3 -2 D
+8 4 D
+-1 -3 D
+-4 0 D
+3 -9 D
+12 -14 D
+-3 -1 D
+10 -13 D
+1 -4 D
+-2 0 D
+6 -7 D
+-1 -2 D
+4 -1 D
+-2 -1 D
+12 -13 D
+-4 -3 D
+3 -11 D
+-5 2 D
+-1 -6 D
+-2 -2 D
+-6 1 D
+-2 6 D
+1 9 D
+8 7 D
+-3 0 D
+-6 -4 D
+6 10 D
+-4 3 D
+-4 -2 D
+-4 -5 D
+0 8 D
+-2 6 D
+-6 -3 D
+2 5 D
+-7 0 D
+1 -6 D
+-7 2 D
+-3 8 D
+-6 2 D
+-11 11 D
+1 2 D
+P
+1970 3335 M
+-2 0 D
+-4 -4 D
+4 1 D
+P
+1976 3336 M
+-2 1 D
+-3 -2 D
+P
+1956 3359 M
+-2 -1 D
+P
+1936 3365 M
+2 -4 D
+0 6 D
+P
+1973 3338 M
+-2 -1 D
+P
+1955 3363 M
+-2 -2 D
+P
+1910 3349 M
+6 -10 D
+-2 7 D
+3 2 D
+3 -4 D
+-2 -4 D
+6 -3 D
+-2 -4 D
+-3 -2 D
+0 -2 D
+9 -2 D
+10 -9 D
+0 -3 D
+-5 -3 D
+-6 -1 D
+-3 2 D
+-1 7 D
+-6 8 D
+0 2 D
+-4 3 D
+1 1 D
+3 -3 D
+0 6 D
+-2 -2 D
+-5 9 D
+-3 -1 D
+-1 3 D
+-4 0 D
+-1 -3 D
+1 6 D
+4 0 D
+2 -4 D
+2 1 D
+P
+1897 3467 M
+4 0 D
+5 6 D
+4 -3 D
+3 5 D
+-1 -4 D
+5 -1 D
+-2 4 D
+5 0 D
+2 4 D
+-6 1 D
+10 1 D
+-3 6 D
+1 1 D
+1 -2 D
+5 3 D
+4 0 D
+-6 -4 D
+3 0 D
+1 -3 D
+5 1 D
+-4 -2 D
+-1 -5 D
+-9 -1 D
+-5 -6 D
+-6 2 D
+-5 -5 D
+-7 1 D
+0 -2 D
+-4 3 D
+P
+1924 3475 M
+5 1 D
+-6 1 D
+P
+1909 3469 M
+-2 -1 D
+P
+2091 3324 M
+-10 -4 D
+2 -3 D
+-3 -2 D
+7 -1 D
+-9 -1 D
+0 2 D
+-3 1 D
+-1 -4 D
+-2 2 D
+-3 -3 D
+0 3 D
+-7 -2 D
+-2 5 D
+-4 -3 D
+0 5 D
+-4 2 D
+4 0 D
+3 -2 D
+3 2 D
+0 -5 D
+7 1 D
+4 -2 D
+7 4 D
+-5 0 D
+8 2 D
+2 2 D
+P
+2040 3420 M
+-7 0 D
+-2 -3 D
+-10 -1 D
+-1 -3 D
+-7 -2 D
+2 3 D
+4 1 D
+-1 2 D
+4 1 D
+-2 3 D
+9 1 D
+P
+2030 3419 M
+-5 -2 D
+P
+1940 3534 M
+3 3 D
+-4 0 D
+3 2 D
+5 -4 D
+-3 -6 D
+-2 2 D
+-5 -2 D
+-2 2 D
+7 2 D
+-2 0 D
+P
+2017 3401 M
+2 0 D
+-4 -2 D
+3 -1 D
+13 1 D
+0 -3 D
+-9 -1 D
+-2 -1 D
+-8 1 D
+-3 5 D
+P
+1968 3424 M
+-8 -2 D
+-1 -2 D
+-5 -1 D
+-2 1 D
+-1 -3 D
+-7 1 D
+-3 -3 D
+-7 0 D
+9 4 D
+P
+2052 3337 M
+-1 -2 D
+3 -1 D
+-5 -1 D
+3 -1 D
+-2 -1 D
+-6 6 D
+2 1 D
+P
+2048 3334 M
+-2 1 D
+P
+2113 3373 M
+1 -2 D
+-4 2 D
+-4 -2 D
+-4 1 D
+5 1 D
+-1 2 D
+4 0 D
+P
+2115 3333 M
+-22 -5 D
+3 3 D
+2 -1 D
+-3 2 D
+8 -1 D
+9 5 D
+-1 -2 D
+3 1 D
+P
+1901 3496 M
+0 -3 D
+-5 -3 D
+0 -5 D
+-5 0 D
+0 3 D
+3 0 D
+1 3 D
+P
+1926 3510 M
+2 2 D
+-3 1 D
+4 -1 D
+3 1 D
+-2 -3 D
+3 0 D
+1 -3 D
+P
+1954 3430 M
+-9 -4 D
+9 0 D
+-16 -2 D
+2 1 D
+-2 0 D
+9 5 D
+P
+2001 3424 M
+-3 -1 D
+1 -2 D
+-12 -3 D
+2 2 D
+-5 0 D
+15 5 D
+P
+1994 3439 M
+-2 -3 D
+-6 -1 D
+0 2 D
+4 1 D
+-2 0 D
+6 2 D
+P
+1934 3515 M
+5 1 D
+4 -2 D
+4 2 D
+-3 -2 D
+P
+1948 3437 M
+-4 -3 D
+-5 -1 D
+5 2 D
+-4 -1 D
+0 1 D
+P
+2016 3315 M
+-3 -2 D
+-7 1 D
+3 2 D
+4 -2 D
+0 2 D
+P
+1917 3516 M
+2 4 D
+1 -3 D
+5 -1 D
+-3 -2 D
+0 2 D
+P
+2065 3378 M
+-2 1 D
+-9 -2 D
+-8 2 D
+17 2 D
+3 -1 D
+P
+1977 3464 M
+1 -3 D
+-11 -1 D
+6 1 D
+-2 2 D
+3 -1 D
+P
+2066 3361 M
+-1 -2 D
+-4 -1 D
+1 2 D
+-3 1 D
+P
+1893 3341 M
+7 -6 D
+-2 -2 D
+-4 2 D
+-3 6 D
+P
+2012 3458 M
+-15 -1 D
+4 1 D
+-3 3 D
+P
+1933 3349 M
+-5 -1 D
+-3 -5 D
+-1 4 D
+6 4 D
+P
+2088 3348 M
+-5 -1 D
+-1 -5 D
+-3 1 D
+2 6 D
+P
+1953 3480 M
+-5 2 D
+9 0 D
+1 -2 D
+-2 -1 D
+-3 0 D
+P
+1955 3482 M
+-3 -2 D
+P
+1939 3464 M
+1 -4 D
+-6 0 D
+3 2 D
+-1 2 D
+P
+1906 3517 M
+-4 3 D
+8 -2 D
+3 2 D
+0 -2 D
+-7 -2 D
+P
+1915 3467 M
+0 -2 D
+4 1 D
+-1 -3 D
+-7 3 D
+4 2 D
+P
+1990 3316 M
+-3 -2 D
+0 2 D
+-3 -2 D
+0 3 D
+P
+1949 3480 M
+0 -4 D
+-2 -1 D
+1 4 D
+-2 1 D
+P
+1979 3400 M
+4 1 D
+4 -1 D
+-1 -2 D
+P
+1972 3406 M
+-6 -1 D
+-9 3 D
+11 1 D
+5 -2 D
+P
+2043 3404 M
+-11 1 D
+5 2 D
+0 -1 D
+P
+1960 3442 M
+-9 -1 D
+-2 -2 D
+1 4 D
+3 -2 D
+P
+1992 3434 M
+-1 -2 D
+-14 -1 D
+P
+1923 3523 M
+-1 3 D
+3 1 D
+0 -4 D
+P
+2051 3317 M
+2 -4 D
+-4 2 D
+0 3 D
+P
+2020 3359 M
+0 -2 D
+-6 0 D
+P
+2050 3420 M
+1 -2 D
+-5 0 D
+1 2 D
+P
+2119 3320 M
+-2 -3 D
+-4 -1 D
+4 5 D
+P
+1945 3475 M
+-4 -5 D
+-6 0 D
+8 7 D
+P
+2069 3412 M
+-5 -3 D
+-2 2 D
+3 2 D
+P
+2082 3396 M
+-8 0 D
+-2 2 D
+4 1 D
+P
+1994 3346 M
+0 -2 D
+-3 0 D
+0 2 D
+P
+1963 3420 M
+-1 -3 D
+-3 -1 D
+-1 3 D
+6 1 D
+P
+1904 3402 M
+3 -2 D
+-2 -5 D
+-2 1 D
+P
+1894 3422 M
+2 -1 D
+-3 -4 D
+-2 4 D
+P
+2112 3309 M
+-3 -2 D
+-2 2 D
+3 2 D
+P
+1900 3360 M
+2 -5 D
+-2 -3 D
+-2 3 D
+P
+1927 3332 M
+0 -1 D
+-4 0 D
+1 2 D
+P
+2077 3405 M
+-3 -1 D
+-2 2 D
+1 1 D
+P
+1987 3407 M
+2 2 D
+4 0 D
+-3 -2 D
+P
+2015 3408 M
+-7 -1 D
+4 2 D
+-1 1 D
+P
+2084 3341 M
+0 -2 D
+-6 -2 D
+2 4 D
+P
+1969 3516 M
+-1 3 D
+9 -1 D
+P
+2047 3382 M
+0 -2 D
+-6 0 D
+-2 3 D
+8 -2 D
+P
+2067 3415 M
+0 -1 D
+-3 1 D
+P
+1982 3454 M
+1 -3 D
+-12 -1 D
+-1 2 D
+P
+2110 3327 M
+-6 -3 D
+1 4 D
+P
+1961 3502 M
+-4 -8 D
+1 7 D
+P
+2049 3326 M
+-8 -3 D
+3 4 D
+P
+1942 3437 M
+-9 -3 D
+4 4 D
+5 0 D
+P
+2047 3412 M
+-3 -2 D
+-9 1 D
+13 1 D
+P
+2002 3401 M
+-4 -3 D
+-2 2 D
+P
+2037 3331 M
+-7 0 D
+6 3 D
+P
+2028 3311 M
+-5 0 D
+-3 3 D
+P
+2039 3361 M
+-1 -5 D
+-3 5 D
+P
+2083 3379 M
+-6 -3 D
+-1 0 D
+P
+2096 3376 M
+-5 -2 D
+2 3 D
+P
+2093 3334 M
+0 -2 D
+-6 2 D
+P
+1972 3414 M
+-3 -2 D
+-3 2 D
+P
+2046 3342 M
+-7 -1 D
+8 2 D
+0 -1 D
+P
+1993 3395 M
+-6 -2 D
+1 2 D
+6 0 D
+P
+1981 3391 M
+-6 -1 D
+4 2 D
+3 -1 D
+P
+2061 3367 M
+-3 -2 D
+-4 1 D
+P
+1935 3474 M
+-2 -4 D
+-2 3 D
+P
+1999 3354 M
+-1 -4 D
+-3 1 D
+P
+2108 3388 M
+-3 -2 D
+-2 3 D
+P
+2042 3331 M
+0 -2 D
+-4 0 D
+P
+2000 3359 M
+0 -3 D
+-4 0 D
+P
+2036 3375 M
+-2 -1 D
+-5 2 D
+P
+2067 3417 M
+-5 -1 D
+4 2 D
+P
+1902 3376 M
+1 -3 D
+-2 -1 D
+0 4 D
+P
+2029 3427 M
+-4 -1 D
+1 2 D
+P
+1967 3493 M
+-2 -2 D
+-3 2 D
+P
+2060 3428 M
+1 -1 D
+-6 0 D
+P
+1905 3376 M
+2 -1 D
+-2 -1 D
+P
+1972 3372 M
+-5 0 D
+3 1 D
+P
+2051 3439 M
+-1 -2 D
+-1 3 D
+P
+2083 3376 M
+-3 -1 D
+P
+1962 3477 M
+-1 -1 D
+0 2 D
+P
+2046 3376 M
+-2 -2 D
+-1 2 D
+P
+1992 3383 M
+0 -1 D
+-2 1 D
+P
+2024 3430 M
+-11 -6 D
+1 4 D
+P
+1935 3410 M
+-6 -6 D
+-3 0 D
+0 2 D
+P
+2109 3400 M
+-3 -4 D
+P
+2022 3370 M
+-6 -1 D
+P
+1904 3366 M
+2 -2 D
+-3 -1 D
+P
+1906 3369 M
+-1 -2 D
+P
+1926 3429 M
+-9 -8 D
+P
+2073 3416 M
+-4 1 D
+4 0 D
+P
+1945 3316 M
+1 -2 D
+P
+1966 3488 M
+-2 -1 D
+2 2 D
+P
+2081 3354 M
+-1 -2 D
+0 2 D
+P
+1947 3317 M
+1 -2 D
+P
+1963 3474 M
+-2 -1 D
+P
+2057 3439 M
+-4 0 D
+4 1 D
+P
+1965 3481 M
+-3 0 D
+P
+1946 3319 M
+0 -1 D
+P
+1903 3368 M
+-2 -1 D
+2 2 D
+P
+2082 3386 M
+-3 -2 D
+P
+1929 3409 M
+-6 -3 D
+-3 1 D
+P
+1895 3405 M
+-5 -6 D
+P
+1913 3334 M
+-2 1 D
+2 0 D
+P
+1904 3371 M
+-1 -1 D
+P
+2091 3369 M
+-3 -1 D
+P
+1900 3414 M
+-4 -2 D
+P
+2033 3315 M
+-2 -2 D
+0 2 D
+P
+1958 3451 M
+-4 0 D
+P
+1926 3439 M
+-3 -2 D
+P
+2074 3415 M
+-1 -2 D
+P
+2088 3378 M
+-3 -2 D
+P
+1928 3497 M
+-3 -2 D
+P
+2091 3366 M
+-5 0 D
+P
+1989 3429 M
+-15 -1 D
+P
+1899 3361 M
+-3 -1 D
+P
+2124 3312 M
+-4 0 D
+P
+1960 3432 M
+-16 0 D
+P
+1981 3456 M
+-12 -3 D
+P
+1981 3370 M
+-4 0 D
+P
+FO
+1890 3543 M
+P
+FO
+1890 3367 M
+0 2 D
+P
+FO
+2 5 1 -4 -3 -2 3 1894 3367 SP
+1 2 4 -1 2 1892 3541 SP
+-2 -1 1 1902 3384 SP
+2152 3307 M
+-1 1 D
+6 6 D
+10 -4 D
+-3 4 D
+6 -4 D
+-2 0 D
+0 -3 D
+2 1 D
+14 -1 D
+2 2 D
+3 -1 D
+-3 -1 D
+30 1 D
+-1 -1 D
+147 0 D
+0 29 D
+-9 3 D
+-6 -2 D
+5 3 D
+-3 7 D
+-11 8 D
+-13 5 D
+3 0 D
+-3 1 D
+1 4 D
+-14 10 D
+-5 2 D
+5 7 D
+-2 8 D
+2 5 D
+-8 9 D
+6 15 D
+-3 8 D
+1 -3 D
+-9 3 D
+-3 -1 D
+-4 2 D
+-9 0 D
+-8 2 D
+1 -2 D
+-6 2 D
+-31 -1 D
+2 2 D
+-18 8 D
+-24 6 D
+-11 1 D
+-4 2 D
+-2 -1 D
+-8 11 D
+-16 5 D
+-4 4 D
+-28 4 D
+0 -74 D
+10 -3 D
+-10 -2 D
+0 -87 D
+P
+2174 3325 M
+-4 0 D
+0 -3 D
+-8 -1 D
+7 4 D
+-10 1 D
+1 1 D
+5 -1 D
+-3 4 D
+5 -4 D
+P
+2191 3374 M
+-4 -1 D
+-1 2 D
+1 2 D
+2 -1 D
+-1 2 D
+-2 -1 D
+2 2 D
+P
+2183 3358 M
+-9 1 D
+-1 2 D
+3 1 D
+4 -3 D
+6 0 D
+P
+2149 3326 M
+-2 -2 D
+-3 2 D
+-3 -1 D
+2 2 D
+7 0 D
+P
+2151 3378 M
+-2 -4 D
+-12 1 D
+6 3 D
+3 -2 D
+6 2 D
+P
+2359 3317 M
+-1 -6 D
+0 4 D
+-5 -1 D
+4 4 D
+P
+2151 3320 M
+-5 -5 D
+0 2 D
+-2 0 D
+2 2 D
+P
+2191 3321 M
+-3 -3 D
+-6 1 D
+6 3 D
+-1 -2 D
+P
+2182 3342 M
+-1 -1 D
+-8 4 D
+P
+2131 3381 M
+3 -3 D
+-5 2 D
+3 1 D
+P
+2241 3407 M
+-2 -1 D
+2 2 D
+-1 -1 D
+P
+2165 3354 M
+-3 -1 D
+-7 0 D
+8 2 D
+P
+2198 3319 M
+-2 -1 D
+2 -1 D
+-3 0 D
+P
+2203 3316 M
+1 0 D
+-6 -1 D
+P
+2198 3326 M
+-7 0 D
+3 2 D
+P
+2239 3364 M
+2 -4 D
+-4 1 D
+1 3 D
+P
+2173 3391 M
+-8 0 D
+6 2 D
+P
+2223 3358 M
+0 -1 D
+0 2 D
+P
+2134 3323 M
+-8 -2 D
+P
+2185 3411 M
+0 -2 D
+P
+2252 3411 M
+-4 -7 D
+P
+2260 3400 M
+-5 0 D
+6 0 D
+P
+2211 3364 M
+1 -2 D
+P
+2179 3391 M
+-4 -1 D
+P
+2230 3343 M
+0 -2 D
+P
+2276 3328 M
+-3 0 D
+P
+2242 3345 M
+0 -2 D
+P
+2293 3335 M
+-3 -1 D
+P
+2244 3414 M
+-1 -2 D
+P
+2205 3432 M
+-1 -2 D
+P
+2267 3400 M
+-4 0 D
+P
+2215 3402 M
+-2 -2 D
+P
+2177 3393 M
+-2 -2 D
+P
+2192 3319 M
+-3 -1 D
+4 1 D
+P
+2208 3366 M
+0 -3 D
+P
+2234 3407 M
+-2 -1 D
+P
+2230 3386 M
+-1 -1 D
+P
+2289 3397 M
+-1 -1 D
+P
+2238 3387 M
+-1 -1 D
+P
+2264 3408 M
+-2 0 D
+P
+2208 3312 M
+-2 -1 D
+P
+2296 3335 M
+-2 -1 D
+P
+2253 3385 M
+-2 -1 D
+P
+2186 3318 M
+-3 -1 D
+P
+2212 3316 M
+-2 -1 D
+P
+2253 3415 M
+-2 -3 D
+P
+2299 3334 M
+-2 0 D
+P
+2284 3416 M
+0 -1 D
+P
+2207 3310 M
+-2 0 D
+P
+2277 3393 M
+-2 0 D
+P
+2216 3362 M
+0 -1 D
+0 2 D
+P
+FO
+2362 3387 M
+-2 -1 D
+2 -3 D
+P
+FO
+2362 3446 M
+P
+FO
+2362 3456 M
+-1 0 D
+-1 -2 D
+2 -1 D
+P
+FO
+2362 3539 M
+-1 2 D
+-3 -3 D
+4 0 D
+P
+FO
+2314 3378 M
+32 -7 D
+-2 5 D
+-8 7 D
+-17 -1 D
+P
+FO
+2356 3537 M
+-2 -2 D
+4 1 D
+P
+FO
+2351 3338 M
+1 1 D
+P
+FO
+2353 3536 M
+-2 -1 D
+P
+FO
+2351 3530 M
+0 -1 D
+P
+FO
+2336 3410 M
+0 -1 D
+P
+FO
+0 -1 -2 0 0 1 3 2160 3307 SP
+-1 0 0 1 2 2165 3307 SP
+0 -2 1 2163 3311 SP
+2421 3307 M
+1 6 D
+-5 2 D
+6 0 D
+-1 -8 D
+18 0 D
+-1 1 D
+129 -1 D
+-1 2 D
+2 4 D
+3 -4 D
+-2 -2 D
+-1 2 D
+0 -2 D
+29 0 D
+-1 40 D
+0 -3 D
+0 3 D
+-2 -4 D
+-3 8 D
+-4 -2 D
+2 2 D
+-2 0 D
+4 1 D
+3 -4 D
+3 2 D
+0 -1 D
+-1 42 D
+-3 3 D
+-2 -1 D
+2 3 D
+4 -3 D
+0 19 D
+-5 0 D
+-5 -2 D
+-1 0 D
+-1 2 D
+2 -1 D
+5 2 D
+5 0 D
+0 101 D
+0 -1 D
+-6 1 D
+6 1 D
+0 28 D
+-13 0 D
+-3 0 D
+-66 0 D
+-1 -1 D
+0 1 D
+-1 0 D
+-2 -2 D
+-4 2 D
+-31 0 D
+0 -1 D
+-51 1 D
+-4 -2 D
+4 -2 D
+-6 -1 D
+2 -3 D
+-8 1 D
+3 -4 D
+-5 0 D
+1 -2 D
+-2 -1 D
+7 -1 D
+-5 0 D
+2 -1 D
+-6 -1 D
+2 -1 D
+-5 -1 D
+1 -2 D
+-3 0 D
+-2 -4 D
+-4 -1 D
+-1 -3 D
+2 0 D
+-3 0 D
+2 -3 D
+-3 1 D
+6 -3 D
+-3 2 D
+3 0 D
+7 -6 D
+12 -3 D
+1 -2 D
+7 -3 D
+5 0 D
+-5 -1 D
+10 -8 D
+5 -11 D
+1 -19 D
+-3 -5 D
+2 0 D
+-15 -12 D
+3 1 D
+-16 -10 D
+3 0 D
+-50 -15 D
+6 -2 D
+-2 0 D
+3 -4 D
+-1 -1 D
+4 -1 D
+-4 0 D
+5 -2 D
+-2 -1 D
+8 0 D
+-1 -2 D
+-2 0 D
+5 -2 D
+-5 -2 D
+4 0 D
+-2 -2 D
+4 -1 D
+-4 0 D
+2 -3 D
+-2 1 D
+2 -1 D
+-2 -2 D
+5 -1 D
+-6 -1 D
+4 -3 D
+-1 -9 D
+5 -1 D
+-2 -2 D
+4 0 D
+-2 -1 D
+2 -1 D
+-4 -1 D
+4 -2 D
+-3 -1 D
+3 -1 D
+-2 -1 D
+7 -1 D
+-1 -3 D
+2 0 D
+-3 -3 D
+4 0 D
+-4 0 D
+-2 -6 D
+-5 -1 D
+1 -3 D
+-5 -1 D
+6 -4 D
+-1 -2 D
+3 -1 D
+-5 -2 D
+1 -5 D
+-3 7 D
+-6 1 D
+1 3 D
+-3 0 D
+-5 -2 D
+1 -2 D
+-6 -3 D
+3 -2 D
+-3 -3 D
+-6 2 D
+0 -29 D
+P
+2533 3339 M
+-9 -4 D
+3 -1 D
+7 3 D
+3 -1 D
+-10 -3 D
+-3 -3 D
+0 1 D
+-9 -7 D
+9 8 D
+-1 3 D
+-10 -10 D
+0 2 D
+-5 -7 D
+2 -4 D
+-2 0 D
+0 -4 D
+-6 -4 D
+-3 0 D
+9 5 D
+-2 3 D
+1 0 D
+2 7 D
+-3 -6 D
+-2 1 D
+-5 -4 D
+9 14 D
+-2 0 D
+1 2 D
+-2 0 D
+21 10 D
+3 -1 D
+-5 -2 D
+P
+2508 3324 M
+-1 -2 D
+P
+2511 3326 M
+-2 -1 D
+P
+2513 3329 M
+-1 -1 D
+P
+2523 3336 M
+-9 -6 D
+P
+2475 3321 M
+3 0 D
+-2 -2 D
+1 -2 D
+5 3 D
+0 -2 D
+4 0 D
+-10 -8 D
+5 7 D
+-3 0 D
+-1 -3 D
+-5 -1 D
+3 1 D
+-1 0 D
+2 3 D
+-1 2 D
+-3 -1 D
+1 2 D
+-3 0 D
+P
+2576 3329 M
+1 -2 D
+5 -4 D
+2 0 D
+1 3 D
+1 -3 D
+0 2 D
+1 -2 D
+1 1 D
+-1 -3 D
+0 2 D
+-1 -2 D
+-3 2 D
+-1 -3 D
+-3 0 D
+3 2 D
+-2 1 D
+-3 -2 D
+0 5 D
+-3 -2 D
+2 6 D
+P
+2445 3389 M
+0 -2 D
+-5 -1 D
+5 -1 D
+-4 -1 D
+2 -1 D
+-3 0 D
+1 -2 D
+-3 1 D
+-2 -2 D
+0 -2 D
+6 -1 D
+-7 0 D
+-2 3 D
+4 3 D
+-3 1 D
+3 1 D
+-2 1 D
+6 3 D
+-2 -4 D
+P
+2580 3379 M
+2 -2 D
+5 1 D
+-2 -2 D
+5 1 D
+-4 -1 D
+2 -8 D
+-3 6 D
+-3 -3 D
+1 2 D
+-3 0 D
+0 3 D
+-5 -3 D
+2 4 D
+4 0 D
+0 1 D
+-3 0 D
+P
+2425 3332 M
+0 -2 D
+5 -1 D
+8 2 D
+-4 -4 D
+7 5 D
+2 -1 D
+-4 -2 D
+1 -1 D
+-3 0 D
+-5 -3 D
+-1 3 D
+-4 1 D
+-3 -4 D
+1 2 D
+-2 0 D
+P
+2436 3331 M
+-3 -2 D
+P
+2497 3485 M
+1 -3 D
+-11 0 D
+6 -1 D
+-9 -2 D
+9 -4 D
+-6 2 D
+-17 -2 D
+-2 2 D
+10 0 D
+-5 2 D
+8 -1 D
+4 1 D
+2 2 D
+-4 2 D
+9 0 D
+6 2 D
+P
+2499 3460 M
+15 2 D
+-6 2 D
+7 -1 D
+2 2 D
+6 0 D
+-9 -3 D
+5 0 D
+-1 -1 D
+4 1 D
+-2 -2 D
+-10 1 D
+0 -2 D
+-3 0 D
+-3 -2 D
+-7 3 D
+P
+2549 3451 M
+4 1 D
+2 -2 D
+-5 0 D
+0 -1 D
+7 -1 D
+-3 1 D
+-1 -2 D
+3 0 D
+-3 -2 D
+-6 1 D
+3 1 D
+-3 1 D
+4 0 D
+-6 0 D
+0 3 D
+P
+2480 3506 M
+-3 -2 D
+1 -4 D
+4 -2 D
+-3 0 D
+-2 -1 D
+2 -1 D
+-4 1 D
+2 0 D
+-3 1 D
+0 2 D
+4 -1 D
+-5 3 D
+3 1 D
+-2 2 D
+P
+2497 3534 M
+4 -3 D
+18 -5 D
+-8 1 D
+-4 2 D
+-2 -1 D
+-1 2 D
+-11 -1 D
+-1 2 D
+-2 -2 D
+-4 2 D
+3 0 D
+-2 1 D
+2 1 D
+10 -2 D
+P
+2458 3513 M
+6 -1 D
+9 1 D
+7 -6 D
+-9 4 D
+0 -1 D
+-10 2 D
+-2 -2 D
+-10 4 D
+6 1 D
+0 -2 D
+4 -1 D
+P
+2509 3349 M
+-3 -3 D
+2 0 D
+0 -2 D
+-1 0 D
+0 -2 D
+-2 -1 D
+2 5 D
+-2 0 D
+2 3 D
+P
+2516 3426 M
+5 0 D
+10 4 D
+14 -1 D
+-12 -4 D
+-14 -1 D
+-1 1 D
+4 1 D
+-7 0 D
+P
+2480 3342 M
+2 -3 D
+3 1 D
+-2 -2 D
+-4 0 D
+1 3 D
+-3 -3 D
+-2 2 D
+-2 -2 D
+1 3 D
+P
+2448 3461 M
+4 -3 D
+-2 -1 D
+9 -5 D
+-16 0 D
+3 1 D
+-3 0 D
+5 3 D
+-2 3 D
+P
+2450 3453 M
+3 -1 D
+P
+2492 3329 M
+2 -2 D
+-2 1 D
+-3 -2 D
+3 0 D
+-1 -2 D
+-4 0 D
+-4 -2 D
+P
+2576 3383 M
+6 -2 D
+-4 -1 D
+-1 1 D
+0 -2 D
+-1 2 D
+-4 -3 D
+-3 2 D
+P
+2576 3382 M
+-1 0 D
+-2 -3 D
+P
+2475 3525 M
+5 -2 D
+-9 0 D
+5 -2 D
+-7 0 D
+0 2 D
+3 1 D
+-2 0 D
+P
+2472 3334 M
+-2 -3 D
+-1 3 D
+-2 -1 D
+3 2 D
+-6 -1 D
+6 2 D
+0 -2 D
+P
+2494 3456 M
+4 -4 D
+7 -1 D
+-2 -3 D
+-5 -1 D
+1 2 D
+-14 2 D
+0 5 D
+P
+2491 3452 M
+-2 0 D
+4 0 D
+P
+2492 3455 M
+2 -1 D
+P
+2501 3500 M
+10 -1 D
+1 1 D
+6 -2 D
+-17 1 D
+1 -1 D
+-7 1 D
+P
+2524 3452 M
+-3 -2 D
+3 -3 D
+-6 -3 D
+2 4 D
+-3 1 D
+6 4 D
+P
+2519 3449 M
+2 0 D
+P
+2573 3392 M
+4 -1 D
+-2 -1 D
+2 0 D
+-1 -1 D
+2 -1 D
+-5 1 D
+P
+2555 3393 M
+3 -2 D
+-4 -1 D
+4 0 D
+-5 -2 D
+-3 4 D
+5 0 D
+P
+2551 3526 M
+5 -7 D
+5 -1 D
+-5 -1 D
+-6 3 D
+2 1 D
+-3 4 D
+P
+2542 3517 M
+2 -3 D
+2 1 D
+-1 -3 D
+-9 5 D
+1 1 D
+P
+2514 3540 M
+1 -5 D
+-4 3 D
+-5 -1 D
+4 2 D
+-2 1 D
+6 1 D
+P
+2505 3522 M
+4 -1 D
+-1 -2 D
+-9 2 D
+4 0 D
+-2 2 D
+P
+2566 3515 M
+1 -1 D
+-9 0 D
+-2 -2 D
+-2 1 D
+2 3 D
+P
+2524 3484 M
+7 -1 D
+-15 -2 D
+4 2 D
+5 0 D
+-1 2 D
+P
+2594 3400 M
+-1 -2 D
+3 0 D
+-5 -2 D
+-2 2 D
+P
+2592 3398 M
+-2 -1 D
+P
+2594 3398 M
+-3 -1 D
+P
+2557 3536 M
+-6 -4 D
+-2 -4 D
+-1 4 D
+4 4 D
+P
+2449 3508 M
+4 -2 D
+-1 -3 D
+-4 3 D
+3 0 D
+P
+2398 3421 M
+12 -2 D
+-13 0 D
+1 2 D
+-4 0 D
+P
+2404 3419 M
+-2 1 D
+P
+2441 3316 M
+-2 -4 D
+-4 -1 D
+2 0 D
+-5 -3 D
+P
+2441 3374 M
+0 -3 D
+-3 -1 D
+2 2 D
+-3 2 D
+P
+2423 3512 M
+8 0 D
+-3 -1 D
+6 -2 D
+P
+2409 3413 M
+6 0 D
+-5 -2 D
+-4 1 D
+P
+2441 3338 M
+-9 0 D
+5 3 D
+0 -2 D
+5 -1 D
+P
+2577 3501 M
+8 -2 D
+-3 -2 D
+-8 4 D
+P
+2449 3368 M
+6 -1 D
+-10 -3 D
+P
+2416 3390 M
+-9 -1 D
+6 2 D
+P
+2526 3388 M
+6 1 D
+0 -1 D
+P
+2580 3536 M
+-4 -2 D
+-6 0 D
+P
+2498 3467 M
+7 -2 D
+-10 1 D
+P
+2503 3389 M
+2 -3 D
+-5 1 D
+P
+2456 3329 M
+-6 -1 D
+2 2 D
+P
+2415 3406 M
+2 -2 D
+-6 1 D
+P
+2435 3411 M
+2 -1 D
+-7 -1 D
+P
+2561 3490 M
+3 -1 D
+-6 -1 D
+P
+2597 3462 M
+1 -3 D
+-3 -1 D
+P
+2439 3409 M
+4 -2 D
+-9 2 D
+P
+2509 3371 M
+5 2 D
+2 -2 D
+P
+2446 3400 M
+6 3 D
+1 -1 D
+-8 -2 D
+P
+2420 3374 M
+4 -1 D
+-6 -1 D
+P
+2391 3334 M
+6 -3 D
+-7 2 D
+P
+2571 3375 M
+3 1 D
+-2 -2 D
+P
+2473 3496 M
+4 -3 D
+-4 1 D
+P
+2491 3340 M
+1 -3 D
+-4 3 D
+P
+2504 3347 M
+-5 -1 D
+2 2 D
+P
+2515 3348 M
+-2 -3 D
+2 4 D
+P
+2574 3494 M
+5 -1 D
+-6 0 D
+P
+2593 3375 M
+1 2 D
+1 -2 D
+-3 0 D
+P
+2568 3412 M
+1 1 D
+2 -1 D
+P
+2521 3387 M
+2 1 D
+0 -2 D
+P
+2381 3413 M
+4 1 D
+1 -2 D
+P
+2548 3368 M
+1 -1 D
+-3 0 D
+P
+2473 3349 M
+2 -1 D
+-6 -1 D
+P
+2379 3416 M
+-1 0 D
+3 0 D
+P
+2595 3528 M
+-11 -3 D
+P
+2503 3338 M
+-2 -1 D
+P
+2384 3416 M
+5 1 D
+P
+2453 3463 M
+2 0 D
+-3 0 D
+P
+2542 3379 M
+2 1 D
+-2 -2 D
+P
+2567 3323 M
+1 3 D
+P
+2492 3336 M
+-8 -5 D
+P
+2413 3382 M
+-4 0 D
+4 1 D
+P
+2456 3385 M
+2 -1 D
+P
+2403 3413 M
+2 1 D
+-3 -1 D
+P
+2494 3340 M
+-1 -2 D
+P
+2526 3372 M
+2 0 D
+P
+2580 3418 M
+2 4 D
+-1 -4 D
+P
+2440 3364 M
+1 -1 D
+P
+2576 3372 M
+2 3 D
+P
+2506 3348 M
+-2 -1 D
+P
+2389 3411 M
+4 1 D
+P
+2536 3400 M
+2 1 D
+P
+2452 3461 M
+3 -1 D
+P
+2552 3403 M
+3 0 D
+P
+2507 3333 M
+0 -1 D
+P
+2510 3342 M
+-5 -2 D
+P
+FO
+2362 3538 M
+0 1 D
+P
+FO
+2362 3453 M
+8 3 D
+3 6 D
+-3 -5 D
+-8 -1 D
+P
+FO
+2362 3446 M
+4 1 D
+-1 -2 D
+1 2 D
+0 -2 D
+8 7 D
+-7 -8 D
+4 3 D
+3 -2 D
+9 9 D
+-4 -9 D
+6 9 D
+-2 -1 D
+1 3 D
+3 2 D
+-6 -12 D
+8 10 D
+-1 3 D
+-8 3 D
+0 2 D
+-4 -10 D
+-5 -3 D
+5 8 D
+-1 3 D
+-2 -7 D
+-11 -9 D
+P
+2383 3458 M
+-9 -12 D
+4 9 D
+-2 -6 D
+P
+FO
+2362 3384 M
+3 2 D
+-3 1 D
+P
+FO
+2371 3354 M
+0 -2 D
+6 1 D
+0 2 D
+3 1 D
+-2 1 D
+P
+FO
+2364 3470 M
+2 0 D
+2 -2 D
+-1 3 D
+P
+FO
+2372 3466 M
+0 -3 D
+2 2 D
+-2 3 D
+P
+FO
+2394 3457 M
+-1 2 D
+-6 -8 D
+7 2 D
+P
+FO
+2381 3442 M
+2 2 D
+-3 -3 D
+P
+FO
+2367 3483 M
+0 2 D
+-1 -3 D
+P
+FO
+2423 3437 M
+1 1 D
+-6 -3 D
+P
+FO
+2386 3448 M
+1 4 D
+-4 -8 D
+P
+FO
+2366 3468 M
+-2 2 D
+0 -4 D
+P
+FO
+2369 3485 M
+-1 2 D
+-2 -2 D
+P
+FO
+2437 3482 M
+2 -3 D
+-2 4 D
+P
+FO
+2380 3465 M
+-1 -1 D
+4 -1 D
+P
+FO
+2400 3480 M
+-2 -1 D
+4 1 D
+P
+FO
+2419 3501 M
+-2 0 D
+3 -1 D
+P
+FO
+2382 3442 M
+1 1 D
+-3 -2 D
+P
+FO
+2386 3455 M
+0 2 D
+-2 -3 D
+P
+FO
+2378 3443 M
+0 -2 D
+3 4 D
+P
+FO
+2370 3421 M
+-2 -1 D
+18 4 D
+P
+FO
+2425 3439 M
+4 2 D
+P
+FO
+2367 3380 M
+0 2 D
+-3 -2 D
+P
+FO
+2397 3517 M
+0 -2 D
+P
+FO
+2442 3466 M
+-1 -4 D
+P
+FO
+2409 3504 M
+6 -1 D
+P
+FO
+2390 3364 M
+3 1 D
+P
+FO
+2439 3451 M
+0 2 D
+P
+FO
+2397 3511 M
+-2 0 D
+P
+FO
+2441 3472 M
+-1 2 D
+P
+FO
+2403 3477 M
+-3 0 D
+P
+FO
+2440 3456 M
+0 1 D
+P
+FO
+2408 3505 M
+-4 1 D
+P
+FO
+2413 3456 M
+-3 -1 D
+P
+FO
+2370 3470 M
+-1 1 D
+0 -1 D
+P
+FO
+2435 3486 M
+1 -2 D
+P
+FO
+2386 3357 M
+-3 0 D
+P
+FO
+2438 3478 M
+2 -1 D
+P
+FO
+2421 3459 M
+0 -1 D
+P
+FO
+2417 3502 M
+-3 1 D
+P
+FO
+2394 3511 M
+-1 1 D
+P
+FO
+2372 3368 M
+-1 -1 D
+P
+FO
+2429 3443 M
+-2 0 D
+P
+FO
+2380 3349 M
+-1 -1 D
+P
+FO
+2388 3515 M
+0 2 D
+P
+FO
+2394 3510 M
+2 0 D
+P
+FO
+2418 3536 M
+-2 0 D
+P
+FO
+2409 3504 M
+-2 1 D
+P
+FO
+2409 3456 M
+-1 -1 D
+P
+FO
+2380 3403 M
+2 0 D
+-2 1 D
+P
+FO
+2405 3506 M
+-2 1 D
+P
+FO
+-2 -2 1 2569 3310 SP
+2619 3307 M
+0 2 D
+-8 3 D
+4 2 D
+-1 4 D
+1 -1 D
+0 5 D
+3 2 D
+-1 -6 D
+2 1 D
+-3 -2 D
+1 -2 D
+1 1 D
+-1 -3 D
+2 -2 D
+1 2 D
+2 -2 D
+1 -4 D
+53 1 D
+2 4 D
+4 -2 D
+-2 2 D
+2 1 D
+2 -2 D
+6 0 D
+4 3 D
+25 -1 D
+10 2 D
+7 -2 D
+9 1 D
+9 -2 D
+15 2 D
+21 -2 D
+2 -2 D
+5 1 D
+-5 -1 D
+2 -1 D
+9 3 D
+7 -1 D
+1 2 D
+2 0 D
+-1 -2 D
+3 2 D
+-1 -1 D
+16 2 D
+0 -2 D
+5 1 D
+0 74 D
+-7 -3 D
+-12 0 D
+12 1 D
+2 2 D
+-5 0 D
+6 2 D
+3 -1 D
+-3 2 D
+3 5 D
+-2 1 D
+3 0 D
+0 34 D
+-9 -6 D
+8 7 D
+-6 -3 D
+3 4 D
+-2 0 D
+-11 -7 D
+9 6 D
+-7 -2 D
+5 3 D
+1 3 D
+4 0 D
+-3 2 D
+-5 -4 D
+5 6 D
+-3 -2 D
+1 3 D
+-3 -1 D
+5 5 D
+-4 0 D
+-4 -6 D
+2 6 D
+-9 -2 D
+5 3 D
+-11 1 D
+3 0 D
+-1 2 D
+-7 0 D
+-2 0 D
+-6 0 D
+11 1 D
+0 3 D
+-5 -2 D
+4 2 D
+-2 0 D
+2 2 D
+-8 0 D
+-2 -1 D
+0 1 D
+-6 0 D
+-2 2 D
+12 -1 D
+-8 2 D
+4 1 D
+-11 2 D
+7 0 D
+-5 0 D
+12 2 D
+-15 1 D
+9 0 D
+-15 4 D
+20 -4 D
+-4 3 D
+3 -1 D
+-1 2 D
+-4 -2 D
+0 3 D
+6 0 D
+3 4 D
+5 -1 D
+-1 4 D
+-8 1 D
+2 2 D
+-4 -2 D
+-4 1 D
+-2 2 D
+5 0 D
+-2 2 D
+3 0 D
+-4 2 D
+-9 -1 D
+-4 2 D
+4 -1 D
+2 2 D
+9 2 D
+-6 5 D
+1 1 D
+-1 -1 D
+5 -1 D
+0 3 D
+-4 -1 D
+-1 3 D
+-5 -2 D
+0 2 D
+-2 -3 D
+0 2 D
+-6 -1 D
+9 3 D
+-2 2 D
+-3 -1 D
+2 2 D
+-2 -1 D
+-1 1 D
+-9 -1 D
+-4 -3 D
+-6 -1 D
+5 1 D
+-2 1 D
+5 3 D
+10 1 D
+-1 1 D
+-6 -1 D
+7 2 D
+-2 3 D
+3 1 D
+-6 1 D
+-8 -3 D
+2 2 D
+-5 0 D
+-8 -4 D
+7 4 D
+-5 0 D
+2 2 D
+7 -1 D
+7 5 D
+-5 -1 D
+4 3 D
+-3 2 D
+-3 -3 D
+0 3 D
+-4 -1 D
+4 2 D
+0 1 D
+-3 -1 D
+2 2 D
+-4 0 D
+6 1 D
+-17 0 D
+-1 -2 D
+-1 2 D
+-3 -1 D
+3 2 D
+8 -1 D
+5 3 D
+-2 0 D
+2 2 D
+-6 -1 D
+2 3 D
+-2 0 D
+-4 -3 D
+2 3 D
+-8 1 D
+5 0 D
+3 3 D
+-6 2 D
+-4 -2 D
+5 3 D
+-8 2 D
+7 1 D
+-3 0 D
+1 2 D
+-3 -2 D
+1 3 D
+-4 1 D
+2 1 D
+-6 -2 D
+2 2 D
+-3 0 D
+-14 0 D
+2 -2 D
+-3 1 D
+-2 -1 D
+3 -1 D
+-4 0 D
+3 -2 D
+-4 2 D
+-5 -3 D
+3 -5 D
+9 -3 D
+-9 2 D
+3 -2 D
+-6 2 D
+5 -6 D
+-5 4 D
+1 -6 D
+-2 3 D
+0 -3 D
+-4 3 D
+2 -5 D
+3 1 D
+5 -1 D
+-6 0 D
+5 -3 D
+-10 3 D
+3 -3 D
+-5 1 D
+-3 -2 D
+7 -2 D
+-3 1 D
+0 -1 D
+-4 2 D
+-2 -2 D
+6 -5 D
+-2 0 D
+-4 -5 D
+3 -2 D
+-3 2 D
+4 6 D
+-11 5 D
+-6 -9 D
+-4 1 D
+-1 -2 D
+-2 2 D
+-4 -4 D
+-2 2 D
+-5 -4 D
+-2 1 D
+-5 -7 D
+-2 11 D
+-2 -5 D
+-6 -4 D
+6 5 D
+-4 7 D
+-4 -2 D
+-3 -10 D
+-9 -2 D
+9 3 D
+3 6 D
+-4 10 D
+-6 3 D
+-15 -1 D
+-8 -3 D
+-5 -4 D
+1 3 D
+-4 -1 D
+1 3 D
+-3 -1 D
+0 -95 D
+2 0 D
+4 -7 D
+-6 0 D
+0 -19 D
+7 -5 D
+-7 2 D
+0 -41 D
+2 -5 D
+-2 2 D
+0 -39 D
+P
+2730 3420 M
+4 -3 D
+-3 -4 D
+11 -6 D
+3 -4 D
+6 0 D
+-5 1 D
+10 -1 D
+2 1 D
+-4 1 D
+8 -1 D
+-4 -1 D
+4 -2 D
+-4 -1 D
+-7 2 D
+8 0 D
+-11 0 D
+7 -2 D
+-17 -2 D
+-1 4 D
+-13 2 D
+2 -2 D
+-3 -2 D
+-9 -1 D
+1 -3 D
+-5 2 D
+1 -1 D
+-2 -1 D
+4 -2 D
+-2 -2 D
+4 -2 D
+-4 2 D
+-1 -2 D
+7 -2 D
+-10 1 D
+-5 2 D
+5 -1 D
+-1 2 D
+4 0 D
+-4 3 D
+3 -1 D
+-2 2 D
+3 0 D
+-1 3 D
+-6 2 D
+2 -1 D
+1 1 D
+-5 4 D
+-3 -1 D
+-16 12 D
+7 -6 D
+-7 0 D
+3 -2 D
+-3 0 D
+4 -4 D
+-4 3 D
+-3 5 D
+3 -1 D
+-4 3 D
+3 -1 D
+-5 3 D
+4 -1 D
+-3 1 D
+5 1 D
+-1 4 D
+4 -2 D
+-7 4 D
+-1 2 D
+3 -1 D
+-3 3 D
+6 -2 D
+-3 3 D
+6 -4 D
+-3 0 D
+2 -2 D
+-3 1 D
+2 -3 D
+-4 3 D
+6 -4 D
+-3 0 D
+1 -2 D
+6 -4 D
+-8 4 D
+26 -16 D
+-1 2 D
+6 -3 D
+3 2 D
+-6 2 D
+13 -2 D
+-6 3 D
+-3 7 D
+-5 0 D
+1 5 D
+4 0 D
+-3 -3 D
+4 -1 D
+4 -8 D
+6 -1 D
+0 2 D
+4 -1 D
+-1 2 D
+5 -2 D
+3 1 D
+-3 3 D
+-5 -2 D
+4 9 D
+P
+2737 3404 M
+-4 0 D
+3 -1 D
+P
+2682 3413 M
+1 -2 D
+P
+2642 3349 M
+-4 -4 D
+4 -7 D
+-4 -5 D
+-4 1 D
+-3 -3 D
+-3 -8 D
+1 6 D
+-11 8 D
+1 7 D
+-6 6 D
+2 -1 D
+1 1 D
+3 -4 D
+1 7 D
+2 -8 D
+3 3 D
+4 -2 D
+3 1 D
+-1 2 D
+2 -1 D
+1 6 D
+1 -4 D
+2 2 D
+-4 -5 D
+6 -1 D
+P
+2632 3346 M
+-8 -1 D
+-4 -4 D
+1 -4 D
+6 -3 D
+8 1 D
+2 2 D
+-5 4 D
+2 1 D
+2 -3 D
+1 4 D
+P
+2626 3343 M
+0 2 D
+2 -2 D
+P
+2632 3333 M
+-3 -1 D
+0 -2 D
+P
+2628 3333 M
+0 -1 D
+P
+2620 3388 M
+2 3 D
+2 0 D
+-1 2 D
+5 0 D
+-4 2 D
+2 1 D
+2 -1 D
+0 2 D
+-4 2 D
+-1 -1 D
+-2 3 D
+-5 -1 D
+1 2 D
+2 -1 D
+-1 2 D
+7 -2 D
+1 -2 D
+5 -2 D
+-2 0 D
+-2 -3 D
+2 -2 D
+-4 0 D
+1 -2 D
+P
+2622 3383 M
+0 2 D
+1 -1 D
+3 3 D
+5 1 D
+0 2 D
+-3 -1 D
+1 2 D
+4 -1 D
+0 4 D
+-2 -2 D
+-1 2 D
+4 2 D
+8 -1 D
+-5 -1 D
+3 -1 D
+-6 0 D
+2 -2 D
+-5 -4 D
+5 -4 D
+-6 5 D
+P
+2635 3394 M
+-1 -1 D
+2 1 D
+P
+2636 3478 M
+0 -3 D
+5 -6 D
+3 1 D
+-1 -3 D
+2 -1 D
+5 1 D
+-6 -3 D
+2 -2 D
+-3 2 D
+-6 0 D
+2 1 D
+4 -1 D
+2 1 D
+-10 10 D
+-2 -1 D
+-3 2 D
+-1 -3 D
+0 4 D
+4 -3 D
+1 2 D
+-3 2 D
+P
+2713 3368 M
+0 1 D
+-8 3 D
+0 1 D
+3 -1 D
+-1 1 D
+3 0 D
+-1 3 D
+6 -2 D
+3 -4 D
+-6 2 D
+-1 -1 D
+4 -1 D
+3 -3 D
+P
+2636 3458 M
+0 -7 D
+3 2 D
+-1 2 D
+6 -3 D
+-3 0 D
+0 -3 D
+-6 3 D
+-2 3 D
+-3 0 D
+-1 4 D
+1 -2 D
+2 3 D
+2 -4 D
+2 3 D
+P
+2738 3451 M
+-3 -3 D
+11 1 D
+-5 -2 D
+-7 1 D
+0 -2 D
+5 -1 D
+-2 -1 D
+-6 1 D
+2 3 D
+-8 2 D
+8 -2 D
+5 4 D
+P
+2705 3449 M
+2 -7 D
+-3 5 D
+-1 -1 D
+-3 2 D
+2 -2 D
+-5 1 D
+1 -3 D
+-4 2 D
+1 2 D
+9 0 D
+-2 1 D
+P
+2637 3381 M
+2 4 D
+4 -3 D
+2 3 D
+3 -1 D
+-2 -3 D
+-3 0 D
+1 -1 D
+-5 -1 D
+0 4 D
+P
+2725 3368 M
+-2 1 D
+3 0 D
+-4 5 D
+3 -1 D
+-1 3 D
+12 -11 D
+-7 2 D
+1 -1 D
+-5 1 D
+P
+2651 3457 M
+4 -3 D
+-2 -5 D
+3 -1 D
+3 2 D
+-1 -2 D
+-3 -1 D
+-6 3 D
+3 0 D
+1 2 D
+P
+2610 3419 M
+-3 1 D
+8 -1 D
+8 2 D
+-4 -3 D
+-3 1 D
+-4 -2 D
+1 2 D
+P
+2690 3367 M
+-2 4 D
+-2 -1 D
+2 8 D
+4 -8 D
+-2 -1 D
+6 -2 D
+-2 0 D
+-1 -4 D
+P
+2689 3373 M
+1 -2 D
+P
+2725 3380 M
+-2 5 D
+-6 3 D
+4 0 D
+0 1 D
+5 -3 D
+-2 0 D
+2 -3 D
+-2 1 D
+P
+2722 3387 M
+2 -1 D
+P
+2757 3408 M
+-6 0 D
+8 -1 D
+-1 -2 D
+-6 1 D
+-4 -1 D
+3 1 D
+-2 3 D
+8 0 D
+P
+2737 3437 M
+-2 -3 D
+-4 0 D
+0 6 D
+3 -4 D
+1 2 D
+P
+2679 3486 M
+0 -5 D
+-2 5 D
+-2 -2 D
+-2 1 D
+4 2 D
+P
+2653 3354 M
+3 -4 D
+1 1 D
+0 -4 D
+-2 2 D
+-6 1 D
+P
+2653 3351 M
+1 -1 D
+P
+2684 3480 M
+0 -2 D
+-6 1 D
+4 1 D
+1 -1 D
+P
+2803 3415 M
+-3 -2 D
+-4 1 D
+3 1 D
+-2 0 D
+8 0 D
+P
+2619 3464 M
+-1 -8 D
+9 -6 D
+-9 6 D
+-2 5 D
+P
+2819 3362 M
+-7 5 D
+-8 2 D
+10 -2 D
+7 -5 D
+P
+2702 3411 M
+-1 -2 D
+3 1 D
+-2 -4 D
+-2 4 D
+2 2 D
+P
+2759 3396 M
+5 -1 D
+16 1 D
+-12 -1 D
+-12 1 D
+P
+2744 3357 M
+0 4 D
+-4 2 D
+6 -1 D
+3 -7 D
+P
+2746 3360 M
+-2 -2 D
+4 -2 D
+P
+2684 3462 M
+4 -6 D
+-2 -7 D
+0 7 D
+-5 5 D
+P
+2718 3397 M
+13 -3 D
+2 -2 D
+-7 3 D
+-6 0 D
+P
+2762 3357 M
+2 -1 D
+-2 -1 D
+-5 3 D
+P
+2822 3367 M
+0 -2 D
+-4 2 D
+8 0 D
+-3 0 D
+P
+2726 3434 M
+4 -2 D
+0 -2 D
+-3 0 D
+P
+2772 3427 M
+-1 -1 D
+3 0 D
+-6 -1 D
+P
+2727 3410 M
+2 -1 D
+-5 -3 D
+-2 2 D
+P
+2602 3500 M
+5 -5 D
+-6 3 D
+-1 5 D
+P
+2633 3324 M
+1 4 D
+1 -3 D
+P
+2697 3417 M
+5 -3 D
+-5 2 D
+-1 -1 D
+P
+2736 3457 M
+-3 -6 D
+1 5 D
+-8 0 D
+P
+2620 3413 M
+2 1 D
+3 -1 D
+P
+2793 3371 M
+5 -3 D
+-8 4 D
+3 0 D
+P
+2707 3345 M
+2 -3 D
+-3 -2 D
+P
+2807 3426 M
+-4 -3 D
+0 2 D
+P
+2754 3367 M
+3 -2 D
+-4 1 D
+P
+2769 3477 M
+-4 -2 D
+-2 2 D
+P
+2742 3443 M
+0 -3 D
+-3 0 D
+P
+2624 3372 M
+1 3 D
+2 -2 D
+P
+2682 3399 M
+1 -6 D
+-3 6 D
+P
+2682 3397 M
+0 -2 D
+P
+2603 3351 M
+1 2 D
+1 -2 D
+-3 0 D
+P
+2722 3337 M
+6 -9 D
+-1 -5 D
+P
+2633 3508 M
+3 -1 D
+-7 -8 D
+4 10 D
+P
+2761 3447 M
+-4 -2 D
+-4 1 D
+P
+2654 3442 M
+6 -6 D
+-9 6 D
+P
+2695 3403 M
+6 -6 D
+-8 5 D
+P
+2626 3474 M
+-2 -5 D
+-2 3 D
+P
+2750 3412 M
+3 -1 D
+-7 -1 D
+P
+2624 3509 M
+1 -8 D
+-3 3 D
+P
+2618 3513 M
+0 -5 D
+-2 3 D
+P
+2680 3373 M
+2 -7 D
+-3 1 D
+P
+2688 3368 M
+3 -4 D
+-8 5 D
+P
+2620 3374 M
+4 4 D
+-2 -5 D
+P
+2744 3438 M
+-4 -1 D
+-1 2 D
+5 0 D
+P
+2799 3410 M
+2 -1 D
+-12 0 D
+P
+2630 3482 M
+0 -3 D
+-3 2 D
+P
+2819 3408 M
+-2 -6 D
+-4 4 D
+P
+2674 3414 M
+4 -2 D
+2 -5 D
+P
+2611 3500 M
+3 -4 D
+P
+2723 3457 M
+-1 -7 D
+0 8 D
+P
+2697 3370 M
+1 -3 D
+P
+2805 3447 M
+-7 -1 D
+P
+2760 3432 M
+1 0 D
+-4 -2 D
+P
+2616 3505 M
+3 -4 D
+-3 5 D
+P
+2710 3330 M
+1 -5 D
+P
+2804 3421 M
+0 -3 D
+P
+2781 3413 M
+-3 -1 D
+3 2 D
+P
+2711 3320 M
+-1 -2 D
+P
+2828 3414 M
+6 0 D
+P
+2606 3350 M
+1 1 D
+P
+2800 3453 M
+-4 0 D
+P
+2708 3337 M
+-2 -3 D
+P
+2785 3479 M
+-3 0 D
+P
+2714 3405 M
+6 -2 D
+P
+2707 3404 M
+3 -1 D
+P
+2784 3474 M
+-2 0 D
+P
+2757 3359 M
+2 -1 D
+P
+2711 3403 M
+2 -1 D
+P
+2608 3350 M
+2 2 D
+P
+FO
+2835 3434 M
+-3 -1 D
+P
+FO
+2599 3543 M
+5 0 D
+P
+FO
+2598 3515 M
+3 1 D
+0 1 D
+2 -1 D
+-1 5 D
+4 -4 D
+1 1 D
+-1 -3 D
+3 0 D
+3 2 D
+-2 5 D
+2 -2 D
+2 2 D
+-5 1 D
+3 2 D
+5 0 D
+-1 2 D
+-12 0 D
+3 2 D
+-2 3 D
+5 3 D
+-4 1 D
+3 4 D
+-5 1 D
+1 2 D
+-7 0 D
+P
+FO
+2598 3413 M
+3 2 D
+-3 3 D
+P
+FO
+2794 3465 M
+4 0 D
+4 -2 D
+1 4 D
+-4 0 D
+4 4 D
+-5 0 D
+P
+FO
+2811 3450 M
+0 2 D
+-3 -1 D
+1 2 D
+-4 -2 D
+7 -2 D
+P
+FO
+2792 3458 M
+9 -2 D
+-3 1 D
+3 0 D
+P
+FO
+2789 3490 M
+3 1 D
+2 -2 D
+2 2 D
+-4 1 D
+P
+FO
+2796 3460 M
+12 -1 D
+-11 3 D
+-1 -1 D
+5 -1 D
+-5 1 D
+P
+FO
+2615 3520 M
+-1 -2 D
+6 3 D
+-4 3 D
+P
+FO
+2789 3483 M
+8 -1 D
+-6 1 D
+4 1 D
+-1 1 D
+P
+FO
+2787 3485 M
+2 -2 D
+3 2 D
+-4 1 D
+P
+FO
+2813 3446 M
+5 1 D
+-3 1 D
+P
+FO
+2811 3447 M
+-1 -1 D
+3 0 D
+P
+FO
+2655 3503 M
+2 3 D
+-3 0 D
+P
+FO
+2622 3519 M
+-1 1 D
+-1 -1 D
+P
+FO
+2793 3480 M
+4 0 D
+-3 1 D
+P
+FO
+2808 3463 M
+-1 2 D
+-2 -2 D
+P
+FO
+2829 3432 M
+3 3 D
+P
+FO
+2790 3460 M
+5 -1 D
+P
+FO
+2825 3444 M
+2 1 D
+P
+FO
+2797 3462 M
+4 0 D
+-4 1 D
+P
+FO
+2742 3312 M
+2 0 D
+-2 1 D
+P
+FO
+2780 3484 M
+3 0 D
+P
+FO
+2804 3452 M
+2 0 D
+P
+FO
+2797 3483 M
+2 0 D
+P
+FO
+2808 3448 M
+3 0 D
+P
+FO
+2795 3463 M
+2 -1 D
+P
+FO
+2804 3449 M
+-2 0 D
+P
+FO
+2805 3467 M
+2 1 D
+P
+FO
+2791 3488 M
+2 0 D
+P
+FO
+2791 3463 M
+3 0 D
+P
+FO
+2809 3459 M
+2 0 D
+P
+FO
+2831 3311 M
+2 1 D
+P
+FO
+2703 3530 M
+2 -1 D
+P
+FO
+2798 3484 M
+2 -1 D
+P
+FO
+2798 3464 M
+2 -1 D
+P
+FO
+2795 3455 M
+2 0 D
+-1 0 D
+P
+FO
+2761 3508 M
+2 0 D
+-2 1 D
+P
+FO
+2815 3449 M
+-3 -1 D
+P
+FO
+2770 3509 M
+3 0 D
+P
+FO
+2803 3458 M
+4 0 D
+P
+FO
+2797 3455 M
+4 0 D
+P
+FO
+2789 3478 M
+3 0 D
+P
+FO
+2806 3468 M
+3 0 D
+P
+FO
+2831 3432 M
+3 1 D
+P
+FO
+2782 3496 M
+0 -1 D
+P
+FO
+2806 3454 M
+4 0 D
+-4 1 D
+P
+FO
+2759 3312 M
+2 0 D
+P
+FO
+2795 3459 M
+3 0 D
+P
+FO
+2793 3494 M
+3 0 D
+P
+FO
+2801 3458 M
+3 0 D
+-3 1 D
+P
+FO
+2804 3454 M
+3 0 D
+P
+FO
+-1 -2 1 2622 3310 SP
+2911 3307 M
+0 1 D
+3 2 D
+-3 0 D
+4 0 D
+4 5 D
+-2 2 D
+2 -1 D
+4 3 D
+-2 1 D
+5 2 D
+-1 6 D
+2 -4 D
+8 9 D
+0 3 D
+-6 -1 D
+-2 4 D
+11 -1 D
+1 2 D
+2 0 D
+-1 3 D
+3 2 D
+-8 0 D
+2 -3 D
+-5 1 D
+-1 3 D
+-19 -8 D
+-2 -4 D
+-4 -2 D
+2 -1 D
+-5 0 D
+4 -2 D
+-11 -5 D
+6 -2 D
+-5 -1 D
+-8 -14 D
+P
+2902 3318 M
+1 0 D
+P
+2896 3319 M
+4 -1 D
+-4 0 D
+P
+2912 3332 M
+5 2 D
+-6 -2 D
+P
+2905 3313 M
+1 1 D
+P
+FO
+2926 3307 M
+1 2 D
+-2 2 D
+-3 -4 D
+P
+FO
+2928 3307 M
+1 1 D
+-2 -1 D
+P
+FO
+2932 3307 M
+-1 1 D
+-2 -1 D
+P
+FO
+2940 3307 M
+P
+FO
+2835 3434 M
+1 1 D
+P
+FO
+2835 3396 M
+4 1 D
+-1 1 D
+9 0 D
+13 4 D
+-3 0 D
+2 1 D
+8 -1 D
+6 5 D
+-24 -5 D
+-5 0 D
+32 5 D
+4 4 D
+11 0 D
+5 2 D
+-7 0 D
+7 0 D
+2 2 D
+-3 2 D
+-7 0 D
+-2 2 D
+-9 0 D
+9 2 D
+-4 -1 D
+1 4 D
+-7 -2 D
+1 -2 D
+-5 0 D
+1 -1 D
+-7 2 D
+-2 -1 D
+-1 2 D
+-4 -1 D
+2 2 D
+-4 0 D
+4 1 D
+-2 2 D
+-2 -1 D
+2 3 D
+-1 1 D
+-9 -5 D
+6 5 D
+-1 2 D
+-5 -5 D
+-1 1 D
+-12 -8 D
+12 10 D
+-2 0 D
+0 1 D
+-4 -2 D
+-7 0 D
+6 2 D
+-1 3 D
+-5 -3 D
+P
+2870 3416 M
+3 0 D
+-2 -2 D
+P
+2836 3414 M
+9 2 D
+P
+FO
+2835 3313 M
+2 0 D
+2 2 D
+-2 1 D
+11 4 D
+-1 2 D
+6 1 D
+-1 2 D
+6 -1 D
+0 7 D
+3 1 D
+0 -3 D
+1 4 D
+2 0 D
+0 -2 D
+5 4 D
+-2 -1 D
+-1 3 D
+2 -1 D
+4 2 D
+2 -1 D
+-3 1 D
+-3 -2 D
+6 -1 D
+1 4 D
+2 -2 D
+2 2 D
+-1 -2 D
+3 2 D
+1 -1 D
+5 2 D
+2 3 D
+0 -2 D
+11 2 D
+1 -3 D
+11 4 D
+0 2 D
+12 3 D
+8 4 D
+-3 2 D
+4 -1 D
+1 2 D
+2 0 D
+-2 3 D
+4 0 D
+-5 1 D
+3 1 D
+-13 4 D
+10 -3 D
+0 1 D
+4 0 D
+1 2 D
+-22 4 D
+13 -1 D
+-2 0 D
+3 1 D
+-4 1 D
+9 -2 D
+0 2 D
+-4 -1 D
+3 2 D
+-4 -1 D
+-5 4 D
+6 -2 D
+-2 2 D
+5 0 D
+-2 4 D
+-6 0 D
+6 0 D
+0 2 D
+3 1 D
+-2 2 D
+2 1 D
+-4 1 D
+3 1 D
+-6 1 D
+0 2 D
+-3 1 D
+3 0 D
+-5 1 D
+6 -1 D
+0 2 D
+-17 2 D
+8 1 D
+-2 2 D
+-3 -2 D
+-2 1 D
+-8 -1 D
+-5 -7 D
+-3 0 D
+1 4 D
+-5 0 D
+10 3 D
+0 2 D
+-3 0 D
+4 0 D
+-4 2 D
+3 1 D
+-7 6 D
+-18 1 D
+-6 -2 D
+6 -1 D
+-16 -4 D
+-6 -6 D
+-5 0 D
+-7 -3 D
+-7 -1 D
+3 -1 D
+-5 -2 D
+P
+2857 3380 M
+3 1 D
+1 -3 D
+-5 2 D
+P
+2874 3364 M
+2 3 D
+1 -1 D
+P
+2886 3395 M
+4 0 D
+P
+2861 3372 M
+3 0 D
+-4 0 D
+P
+2897 3361 M
+2 1 D
+P
+2850 3374 M
+5 0 D
+-6 0 D
+P
+FO
+2937 3324 M
+2 -1 D
+3 3 D
+-4 0 D
+P
+FO
+2934 3378 M
+-2 0 D
+2 -1 D
+P
+FO
+2929 3389 M
+6 -2 D
+-1 2 D
+P
+FO
+2938 3330 M
+1 -2 D
+1 2 D
+P
+FO
+2866 3425 M
+-2 -2 D
+2 0 D
+P
+FO
+2849 3322 M
+1 -3 D
+2 2 D
+P
+FO
+2897 3414 M
+3 0 D
+-1 1 D
+P
+FO
+2901 3413 M
+2 0 D
+P
+FO
+2945 3354 M
+-2 -2 D
+P
+FO
+2932 3379 M
+3 1 D
+P
+FO
+2906 3396 M
+4 1 D
+-5 -1 D
+P
+FO
+2869 3403 M
+4 1 D
+P
+FO
+2863 3425 M
+1 1 D
+P
+FO
+2848 3427 M
+2 2 D
+P
+FO
+2838 3316 M
+2 1 D
+P
+FO
+2929 3367 M
+2 0 D
+P
+FO
+2861 3326 M
+0 1 D
+P
+FO
+2899 3413 M
+3 0 D
+P
+FO
+2863 3429 M
+1 1 D
+P
+FO
+2916 3394 M
+2 -1 D
+P
+FO
+2931 3374 M
+3 -1 D
+P
+FO
+2906 3398 M
+2 0 D
+P
+FO
+2932 3312 M
+1 0 D
+P
+FO
+2929 3372 M
+2 0 D
+P
+FO
+2867 3333 M
+2 0 D
+P
+FO
+2887 3408 M
+2 0 D
+P
+FO
+2931 3387 M
+2 0 D
+P
+FO
+2929 3368 M
+4 0 D
+P
+FO
+2901 3394 M
+4 1 D
+P
+FO
+2868 3333 M
+4 2 D
+P
+FO
+2932 3367 M
+3 0 D
+P
+FO
+2932 3372 M
+2 1 D
+P
+FO
+2933 3368 M
+3 -1 D
+P
+FO
+2933 3390 M
+2 0 D
+P
+FO
+2899 3326 M
+2 1 D
+P
+FO
+2934 3312 M
+2 0 D
+P
+FO
+2851 3323 M
+2 -1 D
+P
+FO
+2937 3360 M
+2 1 D
+-2 0 D
+P
+FO
+2897 3408 M
+2 0 D
+P
+FO
+2861 3425 M
+1 2 D
+P
+FO
+3231 3543 M
+P
+FO
+3229 3543 M
+P
+FO
+3216 3543 M
+-2 0 D
+6 -1 D
+0 1 D
+3 -2 D
+1 2 D
+P
+FO
+3209 3543 M
+0 -3 D
+4 3 D
+-3 0 D
+P
+FO
+3204 3543 M
+-1 -1 D
+3 1 D
+P
+FO
+3201 3543 M
+P
+FO
+3198 3543 M
+0 -1 D
+1 1 D
+P
+FO
+3193 3543 M
+3 0 D
+P
+FO
+3192 3543 M
+1 0 D
+P
+FO
+3213 3542 M
+-2 -4 D
+4 2 D
+0 -2 D
+3 2 D
+0 -2 D
+3 2 D
+P
+FO
+3209 3543 M
+-4 -3 D
+3 0 D
+P
+FO
+3227 3541 M
+4 1 D
+-3 1 D
+P
+FO
+3198 3542 M
+2 -1 D
+P
+FO
+3228 3543 M
+-4 -2 D
+P
+FO
+3222 3539 M
+2 1 D
+P
+FO
+4016 3347 M
+-4 -2 D
+4 1 D
+P
+FO
+4016 3356 M
+-6 -2 D
+0 -2 D
+-4 -1 D
+2 -2 D
+3 2 D
+-1 -2 D
+3 -1 D
+3 1 D
+P
+FO
+4016 3361 M
+-1 1 D
+-1 -2 D
+-3 0 D
+0 1 D
+-4 -1 D
+-2 -3 D
+11 1 D
+P
+FO
+4016 3392 M
+-5 -1 D
+4 -2 D
+-4 -1 D
+5 -1 D
+P
+FO
+4016 3402 M
+-6 -1 D
+6 -2 D
+P
+FO
+4016 3409 M
+-3 -2 D
+0 -3 D
+3 3 D
+P
+FO
+4010 3344 M
+2 1 D
+P
+FO
+4002 3356 M
+2 1 D
+P
+FO
+4005 3352 M
+4 1 D
+P
+FO
+4010 3393 M
+2 0 D
+P
+FO
+4131 3307 M
+1 1 D
+-3 1 D
+4 1 D
+-2 2 D
+2 1 D
+1 -3 D
+5 2 D
+1 3 D
+10 1 D
+2 -2 D
+0 2 D
+4 -2 D
+3 1 D
+3 -3 D
+1 2 D
+0 -2 D
+3 0 D
+2 3 D
+-3 2 D
+4 -2 D
+0 5 D
+-2 0 D
+4 1 D
+-1 2 D
+3 -2 D
+13 3 D
+8 -5 D
+1 3 D
+11 -1 D
+-2 3 D
+11 0 D
+5 2 D
+-3 3 D
+8 -4 D
+-1 2 D
+9 0 D
+-3 -2 D
+3 -1 D
+12 3 D
+7 -1 D
+0 65 D
+-7 4 D
+-8 -1 D
+-2 -1 D
+-1 1 D
+12 2 D
+6 -4 D
+0 4 D
+-5 6 D
+3 2 D
+-7 3 D
+-4 6 D
+-14 4 D
+-2 -2 D
+1 3 D
+-9 11 D
+-2 10 D
+-9 4 D
+-3 4 D
+-12 3 D
+-10 -2 D
+-14 1 D
+-4 3 D
+11 -3 D
+10 5 D
+4 -1 D
+5 2 D
+-8 2 D
+3 2 D
+-14 -1 D
+15 2 D
+5 2 D
+2 3 D
+-2 1 D
+7 3 D
+6 11 D
+5 4 D
+-1 3 D
+-4 2 D
+-25 -1 D
+-7 2 D
+-17 -4 D
+-3 -2 D
+-6 0 D
+8 2 D
+3 3 D
+-11 -3 D
+4 3 D
+6 1 D
+1 -1 D
+5 4 D
+-7 -1 D
+-7 1 D
+8 0 D
+-1 2 D
+20 8 D
+5 8 D
+-9 1 D
+0 -2 D
+-6 1 D
+-6 -2 D
+-3 1 D
+-11 -3 D
+1 2 D
+-3 1 D
+-4 -3 D
+2 2 D
+-3 1 D
+-1 -2 D
+0 2 D
+-4 1 D
+-3 -3 D
+3 -2 D
+-2 1 D
+1 -2 D
+-2 1 D
+-1 -2 D
+6 -2 D
+-11 0 D
+3 -2 D
+-1 -2 D
+-4 0 D
+9 -6 D
+-7 3 D
+4 -3 D
+-10 2 D
+0 -3 D
+-1 2 D
+-3 0 D
+0 -3 D
+3 -1 D
+-3 -1 D
+7 -3 D
+-8 1 D
+0 -5 D
+5 1 D
+2 -1 D
+-4 -2 D
+8 -1 D
+-5 1 D
+-3 -3 D
+8 -1 D
+-8 0 D
+-2 -1 D
+7 -2 D
+-8 1 D
+-2 -3 D
+6 -1 D
+-4 -1 D
+2 -1 D
+-11 -1 D
+16 -1 D
+-11 -1 D
+8 -3 D
+13 7 D
+-5 1 D
+6 -1 D
+-4 -3 D
+6 1 D
+-8 -2 D
+-2 -2 D
+4 0 D
+-4 -1 D
+0 -1 D
+5 0 D
+4 2 D
+-4 -3 D
+-6 0 D
+-2 -2 D
+2 0 D
+-3 0 D
+0 -2 D
+2 0 D
+-3 -3 D
+3 1 D
+-1 -2 D
+-4 -3 D
+3 2 D
+-2 -6 D
+1 -1 D
+4 2 D
+-5 -4 D
+-3 -9 D
+7 2 D
+-2 1 D
+6 8 D
+-3 7 D
+13 5 D
+-10 -6 D
+0 -4 D
+3 0 D
+0 3 D
+3 -2 D
+-1 3 D
+3 -3 D
+2 7 D
+1 -2 D
+3 3 D
+-3 -5 D
+2 0 D
+-1 1 D
+9 -3 D
+-10 0 D
+-1 -5 D
+5 -2 D
+2 -3 D
+-9 -9 D
+0 -5 D
+-4 2 D
+0 -3 D
+7 -6 D
+-2 5 D
+2 1 D
+11 -4 D
+0 5 D
+10 -3 D
+4 3 D
+5 -1 D
+0 3 D
+13 0 D
+-8 -3 D
+-6 -8 D
+7 -8 D
+3 2 D
+2 -5 D
+2 4 D
+3 -2 D
+3 2 D
+-3 -5 D
+1 -1 D
+1 2 D
+0 -2 D
+-4 -1 D
+1 -2 D
+-2 2 D
+0 -5 D
+5 0 D
+-3 -1 D
+-3 -3 D
+5 -5 D
+5 0 D
+-5 -1 D
+-4 3 D
+-4 -1 D
+3 -4 D
+-5 3 D
+-7 -1 D
+-7 1 D
+2 -2 D
+-1 1 D
+-8 -2 D
+-14 -10 D
+6 0 D
+3 2 D
+8 1 D
+-2 -3 D
+2 -2 D
+2 1 D
+-4 -3 D
+5 -2 D
+-3 0 D
+-3 -6 D
+-13 -4 D
+-2 -2 D
+-6 0 D
+-6 -4 D
+5 0 D
+0 -2 D
+-3 -1 D
+2 -1 D
+6 1 D
+-5 -1 D
+4 -2 D
+15 5 D
+0 -3 D
+6 -1 D
+-4 0 D
+-2 -2 D
+11 2 D
+3 -4 D
+13 -2 D
+4 4 D
+2 -1 D
+5 1 D
+6 6 D
+2 -1 D
+-8 -7 D
+-6 -2 D
+-2 -5 D
+-17 1 D
+-11 -1 D
+0 -3 D
+4 1 D
+-7 -3 D
+-4 1 D
+-1 -5 D
+-5 -5 D
+-4 0 D
+3 -2 D
+-5 1 D
+-3 -5 D
+-6 -4 D
+-6 0 D
+-1 -2 D
+3 -1 D
+2 2 D
+5 -3 D
+P
+4129 3474 M
+-4 -1 D
+P
+4138 3472 M
+-3 -1 D
+P
+4147 3454 M
+-4 2 D
+P
+4142 3465 M
+-5 0 D
+P
+4153 3465 M
+-5 0 D
+P
+4182 3411 M
+1 -3 D
+P
+4155 3458 M
+-4 0 D
+P
+4134 3482 M
+-4 1 D
+P
+4124 3490 M
+-2 1 D
+2 -2 D
+P
+4136 3488 M
+-4 0 D
+P
+4149 3432 M
+-1 -2 D
+P
+4137 3474 M
+-3 0 D
+P
+4155 3502 M
+-1 1 D
+2 -1 D
+P
+4150 3502 M
+-2 -1 D
+P
+4141 3455 M
+4 -4 D
+-1 -2 D
+P
+4150 3481 M
+-8 -5 D
+P
+4133 3458 M
+-9 -5 D
+P
+4125 3488 M
+-5 2 D
+P
+4121 3471 M
+-6 0 D
+P
+4147 3497 M
+1 0 D
+-8 3 D
+P
+4157 3462 M
+-6 -2 D
+P
+4151 3470 M
+-4 -4 D
+P
+FO
+4220 3543 M
+-1 -2 D
+3 -1 D
+2 3 D
+P
+FO
+4016 3407 M
+2 -3 D
+-2 -1 D
+4 1 D
+-2 -2 D
+2 -2 D
+-2 1 D
+-1 -2 D
+9 0 D
+0 -2 D
+-8 -1 D
+0 -3 D
+5 -1 D
+-7 0 D
+0 -5 D
+3 1 D
+-1 -2 D
+3 -1 D
+5 2 D
+-1 -4 D
+1 2 D
+1 -2 D
+14 1 D
+-3 -1 D
+4 0 D
+-1 -2 D
+-8 1 D
+-5 -5 D
+3 0 D
+-3 -5 D
+-11 -5 D
+6 1 D
+2 2 D
+8 -1 D
+-1 -1 D
+8 5 D
+0 -3 D
+7 0 D
+-19 -3 D
+-3 1 D
+-1 -3 D
+-7 -1 D
+3 -1 D
+-1 -2 D
+3 -1 D
+-6 1 D
+0 -3 D
+5 0 D
+-5 -2 D
+0 -7 D
+10 3 D
+-10 -5 D
+0 -1 D
+13 2 D
+-10 -5 D
+8 2 D
+-8 -3 D
+2 -1 D
+8 3 D
+1 -2 D
+2 2 D
+-1 -2 D
+5 2 D
+5 -1 D
+1 2 D
+4 -1 D
+-1 2 D
+5 -1 D
+0 2 D
+5 1 D
+1 2 D
+-4 2 D
+7 -1 D
+-2 -1 D
+2 -1 D
+7 3 D
+0 2 D
+3 -1 D
+4 1 D
+1 2 D
+-3 1 D
+15 0 D
+1 3 D
+1 -3 D
+4 4 D
+0 -2 D
+10 -1 D
+1 2 D
+-1 2 D
+-2 -1 D
+-2 2 D
+4 0 D
+8 14 D
+-2 7 D
+-3 2 D
+4 0 D
+-4 3 D
+3 2 D
+-6 4 D
+3 2 D
+-4 5 D
+6 -1 D
+-3 3 D
+5 -2 D
+4 2 D
+1 4 D
+4 -1 D
+3 2 D
+-3 1 D
+0 5 D
+3 -1 D
+1 -5 D
+2 4 D
+-4 5 D
+-8 -2 D
+6 5 D
+-7 4 D
+-4 6 D
+-20 -1 D
+-1 -4 D
+-7 -1 D
+9 6 D
+-11 3 D
+4 -2 D
+-7 0 D
+2 -5 D
+-4 -3 D
+2 4 D
+-2 4 D
+-3 -1 D
+1 -3 D
+-2 3 D
+-2 -3 D
+-3 3 D
+-3 -3 D
+-4 1 D
+0 -3 D
+-4 -1 D
+2 -1 D
+-2 -1 D
+4 -1 D
+-6 -1 D
+3 -2 D
+-5 1 D
+-4 -2 D
+3 -2 D
+7 1 D
+-2 -2 D
+8 2 D
+-4 -3 D
+2 -1 D
+-11 -3 D
+4 -1 D
+-2 0 D
+3 -1 D
+-4 0 D
+3 -1 D
+-13 1 D
+-2 -3 D
+-3 4 D
+-12 1 D
+-2 -1 D
+2 -2 D
+-4 0 D
+1 1 D
+-2 1 D
+P
+4035 3389 M
+4 -1 D
+-2 -3 D
+-1 3 D
+-8 1 D
+4 1 D
+P
+4059 3379 M
+-6 -5 D
+-2 2 D
+4 0 D
+1 4 D
+P
+4063 3394 M
+1 -3 D
+3 0 D
+-2 -2 D
+-3 3 D
+P
+4105 3418 M
+-3 -5 D
+-6 1 D
+2 5 D
+P
+4034 3403 M
+1 -2 D
+-2 0 D
+-1 3 D
+P
+4069 3414 M
+2 -4 D
+-7 3 D
+P
+4034 3395 M
+-1 -1 D
+0 2 D
+P
+4032 3394 M
+0 -3 D
+-4 1 D
+P
+4075 3407 M
+1 -2 D
+-4 3 D
+P
+4053 3401 M
+-2 -1 D
+3 1 D
+P
+4080 3397 M
+-2 -1 D
+P
+4055 3407 M
+-3 1 D
+3 0 D
+P
+4028 3355 M
+-3 1 D
+P
+4078 3394 M
+2 -2 D
+P
+4078 3389 M
+-1 -1 D
+P
+4058 3401 M
+-2 1 D
+2 0 D
+P
+4063 3405 M
+-2 -2 D
+1 2 D
+P
+FO
+4016 3399 M
+0 3 D
+P
+FO
+4087 3495 M
+4 -1 D
+-8 -2 D
+4 -2 D
+6 2 D
+-2 2 D
+4 -1 D
+-3 3 D
+2 1 D
+1 -3 D
+4 1 D
+-2 1 D
+4 0 D
+0 2 D
+-4 0 D
+10 4 D
+-6 -1 D
+5 3 D
+-2 4 D
+-13 -5 D
+2 -3 D
+-4 2 D
+1 -3 D
+-5 3 D
+-2 -3 D
+2 -2 D
+3 0 D
+-4 -1 D
+P
+FO
+4110 3479 M
+-4 0 D
+1 7 D
+-4 3 D
+-3 -1 D
+3 -5 D
+-8 4 D
+1 -5 D
+-3 3 D
+-1 -3 D
+5 -2 D
+1 2 D
+5 -2 D
+-3 1 D
+-1 -2 D
+4 -3 D
+4 1 D
+1 -2 D
+1 3 D
+2 -2 D
+3 1 D
+-4 -4 D
+9 5 D
+P
+FO
+4180 3520 M
+-1 3 D
+-6 0 D
+0 -4 D
+4 -1 D
+5 1 D
+1 -3 D
+-3 -1 D
+3 -2 D
+1 4 D
+4 2 D
+-2 -1 D
+0 2 D
+P
+FO
+4110 3463 M
+-3 1 D
+-4 -1 D
+-1 -2 D
+8 -1 D
+-5 -3 D
+-3 0 D
+1 -2 D
+10 2 D
+1 -1 D
+2 3 D
+2 -1 D
+0 2 D
+P
+FO
+4098 3442 M
+6 2 D
+-2 -5 D
+6 1 D
+-1 7 D
+-4 -2 D
+-1 1 D
+-3 -1 D
+P
+FO
+4144 3385 M
+6 -4 D
+7 4 D
+-5 0 D
+-1 3 D
+-4 0 D
+-3 -1 D
+P
+FO
+4074 3487 M
+9 -3 D
+-2 2 D
+3 0 D
+-2 2 D
+3 0 D
+-6 1 D
+P
+FO
+4076 3478 M
+1 -3 D
+4 0 D
+-3 3 D
+4 2 D
+-3 2 D
+P
+FO
+4171 3517 M
+3 -3 D
+4 1 D
+-3 0 D
+2 1 D
+-4 2 D
+P
+FO
+4139 3403 M
+4 0 D
+5 3 D
+1 5 D
+-4 -1 D
+P
+FO
+4110 3449 M
+4 -1 D
+-6 -2 D
+3 -2 D
+6 8 D
+P
+FO
+4074 3472 M
+-1 -1 D
+5 1 D
+-2 2 D
+P
+FO
+4124 3440 M
+2 -4 D
+6 0 D
+-3 6 D
+P
+FO
+4214 3323 M
+7 -2 D
+6 2 D
+-6 2 D
+P
+FO
+4105 3472 M
+-2 2 D
+-4 -1 D
+3 -2 D
+P
+FO
+4185 3524 M
+2 -1 D
+0 3 D
+P
+FO
+4181 3524 M
+-3 -1 D
+3 0 D
+P
+FO
+4188 3522 M
+4 1 D
+-3 0 D
+P
+FO
+4110 3481 M
+0 3 D
+-2 -2 D
+P
+FO
+4087 3461 M
+2 -2 D
+4 3 D
+P
+FO
+4077 3483 M
+5 -1 D
+-1 2 D
+P
+FO
+4188 3524 M
+7 3 D
+-5 0 D
+P
+FO
+4183 3520 M
+3 0 D
+0 2 D
+P
+FO
+4129 3446 M
+5 -4 D
+-1 3 D
+P
+FO
+4093 3462 M
+7 3 D
+-7 -2 D
+P
+FO
+4181 3527 M
+3 -2 D
+P
+FO
+4104 3450 M
+3 2 D
+P
+FO
+4141 3385 M
+3 -1 D
+P
+FO
+4020 3381 M
+4 -1 D
+P
+FO
+4105 3470 M
+2 1 D
+P
+FO
+4110 3479 M
+2 1 D
+P
+FO
+4226 3326 M
+2 0 D
+P
+FO
+4120 3460 M
+4 2 D
+P
+FO
+4022 3384 M
+2 -1 D
+P
+FO
+4017 3345 M
+4 1 D
+P
+FO
+4104 3460 M
+3 0 D
+P
+FO
+4228 3326 M
+1 1 D
+P
+FO
+4103 3432 M
+3 0 D
+P
+FO
+4116 3453 M
+2 0 D
+P
+FO
+4115 3441 M
+2 1 D
+P
+FO
+4175 3405 M
+2 -2 D
+P
+FO
+4118 3454 M
+1 1 D
+P
+FO
+4120 3458 M
+2 1 D
+P
+FO
+4135 3443 M
+1 1 D
+P
+FO
+4096 3474 M
+3 0 D
+P
+FO
+4073 3471 M
+2 0 D
+P
+FO
+4178 3516 M
+2 0 D
+P
+FO
+4077 3485 M
+1 -1 D
+P
+FO
+4023 3385 M
+1 0 D
+P
+FO
+4080 3484 M
+2 0 D
+P
+FO
+4027 3341 M
+1 0 D
+P
+FO
+4253 3071 M
+13 15 D
+4 0 D
+-4 -2 D
+7 3 D
+-4 3 D
+6 5 D
+27 6 D
+4 4 D
+15 6 D
+7 5 D
+0 4 D
+-3 3 D
+5 3 D
+-3 1 D
+-3 6 D
+0 6 D
+-1 -2 D
+-1 1 D
+1 2 D
+1 -1 D
+0 5 D
+1 -1 D
+6 6 D
+4 -1 D
+13 7 D
+3 -2 D
+9 -1 D
+1 -2 D
+0 3 D
+1 -3 D
+4 0 D
+-1 1 D
+2 -1 D
+0 3 D
+4 -2 D
+-1 0 D
+1 -2 D
+6 1 D
+1 -3 D
+8 -1 D
+4 -3 D
+2 0 D
+0 2 D
+5 -3 D
+1 3 D
+4 -1 D
+7 2 D
+1 2 D
+-3 0 D
+4 4 D
+4 0 D
+1 3 D
+5 0 D
+1 3 D
+21 5 D
+10 10 D
+6 2 D
+11 -3 D
+0 2 D
+14 -8 D
+1 2 D
+3 -2 D
+0 141 D
+-207 0 D
+-3 -2 D
+-12 -1 D
+-9 -4 D
+-3 -4 D
+9 -1 D
+-11 -4 D
+0 -190 D
+6 3 D
+1 -1 D
+-3 0 D
+-4 -2 D
+0 -30 D
+P
+4455 3234 M
+0 2 D
+-7 1 D
+3 1 D
+-1 -1 D
+5 -1 D
+P
+4397 3218 M
+5 6 D
+4 1 D
+10 -2 D
+-15 -2 D
+P
+4455 3206 M
+-3 5 D
+3 0 D
+6 6 D
+-6 -7 D
+P
+4466 3209 M
+8 8 D
+-3 -4 D
+3 -4 D
+-3 3 D
+P
+4462 3211 M
+-1 1 D
+2 -1 D
+4 2 D
+P
+4458 3241 M
+-4 4 D
+6 -3 D
+P
+4462 3252 M
+2 2 D
+4 -2 D
+P
+4419 3236 M
+-10 -5 D
+6 5 D
+P
+4476 3248 M
+-11 7 D
+17 -6 D
+P
+4276 3124 M
+-2 -1 D
+P
+4351 3154 M
+0 1 D
+P
+4445 3239 M
+-1 1 D
+P
+4402 3228 M
+-2 -1 D
+P
+4458 3208 M
+2 0 D
+P
+4446 3242 M
+0 2 D
+P
+4273 3118 M
+0 -1 D
+P
+4460 3238 M
+-1 2 D
+P
+4274 3121 M
+0 -1 D
+P
+4457 3244 M
+-1 1 D
+P
+4260 3122 M
+0 -1 D
+P
+4445 3233 M
+2 1 D
+P
+4355 3153 M
+0 1 D
+P
+4433 3230 M
+4 -2 D
+P
+4336 3150 M
+3 3 D
+P
+4391 3205 M
+-1 3 D
+P
+4423 3239 M
+-4 -2 D
+P
+4453 3238 M
+-1 3 D
+P
+4441 3231 M
+-3 -2 D
+P
+4400 3177 M
+5 1 D
+P
+4264 3101 M
+-3 -1 D
+P
+4399 3208 M
+-2 2 D
+P
+4352 3153 M
+2 1 D
+P
+4256 3128 M
+1 -2 D
+P
+4420 3235 M
+-2 -1 D
+P
+4258 3125 M
+0 -3 D
+P
+4355 3267 M
+-1 -1 D
+2 1 D
+P
+4462 3241 M
+-2 0 D
+P
+4467 3240 M
+5 -1 D
+-5 0 D
+P
+4451 3207 M
+0 3 D
+P
+4308 3118 M
+2 0 D
+P
+FO
+4352 3071 M
+-2 2 D
+-8 -1 D
+0 -1 D
+P
+FO
+4482 3071 M
+0 2 D
+-3 4 D
+5 6 D
+-4 6 D
+2 2 D
+-2 2 D
+-4 0 D
+4 1 D
+-4 1 D
+1 3 D
+-2 -1 D
+0 2 D
+-4 0 D
+-1 2 D
+-16 -10 D
+-6 0 D
+-3 2 D
+-1 -8 D
+4 0 D
+2 -6 D
+2 -2 D
+-1 -6 D
+P
+4463 3074 M
+-1 -1 D
+P
+4465 3089 M
+1 -1 D
+P
+FO
+4465 3106 M
+5 -3 D
+3 5 D
+-2 1 D
+3 2 D
+0 6 D
+4 4 D
+-3 21 D
+-2 0 D
+-1 -8 D
+-5 1 D
+-2 -2 D
+-7 -1 D
+-2 -4 D
+-2 -1 D
+3 -3 D
+-3 0 D
+0 -2 D
+5 -3 D
+-4 -2 D
+0 -1 D
+5 0 D
+-3 -4 D
+6 -1 D
+-3 -3 D
+P
+FO
+4446 3094 M
+3 2 D
+-1 1 D
+P
+FO
+4483 3142 M
+1 2 D
+P
+FO
+4399 3142 M
+-2 0 D
+P
+FO
+4473 3100 M
+2 1 D
+P
+FO
+4404 3142 M
+2 1 D
+P
+FO
+4475 3099 M
+1 1 D
+P
+FO
+4617 3071 M
+3 2 D
+3 -2 D
+22 0 D
+-1 2 D
+7 8 D
+5 2 D
+3 -1 D
+-1 -1 D
+7 -3 D
+9 0 D
+3 -7 D
+11 0 D
+1 3 D
+-2 4 D
+-9 6 D
+0 2 D
+-13 4 D
+-10 6 D
+-26 9 D
+-2 4 D
+7 4 D
+0 3 D
+-9 0 D
+-1 -2 D
+-3 2 D
+-7 -1 D
+4 1 D
+-17 3 D
+-1 3 D
+-5 1 D
+-13 12 D
+-8 20 D
+-22 10 D
+-7 5 D
+-4 13 D
+1 2 D
+3 -1 D
+1 3 D
+0 -2 D
+-1 3 D
+2 1 D
+-5 2 D
+1 3 D
+-3 0 D
+-1 4 D
+2 2 D
+3 -1 D
+-2 1 D
+7 2 D
+-3 -3 D
+11 6 D
+4 -1 D
+1 3 D
+6 -1 D
+0 -1 D
+4 1 D
+0 2 D
+6 -4 D
+-7 -4 D
+2 -4 D
+0 -4 D
+3 0 D
+-2 0 D
+0 -2 D
+6 -7 D
+0 2 D
+3 -1 D
+1 6 D
+0 -2 D
+3 1 D
+3 8 D
+6 -1 D
+7 -4 D
+3 -13 D
+15 -10 D
+-8 4 D
+0 -2 D
+-4 1 D
+1 -2 D
+13 -10 D
+4 -1 D
+2 -5 D
+4 -1 D
+7 2 D
+-1 -1 D
+12 -3 D
+20 -13 D
+-11 4 D
+-6 0 D
+17 -6 D
+-1 2 D
+5 -1 D
+15 -10 D
+-1 2 D
+6 1 D
+0 -2 D
+-2 1 D
+1 -2 D
+-4 1 D
+6 -4 D
+2 1 D
+7 -8 D
+10 -3 D
+0 -5 D
+-4 -1 D
+2 -2 D
+-3 -2 D
+3 -3 D
+-2 -9 D
+2 2 D
+0 -2 D
+-2 -1 D
+0 2 D
+-3 -7 D
+2 -2 D
+2 0 D
+-1 -1 D
+-1 1 D
+2 -5 D
+-4 2 D
+4 -5 D
+12 -5 D
+0 236 D
+-236 0 D
+0 -102 D
+2 0 D
+0 3 D
+0 -3 D
+-2 0 D
+0 -39 D
+4 -2 D
+4 -11 D
+5 -5 D
+-1 -8 D
+6 0 D
+-1 -3 D
+9 -4 D
+2 -3 D
+-2 -3 D
+7 1 D
+6 -3 D
+5 -6 D
+7 -3 D
+2 -4 D
+9 -7 D
+7 -2 D
+3 -3 D
+6 1 D
+7 -2 D
+3 1 D
+7 -7 D
+1 -4 D
+5 2 D
+4 -3 D
+-3 -4 D
+11 3 D
+5 -7 D
+-2 -3 D
+6 -2 D
+3 -4 D
+P
+4703 3125 M
+6 -1 D
+2 2 D
+-2 -2 D
+3 -4 D
+-5 1 D
+P
+4646 3253 M
+2 5 D
+2 0 D
+-3 -4 D
+2 -2 D
+P
+4659 3230 M
+16 4 D
+3 4 D
+3 -2 D
+-16 -6 D
+P
+4501 3201 M
+0 2 D
+8 7 D
+-4 -10 D
+P
+4534 3133 M
+1 -2 D
+-3 1 D
+P
+4588 3275 M
+-4 1 D
+-2 2 D
+P
+4538 3179 M
+0 2 D
+3 -1 D
+P
+4544 3256 M
+2 2 D
+2 -1 D
+P
+4538 3144 M
+-2 2 D
+4 0 D
+P
+4584 3227 M
+5 0 D
+P
+4578 3256 M
+0 2 D
+P
+4505 3250 M
+1 1 D
+P
+4569 3253 M
+1 0 D
+-2 2 D
+P
+4519 3250 M
+2 0 D
+P
+4587 3297 M
+0 -2 D
+P
+4723 3111 M
+1 -1 D
+P
+4569 3255 M
+-2 1 D
+P
+4629 3161 M
+0 1 D
+P
+4499 3207 M
+2 1 D
+P
+4517 3129 M
+-1 -1 D
+P
+4574 3231 M
+-3 1 D
+P
+4554 3258 M
+-1 2 D
+P
+4549 3201 M
+2 1 D
+P
+4543 3188 M
+1 1 D
+P
+4574 3249 M
+0 2 D
+1 -2 D
+P
+4529 3253 M
+0 1 D
+P
+4529 3246 M
+-1 2 D
+P
+4641 3086 M
+2 -1 D
+P
+4595 3227 M
+3 1 D
+P
+4558 3249 M
+1 1 D
+P
+4563 3258 M
+1 0 D
+P
+4541 3257 M
+1 0 D
+-1 -1 D
+P
+4519 3256 M
+1 4 D
+P
+4542 3122 M
+-2 -2 D
+P
+4571 3255 M
+2 4 D
+P
+4515 3259 M
+0 3 D
+P
+4621 3162 M
+-2 2 D
+P
+4697 3306 M
+2 0 D
+P
+4690 3241 M
+3 1 D
+P
+4715 3294 M
+-3 -1 D
+P
+4670 3159 M
+5 -1 D
+P
+FO
+4606 3178 M
+-6 4 D
+4 -5 D
+8 -4 D
+-2 1 D
+2 0 D
+-8 4 D
+4 -1 D
+P
+FO
+4592 3189 M
+-2 4 D
+-1 -2 D
+3 -3 D
+-2 -1 D
+4 -7 D
+P
+FO
+4654 3144 M
+4 1 D
+-11 0 D
+-4 2 D
+0 -1 D
+-4 0 D
+P
+FO
+4653 3141 M
+-8 0 D
+2 0 D
+-1 -1 D
+12 0 D
+P
+FO
+4640 3149 M
+5 -1 D
+6 1 D
+-11 2 D
+P
+FO
+4596 3195 M
+-3 -4 D
+4 -1 D
+3 -3 D
+2 2 D
+P
+FO
+4607 3165 M
+4 -3 D
+-4 5 D
+-5 2 D
+P
+FO
+4591 3182 M
+0 -3 D
+4 -2 D
+P
+FO
+4600 3174 M
+2 -1 D
+-1 2 D
+P
+FO
+4579 3088 M
+3 0 D
+-2 1 D
+P
+FO
+4546 3187 M
+1 0 D
+0 1 D
+P
+FO
+4631 3143 M
+1 -1 D
+4 1 D
+P
+FO
+4598 3184 M
+5 -2 D
+-3 4 D
+P
+FO
+4601 3187 M
+1 -1 D
+P
+FO
+4587 3084 M
+2 0 D
+P
+FO
+4489 3132 M
+1 1 D
+P
+FO
+4543 3197 M
+2 2 D
+P
+FO
+4594 3189 M
+2 -1 D
+P
+FO
+4596 3174 M
+2 -2 D
+P
+FO
+4645 3144 M
+2 0 D
+-1 0 D
+P
+FO
+4603 3176 M
+3 -1 D
+P
+FO
+4626 3158 M
+1 -1 D
+P
+FO
+4558 3092 M
+1 1 D
+P
+FO
+4622 3159 M
+1 -1 D
+P
+FO
+4638 3146 M
+1 -1 D
+P
+FO
+4601 3183 M
+2 -1 D
+P
+FO
+4541 3198 M
+0 -1 D
+P
+FO
+4542 3195 M
+1 2 D
+P
+FO
+4604 3169 M
+1 0 D
+P
+FO
+4621 3158 M
+2 0 D
+-2 1 D
+P
+FO
+4600 3172 M
+2 0 D
+P
+FO
+4498 3135 M
+1 3 D
+-8 -2 D
+P
+FO
+4613 3165 M
+4 -2 D
+P
+FO
+4635 3151 M
+4 -1 D
+P
+FO
+4608 3169 M
+4 -3 D
+P
+FO
+4611 3162 M
+6 -3 D
+P
+FO
+4601 3171 M
+3 -1 D
+P
+FO
+4607 3173 M
+3 -1 D
+P
+FO
+4509 3127 M
+1 -1 D
+P
+FO
+4588 3180 M
+1 2 D
+P
+FO
+4620 3161 M
+2 -1 D
+P
+FO
+4610 3165 M
+-2 2 D
+P
+FO
+4673 3136 M
+2 -1 D
+P
+FO
+4612 3163 M
+3 -2 D
+P
+FO
+4606 3169 M
+-1 1 D
+P
+FO
+4786 3071 M
+-1 3 D
+2 6 D
+-2 2 D
+9 4 D
+1 -2 D
+-4 -1 D
+2 -3 D
+10 -4 D
+2 1 D
+6 -1 D
+5 -5 D
+2 0 D
+1 2 D
+-6 3 D
+0 3 D
+10 -1 D
+3 -4 D
+2 1 D
+-9 7 D
+0 -2 D
+-3 1 D
+-1 2 D
+2 1 D
+-5 3 D
+1 2 D
+2 1 D
+6 -2 D
+6 2 D
+1 3 D
+4 0 D
+2 -2 D
+3 0 D
+9 4 D
+0 -2 D
+21 -3 D
+2 -5 D
+16 1 D
+0 -2 D
+-14 -6 D
+2 -1 D
+-3 -5 D
+12 10 D
+15 5 D
+5 7 D
+5 1 D
+5 -1 D
+7 2 D
+7 -2 D
+0 2 D
+2 -3 D
+9 1 D
+3 6 D
+-22 7 D
+-5 7 D
+1 4 D
+-6 6 D
+-1 4 D
+-6 1 D
+1 2 D
+3 0 D
+2 4 D
+4 0 D
+0 11 D
+5 5 D
+5 1 D
+4 -2 D
+2 3 D
+-1 8 D
+3 4 D
+-1 7 D
+7 8 D
+-4 -4 D
+0 4 D
+6 1 D
+-3 1 D
+-2 -2 D
+-2 3 D
+6 0 D
+-2 5 D
+5 1 D
+-1 -3 D
+3 -1 D
+-5 -2 D
+1 -2 D
+3 3 D
+11 1 D
+3 8 D
+-2 1 D
+2 0 D
+-1 2 D
+2 -1 D
+1 5 D
+-5 0 D
+3 3 D
+-3 -1 D
+1 6 D
+3 -5 D
+2 2 D
+-1 1 D
+2 1 D
+1 -1 D
+1 3 D
+1 0 D
+0 98 D
+-237 0 D
+0 -236 D
+P
+4749 3094 M
+2 -3 D
+-5 -2 D
+2 3 D
+-2 2 D
+3 1 D
+P
+4741 3098 M
+3 -3 D
+-3 -3 D
+-2 4 D
+2 3 D
+P
+4923 3201 M
+-1 -4 D
+-1 1 D
+2 1 D
+P
+4906 3294 M
+-2 -1 D
+-3 0 D
+P
+4767 3090 M
+1 -1 D
+-3 -3 D
+P
+4926 3103 M
+3 -1 D
+-3 0 D
+P
+4845 3097 M
+2 -2 D
+-3 0 D
+P
+4928 3205 M
+2 -10 D
+-3 1 D
+P
+4808 3130 M
+2 -1 D
+-2 0 D
+P
+4765 3089 M
+-1 -2 D
+0 2 D
+P
+4780 3136 M
+-1 -2 D
+P
+4941 3193 M
+1 -1 D
+P
+4833 3200 M
+1 -2 D
+P
+4743 3111 M
+-1 -1 D
+P
+4908 3146 M
+3 0 D
+P
+4927 3172 M
+1 -1 D
+P
+4897 3196 M
+2 -1 D
+P
+4783 3293 M
+1 -1 D
+-2 1 D
+P
+4916 3197 M
+1 -1 D
+P
+4847 3160 M
+0 -1 D
+P
+4870 3124 M
+2 1 D
+P
+4939 3194 M
+2 0 D
+P
+4894 3193 M
+2 0 D
+P
+4930 3178 M
+1 -1 D
+P
+4762 3085 M
+-1 -1 D
+P
+4930 3239 M
+1 -1 D
+-2 1 D
+P
+4849 3133 M
+1 0 D
+P
+4851 3115 M
+2 0 D
+P
+4870 3089 M
+1 0 D
+P
+4872 3176 M
+1 -1 D
+-2 1 D
+P
+4936 3203 M
+1 -5 D
+P
+4804 3087 M
+5 -1 D
+P
+4807 3163 M
+7 -2 D
+P
+4941 3205 M
+-1 -5 D
+P
+4798 3088 M
+2 -1 D
+-3 1 D
+P
+4751 3090 M
+-3 -3 D
+P
+4797 3100 M
+4 -2 D
+-4 1 D
+P
+4790 3100 M
+-1 -1 D
+P
+4865 3238 M
+4 -3 D
+P
+4756 3084 M
+-1 -2 D
+0 2 D
+P
+4764 3286 M
+1 -3 D
+P
+4898 3130 M
+3 0 D
+P
+4931 3188 M
+2 -2 D
+P
+4774 3279 M
+-3 -1 D
+P
+4919 3198 M
+2 -2 D
+P
+4886 3172 M
+2 -1 D
+P
+4942 3186 M
+-1 -1 D
+P
+4926 3175 M
+2 -2 D
+P
+4823 3117 M
+1 2 D
+P
+4741 3301 M
+-1 -1 D
+P
+4931 3096 M
+0 -2 D
+P
+4960 3229 M
+0 -3 D
+P
+4899 3168 M
+2 0 D
+-2 -1 D
+P
+4846 3281 M
+1 -1 D
+P
+FO
+4810 3071 M
+-7 5 D
+1 -5 D
+P
+FO
+4848 3071 M
+-2 0 D
+P
+FO
+4961 3098 M
+-20 2 D
+-4 -5 D
+7 -4 D
+-1 -1 D
+16 -2 D
+-9 -1 D
+-1 1 D
+-13 -2 D
+-4 -3 D
+9 -2 D
+-4 -2 D
+-17 1 D
+-8 -1 D
+-1 1 D
+3 2 D
+-7 1 D
+-1 -1 D
+4 -2 D
+-2 -2 D
+-8 0 D
+-4 4 D
+-7 -2 D
+-5 0 D
+-9 -4 D
+-1 -4 D
+-4 -1 D
+91 0 D
+P
+4915 3076 M
+0 -2 D
+-5 1 D
+2 2 D
+P
+4954 3081 M
+-3 -1 D
+-6 2 D
+1 1 D
+P
+4930 3075 M
+-3 -2 D
+-3 3 D
+P
+FO
+4831 3086 M
+3 -2 D
+3 1 D
+0 3 D
+-3 2 D
+P
+FO
+4853 3082 M
+3 -2 D
+3 1 D
+-2 2 D
+P
+FO
+4902 3086 M
+2 -2 D
+3 2 D
+P
+FO
+4903 3082 M
+2 -1 D
+-1 2 D
+P
+FO
+4866 3074 M
+-2 3 D
+-6 -3 D
+P
+FO
+4926 3083 M
+0 1 D
+P
+FO
+4901 3082 M
+2 1 D
+-2 0 D
+P
+FO
+4949 3184 M
+2 1 D
+P
+FO
+5197 3093 M
+-10 1 D
+-3 3 D
+-4 -2 D
+-3 1 D
+-18 -4 D
+-12 2 D
+-2 3 D
+-3 1 D
+-3 -3 D
+-6 3 D
+-6 1 D
+-5 4 D
+-5 0 D
+-5 -3 D
+-7 6 D
+-3 6 D
+-10 -3 D
+-7 2 D
+-4 5 D
+1 2 D
+2 1 D
+-5 1 D
+-7 -3 D
+-32 2 D
+-27 -8 D
+-19 -9 D
+0 -2 D
+-5 -3 D
+-11 0 D
+-11 3 D
+-6 -2 D
+0 -27 D
+236 0 D
+P
+4968 3088 M
+-4 0 D
+P
+5000 3072 M
+-7 0 D
+P
+FO
+5197 3241 M
+-15 -2 D
+15 3 D
+0 65 D
+-236 0 D
+0 -98 D
+2 -1 D
+1 2 D
+0 -2 D
+8 6 D
+-8 5 D
+0 3 D
+3 0 D
+0 -2 D
+1 1 D
+4 -7 D
+4 7 D
+2 0 D
+1 5 D
+6 2 D
+9 -1 D
+2 3 D
+-2 2 D
+2 -2 D
+2 2 D
+-4 -5 D
+12 1 D
+-1 3 D
+3 3 D
+-2 -3 D
+2 -3 D
+3 -2 D
+4 0 D
+0 -2 D
+-19 2 D
+6 -4 D
+0 2 D
+7 -1 D
+0 -1 D
+-6 -2 D
+0 -1 D
+2 1 D
+9 -3 D
+-1 -1 D
+8 -2 D
+14 1 D
+2 2 D
+-1 -2 D
+8 -2 D
+2 3 D
+0 -5 D
+4 0 D
+-2 -2 D
+-2 1 D
+-9 -3 D
+-1 1 D
+-1 -2 D
+-16 -8 D
+4 -2 D
+3 2 D
+5 -1 D
+5 2 D
+-5 -2 D
+7 -5 D
+4 1 D
+4 -4 D
+-2 -9 D
+2 0 D
+-5 -1 D
+8 -5 D
+14 4 D
+6 6 D
+9 1 D
+3 -1 D
+4 4 D
+3 0 D
+2 4 D
+8 -3 D
+15 2 D
+-1 5 D
+6 2 D
+-7 2 D
+-9 -2 D
+-3 2 D
+-3 -3 D
+-6 -1 D
+-9 9 D
+-7 11 D
+0 -2 D
+-3 1 D
+3 -2 D
+1 -5 D
+1 1 D
+14 -13 D
+-1 -1 D
+-11 3 D
+3 2 D
+-2 4 D
+-3 2 D
+-2 -2 D
+2 3 D
+-5 -2 D
+2 3 D
+-4 -2 D
+5 4 D
+-7 -2 D
+4 3 D
+-3 1 D
+1 -2 D
+-3 1 D
+4 2 D
+0 4 D
+4 -1 D
+9 5 D
+0 4 D
+2 -4 D
+2 0 D
+-8 -7 D
+4 2 D
+6 7 D
+11 5 D
+9 0 D
+-4 -4 D
+6 5 D
+6 2 D
+4 -1 D
+0 -3 D
+4 5 D
+7 3 D
+1 -2 D
+7 6 D
+11 0 D
+1 -2 D
+9 4 D
+2 -2 D
+9 2 D
+0 2 D
+7 -1 D
+1 -5 D
+-4 0 D
+-7 -3 D
+-9 -1 D
+-1 -3 D
+3 0 D
+2 -2 D
+-6 0 D
+-1 2 D
+-7 -2 D
+-8 1 D
+5 -7 D
+6 -1 D
+11 -8 D
+-8 3 D
+0 3 D
+-4 -8 D
+0 3 D
+-3 -1 D
+-3 -6 D
+-5 -2 D
+-2 -7 D
+-9 -1 D
+3 -1 D
+-5 -1 D
+1 2 D
+-8 2 D
+-4 -3 D
+4 3 D
+2 -1 D
+-2 0 D
+0 -2 D
+5 0 D
+-9 -2 D
+15 -6 D
+5 -6 D
+6 -1 D
+2 2 D
+10 -8 D
+13 -3 D
+29 -21 D
+P
+5004 3297 M
+4 1 D
+18 -6 D
+-4 2 D
+3 3 D
+-1 -2 D
+4 -1 D
+9 -9 D
+18 -5 D
+3 1 D
+-1 -1 D
+16 -8 D
+8 -1 D
+4 4 D
+-4 -5 D
+2 -7 D
+-3 -1 D
+3 -2 D
+-2 -4 D
+5 -7 D
+0 -3 D
+-9 -1 D
+-7 4 D
+-8 -3 D
+-6 0 D
+0 -2 D
+4 1 D
+0 -2 D
+-4 1 D
+-8 -8 D
+2 -2 D
+-3 0 D
+1 -1 D
+-25 -5 D
+22 5 D
+2 3 D
+-2 0 D
+9 8 D
+-1 5 D
+7 -1 D
+0 3 D
+5 -2 D
+4 2 D
+10 -2 D
+3 4 D
+-2 10 D
+3 0 D
+-3 7 D
+-14 3 D
+-7 4 D
+-11 4 D
+-1 -1 D
+-11 5 D
+0 -2 D
+-5 0 D
+3 2 D
+-8 0 D
+-3 3 D
+-24 10 D
+-4 5 D
+P
+5128 3193 M
+2 0 D
+0 -2 D
+-6 1 D
+P
+5154 3210 M
+2 -3 D
+-2 -1 D
+-3 1 D
+P
+5087 3228 M
+1 -4 D
+2 0 D
+-3 -2 D
+P
+5045 3194 M
+-1 -1 D
+-2 1 D
+P
+5158 3220 M
+2 -3 D
+-3 1 D
+0 2 D
+P
+5163 3219 M
+2 -2 D
+-2 0 D
+P
+5126 3193 M
+-3 0 D
+P
+5171 3210 M
+0 -1 D
+P
+5150 3213 M
+0 -2 D
+P
+5167 3217 M
+0 -1 D
+P
+5051 3214 M
+1 -2 D
+P
+5133 3194 M
+-3 0 D
+P
+5170 3188 M
+-2 0 D
+P
+5148 3210 M
+1 -1 D
+-1 2 D
+P
+5110 3193 M
+2 0 D
+P
+5044 3192 M
+2 0 D
+P
+4984 3237 M
+5 -5 D
+0 -4 D
+P
+4973 3231 M
+4 -6 D
+-4 3 D
+P
+4975 3231 M
+4 -5 D
+P
+5061 3217 M
+-1 -3 D
+P
+5136 3196 M
+3 -2 D
+P
+5187 3192 M
+-3 -2 D
+P
+5157 3210 M
+0 -2 D
+0 3 D
+P
+5055 3213 M
+1 -3 D
+P
+5057 3213 M
+0 -3 D
+P
+5154 3212 M
+2 -1 D
+P
+5145 3202 M
+-2 -1 D
+P
+5105 3192 M
+1 -2 D
+P
+5141 3198 M
+-2 0 D
+P
+5099 3199 M
+-2 -2 D
+1 2 D
+P
+FO
+5031 3213 M
+2 0 D
+-11 1 D
+P
+FO
+5008 3217 M
+-9 2 D
+0 -1 D
+P
+FO
+4966 3221 M
+1 -1 D
+P
+FO
+5073 3216 M
+1 0 D
+P
+FO
+5073 3211 M
+1 -1 D
+P
+FO
+5009 3217 M
+4 -1 D
+P
+FO
+5115 3196 M
+1 -1 D
+P
+FO
+5081 3202 M
+0 -1 D
+P
+FO
+5420 3071 M
+1 3 D
+9 5 D
+3 0 D
+0 6 D
+-5 -1 D
+-6 3 D
+0 2 D
+-7 6 D
+-5 9 D
+-8 9 D
+-7 3 D
+-6 10 D
+-9 7 D
+-1 5 D
+-6 6 D
+3 5 D
+-2 0 D
+0 4 D
+5 9 D
+-4 0 D
+-3 -8 D
+1 8 D
+-5 9 D
+-2 -1 D
+-3 4 D
+-8 1 D
+0 6 D
+6 2 D
+1 4 D
+2 -3 D
+1 4 D
+6 5 D
+2 5 D
+-2 1 D
+3 0 D
+0 4 D
+2 -1 D
+-5 5 D
+6 -5 D
+-2 5 D
+7 -4 D
+0 3 D
+10 0 D
+1 3 D
+2 0 D
+-1 1 D
+5 2 D
+4 -4 D
+1 1 D
+-3 6 D
+2 1 D
+2 -2 D
+-1 2 D
+2 -2 D
+0 2 D
+2 -1 D
+2 2 D
+2 -1 D
+-1 3 D
+2 1 D
+4 -1 D
+-4 3 D
+3 0 D
+0 2 D
+2 -2 D
+-1 4 D
+4 -2 D
+-1 2 D
+3 -2 D
+1 2 D
+5 -1 D
+4 3 D
+0 51 D
+-3 1 D
+3 0 D
+-3 2 D
+3 -1 D
+0 26 D
+-108 0 D
+-1 -5 D
+-8 -9 D
+-1 -6 D
+-12 -12 D
+2 -3 D
+-4 2 D
+13 14 D
+3 7 D
+-2 2 D
+3 -1 D
+5 6 D
+1 5 D
+-127 0 D
+0 -65 D
+6 0 D
+-6 -1 D
+0 -90 D
+6 -2 D
+1 -3 D
+18 -5 D
+2 -4 D
+7 -1 D
+8 -22 D
+-9 -11 D
+-29 -10 D
+-4 0 D
+0 -22 D
+P
+5286 3288 M
+3 1 D
+3 -2 D
+-3 -5 D
+-6 -1 D
+-4 -3 D
+2 -3 D
+5 1 D
+-6 -2 D
+-1 -2 D
+3 0 D
+-6 -2 D
+0 -4 D
+-5 0 D
+-1 -4 D
+4 -2 D
+-5 -1 D
+1 -6 D
+-2 3 D
+-8 -2 D
+-3 -4 D
+-3 1 D
+-6 -2 D
+-1 3 D
+3 2 D
+-2 1 D
+3 0 D
+-2 1 D
+3 0 D
+1 2 D
+-4 2 D
+3 -1 D
+2 1 D
+3 -5 D
+6 2 D
+2 6 D
+-3 1 D
+6 1 D
+2 3 D
+-4 5 D
+5 -1 D
+0 -1 D
+5 0 D
+4 4 D
+-2 3 D
+5 4 D
+6 1 D
+2 5 D
+-7 0 D
+-3 7 D
+P
+5247 3226 M
+7 0 D
+2 -2 D
+-1 0 D
+10 -3 D
+2 -3 D
+4 0 D
+-3 -1 D
+8 -2 D
+-8 1 D
+-4 4 D
+-8 2 D
+-3 -1 D
+3 2 D
+-19 4 D
+P
+5372 3236 M
+3 1 D
+1 -4 D
+4 0 D
+7 -8 D
+-1 -4 D
+-4 9 D
+-3 3 D
+-3 -1 D
+-1 3 D
+P
+5315 3086 M
+7 -5 D
+3 1 D
+5 -5 D
+0 -2 D
+-9 -1 D
+-1 6 D
+-6 3 D
+P
+5354 3096 M
+12 -7 D
+-13 3 D
+-7 0 D
+5 1 D
+-2 3 D
+P
+5234 3229 M
+-4 6 D
+-15 4 D
+2 1 D
+13 -5 D
+P
+5392 3283 M
+-3 3 D
+4 0 D
+0 -3 D
+4 1 D
+P
+5354 3285 M
+-2 2 D
+4 1 D
+2 -1 D
+-3 -2 D
+P
+5354 3277 M
+-2 2 D
+4 -1 D
+P
+5255 3219 M
+-1 0 D
+3 1 D
+P
+5274 3094 M
+-3 2 D
+5 0 D
+P
+5372 3211 M
+-3 -1 D
+P
+5376 3211 M
+1 -1 D
+-3 0 D
+P
+5255 3220 M
+-1 1 D
+P
+5360 3263 M
+-1 3 D
+2 -3 D
+P
+5288 3104 M
+-1 2 D
+P
+5263 3218 M
+-4 0 D
+P
+5426 3280 M
+0 2 D
+P
+5376 3210 M
+-2 -1 D
+P
+5375 3213 M
+-1 -2 D
+P
+5374 3208 M
+-1 0 D
+P
+5281 3100 M
+-1 1 D
+P
+5235 3085 M
+1 1 D
+P
+FO
+5236 3122 M
+0 -1 D
+P
+FO
+0 -1 1 5433 3188 SP
+4 -2 1 -3 2 5398 3210 SP
+2 -3 1 5395 3208 SP
+-1 -2 -1 0 2 5412 3215 SP
+1 2 0 -2 2 5407 3213 SP
+1 -1 1 5398 3207 SP
+2 -2 1 5393 3207 SP
+-1 -1 1 5383 3203 SP
+1 -2 1 5403 3215 SP
+0 -2 1 5420 3225 SP
+1 -1 1 5408 3214 SP
+0 -2 1 5382 3201 SP
+-1 -2 1 5410 3216 SP
+4 0 -2 -1 2 5379 3165 SP
+5502 3071 M
+167 0 D
+0 82 D
+-5 -2 D
+-2 5 D
+2 1 D
+-5 1 D
+-2 3 D
+-2 -2 D
+-5 2 D
+-1 -3 D
+-4 5 D
+-5 1 D
+5 -2 D
+-3 1 D
+0 -2 D
+4 0 D
+-1 -2 D
+-3 0 D
+-10 -2 D
+-2 3 D
+1 9 D
+-4 4 D
+0 5 D
+2 2 D
+-3 5 D
+12 24 D
+7 4 D
+5 -1 D
+4 2 D
+2 -2 D
+-4 -5 D
+5 1 D
+2 8 D
+-3 4 D
+7 1 D
+4 -6 D
+2 2 D
+0 4 D
+-2 2 D
+0 2 D
+-3 0 D
+5 2 D
+0 80 D
+-236 0 D
+0 -26 D
+6 -1 D
+-4 -1 D
+4 -2 D
+-6 2 D
+0 -51 D
+9 5 D
+0 -1 D
+1 2 D
+4 -1 D
+-1 -1 D
+2 3 D
+3 1 D
+0 -2 D
+2 3 D
+8 2 D
+10 -3 D
+2 1 D
+2 -3 D
+3 1 D
+1 -2 D
+2 2 D
+1 -3 D
+3 0 D
+0 1 D
+4 1 D
+2 2 D
+14 -2 D
+4 -6 D
+-5 -4 D
+2 1 D
+2 -5 D
+-2 -7 D
+-8 -11 D
+12 -5 D
+-8 -1 D
+-10 3 D
+-13 -1 D
+-4 2 D
+-4 -3 D
+-5 1 D
+-3 -5 D
+0 -4 D
+-2 1 D
+-5 -1 D
+0 -3 D
+6 -3 D
+2 -4 D
+3 1 D
+3 -3 D
+-6 1 D
+-4 -1 D
+-6 3 D
+-13 1 D
+-3 -2 D
+1 -5 D
+14 -4 D
+0 -4 D
+11 -14 D
+-1 -7 D
+9 1 D
+6 -8 D
+7 1 D
+2 -2 D
+4 1 D
+7 -3 D
+-1 -3 D
+-3 4 D
+2 -5 D
+-6 -11 D
+2 -4 D
+-2 -4 D
+4 -2 D
+-1 -3 D
+5 -4 D
+3 -7 D
+-1 7 D
+2 7 D
+-4 0 D
+5 7 D
+4 3 D
+13 1 D
+5 -2 D
+4 -13 D
+17 -11 D
+-2 1 D
+2 -2 D
+-4 -4 D
+-3 0 D
+-4 3 D
+-2 -1 D
+4 -5 D
+-5 1 D
+-10 -3 D
+-4 7 D
+-3 -4 D
+-2 2 D
+-2 -1 D
+-1 1 D
+-3 -1 D
+0 2 D
+-5 5 D
+-1 -9 D
+-4 -10 D
+2 -6 D
+P
+5638 3153 M
+-2 -3 D
+-3 -1 D
+-1 3 D
+-2 0 D
+3 3 D
+-1 -2 D
+3 -1 D
+3 2 D
+P
+5479 3270 M
+-2 2 D
+4 -1 D
+P
+5488 3294 M
+0 2 D
+4 -3 D
+P
+5457 3245 M
+0 1 D
+4 1 D
+P
+5531 3150 M
+1 -3 D
+-3 2 D
+2 2 D
+P
+5492 3274 M
+-5 4 D
+4 -2 D
+P
+5500 3265 M
+0 1 D
+3 0 D
+P
+5487 3298 M
+0 1 D
+2 -1 D
+-3 0 D
+P
+5644 3156 M
+-1 -1 D
+-1 1 D
+P
+5634 3228 M
+-4 -1 D
+P
+5659 3256 M
+0 -3 D
+P
+5609 3118 M
+-3 -3 D
+4 3 D
+P
+5515 3281 M
+4 1 D
+P
+5507 3298 M
+-2 2 D
+P
+5610 3116 M
+-2 -1 D
+P
+5646 3249 M
+-1 -2 D
+P
+5549 3240 M
+1 1 D
+P
+5635 3156 M
+0 -2 D
+P
+5651 3253 M
+-2 -2 D
+2 3 D
+P
+5552 3246 M
+2 1 D
+P
+FO
+5433 3280 M
+1 0 D
+-1 0 D
+P
+FO
+5433 3079 M
+6 0 D
+3 -3 D
+0 4 D
+-9 5 D
+P
+FO
+5 1 0 -2 -5 0 3 5669 3205 SP
+-3 -3 3 3 -2 2 -3 0 2 1 3 -2 6 5433 3187 SP
+-1 -3 -2 2 -2 -2 1 2 -2 -1 1 3 6 5652 3189 SP
+0 -2 1 5535 3095 SP
+1 -2 1 5499 3200 SP
+-2 -1 1 5506 3228 SP
+2 -2 1 5502 3199 SP
+1 -2 1 5506 3222 SP
+0 -2 1 5497 3201 SP
+0 -2 1 5496 3201 SP
+0 -2 1 5442 3185 SP
+1 1 -2 -2 2 5441 3188 SP
+1 -2 1 5442 3082 SP
+-1 1 2 -1 2 5446 3079 SP
+1 -1 1 5501 3198 SP
+0 -2 1 5668 3225 SP
+-1 -3 1 5505 3221 SP
+5906 3077 M
+-5 0 D
+5 1 D
+0 229 D
+-18 0 D
+-2 0 D
+-120 0 D
+-97 0 D
+0 -80 D
+8 3 D
+1 -2 D
+1 2 D
+1 -3 D
+1 1 D
+3 -2 D
+2 2 D
+-6 2 D
+10 1 D
+-2 -5 D
+3 -2 D
+7 1 D
+-2 3 D
+4 1 D
+6 4 D
+0 -2 D
+4 -1 D
+-5 -6 D
+-3 0 D
+-4 -8 D
+-8 -1 D
+5 -2 D
+-1 -3 D
+2 0 D
+-3 -1 D
+1 -1 D
+-3 -2 D
+0 -2 D
+5 3 D
+4 -3 D
+-1 -3 D
+6 -5 D
+0 -4 D
+3 0 D
+2 2 D
+0 -1 D
+3 0 D
+-3 -2 D
+0 -2 D
+2 3 D
+1 -2 D
+3 0 D
+-1 -2 D
+-2 1 D
+-2 -3 D
+-7 -3 D
+-4 -3 D
+-4 1 D
+2 -1 D
+-3 -2 D
+1 -3 D
+2 1 D
+-2 -6 D
+-2 4 D
+1 -6 D
+-3 5 D
+-2 -6 D
+-4 -1 D
+1 -3 D
+2 1 D
+2 -3 D
+3 0 D
+-1 -4 D
+-3 1 D
+0 -2 D
+-2 1 D
+-1 -2 D
+-4 0 D
+-1 2 D
+-2 -2 D
+-1 2 D
+-5 -1 D
+-1 -3 D
+-4 0 D
+0 -82 D
+237 0 D
+P
+5757 3285 M
+-1 -2 D
+-6 -1 D
+1 2 D
+4 -1 D
+P
+5715 3214 M
+1 2 D
+1 -2 D
+3 3 D
+-4 -4 D
+P
+5864 3099 M
+5 -2 D
+-4 -2 D
+-6 0 D
+-3 5 D
+P
+5775 3234 M
+3 0 D
+0 -1 D
+-2 -1 D
+P
+5785 3251 M
+-1 3 D
+3 -4 D
+P
+5726 3284 M
+-3 -2 D
+1 0 D
+-3 0 D
+P
+5859 3192 M
+-2 1 D
+3 0 D
+P
+5716 3234 M
+0 -1 D
+-3 -1 D
+P
+5781 3231 M
+1 1 D
+3 -2 D
+P
+5763 3293 M
+1 -1 D
+-2 -1 D
+P
+5818 3208 M
+0 4 D
+3 -2 D
+P
+5715 3218 M
+-1 -2 D
+-6 0 D
+P
+5757 3279 M
+2 1 D
+P
+5704 3212 M
+4 0 D
+P
+5743 3276 M
+4 1 D
+P
+5720 3296 M
+2 1 D
+0 -1 D
+P
+5745 3282 M
+-2 -1 D
+P
+5770 3203 M
+3 -1 D
+P
+5863 3238 M
+-1 -1 D
+P
+5714 3280 M
+3 1 D
+P
+5735 3278 M
+2 1 D
+P
+5734 3285 M
+-1 -2 D
+P
+5761 3297 M
+-2 -1 D
+P
+5705 3208 M
+1 2 D
+P
+5716 3276 M
+1 0 D
+P
+FO
+5669 3217 M
+3 2 D
+-3 2 D
+P
+FO
+-3 0 3 1 2 5669 3204 SP
+3 -2 -11 1 -3 -2 0 2 2 2 4 -2 6 5681 3218 SP
+-3 -1 1 2 2 5694 3175 SP
+0 1 1 5686 3163 SP
+0 1 1 5708 3190 SP
+1 1 1 5680 3169 SP
+0 1 1 5701 3193 SP
+0 2 1 5690 3158 SP
+4 3 1 5691 3178 SP
+-1 -1 1 2 2 5687 3160 SP
+1 2 1 5683 3162 SP
+1 2 1 5689 3169 SP
+1 2 1 5686 3173 SP
+-1 -1 1 5675 3221 SP
+-1 1 1 5695 3199 SP
+5906 3078 M
+8 3 D
+-1 -3 D
+-4 -1 D
+-3 0 D
+0 -6 D
+236 0 D
+0 236 D
+-236 0 D
+P
+6004 3223 M
+9 4 D
+1 4 D
+9 1 D
+1 -1 D
+1 2 D
+6 -3 D
+14 2 D
+11 -2 D
+1 -2 D
+7 1 D
+5 -3 D
+-2 3 D
+7 -4 D
+11 3 D
+13 -1 D
+4 -4 D
+1 5 D
+1 -1 D
+1 1 D
+0 -1 D
+4 3 D
+4 0 D
+0 -3 D
+3 0 D
+-3 4 D
+6 -1 D
+0 2 D
+2 0 D
+3 -4 D
+-4 -1 D
+-3 -6 D
+-12 1 D
+0 -3 D
+-3 2 D
+-6 -1 D
+-5 3 D
+-4 -2 D
+-7 3 D
+-11 -1 D
+-3 2 D
+-12 1 D
+-17 -2 D
+-2 3 D
+2 1 D
+-2 0 D
+-2 -1 D
+2 -3 D
+-3 -1 D
+-1 2 D
+-2 -3 D
+-3 1 D
+1 1 D
+-3 -2 D
+-3 0 D
+-2 -7 D
+-7 -3 D
+-2 2 D
+-5 -2 D
+3 -4 D
+-3 -2 D
+3 -1 D
+-2 0 D
+0 -2 D
+-4 -2 D
+0 -4 D
+2 0 D
+0 -6 D
+-2 -1 D
+1 -2 D
+-3 1 D
+0 5 D
+-3 0 D
+-6 7 D
+-4 2 D
+0 2 D
+3 2 D
+-4 1 D
+4 0 D
+2 4 D
+2 0 D
+-3 2 D
+1 3 D
+2 1 D
+2 -2 D
+5 2 D
+-2 2 D
+P
+6002 3220 M
+-2 0 D
+2 -2 D
+P
+5995 3200 M
+-2 1 D
+P
+6095 3135 M
+7 1 D
+-6 -3 D
+6 -1 D
+-11 -4 D
+1 -1 D
+-9 -5 D
+-14 0 D
+-17 5 D
+0 2 D
+6 0 D
+6 3 D
+P
+6099 3162 M
+-7 -3 D
+-18 2 D
+0 1 D
+5 2 D
+10 -2 D
+P
+6028 3303 M
+5 3 D
+5 -2 D
+-1 -1 D
+-3 2 D
+-4 -3 D
+P
+6009 3187 M
+1 -3 D
+-7 2 D
+1 1 D
+5 -1 D
+P
+5922 3144 M
+1 -3 D
+-2 1 D
+P
+6030 3113 M
+-4 0 D
+-1 3 D
+4 -1 D
+P
+6033 3087 M
+-2 -2 D
+-4 0 D
+P
+5920 3154 M
+-1 -1 D
+P
+5970 3295 M
+3 -1 D
+P
+5963 3298 M
+2 1 D
+P
+5924 3289 M
+2 1 D
+P
+5936 3304 M
+2 -1 D
+P
+6045 3302 M
+2 0 D
+P
+FO
+6378 3273 M
+-1 1 D
+1 0 D
+0 33 D
+-236 0 D
+0 -236 D
+236 0 D
+P
+6241 3253 M
+-13 7 D
+-8 1 D
+-7 4 D
+11 1 D
+3 2 D
+-5 3 D
+1 10 D
+17 6 D
+-4 5 D
+-3 2 D
+-5 -1 D
+-7 6 D
+9 -2 D
+6 4 D
+-8 -6 D
+6 -1 D
+9 -6 D
+4 0 D
+-21 -6 D
+-3 -5 D
+5 -8 D
+7 0 D
+-6 -1 D
+-4 -2 D
+24 -8 D
+-4 -4 D
+-3 0 D
+3 -1 D
+P
+6157 3227 M
+-1 2 D
+13 -1 D
+2 -2 D
+-3 -1 D
+1 -2 D
+-7 1 D
+P
+6174 3215 M
+3 8 D
+2 1 D
+7 -2 D
+4 -5 D
+2 -10 D
+-4 2 D
+-5 -1 D
+P
+6181 3221 M
+-3 0 D
+P
+6184 3218 M
+1 -2 D
+P
+6312 3119 M
+3 -1 D
+2 -4 D
+-7 2 D
+-10 -2 D
+4 4 D
+-1 3 D
+P
+6314 3245 M
+7 1 D
+-2 -3 D
+1 -1 D
+-3 0 D
+-4 -5 D
+-5 6 D
+P
+6277 3275 M
+-4 1 D
+1 2 D
+10 1 D
+-3 -3 D
+-5 0 D
+P
+6319 3235 M
+1 -1 D
+-4 -1 D
+0 3 D
+P
+6210 3189 M
+6 -3 D
+-1 -3 D
+-10 3 D
+P
+6170 3182 M
+4 -3 D
+-5 -2 D
+-4 3 D
+P
+6284 3210 M
+5 1 D
+-2 -3 D
+-11 -3 D
+P
+6171 3222 M
+2 3 D
+1 -3 D
+-2 -1 D
+P
+6341 3273 M
+6 0 D
+-3 -1 D
+P
+6350 3269 M
+2 -3 D
+P
+6208 3190 M
+-4 -1 D
+1 2 D
+P
+6362 3133 M
+-2 1 D
+2 0 D
+P
+6193 3203 M
+1 -1 D
+-2 0 D
+P
+FO
+6441 3307 M
+-2 0 D
+-61 0 D
+0 -33 D
+4 -3 D
+-4 2 D
+0 -202 D
+236 0 D
+0 236 D
+P
+6435 3268 M
+3 0 D
+-3 -1 D
+-1 -4 D
+3 -1 D
+4 3 D
+1 -1 D
+-3 4 D
+5 -1 D
+0 -3 D
+-10 -4 D
+-3 -6 D
+-4 0 D
+-3 6 D
+7 2 D
+1 3 D
+-2 3 D
+P
+6455 3265 M
+4 -1 D
+-4 -4 D
+0 -3 D
+8 -5 D
+-3 -2 D
+-3 2 D
+-2 7 D
+-6 2 D
+0 2 D
+P
+6447 3291 M
+5 0 D
+12 -4 D
+1 1 D
+3 -2 D
+-11 -4 D
+-1 4 D
+-12 3 D
+P
+6589 3291 M
+8 -2 D
+-3 0 D
+0 -2 D
+-8 3 D
+P
+6384 3091 M
+5 -15 D
+-2 -1 D
+-4 10 D
+-4 2 D
+P
+6388 3294 M
+4 4 D
+2 -1 D
+-2 -2 D
+1 -3 D
+P
+6551 3281 M
+5 -2 D
+-8 -1 D
+-1 2 D
+P
+6458 3282 M
+3 1 D
+0 -3 D
+-4 1 D
+P
+6607 3264 M
+3 -1 D
+-4 -1 D
+P
+6594 3205 M
+5 -4 D
+-10 2 D
+P
+6445 3156 M
+-2 0 D
+0 2 D
+3 1 D
+P
+6499 3271 M
+4 -1 D
+-7 0 D
+P
+6535 3288 M
+0 -1 D
+-4 -1 D
+P
+6526 3268 M
+-7 1 D
+P
+FO
+6614 3071 M
+236 0 D
+0 236 D
+-236 0 D
+P
+6699 3178 M
+2 1 D
+1 -3 D
+-2 2 D
+-2 -1 D
+P
+6628 3191 M
+7 0 D
+0 -1 D
+P
+6825 3095 M
+-1 -3 D
+-1 3 D
+P
+6822 3093 M
+1 -2 D
+-3 -1 D
+0 3 D
+P
+6645 3125 M
+-2 -1 D
+0 2 D
+P
+FO
+7083 3071 M
+4 1 D
+0 235 D
+-237 0 D
+0 -236 D
+P
+7032 3290 M
+2 -4 D
+7 0 D
+-1 -2 D
+-4 0 D
+-2 2 D
+-1 -3 D
+-10 -6 D
+0 -3 D
+-6 -1 D
+3 2 D
+-5 4 D
+1 2 D
+7 3 D
+9 8 D
+P
+7030 3201 M
+-2 -3 D
+-5 2 D
+7 1 D
+-1 2 D
+P
+7035 3259 M
+1 -4 D
+-7 -3 D
+-1 3 D
+4 4 D
+P
+7009 3150 M
+0 -3 D
+-6 0 D
+4 4 D
+P
+7017 3084 M
+-2 -3 D
+-4 1 D
+1 2 D
+P
+6915 3085 M
+0 -1 D
+-4 -1 D
+1 2 D
+P
+6984 3295 M
+-3 0 D
+1 2 D
+1 -2 D
+P
+6958 3275 M
+-5 0 D
+2 1 D
+P
+6987 3080 M
+-5 -4 D
+0 2 D
+P
+6963 3151 M
+3 1 D
+2 -1 D
+P
+7022 3247 M
+-1 -1 D
+P
+6970 3153 M
+-2 0 D
+P
+7068 3290 M
+2 1 D
+P
+6928 3090 M
+-3 1 D
+5 0 D
+P
+6996 3292 M
+-2 1 D
+P
+FO
+7275 3071 M
+0 1 D
+8 0 D
+7 3 D
+1 3 D
+10 4 D
+3 5 D
+12 4 D
+2 13 D
+-3 1 D
+2 8 D
+2 -1 D
+1 4 D
+3 2 D
+0 189 D
+-236 0 D
+0 -235 D
+10 3 D
+4 4 D
+-2 2 D
+7 6 D
+5 1 D
+-2 0 D
+1 2 D
+8 3 D
+10 -2 D
+3 5 D
+-1 -6 D
+9 -3 D
+-1 0 D
+-1 -2 D
+3 -3 D
+-10 -11 D
+P
+7248 3159 M
+-1 -2 D
+5 -1 D
+-2 -2 D
+-1 2 D
+-4 0 D
+1 2 D
+-2 0 D
+P
+7300 3165 M
+-2 -5 D
+-6 0 D
+5 2 D
+-2 2 D
+2 -1 D
+2 1 D
+-2 3 D
+P
+7213 3086 M
+-8 -3 D
+1 -2 D
+-2 1 D
+1 0 D
+-2 2 D
+2 -1 D
+P
+7191 3194 M
+-4 -1 D
+-2 3 D
+-2 0 D
+2 1 D
+P
+7190 3217 M
+1 -1 D
+-2 0 D
+P
+7201 3147 M
+1 -3 D
+-2 1 D
+3 4 D
+P
+7188 3116 M
+-4 -3 D
+0 2 D
+P
+7188 3198 M
+-1 -1 D
+P
+7182 3206 M
+-5 -1 D
+P
+7258 3155 M
+-3 -3 D
+P
+7190 3130 M
+-5 1 D
+1 1 D
+P
+7223 3164 M
+1 -1 D
+-2 1 D
+P
+7156 3187 M
+1 -1 D
+P
+7101 3139 M
+-2 0 D
+P
+FO
+7105 3082 M
+1 1 D
+P
+FO
+7556 3071 M
+-4 0 D
+P
+FO
+7559 3075 M
+-3 -4 D
+3 0 D
+P
+FO
+7559 3088 M
+-3 -3 D
+3 -8 D
+P
+FO
+7559 3109 M
+0 -2 D
+P
+FO
+7559 3135 M
+-4 -2 D
+-1 -9 D
+5 -3 D
+P
+FO
+7485 3307 M
+-2 -3 D
+2 -4 D
+-1 -5 D
+-8 -2 D
+-1 -3 D
+-4 -2 D
+1 -4 D
+-12 -6 D
+-13 -1 D
+-5 -3 D
+1 -4 D
+-7 -2 D
+-6 1 D
+-11 -2 D
+-7 -2 D
+-6 -4 D
+-10 1 D
+-6 -4 D
+-4 0 D
+-6 -9 D
+-10 -7 D
+-27 -2 D
+-7 -5 D
+-1 -2 D
+-4 -1 D
+13 9 D
+26 1 D
+12 11 D
+-22 -2 D
+-4 2 D
+-7 -1 D
+9 2 D
+2 -2 D
+23 2 D
+3 5 D
+3 0 D
+7 4 D
+10 0 D
+15 6 D
+20 1 D
+1 5 D
+6 3 D
+10 0 D
+13 7 D
+-1 4 D
+4 6 D
+10 2 D
+0 4 D
+-3 3 D
+-4 0 D
+-10 -7 D
+4 3 D
+-2 3 D
+6 3 D
+7 -2 D
+1 3 D
+-160 0 D
+0 -189 D
+2 2 D
+2 0 D
+1 2 D
+4 2 D
+0 2 D
+5 0 D
+0 -2 D
+2 1 D
+2 4 D
+-2 -1 D
+4 3 D
+-1 2 D
+-3 -1 D
+0 2 D
+4 1 D
+-2 -2 D
+4 1 D
+-3 -1 D
+3 -1 D
+4 2 D
+3 -3 D
+1 5 D
+2 0 D
+3 3 D
+-3 1 D
+5 2 D
+3 4 D
+2 0 D
+-2 0 D
+1 4 D
+5 -2 D
+3 1 D
+-6 -5 D
+3 -1 D
+9 6 D
+-1 -2 D
+2 -1 D
+-2 -3 D
+1 -5 D
+2 2 D
+4 -2 D
+4 2 D
+2 -5 D
+4 3 D
+1 -4 D
+11 4 D
+5 -1 D
+3 3 D
+1 -1 D
+29 15 D
+2 4 D
+-1 1 D
+2 -1 D
+4 2 D
+2 3 D
+-1 -1 D
+0 2 D
+1 -1 D
+1 3 D
+2 0 D
+0 4 D
+6 5 D
+7 3 D
+3 6 D
+3 0 D
+4 6 D
+3 1 D
+1 3 D
+21 14 D
+10 10 D
+11 19 D
+10 7 D
+7 11 D
+17 12 D
+0 40 D
+P
+7389 3193 M
+1 -3 D
+-5 -8 D
+-8 -4 D
+-2 2 D
+2 0 D
+-6 3 D
+2 5 D
+-3 2 D
+0 5 D
+9 2 D
+P
+7442 3279 M
+1 -1 D
+-3 0 D
+P
+7488 3299 M
+1 -1 D
+P
+7341 3130 M
+-1 0 D
+P
+7490 3302 M
+-2 0 D
+P
+7338 3127 M
+-1 -2 D
+P
+7477 3285 M
+2 -1 D
+P
+7379 3198 M
+9 -2 D
+P
+7468 3279 M
+1 2 D
+1 -1 D
+P
+FO
+7365 3142 M
+1 -2 D
+3 2 D
+-4 1 D
+P
+FO
+7545 3122 M
+1 -3 D
+3 5 D
+P
+FO
+7379 3138 M
+2 -1 D
+-1 2 D
+P
+FO
+7377 3136 M
+2 -1 D
+P
+FO
+7363 3141 M
+1 -1 D
+P
+FO
+7356 3133 M
+2 1 D
+P
+FO
+3 0 -2 -1 2 7482 3296 SP
+-1 -1 1 7474 3292 SP
+7604 3071 M
+-2 6 D
+-9 10 D
+-1 11 D
+2 7 D
+-5 -2 D
+-8 4 D
+-2 -3 D
+-1 -6 D
+6 1 D
+3 2 D
+2 -2 D
+-3 -8 D
+-6 4 D
+-1 -3 D
+-3 -1 D
+-2 8 D
+-7 2 D
+-2 -4 D
+4 -2 D
+-2 0 D
+-2 -5 D
+-6 -2 D
+0 -17 D
+P
+7591 3090 M
+-1 -2 D
+0 3 D
+P
+7581 3081 M
+-2 0 D
+0 1 D
+P
+FO
+7795 3213 M
+-8 -4 D
+-6 -6 D
+6 1 D
+8 4 D
+P
+FO
+7610 3307 M
+0 -11 D
+-4 -16 D
+-3 -2 D
+7 -11 D
+1 -8 D
+-6 -8 D
+3 -13 D
+-6 -11 D
+4 -15 D
+2 -2 D
+10 20 D
+5 0 D
+2 -3 D
+14 -1 D
+-2 -1 D
+3 -12 D
+4 8 D
+-3 11 D
+-4 -1 D
+-3 2 D
+0 -2 D
+5 -2 D
+-5 0 D
+-4 13 D
+-4 4 D
+-3 0 D
+-4 9 D
+0 7 D
+10 19 D
+1 6 D
+9 4 D
+16 -2 D
+11 -7 D
+3 -7 D
+2 0 D
+-1 5 D
+-7 4 D
+-10 23 D
+P
+7607 3272 M
+1 -1 D
+P
+7635 3228 M
+2 -1 D
+-2 0 D
+P
+FO
+7559 3267 M
+4 3 D
+1 8 D
+4 5 D
+-1 1 D
+-2 -2 D
+1 2 D
+-2 0 D
+3 0 D
+-2 1 D
+2 1 D
+1 4 D
+-1 0 D
+2 0 D
+3 7 D
+0 5 D
+-3 2 D
+3 3 D
+-13 0 D
+P
+FO
+7559 3121 M
+1 0 D
+2 -5 D
+-3 -9 D
+1 -2 D
+4 -1 D
+5 3 D
+0 4 D
+5 3 D
+2 -2 D
+6 -1 D
+5 2 D
+-10 8 D
+-5 0 D
+-6 3 D
+1 4 D
+3 4 D
+6 0 D
+7 -7 D
+8 6 D
+8 2 D
+30 -12 D
+7 -5 D
+4 13 D
+13 11 D
+6 2 D
+13 -2 D
+-1 2 D
+3 2 D
+2 -1 D
+-3 -1 D
+4 -1 D
+0 2 D
+4 1 D
+0 1 D
+8 1 D
+7 5 D
+-4 0 D
+-3 -4 D
+-6 3 D
+3 -1 D
+-4 8 D
+3 -2 D
+-5 2 D
+-1 4 D
+6 10 D
+0 2 D
+-13 -9 D
+-9 0 D
+-4 4 D
+-2 -2 D
+1 2 D
+-9 2 D
+4 -2 D
+-6 0 D
+-1 2 D
+2 0 D
+-7 1 D
+-37 30 D
+-2 -2 D
+-4 1 D
+-2 -5 D
+5 -15 D
+-3 -7 D
+0 -9 D
+-8 -5 D
+3 -10 D
+-7 -4 D
+-3 2 D
+-5 -1 D
+-7 5 D
+-4 -1 D
+0 -3 D
+4 -5 D
+-5 -6 D
+-3 2 D
+-4 -3 D
+P
+7662 3157 M
+1 0 D
+-1 -2 D
+-2 1 D
+P
+7579 3133 M
+2 -1 D
+-3 -1 D
+P
+7591 3137 M
+1 -2 D
+-3 0 D
+P
+7666 3156 M
+0 -1 D
+P
+7613 3193 M
+1 -1 D
+P
+7611 3174 M
+1 0 D
+-1 -2 D
+P
+7658 3165 M
+-1 -2 D
+P
+FO
+7724 3177 M
+14 8 D
+2 4 D
+6 -1 D
+9 6 D
+13 3 D
+1 4 D
+-5 1 D
+-6 -5 D
+-6 -2 D
+-3 0 D
+-3 4 D
+-1 -5 D
+-5 -3 D
+-4 1 D
+1 -3 D
+-7 -5 D
+-3 1 D
+2 -3 D
+-4 -1 D
+-1 -2 D
+-1 1 D
+-2 -4 D
+P
+FO
+7693 3165 M
+-6 -4 D
+0 -2 D
+3 0 D
+1 3 D
+5 2 D
+3 5 D
+14 5 D
+1 2 D
+-5 -1 D
+-5 2 D
+P
+FO
+7586 3193 M
+2 -2 D
+3 2 D
+-4 2 D
+P
+FO
+7715 3161 M
+1 -3 D
+7 4 D
+-3 1 D
+P
+FO
+7702 3154 M
+2 -1 D
+2 1 D
+P
+FO
+7583 3199 M
+1 -4 D
+0 4 D
+P
+FO
+7697 3153 M
+3 -1 D
+P
+FO
+7588 3218 M
+-1 1 D
+P
+FO
+7707 3157 M
+2 -1 D
+P
+FO
+7701 3151 M
+2 1 D
+P
+FO
+7686 3149 M
+2 -1 D
+P
+FO
+7795 3208 M
+14 10 D
+-9 -1 D
+0 -2 D
+-5 -2 D
+P
+FO
+7842 3234 M
+7 6 D
+-1 -1 D
+-1 1 D
+-8 -7 D
+-3 -1 D
+2 -1 D
+P
+FO
+7904 3292 M
+1 -2 D
+4 0 D
+2 8 D
+-2 0 D
+P
+FO
+7890 3278 M
+0 -1 D
+5 4 D
+-3 0 D
+P
+FO
+7866 3255 M
+-1 -3 D
+3 2 D
+P
+FO
+7900 3287 M
+2 -2 D
+2 1 D
+P
+FO
+7852 3244 M
+1 -1 D
+2 1 D
+-3 1 D
+P
+FO
+7899 3301 M
+1 0 D
+1 2 D
+P
+FO
+7814 3224 M
+1 -1 D
+P
+FO
+7890 3282 M
+-2 0 D
+P
+FO
+7815 3225 M
+2 0 D
+P
+FO
+7870 3262 M
+3 -1 D
+P
+FO
+1417 3256 M
+-11 5 D
+-4 7 D
+5 -6 D
+10 -6 D
+0 51 D
+-93 0 D
+-1 0 D
+3 -2 D
+-2 -3 D
+3 -2 D
+2 2 D
+-2 -4 D
+7 2 D
+-6 -2 D
+1 -3 D
+-4 6 D
+-2 0 D
+-2 -2 D
+3 -3 D
+10 -3 D
+1 3 D
+7 4 D
+-3 -8 D
+7 -1 D
+-6 -1 D
+3 -2 D
+-3 0 D
+3 0 D
+-1 -2 D
+3 0 D
+-3 0 D
+1 -2 D
+3 -1 D
+-1 2 D
+5 1 D
+4 -9 D
+4 1 D
+2 -4 D
+-3 0 D
+2 -3 D
+-6 0 D
+8 -4 D
+0 -1 D
+-4 0 D
+1 -3 D
+4 -2 D
+-3 3 D
+2 1 D
+1 -3 D
+4 -2 D
+-3 -1 D
+-3 -7 D
+4 0 D
+0 2 D
+1 -6 D
+-1 3 D
+-4 1 D
+2 -2 D
+-2 0 D
+2 -6 D
+-2 -2 D
+-3 2 D
+-3 -6 D
+-3 2 D
+0 -1 D
+-2 1 D
+0 -3 D
+-1 3 D
+-2 -2 D
+2 3 D
+-4 -2 D
+4 2 D
+-4 0 D
+2 1 D
+-1 -1 D
+3 0 D
+3 5 D
+1 -6 D
+3 6 D
+-1 -3 D
+2 -1 D
+2 6 D
+-1 2 D
+-3 -1 D
+1 1 D
+-1 2 D
+2 -2 D
+-1 4 D
+1 -1 D
+3 1 D
+-3 4 D
+1 -2 D
+-5 -4 D
+-5 -2 D
+-3 -5 D
+6 1 D
+-7 -1 D
+7 11 D
+1 -4 D
+5 5 D
+-5 5 D
+1 1 D
+-3 -1 D
+0 -2 D
+-1 2 D
+-3 0 D
+1 -2 D
+-5 3 D
+-18 1 D
+-17 5 D
+1 -10 D
+6 -5 D
+6 -19 D
+1 2 D
+7 -1 D
+-5 -3 D
+-2 1 D
+1 -4 D
+6 -1 D
+-3 -1 D
+2 -5 D
+-2 -2 D
+-3 7 D
+0 -9 D
+2 1 D
+3 -2 D
+4 2 D
+6 -2 D
+-10 -1 D
+1 -1 D
+-5 2 D
+3 -5 D
+-2 -2 D
+1 -6 D
+1 1 D
+-1 -4 D
+2 -1 D
+-3 0 D
+-2 -20 D
+2 -1 D
+-2 -3 D
+1 -1 D
+-7 -25 D
+3 2 D
+1 -2 D
+-2 1 D
+-3 -2 D
+-5 -12 D
+4 -5 D
+0 -9 D
+5 -6 D
+-1 -5 D
+2 -1 D
+2 -7 D
+-1 -12 D
+-7 -12 D
+1 -4 D
+8 -6 D
+95 0 D
+P
+1365 3092 M
+-1 -3 D
+3 0 D
+-7 -1 D
+1 2 D
+2 -1 D
+P
+1352 3090 M
+-2 1 D
+3 0 D
+1 4 D
+1 -1 D
+-2 -4 D
+P
+1372 3133 M
+-2 -3 D
+4 -2 D
+1 -4 D
+-7 5 D
+P
+1412 3079 M
+2 -4 D
+-3 2 D
+0 -3 D
+-4 3 D
+P
+1408 3121 M
+2 -4 D
+-4 -4 D
+-1 6 D
+P
+1400 3139 M
+0 -3 D
+-1 1 D
+P
+1368 3301 M
+7 -5 D
+0 -5 D
+P
+1376 3159 M
+2 -2 D
+-3 1 D
+P
+1414 3134 M
+-2 -3 D
+-1 3 D
+3 1 D
+P
+1402 3088 M
+-3 -4 D
+0 3 D
+P
+1392 3115 M
+-2 -2 D
+-1 3 D
+3 0 D
+P
+1392 3077 M
+0 -2 D
+-3 2 D
+P
+1339 3217 M
+-2 1 D
+P
+1347 3244 M
+1 1 D
+P
+1392 3277 M
+0 7 D
+P
+1356 3296 M
+2 -2 D
+-2 -3 D
+P
+1356 3239 M
+1 1 D
+P
+FO
+1307 3307 M
+0 -1 D
+-3 1 D
+7 -5 D
+6 -1 D
+4 1 D
+1 4 D
+1 -3 D
+2 0 D
+-2 4 D
+P
+FO
+1295 3307 M
+P
+FO
+1291 3307 M
+-1 0 D
+-3 0 D
+-3 -2 D
+2 -8 D
+-3 7 D
+2 3 D
+-37 0 D
+-2 -1 D
+2 -2 D
+4 0 D
+-1 2 D
+2 -2 D
+0 3 D
+1 -3 D
+3 1 D
+-2 1 D
+3 -2 D
+2 1 D
+2 -5 D
+3 2 D
+-1 -2 D
+6 -1 D
+-8 -2 D
+1 -5 D
+3 3 D
+3 -3 D
+0 4 D
+1 -3 D
+5 1 D
+0 -3 D
+3 2 D
+-3 -3 D
+1 -1 D
+5 3 D
+0 -5 D
+4 1 D
+-3 -3 D
+-4 2 D
+5 -4 D
+5 -1 D
+3 3 D
+3 -1 D
+-2 0 D
+2 -2 D
+1 4 D
+0 -3 D
+6 0 D
+2 6 D
+0 -5 D
+-9 -6 D
+2 1 D
+1 -2 D
+11 -4 D
+5 0 D
+-1 -1 D
+19 -3 D
+0 -2 D
+3 0 D
+2 4 D
+2 -2 D
+2 2 D
+-4 5 D
+-2 -4 D
+0 4 D
+-3 1 D
+2 0 D
+0 3 D
+-7 4 D
+3 -1 D
+-1 4 D
+-24 7 D
+-4 6 D
+3 0 D
+-9 7 D
+P
+1286 3287 M
+0 -1 D
+2 0 D
+0 -1 D
+-2 -1 D
+P
+1315 3281 M
+7 -2 D
+-10 2 D
+P
+FO
+1244 3307 M
+1 0 D
+P
+FO
+1361 3260 M
+-3 2 D
+-1 -2 D
+-1 5 D
+-3 0 D
+5 2 D
+-4 2 D
+-2 -4 D
+4 -2 D
+1 -4 D
+4 -1 D
+P
+FO
+1254 3303 M
+-1 -1 D
+3 0 D
+-3 -2 D
+8 -3 D
+-1 7 D
+P
+FO
+1346 3274 M
+4 0 D
+-1 2 D
+1 -2 D
+3 1 D
+-5 2 D
+P
+FO
+1274 3291 M
+-1 2 D
+-3 0 D
+0 -3 D
+4 -1 D
+P
+FO
+1346 3271 M
+1 1 D
+-4 3 D
+0 -3 D
+P
+FO
+1308 3301 M
+12 -6 D
+-6 5 D
+-5 2 D
+P
+FO
+1303 3297 M
+4 -2 D
+-4 3 D
+P
+FO
+1323 3302 M
+-5 -3 D
+3 0 D
+P
+FO
+1358 3244 M
+3 1 D
+-2 3 D
+P
+FO
+1348 3271 M
+3 -1 D
+-2 3 D
+P
+FO
+1279 3288 M
+1 -2 D
+1 3 D
+-3 -1 D
+P
+FO
+1356 3252 M
+3 -2 D
+-1 3 D
+P
+FO
+1336 3295 M
+3 -1 D
+-2 2 D
+P
+FO
+1276 3287 M
+1 1 D
+-2 1 D
+0 -2 D
+P
+FO
+1355 3273 M
+2 -1 D
+-2 2 D
+P
+FO
+1332 3282 M
+3 -5 D
+3 1 D
+P
+FO
+1314 3295 M
+5 -1 D
+P
+FO
+1333 3283 M
+6 -3 D
+P
+FO
+1326 3288 M
+4 -1 D
+P
+FO
+1336 3292 M
+3 1 D
+P
+FO
+1350 3243 M
+-1 -3 D
+P
+FO
+1341 3279 M
+4 -1 D
+P
+FO
+1306 3296 M
+3 0 D
+P
+FO
+1354 3260 M
+0 2 D
+P
+FO
+1339 3279 M
+2 -2 D
+P
+FO
+1263 3300 M
+0 -2 D
+P
+FO
+1329 3286 M
+3 -2 D
+P
+FO
+1338 3280 M
+3 -1 D
+P
+FO
+1353 3277 M
+3 -2 D
+P
+FO
+1353 3274 M
+1 -1 D
+P
+FO
+1354 3241 M
+0 -2 D
+P
+FO
+1346 3274 M
+3 0 D
+P
+FO
+1354 3242 M
+1 -1 D
+P
+FO
+1296 3281 M
+2 1 D
+P
+FO
+1365 3249 M
+-1 1 D
+P
+FO
+1345 3276 M
+1 1 D
+P
+FO
+1338 3275 M
+2 -1 D
+P
+FO
+1340 3278 M
+2 -1 D
+P
+FO
+1331 3283 M
+1 -1 D
+P
+FO
+1337 3280 M
+1 -1 D
+P
+FO
+1317 3301 M
+2 0 D
+P
+FO
+1341 3276 M
+2 0 D
+P
+FO
+1335 3293 M
+1 0 D
+P
+FO
+1349 3240 M
+-1 1 D
+P
+FO
+1302 3306 M
+3 0 D
+P
+FO
+1428 3071 M
+-3 3 D
+2 2 D
+2 -1 D
+1 -4 D
+20 0 D
+0 1 D
+0 -1 D
+204 0 D
+0 236 D
+-164 0 D
+1 -8 D
+2 0 D
+4 -12 D
+-8 11 D
+1 9 D
+-11 0 D
+1 -1 D
+-3 -5 D
+0 6 D
+-47 0 D
+-1 -4 D
+-5 -2 D
+2 -6 D
+-3 6 D
+5 2 D
+0 4 D
+-11 0 D
+0 -51 D
+1 0 D
+-1 0 D
+0 -185 D
+P
+1588 3110 M
+0 -3 D
+5 -2 D
+2 -5 D
+3 0 D
+8 -7 D
+-1 -1 D
+-4 4 D
+2 -6 D
+-5 -3 D
+-5 9 D
+-3 -2 D
+-5 8 D
+0 7 D
+P
+1599 3099 M
+-2 0 D
+3 -1 D
+P
+1499 3261 M
+4 4 D
+-3 2 D
+-2 -1 D
+4 1 D
+5 -4 D
+-5 0 D
+-2 -4 D
+-1 0 D
+P
+1555 3253 M
+1 2 D
+-4 1 D
+4 2 D
+0 4 D
+3 -7 D
+-1 -2 D
+P
+1647 3178 M
+2 -5 D
+-2 2 D
+-1 -3 D
+-2 4 D
+-4 0 D
+5 3 D
+P
+1517 3234 M
+-6 -6 D
+-6 -1 D
+-1 -2 D
+1 2 D
+5 1 D
+4 5 D
+P
+1493 3252 M
+3 -1 D
+-2 0 D
+-2 -3 D
+2 -2 D
+-4 2 D
+P
+1447 3151 M
+2 -1 D
+-2 -2 D
+-5 1 D
+P
+1638 3166 M
+2 -4 D
+-2 -1 D
+-2 1 D
+1 4 D
+P
+1462 3276 M
+-2 -5 D
+1 -6 D
+-2 6 D
+4 5 D
+P
+1438 3149 M
+2 -1 D
+-1 -2 D
+-3 1 D
+P
+1433 3238 M
+4 -2 D
+-4 0 D
+-2 2 D
+P
+1458 3088 M
+-1 -5 D
+P
+1574 3134 M
+1 -1 D
+-4 1 D
+P
+1462 3302 M
+1 -8 D
+4 -3 D
+-6 4 D
+P
+1442 3217 M
+2 -3 D
+-4 4 D
+P
+1614 3228 M
+4 -4 D
+0 -3 D
+P
+1627 3149 M
+2 -3 D
+-4 4 D
+P
+1590 3143 M
+3 -2 D
+-7 -4 D
+P
+1510 3182 M
+1 -5 D
+P
+1624 3185 M
+4 -2 D
+-3 0 D
+P
+1511 3188 M
+-2 -1 D
+P
+1638 3175 M
+-3 -1 D
+P
+FO
+1890 3230 M
+-7 -1 D
+7 1 D
+0 77 D
+-140 0 D
+-1 0 D
+-95 0 D
+0 -236 D
+236 0 D
+P
+1874 3229 M
+3 -3 D
+-1 -12 D
+4 -4 D
+2 0 D
+1 -5 D
+-4 -3 D
+5 -4 D
+-2 -7 D
+2 -1 D
+-4 -1 D
+1 -3 D
+-3 -3 D
+-4 1 D
+2 -5 D
+3 1 D
+-2 -3 D
+3 0 D
+0 -1 D
+-6 1 D
+2 1 D
+-2 1 D
+-1 4 D
+-12 -1 D
+9 2 D
+-1 2 D
+3 -1 D
+0 1 D
+5 -2 D
+0 2 D
+3 0 D
+-1 4 D
+3 0 D
+1 5 D
+-2 2 D
+-8 0 D
+10 1 D
+-9 6 D
+4 -1 D
+4 2 D
+-8 10 D
+2 11 D
+-5 3 D
+P
+1698 3250 M
+5 0 D
+1 -3 D
+5 5 D
+-2 1 D
+7 -2 D
+3 3 D
+9 -1 D
+-1 1 D
+5 0 D
+5 4 D
+-2 1 D
+7 1 D
+0 -3 D
+3 -1 D
+0 -6 D
+-2 -2 D
+1 4 D
+-5 6 D
+-2 -5 D
+-2 2 D
+-3 -3 D
+-2 2 D
+-1 -4 D
+0 2 D
+-3 -1 D
+0 1 D
+-8 1 D
+-2 -2 D
+-5 0 D
+-7 -6 D
+1 4 D
+-6 1 D
+P
+1819 3264 M
+11 -4 D
+-1 -5 D
+4 0 D
+-1 4 D
+5 0 D
+0 -5 D
+3 0 D
+-3 -1 D
+0 -2 D
+14 -2 D
+11 3 D
+2 -2 D
+-19 -3 D
+-8 3 D
+-5 -1 D
+4 4 D
+-9 2 D
+2 5 D
+-12 3 D
+-9 -3 D
+-3 3 D
+-4 -3 D
+-1 2 D
+5 2 D
+3 -3 D
+P
+1728 3122 M
+4 -4 D
+-3 1 D
+0 -2 D
+-3 -1 D
+2 1 D
+P
+1665 3101 M
+0 -6 D
+-2 -2 D
+2 5 D
+-2 2 D
+2 2 D
+P
+1728 3129 M
+-1 -5 D
+-2 3 D
+2 3 D
+P
+1697 3151 M
+0 -4 D
+-2 3 D
+P
+1846 3102 M
+5 -2 D
+-9 1 D
+P
+1813 3090 M
+-1 -1 D
+P
+1752 3075 M
+2 -1 D
+P
+1869 3133 M
+-3 -1 D
+P
+1772 3132 M
+1 -3 D
+P
+1712 3272 M
+-3 -1 D
+P
+FO
+2126 3163 M
+-1 1 D
+1 0 D
+-1 4 D
+1 62 D
+-11 -4 D
+-7 3 D
+-4 -2 D
+4 7 D
+-2 1 D
+-22 -6 D
+-6 0 D
+-2 2 D
+31 20 D
+19 6 D
+0 50 D
+-42 0 D
+1 -1 D
+-12 -2 D
+7 3 D
+-190 0 D
+0 -77 D
+1 0 D
+-1 0 D
+0 -159 D
+236 0 D
+P
+2019 3306 M
+2 -5 D
+4 -1 D
+-3 -2 D
+4 -1 D
+-4 0 D
+8 -3 D
+-3 0 D
+4 -2 D
+0 -3 D
+-3 -1 D
+2 2 D
+-4 1 D
+0 2 D
+-2 -1 D
+2 2 D
+-9 1 D
+-5 -4 D
+6 1 D
+-1 -1 D
+3 -2 D
+4 1 D
+1 -3 D
+6 1 D
+-4 -2 D
+-3 0 D
+-8 -6 D
+-4 0 D
+-4 3 D
+-6 -2 D
+0 6 D
+8 2 D
+-1 2 D
+-3 1 D
+4 1 D
+1 3 D
+6 2 D
+-12 -4 D
+-1 4 D
+2 1 D
+4 -2 D
+2 3 D
+7 0 D
+-4 6 D
+P
+2021 3288 M
+-8 0 D
+2 -3 D
+P
+2020 3286 M
+-4 -2 D
+3 0 D
+P
+2048 3282 M
+3 -5 D
+-2 -1 D
+3 1 D
+0 -2 D
+8 1 D
+-2 -2 D
+8 -1 D
+0 -2 D
+-3 0 D
+5 0 D
+0 -4 D
+-1 3 D
+-11 0 D
+-3 2 D
+7 -2 D
+3 2 D
+-17 2 D
+1 4 D
+-7 1 D
+5 0 D
+-1 2 D
+P
+1905 3164 M
+1 -2 D
+-3 -4 D
+2 -1 D
+2 -4 D
+17 -10 D
+-8 2 D
+0 2 D
+-10 6 D
+-1 4 D
+-3 1 D
+4 4 D
+P
+2025 3243 M
+0 -4 D
+-3 -2 D
+-3 3 D
+-1 -3 D
+-1 4 D
+1 -1 D
+4 3 D
+-1 -2 D
+P
+2014 3265 M
+5 -1 D
+-2 -2 D
+-10 -1 D
+6 -1 D
+0 -3 D
+-12 0 D
+1 3 D
+P
+2086 3264 M
+-6 1 D
+-7 3 D
+-1 -3 D
+-1 3 D
+8 1 D
+1 -3 D
+6 -1 D
+P
+2119 3282 M
+-1 -4 D
+-8 1 D
+2 2 D
+-2 2 D
+2 0 D
+1 -3 D
+P
+2096 3282 M
+-1 -3 D
+-3 2 D
+-1 -2 D
+-4 1 D
+4 3 D
+P
+2067 3299 M
+-2 -3 D
+1 3 D
+-9 2 D
+5 1 D
+P
+2056 3297 M
+-2 -1 D
+-1 4 D
+-5 -2 D
+-1 2 D
+5 1 D
+P
+2039 3288 M
+-7 1 D
+2 1 D
+7 -2 D
+P
+2061 3279 M
+-5 -3 D
+0 2 D
+-3 0 D
+8 2 D
+P
+2085 3286 M
+-8 -3 D
+3 2 D
+0 3 D
+P
+2042 3221 M
+2 -5 D
+-4 -1 D
+-5 4 D
+P
+1915 3262 M
+1 -2 D
+-2 0 D
+-1 3 D
+P
+2099 3150 M
+2 -2 D
+-2 -4 D
+1 4 D
+P
+2085 3297 M
+-4 -2 D
+2 3 D
+P
+2105 3265 M
+-1 -1 D
+-2 1 D
+4 1 D
+0 -1 D
+P
+2091 3261 M
+-6 0 D
+6 3 D
+-2 -2 D
+3 -1 D
+P
+2026 3248 M
+4 -1 D
+-4 -2 D
+-3 2 D
+P
+2027 3172 M
+-2 0 D
+0 2 D
+P
+1985 3269 M
+0 -2 D
+-2 0 D
+P
+2048 3302 M
+-1 -1 D
+-3 2 D
+4 0 D
+P
+2098 3212 M
+2 -2 D
+-5 0 D
+P
+2100 3196 M
+-1 -2 D
+-1 2 D
+P
+1991 3224 M
+-3 -1 D
+2 2 D
+P
+1993 3290 M
+-1 -1 D
+-3 1 D
+P
+2112 3266 M
+-3 -1 D
+1 3 D
+P
+2059 3283 M
+0 -2 D
+-3 0 D
+P
+2019 3247 M
+1 -1 D
+-3 -1 D
+1 2 D
+P
+1994 3234 M
+-1 -1 D
+P
+2107 3306 M
+-9 -3 D
+3 3 D
+P
+2066 3179 M
+4 0 D
+6 -4 D
+P
+2063 3293 M
+-5 -1 D
+5 2 D
+P
+2095 3164 M
+1 -4 D
+P
+2121 3216 M
+3 -1 D
+-3 -2 D
+P
+1970 3208 M
+-6 -5 D
+P
+2105 3302 M
+-3 1 D
+P
+2028 3229 M
+-4 -1 D
+P
+1994 3222 M
+-4 -1 D
+4 2 D
+P
+2044 3290 M
+-4 2 D
+P
+2047 3286 M
+-3 -1 D
+P
+2071 3303 M
+-2 -1 D
+2 2 D
+P
+2035 3293 M
+-6 0 D
+P
+2033 3250 M
+1 -2 D
+P
+2076 3237 M
+-4 0 D
+P
+2048 3231 M
+-1 -2 D
+1 3 D
+P
+1954 3174 M
+-1 0 D
+1 1 D
+P
+1998 3235 M
+-2 0 D
+P
+2000 3212 M
+-1 -1 D
+P
+1984 3229 M
+-2 0 D
+P
+1993 3201 M
+-1 0 D
+2 0 D
+P
+2002 3159 M
+1 -1 D
+P
+2081 3217 M
+-1 -1 D
+P
+1902 3216 M
+2 -2 D
+P
+1986 3272 M
+2 -1 D
+P
+1952 3199 M
+-3 -1 D
+P
+2024 3224 M
+-3 -2 D
+P
+2027 3227 M
+-1 -2 D
+P
+1960 3180 M
+-2 -2 D
+P
+1998 3204 M
+-3 -1 D
+P
+2029 3252 M
+-2 -2 D
+P
+2096 3155 M
+1 -3 D
+P
+1900 3229 M
+-1 -1 D
+P
+1986 3226 M
+-2 0 D
+P
+2025 3236 M
+-1 -1 D
+P
+1895 3238 M
+0 -2 D
+P
+1993 3219 M
+-2 0 D
+3 0 D
+P
+2075 3244 M
+-1 -1 D
+P
+1956 3187 M
+-1 -1 D
+P
+2011 3249 M
+0 -2 D
+P
+2093 3210 M
+-2 0 D
+2 1 D
+P
+2018 3236 M
+-1 -1 D
+P
+1954 3173 M
+-2 -1 D
+P
+2000 3214 M
+-2 0 D
+P
+2011 3195 M
+-1 0 D
+P
+2006 3211 M
+-2 -1 D
+P
+1909 3159 M
+-2 -1 D
+P
+1996 3224 M
+-2 0 D
+P
+2026 3223 M
+-2 0 D
+P
+1915 3267 M
+0 -2 D
+P
+2042 3188 M
+-1 -1 D
+P
+1998 3213 M
+0 -1 D
+P
+2032 3245 M
+1 -1 D
+P
+2053 3206 M
+0 -1 D
+P
+2029 3239 M
+-2 0 D
+P
+1954 3196 M
+-1 -1 D
+0 1 D
+P
+1928 3258 M
+-2 0 D
+P
+1911 3268 M
+-1 -1 D
+P
+2004 3151 M
+0 -1 D
+P
+1997 3226 M
+-2 2 D
+P
+2040 3245 M
+-2 0 D
+2 1 D
+P
+1894 3225 M
+0 -2 D
+P
+1991 3215 M
+-2 0 D
+P
+2089 3204 M
+0 -2 D
+P
+1997 3245 M
+0 -2 D
+P
+FO
+2126 3167 M
+0 -1 D
+P
+FO
+-5 -3 1 2112 3233 SP
+-3 -1 1 2113 3235 SP
+-1 -2 1 2116 3238 SP
+2362 3122 M
+-32 -10 D
+-9 -6 D
+-7 1 D
+-10 -3 D
+-5 2 D
+2 -1 D
+-5 1 D
+-3 -1 D
+-3 0 D
+8 2 D
+-3 1 D
+-3 -1 D
+-12 5 D
+7 6 D
+2 7 D
+5 3 D
+2 5 D
+4 1 D
+1 -4 D
+4 0 D
+-1 -4 D
+-14 -1 D
+-2 -5 D
+5 -2 D
+7 1 D
+3 -3 D
+2 5 D
+13 5 D
+0 -2 D
+10 9 D
+7 1 D
+25 -3 D
+-8 2 D
+6 4 D
+4 0 D
+0 44 D
+-2 -5 D
+-12 4 D
+-1 3 D
+-7 -4 D
+1 5 D
+-6 -1 D
+5 5 D
+-5 -1 D
+1 1 D
+-3 1 D
+-2 4 D
+1 2 D
+-10 0 D
+8 -7 D
+2 -8 D
+-11 -13 D
+0 -17 D
+-10 -7 D
+-6 -1 D
+-5 18 D
+-4 6 D
+-4 1 D
+-10 -4 D
+1 0 D
+-3 -4 D
+-5 -3 D
+-6 3 D
+2 6 D
+6 2 D
+2 4 D
+4 2 D
+1 12 D
+-4 4 D
+2 2 D
+3 -1 D
+-3 6 D
+-17 5 D
+-5 4 D
+-4 0 D
+-6 3 D
+-6 -1 D
+1 -1 D
+-3 -5 D
+4 -2 D
+-11 -4 D
+0 -6 D
+-3 -5 D
+0 5 D
+-2 -5 D
+-1 2 D
+2 8 D
+-6 -6 D
+-6 -1 D
+-1 -4 D
+-4 -1 D
+0 -8 D
+-6 -7 D
+2 -6 D
+-2 -4 D
+4 -9 D
+3 0 D
+-2 -1 D
+2 -5 D
+-1 -13 D
+-8 -13 D
+-9 -5 D
+-10 -1 D
+-4 3 D
+-5 11 D
+1 13 D
+-4 10 D
+5 11 D
+0 5 D
+5 7 D
+-1 3 D
+5 11 D
+-3 2 D
+-3 -1 D
+-8 -7 D
+-3 1 D
+5 9 D
+5 1 D
+1 4 D
+14 18 D
+0 -6 D
+5 5 D
+5 0 D
+0 -3 D
+-3 -2 D
+2 -2 D
+8 8 D
+14 1 D
+4 3 D
+12 -2 D
+6 -4 D
+3 5 D
+2 -2 D
+15 0 D
+-3 4 D
+-5 2 D
+1 1 D
+-3 5 D
+-6 -1 D
+-10 1 D
+1 7 D
+-13 -2 D
+-15 0 D
+-12 -6 D
+-8 3 D
+-8 -1 D
+-6 7 D
+-12 3 D
+-5 -3 D
+3 4 D
+-7 -5 D
+1 5 D
+-5 6 D
+-16 -9 D
+-11 -1 D
+-5 -2 D
+0 -61 D
+3 2 D
+-3 -5 D
+1 -4 D
+-1 1 D
+0 -92 D
+236 0 D
+P
+2163 3170 M
+3 -1 D
+0 -6 D
+-3 -2 D
+-2 6 D
+P
+2252 3202 M
+0 -3 D
+-1 1 D
+P
+2250 3174 M
+2 -1 D
+-3 0 D
+P
+2140 3145 M
+1 -1 D
+-3 0 D
+P
+2227 3219 M
+0 -1 D
+-3 1 D
+P
+2129 3207 M
+1 -2 D
+-3 1 D
+P
+2257 3202 M
+-3 -2 D
+3 3 D
+P
+2157 3169 M
+-5 0 D
+P
+2136 3226 M
+0 -3 D
+-1 3 D
+P
+2151 3140 M
+-1 -2 D
+P
+2151 3161 M
+-3 -1 D
+4 1 D
+P
+2261 3201 M
+0 -2 D
+P
+2213 3213 M
+-1 -1 D
+0 1 D
+P
+2146 3209 M
+0 1 D
+1 -3 D
+P
+2180 3227 M
+3 -1 D
+P
+2158 3168 M
+2 -1 D
+P
+2138 3210 M
+-2 -1 D
+P
+2172 3225 M
+-1 -1 D
+P
+2148 3216 M
+-2 0 D
+P
+2170 3128 M
+-2 -1 D
+P
+2162 3132 M
+-2 -1 D
+P
+2227 3217 M
+-2 -1 D
+P
+2140 3218 M
+-1 -1 D
+P
+2129 3211 M
+-2 1 D
+P
+2134 3214 M
+-1 -1 D
+P
+2142 3143 M
+-2 0 D
+2 1 D
+P
+2133 3209 M
+-1 0 D
+2 1 D
+P
+FO
+2362 3185 M
+-2 0 D
+2 -3 D
+P
+FO
+2362 3192 M
+-2 -1 D
+2 -1 D
+P
+FO
+2362 3218 M
+-11 1 D
+9 -1 D
+-2 2 D
+4 1 D
+0 13 D
+-1 -1 D
+-2 1 D
+0 -2 D
+0 8 D
+1 -1 D
+1 1 D
+0 -4 D
+1 0 D
+-1 44 D
+0 -2 D
+-3 0 D
+3 4 D
+1 0 D
+0 25 D
+-147 0 D
+-1 -1 D
+1 1 D
+-29 0 D
+-3 -1 D
+1 1 D
+-12 0 D
+1 -1 D
+-4 -1 D
+2 -1 D
+-1 -11 D
+-5 2 D
+-2 -3 D
+-3 5 D
+-1 -4 D
+-5 2 D
+2 2 D
+4 1 D
+-5 1 D
+-4 -4 D
+-3 2 D
+4 -1 D
+0 5 D
+-2 -1 D
+-3 1 D
+1 3 D
+2 -2 D
+1 1 D
+-1 1 D
+3 2 D
+-27 1 D
+0 -50 D
+13 4 D
+4 4 D
+3 6 D
+9 3 D
+-4 -7 D
+5 1 D
+6 12 D
+4 -2 D
+-6 -5 D
+0 -3 D
+3 3 D
+3 1 D
+-1 1 D
+3 -1 D
+3 5 D
+-4 1 D
+0 3 D
+5 1 D
+18 -6 D
+20 0 D
+7 -12 D
+7 -7 D
+7 -1 D
+17 1 D
+-5 -8 D
+11 -8 D
+-5 -7 D
+10 -3 D
+-4 -1 D
+0 -3 D
+2 2 D
+1 -2 D
+-4 -3 D
+1 -2 D
+9 2 D
+2 -2 D
+1 -4 D
+23 -3 D
+17 0 D
+5 -2 D
+10 0 D
+-1 -2 D
+3 3 D
+2 -2 D
+-4 -1 D
+5 1 D
+-4 -3 D
+4 2 D
+6 -1 D
+2 1 D
+0 -2 D
+8 0 D
+7 -9 D
+3 1 D
+1 -4 D
+3 -2 D
+4 1 D
+-2 -3 D
+3 -2 D
+P
+2308 3245 M
+2 -4 D
+2 2 D
+-2 -4 D
+-2 3 D
+-4 -1 D
+4 1 D
+-1 3 D
+2 -2 D
+P
+2341 3272 M
+-3 -5 D
+1 7 D
+0 -2 D
+2 1 D
+P
+2281 3271 M
+-9 -5 D
+1 2 D
+-4 -1 D
+P
+2261 3282 M
+-4 -3 D
+-1 0 D
+2 5 D
+P
+2349 3232 M
+-2 -3 D
+-4 1 D
+P
+2244 3295 M
+0 -2 D
+-2 1 D
+P
+2207 3301 M
+-12 -12 D
+3 6 D
+9 7 D
+P
+2326 3242 M
+3 -3 D
+-1 -5 D
+-2 -1 D
+P
+2231 3279 M
+-4 -4 D
+1 6 D
+P
+2361 3215 M
+-5 0 D
+P
+2152 3294 M
+2 -4 D
+-3 4 D
+P
+2349 3294 M
+0 -2 D
+P
+2340 3277 M
+0 -2 D
+P
+2220 3301 M
+-4 -1 D
+P
+2360 3304 M
+1 -2 D
+-1 3 D
+P
+2345 3296 M
+2 -1 D
+P
+2262 3284 M
+-2 0 D
+P
+2281 3221 M
+3 -1 D
+P
+2254 3295 M
+-3 0 D
+P
+FO
+2168 3307 M
+P
+FO
+2126 3164 M
+0 2 D
+P
+FO
+0 -1 1 2165 3307 SP
+2 1 0 -1 2 2158 3307 SP
+2323 3210 M
+-3 -4 D
+-4 6 D
+-5 -3 D
+-3 3 D
+-5 -1 D
+-2 -1 D
+1 -2 D
+-5 1 D
+-1 3 D
+-7 -1 D
+-2 1 D
+-1 -2 D
+16 -3 D
+11 -5 D
+8 4 D
+-6 -4 D
+3 -1 D
+7 7 D
+-3 0 D
+P
+FO
+1 -2 0 -1 3 -2 -4 -4 -5 -2 -12 0 7 2 -1 1 8 2174 3244 SP
+2 -3 -4 -6 -4 -3 -2 1 4 2197 3195 SP
+-2 1 7 1 -2 -3 -15 -5 4 2162 3264 SP
+2 1 5 1 1 -2 -8 -1 4 2179 3280 SP
+2 1 -1 -4 -1 1 3 2232 3206 SP
+4 -2 -2 -1 -1 1 3 2158 3304 SP
+1 2 9 -1 -7 -3 3 2277 3215 SP
+-3 1 4 4 4 -6 -5 0 4 2270 3220 SP
+4 0 -2 -2 2 2181 3280 SP
+1 1 1 -2 -2 0 3 2359 3186 SP
+8 0 -5 -1 2 2227 3255 SP
+4 0 -3 -2 2 2283 3212 SP
+-1 5 4 -4 -4 -1 3 2265 3225 SP
+4 -2 -4 0 2 2258 3208 SP
+0 1 4 -1 -4 -1 3 2320 3214 SP
+3 1 -1 -1 2 2256 3234 SP
+2 0 0 -2 2 2198 3199 SP
+0 -1 1 2228 3207 SP
+0 -2 1 2224 3200 SP
+-2 0 1 2302 3216 SP
+-4 0 1 2301 3211 SP
+0 -2 1 2205 3226 SP
+2 1 -2 -2 2 2164 3300 SP
+-3 -1 1 2322 3201 SP
+0 -2 1 2264 3220 SP
+0 -2 1 2220 3193 SP
+1 -1 1 2172 3282 SP
+0 -2 1 2310 3214 SP
+1 -1 1 2185 3279 SP
+1 -1 1 2232 3209 SP
+-1 -1 1 2159 3270 SP
+1 -1 1 2361 3193 SP
+-1 -2 1 2300 3114 SP
+-2 -1 1 2148 3266 SP
+-2 -1 1 2198 3276 SP
+-1 -1 1 2218 3190 SP
+FQ
+-2 -1 0 2 -3 -1 4 -2 4 2314 3209 SP
+-2 0 1 2155 3260 SP
+-2 -2 1 2311 3208 SP
+4 2 -3 0 2 2308 3208 SP
+2501 3071 M
+2 1 D
+1 8 D
+-2 -1 D
+2 1 D
+-7 3 D
+4 5 D
+0 -2 D
+3 3 D
+0 -2 D
+2 3 D
+3 0 D
+-1 1 D
+6 5 D
+9 3 D
+2 -1 D
+5 4 D
+0 -2 D
+19 2 D
+0 1 D
+2 -1 D
+4 1 D
+0 -1 D
+8 2 D
+0 -1 D
+2 6 D
+-1 2 D
+3 0 D
+-2 3 D
+3 -4 D
+1 2 D
+2 0 D
+-1 -7 D
+2 2 D
+2 -1 D
+2 1 D
+1 3 D
+1 -2 D
+4 4 D
+0 -1 D
+2 2 D
+-1 -6 D
+6 3 D
+9 0 D
+-1 9 D
+-4 1 D
+3 -1 D
+2 -5 D
+-7 -3 D
+-5 3 D
+0 2 D
+-5 2 D
+2 1 D
+1 -1 D
+-4 6 D
+-3 1 D
+-1 -1 D
+-3 3 D
+3 -1 D
+-1 2 D
+4 2 D
+-2 1 D
+7 2 D
+0 1 D
+-4 -1 D
+-2 4 D
+7 12 D
+6 3 D
+-1 3 D
+4 0 D
+-2 4 D
+6 3 D
+0 85 D
+-11 -11 D
+-17 -4 D
+12 7 D
+5 8 D
+6 1 D
+2 4 D
+3 1 D
+0 42 D
+-1 0 D
+1 -2 D
+-6 6 D
+-2 -2 D
+1 -2 D
+-4 1 D
+-1 -3 D
+-1 2 D
+-3 -2 D
+-4 4 D
+-3 -5 D
+4 7 D
+3 -4 D
+2 2 D
+-1 -2 D
+4 5 D
+4 -1 D
+-3 6 D
+3 0 D
+2 -6 D
+3 2 D
+2 -3 D
+0 9 D
+-29 0 D
+0 -2 D
+-1 2 D
+-127 0 D
+3 -1 D
+-6 -1 D
+2 -4 D
+-6 -2 D
+3 1 D
+-3 4 D
+6 2 D
+0 1 D
+-18 0 D
+0 -3 D
+6 1 D
+-3 -2 D
+-11 0 D
+2 1 D
+-1 1 D
+6 -1 D
+0 3 D
+-59 0 D
+0 -25 D
+3 0 D
+0 -4 D
+2 -2 D
+5 3 D
+5 -3 D
+3 1 D
+0 -7 D
+-2 0 D
+0 5 D
+-12 -1 D
+-2 1 D
+1 3 D
+-2 -2 D
+-1 1 D
+0 -41 D
+1 0 D
+-1 -15 D
+8 0 D
+7 -4 D
+-4 0 D
+0 -1 D
+-5 2 D
+-6 -2 D
+2 2 D
+-2 0 D
+0 -28 D
+4 -3 D
+1 -2 D
+3 1 D
+0 -3 D
+-5 1 D
+-2 2 D
+-1 -4 D
+1 -1 D
+-1 0 D
+0 -44 D
+13 2 D
+9 -1 D
+4 2 D
+-4 4 D
+4 -1 D
+1 -6 D
+-7 -5 D
+-20 -10 D
+0 -51 D
+P
+2568 3230 M
+-9 -2 D
+-5 0 D
+-24 -14 D
+-6 0 D
+-7 -8 D
+-2 -7 D
+-5 0 D
+-17 -9 D
+-19 -5 D
+-12 -8 D
+8 7 D
+10 5 D
+10 1 D
+10 6 D
+5 1 D
+-1 2 D
+-15 5 D
+-7 -1 D
+-21 -5 D
+-6 3 D
+-7 -1 D
+-7 3 D
+-4 6 D
+-2 1 D
+0 -2 D
+-3 0 D
+-9 5 D
+3 0 D
+-9 4 D
+8 -3 D
+2 -3 D
+11 -1 D
+4 -8 D
+6 -2 D
+7 1 D
+6 -3 D
+13 5 D
+15 1 D
+14 -4 D
+7 5 D
+7 2 D
+8 9 D
+11 3 D
+18 10 D
+P
+2516 3205 M
+-6 0 D
+-5 -6 D
+9 0 D
+P
+2434 3210 M
+-6 0 D
+5 -2 D
+P
+2526 3215 M
+0 1 D
+-2 -2 D
+P
+2506 3198 M
+-2 0 D
+P
+2491 3279 M
+2 -2 D
+-3 -4 D
+3 1 D
+0 -2 D
+2 2 D
+-1 -2 D
+3 -3 D
+2 2 D
+-1 -2 D
+4 -1 D
+-3 0 D
+-1 -1 D
+-6 5 D
+0 -6 D
+-1 4 D
+-4 -2 D
+0 3 D
+0 -2 D
+-5 5 D
+0 -3 D
+-3 -1 D
+3 -2 D
+-3 0 D
+0 3 D
+-2 -5 D
+1 5 D
+3 4 D
+-5 -2 D
+1 -4 D
+-4 0 D
+0 2 D
+-2 -2 D
+1 3 D
+3 1 D
+-2 0 D
+7 4 D
+2 -2 D
+2 3 D
+P
+2486 3274 M
+2 -3 D
+-2 3 D
+4 3 D
+P
+2485 3274 M
+0 -2 D
+P
+2476 3272 M
+-2 -1 D
+P
+2488 3273 M
+2 -2 D
+-1 3 D
+P
+2461 3177 M
+1 -1 D
+-14 -8 D
+1 -2 D
+5 1 D
+-2 -2 D
+3 0 D
+-5 -3 D
+2 -7 D
+-18 -7 D
+-4 1 D
+-10 -1 D
+-13 3 D
+-13 -1 D
+-16 -4 D
+-10 3 D
+4 6 D
+12 6 D
+32 5 D
+6 -2 D
+7 0 D
+-1 -1 D
+2 -1 D
+7 2 D
+-5 0 D
+5 4 D
+-7 -2 D
+1 4 D
+-5 -3 D
+0 2 D
+-6 -1 D
+13 2 D
+-1 -2 D
+4 2 D
+-5 -2 D
+3 -1 D
+6 3 D
+17 4 D
+P
+2448 3170 M
+-2 0 D
+-1 -2 D
+P
+2455 3173 M
+-2 -1 D
+P
+2460 3176 M
+-1 -1 D
+1 0 D
+P
+2447 3163 M
+-1 0 D
+P
+2442 3169 M
+-5 0 D
+P
+2452 3171 M
+-6 -1 D
+P
+2459 3174 M
+-3 -2 D
+P
+2445 3253 M
+-6 -4 D
+4 1 D
+-1 -2 D
+4 0 D
+3 -2 D
+-3 -1 D
+-2 -4 D
+6 -3 D
+-3 -1 D
+-4 2 D
+-1 4 D
+-2 -1 D
+2 -2 D
+-3 2 D
+1 3 D
+-2 0 D
+1 3 D
+-2 0 D
+P
+2441 3247 M
+-2 0 D
+2 -2 D
+P
+2444 3248 M
+-2 -1 D
+2 -2 D
+P
+2442 3246 M
+0 -1 D
+P
+2526 3191 M
+-1 -2 D
+-2 -1 D
+1 -3 D
+-1 -6 D
+-3 -1 D
+2 -3 D
+-4 -8 D
+1 -8 D
+-2 7 D
+3 6 D
+-3 10 D
+3 9 D
+1 -5 D
+P
+2521 3183 M
+-2 -1 D
+1 -2 D
+P
+2522 3187 M
+-2 -3 D
+P
+2384 3240 M
+3 -5 D
+3 0 D
+1 -3 D
+-4 2 D
+0 -2 D
+3 -1 D
+-3 0 D
+-2 3 D
+-5 3 D
+5 -1 D
+-4 2 D
+P
+2402 3177 M
+-3 -3 D
+1 2 D
+-1 1 D
+-3 -4 D
+1 5 D
+-6 -2 D
+1 2 D
+1 -1 D
+4 2 D
+4 0 D
+-3 -2 D
+4 2 D
+P
+2500 3247 M
+1 -2 D
+-3 1 D
+-2 -2 D
+0 -3 D
+-2 1 D
+2 4 D
+-4 -2 D
+0 1 D
+6 2 D
+-1 2 D
+P
+2427 3251 M
+0 -3 D
+3 2 D
+1 -2 D
+4 -1 D
+-5 2 D
+-2 -3 D
+2 -1 D
+-4 -1 D
+P
+2378 3183 M
+0 -3 D
+4 -4 D
+-1 -2 D
+-7 -1 D
+0 -3 D
+-1 5 D
+-3 0 D
+6 3 D
+P
+2580 3189 M
+1 -3 D
+-3 0 D
+1 -3 D
+-2 0 D
+0 4 D
+2 0 D
+-1 2 D
+P
+2424 3255 M
+-1 -7 D
+-5 -2 D
+3 4 D
+-4 -2 D
+0 3 D
+4 1 D
+-3 -3 D
+P
+2461 3275 M
+1 -3 D
+3 1 D
+-3 -3 D
+-2 4 D
+-4 -3 D
+1 3 D
+P
+2512 3232 M
+0 -1 D
+-3 0 D
+1 -2 D
+-4 0 D
+1 5 D
+1 -3 D
+4 2 D
+P
+2501 3306 M
+2 -2 D
+-10 -4 D
+4 4 D
+-2 -2 D
+0 2 D
+P
+2566 3159 M
+4 -3 D
+-1 -3 D
+-5 4 D
+0 1 D
+3 0 D
+P
+2434 3277 M
+-5 -7 D
+3 7 D
+-1 2 D
+1 -2 D
+3 2 D
+P
+2375 3250 M
+-1 -2 D
+2 -9 D
+6 -7 D
+-6 6 D
+-6 10 D
+P
+2550 3278 M
+7 -3 D
+-1 -4 D
+-8 0 D
+-5 4 D
+1 3 D
+P
+2430 3303 M
+1 -1 D
+-6 -1 D
+4 -1 D
+-5 1 D
+4 3 D
+P
+2375 3191 M
+1 -3 D
+-2 2 D
+-2 -1 D
+-1 1 D
+P
+2465 3218 M
+1 -4 D
+-1 1 D
+-2 -4 D
+-2 0 D
+3 3 D
+P
+2475 3295 M
+3 -2 D
+-6 -2 D
+3 3 D
+-4 0 D
+P
+2470 3306 M
+-4 -2 D
+-1 1 D
+2 1 D
+-2 1 D
+P
+2488 3292 M
+-5 -3 D
+1 2 D
+-3 -1 D
+-1 2 D
+P
+2484 3307 M
+2 -3 D
+-2 1 D
+-3 -2 D
+-1 2 D
+P
+2452 3179 M
+-1 -3 D
+-3 -1 D
+3 3 D
+-2 1 D
+P
+2544 3130 M
+2 -2 D
+-3 -3 D
+-1 4 D
+1 -3 D
+P
+2463 3236 M
+0 -7 D
+-4 3 D
+-3 -2 D
+1 4 D
+4 -2 D
+P
+2446 3299 M
+3 -4 D
+-8 0 D
+5 1 D
+-2 2 D
+P
+2402 3269 M
+2 -3 D
+-2 2 D
+0 -2 D
+-5 1 D
+P
+2386 3195 M
+-3 -2 D
+1 4 D
+1 -2 D
+4 0 D
+P
+2395 3252 M
+1 -1 D
+-4 -2 D
+-2 3 D
+P
+2457 3148 M
+6 -2 D
+-9 2 D
+P
+2455 3186 M
+-7 -7 D
+1 3 D
+-2 0 D
+P
+2439 3140 M
+1 -5 D
+5 -6 D
+-7 7 D
+P
+2547 3195 M
+-2 -3 D
+1 -5 D
+-2 6 D
+P
+2409 3179 M
+-5 -2 D
+1 2 D
+-3 0 D
+P
+2470 3291 M
+-2 -2 D
+2 4 D
+3 0 D
+P
+2432 3133 M
+-4 -5 D
+1 4 D
+1 -1 D
+P
+2386 3214 M
+1 -3 D
+-3 0 D
+P
+2587 3163 M
+-1 -3 D
+-2 3 D
+P
+2375 3124 M
+5 -3 D
+-3 0 D
+P
+2503 3250 M
+-3 -2 D
+0 3 D
+3 0 D
+P
+2401 3200 M
+0 -1 D
+-1 2 D
+P
+2414 3200 M
+0 -2 D
+-1 3 D
+P
+2572 3279 M
+-2 -2 D
+1 3 D
+P
+2490 3300 M
+-2 -3 D
+-2 2 D
+P
+2406 3307 M
+2 -2 D
+-4 1 D
+P
+2574 3287 M
+0 -4 D
+-2 0 D
+P
+2502 3289 M
+-1 -3 D
+-2 2 D
+P
+2408 3268 M
+-1 -3 D
+-1 1 D
+P
+2391 3180 M
+-2 -2 D
+P
+2450 3293 M
+-6 -3 D
+P
+2570 3212 M
+1 -4 D
+-2 4 D
+P
+2488 3295 M
+-4 -2 D
+P
+2409 3172 M
+-7 -4 D
+P
+2410 3192 M
+-4 1 D
+5 -1 D
+P
+2468 3235 M
+-3 -1 D
+P
+2497 3297 M
+-3 0 D
+P
+2455 3275 M
+-2 -3 D
+P
+2427 3139 M
+-2 -5 D
+P
+2413 3264 M
+-2 -2 D
+P
+2400 3207 M
+1 -3 D
+P
+2474 3289 M
+-1 -2 D
+1 3 D
+P
+2447 3140 M
+3 -3 D
+P
+2400 3213 M
+-4 1 D
+P
+2421 3256 M
+0 -2 D
+-1 2 D
+P
+2567 3210 M
+-2 -3 D
+P
+2505 3246 M
+-1 -2 D
+1 3 D
+P
+2436 3186 M
+-3 -2 D
+P
+2444 3139 M
+2 -3 D
+-2 4 D
+P
+2575 3184 M
+-1 -2 D
+P
+2450 3256 M
+-3 1 D
+P
+2479 3212 M
+-1 -3 D
+P
+2458 3252 M
+1 -2 D
+P
+2421 3205 M
+-1 0 D
+1 -1 D
+P
+2537 3245 M
+-2 0 D
+2 1 D
+P
+2485 3270 M
+-1 -1 D
+P
+2522 3226 M
+-1 -2 D
+P
+2434 3138 M
+2 -11 D
+P
+2517 3161 M
+-6 -9 D
+P
+{0.565 0.933 0.565 C} FS
+FO
+2598 3100 M
+-1 4 D
+-1 -2 D
+2 0 D
+-5 -1 D
+P
+FO
+2598 3159 M
+P
+FO
+2598 3160 M
+0 -1 D
+P
+FO
+2504 3087 M
+0 -3 D
+6 2 D
+-5 -2 D
+35 7 D
+-4 2 D
+10 5 D
+-10 -4 D
+-12 0 D
+-1 -2 D
+-7 1 D
+1 -2 D
+-4 1 D
+-1 -2 D
+-2 1 D
+0 -2 D
+-4 1 D
+P
+FO
+2581 3104 M
+-2 -1 D
+1 -1 D
+7 1 D
+-3 3 D
+P
+FO
+2567 3107 M
+-1 -2 D
+3 1 D
+1 4 D
+P
+FO
+2498 3083 M
+4 2 D
+0 1 D
+-2 0 D
+P
+FO
+2543 3094 M
+-3 -3 D
+15 5 D
+-13 -2 D
+P
+FO
+2566 3107 M
+-1 -2 D
+1 3 D
+P
+FO
+2514 3085 M
+8 1 D
+P
+FO
+2580 3237 M
+-8 -4 D
+3 0 D
+P
+FO
+2543 3097 M
+-1 -1 D
+3 -1 D
+P
+FO
+2590 3246 M
+-2 -1 D
+P
+FO
+2561 3099 M
+0 -1 D
+P
+FO
+2551 3101 M
+2 0 D
+P
+FO
+2513 3085 M
+-2 0 D
+P
+FO
+2533 3089 M
+7 2 D
+P
+FO
+2588 3240 M
+-3 -3 D
+P
+FO
+2582 3106 M
+-3 -1 D
+P
+FO
+2533 3089 M
+-13 -3 D
+P
+FO
+2588 3103 M
+0 1 D
+P
+FO
+2567 3108 M
+0 2 D
+P
+FO
+0 -1 -1 -1 2 2366 3187 SP
+-1 -3 1 2597 3298 SP
+-1 -2 1 2587 3297 SP
+2835 3164 M
+-3 0 D
+P
+FO
+2835 3218 M
+-3 1 D
+-2 -4 D
+-1 2 D
+-2 -1 D
+3 3 D
+-2 2 D
+-9 -7 D
+9 5 D
+-12 -7 D
+2 -2 D
+8 3 D
+-9 -5 D
+0 -3 D
+-2 0 D
+1 1 D
+-4 1 D
+-5 -1 D
+6 3 D
+-2 1 D
+2 -1 D
+-2 2 D
+5 1 D
+1 2 D
+-6 -1 D
+2 2 D
+7 0 D
+5 5 D
+-1 1 D
+-4 -4 D
+6 10 D
+1 6 D
+-5 1 D
+3 3 D
+-5 0 D
+-22 -23 D
+2 -8 D
+4 -4 D
+2 2 D
+1 -2 D
+7 2 D
+4 -2 D
+15 6 D
+-2 2 D
+4 0 D
+P
+2807 3216 M
+1 -2 D
+-3 2 D
+3 0 D
+P
+FO
+2623 3307 M
+2 -7 D
+-4 2 D
+1 3 D
+-4 -4 D
+-3 1 D
+0 2 D
+3 -2 D
+1 5 D
+-21 0 D
+0 -9 D
+7 -7 D
+-4 0 D
+-2 5 D
+-1 -43 D
+3 1 D
+4 8 D
+-6 4 D
+7 -3 D
+6 4 D
+5 6 D
+2 1 D
+2 4 D
+10 3 D
+-3 1 D
+2 0 D
+2 3 D
+5 2 D
+-2 -3 D
+6 2 D
+-3 2 D
+4 0 D
+1 2 D
+17 1 D
+6 11 D
+5 5 D
+P
+2638 3301 M
+0 -10 D
+-5 9 D
+3 -2 D
+-1 3 D
+P
+2615 3289 M
+1 -2 D
+P
+2609 3300 M
+-2 -3 D
+P
+FO
+2598 3162 M
+2 0 D
+-2 -2 D
+3 3 D
+1 -5 D
+2 1 D
+-2 6 D
+-2 -2 D
+3 4 D
+0 -4 D
+3 2 D
+-1 -3 D
+1 3 D
+2 -4 D
+1 5 D
+1 -5 D
+3 6 D
+2 -3 D
+3 3 D
+-3 -3 D
+2 0 D
+4 3 D
+-1 1 D
+3 5 D
+-1 3 D
+5 0 D
+-1 5 D
+2 -2 D
+-2 -6 D
+2 1 D
+5 -3 D
+-1 4 D
+2 1 D
+1 -2 D
+-1 3 D
+2 0 D
+0 -2 D
+1 2 D
+2 -1 D
+-1 2 D
+2 -2 D
+0 3 D
+4 -6 D
+3 2 D
+-2 2 D
+2 -2 D
+1 2 D
+0 -2 D
+0 3 D
+3 2 D
+1 -3 D
+2 2 D
+2 -1 D
+0 3 D
+4 -2 D
+0 3 D
+3 -2 D
+8 5 D
+-4 2 D
+-1 -2 D
+-1 3 D
+5 -1 D
+-5 7 D
+2 -3 D
+3 2 D
+3 -1 D
+-1 -2 D
+10 3 D
+0 -3 D
+9 5 D
+4 -1 D
+25 10 D
+2 -1 D
+5 6 D
+-3 3 D
+5 -4 D
+-2 -2 D
+5 4 D
+2 -3 D
+-2 0 D
+1 1 D
+-2 0 D
+-4 -5 D
+-8 -4 D
+-1 -2 D
+4 -1 D
+5 3 D
+28 -1 D
+-19 -5 D
+2 -4 D
+-5 3 D
+-1 -1 D
+0 5 D
+-4 1 D
+3 -1 D
+-32 -14 D
+0 -1 D
+5 2 D
+-4 -3 D
+-2 0 D
+0 2 D
+-8 -5 D
+-2 -3 D
+5 5 D
+4 0 D
+-7 -6 D
+-2 -5 D
+1 -7 D
+1 1 D
+0 -3 D
+1 1 D
+2 -2 D
+1 4 D
+4 -6 D
+0 2 D
+1 -5 D
+4 2 D
+2 -3 D
+1 4 D
+3 -2 D
+-1 5 D
+3 -2 D
+0 4 D
+2 -4 D
+1 2 D
+2 -1 D
+0 3 D
+1 -2 D
+0 3 D
+2 -2 D
+-1 2 D
+2 -1 D
+0 3 D
+4 1 D
+-1 2 D
+4 0 D
+-1 2 D
+2 -1 D
+3 4 D
+-1 2 D
+4 -3 D
+-2 3 D
+3 0 D
+-4 2 D
+2 3 D
+2 -1 D
+1 1 D
+2 -3 D
+2 1 D
+-1 3 D
+4 2 D
+-1 -5 D
+3 1 D
+-1 -1 D
+2 1 D
+2 -2 D
+3 1 D
+-3 6 D
+5 -4 D
+0 2 D
+4 -1 D
+1 3 D
+1 -2 D
+1 2 D
+0 -1 D
+1 2 D
+2 -3 D
+-1 3 D
+2 -2 D
+4 0 D
+-1 3 D
+5 -1 D
+1 1 D
+2 -1 D
+0 3 D
+2 -2 D
+4 3 D
+6 1 D
+-2 0 D
+4 0 D
+-1 2 D
+2 -1 D
+-2 1 D
+3 -1 D
+0 1 D
+5 0 D
+-4 4 D
+5 -3 D
+7 1 D
+-2 1 D
+1 1 D
+4 -1 D
+0 2 D
+1 -2 D
+4 3 D
+-13 1 D
+0 1 D
+1 -1 D
+6 2 D
+-7 5 D
+-3 -2 D
+-6 2 D
+-2 -1 D
+2 6 D
+-14 -6 D
+-15 4 D
+1 -1 D
+-5 -1 D
+-2 1 D
+3 1 D
+-6 0 D
+2 0 D
+-1 2 D
+-7 -1 D
+-3 3 D
+-5 1 D
+7 3 D
+-8 0 D
+-3 2 D
+-7 0 D
+0 3 D
+-4 -1 D
+3 1 D
+-2 4 D
+2 -2 D
+-3 6 D
+-3 -1 D
+-1 2 D
+2 0 D
+-4 2 D
+2 1 D
+2 5 D
+-10 -1 D
+1 1 D
+-5 0 D
+10 5 D
+-1 1 D
+2 2 D
+1 -2 D
+1 5 D
+-2 -2 D
+0 2 D
+4 3 D
+-2 1 D
+4 0 D
+-1 1 D
+-1 -1 D
+-2 1 D
+1 1 D
+-6 -1 D
+2 2 D
+-5 0 D
+-11 -6 D
+1 2 D
+-5 6 D
+-13 2 D
+0 2 D
+-10 -2 D
+8 3 D
+9 -1 D
+4 3 D
+11 -5 D
+5 0 D
+6 4 D
+5 1 D
+2 3 D
+9 2 D
+2 2 D
+-1 2 D
+2 1 D
+-9 6 D
+9 -3 D
+-1 2 D
+-9 6 D
+-17 3 D
+-20 -1 D
+-48 -13 D
+-15 -6 D
+-16 -10 D
+-3 -5 D
+-9 -7 D
+P
+2611 3216 M
+1 -1 D
+1 1 D
+2 -4 D
+3 -2 D
+-3 0 D
+0 -1 D
+-4 8 D
+P
+2651 3207 M
+4 -3 D
+3 1 D
+1 -2 D
+-7 1 D
+-3 2 D
+P
+2607 3209 M
+-2 -3 D
+4 0 D
+-1 -6 D
+-5 7 D
+2 3 D
+P
+2607 3204 M
+1 -1 D
+0 1 D
+P
+2715 3172 M
+-1 -2 D
+4 1 D
+-1 -2 D
+-4 -1 D
+-1 3 D
+P
+2695 3214 M
+-3 -4 D
+-3 -1 D
+4 5 D
+P
+2626 3204 M
+-4 2 D
+2 0 D
+0 1 D
+P
+2698 3162 M
+0 -1 D
+-1 1 D
+P
+2750 3188 M
+-1 -2 D
+P
+2701 3159 M
+0 -1 D
+P
+2764 3186 M
+1 -2 D
+P
+2712 3175 M
+-1 -2 D
+0 2 D
+P
+2738 3186 M
+-2 -4 D
+P
+2614 3220 M
+4 -2 D
+1 -2 D
+P
+2692 3166 M
+0 -2 D
+P
+FO
+2598 3159 M
+2 3 D
+P
+FO
+2598 3110 M
+1 0 D
+-1 5 D
+P
+FO
+2598 3100 M
+P
+FO
+2766 3213 M
+10 -1 D
+1 1 D
+-3 0 D
+2 0 D
+0 3 D
+-4 1 D
+4 0 D
+-3 1 D
+5 0 D
+-2 1 D
+2 0 D
+1 2 D
+9 2 D
+-16 1 D
+-2 -1 D
+4 -1 D
+-11 0 D
+1 -1 D
+-8 2 D
+0 1 D
+-6 0 D
+2 1 D
+-4 1 D
+-1 -3 D
+-3 0 D
+0 2 D
+-3 -1 D
+3 2 D
+-4 4 D
+-2 -1 D
+-1 2 D
+4 2 D
+-1 5 D
+-9 -8 D
+0 -3 D
+6 -1 D
+1 2 D
+-1 -6 D
+9 0 D
+-1 -2 D
+3 -2 D
+10 -2 D
+2 2 D
+-3 -1 D
+6 3 D
+-2 -2 D
+6 -2 D
+-4 -2 D
+3 0 D
+P
+FO
+2787 3243 M
+0 -2 D
+5 1 D
+0 1 D
+-4 0 D
+2 3 D
+8 5 D
+2 0 D
+-1 -2 D
+3 2 D
+-4 0 D
+-9 -5 D
+P
+FO
+2787 3285 M
+7 0 D
+-3 6 D
+-9 2 D
+-11 6 D
+-34 7 D
+-9 -2 D
+16 -5 D
+6 -6 D
+15 -5 D
+P
+FO
+2637 3171 M
+2 0 D
+-1 3 D
+1 -2 D
+3 1 D
+-2 3 D
+-4 -2 D
+P
+FO
+2727 3260 M
+-1 -3 D
+3 2 D
+P
+FO
+2627 3166 M
+0 2 D
+-3 0 D
+P
+FO
+2701 3153 M
+1 -2 D
+1 3 D
+P
+FO
+2670 3186 M
+1 -1 D
+0 3 D
+P
+FO
+2603 3162 M
+0 1 D
+P
+FO
+2728 3257 M
+-4 -1 D
+0 -3 D
+P
+FO
+2671 3180 M
+5 2 D
+-1 2 D
+P
+FO
+2811 3200 M
+3 3 D
+-6 -1 D
+P
+FO
+2669 3189 M
+1 -2 D
+1 3 D
+P
+FO
+2629 3169 M
+2 1 D
+-1 2 D
+P
+FO
+2685 3172 M
+3 3 D
+P
+FO
+2796 3249 M
+-5 -3 D
+P
+FO
+2624 3171 M
+1 4 D
+P
+FO
+2773 3208 M
+2 1 D
+P
+FO
+2611 3260 M
+2 1 D
+P
+FO
+2606 3162 M
+0 -2 D
+P
+FO
+2745 3227 M
+2 -1 D
+P
+FO
+2655 3176 M
+1 2 D
+P
+FO
+2706 3155 M
+1 -2 D
+P
+FO
+2684 3171 M
+1 1 D
+P
+FO
+2669 3186 M
+-1 1 D
+P
+FO
+2605 3256 M
+1 2 D
+P
+FO
+2806 3202 M
+2 0 D
+P
+FO
+2636 3174 M
+-1 -1 D
+P
+FO
+2709 3157 M
+1 -1 D
+P
+FO
+2628 3173 M
+1 -1 D
+P
+FO
+2740 3230 M
+3 -2 D
+P
+FO
+2606 3164 M
+0 -2 D
+P
+FO
+2769 3207 M
+2 0 D
+P
+FO
+2831 3242 M
+0 -1 D
+P
+FO
+2688 3260 M
+2 -1 D
+P
+FO
+2751 3180 M
+1 -1 D
+P
+FO
+2716 3240 M
+0 1 D
+P
+FO
+2718 3232 M
+2 -1 D
+P
+FO
+2739 3231 M
+1 -1 D
+P
+FO
+2718 3244 M
+0 -1 D
+P
+FO
+2631 3166 M
+0 2 D
+P
+FO
+2601 3162 M
+0 -2 D
+P
+FO
+2634 3174 M
+0 -1 D
+P
+FO
+2627 3178 M
+0 -1 D
+P
+FO
+2722 3256 M
+0 -1 D
+P
+FO
+2694 3160 M
+1 -1 D
+P
+FO
+2940 3307 M
+-6 -2 D
+-2 2 D
+-3 0 D
+-1 0 D
+-1 0 D
+-3 -2 D
+2 2 D
+-4 0 D
+-7 -4 D
+2 0 D
+-2 0 D
+-6 -7 D
+2 4 D
+-4 1 D
+4 2 D
+0 4 D
+-22 0 D
+-3 -2 D
+4 -2 D
+-4 1 D
+-3 -4 D
+1 -4 D
+2 1 D
+3 -3 D
+-4 2 D
+-1 -2 D
+-2 3 D
+-6 -4 D
+1 -4 D
+6 0 D
+-4 -2 D
+6 1 D
+-7 -2 D
+2 -3 D
+4 -1 D
+-4 1 D
+-2 2 D
+-5 0 D
+-1 2 D
+-7 -14 D
+-3 2 D
+-1 -2 D
+-2 2 D
+5 4 D
+-12 -8 D
+13 2 D
+10 -1 D
+-7 -2 D
+-19 -13 D
+3 -1 D
+-1 -5 D
+15 -1 D
+2 2 D
+-1 -1 D
+2 2 D
+3 -2 D
+2 4 D
+2 -1 D
+-3 -2 D
+7 0 D
+1 2 D
+1 -2 D
+3 1 D
+-1 -1 D
+4 0 D
+2 -2 D
+7 1 D
+2 3 D
+-2 -4 D
+4 1 D
+0 2 D
+1 -3 D
+7 -1 D
+0 2 D
+0 -2 D
+1 1 D
+0 -1 D
+2 1 D
+-1 2 D
+2 -2 D
+-1 2 D
+5 -1 D
+0 2 D
+0 -2 D
+4 0 D
+0 4 D
+1 -4 D
+3 0 D
+0 6 D
+1 -3 D
+3 1 D
+-3 -1 D
+2 -1 D
+5 2 D
+1 4 D
+0 -2 D
+2 0 D
+-3 -2 D
+2 0 D
+-4 -3 D
+1 -1 D
+6 1 D
+-13 -4 D
+1 -1 D
+9 3 D
+-4 -3 D
+3 0 D
+2 3 D
+-2 -3 D
+5 3 D
+-2 -4 D
+6 2 D
+0 3 D
+-1 0 D
+1 2 D
+1 -2 D
+6 1 D
+-1 -2 D
+2 1 D
+2 -1 D
+7 2 D
+-14 -6 D
+-5 -6 D
+-7 -1 D
+-5 -4 D
+6 -2 D
+5 2 D
+4 -2 D
+4 3 D
+0 2 D
+1 -2 D
+2 2 D
+-1 3 D
+2 -1 D
+5 6 D
+0 -1 D
+4 0 D
+6 6 D
+-5 -6 D
+4 1 D
+5 11 D
+3 -1 D
+0 1 D
+5 -6 D
+-1 -5 D
+3 1 D
+-3 -2 D
+1 -2 D
+-3 1 D
+2 -1 D
+-2 -1 D
+-4 -10 D
+3 -1 D
+12 10 D
+0 -2 D
+3 1 D
+-6 -4 D
+1 -1 D
+3 1 D
+-4 -4 D
+1 -4 D
+2 -1 D
+5 4 D
+-2 -2 D
+3 1 D
+3 -3 D
+5 4 D
+2 5 D
+-2 0 D
+2 2 D
+-2 0 D
+2 1 D
+6 10 D
+-4 6 D
+-3 -6 D
+-5 -4 D
+-1 3 D
+-1 -1 D
+1 3 D
+-3 -1 D
+3 2 D
+-3 -1 D
+5 8 D
+6 4 D
+-2 2 D
+-4 -3 D
+-5 -1 D
+-6 -12 D
+-2 2 D
+-1 -2 D
+0 4 D
+-2 -1 D
+-4 5 D
+3 -1 D
+5 6 D
+-9 -1 D
+7 1 D
+-6 1 D
+-1 3 D
+8 -1 D
+6 2 D
+0 3 D
+4 -1 D
+5 5 D
+-2 3 D
+-4 -4 D
+-5 3 D
+-4 -6 D
+1 3 D
+-4 -2 D
+3 3 D
+-5 -4 D
+0 2 D
+-7 -3 D
+-1 1 D
+11 4 D
+-6 0 D
+8 2 D
+-6 1 D
+1 2 D
+-3 -2 D
+1 1 D
+-3 -1 D
+5 4 D
+-9 -2 D
+10 4 D
+-2 1 D
+4 0 D
+-4 1 D
+7 0 D
+-2 3 D
+3 0 D
+1 3 D
+-13 5 D
+-3 -3 D
+-5 2 D
+-2 -4 D
+1 5 D
+-3 -1 D
+2 3 D
+-8 -7 D
+-1 3 D
+-1 -3 D
+-3 -1 D
+-2 3 D
+1 -2 D
+-6 -2 D
+1 -2 D
+2 0 D
+-5 -2 D
+6 12 D
+-1 -1 D
+-3 1 D
+2 -3 D
+-2 -2 D
+0 2 D
+-2 -2 D
+0 2 D
+-1 -1 D
+3 2 D
+-3 -1 D
+1 2 D
+-4 -3 D
+1 3 D
+-3 -3 D
+0 3 D
+-3 -1 D
+1 1 D
+-2 1 D
+-7 -2 D
+7 4 D
+-3 -1 D
+3 3 D
+-4 -1 D
+-4 -2 D
+3 3 D
+-2 0 D
+16 6 D
+P
+2907 3291 M
+1 -1 D
+-5 -2 D
+-14 -12 D
+-5 0 D
+11 6 D
+3 3 D
+1 3 D
+P
+2952 3280 M
+4 3 D
+12 -3 D
+-8 2 D
+P
+2905 3282 M
+-1 2 D
+3 -1 D
+P
+2930 3265 M
+-1 -2 D
+-2 1 D
+P
+2954 3263 M
+-1 2 D
+2 -1 D
+P
+2893 3266 M
+3 2 D
+4 0 D
+-8 -2 D
+P
+2958 3271 M
+2 1 D
+0 -1 D
+P
+2887 3301 M
+-1 1 D
+3 -2 D
+P
+2917 3279 M
+-16 -6 D
+9 5 D
+P
+2918 3267 M
+-7 -3 D
+6 5 D
+P
+2895 3263 M
+2 1 D
+P
+2939 3287 M
+0 -1 D
+0 2 D
+P
+2975 3288 M
+4 0 D
+P
+2915 3291 M
+2 1 D
+P
+2960 3279 M
+3 0 D
+P
+2967 3281 M
+3 1 D
+P
+2898 3293 M
+2 1 D
+P
+2968 3271 M
+3 1 D
+P
+2964 3277 M
+2 0 D
+P
+2972 3283 M
+2 1 D
+P
+2895 3287 M
+-5 -3 D
+P
+2969 3274 M
+5 1 D
+-5 -2 D
+P
+2930 3289 M
+2 2 D
+P
+2947 3261 M
+3 0 D
+P
+2932 3288 M
+3 2 D
+P
+2921 3269 M
+3 0 D
+-4 -1 D
+P
+2924 3267 M
+1 1 D
+P
+2947 3262 M
+3 1 D
+P
+2919 3270 M
+2 1 D
+-2 -2 D
+P
+2960 3269 M
+2 0 D
+-3 0 D
+P
+FO
+2835 3210 M
+5 1 D
+-2 1 D
+0 1 D
+-3 0 D
+4 4 D
+-4 1 D
+P
+FO
+2835 3164 M
+3 0 D
+3 2 D
+-6 -2 D
+P
+FO
+2955 3297 M
+2 -1 D
+-2 -1 D
+8 2 D
+1 2 D
+-6 -3 D
+-1 2 D
+P
+FO
+2923 3236 M
+-3 3 D
+1 -8 D
+2 2 D
+-2 3 D
+P
+FO
+2976 3299 M
+-2 2 D
+-3 -2 D
+-2 2 D
+0 -4 D
+P
+FO
+2972 3250 M
+-4 -4 D
+3 0 D
+2 6 D
+P
+FO
+2978 3264 M
+2 -2 D
+5 0 D
+1 2 D
+P
+FO
+2929 3251 M
+2 0 D
+-5 1 D
+P
+FO
+2935 3297 M
+4 1 D
+-3 0 D
+P
+FO
+2958 3298 M
+2 0 D
+0 1 D
+P
+FO
+2948 3290 M
+2 1 D
+-1 1 D
+P
+FO
+2957 3293 M
+2 0 D
+1 2 D
+P
+FO
+2974 3249 M
+0 4 D
+0 -6 D
+1 2 D
+P
+FO
+2931 3242 M
+1 1 D
+-2 0 D
+P
+FO
+3000 3250 M
+2 2 D
+P
+FO
+2929 3253 M
+4 1 D
+P
+FO
+2936 3295 M
+4 1 D
+P
+FO
+2966 3299 M
+1 -2 D
+P
+FO
+2924 3230 M
+1 2 D
+P
+FO
+2972 3246 M
+0 -1 D
+P
+FO
+2982 3279 M
+3 1 D
+P
+FO
+2931 3296 M
+3 1 D
+P
+FO
+2840 3213 M
+2 0 D
+P
+FO
+2982 3278 M
+2 1 D
+P
+FO
+2961 3296 M
+0 -1 D
+P
+FO
+2971 3251 M
+0 -2 D
+P
+FO
+2984 3236 M
+-1 -1 D
+P
+FO
+2950 3296 M
+2 0 D
+P
+FO
+2981 3274 M
+3 1 D
+P
+FO
+2981 3280 M
+3 1 D
+P
+FO
+2980 3283 M
+3 0 D
+P
+FO
+2982 3282 M
+2 0 D
+P
+FO
+2909 3301 M
+2 1 D
+-2 0 D
+P
+FO
+2953 3294 M
+-1 -1 D
+P
+FO
+2967 3247 M
+0 1 D
+P
+FO
+2957 3299 M
+1 0 D
+P
+FO
+2960 3243 M
+1 1 D
+P
+FO
+2968 3296 M
+2 1 D
+P
+FO
+2979 3280 M
+2 1 D
+P
+FO
+4252 3101 M
+-8 1 D
+8 -1 D
+0 190 D
+-6 -1 D
+-17 3 D
+-3 -2 D
+-5 5 D
+1 4 D
+-8 -1 D
+-8 2 D
+3 -9 D
+6 -3 D
+0 -12 D
+5 -2 D
+-10 -1 D
+-2 3 D
+-4 -2 D
+1 -2 D
+-1 2 D
+-4 -2 D
+-1 2 D
+-2 -1 D
+0 2 D
+-8 -4 D
+-8 7 D
+-3 -1 D
+1 3 D
+-3 -2 D
+0 1 D
+-4 -1 D
+-3 1 D
+-2 -4 D
+-5 1 D
+-1 -2 D
+-4 2 D
+-12 -2 D
+-1 -2 D
+-5 -1 D
+0 -4 D
+11 2 D
+-3 -2 D
+4 0 D
+-2 -1 D
+5 -1 D
+-9 1 D
+0 1 D
+-2 -1 D
+1 -3 D
+3 1 D
+4 -1 D
+-1 -2 D
+-10 -1 D
+7 -2 D
+2 -4 D
+4 0 D
+1 3 D
+2 -2 D
+3 2 D
+2 -3 D
+2 1 D
+6 -1 D
+1 -2 D
+4 2 D
+-1 -2 D
+1 -1 D
+-1 1 D
+3 -2 D
+2 3 D
+-2 -3 D
+2 -4 D
+2 4 D
+3 -2 D
+-1 3 D
+1 -2 D
+5 1 D
+-1 -2 D
+-4 0 D
+2 -1 D
+6 1 D
+-1 -1 D
+6 0 D
+-3 0 D
+1 -2 D
+-2 -1 D
+2 -2 D
+-2 0 D
+6 -1 D
+3 1 D
+-2 -4 D
+6 -2 D
+-4 -5 D
+8 -8 D
+14 -5 D
+3 1 D
+-3 -4 D
+2 0 D
+1 -4 D
+2 0 D
+-4 -3 D
+1 -1 D
+-2 0 D
+0 -3 D
+10 -5 D
+4 -9 D
+3 -2 D
+-3 1 D
+-4 7 D
+-7 5 D
+-4 -22 D
+2 4 D
+4 -3 D
+-4 0 D
+-2 -3 D
+-4 -21 D
+-4 -5 D
+-12 -4 D
+-13 4 D
+-1 -2 D
+-1 3 D
+-5 -1 D
+-1 -3 D
+-11 3 D
+0 -1 D
+-1 1 D
+2 1 D
+-4 1 D
+-5 -3 D
+0 2 D
+-16 -2 D
+-22 3 D
+0 1 D
+-7 0 D
+-3 2 D
+-6 -3 D
+-4 2 D
+-16 -1 D
+-3 -2 D
+1 2 D
+-5 0 D
+-5 4 D
+-4 -2 D
+-2 3 D
+-4 -2 D
+-1 2 D
+-10 -5 D
+0 -2 D
+4 1 D
+-4 -2 D
+4 0 D
+-1 -3 D
+-2 2 D
+-2 -2 D
+-2 2 D
+-6 -3 D
+-3 2 D
+-3 -2 D
+1 -1 D
+-6 -1 D
+0 -2 D
+-3 -1 D
+1 -4 D
+2 2 D
+2 -5 D
+6 2 D
+-4 -3 D
+-1 -5 D
+5 4 D
+3 0 D
+-2 -5 D
+-3 0 D
+2 -2 D
+5 1 D
+-6 -4 D
+7 2 D
+-7 -5 D
+2 -17 D
+2 -5 D
+2 -1 D
+-3 -12 D
+2 1 D
+-5 -12 D
+2 -1 D
+-1 0 D
+-2 -3 D
+211 0 D
+P
+4192 3081 M
+2 0 D
+-5 0 D
+0 -2 D
+-3 1 D
+P
+4106 3108 M
+9 -2 D
+-3 -1 D
+P
+4224 3176 M
+0 2 D
+2 -1 D
+P
+4113 3140 M
+1 -2 D
+-2 2 D
+P
+4120 3086 M
+2 -1 D
+-2 -2 D
+P
+4223 3173 M
+3 1 D
+P
+4140 3140 M
+2 0 D
+-3 -1 D
+P
+4081 3129 M
+3 -1 D
+-3 -1 D
+P
+4234 3128 M
+2 -1 D
+P
+4098 3133 M
+-1 -1 D
+P
+4235 3124 M
+0 -1 D
+P
+4169 3138 M
+1 -1 D
+P
+4099 3083 M
+-1 -1 D
+P
+4111 3108 M
+-3 3 D
+4 -2 D
+P
+4225 3191 M
+1 3 D
+P
+4160 3143 M
+-4 -1 D
+P
+4191 3087 M
+-4 -4 D
+1 2 D
+P
+4071 3137 M
+-1 -5 D
+P
+4091 3151 M
+-1 -7 D
+P
+4108 3079 M
+-1 -3 D
+P
+4161 3103 M
+1 -2 D
+P
+4071 3128 M
+6 0 D
+P
+4225 3133 M
+4 0 D
+P
+4237 3122 M
+0 -1 D
+-1 1 D
+P
+4063 3151 M
+3 1 D
+P
+4096 3120 M
+2 -1 D
+P
+4070 3132 M
+0 -2 D
+P
+4046 3140 M
+-2 -1 D
+P
+4225 3188 M
+1 1 D
+P
+4188 3115 M
+-2 0 D
+P
+4192 3141 M
+0 -2 D
+P
+4062 3117 M
+-2 -1 D
+P
+4150 3138 M
+1 0 D
+P
+FO
+4127 3307 M
+2 -1 D
+2 1 D
+P
+FO
+4199 3289 M
+0 -1 D
+5 -1 D
+0 2 D
+P
+FO
+4219 3213 M
+4 -5 D
+0 4 D
+-4 2 D
+P
+FO
+4189 3294 M
+3 -1 D
+1 2 D
+P
+FO
+4200 3236 M
+-3 1 D
+4 -3 D
+P
+FO
+4175 3245 M
+1 -2 D
+4 1 D
+P
+FO
+4042 3132 M
+1 -1 D
+P
+FO
+4195 3230 M
+3 -1 D
+P
+FO
+4169 3252 M
+2 -1 D
+P
+FO
+4199 3300 M
+2 1 D
+P
+FO
+4215 3218 M
+7 -2 D
+P
+FO
+4131 3270 M
+2 1 D
+P
+FO
+4488 3006 M
+-3 0 D
+-1 -1 D
+3 0 D
+-3 -2 D
+-1 2 D
+2 1 D
+0 2 D
+-3 0 D
+-12 -2 D
+-10 -7 D
+-9 -1 D
+-5 1 D
+-7 -3 D
+-4 1 D
+1 2 D
+-4 0 D
+-6 3 D
+-5 0 D
+2 -3 D
+-7 -2 D
+-12 5 D
+-4 -1 D
+-1 -3 D
+-13 -2 D
+-8 -4 D
+-5 1 D
+0 2 D
+-8 2 D
+-21 1 D
+-10 -3 D
+-6 1 D
+-2 -2 D
+-6 1 D
+-8 -5 D
+-5 2 D
+-29 -4 D
+-18 -7 D
+-8 -8 D
+0 -138 D
+236 0 D
+P
+4482 3004 M
+-1 -1 D
+-3 1 D
+P
+4451 2996 M
+-2 1 D
+2 0 D
+P
+4458 2984 M
+-3 -2 D
+P
+FO
+4451 3071 M
+-1 -2 D
+1 -2 D
+2 2 D
+1 -2 D
+-1 -3 D
+1 0 D
+-3 1 D
+1 -4 D
+-2 -3 D
+1 -4 D
+-1 -2 D
+2 -3 D
+-3 0 D
+2 -3 D
+2 3 D
+3 -5 D
+2 2 D
+3 -2 D
+4 3 D
+2 5 D
+-2 2 D
+12 -5 D
+3 5 D
+2 17 D
+P
+4453 3070 M
+-1 -1 D
+P
+4471 3062 M
+-2 0 D
+P
+FO
+4342 3071 M
+0 -2 D
+4 0 D
+6 -3 D
+2 1 D
+-1 1 D
+1 0 D
+-2 3 D
+P
+FO
+4252 3070 M
+1 1 D
+-1 0 D
+P
+FO
+4252 3038 M
+6 3 D
+-6 3 D
+P
+FO
+4323 3055 M
+1 -1 D
+4 2 D
+6 8 D
+-3 2 D
+-2 -1 D
+-3 1 D
+2 2 D
+-3 1 D
+3 1 D
+-10 -3 D
+-11 -6 D
+5 -3 D
+3 3 D
+3 -5 D
+P
+FO
+4289 3047 M
+-1 3 D
+-4 -1 D
+-3 -3 D
+0 -2 D
+4 -1 D
+P
+FO
+4285 3040 M
+0 -1 D
+4 0 D
+-3 3 D
+P
+FO
+4446 3051 M
+2 -1 D
+0 2 D
+P
+FO
+4321 3051 M
+1 0 D
+P
+FO
+4462 3012 M
+2 0 D
+P
+FO
+4724 2853 M
+-8 -8 D
+-8 -4 D
+-7 0 D
+-27 16 D
+-26 6 D
+-15 1 D
+-9 4 D
+-6 6 D
+-3 12 D
+-4 5 D
+-17 3 D
+-6 4 D
+-20 5 D
+-15 -2 D
+-11 1 D
+-22 10 D
+2 -2 D
+-6 0 D
+-2 3 D
+5 -1 D
+-5 2 D
+-1 6 D
+-3 0 D
+0 -2 D
+-4 -1 D
+-2 1 D
+1 4 D
+-5 -2 D
+-7 4 D
+-4 5 D
+0 5 D
+4 4 D
+12 6 D
+11 14 D
+-3 3 D
+0 7 D
+-5 1 D
+0 2 D
+-4 1 D
+-5 8 D
+2 5 D
+6 2 D
+8 9 D
+-2 6 D
+-10 -5 D
+-5 -4 D
+-3 1 D
+2 3 D
+-5 4 D
+2 2 D
+-3 0 D
+4 1 D
+-7 2 D
+0 -171 D
+236 0 D
+P
+FO
+4724 2883 M
+-1 -7 D
+1 -4 D
+P
+FO
+4724 3058 M
+-1 0 D
+0 4 D
+-2 1 D
+2 3 D
+-6 0 D
+0 -3 D
+7 -6 D
+P
+FO
+4724 3066 M
+0 -3 D
+P
+FO
+4722 3071 M
+2 -3 D
+0 3 D
+P
+FO
+4677 3071 M
+1 -2 D
+7 -3 D
+3 5 D
+P
+FO
+4623 3071 M
+12 -27 D
+-2 -3 D
+-7 -2 D
+2 -4 D
+-3 -4 D
+-4 -2 D
+0 -5 D
+3 -2 D
+7 0 D
+3 5 D
+9 7 D
+1 9 D
+7 3 D
+5 -1 D
+2 3 D
+-2 2 D
+1 7 D
+-9 5 D
+-5 0 D
+-2 3 D
+4 6 D
+P
+4643 3053 M
+-2 -1 D
+P
+4646 3052 M
+-2 0 D
+P
+FO
+4615 3071 M
+2 0 D
+P
+FO
+4606 2993 M
+3 -1 D
+0 4 D
+5 4 D
+-3 4 D
+1 2 D
+-3 1 D
+-1 4 D
+14 19 D
+-3 1 D
+-6 -3 D
+-1 2 D
+-3 -3 D
+-5 1 D
+-14 -4 D
+-7 1 D
+-7 -2 D
+-4 3 D
+-4 0 D
+-2 3 D
+-4 -1 D
+-1 -2 D
+-4 -2 D
+-4 4 D
+-1 -2 D
+-5 -2 D
+-2 -5 D
+6 -6 D
+6 1 D
+6 -2 D
+14 -8 D
+12 -3 D
+5 -6 D
+P
+FO
+4512 2925 M
+-6 2 D
+0 -4 D
+2 0 D
+1 -3 D
+4 4 D
+P
+FO
+4515 2945 M
+4 1 D
+-1 3 D
+P
+FO
+4590 2976 M
+2 -3 D
+4 -1 D
+-2 3 D
+P
+FO
+4535 2996 M
+-1 -1 D
+2 -1 D
+P
+FO
+4601 3037 M
+2 -1 D
+P
+FO
+4606 3032 M
+-1 2 D
+P
+FO
+4542 3022 M
+2 0 D
+P
+FO
+4536 3023 M
+2 -1 D
+P
+FO
+4548 2965 M
+2 0 D
+P
+FO
+4611 3042 M
+1 1 D
+P
+FO
+4595 3037 M
+2 0 D
+P
+FO
+4587 2978 M
+4 -1 D
+P
+FO
+4512 2944 M
+3 1 D
+P
+FO
+4604 3035 M
+2 0 D
+P
+FO
+4961 2865 M
+-12 -8 D
+-10 -3 D
+-15 6 D
+-12 1 D
+-2 3 D
+-4 -2 D
+-6 1 D
+-2 4 D
+-34 6 D
+-12 -3 D
+-5 1 D
+-5 10 D
+-21 1 D
+-9 4 D
+-9 1 D
+0 -1 D
+-6 3 D
+2 4 D
+-1 4 D
+-23 7 D
+-5 -1 D
+-5 1 D
+-7 -3 D
+-8 -1 D
+-10 -4 D
+-16 -13 D
+0 -11 D
+5 -10 D
+-5 -9 D
+0 -18 D
+237 0 D
+P
+4959 2863 M
+0 -2 D
+-2 -1 D
+P
+FO
+4870 3071 M
+-2 -13 D
+21 3 D
+-8 -7 D
+6 -5 D
+-2 -3 D
+6 0 D
+0 -2 D
+-4 -1 D
+0 -2 D
+-3 0 D
+-1 -2 D
+6 -5 D
+5 0 D
+-9 -2 D
+-2 2 D
+-1 -3 D
+-2 3 D
+1 2 D
+-5 4 D
+-1 -6 D
+3 0 D
+-3 -3 D
+-2 1 D
+-1 -2 D
+3 0 D
+5 -4 D
+1 2 D
+3 1 D
+3 -5 D
+2 1 D
+7 -2 D
+0 -6 D
+-6 -1 D
+5 -2 D
+-1 -6 D
+4 0 D
+2 2 D
+1 -4 D
+4 0 D
+-4 -4 D
+-3 2 D
+-2 -1 D
+0 -4 D
+4 2 D
+3 -2 D
+18 2 D
+-4 -3 D
+-3 0 D
+0 -2 D
+-9 0 D
+-7 -3 D
+8 -1 D
+1 2 D
+9 1 D
+0 -1 D
+-3 -1 D
+3 -1 D
+-4 -1 D
+2 -1 D
+7 4 D
+-1 2 D
+3 -1 D
+1 2 D
+0 -1 D
+4 0 D
+0 -3 D
+4 0 D
+1 -3 D
+2 4 D
+4 -2 D
+-2 -3 D
+3 0 D
+-1 -3 D
+14 -7 D
+8 3 D
+0 89 D
+P
+4957 3031 M
+2 -1 D
+-2 -2 D
+P
+4900 3013 M
+2 -2 D
+-3 0 D
+P
+4960 3021 M
+-3 -2 D
+-4 0 D
+P
+4953 3014 M
+0 -2 D
+P
+4915 3038 M
+-3 0 D
+P
+4960 3014 M
+-1 -1 D
+0 1 D
+P
+4926 3013 M
+0 -1 D
+P
+4930 2999 M
+-2 -2 D
+P
+4924 3041 M
+-3 -3 D
+P
+FO
+4846 3071 M
+-3 0 D
+1 -4 D
+4 -1 D
+-1 1 D
+2 2 D
+-1 -2 D
+3 -1 D
+2 5 D
+-4 -2 D
+-1 2 D
+P
+FO
+4816 3071 M
+2 -2 D
+0 2 D
+P
+FO
+4804 3071 M
+9 -2 D
+-3 2 D
+P
+FO
+4724 3068 M
+1 0 D
+-1 -5 D
+5 -1 D
+-1 -2 D
+3 -1 D
+0 -4 D
+5 -1 D
+6 -8 D
+2 0 D
+-1 3 D
+3 -2 D
+5 1 D
+1 -4 D
+-9 2 D
+-1 -3 D
+1 -2 D
+2 1 D
+4 -6 D
+1 0 D
+2 -3 D
+-2 -1 D
+4 -1 D
+2 3 D
+4 -3 D
+10 2 D
+11 -2 D
+0 3 D
+4 -4 D
+2 3 D
+3 -4 D
+11 -2 D
+-2 -2 D
+-7 -1 D
+3 -1 D
+-2 -1 D
+-22 9 D
+-5 0 D
+-4 -4 D
+-5 2 D
+-1 -5 D
+-5 -2 D
+0 -2 D
+4 -2 D
+0 -3 D
+4 0 D
+5 -8 D
+-3 -3 D
+4 -5 D
+0 -3 D
+4 -3 D
+2 2 D
+-1 5 D
+5 1 D
+0 -3 D
+6 -5 D
+-1 -4 D
+3 -3 D
+0 5 D
+4 4 D
+3 0 D
+5 -6 D
+5 -2 D
+-4 4 D
+2 4 D
+-9 18 D
+9 -2 D
+-1 -3 D
+2 -1 D
+3 3 D
+5 0 D
+-2 2 D
+0 3 D
+-3 -1 D
+1 -1 D
+-4 2 D
+1 4 D
+-5 2 D
+13 4 D
+12 -10 D
+1 4 D
+-3 7 D
+3 1 D
+-3 3 D
+-7 2 D
+-3 4 D
+-5 -1 D
+0 4 D
+-3 1 D
+-2 -2 D
+-2 4 D
+-12 2 D
+7 1 D
+6 3 D
+-3 -1 D
+1 3 D
+-4 2 D
+3 4 D
+6 -4 D
+-3 -3 D
+7 3 D
+-18 19 D
+-62 0 D
+P
+4759 3038 M
+3 0 D
+2 -2 D
+-5 0 D
+P
+4801 3034 M
+2 -1 D
+-2 0 D
+P
+4758 3048 M
+5 -4 D
+-3 1 D
+P
+4745 3063 M
+1 -1 D
+-1 2 D
+P
+4725 3066 M
+0 -1 D
+P
+4765 3055 M
+2 -2 D
+P
+FO
+4724 3057 M
+3 -1 D
+-1 2 D
+-2 0 D
+P
+FO
+4837 2953 M
+0 -2 D
+29 3 D
+3 -1 D
+4 2 D
+1 5 D
+-4 -3 D
+-3 1 D
+-5 -3 D
+-3 2 D
+2 4 D
+-8 -1 D
+-9 1 D
+-2 2 D
+-16 -2 D
+-1 3 D
+-5 0 D
+3 1 D
+0 2 D
+-4 -2 D
+-5 0 D
+-1 4 D
+-1 -4 D
+-1 0 D
+-2 3 D
+-2 -8 D
+2 -2 D
+19 -1 D
+8 -2 D
+P
+FO
+4828 3024 M
+4 -1 D
+1 4 D
+-8 2 D
+-2 10 D
+-14 3 D
+-6 6 D
+-11 -4 D
+-1 -1 D
+5 1 D
+7 -2 D
+7 -6 D
+1 -3 D
+9 0 D
+4 -7 D
+P
+FO
+4873 3047 M
+6 0 D
+-2 3 D
+2 -2 D
+2 0 D
+-6 8 D
+-12 -3 D
+-1 -2 D
+6 -2 D
+2 3 D
+3 0 D
+-5 -3 D
+P
+FO
+4732 3028 M
+3 -1 D
+0 3 D
+2 -4 D
+6 -1 D
+1 1 D
+-5 4 D
+-1 5 D
+-1 -3 D
+-3 0 D
+P
+FO
+4911 2976 M
+4 2 D
+4 9 D
+-8 -3 D
+-5 -4 D
+2 -1 D
+-1 -6 D
+P
+FO
+4866 3027 M
+4 4 D
+0 6 D
+-4 1 D
+-4 -1 D
+4 -4 D
+-3 -4 D
+P
+FO
+4737 3037 M
+1 2 D
+2 -2 D
+1 7 D
+P
+FO
+4843 3018 M
+-2 3 D
+-2 1 D
+-1 2 D
+-3 -1 D
+6 -7 D
+P
+FO
+4739 3035 M
+2 -4 D
+2 0 D
+-1 2 D
+-2 -1 D
+0 3 D
+P
+FO
+4890 2994 M
+8 3 D
+-2 1 D
+-8 -4 D
+1 -2 D
+P
+FO
+4826 2992 M
+5 0 D
+1 2 D
+-3 1 D
+0 -2 D
+-2 1 D
+P
+FO
+4890 3017 M
+1 1 D
+-6 1 D
+-5 -2 D
+5 -2 D
+P
+FO
+4890 2999 M
+1 1 D
+-4 2 D
+2 -2 D
+-1 -1 D
+P
+FO
+4856 3000 M
+1 2 D
+-2 3 D
+-5 -3 D
+3 -4 D
+P
+FO
+4739 3020 M
+5 -5 D
+1 2 D
+3 0 D
+-7 5 D
+P
+FO
+4891 2967 M
+2 -5 D
+3 2 D
+-3 3 D
+2 5 D
+P
+FO
+4829 3044 M
+3 0 D
+0 -2 D
+3 0 D
+-5 5 D
+P
+FO
+4872 2990 M
+2 -2 D
+3 2 D
+-2 2 D
+1 -2 D
+P
+FO
+4795 2980 M
+3 2 D
+-4 4 D
+-1 -4 D
+P
+FO
+4844 3000 M
+0 1 D
+-1 -1 D
+1 -1 D
+P
+FO
+4866 2997 M
+2 1 D
+-8 -3 D
+P
+FO
+4848 3000 M
+1 4 D
+-4 -3 D
+0 -1 D
+P
+FO
+4825 3014 M
+1 -2 D
+2 4 D
+P
+FO
+4807 3024 M
+-2 -2 D
+1 -1 D
+3 1 D
+P
+FO
+4843 3015 M
+5 -2 D
+0 2 D
+-6 0 D
+P
+FO
+4866 3012 M
+9 4 D
+-7 -1 D
+P
+FO
+4848 2993 M
+4 -1 D
+-2 3 D
+P
+FO
+4809 3052 M
+2 -3 D
+2 0 D
+P
+FO
+4850 3010 M
+3 1 D
+-2 1 D
+P
+FO
+4839 3009 M
+3 0 D
+-1 3 D
+P
+FO
+4805 3018 M
+2 -2 D
+2 2 D
+P
+FO
+4834 3000 M
+2 -2 D
+1 1 D
+P
+FO
+4851 2985 M
+3 0 D
+-2 3 D
+P
+FO
+4829 3003 M
+2 0 D
+0 2 D
+P
+FO
+4897 2986 M
+3 0 D
+-2 2 D
+P
+FO
+4908 2991 M
+2 -2 D
+0 2 D
+P
+FO
+4884 3004 M
+3 -2 D
+-1 2 D
+P
+FO
+4855 3038 M
+2 -2 D
+0 2 D
+P
+FO
+4879 3007 M
+1 -1 D
+0 3 D
+P
+FO
+4877 3014 M
+1 -2 D
+0 4 D
+P
+FO
+4883 3035 M
+1 -1 D
+-1 3 D
+P
+FO
+4742 3039 M
+2 -2 D
+-1 2 D
+P
+FO
+4894 2973 M
+1 -1 D
+0 2 D
+P
+FO
+4804 3051 M
+3 0 D
+P
+FO
+4844 2991 M
+3 2 D
+P
+FO
+4843 3059 M
+0 2 D
+-1 -2 D
+P
+FO
+4890 3011 M
+-2 0 D
+P
+FO
+4861 3003 M
+1 -1 D
+P
+FO
+4847 2963 M
+1 0 D
+P
+FO
+4822 3056 M
+1 1 D
+P
+FO
+4875 3014 M
+2 0 D
+-1 0 D
+P
+FO
+4950 2979 M
+1 1 D
+P
+FO
+4764 2994 M
+1 1 D
+P
+FO
+4883 3009 M
+1 0 D
+-1 1 D
+P
+FO
+4746 3036 M
+1 2 D
+P
+FO
+4957 2980 M
+2 1 D
+P
+FO
+4821 3049 M
+1 1 D
+P
+FO
+4816 3012 M
+2 -1 D
+P
+FO
+4893 3014 M
+1 -1 D
+P
+FO
+4830 3009 M
+-1 2 D
+-2 -4 D
+P
+FO
+4815 3051 M
+3 3 D
+P
+FO
+4804 3007 M
+5 2 D
+P
+FO
+4893 2990 M
+2 0 D
+P
+FO
+4860 2985 M
+3 0 D
+P
+FO
+4866 3067 M
+2 -1 D
+P
+FO
+4820 2949 M
+2 -1 D
+P
+FO
+4839 2992 M
+3 -1 D
+P
+FO
+4902 2982 M
+3 0 D
+P
+FO
+4727 3053 M
+2 -2 D
+P
+FO
+4820 3055 M
+1 1 D
+P
+FO
+4805 3012 M
+3 0 D
+P
+FO
+4797 3007 M
+2 -1 D
+P
+FO
+4802 2974 M
+1 -2 D
+P
+FO
+4821 3015 M
+1 3 D
+P
+FO
+4852 2996 M
+2 1 D
+P
+FO
+4833 2995 M
+2 -1 D
+P
+FO
+4794 2987 M
+1 1 D
+-1 0 D
+P
+FO
+4834 3014 M
+2 1 D
+P
+FO
+4826 3024 M
+-2 -1 D
+P
+FO
+4883 3007 M
+2 0 D
+-2 1 D
+P
+FO
+4857 2997 M
+2 0 D
+P
+FO
+4892 2999 M
+2 -1 D
+P
+FO
+4817 3052 M
+1 1 D
+P
+FO
+4847 3010 M
+2 -1 D
+P
+FO
+4870 3036 M
+3 0 D
+P
+FO
+4802 3008 M
+2 0 D
+P
+FO
+5021 2835 M
+0 4 D
+-6 4 D
+1 4 D
+-2 1 D
+2 3 D
+-1 14 D
+-2 0 D
+2 -1 D
+-1 -3 D
+-2 0 D
+-2 -2 D
+-2 2 D
+1 2 D
+-3 0 D
+0 1 D
+-4 1 D
+3 6 D
+-8 -2 D
+-13 3 D
+3 -2 D
+-2 0 D
+-6 -1 D
+-1 -2 D
+-4 1 D
+10 4 D
+-12 -3 D
+-3 1 D
+1 -1 D
+-1 1 D
+-2 -5 D
+-5 1 D
+-1 -31 D
+P
+5015 2856 M
+-2 -1 D
+0 2 D
+P
+5015 2856 M
+-1 -1 D
+P
+5015 2854 M
+-1 -1 D
+P
+5016 2852 M
+-2 0 D
+P
+FO
+5197 3025 M
+-1 -2 D
+-4 4 D
+5 -2 D
+0 46 D
+-236 0 D
+0 -89 D
+4 2 D
+5 -1 D
+0 -2 D
+3 3 D
+-1 2 D
+4 11 D
+12 -1 D
+21 -7 D
+8 -9 D
+10 -3 D
+8 2 D
+10 0 D
+2 2 D
+1 -1 D
+4 4 D
+2 -2 D
+3 2 D
+0 2 D
+13 9 D
+5 0 D
+12 -6 D
+7 1 D
+2 3 D
+-2 1 D
+3 0 D
+5 4 D
+4 -2 D
+1 -6 D
+-10 -6 D
+5 -7 D
+-4 -4 D
+1 -3 D
+-3 -3 D
+4 -4 D
+1 -6 D
+-2 -6 D
+3 -9 D
+-8 -6 D
+0 -7 D
+-4 -2 D
+-10 -25 D
+-2 -1 D
+-6 -20 D
+-11 -15 D
+-9 -4 D
+-10 0 D
+-3 -1 D
+1 -1 D
+-5 -1 D
+-1 4 D
+-4 -2 D
+3 0 D
+-1 -2 D
+-2 2 D
+-6 -2 D
+6 3 D
+-9 -2 D
+-4 4 D
+-2 -4 D
+1 -9 D
+-1 -3 D
+3 -7 D
+3 -2 D
+0 -4 D
+176 0 D
+P
+5044 3035 M
+-9 6 D
+1 4 D
+3 1 D
+0 5 D
+4 -4 D
+-2 -3 D
+4 -3 D
+0 4 D
+4 -6 D
+-3 -1 D
+P
+4982 3030 M
+-1 -3 D
+2 0 D
+0 -4 D
+-2 -3 D
+-2 2 D
+1 4 D
+-2 1 D
+1 3 D
+P
+5092 2876 M
+0 -10 D
+-4 -2 D
+3 -3 D
+-2 0 D
+-2 3 D
+1 9 D
+2 3 D
+P
+5085 3004 M
+3 -2 D
+-2 0 D
+1 -1 D
+-5 1 D
+4 1 D
+P
+4994 3023 M
+7 -7 D
+-5 -2 D
+-5 8 D
+P
+4997 3038 M
+-1 -4 D
+-3 0 D
+-2 3 D
+P
+5052 3048 M
+-8 3 D
+0 3 D
+P
+4970 3020 M
+-8 -4 D
+2 2 D
+P
+5093 2903 M
+-1 -4 D
+-1 3 D
+P
+4990 3039 M
+-4 0 D
+4 1 D
+P
+5110 2986 M
+2 -2 D
+-4 0 D
+1 2 D
+P
+5139 2978 M
+-1 -1 D
+-1 1 D
+P
+4981 3034 M
+-2 -1 D
+2 2 D
+P
+5038 3016 M
+2 0 D
+-3 0 D
+1 1 D
+P
+5119 2916 M
+-3 0 D
+0 3 D
+P
+5008 3045 M
+-4 2 D
+P
+5115 2944 M
+2 1 D
+P
+4982 3016 M
+0 -2 D
+-1 2 D
+P
+5098 3047 M
+1 1 D
+P
+5116 2919 M
+-1 1 D
+P
+5030 3037 M
+-1 -2 D
+P
+5180 3034 M
+5 2 D
+P
+5032 3039 M
+3 -2 D
+P
+5083 2992 M
+4 -2 D
+-4 3 D
+P
+5017 2862 M
+0 1 D
+3 -2 D
+P
+FO
+5031 2943 M
+2 2 D
+13 3 D
+2 4 D
+9 0 D
+-4 7 D
+16 10 D
+-22 -8 D
+-17 1 D
+-2 -6 D
+-5 1 D
+-6 -3 D
+-2 1 D
+2 -8 D
+7 -3 D
+4 1 D
+P
+FO
+5031 2862 M
+6 2 D
+-3 0 D
+-4 -2 D
+P
+FO
+5013 2863 M
+2 0 D
+P
+FO
+5006 2868 M
+1 -1 D
+P
+FO
+5011 2863 M
+2 0 D
+-2 1 D
+P
+FO
+5009 2867 M
+1 -1 D
+P
+FO
+5008 2867 M
+-2 1 D
+P
+FO
+5010 2862 M
+3 0 D
+P
+FO
+5005 2871 M
+2 -2 D
+P
+FO
+5005 2868 M
+2 -1 D
+P
+FO
+5385 2835 M
+11 0 D
+-4 7 D
+-2 0 D
+-2 3 D
+-5 1 D
+-3 3 D
+3 -3 D
+5 -1 D
+3 -3 D
+5 -2 D
+0 -5 D
+5 0 D
+0 1 D
+6 -1 D
+1 4 D
+-4 3 D
+7 3 D
+-4 2 D
+4 0 D
+0 -2 D
+2 2 D
+3 -2 D
+-1 -2 D
+-7 1 D
+6 -4 D
+1 1 D
+0 -3 D
+6 0 D
+2 -3 D
+9 5 D
+1 -1 D
+0 171 D
+-19 4 D
+-6 7 D
+-3 23 D
+3 2 D
+1 5 D
+4 -1 D
+-2 -3 D
+2 0 D
+2 8 D
+4 -1 D
+0 2 D
+-3 3 D
+3 5 D
+1 7 D
+-223 0 D
+0 -236 D
+P
+5292 2931 M
+10 -3 D
+-3 -11 D
+6 -10 D
+4 -1 D
+0 -1 D
+7 -2 D
+1 -2 D
+4 -1 D
+0 -2 D
+4 -3 D
+3 1 D
+0 -1 D
+6 -1 D
+7 3 D
+13 -3 D
+2 -4 D
+-1 -5 D
+4 -1 D
+0 -2 D
+-4 3 D
+1 5 D
+-2 3 D
+-10 2 D
+-3 2 D
+-6 -3 D
+-1 -2 D
+-1 2 D
+-8 1 D
+-4 3 D
+0 2 D
+-4 0 D
+-1 3 D
+-2 -1 D
+-9 5 D
+-7 10 D
+4 11 D
+P
+5324 3029 M
+3 -2 D
+-2 -8 D
+2 -2 D
+6 0 D
+0 -2 D
+-3 0 D
+7 -6 D
+-5 -2 D
+-1 0 D
+-2 -4 D
+-3 0 D
+-4 3 D
+-1 12 D
+-5 2 D
+0 3 D
+4 3 D
+-5 1 D
+2 3 D
+P
+5329 3011 M
+2 1 D
+P
+5327 3010 M
+1 -2 D
+0 2 D
+P
+5251 3035 M
+5 3 D
+0 3 D
+13 1 D
+4 3 D
+-3 -1 D
+-1 2 D
+8 1 D
+6 -1 D
+-8 -3 D
+-5 -5 D
+5 -2 D
+0 -2 D
+-4 -3 D
+-5 1 D
+-1 4 D
+-5 -2 D
+-2 2 D
+P
+5280 2908 M
+5 -8 D
+4 -2 D
+-3 -4 D
+-6 2 D
+-3 6 D
+2 1 D
+P
+5271 2937 M
+1 -3 D
+8 -7 D
+-2 -5 D
+-4 1 D
+-4 5 D
+-1 7 D
+P
+5276 2916 M
+3 -3 D
+2 0 D
+0 -2 D
+-3 -1 D
+-3 3 D
+P
+5336 2959 M
+-2 -2 D
+3 -2 D
+-5 1 D
+3 3 D
+-1 1 D
+P
+5400 2899 M
+-3 -3 D
+-2 2 D
+4 0 D
+0 2 D
+2 -1 D
+P
+5314 2981 M
+2 -4 D
+-2 -2 D
+1 2 D
+-4 3 D
+P
+5280 3038 M
+1 3 D
+2 0 D
+P
+5419 3010 M
+-4 2 D
+P
+5250 3044 M
+2 1 D
+P
+5281 3065 M
+0 2 D
+P
+5251 3047 M
+1 1 D
+P
+5249 3038 M
+1 1 D
+P
+5237 3051 M
+2 0 D
+-2 -1 D
+P
+5295 3061 M
+-1 2 D
+P
+5407 3047 M
+-2 -2 D
+P
+FO
+5389 2835 M
+1 0 D
+-3 0 D
+P
+FO
+5413 2838 M
+2 0 D
+P
+FO
+5410 2846 M
+1 0 D
+P
+FO
+5514 3071 M
+4 -1 D
+-5 -5 D
+1 -2 D
+3 0 D
+4 -4 D
+-3 1 D
+-1 -2 D
+-3 2 D
+-5 -1 D
+1 4 D
+-4 -6 D
+2 -6 D
+0 4 D
+5 -1 D
+4 2 D
+0 -4 D
+1 1 D
+2 -4 D
+1 4 D
+0 -4 D
+6 -4 D
+-4 -9 D
+0 -15 D
+5 -25 D
+-3 -1 D
+-7 2 D
+9 2 D
+-50 -9 D
+-20 4 D
+-16 9 D
+-4 6 D
+-4 1 D
+0 -171 D
+2 0 D
+1 -4 D
+233 0 D
+0 236 D
+P
+5451 2898 M
+-5 0 D
+-3 -2 D
+1 3 D
+3 1 D
+P
+FO
+5503 3071 M
+8 -2 D
+3 2 D
+P
+FO
+5499 3071 M
+6 -6 D
+-3 6 D
+P
+FO
+2 -7 -2 -1 2 5506 3049 SP
+0 -2 1 5516 3061 SP
+-1 -1 1 5519 3061 SP
+5669 2835 M
+237 0 D
+0 236 D
+-237 0 D
+P
+5817 3067 M
+1 -2 D
+-3 1 D
+P
+5702 3006 M
+-1 -2 D
+-2 1 D
+P
+5779 3018 M
+4 0 D
+3 -2 D
+P
+5699 2869 M
+2 -1 D
+-1 -2 D
+P
+5690 2997 M
+2 0 D
+-1 0 D
+P
+5851 3021 M
+-2 -1 D
+P
+5785 3067 M
+-4 -1 D
+4 3 D
+P
+5690 2999 M
+-2 2 D
+P
+FO
+5906 2835 M
+236 0 D
+0 236 D
+-236 0 D
+P
+6062 2864 M
+-4 4 D
+-2 4 D
+6 -7 D
+1 0 D
+-2 2 D
+4 -2 D
+0 3 D
+1 -5 D
+-2 2 D
+P
+6119 2923 M
+12 0 D
+5 -4 D
+4 0 D
+-3 -3 D
+-3 4 D
+-3 2 D
+P
+5988 3050 M
+1 -4 D
+-3 2 D
+-2 -4 D
+0 6 D
+P
+6106 2928 M
+6 -5 D
+6 -1 D
+-6 -1 D
+-7 7 D
+P
+6139 2958 M
+-1 -2 D
+-2 3 D
+3 0 D
+P
+6013 2939 M
+3 -1 D
+-3 0 D
+0 -2 D
+P
+5968 3030 M
+4 -1 D
+0 -2 D
+-5 1 D
+P
+5938 3009 M
+0 1 D
+-2 -1 D
+P
+6102 2906 M
+1 -6 D
+-2 2 D
+P
+6136 2931 M
+-1 3 D
+3 1 D
+P
+6114 2919 M
+4 -1 D
+P
+6096 2913 M
+-3 0 D
+P
+5924 2854 M
+-1 -2 D
+P
+FO
+6378 2892 M
+-2 -1 D
+-1 2 D
+3 1 D
+0 177 D
+-236 0 D
+0 -236 D
+236 0 D
+P
+6346 2875 M
+-2 4 D
+4 0 D
+1 -2 D
+1 2 D
+8 1 D
+5 -2 D
+-3 -1 D
+-3 -6 D
+-4 2 D
+0 3 D
+P
+6269 2856 M
+-1 2 D
+2 2 D
+11 -3 D
+-2 0 D
+1 -1 D
+-1 -4 D
+-2 3 D
+-4 -1 D
+P
+6293 2853 M
+-1 2 D
+5 5 D
+2 7 D
+2 -1 D
+1 -5 D
+-4 -1 D
+-2 -6 D
+P
+6210 2870 M
+-2 2 D
+7 2 D
+0 -2 D
+6 -3 D
+-5 0 D
+-3 2 D
+P
+6217 2870 M
+1 0 D
+-2 1 D
+P
+6353 2944 M
+7 -1 D
+0 -1 D
+-4 1 D
+0 -2 D
+-4 0 D
+-1 3 D
+P
+6373 2913 M
+1 3 D
+-4 1 D
+4 -1 D
+2 2 D
+1 -3 D
+-3 -4 D
+P
+6178 2932 M
+6 -3 D
+-2 1 D
+-1 -3 D
+-3 3 D
+-3 -2 D
+P
+6347 2869 M
+-2 3 D
+3 -1 D
+-3 1 D
+2 2 D
+3 0 D
+-3 -8 D
+P
+6344 3003 M
+0 -2 D
+-2 0 D
+-1 -2 D
+-4 2 D
+3 3 D
+P
+6235 2865 M
+0 2 D
+3 0 D
+-2 2 D
+1 1 D
+2 -4 D
+P
+6169 2849 M
+-1 2 D
+2 0 D
+1 4 D
+2 -6 D
+P
+6306 2857 M
+4 5 D
+4 -3 D
+0 -1 D
+P
+6368 3014 M
+2 -3 D
+-14 2 D
+P
+6226 2884 M
+-2 2 D
+3 -2 D
+-1 -2 D
+P
+6225 2854 M
+2 4 D
+1 -3 D
+-2 -2 D
+P
+6290 2848 M
+-2 4 D
+3 -2 D
+0 -2 D
+-1 1 D
+P
+6365 2876 M
+2 1 D
+2 -1 D
+-3 0 D
+-1 -2 D
+P
+6235 2860 M
+1 3 D
+8 -1 D
+-3 -2 D
+P
+6175 2848 M
+-1 5 D
+5 -1 D
+0 -2 D
+P
+6328 2876 M
+10 2 D
+0 -1 D
+-4 0 D
+-8 -4 D
+P
+6171 2954 M
+-8 -1 D
+4 2 D
+P
+6362 2961 M
+1 -3 D
+-7 2 D
+4 2 D
+P
+6292 2840 M
+0 3 D
+2 0 D
+-1 -5 D
+P
+6318 2878 M
+-1 2 D
+4 1 D
+-1 -3 D
+P
+6223 2863 M
+-3 2 D
+4 2 D
+1 -2 D
+P
+6315 2961 M
+0 -2 D
+-3 -1 D
+P
+6335 2863 M
+-3 3 D
+12 -7 D
+-2 -1 D
+P
+6299 2902 M
+1 3 D
+3 1 D
+P
+6197 2935 M
+3 -3 D
+-7 5 D
+P
+6217 2955 M
+1 -2 D
+-5 -1 D
+P
+6197 2931 M
+3 -3 D
+-1 -1 D
+P
+6184 2941 M
+5 -2 D
+-4 0 D
+P
+6162 2929 M
+2 0 D
+0 -3 D
+P
+6257 2863 M
+1 2 D
+3 -1 D
+P
+6372 2904 M
+1 4 D
+1 -2 D
+P
+6368 2856 M
+2 2 D
+2 -2 D
+P
+6240 2882 M
+-3 0 D
+3 2 D
+P
+6253 2886 M
+2 1 D
+0 -2 D
+P
+6366 2973 M
+1 -1 D
+-5 -1 D
+P
+6208 2967 M
+0 -1 D
+-4 -1 D
+P
+6154 2945 M
+0 -2 D
+-4 0 D
+P
+6217 2960 M
+-3 -1 D
+P
+6356 2858 M
+-5 3 D
+5 -1 D
+P
+6350 2977 M
+0 -2 D
+-5 2 D
+P
+6347 2945 M
+3 -1 D
+-7 1 D
+P
+6238 2843 M
+-1 4 D
+2 -2 D
+P
+6319 2857 M
+-3 2 D
+4 -1 D
+P
+6316 2943 M
+-5 -1 D
+P
+6301 2971 M
+-1 -2 D
+-3 1 D
+P
+6315 2970 M
+1 -2 D
+-5 1 D
+P
+6263 2886 M
+-2 1 D
+2 0 D
+P
+6276 2870 M
+-2 1 D
+3 -1 D
+P
+6347 2881 M
+-1 1 D
+2 -1 D
+P
+6279 2940 M
+-3 -3 D
+P
+6194 2888 M
+-1 1 D
+P
+6180 2952 M
+0 -2 D
+-3 2 D
+P
+6330 2890 M
+3 2 D
+P
+6253 2843 M
+3 -4 D
+0 -2 D
+P
+6166 2940 M
+-1 2 D
+2 1 D
+P
+6278 2920 M
+1 2 D
+1 -2 D
+P
+6318 2976 M
+-5 0 D
+P
+6270 2863 M
+1 0 D
+P
+6272 2863 M
+1 0 D
+P
+6184 2899 M
+-1 0 D
+-1 2 D
+P
+6250 2918 M
+0 1 D
+P
+6306 2925 M
+3 2 D
+P
+6288 2886 M
+-1 0 D
+P
+6190 2881 M
+0 1 D
+P
+6347 2889 M
+1 1 D
+P
+6359 2865 M
+1 -2 D
+-2 -1 D
+P
+6289 2895 M
+1 2 D
+P
+FO
+6614 2992 M
+-5 1 D
+0 3 D
+-4 2 D
+5 1 D
+-1 5 D
+5 1 D
+0 66 D
+-236 0 D
+0 -154 D
+5 -2 D
+2 1 D
+0 7 D
+3 -8 D
+-3 -2 D
+-1 0 D
+-6 2 D
+0 1 D
+1 -24 D
+-1 0 D
+0 -57 D
+236 0 D
+P
+6386 2847 M
+-1 9 D
+6 -2 D
+3 2 D
+8 0 D
+0 -3 D
+-4 0 D
+0 -2 D
+P
+6388 2959 M
+5 -2 D
+-10 -1 D
+-3 2 D
+1 1 D
+3 -2 D
+1 2 D
+2 -1 D
+P
+6387 2951 M
+8 -2 D
+-6 0 D
+-2 -1 D
+3 -1 D
+-2 -2 D
+-4 4 D
+P
+6421 2966 M
+2 1 D
+5 -2 D
+-5 -1 D
+-2 1 D
+P
+6560 3032 M
+2 -2 D
+-1 -2 D
+-8 2 D
+2 3 D
+P
+6560 2954 M
+2 1 D
+2 -7 D
+-7 0 D
+-1 2 D
+P
+6432 2957 M
+-3 -1 D
+-5 2 D
+4 1 D
+P
+6397 3027 M
+5 -2 D
+-3 -1 D
+-4 2 D
+P
+6582 2960 M
+2 -2 D
+-5 0 D
+-3 3 D
+P
+6412 2882 M
+-3 0 D
+5 3 D
+0 -6 D
+P
+6399 2882 M
+-4 1 D
+3 3 D
+2 -3 D
+P
+6543 3003 M
+1 -1 D
+-4 -1 D
+0 4 D
+P
+6459 3017 M
+0 -1 D
+-3 0 D
+1 2 D
+P
+6409 2967 M
+-2 -2 D
+-7 3 D
+P
+6503 2999 M
+-1 -2 D
+-7 4 D
+P
+6416 2936 M
+-3 2 D
+4 0 D
+P
+6472 3012 M
+0 -2 D
+-3 3 D
+P
+6542 3006 M
+-2 -1 D
+0 2 D
+P
+6384 2969 M
+-5 2 D
+7 1 D
+P
+6406 2862 M
+-4 3 D
+6 -2 D
+P
+6390 2862 M
+1 4 D
+1 -3 D
+P
+6404 2876 M
+2 1 D
+1 -2 D
+-3 -2 D
+P
+6450 2968 M
+-3 0 D
+-8 4 D
+7 -1 D
+P
+6405 2925 M
+1 3 D
+1 -2 D
+P
+6400 2869 M
+1 4 D
+1 -2 D
+P
+FO
+6785 2835 M
+-1 1 D
+6 -1 D
+-2 0 D
+62 0 D
+0 236 D
+-236 0 D
+0 -66 D
+7 -1 D
+7 -7 D
+4 -1 D
+-2 -7 D
+-7 3 D
+-6 -1 D
+-3 1 D
+0 -157 D
+P
+6828 3052 M
+-2 -1 D
+P
+6834 3055 M
+-1 -1 D
+P
+6790 3024 M
+0 -2 D
+P
+FO
+6944 2835 M
+4 0 D
+0 2 D
+3 1 D
+-1 -3 D
+2 0 D
+-1 0 D
+26 0 D
+-7 5 D
+0 3 D
+-6 2 D
+-1 4 D
+-4 -1 D
+-3 2 D
+-4 -2 D
+3 3 D
+4 -3 D
+7 1 D
+-1 -4 D
+6 -2 D
+-1 -3 D
+5 -2 D
+2 -3 D
+14 0 D
+-1 1 D
+6 -1 D
+0 1 D
+1 -1 D
+1 3 D
+1 -2 D
+0 2 D
+2 -3 D
+2 2 D
+-2 0 D
+-2 3 D
+2 1 D
+1 -2 D
+3 1 D
+0 -3 D
+-3 -1 D
+3 -1 D
+6 3 D
+2 4 D
+0 4 D
+8 1 D
+0 4 D
+11 3 D
+3 8 D
+3 -2 D
+1 5 D
+2 -1 D
+6 2 D
+-1 4 D
+11 17 D
+4 -1 D
+4 2 D
+12 -1 D
+1 -1 D
+-13 1 D
+-8 -2 D
+-7 -9 D
+-3 -11 D
+-4 -1 D
+-5 -4 D
+-3 1 D
+-2 -7 D
+-11 -4 D
+-2 -4 D
+-5 0 D
+-3 -9 D
+-5 -2 D
+80 0 D
+0 24 D
+-2 1 D
+-1 5 D
+3 4 D
+0 70 D
+-2 1 D
+-3 -1 D
+0 2 D
+-4 0 D
+-4 6 D
+-6 0 D
+-1 -2 D
+1 8 D
+4 2 D
+6 12 D
+2 1 D
+1 -1 D
+2 2 D
+1 -2 D
+1 4 D
+2 -1 D
+0 41 D
+-4 -2 D
+1 -3 D
+-4 -3 D
+-13 0 D
+-6 5 D
+4 9 D
+-3 2 D
+2 2 D
+-2 4 D
+-3 -2 D
+0 6 D
+-6 -2 D
+-1 -2 D
+-3 2 D
+-9 0 D
+-8 6 D
+-3 6 D
+2 5 D
+3 3 D
+-1 3 D
+7 2 D
+7 -5 D
+6 4 D
+5 -1 D
+12 7 D
+-1 4 D
+3 5 D
+3 0 D
+1 3 D
+7 2 D
+-233 0 D
+0 -236 D
+P
+7038 2904 M
+4 2 D
+4 -1 D
+-2 4 D
+-7 0 D
+0 -3 D
+-3 0 D
+3 1 D
+0 3 D
+7 1 D
+2 -5 D
+4 1 D
+-3 -1 D
+4 3 D
+-6 1 D
+-1 5 D
+3 -4 D
+4 5 D
+0 -2 D
+3 0 D
+-4 6 D
+3 1 D
+1 -5 D
+4 0 D
+2 -2 D
+-3 -7 D
+-2 0 D
+0 3 D
+-2 0 D
+-2 -5 D
+-8 -3 D
+2 2 D
+-2 2 D
+P
+7066 2900 M
+-2 3 D
+6 -1 D
+-2 3 D
+2 1 D
+0 2 D
+-2 1 D
+0 -2 D
+-3 -1 D
+-6 2 D
+6 -1 D
+4 4 D
+4 -11 D
+-1 -1 D
+-4 1 D
+-1 -3 D
+P
+6954 2837 M
+0 4 D
+4 1 D
+-3 1 D
+5 -1 D
+0 -6 D
+-1 3 D
+-2 -1 D
+1 2 D
+-2 0 D
+0 -4 D
+-1 3 D
+P
+6959 2843 M
+-3 2 D
+2 0 D
+1 -2 D
+1 2 D
+-1 2 D
+4 -1 D
+0 -2 D
+-1 1 D
+P
+7026 2870 M
+-3 2 D
+0 3 D
+3 0 D
+0 -3 D
+6 2 D
+3 -2 D
+-5 -3 D
+P
+7078 2890 M
+-3 0 D
+-2 5 D
+-3 2 D
+3 1 D
+2 -8 D
+P
+7057 2869 M
+-1 2 D
+6 0 D
+-2 -4 D
+-3 3 D
+1 -3 D
+P
+7012 2888 M
+1 5 D
+-3 0 D
+2 2 D
+3 -4 D
+-3 -4 D
+P
+6962 2843 M
+3 -1 D
+-1 -1 D
+-2 1 D
+1 -2 D
+-3 0 D
+P
+6952 2844 M
+0 2 D
+3 0 D
+-1 -2 D
+P
+7016 2853 M
+1 4 D
+2 -5 D
+-2 -1 D
+P
+7015 2842 M
+0 2 D
+4 1 D
+1 -1 D
+P
+6961 2849 M
+-1 2 D
+2 0 D
+0 2 D
+2 -3 D
+P
+6956 2852 M
+0 2 D
+3 0 D
+-2 -1 D
+1 -1 D
+P
+7061 2860 M
+-2 1 D
+4 1 D
+0 -1 D
+P
+6967 2837 M
+0 1 D
+7 -1 D
+P
+7020 2946 M
+4 -3 D
+-4 -3 D
+P
+7080 2888 M
+2 0 D
+2 -4 D
+P
+7012 2841 M
+-6 -1 D
+1 1 D
+-2 1 D
+P
+6997 2978 M
+0 -4 D
+-2 2 D
+P
+7075 2871 M
+0 2 D
+2 1 D
+P
+6999 2887 M
+3 4 D
+-2 -5 D
+P
+7023 2853 M
+-2 3 D
+5 -2 D
+P
+7009 2845 M
+3 2 D
+4 0 D
+P
+6952 2846 M
+2 3 D
+1 -2 D
+P
+6869 2951 M
+2 0 D
+P
+7043 2931 M
+3 1 D
+-1 -3 D
+P
+6950 2842 M
+1 -3 D
+-3 1 D
+P
+7083 2875 M
+0 -4 D
+-3 -1 D
+P
+6967 2841 M
+2 2 D
+0 -2 D
+P
+6951 2907 M
+0 -3 D
+-1 3 D
+P
+6913 2914 M
+0 -1 D
+-4 1 D
+P
+6945 3032 M
+-3 -1 D
+P
+7026 3041 M
+-3 -1 D
+P
+6872 2951 M
+4 2 D
+P
+6940 2843 M
+3 1 D
+P
+6948 2984 M
+1 -2 D
+P
+6951 3030 M
+1 -1 D
+P
+7015 2847 M
+0 1 D
+1 -1 D
+P
+6858 2955 M
+1 1 D
+P
+FO
+6999 2835 M
+-1 0 D
+P
+FO
+7058 3050 M
+2 1 D
+P
+FO
+7051 3045 M
+2 2 D
+P
+FO
+7073 2948 M
+2 -1 D
+P
+FO
+7063 3052 M
+-3 -2 D
+P
+FO
+7056 3047 M
+1 2 D
+P
+FO
+2 1 1 7006 2835 SP
+-2 1 2 1 0 -1 3 7057 2886 SP
+2 0 1 7039 2864 SP
+1 0 1 7076 2887 SP
+2 0 1 7026 2852 SP
+-1 -1 1 2 2 7048 2872 SP
+-1 1 2 -1 2 7035 2862 SP
+7126 2835 M
+-4 5 D
+-6 2 D
+-9 -4 D
+-5 0 D
+2 -1 D
+-2 1 D
+-1 5 D
+-4 0 D
+-2 -2 D
+-5 -2 D
+3 3 D
+2 -1 D
+1 3 D
+6 0 D
+3 -2 D
+3 1 D
+3 5 D
+11 6 D
+9 1 D
+1 2 D
+-6 9 D
+-4 1 D
+-10 8 D
+-7 2 D
+-1 5 D
+-7 0 D
+-6 -2 D
+-3 1 D
+4 0 D
+7 3 D
+5 -1 D
+1 1 D
+-1 -1 D
+2 0 D
+3 -6 D
+4 0 D
+0 2 D
+4 0 D
+13 -5 D
+2 2 D
+-5 7 D
+-7 2 D
+-1 6 D
+-12 5 D
+2 2 D
+-3 3 D
+3 1 D
+-8 12 D
+-3 10 D
+-1 -1 D
+1 2 D
+-2 0 D
+-3 11 D
+-6 3 D
+0 -70 D
+5 2 D
+0 -3 D
+4 1 D
+-3 -3 D
+2 0 D
+0 -3 D
+3 0 D
+-4 -4 D
+2 -1 D
+4 4 D
+1 -2 D
+-6 -3 D
+-4 -1 D
+-4 3 D
+0 -24 D
+P
+7102 2867 M
+2 2 D
+0 -2 D
+2 2 D
+1 -2 D
+P
+7107 2860 M
+3 3 D
+0 -3 D
+P
+FO
+7131 2835 M
+1 0 D
+-1 2 D
+-1 -2 D
+P
+FO
+7142 2835 M
+-9 4 D
+2 -4 D
+P
+FO
+7321 2835 M
+P
+FO
+7323 2888 M
+-1 0 D
+1 -1 D
+P
+FO
+7323 2892 M
+0 -3 D
+P
+FO
+7323 2902 M
+-5 0 D
+1 3 D
+-4 3 D
+-1 -4 D
+4 -5 D
+2 1 D
+-3 -5 D
+6 5 D
+P
+FO
+7323 2917 M
+-4 2 D
+0 -3 D
+-1 0 D
+2 -1 D
+-2 0 D
+2 -3 D
+-5 3 D
+-3 -2 D
+2 0 D
+-2 -2 D
+2 0 D
+1 -3 D
+3 1 D
+-1 -1 D
+4 -2 D
+2 -4 D
+P
+FO
+7131 3071 M
+-10 -5 D
+2 -6 D
+-2 -1 D
+0 -1 D
+-3 1 D
+-2 -3 D
+3 2 D
+-1 -2 D
+2 0 D
+1 2 D
+2 -2 D
+10 1 D
+-9 -3 D
+2 -5 D
+-5 -1 D
+-2 1 D
+-1 -2 D
+-5 -1 D
+1 -5 D
+2 2 D
+11 1 D
+-3 2 D
+2 2 D
+2 -1 D
+-1 2 D
+4 -3 D
+-1 2 D
+5 1 D
+-1 1 D
+4 1 D
+-3 1 D
+8 6 D
+3 -1 D
+0 3 D
+1 -2 D
+10 5 D
+7 1 D
+-2 0 D
+2 3 D
+3 -1 D
+0 -1 D
+3 1 D
+1 -1 D
+1 4 D
+2 -2 D
+3 1 D
+4 -2 D
+6 3 D
+-1 -3 D
+4 5 D
+-2 -2 D
+3 -3 D
+4 1 D
+1 -6 D
+3 1 D
+0 4 D
+9 -5 D
+2 1 D
+1 -2 D
+7 3 D
+-3 -2 D
+4 1 D
+-6 -4 D
+0 -2 D
+3 1 D
+-2 -1 D
+1 -1 D
+-7 -11 D
+3 -4 D
+4 2 D
+4 -3 D
+-4 2 D
+-3 -3 D
+-4 2 D
+-2 -4 D
+-2 2 D
+1 -3 D
+-4 -3 D
+1 -3 D
+-5 -2 D
+14 -1 D
+-1 -2 D
+-3 1 D
+1 -2 D
+-4 -1 D
+5 -1 D
+1 1 D
+2 -1 D
+-2 -2 D
+2 0 D
+1 2 D
+2 -1 D
+-1 1 D
+3 0 D
+0 -2 D
+-4 0 D
+2 -1 D
+-2 0 D
+0 -2 D
+4 3 D
+2 -1 D
+1 4 D
+2 0 D
+-4 2 D
+2 1 D
+4 -2 D
+2 -3 D
+4 1 D
+1 -3 D
+1 2 D
+6 2 D
+4 -4 D
+4 2 D
+-2 -4 D
+6 -3 D
+-6 3 D
+0 2 D
+-3 0 D
+0 -3 D
+3 -1 D
+-2 -3 D
+7 -5 D
+-5 0 D
+0 -2 D
+3 0 D
+-1 -3 D
+3 -1 D
+-2 0 D
+3 -2 D
+2 1 D
+-3 -4 D
+-2 4 D
+-4 0 D
+-3 2 D
+2 -4 D
+-2 2 D
+-1 -3 D
+0 4 D
+-2 0 D
+2 -2 D
+-3 -2 D
+1 -1 D
+-2 0 D
+0 5 D
+0 -3 D
+-2 0 D
+0 -2 D
+-1 1 D
+-1 -3 D
+1 2 D
+2 -2 D
+-2 -1 D
+3 2 D
+1 -7 D
+2 -1 D
+-3 7 D
+2 1 D
+0 -3 D
+2 3 D
+1 -7 D
+2 1 D
+-2 -2 D
+2 -5 D
+-2 -1 D
+5 -4 D
+4 4 D
+0 -2 D
+-6 -3 D
+0 -1 D
+5 0 D
+-4 -1 D
+3 -2 D
+-8 -3 D
+1 -2 D
+4 1 D
+0 -2 D
+-4 0 D
+0 -2 D
+-2 -1 D
+2 -2 D
+-2 2 D
+-2 -4 D
+4 -3 D
+-2 -2 D
+-1 4 D
+-3 -2 D
+4 -1 D
+-2 -3 D
+3 1 D
+-2 -4 D
+4 0 D
+0 4 D
+1 -3 D
+2 -1 D
+-7 -1 D
+3 0 D
+3 -3 D
+-5 2 D
+2 -2 D
+-3 -1 D
+-2 4 D
+0 -4 D
+2 -1 D
+4 1 D
+-2 -2 D
+2 -5 D
+5 4 D
+0 4 D
+1 -4 D
+2 -1 D
+2 1 D
+0 4 D
+5 1 D
+2 2 D
+2 -1 D
+-1 -1 D
+-1 1 D
+-1 -3 D
+0 2 D
+-2 -3 D
+5 -2 D
+2 2 D
+-2 1 D
+4 0 D
+-4 6 D
+4 1 D
+2 -3 D
+-1 -2 D
+2 -1 D
+1 3 D
+3 -4 D
+-1 6 D
+-4 1 D
+0 2 D
+3 -1 D
+0 2 D
+4 -2 D
+1 2 D
+2 -1 D
+1 3 D
+0 -4 D
+3 -1 D
+3 2 D
+0 -2 D
+3 -1 D
+-3 0 D
+3 -2 D
+1 3 D
+-2 0 D
+0 3 D
+2 0 D
+-1 2 D
+5 -1 D
+-1 4 D
+2 -3 D
+6 1 D
+0 -2 D
+2 1 D
+1 -1 D
+-1 2 D
+2 -1 D
+6 6 D
+0 5 D
+2 -2 D
+3 13 D
+-1 1 D
+-2 -2 D
+-2 1 D
+3 17 D
+-2 7 D
+-8 15 D
+-11 11 D
+-8 15 D
+-2 -1 D
+-10 9 D
+-9 2 D
+0 3 D
+2 1 D
+-2 0 D
+3 1 D
+1 -3 D
+-1 11 D
+6 4 D
+3 -1 D
+2 3 D
+P
+7275 3026 M
+-5 0 D
+5 1 D
+P
+FO
+7087 2970 M
+1 4 D
+6 2 D
+-1 1 D
+-2 -1 D
+1 2 D
+-3 1 D
+1 2 D
+4 0 D
+0 2 D
+1 -6 D
+8 3 D
+-1 4 D
+2 0 D
+-1 3 D
+3 0 D
+1 -2 D
+3 4 D
+-3 2 D
+-2 -1 D
+0 1 D
+3 1 D
+3 -2 D
+4 3 D
+4 0 D
+2 2 D
+0 2 D
+1 -2 D
+3 1 D
+-3 -1 D
+3 -1 D
+0 2 D
+8 3 D
+-1 1 D
+1 1 D
+2 -4 D
+4 4 D
+-2 -2 D
+3 -1 D
+-2 -2 D
+6 1 D
+0 2 D
+2 0 D
+0 -1 D
+1 3 D
+-4 0 D
+2 2 D
+0 -1 D
+4 3 D
+-2 3 D
+3 2 D
+-12 0 D
+-1 3 D
+-4 -3 D
+-10 0 D
+-4 3 D
+1 1 D
+-2 1 D
+-1 -2 D
+-8 6 D
+-5 1 D
+-12 -4 D
+2 0 D
+0 -2 D
+-7 -3 D
+P
+FO
+7292 2953 M
+-3 -1 D
+2 -2 D
+-4 0 D
+1 -2 D
+2 1 D
+-1 -3 D
+3 1 D
+-1 1 D
+2 0 D
+P
+FO
+7232 2912 M
+3 -2 D
+13 3 D
+3 3 D
+-3 3 D
+-4 0 D
+-8 -2 D
+P
+FO
+7290 2896 M
+4 -1 D
+0 2 D
+3 0 D
+-2 4 D
+-1 -2 D
+-3 1 D
+P
+FO
+7276 2949 M
+-3 0 D
+0 2 D
+-2 -2 D
+1 -3 D
+2 1 D
+3 -1 D
+P
+FO
+7305 2938 M
+3 0 D
+-2 -1 D
+2 0 D
+2 9 D
+-3 -2 D
+P
+FO
+7230 2939 M
+3 -2 D
+3 2 D
+1 2 D
+-3 2 D
+-1 -4 D
+0 2 D
+P
+FO
+7299 2905 M
+2 -4 D
+1 4 D
+2 0 D
+-3 0 D
+1 4 D
+P
+FO
+7114 2877 M
+10 -6 D
+7 -1 D
+0 1 D
+-12 7 D
+P
+FO
+7303 2932 M
+3 0 D
+1 4 D
+-3 1 D
+P
+FO
+7237 3019 M
+0 -5 D
+3 0 D
+0 4 D
+P
+FO
+7314 2924 M
+2 -2 D
+2 2 D
+-2 2 D
+P
+FO
+7246 2938 M
+3 1 D
+-1 1 D
+P
+FO
+7316 2915 M
+2 1 D
+-1 1 D
+P
+FO
+7229 2954 M
+2 0 D
+1 2 D
+P
+FO
+7295 2901 M
+2 0 D
+-1 1 D
+P
+FO
+7230 2949 M
+1 -1 D
+1 2 D
+P
+FO
+7232 2955 M
+3 -2 D
+-1 2 D
+P
+FO
+7241 3005 M
+2 0 D
+-1 2 D
+P
+FO
+7129 2867 M
+1 -2 D
+1 2 D
+P
+FO
+7199 3036 M
+3 0 D
+-2 1 D
+P
+FO
+7229 2942 M
+2 0 D
+-1 2 D
+P
+FO
+7307 2910 M
+3 1 D
+2 4 D
+P
+FO
+7136 2841 M
+3 -1 D
+1 2 D
+-4 0 D
+P
+FO
+7141 3052 M
+2 -1 D
+0 1 D
+P
+FO
+7296 2902 M
+2 -1 D
+0 2 D
+P
+FO
+7315 2874 M
+1 -1 D
+2 4 D
+P
+FO
+7254 2940 M
+1 -1 D
+3 1 D
+P
+FO
+7243 2933 M
+1 -1 D
+1 1 D
+P
+FO
+7276 2951 M
+-1 -2 D
+3 0 D
+P
+FO
+7120 3059 M
+3 2 D
+-2 2 D
+-5 -3 D
+P
+FO
+7196 3023 M
+1 -1 D
+2 1 D
+P
+FO
+7230 3005 M
+2 1 D
+P
+FO
+7319 2879 M
+1 -2 D
+1 2 D
+P
+FO
+7100 2883 M
+2 0 D
+P
+FO
+7230 2948 M
+2 0 D
+P
+FO
+7311 2917 M
+2 0 D
+P
+FO
+7286 2948 M
+2 -1 D
+P
+FO
+7280 2948 M
+2 0 D
+-2 1 D
+P
+FO
+7237 3011 M
+2 -1 D
+P
+FO
+7321 2854 M
+1 0 D
+P
+FO
+7281 2944 M
+2 0 D
+P
+FO
+7132 2837 M
+1 0 D
+P
+FO
+7253 2940 M
+0 -1 D
+P
+FO
+7300 2910 M
+2 1 D
+P
+FO
+7244 2938 M
+3 -2 D
+P
+FO
+7124 2869 M
+5 -3 D
+P
+FO
+7140 2846 M
+4 -2 D
+P
+FO
+7200 3059 M
+3 3 D
+P
+FO
+7228 2950 M
+3 1 D
+P
+FO
+7237 2949 M
+-2 2 D
+-1 -2 D
+P
+FO
+7233 3018 M
+3 1 D
+P
+FO
+7228 2948 M
+-2 -2 D
+P
+FO
+7228 2945 M
+-2 1 D
+P
+FO
+7235 3017 M
+1 1 D
+P
+FO
+7230 2947 M
+3 -1 D
+P
+FO
+7240 3011 M
+2 1 D
+P
+FO
+7140 2840 M
+4 1 D
+P
+FO
+7240 2932 M
+3 1 D
+P
+FO
+7248 2933 M
+2 1 D
+P
+FO
+7299 2904 M
+1 -2 D
+P
+FO
+7268 2942 M
+3 -1 D
+P
+FO
+7263 2940 M
+2 -1 D
+P
+FO
+7146 3054 M
+4 0 D
+P
+FO
+7157 3059 M
+0 1 D
+P
+FO
+7241 2934 M
+2 0 D
+P
+FO
+7249 2939 M
+2 -1 D
+P
+FO
+7301 2912 M
+2 0 D
+P
+FO
+7231 2953 M
+2 -1 D
+P
+FO
+7231 2944 M
+2 0 D
+-2 1 D
+P
+FO
+7144 2851 M
+2 1 D
+P
+FO
+7252 2937 M
+2 0 D
+P
+FO
+7238 3006 M
+2 0 D
+-1 0 D
+P
+FO
+7262 2941 M
+2 0 D
+P
+FO
+7137 2839 M
+2 0 D
+P
+FO
+7161 3049 M
+0 -1 D
+P
+FO
+7295 2953 M
+0 1 D
+P
+FO
+7313 2905 M
+1 2 D
+P
+FO
+7149 3053 M
+3 0 D
+P
+FO
+7195 3060 M
+3 1 D
+P
+FO
+7229 2936 M
+2 0 D
+P
+FO
+7236 3013 M
+1 -1 D
+P
+FO
+7235 3006 M
+2 0 D
+P
+FO
+7208 3019 M
+1 0 D
+P
+FO
+7302 2910 M
+0 -1 D
+P
+FO
+7209 2945 M
+1 1 D
+P
+FO
+7232 3016 M
+1 -1 D
+P
+FO
+7133 2842 M
+1 1 D
+P
+FO
+7197 3019 M
+1 1 D
+P
+FO
+7207 2931 M
+1 -1 D
+P
+FO
+7234 2967 M
+2 0 D
+P
+FO
+7280 2949 M
+1 0 D
+P
+FO
+7267 2942 M
+2 1 D
+-2 0 D
+P
+FO
+7140 2841 M
+1 0 D
+P
+FO
+7224 2944 M
+1 -1 D
+P
+FO
+7231 2954 M
+2 -1 D
+P
+FO
+7237 2985 M
+2 0 D
+P
+FO
+7151 3048 M
+1 -1 D
+P
+FO
+7134 2839 M
+1 0 D
+P
+FO
+7281 3071 M
+-2 -1 D
+P
+FO
+7099 2883 M
+1 0 D
+P
+FO
+7268 2950 M
+2 0 D
+P
+FO
+7124 3011 M
+2 0 D
+P
+FO
+7228 2937 M
+2 0 D
+P
+FO
+7103 3023 M
+1 0 D
+P
+FO
+7258 2930 M
+2 -1 D
+P
+FO
+7205 3019 M
+1 1 D
+P
+FO
+-3 0 2 1 2 7093 2860 SP
+7559 2964 M
+-5 -4 D
+2 -2 D
+0 -5 D
+-3 -1 D
+3 -2 D
+3 3 D
+P
+FO
+7559 3056 M
+-4 -11 D
+-7 -8 D
+-3 -10 D
+-13 -8 D
+-7 -10 D
+-8 -5 D
+-19 -6 D
+-2 -4 D
+-7 1 D
+-1 2 D
+2 6 D
+-2 -2 D
+-3 1 D
+1 3 D
+2 -1 D
+6 3 D
+2 5 D
+-14 -3 D
+-2 -5 D
+3 -4 D
+-2 -6 D
+-7 -8 D
+-7 -4 D
+-3 -6 D
+3 -5 D
+-1 -3 D
+-1 3 D
+-1 -3 D
+-4 0 D
+1 -3 D
+-3 1 D
+0 -2 D
+-3 0 D
+2 2 D
+-4 -2 D
+-1 3 D
+-4 -4 D
+-1 4 D
+-2 -1 D
+3 2 D
+-2 3 D
+-7 -3 D
+-9 1 D
+-9 -4 D
+-14 0 D
+-4 -2 D
+-3 2 D
+1 1 D
+-5 1 D
+-11 -4 D
+0 -3 D
+-19 -14 D
+-5 -1 D
+-5 -6 D
+-6 -1 D
+-4 2 D
+-1 -2 D
+2 0 D
+-3 0 D
+-1 -2 D
+2 -2 D
+-2 -2 D
+1 -5 D
+3 4 D
+6 -4 D
+3 4 D
+1 -2 D
+7 2 D
+2 -1 D
+-1 -1 D
+2 0 D
+2 -2 D
+3 1 D
+1 -3 D
+-1 3 D
+3 1 D
+0 6 D
+7 3 D
+1 -3 D
+-2 -4 D
+2 0 D
+1 4 D
+15 4 D
+0 -1 D
+1 2 D
+2 -2 D
+0 2 D
+3 1 D
+2 -1 D
+3 2 D
+2 -3 D
+4 1 D
+2 3 D
+-3 -1 D
+0 1 D
+6 1 D
+2 2 D
+-1 1 D
+11 1 D
+9 -4 D
+7 2 D
+2 -1 D
+1 -2 D
+-5 -5 D
+-4 -2 D
+3 -3 D
+-3 -2 D
+2 -1 D
+-3 -4 D
+8 -3 D
+-1 -2 D
+10 -4 D
+0 -1 D
+5 3 D
+6 10 D
+1 -1 D
+-2 3 D
+2 1 D
+1 -1 D
+0 3 D
+7 1 D
+1 2 D
+2 0 D
+-1 -1 D
+4 0 D
+-2 -1 D
+3 1 D
+0 2 D
+-2 0 D
+2 0 D
+0 2 D
+-10 5 D
+5 9 D
+5 1 D
+-2 -5 D
+2 -4 D
+2 0 D
+-2 2 D
+2 4 D
+1 -5 D
+3 0 D
+1 2 D
+4 -1 D
+-2 -3 D
+-5 0 D
+-1 -2 D
+13 2 D
+-2 2 D
+4 1 D
+-2 -3 D
+15 -2 D
+3 8 D
+4 1 D
+1 3 D
+4 1 D
+4 -2 D
+-3 -2 D
+-1 -7 D
+3 -2 D
+3 2 D
+4 5 D
+-2 4 D
+2 5 D
+9 1 D
+2 -4 D
+2 0 D
+1 3 D
+-3 1 D
+0 4 D
+4 1 D
+0 4 D
+3 -2 D
+2 2 D
+P
+7471 2960 M
+-7 -5 D
+-2 -3 D
+1 5 D
+3 3 D
+0 3 D
+3 0 D
+P
+7399 2964 M
+2 -2 D
+-4 1 D
+0 2 D
+P
+7515 2977 M
+-2 0 D
+P
+7395 2963 M
+-4 0 D
+P
+7481 2992 M
+-1 -1 D
+P
+FO
+7559 3068 M
+-1 0 D
+1 -1 D
+P
+FO
+7556 3071 M
+-4 0 D
+0 -2 D
+3 -2 D
+4 3 D
+0 1 D
+P
+FO
+7323 2902 M
+0 -2 D
+2 1 D
+3 -1 D
+-2 -2 D
+1 -2 D
+4 2 D
+0 4 D
+-6 0 D
+3 2 D
+-2 5 D
+1 1 D
+4 -1 D
+0 1 D
+1 -4 D
+4 -3 D
+2 -5 D
+-5 -1 D
+5 0 D
+-7 -12 D
+-4 -1 D
+2 -6 D
+-2 -1 D
+4 -5 D
+-1 -3 D
+-5 -1 D
+3 -4 D
+6 0 D
+3 -2 D
+2 3 D
+-3 1 D
+-1 4 D
+3 6 D
+4 -1 D
+-1 -3 D
+-2 1 D
+-2 -1 D
+2 -1 D
+3 -5 D
+-3 -8 D
+11 7 D
+-4 2 D
+2 2 D
+7 -2 D
+3 10 D
+-2 3 D
+1 -1 D
+1 4 D
+-1 0 D
+1 0 D
+3 9 D
+2 0 D
+-1 1 D
+2 1 D
+-2 2 D
+5 2 D
+1 3 D
+2 0 D
+-1 1 D
+1 2 D
+2 0 D
+-5 0 D
+4 3 D
+-6 1 D
+3 4 D
+-10 0 D
+0 2 D
+2 0 D
+4 3 D
+-2 4 D
+-3 1 D
+-4 -4 D
+0 1 D
+-6 1 D
+-4 5 D
+2 3 D
+-3 -2 D
+-4 0 D
+3 2 D
+-4 0 D
+0 -2 D
+-4 1 D
+-2 -4 D
+-3 -1 D
+1 -1 D
+2 1 D
+-1 -2 D
+-3 -1 D
+-1 2 D
+-4 -5 D
+-1 1 D
+P
+FO
+7323 2889 M
+2 0 D
+-2 -1 D
+0 -2 D
+5 4 D
+0 5 D
+-5 0 D
+P
+FO
+7394 2905 M
+5 4 D
+2 6 D
+0 -1 D
+3 1 D
+-2 0 D
+5 2 D
+8 0 D
+7 -6 D
+3 8 D
+10 6 D
+-3 1 D
+2 2 D
+-4 4 D
+2 -1 D
+-1 4 D
+-3 -1 D
+-7 5 D
+-2 -2 D
+-4 1 D
+-5 -4 D
+-3 1 D
+2 -3 D
+-2 -3 D
+-6 0 D
+-4 -2 D
+-5 6 D
+-4 -4 D
+-3 -7 D
+-14 -8 D
+9 2 D
+-1 -3 D
+3 0 D
+-1 -1 D
+2 -1 D
+-1 -2 D
+-3 1 D
+3 -2 D
+-3 -2 D
+2 1 D
+2 -2 D
+-2 0 D
+1 -2 D
+0 1 D
+5 0 D
+-2 -4 D
+9 -1 D
+-1 2 D
+P
+FO
+7519 3024 M
+-2 -5 D
+7 3 D
+1 4 D
+-3 -1 D
+2 6 D
+-7 -5 D
+0 -3 D
+P
+FO
+7332 2843 M
+1 -3 D
+2 0 D
+4 4 D
+-4 2 D
+-3 -2 D
+P
+FO
+7379 2935 M
+1 -3 D
+2 1 D
+-1 3 D
+0 -2 D
+P
+FO
+7441 2944 M
+-8 -8 D
+2 -2 D
+5 1 D
+-1 4 D
+P
+FO
+7346 2848 M
+2 6 D
+-5 -8 D
+0 -3 D
+3 0 D
+P
+FO
+7398 2982 M
+2 -2 D
+3 3 D
+-3 2 D
+P
+FO
+7374 2927 M
+4 -1 D
+3 2 D
+P
+FO
+7328 2892 M
+0 -1 D
+4 0 D
+2 5 D
+-2 -3 D
+P
+FO
+7394 2979 M
+0 -2 D
+2 3 D
+P
+FO
+7421 2940 M
+4 -1 D
+1 3 D
+P
+FO
+7325 2886 M
+2 -2 D
+0 3 D
+P
+FO
+7544 2947 M
+2 -2 D
+0 3 D
+P
+FO
+7342 3012 M
+3 -1 D
+0 2 D
+P
+FO
+7553 2909 M
+2 -2 D
+0 1 D
+P
+FO
+7394 2936 M
+-1 -2 D
+2 0 D
+P
+FO
+7488 3003 M
+-2 1 D
+1 -2 D
+P
+FO
+7394 2932 M
+2 1 D
+-2 1 D
+P
+FO
+7390 2935 M
+2 -1 D
+0 2 D
+P
+FO
+7397 2937 M
+1 -2 D
+1 2 D
+P
+FO
+7395 2979 M
+0 -2 D
+2 1 D
+P
+FO
+7547 2931 M
+2 1 D
+P
+FO
+7540 3034 M
+2 1 D
+P
+FO
+7385 2927 M
+2 0 D
+P
+FO
+7401 2938 M
+1 0 D
+P
+FO
+7484 2941 M
+2 1 D
+P
+FO
+7361 2923 M
+2 0 D
+P
+FO
+7364 2930 M
+1 0 D
+P
+FO
+7373 2923 M
+1 1 D
+P
+FO
+7376 2910 M
+1 -1 D
+P
+FO
+7326 2846 M
+3 -1 D
+P
+FO
+7395 2935 M
+2 2 D
+-2 -1 D
+P
+FO
+7376 2935 M
+2 2 D
+P
+FO
+7541 2938 M
+1 1 D
+P
+FO
+7385 2929 M
+-1 -1 D
+P
+FO
+7395 2934 M
+2 0 D
+P
+FO
+7386 2933 M
+2 0 D
+P
+FO
+7549 2926 M
+1 0 D
+P
+FO
+7389 2933 M
+2 0 D
+P
+FO
+7538 2934 M
+1 1 D
+P
+FO
+7374 2924 M
+3 0 D
+-3 1 D
+P
+FO
+7350 2939 M
+3 0 D
+P
+FO
+7371 2924 M
+2 1 D
+P
+FO
+7418 2941 M
+2 0 D
+P
+FO
+7330 2889 M
+2 1 D
+P
+FO
+7329 2853 M
+1 0 D
+P
+FO
+7424 2946 M
+2 0 D
+P
+FO
+7460 2917 M
+1 0 D
+P
+FO
+7559 3070 M
+2 1 D
+-1 -3 D
+-1 0 D
+3 -5 D
+-3 -7 D
+0 -87 D
+3 -3 D
+-3 -2 D
+0 -11 D
+9 4 D
+1 6 D
+3 4 D
+3 2 D
+4 0 D
+-3 3 D
+3 -2 D
+-4 5 D
+-3 8 D
+6 14 D
+4 3 D
+2 12 D
+-3 16 D
+4 3 D
+-1 2 D
+9 0 D
+2 -3 D
+0 3 D
+-2 1 D
+3 2 D
+-3 1 D
+2 2 D
+-2 0 D
+3 1 D
+0 5 D
+3 -1 D
+-1 3 D
+1 -1 D
+1 3 D
+3 -1 D
+-1 2 D
+2 0 D
+-2 1 D
+4 2 D
+-2 2 D
+2 1 D
+-2 -1 D
+3 2 D
+0 2 D
+-2 -1 D
+3 2 D
+-1 3 D
+-2 -2 D
+1 5 D
+-2 5 D
+-45 0 D
+P
+7570 2977 M
+0 -2 D
+-6 3 D
+4 0 D
+-1 2 D
+2 -3 D
+P
+7561 3012 M
+1 -2 D
+-2 1 D
+P
+7572 2978 M
+0 1 D
+2 -4 D
+P
+7575 3065 M
+0 -1 D
+P
+FO
+7561 3064 M
+-1 1 D
+P
+FO
+1417 2929 M
+-1 1 D
+-5 -1 D
+4 -2 D
+2 1 D
+P
+FO
+1417 3046 M
+-3 4 D
+2 3 D
+1 0 D
+0 18 D
+-95 0 D
+4 -4 D
+3 -22 D
+18 -15 D
+-1 -7 D
+4 1 D
+8 -5 D
+0 2 D
+2 0 D
+-2 6 D
+6 -2 D
+-4 -3 D
+3 -1 D
+-1 -3 D
+4 -1 D
+2 -5 D
+-6 2 D
+-1 5 D
+-2 0 D
+-1 -6 D
+3 -5 D
+-1 -3 D
+7 -6 D
+6 -1 D
+1 -6 D
+-3 -2 D
+1 -6 D
+10 -8 D
+5 -8 D
+11 -7 D
+-2 -3 D
+6 -2 D
+0 -14 D
+5 -2 D
+10 -1 D
+P
+1382 3063 M
+3 -3 D
+-3 0 D
+-1 3 D
+P
+1351 3050 M
+5 -4 D
+-7 2 D
+P
+1364 3039 M
+3 -3 D
+-2 0 D
+P
+1391 3002 M
+1 -1 D
+-1 -2 D
+P
+1392 3043 M
+-1 -3 D
+P
+FO
+1409 2929 M
+1 1 D
+-1 1 D
+-2 -1 D
+P
+FO
+1546 2835 M
+-3 4 D
+1 7 D
+-2 10 D
+-3 2 D
+-2 6 D
+4 10 D
+-2 4 D
+6 -1 D
+10 -7 D
+4 0 D
+1 4 D
+7 -4 D
+1 -4 D
+8 -2 D
+1 1 D
+3 -2 D
+1 -12 D
+7 -12 D
+1 -4 D
+65 0 D
+0 236 D
+-204 0 D
+-20 0 D
+1 -3 D
+-3 3 D
+-11 0 D
+0 -18 D
+2 0 D
+0 -6 D
+-2 -1 D
+0 -107 D
+11 0 D
+6 -3 D
+4 -5 D
+7 -2 D
+7 1 D
+2 -1 D
+1 -6 D
+7 0 D
+16 -11 D
+4 -6 D
+0 -8 D
+2 1 D
+2 -2 D
+-3 1 D
+4 -9 D
+3 -2 D
+1 -5 D
+6 -4 D
+0 -1 D
+-3 -1 D
+2 -2 D
+-1 -3 D
+8 -7 D
+1 -7 D
+6 -3 D
+2 -11 D
+0 4 D
+1 -2 D
+-1 -1 D
+4 -2 D
+0 -7 D
+P
+1645 3021 M
+-2 -6 D
+-6 -4 D
+1 -1 D
+-5 -5 D
+5 0 D
+-12 -3 D
+1 -2 D
+-3 1 D
+-5 -3 D
+-2 3 D
+3 0 D
+-1 1 D
+3 -1 D
+1 3 D
+2 -2 D
+1 2 D
+5 -1 D
+1 5 D
+4 1 D
+0 4 D
+2 -1 D
+P
+1620 3000 M
+-1 -1 D
+P
+1551 2990 M
+-1 -9 D
+2 -3 D
+3 -1 D
+4 6 D
+9 -11 D
+-9 9 D
+-3 -4 D
+-5 0 D
+0 3 D
+-3 -2 D
+-2 2 D
+-4 -3 D
+-2 1 D
+-1 2 D
+9 0 D
+1 8 D
+2 0 D
+P
+1440 3058 M
+-3 -1 D
+2 -1 D
+0 -2 D
+-3 3 D
+P
+1513 2918 M
+8 -6 D
+-2 -4 D
+-8 7 D
+-1 2 D
+P
+1452 3064 M
+3 2 D
+-1 -4 D
+-1 1 D
+1 1 D
+-3 0 D
+P
+1625 2924 M
+6 -3 D
+-5 1 D
+P
+1447 3043 M
+2 -5 D
+-2 2 D
+P
+1538 2881 M
+2 0 D
+3 -3 D
+P
+1438 3023 M
+2 2 D
+3 -1 D
+-2 -2 D
+P
+1544 2966 M
+1 -5 D
+-2 2 D
+P
+1551 2941 M
+7 -5 D
+-8 4 D
+P
+1427 3001 M
+-2 -1 D
+P
+1454 2968 M
+0 2 D
+2 -2 D
+P
+1447 3016 M
+0 -2 D
+P
+1607 3056 M
+1 0 D
+-1 1 D
+P
+FO
+1417 2928 M
+1 0 D
+-1 1 D
+P
+FO
+1452 2905 M
+-2 1 D
+3 -4 D
+3 -1 D
+P
+FO
+1427 2929 M
+2 1 D
+-10 1 D
+3 -3 D
+P
+FO
+1450 2917 M
+4 -4 D
+3 0 D
+-1 2 D
+P
+FO
+1543 2874 M
+1 1 D
+-4 2 D
+2 -3 D
+P
+FO
+1429 2912 M
+-2 0 D
+4 -1 D
+P
+FO
+1545 2875 M
+-2 1 D
+P
+FO
+1432 2929 M
+-2 0 D
+P
+FO
+1654 2835 M
+236 0 D
+0 236 D
+-236 0 D
+P
+1791 2965 M
+0 -3 D
+-3 0 D
+3 1 D
+-1 1 D
+1 2 D
+P
+1853 2969 M
+-6 -5 D
+4 6 D
+2 0 D
+P
+1808 2962 M
+1 -1 D
+-4 0 D
+P
+1718 3035 M
+7 1 D
+-9 -2 D
+2 2 D
+P
+1719 2908 M
+-1 -5 D
+0 5 D
+P
+1861 2897 M
+2 -2 D
+P
+1668 2848 M
+0 -3 D
+P
+1815 3030 M
+-2 -1 D
+P
+1721 2913 M
+-1 -4 D
+1 5 D
+P
+1789 2899 M
+-2 -3 D
+P
+1796 2882 M
+2 -2 D
+P
+FO
+2047 2835 M
+1 1 D
+0 -1 D
+40 0 D
+-1 1 D
+39 -1 D
+0 2 D
+-4 -2 D
+-5 1 D
+-1 4 D
+5 4 D
+5 -2 D
+0 229 D
+-236 0 D
+0 -236 D
+P
+2032 2881 M
+3 -2 D
+2 -7 D
+2 1 D
+-1 -2 D
+2 0 D
+-1 -1 D
+2 -1 D
+0 -7 D
+-5 2 D
+3 1 D
+-2 0 D
+2 2 D
+-4 0 D
+2 2 D
+-3 8 D
+-4 5 D
+P
+1972 2931 M
+0 -6 D
+-6 0 D
+0 -1 D
+-3 3 D
+-2 0 D
+0 1 D
+2 1 D
+1 -3 D
+3 0 D
+1 2 D
+2 0 D
+-1 2 D
+P
+2049 2943 M
+-6 0 D
+3 2 D
+1 -1 D
+3 1 D
+P
+2115 2843 M
+1 -3 D
+-3 -1 D
+-1 2 D
+P
+1928 2849 M
+1 -1 D
+-2 0 D
+P
+1927 2856 M
+2 -1 D
+-2 -3 D
+P
+FO
+2129 2835 M
+3 4 D
+-1 -2 D
+-2 1 D
+-3 -1 D
+0 -2 D
+P
+FO
+2139 2835 M
+0 1 D
+-3 -1 D
+P
+FO
+2153 2835 M
+-1 1 D
+P
+FO
+2259 2835 M
+0 1 D
+4 1 D
+0 1 D
+1 -2 D
+4 1 D
+4 -2 D
+50 0 D
+1 5 D
+-1 1 D
+2 1 D
+0 3 D
+2 -1 D
+0 -1 D
+-3 -1 D
+0 -7 D
+7 0 D
+-2 12 D
+1 4 D
+-3 1 D
+1 1 D
+1 -1 D
+1 6 D
+-2 -2 D
+1 1 D
+-2 1 D
+2 1 D
+-2 1 D
+1 -1 D
+-1 1 D
+2 -1 D
+0 1 D
+0 -1 D
+1 2 D
+-1 0 D
+1 4 D
+-1 1 D
+2 0 D
+-2 0 D
+3 0 D
+-2 1 D
+2 0 D
+0 2 D
+1 -2 D
+2 4 D
+-3 -2 D
+1 2 D
+-2 0 D
+4 1 D
+-3 2 D
+3 -2 D
+-2 2 D
+2 1 D
+-3 2 D
+4 -1 D
+0 3 D
+1 0 D
+-2 1 D
+5 -1 D
+1 1 D
+-1 1 D
+3 0 D
+-1 2 D
+1 3 D
+2 0 D
+-1 -2 D
+3 3 D
+-3 2 D
+0 5 D
+5 -6 D
+3 4 D
+-3 2 D
+4 0 D
+0 1 D
+2 -2 D
+4 2 D
+-1 1 D
+1 -1 D
+4 1 D
+0 16 D
+-1 -1 D
+-2 2 D
+3 1 D
+0 157 D
+-236 0 D
+0 -229 D
+8 -4 D
+2 2 D
+3 -1 D
+3 3 D
+-2 1 D
+4 0 D
+-1 -1 D
+10 2 D
+-2 1 D
+5 -2 D
+3 1 D
+3 -2 D
+3 2 D
+5 -2 D
+0 7 D
+2 -1 D
+1 5 D
+2 -9 D
+5 -2 D
+-7 -2 D
+12 2 D
+-3 0 D
+0 1 D
+2 -1 D
+3 4 D
+2 -1 D
+-5 -4 D
+5 1 D
+-2 0 D
+6 3 D
+0 3 D
+2 -3 D
+1 4 D
+0 -2 D
+4 -2 D
+-8 -2 D
+15 1 D
+2 3 D
+1 -2 D
+6 1 D
+2 -3 D
+-3 2 D
+-7 -1 D
+11 -2 D
+8 -4 D
+0 2 D
+-3 0 D
+-1 2 D
+3 0 D
+1 -2 D
+3 2 D
+0 -2 D
+-3 -1 D
+3 -2 D
+2 1 D
+1 -3 D
+2 1 D
+-2 -1 D
+-5 3 D
+4 -3 D
+P
+2168 2999 M
+8 -19 D
+-2 -5 D
+-2 3 D
+3 1 D
+-3 7 D
+-1 -4 D
+-1 2 D
+2 5 D
+-5 11 D
+P
+2306 2928 M
+5 -7 D
+-10 0 D
+8 1 D
+-6 5 D
+-2 -2 D
+2 3 D
+-2 0 D
+0 2 D
+5 -5 D
+-1 4 D
+P
+2295 2943 M
+2 -1 D
+-2 -5 D
+-3 1 D
+3 1 D
+-4 1 D
+-4 3 D
+8 -3 D
+0 2 D
+-2 1 D
+P
+2238 2992 M
+3 -1 D
+-3 0 D
+2 -2 D
+-1 -1 D
+-2 3 D
+-4 -2 D
+3 3 D
+P
+2271 2940 M
+2 -2 D
+-4 -4 D
+-3 -1 D
+-1 2 D
+4 1 D
+-1 3 D
+3 -2 D
+P
+2250 2854 M
+2 -1 D
+-5 -2 D
+-2 1 D
+0 4 D
+1 -3 D
+4 2 D
+P
+2351 2919 M
+2 -2 D
+5 1 D
+1 -3 D
+-6 1 D
+-3 4 D
+P
+2172 3001 M
+4 -4 D
+-2 -2 D
+2 -5 D
+-4 10 D
+-4 0 D
+P
+2329 2932 M
+4 0 D
+0 -2 D
+-7 1 D
+P
+2185 2949 M
+8 -2 D
+6 -4 D
+-11 5 D
+-8 -1 D
+P
+2216 2919 M
+-2 -3 D
+-1 0 D
+P
+2209 2905 M
+1 -4 D
+-2 5 D
+P
+FO
+2330 2861 M
+2 4 D
+-2 0 D
+-1 -2 D
+P
+FO
+2334 2874 M
+1 -2 D
+0 3 D
+P
+FO
+2335 2876 M
+3 2 D
+-3 0 D
+P
+FO
+2197 2843 M
+-7 -1 D
+18 2 D
+P
+FO
+2170 2840 M
+-4 0 D
+5 1 D
+P
+FO
+2352 2889 M
+-2 1 D
+-2 -2 D
+P
+FO
+2131 2836 M
+2 -1 D
+1 2 D
+P
+FO
+2142 2836 M
+2 0 D
+0 2 D
+P
+FO
+2227 2837 M
+2 -1 D
+P
+FO
+2141 2836 M
+1 0 D
+P
+FO
+2353 2893 M
+0 2 D
+P
+FO
+2349 2893 M
+2 0 D
+P
+FO
+2160 2840 M
+-5 0 D
+P
+FO
+2331 2867 M
+1 -1 D
+P
+FO
+2135 2838 M
+2 1 D
+-2 0 D
+P
+FO
+2146 2840 M
+2 0 D
+P
+FO
+2144 2836 M
+1 0 D
+P
+FO
+2132 2838 M
+2 0 D
+P
+FO
+2161 2840 M
+3 0 D
+P
+FO
+2332 2874 M
+2 0 D
+P
+FO
+2362 2914 M
+1 -2 D
+-1 0 D
+0 -16 D
+3 3 D
+-2 1 D
+1 2 D
+2 -2 D
+7 6 D
+4 0 D
+0 1 D
+5 3 D
+-3 4 D
+3 -4 D
+2 7 D
+7 7 D
+9 3 D
+9 -1 D
+1 7 D
+2 -3 D
+5 7 D
+7 4 D
+0 2 D
+2 0 D
+3 3 D
+1 -1 D
+0 2 D
+1 -2 D
+9 1 D
+-2 1 D
+2 1 D
+2 -2 D
+0 2 D
+3 -2 D
+2 4 D
+2 0 D
+2 3 D
+-3 1 D
+1 -2 D
+-3 -1 D
+0 4 D
+-1 -3 D
+-4 0 D
+-2 -2 D
+-5 3 D
+1 2 D
+3 -3 D
+6 4 D
+-2 2 D
+2 -1 D
+-1 1 D
+3 1 D
+-13 5 D
+10 -2 D
+-2 4 D
+5 -1 D
+-3 0 D
+1 -3 D
+2 0 D
+1 2 D
+0 -3 D
+1 2 D
+5 -3 D
+6 8 D
+1 -2 D
+3 2 D
+0 6 D
+-3 2 D
+1 -1 D
+-4 -1 D
+-1 -6 D
+-1 8 D
+-6 -1 D
+2 -1 D
+-4 2 D
+-8 -1 D
+1 4 D
+5 -2 D
+5 2 D
+-4 2 D
+6 -2 D
+-2 2 D
+2 -2 D
+3 1 D
+-3 3 D
+7 -3 D
+-1 3 D
+4 -5 D
+-4 8 D
+0 -1 D
+-3 4 D
+1 1 D
+3 -2 D
+-2 2 D
+1 3 D
+5 -16 D
+5 -6 D
+-11 27 D
+-2 -1 D
+-5 2 D
+0 -3 D
+-2 2 D
+-4 -1 D
+1 2 D
+-4 2 D
+0 4 D
+-2 -2 D
+-6 3 D
+8 -1 D
+6 -6 D
+2 1 D
+1 3 D
+-8 4 D
+-4 6 D
+7 -7 D
+3 0 D
+-2 1 D
+0 3 D
+4 -3 D
+1 4 D
+-4 1 D
+3 1 D
+-6 2 D
+-9 8 D
+8 -5 D
+2 -3 D
+1 1 D
+2 -2 D
+2 1 D
+-2 1 D
+3 5 D
+-5 2 D
+-4 4 D
+-9 1 D
+-1 5 D
+-7 -1 D
+2 7 D
+2 -2 D
+-2 -2 D
+0 -2 D
+3 1 D
+1 -1 D
+1 2 D
+3 -4 D
+4 -2 D
+2 1 D
+8 -5 D
+-1 6 D
+-3 0 D
+3 2 D
+-3 3 D
+-2 6 D
+2 2 D
+-1 2 D
+2 0 D
+-3 3 D
+3 -2 D
+1 1 D
+-3 1 D
+3 1 D
+-5 3 D
+3 1 D
+1 -2 D
+1 1 D
+-2 1 D
+2 -1 D
+1 4 D
+2 -3 D
+0 4 D
+1 0 D
+0 -3 D
+4 5 D
+3 1 D
+-2 -3 D
+4 2 D
+0 -2 D
+-8 -3 D
+-2 -4 D
+1 -2 D
+2 1 D
+1 -1 D
+-3 -2 D
+-2 1 D
+-1 -4 D
+1 2 D
+1 -1 D
+1 1 D
+1 -2 D
+2 0 D
+-2 0 D
+1 -3 D
+-2 3 D
+-2 -5 D
+1 4 D
+0 -2 D
+1 2 D
+1 -3 D
+4 -3 D
+2 3 D
+-2 -3 D
+-6 2 D
+0 -3 D
+2 1 D
+-2 -3 D
+-1 1 D
+2 -4 D
+0 2 D
+5 -4 D
+-1 2 D
+2 1 D
+1 -3 D
+2 4 D
+-1 -3 D
+2 0 D
+-3 -2 D
+4 -1 D
+-2 -2 D
+3 1 D
+-4 -3 D
+1 -1 D
+5 1 D
+-3 -2 D
+3 0 D
+-1 -2 D
+-3 0 D
+1 -2 D
+-4 -4 D
+2 0 D
+-2 0 D
+0 -2 D
+1 1 D
+-3 -5 D
+2 -4 D
+1 5 D
+3 1 D
+-1 2 D
+3 1 D
+0 3 D
+6 6 D
+-2 -1 D
+6 9 D
+2 1 D
+0 -1 D
+2 2 D
+-2 2 D
+2 0 D
+1 3 D
+-1 -5 D
+1 7 D
+-3 0 D
+2 0 D
+-1 2 D
+2 -2 D
+-1 5 D
+-5 3 D
+-2 7 D
+-5 5 D
+2 7 D
+3 1 D
+-4 -4 D
+2 -1 D
+-1 -3 D
+9 -7 D
+2 1 D
+4 -1 D
+-2 -5 D
+3 0 D
+5 6 D
+-2 -1 D
+2 3 D
+-1 1 D
+6 1 D
+-2 1 D
+3 2 D
+-1 1 D
+3 -1 D
+-1 2 D
+4 3 D
+1 5 D
+-1 1 D
+1 1 D
+-139 0 D
+P
+2394 2995 M
+4 -4 D
+5 0 D
+-2 -5 D
+1 4 D
+-6 -1 D
+1 2 D
+-5 1 D
+P
+2409 2991 M
+1 -2 D
+2 1 D
+6 -2 D
+-7 0 D
+-5 2 D
+P
+2369 3005 M
+5 -4 D
+-5 0 D
+2 0 D
+-3 4 D
+P
+FO
+2468 2971 M
+0 -12 D
+-5 -2 D
+5 1 D
+1 9 D
+P
+FO
+2433 2945 M
+-2 -1 D
+10 2 D
+P
+FO
+2465 3015 M
+1 -1 D
+1 2 D
+P
+FO
+2409 2926 M
+1 -1 D
+2 6 D
+P
+FO
+2457 3023 M
+-2 1 D
+1 -2 D
+P
+FO
+2459 3004 M
+1 3 D
+P
+FO
+2444 2944 M
+6 6 D
+P
+FO
+2464 3012 M
+2 2 D
+P
+FO
+2470 3021 M
+3 2 D
+P
+FO
+2457 3023 M
+-1 2 D
+P
+FO
+2455 3028 M
+1 -1 D
+P
+FO
+2429 2944 M
+1 0 D
+P
+FO
+2450 2950 M
+2 1 D
+P
+FO
+2368 2901 M
+0 1 D
+P
+FO
+2457 2954 M
+5 3 D
+P
+FO
+2494 3056 M
+2 2 D
+P
+FO
+2459 2975 M
+1 1 D
+P
+FO
+2486 3048 M
+1 2 D
+P
+FO
+2495 3058 M
+1 1 D
+P
+FO
+2488 3052 M
+3 2 D
+-3 -1 D
+P
+FO
+2474 3024 M
+-1 0 D
+-2 -4 D
+P
+FO
+2459 3004 M
+2 1 D
+P
+FO
+2460 3005 M
+2 1 D
+P
+FO
+2428 2944 M
+1 1 D
+P
+FO
+2459 3007 M
+1 1 D
+P
+FO
+2443 2946 M
+1 -1 D
+P
+FO
+2440 2946 M
+2 0 D
+P
+FO
+2458 3003 M
+2 1 D
+P
+FO
+2426 2942 M
+2 1 D
+P
+FO
+2493 3057 M
+1 -1 D
+P
+FO
+2452 2951 M
+1 1 D
+P
+FO
+2454 2953 M
+2 1 D
+P
+FO
+2720 2888 M
+4 2 D
+-3 -2 D
+-1 1 D
+P
+FO
+2725 2891 M
+-2 -1 D
+P
+FO
+2724 2891 M
+-1 -1 D
+P
+FO
+3513 3058 M
+2 -2 D
+2 2 D
+-2 2 D
+P
+FO
+3641 3020 M
+4 -3 D
+13 1 D
+-1 2 D
+-9 -1 D
+-5 2 D
+P
+FO
+3657 3000 M
+4 -2 D
+-1 2 D
+P
+FO
+3578 3035 M
+12 -2 D
+-9 4 D
+P
+FO
+3605 3041 M
+4 -2 D
+4 1 D
+-1 2 D
+P
+FO
+3571 3038 M
+2 -2 D
+3 1 D
+-2 2 D
+P
+FO
+3590 3039 M
+-7 2 D
+13 -5 D
+P
+FO
+3591 3049 M
+-2 0 D
+3 -1 D
+P
+FO
+3850 2901 M
+-4 1 D
+-2 -1 D
+8 -4 D
+6 2 D
+P
+FO
+3861 2895 M
+2 -2 D
+P
+FO
+3862 2892 M
+1 -1 D
+P
+FO
+4252 2973 M
+-4 -2 D
+-5 3 D
+-6 -4 D
+-4 1 D
+-9 -5 D
+-2 -5 D
+-16 -6 D
+-11 1 D
+-5 -1 D
+-6 3 D
+3 -3 D
+-2 0 D
+-2 2 D
+0 2 D
+1 -1 D
+-2 5 D
+-3 -4 D
+-6 -2 D
+-9 3 D
+-2 -2 D
+-3 1 D
+-10 -3 D
+-8 2 D
+-13 8 D
+-3 6 D
+2 2 D
+-4 0 D
+-8 -3 D
+-3 0 D
+-5 -13 D
+-16 -28 D
+-17 -10 D
+-23 -8 D
+-6 -7 D
+-12 -10 D
+0 -9 D
+-14 -18 D
+1 -14 D
+-2 -4 D
+7 -6 D
+-1 -8 D
+-2 -1 D
+230 0 D
+P
+FO
+4252 3044 M
+-6 6 D
+-2 7 D
+8 14 D
+-211 0 D
+-6 -14 D
+-5 -1 D
+1 -3 D
+-3 -11 D
+1 -2 D
+7 0 D
+5 7 D
+-2 -2 D
+2 -3 D
+-3 -2 D
+2 0 D
+-3 -1 D
+1 -1 D
+-2 2 D
+-3 -1 D
+2 -3 D
+-1 -3 D
+8 3 D
+2 -1 D
+2 2 D
+0 -3 D
+2 -1 D
+-5 1 D
+1 -1 D
+-3 2 D
+3 -4 D
+-2 -8 D
+3 -6 D
+-6 -16 D
+12 3 D
+13 -4 D
+-2 1 D
+7 0 D
+8 3 D
+0 2 D
+1 -2 D
+7 1 D
+3 -1 D
+-1 2 D
+1 -1 D
+2 2 D
+-2 -3 D
+10 -5 D
+4 -4 D
+-2 -2 D
+1 -2 D
+4 -1 D
+-1 -1 D
+2 -1 D
+-3 1 D
+6 -8 D
+4 0 D
+6 -5 D
+5 2 D
+0 3 D
+2 -2 D
+4 7 D
+12 2 D
+6 5 D
+13 1 D
+10 -1 D
+12 1 D
+5 -2 D
+3 4 D
+11 -2 D
+5 5 D
+3 6 D
+8 7 D
+5 2 D
+3 -1 D
+9 1 D
+-3 3 D
+2 2 D
+3 9 D
+3 0 D
+0 4 D
+12 6 D
+P
+4111 3067 M
+7 -1 D
+7 2 D
+2 -2 D
+-13 -1 D
+P
+4135 3057 M
+4 -4 D
+-5 3 D
+-5 -5 D
+4 6 D
+P
+4208 3034 M
+2 -1 D
+-2 -1 D
+P
+4198 3066 M
+4 -6 D
+-4 4 D
+P
+4184 3034 M
+-1 -1 D
+3 1 D
+-3 -2 D
+P
+4066 3050 M
+-3 -2 D
+P
+4134 3022 M
+-2 -2 D
+P
+4142 3007 M
+0 -1 D
+P
+4226 3066 M
+0 -1 D
+P
+4214 3064 M
+2 -4 D
+P
+4123 3046 M
+6 0 D
+0 -1 D
+P
+4233 3054 M
+3 -4 D
+P
+4132 3028 M
+4 -2 D
+P
+4126 3049 M
+-6 -2 D
+P
+4152 3006 M
+-3 1 D
+P
+4110 3026 M
+2 -3 D
+P
+4244 3056 M
+-1 -2 D
+P
+4176 3022 M
+-4 -1 D
+P
+4118 2997 M
+-1 -2 D
+P
+FO
+4234 3018 M
+1 -3 D
+P
+FO
+4068 3001 M
+1 0 D
+P
+FO
+4064 3000 M
+2 -1 D
+P
+FO
+4252 2598 M
+236 0 D
+0 237 D
+-236 0 D
+P
+FO
+4488 2598 M
+236 0 D
+0 237 D
+-236 0 D
+P
+FO
+4724 2598 M
+237 0 D
+0 237 D
+-237 0 D
+P
+FO
+5130 2598 M
+0 11 D
+2 2 D
+-4 12 D
+1 4 D
+3 -2 D
+0 -3 D
+2 2 D
+-9 7 D
+-2 10 D
+1 6 D
+-11 7 D
+-5 6 D
+-7 2 D
+-6 6 D
+-5 13 D
+1 11 D
+0 -1 D
+6 0 D
+-7 5 D
+-8 9 D
+-14 29 D
+-14 22 D
+1 4 D
+-4 6 D
+1 3 D
+-4 3 D
+-5 7 D
+3 0 D
+-3 4 D
+3 -1 D
+-18 19 D
+-1 4 D
+-4 5 D
+1 3 D
+-2 6 D
+-6 6 D
+4 6 D
+-1 2 D
+2 1 D
+0 -1 D
+0 2 D
+-60 0 D
+0 -237 D
+P
+5029 2693 M
+2 -7 D
+-2 -3 D
+3 -2 D
+-3 1 D
+3 -7 D
+-2 0 D
+1 -2 D
+-3 0 D
+2 -4 D
+3 -2 D
+-3 0 D
+-5 4 D
+0 -3 D
+-3 -1 D
+0 -4 D
+-6 -3 D
+0 -2 D
+-2 0 D
+1 2 D
+-3 3 D
+-3 -1 D
+-3 -3 D
+1 -2 D
+-4 -1 D
+1 -2 D
+-4 -1 D
+0 -2 D
+-5 -2 D
+-3 -8 D
+-7 -7 D
+3 3 D
+1 4 D
+3 3 D
+1 5 D
+8 6 D
+-1 2 D
+4 0 D
+-4 4 D
+4 -2 D
+1 2 D
+7 4 D
+4 -5 D
+5 4 D
+0 4 D
+2 1 D
+2 6 D
+4 2 D
+-2 1 D
+2 1 D
+-2 1 D
+1 2 D
+-6 -1 D
+3 1 D
+-1 2 D
+3 -1 D
+2 5 D
+-3 2 D
+P
+5030 2679 M
+0 -1 D
+P
+4980 2823 M
+-5 -2 D
+-5 1 D
+P
+FO
+5197 2604 M
+P
+FO
+5021 2835 M
+0 -2 D
+2 -1 D
+2 -10 D
+11 -11 D
+1 -11 D
+13 -12 D
+11 -7 D
+-1 1 D
+5 5 D
+0 8 D
+5 10 D
+3 13 D
+3 4 D
+3 1 D
+-6 -20 D
+1 -3 D
+-5 -11 D
+1 -1 D
+1 3 D
+2 -2 D
+6 1 D
+5 -1 D
+-1 -2 D
+6 -5 D
+4 -8 D
+5 -5 D
+0 -3 D
+10 -11 D
+6 -12 D
+5 -2 D
+-1 -4 D
+1 -3 D
+3 0 D
+3 -2 D
+7 -11 D
+0 -8 D
+-2 -1 D
+7 -9 D
+-1 -1 D
+4 -3 D
+2 1 D
+4 -4 D
+2 2 D
+1 -2 D
+11 -8 D
+9 -16 D
+0 -3 D
+2 -1 D
+1 -2 D
+-3 3 D
+3 -6 D
+2 1 D
+1 -10 D
+2 1 D
+-4 -7 D
+1 1 D
+-1 -4 D
+0 2 D
+-1 -3 D
+3 -5 D
+2 1 D
+-2 -1 D
+3 -7 D
+-2 -2 D
+2 -6 D
+13 -16 D
+5 -4 D
+-1 2 D
+2 -1 D
+0 230 D
+P
+FO
+5118 2729 M
+5 -4 D
+2 1 D
+-5 3 D
+3 -2 D
+-1 2 D
+P
+FO
+5114 2732 M
+5 -2 D
+-4 1 D
+0 2 D
+P
+FO
+5115 2735 M
+2 -2 D
+-2 2 D
+2 2 D
+P
+FO
+5049 2778 M
+1 -1 D
+0 2 D
+P
+FO
+5126 2726 M
+1 1 D
+-2 1 D
+P
+FO
+5093 2675 M
+3 -1 D
+P
+FO
+5053 2770 M
+1 -2 D
+P
+FO
+5122 2729 M
+1 1 D
+P
+FO
+5116 2730 M
+2 -3 D
+P
+FO
+5096 2767 M
+1 -1 D
+P
+FO
+5083 2787 M
+1 -1 D
+P
+FO
+5129 2710 M
+1 -1 D
+-1 2 D
+P
+FO
+5103 2755 M
+2 -1 D
+-2 2 D
+P
+FO
+5084 2780 M
+2 -1 D
+P
+FO
+5125 2724 M
+1 1 D
+P
+FO
+5107 2664 M
+1 0 D
+P
+FO
+5130 2721 M
+0 1 D
+P
+FO
+5118 2727 M
+1 -1 D
+P
+FO
+5175 2652 M
+0 1 D
+P
+FO
+5110 2662 M
+1 -1 D
+P
+FO
+5154 2690 M
+1 0 D
+P
+FO
+5172 2649 M
+0 -1 D
+P
+FO
+5115 2655 M
+1 -1 D
+P
+FO
+5124 2728 M
+2 0 D
+P
+FO
+5067 2787 M
+3 -1 D
+P
+FO
+5055 2775 M
+-2 1 D
+P
+FO
+5132 2616 M
+1 2 D
+P
+FO
+5071 2786 M
+2 0 D
+P
+FO
+5124 2730 M
+1 -1 D
+-1 2 D
+P
+FO
+5433 2757 M
+0 3 D
+-7 3 D
+-3 5 D
+-2 0 D
+1 -2 D
+-4 1 D
+1 1 D
+-2 0 D
+0 3 D
+-2 0 D
+1 2 D
+-4 0 D
+5 1 D
+-2 2 D
+-9 2 D
+1 2 D
+-3 1 D
+1 2 D
+0 -1 D
+1 1 D
+0 -2 D
+1 2 D
+-4 3 D
+2 1 D
+-4 2 D
+-2 8 D
+-4 5 D
+0 3 D
+-2 1 D
+-3 5 D
+-2 8 D
+-2 1 D
+-4 -1 D
+0 1 D
+-3 0 D
+6 5 D
+5 -1 D
+-5 11 D
+-188 0 D
+0 -230 D
+2 0 D
+9 -7 D
+225 0 D
+P
+FO
+5396 2835 M
+0 -1 D
+0 1 D
+-4 0 D
+7 -2 D
+-2 2 D
+4 -2 D
+0 2 D
+P
+FO
+5387 2835 M
+-1 -1 D
+3 1 D
+P
+FO
+5197 2604 M
+5 -2 D
+P
+FO
+5391 2825 M
+4 4 D
+-5 5 D
+-2 0 D
+2 -3 D
+-1 1 D
+-1 -2 D
+P
+FO
+5420 2770 M
+2 2 D
+1 -2 D
+3 1 D
+-4 1 D
+P
+FO
+5420 2769 M
+2 -1 D
+-1 3 D
+P
+FO
+5392 2821 M
+3 -1 D
+-2 2 D
+P
+FO
+5617 2598 M
+1 6 D
+9 9 D
+1 -1 D
+-1 -4 D
+6 -1 D
+3 6 D
+4 3 D
+-2 1 D
+3 5 D
+6 6 D
+7 4 D
+11 19 D
+-1 7 D
+-6 0 D
+-18 24 D
+-5 2 D
+-6 0 D
+-26 7 D
+-13 13 D
+-5 9 D
+-2 16 D
+-2 2 D
+5 8 D
+-2 2 D
+2 1 D
+-3 0 D
+1 3 D
+2 -2 D
+-1 2 D
+1 1 D
+-2 1 D
+2 1 D
+-2 1 D
+-2 -2 D
+2 -1 D
+-2 1 D
+0 -2 D
+1 0 D
+-3 0 D
+0 1 D
+-6 -11 D
+-4 -2 D
+-4 -4 D
+-2 0 D
+0 1 D
+-2 -4 D
+-9 -9 D
+-7 -4 D
+-1 -2 D
+-1 1 D
+-2 -7 D
+-2 0 D
+2 -1 D
+-3 0 D
+2 -1 D
+-5 2 D
+-1 -1 D
+4 -2 D
+-1 -2 D
+-5 -2 D
+1 2 D
+-2 1 D
+1 -2 D
+-2 2 D
+-1 -3 D
+3 -1 D
+-15 -3 D
+-4 2 D
+-3 -1 D
+-4 2 D
+-11 -1 D
+-2 2 D
+-6 -5 D
+-5 -1 D
+0 -1 D
+-2 2 D
+-2 -1 D
+-3 1 D
+-1 6 D
+-2 -1 D
+0 1 D
+-1 -1 D
+-1 4 D
+0 -3 D
+-4 2 D
+-3 -1 D
+0 3 D
+5 3 D
+-3 2 D
+-2 -3 D
+0 2 D
+-2 1 D
+3 0 D
+0 -1 D
+7 10 D
+-1 6 D
+-2 1 D
+-1 5 D
+2 3 D
+-1 1 D
+2 1 D
+-2 0 D
+1 3 D
+1 -2 D
+-1 3 D
+-4 1 D
+-1 4 D
+-2 1 D
+-7 -4 D
+0 -5 D
+-1 1 D
+-1 -3 D
+2 -2 D
+-2 -3 D
+-1 4 D
+-1 -1 D
+1 -3 D
+-2 0 D
+3 -16 D
+-3 -2 D
+-5 8 D
+-1 8 D
+-3 3 D
+0 -3 D
+-6 8 D
+3 -3 D
+-3 9 D
+-3 0 D
+1 5 D
+3 -4 D
+1 11 D
+-1 -2 D
+-3 1 D
+-1 6 D
+0 -159 D
+P
+FO
+5436 2835 M
+1 -2 D
+12 -11 D
+0 -8 D
+6 -1 D
+0 -4 D
+-2 2 D
+-1 -2 D
+2 -2 D
+2 0 D
+0 1 D
+3 -9 D
+7 -13 D
+7 -3 D
+8 1 D
+4 -4 D
+6 -1 D
+5 -5 D
+-2 -1 D
+21 -10 D
+1 -3 D
+5 -3 D
+13 1 D
+3 -4 D
+9 -2 D
+11 7 D
+6 -1 D
+3 5 D
+8 1 D
+4 3 D
+6 2 D
+7 -1 D
+0 -1 D
+4 -1 D
+2 -3 D
+1 1 D
+-2 -1 D
+3 -4 D
+1 -10 D
+4 -5 D
+-1 -3 D
+3 -6 D
+12 -2 D
+-2 -1 D
+5 1 D
+4 -3 D
+4 2 D
+4 -2 D
+0 2 D
+15 -6 D
+3 1 D
+-2 -1 D
+0 2 D
+3 0 D
+0 -1 D
+3 0 D
+-1 2 D
+15 -4 D
+0 110 D
+P
+FO
+5433 2758 M
+4 -3 D
+-4 4 D
+P
+FO
+5575 2757 M
+6 6 D
+-3 1 D
+-6 -3 D
+-3 2 D
+1 -4 D
+-13 -3 D
+1 -2 D
+P
+FO
+5448 2740 M
+0 3 D
+-2 2 D
+1 1 D
+-3 0 D
+0 -7 D
+3 -4 D
+P
+FO
+5519 2697 M
+3 -1 D
+5 1 D
+-3 2 D
+P
+FO
+5537 2705 M
+3 0 D
+-1 2 D
+P
+FO
+5637 2605 M
+0 -3 D
+8 8 D
+-1 5 D
+P
+FO
+5451 2732 M
+1 -3 D
+-1 4 D
+P
+FO
+5528 2754 M
+-3 -1 D
+4 -1 D
+P
+FO
+5494 2700 M
+0 -1 D
+2 2 D
+P
+FO
+5534 2702 M
+1 -2 D
+1 1 D
+P
+FO
+5487 2705 M
+1 -1 D
+0 2 D
+P
+FO
+5532 2701 M
+2 0 D
+0 1 D
+-2 0 D
+P
+FO
+5539 2738 M
+2 0 D
+P
+FO
+5454 2813 M
+0 -2 D
+P
+FO
+5529 2698 M
+2 -1 D
+P
+FO
+5534 2701 M
+1 -2 D
+P
+FO
+5649 2727 M
+2 1 D
+P
+FO
+5565 2730 M
+3 2 D
+P
+FO
+5440 2730 M
+1 -2 D
+P
+FO
+5466 2785 M
+1 -1 D
+-1 2 D
+P
+FO
+5513 2698 M
+1 -1 D
+P
+FO
+5447 2744 M
+1 -1 D
+P
+FO
+5567 2760 M
+1 1 D
+-1 0 D
+P
+FO
+5539 2707 M
+2 1 D
+P
+FO
+5447 2822 M
+1 0 D
+-1 1 D
+P
+FO
+5529 2698 M
+1 -1 D
+P
+FO
+5540 2706 M
+1 0 D
+P
+FO
+5537 2699 M
+1 2 D
+P
+FO
+5634 2731 M
+1 0 D
+P
+FO
+5441 2818 M
+1 1 D
+P
+FO
+5541 2708 M
+1 1 D
+P
+FO
+5463 2744 M
+1 -1 D
+P
+FO
+5508 2760 M
+5 -1 D
+P
+FO
+5582 2760 M
+3 1 D
+P
+FO
+5585 2765 M
+2 0 D
+P
+FO
+5509 2700 M
+3 0 D
+P
+FO
+5571 2755 M
+2 1 D
+P
+FO
+5539 2747 M
+1 -1 D
+P
+FO
+5566 2759 M
+2 1 D
+P
+FO
+5518 2756 M
+2 0 D
+P
+FO
+5440 2817 M
+1 -1 D
+P
+FO
+5442 2744 M
+1 -1 D
+P
+FO
+5528 2697 M
+1 0 D
+P
+FO
+5434 2754 M
+1 0 D
+P
+FO
+5906 2659 M
+-5 -4 D
+-2 2 D
+-1 -4 D
+-3 0 D
+-1 3 D
+-1 -2 D
+-6 -2 D
+-1 4 D
+-3 -1 D
+1 2 D
+-4 -4 D
+26 -26 D
+P
+FO
+5669 2725 M
+5 -1 D
+3 2 D
+0 -2 D
+3 -1 D
+-1 2 D
+3 2 D
+2 -1 D
+0 -3 D
+19 -5 D
+1 3 D
+3 1 D
+-1 -1 D
+5 -1 D
+0 -3 D
+3 2 D
+5 0 D
+-1 1 D
+2 2 D
+4 -2 D
+-1 -1 D
+3 0 D
+-1 2 D
+4 2 D
+11 -1 D
+5 1 D
+7 -2 D
+-1 3 D
+3 1 D
+11 -1 D
+0 2 D
+-3 0 D
+4 2 D
+3 -1 D
+-3 -1 D
+0 -2 D
+7 -2 D
+4 1 D
+1 -3 D
+2 1 D
+-1 2 D
+3 2 D
+10 -1 D
+3 2 D
+8 -1 D
+15 3 D
+5 -2 D
+-1 1 D
+1 1 D
+-4 1 D
+-6 -2 D
+4 4 D
+5 0 D
+3 -5 D
+-1 -1 D
+5 -4 D
+-2 -8 D
+6 0 D
+4 -2 D
+-1 1 D
+6 -1 D
+-4 -3 D
+5 0 D
+-1 -2 D
+-3 0 D
+3 -1 D
+-1 -2 D
+2 1 D
+-2 -3 D
+2 1 D
+1 -2 D
+-3 0 D
+3 -1 D
+-2 -1 D
+1 -3 D
+2 1 D
+1 -2 D
+-2 0 D
+1 -1 D
+1 1 D
+-1 -2 D
+2 0 D
+-1 -1 D
+2 1 D
+-1 -2 D
+2 -1 D
+1 2 D
+0 -2 D
+2 -1 D
+-1 2 D
+3 -2 D
+2 4 D
+-1 -2 D
+4 -3 D
+0 4 D
+1 -2 D
+2 0 D
+4 3 D
+-3 -3 D
+1 -4 D
+3 2 D
+-5 -3 D
+2 -1 D
+1 1 D
+0 -2 D
+2 1 D
+1 6 D
+1 -2 D
+8 3 D
+-6 -4 D
+-3 -5 D
+1 1 D
+0 -1 D
+1 0 D
+4 -5 D
+-2 -1 D
+3 -3 D
+-2 1 D
+14 -8 D
+3 0 D
+0 1 D
+0 -1 D
+9 -2 D
+4 4 D
+3 0 D
+0 168 D
+-237 0 D
+P
+5896 2794 M
+-16 -7 D
+1 -3 D
+-2 -1 D
+2 -2 D
+-4 -2 D
+-3 3 D
+-1 -2 D
+-4 0 D
+-4 -3 D
+2 -4 D
+-4 -2 D
+0 -2 D
+-3 -1 D
+1 -2 D
+-5 -3 D
+1 -16 D
+11 -11 D
+-2 -2 D
+3 -2 D
+-3 -4 D
+-1 -7 D
+2 -1 D
+-2 0 D
+0 -4 D
+-2 0 D
+-1 -2 D
+-2 -1 D
+-2 -10 D
+-3 0 D
+0 -2 D
+-2 0 D
+1 -2 D
+-4 -3 D
+2 -2 D
+4 1 D
+3 -3 D
+-7 1 D
+1 -1 D
+-3 -1 D
+2 3 D
+-5 0 D
+3 1 D
+0 2 D
+4 2 D
+-1 2 D
+2 0 D
+-1 2 D
+3 0 D
+2 11 D
+3 0 D
+-1 1 D
+3 1 D
+1 4 D
+2 0 D
+-2 1 D
+3 11 D
+-2 2 D
+1 2 D
+-3 2 D
+-3 5 D
+-5 4 D
+0 16 D
+5 3 D
+-1 2 D
+3 1 D
+-1 3 D
+4 1 D
+-1 4 D
+4 3 D
+4 0 D
+1 2 D
+3 -2 D
+3 1 D
+-2 2 D
+3 1 D
+-1 3 D
+2 1 D
+0 1 D
+7 2 D
+P
+5862 2718 M
+-4 -5 D
+1 4 D
+P
+5850 2751 M
+2 -2 D
+-3 1 D
+P
+5897 2796 M
+1 1 D
+P
+5716 2828 M
+2 0 D
+P
+FO
+5860 2688 M
+-1 -2 D
+3 0 D
+1 3 D
+P
+FO
+5867 2680 M
+1 -1 D
+2 1 D
+P
+FO
+5839 2710 M
+2 0 D
+P
+FO
+5870 2677 M
+2 0 D
+P
+FO
+5902 2658 M
+2 1 D
+P
+FO
+5884 2656 M
+1 1 D
+P
+FO
+5896 2656 M
+1 0 D
+P
+FO
+5871 2676 M
+2 1 D
+P
+FO
+5837 2710 M
+1 -1 D
+P
+FO
+5869 2679 M
+1 1 D
+P
+FO
+5906 2667 M
+2 0 D
+1 2 D
+2 -1 D
+0 3 D
+1 -3 D
+4 1 D
+-6 -11 D
+-4 1 D
+0 -32 D
+3 -4 D
+16 -8 D
+15 4 D
+1 2 D
+14 6 D
+0 2 D
+5 8 D
+-3 4 D
+1 1 D
+1 -1 D
+0 3 D
+-2 1 D
+2 -1 D
+-2 2 D
+3 2 D
+0 5 D
+2 1 D
+1 -4 D
+2 3 D
+5 -2 D
+4 1 D
+-3 -2 D
+-4 1 D
+-2 -8 D
+5 2 D
+-3 -2 D
+-1 -5 D
+9 0 D
+-3 0 D
+-4 -5 D
+3 0 D
+-4 -4 D
+3 -2 D
+-2 0 D
+0 -3 D
+3 2 D
+-2 -2 D
+4 -1 D
+-3 0 D
+1 -3 D
+2 1 D
+-2 -1 D
+1 -3 D
+3 -1 D
+-2 0 D
+1 -5 D
+-3 -6 D
+-1 -7 D
+172 0 D
+0 237 D
+-236 0 D
+P
+6034 2702 M
+3 3 D
+0 3 D
+2 0 D
+-1 -5 D
+P
+5925 2833 M
+0 1 D
+P
+FO
+5967 2636 M
+4 1 D
+-2 0 D
+P
+FO
+6293 2598 M
+3 5 D
+6 4 D
+-3 -2 D
+3 2 D
+-2 1 D
+1 3 D
+1 -1 D
+7 5 D
+-3 0 D
+1 2 D
+-3 0 D
+2 1 D
+-3 7 D
+2 5 D
+4 5 D
+7 0 D
+10 3 D
+9 10 D
+-4 3 D
+5 -2 D
+-2 -4 D
+3 -10 D
+1 1 D
+-1 3 D
+3 0 D
+0 -3 D
+1 3 D
+0 -2 D
+2 7 D
+1 -3 D
+2 6 D
+2 -1 D
+-1 1 D
+2 0 D
+-1 -9 D
+3 -1 D
+0 3 D
+1 -2 D
+3 -2 D
+0 2 D
+2 -1 D
+-3 6 D
+1 2 D
+2 -4 D
+2 1 D
+1 -2 D
+1 0 D
+2 4 D
+0 -4 D
+2 0 D
+-1 5 D
+2 -2 D
+1 5 D
+0 -3 D
+1 2 D
+0 -3 D
+2 1 D
+0 -3 D
+5 1 D
+-1 4 D
+1 1 D
+-1 3 D
+2 4 D
+0 -11 D
+2 3 D
+0 93 D
+-1 -4 D
+-5 -3 D
+1 -4 D
+-2 -1 D
+-1 -9 D
+2 -3 D
+-2 -1 D
+3 -4 D
+2 -13 D
+-2 4 D
+1 -5 D
+-3 -4 D
+-1 0 D
+2 4 D
+-1 10 D
+-3 9 D
+2 13 D
+2 0 D
+-1 4 D
+7 8 D
+0 94 D
+-236 0 D
+0 -237 D
+P
+6332 2708 M
+2 0 D
+4 -5 D
+8 -2 D
+3 -4 D
+5 0 D
+5 -6 D
+-4 2 D
+-1 3 D
+-6 -1 D
+-2 6 D
+-4 -2 D
+-13 11 D
+-2 8 D
+P
+6342 2700 M
+4 1 D
+-5 0 D
+P
+6221 2639 M
+3 -1 D
+0 2 D
+4 0 D
+3 -3 D
+3 1 D
+1 -2 D
+0 4 D
+2 -4 D
+-5 -3 D
+-5 6 D
+-3 -3 D
+-5 2 D
+P
+6272 2806 M
+1 2 D
+-2 3 D
+3 1 D
+1 -5 D
+P
+6204 2692 M
+-2 1 D
+1 2 D
+10 3 D
+-6 -6 D
+P
+6363 2789 M
+-2 2 D
+2 1 D
+1 -1 D
+P
+6299 2683 M
+2 2 D
+-7 -1 D
+7 2 D
+0 -3 D
+P
+6229 2831 M
+-3 0 D
+5 0 D
+P
+6302 2688 M
+-1 2 D
+2 0 D
+P
+6250 2654 M
+2 -2 D
+P
+6276 2834 M
+2 -3 D
+-2 -1 D
+P
+FO
+6378 2647 M
+0 -1 D
+P
+FO
+6367 2642 M
+2 -2 D
+2 0 D
+-2 4 D
+P
+FO
+6343 2636 M
+2 0 D
+-2 1 D
+P
+FO
+6362 2642 M
+0 -1 D
+1 1 D
+P
+FO
+6347 2638 M
+1 -2 D
+1 0 D
+P
+FO
+6332 2638 M
+2 -1 D
+0 6 D
+P
+FO
+6343 2640 M
+1 -1 D
+0 2 D
+P
+FO
+6345 2642 M
+1 -1 D
+1 3 D
+P
+FO
+6346 2646 M
+1 -2 D
+1 2 D
+P
+FO
+6338 2639 M
+0 -3 D
+P
+FO
+6355 2643 M
+3 -4 D
+-3 5 D
+P
+FO
+6344 2637 M
+1 0 D
+-1 2 D
+P
+FO
+6367 2641 M
+2 -2 D
+-2 3 D
+P
+FO
+6350 2635 M
+2 0 D
+P
+FO
+6359 2639 M
+2 0 D
+P
+FO
+6359 2638 M
+2 0 D
+P
+FO
+6335 2638 M
+1 -2 D
+P
+FO
+6342 2635 M
+2 0 D
+P
+FO
+6345 2640 M
+0 -1 D
+P
+FO
+6367 2643 M
+0 2 D
+P
+FO
+6335 2636 M
+0 -1 D
+P
+FO
+6302 2608 M
+1 2 D
+P
+FO
+2 2 1 6375 2737 SP
+-1 -2 1 3 2 6372 2708 SP
+-1 -1 1 2 2 6375 2735 SP
+0 -3 0 4 2 6371 2707 SP
+0 4 1 6369 2715 SP
+1 2 1 6372 2705 SP
+6448 2598 M
+-1 3 D
+P
+FO
+6452 2598 M
+0 1 D
+-4 3 D
+2 -4 D
+P
+FO
+6453 2598 M
+-1 2 D
+0 -2 D
+P
+FO
+6378 2741 M
+14 5 D
+5 -3 D
+-5 2 D
+-6 -1 D
+-8 -4 D
+0 -93 D
+1 3 D
+-1 0 D
+2 -1 D
+-2 -3 D
+0 -1 D
+5 4 D
+-5 -6 D
+2 -1 D
+1 3 D
+-1 -3 D
+3 -1 D
+4 9 D
+1 -2 D
+4 5 D
+-1 7 D
+3 -3 D
+-1 -11 D
+5 3 D
+0 8 D
+-4 7 D
+2 0 D
+5 -5 D
+3 5 D
+4 -1 D
+4 1 D
+6 -7 D
+2 -5 D
+1 0 D
+3 -10 D
+-1 -2 D
+2 1 D
+-2 -6 D
+2 -1 D
+-1 4 D
+2 0 D
+0 -4 D
+-2 -1 D
+3 -4 D
+-1 -3 D
+8 -10 D
+-2 5 D
+2 1 D
+0 -7 D
+9 -10 D
+0 7 D
+-5 4 D
+0 2 D
+1 -3 D
+1 1 D
+3 -3 D
+0 -8 D
+2 0 D
+-2 -2 D
+3 -2 D
+0 3 D
+1 -1 D
+4 9 D
+-1 -5 D
+2 0 D
+-2 -1 D
+-1 -4 D
+3 2 D
+1 -1 D
+-3 -1 D
+1 -2 D
+3 1 D
+1 -2 D
+1 4 D
+3 -5 D
+155 0 D
+0 237 D
+-236 0 D
+P
+6391 2806 M
+-2 1 D
+2 -1 D
+1 4 D
+3 0 D
+-2 4 D
+-2 1 D
+-4 -3 D
+-1 1 D
+5 2 D
+4 -1 D
+2 -4 D
+2 1 D
+3 -1 D
+-2 -1 D
+2 -1 D
+-7 2 D
+1 -2 D
+-3 0 D
+P
+6400 2810 M
+-1 1 D
+P
+6437 2669 M
+1 -2 D
+-1 1 D
+-1 -3 D
+1 -3 D
+-2 5 D
+-1 -2 D
+0 3 D
+2 -1 D
+P
+6430 2670 M
+2 -6 D
+2 -3 D
+-3 1 D
+0 -4 D
+-5 9 D
+4 -6 D
+1 3 D
+-3 6 D
+P
+6385 2800 M
+-1 2 D
+4 0 D
+3 -2 D
+P
+6444 2609 M
+1 -4 D
+P
+6390 2664 M
+0 -2 D
+P
+6433 2658 M
+0 -2 D
+P
+6476 2761 M
+2 0 D
+P
+6430 2674 M
+1 -4 D
+P
+6528 2722 M
+-1 -4 D
+P
+FO
+6411 2657 M
+2 -3 D
+2 1 D
+-3 5 D
+P
+FO
+6403 2662 M
+1 -3 D
+3 1 D
+-2 2 D
+P
+FO
+6405 2662 M
+3 -3 D
+0 3 D
+P
+FO
+6390 2646 M
+1 3 D
+P
+FO
+6388 2646 M
+0 -3 D
+1 2 D
+P
+FO
+6402 2648 M
+4 3 D
+-2 6 D
+P
+FO
+6408 2662 M
+2 0 D
+P
+FO
+6392 2656 M
+1 -2 D
+P
+FO
+6421 2640 M
+1 4 D
+P
+FO
+6387 2646 M
+-1 -4 D
+P
+FO
+6390 2643 M
+2 2 D
+P
+FO
+6400 2649 M
+0 2 D
+P
+FO
+6422 2638 M
+1 2 D
+P
+FO
+6400 2651 M
+1 3 D
+P
+FO
+6402 2647 M
+-1 -1 D
+P
+FO
+6401 2651 M
+0 -1 D
+0 2 D
+P
+FO
+6405 2656 M
+1 -1 D
+P
+FO
+6439 2615 M
+1 1 D
+P
+FO
+6394 2644 M
+1 1 D
+P
+FO
+6386 2646 M
+0 -1 D
+1 2 D
+P
+FO
+6422 2634 M
+2 -1 D
+P
+FO
+6391 2646 M
+-1 -1 D
+P
+FO
+6757 2598 M
+2 1 D
+0 -1 D
+1 0 D
+0 4 D
+1 -4 D
+3 5 D
+4 0 D
+1 2 D
+-1 1 D
+1 -1 D
+1 4 D
+-1 0 D
+1 3 D
+-2 -1 D
+3 2 D
+-1 1 D
+3 0 D
+-4 2 D
+6 -2 D
+-2 3 D
+1 1 D
+-2 1 D
+2 2 D
+-4 2 D
+5 0 D
+1 -2 D
+-2 0 D
+3 -2 D
+0 3 D
+2 -1 D
+1 2 D
+4 0 D
+-3 -2 D
+2 -1 D
+5 2 D
+2 6 D
+-2 -1 D
+2 2 D
+-1 1 D
+5 -1 D
+1 2 D
+2 1 D
+1 2 D
+1 -1 D
+2 1 D
+1 -2 D
+2 2 D
+-1 1 D
+3 0 D
+3 2 D
+-1 -3 D
+3 2 D
+0 3 D
+0 -3 D
+2 2 D
+-1 -3 D
+2 0 D
+3 3 D
+-2 1 D
+1 1 D
+-2 3 D
+2 1 D
+1 -2 D
+1 1 D
+-2 -2 D
+1 -2 D
+2 2 D
+2 -5 D
+3 1 D
+-1 4 D
+2 -4 D
+5 0 D
+1 -3 D
+-3 -1 D
+3 -1 D
+1 2 D
+2 -2 D
+6 2 D
+1 2 D
+-3 2 D
+3 2 D
+-1 -2 D
+2 -3 D
+1 2 D
+0 -3 D
+2 -1 D
+0 3 D
+1 -3 D
+1 1 D
+3 -1 D
+-2 0 D
+1 -3 D
+-4 0 D
+0 -4 D
+-1 1 D
+-2 -6 D
+2 -3 D
+1 1 D
+0 -4 D
+2 0 D
+-3 -1 D
+2 -3 D
+4 -2 D
+0 226 D
+-62 0 D
+-2 -2 D
+-1 2 D
+-171 0 D
+0 -237 D
+P
+6768 2605 M
+-6 1 D
+-2 5 D
+-5 4 D
+-3 9 D
+-8 2 D
+-2 3 D
+2 -3 D
+8 -2 D
+2 -6 D
+3 -4 D
+2 0 D
+3 -7 D
+P
+6621 2732 M
+-1 -1 D
+-3 8 D
+1 0 D
+P
+6677 2717 M
+3 -4 D
+-3 -4 D
+P
+6673 2686 M
+3 -1 D
+P
+6630 2755 M
+0 -4 D
+P
+6682 2708 M
+2 -2 D
+-3 -5 D
+P
+6686 2716 M
+-1 -3 D
+P
+FO
+6844 2598 M
+0 1 D
+-1 -1 D
+P
+FO
+6850 2608 M
+0 -1 D
+0 1 D
+-3 0 D
+2 -4 D
+P
+FO
+6787 2835 M
+0 -1 D
+1 1 D
+P
+FO
+6780 2616 M
+1 -1 D
+0 3 D
+1 -1 D
+-3 2 D
+-1 -1 D
+P
+FO
+6789 2624 M
+5 3 D
+-2 0 D
+-2 2 D
+1 -2 D
+-2 -1 D
+P
+FO
+6792 2622 M
+-3 -3 D
+3 1 D
+1 3 D
+P
+FO
+6797 2622 M
+0 -1 D
+1 1 D
+P
+FO
+6791 2623 M
+2 2 D
+P
+FO
+6791 2618 M
+2 3 D
+P
+FO
+6774 2619 M
+2 -1 D
+P
+FO
+6777 2620 M
+1 0 D
+-1 1 D
+P
+FO
+6799 2622 M
+1 1 D
+P
+FO
+6787 2619 M
+2 0 D
+P
+FO
+6803 2633 M
+2 1 D
+P
+FO
+6796 2629 M
+3 1 D
+P
+FO
+6787 2618 M
+2 -1 D
+P
+FO
+6787 2621 M
+2 0 D
+P
+FO
+6780 2621 M
+1 0 D
+P
+FO
+6773 2622 M
+1 -1 D
+P
+FO
+6776 2618 M
+1 -1 D
+P
+FO
+6774 2618 M
+1 0 D
+P
+FO
+6806 2634 M
+2 1 D
+P
+FO
+6773 2619 M
+1 -1 D
+P
+FO
+6795 2625 M
+1 2 D
+P
+FO
+6786 2620 M
+1 -1 D
+P
+FO
+6774 2620 M
+3 -2 D
+P
+FO
+6803 2631 M
+-4 0 D
+P
+FO
+6829 2623 M
+1 0 D
+P
+FO
+6793 2622 M
+2 3 D
+P
+FO
+6864 2598 M
+-5 3 D
+-2 -2 D
+-3 1 D
+-1 -2 D
+P
+FO
+6873 2598 M
+-4 1 D
+-2 3 D
+-3 -1 D
+0 -3 D
+P
+FO
+7087 2757 M
+-4 -5 D
+4 2 D
+P
+FO
+7007 2835 M
+-10 -7 D
+1 -1 D
+-1 -3 D
+-1 1 D
+0 -4 D
+-2 -1 D
+3 1 D
+-2 -4 D
+6 0 D
+-1 -3 D
+2 1 D
+0 3 D
+2 -2 D
+0 1 D
+3 -1 D
+0 1 D
+1 -1 D
+-1 -1 D
+2 -1 D
+-2 -1 D
+0 1 D
+-4 1 D
+2 -2 D
+-2 -1 D
+2 -4 D
+-1 -2 D
+-2 1 D
+1 2 D
+-2 -2 D
+1 3 D
+-2 -3 D
+0 4 D
+-7 4 D
+3 1 D
+-4 1 D
+-2 -1 D
+5 10 D
+-2 1 D
+3 2 D
+-8 -1 D
+-4 3 D
+-5 0 D
+-2 4 D
+-26 0 D
+-2 -1 D
+2 -2 D
+-3 1 D
+0 2 D
+-1 0 D
+2 -4 D
+-3 3 D
+0 -2 D
+-2 0 D
+1 1 D
+-2 1 D
+1 1 D
+-94 0 D
+0 -226 D
+1 0 D
+-1 -4 D
+7 -1 D
+6 6 D
+-5 4 D
+0 3 D
+2 -1 D
+-1 2 D
+-5 0 D
+0 4 D
+6 4 D
+-1 6 D
+3 -3 D
+-2 -1 D
+1 -2 D
+4 1 D
+0 3 D
+1 -2 D
+3 4 D
+7 1 D
+-2 0 D
+1 2 D
+1 -2 D
+5 1 D
+-1 -2 D
+4 2 D
+-2 0 D
+3 1 D
+-1 1 D
+1 -2 D
+4 0 D
+-1 2 D
+1 -2 D
+4 3 D
+0 2 D
+-3 2 D
+4 -1 D
+0 -2 D
+4 2 D
+0 2 D
+1 -1 D
+3 1 D
+0 -2 D
+4 -1 D
+1 1 D
+-1 6 D
+3 -2 D
+-2 -2 D
+4 -2 D
+6 5 D
+2 -3 D
+3 2 D
+-1 4 D
+2 3 D
+-1 5 D
+-3 2 D
+5 -2 D
+0 -9 D
+4 0 D
+1 4 D
+-1 3 D
+3 -4 D
+2 0 D
+0 1 D
+1 -1 D
+2 5 D
+-2 0 D
+1 4 D
+-2 0 D
+2 1 D
+-2 2 D
+3 -1 D
+-3 3 D
+3 0 D
+-3 3 D
+-3 0 D
+3 0 D
+0 2 D
+-3 3 D
+4 -1 D
+1 -3 D
+1 0 D
+0 -3 D
+4 -2 D
+2 -6 D
+5 1 D
+-4 -4 D
+9 -2 D
+-1 2 D
+3 0 D
+0 2 D
+-2 1 D
+-3 -2 D
+0 1 D
+4 2 D
+-3 0 D
+4 2 D
+3 -4 D
+2 1 D
+-3 2 D
+3 2 D
+-2 0 D
+0 1 D
+6 3 D
+1 -1 D
+-2 -1 D
+0 -3 D
+4 0 D
+0 -1 D
+2 3 D
+-3 2 D
+3 -2 D
+2 3 D
+3 -1 D
+3 3 D
+-2 -3 D
+4 0 D
+-1 -1 D
+5 -2 D
+1 3 D
+-2 -1 D
+2 3 D
+5 -1 D
+0 -2 D
+6 3 D
+-1 2 D
+2 -1 D
+-1 -2 D
+5 4 D
+5 -1 D
+2 6 D
+-2 0 D
+0 1 D
+3 -2 D
+3 2 D
+-7 5 D
+7 -3 D
+1 2 D
+-2 2 D
+4 -2 D
+-2 1 D
+2 0 D
+-2 1 D
+2 1 D
+-2 0 D
+2 1 D
+-1 0 D
+2 2 D
+0 -1 D
+3 1 D
+1 -3 D
+3 2 D
+-1 1 D
+2 -1 D
+0 4 D
+4 -1 D
+1 4 D
+-3 1 D
+5 -1 D
+1 -5 D
+2 8 D
+2 0 D
+-1 -3 D
+1 0 D
+2 4 D
+1 -1 D
+1 4 D
+1 -1 D
+4 2 D
+-1 2 D
+-2 0 D
+1 2 D
+-4 -2 D
+-3 4 D
+6 -2 D
+1 2 D
+-2 1 D
+1 0 D
+0 2 D
+2 -2 D
+2 3 D
+1 -3 D
+4 1 D
+1 3 D
+0 -2 D
+3 -2 D
+0 -1 D
+2 1 D
+0 3 D
+3 2 D
+-4 0 D
+-1 3 D
+2 0 D
+0 2 D
+2 -2 D
+-1 -1 D
+7 1 D
+-2 1 D
+2 1 D
+0 2 D
+-1 -1 D
+-3 2 D
+3 0 D
+1 2 D
+-3 1 D
+5 1 D
+-3 -1 D
+3 1 D
+-1 -4 D
+3 1 D
+-2 1 D
+1 2 D
+4 -2 D
+2 2 D
+-3 1 D
+-1 -1 D
+0 2 D
+-3 2 D
+6 4 D
+1 -2 D
+2 0 D
+0 -4 D
+3 2 D
+0 -2 D
+1 0 D
+0 3 D
+-2 0 D
+1 2 D
+-2 0 D
+-2 3 D
+4 0 D
+-1 4 D
+3 1 D
+1 2 D
+-5 2 D
+4 4 D
+-2 0 D
+9 3 D
+-3 -1 D
+-1 2 D
+-2 -2 D
+-1 3 D
+-2 -1 D
+1 2 D
+3 -2 D
+2 1 D
+-2 3 D
+-2 1 D
+-2 -2 D
+-1 2 D
+1 1 D
+-1 3 D
+4 -2 D
+-2 4 D
+3 -4 D
+2 3 D
+-1 -3 D
+2 -2 D
+1 4 D
+2 0 D
+0 76 D
+P
+6883 2680 M
+-12 -2 D
+-2 2 D
+-6 -1 D
+-7 4 D
+-4 -4 D
+4 4 D
+7 -3 D
+6 1 D
+2 -3 D
+4 2 D
+8 1 D
+2 -1 D
+2 -6 D
+15 -3 D
+3 2 D
+3 -2 D
+4 3 D
+4 -1 D
+3 -7 D
+4 -2 D
+2 -5 D
+-3 5 D
+-3 2 D
+-3 7 D
+-4 0 D
+-4 -3 D
+-3 3 D
+-3 -2 D
+-16 3 D
+P
+6918 2668 M
+1 -1 D
+P
+6897 2811 M
+4 -2 D
+3 4 D
+0 -5 D
+1 1 D
+3 -2 D
+1 2 D
+6 -1 D
+4 3 D
+-2 -4 D
+0 2 D
+-5 -3 D
+-1 1 D
+-2 -1 D
+-3 2 D
+-2 -3 D
+1 2 D
+-2 -1 D
+P
+6958 2695 M
+1 -2 D
+-2 -3 D
+1 -1 D
+2 2 D
+2 -1 D
+-3 -2 D
+1 -1 D
+-5 -1 D
+-1 2 D
+4 0 D
+-2 2 D
+-3 -1 D
+4 2 D
+P
+7055 2821 M
+0 1 D
+6 3 D
+-5 3 D
+7 -2 D
+3 4 D
+-1 -1 D
+2 -1 D
+-3 -2 D
+4 -3 D
+-5 1 D
+-8 -4 D
+P
+7059 2823 M
+2 0 D
+P
+7062 2824 M
+2 1 D
+P
+6917 2817 M
+2 3 D
+-3 2 D
+5 -3 D
+2 1 D
+-2 -6 D
+0 5 D
+P
+6927 2830 M
+0 2 D
+2 -1 D
+0 2 D
+3 0 D
+-3 -5 D
+P
+7000 2797 M
+-1 5 D
+4 -3 D
+-3 1 D
+1 -2 D
+P
+6994 2800 M
+4 1 D
+-2 -1 D
+2 -3 D
+-3 1 D
+P
+6856 2644 M
+2 -1 D
+0 -3 D
+1 0 D
+-1 -1 D
+P
+6908 2816 M
+3 1 D
+-2 -4 D
+P
+7068 2742 M
+4 -3 D
+P
+6999 2803 M
+1 1 D
+P
+6926 2658 M
+1 -2 D
+P
+6895 2643 M
+2 -2 D
+P
+6938 2673 M
+-1 -1 D
+P
+FO
+7003 2835 M
+1 -1 D
+-4 -1 D
+-1 2 D
+-1 0 D
+-1 -3 D
+-5 0 D
+-1 3 D
+-14 0 D
+2 -3 D
+7 0 D
+4 -4 D
+6 3 D
+2 -1 D
+6 3 D
+1 2 D
+P
+FO
+6997 2835 M
+0 -1 D
+P
+FO
+6994 2835 M
+2 -1 D
+0 1 D
+P
+FO
+7079 2728 M
+1 0 D
+1 -2 D
+2 1 D
+-1 2 D
+2 1 D
+-2 2 D
+-3 -1 D
+2 -2 D
+P
+FO
+7023 2683 M
+3 0 D
+0 2 D
+2 2 D
+-3 0 D
+-1 -2 D
+2 0 D
+P
+FO
+6945 2652 M
+1 2 D
+-4 -1 D
+-1 -3 D
+4 1 D
+P
+FO
+7076 2682 M
+3 0 D
+-1 2 D
+-2 -1 D
+P
+FO
+6861 2622 M
+2 -2 D
+0 4 D
+-3 0 D
+-4 -2 D
+P
+FO
+6916 2638 M
+-1 -2 D
+2 0 D
+1 4 D
+-4 -2 D
+P
+FO
+7046 2703 M
+4 0 D
+-1 2 D
+P
+FO
+7041 2704 M
+1 -1 D
+2 2 D
+-2 1 D
+P
+FO
+7016 2679 M
+3 0 D
+0 1 D
+-5 0 D
+P
+FO
+7069 2728 M
+2 -1 D
+0 2 D
+P
+FO
+6930 2646 M
+0 2 D
+-2 -2 D
+P
+FO
+7073 2722 M
+2 -2 D
+2 1 D
+P
+FO
+6898 2637 M
+-4 1 D
+-1 -3 D
+P
+FO
+6863 2620 M
+2 -1 D
+1 1 D
+P
+FO
+7007 2677 M
+4 -3 D
+-1 3 D
+P
+FO
+6948 2652 M
+3 -1 D
+P
+FO
+7076 2742 M
+2 0 D
+-1 1 D
+P
+FO
+6860 2626 M
+4 -2 D
+1 3 D
+P
+FO
+6924 2643 M
+1 1 D
+P
+FO
+6913 2637 M
+0 2 D
+-3 -3 D
+P
+FO
+6928 2647 M
+2 2 D
+-2 -1 D
+P
+FO
+6926 2644 M
+2 0 D
+P
+FO
+6860 2614 M
+2 -2 D
+P
+FO
+6932 2648 M
+2 0 D
+P
+FO
+7016 2682 M
+-2 0 D
+P
+FO
+7074 2683 M
+2 1 D
+P
+FO
+6855 2621 M
+1 1 D
+P
+FO
+7014 2682 M
+1 1 D
+P
+FO
+7044 2703 M
+2 0 D
+P
+FO
+7065 2718 M
+2 1 D
+P
+FO
+7076 2685 M
+1 -1 D
+P
+FO
+6936 2655 M
+1 1 D
+P
+FO
+6947 2651 M
+1 -1 D
+P
+FO
+6950 2646 M
+2 1 D
+P
+FO
+6924 2642 M
+2 1 D
+P
+FO
+7085 2744 M
+1 0 D
+P
+FO
+6932 2649 M
+2 0 D
+P
+FO
+7079 2732 M
+1 0 D
+P
+FO
+6949 2646 M
+1 0 D
+P
+FO
+7081 2755 M
+1 0 D
+P
+FO
+7076 2732 M
+1 0 D
+P
+FO
+6862 2620 M
+1 0 D
+P
+FO
+7076 2742 M
+1 0 D
+P
+FO
+6863 2606 M
+1 1 D
+P
+FO
+6949 2646 M
+-1 -1 D
+P
+FO
+0 -1 1 7006 2835 SP
+-4 1 4 0 2 6994 2829 SP
+1 0 1 6985 2831 SP
+7323 2796 M
+-2 -2 D
+2 1 D
+P
+FO
+7321 2835 M
+1 -2 D
+P
+FO
+7135 2835 M
+6 -2 D
+1 2 D
+P
+FO
+7130 2835 M
+1 0 D
+P
+FO
+7087 2759 M
+1 0 D
+-1 -5 D
+2 1 D
+1 4 D
+-3 1 D
+5 2 D
+-2 1 D
+3 1 D
+0 3 D
+3 -1 D
+1 1 D
+-2 1 D
+0 2 D
+1 -2 D
+1 1 D
+2 -1 D
+0 5 D
+3 -1 D
+1 3 D
+-3 3 D
+3 1 D
+-1 2 D
+2 0 D
+3 5 D
+-6 2 D
+-1 2 D
+1 -2 D
+8 -1 D
+4 6 D
+-2 1 D
+2 0 D
+1 3 D
+3 -1 D
+-2 -1 D
+3 -4 D
+3 4 D
+4 -1 D
+1 2 D
+-2 0 D
+-2 7 D
+-4 1 D
+8 0 D
+0 4 D
+-4 2 D
+6 0 D
+-2 2 D
+-3 -1 D
+3 3 D
+-5 -1 D
+-1 2 D
+3 0 D
+-1 2 D
+2 1 D
+1 -3 D
+1 4 D
+0 -4 D
+2 1 D
+1 4 D
+0 -4 D
+4 0 D
+-1 4 D
+2 5 D
+-2 1 D
+-3 -1 D
+-1 -1 D
+2 0 D
+-1 -2 D
+-2 2 D
+-5 -4 D
+1 2 D
+-2 -1 D
+-1 1 D
+2 2 D
+1 -1 D
+4 1 D
+4 5 D
+6 3 D
+-10 1 D
+-1 2 D
+-39 0 D
+P
+FO
+7107 2646 M
+3 13 D
+10 13 D
+5 23 D
+5 9 D
+0 9 D
+4 4 D
+-2 3 D
+-4 0 D
+-4 4 D
+-3 -2 D
+0 -2 D
+-10 -3 D
+-4 -8 D
+-4 -2 D
+-4 -10 D
+-5 -4 D
+-1 -4 D
+2 0 D
+-3 0 D
+-2 -5 D
+0 -7 D
+-2 -4 D
+1 -1 D
+-2 -1 D
+4 -1 D
+-1 -1 D
+4 -11 D
+8 -5 D
+1 -9 D
+4 -1 D
+P
+FO
+7276 2752 M
+6 4 D
+1 3 D
+-1 2 D
+-3 -5 D
+-3 -1 D
+0 1 D
+-3 1 D
+0 -2 D
+2 -1 D
+-6 -3 D
+1 -4 D
+-3 -2 D
+1 -3 D
+4 2 D
+-2 1 D
+1 2 D
+3 0 D
+-2 3 D
+P
+FO
+7302 2793 M
+4 0 D
+2 -3 D
+-1 1 D
+4 1 D
+-2 1 D
+7 4 D
+0 3 D
+-2 -3 D
+0 2 D
+-2 -1 D
+-1 -2 D
+-7 -1 D
+2 -1 D
+P
+FO
+7173 2700 M
+5 -1 D
+2 2 D
+-4 2 D
+-1 -3 D
+-1 1 D
+P
+FO
+7299 2783 M
+0 2 D
+-2 0 D
+1 -6 D
+2 2 D
+P
+FO
+7113 2791 M
+1 -3 D
+3 1 D
+-1 3 D
+P
+FO
+7134 2609 M
+0 1 D
+-1 0 D
+-1 -3 D
+P
+FO
+7183 2703 M
+4 -2 D
+2 6 D
+-3 -3 D
+P
+FO
+7315 2826 M
+1 -1 D
+1 2 D
+P
+FO
+7142 2833 M
+2 -2 D
+0 2 D
+P
+FO
+7245 2749 M
+3 -2 D
+-1 2 D
+P
+FO
+7122 2648 M
+2 -2 D
+-1 2 D
+P
+FO
+7157 2703 M
+2 1 D
+-3 -1 D
+P
+FO
+7211 2711 M
+5 -1 D
+-5 4 D
+P
+FO
+7288 2773 M
+1 -1 D
+3 2 D
+P
+FO
+7135 2828 M
+4 -1 D
+-2 3 D
+P
+FO
+7131 2814 M
+2 -2 D
+0 3 D
+P
+FO
+7129 2615 M
+1 0 D
+1 3 D
+P
+FO
+7303 2792 M
+1 -3 D
+3 0 D
+P
+FO
+7248 2748 M
+2 1 D
+P
+FO
+7139 2831 M
+3 -2 D
+P
+FO
+7208 2712 M
+2 0 D
+P
+FO
+7129 2814 M
+2 0 D
+P
+FO
+7130 2606 M
+1 -1 D
+P
+FO
+7319 2831 M
+2 -1 D
+P
+FO
+7111 2786 M
+3 1 D
+P
+FO
+7125 2796 M
+1 1 D
+P
+FO
+7087 2672 M
+1 1 D
+P
+FO
+7112 2783 M
+3 1 D
+P
+FO
+7134 2830 M
+-1 -1 D
+P
+FO
+7270 2757 M
+2 0 D
+P
+FO
+7094 2763 M
+2 -1 D
+P
+FO
+7276 2765 M
+-2 -1 D
+P
+FO
+7285 2765 M
+1 -1 D
+P
+FO
+7197 2708 M
+1 0 D
+P
+FO
+7139 2829 M
+2 -1 D
+P
+FO
+7107 2787 M
+1 0 D
+P
+FO
+7260 2744 M
+1 1 D
+-1 0 D
+P
+FO
+7121 2662 M
+1 -1 D
+P
+FO
+7274 2762 M
+1 0 D
+P
+FO
+7304 2788 M
+2 0 D
+P
+FO
+7129 2815 M
+1 0 D
+P
+FO
+7129 2813 M
+1 0 D
+P
+FO
+7111 2784 M
+2 0 D
+P
+FO
+7141 2831 M
+1 1 D
+P
+FO
+7175 2694 M
+2 0 D
+P
+FO
+7089 2754 M
+2 0 D
+P
+FO
+7111 2775 M
+2 -1 D
+P
+FO
+7303 2788 M
+0 1 D
+P
+FO
+7139 2828 M
+1 -1 D
+P
+FO
+7259 2746 M
+1 0 D
+P
+FO
+7113 2784 M
+1 1 D
+P
+FO
+7087 2681 M
+1 1 D
+P
+FO
+7130 2806 M
+1 1 D
+P
+FO
+7131 2798 M
+1 0 D
+P
+FO
+7323 2795 M
+0 1 D
+P
+FO
+7352 2736 M
+1 1 D
+P
+FO
+7589 2710 M
+2 2 D
+-2 -1 D
+P
+FO
+7611 2765 M
+1 0 D
+P
+FO
+7609 2757 M
+2 -3 D
+P
+FO
+471 2646 M
+-4 -3 D
+0 -2 D
+4 2 D
+P
+FO
+584 2598 M
+-14 7 D
+-1 -2 D
+2 -5 D
+P
+FO
+520 2629 M
+0 2 D
+4 -3 D
+4 1 D
+-2 4 D
+-1 -1 D
+-2 1 D
+-3 6 D
+-3 -3 D
+-4 0 D
+4 -7 D
+P
+FO
+567 2615 M
+0 2 D
+-6 4 D
+-5 -1 D
+-3 3 D
+-2 -1 D
+1 -4 D
+4 -1 D
+1 -5 D
+P
+FO
+478 2646 M
+8 -3 D
+2 2 D
+1 4 D
+-2 2 D
+-5 0 D
+-3 -2 D
+P
+FO
+543 2624 M
+4 -1 D
+3 3 D
+-13 1 D
+-1 -2 D
+P
+FO
+543 2618 M
+1 -2 D
+4 2 D
+-3 2 D
+-3 0 D
+P
+FO
+552 2612 M
+-1 -2 D
+3 1 D
+P
+FO
+1654 2696 M
+-7 5 D
+-1 -4 D
+-2 -2 D
+-1 2 D
+3 0 D
+-6 1 D
+-3 3 D
+-1 7 D
+2 4 D
+-6 8 D
+-3 9 D
+-2 0 D
+-4 6 D
+-4 17 D
+-2 1 D
+0 4 D
+-6 4 D
+0 -4 D
+3 -3 D
+-2 -1 D
+-4 4 D
+1 3 D
+-3 3 D
+1 3 D
+-6 3 D
+-3 8 D
+-8 5 D
+-2 10 D
+-2 2 D
+0 4 D
+-6 1 D
+-2 7 D
+-4 0 D
+0 4 D
+-4 -2 D
+-2 10 D
+-14 11 D
+-4 0 D
+-4 6 D
+-30 0 D
+0 -2 D
+3 -1 D
+0 -3 D
+12 -8 D
+5 -1 D
+22 -22 D
+-2 -5 D
+2 0 D
+0 -1 D
+-2 -2 D
+2 -2 D
+-1 -1 D
+-1 1 D
+0 -2 D
+0 3 D
+-4 -4 D
+3 1 D
+1 -5 D
+2 0 D
+-1 2 D
+4 -2 D
+-1 -2 D
+-2 1 D
+-1 -2 D
+-6 4 D
+1 2 D
+-5 -2 D
+-13 2 D
+1 -3 D
+12 -7 D
+2 -6 D
+6 -1 D
+4 -4 D
+4 0 D
+5 -6 D
+4 3 D
+4 -2 D
+3 6 D
+0 -4 D
+-2 -1 D
+3 0 D
+1 -5 D
+9 -6 D
+7 -2 D
+2 -5 D
+2 1 D
+3 -6 D
+0 -8 D
+2 0 D
+-2 -1 D
+-1 -6 D
+2 0 D
+-2 -1 D
+-1 -8 D
+2 5 D
+0 -7 D
+1 3 D
+1 -3 D
+1 1 D
+-1 2 D
+5 -8 D
+1 0 D
+-1 1 D
+4 0 D
+1 -3 D
+1 1 D
+22 -18 D
+7 -3 D
+7 -16 D
+1 0 D
+P
+1557 2786 M
+0 -2 D
+P
+FO
+1654 2765 M
+-2 1 D
+P
+FO
+1589 2835 M
+0 -2 D
+8 -10 D
+0 -4 D
+4 -1 D
+1 -8 D
+8 -4 D
+-3 -1 D
+6 -7 D
+7 -2 D
+-1 -1 D
+8 -9 D
+4 1 D
+2 -3 D
+0 1 D
+9 -1 D
+-3 -1 D
+0 -2 D
+2 0 D
+-2 -2 D
+1 -4 D
+3 -4 D
+-2 0 D
+6 -4 D
+7 -1 D
+0 69 D
+P
+FO
+1569 2823 M
+1 -5 D
+9 -7 D
+-1 7 D
+-5 1 D
+1 2 D
+-4 4 D
+P
+FO
+1602 2715 M
+1 7 D
+-4 -10 D
+3 -2 D
+0 -2 D
+3 -2 D
+-5 7 D
+P
+FO
+1594 2811 M
+-2 -3 D
+8 -3 D
+2 5 D
+-2 7 D
+-5 -2 D
+P
+FO
+1638 2717 M
+1 -3 D
+2 0 D
+-1 3 D
+-3 2 D
+P
+FO
+1457 2811 M
+1 -3 D
+0 8 D
+-2 -1 D
+P
+FO
+1640 2771 M
+0 3 D
+-1 -3 D
+2 0 D
+P
+FO
+1617 2702 M
+-3 -1 D
+5 0 D
+P
+FO
+1527 2790 M
+4 -2 D
+-1 8 D
+P
+FO
+1606 2705 M
+7 -5 D
+-1 3 D
+P
+FO
+1626 2740 M
+-1 -5 D
+3 7 D
+P
+FO
+1644 2705 M
+2 -3 D
+0 3 D
+P
+FO
+1593 2804 M
+-1 1 D
+0 -2 D
+P
+FO
+1578 2757 M
+-2 0 D
+3 -1 D
+P
+FO
+1604 2725 M
+-1 -2 D
+1 5 D
+P
+FO
+1588 2801 M
+-3 3 D
+P
+FO
+1635 2731 M
+-1 2 D
+P
+FO
+1644 2706 M
+1 0 D
+-1 1 D
+P
+FO
+1628 2733 M
+1 -1 D
+P
+FO
+1604 2732 M
+0 -4 D
+P
+FO
+1637 2724 M
+-1 -1 D
+P
+FO
+1570 2813 M
+1 -1 D
+P
+FO
+1623 2742 M
+1 1 D
+P
+FO
+1555 2781 M
+-2 1 D
+P
+FO
+1624 2736 M
+0 -1 D
+P
+FO
+1654 2766 M
+4 -8 D
+3 -2 D
+4 0 D
+-1 1 D
+1 1 D
+2 -1 D
+-1 -1 D
+5 -4 D
+0 -1 D
+4 -4 D
+-1 -3 D
+-2 4 D
+-2 -5 D
+1 5 D
+-4 -7 D
+1 -8 D
+1 2 D
+3 -3 D
+-1 2 D
+2 -3 D
+3 0 D
+0 -2 D
+-2 0 D
+2 -2 D
+1 2 D
+2 -2 D
+1 3 D
+2 -1 D
+1 -3 D
+6 -2 D
+3 -3 D
+-1 2 D
+2 0 D
+0 -2 D
+7 -3 D
+1 -5 D
+2 1 D
+-3 -1 D
+2 -3 D
+-3 1 D
+2 -3 D
+8 -4 D
+3 1 D
+1 -3 D
+-2 0 D
+2 -1 D
+-8 4 D
+18 -11 D
+-8 4 D
+12 -9 D
+11 -16 D
+1 2 D
+-1 -2 D
+4 -1 D
+5 -7 D
+2 1 D
+-2 -1 D
+7 -7 D
+2 -12 D
+5 -9 D
+6 -4 D
+-1 -10 D
+-7 -6 D
+5 -1 D
+2 -4 D
+-11 -4 D
+4 -5 D
+1 -5 D
+130 0 D
+0 237 D
+-236 0 D
+P
+1659 2819 M
+2 1 D
+1 -5 D
+1 1 D
+3 -2 D
+3 1 D
+-2 -2 D
+-5 0 D
+1 -4 D
+P
+1859 2823 M
+2 2 D
+-2 0 D
+0 1 D
+2 0 D
+0 -2 D
+4 -2 D
+3 4 D
+0 -4 D
+P
+1656 2791 M
+3 -4 D
+-2 -4 D
+-2 3 D
+2 -1 D
+2 2 D
+P
+1821 2606 M
+4 -1 D
+-1 -2 D
+2 -1 D
+-3 -1 D
+-14 3 D
+P
+1755 2663 M
+3 -11 D
+3 -3 D
+-1 -2 D
+-5 11 D
+P
+1672 2774 M
+5 -5 D
+1 2 D
+-1 -2 D
+-3 0 D
+P
+1760 2644 M
+2 -2 D
+-1 1 D
+-1 -2 D
+1 3 D
+P
+1763 2777 M
+-2 -1 D
+-6 0 D
+P
+1873 2599 M
+4 2 D
+2 -1 D
+P
+1875 2775 M
+-3 0 D
+3 1 D
+P
+1743 2671 M
+5 -3 D
+0 -2 D
+P
+1770 2733 M
+2 -2 D
+-2 -1 D
+P
+1763 2651 M
+1 -1 D
+-2 0 D
+P
+1751 2666 M
+1 -1 D
+-2 -1 D
+P
+1805 2621 M
+-3 -1 D
+P
+1885 2600 M
+-1 -1 D
+0 2 D
+P
+1811 2638 M
+-1 -1 D
+P
+1688 2757 M
+-1 -5 D
+P
+1769 2641 M
+2 -1 D
+P
+1749 2666 M
+0 -2 D
+P
+FO
+1654 2765 M
+1 -1 D
+P
+FO
+1654 2667 M
+3 0 D
+9 7 D
+1 4 D
+-1 4 D
+-5 3 D
+0 3 D
+-4 3 D
+1 3 D
+-3 -1 D
+-1 3 D
+P
+FO
+1658 2696 M
+-3 6 D
+1 -5 D
+P
+FO
+1699 2716 M
+-2 2 D
+3 -6 D
+P
+FO
+1696 2717 M
+-3 3 D
+6 -8 D
+P
+FO
+1668 2732 M
+5 -2 D
+-1 2 D
+P
+FO
+1735 2637 M
+-3 1 D
+3 -3 D
+P
+FO
+1668 2732 M
+2 0 D
+P
+FO
+1736 2633 M
+4 0 D
+P
+FO
+1683 2725 M
+5 -1 D
+P
+FO
+1692 2721 M
+2 -1 D
+P
+FO
+1742 2629 M
+1 1 D
+P
+FO
+1673 2731 M
+2 -1 D
+P
+FO
+1682 2726 M
+1 0 D
+P
+FO
+1671 2748 M
+0 2 D
+P
+FO
+1677 2727 M
+5 -2 D
+P
+FO
+1971 2598 M
+-14 16 D
+-8 19 D
+-2 0 D
+-5 14 D
+10 -13 D
+-1 -5 D
+2 7 D
+-10 10 D
+-2 16 D
+-1 -2 D
+3 8 D
+-1 -2 D
+1 21 D
+-1 0 D
+-1 8 D
+2 9 D
+-1 -4 D
+-2 4 D
+2 1 D
+-2 0 D
+1 2 D
+2 -3 D
+0 10 D
+1 -1 D
+2 2 D
+-3 1 D
+1 4 D
+-2 0 D
+3 1 D
+-3 2 D
+2 0 D
+0 3 D
+4 -3 D
+-1 2 D
+2 0 D
+-2 3 D
+4 -1 D
+-1 -2 D
+2 0 D
+-4 -8 D
+8 15 D
+1 10 D
+-1 -3 D
+-2 1 D
+2 2 D
+-3 1 D
+0 5 D
+-3 0 D
+2 2 D
+-2 -1 D
+1 4 D
+-4 7 D
+1 1 D
+2 -1 D
+-3 3 D
+2 1 D
+2 6 D
+-3 -1 D
+-6 1 D
+3 1 D
+-2 3 D
+3 -3 D
+0 1 D
+1 -1 D
+2 2 D
+-1 0 D
+1 2 D
+0 -4 D
+2 1 D
+4 8 D
+-3 -1 D
+1 2 D
+-4 2 D
+3 1 D
+-4 0 D
+6 1 D
+2 -2 D
+4 7 D
+-4 -3 D
+1 1 D
+-2 1 D
+2 2 D
+-1 0 D
+4 1 D
+1 -2 D
+2 4 D
+-2 -4 D
+2 0 D
+3 3 D
+-2 4 D
+2 0 D
+-1 2 D
+3 -4 D
+2 1 D
+-2 -1 D
+7 3 D
+-6 3 D
+0 3 D
+2 0 D
+0 1 D
+0 -2 D
+2 -1 D
+0 1 D
+0 -2 D
+2 1 D
+-1 4 D
+2 -4 D
+4 3 D
+-1 -2 D
+2 -1 D
+-2 -1 D
+6 2 D
+-6 -4 D
+12 6 D
+-6 -3 D
+1 2 D
+13 4 D
+6 5 D
+-2 -1 D
+0 4 D
+2 -1 D
+5 3 D
+0 2 D
+2 0 D
+-3 1 D
+1 2 D
+-4 1 D
+2 3 D
+1 -1 D
+-1 2 D
+2 -1 D
+4 3 D
+1 -4 D
+-2 -2 D
+7 0 D
+-7 -4 D
+16 7 D
+6 0 D
+-2 3 D
+2 4 D
+2 0 D
+-1 -3 D
+-2 -1 D
+1 -3 D
+12 2 D
+0 1 D
+24 -6 D
+8 1 D
+-3 0 D
+-2 4 D
+2 0 D
+-1 -1 D
+4 3 D
+4 0 D
+-2 -3 D
+7 1 D
+-1 -3 D
+2 0 D
+0 -3 D
+3 1 D
+1 2 D
+-1 -3 D
+3 0 D
+1 3 D
+0 -4 D
+4 -4 D
+-1 -2 D
+5 0 D
+2 -3 D
+4 2 D
+1 -1 D
+1 4 D
+3 0 D
+0 1 D
+1 -2 D
+2 1 D
+1 -2 D
+1 1 D
+0 -4 D
+3 1 D
+2 7 D
+-4 2 D
+0 1 D
+5 -2 D
+0 13 D
+-38 0 D
+2 -2 D
+-2 2 D
+-40 0 D
+1 -3 D
+-3 -2 D
+-1 2 D
+2 0 D
+0 3 D
+-157 0 D
+0 -237 D
+P
+1910 2753 M
+-3 2 D
+0 5 D
+-2 -2 D
+-1 1 D
+1 0 D
+0 3 D
+-2 3 D
+4 -4 D
+2 1 D
+-1 -1 D
+1 -4 D
+1 0 D
+P
+1915 2747 M
+0 -4 D
+-2 -1 D
+1 3 D
+-3 -1 D
+0 2 D
+3 -1 D
+P
+2093 2833 M
+1 -3 D
+4 -1 D
+-1 -1 D
+-4 1 D
+-1 5 D
+P
+2060 2834 M
+3 -1 D
+-2 -1 D
+2 -2 D
+-4 1 D
+P
+2066 2830 M
+3 0 D
+-1 -3 D
+-4 2 D
+P
+2121 2831 M
+1 -2 D
+-3 -2 D
+-1 1 D
+3 4 D
+P
+2100 2829 M
+0 -2 D
+-2 1 D
+P
+1952 2777 M
+0 -2 D
+-2 1 D
+P
+1940 2650 M
+0 -3 D
+-1 3 D
+P
+1936 2652 M
+0 -2 D
+-2 1 D
+P
+1935 2654 M
+0 -2 D
+-1 2 D
+P
+1926 2647 M
+-2 0 D
+P
+1939 2792 M
+1 -4 D
+P
+1927 2649 M
+-1 -1 D
+P
+1935 2656 M
+2 -2 D
+P
+1929 2658 M
+0 -2 D
+P
+FO
+2126 2626 M
+-7 -3 D
+-5 -12 D
+0 -13 D
+12 0 D
+P
+FO
+2126 2817 M
+-1 -1 D
+P
+FO
+2126 2822 M
+-3 1 D
+P
+FO
+2079 2825 M
+-1 -1 D
+5 -2 D
+3 2 D
+-5 2 D
+P
+FO
+1952 2769 M
+7 15 D
+-3 -6 D
+-1 1 D
+P
+FO
+1964 2789 M
+11 6 D
+0 2 D
+-10 -5 D
+P
+FO
+2008 2815 M
+6 4 D
+-9 -6 D
+P
+FO
+2109 2813 M
+-1 -1 D
+3 1 D
+P
+FO
+1951 2764 M
+1 -3 D
+0 8 D
+P
+FO
+2094 2819 M
+5 -3 D
+-2 4 D
+P
+FO
+1961 2785 M
+1 5 D
+-3 -6 D
+P
+FO
+1943 2693 M
+0 -5 D
+2 17 D
+P
+FO
+1951 2633 M
+-2 -1 D
+1 -1 D
+P
+FO
+1945 2705 M
+3 11 D
+P
+FO
+1975 2797 M
+4 2 D
+P
+FO
+2114 2813 M
+2 -1 D
+P
+FO
+2116 2816 M
+1 1 D
+P
+FO
+1953 2755 M
+1 -2 D
+P
+FO
+2112 2817 M
+2 -1 D
+P
+FO
+1948 2771 M
+1 0 D
+P
+FO
+2117 2813 M
+2 0 D
+P
+FO
+2115 2817 M
+0 -1 D
+1 1 D
+P
+FO
+1948 2636 M
+1 -1 D
+P
+FO
+2118 2814 M
+-2 0 D
+P
+FO
+2103 2813 M
+2 -1 D
+P
+FO
+1971 2796 M
+2 1 D
+P
+FO
+1942 2663 M
+0 1 D
+P
+FO
+1949 2723 M
+0 1 D
+P
+FO
+1950 2724 M
+1 1 D
+P
+FO
+1943 2698 M
+1 1 D
+P
+FO
+2186 2598 M
+0 4 D
+4 7 D
+10 9 D
+3 7 D
+-2 1 D
+1 4 D
+-2 -2 D
+-4 8 D
+-2 0 D
+0 -3 D
+-2 -1 D
+-22 5 D
+-11 -3 D
+-30 -6 D
+-3 -2 D
+0 -28 D
+P
+2175 2635 M
+-3 1 D
+P
+FO
+2362 2668 M
+-3 0 D
+-3 -1 D
+-10 5 D
+-6 -2 D
+-1 2 D
+-4 -2 D
+-3 2 D
+3 2 D
+-9 -4 D
+-1 3 D
+-16 0 D
+-12 -4 D
+-5 1 D
+0 -2 D
+0 2 D
+-4 -1 D
+-1 -2 D
+-1 2 D
+-4 -3 D
+-1 1 D
+-13 -5 D
+-1 1 D
+-9 -10 D
+-1 -3 D
+3 -4 D
+1 1 D
+0 -1 D
+-5 1 D
+-11 -4 D
+4 -2 D
+7 3 D
+0 -4 D
+6 3 D
+5 0 D
+3 7 D
+8 1 D
+5 -1 D
+14 12 D
+21 0 D
+5 -3 D
+0 -2 D
+-12 -2 D
+9 -5 D
+9 0 D
+1 -3 D
+3 2 D
+0 -2 D
+1 5 D
+3 -4 D
+14 -1 D
+4 -4 D
+7 -4 D
+P
+FO
+2324 2835 M
+2 -1 D
+0 -5 D
+-2 -2 D
+0 -2 D
+-1 3 D
+3 1 D
+-4 6 D
+-50 0 D
+3 -2 D
+2 -4 D
+5 -2 D
+0 -4 D
+4 -2 D
+4 -6 D
+6 0 D
+1 -4 D
+3 -3 D
+-2 0 D
+2 -1 D
+0 -7 D
+-5 -16 D
+2 -1 D
+0 2 D
+2 -5 D
+2 5 D
+-3 1 D
+1 2 D
+3 -1 D
+0 -4 D
+2 0 D
+-1 2 D
+2 1 D
+0 -5 D
+-5 -5 D
+4 0 D
+-5 -1 D
+2 -1 D
+0 -4 D
+7 -10 D
+3 0 D
+-3 4 D
+4 -2 D
+3 1 D
+-2 -1 D
+0 -8 D
+3 -1 D
+4 4 D
+-5 -5 D
+3 -1 D
+2 -9 D
+3 -2 D
+-2 0 D
+2 0 D
+-2 -1 D
+0 -1 D
+3 0 D
+0 1 D
+2 -2 D
+1 1 D
+5 -3 D
+-2 0 D
+0 -1 D
+3 0 D
+-1 -1 D
+1 -3 D
+3 1 D
+2 -1 D
+-4 -1 D
+1 -3 D
+6 -4 D
+-6 2 D
+-1 -2 D
+2 -3 D
+7 2 D
+3 -1 D
+3 2 D
+4 -1 D
+-2 -1 D
+1 -1 D
+4 6 D
+-4 -4 D
+7 17 D
+0 -2 D
+2 23 D
+-2 8 D
+-4 2 D
+3 -1 D
+-15 35 D
+2 -1 D
+1 -6 D
+1 -2 D
+0 3 D
+3 1 D
+-1 3 D
+-9 12 D
+-10 22 D
+P
+2333 2808 M
+3 -2 D
+-3 -2 D
+1 2 D
+-3 1 D
+P
+2323 2823 M
+3 -5 D
+-1 -2 D
+-2 2 D
+P
+2344 2768 M
+4 -6 D
+-4 -6 D
+-8 7 D
+P
+2320 2806 M
+1 -2 D
+-3 2 D
+P
+2333 2735 M
+2 -2 D
+-4 3 D
+P
+2338 2804 M
+2 -3 D
+-3 5 D
+P
+2333 2787 M
+1 -5 D
+-4 4 D
+P
+2325 2802 M
+0 -1 D
+-2 0 D
+0 2 D
+P
+2333 2774 M
+-1 -3 D
+-1 3 D
+P
+2330 2794 M
+0 -3 D
+-1 1 D
+P
+2329 2784 M
+-1 -1 D
+P
+2329 2789 M
+1 -2 D
+P
+2333 2794 M
+-2 -1 D
+P
+2341 2811 M
+6 -8 D
+P
+FO
+2232 2835 M
+5 -4 D
+-1 -4 D
+-2 4 D
+2 -4 D
+8 1 D
+3 2 D
+0 -2 D
+8 5 D
+5 -1 D
+-3 3 D
+3 -1 D
+P
+FO
+2153 2835 M
+0 -4 D
+1 2 D
+P
+FO
+2136 2835 M
+-1 -3 D
+-2 0 D
+-1 2 D
+-2 -1 D
+-1 2 D
+-3 0 D
+0 -13 D
+2 1 D
+3 -1 D
+-1 -1 D
+1 0 D
+-1 -3 D
+5 1 D
+0 -2 D
+-1 1 D
+5 -1 D
+1 -4 D
+3 1 D
+-3 -5 D
+3 5 D
+3 -3 D
+3 3 D
+-2 1 D
+3 0 D
+-3 0 D
+-2 4 D
+-1 -1 D
+-3 2 D
+-5 0 D
+1 2 D
+-4 2 D
+2 1 D
+-2 0 D
+2 1 D
+-1 1 D
+2 0 D
+-1 2 D
+5 -2 D
+-3 3 D
+3 -2 D
+-1 2 D
+3 -1 D
+-2 1 D
+2 0 D
+2 2 D
+-2 -1 D
+-1 3 D
+-3 0 D
+1 1 D
+P
+FO
+2126 2822 M
+P
+FO
+2126 2817 M
+1 0 D
+-1 0 D
+P
+FO
+2291 2633 M
+4 0 D
+7 3 D
+-3 7 D
+-6 1 D
+-4 -3 D
+3 -5 D
+-1 -1 D
+-4 2 D
+P
+FO
+2357 2669 M
+0 1 D
+-4 -2 D
+4 0 D
+P
+FO
+2197 2609 M
+0 -4 D
+6 8 D
+-4 -1 D
+P
+FO
+2315 2636 M
+1 1 D
+-4 -2 D
+P
+FO
+2188 2634 M
+3 0 D
+3 2 D
+-7 -2 D
+P
+FO
+2316 2637 M
+1 -1 D
+2 2 D
+P
+FO
+2339 2672 M
+4 1 D
+0 1 D
+P
+FO
+2357 2671 M
+1 -2 D
+1 2 D
+P
+FO
+2331 2831 M
+2 -3 D
+-1 5 D
+P
+FO
+2325 2637 M
+2 -1 D
+3 3 D
+P
+FO
+2326 2708 M
+-1 1 D
+P
+FO
+2350 2787 M
+9 -19 D
+-12 29 D
+P
+FO
+2250 2828 M
+1 1 D
+-6 -3 D
+P
+FO
+2311 2756 M
+3 -4 D
+-1 3 D
+P
+FO
+2351 2673 M
+2 0 D
+P
+FO
+2244 2825 M
+0 0 D
+P
+FO
+2328 2710 M
+1 -2 D
+P
+FO
+2337 2724 M
+1 -1 D
+P
+FO
+2301 2640 M
+2 -1 D
+P
+FO
+2309 2756 M
+1 -1 D
+P
+FO
+2298 2807 M
+2 -1 D
+P
+FO
+2325 2647 M
+1 0 D
+-1 1 D
+P
+FO
+2339 2710 M
+1 1 D
+-2 -1 D
+P
+FO
+2253 2830 M
+1 1 D
+P
+FO
+2308 2759 M
+1 -2 D
+P
+FO
+2345 2674 M
+2 0 D
+P
+FO
+2297 2776 M
+2 -2 D
+-2 3 D
+P
+FO
+2298 2805 M
+2 1 D
+P
+FO
+2202 2630 M
+-1 2 D
+P
+FO
+2307 2635 M
+1 1 D
+P
+FO
+2316 2751 M
+2 -1 D
+P
+FO
+2324 2708 M
+1 0 D
+P
+FO
+2135 2824 M
+1 0 D
+P
+FO
+2142 2833 M
+2 0 D
+P
+FO
+2142 2833 M
+1 1 D
+P
+FO
+2203 2627 M
+0 1 D
+P
+FO
+2312 2750 M
+3 1 D
+-4 1 D
+P
+FO
+2348 2674 M
+3 -1 D
+P
+FO
+2329 2710 M
+2 -2 D
+P
+FO
+2328 2736 M
+2 0 D
+P
+FO
+2342 2674 M
+4 0 D
+P
+FO
+2339 2722 M
+0 1 D
+P
+FO
+2355 2672 M
+2 -1 D
+-2 2 D
+P
+FO
+2319 2706 M
+2 1 D
+P
+FO
+2328 2647 M
+3 -1 D
+P
+FO
+2340 2675 M
+2 0 D
+-2 1 D
+P
+FO
+2326 2709 M
+1 -1 D
+P
+FO
+2141 2830 M
+2 -1 D
+P
+FO
+2336 2710 M
+2 0 D
+P
+FO
+2324 2649 M
+0 -2 D
+P
+FO
+2299 2774 M
+2 -2 D
+P
+FO
+2302 2659 M
+1 2 D
+P
+FO
+2327 2737 M
+1 -1 D
+P
+FO
+2257 2655 M
+2 0 D
+P
+FO
+2360 2671 M
+1 -1 D
+P
+FO
+2297 2782 M
+1 -2 D
+P
+FO
+2281 2644 M
+2 0 D
+P
+FO
+2272 2664 M
+1 1 D
+P
+FO
+2347 2673 M
+1 0 D
+P
+FO
+2303 2639 M
+1 0 D
+P
+FO
+2311 2707 M
+2 -1 D
+P
+FO
+2345 2713 M
+1 1 D
+P
+FO
+2347 2671 M
+1 1 D
+-1 0 D
+P
+FO
+2347 2714 M
+1 1 D
+P
+FO
+2202 2633 M
+-1 2 D
+P
+FO
+2286 2642 M
+1 -2 D
+P
+FO
+2332 2646 M
+1 1 D
+-1 0 D
+P
+FO
+2310 2754 M
+0 -1 D
+P
+FO
+2144 2822 M
+2 0 D
+P
+FO
+2147 2823 M
+2 1 D
+P
+FO
+2345 2672 M
+1 0 D
+P
+FO
+2143 2833 M
+1 1 D
+P
+FO
+2277 2645 M
+2 0 D
+P
+FO
+2304 2636 M
+1 -1 D
+P
+FO
+2312 2636 M
+2 1 D
+-2 0 D
+P
+FO
+2329 2735 M
+2 0 D
+P
+FO
+2342 2712 M
+2 0 D
+P
+FO
+2459 2598 M
+1 1 D
+0 -1 D
+16 0 D
+0 1 D
+2 1 D
+-1 -2 D
+21 2 D
+3 4 D
+-2 2 D
+-4 -1 D
+-8 8 D
+-5 2 D
+-9 0 D
+0 -1 D
+-3 2 D
+-3 -2 D
+-1 3 D
+-3 -2 D
+-1 3 D
+5 -1 D
+-3 2 D
+3 3 D
+-3 3 D
+-8 -1 D
+-9 5 D
+-3 -1 D
+1 -1 D
+-1 -1 D
+-2 1 D
+2 2 D
+-3 0 D
+0 -1 D
+-2 1 D
+2 1 D
+-3 1 D
+-2 -2 D
+1 2 D
+-3 1 D
+-2 4 D
+-4 -3 D
+-2 1 D
+2 1 D
+-4 1 D
+5 -1 D
+1 3 D
+-7 3 D
+2 -4 D
+-2 0 D
+-1 3 D
+-6 1 D
+-3 4 D
+-1 -3 D
+-4 5 D
+-6 2 D
+-2 3 D
+-7 3 D
+0 -2 D
+-2 2 D
+-14 1 D
+-7 8 D
+-4 1 D
+1 2 D
+-4 -1 D
+-1 2 D
+0 -29 D
+3 1 D
+1 -2 D
+2 1 D
+13 -4 D
+11 2 D
+1 -1 D
+-2 -1 D
+3 0 D
+4 -6 D
+0 -6 D
+10 -8 D
+19 -1 D
+0 -3 D
+4 -1 D
+-1 -3 D
+-11 -6 D
+-1 -3 D
+P
+FO
+2536 2598 M
+-4 3 D
+-4 -1 D
+P
+FO
+2409 2700 M
+2 0 D
+1 2 D
+4 2 D
+-1 5 D
+-4 7 D
+-2 0 D
+1 2 D
+-1 3 D
+-2 -2 D
+-3 2 D
+2 -4 D
+-4 -6 D
+3 1 D
+0 -2 D
+-3 1 D
+1 -3 D
+-1 3 D
+2 -2 D
+-1 -2 D
+-1 3 D
+-4 -3 D
+7 -4 D
+2 2 D
+-2 -3 D
+3 0 D
+1 -4 D
+1 1 D
+-1 0 D
+P
+FO
+2424 2740 M
+2 0 D
+3 -3 D
+0 8 D
+4 3 D
+-1 2 D
+1 3 D
+-6 2 D
+-8 7 D
+4 -6 D
+2 0 D
+0 -1 D
+5 -2 D
+-2 0 D
+1 -3 D
+-2 0 D
+2 -1 D
+-2 -1 D
+1 -2 D
+-1 -1 D
+2 -1 D
+-6 -4 D
+P
+FO
+2421 2693 M
+-2 5 D
+-2 -4 D
+-3 -1 D
+3 3 D
+-2 0 D
+3 2 D
+-1 2 D
+-6 -4 D
+3 -4 D
+1 0 D
+-1 -2 D
+4 0 D
+-2 -1 D
+2 -1 D
+2 2 D
+1 -2 D
+P
+FO
+2453 2717 M
+-1 -5 D
+-4 0 D
+5 -5 D
+-1 4 D
+2 9 D
+-15 10 D
+-1 -4 D
+4 1 D
+11 -8 D
+P
+FO
+2482 2669 M
+2 -3 D
+0 3 D
+-5 4 D
+-4 9 D
+-3 3 D
+5 -7 D
+0 -3 D
+2 -3 D
+-4 1 D
+P
+FO
+2524 2622 M
+3 5 D
+0 3 D
+-3 -4 D
+-4 -1 D
+-2 3 D
+-6 -3 D
+-1 -3 D
+1 -2 D
+P
+FO
+2504 2656 M
+-7 -6 D
+7 3 D
+3 4 D
+0 6 D
+-4 -1 D
+0 -2 D
+4 -2 D
+P
+FO
+2409 2757 M
+-8 -1 D
+-4 1 D
+-1 2 D
+-1 -4 D
+-4 -3 D
+21 4 D
+0 2 D
+P
+FO
+2413 2646 M
+4 -3 D
+1 3 D
+-5 2 D
+0 3 D
+-3 0 D
+-1 2 D
+-1 -3 D
+5 -5 D
+P
+FO
+2527 2656 M
+-3 1 D
+0 -3 D
+6 0 D
+3 -2 D
+1 2 D
+P
+FO
+2462 2709 M
+9 -10 D
+-3 -3 D
+5 0 D
+-7 12 D
+P
+FO
+2556 2642 M
+-3 -1 D
+7 -2 D
+-1 3 D
+P
+FO
+2457 2684 M
+-1 -1 D
+9 -3 D
+-8 6 D
+-1 -2 D
+P
+FO
+2496 2665 M
+1 -3 D
+0 2 D
+2 -2 D
+5 1 D
+P
+FO
+2543 2640 M
+5 1 D
+-5 1 D
+P
+FO
+2393 2658 M
+4 -2 D
+6 0 D
+-3 3 D
+P
+FO
+2402 2655 M
+5 -4 D
+1 1 D
+-1 3 D
+P
+FO
+2425 2716 M
+2 1 D
+-4 1 D
+-3 -1 D
+P
+FO
+2551 2645 M
+-1 -3 D
+4 -1 D
+-1 3 D
+P
+FO
+2560 2640 M
+-1 -2 D
+4 -2 D
+1 3 D
+P
+FO
+2491 2693 M
+-1 -1 D
+2 0 D
+1 4 D
+P
+FO
+2528 2635 M
+-2 -1 D
+0 -2 D
+4 2 D
+P
+FO
+2379 2733 M
+1 0 D
+-1 1 D
+P
+FO
+2410 2697 M
+3 0 D
+1 2 D
+P
+FO
+2414 2701 M
+3 0 D
+-1 2 D
+P
+FO
+2371 2664 M
+8 -4 D
+-7 5 D
+P
+FO
+2417 2688 M
+1 -2 D
+3 2 D
+P
+FO
+2386 2619 M
+-2 1 D
+3 -2 D
+P
+FO
+2418 2643 M
+5 -3 D
+-3 4 D
+P
+FO
+2404 2764 M
+0 -2 D
+1 3 D
+P
+FO
+2412 2754 M
+1 -1 D
+0 2 D
+-1 0 D
+P
+FO
+2481 2685 M
+3 -1 D
+1 2 D
+P
+FO
+2457 2707 M
+2 -1 D
+P
+FO
+2411 2755 M
+2 1 D
+P
+FO
+2405 2656 M
+1 0 D
+P
+FO
+2376 2661 M
+1 -1 D
+P
+FO
+2427 2749 M
+0 -1 D
+P
+FO
+2412 2755 M
+1 0 D
+P
+FO
+2391 2658 M
+1 1 D
+P
+FO
+2513 2659 M
+0 1 D
+P
+FO
+2389 2657 M
+1 0 D
+P
+FO
+2412 2726 M
+2 1 D
+P
+FO
+2514 2660 M
+2 0 D
+P
+FO
+2411 2654 M
+1 -1 D
+P
+FO
+2413 2699 M
+2 1 D
+P
+FO
+2374 2661 M
+2 0 D
+P
+FO
+2380 2661 M
+2 0 D
+P
+FO
+2411 2755 M
+2 1 D
+P
+FO
+2429 2757 M
+2 -1 D
+P
+FO
+2554 2644 M
+0 -2 D
+P
+FO
+2425 2748 M
+1 -1 D
+P
+FO
+2378 2656 M
+2 0 D
+P
+FO
+2427 2719 M
+4 0 D
+P
+FO
+2461 2655 M
+0 -1 D
+P
+FO
+2409 2649 M
+-1 1 D
+P
+FO
+2383 2658 M
+1 0 D
+P
+FO
+2433 2752 M
+1 1 D
+P
+FO
+2437 2707 M
+1 1 D
+P
+FO
+2414 2726 M
+1 1 D
+P
+FO
+2407 2650 M
+1 0 D
+P
+FO
+2410 2761 M
+3 1 D
+P
+FO
+2392 2625 M
+1 -1 D
+P
+FO
+2425 2719 M
+1 -1 D
+P
+FO
+2454 2688 M
+1 -1 D
+P
+FO
+2416 2728 M
+0 1 D
+P
+FO
+2414 2689 M
+1 0 D
+P
+FO
+2436 2728 M
+2 1 D
+P
+FO
+2443 2702 M
+0 -2 D
+P
+FO
+2462 2682 M
+1 -1 D
+P
+FO
+2417 2764 M
+1 -1 D
+P
+FO
+2383 2659 M
+1 0 D
+P
+FO
+2450 2690 M
+1 0 D
+P
+FO
+2433 2751 M
+0 -1 D
+P
+FO
+2374 2661 M
+1 -1 D
+P
+FO
+2372 2683 M
+1 -1 D
+P
+FO
+2467 2617 M
+2 -1 D
+P
+FO
+2409 2698 M
+2 1 D
+P
+FO
+2415 2688 M
+3 0 D
+P
+FO
+2387 2617 M
+3 0 D
+P
+FO
+2381 2622 M
+3 -2 D
+P
+FO
+2508 2671 M
+4 0 D
+P
+FO
+2377 2625 M
+2 -2 D
+P
+FO
+2465 2680 M
+3 -1 D
+P
+FO
+2412 2653 M
+3 -3 D
+P
+FO
+2368 2666 M
+2 0 D
+P
+FO
+2412 2735 M
+2 -2 D
+-2 3 D
+P
+FO
+2363 2668 M
+2 -1 D
+P
+FO
+2563 2636 M
+-1 -2 D
+P
+FO
+2365 2668 M
+2 0 D
+P
+FO
+2540 2637 M
+1 2 D
+P
+FO
+2414 2690 M
+3 -1 D
+P
+FO
+2386 2661 M
+-2 0 D
+P
+FO
+2571 2632 M
+1 2 D
+P
+FO
+2398 2613 M
+3 -2 D
+P
+FO
+2419 2748 M
+1 -2 D
+P
+FO
+2390 2616 M
+2 -1 D
+P
+FO
+2398 2708 M
+1 1 D
+P
+FO
+2449 2693 M
+-2 3 D
+P
+FO
+2426 2751 M
+1 0 D
+P
+FO
+2463 2651 M
+1 -1 D
+P
+FO
+2455 2686 M
+0 -1 D
+P
+FO
+2393 2660 M
+1 -1 D
+P
+FO
+2398 2616 M
+1 0 D
+P
+FO
+2375 2625 M
+2 0 D
+P
+FO
+2401 2651 M
+1 1 D
+P
+FO
+2436 2724 M
+2 2 D
+P
+FO
+4016 2825 M
+-5 -7 D
+-8 -7 D
+-13 -6 D
+-10 -11 D
+-17 -6 D
+-16 -2 D
+-7 -7 D
+-11 -23 D
+-12 -6 D
+-7 -5 D
+-8 -21 D
+-2 -15 D
+-24 -21 D
+-2 -4 D
+7 8 D
+-1 -4 D
+-11 -17 D
+1 1 D
+0 -3 D
+-3 -2 D
+-5 -14 D
+-4 0 D
+-3 -3 D
+-4 -9 D
+-3 -23 D
+1 -1 D
+1 6 D
+2 3 D
+6 -12 D
+3 -3 D
+1 5 D
+1 -2 D
+1 0 D
+-1 0 D
+6 -10 D
+-1 -3 D
+1 -3 D
+147 0 D
+P
+FO
+3858 2787 M
+3 1 D
+3 3 D
+2 5 D
+5 5 D
+-5 0 D
+-4 -4 D
+-10 -1 D
+P
+FO
+3921 2792 M
+4 5 D
+-1 8 D
+-3 -1 D
+-5 -12 D
+-7 -3 D
+5 -1 D
+2 3 D
+P
+FO
+3934 2811 M
+1 5 D
+-1 1 D
+-2 -3 D
+-6 -2 D
+-2 -4 D
+2 -1 D
+P
+FO
+3889 2787 M
+-1 5 D
+-1 -2 D
+-6 1 D
+-3 -6 D
+6 -4 D
+5 3 D
+P
+FO
+3827 2806 M
+4 -8 D
+3 7 D
+-5 3 D
+P
+FO
+3842 2790 M
+3 -2 D
+3 2 D
+-4 3 D
+P
+FO
+3827 2779 M
+3 4 D
+-1 1 D
+-6 -2 D
+P
+FO
+3932 2816 M
+2 2 D
+P
+FO
+4022 2835 M
+-6 -10 D
+0 -227 D
+236 0 D
+0 237 D
+P
+FO
+4360 2362 M
+-1 2 D
+-2 -1 D
+1 2 D
+-1 0 D
+2 1 D
+-2 1 D
+1 0 D
+0 2 D
+-4 2 D
+3 0 D
+0 7 D
+3 -2 D
+2 1 D
+1 6 D
+-3 5 D
+-7 2 D
+-3 5 D
+4 -4 D
+5 -2 D
+5 -5 D
+-1 -8 D
+-2 -1 D
+2 -4 D
+-4 -6 D
+2 0 D
+0 -3 D
+127 0 D
+0 236 D
+-236 0 D
+0 -89 D
+7 -10 D
+-7 9 D
+0 -146 D
+P
+4273 2475 M
+5 -7 D
+-5 4 D
+P
+4336 2404 M
+7 -5 D
+-5 1 D
+P
+4270 2489 M
+-3 -8 D
+P
+FO
+4488 2362 M
+236 0 D
+0 236 D
+-236 0 D
+P
+4610 2434 M
+1 -1 D
+-1 -2 D
+-15 0 D
+1 -2 D
+-1 1 D
+-1 -5 D
+-6 0 D
+1 -2 D
+-2 -3 D
+-1 2 D
+-3 -1 D
+-4 4 D
+1 4 D
+-2 1 D
+2 3 D
+-2 -1 D
+2 4 D
+-3 -2 D
+-4 2 D
+-5 7 D
+-1 7 D
+-3 3 D
+10 3 D
+5 -5 D
+0 -3 D
+-2 -3 D
+2 -4 D
+3 0 D
+1 2 D
+5 2 D
+-2 -3 D
+2 -2 D
+-2 -1 D
+2 -2 D
+10 2 D
+6 -1 D
+1 -3 D
+P
+4590 2428 M
+1 -2 D
+2 0 D
+P
+4711 2366 M
+1 -2 D
+-1 -1 D
+-1 1 D
+P
+4664 2432 M
+2 -1 D
+-2 -1 D
+P
+FO
+4724 2362 M
+237 0 D
+0 236 D
+-237 0 D
+P
+FO
+5197 2490 M
+-3 2 D
+-2 -2 D
+1 -6 D
+-1 -2 D
+-2 1 D
+-2 9 D
+-4 1 D
+0 6 D
+-4 2 D
+-3 19 D
+-6 17 D
+-8 16 D
+-4 1 D
+0 2 D
+-3 0 D
+0 2 D
+-1 -1 D
+-4 1 D
+1 3 D
+-9 7 D
+-5 0 D
+-7 22 D
+1 -1 D
+-2 9 D
+-169 0 D
+0 -236 D
+236 0 D
+P
+5134 2401 M
+-1 4 D
+-4 1 D
+-1 -1 D
+-2 2 D
+0 6 D
+3 3 D
+3 -2 D
+5 3 D
+3 -7 D
+-4 -9 D
+P
+5131 2407 M
+2 1 D
+P
+5071 2395 M
+-8 5 D
+1 5 D
+2 -1 D
+-2 -4 D
+P
+5100 2474 M
+-1 5 D
+2 -3 D
+P
+5190 2395 M
+0 -1 D
+P
+5191 2392 M
+0 -1 D
+P
+FO
+5197 2495 M
+-2 2 D
+2 -3 D
+P
+FO
+5197 2499 M
+-2 -2 D
+2 0 D
+P
+FO
+5197 2501 M
+-1 0 D
+P
+FO
+5197 2505 M
+0 -1 D
+P
+FO
+5141 2572 M
+-2 -1 D
+3 -1 D
+P
+FO
+5188 2502 M
+1 0 D
+P
+FO
+5183 2507 M
+1 -2 D
+-1 3 D
+P
+FO
+5193 2512 M
+2 0 D
+P
+FO
+5159 2556 M
+2 -2 D
+P
+FO
+5191 2491 M
+0 1 D
+P
+FO
+5138 2569 M
+P
+FO
+5186 2512 M
+1 0 D
+P
+FO
+5433 2398 M
+-10 -1 D
+-3 -3 D
+-11 -2 D
+-11 1 D
+-9 -4 D
+-10 -1 D
+-7 2 D
+-18 -10 D
+-5 -2 D
+-15 5 D
+-20 -11 D
+-9 -1 D
+-7 1 D
+-9 7 D
+-9 12 D
+-1 4 D
+-6 2 D
+-2 3 D
+-8 0 D
+-4 -3 D
+-2 1 D
+0 2 D
+3 -1 D
+3 5 D
+6 1 D
+3 3 D
+5 1 D
+1 4 D
+-3 8 D
+-7 10 D
+-2 -3 D
+-3 1 D
+-1 5 D
+-5 5 D
+-4 -1 D
+-3 10 D
+-2 1 D
+2 -3 D
+-7 7 D
+-6 2 D
+-12 16 D
+-10 2 D
+-1 5 D
+-3 0 D
+1 1 D
+-3 2 D
+0 -2 D
+-3 1 D
+-2 -2 D
+-2 1 D
+-5 7 D
+2 2 D
+-2 2 D
+0 -128 D
+236 0 D
+P
+5239 2393 M
+2 -3 D
+-2 -2 D
+-3 3 D
+P
+5236 2400 M
+1 -2 D
+-2 1 D
+P
+5254 2403 M
+1 -2 D
+-1 0 D
+P
+5209 2369 M
+1 -1 D
+-2 -2 D
+P
+5208 2455 M
+1 1 D
+P
+5217 2438 M
+2 5 D
+P
+5207 2456 M
+-2 3 D
+P
+5237 2397 M
+0 -3 D
+P
+FO
+5208 2598 M
+2 0 D
+2 -5 D
+2 1 D
+2 -2 D
+-1 -3 D
+5 -3 D
+-1 -3 D
+3 -5 D
+2 -1 D
+-1 -3 D
+3 -3 D
+-1 -3 D
+5 -5 D
+6 -12 D
+15 -13 D
+2 -10 D
+0 4 D
+4 -4 D
+0 -3 D
+4 -4 D
+3 -16 D
+-1 -4 D
+-3 -4 D
+3 -10 D
+-1 -2 D
+-1 4 D
+-1 -3 D
+-2 0 D
+6 -2 D
+2 -8 D
+-1 2 D
+3 -11 D
+-1 1 D
+7 -19 D
+-1 -10 D
+6 -10 D
+0 -4 D
+3 2 D
+8 -4 D
+11 2 D
+4 4 D
+8 -2 D
+-1 1 D
+3 2 D
+-1 -2 D
+2 -1 D
+2 6 D
+6 1 D
+7 7 D
+24 2 D
+16 5 D
+14 10 D
+5 -2 D
+12 2 D
+7 6 D
+2 5 D
+22 8 D
+0 121 D
+P
+FO
+5197 2504 M
+3 0 D
+-1 1 D
+1 1 D
+-2 1 D
+P
+FO
+5197 2501 M
+1 -1 D
+-1 -3 D
+2 -1 D
+-2 -1 D
+0 -1 D
+10 0 D
+-3 3 D
+-2 -1 D
+2 0 D
+-3 -1 D
+-2 5 D
+P
+FO
+5244 2520 M
+2 0 D
+0 -1 D
+2 -1 D
+1 3 D
+-3 2 D
+-1 -2 D
+-7 4 D
+1 -2 D
+P
+FO
+5244 2522 M
+-2 2 D
+2 1 D
+-2 2 D
+-2 -1 D
+1 -3 D
+P
+FO
+5257 2488 M
+1 -1 D
+1 4 D
+P
+FO
+5203 2480 M
+2 1 D
+-1 1 D
+P
+FO
+5242 2528 M
+-2 0 D
+3 -1 D
+P
+FO
+5260 2457 M
+3 -2 D
+-1 3 D
+P
+FO
+5202 2484 M
+1 -1 D
+1 2 D
+P
+FO
+5244 2519 M
+1 0 D
+P
+FO
+5251 2511 M
+1 1 D
+P
+FO
+5277 2425 M
+1 0 D
+P
+FO
+5255 2511 M
+2 0 D
+P
+FO
+5215 2492 M
+2 0 D
+P
+FO
+5268 2431 M
+-1 1 D
+P
+FO
+5262 2453 M
+1 1 D
+P
+FO
+5264 2434 M
+1 -1 D
+P
+FO
+5265 2471 M
+2 0 D
+P
+FO
+5264 2433 M
+0 -1 D
+P
+FO
+5253 2493 M
+1 -2 D
+P
+FO
+5236 2526 M
+2 0 D
+P
+FO
+5200 2507 M
+2 1 D
+P
+FO
+5237 2521 M
+3 -1 D
+P
+FO
+5201 2496 M
+1 2 D
+P
+FO
+5253 2498 M
+2 -1 D
+P
+FO
+5265 2432 M
+2 -1 D
+P
+FO
+5234 2525 M
+1 -2 D
+P
+FO
+5200 2516 M
+1 1 D
+P
+FO
+5200 2505 M
+1 0 D
+P
+FO
+5276 2397 M
+1 1 D
+P
+FO
+5205 2492 M
+1 0 D
+P
+FO
+5198 2508 M
+1 1 D
+P
+FO
+5240 2520 M
+1 -1 D
+P
+FO
+5255 2492 M
+2 0 D
+P
+FO
+5222 2562 M
+0 2 D
+P
+FO
+5211 2590 M
+1 -1 D
+P
+FO
+5234 2525 M
+1 -1 D
+P
+FO
+5216 2586 M
+0 -1 D
+P
+FO
+5258 2496 M
+1 -1 D
+P
+FO
+5204 2483 M
+1 1 D
+P
+FO
+5266 2431 M
+1 -1 D
+P
+FO
+5454 2362 M
+0 8 D
+7 2 D
+5 -1 D
+1 2 D
+-6 3 D
+1 -4 D
+-5 0 D
+4 4 D
+-1 9 D
+1 4 D
+-2 1 D
+5 16 D
+-12 3 D
+-5 -2 D
+-2 -4 D
+-6 -3 D
+-6 -2 D
+0 -36 D
+P
+FO
+5433 2477 M
+4 0 D
+7 4 D
+21 5 D
+20 9 D
+-1 9 D
+3 6 D
+5 4 D
+18 7 D
+8 1 D
+11 5 D
+13 1 D
+4 -2 D
+6 2 D
+5 5 D
+1 4 D
+-1 3 D
+4 7 D
+22 2 D
+5 5 D
+2 11 D
+4 4 D
+7 3 D
+17 3 D
+-4 17 D
+3 6 D
+-184 0 D
+P
+FO
+5528 2417 M
+12 6 D
+-10 3 D
+-8 -2 D
+-3 2 D
+-3 0 D
+-5 -4 D
+6 -4 D
+P
+FO
+5575 2539 M
+2 1 D
+-1 1 D
+-2 -1 D
+P
+FO
+5482 2415 M
+5 -2 D
+3 1 D
+P
+FO
+5504 2413 M
+2 0 D
+P
+FO
+5571 2539 M
+1 0 D
+P
+FO
+5510 2412 M
+1 0 D
+P
+FO
+6053 2362 M
+1 1 D
+0 -1 D
+70 0 D
+1 6 D
+8 3 D
+6 -2 D
+-1 25 D
+-2 1 D
+2 -1 D
+-2 8 D
+6 13 D
+0 183 D
+-172 0 D
+0 -1 D
+-2 0 D
+2 -10 D
+4 0 D
+-4 -1 D
+1 -3 D
+3 -1 D
+-3 0 D
+0 -3 D
+2 2 D
+-2 -3 D
+1 1 D
+0 -7 D
+4 7 D
+0 -4 D
+2 0 D
+-4 -3 D
+2 0 D
+1 -4 D
+-2 3 D
+-2 -1 D
+0 -2 D
+4 -6 D
+-3 2 D
+1 -5 D
+2 -2 D
+1 2 D
+1 -4 D
+-3 3 D
+-1 -2 D
+2 -5 D
+2 0 D
+-2 -1 D
+4 -9 D
+-1 0 D
+1 -3 D
+-1 -1 D
+3 -3 D
+-2 1 D
+3 -6 D
+-1 -1 D
+1 -1 D
+-1 -4 D
+2 1 D
+-1 -5 D
+2 -1 D
+-2 0 D
+3 -2 D
+-2 -1 D
+-1 2 D
+1 -4 D
+2 1 D
+-2 -1 D
+1 0 D
+1 -8 D
+4 -4 D
+3 -6 D
+1 1 D
+-1 -2 D
+1 -2 D
+1 0 D
+-1 -1 D
+2 -1 D
+-2 0 D
+3 -2 D
+1 -4 D
+-1 -2 D
+6 -5 D
+-1 -2 D
+4 -1 D
+3 -11 D
+2 -1 D
+-2 1 D
+5 -14 D
+2 -1 D
+-1 0 D
+0 -7 D
+3 -12 D
+9 -19 D
+3 -1 D
+5 -6 D
+2 -6 D
+6 -8 D
+1 -8 D
+1 0 D
+-1 0 D
+4 -6 D
+2 -8 D
+1 0 D
+P
+6020 2461 M
+2 -4 D
+3 0 D
+-1 -2 D
+-2 2 D
+0 -1 D
+-2 0 D
+2 1 D
+-2 2 D
+P
+6053 2487 M
+2 -1 D
+-11 -3 D
+3 2 D
+2 -1 D
+0 3 D
+4 -1 D
+P
+6038 2450 M
+1 -2 D
+-2 1 D
+-1 -4 D
+-1 3 D
+P
+6087 2409 M
+5 -2 D
+-2 -2 D
+0 2 D
+-3 1 D
+P
+6058 2421 M
+3 -2 D
+-3 1 D
+P
+6138 2471 M
+1 -2 D
+P
+6131 2394 M
+0 -2 D
+P
+FO
+6131 2370 M
+5 -1 D
+P
+FO
+5971 2390 M
+1 2 D
+P
+FO
+5967 2375 M
+0 1 D
+P
+FO
+6142 2415 M
+3 5 D
+5 20 D
+-2 12 D
+-4 11 D
+2 7 D
+-1 0 D
+1 1 D
+-3 11 D
+5 14 D
+10 5 D
+3 -1 D
+0 -3 D
+3 0 D
+-1 1 D
+1 -1 D
+5 6 D
+3 8 D
+6 2 D
+4 -2 D
+0 2 D
+0 -2 D
+14 6 D
+2 8 D
+-1 2 D
+0 -3 D
+-2 1 D
+1 3 D
+7 6 D
+15 8 D
+8 10 D
+13 6 D
+0 1 D
+6 5 D
+-2 0 D
+12 13 D
+-1 1 D
+8 6 D
+-1 0 D
+13 7 D
+-1 0 D
+19 6 D
+-1 1 D
+2 0 D
+-151 0 D
+P
+6173 2522 M
+0 -4 D
+-5 0 D
+3 2 D
+0 -2 D
+P
+6183 2529 M
+0 -3 D
+-1 3 D
+P
+6192 2521 M
+4 -1 D
+-5 0 D
+P
+6281 2596 M
+1 -1 D
+-1 0 D
+P
+6162 2499 M
+1 -2 D
+-1 0 D
+P
+FO
+6160 2498 M
+1 -1 D
+P
+FO
+6573 2362 M
+1 1 D
+-3 -1 D
+P
+FO
+6580 2362 M
+2 5 D
+1 -1 D
+2 4 D
+-3 -8 D
+12 0 D
+0 3 D
+2 3 D
+-2 2 D
+3 1 D
+-1 4 D
+5 8 D
+2 0 D
+-1 7 D
+2 0 D
+2 8 D
+8 15 D
+-1 14 D
+1 12 D
+-1 1 D
+1 158 D
+-155 0 D
+1 -1 D
+1 1 D
+0 -1 D
+2 0 D
+-1 -1 D
+4 1 D
+1 -1 D
+-3 0 D
+-1 -4 D
+2 2 D
+-1 -2 D
+3 2 D
+-1 -3 D
+2 1 D
+0 -2 D
+-2 -1 D
+4 -3 D
+1 2 D
+-1 -2 D
+2 0 D
+1 -2 D
+-5 -4 D
+-3 2 D
+-1 -1 D
+-1 4 D
+-2 0 D
+-1 -2 D
+5 -6 D
+0 -2 D
+6 -4 D
+1 3 D
+-2 6 D
+2 -2 D
+0 3 D
+2 2 D
+-1 -5 D
+2 0 D
+-2 -1 D
+2 0 D
+-2 -6 D
+2 -1 D
+1 2 D
+0 -2 D
+3 -1 D
+-3 0 D
+6 -10 D
+-2 -2 D
+3 -2 D
+1 -4 D
+-1 0 D
+4 -10 D
+-2 0 D
+2 -6 D
+-3 0 D
+1 -4 D
+-2 1 D
+1 -6 D
+-3 0 D
+-1 -9 D
+-2 0 D
+-1 -12 D
+1 -2 D
+5 3 D
+2 4 D
+2 0 D
+-3 -5 D
+-3 -1 D
+1 -4 D
+1 3 D
+0 -1 D
+4 4 D
+-2 -3 D
+3 0 D
+-1 -1 D
+2 -2 D
+1 4 D
+2 0 D
+-2 -5 D
+2 0 D
+0 3 D
+2 -2 D
+-2 -1 D
+3 -1 D
+1 2 D
+0 -1 D
+1 0 D
+0 6 D
+2 2 D
+0 -8 D
+2 0 D
+0 3 D
+1 -2 D
+1 2 D
+0 -5 D
+4 1 D
+5 6 D
+1 6 D
+1 -3 D
+5 4 D
+-1 -2 D
+4 3 D
+-2 1 D
+3 -2 D
+4 3 D
+-5 9 D
+2 -1 D
+3 2 D
+-2 -2 D
+1 -4 D
+4 -2 D
+6 2 D
+3 7 D
+-1 1 D
+2 0 D
+-1 -2 D
+1 3 D
+1 -4 D
+1 11 D
+-3 3 D
+1 3 D
+1 -4 D
+3 -2 D
+-1 -2 D
+3 -3 D
+1 1 D
+0 -3 D
+3 -3 D
+0 -4 D
+2 1 D
+0 -5 D
+6 0 D
+0 3 D
+1 -2 D
+2 0 D
+-3 -1 D
+0 -11 D
+-1 1 D
+4 -5 D
+-1 -3 D
+2 -8 D
+-2 -1 D
+1 -3 D
+2 -1 D
+-1 -8 D
+1 -3 D
+2 0 D
+-1 -1 D
+2 -6 D
+1 1 D
+-1 -3 D
+3 -4 D
+-1 -4 D
+1 -6 D
+2 -2 D
+-1 -3 D
+1 0 D
+1 10 D
+0 -6 D
+2 1 D
+4 -7 D
+2 -6 D
+1 1 D
+1 -12 D
+2 -2 D
+-2 -2 D
+2 0 D
+-1 -1 D
+2 -1 D
+-4 0 D
+1 -2 D
+-2 -1 D
+3 -1 D
+-4 -1 D
+1 -2 D
+2 1 D
+2 -2 D
+-2 -1 D
+2 -1 D
+-1 -1 D
+2 -1 D
+-5 -2 D
+3 0 D
+-2 -2 D
+3 -2 D
+2 3 D
+0 -3 D
+2 -1 D
+-4 0 D
+0 -4 D
+2 -2 D
+-3 0 D
+2 -4 D
+-3 -3 D
+2 -1 D
+-1 -2 D
+3 0 D
+-2 0 D
+0 -3 D
+-3 0 D
+1 -1 D
+-2 -3 D
+-1 1 D
+1 -2 D
+-1 2 D
+-1 -2 D
+2 -7 D
+-2 -4 D
+P
+6611 2579 M
+1 -1 D
+P
+6498 2565 M
+0 -1 D
+P
+6534 2541 M
+1 -1 D
+-2 0 D
+P
+FO
+6452 2598 M
+3 -4 D
+-2 4 D
+P
+FO
+6450 2598 M
+3 -5 D
+-1 5 D
+P
+FO
+6448 2598 M
+1 -4 D
+0 4 D
+-1 0 D
+P
+FO
+6445 2433 M
+-1 -2 D
+2 -1 D
+1 3 D
+1 -1 D
+-2 3 D
+2 -2 D
+2 1 D
+1 5 D
+-3 2 D
+3 0 D
+-2 2 D
+1 4 D
+-5 -4 D
+P
+FO
+6443 2409 M
+-1 6 D
+-2 -9 D
+-1 2 D
+-1 -2 D
+4 -9 D
+1 4 D
+-2 0 D
+2 1 D
+1 5 D
+-2 1 D
+P
+FO
+6464 2586 M
+3 -4 D
+2 0 D
+0 2 D
+1 -2 D
+2 1 D
+0 2 D
+-7 3 D
+P
+FO
+6442 2424 M
+0 -7 D
+4 0 D
+-2 3 D
+3 -1 D
+1 2 D
+-4 3 D
+P
+FO
+6569 2383 M
+3 0 D
+0 -4 D
+1 0 D
+1 2 D
+-2 4 D
+-2 0 D
+P
+FO
+6434 2381 M
+0 -6 D
+4 -1 D
+2 4 D
+-2 5 D
+P
+FO
+6574 2425 M
+1 -8 D
+3 6 D
+-1 1 D
+0 -2 D
+-1 3 D
+P
+FO
+6577 2409 M
+1 -3 D
+5 2 D
+-4 1 D
+-2 3 D
+P
+FO
+6567 2418 M
+1 1 D
+-3 -2 D
+2 -1 D
+3 3 D
+P
+FO
+6576 2404 M
+1 -5 D
+2 -1 D
+1 6 D
+P
+FO
+6574 2433 M
+0 -2 D
+1 4 D
+-2 3 D
+P
+FO
+6449 2409 M
+1 -2 D
+-2 4 D
+-1 -2 D
+P
+FO
+6580 2386 M
+-1 2 D
+-1 -3 D
+1 -1 D
+P
+FO
+6443 2412 M
+3 2 D
+0 3 D
+-2 0 D
+P
+FO
+6571 2366 M
+0 -3 D
+2 3 D
+-2 1 D
+P
+FO
+6460 2572 M
+4 -5 D
+2 0 D
+0 5 D
+P
+FO
+6554 2515 M
+0 -4 D
+2 -2 D
+2 6 D
+P
+FO
+6461 2592 M
+1 -1 D
+1 2 D
+P
+FO
+6558 2406 M
+1 -1 D
+0 2 D
+P
+FO
+6571 2396 M
+2 1 D
+1 8 D
+P
+FO
+6458 2597 M
+3 -5 D
+0 4 D
+P
+FO
+6439 2394 M
+3 0 D
+-2 4 D
+P
+FO
+6568 2414 M
+2 -1 D
+0 3 D
+P
+FO
+6441 2430 M
+0 -2 D
+1 5 D
+P
+FO
+6581 2404 M
+2 -2 D
+0 1 D
+P
+FO
+6567 2405 M
+2 -4 D
+0 2 D
+P
+FO
+6579 2383 M
+0 -3 D
+1 2 D
+P
+FO
+6450 2412 M
+1 0 D
+0 2 D
+P
+FO
+6447 2416 M
+0 -1 D
+1 2 D
+P
+FO
+6578 2419 M
+1 0 D
+0 3 D
+P
+FO
+6572 2422 M
+2 0 D
+-1 1 D
+P
+FO
+6564 2372 M
+2 0 D
+-1 2 D
+P
+FO
+6462 2594 M
+1 0 D
+P
+FO
+6573 2365 M
+1 -1 D
+P
+FO
+6565 2452 M
+0 2 D
+P
+FO
+6569 2395 M
+1 0 D
+-1 1 D
+P
+FO
+6450 2415 M
+2 1 D
+P
+FO
+6562 2460 M
+1 1 D
+P
+FO
+6430 2400 M
+2 -2 D
+P
+FO
+6462 2594 M
+3 2 D
+-3 -1 D
+P
+FO
+6564 2382 M
+2 2 D
+P
+FO
+6458 2592 M
+3 -1 D
+P
+FO
+6449 2412 M
+1 -1 D
+-1 2 D
+P
+FO
+6472 2579 M
+1 2 D
+P
+FO
+6577 2418 M
+2 1 D
+P
+FO
+6572 2392 M
+2 -1 D
+P
+FO
+6578 2438 M
+1 -1 D
+P
+FO
+6557 2511 M
+0 -1 D
+P
+FO
+6573 2407 M
+1 -1 D
+P
+FO
+6567 2376 M
+-1 -1 D
+P
+FO
+6471 2571 M
+1 -1 D
+P
+FO
+6571 2374 M
+2 1 D
+P
+FO
+6449 2412 M
+0 -1 D
+P
+FO
+6569 2418 M
+2 -1 D
+P
+FO
+6467 2582 M
+2 -1 D
+P
+FO
+6610 2364 M
+0 1 D
+P
+FO
+6563 2423 M
+1 0 D
+P
+FO
+6463 2588 M
+2 0 D
+P
+FO
+6582 2387 M
+1 0 D
+P
+FO
+6563 2428 M
+1 0 D
+P
+FO
+6568 2382 M
+1 0 D
+P
+FO
+6457 2460 M
+1 -2 D
+P
+FO
+6572 2408 M
+2 0 D
+P
+FO
+6447 2418 M
+1 2 D
+P
+FO
+6580 2437 M
+1 0 D
+P
+FO
+6442 2428 M
+0 -2 D
+P
+FO
+6449 2405 M
+2 1 D
+-2 0 D
+P
+FO
+6449 2432 M
+-1 0 D
+P
+FO
+6463 2586 M
+1 -1 D
+P
+FO
+6555 2405 M
+1 -1 D
+P
+FO
+6570 2419 M
+1 0 D
+P
+FO
+6566 2365 M
+1 1 D
+P
+FO
+6461 2587 M
+2 -1 D
+P
+FO
+6442 2391 M
+0 2 D
+P
+FO
+6439 2409 M
+1 -1 D
+P
+FO
+6497 2497 M
+1 1 D
+P
+FO
+6558 2517 M
+1 1 D
+P
+FO
+6461 2596 M
+0 -1 D
+P
+FO
+6438 2399 M
+0 1 D
+P
+FO
+6554 2405 M
+1 -1 D
+P
+FO
+6578 2386 M
+-1 -1 D
+P
+FO
+6445 2419 M
+2 0 D
+P
+FO
+6465 2477 M
+0 1 D
+P
+FO
+6558 2494 M
+1 -2 D
+P
+FO
+6467 2566 M
+1 1 D
+P
+FO
+6578 2396 M
+1 1 D
+P
+FO
+6575 2428 M
+1 -2 D
+P
+FO
+6579 2393 M
+1 -1 D
+P
+FO
+6568 2405 M
+1 0 D
+P
+FO
+6498 2503 M
+1 1 D
+P
+FO
+6764 2362 M
+-4 4 D
+5 -4 D
+3 0 D
+-4 5 D
+7 -5 D
+1 3 D
+0 -2 D
+2 1 D
+1 2 D
+-9 4 D
+8 -1 D
+1 3 D
+-2 2 D
+-1 -1 D
+2 3 D
+2 -5 D
+1 2 D
+0 -2 D
+2 1 D
+-1 1 D
+2 2 D
+3 -3 D
+-2 -1 D
+1 -1 D
+2 2 D
+2 -1 D
+13 8 D
+4 0 D
+2 5 D
+5 0 D
+6 5 D
+4 1 D
+2 3 D
+5 1 D
+0 7 D
+3 -2 D
+2 4 D
+-1 3 D
+-1 -1 D
+0 2 D
+2 2 D
+0 -2 D
+2 0 D
+-3 7 D
+2 3 D
+-3 3 D
+4 -2 D
+1 1 D
+-4 5 D
+4 4 D
+0 -3 D
+1 1 D
+1 -3 D
+1 2 D
+-3 4 D
+3 2 D
+-4 4 D
+-1 5 D
+1 2 D
+-2 0 D
+0 3 D
+2 -2 D
+1 1 D
+-3 3 D
+2 -1 D
+-2 9 D
+1 -4 D
+1 3 D
+-4 7 D
+2 -1 D
+-3 8 D
+0 5 D
+-5 11 D
+1 2 D
+-2 4 D
+-1 -1 D
+-2 3 D
+-1 -2 D
+-10 14 D
+2 3 D
+-2 0 D
+-1 -3 D
+1 2 D
+-3 1 D
+2 2 D
+-4 0 D
+1 0 D
+-1 3 D
+-5 -1 D
+-1 2 D
+1 0 D
+-3 3 D
+-3 0 D
+1 1 D
+-4 3 D
+4 -3 D
+-10 8 D
+-1 -1 D
+1 1 D
+-2 5 D
+-11 8 D
+-4 6 D
+-1 4 D
+2 2 D
+-2 4 D
+-2 -1 D
+0 1 D
+-4 3 D
+-2 0 D
+-3 5 D
+-2 -1 D
+1 1 D
+-3 7 D
+-1 -1 D
+-3 4 D
+0 4 D
+3 1 D
+0 3 D
+2 2 D
+-1 7 D
+3 4 D
+-1 0 D
+1 0 D
+0 3 D
+3 2 D
+-143 0 D
+0 -157 D
+7 5 D
+6 -1 D
+1 2 D
+2 -2 D
+8 0 D
+-3 -5 D
+1 -2 D
+-1 -3 D
+1 -2 D
+-2 -2 D
+2 -3 D
+-2 -1 D
+0 -2 D
+3 -2 D
+4 2 D
+7 -2 D
+8 3 D
+4 -4 D
+1 2 D
+1 -2 D
+2 0 D
+-1 -1 D
+4 -4 D
+0 3 D
+2 -3 D
+1 1 D
+-2 -2 D
+0 -2 D
+5 -1 D
+2 -3 D
+0 5 D
+2 -1 D
+7 -15 D
+0 3 D
+1 -1 D
+-1 -3 D
+2 1 D
+2 -2 D
+-1 -1 D
+2 -3 D
+-3 -2 D
+2 -2 D
+0 -6 D
+4 1 D
+3 -1 D
+2 7 D
+5 -3 D
+-2 0 D
+2 -4 D
+-1 -3 D
+-3 -1 D
+-1 -2 D
+3 -3 D
+4 1 D
+1 4 D
+2 -3 D
+8 0 D
+4 -5 D
+2 1 D
+-1 -1 D
+3 -5 D
+3 2 D
+8 -6 D
+P
+6752 2362 M
+-17 17 D
+-3 16 D
+1 1 D
+-2 1 D
+-4 10 D
+1 7 D
+-6 4 D
+2 0 D
+0 3 D
+-2 1 D
+2 -1 D
+1 -5 D
+4 -2 D
+-2 -8 D
+4 -7 D
+1 7 D
+3 0 D
+2 2 D
+5 0 D
+4 9 D
+8 -1 D
+3 1 D
+-3 12 D
+2 8 D
+-3 5 D
+3 8 D
+-1 6 D
+-4 1 D
+-1 3 D
+2 4 D
+2 11 D
+-1 5 D
+-6 8 D
+-9 -2 D
+6 2 D
+3 8 D
+-6 4 D
+-1 2 D
+2 2 D
+-8 2 D
+-8 10 D
+1 21 D
+-12 11 D
+-7 11 D
+-2 -1 D
+-13 3 D
+-2 -1 D
+1 -2 D
+-5 -4 D
+5 4 D
+-2 2 D
+7 1 D
+9 -3 D
+2 1 D
+12 -15 D
+7 -6 D
+0 -22 D
+7 -10 D
+8 -2 D
+-1 -2 D
+1 -2 D
+6 -4 D
+-1 -5 D
+-2 -2 D
+2 -1 D
+7 -8 D
+1 -6 D
+-2 -3 D
+-1 -12 D
+4 -3 D
+1 -7 D
+-2 -3 D
+6 1 D
+-6 -2 D
+0 -6 D
+3 -2 D
+-3 -9 D
+2 -10 D
+-1 -3 D
+-10 0 D
+-3 -8 D
+-6 1 D
+-5 -3 D
+-1 -5 D
+8 -5 D
+-2 -11 D
+1 -3 D
+2 0 D
+3 -6 D
+10 -6 D
+13 1 D
+-6 -1 D
+3 -1 D
+-1 -1 D
+-5 2 D
+2 -1 D
+-6 0 D
+-10 7 D
+-3 0 D
+P
+6740 2375 M
+1 5 D
+-4 1 D
+1 14 D
+-7 4 D
+3 -3 D
+-1 -1 D
+3 -16 D
+P
+6754 2444 M
+-1 -2 D
+1 -1 D
+P
+6757 2437 M
+-2 -8 D
+P
+6751 2460 M
+3 -3 D
+-2 2 D
+1 4 D
+P
+6755 2441 M
+0 -2 D
+P
+6752 2470 M
+1 -2 D
+P
+6739 2381 M
+1 0 D
+P
+6757 2419 M
+0 -1 D
+P
+6756 2449 M
+0 -1 D
+P
+6741 2378 M
+2 -3 D
+P
+6745 2411 M
+-1 -1 D
+P
+6709 2437 M
+5 -10 D
+5 0 D
+1 -4 D
+-1 -1 D
+2 1 D
+2 -5 D
+-3 4 D
+-7 1 D
+-2 6 D
+-2 -1 D
+-4 2 D
+-3 6 D
+0 3 D
+P
+6774 2378 M
+-1 4 D
+1 -2 D
+3 1 D
+-3 5 D
+1 2 D
+2 -7 D
+P
+6812 2500 M
+0 -1 D
+-2 1 D
+2 1 D
+P
+6676 2524 M
+-2 -7 D
+1 4 D
+-5 2 D
+P
+6621 2497 M
+1 0 D
+-4 0 D
+P
+6772 2374 M
+1 0 D
+-1 -1 D
+P
+6697 2523 M
+1 -1 D
+-4 -4 D
+P
+6713 2533 M
+2 -2 D
+-2 -1 D
+P
+6713 2432 M
+2 -2 D
+-1 -2 D
+P
+6716 2430 M
+1 -2 D
+P
+6818 2407 M
+0 -1 D
+-1 1 D
+P
+6777 2377 M
+0 -3 D
+P
+FO
+6850 2561 M
+0 -1 D
+P
+FO
+6850 2596 M
+-1 2 D
+-3 -1 D
+-3 1 D
+-4 -1 D
+0 -2 D
+-6 1 D
+-2 -4 D
+2 1 D
+1 -2 D
+-2 1 D
+-13 -8 D
+-1 -3 D
+1 -18 D
+19 -5 D
+0 -2 D
+2 1 D
+0 -2 D
+2 2 D
+2 -1 D
+-1 2 D
+1 0 D
+1 3 D
+5 1 D
+P
+6839 2584 M
+4 -1 D
+-4 -1 D
+P
+FO
+6759 2598 M
+-1 0 D
+2 0 D
+P
+FO
+6614 2428 M
+3 6 D
+-3 5 D
+P
+FO
+6614 2413 M
+1 1 D
+-1 5 D
+P
+FO
+6709 2363 M
+1 -1 D
+1 9 D
+-2 2 D
+-2 -2 D
+-2 0 D
+3 -3 D
+P
+FO
+6672 2409 M
+-5 4 D
+2 -5 D
+2 1 D
+1 -1 D
+P
+FO
+6689 2380 M
+2 -2 D
+2 1 D
+-2 2 D
+P
+FO
+6674 2401 M
+2 -2 D
+-1 5 D
+P
+FO
+6685 2392 M
+1 2 D
+-1 2 D
+P
+FO
+6702 2373 M
+2 1 D
+P
+FO
+6685 2398 M
+1 -2 D
+1 1 D
+P
+FO
+6825 2375 M
+1 -1 D
+P
+FO
+6815 2503 M
+1 -1 D
+P
+FO
+6672 2405 M
+2 0 D
+P
+FO
+6768 2369 M
+4 -1 D
+P
+FO
+6829 2489 M
+1 0 D
+P
+FO
+6688 2369 M
+1 0 D
+P
+FO
+6818 2492 M
+1 0 D
+P
+FO
+6648 2422 M
+1 1 D
+P
+FO
+6763 2363 M
+1 0 D
+P
+FO
+6766 2365 M
+1 -1 D
+P
+FO
+6794 2517 M
+7 -5 D
+P
+FO
+6767 2369 M
+7 -1 D
+P
+FO
+6834 2424 M
+3 -1 D
+P
+FO
+6832 2415 M
+3 -1 D
+P
+FO
+6692 2376 M
+1 -1 D
+-1 2 D
+P
+FO
+7063 2362 M
+5 1 D
+2 6 D
+6 2 D
+4 3 D
+-2 3 D
+1 1 D
+-3 0 D
+1 4 D
+-3 1 D
+1 3 D
+1 0 D
+-1 3 D
+1 4 D
+-1 3 D
+-3 -6 D
+1 -3 D
+-2 1 D
+1 -2 D
+-2 0 D
+1 -3 D
+3 -1 D
+0 -3 D
+-6 6 D
+1 -2 D
+-1 -1 D
+3 -2 D
+0 -4 D
+-3 -1 D
+1 -1 D
+-3 -3 D
+0 3 D
+-2 -3 D
+-1 1 D
+1 -2 D
+-3 -1 D
+1 -2 D
+-4 0 D
+0 -4 D
+-1 2 D
+-2 -3 D
+P
+FO
+7087 2407 M
+-3 2 D
+0 -1 D
+-1 0 D
+2 -4 D
+2 0 D
+-2 -3 D
+2 2 D
+P
+FO
+7087 2415 M
+-3 2 D
+-1 -4 D
+1 1 D
+3 -5 D
+P
+FO
+7087 2509 M
+-3 1 D
+0 3 D
+-3 -2 D
+0 -9 D
+2 1 D
+1 -3 D
+-1 -2 D
+3 -6 D
+-2 -2 D
+3 -3 D
+P
+FO
+6864 2598 M
+1 -2 D
+-1 2 D
+-11 0 D
+-3 -2 D
+0 -34 D
+1 0 D
+-1 -2 D
+2 0 D
+3 6 D
+5 2 D
+-2 -1 D
+2 0 D
+3 3 D
+0 2 D
+-1 -2 D
+-1 1 D
+3 5 D
+-1 2 D
+7 10 D
+-1 1 D
+2 1 D
+-1 -1 D
+1 -2 D
+4 3 D
+-2 8 D
+P
+FO
+7087 2376 M
+-4 2 D
+-2 -3 D
+1 -2 D
+3 1 D
+-1 1 D
+1 -1 D
+P
+FO
+7087 2509 M
+-1 3 D
+-1 -1 D
+1 -2 D
+P
+FO
+7080 2397 M
+3 -2 D
+1 3 D
+P
+FO
+7078 2396 M
+1 -1 D
+P
+FO
+7082 2408 M
+2 1 D
+P
+FO
+7069 2391 M
+1 -2 D
+P
+FO
+7078 2386 M
+-1 2 D
+P
+FO
+7076 2390 M
+2 0 D
+P
+FO
+7084 2513 M
+2 0 D
+-2 1 D
+P
+FO
+7070 2386 M
+0 -1 D
+P
+FO
+7078 2393 M
+1 1 D
+P
+FO
+7066 2376 M
+2 0 D
+P
+FO
+7079 2389 M
+0 -1 D
+P
+FO
+7163 2362 M
+3 11 D
+5 8 D
+-1 3 D
+-8 2 D
+-5 -3 D
+-1 -5 D
+-3 -3 D
+2 -4 D
+-1 -7 D
+-3 -2 D
+P
+FO
+7172 2362 M
+4 6 D
+6 3 D
+-1 17 D
+2 5 D
+-3 -3 D
+-6 -16 D
+-8 -12 D
+P
+FO
+7194 2362 M
+0 1 D
+-3 1 D
+-1 2 D
+-1 -2 D
+-1 2 D
+-4 0 D
+-3 -4 D
+P
+FO
+7211 2362 M
+-1 3 D
+-3 1 D
+2 -4 D
+P
+FO
+7221 2362 M
+0 4 D
+-2 0 D
+1 1 D
+-1 2 D
+1 -1 D
+1 3 D
+-1 2 D
+-3 -3 D
+-1 -5 D
+2 -1 D
+0 -2 D
+P
+FO
+7230 2362 M
+0 2 D
+-1 -2 D
+P
+FO
+7087 2487 M
+2 -12 D
+2 -1 D
+0 3 D
+2 0 D
+-1 -4 D
+3 -2 D
+3 -5 D
+3 2 D
+-1 8 D
+6 -1 D
+3 -3 D
+1 -4 D
+-2 0 D
+-8 -6 D
+2 -11 D
+1 4 D
+4 -1 D
+1 -5 D
+2 3 D
+1 -4 D
+6 -1 D
+4 2 D
+1 4 D
+6 3 D
+15 -11 D
+5 -8 D
+2 1 D
+0 4 D
+-3 4 D
+2 0 D
+-3 2 D
+0 4 D
+-2 3 D
+2 1 D
+8 -6 D
+-1 -2 D
+9 -5 D
+3 -5 D
+0 -5 D
+3 1 D
+7 -5 D
+3 4 D
+3 -1 D
+0 -2 D
+-4 0 D
+0 -3 D
+3 -4 D
+3 -1 D
+3 13 D
+-3 -2 D
+-5 4 D
+-3 -2 D
+1 3 D
+2 1 D
+-8 7 D
+1 4 D
+10 0 D
+-7 5 D
+0 -1 D
+-6 2 D
+-1 -1 D
+-1 4 D
+-1 -1 D
+-2 1 D
+0 -3 D
+3 0 D
+-2 -1 D
+1 -3 D
+-5 -3 D
+-1 2 D
+1 3 D
+-2 5 D
+-8 6 D
+-1 -2 D
+-4 2 D
+-4 -6 D
+-1 3 D
+-2 -2 D
+3 -4 D
+-3 1 D
+1 -3 D
+-6 2 D
+-5 4 D
+-4 12 D
+4 1 D
+-4 3 D
+-5 12 D
+6 9 D
+-2 2 D
+0 3 D
+5 4 D
+9 4 D
+-3 -5 D
+5 5 D
+0 4 D
+6 11 D
+1 6 D
+-2 0 D
+-1 5 D
+-3 0 D
+-3 10 D
+1 7 D
+3 4 D
+0 3 D
+-3 4 D
+-1 -4 D
+-3 -2 D
+-9 2 D
+1 -3 D
+-1 3 D
+-11 6 D
+-5 -2 D
+-3 3 D
+-1 -3 D
+-4 0 D
+-4 -19 D
+-2 -1 D
+2 -7 D
+-1 -4 D
+1 -5 D
+-4 -9 D
+4 -11 D
+-7 -3 D
+-1 3 D
+-2 1 D
+P
+7118 2466 M
+0 -2 D
+2 2 D
+1 -2 D
+-6 -3 D
+-3 5 D
+0 3 D
+2 0 D
+1 -2 D
+2 2 D
+P
+7116 2466 M
+0 -3 D
+P
+7112 2459 M
+0 -3 D
+-2 -2 D
+-1 4 D
+P
+7111 2457 M
+-1 -1 D
+P
+7166 2442 M
+0 -2 D
+P
+FO
+7087 2409 M
+3 1 D
+5 -1 D
+0 2 D
+-3 4 D
+-1 -3 D
+-4 3 D
+P
+FO
+7087 2403 M
+1 1 D
+-1 3 D
+P
+FO
+7205 2392 M
+3 1 D
+2 -5 D
+2 1 D
+5 -1 D
+0 1 D
+3 0 D
+3 -3 D
+-3 5 D
+-3 -1 D
+3 4 D
+-4 2 D
+-1 4 D
+1 2 D
+-2 6 D
+3 3 D
+-2 1 D
+2 2 D
+-3 3 D
+-2 -1 D
+1 3 D
+-5 4 D
+-3 -1 D
+-4 1 D
+0 -1 D
+-5 -1 D
+-8 2 D
+2 -9 D
+8 -4 D
+4 -6 D
+4 0 D
+-1 -4 D
+-5 -2 D
+5 -2 D
+P
+FO
+7134 2373 M
+5 4 D
+9 1 D
+0 3 D
+3 0 D
+1 3 D
+-1 1 D
+5 2 D
+2 3 D
+2 0 D
+1 7 D
+-1 1 D
+1 2 D
+-7 -4 D
+2 2 D
+-5 2 D
+-4 -2 D
+0 1 D
+-2 0 D
+1 1 D
+-3 3 D
+-10 5 D
+-2 -1 D
+-1 -3 D
+6 -2 D
+-1 -15 D
+-3 -7 D
+1 -2 D
+-1 -5 D
+P
+FO
+7191 2386 M
+-1 -2 D
+2 -1 D
+2 3 D
+3 -2 D
+3 -6 D
+-2 -4 D
+2 -4 D
+-1 -4 D
+6 -4 D
+-1 9 D
+4 -5 D
+0 3 D
+3 -1 D
+0 2 D
+-2 2 D
+0 4 D
+-4 3 D
+-1 16 D
+-4 1 D
+-2 -3 D
+-3 0 D
+-1 3 D
+-2 0 D
+0 -2 D
+-4 5 D
+P
+FO
+7105 2433 M
+0 -6 D
+8 -10 D
+0 -2 D
+3 -1 D
+2 3 D
+2 -1 D
+1 6 D
+2 2 D
+-2 4 D
+2 8 D
+-2 0 D
+0 2 D
+-6 5 D
+-4 0 D
+-1 2 D
+-5 -1 D
+-10 1 D
+-1 -2 D
+3 0 D
+2 -5 D
+3 0 D
+P
+7119 2438 M
+-1 -2 D
+P
+FO
+7181 2405 M
+2 -2 D
+-2 7 D
+1 -1 D
+-3 5 D
+-3 0 D
+-8 8 D
+-3 -2 D
+1 2 D
+-3 2 D
+1 -5 D
+-1 -4 D
+1 0 D
+-3 -8 D
+9 8 D
+2 -4 D
+3 -2 D
+0 -1 D
+5 -1 D
+P
+FO
+7188 2457 M
+-2 2 D
+-2 -1 D
+0 -6 D
+-2 -3 D
+4 -4 D
+1 2 D
+2 -1 D
+0 2 D
+2 1 D
+0 4 D
+P
+FO
+7134 2412 M
+4 12 D
+-2 1 D
+-2 -1 D
+0 -4 D
+-2 -3 D
+2 -3 D
+-1 1 D
+P
+FO
+7134 2472 M
+1 4 D
+-2 2 D
+2 2 D
+-5 1 D
+-1 -2 D
+3 -4 D
+0 -3 D
+P
+FO
+7161 2433 M
+-3 3 D
+-2 0 D
+0 -2 D
+3 -1 D
+7 -7 D
+P
+FO
+7134 2438 M
+3 4 D
+0 2 D
+-6 3 D
+-1 -6 D
+P
+FO
+7145 2374 M
+1 -2 D
+3 1 D
+2 6 D
+-3 0 D
+P
+FO
+7144 2420 M
+5 -4 D
+1 1 D
+-1 4 D
+P
+FO
+7118 2583 M
+5 -2 D
+0 3 D
+P
+FO
+7134 2461 M
+-2 1 D
+1 -3 D
+5 -2 D
+P
+FO
+7174 2391 M
+1 -2 D
+2 0 D
+-2 4 D
+P
+FO
+7171 2424 M
+5 -7 D
+-1 7 D
+-3 2 D
+P
+FO
+7189 2402 M
+3 -5 D
+3 0 D
+-1 5 D
+P
+FO
+7188 2376 M
+2 1 D
+0 2 D
+-1 0 D
+P
+FO
+7140 2423 M
+1 -2 D
+0 3 D
+P
+FO
+7111 2415 M
+2 -2 D
+-1 4 D
+P
+FO
+7091 2408 M
+2 -3 D
+0 4 D
+P
+FO
+7131 2588 M
+3 -1 D
+P
+FO
+7115 2576 M
+1 -1 D
+-1 4 D
+P
+FO
+7181 2370 M
+-2 -2 D
+3 2 D
+P
+FO
+7110 2382 M
+2 -1 D
+0 3 D
+P
+FO
+7119 2409 M
+1 1 D
+-1 2 D
+P
+FO
+7220 2381 M
+4 -2 D
+-3 3 D
+P
+FO
+7135 2432 M
+0 -1 D
+1 1 D
+P
+FO
+7136 2564 M
+1 -1 D
+1 2 D
+P
+FO
+7088 2453 M
+6 -4 D
+-2 4 D
+P
+FO
+7131 2575 M
+-1 -5 D
+4 4 D
+P
+FO
+7224 2386 M
+-1 1 D
+1 -3 D
+P
+FO
+7193 2365 M
+1 -2 D
+2 3 D
+P
+FO
+7190 2377 M
+3 1 D
+-2 1 D
+P
+FO
+7198 2402 M
+3 -4 D
+0 2 D
+-3 3 D
+P
+FO
+7200 2402 M
+2 -1 D
+0 1 D
+P
+FO
+7136 2477 M
+4 -3 D
+-1 3 D
+P
+FO
+7181 2438 M
+2 1 D
+-4 1 D
+P
+FO
+7090 2404 M
+1 0 D
+P
+FO
+7117 2571 M
+5 1 D
+-5 0 D
+P
+FO
+7177 2440 M
+0 1 D
+P
+FO
+7182 2438 M
+4 -1 D
+P
+FO
+7141 2473 M
+3 0 D
+P
+FO
+7120 2406 M
+3 0 D
+P
+FO
+7172 2455 M
+2 0 D
+P
+FO
+7193 2380 M
+1 1 D
+P
+FO
+7184 2420 M
+1 -2 D
+P
+FO
+7205 2425 M
+2 -1 D
+P
+FO
+7106 2449 M
+3 -1 D
+P
+FO
+7205 2425 M
+1 -2 D
+P
+FO
+7188 2404 M
+1 0 D
+-1 1 D
+P
+FO
+7123 2408 M
+1 -1 D
+P
+FO
+7184 2411 M
+3 0 D
+P
+FO
+7093 2452 M
+1 0 D
+P
+FO
+7187 2420 M
+1 -2 D
+P
+FO
+7132 2411 M
+1 -1 D
+P
+FO
+7128 2455 M
+1 -1 D
+P
+FO
+7188 2407 M
+1 2 D
+P
+FO
+7162 2397 M
+1 1 D
+P
+FO
+7094 2449 M
+3 -1 D
+P
+FO
+7175 2443 M
+3 -1 D
+P
+FO
+7191 2407 M
+1 0 D
+P
+FO
+7126 2431 M
+2 0 D
+P
+FO
+7134 2428 M
+2 1 D
+P
+FO
+7177 2455 M
+0 -1 D
+P
+FO
+7129 2464 M
+1 0 D
+P
+FO
+7111 2446 M
+2 0 D
+-2 1 D
+P
+FO
+7161 2392 M
+1 1 D
+P
+FO
+7134 2477 M
+2 0 D
+P
+FO
+7186 2367 M
+1 0 D
+P
+FO
+7216 2373 M
+0 -1 D
+P
+FO
+7161 2397 M
+1 2 D
+P
+FO
+7156 2467 M
+1 -1 D
+P
+FO
+7100 2466 M
+1 0 D
+P
+FO
+7095 2417 M
+0 -1 D
+P
+FO
+7154 2437 M
+1 -1 D
+P
+FO
+7167 2373 M
+1 1 D
+P
+FO
+7189 2426 M
+1 -1 D
+P
+FO
+7178 2393 M
+1 1 D
+P
+FO
+7160 2389 M
+1 0 D
+P
+FO
+7155 2467 M
+2 1 D
+P
+FO
+7188 2456 M
+1 -1 D
+P
+FO
+7090 2409 M
+1 0 D
+P
+FO
+7191 2423 M
+1 -1 D
+P
+FO
+7182 2368 M
+1 1 D
+P
+FO
+7132 2409 M
+0 -1 D
+P
+FO
+7088 2406 M
+1 -1 D
+P
+FO
+7192 2423 M
+1 -1 D
+P
+FO
+7674 2449 M
+-2 -5 D
+-4 0 D
+2 -5 D
+6 8 D
+P
+FO
+7696 2487 M
+-2 -2 D
+0 -2 D
+2 1 D
+P
+FO
+7692 2483 M
+-1 -2 D
+1 -3 D
+P
+FO
+7683 2461 M
+-3 -2 D
+4 1 D
+P
+FO
+7696 2555 M
+-2 -3 D
+P
+FO
+8187 2582 M
+2 -1 D
+P
+FO
+8244 2471 M
+-1 -1 D
+P
+FO
+8193 2389 M
+2 1 D
+P
+FO
+571 2598 M
+-6 -6 D
+5 -9 D
+-1 -6 D
+6 -4 D
+4 5 D
+12 5 D
+4 4 D
+-4 3 D
+-1 2 D
+-2 0 D
+1 3 D
+-3 3 D
+-2 0 D
+P
+FO
+1630 2569 M
+1 -1 D
+1 1 D
+-2 3 D
+-1 -1 D
+P
+FO
+1541 2560 M
+2 0 D
+P
+FO
+1890 2526 M
+-1 0 D
+1 0 D
+0 72 D
+-130 0 D
+5 -7 D
+5 -3 D
+1 -4 D
+4 -3 D
+1 1 D
+0 -2 D
+9 -3 D
+2 1 D
+1 -2 D
+-1 -1 D
+12 -5 D
+8 -11 D
+29 -9 D
+8 0 D
+3 -2 D
+4 -5 D
+10 -5 D
+3 -4 D
+26 -9 D
+P
+1858 2563 M
+-2 -2 D
+-5 4 D
+-5 -1 D
+0 -6 D
+2 0 D
+-2 -1 D
+-3 5 D
+2 0 D
+0 5 D
+-6 4 D
+2 2 D
+1 -2 D
+2 2 D
+-1 -3 D
+3 -1 D
+0 -1 D
+1 1 D
+-1 -3 D
+3 1 D
+2 -1 D
+0 1 D
+3 -4 D
+P
+1880 2530 M
+4 -2 D
+P
+1806 2598 M
+-1 -1 D
+P
+1821 2598 M
+0 -1 D
+P
+1824 2596 M
+1 0 D
+P
+1788 2576 M
+7 -3 D
+P
+FO
+2114 2598 M
+1 -2 D
+-6 -5 D
+0 -8 D
+-17 -11 D
+-2 -2 D
+3 2 D
+0 -2 D
+4 -1 D
+-2 -5 D
+-6 -2 D
+-7 1 D
+-2 2 D
+-2 -1 D
+4 1 D
+-3 3 D
+-8 -1 D
+-8 -1 D
+0 -3 D
+-1 2 D
+-6 -4 D
+-4 1 D
+1 -1 D
+-1 -2 D
+0 3 D
+-7 0 D
+-10 -4 D
+6 2 D
+-4 -3 D
+-3 0 D
+1 1 D
+-7 -3 D
+-6 0 D
+0 -2 D
+0 2 D
+-5 1 D
+-4 8 D
+-6 -1 D
+1 1 D
+-5 4 D
+-13 2 D
+2 -2 D
+-4 0 D
+1 1 D
+-2 2 D
+3 -1 D
+-4 3 D
+-1 3 D
+-3 1 D
+-1 3 D
+-4 2 D
+-3 13 D
+-3 3 D
+-81 0 D
+1 -73 D
+-1 1 D
+0 -1 D
+7 -4 D
+21 -4 D
+6 -5 D
+11 -4 D
+7 -5 D
+14 -1 D
+15 -6 D
+7 0 D
+19 7 D
+7 5 D
+11 1 D
+9 -2 D
+15 -6 D
+45 -40 D
+11 -6 D
+18 -1 D
+13 -5 D
+0 149 D
+P
+2061 2513 M
+-2 -2 D
+6 -3 D
+2 2 D
+-1 -3 D
+11 -7 D
+-2 1 D
+-1 -1 D
+1 2 D
+-7 3 D
+-4 -2 D
+2 3 D
+-2 -1 D
+-3 1 D
+-1 -2 D
+1 4 D
+3 -1 D
+-4 3 D
+-2 -2 D
+-2 1 D
+P
+1972 2559 M
+4 -3 D
+-2 0 D
+1 -3 D
+-1 2 D
+-2 -1 D
+-3 5 D
+1 0 D
+-2 2 D
+4 -1 D
+-2 0 D
+P
+1972 2558 M
+2 -2 D
+P
+2038 2532 M
+5 0 D
+4 -4 D
+-7 2 D
+-1 2 D
+-3 -3 D
+1 3 D
+P
+2100 2473 M
+-4 -2 D
+0 2 D
+2 1 D
+P
+1935 2573 M
+-2 -1 D
+-2 2 D
+P
+2014 2546 M
+2 2 D
+0 -4 D
+P
+1995 2514 M
+1 4 D
+2 -4 D
+P
+2005 2560 M
+1 2 D
+2 -1 D
+P
+1897 2523 M
+1 -2 D
+-3 1 D
+P
+2006 2509 M
+3 1 D
+P
+2101 2533 M
+2 -1 D
+P
+2125 2527 M
+1 0 D
+P
+1910 2519 M
+3 -1 D
+P
+1905 2520 M
+2 -1 D
+P
+2104 2541 M
+1 3 D
+P
+1988 2567 M
+2 1 D
+P
+2095 2513 M
+1 1 D
+P
+2120 2529 M
+2 0 D
+P
+2113 2467 M
+-1 1 D
+P
+1987 2565 M
+1 0 D
+P
+FO
+2086 2568 M
+-4 -2 D
+4 0 D
+4 3 D
+P
+FO
+2241 2362 M
+-4 7 D
+11 -7 D
+43 0 D
+-6 5 D
+-6 9 D
+0 -1 D
+-2 8 D
+-3 2 D
+-3 8 D
+2 5 D
+3 2 D
+-1 6 D
+-2 -1 D
+-2 2 D
+2 1 D
+1 4 D
+1 -3 D
+2 9 D
+-2 -2 D
+-2 5 D
+4 3 D
+0 5 D
+1 -2 D
+-2 -9 D
+4 1 D
+-2 27 D
+3 10 D
+6 8 D
+-3 11 D
+-1 -1 D
+-2 2 D
+3 2 D
+0 -3 D
+4 5 D
+-4 2 D
+-2 4 D
+-8 4 D
+4 -3 D
+-2 1 D
+-3 -3 D
+0 2 D
+-5 3 D
+-2 -2 D
+-2 2 D
+3 3 D
+7 -3 D
+-13 10 D
+-9 1 D
+4 -2 D
+-4 0 D
+0 2 D
+-8 3 D
+-11 -3 D
+-13 4 D
+2 -1 D
+0 -2 D
+-10 -3 D
+-13 -1 D
+-11 2 D
+-3 -1 D
+-2 3 D
+-1 -1 D
+-2 1 D
+-6 -1 D
+-4 -5 D
+-11 7 D
+3 -3 D
+-2 1 D
+-1 -4 D
+-5 4 D
+-3 0 D
+7 10 D
+1 -1 D
+5 7 D
+1 -1 D
+3 11 D
+-2 6 D
+1 6 D
+2 0 D
+-3 3 D
+5 12 D
+0 6 D
+-6 -1 D
+-1 1 D
+8 11 D
+1 -4 D
+-2 -5 D
+4 0 D
+2 -6 D
+7 24 D
+2 2 D
+-2 0 D
+-2 -3 D
+-2 1 D
+2 4 D
+4 2 D
+1 3 D
+-1 1 D
+1 -2 D
+-6 -1 D
+-2 4 D
+6 3 D
+1 3 D
+0 -4 D
+0 5 D
+-60 0 D
+0 -149 D
+4 -4 D
+12 0 D
+12 -6 D
+1 1 D
+-1 -1 D
+8 -2 D
+-3 2 D
+-3 0 D
+2 1 D
+7 -2 D
+0 -1 D
+11 0 D
+-1 1 D
+3 2 D
+-2 2 D
+1 2 D
+2 -3 D
+4 3 D
+0 -2 D
+-2 -1 D
+2 -1 D
+0 2 D
+4 1 D
+-2 -4 D
+1 0 D
+1 -4 D
+3 0 D
+-2 0 D
+2 -1 D
+-2 -2 D
+2 -1 D
+-4 1 D
+-3 3 D
+-3 -4 D
+5 -4 D
+0 2 D
+9 -9 D
+-1 0 D
+9 -5 D
+6 -11 D
+20 -17 D
+-2 -1 D
+1 -2 D
+-4 1 D
+-1 -2 D
+6 -2 D
+0 -4 D
+1 0 D
+-4 -3 D
+1 -1 D
+-3 -2 D
+4 -9 D
+P
+2214 2421 M
+2 -5 D
+2 1 D
+0 -3 D
+-5 -1 D
+0 3 D
+-2 -1 D
+-5 3 D
+P
+2226 2412 M
+14 -8 D
+9 -12 D
+0 -4 D
+-3 -2 D
+-8 2 D
+-11 6 D
+-5 14 D
+1 4 D
+P
+2224 2402 M
+2 1 D
+-2 1 D
+P
+2244 2390 M
+-1 -1 D
+P
+2227 2398 M
+6 -2 D
+-3 4 D
+P
+2142 2489 M
+-1 3 D
+7 2 D
+2 2 D
+0 -4 D
+-2 -2 D
+P
+2174 2476 M
+-1 0 D
+0 3 D
+P
+2149 2448 M
+-1 0 D
+0 2 D
+2 0 D
+P
+2274 2429 M
+1 -1 D
+-2 1 D
+P
+2277 2448 M
+2 2 D
+-1 -3 D
+P
+2280 2455 M
+-1 1 D
+2 1 D
+P
+2138 2462 M
+-2 1 D
+2 1 D
+P
+2247 2375 M
+1 -1 D
+-3 1 D
+P
+2155 2456 M
+-2 0 D
+1 1 D
+P
+2139 2529 M
+1 0 D
+P
+2165 2536 M
+1 1 D
+-1 -2 D
+P
+2275 2430 M
+1 -1 D
+P
+2129 2528 M
+4 -1 D
+-5 0 D
+P
+2284 2466 M
+1 -3 D
+-1 0 D
+P
+2223 2438 M
+-2 -2 D
+-1 1 D
+P
+2182 2499 M
+0 1 D
+2 -1 D
+P
+2165 2532 M
+1 2 D
+P
+2137 2454 M
+-1 -1 D
+P
+2285 2468 M
+0 1 D
+P
+2221 2412 M
+0 -1 D
+P
+2172 2440 M
+-1 0 D
+P
+2250 2383 M
+-1 -1 D
+P
+FO
+2362 2592 M
+-2 -2 D
+P
+FO
+2329 2584 M
+0 -3 D
+8 1 D
+-5 2 D
+-2 -2 D
+0 2 D
+P
+FO
+2211 2513 M
+4 1 D
+-4 0 D
+-6 -4 D
+P
+FO
+2274 2409 M
+1 -3 D
+0 3 D
+P
+FO
+2223 2515 M
+1 1 D
+-3 -2 D
+P
+FO
+2240 2365 M
+0 -1 D
+2 0 D
+P
+FO
+2176 2534 M
+2 1 D
+0 3 D
+P
+FO
+2174 2534 M
+4 6 D
+P
+FO
+2198 2507 M
+-1 -1 D
+3 1 D
+P
+FO
+2161 2438 M
+2 0 D
+P
+FO
+2174 2533 M
+1 -1 D
+P
+FO
+2176 2556 M
+0 -1 D
+P
+FO
+2168 2566 M
+0 -2 D
+P
+FO
+2177 2554 M
+0 2 D
+-4 -7 D
+P
+FO
+2296 2465 M
+2 1 D
+P
+FO
+2164 2437 M
+-1 1 D
+P
+FO
+2322 2423 M
+-1 -2 D
+P
+FO
+2182 2440 M
+-1 -1 D
+P
+FO
+2330 2442 M
+-1 -1 D
+P
+FO
+2180 2438 M
+1 -1 D
+P
+FO
+2169 2543 M
+2 2 D
+P
+FO
+2551 2362 M
+5 8 D
+4 3 D
+1 6 D
+-4 7 D
+4 0 D
+-7 5 D
+-2 8 D
+14 5 D
+2 4 D
+4 3 D
+-4 7 D
+-9 2 D
+-2 -1 D
+3 0 D
+-1 -1 D
+-1 1 D
+-1 -2 D
+-2 1 D
+-3 -2 D
+3 -1 D
+-2 -2 D
+-2 1 D
+1 2 D
+-5 -1 D
+1 -3 D
+-4 -6 D
+-11 -4 D
+-12 -9 D
+-12 -1 D
+-8 2 D
+-3 -3 D
+1 -3 D
+-4 -8 D
+-2 -1 D
+-1 6 D
+5 1 D
+-5 0 D
+-8 3 D
+2 -3 D
+-2 3 D
+-5 -5 D
+-5 -3 D
+0 -2 D
+-6 -3 D
+1 -2 D
+-2 -2 D
+1 -3 D
+-2 0 D
+-2 -3 D
+4 2 D
+-2 -6 D
+P
+2552 2394 M
+1 -6 D
+-2 3 D
+P
+2478 2377 M
+2 -1 D
+0 -2 D
+P
+2486 2367 M
+-1 -4 D
+P
+FO
+2598 2398 M
+-3 1 D
+3 -2 D
+-3 0 D
+-1 -3 D
+-15 -3 D
+-11 -6 D
+-5 0 D
+2 -1 D
+0 -3 D
+-4 0 D
+3 -9 D
+6 -10 D
+28 0 D
+P
+FO
+2598 2414 M
+-5 -2 D
+-1 -5 D
+2 -3 D
+-1 -3 D
+5 1 D
+P
+FO
+2598 2423 M
+-1 1 D
+1 -3 D
+P
+FO
+2598 2591 M
+-6 -1 D
+-4 3 D
+-4 0 D
+-5 3 D
+-5 1 D
+-5 -3 D
+-10 2 D
+-3 -3 D
+2 -2 D
+-3 1 D
+0 -2 D
+-2 1 D
+2 1 D
+-5 -1 D
+-6 2 D
+0 -1 D
+-2 2 D
+-10 3 D
+-14 -2 D
+1 -1 D
+-2 -3 D
+2 -2 D
+7 1 D
+9 -4 D
+-2 -3 D
+1 -1 D
+-2 -2 D
+3 -2 D
+-3 -2 D
+6 -7 D
+6 -2 D
+-1 -3 D
+-6 0 D
+-2 -3 D
+-18 3 D
+-5 -1 D
+-1 1 D
+3 1 D
+-5 -1 D
+-10 3 D
+-5 -1 D
+-1 -5 D
+2 -3 D
+7 -1 D
+5 -5 D
+2 0 D
+-1 2 D
+4 3 D
+6 1 D
+1 -2 D
+13 -2 D
+6 1 D
+0 2 D
+12 0 D
+9 -7 D
+1 -3 D
+-2 -1 D
+4 -1 D
+3 -3 D
+8 13 D
+0 3 D
+3 -1 D
+9 4 D
+-1 -3 D
+2 -2 D
+-1 0 D
+10 1 D
+3 4 D
+P
+2556 2564 M
+7 -2 D
+-3 -1 D
+P
+2557 2563 M
+3 0 D
+P
+2551 2567 M
+2 -4 D
+-3 1 D
+P
+2550 2573 M
+4 -1 D
+-4 0 D
+P
+2569 2558 M
+-1 0 D
+2 0 D
+P
+FO
+2536 2598 M
+P
+FO
+2477 2598 M
+-1 -2 D
+4 0 D
+3 2 D
+P
+FO
+2460 2598 M
+6 -2 D
+11 1 D
+P
+FO
+2418 2598 M
+-2 -3 D
+35 3 D
+7 -1 D
+1 1 D
+P
+FO
+2362 2592 M
+P
+FO
+2433 2547 M
+2 1 D
+2 3 D
+3 -1 D
+-3 0 D
+4 0 D
+3 -2 D
+8 1 D
+-3 6 D
+-11 3 D
+-3 3 D
+-22 3 D
+-2 -2 D
+-7 0 D
+-3 -2 D
+0 -3 D
+7 -1 D
+8 -8 D
+7 0 D
+6 -4 D
+1 2 D
+-2 0 D
+2 3 D
+3 -1 D
+P
+FO
+2528 2572 M
+-5 2 D
+-3 -1 D
+2 -2 D
+10 -3 D
+-1 3 D
+P
+FO
+2468 2370 M
+-1 1 D
+-1 -1 D
+P
+FO
+2562 2541 M
+2 0 D
+-2 1 D
+P
+FO
+2365 2591 M
+4 2 D
+P
+FO
+2509 2565 M
+2 1 D
+P
+FO
+2511 2553 M
+3 0 D
+-3 1 D
+P
+FO
+2561 2386 M
+1 -1 D
+P
+FO
+2559 2385 M
+1 0 D
+P
+FO
+2776 2362 M
+-1 5 D
+-2 1 D
+0 -3 D
+-3 6 D
+-4 0 D
+2 1 D
+-1 3 D
+5 1 D
+7 -1 D
+3 2 D
+7 1 D
+2 2 D
+-8 -2 D
+-12 2 D
+-20 -3 D
+-6 2 D
+-3 -2 D
+-8 1 D
+1 -4 D
+4 2 D
+10 -2 D
+-5 -1 D
+-8 1 D
+-7 -4 D
+3 -1 D
+-3 -1 D
+-4 0 D
+-1 -2 D
+-1 2 D
+-1 -3 D
+-7 -1 D
+-19 5 D
+4 -2 D
+-3 1 D
+-7 6 D
+2 2 D
+-5 2 D
+-18 -1 D
+-19 -4 D
+-7 1 D
+-5 8 D
+2 1 D
+-3 1 D
+3 0 D
+-4 6 D
+-11 7 D
+-4 -1 D
+-5 3 D
+-9 -2 D
+-3 5 D
+-2 8 D
+-4 4 D
+0 -12 D
+5 0 D
+2 -4 D
+-2 -2 D
+-5 2 D
+0 -36 D
+P
+2649 2366 M
+3 2 D
+3 -1 D
+-1 -2 D
+-5 0 D
+P
+2710 2364 M
+-3 1 D
+4 -1 D
+P
+FO
+2777 2362 M
+0 1 D
+P
+FO
+2782 2362 M
+0 2 D
+-1 -2 D
+P
+FO
+2784 2362 M
+-1 1 D
+-1 -1 D
+P
+FO
+2598 2561 M
+3 1 D
+6 -1 D
+7 1 D
+12 -2 D
+2 -4 D
+2 0 D
+1 4 D
+4 -1 D
+3 7 D
+-14 9 D
+-3 -1 D
+-9 3 D
+-5 0 D
+0 3 D
+10 -1 D
+1 3 D
+-2 0 D
+0 1 D
+-2 -1 D
+-10 0 D
+-5 9 D
+-1 0 D
+P
+FO
+2598 2421 M
+4 -2 D
+-4 4 D
+P
+FO
+2693 2551 M
+4 0 D
+1 3 D
+5 2 D
+-1 4 D
+-35 3 D
+-4 -3 D
+3 -4 D
+-1 -6 D
+6 -1 D
+4 2 D
+14 -2 D
+P
+FO
+2811 2470 M
+-2 -1 D
+0 -1 D
+5 0 D
+-1 -1 D
+2 -1 D
+0 4 D
+-3 2 D
+2 3 D
+-2 -1 D
+-2 2 D
+-4 1 D
+1 -5 D
+P
+FO
+2739 2386 M
+-4 2 D
+-4 -1 D
+-1 -2 D
+6 0 D
+3 -2 D
+2 1 D
+2 -1 D
+2 3 D
+-2 4 D
+-3 -4 D
+P
+FO
+2797 2504 M
+0 6 D
+10 0 D
+-5 2 D
+-2 4 D
+-2 -5 D
+-4 2 D
+-2 -2 D
+1 -7 D
+2 -1 D
+P
+FO
+2811 2365 M
+1 5 D
+-2 8 D
+2 4 D
+-17 -3 D
+4 -2 D
+1 -8 D
+-11 -6 D
+P
+FO
+2790 2544 M
+1 -3 D
+3 -1 D
+-2 4 D
+-1 0 D
+0 -2 D
+P
+FO
+2799 2493 M
+3 -8 D
+3 1 D
+-1 8 D
+-4 1 D
+P
+FO
+2622 2415 M
+-4 4 D
+2 -5 D
+8 -3 D
+P
+FO
+2636 2416 M
+3 -2 D
+1 -4 D
+1 5 D
+-4 2 D
+P
+FO
+2811 2451 M
+1 -1 D
+2 2 D
+-1 7 D
+-4 -5 D
+P
+FO
+2793 2528 M
+2 2 D
+-4 2 D
+-1 -4 D
+P
+FO
+2772 2531 M
+2 -1 D
+0 2 D
+P
+FO
+2763 2553 M
+0 1 D
+-3 -1 D
+3 -2 D
+P
+FO
+2805 2504 M
+-2 -1 D
+1 -2 D
+2 1 D
+P
+FO
+2793 2409 M
+3 1 D
+1 5 D
+-3 -1 D
+P
+FO
+2676 2404 M
+3 0 D
+-1 1 D
+0 -1 D
+P
+FO
+2719 2544 M
+8 1 D
+-8 1 D
+P
+FO
+2689 2404 M
+1 1 D
+-2 0 D
+P
+FO
+2804 2438 M
+3 -2 D
+1 6 D
+P
+FO
+2730 2561 M
+3 2 D
+-3 0 D
+P
+FO
+2821 2392 M
+1 2 D
+-7 -5 D
+P
+FO
+2725 2406 M
+2 0 D
+-1 1 D
+P
+FO
+2806 2433 M
+0 1 D
+-2 -1 D
+P
+FO
+2767 2536 M
+6 -3 D
+-4 4 D
+P
+FO
+2707 2384 M
+5 0 D
+-3 1 D
+P
+FO
+2782 2521 M
+2 -1 D
+-1 3 D
+P
+FO
+2769 2372 M
+2 -1 D
+-2 3 D
+P
+FO
+2726 2559 M
+1 0 D
+-1 1 D
+P
+FO
+2703 2554 M
+7 0 D
+P
+FO
+2627 2555 M
+5 -1 D
+P
+FO
+2717 2560 M
+4 -1 D
+P
+FO
+2764 2557 M
+-4 -2 D
+P
+FO
+2723 2560 M
+4 2 D
+P
+FO
+2740 2381 M
+3 -1 D
+P
+FO
+2647 2553 M
+2 0 D
+P
+FO
+2721 2559 M
+4 0 D
+P
+FO
+2730 2569 M
+4 -1 D
+P
+FO
+2799 2420 M
+2 2 D
+P
+FO
+2708 2559 M
+3 -1 D
+P
+FO
+2735 2381 M
+2 1 D
+P
+FO
+2767 2549 M
+2 0 D
+P
+FO
+2764 2539 M
+1 0 D
+P
+FO
+2674 2406 M
+2 0 D
+P
+FO
+2729 2371 M
+1 0 D
+P
+FO
+2673 2404 M
+3 0 D
+P
+FO
+2690 2406 M
+0 -1 D
+1 1 D
+P
+FO
+2653 2409 M
+1 0 D
+P
+FO
+2697 2368 M
+2 0 D
+-2 1 D
+P
+FO
+2724 2369 M
+2 0 D
+P
+FO
+2722 2562 M
+1 0 D
+P
+FO
+2800 2423 M
+1 1 D
+P
+FO
+2803 2426 M
+1 1 D
+P
+FO
+2848 2435 M
+0 2 D
+-5 4 D
+1 -6 D
+2 -1 D
+P
+FO
+3711 2504 M
+2 -1 D
+3 2 D
+0 4 D
+-5 0 D
+-2 -4 D
+P
+FO
+3654 2528 M
+0 -3 D
+2 0 D
+6 5 D
+-3 3 D
+-6 -3 D
+P
+FO
+3691 2480 M
+5 -2 D
+2 2 D
+-7 8 D
+-1 -6 D
+2 -2 D
+P
+FO
+3661 2525 M
+-2 -2 D
+3 -1 D
+2 1 D
+-1 3 D
+P
+FO
+3675 2519 M
+2 -4 D
+2 3 D
+6 -1 D
+-8 3 D
+P
+FO
+3703 2484 M
+3 0 D
+0 4 D
+-2 0 D
+P
+FO
+3678 2480 M
+-3 1 D
+-2 -3 D
+4 -2 D
+P
+FO
+3709 2523 M
+2 -5 D
+0 6 D
+P
+FO
+3667 2476 M
+2 0 D
+0 2 D
+P
+FO
+3666 2522 M
+3 -1 D
+P
+FO
+3869 2598 M
+-2 -2 D
+1 0 D
+0 -4 D
+-5 -7 D
+4 3 D
+0 -2 D
+-6 -2 D
+9 -11 D
+3 -12 D
+0 -16 D
+-9 -27 D
+-2 -13 D
+1 1 D
+-3 -9 D
+-13 -19 D
+-9 -4 D
+2 -2 D
+1 2 D
+4 -1 D
+6 -7 D
+4 -7 D
+1 -6 D
+0 3 D
+2 -5 D
+4 3 D
+-3 -4 D
+4 -7 D
+-1 -1 D
+5 -1 D
+4 4 D
+4 -1 D
+9 1 D
+-1 -1 D
+-1 1 D
+-6 -2 D
+-6 0 D
+-1 -3 D
+-3 -1 D
+-6 1 D
+-1 3 D
+1 1 D
+-3 0 D
+-2 -3 D
+1 -7 D
+-1 -8 D
+2 1 D
+-1 -4 D
+3 1 D
+0 2 D
+3 -2 D
+1 2 D
+1 -3 D
+5 1 D
+-4 -2 D
+-3 2 D
+0 -2 D
+-2 2 D
+-2 -2 D
+0 -2 D
+-2 2 D
+0 -3 D
+7 -5 D
+1 1 D
+2 -1 D
+0 1 D
+1 0 D
+1 2 D
+6 1 D
+-6 -3 D
+-2 -5 D
+6 -3 D
+5 2 D
+-2 -6 D
+7 2 D
+6 4 D
+6 -2 D
+2 2 D
+3 0 D
+-5 -2 D
+-5 0 D
+-4 -5 D
+3 0 D
+0 -2 D
+1 0 D
+0 1 D
+1 -1 D
+0 2 D
+1 -1 D
+0 2 D
+1 -2 D
+2 1 D
+2 -2 D
+1 1 D
+-1 -2 D
+-3 2 D
+0 -2 D
+-2 1 D
+1 -1 D
+-1 1 D
+0 -2 D
+-4 -1 D
+-1 -3 D
+3 2 D
+-1 -5 D
+5 -2 D
+-1 -3 D
+6 4 D
+-3 -3 D
+1 -3 D
+4 1 D
+0 2 D
+1 -2 D
+4 3 D
+1 -2 D
+-4 -2 D
+0 -2 D
+2 2 D
+-1 -4 D
+1 -2 D
+1 2 D
+0 -3 D
+4 5 D
+-3 -9 D
+3 2 D
+-1 -3 D
+2 -2 D
+0 -3 D
+5 -1 D
+1 1 D
+-1 -1 D
+1 -1 D
+2 2 D
+3 -1 D
+-1 -4 D
+96 0 D
+0 236 D
+P
+3948 2487 M
+-2 2 D
+0 3 D
+-3 0 D
+-1 2 D
+-3 1 D
+-4 10 D
+-2 1 D
+0 1 D
+-4 -1 D
+-1 2 D
+-3 -1 D
+-3 2 D
+0 3 D
+-9 7 D
+-15 1 D
+-2 -1 D
+-1 1 D
+0 -2 D
+-8 -1 D
+-5 -2 D
+-9 0 D
+-2 2 D
+-4 -1 D
+-5 -10 D
+5 10 D
+3 1 D
+3 -2 D
+8 0 D
+6 3 D
+8 0 D
+0 2 D
+18 -1 D
+9 -7 D
+0 -2 D
+3 -3 D
+3 2 D
+1 -3 D
+4 2 D
+0 -2 D
+2 0 D
+4 -11 D
+4 -1 D
+0 -2 D
+3 0 D
+3 -5 D
+-1 -1 D
+P
+3879 2512 M
+-1 -4 D
+-3 -1 D
+2 1 D
+1 5 D
+P
+3875 2503 M
+2 -2 D
+2 0 D
+-2 -1 D
+P
+3865 2506 M
+-1 -2 D
+-1 2 D
+P
+3870 2514 M
+-1 -1 D
+0 1 D
+P
+3866 2515 M
+-1 -1 D
+P
+3866 2506 M
+-1 -1 D
+P
+3865 2520 M
+-1 -1 D
+P
+3893 2525 M
+-6 -3 D
+7 4 D
+P
+3868 2506 M
+-3 -2 D
+P
+FO
+3897 2382 M
+3 2 D
+-4 -1 D
+1 -2 D
+2 0 D
+P
+FO
+3874 2387 M
+3 0 D
+-2 4 D
+0 -3 D
+1 0 D
+P
+FO
+3868 2388 M
+2 -2 D
+1 2 D
+2 -1 D
+0 3 D
+P
+FO
+3874 2406 M
+-4 1 D
+0 -2 D
+3 -1 D
+P
+FO
+3874 2398 M
+-2 -2 D
+4 1 D
+0 1 D
+P
+FO
+3879 2390 M
+2 0 D
+1 3 D
+-3 -2 D
+P
+FO
+3874 2399 M
+0 -1 D
+1 1 D
+P
+FO
+3863 2591 M
+1 -2 D
+2 6 D
+P
+FO
+3864 2398 M
+4 -1 D
+0 3 D
+P
+FO
+3883 2398 M
+2 0 D
+2 3 D
+P
+FO
+3917 2364 M
+2 0 D
+0 2 D
+P
+FO
+3899 2383 M
+1 -1 D
+0 2 D
+P
+FO
+3867 2396 M
+2 0 D
+1 2 D
+-3 -1 D
+P
+FO
+3876 2391 M
+2 0 D
+0 2 D
+P
+FO
+3867 2391 M
+3 1 D
+-1 1 D
+-2 -1 D
+P
+FO
+3866 2406 M
+4 1 D
+-3 2 D
+P
+FO
+3878 2393 M
+1 2 D
+P
+FO
+3874 2391 M
+0 -1 D
+P
+FO
+3871 2393 M
+3 1 D
+-3 0 D
+P
+FO
+3874 2400 M
+2 -1 D
+P
+FO
+3880 2397 M
+2 0 D
+P
+FO
+3870 2395 M
+3 0 D
+P
+FO
+3865 2589 M
+2 3 D
+P
+FO
+3871 2387 M
+2 0 D
+P
+FO
+3904 2386 M
+-2 -1 D
+P
+FO
+3857 2422 M
+1 0 D
+P
+FO
+3863 2392 M
+1 1 D
+-1 0 D
+P
+FO
+3876 2394 M
+2 1 D
+P
+FO
+3859 2452 M
+1 1 D
+P
+FO
+3900 2384 M
+1 -1 D
+P
+FO
+3865 2591 M
+1 1 D
+P
+FO
+3862 2592 M
+0 1 D
+P
+FO
+4252 2508 M
+-1 2 D
+1 -1 D
+0 89 D
+-236 0 D
+0 -236 D
+236 0 D
+P
+4089 2442 M
+11 0 D
+6 3 D
+3 6 D
+5 -1 D
+8 6 D
+6 0 D
+2 3 D
+14 4 D
+2 -1 D
+-15 -3 D
+-3 -3 D
+-6 -1 D
+-7 -5 D
+-6 0 D
+-3 -5 D
+-6 -4 D
+-11 0 D
+-9 -6 D
+P
+4160 2503 M
+-3 -3 D
+-4 1 D
+-3 -5 D
+2 -6 D
+6 -3 D
+-4 0 D
+-2 -1 D
+1 1 D
+-2 -1 D
+3 2 D
+-3 1 D
+-2 7 D
+4 5 D
+4 0 D
+P
+4045 2400 M
+8 7 D
+2 5 D
+4 3 D
+3 9 D
+7 2 D
+-7 -2 D
+-2 -9 D
+-5 -3 D
+1 -2 D
+-4 -5 D
+P
+4180 2520 M
+18 4 D
+5 -1 D
+12 5 D
+8 1 D
+-9 -1 D
+-10 -5 D
+-5 1 D
+-21 -6 D
+P
+4163 2506 M
+7 1 D
+4 6 D
+3 1 D
+-7 -7 D
+P
+4166 2524 M
+1 1 D
+-3 -5 D
+1 -6 D
+-2 -1 D
+0 6 D
+P
+4226 2529 M
+13 -2 D
+-3 -1 D
+-8 1 D
+P
+4037 2390 M
+-1 6 D
+4 0 D
+-4 -1 D
+1 -5 D
+-4 -3 D
+P
+4177 2514 M
+2 -1 D
+-1 0 D
+-1 -2 D
+P
+4148 2518 M
+15 6 D
+0 -3 D
+P
+4184 2502 M
+1 -3 D
+-8 0 D
+P
+4164 2511 M
+1 0 D
+0 -3 D
+P
+4187 2502 M
+2 -2 D
+-3 1 D
+1 2 D
+P
+4175 2497 M
+1 -1 D
+-4 1 D
+P
+4163 2488 M
+-1 -1 D
+-1 1 D
+P
+4144 2499 M
+1 1 D
+1 -3 D
+P
+4247 2518 M
+3 -2 D
+-1 -2 D
+-6 13 D
+P
+4153 2472 M
+2 5 D
+5 4 D
+P
+4189 2506 M
+-2 -1 D
+P
+4159 2489 M
+-1 -1 D
+P
+4173 2498 M
+2 0 D
+P
+4176 2506 M
+2 0 D
+P
+4163 2494 M
+-1 -1 D
+P
+4172 2507 M
+2 1 D
+P
+4158 2500 M
+2 1 D
+P
+4145 2462 M
+-1 -1 D
+0 1 D
+P
+4187 2505 M
+-1 -1 D
+P
+4159 2486 M
+1 -1 D
+P
+4180 2510 M
+-3 -1 D
+P
+4149 2508 M
+1 1 D
+-2 -1 D
+P
+4176 2501 M
+-2 -2 D
+P
+4151 2506 M
+2 2 D
+P
+4138 2497 M
+5 1 D
+P
+4168 2505 M
+2 1 D
+P
+4142 2495 M
+3 0 D
+P
+FO
+4488 2215 M
+-1 107 D
+-13 -6 D
+14 7 D
+0 39 D
+-127 0 D
+-1 -4 D
+0 4 D
+-108 0 D
+0 -53 D
+2 0 D
+-1 4 D
+2 2 D
+-2 2 D
+3 0 D
+-2 3 D
+3 3 D
+-3 1 D
+2 10 D
+2 4 D
+-4 -13 D
+5 -2 D
+-2 0 D
+-2 -3 D
+2 0 D
+0 -2 D
+2 0 D
+-4 -2 D
+1 -1 D
+-2 -1 D
+2 -1 D
+0 -3 D
+2 3 D
+-1 -2 D
+2 -1 D
+0 -5 D
+-2 -1 D
+1 -2 D
+2 3 D
+-2 -5 D
+2 -2 D
+-2 -4 D
+1 0 D
+-2 -6 D
+1 -5 D
+2 3 D
+-1 -3 D
+-4 -1 D
+-1 -11 D
+0 8 D
+-2 -3 D
+0 -17 D
+4 3 D
+12 0 D
+-1 3 D
+1 -3 D
+6 1 D
+4 6 D
+6 3 D
+14 3 D
+34 2 D
+-1 1 D
+3 4 D
+1 -2 D
+9 2 D
+-12 -5 D
+12 1 D
+13 -2 D
+7 -5 D
+8 -9 D
+2 1 D
+0 -1 D
+-2 -1 D
+2 -3 D
+3 1 D
+1 2 D
+0 -3 D
+5 1 D
+-9 -1 D
+1 -3 D
+4 -2 D
+3 3 D
+1 -3 D
+-2 -1 D
+-3 1 D
+1 -5 D
+2 0 D
+0 1 D
+1 -2 D
+-3 0 D
+4 -9 D
+5 -6 D
+5 -4 D
+0 2 D
+0 -2 D
+2 -1 D
+0 3 D
+0 -1 D
+2 2 D
+-1 -4 D
+3 0 D
+0 5 D
+1 -2 D
+2 2 D
+1 -4 D
+5 0 D
+-2 5 D
+2 -5 D
+2 0 D
+-2 5 D
+2 -3 D
+1 5 D
+0 -6 D
+3 0 D
+-2 7 D
+2 -6 D
+3 -1 D
+-2 8 D
+2 -2 D
+0 2 D
+3 -6 D
+2 3 D
+-3 4 D
+5 -6 D
+4 1 D
+-3 -2 D
+6 0 D
+-1 4 D
+2 -3 D
+8 2 D
+8 -1 D
+1 3 D
+-2 1 D
+2 0 D
+-4 4 D
+2 -1 D
+0 2 D
+3 -3 D
+-1 3 D
+1 -4 D
+3 0 D
+-1 -1 D
+2 3 D
+1 -5 D
+-2 -1 D
+0 -2 D
+2 1 D
+-1 -1 D
+4 0 D
+-2 1 D
+1 0 D
+-1 5 D
+1 -2 D
+1 2 D
+-1 -2 D
+2 -3 D
+-1 4 D
+1 1 D
+-1 -2 D
+2 0 D
+1 2 D
+1 -6 D
+2 3 D
+-2 -5 D
+2 -7 D
+5 -2 D
+1 -2 D
+3 2 D
+-1 -2 D
+3 -1 D
+1 5 D
+2 -2 D
+4 2 D
+-3 -4 D
+4 1 D
+0 -2 D
+-2 0 D
+2 0 D
+-1 -1 D
+2 -1 D
+-1 -1 D
+-2 2 D
+1 -3 D
+-3 0 D
+1 -1 D
+-3 3 D
+3 -5 D
+3 1 D
+-3 -2 D
+6 -7 D
+2 1 D
+-2 -1 D
+2 -4 D
+-4 -13 D
+1 -5 D
+-2 0 D
+1 -10 D
+-11 -17 D
+1 -2 D
+3 1 D
+1 -3 D
+3 1 D
+-3 -3 D
+2 -11 D
+-2 1 D
+0 2 D
+-3 -1 D
+2 1 D
+-1 2 D
+-4 -1 D
+0 -3 D
+2 0 D
+3 -5 D
+1 2 D
+0 -2 D
+3 -2 D
+1 1 D
+0 -2 D
+6 0 D
+-6 -1 D
+2 -3 D
+-5 4 D
+0 -3 D
+-2 3 D
+-1 -3 D
+-1 4 D
+-2 -1 D
+0 4 D
+-1 -8 D
+16 0 D
+P
+4405 2325 M
+7 -9 D
+0 -6 D
+13 6 D
+15 -1 D
+15 -6 D
+10 3 D
+-10 -4 D
+-15 6 D
+-15 2 D
+-13 -6 D
+-3 -26 D
+3 -13 D
+-5 -16 D
+-2 -1 D
+6 17 D
+-3 16 D
+4 29 D
+-8 9 D
+-1 6 D
+P
+4361 2347 M
+4 -2 D
+0 -3 D
+5 2 D
+5 -5 D
+7 -2 D
+7 -4 D
+0 2 D
+0 -2 D
+7 0 D
+-8 0 D
+-8 5 D
+-5 0 D
+-5 5 D
+-5 -1 D
+P
+4349 2281 M
+3 0 D
+-2 -3 D
+-6 1 D
+5 0 D
+-4 2 D
+P
+4275 2268 M
+1 -1 D
+-3 -4 D
+0 4 D
+P
+4263 2264 M
+2 -1 D
+-4 0 D
+P
+4310 2279 M
+2 -2 D
+-4 0 D
+P
+4285 2275 M
+2 -2 D
+-2 0 D
+P
+4270 2268 M
+1 -1 D
+-3 0 D
+P
+4313 2279 M
+2 -1 D
+P
+4299 2281 M
+-1 -5 D
+P
+4321 2280 M
+-1 -2 D
+P
+4263 2268 M
+1 -1 D
+P
+FO
+4252 2304 M
+1 0 D
+-1 1 D
+P
+FO
+4252 2288 M
+3 1 D
+-3 0 D
+1 2 D
+2 -1 D
+-2 2 D
+2 1 D
+-1 2 D
+-2 1 D
+2 -1 D
+3 3 D
+-5 5 D
+P
+FO
+4451 2205 M
+1 -2 D
+5 -1 D
+6 10 D
+0 2 D
+-6 1 D
+-2 -7 D
+-3 0 D
+P
+FO
+4405 2132 M
+1 -6 D
+6 7 D
+-4 3 D
+P
+FO
+4421 2230 M
+4 0 D
+0 2 D
+-2 0 D
+P
+FO
+4417 2234 M
+1 -3 D
+1 0 D
+-1 3 D
+P
+FO
+4453 2235 M
+2 0 D
+-1 1 D
+P
+FO
+4399 2228 M
+5 0 D
+-3 3 D
+P
+FO
+4425 2164 M
+2 -1 D
+1 3 D
+P
+FO
+4478 2216 M
+3 -1 D
+-2 2 D
+P
+FO
+4459 2235 M
+2 -2 D
+-1 3 D
+-1 0 D
+P
+FO
+4416 2234 M
+1 -1 D
+0 2 D
+P
+FO
+4332 2279 M
+2 -1 D
+P
+FO
+4382 2253 M
+1 0 D
+P
+FO
+4476 2220 M
+1 -1 D
+P
+FO
+-2 -1 -2 2 2 2 2 -2 4 4252 2285 SP
+1 3 2 -3 -2 0 3 4255 2309 SP
+-1 3 1 1 1 -4 3 4255 2305 SP
+-1 -1 1 4256 2312 SP
+4671 2126 M
+5 10 D
+-3 14 D
+6 13 D
+0 16 D
+3 4 D
+-3 -8 D
+0 -13 D
+-5 -12 D
+2 -15 D
+-3 -9 D
+8 0 D
+4 19 D
+3 6 D
+20 16 D
+16 5 D
+0 190 D
+-236 0 D
+0 -39 D
+3 4 D
+-3 -4 D
+1 -3 D
+-1 1 D
+1 -105 D
+-1 -90 D
+P
+4553 2280 M
+3 -1 D
+-2 -1 D
+3 -3 D
+1 3 D
+1 0 D
+0 -3 D
+-4 0 D
+-2 3 D
+-3 0 D
+P
+4586 2353 M
+2 0 D
+-3 0 D
+P
+FO
+4687 2126 M
+-4 1 D
+-1 -1 D
+P
+FO
+4724 2170 M
+-12 -6 D
+-6 -1 D
+-15 -11 D
+-4 -6 D
+-3 -17 D
+1 0 D
+-1 -1 D
+3 -2 D
+37 0 D
+P
+FO
+-10 -3 8 5 10 2 3 4706 2164 SP
+-2 -2 1 3 1 0 3 4681 2126 SP
+1 0 1 4702 2162 SP
+2 0 0 1 2 4699 2159 SP
+4 3 1 4693 2153 SP
+1 3 1 4682 2130 SP
+2 2 1 4691 2152 SP
+0 -2 1 4675 2145 SP
+3 0 1 4717 2170 SP
+1 0 1 4723 2171 SP
+1 1 1 4683 2136 SP
+1 1 1 4688 2150 SP
+2 0 1 4695 2157 SP
+4724 2172 M
+25 2 D
+25 4 D
+13 -2 D
+4 -4 D
+4 -1 D
+15 -17 D
+13 -5 D
+3 -5 D
+5 0 D
+2 -2 D
+-8 2 D
+-3 5 D
+-11 3 D
+-15 17 D
+-8 3 D
+-7 5 D
+-19 -1 D
+-11 -5 D
+-15 2 D
+-10 -2 D
+-2 -1 D
+0 -44 D
+237 0 D
+0 236 D
+-237 0 D
+P
+FO
+-4 0 0 1 -8 -2 4 3 8 -1 5 4744 2173 SP
+-4 1 1 4777 2177 SP
+-3 1 1 4789 2172 SP
+3 0 1 4738 2173 SP
+-2 1 1 4795 2170 SP
+-2 0 3 0 2 4731 2172 SP
+-3 0 1 4773 2177 SP
+-1 1 1 4808 2156 SP
+-3 3 1 4788 2173 SP
+4963 2126 M
+-1 1 D
+3 1 D
+3 -1 D
+-1 -1 D
+46 0 D
+0 1 D
+1 -1 D
+0 1 D
+3 -1 D
+1 3 D
+0 -2 D
+3 0 D
+0 3 D
+2 3 D
+0 -3 D
+2 0 D
+-1 -2 D
+5 3 D
+0 -3 D
+5 2 D
+-1 2 D
+2 -1 D
+0 2 D
+3 2 D
+-2 1 D
+4 2 D
+-1 -4 D
+5 -1 D
+-3 0 D
+2 -3 D
+0 1 D
+1 -1 D
+2 1 D
+1 3 D
+2 -1 D
+-1 -2 D
+2 1 D
+1 -2 D
+4 2 D
+0 -6 D
+142 0 D
+0 236 D
+-236 0 D
+0 -236 D
+P
+5021 2159 M
+0 3 D
+3 -1 D
+3 3 D
+0 -2 D
+5 0 D
+2 3 D
+0 -1 D
+4 2 D
+0 -1 D
+4 3 D
+0 -3 D
+1 0 D
+-9 -3 D
+4 -1 D
+-3 -1 D
+4 -1 D
+-1 -4 D
+-8 5 D
+-2 -1 D
+0 -2 D
+-3 2 D
+1 -2 D
+P
+5027 2160 M
+1 0 D
+-3 0 D
+P
+5106 2236 M
+2 -12 D
+-1 -5 D
+2 -4 D
+-2 -11 D
+6 -8 D
+6 -2 D
+0 -9 D
+-2 -2 D
+-2 0 D
+-4 10 D
+-3 3 D
+-3 1 D
+1 5 D
+-5 3 D
+0 5 D
+-1 -2 D
+-1 4 D
+3 23 D
+1 -2 D
+0 2 D
+P
+5117 2189 M
+-1 -2 D
+P
+5015 2165 M
+7 1 D
+4 4 D
+3 -1 D
+3 2 D
+-2 -1 D
+2 -1 D
+-1 -3 D
+0 2 D
+-4 1 D
+0 -2 D
+-6 -3 D
+0 1 D
+-3 0 D
+-2 0 D
+4 -2 D
+-7 2 D
+P
+4973 2150 M
+0 5 D
+-3 2 D
+2 5 D
+18 14 D
+5 7 D
+-2 -4 D
+1 -8 D
+-3 -5 D
+-8 -4 D
+-8 -12 D
+P
+5153 2282 M
+-7 -13 D
+-4 -1 D
+0 2 D
+5 3 D
+-1 7 D
+4 2 D
+1 -1 D
+P
+5150 2277 M
+-1 -1 D
+P
+5172 2317 M
+0 -3 D
+-3 -3 D
+-2 2 D
+0 2 D
+P
+5176 2326 M
+-1 -4 D
+-2 1 D
+2 3 D
+P
+5041 2155 M
+1 1 D
+1 -4 D
+P
+5142 2267 M
+1 -4 D
+-4 -2 D
+0 2 D
+P
+5163 2308 M
+2 -2 D
+-1 -2 D
+-2 2 D
+P
+5054 2165 M
+2 2 D
+1 -2 D
+-3 -1 D
+-2 2 D
+P
+5164 2303 M
+0 -2 D
+-5 1 D
+1 2 D
+P
+5168 2308 M
+1 -3 D
+-2 -2 D
+-1 4 D
+P
+5104 2139 M
+-1 1 D
+1 3 D
+1 -4 D
+P
+5115 2179 M
+1 0 D
+P
+5166 2335 M
+1 0 D
+-1 -1 D
+P
+5161 2294 M
+-1 -3 D
+P
+5059 2165 M
+2 0 D
+P
+5045 2157 M
+2 0 D
+P
+5048 2158 M
+1 0 D
+P
+5044 2158 M
+2 0 D
+P
+5047 2153 M
+1 -1 D
+P
+FO
+1 1 1 5026 2126 SP
+-2 0 1 -3 -4 1 2 1 0 3 5 5039 2128 SP
+0 1 1 5038 2126 SP
+1 0 1 5034 2128 SP
+2 -1 -2 0 2 5052 2128 SP
+0 -1 0 2 2 5036 2128 SP
+5266 2126 M
+15 17 D
+28 23 D
+30 17 D
+46 49 D
+23 36 D
+6 17 D
+15 24 D
+0 4 D
+4 4 D
+0 45 D
+-236 0 D
+0 -236 D
+P
+FO
+5433 2317 M
+3 3 D
+7 15 D
+5 5 D
+1 4 D
+4 4 D
+1 14 D
+-21 0 D
+P
+FO
+6142 2338 M
+-2 -1 D
+1 -5 D
+-4 -12 D
+1 -6 D
+-2 1 D
+1 8 D
+-2 -3 D
+4 -33 D
+3 -10 D
+P
+6137 2311 M
+0 -2 D
+P
+FO
+6142 2357 M
+-2 -1 D
+2 -1 D
+P
+FO
+6054 2362 M
+1 -14 D
+3 -6 D
+-1 2 D
+2 -1 D
+1 -6 D
+3 1 D
+-3 -2 D
+11 -13 D
+7 -5 D
+6 -1 D
+12 7 D
+3 10 D
+-2 -1 D
+4 6 D
+14 6 D
+8 0 D
+-6 2 D
+-1 3 D
+8 12 D
+P
+6075 2352 M
+2 -1 D
+-3 -1 D
+P
+6055 2361 M
+0 -2 D
+-1 2 D
+P
+FO
+6053 2362 M
+P
+FO
+6139 2338 M
+1 0 D
+-2 2 D
+2 -1 D
+-6 1 D
+P
+FO
+6123 2345 M
+6 -3 D
+-3 4 D
+P
+FO
+6138 2355 M
+1 -2 D
+2 0 D
+P
+FO
+6136 2327 M
+1 -3 D
+P
+FO
+5989 2171 M
+0 2 D
+P
+FO
+5977 2321 M
+1 2 D
+P
+FO
+5980 2285 M
+1 1 D
+P
+FO
+5985 2184 M
+0 -2 D
+P
+FO
+5982 2289 M
+0 1 D
+P
+FO
+6116 2343 M
+1 0 D
+P
+FO
+6134 2351 M
+1 -1 D
+P
+FO
+6137 2352 M
+2 1 D
+P
+FO
+6138 2355 M
+1 2 D
+P
+FO
+6142 2355 M
+9 -5 D
+-2 -1 D
+-6 4 D
+3 -3 D
+-3 -2 D
+2 -3 D
+-3 -7 D
+1 -66 D
+5 -4 D
+8 -2 D
+17 6 D
+9 7 D
+4 13 D
+-2 13 D
+-5 8 D
+-2 -1 D
+1 3 D
+-2 1 D
+-2 11 D
+-4 -2 D
+1 5 D
+-9 11 D
+-1 4 D
+-14 13 D
+-5 -1 D
+P
+6176 2297 M
+2 -1 D
+-3 -2 D
+1 2 D
+-2 0 D
+P
+6152 2346 M
+1 -1 D
+P
+FO
+6614 2189 M
+-1 1 D
+1 5 D
+-3 3 D
+-1 -1 D
+1 1 D
+-19 14 D
+-9 3 D
+0 3 D
+-7 4 D
+-2 0 D
+-1 2 D
+-2 -2 D
+0 2 D
+2 1 D
+1 6 D
+-5 3 D
+-3 -1 D
+1 2 D
+-2 7 D
+-10 8 D
+-7 -2 D
+-5 2 D
+-14 -1 D
+-7 2 D
+-5 5 D
+-6 3 D
+-3 -1 D
+-2 2 D
+-5 -2 D
+0 -7 D
+8 -15 D
+11 -11 D
+3 -1 D
+9 -9 D
+8 -2 D
+12 -16 D
+5 -3 D
+2 -11 D
+2 -3 D
+5 0 D
+7 -6 D
+5 -1 D
+5 -6 D
+1 0 D
+0 1 D
+2 -1 D
+1 -2 D
+-2 -3 D
+-1 1 D
+8 -19 D
+2 -12 D
+6 -2 D
+7 -4 D
+7 0 D
+P
+6594 2182 M
+-8 -1 D
+-3 6 D
+5 -4 D
+2 2 D
+-5 6 D
+-2 -1 D
+0 -2 D
+-4 6 D
+6 -2 D
+4 -3 D
+3 -6 D
+P
+FO
+6614 2190 M
+-1 0 D
+1 -1 D
+P
+FO
+6614 2328 M
+-3 17 D
+-4 2 D
+-8 -4 D
+-3 2 D
+0 2 D
+2 1 D
+-4 8 D
+0 6 D
+-12 0 D
+-1 -2 D
+-2 -1 D
+1 -2 D
+1 1 D
+-2 -2 D
+1 0 D
+-2 -3 D
+3 -1 D
+-3 -2 D
+0 2 D
+-2 -9 D
+-2 0 D
+2 -6 D
+-1 1 D
+-2 -3 D
+0 -8 D
+-1 1 D
+2 -8 D
+3 -2 D
+1 6 D
+1 0 D
+0 -1 D
+4 1 D
+-1 -2 D
+2 0 D
+1 -7 D
+4 1 D
+2 -4 D
+2 2 D
+-2 -3 D
+1 -3 D
+2 2 D
+1 -3 D
+2 0 D
+-1 -1 D
+1 1 D
+0 -4 D
+3 -4 D
+2 -1 D
+1 4 D
+0 -3 D
+2 1 D
+-2 -3 D
+2 -2 D
+0 1 D
+2 0 D
+-1 -2 D
+2 1 D
+-2 -3 D
+1 -4 D
+5 -3 D
+1 -3 D
+1 0 D
+P
+FO
+6614 2352 M
+-2 0 D
+1 -4 D
+P
+FO
+6614 2357 M
+-1 0 D
+1 -2 D
+P
+FO
+6580 2362 M
+P
+FO
+6571 2362 M
+-1 -4 D
+3 4 D
+P
+FO
+6520 2192 M
+-5 3 D
+0 -2 D
+-3 -1 D
+3 -4 D
+7 -1 D
+5 -5 D
+4 0 D
+-1 3 D
+-1 0 D
+0 -1 D
+-5 5 D
+0 -1 D
+-2 0 D
+1 2 D
+-1 1 D
+1 0 D
+P
+FO
+6553 2150 M
+0 -2 D
+5 -3 D
+2 -6 D
+4 1 D
+1 10 D
+-14 12 D
+-1 -2 D
+-5 -1 D
+4 -3 D
+P
+FO
+6471 2291 M
+-2 6 D
+-4 -1 D
+0 -4 D
+3 -3 D
+0 -3 D
+2 1 D
+P
+FO
+6461 2315 M
+1 1 D
+-1 5 D
+-1 -2 D
+1 -3 D
+1 1 D
+P
+FO
+6574 2315 M
+0 -6 D
+2 2 D
+1 -1 D
+1 7 D
+-4 3 D
+P
+FO
+6606 2278 M
+2 -4 D
+4 2 D
+-2 3 D
+P
+FO
+6501 2265 M
+2 -2 D
+2 0 D
+-1 2 D
+-1 -1 D
+P
+FO
+6464 2299 M
+1 -2 D
+2 2 D
+-1 3 D
+P
+FO
+6605 2282 M
+1 -2 D
+1 0 D
+-1 5 D
+P
+FO
+6496 2261 M
+3 -1 D
+-2 2 D
+P
+FO
+6458 2315 M
+-1 0 D
+-1 -2 D
+4 -1 D
+P
+FO
+6545 2175 M
+1 -2 D
+1 2 D
+P
+FO
+6462 2315 M
+-1 0 D
+2 -2 D
+P
+FO
+6580 2318 M
+2 -1 D
+0 2 D
+P
+FO
+6599 2297 M
+2 0 D
+-1 1 D
+P
+FO
+6579 2129 M
+8 -1 D
+-1 2 D
+P
+FO
+6546 2178 M
+5 -4 D
+-1 5 D
+-4 0 D
+P
+FO
+6591 2307 M
+2 -5 D
+1 5 D
+P
+FO
+6442 2342 M
+3 0 D
+-1 3 D
+P
+FO
+6573 2339 M
+2 1 D
+-1 2 D
+P
+FO
+6581 2315 M
+-2 3 D
+2 -6 D
+P
+FO
+6451 2322 M
+3 -2 D
+-2 3 D
+P
+FO
+6499 2258 M
+2 1 D
+-2 1 D
+P
+FO
+6609 2273 M
+1 -1 D
+1 3 D
+P
+FO
+6463 2328 M
+1 -3 D
+P
+FO
+6577 2166 M
+4 -2 D
+P
+FO
+6534 2176 M
+2 -1 D
+P
+FO
+6597 2281 M
+1 -1 D
+P
+FO
+6612 2275 M
+1 0 D
+P
+FO
+6518 2186 M
+1 0 D
+P
+FO
+6528 2189 M
+1 0 D
+P
+FO
+6567 2358 M
+1 0 D
+P
+FO
+6594 2281 M
+3 0 D
+P
+FO
+6589 2311 M
+1 -1 D
+P
+FO
+6577 2358 M
+1 1 D
+P
+FO
+6573 2343 M
+1 2 D
+P
+FO
+6563 2349 M
+2 0 D
+P
+FO
+6576 2356 M
+1 1 D
+P
+FO
+6462 2318 M
+1 -2 D
+P
+FO
+6606 2351 M
+1 0 D
+P
+FO
+6572 2224 M
+1 1 D
+P
+FO
+6534 2178 M
+1 -1 D
+P
+FO
+6604 2294 M
+1 -1 D
+P
+FO
+6585 2310 M
+0 -2 D
+P
+FO
+6563 2349 M
+1 -1 D
+P
+FO
+6552 2182 M
+1 -1 D
+P
+FO
+6574 2342 M
+1 0 D
+-1 1 D
+P
+FO
+6704 2126 M
+-2 7 D
+-2 1 D
+-1 -1 D
+0 2 D
+-6 4 D
+-5 -4 D
+-10 -4 D
+10 6 D
+-5 6 D
+-12 2 D
+-4 5 D
+-2 9 D
+-9 7 D
+-5 -1 D
+-4 1 D
+-2 8 D
+-6 6 D
+-4 0 D
+-2 -2 D
+3 -9 D
+1 0 D
+-1 0 D
+-3 6 D
+-3 1 D
+0 -1 D
+-7 6 D
+-4 9 D
+-2 -1 D
+1 -4 D
+-1 0 D
+-1 6 D
+-2 -1 D
+1 -2 D
+-1 1 D
+0 -63 D
+P
+6667 2141 M
+-1 1 D
+P
+6652 2152 M
+-1 2 D
+P
+FO
+6722 2126 M
+0 1 D
+-2 -1 D
+P
+FO
+6850 2166 M
+-2 0 D
+-1 2 D
+-4 2 D
+-1 5 D
+-1 -2 D
+-7 -1 D
+0 -4 D
+2 1 D
+-8 -7 D
+-2 -8 D
+4 1 D
+-5 -2 D
+1 -4 D
+-3 -4 D
+2 -4 D
+0 -7 D
+4 -2 D
+4 -6 D
+-2 1 D
+0 -1 D
+19 0 D
+P
+FO
+6770 2362 M
+1 0 D
+P
+FO
+6765 2362 M
+5 -4 D
+2 2 D
+P
+FO
+6734 2362 M
+1 -2 D
+-1 1 D
+-5 -5 D
+-2 -22 D
+4 0 D
+-2 -3 D
+5 3 D
+5 -1 D
+6 8 D
+16 6 D
+-2 1 D
+1 4 D
+-8 10 D
+13 -11 D
+3 1 D
+1 4 D
+-5 6 D
+P
+FO
+6614 2355 M
+2 -1 D
+-1 4 D
+P
+FO
+6614 2349 M
+2 1 D
+0 3 D
+-2 -1 D
+P
+FO
+6614 2282 M
+1 0 D
+1 -2 D
+1 1 D
+-1 -2 D
+6 -12 D
+0 -6 D
+2 -2 D
+-2 1 D
+3 -11 D
+-2 -4 D
+5 -4 D
+-1 -2 D
+2 0 D
+-1 -3 D
+2 1 D
+-2 -2 D
+1 -1 D
+1 1 D
+-3 -7 D
+3 -1 D
+-2 -2 D
+4 -2 D
+0 -2 D
+2 1 D
+2 -2 D
+-5 1 D
+0 -4 D
+5 0 D
+-3 -1 D
+6 -4 D
+6 -9 D
+1 -5 D
+-1 -5 D
+3 0 D
+1 -3 D
+7 -3 D
+2 -4 D
+3 0 D
+4 -5 D
+10 -3 D
+3 -5 D
+5 -1 D
+0 -1 D
+10 -5 D
+4 -7 D
+0 4 D
+2 -2 D
+5 4 D
+5 -2 D
+-2 5 D
+3 -4 D
+2 1 D
+-2 -1 D
+2 -2 D
+-1 -1 D
+4 0 D
+0 6 D
+-7 17 D
+-3 3 D
+0 3 D
+-5 2 D
+-4 4 D
+-1 12 D
+1 4 D
+-2 0 D
+2 1 D
+-3 6 D
+2 4 D
+-1 3 D
+3 5 D
+-1 11 D
+-7 13 D
+-2 -1 D
+1 1 D
+-3 4 D
+-12 9 D
+-3 7 D
+-6 1 D
+-7 5 D
+-6 10 D
+-6 2 D
+1 -2 D
+-8 0 D
+-6 3 D
+-4 5 D
+-4 -1 D
+1 2 D
+3 -1 D
+-9 29 D
+-2 2 D
+1 -3 D
+-2 1 D
+-2 3 D
+P
+6623 2303 M
+-1 -3 D
+P
+6617 2310 M
+1 -1 D
+P
+6624 2299 M
+0 -1 D
+-1 1 D
+P
+FO
+6812 2220 M
+-4 6 D
+-6 -5 D
+3 -4 D
+4 -1 D
+1 -2 D
+-2 2 D
+-3 -3 D
+2 -1 D
+3 1 D
+2 3 D
+P
+FO
+6679 2150 M
+-3 -1 D
+-3 4 D
+0 -5 D
+-2 -2 D
+11 -1 D
+4 -3 D
+0 3 D
+-6 5 D
+-2 -2 D
+P
+FO
+6719 2150 M
+1 -4 D
+3 -1 D
+1 6 D
+-1 4 D
+-7 -1 D
+-2 -2 D
+1 -2 D
+5 1 D
+P
+FO
+6656 2173 M
+-3 3 D
+-2 -2 D
+-3 0 D
+-1 -3 D
+1 -4 D
+4 -1 D
+3 1 D
+P
+FO
+6685 2147 M
+3 -2 D
+1 2 D
+-7 6 D
+-3 1 D
+-3 -4 D
+5 1 D
+-1 -2 D
+P
+FO
+6708 2150 M
+3 -1 D
+1 5 D
+-2 -1 D
+-1 1 D
+0 -1 D
+-2 0 D
+P
+FO
+6668 2149 M
+5 -1 D
+-1 3 D
+1 4 D
+-7 5 D
+P
+FO
+6760 2202 M
+1 -2 D
+2 -1 D
+1 2 D
+-2 -1 D
+1 1 D
+P
+FO
+6732 2332 M
+-6 -3 D
+7 0 D
+5 3 D
+-5 1 D
+P
+FO
+6709 2158 M
+-5 3 D
+-4 -3 D
+5 -2 D
+P
+FO
+6688 2139 M
+4 -1 D
+-2 5 D
+P
+FO
+6707 2150 M
+-2 0 D
+0 -1 D
+3 -2 D
+P
+FO
+6749 2197 M
+0 1 D
+0 -4 D
+3 2 D
+P
+FO
+6696 2150 M
+-2 3 D
+-1 -3 D
+P
+FO
+6618 2255 M
+1 -4 D
+2 -1 D
+1 4 D
+P
+FO
+6693 2145 M
+3 -4 D
+1 3 D
+-3 3 D
+P
+FO
+6713 2144 M
+3 -1 D
+-1 2 D
+P
+FO
+6718 2129 M
+2 -3 D
+-1 3 D
+P
+FO
+6769 2331 M
+1 -1 D
+2 3 D
+P
+FO
+6792 2150 M
+1 -2 D
+1 1 D
+P
+FO
+6646 2197 M
+-1 2 D
+-1 -3 D
+P
+FO
+6760 2205 M
+1 -1 D
+0 2 D
+P
+FO
+6661 2164 M
+12 -8 D
+-1 6 D
+P
+FO
+6711 2148 M
+2 -3 D
+2 1 D
+P
+FO
+6712 2192 M
+2 -2 D
+-1 5 D
+P
+FO
+6758 2356 M
+4 -5 D
+1 1 D
+-5 5 D
+P
+FO
+6702 2147 M
+3 -3 D
+-1 2 D
+P
+FO
+6761 2203 M
+2 -1 D
+0 4 D
+P
+FO
+6721 2136 M
+0 -2 D
+P
+FO
+6720 2132 M
+5 -6 D
+P
+FO
+6822 2194 M
+0 -1 D
+2 4 D
+P
+FO
+6827 2185 M
+3 0 D
+-3 1 D
+P
+FO
+6704 2147 M
+2 -2 D
+P
+FO
+6695 2147 M
+3 -3 D
+P
+FO
+6766 2361 M
+3 -3 D
+P
+FO
+6695 2147 M
+2 -1 D
+P
+FO
+6716 2135 M
+3 -2 D
+P
+FO
+6687 2143 M
+1 2 D
+P
+FO
+6721 2144 M
+3 1 D
+P
+FO
+6710 2179 M
+1 -1 D
+P
+FO
+6701 2147 M
+0 -2 D
+P
+FO
+6767 2360 M
+1 -2 D
+P
+FO
+6764 2362 M
+1 -1 D
+P
+FO
+6715 2138 M
+1 -1 D
+P
+FO
+6719 2132 M
+1 -1 D
+P
+FO
+6757 2358 M
+0 -1 D
+P
+FO
+6803 2238 M
+-1 -1 D
+P
+FO
+6714 2143 M
+2 -3 D
+P
+FO
+6686 2141 M
+1 -2 D
+P
+FO
+6727 2150 M
+2 -1 D
+P
+FO
+6704 2149 M
+-1 2 D
+P
+FO
+6760 2192 M
+2 -1 D
+P
+FO
+6696 2141 M
+1 1 D
+P
+FO
+6797 2197 M
+2 0 D
+P
+FO
+6685 2263 M
+1 -1 D
+P
+FO
+6725 2144 M
+2 0 D
+P
+FO
+6706 2145 M
+1 -1 D
+P
+FO
+6701 2143 M
+2 -1 D
+P
+FO
+6629 2178 M
+1 -1 D
+P
+FO
+6697 2148 M
+1 -2 D
+P
+FO
+6627 2227 M
+1 -2 D
+P
+FO
+6790 2149 M
+1 -1 D
+P
+FO
+6805 2211 M
+1 1 D
+P
+FO
+6701 2146 M
+1 -2 D
+P
+FO
+6643 2195 M
+1 1 D
+P
+FO
+6723 2145 M
+1 1 D
+P
+FO
+6709 2159 M
+2 0 D
+P
+FO
+6695 2149 M
+1 -1 D
+P
+FO
+6643 2197 M
+1 1 D
+-1 0 D
+P
+FO
+6716 2134 M
+2 -1 D
+P
+FO
+6705 2151 M
+1 0 D
+P
+FO
+6711 2181 M
+1 -1 D
+P
+FO
+6644 2195 M
+1 1 D
+P
+FO
+6713 2140 M
+1 -1 D
+P
+FO
+6724 2146 M
+1 1 D
+P
+FO
+6715 2130 M
+2 -2 D
+P
+FO
+6721 2184 M
+P
+FO
+6723 2147 M
+1 0 D
+P
+FO
+6726 2143 M
+1 0 D
+P
+FO
+6712 2148 M
+1 0 D
+P
+FO
+6755 2198 M
+1 1 D
+P
+FO
+6804 2213 M
+1 -1 D
+P
+FO
+6713 2130 M
+1 1 D
+P
+FO
+6763 2205 M
+1 2 D
+P
+FO
+6698 2139 M
+2 -1 D
+P
+FO
+6723 2357 M
+1 1 D
+P
+FO
+6696 2346 M
+1 0 D
+P
+FO
+6820 2145 M
+0 -2 D
+P
+FO
+6803 2216 M
+1 -1 D
+P
+FO
+6698 2136 M
+1 0 D
+-1 1 D
+P
+FO
+6707 2160 M
+1 -1 D
+P
+FO
+6784 2129 M
+1 0 D
+P
+FO
+6831 2127 M
+1 -1 D
+P
+FO
+6701 2141 M
+1 -1 D
+P
+FO
+6726 2127 M
+1 0 D
+P
+FO
+6772 2331 M
+1 0 D
+P
+FO
+6799 2223 M
+1 1 D
+-1 0 D
+P
+FO
+6720 2129 M
+1 0 D
+P
+FO
+6716 2144 M
+1 0 D
+P
+FO
+6707 2150 M
+1 -1 D
+P
+FO
+6719 2129 M
+1 -1 D
+P
+FO
+7028 2126 M
+-1 2 D
+2 8 D
+1 0 D
+4 8 D
+3 2 D
+3 -1 D
+-3 7 D
+4 -5 D
+7 -2 D
+3 1 D
+7 -1 D
+5 4 D
+-7 4 D
+2 1 D
+-5 4 D
+-4 1 D
+0 2 D
+-7 4 D
+-1 3 D
+-5 2 D
+0 3 D
+-3 1 D
+4 1 D
+-4 3 D
+7 0 D
+2 3 D
+-7 7 D
+-1 3 D
+-4 2 D
+3 1 D
+-4 1 D
+3 1 D
+0 1 D
+-4 -2 D
+2 4 D
+-4 0 D
+0 2 D
+-4 0 D
+6 3 D
+-2 1 D
+0 2 D
+-5 0 D
+0 4 D
+-5 0 D
+3 1 D
+9 -1 D
+-1 3 D
+3 -2 D
+4 0 D
+2 4 D
+-8 6 D
+-2 -1 D
+1 1 D
+-3 1 D
+2 0 D
+-2 1 D
+4 -1 D
+2 1 D
+-1 2 D
+2 1 D
+-2 3 D
+2 1 D
+8 -5 D
+9 2 D
+-1 1 D
+5 0 D
+3 2 D
+-2 2 D
+-2 -2 D
+-1 2 D
+1 1 D
+-5 2 D
+-4 5 D
+5 4 D
+3 -3 D
+17 5 D
+2 2 D
+0 4 D
+-2 2 D
+-7 -2 D
+2 1 D
+-3 2 D
+0 -3 D
+-1 3 D
+-4 3 D
+-2 -2 D
+-1 2 D
+2 2 D
+-5 3 D
+0 -2 D
+-3 2 D
+-2 -1 D
+0 -3 D
+-2 1 D
+-3 -1 D
+-1 3 D
+6 1 D
+-3 5 D
+-3 -3 D
+-3 0 D
+0 -1 D
+-5 0 D
+3 2 D
+-2 1 D
+1 1 D
+-2 4 D
+4 1 D
+0 4 D
+-4 2 D
+-1 3 D
+-1 -4 D
+-4 3 D
+-2 5 D
+1 3 D
+-3 2 D
+-3 -2 D
+1 -2 D
+-6 -7 D
+-1 0 D
+3 6 D
+-2 1 D
+1 1 D
+-2 3 D
+-6 -13 D
+-7 -5 D
+2 0 D
+0 -1 D
+-2 0 D
+-1 -2 D
+-2 -1 D
+2 -1 D
+-3 -2 D
+0 -3 D
+-3 -2 D
+-1 -4 D
+-5 -1 D
+-2 2 D
+-5 -5 D
+0 -3 D
+1 2 D
+-1 -2 D
+3 -2 D
+3 1 D
+-6 -8 D
+-4 1 D
+-4 -4 D
+0 5 D
+2 1 D
+-16 -9 D
+-11 -1 D
+-1 -8 D
+-5 -7 D
+-7 -5 D
+-9 -14 D
+-11 -4 D
+-21 -4 D
+2 -1 D
+-3 1 D
+-5 -3 D
+0 -4 D
+2 -1 D
+-3 0 D
+3 -3 D
+-5 0 D
+-1 2 D
+-2 -5 D
+1 0 D
+-1 -2 D
+4 0 D
+-3 -2 D
+-3 -6 D
+2 0 D
+-2 -1 D
+3 -3 D
+-4 1 D
+-1 -3 D
+4 -5 D
+-9 5 D
+-2 -3 D
+1 3 D
+-3 1 D
+-2 -1 D
+-2 2 D
+2 2 D
+-4 -1 D
+-1 3 D
+-1 -3 D
+-7 0 D
+0 -40 D
+P
+6902 2149 M
+1 1 D
+1 -2 D
+-1 -1 D
+P
+6900 2145 M
+-1 2 D
+3 -1 D
+0 -1 D
+P
+6897 2146 M
+1 2 D
+P
+6902 2143 M
+1 1 D
+P
+6903 2144 M
+1 0 D
+P
+FO
+7079 2126 M
+0 1 D
+-1 -1 D
+P
+FO
+7087 2138 M
+-3 -1 D
+-1 -3 D
+1 -3 D
+-3 0 D
+3 -3 D
+-1 -2 D
+4 0 D
+P
+FO
+7087 2250 M
+-5 -2 D
+0 -3 D
+5 2 D
+P
+FO
+7055 2362 M
+-14 -17 D
+-4 0 D
+-4 -5 D
+-2 0 D
+-9 -11 D
+-2 -6 D
+6 4 D
+-1 1 D
+2 -1 D
+2 4 D
+4 0 D
+6 5 D
+3 6 D
+5 1 D
+5 4 D
+5 7 D
+-1 3 D
+2 -1 D
+-1 5 D
+6 1 D
+P
+FO
+6881 2190 M
+1 -8 D
+2 0 D
+-2 10 D
+P
+FO
+7016 2310 M
+2 3 D
+-1 4 D
+-2 -1 D
+-1 -2 D
+P
+FO
+7017 2296 M
+0 -2 D
+5 2 D
+0 4 D
+-5 -2 D
+P
+FO
+7031 2220 M
+2 0 D
+1 2 D
+-3 2 D
+-1 -1 D
+P
+FO
+7037 2225 M
+-4 2 D
+-3 -1 D
+6 -5 D
+2 1 D
+P
+FO
+7023 2283 M
+3 -1 D
+2 2 D
+-3 2 D
+1 -2 D
+P
+FO
+7027 2207 M
+1 2 D
+3 -1 D
+-9 3 D
+-1 -1 D
+P
+FO
+7028 2206 M
+3 -3 D
+1 4 D
+-3 0 D
+P
+FO
+7054 2232 M
+3 -1 D
+P
+FO
+7035 2178 M
+0 -2 D
+3 0 D
+P
+FO
+7080 2245 M
+2 1 D
+0 1 D
+P
+FO
+7052 2180 M
+3 -3 D
+-1 2 D
+P
+FO
+7047 2236 M
+6 -1 D
+-3 2 D
+P
+FO
+7022 2320 M
+2 0 D
+-1 3 D
+P
+FO
+7034 2209 M
+3 -1 D
+-2 3 D
+P
+FO
+7016 2298 M
+0 2 D
+-4 -4 D
+P
+FO
+7072 2238 M
+0 -2 D
+1 3 D
+P
+FO
+7074 2242 M
+0 -6 D
+1 3 D
+P
+FO
+6972 2250 M
+3 1 D
+-1 2 D
+P
+FO
+7052 2291 M
+-1 2 D
+-2 -1 D
+P
+FO
+7082 2240 M
+2 -1 D
+P
+FO
+7028 2211 M
+4 -1 D
+P
+FO
+7023 2211 M
+4 -1 D
+P
+FO
+7082 2242 M
+1 -1 D
+P
+FO
+7031 2193 M
+2 0 D
+P
+FO
+7020 2322 M
+2 0 D
+P
+FO
+7026 2206 M
+2 -1 D
+P
+FO
+7022 2293 M
+2 -1 D
+P
+FO
+7052 2259 M
+2 1 D
+-2 0 D
+P
+FO
+7016 2317 M
+1 0 D
+P
+FO
+7039 2262 M
+-2 1 D
+P
+FO
+7029 2195 M
+3 0 D
+P
+FO
+7043 2264 M
+2 0 D
+P
+FO
+7050 2160 M
+2 -1 D
+P
+FO
+7052 2258 M
+1 0 D
+-1 1 D
+P
+FO
+7019 2319 M
+2 0 D
+P
+FO
+7046 2243 M
+2 1 D
+P
+FO
+6994 2268 M
+-2 1 D
+P
+FO
+7018 2321 M
+1 -1 D
+P
+FO
+7035 2178 M
+2 -1 D
+P
+FO
+7052 2233 M
+1 1 D
+P
+FO
+7065 2255 M
+2 0 D
+P
+FO
+7056 2235 M
+2 0 D
+P
+FO
+6983 2261 M
+1 0 D
+P
+FO
+7048 2240 M
+1 -1 D
+P
+FO
+6971 2244 M
+1 0 D
+-2 0 D
+P
+FO
+7051 2177 M
+2 -1 D
+P
+FO
+7028 2211 M
+1 0 D
+P
+FO
+7088 2126 M
+6 10 D
+8 3 D
+5 -3 D
+6 0 D
+3 2 D
+6 -1 D
+1 2 D
+4 -1 D
+2 -2 D
+7 2 D
+23 0 D
+5 -5 D
+8 -1 D
+17 3 D
+4 2 D
+3 8 D
+8 6 D
+2 7 D
+5 4 D
+-3 1 D
+1 3 D
+-5 1 D
+-4 -4 D
+1 -2 D
+-7 -3 D
+-1 -1 D
+3 -1 D
+-1 -2 D
+-5 0 D
+-2 -4 D
+-8 -4 D
+-23 3 D
+-3 -4 D
+-10 5 D
+-5 -1 D
+-4 2 D
+-2 -1 D
+-1 2 D
+-6 -2 D
+-5 3 D
+0 4 D
+-5 -2 D
+-3 2 D
+-5 0 D
+0 1 D
+-2 -1 D
+0 -6 D
+-4 -3 D
+-1 -4 D
+-7 2 D
+1 3 D
+-2 0 D
+-1 -4 D
+-4 -2 D
+0 -5 D
+-1 0 D
+0 -12 D
+P
+FO
+7263 2126 M
+-1 3 D
+-1 -3 D
+P
+FO
+7273 2126 M
+1 6 D
+-2 1 D
+2 4 D
+12 -2 D
+11 -4 D
+-6 3 D
+1 5 D
+-9 2 D
+-3 4 D
+12 6 D
+1 12 D
+-7 0 D
+-6 -4 D
+-2 -3 D
+2 -1 D
+0 -1 D
+-5 -2 D
+-2 -7 D
+-2 0 D
+-4 3 D
+0 2 D
+6 3 D
+3 4 D
+0 9 D
+-4 4 D
+5 7 D
+-3 2 D
+-9 -12 D
+-4 -16 D
+3 0 D
+0 -4 D
+3 -1 D
+-3 -7 D
+2 -5 D
+3 -1 D
+-1 -7 D
+P
+FO
+7307 2126 M
+-1 1 D
+P
+FO
+7323 2130 M
+P
+FO
+7229 2362 M
+-2 -3 D
+1 -2 D
+3 -1 D
+1 2 D
+-2 0 D
+1 1 D
+-1 3 D
+P
+FO
+7218 2362 M
+2 -3 D
+1 3 D
+P
+FO
+7209 2362 M
+2 -2 D
+0 2 D
+P
+FO
+7181 2362 M
+-5 -5 D
+2 -3 D
+9 -1 D
+5 4 D
+3 -1 D
+0 2 D
+-2 1 D
+2 1 D
+-1 2 D
+P
+FO
+7166 2362 M
+-1 -14 D
+3 4 D
+4 10 D
+P
+FO
+7151 2362 M
+-6 0 D
+-2 -4 D
+2 -6 D
+5 -4 D
+4 -1 D
+2 -6 D
+2 -1 D
+4 1 D
+3 5 D
+-5 6 D
+3 10 D
+P
+FO
+7087 2247 M
+2 1 D
+0 2 D
+3 -3 D
+1 4 D
+-2 1 D
+-4 -2 D
+P
+FO
+7205 2264 M
+2 1 D
+2 5 D
+2 0 D
+0 -4 D
+-2 -3 D
+3 -5 D
+2 -1 D
+7 10 D
+1 5 D
+-3 8 D
+-4 3 D
+0 -2 D
+-1 4 D
+2 6 D
+4 3 D
+1 4 D
+4 2 D
+1 -6 D
+4 -6 D
+0 -8 D
+3 -6 D
+2 12 D
+-3 3 D
+3 1 D
+2 -3 D
+-2 3 D
+4 1 D
+4 7 D
+-2 1 D
+1 9 D
+-5 4 D
+2 3 D
+0 6 D
+-4 -1 D
+2 2 D
+-1 1 D
+2 4 D
+-6 0 D
+-2 2 D
+4 2 D
+-1 1 D
+3 3 D
+-4 6 D
+1 5 D
+-4 -2 D
+-1 4 D
+-2 0 D
+1 2 D
+-6 2 D
+-3 5 D
+-3 1 D
+-1 -4 D
+3 -16 D
+-6 0 D
+-1 3 D
+-1 -6 D
+-2 0 D
+-5 4 D
+-2 0 D
+-1 -12 D
+-3 -1 D
+-4 4 D
+-4 -2 D
+-2 -8 D
+-6 -1 D
+-7 -5 D
+0 1 D
+5 4 D
+-3 10 D
+-4 2 D
+0 -2 D
+-2 3 D
+-3 0 D
+2 -1 D
+-3 -4 D
+-7 0 D
+-2 -5 D
+1 -2 D
+-2 -2 D
+-6 1 D
+-10 -5 D
+-3 -5 D
+1 -4 D
+-2 -7 D
+-4 -4 D
+2 -4 D
+4 -1 D
+4 10 D
+2 2 D
+-1 1 D
+3 1 D
+1 2 D
+-2 1 D
+5 4 D
+5 -2 D
+-2 -1 D
+1 -5 D
+2 2 D
+2 -2 D
+3 7 D
+2 -4 D
+-2 -1 D
+2 -2 D
+3 2 D
+-1 -2 D
+3 -2 D
+1 2 D
+-3 2 D
+4 3 D
+-1 4 D
+6 0 D
+2 -3 D
+5 -1 D
+4 -6 D
+2 -1 D
+-1 0 D
+1 -3 D
+-2 -1 D
+1 0 D
+-3 -1 D
+-3 -6 D
+0 -3 D
+2 0 D
+0 -9 D
+7 -6 D
+P
+7189 2315 M
+-1 -5 D
+-4 1 D
+3 4 D
+P
+7217 2347 M
+-1 4 D
+1 0 D
+P
+7201 2284 M
+-1 -1 D
+P
+FO
+7246 2220 M
+1 4 D
+3 3 D
+-1 5 D
+-3 1 D
+-1 -5 D
+2 -2 D
+-3 -5 D
+P
+FO
+7214 2213 M
+2 -2 D
+1 -4 D
+3 -1 D
+0 3 D
+-3 4 D
+-2 1 D
+P
+FO
+7119 2268 M
+-8 2 D
+-4 -4 D
+5 -1 D
+3 2 D
+2 -3 D
+3 3 D
+P
+FO
+7282 2173 M
+7 3 D
+3 8 D
+-3 4 D
+-3 -1 D
+-6 -7 D
+P
+FO
+7134 2285 M
+-5 -2 D
+4 -6 D
+5 2 D
+1 3 D
+3 0 D
+P
+FO
+7223 2291 M
+1 3 D
+-3 2 D
+-1 -2 D
+3 -5 D
+P
+FO
+7196 2343 M
+1 -2 D
+3 0 D
+-2 3 D
+-2 0 D
+P
+FO
+7243 2220 M
+2 -4 D
+1 2 D
+-3 4 D
+P
+FO
+7168 2343 M
+3 -2 D
+3 1 D
+-2 4 D
+P
+FO
+7106 2257 M
+1 -1 D
+1 1 D
+-1 1 D
+P
+FO
+7213 2191 M
+2 -3 D
+0 4 D
+P
+FO
+7152 2300 M
+2 -2 D
+3 2 D
+-4 2 D
+P
+FO
+7259 2145 M
+0 -1 D
+2 0 D
+-1 2 D
+P
+FO
+7260 2134 M
+1 -1 D
+1 2 D
+P
+FO
+7126 2268 M
+1 1 D
+-1 0 D
+P
+FO
+7226 2353 M
+2 -1 D
+-1 5 D
+P
+FO
+7260 2142 M
+2 -1 D
+1 3 D
+P
+FO
+7098 2274 M
+2 0 D
+1 3 D
+P
+FO
+7174 2353 M
+2 -1 D
+2 1 D
+P
+FO
+7218 2360 M
+0 -1 D
+1 1 D
+P
+FO
+7209 2159 M
+2 0 D
+1 4 D
+P
+FO
+7278 2181 M
+2 -1 D
+-1 3 D
+P
+FO
+7212 2253 M
+3 0 D
+0 1 D
+P
+FO
+7128 2270 M
+2 -2 D
+3 1 D
+P
+FO
+7215 2254 M
+1 -1 D
+0 3 D
+P
+FO
+7207 2169 M
+1 -2 D
+1 1 D
+P
+FO
+7237 2157 M
+0 -1 D
+1 1 D
+P
+FO
+7219 2357 M
+2 -1 D
+P
+FO
+7101 2151 M
+2 -1 D
+P
+FO
+7264 2165 M
+0 2 D
+P
+FO
+7094 2253 M
+1 0 D
+P
+FO
+7115 2352 M
+1 2 D
+P
+FO
+7206 2361 M
+0 -1 D
+P
+FO
+7198 2164 M
+2 0 D
+P
+FO
+7177 2360 M
+1 0 D
+P
+FO
+7127 2283 M
+0 1 D
+P
+FO
+7218 2215 M
+2 1 D
+P
+FO
+7298 2130 M
+1 0 D
+P
+FO
+7108 2256 M
+1 0 D
+P
+FO
+7101 2274 M
+1 1 D
+P
+FO
+7246 2217 M
+2 -3 D
+P
+FO
+7213 2182 M
+3 -1 D
+P
+FO
+7113 2263 M
+2 0 D
+P
+FO
+7140 2291 M
+-2 -1 D
+P
+FO
+7094 2249 M
+-1 1 D
+-1 -1 D
+P
+FO
+7104 2256 M
+2 1 D
+P
+FO
+7105 2260 M
+3 0 D
+P
+FO
+7270 2179 M
+1 0 D
+P
+FO
+7107 2261 M
+2 1 D
+P
+FO
+7221 2290 M
+1 -1 D
+P
+FO
+7124 2284 M
+1 -3 D
+P
+FO
+7213 2175 M
+1 1 D
+P
+FO
+7319 2133 M
+2 0 D
+P
+FO
+7261 2137 M
+1 0 D
+P
+FO
+7095 2150 M
+1 1 D
+P
+FO
+7181 2299 M
+2 1 D
+P
+FO
+7119 2268 M
+2 1 D
+-2 0 D
+P
+FO
+7295 2139 M
+1 -1 D
+P
+FO
+7198 2166 M
+1 0 D
+P
+FO
+7132 2285 M
+2 1 D
+P
+FO
+7226 2360 M
+2 1 D
+P
+FO
+7206 2169 M
+1 1 D
+P
+FO
+7219 2355 M
+1 -1 D
+P
+FO
+7102 2278 M
+2 0 D
+P
+FO
+7152 2148 M
+1 -1 D
+P
+FO
+7111 2260 M
+1 0 D
+P
+FO
+7093 2246 M
+1 1 D
+P
+FO
+7221 2357 M
+1 -1 D
+P
+FO
+7134 2275 M
+-1 0 D
+P
+FO
+7269 2178 M
+1 -1 D
+P
+FO
+7123 2268 M
+0 1 D
+P
+FO
+7217 2360 M
+1 -1 D
+P
+FO
+7323 2130 M
+1 0 D
+-1 0 D
+P
+FO
+7428 2302 M
+2 -3 D
+2 7 D
+P
+FO
+7513 2349 M
+2 3 D
+2 -1 D
+-1 2 D
+P
+FO
+7426 2297 M
+0 -1 D
+2 3 D
+P
+FO
+7428 2300 M
+2 -1 D
+P
+FO
+7428 2299 M
+1 0 D
+P
+FO
+7987 2290 M
+1 -3 D
+3 -1 D
+1 2 D
+-2 3 D
+P
+FO
+7895 2318 M
+2 0 D
+0 1 D
+P
+FO
+7832 2299 M
+2 1 D
+P
+FO
+7839 2302 M
+1 0 D
+P
+FO
+7838 2300 M
+1 -1 D
+P
+FO
+7881 2251 M
+2 1 D
+P
+FO
+8102 2253 M
+-2 -2 D
+3 0 D
+P
+FO
+8243 2305 M
+0 -2 D
+P
+FO
+8258 2263 M
+1 3 D
+P
+FO
+8237 2234 M
+2 1 D
+P
+FO
+8223 2258 M
+1 1 D
+P
+FO
+8233 2302 M
+1 -2 D
+P
+FO
+8238 2298 M
+2 0 D
+P
+FO
+8237 2298 M
+1 0 D
+P
+FO
+8204 2341 M
+2 0 D
+P
+FO
+8346 2173 M
+-1 0 D
+1 0 D
+-1 2 D
+P
+FO
+8292 2295 M
+8 -2 D
+P
+FO
+8339 2146 M
+1 3 D
+-1 1 D
+1 -1 D
+P
+FO
+8333 2199 M
+0 -1 D
+4 1 D
+P
+FO
+8358 2137 M
+3 -1 D
+-2 2 D
+P
+FO
+8307 2291 M
+2 -1 D
+-4 2 D
+P
+FO
+8336 2200 M
+2 1 D
+P
+FO
+8309 2291 M
+2 2 D
+P
+FO
+8339 2161 M
+1 -1 D
+P
+FO
+8339 2157 M
+1 1 D
+P
+FO
+8340 2169 M
+-3 3 D
+3 -4 D
+P
+FO
+8334 2171 M
+1 0 D
+P
+FO
+8353 2131 M
+0 -2 D
+P
+FO
+8360 2133 M
+1 3 D
+P
+FO
+8347 2131 M
+2 0 D
+P
+FO
+8340 2158 M
+3 0 D
+P
+FO
+8341 2160 M
+1 -1 D
+P
+FO
+463 2237 M
+-1 0 D
+2 0 D
+P
+FO
+423 2265 M
+1 0 D
+P
+FO
+535 2173 M
+-3 1 D
+2 -1 D
+0 -3 D
+-3 0 D
+1 2 D
+-2 -2 D
+9 -4 D
+-4 4 D
+1 3 D
+P
+FO
+487 2217 M
+1 2 D
+-2 -1 D
+P
+FO
+490 2217 M
+-3 0 D
+1 -1 D
+P
+FO
+490 2218 M
+-2 1 D
+P
+FO
+2097 2126 M
+-3 4 D
+-5 -4 D
+P
+FO
+2115 2135 M
+-2 -1 D
+3 -1 D
+P
+FO
+2109 2140 M
+-1 1 D
+0 -2 D
+1 0 D
+P
+FO
+2362 2129 M
+-1 6 D
+-2 -9 D
+3 0 D
+P
+FO
+2362 2145 M
+-2 -1 D
+2 -9 D
+P
+FO
+2362 2304 M
+-8 11 D
+-3 1 D
+0 4 D
+2 3 D
+5 0 D
+4 2 D
+0 15 D
+-2 -1 D
+2 2 D
+0 6 D
+-3 -3 D
+-9 -3 D
+-7 -5 D
+-6 -2 D
+-11 0 D
+-9 9 D
+-1 -1 D
+4 -3 D
+0 -2 D
+-3 1 D
+-4 -1 D
+-4 2 D
+0 3 D
+2 1 D
+-5 2 D
+1 1 D
+-1 1 D
+1 2 D
+-3 0 D
+-4 5 D
+-3 0 D
+-6 8 D
+-43 0 D
+1 0 D
+-1 0 D
+2 -1 D
+3 -4 D
+-1 -3 D
+1 -2 D
+10 -3 D
+-1 1 D
+15 -10 D
+-1 -3 D
+2 -1 D
+-2 -2 D
+2 0 D
+-4 -5 D
+4 -4 D
+7 -1 D
+0 4 D
+-5 3 D
+2 2 D
+6 -4 D
+-1 0 D
+2 -3 D
+-1 -2 D
+4 -3 D
+2 -5 D
+0 5 D
+4 2 D
+5 -1 D
+5 1 D
+1 -1 D
+2 1 D
+-1 0 D
+1 -4 D
+1 2 D
+4 0 D
+0 -2 D
+4 -1 D
+1 2 D
+5 -12 D
+7 -2 D
+2 4 D
+-2 2 D
+3 -1 D
+1 2 D
+1 -2 D
+-2 -1 D
+4 -6 D
+1 -8 D
+11 1 D
+2 2 D
+0 2 D
+8 2 D
+P
+FO
+2227 2362 M
+1 -2 D
+9 -3 D
+4 -5 D
+3 4 D
+3 2 D
+-1 0 D
+0 2 D
+-5 2 D
+P
+FO
+2322 2305 M
+-1 2 D
+-3 -4 D
+3 -3 D
+4 -1 D
+-4 3 D
+2 2 D
+P
+FO
+2306 2321 M
+-1 0 D
+1 -1 D
+2 1 D
+P
+FO
+2310 2347 M
+1 -3 D
+2 1 D
+P
+FO
+2309 2348 M
+-2 0 D
+2 -2 D
+P
+FO
+2313 2342 M
+-1 2 D
+-1 -2 D
+P
+FO
+2308 2345 M
+1 -1 D
+0 1 D
+P
+FO
+2309 2319 M
+1 1 D
+-3 0 D
+P
+FO
+2336 2308 M
+-1 1 D
+P
+FO
+2333 2303 M
+5 2 D
+P
+FO
+2315 2342 M
+-1 1 D
+P
+FO
+2362 2134 M
+-1 1 D
+P
+FO
+2321 2318 M
+1 -1 D
+P
+FO
+2195 2256 M
+1 1 D
+P
+FO
+2320 2297 M
+-1 1 D
+P
+FO
+2307 2318 M
+-1 -1 D
+P
+FO
+2570 2362 M
+4 -6 D
+-1 -10 D
+-6 -5 D
+-9 -1 D
+-1 4 D
+-2 0 D
+2 1 D
+1 3 D
+-1 -1 D
+-2 2 D
+-2 -1 D
+2 1 D
+-2 1 D
+-2 -1 D
+0 2 D
+1 0 D
+-1 2 D
+2 -2 D
+-5 7 D
+3 4 D
+-85 0 D
+-2 -7 D
+3 -1 D
+-1 -5 D
+-5 -1 D
+0 1 D
+-6 -2 D
+-6 -10 D
+-14 -9 D
+4 -4 D
+1 -7 D
+-2 -4 D
+-3 0 D
+2 5 D
+-3 -1 D
+-1 4 D
+-6 6 D
+-2 4 D
+-5 1 D
+-8 9 D
+1 -1 D
+-4 4 D
+-13 5 D
+-12 0 D
+0 2 D
+3 1 D
+-16 1 D
+-7 -6 D
+0 -2 D
+2 1 D
+2 -1 D
+-2 -2 D
+1 0 D
+1 -2 D
+2 1 D
+3 -5 D
+1 2 D
+10 1 D
+5 -6 D
+2 1 D
+6 -5 D
+3 -7 D
+1 1 D
+-1 4 D
+1 -3 D
+3 2 D
+0 -3 D
+2 2 D
+2 -1 D
+2 -4 D
+-4 4 D
+-1 -3 D
+-3 -1 D
+2 -2 D
+-1 -2 D
+-4 0 D
+1 -4 D
+10 -15 D
+7 -6 D
+0 -4 D
+3 -1 D
+1 -4 D
+3 1 D
+2 -3 D
+-1 -4 D
+-1 0 D
+0 -4 D
+-1 2 D
+-1 -3 D
+3 -4 D
+0 1 D
+2 -7 D
+-2 -3 D
+-4 -1 D
+-1 -3 D
+3 -1 D
+2 -14 D
+2 -3 D
+-2 1 D
+1 -4 D
+-3 -8 D
+-2 1 D
+0 -2 D
+1 1 D
+-1 -2 D
+2 1 D
+1 -4 D
+-1 0 D
+2 -2 D
+2 4 D
+2 -1 D
+-2 -2 D
+1 -1 D
+-2 0 D
+0 -2 D
+7 2 D
+-2 -4 D
+-1 1 D
+0 -1 D
+-1 0 D
+1 -1 D
+-2 1 D
+0 -2 D
+3 1 D
+-2 -1 D
+1 -1 D
+-2 0 D
+0 -2 D
+-2 0 D
+2 -2 D
+-2 1 D
+0 -2 D
+0 2 D
+-2 -7 D
+-3 0 D
+1 -3 D
+-1 1 D
+0 -2 D
+-4 0 D
+-1 -2 D
+2 0 D
+-1 0 D
+1 -1 D
+-1 -1 D
+2 -1 D
+-4 -1 D
+2 0 D
+-3 -1 D
+1 -2 D
+-3 1 D
+-1 -2 D
+-2 1 D
+0 -3 D
+-2 0 D
+0 -2 D
+-3 3 D
+-2 -5 D
+-2 3 D
+-3 -2 D
+0 -2 D
+-1 3 D
+-2 -5 D
+1 -1 D
+-2 -1 D
+4 -9 D
+-1 1 D
+-1 -2 D
+0 1 D
+-5 1 D
+-5 -4 D
+4 -3 D
+2 -3 D
+-2 -2 D
+2 -1 D
+-4 -1 D
+1 -2 D
+-2 -1 D
+2 -1 D
+-3 0 D
+-1 4 D
+-2 -3 D
+-6 -1 D
+-5 -2 D
+-1 -2 D
+0 2 D
+-8 -4 D
+1 -15 D
+-1 -4 D
+236 0 D
+0 236 D
+P
+2509 2344 M
+-1 -1 D
+2 -3 D
+-3 0 D
+0 4 D
+0 -2 D
+P
+2529 2258 M
+1 -1 D
+-2 -1 D
+P
+2509 2256 M
+2 -1 D
+-1 -1 D
+P
+FO
+2362 2341 M
+2 6 D
+-1 0 D
+-1 0 D
+P
+FO
+2362 2325 M
+6 4 D
+1 2 D
+-1 -2 D
+-2 1 D
+2 1 D
+1 5 D
+4 1 D
+-3 5 D
+-2 -1 D
+-2 -1 D
+-1 3 D
+-2 -3 D
+-1 0 D
+P
+FO
+2362 2303 M
+0 1 D
+P
+FO
+2390 2324 M
+-1 2 D
+-3 0 D
+2 -6 D
+P
+FO
+2404 2187 M
+3 -1 D
+-1 3 D
+-2 0 D
+P
+FO
+2419 2200 M
+-1 -2 D
+2 0 D
+0 3 D
+P
+FO
+2383 2321 M
+0 1 D
+P
+FO
+2388 2155 M
+0 3 D
+-2 -2 D
+P
+FO
+2421 2204 M
+-1 -2 D
+3 2 D
+P
+FO
+2400 2187 M
+1 -1 D
+1 2 D
+P
+FO
+2397 2184 M
+1 0 D
+0 1 D
+P
+FO
+2422 2205 M
+2 -1 D
+P
+FO
+2388 2153 M
+-1 2 D
+0 -3 D
+P
+FO
+2422 2223 M
+0 1 D
+-1 0 D
+P
+FO
+2405 2197 M
+0 -2 D
+P
+FO
+2400 2185 M
+1 -1 D
+P
+FO
+2386 2155 M
+1 -2 D
+P
+FO
+2389 2159 M
+1 0 D
+P
+FO
+2398 2186 M
+2 1 D
+P
+FO
+2402 2189 M
+2 0 D
+P
+FO
+2421 2201 M
+-1 -1 D
+P
+FO
+2434 2321 M
+0 -2 D
+P
+FO
+2386 2155 M
+-1 0 D
+P
+FO
+2384 2324 M
+-1 1 D
+P
+FO
+2408 2188 M
+1 1 D
+P
+FO
+2400 2188 M
+2 1 D
+P
+FO
+2835 2328 M
+-10 2 D
+-1 -3 D
+-10 2 D
+2 3 D
+-2 3 D
+1 1 D
+-1 -1 D
+1 3 D
+-1 -1 D
+1 2 D
+-3 0 D
+2 1 D
+1 3 D
+-4 0 D
+5 3 D
+-2 3 D
+-3 0 D
+0 3 D
+-5 1 D
+-10 7 D
+3 -4 D
+-2 2 D
+-6 0 D
+1 -2 D
+-5 5 D
+-5 1 D
+-3 -4 D
+-3 4 D
+-178 0 D
+0 -236 D
+237 0 D
+P
+2658 2272 M
+8 7 D
+2 8 D
+-1 8 D
+11 4 D
+4 6 D
+3 2 D
+10 1 D
+4 4 D
+4 1 D
+10 -1 D
+8 -5 D
+7 3 D
+-2 3 D
+3 3 D
+2 -1 D
+4 2 D
+5 -3 D
+5 5 D
+7 0 D
+8 4 D
+6 -2 D
+8 6 D
+7 2 D
+6 7 D
+-2 2 D
+1 2 D
+-7 2 D
+-2 9 D
+2 5 D
+1 -1 D
+-3 -3 D
+1 -4 D
+2 -2 D
+2 0 D
+6 -10 D
+-3 -4 D
+11 -2 D
+-6 -3 D
+-9 2 D
+-15 -8 D
+-6 1 D
+-7 -4 D
+-8 -1 D
+-4 -4 D
+-7 3 D
+-5 -2 D
+1 -3 D
+-2 -2 D
+-8 -3 D
+-4 4 D
+-13 2 D
+-8 -5 D
+-10 -1 D
+-5 -7 D
+-12 -7 D
+1 -3 D
+-2 -10 D
+-8 -7 D
+P
+2791 2329 M
+-6 2 D
+-2 -2 D
+7 -1 D
+P
+2780 2345 M
+0 -3 D
+2 3 D
+P
+2671 2295 M
+-2 0 D
+P
+2680 2301 M
+0 -2 D
+1 2 D
+P
+2749 2318 M
+-1 0 D
+P
+2771 2323 M
+-2 0 D
+P
+2794 2329 M
+-2 0 D
+3 0 D
+P
+2703 2313 M
+1 -1 D
+P
+2777 2327 M
+-1 0 D
+P
+2784 2331 M
+-2 -2 D
+P
+2728 2314 M
+0 -2 D
+P
+2678 2298 M
+-3 0 D
+P
+2667 2284 M
+1 1 D
+P
+2709 2312 M
+-1 -1 D
+2 1 D
+P
+2670 2294 M
+-2 -1 D
+P
+2680 2301 M
+-1 -2 D
+P
+2770 2309 M
+2 -2 D
+-3 1 D
+1 -2 D
+-3 -1 D
+5 0 D
+-3 -2 D
+1 -4 D
+-4 -9 D
+2 -1 D
+-1 -2 D
+-3 3 D
+0 3 D
+4 4 D
+0 3 D
+-1 0 D
+1 1 D
+-1 3 D
+-2 -2 D
+-1 1 D
+1 2 D
+-3 0 D
+3 2 D
+-1 2 D
+2 -1 D
+P
+2667 2360 M
+4 -2 D
+-2 -1 D
+P
+2802 2329 M
+5 -2 D
+-9 1 D
+P
+2660 2342 M
+2 -1 D
+-2 -4 D
+P
+2807 2331 M
+6 1 D
+-2 -2 D
+P
+2807 2330 M
+4 0 D
+-4 -2 D
+P
+2803 2326 M
+2 -1 D
+-1 -1 D
+P
+2815 2333 M
+-4 -3 D
+P
+2811 2337 M
+-2 -2 D
+P
+2812 2342 M
+-2 -3 D
+P
+2796 2329 M
+2 0 D
+P
+2808 2334 M
+0 -1 D
+P
+2811 2329 M
+-1 -2 D
+P
+FO
+2781 2362 M
+-1 0 D
+2 0 D
+P
+FO
+2777 2362 M
+P
+FO
+2816 2330 M
+3 1 D
+P
+FO
+2815 2339 M
+2 1 D
+P
+FO
+2779 2359 M
+0 2 D
+P
+FO
+2817 2332 M
+2 2 D
+P
+FO
+2814 2339 M
+2 1 D
+P
+FO
+2817 2343 M
+-2 0 D
+0 -2 D
+P
+FO
+2816 2334 M
+2 1 D
+P
+FO
+2816 2333 M
+2 0 D
+P
+FO
+2814 2343 M
+1 1 D
+P
+FO
+2816 2342 M
+1 1 D
+P
+FO
+2817 2334 M
+1 0 D
+P
+FO
+2819 2330 M
+1 1 D
+-1 0 D
+P
+FO
+2817 2341 M
+1 0 D
+P
+FO
+2815 2330 M
+3 2 D
+P
+FO
+2815 2337 M
+1 1 D
+P
+FO
+2816 2335 M
+1 1 D
+P
+FO
+3046 2126 M
+1 2 D
+5 2 D
+8 11 D
+3 2 D
+1 5 D
+0 -2 D
+4 2 D
+2 4 D
+1 0 D
+0 3 D
+-3 0 D
+3 1 D
+0 11 D
+-4 2 D
+-7 0 D
+-4 7 D
+-3 0 D
+2 2 D
+-3 7 D
+-1 0 D
+0 3 D
+-5 12 D
+-1 18 D
+-2 -1 D
+0 -10 D
+0 14 D
+-3 5 D
+-6 5 D
+1 -7 D
+-2 2 D
+-1 -4 D
+-2 9 D
+-4 3 D
+-1 -5 D
+0 4 D
+-5 4 D
+-2 -2 D
+2 3 D
+-2 3 D
+-2 -2 D
+2 2 D
+-1 2 D
+-3 -2 D
+1 1 D
+-5 6 D
+-3 -1 D
+2 1 D
+-4 3 D
+-7 2 D
+-19 9 D
+3 -2 D
+-4 2 D
+-2 -3 D
+0 5 D
+-24 4 D
+-3 -1 D
+3 -2 D
+-3 -2 D
+2 -2 D
+-2 2 D
+1 2 D
+-13 3 D
+-7 -2 D
+5 -2 D
+-4 0 D
+0 -1 D
+-13 4 D
+-11 1 D
+-5 -4 D
+0 6 D
+-4 4 D
+-4 2 D
+-1 -4 D
+-2 0 D
+2 0 D
+0 3 D
+-3 4 D
+-10 8 D
+-2 0 D
+-1 -4 D
+1 4 D
+-4 2 D
+-3 -1 D
+-2 -4 D
+-1 -9 D
+-1 3 D
+-1 -1 D
+2 12 D
+2 3 D
+1 7 D
+-14 15 D
+-18 11 D
+3 -3 D
+-2 1 D
+0 -1 D
+-5 6 D
+0 -202 D
+P
+2953 2243 M
+0 -2 D
+4 2 D
+1 -2 D
+-2 -3 D
+-1 2 D
+-1 -2 D
+1 -2 D
+1 1 D
+0 -3 D
+-2 1 D
+0 -2 D
+-1 4 D
+-3 -6 D
+-3 1 D
+1 1 D
+-4 -1 D
+1 3 D
+2 -1 D
+-1 3 D
+3 3 D
+0 4 D
+P
+2949 2233 M
+1 -1 D
+P
+2954 2241 M
+1 -1 D
+P
+2950 2235 M
+0 -2 D
+P
+2902 2262 M
+0 -2 D
+P
+2975 2255 M
+-2 -2 D
+P
+2976 2258 M
+0 -1 D
+P
+FO
+3051 2126 M
+3 0 D
+-5 0 D
+P
+FO
+3055 2126 M
+-1 0 D
+P
+FO
+3056 2126 M
+P
+FO
+3061 2126 M
+-1 3 D
+-4 1 D
+0 -2 D
+P
+FO
+3071 2133 M
+-10 -2 D
+2 -4 D
+8 -1 D
+P
+FO
+3071 2150 M
+-3 -2 D
+3 0 D
+P
+FO
+3061 2137 M
+-1 -5 D
+-2 -1 D
+3 -1 D
+0 1 D
+3 2 D
+-1 7 D
+P
+FO
+3066 2140 M
+-2 0 D
+0 -6 D
+6 4 D
+-1 3 D
+-1 -2 D
+P
+FO
+3066 2147 M
+-2 -2 D
+0 -2 D
+5 1 D
+2 3 D
+P
+FO
+3063 2173 M
+-1 3 D
+-3 -1 D
+2 -5 D
+P
+FO
+2871 2289 M
+3 1 D
+-2 1 D
+P
+FO
+2871 2291 M
+-1 -2 D
+2 2 D
+P
+FO
+3066 2133 M
+-1 -1 D
+4 2 D
+P
+FO
+2868 2285 M
+2 4 D
+P
+FO
+3060 2178 M
+-2 -1 D
+P
+FO
+2868 2288 M
+2 2 D
+P
+FO
+3056 2134 M
+0 -2 D
+P
+FO
+2871 2294 M
+0 -2 D
+P
+FO
+2869 2286 M
+1 1 D
+P
+FO
+3073 2126 M
+6 5 D
+0 3 D
+-8 -1 D
+0 -7 D
+P
+FO
+3086 2126 M
+-6 2 D
+-2 -2 D
+P
+FO
+3071 2156 M
+2 1 D
+-2 10 D
+P
+FO
+3071 2152 M
+1 0 D
+1 4 D
+-2 -1 D
+P
+FO
+3071 2148 M
+1 3 D
+P
+FO
+3079 2130 M
+1 0 D
+P
+FO
+3921 2362 M
+2 0 D
+3 -4 D
+3 3 D
+-2 -3 D
+2 1 D
+3 -2 D
+-4 -6 D
+4 1 D
+-1 0 D
+2 -2 D
+1 2 D
+-1 -2 D
+3 -2 D
+-1 -3 D
+3 1 D
+-1 -4 D
+3 1 D
+-3 -3 D
+1 -2 D
+4 -1 D
+0 -2 D
+-3 -1 D
+2 -6 D
+1 1 D
+-1 1 D
+2 1 D
+0 -2 D
+0 2 D
+2 -1 D
+-2 -1 D
+6 -1 D
+-3 -1 D
+-2 1 D
+1 -2 D
+-1 1 D
+-2 -1 D
+2 -2 D
+-4 3 D
+-2 0 D
+0 -2 D
+3 -3 D
+0 -3 D
+5 2 D
+1 -3 D
+2 -1 D
+-2 -1 D
+2 -3 D
+-3 0 D
+2 -2 D
+3 0 D
+-1 -2 D
+4 -1 D
+4 1 D
+-2 -2 D
+2 0 D
+-1 -3 D
+4 0 D
+-4 -2 D
+3 -2 D
+-4 0 D
+23 -9 D
+5 -5 D
+3 0 D
+0 -2 D
+-4 1 D
+14 -8 D
+-1 -2 D
+3 -2 D
+8 -1 D
+9 -9 D
+0 99 D
+P
+3973 2296 M
+2 -1 D
+-3 1 D
+P
+3975 2296 M
+1 -1 D
+P
+FO
+3946 2305 M
+7 -2 D
+2 -2 D
+2 2 D
+-2 3 D
+P
+FO
+3927 2357 M
+2 -1 D
+1 1 D
+P
+FO
+3943 2306 M
+1 1 D
+P
+FO
+3939 2317 M
+1 1 D
+P
+FO
+3925 2350 M
+1 1 D
+P
+FO
+3927 2350 M
+0 -1 D
+P
+FO
+4252 2276 M
+-3 4 D
+-11 4 D
+-3 4 D
+4 -2 D
+0 2 D
+1 -3 D
+2 -1 D
+1 4 D
+1 -4 D
+3 2 D
+1 -3 D
+3 0 D
+1 3 D
+-2 1 D
+2 1 D
+0 15 D
+-2 0 D
+1 -2 D
+-5 3 D
+6 0 D
+-2 3 D
+-14 -3 D
+14 5 D
+-2 0 D
+1 2 D
+-2 2 D
+1 2 D
+-4 2 D
+0 -3 D
+-3 0 D
+3 2 D
+-3 1 D
+-2 -2 D
+1 3 D
+-1 1 D
+-2 -3 D
+0 2 D
+-3 -1 D
+4 2 D
+-6 3 D
+2 1 D
+-4 7 D
+-5 1 D
+0 -3 D
+-1 3 D
+-5 2 D
+-8 -3 D
+8 3 D
+0 2 D
+4 -4 D
+5 0 D
+0 2 D
+-4 1 D
+2 0 D
+-2 3 D
+1 4 D
+1 -2 D
+-1 -2 D
+2 -3 D
+1 2 D
+4 -8 D
+1 1 D
+-1 2 D
+1 2 D
+1 -3 D
+1 1 D
+-3 -5 D
+7 -4 D
+1 -3 D
+2 0 D
+1 2 D
+5 -1 D
+0 -1 D
+-4 1 D
+0 -2 D
+5 -2 D
+2 -7 D
+1 0 D
+0 53 D
+-236 0 D
+0 -99 D
+5 -5 D
+5 -3 D
+-1 -1 D
+7 -6 D
+37 -19 D
+6 0 D
+11 4 D
+3 3 D
+19 7 D
+-1 1 D
+14 2 D
+-2 1 D
+38 3 D
+7 -1 D
+-2 0 D
+2 0 D
+0 1 D
+1 -2 D
+31 -5 D
+7 -5 D
+2 0 D
+9 7 D
+19 4 D
+19 10 D
+P
+4123 2317 M
+-3 -4 D
+2 0 D
+-3 -4 D
+3 2 D
+-3 -5 D
+1 -3 D
+-2 0 D
+-1 -2 D
+2 0 D
+-1 -2 D
+3 -3 D
+0 5 D
+1 -1 D
+-1 2 D
+1 1 D
+1 -1 D
+0 3 D
+2 -3 D
+-1 -2 D
+3 2 D
+-4 -4 D
+2 0 D
+0 -1 D
+-3 0 D
+1 -2 D
+2 -1 D
+-1 -1 D
+1 -3 D
+-8 4 D
+1 1 D
+-2 1 D
+1 1 D
+-3 2 D
+2 0 D
+0 6 D
+1 -1 D
+-1 6 D
+2 0 D
+-1 3 D
+2 -2 D
+2 6 D
+P
+4175 2266 M
+3 -9 D
+-3 1 D
+2 1 D
+P
+4219 2280 M
+-1 -1 D
+P
+4160 2254 M
+1 -1 D
+P
+FO
+4488 2100 M
+0 -1 D
+-1 16 D
+1 0 D
+0 11 D
+-16 0 D
+0 -9 D
+-5 -6 D
+1 -2 D
+-2 0 D
+-1 2 D
+-2 -3 D
+-2 0 D
+0 -2 D
+-3 5 D
+-1 -1 D
+4 -7 D
+3 0 D
+-1 -2 D
+-2 1 D
+9 -15 D
+1 -5 D
+1 0 D
+0 -2 D
+-1 1 D
+7 -7 D
+1 -5 D
+3 -2 D
+0 1 D
+1 -2 D
+-2 2 D
+6 -5 D
+-2 0 D
+3 -2 D
+P
+4478 2100 M
+-1 -1 D
+-3 2 D
+P
+4484 2103 M
+-3 1 D
+1 1 D
+P
+4487 2113 M
+0 -2 D
+-1 3 D
+P
+4476 2089 M
+-2 0 D
+P
+4485 2112 M
+-2 -2 D
+P
+4482 2112 M
+0 -2 D
+P
+4485 2108 M
+-1 0 D
+P
+FO
+4384 2093 M
+1 -2 D
+P
+FO
+4687 2126 M
+1 0 D
+-1 0 D
+-5 0 D
+-10 -14 D
+-11 -11 D
+-4 0 D
+-5 -4 D
+-10 -17 D
+-6 -4 D
+-2 -22 D
+1 10 D
+-2 10 D
+9 9 D
+7 15 D
+14 7 D
+7 10 D
+-1 7 D
+2 4 D
+-183 0 D
+0 -11 D
+2 -1 D
+-2 -1 D
+0 -6 D
+2 -2 D
+1 1 D
+-1 -2 D
+2 -1 D
+2 1 D
+0 -2 D
+-4 0 D
+1 0 D
+-3 -2 D
+0 -39 D
+7 -5 D
+-1 0 D
+11 -12 D
+-1 2 D
+-1 -1 D
+8 -6 D
+1 -3 D
+17 -15 D
+2 -8 D
+9 -13 D
+1 -5 D
+-2 -2 D
+0 -2 D
+6 -7 D
+1 1 D
+0 -2 D
+5 1 D
+-4 -2 D
+1 -1 D
+-5 -1 D
+0 2 D
+-1 -1 D
+13 -20 D
+1 -7 D
+12 -26 D
+-1 -2 D
+2 -7 D
+-5 -1 D
+-5 -7 D
+3 5 D
+-3 -5 D
+4 -5 D
+3 -16 D
+158 0 D
+0 236 D
+P
+4682 2063 M
+2 13 D
+-2 2 D
+-1 5 D
+-3 1 D
+2 3 D
+2 -2 D
+-1 2 D
+2 2 D
+2 -2 D
+4 2 D
+-1 -4 D
+-4 -1 D
+0 -4 D
+2 -2 D
+2 1 D
+-1 -5 D
+4 2 D
+-4 -3 D
+2 0 D
+-2 -1 D
+-3 -4 D
+-1 -6 D
+P
+4678 2103 M
+-3 4 D
+1 2 D
+-4 1 D
+7 0 D
+1 -8 D
+P
+4619 2027 M
+-2 -4 D
+-4 1 D
+3 5 D
+3 0 D
+P
+4618 2028 M
+-2 0 D
+-2 -3 D
+2 0 D
+P
+4576 1915 M
+0 -2 D
+-1 1 D
+P
+4497 2059 M
+-2 0 D
+0 2 D
+P
+4558 1988 M
+-2 0 D
+P
+4576 1923 M
+-1 -1 D
+P
+4515 2038 M
+-6 4 D
+P
+4558 1987 M
+-5 -1 D
+2 2 D
+P
+4581 1905 M
+-1 -1 D
+P
+4574 1916 M
+-1 0 D
+P
+4587 1902 M
+-1 -1 D
+P
+4570 1920 M
+-1 -1 D
+P
+4575 1910 M
+-2 -1 D
+P
+4557 1986 M
+-1 -1 D
+P
+FO
+4673 2126 M
+-2 -4 D
+1 -6 D
+9 10 D
+P
+FO
+4488 2104 M
+1 1 D
+-1 1 D
+P
+FO
+4488 2100 M
+2 2 D
+-2 1 D
+P
+FO
+4564 1918 M
+1 1 D
+P
+FO
+-1 -1 1 4650 2097 SP
+-1 -1 1 4666 2108 SP
+-1 -1 1 4671 2112 SP
+-2 -2 1 4675 2117 SP
+-2 -2 1 4642 2081 SP
+-1 -1 1 4672 2115 SP
+4961 1924 M
+-3 -1 D
+-5 -6 D
+0 -3 D
+-6 1 D
+7 11 D
+7 -1 D
+-1 33 D
+-5 1 D
+-5 7 D
+-2 6 D
+-6 10 D
+-1 4 D
+4 2 D
+1 5 D
+-7 13 D
+1 11 D
+2 2 D
+1 11 D
+-3 -7 D
+-2 1 D
+2 2 D
+0 21 D
+4 0 D
+1 -10 D
+8 -15 D
+-2 -12 D
+4 -2 D
+1 -4 D
+-2 -7 D
+5 -11 D
+-5 -3 D
+0 -5 D
+6 -6 D
+1 154 D
+-237 0 D
+0 -236 D
+237 0 D
+P
+4933 2068 M
+0 2 D
+3 2 D
+-2 -1 D
+1 2 D
+-1 0 D
+1 2 D
+-1 0 D
+2 3 D
+-2 0 D
+5 10 D
+-2 -2 D
+2 2 D
+4 -2 D
+3 -8 D
+-3 -2 D
+1 -1 D
+-2 0 D
+0 -2 D
+-4 -4 D
+0 3 D
+P
+4937 2073 M
+2 1 D
+1 7 D
+-2 -1 D
+P
+4921 1901 M
+0 10 D
+13 14 D
+6 -2 D
+1 -2 D
+-11 -15 D
+0 -3 D
+-4 0 D
+-1 2 D
+-1 -3 D
+2 -1 D
+P
+4925 1908 M
+-3 -1 D
+3 -1 D
+P
+4930 1905 M
+-1 -1 D
+P
+4946 2110 M
+-2 4 D
+5 8 D
+5 2 D
+2 -2 D
+2 1 D
+-2 -6 D
+-6 -5 D
+-4 -1 D
+P
+4878 1925 M
+2 -1 D
+-5 -5 D
+-1 2 D
+-2 -1 D
+0 2 D
+P
+4888 1937 M
+1 -2 D
+-3 -2 D
+-1 2 D
+P
+4867 1911 M
+1 -2 D
+-1 -1 D
+-2 1 D
+1 2 D
+P
+4883 1935 M
+1 -1 D
+-1 -1 D
+P
+4878 1930 M
+3 -2 D
+-4 1 D
+P
+4879 1933 M
+-1 -2 D
+-3 0 D
+P
+4925 1895 M
+2 1 D
+1 -1 D
+P
+4931 1899 M
+-1 -2 D
+-1 1 D
+P
+4957 2098 M
+3 -4 D
+-1 1 D
+-1 -1 D
+P
+4955 2092 M
+1 1 D
+0 -2 D
+P
+4869 1920 M
+1 -2 D
+-2 2 D
+P
+4925 1893 M
+2 1 D
+P
+4954 2090 M
+1 -1 D
+P
+4926 1891 M
+1 1 D
+P
+4925 1898 M
+2 1 D
+P
+4895 1894 M
+-1 -1 D
+P
+4875 1930 M
+1 -1 D
+P
+4956 1916 M
+-2 -1 D
+P
+4884 1932 M
+1 -1 D
+P
+4877 1927 M
+-2 -2 D
+P
+FO
+-1 -2 1 4950 1917 SP
+5055 1890 M
+-2 7 D
+1 4 D
+2 1 D
+11 -12 D
+123 0 D
+2 4 D
+-2 2 D
+-1 6 D
+-3 3 D
+3 0 D
+-1 7 D
+-2 1 D
+1 -3 D
+-1 1 D
+-1 -2 D
+0 6 D
+-3 0 D
+1 1 D
+3 -1 D
+-3 5 D
+-2 0 D
+1 2 D
+-3 8 D
+2 0 D
+0 2 D
+1 0 D
+2 5 D
+-2 2 D
+2 2 D
+-2 0 D
+0 1 D
+-2 -3 D
+1 4 D
+-1 3 D
+1 7 D
+2 3 D
+3 2 D
+-2 6 D
+-3 1 D
+-1 -1 D
+0 3 D
+-6 6 D
+-4 2 D
+0 5 D
+-2 3 D
+5 14 D
+-1 1 D
+2 0 D
+3 7 D
+-2 1 D
+2 1 D
+-1 3 D
+1 1 D
+0 -2 D
+1 2 D
+-1 2 D
+3 4 D
+3 -1 D
+-1 2 D
+2 0 D
+5 11 D
+-2 0 D
+0 2 D
+3 -1 D
+4 9 D
+-2 2 D
+2 -1 D
+2 7 D
+0 -1 D
+1 0 D
+0 80 D
+-142 0 D
+1 -3 D
+2 2 D
+-1 -3 D
+4 -2 D
+1 -3 D
+2 2 D
+-1 2 D
+10 3 D
+2 -5 D
+-9 -1 D
+1 -3 D
+-2 -1 D
+-1 1 D
+-1 -1 D
+-3 2 D
+-3 -3 D
+-1 -4 D
+3 -4 D
+-1 -3 D
+-2 0 D
+1 0 D
+-5 -6 D
+3 -2 D
+-5 1 D
+2 -2 D
+-2 0 D
+4 -3 D
+-7 1 D
+1 -1 D
+-2 -1 D
+2 -3 D
+-4 0 D
+3 -2 D
+-4 -2 D
+-3 1 D
+-2 -3 D
+4 2 D
+3 -4 D
+-4 1 D
+-1 -2 D
+-3 1 D
+0 -3 D
+9 -1 D
+4 3 D
+1 -4 D
+-10 -5 D
+1 -2 D
+-6 1 D
+-2 2 D
+-4 0 D
+-2 -5 D
+2 -5 D
+2 -1 D
+-3 2 D
+-3 -5 D
+1 2 D
+-2 1 D
+3 1 D
+-1 5 D
+1 3 D
+-4 -1 D
+-1 4 D
+-3 -5 D
+1 3 D
+-4 0 D
+-2 4 D
+-2 1 D
+-1 -3 D
+-3 -1 D
+3 -3 D
+-3 2 D
+-3 -3 D
+2 -4 D
+-3 3 D
+-2 -5 D
+-1 4 D
+3 1 D
+-3 0 D
+-1 2 D
+2 2 D
+-1 3 D
+-3 -1 D
+2 9 D
+-2 -1 D
+6 24 D
+-1 1 D
+-2 -2 D
+-1 6 D
+3 8 D
+5 3 D
+-3 3 D
+0 2 D
+4 1 D
+-2 1 D
+4 -1 D
+1 2 D
+-46 0 D
+-2 -2 D
+-2 2 D
+-2 0 D
+0 -55 D
+3 -2 D
+0 -2 D
+-3 4 D
+0 -98 D
+3 0 D
+10 -12 D
+0 -3 D
+-2 0 D
+3 -6 D
+-1 -3 D
+10 -18 D
+4 -4 D
+0 -8 D
+-1 1 D
+-2 -2 D
+-8 8 D
+-4 -3 D
+1 2 D
+-2 0 D
+-1 2 D
+3 3 D
+0 4 D
+-7 7 D
+-3 13 D
+-3 3 D
+0 -32 D
+2 0 D
+-2 -1 D
+0 -34 D
+P
+5073 2037 M
+1 1 D
+-2 0 D
+2 2 D
+4 1 D
+8 6 D
+1 -3 D
+-4 -4 D
+-9 -4 D
+P
+5136 2104 M
+0 1 D
+-3 2 D
+5 -2 D
+3 2 D
+0 1 D
+1 -1 D
+P
+5102 2065 M
+-1 1 D
+2 1 D
+-2 7 D
+2 2 D
+2 -4 D
+P
+5006 1947 M
+14 -10 D
+1 -3 D
+-10 5 D
+-5 -2 D
+-4 8 D
+P
+5111 2107 M
+-2 0 D
+0 2 D
+2 0 D
+P
+4967 2069 M
+1 3 D
+1 -2 D
+-2 -2 D
+P
+5096 2037 M
+0 4 D
+3 5 D
+0 -7 D
+P
+4968 2076 M
+3 1 D
+-3 -1 D
+2 -2 D
+-3 2 D
+P
+5108 2079 M
+-1 3 D
+1 -1 D
+1 4 D
+0 -6 D
+P
+5022 1933 M
+6 -6 D
+-5 0 D
+-3 4 D
+P
+5084 2015 M
+-2 0 D
+2 1 D
+1 -1 D
+P
+4978 2081 M
+2 2 D
+-2 -3 D
+P
+4978 2077 M
+1 1 D
+P
+5136 2037 M
+-2 3 D
+3 2 D
+P
+5099 2033 M
+0 3 D
+P
+4982 2076 M
+2 -1 D
+P
+5086 2022 M
+2 2 D
+P
+4981 2088 M
+1 -2 D
+P
+5145 2040 M
+-2 2 D
+P
+5133 2032 M
+-1 2 D
+P
+5108 2115 M
+0 2 D
+P
+4976 2091 M
+1 1 D
+P
+4977 2086 M
+1 0 D
+P
+5095 2024 M
+1 2 D
+0 -2 D
+P
+4982 2078 M
+1 1 D
+P
+4977 2078 M
+2 1 D
+P
+5073 2013 M
+0 1 D
+P
+5109 2084 M
+-1 0 D
+1 2 D
+P
+4979 2077 M
+1 1 D
+P
+FO
+5193 1890 M
+-2 0 D
+P
+FO
+5016 2126 M
+1 -1 D
+0 1 D
+P
+FO
+5014 2126 M
+1 -1 D
+P
+FO
+5182 1984 M
+-2 7 D
+0 -4 D
+-2 -1 D
+0 -6 D
+5 -5 D
+0 2 D
+2 -4 D
+2 2 D
+-2 6 D
+0 -2 D
+-2 1 D
+P
+FO
+5189 2008 M
+2 -4 D
+-2 -1 D
+3 -1 D
+-3 0 D
+-1 -4 D
+3 -1 D
+3 13 D
+-2 -2 D
+-3 3 D
+P
+FO
+5187 1938 M
+2 -1 D
+4 2 D
+2 6 D
+P
+FO
+5178 1988 M
+0 2 D
+P
+FO
+5188 2006 M
+1 2 D
+P
+FO
+5192 1937 M
+-1 -1 D
+P
+FO
+5187 1998 M
+2 -2 D
+P
+FO
+5185 1913 M
+1 1 D
+P
+FO
+5181 2016 M
+2 0 D
+P
+FO
+5182 1915 M
+2 1 D
+P
+FO
+0 -1 1 5026 2126 SP
+4 -5 -2 1 0 2 -3 0 0 3 4 2 6 5011 2113 SP
+-1 -2 2 -1 -7 0 -2 5 3 0 5 5033 2075 SP
+-1 1 -1 -1 0 2 2 1 4 5018 2069 SP
+1 1 2 -4 0 -2 -1 1 4 5004 2073 SP
+3 2 0 -2 -2 -1 3 5009 2073 SP
+-2 -1 -1 1 2 1 3 5055 2114 SP
+-1 -1 0 2 2 5048 2122 SP
+0 -3 -1 1 2 5006 2087 SP
+-2 0 2 2 2 5032 2081 SP
+-2 1 3 1 2 5024 2123 SP
+-1 -1 1 5004 2084 SP
+1 0 1 5016 2116 SP
+0 -1 1 5011 2092 SP
+2 3 1 5019 2114 SP
+1 1 1 5059 2116 SP
+1 -1 0 -1 2 5003 2077 SP
+-2 0 1 0 2 5017 2117 SP
+0 1 1 5015 2113 SP
+5197 2046 M
+3 2 D
+0 5 D
+3 2 D
+-2 0 D
+0 6 D
+5 4 D
+5 0 D
+4 3 D
+1 2 D
+-1 3 D
+1 -2 D
+2 3 D
+1 -3 D
+1 2 D
+-2 6 D
+-3 1 D
+3 0 D
+1 -3 D
+3 5 D
+-1 -5 D
+2 2 D
+2 0 D
+0 1 D
+-1 0 D
+2 1 D
+2 -1 D
+11 14 D
+1 3 D
+-1 2 D
+3 -2 D
+4 9 D
+2 1 D
+18 19 D
+-69 0 D
+P
+FO
+5343 1904 M
+2 -2 D
+6 2 D
+-2 1 D
+0 -1 D
+-4 -2 D
+P
+FO
+5220 2074 M
+0 1 D
+4 2 D
+-1 1 D
+-3 -2 D
+P
+FO
+5227 2079 M
+1 1 D
+-2 -2 D
+P
+FO
+5224 2078 M
+1 1 D
+P
+FO
+5252 2110 M
+0 1 D
+P
+FO
+5247 2105 M
+2 1 D
+P
+FO
+5230 2081 M
+1 2 D
+P
+FO
+5250 2108 M
+1 1 D
+P
+FO
+5249 2106 M
+1 1 D
+P
+FO
+5216 2072 M
+2 0 D
+-1 1 D
+P
+FO
+5344 1905 M
+5 0 D
+P
+FO
+5350 1896 M
+1 1 D
+P
+FO
+5560 2016 M
+4 -3 D
+-2 5 D
+P
+FO
+5567 2024 M
+3 0 D
+P
+FO
+5556 2020 M
+1 0 D
+P
+FO
+5581 1956 M
+1 3 D
+P
+FO
+5519 1991 M
+2 1 D
+P
+FO
+5961 1954 M
+2 -4 D
+0 3 D
+P
+FO
+5978 2112 M
+1 -1 D
+P
+FO
+6614 2067 M
+0 -4 D
+P
+FO
+6607 2126 M
+3 -7 D
+4 -5 D
+0 12 D
+P
+FO
+6589 2102 M
+-1 3 D
+-5 -2 D
+-2 -6 D
+7 -11 D
+5 -3 D
+3 1 D
+-1 3 D
+2 -2 D
+0 3 D
+-4 4 D
+2 -1 D
+P
+FO
+6574 2114 M
+3 -2 D
+0 1 D
+2 0 D
+0 4 D
+-2 3 D
+-2 -6 D
+P
+FO
+6603 2075 M
+2 -3 D
+6 -3 D
+-6 9 D
+-1 0 D
+P
+FO
+6577 2126 M
+-3 0 D
+6 -9 D
+P
+FO
+6596 2082 M
+1 1 D
+-1 0 D
+P
+FO
+6563 2125 M
+2 -1 D
+P
+FO
+6850 1963 M
+-12 3 D
+-5 -2 D
+-6 2 D
+-2 -2 D
+-2 2 D
+-2 -1 D
+-4 1 D
+-1 7 D
+-6 6 D
+-2 0 D
+-2 -3 D
+-6 4 D
+-5 -2 D
+-4 3 D
+-3 4 D
+-8 1 D
+-1 -2 D
+1 -2 D
+-4 -1 D
+-4 3 D
+-5 -1 D
+-5 3 D
+-2 -2 D
+-3 3 D
+-4 -5 D
+-2 -9 D
+-2 -1 D
+-1 1 D
+-5 -8 D
+-2 4 D
+-4 -3 D
+1 -2 D
+17 1 D
+8 -4 D
+5 0 D
+1 -2 D
+-4 -4 D
+0 -3 D
+24 -3 D
+10 -6 D
+15 -2 D
+1 3 D
+4 -1 D
+5 3 D
+0 -2 D
+-2 1 D
+0 -2 D
+6 -1 D
+-2 2 D
+10 0 D
+0 -2 D
+14 -3 D
+P
+6787 1973 M
+2 -2 D
+-2 0 D
+0 -2 D
+P
+FO
+6850 2085 M
+-2 -2 D
+2 -3 D
+P
+FO
+6831 2126 M
+1 -5 D
+-4 -1 D
+2 -3 D
+-1 1 D
+0 -4 D
+9 -3 D
+-3 0 D
+2 -2 D
+-4 1 D
+1 -5 D
+2 -1 D
+1 2 D
+5 -3 D
+-5 -1 D
+0 -6 D
+2 -1 D
+6 4 D
+0 3 D
+1 -2 D
+3 0 D
+-1 -3 D
+2 -2 D
+0 31 D
+P
+FO
+6720 2126 M
+1 -3 D
+-2 -3 D
+2 -1 D
+4 2 D
+4 -3 D
+3 1 D
+-4 4 D
+-2 -2 D
+-4 5 D
+P
+FO
+6614 2114 M
+8 -8 D
+2 -5 D
+-2 -3 D
+2 0 D
+-1 -2 D
+5 -1 D
+1 -7 D
+6 -8 D
+-2 -5 D
+2 -4 D
+10 -10 D
+7 -11 D
+15 -11 D
+2 -8 D
+14 -11 D
+8 -4 D
+2 -4 D
+9 -4 D
+5 -4 D
+-1 -1 D
+16 -17 D
+4 0 D
+-5 10 D
+4 0 D
+11 -7 D
+2 0 D
+-2 1 D
+1 1 D
+-1 3 D
+2 0 D
+1 3 D
+10 -10 D
+2 2 D
+3 20 D
+-2 8 D
+1 -2 D
+1 6 D
+-2 1 D
+-1 7 D
+1 -1 D
+3 7 D
+-3 3 D
+-1 3 D
+3 6 D
+4 3 D
+-1 5 D
+-6 2 D
+0 5 D
+-4 1 D
+0 6 D
+-10 2 D
+-2 -3 D
+-1 2 D
+-1 -3 D
+0 3 D
+-2 1 D
+0 -4 D
+-1 3 D
+-1 -1 D
+1 3 D
+-1 0 D
+-3 -7 D
+0 5 D
+-3 -1 D
+1 2 D
+2 -1 D
+3 4 D
+0 3 D
+-2 2 D
+-2 -1 D
+-1 2 D
+-3 -2 D
+3 3 D
+-2 1 D
+-2 -3 D
+-1 3 D
+2 3 D
+-2 3 D
+-2 14 D
+-4 -2 D
+0 1 D
+-5 2 D
+-4 -1 D
+-4 1 D
+-3 4 D
+-2 -1 D
+1 2 D
+-4 1 D
+2 1 D
+-2 0 D
+3 2 D
+-1 4 D
+1 -2 D
+4 2 D
+-7 2 D
+3 0 D
+2 3 D
+-4 -1 D
+3 2 D
+-1 1 D
+2 -1 D
+-2 2 D
+2 -1 D
+2 2 D
+-1 1 D
+6 0 D
+-90 0 D
+P
+6620 2119 M
+-2 -2 D
+0 2 D
+P
+6628 2111 M
+0 -2 D
+-2 4 D
+P
+6650 2075 M
+-2 0 D
+P
+FO
+6614 2063 M
+1 -4 D
+4 1 D
+-1 3 D
+-4 4 D
+P
+FO
+6772 2055 M
+-2 1 D
+3 8 D
+3 1 D
+-13 4 D
+-4 8 D
+1 4 D
+-3 7 D
+-3 3 D
+-5 -1 D
+2 -7 D
+-3 2 D
+1 2 D
+-2 0 D
+-1 3 D
+-6 -3 D
+2 -3 D
+-7 -4 D
+0 -3 D
+8 -2 D
+2 2 D
+5 -2 D
+1 -5 D
+3 -3 D
+-1 -3 D
+2 -4 D
+11 -4 D
+2 -4 D
+5 1 D
+P
+FO
+6803 2049 M
+5 3 D
+0 3 D
+2 3 D
+-1 3 D
+-4 3 D
+-1 -1 D
+-1 2 D
+-8 1 D
+0 -6 D
+-3 -3 D
+2 0 D
+-1 -2 D
+1 -5 D
+5 1 D
+1 3 D
+P
+FO
+6714 2114 M
+2 0 D
+1 -4 D
+2 2 D
+2 -1 D
+2 4 D
+-3 3 D
+-4 -2 D
+0 2 D
+P
+FO
+6624 2055 M
+-4 5 D
+-2 0 D
+1 -5 D
+6 -8 D
+-2 4 D
+2 1 D
+P
+FO
+6822 2089 M
+1 0 D
+1 -3 D
+2 2 D
+-2 2 D
+P
+FO
+6664 2000 M
+4 -4 D
+3 0 D
+-1 3 D
+-5 2 D
+P
+FO
+6735 1970 M
+1 1 D
+1 -3 D
+2 4 D
+P
+FO
+6777 2055 M
+0 2 D
+-2 1 D
+-2 -2 D
+P
+FO
+6830 2123 M
+1 -2 D
+0 3 D
+P
+FO
+6696 2117 M
+7 1 D
+-5 3 D
+P
+FO
+6788 2058 M
+1 -2 D
+2 3 D
+P
+FO
+6780 2058 M
+2 0 D
+-1 1 D
+P
+FO
+6741 1982 M
+1 1 D
+P
+FO
+6718 2119 M
+2 0 D
+P
+FO
+6727 1989 M
+2 -1 D
+-2 2 D
+P
+FO
+6697 2123 M
+2 1 D
+P
+FO
+6832 2097 M
+1 1 D
+P
+FO
+6743 1985 M
+1 1 D
+P
+FO
+6819 2085 M
+3 1 D
+P
+FO
+6829 2122 M
+2 -1 D
+P
+FO
+6738 1988 M
+2 1 D
+P
+FO
+6626 2051 M
+1 -1 D
+P
+FO
+6792 2050 M
+0 -1 D
+P
+FO
+6744 1987 M
+1 0 D
+P
+FO
+6829 2123 M
+2 -1 D
+P
+FO
+6742 1981 M
+1 0 D
+P
+FO
+6696 2121 M
+2 0 D
+P
+FO
+6713 2117 M
+1 0 D
+P
+FO
+6699 2125 M
+1 0 D
+P
+FO
+6629 2044 M
+1 0 D
+P
+FO
+6750 1961 M
+2 1 D
+P
+FO
+6728 2125 M
+1 -1 D
+P
+FO
+6726 2124 M
+1 -2 D
+P
+FO
+6725 2125 M
+1 -1 D
+P
+FO
+6830 2095 M
+1 1 D
+P
+FO
+7087 1905 M
+-2 2 D
+-3 -3 D
+-12 1 D
+-8 -4 D
+3 -4 D
+7 -2 D
+2 1 D
+5 -1 D
+6 -5 D
+2 0 D
+P
+FO
+7087 1926 M
+-4 1 D
+-1 -7 D
+3 -4 D
+2 1 D
+P
+FO
+7083 2126 M
+0 -2 D
+-2 -1 D
+-2 3 D
+-1 0 D
+-1 0 D
+3 -3 D
+2 0 D
+-1 -9 D
+3 -8 D
+-4 5 D
+-9 -13 D
+-1 -12 D
+1 -5 D
+-3 -2 D
+-2 -11 D
+-5 -5 D
+-2 1 D
+-2 -6 D
+3 0 D
+-1 -5 D
+-1 0 D
+3 -11 D
+9 3 D
+5 -3 D
+-1 -4 D
+3 -8 D
+1 2 D
+-1 -14 D
+-3 -4 D
+1 -4 D
+-4 -10 D
+2 -6 D
+2 1 D
+1 -3 D
+1 1 D
+2 -2 D
+3 0 D
+3 4 D
+2 0 D
+0 131 D
+P
+7087 2030 M
+-2 -2 D
+-1 2 D
+P
+7083 2033 M
+1 -2 D
+P
+FO
+6850 2095 M
+2 -2 D
+-2 -13 D
+3 -2 D
+-1 -5 D
+5 -7 D
+-2 0 D
+-1 -2 D
+3 -3 D
+1 -6 D
+7 4 D
+1 -5 D
+2 2 D
+5 -3 D
+11 5 D
+3 -4 D
+3 2 D
+1 4 D
+3 -6 D
+-1 -11 D
+2 -1 D
+9 6 D
+6 -3 D
+3 0 D
+9 7 D
+-2 0 D
+2 5 D
+7 -9 D
+0 2 D
+1 -1 D
+6 3 D
+-1 -7 D
+1 -1 D
+10 3 D
+2 3 D
+-1 -3 D
+2 -1 D
+3 2 D
+-1 -2 D
+5 -3 D
+1 4 D
+0 -5 D
+2 -3 D
+0 -11 D
+10 3 D
+22 10 D
+3 8 D
+3 1 D
+-3 1 D
+5 1 D
+-3 3 D
+-2 0 D
+1 1 D
+-1 2 D
+2 2 D
+1 -5 D
+3 1 D
+2 9 D
+-3 -1 D
+1 2 D
+-2 0 D
+4 1 D
+2 -2 D
+2 9 D
+-2 0 D
+1 1 D
+-4 -2 D
+0 3 D
+-2 -1 D
+1 3 D
+1 -2 D
+2 2 D
+0 3 D
+-2 1 D
+2 2 D
+-7 -1 D
+2 1 D
+1 3 D
+6 1 D
+0 3 D
+5 3 D
+-1 6 D
+2 -2 D
+0 -2 D
+2 0 D
+9 9 D
+0 2 D
+2 -3 D
+0 3 D
+2 -2 D
+0 3 D
+2 -1 D
+2 1 D
+-4 2 D
+2 0 D
+0 1 D
+1 0 D
+-1 1 D
+2 0 D
+0 2 D
+-3 0 D
+4 2 D
+-4 -2 D
+2 3 D
+-2 -2 D
+0 3 D
+0 -1 D
+-1 4 D
+2 5 D
+-178 0 D
+P
+6999 2119 M
+1 1 D
+1 -1 D
+2 3 D
+2 -2 D
+-4 -2 D
+P
+6995 2117 M
+4 -1 D
+-3 -2 D
+P
+6907 2065 M
+0 -3 D
+-3 -3 D
+P
+FO
+6850 1939 M
+6 -1 D
+-1 -1 D
+12 -5 D
+9 0 D
+2 -2 D
+6 1 D
+1 -2 D
+6 -1 D
+0 2 D
+1 -1 D
+2 2 D
+19 -5 D
+13 4 D
+12 -5 D
+2 1 D
+0 -2 D
+10 -2 D
+1 1 D
+3 -2 D
+-1 -2 D
+6 0 D
+-1 2 D
+-3 1 D
+-1 4 D
+-1 -1 D
+2 17 D
+-7 2 D
+-2 2 D
+-7 -3 D
+-6 1 D
+-5 -2 D
+-10 5 D
+0 6 D
+-2 3 D
+-3 0 D
+0 4 D
+-2 4 D
+-11 -1 D
+-3 3 D
+-6 0 D
+-5 4 D
+-3 -2 D
+-6 1 D
+-2 5 D
+-8 0 D
+-4 -10 D
+-3 -2 D
+-5 2 D
+-5 -1 D
+P
+6912 1958 M
+-1 -1 D
+P
+FO
+7016 1911 M
+3 0 D
+1 2 D
+6 -1 D
+6 3 D
+5 0 D
+4 2 D
+1 -1 D
+7 5 D
+-1 -3 D
+2 -2 D
+6 2 D
+5 -1 D
+0 2 D
+-5 0 D
+5 2 D
+1 -2 D
+4 0 D
+2 4 D
+-1 1 D
+-3 -2 D
+-1 8 D
+-6 0 D
+-2 -6 D
+0 6 D
+-5 1 D
+-4 -3 D
+-3 6 D
+-5 1 D
+-5 -1 D
+-1 -3 D
+7 -5 D
+6 -2 D
+1 -2 D
+-11 -2 D
+-2 4 D
+-2 0 D
+-1 3 D
+0 -2 D
+-1 2 D
+-3 0 D
+-1 -1 D
+-6 2 D
+-3 -3 D
+-5 0 D
+-1 -4 D
+2 -3 D
+-3 -2 D
+0 -3 D
+P
+FO
+6992 1919 M
+-3 1 D
+-1 -2 D
+4 -3 D
+2 2 D
+7 -2 D
+0 -1 D
+1 3 D
+1 0 D
+-1 -2 D
+4 1 D
+-2 2 D
+4 6 D
+1 5 D
+-6 3 D
+-5 -1 D
+-5 -4 D
+1 -7 D
+P
+FO
+6969 1933 M
+-14 2 D
+4 -7 D
+7 -2 D
+6 -5 D
+-1 -4 D
+3 0 D
+-1 2 D
+4 4 D
+6 2 D
+2 3 D
+-6 5 D
+-6 3 D
+P
+FO
+6916 1961 M
+-2 -1 D
+1 -3 D
+18 -2 D
+3 3 D
+6 -1 D
+1 3 D
+5 1 D
+-5 3 D
+-25 -1 D
+P
+FO
+6976 1961 M
+0 1 D
+2 -1 D
+-2 1 D
+1 1 D
+5 -1 D
+-8 3 D
+-1 -3 D
+P
+FO
+7077 1919 M
+3 -1 D
+0 3 D
+2 1 D
+-3 -1 D
+-1 2 D
+1 -2 D
+P
+FO
+7072 1923 M
+0 -3 D
+2 -1 D
+0 4 D
+3 0 D
+0 2 D
+-3 2 D
+P
+FO
+6993 2031 M
+1 -2 D
+5 5 D
+0 16 D
+-4 -2 D
+-2 -4 D
+P
+FO
+6986 1957 M
+3 -1 D
+1 2 D
+-1 -1 D
+-2 1 D
+P
+FO
+7027 1928 M
+1 0 D
+4 5 D
+-5 0 D
+P
+FO
+6979 1920 M
+3 -2 D
+1 1 D
+-1 2 D
+P
+FO
+7063 1932 M
+2 -1 D
+1 2 D
+-2 1 D
+P
+FO
+6999 2042 M
+2 -2 D
+1 7 D
+P
+FO
+6911 1989 M
+3 -1 D
+1 2 D
+P
+FO
+6951 1958 M
+3 -1 D
+-1 2 D
+P
+FO
+7001 2075 M
+4 0 D
+-4 1 D
+P
+FO
+6945 1959 M
+-2 0 D
+3 -1 D
+P
+FO
+6851 2061 M
+2 0 D
+0 2 D
+P
+FO
+6983 1961 M
+2 -1 D
+-3 2 D
+P
+FO
+6927 1926 M
+4 0 D
+P
+FO
+6985 2015 M
+1 0 D
+P
+FO
+7022 1948 M
+2 0 D
+P
+FO
+7009 1929 M
+1 0 D
+-1 1 D
+P
+FO
+6956 1957 M
+4 0 D
+P
+FO
+7032 1925 M
+3 -1 D
+P
+FO
+7069 1996 M
+2 0 D
+P
+FO
+6986 2012 M
+3 2 D
+P
+FO
+7069 1927 M
+2 -1 D
+-2 2 D
+P
+FO
+6854 2058 M
+1 0 D
+P
+FO
+7039 1921 M
+-1 1 D
+P
+FO
+7031 1925 M
+0 1 D
+P
+FO
+6954 1995 M
+2 0 D
+P
+FO
+6860 1988 M
+2 0 D
+P
+FO
+6942 1956 M
+2 -1 D
+P
+FO
+7012 1926 M
+3 1 D
+P
+FO
+7076 1921 M
+1 1 D
+P
+FO
+6980 1961 M
+-1 0 D
+P
+FO
+7038 1999 M
+0 -1 D
+P
+FO
+6983 2009 M
+2 2 D
+P
+FO
+7024 1933 M
+2 1 D
+P
+FO
+6939 1955 M
+1 0 D
+P
+FO
+7105 1890 M
+-8 9 D
+-4 -1 D
+-1 4 D
+-3 0 D
+-2 3 D
+0 -15 D
+P
+FO
+7195 1890 M
+9 8 D
+0 3 D
+10 6 D
+13 3 D
+6 4 D
+7 0 D
+2 4 D
+10 3 D
+7 7 D
+-8 1 D
+-9 -4 D
+-4 2 D
+-6 -2 D
+-7 1 D
+-17 -4 D
+-4 -8 D
+-10 -5 D
+-6 0 D
+-15 -10 D
+0 -6 D
+-2 -1 D
+0 -2 D
+P
+FO
+7323 1944 M
+P
+FO
+7323 2055 M
+-11 6 D
+-4 -1 D
+-6 -4 D
+-2 4 D
+-5 -2 D
+-15 1 D
+-3 -3 D
+1 0 D
+0 -2 D
+-2 -1 D
+-4 -2 D
+2 -4 D
+-1 -5 D
+4 5 D
+1 5 D
+2 2 D
+0 -4 D
+2 0 D
+4 -6 D
+5 1 D
+1 2 D
+6 3 D
+0 -3 D
+14 -3 D
+-1 4 D
+10 -1 D
+2 -3 D
+P
+FO
+7323 2084 M
+-7 -2 D
+7 -3 D
+P
+FO
+7307 2126 M
+6 -5 D
+P
+FO
+7268 2126 M
+-1 -5 D
+6 -4 D
+3 -7 D
+5 -2 D
+0 -2 D
+5 -2 D
+-6 6 D
+-7 16 D
+P
+FO
+7261 2126 M
+2 -2 D
+0 2 D
+P
+FO
+7087 1995 M
+2 -1 D
+5 2 D
+4 -3 D
+-5 12 D
+1 6 D
+2 1 D
+1 4 D
+-2 5 D
+1 3 D
+-2 5 D
+3 9 D
+-1 5 D
+1 6 D
+-4 2 D
+-2 5 D
+6 3 D
+3 4 D
+4 1 D
+6 -1 D
+1 1 D
+1 -2 D
+-2 -2 D
+2 -2 D
+0 -8 D
+-5 -5 D
+1 -3 D
+8 -6 D
+0 -2 D
+1 0 D
+1 -2 D
+7 -2 D
+-4 -13 D
+2 -4 D
+11 -3 D
+3 2 D
+-3 4 D
+2 4 D
+1 -1 D
+11 3 D
+3 -3 D
+-1 5 D
+3 -3 D
+2 1 D
+-1 8 D
+-2 0 D
+2 -2 D
+-4 0 D
+0 3 D
+-4 1 D
+4 2 D
+-4 0 D
+-2 3 D
+-5 4 D
+2 3 D
+-2 2 D
+3 0 D
+-2 2 D
+2 2 D
+2 -1 D
+1 2 D
+-5 4 D
+1 2 D
+-7 5 D
+1 1 D
+-5 9 D
+-4 3 D
+-3 0 D
+-3 6 D
+-2 -2 D
+1 3 D
+-2 0 D
+1 2 D
+6 -4 D
+2 0 D
+5 7 D
+8 1 D
+4 2 D
+8 9 D
+2 5 D
+7 2 D
+1 -3 D
+4 -2 D
+3 7 D
+-1 3 D
+-8 2 D
+-2 -2 D
+-6 -1 D
+6 -2 D
+-6 -1 D
+-12 1 D
+-3 -4 D
+-4 -1 D
+-5 1 D
+-2 3 D
+-4 -2 D
+-9 -13 D
+-6 2 D
+-3 -1 D
+-3 3 D
+-1 6 D
+-3 2 D
+-2 -1 D
+-6 8 D
+-1 13 D
+1 2 D
+-1 0 D
+P
+7126 2062 M
+-4 -5 D
+-3 0 D
+1 2 D
+-1 2 D
+2 -1 D
+-1 3 D
+P
+7101 2084 M
+2 -6 D
+-1 -1 D
+-3 4 D
+0 3 D
+P
+7117 2069 M
+4 -3 D
+-1 -1 D
+-5 3 D
+P
+7088 2096 M
+0 -2 D
+P
+FO
+7087 1917 M
+3 2 D
+3 -2 D
+8 1 D
+3 -2 D
+2 2 D
+4 -4 D
+4 2 D
+3 -1 D
+2 3 D
+5 0 D
+2 -3 D
+0 2 D
+3 -1 D
+8 4 D
+6 -1 D
+10 4 D
+-1 4 D
+3 -1 D
+1 3 D
+1 0 D
+0 5 D
+-3 1 D
+-3 -3 D
+4 1 D
+1 -1 D
+-1 -2 D
+-10 -4 D
+0 -3 D
+-6 -1 D
+-5 3 D
+0 2 D
+-5 -2 D
+-4 1 D
+-3 -4 D
+-12 7 D
+-6 0 D
+-3 2 D
+-3 -1 D
+-1 2 D
+-6 -2 D
+-2 -3 D
+0 1 D
+-2 -2 D
+P
+FO
+7152 2008 M
+-1 -4 D
+2 -1 D
+-4 -3 D
+0 -3 D
+-2 -1 D
+2 -5 D
+2 2 D
+0 -1 D
+1 1 D
+1 -2 D
+2 6 D
+6 2 D
+2 2 D
+-5 4 D
+-1 -2 D
+-1 1 D
+2 10 D
+2 -1 D
+0 2 D
+3 -4 D
+-1 6 D
+-3 4 D
+0 2 D
+-5 -4 D
+P
+FO
+7151 2008 M
+1 1 D
+-2 8 D
+-7 -3 D
+-2 -2 D
+2 -6 D
+-3 -7 D
+3 1 D
+2 -2 D
+2 4 D
+-1 -5 D
+2 1 D
+1 3 D
+-1 3 D
+P
+FO
+7162 1924 M
+5 -1 D
+2 2 D
+1 -2 D
+2 4 D
+7 4 D
+-3 2 D
+-2 -2 D
+-2 1 D
+0 -2 D
+-1 0 D
+0 -2 D
+-2 0 D
+2 3 D
+-4 0 D
+-1 -1 D
+3 -1 D
+P
+FO
+7157 2090 M
+4 5 D
+1 -5 D
+-2 -2 D
+3 -1 D
+1 5 D
+1 0 D
+1 -2 D
+2 0 D
+3 6 D
+-5 1 D
+-3 -4 D
+-1 6 D
+-1 -2 D
+-6 1 D
+-2 -7 D
+2 -3 D
+P
+FO
+7228 2048 M
+5 -7 D
+11 -6 D
+13 4 D
+1 7 D
+-4 0 D
+-1 3 D
+2 -1 D
+-1 2 D
+-7 4 D
+-12 -1 D
+-2 -2 D
+-3 2 D
+P
+FO
+7190 2079 M
+11 2 D
+4 -1 D
+7 1 D
+-1 4 D
+-2 -1 D
+-1 2 D
+-2 -2 D
+-2 2 D
+-10 2 D
+-4 -2 D
+-1 -5 D
+P
+FO
+7259 2115 M
+4 -4 D
+0 -5 D
+4 2 D
+3 -3 D
+3 2 D
+-1 2 D
+-4 0 D
+-2 2 D
+2 4 D
+-3 3 D
+-2 -2 D
+-4 2 D
+P
+FO
+7205 1928 M
+3 1 D
+-1 4 D
+-12 -1 D
+0 2 D
+-2 0 D
+-2 -4 D
+3 2 D
+-3 -2 D
+-2 -3 D
+2 -1 D
+P
+FO
+7276 2041 M
+-3 -2 D
+1 -2 D
+7 3 D
+-3 -4 D
+4 3 D
+-1 1 D
+3 0 D
+0 3 D
+-3 0 D
+-2 -2 D
+P
+FO
+7134 2117 M
+3 -1 D
+-1 4 D
+-2 -3 D
+-3 1 D
+0 -2 D
+-5 -1 D
+0 -3 D
+1 2 D
+4 -1 D
+1 3 D
+P
+FO
+7181 1929 M
+-2 -3 D
+3 1 D
+0 -3 D
+2 0 D
+4 5 D
+1 4 D
+-2 -1 D
+-3 -4 D
+-1 2 D
+P
+FO
+7224 1937 M
+6 3 D
+9 -2 D
+3 3 D
+6 2 D
+-5 4 D
+-10 -4 D
+-5 2 D
+-4 -5 D
+P
+FO
+7228 2084 M
+-8 -1 D
+-6 1 D
+-2 -2 D
+3 -1 D
+0 -1 D
+10 1 D
+1 -1 D
+11 3 D
+P
+FO
+7134 2004 M
+-1 2 D
+-1 -1 D
+-1 2 D
+-2 -5 D
+4 -6 D
+2 1 D
+1 6 D
+P
+FO
+7276 2090 M
+-9 5 D
+-3 -3 D
+-2 0 D
+-1 -4 D
+4 -3 D
+14 1 D
+0 2 D
+P
+FO
+7254 2116 M
+1 -2 D
+3 0 D
+1 5 D
+-5 0 D
+P
+FO
+7288 2043 M
+3 -3 D
+0 2 D
+2 -2 D
+-1 3 D
+P
+FO
+7318 1937 M
+1 4 D
+-6 0 D
+0 -2 D
+3 -3 D
+P
+FO
+7228 2072 M
+0 6 D
+-2 1 D
+0 -5 D
+4 -7 D
+P
+FO
+7157 2027 M
+4 -2 D
+3 5 D
+-6 2 D
+-2 -2 D
+P
+FO
+7272 2055 M
+-1 -1 D
+2 0 D
+3 3 D
+-2 0 D
+P
+FO
+7258 2093 M
+1 -1 D
+2 1 D
+-2 1 D
+P
+FO
+7097 1984 M
+1 -12 D
+2 11 D
+-2 7 D
+P
+FO
+7157 1927 M
+7 1 D
+2 3 D
+-5 0 D
+-4 -3 D
+P
+FO
+7276 1931 M
+3 2 D
+-9 1 D
+1 -2 D
+P
+FO
+7169 2087 M
+1 -2 D
+2 1 D
+-2 5 D
+P
+FO
+7157 1927 M
+-2 -2 D
+0 -2 D
+7 4 D
+-4 0 D
+P
+FO
+7288 1957 M
+3 -2 D
+1 3 D
+-2 1 D
+P
+FO
+7260 1946 M
+1 -1 D
+2 3 D
+-2 1 D
+P
+FO
+7101 1959 M
+2 -2 D
+2 2 D
+-4 2 D
+P
+FO
+7316 2098 M
+4 0 D
+-1 -2 D
+3 2 D
+P
+FO
+7255 1936 M
+0 -1 D
+2 -1 D
+0 3 D
+P
+FO
+7255 2035 M
+3 -1 D
+-1 2 D
+P
+FO
+7255 2108 M
+5 -1 D
+-2 5 D
+P
+FO
+7170 2001 M
+2 -2 D
+0 2 D
+-2 1 D
+P
+FO
+7217 1931 M
+2 -1 D
+1 4 D
+P
+FO
+7267 2050 M
+4 -1 D
+0 2 D
+P
+FO
+7140 2041 M
+2 0 D
+-1 2 D
+P
+FO
+7299 1931 M
+-1 2 D
+-3 -1 D
+P
+FO
+7263 2048 M
+4 -1 D
+-2 2 D
+P
+FO
+7277 1931 M
+4 -1 D
+-1 2 D
+P
+FO
+7159 2081 M
+2 1 D
+-1 2 D
+P
+FO
+7119 2029 M
+0 -1 D
+2 1 D
+P
+FO
+7110 1953 M
+2 1 D
+-6 0 D
+P
+FO
+7164 2097 M
+1 -1 D
+0 2 D
+P
+FO
+7137 2120 M
+3 -1 D
+-1 2 D
+P
+FO
+7159 2041 M
+3 0 D
+-1 1 D
+P
+FO
+7139 2121 M
+4 -4 D
+0 3 D
+P
+FO
+7285 2102 M
+-2 2 D
+1 -2 D
+P
+FO
+7112 1952 M
+2 0 D
+-2 1 D
+P
+FO
+7285 2040 M
+4 2 D
+-3 1 D
+P
+FO
+7124 2122 M
+1 -1 D
+1 2 D
+P
+FO
+7263 2097 M
+5 -1 D
+-3 2 D
+P
+FO
+7177 2077 M
+2 0 D
+-1 2 D
+P
+FO
+7319 2115 M
+1 -1 D
+1 2 D
+P
+FO
+7168 2000 M
+2 -1 D
+P
+FO
+7181 1987 M
+1 -3 D
+P
+FO
+7266 1932 M
+4 1 D
+P
+FO
+7176 2082 M
+0 -3 D
+1 0 D
+P
+FO
+7128 1951 M
+2 1 D
+P
+FO
+7164 2084 M
+2 3 D
+P
+FO
+7174 1997 M
+3 -3 D
+P
+FO
+7145 1991 M
+2 1 D
+P
+FO
+7181 1990 M
+-2 1 D
+P
+FO
+7142 1927 M
+2 -1 D
+P
+FO
+7318 1932 M
+3 3 D
+P
+FO
+7143 2045 M
+2 -1 D
+P
+FO
+7190 2079 M
+-2 0 D
+P
+FO
+7311 1940 M
+1 -2 D
+P
+FO
+7259 2111 M
+3 -1 D
+P
+FO
+7126 1929 M
+2 0 D
+P
+FO
+7158 2012 M
+2 1 D
+P
+FO
+7282 2087 M
+2 1 D
+P
+FO
+7256 2123 M
+2 1 D
+P
+FO
+7237 2083 M
+3 0 D
+P
+FO
+7189 1930 M
+1 0 D
+P
+FO
+7261 2099 M
+1 -2 D
+P
+FO
+7284 2100 M
+2 -1 D
+P
+FO
+7313 2125 M
+2 -1 D
+P
+FO
+7293 2039 M
+1 0 D
+P
+FO
+7222 1937 M
+0 -1 D
+P
+FO
+7252 2120 M
+2 0 D
+P
+FO
+7319 2018 M
+3 1 D
+-3 0 D
+P
+FO
+7254 2120 M
+1 2 D
+P
+FO
+7310 1966 M
+2 1 D
+P
+FO
+7265 2082 M
+2 1 D
+P
+FO
+7096 1980 M
+1 2 D
+P
+FO
+7145 1995 M
+1 1 D
+P
+FO
+7150 2019 M
+2 -1 D
+P
+FO
+7181 2082 M
+1 -1 D
+P
+FO
+7146 2114 M
+2 0 D
+P
+FO
+7315 2098 M
+2 1 D
+P
+FO
+7174 2080 M
+1 1 D
+P
+FO
+7105 1965 M
+0 -1 D
+P
+FO
+7293 1933 M
+1 -1 D
+P
+FO
+7140 1928 M
+1 1 D
+P
+FO
+7150 2001 M
+1 1 D
+P
+FO
+7159 2043 M
+1 0 D
+P
+FO
+7141 2016 M
+1 1 D
+P
+FO
+7256 2126 M
+1 -1 D
+P
+FO
+7177 1994 M
+1 0 D
+P
+FO
+7093 1916 M
+1 1 D
+P
+FO
+7261 2124 M
+1 2 D
+P
+FO
+7315 1948 M
+1 -1 D
+P
+FO
+7306 2098 M
+2 0 D
+P
+FO
+7141 2014 M
+2 2 D
+P
+FO
+7134 2120 M
+2 0 D
+P
+FO
+7179 1928 M
+1 1 D
+P
+FO
+7171 1998 M
+2 0 D
+P
+FO
+7127 1954 M
+2 0 D
+P
+FO
+7266 1947 M
+0 -1 D
+P
+FO
+7269 2117 M
+1 1 D
+P
+FO
+7261 2095 M
+1 0 D
+P
+FO
+7127 1949 M
+2 0 D
+P
+FO
+7100 1959 M
+1 0 D
+P
+FO
+7134 1996 M
+1 0 D
+P
+FO
+7173 2081 M
+0 -1 D
+P
+FO
+7096 1970 M
+1 -1 D
+P
+FO
+7283 2113 M
+2 0 D
+P
+FO
+7217 2084 M
+1 0 D
+P
+FO
+7150 1980 M
+1 -1 D
+P
+FO
+7270 2051 M
+2 0 D
+P
+FO
+7188 2085 M
+0 -1 D
+P
+FO
+7559 1935 M
+-1 -2 D
+1 -1 D
+P
+FO
+7559 2071 M
+-6 -1 D
+-21 10 D
+-4 4 D
+-16 6 D
+-1 -1 D
+-2 2 D
+-5 -1 D
+-9 -6 D
+-3 0 D
+1 -1 D
+-2 1 D
+3 -6 D
+-2 -2 D
+-5 0 D
+-5 -3 D
+-8 1 D
+-4 -10 D
+-5 -2 D
+-3 -4 D
+1 -2 D
+-5 -2 D
+1 -2 D
+-4 -1 D
+-3 -5 D
+-12 1 D
+0 3 D
+-2 -1 D
+-2 3 D
+1 6 D
+-2 -3 D
+-2 1 D
+-1 11 D
+-2 1 D
+1 -1 D
+-3 -1 D
+2 -6 D
+-2 -2 D
+-3 9 D
+-4 3 D
+-2 17 D
+3 2 D
+2 5 D
+-6 9 D
+1 3 D
+2 0 D
+-4 3 D
+-14 0 D
+-10 7 D
+-13 2 D
+-6 -2 D
+-8 -7 D
+-14 -3 D
+2 -2 D
+-2 -5 D
+-7 -7 D
+7 -2 D
+2 1 D
+-1 2 D
+2 1 D
+2 -4 D
+3 3 D
+-1 -2 D
+3 1 D
+-2 -1 D
+2 -1 D
+2 2 D
+-1 -3 D
+2 0 D
+0 2 D
+1 -3 D
+3 1 D
+-1 -3 D
+4 1 D
+-4 -5 D
+3 -4 D
+2 1 D
+-2 -2 D
+6 -5 D
+7 2 D
+3 -2 D
+3 1 D
+3 -1 D
+7 2 D
+6 -1 D
+2 2 D
+1 -2 D
+7 4 D
+1 -4 D
+-3 -2 D
+3 -2 D
+-3 1 D
+1 -2 D
+-4 1 D
+2 -1 D
+0 -5 D
+-3 4 D
+0 -3 D
+1 0 D
+-1 0 D
+-1 -3 D
+0 5 D
+-3 -2 D
+-1 3 D
+-1 -3 D
+0 3 D
+-1 -5 D
+-2 1 D
+2 0 D
+0 4 D
+-4 2 D
+-4 -2 D
+-8 -7 D
+-6 2 D
+0 -1 D
+-1 2 D
+-5 0 D
+-6 -3 D
+3 0 D
+-3 -1 D
+2 0 D
+-1 -2 D
+8 -1 D
+7 -5 D
+-1 -1 D
+2 -3 D
+1 0 D
+1 2 D
+2 -1 D
+-1 -3 D
+3 -3 D
+-1 -2 D
+-4 0 D
+4 -11 D
+8 1 D
+4 4 D
+-1 0 D
+2 1 D
+-1 4 D
+5 4 D
+-4 2 D
+2 0 D
+0 2 D
+0 -2 D
+3 1 D
+0 6 D
+3 2 D
+1 3 D
+2 -4 D
+-2 2 D
+-1 -5 D
+-2 1 D
+0 -6 D
+-2 -1 D
+2 -5 D
+1 1 D
+2 -2 D
+-1 3 D
+1 1 D
+4 -7 D
+4 3 D
+1 -2 D
+-2 -2 D
+5 -3 D
+-1 2 D
+2 0 D
+-1 2 D
+3 -1 D
+1 -3 D
+4 2 D
+6 0 D
+-1 -1 D
+-2 1 D
+-3 -1 D
+1 -2 D
+-2 -1 D
+14 -8 D
+16 -1 D
+17 -8 D
+2 1 D
+1 -2 D
+1 2 D
+1 -3 D
+3 1 D
+1 -2 D
+2 1 D
+1 -2 D
+0 2 D
+2 -2 D
+1 2 D
+0 -2 D
+3 0 D
+1 -3 D
+0 2 D
+0 -2 D
+2 3 D
+-1 -3 D
+1 -1 D
+2 3 D
+-1 -3 D
+2 1 D
+-2 -1 D
+3 -1 D
+1 1 D
+-1 -2 D
+3 0 D
+-1 -2 D
+2 2 D
+-1 -3 D
+5 2 D
+-3 -2 D
+3 -3 D
+1 3 D
+2 0 D
+-2 0 D
+0 -3 D
+2 -1 D
+-2 -1 D
+0 -3 D
+7 1 D
+-5 -2 D
+5 -2 D
+1 3 D
+0 -3 D
+-3 -1 D
+3 -11 D
+10 -8 D
+-4 1 D
+0 -2 D
+7 -2 D
+-8 -2 D
+-1 -1 D
+7 -5 D
+8 -1 D
+1 1 D
+-2 -2 D
+-11 1 D
+6 -5 D
+1 -3 D
+4 -1 D
+-2 -6 D
+-3 -2 D
+1 -3 D
+-3 -1 D
+2 -4 D
+8 5 D
+3 -3 D
+4 2 D
+10 1 D
+P
+7472 2036 M
+2 -1 D
+-1 -3 D
+-2 1 D
+P
+7511 2082 M
+1 -1 D
+-2 0 D
+-1 2 D
+P
+7471 2030 M
+0 -1 D
+P
+7440 2040 M
+-1 -1 D
+P
+FO
+7323 2079 M
+3 -2 D
+4 2 D
+4 -1 D
+-3 3 D
+3 2 D
+-3 4 D
+-8 -3 D
+P
+FO
+7323 2044 M
+20 -9 D
+-1 9 D
+-4 2 D
+-1 6 D
+-6 4 D
+-8 -1 D
+P
+FO
+7323 1944 M
+0 -1 D
+P
+FO
+7424 1984 M
+0 -4 D
+-2 4 D
+-2 -1 D
+3 -4 D
+-4 1 D
+1 -6 D
+2 0 D
+0 -2 D
+-2 2 D
+-2 -8 D
+4 -4 D
+4 3 D
+1 4 D
+2 0 D
+-1 4 D
+2 -2 D
+2 1 D
+0 2 D
+-2 -2 D
+1 2 D
+-1 2 D
+2 -1 D
+3 3 D
+0 2 D
+-2 1 D
+2 1 D
+-4 4 D
+3 -1 D
+1 2 D
+-2 1 D
+2 5 D
+-3 1 D
+2 2 D
+-2 2 D
+-3 0 D
+0 -3 D
+-1 0 D
+-2 -4 D
+-3 1 D
+-1 -1 D
+5 -2 D
+-3 -2 D
+P
+FO
+7346 2118 M
+3 1 D
+3 -2 D
+2 2 D
+-1 3 D
+-5 3 D
+-2 -1 D
+-4 2 D
+-10 -3 D
+-1 1 D
+0 -1 D
+-2 1 D
+1 -2 D
+2 1 D
+-1 -1 D
+2 -1 D
+-5 0 D
+2 -2 D
+5 1 D
+1 -4 D
+0 2 D
+3 1 D
+1 -4 D
+4 1 D
+0 3 D
+-4 0 D
+-3 4 D
+1 0 D
+-1 1 D
+2 0 D
+3 -4 D
+P
+FO
+7350 1937 M
+2 0 D
+1 2 D
+0 -3 D
+2 4 D
+6 5 D
+2 6 D
+-1 0 D
+-1 4 D
+3 0 D
+-1 2 D
+-4 0 D
+0 -2 D
+-1 0 D
+-1 -3 D
+-5 -3 D
+-2 -4 D
+2 -1 D
+-3 0 D
+P
+FO
+7465 2099 M
+3 -2 D
+6 3 D
+-5 1 D
+-7 8 D
+-3 -1 D
+-3 2 D
+-1 -1 D
+-6 2 D
+5 -6 D
+-2 3 D
+4 -3 D
+2 2 D
+2 -8 D
+2 -1 D
+P
+FO
+7512 1928 M
+12 1 D
+10 7 D
+0 4 D
+2 1 D
+1 6 D
+-9 5 D
+-12 -4 D
+-6 -6 D
+-2 -5 D
+1 -1 D
+-2 0 D
+-4 -8 D
+P
+FO
+7332 2104 M
+10 1 D
+3 2 D
+-3 1 D
+0 -2 D
+-6 1 D
+0 -1 D
+-2 1 D
+P
+FO
+7464 2083 M
+7 -2 D
+15 3 D
+-17 3 D
+-18 1 D
+1 -2 D
+6 0 D
+P
+FO
+7384 1994 M
+2 -4 D
+0 -4 D
+2 -1 D
+0 6 D
+-2 1 D
+1 2 D
+P
+FO
+7346 2096 M
+2 6 D
+-1 2 D
+-9 -1 D
+5 -9 D
+3 0 D
+P
+FO
+7333 2114 M
+3 1 D
+0 -2 D
+2 0 D
+1 2 D
+-5 1 D
+P
+FO
+7363 1957 M
+4 0 D
+3 -2 D
+-2 3 D
+P
+FO
+7440 2102 M
+-2 2 D
+-2 -1 D
+1 -4 D
+3 0 D
+P
+FO
+7346 1935 M
+-5 -6 D
+10 5 D
+-3 -1 D
+P
+FO
+7346 1951 M
+0 -2 D
+2 -1 D
+3 3 D
+P
+FO
+7432 1973 M
+1 -2 D
+2 1 D
+-2 2 D
+P
+FO
+7343 1948 M
+3 -1 D
+0 2 D
+-3 0 D
+P
+FO
+7429 2070 M
+2 -2 D
+0 4 D
+0 -2 D
+P
+FO
+7526 1929 M
+8 0 D
+-2 5 D
+-3 -1 D
+P
+FO
+7357 2031 M
+-2 1 D
+2 -2 D
+P
+FO
+7435 1972 M
+1 -1 D
+1 1 D
+P
+FO
+7527 1964 M
+3 0 D
+-1 2 D
+P
+FO
+7387 1993 M
+2 -1 D
+0 4 D
+P
+FO
+7526 1966 M
+2 -2 D
+1 2 D
+P
+FO
+7346 1943 M
+3 3 D
+-3 -1 D
+P
+FO
+7421 2081 M
+0 -1 D
+2 5 D
+P
+FO
+7427 2079 M
+-2 -2 D
+1 -2 D
+P
+FO
+7436 1975 M
+1 -2 D
+1 4 D
+P
+FO
+7432 1966 M
+2 2 D
+0 2 D
+P
+FO
+7428 1966 M
+2 0 D
+-1 3 D
+P
+FO
+7390 1984 M
+6 10 D
+1 7 D
+P
+FO
+7412 2073 M
+4 -1 D
+0 3 D
+P
+FO
+7401 2029 M
+0 -2 D
+7 -3 D
+P
+FO
+7359 1966 M
+1 0 D
+1 2 D
+P
+FO
+7352 2031 M
+-1 1 D
+1 -2 D
+P
+FO
+7328 2074 M
+2 0 D
+P
+FO
+7428 1959 M
+2 0 D
+P
+FO
+7336 2111 M
+2 1 D
+P
+FO
+7472 2081 M
+1 -1 D
+P
+FO
+7357 1956 M
+1 1 D
+P
+FO
+7412 2053 M
+P
+FO
+7386 1995 M
+2 0 D
+P
+FO
+7431 1963 M
+2 1 D
+-2 0 D
+P
+FO
+7323 1942 M
+2 1 D
+P
+FO
+7535 1955 M
+-1 1 D
+P
+FO
+7374 2056 M
+3 -1 D
+P
+FO
+7409 2067 M
+1 -1 D
+P
+FO
+7435 1970 M
+1 -1 D
+P
+FO
+7433 2033 M
+2 0 D
+P
+FO
+7403 2063 M
+0 2 D
+P
+FO
+7443 2090 M
+6 1 D
+-6 0 D
+P
+FO
+7405 2069 M
+3 -2 D
+P
+FO
+7421 2031 M
+-2 2 D
+P
+FO
+7385 2045 M
+2 -2 D
+P
+FO
+7421 1989 M
+2 0 D
+P
+FO
+7353 2030 M
+3 -3 D
+P
+FO
+7325 2126 M
+1 -2 D
+P
+FO
+7429 1999 M
+2 1 D
+P
+FO
+7349 2102 M
+-1 -2 D
+P
+FO
+7423 1993 M
+2 1 D
+P
+FO
+7414 2038 M
+2 -4 D
+P
+FO
+7370 2000 M
+-1 -1 D
+1 2 D
+P
+FO
+7370 1961 M
+-2 -2 D
+P
+FO
+7412 2066 M
+1 -2 D
+P
+FO
+7351 1952 M
+3 1 D
+P
+FO
+7412 2074 M
+2 1 D
+P
+FO
+7361 2021 M
+1 -2 D
+P
+FO
+7410 2073 M
+2 1 D
+P
+FO
+7377 1995 M
+2 0 D
+P
+FO
+7458 2056 M
+2 0 D
+P
+FO
+7357 1963 M
+2 1 D
+P
+FO
+7376 1994 M
+1 -2 D
+P
+FO
+7426 2031 M
+2 0 D
+P
+FO
+7380 2053 M
+3 -2 D
+P
+FO
+7406 2065 M
+1 1 D
+P
+FO
+7401 2068 M
+1 -1 D
+P
+FO
+7436 2062 M
+2 0 D
+P
+FO
+7488 2082 M
+2 0 D
+P
+FO
+7410 2072 M
+2 2 D
+-2 -1 D
+P
+FO
+7363 2015 M
+1 -2 D
+P
+FO
+7423 1996 M
+0 -1 D
+P
+FO
+7414 2075 M
+2 0 D
+P
+FO
+7381 2063 M
+1 1 D
+P
+FO
+7435 1976 M
+1 1 D
+P
+FO
+7478 2098 M
+1 -2 D
+P
+FO
+7434 1974 M
+1 2 D
+P
+FO
+7333 2076 M
+1 -1 D
+P
+FO
+7334 2073 M
+2 0 D
+P
+FO
+7360 2022 M
+1 0 D
+P
+FO
+7323 2124 M
+1 0 D
+P
+FO
+7344 2075 M
+1 0 D
+P
+FO
+7505 2000 M
+1 0 D
+P
+FO
+7328 2091 M
+1 0 D
+P
+FO
+7457 2057 M
+1 0 D
+P
+FO
+7435 1974 M
+0 2 D
+P
+FO
+7344 2034 M
+1 0 D
+P
+FO
+7469 2096 M
+1 1 D
+P
+FO
+7430 1999 M
+1 0 D
+P
+FO
+7471 2096 M
+2 1 D
+P
+FO
+7327 2118 M
+1 0 D
+P
+FO
+7360 2063 M
+2 1 D
+P
+FO
+7329 2110 M
+1 1 D
+P
+FO
+7414 2074 M
+1 0 D
+P
+FO
+7478 2096 M
+1 -1 D
+P
+FO
+7329 2122 M
+1 -1 D
+P
+FO
+7329 2113 M
+0 -1 D
+P
+FO
+7337 2079 M
+-1 0 D
+P
+FO
+7336 2073 M
+1 0 D
+P
+FO
+7349 2097 M
+1 0 D
+P
+FO
+7483 2010 M
+1 0 D
+P
+FO
+7332 2074 M
+1 0 D
+P
+FO
+7388 1991 M
+1 -1 D
+P
+FO
+7792 1890 M
+-4 4 D
+7 2 D
+0 2 D
+-13 1 D
+-5 3 D
+-1 3 D
+3 6 D
+-1 0 D
+1 1 D
+-1 1 D
+-12 -2 D
+-4 0 D
+-4 10 D
+-5 3 D
+-2 11 D
+-3 0 D
+-3 3 D
+-4 0 D
+-1 4 D
+-4 2 D
+-1 3 D
+-6 3 D
+-1 5 D
+-2 2 D
+0 3 D
+-1 -1 D
+-2 2 D
+0 6 D
+15 0 D
+7 2 D
+-1 6 D
+-5 7 D
+-7 4 D
+-6 -1 D
+-14 9 D
+-17 3 D
+1 14 D
+-11 11 D
+-7 1 D
+-4 4 D
+0 2 D
+-7 2 D
+-1 5 D
+-6 1 D
+3 -1 D
+-3 0 D
+0 -1 D
+-4 1 D
+2 1 D
+-4 -1 D
+-12 9 D
+-23 4 D
+-32 15 D
+-11 0 D
+1 3 D
+-10 2 D
+0 -1 D
+-5 3 D
+-3 0 D
+0 -135 D
+1 1 D
+-1 -5 D
+9 -6 D
+6 -8 D
+12 -10 D
+5 2 D
+6 -2 D
+11 1 D
+3 3 D
+0 -2 D
+10 -5 D
+9 6 D
+9 2 D
+0 6 D
+-7 7 D
+-8 4 D
+-7 -2 D
+-2 5 D
+-4 0 D
+4 0 D
+3 -4 D
+4 2 D
+7 -2 D
+18 4 D
+-6 2 D
+-1 2 D
+3 -3 D
+-4 5 D
+11 -3 D
+0 2 D
+2 -1 D
+-7 13 D
+6 -6 D
+4 -2 D
+0 1 D
+2 -1 D
+-1 5 D
+3 -4 D
+1 1 D
+-2 2 D
+2 -1 D
+0 2 D
+5 -6 D
+-3 9 D
+4 -6 D
+1 7 D
+0 -6 D
+2 0 D
+-1 6 D
+1 -2 D
+2 2 D
+-1 -3 D
+2 -4 D
+1 4 D
+2 -1 D
+-1 -5 D
+2 1 D
+3 -2 D
+-1 2 D
+3 -2 D
+0 1 D
+1 -2 D
+0 2 D
+5 -4 D
+9 1 D
+-1 -1 D
+2 -2 D
+6 -1 D
+0 -2 D
+4 -3 D
+2 -6 D
+6 -6 D
+-1 -2 D
+1 -3 D
+7 -2 D
+2 1 D
+-2 -2 D
+0 -3 D
+2 0 D
+2 -5 D
+1 1 D
+4 -2 D
+9 -11 D
+P
+7594 1965 M
+2 -4 D
+2 0 D
+-3 -4 D
+-3 1 D
+2 0 D
+1 4 D
+-4 3 D
+P
+7574 2064 M
+-1 -1 D
+0 1 D
+-5 1 D
+P
+7632 2028 M
+2 -3 D
+-2 1 D
+P
+7612 2024 M
+-1 -1 D
+P
+7605 2023 M
+-1 -1 D
+P
+7617 2024 M
+0 -2 D
+P
+7637 1976 M
+-1 0 D
+3 -3 D
+P
+FO
+7795 2002 M
+-2 -2 D
+1 -2 D
+-2 -2 D
+-2 0 D
+-2 -1 D
+-1 2 D
+-4 -2 D
+-5 -1 D
+-7 3 D
+-10 -2 D
+-3 2 D
+-2 -3 D
+1 -4 D
+9 -3 D
+0 -1 D
+1 0 D
+1 -2 D
+4 0 D
+1 -4 D
+2 2 D
+5 1 D
+6 -6 D
+9 1 D
+P
+FO
+7795 2068 M
+-1 0 D
+1 -1 D
+P
+FO
+7724 2074 M
+5 0 D
+2 3 D
+4 1 D
+-2 1 D
+0 -2 D
+-6 2 D
+-11 0 D
+-2 0 D
+1 -3 D
+-2 -1 D
+1 -2 D
+4 1 D
+-1 2 D
+P
+FO
+7748 1995 M
+-4 2 D
+-2 -1 D
+1 -4 D
+5 -4 D
+2 4 D
+P
+FO
+7724 2000 M
+3 -3 D
+3 1 D
+-3 5 D
+-3 -1 D
+P
+FO
+7701 2019 M
+-3 -2 D
+1 -3 D
+3 1 D
+P
+FO
+7784 2092 M
+2 -2 D
+3 0 D
+-4 5 D
+P
+FO
+7677 2029 M
+2 1 D
+-2 0 D
+P
+FO
+7642 1929 M
+4 -2 D
+-1 2 D
+P
+FO
+7782 2015 M
+3 0 D
+-2 1 D
+P
+FO
+7634 1927 M
+11 -7 D
+-4 5 D
+P
+FO
+7637 1928 M
+8 -1 D
+-2 2 D
+P
+FO
+7795 2086 M
+-1 2 D
+-1 -1 D
+P
+FO
+7741 2070 M
+4 2 D
+-2 1 D
+P
+FO
+7643 2046 M
+0 -2 D
+2 1 D
+P
+FO
+7640 1927 M
+3 -2 D
+1 1 D
+P
+FO
+7705 2013 M
+2 -1 D
+P
+FO
+7636 2050 M
+2 -1 D
+P
+FO
+7620 1904 M
+5 0 D
+P
+FO
+7643 1936 M
+4 -1 D
+P
+FO
+7644 1934 M
+2 -1 D
+P
+FO
+7650 1944 M
+3 -3 D
+P
+FO
+7609 1907 M
+4 0 D
+P
+FO
+7633 1929 M
+4 0 D
+P
+FO
+7642 2047 M
+2 -1 D
+P
+FO
+7658 1942 M
+2 0 D
+-2 1 D
+P
+FO
+7670 1947 M
+1 -1 D
+P
+FO
+7644 1925 M
+2 0 D
+P
+FO
+7749 1998 M
+2 0 D
+P
+FO
+7737 2000 M
+2 0 D
+P
+FO
+7637 1929 M
+5 1 D
+P
+FO
+7647 1926 M
+2 -1 D
+P
+FO
+7639 1913 M
+2 1 D
+P
+FO
+7738 2077 M
+2 0 D
+P
+FO
+7638 1921 M
+2 -1 D
+P
+FO
+7622 1905 M
+1 0 D
+P
+FO
+7786 2089 M
+1 -1 D
+P
+FO
+7638 1929 M
+1 0 D
+P
+FO
+7779 2017 M
+2 0 D
+P
+FO
+7678 2090 M
+1 0 D
+P
+FO
+7613 1909 M
+1 -1 D
+P
+FO
+7658 2093 M
+1 0 D
+P
+FO
+7635 1910 M
+1 1 D
+P
+FO
+7774 2010 M
+2 0 D
+P
+FO
+7732 2069 M
+2 1 D
+P
+FO
+7654 2049 M
+1 1 D
+-2 -1 D
+P
+FO
+7660 1945 M
+2 -1 D
+P
+FO
+7648 1925 M
+2 0 D
+P
+FO
+7640 1920 M
+0 -2 D
+P
+FO
+7636 1925 M
+2 -2 D
+P
+FO
+7742 2077 M
+1 1 D
+P
+FO
+7636 1927 M
+1 0 D
+P
+FO
+7650 1942 M
+1 -1 D
+P
+FO
+7633 1926 M
+3 -2 D
+P
+FO
+7658 2037 M
+2 -1 D
+P
+FO
+7634 1911 M
+2 0 D
+P
+FO
+7626 2085 M
+1 0 D
+P
+FO
+7731 2065 M
+1 1 D
+P
+FO
+7631 1929 M
+2 0 D
+P
+FO
+7638 1922 M
+2 -1 D
+P
+FO
+7669 1949 M
+1 -1 D
+P
+FO
+7730 1951 M
+1 0 D
+P
+FO
+7713 1919 M
+1 -2 D
+P
+FO
+7612 1900 M
+2 0 D
+P
+FO
+7662 1943 M
+1 -1 D
+P
+FO
+7647 1947 M
+1 -1 D
+P
+FO
+7607 1909 M
+1 0 D
+P
+FO
+7627 1893 M
+2 0 D
+P
+FO
+7820 1890 M
+-7 7 D
+3 -7 D
+P
+FO
+7825 1890 M
+0 2 D
+-2 -2 D
+P
+FO
+8031 1903 M
+-7 4 D
+-2 -1 D
+0 -5 D
+5 -7 D
+4 0 D
+P
+FO
+8031 1916 M
+P
+FO
+7795 2067 M
+4 -4 D
+7 0 D
+0 4 D
+-6 3 D
+-5 -2 D
+P
+FO
+7795 1978 M
+10 0 D
+5 3 D
+3 0 D
+1 3 D
+6 0 D
+11 8 D
+-1 4 D
+4 -2 D
+1 2 D
+3 -2 D
+7 4 D
+0 3 D
+-4 3 D
+0 4 D
+7 0 D
+4 7 D
+-2 5 D
+2 4 D
+-6 0 D
+0 3 D
+2 -1 D
+-2 2 D
+-4 -1 D
+1 -2 D
+-2 -2 D
+-2 3 D
+-9 0 D
+4 -6 D
+1 -9 D
+-2 -2 D
+-6 1 D
+-6 -6 D
+-5 -8 D
+-3 1 D
+-3 -2 D
+-4 3 D
+-4 -3 D
+-5 1 D
+-1 5 D
+1 4 D
+3 2 D
+-3 1 D
+-2 -6 D
+P
+7799 2007 M
+0 -1 D
+-1 1 D
+-1 -1 D
+P
+FO
+7795 1896 M
+2 0 D
+-1 2 D
+-1 0 D
+P
+FO
+7866 2029 M
+-1 3 D
+-2 0 D
+-1 3 D
+-6 1 D
+-2 4 D
+-2 -1 D
+-8 10 D
+-6 2 D
+-9 6 D
+-5 1 D
+-10 8 D
+0 -2 D
+2 -1 D
+-4 -2 D
+9 -2 D
+19 -14 D
+6 -1 D
+5 -4 D
+8 -13 D
+-1 -9 D
+5 -7 D
+5 6 D
+-1 3 D
+2 3 D
+P
+FO
+7913 1979 M
+5 -2 D
+1 -3 D
+-2 -2 D
+9 -8 D
+4 -1 D
+5 4 D
+0 -2 D
+1 1 D
+-3 10 D
+-5 4 D
+-1 -1 D
+-3 2 D
+-1 3 D
+-5 4 D
+-3 7 D
+-4 0 D
+-4 3 D
+-1 -1 D
+2 -2 D
+-1 0 D
+-1 -5 D
+1 -4 D
+P
+FO
+7970 1937 M
+-2 -4 D
+-2 -1 D
+0 -2 D
+8 1 D
+1 -3 D
+-1 1 D
+0 -2 D
+4 -2 D
+2 -3 D
+-1 2 D
+2 -1 D
+1 3 D
+-3 5 D
+-4 0 D
+-1 6 D
+P
+FO
+7961 1954 M
+2 -2 D
+5 1 D
+2 -2 D
+4 1 D
+-1 2 D
+-3 -1 D
+-5 4 D
+-4 6 D
+-14 7 D
+0 -3 D
+P
+FO
+7866 1910 M
+-5 3 D
+-7 -1 D
+5 -1 D
+0 -2 D
+-1 0 D
+2 -2 D
+0 2 D
+2 -2 D
+3 0 D
+-1 2 D
+P
+FO
+7805 1904 M
+3 -3 D
+-2 -3 D
+9 0 D
+0 -2 D
+2 2 D
+-3 6 D
+-3 -1 D
+-4 3 D
+-2 -1 D
+P
+FO
+8008 1935 M
+21 -11 D
+-3 3 D
+2 2 D
+-10 8 D
+-8 2 D
+-8 8 D
+-8 1 D
+4 -6 D
+P
+FO
+7798 1906 M
+1 -3 D
+4 -2 D
+1 3 D
+-1 4 D
+-3 1 D
+P
+FO
+7902 2005 M
+1 0 D
+1 -8 D
+3 5 D
+-2 5 D
+P
+FO
+7965 1924 M
+5 -4 D
+-2 2 D
+2 5 D
+P
+FO
+7819 1925 M
+3 -2 D
+-2 -3 D
+2 -2 D
+0 9 D
+P
+FO
+7852 1913 M
+1 -2 D
+-1 3 D
+3 0 D
+-2 1 D
+P
+FO
+7961 1935 M
+4 0 D
+0 4 D
+-2 2 D
+-3 -2 D
+P
+FO
+7932 1961 M
+-2 0 D
+-1 -2 D
+4 -1 D
+1 2 D
+P
+FO
+7852 2028 M
+1 -2 D
+1 1 D
+-1 2 D
+P
+FO
+7822 1916 M
+2 1 D
+-2 1 D
+1 -1 D
+P
+FO
+7949 1945 M
+5 -7 D
+2 6 D
+-5 3 D
+P
+FO
+8020 1927 M
+3 -3 D
+2 1 D
+P
+FO
+8010 1913 M
+-1 -1 D
+1 -2 D
+3 3 D
+P
+FO
+7843 2061 M
+-3 1 D
+1 -3 D
+1 0 D
+P
+FO
+7855 2053 M
+3 -3 D
+-1 4 D
+P
+FO
+7819 1900 M
+-1 -1 D
+1 -1 D
+P
+FO
+7971 1920 M
+5 -2 D
+-2 3 D
+P
+FO
+7843 2065 M
+-2 -2 D
+2 0 D
+P
+FO
+7819 2056 M
+-3 1 D
+-3 -2 D
+P
+FO
+7883 2031 M
+-1 0 D
+2 0 D
+P
+FO
+7963 1933 M
+2 -3 D
+0 3 D
+P
+FO
+7988 1918 M
+2 0 D
+-1 3 D
+P
+FO
+7880 2029 M
+1 -1 D
+1 3 D
+P
+FO
+7978 1950 M
+2 -1 D
+-1 2 D
+P
+FO
+7895 2018 M
+-1 3 D
+P
+FO
+7961 1932 M
+3 -3 D
+-1 3 D
+P
+FO
+7988 1950 M
+2 -1 D
+1 2 D
+P
+FO
+7985 1919 M
+2 5 D
+-3 0 D
+P
+FO
+8011 1910 M
+2 0 D
+0 3 D
+P
+FO
+7951 1937 M
+-2 2 D
+2 -6 D
+P
+FO
+7995 1945 M
+1 -1 D
+P
+FO
+7844 2055 M
+0 2 D
+P
+FO
+7940 1962 M
+-1 3 D
+-1 -4 D
+P
+FO
+7972 1951 M
+4 0 D
+P
+FO
+7822 2010 M
+2 0 D
+P
+FO
+7926 1952 M
+2 0 D
+P
+FO
+7817 1923 M
+1 3 D
+P
+FO
+7870 2044 M
+2 -1 D
+P
+FO
+7955 1935 M
+2 -1 D
+P
+FO
+8026 1910 M
+2 0 D
+P
+FO
+7872 2046 M
+2 0 D
+P
+FO
+7808 2063 M
+2 -1 D
+P
+FO
+7905 1996 M
+0 -2 D
+P
+FO
+7810 2062 M
+2 -1 D
+P
+FO
+7949 1941 M
+1 0 D
+P
+FO
+7988 1923 M
+1 -2 D
+P
+FO
+8019 2019 M
+0 -1 D
+P
+FO
+7987 1926 M
+1 -1 D
+P
+FO
+7937 1965 M
+1 1 D
+P
+FO
+7811 2062 M
+2 0 D
+P
+FO
+7972 1930 M
+1 0 D
+P
+FO
+8001 1947 M
+1 -1 D
+P
+FO
+7809 2064 M
+1 -1 D
+P
+FO
+7949 1930 M
+1 1 D
+P
+FO
+7807 2067 M
+1 -1 D
+P
+FO
+7988 1951 M
+2 0 D
+P
+FO
+7979 1932 M
+1 -2 D
+P
+FO
+7892 2023 M
+1 -2 D
+P
+FO
+7839 1907 M
+2 0 D
+P
+FO
+7969 1930 M
+2 0 D
+P
+FO
+7907 2046 M
+0 -2 D
+P
+FO
+7973 1928 M
+1 -1 D
+P
+FO
+7926 1951 M
+1 0 D
+P
+FO
+7986 1919 M
+2 0 D
+P
+FO
+7805 2069 M
+2 -1 D
+P
+FO
+7989 1921 M
+1 -1 D
+P
+FO
+7852 1900 M
+2 0 D
+P
+FO
+8000 1949 M
+1 -1 D
+P
+FO
+7815 1929 M
+1 -1 D
+P
+FO
+7989 1952 M
+1 -1 D
+P
+FO
+7988 1925 M
+1 -2 D
+P
+FO
+8031 1916 M
+2 0 D
+-2 0 D
+P
+FO
+8031 1894 M
+8 0 D
+7 -3 D
+5 2 D
+-1 3 D
+-3 1 D
+-1 3 D
+-6 3 D
+-9 0 D
+P
+FO
+8055 1907 M
+9 -8 D
+0 3 D
+-4 5 D
+1 -1 D
+0 4 D
+-1 0 D
+-2 5 D
+-5 3 D
+2 4 D
+-6 7 D
+-2 1 D
+1 -2 D
+-3 1 D
+4 -5 D
+-2 -1 D
+3 -10 D
+P
+FO
+8035 1913 M
+-2 -1 D
+5 -1 D
+-1 -2 D
+4 1 D
+P
+FO
+8063 1905 M
+5 -10 D
+0 5 D
+P
+FO
+8077 1896 M
+1 -3 D
+0 4 D
+P
+FO
+8033 1913 M
+1 1 D
+-1 1 D
+P
+FO
+8052 1895 M
+0 -1 D
+P
+FO
+8055 1919 M
+1 0 D
+P
+FO
+8195 2113 M
+1 1 D
+-1 0 D
+P
+FO
+8046 1940 M
+1 -1 D
+P
+FO
+8049 1930 M
+2 -1 D
+P
+FO
+8201 1893 M
+0 -1 D
+P
+FO
+8409 2094 M
+0 2 D
+1 -3 D
+P
+FO
+8419 2095 M
+2 -2 D
+P
+FO
+8371 2112 M
+2 -4 D
+P
+FO
+8399 2083 M
+1 -2 D
+P
+FO
+8473 1950 M
+0 -1 D
+P
+FO
+8428 2064 M
+1 -1 D
+P
+FO
+8386 2092 M
+1 0 D
+P
+FO
+8398 2084 M
+1 -1 D
+P
+FO
+8381 2096 M
+0 -1 D
+P
+FO
+8465 1935 M
+1 2 D
+P
+FO
+8378 2099 M
+3 -2 D
+P
+FO
+8501 1904 M
+1 -1 D
+P
+FO
+195 2060 M
+3 -2 D
+P
+FO
+184 2019 M
+1 0 D
+P
+FO
+129 2016 M
+1 -1 D
+P
+FO
+177 1924 M
+1 -1 D
+P
+FO
+207 1906 M
+1 -1 D
+P
+FO
+194 1910 M
+0 -1 D
+P
+FO
+593 2031 M
+-2 0 D
+1 -1 D
+P
+FO
+568 1993 M
+3 0 D
+-2 0 D
+P
+FO
+520 1914 M
+1 0 D
+P
+FO
+520 1912 M
+0 -1 D
+P
+FO
+518 1913 M
+1 -1 D
+P
+FO
+939 1917 M
+1 -3 D
+4 2 D
+1 -1 D
+0 3 D
+P
+FO
+942 1904 M
+2 -1 D
+0 2 D
+P
+FO
+928 1937 M
+0 -1 D
+2 2 D
+P
+FO
+931 1939 M
+1 0 D
+P
+FO
+966 1890 M
+2 1 D
+-1 1 D
+P
+FO
+973 1890 M
+-1 1 D
+P
+FO
+968 1897 M
+-3 -2 D
+0 -1 D
+2 -1 D
+6 3 D
+P
+FO
+954 1915 M
+3 0 D
+-2 2 D
+P
+FO
+2089 2126 M
+-1 0 D
+4 -1 D
+1 -5 D
+8 -9 D
+-6 -1 D
+-5 -5 D
+3 -3 D
+5 -1 D
+8 3 D
+2 4 D
+-5 4 D
+1 4 D
+-6 5 D
+-1 5 D
+P
+FO
+2113 2111 M
+7 -3 D
+2 4 D
+-2 3 D
+-6 -2 D
+P
+FO
+2105 2120 M
+4 -2 D
+4 1 D
+-5 3 D
+P
+FO
+2114 2095 M
+2 -1 D
+2 2 D
+-3 1 D
+P
+FO
+2087 2118 M
+1 -3 D
+5 0 D
+-1 5 D
+-5 -1 D
+P
+FO
+2119 2115 M
+0 1 D
+P
+FO
+2124 2107 M
+1 -1 D
+P
+FO
+2110 2112 M
+1 -1 D
+P
+FO
+2362 2050 M
+0 -4 D
+-4 -1 D
+-3 1 D
+-2 -3 D
+-2 0 D
+-18 -18 D
+-2 -10 D
+5 -4 D
+1 -4 D
+-2 -1 D
+-1 -3 D
+6 -6 D
+2 -7 D
+-2 -2 D
+-3 1 D
+-2 -4 D
+9 -8 D
+18 -10 D
+P
+FO
+2362 2063 M
+-5 -2 D
+-1 -6 D
+3 0 D
+-1 4 D
+4 -1 D
+P
+FO
+2362 2069 M
+-1 -2 D
+1 0 D
+P
+FO
+2359 2126 M
+-9 -9 D
+3 -6 D
+3 -1 D
+-5 1 D
+-3 -7 D
+-5 -1 D
+-2 -2 D
+4 -7 D
+-3 -6 D
+3 -8 D
+-1 -5 D
+-3 -1 D
+-3 0 D
+3 -3 D
+6 -2 D
+9 -8 D
+-1 4 D
+1 -1 D
+2 1 D
+0 1 D
+1 -1 D
+1 4 D
+2 2 D
+0 55 D
+P
+FO
+2357 2047 M
+3 -1 D
+2 4 D
+-2 -4 D
+P
+FO
+2135 2104 M
+4 0 D
+5 5 D
+-3 1 D
+P
+FO
+2360 2058 M
+1 -1 D
+1 1 D
+P
+FO
+2355 2046 M
+2 -1 D
+-1 2 D
+P
+FO
+2341 1974 M
+1 -1 D
+0 2 D
+P
+FO
+2356 2047 M
+2 -2 D
+P
+FO
+2361 2065 M
+1 0 D
+P
+FO
+2360 2068 M
+1 2 D
+P
+FO
+2360 2058 M
+1 -1 D
+P
+FO
+2132 2094 M
+3 -1 D
+P
+FO
+2598 2023 M
+0 4 D
+-4 4 D
+-2 4 D
+-5 -1 D
+-1 -1 D
+0 2 D
+-12 -1 D
+-3 4 D
+-7 0 D
+-6 5 D
+-2 8 D
+-10 -6 D
+-9 2 D
+-10 -3 D
+8 4 D
+-5 2 D
+6 -1 D
+-1 -2 D
+8 -1 D
+12 5 D
+4 -3 D
+0 -6 D
+5 -4 D
+5 1 D
+7 -5 D
+1 2 D
+3 -1 D
+12 1 D
+6 -9 D
+0 99 D
+-236 0 D
+0 -55 D
+1 0 D
+0 3 D
+2 -2 D
+0 2 D
+3 -7 D
+1 1 D
+-5 -17 D
+-2 -1 D
+0 -83 D
+1 0 D
+7 -9 D
+5 -14 D
+11 -12 D
+2 -4 D
+-1 -1 D
+5 -5 D
+-1 -3 D
+5 -9 D
+-1 -1 D
+1 -1 D
+2 1 D
+-1 -2 D
+3 -2 D
+1 -6 D
+3 -4 D
+1 -5 D
+193 0 D
+P
+FO
+2362 2067 M
+1 0 D
+1 -2 D
+1 7 D
+-3 -3 D
+P
+FO
+2362 2059 M
+3 2 D
+-3 2 D
+P
+FO
+2367 2065 M
+1 -1 D
+0 2 D
+P
+FO
+2365 2063 M
+1 0 D
+0 5 D
+P
+FO
+2362 2064 M
+2 0 D
+P
+FO
+2366 2068 M
+1 -2 D
+P
+FO
+2364 2073 M
+0 -1 D
+P
+FO
+-1 -2 -2 1 2 2591 2035 SP
+1 0 1 2531 2046 SP
+-1 1 1 2535 2046 SP
+2835 2048 M
+-4 -1 D
+-12 0 D
+-5 -7 D
+-12 0 D
+-10 -8 D
+-4 0 D
+-10 7 D
+1 -4 D
+-9 -1 D
+-8 -5 D
+-6 0 D
+-1 -5 D
+-4 -4 D
+4 6 D
+-1 2 D
+-6 -2 D
+4 3 D
+-3 0 D
+11 2 D
+0 2 D
+-19 3 D
+-17 11 D
+-2 -5 D
+-1 4 D
+2 2 D
+-13 13 D
+-17 6 D
+-4 0 D
+-1 -2 D
+-2 -1 D
+-7 2 D
+-9 -5 D
+-9 5 D
+-1 -3 D
+-8 -3 D
+-4 -4 D
+0 -10 D
+-6 -2 D
+-26 1 D
+-3 -4 D
+1 -2 D
+-6 -6 D
+5 -3 D
+-6 -6 D
+-6 -2 D
+-3 1 D
+0 -133 D
+237 0 D
+P
+2783 2021 M
+3 1 D
+-1 -2 D
+-4 0 D
+P
+FO
+2835 2051 M
+-14 3 D
+-11 13 D
+-1 5 D
+-4 6 D
+-6 4 D
+1 3 D
+-4 6 D
+-9 2 D
+-17 7 D
+-6 5 D
+-1 3 D
+-11 5 D
+-7 5 D
+-9 0 D
+-12 -4 D
+-3 1 D
+-3 -2 D
+-3 3 D
+-4 -1 D
+-8 4 D
+-7 1 D
+-2 -2 D
+-7 0 D
+-2 -2 D
+2 3 D
+6 -1 D
+3 2 D
+24 -4 D
+19 4 D
+8 -1 D
+8 -6 D
+9 -2 D
+4 -6 D
+10 -5 D
+10 -3 D
+3 -4 D
+2 1 D
+4 -2 D
+5 -10 D
+6 -6 D
+3 -6 D
+9 -8 D
+3 -6 D
+4 -2 D
+4 0 D
+4 -3 D
+0 75 D
+-237 0 D
+0 -99 D
+5 -3 D
+10 6 D
+-6 3 D
+9 12 D
+17 -1 D
+3 2 D
+2 -2 D
+9 2 D
+1 3 D
+-3 3 D
+6 7 D
+10 7 D
+10 -4 D
+4 2 D
+2 4 D
+4 0 D
+6 -3 D
+3 4 D
+11 -4 D
+6 4 D
+2 -3 D
+-2 -4 D
+4 0 D
+5 -6 D
+11 -9 D
+4 -5 D
+10 -4 D
+1 -2 D
+5 -1 D
+5 1 D
+8 -3 D
+2 -3 D
+4 3 D
+9 2 D
+3 4 D
+11 -6 D
+6 2 D
+7 6 D
+10 0 D
+6 7 D
+-4 -2 D
+0 2 D
+4 1 D
+-3 2 D
+6 -3 D
+10 0 D
+4 2 D
+P
+2771 2046 M
+-3 4 D
+-3 -2 D
+-2 3 D
+3 -2 D
+2 2 D
+6 -5 D
+P
+2760 2040 M
+-7 3 D
+-1 3 D
+8 -5 D
+4 1 D
+P
+2804 2055 M
+-4 -2 D
+-4 1 D
+P
+FO
+2598 2025 M
+1 1 D
+-1 1 D
+P
+FO
+-1 -1 -2 1 2 1 3 2718 2114 SP
+-2 -1 -3 1 2 2742 2119 SP
+2 -2 -3 -3 -1 2 3 2707 2066 SP
+-3 0 0 1 2 2775 2100 SP
+-2 2 2 0 2 2600 2023 SP
+2 -3 -2 2 2 2819 2060 SP
+-2 2 1 0 2 2770 2103 SP
+0 2 1 2810 2068 SP
+-2 3 1 2814 2065 SP
+-3 1 1 2733 2117 SP
+4 -1 -5 1 2 2779 2098 SP
+-2 1 1 2780 2097 SP
+0 2 1 2766 2105 SP
+1 0 2 -2 2 2724 2048 SP
+-2 1 1 2784 2097 SP
+-1 1 1 2768 2103 SP
+3071 2083 M
+-4 -1 D
+0 -2 D
+-2 1 D
+-3 -1 D
+-3 0 D
+-6 5 D
+2 -1 D
+0 3 D
+-3 5 D
+-1 5 D
+-3 2 D
+3 2 D
+0 3 D
+-4 0 D
+0 -3 D
+-28 -15 D
+-2 0 D
+0 4 D
+-10 -2 D
+11 6 D
+6 -1 D
+2 6 D
+5 4 D
+0 5 D
+11 16 D
+-2 0 D
+6 2 D
+-211 0 D
+0 -75 D
+7 3 D
+21 -6 D
+7 4 D
+6 -1 D
+3 7 D
+8 4 D
+5 7 D
+3 1 D
+3 -3 D
+15 -2 D
+4 3 D
+3 4 D
+5 3 D
+3 5 D
+11 1 D
+10 -6 D
+7 4 D
+8 -3 D
+-3 -6 D
+1 -2 D
+12 4 D
+1 5 D
+2 2 D
+21 6 D
+5 4 D
+4 0 D
+-8 -5 D
+-17 -4 D
+-3 -2 D
+-5 -8 D
+-10 -2 D
+-7 1 D
+-4 -2 D
+-4 -16 D
+-6 -11 D
+2 8 D
+3 5 D
+-1 4 D
+5 14 D
+-4 -1 D
+-1 -3 D
+1 3 D
+7 3 D
+0 -3 D
+2 3 D
+-2 2 D
+-11 -3 D
+-6 1 D
+6 1 D
+-7 0 D
+1 1 D
+-2 0 D
+0 1 D
+14 -2 D
+-12 7 D
+-11 -5 D
+-10 -10 D
+-4 -2 D
+-8 2 D
+-4 -2 D
+-5 5 D
+-3 0 D
+-6 -8 D
+-7 -3 D
+-3 -8 D
+-7 1 D
+-3 -5 D
+-5 0 D
+-4 3 D
+-3 -1 D
+-8 4 D
+-1 -2 D
+-2 2 D
+-4 -1 D
+3 2 D
+-3 0 D
+-3 -1 D
+1 -2 D
+-3 -2 D
+0 -158 D
+236 0 D
+P
+3038 2071 M
+-2 2 D
+-1 5 D
+2 5 D
+-4 1 D
+4 0 D
+2 3 D
+2 -2 D
+4 0 D
+-1 -2 D
+8 -2 D
+3 2 D
+0 -4 D
+-1 2 D
+-3 -1 D
+2 -6 D
+-4 5 D
+-2 -9 D
+4 -3 D
+-2 0 D
+-3 7 D
+1 4 D
+-7 6 D
+-4 -7 D
+P
+3044 2083 M
+2 -4 D
+5 0 D
+-1 2 D
+P
+3018 2086 M
+2 -11 D
+5 -9 D
+0 -3 D
+-2 -2 D
+3 -2 D
+1 -5 D
+-5 5 D
+1 6 D
+-6 10 D
+-1 5 D
+1 3 D
+-2 3 D
+1 2 D
+1 -2 D
+P
+3024 2061 M
+2 -3 D
+P
+2928 2089 M
+-6 0 D
+-1 2 D
+-5 2 D
+2 1 D
+-5 1 D
+6 -1 D
+5 -4 D
+5 2 D
+3 -8 D
+P
+2952 2079 M
+-3 0 D
+0 2 D
+5 0 D
+-3 -3 D
+-4 0 D
+P
+2968 2071 M
+1 2 D
+-3 1 D
+1 1 D
+6 -2 D
+P
+2912 2062 M
+0 -4 D
+-1 1 D
+-1 -3 D
+P
+2902 2056 M
+1 3 D
+5 1 D
+P
+FO
+3071 2122 M
+-8 2 D
+-2 -2 D
+1 -2 D
+-2 2 D
+-5 -3 D
+-1 -2 D
+2 -2 D
+-2 -1 D
+3 0 D
+-2 -1 D
+3 -1 D
+-1 -3 D
+-2 2 D
+0 -3 D
+-3 1 D
+1 -8 D
+7 0 D
+-4 -2 D
+2 -1 D
+-6 2 D
+0 -8 D
+6 -7 D
+-1 -1 D
+5 -1 D
+9 2 D
+P
+FO
+3070 2126 M
+1 -1 D
+0 1 D
+P
+FO
+3059 2126 M
+2 0 D
+P
+FO
+3056 2126 M
+2 -1 D
+P
+FO
+3054 2126 M
+-7 -2 D
+-1 -4 D
+4 -1 D
+6 4 D
+-1 3 D
+P
+FO
+3049 2126 M
+-1 -1 D
+3 1 D
+P
+FO
+2835 2050 M
+2 1 D
+-2 0 D
+P
+FO
+3031 2102 M
+0 -2 D
+-5 -4 D
+-1 -4 D
+1 -1 D
+8 4 D
+5 7 D
+2 0 D
+3 9 D
+-4 3 D
+-2 -3 D
+1 2 D
+-3 -1 D
+-5 -6 D
+P
+FO
+3047 2119 M
+-1 1 D
+-2 -3 D
+0 -4 D
+4 5 D
+P
+FO
+3049 2105 M
+-2 0 D
+-4 -4 D
+3 1 D
+1 2 D
+P
+FO
+3037 2115 M
+6 3 D
+1 4 D
+-2 0 D
+P
+FO
+3047 2112 M
+4 3 D
+0 2 D
+-2 0 D
+P
+FO
+3047 2116 M
+-2 -3 D
+2 0 D
+2 4 D
+P
+FO
+3052 2110 M
+2 0 D
+-1 3 D
+P
+FO
+3054 2113 M
+1 -2 D
+2 1 D
+P
+FO
+3051 2112 M
+-5 -2 D
+-1 -3 D
+6 2 D
+P
+FO
+3045 2111 M
+1 0 D
+1 2 D
+P
+FO
+3041 2114 M
+3 0 D
+0 2 D
+P
+FO
+3041 2115 M
+1 0 D
+-3 -1 D
+P
+FO
+3043 2107 M
+1 0 D
+0 2 D
+P
+FO
+3043 2105 M
+-5 -8 D
+3 2 D
+P
+FO
+3018 2091 M
+0 -2 D
+4 -1 D
+4 2 D
+P
+FO
+3053 2114 M
+2 0 D
+-1 2 D
+P
+FO
+3019 2094 M
+-6 -4 D
+7 2 D
+P
+FO
+3049 2118 M
+3 0 D
+1 3 D
+P
+FO
+3042 2105 M
+1 2 D
+P
+FO
+3044 2123 M
+1 0 D
+P
+FO
+3051 2108 M
+-3 -2 D
+3 1 D
+P
+FO
+3051 2100 M
+-1 -1 D
+2 -2 D
+P
+FO
+3057 2083 M
+2 -2 D
+2 1 D
+P
+FO
+3047 2120 M
+2 -1 D
+P
+FO
+3046 2106 M
+-2 -1 D
+3 1 D
+P
+FO
+3059 2123 M
+3 0 D
+P
+FO
+3023 2091 M
+-2 -1 D
+4 1 D
+P
+FO
+3043 2112 M
+0 2 D
+P
+FO
+3037 2114 M
+2 1 D
+P
+FO
+3043 2112 M
+2 1 D
+P
+FO
+3042 2117 M
+2 1 D
+P
+FO
+3056 2125 M
+2 0 D
+P
+FO
+3061 2124 M
+1 1 D
+P
+FO
+3039 2118 M
+1 2 D
+P
+FO
+3044 2120 M
+1 1 D
+P
+FO
+3042 2124 M
+2 0 D
+P
+FO
+3051 2107 M
+0 1 D
+P
+FO
+3066 2084 M
+0 -1 D
+P
+FO
+3032 2107 M
+0 2 D
+P
+FO
+3031 2108 M
+1 1 D
+P
+FO
+3055 2125 M
+1 -1 D
+P
+FO
+3034 2111 M
+2 1 D
+-2 0 D
+P
+FO
+-2 -1 -4 2 2 6 1 -1 4 2960 2070 SP
+-3 -4 -3 2 1 1 3 2957 2076 SP
+-3 -1 -1 1 1 1 3 2930 2077 SP
+-5 1 3 1 2 2901 2065 SP
+-4 -2 2 2 2 2866 2047 SP
+-2 -2 1 3005 2089 SP
+3 0 1 2990 2083 SP
+-2 -1 1 2999 2086 SP
+FQ
+2 0 0 1 2 2960 2072 SP
+2 -2 0 3 2 2959 2073 SP
+-1 0 1 2962 2075 SP
+3307 2059 M
+-12 1 D
+-8 -2 D
+1 -1 D
+-1 1 D
+-5 -1 D
+-5 1 D
+-1 -1 D
+1 0 D
+-1 -1 D
+-2 2 D
+-7 0 D
+-4 3 D
+1 1 D
+-5 0 D
+2 -3 D
+-2 0 D
+0 2 D
+-5 -3 D
+-1 3 D
+-5 0 D
+-5 5 D
+1 -3 D
+-1 -1 D
+-1 3 D
+-16 6 D
+-1 -1 D
+3 -2 D
+-3 1 D
+2 -3 D
+-2 -1 D
+-1 4 D
+-3 -4 D
+0 2 D
+-2 -2 D
+0 2 D
+-3 -2 D
+-2 1 D
+0 -3 D
+-3 -1 D
+0 -6 D
+-1 5 D
+-3 -5 D
+-1 3 D
+0 -1 D
+-1 2 D
+-1 -2 D
+0 3 D
+-2 -6 D
+-5 -5 D
+-2 0 D
+0 -2 D
+-2 -1 D
+0 2 D
+2 -1 D
+-2 3 D
+3 0 D
+2 3 D
+-2 1 D
+2 6 D
+-2 0 D
+2 1 D
+2 4 D
+-5 -2 D
+5 2 D
+1 3 D
+-1 0 D
+3 0 D
+1 2 D
+-1 3 D
+-2 1 D
+-2 -1 D
+2 -1 D
+-4 -2 D
+1 -3 D
+-1 2 D
+-3 -1 D
+2 1 D
+-1 2 D
+-6 -4 D
+6 5 D
+1 -1 D
+0 1 D
+1 0 D
+4 5 D
+-2 0 D
+2 1 D
+-1 2 D
+-2 -1 D
+2 3 D
+-3 -1 D
+2 2 D
+-3 -3 D
+3 4 D
+-2 0 D
+-1 -2 D
+-2 0 D
+2 2 D
+-2 0 D
+-1 3 D
+0 -2 D
+-1 2 D
+-2 0 D
+3 5 D
+-3 -2 D
+0 -2 D
+-2 -1 D
+2 2 D
+-3 2 D
+0 -2 D
+-2 1 D
+-2 -2 D
+1 -3 D
+1 0 D
+-3 0 D
+1 -4 D
+-1 3 D
+-2 0 D
+1 4 D
+-2 0 D
+3 3 D
+-1 3 D
+-3 -5 D
+-1 0 D
+2 5 D
+-3 -3 D
+1 3 D
+-1 -1 D
+-1 2 D
+-2 -4 D
+-2 5 D
+2 2 D
+-2 0 D
+0 -3 D
+-2 0 D
+1 2 D
+-1 -2 D
+-1 4 D
+-2 -3 D
+0 4 D
+-4 -6 D
+2 7 D
+-3 -3 D
+0 4 D
+-2 -6 D
+2 8 D
+-3 -3 D
+1 -1 D
+-1 1 D
+-1 -2 D
+-1 3 D
+0 -2 D
+-2 0 D
+0 1 D
+-4 0 D
+1 2 D
+-4 -1 D
+3 1 D
+1 2 D
+-3 1 D
+0 -3 D
+-1 2 D
+-1 -2 D
+-1 5 D
+-3 -5 D
+1 5 D
+-1 -3 D
+-2 0 D
+0 4 D
+-2 -3 D
+-1 1 D
+1 2 D
+-2 -1 D
+1 2 D
+-2 -1 D
+0 2 D
+-3 -2 D
+0 2 D
+-1 0 D
+2 -6 D
+-1 2 D
+-2 -1 D
+-1 4 D
+-1 -3 D
+-1 1 D
+-2 -2 D
+2 3 D
+-1 2 D
+-2 -2 D
+-2 2 D
+0 -4 D
+-2 3 D
+-1 -3 D
+0 2 D
+-1 -2 D
+-1 2 D
+-3 -3 D
+1 -2 D
+-2 1 D
+-2 -2 D
+1 -4 D
+-2 -5 D
+-1 2 D
+-2 -1 D
+-1 -5 D
+6 1 D
+5 -3 D
+-5 2 D
+-6 -1 D
+3 -4 D
+-1 0 D
+-4 5 D
+-1 -1 D
+0 3 D
+-8 -12 D
+-4 1 D
+0 -2 D
+-1 1 D
+-8 -17 D
+-4 -1 D
+4 3 D
+0 6 D
+3 9 D
+3 2 D
+0 2 D
+-2 0 D
+0 -2 D
+-4 1 D
+-3 -4 D
+-5 1 D
+0 -3 D
+0 3 D
+-3 2 D
+0 -193 D
+236 0 D
+P
+3078 2063 M
+3 -14 D
+-3 -13 D
+1 17 D
+-3 8 D
+P
+3079 2056 M
+0 -1 D
+P
+3079 2052 M
+1 -7 D
+P
+3077 2061 M
+2 -6 D
+-1 6 D
+P
+3078 2062 M
+0 -1 D
+P
+3294 2023 M
+2 3 D
+3 -5 D
+-2 2 D
+-1 -1 D
+P
+3197 2035 M
+-1 2 D
+2 -2 D
+P
+{0.565 0.933 0.565 C} FS
+FO
+3078 2126 M
+-3 -2 D
+8 -1 D
+3 3 D
+P
+FO
+3071 2125 M
+2 1 D
+-2 0 D
+P
+FO
+3071 2085 M
+4 -2 D
+2 1 D
+0 4 D
+1 -4 D
+4 1 D
+0 5 D
+1 -1 D
+2 1 D
+1 -2 D
+0 2 D
+2 -2 D
+0 3 D
+1 -3 D
+3 1 D
+-1 4 D
+2 -4 D
+5 3 D
+-2 2 D
+-1 -1 D
+1 2 D
+-1 1 D
+1 -1 D
+2 1 D
+-2 3 D
+3 -2 D
+4 4 D
+0 3 D
+3 1 D
+-1 4 D
+2 0 D
+2 10 D
+-2 2 D
+-10 -1 D
+-7 3 D
+-5 -2 D
+0 -1 D
+-14 2 D
+P
+3092 2114 M
+-1 -7 D
+-1 6 D
+P
+3090 2121 M
+0 -2 D
+P
+3094 2119 M
+-2 0 D
+2 1 D
+P
+FO
+3204 2065 M
+1 -2 D
+-1 -2 D
+4 1 D
+-1 1 D
+2 0 D
+3 4 D
+-1 -1 D
+-1 3 D
+-5 -2 D
+1 -2 D
+P
+FO
+3094 2084 M
+2 0 D
+1 5 D
+-6 -7 D
+3 0 D
+-1 2 D
+P
+FO
+3194 2088 M
+0 -2 D
+3 1 D
+-1 2 D
+0 -1 D
+-1 1 D
+P
+FO
+3200 2055 M
+1 1 D
+-1 1 D
+1 3 D
+-2 -6 D
+P
+FO
+3154 2103 M
+0 2 D
+-1 -2 D
+-1 2 D
+0 -3 D
+P
+FO
+3172 2094 M
+2 0 D
+0 6 D
+P
+FO
+3256 2062 M
+3 -1 D
+P
+FO
+3216 2067 M
+1 -1 D
+0 2 D
+P
+FO
+3104 2092 M
+2 -2 D
+-1 4 D
+P
+FO
+3120 2112 M
+2 -2 D
+-1 3 D
+P
+FO
+3218 2069 M
+3 0 D
+0 2 D
+P
+FO
+3199 2055 M
+-1 2 D
+P
+FO
+3107 2098 M
+2 -1 D
+1 4 D
+-3 -2 D
+P
+FO
+3222 2070 M
+1 -1 D
+1 1 D
+P
+FO
+3096 2095 M
+3 -3 D
+0 4 D
+P
+FO
+3182 2087 M
+0 -1 D
+1 1 D
+P
+FO
+3189 2096 M
+0 -3 D
+3 2 D
+P
+FO
+3124 2112 M
+1 -1 D
+0 2 D
+-1 0 D
+P
+FO
+3149 2107 M
+2 -1 D
+P
+FO
+3217 2068 M
+1 0 D
+P
+FO
+3175 2097 M
+1 0 D
+P
+FO
+3210 2069 M
+2 -1 D
+P
+FO
+3196 2071 M
+1 1 D
+P
+FO
+3083 2084 M
+2 0 D
+P
+FO
+3107 2096 M
+1 1 D
+P
+FO
+3088 2087 M
+2 1 D
+P
+FO
+3186 2091 M
+1 3 D
+P
+FO
+3189 2094 M
+0 -1 D
+P
+FO
+3078 2082 M
+2 1 D
+P
+FO
+3216 2069 M
+1 1 D
+P
+FO
+3085 2087 M
+1 0 D
+P
+FO
+3087 2080 M
+1 1 D
+P
+FO
+3224 2069 M
+0 1 D
+P
+FO
+3083 2087 M
+1 -1 D
+P
+FO
+3105 2097 M
+1 0 D
+P
+FO
+3086 2079 M
+1 1 D
+P
+FO
+3217 2069 M
+1 1 D
+P
+FO
+3157 2104 M
+1 -2 D
+P
+FO
+3081 2084 M
+1 0 D
+P
+FO
+3222 2067 M
+1 1 D
+P
+FO
+3122 2112 M
+1 1 D
+P
+FO
+3083 2088 M
+3 0 D
+P
+FO
+3218 2070 M
+4 3 D
+-4 -2 D
+P
+FO
+3253 2062 M
+4 -1 D
+P
+FO
+3181 2086 M
+1 2 D
+P
+FO
+3082 2086 M
+1 -1 D
+P
+FO
+3079 2083 M
+3 1 D
+P
+FO
+3200 2066 M
+1 3 D
+P
+FO
+3180 2090 M
+2 1 D
+P
+FO
+3099 2096 M
+1 2 D
+P
+FO
+3168 2100 M
+1 1 D
+P
+FO
+3096 2121 M
+1 1 D
+P
+FO
+3207 2060 M
+1 -1 D
+P
+FO
+3104 2093 M
+1 2 D
+-1 0 D
+P
+FO
+3255 2060 M
+3 0 D
+P
+FO
+3203 2060 M
+1 3 D
+P
+FO
+3206 2060 M
+2 -1 D
+P
+FO
+3077 2081 M
+2 0 D
+P
+FO
+3128 2112 M
+1 -1 D
+P
+FO
+3105 2089 M
+2 -1 D
+P
+FO
+3194 2090 M
+1 1 D
+P
+FO
+3224 2067 M
+1 -1 D
+P
+FO
+3076 2082 M
+1 0 D
+P
+FO
+3191 2094 M
+1 1 D
+P
+FO
+3105 2094 M
+1 -1 D
+P
+FO
+3187 2092 M
+0 2 D
+P
+FO
+3124 2113 M
+1 0 D
+P
+FO
+3188 2094 M
+0 -1 D
+P
+FO
+3075 2081 M
+2 0 D
+P
+FO
+3108 2091 M
+1 0 D
+P
+FO
+3084 2074 M
+1 1 D
+P
+FO
+3401 1890 M
+3 3 D
+-2 1 D
+2 -1 D
+2 3 D
+-2 0 D
+-1 3 D
+2 -3 D
+2 1 D
+-1 2 D
+2 -1 D
+-1 -1 D
+1 0 D
+5 6 D
+0 2 D
+0 -2 D
+4 4 D
+10 22 D
+2 10 D
+-2 4 D
+3 3 D
+-2 2 D
+2 1 D
+-1 12 D
+-2 -3 D
+2 5 D
+-2 0 D
+0 3 D
+-1 0 D
+1 2 D
+-2 7 D
+-2 1 D
+1 3 D
+-1 1 D
+-1 -1 D
+1 4 D
+-2 7 D
+-2 -1 D
+2 2 D
+-6 12 D
+-13 4 D
+-8 -1 D
+2 -1 D
+-11 1 D
+-6 4 D
+-5 -2 D
+-4 7 D
+-6 2 D
+-4 4 D
+-1 -1 D
+1 2 D
+-10 8 D
+-1 -1 D
+1 1 D
+-7 9 D
+-4 -1 D
+-8 8 D
+-2 -1 D
+-4 5 D
+-18 9 D
+0 -169 D
+P
+3332 1979 M
+0 -2 D
+-1 1 D
+-2 -2 D
+1 2 D
+-2 0 D
+-2 -3 D
+0 2 D
+-2 0 D
+3 0 D
+-1 1 D
+3 1 D
+-1 2 D
+2 0 D
+-1 -3 D
+3 2 D
+P
+3357 1958 M
+-5 0 D
+4 2 D
+3 -2 D
+P
+FO
+3428 1942 M
+1 0 D
+0 2 D
+P
+FO
+3485 2034 M
+2 1 D
+P
+FO
+3911 1938 M
+1 -1 D
+2 1 D
+-2 2 D
+P
+FO
+4567 1890 M
+5 -7 D
+0 -2 D
+6 -7 D
+-2 -2 D
+3 -6 D
+-2 -13 D
+1 -5 D
+-3 -11 D
+-6 -8 D
+-5 -1 D
+-6 -5 D
+1 -4 D
+-11 -10 D
+0 -10 D
+-3 -1 D
+-1 -4 D
+1 -5 D
+-3 -12 D
+-4 -8 D
+1 -2 D
+-2 -1 D
+-4 -13 D
+-4 -1 D
+2 -15 D
+-2 -24 D
+3 -16 D
+3 -3 D
+1 -5 D
+7 -5 D
+6 -9 D
+10 -21 D
+165 0 D
+0 236 D
+P
+FO
+4528 1735 M
+2 -6 D
+-1 7 D
+P
+FO
+4961 1864 M
+-1 -1 D
+0 1 D
+-2 -1 D
+1 -4 D
+-3 -3 D
+-5 0 D
+-1 3 D
+4 6 D
+-4 -5 D
+-1 1 D
+5 7 D
+1 0 D
+-1 -2 D
+2 2 D
+-2 -3 D
+5 4 D
+2 -2 D
+0 23 D
+-237 0 D
+0 -236 D
+237 0 D
+P
+4890 1701 M
+4 7 D
+5 4 D
+0 2 D
+-2 0 D
+8 9 D
+2 0 D
+-2 1 D
+2 1 D
+-1 1 D
+4 1 D
+-1 1 D
+6 0 D
+0 2 D
+3 2 D
+-1 1 D
+4 1 D
+-1 1 D
+3 -1 D
+6 3 D
+8 -3 D
+-2 -3 D
+-2 1 D
+1 -2 D
+-2 -1 D
+-2 1 D
+0 2 D
+-4 -1 D
+-2 -2 D
+1 -2 D
+-3 3 D
+-6 -2 D
+-2 -3 D
+2 0 D
+-2 -3 D
+-2 2 D
+-2 -4 D
+-4 0 D
+-3 -7 D
+-5 -2 D
+-6 -10 D
+P
+4903 1716 M
+1 0 D
+P
+4890 1871 M
+3 -1 D
+2 1 D
+-3 -3 D
+-1 -3 D
+-2 3 D
+2 1 D
+P
+4953 1849 M
+1 1 D
+-1 -3 D
+-1 2 D
+3 5 D
+P
+4940 1790 M
+-1 3 D
+P
+4896 1889 M
+0 -1 D
+P
+4918 1727 M
+1 1 D
+P
+FO
+-2 -1 1 4958 1865 SP
+5073 1654 M
+-1 2 D
+2 1 D
+-4 5 D
+6 -5 D
+11 8 D
+12 13 D
+4 2 D
+-1 -1 D
+7 1 D
+0 2 D
+1 -2 D
+4 7 D
+-2 1 D
+2 0 D
+0 1 D
+8 7 D
+-2 0 D
+3 0 D
+2 3 D
+-2 5 D
+3 -4 D
+4 8 D
+1 -1 D
+5 4 D
+14 7 D
+2 -1 D
+-1 3 D
+2 0 D
+0 -2 D
+10 5 D
+0 -1 D
+3 0 D
+0 2 D
+0 -1 D
+9 1 D
+1 4 D
+3 1 D
+-1 1 D
+1 1 D
+1 -1 D
+13 8 D
+-1 -1 D
+1 1 D
+-2 3 D
+1 0 D
+-1 1 D
+2 0 D
+1 2 D
+1 -2 D
+2 1 D
+0 144 D
+-1 -2 D
+-3 5 D
+-2 0 D
+-1 -1 D
+0 1 D
+-123 0 D
+2 -14 D
+2 -4 D
+-1 -8 D
+3 -6 D
+3 0 D
+2 -3 D
+0 -8 D
+-2 -5 D
+-4 -4 D
+-1 -6 D
+4 -6 D
+-2 -6 D
+1 -9 D
+2 -1 D
+-1 -7 D
+5 -2 D
+6 -14 D
+-2 -1 D
+-8 9 D
+-2 -6 D
+-2 0 D
+-4 4 D
+-1 3 D
+3 6 D
+-7 7 D
+0 12 D
+-3 6 D
+-1 6 D
+-4 4 D
+1 4 D
+7 10 D
+-3 10 D
+1 6 D
+-2 9 D
+2 4 D
+-6 7 D
+0 3 D
+-94 0 D
+1 -24 D
+-1 -212 D
+P
+4979 1756 M
+28 1 D
+11 2 D
+6 -1 D
+-6 0 D
+-2 -2 D
+-5 0 D
+-2 -2 D
+-15 1 D
+-5 -3 D
+P
+5096 1760 M
+-4 3 D
+2 0 D
+0 3 D
+3 2 D
+2 -5 D
+-1 -3 D
+P
+5059 1733 M
+16 -8 D
+7 -15 D
+5 -3 D
+4 -6 D
+-10 10 D
+-6 14 D
+-16 7 D
+P
+5085 1783 M
+2 -2 D
+-2 -4 D
+-2 2 D
+P
+5034 1672 M
+-3 1 D
+2 4 D
+2 -2 D
+P
+5101 1787 M
+1 -2 D
+-1 0 D
+-1 -3 D
+P
+5062 1816 M
+1 -1 D
+P
+5081 1736 M
+0 2 D
+1 -2 D
+P
+4971 1855 M
+-1 -1 D
+0 1 D
+P
+5099 1780 M
+0 -3 D
+P
+4975 1855 M
+-2 0 D
+P
+FO
+5192 1740 M
+2 -2 D
+1 3 D
+P
+FO
+5073 1659 M
+0 -1 D
+P
+FO
+0 -2 1 5072 1842 SP
+5404 1654 M
+-1 0 D
+3 1 D
+0 7 D
+6 15 D
+-1 2 D
+1 -1 D
+8 19 D
+-1 2 D
+3 9 D
+-3 8 D
+4 11 D
+6 1 D
+-3 2 D
+3 5 D
+1 8 D
+-4 2 D
+1 5 D
+-3 9 D
+2 2 D
+5 0 D
+2 -8 D
+0 58 D
+-2 3 D
+0 4 D
+-4 7 D
+-2 -2 D
+-1 3 D
+-2 1 D
+1 5 D
+-2 0 D
+1 2 D
+-2 -1 D
+-2 4 D
+-1 -2 D
+-3 0 D
+2 1 D
+-1 3 D
+3 -2 D
+-2 7 D
+-3 -2 D
+2 -2 D
+-2 1 D
+-2 -1 D
+3 -1 D
+-5 -5 D
+-1 -3 D
+-4 2 D
+-1 -1 D
+2 -3 D
+2 1 D
+-1 -3 D
+3 -6 D
+-4 -5 D
+0 -6 D
+-4 -2 D
+-4 2 D
+1 -4 D
+-4 0 D
+0 -5 D
+-2 -1 D
+-2 1 D
+-1 4 D
+-1 -1 D
+-1 3 D
+-1 -2 D
+-1 2 D
+0 -3 D
+-2 1 D
+0 -3 D
+1 0 D
+-1 -4 D
+4 -2 D
+-3 -1 D
+3 -1 D
+-1 -4 D
+1 -1 D
+-2 -3 D
+1 6 D
+-2 1 D
+0 -4 D
+-4 0 D
+-2 -4 D
+3 -4 D
+-7 -11 D
+-2 -1 D
+2 7 D
+-1 3 D
+-4 -4 D
+2 0 D
+0 -1 D
+-8 -7 D
+3 -5 D
+2 0 D
+-3 -1 D
+-2 -3 D
+-1 2 D
+-2 -3 D
+4 7 D
+-3 3 D
+-7 -5 D
+1 -1 D
+-2 1 D
+-3 -3 D
+0 1 D
+-4 -4 D
+0 -2 D
+2 0 D
+-2 -2 D
+3 -1 D
+1 -3 D
+-4 1 D
+-2 3 D
+0 3 D
+-5 -2 D
+2 0 D
+-1 -2 D
+-4 3 D
+-3 -2 D
+-2 1 D
+-2 -1 D
+0 -6 D
+-1 3 D
+-5 -1 D
+2 -1 D
+-3 -2 D
+-1 5 D
+-8 -6 D
+2 0 D
+-13 0 D
+0 -13 D
+-12 -18 D
+2 -6 D
+0 -16 D
+5 -7 D
+0 -8 D
+6 -13 D
+-1 1 D
+-2 -5 D
+1 -2 D
+2 1 D
+0 -4 D
+P
+5397 1709 M
+0 3 D
+3 5 D
+1 -2 D
+P
+5336 1744 M
+-3 1 D
+2 1 D
+P
+5357 1675 M
+0 1 D
+2 0 D
+P
+5414 1686 M
+1 1 D
+P
+FO
+5433 1731 M
+-4 -9 D
+P
+FO
+5197 1743 M
+3 6 D
+-2 -1 D
+10 10 D
+-2 0 D
+3 1 D
+4 6 D
+-1 -1 D
+0 3 D
+-3 0 D
+0 2 D
+5 1 D
+-2 3 D
+3 -1 D
+-3 3 D
+1 1 D
+0 -2 D
+4 2 D
+0 7 D
+-2 -1 D
+2 1 D
+-1 3 D
+-3 -1 D
+-1 -3 D
+0 6 D
+1 -2 D
+1 5 D
+-3 -2 D
+-2 2 D
+2 1 D
+1 3 D
+-2 8 D
+1 3 D
+-3 1 D
+1 0 D
+2 3 D
+-1 3 D
+1 7 D
+-3 0 D
+0 -3 D
+-2 4 D
+2 1 D
+1 -1 D
+1 3 D
+1 -1 D
+1 2 D
+-2 1 D
+0 3 D
+2 -2 D
+-2 3 D
+-2 1 D
+2 2 D
+-1 0 D
+-1 3 D
+2 7 D
+-3 7 D
+1 7 D
+-3 2 D
+4 2 D
+1 4 D
+-2 2 D
+3 3 D
+-3 2 D
+0 -2 D
+-1 1 D
+5 3 D
+-5 3 D
+2 0 D
+0 1 D
+-3 0 D
+1 3 D
+-2 0 D
+-3 4 D
+0 -2 D
+-3 0 D
+1 2 D
+-3 2 D
+P
+FO
+5316 1825 M
+2 -4 D
+-1 0 D
+0 -1 D
+3 -1 D
+1 6 D
+-4 2 D
+P
+FO
+5273 1849 M
+1 -3 D
+4 -2 D
+2 1 D
+-3 6 D
+0 6 D
+-3 -1 D
+P
+FO
+5390 1813 M
+1 -4 D
+3 0 D
+-1 5 D
+-1 -2 D
+P
+FO
+5296 1839 M
+8 -5 D
+-1 7 D
+-3 -3 D
+P
+FO
+5282 1836 M
+1 -2 D
+5 -1 D
+-3 3 D
+P
+FO
+5210 1834 M
+1 -1 D
+1 2 D
+P
+FO
+5376 1782 M
+1 0 D
+-1 1 D
+P
+FO
+5399 1822 M
+1 -2 D
+1 3 D
+P
+FO
+5214 1866 M
+-3 0 D
+P
+FO
+5210 1838 M
+1 -1 D
+P
+FO
+5393 1808 M
+2 0 D
+P
+FO
+5381 1795 M
+1 -1 D
+P
+FO
+5397 1812 M
+1 -2 D
+P
+FO
+5260 1723 M
+2 0 D
+P
+FO
+5210 1826 M
+0 1 D
+P
+FO
+5209 1836 M
+0 -2 D
+P
+FO
+5211 1862 M
+1 0 D
+P
+FO
+5347 1750 M
+1 0 D
+P
+FO
+5212 1869 M
+1 1 D
+P
+FO
+5321 1824 M
+1 0 D
+P
+FO
+5212 1765 M
+1 2 D
+P
+FO
+5348 1750 M
+2 -1 D
+P
+FO
+5347 1750 M
+2 0 D
+-2 1 D
+P
+FO
+5212 1862 M
+1 1 D
+P
+FO
+5381 1792 M
+1 -1 D
+P
+FO
+5611 1654 M
+P
+FO
+5433 1753 M
+4 -5 D
+4 4 D
+3 9 D
+0 5 D
+-7 15 D
+-1 19 D
+-3 7 D
+0 4 D
+P
+FO
+5433 1731 M
+P
+FO
+5589 1881 M
+1 -1 D
+P
+FO
+5590 1879 M
+1 -1 D
+P
+FO
+5748 1660 M
+1 -1 D
+3 2 D
+P
+FO
+6539 1839 M
+1 -1 D
+P
+FO
+6541 1838 M
+0 1 D
+P
+FO
+6745 1878 M
+3 -2 D
+1 4 D
+-4 -1 D
+P
+FO
+7067 1654 M
+-2 1 D
+-1 -1 D
+P
+FO
+7074 1654 M
+-7 1 D
+P
+FO
+7087 1655 M
+-6 0 D
+-2 -1 D
+8 0 D
+P
+FO
+7085 1890 M
+2 -1 D
+0 1 D
+P
+FO
+7323 1806 M
+-3 2 D
+-2 -7 D
+1 0 D
+-3 -2 D
+1 -3 D
+-3 -2 D
+-1 1 D
+1 -3 D
+-1 1 D
+-1 -3 D
+-1 2 D
+-3 -7 D
+2 -2 D
+1 1 D
+1 -2 D
+3 1 D
+0 -2 D
+3 2 D
+0 -2 D
+-4 -2 D
+2 0 D
+0 -2 D
+-1 1 D
+1 -1 D
+2 1 D
+-1 -2 D
+6 3 D
+0 -3 D
+-3 0 D
+1 -1 D
+-2 1 D
+0 -1 D
+-5 1 D
+2 -4 D
+-2 2 D
+1 -5 D
+-2 -1 D
+-2 5 D
+-3 1 D
+2 -3 D
+-4 4 D
+1 -2 D
+-2 1 D
+1 -3 D
+-1 -1 D
+2 -1 D
+-2 0 D
+-1 -3 D
+0 2 D
+-2 -3 D
+2 4 D
+-3 5 D
+-1 -2 D
+0 2 D
+-7 0 D
+-1 3 D
+-3 0 D
+-4 -1 D
+3 -5 D
+-3 4 D
+3 -4 D
+-2 1 D
+0 -2 D
+-2 2 D
+0 -3 D
+-2 3 D
+-2 -2 D
+4 -10 D
+-1 0 D
+-1 4 D
+-3 3 D
+-1 -6 D
+-2 -1 D
+2 2 D
+-2 3 D
+2 0 D
+-1 5 D
+2 5 D
+-1 0 D
+2 0 D
+-1 3 D
+2 0 D
+-6 4 D
+0 -1 D
+-7 10 D
+-5 3 D
+-1 3 D
+-2 0 D
+0 -2 D
+-2 3 D
+-2 -2 D
+0 2 D
+-1 -2 D
+-2 4 D
+-4 1 D
+0 -1 D
+-3 0 D
+1 -3 D
+3 -2 D
+-5 1 D
+1 -2 D
+-1 -2 D
+-1 1 D
+-1 -4 D
+-2 5 D
+-2 -1 D
+2 4 D
+-5 -3 D
+-1 -2 D
+2 -1 D
+-3 -2 D
+-1 4 D
+-1 0 D
+2 2 D
+-2 0 D
+1 1 D
+-2 -1 D
+1 2 D
+-3 0 D
+2 -1 D
+0 -2 D
+-2 2 D
+0 -2 D
+-1 2 D
+0 -2 D
+4 -2 D
+-2 -5 D
+-2 -1 D
+1 -3 D
+-3 0 D
+0 -4 D
+-2 2 D
+1 3 D
+-3 0 D
+0 2 D
+-2 -6 D
+0 6 D
+2 3 D
+-3 1 D
+0 -8 D
+-3 1 D
+-1 -3 D
+-1 2 D
+-1 -1 D
+0 2 D
+-2 -2 D
+1 -1 D
+-4 -2 D
+2 -3 D
+3 -1 D
+-4 -1 D
+5 -2 D
+0 1 D
+2 0 D
+-3 -3 D
+4 -1 D
+-4 -1 D
+-2 2 D
+-2 -1 D
+-3 4 D
+-1 0 D
+0 -3 D
+-4 -1 D
+1 0 D
+0 -3 D
+4 3 D
+-4 -4 D
+1 -1 D
+4 2 D
+0 -1 D
+1 0 D
+-2 -3 D
+5 -3 D
+-4 3 D
+-2 -2 D
+-1 3 D
+-3 1 D
+0 2 D
+-2 -2 D
+-2 3 D
+0 -3 D
+2 0 D
+-2 -3 D
+-1 2 D
+0 -3 D
+-4 1 D
+1 -1 D
+-2 -2 D
+1 -1 D
+-2 0 D
+3 -8 D
+3 5 D
+2 1 D
+-1 -1 D
+2 -1 D
+-4 -1 D
+0 -6 D
+1 1 D
+-3 -2 D
+2 -1 D
+-2 0 D
+-1 3 D
+-2 -6 D
+5 1 D
+5 -3 D
+4 1 D
+-4 -2 D
+-1 2 D
+-7 -1 D
+-2 2 D
+-1 -2 D
+4 -2 D
+-2 -1 D
+-1 2 D
+-3 0 D
+2 1 D
+-3 0 D
+-2 3 D
+-5 2 D
+3 -2 D
+-2 0 D
+1 -2 D
+-3 2 D
+0 -1 D
+-3 2 D
+1 0 D
+-1 2 D
+2 0 D
+-3 1 D
+0 -1 D
+-3 0 D
+1 -1 D
+-1 1 D
+1 -2 D
+-2 -1 D
+5 -2 D
+-3 1 D
+3 -2 D
+-6 0 D
+4 -2 D
+-6 0 D
+3 -2 D
+0 1 D
+3 0 D
+-4 -3 D
+5 -1 D
+2 -4 D
+3 1 D
+0 1 D
+1 0 D
+-3 -4 D
+2 -1 D
+-3 0 D
+3 -6 D
+-6 6 D
+-2 0 D
+3 -5 D
+-2 1 D
+-1 -8 D
+-5 5 D
+-2 7 D
+-3 2 D
+0 6 D
+-5 2 D
+1 3 D
+2 1 D
+-1 2 D
+-2 -1 D
+-5 -7 D
+2 -2 D
+-6 0 D
+-1 -2 D
+2 -3 D
+-3 2 D
+0 -2 D
+-2 0 D
+-3 -3 D
+1 -1 D
+-3 -3 D
+-1 -7 D
+2 -5 D
+-1 -5 D
+5 0 D
+0 -3 D
+-10 -8 D
+-4 0 D
+-2 -3 D
+2 -2 D
+-4 -1 D
+1 -3 D
+-13 -17 D
+-21 -8 D
+-5 -1 D
+0 -1 D
+236 0 D
+P
+7293 1730 M
+0 2 D
+-4 1 D
+1 3 D
+-3 -1 D
+4 4 D
+-1 3 D
+2 0 D
+-2 2 D
+4 2 D
+-1 -2 D
+1 -1 D
+3 2 D
+3 0 D
+0 -2 D
+-3 -1 D
+1 -3 D
+-2 -2 D
+-1 1 D
+0 -5 D
+P
+FO
+7171 1890 M
+0 -1 D
+5 -1 D
+-6 -2 D
+-2 -5 D
+8 0 D
+5 2 D
+3 3 D
+8 1 D
+3 3 D
+P
+FO
+7087 1889 M
+3 -5 D
+7 -2 D
+7 4 D
+2 3 D
+-19 1 D
+P
+FO
+7157 1870 M
+6 0 D
+0 2 D
+4 2 D
+0 1 D
+-2 1 D
+2 3 D
+-1 1 D
+-7 -7 D
+-6 -2 D
+1 -3 D
+P
+FO
+7165 1883 M
+0 -1 D
+2 0 D
+0 3 D
+2 1 D
+-2 0 D
+P
+FO
+7192 1763 M
+3 0 D
+-2 -2 D
+4 1 D
+-3 2 D
+1 2 D
+P
+FO
+7127 1876 M
+4 -1 D
+3 4 D
+-3 1 D
+P
+FO
+7302 1772 M
+1 -2 D
+1 2 D
+-2 1 D
+P
+FO
+7189 1764 M
+3 1 D
+P
+FO
+7285 1772 M
+1 -1 D
+-2 3 D
+P
+FO
+7313 1780 M
+1 -1 D
+3 2 D
+P
+FO
+7278 1769 M
+2 -2 D
+-1 3 D
+P
+FO
+7207 1781 M
+3 0 D
+-1 4 D
+P
+FO
+7208 1771 M
+1 -2 D
+1 0 D
+P
+FO
+7203 1772 M
+-1 1 D
+1 -3 D
+P
+FO
+7154 1867 M
+1 -1 D
+P
+FO
+7168 1733 M
+2 1 D
+P
+FO
+7185 1750 M
+2 -1 D
+P
+FO
+7178 1742 M
+2 -1 D
+P
+FO
+7182 1745 M
+1 0 D
+P
+FO
+7315 1777 M
+2 -1 D
+P
+FO
+7186 1740 M
+1 -1 D
+P
+FO
+7170 1719 M
+0 -1 D
+P
+FO
+7204 1769 M
+0 2 D
+P
+FO
+7248 1796 M
+2 0 D
+P
+FO
+7149 1871 M
+1 -1 D
+P
+FO
+7313 1771 M
+1 -1 D
+P
+FO
+7183 1742 M
+1 0 D
+P
+FO
+7188 1763 M
+1 1 D
+P
+FO
+7283 1778 M
+1 -1 D
+P
+FO
+7194 1740 M
+2 0 D
+P
+FO
+7169 1748 M
+2 -1 D
+P
+FO
+7171 1746 M
+2 0 D
+P
+FO
+7172 1739 M
+1 -1 D
+P
+FO
+7166 1747 M
+1 -1 D
+P
+FO
+7215 1784 M
+1 -1 D
+P
+FO
+7311 1777 M
+2 -5 D
+P
+FO
+7123 1875 M
+2 1 D
+P
+FO
+7200 1765 M
+1 1 D
+P
+FO
+7310 1794 M
+2 -2 D
+P
+FO
+7313 1776 M
+1 -2 D
+P
+FO
+7240 1798 M
+3 0 D
+P
+FO
+7174 1745 M
+2 0 D
+P
+FO
+7304 1775 M
+1 -1 D
+P
+FO
+7194 1749 M
+1 1 D
+P
+FO
+7228 1788 M
+1 1 D
+P
+FO
+7168 1743 M
+2 -1 D
+P
+FO
+7217 1785 M
+1 -1 D
+P
+FO
+7166 1735 M
+1 -1 D
+P
+FO
+7227 1786 M
+1 2 D
+P
+FO
+7559 1708 M
+-4 3 D
+-5 1 D
+-3 3 D
+-6 2 D
+-2 7 D
+-12 6 D
+-12 1 D
+-10 12 D
+-7 2 D
+-10 6 D
+-2 -1 D
+1 -1 D
+-4 2 D
+-2 -1 D
+0 3 D
+-9 4 D
+-2 5 D
+-13 8 D
+-1 -1 D
+0 2 D
+-2 -1 D
+-3 3 D
+-2 5 D
+5 2 D
+3 9 D
+5 2 D
+0 4 D
+4 8 D
+-3 -2 D
+-2 7 D
+3 1 D
+-2 1 D
+0 2 D
+3 2 D
+1 -2 D
+2 4 D
+1 -4 D
+1 4 D
+2 -1 D
+0 3 D
+2 -4 D
+-2 -3 D
+3 2 D
+3 5 D
+-3 1 D
+5 0 D
+-5 5 D
+2 -1 D
+0 2 D
+2 -2 D
+0 2 D
+2 1 D
+2 3 D
+-1 2 D
+1 1 D
+0 -3 D
+5 5 D
+-5 5 D
+-3 -1 D
+2 -2 D
+-2 0 D
+-3 7 D
+-2 0 D
+3 2 D
+-9 -6 D
+5 -2 D
+-4 -6 D
+-4 1 D
+-1 -1 D
+0 2 D
+-2 0 D
+3 4 D
+-2 -1 D
+-1 1 D
+3 4 D
+-6 -3 D
+-1 -2 D
+-3 2 D
+7 6 D
+-9 -5 D
+0 2 D
+-4 0 D
+-4 -3 D
+3 -1 D
+-4 0 D
+1 -2 D
+-9 4 D
+-2 5 D
+-4 -4 D
+-8 3 D
+-2 -5 D
+1 4 D
+-2 3 D
+-1 -1 D
+-1 2 D
+-3 -2 D
+-2 2 D
+2 3 D
+-3 0 D
+-6 -4 D
+0 3 D
+-1 -1 D
+-2 2 D
+-2 -1 D
+1 2 D
+-5 -1 D
+-5 9 D
+-2 0 D
+1 -2 D
+-1 1 D
+-4 -3 D
+-5 7 D
+-2 -2 D
+-1 4 D
+-2 -1 D
+1 -2 D
+-4 3 D
+1 -5 D
+2 0 D
+-2 -2 D
+-1 5 D
+-4 2 D
+0 -3 D
+-3 1 D
+1 -1 D
+-2 -2 D
+4 1 D
+1 -2 D
+-1 0 D
+2 -1 D
+2 -3 D
+3 2 D
+7 1 D
+-1 -2 D
+1 1 D
+-1 -1 D
+2 -1 D
+-1 0 D
+2 -1 D
+-2 0 D
+4 -1 D
+-3 -3 D
+3 -3 D
+-2 0 D
+0 -4 D
+3 -2 D
+-5 1 D
+-3 -1 D
+0 -4 D
+-2 3 D
+-2 -2 D
+0 3 D
+-4 -4 D
+-4 2 D
+-11 -1 D
+-3 2 D
+-1 3 D
+-1 -4 D
+-6 1 D
+1 -5 D
+-3 2 D
+-2 -2 D
+4 -3 D
+-3 1 D
+3 -4 D
+-2 1 D
+-1 -1 D
+-1 3 D
+-1 -2 D
+0 1 D
+-1 0 D
+1 3 D
+-5 1 D
+1 -5 D
+-1 0 D
+4 -3 D
+-3 1 D
+1 -2 D
+-4 3 D
+-2 0 D
+1 -2 D
+-2 2 D
+0 -5 D
+-5 -1 D
+0 -6 D
+4 -5 D
+-2 1 D
+-5 -5 D
+0 -152 D
+236 0 D
+P
+7405 1702 M
+-2 4 D
+3 4 D
+2 -6 D
+P
+FO
+7346 1858 M
+-2 1 D
+-5 -2 D
+3 -4 D
+-3 2 D
+-1 3 D
+-1 -1 D
+1 -1 D
+-1 0 D
+0 3 D
+-5 3 D
+2 -11 D
+12 -7 D
+7 5 D
+2 3 D
+3 0 D
+-1 2 D
+2 1 D
+-2 5 D
+-3 0 D
+-1 2 D
+-2 -3 D
+1 -4 D
+-2 5 D
+-1 -2 D
+-2 1 D
+0 -5 D
+P
+FO
+7323 1848 M
+14 -2 D
+1 2 D
+-4 2 D
+-1 -1 D
+1 4 D
+-3 -1 D
+1 1 D
+-1 0 D
+1 3 D
+-1 3 D
+-5 -4 D
+3 -1 D
+-2 0 D
+0 -3 D
+3 -2 D
+-2 1 D
+0 -1 D
+-1 2 D
+-1 -2 D
+-2 1 D
+1 -2 D
+P
+FO
+7474 1795 M
+1 -3 D
+-3 -3 D
+3 2 D
+5 -3 D
+7 0 D
+-1 4 D
+-1 -2 D
+-4 1 D
+1 3 D
+2 0 D
+-1 3 D
+3 3 D
+-2 1 D
+0 -2 D
+-2 0 D
+-1 3 D
+1 2 D
+-4 -1 D
+1 -3 D
+-5 -1 D
+P
+FO
+7539 1733 M
+4 -2 D
+1 2 D
+2 -1 D
+2 5 D
+1 -2 D
+3 1 D
+-4 3 D
+-6 -2 D
+P
+FO
+7458 1842 M
+5 5 D
+-1 1 D
+-3 -4 D
+-4 -1 D
+-1 -2 D
+P
+FO
+7488 1753 M
+2 -1 D
+1 1 D
+-3 5 D
+0 -2 D
+-2 -1 D
+P
+FO
+7467 1800 M
+1 -1 D
+1 2 D
+1 -2 D
+1 3 D
+-2 1 D
+P
+FO
+7482 1754 M
+2 0 D
+0 2 D
+-2 0 D
+P
+FO
+7384 1866 M
+-3 -1 D
+3 -7 D
+1 4 D
+P
+FO
+7547 1724 M
+-2 -2 D
+1 -1 D
+3 1 D
+P
+FO
+7467 1810 M
+1 -4 D
+0 2 D
+1 0 D
+P
+FO
+7476 1756 M
+3 0 D
+0 3 D
+-2 0 D
+P
+FO
+7484 1757 M
+2 1 D
+-1 2 D
+P
+FO
+7382 1850 M
+3 -1 D
+0 2 D
+P
+FO
+7479 1755 M
+2 -2 D
+1 2 D
+P
+FO
+7402 1851 M
+0 -1 D
+3 2 D
+P
+FO
+7465 1851 M
+-1 -2 D
+2 2 D
+P
+FO
+7437 1841 M
+2 -2 D
+0 1 D
+P
+FO
+7476 1801 M
+1 0 D
+0 1 D
+-1 0 D
+P
+FO
+7403 1853 M
+2 1 D
+0 1 D
+P
+FO
+7465 1839 M
+0 1 D
+P
+FO
+7480 1846 M
+1 1 D
+P
+FO
+7378 1840 M
+2 0 D
+P
+FO
+7473 1853 M
+3 2 D
+P
+FO
+7555 1732 M
+1 0 D
+P
+FO
+7457 1774 M
+2 1 D
+P
+FO
+7539 1730 M
+1 2 D
+P
+FO
+7477 1847 M
+2 2 D
+P
+FO
+7439 1842 M
+2 0 D
+P
+FO
+7475 1845 M
+1 2 D
+P
+FO
+7442 1844 M
+2 0 D
+P
+FO
+7323 1816 M
+2 -1 D
+P
+FO
+7537 1728 M
+2 1 D
+P
+FO
+7373 1852 M
+0 1 D
+P
+FO
+7483 1840 M
+1 1 D
+P
+FO
+7386 1851 M
+1 0 D
+P
+FO
+7483 1758 M
+1 0 D
+P
+FO
+7473 1845 M
+2 1 D
+P
+FO
+7467 1838 M
+1 0 D
+P
+FO
+7390 1862 M
+2 0 D
+-2 1 D
+P
+FO
+7348 1841 M
+1 0 D
+P
+FO
+7549 1722 M
+1 1 D
+P
+FO
+7540 1724 M
+2 -1 D
+P
+FO
+7478 1754 M
+1 1 D
+P
+FO
+7463 1845 M
+1 1 D
+P
+FO
+7472 1842 M
+-5 -1 D
+P
+FO
+7468 1850 M
+5 3 D
+P
+FO
+7394 1864 M
+-1 1 D
+P
+FO
+7481 1860 M
+2 6 D
+-7 -10 D
+P
+FO
+7754 1654 M
+-4 2 D
+-4 0 D
+-2 4 D
+-2 0 D
+1 -3 D
+-3 1 D
+-4 4 D
+2 -2 D
+-4 10 D
+1 -3 D
+-8 -1 D
+-2 7 D
+-1 -3 D
+-2 0 D
+-3 3 D
+-7 2 D
+-5 5 D
+2 8 D
+-3 1 D
+-5 8 D
+3 12 D
+-1 6 D
+-5 8 D
+2 4 D
+-4 -1 D
+-9 12 D
+0 3 D
+2 0 D
+-1 5 D
+-3 4 D
+0 8 D
+-3 3 D
+4 4 D
+-3 1 D
+-1 3 D
+3 4 D
+-1 0 D
+-1 3 D
+-5 0 D
+-3 5 D
+-5 1 D
+-4 9 D
+-4 -3 D
+-4 1 D
+-1 -4 D
+-5 -2 D
+-4 3 D
+-2 9 D
+-4 6 D
+2 7 D
+-2 8 D
+1 7 D
+-5 -2 D
+2 7 D
+-4 2 D
+0 3 D
+-4 1 D
+-1 5 D
+5 4 D
+-4 2 D
+-3 -1 D
+-3 2 D
+1 11 D
+-3 9 D
+-2 0 D
+-2 3 D
+0 -2 D
+-3 -1 D
+4 6 D
+-5 1 D
+-2 -5 D
+-5 -1 D
+1 -4 D
+-2 -9 D
+1 0 D
+-3 -6 D
+3 1 D
+-3 -1 D
+-1 -5 D
+2 -2 D
+1 2 D
+-1 -2 D
+-2 0 D
+-1 -3 D
+-1 5 D
+-3 -6 D
+2 0 D
+-3 0 D
+-2 -8 D
+2 0 D
+-1 3 D
+3 -1 D
+-2 -1 D
+3 -2 D
+4 0 D
+-4 -1 D
+4 -1 D
+-2 -1 D
+1 -4 D
+-3 6 D
+-2 -5 D
+-3 -2 D
+2 -7 D
+-1 -2 D
+2 1 D
+-1 -1 D
+1 -1 D
+-3 0 D
+-3 -11 D
+3 -8 D
+-2 -7 D
+3 -13 D
+-7 -21 D
+2 -4 D
+-5 -14 D
+-6 -8 D
+-2 -9 D
+-7 -5 D
+-13 -3 D
+-1 1 D
+0 -54 D
+P
+FO
+7795 1878 M
+-3 -1 D
+3 0 D
+0 -1 D
+P
+FO
+7795 1888 M
+-3 1 D
+0 1 D
+-52 0 D
+2 -3 D
+3 2 D
+0 -2 D
+3 -1 D
+6 3 D
+-2 -1 D
+5 -3 D
+6 0 D
+2 2 D
+2 -1 D
+-1 -2 D
+5 -1 D
+3 1 D
+9 -3 D
+6 1 D
+4 -4 D
+1 2 D
+1 0 D
+P
+FO
+7702 1695 M
+4 -3 D
+0 -3 D
+2 0 D
+0 6 D
+-2 1 D
+0 -2 D
+P
+FO
+7609 1873 M
+2 -1 D
+2 1 D
+-2 3 D
+P
+FO
+7611 1885 M
+2 -1 D
+1 2 D
+-1 1 D
+P
+FO
+7608 1887 M
+2 -2 D
+1 3 D
+P
+FO
+7714 1683 M
+3 0 D
+-3 2 D
+P
+FO
+7719 1674 M
+2 -1 D
+1 1 D
+P
+FO
+7658 1791 M
+2 1 D
+P
+FO
+7713 1685 M
+0 -1 D
+P
+FO
+7704 1702 M
+1 0 D
+P
+FO
+7620 1873 M
+1 -1 D
+P
+FO
+7612 1875 M
+2 0 D
+P
+FO
+7704 1692 M
+1 -1 D
+P
+FO
+7611 1876 M
+1 1 D
+-1 0 D
+P
+FO
+7659 1791 M
+1 0 D
+P
+FO
+7712 1687 M
+0 -2 D
+P
+FO
+7622 1868 M
+1 -1 D
+P
+FO
+8031 1855 M
+-1 -1 D
+1 -2 D
+P
+FO
+7823 1890 M
+-1 -1 D
+-4 1 D
+0 -3 D
+6 -2 D
+1 5 D
+P
+FO
+7795 1880 M
+2 -1 D
+-2 -1 D
+0 -2 D
+5 -3 D
+3 1 D
+2 -1 D
+1 2 D
+6 1 D
+-1 2 D
+-8 2 D
+0 2 D
+7 -1 D
+6 3 D
+-6 -1 D
+-1 2 D
+-14 3 D
+P
+FO
+7870 1857 M
+2 -3 D
+3 0 D
+0 -1 D
+4 -1 D
+0 -1 D
+5 0 D
+-1 3 D
+-12 4 D
+P
+FO
+7813 1875 M
+3 -1 D
+1 3 D
+-3 0 D
+2 -3 D
+P
+FO
+7890 1858 M
+1 -2 D
+5 1 D
+-1 2 D
+P
+FO
+7855 1875 M
+5 -2 D
+3 1 D
+P
+FO
+7819 1876 M
+-2 -2 D
+3 0 D
+1 2 D
+P
+FO
+7868 1861 M
+3 -2 D
+1 1 D
+P
+FO
+7851 1873 M
+1 0 D
+0 1 D
+P
+FO
+7865 1870 M
+1 0 D
+P
+FO
+7866 1861 M
+1 1 D
+P
+FO
+7811 1875 M
+2 0 D
+-2 1 D
+P
+FO
+8026 1860 M
+2 -1 D
+P
+FO
+7876 1859 M
+1 -1 D
+P
+FO
+7810 1875 M
+1 -1 D
+P
+FO
+7855 1864 M
+2 0 D
+P
+FO
+7868 1864 M
+1 -1 D
+P
+FO
+8031 1852 M
+6 -1 D
+4 -4 D
+4 0 D
+-14 8 D
+P
+FO
+8187 1772 M
+1 -10 D
+3 -6 D
+12 3 D
+-3 9 D
+-2 1 D
+1 4 D
+-3 0 D
+-1 -5 D
+-3 -1 D
+-1 9 D
+-3 4 D
+-2 -5 D
+P
+FO
+8206 1748 M
+-4 3 D
+-2 -5 D
+6 -3 D
+0 -8 D
+2 -1 D
+3 2 D
+4 -1 D
+1 3 D
+-1 -1 D
+0 3 D
+-9 5 D
+P
+FO
+8079 1871 M
+9 -1 D
+-3 0 D
+0 4 D
+-5 5 D
+-1 -1 D
+-14 7 D
+-4 0 D
+0 -3 D
+6 -1 D
+0 -5 D
+6 -4 D
+P
+FO
+8224 1707 M
+2 1 D
+2 -1 D
+0 -1 D
+5 -1 D
+1 3 D
+-3 4 D
+-3 0 D
+P
+FO
+8249 1667 M
+1 -3 D
+4 -2 D
+2 3 D
+-4 1 D
+0 4 D
+-2 -1 D
+P
+FO
+8244 1680 M
+6 -3 D
+2 1 D
+-4 4 D
+2 1 D
+-4 3 D
+-2 -1 D
+P
+FO
+8173 1871 M
+2 3 D
+-6 0 D
+-3 -3 D
+3 -2 D
+2 3 D
+P
+FO
+8220 1743 M
+-2 0 D
+6 -4 D
+4 2 D
+-4 5 D
+P
+FO
+8223 1732 M
+1 -3 D
+7 -1 D
+0 2 D
+-5 2 D
+-1 3 D
+P
+FO
+8192 1851 M
+2 -2 D
+3 1 D
+-3 2 D
+P
+FO
+8220 1765 M
+-4 -1 D
+-3 -3 D
+4 -1 D
+P
+FO
+8226 1748 M
+1 2 D
+-2 11 D
+-2 -5 D
+P
+FO
+8206 1799 M
+1 -3 D
+4 2 D
+-3 4 D
+P
+FO
+8179 1883 M
+1 0 D
+-1 0 D
+0 2 D
+P
+FO
+8206 1788 M
+4 -1 D
+1 4 D
+-4 0 D
+P
+FO
+8186 1815 M
+1 1 D
+-1 1 D
+P
+FO
+8224 1772 M
+-1 1 D
+2 -11 D
+P
+FO
+8199 1755 M
+3 -1 D
+0 2 D
+-3 0 D
+P
+FO
+8184 1860 M
+1 -1 D
+1 1 D
+P
+FO
+8199 1757 M
+3 0 D
+0 2 D
+P
+FO
+8072 1884 M
+1 -1 D
+0 2 D
+P
+FO
+8078 1884 M
+0 -1 D
+P
+FO
+8204 1806 M
+1 0 D
+P
+FO
+8228 1722 M
+3 1 D
+P
+FO
+8225 1736 M
+1 2 D
+P
+FO
+8187 1813 M
+2 0 D
+P
+FO
+8117 1662 M
+1 -3 D
+P
+FO
+8227 1736 M
+2 0 D
+P
+FO
+8211 1802 M
+3 2 D
+P
+FO
+8228 1714 M
+1 -1 D
+P
+FO
+8225 1711 M
+3 1 D
+P
+FO
+8195 1851 M
+2 1 D
+P
+FO
+8257 1671 M
+1 -1 D
+P
+FO
+8189 1809 M
+1 -1 D
+P
+FO
+8187 1811 M
+1 -1 D
+P
+FO
+8203 1758 M
+0 1 D
+P
+FO
+8199 1773 M
+1 -1 D
+P
+FO
+8116 1664 M
+1 -1 D
+P
+FO
+8167 1873 M
+0 1 D
+P
+FO
+8233 1727 M
+1 0 D
+P
+FO
+8504 1729 M
+-2 -5 D
+2 1 D
+P
+FO
+8504 1736 M
+-1 -1 D
+1 0 D
+P
+FO
+8504 1745 M
+-4 -3 D
+-7 0 D
+-4 -4 D
+-10 -1 D
+-6 -5 D
+-4 1 D
+-1 -4 D
+3 0 D
+-1 -2 D
+4 -3 D
+3 4 D
+3 -2 D
+2 1 D
+0 2 D
+3 3 D
+4 -1 D
+-1 -2 D
+6 0 D
+3 2 D
+5 -1 D
+-2 2 D
+2 5 D
+-8 -7 D
+-2 0 D
+9 12 D
+3 2 D
+P
+FO
+8472 1701 M
+-2 5 D
+1 3 D
+-7 5 D
+-1 -1 D
+0 2 D
+-2 2 D
+-5 -3 D
+-3 0 D
+-1 2 D
+-10 -7 D
+1 -3 D
+-4 -4 D
+2 -4 D
+13 -4 D
+6 1 D
+6 3 D
+1 -1 D
+2 1 D
+1 -1 D
+3 2 D
+P
+FO
+8457 1675 M
+-1 -1 D
+5 -1 D
+0 3 D
+3 1 D
+0 -1 D
+4 1 D
+-4 2 D
+P
+FO
+8488 1701 M
+-1 1 D
+-1 -2 D
+3 -2 D
+P
+FO
+8474 1709 M
+1 -2 D
+2 0 D
+-1 3 D
+P
+FO
+8490 1706 M
+1 -2 D
+0 2 D
+P
+FO
+8489 1718 M
+0 -3 D
+2 3 D
+P
+FO
+8500 1687 M
+2 -2 D
+1 2 D
+P
+FO
+8435 1718 M
+1 -1 D
+P
+FO
+8474 1707 M
+1 -1 D
+-1 2 D
+P
+FO
+8463 1729 M
+2 -1 D
+P
+FO
+8475 1736 M
+1 0 D
+P
+FO
+8480 1710 M
+1 -1 D
+P
+FO
+8470 1734 M
+2 0 D
+P
+FO
+8437 1707 M
+1 -1 D
+P
+FO
+8488 1740 M
+1 0 D
+P
+FO
+8433 1831 M
+3 0 D
+P
+FO
+8459 1691 M
+2 1 D
+P
+FO
+8438 1721 M
+2 2 D
+P
+FO
+8444 1728 M
+3 3 D
+P
+FO
+8447 1689 M
+2 -2 D
+P
+FO
+8498 1673 M
+1 1 D
+P
+FO
+8468 1679 M
+1 1 D
+P
+FO
+8442 1726 M
+2 2 D
+P
+FO
+0 1744 M
+2 1 D
+-2 0 D
+P
+FO
+0 1735 M
+2 1 D
+1 2 D
+-3 -2 D
+P
+FO
+0 1725 M
+4 2 D
+1 2 D
+-1 3 D
+-4 -3 D
+P
+FO
+142 1685 M
+0 -1 D
+1 2 D
+1 0 D
+-1 1 D
+-3 -1 D
+1 -1 D
+1 1 D
+P
+FO
+169 1807 M
+7 -7 D
+5 1 D
+2 -1 D
+2 3 D
+-5 6 D
+P
+FO
+193 1795 M
+9 0 D
+-4 3 D
+-6 2 D
+-5 -2 D
+P
+FO
+216 1788 M
+2 -2 D
+1 2 D
+3 1 D
+P
+FO
+3 1677 M
+2 2 D
+-2 0 D
+P
+FO
+88 1812 M
+2 -1 D
+0 3 D
+P
+FO
+115 1659 M
+2 0 D
+-1 1 D
+P
+FO
+24 1720 M
+0 -3 D
+2 2 D
+P
+FO
+134 1662 M
+1 -1 D
+P
+FO
+102 1757 M
+2 1 D
+-2 0 D
+P
+FO
+5 1729 M
+3 1 D
+P
+FO
+15 1707 M
+2 0 D
+P
+FO
+43 1789 M
+3 -1 D
+P
+FO
+24 1678 M
+1 0 D
+P
+FO
+19 1714 M
+2 0 D
+P
+FO
+126 1682 M
+1 0 D
+P
+FO
+33 1674 M
+2 0 D
+P
+FO
+22 1701 M
+0 1 D
+P
+FO
+147 1749 M
+2 1 D
+P
+FO
+1 1755 M
+2 -1 D
+P
+FO
+37 1673 M
+1 1 D
+-1 0 D
+P
+FO
+32 1681 M
+1 0 D
+P
+FO
+28 1709 M
+0 -1 D
+P
+FO
+138 1684 M
+2 1 D
+P
+FO
+26 1680 M
+1 1 D
+P
+FO
+28 1696 M
+2 0 D
+P
+FO
+141 1685 M
+0 -1 D
+P
+FO
+238 1677 M
+0 -3 D
+2 0 D
+1 4 D
+P
+FO
+247 1790 M
+2 -1 D
+P
+FO
+243 1791 M
+1 0 D
+P
+FO
+449 1880 M
+1 -1 D
+P
+FO
+517 1654 M
+P
+FO
+673 1730 M
+1 -4 D
+3 2 D
+-3 3 D
+P
+FO
+672 1733 M
+2 -1 D
+1 1 D
+P
+FO
+685 1730 M
+0 -1 D
+P
+FO
+667 1737 M
+1 -2 D
+P
+FO
+477 1680 M
+1 1 D
+P
+FO
+665 1742 M
+1 0 D
+P
+FO
+615 1730 M
+1 -2 D
+P
+FO
+668 1735 M
+1 1 D
+P
+FO
+685 1732 M
+-1 -2 D
+P
+FO
+718 1711 M
+1 -4 D
+6 0 D
+1 -3 D
+3 0 D
+-1 3 D
+-3 0 D
+-1 5 D
+-3 1 D
+P
+FO
+711 1712 M
+2 -2 D
+1 3 D
+P
+FO
+794 1744 M
+2 0 D
+-2 1 D
+P
+FO
+812 1747 M
+3 -6 D
+P
+FO
+749 1752 M
+2 0 D
+P
+FO
+821 1778 M
+1 3 D
+P
+FO
+921 1699 M
+5 -3 D
+P
+FO
+823 1753 M
+3 -3 D
+P
+FO
+927 1705 M
+2 3 D
+P
+FO
+829 1786 M
+1 0 D
+P
+FO
+925 1705 M
+3 3 D
+P
+FO
+823 1781 M
+0 1 D
+-1 0 D
+P
+FO
+941 1748 M
+2 1 D
+P
+FO
+926 1693 M
+3 -2 D
+P
+FO
+861 1733 M
+4 -1 D
+P
+FO
+814 1761 M
+2 -1 D
+P
+FO
+739 1775 M
+2 -1 D
+P
+FO
+856 1735 M
+5 -2 D
+P
+FO
+805 1787 M
+2 0 D
+-1 0 D
+P
+FO
+814 1716 M
+2 -1 D
+P
+FO
+767 1770 M
+2 -2 D
+P
+FO
+798 1764 M
+0 -2 D
+P
+FO
+813 1716 M
+1 -1 D
+P
+FO
+753 1774 M
+2 -1 D
+P
+FO
+817 1714 M
+1 -1 D
+P
+FO
+844 1738 M
+1 -1 D
+P
+FO
+804 1752 M
+1 -1 D
+P
+FO
+847 1731 M
+2 0 D
+P
+FO
+841 1740 M
+1 0 D
+P
+FO
+928 1674 M
+1 0 D
+P
+FO
+794 1765 M
+2 -1 D
+P
+FO
+791 1753 M
+1 -1 D
+P
+FO
+823 1731 M
+1 -1 D
+P
+FO
+852 1738 M
+2 -1 D
+P
+FO
+761 1767 M
+1 -1 D
+P
+FO
+916 1791 M
+1 0 D
+P
+FO
+821 1750 M
+1 -1 D
+P
+FO
+863 1714 M
+1 -1 D
+P
+FO
+924 1752 M
+1 0 D
+P
+FO
+935 1663 M
+1 -1 D
+P
+FO
+788 1766 M
+1 -1 D
+P
+FO
+845 1733 M
+1 0 D
+P
+FO
+885 1745 M
+1 1 D
+P
+FO
+973 1890 M
+P
+FO
+966 1890 M
+P
+FO
+976 1877 M
+2 1 D
+-1 2 D
+P
+FO
+1016 1693 M
+-2 2 D
+3 -3 D
+P
+FO
+1028 1690 M
+4 -3 D
+P
+FO
+981 1716 M
+3 1 D
+P
+FO
+2598 1751 M
+-1 4 D
+1 0 D
+0 12 D
+-3 1 D
+2 1 D
+1 -1 D
+0 122 D
+-193 0 D
+0 -3 D
+14 -25 D
+-1 -3 D
+7 -4 D
+3 -4 D
+2 -8 D
+-1 -2 D
+9 -7 D
+0 -3 D
+14 -21 D
+-1 -11 D
+-3 1 D
+-1 -3 D
+3 0 D
+0 -5 D
+3 -2 D
+0 -3 D
+4 -3 D
+2 -4 D
+10 -6 D
+2 -6 D
+4 -1 D
+-1 -1 D
+3 -4 D
+26 -13 D
+8 -7 D
+7 -1 D
+15 -8 D
+8 -2 D
+8 -7 D
+15 -6 D
+2 -5 D
+0 -5 D
+10 -5 D
+15 -13 D
+-1 -8 D
+5 -28 D
+3 0 D
+P
+2456 1865 M
+-2 -1 D
+-2 3 D
+3 0 D
+P
+2512 1765 M
+-2 -1 D
+0 1 D
+P
+2580 1755 M
+2 -1 D
+-2 0 D
+P
+2569 1785 M
+2 -2 D
+P
+2594 1754 M
+-1 0 D
+1 1 D
+P
+FO
+2427 1841 M
+2 -1 D
+P
+FO
+2452 1789 M
+1 -1 D
+P
+FO
+2598 1768 M
+2 0 D
+2 -2 D
+-4 1 D
+0 -12 D
+1 0 D
+1 3 D
+4 -3 D
+-4 7 D
+3 1 D
+-2 1 D
+4 1 D
+0 1 D
+8 -6 D
+3 -4 D
+2 0 D
+3 -3 D
+1 -3 D
+5 -1 D
+-3 -3 D
+2 -3 D
+6 -1 D
+0 -2 D
+-3 1 D
+-2 -3 D
+-4 0 D
+2 -1 D
+0 -3 D
+-5 2 D
+1 3 D
+-1 3 D
+3 1 D
+3 -1 D
+-7 5 D
+1 -5 D
+-5 -1 D
+-2 3 D
+-3 -1 D
+2 5 D
+-6 1 D
+-3 4 D
+-2 -2 D
+2 -1 D
+-5 1 D
+0 -97 D
+237 0 D
+0 236 D
+-237 0 D
+P
+2671 1674 M
+-3 0 D
+0 6 D
+-4 2 D
+2 2 D
+-3 2 D
+5 7 D
+0 2 D
+-4 3 D
+3 2 D
+2 -1 D
+-2 -3 D
+2 -1 D
+-2 -10 D
+2 -1 D
+3 -6 D
+P
+2804 1713 M
+0 -2 D
+-1 3 D
+-1 -2 D
+-2 1 D
+4 2 D
+P
+2703 1818 M
+-2 1 D
+0 6 D
+3 -3 D
+1 -3 D
+P
+2693 1815 M
+-1 0 D
+-1 3 D
+3 3 D
+1 -2 D
+P
+2741 1804 M
+1 -5 D
+-3 1 D
+1 4 D
+P
+2672 1805 M
+1 -2 D
+-2 -5 D
+-1 6 D
+P
+2671 1796 M
+0 -2 D
+-2 0 D
+1 2 D
+P
+2664 1794 M
+1 -1 D
+-2 0 D
+P
+2642 1673 M
+2 -2 D
+P
+2674 1798 M
+-2 -2 D
+P
+FO
+-1 1 1 2618 1748 SP
+2835 1654 M
+236 0 D
+0 236 D
+-236 0 D
+P
+2892 1700 M
+2 -3 D
+-2 -1 D
+-1 0 D
+P
+2888 1713 M
+-1 -3 D
+-2 3 D
+P
+FO
+3304 1654 M
+-2 1 D
+5 4 D
+0 231 D
+-236 0 D
+0 -236 D
+P
+3186 1676 M
+-1 4 D
+0 -2 D
+-2 1 D
+-4 -2 D
+2 1 D
+-2 1 D
+5 0 D
+0 5 D
+-2 -2 D
+2 -1 D
+-4 0 D
+3 2 D
+0 4 D
+-2 -3 D
+0 1 D
+-2 1 D
+5 2 D
+-4 1 D
+0 1 D
+0 -3 D
+-2 1 D
+-2 -2 D
+2 5 D
+1 -1 D
+3 1 D
+0 2 D
+-2 -1 D
+2 3 D
+-3 -1 D
+3 2 D
+2 -1 D
+-1 -1 D
+2 0 D
+-2 -1 D
+-1 -2 D
+2 -1 D
+-3 0 D
+3 0 D
+-1 -1 D
+2 -1 D
+-1 -2 D
+2 1 D
+0 -2 D
+-2 0 D
+2 -2 D
+-1 -1 D
+2 0 D
+0 -1 D
+2 3 D
+-1 -2 D
+4 -1 D
+-1 -1 D
+-6 2 D
+2 -3 D
+P
+FO
+3307 1659 M
+5 4 D
+2 6 D
+0 23 D
+3 7 D
+9 7 D
+-4 1 D
+5 1 D
+-2 12 D
+5 22 D
+4 9 D
+-3 5 D
+-1 20 D
+-1 0 D
+2 12 D
+-1 0 D
+2 9 D
+-1 0 D
+0 -4 D
+-2 5 D
+2 1 D
+0 5 D
+0 -1 D
+2 0 D
+-2 2 D
+2 5 D
+-3 0 D
+2 0 D
+0 4 D
+3 1 D
+-1 3 D
+3 4 D
+-3 1 D
+2 0 D
+2 6 D
+2 -4 D
+4 -1 D
+-2 -5 D
+11 8 D
+17 28 D
+-2 -1 D
+0 2 D
+2 0 D
+4 8 D
+0 -1 D
+3 4 D
+0 2 D
+0 -2 D
+14 12 D
+1 -1 D
+9 12 D
+-94 0 D
+P
+FO
+3337 1819 M
+-2 -1 D
+1 -2 D
+4 3 D
+-2 3 D
+0 -3 D
+P
+FO
+3339 1824 M
+0 -1 D
+1 1 D
+P
+FO
+3332 1755 M
+1 -2 D
+P
+FO
+3336 1818 M
+1 1 D
+P
+FO
+3332 1757 M
+0 -2 D
+P
+FO
+3332 1759 M
+0 1 D
+P
+FO
+4115 1748 M
+3 0 D
+0 2 D
+P
+FO
+4559 1654 M
+5 -6 D
+5 -15 D
+10 -15 D
+2 -6 D
+11 -12 D
+3 -7 D
+0 -8 D
+-2 -3 D
+0 4 D
+-1 -4 D
+2 -7 D
+-1 -2 D
+2 -5 D
+-2 -10 D
+4 -12 D
+4 -5 D
+2 -8 D
+-1 -4 D
+1 -6 D
+-1 -5 D
+4 -8 D
+-1 -6 D
+4 -3 D
+1 -5 D
+-2 1 D
+2 -7 D
+2 0 D
+1 -9 D
+6 -11 D
+7 -8 D
+12 -11 D
+4 -1 D
+2 -6 D
+5 -5 D
+8 -22 D
+67 0 D
+0 237 D
+P
+FO
+4837 1417 M
+-1 1 D
+1 0 D
+0 -1 D
+124 0 D
+0 237 D
+-237 0 D
+0 -237 D
+P
+4875 1479 M
+-7 -6 D
+2 -4 D
+-2 0 D
+-4 4 D
+-3 1 D
+-2 -1 D
+8 -6 D
+-5 2 D
+0 -2 D
+-5 4 D
+0 2 D
+4 3 D
+6 -4 D
+1 4 D
+1 -1 D
+2 3 D
+P
+4925 1489 M
+-2 -1 D
+-1 2 D
+-4 0 D
+2 -1 D
+-2 -1 D
+2 -1 D
+2 1 D
+1 -2 D
+-1 -2 D
+-1 3 D
+0 -2 D
+-4 2 D
+2 2 D
+-3 1 D
+1 3 D
+P
+4834 1621 M
+2 4 D
+2 -3 D
+P
+4849 1429 M
+2 -2 D
+-3 3 D
+1 0 D
+P
+4788 1641 M
+2 3 D
+3 1 D
+P
+4946 1525 M
+-2 0 D
+2 1 D
+P
+4885 1453 M
+2 -3 D
+P
+4910 1518 M
+-1 -1 D
+P
+FO
+4983 1417 M
+8 13 D
+11 12 D
+6 2 D
+9 8 D
+11 36 D
+3 22 D
+-3 -5 D
+-4 2 D
+-4 6 D
+2 -1 D
+2 3 D
+0 3 D
+2 -3 D
+1 6 D
+11 8 D
+0 -1 D
+43 17 D
+10 12 D
+0 7 D
+-1 -2 D
+-2 1 D
+-1 -4 D
+1 7 D
+-2 0 D
+2 1 D
+1 -1 D
+1 13 D
+3 5 D
+-2 4 D
+1 14 D
+-1 -3 D
+-1 5 D
+-1 -3 D
+-3 1 D
+-1 13 D
+-3 6 D
+0 5 D
+-1 -4 D
+-2 2 D
+2 1 D
+-2 2 D
+3 5 D
+-4 2 D
+1 3 D
+-3 -1 D
+0 2 D
+-1 -1 D
+-2 4 D
+-2 -1 D
+1 2 D
+-1 3 D
+2 3 D
+-2 2 D
+3 0 D
+-1 4 D
+-112 0 D
+0 -237 D
+P
+5020 1464 M
+-3 -6 D
+1 6 D
+-2 0 D
+2 3 D
+0 -2 D
+1 2 D
+2 -1 D
+P
+5009 1478 M
+-1 -2 D
+-2 3 D
+-1 0 D
+1 3 D
+2 -4 D
+2 0 D
+P
+4986 1648 M
+-3 0 D
+-1 2 D
+3 -2 D
+1 1 D
+P
+5025 1480 M
+-1 -1 D
+-3 1 D
+3 2 D
+0 -2 D
+P
+5029 1534 M
+-2 2 D
+3 0 D
+P
+5081 1546 M
+-4 -1 D
+5 4 D
+P
+5063 1538 M
+-4 -1 D
+P
+5028 1489 M
+-1 -2 D
+P
+5028 1497 M
+1 2 D
+P
+5079 1544 M
+-3 -1 D
+P
+5079 1551 M
+-1 -1 D
+P
+5011 1447 M
+-1 0 D
+P
+5078 1548 M
+-8 -3 D
+9 3 D
+P
+5031 1525 M
+1 1 D
+P
+5062 1541 M
+-4 1 D
+P
+FO
+5089 1613 M
+1 -2 D
+0 7 D
+P
+FO
+5088 1610 M
+2 -2 D
+0 3 D
+P
+FO
+5076 1639 M
+2 -1 D
+P
+FO
+5404 1654 M
+1 -1 D
+0 1 D
+P
+FO
+5303 1654 M
+-5 -9 D
+-4 -3 D
+-3 -6 D
+1 0 D
+-3 -2 D
+-4 -12 D
+-3 1 D
+0 -4 D
+-3 4 D
+0 -9 D
+-1 1 D
+-3 -8 D
+0 3 D
+-2 -8 D
+2 -1 D
+-2 0 D
+3 -15 D
+6 -5 D
+0 -6 D
+4 -3 D
+-1 -2 D
+2 -1 D
+-4 -2 D
+0 -10 D
+4 -12 D
+5 -5 D
+0 -5 D
+9 -4 D
+-1 -2 D
+-2 3 D
+2 -3 D
+10 -2 D
+9 -6 D
+8 1 D
+21 10 D
+6 -1 D
+2 1 D
+-1 1 D
+2 -1 D
+3 3 D
+1 -1 D
+4 2 D
+5 17 D
+0 -1 D
+2 3 D
+-1 0 D
+3 3 D
+3 10 D
+-1 1 D
+1 0 D
+6 26 D
+7 16 D
+-2 1 D
+3 0 D
+7 28 D
+6 14 D
+P
+5283 1608 M
+1 1 D
+1 -1 D
+-1 -2 D
+-2 2 D
+P
+5286 1555 M
+-1 4 D
+P
+FO
+5205 1599 M
+1 -1 D
+P
+FO
+5280 1623 M
+2 -1 D
+P
+FO
+5611 1654 M
+-6 -11 D
+3 -2 D
+6 1 D
+3 5 D
+-3 6 D
+P
+FO
+5557 1630 M
+2 -6 D
+7 -3 D
+4 1 D
+1 4 D
+-4 6 D
+-6 1 D
+-3 -1 D
+P
+FO
+7079 1654 M
+-3 -3 D
+-2 3 D
+-6 0 D
+0 -1 D
+-4 1 D
+-4 -7 D
+-16 -3 D
+-1 2 D
+-5 -4 D
+1 -1 D
+-3 0 D
+-2 -3 D
+-3 -1 D
+0 1 D
+-6 -3 D
+-5 2 D
+0 3 D
+-6 -4 D
+-3 2 D
+2 3 D
+-2 0 D
+-4 -4 D
+1 -1 D
+-1 1 D
+-8 -4 D
+-2 1 D
+-1 -3 D
+-6 -3 D
+-2 -4 D
+-4 -1 D
+-4 -6 D
+-14 -3 D
+-6 -4 D
+-2 -5 D
+-1 1 D
+0 -3 D
+-2 -3 D
+1 -2 D
+-1 1 D
+-2 -5 D
+-2 2 D
+-4 -2 D
+2 5 D
+-2 -1 D
+2 13 D
+-4 -2 D
+-8 -16 D
+4 -9 D
+-2 -4 D
+1 -8 D
+-8 -10 D
+-1 -13 D
+6 -9 D
+-1 -1 D
+2 -5 D
+3 -2 D
+10 -17 D
+0 -3 D
+-2 0 D
+1 -8 D
+-3 -3 D
+-4 5 D
+-1 7 D
+0 -3 D
+-4 -3 D
+1 8 D
+-6 8 D
+-2 -5 D
+1 -1 D
+0 2 D
+3 -9 D
+7 -6 D
+-1 -6 D
+-4 -2 D
+-1 5 D
+-1 -4 D
+-1 8 D
+-1 -5 D
+-3 12 D
+0 -10 D
+-2 10 D
+0 -6 D
+-3 2 D
+19 -26 D
+5 -10 D
+-2 -4 D
+2 -6 D
+8 -9 D
+2 -4 D
+-1 -3 D
+7 -8 D
+3 -9 D
+-1 -12 D
+120 0 D
+0 237 D
+P
+FO
+6926 1512 M
+-6 12 D
+0 -7 D
+6 -9 D
+P
+FO
+6976 1633 M
+2 0 D
+1 5 D
+P
+FO
+6948 1595 M
+1 1 D
+P
+FO
+6924 1535 M
+-1 -6 D
+P
+FO
+6941 1516 M
+2 -2 D
+P
+FO
+6924 1536 M
+1 5 D
+P
+FO
+7011 1641 M
+2 3 D
+P
+FO
+7006 1637 M
+1 0 D
+P
+FO
+7006 1639 M
+2 2 D
+P
+FO
+7012 1645 M
+2 -1 D
+P
+FO
+7005 1642 M
+1 1 D
+P
+FO
+6981 1643 M
+0 -1 D
+P
+FO
+7007 1639 M
+1 1 D
+P
+FO
+7011 1642 M
+1 2 D
+P
+FO
+6952 1613 M
+1 1 D
+P
+FO
+7052 1646 M
+1 1 D
+P
+FO
+7016 1639 M
+2 0 D
+P
+FO
+6981 1645 M
+1 -1 D
+P
+FO
+7007 1641 M
+1 1 D
+-1 0 D
+P
+FO
+6945 1443 M
+-1 -2 D
+P
+FO
+7087 1417 M
+236 0 D
+0 237 D
+-236 0 D
+P
+FO
+7323 1417 M
+236 0 D
+0 237 D
+-236 0 D
+P
+FO
+7795 1592 M
+-4 5 D
+-4 -5 D
+1 5 D
+-3 0 D
+2 1 D
+0 1 D
+-3 -1 D
+2 2 D
+-4 10 D
+1 7 D
+-1 -1 D
+-2 3 D
+-1 -2 D
+0 6 D
+-3 -1 D
+1 2 D
+-2 1 D
+2 3 D
+-5 2 D
+1 2 D
+-5 0 D
+-1 2 D
+1 1 D
+-4 2 D
+1 2 D
+-2 1 D
+2 2 D
+-1 1 D
+2 -1 D
+1 2 D
+3 -3 D
+-4 7 D
+-2 -1 D
+0 2 D
+-2 0 D
+-1 3 D
+-3 0 D
+1 -3 D
+-6 3 D
+1 2 D
+-195 0 D
+0 -237 D
+236 0 D
+P
+FO
+7795 1602 M
+-2 -4 D
+2 -4 D
+P
+FO
+7795 1603 M
+-1 -1 D
+P
+FO
+7772 1648 M
+-1 2 D
+-1 -3 D
+3 -1 D
+P
+FO
+7792 1602 M
+1 -1 D
+0 4 D
+P
+FO
+7769 1650 M
+2 0 D
+0 2 D
+P
+FO
+7773 1642 M
+1 1 D
+P
+FO
+7768 1646 M
+1 -2 D
+P
+FO
+7785 1633 M
+1 0 D
+P
+FO
+7773 1647 M
+1 1 D
+P
+FO
+7788 1596 M
+2 2 D
+P
+FO
+7759 1654 M
+0 -2 D
+P
+FO
+7818 1417 M
+-1 3 D
+2 0 D
+-1 -3 D
+54 0 D
+3 14 D
+-2 1 D
+2 -1 D
+-1 3 D
+6 10 D
+-1 0 D
+1 0 D
+1 5 D
+-2 3 D
+1 8 D
+-3 2 D
+-4 14 D
+-3 3 D
+-2 -1 D
+2 2 D
+-3 1 D
+2 2 D
+-2 2 D
+3 1 D
+-3 2 D
+1 2 D
+3 -4 D
+-2 7 D
+-1 -2 D
+1 5 D
+-2 1 D
+2 0 D
+0 6 D
+-2 0 D
+4 10 D
+-4 3 D
+-1 -4 D
+1 4 D
+-3 0 D
+2 1 D
+-3 2 D
+0 4 D
+2 2 D
+-5 -2 D
+4 2 D
+0 4 D
+-9 2 D
+2 1 D
+-4 5 D
+1 3 D
+-2 1 D
+-1 -2 D
+0 3 D
+-4 2 D
+0 -1 D
+-4 3 D
+-3 10 D
+0 -1 D
+-3 1 D
+0 3 D
+-1 -2 D
+0 2 D
+-2 1 D
+1 -4 D
+-3 2 D
+0 -2 D
+-3 2 D
+0 -1 D
+-10 12 D
+-2 -2 D
+-3 4 D
+2 0 D
+-3 4 D
+2 2 D
+-2 8 D
+1 -1 D
+1 6 D
+-1 4 D
+-1 -3 D
+-2 4 D
+1 -1 D
+1 1 D
+-2 3 D
+0 -2 D
+-1 3 D
+-1 0 D
+-1 -2 D
+3 -3 D
+-2 0 D
+1 -3 D
+-10 7 D
+-4 5 D
+-1 -9 D
+2 -3 D
+-2 1 D
+0 -175 D
+P
+FO
+7795 1603 M
+P
+FO
+7866 1525 M
+-1 -3 D
+3 -5 D
+7 18 D
+-3 3 D
+0 5 D
+-3 -3 D
+3 -4 D
+-6 -6 D
+1 0 D
+P
+FO
+7819 1571 M
+2 -3 D
+5 -4 D
+-1 7 D
+-2 -1 D
+-3 2 D
+P
+FO
+7806 1599 M
+1 -1 D
+2 1 D
+-2 2 D
+P
+FO
+7875 1471 M
+2 0 D
+2 7 D
+-2 1 D
+P
+FO
+7876 1468 M
+0 -2 D
+1 5 D
+P
+FO
+7875 1487 M
+1 -7 D
+1 8 D
+P
+FO
+7816 1569 M
+1 -1 D
+1 2 D
+P
+FO
+7801 1614 M
+1 0 D
+-1 1 D
+P
+FO
+7829 1559 M
+3 -1 D
+P
+FO
+7865 1529 M
+1 -2 D
+P
+FO
+7827 1564 M
+1 -2 D
+P
+FO
+7875 1473 M
+0 -2 D
+P
+FO
+7817 1578 M
+2 0 D
+P
+FO
+7802 1612 M
+2 1 D
+P
+FO
+7805 1600 M
+1 1 D
+P
+FO
+7829 1559 M
+-1 1 D
+P
+FO
+7875 1471 M
+1 -1 D
+P
+FO
+7875 1470 M
+1 1 D
+P
+FO
+8197 1598 M
+1 2 D
+-3 4 D
+-6 3 D
+1 0 D
+-8 7 D
+-7 3 D
+-2 3 D
+0 -2 D
+-3 3 D
+0 -1 D
+-3 3 D
+-3 0 D
+-1 2 D
+1 1 D
+-5 2 D
+0 3 D
+-3 2 D
+-1 2 D
+-7 2 D
+-10 9 D
+-5 2 D
+0 -2 D
+-7 6 D
+1 -4 D
+-1 0 D
+4 -2 D
+-1 -2 D
+7 -8 D
+-1 -1 D
+6 -3 D
+2 -4 D
+2 0 D
+3 -7 D
+1 2 D
+1 -2 D
+2 0 D
+4 -5 D
+5 0 D
+0 -2 D
+4 -2 D
+2 1 D
+2 -4 D
+4 -2 D
+2 2 D
+2 -4 D
+-1 -1 D
+5 -1 D
+0 -2 D
+2 1 D
+0 -3 D
+2 2 D
+6 -4 D
+2 0 D
+0 2 D
+1 -2 D
+P
+8193 1603 M
+1 0 D
+-5 0 D
+P
+FO
+8206 1630 M
+-3 2 D
+1 4 D
+-3 2 D
+-3 -2 D
+0 -1 D
+3 -1 D
+-1 -2 D
+-3 0 D
+3 -4 D
+6 -2 D
+2 3 D
+P
+FO
+8220 1614 M
+3 1 D
+1 4 D
+-3 0 D
+-1 3 D
+-4 -1 D
+1 -5 D
+P
+FO
+8187 1637 M
+1 2 D
+-1 2 D
+2 2 D
+-1 1 D
+-3 -7 D
+P
+FO
+8206 1592 M
+1 -2 D
+2 2 D
+-2 2 D
+P
+FO
+8260 1649 M
+3 -1 D
+1 1 D
+-1 1 D
+P
+FO
+8174 1605 M
+1 -1 D
+P
+FO
+8182 1636 M
+2 1 D
+P
+FO
+8132 1648 M
+1 -1 D
+P
+FO
+8182 1600 M
+1 0 D
+P
+FO
+8130 1651 M
+2 -1 D
+-2 2 D
+P
+FO
+8218 1441 M
+2 -2 D
+P
+FO
+8191 1596 M
+2 1 D
+P
+FO
+8125 1653 M
+1 -1 D
+P
+FO
+8121 1652 M
+1 0 D
+P
+FO
+8216 1627 M
+1 0 D
+P
+FO
+110 1628 M
+5 -5 D
+2 3 D
+-2 1 D
+-1 -2 D
+-2 1 D
+3 1 D
+P
+FO
+119 1621 M
+1 -2 D
+0 4 D
+P
+FO
+48 1435 M
+2 -1 D
+P
+FO
+517 1654 M
+1 -1 D
+P
+FO
+520 1608 M
+3 0 D
+-1 1 D
+P
+FO
+476 1625 M
+3 -1 D
+P
+FO
+676 1596 M
+1 -2 D
+P
+FO
+841 1474 M
+2 -1 D
+0 2 D
+P
+FO
+720 1574 M
+2 0 D
+P
+FO
+763 1562 M
+2 0 D
+P
+FO
+971 1611 M
+2 -1 D
+-1 -1 D
+2 1 D
+P
+FO
+1063 1580 M
+1 1 D
+P
+FO
+979 1635 M
+1 -2 D
+P
+FO
+1051 1618 M
+1 -1 D
+P
+FO
+1065 1581 M
+1 -1 D
+P
+FO
+1220 1551 M
+2 -1 D
+-1 2 D
+P
+FO
+1666 1484 M
+6 2 D
+-4 1 D
+P
+FO
+2595 1654 M
+1 -1 D
+-3 -19 D
+2 -1 D
+-1 -4 D
+3 -9 D
+-3 -11 D
+-2 -24 D
+-3 -4 D
+-2 -1 D
+-1 2 D
+-2 -11 D
+2 -1 D
+1 2 D
+2 -3 D
+-3 -7 D
+-1 -16 D
+3 -19 D
+-5 -4 D
+-2 -6 D
+3 -5 D
+-2 -7 D
+2 -1 D
+-2 -1 D
+0 -5 D
+-3 -7 D
+0 -4 D
+-4 -3 D
+2 -10 D
+-3 -1 D
+-4 -11 D
+1 -6 D
+-4 -5 D
+1 -2 D
+-5 -6 D
+0 -7 D
+4 -5 D
+1 -12 D
+-3 -2 D
+33 0 D
+0 237 D
+P
+FO
+2598 1417 M
+237 0 D
+0 237 D
+-237 0 D
+P
+2622 1543 M
+1 4 D
+P
+FO
+2843 1417 M
+-1 3 D
+2 15 D
+4 4 D
+5 2 D
+3 8 D
+0 11 D
+5 4 D
+1 4 D
+-1 9 D
+13 6 D
+13 -1 D
+16 -5 D
+18 3 D
+4 2 D
+7 -1 D
+2 -3 D
+-8 3 D
+-3 -2 D
+0 -2 D
+-3 -3 D
+-7 3 D
+-1 -3 D
+-19 3 D
+-11 5 D
+-12 -1 D
+-8 -4 D
+1 -12 D
+-5 -5 D
+-1 -11 D
+-3 -8 D
+-4 -5 D
+-3 -1 D
+-2 -5 D
+0 -5 D
+-2 -4 D
+2 -4 D
+223 0 D
+3 6 D
+0 231 D
+-236 0 D
+0 -237 D
+P
+2900 1453 M
+2 3 D
+4 0 D
+-5 -4 D
+P
+2883 1450 M
+2 2 D
+-1 -1 D
+2 -1 D
+P
+3062 1418 M
+-1 2 D
+2 0 D
+P
+2905 1458 M
+0 2 D
+3 1 D
+P
+3069 1423 M
+0 3 D
+2 -2 D
+P
+2877 1446 M
+1 2 D
+3 1 D
+P
+2903 1459 M
+1 2 D
+P
+2910 1462 M
+2 1 D
+P
+2892 1455 M
+4 4 D
+P
+FO
+-1 2 1 2844 1417 SP
+7 4 3 -1 4 2 1 -2 4 2910 1478 SP
+-4 2 2 2 4 -3 3 2906 1477 SP
+-4 -2 4 4 2 2845 1433 SP
+3 1 1 2847 1438 SP
+4 -1 1 2892 1479 SP
+2 0 1 2873 1482 SP
+2 0 1 2895 1479 SP
+-2 1 3 -1 2 2924 1482 SP
+2 -2 1 2906 1476 SP
+1 0 1 2887 1481 SP
+2 -1 1 2887 1480 SP
+-4 -1 2 2 2 2920 1475 SP
+1 -1 1 2861 1475 SP
+3071 1428 M
+5 4 D
+-4 -5 D
+-1 0 D
+0 1 D
+0 -5 D
+7 11 D
+8 9 D
+12 7 D
+-2 1 D
+3 -1 D
+1 2 D
+-2 1 D
+-1 4 D
+3 -1 D
+-2 -2 D
+2 -1 D
+4 14 D
+-2 6 D
+3 1 D
+-2 3 D
+3 2 D
+-3 3 D
+4 3 D
+-3 0 D
+1 3 D
+-3 3 D
+2 2 D
+-2 3 D
+1 6 D
+-4 3 D
+1 3 D
+1 -2 D
+3 2 D
+0 8 D
+1 -1 D
+5 7 D
+-9 2 D
+0 3 D
+2 -3 D
+4 0 D
+1 3 D
+-2 1 D
+2 0 D
+0 2 D
+1 -1 D
+1 1 D
+0 -3 D
+1 2 D
+4 0 D
+-2 -2 D
+0 -3 D
+5 6 D
+-1 4 D
+11 9 D
+8 3 D
+10 9 D
+10 3 D
+-1 2 D
+1 1 D
+3 -3 D
+2 1 D
+1 3 D
+6 3 D
+11 -2 D
+0 5 D
+5 1 D
+1 2 D
+2 -1 D
+1 3 D
+3 2 D
+2 -2 D
+8 3 D
+-2 1 D
+-2 -1 D
+1 1 D
+-2 0 D
+2 1 D
+-2 0 D
+1 3 D
+5 1 D
+1 2 D
+2 0 D
+-1 -2 D
+3 1 D
+1 -2 D
+3 3 D
+5 1 D
+7 -4 D
+9 2 D
+0 2 D
+-3 2 D
+5 3 D
+2 -1 D
+-3 -4 D
+2 -2 D
+13 1 D
+12 -1 D
+-1 3 D
+4 2 D
+-3 2 D
+1 4 D
+6 6 D
+17 6 D
+-2 12 D
+7 15 D
+3 2 D
+0 -1 D
+5 5 D
+4 7 D
+-1 0 D
+4 8 D
+-233 0 D
+P
+3176 1617 M
+-1 2 D
+-2 -1 D
+0 1 D
+-2 1 D
+-2 -3 D
+0 5 D
+-3 2 D
+-1 -4 D
+-4 -1 D
+4 3 D
+-4 1 D
+4 0 D
+-1 1 D
+2 0 D
+0 2 D
+-1 0 D
+1 2 D
+-5 1 D
+4 1 D
+-4 1 D
+3 2 D
+-4 1 D
+2 3 D
+-4 1 D
+5 -1 D
+0 1 D
+0 -1 D
+3 1 D
+1 -1 D
+3 5 D
+2 -4 D
+-2 0 D
+2 -1 D
+2 4 D
+1 -2 D
+1 1 D
+-2 -3 D
+4 0 D
+-6 -1 D
+2 -1 D
+-1 -1 D
+3 1 D
+-2 -1 D
+1 -2 D
+3 0 D
+-1 -1 D
+3 -3 D
+4 2 D
+-1 -3 D
+1 0 D
+0 1 D
+0 -1 D
+-2 0 D
+0 2 D
+-2 -1 D
+-3 2 D
+-1 -2 D
+0 3 D
+-3 1 D
+0 2 D
+-4 4 D
+-2 -3 D
+-2 1 D
+0 2 D
+-3 -4 D
+2 0 D
+2 -2 D
+-2 -1 D
+2 -1 D
+-1 -1 D
+3 1 D
+4 -2 D
+-5 1 D
+-1 -2 D
+2 -1 D
+-1 -1 D
+4 -2 D
+-1 -3 D
+6 0 D
+P
+3103 1572 M
+-2 0 D
+1 2 D
+-3 2 D
+-1 -2 D
+-1 2 D
+-2 -1 D
+1 -3 D
+-2 2 D
+0 2 D
+-4 0 D
+3 -3 D
+-3 2 D
+1 -4 D
+-2 6 D
+1 2 D
+1 -2 D
+2 1 D
+-1 -1 D
+3 2 D
+0 -2 D
+1 1 D
+0 -2 D
+3 2 D
+3 -3 D
+2 2 D
+-1 -2 D
+2 1 D
+-2 -1 D
+2 0 D
+-3 0 D
+P
+3151 1639 M
+-5 3 D
+1 -2 D
+-2 0 D
+-1 3 D
+2 0 D
+-4 1 D
+-2 3 D
+4 0 D
+-2 -2 D
+3 1 D
+-1 -2 D
+2 1 D
+0 -3 D
+6 -2 D
+P
+3114 1588 M
+-2 2 D
+-3 -1 D
+1 2 D
+-2 1 D
+-1 -1 D
+1 2 D
+-1 -1 D
+-2 2 D
+14 -3 D
+-7 1 D
+-2 -1 D
+5 -1 D
+P
+3152 1562 M
+-1 2 D
+-1 -2 D
+-1 4 D
+2 -2 D
+4 2 D
+-3 -2 D
+2 -1 D
+P
+3202 1618 M
+-3 4 D
+-2 0 D
+2 2 D
+3 -2 D
+-2 -1 D
+3 -1 D
+P
+3276 1604 M
+-3 3 D
+4 1 D
+1 -2 D
+-3 0 D
+P
+3254 1586 M
+5 0 D
+-1 -2 D
+P
+3146 1564 M
+2 3 D
+0 -2 D
+P
+3096 1452 M
+-1 1 D
+4 -1 D
+P
+3080 1439 M
+2 1 D
+P
+3251 1585 M
+3 0 D
+P
+3239 1584 M
+3 0 D
+P
+3077 1435 M
+3 3 D
+P
+3246 1585 M
+3 0 D
+P
+FO
+3104 1470 M
+1 -2 D
+2 2 D
+3 8 D
+-2 1 D
+-3 -2 D
+P
+FO
+3178 1562 M
+5 -2 D
+-1 2 D
+2 2 D
+-3 2 D
+-2 -4 D
+P
+FO
+3119 1531 M
+-2 -3 D
+3 4 D
+0 2 D
+-2 -1 D
+0 -2 D
+P
+FO
+3204 1578 M
+0 -1 D
+6 2 D
+-3 2 D
+-3 -2 D
+P
+FO
+3213 1580 M
+9 1 D
+-7 1 D
+0 -1 D
+P
+FO
+3120 1535 M
+1 -1 D
+10 9 D
+-10 -8 D
+P
+FO
+3101 1504 M
+3 -1 D
+2 5 D
+P
+FO
+3110 1526 M
+2 -2 D
+0 3 D
+P
+FO
+3230 1587 M
+3 1 D
+P
+FO
+3118 1534 M
+4 4 D
+P
+FO
+3109 1523 M
+2 -1 D
+-2 2 D
+P
+FO
+3107 1524 M
+1 -2 D
+P
+FO
+3107 1523 M
+2 0 D
+P
+FO
+3203 1582 M
+1 -1 D
+P
+FO
+3559 1642 M
+1 -1 D
+P
+FO
+4657 1417 M
+3 -8 D
+11 -18 D
+11 -13 D
+3 -13 D
+0 -7 D
+-4 -6 D
+-5 2 D
+-2 -3 D
+1 -5 D
+3 0 D
+2 -4 D
+-3 3 D
+-1 -1 D
+12 -14 D
+1 -4 D
+-5 -4 D
+3 -6 D
+2 -1 D
+-1 5 D
+8 1 D
+2 -2 D
+-1 -5 D
+7 1 D
+0 -2 D
+3 0 D
+2 -2 D
+-1 -3 D
+3 1 D
+5 -5 D
+5 1 D
+3 -2 D
+0 114 D
+P
+FO
+4837 1417 M
+5 -5 D
+-5 5 D
+-113 0 D
+0 -114 D
+13 9 D
+7 0 D
+0 2 D
+11 -1 D
+13 1 D
+3 4 D
+5 1 D
+-1 2 D
+10 2 D
+20 -3 D
+0 3 D
+34 -5 D
+4 5 D
+16 -1 D
+-2 4 D
+6 4 D
+14 -2 D
+13 5 D
+36 23 D
+21 21 D
+14 10 D
+0 30 D
+P
+4856 1403 M
+2 1 D
+1 -2 D
+4 1 D
+-5 -2 D
+P
+4802 1402 M
+0 1 D
+P
+FO
+4961 1387 M
+13 15 D
+9 15 D
+-22 0 D
+P
+FO
+6083 1232 M
+2 -1 D
+0 2 D
+P
+FO
+6967 1417 M
+3 -12 D
+15 -27 D
+1 -9 D
+3 2 D
+1 -1 D
+-4 -1 D
+1 -3 D
+-2 -2 D
+1 -5 D
+-3 -5 D
+2 -15 D
+-8 -8 D
+-4 0 D
+-4 3 D
+-1 -14 D
+4 -5 D
+5 0 D
+8 -3 D
+7 -9 D
+9 -2 D
+1 1 D
+2 -2 D
+-3 1 D
+6 -3 D
+2 2 D
+5 -2 D
+10 1 D
+6 -3 D
+2 2 D
+6 -2 D
+2 1 D
+-4 1 D
+2 3 D
+1 0 D
+0 -2 D
+5 0 D
+-1 2 D
+6 0 D
+1 4 D
+6 2 D
+1 3 D
+4 1 D
+-1 1 D
+9 -2 D
+1 2 D
+3 0 D
+0 2 D
+3 0 D
+-2 2 D
+10 8 D
+3 0 D
+0 93 D
+P
+FO
+6981 1370 M
+-2 0 D
+P
+FO
+6984 1366 M
+1 -2 D
+P
+FO
+7087 1324 M
+10 -1 D
+3 2 D
+19 2 D
+10 -2 D
+5 2 D
+3 -5 D
+4 1 D
+2 2 D
+4 -1 D
+11 2 D
+2 -1 D
+1 -3 D
+5 3 D
+4 -1 D
+10 9 D
+4 10 D
+3 3 D
+13 3 D
+33 16 D
+11 -2 D
+13 1 D
+24 6 D
+18 7 D
+24 3 D
+0 37 D
+-236 0 D
+P
+FO
+7161 1320 M
+1 1 D
+P
+FO
+7139 1320 M
+1 -1 D
+P
+FO
+7170 1314 M
+1 1 D
+P
+FO
+7559 1241 M
+0 2 D
+0 -1 D
+0 175 D
+-236 0 D
+0 -37 D
+19 -1 D
+8 4 D
+14 -6 D
+11 -8 D
+6 0 D
+1 3 D
+6 -1 D
+9 -6 D
+8 0 D
+-2 2 D
+2 1 D
+2 -2 D
+1 2 D
+8 -7 D
+-2 0 D
+0 -4 D
+4 2 D
+4 0 D
+2 -5 D
+-2 -3 D
+1 2 D
+-4 0 D
+2 -3 D
+-2 -2 D
+3 0 D
+-1 -2 D
+4 -4 D
+-1 4 D
+2 -4 D
+2 1 D
+4 -2 D
+-1 2 D
+3 -1 D
+-1 -1 D
+4 -5 D
+0 -4 D
+8 -6 D
+5 -17 D
+1 2 D
+0 -3 D
+2 0 D
+-3 0 D
+-2 2 D
+1 0 D
+-3 1 D
+0 2 D
+-2 -4 D
+3 1 D
+9 -9 D
+4 1 D
+4 -3 D
+1 6 D
+-5 -1 D
+2 1 D
+1 5 D
+3 1 D
+1 -1 D
+0 4 D
+12 11 D
+8 4 D
+-2 -1 D
+2 2 D
+1 -1 D
+5 2 D
+6 12 D
+4 4 D
+4 -1 D
+-1 13 D
+4 -7 D
+0 -6 D
+3 -2 D
+-6 -4 D
+4 -7 D
+-9 -7 D
+-1 -6 D
+-2 0 D
+1 -4 D
+-2 -4 D
+2 0 D
+-1 -11 D
+-2 -1 D
+-8 2 D
+-4 -10 D
+13 5 D
+5 -2 D
+3 1 D
+-1 2 D
+4 6 D
+0 7 D
+5 9 D
+11 -17 D
+-2 1 D
+-1 -13 D
+-8 -7 D
+10 0 D
+5 3 D
+4 0 D
+15 -10 D
+4 -8 D
+-8 10 D
+-11 7 D
+10 -6 D
+7 -8 D
+6 -13 D
+-1 -3 D
+-4 -3 D
+3 -4 D
+-1 -1 D
+P
+7556 1245 M
+0 2 D
+P
+7557 1243 M
+-1 2 D
+2 -2 D
+P
+FO
+7488 1275 M
+5 1 D
+6 -2 D
+3 1 D
+2 3 D
+9 0 D
+2 2 D
+-5 2 D
+-4 -3 D
+1 3 D
+-5 0 D
+1 4 D
+-25 -5 D
+-1 -3 D
+4 -4 D
+P
+FO
+7406 1363 M
+4 1 D
+P
+FO
+7469 1299 M
+-2 1 D
+2 -2 D
+P
+FO
+7524 1305 M
+1 -1 D
+P
+FO
+7471 1310 M
+1 1 D
+P
+FO
+7463 1306 M
+1 0 D
+P
+FO
+7428 1328 M
+2 2 D
+P
+FO
+7412 1362 M
+2 -1 D
+P
+FO
+7475 1296 M
+1 -1 D
+P
+FO
+7657 1181 M
+-1 8 D
+-4 2 D
+-2 -3 D
+1 -7 D
+P
+FO
+7755 1181 M
+0 1 D
+-3 0 D
+-5 6 D
+-5 -4 D
+3 -1 D
+0 -2 D
+P
+FO
+7795 1249 M
+-3 0 D
+2 3 D
+-2 2 D
+2 0 D
+1 163 D
+-236 0 D
+0 -176 D
+9 -10 D
+-1 5 D
+1 -5 D
+5 -3 D
+10 -1 D
+8 -5 D
+1 -3 D
+2 1 D
+2 -2 D
+4 4 D
+10 -3 D
+5 1 D
+28 -12 D
+12 9 D
+9 5 D
+5 0 D
+1 3 D
+-5 -1 D
+-3 2 D
+4 0 D
+9 6 D
+5 -7 D
+-5 -5 D
+-6 1 D
+7 -4 D
+7 2 D
+0 4 D
+6 0 D
+1 -4 D
+-3 0 D
+-1 -3 D
+6 -4 D
+5 1 D
+0 -1 D
+-2 0 D
+4 -5 D
+3 2 D
+3 -1 D
+0 1 D
+2 -4 D
+4 -3 D
+1 7 D
+-4 -2 D
+-2 5 D
+17 2 D
+-1 -1 D
+15 13 D
+10 5 D
+-12 -5 D
+7 4 D
+-2 2 D
+5 -1 D
+6 2 D
+-1 -1 D
+33 2 D
+7 4 D
+-2 2 D
+3 0 D
+-1 -1 D
+5 1 D
+-1 5 D
+P
+7727 1270 M
+-1 6 D
+5 -2 D
+-4 1 D
+-1 -3 D
+3 -1 D
+P
+7777 1349 M
+-3 5 D
+4 4 D
+1 -3 D
+-3 -1 D
+P
+7640 1221 M
+-2 3 D
+2 0 D
+1 3 D
+2 -2 D
+P
+7614 1361 M
+-2 1 D
+2 2 D
+2 -2 D
+-2 -2 D
+P
+7767 1299 M
+0 1 D
+-3 -2 D
+-2 1 D
+5 3 D
+P
+7604 1273 M
+-1 3 D
+3 -2 D
+-1 -2 D
+P
+7772 1323 M
+-1 2 D
+3 0 D
+-1 -2 D
+P
+7731 1225 M
+0 2 D
+3 0 D
+P
+7589 1322 M
+0 2 D
+1 -3 D
+P
+7611 1358 M
+1 2 D
+1 -1 D
+P
+7616 1363 M
+1 2 D
+1 -1 D
+P
+7705 1275 M
+0 -1 D
+-4 2 D
+P
+FO
+7684 1219 M
+2 -1 D
+3 2 D
+-5 2 D
+P
+FO
+7680 1216 M
+6 -1 D
+-2 3 D
+P
+FO
+7712 1211 M
+2 -1 D
+3 1 D
+P
+FO
+7718 1212 M
+2 0 D
+P
+FO
+7715 1211 M
+2 1 D
+P
+FO
+7745 1188 M
+2 0 D
+P
+FO
+7741 1230 M
+2 1 D
+P
+FO
+7711 1211 M
+2 0 D
+P
+FO
+7717 1212 M
+1 0 D
+P
+FO
+7720 1212 M
+1 1 D
+P
+FO
+7818 1417 M
+-23 0 D
+0 -158 D
+4 9 D
+-2 6 D
+2 4 D
+-1 0 D
+3 2 D
+-2 3 D
+3 -1 D
+6 12 D
+5 1 D
+-2 4 D
+3 1 D
+0 -3 D
+1 1 D
+-1 4 D
+-2 -1 D
+0 1 D
+-2 0 D
+5 2 D
+2 5 D
+-2 2 D
+2 0 D
+0 5 D
+6 5 D
+-3 0 D
+4 1 D
+-4 1 D
+5 1 D
+1 3 D
+-2 -1 D
+-2 1 D
+2 -1 D
+0 2 D
+2 -1 D
+1 6 D
+-1 -2 D
+0 2 D
+-3 -2 D
+2 2 D
+-1 1 D
+2 -1 D
+1 3 D
+0 -2 D
+3 1 D
+1 3 D
+-2 1 D
+3 1 D
+3 4 D
+-3 -2 D
+-1 3 D
+2 -1 D
+0 3 D
+2 -3 D
+2 5 D
+-1 1 D
+2 0 D
+0 -1 D
+9 4 D
+-3 1 D
+-3 -2 D
+-1 0 D
+2 1 D
+-1 2 D
+3 -1 D
+3 1 D
+0 -2 D
+3 5 D
+5 2 D
+1 5 D
+-2 0 D
+0 -3 D
+0 3 D
+-3 1 D
+3 0 D
+1 4 D
+5 4 D
+8 18 D
+-1 14 D
+5 11 D
+P
+7849 1359 M
+2 2 D
+3 0 D
+-4 -3 D
+P
+FO
+7795 1246 M
+2 0 D
+-2 3 D
+P
+FO
+8009 1381 M
+1 -2 D
+P
+FO
+8431 1181 M
+4 8 D
+-3 1 D
+-2 3 D
+4 7 D
+9 4 D
+10 -1 D
+1 -5 D
+3 4 D
+-3 2 D
+1 8 D
+3 0 D
+6 4 D
+1 12 D
+3 6 D
+-2 -1 D
+4 3 D
+-5 1 D
+-1 2 D
+-8 0 D
+-2 -3 D
+-4 0 D
+-2 -5 D
+-5 -2 D
+-6 0 D
+0 -2 D
+-2 1 D
+1 1 D
+-22 8 D
+1 -2 D
+-5 1 D
+1 1 D
+-3 1 D
+1 3 D
+-3 5 D
+-1 9 D
+-3 0 D
+3 3 D
+-5 0 D
+-2 6 D
+-4 0 D
+3 -3 D
+-1 -2 D
+2 -2 D
+-3 -2 D
+4 -9 D
+0 2 D
+-5 -1 D
+-1 5 D
+-3 2 D
+-2 -1 D
+-1 2 D
+-2 -1 D
+-1 2 D
+-1 -2 D
+0 2 D
+-5 -1 D
+0 2 D
+3 -1 D
+-2 5 D
+3 0 D
+-4 0 D
+1 5 D
+1 -2 D
+-1 2 D
+4 1 D
+-3 1 D
+2 1 D
+-6 5 D
+0 -2 D
+0 2 D
+-3 2 D
+1 3 D
+-4 0 D
+0 3 D
+6 -3 D
+0 3 D
+-2 0 D
+0 2 D
+1 0 D
+-5 7 D
+1 0 D
+-2 2 D
+1 2 D
+-3 -3 D
+-2 1 D
+0 -1 D
+3 -1 D
+-3 0 D
+-1 3 D
+-2 0 D
+1 1 D
+-1 1 D
+3 -1 D
+-4 1 D
+-2 3 D
+-3 -2 D
+0 2 D
+-4 2 D
+-1 -2 D
+-2 0 D
+-2 3 D
+3 1 D
+-2 1 D
+-3 -2 D
+1 -3 D
+-2 0 D
+1 3 D
+-4 2 D
+0 1 D
+2 -1 D
+-5 6 D
+0 -2 D
+-1 2 D
+-2 0 D
+1 2 D
+3 -1 D
+1 2 D
+-9 0 D
+-1 -2 D
+12 -12 D
+0 -4 D
+-2 0 D
+3 -3 D
+1 1 D
+-2 -1 D
+5 -5 D
+1 3 D
+2 0 D
+-3 -4 D
+14 -15 D
+2 -5 D
+3 2 D
+-6 7 D
+8 -6 D
+1 1 D
+-2 3 D
+1 0 D
+2 -3 D
+2 2 D
+-2 -3 D
+-1 0 D
+3 1 D
+-4 -2 D
+3 -2 D
+1 1 D
+1 -7 D
+-3 1 D
+1 1 D
+-3 4 D
+-2 -1 D
+8 -14 D
+7 3 D
+1 -1 D
+-2 -1 D
+4 -1 D
+-5 -2 D
+0 -2 D
+-1 4 D
+-3 0 D
+3 -7 D
+3 0 D
+-2 -2 D
+3 -9 D
+2 2 D
+1 -2 D
+-5 -1 D
+1 -4 D
+2 1 D
+-2 -3 D
+1 1 D
+2 -1 D
+-2 -1 D
+-4 1 D
+-2 -17 D
+-5 -4 D
+-8 -2 D
+-7 -5 D
+5 -6 D
+8 -2 D
+6 -5 D
+12 -2 D
+-1 -1 D
+P
+8433 1209 M
+2 2 D
+2 0 D
+-1 -2 D
+P
+8404 1206 M
+0 6 D
+7 0 D
+-1 -4 D
+P
+8420 1227 M
+-2 0 D
+4 0 D
+P
+8416 1225 M
+-1 2 D
+3 0 D
+P
+8400 1226 M
+2 1 D
+0 -4 D
+P
+8391 1241 M
+-1 1 D
+2 -1 D
+P
+8419 1225 M
+2 1 D
+P
+8401 1229 M
+-2 1 D
+P
+8403 1203 M
+-1 1 D
+P
+8422 1221 M
+1 0 D
+P
+8387 1240 M
+1 1 D
+P
+8419 1223 M
+3 1 D
+P
+FO
+8386 1257 M
+3 -2 D
+2 2 D
+P
+FO
+8409 1241 M
+1 -3 D
+3 -1 D
+P
+FO
+8387 1271 M
+1 -1 D
+0 1 D
+P
+FO
+8389 1255 M
+1 -1 D
+1 2 D
+P
+FO
+8393 1271 M
+5 -4 D
+-3 8 D
+P
+FO
+8381 1265 M
+2 0 D
+P
+FO
+8404 1262 M
+2 -1 D
+P
+FO
+8382 1257 M
+1 0 D
+P
+FO
+2344 1329 M
+1 -1 D
+0 2 D
+P
+FO
+2565 1417 M
+0 -4 D
+-1 0 D
+-2 -3 D
+-3 1 D
+-1 -8 D
+1 -18 D
+3 -6 D
+-1 -6 D
+2 0 D
+-1 -8 D
+3 -4 D
+-1 -7 D
+-2 -3 D
+1 -2 D
+-6 -5 D
+3 -12 D
+-4 -4 D
+-5 -8 D
+1 -5 D
+-6 -19 D
+-4 -2 D
+1 -4 D
+-2 2 D
+-5 -7 D
+2 -4 D
+-5 -5 D
+-5 -17 D
+-3 -1 D
+0 3 D
+-1 -3 D
+-2 -1 D
+4 -1 D
+-2 0 D
+0 -7 D
+-3 -3 D
+-4 0 D
+-3 3 D
+-3 -5 D
+3 -3 D
+-2 -6 D
+5 -9 D
+-2 -7 D
+1 -6 D
+3 -2 D
+-1 -1 D
+5 -16 D
+-5 -6 D
+0 -4 D
+3 0 D
+-2 0 D
+1 -2 D
+-4 3 D
+-5 -4 D
+87 0 D
+0 236 D
+P
+2550 1200 M
+2 -1 D
+-1 -1 D
+-5 1 D
+0 1 D
+P
+2567 1247 M
+2 0 D
+-1 -2 D
+1 -5 D
+-3 3 D
+P
+2546 1190 M
+2 -5 D
+-5 3 D
+0 2 D
+P
+2521 1226 M
+0 -2 D
+-3 -1 D
+0 3 D
+P
+2548 1193 M
+2 -2 D
+-6 1 D
+P
+2568 1187 M
+-8 -1 D
+P
+2551 1204 M
+3 -2 D
+-4 1 D
+0 1 D
+P
+2558 1203 M
+-2 -3 D
+0 3 D
+P
+2569 1210 M
+-2 -1 D
+P
+2521 1209 M
+-1 -3 D
+0 3 D
+P
+2541 1187 M
+6 -4 D
+P
+2571 1207 M
+3 -1 D
+P
+FO
+2515 1252 M
+0 -2 D
+2 1 D
+P
+FO
+2387 1331 M
+4 0 D
+-2 1 D
+P
+FO
+2526 1260 M
+0 1 D
+P
+FO
+2505 1221 M
+2 -2 D
+P
+FO
+2780 1181 M
+0 3 D
+5 1 D
+0 3 D
+-1 0 D
+3 6 D
+-7 4 D
+7 -2 D
+-7 3 D
+2 0 D
+-3 2 D
+1 4 D
+-2 4 D
+1 1 D
+13 -5 D
+16 0 D
+27 3 D
+0 179 D
+-3 -4 D
+-7 -6 D
+-4 -1 D
+-3 -5 D
+2 -2 D
+-3 -11 D
+5 -14 D
+4 -1 D
+2 -3 D
+-4 2 D
+-6 7 D
+-2 9 D
+3 10 D
+-2 5 D
+2 5 D
+5 0 D
+6 5 D
+5 6 D
+0 28 D
+-237 0 D
+0 -236 D
+P
+2770 1395 M
+-6 6 D
+7 2 D
+1 2 D
+10 -2 D
+0 -5 D
+-9 -1 D
+P
+2627 1300 M
+3 -1 D
+-1 -3 D
+-4 2 D
+P
+2813 1367 M
+2 2 D
+0 -2 D
+P
+2728 1364 M
+0 2 D
+2 0 D
+P
+FO
+2787 1203 M
+-2 0 D
+1 -2 D
+1 1 D
+-1 -1 D
+5 -2 D
+-1 3 D
+P
+FO
+2784 1205 M
+4 -2 D
+P
+FO
+2784 1200 M
+2 -1 D
+P
+FO
+1 4 0 -3 2 2818 1374 SP
+2845 1417 M
+-2 -7 D
+2 -8 D
+-10 -15 D
+0 -179 D
+35 8 D
+15 5 D
+8 5 D
+2 10 D
+1 -2 D
+6 6 D
+11 15 D
+-2 14 D
+1 -2 D
+-5 0 D
+-5 2 D
+-5 7 D
+0 6 D
+6 7 D
+-2 3 D
+-8 7 D
+-20 9 D
+-5 5 D
+3 2 D
+-4 2 D
+4 -1 D
+2 2 D
+-1 4 D
+-4 0 D
+4 2 D
+-3 1 D
+2 1 D
+-2 1 D
+2 0 D
+-2 3 D
+0 5 D
+3 4 D
+-1 6 D
+5 -1 D
+-3 -1 D
+-1 -18 D
+5 -6 D
+6 -3 D
+2 -4 D
+17 0 D
+8 -5 D
+11 -3 D
+-2 3 D
+2 -1 D
+0 -2 D
+-2 -1 D
+6 -2 D
+11 4 D
+7 0 D
+4 -4 D
+4 1 D
+3 -2 D
+1 2 D
+18 5 D
+1 3 D
+8 3 D
+0 3 D
+5 5 D
+2 6 D
+16 12 D
+5 6 D
+6 17 D
+5 4 D
+1 3 D
+-2 -1 D
+2 1 D
+-4 0 D
+1 2 D
+2 0 D
+-3 2 D
+-1 2 D
+5 3 D
+-1 3 D
+2 -1 D
+0 -3 D
+2 9 D
+4 1 D
+0 1 D
+4 -1 D
+0 3 D
+4 2 D
+-2 3 D
+4 2 D
+-1 5 D
+2 0 D
+0 -4 D
+1 8 D
+4 3 D
+-5 1 D
+0 7 D
+2 0 D
+-1 -4 D
+5 -2 D
+0 -3 D
+3 -1 D
+0 3 D
+6 0 D
+0 2 D
+2 1 D
+1 -2 D
+-1 -5 D
+-3 3 D
+0 -10 D
+-6 -3 D
+0 -3 D
+-5 -1 D
+0 -5 D
+-2 -5 D
+-2 -1 D
+-2 1 D
+0 -3 D
+-1 1 D
+-4 -4 D
+-5 -1 D
+2 0 D
+-2 -2 D
+-6 1 D
+2 -3 D
+-1 -5 D
+30 24 D
+11 15 D
+5 12 D
+P
+2910 1349 M
+0 3 D
+1 -2 D
+1 2 D
+1 -2 D
+2 5 D
+-1 -5 D
+2 1 D
+3 -1 D
+2 6 D
+-1 -4 D
+2 1 D
+0 -2 D
+4 5 D
+1 -2 D
+3 3 D
+3 -1 D
+0 3 D
+3 -2 D
+0 3 D
+4 -2 D
+1 2 D
+1 -2 D
+-4 0 D
+0 -1 D
+-3 1 D
+1 -4 D
+-2 1 D
+1 -3 D
+-3 3 D
+-1 -4 D
+-6 1 D
+0 -2 D
+4 -2 D
+-4 1 D
+-1 -2 D
+-2 3 D
+-11 -1 D
+P
+2987 1332 M
+-2 13 D
+1 -1 D
+2 3 D
+4 1 D
+1 2 D
+-1 2 D
+8 4 D
+8 10 D
+-1 -4 D
+3 -6 D
+-4 -6 D
+-3 -2 D
+-3 4 D
+-3 -1 D
+-2 -6 D
+-5 -2 D
+0 -9 D
+P
+2997 1334 M
+12 17 D
+1 0 D
+-3 -8 D
+P
+2984 1320 M
+-1 3 D
+3 0 D
+P
+2978 1314 M
+0 3 D
+2 -2 D
+P
+3002 1348 M
+3 0 D
+P
+3056 1404 M
+-1 1 D
+P
+3063 1408 M
+0 2 D
+P
+3065 1412 M
+0 2 D
+P
+2877 1357 M
+0 -2 D
+P
+2880 1350 M
+0 -2 D
+-1 2 D
+P
+3062 1406 M
+0 1 D
+P
+2878 1351 M
+1 -2 D
+P
+2879 1348 M
+1 -1 D
+P
+2878 1355 M
+0 -2 D
+P
+FO
+2835 1389 M
+7 10 D
+-1 11 D
+3 6 D
+-9 1 D
+P
+FO
+3056 1408 M
+1 0 D
+-1 2 D
+P
+FO
+2869 1325 M
+3 -1 D
+P
+FO
+3019 1370 M
+2 0 D
+P
+FO
+1 -7 1 2843 1409 SP
+3960 1249 M
+2 -2 D
+1 2 D
+-2 1 D
+P
+FO
+3952 1244 M
+1 1 D
+P
+FO
+5140 1017 M
+6 -1 D
+2 2 D
+-6 2 D
+P
+FO
+5146 1025 M
+4 -1 D
+P
+FO
+5472 1030 M
+2 -2 D
+3 2 D
+-2 1 D
+P
+FO
+5482 1029 M
+6 0 D
+-2 1 D
+P
+FO
+5437 1037 M
+3 0 D
+-1 1 D
+P
+FO
+5906 954 M
+-2 0 D
+-8 5 D
+5 -2 D
+-1 2 D
+4 -1 D
+-3 3 D
+5 -1 D
+0 5 D
+-7 -4 D
+-4 0 D
+4 1 D
+-8 0 D
+4 1 D
+-5 1 D
+2 1 D
+-3 -1 D
+1 2 D
+8 0 D
+-3 0 D
+3 1 D
+-3 1 D
+2 1 D
+-2 1 D
+-2 -4 D
+-1 2 D
+-5 -3 D
+-3 4 D
+-1 -3 D
+-1 3 D
+3 0 D
+-2 1 D
+3 4 D
+-6 -3 D
+5 4 D
+-4 -1 D
+3 1 D
+-3 0 D
+3 1 D
+-3 0 D
+-1 -2 D
+-3 -2 D
+2 -3 D
+-2 0 D
+1 -2 D
+-2 0 D
+4 -2 D
+-4 -1 D
+4 -3 D
+-3 -1 D
+3 -2 D
+-4 -6 D
+1 -1 D
+7 1 D
+0 4 D
+1 -3 D
+1 2 D
+-1 1 D
+2 -1 D
+-3 2 D
+5 -2 D
+0 2 D
+3 -4 D
+6 0 D
+0 4 D
+4 -5 D
+4 0 D
+P
+FO
+5906 955 M
+-5 2 D
+P
+FO
+5890 968 M
+0 3 D
+-3 -2 D
+0 -3 D
+P
+FO
+5885 970 M
+1 -1 D
+1 3 D
+P
+FO
+5891 972 M
+3 0 D
+P
+FO
+5901 958 M
+2 -1 D
+P
+FO
+5903 960 M
+2 -1 D
+P
+FO
+5894 964 M
+4 1 D
+P
+FO
+5874 960 M
+3 0 D
+P
+FO
+5906 960 M
+4 0 D
+2 -2 D
+4 0 D
+-3 1 D
+5 2 D
+0 5 D
+-5 1 D
+-4 -3 D
+-2 2 D
+P
+5915 965 M
+3 0 D
+P
+FO
+5906 955 M
+0 0 D
+P
+FO
+5906 952 M
+5 0 D
+-2 2 D
+4 1 D
+-7 1 D
+2 -3 D
+-2 1 D
+P
+FO
+7745 1181 M
+3 -2 D
+2 -4 D
+6 1 D
+-1 3 D
+-2 -1 D
+2 3 D
+P
+FO
+7651 1181 M
+1 -4 D
+5 4 D
+P
+FO
+7706 1103 M
+0 -2 D
+-6 1 D
+1 -1 D
+-2 0 D
+3 -4 D
+4 2 D
+9 -2 D
+-1 2 D
+3 -4 D
+4 0 D
+3 4 D
+-1 1 D
+2 0 D
+1 2 D
+-2 0 D
+3 1 D
+-4 3 D
+1 1 D
+0 -1 D
+2 -1 D
+1 1 D
+-1 -2 D
+4 0 D
+1 6 D
+2 -1 D
+0 3 D
+-4 5 D
+5 -5 D
+2 0 D
+-2 -3 D
+4 2 D
+-2 2 D
+3 1 D
+-4 2 D
+5 -3 D
+3 0 D
+3 -3 D
+-3 -1 D
+-3 3 D
+-1 -4 D
+3 0 D
+-1 -1 D
+2 -2 D
+2 0 D
+0 3 D
+3 -3 D
+-2 5 D
+1 3 D
+-3 0 D
+3 5 D
+-2 3 D
+3 1 D
+0 4 D
+-2 0 D
+4 5 D
+3 0 D
+-3 1 D
+3 3 D
+-1 -3 D
+3 -1 D
+0 -4 D
+2 2 D
+-3 4 D
+2 10 D
+-2 4 D
+2 4 D
+-3 -1 D
+3 1 D
+-2 2 D
+2 5 D
+-6 5 D
+-3 1 D
+-2 -4 D
+-5 2 D
+-5 -5 D
+-4 2 D
+-3 -2 D
+-3 1 D
+-6 -2 D
+4 -3 D
+-1 -1 D
+-4 4 D
+-4 -2 D
+1 -3 D
+-2 4 D
+-6 -2 D
+-18 8 D
+-4 0 D
+-2 3 D
+0 -2 D
+-3 0 D
+0 -1 D
+-10 4 D
+0 -4 D
+-2 -4 D
+3 -9 D
+5 -6 D
+-1 -1 D
+8 -7 D
+0 -5 D
+2 1 D
+4 -5 D
+1 0 D
+-2 -4 D
+0 4 D
+-7 4 D
+2 -10 D
+3 -1 D
+3 -8 D
+4 -1 D
+4 -6 D
+2 0 D
+-1 1 D
+1 2 D
+2 -4 D
+P
+7706 1114 M
+-2 3 D
+-4 0 D
+3 3 D
+1 -2 D
+2 2 D
+3 -5 D
+P
+7707 1110 M
+-7 6 D
+5 -2 D
+-2 0 D
+2 -2 D
+3 1 D
+2 -3 D
+P
+7722 1133 M
+0 3 D
+2 -1 D
+P
+7707 1128 M
+-2 0 D
+1 2 D
+P
+7728 1129 M
+0 3 D
+2 0 D
+P
+7717 1134 M
+0 5 D
+3 -2 D
+P
+7705 1131 M
+-2 3 D
+P
+FO
+7727 1100 M
+1 -2 D
+2 2 D
+2 -2 D
+0 5 D
+3 1 D
+-2 5 D
+-2 -3 D
+2 0 D
+0 -2 D
+-4 -2 D
+-1 -3 D
+P
+FO
+7748 1171 M
+7 0 D
+1 -2 D
+3 2 D
+-3 3 D
+P
+FO
+7677 1165 M
+-2 1 D
+-1 -2 D
+5 0 D
+P
+FO
+7748 1118 M
+0 -2 D
+4 3 D
+-2 1 D
+P
+FO
+7750 1168 M
+3 -1 D
+1 3 D
+-4 -1 D
+P
+FO
+7670 1170 M
+1 -3 D
+1 5 D
+P
+FO
+7673 1171 M
+2 -1 D
+1 2 D
+P
+FO
+7754 1126 M
+2 0 D
+-2 1 D
+P
+FO
+7744 1174 M
+2 0 D
+P
+FO
+7741 1179 M
+2 2 D
+P
+FO
+7678 1163 M
+2 -1 D
+P
+FO
+8268 1042 M
+-3 1 D
+3 -1 D
+0 34 D
+-2 -1 D
+2 1 D
+0 27 D
+-5 -3 D
+4 -1 D
+-5 1 D
+1 -3 D
+-2 2 D
+-3 -4 D
+-1 1 D
+-3 -1 D
+1 -1 D
+-2 1 D
+-8 -4 D
+3 -3 D
+3 0 D
+-2 -1 D
+-4 3 D
+-8 -4 D
+-2 2 D
+-6 -2 D
+-7 -6 D
+1 -1 D
+-7 -4 D
+3 -4 D
+-4 2 D
+-6 -4 D
+0 -3 D
+-1 2 D
+-3 -1 D
+2 -4 D
+-2 4 D
+-5 -4 D
+4 -1 D
+-4 1 D
+1 -4 D
+-2 3 D
+-2 -1 D
+3 -2 D
+-4 1 D
+1 -4 D
+4 1 D
+0 -2 D
+-4 1 D
+4 -4 D
+-3 -1 D
+0 3 D
+-3 -1 D
+3 2 D
+-6 1 D
+0 -2 D
+2 -1 D
+-3 0 D
+-2 -4 D
+8 2 D
+-3 -1 D
+3 0 D
+-7 -1 D
+1 -2 D
+5 2 D
+-6 -3 D
+6 0 D
+-13 -3 D
+1 -4 D
+6 4 D
+-2 -2 D
+3 0 D
+-3 -1 D
+-1 -3 D
+8 4 D
+-7 -5 D
+1 -2 D
+13 -1 D
+3 1 D
+1 2 D
+6 -1 D
+3 -5 D
+8 1 D
+4 -3 D
+1 1 D
+2 -1 D
+-4 -1 D
+2 -2 D
+1 2 D
+3 -2 D
+7 1 D
+5 -3 D
+3 2 D
+2 -1 D
+9 2 D
+6 3 D
+-1 2 D
+5 2 D
+P
+8219 1063 M
+-5 -9 D
+-6 1 D
+7 0 D
+-1 3 D
+-4 1 D
+2 1 D
+4 -1 D
+-1 4 D
+2 -3 D
+1 4 D
+2 0 D
+P
+8231 1068 M
+2 -7 D
+5 1 D
+1 -7 D
+-2 6 D
+-4 -1 D
+-2 1 D
+-2 11 D
+P
+8249 1079 M
+-1 -9 D
+-3 1 D
+1 1 D
+-5 3 D
+5 -3 D
+3 8 D
+-3 1 D
+3 -1 D
+P
+8265 1083 M
+2 -3 D
+-2 1 D
+-1 5 D
+1 2 D
+0 -3 D
+2 2 D
+P
+8212 1051 M
+-1 -2 D
+-6 1 D
+2 2 D
+P
+8207 1039 M
+-2 -1 D
+1 2 D
+-3 3 D
+P
+8210 1043 M
+-4 -1 D
+0 1 D
+P
+8237 1082 M
+-3 -3 D
+4 4 D
+P
+8252 1072 M
+-1 4 D
+4 2 D
+P
+8202 1040 M
+-2 -4 D
+P
+8223 1077 M
+0 -3 D
+P
+8197 1036 M
+-1 -1 D
+P
+FO
+8220 1013 M
+6 0 D
+-1 5 D
+-1 -2 D
+-3 2 D
+-2 -1 D
+1 2 D
+4 -1 D
+-4 4 D
+-5 1 D
+-2 -1 D
+1 -7 D
+-4 -1 D
+-2 -5 D
+4 0 D
+-2 1 D
+3 2 D
+3 -1 D
+P
+FO
+8184 1045 M
+2 2 D
+1 -2 D
+2 0 D
+1 4 D
+-4 -1 D
+P
+FO
+8197 1056 M
+-1 3 D
+-2 -2 D
+P
+FO
+8192 1046 M
+2 0 D
+P
+FO
+8188 1045 M
+4 0 D
+P
+FO
+8211 1021 M
+2 0 D
+P
+FO
+8185 1045 M
+2 0 D
+P
+FO
+8387 1181 M
+3 -3 D
+2 -9 D
+-8 -12 D
+-2 -1 D
+2 -1 D
+-3 0 D
+-4 -4 D
+5 -2 D
+-1 2 D
+2 1 D
+0 -4 D
+6 1 D
+2 -6 D
+5 1 D
+13 8 D
+8 12 D
+7 5 D
+1 5 D
+5 4 D
+1 3 D
+P
+8390 1151 M
+3 2 D
+P
+FO
+8268 1076 M
+0 -43 D
+7 7 D
+10 2 D
+0 3 D
+0 -1 D
+-4 2 D
+6 6 D
+1 5 D
+7 7 D
+-6 2 D
+6 -1 D
+1 10 D
+-2 1 D
+2 -1 D
+3 5 D
+5 2 D
+-5 4 D
+5 -4 D
+6 3 D
+0 1 D
+0 -1 D
+10 4 D
+-13 9 D
+12 -7 D
+1 -2 D
+12 2 D
+5 -2 D
+0 3 D
+1 -3 D
+2 1 D
+2 3 D
+-2 2 D
+-10 0 D
+4 1 D
+-2 1 D
+0 4 D
+-2 -1 D
+3 7 D
+11 4 D
+7 12 D
+5 1 D
+-1 1 D
+14 15 D
+-6 7 D
+2 3 D
+2 1 D
+-2 -2 D
+5 3 D
+-10 -1 D
+7 2 D
+-1 2 D
+1 -1 D
+3 4 D
+-3 -2 D
+1 2 D
+-3 0 D
+0 -2 D
+-3 2 D
+-1 -1 D
+2 0 D
+0 -2 D
+-2 -1 D
+0 1 D
+-2 -2 D
+6 0 D
+-6 -1 D
+1 0 D
+-2 -1 D
+-1 0 D
+2 2 D
+-2 1 D
+4 2 D
+-4 -1 D
+0 2 D
+2 1 D
+-1 1 D
+-4 -4 D
+-1 1 D
+-10 -6 D
+-4 4 D
+1 7 D
+-1 -1 D
+-1 3 D
+-4 -1 D
+-4 4 D
+3 3 D
+7 -1 D
+-10 1 D
+-2 -1 D
+2 -1 D
+-3 -1 D
+1 1 D
+-10 -6 D
+-2 -13 D
+-8 -8 D
+-6 0 D
+-7 -19 D
+-12 -10 D
+2 -3 D
+-2 3 D
+-5 -2 D
+4 -1 D
+1 -2 D
+-4 3 D
+0 -1 D
+-2 1 D
+0 -1 D
+-3 0 D
+3 -2 D
+-3 1 D
+-5 -4 D
+2 -1 D
+-3 1 D
+P
+8280 1098 M
+1 -5 D
+2 2 D
+-10 -19 D
+-1 3 D
+3 1 D
+5 8 D
+P
+8287 1101 M
+5 -4 D
+0 -3 D
+4 -1 D
+-5 0 D
+-6 6 D
+3 -1 D
+P
+8273 1093 M
+1 -10 D
+-2 -1 D
+-1 10 D
+P
+8279 1089 M
+0 -1 D
+P
+8303 1104 M
+3 -2 D
+P
+8302 1118 M
+0 2 D
+P
+8273 1074 M
+-3 1 D
+P
+8330 1137 M
+-1 1 D
+P
+8335 1137 M
+0 1 D
+P
+FO
+8357 1159 M
+3 1 D
+1 5 D
+-1 -3 D
+-2 1 D
+P
+FO
+8474 952 M
+3 1 D
+P
+FO
+8371 1153 M
+1 2 D
+-6 -3 D
+P
+FO
+8363 1158 M
+1 1 D
+P
+FO
+79 1087 M
+1 -3 D
+7 1 D
+-2 4 D
+5 4 D
+-10 1 D
+-5 -1 D
+-1 -3 D
+5 1 D
+2 -1 D
+1 -2 D
+P
+FO
+88 1081 M
+1 -3 D
+2 2 D
+P
+FO
+2492 945 M
+-3 3 D
+3 -3 D
+1 3 D
+1 -1 D
+1 1 D
+-4 3 D
+4 -1 D
+-1 4 D
+-4 -2 D
+3 2 D
+-2 2 D
+3 5 D
+0 5 D
+-3 2 D
+2 1 D
+-1 2 D
+-2 -1 D
+2 5 D
+-4 -4 D
+1 4 D
+-2 1 D
+-1 -4 D
+-1 4 D
+-5 -2 D
+3 -2 D
+-3 2 D
+-1 -2 D
+1 -1 D
+4 2 D
+-4 -2 D
+4 0 D
+-3 -2 D
+4 1 D
+1 -2 D
+-2 1 D
+-2 -1 D
+4 -2 D
+-2 0 D
+2 -2 D
+-3 0 D
+2 -1 D
+-2 0 D
+0 -4 D
+-5 5 D
+3 -3 D
+-3 1 D
+1 -2 D
+-3 2 D
+3 -2 D
+-3 0 D
+-1 2 D
+-2 0 D
+3 -2 D
+-2 1 D
+3 -2 D
+-2 -1 D
+6 1 D
+-6 -1 D
+3 -1 D
+-7 4 D
+1 1 D
+-3 -1 D
+1 -3 D
+3 1 D
+-2 -3 D
+2 2 D
+0 -2 D
+3 1 D
+-3 -2 D
+4 1 D
+-4 -2 D
+4 0 D
+-2 -1 D
+2 0 D
+-3 0 D
+3 -1 D
+-2 0 D
+2 -4 D
+3 1 D
+-1 -2 D
+3 3 D
+-2 1 D
+2 2 D
+-2 -2 D
+1 3 D
+-3 2 D
+3 -2 D
+0 4 D
+1 -3 D
+1 4 D
+0 -3 D
+4 2 D
+-2 2 D
+2 -1 D
+4 2 D
+-4 -3 D
+3 0 D
+-4 -1 D
+1 -1 D
+-1 1 D
+-3 -1 D
+5 -3 D
+-5 1 D
+2 -2 D
+-3 0 D
+2 -3 D
+3 2 D
+-2 -3 D
+5 2 D
+-4 -2 D
+-3 0 D
+0 -2 D
+4 1 D
+3 -1 D
+-3 1 D
+-4 -2 D
+P
+2491 958 M
+-1 2 D
+P
+FO
+2502 945 M
+-5 2 D
+-1 -2 D
+P
+FO
+2521 945 M
+3 1 D
+74 -1 D
+0 236 D
+-87 0 D
+1 -3 D
+-3 -7 D
+2 -3 D
+-4 -2 D
+2 -3 D
+-2 0 D
+0 -4 D
+-2 -2 D
+3 -6 D
+1 -7 D
+7 0 D
+-2 -2 D
+-2 1 D
+-3 -3 D
+10 -2 D
+-1 1 D
+3 0 D
+1 2 D
+2 -2 D
+0 2 D
+0 -1 D
+2 1 D
+-1 2 D
+4 3 D
+5 -1 D
+2 -4 D
+4 0 D
+4 7 D
+0 -6 D
+-8 -2 D
+-6 -4 D
+7 -3 D
+4 2 D
+-1 -5 D
+3 0 D
+-3 -1 D
+0 -1 D
+2 0 D
+-3 -1 D
+1 -5 D
+-2 7 D
+-7 -2 D
+8 -8 D
+-7 3 D
+-1 -6 D
+4 -4 D
+-2 -2 D
+1 -2 D
+-3 1 D
+0 -4 D
+-5 -2 D
+-1 -4 D
+6 -4 D
+-5 -2 D
+5 -1 D
+0 3 D
+0 -3 D
+-2 -2 D
+-1 2 D
+-3 -4 D
+1 -2 D
+-2 1 D
+2 -3 D
+-3 1 D
+0 -2 D
+-2 1 D
+0 -1 D
+2 -1 D
+2 2 D
+0 -3 D
+-2 0 D
+8 -1 D
+-2 -2 D
+4 0 D
+2 -3 D
+3 4 D
+0 -5 D
+-2 0 D
+-1 -6 D
+-2 1 D
+-8 -5 D
+-6 0 D
+2 -5 D
+-4 -1 D
+-2 0 D
+5 -2 D
+3 1 D
+5 -4 D
+5 0 D
+-2 -1 D
+-3 0 D
+-5 4 D
+-5 -2 D
+0 -1 D
+-2 -1 D
+-2 -8 D
+7 5 D
+0 -1 D
+3 0 D
+-6 -2 D
+-3 -3 D
+2 -1 D
+-5 -2 D
+0 -8 D
+6 7 D
+2 -1 D
+-6 -5 D
+4 -1 D
+-4 0 D
+-4 -2 D
+3 -3 D
+-3 1 D
+-2 -2 D
+-3 0 D
+5 7 D
+-3 3 D
+-3 -2 D
+4 -3 D
+-4 2 D
+-2 -2 D
+2 4 D
+-7 -2 D
+-4 2 D
+4 -2 D
+7 3 D
+0 4 D
+-2 -4 D
+-6 0 D
+6 1 D
+0 2 D
+-5 0 D
+6 1 D
+0 1 D
+-5 1 D
+4 2 D
+-5 -2 D
+0 2 D
+-3 0 D
+2 -4 D
+-2 -2 D
+-2 5 D
+-3 0 D
+-2 -1 D
+0 2 D
+-3 -2 D
+-2 1 D
+3 -2 D
+-7 1 D
+1 -2 D
+3 0 D
+-2 -1 D
+5 0 D
+-6 -1 D
+4 -1 D
+5 5 D
+-1 -3 D
+4 -1 D
+-5 0 D
+0 -3 D
+2 0 D
+-2 -1 D
+-3 2 D
+1 -4 D
+-5 1 D
+2 -1 D
+-2 0 D
+5 -1 D
+-7 1 D
+0 -3 D
+-1 1 D
+-2 -1 D
+-1 -2 D
+-4 0 D
+2 -3 D
+-4 1 D
+-1 -3 D
+3 -5 D
+4 0 D
+2 2 D
+-3 -1 D
+2 2 D
+-1 1 D
+-2 -1 D
+2 2 D
+-4 0 D
+-2 -2 D
+1 2 D
+4 3 D
+1 -2 D
+3 1 D
+0 2 D
+1 -2 D
+6 5 D
+-3 -5 D
+4 -4 D
+2 2 D
+2 -3 D
+5 -1 D
+1 1 D
+-6 1 D
+5 1 D
+-3 1 D
+9 0 D
+-2 -2 D
+2 -1 D
+3 1 D
+-3 -1 D
+3 -3 D
+3 0 D
+-2 -4 D
+3 -1 D
+-5 0 D
+1 -4 D
+-1 4 D
+-3 0 D
+2 -4 D
+-3 4 D
+-5 -6 D
+6 1 D
+-5 -1 D
+2 -2 D
+0 1 D
+7 1 D
+-6 -2 D
+1 -1 D
+9 2 D
+-5 -2 D
+3 -1 D
+-7 0 D
+5 0 D
+-5 -1 D
+4 -2 D
+-5 2 D
+-6 -1 D
+5 2 D
+-2 2 D
+-1 -2 D
+0 2 D
+-5 -4 D
+3 0 D
+0 -1 D
+-2 0 D
+3 -1 D
+2 2 D
+-2 -2 D
+12 0 D
+2 -2 D
+4 2 D
+1 4 D
+2 -1 D
+-2 -3 D
+4 -1 D
+1 -3 D
+7 -1 D
+-6 0 D
+-4 2 D
+0 -3 D
+3 1 D
+-2 -1 D
+5 -4 D
+2 4 D
+-2 -4 D
+3 -1 D
+-3 -1 D
+-2 2 D
+-4 -1 D
+1 2 D
+-3 1 D
+-2 -1 D
+1 3 D
+-3 -2 D
+1 2 D
+-6 1 D
+-1 -2 D
+-1 2 D
+-2 -1 D
+2 -5 D
+2 1 D
+-2 -1 D
+-1 1 D
+-1 -1 D
+-1 6 D
+-5 1 D
+-2 -1 D
+1 -2 D
+5 2 D
+-3 -2 D
+4 -3 D
+2 -3 D
+7 1 D
+-7 -1 D
+10 -2 D
+-5 0 D
+2 -4 D
+-5 3 D
+-5 -3 D
+1 -2 D
+3 1 D
+-2 -2 D
+6 0 D
+-6 -1 D
+2 -2 D
+-4 3 D
+-1 -2 D
+2 -3 D
+-3 -1 D
+3 -5 D
+-1 0 D
+-1 -5 D
+6 -3 D
+0 8 D
+2 -2 D
+1 2 D
+6 -5 D
+-6 3 D
+-1 -6 D
+5 0 D
+1 -3 D
+4 -2 D
+-1 -2 D
+-5 6 D
+-3 -2 D
+1 2 D
+-2 1 D
+-6 -3 D
+1 -3 D
+6 1 D
+0 -1 D
+-7 0 D
+2 -3 D
+6 -2 D
+4 4 D
+-2 -2 D
+2 0 D
+-4 -2 D
+P
+2526 970 M
+2 4 D
+-4 2 D
+7 -2 D
+1 4 D
+-1 3 D
+-3 2 D
+4 -2 D
+0 -7 D
+3 -1 D
+3 1 D
+-3 7 D
+2 1 D
+4 -11 D
+-2 2 D
+-2 -1 D
+7 -2 D
+-4 -4 D
+5 -1 D
+-6 0 D
+1 5 D
+-2 -3 D
+-1 4 D
+-5 2 D
+-6 -4 D
+P
+2529 1015 M
+3 6 D
+4 3 D
+-3 3 D
+2 2 D
+1 -4 D
+4 0 D
+16 5 D
+-4 3 D
+5 -2 D
+4 2 D
+-2 -2 D
+9 -2 D
+3 -2 D
+-2 -2 D
+-14 3 D
+-9 -2 D
+-14 -7 D
+-1 -3 D
+P
+2558 1164 M
+2 -3 D
+0 1 D
+7 -4 D
+-4 1 D
+1 -2 D
+6 -2 D
+-4 -1 D
+-5 2 D
+-3 -2 D
+2 2 D
+-4 1 D
+5 1 D
+-5 5 D
+P
+2561 1160 M
+1 -2 D
+P
+2487 1031 M
+6 -2 D
+-2 4 D
+4 -3 D
+5 1 D
+-5 -2 D
+4 -1 D
+-3 -1 D
+0 -2 D
+-2 3 D
+-2 -1 D
+1 -3 D
+P
+2545 950 M
+-11 4 D
+-7 -2 D
+3 2 D
+-3 3 D
+3 2 D
+4 -3 D
+13 -2 D
+2 -3 D
+P
+2548 1154 M
+-1 1 D
+-3 -3 D
+-3 3 D
+6 1 D
+2 -1 D
+1 1 D
+P
+2569 968 M
+-4 2 D
+0 3 D
+5 -1 D
+0 2 D
+3 -3 D
+P
+2529 1150 M
+-3 5 D
+5 4 D
+4 -2 D
+3 -4 D
+P
+2549 1009 M
+-2 2 D
+-7 -1 D
+7 2 D
+8 -6 D
+P
+2561 1149 M
+-1 2 D
+2 -2 D
+1 2 D
+-1 -2 D
+P
+2569 982 M
+-2 1 D
+5 1 D
+0 -1 D
+P
+2544 1177 M
+1 -3 D
+-7 0 D
+1 4 D
+P
+2540 1163 M
+7 -3 D
+-8 0 D
+-4 3 D
+P
+2563 1087 M
+-5 0 D
+-3 2 D
+10 0 D
+P
+2545 1100 M
+-5 6 D
+7 -4 D
+P
+2543 1166 M
+-3 -2 D
+-3 1 D
+P
+2503 1022 M
+0 2 D
+3 1 D
+P
+2562 1169 M
+6 -4 D
+-6 2 D
+P
+2562 1008 M
+-2 2 D
+4 -2 D
+-1 0 D
+P
+2559 1066 M
+-5 -1 D
+-2 2 D
+8 -1 D
+P
+2557 1114 M
+0 2 D
+4 -2 D
+P
+2552 1117 M
+1 3 D
+4 -3 D
+P
+2560 981 M
+2 2 D
+1 -1 D
+P
+2559 1130 M
+-1 2 D
+2 0 D
+P
+2556 1168 M
+2 -3 D
+P
+2566 1064 M
+-6 2 D
+P
+2559 1005 M
+2 0 D
+-1 -1 D
+P
+2542 1083 M
+1 4 D
+0 -5 D
+P
+2553 1004 M
+2 1 D
+0 -1 D
+P
+FO
+2504 1101 M
+3 -1 D
+2 1 D
+-2 3 D
+5 -1 D
+-2 5 D
+6 -1 D
+-4 6 D
+4 0 D
+0 2 D
+-7 5 D
+5 1 D
+-3 1 D
+1 3 D
+7 1 D
+0 3 D
+-3 1 D
+2 2 D
+-4 3 D
+2 1 D
+-1 3 D
+-7 -2 D
+1 -1 D
+-5 1 D
+3 1 D
+-5 1 D
+2 -7 D
+-5 -5 D
+0 -5 D
+2 -3 D
+-3 -10 D
+-5 -5 D
+9 -3 D
+0 1 D
+P
+FO
+2466 990 M
+2 -4 D
+3 1 D
+-4 -3 D
+5 1 D
+-5 -3 D
+7 2 D
+-1 -2 D
+2 0 D
+-2 -1 D
+1 -4 D
+2 0 D
+-1 -2 D
+4 4 D
+-2 1 D
+0 3 D
+-2 -1 D
+2 1 D
+-4 4 D
+1 2 D
+-2 -1 D
+1 2 D
+-2 0 D
+2 1 D
+P
+FO
+2528 1067 M
+4 4 D
+-4 2 D
+4 -2 D
+3 3 D
+-4 2 D
+-3 -3 D
+2 3 D
+-2 2 D
+-3 0 D
+0 -2 D
+-1 1 D
+-2 -1 D
+3 -3 D
+-4 1 D
+1 -2 D
+-4 1 D
+-1 -2 D
+2 -3 D
+2 1 D
+3 -1 D
+-6 -1 D
+3 -2 D
+P
+FO
+2468 968 M
+1 -1 D
+4 3 D
+1 -4 D
+2 2 D
+-2 3 D
+-2 1 D
+1 -2 D
+-2 2 D
+-1 -1 D
+1 2 D
+-3 -2 D
+2 1 D
+-5 -1 D
+0 -2 D
+5 1 D
+-2 -1 D
+P
+FO
+2480 989 M
+-6 1 D
+3 -2 D
+-2 0 D
+2 0 D
+-1 -2 D
+2 1 D
+-1 -1 D
+2 -1 D
+-2 0 D
+3 -4 D
+4 2 D
+1 3 D
+-2 -1 D
+3 2 D
+-4 -1 D
+1 2 D
+P
+FO
+2480 978 M
+10 -2 D
+3 1 D
+-1 2 D
+0 -2 D
+-2 1 D
+-2 4 D
+2 1 D
+-3 6 D
+-2 -4 D
+2 -4 D
+-1 -2 D
+-2 4 D
+-4 -3 D
+P
+FO
+2473 968 M
+-6 -4 D
+1 2 D
+-2 -3 D
+3 -1 D
+0 3 D
+3 1 D
+-1 -2 D
+2 1 D
+0 3 D
+-1 -1 D
+P
+FO
+2492 1046 M
+3 -1 D
+2 1 D
+-3 1 D
+5 0 D
+0 2 D
+-4 1 D
+4 0 D
+-3 1 D
+2 0 D
+-3 2 D
+P
+FO
+2465 981 M
+0 -4 D
+6 2 D
+-3 -2 D
+3 1 D
+-2 -2 D
+-3 0 D
+1 -1 D
+7 3 D
+-1 2 D
+-2 -1 D
+1 3 D
+P
+FO
+2504 1070 M
+1 1 D
+-1 -1 D
+3 0 D
+-2 3 D
+-11 -1 D
+2 0 D
+-1 -2 D
+6 -1 D
+-6 1 D
+2 -2 D
+P
+FO
+2480 967 M
+-2 1 D
+1 -1 D
+-2 1 D
+-2 -3 D
+3 1 D
+-2 -1 D
+3 0 D
+4 -4 D
+1 5 D
+P
+FO
+2504 1057 M
+7 -1 D
+0 6 D
+-3 1 D
+-10 -2 D
+1 -2 D
+1 2 D
+1 -2 D
+7 -1 D
+-4 0 D
+P
+FO
+2480 992 M
+3 -2 D
+-4 1 D
+4 -1 D
+2 1 D
+-6 3 D
+-4 -1 D
+2 -1 D
+-3 -1 D
+P
+FO
+2466 953 M
+4 -2 D
+-3 -3 D
+5 4 D
+0 -4 D
+3 -1 D
+-1 2 D
+3 -2 D
+-5 7 D
+P
+FO
+2504 995 M
+-7 2 D
+-1 -1 D
+2 -2 D
+-3 2 D
+-3 -2 D
+5 -2 D
+11 1 D
+0 2 D
+P
+FO
+2506 1073 M
+4 -4 D
+4 1 D
+-4 -1 D
+3 3 D
+-1 2 D
+-4 -1 D
+1 -2 D
+P
+FO
+2504 1083 M
+-2 0 D
+2 -2 D
+-3 1 D
+4 -3 D
+-2 2 D
+4 0 D
+P
+FO
+2471 998 M
+5 -1 D
+-1 -1 D
+5 1 D
+-4 0 D
+2 1 D
+0 2 D
+-3 -2 D
+P
+FO
+2490 989 M
+0 -4 D
+2 2 D
+-1 -2 D
+1 -1 D
+3 2 D
+P
+FO
+2509 1048 M
+4 -3 D
+1 2 D
+-3 2 D
+3 -1 D
+0 4 D
+-3 1 D
+P
+FO
+2503 1063 M
+-1 1 D
+4 0 D
+-5 2 D
+-6 -3 D
+3 -1 D
+P
+FO
+2504 1052 M
+-3 -1 D
+0 -2 D
+4 2 D
+3 -2 D
+1 3 D
+-7 1 D
+P
+FO
+2494 1060 M
+4 -1 D
+0 2 D
+-1 -1 D
+-2 1 D
+1 -1 D
+0 2 D
+P
+FO
+2492 983 M
+6 -2 D
+2 1 D
+-4 3 D
+-2 -1 D
+4 -2 D
+P
+FO
+2504 1057 M
+-4 1 D
+2 -4 D
+-1 2 D
+4 -2 D
+5 1 D
+P
+FO
+2504 1076 M
+-5 1 D
+5 -2 D
+-3 0 D
+2 -2 D
+3 1 D
+P
+FO
+2496 1045 M
+5 -1 D
+-4 1 D
+2 0 D
+-1 1 D
+P
+FO
+2506 1066 M
+2 -2 D
+2 0 D
+-2 4 D
+-2 -1 D
+2 -2 D
+P
+FO
+2494 1057 M
+3 -2 D
+1 3 D
+1 -3 D
+0 3 D
+-4 1 D
+P
+FO
+2504 1088 M
+3 0 D
+-2 2 D
+4 1 D
+-8 0 D
+-1 -2 D
+4 0 D
+P
+FO
+2504 1043 M
+0 -2 D
+3 4 D
+-4 1 D
+-1 -2 D
+P
+FO
+2477 968 M
+3 1 D
+-4 2 D
+3 0 D
+-5 3 D
+P
+FO
+2505 1040 M
+2 -1 D
+1 3 D
+3 -1 D
+0 3 D
+-6 -3 D
+P
+FO
+2480 976 M
+0 -2 D
+5 2 D
+-5 1 D
+3 -2 D
+P
+FO
+2491 1075 M
+4 -1 D
+-2 1 D
+6 1 D
+-3 1 D
+P
+FO
+2504 1015 M
+-4 0 D
+0 -4 D
+3 1 D
+P
+FO
+2522 1087 M
+2 -1 D
+1 3 D
+-3 0 D
+P
+FO
+2491 1069 M
+2 -2 D
+4 0 D
+-3 3 D
+P
+FO
+2484 1096 M
+1 -2 D
+5 1 D
+-4 2 D
+P
+FO
+2528 1116 M
+1 -1 D
+0 2 D
+-2 1 D
+P
+FO
+2506 1076 M
+4 0 D
+-3 0 D
+1 2 D
+P
+FO
+2510 1087 M
+3 -3 D
+0 2 D
+-2 2 D
+P
+FO
+2495 1074 M
+1 -1 D
+5 1 D
+-2 2 D
+-4 -1 D
+P
+FO
+2504 1066 M
+1 1 D
+-1 1 D
+-5 -1 D
+P
+FO
+2507 1039 M
+-2 -2 D
+5 -3 D
+2 3 D
+P
+FO
+2475 1067 M
+1 -2 D
+3 0 D
+-2 3 D
+P
+FO
+2528 1137 M
+-2 3 D
+0 -2 D
+-1 0 D
+P
+FO
+2504 1050 M
+-3 -1 D
+4 -3 D
+2 2 D
+P
+FO
+2493 956 M
+2 -3 D
+3 2 D
+-4 4 D
+P
+FO
+2508 1039 M
+3 -1 D
+1 3 D
+-3 -1 D
+P
+FO
+2465 976 M
+2 -3 D
+6 5 D
+-5 -3 D
+P
+FO
+2509 1078 M
+2 -2 D
+-1 1 D
+3 1 D
+P
+FO
+2499 1081 M
+2 -2 D
+0 2 D
+P
+FO
+2515 1084 M
+1 -2 D
+1 2 D
+P
+FO
+2504 1054 M
+-2 1 D
+1 -2 D
+P
+FO
+2489 994 M
+0 -2 D
+2 2 D
+P
+FO
+2517 1130 M
+2 0 D
+-2 1 D
+P
+FO
+2522 1139 M
+2 0 D
+-2 2 D
+P
+FO
+2474 974 M
+4 -2 D
+1 5 D
+P
+FO
+2483 993 M
+2 1 D
+-2 3 D
+-2 -2 D
+P
+FO
+2492 1055 M
+6 -2 D
+-3 3 D
+P
+FO
+2488 1046 M
+2 -1 D
+1 4 D
+P
+FO
+2492 983 M
+3 -4 D
+2 2 D
+P
+FO
+2512 1124 M
+6 -4 D
+-3 4 D
+-3 1 D
+P
+FO
+2492 1013 M
+1 -2 D
+4 3 D
+P
+FO
+2506 1076 M
+0 2 D
+-2 0 D
+P
+FO
+2488 1071 M
+6 -1 D
+-4 2 D
+P
+FO
+2510 1069 M
+3 -2 D
+0 2 D
+P
+FO
+2504 1083 M
+4 -1 D
+-2 2 D
+P
+FO
+2504 1080 M
+5 -1 D
+0 1 D
+P
+FO
+2491 1050 M
+2 -1 D
+1 4 D
+P
+FO
+2480 999 M
+-2 1 D
+4 -3 D
+P
+FO
+2494 1080 M
+4 -1 D
+-2 2 D
+P
+FO
+2485 1073 M
+2 -2 D
+0 2 D
+P
+FO
+2511 992 M
+-2 2 D
+0 -2 D
+P
+FO
+2537 1131 M
+2 -1 D
+1 2 D
+P
+FO
+2521 1078 M
+3 -1 D
+-2 2 D
+P
+FO
+2483 1048 M
+4 -2 D
+-2 3 D
+P
+FO
+2506 1090 M
+4 -1 D
+-1 2 D
+P
+FO
+2499 1078 M
+3 -1 D
+-1 2 D
+P
+FO
+2493 1065 M
+2 -1 D
+2 1 D
+P
+FO
+2490 1044 M
+3 0 D
+-1 2 D
+P
+FO
+2517 1060 M
+3 -1 D
+-2 2 D
+P
+FO
+2488 996 M
+3 -2 D
+0 2 D
+P
+FO
+2523 1127 M
+1 -1 D
+2 1 D
+P
+FO
+2495 1083 M
+0 -1 D
+3 1 D
+P
+FO
+2485 992 M
+2 -1 D
+-2 3 D
+P
+FO
+2510 1080 M
+1 -1 D
+1 2 D
+P
+FO
+2487 996 M
+2 -1 D
+P
+FO
+2530 1052 M
+2 1 D
+P
+FO
+2517 1061 M
+1 1 D
+P
+FO
+2524 1136 M
+1 0 D
+P
+FO
+2528 1145 M
+1 1 D
+-2 -1 D
+P
+FO
+2523 1128 M
+1 -1 D
+P
+FO
+2511 1063 M
+1 -1 D
+P
+FO
+2504 1053 M
+5 1 D
+P
+FO
+2510 1119 M
+5 -1 D
+-2 2 D
+P
+FO
+2519 1110 M
+-6 2 D
+P
+FO
+2464 967 M
+5 0 D
+P
+FO
+2475 964 M
+4 -1 D
+P
+FO
+2508 1103 M
+3 -2 D
+P
+FO
+2474 975 M
+0 2 D
+-3 -2 D
+P
+FO
+2506 1043 M
+3 1 D
+P
+FO
+2506 1088 M
+3 -1 D
+P
+FO
+2467 957 M
+3 -1 D
+P
+FO
+2495 1084 M
+4 0 D
+P
+FO
+2508 1047 M
+3 -2 D
+P
+FO
+2528 1141 M
+-1 0 D
+3 0 D
+P
+FO
+2513 1056 M
+3 1 D
+P
+FO
+2495 1078 M
+3 0 D
+P
+FO
+2513 1055 M
+4 0 D
+P
+FO
+2512 1076 M
+2 0 D
+P
+FO
+2490 1058 M
+2 1 D
+P
+FO
+2468 973 M
+4 1 D
+P
+FO
+2478 968 M
+3 -1 D
+-3 2 D
+P
+FO
+2511 1075 M
+3 -1 D
+P
+FO
+2500 1083 M
+3 1 D
+P
+FO
+2515 1119 M
+2 0 D
+P
+FO
+2495 1085 M
+5 0 D
+P
+FO
+2519 1119 M
+3 -1 D
+P
+FO
+2499 1054 M
+2 1 D
+P
+FO
+2475 1022 M
+3 -1 D
+P
+FO
+2513 1105 M
+2 2 D
+P
+FO
+2494 1000 M
+1 2 D
+P
+FO
+2474 993 M
+4 2 D
+P
+FO
+2497 1055 M
+1 -1 D
+P
+FO
+2507 1088 M
+3 1 D
+P
+FO
+2472 973 M
+2 -1 D
+P
+FO
+2483 988 M
+2 0 D
+P
+FO
+2540 1134 M
+-1 -2 D
+P
+FO
+2517 1056 M
+3 0 D
+P
+FO
+2512 1106 M
+2 -2 D
+P
+FO
+2518 1122 M
+2 1 D
+-2 0 D
+P
+FO
+2511 990 M
+2 -1 D
+P
+FO
+2505 1081 M
+2 0 D
+P
+FO
+2509 995 M
+3 1 D
+P
+FO
+2519 1074 M
+1 -1 D
+P
+FO
+2474 991 M
+3 0 D
+P
+FO
+2506 1075 M
+2 0 D
+P
+FO
+2467 958 M
+2 0 D
+P
+FO
+2475 994 M
+3 1 D
+P
+FO
+2510 1082 M
+2 1 D
+P
+FO
+2485 991 M
+1 -2 D
+P
+FO
+2505 1069 M
+3 0 D
+P
+FO
+2526 1119 M
+1 -1 D
+P
+FO
+2497 1086 M
+2 0 D
+P
+FO
+2476 1023 M
+2 -1 D
+P
+FO
+2493 956 M
+0 -2 D
+P
+FO
+2501 1042 M
+2 0 D
+P
+FO
+2509 1075 M
+2 -1 D
+P
+FO
+2520 1127 M
+2 0 D
+P
+FO
+2527 1144 M
+0 -1 D
+1 1 D
+P
+FO
+2498 1051 M
+2 -1 D
+-2 2 D
+P
+FO
+2497 1100 M
+1 1 D
+P
+FO
+2472 955 M
+2 0 D
+P
+FO
+2505 1039 M
+-1 2 D
+P
+FO
+2484 990 M
+2 -1 D
+P
+FO
+2496 1082 M
+3 -1 D
+P
+FO
+2519 1124 M
+2 0 D
+P
+FO
+2477 964 M
+2 -1 D
+P
+FO
+2522 1119 M
+0 2 D
+P
+FO
+2524 1079 M
+1 0 D
+P
+FO
+2508 1075 M
+1 0 D
+P
+FO
+2515 1120 M
+1 1 D
+P
+FO
+2495 987 M
+1 -1 D
+P
+FO
+2494 1044 M
+2 1 D
+P
+FO
+2500 1085 M
+2 0 D
+P
+FO
+2517 1063 M
+-1 -1 D
+P
+FO
+2521 1127 M
+2 -1 D
+P
+FO
+2498 1012 M
+1 -1 D
+P
+FO
+2520 1123 M
+1 -1 D
+P
+FO
+2500 1087 M
+-2 0 D
+P
+FO
+2499 1082 M
+2 0 D
+P
+FO
+2494 1078 M
+1 -1 D
+P
+FO
+2520 1120 M
+1 0 D
+P
+FO
+2528 1092 M
+0 -1 D
+P
+FO
+2510 1066 M
+1 0 D
+P
+FO
+2473 964 M
+1 1 D
+P
+FO
+2499 1085 M
+2 1 D
+P
+FO
+2506 1085 M
+2 0 D
+P
+FO
+2506 1044 M
+1 1 D
+P
+FO
+2485 992 M
+1 -1 D
+P
+FO
+2521 1126 M
+1 0 D
+P
+FO
+2523 1139 M
+1 0 D
+P
+FO
+2633 945 M
+-6 1 D
+5 0 D
+-4 5 D
+6 -6 D
+14 0 D
+4 5 D
+3 13 D
+-2 -3 D
+-3 -1 D
+6 8 D
+8 5 D
+4 5 D
+17 7 D
+5 5 D
+5 0 D
+-2 2 D
+1 2 D
+4 1 D
+-3 4 D
+-4 -1 D
+5 1 D
+3 13 D
+-6 3 D
+-5 -1 D
+-14 3 D
+-15 10 D
+-5 12 D
+7 6 D
+0 4 D
+9 9 D
+11 1 D
+-2 2 D
+3 -1 D
+-1 2 D
+7 2 D
+12 -1 D
+4 3 D
+-5 2 D
+2 4 D
+9 3 D
+-1 2 D
+2 2 D
+-2 4 D
+3 4 D
+-2 2 D
+-1 7 D
+6 6 D
+0 2 D
+18 8 D
+-17 4 D
+1 3 D
+8 4 D
+6 0 D
+4 -3 D
+-1 -3 D
+4 -3 D
+10 2 D
+2 4 D
+-2 9 D
+1 -6 D
+1 4 D
+-4 6 D
+-15 -4 D
+7 0 D
+-1 -4 D
+-8 -1 D
+-3 1 D
+3 4 D
+-9 1 D
+-5 4 D
+1 10 D
+-2 1 D
+2 -1 D
+1 2 D
+-4 11 D
+1 5 D
+5 2 D
+-3 1 D
+7 -2 D
+-3 1 D
+0 -2 D
+7 0 D
+9 -4 D
+2 1 D
+7 -4 D
+16 0 D
+7 2 D
+0 2 D
+2 -1 D
+8 3 D
+5 6 D
+-6 4 D
+-1 4 D
+3 3 D
+1 4 D
+-182 0 D
+0 -236 D
+P
+2629 1047 M
+-4 1 D
+-3 4 D
+1 5 D
+2 -1 D
+-1 -3 D
+3 -1 D
+2 2 D
+1 -4 D
+3 -1 D
+-1 -2 D
+P
+2616 1054 M
+-2 2 D
+2 -1 D
+2 2 D
+1 -7 D
+-4 -1 D
+P
+2651 964 M
+-2 2 D
+P
+FO
+2780 1169 M
+3 -3 D
+0 1 D
+P
+FO
+2779 1173 M
+1 1 D
+P
+FO
+2783 1180 M
+2 0 D
+P
+FO
+2784 1177 M
+1 -1 D
+P
+FO
+2783 1171 M
+0 2 D
+P
+FO
+2782 1169 M
+2 1 D
+P
+FO
+4016 1174 M
+2 -2 D
+0 2 D
+P
+FO
+4331 840 M
+3 0 D
+P
+FO
+5982 874 M
+3 -1 D
+2 -4 D
+9 2 D
+-13 4 D
+P
+FO
+8173 925 M
+2 2 D
+1 -2 D
+4 0 D
+-3 3 D
+2 0 D
+-2 1 D
+3 2 D
+0 1 D
+-3 0 D
+2 1 D
+-3 0 D
+-1 -4 D
+-4 -2 D
+-1 -2 D
+P
+FO
+8244 885 M
+4 -2 D
+2 1 D
+-2 1 D
+3 0 D
+-2 2 D
+P
+FO
+8173 924 M
+-2 1 D
+4 -2 D
+4 1 D
+P
+FO
+2598 819 M
+0 1 D
+-2 0 D
+2 -2 D
+P
+FO
+2598 824 M
+0 -1 D
+P
+FO
+2598 828 M
+-4 -1 D
+P
+FO
+2598 830 M
+-2 0 D
+P
+FO
+2598 844 M
+-4 -1 D
+4 -1 D
+-3 0 D
+1 -2 D
+-20 8 D
+3 -2 D
+-2 1 D
+1 -3 D
+8 -1 D
+1 -2 D
+9 -4 D
+-5 2 D
+3 -2 D
+-2 0 D
+-6 4 D
+-4 -3 D
+3 4 D
+-6 1 D
+-2 -1 D
+0 -4 D
+-5 2 D
+1 -2 D
+-6 4 D
+-1 -3 D
+-6 2 D
+5 -2 D
+-3 -1 D
+-4 3 D
+-4 -1 D
+9 -3 D
+-6 2 D
+3 -2 D
+-9 3 D
+3 -4 D
+-2 0 D
+8 1 D
+0 -2 D
+1 2 D
+1 -2 D
+1 2 D
+1 -3 D
+3 2 D
+-2 1 D
+2 0 D
+0 1 D
+5 -2 D
+-4 -1 D
+2 -1 D
+7 2 D
+-3 -4 D
+3 3 D
+4 -1 D
+-4 0 D
+1 -2 D
+9 3 D
+-8 -3 D
+1 -1 D
+5 1 D
+6 -2 D
+2 4 D
+-2 -4 D
+6 2 D
+-1 -2 D
+2 1 D
+P
+FO
+2598 857 M
+-3 -1 D
+3 -8 D
+P
+FO
+2598 879 M
+-3 1 D
+-7 -1 D
+4 -1 D
+-1 -2 D
+5 -1 D
+-3 -3 D
+-3 0 D
+1 3 D
+-3 -2 D
+0 -6 D
+2 0 D
+-2 -2 D
+6 -2 D
+4 1 D
+P
+FO
+2525 945 M
+2 -5 D
+22 2 D
+2 -1 D
+0 -2 D
+-6 -2 D
+-12 2 D
+-6 -2 D
+0 -3 D
+7 0 D
+-6 -4 D
+2 3 D
+-4 1 D
+-2 3 D
+-4 -1 D
+2 3 D
+5 -1 D
+4 1 D
+-8 3 D
+-3 -3 D
+2 4 D
+-2 0 D
+1 2 D
+-17 0 D
+3 -2 D
+-5 2 D
+-6 0 D
+3 -4 D
+2 2 D
+-1 -3 D
+5 0 D
+-2 -1 D
+4 -1 D
+-5 1 D
+-2 -1 D
+-2 3 D
+-2 -1 D
+2 2 D
+-4 2 D
+-4 -2 D
+5 1 D
+-3 -2 D
+-1 1 D
+-4 -2 D
+4 1 D
+-2 -2 D
+4 -1 D
+-2 0 D
+5 -3 D
+1 4 D
+1 -2 D
+3 0 D
+-4 0 D
+1 -3 D
+7 2 D
+-5 -2 D
+7 -2 D
+-10 2 D
+5 -3 D
+-3 0 D
+2 -4 D
+2 1 D
+-2 -1 D
+2 -2 D
+5 2 D
+1 5 D
+5 4 D
+-4 -4 D
+10 -4 D
+-10 1 D
+0 -4 D
+-3 0 D
+2 -3 D
+-3 2 D
+-8 -1 D
+1 -3 D
+4 2 D
+-3 -2 D
+2 -4 D
+2 3 D
+2 -4 D
+4 2 D
+-2 3 D
+3 -3 D
+1 2 D
+1 -5 D
+-2 0 D
+1 -3 D
+3 -1 D
+-2 0 D
+1 -2 D
+-2 2 D
+2 -3 D
+-8 5 D
+0 -4 D
+3 0 D
+-3 -2 D
+4 0 D
+-2 -1 D
+3 -3 D
+2 4 D
+0 -2 D
+4 1 D
+-4 -1 D
+6 -7 D
+-6 5 D
+-1 -1 D
+2 -4 D
+7 -4 D
+-3 13 D
+4 -6 D
+-2 0 D
+1 -4 D
+3 -1 D
+0 3 D
+5 3 D
+-1 1 D
+-6 -2 D
+4 1 D
+-3 1 D
+4 0 D
+-6 2 D
+-2 4 D
+4 -2 D
+0 -1 D
+5 -1 D
+4 -3 D
+3 0 D
+3 2 D
+-14 6 D
+-2 -2 D
+1 2 D
+-5 1 D
+7 3 D
+0 2 D
+4 3 D
+2 -1 D
+-5 -2 D
+-2 -6 D
+10 -2 D
+1 -2 D
+-1 2 D
+6 -4 D
+0 -4 D
+-5 -1 D
+5 -5 D
+-2 -4 D
+-9 -3 D
+-1 0 D
+8 3 D
+2 3 D
+-5 6 D
+-5 -2 D
+1 -3 D
+3 1 D
+-1 -4 D
+-3 -1 D
+0 4 D
+-4 -2 D
+4 5 D
+-8 -4 D
+-10 5 D
+5 -5 D
+-3 -5 D
+4 1 D
+1 -2 D
+-2 0 D
+0 -2 D
+-2 1 D
+1 -1 D
+-2 -1 D
+2 -1 D
+-3 -3 D
+8 3 D
+-1 2 D
+4 -3 D
+2 3 D
+-3 1 D
+2 3 D
+1 -2 D
+6 0 D
+0 -1 D
+-5 0 D
+2 -1 D
+-2 0 D
+0 -2 D
+-5 -1 D
+2 -3 D
+-8 0 D
+7 -3 D
+3 1 D
+-5 -2 D
+2 0 D
+-4 -1 D
+7 -2 D
+0 2 D
+1 -2 D
+3 1 D
+1 4 D
+-2 1 D
+8 4 D
+-4 2 D
+-2 -3 D
+2 3 D
+-3 0 D
+4 0 D
+-3 1 D
+8 1 D
+1 -2 D
+4 3 D
+-4 -3 D
+3 -1 D
+3 3 D
+18 -1 D
+4 -6 D
+6 -1 D
+-5 -6 D
+-10 -2 D
+0 -6 D
+-5 -3 D
+-4 1 D
+9 2 D
+-2 6 D
+-4 -1 D
+0 -3 D
+-4 -2 D
+-2 1 D
+4 1 D
+0 3 D
+-5 0 D
+-4 -3 D
+9 -7 D
+5 0 D
+1 -2 D
+13 -3 D
+7 2 D
+2 4 D
+-2 6 D
+5 10 D
+-3 1 D
+4 3 D
+-3 1 D
+4 0 D
+4 2 D
+0 -2 D
+12 4 D
+0 61 D
+P
+2572 890 M
+-2 -4 D
+-2 3 D
+P
+2530 920 M
+7 0 D
+-8 0 D
+P
+2545 901 M
+-4 -1 D
+P
+2542 898 M
+-2 -2 D
+P
+2524 919 M
+-1 2 D
+P
+2526 920 M
+4 1 D
+P
+2576 880 M
+-1 -1 D
+P
+2533 914 M
+1 -1 D
+P
+FO
+2521 945 M
+2 -2 D
+-1 2 D
+P
+FO
+2483 945 M
+2 -2 D
+4 2 D
+0 -2 D
+3 2 D
+P
+FO
+2528 848 M
+7 0 D
+2 2 D
+-1 -2 D
+1 2 D
+1 -2 D
+2 3 D
+0 -2 D
+2 0 D
+1 5 D
+-3 1 D
+6 -1 D
+-2 1 D
+4 0 D
+-5 1 D
+3 1 D
+-8 1 D
+4 1 D
+-6 3 D
+-1 -4 D
+-1 4 D
+-3 1 D
+0 -5 D
+-1 3 D
+-1 0 D
+-1 4 D
+-1 -2 D
+0 2 D
+-3 0 D
+3 -4 D
+-10 2 D
+5 -2 D
+0 -3 D
+-7 2 D
+-3 -2 D
+5 -1 D
+-3 -1 D
+6 1 D
+2 -5 D
+-3 -1 D
+6 -1 D
+1 5 D
+1 -2 D
+5 2 D
+1 -2 D
+2 1 D
+-5 -3 D
+3 -1 D
+-5 0 D
+5 -1 D
+-6 -1 D
+P
+FO
+2527 870 M
+-7 0 D
+18 -9 D
+4 0 D
+-7 5 D
+3 -1 D
+1 3 D
+1 -1 D
+2 1 D
+-6 1 D
+10 0 D
+-2 2 D
+-4 0 D
+3 1 D
+8 -1 D
+2 3 D
+12 4 D
+-2 4 D
+-5 -1 D
+-10 1 D
+-6 -6 D
+-5 1 D
+3 1 D
+-5 -2 D
+3 3 D
+-3 1 D
+-7 -3 D
+2 -1 D
+-2 -5 D
+6 0 D
+0 -2 D
+-3 0 D
+4 -1 D
+-2 -1 D
+0 1 D
+P
+FO
+2504 871 M
+-2 1 D
+5 0 D
+2 -2 D
+0 1 D
+0 -1 D
+7 -3 D
+-3 -1 D
+12 -1 D
+-6 2 D
+1 1 D
+-4 2 D
+1 -2 D
+-2 0 D
+-2 4 D
+0 -2 D
+-12 5 D
+0 -1 D
+-4 2 D
+-1 -2 D
+0 3 D
+-3 0 D
+0 1 D
+-6 2 D
+8 -8 D
+1 2 D
+0 -3 D
+2 0 D
+0 2 D
+2 -2 D
+P
+FO
+2551 845 M
+3 0 D
+-2 -3 D
+4 0 D
+-2 2 D
+4 1 D
+-5 4 D
+4 -3 D
+3 2 D
+-3 0 D
+2 2 D
+-3 0 D
+4 2 D
+-4 1 D
+-1 -2 D
+-1 3 D
+-3 -3 D
+-2 1 D
+1 -1 D
+-5 1 D
+0 -3 D
+2 -1 D
+1 1 D
+3 -1 D
+-3 -1 D
+3 0 D
+-3 0 D
+P
+FO
+2575 843 M
+0 5 D
+-2 1 D
+-1 -2 D
+-1 1 D
+-1 -2 D
+-1 4 D
+-3 1 D
+-1 -3 D
+-1 4 D
+-1 -2 D
+-3 2 D
+2 -4 D
+-4 -1 D
+1 -2 D
+4 1 D
+-2 -1 D
+2 -1 D
+0 3 D
+2 1 D
+1 -4 D
+5 1 D
+-4 -2 D
+5 -2 D
+-1 2 D
+3 -1 D
+P
+FO
+2480 943 M
+0 -2 D
+-2 1 D
+-1 2 D
+-3 -1 D
+0 2 D
+-3 -1 D
+3 -3 D
+4 1 D
+-2 -4 D
+-4 2 D
+3 1 D
+-4 0 D
+-1 -5 D
+6 2 D
+-3 -4 D
+3 0 D
+6 6 D
+3 0 D
+-1 2 D
+0 -1 D
+-2 0 D
+0 1 D
+-3 -2 D
+3 2 D
+P
+FO
+2575 827 M
+1 -2 D
+6 0 D
+0 -1 D
+3 1 D
+-2 1 D
+2 -1 D
+1 -2 D
+1 -1 D
+3 1 D
+-2 2 D
+4 -1 D
+-2 1 D
+1 1 D
+-10 0 D
+6 1 D
+3 2 D
+-7 -2 D
+-3 2 D
+-2 -2 D
+0 2 D
+P
+FO
+2486 921 M
+4 1 D
+-4 -2 D
+1 -2 D
+6 3 D
+2 -2 D
+0 7 D
+-3 -1 D
+1 2 D
+-4 1 D
+-1 -1 D
+4 -1 D
+-3 -2 D
+2 -1 D
+-9 1 D
+2 -1 D
+-3 -2 D
+5 1 D
+-3 -2 D
+2 -1 D
+P
+FO
+2488 933 M
+8 -1 D
+-3 0 D
+1 -1 D
+-4 -1 D
+3 -1 D
+-1 -2 D
+3 1 D
+1 -3 D
+2 2 D
+0 -2 D
+2 0 D
+-1 3 D
+-5 1 D
+5 0 D
+-4 5 D
+-4 1 D
+P
+FO
+2481 926 M
+3 0 D
+-2 0 D
+2 -1 D
+-2 -1 D
+6 0 D
+1 2 D
+-2 -2 D
+-2 2 D
+2 -1 D
+-2 2 D
+2 2 D
+-5 0 D
+3 -1 D
+-3 0 D
+1 -2 D
+P
+FO
+2468 929 M
+3 0 D
+-1 -2 D
+4 -1 D
+-1 4 D
+2 0 D
+-2 2 D
+2 -2 D
+0 2 D
+4 1 D
+-6 -1 D
+1 1 D
+-3 1 D
+-2 -1 D
+4 -2 D
+P
+FO
+2578 850 M
+4 -4 D
+12 -1 D
+-8 2 D
+-3 5 D
+6 -3 D
+2 1 D
+-3 3 D
+0 8 D
+-6 -4 D
+2 -4 D
+-4 1 D
+-3 -1 D
+P
+FO
+2504 896 M
+3 -1 D
+1 2 D
+0 -3 D
+4 -2 D
+-3 5 D
+-4 2 D
+-3 -1 D
+3 -1 D
+-4 0 D
+P
+FO
+2480 910 M
+6 1 D
+2 4 D
+1 -4 D
+2 1 D
+-3 3 D
+3 -1 D
+0 2 D
+-6 0 D
+-4 -4 D
+4 1 D
+P
+FO
+2480 897 M
+1 -2 D
+5 7 D
+-2 4 D
+-2 0 D
+3 -5 D
+-3 -2 D
+0 3 D
+-2 -3 D
+2 0 D
+-3 -1 D
+P
+FO
+2504 906 M
+-1 3 D
+0 -2 D
+-3 0 D
+2 -2 D
+-2 1 D
+-2 -2 D
+7 -2 D
+0 2 D
+-2 0 D
+P
+FO
+2504 889 M
+2 1 D
+-2 2 D
+-6 1 D
+4 -2 D
+-3 1 D
+-1 -3 D
+3 1 D
+-2 -1 D
+2 -1 D
+P
+FO
+2508 864 M
+8 -4 D
+3 1 D
+-2 2 D
+-2 -1 D
+3 2 D
+-4 1 D
+1 -2 D
+-3 0 D
+3 -1 D
+P
+FO
+2504 884 M
+3 0 D
+-2 -2 D
+4 3 D
+-4 -5 D
+4 0 D
+2 7 D
+-3 0 D
+-6 -4 D
+P
+FO
+2480 912 M
+-1 2 D
+-2 -2 D
+0 3 D
+-3 -9 D
+3 1 D
+0 4 D
+1 -1 D
+P
+FO
+2504 894 M
+-2 -1 D
+7 -4 D
+-2 -1 D
+4 0 D
+-1 3 D
+P
+FO
+2575 829 M
+2 0 D
+-6 2 D
+-7 -1 D
+3 -2 D
+1 2 D
+5 -2 D
+P
+FO
+2492 904 M
+3 -4 D
+6 -2 D
+2 2 D
+-4 0 D
+1 1 D
+P
+FO
+2480 935 M
+2 1 D
+-3 0 D
+3 0 D
+0 2 D
+-5 -2 D
+P
+FO
+2498 914 M
+2 -2 D
+-2 -1 D
+4 0 D
+-1 3 D
+P
+FO
+2484 898 M
+-1 -4 D
+7 7 D
+-2 -1 D
+-2 2 D
+P
+FO
+2490 919 M
+5 -3 D
+0 3 D
+-3 0 D
+1 2 D
+P
+FO
+2505 906 M
+4 -4 D
+0 2 D
+-2 0 D
+1 1 D
+P
+FO
+2509 898 M
+2 0 D
+-2 2 D
+-2 -1 D
+P
+FO
+2538 842 M
+2 -2 D
+1 2 D
+3 0 D
+P
+FO
+2498 921 M
+-2 2 D
+2 -8 D
+2 1 D
+P
+FO
+2487 935 M
+-1 -2 D
+5 2 D
+-3 2 D
+-3 -2 D
+P
+FO
+2528 897 M
+2 3 D
+-5 -2 D
+0 -3 D
+P
+FO
+2509 876 M
+11 -1 D
+-7 3 D
+1 -1 D
+P
+FO
+2489 898 M
+-2 -3 D
+6 4 D
+-2 0 D
+P
+FO
+2480 900 M
+1 4 D
+-4 -2 D
+0 -3 D
+P
+FO
+2506 861 M
+2 -2 D
+4 1 D
+-4 3 D
+P
+FO
+2551 834 M
+3 0 D
+-4 2 D
+-1 -1 D
+1 1 D
+P
+FO
+2539 845 M
+5 -1 D
+2 3 D
+-2 2 D
+P
+FO
+2514 874 M
+2 1 D
+-2 1 D
+P
+FO
+2487 902 M
+3 0 D
+-2 1 D
+P
+FO
+2509 916 M
+2 -2 D
+0 3 D
+P
+FO
+2482 921 M
+-1 -2 D
+4 2 D
+P
+FO
+2481 908 M
+2 0 D
+-1 2 D
+P
+FO
+2493 893 M
+3 0 D
+-2 1 D
+P
+FO
+2499 882 M
+3 -1 D
+-3 2 D
+P
+FO
+2504 912 M
+1 4 D
+-3 0 D
+P
+FO
+2483 892 M
+5 -2 D
+2 3 D
+P
+FO
+2581 830 M
+9 0 D
+-5 1 D
+P
+FO
+2516 849 M
+5 -2 D
+2 2 D
+P
+FO
+2506 914 M
+4 -2 D
+0 3 D
+P
+FO
+2494 894 M
+9 -2 D
+-5 3 D
+P
+FO
+2480 929 M
+-2 -1 D
+2 -3 D
+P
+FO
+2587 848 M
+3 -1 D
+2 2 D
+P
+FO
+2485 894 M
+2 -2 D
+3 4 D
+P
+FO
+2497 866 M
+4 0 D
+2 2 D
+P
+FO
+2486 917 M
+5 0 D
+-2 2 D
+P
+FO
+2505 871 M
+5 -3 D
+-3 4 D
+P
+FO
+2546 853 M
+3 -1 D
+1 2 D
+P
+FO
+2498 895 M
+3 -1 D
+2 1 D
+-5 1 D
+P
+FO
+2563 843 M
+3 0 D
+-2 2 D
+P
+FO
+2480 916 M
+4 -1 D
+1 2 D
+P
+FO
+2480 915 M
+1 -1 D
+2 1 D
+P
+FO
+2488 932 M
+0 -2 D
+2 2 D
+P
+FO
+2506 864 M
+3 0 D
+P
+FO
+2504 902 M
+1 -2 D
+4 0 D
+P
+FO
+2480 918 M
+5 0 D
+P
+FO
+2541 861 M
+4 -3 D
+P
+FO
+2540 879 M
+3 1 D
+P
+FO
+2543 841 M
+3 -1 D
+P
+FO
+2509 901 M
+2 -2 D
+P
+FO
+2530 852 M
+2 1 D
+P
+FO
+2486 938 M
+5 0 D
+P
+FO
+2504 887 M
+3 0 D
+P
+FO
+2505 894 M
+4 -2 D
+P
+FO
+2486 911 M
+2 2 D
+P
+FO
+2580 876 M
+4 2 D
+P
+FO
+2560 833 M
+2 0 D
+P
+FO
+2504 870 M
+0 1 D
+P
+FO
+2488 899 M
+3 3 D
+P
+FO
+2546 841 M
+3 0 D
+P
+FO
+2570 827 M
+0 1 D
+P
+FO
+2499 884 M
+4 0 D
+P
+FO
+2478 934 M
+2 1 D
+P
+FO
+2557 843 M
+3 0 D
+-3 1 D
+P
+FO
+2486 943 M
+3 0 D
+P
+FO
+2535 848 M
+3 -1 D
+P
+FO
+2489 891 M
+1 1 D
+P
+FO
+2487 889 M
+3 0 D
+P
+FO
+2491 916 M
+4 -1 D
+P
+FO
+2509 892 M
+2 -1 D
+P
+FO
+2491 889 M
+1 2 D
+P
+FO
+2512 902 M
+1 1 D
+P
+FO
+2500 919 M
+0 -2 D
+P
+FO
+2511 865 M
+2 0 D
+P
+FO
+2526 846 M
+1 2 D
+P
+FO
+2489 907 M
+2 -1 D
+P
+FO
+2494 907 M
+1 1 D
+P
+FO
+2560 841 M
+2 0 D
+-2 1 D
+P
+FO
+2518 865 M
+2 0 D
+P
+FO
+2480 934 M
+1 1 D
+P
+FO
+2520 871 M
+2 -1 D
+P
+FO
+2512 891 M
+1 -1 D
+P
+FO
+2482 939 M
+2 -1 D
+P
+FO
+2551 844 M
+-2 0 D
+P
+FO
+2598 826 M
+-1 -1 D
+P
+FO
+2556 835 M
+3 -1 D
+P
+FO
+2543 843 M
+2 0 D
+P
+FO
+2491 896 M
+2 1 D
+P
+FO
+2594 828 M
+3 1 D
+P
+FO
+2546 845 M
+1 -2 D
+P
+FO
+2490 887 M
+2 0 D
+P
+FO
+2569 850 M
+1 -2 D
+P
+FO
+2524 847 M
+1 1 D
+P
+FO
+2500 926 M
+2 -1 D
+P
+FO
+2554 833 M
+3 -1 D
+P
+FO
+2491 931 M
+2 1 D
+P
+FO
+2504 885 M
+3 1 D
+P
+FO
+2495 870 M
+2 1 D
+P
+FO
+2517 880 M
+3 1 D
+-3 0 D
+P
+FO
+2491 888 M
+2 -1 D
+P
+FO
+2528 839 M
+-3 -1 D
+P
+FO
+2500 903 M
+3 -1 D
+P
+FO
+2518 880 M
+2 1 D
+P
+FO
+2480 921 M
+-1 1 D
+P
+FO
+2471 935 M
+2 1 D
+P
+FO
+2480 944 M
+-1 -1 D
+P
+FO
+2486 939 M
+2 0 D
+P
+FO
+2496 892 M
+2 0 D
+P
+FO
+2528 845 M
+2 1 D
+P
+FO
+2482 891 M
+2 -1 D
+P
+FO
+2507 866 M
+2 -1 D
+P
+FO
+2538 844 M
+3 -1 D
+P
+FO
+2545 884 M
+1 -1 D
+P
+FO
+2582 823 M
+2 1 D
+P
+FO
+2490 903 M
+1 1 D
+P
+FO
+2486 903 M
+1 1 D
+P
+FO
+2495 912 M
+2 0 D
+P
+FO
+2568 833 M
+2 1 D
+P
+FO
+2541 840 M
+2 -1 D
+P
+FO
+2485 917 M
+1 -1 D
+P
+FO
+2594 821 M
+4 -1 D
+P
+FO
+2483 909 M
+1 1 D
+P
+FO
+2561 835 M
+2 -1 D
+P
+FO
+2494 891 M
+2 1 D
+P
+FO
+2543 881 M
+1 1 D
+P
+FO
+2559 841 M
+2 -1 D
+P
+FO
+2535 844 M
+2 1 D
+P
+FO
+2484 909 M
+2 2 D
+P
+FO
+2520 865 M
+2 -1 D
+P
+FO
+2491 905 M
+3 -1 D
+P
+FO
+2497 870 M
+1 1 D
+P
+FO
+2489 939 M
+2 -1 D
+P
+FO
+2504 888 M
+-2 -1 D
+P
+FO
+2835 910 M
+-3 -1 D
+-13 4 D
+0 -2 D
+7 -1 D
+-3 -1 D
+5 -1 D
+6 -4 D
+-5 2 D
+-7 -2 D
+-3 2 D
+3 -4 D
+5 3 D
+3 -1 D
+-3 -1 D
+-1 -2 D
+0 2 D
+-2 0 D
+-1 -4 D
+2 0 D
+-4 -1 D
+2 -1 D
+-8 2 D
+2 -2 D
+-3 -1 D
+2 0 D
+-7 1 D
+9 -4 D
+-3 2 D
+4 0 D
+-2 -1 D
+3 -3 D
+3 2 D
+-2 2 D
+5 -2 D
+2 2 D
+-1 3 D
+5 -1 D
+1 2 D
+2 -1 D
+P
+FO
+2835 912 M
+-3 -1 D
+3 -1 D
+P
+FO
+2835 914 M
+P
+FO
+2634 945 M
+4 -3 D
+10 3 D
+P
+FO
+2598 884 M
+4 2 D
+4 -1 D
+5 6 D
+6 2 D
+18 -5 D
+2 2 D
+-14 16 D
+-8 -1 D
+3 1 D
+-10 1 D
+15 1 D
+-5 14 D
+-6 -3 D
+7 4 D
+2 11 D
+16 7 D
+-4 4 D
+-35 0 D
+P
+FO
+2598 864 M
+10 2 D
+5 -1 D
+1 -2 D
+-1 -2 D
+-15 -4 D
+0 -9 D
+25 -9 D
+-4 1 D
+0 -4 D
+-3 2 D
+-2 -4 D
+-1 1 D
+-3 -1 D
+7 6 D
+-8 2 D
+1 -2 D
+-8 4 D
+1 -4 D
+-2 -2 D
+2 2 D
+-4 2 D
+0 2 D
+-1 0 D
+0 -13 D
+1 0 D
+1 4 D
+0 -4 D
+4 0 D
+0 2 D
+2 -2 D
+-1 3 D
+1 -2 D
+2 1 D
+-1 -2 D
+13 -3 D
+9 1 D
+-3 2 D
+6 -2 D
+7 3 D
+14 -3 D
+9 1 D
+20 -5 D
+12 3 D
+-1 1 D
+6 1 D
+2 -2 D
+5 2 D
+1 -1 D
+7 6 D
+-25 2 D
+-27 12 D
+-9 7 D
+-2 -2 D
+2 2 D
+-6 3 D
+-5 7 D
+-9 2 D
+4 6 D
+4 -3 D
+-2 4 D
+-11 10 D
+-9 -4 D
+-7 6 D
+-4 -2 D
+-2 -5 D
+-5 -3 D
+-3 2 D
+P
+2663 838 M
+-5 -2 D
+-26 1 D
+-5 2 D
+P
+2624 851 M
+-6 -4 D
+3 4 D
+P
+2618 850 M
+-1 -1 D
+P
+2630 869 M
+-2 -1 D
+P
+2615 851 M
+-4 0 D
+2 2 D
+P
+2651 842 M
+3 -2 D
+P
+2656 841 M
+-3 0 D
+2 1 D
+P
+FO
+2598 830 M
+P
+FO
+2598 828 M
+2 0 D
+-2 0 D
+P
+FO
+2598 823 M
+4 0 D
+-3 0 D
+3 -3 D
+8 3 D
+-4 -2 D
+3 -1 D
+-6 -1 D
+10 -1 D
+-3 -1 D
+3 -2 D
+0 3 D
+1 -3 D
+5 0 D
+0 1 D
+-4 0 D
+0 3 D
+-5 2 D
+6 0 D
+-1 2 D
+4 -2 D
+1 2 D
+2 -3 D
+5 3 D
+-4 -5 D
+5 0 D
+-5 -1 D
+1 -2 D
+4 0 D
+0 2 D
+4 -1 D
+-1 1 D
+2 0 D
+0 -1 D
+7 -2 D
+-1 -2 D
+3 1 D
+2 -3 D
+2 1 D
+-3 3 D
+2 1 D
+-4 1 D
+1 2 D
+-4 -1 D
+-3 2 D
+-3 -1 D
+1 1 D
+-5 1 D
+13 0 D
+-2 2 D
+-19 3 D
+1 1 D
+10 -3 D
+0 2 D
+4 -1 D
+0 2 D
+3 -1 D
+-3 3 D
+-20 -1 D
+-1 -2 D
+-5 1 D
+0 -3 D
+0 3 D
+-11 -2 D
+P
+FO
+2598 819 M
+2 1 D
+-2 0 D
+P
+FO
+2598 818 M
+1 0 D
+-1 1 D
+P
+FO
+2740 833 M
+-7 1 D
+-2 -3 D
+0 2 D
+-3 -1 D
+-1 2 D
+1 -2 D
+-4 0 D
+-2 -1 D
+3 -2 D
+9 3 D
+1 -2 D
+6 3 D
+1 -2 D
+5 3 D
+P
+FO
+2641 827 M
+4 -6 D
+3 2 D
+4 -2 D
+-3 0 D
+6 -1 D
+2 3 D
+2 -3 D
+4 -1 D
+5 4 D
+-6 6 D
+-26 -1 D
+P
+2655 824 M
+2 -1 D
+P
+2663 825 M
+-2 -2 D
+P
+FO
+2600 827 M
+6 -1 D
+13 2 D
+-8 1 D
+-2 -1 D
+1 1 D
+-6 1 D
+2 -2 D
+-4 2 D
+-2 -1 D
+3 -1 D
+-3 0 D
+P
+FO
+2811 901 M
+1 2 D
+-2 -2 D
+-3 1 D
+4 -4 D
+3 2 D
+0 3 D
+-4 -3 D
+P
+FO
+2656 809 M
+7 -1 D
+-3 2 D
+1 3 D
+-3 -1 D
+2 -2 D
+-3 1 D
+P
+FO
+2827 915 M
+5 -2 D
+-5 -1 D
+5 0 D
+1 2 D
+P
+FO
+2649 807 M
+6 0 D
+0 -2 D
+3 2 D
+P
+FO
+2669 819 M
+4 0 D
+-1 3 D
+-4 -1 D
+P
+FO
+2669 826 M
+4 -2 D
+0 2 D
+-5 1 D
+P
+FO
+2603 817 M
+4 1 D
+-4 1 D
+P
+FO
+2665 806 M
+3 -1 D
+-1 3 D
+P
+FO
+2653 811 M
+1 -1 D
+3 2 D
+P
+FO
+2803 901 M
+2 -1 D
+2 2 D
+-4 0 D
+P
+FO
+2677 822 M
+1 -2 D
+5 1 D
+P
+FO
+2660 807 M
+5 -1 D
+-2 2 D
+P
+FO
+2803 905 M
+1 -2 D
+2 2 D
+P
+FO
+2613 815 M
+2 0 D
+P
+FO
+2656 812 M
+-2 3 D
+-2 -3 D
+P
+FO
+2623 814 M
+2 0 D
+P
+FO
+2646 821 M
+2 1 D
+P
+FO
+2639 827 M
+1 -1 D
+P
+FO
+2627 823 M
+2 0 D
+P
+FO
+2805 921 M
+2 -1 D
+P
+FO
+2818 907 M
+1 -2 D
+P
+FO
+2617 813 M
+0 -1 D
+0 2 D
+P
+FO
+2815 908 M
+2 -1 D
+P
+FO
+2602 819 M
+1 0 D
+P
+FO
+2806 900 M
+1 1 D
+P
+FO
+2812 916 M
+3 1 D
+P
+FO
+2813 919 M
+1 -1 D
+P
+FO
+2622 818 M
+3 3 D
+-3 -2 D
+P
+FO
+2607 817 M
+4 -1 D
+P
+FO
+2638 823 M
+3 -1 D
+P
+FO
+2618 818 M
+4 -1 D
+-4 2 D
+P
+FO
+2612 821 M
+4 0 D
+P
+FO
+2620 813 M
+1 -1 D
+P
+FO
+2629 815 M
+2 0 D
+P
+FO
+2627 814 M
+3 -1 D
+P
+FO
+2661 805 M
+3 -1 D
+P
+FO
+2600 827 M
+-2 -1 D
+P
+FO
+2656 829 M
+3 0 D
+-3 1 D
+P
+FO
+2820 915 M
+2 -1 D
+P
+FO
+2663 808 M
+3 1 D
+P
+FO
+2814 898 M
+-2 0 D
+P
+FO
+2622 820 M
+0 -1 D
+P
+FO
+2808 920 M
+2 -1 D
+P
+FO
+2835 914 M
+1 -1 D
+P
+FO
+2835 910 M
+0 -12 D
+19 14 D
+-6 1 D
+-1 -1 D
+2 -1 D
+-3 -1 D
+-2 1 D
+3 1 D
+-6 -2 D
+-3 1 D
+2 1 D
+-5 0 D
+P
+FO
+2858 896 M
+2 -1 D
+1 2 D
+5 -3 D
+0 3 D
+2 0 D
+-10 4 D
+1 2 D
+4 -3 D
+10 0 D
+5 2 D
+-5 0 D
+6 1 D
+-4 1 D
+5 -1 D
+9 2 D
+-5 0 D
+5 1 D
+-11 2 D
+3 1 D
+-1 1 D
+7 -2 D
+-3 1 D
+4 0 D
+-4 3 D
+-9 0 D
+-2 -3 D
+4 0 D
+-1 -1 D
+2 -1 D
+-2 0 D
+2 -1 D
+-3 0 D
+0 2 D
+-3 0 D
+0 2 D
+-3 -1 D
+1 2 D
+-2 0 D
+2 1 D
+4 -2 D
+-1 3 D
+-6 1 D
+1 -1 D
+-3 0 D
+-6 3 D
+2 -4 D
+-6 -2 D
+5 -1 D
+-3 0 D
+0 -2 D
+-2 3 D
+-1 -3 D
+5 -2 D
+-2 1 D
+2 -4 D
+-2 0 D
+-1 3 D
+-6 -2 D
+-1 -2 D
+-3 1 D
+1 -3 D
+-3 0 D
+2 -1 D
+-3 0 D
+2 -2 D
+-4 -1 D
+9 -6 D
+1 4 D
+-3 -1 D
+0 3 D
+10 -3 D
+-2 1 D
+2 1 D
+-4 0 D
+3 1 D
+-3 0 D
+1 2 D
+-4 0 D
+4 1 D
+P
+FO
+2871 898 M
+-2 -1 D
+3 -2 D
+P
+FO
+2839 894 M
+2 -3 D
+1 2 D
+P
+FO
+2858 892 M
+4 1 D
+0 1 D
+P
+FO
+2839 915 M
+9 -2 D
+-1 2 D
+P
+FO
+2839 913 M
+4 -1 D
+-2 2 D
+P
+FO
+2839 889 M
+3 1 D
+P
+FO
+2840 912 M
+2 0 D
+P
+FO
+2843 902 M
+3 1 D
+P
+FO
+2841 889 M
+2 0 D
+P
+FO
+2855 887 M
+2 0 D
+P
+FO
+2871 900 M
+2 0 D
+P
+FO
+2841 913 M
+2 0 D
+P
+FO
+3402 831 M
+5 1 D
+-4 2 D
+1 4 D
+-4 -1 D
+2 2 D
+-7 2 D
+0 3 D
+-3 1 D
+2 -3 D
+-3 1 D
+-1 -1 D
+0 3 D
+-4 -1 D
+4 2 D
+-5 0 D
+2 2 D
+-4 -1 D
+-3 2 D
+-3 -2 D
+1 2 D
+-4 -2 D
+1 3 D
+-8 -1 D
+1 2 D
+-14 -1 D
+0 -1 D
+10 0 D
+-3 -1 D
+1 -2 D
+10 1 D
+-4 -1 D
+3 -1 D
+-3 -1 D
+4 1 D
+9 -3 D
+1 -2 D
+9 -2 D
+8 -9 D
+4 1 D
+-3 2 D
+P
+FO
+3375 839 M
+3 0 D
+P
+FO
+3627 746 M
+5 -2 D
+-1 3 D
+P
+FO
+3622 731 M
+4 0 D
+P
+FO
+3626 761 M
+3 0 D
+P
+FO
+3609 786 M
+3 0 D
+P
+FO
+3608 721 M
+3 1 D
+P
+FO
+3600 796 M
+2 0 D
+P
+FO
+3604 722 M
+3 -1 D
+P
+FO
+3621 778 M
+1 -1 D
+P
+FO
+4261 472 M
+1 2 D
+-2 1 D
+-2 -1 D
+0 3 D
+-2 -3 D
+-4 8 D
+0 -10 D
+P
+FO
+4280 472 M
+1 1 D
+-8 2 D
+-7 -3 D
+P
+FO
+4300 472 M
+-3 2 D
+-5 -2 D
+P
+FO
+4388 472 M
+-1 1 D
+0 -1 D
+P
+FO
+4422 472 M
+P
+FO
+4452 472 M
+-8 3 D
+-2 -3 D
+P
+FO
+4466 472 M
+0 1 D
+-14 3 D
+1 -4 D
+P
+FO
+4488 473 M
+-1 -1 D
+1 0 D
+P
+FO
+4505 472 M
+-12 3 D
+-5 -2 D
+0 -1 D
+P
+FO
+4524 472 M
+-5 2 D
+-4 -2 D
+P
+FO
+4538 472 M
+-4 2 D
+-2 -2 D
+P
+FO
+4724 479 M
+-10 -2 D
+9 -4 D
+-15 1 D
+-6 -1 D
+-30 6 D
+-1 2 D
+-9 -2 D
+-32 0 D
+-10 -3 D
+0 3 D
+-8 1 D
+7 0 D
+-2 2 D
+-12 1 D
+12 0 D
+0 1 D
+-15 1 D
+-26 -2 D
+3 -2 D
+-3 0 D
+-4 -2 D
+-7 1 D
+1 -2 D
+-10 -3 D
+2 -3 D
+166 0 D
+P
+FO
+4755 472 M
+4 2 D
+-4 2 D
+-31 3 D
+0 -7 D
+P
+FO
+4888 472 M
+-11 2 D
+2 -2 D
+P
+FO
+4961 491 M
+-18 -4 D
+1 -7 D
+-14 -2 D
+-5 2 D
+-2 -3 D
+-10 -1 D
+3 -2 D
+-9 -1 D
+-8 1 D
+-5 -2 D
+67 0 D
+P
+FO
+5168 472 M
+-3 5 D
+-6 -3 D
+-8 5 D
+-6 -1 D
+0 2 D
+-6 0 D
+-4 -2 D
+-3 1 D
+19 10 D
+-10 -1 D
+-14 -8 D
+-21 8 D
+11 -2 D
+-3 3 D
+-16 4 D
+-5 -2 D
+-11 4 D
+-5 -1 D
+-1 5 D
+-12 2 D
+-1 2 D
+-28 1 D
+-14 -4 D
+-2 -7 D
+-21 1 D
+-4 -1 D
+-13 2 D
+-7 -2 D
+-2 -3 D
+-11 1 D
+0 -19 D
+P
+FO
+5197 501 M
+-4 -1 D
+-3 -5 D
+2 -13 D
+-15 -3 D
+1 -4 D
+-10 -2 D
+0 -1 D
+29 0 D
+P
+FO
+5433 540 M
+-2 0 D
+-2 3 D
+-11 1 D
+-4 4 D
+-20 -5 D
+2 -4 D
+20 -4 D
+-15 -2 D
+-4 -3 D
+-11 -2 D
+-15 6 D
+-10 1 D
+1 2 D
+-13 0 D
+-5 -3 D
+4 -5 D
+-3 -1 D
+-11 0 D
+-1 -3 D
+-8 2 D
+-12 -1 D
+-10 -4 D
+4 -1 D
+-37 -2 D
+-20 -9 D
+-29 -4 D
+-3 -3 D
+-21 -2 D
+0 -29 D
+236 0 D
+P
+FO
+5402 550 M
+-8 0 D
+-1 -2 D
+11 0 D
+P
+FO
+5669 534 M
+-8 0 D
+0 -2 D
+-10 3 D
+-3 -2 D
+-6 2 D
+6 2 D
+-7 3 D
+-9 -1 D
+-4 3 D
+-6 -1 D
+-10 3 D
+-5 -3 D
+-10 1 D
+4 3 D
+-11 1 D
+0 2 D
+5 2 D
+10 0 D
+-1 4 D
+-11 3 D
+-10 0 D
+-17 9 D
+-10 3 D
+-34 2 D
+-20 -3 D
+-17 -1 D
+-17 -3 D
+-3 -3 D
+-22 -2 D
+-5 -4 D
+0 -5 D
+7 -2 D
+8 1 D
+-10 -5 D
+1 -2 D
+12 -1 D
+-2 -3 D
+-6 1 D
+0 -1 D
+-11 3 D
+-4 -1 D
+0 -68 D
+236 0 D
+P
+FO
+5906 510 M
+-9 6 D
+-1 10 D
+-7 0 D
+-9 -3 D
+-14 -1 D
+-83 6 D
+-30 4 D
+-21 -4 D
+-14 2 D
+-16 0 D
+0 2 D
+-10 0 D
+-12 3 D
+-11 -1 D
+0 -62 D
+237 0 D
+P
+FO
+6142 520 M
+-7 -1 D
+-22 -5 D
+-7 -4 D
+2 -5 D
+-18 -1 D
+8 -2 D
+-6 -7 D
+-25 -6 D
+-2 1 D
+-6 -3 D
+-22 -5 D
+-11 1 D
+-5 -3 D
+-3 2 D
+-4 -1 D
+-1 -3 D
+-20 0 D
+1 4 D
+10 2 D
+-6 2 D
+9 0 D
+-1 2 D
+-18 11 D
+-17 4 D
+-1 2 D
+-32 1 D
+-3 -3 D
+-9 2 D
+-5 -2 D
+-7 0 D
+-8 7 D
+0 -38 D
+236 0 D
+P
+FO
+6378 548 M
+-10 -1 D
+-19 1 D
+-13 6 D
+-52 6 D
+-19 -4 D
+-5 -5 D
+-11 3 D
+-12 -3 D
+-2 -3 D
+13 -4 D
+-17 -1 D
+-9 -4 D
+-40 -3 D
+2 -1 D
+-11 -4 D
+-2 -7 D
+-29 -4 D
+0 -48 D
+236 0 D
+P
+FO
+6614 573 M
+-8 1 D
+-5 -2 D
+-11 4 D
+-11 -1 D
+-3 -2 D
+-10 0 D
+-4 3 D
+2 3 D
+-18 10 D
+-17 2 D
+-11 -3 D
+-2 -4 D
+-7 0 D
+-3 -6 D
+4 -15 D
+-6 -2 D
+-11 1 D
+2 -6 D
+-15 -4 D
+-4 -1 D
+-9 3 D
+-18 0 D
+-7 -2 D
+-17 3 D
+-14 -2 D
+-7 0 D
+-15 -4 D
+-11 -1 D
+0 -76 D
+236 0 D
+P
+FO
+6432 574 M
+1 -3 D
+8 1 D
+P
+FO
+6850 552 M
+-6 1 D
+-5 -6 D
+-18 -2 D
+-16 8 D
+-5 -1 D
+-2 2 D
+-75 9 D
+-17 5 D
+5 6 D
+-3 4 D
+-8 3 D
+-9 1 D
+-2 4 D
+-6 2 D
+-3 -3 D
+9 -3 D
+-1 -4 D
+-6 -1 D
+5 -4 D
+-4 -1 D
+0 -2 D
+-28 2 D
+-1 3 D
+-11 2 D
+1 2 D
+-8 2 D
+-12 -1 D
+-4 -7 D
+-6 0 D
+0 -101 D
+236 0 D
+P
+FO
+7087 545 M
+-12 -1 D
+-22 1 D
+-23 -2 D
+-13 4 D
+-11 1 D
+2 2 D
+-9 4 D
+-10 0 D
+-4 -3 D
+-13 4 D
+-16 1 D
+-2 4 D
+3 2 D
+-30 11 D
+-55 -7 D
+-7 -6 D
+3 -4 D
+-6 -1 D
+-4 1 D
+-4 -2 D
+2 -2 D
+-6 0 D
+0 -80 D
+237 0 D
+P
+FO
+7323 560 M
+-7 -3 D
+-5 -10 D
+-17 -5 D
+-2 2 D
+-19 -1 D
+-6 2 D
+-6 8 D
+-10 2 D
+-16 6 D
+-21 -4 D
+-4 -5 D
+-8 -2 D
+-5 2 D
+5 3 D
+-13 0 D
+-18 -6 D
+-23 -1 D
+-4 4 D
+-9 2 D
+-14 -3 D
+-5 1 D
+-1 -3 D
+-12 -4 D
+-8 2 D
+-8 -2 D
+0 -73 D
+236 0 D
+P
+FO
+7559 551 M
+-10 2 D
+-30 1 D
+-14 4 D
+-19 1 D
+-8 -2 D
+-19 7 D
+-23 1 D
+-3 2 D
+-12 -5 D
+-17 3 D
+-14 -3 D
+-8 2 D
+-18 -3 D
+-32 3 D
+-9 -4 D
+0 -88 D
+236 0 D
+P
+FO
+7795 510 M
+-13 2 D
+-5 -3 D
+-2 1 D
+-7 -1 D
+-3 2 D
+-23 1 D
+7 2 D
+-10 3 D
+-7 -1 D
+-11 6 D
+-4 -1 D
+-12 8 D
+-13 3 D
+-9 -1 D
+21 8 D
+12 8 D
+-6 2 D
+-5 -1 D
+1 3 D
+-6 -1 D
+-22 -11 D
+-5 1 D
+-3 -2 D
+-4 5 D
+-14 -1 D
+-1 3 D
+-9 2 D
+-16 -4 D
+-8 0 D
+-15 5 D
+-12 -1 D
+-32 4 D
+0 -79 D
+236 0 D
+P
+FO
+8031 482 M
+-5 2 D
+-7 0 D
+-8 4 D
+-14 0 D
+-13 4 D
+-12 -1 D
+-5 4 D
+-7 -3 D
+-1 2 D
+-7 -1 D
+-1 3 D
+-6 1 D
+-9 -2 D
+-6 3 D
+-7 -1 D
+-6 2 D
+0 2 D
+-12 7 D
+-18 5 D
+-10 -3 D
+-8 3 D
+-28 -2 D
+-1 -5 D
+-11 -1 D
+-9 1 D
+2 3 D
+-5 3 D
+-19 -3 D
+-3 1 D
+0 -38 D
+236 0 D
+P
+FO
+8043 472 M
+-2 1 D
+4 2 D
+-14 7 D
+0 -10 D
+P
+FO
+8141 531 M
+4 -1 D
+3 3 D
+-6 5 D
+P
+FO
+8106 547 M
+3 -1 D
+-2 5 D
+-3 -1 D
+P
+FO
+8090 555 M
+4 1 D
+-8 5 D
+P
+FO
+2110 502 M
+0 -4 D
+5 0 D
+P
+FO
+2489 472 M
+5 2 D
+-10 5 D
+-14 -1 D
+2 -2 D
+-11 -2 D
+1 -2 D
+P
+FO
+2598 489 M
+-2 0 D
+0 9 D
+-8 3 D
+-37 -4 D
+-5 -3 D
+3 -5 D
+10 -2 D
+-1 -6 D
+-5 -1 D
+-12 5 D
+-10 1 D
+-2 -3 D
+11 -6 D
+-5 -5 D
+63 0 D
+P
+FO
+2618 472 M
+-4 9 D
+-9 8 D
+-7 0 D
+0 -17 D
+P
+FO
+2809 472 M
+-4 4 D
+10 2 D
+-16 9 D
+19 11 D
+-4 2 D
+6 4 D
+-4 2 D
+7 13 D
+-10 9 D
+3 3 D
+11 2 D
+2 8 D
+-4 2 D
+9 5 D
+-9 3 D
+-3 17 D
+-18 5 D
+-1 4 D
+-19 3 D
+3 1 D
+-4 2 D
+5 3 D
+9 -1 D
+0 4 D
+9 1 D
+7 -2 D
+13 1 D
+9 -2 D
+0 3 D
+-14 3 D
+-4 4 D
+9 2 D
+9 6 D
+0 10 D
+-8 1 D
+-10 -2 D
+0 -2 D
+-6 1 D
+4 -2 D
+-3 -1 D
+-3 -5 D
+-5 -1 D
+-4 2 D
+-3 -2 D
+3 -2 D
+-3 0 D
+-2 -2 D
+-3 3 D
+-3 -5 D
+-7 -1 D
+2 -1 D
+-5 0 D
+1 3 D
+-5 1 D
+1 -3 D
+-5 -1 D
+7 -2 D
+-4 -1 D
+-6 2 D
+0 -3 D
+-11 0 D
+7 -2 D
+-2 -3 D
+-4 2 D
+-14 1 D
+-7 -6 D
+4 -2 D
+-3 -1 D
+10 -2 D
+-3 -3 D
+-10 2 D
+4 -4 D
+-10 2 D
+3 -4 D
+-7 1 D
+-1 -2 D
+5 -3 D
+-2 -2 D
+-9 3 D
+-9 -2 D
+4 -4 D
+-11 2 D
+-3 -1 D
+4 -2 D
+-7 -2 D
+8 -3 D
+-6 -4 D
+3 -2 D
+-4 -1 D
+-10 3 D
+-7 -1 D
+-1 -4 D
+4 -2 D
+-5 -3 D
+4 -2 D
+0 -6 D
+-6 4 D
+-1 -2 D
+-4 2 D
+0 6 D
+-4 0 D
+-1 -2 D
+-2 1 D
+-2 -3 D
+-4 1 D
+-3 -11 D
+11 1 D
+0 -3 D
+9 1 D
+-5 -3 D
+6 -1 D
+-9 -1 D
+8 0 D
+-2 -3 D
+-10 -2 D
+7 -6 D
+5 1 D
+3 -1 D
+-3 -2 D
+-10 1 D
+8 -2 D
+-8 -3 D
+5 -6 D
+-12 -2 D
+12 -5 D
+-6 -2 D
+2 -3 D
+-14 -3 D
+-13 2 D
+-1 -3 D
+-12 1 D
+12 -7 D
+-2 -8 D
+P
+FO
+2835 647 M
+-1 0 D
+0 2 D
+-3 2 D
+-3 -3 D
+-7 0 D
+-5 3 D
+-1 -3 D
+-9 -1 D
+2 -2 D
+6 0 D
+3 2 D
+9 0 D
+-2 -2 D
+5 -1 D
+6 1 D
+P
+FO
+2767 601 M
+-4 1 D
+-6 -2 D
+5 3 D
+-4 0 D
+2 2 D
+-5 -1 D
+5 3 D
+-5 2 D
+-5 -1 D
+-2 -4 D
+-5 0 D
+0 -3 D
+-8 -1 D
+-2 -3 D
+15 -3 D
+2 3 D
+6 -1 D
+P
+FO
+2654 552 M
+-6 0 D
+-10 -4 D
+-19 -15 D
+-1 -3 D
+6 -5 D
+9 1 D
+3 4 D
+4 1 D
+3 -1 D
+3 2 D
+1 2 D
+-7 1 D
+13 5 D
+-7 1 D
+-1 4 D
+P
+FO
+2783 611 M
+-3 3 D
+-6 -1 D
+3 -4 D
+-6 -4 D
+3 -2 D
+-5 -1 D
+8 0 D
+7 4 D
+2 3 D
+-4 1 D
+6 1 D
+P
+FO
+2821 621 M
+-6 1 D
+4 -1 D
+-3 -3 D
+-4 0 D
+2 -2 D
+6 2 D
+P
+FO
+2822 640 M
+-5 0 D
+2 -2 D
+2 0 D
+-2 2 D
+4 -2 D
+P
+FO
+2702 578 M
+-8 0 D
+-4 -8 D
+8 1 D
+-3 3 D
+6 1 D
+P
+FO
+2663 548 M
+-5 2 D
+-3 -4 D
+5 -1 D
+P
+FO
+2666 529 M
+-10 0 D
+-4 -3 D
+7 -1 D
+P
+FO
+2680 565 M
+-6 -1 D
+-2 -5 D
+7 3 D
+P
+FO
+2787 631 M
+-5 1 D
+-1 -3 D
+6 0 D
+P
+FO
+2805 644 M
+-6 0 D
+0 -2 D
+3 0 D
+P
+FO
+2796 621 M
+-4 0 D
+3 -2 D
+P
+FO
+2780 640 M
+-5 0 D
+-4 -4 D
+P
+FO
+2760 597 M
+-10 -4 D
+7 1 D
+P
+FO
+2712 570 M
+-4 1 D
+2 -2 D
+P
+FO
+2669 559 M
+-3 0 D
+0 -1 D
+P
+FO
+2667 524 M
+-6 0 D
+2 -2 D
+P
+FO
+2835 645 M
+4 2 D
+-4 0 D
+P
+FO
+2835 605 M
+6 -2 D
+-1 -2 D
+5 0 D
+-3 4 D
+5 2 D
+3 -3 D
+9 0 D
+-1 -2 D
+5 -1 D
+1 3 D
+-5 2 D
+5 1 D
+-8 2 D
+7 0 D
+1 4 D
+15 9 D
+12 1 D
+-3 0 D
+1 2 D
+8 0 D
+-2 2 D
+7 -1 D
+0 -4 D
+9 1 D
+-6 4 D
+2 1 D
+-3 0 D
+1 3 D
+-7 2 D
+-13 -3 D
+-4 -2 D
+-3 1 D
+0 -2 D
+-19 -2 D
+1 -3 D
+-12 -1 D
+0 -5 D
+-8 1 D
+-2 3 D
+-2 -5 D
+-1 0 D
+P
+FO
+2835 587 M
+13 -2 D
+-13 5 D
+P
+FO
+2877 617 M
+-6 -5 D
+3 -1 D
+5 1 D
+-1 -3 D
+4 0 D
+-7 -2 D
+1 -2 D
+7 2 D
+2 -3 D
+1 3 D
+4 0 D
+-1 -2 D
+1 1 D
+8 -1 D
+-6 2 D
+12 3 D
+-8 1 D
+6 1 D
+-9 2 D
+1 2 D
+-6 -4 D
+-3 1 D
+2 6 D
+P
+FO
+2882 664 M
+-17 -3 D
+-7 -5 D
+4 2 D
+2 -2 D
+7 0 D
+0 2 D
+-4 -1 D
+4 3 D
+4 0 D
+-2 -2 D
+3 -1 D
+3 3 D
+13 1 D
+-2 2 D
+P
+FO
+2925 634 M
+-9 -4 D
+3 -2 D
+15 3 D
+11 -2 D
+6 1 D
+-2 3 D
+-7 0 D
+-3 2 D
+P
+FO
+2950 683 M
+-6 1 D
+-2 -2 D
+5 -3 D
+4 2 D
+10 1 D
+P
+FO
+2897 619 M
+-8 -1 D
+11 -2 D
+3 2 D
+-7 0 D
+P
+FO
+2841 651 M
+-6 0 D
+8 -3 D
+2 2 D
+-4 -1 D
+P
+FO
+2922 638 M
+-4 0 D
+-4 -2 D
+8 -3 D
+7 4 D
+P
+FO
+2907 605 M
+1 1 D
+-13 -2 D
+0 -3 D
+9 1 D
+P
+FO
+2861 655 M
+-8 -1 D
+4 -1 D
+5 1 D
+P
+FO
+2848 653 M
+-6 -1 D
+4 -2 D
+3 1 D
+P
+FO
+2929 628 M
+-6 -2 D
+7 -2 D
+6 3 D
+P
+FO
+2971 678 M
+4 0 D
+1 4 D
+P
+FO
+3169 696 M
+-3 0 D
+-1 -2 D
+5 1 D
+3 -2 D
+6 1 D
+7 -3 D
+-2 3 D
+-7 2 D
+P
+FO
+3195 691 M
+7 1 D
+-9 0 D
+P
+FO
+4252 482 M
+-31 -3 D
+-8 -5 D
+5 0 D
+-1 -2 D
+35 0 D
+P
+FO
+4487 472 M
+-22 -2 D
+1 2 D
+-13 0 D
+-1 0 D
+-10 0 D
+-3 -3 D
+-12 -1 D
+-5 4 D
+-17 -1 D
+-18 1 D
+-5 -2 D
+4 -3 D
+-4 0 D
+-4 3 D
+-30 -4 D
+1 4 D
+-10 1 D
+-28 -2 D
+-11 3 D
+-8 0 D
+-5 -1 D
+-10 0 D
+3 1 D
+-14 0 D
+-7 -2 D
+2 2 D
+-9 0 D
+0 -236 D
+236 0 D
+0 236 D
+P
+FO
+4558 472 M
+1 -1 D
+-5 0 D
+-11 -1 D
+-5 2 D
+-6 0 D
+-2 -1 D
+-15 1 D
+-4 -1 D
+-23 1 D
+0 -236 D
+236 0 D
+0 236 D
+P
+FO
+4894 472 M
+-2 0 D
+-4 0 D
+-9 0 D
+4 -2 D
+-11 1 D
+-8 -5 D
+0 2 D
+-10 0 D
+9 2 D
+-1 2 D
+-17 0 D
+-7 -1 D
+6 -1 D
+-6 -1 D
+3 -2 D
+-7 1 D
+0 -4 D
+-8 2 D
+-12 -1 D
+-3 3 D
+-15 3 D
+-7 -1 D
+-1 -2 D
+-12 -1 D
+-21 5 D
+-31 0 D
+0 -236 D
+237 0 D
+0 236 D
+P
+FO
+5168 472 M
+1 -1 D
+-208 1 D
+0 -236 D
+236 0 D
+0 236 D
+P
+FO
+5197 236 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+5433 236 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+5669 236 M
+237 0 D
+0 236 D
+-237 0 D
+P
+FO
+5906 236 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+6142 236 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+6378 236 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+6614 236 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+6850 236 M
+237 0 D
+0 236 D
+-237 0 D
+P
+FO
+7087 236 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+7323 236 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+7559 236 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+7795 236 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+8268 296 M
+-40 2 D
+-20 -1 D
+-18 6 D
+-8 -2 D
+7 -2 D
+-12 -5 D
+19 -3 D
+-12 -1 D
+11 0 D
+-7 -3 D
+5 -1 D
+-25 2 D
+-32 -6 D
+-1 9 D
+-21 -1 D
+8 7 D
+-16 9 D
+-17 1 D
+2 1 D
+-6 0 D
+17 5 D
+-8 3 D
+6 1 D
+0 3 D
+-8 5 D
+12 2 D
+-18 1 D
+0 1 D
+4 -1 D
+-3 1 D
+9 0 D
+-2 3 D
+9 0 D
+-6 1 D
+6 10 D
+-5 0 D
+0 -2 D
+-7 2 D
+2 2 D
+73 -5 D
+3 3 D
+-11 0 D
+0 2 D
+-12 0 D
+0 1 D
+-39 2 D
+-10 -1 D
+-5 2 D
+2 2 D
+6 -1 D
+-3 2 D
+7 2 D
+1 -4 D
+5 2 D
+7 0 D
+10 11 D
+12 -2 D
+-1 4 D
+17 0 D
+5 -2 D
+1 3 D
+-15 7 D
+-1 3 D
+6 -2 D
+1 3 D
+28 -1 D
+0 2 D
+-15 2 D
+12 0 D
+-8 2 D
+11 2 D
+3 -1 D
+9 1 D
+-7 2 D
+2 2 D
+11 -2 D
+-4 2 D
+5 2 D
+5 -2 D
+-5 2 D
+32 -2 D
+2 5 D
+10 -3 D
+5 1 D
+-4 4 D
+5 0 D
+1 3 D
+8 2 D
+6 9 D
+4 0 D
+0 10 D
+-6 1 D
+6 1 D
+0 13 D
+-29 8 D
+-2 2 D
+-12 1 D
+-10 4 D
+3 2 D
+-4 3 D
+-30 0 D
+-1 2 D
+10 0 D
+-3 2 D
+-10 0 D
+-9 -2 D
+-11 2 D
+1 2 D
+-8 -2 D
+-23 3 D
+-3 -2 D
+-8 2 D
+-2 -2 D
+5 -1 D
+-5 -1 D
+-16 3 D
+-6 6 D
+-14 -1 D
+-2 -3 D
+-10 7 D
+-10 -1 D
+-2 -3 D
+-7 5 D
+-5 0 D
+2 1 D
+-16 1 D
+0 -236 D
+237 0 D
+P
+FO
+8259 387 M
+5 0 D
+3 2 D
+-5 5 D
+-7 -6 D
+P
+FO
+8504 287 M
+-62 0 D
+-46 7 D
+-128 2 D
+0 -60 D
+236 0 D
+P
+FO
+8268 421 M
+1 3 D
+16 2 D
+6 3 D
+-17 13 D
+2 -6 D
+-4 -3 D
+-4 1 D
+P
+FO
+8268 409 M
+3 0 D
+5 6 D
+-2 3 D
+-6 1 D
+P
+FO
+236 273 M
+-73 0 D
+-91 4 D
+3 3 D
+-13 3 D
+-40 4 D
+-22 0 D
+0 -51 D
+236 0 D
+P
+FO
+472 281 M
+-77 -12 D
+-32 1 D
+-9 -1 D
+-118 4 D
+0 -37 D
+236 0 D
+P
+FO
+709 317 M
+-8 -2 D
+-13 -2 D
+19 -3 D
+-8 0 D
+-11 -3 D
+-5 2 D
+-15 -1 D
+-3 -3 D
+4 1 D
+3 -2 D
+12 1 D
+-8 -2 D
+8 -1 D
+-11 -2 D
+-15 3 D
+-4 -2 D
+11 -3 D
+-16 3 D
+2 2 D
+-23 -1 D
+-1 2 D
+-18 2 D
+-26 -2 D
+-8 3 D
+2 -2 D
+-19 0 D
+-9 -2 D
+-11 5 D
+-11 -3 D
+2 -2 D
+-14 2 D
+2 -11 D
+-12 -8 D
+-33 -5 D
+0 -45 D
+237 0 D
+P
+FO
+709 320 M
+-14 -2 D
+2 -1 D
+12 1 D
+P
+FO
+945 346 M
+-20 -4 D
+-11 1 D
+-1 2 D
+-14 -2 D
+-30 3 D
+-30 0 D
+-12 -2 D
+-11 1 D
+-6 -1 D
+4 2 D
+-6 -4 D
+-16 -1 D
+-18 -4 D
+-27 0 D
+6 -7 D
+-14 -3 D
+4 -2 D
+-23 -1 D
+-4 -4 D
+-7 0 D
+0 -2 D
+5 0 D
+-5 -1 D
+0 -81 D
+236 0 D
+P
+FO
+1181 369 M
+-21 0 D
+-5 -1 D
+-13 3 D
+-11 -3 D
+-10 1 D
+-19 -3 D
+-27 -1 D
+-4 -2 D
+-18 2 D
+-13 -4 D
+-21 -1 D
+-4 -6 D
+-62 -3 D
+-8 -5 D
+0 -110 D
+236 0 D
+P
+FO
+1417 382 M
+-11 2 D
+-15 -1 D
+-30 3 D
+-17 0 D
+-4 -4 D
+-18 -1 D
+-13 4 D
+-21 3 D
+-2 3 D
+-12 4 D
+-25 0 D
+-9 -3 D
+1 -3 D
+7 -2 D
+-2 -4 D
+-22 -12 D
+-28 -3 D
+-15 1 D
+0 -133 D
+236 0 D
+P
+FO
+1654 362 M
+-2 0 D
+-3 7 D
+-8 3 D
+-8 -1 D
+-17 3 D
+-10 -2 D
+-33 2 D
+-3 3 D
+-7 0 D
+-9 4 D
+-14 -1 D
+-10 -4 D
+-13 1 D
+-14 4 D
+-23 -4 D
+-29 2 D
+-14 4 D
+-20 -1 D
+0 -146 D
+237 0 D
+P
+FO
+1890 428 M
+-5 1 D
+-8 -2 D
+-21 1 D
+-19 -3 D
+-1 -3 D
+-9 -3 D
+-18 0 D
+15 -6 D
+2 -3 D
+-17 -4 D
+3 -8 D
+13 -4 D
+22 0 D
+11 -7 D
+-9 -1 D
+-29 2 D
+1 -8 D
+32 -2 D
+5 -5 D
+-2 -2 D
+-11 -1 D
+-13 -4 D
+30 -5 D
+-14 -9 D
+-65 0 D
+-13 3 D
+-4 5 D
+-21 -2 D
+-10 3 D
+-13 -5 D
+-26 -3 D
+11 -2 D
+-7 -1 D
+7 0 D
+-16 -2 D
+-24 3 D
+7 1 D
+-12 4 D
+4 2 D
+-12 4 D
+0 -126 D
+236 0 D
+P
+FO
+1782 397 M
+-11 6 D
+1 -5 D
+P
+FO
+2126 413 M
+-17 -6 D
+-2 4 D
+-8 2 D
+-30 -3 D
+-11 2 D
+-31 1 D
+-26 6 D
+-4 4 D
+-18 6 D
+-16 0 D
+-14 -2 D
+-29 5 D
+-10 -5 D
+-20 1 D
+0 -192 D
+236 0 D
+P
+FO
+2362 402 M
+-12 1 D
+-3 -3 D
+7 -6 D
+-22 1 D
+2 -10 D
+-24 -3 D
+-17 3 D
+-13 0 D
+2 2 D
+-4 2 D
+-30 0 D
+-15 4 D
+2 3 D
+-10 2 D
+0 3 D
+-52 4 D
+-4 4 D
+-39 2 D
+-1 4 D
+-3 -2 D
+0 -177 D
+236 0 D
+P
+FO
+2535 472 M
+-12 -1 D
+0 -3 D
+-7 -3 D
+-28 7 D
+1 0 D
+-27 0 D
+1 -2 D
+26 -1 D
+17 -9 D
+-7 -2 D
+-6 1 D
+-1 -3 D
+-12 2 D
+-5 -4 D
+-29 -3 D
+-1 -4 D
+5 -1 D
+43 3 D
+19 5 D
+8 -1 D
+0 -4 D
+9 -2 D
+-9 -5 D
+-13 -3 D
+-11 1 D
+-5 -5 D
+-13 1 D
+-7 -2 D
+5 -3 D
+-6 -2 D
+14 -5 D
+11 1 D
+7 -4 D
+10 3 D
+8 0 D
+8 -4 D
+8 -1 D
+-13 -4 D
+20 -6 D
+3 -11 D
+-17 0 D
+-6 3 D
+-7 -3 D
+-19 1 D
+-1 5 D
+-24 2 D
+-11 -1 D
+-15 5 D
+-1 3 D
+-16 -2 D
+-7 4 D
+-19 -2 D
+-16 5 D
+-8 -4 D
+10 -2 D
+5 -5 D
+-15 -2 D
+-1 -2 D
+12 -4 D
+11 3 D
+23 0 D
+0 -7 D
+-5 -1 D
+-3 3 D
+-8 1 D
+-6 -2 D
+4 -3 D
+-14 -1 D
+-22 9 D
+-8 1 D
+0 -166 D
+236 0 D
+0 236 D
+P
+FO
+2835 350 M
+-39 8 D
+4 7 D
+11 1 D
+8 5 D
+-8 8 D
+7 7 D
+-4 1 D
+21 8 D
+-2 10 D
+2 1 D
+0 12 D
+-8 5 D
+2 8 D
+-5 3 D
+-1 15 D
+-5 3 D
+6 8 D
+-15 12 D
+-173 0 D
+-1 -2 D
+-17 2 D
+-20 0 D
+0 -236 D
+237 0 D
+P
+FO
+3071 296 M
+-14 6 D
+14 -1 D
+0 1 D
+-9 5 D
+-7 -4 D
+-22 3 D
+-10 5 D
+-17 0 D
+-37 12 D
+-134 27 D
+0 -114 D
+236 0 D
+P
+FO
+2835 406 M
+8 8 D
+-8 4 D
+P
+FO
+2835 395 M
+0 4 D
+P
+FO
+3307 281 M
+-24 2 D
+-54 -4 D
+-17 0 D
+-43 9 D
+-68 1 D
+-23 4 D
+-7 3 D
+0 -60 D
+236 0 D
+P
+FO
+3071 301 M
+1 0 D
+-1 1 D
+P
+FO
+3543 315 M
+-15 -4 D
+-25 -3 D
+-5 -4 D
+-16 0 D
+-26 -4 D
+-26 -10 D
+-7 0 D
+2 -2 D
+-8 -1 D
+-3 -5 D
+-11 -1 D
+-2 -3 D
+-94 3 D
+0 -45 D
+236 0 D
+P
+FO
+3780 400 M
+-10 -5 D
+-16 -16 D
+-21 -3 D
+-3 -4 D
+-12 3 D
+-9 -1 D
+-5 5 D
+-8 -2 D
+0 3 D
+-8 1 D
+-42 -5 D
+-3 -3 D
+12 -8 D
+-10 -3 D
+17 -6 D
+-6 -5 D
+-26 -7 D
+-19 -1 D
+-12 -3 D
+20 -5 D
+4 -7 D
+-65 -8 D
+-15 -5 D
+0 -79 D
+237 0 D
+P
+FO
+4016 451 M
+-11 -2 D
+-9 1 D
+3 -1 D
+-11 -1 D
+-10 -6 D
+-15 0 D
+-3 -3 D
+8 -6 D
+-21 -5 D
+-1 -1 D
+9 1 D
+-8 -3 D
+-8 -1 D
+-5 2 D
+-45 -5 D
+-3 -2 D
+-21 -3 D
+-3 -3 D
+-23 0 D
+-12 -4 D
+-8 2 D
+-19 -2 D
+-20 -9 D
+0 -164 D
+236 0 D
+P
+FO
+4217 472 M
+5 -1 D
+-46 -6 D
+-5 -3 D
+-37 2 D
+-14 -1 D
+0 1 D
+-5 -3 D
+-5 2 D
+-8 -2 D
+-17 1 D
+-16 -6 D
+-8 1 D
+-3 3 D
+-13 0 D
+-19 -4 D
+-10 -5 D
+0 -215 D
+236 0 D
+0 236 D
+P
+FO
+4252 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+4488 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+4724 0 M
+237 0 D
+0 236 D
+-237 0 D
+P
+FO
+4961 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+5197 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+5433 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+5669 0 M
+237 0 D
+0 236 D
+-237 0 D
+P
+FO
+5906 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+6142 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+6378 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+6614 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+6850 0 M
+237 0 D
+0 236 D
+-237 0 D
+P
+FO
+7087 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+7323 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+7559 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+7795 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+8031 0 M
+237 0 D
+0 236 D
+-237 0 D
+P
+FO
+8268 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+0 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+236 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+472 0 M
+237 0 D
+0 236 D
+-237 0 D
+P
+FO
+709 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+945 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+1181 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+1417 0 M
+237 0 D
+0 236 D
+-237 0 D
+P
+FO
+1654 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+1890 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+2126 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+2362 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+2598 0 M
+237 0 D
+0 236 D
+-237 0 D
+P
+FO
+2835 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+3071 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+3307 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+3543 0 M
+237 0 D
+0 236 D
+-237 0 D
+P
+FO
+3780 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+4016 0 M
+236 0 D
+0 236 D
+-236 0 D
+P
+FO
+25 W
+8 W
+N 0 0 M 0 -83 D S
+N 0 4252 M 0 83 D S
+N 1417 0 M 0 -83 D S
+N 1417 4252 M 0 83 D S
+N 2835 0 M 0 -83 D S
+N 2835 4252 M 0 83 D S
+N 4252 0 M 0 -83 D S
+N 4252 4252 M 0 83 D S
+N 5669 0 M 0 -83 D S
+N 5669 4252 M 0 83 D S
+N 7087 0 M 0 -83 D S
+N 7087 4252 M 0 83 D S
+N 8504 0 M 0 -83 D S
+N 8504 4252 M 0 83 D S
+N 8504 709 M 83 0 D S
+N 0 709 M -83 0 D S
+N 8504 709 M 83 0 D S
+N 0 709 M -83 0 D S
+N 8504 2126 M 83 0 D S
+N 0 2126 M -83 0 D S
+N 8504 2126 M 83 0 D S
+N 0 2126 M -83 0 D S
+N 8504 3543 M 83 0 D S
+N 0 3543 M -83 0 D S
+N 8504 3543 M 83 0 D S
+N 0 3543 M -83 0 D S
+83 W
+N -42 0 M 0 354 D S
+N 8546 0 M 0 354 D S
+1 A
+N -42 354 M 0 355 D S
+N 8546 354 M 0 355 D S
+0 A
+N -42 709 M 0 354 D S
+N 8546 709 M 0 354 D S
+1 A
+N -42 1063 M 0 354 D S
+N 8546 1063 M 0 354 D S
+0 A
+N -42 1417 M 0 355 D S
+N 8546 1417 M 0 355 D S
+1 A
+N -42 1772 M 0 354 D S
+N 8546 1772 M 0 354 D S
+0 A
+N -42 2126 M 0 354 D S
+N 8546 2126 M 0 354 D S
+1 A
+N -42 2480 M 0 355 D S
+N 8546 2480 M 0 355 D S
+0 A
+N -42 2835 M 0 354 D S
+N 8546 2835 M 0 354 D S
+1 A
+N -42 3189 M 0 354 D S
+N 8546 3189 M 0 354 D S
+0 A
+N -42 3543 M 0 355 D S
+N 8546 3543 M 0 355 D S
+1 A
+N -42 3898 M 0 354 D S
+N 8546 3898 M 0 354 D S
+0 A
+N 0 -42 M 354 0 D S
+N 0 4294 M 354 0 D S
+1 A
+N 354 -42 M 355 0 D S
+N 354 4294 M 355 0 D S
+0 A
+N 709 -42 M 354 0 D S
+N 709 4294 M 354 0 D S
+1 A
+N 1063 -42 M 354 0 D S
+N 1063 4294 M 354 0 D S
+0 A
+N 1417 -42 M 355 0 D S
+N 1417 4294 M 355 0 D S
+1 A
+N 1772 -42 M 354 0 D S
+N 1772 4294 M 354 0 D S
+0 A
+N 2126 -42 M 354 0 D S
+N 2126 4294 M 354 0 D S
+1 A
+N 2480 -42 M 355 0 D S
+N 2480 4294 M 355 0 D S
+0 A
+N 2835 -42 M 354 0 D S
+N 2835 4294 M 354 0 D S
+1 A
+N 3189 -42 M 354 0 D S
+N 3189 4294 M 354 0 D S
+0 A
+N 3543 -42 M 355 0 D S
+N 3543 4294 M 355 0 D S
+1 A
+N 3898 -42 M 354 0 D S
+N 3898 4294 M 354 0 D S
+0 A
+N 4252 -42 M 354 0 D S
+N 4252 4294 M 354 0 D S
+1 A
+N 4606 -42 M 355 0 D S
+N 4606 4294 M 355 0 D S
+0 A
+N 4961 -42 M 354 0 D S
+N 4961 4294 M 354 0 D S
+1 A
+N 5315 -42 M 354 0 D S
+N 5315 4294 M 354 0 D S
+0 A
+N 5669 -42 M 355 0 D S
+N 5669 4294 M 355 0 D S
+1 A
+N 6024 -42 M 354 0 D S
+N 6024 4294 M 354 0 D S
+0 A
+N 6378 -42 M 354 0 D S
+N 6378 4294 M 354 0 D S
+1 A
+N 6732 -42 M 355 0 D S
+N 6732 4294 M 355 0 D S
+0 A
+N 7087 -42 M 354 0 D S
+N 7087 4294 M 354 0 D S
+1 A
+N 7441 -42 M 354 0 D S
+N 7441 4294 M 354 0 D S
+0 A
+N 7795 -42 M 355 0 D S
+N 7795 4294 M 355 0 D S
+1 A
+N 8150 -42 M 354 0 D S
+N 8150 4294 M 354 0 D S
+0 A
+8 W
+N -83 0 M 8670 0 D S
+N -83 -83 M 8670 0 D S
+N 8504 -83 M 0 4418 D S
+N 8587 -83 M 0 4418 D S
+N 8587 4252 M -8670 0 D S
+N 8587 4335 M -8670 0 D S
+N 0 4335 M 0 -4418 D S
+N -83 4335 M 0 -4418 D S
+/PSL_H_y 400 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(100°) sh add def
+4252 4252 PSL_H_y add M
+400 F0
+(Testing Matrix i/o) bc Z
+0 -167 M 200 F0
+(-180°) tc Z
+1417 -167 M (-120°) tc Z
+2835 -167 M (-60°) tc Z
+4252 -167 M (0°) tc Z
+5669 -167 M (60°) tc Z
+7087 -167 M (120°) tc Z
+8504 -167 M (180°) tc Z
+-167 709 M (-60°) mr Z
+-167 2126 M (0°) mr Z
+-167 3543 M (60°) mr Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -Rg -JQ0/18c -O -K test_hotspots.txt -Sc0.2c -Gred
+%@PROJ: eqc -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.356 20015109.356 -10007554.678 10007554.678 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+8504 0 D
+0 4252 D
+-8504 0 D
+P
+PSL_clip N
+4 W
+V
+{1 0 0 C} FS
+47 5244 2409 Sc
+47 -3260 2409 Sc
+47 3661 1724 Sc
+47 12165 1724 Sc
+47 3921 1937 Sc
+47 12425 1937 Sc
+47 946 1432 Sc
+47 9450 1432 Sc
+47 3591 3024 Sc
+47 12094 3024 Sc
+47 1583 2764 Sc
+47 10087 2764 Sc
+47 8143 534 Sc
+47 -361 534 Sc
+47 2835 2835 Sc
+47 11339 2835 Sc
+47 4346 850 Sc
+47 -4157 850 Sc
+47 1049 3390 Sc
+47 9553 3390 Sc
+47 3850 2787 Sc
+47 12354 2787 Sc
+47 3685 2480 Sc
+47 12189 2480 Sc
+47 4107 1819 Sc
+47 12611 1819 Sc
+47 8173 2244 Sc
+47 -331 2244 Sc
+47 5291 1843 Sc
+47 -3213 1843 Sc
+47 5315 1033 Sc
+47 -3189 1033 Sc
+47 723 1469 Sc
+47 9227 1469 Sc
+47 4417 3307 Sc
+47 -4087 3307 Sc
+47 3496 2031 Sc
+47 12000 2031 Sc
+47 2102 2126 Sc
+47 10606 2126 Sc
+47 591 2598 Sc
+47 9094 2598 Sc
+47 4394 2669 Sc
+47 -4110 2669 Sc
+47 3780 3638 Sc
+47 12283 3638 Sc
+47 4819 2433 Sc
+47 -3685 2433 Sc
+47 1228 3213 Sc
+47 9732 3213 Sc
+47 2386 1323 Sc
+47 10890 1323 Sc
+47 5740 969 Sc
+47 -2764 969 Sc
+47 5102 2055 Sc
+47 -3402 2055 Sc
+47 1495 1505 Sc
+47 9999 1505 Sc
+47 990 924 Sc
+47 9494 924 Sc
+47 1422 1441 Sc
+47 9926 1441 Sc
+47 3850 2906 Sc
+47 12354 2906 Sc
+47 5143 1020 Sc
+47 -3361 1020 Sc
+47 1004 1949 Sc
+47 9508 1949 Sc
+47 626 1630 Sc
+47 9130 1630 Sc
+47 4465 2220 Sc
+47 -4039 2220 Sc
+47 8197 283 Sc
+47 -307 283 Sc
+47 1410 1890 Sc
+47 9914 1890 Sc
+47 1179 1557 Sc
+47 9683 1557 Sc
+47 1795 3000 Sc
+47 10299 3000 Sc
+47 5563 1630 Sc
+47 -2941 1630 Sc
+47 6083 1211 Sc
+47 -2421 1211 Sc
+47 1677 1488 Sc
+47 10181 1488 Sc
+47 246 1791 Sc
+47 8750 1791 Sc
+47 2362 1488 Sc
+47 10866 1488 Sc
+47 756 1699 Sc
+47 9260 1699 Sc
+47 720 1710 Sc
+47 9224 1710 Sc
+47 7944 1169 Sc
+47 -560 1169 Sc
+47 4654 2622 Sc
+47 -3850 2622 Sc
+47 3567 1654 Sc
+47 12071 1654 Sc
+47 3969 1252 Sc
+47 12472 1252 Sc
+47 4630 1370 Sc
+47 -3874 1370 Sc
+47 1630 3189 Sc
+47 10134 3189 Sc
+47 3579 2819 Sc
+47 12083 2819 Sc
+47 5395 865 Sc
+47 -3109 865 Sc
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -Rg -JQ0/18c -O -F+f6p+jBL -Dj4p
+%@PROJ: eqc -180.00000000 180.00000000 -90.00000000 90.00000000 -20015109.356 20015109.356 -10007554.678 10007554.678 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+8504 0 D
+0 4252 D
+-8504 0 D
+P
+PSL_clip N
+5311 2476 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+100 F0
+(EHTIOPIA) bl Z
+3728 1791 M (SEAMOUNT) bl Z
+1012 1499 M (ISLANDS HOTSPOT) bl Z
+1649 2830 M (CALIFORNIA, GUADAL) bl Z
+1115 3456 M (SEAMOUNT, KODIAC SEAMOUNTS) bl Z
+3917 2854 M (ISLANDS) bl Z
+3752 2547 M (VERDE) bl Z
+4173 1886 M (SEAMOUNT) bl Z
+8240 2311 M (ISLANDS) bl Z
+5358 1909 M (ISLANDS) bl Z
+790 1536 M (ISLAND) bl Z
+4484 3374 M (BELGIUM) bl Z
+2169 2193 M (ISLANDS) bl Z
+4460 2736 M (MOUNTAINS, ALGER) bl Z
+4886 2500 M (MARRA, SUDAN) bl Z
+1295 3279 M (DE FUCA, COBB SEAM) bl Z
+2452 1390 M (FERNANDEZ) bl Z
+5169 2122 M (VICTORIA, EAST AFRICA) bl Z
+1562 1571 M (ISLANDS) bl Z
+1056 990 M (HOTSPOT) bl Z
+1489 1508 M (SEAMOUNT) bl Z
+5209 1087 M (ISLAND) bl Z
+1071 2015 M (ISLANDS) bl Z
+693 1697 M (ISLANDS) bl Z
+4531 2287 M (CAMEROON) bl Z
+8264 350 M (EREBUS) bl Z
+1477 1956 M (HOTSPOT) bl Z
+1245 1623 M (ISLAND) bl Z
+1862 3067 M (NEW MEXICO) bl Z
+6149 1278 M (PAUL ISLAND) bl Z
+1744 1555 M (Y GOMEZ) bl Z
+2429 1555 M (FELIX) bl Z
+823 1765 M (ISLANDS) bl Z
+4720 2689 M (CHAD) bl Z
+4035 1319 M (DA CUNHA) bl Z
+4697 1437 M (SEAMOUNT) bl Z
+3645 2886 M (SEAMOUNT S OF GREENLAND) bl Z
+5462 931 M (SEAMOUNT EAST OF LENA SEAMOUNT ON CONRAD RISE) bl Z
+PSL_cliprestore
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/api/apimat_io.sh
+++ b/test/api/apimat_io.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Test the C API for reading and writing native matrices.
+# We read @hotspots.txt and write it out again, then plot it.
+
+ps=apimat_io.ps
+testapi_matrix_io
+gmt pscoast -Rg -JQ0/18c -Glightgreen -Baf -BWSne+t"Testing Matrix i/o" -K -P > $ps
+gmt psxy -R -J -O -K test_hotspots.txt -Sc0.2c -Gred >> $ps
+gmt convert test_hotspots.txt -o0,1,t | gmt pstext -R -J -O -F+f6p+jBL -Dj4p >> $ps


### PR DESCRIPTION
**Description of proposed changes**

Following up on the work for **GMT_VECTOR**, this PR completes the work on matrix i/o, i.e., reading a datasets with optional headers and trailing text records into a **GMT_MATRIX** structure, and then back out to file.  Similar scheme as for **GMT_VECTOR** so most of the fixes had already been applied.  I added another api test C program and script to make sure the full roundtrip of reading a table in and writing it out preserves the data and trailing text (it does not check if the header records are there though but they are for now).