### PR TITLE
Enable the GMT build script to build any branches or tags

### DIFF
--- a/ci/build-gmt.sh
+++ b/ci/build-gmt.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Build the GMT source codes of a specific branch, version or commit
+# Build the GMT source codes of a specific branch or tag/release
 #
 # Usage:
 #
@@ -12,7 +12,7 @@
 # Environmental variables that affect the building process:
 #
 # - GMT_INSTALL_DIR : GMT installation location [$HOME/gmt-install-dir]
-# - GMT_GIT_REF     : branch name, version, or commit full sha [master]
+# - GMT_GIT_REF     : branch name or tag/release [master]
 #
 
 set -x -e
@@ -34,19 +34,18 @@ GMT_BUILD_TMPDIR=$(mktemp -d ${TMPDIR:-/tmp/}gmt.XXXXXX)
 cd ${GMT_BUILD_TMPDIR}
 
 # 2. Download GMT, GSHHG and DCW from GitHub
-curl -SLO https://github.com/GenericMappingTools/gmt/archive/${GMT_GIT_REF}.${EXT}
+git clone --depth=1 --single-branch --branch ${GMT_GIT_REF} https://github.com/GenericMappingTools/gmt
 curl -SLO https://github.com/GenericMappingTools/gshhg-gmt/releases/download/${GSHHG_VERSION}/${GSHHG}.${EXT}
 curl -SLO https://github.com/GenericMappingTools/dcw-gmt/releases/download/${DCW_VERSION}/${DCW}.${EXT}
 
 # 3. Extract tarballs
-tar -xvf ${GMT_GIT_REF}.${EXT}
 tar -xvf ${GSHHG}.${EXT}
 tar -xvf ${DCW}.${EXT}
-mv ${GSHHG} gmt-${GMT_GIT_REF}/share/gshhg-gmt
-mv ${DCW} gmt-${GMT_GIT_REF}/share/dcw-gmt
+mv ${GSHHG} gmt/share/gshhg-gmt
+mv ${DCW} gmt/share/dcw-gmt
 
 # 4. Configure GMT
-cd gmt-${GMT_GIT_REF}/
+cd gmt/
 cat > cmake/ConfigUser.cmake << EOF
 set (CMAKE_INSTALL_PREFIX "${GMT_INSTALL_DIR}")
 set (CMAKE_C_FLAGS "-Wall -Wdeclaration-after-statement \${CMAKE_C_FLAGS}")

--- a/ci/build-gmt.sh
+++ b/ci/build-gmt.sh
@@ -1,25 +1,33 @@
 #!/usr/bin/env bash
 #
-# Build the GMT source codes of a specific branch or tag/release
+# Build the GMT source codes of a specific branch or tag/release.
 #
 # Usage:
 #
-# 1. Install GMT dependencies following the [wiki](https://github.com/GenericMappingTools/gmt/wiki)
-# 2. Run the following command to build the GMT source codes (master branch by default):
+#    bash build-gmt.sh [branch-or-tag]
 #
-#      curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/build-gmt.sh | bash
-#
-# Environmental variables that affect the building process:
+# Environmental variables that controls the building process:
 #
 # - GMT_INSTALL_DIR : GMT installation location [$HOME/gmt-install-dir]
-# - GMT_GIT_REF     : branch name or tag/release [master]
+# - GMT_GIT_REF     : branch name or tag/release [master if CLI argument isn't given]
+#
+# Notes for CI service users:
+#
+# 1. Install GMT dependencies following the [wiki](https://github.com/GenericMappingTools/gmt/wiki)
+# 2. Run the following command to build the GMT source codes:
+#
+#      curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/build-gmt.sh | bash
 #
 
 set -x -e
 
 # Following variables can be modified via environment variables
 GMT_INSTALL_DIR=${GMT_INSTALL_DIR:-${HOME}/gmt-install-dir}
-GMT_GIT_REF=${GMT_GIT_REF:-master}
+if [ "X$1" = "X" ]; then
+	GMT_GIT_REF=${GMT_GIT_REF:-master}
+else
+	GMT_GIT_REF=$1
+fi
 
 # General settings
 GSHHG_VERSION="2.3.7"


### PR DESCRIPTION
**Description of proposed changes**

Add one more environmental variable `GMT_GIT_REF` to the building script, so that it can build any branches or tags. Some example values of `GMT_GIT_REF` are:

- master [the default value]
- 6.1 (build the 6.1 branch)
- 6.1.0  (build the 6.1.0 release)
- et. al.

~The only issue is that, the build script uses the tarballs provided by GitHub, which don't have any git history information. So the GMT version string doesn't contain commit hash and commit date. For example, building the master branch gives you `6.2.0` instead of `6.2_b234d76_2020.08.04`.~

The script is also renamed from `build-gmt-master.sh` to `build-gmt.sh`, so https://github.com/GenericMappingTools/custom-supplements and https://github.com/GenericMappingTools/pygmt should make changes after this PR is merged.

Fixes #3837 