### PR TITLE
Add option to specify the debug pen in helping with contour crossing lines

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -402,7 +402,8 @@
 
             **+d**
                 Turns on debug which will draw helper points and lines to illustrate
-                the workings of the quoted line setup.
+                the workings of the quoted line setup. Optionally append the pen
+                to use [:term:`MAP_DEFAULT_PEN`].
 
             **+e**
                 Delay the plotting of the text. This is used to build a clip path
@@ -579,7 +580,8 @@
 
             **+d**
                 Turns on debug which will draw helper points and lines to illustrate
-                the workings of the decorated line setup.
+                the workings of the decorated line setup. Optionally append the pen
+                to use [:term:`MAP_DEFAULT_PEN`].
 
             **+g**\ [*fill*]
                 Sets the symbol fill [no fill].

--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -400,7 +400,7 @@
                 **c**\|\ **i**\|\ **p** to specify the unit or % to indicate a
                 percentage of the label font size [15%].
 
-            **+d**
+            **+d**\ [*pen*]
                 Turns on debug which will draw helper points and lines to illustrate
                 the workings of the quoted line setup. Optionally append the pen
                 to use [:term:`MAP_DEFAULT_PEN`].
@@ -578,7 +578,7 @@
                 For symbols at a fixed angle, **+an** for line-normal, or
                 **+ap** for line-parallel [Default].
 
-            **+d**
+            **+d**\ [*pen*]
                 Turns on debug which will draw helper points and lines to illustrate
                 the workings of the decorated line setup. Optionally append the pen
                 to use [:term:`MAP_DEFAULT_PEN`].

--- a/doc/rst/source/explain_symbols2.rst_
+++ b/doc/rst/source/explain_symbols2.rst_
@@ -478,7 +478,7 @@
                 For symbols at a fixed angle, **+an** for line-normal, or
                 **+ap** for line-parallel [Default].
 
-            **+d**
+            **+d**\ [*pen*]
                 Turns on debug which will draw helper points and lines to illustrate
                 the workings of the decorated line setup. Optionally append the pen
                 to use [:term:`MAP_DEFAULT_PEN`].

--- a/doc/rst/source/explain_symbols2.rst_
+++ b/doc/rst/source/explain_symbols2.rst_
@@ -244,9 +244,10 @@
                 **c**\|\ **i**\|\ **p** to specify the unit or % to indicate a
                 percentage of the label font size [15%].
 
-            **+d**
+            **+d**\ [*pen*]
                 Turns on debug which will draw helper points and lines to illustrate
-                the workings of the quoted line setup.
+                the workings of the quoted line setup.  Optionally append the pen
+                to use [:term:`MAP_DEFAULT_PEN`].
 
             **+e**
                 Delay the plotting of the text. This is used to build a clip path
@@ -479,7 +480,8 @@
 
             **+d**
                 Turns on debug which will draw helper points and lines to illustrate
-                the workings of the decorated line setup.
+                the workings of the decorated line setup. Optionally append the pen
+                to use [:term:`MAP_DEFAULT_PEN`].
 
             **+g**\ [*fill*]
                 Sets the symbol fill [no fill].

--- a/src/gmt_contour.h
+++ b/src/gmt_contour.h
@@ -160,6 +160,7 @@ struct GMT_CONTOUR {
 	struct GMT_XOVER XC;		/* Structure with resulting crossovers */
 	struct GMT_PEN pen;		/* Pen for drawing textbox outline */
 	struct GMT_PEN line_pen;	/* Pen for drawing the contour line */
+	struct GMT_PEN debug_pen;	/* Pen for drawing the debugging lines */
 	struct GMT_LABEL **L;		/* Pointers to sorted list of labels */
 	struct GMT_DATASET *Out;	/* Textset with positions, angles and labels used in contouring */
 	/* Contour line section */

--- a/src/gmt_decorate.h
+++ b/src/gmt_decorate.h
@@ -70,6 +70,7 @@ struct GMT_DECORATE {
 	char size[GMT_LEN64];		/* The symbol size */
 	char fill[GMT_LEN64];		/* The symbol fill */
 	char pen[GMT_LEN64];		/* The symbol outline pen */
+	struct GMT_PEN debug_pen;	/* Pen for drawing the debugging lines */
 	char symbol_code[GMT_LEN64];	/* The symbol code only as a null-terminated string */
 	char flag;			/* Char for the option key */
 	struct GMT_DATASET *X;		/* Dataset with list of structures with crossing-line coordinates */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7207,7 +7207,7 @@ void gmt_label_syntax (struct GMT_CTRL *GMT, unsigned int indent, unsigned int k
 		gmt_message (GMT, "%s   and d for down-hill cartographic annotations.\n", pad);
 	}
 	if (kind < 2) gmt_message (GMT, "%s +c<dx>[/<dy>] sets clearance between label and text box [15%%].\n", pad);
-	gmt_message (GMT, "%s +d turns on debug which draws helper points and lines.\n", pad);
+	gmt_message (GMT, "%s +d turns on debug which draws helper points and lines; optionally add a pen [%s]\n", pad, gmt_putpen (GMT, &GMT->current.setting.map_default_pen));
 	if (kind < 2) gmt_message (GMT, "%s +e delays the plotting of the text as text clipping is set instead.\n", pad);
 	if (kind < 2) gmt_message (GMT, "%s +f sets specified label font [Default is %s].\n", pad, gmt_putfont (GMT, &GMT->current.setting.font_annot[GMT_PRIMARY]));
 	if (kind < 2)

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -3281,7 +3281,7 @@ GMT_LOCAL void gmtplot_contlabel_debug (struct GMT_CTRL *GMT, struct PSL_CTRL *P
 
 	/* If called we simply draw the helper lines or points to assist in debug */
 
-	gmt_setpen (GMT, &GMT->current.setting.map_default_pen);
+	gmt_setpen (GMT, &G->debug_pen);
 	if (G->fixed) {	/* Place a small open circle at each fixed point */
 		PSL_setfill (PSL, GMT->session.no_rgb, PSL_OUTLINE);
 		for (row = 0; row < (uint64_t)G->f_n; row++)

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -9333,6 +9333,7 @@ void gmt_contlabel_init (struct GMT_CTRL *GMT, struct GMT_CONTOUR *G, unsigned i
 	G->font_label.set = 0;
 	G->dist_unit = GMT->current.setting.proj_length_unit;
 	G->pen = GMT->current.setting.map_default_pen;
+	G->debug_pen = GMT->current.setting.map_default_pen;
 	G->line_pen = GMT->current.setting.map_default_pen;
 	gmt_M_rgb_copy (G->rgb, GMT->current.setting.ps_page_rgb);		/* Default box color is page color [nominally white] */
 }
@@ -9547,7 +9548,7 @@ int gmt_contlabel_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_CONTOUR *G)
 	char p[GMT_BUFSIZ] = {""}, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, c;
 	char *specs = NULL;
 
-	/* Decode [+a<angle>|n|p[u|d]][+c<dx>[/<dy>]][+d][+e][+f<font>][+g<fill>][+i][+j<just>][+l<label>][+n|N<dx>[/<dy>]][+o][+p[<pen>]][+r<min_rc>][+t[<file>]][+u<unit>][+v][+w<width>][+x|X<suffix>][+=<prefix>] strings */
+	/* Decode [+a<angle>|n|p[u|d]][+c<dx>[/<dy>]][+d[<pen>]][+e][+f<font>][+g<fill>][+i][+j<just>][+l<label>][+n|N<dx>[/<dy>]][+o][+p[<pen>]][+r<min_rc>][+t[<file>]][+u<unit>][+v][+w<width>][+x|X<suffix>][+=<prefix>] strings */
 
 	/* txt is pointing to the very first modifier */
 
@@ -9597,6 +9598,7 @@ int gmt_contlabel_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_CONTOUR *G)
 
 			case 'd':	/* Debug option - draw helper points or lines */
 				G->debug = true;
+				if (p[1] && gmt_getpen (GMT, &p[1], &G->debug_pen)) bad++;
 				break;
 
 			case 'e':	/* Just lay down text info; Delay actual label plotting until a psclip -C call */
@@ -9885,7 +9887,7 @@ int gmtlib_decorate_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_DECORATE 
 	char p[GMT_BUFSIZ] = {""}, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""};
 	char *specs = NULL;
 
-	/* Decode [+a<angle>|n|p[u|d]][+d][+g<fill>][+i][+n|N<dx>[/<dy>]][+p[<pen>]]+s<symbolinfo>[+w<width>] strings */
+	/* Decode [+a<angle>|n|p[u|d]][+d[<pen>]][+g<fill>][+i][+n|N<dx>[/<dy>]][+p[<pen>]]+s<symbolinfo>[+w<width>] strings */
 
 	for (k = 0; txt[k] && txt[k] != '+'; k++);	/* Look for +<options> strings */
 
@@ -9913,6 +9915,7 @@ int gmtlib_decorate_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_DECORATE 
 
 			case 'd':	/* Debug option - draw helper points or lines */
 				G->debug = true;
+				if (p[1] && gmt_getpen (GMT, &p[1], &G->debug_pen)) bad++;
 				break;
 
 			case 'g':	/* Symbol Fill specification */
@@ -13175,6 +13178,7 @@ int gmt_getpanel (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_
 	gmt_init_fill (GMT, &P->sfill, gmt_M_is255 (127), gmt_M_is255 (127), gmt_M_is255 (127));	/* Default if gray shade is used */
 	P->pen1 = GMT->current.setting.map_frame_pen;			/* Heavier pen for main outline */
 	P->pen2 = GMT->current.setting.map_default_pen;			/* Thinner pen for optional inner outline */
+	P->debug_pen = GMT->current.setting.map_default_pen;			/* Thinner pen for optional inner outline */
 	P->gap = GMT->session.u2u[GMT_PT][GMT_INCH] * GMT_FRAME_GAP;	/* Default is 2p */
 	/* Initialize the panel clearances */
 	P->padding[XLO] = GMT->session.u2u[GMT_PT][GMT_INCH] * GMT_FRAME_CLEARANCE;	/* Default is 4p */
@@ -13208,6 +13212,7 @@ int gmt_getpanel (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_
 				break;
 			case 'd':	/* debug mode for developers */
 				P->debug = true;
+				if (p[1] && gmt_getpen (GMT, &p[1], &P->debug_pen)) n_errors++;
 				break;
 			case 'g':	/* Set fill */
 				if (!p[1] || gmt_getfill (GMT, &p[1], &P->fill)) n_errors++;

--- a/src/gmt_symbol.h
+++ b/src/gmt_symbol.h
@@ -113,6 +113,7 @@ struct GMT_MAP_PANEL {
 	double off[2];			/* Offset for background shaded rectangle (+s) */
 	double gap;			/* Space between main and secondary frame */
 	struct GMT_PEN pen1, pen2;	/* Pen for main and secondary frame outline */
+	struct GMT_PEN debug_pen;	/* Pen for debug lines */
 	struct GMT_FILL fill;		/* Frame fill */
 	struct GMT_FILL sfill;		/* Background shade */
 	bool clearance;			/* Used by pslegend since it has the -C option as well */

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -284,13 +284,39 @@ GMT_LOCAL void psxy_plot_y_whiskerbar (struct GMT_CTRL *GMT, struct PSL_CTRL *PS
 	}
 }
 
-GMT_LOCAL int psxy_plot_decorations (struct GMT_CTRL *GMT, struct GMT_DATASET *D, char *symbol_code, bool decorate_custom) {
+GMT_LOCAL void psxy_decorate_debug (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, struct GMT_DECORATE *G) {
+	uint64_t row;
+	double size[1] = {0.05};
+
+	/* If called we simply draw the helper lines or points to assist in debug */
+
+	gmt_setpen (GMT, &G->debug_pen);
+	if (G->fixed) {	/* Place a small open circle at each fixed point */
+		PSL_setfill (PSL, GMT->session.no_rgb, PSL_OUTLINE);
+		for (row = 0; row < (uint64_t)G->f_n; row++)
+			PSL_plotsymbol (PSL, G->f_xy[0][row], G->f_xy[1][row], size, PSL_CIRCLE);
+	}
+	else if (G->crossing) {	/* Draw a thin line */
+		uint64_t seg;
+		unsigned int *pen = NULL;
+		struct GMT_DATASEGMENT *S = NULL;
+		for (seg = 0; seg < G->X->n_segments; seg++) {
+			S = G->X->table[0]->segment[seg];	/* Current segment */
+			pen = gmt_M_memory (GMT, NULL, S->n_rows, unsigned int);
+			for (row = 1, pen[0] = PSL_MOVE; row < S->n_rows; row++) pen[row] = PSL_DRAW;
+			gmt_plot_line (GMT, S->data[GMT_X], S->data[GMT_Y], pen, S->n_rows, PSL_LINEAR);
+			gmt_M_free (GMT, pen);
+		}
+	}
+}
+
+GMT_LOCAL int psxy_plot_decorations (struct GMT_CTRL *GMT, struct GMT_DATASET *D, struct GMT_DECORATE *G, bool decorate_custom) {
 	/* Accept the dataset D with records of {x, y, size, angle, symbol} and plot rotated symbols at those locations.
 	 * Note: The x,y are projected coordinates in inches, hence our -R -J choice below. */
 	unsigned int type = 0, pos = 0;
 	size_t len;
 	char string[GMT_VF_LEN] = {""}, buffer[GMT_BUFSIZ] = {""}, tmp_file[PATH_MAX] = {""}, kode[2] = {'K', 'k'};
-	char name[GMT_BUFSIZ] = {""}, path[PATH_MAX] = {""};
+	char name[GMT_BUFSIZ] = {""}, path[PATH_MAX] = {""}, *symbol_code = G->symbol_code;
 	FILE *fp = NULL;
 	gmt_set_dataset_minmax (GMT, D);	/* Determine min/max for each column and add up total records */
 	if (D->n_records == 0)	/* No symbols to plot */
@@ -306,6 +332,9 @@ GMT_LOCAL int psxy_plot_decorations (struct GMT_CTRL *GMT, struct GMT_DATASET *D
 			return (GMT_RUNTIME_ERROR);
 		}
 	}
+
+	if (G->debug) psxy_decorate_debug (GMT, GMT->PSL, G);		/* Debugging lines and points */
+
 	if (GMT->parent->tmp_dir)	/* Make unique file in temp dir */
 		sprintf (tmp_file, "%s/GMT_symbol%d.def", GMT->parent->tmp_dir, (int)getpid());
 	else	/* Make unique file in current dir */
@@ -2286,7 +2315,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 	gmt_plane_perspective (GMT, -1, 0.0);
 
 	if (S.symbol == GMT_SYMBOL_DECORATED_LINE) {	/* Plot those line decorating symbols via call to psxy */
-		if ((error = psxy_plot_decorations (GMT, Decorate, S.D.symbol_code, decorate_custom)) != 0)	/* Cannot possibly be a good thing */
+		if ((error = psxy_plot_decorations (GMT, Decorate, &S.D, decorate_custom)) != 0)	/* Cannot possibly be a good thing */
 			Return (error);
 		if (GMT_Destroy_Data (API, &Decorate) != GMT_NOERROR) {	/* Might as well delete since no good later */
 			Return (API->error);

--- a/test/grdcontour/periodic.sh
+++ b/test/grdcontour/periodic.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 # GMT_KNOWN_FAILURE
-# Demonstrate issue #536 with labeling of periodic contours
-# Turns out non-issue due to different contour lengths and -Gd
-# Using -Gl shows annotation machinery works fine.
+# Update 2020/08/11 PW: Currently, the problem with this script is this:
+# When plotting with -Zp, the top plot is mostly OK but the labels for 140 and 160
+# degrees have contours cutting right through them.  The bottom plot without -Zp
+# plots as expected.  I added the debug drawing of the helper lines in red, which
+# required the C-code changes to allow a debug pen.
 ps=periodic.ps
 gmt grdmath -Rg -I1 32 22 SBAZ = t.nc
 # Plot as non-periodic.  This plots labels.  The pile of blue contours around
 # 180 occurs because the grid goes rapidly from -180 to +180 here and -Z+p is not used
 # This is expected and correct.
-gmt grdcontour t.nc -JG0/0/5.0i -A20+u@. -Bgaf -K -Wa1,blue -Gl-90/0/0/0,0/0/90/0 -P -Xc -Y0.3i > $ps
+gmt grdcontour t.nc -JG0/0/5.0i -A20+u@.+d0.75p,red -Bgaf -K -Wa1,blue -Gl-90/0/0/0,0/0/90/0 -P -Xc -Y0.3i > $ps
 # Plot as periodic with -Zp.  Transition from -180 to +180 goes well for contouring
-# but we have no contour labels anymore. This is the main issue here.
-gmt grdcontour t.nc -J -A20+u@. -Wa1,blue -Bgaf -Gl-90/0/0/0,0/0/90/0 -Z+p -O -Y5.2i >> $ps
+# but lon 140, 160 has labels overdrawn by contour. This is the main issue here.
+gmt grdcontour t.nc -J -A20+u@.+d0.75p,red -Wa1,blue -Bgaf -Gl-90/0/0/0,0/0/90/0 -Z+p -O -Y5.2i >> $ps


### PR DESCRIPTION
The **+d** for debug crossing lines for contours and decorated lines can now take an optional pen argument.  This was needed because in the periodic.sh test I could not tell the helper line from a gridline since they used similar pens.

The periodic.sh test script still has issues but I updated the comments.

Not sure if it is worth backporting @seisman so I did not label it.  Won't be fixed before 6.2 anyway.