### PR TITLE
Let psxy[z] -Sr accept width/height on command line

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -133,8 +133,8 @@
         For allowable geographical units, see `Units`_ [Default is k for km].
 
     **-Sr**
-        **r**\ ectangle. No size needs to be specified, but the x- and
-        y-dimensions must be found in columns 3 and 4.  Alternatively, append **+s**
+        **r**\ ectangle. If *width*/*height* are not given, then the x- and
+        y-dimensions must be found in data columns 3 and 4.  Alternatively, append **+s**
         and then the diagonal corner coordinates are expected in columns 3 and 4.
 
     **-SR**

--- a/doc/rst/source/explain_symbols2.rst_
+++ b/doc/rst/source/explain_symbols2.rst_
@@ -345,8 +345,8 @@
         the quoted text attributes on a segment-by-segment basis.
 
     **-Sr**
-        **r**\ ectangle. No size needs to be specified, but the x- and
-        y-dimensions must be found in columns 4 and 5.
+        **r**\ ectangle. If *width*/*height* are not given, then, the x- and
+        y-dimensions must be found in data columns 4 and 5.
 
     **-SR**
         **R**\ ounded rectangle. No size needs to be specified, but the x-

--- a/doc/rst/source/explain_symbols_only.rst_
+++ b/doc/rst/source/explain_symbols_only.rst_
@@ -104,8 +104,8 @@
         **p**\ oint. No size needs to be specified (1 pixel is used).
 
     **-Sr**
-        **r**\ ectangle. No size needs to be specified, but the x- and
-        y-dimensions must be found in columns 3 and 4.
+        **r**\ ectangle. If *width*/*height* are not given, then the x- and
+        y-dimensions must be found in data columns 3 and 4.
 
     **-SR**
         **R**\ ounded rectangle. No size needs to be specified, but the x-

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15308,7 +15308,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 			p->symbol = PSL_RECT;
 			if (strstr (text, "+s"))	/* Make a rectangle from two corners of a diagonal */
 				p->diagonal = true;
-			p->n_required = 2;
+			p->n_required = (n == 3) ? 0 : 2;	/* If we did not give width/height then we must read them from input */
 			check = false;
 			break;
 		case 'R':

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15308,7 +15308,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 			p->symbol = PSL_RECT;
 			if (strstr (text, "+s"))	/* Make a rectangle from two corners of a diagonal */
 				p->diagonal = true;
-			p->n_required = (n == 3) ? 0 : 2;	/* If we did not give width/height then we must read them from input */
+			p->n_required = (n >= 2) ? 0 : 2;	/* If we did not give width/height then we must read them from input */
 			check = false;
 			break;
 		case 'R':

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -570,7 +570,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	gmt_cont_syntax (API->GMT, 7, 1);
 	GMT_Message (API, GMT_TIME_NONE, "\t     <labelinfo> controls the label attributes.  Choose from\n");
 	gmt_label_syntax (API->GMT, 7, 1);
-	GMT_Message (API, GMT_TIME_NONE, "\t   Rectangles: x- and y-dimensions must be in columns 3-4.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Rectangles: If not given, the x- and y-dimensions must be in columns 3-4.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Append +s if instead the diagonal corner coordinates are given in columns 3-4.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Rounded rectangles: x- and y-dimensions and corner radius must be in columns 3-5.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Vectors: Direction and length must be in columns 3-4.\n");
@@ -1580,16 +1580,20 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 							gmt_geo_polygons (GMT, S_Diag);
 							break;
 						}
-						dim[0] = in[ex1];
-						if (gmt_M_is_dnan (dim[0])) {
-							GMT_Report (API, GMT_MSG_WARNING, "Rounded rectangle width = NaN near line %d. Skipped\n", n_total_read);
-							continue;
+						if (S.n_required >= 2) {	/* Got dimensions from input file */
+							dim[0] = in[ex1];
+							if (gmt_M_is_dnan (dim[0])) {
+								GMT_Report (API, GMT_MSG_WARNING, "Rounded rectangle width = NaN near line %d. Skipped\n", n_total_read);
+								continue;
+							}
+							dim[1] = in[ex2];
+							if (gmt_M_is_dnan (dim[1])) {
+								GMT_Report (API, GMT_MSG_WARNING, "Rounded rectangle height = NaN near line %d. Skipped\n", n_total_read);
+								continue;
+							}
 						}
-						dim[1] = in[ex2];
-						if (gmt_M_is_dnan (dim[1])) {
-							GMT_Report (API, GMT_MSG_WARNING, "Rounded rectangle height = NaN near line %d. Skipped\n", n_total_read);
-							continue;
-						}
+						else	/* Already set dim[0] to S.size_x before loop */
+							dim[1] = S.size_y;
 						PSL_plotsymbol (PSL, plot_x, plot_y, dim, S.symbol);
 						break;
 					case PSL_ROTRECT:

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -259,7 +259,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	gmt_cont_syntax (API->GMT, 7, 1);
 	GMT_Message (API, GMT_TIME_NONE, "\t     <labelinfo> controls the label attributes.  Choose from\n");
 	gmt_label_syntax (API->GMT, 7, 1);
-	GMT_Message (API, GMT_TIME_NONE, "\t   Rectangles: x- and y-dimensions must be in columns 4-5.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Rectangles: If not given. the x- and y-dimensions must be in columns 4-5.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Rounded rectangles: x- and y-dimensions and corner radius must be in columns 3-5.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Vectors: Direction and length must be in columns 4-5.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     If -SV rather than -Sv is use, %s will expect azimuth and\n", mod_name);
@@ -1166,16 +1166,18 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 					data[n].dim[2] = in[ex3];	/* radius */
 					/* Intentionally fall through - to do the rest under regular rectangle */
 				case PSL_RECT:
-					if (gmt_M_is_dnan (in[ex1])) {
-						GMT_Report (API, GMT_MSG_WARNING, "Rounded rectangle width = NaN near line %d. Skipped\n", n_total_read);
-						continue;
+					if (S.n_required == 2) {	/* Got dimensions from input file */
+						if (gmt_M_is_dnan (in[ex1])) {
+							GMT_Report (API, GMT_MSG_WARNING, "Rectangle width = NaN near line %d. Skipped\n", n_total_read);
+							continue;
+						}
+						data[n].dim[0] = in[ex1];
+						if (gmt_M_is_dnan (in[ex2])) {
+							GMT_Report (API, GMT_MSG_WARNING, "Rectangle height = NaN near line %d. Skipped\n", n_total_read);
+							continue;
+						}
+						data[n].dim[1] = in[ex2];	/* y-dim */
 					}
-					if (gmt_M_is_dnan (in[ex2])) {
-						GMT_Report (API, GMT_MSG_WARNING, "Rounded rectangle height = NaN near line %d. Skipped\n", n_total_read);
-						continue;
-					}
-					data[n].dim[0] = in[ex1];	/* x-dim */
-					data[n].dim[1] = in[ex2];	/* y-dim */
 					break;
 				case PSL_ELLIPSE:
 				case PSL_ROTRECT:


### PR DESCRIPTION
If not given, then we read from data file, but this PR will allow you to give -Sr2c/1c, for instance.  We almost had that in the code as the parsing correctly obtains the dimensions, but then we overrode that and insisted we always must read from file.  Will do **-SR**_width_/_height_/_radius_ next.  All test pass as before.
