### PR TITLE
Ensure a duplicated grid via gmt_new_grid has the minimum padding required by module

### DIFF
--- a/src/geodesy/gpsgridder.c
+++ b/src/geodesy/gpsgridder.c
@@ -739,7 +739,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 		if (GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_DATA_ONLY, NULL, Ctrl->T.file, Grid) == NULL) {	/* Get data */
 			Return (API->error);
 		}
-		(void)gmt_set_outgrid (GMT, Ctrl->T.file, false, Grid, &Out[GMT_X]);	/* true if input is a read-only array; otherwise Out[GMT_X] is just a pointer to Grid */
+		(void)gmt_set_outgrid (GMT, Ctrl->T.file, false, 0, Grid, &Out[GMT_X]);	/* true if input is a read-only array; otherwise Out[GMT_X] is just a pointer to Grid */
 		n_ok = Out[GMT_X]->header->nm;
 		gmt_M_grd_loop (GMT, Out[GMT_X], row, col, k) if (gmt_M_is_fnan (Out[GMT_X]->data[k])) n_ok--;
 		/* Duplicate u grid to get another grid for v predictions */

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -2759,7 +2759,7 @@ int gmt_set_outgrid (struct GMT_CTRL *GMT, char *file, bool separate, unsigned i
 			GH->alloc_mode = GMT_ALLOC_INTERNALLY;
 			if (add_pad) {
 				gmt_grd_pad_on (GMT, *Out, pad);	/* Add pad */
-				gmt_BC_init (GMT, *Out->header);	/* Initialize grid interpolation and boundary condition parameters */
+				gmt_BC_init (GMT, (*Out)->header);	/* Initialize grid interpolation and boundary condition parameters */
 				gmt_grd_BC_set (GMT, *Out, GMT_IN);	/* Set boundary conditions */
 			}
 		}
@@ -2769,7 +2769,7 @@ int gmt_set_outgrid (struct GMT_CTRL *GMT, char *file, bool separate, unsigned i
 	(*Out) = G;
 	if (add_pad) {
 		gmt_grd_pad_on (GMT, *Out, pad);	/* Add pad */
-		gmt_BC_init (GMT, *Out->header);	/* Initialize grid interpolation and boundary condition parameters */
+		gmt_BC_init (GMT, (*Out)->header);	/* Initialize grid interpolation and boundary condition parameters */
 		gmt_grd_BC_set (GMT, *Out, GMT_IN);	/* Set boundary conditions */
 	}
 	return (false);

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -2732,7 +2732,7 @@ void gmt_free_grid (struct GMT_CTRL *GMT, struct GMT_GRID **G, bool free_grid) {
 	gmt_M_free (GMT, *G);
 }
 
-int gmt_set_outgrid (struct GMT_CTRL *GMT, char *file, bool separate, struct GMT_GRID *G, struct GMT_GRID **Out) {
+int gmt_set_outgrid (struct GMT_CTRL *GMT, char *file, bool separate, unsigned int min_pad, struct GMT_GRID *G, struct GMT_GRID **Out) {
 	/* In most situations we can recycle the input grid to be the output grid as well.  However, there
 	 * are a few situations when we must override this situation:
 	 *   1) When OpenMP is enabled and calculations depend on nearby nodes.
@@ -2741,9 +2741,14 @@ int gmt_set_outgrid (struct GMT_CTRL *GMT, char *file, bool separate, struct GMT
 	 * To avoid wasting memory we try to reuse the input array when
 	 * it is possible. We return true when new memory had to be allocated.
 	 * Note we duplicate the grid if we must so that Out always has the input
-	 * data in it (directly or via the pointer).  */
+	 * data in it (directly or via the pointer).
+	 * If the selected grid has a smaller pad than min_pad then we extend it to min_pad  */
+	bool add_pad = false;
+	unsigned int k, pad[4] = {min_pad, min_pad, min_pad, min_pad};
 	struct GMT_GRID_HIDDEN *GH = gmt_get_G_hidden (G);
 
+	for (k = 0; !add_pad && k < 4; k++)
+		if (G->header->pad[k] < min_pad) add_pad = true;
 	if (separate || gmt_M_file_is_memory (file) || GH->alloc_mode == GMT_ALLOC_EXTERNALLY) {	/* Cannot store results in a non-GMT read-only input array */
 		if ((*Out = GMT_Duplicate_Data (GMT->parent, GMT_IS_GRID, GMT_DUPLICATE_DATA, G)) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to duplicate grid! - this is not a good thing and may crash this module\n");
@@ -2752,11 +2757,21 @@ int gmt_set_outgrid (struct GMT_CTRL *GMT, char *file, bool separate, struct GMT
 		else {
 			struct GMT_GRID_HIDDEN *GH = gmt_get_G_hidden (*Out);
 			GH->alloc_mode = GMT_ALLOC_INTERNALLY;
+			if (add_pad) {
+				gmt_grd_pad_on (GMT, *Out, pad);	/* Add pad */
+				gmt_BC_init (GMT, *Out->header);	/* Initialize grid interpolation and boundary condition parameters */
+				gmt_grd_BC_set (GMT, *Out, GMT_IN);	/* Set boundary conditions */
+			}
 		}
 		return (true);
 	}
 	/* Here we may overwrite the input grid and just pass the pointer back */
 	(*Out) = G;
+	if (add_pad) {
+		gmt_grd_pad_on (GMT, *Out, pad);	/* Add pad */
+		gmt_BC_init (GMT, *Out->header);	/* Initialize grid interpolation and boundary condition parameters */
+		gmt_grd_BC_set (GMT, *Out, GMT_IN);	/* Set boundary conditions */
+	}
 	return (false);
 }
 

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -213,7 +213,7 @@ EXTERN_MSC int gmt_grd_setregion (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *
 EXTERN_MSC int gmt_grd_RI_verify (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h, unsigned int mode);
 EXTERN_MSC int gmt_read_img (struct GMT_CTRL *GMT, char *imgfile, struct GMT_GRID *G, double *wesn, double scale, unsigned int mode, double lat, bool init);
 EXTERN_MSC bool gmt_grd_pad_status (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, unsigned int *pad);
-EXTERN_MSC int gmt_set_outgrid (struct GMT_CTRL *GMT, char *file, bool separate, struct GMT_GRID *G, struct GMT_GRID **Out);
+EXTERN_MSC int gmt_set_outgrid (struct GMT_CTRL *GMT, char *file, bool separate, unsigned int min_pad, struct GMT_GRID *G, struct GMT_GRID **Out);
 EXTERN_MSC int gmt_change_grdreg (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h, unsigned int registration);
 EXTERN_MSC void gmt_grd_shift (struct GMT_CTRL *GMT, struct GMT_GRID *Grid, double shift);
 EXTERN_MSC void gmt_grd_set_ij_inc (struct GMT_CTRL *GMT, unsigned int n_columns, int *ij_inc);

--- a/src/grdclip.c
+++ b/src/grdclip.c
@@ -342,7 +342,7 @@ EXTERN_MSC int GMT_grdclip (void *V_API, int mode, void *args) {
 		Return (API->error);	/* Get subset */
 	}
 
-	new_grid = gmt_set_outgrid (GMT, Ctrl->In.file, false, G, &Out);	/* true if input is a read-only array */
+	new_grid = gmt_set_outgrid (GMT, Ctrl->In.file, false, 0, G, &Out);	/* true if input is a read-only array */
 
 	gmt_M_grd_loop (GMT, G, row, col, ij) {
 		/* Checking if extremes are exceeded (need not check NaN) */

--- a/src/grdfft.c
+++ b/src/grdfft.c
@@ -876,7 +876,7 @@ EXTERN_MSC int GMT_grdfft (void *V_API, int mode, void *args) {
 		/* Note: If input grid(s) are read-only then we must duplicate them; otherwise Grid[k] points to Orig[k]
 		 * From here we address the first grid via Grid[0] and the 2nd grid (if given) as Grid[1];
 	 	 * we are done with using the addresses Orig[k] directly. */
-		(void) gmt_set_outgrid (GMT, Ctrl->In.file[k], false, Orig[k], &Grid[k]);
+		(void) gmt_set_outgrid (GMT, Ctrl->In.file[k], false, 0, Orig[k], &Grid[k]);
 		FFT_info[k] = GMT_FFT_Create (API, Grid[k], GMT_FFT_DIM, GMT_GRID_IS_COMPLEX_REAL, Ctrl->N.info);
 	}
 	K = FFT_info[0];	/* We only need one of these anyway; K is a shorthand */

--- a/src/grdgradient.c
+++ b/src/grdgradient.c
@@ -560,7 +560,7 @@ EXTERN_MSC int GMT_grdgradient (void *V_API, int mode, void *args) {
 	separate = true;	/* Cannot use input grid to hold output grid when doing things in parallel */
 #endif
 #endif
-	new_grid = gmt_set_outgrid (GMT, Ctrl->In.file, separate, Surf, &Out);	/* true if input is a read-only array */
+	new_grid = gmt_set_outgrid (GMT, Ctrl->In.file, separate, 1, Surf, &Out);	/* true if input is a read-only array */
 
 	if (gmt_M_is_geographic (GMT, GMT_IN) && !Ctrl->E.active) {	/* Flat-Earth approximation */
 		dx_grid = GMT->current.proj.DIST_M_PR_DEG * Surf->header->inc[GMT_X] * cosd ((Surf->header->wesn[YHI] + Surf->header->wesn[YLO]) / 2.0);

--- a/src/grdhisteq.c
+++ b/src/grdhisteq.c
@@ -470,7 +470,7 @@ EXTERN_MSC int GMT_grdhisteq (void *V_API, int mode, void *args) {
 	if (GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_DATA_ONLY, wesn, Ctrl->In.file, Grid) == NULL) {	/* Get subset */
 		Return (API->error);
 	}
-	(void)gmt_set_outgrid (GMT, Ctrl->In.file, false, Grid, &Out);	/* true if input is a read-only array */
+	(void)gmt_set_outgrid (GMT, Ctrl->In.file, false, 0, Grid, &Out);	/* true if input is a read-only array */
 	gmt_grd_init (GMT, Out->header, options, true);
 
 	if (Ctrl->N.active)

--- a/src/grdvolume.c
+++ b/src/grdvolume.c
@@ -526,7 +526,7 @@ EXTERN_MSC int GMT_grdvolume (void *V_API, int mode, void *args) {
 		}
 	}
 
-	(void) gmt_set_outgrid (GMT, Ctrl->In.file, false, Grid, &Work);	/* true if input is a read-only array */
+	(void) gmt_set_outgrid (GMT, Ctrl->In.file, false, 0, Grid, &Work);	/* true if input is a read-only array */
 	gmt_grd_init (GMT, Work->header, options, true);
 
 	/* Set node increments relative to the lower-left node of a 4-point box */

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -1864,7 +1864,7 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 			gmt_M_free (GMT, X);	gmt_M_free (GMT, obs);
 			Return (API->error);
 		}
-		(void)gmt_set_outgrid (GMT, Ctrl->T.file, false, Grid, &Out);	/* true if input is a read-only array; otherwise Out is just a pointer to Grid */
+		(void)gmt_set_outgrid (GMT, Ctrl->T.file, false, 0, Grid, &Out);	/* true if input is a read-only array; otherwise Out is just a pointer to Grid */
 		n_ok = Grid->header->nm;
 		gmt_M_grd_loop (GMT, Grid, row, col, ij) if (gmt_M_is_fnan (Grid->data[ij])) n_ok--;
 		Z.nz = 1;

--- a/src/potential/gravfft.c
+++ b/src/potential/gravfft.c
@@ -625,7 +625,7 @@ EXTERN_MSC int GMT_gravfft (void *V_API, int mode, void *args) {
                                       GMT_GRID_IS_COMPLEX_REAL, NULL, Ctrl->In.file[k], Orig[k])) == NULL)	/* Get data only */
 			Return (API->error);
 		/* Note: If input grid(s) are read-only then we must duplicate them; otherwise Grid[k] points to Orig[k] */
-		(void) gmt_set_outgrid (GMT, Ctrl->In.file[k], false, Orig[k], &Grid[k]);
+		(void) gmt_set_outgrid (GMT, Ctrl->In.file[k], false, 0, Orig[k], &Grid[k]);
 	}
 
 	/* From here we address the first grid via Grid[0] and the 2nd grid (if given) as Grid[1];

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -830,7 +830,7 @@ GMT_LOCAL struct GRDFLEXURE_GRID *grdflexure_prepare_load (struct GMT_CTRL *GMT,
 		return NULL;
 	}
 	/* Note: If input grid is read-only then we must duplicate it; otherwise Grid points to Orig */
-	(void) gmt_set_outgrid (API->GMT, file, false, Orig, &Grid);
+	(void) gmt_set_outgrid (API->GMT, file, false, 0, Orig, &Grid);
 	if (Ctrl->W.active) {	/* See if any part of the load sticks above water, and if so scale this amount as if it was submerged */
 		uint64_t node, n_subaerial = 0;
 		double boost = Ctrl->D.rhol / (Ctrl->D.rhol - Ctrl->D.rhow);


### PR DESCRIPTION
**Description of proposed changes**

Addresses #3843.  What happens here is that the _gmt_new_grid_ determines that the input grid is a memory grid so it duplicates another grid since it will be written into.  Because the input grid was a matrix it had no padding, so we get a grid with no padding.  Unfortunately, the **grdgradient** algorithm requires at least 1 pad row/column. I have added a new argument to _gmt_new_grid_ (a _minimum_ pad required) and pass that for each module.  It is usually 0 (pad is not going to be needed) but for **grdgradient** it is 1.  There may be future places where 2 might be needed.  Now, _gmt_new_grid_ will extend the pad to the minimum required if it is too small.  @seisman, please see if this fixes #3843 - I did not yet test it...

