### PR TITLE
Fix reST styling issue in #1605

### DIFF
--- a/doc/rst/_static/style.css
+++ b/doc/rst/_static/style.css
@@ -3,6 +3,11 @@
     max-width: 1000px;
 }
 
+/* See https://github.com/GenericMappingTools/gmt/pull/1605 */
+.rst-content dl dt {
+    font-weight: normal;
+}
+
 /* style for example gallery */
 .gmtgallary li {
     list-style: none;


### PR DESCRIPTION
See #1605 for the issue and fix.

When bumping sphinx_rtd_them to 0.5.0, I thought we don't need the fix,
so I removed it, but it turns out we still need the fix.

This PR adds the fix back.

Need to backport to 6.1 branch.