### PR TITLE
admin: Add a script to show git history since a tag

### DIFF
--- a/admin/git_release_history.sh
+++ b/admin/git_release_history.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if [ "$#" == 0 ]; then
+    echo "Usage: bash git_release_history.sh tag"
+    exit 1
+fi
+
+tag=$1
+git log --oneline --remove-empty --no-merges --pretty="format:%h %ad %s" --date=format:'%Y-%m-%dT%H:%M:%S' \
+	${tag}..master


### PR DESCRIPTION
It would be easier if we follow a better "commit message" style, for example, we can add a *type* before each commit subject. For example:

![image](https://user-images.githubusercontent.com/3974108/93704943-de773d80-fae6-11ea-92ee-64ed69166cbf.png)
Figure from https://medium.com/@menuka/writing-meaningful-git-commit-messages-a62756b65c81.
