### PR TITLE
Migrate the "Code Check" CI job from Azure Pipelines to GitHub Actions

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -17,24 +17,6 @@ variables:
 
 jobs:
 
-- job:
-  displayName: 'Code Checker'
-
-  steps:
-  - bash: |
-      set -x -e
-      cd src
-      bash gmt_make_PSL_strings.sh
-      bash gmt_make_enum_dicts.sh
-      bash gmt_make_module_purpose.sh
-      cd ..
-      # check if any files are changed
-      if [ $(git ls-files -m) ]; then
-        git diff HEAD
-        exit 1
-      fi
-    displayName: Check if any C codes and headers need to be manually updated
-
 # Lint Checker
 - job:
   displayName: 'Lint Checker'

--- a/.github/workflows/code-validator.yml
+++ b/.github/workflows/code-validator.yml
@@ -1,0 +1,45 @@
+# Workflow to validify the consistence of the codes
+
+on:
+  push:
+    branches:
+      - master
+      - '[0-9]+.[0-9]+'
+  pull_request:
+
+name: Code Validator
+
+jobs:
+  code-validator:
+    name: Code Validator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Check PSL_strings.h
+        run: |
+          cd src/
+          bash gmt_make_PSL_strings.sh
+          if [ $(git ls-files -m) ]; then git --no-pager diff HEAD; exit 1; fi
+          cd ..
+
+      - name: Check gmt_enum_dict.h
+        run: |
+          cd src/
+          bash gmt_make_enum_dicts.sh
+          if [ $(git ls-files -m) ]; then git --no-pager diff HEAD; exit 1; fi
+          cd ..
+
+      - name: Check module purposes
+        run: |
+          cd src/
+          bash gmt_make_module_purpose.sh
+          if [ $(git ls-files -m) ]; then git --no-pager diff HEAD; exit 1; fi
+          cd ..
+
+      - name: Check GMT_VERSION_YEAR in cmake/ConfigDefault.cmake is up-to-date
+        run: |
+          current_year=$(date +%Y)
+          gmt_version_year=$(grep GMT_VERSION_YEAR cmake/ConfigDefault.cmake | awk -F'"' '{print $2}')
+          if [ "$current_year" != "$gmt_version_year" ]; then exit 1; fi

--- a/.github/workflows/code-validator.yml
+++ b/.github/workflows/code-validator.yml
@@ -38,7 +38,7 @@ jobs:
           if [ $(git ls-files -m) ]; then git --no-pager diff HEAD; exit 1; fi
           cd ..
 
-      - name: Check GMT_VERSION_YEAR in cmake/ConfigDefault.cmake is up-to-date
+      - name: Check GMT version year
         run: |
           current_year=$(date +%Y)
           gmt_version_year=$(grep GMT_VERSION_YEAR cmake/ConfigDefault.cmake | awk -F'"' '{print $2}')


### PR DESCRIPTION
Migrate the "Code Check" CI job from Azure Pipelines to GitHub Actions,
and also add a check of the current year, so that when the new year begins,
we won't forget to update the copyright year.