### PR TITLE
Intercept grdcut -S implicit region if remote grids

### DIFF
--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -521,6 +521,8 @@ EXTERN_MSC void gmt_gcal_from_dt (struct GMT_CTRL *GMT, double t, struct GMT_GCA
 
 /* gmt_map.c: */
 
+
+EXTERN_MSC int gmt_circle_to_region (struct GMT_CTRL *GMT, double lon, double lat, double radius, double *wesn);
 EXTERN_MSC void gmt_translate_point (struct GMT_CTRL *GMT, double lon, double lat, double azimuth, double distance, double *tlon, double *tlat);
 EXTERN_MSC bool gmt_segment_BB_outside_map_BB (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S);
 EXTERN_MSC struct GMT_DATASEGMENT * gmt_get_geo_ellipse (struct GMT_CTRL *GMT, double lon, double lat, double major, double minor, double azimuth, uint64_t m);


### PR DESCRIPTION
Since we need to know the region to collect the necessary tiles we need to intercept the grdcut -S option earlier and decode it into a region.  Closes #4206.  Works correctly for @seisman examples.