### PR TITLE
Just ensure grdinfo of remote grid reports it as geographic

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -1555,7 +1555,7 @@ struct GMT_GRID *gmtlib_assemble_tiles (struct GMTAPI_CTRL *API, double *region,
 
 	GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, grid);
 	/* Pass -N0 so that missing tiles (oceans) yield z = 0 and not NaN, and -Co+n to override using negative earth_relief_15s values */
-	snprintf (cmd, GMT_LEN256, "%s -R%.16g/%.16g/%.16g/%.16g -I%s -r%c -G%s -Co+n", file, wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI], API->remote_info[k_data].inc, API->remote_info[k_data].reg, grid);
+	snprintf (cmd, GMT_LEN256, "%s -R%.16g/%.16g/%.16g/%.16g -I%s -r%c -G%s -fg -Co+n", file, wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI], API->remote_info[k_data].inc, API->remote_info[k_data].reg, grid);
 	if (code != 'X') strcat (cmd, " -N0");	/* If ocean/land, set empty nodes to 0, else NaN */
 	if (GMT_Call_Module (API, "grdblend", GMT_MODULE_CMD, cmd) != GMT_NOERROR) {
 		GMT_Report (API, GMT_MSG_ERROR, "ERROR - Unable to produce blended grid from %s\n", file);

--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -474,7 +474,7 @@ GMT_LOCAL void grdinfo_smart_increments (struct GMT_CTRL *GMT, double inc[], uns
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
 EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
-	int error = 0;
+	int error = 0, k_data;
 	unsigned int n_grds = 0, n_cols = 0, col, i_status, gtype, cmode = GMT_COL_FIX, geometry = GMT_IS_TEXT;
 	bool subset, delay, num_report;
 
@@ -576,6 +576,8 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 		if (opt->option != '<') continue;	/* We are only processing filenames here */
 
 		gmt_set_cartesian (GMT, GMT_IN);	/* Reset since we may get a bunch of files, some geo, some not */
+		if ((k_data = gmt_remote_dataset_id (API, opt->arg)) != GMT_NOTSET || (k_data = gmt_get_tile_id (API, opt->arg)) != GMT_NOTSET)
+			gmt_set_geographic (GMT, GMT_IN);	/* Since this will be returned as a memory grid */
 
 		if ((G = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, opt->arg, NULL)) == NULL) {
 			Return (API->error);


### PR DESCRIPTION
Since no file is read but returned in memory from **grdblend**, there was no check set.  Closes #3960.