### PR TITLE
Let -R handle east < west for common cases

### DIFF
--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -9180,7 +9180,7 @@ int gmt_proj_setup (struct GMT_CTRL *GMT, double wesn[]) {
 
 	if (gmt_M_x_is_lon (GMT, GMT_IN)) {
 		/* Limit east-west range to 360 and make sure east > -180 and west < 360 */
-		if (!GMT->common.R.oblique) {	/* Only makes sense if not corner coordinates */
+		if (!GMT->common.R.oblique || gmt_M_is_rect_graticule (GMT)) {	/* Only makes sense if not corner coordinates */
 			if (wesn[XHI] < wesn[XLO]) wesn[XHI] += 360.0;
 			if ((fabs (wesn[XHI] - wesn[XLO]) - 360.0) > GMT_CONV4_LIMIT) Return (GMT_MAP_EXCEEDS_360);
 		}


### PR DESCRIPTION
See this [forum post](https://forum.generic-mapping-tools.org/t/grdview-issue-in-gmt-6-1-over-180-longitude/749/3).  Making a map from 130E to 110W means -R130/-110.  This PR allows the implied east < west for a Mercator projection when the region is set by giving the two corners.  So this will now be accepted:

`gmt pscoast -JM22.7c -R130/-40.2/-112/36.0790121389+r -Gred -Baf > t.ps`

which previously failed because it is not an oblique projection and hence we applied the east > west criteria, but since the same syntax is allowed for other cases with oblique region notation we can let this one through.

For non-oblique projections, all you have to do is use proper longitude specification, i.e., not -R130/-110 but -R130E/110W.  All tests still pass.
