### PR TITLE
Clear geography data

### DIFF
--- a/doc/rst/source/clear.rst
+++ b/doc/rst/source/clear.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt clear** **all** \| **cache** \| **data**\ [=\ *planet*] \| **geography** \| **sessions** \| **settings**
+**gmt clear** **all** \| **cache** \| **data**\ [=\ *planet*] \| **geography**\ [=\ *name*] \| **sessions** \| **settings**
 [ |SYN_OPT-V| ]
 
 |No-spaces|
@@ -45,8 +45,9 @@ Optional Arguments
 
 .. _clear-geography:
 
-**geography**
-    Delete the user's geography directory.
+**geography**\ [=\ *name*]
+    Delete the user's geography directory.  Append either *=gshhg* or *=dcw*
+    if you only want to delete the named data set [both].
 
 .. _clear-sessions:
 

--- a/doc/rst/source/clear.rst
+++ b/doc/rst/source/clear.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt clear** **all** \| **cache** \| **data**\ [=\ *planet*] \| **sessions** \| **settings**
+**gmt clear** **all** \| **cache** \| **data**\ [=\ *planet*] \| **geography** \| **sessions** \| **settings**
 [ |SYN_OPT-V| ]
 
 |No-spaces|
@@ -20,7 +20,7 @@ Synopsis
 Description
 -----------
 
-The clear command allows users to delete their entire user cache, data, or sessions
+The clear command allows users to delete their entire user cache, data, geography, or sessions
 directories, and in modern mode their defaults settings (i.e., gmt.conf), or all of the above.
 
 Optional Arguments
@@ -42,6 +42,11 @@ Optional Arguments
     Delete the user's data download server directory and all of its contents.
     Alternatively, append =\ *planet* for a specific planet and we only delete
     data for that sub-directory [all planets].
+
+.. _clear-geography:
+
+**geography**
+    Delete the user's geography directory.
 
 .. _clear-sessions:
 
@@ -70,6 +75,10 @@ To remove the current default settings in a modern mode session, use::
 To completely wipe your GMT cache directory, try::
 
     gmt clear cache
+
+To remove your GMT geography directory with downloaded GSHHG and DCW data, try::
+
+    gmt clear geography
 
 To only wipe your GMT server directory for Earth data, try::
 

--- a/src/clear.c
+++ b/src/clear.c
@@ -271,7 +271,7 @@ EXTERN_MSC int GMT_clear (void *V_API, int mode, void *args) {
 			if (clear_sessions (API))
 				error = GMT_RUNTIME_ERROR;
 		}
-		else if (!strcmp (opt->arg, "geography")) {	/* Clear the geography dir */
+		else if (!strncmp (opt->arg, "geography", 9U)) {	/* Clear the geography dir */
 			char *set = strchr (opt->arg, '=');
 			if (set) set++;	/* Skip past the = sign */
 			if (clear_geography (API, set))

--- a/src/clear.c
+++ b/src/clear.c
@@ -20,7 +20,7 @@
  * Version:	6 API
  *
  * Brief synopsis: gmt clear cleans up by removing files or dirs.
- *	gmt clear [all | cache | data[=<planet>] | geography | sessions | settings ]
+ *	gmt clear [all | cache | data[=<planet>] | geography[=<name>] | sessions | settings ]
  */
 
 #include "gmt_dev.h"

--- a/src/clear.c
+++ b/src/clear.c
@@ -198,7 +198,7 @@ static int clear_geography (struct GMTAPI_CTRL *API, char *data) {
 			d++;
 			continue;
 		}
-		sprintf (current_dir, "%s/%s", geography_dir, dir[d]);	/* E.g., ~/.gmt/server/gshhg */
+		sprintf (current_dir, "%s/%s", geography_dir, dir[d]);	/* E.g., ~/.gmt/geography/gshhg */
 		if (gmt_remove_dir (API, current_dir, false)) {
 			GMT_Report (API, GMT_MSG_ERROR, "Unable to remove directory %s [permissions?]\n", current_dir);
 			return GMT_NOERROR;

--- a/src/clear.c
+++ b/src/clear.c
@@ -20,7 +20,7 @@
  * Version:	6 API
  *
  * Brief synopsis: gmt clear cleans up by removing files or dirs.
- *	gmt clear [all | cache | data[=<planet>] | sessions | settings ]
+ *	gmt clear [all | cache | data[=<planet>] | geography | sessions | settings ]
  */
 
 #include "gmt_dev.h"
@@ -29,7 +29,7 @@
 #define THIS_MODULE_CLASSIC_NAME	"clear"
 #define THIS_MODULE_MODERN_NAME	"clear"
 #define THIS_MODULE_LIB		"core"
-#define THIS_MODULE_PURPOSE	"Delete current default settings, or the cache, data or sessions directories"
+#define THIS_MODULE_PURPOSE	"Delete current default settings, or the cache, data, geography or sessions directories"
 #define THIS_MODULE_KEYS	""
 #define THIS_MODULE_NEEDS	""
 #define THIS_MODULE_OPTIONS	"V"
@@ -37,7 +37,7 @@
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s all|cache|data[=<planet>]|sessions|settings [%s]\n\n", name, GMT_V_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s all|cache|data[=<planet>]|geography|sessions|settings [%s]\n\n", name, GMT_V_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -45,6 +45,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   cache     Deletes the user\'s cache directory [%s].\n", API->GMT->session.CACHEDIR);
 	GMT_Message (API, GMT_TIME_NONE, "\t   data      Deletes the user\'s data download directory [%s/server].\n", API->GMT->session.USERDIR);
 	GMT_Message (API, GMT_TIME_NONE, "\t             Append =<planet> to limit removal to such data for a specific <planet> [all].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   geography Deletes the user\'s geography directory (gshhg, dcw) [%s/geography].\n", API->GMT->session.USERDIR);
 	GMT_Message (API, GMT_TIME_NONE, "\t   sessions  Deletes the user\'s sessions directory [%s].\n", API->session_dir);
 	GMT_Message (API, GMT_TIME_NONE, "\t   settings  Deletes a modern mode session\'s %s file.\n", GMT_SETTINGS_FILE);
 	GMT_Message (API, GMT_TIME_NONE, "\t   all       All of the above.\n");
@@ -174,6 +175,40 @@ static int clear_sessions (struct GMTAPI_CTRL *API) {
 	return GMT_NOERROR;
 }
 
+static int clear_geography (struct GMTAPI_CTRL *API) {
+	int d;
+	char geography_dir[PATH_MAX] = {""}, current_dir[PATH_MAX] = {""};
+	char **dir;
+	struct GMT_CTRL *GMT = API->GMT;
+
+	sprintf (geography_dir, "%s/geography", API->GMT->session.USERDIR);
+	if (access (geography_dir, F_OK)) {
+		GMT_Report (API, GMT_MSG_INFORMATION, "No directory named %s\n", geography_dir);
+		return GMT_FILE_NOT_FOUND;
+	}
+	if ((dir = gmtlib_get_dirs (GMT, geography_dir)) == NULL) {
+		GMT_Report (API, GMT_MSG_NOTICE, "No directories found under %s\n", geography_dir);
+		return GMT_NOERROR;
+	}
+
+	d = 0;
+	while (dir[d]) {	/* Look through geography subdirectories */
+		sprintf (current_dir, "%s/%s", geography_dir, dir[d]);	/* E.g., ~/.gmt/server/gshhg */
+		if (gmt_remove_dir (API, current_dir, false)) {
+			GMT_Report (API, GMT_MSG_ERROR, "Unable to remove directory %s [permissions?]\n", current_dir);
+			return GMT_NOERROR;
+		}
+		d++;
+	}
+	gmtlib_free_dir_list (GMT, &dir);
+
+	if (gmt_remove_dir (API, geography_dir, false)) {
+		GMT_Report (API, GMT_MSG_ERROR, "Unable to remove directory %s [permissions?]\n", geography_dir);
+		return GMT_NOERROR;
+	}
+	return GMT_NOERROR;
+}
+
 #define bailout(code) {gmt_M_free_options (mode); return (code);}
 #define Return(code) {gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
@@ -208,6 +243,8 @@ EXTERN_MSC int GMT_clear (void *V_API, int mode, void *args) {
 				error = GMT_RUNTIME_ERROR;
 			if (clear_data (API, NULL))
 				error = GMT_RUNTIME_ERROR;
+			if (clear_geography (API))
+				error = GMT_RUNTIME_ERROR;
 			if (clear_sessions (API))
 				error = GMT_RUNTIME_ERROR;
 			if (API->GMT->current.setting.run_mode == GMT_MODERN && clear_defaults (API))
@@ -225,6 +262,10 @@ EXTERN_MSC int GMT_clear (void *V_API, int mode, void *args) {
 		}
 		else if (!strcmp (opt->arg, "sessions")) {	/* Clear the sessions dir */
 			if (clear_sessions (API))
+				error = GMT_RUNTIME_ERROR;
+		}
+		else if (!strcmp (opt->arg, "geography")) {	/* Clear the geography dir */
+			if (clear_geography (API))
 				error = GMT_RUNTIME_ERROR;
 		}
 		else if (!strcmp (opt->arg, "settings") || !strcmp (opt->arg, "defaults") || !strcmp (opt->arg, "conf")) {	/* Clear the default settings in modern mode */

--- a/src/clear.c
+++ b/src/clear.c
@@ -37,7 +37,7 @@
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s all|cache|data[=<planet>]|geography[=<name>|sessions|settings [%s]\n\n", name, GMT_V_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s all|cache|data[=<planet>]|geography[=<name>]|sessions|settings [%s]\n\n", name, GMT_V_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 


### PR DESCRIPTION
**Description of proposed changes**

New target added to clear: _geography_[=_name_], where name can be either gshhg or dcw.  Default deletes both.