### PR TITLE
Fix the description of -Rcode syntax

### DIFF
--- a/doc/rst/source/cookbook/options.rst
+++ b/doc/rst/source/cookbook/options.rst
@@ -94,7 +94,7 @@ may be specified in one of five ways, two of which are shown in Figure
    possibly the grid registration (see
    Section `Grid registration: The -r option`_).
 
-#. **-R**\ *code1,code2,...*\ [**+r**\|\ **R**\ [*incs*]]. This indirectly supplies
+#. **-R**\ *code1,code2,...*\ [**+e**\|\ **r**\|\ **R**\ [*incs*]]. This indirectly supplies
    the region by consulting the DCW (Digital Chart of the World) database and derives
    the bounding regions for one or more countries given by the codes.
    Simply append one or more comma-separated countries using the two-character
@@ -106,7 +106,8 @@ may be specified in one of five ways, two of which are shown in Figure
    the polygon(s): Append *inc*, *xinc*/*yinc*, or *winc*/*einc*/*sinc*/*ninc* to adjust the
    final region boundaries to be multiples of these steps [default is no adjustment].
    Alternatively, use **+R** to extend the region outward by adding these increments
-   instead [default is no extension].  As an example, **-R**\ *FR*\ **+r**\ 1 will select
+   instead, or **+e** which is like **+r** but it ensures that the bounding box extends
+   by at least 0.25 times the increment [no extension]. As an example, **-R**\ *FR*\ **+r**\ 1 will select
    the national bounding box of France rounded to nearest integer degree.
 
 #. **-R**\ *code*\ *x0*/*y0*/*nx*/*ny*.  This method can be used when creating

--- a/doc/rst/source/explain_-R_full.rst_
+++ b/doc/rst/source/explain_-R_full.rst_
@@ -10,7 +10,7 @@
     two shorthands **-Rg** and **-Rd** stand for global domain (0/360
     and -180/+180 in longitude respectively, with -90/+90 in latitude).
     Set geographic regions by specifying ISO country codes from the Digital Chart of the World using
-    **-R**\ *code1,code2,...*\ [**+r**\|\ **R**\ [*incs*]] instead:
+    **-R**\ *code1,code2,...*\ [**+e**\|\ **r**\|\ **R**\ [*incs*]] instead:
     Append one or more comma-separated countries using the 2-character
     ISO 3166-1 alpha-2 convention.  To select a state of a country
     (if available), append .state, e.g, US.TX for Texas.  To specify a


### PR DESCRIPTION
The syntax `-R<code>+e<incs>` is missing.