### PR TITLE
Handle GMT_IS_DUPLICATE flag to GMT_Open_VirtualFile

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -7527,6 +7527,8 @@ int GMT_Open_VirtualFile (void *V_API, unsigned int family, unsigned int geometr
 		direction -= GMT_IS_REFERENCE;
 		the_mode = GMT_IS_REFERENCE;
 	}
+	else if (direction & GMT_IS_DUPLICATE)	/* This is the default - just remove the mode flag */
+		direction -= GMT_IS_DUPLICATE;
 	if (!(direction == GMT_IN || direction == GMT_OUT)) return GMT_NOT_A_VALID_DIRECTION;
 	if (direction == GMT_IN && data == NULL) return GMT_PTR_IS_NULL;
 	if (name == NULL) return_error (V_API, GMT_PTR_IS_NULL);


### PR DESCRIPTION
While duplicate is the default, we must still handle the flag so that direction is set correctly.  if not we get a crash because no virtual file name is assigned.
