### PR TITLE
Improve wedges -Sw|W in plot and plot3d

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -139,29 +139,30 @@
         **R**\ ounded rectangle. If *width*/*height*/*radius* are not given, then the
         two dimensions and corner radius must be found in columns 3, 4, and 5.
 
-    **-Sw**
-        Pie **w**\ edge. Start and stop directions (in degrees
-        counter-clockwise from horizontal) for pie slice must be found in
-        columns 3 and 4.  Append /*inner* to select a separate inner diameter [0].
+    **-Sw**\ [*outer*[/*startdir*/*stopdir*]][**+i**\ [*inner*]]
+        pie **w**\ edge. Give the outer diameter *outer*, *startdir* and *stopdir*.
+        These are directions (in degrees counter-clockwise from horizontal) for pie slice.
+        Parameters not appended are read from file starting from column 3.
+        Append **+i and append a nonzero inner diameter *inner* or it will be read last [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);
         if *dr* is appended then we draw all arc lines separated radially by *dr*.
-        Append **+r**\ [*da*] to draw radial lines (at start and stop directions);
+        Append **+r**\ [*da*] to draw radial lines (at start and stop directions)
         if *da* is appended then we draw all radial lines separated angularly by *da*.
-        These spider-web lines are drawn using the current pen, unless **+p**\ *pen* is added.
+        These spider-web lines are drawn using the current pen unless **+p**\ *pen* is added.
 
-    **-SW**
+    **-SW**\ [*outer*[/*startaz*/*stopaz*]][**+i**\ [*inner*]]
         Same as **-Sw**, except azimuths (in degrees east of north) should
         be given instead of the two directions. The azimuths will be mapped
         into angles based on the chosen map projection (**-Sw** leaves the
-        directions unchanged). Specify *size* as a geographical diameter.
-        For allowable geographical units, see `Units`_ [Default is k for km]. To instead
-        specify a diameter in plot units, you must append the desired unit.
-        Append /*inner* to select a separate inner diameter [0].
+        directions unchanged).  The two diameters are expected in geographic units.
+        However, if specified on the command line we also accept plot dimension units.
+        Append **+i and append a nonzero inner diameter *inner* or it will be read last [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);
         if *dr* is appended then we draw all arc lines separated radially by *dr*.
-        Append **+r**\ [*da*] to draw radial lines (at start and stop directions);
+        Append **+r**\ [*da*] to draw radial lines (at start and stop directions)
         if *da* is appended then we draw all radial lines separated angularly by *da*.
         These spider-web lines are drawn using the current pen unless **+p**\ *pen* is added.
+        For allowable geographical units, see `Units`_ [Default is k for km].
 
     Text is normally placed with :doc:`text` but there are times we wish to treat a character
     of even a string as a plottable symbol:

--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -1,5 +1,5 @@
 **-S**\ [*symbol*][*size*]
-    Plot symbols (including vectors, pie slices, fronts, decorated or quoted lines).
+    Plot symbols (including vectors, wedges, fronts, decorated or quoted lines).
     If present, *size* is symbol size in the unit set in
     :doc:`gmt.conf` (unless **c**, **i**, or **p** is appended). If the symbol
     code (see below) is not given it will be read from the last column in
@@ -139,24 +139,24 @@
         **R**\ ounded rectangle. If *width*/*height*/*radius* are not given, then the
         two dimensions and corner radius must be found in columns 3, 4, and 5.
 
-    **-Sw**\ [*outer*[/*startdir*/*stopdir*]][**+i**\ [*inner*]]
-        pie **w**\ edge. Give the outer diameter *outer*, *startdir* and *stopdir*.
-        These are directions (in degrees counter-clockwise from horizontal) for pie slice.
+    **-Sw**\ [*outer*\ [/*startdir*/*stopdir*]][**+i**\ [*inner*]]
+        Pie **w**\ edge. Give the outer diameter *outer*, *startdir* and *stopdir*.
+        These are directions (in degrees counter-clockwise from horizontal) for wedge.
         Parameters not appended are read from file starting from column 3.
-        Append **+i and append a nonzero inner diameter *inner* or it will be read last [0].
+        Append **+i** and append a nonzero inner diameter *inner* or it will be read last [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);
         if *dr* is appended then we draw all arc lines separated radially by *dr*.
         Append **+r**\ [*da*] to draw radial lines (at start and stop directions)
         if *da* is appended then we draw all radial lines separated angularly by *da*.
         These spider-web lines are drawn using the current pen unless **+p**\ *pen* is added.
 
-    **-SW**\ [*outer*[/*startaz*/*stopaz*]][**+i**\ [*inner*]]
+    **-SW**\ [*outer*\ [/*startaz*/*stopaz*]][**+i**\ [*inner*]]
         Same as **-Sw**, except azimuths (in degrees east of north) should
         be given instead of the two directions. The azimuths will be mapped
         into angles based on the chosen map projection (**-Sw** leaves the
         directions unchanged).  The two diameters are expected in geographic units.
         However, if specified on the command line we also accept plot dimension units.
-        Append **+i and append a nonzero inner diameter *inner* or it will be read last [0].
+        Append **+i** and append a nonzero inner diameter *inner* or it will be read last [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);
         if *dr* is appended then we draw all arc lines separated radially by *dr*.
         Append **+r**\ [*da*] to draw radial lines (at start and stop directions)

--- a/doc/rst/source/explain_symbols2.rst_
+++ b/doc/rst/source/explain_symbols2.rst_
@@ -380,24 +380,24 @@
         based on the chosen map projection (**-Sv** leaves the directions
         unchanged.) See `Vector Attributes`_ for specifying attributes.
 
-    **-Sw**\ [*outer*[/*startdir*/*stopdir*]][**+i**\ [*inner*]]
-        pie **w**\ edge. Give the outer diameter *outer*, *startdir* and *stopdir*.
-        These are directions (in degrees counter-clockwise from horizontal) for pie slice.
+    **-Sw**\ [*outer*\ [/*startdir*/*stopdir*]][**+i**\ [*inner*]]
+        Pie **w**\ edge. Give the outer diameter *outer*, *startdir* and *stopdir*.
+        These are directions (in degrees counter-clockwise from horizontal) for wedge.
         Parameters not appended are read from file starting from column 4.
-        Append **+i and append a nonzero inner diameter *inner* or it will be read last [0].
+        Append **+i** and append a nonzero inner diameter *inner* or it will be read last [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);
         if *dr* is appended then we draw all arc lines separated radially by *dr*.
         Append **+r**\ [*da*] to draw radial lines (at start and stop directions)
         if *da* is appended then we draw all radial lines separated angularly by *da*.
         These spider-web lines are drawn using the current pen unless **+p**\ *pen* is added.
 
-    **-SW**\ [*outer*[/*startdir*/*stopdir*]][**+i**\ [*inner*]]
+    **-SW**\ [*outer*\ [/*startdir*/*stopdir*]][**+i**\ [*inner*]]
         Same as **-Sw**, except azimuths (in degrees east of north) should
         be given instead of the two directions. The azimuths will be mapped
         into angles based on the chosen map projection (**-Sw** leaves the
         directions unchanged).The two diameters are expected in geographic units.
         However, if specified on the command line we also accept plot dimension units.
-        Append **+i and append a nonzero inner diameter *inner* or it will be read last [0].
+        Append **+i** and append a nonzero inner diameter *inner* or it will be read last [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);
         if *dr* is appended then we draw all arc lines separated radially by *dr*.
         Append **+r**\ [*da*] to draw radial lines (at start and stop directions)

--- a/doc/rst/source/explain_symbols2.rst_
+++ b/doc/rst/source/explain_symbols2.rst_
@@ -380,29 +380,30 @@
         based on the chosen map projection (**-Sv** leaves the directions
         unchanged.) See `Vector Attributes`_ for specifying attributes.
 
-    **-Sw**
-        pie **w**\ edge. Start and stop directions (in degrees
-        counter-clockwise from horizontal) for pie slice must be found in
-        columns 4 and 5.  Append /*inner* to select a separate inner diameter [0].
+    **-Sw**\ [*outer*[/*startdir*/*stopdir*]][**+i**\ [*inner*]]
+        pie **w**\ edge. Give the outer diameter *outer*, *startdir* and *stopdir*.
+        These are directions (in degrees counter-clockwise from horizontal) for pie slice.
+        Parameters not appended are read from file starting from column 4.
+        Append **+i and append a nonzero inner diameter *inner* or it will be read last [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);
         if *dr* is appended then we draw all arc lines separated radially by *dr*.
         Append **+r**\ [*da*] to draw radial lines (at start and stop directions)
         if *da* is appended then we draw all radial lines separated angularly by *da*.
         These spider-web lines are drawn using the current pen unless **+p**\ *pen* is added.
 
-    **-SW**
+    **-SW**\ [*outer*[/*startdir*/*stopdir*]][**+i**\ [*inner*]]
         Same as **-Sw**, except azimuths (in degrees east of north) should
         be given instead of the two directions. The azimuths will be mapped
         into angles based on the chosen map projection (**-Sw** leaves the
-        directions unchanged). Specify *size* as a geographical diameter.
-        For allowable geographical units, see `Units`_ [Default is k for km]. To instead
-        specify a diameter in plot units, you must append the desired unit.
-        Append /*inner* to select a separate inner diameter [0].
+        directions unchanged).The two diameters are expected in geographic units.
+        However, if specified on the command line we also accept plot dimension units.
+        Append **+i and append a nonzero inner diameter *inner* or it will be read last [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);
         if *dr* is appended then we draw all arc lines separated radially by *dr*.
         Append **+r**\ [*da*] to draw radial lines (at start and stop directions)
         if *da* is appended then we draw all radial lines separated angularly by *da*.
         These spider-web lines are drawn using the current pen unless **+p**\ *pen* is added.
+        For allowable geographical units, see `Units`_ [Default is k for km].
 
     **-Sx**
         cross (x). *size* is diameter of circumscribing circle.

--- a/doc/rst/source/explain_symbols_only.rst_
+++ b/doc/rst/source/explain_symbols_only.rst_
@@ -119,27 +119,30 @@
     **-St**
         **t**\ riangle. *size* is diameter of circumscribing circle.
 
-    **-Sw**
-        pie **w**\ edge. Start and stop directions (in degrees
-        counter-clockwise from horizontal) for pie slice must be found in
-        columns 3 and 4.  Append /*inner* to select a separate inner diameter [0].
+    **-Sw**\ [*outer*[/*startdir*/*stopdir*]][**+i**\ [*inner*]]
+        pie **w**\ edge. Give the outer diameter *outer*, *startdir* and *stopdir*.
+        These are directions (in degrees counter-clockwise from horizontal) for pie slice.
+        Parameters not appended are read from file starting from column 3.
+        Append **+i and append a nonzero inner diameter *inner* or it will be read last [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);
         if *dr* is appended then we draw all arc lines separated radially by *dr*.
         Append **+r**\ [*da*] to draw radial lines (at start and stop directions)
         if *da* is appended then we draw all radial lines separated angularly by *da*.
         These spider-web lines are drawn using the current pen unless **+p**\ *pen* is added.
 
-    **-SW**
+    **-SW**\ [*outer*[/*startdir*/*stopdir*]][**+i**\ [*inner*]]
         Same as **-Sw**, except azimuths (in degrees east of north) should
         be given instead of the two directions. The azimuths will be mapped
         into angles based on the chosen map projection (**-Sw** leaves the
-        directions unchanged).
-        Append /*inner* to select a separate inner diameter [0].
+        directions unchanged).  The two diameters are expected in geographic units.
+        However, if specified on the command line we also accept plot dimension units.
+        Append **+i and append a nonzero inner diameter *inner* or it will be read last [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);
         if *dr* is appended then we draw all arc lines separated radially by *dr*.
         Append **+r**\ [*da*] to draw radial lines (at start and stop directions)
         if *da* is appended then we draw all radial lines separated angularly by *da*.
         These spider-web lines are drawn using the current pen unless **+p**\ *pen* is added.
+        For allowable geographical units, see `Units`_ [Default is k for km].
 
     **-Sx**
         cross (x). *size* is diameter of circumscribing circle.

--- a/doc/rst/source/explain_symbols_only.rst_
+++ b/doc/rst/source/explain_symbols_only.rst_
@@ -119,24 +119,24 @@
     **-St**
         **t**\ riangle. *size* is diameter of circumscribing circle.
 
-    **-Sw**\ [*outer*[/*startdir*/*stopdir*]][**+i**\ [*inner*]]
-        pie **w**\ edge. Give the outer diameter *outer*, *startdir* and *stopdir*.
-        These are directions (in degrees counter-clockwise from horizontal) for pie slice.
+    **-Sw**\ [*outer*\ [/*startdir*/*stopdir*]][**+i**\ [*inner*]]
+        Pie **w**\ edge. Give the outer diameter *outer*, *startdir* and *stopdir*.
+        These are directions (in degrees counter-clockwise from horizontal) for wedge.
         Parameters not appended are read from file starting from column 3.
-        Append **+i and append a nonzero inner diameter *inner* or it will be read last [0].
+        Append **+i** and append a nonzero inner diameter *inner* or it will be read last [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);
         if *dr* is appended then we draw all arc lines separated radially by *dr*.
         Append **+r**\ [*da*] to draw radial lines (at start and stop directions)
         if *da* is appended then we draw all radial lines separated angularly by *da*.
         These spider-web lines are drawn using the current pen unless **+p**\ *pen* is added.
 
-    **-SW**\ [*outer*[/*startdir*/*stopdir*]][**+i**\ [*inner*]]
+    **-SW**\ [*outer*\ [/*startdir*/*stopdir*]][**+i**\ [*inner*]]
         Same as **-Sw**, except azimuths (in degrees east of north) should
         be given instead of the two directions. The azimuths will be mapped
         into angles based on the chosen map projection (**-Sw** leaves the
         directions unchanged).  The two diameters are expected in geographic units.
         However, if specified on the command line we also accept plot dimension units.
-        Append **+i and append a nonzero inner diameter *inner* or it will be read last [0].
+        Append **+i** and append a nonzero inner diameter *inner* or it will be read last [0].
         Append **+a**\ [*dr*] to draw the arc line (at inner and outer diameter);
         if *dr* is appended then we draw all arc lines separated radially by *dr*.
         Append **+r**\ [*da*] to draw radial lines (at start and stop directions)

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14879,7 +14879,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 		}
 		col_off++;
 	}
-	else if (strchr (allowed_symbols[mode], (int) text[0]) && (text[1] == '\n' || !text[1]) && !strchr ("EJW", text[0])) {
+	else if (strchr (allowed_symbols[mode], (int) text[0]) && (text[1] == '\n' || !text[1]) && !strchr ("EJWw", text[0])) {
 		/* Symbol, but no size given (size assumed given on command line) */
 		sscanf (text, "%c", &symbol_type);
 		if (p->size_x == 0.0) p->size_x = p->given_size_x;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14997,8 +14997,12 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad argument -S%s\n", text);
 					decode_error++;
 			}
+			if (p->w_get_do && p->read_symbol_cmd && p->size_x > 0.0) {	/* Got a fixed size via -S<size> and must honor it throughout as diameter */
+				p->w_radius = p->size_x;
+				p->w_get_do = false;
+			}
 			check = false;
-			if (n == 1) {	/* Got at least the diameter */
+			if (n >= 1) {	/* Got at least the diameter */
 				p->w_radius = gmtinit_get_diameter (GMT, symbol_type, txt_a, &p->w_active);
 			}
 			if (n_slash == 1)	/* Deprecated syntax */
@@ -15007,7 +15011,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 				p->size_x = p->given_size_x = atof (txt_b);
 				p->size_y = p->given_size_y = atof (txt_c);
 			}
-			if (c && c[0]) {	/* Now process any modifiers (other than +i) */
+			if (c) {	/* Now process any modifiers (other than +i) */
 				char q[GMT_LEN256] = {""};
 				unsigned int pos = 0, error = 0;
 				c[0] = '+';	/* Restore that character */

--- a/src/gmt_plot.h
+++ b/src/gmt_plot.h
@@ -162,6 +162,9 @@ struct GMT_SYMBOL {
 	unsigned int w_mode;	/* Distance mode */
 	enum GMT_enum_wedgetype w_type;	/* Wedge type */
 	bool w_active;
+	bool w_get_do;	/* True if we must read outer diameter */
+	bool w_get_di;	/* True if we must read inner diameter */
+	bool w_get_a;	/* True if we must read the two angles */
 
 	/* These apply to vectors */
 

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1832,7 +1832,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 								GMT_Report (API, GMT_MSG_WARNING, "Wedge inner diameter = NaN near line %d. Skipped\n", n_total_read);
 								continue;
 							}
-							S.w_radius_i = in[col++];
+							S.w_radius_i = in[col];
 						}
 						if (S.convert_angles) {
 							if (gmt_M_is_cartesian (GMT, GMT_IN)) {
@@ -1844,6 +1844,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 								dim[2] = gmt_azim_to_angle (GMT, in[GMT_X], in[GMT_Y], 0.1, dim[2]);
 								dim[1] = gmt_azim_to_angle (GMT, in[GMT_X], in[GMT_Y], 0.1, dim[1]);
 							}
+							gmt_M_double_swap (dim[1], dim[2]);	/* Must switch the order of the angles */
 						}
 						if (S.w_active)	/* Geo-wedge */
 							gmt_geo_wedge (GMT, in[GMT_X], in[GMT_Y], S.w_radius_i, dim[0], S.w_dr, dim[1], dim[2], S.w_da, S.w_type, fill_active || get_rgb, outline_active);

--- a/test/psxy/varwedges.ps
+++ b/test/psxy/varwedges.ps
@@ -1,0 +1,5503 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.2.0_8ef2629-dirty_2020.09.08 [64-bit] Document from psbasemap
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Tue Sep  8 11:15:20 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+-3600 PSL_xorig sub PSL_page_xsize 2 div add 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/6/0/3 -Jx1i -P -Xc -Bafg -K
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%GMTBoundingBox: -216 72 432 216
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+4 W
+0 0 M
+0 3600 D
+S
+1200 0 M
+0 3600 D
+S
+2400 0 M
+0 3600 D
+S
+3600 0 M
+0 3600 D
+S
+4800 0 M
+0 3600 D
+S
+6000 0 M
+0 3600 D
+S
+7200 0 M
+0 3600 D
+S
+0 0 M
+7200 0 D
+S
+0 1200 M
+7200 0 D
+S
+0 2400 M
+7200 0 D
+S
+0 3600 M
+7200 0 D
+S
+/PSL_slant_y 0 def
+2 setlinecap
+25 W
+N 0 3600 M 0 -3600 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 1200 M -83 0 D S
+N 0 2400 M -83 0 D S
+N 0 3600 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) sw mx
+(1) sw mx
+(2) sw mx
+(3) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+1200 PSL_A0_y MM
+(1) mr Z
+2400 PSL_A0_y MM
+(2) mr Z
+3600 PSL_A0_y MM
+(3) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 240 M -42 0 D S
+N 0 480 M -42 0 D S
+N 0 720 M -42 0 D S
+N 0 960 M -42 0 D S
+N 0 1440 M -42 0 D S
+N 0 1680 M -42 0 D S
+N 0 1920 M -42 0 D S
+N 0 2160 M -42 0 D S
+N 0 2640 M -42 0 D S
+N 0 2880 M -42 0 D S
+N 0 3120 M -42 0 D S
+N 0 3360 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7200 0 T
+25 W
+N 0 3600 M 0 -3600 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 1200 M 83 0 D S
+N 0 2400 M 83 0 D S
+N 0 3600 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+(0) sw mx
+(1) sw mx
+(2) sw mx
+(3) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) mr Z
+1200 PSL_A0_y MM
+(1) mr Z
+2400 PSL_A0_y MM
+(2) mr Z
+3600 PSL_A0_y MM
+(3) mr Z
+N 0 240 M 42 0 D S
+N 0 480 M 42 0 D S
+N 0 720 M 42 0 D S
+N 0 960 M 42 0 D S
+N 0 1440 M 42 0 D S
+N 0 1680 M 42 0 D S
+N 0 1920 M 42 0 D S
+N 0 2160 M 42 0 D S
+N 0 2640 M 42 0 D S
+N 0 2880 M 42 0 D S
+N 0 3120 M 42 0 D S
+N 0 3360 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7200 0 T
+25 W
+N 0 0 M 7200 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 1200 0 M 0 -83 D S
+N 2400 0 M 0 -83 D S
+N 3600 0 M 0 -83 D S
+N 4800 0 M 0 -83 D S
+N 6000 0 M 0 -83 D S
+N 7200 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(1) sh mx
+(2) sh mx
+(3) sh mx
+(4) sh mx
+(5) sh mx
+(6) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+1200 PSL_A0_y MM
+(1) bc Z
+2400 PSL_A0_y MM
+(2) bc Z
+3600 PSL_A0_y MM
+(3) bc Z
+4800 PSL_A0_y MM
+(4) bc Z
+6000 PSL_A0_y MM
+(5) bc Z
+7200 PSL_A0_y MM
+(6) bc Z
+N 240 0 M 0 -42 D S
+N 480 0 M 0 -42 D S
+N 720 0 M 0 -42 D S
+N 960 0 M 0 -42 D S
+N 1440 0 M 0 -42 D S
+N 1680 0 M 0 -42 D S
+N 1920 0 M 0 -42 D S
+N 2160 0 M 0 -42 D S
+N 2640 0 M 0 -42 D S
+N 2880 0 M 0 -42 D S
+N 3120 0 M 0 -42 D S
+N 3360 0 M 0 -42 D S
+N 3840 0 M 0 -42 D S
+N 4080 0 M 0 -42 D S
+N 4320 0 M 0 -42 D S
+N 4560 0 M 0 -42 D S
+N 5040 0 M 0 -42 D S
+N 5280 0 M 0 -42 D S
+N 5520 0 M 0 -42 D S
+N 5760 0 M 0 -42 D S
+N 6240 0 M 0 -42 D S
+N 6480 0 M 0 -42 D S
+N 6720 0 M 0 -42 D S
+N 6960 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3600 T
+25 W
+N 0 0 M 7200 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 1200 0 M 0 83 D S
+N 2400 0 M 0 83 D S
+N 3600 0 M 0 83 D S
+N 4800 0 M 0 83 D S
+N 6000 0 M 0 83 D S
+N 7200 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+(0) sh mx
+(1) sh mx
+(2) sh mx
+(3) sh mx
+(4) sh mx
+(5) sh mx
+(6) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) bc Z
+1200 PSL_A0_y MM
+(1) bc Z
+2400 PSL_A0_y MM
+(2) bc Z
+3600 PSL_A0_y MM
+(3) bc Z
+4800 PSL_A0_y MM
+(4) bc Z
+6000 PSL_A0_y MM
+(5) bc Z
+7200 PSL_A0_y MM
+(6) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 240 0 M 0 42 D S
+N 480 0 M 0 42 D S
+N 720 0 M 0 42 D S
+N 960 0 M 0 42 D S
+N 1440 0 M 0 42 D S
+N 1680 0 M 0 42 D S
+N 1920 0 M 0 42 D S
+N 2160 0 M 0 42 D S
+N 2640 0 M 0 42 D S
+N 2880 0 M 0 42 D S
+N 3120 0 M 0 42 D S
+N 3360 0 M 0 42 D S
+N 3840 0 M 0 42 D S
+N 4080 0 M 0 42 D S
+N 4320 0 M 0 42 D S
+N 4560 0 M 0 42 D S
+N 5040 0 M 0 42 D S
+N 5280 0 M 0 42 D S
+N 5520 0 M 0 42 D S
+N 5760 0 M 0 42 D S
+N 6240 0 M 0 42 D S
+N 6480 0 M 0 42 D S
+N 6720 0 M 0 42 D S
+N 6960 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3600 T
+0 setlinecap
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R0/6/0/3 -Jx1i -O -K -Sw2i -Gred -W2p
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 3600 D
+-7200 0 D
+P
+PSL_clip N
+/PSL_spiderpen {33 W 0 A [] 0 B} def
+33 W
+V
+{1 0 0 C} FS
+O1
+1200 30 100 600 600 Sw
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R0/6/0/3 -Jx1i -O -K -Sw -Gred
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 3600 D
+-7200 0 D
+P
+PSL_clip N
+4 W
+V
+{1 0 0 C} FS
+1200 30 100 3000 600 Sw
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R0/6/0/3 -Jx1i -O -K -Sw2i/30/100 -W1p
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 3600 D
+-7200 0 D
+P
+PSL_clip N
+/PSL_spiderpen {17 W 0 A [] 0 B} def
+17 W
+V
+O1
+1200 30 100 5400 600 Sw
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R0/6/0/3 -Jx1i -O -K -Sw2i+a+p2p
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 3600 D
+-7200 0 D
+P
+PSL_clip N
+/PSL_spiderpen {33 W 0 A [] 0 B} def
+4 W
+V
+V PSL_spiderpen
+N 600 2100 1200 30 100 arc S
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R0/6/0/3 -Jx1i -O -K -Sw+r+p2p
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 3600 D
+-7200 0 D
+P
+PSL_clip N
+/PSL_spiderpen {33 W 0 A [] 0 B} def
+4 W
+V
+V PSL_spiderpen
+4039 2700 M
+-1039 -600 D
+-208 1182 D
+S
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R0/6/0/3 -Jx1i -O -K -Sw2i/30/100+a+p2p -Gred
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 3600 D
+-7200 0 D
+P
+PSL_clip N
+/PSL_spiderpen {33 W 0 A [] 0 B} def
+4 W
+V
+{1 0 0 C} FS
+1200 30 100 5400 2100 2 copy M 5 2 roll arc fs
+V PSL_spiderpen
+N 5400 2100 1200 30 100 arc S
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 4200 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -Rg -JG0/25/6i -O -Bafg -K -Y3.5i
+%@PROJ: ortho 0.00000000 360.00000000 -90.00000000 90.00000000 -6371008.771 6371008.771 -6371008.771 6371008.771 +unavailable +a=6371008.771 +b=6371008.771 +units=m +no_defs
+%%BeginObject PSL_Layer_8
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+4 W
+3600 0 M
+0 6718 D
+S
+4005 23 M
+29 5 D
+18 6 D
+22 9 D
+26 15 D
+30 22 D
+28 27 D
+36 43 D
+20 27 D
+26 42 D
+29 54 D
+24 53 D
+23 57 D
+25 72 D
+16 47 D
+31 113 D
+31 135 D
+29 160 D
+22 146 D
+23 199 D
+14 166 D
+14 231 D
+7 192 D
+3 172 D
+1 186 D
+-4 245 D
+-10 271 D
+-16 276 D
+-15 203 D
+-16 184 D
+-29 292 D
+-28 234 D
+-40 290 D
+-28 181 D
+-38 227 D
+-36 194 D
+-38 191 D
+-34 160 D
+-70 299 D
+-49 188 D
+-42 150 D
+-57 187 D
+-49 149 D
+-36 102 D
+-46 122 D
+-32 80 D
+-25 58 D
+-47 106 D
+-30 62 D
+-36 69 D
+S
+4453 103 M
+12 2 D
+59 19 D
+50 19 D
+41 19 D
+64 36 D
+54 37 D
+37 29 D
+37 32 D
+36 34 D
+56 60 D
+53 66 D
+44 62 D
+60 97 D
+11 21 D
+28 53 D
+32 66 D
+40 92 D
+28 74 D
+22 63 D
+27 84 D
+29 102 D
+29 121 D
+15 73 D
+18 97 D
+19 124 D
+12 87 D
+17 172 D
+11 177 D
+4 121 D
+2 132 D
+-1 134 D
+-7 191 D
+-8 129 D
+-13 159 D
+-12 122 D
+-25 199 D
+-23 153 D
+-21 124 D
+-25 134 D
+-41 201 D
+-47 200 D
+-50 190 D
+-46 160 D
+-43 139 D
+-73 220 D
+-73 198 D
+-63 158 D
+-55 129 D
+-49 109 D
+-66 140 D
+-64 128 D
+-58 109 D
+-21 39 D
+-13 22 D
+-8 16 D
+-91 154 D
+-62 99 D
+-81 121 D
+-60 85 D
+-84 111 D
+-42 53 D
+-76 90 D
+-72 79 D
+-53 56 D
+-59 57 D
+-5 4 D
+-4 5 D
+-34 31 D
+-15 13 D
+S
+5001 284 M
+46 20 D
+51 25 D
+50 26 D
+21 13 D
+49 29 D
+58 39 D
+21 15 D
+61 46 D
+45 37 D
+4 5 D
+30 26 D
+19 17 D
+4 5 D
+24 22 D
+9 10 D
+5 4 D
+9 10 D
+5 4 D
+71 79 D
+59 73 D
+29 38 D
+36 51 D
+49 76 D
+36 60 D
+51 95 D
+41 85 D
+50 116 D
+24 64 D
+25 72 D
+28 88 D
+45 168 D
+25 119 D
+21 121 D
+15 108 D
+14 126 D
+10 146 D
+4 149 D
+1 71 D
+-4 161 D
+-8 136 D
+-11 129 D
+-18 157 D
+-27 176 D
+-30 159 D
+-30 140 D
+-42 168 D
+-29 103 D
+-39 130 D
+-39 121 D
+-46 129 D
+-49 128 D
+-41 99 D
+-11 28 D
+-71 161 D
+-72 150 D
+-72 138 D
+-75 137 D
+-84 141 D
+-82 130 D
+-69 103 D
+-49 71 D
+-107 144 D
+-58 73 D
+-11 15 D
+-89 107 D
+-72 83 D
+-7 6 D
+-36 41 D
+-7 6 D
+-55 60 D
+-7 6 D
+-37 39 D
+-13 12 D
+-6 7 D
+-45 43 D
+-12 13 D
+-110 101 D
+-39 35 D
+-99 83 D
+-67 52 D
+-13 11 D
+-87 65 D
+-102 70 D
+-21 13 D
+-13 9 D
+-28 17 D
+-13 9 D
+-96 58 D
+-76 42 D
+S
+5726 695 M
+70 53 D
+77 64 D
+74 67 D
+5 6 D
+66 65 D
+5 6 D
+6 5 D
+67 75 D
+79 96 D
+38 50 D
+9 13 D
+58 84 D
+42 67 D
+9 13 D
+63 111 D
+47 93 D
+53 117 D
+31 76 D
+39 108 D
+39 126 D
+34 130 D
+26 123 D
+20 118 D
+21 171 D
+10 148 D
+3 106 D
+1 89 D
+-6 170 D
+-11 135 D
+-19 164 D
+-16 100 D
+-24 127 D
+-19 91 D
+-29 119 D
+-41 145 D
+-43 136 D
+-55 153 D
+-43 107 D
+-30 72 D
+-55 123 D
+-21 44 D
+-9 17 D
+-8 18 D
+-9 17 D
+-44 87 D
+-42 77 D
+-48 85 D
+-81 134 D
+-74 115 D
+-72 105 D
+-41 55 D
+-82 110 D
+-18 23 D
+-13 15 D
+-37 46 D
+-24 30 D
+-32 37 D
+-64 74 D
+-33 36 D
+-13 15 D
+-20 21 D
+-13 15 D
+-109 112 D
+-7 6 D
+-27 28 D
+-70 67 D
+-15 13 D
+-35 33 D
+-29 25 D
+-80 70 D
+-52 43 D
+-113 90 D
+-115 85 D
+-54 38 D
+-32 21 D
+-15 11 D
+-127 82 D
+-88 53 D
+-17 9 D
+-65 37 D
+-106 56 D
+-49 25 D
+-125 59 D
+-83 36 D
+-92 37 D
+-110 41 D
+-42 14 D
+S
+6640 1672 M
+37 60 D
+26 44 D
+29 53 D
+13 22 D
+20 38 D
+19 39 D
+37 77 D
+41 95 D
+61 161 D
+8 25 D
+38 124 D
+28 109 D
+23 102 D
+17 94 D
+14 96 D
+11 87 D
+10 122 D
+5 142 D
+-1 142 D
+-6 116 D
+-7 81 D
+-15 134 D
+-20 125 D
+-23 116 D
+-31 133 D
+-35 124 D
+-31 97 D
+-49 140 D
+-49 121 D
+-38 86 D
+-35 76 D
+-51 102 D
+-45 83 D
+-47 82 D
+-34 57 D
+-61 97 D
+-48 72 D
+-17 23 D
+-33 47 D
+-63 85 D
+-47 61 D
+-30 38 D
+-25 29 D
+-37 45 D
+-51 58 D
+-79 86 D
+-81 84 D
+-105 101 D
+-36 33 D
+-22 19 D
+-51 46 D
+-38 31 D
+-22 19 D
+-91 74 D
+-70 54 D
+-119 86 D
+-81 55 D
+-124 78 D
+-68 41 D
+-59 34 D
+-26 14 D
+-112 60 D
+-79 39 D
+-97 46 D
+-117 51 D
+-136 54 D
+-119 42 D
+-138 44 D
+-75 22 D
+-103 27 D
+-103 24 D
+-94 20 D
+S
+7200 3600 M
+-1 89 D
+-6 115 D
+-12 133 D
+-14 106 D
+-23 131 D
+-35 157 D
+-36 129 D
+-42 128 D
+-21 59 D
+-50 125 D
+-52 115 D
+-52 106 D
+-61 111 D
+-37 63 D
+-78 123 D
+-11 15 D
+-57 83 D
+-61 80 D
+-11 15 D
+-81 100 D
+-80 91 D
+-56 61 D
+-7 6 D
+-32 34 D
+-7 6 D
+-6 7 D
+-7 6 D
+-13 14 D
+-7 6 D
+-6 7 D
+-96 89 D
+-91 80 D
+-80 66 D
+-23 17 D
+-37 29 D
+-38 28 D
+-69 50 D
+-55 37 D
+-15 11 D
+-120 77 D
+-99 58 D
+-84 46 D
+-59 31 D
+-103 51 D
+-123 56 D
+-125 51 D
+-109 40 D
+-101 35 D
+-139 42 D
+-122 32 D
+-143 33 D
+-154 29 D
+-145 21 D
+-184 20 D
+-10 0 D
+S
+6640 5528 M
+-41 63 D
+-44 64 D
+-25 34 D
+-31 42 D
+-11 13 D
+-10 14 D
+-17 20 D
+-21 27 D
+-67 78 D
+-70 76 D
+-42 43 D
+-94 90 D
+-32 29 D
+-33 28 D
+-53 45 D
+-41 32 D
+-13 11 D
+-112 83 D
+-87 59 D
+-15 9 D
+-67 42 D
+-91 53 D
+-86 46 D
+-111 55 D
+-114 50 D
+-125 49 D
+-137 47 D
+-121 36 D
+-141 35 D
+-108 23 D
+-135 23 D
+-129 17 D
+-110 11 D
+-112 7 D
+-122 4 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-9 0 D
+-10 0 D
+-9 0 D
+-10 -1 D
+-9 0 D
+-10 0 D
+-9 0 D
+S
+5726 6505 M
+-48 34 D
+-44 30 D
+-118 73 D
+-82 44 D
+-83 41 D
+-121 52 D
+-73 28 D
+-97 32 D
+-83 24 D
+-108 27 D
+-101 20 D
+-87 14 D
+-145 17 D
+-122 7 D
+-90 2 D
+-9 0 D
+-8 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 -1 D
+-8 0 D
+-9 0 D
+-8 0 D
+-8 -1 D
+-9 0 D
+-8 0 D
+-8 -1 D
+-9 0 D
+-8 0 D
+-8 -1 D
+-9 0 D
+-8 -1 D
+-8 0 D
+-9 -1 D
+-8 0 D
+-9 -1 D
+-8 -1 D
+-8 0 D
+-9 -1 D
+-8 -1 D
+-8 0 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-8 0 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+-8 -1 D
+-9 -2 D
+-8 -1 D
+-9 -1 D
+-8 -1 D
+S
+5001 6916 M
+-47 19 D
+-89 31 D
+-85 24 D
+-99 21 D
+-95 14 D
+-110 9 D
+-7 0 D
+-6 0 D
+-118 1 D
+-7 -1 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-6 -2 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-6 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-6 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-6 -2 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+S
+4453 7097 M
+-49 11 D
+-62 8 D
+-72 3 D
+-9 0 D
+-9 -1 D
+-10 0 D
+-9 0 D
+-9 -1 D
+-9 0 D
+-9 -1 D
+-10 -1 D
+-9 -1 D
+-9 -1 D
+-9 -1 D
+-10 -1 D
+-9 -2 D
+-9 -1 D
+-10 -2 D
+-9 -1 D
+-10 -2 D
+-9 -2 D
+-9 -2 D
+-10 -2 D
+-9 -2 D
+-10 -3 D
+-9 -2 D
+-10 -2 D
+-9 -3 D
+-10 -3 D
+-9 -3 D
+-10 -2 D
+-9 -3 D
+-10 -4 D
+-9 -3 D
+-10 -3 D
+-10 -4 D
+-9 -3 D
+-10 -4 D
+-9 -3 D
+-10 -4 D
+-10 -4 D
+-9 -4 D
+-10 -4 D
+-10 -5 D
+-9 -4 D
+-10 -4 D
+-19 -10 D
+-10 -4 D
+-20 -10 D
+-19 -10 D
+-20 -11 D
+-19 -11 D
+S
+4005 7177 M
+-37 1 D
+-5 -1 D
+-5 0 D
+-4 -1 D
+-5 0 D
+-5 -1 D
+-4 -1 D
+-5 -1 D
+-5 -1 D
+-5 -1 D
+-4 -2 D
+-5 -1 D
+-5 -2 D
+-5 -2 D
+-4 -1 D
+-5 -2 D
+-5 -2 D
+-5 -2 D
+-10 -5 D
+-9 -5 D
+-10 -5 D
+-10 -6 D
+-10 -6 D
+-14 -10 D
+-20 -15 D
+-30 -25 D
+-35 -34 D
+-45 -52 D
+-13 -16 D
+S
+3600 7200 M
+0 -217 D
+S
+3195 7177 M
+37 1 D
+33 -5 D
+24 -7 D
+34 -14 D
+39 -22 D
+34 -25 D
+30 -25 D
+35 -34 D
+45 -52 D
+13 -16 D
+S
+2747 7097 M
+49 11 D
+62 8 D
+72 3 D
+64 -3 D
+65 -8 D
+66 -13 D
+48 -13 D
+28 -8 D
+87 -32 D
+58 -26 D
+58 -29 D
+39 -22 D
+S
+2199 6916 M
+47 19 D
+89 31 D
+85 24 D
+99 21 D
+95 14 D
+110 9 D
+131 1 D
+87 -5 D
+87 -9 D
+82 -12 D
+82 -16 D
+75 -18 D
+110 -31 D
+S
+1474 6505 M
+48 34 D
+44 30 D
+118 73 D
+82 44 D
+83 41 D
+121 52 D
+73 28 D
+97 32 D
+83 24 D
+108 27 D
+101 20 D
+87 14 D
+145 17 D
+122 7 D
+90 2 D
+108 -1 D
+109 -6 D
+109 -10 D
+126 -16 D
+S
+560 5528 M
+41 63 D
+44 64 D
+25 34 D
+31 42 D
+11 13 D
+10 14 D
+17 20 D
+21 27 D
+67 78 D
+70 76 D
+42 43 D
+94 90 D
+32 29 D
+33 28 D
+53 45 D
+41 32 D
+13 11 D
+112 83 D
+87 59 D
+15 9 D
+67 42 D
+91 53 D
+86 46 D
+111 55 D
+114 50 D
+125 49 D
+137 47 D
+121 36 D
+141 35 D
+108 23 D
+135 23 D
+129 17 D
+110 11 D
+112 7 D
+122 4 D
+169 -1 D
+S
+0 3600 M
+1 89 D
+6 115 D
+12 133 D
+14 106 D
+23 131 D
+35 157 D
+36 129 D
+42 128 D
+21 59 D
+50 125 D
+52 115 D
+52 106 D
+61 111 D
+37 63 D
+78 123 D
+11 15 D
+57 83 D
+61 80 D
+11 15 D
+81 100 D
+80 91 D
+56 61 D
+7 6 D
+32 34 D
+7 6 D
+6 7 D
+7 6 D
+13 14 D
+7 6 D
+6 7 D
+96 89 D
+91 80 D
+80 66 D
+23 17 D
+37 29 D
+38 28 D
+69 50 D
+55 37 D
+15 11 D
+120 77 D
+99 58 D
+84 46 D
+59 31 D
+103 51 D
+123 56 D
+125 51 D
+109 40 D
+101 35 D
+139 42 D
+122 32 D
+143 33 D
+154 29 D
+145 21 D
+184 20 D
+10 0 D
+S
+560 1672 M
+-37 60 D
+-26 44 D
+-29 53 D
+-13 22 D
+-20 38 D
+-19 39 D
+-37 77 D
+-41 95 D
+-61 161 D
+-8 25 D
+-38 124 D
+-28 109 D
+-23 102 D
+-17 94 D
+-14 96 D
+-11 87 D
+-10 122 D
+-5 142 D
+1 142 D
+6 116 D
+7 81 D
+15 134 D
+20 125 D
+23 116 D
+31 133 D
+35 124 D
+31 97 D
+49 140 D
+49 121 D
+38 86 D
+35 76 D
+51 102 D
+45 83 D
+47 82 D
+34 57 D
+61 97 D
+48 72 D
+17 23 D
+33 47 D
+63 85 D
+47 61 D
+30 38 D
+25 29 D
+37 45 D
+51 58 D
+79 86 D
+81 84 D
+105 101 D
+36 33 D
+22 19 D
+51 46 D
+38 31 D
+22 19 D
+91 74 D
+70 54 D
+119 86 D
+81 55 D
+124 78 D
+68 41 D
+59 34 D
+26 14 D
+112 60 D
+79 39 D
+97 46 D
+117 51 D
+136 54 D
+119 42 D
+138 44 D
+75 22 D
+103 27 D
+103 24 D
+94 20 D
+S
+1474 695 M
+-70 53 D
+-77 64 D
+-74 67 D
+-5 6 D
+-66 65 D
+-5 6 D
+-6 5 D
+-67 75 D
+-79 96 D
+-38 50 D
+-9 13 D
+-58 84 D
+-42 67 D
+-9 13 D
+-63 111 D
+-47 93 D
+-53 117 D
+-31 76 D
+-39 108 D
+-39 126 D
+-34 130 D
+-26 123 D
+-20 118 D
+-21 171 D
+-10 148 D
+-3 106 D
+-1 89 D
+6 170 D
+11 135 D
+19 164 D
+16 100 D
+24 127 D
+19 91 D
+29 119 D
+41 145 D
+43 136 D
+55 153 D
+43 107 D
+30 72 D
+55 123 D
+21 44 D
+9 17 D
+8 18 D
+9 17 D
+44 87 D
+42 77 D
+48 85 D
+81 134 D
+74 115 D
+72 105 D
+41 55 D
+82 110 D
+18 23 D
+13 15 D
+37 46 D
+24 30 D
+32 37 D
+64 74 D
+33 36 D
+13 15 D
+20 21 D
+13 15 D
+109 112 D
+7 6 D
+27 28 D
+70 67 D
+15 13 D
+35 33 D
+29 25 D
+80 70 D
+52 43 D
+113 90 D
+115 85 D
+54 38 D
+32 21 D
+15 11 D
+127 82 D
+88 53 D
+17 9 D
+65 37 D
+106 56 D
+49 25 D
+125 59 D
+83 36 D
+92 37 D
+110 41 D
+42 14 D
+S
+2199 284 M
+-46 20 D
+-51 25 D
+-50 26 D
+-21 13 D
+-49 29 D
+-58 39 D
+-21 15 D
+-61 46 D
+-45 37 D
+-4 5 D
+-30 26 D
+-19 17 D
+-4 5 D
+-24 22 D
+-9 10 D
+-5 4 D
+-9 10 D
+-5 4 D
+-71 79 D
+-59 73 D
+-29 38 D
+-36 51 D
+-49 76 D
+-36 60 D
+-51 95 D
+-41 85 D
+-50 116 D
+-24 64 D
+-25 72 D
+-28 88 D
+-45 168 D
+-25 119 D
+-21 121 D
+-15 108 D
+-14 126 D
+-10 146 D
+-4 149 D
+-1 71 D
+4 161 D
+8 136 D
+11 129 D
+18 157 D
+27 176 D
+30 159 D
+30 140 D
+42 168 D
+29 103 D
+39 130 D
+39 121 D
+46 129 D
+49 128 D
+41 99 D
+11 28 D
+71 161 D
+72 150 D
+72 138 D
+75 137 D
+84 141 D
+82 130 D
+69 103 D
+49 71 D
+107 144 D
+58 73 D
+11 15 D
+89 107 D
+72 83 D
+7 6 D
+36 41 D
+7 6 D
+55 60 D
+7 6 D
+37 39 D
+13 12 D
+6 7 D
+45 43 D
+12 13 D
+110 101 D
+39 35 D
+99 83 D
+67 52 D
+13 11 D
+87 65 D
+102 70 D
+21 13 D
+13 9 D
+28 17 D
+13 9 D
+96 58 D
+76 42 D
+S
+2747 103 M
+-12 2 D
+-59 19 D
+-50 19 D
+-41 19 D
+-64 36 D
+-54 37 D
+-37 29 D
+-37 32 D
+-36 34 D
+-56 60 D
+-53 66 D
+-44 62 D
+-60 97 D
+-11 21 D
+-28 53 D
+-32 66 D
+-40 92 D
+-28 74 D
+-22 63 D
+-27 84 D
+-29 102 D
+-29 121 D
+-15 73 D
+-18 97 D
+-19 124 D
+-12 87 D
+-17 172 D
+-11 177 D
+-4 121 D
+-2 132 D
+1 134 D
+7 191 D
+8 129 D
+13 159 D
+12 122 D
+25 199 D
+23 153 D
+21 124 D
+25 134 D
+41 201 D
+47 200 D
+50 190 D
+46 160 D
+43 139 D
+73 220 D
+73 198 D
+63 158 D
+55 129 D
+49 109 D
+66 140 D
+64 128 D
+58 109 D
+21 39 D
+13 22 D
+8 16 D
+91 154 D
+62 99 D
+81 121 D
+60 85 D
+84 111 D
+42 53 D
+76 90 D
+72 79 D
+53 56 D
+59 57 D
+5 4 D
+4 5 D
+34 31 D
+15 13 D
+S
+3195 23 M
+-29 5 D
+-18 6 D
+-22 9 D
+-26 15 D
+-30 22 D
+-28 27 D
+-36 43 D
+-20 27 D
+-26 42 D
+-29 54 D
+-24 53 D
+-23 57 D
+-25 72 D
+-16 47 D
+-31 113 D
+-31 135 D
+-29 160 D
+-22 146 D
+-23 199 D
+-14 166 D
+-14 231 D
+-7 192 D
+-3 172 D
+-1 186 D
+4 245 D
+10 271 D
+16 276 D
+15 203 D
+16 184 D
+29 292 D
+28 234 D
+40 290 D
+28 181 D
+38 227 D
+36 194 D
+38 191 D
+34 160 D
+70 299 D
+49 188 D
+42 150 D
+57 187 D
+49 149 D
+36 102 D
+46 122 D
+32 80 D
+25 58 D
+47 106 D
+30 62 D
+36 69 D
+S
+3600 6718 M
+0 145 D
+S
+3914 6850 M
+-120 8 D
+-129 4 D
+-10 0 D
+-55 1 D
+S
+3600 6983 M
+0 -120 D
+S
+3286 6850 M
+120 8 D
+129 4 D
+65 1 D
+S
+3600 6718 M
+51 1 D
+53 6 D
+47 9 D
+45 13 D
+28 10 D
+37 19 D
+1 2 D
+8 5 D
+5 3 D
+1 2 D
+7 5 D
+3 2 D
+2 3 D
+2 1 D
+15 19 D
+2 5 D
+4 10 D
+3 18 D
+-3 18 D
+-5 11 D
+-9 13 D
+-12 13 D
+-2 1 D
+-1 2 D
+-5 3 D
+-1 2 D
+-13 8 D
+-1 2 D
+-25 13 D
+-24 11 D
+-46 15 D
+-52 11 D
+-52 6 D
+-58 3 D
+-3 0 D
+-4 0 D
+-3 0 D
+-4 0 D
+-3 0 D
+-3 0 D
+-4 0 D
+-3 0 D
+-4 -1 D
+-3 0 D
+-3 0 D
+-4 0 D
+-3 0 D
+-4 0 D
+-3 -1 D
+-3 0 D
+-4 0 D
+-3 0 D
+-3 -1 D
+-4 0 D
+-3 0 D
+-3 0 D
+-4 -1 D
+-3 0 D
+-3 0 D
+-4 -1 D
+-3 0 D
+-3 -1 D
+-4 0 D
+-3 0 D
+-3 -1 D
+-3 0 D
+-4 -1 D
+-3 0 D
+-3 -1 D
+-3 0 D
+-3 -1 D
+-3 0 D
+-4 -1 D
+-3 -1 D
+-3 0 D
+-3 -1 D
+-3 0 D
+-3 -1 D
+-3 -1 D
+-3 0 D
+-3 -1 D
+-3 -1 D
+-3 0 D
+-3 -1 D
+-3 -1 D
+-3 -1 D
+-3 0 D
+-3 -1 D
+-3 -1 D
+-5 -2 D
+-3 0 D
+-3 -1 D
+-3 -1 D
+-5 -2 D
+-3 -1 D
+-5 -2 D
+-3 0 D
+-5 -2 D
+-5 -2 D
+-5 -2 D
+-5 -2 D
+-5 -2 D
+-6 -4 D
+-3 -1 D
+-4 -2 D
+-4 -2 D
+-3 -1 D
+-6 -4 D
+-4 -2 D
+-4 -2 D
+-1 -2 D
+-4 -2 D
+-7 -5 D
+-2 -1 D
+-1 -2 D
+-5 -3 D
+-1 -2 D
+-11 -10 D
+-8 -11 D
+-5 -7 D
+-6 -19 D
+-1 -14 D
+4 -16 D
+4 -9 D
+5 -8 D
+9 -11 D
+2 -3 D
+3 -2 D
+1 -2 D
+10 -7 D
+1 -2 D
+13 -8 D
+1 -2 D
+25 -13 D
+29 -13 D
+59 -17 D
+60 -10 D
+47 -4 D
+P S
+2539 160 M
+79 -23 D
+100 -26 D
+114 -25 D
+117 -21 D
+148 -21 D
+85 -10 D
+106 -9 D
+146 -8 D
+127 -3 D
+157 1 D
+146 7 D
+106 8 D
+86 8 D
+159 21 D
+136 24 D
+131 28 D
+116 30 D
+63 19 D
+S
+1348 791 M
+57 -43 D
+66 -45 D
+70 -43 D
+59 -33 D
+89 -45 D
+123 -55 D
+122 -48 D
+108 -37 D
+134 -41 D
+189 -49 D
+130 -28 D
+81 -16 D
+122 -21 D
+118 -18 D
+167 -20 D
+128 -12 D
+144 -10 D
+130 -6 D
+132 -3 D
+145 -1 D
+166 4 D
+152 8 D
+143 11 D
+128 13 D
+113 14 D
+183 27 D
+121 22 D
+167 36 D
+166 43 D
+91 26 D
+131 43 D
+84 31 D
+110 44 D
+113 52 D
+79 41 D
+90 52 D
+68 44 D
+63 46 D
+22 17 D
+S
+597 1614 M
+39 -55 D
+17 -20 D
+34 -40 D
+45 -47 D
+41 -39 D
+45 -39 D
+47 -38 D
+68 -50 D
+92 -60 D
+89 -53 D
+106 -56 D
+102 -48 D
+82 -36 D
+93 -37 D
+108 -40 D
+86 -29 D
+96 -30 D
+112 -33 D
+159 -41 D
+143 -32 D
+169 -33 D
+142 -24 D
+144 -21 D
+237 -28 D
+192 -16 D
+193 -11 D
+161 -5 D
+169 -2 D
+179 2 D
+202 8 D
+177 12 D
+124 11 D
+124 13 D
+219 28 D
+182 30 D
+169 33 D
+135 30 D
+139 35 D
+121 33 D
+55 17 D
+95 30 D
+111 39 D
+82 31 D
+115 48 D
+59 26 D
+106 51 D
+94 51 D
+89 53 D
+99 66 D
+83 63 D
+15 13 D
+52 45 D
+54 53 D
+31 33 D
+34 41 D
+21 27 D
+29 41 D
+S
+150 2572 M
+17 -51 D
+24 -56 D
+33 -62 D
+34 -54 D
+40 -54 D
+43 -53 D
+56 -59 D
+8 -7 D
+7 -8 D
+16 -14 D
+7 -8 D
+66 -57 D
+18 -14 D
+17 -15 D
+56 -42 D
+68 -47 D
+68 -44 D
+43 -26 D
+85 -48 D
+84 -44 D
+125 -60 D
+40 -17 D
+53 -23 D
+110 -44 D
+107 -39 D
+89 -30 D
+137 -43 D
+70 -20 D
+104 -28 D
+147 -37 D
+185 -40 D
+138 -26 D
+150 -25 D
+152 -22 D
+155 -19 D
+193 -20 D
+224 -16 D
+169 -8 D
+142 -4 D
+161 -2 D
+160 1 D
+218 7 D
+159 9 D
+196 15 D
+247 26 D
+190 26 D
+176 29 D
+139 26 D
+161 34 D
+164 39 D
+152 41 D
+153 47 D
+104 35 D
+108 39 D
+76 30 D
+95 39 D
+39 18 D
+26 11 D
+125 60 D
+94 51 D
+45 25 D
+16 10 D
+85 53 D
+51 34 D
+76 55 D
+27 21 D
+17 15 D
+51 43 D
+24 21 D
+7 8 D
+16 14 D
+7 8 D
+15 14 D
+49 52 D
+61 76 D
+37 54 D
+32 54 D
+31 63 D
+16 39 D
+14 44 D
+S
+0 3600 M
+1 -41 D
+5 -50 D
+13 -66 D
+17 -58 D
+22 -57 D
+31 -65 D
+38 -64 D
+39 -56 D
+44 -55 D
+48 -54 D
+30 -31 D
+73 -67 D
+35 -30 D
+65 -51 D
+49 -36 D
+78 -53 D
+72 -44 D
+64 -37 D
+47 -26 D
+87 -45 D
+20 -9 D
+25 -13 D
+127 -58 D
+120 -49 D
+139 -52 D
+162 -54 D
+128 -38 D
+131 -36 D
+161 -40 D
+166 -36 D
+170 -32 D
+210 -34 D
+196 -26 D
+200 -22 D
+182 -15 D
+185 -11 D
+146 -6 D
+137 -3 D
+255 -1 D
+195 5 D
+146 7 D
+194 13 D
+192 17 D
+179 20 D
+187 26 D
+210 35 D
+169 33 D
+156 34 D
+194 49 D
+130 37 D
+134 42 D
+137 47 D
+131 50 D
+139 58 D
+105 49 D
+19 10 D
+26 12 D
+104 55 D
+11 7 D
+53 30 D
+11 7 D
+72 44 D
+88 60 D
+58 43 D
+55 44 D
+67 60 D
+32 30 D
+51 54 D
+47 55 D
+47 63 D
+31 48 D
+31 56 D
+30 65 D
+23 66 D
+13 49 D
+11 66 D
+4 58 D
+0 17 D
+S
+150 4628 M
+-12 -44 D
+-11 -64 D
+-4 -56 D
+1 -64 D
+5 -48 D
+15 -71 D
+23 -72 D
+10 -23 D
+18 -40 D
+20 -39 D
+43 -69 D
+40 -54 D
+30 -38 D
+69 -74 D
+8 -7 D
+7 -8 D
+16 -14 D
+7 -8 D
+66 -57 D
+53 -43 D
+47 -35 D
+59 -41 D
+21 -13 D
+101 -63 D
+98 -54 D
+66 -34 D
+126 -60 D
+120 -51 D
+118 -46 D
+146 -51 D
+145 -45 D
+102 -29 D
+153 -40 D
+82 -20 D
+203 -43 D
+201 -36 D
+169 -25 D
+154 -20 D
+174 -19 D
+196 -16 D
+178 -10 D
+132 -5 D
+132 -3 D
+218 -1 D
+226 6 D
+160 8 D
+131 9 D
+130 11 D
+239 25 D
+189 26 D
+185 31 D
+146 28 D
+144 31 D
+132 31 D
+176 47 D
+153 47 D
+119 40 D
+93 34 D
+76 30 D
+95 39 D
+103 47 D
+93 45 D
+88 48 D
+67 38 D
+79 50 D
+41 27 D
+67 48 D
+54 42 D
+76 65 D
+8 7 D
+7 8 D
+16 14 D
+7 8 D
+15 14 D
+49 52 D
+61 76 D
+37 54 D
+32 54 D
+31 63 D
+9 24 D
+7 15 D
+22 72 D
+10 48 D
+6 39 D
+3 56 D
+-1 56 D
+-5 48 D
+-13 64 D
+-8 28 D
+S
+597 5586 M
+-34 -56 D
+-24 -49 D
+-7 -14 D
+-21 -57 D
+-17 -64 D
+-9 -57 D
+-3 -58 D
+2 -43 D
+7 -57 D
+12 -50 D
+15 -50 D
+14 -35 D
+24 -49 D
+19 -35 D
+36 -56 D
+31 -41 D
+28 -34 D
+17 -20 D
+7 -6 D
+31 -34 D
+48 -46 D
+76 -64 D
+75 -56 D
+91 -61 D
+109 -64 D
+118 -61 D
+115 -53 D
+24 -10 D
+78 -33 D
+25 -9 D
+95 -36 D
+126 -43 D
+158 -48 D
+129 -35 D
+37 -9 D
+156 -36 D
+161 -32 D
+158 -27 D
+136 -20 D
+146 -19 D
+190 -19 D
+151 -11 D
+168 -9 D
+178 -5 D
+229 -1 D
+212 6 D
+143 8 D
+125 9 D
+141 13 D
+164 18 D
+154 21 D
+181 30 D
+139 27 D
+106 23 D
+119 28 D
+129 34 D
+91 26 D
+129 41 D
+92 32 D
+95 36 D
+97 40 D
+59 26 D
+102 48 D
+106 56 D
+108 64 D
+99 67 D
+74 57 D
+74 64 D
+34 33 D
+31 34 D
+7 6 D
+51 61 D
+39 55 D
+34 56 D
+24 49 D
+7 14 D
+19 49 D
+16 57 D
+9 50 D
+5 51 D
+1 43 D
+-5 57 D
+-7 43 D
+-19 71 D
+-19 50 D
+-24 49 D
+-19 35 D
+-22 35 D
+S
+1348 6409 M
+-41 -35 D
+-46 -42 D
+-5 -6 D
+-6 -5 D
+-31 -33 D
+-41 -50 D
+-32 -44 D
+-24 -40 D
+-23 -46 D
+-14 -35 D
+-15 -46 D
+-10 -47 D
+-5 -47 D
+-1 -23 D
+5 -70 D
+7 -35 D
+13 -47 D
+15 -40 D
+25 -52 D
+31 -51 D
+32 -45 D
+37 -44 D
+10 -11 D
+6 -5 D
+15 -17 D
+11 -10 D
+5 -6 D
+59 -53 D
+52 -41 D
+78 -56 D
+39 -24 D
+47 -29 D
+17 -9 D
+16 -10 D
+105 -54 D
+56 -26 D
+97 -42 D
+134 -51 D
+120 -40 D
+113 -33 D
+166 -43 D
+148 -32 D
+127 -23 D
+169 -27 D
+120 -15 D
+182 -18 D
+164 -11 D
+145 -6 D
+118 -2 D
+111 -1 D
+172 4 D
+159 8 D
+163 13 D
+141 15 D
+93 12 D
+99 14 D
+122 20 D
+114 22 D
+147 33 D
+165 43 D
+112 34 D
+119 41 D
+113 43 D
+78 33 D
+56 26 D
+46 22 D
+86 46 D
+16 10 D
+17 9 D
+55 34 D
+45 29 D
+76 56 D
+56 47 D
+35 32 D
+10 11 D
+6 5 D
+15 17 D
+6 5 D
+29 33 D
+26 33 D
+35 51 D
+26 45 D
+24 52 D
+19 58 D
+10 47 D
+5 47 D
+1 23 D
+-5 70 D
+-7 35 D
+-13 47 D
+-15 40 D
+-25 52 D
+-6 12 D
+-29 45 D
+-37 50 D
+-38 44 D
+-21 22 D
+-6 5 D
+-10 11 D
+-59 53 D
+-23 19 D
+S
+2539 7040 M
+-10 -3 D
+-8 -2 D
+-7 -3 D
+-8 -2 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-8 -2 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-7 -2 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -2 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-7 -3 D
+-13 -6 D
+-12 -6 D
+-13 -7 D
+-13 -6 D
+-12 -6 D
+-12 -7 D
+-12 -6 D
+-12 -7 D
+-12 -7 D
+-11 -6 D
+-12 -7 D
+-11 -7 D
+-11 -7 D
+-11 -7 D
+-16 -10 D
+-35 -25 D
+-20 -14 D
+-53 -45 D
+-32 -30 D
+-41 -46 D
+-35 -48 D
+-27 -48 D
+-22 -57 D
+-9 -42 D
+-4 -41 D
+1 -33 D
+1 -17 D
+8 -41 D
+13 -41 D
+18 -41 D
+29 -48 D
+17 -24 D
+40 -46 D
+15 -16 D
+32 -30 D
+54 -44 D
+50 -36 D
+66 -41 D
+73 -39 D
+51 -25 D
+110 -47 D
+89 -33 D
+126 -39 D
+91 -24 D
+77 -19 D
+124 -25 D
+137 -22 D
+122 -15 D
+144 -14 D
+126 -7 D
+98 -3 D
+157 -1 D
+146 5 D
+155 11 D
+189 21 D
+120 19 D
+80 15 D
+123 26 D
+108 28 D
+96 29 D
+77 26 D
+101 39 D
+100 45 D
+56 29 D
+53 30 D
+54 35 D
+50 35 D
+53 45 D
+32 30 D
+41 47 D
+35 47 D
+27 48 D
+22 58 D
+9 41 D
+4 41 D
+-1 33 D
+-1 17 D
+-8 41 D
+-13 41 D
+-18 41 D
+-29 48 D
+-17 24 D
+-40 47 D
+-8 7 D
+-15 16 D
+-50 44 D
+-48 37 D
+-30 21 D
+-66 41 D
+-66 36 D
+-78 37 D
+-90 38 D
+-89 33 D
+-72 23 D
+S
+3600 6358 M
+81 1 D
+110 7 D
+98 11 D
+86 14 D
+99 21 D
+100 29 D
+62 23 D
+64 27 D
+51 27 D
+50 32 D
+34 27 D
+17 15 D
+23 24 D
+22 29 D
+12 20 D
+13 30 D
+8 30 D
+2 34 D
+-3 21 D
+-2 13 D
+-9 26 D
+-17 33 D
+-11 17 D
+-24 28 D
+-24 24 D
+-44 34 D
+-44 28 D
+-51 27 D
+-14 6 D
+-13 7 D
+-51 21 D
+-79 27 D
+-94 25 D
+-91 19 D
+-106 15 D
+-49 6 D
+-120 8 D
+-10 0 D
+-132 1 D
+-10 -1 D
+-10 0 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-11 -1 D
+-10 0 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 0 D
+-10 -1 D
+-10 -1 D
+-10 -2 D
+-10 -1 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-9 -2 D
+-9 -2 D
+-10 -2 D
+-9 -1 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-9 -2 D
+-8 -3 D
+-9 -2 D
+-9 -2 D
+-8 -2 D
+-9 -3 D
+-8 -2 D
+-8 -2 D
+-9 -3 D
+-8 -2 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-8 -3 D
+-8 -2 D
+-8 -3 D
+-8 -3 D
+-8 -3 D
+-7 -3 D
+-8 -2 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-8 -3 D
+-7 -3 D
+-7 -3 D
+-13 -7 D
+-7 -3 D
+-7 -3 D
+-13 -7 D
+-7 -3 D
+-12 -7 D
+-12 -6 D
+-12 -7 D
+-12 -7 D
+-17 -11 D
+-16 -11 D
+-24 -19 D
+-18 -15 D
+-31 -32 D
+-13 -16 D
+-20 -33 D
+-10 -21 D
+-8 -26 D
+-3 -21 D
+-1 -22 D
+4 -30 D
+9 -30 D
+17 -33 D
+20 -29 D
+26 -28 D
+12 -12 D
+14 -11 D
+29 -23 D
+39 -25 D
+49 -27 D
+41 -19 D
+66 -27 D
+89 -28 D
+78 -20 D
+102 -20 D
+106 -14 D
+90 -8 D
+111 -4 D
+P S
+8 W
+25 W
+N 3600 3600 3600 0 360 arc S
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -Rg -JG0/25/6i -O -K -SW4000k -Gred -W2p
+%@PROJ: ortho 0.00000000 360.00000000 -90.00000000 90.00000000 -6371008.771 6371008.771 -6371008.771 6371008.771 +unavailable +a=6371008.771 +b=6371008.771 +units=m +no_defs
+%%BeginObject PSL_Layer_9
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+7200 3600 M
+-1 98 D
+-5 117 D
+-13 157 D
+-17 136 D
+-22 135 D
+-31 154 D
+-38 152 D
+-39 132 D
+-37 111 D
+-55 147 D
+-46 109 D
+-40 89 D
+-61 123 D
+-66 120 D
+-39 68 D
+-62 100 D
+-99 146 D
+-82 110 D
+-99 122 D
+-77 88 D
+-67 72 D
+-83 84 D
+-56 54 D
+-117 105 D
+-90 75 D
+-77 61 D
+-127 92 D
+-114 76 D
+-117 72 D
+-137 76 D
+-123 62 D
+-142 65 D
+-146 59 D
+-92 33 D
+-130 43 D
+-151 42 D
+-134 32 D
+-134 27 D
+-116 19 D
+-156 19 D
+-137 11 D
+-137 6 D
+-137 1 D
+-20 -1 D
+-19 0 D
+-20 -1 D
+-19 0 D
+-20 -1 D
+-20 -1 D
+-19 -1 D
+-20 -1 D
+-19 -1 D
+-20 -1 D
+-19 -2 D
+-20 -1 D
+-19 -2 D
+-20 -2 D
+-19 -1 D
+-20 -2 D
+-20 -2 D
+-19 -2 D
+-19 -3 D
+-20 -2 D
+-19 -2 D
+-20 -3 D
+-19 -3 D
+-20 -2 D
+-19 -3 D
+-19 -3 D
+-20 -3 D
+-19 -4 D
+-19 -3 D
+-20 -3 D
+-19 -4 D
+-19 -3 D
+-20 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-20 -5 D
+-19 -4 D
+-19 -5 D
+-19 -4 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-18 -5 D
+-19 -6 D
+-19 -5 D
+-19 -6 D
+-19 -5 D
+-18 -6 D
+-19 -6 D
+-19 -6 D
+-18 -6 D
+-19 -6 D
+-19 -7 D
+-18 -6 D
+-19 -6 D
+-18 -7 D
+-18 -7 D
+-19 -7 D
+-18 -6 D
+-18 -7 D
+-19 -7 D
+-18 -8 D
+-18 -7 D
+-18 -7 D
+-18 -8 D
+-19 -7 D
+-18 -8 D
+-18 -8 D
+-17 -8 D
+-18 -8 D
+-18 -8 D
+-18 -8 D
+-18 -8 D
+-18 -9 D
+-35 -17 D
+-35 -17 D
+-35 -18 D
+-35 -18 D
+-34 -19 D
+-35 -19 D
+-34 -19 D
+-34 -19 D
+-33 -20 D
+-34 -21 D
+-33 -21 D
+-33 -21 D
+-33 -21 D
+-49 -33 D
+-48 -34 D
+-47 -34 D
+-48 -35 D
+-77 -61 D
+-90 -75 D
+-88 -78 D
+-57 -54 D
+-84 -83 D
+-54 -56 D
+-79 -88 D
+-63 -74 D
+-86 -108 D
+-70 -94 D
+-99 -146 D
+-72 -117 D
+-67 -119 D
+-46 -87 D
+-51 -106 D
+-48 -107 D
+-51 -128 D
+-34 -92 D
+-49 -149 D
+-42 -151 D
+-31 -133 D
+-23 -116 D
+-25 -154 D
+-18 -156 D
+-12 -176 D
+-3 -137 D
+1 -118 D
+5 -117 D
+13 -157 D
+17 -136 D
+22 -135 D
+31 -154 D
+38 -152 D
+39 -132 D
+37 -111 D
+55 -147 D
+46 -109 D
+40 -89 D
+61 -123 D
+66 -120 D
+39 -68 D
+62 -100 D
+99 -146 D
+82 -110 D
+99 -122 D
+77 -88 D
+67 -72 D
+83 -84 D
+56 -54 D
+117 -105 D
+90 -75 D
+77 -61 D
+127 -92 D
+114 -76 D
+117 -72 D
+137 -76 D
+123 -62 D
+142 -65 D
+146 -59 D
+92 -33 D
+130 -43 D
+151 -42 D
+134 -32 D
+134 -27 D
+116 -19 D
+156 -19 D
+137 -11 D
+137 -6 D
+137 -1 D
+157 6 D
+97 7 D
+98 9 D
+155 21 D
+136 24 D
+134 29 D
+151 39 D
+113 34 D
+130 44 D
+92 34 D
+127 53 D
+124 57 D
+140 71 D
+120 67 D
+117 72 D
+130 87 D
+126 93 D
+107 86 D
+104 90 D
+86 80 D
+84 83 D
+54 56 D
+79 88 D
+63 74 D
+86 108 D
+70 94 D
+99 146 D
+72 117 D
+67 119 D
+46 87 D
+51 106 D
+48 107 D
+51 128 D
+34 92 D
+49 149 D
+42 151 D
+31 133 D
+23 116 D
+25 154 D
+18 156 D
+12 176 D
+3 137 D
+P
+PSL_clip N
+/PSL_spiderpen {33 W 0 A [] 0 B} def
+33 W
+V
+{1 0 0 C} FS
+O1
+/FO {P}!
+4657 4028 M
+65 -35 D
+42 -24 D
+93 -59 D
+69 -48 D
+39 -29 D
+84 -68 D
+80 -72 D
+26 -25 D
+8 -9 D
+9 -8 D
+65 -69 D
+62 -72 D
+58 -74 D
+20 -29 D
+53 -77 D
+65 -110 D
+37 -72 D
+39 -84 D
+42 -107 D
+18 -55 D
+29 -99 D
+22 -100 D
+14 -78 D
+13 -114 D
+4 -68 D
+2 -91 D
+-3 -79 D
+-7 -91 D
+-11 -79 D
+-11 -67 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-9 -2 D
+-10 -1 D
+-9 -1 D
+-10 -2 D
+-9 -1 D
+-10 -1 D
+-10 -2 D
+-9 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-10 -2 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-10 -1 D
+-10 -2 D
+-10 -1 D
+-10 -1 D
+-11 -1 D
+-10 -1 D
+-10 -1 D
+-11 -1 D
+-10 -1 D
+-10 -1 D
+-11 -1 D
+-10 -1 D
+-11 -1 D
+-11 -1 D
+-10 0 D
+-11 -1 D
+-11 -1 D
+-10 -1 D
+-11 -1 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-10 -1 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 -1 D
+-11 0 D
+-12 -1 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-11 0 D
+-11 -1 D
+-12 0 D
+-11 -1 D
+-11 0 D
+-12 -1 D
+-11 0 D
+-12 -1 D
+-11 0 D
+-11 0 D
+-12 -1 D
+-11 0 D
+-12 0 D
+-12 -1 D
+-11 0 D
+-12 0 D
+-11 0 D
+-12 -1 D
+-12 0 D
+-12 0 D
+-11 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-11 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-12 0 D
+-182 5 D
+-135 7 D
+-135 9 D
+-209 18 D
+-218 25 D
+-189 27 D
+-69 11 D
+18 27 D
+11 19 D
+90 144 D
+55 90 D
+74 123 D
+137 236 D
+50 89 D
+130 235 D
+24 46 D
+25 45 D
+131 251 D
+74 146 D
+11 23 D
+92 188 D
+107 225 D
+19 42 D
+P
+FO
+/FO {fs os}!
+FO
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -Rg -JG0/25/6i -O -K -SW -Gblue -W2p
+%@PROJ: ortho 0.00000000 360.00000000 -90.00000000 90.00000000 -6371008.771 6371008.771 -6371008.771 6371008.771 +unavailable +a=6371008.771 +b=6371008.771 +units=m +no_defs
+%%BeginObject PSL_Layer_10
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+7200 3600 M
+-1 98 D
+-5 117 D
+-13 157 D
+-17 136 D
+-22 135 D
+-31 154 D
+-38 152 D
+-39 132 D
+-37 111 D
+-55 147 D
+-46 109 D
+-40 89 D
+-61 123 D
+-66 120 D
+-39 68 D
+-62 100 D
+-99 146 D
+-82 110 D
+-99 122 D
+-77 88 D
+-67 72 D
+-83 84 D
+-56 54 D
+-117 105 D
+-90 75 D
+-77 61 D
+-127 92 D
+-114 76 D
+-117 72 D
+-137 76 D
+-123 62 D
+-142 65 D
+-146 59 D
+-92 33 D
+-130 43 D
+-151 42 D
+-134 32 D
+-134 27 D
+-116 19 D
+-156 19 D
+-137 11 D
+-137 6 D
+-137 1 D
+-20 -1 D
+-19 0 D
+-20 -1 D
+-19 0 D
+-20 -1 D
+-20 -1 D
+-19 -1 D
+-20 -1 D
+-19 -1 D
+-20 -1 D
+-19 -2 D
+-20 -1 D
+-19 -2 D
+-20 -2 D
+-19 -1 D
+-20 -2 D
+-20 -2 D
+-19 -2 D
+-19 -3 D
+-20 -2 D
+-19 -2 D
+-20 -3 D
+-19 -3 D
+-20 -2 D
+-19 -3 D
+-19 -3 D
+-20 -3 D
+-19 -4 D
+-19 -3 D
+-20 -3 D
+-19 -4 D
+-19 -3 D
+-20 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-20 -5 D
+-19 -4 D
+-19 -5 D
+-19 -4 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-18 -5 D
+-19 -6 D
+-19 -5 D
+-19 -6 D
+-19 -5 D
+-18 -6 D
+-19 -6 D
+-19 -6 D
+-18 -6 D
+-19 -6 D
+-19 -7 D
+-18 -6 D
+-19 -6 D
+-18 -7 D
+-18 -7 D
+-19 -7 D
+-18 -6 D
+-18 -7 D
+-19 -7 D
+-18 -8 D
+-18 -7 D
+-18 -7 D
+-18 -8 D
+-19 -7 D
+-18 -8 D
+-18 -8 D
+-17 -8 D
+-18 -8 D
+-18 -8 D
+-18 -8 D
+-18 -8 D
+-18 -9 D
+-35 -17 D
+-35 -17 D
+-35 -18 D
+-35 -18 D
+-34 -19 D
+-35 -19 D
+-34 -19 D
+-34 -19 D
+-33 -20 D
+-34 -21 D
+-33 -21 D
+-33 -21 D
+-33 -21 D
+-49 -33 D
+-48 -34 D
+-47 -34 D
+-48 -35 D
+-77 -61 D
+-90 -75 D
+-88 -78 D
+-57 -54 D
+-84 -83 D
+-54 -56 D
+-79 -88 D
+-63 -74 D
+-86 -108 D
+-70 -94 D
+-99 -146 D
+-72 -117 D
+-67 -119 D
+-46 -87 D
+-51 -106 D
+-48 -107 D
+-51 -128 D
+-34 -92 D
+-49 -149 D
+-42 -151 D
+-31 -133 D
+-23 -116 D
+-25 -154 D
+-18 -156 D
+-12 -176 D
+-3 -137 D
+1 -118 D
+5 -117 D
+13 -157 D
+17 -136 D
+22 -135 D
+31 -154 D
+38 -152 D
+39 -132 D
+37 -111 D
+55 -147 D
+46 -109 D
+40 -89 D
+61 -123 D
+66 -120 D
+39 -68 D
+62 -100 D
+99 -146 D
+82 -110 D
+99 -122 D
+77 -88 D
+67 -72 D
+83 -84 D
+56 -54 D
+117 -105 D
+90 -75 D
+77 -61 D
+127 -92 D
+114 -76 D
+117 -72 D
+137 -76 D
+123 -62 D
+142 -65 D
+146 -59 D
+92 -33 D
+130 -43 D
+151 -42 D
+134 -32 D
+134 -27 D
+116 -19 D
+156 -19 D
+137 -11 D
+137 -6 D
+137 -1 D
+157 6 D
+97 7 D
+98 9 D
+155 21 D
+136 24 D
+134 29 D
+151 39 D
+113 34 D
+130 44 D
+92 34 D
+127 53 D
+124 57 D
+140 71 D
+120 67 D
+117 72 D
+130 87 D
+126 93 D
+107 86 D
+104 90 D
+86 80 D
+84 83 D
+54 56 D
+79 88 D
+63 74 D
+86 108 D
+70 94 D
+99 146 D
+72 117 D
+67 119 D
+46 87 D
+51 106 D
+48 107 D
+51 128 D
+34 92 D
+49 149 D
+42 151 D
+31 133 D
+23 116 D
+25 154 D
+18 156 D
+12 176 D
+3 137 D
+P
+PSL_clip N
+/PSL_spiderpen {33 W 0 A [] 0 B} def
+33 W
+V
+{0 0 1 C} FS
+O1
+/FO {P}!
+2222 4785 M
+-22 -12 D
+-21 -11 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+-20 -13 D
+-21 -13 D
+-21 -13 D
+-30 -20 D
+-21 -13 D
+-30 -21 D
+-30 -21 D
+-29 -21 D
+-20 -14 D
+-19 -15 D
+-38 -29 D
+-47 -38 D
+-55 -47 D
+-80 -72 D
+-52 -50 D
+-8 -9 D
+-9 -8 D
+-81 -87 D
+-62 -72 D
+-30 -36 D
+-64 -84 D
+-35 -48 D
+-58 -88 D
+-49 -80 D
+-34 -61 D
+-53 -103 D
+-25 -52 D
+-45 -106 D
+-51 -141 D
+-29 -99 D
+-15 -55 D
+-20 -90 D
+-19 -101 D
+-16 -124 D
+-10 -125 D
+-2 -103 D
+1 -91 D
+7 -113 D
+11 -102 D
+20 -124 D
+2 -11 D
+80 -27 D
+77 -23 D
+107 -29 D
+52 -12 D
+35 -9 D
+169 -34 D
+152 -24 D
+117 -15 D
+144 -15 D
+137 -11 D
+166 -8 D
+157 -4 D
+245 1 D
+185 7 D
+135 8 D
+243 19 D
+165 18 D
+206 27 D
+132 20 D
+11 2 D
+-96 152 D
+-58 94 D
+-125 211 D
+-25 41 D
+-24 43 D
+-13 21 D
+-118 208 D
+-94 171 D
+-106 199 D
+-80 154 D
+-149 297 D
+-90 188 D
+-75 161 D
+-115 256 D
+-98 231 D
+-57 138 D
+P
+FO
+/FO {fs os}!
+FO
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -Rg -JG0/25/6i -O -K -SW30d/-50/-110+a+p2p -Gcyan
+%@PROJ: ortho 0.00000000 360.00000000 -90.00000000 90.00000000 -6371008.771 6371008.771 -6371008.771 6371008.771 +unavailable +a=6371008.771 +b=6371008.771 +units=m +no_defs
+%%BeginObject PSL_Layer_11
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+7200 3600 M
+-1 98 D
+-5 117 D
+-13 157 D
+-17 136 D
+-22 135 D
+-31 154 D
+-38 152 D
+-39 132 D
+-37 111 D
+-55 147 D
+-46 109 D
+-40 89 D
+-61 123 D
+-66 120 D
+-39 68 D
+-62 100 D
+-99 146 D
+-82 110 D
+-99 122 D
+-77 88 D
+-67 72 D
+-83 84 D
+-56 54 D
+-117 105 D
+-90 75 D
+-77 61 D
+-127 92 D
+-114 76 D
+-117 72 D
+-137 76 D
+-123 62 D
+-142 65 D
+-146 59 D
+-92 33 D
+-130 43 D
+-151 42 D
+-134 32 D
+-134 27 D
+-116 19 D
+-156 19 D
+-137 11 D
+-137 6 D
+-137 1 D
+-20 -1 D
+-19 0 D
+-20 -1 D
+-19 0 D
+-20 -1 D
+-20 -1 D
+-19 -1 D
+-20 -1 D
+-19 -1 D
+-20 -1 D
+-19 -2 D
+-20 -1 D
+-19 -2 D
+-20 -2 D
+-19 -1 D
+-20 -2 D
+-20 -2 D
+-19 -2 D
+-19 -3 D
+-20 -2 D
+-19 -2 D
+-20 -3 D
+-19 -3 D
+-20 -2 D
+-19 -3 D
+-19 -3 D
+-20 -3 D
+-19 -4 D
+-19 -3 D
+-20 -3 D
+-19 -4 D
+-19 -3 D
+-20 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-20 -5 D
+-19 -4 D
+-19 -5 D
+-19 -4 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-18 -5 D
+-19 -6 D
+-19 -5 D
+-19 -6 D
+-19 -5 D
+-18 -6 D
+-19 -6 D
+-19 -6 D
+-18 -6 D
+-19 -6 D
+-19 -7 D
+-18 -6 D
+-19 -6 D
+-18 -7 D
+-18 -7 D
+-19 -7 D
+-18 -6 D
+-18 -7 D
+-19 -7 D
+-18 -8 D
+-18 -7 D
+-18 -7 D
+-18 -8 D
+-19 -7 D
+-18 -8 D
+-18 -8 D
+-17 -8 D
+-18 -8 D
+-18 -8 D
+-18 -8 D
+-18 -8 D
+-18 -9 D
+-35 -17 D
+-35 -17 D
+-35 -18 D
+-35 -18 D
+-34 -19 D
+-35 -19 D
+-34 -19 D
+-34 -19 D
+-33 -20 D
+-34 -21 D
+-33 -21 D
+-33 -21 D
+-33 -21 D
+-49 -33 D
+-48 -34 D
+-47 -34 D
+-48 -35 D
+-77 -61 D
+-90 -75 D
+-88 -78 D
+-57 -54 D
+-84 -83 D
+-54 -56 D
+-79 -88 D
+-63 -74 D
+-86 -108 D
+-70 -94 D
+-99 -146 D
+-72 -117 D
+-67 -119 D
+-46 -87 D
+-51 -106 D
+-48 -107 D
+-51 -128 D
+-34 -92 D
+-49 -149 D
+-42 -151 D
+-31 -133 D
+-23 -116 D
+-25 -154 D
+-18 -156 D
+-12 -176 D
+-3 -137 D
+1 -118 D
+5 -117 D
+13 -157 D
+17 -136 D
+22 -135 D
+31 -154 D
+38 -152 D
+39 -132 D
+37 -111 D
+55 -147 D
+46 -109 D
+40 -89 D
+61 -123 D
+66 -120 D
+39 -68 D
+62 -100 D
+99 -146 D
+82 -110 D
+99 -122 D
+77 -88 D
+67 -72 D
+83 -84 D
+56 -54 D
+117 -105 D
+90 -75 D
+77 -61 D
+127 -92 D
+114 -76 D
+117 -72 D
+137 -76 D
+123 -62 D
+142 -65 D
+146 -59 D
+92 -33 D
+130 -43 D
+151 -42 D
+134 -32 D
+134 -27 D
+116 -19 D
+156 -19 D
+137 -11 D
+137 -6 D
+137 -1 D
+157 6 D
+97 7 D
+98 9 D
+155 21 D
+136 24 D
+134 29 D
+151 39 D
+113 34 D
+130 44 D
+92 34 D
+127 53 D
+124 57 D
+140 71 D
+120 67 D
+117 72 D
+130 87 D
+126 93 D
+107 86 D
+104 90 D
+86 80 D
+84 83 D
+54 56 D
+79 88 D
+63 74 D
+86 108 D
+70 94 D
+99 146 D
+72 117 D
+67 119 D
+46 87 D
+51 106 D
+48 107 D
+51 128 D
+34 92 D
+49 149 D
+42 151 D
+31 133 D
+23 116 D
+25 154 D
+18 156 D
+12 176 D
+3 137 D
+P
+PSL_clip N
+/PSL_spiderpen {33 W 0 A [] 0 B} def
+4 W
+V
+{0 1 1 C} FS
+V O0
+/FO {P}!
+5225 1758 M
+-109 -111 D
+-59 -63 D
+-91 -101 D
+-66 -76 D
+-83 -101 D
+-69 -88 D
+-65 -86 D
+-17 -25 D
+-67 -96 D
+-60 -94 D
+-60 -102 D
+-45 -86 D
+-38 -82 D
+-24 -59 D
+-22 -64 D
+-5 -17 D
+105 13 D
+105 16 D
+140 27 D
+129 30 D
+140 37 D
+116 36 D
+114 39 D
+101 39 D
+121 51 D
+128 60 D
+113 59 D
+100 57 D
+86 53 D
+92 60 D
+45 31 D
+8 7 D
+-51 36 D
+-67 50 D
+-29 23 D
+-53 42 D
+-129 106 D
+-32 28 D
+-34 28 D
+-140 121 D
+-125 110 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V PSL_spiderpen
+5225 1758 M
+-109 -111 D
+-59 -63 D
+-91 -101 D
+-66 -76 D
+-83 -101 D
+-69 -88 D
+-65 -86 D
+-17 -25 D
+-67 -96 D
+-60 -94 D
+-60 -102 D
+-45 -86 D
+-38 -82 D
+-24 -59 D
+-22 -64 D
+-5 -17 D
+S
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -Rg -JG0/25/6i -O -K -SW+r+p2p -Gorange
+%@PROJ: ortho 0.00000000 360.00000000 -90.00000000 90.00000000 -6371008.771 6371008.771 -6371008.771 6371008.771 +unavailable +a=6371008.771 +b=6371008.771 +units=m +no_defs
+%%BeginObject PSL_Layer_12
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+7200 3600 M
+-1 98 D
+-5 117 D
+-13 157 D
+-17 136 D
+-22 135 D
+-31 154 D
+-38 152 D
+-39 132 D
+-37 111 D
+-55 147 D
+-46 109 D
+-40 89 D
+-61 123 D
+-66 120 D
+-39 68 D
+-62 100 D
+-99 146 D
+-82 110 D
+-99 122 D
+-77 88 D
+-67 72 D
+-83 84 D
+-56 54 D
+-117 105 D
+-90 75 D
+-77 61 D
+-127 92 D
+-114 76 D
+-117 72 D
+-137 76 D
+-123 62 D
+-142 65 D
+-146 59 D
+-92 33 D
+-130 43 D
+-151 42 D
+-134 32 D
+-134 27 D
+-116 19 D
+-156 19 D
+-137 11 D
+-137 6 D
+-137 1 D
+-20 -1 D
+-19 0 D
+-20 -1 D
+-19 0 D
+-20 -1 D
+-20 -1 D
+-19 -1 D
+-20 -1 D
+-19 -1 D
+-20 -1 D
+-19 -2 D
+-20 -1 D
+-19 -2 D
+-20 -2 D
+-19 -1 D
+-20 -2 D
+-20 -2 D
+-19 -2 D
+-19 -3 D
+-20 -2 D
+-19 -2 D
+-20 -3 D
+-19 -3 D
+-20 -2 D
+-19 -3 D
+-19 -3 D
+-20 -3 D
+-19 -4 D
+-19 -3 D
+-20 -3 D
+-19 -4 D
+-19 -3 D
+-20 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-20 -5 D
+-19 -4 D
+-19 -5 D
+-19 -4 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-18 -5 D
+-19 -6 D
+-19 -5 D
+-19 -6 D
+-19 -5 D
+-18 -6 D
+-19 -6 D
+-19 -6 D
+-18 -6 D
+-19 -6 D
+-19 -7 D
+-18 -6 D
+-19 -6 D
+-18 -7 D
+-18 -7 D
+-19 -7 D
+-18 -6 D
+-18 -7 D
+-19 -7 D
+-18 -8 D
+-18 -7 D
+-18 -7 D
+-18 -8 D
+-19 -7 D
+-18 -8 D
+-18 -8 D
+-17 -8 D
+-18 -8 D
+-18 -8 D
+-18 -8 D
+-18 -8 D
+-18 -9 D
+-35 -17 D
+-35 -17 D
+-35 -18 D
+-35 -18 D
+-34 -19 D
+-35 -19 D
+-34 -19 D
+-34 -19 D
+-33 -20 D
+-34 -21 D
+-33 -21 D
+-33 -21 D
+-33 -21 D
+-49 -33 D
+-48 -34 D
+-47 -34 D
+-48 -35 D
+-77 -61 D
+-90 -75 D
+-88 -78 D
+-57 -54 D
+-84 -83 D
+-54 -56 D
+-79 -88 D
+-63 -74 D
+-86 -108 D
+-70 -94 D
+-99 -146 D
+-72 -117 D
+-67 -119 D
+-46 -87 D
+-51 -106 D
+-48 -107 D
+-51 -128 D
+-34 -92 D
+-49 -149 D
+-42 -151 D
+-31 -133 D
+-23 -116 D
+-25 -154 D
+-18 -156 D
+-12 -176 D
+-3 -137 D
+1 -118 D
+5 -117 D
+13 -157 D
+17 -136 D
+22 -135 D
+31 -154 D
+38 -152 D
+39 -132 D
+37 -111 D
+55 -147 D
+46 -109 D
+40 -89 D
+61 -123 D
+66 -120 D
+39 -68 D
+62 -100 D
+99 -146 D
+82 -110 D
+99 -122 D
+77 -88 D
+67 -72 D
+83 -84 D
+56 -54 D
+117 -105 D
+90 -75 D
+77 -61 D
+127 -92 D
+114 -76 D
+117 -72 D
+137 -76 D
+123 -62 D
+142 -65 D
+146 -59 D
+92 -33 D
+130 -43 D
+151 -42 D
+134 -32 D
+134 -27 D
+116 -19 D
+156 -19 D
+137 -11 D
+137 -6 D
+137 -1 D
+157 6 D
+97 7 D
+98 9 D
+155 21 D
+136 24 D
+134 29 D
+151 39 D
+113 34 D
+130 44 D
+92 34 D
+127 53 D
+124 57 D
+140 71 D
+120 67 D
+117 72 D
+130 87 D
+126 93 D
+107 86 D
+104 90 D
+86 80 D
+84 83 D
+54 56 D
+79 88 D
+63 74 D
+86 108 D
+70 94 D
+99 146 D
+72 117 D
+67 119 D
+46 87 D
+51 106 D
+48 107 D
+51 128 D
+34 92 D
+49 149 D
+42 151 D
+31 133 D
+23 116 D
+25 154 D
+18 156 D
+12 176 D
+3 137 D
+P
+PSL_clip N
+/PSL_spiderpen {33 W 0 A [] 0 B} def
+4 W
+V
+{1 0.647 0 C} FS
+V O0
+/FO {P}!
+1975 1758 M
+49 -50 D
+13 -12 D
+96 -101 D
+69 -77 D
+23 -25 D
+67 -77 D
+74 -89 D
+61 -76 D
+94 -125 D
+35 -49 D
+88 -133 D
+36 -58 D
+63 -112 D
+22 -43 D
+43 -93 D
+23 -58 D
+24 -73 D
+-105 13 D
+-105 16 D
+-140 27 D
+-129 30 D
+-140 37 D
+-116 36 D
+-114 39 D
+-101 39 D
+-121 51 D
+-128 60 D
+-113 59 D
+-100 57 D
+-86 53 D
+-92 60 D
+-45 31 D
+-8 7 D
+51 36 D
+67 50 D
+29 23 D
+53 42 D
+129 106 D
+32 28 D
+34 28 D
+140 121 D
+125 110 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V PSL_spiderpen
+1212 1122 M
+51 36 D
+67 50 D
+29 23 D
+53 42 D
+129 106 D
+32 28 D
+34 28 D
+140 121 D
+125 110 D
+103 92 D
+S
+1212 1122 M
+17 -13 D
+109 -73 D
+86 -54 D
+139 -79 D
+114 -58 D
+129 -60 D
+133 -54 D
+101 -38 D
+126 -42 D
+128 -37 D
+164 -41 D
+129 -26 D
+58 -11 D
+140 -21 D
+70 -8 D
+S
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -Rg -JG0/25/6i -O -K -SW20d/-60/240 -W2p -Gyellow
+%@PROJ: ortho 0.00000000 360.00000000 -90.00000000 90.00000000 -6371008.771 6371008.771 -6371008.771 6371008.771 +unavailable +a=6371008.771 +b=6371008.771 +units=m +no_defs
+%%BeginObject PSL_Layer_13
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+7200 3600 M
+-1 98 D
+-5 117 D
+-13 157 D
+-17 136 D
+-22 135 D
+-31 154 D
+-38 152 D
+-39 132 D
+-37 111 D
+-55 147 D
+-46 109 D
+-40 89 D
+-61 123 D
+-66 120 D
+-39 68 D
+-62 100 D
+-99 146 D
+-82 110 D
+-99 122 D
+-77 88 D
+-67 72 D
+-83 84 D
+-56 54 D
+-117 105 D
+-90 75 D
+-77 61 D
+-127 92 D
+-114 76 D
+-117 72 D
+-137 76 D
+-123 62 D
+-142 65 D
+-146 59 D
+-92 33 D
+-130 43 D
+-151 42 D
+-134 32 D
+-134 27 D
+-116 19 D
+-156 19 D
+-137 11 D
+-137 6 D
+-137 1 D
+-20 -1 D
+-19 0 D
+-20 -1 D
+-19 0 D
+-20 -1 D
+-20 -1 D
+-19 -1 D
+-20 -1 D
+-19 -1 D
+-20 -1 D
+-19 -2 D
+-20 -1 D
+-19 -2 D
+-20 -2 D
+-19 -1 D
+-20 -2 D
+-20 -2 D
+-19 -2 D
+-19 -3 D
+-20 -2 D
+-19 -2 D
+-20 -3 D
+-19 -3 D
+-20 -2 D
+-19 -3 D
+-19 -3 D
+-20 -3 D
+-19 -4 D
+-19 -3 D
+-20 -3 D
+-19 -4 D
+-19 -3 D
+-20 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-19 -4 D
+-20 -5 D
+-19 -4 D
+-19 -5 D
+-19 -4 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-19 -5 D
+-18 -5 D
+-19 -6 D
+-19 -5 D
+-19 -6 D
+-19 -5 D
+-18 -6 D
+-19 -6 D
+-19 -6 D
+-18 -6 D
+-19 -6 D
+-19 -7 D
+-18 -6 D
+-19 -6 D
+-18 -7 D
+-18 -7 D
+-19 -7 D
+-18 -6 D
+-18 -7 D
+-19 -7 D
+-18 -8 D
+-18 -7 D
+-18 -7 D
+-18 -8 D
+-19 -7 D
+-18 -8 D
+-18 -8 D
+-17 -8 D
+-18 -8 D
+-18 -8 D
+-18 -8 D
+-18 -8 D
+-18 -9 D
+-35 -17 D
+-35 -17 D
+-35 -18 D
+-35 -18 D
+-34 -19 D
+-35 -19 D
+-34 -19 D
+-34 -19 D
+-33 -20 D
+-34 -21 D
+-33 -21 D
+-33 -21 D
+-33 -21 D
+-49 -33 D
+-48 -34 D
+-47 -34 D
+-48 -35 D
+-77 -61 D
+-90 -75 D
+-88 -78 D
+-57 -54 D
+-84 -83 D
+-54 -56 D
+-79 -88 D
+-63 -74 D
+-86 -108 D
+-70 -94 D
+-99 -146 D
+-72 -117 D
+-67 -119 D
+-46 -87 D
+-51 -106 D
+-48 -107 D
+-51 -128 D
+-34 -92 D
+-49 -149 D
+-42 -151 D
+-31 -133 D
+-23 -116 D
+-25 -154 D
+-18 -156 D
+-12 -176 D
+-3 -137 D
+1 -118 D
+5 -117 D
+13 -157 D
+17 -136 D
+22 -135 D
+31 -154 D
+38 -152 D
+39 -132 D
+37 -111 D
+55 -147 D
+46 -109 D
+40 -89 D
+61 -123 D
+66 -120 D
+39 -68 D
+62 -100 D
+99 -146 D
+82 -110 D
+99 -122 D
+77 -88 D
+67 -72 D
+83 -84 D
+56 -54 D
+117 -105 D
+90 -75 D
+77 -61 D
+127 -92 D
+114 -76 D
+117 -72 D
+137 -76 D
+123 -62 D
+142 -65 D
+146 -59 D
+92 -33 D
+130 -43 D
+151 -42 D
+134 -32 D
+134 -27 D
+116 -19 D
+156 -19 D
+137 -11 D
+137 -6 D
+137 -1 D
+157 6 D
+97 7 D
+98 9 D
+155 21 D
+136 24 D
+134 29 D
+151 39 D
+113 34 D
+130 44 D
+92 34 D
+127 53 D
+124 57 D
+140 71 D
+120 67 D
+117 72 D
+130 87 D
+126 93 D
+107 86 D
+104 90 D
+86 80 D
+84 83 D
+54 56 D
+79 88 D
+63 74 D
+86 108 D
+70 94 D
+99 146 D
+72 117 D
+67 119 D
+46 87 D
+51 106 D
+48 107 D
+51 128 D
+34 92 D
+49 149 D
+42 151 D
+31 133 D
+23 116 D
+25 154 D
+18 156 D
+12 176 D
+3 137 D
+P
+PSL_clip N
+/PSL_spiderpen {33 W 0 A [] 0 B} def
+33 W
+V
+{1 1 0 C} FS
+O1
+O0
+/FO {P}!
+2553 6802 M
+42 29 D
+62 37 D
+77 40 D
+61 27 D
+97 37 D
+67 22 D
+93 26 D
+108 23 D
+61 11 D
+112 14 D
+63 6 D
+88 4 D
+114 1 D
+101 -5 D
+99 -9 D
+109 -16 D
+105 -22 D
+102 -28 D
+64 -21 D
+62 -23 D
+78 -35 D
+73 -39 D
+34 -20 D
+25 -16 D
+23 -17 D
+30 -22 D
+49 -41 D
+6 -7 D
+31 -30 D
+38 -45 D
+24 -33 D
+17 -27 D
+21 -41 D
+17 -42 D
+7 -21 D
+12 -57 D
+3 -37 D
+1 -28 D
+-3 -37 D
+-7 -43 D
+-7 -29 D
+-18 -50 D
+-24 -49 D
+-21 -35 D
+-29 -41 D
+-28 -33 D
+-30 -33 D
+-47 -44 D
+-37 -30 D
+-24 -17 D
+-24 -18 D
+-26 -17 D
+-17 -11 D
+-18 -10 D
+-18 -11 D
+-18 -10 D
+-19 -11 D
+-19 -9 D
+-19 -10 D
+-20 -10 D
+-10 -4 D
+-20 -10 D
+-11 -4 D
+-10 -5 D
+-10 -4 D
+-11 -4 D
+-10 -5 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-10 -4 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-11 -3 D
+-11 -4 D
+-12 -4 D
+-11 -3 D
+-11 -4 D
+-12 -3 D
+-11 -4 D
+-12 -3 D
+-11 -3 D
+-12 -3 D
+-11 -4 D
+-12 -3 D
+-12 -3 D
+-12 -2 D
+-12 -3 D
+-11 -3 D
+-12 -3 D
+-12 -2 D
+-12 -3 D
+-12 -3 D
+-13 -2 D
+-12 -2 D
+-12 -3 D
+-12 -2 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-12 -1 D
+-13 -2 D
+-12 -1 D
+-13 -2 D
+-12 -1 D
+-13 -2 D
+-12 -1 D
+-13 -1 D
+-13 -1 D
+-12 -1 D
+-13 -1 D
+-12 -1 D
+-13 -1 D
+-13 -1 D
+-12 -1 D
+-13 0 D
+-13 -1 D
+-12 0 D
+-13 -1 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-113 5 D
+-87 8 D
+-121 18 D
+-128 28 D
+-100 29 D
+-84 30 D
+-69 30 D
+-57 28 D
+-78 45 D
+-63 44 D
+-29 23 D
+-40 36 D
+-19 18 D
+-34 38 D
+-25 33 D
+-13 20 D
+129 70 D
+133 66 D
+158 72 D
+126 52 D
+151 56 D
+116 40 D
+174 52 D
+161 41 D
+-112 49 D
+-95 37 D
+-133 46 D
+-133 39 D
+-103 25 D
+-111 23 D
+-91 14 D
+-134 15 D
+P
+FO
+/FO {fs os}!
+FO
+O1
+2553 6802 M
+42 29 D
+62 37 D
+77 40 D
+61 27 D
+97 37 D
+67 22 D
+93 26 D
+108 23 D
+61 11 D
+112 14 D
+63 6 D
+88 4 D
+114 1 D
+101 -5 D
+99 -9 D
+109 -16 D
+105 -22 D
+102 -28 D
+64 -21 D
+62 -23 D
+78 -35 D
+73 -39 D
+34 -20 D
+25 -16 D
+23 -17 D
+30 -22 D
+49 -41 D
+6 -7 D
+31 -30 D
+38 -45 D
+24 -33 D
+17 -27 D
+21 -41 D
+17 -42 D
+7 -21 D
+12 -57 D
+3 -37 D
+1 -28 D
+-3 -37 D
+-7 -43 D
+-7 -29 D
+-18 -50 D
+-24 -49 D
+-21 -35 D
+-29 -41 D
+-28 -33 D
+-30 -33 D
+-47 -44 D
+-37 -30 D
+-24 -17 D
+-24 -18 D
+-26 -17 D
+-17 -11 D
+-18 -10 D
+-18 -11 D
+-18 -10 D
+-19 -11 D
+-19 -9 D
+-19 -10 D
+-20 -10 D
+-10 -4 D
+-20 -10 D
+-11 -4 D
+-10 -5 D
+-10 -4 D
+-11 -4 D
+-10 -5 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-10 -4 D
+-11 -4 D
+-11 -4 D
+-11 -4 D
+-11 -3 D
+-11 -4 D
+-12 -4 D
+-11 -3 D
+-11 -4 D
+-12 -3 D
+-11 -4 D
+-12 -3 D
+-11 -3 D
+-12 -3 D
+-11 -4 D
+-12 -3 D
+-12 -3 D
+-12 -2 D
+-12 -3 D
+-11 -3 D
+-12 -3 D
+-12 -2 D
+-12 -3 D
+-12 -3 D
+-13 -2 D
+-12 -2 D
+-12 -3 D
+-12 -2 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-12 -2 D
+-13 -2 D
+-12 -2 D
+-12 -1 D
+-13 -2 D
+-12 -1 D
+-13 -2 D
+-12 -1 D
+-13 -2 D
+-12 -1 D
+-13 -1 D
+-13 -1 D
+-12 -1 D
+-13 -1 D
+-12 -1 D
+-13 -1 D
+-13 -1 D
+-12 -1 D
+-13 0 D
+-13 -1 D
+-12 0 D
+-13 -1 D
+-13 0 D
+-12 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-13 0 D
+-12 0 D
+-13 0 D
+-113 5 D
+-87 8 D
+-121 18 D
+-128 28 D
+-100 29 D
+-84 30 D
+-69 30 D
+-57 28 D
+-78 45 D
+-63 44 D
+-29 23 D
+-40 36 D
+-19 18 D
+-34 38 D
+-25 33 D
+-13 20 D
+129 70 D
+133 66 D
+158 72 D
+126 52 D
+151 56 D
+116 40 D
+174 52 D
+161 41 D
+-112 49 D
+-95 37 D
+-133 46 D
+-133 39 D
+-103 25 D
+-111 23 D
+-91 14 D
+-134 15 D
+P S
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -Rg -JG0/25/6i -O -T
+%@PROJ: ortho 0.00000000 360.00000000 -90.00000000 90.00000000 -6371008.771 6371008.771 -6371008.771 6371008.771 +unavailable +a=6371008.771 +b=6371008.771 +units=m +no_defs
+%%BeginObject PSL_Layer_14
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/psxy/varwedges.sh
+++ b/test/psxy/varwedges.sh
@@ -12,7 +12,7 @@ echo 2.5 0.5 2i 30 100 | gmt psxy -R -J -O -K -Sw -Gred >> $ps
 echo 4.5 0.5 | gmt psxy -R -J -O -K -Sw2i/30/100 -W1p >> $ps
 echo 0.5 1.75 30 100 | gmt psxy -R -J -O -K -Sw2i+a+p2p >> $ps
 echo 2.5 1.75 2i 30 100 | gmt psxy -R -J -O -K -Sw+r+p2p >> $ps
-echo 4.5 1.75 | gmt psxy -R -J -O -K -Sw2i/30/300+a+p2p -Gred >> $ps
+echo 4.5 1.75 | gmt psxy -R -J -O -K -Sw2i/30/100+a+p2p -Gred >> $ps
 # Geographic
 gmt psbasemap -Rg -JG0/25/6i -O -Bafg -K -Y3.5i >> $ps
 echo 0 0 30 100 | gmt psxy -R -J -O -K -SW4000k -Gred -W2p >> $ps

--- a/test/psxy/varwedges.sh
+++ b/test/psxy/varwedges.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Check wedges and geowedges
+
+ps=varwedges.ps
+gmt set PROJ_ELLIPSOID Sphere
+
+# Cartesian
+gmt psbasemap -R0/6/0/3 -Jx1i -P -Xc -Bafg -K > $ps
+echo 0.5 0.5 30 100 | gmt psxy -R -J -O -K -Sw2i -Gred -W2p >> $ps
+echo 2.5 0.5 2i 30 100 | gmt psxy -R -J -O -K -Sw -Gred >> $ps
+echo 4.5 0.5 | gmt psxy -R -J -O -K -Sw2i/30/100 -W1p >> $ps
+echo 0.5 1.75 30 100 | gmt psxy -R -J -O -K -Sw2i+a+p2p >> $ps
+echo 2.5 1.75 2i 30 100 | gmt psxy -R -J -O -K -Sw+r+p2p >> $ps
+echo 4.5 1.75 | gmt psxy -R -J -O -K -Sw2i/30/300+a+p2p -Gred >> $ps
+# Geographic
+gmt psbasemap -Rg -JG0/25/6i -O -Bafg -K -Y3.5i >> $ps
+echo 0 0 30 100 | gmt psxy -R -J -O -K -SW4000k -Gred -W2p >> $ps
+echo 0 0 3000n -30 -100 | gmt psxy -R -J -O -K -SW -Gblue -W2p >> $ps
+echo 50 -30 | gmt psxy -R -J -O -K -SW30d/-50/-110+a+p2p -Gcyan >> $ps
+echo -50 -30 30d 50 110 | gmt psxy -R -J -O -K -SW+r+p2p -Gorange >> $ps
+echo -10 80 | gmt psxy -R -J -O -K -SW20d/-60/240 -W2p -Gyellow >> $ps
+gmt psxy -R -J -O -T >> $ps

--- a/test/psxyz/varwedges.ps
+++ b/test/psxyz/varwedges.ps
@@ -1,0 +1,1066 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.2.0_8ef2629-dirty_2020.09.08 [64-bit] Document from psbasemap
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Tue Sep  8 11:19:15 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+-3600 PSL_xorig sub PSL_page_xsize 2 div add 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/6/0/3 -Jx1i -p135/35 -P -Xc -Bafg -K
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%GMTBoundingBox: -216 72 432 216
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.405579787673 0.707106781187 0.405579787673 -0 2920.17447124] concat
+25 W
+4 W
+0 0 M
+0 3600 D
+S
+2400 0 M
+0 3600 D
+S
+4800 0 M
+0 3600 D
+S
+7200 0 M
+0 3600 D
+S
+0 0 M
+7200 0 D
+S
+0 1200 M
+7200 0 D
+S
+0 2400 M
+7200 0 D
+S
+0 3600 M
+7200 0 D
+S
+/PSL_slant_y 0 def
+2 setlinecap
+25 W
+N 0 3600 M 0 -3600 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 1200 M -83 0 D S
+N 0 2400 M -83 0 D S
+N 0 3600 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) sw mx
+(1) sw mx
+(2) sw mx
+(3) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+1200 PSL_A0_y MM
+(1) mr Z
+2400 PSL_A0_y MM
+(2) mr Z
+3600 PSL_A0_y MM
+(3) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 240 M -42 0 D S
+N 0 480 M -42 0 D S
+N 0 720 M -42 0 D S
+N 0 960 M -42 0 D S
+N 0 1440 M -42 0 D S
+N 0 1680 M -42 0 D S
+N 0 1920 M -42 0 D S
+N 0 2160 M -42 0 D S
+N 0 2640 M -42 0 D S
+N 0 2880 M -42 0 D S
+N 0 3120 M -42 0 D S
+N 0 3360 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7200 0 T
+25 W
+N 0 3600 M 0 -3600 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 1200 M 83 0 D S
+N 0 2400 M 83 0 D S
+N 0 3600 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+(0) sw mx
+(1) sw mx
+(2) sw mx
+(3) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) mr Z
+1200 PSL_A0_y MM
+(1) mr Z
+2400 PSL_A0_y MM
+(2) mr Z
+3600 PSL_A0_y MM
+(3) mr Z
+N 0 240 M 42 0 D S
+N 0 480 M 42 0 D S
+N 0 720 M 42 0 D S
+N 0 960 M 42 0 D S
+N 0 1440 M 42 0 D S
+N 0 1680 M 42 0 D S
+N 0 1920 M 42 0 D S
+N 0 2160 M 42 0 D S
+N 0 2640 M 42 0 D S
+N 0 2880 M 42 0 D S
+N 0 3120 M 42 0 D S
+N 0 3360 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7200 0 T
+25 W
+N 0 0 M 7200 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 2400 0 M 0 -83 D S
+N 4800 0 M 0 -83 D S
+N 7200 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+2400 PSL_A0_y MM
+(2) bc Z
+4800 PSL_A0_y MM
+(4) bc Z
+7200 PSL_A0_y MM
+(6) bc Z
+N 1200 0 M 0 -42 D S
+N 3600 0 M 0 -42 D S
+N 6000 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3600 T
+25 W
+N 0 0 M 7200 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 2400 0 M 0 83 D S
+N 4800 0 M 0 83 D S
+N 7200 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) bc Z
+2400 PSL_A0_y MM
+(2) bc Z
+4800 PSL_A0_y MM
+(4) bc Z
+7200 PSL_A0_y MM
+(6) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 1200 0 M 0 42 D S
+N 3600 0 M 0 42 D S
+N 6000 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3600 T
+0 setlinecap
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxyz -R0/6/0/3 -Jx1i -O -K -p135/35 -Sw -Gred -W2p
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.405579787673 0.707106781187 0.405579787673 -0 2920.17447124] concat
+clipsave
+0 0 M
+7200 0 D
+0 3600 D
+-7200 0 D
+P
+PSL_clip N
+33 W
+/PSL_spiderpen {33 W 0 A [] 0 B} def
+V
+{1 0 0 C} FS
+O1
+PSL_GPP setmatrix [0.707106781187 -0.405579787673 0.707106781187 0.405579787673 -0 2920.17447124] concat
+1200 30 100 600 600 Sw
+U
+PSL_cliprestore
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxyz -R0/6/0/3 -Jx1i -O -K -p135/35 -Sw2i -Gred
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.405579787673 0.707106781187 0.405579787673 -0 2920.17447124] concat
+clipsave
+0 0 M
+7200 0 D
+0 3600 D
+-7200 0 D
+P
+PSL_clip N
+4 W
+V
+{1 0 0 C} FS
+PSL_GPP setmatrix [0.707106781187 -0.405579787673 0.707106781187 0.405579787673 -0 2920.17447124] concat
+1200 30 100 3000 600 Sw
+U
+PSL_cliprestore
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxyz -R0/6/0/3 -Jx1i -O -K -p135/35 -Sw2i/30/100 -W1p
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.405579787673 0.707106781187 0.405579787673 -0 2920.17447124] concat
+clipsave
+0 0 M
+7200 0 D
+0 3600 D
+-7200 0 D
+P
+PSL_clip N
+17 W
+/PSL_spiderpen {17 W 0 A [] 0 B} def
+V
+O1
+PSL_GPP setmatrix [0.707106781187 -0.405579787673 0.707106781187 0.405579787673 -0 2920.17447124] concat
+1200 30 100 5400 600 Sw
+U
+PSL_cliprestore
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxyz -R0/6/0/3 -Jx1i -O -K -p135/35 -Sw2i+a+p2p
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.405579787673 0.707106781187 0.405579787673 -0 2920.17447124] concat
+clipsave
+0 0 M
+7200 0 D
+0 3600 D
+-7200 0 D
+P
+PSL_clip N
+4 W
+/PSL_spiderpen {33 W 0 A [] 0 B} def
+V
+PSL_GPP setmatrix [0.707106781187 -0.405579787673 0.707106781187 0.405579787673 -0 2920.17447124] concat
+V PSL_spiderpen
+N 600 2100 1200 30 100 arc S
+U
+U
+PSL_cliprestore
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxyz -R0/6/0/3 -Jx1i -O -K -p135/35 -Sw2i/30/100+r+p2p
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.405579787673 0.707106781187 0.405579787673 -0 2920.17447124] concat
+clipsave
+0 0 M
+7200 0 D
+0 3600 D
+-7200 0 D
+P
+PSL_clip N
+4 W
+/PSL_spiderpen {33 W 0 A [] 0 B} def
+V
+PSL_GPP setmatrix [0.707106781187 -0.405579787673 0.707106781187 0.405579787673 -0 2920.17447124] concat
+V PSL_spiderpen
+4039 2700 M
+-1039 -600 D
+-208 1182 D
+S
+U
+U
+PSL_cliprestore
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxyz -R0/6/0/3 -Jx1i -O -K -p135/35 -Sw2i/30/100+a+p2p -Gred
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.405579787673 0.707106781187 0.405579787673 -0 2920.17447124] concat
+clipsave
+0 0 M
+7200 0 D
+0 3600 D
+-7200 0 D
+P
+PSL_clip N
+4 W
+/PSL_spiderpen {33 W 0 A [] 0 B} def
+V
+{1 0 0 C} FS
+PSL_GPP setmatrix [0.707106781187 -0.405579787673 0.707106781187 0.405579787673 -0 2920.17447124] concat
+1200 30 100 5400 2100 2 copy M 5 2 roll arc fs
+V PSL_spiderpen
+N 5400 2100 1200 30 100 arc S
+U
+U
+PSL_cliprestore
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R0/6/0/3 -Jx1i -O -T
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 3.00000000 0.000 6.000 0.000 3.000 +xy
+%%BeginObject PSL_Layer_8
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/psxyz/varwedges.sh
+++ b/test/psxyz/varwedges.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Check wedges
+
+ps=varwedges.ps
+gmt set PROJ_ELLIPSOID Sphere
+
+# Cartesian
+gmt psbasemap -R0/6/0/3 -Jx1i -p135/35 -P -Xc -Bafg -K > $ps
+echo 0.5 0.5  0 2i 30 100 | gmt psxyz -R -J -O -K -p -Sw -Gred -W2p >> $ps
+echo 2.5 0.5  0 30 100 | gmt psxyz -R -J -O -K -p -Sw2i -Gred >> $ps
+echo 4.5 0.5  0 | gmt psxyz -R -J -O -K -p -Sw2i/30/100 -W1p >> $ps
+echo 0.5 1.75 0 30 100 | gmt psxyz -R -J -O -K -p -Sw2i+a+p2p >> $ps
+echo 2.5 1.75 0 | gmt psxyz -R -J -O -K -p -Sw2i/30/100+r+p2p >> $ps
+echo 4.5 1.75 0 | gmt psxyz -R -J -O -K -p -Sw2i/30/100+a+p2p -Gred >> $ps
+gmt psxy -R -J -O -T >> $ps


### PR DESCRIPTION
**Description of proposed changes**

Similar to the recent enhancement for rectangles and rotated rectangles, this PR does the same to the wedges.  You can now specify the wedge diameter(s) and two angles/azimuths on the command line, or read them from the data file, or a mix.  Added two new varwedges.sh scripts to ensure the parsing of the new syntax work, plus we honor the deprecated syntax of giving the inner diameter after a slash.  All tests work the same.
