### PR TITLE
Check if all bash scripts have execute permission

### DIFF
--- a/.github/workflows/code-validator.yml
+++ b/.github/workflows/code-validator.yml
@@ -43,3 +43,16 @@ jobs:
           current_year=$(date +%Y)
           gmt_version_year=$(grep GMT_VERSION_YEAR cmake/ConfigDefault.cmake | awk -F'"' '{print $2}')
           if [ "$current_year" != "$gmt_version_year" ]; then exit 1; fi
+
+      - name: Check permission of bash scripts:
+        run: |
+          error=0
+          echo "Following bash scripts may don't execute permission:"
+          # exclude share/tools/gmt_functions.sh
+          for file in $(find . -name "*.sh" ! -path "./share/tools/gmt_functions.sh"); do
+            if [[ ! -x "$file" ]]; then
+              ((++error))
+              echo "$error: $file"
+            fi
+          done
+          exit $error

--- a/.github/workflows/code-validator.yml
+++ b/.github/workflows/code-validator.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Check execute permission of bash scripts
         run: |
           error=0
-          echo "Following bash scripts may don't execute permission:"
+          echo "Following bash scripts may not have execute permission:"
           # exclude share/tools/gmt_functions.sh
           for file in $(find . -name "*.sh" ! -path "./share/tools/gmt_functions.sh"); do
             if [[ ! -x "$file" ]]; then

--- a/.github/workflows/code-validator.yml
+++ b/.github/workflows/code-validator.yml
@@ -44,7 +44,7 @@ jobs:
           gmt_version_year=$(grep GMT_VERSION_YEAR cmake/ConfigDefault.cmake | awk -F'"' '{print $2}')
           if [ "$current_year" != "$gmt_version_year" ]; then exit 1; fi
 
-      - name: Check permission of bash scripts:
+      - name: Check execute permission of bash scripts
         run: |
           error=0
           echo "Following bash scripts may don't execute permission:"


### PR DESCRIPTION
A test fails if the bash script doesn't have execute permission.
It may happen when we add new tests to the repository.

This PR checks if all bash scripts in the repository have execute
permission set. The only exception is `share/tools/gmt_functions.sh`.