### PR TITLE
Better debugging of x2sys_solve

### DIFF
--- a/src/x2sys/x2sys_solve.c
+++ b/src/x2sys/x2sys_solve.c
@@ -154,7 +154,6 @@ GMT_LOCAL double x2syssolve_basis_z (double **P, unsigned int which, uint64_t ro
 	return (P[COL_Z1+which][row]);
 }
 
-
 static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
 	struct X2SYS_SOLVE_CTRL *C;
 
@@ -280,7 +279,6 @@ static int parse (struct GMT_CTRL *GMT, struct X2SYS_SOLVE_CTRL *Ctrl, struct GM
 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
-
 
 #define bailout(code) {gmt_M_free_options (mode); return (code);}
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}

--- a/src/x2sys/x2sys_solve.c
+++ b/src/x2sys/x2sys_solve.c
@@ -29,8 +29,6 @@
  *
  */
 
-/* #define DEBUGX */	/* Uncomment for testing */
-
 #include "gmt_dev.h"
 #include "mgd77/mgd77.h"
 #include "x2sys.h"
@@ -713,7 +711,7 @@ EXTERN_MSC int GMT_x2sys_solve (void *V_API, int mode, void *args) {
 				}
 			}
 			else
-				GMT_Report (API, GMT_MSG_INFORMATION, "%" PRIu64 " tracks form a single connected cluster\n", n);
+				GMT_Report (API, GMT_MSG_INFORMATION, "%" PRIu64 " tracks form a single connected cluster\n", n_tracks);
 		}
 	}
 
@@ -761,12 +759,15 @@ EXTERN_MSC int GMT_x2sys_solve (void *V_API, int mode, void *args) {
 
 	GMT_Report (API, GMT_MSG_INFORMATION, "Matrix equation N * a = b: (N = %" PRIu64 " x %" PRIu64 ")\n", m, m);
 
-#ifdef DEBUGX
-	for (i = 0; i < m; i++) {
-		for (j = 0; j < m; j++) GMT_Message (API, GMT_TIME_NONE, "%8.2f\t", N[i*m+j]);
-		GMT_Message (API, GMT_TIME_NONE, "\t%8.2f\n", b[i]);
+	if (gmt_M_is_verbose (GMT, GMT_MSG_DEBUG)) {
+		char format1[GMT_LEN64] = {""}, format2[GMT_LEN64] = {""};
+		sprintf (format1, "%s\t", GMT->current.setting.format_float_out);
+		sprintf (format2, "\t%s\n", GMT->current.setting.format_float_out);
+		for (i = 0; i < m; i++) {
+			for (j = 0; j < m; j++) GMT_Message (API, GMT_TIME_NONE, format1, N[i*m+j]);
+			GMT_Message (API, GMT_TIME_NONE, format2, b[i]);
+		}
 	}
-#endif
 
 	/* Get LS solution */
 
@@ -800,9 +801,7 @@ EXTERN_MSC int GMT_x2sys_solve (void *V_API, int mode, void *args) {
 			Sx += (data[COL_WW][k] * e_k);
 			Sxx += (data[COL_WW][k] * e_k * e_k);
 		}
-#ifdef DEBUGX
-		GMT_Message (API, GMT_TIME_NONE, "COE # %d: Before: %g After: %g\n", k, data[COL_COE][k], e_k);
-#endif
+		GMT_Report (API, GMT_MSG_DEBUG, "COE # %d: Before: %g After: %g\n", k, data[COL_COE][k], e_k);
 	}
 	if (Ctrl->W.unweighted_stats) Sw = (double)n_COE;
 	new_mean = Sx / Sw;


### PR DESCRIPTION
Too tedious to have to edit code, plus dumping corrected individual COEs is helpful as well.  Now using -Vd for this.  Also, fixed a bug in the reporting to screen of how many tracks.