### PR TITLE
Remove exit from gmtlogo

### DIFF
--- a/src/gmtlogo.c
+++ b/src/gmtlogo.c
@@ -421,7 +421,7 @@ EXTERN_MSC int GMT_gmtlogo (void *V_API, int mode, void *args) {
 	/* Allocate a matrix container for holding the GMT-matrix coordinates */
 	par[0] = 2;	par[1] = GMT_N_LETTERS;
 	if ((M = GMT_Create_Data (API, GMT_IS_DATASET|GMT_VIA_MATRIX, GMT_IS_POLY, GMT_CONTAINER_ONLY, par, NULL, NULL, 0, GMT_IS_ROW_FORMAT, NULL)) == NULL)
-		exit (EXIT_FAILURE);
+		Return (GMT_RUNTIME_ERROR);
 	GMT_Put_Matrix (API, M, GMT_FLOAT, 0, gmt_letters);	/* Hook in our static float matrix */
 	GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_MATRIX, GMT_IS_POLY, GMT_IN|GMT_IS_REFERENCE, M, file);	/* Open matrix for reading */
 	sprintf (cmd, "-<%s -R167/527/-90/90 -JI-13/%gi -O -K -G%s@40 --GMT_HISTORY=readonly",


### PR DESCRIPTION
While this exit cannot actually happen, it is also no point having it.
