### PR TITLE
Increase the length of variable tmp

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -1145,7 +1145,7 @@ not_local:	/* Get here if we failed to find a remote file already on disk */
 
 int gmtlib_file_is_jpeg2000_tile (struct GMTAPI_CTRL *API, char *file) {
 	/* Detect if a file matches the name <path>/[N|S]yy[E|W]xxx.tag.jp2 (e.g., N22W160.earth_relief_01m_p.jp2) */
-	char *c, tmp[GMT_LEN64] = {""};
+	char *c, tmp[PATH_MAX] = {""};
 	if (file == NULL || file[0] == '\0') return GMT_NOTSET;	/* Bad argument */
 	if ((c = strrchr (file, '/')) == NULL)	/* Get place of the last slash */
 		sprintf (tmp, "@%s", file);	/* Now should have something like @N22W160.earth_relief_01m_p.jp2 */


### PR DESCRIPTION
This is a very bad bug because apparently the gmtlib_file_is_jpeg2000_tile() gets called when reading a gaotiff. And the variable was very small (64 bytes). This risks to bite as soon.

I'm having further problems reading Landsat geotiffs in Julia. Don't know if related.
```
julia> I = gmtread(fname, img=true)
gmtread [ERROR]: Using this data type (Float32) is not implemented
gmtread (gmtapi_import_image): Wrong flag passed to gmt_dist_array [C:\SIG_AnaliseDadosSatelite\madeira\LC08_L1TP_208037_20140110_20170426_01_T1_2014-01-10_converted\RT_LC08_L1TP_208037_20140110_20170426_01_T1_2014-01-10_B4.TIF]
```

