### PR TITLE
Add a CI job to compile GMT without optional dependencies

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -54,6 +54,25 @@ jobs:
   steps:
   - template: ci/azure-pipelines-linux.yml
 
+# Linux - Compile only (no GDAL et. al.)
+########################################################################################
+- job:
+  displayName: 'Linux | Compile only (GDAL et. al. excluded)'
+  condition: ne(variables['Build.Reason'], 'Schedule')
+
+  pool:
+    vmImage: 'ubuntu-18.04'
+
+  variables:
+    BUILD_DOCS: false
+    DEPLOY_DOCS: false
+    PACKAGE: false
+    RUN_TESTS: false
+    EXCLUDE_OPTIONAL: true
+
+  steps:
+  - template: ci/azure-pipelines-linux.yml
+
 # Linux - Build docs + Deploy docs + Package
 ########################################################################################
 - job:

--- a/ci/install-dependencies-linux.sh
+++ b/ci/install-dependencies-linux.sh
@@ -12,11 +12,16 @@ set -x -e
 # set defaults to false
 BUILD_DOCS="${BUILD_DOCS:-false}"
 RUN_TESTS="${RUN_TESTS:-false}"
+EXCLUDE_OPTIONAL=${EXCLUDE_OPTIONAL:-false}
 
-# packages for compiling GMT
+# required packages for compiling GMT
 packages="build-essential cmake ninja-build libcurl4-gnutls-dev libnetcdf-dev \
-          libgdal-dev libfftw3-dev libpcre3-dev liblapack-dev libglib2.0-dev \
           ghostscript curl git"
+#
+if [ "$EXCLUDE_OPTIONAL" = "false" ]; then
+	packages+=" libgdal-dev libfftw3-dev libpcre3-dev liblapack-dev libglib2.0-dev"
+fi
+
 # packages for building documentations
 if [ "$BUILD_DOCS" = "true" ]; then
     packages+=" python3-pip python3-setuptools python3-wheel graphicsmagick ffmpeg"


### PR DESCRIPTION
Sometimes we may write codes which depend on the optional
packages like GDAL, but forget to enclose the codes with HAVE_GDAL
macros. This causes compilation errors for users who don't have these
optional dependencies installed.

This PR add one more CI job on Linux, in which only required packages
(CURL and netCDF) are installed. If the CI job fails, then we know that 
GMT doesn't work without the optional dependencies.