### PR TITLE
Only turn on clobber background if it can work

### DIFF
--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -367,6 +367,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC bool gmt_same_fill (struct GMT_CTRL *GMT, struct GMT_FILL *F1, struct GMT_FILL *F2);
 EXTERN_MSC unsigned int gmt_contour_first_pos (struct GMT_CTRL *GMT, char *arg);
 EXTERN_MSC unsigned int gmt_contour_A_arg_parsing (struct GMT_CTRL *GMT, char *arg, struct CONTOUR_ARGS *A);
 EXTERN_MSC unsigned int gmt_contour_C_arg_parsing (struct GMT_CTRL *GMT, char *arg, struct CONTOUR_ARGS *A);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -8974,6 +8974,18 @@ int gmt_get_fill_from_z (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, double val
 	return (index);
 }
 
+bool gmt_same_fill (struct GMT_CTRL *GMT, struct GMT_FILL *F1, struct GMT_FILL *F2) {
+	/* Return true if the two fills are identical */
+	if (F1->use_pattern != F2->use_pattern) return false;	/* One is a pattern, the other isn't, so cannot be the same */
+	if (F1->use_pattern) {	/* Both are patterns */
+		if (F1->pattern_no != F2->pattern_no) return false;	/* Different patters used */
+		if (F1->pattern_no == -1)	/* Both have custom fill patterns */
+			return !strcmp (F1->pattern, F2->pattern);
+		return true;	/* They are the same */
+	}
+	return gmt_M_same_rgb (F1->rgb, F2->rgb);	/* true if the same color, including transparency level */
+}
+
 /*! . */
 GMT_LOCAL int gmtsupport_get_index_from_key (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, char *key) {
 	/* Will match key to a key in the color table.  Because a key is a string and may

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -758,21 +758,21 @@ EXTERN_MSC int GMT_pscoast (void *V_API, int mode, void *args) {
 		Ctrl->D.set = 'a';	/* Auto-select resolution under modern mode if -D not given */
 	clipping = (Ctrl->G.clip || Ctrl->S.clip);
 	if (Ctrl->D.force) Ctrl->D.set = gmt_shore_adjust_res (GMT, Ctrl->D.set);
-	fill[0] = (Ctrl->S.active) ? Ctrl->S.fill : no_fill;
-	fill[1] = fill[3] = (Ctrl->G.active) ? Ctrl->G.fill : no_fill;
-	fill[2] = fill[4] = (Ctrl->C.active) ? Ctrl->C.fill[LAKE] : fill[0];
-	fill[5] = (Ctrl->C.active) ? Ctrl->C.fill[RIVER] : fill[2];
+	fill[0] = (Ctrl->S.active) ? Ctrl->S.fill : no_fill;	/* Ocean fill */
+	fill[1] = fill[3] = (Ctrl->G.active) ? Ctrl->G.fill : no_fill;	/* Continent and islands in lakes fill */
+	fill[2] = fill[4] = (Ctrl->C.active) ? Ctrl->C.fill[LAKE] : fill[0];	/* Lakes and ponds-in-islands-in-lakes fill */
+	fill[5] = (Ctrl->C.active) ? Ctrl->C.fill[RIVER] : fill[2];		/* River-lake fill */
 	need_coast_base = (Ctrl->G.active || Ctrl->S.active || Ctrl->C.active || Ctrl->W.active);
 	if (Ctrl->Q.active) need_coast_base = false;	/* Since we just end clipping */
-	if (Ctrl->G.active && Ctrl->S.active) {	/* Must check if any of then are transparent */
+	if (Ctrl->G.active && Ctrl->S.active ) {	/* Must check if any of then are transparent */
 		if (Ctrl->G.fill.rgb[3] > 0.0 || Ctrl->S.fill.rgb[3] > 0.0) {	/* Transparency requested */
 			/* Special case since we cannot overprint so must run recursive twice */
 			double_recursive = true;
 			clobber_background = false;
 			GMT_Report (API, GMT_MSG_DEBUG, "Do double recursive painting due to transparency option for land or ocean\n");
 		}
-		else	/* OK to paint ocean first then overlay land */
-			clobber_background = true;
+		else	/* OK to paint ocean first then overlay land unless lakes have a different fill */
+			clobber_background = (!Ctrl->C.active || gmt_same_fill (GMT, &(Ctrl->C.fill[LAKE]), &(Ctrl->S.fill))) ? true : false;
 	}
 	recursive = (double_recursive || (Ctrl->G.active != (Ctrl->S.active || Ctrl->C.active)) || clipping);
 	paint_polygons = (Ctrl->G.active || Ctrl->S.active || Ctrl->C.active);

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -764,7 +764,7 @@ EXTERN_MSC int GMT_pscoast (void *V_API, int mode, void *args) {
 	fill[5] = (Ctrl->C.active) ? Ctrl->C.fill[RIVER] : fill[2];		/* River-lake fill */
 	need_coast_base = (Ctrl->G.active || Ctrl->S.active || Ctrl->C.active || Ctrl->W.active);
 	if (Ctrl->Q.active) need_coast_base = false;	/* Since we just end clipping */
-	if (Ctrl->G.active && Ctrl->S.active ) {	/* Must check if any of then are transparent */
+	if (Ctrl->G.active && Ctrl->S.active) {	/* Must check if any of then are transparent */
 		if (Ctrl->G.fill.rgb[3] > 0.0 || Ctrl->S.fill.rgb[3] > 0.0) {	/* Transparency requested */
 			/* Special case since we cannot overprint so must run recursive twice */
 			double_recursive = true;


### PR DESCRIPTION
See #3802 for background.  The problem was that **pscoast** decided that if both ocean and land will be painted, we can save some work by painting the entire canvas with ocean color since then the lakes are open holes that see through to that color.  However, if **-C** is used to change the color of lakes then of course we must paint the lakes individually anyway.  The code did not check for this case.  I added a new function _gmt_same_fill_ that carefully determines if two fills are the same or now, and if lake fill and ocean fill are different then we cannot use the simplified clobbering.  Closes #3802.
