### PR TITLE
Fix an error message

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8394,7 +8394,7 @@ int gmt_parse_R_option (struct GMT_CTRL *GMT, char *arg) {
 						gmt_set_column (GMT, GMT_IN, icol, got);
 				}
 				else {	/* Testing this, could we ever get here with sane data? */
-					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not parse %s into Geographical, Cartesian, or Temporal coordinates!", text);
+					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not parse %s into Geographical, Cartesian, or Temporal coordinates!\n", text);
 					error++;
 				}
 			}


### PR DESCRIPTION
When running an wrong command, I get following messages.
Obviously, we need a "newline" for the first error message.

```
plot [ERROR]: Could not parse nan into Geographical, Cartesian, or Temporal coordinates!plot [ERROR]: Option -R parsing failure. Correct syntax:
	-R<xmin>/<xmax>/<ymin>/<ymax>[/<zmin>/<zmax>]
	  Append +r if giving lower left and upper right coordinates
	-Rg or -Rd for global domain
	-R<grdfile> to take the domain from a grid file
plot [ERROR]: Offending option -R0/12.5008/0/nan
```