### PR TITLE
Simplify anim07

### DIFF
--- a/doc/examples/anim07/anim07.sh
+++ b/doc/examples/anim07/anim07.sh
@@ -5,7 +5,7 @@
 # by position relative to an artificial sun in the east.  A progress slice is added as well.
 # We add a 1 second fade in and a 1 second fade out for the animation
 # DEM:   @earth_relief_02m
-# Ages:   @earth_age_02m.grd
+# Ages:  @earth_age_02m
 # The resulting movie was presented at the Fall 2019 AGU meeting in an eLighting talk:
 # P. Wessel, 2019, GMT science animations for the masses, Abstract IN21B-11.
 # The finished movie is available in our YouTube channel as well (without fading):
@@ -19,8 +19,13 @@ gmt begin
 	gmt math -T-12/372/0.5 -I T 5 SUB = longitudes.txt
 	# Extract a topography CPT
 	gmt makecpt -Cdem2 -T0/6000 -H > z.cpt
+	# Extract a Age CPT
+	gmt makecpt -C@age_chrons_GTS2012_2020.cpt -H > t.cpt
+	# Get single local global grids for DEM and crustal ages
+	gmt grdcut -Rg @earth_relief_02m -GDEM2m.grd
+	gmt grdcut -Rg @earth_age_02m -GAGE2m.grd
 	# Get gradients of the relief from N45E
-	gmt grdgradient @earth_relief_02m -Nt1.2 -A45 -Gintens.grd
+	gmt grdgradient DEM2m.grd -Nt1.2 -A45 -Gintens.grd
 gmt end
 EOF
 # 2. Set up main script
@@ -31,14 +36,14 @@ gmt begin
 	# Fake simulation of sun illumination from east added to relief intensities
 	gmt grdmath intens.grd X \${MOVIE_COL1} SUB SIND 0.8 MUL ADD 0.2 SUB = s.nc
 	# Plot age grid first using EarthByte age cpt
-	gmt grdimage @earth_age_02m.grd+s0.01 -Is.nc -C@crustal_age.cpt -JG\${MOVIE_COL0}/15/10.8c -X0 -Y0
+	gmt grdimage AGE2m.grd -Is.nc -JG\${MOVIE_COL0}/15/10.8c -Ct.cpt -X0 -Y0
 	# Clip to expose land areas only
 	gmt coast -G -Di
 	# Overlay relief over land only using dem cpt
-	gmt grdimage @earth_relief_02m -Is.nc -Cz.cpt
+	gmt grdimage DEM2m.grd -Is.nc -Cz.cpt
 	# Undo clipping and overlay gridlines
 	gmt coast -Q -B30g30
-gmt end
+gmt end show
 EOF
 # 3. Run the movie, requesting a fade in/out via white
 gmt movie main.sh -Sbpre.sh -C10.8cx10.8cx100 -Tlongitudes.txt -Nanim07 -Lf -K+gwhite -H8 -Pa+w1c+Gwhite -Fmp4 -V -W -Zs

--- a/doc/examples/anim07/anim07.sh
+++ b/doc/examples/anim07/anim07.sh
@@ -4,13 +4,14 @@
 # and topographic relief on land, with shading given by the global relief and modified
 # by position relative to an artificial sun in the east.  A progress slice is added as well.
 # We add a 1 second fade in and a 1 second fade out for the animation
-# DEM:   @earth_relief_02m
-# Ages:  @earth_age_02m
-# The resulting movie was presented at the Fall 2019 AGU meeting in an eLighting talk:
+# DEM:   @earth_relief_06m
+# Ages:  @earth_age_06m
+# A similar movie was presented at the Fall 2019 AGU meeting in an eLighting talk:
 # P. Wessel, 2019, GMT science animations for the masses, Abstract IN21B-11.
 # The finished movie is available in our YouTube channel as well (without fading):
 # https://youtu.be/KfBwQlyjz5w
-# The movie took ~2.5 hours to render on a 24-core MacPro 2013.
+# The movie takes about ~20 minutes to render on a 24-core MacPro 2013.
+# A higher resolution movie requires the higher-resolution data sets.
 
 # 1. Create background plot and data files needed in the loop
 cat << EOF > pre.sh
@@ -19,13 +20,8 @@ gmt begin
 	gmt math -T-12/372/0.5 -I T 5 SUB = longitudes.txt
 	# Extract a topography CPT
 	gmt makecpt -Cdem2 -T0/6000 -H > z.cpt
-	# Extract a Age CPT
-	gmt makecpt -C@age_chrons_GTS2012_2020.cpt -H > t.cpt
-	# Get single local global grids for DEM and crustal ages
-	gmt grdcut -Rg @earth_relief_02m -GDEM2m.grd
-	gmt grdcut -Rg @earth_age_02m -GAGE2m.grd
 	# Get gradients of the relief from N45E
-	gmt grdgradient DEM2m.grd -Nt1.2 -A45 -Gintens.grd
+	gmt grdgradient @earth_relief_06m -Nt1.2 -A45 -Gintens.grd
 gmt end
 EOF
 # 2. Set up main script
@@ -36,11 +32,11 @@ gmt begin
 	# Fake simulation of sun illumination from east added to relief intensities
 	gmt grdmath intens.grd X \${MOVIE_COL1} SUB SIND 0.8 MUL ADD 0.2 SUB = s.nc
 	# Plot age grid first using EarthByte age cpt
-	gmt grdimage AGE2m.grd -Is.nc -JG\${MOVIE_COL0}/15/10.8c -Ct.cpt -X0 -Y0
+	gmt grdimage @earth_age_06m -Is.nc -JG\${MOVIE_COL0}/15/10.8c -X0 -Y0
 	# Clip to expose land areas only
 	gmt coast -G -Di
 	# Overlay relief over land only using dem cpt
-	gmt grdimage DEM2m.grd -Is.nc -Cz.cpt
+	gmt grdimage @earth_relief_06m -Is.nc -Cz.cpt
 	# Undo clipping and overlay gridlines
 	gmt coast -Q -B30g30
 gmt end show

--- a/doc/examples/anim07/anim07.sh
+++ b/doc/examples/anim07/anim07.sh
@@ -11,7 +11,7 @@
 # The finished movie is available in our YouTube channel as well (without fading):
 # https://youtu.be/KfBwQlyjz5w
 # The movie takes about ~20 minutes to render on a 24-core MacPro 2013.
-# A higher resolution movie requires the higher-resolution data sets.
+# The higher resolution movie on YouTube used the 02m data set resolution.
 
 # 1. Create background plot and data files needed in the loop
 cat << EOF > pre.sh


### PR DESCRIPTION
**Description of proposed changes**

I have dropped the data used from 2m to 6m for two reasons:

1. This drops the rendering time (on my Mac) from ~3 hours to 20 minutes
2. It avoids grdblending the tiled data again and again (for now).

The resulting movie is not as crisp as the 2m version but it is pretty good and a reasonable compromise for now.