### PR TITLE
Fix a typo in coast documentation

### DIFF
--- a/doc/rst/source/coast_common.rst_
+++ b/doc/rst/source/coast_common.rst_
@@ -80,7 +80,7 @@ Optional Arguments
     NA (North America), or SA (South America).  Append **+l** to
     just list the countries and their codes [no data extraction or plotting takes place].
     Use **+L** to see states/territories for Argentina, Australia, Brazil, Canada, China, India, Russia and the US.
-    Finally, you can append **+l**\|\ **+L** to **-E**\ =*continent* to only list countries in that continent;
+    Finally, you can append **+l**\|\ **+L** to **-E**\ =\ *continent* to only list countries in that continent;
     repeat if more than one continent is requested.
     Append **+p**\ *pen* to draw polygon outlines [no outline] and
     **+g**\ *fill* to fill them [no fill].  One of **+p**\|\ **g** must be


### PR DESCRIPTION
Old documentation:

![image](https://user-images.githubusercontent.com/3974108/90545344-81d6da80-e156-11ea-988a-a9868db8a658.png)
