### PR TITLE
Wrap testapi_grid2matrix so that Windows test can find it

### DIFF
--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -90,7 +90,8 @@ for apiprog in \
     testapi_vector_io \
     testapi_matrix_io \
     testapi_matrix_360 \
-    testapi_matrix_360_ref
+    testapi_matrix_360_ref \
+    testapi_grid2matrix
 do
     eval "${apiprog}() { valgrind_wrapper \"@GMT_BINARY_DIR@/src/${apiprog}\" \"\$@\"; }"
 done


### PR DESCRIPTION
Fix the failing test on Windows:
```
1/9 Test #215: api/apimat2grd.sh ................***Failed    3.19 sec
Set GMT_SESSION_NAME = 39537
apimat2grd.sh: line 7: testapi_grid2matrix: command not found
ERROR: apimat2grd.sh:7
memtrack errors: 0
exit status: 1
```