### PR TITLE
Enable CI jobs on Debian 9, 10 and sid via dockers

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -241,6 +241,13 @@ jobs:
         containerImage: ubuntu:16.04
       Ubuntu1804:   # CMake 3.10.2 + GNU 7.4.0
         containerImage: ubuntu:18.04
+      Debian9:      # CMake 3.7.2 + GNU 6.3.0
+        containerImage: debian:stretch
+      Debian10:     # CMake 3.13.4 + GNU 8.3.0
+        containerImage: debian:buster
+      DebianSid:    # CMake 3.16.3 + GNU 10.1.0
+        containerImage: debian:sid
+
 
   container:
     image: $[ variables['containerImage'] ]

--- a/ci/azure-pipelines-linux.yml
+++ b/ci/azure-pipelines-linux.yml
@@ -74,7 +74,7 @@ steps:
     gmt defaults -Vd
     gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
     gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
-    gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
+    gmt grdimage @earth_relief_01d -JH10c -Baf -Vd -pdf map
     gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
   displayName: Check a few simple commands
 

--- a/ci/azure-pipelines-mac.yml
+++ b/ci/azure-pipelines-mac.yml
@@ -73,7 +73,7 @@ steps:
     gmt defaults -Vd
     gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
     gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
-    gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
+    gmt grdimage @earth_relief_01d -JH10c -Baf -Vd -pdf map
     gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
   displayName: Check a few simple commands
 

--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -135,7 +135,7 @@ steps:
     gmt defaults -Vd
     gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
     gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
-    gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
+    gmt grdimage @earth_relief_01d -JH10c -Baf -Vd -pdf map
     gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
   displayName: Check a few simple commands
 


### PR DESCRIPTION
**Description of proposed changes**

Add three more nightly CI jobs, building GMT on Debian 9, 10 and sid.

The idea of this PR is to test GMT on different CMake and GCC versions, especially
Debian sid, which provides GCC 10. Remember that we have one or two
issues reporting that GMT fails to build with GCC 10.