### PR TITLE
Let gmt have option to only list core modules

### DIFF
--- a/src/gmt.c
+++ b/src/gmt.c
@@ -140,9 +140,21 @@ int main (int argc, char *argv[]) {
 				status = GMT_NOERROR;
 			}
 
+			/* Print all modern modules (core only) and exit */
+			else if (!strncmp (argv[arg_n], "--show-modules-core", 15U)) {
+				GMT_Call_Module (api_ctrl, NULL, GMT_MODULE_LIST_CORE, NULL);
+				status = GMT_NOERROR;
+			}
+
 			/* Print all modern modules and exit */
 			else if (!strncmp (argv[arg_n], "--show-modules", 8U)) {
 				GMT_Call_Module (api_ctrl, NULL, GMT_MODULE_LIST, NULL);
+				status = GMT_NOERROR;
+			}
+
+			/* Print all classic modules (core only) and exit */
+			else if (!strncmp (argv[arg_n], "--show-classic-core", 15U)) {
+				GMT_Call_Module (api_ctrl, NULL, GMT_MODULE_CLASSIC_CORE, NULL);
 				status = GMT_NOERROR;
 			}
 
@@ -328,23 +340,25 @@ int main (int argc, char *argv[]) {
 			fprintf (stderr, "usage: %s [options]\n", PROGRAM_NAME);
 			fprintf (stderr, "       %s <module name> [<module-options>]\n\n", PROGRAM_NAME);
 			fprintf (stderr, "options:\n");
-			fprintf (stderr, "  --help            List descriptions of available GMT modules.\n");
-			fprintf (stderr, "  --new-script[=L]  Write GMT modern mode script template to stdout.\n");
-			fprintf (stderr, "                    Optionally specify bash|csh|batch [Default is current shell].\n");
-			fprintf (stderr, "  --new-glue=name   Write C code for external supplements to glue them to GMT.\n");
-			fprintf (stderr, "  --show-bindir     Show directory with GMT executables.\n");
-			fprintf (stderr, "  --show-citation   Show the most recent citation for GMT.\n");
-			fprintf (stderr, "  --show-classic    Show all classic module names.\n");
-			fprintf (stderr, "  --show-cores      Show number of available cores.\n");
-			fprintf (stderr, "  --show-datadir    Show directory/ies with user data.\n");
-			fprintf (stderr, "  --show-dataserver Show URL of the remote GMT data server.\n");
-			fprintf (stderr, "  --show-doi        Show the DOI for the current release.\n");
-			fprintf (stderr, "  --show-library    Show path of the shared GMT library.\n");
-			fprintf (stderr, "  --show-modules    Show all modern module names.\n");
-			fprintf (stderr, "  --show-plugindir  Show directory for plug-ins.\n");
-			fprintf (stderr, "  --show-sharedir   Show directory for shared GMT resources.\n");
-			fprintf (stderr, "  --show-userdir    Show full path of user's ~/.gmt dir\n");
-			fprintf (stderr, "  --version         Print GMT version number.\n\n");
+			fprintf (stderr, "  --help              List descriptions of available GMT modules.\n");
+			fprintf (stderr, "  --new-script[=L]    Write GMT modern mode script template to stdout.\n");
+			fprintf (stderr, "                      Optionally specify bash|csh|batch [Default is current shell].\n");
+			fprintf (stderr, "  --new-glue=name     Write C code for external supplements to glue them to GMT.\n");
+			fprintf (stderr, "  --show-bindir       Show directory with GMT executables.\n");
+			fprintf (stderr, "  --show-citation     Show the most recent citation for GMT.\n");
+			fprintf (stderr, "  --show-classic      Show all classic module names.\n");
+			fprintf (stderr, "  --show-classic-core Show all classic module names (core only).\n");
+			fprintf (stderr, "  --show-cores        Show number of available cores.\n");
+			fprintf (stderr, "  --show-datadir      Show directory/ies with user data.\n");
+			fprintf (stderr, "  --show-dataserver   Show URL of the remote GMT data server.\n");
+			fprintf (stderr, "  --show-doi          Show the DOI for the current release.\n");
+			fprintf (stderr, "  --show-library      Show path of the shared GMT library.\n");
+			fprintf (stderr, "  --show-modules      Show all modern module names.\n");
+			fprintf (stderr, "  --show-modules-core Show all modern module names (core only).\n");
+			fprintf (stderr, "  --show-plugindir    Show directory for plug-ins.\n");
+			fprintf (stderr, "  --show-sharedir     Show directory for shared GMT resources.\n");
+			fprintf (stderr, "  --show-userdir      Show full path of user's ~/.gmt dir\n");
+			fprintf (stderr, "  --version           Print GMT version number.\n\n");
 			fprintf (stderr, "if <module-options> is \'=\' we call exit (0) if module exist and non-zero otherwise.\n\n");
 		}
 		status = GMT_RUNTIME_ERROR;

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -10962,8 +10962,10 @@ GMT_LOCAL void * gmtapi_get_module_func (struct GMTAPI_CTRL *API, const char *mo
 int GMT_Call_Module (void *V_API, const char *module, int mode, void *args) {
 	/* Call the specified shared module and pass it the mode and args.
  	 * mode can be one of the following:
-	 * GMT_MODULE_CLASSIC [-5]:	As GMT_MODULE_PURPOSE, but only lists the classic modules.
-	 * GMT_MODULE_LIST [-4]:	As GMT_MODULE_PURPOSE, but only lists the modern modules.
+	 * GMT_MODULE_CLASSIC [-7]:	As GMT_MODULE_PURPOSE, but only lists the classic modules.
+	 * GMT_MODULE_LIST [-6]:	As GMT_MODULE_PURPOSE, but only lists the modern modules.
+	 * GMT_MODULE_CLASSIC_CORE [-5]:	As GMT_MODULE_PURPOSE, but only lists the classic modules (core only).
+	 * GMT_MODULE_LIST_CORE [-4]:	As GMT_MODULE_PURPOSE, but only lists the modern modules (core only).
 	 * GMT_MODULE_EXIST [-3]:	Return GMT_NOERROR (0) if module exists, GMT_NOT_A_VALID_MODULE otherwise.
 	 * GMT_MODULE_PURPOSE [-2]:	As GMT_MODULE_EXIST, but also print the module purpose.
 	 * GMT_MODULE_OPT [-1]:		Args is a linked list of option structures.
@@ -10977,18 +10979,18 @@ int GMT_Call_Module (void *V_API, const char *module, int mode, void *args) {
 	int (*p_func)(void*, int, void*) = NULL;       /* function pointer */
 
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
-	if (module == NULL && !(mode == GMT_MODULE_LIST || mode == GMT_MODULE_CLASSIC || mode == GMT_MODULE_PURPOSE))
+	if (module == NULL && !(mode == GMT_MODULE_LIST || mode == GMT_MODULE_LIST_CORE || mode == GMT_MODULE_CLASSIC || mode == GMT_MODULE_CLASSIC_CORE || mode == GMT_MODULE_PURPOSE))
 		return_error (V_API, GMT_ARG_IS_NULL);
 	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 
 	if (module == NULL) {	/* Did not specify any specific module, so list purpose of all modules in all shared libs */
 		char gmt_module[GMT_LEN256] = {""};	/* To form name of gmt_<lib>_module_show|list_all function */
-		char *listfunc = (mode == GMT_MODULE_LIST) ? "list" : ( (mode == GMT_MODULE_CLASSIC) ? "classic" : "show");
+		char *listfunc = (mode == GMT_MODULE_LIST || mode == GMT_MODULE_LIST_CORE) ? "list" : ( (mode == GMT_MODULE_CLASSIC || mode == GMT_MODULE_CLASSIC_CORE) ? "classic" : "show");
 		void (*l_func)(void*);       /* function pointer to gmt_<lib>_module_show|list_all which takes one arg (the API) */
-
+		unsigned int n_libs = (mode == GMT_MODULE_LIST_CORE || mode == GMT_MODULE_CLASSIC_CORE) ? 1 : API->n_shared_libs;
 		/* Here we list purpose of all the available modules in each shared library */
-		for (lib = 0; lib < API->n_shared_libs; lib++) {
+		for (lib = 0; lib < n_libs; lib++) {
 			snprintf (gmt_module, GMT_LEN64, "%s_module_%s_all", API->lib[lib].name, listfunc);
 			*(void **) (&l_func) = gmtapi_get_module_func (API, gmt_module, lib);
 			if (l_func == NULL) continue;	/* Not found in this shared library */

--- a/src/gmt_enum_dict.h
+++ b/src/gmt_enum_dict.h
@@ -28,7 +28,7 @@ struct GMT_API_DICT {
 	int value;
 };
 
-#define GMT_N_API_ENUMS 246
+#define GMT_N_API_ENUMS 248
 
 static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_ADD_DEFAULT", 6},
@@ -166,19 +166,21 @@ static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_LOG_ONCE", 1},
 	{"GMT_LOG_SET", 2},
 	{"GMT_LONG", 6},
-	{"GMT_MODULE_CLASSIC", -5},
+	{"GMT_MODULE_CLASSIC", -7},
+	{"GMT_MODULE_CLASSIC_CORE", -5},
 	{"GMT_MODULE_CMD", 0},
 	{"GMT_MODULE_EXIST", -3},
 	{"GMT_MODULE_GROUP", 1},
 	{"GMT_MODULE_HELP", 0},
 	{"GMT_MODULE_KEYS", 0},
-	{"GMT_MODULE_LIST", -4},
+	{"GMT_MODULE_LIST", -6},
+	{"GMT_MODULE_LIST_CORE", -4},
 	{"GMT_MODULE_OPT", -1},
 	{"GMT_MODULE_PURPOSE", -2},
 	{"GMT_MODULE_SHOW_CLASSIC", 2},
 	{"GMT_MODULE_SHOW_MODERN", 1},
-	{"GMT_MODULE_SYNOPSIS", -6},
-	{"GMT_MODULE_USAGE", -7},
+	{"GMT_MODULE_SYNOPSIS", -8},
+	{"GMT_MODULE_USAGE", -9},
 	{"GMT_MSG_COMPAT", 6},
 	{"GMT_MSG_DEBUG", 7},
 	{"GMT_MSG_ERROR", 2},

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -176,10 +176,12 @@ enum GMT_enum_apierr {
 };
 
 enum GMT_enum_module {
-	GMT_MODULE_USAGE		= -7,	/* What GMT_Call_Module returns if told to print usage only */
-	GMT_MODULE_SYNOPSIS		= -6,	/* What GMT_Call_Module returns if told to print synopsis only */
-	GMT_MODULE_CLASSIC		= -5,	/* mode for GMT_Call_Module to print list of all classic modules */
-	GMT_MODULE_LIST			= -4,	/* mode for GMT_Call_Module to print list of all modern modules */
+	GMT_MODULE_USAGE		= -9,	/* What GMT_Call_Module returns if told to print usage only */
+	GMT_MODULE_SYNOPSIS		= -8,	/* What GMT_Call_Module returns if told to print synopsis only */
+	GMT_MODULE_CLASSIC		= -7,	/* mode for GMT_Call_Module to print list of all classic modules */
+	GMT_MODULE_LIST			= -6,	/* mode for GMT_Call_Module to print list of all modern modules */
+	GMT_MODULE_CLASSIC_CORE	= -5,	/* mode for GMT_Call_Module to print list of all classic modules (core only) */
+	GMT_MODULE_LIST_CORE	= -4,	/* mode for GMT_Call_Module to print list of all modern modules (core only) */
 	GMT_MODULE_EXIST		= -3,	/* mode for GMT_Call_Module to return 0 if it exists */
 	GMT_MODULE_PURPOSE		= -2,	/* mode for GMT_Call_Module to print purpose of module, or all modules */
 	GMT_MODULE_OPT			= -1,	/* Gave linked list of option structures to GMT_Call_Module */


### PR DESCRIPTION
This PR implements new options **--show-modules-core** and **--show-classic-core**.  Comes in handy when doing various checks on what tests we have and what is left out, plus avoid listing supplements when not needed.

