### PR TITLE
Set z_hinge=0 if +h is used but hinge isn't given

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -1217,6 +1217,7 @@ GMT_LOCAL struct CPT_Z_SCALE *gmtsupport_cpt_parse (struct GMT_CTRL *GMT, char *
 			}
 		}
 		else {	/* Accept zero as hard hinge value */
+			*z_hinge = 0.0;
 			*hinge_mode = 1;
 			c[0] = '\0';	/* Chop off the hinge specification from the file name */
 			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "gmtsupport_cpt_parse: CPT CPT hard hinge was added at z = 0 for file %s\n", file);
@@ -7945,7 +7946,7 @@ char * gmt_cpt_default (struct GMTAPI_CTRL *API, char *cpt, char *file) {
 		if (file[LOX] == 'L') return strdup (srtm_cpt);
 	}
 	if (API->remote_info[k_data].CPT[0] == '-') return (NULL);
-	
+
 	return (strdup (API->remote_info[k_data].CPT));
 }
 


### PR DESCRIPTION
The tests hardsoft.sh and cpthinges.sh fail occasionally, because the
z_hinge is uninitialized if only **+h** is used.


**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.