### PR TITLE
Fix -l option and related error messages

### DIFF
--- a/doc/rst/source/explain_-l.rst_
+++ b/doc/rst/source/explain_-l.rst_
@@ -1,2 +1,2 @@
-**-l**\ [*label*]\ [**+D**\ *pen*][**+G**\ *gap*][**+H**\ *header*][**+L**\ [*code*/]\ *txt*][**+N**\ *cols*][**+S**\ *size*][**+V**\ [*pen*]][**+f**\ *font*][**+g**\ *fill*][**+j**\ *just*][**+o**\ *off*][**+p**\ *pen*][**+s**\ *scale*][**+w**\ *width*] :ref:`(more ...) <-l_full>`
+**-l**\ [*label*]\ [**+D**\ *pen*][**+G**\ *gap*][**+H**\ *header*][**+L**\ [*code*/]\ *txt*][**+N**\ *cols*][**+S**\ *size*\ [/*height*]][**+V**\ [*pen*]][**+f**\ *font*][**+g**\ *fill*][**+j**\ *just*][**+o**\ *off*][**+p**\ *pen*][**+s**\ *scale*][**+w**\ *width*] :ref:`(more ...) <-l_full>`
     Add a legend entry for the symbol or line being plotted. |Add_-l|

--- a/doc/rst/source/explain_-l_full.rst_
+++ b/doc/rst/source/explain_-l_full.rst_
@@ -1,6 +1,6 @@
 .. _-l_full:
 
-**-l**\ [*label*]\ [**+D**\ *pen*][**+G**\ *gap*][**+H**\ *header*][**+L**\ [*code*/]\ *txt*][**+N**\ *cols*][**+S**\ *size*[/*height*]][**+V**\ [*pen*]][**+f**\ *font*][**+g**\ *fill*][**+j**\ *just*][**+o**\ *off*][**+p**\ *pen*][**+s**\ *scale*][**+w**\ *width*]
+**-l**\ [*label*]\ [**+D**\ *pen*][**+G**\ *gap*][**+H**\ *header*][**+L**\ [*code*/]\ *txt*][**+N**\ *cols*][**+S**\ *size*\ [/*height*]][**+V**\ [*pen*]][**+f**\ *font*][**+g**\ *fill*][**+j**\ *just*][**+o**\ *off*][**+p**\ *pen*][**+s**\ *scale*][**+w**\ *width*]
     Add a map legend entry to the session legend information file for the
     current plot.  Optionally append a text *label* to describe the entry.
     Several modifiers allow further changes to the legend (to be built

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1241,7 +1241,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 				if (get_rgb)
 					GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for variable symbol color. Option -l ignored.\n");
 				else if (S.read_size && gmt_M_is_zero (GMT->common.l.item.size))
-					GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for variable symbol size unless +s<size> is used. Option -l ignored.\n");
+					GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for variable symbol size unless +S<size> is used. Option -l ignored.\n");
 				else {
 					/* For specified symbol, size, color we can do an auto-legend entry under modern mode */
 					gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -926,7 +926,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 			if (get_rgb)
 				GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for variable symbol color. Option -l ignored.\n");
 			else if (S.read_size && gmt_M_is_zero (GMT->common.l.item.size))
-				GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for variable symbol size unless +s<size> is used. Option -l ignored.\n");
+				GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for variable symbol size unless +S<size> is used. Option -l ignored.\n");
 			else {
 				/* For specified symbol, size, color we can do an auto-legend entry under modern mode */
 				gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));


### PR DESCRIPTION
Auto-legend for variable symbol sizes needs +Ssize modifier, not +ssize.

And also fixes the incorrectly formatted ReST codes.