### PR TITLE
Fix an unintvar compilation error

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -5607,7 +5607,7 @@ GMT_LOCAL int gmtapi_write_matrix (struct GMT_CTRL *GMT, void *dest, unsigned in
 			fprintf (fp, "\n");
 		}
 	}
-	GMT->current.setting.io_header[GMT_OUT] = was;
+	if (M->n_headers) GMT->current.setting.io_header[GMT_OUT] = was;  /* Revert to the original setting */
 
 	if (close_file) fclose (fp);
 	return (GMT_NOERROR);
@@ -5764,7 +5764,7 @@ GMT_LOCAL int gmtapi_write_vector (struct GMT_CTRL *GMT, void *dest, unsigned in
 	gmt_M_free (GMT, api_get_val);
 
 	if (close_file) fclose (fp);
-	GMT->current.setting.io_header[GMT_OUT] = was;
+	if (V->n_headers) GMT->current.setting.io_header[GMT_OUT] = was;  /* Revert to the original setting */
 
 	return (GMT_NOERROR);
 }


### PR DESCRIPTION
cppcheck reports following errors:

```
src/gmt_api.c:5610:44: error: Uninitialized variable: was [uninitvar]
 GMT->current.setting.io_header[GMT_OUT] = was;
                                           ^
src/gmt_api.c:5767:44: error: Uninitialized variable: was [uninitvar]
 GMT->current.setting.io_header[GMT_OUT] = was;
```

`was` is assigned a value only if `M->n_headers` or `V->n_headers` is non-zero.