### PR TITLE
More flexible scale origin selection in -L

### DIFF
--- a/doc/rst/source/explain_-L_scale.rst_
+++ b/doc/rst/source/explain_-L_scale.rst_
@@ -1,13 +1,17 @@
-**-L**\ [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\ **+c**\ [*slon*/]\ *slat*\ **+w**\ *length*\ [**e**\|\ **f**\|\ **k**\|\ **M**\|\ **n**\|\ **u**]\ [**+a**\ *align*]\ [**+f**]\ [**+j**\ *justify*]\ [**+l**\ [*label*]\ ]\ [**+o**\ *dx*\ [/*dy*]]\ [**+u**][**+v**]
+**-L**\ [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\ **+w**\ *length*\ [**e**\|\ **f**\|\ **k**\|\ **M**\|\ **n**\|\ **u**]\ [**+a**\ *align*]\ [**+c**\ [[*slon*/]\ *slat*]]\ [**+f**]\ [**+j**\ *justify*]\ [**+l**\ [*label*]\ ]\ [**+o**\ *dx*\ [/*dy*]]\ [**+u**][**+v**]
     Draw a simple map scale centered on the reference point specified
     using one of four coordinate systems:
 
     .. include:: explain_refpoint.rst_
 
-    Scale is calculated for latitude *slat*
-    (optionally supply longitude *slon* for oblique projections [Default
-    is central meridian]), *length* is in km, or append unit from
+    Use **+w** to set scale *length* in km, or append unit from
     **e**\|\ **f**\|\ **k**\|\ **M**\|\ **n**\|\ **u**.
+    The **+c** modifier is use to control where on the map the scale applies.
+    Map scale is calculated for latitude *slat* (optionally supply longitude
+    *slon* for oblique projections [Default is central meridian]).
+    If **+c** is not given we default to the location of the *refpoint*.
+    If **+c** is given with no arguments then we select the scale origin
+    at the middle of the map.
     Change the label alignment with **+a**\ *align* (choose among
     **l**\ (eft), **r**\ (ight), **t**\ (op), and **b**\ (ottom)).
     Append **+f** to get a "fancy" scale [Default is plain].
@@ -21,7 +25,7 @@
     Select **+u** to append the unit to all distance annotations along the
     scale (for the plain scale, **+u** will instead select the unit to be
     appended to the distance length). Cartesian projections: Origin **+c** is
-    not required, **+f** is not allowed, and no units should be specified in **+w**.
+    not allowed, **+f** is not allowed, and no units should be specified in **+w**.
     You must set any Cartesian data units via **+l**.
     For a vertical rather than horizontal Cartesian scale, append **+v**.
     **Note**: Use :term:`FONT_LABEL` to change the label font and

--- a/doc/rst/source/explain_-L_scale.rst_
+++ b/doc/rst/source/explain_-L_scale.rst_
@@ -6,12 +6,12 @@
 
     Use **+w** to set scale *length* in km, or append unit from
     **e**\|\ **f**\|\ **k**\|\ **M**\|\ **n**\|\ **u**.
-    The **+c** modifier is use to control where on the map the scale applies.
+    The **+c** modifier is use to control where on a geographic map the scale applies.
     Map scale is calculated for latitude *slat* (optionally supply longitude
     *slon* for oblique projections [Default is central meridian]).
     If **+c** is not given we default to the location of the *refpoint*.
     If **+c** is given with no arguments then we select the scale origin
-    at the middle of the map.
+    to be the middle of the map.
     Change the label alignment with **+a**\ *align* (choose among
     **l**\ (eft), **r**\ (ight), **t**\ (op), and **b**\ (ottom)).
     Append **+f** to get a "fancy" scale [Default is plain].
@@ -24,9 +24,9 @@
     label (append **+l**\ *label*).
     Select **+u** to append the unit to all distance annotations along the
     scale (for the plain scale, **+u** will instead select the unit to be
-    appended to the distance length). Cartesian projections: Origin **+c** is
-    not allowed, **+f** is not allowed, and no units should be specified in **+w**.
-    You must set any Cartesian data units via **+l**.
+    appended to the distance length). Cartesian projections: Modifiers **+c** and
+    **+f** are not allowed, and no units should be appended in **+w**.
+    You ca indicate any Cartesian data units via the label in **+l**.
     For a vertical rather than horizontal Cartesian scale, append **+v**.
     **Note**: Use :term:`FONT_LABEL` to change the label font and
     :term:`FONT_ANNOT_PRIMARY`

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7557,11 +7557,11 @@ void gmt_mapscale_syntax (struct GMT_CTRL *GMT, char option, char *string) {
 	if (string[0] == ' ') GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c parsing failure.  Correct syntax:\n", option);
 	gmt_message (GMT, "\t-%c %s\n", option, string);
 	gmt_refpoint_syntax (GMT, "L", NULL, GMT_ANCHOR_MAPSCALE, 3);
-	gmt_message (GMT, "\t   Set scale length with +w<length> and (for geo projection) append a unit from %s [km].\n", GMT_LEN_UNITS2_DISPLAY);
+	gmt_message (GMT, "\t   Set scale length with +w<length> and (for geographic projection) append a unit from %s [km].\n", GMT_LEN_UNITS2_DISPLAY);
 	gmt_message (GMT, "\t   Several modifiers are optional:\n");
-	gmt_message (GMT, "\t   Use +c to control where on the map the scale should apply [Default is at scale placement].\n");
-	gmt_message (GMT, "\t   Use +c with no arguments to select the center of the map as scale origin.\n");
-	gmt_message (GMT, "\t   Use +c<slat> (with central longitude) or +c<slon>/<slat> to specify scale origin for geographic projections.\n");
+	gmt_message (GMT, "\t   Use +c to control where on a geographic map the map scale should apply [Default is at scale bar placement].\n");
+	gmt_message (GMT, "\t   Use +c with no arguments to select the center of the map as map scale origin.\n");
+	gmt_message (GMT, "\t   Use +c<slat> (with central longitude) or +c<slon>/<slat> to specify map scale origin.\n");
 	gmt_message (GMT, "\t   Add +f to draw a \"fancy\" scale [Default is plain].\n");
 	gmt_message (GMT, "\t   By default, the scale label equals the distance unit name and is placed on top [+at].  Use the +l<label>\n");
 	gmt_message (GMT, "\t   and +a<align> mechanisms to specify another label and placement (t,b,l,r).  For the fancy scale,\n");

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7557,9 +7557,11 @@ void gmt_mapscale_syntax (struct GMT_CTRL *GMT, char option, char *string) {
 	if (string[0] == ' ') GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c parsing failure.  Correct syntax:\n", option);
 	gmt_message (GMT, "\t-%c %s\n", option, string);
 	gmt_refpoint_syntax (GMT, "L", NULL, GMT_ANCHOR_MAPSCALE, 3);
-	gmt_message (GMT, "\t   Use +c<slat> (with central longitude) or +c<slon>/<slat> to specify scale origin for geographic projections.\n");
 	gmt_message (GMT, "\t   Set scale length with +w<length> and (for geo projection) append a unit from %s [km].\n", GMT_LEN_UNITS2_DISPLAY);
 	gmt_message (GMT, "\t   Several modifiers are optional:\n");
+	gmt_message (GMT, "\t   Use +c to control where on the map the scale should apply [Default is at scale placement].\n");
+	gmt_message (GMT, "\t   Use +c with no arguments to select the center of the map as scale origin.\n");
+	gmt_message (GMT, "\t   Use +c<slat> (with central longitude) or +c<slon>/<slat> to specify scale origin for geographic projections.\n");
 	gmt_message (GMT, "\t   Add +f to draw a \"fancy\" scale [Default is plain].\n");
 	gmt_message (GMT, "\t   By default, the scale label equals the distance unit name and is placed on top [+at].  Use the +l<label>\n");
 	gmt_message (GMT, "\t   and +a<align> mechanisms to specify another label and placement (t,b,l,r).  For the fancy scale,\n");

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5911,10 +5911,14 @@ int gmt_draw_map_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *ms) {
 			return GMT_PARSE_ERROR;
 		}
 		bar_length_km = 0.001 * GMT->current.proj.m_per_unit[unit] * ms->length;	/* Now in km */
-		if (ms->origin_mode == GMT_SCALE_ORIGIN_PLACE)	/* Pick the lon/lat of the scale placement as map scale origin */
+		if (ms->origin_mode == GMT_SCALE_ORIGIN_PLACE) {	/* Pick the lon/lat of the scale placement as map scale origin */
 			gmt_xy_to_geo (GMT, &ms->origin[GMT_X], &ms->origin[GMT_Y], ms->refpoint->x, ms->refpoint->y);
-		else if (ms->origin_mode == GMT_SCALE_ORIGIN_MIDDLE)	/* Pick middle of map as map scale origin */
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Map scale origin selected to be %g/%g\n", ms->origin[GMT_X], ms->origin[GMT_Y]);
+		}
+		else if (ms->origin_mode == GMT_SCALE_ORIGIN_MIDDLE) {	/* Pick middle of map as map scale origin */
 			gmt_xy_to_geo (GMT, &ms->origin[GMT_X], &ms->origin[GMT_Y], 0.5 * GMT->current.map.width, 0.5 * GMT->current.map.height);
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Map scale origin selected to be %g/%g\n", ms->origin[GMT_X], ms->origin[GMT_Y]);
+		}
 	}
 
 	/* We will determine the scale at the point ms->origin[GMT_X], ms->origin[GMT_Y] */
@@ -6091,10 +6095,14 @@ void gmt_draw_vertical_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *ms) {
 
 	gmt_set_refpoint (GMT, ms->refpoint);	/* Finalize reference point plot coordinates, if needed */
 	/* The ms->origin_mode checks only kick in for geographic plots */
-	if (ms->origin_mode == GMT_SCALE_ORIGIN_PLACE)	/* Pick the lon/lat of the scale placement as map scale origin */
+	if (ms->origin_mode == GMT_SCALE_ORIGIN_PLACE) {	/* Pick the lon/lat of the scale placement as map scale origin */
 		gmt_xy_to_geo (GMT, &ms->origin[GMT_X], &ms->origin[GMT_Y], ms->refpoint->x, ms->refpoint->y);
-	else if (ms->origin_mode == GMT_SCALE_ORIGIN_MIDDLE)	/* Pick middle of map as map scale origin */
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Vertical map scale origin selected to be %g/%g\n", ms->origin[GMT_X], ms->origin[GMT_Y]);
+	}
+	else if (ms->origin_mode == GMT_SCALE_ORIGIN_MIDDLE) {	/* Pick middle of map as map scale origin */
 		gmt_xy_to_geo (GMT, &ms->origin[GMT_X], &ms->origin[GMT_Y], 0.5 * GMT->current.map.width, 0.5 * GMT->current.map.height);
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Vertical map scale origin selected to be %g/%g\n", ms->origin[GMT_X], ms->origin[GMT_Y]);
+	}
 	if (ms->label[0]) /* Append data unit to the scale length */
 		snprintf (txt, GMT_LEN256, "%g %s", ms->length, ms->label);
 	else

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5900,6 +5900,8 @@ int gmt_draw_map_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *ms) {
 
 	if (!ms->plot) return GMT_OK;
 
+	gmt_set_refpoint (GMT, ms->refpoint);	/* Finalize reference point plot coordinates, if needed */
+
 	if (gmt_M_is_cartesian (GMT, GMT_IN))
 		bar_length_km = ms->length;	/* Just as is */
 	else {
@@ -5909,9 +5911,11 @@ int gmt_draw_map_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *ms) {
 			return GMT_PARSE_ERROR;
 		}
 		bar_length_km = 0.001 * GMT->current.proj.m_per_unit[unit] * ms->length;	/* Now in km */
+		if (ms->origin_mode == GMT_SCALE_ORIGIN_PLACE)	/* Pick the lon/lat of the scale placement as map scale origin */
+			gmt_xy_to_geo (GMT, &ms->origin[GMT_X], &ms->origin[GMT_Y], ms->refpoint->x, ms->refpoint->y);
+		else if (ms->origin_mode == GMT_SCALE_ORIGIN_MIDDLE)	/* Pick middle of map as map scale origin */
+			gmt_xy_to_geo (GMT, &ms->origin[GMT_X], &ms->origin[GMT_Y], 0.5 * GMT->current.map.width, 0.5 * GMT->current.map.height);
 	}
-
-	gmt_set_refpoint (GMT, ms->refpoint);	/* Finalize reference point plot coordinates, if needed */
 
 	/* We will determine the scale at the point ms->origin[GMT_X], ms->origin[GMT_Y] */
 	if (gmt_M_is_dnan (ms->origin[GMT_X])) ms->origin[GMT_X] = GMT->current.proj.central_meridian;
@@ -6086,6 +6090,7 @@ void gmt_draw_vertical_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *ms) {
 	int form, just = PSL_ML;
 
 	gmt_set_refpoint (GMT, ms->refpoint);	/* Finalize reference point plot coordinates, if needed */
+	/* The ms->origin_mode checks only kick in for geographic plots */
 	if (ms->origin_mode == GMT_SCALE_ORIGIN_PLACE)	/* Pick the lon/lat of the scale placement as map scale origin */
 		gmt_xy_to_geo (GMT, &ms->origin[GMT_X], &ms->origin[GMT_Y], ms->refpoint->x, ms->refpoint->y);
 	else if (ms->origin_mode == GMT_SCALE_ORIGIN_MIDDLE)	/* Pick middle of map as map scale origin */

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -6085,6 +6085,11 @@ void gmt_draw_vertical_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *ms) {
 	char txt[GMT_LEN256] = {""};
 	int form, just = PSL_ML;
 
+	gmt_set_refpoint (GMT, ms->refpoint);	/* Finalize reference point plot coordinates, if needed */
+	if (ms->origin_mode == GMT_SCALE_ORIGIN_PLACE)	/* Pick the lon/lat of the scale placement as map scale origin */
+		gmt_xy_to_geo (GMT, &ms->origin[GMT_X], &ms->origin[GMT_Y], ms->refpoint->x, ms->refpoint->y);
+	else if (ms->origin_mode == GMT_SCALE_ORIGIN_MIDDLE)	/* Pick middle of map as map scale origin */
+		gmt_xy_to_geo (GMT, &ms->origin[GMT_X], &ms->origin[GMT_Y], 0.5 * GMT->current.map.width, 0.5 * GMT->current.map.height);
 	if (ms->label[0]) /* Append data unit to the scale length */
 		snprintf (txt, GMT_LEN256, "%g %s", ms->length, ms->label);
 	else
@@ -6100,7 +6105,6 @@ void gmt_draw_vertical_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *ms) {
 	dim[GMT_X] = strlen (txt) * GMT_DEC_WIDTH * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH + off;
 	dim[GMT_Y] = 2.0 * half_scale_length;
 
-	gmt_set_refpoint (GMT, ms->refpoint);	/* Finalize reference point plot coordinates, if needed */
 	gmt_adjust_refpoint (GMT, ms->refpoint, dim, ms->off, ms->justify, PSL_ML);	/* Adjust refpoint to ML */
 
 	x0 = ms->refpoint->x;	y0 = ms->refpoint->y;

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -12852,16 +12852,15 @@ int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, unsigned int fl
 
 	if (gmt_validate_modifiers (GMT, ms->refpoint->args, option, "acfjlouwv", GMT_MSG_ERROR)) return (1);
 
-	/* Required modifiers +c, +w */
+	/* Required modifier is +w */
 
-	if (gmt_get_modifier (ms->refpoint->args, 'c', string)) {
-		if (gmt_M_is_cartesian (GMT, GMT_IN)) {	/* No use */
+	ms->origin[GMT_X] = ms->origin[GMT_Y] = GMT->session.d_NaN;	/* One or both may need to set after gmt_map_setup is called */
+	if (gmt_get_modifier (ms->refpoint->args, 'c', string)) {	/* Specific scale origin */
+		ms->origin_mode = GMT_SCALE_ORIGIN_GIVEN;	/* Presumably we are specifying the actual origin lat/lon */
+		if (gmt_M_is_cartesian (GMT, GMT_IN))	/* No use */
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  Not allowed for Cartesian projections\n", option);
-		}
-		else if (string[0] == '\0') {	/* Got nutin' */
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  No scale [<longitude>/]<latitude> argument given to +c modifier\n", option);
-			error++;
-		}
+		else if (string[0] == '\0')	/* No argument means pick map center */
+			ms->origin_mode = GMT_SCALE_ORIGIN_MIDDLE;
 		else if (strchr (string, '/')) {	/* Got both lon and lat for scale */
 			if ((n = gmt_get_pair (GMT, string, GMT_PAIR_COORD, ms->origin)) < 2) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  Failed to parse scale <longitude>/<latitude> for +c modifier\n", option);
@@ -12877,17 +12876,14 @@ int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, unsigned int fl
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  Failed to parse scale latitude for +c modifier\n", option);
 				error++;
 			}
-			ms->origin[GMT_X] = GMT->session.d_NaN;	/* Must be set after gmt_map_setup is called */
 		}
-		if (fabs (ms->origin[GMT_Y]) > 90.0) {
+		if (ms->origin_mode == GMT_SCALE_ORIGIN_GIVEN && fabs (ms->origin[GMT_Y]) > 90.0) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  Scale latitude is out of range for +c modifier\n", option);
 			error++;
 		}
 	}
-	else if ((flag & GMT_SCALE_MAP) && gmt_M_is_geographic (GMT, GMT_IN) && !vertical) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  Scale origin modifier +c[<lon>/]/<lat> is required\n", option);
-		error++;
-	}
+	else	/* Pick the same location for scale origin as the placement of the scale */
+		ms->origin_mode = GMT_SCALE_ORIGIN_PLACE;
 
 	if (gmt_get_modifier (ms->refpoint->args, 'w', string)) {	/* Get bar length */
 		if (string[0] == '\0') {	/* Got nutin' */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -12854,7 +12854,7 @@ int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, unsigned int fl
 
 	/* Required modifier is +w */
 
-	ms->origin[GMT_X] = ms->origin[GMT_Y] = GMT->session.d_NaN;	/* One or both may need to set after gmt_map_setup is called */
+	if (gmt_M_is_geographic (GMT, GMT_IN)) ms->origin[GMT_X] = ms->origin[GMT_Y] = GMT->session.d_NaN;	/* One or both may need to set after gmt_map_setup is called */
 	if (gmt_get_modifier (ms->refpoint->args, 'c', string)) {	/* Specific scale origin */
 		ms->origin_mode = GMT_SCALE_ORIGIN_GIVEN;	/* Presumably we are specifying the actual origin lat/lon */
 		if (gmt_M_is_cartesian (GMT, GMT_IN))	/* No use */

--- a/src/gmt_symbol.h
+++ b/src/gmt_symbol.h
@@ -53,6 +53,12 @@ enum gmt_enum_panel {
 	GMT_PANEL_OUTLINE	= 16
 };
 
+enum gmt_enum_scale_orig {
+	GMT_SCALE_ORIGIN_GIVEN = 0,
+	GMT_SCALE_ORIGIN_PLACE = 1,
+	GMT_SCALE_ORIGIN_MIDDLE = 2
+};
+
 /*! Definition of structure used for holding information about a reference point */
 struct GMT_REFPOINT {	/* Used to hold items relevant for a reference point */
 	double x;		/* X position of reference point */
@@ -151,6 +157,7 @@ struct GMT_MAP_SCALE {
 	bool vertical;		/* Want a Cartesian vertical scale (i.e., for y-data) */
 	bool zdata;		/* z-data vertical scale (i.e., for z-data in pswiggle) */
 	int justify;		/* Justification of anchor point */
+	int origin_mode;	/* 0 gave scale origin, 1 select same as placement point, 2 use mid-plot location for scale origin */
 	char measure;		/* The unit, i.e., e|f|k|M|n|u */
 	char alignment;		/* Placement of label: t(op), b(ottom), l(eft), r(ight) */
 	char label[GMT_LEN128];	/* Alternative user-specified label */

--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -73,7 +73,7 @@
 #define GMT_OFFSET	"[+o<dx>[/<dy>]]"
 #define GMT_TROSE_DIR	GMT_XYANCHOR "+w<width>[+f[<level>]]" GMT_JUSTIFY "[+l<w,e,s,n>]" GMT_OFFSET
 #define GMT_TROSE_MAG	GMT_XYANCHOR "+w<width>[+d[<dec>[/<dlabel>]]][+i<pen>]" GMT_JUSTIFY "[+l<w,e,s,n>][+p<pen>][+t<ints>]" GMT_OFFSET
-#define GMT_SCALE	GMT_XYANCHOR "+c[<slon>/]<slat>+w<length>[e|f|M|n|k|u][+a<align>][+f]" GMT_JUSTIFY "[+l[<label>]]" GMT_OFFSET "[+u]"
+#define GMT_SCALE	GMT_XYANCHOR "+w<length>[e|f|M|n|k|u][+a<align>][+c[[<slon>/]<slat>]][+f]" GMT_JUSTIFY "[+l[<label>]]" GMT_OFFSET "[+u]"
 #define GMT_INSET_A	GMT_XYANCHOR "+w<width>[/<height>]" GMT_JUSTIFY GMT_OFFSET
 #define GMT_INSET_B	"<xmin>/<xmax>/<ymin>/<ymax>[+r][+u<unit>]"
 #define GMT_INSET_A_CL	GMT_XYANCHOR "+w<width>[/<height>]" GMT_JUSTIFY GMT_OFFSET "[+s<file>][+t]"

--- a/test/psbasemap/mapbardefault.ps
+++ b/test/psbasemap/mapbardefault.ps
@@ -1,0 +1,1064 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.2.0_beebf1f_2020.09.17 [64-bit] Document from psbasemap
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sat Sep 19 13:29:42 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+-3600 PSL_xorig sub PSL_page_xsize 2 div add 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R-100/100/0/80 -JM6i -P -Baf -K -Xc
+%@PROJ: merc -100.00000000 100.00000000 0.00000000 80.00000000 -11131949.079 11131949.079 -0.000 15496570.740 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%GMTBoundingBox: -216 72 432 300.689417095
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+8 W
+N 360 0 M 0 -83 D S
+N 360 5011 M 0 84 D S
+N 1440 0 M 0 -83 D S
+N 1440 5011 M 0 84 D S
+N 2520 0 M 0 -83 D S
+N 2520 5011 M 0 84 D S
+N 3600 0 M 0 -83 D S
+N 3600 5011 M 0 84 D S
+N 4680 0 M 0 -83 D S
+N 4680 5011 M 0 84 D S
+N 5760 0 M 0 -83 D S
+N 5760 5011 M 0 84 D S
+N 6840 0 M 0 -83 D S
+N 6840 5011 M 0 84 D S
+N 0 0 M -83 0 D S
+N 7200 0 M 83 0 D S
+N 0 1126 M -83 0 D S
+N 7200 1126 M 83 0 D S
+N 0 2704 M -83 0 D S
+N 7200 2704 M 83 0 D S
+83 W
+N -42 0 M 0 359 D S
+N 7242 0 M 0 359 D S
+1 A
+N -42 359 M 0 371 D S
+N 7242 359 M 0 371 D S
+0 A
+N -42 730 M 0 396 D S
+N 7242 730 M 0 396 D S
+1 A
+N -42 1126 M 0 439 D S
+N 7242 1126 M 0 439 D S
+0 A
+N -42 1565 M 0 509 D S
+N 7242 1565 M 0 509 D S
+1 A
+N -42 2074 M 0 630 D S
+N 7242 2074 M 0 630 D S
+0 A
+N -42 2704 M 0 863 D S
+N 7242 2704 M 0 863 D S
+1 A
+N -42 3567 M 0 1444 D S
+N 7242 3567 M 0 1444 D S
+0 A
+N 0 -42 M 360 0 D S
+N 0 5053 M 360 0 D S
+1 A
+N 360 -42 M 360 0 D S
+N 360 5053 M 360 0 D S
+0 A
+N 720 -42 M 360 0 D S
+N 720 5053 M 360 0 D S
+1 A
+N 1080 -42 M 360 0 D S
+N 1080 5053 M 360 0 D S
+0 A
+N 1440 -42 M 360 0 D S
+N 1440 5053 M 360 0 D S
+1 A
+N 1800 -42 M 360 0 D S
+N 1800 5053 M 360 0 D S
+0 A
+N 2160 -42 M 360 0 D S
+N 2160 5053 M 360 0 D S
+1 A
+N 2520 -42 M 360 0 D S
+N 2520 5053 M 360 0 D S
+0 A
+N 2880 -42 M 360 0 D S
+N 2880 5053 M 360 0 D S
+1 A
+N 3240 -42 M 360 0 D S
+N 3240 5053 M 360 0 D S
+0 A
+N 3600 -42 M 360 0 D S
+N 3600 5053 M 360 0 D S
+1 A
+N 3960 -42 M 360 0 D S
+N 3960 5053 M 360 0 D S
+0 A
+N 4320 -42 M 360 0 D S
+N 4320 5053 M 360 0 D S
+1 A
+N 4680 -42 M 360 0 D S
+N 4680 5053 M 360 0 D S
+0 A
+N 5040 -42 M 360 0 D S
+N 5040 5053 M 360 0 D S
+1 A
+N 5400 -42 M 360 0 D S
+N 5400 5053 M 360 0 D S
+0 A
+N 5760 -42 M 360 0 D S
+N 5760 5053 M 360 0 D S
+1 A
+N 6120 -42 M 360 0 D S
+N 6120 5053 M 360 0 D S
+0 A
+N 6480 -42 M 360 0 D S
+N 6480 5053 M 360 0 D S
+1 A
+N 6840 -42 M 360 0 D S
+N 6840 5053 M 360 0 D S
+0 A
+8 W
+N -83 0 M 7366 0 D S
+N -83 -83 M 7366 0 D S
+N 7200 -83 M 0 5178 D S
+N 7283 -83 M 0 5178 D S
+N 7283 5011 M -7366 0 D S
+N 7283 5095 M -7366 0 D S
+N 0 5095 M 0 -5178 D S
+N -83 5095 M 0 -5178 D S
+360 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-90°) tc Z
+360 5178 M (-90°) bc Z
+1440 -167 M (-60°) tc Z
+1440 5178 M (-60°) bc Z
+2520 -167 M (-30°) tc Z
+2520 5178 M (-30°) bc Z
+3600 -167 M (0°) tc Z
+3600 5178 M (0°) bc Z
+4680 -167 M (30°) tc Z
+4680 5178 M (30°) bc Z
+5760 -167 M (60°) tc Z
+5760 5178 M (60°) bc Z
+6840 -167 M (90°) tc Z
+6840 5178 M (90°) bc Z
+-167 0 M (0°) mr Z
+7367 0 M (0°) ml Z
+-167 1126 M (30°) mr Z
+7367 1126 M (30°) ml Z
+-167 2704 M (60°) mr Z
+7367 2704 M (60°) ml Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R-100/100/0/80 -JM6i '-Lg-50/75+c0+f+w5000k+l5000 km at Equator+jTC' -O -K -V
+%@PROJ: merc -100.00000000 100.00000000 0.00000000 80.00000000 -11131949.079 11131949.079 -0.000 15496570.740 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+N 991 4106 M 0 63 D S
+{0 A} FS
+O1
+-42 323 991 4169 Sb
+N 1314 4106 M 0 63 D S
+{1 A} FS
+-42 324 1314 4169 Sb
+N 1638 4106 M 0 63 D S
+{0 A} FS
+-42 324 1638 4169 Sb
+N 1962 4106 M 0 63 D S
+{1 A} FS
+-42 324 1962 4169 Sb
+N 2286 4106 M 0 63 D S
+{0 A} FS
+-42 323 2286 4169 Sb
+N 2609 4106 M 0 63 D S
+N 991 4086 M 0 83 D S
+991 4023 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) tc Z
+N 2609 4086 M 0 83 D S
+2609 4023 M (5000) tc Z
+1800 4302 M 150 F0
+(5000 km at Equator) bc Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R-100/100/0/80 -JM6i '-Lg50/75+c0+f+w5000k+l5000 km at Equator+jTC' -O -K -V
+%@PROJ: merc -100.00000000 100.00000000 0.00000000 80.00000000 -11131949.079 11131949.079 -0.000 15496570.740 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+N 4591 4106 M 0 63 D S
+{0 A} FS
+O1
+-42 323 4591 4169 Sb
+N 4914 4106 M 0 63 D S
+{1 A} FS
+-42 324 4914 4169 Sb
+N 5238 4106 M 0 63 D S
+{0 A} FS
+-42 324 5238 4169 Sb
+N 5562 4106 M 0 63 D S
+{1 A} FS
+-42 324 5562 4169 Sb
+N 5886 4106 M 0 63 D S
+{0 A} FS
+-42 323 5886 4169 Sb
+N 6209 4106 M 0 63 D S
+N 4591 4086 M 0 83 D S
+4591 4023 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) tc Z
+N 6209 4086 M 0 83 D S
+6209 4023 M (5000) tc Z
+5400 4302 M 150 F0
+(5000 km at Equator) bc Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R-100/100/0/80 -JM6i '-Lg-50/60+c+f+w5000k+l5000 km at mid map+jTC' -O -K -V
+%@PROJ: merc -100.00000000 100.00000000 0.00000000 80.00000000 -11131949.079 11131949.079 -0.000 15496570.740 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+N 309 2642 M 0 62 D S
+{0 A} FS
+O1
+-41 596 309 2704 Sb
+N 905 2642 M 0 62 D S
+{1 A} FS
+-41 597 905 2704 Sb
+N 1502 2642 M 0 62 D S
+{0 A} FS
+-41 596 1502 2704 Sb
+N 2098 2642 M 0 62 D S
+{1 A} FS
+-41 597 2098 2704 Sb
+N 2695 2642 M 0 62 D S
+{0 A} FS
+-41 596 2695 2704 Sb
+N 3291 2642 M 0 62 D S
+N 309 2621 M 0 83 D S
+309 2559 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) tc Z
+N 3291 2621 M 0 83 D S
+3291 2559 M (5000) tc Z
+1800 2838 M 150 F0
+(5000 km at mid map) bc Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R-100/100/0/80 -JM6i '-Lg50/60+c57.1176+f+w5000k+l5000 km at mid map+jTC' -O -K -V
+%@PROJ: merc -100.00000000 100.00000000 0.00000000 80.00000000 -11131949.079 11131949.079 -0.000 15496570.740 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+N 3909 2642 M 0 62 D S
+{0 A} FS
+O1
+-41 596 3909 2704 Sb
+N 4505 2642 M 0 62 D S
+{1 A} FS
+-41 597 4505 2704 Sb
+N 5102 2642 M 0 62 D S
+{0 A} FS
+-41 596 5102 2704 Sb
+N 5698 2642 M 0 62 D S
+{1 A} FS
+-41 597 5698 2704 Sb
+N 6295 2642 M 0 62 D S
+{0 A} FS
+-41 596 6295 2704 Sb
+N 6891 2642 M 0 62 D S
+N 3909 2621 M 0 83 D S
+3909 2559 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) tc Z
+N 6891 2621 M 0 83 D S
+6891 2559 M (5000) tc Z
+5400 2838 M 150 F0
+(5000 km at mid map) bc Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R-100/100/0/80 -JM6i '-Lg-50/30+f+w5000k+l5000 km at 30N+jTC' -O -K -V
+%@PROJ: merc -100.00000000 100.00000000 0.00000000 80.00000000 -11131949.079 11131949.079 -0.000 15496570.740 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+N 865 1064 M 0 62 D S
+{0 A} FS
+O1
+-42 374 865 1126 Sb
+N 1239 1064 M 0 62 D S
+{1 A} FS
+-42 374 1239 1126 Sb
+N 1613 1064 M 0 62 D S
+{0 A} FS
+-42 374 1613 1126 Sb
+N 1987 1064 M 0 62 D S
+{1 A} FS
+-42 374 1987 1126 Sb
+N 2361 1064 M 0 62 D S
+{0 A} FS
+-42 374 2361 1126 Sb
+N 2735 1064 M 0 62 D S
+N 865 1043 M 0 83 D S
+865 980 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) tc Z
+N 2735 1043 M 0 83 D S
+2735 980 M (5000) tc Z
+1800 1259 M 150 F0
+(5000 km at 30N) bc Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R-100/100/0/80 -JM6i '-Lg50/30+c30+f+w5000k+l5000 km at 30N+jTC' -O -V
+%@PROJ: merc -100.00000000 100.00000000 0.00000000 80.00000000 -11131949.079 11131949.079 -0.000 15496570.740 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+N 4465 1064 M 0 62 D S
+{0 A} FS
+O1
+-42 374 4465 1126 Sb
+N 4839 1064 M 0 62 D S
+{1 A} FS
+-42 374 4839 1126 Sb
+N 5213 1064 M 0 62 D S
+{0 A} FS
+-42 374 5213 1126 Sb
+N 5587 1064 M 0 62 D S
+{1 A} FS
+-42 374 5587 1126 Sb
+N 5961 1064 M 0 62 D S
+{0 A} FS
+-42 374 5961 1126 Sb
+N 6335 1064 M 0 62 D S
+N 4465 1043 M 0 83 D S
+4465 980 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) tc Z
+N 6335 1043 M 0 83 D S
+6335 980 M (5000) tc Z
+5400 1259 M 150 F0
+(5000 km at 30N) bc Z
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/psbasemap/mapbardefault.sh
+++ b/test/psbasemap/mapbardefault.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Test the two new +c modifier selection:
+# a) Not give +c at all: Pick map scale origin as scale bar placement location.
+# b) Give +c with no arguments: Pick the middle of the map as map scale origin.
+
+ps=mapbardefault.ps
+gmt set FONT_LABEL 9p
+gmt psbasemap -R-100/100/0/80 -JM6i -P -Baf -K -Xc > $ps
+# Specific latitude [same syntax]
+gmt psbasemap -R -J -Lg-50/75+c0+f+w5000k+l"5000 km at Equator"+jTC -O -K -V >> $ps
+gmt psbasemap -R -J -Lg50/75+c0+f+w5000k+l"5000 km at Equator"+jTC -O -K -V >> $ps
+# Get origin at mid-map location [+c no args]
+gmt psbasemap -R -J -Lg-50/60+c+f+w5000k+l"5000 km at mid map"+jTC -O -K -V >> $ps
+gmt psbasemap -R -J -Lg50/60+c57.1176+f+w5000k+l"5000 km at mid map"+jTC -O -K -V >> $ps
+# Get origin at scale placement location [no +c]
+gmt psbasemap -R -J -Lg-50/30+f+w5000k+l"5000 km at 30N"+jTC -O -K -V >> $ps
+gmt psbasemap -R -J -Lg50/30+c30+f+w5000k+l"5000 km at 30N"+jTC -O -V >> $ps


### PR DESCRIPTION
**Description of proposed changes**

Until now, the **+c**[_lon_/]_lat_ modifier in **-L** used to specify the origin for the map scale computation has been required.  This PR relaxes that by introducing two new flavors:

Here, **+c** with no arguments sets the scale origin to the mid-point of the map frame
No **+c** given at all sets the scale origin to match the placement location specified by the refpoint

I have updated the docs and added a new test to make sure this works.  Should be good to go I tope.
Closes #4227 
