### PR TITLE
Fix GMT_base_symbols3D.ps

### DIFF
--- a/doc/scripts/GMT_base_symbols3D.ps
+++ b/doc/scripts/GMT_base_symbols3D.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
-%%BoundingBox: 0 0 595 842
-%%HiResBoundingBox: 0 0 595.0000 842.0000             
-%%Title: GMT v6.2.0_5a8527b_2020.09.08 [64-bit] Document from psxyz
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.2.0_adb56d9-dirty_2020.09.10 [64-bit] Document from psxyz
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Tue Sep  8 16:14:02 2020
+%%CreationDate: Thu Sep 10 20:59:00 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -647,7 +647,7 @@ end
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
 PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
-PSLevel 1 gt { << /PageSize [595 842] /ImagingBBox null >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
 %%Page: 1 1
@@ -656,8 +656,8 @@ PSLevel 1 gt { << /PageSize [595 842] /ImagingBBox null >> setpagedevice } if
 V 0.06 0.06 scale
 %%EndPageSetup
 
-/PSL_page_xsize 9917 def
-/PSL_page_ysize 14033 def
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
 /PSL_plot_completion {} def
 /PSL_movie_label_completion {} def
 /PSL_movie_prog_indicator_completion {} def


### PR DESCRIPTION
GMT_base_symbols3D.sh fails. It seems the PS file was generated using SI units.