### PR TITLE
[Backport 6.1] File lock on CURL downloads

### DIFF
--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -53,6 +53,8 @@ EXTERN_MSC char *dlerror (void);
 #endif
 
 EXTERN_MSC int gmtlib_delete_virtualfile  (void *API, const char *string);
+EXTERN_MSC bool gmtlib_file_lock (struct GMT_CTRL *GMT, int fd);
+EXTERN_MSC bool gmtlib_file_unlock (struct GMT_CTRL *GMT, int fd);
 EXTERN_MSC int gmtlib_file_is_jpeg2000_tile (struct GMTAPI_CTRL *API, char *file);
 EXTERN_MSC int gmtlib_download_remote_file (struct GMT_CTRL *GMT, const char* file_name, char *path, int k_data, unsigned int mode);
 EXTERN_MSC int gmtlib_get_serverfile_index (struct GMTAPI_CTRL *API, const char *file);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -1110,6 +1110,7 @@ int gmtlib_file_is_jpeg2000_tile (struct GMTAPI_CTRL *API, char *file) {
 }
 
 int gmt_download_file (struct GMT_CTRL *GMT, const char *name, char *url, char *localfile, bool be_fussy) {
+	bool query = gmt_M_file_is_query (url);
 	int curl_err, error;
 	size_t fsize;
 	char *Lfile = NULL;
@@ -1135,12 +1136,14 @@ int gmt_download_file (struct GMT_CTRL *GMT, const char *name, char *url, char *
 
 	/* Here we will try to download a file */
 
-	Lfile = gmtremote_lockfile (API, (char *)name);
-	if ((fp = fopen (Lfile, "w")) == NULL) {
-		GMT_Report (API, GMT_MSG_ERROR, "Failed to create lock file %s\n", Lfile);
-		return 1;
+	if (!query) {	/* Only make a filename if not a query */
+		Lfile = gmtremote_lockfile (API, (char *)name);
+		if ((fp = fopen (Lfile, "w")) == NULL) {
+			GMT_Report (API, GMT_MSG_ERROR, "Failed to create lock file %s\n", Lfile);
+			return 1;
+		}
+		gmtlib_file_lock (GMT, fileno(fp));	/* Attempt exclusive lock */
 	}
-	gmtlib_file_lock (GMT, fileno(fp));	/* Attempt exclusive lock */
 
   	if ((Curl = curl_easy_init ()) == NULL) {
 		GMT_Report (API, GMT_MSG_ERROR, "Failed to initiate curl\n");
@@ -1196,9 +1199,11 @@ int gmt_download_file (struct GMT_CTRL *GMT, const char *name, char *url, char *
 	if (urlfile.fp) /* close the local file */
 		fclose (urlfile.fp);
 
-	gmtlib_file_unlock (GMT, fileno(fp));
-	gmt_remove_file (GMT, Lfile);
-	gmt_M_str_free (Lfile);
+	if (!query) {	/* Remove lock file after successful download */
+		gmtlib_file_unlock (GMT, fileno(fp));
+		gmt_remove_file (GMT, Lfile);
+		gmt_M_str_free (Lfile);
+	}
 
 	gmtremote_turn_off_ctrl_C_check ();
 

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -520,7 +520,7 @@ GMT_LOCAL size_t gmtremote_skip_large_files (struct GMT_CTRL *GMT, char * URL, s
 #define GMT_HASH_TIME_OUT 10L	/* Not waiting longer than this to time out on getting the hash file */
 
 GMT_LOCAL int gmtremote_get_url (struct GMT_CTRL *GMT, char *url, char *file, char *orig, unsigned int index) {
-	bool query = gmt_M_file_is_query (file);
+	bool query = gmt_M_file_is_query (url);
 	int curl_err = 0;
 	long time_spent;
 	char *Lfile = NULL;

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -606,6 +606,7 @@ GMT_LOCAL int gmtremote_get_url (struct GMT_CTRL *GMT, char *url, char *file, ch
 
 	if (!query) {	/* Remove lock file after successful download */
 		gmtlib_file_unlock (GMT, fileno(fp));
+		fclose(fp);
 		gmt_remove_file (GMT, Lfile);
 		gmt_M_str_free (Lfile);
 	}
@@ -1201,6 +1202,7 @@ int gmt_download_file (struct GMT_CTRL *GMT, const char *name, char *url, char *
 
 	if (!query) {	/* Remove lock file after successful download */
 		gmtlib_file_unlock (GMT, fileno(fp));
+		fclose(fp);
 		gmt_remove_file (GMT, Lfile);
 		gmt_M_str_free (Lfile);
 	}


### PR DESCRIPTION
Backport #3735, #3768, #3780, #3785, and #3804.