### PR TITLE
Keep track of allocation modes for grids and x/y vectors separately

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -604,10 +604,13 @@ GMT_LOCAL double * gmtapi_grid_coord (struct GMTAPI_CTRL *API, int dim, struct G
 GMT_LOCAL int gmtapi_alloc_grid_xy (struct GMTAPI_CTRL *API, struct GMT_GRID *G) {
 	/* Use information in Grid header to allocate the grid x/y vectors.
 	 * We assume gmtapi_init_grdheader has been called. */
+	struct GMT_GRID_HIDDEN *GH = NULL;
 	if (G == NULL) return (GMT_PTR_IS_NULL);
 	if (G->x || G->y) return (GMT_PTR_NOT_NULL);
+	GH = gmt_get_G_hidden (G);
 	G->x = gmtapi_grid_coord (API, GMT_X, G);	/* Get array of x coordinates */
 	G->y = gmtapi_grid_coord (API, GMT_Y, G);	/* Get array of y coordinates */
+	GH->xy_alloc_mode[GMT_X] = GH->xy_alloc_mode[GMT_Y] = GMT_ALLOC_INTERNALLY;
 	return (GMT_NOERROR);
 }
 
@@ -5566,12 +5569,14 @@ GMT_LOCAL struct GMT_GRID * gmtapi_import_grid (struct GMTAPI_CTRL *API, int obj
 	}
 	if ((mode & GMT_CONTAINER_ONLY) == 0) {	/* Also allocate and initialize the x and y vectors unless already present  */
 		if (G_obj->x == NULL) {
+			GH->xy_alloc_mode[GMT_X] = GMT_ALLOC_INTERNALLY;
 			if (GMT->current.io.nc_xarray)	/* Got variable x-array and asked to used this instead */
 				G_obj->x = GMT->current.io.nc_xarray, GMT->current.io.nc_xarray = NULL;
 			else
 				G_obj->x = gmtapi_grid_coord (API, GMT_X, G_obj);	/* Get array of x coordinates */
 		}
 		if (G_obj->y == NULL) {
+			GH->xy_alloc_mode[GMT_Y] = GMT_ALLOC_INTERNALLY;
 			if (GMT->current.io.nc_yarray)	/* Got variable y-array and asked to used this instead */
 				G_obj->y = GMT->current.io.nc_yarray, GMT->current.io.nc_yarray = NULL;
 			else

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -2713,10 +2713,10 @@ unsigned int gmtlib_free_grid_ptr (struct GMT_CTRL *GMT, struct GMT_GRID *G, boo
 		G->data = NULL;	/* This will remove reference to external memory since gmt_M_free_aligned would not have been called */
 	}
 	if (G->x && G->y && free_grid) {
-		if (GH->alloc_mode == GMT_ALLOC_INTERNALLY) {
+		if (GH->xy_alloc_mode[GMT_X] == GMT_ALLOC_INTERNALLY)
 			gmt_M_free (GMT, G->x);
+		if (GH->xy_alloc_mode[GMT_Y] == GMT_ALLOC_INTERNALLY)
 			gmt_M_free (GMT, G->y);
-		}
 		G->x = G->y = NULL;	/* This will remove reference to external memory since gmt_M_free would not have been called */
 	}
 	if (GH->extra) gmtlib_close_grd (GMT, G);	/* Close input file used for row-by-row i/o */

--- a/src/gmt_hidden.h
+++ b/src/gmt_hidden.h
@@ -193,6 +193,7 @@ struct GMT_GRID_HIDDEN {	/* Supporting information hidden from the API */
 	unsigned int id;                /* The internal number of the grid */
 	unsigned int alloc_level;       /* The level it was allocated at */
 	enum GMT_enum_alloc alloc_mode; /* Allocation mode [GMT_ALLOC_INTERNALLY] */
+	enum GMT_enum_alloc xy_alloc_mode[2];	 /* Stores how the x and y arrays were allocated (external or internal) */
 	void *extra;                    /* Row-by-row machinery information [NULL] */
 };
 


### PR DESCRIPTION
**Description of proposed changes**

Because some grids are passed in by reference and the corresponding x/y vectors may be created by GMT, we need separate alloc mode variables for the grid and the two vectors so we can free what should be freed while leading the grid alone.