### PR TITLE
Let events handle time-sensitive lines and polygons

### DIFF
--- a/doc/rst/source/cookbook/file-formats.rst
+++ b/doc/rst/source/cookbook/file-formats.rst
@@ -88,7 +88,7 @@ columns as are needed by the program, starting with the first
 variables are to be read, append the suffix
 **?**\ *var1*\ **/**\ *var2*\ **/**\ *...* to the netCDF file name or
 add the option **-bic**\ *var1*\ **/**\ *var2*\ **/**\ *...*, where
-*var1*, *var2*, etc.are the names of the variables to be processed. The
+*var1*, *var2*, etc. are the names of the variables to be processed. The
 latter option is particularly practical when more than one file is read:
 the **-bic** option will apply to all files. Currently, GMT only
 reads, but does not write, netCDF tabular data.

--- a/doc/rst/source/events.rst
+++ b/doc/rst/source/events.rst
@@ -1,9 +1,9 @@
 .. index:: ! events
 .. include:: module_core_purpose.rst_
 
-********
+******
 events
-********
+******
 
 |events_purpose|
 
@@ -12,8 +12,12 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt events** [ *table* ] |-J|\ *parameters* |SYN_OPT-Rz| |-S|\ *symbol*\ [*size*]
+**gmt events**
+|-J|\ *parameters*
+|SYN_OPT-Rz|
 |-T|\ *now*
+[ *table* ]
+[ |-A|\ **r**\|\ **s** ]
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
 [ |-D|\ [**j**\|\ **J**]\ *dx*\ [/*dy*][**+v**\ [*pen*]] ]
@@ -24,6 +28,7 @@ Synopsis
 [ |-M|\ **i**\|\ **s**\|\ **t**\ [*val1*]\ [**+c**\ *val2*] ]
 [ |-N|\ [**c**\|\ **r**] ]
 [ |-Q|\ *prefix* ]
+[ |-S|\ *symbol*\ [*size*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]

--- a/doc/rst/source/events_common.rst_
+++ b/doc/rst/source/events_common.rst_
@@ -155,7 +155,7 @@ Optional Arguments
     Optionally, append symbol *size* with unit from
     (**c**\|\ **i**\|\ **p**\ ).  If no *size* is given then we read an event-specific size
     from the data file's third column (fourth if **-C** is used). **Note**: Not all the symbols that
-    are available in :doc:`psxy` can be used here.  At the moment we only support the basic
+    are available in :doc:`plot` can be used here.  At the moment we only support the basic
     symbols and custom symbols; bars, vectors, ellipses, fronts, decorated and quoted lines cannot
     be specified.  Symbols sizes read from a data file will be assumed to be in the unit controlled
     by :term:`PROJ_LENGTH_UNIT` unless they have **c**, **i**, or **p** appended.  If you are only

--- a/doc/rst/source/events_common.rst_
+++ b/doc/rst/source/events_common.rst_
@@ -29,18 +29,6 @@ Required Arguments
 .. |Add_-Rz| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-Rz.rst_
 
-.. _-S:
-
-**-S**\ *symbol*\ [*size*]
-    Specify the symbol to use for the event.  Optionally, append symbol *size* with unit from
-    (**c**\|\ **i**\|\ **p**\ ).  If no *size* is given then we read an event-specific size
-    from the data file's third column (fourth if **-C** is used). **Note**: Not all the symbols that
-    are available in :doc:`psxy` can be used here.  At the moment we only support the basic
-    symbols and custom symbols; bars, vectors, ellipses, fronts, decorated and quoted lines cannot
-    be specified.  Symbols sizes read from a data file will be assumed to be in the unit controlled
-    by :term:`PROJ_LENGTH_UNIT` unless they have **c**, **i**, or **p** appended.  If you are only
-    plotting labels then **-S** is not required.
-
 .. _-T:
 
 **-T**\ *now*
@@ -53,6 +41,16 @@ Optional Arguments
 
 .. |Add_intables| unicode:: 0x20 .. just an invisible code
 .. include:: explain_intables.rst_
+
+.. _-A:
+
+**-A**\ **r**\|\ **s**
+    When no **-S** is given we expect to read lines or polygons.  Two different forms for input are
+    considered and specified via **-A**\ : (1) Choose **-Ar** if your input data is *x, t, time* and
+    we should plot the portion of that line given the current time (*now*) and the event duration, or
+    (2) use **-As** to expect to read each complete segment (i.e., a polygon) from a multisegment file
+    and get a common time via a **-T**\ *string* in the segment header.  If **-L**\ [**t**] is set then
+    *string* must be either *begin*/*length\|\ end* or *begin*,*length\|\ end* (if *begin* is absolute time).
 
 .. _-B:
 
@@ -141,6 +139,19 @@ Optional Arguments
 **-Q**\ *prefix*
     Save the intermediate event symbols and labels to permanent files instead of removing them when done.
     Files will be named *prefix*\ _symbols.txt and *prefix*\ _labels.txt.
+
+.. _-S:
+
+**-S**\ *symbol*\ [*size*]
+    Specify the symbol to use for the event [Default plots lines or polygons; see **-A**].
+    Optionally, append symbol *size* with unit from
+    (**c**\|\ **i**\|\ **p**\ ).  If no *size* is given then we read an event-specific size
+    from the data file's third column (fourth if **-C** is used). **Note**: Not all the symbols that
+    are available in :doc:`psxy` can be used here.  At the moment we only support the basic
+    symbols and custom symbols; bars, vectors, ellipses, fronts, decorated and quoted lines cannot
+    be specified.  Symbols sizes read from a data file will be assumed to be in the unit controlled
+    by :term:`PROJ_LENGTH_UNIT` unless they have **c**, **i**, or **p** appended.  If you are only
+    plotting labels then **-S** is not required.
 
 .. _-U:
 

--- a/doc/rst/source/events_common.rst_
+++ b/doc/rst/source/events_common.rst_
@@ -47,12 +47,13 @@ Optional Arguments
 **-A**\ **r**\|\ **s**
     When no **-S** is given we expect to read lines or polygons.  Two different forms for input are
     considered and specified via **-A**\ : (1) Choose **-Ar** if your input data are *lines*, the data
-    format is given as *x, t, time*, and the "event" is the portion of that line limited by the current
-    time (*now*) and event duration (via **-L**), or (2) choose **-As** to expect to read each complete
-    segment (i.e., a polygon or line) from a multisegment file and get a common time via a required
-    **-T**\ *string* specified in the segment header.  Here, the entire polygon is the "event" if inside
-    the limits of current time (*now*) and event duration.  If **-L**\ [**t**] is set then *string* must be
-    either *begin*/*length\|\ end* or *begin*,*length\|\ end* (if *begin* is absolute time).  **Note**:
+    format is given as *x, y, time*, and the "event" is the portion of that line limited by the current
+    time (*now*), event duration and rise/fade periods (via **-L** and **-Es**), or (2) choose **-As**
+    to expect to read each complete segment (i.e., a polygon or line with just *x, y*) from a multisegment
+    file and get a common time for each segment via a required **-T**\ *string* specified in the segment
+    header.  Here, the entire polygon is the "event" if inside the limits of current time (*now*), event
+    duration and rise/fade periods.  If **-L**\ [**t**] is set then the *string* must be either
+    *begin*/*length\|\ end* or *begin*,*length\|\ end* (if *begin* is absolute time).  **Note**:
     Neither lines nor polygons allow for any labels to be placed.
 
 .. _-B:
@@ -62,7 +63,8 @@ Optional Arguments
 .. _-C:
 
 **-C**\ *cpt*
-    Use the *cpt* to convert *z* values given in the optional third column to assign symbol colors.
+    Use the *cpt* to convert *z* values given in the optional third column to assign symbol or polygon colors.
+    Not allowed if **-Ar** is used.
 
 .. _-D:
 
@@ -90,7 +92,7 @@ Optional Arguments
     restricted to **-Et** and specifies an alternative duration (visibility) of the text [same duration as symbol].
     Furthermore, the **+p** and **+d** periods do not apply to text labels.  **Note 2**: The **-Et** option is
     required if you wish to plot labels [plot symbols only].  **Note 3**: For lines or polygons the the **+p**
-    and **+d** periods do not apply.
+    and **+d** periods do not apply., and for lines none of the modifiers apply.
 
 .. _-F:
 
@@ -107,7 +109,7 @@ Optional Arguments
 .. _-G:
 
 **-G**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
-    Set constant shade or color for all symbols.
+    Set constant shade or color for all symbols or polygons.
 
 .. include:: explain_-Jz.rst_
 
@@ -117,7 +119,8 @@ Optional Arguments
     Specify the length (i.e., duration) of the event.  Append a *length* if all events have the same length,
     append **t** if end-times instead of lengths are given in the file after the *time* column,
     or leave blank if lengths can be read from the input file after the *time* column.  If **-L** is not
-    given we assume events have an infinite duration.
+    given we assume events have an infinite duration. See **-A** for how duration is handled for lines and
+    polygons.
 
 .. _-M:
 
@@ -125,7 +128,7 @@ Optional Arguments
     Modify the initial **i**\ ntensity, **s**\ ize magnification, or **t**\ ransparency of the symbol during
     the *rise* interval [1, 1, and 100, respectively].  Repeatable for the different attributes.
     Optionally, for finite-duration events you may append **+c** to set the corresponding terminal value
-    during the coda [0, 0, 100, respectively].
+    during the coda [0, 0, 100, respectively].  Polygons can only use **-Mt**.
 
 .. _-N:
 

--- a/doc/rst/source/events_common.rst_
+++ b/doc/rst/source/events_common.rst_
@@ -53,7 +53,8 @@ Optional Arguments
     file and get a common time for each segment via a required **-T**\ *string* specified in the segment
     header.  Here, the entire polygon is the "event" if inside the limits of current time (*now*), event
     duration and rise/fade periods.  If **-L**\ [**t**] is set then the *string* must be either
-    *begin*/*length\|\ end* or *begin*,*length\|\ end* (if *begin* is absolute time).  **Note**:
+    *begin*/*length\|\ end* or *begin*,*length\|\ end* (if *begin* is absolute time).  Use a comma to
+    separate absolute time specifications, otherwise a slash is adequate. **Note**:
     Neither lines nor polygons allow for any labels to be placed.
 
 .. _-B:

--- a/doc/rst/source/events_common.rst_
+++ b/doc/rst/source/events_common.rst_
@@ -46,11 +46,14 @@ Optional Arguments
 
 **-A**\ **r**\|\ **s**
     When no **-S** is given we expect to read lines or polygons.  Two different forms for input are
-    considered and specified via **-A**\ : (1) Choose **-Ar** if your input data is *x, t, time* and
-    we should plot the portion of that line given the current time (*now*) and the event duration, or
-    (2) use **-As** to expect to read each complete segment (i.e., a polygon) from a multisegment file
-    and get a common time via a **-T**\ *string* in the segment header.  If **-L**\ [**t**] is set then
-    *string* must be either *begin*/*length\|\ end* or *begin*,*length\|\ end* (if *begin* is absolute time).
+    considered and specified via **-A**\ : (1) Choose **-Ar** if your input data are *lines*, the data
+    format is given as *x, t, time*, and the "event" is the portion of that line limited by the current
+    time (*now*) and event duration (via **-L**), or (2) choose **-As** to expect to read each complete
+    segment (i.e., a polygon or line) from a multisegment file and get a common time via a required
+    **-T**\ *string* specified in the segment header.  Here, the entire polygon is the "event" if inside
+    the limits of current time (*now*) and event duration.  If **-L**\ [**t**] is set then *string* must be
+    either *begin*/*length\|\ end* or *begin*,*length\|\ end* (if *begin* is absolute time).  **Note**:
+    Neither lines nor polygons allow for any labels to be placed.
 
 .. _-B:
 
@@ -83,10 +86,11 @@ Optional Arguments
     duration of the rise phase, **+p** to set the duration of the plateau phase, **+d**
     to specify the duration of the decay phase, and **+f** to set the duration of the
     fade phase.  These are all optional [and default to zero], and can be set separately for symbols and texts.
-    If neither **s** or **t** is given then we set the time knots for both features. **Note**: The **+l** modifier is
+    If neither **s** or **t** is given then we set the time knots for both features. **Note 1**: The **+l** modifier is
     restricted to **-Et** and specifies an alternative duration (visibility) of the text [same duration as symbol].
-    Furthermore, the **+p** and **+d** periods do not apply to text labels.  **Note**: The **-Et** option is
-    required if you wish to plot labels [plot symbols only].
+    Furthermore, the **+p** and **+d** periods do not apply to text labels.  **Note 2**: The **-Et** option is
+    required if you wish to plot labels [plot symbols only].  **Note 3**: For lines or polygons the the **+p**
+    and **+d** periods do not apply.
 
 .. _-F:
 

--- a/doc/rst/source/plot3d_notes.rst_
+++ b/doc/rst/source/plot3d_notes.rst_
@@ -22,6 +22,8 @@ Segment header records may contain one of more of the following options:
     Obtain fill via cpt lookup using z-value *zval*
 **-Z**\ *NaN*
     Get the NaN color from the CPT
+**-t**\ *transparency*
+    Obtain transparency and apply it to fill and pen colors.
 
 Custom Symbols
 --------------

--- a/doc/rst/source/plot_notes.rst_
+++ b/doc/rst/source/plot_notes.rst_
@@ -22,6 +22,8 @@ Segment header records may contain one of more of the following options:
     Obtain fill via cpt lookup using z-value *zval*
 **-Z**\ *NaN*
     Get the NaN color from the CPT
+**-t**\ *transparency*
+    Obtain transparency and apply it to fill and pen colors.
 
 Custom Symbols
 --------------

--- a/doc/rst/source/psevents.rst
+++ b/doc/rst/source/psevents.rst
@@ -12,8 +12,12 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt psevents** [ *table* ] |-J|\ *parameters* |SYN_OPT-Rz| |-S|\ *symbol*\ [*size*]
+**gmt psevents**
+|-J|\ *parameters*
+|SYN_OPT-Rz|
 |-T|\ *now*
+[ *table* ]
+[ |-A|\ **r**\|\ **s** ]
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
 [ |-D|\ [**j**\|\ **J**]\ *dx*\ [/*dy*][**+v**\ [*pen*]] ]
@@ -26,6 +30,7 @@ Synopsis
 [ |-N|\ [**c**\|\ **r**] ]
 [ |-O| ] [ **-P** ]
 [ |-Q|\ *prefix* ]
+[ |-S|\ *symbol*\ [*size*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -7116,7 +7116,7 @@ int gmt_parse_segment_header (struct GMT_CTRL *GMT, char *header, struct GMT_PAL
 	if (!header || !header[0]) return (0);
 
 	if (gmt_parse_segment_item (GMT, header, "-t", line)) {	/* Found a potential -t option for transparency */
-		transparency = atof (line);
+		transparency = atof (line) * 0.01;
 		got_transparency = true;	/* Must apply to any fill and pen settings */
 	}
 	if (gmt_parse_segment_item (GMT, header, "-G", line)) {	/* Found a potential -G option */
@@ -7134,7 +7134,7 @@ int gmt_parse_segment_header (struct GMT_CTRL *GMT, char *header, struct GMT_PAL
 		}
 		else if (!gmt_getfill (GMT, line, &test_fill)) {	/* Successfully processed a -G<fill> option */
 			*fill = test_fill;
-			if (got_transparency) fill->rgb[4] = transparency;
+			if (got_transparency) fill->rgb[3] = transparency;
 			*use_fill = true;
 			change = 1;
 			processed++;	/* Processed one option */
@@ -7144,7 +7144,7 @@ int gmt_parse_segment_header (struct GMT_CTRL *GMT, char *header, struct GMT_PAL
 	if (P && gmt_parse_segment_item (GMT, header, "-Z", line)) {	/* Found a potential -Z option to set symbol r/g/b via cpt-lookup */
 		if(!strncmp (line, "NaN", 3U))	{	/* Got -ZNaN */
 			gmt_get_fill_from_z (GMT, P, GMT->session.d_NaN, fill);
-			if (got_transparency) fill->rgb[4] = transparency;
+			if (got_transparency) fill->rgb[3] = transparency;
 			*use_fill = true;
 			change |= 2;
 			processed++;	/* Processed one option */
@@ -7154,7 +7154,7 @@ int gmt_parse_segment_header (struct GMT_CTRL *GMT, char *header, struct GMT_PAL
 				gmt_get_fill_from_key (GMT, P, line, fill);
 			else if (sscanf (line, "%lg", &z) == 1)
 				gmt_get_fill_from_z (GMT, P, z, fill);
-			if (got_transparency) fill->rgb[4] = transparency;
+			if (got_transparency) fill->rgb[3] = transparency;
 			*use_fill = true;
 			change |= 2;
 			processed++;	/* Processed one option */
@@ -7177,7 +7177,7 @@ int gmt_parse_segment_header (struct GMT_CTRL *GMT, char *header, struct GMT_PAL
 		}
 		else if (!gmt_getpen (GMT, line, &test_pen)) {
 			*pen = test_pen;
-			if (got_transparency) pen->rgb[4] = transparency;
+			if (got_transparency) pen->rgb[3] = transparency;
 			*use_pen = true;
 			change |= 4;
 		}

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -557,7 +557,7 @@ EXTERN_MSC int GMT_psevents (void *V_API, int mode, void *args) {
 
 		if (Ctrl->A.mode == PSEVENTS_LINE_SEG) {	/* Assign new segment start/end times for lines/polygons */
 			in[t_in] = t_event_seg;	/* Current segment event start time */
-			if (Ctrl->L.mode == PSEVENTS_VAR_ENDTIME)	/* Only show the event as stable until its end time */
+			if (Ctrl->L.mode == PSEVENTS_VAR_ENDTIME)	/* Set segment end time */
 				in[d_in] = t_end_seg;
 		}
 
@@ -629,7 +629,6 @@ EXTERN_MSC int GMT_psevents (void *V_API, int mode, void *args) {
 				out[t_col] = Ctrl->M.value[PSEVENTS_TRANSP][PSEVENTS_VAL2];
 			}
 			if (out_segment) {	/* Write segment header for lines and polygons only */
-				char new_header[GMT_LEN256] = {""};
 				fprintf (fp_symbols, "%c -t%g %s\n", GMT->current.setting.io_seg_marker[GMT_OUT], out[t_col], GMT->current.io.segment_header);
 				out_segment = false;	/* Wait for next */
 			}
@@ -714,7 +713,10 @@ Do_txt:	if (Ctrl->E.active[PSEVENTS_TEXT] && In->text) {	/* Also plot trailing t
 		fclose (fp_symbols);	/* First close the file so symbol output is flushed */
 		/* Build plot command with fixed options and those that depend on -C -G -W.
 		 * We must set symbol unit as inch since we are passing sizes in inches directly (dimensions are in inches internally in GMT).  */
-		sprintf (cmd, "%s -R -J -O -K -I -t -S%s --GMT_HISTORY=readonly --PROJ_LENGTH_UNIT=%s", tmp_file_symbols, Ctrl->S.symbol, GMT->session.unit_name[GMT->current.setting.proj_length_unit]);
+		if (Ctrl->A.active)
+			sprintf (cmd, "%s -R -J -O -K--GMT_HISTORY=readonly", tmp_file_symbols);
+		else
+			sprintf (cmd, "%s -R -J -O -K -I -t -S%s --GMT_HISTORY=readonly --PROJ_LENGTH_UNIT=%s", tmp_file_symbols, Ctrl->S.symbol, GMT->session.unit_name[GMT->current.setting.proj_length_unit]);
 		if (Ctrl->C.active) {strcat (cmd, " -C"); strcat (cmd, Ctrl->C.file);}
 		if (Ctrl->G.active) {strcat (cmd, " -G"); strcat (cmd, Ctrl->G.color);}
 		if (Ctrl->W.pen) {strcat (cmd, " -W"); strcat (cmd, Ctrl->W.pen);}

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -439,7 +439,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *Ctrl, struct GMT_O
 
 EXTERN_MSC int GMT_psevents (void *V_API, int mode, void *args) {
 	char tmp_file_symbols[PATH_MAX] = {""}, tmp_file_labels[PATH_MAX] = {""}, cmd[BUFSIZ] = {""};
-	char t_string[GMT_LEN128] = {""};
+	char string[GMT_LEN128] = {""};
 
 	bool do_coda, finite_duration;
 
@@ -452,7 +452,7 @@ EXTERN_MSC int GMT_psevents (void *V_API, int mode, void *args) {
 	uint64_t n_total_read = 0, n_symbols_plotted = 0, n_labels_plotted = 0;
 
 	double out[6] = {0, 0, 0, 0, 0, 0}, t_end = DBL_MAX, *in = NULL;
-	double t_event, t_rise, t_plateau, t_decay, t_fade, x, size, t_event_seg, t_end_seg;
+	double t_event, t_rise, t_plateau, t_decay, t_fade, x, size, t_event_seg, t_end_seg, z_val;
 
 	FILE *fp_symbols = NULL, *fp_labels = NULL;
 
@@ -522,16 +522,19 @@ EXTERN_MSC int GMT_psevents (void *V_API, int mode, void *args) {
 			else if (gmt_M_rec_is_eof (GMT)) 	/* Reached end of file */
 				break;
 			else if (gmt_M_rec_is_segment_header (GMT) && Ctrl->A.active) {	/* Process and echo any segment headers for lines and polygons */
-				if (gmt_parse_segment_item (GMT, GMT->current.io.segment_header, "-T", t_string)) {	/* Found -Targs */
+				if (gmt_parse_segment_item (GMT, GMT->current.io.segment_header, "-T", string)) {	/* Found required -Targs */
 					if (Ctrl->L.mode == PSEVENTS_FIXED_DURATION) {	/* Just get event time */
-						gmt_scanf_arg (GMT, t_string, time_type, false, &t_event_seg);
+						gmt_scanf_arg (GMT, string, time_type, false, &t_event_seg);
 					}
 					else {	/* Get both event time and end time */
 						char start[GMT_LEN64] = {""}, stop[GMT_LEN64] = {""};
-						sscanf (t_string, "%s,%s", start, stop);
+						sscanf (string, "%s,%s", start, stop);
 						gmt_scanf_arg (GMT, start, time_type, false, &t_event_seg);
 						gmt_scanf_arg (GMT, stop,  time_type, false, &t_end_seg);
 					}
+				}
+				if (Ctrl->C.active && gmt_parse_segment_item (GMT, GMT->current.io.segment_header, "-Z", string)) {	/* Found required -Z<val> */
+					gmt_scanf_arg (GMT, string, GMT_FLOAT, false, &z_val);
 				}
 				if (!GMT->current.io.segment_header[0])		/* No header contents */
 					fprintf (fp_symbols, "%c\n", GMT->current.setting.io_seg_marker[GMT_OUT]);

--- a/test/psevents/lines.ps
+++ b/test/psevents/lines.ps
@@ -1,0 +1,935 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.2.0_909b2ff_2020.10.04 [64-bit] Document from psevents
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Mon Oct  5 13:30:50 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt psevents -R-40/400/-2/2 -JX15c/10c -Baf '-B+tSnake line' line.txt -Ar -T200 -Es -W2p,red -L90 -P -Qtmp
+%@PROJ: xy -40.00000000 400.00000000 -2.00000000 2.00000000 -40.000 400.000 -2.000 2.000 +xy
+%GMTBoundingBox: 72 72 425.196850394 283.464566929
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 1181 M -83 0 D S
+N 0 2362 M -83 0 D S
+N 0 3543 M -83 0 D S
+N 0 4724 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-2) sw mx
+(-1) sw mx
+(0) sw mx
+(1) sw mx
+(2) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(-2) mr Z
+1181 PSL_A0_y MM
+(-1) mr Z
+2362 PSL_A0_y MM
+(0) mr Z
+3543 PSL_A0_y MM
+(1) mr Z
+4724 PSL_A0_y MM
+(2) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 236 M -42 0 D S
+N 0 472 M -42 0 D S
+N 0 709 M -42 0 D S
+N 0 945 M -42 0 D S
+N 0 1417 M -42 0 D S
+N 0 1654 M -42 0 D S
+N 0 1890 M -42 0 D S
+N 0 2126 M -42 0 D S
+N 0 2598 M -42 0 D S
+N 0 2835 M -42 0 D S
+N 0 3071 M -42 0 D S
+N 0 3307 M -42 0 D S
+N 0 3780 M -42 0 D S
+N 0 4016 M -42 0 D S
+N 0 4252 M -42 0 D S
+N 0 4488 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7087 0 T
+25 W
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 1181 M 83 0 D S
+N 0 2362 M 83 0 D S
+N 0 3543 M 83 0 D S
+N 0 4724 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+(-2) sw mx
+(-1) sw mx
+(0) sw mx
+(1) sw mx
+(2) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(-2) mr Z
+1181 PSL_A0_y MM
+(-1) mr Z
+2362 PSL_A0_y MM
+(0) mr Z
+3543 PSL_A0_y MM
+(1) mr Z
+4724 PSL_A0_y MM
+(2) mr Z
+N 0 236 M 42 0 D S
+N 0 472 M 42 0 D S
+N 0 709 M 42 0 D S
+N 0 945 M 42 0 D S
+N 0 1417 M 42 0 D S
+N 0 1654 M 42 0 D S
+N 0 1890 M 42 0 D S
+N 0 2126 M 42 0 D S
+N 0 2598 M 42 0 D S
+N 0 2835 M 42 0 D S
+N 0 3071 M 42 0 D S
+N 0 3307 M 42 0 D S
+N 0 3780 M 42 0 D S
+N 0 4016 M 42 0 D S
+N 0 4252 M 42 0 D S
+N 0 4488 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7087 0 T
+25 W
+N 0 0 M 7087 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 644 0 M 0 -83 D S
+N 2255 0 M 0 -83 D S
+N 3865 0 M 0 -83 D S
+N 5476 0 M 0 -83 D S
+N 7087 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(100) sh mx
+(200) sh mx
+(300) sh mx
+(400) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+644 PSL_A0_y MM
+(0) bc Z
+2255 PSL_A0_y MM
+(100) bc Z
+3865 PSL_A0_y MM
+(200) bc Z
+5476 PSL_A0_y MM
+(300) bc Z
+7087 PSL_A0_y MM
+(400) bc Z
+N 0 0 M 0 -42 D S
+N 322 0 M 0 -42 D S
+N 966 0 M 0 -42 D S
+N 1288 0 M 0 -42 D S
+N 1611 0 M 0 -42 D S
+N 1933 0 M 0 -42 D S
+N 2577 0 M 0 -42 D S
+N 2899 0 M 0 -42 D S
+N 3221 0 M 0 -42 D S
+N 3543 0 M 0 -42 D S
+N 4188 0 M 0 -42 D S
+N 4510 0 M 0 -42 D S
+N 4832 0 M 0 -42 D S
+N 5154 0 M 0 -42 D S
+N 5798 0 M 0 -42 D S
+N 6120 0 M 0 -42 D S
+N 6442 0 M 0 -42 D S
+N 6764 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 4724 T
+25 W
+N 0 0 M 7087 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 644 0 M 0 83 D S
+N 2255 0 M 0 83 D S
+N 3865 0 M 0 83 D S
+N 5476 0 M 0 83 D S
+N 7087 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+(0) sh mx
+(100) sh mx
+(200) sh mx
+(300) sh mx
+(400) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+644 PSL_A0_y MM
+(0) bc Z
+2255 PSL_A0_y MM
+(100) bc Z
+3865 PSL_A0_y MM
+(200) bc Z
+5476 PSL_A0_y MM
+(300) bc Z
+7087 PSL_A0_y MM
+(400) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M 0 42 D S
+N 322 0 M 0 42 D S
+N 966 0 M 0 42 D S
+N 1288 0 M 0 42 D S
+N 1611 0 M 0 42 D S
+N 1933 0 M 0 42 D S
+N 2577 0 M 0 42 D S
+N 2899 0 M 0 42 D S
+N 3221 0 M 0 42 D S
+N 3543 0 M 0 42 D S
+N 4188 0 M 0 42 D S
+N 4510 0 M 0 42 D S
+N 4832 0 M 0 42 D S
+N 5154 0 M 0 42 D S
+N 5798 0 M 0 42 D S
+N 6120 0 M 0 42 D S
+N 6442 0 M 0 42 D S
+N 6764 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -4724 T
+0 setlinecap
+/PSL_H_y PSL_L_y PSL_LH add 233 add def
+3543 4724 PSL_H_y add PSL_slant_y add M
+400 F0
+(Snake line) bc Z
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy tmp_symbols.txt -R-40/400/-2/2 -JX15c/10c -O -K --GMT_HISTORY=readonly -W2p,red
+%@PROJ: xy -40.00000000 400.00000000 -2.00000000 2.00000000 -40.000 400.000 -2.000 2.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+33 W
+1 0 0 C
+clipsave
+0 0 M
+7087 0 D
+0 4724 D
+-7087 0 D
+P
+PSL_clip N
+2416 3472 M
+97 -48 D
+80 -49 D
+81 -57 D
+80 -64 D
+97 -86 D
+96 -95 D
+16 -17 D
+17 -16 D
+96 -105 D
+97 -111 D
+80 -97 D
+33 -39 D
+193 -243 D
+241 -308 D
+145 -179 D
+S
+PSL_cliprestore
+%%EndObject
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/psevents/lines.sh
+++ b/test/psevents/lines.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Test gmt psevents with lines
+
+ps=lines.ps
+
+# Create a sinusoid, then only plot what should be visible at t = 200 given a duration of 90
+echo "> Snake line" > line.txt
+gmt math -T0/360/1 T SIND -o0,1,0 = >> line.txt
+gmt psevents -R-40/400/-2/2 -JX15c/10c -Baf -B+t"Snake line" line.txt -Ar -T200 -Es+r5+f5 -W2p,red -L90 -P > $ps

--- a/test/psevents/lines.sh
+++ b/test/psevents/lines.sh
@@ -6,4 +6,4 @@ ps=lines.ps
 # Create a sinusoid, then only plot what should be visible at t = 200 given a duration of 90
 echo "> Snake line" > line.txt
 gmt math -T0/360/1 T SIND -o0,1,0 = >> line.txt
-gmt psevents -R-40/400/-2/2 -JX15c/10c -Baf -B+t"Snake line" line.txt -Ar -T200 -Es+r5+f5 -W2p,red -L90 -P > $ps
+gmt psevents -R-40/400/-2/2 -JX15c/10c -Baf -B+t"Snake line" line.txt -Ar -T200 -Es -W2p,red -L90 -P > $ps

--- a/test/psevents/polygons.ps
+++ b/test/psevents/polygons.ps
@@ -1,0 +1,934 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.2.0_909b2ff_2020.10.04 [64-bit] Document from psevents
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Mon Oct  5 12:42:06 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt psevents -R-40/400/-2/2 -JX15c/10c -Baf -B+tPolygon polygon.txt -As -T248 -Es+r5+f5 -L -P
+%@PROJ: xy -40.00000000 400.00000000 -2.00000000 2.00000000 -40.000 400.000 -2.000 2.000 +xy
+%GMTBoundingBox: 72 72 425.196850394 283.464566929
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 1181 M -83 0 D S
+N 0 2362 M -83 0 D S
+N 0 3543 M -83 0 D S
+N 0 4724 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-2) sw mx
+(-1) sw mx
+(0) sw mx
+(1) sw mx
+(2) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(-2) mr Z
+1181 PSL_A0_y MM
+(-1) mr Z
+2362 PSL_A0_y MM
+(0) mr Z
+3543 PSL_A0_y MM
+(1) mr Z
+4724 PSL_A0_y MM
+(2) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 236 M -42 0 D S
+N 0 472 M -42 0 D S
+N 0 709 M -42 0 D S
+N 0 945 M -42 0 D S
+N 0 1417 M -42 0 D S
+N 0 1654 M -42 0 D S
+N 0 1890 M -42 0 D S
+N 0 2126 M -42 0 D S
+N 0 2598 M -42 0 D S
+N 0 2835 M -42 0 D S
+N 0 3071 M -42 0 D S
+N 0 3307 M -42 0 D S
+N 0 3780 M -42 0 D S
+N 0 4016 M -42 0 D S
+N 0 4252 M -42 0 D S
+N 0 4488 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7087 0 T
+25 W
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 1181 M 83 0 D S
+N 0 2362 M 83 0 D S
+N 0 3543 M 83 0 D S
+N 0 4724 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+(-2) sw mx
+(-1) sw mx
+(0) sw mx
+(1) sw mx
+(2) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(-2) mr Z
+1181 PSL_A0_y MM
+(-1) mr Z
+2362 PSL_A0_y MM
+(0) mr Z
+3543 PSL_A0_y MM
+(1) mr Z
+4724 PSL_A0_y MM
+(2) mr Z
+N 0 236 M 42 0 D S
+N 0 472 M 42 0 D S
+N 0 709 M 42 0 D S
+N 0 945 M 42 0 D S
+N 0 1417 M 42 0 D S
+N 0 1654 M 42 0 D S
+N 0 1890 M 42 0 D S
+N 0 2126 M 42 0 D S
+N 0 2598 M 42 0 D S
+N 0 2835 M 42 0 D S
+N 0 3071 M 42 0 D S
+N 0 3307 M 42 0 D S
+N 0 3780 M 42 0 D S
+N 0 4016 M 42 0 D S
+N 0 4252 M 42 0 D S
+N 0 4488 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7087 0 T
+25 W
+N 0 0 M 7087 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 644 0 M 0 -83 D S
+N 2255 0 M 0 -83 D S
+N 3865 0 M 0 -83 D S
+N 5476 0 M 0 -83 D S
+N 7087 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(100) sh mx
+(200) sh mx
+(300) sh mx
+(400) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+644 PSL_A0_y MM
+(0) bc Z
+2255 PSL_A0_y MM
+(100) bc Z
+3865 PSL_A0_y MM
+(200) bc Z
+5476 PSL_A0_y MM
+(300) bc Z
+7087 PSL_A0_y MM
+(400) bc Z
+N 0 0 M 0 -42 D S
+N 322 0 M 0 -42 D S
+N 966 0 M 0 -42 D S
+N 1288 0 M 0 -42 D S
+N 1611 0 M 0 -42 D S
+N 1933 0 M 0 -42 D S
+N 2577 0 M 0 -42 D S
+N 2899 0 M 0 -42 D S
+N 3221 0 M 0 -42 D S
+N 3543 0 M 0 -42 D S
+N 4188 0 M 0 -42 D S
+N 4510 0 M 0 -42 D S
+N 4832 0 M 0 -42 D S
+N 5154 0 M 0 -42 D S
+N 5798 0 M 0 -42 D S
+N 6120 0 M 0 -42 D S
+N 6442 0 M 0 -42 D S
+N 6764 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 4724 T
+25 W
+N 0 0 M 7087 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 644 0 M 0 83 D S
+N 2255 0 M 0 83 D S
+N 3865 0 M 0 83 D S
+N 5476 0 M 0 83 D S
+N 7087 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+(0) sh mx
+(100) sh mx
+(200) sh mx
+(300) sh mx
+(400) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+644 PSL_A0_y MM
+(0) bc Z
+2255 PSL_A0_y MM
+(100) bc Z
+3865 PSL_A0_y MM
+(200) bc Z
+5476 PSL_A0_y MM
+(300) bc Z
+7087 PSL_A0_y MM
+(400) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M 0 42 D S
+N 322 0 M 0 42 D S
+N 966 0 M 0 42 D S
+N 1288 0 M 0 42 D S
+N 1611 0 M 0 42 D S
+N 1933 0 M 0 42 D S
+N 2577 0 M 0 42 D S
+N 2899 0 M 0 42 D S
+N 3221 0 M 0 42 D S
+N 3543 0 M 0 42 D S
+N 4188 0 M 0 42 D S
+N 4510 0 M 0 42 D S
+N 4832 0 M 0 42 D S
+N 5154 0 M 0 42 D S
+N 5798 0 M 0 42 D S
+N 6120 0 M 0 42 D S
+N 6442 0 M 0 42 D S
+N 6764 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -4724 T
+0 setlinecap
+/PSL_H_y PSL_L_y PSL_LH add 233 add def
+3543 4724 PSL_H_y add PSL_slant_y add M
+400 F0
+(Polygon) bc Z
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy /tmp/GMT_psevents_symbols_36842.txt -R-40/400/-2/2 -JX15c/10c -O -K --GMT_HISTORY=readonly
+%@PROJ: xy -40.00000000 400.00000000 -2.00000000 2.00000000 -40.000 400.000 -2.000 2.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+clipsave
+0 0 M
+7087 0 D
+0 4724 D
+-7087 0 D
+P
+PSL_clip N
+33 W
+1 0 0 C
+{1 0.753 0.796 C} FS
+O1
+/FO {P}!
+-902 -473 -1111 355 1449 1653 1450 -590 4 644 2362 SP
+/FO {fs os}!
+FO
+67 W
+0 A 0.36 /Normal PSL_transp
+{0.678 0.847 0.902 C 0.36 /Normal PSL_transp} FS
+/FO {P}!
+-902 -473 -1111 355 1449 1653 1450 -590 4 3865 2362 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+%%EndObject
+1 /Normal PSL_transp
+%%EndObject
+1 /Normal PSL_transp
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/psevents/polygons.sh
+++ b/test/psevents/polygons.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Test gmt psevents with polygons
+
+ps=polygons.ps
+
+# Create a simple polygon, then only plot what should be visible at t = 200 given a duration of 90
+cat << EOF > polygon.txt
+> Polygon -T200/90
+0	0
+90	-0.5
+180	0.9
+111	1.2
+55	0.8
+0	0
+EOF
+gmt psevents -R-40/400/-2/2 -JX15c/10c -Baf -B+t"Polygon" polygon.txt -As -T200 -Es+r5+f5 -W2p,red -L90 -P > $ps

--- a/test/psevents/polygons.sh
+++ b/test/psevents/polygons.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
-# Test gmt psevents with polygons
+# Test gmt psevents with two polygons of different lifetimes
 
 ps=polygons.ps
 
-# Create a simple polygon, then only plot what should be visible at t = 200 given a duration of 90
 cat << EOF > polygon.txt
-> Polygon -T200/90
+> Polygon -T200/90 -Gpink -W2p,red
 0	0
 90	-0.5
 180	0.9
 111	1.2
 55	0.8
 0	0
+> Polygon -T250/60 -Glightblue -W4p
+200	0
+290	-0.5
+380	0.9
+311	1.2
+255	0.8
+200	0
 EOF
-gmt psevents -R-40/400/-2/2 -JX15c/10c -Baf -B+t"Polygon" polygon.txt -As -T200 -Es+r5+f5 -W2p,red -L90 -P > $ps
+gmt psevents -R-40/400/-2/2 -JX15c/10c -Baf -B+t"Polygon" polygon.txt -As -T248 -Es+r5+f5 -L -P > $ps


### PR DESCRIPTION
**Description of proposed changes**

So far, **events** can plot various symbols that each have their own duration, with optional enhancements like rise time, decay, and fading.  However, there is also a need to be able to plot lines and polygons on a temporal basis in animations.  This PR adds this capability.  A new option **-A** selects lines or polygons, whereas the existing **-S** option selections symbols.  We support two modes for lines and polygons via **-A**:

1. **-Ar**: Lines only, and these lines are given with three columns, _x y time_, and for the current time passed to **events** (via **-T**) we determine which _records_ of the line falls inside the event duration and just plot that segment.  For now, the line can only have a single pen/color, but a likely extension to this would be to assign a color based on a CPT via time, since the entire segment can only have one color.
2. **-As**: Polygons or lines, but per _segment_.  Here we read multi-segment files and each segment must have a header option **-T**_string_ that indicates the time (and possibly end time or duration, depending on **-L**) for the segment.  Thus, when the current plot time falls within the event duration we plot the entire segment (as line or polygon).  Unlike **-Ar**, this mode allows color to be assigned via **-Z**_val_ in the header (and via CPT lookup) and users can supply **-W** and **-G** options as well.  This mode also supports variations in transparency during the optional rise and fad sections of the even and passes a **-t**_transparency_ via the output segment header that **plot** understands.

As an example of basic operations, here is a simple movie that shows how line animation may work:

![line](https://user-images.githubusercontent.com/26473567/95147590-de994f00-071c-11eb-9900-823d5444cb3f.gif)

Likewise, here is a simple movie showing two static polygons (of course, sophisticated applications could produce lots of segments with motion in space during time as well):

![pol](https://user-images.githubusercontent.com/26473567/95147642-02f52b80-071d-11eb-9794-75e172d69a20.gif)

This PR updates the code, documentation, and adds a simple test for each modes to the test/psevents folder.
