### PR TITLE
Improve the subplot with inside annotation/tick system

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12939,6 +12939,8 @@ struct GMT_SUBPLOT *gmt_subplot_info (struct GMTAPI_CTRL *API, int fig) {
 				sscanf (&line[13], "%lg %lg", &P->dim[GMT_X], &P->dim[GMT_Y]);
 			else if (!strncmp (line, "# PARALLEL:", 11U))
 				P->parallel = atoi (&line[12]);
+			else if (!strncmp (line, "# INSIDE:", 9U))
+				P->inside = atoi (&line[12]);
 			else if (!strncmp (line, "# DIRECTION:", 12U))
 				sscanf (&line[13], "%d %d", &P->dir[GMT_X], &P->dir[GMT_Y]);
 			else if (!strncmp (line, "# GAPS:", 7U))

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12941,7 +12941,7 @@ struct GMT_SUBPLOT *gmt_subplot_info (struct GMTAPI_CTRL *API, int fig) {
 				P->parallel = atoi (&line[12]);
 			else if (!strncmp (line, "# INSIDE:", 9U))
 				P->inside = atoi (&line[10]);
-			else if (!strncmp (line, "# DIRECTION:", 1U))
+			else if (!strncmp (line, "# DIRECTION:", 12U))
 				sscanf (&line[13], "%d %d", &P->dir[GMT_X], &P->dir[GMT_Y]);
 			else if (!strncmp (line, "# GAPS:", 7U))
 				sscanf (&line[8], "%lg %lg %lg %lg", &P->gap[XLO], &P->gap[XHI], &P->gap[YLO], &P->gap[YHI]);

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12940,8 +12940,8 @@ struct GMT_SUBPLOT *gmt_subplot_info (struct GMTAPI_CTRL *API, int fig) {
 			else if (!strncmp (line, "# PARALLEL:", 11U))
 				P->parallel = atoi (&line[12]);
 			else if (!strncmp (line, "# INSIDE:", 9U))
-				P->inside = atoi (&line[12]);
-			else if (!strncmp (line, "# DIRECTION:", 12U))
+				P->inside = atoi (&line[10]);
+			else if (!strncmp (line, "# DIRECTION:", 1U))
 				sscanf (&line[13], "%d %d", &P->dir[GMT_X], &P->dir[GMT_Y]);
 			else if (!strncmp (line, "# GAPS:", 7U))
 				sscanf (&line[8], "%lg %lg %lg %lg", &P->gap[XLO], &P->gap[XHI], &P->gap[YLO], &P->gap[YHI]);
@@ -14088,6 +14088,11 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 					else if ((opt = GMT_Make_Option (API, 'B', "0")) == NULL) return NULL;	/* Add -B0 to just draw frame */
 					if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
 					GMT_Report (API, GMT_MSG_DEBUG, "Subplot-checker added -B frame option with arg %s\n", arg);
+				}
+				if (P->inside) {	/* Ensure we get inside ticks/annots */
+					GMT_Report (API, GMT_MSG_DEBUG, "Subplot-checker added --MAP_FRAME_TYPE=inside\n");
+					if ((opt = GMT_Make_Option (API, '-', "MAP_FRAME_TYPE=inside")) == NULL) return NULL;
+					if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
 				}
 				if (!x_set) {	/* Did not specify x-axis setting either via -Bx or -B so do that now */
 					snprintf (arg, GMT_LEN256, "x%s", P->Bxannot);	/* Start with the x tick,annot,grid choices */

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -164,6 +164,7 @@ struct GMT_SUBPLOT {
 	unsigned int first;		/* 1 the first time we reach panel, 0 later */
 	unsigned int no_scaling;	/* 1 when we are plotting a scale, bar, etc and not map and don't want to auto-scale plot */
 	unsigned int parallel;	/* 1 for axis-parallel annotations [0 for standard] */
+	unsigned int inside;	/* 1 if all annots/ticks are inside panels [0 for outside] */
 	int row, col;			/* Current panel position e.g., 0,0 */
 	int nrows, ncolumns;	/* Panel arrangement for subplot window */
 	int dir[2];				/* Cartesian axis direction: +1 or -1 [1/1] */

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -1109,6 +1109,7 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 		fprintf (fp, "# ORIGIN: %g %g\n", off[GMT_X], off[GMT_Y]);
 		fprintf (fp, "# DIMENSION: %g %g\n", width, height);
 		fprintf (fp, "# PARALLEL: %d\n", Ctrl->S[GMT_Y].parallel);
+		fprintf (fp, "# INSIDE: %d\n", (GMT->current.setting.map_frame_type == GMT_IS_INSIDE) ? 1 : 0);
 		if (Ctrl->C.active) {	/* Got common gaps setting */
 			gmt_M_memcpy (GMT->current.plot.panel.gap, Ctrl->C.gap, 4, double);
 			fprintf (fp, "# GAPS: %g %g %g %g\n", Ctrl->C.gap[XLO], Ctrl->C.gap[XHI], Ctrl->C.gap[YLO], Ctrl->C.gap[YHI]);

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -64,7 +64,7 @@
 #define THIS_MODULE_PURPOSE	"Manage modern mode figure subplot configuration and selection"
 #define THIS_MODULE_KEYS	""
 #define THIS_MODULE_NEEDS	""
-#define THIS_MODULE_OPTIONS	"JRVXY"
+#define THIS_MODULE_OPTIONS	"-JRVXY"
 
 /* Control structure for subplot */
 

--- a/test/subplot/panelsinside.sh
+++ b/test/subplot/panelsinside.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # Test very minimal 2x2 basemap matrix under inside frame type
 gmt begin panelsinside ps
-  gmt set MAP_FRAME_TYPE inside
-  gmt subplot begin 2x2 -Fs3i -M5p -A -SCb -SRl -Bwstr -R0/80/0/10 -T"Inside annotations"
+  gmt subplot begin 2x2 -Fs3i -M5p -A -SCb -SRl -Bwstr -R0/80/0/10 -T"Inside annotations" --MAP_FRAME_TYPE=inside
     gmt basemap
     gmt basemap -c
     gmt basemap -c


### PR DESCRIPTION
**Description of proposed changes**

While running gmt set MAP_FRAME_TYPE plain before gmt subset begin worked, it did not work to just add --MAP_FRAME_TYPE=plain to the gmt subplot begin call.  This turned out to be a lack of "-" in the THIS_MODULE_OPTIONS in subplot.c which prevented parsing of --.  With that added,  that solution works and the lone inside subplot script was updated to use that mechanism instead of gmt set.  I see think PR approved because it improves the handling of inside frames but still plots the frame on the first plot - thus future plot call may obscure ticks and annotations.  I will work on that next.