### PR TITLE
Fix issues in Mercator projection

### DIFF
--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -15,7 +15,7 @@ Synopsis
 **gmt mapproject** [ *tables* ] |-J|\ *parameters*
 |SYN_OPT-R|
 [ |-A|\ **b**\|\ **B**\|\ **f**\|\ **F**\|\ **o**\|\ **O**\ [*lon0*/*lat0*][**+v**] ]
-[ |-C|\ [*dx*/*dy*] ]
+[ |-C|\ [*dx*/*dy*][**+m**] ]
 [ |-D|\ **c**\|\ **i**\|\ **p** ]
 [ |-E|\ [*datum*] ] [ |-F|\ [*unit*] ]
 [ |-G|\ [*lon0*/*lat0*][**+a**][**+i**][**+u**\ *unit*][**+v**] ]
@@ -105,7 +105,7 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ [*dx*/*dy*]
+**-C**\ [*dx*/*dy*][**+m**]
     Set center of projected coordinates to be at map projection center
     [Default is lower left corner]. Optionally, add offsets in the
     projected units to be added (or subtracted when **-I** is set) to
@@ -113,7 +113,9 @@ Optional Arguments
     northings for particular projection zones [0/0]. The unit used for
     the offsets is the plot distance unit in effect (see
     :term:`PROJ_LENGTH_UNIT`) unless **-F** is used, in which case the
-    offsets are in meters.
+    offsets are in meters.  Alternatively, for the Mercator projection
+    only, append **+m** to set the origin of the projected *y* coordinates
+    to coincide with the standard parallel [Equator].
 
 .. _-D:
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -865,7 +865,7 @@ GMT_LOCAL int gmtinit_rectR_to_geoR (struct GMT_CTRL *GMT, char unit, double rec
 	uint64_t dim[GMT_DIM_SIZE] = {1, 1, 2, 2};	/* Just a single data table with one segment with two 2-column records */
 	bool was_R, was_J;
 	double wesn[4];
-	char buffer[GMT_LEN256] = {""}, Jstring[GMT_LEN128] = {""}, in_string[GMT_VF_LEN] = {""}, out_string[GMT_VF_LEN] = {""}, *v = NULL;
+	char buffer[GMT_LEN256] = {""}, Jstring[GMT_LEN128] = {""}, in_string[GMT_VF_LEN] = {""}, out_string[GMT_VF_LEN] = {""}, origin_flag[4] = {""}, *v = NULL;
 	struct GMT_DATASET *In = NULL, *Out = NULL;
 
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Call gmtinit_rectR_to_geoR to convert projected -R to geo -R\n");
@@ -911,6 +911,8 @@ GMT_LOCAL int gmtinit_rectR_to_geoR (struct GMT_CTRL *GMT, char unit, double rec
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "UTM projection insufficiently specified to auto-determine geographic region\n");
 				return (GMT_MAP_NO_PROJECTION);
 			}
+			if (GMT->current.proj.projection_GMT == GMT_MERCATOR)	/* Special use of Mercator units relative to stated origin */
+				strcpy (origin_flag, "+m");
 			break;
 		case 2: /* Conical: Use default patch */
 			break;
@@ -948,8 +950,8 @@ GMT_LOCAL int gmtinit_rectR_to_geoR (struct GMT_CTRL *GMT, char unit, double rec
 				v[0] = '\0';
 		}
 	}
-	snprintf (buffer, GMT_LEN256, "-R%g/%g/%g/%g -J%s -I -F%c -C -bi2d -bo2d -<%s ->%s --GMT_HISTORY=readonly",
-		wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI], Jstring, unit, in_string, out_string);
+	snprintf (buffer, GMT_LEN256, "-R%g/%g/%g/%g -J%s -I -F%c -C%s -bi2d -bo2d -<%s ->%s --GMT_HISTORY=readonly",
+		wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI], Jstring, unit, origin_flag, in_string, out_string);
 	if (get_R) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Obtaining geographic corner coordinates via mapproject %s\n", buffer);
 	if (GMT_Call_Module (GMT->parent, "mapproject", GMT_MODULE_CMD, buffer) != GMT_OK)	/* Get the corners in degrees via mapproject */
 		return (GMT->parent->error);

--- a/src/gmt_proj.c
+++ b/src/gmt_proj.c
@@ -672,14 +672,14 @@ GMT_LOCAL void gmtproj_merc_sph (struct GMT_CTRL *GMT, double lon, double lat, d
 	if (GMT->current.proj.GMT_convert_latitudes) lat = gmt_M_latg_to_latc (GMT, lat);
 
 	*x = GMT->current.proj.j_x * D2R * lon;
-	*y = (fabs (lat) < 90.0) ? GMT->current.proj.j_x * d_log (GMT, tand (45.0 + 0.5 * lat)) - GMT->current.proj.j_yc : copysign (DBL_MAX, lat);
+	*y = (fabs (lat) < 90.0) ? GMT->current.proj.j_x * d_log (GMT, tand (45.0 + 0.5 * lat)) : copysign (DBL_MAX, lat);
 }
 
 GMT_LOCAL void gmtproj_imerc_sph (struct GMT_CTRL *GMT, double *lon, double *lat, double x, double y) {
 	/* Convert Mercator x/y to lon/lat  (GMT->current.proj.EQ_RAD in GMT->current.proj.j_ix) */
 
 	*lon = x * GMT->current.proj.j_ix * R2D + GMT->current.proj.central_meridian;
-	*lat = atand (sinh ((y + GMT->current.proj.j_yc) * GMT->current.proj.j_ix));
+	*lat = atand (sinh (y * GMT->current.proj.j_ix));
 	if (GMT->current.proj.GMT_convert_latitudes) *lat = gmt_M_latc_to_latg (GMT, *lat);
 }
 

--- a/src/gmt_proj.c
+++ b/src/gmt_proj.c
@@ -655,8 +655,6 @@ GMT_LOCAL void gmtproj_ipolar (struct GMT_CTRL *GMT, double *x, double *y, doubl
 GMT_LOCAL void gmtproj_vmerc (struct GMT_CTRL *GMT, double lon0, double slat) {
 	/* Set up a Mercator transformation with origin at (lon0, lat0) */
 
-	if (GMT->current.proj.GMT_convert_latitudes) slat = gmt_M_latg_to_latc (GMT, slat);
-
 	GMT->current.proj.central_meridian = lon0;
 	GMT->current.proj.j_x = cosd (slat) / d_sqrt (1.0 - GMT->current.proj.ECC2 * sind (slat) * sind (slat)) * GMT->current.proj.EQ_RAD;
 	GMT->current.proj.j_ix = 1.0 / GMT->current.proj.j_x;

--- a/src/gmt_proj.c
+++ b/src/gmt_proj.c
@@ -652,13 +652,17 @@ GMT_LOCAL void gmtproj_ipolar (struct GMT_CTRL *GMT, double *x, double *y, doubl
 
 /* -JM MERCATOR PROJECTION */
 
-GMT_LOCAL void gmtproj_vmerc (struct GMT_CTRL *GMT, double lon0, double slat) {
+GMT_LOCAL void gmtproj_vmerc (struct GMT_CTRL *GMT, double lon0, double lat0) {
 	/* Set up a Mercator transformation with origin at (lon0, lat0) */
 
+	double aux_lat0 = (GMT->current.proj.GMT_convert_latitudes) ? gmt_M_latg_to_latc (GMT, lat0) : lat0;
+
 	GMT->current.proj.central_meridian = lon0;
-	GMT->current.proj.j_x = cosd (slat) / d_sqrt (1.0 - GMT->current.proj.ECC2 * sind (slat) * sind (slat)) * GMT->current.proj.EQ_RAD;
+	/* Need geodetic latitude in this expression: */
+	GMT->current.proj.j_x = cosd (lat0) / d_sqrt (1.0 - GMT->current.proj.ECC2 * sind (lat0) * sind (lat0)) * GMT->current.proj.EQ_RAD;
 	GMT->current.proj.j_ix = 1.0 / GMT->current.proj.j_x;
-	GMT->current.proj.j_yc = (fabs (slat) > 0.0) ? GMT->current.proj.j_x * d_log (GMT, tand (45.0 + 0.5 * slat)) : 0.0;
+	/* Need conformal latitude in this expression (same as in gmtproj_merc_sph) */
+	GMT->current.proj.j_yc = (fabs (lat0) > 0.0) ? GMT->current.proj.j_x * d_log (GMT, tand (45.0 + 0.5 * aux_lat0)) : 0.0;
 }
 
 /* Mercator projection for the sphere */

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -190,7 +190,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s <table> %s %s\n", name, GMT_J_OPT, GMT_Rgeo_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-Ab|B|f|F|o|O[<lon0>/<lat0>][+v]] [-C[<dx></dy>]] [-D%s] [-E[<datum>]] [-F[<unit>]]\n\t[-G[<lon0>/<lat0>][+a][+i][+u<unit>][+v]]", GMT_DIM_UNITS_DISPLAY);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-Ab|B|f|F|o|O[<lon0>/<lat0>][+v]] [-C[<dx></dy>][+m]] [-D%s] [-E[<datum>]] [-F[<unit>]]\n\t[-G[<lon0>/<lat0>][+a][+i][+u<unit>][+v]]", GMT_DIM_UNITS_DISPLAY);
 	GMT_Message (API, GMT_TIME_NONE, " [-I] [-L<table>[+u<unit>][+p]] [-N[a|c|g|m]]\n\t[-Q[e|d]] [-S] [-T[h]<from>[/<to>] [%s] [-W[g|h|j|n|w|x]] [-Z[<speed>][+a][+i][+f][+t<epoch>]]\n", GMT_V_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s]\n\t[%s]\n\t[%s] [%s] [%s] [%s]\n\n",
 		GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT, GMT_i_OPT, GMT_j_OPT, GMT_o_OPT, GMT_p_OPT, GMT_q_OPT, GMT_s_OPT, GMT_colon_OPT, GMT_PAR_OPT);
@@ -210,6 +210,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Return x/y relative to projection center [Default is relative to lower left corner].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally append <dx></dy> to add (or subtract if -I) (i.e., false easting & northing) [0/0].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Units are plot units unless -F is set in which case the unit is meters.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Mercator only: Append +m to set origin for projected y-values to the standard parallel [Equator].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-D Temporarily reset PROJ_LENGTH_UNIT to be c (cm), i (inch), or p (point).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Cannot be used if -F is set.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-E Convert (lon, lat, h) to Earth Centered Earth Fixed (ECEF) coordinates [-I for inverse].\n");
@@ -759,6 +760,7 @@ static int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct GMT
 	                                   GMT->common.b.active[GMT_IN] && gmt_get_cols (GMT, GMT_IN) < 3,
 	                                   "For -E or -T, binary input data (-bi) must have at least 3 columns\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.m_origin && GMT->current.proj.projection_GMT != GMT_MERCATOR, "Option -C: Can only give +m for Mercator projection\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->C.m_origin && Ctrl->C.northing != 0.0, "Option -C: Cannot mix +m and the \"northing\" setting\n");
 
 	if (!(n_errors || GMT->common.R.active[RSET])) {
 		GMT->common.R.wesn[XLO] = 0.0;	GMT->common.R.wesn[XHI] = 360.0;

--- a/test/psbasemap/merc_origin.ps
+++ b/test/psbasemap/merc_origin.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.2.0_6ee2397_2020.08.29 [64-bit] Document from psbasemap
+%%Title: GMT v6.2.0_f9ac5e7_2020.08.29 [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sat Aug 29 09:40:18 2020
+%%CreationDate: Sat Aug 29 14:19:33 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -670,7 +670,7 @@ O0
 
 % PostScript produced by:
 %@GMT: gmt psbasemap -JM173/-42/16c -R-200/200/-200/200+uk -Baf -BWSne -P --MAP_FRAME_TYPE=plain -K
-%@PROJ: merc 170.59321263 175.40678737 -43.76969644 -40.17929720 -200000.000 200000.000 -200000.000 200000.000 +proj=merc +lon_0=173 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@PROJ: merc 170.58602098 175.41397902 -43.77490773 -40.17378073 -200000.000 200000.000 -4019830.943 -3619830.943 +proj=merc +lon_0=173 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %GMTBoundingBox: 72 72 453.543307087 453.543307086
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -678,90 +678,90 @@ O0
 3.32550952342 setmiterlimit
 25 W
 8 W
-N 639 0 M 0 -83 D S
-N 639 7559 M 0 83 D S
-N 2209 0 M 0 -83 D S
-N 2209 7559 M 0 83 D S
+N 648 0 M 0 -83 D S
+N 648 7559 M 0 83 D S
+N 2214 0 M 0 -83 D S
+N 2214 7559 M 0 83 D S
 N 3780 0 M 0 -83 D S
 N 3780 7559 M 0 83 D S
-N 5350 0 M 0 -83 D S
-N 5350 7559 M 0 83 D S
-N 6920 0 M 0 -83 D S
-N 6920 7559 M 0 83 D S
-N 0 1657 M -83 0 D S
-N 7559 1657 M 83 0 D S
+N 5345 0 M 0 -83 D S
+N 5345 7559 M 0 83 D S
+N 6911 0 M 0 -83 D S
+N 6911 7559 M 0 83 D S
+N 0 1664 M -83 0 D S
+N 7559 1664 M 83 0 D S
 N 0 3780 M -83 0 D S
 N 7559 3780 M 83 0 D S
-N 0 5868 M -83 0 D S
-N 7559 5868 M 83 0 D S
-N 246 0 M 0 -42 D S
-N 246 7559 M 0 42 D S
-N 639 0 M 0 -42 D S
-N 639 7559 M 0 42 D S
-N 1031 0 M 0 -42 D S
-N 1031 7559 M 0 42 D S
-N 1424 0 M 0 -42 D S
-N 1424 7559 M 0 42 D S
-N 1817 0 M 0 -42 D S
-N 1817 7559 M 0 42 D S
-N 2209 0 M 0 -42 D S
-N 2209 7559 M 0 42 D S
-N 2602 0 M 0 -42 D S
-N 2602 7559 M 0 42 D S
-N 2994 0 M 0 -42 D S
-N 2994 7559 M 0 42 D S
-N 3387 0 M 0 -42 D S
-N 3387 7559 M 0 42 D S
+N 0 5862 M -83 0 D S
+N 7559 5862 M 83 0 D S
+N 257 0 M 0 -42 D S
+N 257 7559 M 0 42 D S
+N 648 0 M 0 -42 D S
+N 648 7559 M 0 42 D S
+N 1040 0 M 0 -42 D S
+N 1040 7559 M 0 42 D S
+N 1431 0 M 0 -42 D S
+N 1431 7559 M 0 42 D S
+N 1822 0 M 0 -42 D S
+N 1822 7559 M 0 42 D S
+N 2214 0 M 0 -42 D S
+N 2214 7559 M 0 42 D S
+N 2605 0 M 0 -42 D S
+N 2605 7559 M 0 42 D S
+N 2997 0 M 0 -42 D S
+N 2997 7559 M 0 42 D S
+N 3388 0 M 0 -42 D S
+N 3388 7559 M 0 42 D S
 N 3780 0 M 0 -42 D S
 N 3780 7559 M 0 42 D S
-N 4172 0 M 0 -42 D S
-N 4172 7559 M 0 42 D S
-N 4565 0 M 0 -42 D S
-N 4565 7559 M 0 42 D S
-N 4957 0 M 0 -42 D S
-N 4957 7559 M 0 42 D S
-N 5350 0 M 0 -42 D S
-N 5350 7559 M 0 42 D S
-N 5742 0 M 0 -42 D S
-N 5742 7559 M 0 42 D S
-N 6135 0 M 0 -42 D S
-N 6135 7559 M 0 42 D S
-N 6528 0 M 0 -42 D S
-N 6528 7559 M 0 42 D S
-N 6920 0 M 0 -42 D S
-N 6920 7559 M 0 42 D S
-N 7313 0 M 0 -42 D S
-N 7313 7559 M 0 42 D S
-N 0 43 M -42 0 D S
-N 7559 43 M 42 0 D S
-N 0 583 M -42 0 D S
-N 7559 583 M 42 0 D S
-N 0 1121 M -42 0 D S
-N 7559 1121 M 42 0 D S
-N 0 1657 M -42 0 D S
-N 7559 1657 M 42 0 D S
-N 0 2191 M -42 0 D S
-N 7559 2191 M 42 0 D S
-N 0 2723 M -42 0 D S
-N 7559 2723 M 42 0 D S
-N 0 3252 M -42 0 D S
-N 7559 3252 M 42 0 D S
+N 4171 0 M 0 -42 D S
+N 4171 7559 M 0 42 D S
+N 4562 0 M 0 -42 D S
+N 4562 7559 M 0 42 D S
+N 4954 0 M 0 -42 D S
+N 4954 7559 M 0 42 D S
+N 5345 0 M 0 -42 D S
+N 5345 7559 M 0 42 D S
+N 5737 0 M 0 -42 D S
+N 5737 7559 M 0 42 D S
+N 6128 0 M 0 -42 D S
+N 6128 7559 M 0 42 D S
+N 6519 0 M 0 -42 D S
+N 6519 7559 M 0 42 D S
+N 6911 0 M 0 -42 D S
+N 6911 7559 M 0 42 D S
+N 7302 0 M 0 -42 D S
+N 7302 7559 M 0 42 D S
+N 0 54 M -42 0 D S
+N 7559 54 M 42 0 D S
+N 0 593 M -42 0 D S
+N 7559 593 M 42 0 D S
+N 0 1129 M -42 0 D S
+N 7559 1129 M 42 0 D S
+N 0 1664 M -42 0 D S
+N 7559 1664 M 42 0 D S
+N 0 2196 M -42 0 D S
+N 7559 2196 M 42 0 D S
+N 0 2726 M -42 0 D S
+N 7559 2726 M 42 0 D S
+N 0 3254 M -42 0 D S
+N 7559 3254 M 42 0 D S
 N 0 3780 M -42 0 D S
 N 7559 3780 M 42 0 D S
-N 0 4305 M -42 0 D S
-N 7559 4305 M 42 0 D S
-N 0 4828 M -42 0 D S
-N 7559 4828 M 42 0 D S
-N 0 5349 M -42 0 D S
-N 7559 5349 M 42 0 D S
-N 0 5868 M -42 0 D S
-N 7559 5868 M 42 0 D S
-N 0 6386 M -42 0 D S
-N 7559 6386 M 42 0 D S
-N 0 6901 M -42 0 D S
-N 7559 6901 M 42 0 D S
-N 0 7414 M -42 0 D S
-N 7559 7414 M 42 0 D S
+N 0 4303 M -42 0 D S
+N 7559 4303 M 42 0 D S
+N 0 4825 M -42 0 D S
+N 7559 4825 M 42 0 D S
+N 0 5345 M -42 0 D S
+N 7559 5345 M 42 0 D S
+N 0 5862 M -42 0 D S
+N 7559 5862 M 42 0 D S
+N 0 6378 M -42 0 D S
+N 7559 6378 M 42 0 D S
+N 0 6892 M -42 0 D S
+N 7559 6892 M 42 0 D S
+N 0 7403 M -42 0 D S
+N 7559 7403 M 42 0 D S
 25 W
 0 0 M
 7559 0 D
@@ -772,16 +772,16 @@ N 7559 7414 M 42 0 D S
 -1890 0 D
 0 -7559 D
 P S
-639 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+648 -167 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(171∞) tc Z
-2209 -167 M (172∞) tc Z
-3780 -167 M (173∞) tc Z
-5350 -167 M (174∞) tc Z
-6920 -167 M (175∞) tc Z
--167 1657 M (-43∞) mr Z
--167 3780 M (-42∞) mr Z
--167 5868 M (-41∞) mr Z
+(171è) tc Z
+2214 -167 M (172è) tc Z
+3780 -167 M (173è) tc Z
+5345 -167 M (174è) tc Z
+6911 -167 M (175è) tc Z
+-167 1664 M (î43è) mr Z
+-167 3780 M (î42è) mr Z
+-167 5862 M (î41è) mr Z
 %%EndObject
 0 A
 FQ
@@ -790,7 +790,7 @@ O0
 
 % PostScript produced by:
 %@GMT: gmt psxy -R-200/200/-200/200+uk -JM173/-42/16c -O -S+1c -W1p
-%@PROJ: merc 170.59321263 175.40678737 -43.76969644 -40.17929720 -200000.000 200000.000 -200000.000 200000.000 +proj=merc +lon_0=173 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@PROJ: merc 170.58602098 175.41397902 -43.77490773 -40.17378073 -200000.000 200000.000 -4019830.943 -3619830.943 +proj=merc +lon_0=173 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin


### PR DESCRIPTION
**Description of proposed changes**

There were two problems in the Mercator projection in 6.1.0 that this PR will fix:

1. The handling of relative distances around a projection origin in setting up a Mercator map (issue #2287) leaked into coordinate projection from **mapproject** and affected the output of projected values, as reported on the [forum](https://forum.generic-mapping-tools.org/t/mapproject-grdproject-issues-and-changes-between-versions/823).
2. The conformal rather than geodetic standard latitude was used in computing the true scale at that latitude.

With the corrections we are again compatible with 6.0.0 output while handling the relative coordinates for projection setup.  For flexibility, we also added a **+m** modifier to **-C** in **mapproject** to allow moving the origin for projected Mercator y-values to the standard latitude [Default remains the Equator].

The recently added merc_origin.ps test changed slightly due to point 2 above.
