### PR TITLE
Wrap testapi programs for testing

### DIFF
--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -86,7 +86,11 @@ for apiprog in \
     testapi_imageshading \
     testapi_matrix_as_grid \
     testapi_vector_strings \
-    testapi_vector_plot
+    testapi_vector_plot \
+    testapi_vector_io \
+    testapi_matrix_io \
+    testapi_matrix_360 \
+    testapi_matrix_360_ref
 do
     eval "${apiprog}() { valgrind_wrapper \"@GMT_BINARY_DIR@/src/${apiprog}\" \"\$@\"; }"
 done


### PR DESCRIPTION
The new API tests fail on Windows only, because the new API test
programs are not wrapped and the test scripts can't find them.