### PR TITLE
Fix the syntax of grdinfo -E

### DIFF
--- a/doc/rst/source/grdinfo.rst
+++ b/doc/rst/source/grdinfo.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt grdinfo** *grdfiles* [ |-C|\ [**n**\|\ **t**\] ]
 [ |-D|\ [*xoff*\ [/*yoff*]][**+i**] ]
-[ |-E|\ [**x**\|\ **y**][**+h**\|\ **H**\|\ **l**\|\ **L**] ]
+[ |-E|\ [**x**\|\ **y**][**+l**\|\ **L**\|\ **u**\|\ **U**] ]
 [ |-F| ]
 [ |-I|\ [*dx*\ [/*dy*]\|\ **b**\|\ **i**\|\ **r**] ]
 [ |-L|\ [**0**\|\ **1**\|\ **2**\|\ **p**\|\ **a**] ] [ |-M| ]
@@ -79,9 +79,9 @@ Optional Arguments
 
 .. _-E:
 
-**-E**\ [**x**\|\ **y**][**+h**\|\ **H**\|\ **l**\|\ **L**]
+**-E**\ [**x**\|\ **y**][**+l**\|\ **L**\|\ **u**\|\ **U**]
     Report the extreme values found on a per column (**-Ex**) or per
-    row (**-Ey**) basis.  By default, we look for the global maxima (**+h**\|\ **H**)
+    row (**-Ey**) basis.  By default, we look for the global maxima (**+u**\|\ **U**)
     for each column.  Append **+l**\|\ **L** to look for minima instead.
     Upper case **+L** means we find the minimum of the positive values only, while
     upper case **+U** means we find the maximum of the negative values only [use all values].

--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -40,7 +40,7 @@ Description
 -----------
 
 **makecpt** is a module that will help you make static color palette tables
-(CPTs). In classic mode we write the CMT to standard output, while under
+(CPTs). In classic mode we write the CPT to standard output, while under
 modern mode we simply save the CPT as the current session CPT (but see **-H**).
 You define an equidistant set of contour intervals or pass
 your own z-table or list, and create a new CPT based on an existing master (dynamic)


### PR DESCRIPTION
The syntax of **grdinfo -E** should be `-E[x|y][+l|L|u|U]`, but the
documentation says `-E[x|y][+l|L|h|H]`.