### PR TITLE
Check for and if found, use strsignal

### DIFF
--- a/cmake/modules/ConfigureChecks.cmake
+++ b/cmake/modules/ConfigureChecks.cmake
@@ -160,9 +160,10 @@ check_function_exists (strdup           HAVE_STRDUP)
 check_function_exists (strndup          HAVE_STRNDUP)
 check_function_exists (strsep           HAVE_STRSEP)
 check_function_exists (strtod           HAVE_STRTOD)
+check_function_exists (strtod           HAVE_STRTOD)
 # Note: trailing underscore = GDAL workaround
 check_function_exists (strtof           HAVE_STRTOF_)
-check_function_exists (strtok_r         HAVE_STRTOK_R)
+check_function_exists (strsignal        HAVE_STRSIGNAL)
 
 if (WIN32)
 	check_function_exists (_fseeki64      HAVE__FSEEKI64)

--- a/src/gmt_common_sighandler.c
+++ b/src/gmt_common_sighandler.c
@@ -194,7 +194,11 @@ void sig_handler(int sig_num, siginfo_t *info, void *ucontext) {
 		return;
 	}
 	else {
+#ifdef HAVE_STRSIGNAL
+		fprintf (stderr, "ERROR: Caught signal number %d (%s) at\n", sig_num, strsignal(sig_num);
+#else
 		fprintf (stderr, "ERROR: Caught signal number %d (%s) at\n", sig_num, sys_siglist[sig_num]);
+#endif
 		backtrace_symbols_fd (array, 2, STDERR_FILENO); /* print function with faulting instruction */
 		size = backtrace (array, 50); /* get void*'s for all entries on the stack */
 		fprintf (stderr, "Stack backtrace:\n");


### PR DESCRIPTION
See #4019 for background.  This PR adds a check to see if _strsignal_ is present, and if so we use it instead.  The old _sys_siglist_ array is kept as a backup for systems that do not have _strsignal_.  Closes #4019.
