### PR TITLE
Sphinterpolate improvement

### DIFF
--- a/doc/rst/source/sphinterpolate.rst
+++ b/doc/rst/source/sphinterpolate.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt sphinterpolate** [ *table* ]
 |-G|\ *grdfile*
-[ |-D| ]
+[ |-D|\ [*east*] ]
 [ |SYN_OPT-I| ]
 [ |-Q|\ *mode*\ [*options*] ]
 [ |SYN_OPT-R| ]
@@ -59,9 +59,11 @@ Optional Arguments
 
 .. _-D:
 
-**-D**
-    Used to skip duplicate points since the algorithm cannot handle them.
-    [Default assumes there are no duplicates].
+**-D**\ [*east*]
+    Skip duplicate points since the spherical gridding algorithm cannot handle them.
+    [Default assumes there are no duplicates, except possibly at the poles].
+    Append a repeating longitude (*east*) to skip records with that longitude instead
+    of the full (slow) search for duplicates.
 
 .. _-I:
 
@@ -161,7 +163,8 @@ The STRIPACK algorithm and implementation expect that there are no duplicate poi
 in the input.  It is best that the user ensures that this is the case.  GMT has tools,
 such as :doc:`blockmean` and others, to combine close points into single entries.
 Also, **sphinterpolate** has a **-D** option to determine and exclude duplicates, but
-it is a very brute-force yet exact comparision that is very slow for large data sets.
+it is a very brute-force yet exact comparison that is very slow for large data sets.
+A much quicker check involves appending a specific repeating longitude value.
 Detection of duplicates in the STRIPACK library will exit the module.
 
 See Also

--- a/src/sphinterpolate.c
+++ b/src/sphinterpolate.c
@@ -110,8 +110,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t<table> is one or more data file (in ASCII, binary, netCDF) with (x,y,z[,w]).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If no files are given, standard input is read.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-D Delete exact duplicate points [Default assumes there are no duplicates].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-D Delete exact duplicate points [Default deletes no duplicates except at poles].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append <east> to exclude points with this particular longitude as repeating west.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   [-D with no arg does a full comprehensive duplicate check - this may be very slow].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Q Compute tension factors to achieve the following [Default is no tension]:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   p: Piecewise linear interpolation ; no tension [Default]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   l: Smooth interpolation with local gradient estimates.\n");


### PR DESCRIPTION
**Description of proposed changes**

Strengthen **sphinterpolate** against duplicates by

1. Always skip repeated pole point values
2. Optionally skip repeated east values (**-D**_east_)
3. Perform full search and deletion of duplicates (very slow; **-D**)

I also fixed a few memory leaks in gmt_sph.c and update the docs.  Closes #4254.
