### PR TITLE
Avoid calling exit in spotter supplement

### DIFF
--- a/src/spotter/backtracker.c
+++ b/src/spotter/backtracker.c
@@ -398,6 +398,7 @@ EXTERN_MSC int GMT_backtracker (void *V_API, int mode, void *args) {
 	unsigned int n_stages = 0;	/* Number of stage poles */
 	unsigned int geometry;
 	int n_fields, error;		/* Misc. signed counters */
+	int sval;
 	int spotter_way = 0;		/* Either SPOTTER_FWD or SPOTTER_BACK */
 	bool make_path = false;		/* true means create continuous path, false works on discrete points */
 	bool E_first = true;
@@ -456,12 +457,14 @@ EXTERN_MSC int GMT_backtracker (void *V_API, int mode, void *args) {
 				GMT_Report (API, GMT_MSG_ERROR, "Unable to convert %s to half-rates\n", Ctrl->E.rot.file);
 				Return (API->error);
 			}
-			n_stages = spotter_init (GMT, tmpfile, &p, Ctrl->L.mode, Ctrl->W.active, Ctrl->E.rot.invert, &Ctrl->N.t_upper);
+			sval = spotter_init (GMT, tmpfile, &p, Ctrl->L.mode, Ctrl->W.active, Ctrl->E.rot.invert, &Ctrl->N.t_upper);
 			gmt_remove_file (GMT, tmpfile);
 		}
 		else
-			n_stages = spotter_init (GMT, Ctrl->E.rot.file, &p, Ctrl->L.mode, Ctrl->W.active, Ctrl->E.rot.invert, &Ctrl->N.t_upper);
-
+			sval = spotter_init (GMT, Ctrl->E.rot.file, &p, Ctrl->L.mode, Ctrl->W.active, Ctrl->E.rot.invert, &Ctrl->N.t_upper);
+		if (sval < 0)
+			Return (-sval);
+		n_stages = (unsigned int)sval;
 		spotter_way = ((Ctrl->L.mode + Ctrl->D.mode) == 1) ? SPOTTER_FWD : SPOTTER_BACK;
 		GMT_Report (API, GMT_MSG_INFORMATION, "Loaded rotations in order for %slines; calling backtracker_spotter_track with direction %swards\n", emode[mode], fmode[(spotter_way+1)/2]);
 

--- a/src/spotter/gmtpmodeler.c
+++ b/src/spotter/gmtpmodeler.c
@@ -278,8 +278,11 @@ EXTERN_MSC int GMT_gmtpmodeler (void *V_API, int mode, void *args) {
 		}
 		spotter_setrot (GMT, &(p[0]));
 	}
-	else	/* Got a file or Gplates plate pair */
-		n_stages = spotter_init (GMT, Ctrl->E.rot.file, &p, 0, false, Ctrl->E.rot.invert, &Ctrl->N.t_upper);
+	else {	/* Got a file or Gplates plate pair */
+		if ((retval = spotter_init (GMT, Ctrl->E.rot.file, &p, 0, false, Ctrl->E.rot.invert, &Ctrl->N.t_upper)) < 0)
+			Return (-retval);
+		n_stages = (unsigned int)retval;
+	}
 
 	for (stage = 0; stage < n_stages; stage++) {
 		if (p[stage].omega < 0.0) {	/* Ensure all stages have positive rotation angles */
@@ -407,7 +410,8 @@ EXTERN_MSC int GMT_gmtpmodeler (void *V_API, int mode, void *args) {
 				case PM_DIST:	/* Compute great-circle distance between node and point of origin at ridge */
 					if (!spotted) {
 						lon = in[GMT_X] * D2R;	lat = lat_c * D2R;
-						(void)spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL);
+						if (spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL) < 0)
+							Return (GMT_RUNTIME_ERROR);
 						spotted = true;
 					}
 					value = GMT->current.proj.DIST_KM_PR_DEG * gmt_distance (GMT, in[GMT_X], lat_c, lon * R2D, lat * R2D);
@@ -425,7 +429,8 @@ EXTERN_MSC int GMT_gmtpmodeler (void *V_API, int mode, void *args) {
 					case PM_DLON:	/* Compute latitude where this point was formed in the model */
 					if (!spotted) {
 						lon = in[GMT_X] * D2R;	lat = lat_c * D2R;
-						(void)spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL);
+						if (spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL) < 0)
+							Return (GMT_RUNTIME_ERROR);
 						spotted = true;
 					}
 					value = in[GMT_X] - lon * R2D;
@@ -434,7 +439,8 @@ EXTERN_MSC int GMT_gmtpmodeler (void *V_API, int mode, void *args) {
 				case PM_DLAT:	/* Compute latitude where this point was formed in the model */
 					if (!spotted) {
 						lon = in[GMT_X] * D2R;	lat = lat_c * D2R;
-						(void)spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL);
+						if (spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL) < 0)
+							Return (GMT_RUNTIME_ERROR);
 						spotted = true;
 					}
 					value = in[GMT_Y] - gmt_lat_swap (GMT, lat * R2D, GMT_LATSWAP_O2G);	/* Convert back to geodetic */
@@ -442,7 +448,8 @@ EXTERN_MSC int GMT_gmtpmodeler (void *V_API, int mode, void *args) {
 				case PM_LON:	/* Compute latitude where this point was formed in the model */
 					if (!spotted) {
 						lon = in[GMT_X] * D2R;	lat = lat_c * D2R;
-						(void)spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL);
+						if (spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL) < 0)
+							Return (GMT_RUNTIME_ERROR);
 						spotted = true;
 					}
 					value = lon * R2D;
@@ -450,7 +457,8 @@ EXTERN_MSC int GMT_gmtpmodeler (void *V_API, int mode, void *args) {
 				case PM_LAT:	/* Compute latitude where this point was formed in the model */
 					if (!spotted) {
 						lon = in[GMT_X] * D2R;	lat = lat_c * D2R;
-						(void)spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL);
+						if (spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL) < 0)
+							Return (GMT_RUNTIME_ERROR);
 						spotted = true;
 					}
 					value = gmt_lat_swap (GMT, lat * R2D, GMT_LATSWAP_O2G);			/* Convert back to geodetic */

--- a/src/spotter/grdpmodeler.c
+++ b/src/spotter/grdpmodeler.c
@@ -327,8 +327,11 @@ EXTERN_MSC int GMT_grdpmodeler (void *V_API, int mode, void *args) {
 		}
 		spotter_setrot (GMT, &(p[0]));
 	}
-	else	/* Got a file or Gplates plate pair */
-		n_stages = spotter_init (GMT, Ctrl->E.rot.file, &p, 0, false, Ctrl->E.rot.invert, &Ctrl->N.t_upper);
+	else {	/* Got a file or Gplates plate pair */
+		if ((retval = spotter_init (GMT, Ctrl->E.rot.file, &p, 0, false, Ctrl->E.rot.invert, &Ctrl->N.t_upper)) < 0)
+			Return (-retval);
+		n_stages = (unsigned int)retval;
+	}
 	for (stage = 0; stage < n_stages; stage++) {
 		if (p[stage].omega < 0.0) {	/* Ensure all stages have positive rotation angles */
 			p[stage].omega = -p[stage].omega;
@@ -450,7 +453,8 @@ EXTERN_MSC int GMT_grdpmodeler (void *V_API, int mode, void *args) {
 				case PM_DIST:	/* Compute great-circle distance between node and point of origin at ridge */
 					if (!spotted) {
 						lon = grd_x[col] * D2R;	lat = grd_yc[row] * D2R;
-						(void)spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL);
+						if (spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL) < 0)
+							Return (GMT_RUNTIME_ERROR);
 						spotted = true;
 					}
 					value = GMT->current.proj.DIST_KM_PR_DEG * gmt_distance (GMT, grd_x[col], grd_yc[row], lon * R2D, lat * R2D);
@@ -468,7 +472,8 @@ EXTERN_MSC int GMT_grdpmodeler (void *V_API, int mode, void *args) {
 					case PM_DLON:	/* Compute latitude where this point was formed in the model */
 					if (!spotted) {
 						lon = grd_x[col] * D2R;	lat = grd_yc[row] * D2R;
-						(void)spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL);
+						if (spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL) < 0)
+							Return (GMT_RUNTIME_ERROR);
 						spotted = true;
 					}
 					value = grd_x[col] - lon * R2D;
@@ -477,7 +482,8 @@ EXTERN_MSC int GMT_grdpmodeler (void *V_API, int mode, void *args) {
 				case PM_DLAT:	/* Compute latitude where this point was formed in the model */
 					if (!spotted) {
 						lon = grd_x[col] * D2R;	lat = grd_yc[row] * D2R;
-						(void)spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL);
+						if (spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL) < 0)
+							Return (GMT_RUNTIME_ERROR);
 						spotted = true;
 					}
 					value = grd_y[row] - gmt_lat_swap (GMT, lat * R2D, GMT_LATSWAP_O2G);	/* Convert back to geodetic */
@@ -485,7 +491,8 @@ EXTERN_MSC int GMT_grdpmodeler (void *V_API, int mode, void *args) {
 				case PM_LON:	/* Compute latitude where this point was formed in the model */
 					if (!spotted) {
 						lon = grd_x[col] * D2R;	lat = grd_yc[row] * D2R;
-						(void)spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL);
+						if (spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL) < 0)
+							Return (GMT_RUNTIME_ERROR);
 						spotted = true;
 					}
 					value = lon * R2D;
@@ -493,7 +500,8 @@ EXTERN_MSC int GMT_grdpmodeler (void *V_API, int mode, void *args) {
 				case PM_LAT:	/* Compute latitude where this point was formed in the model */
 					if (!spotted) {
 						lon = grd_x[col] * D2R;	lat = grd_yc[row] * D2R;
-						(void)spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL);
+						if (spotter_backtrack (GMT, &lon, &lat, &age, 1U, p, n_stages, 0.0, 0.0, 0, NULL, NULL) < 0)
+							Return (GMT_RUNTIME_ERROR);
 						spotted = true;
 					}
 					value = gmt_lat_swap (GMT, lat * R2D, GMT_LATSWAP_O2G);			/* Convert back to geodetic */

--- a/src/spotter/grdrotater.c
+++ b/src/spotter/grdrotater.c
@@ -508,7 +508,8 @@ EXTERN_MSC int GMT_grdrotater (void *V_API, int mode, void *args) {
 	}
 	else {	/* Got a rotation file with multiple rotations in total reconstruction format */
 		double t_max = 0.0;
-		n_stages = spotter_init (GMT, Ctrl->E.rot.file, &p, 0, true, Ctrl->E.rot.invert, &t_max);
+		if ((n_stages = spotter_init (GMT, Ctrl->E.rot.file, &p, 0, true, Ctrl->E.rot.invert, &t_max)) < 0)
+			Return (-n_stages);
 		gmt_set_segmentheader (GMT, GMT_OUT, true);
 	}
 

--- a/src/spotter/grdspotter.c
+++ b/src/spotter/grdspotter.c
@@ -567,7 +567,10 @@ EXTERN_MSC int GMT_grdspotter (void *V_API, int mode, void *args) {
 
 	/* Load in the Euler stage poles */
 
-	n_stages = spotter_init (GMT, Ctrl->E.file, &p, 1, false, Ctrl->E.mode, &Ctrl->N.t_upper);
+	if ((i = spotter_init (GMT, Ctrl->E.file, &p, 1, false, Ctrl->E.mode, &Ctrl->N.t_upper)) < 0)
+		Return (-i);
+	
+	n_stages = (unsigned int)i;
 
 	/* Assign grid-region variables in radians to avoid conversions inside convolution loop */
 

--- a/src/spotter/hotspotter.c
+++ b/src/spotter/hotspotter.c
@@ -347,7 +347,9 @@ EXTERN_MSC int GMT_hotspotter (void *V_API, int mode, void *args) {
 
 	/* Load in the Euler stage poles */
 
-	n_stages = spotter_init (GMT, Ctrl->E.file, &p, 1, false, Ctrl->E.mode, &Ctrl->N.t_upper);
+	if ((error = spotter_init (GMT, Ctrl->E.file, &p, 1, false, Ctrl->E.mode, &Ctrl->N.t_upper)) < 0)
+		Return (-error);
+	n_stages = (unsigned int)error;
 
 	/* Initialize the CVA grid and structure */
 

--- a/src/spotter/originater.c
+++ b/src/spotter/originater.c
@@ -442,7 +442,9 @@ EXTERN_MSC int GMT_originater (void *V_API, int mode, void *args) {
 		}
 	}
 
-	n_stages = spotter_init (GMT, Ctrl->E.file, &p, 1, false, Ctrl->E.mode, &Ctrl->N.t_upper);
+	if ((error = spotter_init (GMT, Ctrl->E.file, &p, 1, false, Ctrl->E.mode, &Ctrl->N.t_upper)) < 0)
+		Return (-error);
+	n_stages = (unsigned int)error;
 
 	hot = gmt_M_memory (GMT, NULL, n_hotspots, struct HOTSPOT_ORIGINATOR);
 

--- a/src/spotter/rotconverter.c
+++ b/src/spotter/rotconverter.c
@@ -407,8 +407,11 @@ EXTERN_MSC int GMT_rotconverter (void *V_API, int mode, void *args) {
 				a[0].omega = angle / a[0].duration;
 				if (online_stage) spotter_stages_to_total (GMT, a, n_a, true, true);
 			}
-			else
-				n_a = spotter_init (GMT, opt->arg, &a, 0, true, false, &zero);	/* Return total reconstruction rotations */
+			else {
+				if ((error = spotter_init (GMT, opt->arg, &a, 0, true, false, &zero)) < 0)	/* Return total reconstruction rotations */
+					Return (-error);
+				n_a = (unsigned int)error;
+			}
 			zero = 0.0;
 			if (last_sign == -1) {	/* Leading - sign, simply reverse the rotation angles */
 				for (stage = 0; stage < n_a; stage++) {
@@ -429,8 +432,11 @@ EXTERN_MSC int GMT_rotconverter (void *V_API, int mode, void *args) {
 				b[0].omega = angle / b[0].duration;
 				if (online_stage) spotter_stages_to_total (GMT, b, n_b, true, true);
 			}
-			else
-				n_b = spotter_init (GMT, opt->arg, &b, 0, true, false, &zero);	/* Return total reconstruction rotations */
+			else {
+				if ((error = spotter_init (GMT, opt->arg, &b, 0, true, false, &zero)) < 0)	/* Return total reconstruction rotations */
+					Return (-error);
+				n_b = (unsigned int)error;
+			}
 			zero = 0.0;
 			spotter_add_rotations (GMT, a, n_a, b, last_sign * n_b, &p, &n_p);		/* Add the two total reconstruction rotations sets, returns total reconstruction rotations in p */
 			gmt_M_free (GMT, a);

--- a/src/spotter/spotter.h
+++ b/src/spotter/spotter.h
@@ -93,10 +93,10 @@ EXTERN_MSC unsigned int spotter_parse (struct GMT_CTRL *GMT, char option, char *
 EXTERN_MSC int spotter_stage (struct GMT_CTRL *GMT, double t, struct EULER p[], unsigned int ns);
 EXTERN_MSC void spotter_rot_usage (struct GMTAPI_CTRL *API, char option);
 EXTERN_MSC bool spotter_GPlates_pair (char *file);
-EXTERN_MSC unsigned int spotter_init (struct GMT_CTRL *GMT, char *file, struct EULER **p, unsigned int flowline, bool total_out, bool invert, double *t_max);
+EXTERN_MSC int spotter_init (struct GMT_CTRL *GMT, char *file, struct EULER **p, unsigned int flowline, bool total_out, bool invert, double *t_max);
 EXTERN_MSC int spotter_hotspot_init (struct GMT_CTRL *GMT, char *file, bool geocentric, struct HOTSPOT **p);
-EXTERN_MSC unsigned int spotter_backtrack  (struct GMT_CTRL *GMT, double xp[], double yp[], double tp[], unsigned int np, struct EULER p[], unsigned int ns, double d_km, double t_zero, unsigned int do_time, double wesn[], double **c);
-EXTERN_MSC unsigned int spotter_forthtrack (struct GMT_CTRL *GMT, double xp[], double yp[], double tp[], unsigned int np, struct EULER p[], unsigned int ns, double d_km, double t_zero, unsigned int do_time, double wesn[], double **c);
+EXTERN_MSC int spotter_backtrack  (struct GMT_CTRL *GMT, double xp[], double yp[], double tp[], unsigned int np, struct EULER p[], unsigned int ns, double d_km, double t_zero, unsigned int do_time, double wesn[], double **c);
+EXTERN_MSC int spotter_forthtrack (struct GMT_CTRL *GMT, double xp[], double yp[], double tp[], unsigned int np, struct EULER p[], unsigned int ns, double d_km, double t_zero, unsigned int do_time, double wesn[], double **c);
 EXTERN_MSC void spotter_total_to_stages (struct GMT_CTRL *GMT, struct EULER p[], unsigned int n, bool total_rates, bool stage_rates);
 EXTERN_MSC void spotter_stages_to_total (struct GMT_CTRL *GMT, struct EULER p[], unsigned int n, bool total_rates, bool stage_rates);
 EXTERN_MSC void spotter_add_rotations (struct GMT_CTRL *GMT, struct EULER a[], int n_a, struct EULER b[], int n_b, struct EULER *c[], unsigned int *n_c);


### PR DESCRIPTION
Simply return a negative error and let module call Return. All spotter tests pass.