### PR TITLE
Allow histograms with custom bar width and optional shift

### DIFF
--- a/doc/rst/source/histogram.rst
+++ b/doc/rst/source/histogram.rst
@@ -18,6 +18,7 @@ Synopsis
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
 [ |-D|\ [**+b**][**+f**\ *font*][**+o**\ *off*][**+r**] ]
+[ |-E|\ *width*\ [**+o**\ *offset*] ]
 [ |-F| ]
 [ |-G|\ *fill* ] [ |-J|\ **z**\|\ **Z**\ *parameters* ]
 [ |-I|\ [**o**\|\ **O**] ]

--- a/doc/rst/source/histogram_common.rst_
+++ b/doc/rst/source/histogram_common.rst_
@@ -57,6 +57,17 @@ Optional Arguments
     annotation font; use **+o** to change the offset between bar and label [6p];
     use **+r** to rotate the labels from horizontal to vertical.
 
+.. _-E:
+
+**-E**\ *width*\ [**+o**\ *offset*]
+    Use an alternative histogram bar width than the default set via **-T**,
+    and optionally shift all bars by an *offset*.  Here *width* is either
+    an alternative width in data units, or the user may append a valid plot
+    dimension unit (**c**\|\ **i**\|\ **p**) for a fixed dimension instead.
+    Optionally, all bins may be shifted along the axis by *offset*. As for
+    *width*, it may be given in data units of plot dimension units by appending
+    the relevant unit.
+
 .. _-F:
 
 **-F**

--- a/doc/rst/source/pshistogram.rst
+++ b/doc/rst/source/pshistogram.rst
@@ -18,6 +18,7 @@ Synopsis
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
 [ |-D|\ [**+b**][**+f**\ *font*][**+o**\ *off*][**+r**] ]
+[ |-E|\ *width*\ [**+o**\ *offset*] ]
 [ |-F| ]
 [ |-G|\ *fill* ]
 [ |-I|\ [**o**\|\ **O**] ]

--- a/test/pshistogram/altwidth.ps
+++ b/test/pshistogram/altwidth.ps
@@ -1,0 +1,1448 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.2.0_f0f626b_2020.09.27 [64-bit] Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun Sep 27 15:20:16 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot -R0/5.74792/0/8.73994 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 5.74792000 0.00000000 8.73994000 0.000 5.748 0.000 8.740 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 7181 TM
+% PostScript produced by:
+%@GMT: gmt histogram hist.txt -T0.2 -Gred -W0.5p -BWrts -Bxaf -Byaf -Xa0i -Ya5.984i -R3/7/0/8 -JX15c
+%@PROJ: xy 3.00000000 7.00000000 0.00000000 8.00000000 3.000 7.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 7181 T
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(No ­E) tl Z
+U
+}!
+clipsave
+0 0 M
+3307 0 D
+0 3307 D
+-3307 0 D
+P
+PSL_clip N
+8 W
+{1 0 0 C} FS
+O1
+-166 0 0 413 166 0 3 661 0 SP
+-165 0 0 1240 165 0 3 827 0 SP
+-165 0 0 2067 165 0 3 992 0 SP
+-166 0 0 1654 166 0 3 1157 0 SP
+-165 0 0 1654 165 0 3 1323 0 SP
+-166 0 0 1654 166 0 3 1488 0 SP
+-165 0 0 2894 165 0 3 1654 0 SP
+-165 0 0 2480 165 0 3 1819 0 SP
+-166 0 0 2480 166 0 3 1984 0 SP
+-165 0 0 1654 165 0 3 2150 0 SP
+-165 0 0 413 165 0 3 2315 0 SP
+-166 0 0 413 166 0 3 2480 0 SP
+-165 0 0 413 165 0 3 2646 0 SP
+PSL_cliprestore
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+827 PSL_A0_y MM
+(2) mr Z
+1654 PSL_A0_y MM
+(4) mr Z
+2480 PSL_A0_y MM
+(6) mr Z
+3307 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3307 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+-3307 0 T
+N 0 0 M 3307 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 827 0 M 0 -83 D S
+N 1654 0 M 0 -83 D S
+N 2480 0 M 0 -83 D S
+N 3307 0 M 0 -83 D S
+N 165 0 M 0 -42 D S
+N 331 0 M 0 -42 D S
+N 496 0 M 0 -42 D S
+N 661 0 M 0 -42 D S
+N 992 0 M 0 -42 D S
+N 1157 0 M 0 -42 D S
+N 1323 0 M 0 -42 D S
+N 1488 0 M 0 -42 D S
+N 1819 0 M 0 -42 D S
+N 1984 0 M 0 -42 D S
+N 2150 0 M 0 -42 D S
+N 2315 0 M 0 -42 D S
+N 2646 0 M 0 -42 D S
+N 2811 0 M 0 -42 D S
+N 2976 0 M 0 -42 D S
+N 3142 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 3307 0 D S
+0 -3307 T
+0 setlinecap
+%%EndObject
+0 -7181 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3590 7181 TM
+% PostScript produced by:
+%@GMT: gmt histogram hist.txt -T0.2 -Gred -W0.5p -E0.1 -Bwrts -Bxaf -Byaf -Xa2.992i -Ya5.984i -R3/7/0/8 -JX15c
+%@PROJ: xy 3.00000000 7.00000000 0.00000000 8.00000000 3.000 7.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+3590 7181 T
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(w=0.1) tl Z
+U
+}!
+clipsave
+0 0 M
+3307 0 D
+0 3307 D
+-3307 0 D
+P
+PSL_clip N
+8 W
+{1 0 0 C} FS
+O1
+-82 0 0 413 82 0 3 703 0 SP
+-83 0 0 1240 83 0 3 868 0 SP
+-83 0 0 2067 83 0 3 1033 0 SP
+-82 0 0 1654 82 0 3 1199 0 SP
+-83 0 0 1654 83 0 3 1364 0 SP
+-82 0 0 1654 82 0 3 1530 0 SP
+-83 0 0 2894 83 0 3 1695 0 SP
+-83 0 0 2480 83 0 3 1860 0 SP
+-82 0 0 2480 82 0 3 2026 0 SP
+-83 0 0 1654 83 0 3 2191 0 SP
+-83 0 0 413 83 0 3 2356 0 SP
+-82 0 0 413 82 0 3 2522 0 SP
+-83 0 0 413 83 0 3 2687 0 SP
+PSL_cliprestore
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3307 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+-3307 0 T
+N 0 0 M 3307 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 827 0 M 0 -83 D S
+N 1654 0 M 0 -83 D S
+N 2480 0 M 0 -83 D S
+N 3307 0 M 0 -83 D S
+N 165 0 M 0 -42 D S
+N 331 0 M 0 -42 D S
+N 496 0 M 0 -42 D S
+N 661 0 M 0 -42 D S
+N 992 0 M 0 -42 D S
+N 1157 0 M 0 -42 D S
+N 1323 0 M 0 -42 D S
+N 1488 0 M 0 -42 D S
+N 1819 0 M 0 -42 D S
+N 1984 0 M 0 -42 D S
+N 2150 0 M 0 -42 D S
+N 2315 0 M 0 -42 D S
+N 2646 0 M 0 -42 D S
+N 2811 0 M 0 -42 D S
+N 2976 0 M 0 -42 D S
+N 3142 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 3307 0 D S
+0 -3307 T
+0 setlinecap
+%%EndObject
+-3590 -7181 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 3590 TM
+% PostScript produced by:
+%@GMT: gmt histogram hist.txt -T0.2 -Gred -W0.5p -E0.1+o-0.05 -BWrts -Bxaf -Byaf -Xa0i -Ya2.992i -R3/7/0/8 -JX15c
+%@PROJ: xy 3.00000000 7.00000000 0.00000000 8.00000000 3.000 7.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 3590 T
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(w=0.1 |off|=0.05) tl Z
+U
+}!
+clipsave
+0 0 M
+3307 0 D
+0 3307 D
+-3307 0 D
+P
+PSL_clip N
+8 W
+{1 0 0 C} FS
+O1
+-83 0 0 413 83 0 3 661 0 SP
+-82 0 0 1240 82 0 3 827 0 SP
+-83 0 0 2067 83 0 3 992 0 SP
+-83 0 0 1654 83 0 3 1157 0 SP
+-83 0 0 1654 83 0 3 1323 0 SP
+-83 0 0 1654 83 0 3 1488 0 SP
+-82 0 0 2894 82 0 3 1654 0 SP
+-83 0 0 2480 83 0 3 1819 0 SP
+-83 0 0 2480 83 0 3 1984 0 SP
+-82 0 0 1654 82 0 3 2150 0 SP
+-83 0 0 413 83 0 3 2315 0 SP
+-83 0 0 413 83 0 3 2480 0 SP
+-82 0 0 413 82 0 3 2646 0 SP
+PSL_cliprestore
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+827 PSL_A0_y MM
+(2) mr Z
+1654 PSL_A0_y MM
+(4) mr Z
+2480 PSL_A0_y MM
+(6) mr Z
+3307 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3307 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+-3307 0 T
+N 0 0 M 3307 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 827 0 M 0 -83 D S
+N 1654 0 M 0 -83 D S
+N 2480 0 M 0 -83 D S
+N 3307 0 M 0 -83 D S
+N 165 0 M 0 -42 D S
+N 331 0 M 0 -42 D S
+N 496 0 M 0 -42 D S
+N 661 0 M 0 -42 D S
+N 992 0 M 0 -42 D S
+N 1157 0 M 0 -42 D S
+N 1323 0 M 0 -42 D S
+N 1488 0 M 0 -42 D S
+N 1819 0 M 0 -42 D S
+N 1984 0 M 0 -42 D S
+N 2150 0 M 0 -42 D S
+N 2315 0 M 0 -42 D S
+N 2646 0 M 0 -42 D S
+N 2811 0 M 0 -42 D S
+N 2976 0 M 0 -42 D S
+N 3142 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 3307 0 D S
+0 -3307 T
+0 setlinecap
+%%EndObject
+0 -3590 TM
+0 A
+FQ
+O0
+0 3590 TM
+% PostScript produced by:
+%@GMT: gmt histogram hist.txt -T0.2 -Ggreen -W0.5p -E0.1+o0.05 -Xa0i -Ya2.992i -R3/7/0/8 -JX15c
+%@PROJ: xy 3.00000000 7.00000000 0.00000000 8.00000000 3.000 7.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3307 0 D
+0 3307 D
+-3307 0 D
+P
+PSL_clip N
+8 W
+{0 1 0 C} FS
+O1
+-83 0 0 413 83 0 3 744 0 SP
+-83 0 0 1240 83 0 3 909 0 SP
+-82 0 0 2067 82 0 3 1075 0 SP
+-83 0 0 1654 83 0 3 1240 0 SP
+-82 0 0 1654 82 0 3 1406 0 SP
+-83 0 0 1654 83 0 3 1571 0 SP
+-83 0 0 2894 83 0 3 1736 0 SP
+-82 0 0 2480 82 0 3 1902 0 SP
+-83 0 0 2480 83 0 3 2067 0 SP
+-83 0 0 1654 83 0 3 2232 0 SP
+-82 0 0 413 82 0 3 2398 0 SP
+-83 0 0 413 83 0 3 2563 0 SP
+-83 0 0 413 83 0 3 2728 0 SP
+PSL_cliprestore
+%%EndObject
+0 -3590 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3590 3590 TM
+% PostScript produced by:
+%@GMT: gmt histogram hist.txt -T0.2 -Gred -W0.5p -E0.1c -Bwrts -Bxaf -Byaf -Xa2.992i -Ya2.992i -R3/7/0/8 -JX15c
+%@PROJ: xy 3.00000000 7.00000000 0.00000000 8.00000000 3.000 7.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+3590 3590 T
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(w=0.1c) tl Z
+U
+}!
+clipsave
+0 0 M
+3307 0 D
+0 3307 D
+-3307 0 D
+P
+PSL_clip N
+8 W
+{1 0 0 C} FS
+O1
+-48 0 0 413 48 0 3 720 0 SP
+-47 0 0 1240 47 0 3 886 0 SP
+-47 0 0 2067 47 0 3 1051 0 SP
+-47 0 0 1654 47 0 3 1217 0 SP
+-47 0 0 1654 47 0 3 1382 0 SP
+-47 0 0 1654 47 0 3 1547 0 SP
+-47 0 0 2894 47 0 3 1713 0 SP
+-47 0 0 2480 47 0 3 1878 0 SP
+-48 0 0 2480 48 0 3 2043 0 SP
+-47 0 0 1654 47 0 3 2209 0 SP
+-47 0 0 413 47 0 3 2374 0 SP
+-48 0 0 413 48 0 3 2539 0 SP
+-47 0 0 413 47 0 3 2705 0 SP
+PSL_cliprestore
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3307 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+-3307 0 T
+N 0 0 M 3307 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 827 0 M 0 -83 D S
+N 1654 0 M 0 -83 D S
+N 2480 0 M 0 -83 D S
+N 3307 0 M 0 -83 D S
+N 165 0 M 0 -42 D S
+N 331 0 M 0 -42 D S
+N 496 0 M 0 -42 D S
+N 661 0 M 0 -42 D S
+N 992 0 M 0 -42 D S
+N 1157 0 M 0 -42 D S
+N 1323 0 M 0 -42 D S
+N 1488 0 M 0 -42 D S
+N 1819 0 M 0 -42 D S
+N 1984 0 M 0 -42 D S
+N 2150 0 M 0 -42 D S
+N 2315 0 M 0 -42 D S
+N 2646 0 M 0 -42 D S
+N 2811 0 M 0 -42 D S
+N 2976 0 M 0 -42 D S
+N 3142 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 3307 0 D S
+0 -3307 T
+0 setlinecap
+%%EndObject
+-3590 -3590 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt histogram hist.txt -T0.2 -Gred -W0.5p -E0.1c+o-0.05c -BWrtS -Bxaf -Byaf -Xa0i -Ya0i -R3/7/0/8 -JX15c
+%@PROJ: xy 3.00000000 7.00000000 0.00000000 8.00000000 3.000 7.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(w=0.1c off=­0.05c) tl Z
+U
+}!
+clipsave
+0 0 M
+3307 0 D
+0 3307 D
+-3307 0 D
+P
+PSL_clip N
+8 W
+{1 0 0 C} FS
+O1
+-47 0 0 413 47 0 3 697 0 SP
+-47 0 0 1240 47 0 3 862 0 SP
+-47 0 0 2067 47 0 3 1028 0 SP
+-47 0 0 1654 47 0 3 1193 0 SP
+-48 0 0 1654 48 0 3 1358 0 SP
+-47 0 0 1654 47 0 3 1524 0 SP
+-47 0 0 2894 47 0 3 1689 0 SP
+-48 0 0 2480 48 0 3 1854 0 SP
+-47 0 0 2480 47 0 3 2020 0 SP
+-47 0 0 1654 47 0 3 2185 0 SP
+-48 0 0 413 48 0 3 2350 0 SP
+-47 0 0 413 47 0 3 2516 0 SP
+-47 0 0 413 47 0 3 2681 0 SP
+PSL_cliprestore
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+827 PSL_A0_y MM
+(2) mr Z
+1654 PSL_A0_y MM
+(4) mr Z
+2480 PSL_A0_y MM
+(6) mr Z
+3307 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3307 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+-3307 0 T
+N 0 0 M 3307 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 827 0 M 0 -83 D S
+N 1654 0 M 0 -83 D S
+N 2480 0 M 0 -83 D S
+N 3307 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(3) sh mx
+(4) sh mx
+(5) sh mx
+(6) sh mx
+(7) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(3) bc Z
+827 PSL_A0_y MM
+(4) bc Z
+1654 PSL_A0_y MM
+(5) bc Z
+2480 PSL_A0_y MM
+(6) bc Z
+3307 PSL_A0_y MM
+(7) bc Z
+N 165 0 M 0 -42 D S
+N 331 0 M 0 -42 D S
+N 496 0 M 0 -42 D S
+N 661 0 M 0 -42 D S
+N 992 0 M 0 -42 D S
+N 1157 0 M 0 -42 D S
+N 1323 0 M 0 -42 D S
+N 1488 0 M 0 -42 D S
+N 1819 0 M 0 -42 D S
+N 1984 0 M 0 -42 D S
+N 2150 0 M 0 -42 D S
+N 2315 0 M 0 -42 D S
+N 2646 0 M 0 -42 D S
+N 2811 0 M 0 -42 D S
+N 2976 0 M 0 -42 D S
+N 3142 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 3307 0 D S
+0 -3307 T
+0 setlinecap
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3590 0 TM
+% PostScript produced by:
+%@GMT: gmt histogram hist.txt -T0.2 -Gred -W0.5p -E0.1c+o-0.05c -BwrtS -Bxaf -Byaf -Xa2.992i -Ya0i -R3/7/0/8 -JX15c
+%@PROJ: xy 3.00000000 7.00000000 0.00000000 8.00000000 3.000 7.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+3590 0 T
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(w=0.1c |off|=0.05c) tl Z
+U
+}!
+clipsave
+0 0 M
+3307 0 D
+0 3307 D
+-3307 0 D
+P
+PSL_clip N
+8 W
+{1 0 0 C} FS
+O1
+-47 0 0 413 47 0 3 697 0 SP
+-47 0 0 1240 47 0 3 862 0 SP
+-47 0 0 2067 47 0 3 1028 0 SP
+-47 0 0 1654 47 0 3 1193 0 SP
+-48 0 0 1654 48 0 3 1358 0 SP
+-47 0 0 1654 47 0 3 1524 0 SP
+-47 0 0 2894 47 0 3 1689 0 SP
+-48 0 0 2480 48 0 3 1854 0 SP
+-47 0 0 2480 47 0 3 2020 0 SP
+-47 0 0 1654 47 0 3 2185 0 SP
+-48 0 0 413 48 0 3 2350 0 SP
+-47 0 0 413 47 0 3 2516 0 SP
+-47 0 0 413 47 0 3 2681 0 SP
+PSL_cliprestore
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3307 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+-3307 0 T
+N 0 0 M 3307 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 827 0 M 0 -83 D S
+N 1654 0 M 0 -83 D S
+N 2480 0 M 0 -83 D S
+N 3307 0 M 0 -83 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg M} def
+/PSL_AH0 0
+200 F0
+(3) sh mx
+(4) sh mx
+(5) sh mx
+(6) sh mx
+(7) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(3) bc Z
+827 PSL_A0_y MM
+(4) bc Z
+1654 PSL_A0_y MM
+(5) bc Z
+2480 PSL_A0_y MM
+(6) bc Z
+3307 PSL_A0_y MM
+(7) bc Z
+N 165 0 M 0 -42 D S
+N 331 0 M 0 -42 D S
+N 496 0 M 0 -42 D S
+N 661 0 M 0 -42 D S
+N 992 0 M 0 -42 D S
+N 1157 0 M 0 -42 D S
+N 1323 0 M 0 -42 D S
+N 1488 0 M 0 -42 D S
+N 1819 0 M 0 -42 D S
+N 1984 0 M 0 -42 D S
+N 2150 0 M 0 -42 D S
+N 2315 0 M 0 -42 D S
+N 2646 0 M 0 -42 D S
+N 2811 0 M 0 -42 D S
+N 2976 0 M 0 -42 D S
+N 3142 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 3307 0 D S
+0 -3307 T
+0 setlinecap
+%%EndObject
+-3590 0 TM
+0 A
+FQ
+O0
+3590 0 TM
+% PostScript produced by:
+%@GMT: gmt histogram hist.txt -T0.2 -Ggreen -W0.5p -E0.1c+o0.05c -Xa2.992i -Ya0i -R3/7/0/8 -JX15c
+%@PROJ: xy 3.00000000 7.00000000 0.00000000 8.00000000 3.000 7.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3307 0 D
+0 3307 D
+-3307 0 D
+P
+PSL_clip N
+8 W
+{0 1 0 C} FS
+O1
+-47 0 0 413 47 0 3 744 0 SP
+-48 0 0 1240 48 0 3 909 0 SP
+-47 0 0 2067 47 0 3 1075 0 SP
+-47 0 0 1654 47 0 3 1240 0 SP
+-47 0 0 1654 47 0 3 1406 0 SP
+-47 0 0 1654 47 0 3 1571 0 SP
+-47 0 0 2894 47 0 3 1736 0 SP
+-47 0 0 2480 47 0 3 1902 0 SP
+-47 0 0 2480 47 0 3 2067 0 SP
+-48 0 0 1654 48 0 3 2232 0 SP
+-47 0 0 413 47 0 3 2398 0 SP
+-47 0 0 413 47 0 3 2563 0 SP
+-48 0 0 413 48 0 3 2728 0 SP
+PSL_cliprestore
+%%EndObject
+-3590 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/pshistogram/altwidth.sh
+++ b/test/pshistogram/altwidth.sh
@@ -4,13 +4,17 @@ gmt begin altwidth ps
 	gmt subplot begin 3x2 -Fs7c -SCb -SRl -R3/7/0/8 -BWSrt -A
 		gmt subplot set -A"original"
 		gmt histogram  hist.txt -T0.2 -Gred -W0.5p
-		gmt subplot set -A"New x-width"
+		gmt subplot set -A"Width 0.1"
 		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.1
-		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.1+o-0.05 -c
+		gmt subplot set -A"Width 0.1 and offset -0.05"
+		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.1+o-0.05
 		gmt histogram  hist.txt -T0.2 -Ggreen -W0.5p -E0.1+o0.05
-		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.2c -c
-		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.2c+o-0.1c -c
-		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.2c+o-0.1c -c
+		gmt subplot set -A"Width 0.2c"
+		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.2c
+		gmt subplot set -A"Width 0.2c and offset -0.1c"
+		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.2c+o-0.1c
+		gmt subplot set -A"Width 0.2c and offset -0.1c"
+		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.2c+o-0.1c
 		gmt histogram  hist.txt -T0.2 -Ggreen -W0.5p -E0.2c+o0.1c
 	gmt subplot end
 gmt end show

--- a/test/pshistogram/altwidth.sh
+++ b/test/pshistogram/altwidth.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Ensure the new -E option works as advertised
+gmt begin altwidth ps
+	gmt subplot begin 3x2 -Fs7c -SCb -SRl -R3/7/0/8 -BWSrt -A
+		gmt subplot set -A"original"
+		gmt histogram  hist.txt -T0.2 -Gred -W0.5p
+		gmt subplot set -A"New x-width"
+		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.1
+		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.1+o-0.05 -c
+		gmt histogram  hist.txt -T0.2 -Ggreen -W0.5p -E0.1+o0.05
+		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.2c -c
+		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.2c+o-0.1c -c
+		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.2c+o-0.1c -c
+		gmt histogram  hist.txt -T0.2 -Ggreen -W0.5p -E0.2c+o0.1c
+	gmt subplot end
+gmt end show

--- a/test/pshistogram/altwidth.sh
+++ b/test/pshistogram/altwidth.sh
@@ -2,19 +2,19 @@
 # Ensure the new -E option works as advertised
 gmt begin altwidth ps
 	gmt subplot begin 3x2 -Fs7c -SCb -SRl -R3/7/0/8 -BWSrt -A
-		gmt subplot set -A"original"
+		gmt subplot set -A"No -E"
 		gmt histogram  hist.txt -T0.2 -Gred -W0.5p
-		gmt subplot set -A"Width 0.1"
+		gmt subplot set -A"w=0.1"
 		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.1
-		gmt subplot set -A"Width 0.1 and offset -0.05"
+		gmt subplot set -A"w=0.1 |off|=0.05"
 		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.1+o-0.05
 		gmt histogram  hist.txt -T0.2 -Ggreen -W0.5p -E0.1+o0.05
-		gmt subplot set -A"Width 0.2c"
-		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.2c
-		gmt subplot set -A"Width 0.2c and offset -0.1c"
-		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.2c+o-0.1c
-		gmt subplot set -A"Width 0.2c and offset -0.1c"
-		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.2c+o-0.1c
-		gmt histogram  hist.txt -T0.2 -Ggreen -W0.5p -E0.2c+o0.1c
+		gmt subplot set -A"w=0.1c"
+		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.1c
+		gmt subplot set -A"w=0.1c off=-0.05c"
+		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.1c+o-0.05c
+		gmt subplot set -A"w=0.1c |off|=0.05c"
+		gmt histogram  hist.txt -T0.2 -Gred -W0.5p -E0.1c+o-0.05c
+		gmt histogram  hist.txt -T0.2 -Ggreen -W0.5p -E0.1c+o0.05c
 	gmt subplot end
 gmt end show


### PR DESCRIPTION
**Description of proposed changes**

So far, all bars plotted by **histogram** inherited the width from the bin interval set via **-T**.  We had no mechanism to change that width other than choosing another binning interval.  The new option **-E**_width_[**+o**_offset_] allows users to

1. Specify the bar width in data units or plot units (by adding **c**|**i**|**p**)
2. Optionally shift all bars along the axis by giving an offset in data units or plot units (by adding **c**|**i**|**p**)

I have added a test _altwidth.sh_ that exercises this option to test the various parsing cases.  Tests pass.

In the process I consolidate the calculation of x,y plot coordinates for a bar in a new local function since this is cleaner to read and in fact it is needed in two places [the label locations are also affected by **-E**].