### PR TITLE
Better documentation of grid-registration switching

### DIFF
--- a/doc/rst/source/cookbook/options.rst
+++ b/doc/rst/source/cookbook/options.rst
@@ -1313,6 +1313,32 @@ Thus, given the same region (**-R**) and grid spacing, the
 pixel-registered grids have one less column and one less row than the
 gridline-registered grids; here we find nx = ny = 3.
 
+Switching registrations
+^^^^^^^^^^^^^^^^^^^^^^^
+
+GMT offer ways to convert a pixel-registered grid to a gridline-registered grid.
+One way is to simply adjust the region of the grid by half the grid-spacing and
+toggle the registration in :doc:`grdedit`.  This is a *non-destructive* way to convert the grid,
+but it does change the domain which may not be desirable depending on application.
+The other is to *resample* the grid at the other set of nodes via :doc:`grdsample`.
+This approach leaves the region exactly the same but is *destructive* due to the loss
+of the higher data frequencies, as shown in Figure :ref:`Registration resampling <Grid_grid2pix>`.
+
+.. _Grid_grid2pix:
+
+.. figure:: /_images/GMT_grid2pix.*
+   :width: 500 px
+   :align: center
+
+   a) Cross-section of a grid along the *x*-axis for a constant value of *y*, showing just the Nyquist
+   *x*-component (heavy line) at its grid nodes (red circles).  Resampling this component half-way
+   between nodes (vertical lines) will always give zero (red triangles), hence this signal is lost,
+   unlike long wavelength components (thin line), which can be interpolated (blue triangles).
+   Intermediate wavelengths will experience attenuated amplitudes as well. b) Transfer function for
+   resampling data from a pixel-registered to a gridline-registered grid format illustrates the loss
+   of amplitude that will occur.  There is also a linear change in phase from 0 to 90 degrees as a
+   function of wavenumber :math:`k_j` [Marks and Smith, 2007].
+
 .. _option_-s:
 
 NaN-record treatment: The **-s** option

--- a/doc/rst/source/cookbook/options.rst
+++ b/doc/rst/source/cookbook/options.rst
@@ -1316,11 +1316,13 @@ gridline-registered grids; here we find nx = ny = 3.
 Switching registrations
 ^^^^^^^^^^^^^^^^^^^^^^^
 
+.. _Switch_Registrations:
+
 GMT offer ways to convert a pixel-registered grid to a gridline-registered grid.
 One way is to simply adjust the region of the grid by half the grid-spacing and
-toggle the registration in :doc:`grdedit`.  This is a *non-destructive* way to convert the grid,
+toggle the registration in :doc:`/grdedit` **-T**.  This is a *non-destructive* way to convert the grid,
 but it does change the domain which may not be desirable depending on application.
-The other is to *resample* the grid at the other set of nodes via :doc:`grdsample`.
+The other is to *resample* the grid at the other set of nodes via :doc:`/grdsample` **-T**.
 This approach leaves the region exactly the same but is *destructive* due to the loss
 of the higher data frequencies, as shown in Figure :ref:`Registration resampling <Grid_grid2pix>`.
 

--- a/doc/rst/source/grdedit.rst
+++ b/doc/rst/source/grdedit.rst
@@ -133,6 +133,7 @@ Optional Arguments
     Basically, gridline-registered grids will have their domain extended
     by half the x- and y-increments whereas pixel-registered grids will
     have their domain shrunk by the same amount.
+    This is a *non-destructive* grid change; see :ref:`Switching registrations <Switch_Registrations>`.
 
 .. _-V:
 

--- a/doc/rst/source/grdsample.rst
+++ b/doc/rst/source/grdsample.rst
@@ -71,7 +71,7 @@ Optional Arguments
 **-T**
     Translate between grid and pixel registration; if the input is
     grid-registered, the output will be pixel-registered and vice-versa.
-    This is a destructive grid change; see :ref:`Registration resampling <Grid_grid2pix>`.
+    This is a *destructive* grid change; see :ref:`Switching registrations <Switch_Registrations>`.
 
 .. _-V:
 

--- a/doc/rst/source/grdsample.rst
+++ b/doc/rst/source/grdsample.rst
@@ -71,19 +71,7 @@ Optional Arguments
 **-T**
     Translate between grid and pixel registration; if the input is
     grid-registered, the output will be pixel-registered and vice-versa.
-
-.. figure:: /_images/GMT_grid2pix.*
-   :width: 500 px
-   :align: center
-
-   a) Cross-section of a grid along the *x*-axis for a constant value of *y*, showing just the Nyquist
-   *x*-component (heavy line) at its grid nodes (red circles).  Resampling this component half-way
-   between nodes (vertical lines) will always give zero (red triangles), hence this signal is lost,
-   unlike long wavelength components (thin line), which can be interpolated (blue triangles).
-   Intermediate wavelengths will experience attenuated amplitudes as well. b) Transfer function for
-   resampling data from a pixel-registered to a gridline-registered grid format illustrates the loss
-   of amplitude that will occur.  There is also a linear change in phase from 0 to 90 degrees as a
-   function of wavenumber :math:`k_j` [Marks and Smith, 2007].
+    This is a destructive grid change; see :ref:`Registration resampling <Grid_grid2pix>`.
 
 .. _-V:
 

--- a/src/grdedit.c
+++ b/src/grdedit.c
@@ -134,6 +134,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-T Toggle header from grid-line to pixel-registered grid or vice versa.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   This shrinks -R by 0.5*{dx,dy} going from pixel to grid-line registration\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   and expands  -R by 0.5*{dx,dy} going from grid-line to pixel registration.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   No grid values will be changed (a non-destructive change to the grid).\n");
 	GMT_Option (API, "V,bi3,di,e,f,h,i.:,.");
 
 	return (GMT_MODULE_USAGE);

--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -84,6 +84,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (gmt_M_showusage (API)) GMT_Message (API, GMT_TIME_NONE, "\t   When omitted: grid spacing is copied from input grid.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-R Specify a subregion [Default is old region].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-T Toggle between grid registration and pixel registration.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Obtained by resampling halfway between nodes (a destructive change to the grid).\n");
 	GMT_Option (API, "V,f,n,r,x,.");
 
 	return (GMT_MODULE_USAGE);

--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -83,7 +83,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Option (API, "I");
 	if (gmt_M_showusage (API)) GMT_Message (API, GMT_TIME_NONE, "\t   When omitted: grid spacing is copied from input grid.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-R Specify a subregion [Default is old region].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-T Toggle between grid registration and pixel registration.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-T Translate between grid registration and pixel registration.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Implies resampling halfway between nodes (a destructive change to the grid).\n");
 	GMT_Option (API, "V,f,n,r,x,.");
 

--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -84,7 +84,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (gmt_M_showusage (API)) GMT_Message (API, GMT_TIME_NONE, "\t   When omitted: grid spacing is copied from input grid.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-R Specify a subregion [Default is old region].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-T Toggle between grid registration and pixel registration.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Obtained by resampling halfway between nodes (a destructive change to the grid).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Implies resampling halfway between nodes (a destructive change to the grid).\n");
 	GMT_Option (API, "V,f,n,r,x,.");
 
 	return (GMT_MODULE_USAGE);


### PR DESCRIPTION
Move the figure from grdsample to the option -r section, and add cross-links to/from grdsample and grdedit, and explain the difference between destructive and non-destructive changes.