### PR TITLE
doc: Fix the incorrect ReST syntax in histogram -l option

### DIFF
--- a/doc/rst/source/histogram_common.rst_
+++ b/doc/rst/source/histogram_common.rst_
@@ -167,7 +167,7 @@ Optional Arguments
 
 .. include:: explain_-icols.rst_
 
-.. |Add_-l| replace:: Symbol is a rectangle with width-to-height ratio of 3:2.  Use **+S**\ *width*[/*height*] to overwrite with custom width and optionally height.
+.. |Add_-l| replace:: Symbol is a rectangle with width-to-height ratio of 3:2.  Use **+S**\ *width*\ [/*height*] to overwrite with custom width and optionally height.
 .. include:: explain_-l.rst_
 
 .. |Add_perspective| unicode:: 0x20 .. just an invisible code


### PR DESCRIPTION
**Description of proposed changes**

Old documentation:

![image](https://user-images.githubusercontent.com/3974108/93721126-d6a5b080-fb5b-11ea-8611-a076e1e1455b.png)
