### PR TITLE
CI: Force to install ghostscript 9.50

### DIFF
--- a/ci/azure-pipelines-windows.yml
+++ b/ci/azure-pipelines-windows.yml
@@ -47,7 +47,7 @@ steps:
 - bash: |
     set -x -e
     choco install ninja
-    choco install ghostscript
+    choco install ghostscript --version 9.50
   displayName: Install dependencies via chocolatey
 
 - bash: |


### PR DESCRIPTION
GraphicsMagick can't find gs >=9.53.0 correctly. This PR forces the Windows CI to install the old gs 9.50.

Temporarily addresses #4231.