### PR TITLE
Correct wrong info in quoted line modfiier +t discussion

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -475,8 +475,7 @@
                 less than *min_rad* [Default is 0].
 
             **+t**\ [*file*]
-                Save line label *x, y, text* to *file* [Line_labels.txt].
-                Use **+T** to save *x, y, angle, text* instead.
+                Save line label *x, y, angle, text* to *file* [Line_labels.txt].
 
             **+u**\ *unit*
                 Append *unit* to all line labels. If *unit* starts with a


### PR DESCRIPTION
There is no **+T**, only **+t**,  just as there is no **+T** for contour label modifiers.  As for not plotting anything, I think @seisman is better off running gmt **psxy** and send output to /dev/null before the start of a modern mode session.
