### PR TITLE
More consistency with how -B0 is used

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -4263,7 +4263,8 @@ GMT_LOCAL int gmtinit_parse5_B_option (struct GMT_CTRL *GMT, char *in) {
 		if (no == GMT_Z) GMT->current.map.frame.drawz = true;
 		if (!text[0]) continue;	 	/* Skip any empty format string */
 		if (text[0] == '0' && !text[1]) {	 /* Understand format '0' to mean "no annotation, ticks, or gridlines" */
-			GMT->current.map.frame.draw = GMT->current.map.frame.drawz = true;	/* But we do wish to draw the frame */
+			//GMT->current.map.frame.draw = GMT->current.map.frame.drawz = true;	/* But we do wish to draw the frame */
+			GMT->current.map.frame.draw = true;	/* But we do wish to draw the frame */
 			GMT->current.setting.map_frame_type = GMT_IS_PLAIN;	/* Since checkerboard without intervals look stupid */
 			continue;
 		}

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -4263,8 +4263,8 @@ GMT_LOCAL int gmtinit_parse5_B_option (struct GMT_CTRL *GMT, char *in) {
 		if (no == GMT_Z) GMT->current.map.frame.drawz = true;
 		if (!text[0]) continue;	 	/* Skip any empty format string */
 		if (text[0] == '0' && !text[1]) {	 /* Understand format '0' to mean "no annotation, ticks, or gridlines" */
-			//GMT->current.map.frame.draw = GMT->current.map.frame.drawz = true;	/* But we do wish to draw the frame */
 			GMT->current.map.frame.draw = true;	/* But we do wish to draw the frame */
+			if (GMT->common.J.zactive) GMT->current.map.frame.drawz = true;	/* Also brings z-axis into contention */
 			GMT->current.setting.map_frame_type = GMT_IS_PLAIN;	/* Since checkerboard without intervals look stupid */
 			continue;
 		}

--- a/test/psxyz/QR.ps
+++ b/test/psxyz/QR.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_ddaeea2-dirty_2019.03.23 [64-bit] Document from psxyz
+%%Title: GMT v6.2.0_0fb503e_2020.10.06 [64-bit] Document from psxyz
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Tue Mar 26 10:53:27 2019
+%%CreationDate: Tue Oct  6 14:02:03 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -646,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -657,8 +658,9 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
-/PSL_movie_completion {} def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
@@ -673,16 +675,12 @@ O0
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
-/PSL_GPP matrix currentmatrix def [0.984808 -0.111619 0.173648 0.633022 -0 535.771] concat
+3.32550952342 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.984807753012 -0.111618897049 0.173648177667 0.633022221559 -0 535.770705835] concat
 {0.827 A} FS
 -4800 0 0 4800 4800 0 3 0 0 SP
 25 W
-PSL_GPP setmatrix
-2780 3808 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-400 F0
-(QR \(opaque\)) bc Z
-/PSL_GPP matrix currentmatrix def [0.984808 -0.111619 0.173648 0.633022 -0 535.771] concat
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 4800 M 0 -4800 D S
 /PSL_A0_y 0 def
@@ -705,6 +703,11 @@ N 0 0 M 4800 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 -4800 T
 0 setlinecap
+/PSL_H_y PSL_L_y PSL_LH add 233 add def
+2400 4800 PSL_H_y add PSL_slant_y add M
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+400 F0
+(QR \(opaque\)) bc Z
 clipsave
 0 0 M
 4800 0 D
@@ -742,7 +745,7 @@ V
 {0.745 A} FS
 /QR_fill {0.745 A} def
 /QR_outline false def
-PSL_GPP setmatrix [0.984808 -0.111619 0.173648 0.633022 -0 535.771] concat
+PSL_GPP setmatrix [0.984807753012 -0.111618897049 0.173648177667 0.633022221559 -0 535.770705835] concat
 /Sk_QR {
 PSL_eps_begin
 0.36000000 dup scale
@@ -4742,13 +4745,6 @@ V 3150 750 T
 0.75 dup scale Sk_QR U
 U
 PSL_cliprestore
-PSL_GPP setmatrix
-/PSL_GPP matrix currentmatrix def [0.984808 -0.111619 0 0.766044 0 535.771] concat
-25 W
-N 0 0 M 0 0 D S
-/PSL_A0_y 0 def
-/PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 PSL_GPP setmatrix
 %%EndObject
 0 A
@@ -4762,16 +4758,12 @@ O0
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
-/PSL_GPP matrix currentmatrix def [0.984808 -0.111619 0.173648 0.633022 -0 535.771] concat
+3.32550952342 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.984807753012 -0.111618897049 0.173648177667 0.633022221559 -0 535.770705835] concat
 {0.827 A} FS
 -4800 0 0 4800 4800 0 3 0 0 SP
 25 W
-PSL_GPP setmatrix
-2780 3808 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-400 F0
-(QR \(transparent\)) bc Z
-/PSL_GPP matrix currentmatrix def [0.984808 -0.111619 0.173648 0.633022 -0 535.771] concat
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 4800 M 0 -4800 D S
 /PSL_A0_y 0 def
@@ -4794,6 +4786,11 @@ N 0 0 M 4800 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 -4800 T
 0 setlinecap
+/PSL_H_y PSL_L_y PSL_LH add 233 add def
+2400 4800 PSL_H_y add PSL_slant_y add M
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+400 F0
+(QR \(transparent\)) bc Z
 clipsave
 0 0 M
 4800 0 D
@@ -4831,7 +4828,7 @@ V
 {0.745 A} FS
 /QR_fill {0.745 A} def
 /QR_outline false def
-PSL_GPP setmatrix [0.984808 -0.111619 0.173648 0.633022 -0 535.771] concat
+PSL_GPP setmatrix [0.984807753012 -0.111618897049 0.173648177667 0.633022221559 -0 535.770705835] concat
 /Sk_QR_transparent {
 PSL_eps_begin
 0.36000000 dup scale
@@ -8814,17 +8811,11 @@ V 3150 750 T
 U
 PSL_cliprestore
 PSL_GPP setmatrix
-/PSL_GPP matrix currentmatrix def [0.984808 -0.111619 0 0.766044 0 535.771] concat
-25 W
-N 0 0 M 0 0 D S
-/PSL_A0_y 0 def
-/PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-PSL_GPP setmatrix
 %%EndObject
 
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U

--- a/test/psxyz/filler.sh
+++ b/test/psxyz/filler.sh
@@ -8,10 +8,10 @@ cat << EOF > t.txt
 4 4 0
 EOF
 
-gmt psxyz -R0/5/0/5/0/1 -JX3i -JZ1i -P -K -p170/35 -Bwesn t.txt -Gred -W2p -L+yb > $ps
-gmt psxyz -R -J -JZ -O -K -Bwesn -p t.txt -Gred -W2p -L+yt -X3.5i >> $ps
-gmt psxyz -R -J -JZ -O -K -Bwesn -p t.txt -Ggreen -W2p -L+xl -X-3.5i -Y3.2i >> $ps
-gmt psxyz -R -J -JZ -O -K -Bwesn -p t.txt -Ggreen -W2p -L+xr -X3.5i >> $ps
-gmt psxyz -R -J -JZ -O -K -Bwesn -p t.txt -Gorange -W2p -L+y4 -X-3.5i -Y3.2i >> $ps
-gmt psxyz -R -J -JZ -O -K -Bwesn -p t.txt -Gorange -W0.5p,white -L+x4.5+p2p -X3.5i >> $ps
+gmt psxyz -R0/5/0/5/0/1 -JX3i -JZ1i -P -K -p170/35 -B0 t.txt -Gred -W2p -L+yb > $ps
+gmt psxyz -R -J -JZ -O -K -B0 -p t.txt -Gred -W2p -L+yt -X3.5i >> $ps
+gmt psxyz -R -J -JZ -O -K -B0 -p t.txt -Ggreen -W2p -L+xl -X-3.5i -Y3.2i >> $ps
+gmt psxyz -R -J -JZ -O -K -B0 -p t.txt -Ggreen -W2p -L+xr -X3.5i >> $ps
+gmt psxyz -R -J -JZ -O -K -B0 -p t.txt -Gorange -W2p -L+y4 -X-3.5i -Y3.2i >> $ps
+gmt psxyz -R -J -JZ -O -K -B0 -p t.txt -Gorange -W0.5p,white -L+x4.5+p2p -X3.5i >> $ps
 gmt psxy -R0/5/0/5 -J -O -T >> $ps

--- a/test/psxyz/filler.sh
+++ b/test/psxyz/filler.sh
@@ -8,10 +8,9 @@ cat << EOF > t.txt
 4 4 0
 EOF
 
-gmt psxyz -R0/5/0/5/0/1 -JX3i -JZ1i -P -K -p170/35 -B0 t.txt -Gred -W2p -L+yb > $ps
-gmt psxyz -R -J -JZ -O -K -B0 -p t.txt -Gred -W2p -L+yt -X3.5i >> $ps
-gmt psxyz -R -J -JZ -O -K -B0 -p t.txt -Ggreen -W2p -L+xl -X-3.5i -Y3.2i >> $ps
-gmt psxyz -R -J -JZ -O -K -B0 -p t.txt -Ggreen -W2p -L+xr -X3.5i >> $ps
-gmt psxyz -R -J -JZ -O -K -B0 -p t.txt -Gorange -W2p -L+y4 -X-3.5i -Y3.2i >> $ps
-gmt psxyz -R -J -JZ -O -K -B0 -p t.txt -Gorange -W0.5p,white -L+x4.5+p2p -X3.5i >> $ps
-gmt psxy -R0/5/0/5 -J -O -T >> $ps
+gmt psxyz -R0/5/0/5/0/1 -JX3i -P -K -p170/35 -B0 t.txt -Gred -W2p -L+yb > $ps
+gmt psxyz -R -J -O -K -B0 -p t.txt -Gred -W2p -L+yt -X3.5i >> $ps
+gmt psxyz -R -J -O -K -B0 -p t.txt -Ggreen -W2p -L+xl -X-3.5i -Y3.2i >> $ps
+gmt psxyz -R -J -O -K -B0 -p t.txt -Ggreen -W2p -L+xr -X3.5i >> $ps
+gmt psxyz -R -J -O -K -B0 -p t.txt -Gorange -W2p -L+y4 -X-3.5i -Y3.2i >> $ps
+gmt psxyz -R -J -O -B0 -p t.txt -Gorange -W0.5p,white -L+x4.5+p2p -X3.5i >> $ps


### PR DESCRIPTION
**Description of proposed changes**

This PR interprets -B0 different when there is a 2-D, 2-D perspective, or true 3-D projection involved.  Basically, the z-axis is only drawn for a true 3D projection.  Also fixes wrong use of -B in filler.sh and incorrect title format (2D) for a perspective 2-D plot (in QR.sh).  Note: Does not fix #4181.