### PR TITLE
Fix signed/unsigned mix for gmt_lat_swap

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -784,7 +784,7 @@ Projection Parameters
     **PROJ_AUX_LATITUDE**
         Only applies when geodesics are approximated by great circle
         distances on an equivalent sphere. Select from authalic, geocentric,
-        conformal, meridional, parametric, or none [authalic]. When not none
+        conformal, meridional, parametric, or none (i.e., geodetic) [authalic]. When not none
         we convert any latitude used in the great circle calculation to the
         chosen auxiliary latitude before doing the distance calculation. See
         also :term:`PROJ_MEAN_RADIUS`.

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -8629,7 +8629,7 @@ double gmtmap_lat_swap_quick (struct GMT_CTRL *GMT, double lat, double c[]) {
 }
 
 /*! . */
-double gmt_lat_swap (struct GMT_CTRL *GMT, double lat, unsigned int itype) {
+double gmt_lat_swap (struct GMT_CTRL *GMT, double lat, int itype) {
 	/* Return latitude, in degrees, given latitude, in degrees, based on itype */
 
 	double delta, cos2phi, sin2phi;

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -565,7 +565,7 @@ EXTERN_MSC bool gmt_near_lines (struct GMT_CTRL *GMT, double lon, double lat, st
 EXTERN_MSC bool gmt_near_a_line (struct GMT_CTRL *GMT, double lon, double lat, uint64_t seg, struct GMT_DATASEGMENT *S, unsigned int return_mindist, double *dist_min, double *x_near, double *y_near);
 EXTERN_MSC bool gmt_near_a_point (struct GMT_CTRL *GMT, double x, double y, struct GMT_DATATABLE *T, double dist);
 EXTERN_MSC double gmt_great_circle_dist_meter (struct GMT_CTRL *GMT, double x0, double y0, double x1, double y1);
-EXTERN_MSC double gmt_lat_swap (struct GMT_CTRL *GMT, double lat, unsigned int itype);
+EXTERN_MSC double gmt_lat_swap (struct GMT_CTRL *GMT, double lat, int itype);
 EXTERN_MSC double gmt_mindist_to_point (struct GMT_CTRL *GMT, double lon, double lat, struct GMT_DATATABLE *T, uint64_t *id);
 EXTERN_MSC bool gmt_UTMzone_to_wesn (struct GMT_CTRL *GMT, unsigned int zone_x, char zone_y, int hemi, double wesn[]);
 EXTERN_MSC void gmt_ECEF_forward (struct GMT_CTRL *GMT, double in[], double out[]);

--- a/src/gmt_stat.c
+++ b/src/gmt_stat.c
@@ -2750,13 +2750,14 @@ GMT_LOCAL void gmtstat_get_geo_cellarea (struct GMT_CTRL *GMT, struct GMT_GRID *
 	 * P.Wessel, July 2016.
 	 */
 	uint64_t node;
-	unsigned int row, col, j, first_row = 0, last_row = G->header->n_rows - 1, last_col = G->header->n_columns - 1;
+	unsigned int row, col, j, first_row = 0, last_row = G->header->n_rows - 1, last_col = G->header->n_columns - 1, ltype;
 	double lat, area, f, row_weight, col_weight = 1.0, R2 = pow (0.001 * GMT->current.proj.mean_radius, 2.0);	/* squared mean radius in km */
 	char *aux[6] = {"geodetic", "authalic", "conformal", "meridional", "geocentric", "parametric"};
 	char *rad[5] = {"mean (R_1)", "authalic (R_2)", "volumetric (R_3)", "meridional", "quadratic"};
 
+	ltype = (GMT->current.setting.proj_aux_latitude == GMT_LATSWAP_NONE) ? 0 : 1+GMT->current.setting.proj_aux_latitude/2;
 	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Compute spherical gridnode areas using %s radius [R = %.12g km] and %s latitudes\n",
-		rad[GMT->current.setting.proj_mean_radius], GMT->current.proj.mean_radius, aux[1+GMT->current.setting.proj_aux_latitude/2]);
+		rad[GMT->current.setting.proj_mean_radius], GMT->current.proj.mean_radius, aux[ltype]);
 	/* May need special treatment of pole points */
 	f = (G->header->registration == GMT_GRID_NODE_REG) ? 0.5 : 1.0;	/* Half pizza-slice for gridline regs with node at pole, full slice for grids */
 	area = R2 * (G->header->inc[GMT_X] * D2R);


### PR DESCRIPTION
The enums were signed but the arg was set to unsigned int, causing problem if anyone set --**PROJ_AUX_LATITUDE**=_none_.  Also. the verbose information report in _gmtstat_get_geo_cellarea_ did not handle that case.  Fixed.
