### PR TITLE
Eliminate exit calls in grdfft and psconvert

### DIFF
--- a/src/grdfft.c
+++ b/src/grdfft.c
@@ -889,7 +889,7 @@ EXTERN_MSC int GMT_grdfft (void *V_API, int mode, void *args) {
 			printf ("%g\t%g\n", f, f_info.filter (f, 0));	/* Radial filter */
 			f += 0.01;
 		}
-		exit (-1);
+		Return (GMT_RUNTIME_ERROR);
 	}
 #endif
 

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -217,7 +217,7 @@ GMT_LOCAL struct popen2 * psconvert_popen2 (const char *cmdline) {
 		close (pipe_stdout[0]);
 		dup2 (pipe_stdout[1], 1);
 		execl ("/bin/sh", "sh", "-c", cmdline, NULL);
-		perror ("execl"); exit (99);
+		perror ("execl"); return NULL;
 	}
 	/* Return the file handles back via structure */
 	F = calloc (1, sizeof (struct popen2));


### PR DESCRIPTION
The grdconvert case would only exit when compiled for a specific test case
