### PR TITLE
meca: Fix the default depth range

### DIFF
--- a/src/seis/meca.h
+++ b/src/seis/meca.h
@@ -16,20 +16,6 @@
 
 #define EPSIL 0.0001
 
-#ifndef true
-#define true 1
-#endif
-#ifndef false
-#define false 0
-#endif
-
-#ifndef M_PI_4
-#define M_PI_4          0.78539816339744830962
-#endif
-#ifndef M_PI_2
-#define M_PI_2          1.57079632679489661923
-#endif
-
 #define squared(x) ((x) * (x))
 
 struct AXIS {

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -146,7 +146,8 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 	C->C.pen = C->L.pen = C->T.pen = C->T2.pen = C->P2.pen = C->Z2.pen = C->W.pen = GMT->current.setting.map_default_pen;
 	/* Set width temporarily to -1. This will indicate later that we need to replace by W.pen */
 	C->C.pen.width = C->L.pen.width = C->T.pen.width = C->T2.pen.width = C->P2.pen.width = C->Z2.pen.width = -1.0;
-	C->D.depmax = 900.0;
+	C->D.depmin = -FLT_MAX;
+	C->D.depmax = FLT_MAX;
 	C->L.active = false;
 	gmt_init_fill (GMT, &C->E.fill, 1.0, 1.0, 1.0);
 	gmt_init_fill (GMT, &C->G.fill, 0.0, 0.0, 0.0);


### PR DESCRIPTION
**meca -D** option can limit the depth range of beachballs. The default depth
range is [0, 900]. These default values make sense for earthquakes (no deep than
800 km), but doesn't make sense for moonquakes (some are as deep as 1000 km),
and potential marsquakes (AFAIK, most marsquakes are shallow, but who knows if
we can find deep ones). Studies for microseismic focal mechanism may prefer to
use depths in meter instead of kilometer, and there may be earthquakes with
negative depths (above the sea level).

Anyway, **meca** should NOT limit depth range by default.

In this PR, I change the default depth range from [0, 900] to [-FLT_MAX, FLT_MAX].