### PR TITLE
Adding API test for plotting a global matrix/grid for different central meridians

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -5482,6 +5482,10 @@ GMT_LOCAL struct GMT_GRID * gmtapi_import_grid (struct GMTAPI_CTRL *API, int obj
 					}
 				}
 			}
+			if (gmt_M_is_geographic (GMT, GMT_IN) && gmt_M_360_range (M_obj->range[XLO], M_obj->range[XHI])) {
+				double shift_amount = M_obj->range[XLO] - G_obj->header->wesn[XLO];
+				if (!gmt_M_is_zero (shift_amount)) gmt_grd_shift (GMT, G_obj, shift_amount);
+			}
 			gmt_BC_init (GMT, G_obj->header);	/* Initialize grid interpolation and boundary condition parameters */
 			if (gmt_M_err_pass (GMT, gmt_grd_BC_set (GMT, G_obj, GMT_IN), "Grid memory"))
 				return_null (API, GMT_GRID_BC_ERROR);	/* Set boundary conditions */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -5482,10 +5482,6 @@ GMT_LOCAL struct GMT_GRID * gmtapi_import_grid (struct GMTAPI_CTRL *API, int obj
 					}
 				}
 			}
-			if (gmt_M_is_geographic (GMT, GMT_IN) && gmt_M_360_range (M_obj->range[XLO], M_obj->range[XHI])) {
-				double shift_amount = M_obj->range[XLO] - G_obj->header->wesn[XLO];
-				if (!gmt_M_is_zero (shift_amount)) gmt_grd_shift (GMT, G_obj, shift_amount);
-			}
 			gmt_BC_init (GMT, G_obj->header);	/* Initialize grid interpolation and boundary condition parameters */
 			if (gmt_M_err_pass (GMT, gmt_grd_BC_set (GMT, G_obj, GMT_IN), "Grid memory"))
 				return_null (API, GMT_GRID_BC_ERROR);	/* Set boundary conditions */

--- a/src/testapi_matrix_360.c
+++ b/src/testapi_matrix_360.c
@@ -1,7 +1,8 @@
 #include "gmt_dev.h"
 
 /* Testing the passing of a matrix to grdimage for global projection
- * when the central meridian changes.
+ * when the central meridian changes. This currently fails as in
+ * https://github.com/GenericMappingTools/pygmt/issues/515#issue-655281714
  */
 
 int main () {
@@ -12,16 +13,18 @@ int main () {
 
 	API = GMT_Create_Session ("test", 2U, mode, NULL);
 
+	/* Read in earth_relief_01d as a matrix from text file and set correct region, inc, registartion */
 	M = GMT_Read_Data (API, GMT_IS_MATRIX, GMT_IS_FILE, GMT_IS_SURFACE, GMT_READ_NORMAL, NULL, "@earth_relief_01d.txt", NULL);
 	M->range[0] = -180;	M->range[1] = 180; M->range[2] = -90;	M->range[3] = 90.0;
 	M->inc[0] = M->inc[1] = 1.0;
 	M->registration = 1;
-	GMT_Open_VirtualFile (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_IN|GMT_IS_DUPLICATE, M, input);
-	/* call grdimage with central longitude 0 */
+	/* Create a virtual file to pass as a grid */
+	GMT_Open_VirtualFile (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, M, input);
+	/* Call grdimage with central longitude 0, which is the center of the grid */
 	sprintf (args, "%s -Rg -JH0/6i -Bg30 -K -Cgeo -P", input);
 	GMT_Call_Module (API, "grdimage", GMT_MODULE_CMD, args);
 	GMT_Init_VirtualFile (API, 0, input);
-	/* call grdimage with central longitude 180 */
+	/* Call grdimage with central longitude 180 which means grid needs to be rotated 180 */
 	sprintf (args, "%s -R -JH180/6i -Bg30 -O -Cgeo -Y3.5i", input);
 	GMT_Call_Module (API, "grdimage", GMT_MODULE_CMD, args);
 	GMT_Close_VirtualFile (API, input);

--- a/src/testapi_matrix_360.c
+++ b/src/testapi_matrix_360.c
@@ -12,10 +12,13 @@ int main () {
 
 	API = GMT_Create_Session ("test", 2U, mode, NULL);
 
-	M = GMT_Read_Data (API, GMT_IS_MATRIX, GMT_IS_FILE, GMT_IS_SURFACE, GMT_READ_NORMAL, NULL, "earth_relief_01d_p.grd", NULL);
-	GMT_Open_VirtualFile (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, M, input);
+	M = GMT_Read_Data (API, GMT_IS_MATRIX, GMT_IS_FILE, GMT_IS_SURFACE, GMT_READ_NORMAL, NULL, "@earth_relief_01d.txt", NULL);
+	M->range[0] = -180;	M->range[1] = 180; M->range[2] = -90;	M->range[3] = 90.0;
+	M->inc[0] = M->inc[1] = 1.0;
+	M->registration = 1;
+	GMT_Open_VirtualFile (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_IN|GMT_IS_DUPLICATE, M, input);
 	/* call grdimage with central longitude 0 */
-	sprintf (args, "%s -Rg -JH0/6i -Bg30 -K -Cgeo", input);
+	sprintf (args, "%s -Rg -JH0/6i -Bg30 -K -Cgeo -P", input);
 	GMT_Call_Module (API, "grdimage", GMT_MODULE_CMD, args);
 	GMT_Init_VirtualFile (API, 0, input);
 	/* call grdimage with central longitude 180 */

--- a/src/testapi_matrix_360.c
+++ b/src/testapi_matrix_360.c
@@ -12,10 +12,10 @@ int main () {
 
 	API = GMT_Create_Session ("test", 2U, mode, NULL);
 
-	M = GMT_Read_Data (API, GMT_IS_MATRIX, GMT_IS_FILE, GMT_IS_POINT, GMT_READ_NORMAL, NULL, "@earth_relief_01d", NULL);
+	M = GMT_Read_Data (API, GMT_IS_MATRIX, GMT_IS_FILE, GMT_IS_SURFACE, GMT_READ_NORMAL, NULL, "earth_relief_01d_p.grd", NULL);
 	GMT_Open_VirtualFile (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, M, input);
 	/* call grdimage with central longitude 0 */
-	sprintf (args, "%s -Rg -JH0/6i -g30 -K -Cgeo", input);
+	sprintf (args, "%s -Rg -JH0/6i -Bg30 -K -Cgeo", input);
 	GMT_Call_Module (API, "grdimage", GMT_MODULE_CMD, args);
 	GMT_Init_VirtualFile (API, 0, input);
 	/* call grdimage with central longitude 180 */

--- a/src/testapi_matrix_360.c
+++ b/src/testapi_matrix_360.c
@@ -1,0 +1,28 @@
+#include "gmt_dev.h"
+
+/* Testing the passing of a matrix to grdimage for global projection
+ * when the central meridian changes.
+ */
+
+int main () {
+	unsigned int mode = GMT_SESSION_EXTERNAL;
+	struct GMT_MATRIX *M = NULL;
+	char input[GMT_VF_LEN], args[256] = {""};
+	struct GMTAPI_CTRL *API = NULL;
+
+	API = GMT_Create_Session ("test", 2U, mode, NULL);
+
+	M = GMT_Read_Data (API, GMT_IS_MATRIX, GMT_IS_FILE, GMT_IS_POINT, GMT_READ_NORMAL, NULL, "@earth_relief_01d", NULL);
+	GMT_Open_VirtualFile (API, GMT_IS_GRID|GMT_VIA_MATRIX, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, M, input);
+	/* call grdimage with central longitude 0 */
+	sprintf (args, "%s -Rg -JH0/6i -g30 -K -Cgeo", input);
+	GMT_Call_Module (API, "grdimage", GMT_MODULE_CMD, args);
+	GMT_Init_VirtualFile (API, 0, input);
+	/* call grdimage with central longitude 180 */
+	sprintf (args, "%s -R -JH180/6i -Bg30 -O -Cgeo -Y3.5i", input);
+	GMT_Call_Module (API, "grdimage", GMT_MODULE_CMD, args);
+	GMT_Close_VirtualFile (API, input);
+
+	if (GMT_Destroy_Session (API)) return EXIT_FAILURE;
+	exit (0);
+}

--- a/test/api/apimat_360.sh
+++ b/test/api/apimat_360.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#
+# Test the C API for passing a global grid as a matrix to grdimage
+# and have the central meridian work correctly.
+
+ps=apimat_360.ps
+testapi_matrix_360 > $ps


### PR DESCRIPTION
**Description of proposed changes**

See https://github.com/GenericMappingTools/pygmt/issues/515#issue-655281714 for the backstory.  This PR adds a new testapi_matrix_360.c test program in C that recreates the same type of problem.  The plot with a zero central meridian looks fine but the one for 180 is not rotated to show the Pacific and has a nasty notch at Greenwhich instead.  I will try to make this case work once I better understand the reason.  Initial attempts to rotate the grid failed, so there is more to it.