### PR TITLE
Improve the Developer documentation for how to debug

### DIFF
--- a/doc/rst/source/debug.rst
+++ b/doc/rst/source/debug.rst
@@ -125,44 +125,63 @@ Applications).  Xcode may change as versions change; the images below is for Xco
 Debug PyGMT in Xcode on macOS
 ------------------------------
 
-Install PyGMT following the official instructions:
+Install PyGMT following the official instructions (if you already have the dev version then you may just
+need to cd into your pygmt dir and call git pull):
 
-#. Add conda-forge channel
-   conda config --prepend channels conda-forge
-   **Note**: The next step is different from the PyGMT official instructions, because we want to use the GMT dev version
-   conda create --name pygmt python=3.8 pip numpy pandas xarray netcdf4 packaging
+#. Add conda-forge channel::
 
-#. Activate the pygmt environment
-   conda activate pygmt
+    conda config --prepend channels conda-forge
+    **Note**: The next step is different from the PyGMT official instructions, because we want to use the GMT dev version
+    conda create --name pygmt python=3.8 pip numpy pandas xarray netcdf4 packaging
 
-#. Install Pygmt in editable/development mode
-   cd pygmt
-   make install
+#. Activate the PyGMT environment::
 
-#. Compile GMT using Xcode
-   Tell PyGMT where to find the GMT library by setting the environmental variable GMT_LIBRARY_PATH
-   export GMT_LIBRARY_PATH=~/Gits/gmt/gmt/build/xcode/src/Debug
+    conda activate pygmt
 
-#. Open Xcode
-   Run a python console, attach the process id in Xcode, and run PyGMT codes in the Python console.
-   Set a stop point in Xcode, say in GMT_Call_Module or GMT_Create_Session and Xcode will stop at the breakpoint.
+#. Install Pygmt in editable/development mode::
+
+    cd pygmt
+    make install
+
+#. Compile GMT using Xcode (see `Xcode on macOS`_), the let $GMT_LIBRARY_PATH be set to the full path that contains the src/Debug
+   directory created by xcodebuild so that PyGMT can find it.
+
+#. Open Xcode, select scheme "gmt", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
+   say in *GMT_Call_Module* or *GMT_Create_Session* and Xcode will stop at the breakpoint when it is reached.
+
+#. Run a python console, attach the process id in Xcode, and run PyGMT codes in the Python console. Execution should
+   stop at your stop point after the first GMT library call takes place from your python script. You are now in Xcode
+   and can follow strategies outlined above (`Xcode on macOS`_).
+
 
 Debug GMT.jl in Xcode on macOS
 ------------------------------
 
+**IN PROGRESS**
+
 Debug GMT/MEX in Xcode on macOS
 -------------------------------
 
-Because GMT/MEX involves compiling C and MEX code we have a separate Xcode project for GMT/MEX.
+**IN PROGRESS**. Because GMT/MEX involves compiling C and MEX code we have a separate Xcode project for GMT/MEX.
 It obviously links with the GMT development libraries but here we start Xcode and place a stop point
 in gmtmex.c.  Usually this is helpful so we can step through the gmtmex_parser.c library which is
 handling the interface between Matlab data structures and GMT containers.  It also relies on the
 GMT_Encode_Options API function to fill in implicit sources and destinations by examining Matlab's
 left and right side number of specified arguments.  Thus it is quite different from how things are
-done in PyGMT and GMT.jl.  To debug GMT/MEX you must:
+done in PyGMT and GMT.jl.  For macOS and Linux there are Makefiles to help do the steps, while for
+Windows there is a src/compile_mex.bat file.  To debug GMT/MEX you must:
+
+#. Set an environmental variable ${MATLAB} to point to the Matlab app (e.g., /Applications/MATLAB_R2019a.app).
 
 #. Checkout gmtmex from the repo, configure for Matlab, and build for Xcode.
+   git clone https://github.com/GenericMappingTools/gmtmex.git
+   cd gmtmex
    autoconf
-   configure --enable-matlab=dir --enable-debug --with-gmt-config=path
-   cd src
-   xcodebuild 
+   configure --enable-matlab --enable-debug --with-gmt-config=path-to-gmt-config-script
+   
+#. Make and make install
+   make install
+
+#. Start MATLAB (I usually do this without the java and display):
+   $MATLAB/bin/matlab -nojvm
+

--- a/doc/rst/source/debug.rst
+++ b/doc/rst/source/debug.rst
@@ -9,7 +9,9 @@ an issue.  Often there is a bit of detective work involved to find out where a m
 crashes and then step carefully through that section, examining variables etc., to learn
 why something fails.  This process depends on the particular debug tool one uses.  This page
 will explain the steps a developer must take to build gmt so it is suitable for your debug
-tool and how to use that tool.
+tool and how to use that tool.  **Note**: If the offending script is coming from PyGMT,
+GMT.jl, or GMT/MEX there are instructions below on how to connect your debugger to that
+process and have you land in the debugger when the script is run.
 
 Xcode on macOS
 --------------
@@ -119,3 +121,48 @@ Applications).  Xcode may change as versions change; the images below is for Xco
    .. figure:: /_images/xcode-8.*
       :width: 100%
       :align: center
+
+Debug PyGMT in Xcode on macOS
+------------------------------
+
+Install PyGMT following the official instructions:
+
+#. Add conda-forge channel
+   conda config --prepend channels conda-forge
+   **Note**: The next step is different from the PyGMT official instructions, because we want to use the GMT dev version
+   conda create --name pygmt python=3.8 pip numpy pandas xarray netcdf4 packaging
+
+#. Activate the pygmt environment
+   conda activate pygmt
+
+#. Install Pygmt in editable/development mode
+   cd pygmt
+   make install
+
+#. Compile GMT using Xcode
+   Tell PyGMT where to find the GMT library by setting the environmental variable GMT_LIBRARY_PATH
+   export GMT_LIBRARY_PATH=~/Gits/gmt/gmt/build/xcode/src/Debug
+
+#. Open Xcode
+   Run a python console, attach the process id in Xcode, and run PyGMT codes in the Python console.
+   Set a stop point in Xcode, say in GMT_Call_Module or GMT_Create_Session and Xcode will stop at the breakpoint.
+
+Debug GMT.jl in Xcode on macOS
+------------------------------
+
+Debug GMT/MEX in Xcode on macOS
+-------------------------------
+
+Because GMT/MEX involves compiling C and MEX code we have a separate Xcode project for GMT/MEX.
+It obviously links with the GMT development libraries but here we start Xcode and place a stop point
+in gmtmex.c.  Usually this is helpful so we can step through the gmtmex_parser.c library which is
+handling the interface between Matlab data structures and GMT containers.  It also relies on the
+GMT_Encode_Options API function to fill in implicit sources and destinations by examining Matlab's
+left and right side number of specified arguments.  Thus it is quite different from how things are
+done in PyGMT and GMT.jl.  To debug GMT/MEX you must:
+
+#. Checkout gmtmex from the repo, configure for Matlab, and build for Xcode.
+   autoconf
+   configure --enable-matlab=dir --enable-debug --with-gmt-config=path
+   cd src
+   xcodebuild 

--- a/doc/rst/source/debug.rst
+++ b/doc/rst/source/debug.rst
@@ -128,20 +128,19 @@ Debug PyGMT in Xcode on macOS
 **Note**: Tested with Xcode 12.0.  Install PyGMT following the official instructions at https://www.pygmt.org/dev/install.
 If you already have the dev version then you may just need to `cd` into your pygmt dir and call git pull:
 
-#. Add conda-forge channel::
+#. Add conda-forge channel and activate virtual environment (optional)::
 
     conda config --prepend channels conda-forge
     **Note**: The next step is different from the PyGMT official instructions, because we want to use the GMT dev version
     conda create --name pygmt python=3.8 pip numpy pandas xarray netcdf4 packaging
 
-#. Activate the PyGMT environment::
-
+    # Activate the PyGMT environment
     conda activate pygmt
 
 #. Install Pygmt in editable/development mode::
 
     cd pygmt
-    make install
+    pip install --editable .
 
 #. Compile GMT using Xcode (see `Xcode on macOS`_), then let $GMT_LIBRARY_PATH point to the full path that contains the src/Debug
    directory created by xcodebuild so that PyGMT can find the GMT library.

--- a/doc/rst/source/debug.rst
+++ b/doc/rst/source/debug.rst
@@ -149,7 +149,7 @@ need to cd into your pygmt dir and call git pull):
 #. Open Xcode, select scheme "gmt", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
    say in *GMT_Call_Module* or *GMT_Create_Session* and Xcode will stop at the breakpoint when it is reached.
 
-#. Run a python console, attach the process id in Xcode, and run PyGMT codes in the Python console. Execution should
+#. Type python in the terminal to get a python console, attach the process id in Xcode, and run PyGMT codes in the Python console. Execution should
    stop at your stop point after the first GMT library call takes place from your python script. You are now in Xcode
    and can follow strategies outlined above (`Xcode on macOS`_).
 
@@ -157,7 +157,28 @@ need to cd into your pygmt dir and call git pull):
 Debug GMT.jl in Xcode on macOS
 ------------------------------
 
-**IN PROGRESS**
+First install Julia from your distribution if you have not done so already (, e.g. via brew or port).  Once that is
+done you can proceed to installing the master GMT.jl:
+
+#. Compile GMT using Xcode (see `Xcode on macOS`_), the let $GMT_LIBRARY_PATH be set to the full path that contains the src/Debug
+   directory created by xcodebuild so that GMT.jl can find it.
+
+#. Type julia in terminal to get a Julia console, and in the console, type::
+
+    ]
+    add GMT#master
+
+#. Open Xcode, select scheme "gmt", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
+   say in *GMT_Call_Module* or *GMT_Create_Session* and Xcode will stop at the breakpoint when it is reached.
+
+#. Ensure we use the Xcode-built GMT library::
+
+    using Libdl
+    push!(Libdl.DL_LOAD_PATH, "$GMT_LIBRARY_PATH")
+
+#. Attach the Julia process id in Xcode, and run GMT.jl codes in the Julia console. Execution should
+   stop at your stop point after the first GMT library call takes place from your Julia script. You are now in Xcode
+   and can follow strategies outlined above (`Xcode on macOS`_).
 
 Debug GMT/MEX in Xcode on macOS
 -------------------------------

--- a/doc/rst/source/debug.rst
+++ b/doc/rst/source/debug.rst
@@ -183,30 +183,3 @@ done you can proceed to installing the master GMT.jl:
    codes in the Julia console. Execution should
    stop at your stop point after the first GMT library call takes place from your Julia script. You are now in Xcode
    and can follow strategies outlined above (`Xcode on macOS`_).
-
-Debug GMT/MEX in Xcode on macOS
--------------------------------
-
-**IN PROGRESS, WILL CHANGE**. Because GMT/MEX involves compiling C and MEX code we have a separate Xcode project for GMT/MEX.
-It obviously links with the GMT development libraries but here we start Xcode and place a stop point
-in gmtmex.c.  Usually this is helpful so we can step through the gmtmex_parser.c library which is
-handling the interface between Matlab data structures and GMT containers.  It also relies on the
-GMT_Encode_Options API function to fill in implicit sources and destinations by examining Matlab's
-left and right side number of specified arguments.  Thus it is quite different from how things are
-done in PyGMT and GMT.jl.  For macOS and Linux there are Makefiles to help do the steps, while for
-Windows there is a src/compile_mex.bat file.  To debug GMT/MEX you must:
-
-#. Set an environmental variable ${MATLAB} to point to the Matlab app (e.g., /Applications/MATLAB_R2019a.app).
-
-#. Checkout gmtmex from the repo, configure for Matlab, and build for Xcode.
-   git clone https://github.com/GenericMappingTools/gmtmex.git
-   cd gmtmex
-   autoconf
-   configure --enable-matlab --enable-debug --with-gmt-config=path-to-gmt-config-script
-   
-#. Make and make install
-   make install
-
-#. Start MATLAB (I usually do this without the java and display):
-   $MATLAB/bin/matlab -nojvm
-

--- a/doc/rst/source/debug.rst
+++ b/doc/rst/source/debug.rst
@@ -143,8 +143,8 @@ need to cd into your pygmt dir and call git pull):
     cd pygmt
     make install
 
-#. Compile GMT using Xcode (see `Xcode on macOS`_), the let $GMT_LIBRARY_PATH be set to the full path that contains the src/Debug
-   directory created by xcodebuild so that PyGMT can find it.
+#. Compile GMT using Xcode (see `Xcode on macOS`_), then let $GMT_LIBRARY_PATH point to the full path that contains the src/Debug
+   directory created by xcodebuild so that PyGMT can find the GMT library.
 
 #. Open Xcode, select scheme "gmt", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
    say in *GMT_Call_Module* or *GMT_Create_Session* and Xcode will stop at the breakpoint when it is reached.
@@ -157,16 +157,18 @@ need to cd into your pygmt dir and call git pull):
 Debug GMT.jl in Xcode on macOS
 ------------------------------
 
-First install Julia from your distribution if you have not done so already (, e.g. via brew or port).  Once that is
+First install Julia from your distribution if you have not done so already (e.g., via brew or port).  Once that is
 done you can proceed to installing the master GMT.jl:
 
-#. Compile GMT using Xcode (see `Xcode on macOS`_), the let $GMT_LIBRARY_PATH be set to the full path that contains the src/Debug
-   directory created by xcodebuild so that GMT.jl can find it.
+#. Compile GMT using Xcode (see `Xcode on macOS`_), then let $GMT_LIBRARY_PATH point to the full path that contains the src/Debug
+   directory created by xcodebuild so that GMT.jl can find the GMT library.
 
-#. Type julia in terminal to get a Julia console, and in the console, type::
+#. Type julia in a terminal to get a Julia console, and in that console, type::
 
     ]
     add GMT#master
+
+#. When done, end package install mode by hitting backspace.
 
 #. Open Xcode, select scheme "gmt", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
    say in *GMT_Call_Module* or *GMT_Create_Session* and Xcode will stop at the breakpoint when it is reached.

--- a/doc/rst/source/debug.rst
+++ b/doc/rst/source/debug.rst
@@ -161,10 +161,10 @@ Debug GMT.jl in Xcode on macOS
 First install Julia from your distribution if you have not done so already (e.g., via brew or port).  Once that is
 done you can proceed to installing the master GMT.jl:
 
-#. Compile GMT using Xcode (see `Xcode on macOS`_), then let $GMT_LIBRARY_PATH point to the full path that contains the src/Debug
+#. Compile GMT using Xcode (see `Xcode on macOS`_), then let $GMT_LIBRARY point to the full path to the libgmt.* file in the src/Debug
    directory created by xcodebuild so that GMT.jl can find the GMT library.
 
-#. Type julia in a terminal to get a Julia console, and in that console, type::
+#. Type julia in a terminal to get a Julia console, and in that console, update to latest GMT.jl master version by typing::
 
     ]
     add GMT#master
@@ -173,11 +173,6 @@ done you can proceed to installing the master GMT.jl:
 
 #. Open Xcode, select scheme "gmt", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
    say in *GMT_Call_Module* or *GMT_Create_Session* and Xcode will stop at the breakpoint when it is reached.
-
-#. Ensure we use the Xcode-built GMT library::
-
-    using Libdl
-    push!(Libdl.DL_LOAD_PATH, "$GMT_LIBRARY_PATH")
 
 #. Attach the Julia process id or name in Xcode (menu item Debug->Attach to Process by PID or Name), and run GMT.jl
    codes in the Julia console. Execution should

--- a/doc/rst/source/debug.rst
+++ b/doc/rst/source/debug.rst
@@ -137,7 +137,7 @@ If you already have the dev version then you may just need to `cd` into your pyg
     # Activate the PyGMT environment
     conda activate pygmt
 
-#. Install Pygmt in editable/development mode::
+#. Install PyGMT in editable/development mode::
 
     cd pygmt
     pip install --editable .

--- a/doc/rst/source/debug.rst
+++ b/doc/rst/source/debug.rst
@@ -185,7 +185,7 @@ done you can proceed to installing the master GMT.jl:
 Debug GMT/MEX in Xcode on macOS
 -------------------------------
 
-**IN PROGRESS**. Because GMT/MEX involves compiling C and MEX code we have a separate Xcode project for GMT/MEX.
+**IN PROGRESS, WILL CHANGE**. Because GMT/MEX involves compiling C and MEX code we have a separate Xcode project for GMT/MEX.
 It obviously links with the GMT development libraries but here we start Xcode and place a stop point
 in gmtmex.c.  Usually this is helpful so we can step through the gmtmex_parser.c library which is
 handling the interface between Matlab data structures and GMT containers.  It also relies on the

--- a/doc/rst/source/debug.rst
+++ b/doc/rst/source/debug.rst
@@ -125,8 +125,8 @@ Applications).  Xcode may change as versions change; the images below is for Xco
 Debug PyGMT in Xcode on macOS
 ------------------------------
 
-**Note**: Tested with Xcode 12.0.  Install PyGMT following the official instructions (if you already have the dev version then you may just
-need to cd into your pygmt dir and call git pull):
+**Note**: Tested with Xcode 12.0.  Install PyGMT following the official instructions at https://www.pygmt.org/dev/install.
+If you already have the dev version then you may just need to `cd` into your pygmt dir and call git pull:
 
 #. Add conda-forge channel::
 

--- a/doc/rst/source/debug.rst
+++ b/doc/rst/source/debug.rst
@@ -125,7 +125,7 @@ Applications).  Xcode may change as versions change; the images below is for Xco
 Debug PyGMT in Xcode on macOS
 ------------------------------
 
-Install PyGMT following the official instructions (if you already have the dev version then you may just
+**Note**: Tested with Xcode 12.0.  Install PyGMT following the official instructions (if you already have the dev version then you may just
 need to cd into your pygmt dir and call git pull):
 
 #. Add conda-forge channel::
@@ -158,7 +158,7 @@ need to cd into your pygmt dir and call git pull):
 Debug GMT.jl in Xcode on macOS
 ------------------------------
 
-First install Julia from your distribution if you have not done so already (e.g., via brew or port).  Once that is
+**Note**: Tested with Xcode 11.7. First install Julia from your distribution if you have not done so already (e.g., via brew or port).  Once that is
 done you can proceed to installing the master GMT.jl:
 
 #. Compile GMT using Xcode (see `Xcode on macOS`_), then let $GMT_LIBRARY point to the full path to the libgmt.* file in the src/Debug

--- a/doc/rst/source/debug.rst
+++ b/doc/rst/source/debug.rst
@@ -149,7 +149,8 @@ need to cd into your pygmt dir and call git pull):
 #. Open Xcode, select scheme "gmt", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
    say in *GMT_Call_Module* or *GMT_Create_Session* and Xcode will stop at the breakpoint when it is reached.
 
-#. Type python in the terminal to get a python console, attach the process id in Xcode, and run PyGMT codes in the Python console. Execution should
+#. Type python in the terminal to get a python console, attach the process id or name to Xcode (menu item Debug->Attach to Process by PID or Name),
+   and run PyGMT codes in the Python console. Execution should
    stop at your stop point after the first GMT library call takes place from your python script. You are now in Xcode
    and can follow strategies outlined above (`Xcode on macOS`_).
 
@@ -178,7 +179,8 @@ done you can proceed to installing the master GMT.jl:
     using Libdl
     push!(Libdl.DL_LOAD_PATH, "$GMT_LIBRARY_PATH")
 
-#. Attach the Julia process id in Xcode, and run GMT.jl codes in the Julia console. Execution should
+#. Attach the Julia process id or name in Xcode (menu item Debug->Attach to Process by PID or Name), and run GMT.jl
+   codes in the Julia console. Execution should
    stop at your stop point after the first GMT library call takes place from your Julia script. You are now in Xcode
    and can follow strategies outlined above (`Xcode on macOS`_).
 


### PR DESCRIPTION
**Description of proposed changes**

In addition to debug the GMT C from command line calls, I have added sections (for macOS) on how to debug PyGMT and GMT.jl scripts.  I am holding back on GMT/MEX as we will explore adding it as a supplement due to the compiled nature of the interface (not a wrapper).
We learned that Xcode 12.0 does not work with the julia process but 11.7 does.