### PR TITLE
Plot bar-symbol errorbars on top of symbol

### DIFF
--- a/doc/rst/source/plot_common.rst_
+++ b/doc/rst/source/plot_common.rst_
@@ -94,7 +94,9 @@ Optional Arguments
     used we can control how the look-up color is applied to our symbol.
     Append **+cf** to use it to fill the symbol, while **+cl** will just
     set the error pen color and turn off symbol fill.  Giving **+c** will
-    set both color items.
+    set both color items.  **Note**: The error bars are placed behind symbols
+    except for the large vertical and horizontal bar symbols (**-Sb**\|\ **B**)
+    where they are plotted on top to avoid the lower bounds to be obscured.
 
 .. _-F:
 

--- a/doc/rst/source/plot_common.rst_
+++ b/doc/rst/source/plot_common.rst_
@@ -96,7 +96,7 @@ Optional Arguments
     set the error pen color and turn off symbol fill.  Giving **+c** will
     set both color items.  **Note**: The error bars are placed behind symbols
     except for the large vertical and horizontal bar symbols (**-Sb**\|\ **B**)
-    where they are plotted on top to avoid the lower bounds to be obscured.
+    where they are plotted on top to avoid the lower bounds being obscured.
 
 .. _-F:
 

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1223,7 +1223,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 	in = GMT->current.io.curr_rec;
 
 	if (not_line) {	/* Symbol part (not counting GMT_SYMBOL_FRONT, GMT_SYMBOL_QUOTED_LINE, GMT_SYMBOL_DECORATED_LINE) */
-		bool periodic = false, delayed_unit_scaling = false;
+		bool periodic = false, delayed_unit_scaling = false, E_bar_above = false, E_bar_below = false;
 		unsigned int n_warn[3] = {0, 0, 0}, warn, item, n_times, col;
 		double xpos[2], width = 0.0, dim[PSL_MAX_DIMS];
 		struct GMT_RECORD *In = NULL;
@@ -1263,6 +1263,11 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 			Return (API->error);
 		}
 		PSL_command (GMT->PSL, "V\n");	/* Place all symbols under a gsave/grestore clause */
+
+		if (Ctrl->E.active) {	/* Place errorbars below symbol except for large bars */
+			E_bar_above = (S.symbol == GMT_SYMBOL_BARX || S.symbol == GMT_SYMBOL_BARY);
+			E_bar_below = !E_bar_above;
+		}
 
 		if (S.read_size && GMT->current.io.col[GMT_IN][ex1].convert) {	/* Doing math on the size column, must delay unit conversion unless inch */
 			gmt_set_column (GMT, GMT_IN, ex1, GMT_IS_FLOAT);
@@ -1383,6 +1388,10 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 				}
 				else if (S.symbol == PSL_DOT && !Ctrl->G.active)	/* Must switch on default black fill */
 					current_fill = black;
+				if (Ctrl->E.active) {	/* Must update decision on where error bars go since symbol has changed */
+					E_bar_above = (S.symbol == GMT_SYMBOL_BARX || S.symbol == GMT_SYMBOL_BARY);
+					E_bar_below = !E_bar_above;
+				}
 			}
 
 			if (get_rgb) {
@@ -1443,7 +1452,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 			if (GMT->common.t.variable)	/* Update the transparency for current symbol (or -t was given) */
 				PSL_settransparency (PSL, 0.01 * in[tcol]);
 
-			if (Ctrl->E.active) {
+			if (E_bar_below) {
 				if (Ctrl->E.mode) gmt_M_rgb_copy (Ctrl->E.pen.rgb, current_fill.rgb);
 				if (Ctrl->E.mode & 1) gmt_M_rgb_copy (current_fill.rgb, GMT->session.no_rgb);
 				gmt_setpen (GMT, &Ctrl->E.pen);
@@ -1882,6 +1891,23 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 						if ((error = gmt_draw_custom_symbol (GMT, xpos[item], plot_y, dim, In->text, S.custom, &current_pen, &current_fill, outline_setting)))
 							Return (error);
 						break;
+				}
+			}
+			if (E_bar_above) {	/* Delayed placement or errorbar on top of bar symbols */
+				if (Ctrl->E.mode) gmt_M_rgb_copy (Ctrl->E.pen.rgb, current_fill.rgb);
+				if (Ctrl->E.mode & 1) gmt_M_rgb_copy (current_fill.rgb, GMT->session.no_rgb);
+				gmt_setpen (GMT, &Ctrl->E.pen);
+				if (error_x) {
+					if (error_type[GMT_X] < EBAR_WHISKER)
+						psxy_plot_x_errorbar (GMT, PSL, in[GMT_X], in[GMT_Y], &in[xy_errors[GMT_X]], Ctrl->E.size, n_total_read, error_type[GMT_X]);
+					else
+						psxy_plot_x_whiskerbar (GMT, PSL, plot_x, in[GMT_Y], &in[xy_errors[GMT_X]], Ctrl->E.size, current_fill.rgb, n_total_read, error_type[GMT_X]);
+				}
+				if (error_y) {
+					if (error_type[GMT_Y] < EBAR_WHISKER)
+						psxy_plot_y_errorbar (GMT, PSL, in[GMT_X], in[GMT_Y], &in[xy_errors[GMT_Y]], Ctrl->E.size, n_total_read, error_type[GMT_Y]);
+					else
+						psxy_plot_y_whiskerbar (GMT, PSL, in[GMT_X], plot_y, &in[xy_errors[GMT_Y]], Ctrl->E.size, current_fill.rgb, n_total_read, error_type[GMT_Y]);
 				}
 			}
 			if (S.read_symbol_cmd && (S.symbol == PSL_VECTOR || S.symbol == GMT_SYMBOL_GEOVECTOR || S.symbol == PSL_MARC)) {	/* Reset status */


### PR DESCRIPTION
Unlike regular (smaller) symbols with error bars, a bar symbol usually goes all the way from the axis to the value.  Plotting an error bar behind it means the lower bound of the bar will be obscured.  Here we plot the errorbar on top if bar symbols are used.  This is now clarified in the docs.  Tests pass but we have no test for this so need @joa-quim to try this before approving as he pointed this out.