### PR TITLE
Document that GMT_Call_Module will print command from externals -Vd

### DIFF
--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -2791,6 +2791,8 @@ how the options are passed to the module:
         Expects ``args`` to be an array of text strings and ``mode`` to be a count of how many
         options are passed (i.e., the ``argc, argv[]`` model used by the GMT programs themselves).
 
+From external interfaces and with a debug verbosity level set, ``GMT_Call_Module`` will
+also print out the equivalent command line to standard error (or its substitute).
 
 Set program options via text array arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
See #4131 and https://github.com/GenericMappingTools/pygmt/issues/573#issuecomment-701096962.

While users of the API may or may not see this documentation, at least this behavior is now documented in the API.
