### PR TITLE
Ensure files on remote server has correct permissions

### DIFF
--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -125,6 +125,7 @@ echo "build-release.sh: Place gmt-${Version}-src.tar.* on the ftp site" >&2
 if [ -f gmt-${Version}-darwin-x86_64.dmg ]; then
 	echo "build-release.sh: Place gmt-${Version}-darwin-x86_64.dmg on the ftp site" >&2
 fi
-if [ "${USER}" = "pwessel" ]; then	# Place file in pwessel SOEST ftp release directory
+if [ "${USER}" = "pwessel" ]; then	# Place file in pwessel SOEST ftp release directory and set permissions
 	scp gmt-${Version}-darwin-x86_64.dmg gmt-${Version}-src.tar.* ftp.soest.hawaii.edu:/export/ftp1/ftp/pub/pwessel/release
+	ssh pwessel@ftp.soest.hawaii.edu 'chmod og+r /export/ftp1/ftp/pub/pwessel/release/gmt-*'
 fi


### PR DESCRIPTION
Seems to be simpler way than to have a ssh command after the scp to set the permissions for read to group/other.  I don't want to mess with umask on that account.
