### PR TITLE
Fix minor issue in sample1d doc file

### DIFF
--- a/doc/rst/source/sample1d.rst
+++ b/doc/rst/source/sample1d.rst
@@ -65,7 +65,7 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ **f**\|\ **p**\|\ **m**\|\ **r**\|\ **R**
+**-A**\ **f**\|\ **p**\|\ **m**\|\ **r**\|\ **R**\ [**+l**]
     For track resampling (if **-T**...\ *unit* is set) we can select how
     this is to be performed. Append **f** to keep original points, but
     add intermediate points if needed; note this selection does not


### PR DESCRIPTION
Did not show the +l modifier other than in synopsis.
