### PR TITLE
Special attention when tile grids are passed to grdimage

### DIFF
--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -8029,8 +8029,9 @@ int gmt_grd_project (struct GMT_CTRL *GMT, struct GMT_GRID *I, struct GMT_GRID *
 
 			if (!GMT->common.n.antialias || nz[ij_out] < 2)	/* Just use the interpolated value */
 				O->data[ij_out] = (gmt_grdfloat)z_int;
-			else if (gmt_M_is_dnan (z_int))		/* Take the average of what we accumulated */
-				O->data[ij_out] /= nz[ij_out];	/* Plain average */
+			else if (gmt_M_is_dnan (z_int)) {		/* Take the average of what we accumulated */
+				if (nz[ij_out]) O->data[ij_out] /= nz[ij_out];	/* Plain average */
+			}
 			else {					/* Weighted average between blockmean'ed and interpolated values */
 				inv_nz = 1.0 / nz[ij_out];
 				O->data[ij_out] = (gmt_grdfloat) ((O->data[ij_out] + z_int * inv_nz) / (nz[ij_out] + inv_nz));


### PR DESCRIPTION
This addresses issue #3694.  The problem turned out to be this:

**grdimage** usually reads in a grid in two steps:

1. Read in the grid header only to determine the grid region
2. After calling _gmt_map_setup_, which may adjust **-R** for global grids, we read the grid, this time passing the adjusted wesn for the map.

So, in the case that caused this issue, we may use -Rg and -JN120/20c, but after _gmt_map_setup_, the R.wesn is no longer 0/30 but -60/300.  So the grid is read in correctly relative to the desired region.

However, when we read a global tiled region there is a difference: Because the grid is assembled by **grdblend**, the first call (to get the header) needs to do the whole thing since we are not going to assemble the grid twice just to be the region.  Thus, the tiled region in this case remains 0/360 since there is no second read after projection is set.  Nevertheless, none of this caused a problem until we also selected auto-shading.  Now, the 0/360 grid is passed to **grdgradient** with the actual region and two grids are out of sync.

There may be more than one solution to this.  Since this case is unique to **grdimage** the following solution was implemented there: Since we know we read a tiled_grid up front in this specific case (tiled grid + auto-shading) we simply pass the 0/360 region to **grdgradient** rather than the adjusted region.  With that change, the case works and all tests work fine.
