### PR TITLE
Updating a few keyword-value pairs for common options

### DIFF
--- a/src/block_subs.h
+++ b/src/block_subs.h
@@ -102,7 +102,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = { /* Local options for all th
 	{ 0, 'E', "extend", "b,r,s", "box-whisker,record,source", "l,h", "lower,higher" },
 #endif
 	{ 0, 'G', "gridfile", "", "", "", "" },
-	{ '/', 'I', "increment", "", "", "e,n", "exact,number" },
+	GMT_INCREMENT_KW,
 #if !defined(BLOCKMEAN)		/* Only blockmedian & blockmode have a -Q option */
 	{ 0, 'Q', "quicker", "", "", "", "" },
 #endif

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -158,11 +158,9 @@ enum GMT_enum_script {GMT_BASH_MODE = 0,	/* Write Bash script */
 	GMT_CSH_MODE,			/* Write C-shell script */
 	GMT_DOS_MODE};			/* Write DOS script */
 
-#if defined(USE_COMMON_LONG_OPTIONS)
 /* Since -I is not a global option but we almost use it as such, we define the long-option for it here.
  * Modules that need it in their module_kw[] array can just add it to their list. */
 #define GMT_INCREMENT_KW { '/', 'I', "increment", "", "", "e,n", "exact,number" }
-#endif
 
 #define GMT_VERBOSE_CODES	"q ewticd"	/* List of valid codes to -V (the blank is for NOTICE which is not user selectable */
 #define GMT_DIM_UNITS	"cip"		/* Plot dimensions in cm, inch, or point */

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -122,7 +122,7 @@ enum GMT_enum_length {
 	GMT_LEN128      = 128U,         /* Double of 64 */
 	GMT_LEN256      = 256U,         /* Max size of some text items */
 	GMT_LEN512      = 512U,         /* Max size of other text items */
-	GMT_LEN1024     = 1024U,        /* For file names (antecipating web fnames) */
+	GMT_LEN1024     = 1024U,        /* For file names (anticipating web fnames) */
 	GMT_MAX_RANGES  = 64U,          /* Limit on number of row ranges given in -q */
 	GMT_MAX_COLUMNS = 4096U,        /* Limit on number of columns in data tables (not grids) */
 	GMT_BUFSIZ      = 4096U,        /* Size of char record for i/o */
@@ -157,6 +157,12 @@ enum GMT_swap_direction {
 enum GMT_enum_script {GMT_BASH_MODE = 0,	/* Write Bash script */
 	GMT_CSH_MODE,			/* Write C-shell script */
 	GMT_DOS_MODE};			/* Write DOS script */
+
+#if defined(USE_COMMON_LONG_OPTIONS)
+/* Since -I is not a global option but we almost use it as such, we define the long-option for it here.
+ * Modules that need it in their module_kw[] array can just add it to their list. */
+#define GMT_INCREMENT_KW { '/', 'I', "increment", "", "", "e,n", "exact,number" }
+#endif
 
 #define GMT_VERBOSE_CODES	"q ewticd"	/* List of valid codes to -V (the blank is for NOTICE which is not user selectable */
 #define GMT_DIM_UNITS	"cip"		/* Plot dimensions in cm, inch, or point */
@@ -398,7 +404,7 @@ enum GMT_enum_derivative {
 enum GMT_enum_extrap {
 	GMT_EXTRAPOLATE_NONE = 0,   /* No extrapolation; set to NaN outside bounds */
 	GMT_EXTRAPOLATE_SPLINE,     /* Let spline extrapolate beyond bounds */
-	GMT_EXTRAPOLATE_CONSTANT};  /* Set extrapolation beyond bound to specifiec constant */
+	GMT_EXTRAPOLATE_CONSTANT};  /* Set extrapolation beyond bound to specific constant */
 
 enum GMT_enum_cross {
 	GMT_CROSS_NORMAL = 0,	/* Regular grid cross */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -378,7 +378,9 @@ static char *map_annot_oblique_item[N_MAP_ANNOT_OBLIQUE_ITEMS] = {
  *
  * Without these we are blind to the keyword arrays.  Note that while you can test the
  * common options without the module options, you cannot do the reverse.
-  */
+ *
+ * Note: For the near-global option -I (--increment), see gmt_constants.h for GMT_INCREMENT_KW definition.
+ */
 
 static struct GMT_KEYWORD_DICTIONARY gmt_common_kw[] = {
 	/* separator, short-option, long-option, short-directives, long-directives, short-modifiers, long-modifiers */
@@ -392,6 +394,7 @@ static struct GMT_KEYWORD_DICTIONARY gmt_common_kw[] = {
 	{   0, 'Y', "yshift",        "a,c,f,r", "absolute,center,fixed,relative",           "",         				""},
 	{   0, 'a', "aspatial",      "",        "",                                         "",         				""},
 	{   0, 'b', "binary",        "",        "",                                         "b,l",      				"big-endian,little-endian"},
+	{   0, 'c', "panel",         "",        "",                                         "",      				    ""},
 	{   0, 'd', "nodata",        "i,o",     "in,out",                                   "",         				""},
 	{   0, 'e', "find",          "",        "",                                         "f",        				"file"},
 	{ ',', 'f', "coltypes",      "i,o",     "in,out",                                   "",        					""},
@@ -399,12 +402,14 @@ static struct GMT_KEYWORD_DICTIONARY gmt_common_kw[] = {
 	{   0, 'h', "header",        "i,o",     "in,out",                                   "c,d,r,t", 					"columns,delete,remark,title"},
 	{ ',', 'i', "read-columns",  "",        "",                                         "l,o,s",   					"log10,offset,scale"},
 	{   0, 'j', "spherical",     "e,f,g",   "ellipsoidal,flat-earth,great-circle",      "",   			    		""},
-	{   0, 'l', "legend",        "",        "",                                         "d,f,g,h,j,l,n,s,v,w,x",   	"drawline,font,gap,header,justify,linetext,ncols,size,vertline,width,scale"},
+	{   0, 'l', "legend",        "",        "",                                         "D,G,H,L,N,S,V,f,g,j,o,p,s,w",   	"drawline,gap,header,linetext,ncols,size,vertline,font,fill,justify,offset,pen,scale,width"},
 	{   0, 'n', "interpolation", "b,c,l,n", "b-spline,bicubic,linear,nearest-neighbor", "a,b,c,t",     				"antialias,bc,clip,threshold"},
 	{ ',', 'o', "write-columns", "",        "",                                         "",        					""},
 	{   0, 'p', "perspective",   "x,y,z",   "x,y,z",                                    "v,w",     					"view,world"},
+	{ ',', 'q', "read-rows",     "~",       "invert",                                   "a,c,f,s",   				"per-set,column,per-file,per-segment"},
+	{ ',', 'q', "write-rows",    "~",       "invert",                                   "a,c,f,s",   				"per-set,column,per-file,per-segment"},
 	{   0, 'r', "registration",  "g,p",     "gridline,pixel",                           "",        					""},
-	{   0, 's', "skip-record",   "",       "",                                         "a,r",     					"any,reverse"},
+	{   0, 's', "skip-rows",     "",       "",                                         "a,r",     					"any,reverse"},
 	{   0, 't', "transparency",  "",        "",                                         "",        					""},
 	{   0, 'x', "cores",         "",        "",                                         "",        					""},
 	{   0, '\0', "",             "",        "",                                         "",        					""}	/* End of list marked with empty code and strings */
@@ -656,6 +661,11 @@ GMT_LOCAL void gmtinit_kw_replace (struct GMTAPI_CTRL *API, struct GMT_KEYWORD_D
 		sep[0] = kw[k].separator;			/* Need a string with separator to strcat below */
 		new_arg[0] = '\0';					/* Initialize short option arguments */
 		modified = true;					/* We have at least modified one option */
+		/* Special handling for --read-rows and --write-rows since they both map to q and need -qi and -qo, respectively */
+		if (!strcmp (kw[k].long_option, "read-rows"))
+			strcat (new_arg, "i");
+		else if (!strcmp (kw[k].long_option, "write-rows"))
+			strcat (new_arg, "o");
 
 		for (section = 0; section < n_sections; section++) {	/* Parse the sections separately but strcat together a single short option */
 			/* Make sure a few things are correct */


### PR DESCRIPTION
I added the relatively new **-qi** (--read-rows) and **-qo** (write-rows)  and **-c** (--panel) to the mix,  Also updated the information for **-l** (--legend) since we made some major changes since that was first coded.  Tested these informallly to make sure they worked in the translation from long to short syntax.  Also made a constant for the structure record used for grid increments (**-I**) since it is a near-global option that will be needed by many modules, so to avoid typos we will use **GMT_INCREMENT_KW**.
