### PR TITLE
Fix GMT_Read_Data to handle output virtual files

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -7895,6 +7895,7 @@ GMT_LOCAL bool gmtapi_is_passable (struct GMTAPI_DATA_OBJECT *S_obj, unsigned in
 	return true; /* True to its word, otherwise we fall through and read the data */
 }
 
+/* Simple macro to tell us if this file (which we know is a memory file when called) is an output file */
 #define gmtapi_M_is_output(file) (file[GMTAPI_OBJECT_DIR_START] == 'O')
 
 /*! . */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -7895,6 +7895,8 @@ GMT_LOCAL bool gmtapi_is_passable (struct GMTAPI_DATA_OBJECT *S_obj, unsigned in
 	return true; /* True to its word, otherwise we fall through and read the data */
 }
 
+#define gmtapi_M_is_output(file) (file[GMTAPI_OBJECT_DIR_START] == 'O')
+
 /*! . */
 void * GMT_Read_Data (void *V_API, unsigned int family, unsigned int method, unsigned int geometry, unsigned int mode, double wesn[], const char *infile, void *data) {
 	/* Function to read data files directly into program memory as a set (not record-by-record).
@@ -7919,6 +7921,8 @@ void * GMT_Read_Data (void *V_API, unsigned int family, unsigned int method, uns
 	API = gmtapi_get_api_ptr (V_API);
 	API->error = GMT_NOERROR;
 	just_get_data = (gmt_M_file_is_memory (input));	/* A regular GMT resource passed via memory */
+	if (just_get_data && gmtapi_M_is_output (input))	/* A virtual output file created elsewhere, retrieve and we are done */
+		return (GMT_Read_VirtualFile (API, input));
 	reset = (mode & GMT_IO_RESET);	/* We want to reset resource as unread after reading it */
 	if (reset) mode -= GMT_IO_RESET;
 	module_input = (family & GMT_VIA_MODULE_INPUT);	/* Are we reading a resource that should be considered a module input? */

--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -211,6 +211,7 @@ struct GMTAPI_CTRL {
 
 #define GMTAPI_PREFIX_LEN 9U		/* The length of the unique leading prefix of virtual filenames */
 #define GMTAPI_MEMFILE_LEN 27U		/* The length of the virtual filenames (see gmtapi_encode_id) */
+#define GMTAPI_OBJECT_DIR_START 11U	/* Start position of the encoded object direction in the virtual filename */
 #define GMTAPI_OBJECT_ID_START 21U	/* Start position of the encoded object ID in the virtual filename */
 #define gmt_M_file_is_memory(file) (file && !strncmp (file, "@GMTAPI@-", GMTAPI_PREFIX_LEN) && strlen (file) == GMTAPI_MEMFILE_LEN)
 


### PR DESCRIPTION
When we read virtual files via _GMT_Read_VirtualFile_ they are **always** output data produced by a process or module.  However, if we save the virtual file name and another module wish to read that file we would have to have an if-test to determine if we need _GMT_Read_VirtualFile_ or if _GMT_Read_Data_ can handle it.  This PR places such a check inside _GMT_Read_Data_ so that it will  immediately retrieve the data from the virtual output file and return.  I anticipate this to be used in a few places, but for now most likely in **grdimage**.
