### PR TITLE
Forgot to rewind opt

### DIFF
--- a/src/subplot.c
+++ b/src/subplot.c
@@ -293,6 +293,7 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 		else {	/* Default to go to next subplot */
 			Ctrl->In.row = 0;
 			Ctrl->In.next = true;
+			if (opt) opt = opt->previous;	/* Since we will advance below */
 		}
 		Ctrl->In.mode = SUBPLOT_SET;
 	}


### PR DESCRIPTION
When opt is not used to determine _row,col|index_ we must reset opt to the previous opt for the rest of the logic in the parser to work. My first implementation would just eat the next opt, like **-A**_alternatetext_.
