### PR TITLE
Ignore classic history when modern session starts

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -17533,7 +17533,9 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 					}
 				}
 			}
-			if (error) return (error);			/* Bail at this point */
+			if (error) return (error);		/* Bail at this point */
+			gmt_reset_history (API->GMT);	/* No old classic history shall affect a new modern mode session */
+
 			gmt_conf (API->GMT);				/* Get the original system defaults */
 			if (!clean_start) gmt_getdefaults (API->GMT, NULL);		/* Overload user defaults */
 			snprintf (dir, PATH_MAX, "%s/%s", API->gwf_dir, GMT_SETTINGS_FILE);	/* Reuse dir string for saving gmt.conf to this dir */


### PR DESCRIPTION
See troubles found in #3844.  In modern mode, no old gmt.history file in the current directory shall infect the session.