### PR TITLE
Let GMT_ENABLE_KNOWN2FAIL to disable the GMT_KNOWN_FAILURE comment

### DIFF
--- a/cmake/ConfigUserAdvancedTemplate.cmake
+++ b/cmake/ConfigUserAdvancedTemplate.cmake
@@ -189,6 +189,10 @@
 # Number of parallel test jobs with "make check":
 #set (N_TEST_JOBS 4)
 
+# Ignore the "GMT_KNOWN_FAILURE" comment in tests to let tests fail normally
+# Can only be "ON" or "OFF" in uppercase!
+#set (GMT_ENABLE_KNOWN2FAIL OFF)
+
 # Enable this option to run GMT programs from within ${GMT_BINARY_DIR} without
 # installing or setting GMT_SHAREDIR and GMT_USERDIR first. This is required
 # for testing [OFF]:

--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -221,6 +221,12 @@ if (DO_EXAMPLES OR DO_TESTS AND NOT SUPPORT_EXEC_IN_BINARY_DIR)
 	set (SUPPORT_EXEC_IN_BINARY_DIR ON)
 endif (DO_EXAMPLES OR DO_TESTS AND NOT SUPPORT_EXEC_IN_BINARY_DIR)
 
+# Some tests are known to fail, and can be excluded from the test by adding
+# the comment "# GMT_KNOWN_FAILURE".
+if (NOT DEFINED GMT_ENABLE_KNOWN2FAIL)
+	set (GMT_ENABLE_KNOWN2FAIL ON)
+endif (NOT DEFINED GMT_ENABLE_KNOWN2FAIL)
+
 # Make GNU, Intel, Clang and AppleClang compilers default to C99
 if (CMAKE_C_COMPILER_ID MATCHES "(GNU|Intel|Clang)" AND NOT CMAKE_C_FLAGS MATCHES "-std=")
 	set (CMAKE_C_FLAGS "-std=gnu99 ${CMAKE_C_FLAGS}")

--- a/doc/examples/gmtest.in
+++ b/doc/examples/gmtest.in
@@ -14,8 +14,13 @@ script="@GMT_SOURCE_DIR@/doc/examples/${script_name}"
 src="@GMT_SOURCE_DIR@/doc/examples/${script_dir}"
 # Is it a modern mode script?
 modern=$(grep "gmt begin" "$script" -c)
+
 # Is it a script that is known to fail?
-known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
+if [ "@GMT_ENABLE_KNOWN2FAIL@" = "ON" ]; then
+	known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
+else
+	known2fail=0
+fi
 # Any script override of GRAPHICSMAGICK_RMS?  Must be a comment line of the format
 # GRAPHICSMAGICK_RMS = <custom-limit>
 GRAPHICSMAGICK_RMS=$(grep "GRAPHICSMAGICK_RMS" "$script" | awk '{print $4}')

--- a/doc/scripts/gmtest.in
+++ b/doc/scripts/gmtest.in
@@ -12,8 +12,13 @@ local_script=$(basename "${script_name}")
 src="@GMT_SOURCE_DIR@/doc/scripts"
 # Is it a modern mode script?
 modern=$(grep "gmt begin" "$script" -c)
+
 # Is it a script that is known to fail?
-known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
+if [ "@GMT_ENABLE_KNOWN2FAIL@" = "ON" ]; then
+	known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
+else
+	known2fail=0
+fi
 # Any script override of GRAPHICSMAGICK_RMS?  Must be a comment line of the format
 # GRAPHICSMAGICK_RMS = <custom-limit>
 GRAPHICSMAGICK_RMS=$(grep "GRAPHICSMAGICK_RMS" "$script" | awk '{print $4}')

--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -16,8 +16,13 @@ script="@GMT_SOURCE_DIR@/test/${script_name}"
 src="@GMT_SOURCE_DIR@/test/${script_dir}"
 # Is it a modern mode script?
 modern=$(grep "gmt begin" "$script" -c)
+
 # Is it a script that is known to fail?
-known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
+if [ "@GMT_ENABLE_KNOWN2FAIL@" = "ON" ]; then
+	known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
+else
+	known2fail=0
+fi
 # Any script override of GRAPHICSMAGICK_RMS?  Must be a comment line of the format
 # GRAPHICSMAGICK_RMS = <custom-limit>
 GRAPHICSMAGICK_RMS=$(grep "GRAPHICSMAGICK_RMS" "$script" | awk '{print $4}')


### PR DESCRIPTION
Set GMT_ENABLE_KNOWN2FAIL to `OFF` to disable the "GMT_KNOWN_FAILURE" comment.