### PR TITLE
subplot set fails if not given index|row,col

### DIFF
--- a/src/subplot.c
+++ b/src/subplot.c
@@ -279,7 +279,7 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 		Ctrl->In.mode = SUBPLOT_END;
 	else if (!strncmp (opt->arg, "set", 3U)) {	/* Explicitly called set row,col or set index */
 		opt = opt->next;	/* The row,col part */
-		if (opt) {	/* There is an argument */
+		if (opt && opt->option == GMT_OPT_INFILE) {	/* There is an argument without a leading -? option (thus flagged as input file) */
 			if (isdigit (opt->arg[0]) && (n = sscanf (opt->arg, "%d,%d", &Ctrl->In.row, &Ctrl->In.col)) < 1) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to parse row,col: %s\n", opt->arg);
 				return GMT_PARSE_ERROR;


### PR DESCRIPTION
Per the subplot documentation, **gmt subplot set** without any _row,col_ or _index_ shall go to the next logical panel, but in reality it fails parsing by trying to read the next option.  This PR checks if the next option is a non-option argument (hence flagged as "input file") and only then tries to parse.  Otherwise we default to the next panel.
