### PR TITLE
Simplify Curl operations

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -75,7 +75,7 @@ char *file_to_delete_if_ctrl_C;
 
 struct LOCFILE_FP {
 	char *file;	/* Pointer to file name */
-	FILE *fp;	/* Open file p[pointer */
+	FILE *fp;	/* Open file pointer */
 };
 
 GMT_LOCAL void gmtremote_delete_file_then_exit (int sig_no) {


### PR DESCRIPTION
**Description of proposed changes**

We have two separate functions for Curl download.  One is specific to the hash and index files (and has some special checks) while the other is for data download.  There was a lot of repeated code.  We still have two functions, but this PR uses sub-functions to greatly simplify them and avoid the duplications.
