### PR TITLE
pssac: Use Cartesian projection by default unless -S is used

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13404,7 +13404,8 @@ GMT_LOCAL bool gmtinit_is_region_geographic (struct GMT_CTRL *GMT, struct GMT_OP
 	if (!strncmp (module, "pscoupe", 7U)) return true;
 	if (!strncmp (module, "psmeca", 6U)) return true;
 	if (!strncmp (module, "pspolar", 7U)) return true;
-	if (!strncmp (module, "pssac", 5U)) return true;
+	/* pssac: Cartesion by default, unless -S option is used */
+	if (!strncmp (module, "pssac", 5U) && (opt = GMT_Find_Option (GMT->parent, 'S', options)) != NULL) return true;
 	if (!strncmp (module, "psvelo", 6U)) return true;
 	if (!strncmp (module, "mgd77track", 10U)) return true;
 	if (!strncmp (module, "grdpmodeler", 11U)) return true;


### PR DESCRIPTION
**Description of proposed changes**

For most GMT modules, if -J is not given, GMT uses -JX15c for Cartesian
data, and -JQ15c for Geographic data.

pssac can either plot seismograms as time series (Cartesian data)
or plot seismograms on maps (Geographic data). Currently, pssac always
uses -JQ15c when -J is not given.

Plotting seismograms as time series gives the following error:
```
gmt sac seis.SAC -R9/20/-2/2 -Baf -Fr -Gp+gblack -Gn+gred -pdf single
sac [ERROR]: -S option is needed in geographic plots.
```
because GMT sets the default -JQ15c. But for geographic plots, -S
(controling the waveform time scaling) is required.

Obviously, the -JQ15c is the wrong choice. This PR fixes the issue.

In this PR, pssac always use Cartesian projection, unless -S is used.

All tests still pass. With this PR, the command
```
gmt sac seis.SAC -R9/20/-2/2 -Baf -Fr -Gp+gblack -Gn+gred -pdf single
```
plots seismograms using -JX15c, and command (with -S option)
```
gmt sac *.z -R-120/-40/35/65 -Baf -M1i -S300c -pdf map
```
plots seismograms on maps, using -JQ15c.