### PR TITLE
Skip record if gmt_create_array() returns error and thus prevent crash.

### DIFF
--- a/src/sample1d.c
+++ b/src/sample1d.c
@@ -458,7 +458,10 @@ EXTERN_MSC int GMT_sample1d (void *V_API, int mode, void *args) {
 				double min, max;
 				min = (Ctrl->T.T.delay[GMT_X]) ? ceil (S->data[Ctrl->N.col][0] / Ctrl->T.T.inc) * Ctrl->T.T.inc : Ctrl->T.T.min;
 				max = (Ctrl->T.T.delay[GMT_Y]) ? floor (S->data[Ctrl->N.col][S->n_rows-1] / Ctrl->T.T.inc) * Ctrl->T.T.inc : Ctrl->T.T.max;
-				gmt_create_array (GMT, 'T', &(Ctrl->T.T), &min, &max);
+				if (gmt_create_array(GMT, 'T', &(Ctrl->T.T), &min, &max) != GMT_NOERROR) {
+					GMT_Report(API, GMT_MSG_WARNING, "Segment %" PRIu64 " in table %" PRIu64 " had troubles.\n", seg, tbl);
+					continue;
+				}
 				m = Ctrl->T.T.n;
 				t_out = Ctrl->T.T.array;
 			}


### PR DESCRIPTION
See [forum post](https://forum.generic-mapping-tools.org/t/sample1d-on-gmt6-1-and-gmt6-2/830/9) for context.