### PR TITLE
Initialize variable to zero

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14730,7 +14730,7 @@ double gmtinit_get_diameter (struct GMT_CTRL *GMT, char code, char *text, bool *
 /*! . */
 int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL *p, unsigned int mode, bool cmd) {
 	/* mode = 0 for 2-D (psxy) and = 1 for 3-D (psxyz); cmd = true when called to process command line options */
-	int decode_error = 0, bset = 0, j, n, k, slash = 0, colon, col_off = mode, len, n_z = 0;
+	int decode_error = 0, bset = 0, j, n = 0, k, slash = 0, colon, col_off = mode, len, n_z = 0;
 	bool check = true, degenerate = false, add_to_base = false;
 	unsigned int ju, col;
 	char symbol_type, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""}, txt_d[GMT_LEN256] = {""};


### PR DESCRIPTION
The int _n_ was not initialized and thus it is possible that it could have junk further down.  I am hoping this fixes #4175 but since that never failed for me perhaps @seisman can see if it helps with the CI.