### PR TITLE
Use GMT_WRITE_NORMAL instead of 0 for better readability

### DIFF
--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -695,7 +695,7 @@ unsigned int gmt_DCW_list (struct GMT_CTRL *GMT, struct GMT_DCW_SELECT *F) {
 		}
 	}
 
-	if (GMT_Write_Data (GMT->parent, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_TEXT, 0, NULL, NULL, D) != GMT_NOERROR) {
+	if (GMT_Write_Data (GMT->parent, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_TEXT, GMT_WRITE_NORMAL, NULL, NULL, D) != GMT_NOERROR) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to write data set for country listing to stdout!\n");
 		return GMT_RUNTIME_ERROR;
 	}

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -8177,7 +8177,7 @@ void gmt_plotend (struct GMT_CTRL *GMT) {
 		P->n_bytes = PSL->internal.n;   /* Length of plot buffer; note P->n_alloc = 0 since we did not allocate this string here */
 		P->mode = PSL->internal.pmode;  /* Mode of plot (GMT_PS_{HEADER,TRAILER,COMPLETE}) */
 		PH->alloc_mode = GMT_ALLOC_EXTERNALLY;	/* Since created in PSL */
-		if (GMT_Write_Data (GMT->parent, GMT_IS_POSTSCRIPT, GMT_IS_REFERENCE, GMT_IS_TEXT, 0, NULL, GMT->current.ps.memname, P) != GMT_OK) {
+		if (GMT_Write_Data (GMT->parent, GMT_IS_POSTSCRIPT, GMT_IS_REFERENCE, GMT_IS_TEXT, GMT_WRITE_NORMAL, NULL, GMT->current.ps.memname, P) != GMT_OK) {
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Unable to write PS structure to file %s!\n", GMT->current.ps.memname);
 		}
 		/* coverity[leaked_storage] */	/* We can't free P because it was written into a 'memory file' */

--- a/src/gmtmath.c
+++ b/src/gmtmath.c
@@ -387,7 +387,7 @@ GMT_LOCAL int gmtmath_solve_LS_system (struct GMT_CTRL *GMT, struct GMTMATH_INFO
 			sprintf (header, "#coefficients");
 			if (GMT_Set_Comment (GMT->parent, GMT_IS_DATASET, GMT_COMMENT_IS_COLNAMES, header, D)) return (GMT->parent->error);
 		}
-		if (GMT_Write_Data (GMT->parent, GMT_IS_DATASET, (file ? GMT_IS_FILE : GMT_IS_STREAM), GMT_IS_NONE, 0, NULL, file, D) != GMT_NOERROR)
+		if (GMT_Write_Data (GMT->parent, GMT_IS_DATASET, (file ? GMT_IS_FILE : GMT_IS_STREAM), GMT_IS_NONE, GMT_WRITE_NORMAL, NULL, file, D) != GMT_NOERROR)
 			return (GMT->parent->error);
 	}
 	else {	/* Return t, y, p(t), r(t), where p(t) is the predicted solution and r(t) is the residuals */
@@ -420,7 +420,7 @@ GMT_LOCAL int gmtmath_solve_LS_system (struct GMT_CTRL *GMT, struct GMTMATH_INFO
 			else if (info->w_mode == GMTMATH_SIGMAS) strcat (header, "\tsigma(t)[4]");
 			if (GMT_Set_Comment (GMT->parent, GMT_IS_DATASET, GMT_COMMENT_IS_COLNAMES, header, D)) return (GMT->parent->error);
 		}
-		if (GMT_Write_Data (GMT->parent, GMT_IS_DATASET, (file ? GMT_IS_FILE : GMT_IS_STREAM), GMT_IS_NONE, 0, NULL, file, D) != GMT_NOERROR) {
+		if (GMT_Write_Data (GMT->parent, GMT_IS_DATASET, (file ? GMT_IS_FILE : GMT_IS_STREAM), GMT_IS_NONE, GMT_WRITE_NORMAL, NULL, file, D) != GMT_NOERROR) {
 			return (GMT->parent->error);
 		}
 	}

--- a/src/grd2kml.c
+++ b/src/grd2kml.c
@@ -675,7 +675,7 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 		}
 		if (cpt) gmt_M_str_free (cpt);
 		sprintf (cptfile, "%s/grd2kml_%d.cpt", API->tmp_dir, uniq);
-		if (GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, 0, NULL, cptfile, P) != GMT_NOERROR) {
+		if (GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_WRITE_NORMAL, NULL, cptfile, P) != GMT_NOERROR) {
 			Return (API->error);
 		}
 		Ctrl->C.active = tmp_cpt = true;

--- a/src/potential/gmtflexure.c
+++ b/src/potential/gmtflexure.c
@@ -1461,7 +1461,7 @@ EXTERN_MSC int GMT_gmtflexure (void *V_API, int mode, void *args) {
 		}
 	}
 
-	if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_LINE, 0, NULL, Ctrl->Out.file, W) != GMT_NOERROR) {
+	if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_LINE, GMT_WRITE_NORMAL, NULL, Ctrl->Out.file, W) != GMT_NOERROR) {
 		Return (API->error);
 	}
 

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -1205,7 +1205,7 @@ EXTERN_MSC int GMT_grdflexure (void *V_API, int mode, void *args) {
 	}
 
 	error = GMT_NOERROR;
-	if (Ctrl->L.active && GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_NONE, 0, NULL, Ctrl->L.file, L) != GMT_NOERROR) {
+	if (Ctrl->L.active && GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_NONE, GMT_WRITE_NORMAL, NULL, Ctrl->L.file, L) != GMT_NOERROR) {
 		GMT_Report (API, GMT_MSG_ERROR, "Failure while writing list of grid files to %s\n", Ctrl->L.file);
 		error = API->error;
 	}

--- a/src/potential/grdseamount.c
+++ b/src/potential/grdseamount.c
@@ -997,7 +997,7 @@ EXTERN_MSC int GMT_grdseamount (void *V_API, int mode, void *args) {
 		gmt_M_memcpy (Grid->data, data, Grid->header->size, gmt_grdfloat);
 	}
 	if (Ctrl->M.active) L->table[0]->n_records = L->table[0]->segment[0]->n_rows = t_use;
-	if (Ctrl->M.active && GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_NONE, 0, NULL, Ctrl->M.file, L) != GMT_NOERROR) {
+	if (Ctrl->M.active && GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_NONE, GMT_WRITE_NORMAL, NULL, Ctrl->M.file, L) != GMT_NOERROR) {
 		GMT_Report (API, GMT_MSG_ERROR, "Failure while writing list of grid files to %s\n", Ctrl->M.file);
 		goto wrap_up;
 	}

--- a/src/potential/talwani2d.c
+++ b/src/potential/talwani2d.c
@@ -741,7 +741,7 @@ EXTERN_MSC int GMT_talwani2d (void *V_API, int mode, void *args) {
 			}
 		}
 	}
-	if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, geometry, 0, NULL, Ctrl->Out.file, Out) != GMT_NOERROR)
+	if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, geometry, GMT_WRITE_NORMAL, NULL, Ctrl->Out.file, Out) != GMT_NOERROR)
 		error++;
 
 	/* Clean up memory */

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -1007,7 +1007,7 @@ EXTERN_MSC int GMT_pshistogram (void *V_API, int mode, void *args) {
 				row++;
 			}
 			S->n_rows = row;
-			if (GMT_Write_Data (GMT->parent, GMT_IS_DATASET, GMT_IS_STREAM, GMT_IS_POINT, 0, NULL, Ctrl->Out.file, D) != GMT_NOERROR) {
+			if (GMT_Write_Data (GMT->parent, GMT_IS_DATASET, GMT_IS_STREAM, GMT_IS_POINT, GMT_WRITE_NORMAL, NULL, Ctrl->Out.file, D) != GMT_NOERROR) {
 				gmt_M_free (GMT, data);		gmt_M_free (GMT, F.boxh);
 				if (F.weights) gmt_M_free (GMT, weights);
 				Return (API->error);

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -508,7 +508,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 		if ((In = GMT_Read_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_TEXT, GMT_READ_NORMAL, NULL, legend_file, NULL)) == NULL) {
 			Return (API->error);
 		}
-		if (Ctrl->T.active && GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_TEXT, 0, NULL, Ctrl->T.file, In) != GMT_NOERROR) {
+		if (Ctrl->T.active && GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_TEXT, GMT_WRITE_NORMAL, NULL, Ctrl->T.file, In) != GMT_NOERROR) {
 			Return (API->error);
 		}
 	}

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -1615,7 +1615,7 @@ EXTERN_MSC int GMT_psscale (void *V_API, int mode, void *args) {
 		if (Ptrunc == NULL)
 			Return (EXIT_FAILURE);
 		P = Ptrunc;
-		//GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, 0, NULL, "chop.cpt", P);
+		//GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_WRITE_NORMAL, NULL, "chop.cpt", P);
 	}
 	if (Ctrl->W.active)	/* Scale all z values */
 		gmt_scale_cpt (GMT, P, Ctrl->W.scale);

--- a/src/psternary.c
+++ b/src/psternary.c
@@ -396,7 +396,7 @@ EXTERN_MSC int GMT_psternary (void *V_API, int mode, void *args) {
 	gmt_set_dataset_minmax (GMT, D);		/* Update column stats */
 
 	if (Ctrl->M.active) {	/* Just print the converted data and exit */
-		if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POINT, 0, NULL, NULL, D) != GMT_NOERROR) {
+		if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POINT, GMT_WRITE_NORMAL, NULL, NULL, D) != GMT_NOERROR) {
 			GMT_Report (API, GMT_MSG_ERROR, "Unable to write x,y file to stdout\n");
 			Return (API->error);
 		}

--- a/src/sample1d.c
+++ b/src/sample1d.c
@@ -517,7 +517,7 @@ EXTERN_MSC int GMT_sample1d (void *V_API, int mode, void *args) {
 			Dout->table[tbl]->segment[seg] = Sout;
 		}
 	}
-	if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, geometry, 0, NULL, Ctrl->Out.file, Dout) != GMT_NOERROR) {
+	if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, geometry, GMT_WRITE_NORMAL, NULL, Ctrl->Out.file, Dout) != GMT_NOERROR) {
 		Return (API->error);
 	}
 

--- a/src/spectrum1d.c
+++ b/src/spectrum1d.c
@@ -783,7 +783,7 @@ EXTERN_MSC int GMT_spectrum1d (void *V_API, int mode, void *args) {
 
 	spectrum1d_free_space (GMT, &C);
 
-	if (!Ctrl->T.active && GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_NONE, 0, NULL, Ctrl->Out.file, Dout) != GMT_NOERROR) {
+	if (!Ctrl->T.active && GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_NONE, GMT_WRITE_NORMAL, NULL, Ctrl->Out.file, Dout) != GMT_NOERROR) {
 		Return (API->error);
 	}
 

--- a/src/sphtriangulate.c
+++ b/src/sphtriangulate.c
@@ -692,7 +692,7 @@ EXTERN_MSC int GMT_sphtriangulate (void *V_API, int mode, void *args) {
 
 	if (Ctrl->T.active) gmt_set_segmentheader (GMT, GMT_OUT, true);	/* Must produce multisegment output files */
 
-	if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POINT, 0, NULL, Ctrl->Out.file, Dout[0]) != GMT_NOERROR) {
+	if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POINT, GMT_WRITE_NORMAL, NULL, Ctrl->Out.file, Dout[0]) != GMT_NOERROR) {
 		gmt_M_free (GMT, lon);	gmt_M_free (GMT, lat);
 		gmt_M_free (GMT, xx);	gmt_M_free (GMT, yy);
 		Return (API->error);
@@ -704,7 +704,7 @@ EXTERN_MSC int GMT_sphtriangulate (void *V_API, int mode, void *args) {
 		Dout[1]->table[0]->header = gmt_M_memory (GMT, NULL, 1, char *);
 		Dout[1]->table[0]->n_headers = 1;
 		Dout[1]->table[0]->header[0] = strdup (header);
-		if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POINT, 0, NULL, Ctrl->N.file, Dout[1]) != GMT_NOERROR) {
+		if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POINT, GMT_WRITE_NORMAL, NULL, Ctrl->N.file, Dout[1]) != GMT_NOERROR) {
 			gmt_M_free (GMT, lon);	gmt_M_free (GMT, lat);
 			gmt_M_free (GMT, xx);	gmt_M_free (GMT, yy);
 			Return (API->error);

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -1245,7 +1245,7 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 			sprintf (command, "0/%g/0/%g", Ctrl->F.dim[GMT_X] + GMT->current.setting.map_origin[GMT_X], Ctrl->F.dim[GMT_Y] + GMT->current.setting.map_origin[GMT_Y]);	/* Save page region */
 			GMT_Set_Comment (API, GMT_IS_DATASET, GMT_COMMENT_IS_TEXT, command, D);
 			gmt_set_tableheader (API->GMT, GMT_OUT, true);	/* So header is written */
-			if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POLY, 0, NULL, file, D) != GMT_NOERROR) {
+			if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POLY, GMT_WRITE_NORMAL, NULL, file, D) != GMT_NOERROR) {
 				Return (API->error);
 			}
 			gmt_set_tableheader (API->GMT, GMT_OUT, save);	/* Restore the state of affairs */
@@ -1353,7 +1353,7 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 		/* Check if we should draw debug lines */
 		sprintf (file, "%s/gmt.subplotdebug.%d", API->gwf_dir, fig);
 		if (!access (file, R_OK)) {	/* Yes, must draw debug lines on top */
-			if ((D = GMT_Read_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POLY, 0, NULL, file, NULL)) == NULL) {
+			if ((D = GMT_Read_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POLY, GMT_READ_NORMAL, NULL, file, NULL)) == NULL) {
 				Return (API->error);
 			}
 			if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_POLY, GMT_IN|GMT_IS_REFERENCE, D, vfile) != GMT_NOERROR) {

--- a/src/test_JL.c
+++ b/src/test_JL.c
@@ -30,7 +30,7 @@ int main () {
 	GMT_Close_VirtualFile (API, input);
 	GMT_Close_VirtualFile (API, output);
     /* Write the data to file */
-    if (GMT_Write_Data (API, GMT_IS_VECTOR, GMT_IS_FILE, GMT_IS_PLP, 0, NULL, "vjunk.txt", V[GMT_OUT])) return EXIT_FAILURE;
+    if (GMT_Write_Data (API, GMT_IS_VECTOR, GMT_IS_FILE, GMT_IS_PLP, GMT_WRITE_NORMAL, NULL, "vjunk.txt", V[GMT_OUT])) return EXIT_FAILURE;
 
 	/* NEXT TEST GMT_MATRIX */
     M[GMT_IN] = GMT_Read_Data (API, GMT_IS_MATRIX, GMT_IS_FILE, GMT_IS_PLP, GMT_READ_NORMAL, NULL, "belgium.txt", NULL);
@@ -48,7 +48,7 @@ int main () {
 	GMT_Close_VirtualFile (API, input);
 	GMT_Close_VirtualFile (API, output);
     /* Write the data to file */
-    if (GMT_Write_Data (API, GMT_IS_MATRIX, GMT_IS_FILE, GMT_IS_PLP, 0, NULL, "mjunk.txt", M[GMT_OUT])) return EXIT_FAILURE;
+    if (GMT_Write_Data (API, GMT_IS_MATRIX, GMT_IS_FILE, GMT_IS_PLP, GMT_WRITE_NORMAL, NULL, "mjunk.txt", M[GMT_OUT])) return EXIT_FAILURE;
     /* Destroy the GMT session */
     if (GMT_Destroy_Session (API)) return EXIT_FAILURE;
 };

--- a/src/testpsl.c
+++ b/src/testpsl.c
@@ -61,7 +61,7 @@ int main () {
 	if (GMT_Close_VirtualFile (API, string) != GMT_NOERROR) exit (EXIT_FAILURE);
 
 	/* 6. Write the plot to file */
-	if (GMT_Write_Data (API, GMT_IS_POSTSCRIPT, GMT_IS_FILE, GMT_IS_NONE, 0, NULL, "newmap.ps", PS) != GMT_NOERROR) exit (EXIT_FAILURE);
+	if (GMT_Write_Data (API, GMT_IS_POSTSCRIPT, GMT_IS_FILE, GMT_IS_NONE, GMT_WRITE_NORMAL, NULL, "newmap.ps", PS) != GMT_NOERROR) exit (EXIT_FAILURE);
 
 	/* 7. Destroy GMT session */
 	if (GMT_Destroy_Session (API)) exit (EXIT_FAILURE);


### PR DESCRIPTION
0 is the normal way to write but GMT_WRITE_NORMAL conveys that to developers without having to know that 0 stands for.  This PR just cleans up a bunch of GMT_Write_Data calls.
