### PR TITLE
Make the duplicate check optional via -D for sph* modules

### DIFF
--- a/doc/rst/source/sphdistance.rst
+++ b/doc/rst/source/sphdistance.rst
@@ -192,6 +192,7 @@ in the input.  It is best that the user ensures that this is the case.  GMT has 
 such as :doc:`blockmean` and others, to combine close points into single entries.
 Also, **sphdistance** has a **-D** option to determine and exclude duplicates, but
 it is a very brute-force yet exact comparision that is very slow for large data sets.
+Detection of duplicates in the STRIPACK library will exit the module.
 
 See Also
 --------

--- a/doc/rst/source/sphdistance.rst
+++ b/doc/rst/source/sphdistance.rst
@@ -184,6 +184,15 @@ To generate the same grid in two steps using :doc:`sphtriangulate` separately, t
     gmt sphtriangulate testdata.txt -Qv > voronoi.txt
     gmt sphdistance -Qvoronoi.txt -Rg -I1 -Gglobedist.nc
 
+Notes
+-----
+
+The STRIPACK algorithm and implementation expect that there are no duplicate points
+in the input.  It is best that the user ensures that this is the case.  GMT has tools,
+such as :doc:`blockmean` and others, to combine close points into single entries.
+Also, **sphdistance** has a **-D** option to determine and exclude duplicates, but
+it is a very brute-force yet exact comparision that is very slow for large data sets.
+
 See Also
 --------
 

--- a/doc/rst/source/sphdistance.rst
+++ b/doc/rst/source/sphdistance.rst
@@ -12,8 +12,10 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt sphdistance** [ *table* ] |-G|\ *grdfile*
+**gmt sphdistance** [ *table* ]
+|-G|\ *grdfile*
 [ |-C| ]
+[ |-D| ]
 [ |-E|\ **d**\|\ **n**\|\ **z**\ [*dist*] ]
 [ |SYN_OPT-I| ]
 [ |-L|\ *unit* ]
@@ -69,6 +71,12 @@ Optional Arguments
     (geographic or Cartesian 3-D vectors) at any given time, translating
     from one form to the other when necessary [Default keeps both arrays
     in memory]. Not applicable with **-Q**.
+
+.. _-D:
+
+**-D**
+    Used to skip duplicate points since the algorithm cannot handle them.
+    [Default assumes there are no duplicates].
 
 .. _-E:
 

--- a/doc/rst/source/sphinterpolate.rst
+++ b/doc/rst/source/sphinterpolate.rst
@@ -162,6 +162,7 @@ in the input.  It is best that the user ensures that this is the case.  GMT has 
 such as :doc:`blockmean` and others, to combine close points into single entries.
 Also, **sphinterpolate** has a **-D** option to determine and exclude duplicates, but
 it is a very brute-force yet exact comparision that is very slow for large data sets.
+Detection of duplicates in the STRIPACK library will exit the module.
 
 See Also
 --------

--- a/doc/rst/source/sphinterpolate.rst
+++ b/doc/rst/source/sphinterpolate.rst
@@ -154,6 +154,15 @@ degree grid with no tension, use::
 
     gmt sphinterpolate testdata.txt -Rg -I1 -Gsolution.nc
 
+Notes
+-----
+
+The STRIPACK algorithm and implementation expect that there are no duplicate points
+in the input.  It is best that the user ensures that this is the case.  GMT has tools,
+such as :doc:`blockmean` and others, to combine close points into single entries.
+Also, **sphinterpolate** has a **-D** option to determine and exclude duplicates, but
+it is a very brute-force yet exact comparision that is very slow for large data sets.
+
 See Also
 --------
 

--- a/doc/rst/source/sphinterpolate.rst
+++ b/doc/rst/source/sphinterpolate.rst
@@ -12,7 +12,9 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt sphinterpolate** [ *table* ] |-G|\ *grdfile*
+**gmt sphinterpolate** [ *table* ]
+|-G|\ *grdfile*
+[ |-D| ]
 [ |SYN_OPT-I| ]
 [ |-Q|\ *mode*\ [*options*] ]
 [ |SYN_OPT-R| ]
@@ -54,6 +56,12 @@ Optional Arguments
 
 .. |Add_intables| unicode:: 0x20 .. just an invisible code
 .. include:: explain_intables.rst_
+
+.. _-D:
+
+**-D**
+    Used to skip duplicate points since the algorithm cannot handle them.
+    [Default assumes there are no duplicates].
 
 .. _-I:
 

--- a/doc/rst/source/sphtriangulate.rst
+++ b/doc/rst/source/sphtriangulate.rst
@@ -12,9 +12,16 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt sphtriangulate** [ *table* ] [ |-A| ] [ |-C| ] [ |-D| ]
-[ |-L|\ *unit* ] [ |-N|\ *file* ] [ |-Q|\ **d**\|\ **v** ]
-[ |-T| ] [ |SYN_OPT-V| ]
+**gmt sphtriangulate**
+[ *table* ]
+[ |-A| ]
+[ |-C| ]
+[ |-D| ]
+[ |-L|\ *unit* ]
+[ |-N|\ *file* ]
+[ |-Q|\ **d**\|\ **v** ]
+[ |-T| ]
+[ |SYN_OPT-V| ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
 [ |SYN_OPT-e| ]

--- a/doc/rst/source/sphtriangulate.rst
+++ b/doc/rst/source/sphtriangulate.rst
@@ -174,6 +174,15 @@ in the header record, try
 
     gmt sphtriangulate globalnodes.txt -Qd -A > global_tri.txt
 
+Notes
+-----
+
+The STRIPACK algorithm and implementation expect that there are no duplicate points
+in the input.  It is best that the user ensures that this is the case.  GMT has tools,
+such as :doc:`blockmean` and others, to combine close points into single entries.
+Also, **sphtriangulate** has a **-D** option to determine and exclude duplicates, but
+it is a very brute-force yet exact comparision that is very slow for large data sets.
+
 See Also
 --------
 

--- a/doc/rst/source/sphtriangulate.rst
+++ b/doc/rst/source/sphtriangulate.rst
@@ -182,6 +182,7 @@ in the input.  It is best that the user ensures that this is the case.  GMT has 
 such as :doc:`blockmean` and others, to combine close points into single entries.
 Also, **sphtriangulate** has a **-D** option to determine and exclude duplicates, but
 it is a very brute-force yet exact comparision that is very slow for large data sets.
+Detection of duplicates in the STRIPACK library will exit the module.
 
 See Also
 --------

--- a/src/gmt_sph.c
+++ b/src/gmt_sph.c
@@ -81,11 +81,10 @@ int gmt_stripack_lists (struct GMT_CTRL *GMT, uint64_t n_in, double *x, double *
 
 	/* Create the triangulation. Main output is (list, lptr, lend) */
 
-	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Call STRIPACK TRMESH subroutine...");
+	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Call STRIPACK TRMESH subroutine\n");
 	trmesh_ (&n, x, y, z, list, lptr, lend, &lnew, iwk, &iwk[n], ds, &ierror);
 	gmt_M_free (GMT, ds);
 	gmt_M_free (GMT, iwk);
-	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "OK\n");
 
 	if (ierror == -2) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "STRIPACK: Failure in TRMESH. The first 3 nodes are collinear.\n");
@@ -114,9 +113,8 @@ int gmt_stripack_lists (struct GMT_CTRL *GMT, uint64_t n_in, double *x, double *
 
 	n_alloc = 2 * (n - 2);
 	T->D.tri = gmt_M_memory (GMT, NULL, TRI_NROW*n_alloc, int64_t);
-	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Call STRIPACK TRLIST subroutine...");
+	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Call STRIPACK TRLIST subroutine\n");
 	trlist_ (&n, list, lptr, lend, &nrow, &n_out, T->D.tri, &ierror);
-	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "OK\n");
 	T->D.n = n_out;
 
 	if (ierror) {
@@ -141,9 +139,8 @@ int gmt_stripack_lists (struct GMT_CTRL *GMT, uint64_t n_in, double *x, double *
 		T->V.listc = gmt_M_memory (GMT, NULL, n_alloc, int64_t);
 		lbtri = gmt_M_memory (GMT, NULL, 6*n, int64_t);
 
-		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Call STRIPACK CRLIST subroutine...");
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Call STRIPACK CRLIST subroutine\n");
 		crlist_ (&n, &n, x, y, z, list, lend, lptr, &lnew, lbtri, T->V.listc, &n_out, xc, yc, zc, rc, &ierror);
-		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "OK\n");
 		T->V.n = n_out;
 		gmt_M_free (GMT, lbtri);
 		gmt_M_free (GMT, rc);

--- a/src/sphdistance.c
+++ b/src/sphdistance.c
@@ -59,6 +59,9 @@ struct SPHDISTANCE_CTRL {
 	struct SPHDISTANCE_C {	/* -C */
 		bool active;
 	} C;
+	struct SPHDISTANCE_D {	/* -D for variable tension */
+		bool active;
+	} D;
 	struct SPHDISTANCE_E {	/* -Ed|n|z[<dist>] */
 		bool active;
 		unsigned int mode;
@@ -136,7 +139,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "\t==> The hard work is done by algorithms 772 (STRIPACK) & 773 (SSRFPACK) by R. J. Renka [1997] <==\n\n");
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] -G<outgrid> %s [-C] [-En|z|d[<dr>]]\n", name, GMT_I_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] -G<outgrid> %s [-C] [-D] [-En|z|d[<dr>]]\n", name, GMT_I_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-L<unit>] [-N<nodetable>] [-Q<voronoitable>] [%s] [%s] [%s] [%s]\n", GMT_Rgeo_OPT, GMT_V_OPT, GMT_bi_OPT, GMT_di_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [%s]\n\t[%s] [%s] [%s] [%s] [%s] [%s]\n\n", GMT_e_OPT, GMT_h_OPT, GMT_i_OPT, GMT_j_OPT, GMT_qi_OPT, GMT_r_OPT, GMT_s_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
@@ -152,6 +155,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-A Suppress connecting Voronoi arcs using great circles, i.e., connect by straight lines,\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   unless m or p is appended to first follow meridian then parallel, or vice versa.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Conserve memory (Converts lon/lat <--> x/y/z when needed) [store both in memory]. Not used with -Q.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-D Delete any duplicate points [Default assumes there are no duplicates].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-E Specify the quantity that should be assigned to the grid nodes:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   -En The Voronoi polygon ID.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   -Ez The z-value of the Voronoi center node (natural NN gridding).\n");
@@ -192,10 +196,7 @@ static int parse (struct GMT_CTRL *GMT, struct SPHDISTANCE_CTRL *Ctrl, struct GM
 				Ctrl->C.active = true;
 				break;
 			case 'D':
-				if (gmt_M_compat_check (GMT, 4))
-					GMT_Report (API, GMT_MSG_COMPAT, "-D option is deprecated; duplicates are automatically removed.\n");
-				else
-					n_errors += gmt_default_error (GMT, opt->option);
+				Ctrl->D.active = true;
 				break;
 			case 'E':
 				Ctrl->E.active = true;
@@ -408,22 +409,24 @@ EXTERN_MSC int GMT_sphdistance (void *V_API, int mode, void *args) {
 				Return (API->error);
 			}
 
-			/* Data record to process - avoid duplicate points as gmt_stripack_lists cannot handle that */
+			/* Data record to process - avoid duplicate points with -D as gmt_stripack_lists cannot handle that */
 			in = In->data;	/* Only need to process numerical part here */
 
-			if (first) {	/* Beginning of new segment; keep track of the very first coordinate in case of duplicates */
-				first_x = prev_x = in[GMT_X];	first_y = prev_y = in[GMT_Y];
-			}
-			else {	/* Look for duplicate point at end of segments that replicate start point */
-				if (in[GMT_X] == first_x && in[GMT_Y] == first_y) {	/* If any point after the first matches the first */
-					n_dup++;
-					continue;
+			if (Ctrl->D.active) {	/* Check for duplicates */
+				if (first) {	/* Beginning of new segment; keep track of the very first coordinate in case of duplicates */
+					first_x = prev_x = in[GMT_X];	first_y = prev_y = in[GMT_Y];
 				}
-				if (n && in[GMT_X] == prev_x && in[GMT_Y] == prev_y) {	/* Identical neighbors */
-					n_dup++;
-					continue;
+				else {	/* Look for duplicate point at end of segments that replicate start point */
+					if (in[GMT_X] == first_x && in[GMT_Y] == first_y) {	/* If any point after the first matches the first */
+						n_dup++;
+						continue;
+					}
+					if (n && in[GMT_X] == prev_x && in[GMT_Y] == prev_y) {	/* Identical neighbors */
+						n_dup++;
+						continue;
+					}
+					prev_x = in[GMT_X];	prev_y = in[GMT_Y];
 				}
-				prev_x = in[GMT_X];	prev_y = in[GMT_Y];
 			}
 
 			/* Convert lon,lat in degrees to Cartesian x,y,z triplets */

--- a/src/sphdistance.c
+++ b/src/sphdistance.c
@@ -450,7 +450,15 @@ EXTERN_MSC int GMT_sphdistance (void *V_API, int mode, void *args) {
 		if (!Ctrl->C.active) gmt_M_malloc2 (GMT, lon, lat, 0, &n_alloc, double);
 		gmt_M_malloc3 (GMT, xx, yy, zz, 0, &n_alloc, double);
 
-		if (n_dup) GMT_Report (API, GMT_MSG_WARNING, "Skipped %" PRIu64 " duplicate points in segments\n", n_dup);
+		if (Ctrl->D.active) {	/* Report */
+			if (n_dup)
+				GMT_Report (API, GMT_MSG_WARNING, "Skipped %" PRIu64 " duplicate points in segments\n", n_dup);
+			else
+				GMT_Report (API, GMT_MSG_INFORMATION, "No duplicate points found in the segments\n");
+		}
+		else
+			GMT_Report (API, GMT_MSG_INFORMATION, "No duplicate check performed [-D was not activated]\n");
+
 		GMT_Report (API, GMT_MSG_INFORMATION, "Do Voronoi construction using %" PRIu64 " points\n", n);
 
 		T.mode = VORONOI;

--- a/src/sphinterpolate.c
+++ b/src/sphinterpolate.c
@@ -337,6 +337,10 @@ EXTERN_MSC int GMT_sphinterpolate (void *V_API, int mode, void *args) {
 		}
 		Return (API->error);
 	}
+	if (Ctrl->D.active)	/* Report */
+		GMT_Report (API, GMT_MSG_INFORMATION, "No duplicate points found in the input data\n");
+	else
+		GMT_Report (API, GMT_MSG_INFORMATION, "No duplicate check performed [-D was not activated]\n");
 
 	n_alloc = n;
 	gmt_M_malloc4 (GMT, xx, yy, zz, ww, 0, &n_alloc, double);

--- a/src/sphtriangulate.c
+++ b/src/sphtriangulate.c
@@ -652,7 +652,15 @@ EXTERN_MSC int GMT_sphtriangulate (void *V_API, int mode, void *args) {
 	gmt_M_malloc3 (GMT, xx, yy, zz, 0, &n_alloc, double);
 	GMT->session.min_meminc = GMT_MIN_MEMINC;		/* Reset to the default value */
 
-	if (Ctrl->D.active && n_dup) GMT_Report (API, GMT_MSG_INFORMATION, "Skipped %d duplicate points in segments\n", n_dup);
+	if (Ctrl->D.active) {	/* Report */
+		if (n_dup)
+			GMT_Report (API, GMT_MSG_WARNING, "Skipped %d duplicate points in segments\n", n_dup);
+		else
+			GMT_Report (API, GMT_MSG_INFORMATION, "No duplicate points found in the segments\n");
+	}
+	else
+		GMT_Report (API, GMT_MSG_INFORMATION, "No duplicate check performed [-D was not activated]\n");
+
 	GMT_Report (API, GMT_MSG_INFORMATION, "Do Voronoi construction using %d points\n", n);
 
 	gmt_M_memset (&T, 1, struct STRIPACK);

--- a/src/sphtriangulate.c
+++ b/src/sphtriangulate.c
@@ -439,7 +439,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   If -T is selected we print arc lengths instead.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Cannot be used with the binary output option.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Conserve memory (Converts lon/lat <--> x/y/z when needed) [store both in memory].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-D Skip repeated input vertex at the end of a closed segment.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-D Delete any duplicate points [Default assumes there are no duplicates].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-L Set distance unit arc (d)egree, m(e)ter, (f)oot, (k)m, (M)ile, (n)autical mile, or s(u)rvey foot [e].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Output filename for Delaunay or Voronoi polygon information [Store in output segment headers].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Delaunay: output is the node triplets and area (i, j, k, area).\n");


### PR DESCRIPTION
**Description of proposed changes**

See #4252 for context.  This PR adds (or resurrects) a **-D** option across the sph*c modules where one now will have to add **-D** to experience that slow check - otherwise it is up to you to ensure you have unique locations (e.g., via **blockmean** or similar).  I have improved the documentation accordingly as well as some of the warning/information reporting.  The user's case now takes ~30 minutes for me (debug build - probably faster as release).
