### PR TITLE
Eliminate final psxy -R -J -O -T calls by removing -K from previous command

### DIFF
--- a/test/filter1d/cfilter.sh
+++ b/test/filter1d/cfilter.sh
@@ -51,5 +51,4 @@ cat << EOF > myfilt.txt
 EOF
 gmt psxy -R -J -O -T -K -Y-2.5i >> $ps
 cat tmp.eps >> $ps
-gmt filter1d -Ffmyfilt.txt noise.txt | gmt psxy -R-500/500/-300/300 -J -O -K -W2p,blue >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt filter1d -Ffmyfilt.txt noise.txt | gmt psxy -R-500/500/-300/300 -J -O -W2p,blue >> $ps

--- a/test/filter1d/filter.sh
+++ b/test/filter1d/filter.sh
@@ -20,5 +20,4 @@ gmt filter1d -Fm100 -E -N0 noise.txt | gmt psxy -R-500/500/-300/300 -J -O -K -W2
 # Median with -E then Gaussian
 gmt psxy -R -J -O -T -K -Y-2.5i >> $ps
 cat tmp.eps >> $ps
-gmt filter1d -Fm100 -E -N0 noise.txt | gmt filter1d -Fg100 -E -N0 | gmt psxy -R-500/500/-300/300 -J -O -K -W2p,blue >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt filter1d -Fm100 -E -N0 noise.txt | gmt filter1d -Fg100 -E -N0 | gmt psxy -R-500/500/-300/300 -J -O -W2p,blue >> $ps

--- a/test/fitcircle/circles.sh
+++ b/test/fitcircle/circles.sh
@@ -28,6 +28,4 @@ grep "Small Circle Pole" s.txt | gmt psxy -R -J -O -K -Sa0.2i -Ggreen -W0.25p >>
 grep "L1 Average" g.txt | gmt psxy -R -J -O -K -Sa0.2i -Gyellow -W0.25p >> $ps
 grep "L2 Average" g.txt | gmt psxy -R -J -O -K -Sa0.2i -Gyellow -W0.25p >> $ps
 grep "L1 Average" s.txt | gmt psxy -R -J -O -K -Sa0.2i -Gyellow -W0.25p >> $ps
-grep "L2 Average" s.txt | gmt psxy -R -J -O -K -Sa0.2i -Gyellow -W0.25p >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+grep "L2 Average" s.txt | gmt psxy -R -J -O -Sa0.2i -Gyellow -W0.25p >> $ps

--- a/test/gmtconnect/connect.sh
+++ b/test/gmtconnect/connect.sh
@@ -10,5 +10,4 @@ split -l 11 t.txt piece
 gmt psxy t.txt -R-5/5/-5/5 -JX3i -P -W1p -Gorange -B2g1 -BWSne -Y5i -K > $ps
 gmt psxy piece?? -R -J -O -W1p -B2g1 -BWSne -X3.5i -K >> $ps
 gmt connect piece?? -T0.6 | gmt psxy -R -J -O -W1p -Gorange -B2g1 -BWSne -X-3.5i -Y-3.5i -K >> $ps
-gmt connect piece?? -T60k -fg | gmt psxy -R -JM3i -O -W1p -Gred -B2g1 -BWSne -X3.5i -K >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt connect piece?? -T60k -fg | gmt psxy -R -JM3i -O -W1p -Gred -B2g1 -BWSne -X3.5i >> $ps

--- a/test/gmtconvert/segments.sh
+++ b/test/gmtconvert/segments.sh
@@ -68,6 +68,4 @@ gmt convert nan_i.txt --IO_SEGMENT_MARKER='N,B' > t.txt
 gmt psxy -R -J -O -K -Ba -BWSne nan_i.txt -Sc0.2i -Ggreen -X3.5i --IO_SEGMENT_MARKER=N >> $ps
 gmt psxy -R -J -O -K t.txt -Sc0.1i -Gred  --IO_SEGMENT_MARKER=B >> $ps
 gmt psxy -R -J -O -K t.txt -W0.5p  --IO_SEGMENT_MARKER=B >> $ps
-echo "10 10 NaN->blank" | gmt pstext -R -J -O -K -F+jTR+f12 -Dj0.1i >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+echo "10 10 NaN->blank" | gmt pstext -R -J -O -F+jTR+f12 -Dj0.1i >> $ps

--- a/test/gmtlogo/logos.sh
+++ b/test/gmtlogo/logos.sh
@@ -32,5 +32,4 @@ gmt logo -Dx0/0+w3.5i -O -K -F+glightyellow -X4.25i >> $ps
 # Logo by itself
 gmt logo -Dx0/0+w3.5i -O -K -Y2.75i -X-4.25i >> $ps
 # Logo with outline
-gmt logo -Dx0/0+w3.5i -O -K -F -X4.25i >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt logo -Dx0/0+w3.5i -O -F -X4.25i >> $ps

--- a/test/gmtmath/cdfs1.sh
+++ b/test/gmtmath/cdfs1.sh
@@ -83,6 +83,4 @@ EOF
 gmt math -T0/8/0.02 T 20 12 FCDF = p.d
 gmt psxy -R0/8/0/1.2 -J -O -K p.d -W1p -BWS+t"Cumulative Distribution Functions" -Bxa1 -Byaf --MAP_FRAME_TYPE=graph -Y1.65i >> $ps
 gmt psxy -R -J -O -K ML.txt -Sc0.2c -Gred -N >> $ps
-gmt pstext -R -J -O -K -F+f12p,Times-Italic+cTL+jTL+t"F(@~n@-1@-=20, n@-2@- = 12@~)" -Dj0.1i/0 >> $ps
-# Done
-gmt psxy -R -J -O -T >> $ps
+gmt pstext -R -J -O -F+f12p,Times-Italic+cTL+jTL+t"F(@~n@-1@-=20, n@-2@- = 12@~)" -Dj0.1i/0 >> $ps

--- a/test/gmtmath/lsfit.sh
+++ b/test/gmtmath/lsfit.sh
@@ -44,5 +44,4 @@ gmt math -A@sinusoiddata.txt+e+r -N4/1 -C0 1 ADD -C1,2 T ADD 2 DIV 2 MUL PI MUL 
 gmt psxy -R0/2/-3/4 -J -O -Baf @sinusoiddata.txt -Sc0.15c -Gblue -K -Y5i >> $ps
 gmt psxy -R -J -O -K sinusoidfit_lsq.txt -W2p -i0,2 >> $ps
 gmt psxy -R -J -O -K sinusoidfit_svd.txt -Sc2p -Gred -i0,2 >> $ps
-gmt pstext -R -J -O -K -F+f12p+jRB+cRB+t"Fit y(x) = a + b*cos(6@~p@~x - c) + @~e@~(x) = a + b@-1@-*cos(6@~p@~x) + b@-2@-*sin(6@~p@~x) + @~e@~(x)" -Dj0.2i >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt pstext -R -J -O -F+f12p+jRB+cRB+t"Fit y(x) = a + b*cos(6@~p@~x - c) + @~e@~(x) = a + b@-1@-*cos(6@~p@~x) + b@-2@-*sin(6@~p@~x) + @~e@~(x)" -Dj0.2i >> $ps

--- a/test/gmtmath/pdfs1.sh
+++ b/test/gmtmath/pdfs1.sh
@@ -83,6 +83,4 @@ EOF
 gmt math -T0/8/0.02 T 20 12 FPDF = p.d
 gmt psxy -R0/8/0/1 -J -O -K p.d -W1p -BWS+t"Probability Density Functions" -Bxa1 -Byaf --MAP_FRAME_TYPE=graph -Y1.65i >> $ps
 gmt psxy -R -J -O -K ML.txt -Sc0.2c -Gred -N >> $ps
-gmt pstext -R -J -O -K -F+f12p,Times-Italic+cTR+jTR+t"F(@~n@-1@-=20, n@-2@- = 12@~)" >> $ps
-# Done
-gmt psxy -R -J -O -T >> $ps
+gmt pstext -R -J -O -F+f12p,Times-Italic+cTR+jTR+t"F(@~n@-1@-=20, n@-2@- = 12@~)" >> $ps

--- a/test/gmtmath/pdfs2.sh
+++ b/test/gmtmath/pdfs2.sh
@@ -73,6 +73,4 @@ EOF
 gmt math -T0/8/0.1 T 4 CHI2PDF = p.d
 gmt psxy -R0/8/0/0.25 -J -O -K p.d -W1p -BWS+t"Probability Density Functions" -Bxa1 -Byaf --MAP_FRAME_TYPE=graph -Y1.65i >> $ps
 gmt psxy -R -J -O -K ML.txt -Sc0.2c -Gred -N >> $ps
-gmt pstext -R -J -O -K -F+f12p,Times-Italic+cTR+jTR+t"@~c@~@+2@+(z,@~n=4@~)" >> $ps
-# Done
-gmt psxy -R -J -O -T >> $ps
+gmt pstext -R -J -O -F+f12p,Times-Italic+cTR+jTR+t"@~c@~@+2@+(z,@~n=4@~)" >> $ps

--- a/test/gmtregress/regress_1.sh
+++ b/test/gmtregress/regress_1.sh
@@ -38,5 +38,4 @@ echo 90 0.5 REDUCED MAJOR AXIS | gmt pstext -R -J -O -K -F+jTC+a90 -N -Dj0.2i -X
 echo 90 0.5 ORTHOGONAL | gmt pstext -R -J -O -K -F+jTC+a90 -N -Dj0.2i -Xa5.7i -Ya3.25i >> $ps
 echo 90 0.5 X ON Y | gmt pstext -R -J -O -K -F+jTC+a90 -N -Dj0.2i -Xa5.7i -Ya5.5i >> $ps
 echo 90 0.5 Y ON X | gmt pstext -R -J -O -K -F+jTC+a90 -N -Dj0.2i -Xa5.7i -Ya7.75i >> $ps
-echo -90 0.001 MISFIT | gmt pstext -R -J -O -K -F+jBC+a90 -N -Dj0.5i -Xa1.1i -Ya5.5i >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo -90 0.001 MISFIT | gmt pstext -R -J -O -F+jBC+a90 -N -Dj0.5i -Xa1.1i -Ya5.5i >> $ps

--- a/test/gmtregress/regress_2.sh
+++ b/test/gmtregress/regress_2.sh
@@ -40,5 +40,4 @@ plot_one -Ey -Nr wesN+tLMS -Xa5.4i -Ya7.75i >> $ps
 echo 2.85 5.1 REDUCED MAJOR AXIS | gmt pstext -R -J -O -K -F+jTC+a90 -N -Dj0.2i -Xa5.4i -Ya1i >> $ps
 echo 2.85 5.1 ORTHOGONAL | gmt pstext -R -J -O -K -F+jTC+a90 -N -Dj0.2i -Xa5.4i -Ya3.25i >> $ps
 echo 2.85 5.1 X ON Y | gmt pstext -R -J -O -K -F+jTC+a90 -N -Dj0.2i -Xa5.4i -Ya5.5i >> $ps
-echo 2.85 5.1 Y ON X | gmt pstext -R -J -O -K -F+jTC+a90 -N -Dj0.2i -Xa5.4i -Ya7.75i >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo 2.85 5.1 Y ON X | gmt pstext -R -J -O -F+jTC+a90 -N -Dj0.2i -Xa5.4i -Ya7.75i >> $ps

--- a/test/gmtsimplify/reduce.sh
+++ b/test/gmtsimplify/reduce.sh
@@ -8,5 +8,4 @@ gmt simplify @GSHHS_h_Australia.txt -T50k | gmt psxy -R -J -O -K -W0.25p,blue >>
 echo 112 -10 T = 50km | gmt pstext -R -J -O -K -Dj0.1i/0.1i -F+jTL+f18p >> $ps
 gmt psxy @GSHHS_h_Australia.txt -R -J -O -Sc0.01c -Gred -K -B20 -BWsne -Y4.7i >> $ps
 gmt simplify @GSHHS_h_Australia.txt -T100k | gmt psxy -R -J -O -K -W0.25p,blue >> $ps
-echo 112 -10 T = 100km | gmt pstext -R -J -O -K -Dj0.1i/0.1i -F+jTL+f18p >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo 112 -10 T = 100km | gmt pstext -R -J -O -Dj0.1i/0.1i -F+jTL+f18p >> $ps

--- a/test/gmtspatial/intersect.sh
+++ b/test/gmtspatial/intersect.sh
@@ -64,7 +64,4 @@ gmt psxy $R -J -O -K -L -W0.5p,- << EOF >> $ps
 EOF
 # Do clipping and plot the clipped files
 gmt spatial Ag.txt -C -R-2/11/-4/9 -fg | gmt psxy $R -Jm0.15i -O -K -W3p,red >> $ps
-gmt spatial Bg.txt -C -R-2/11/-4/9 -fg | gmt psxy $R -Jm0.15i -O -K -W3p,blue >> $ps
-
-gmt psxy $R -J -O -T >> $ps
-
+gmt spatial Bg.txt -C -R-2/11/-4/9 -fg | gmt psxy $R -Jm0.15i -O -W3p,blue >> $ps

--- a/test/gmtspatial/nn.sh
+++ b/test/gmtspatial/nn.sh
@@ -27,5 +27,4 @@ gmt psxy -R -J -O -K -W1p,green tmp >> $ps
 gmt spatial -Aa75k -fg $DATA > results.txt
 gmt psxy -R -J -O -K -Bag1 -BWsne $DATA -Sc0.1i -Glightgray -Y4.75i $DATA >> $ps
 awk '{print $1, $2, 0, 150, 150}' results.txt | gmt psxy -R -J -O -K -SE -W0.5p,blue >> $ps
-gmt psxy -R -J -O -K results.txt -Sc0.1i -Gred >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psxy -R -J -O results.txt -Sc0.1i -Gred >> $ps

--- a/test/gmtspatial/poldecimate.sh
+++ b/test/gmtspatial/poldecimate.sh
@@ -15,5 +15,4 @@ echo "90 60 N = 2000" | gmt pstext -R -J -O -K -N -F+f12+jLM -Dj0.25i >> $ps
 gmt psxy -R -J -O -K $DATA -Sc0.05i -Bafg -BWsne -Gdarkseagreen1 -Y5i >> $ps
 gmt psxy -R -J -O -K results.txt -Sc0.05i -Gred >> $ps
 N=$(wc -l results.txt | awk '{printf "%d\n", $1}')
-echo "90 60 N = $N" | gmt pstext -R -J -O -K -N -F+f12+jLM -Dj0.25i >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo "90 60 N = $N" | gmt pstext -R -J -O -N -F+f12+jLM -Dj0.25i >> $ps

--- a/test/gmtvector/meanvec.sh
+++ b/test/gmtvector/meanvec.sh
@@ -10,6 +10,4 @@ gmt psxy -R -J -O -K -Sa0.5i -Gyellow -W1p mean.txt >> $ps
 gmt psxy -R -J -O -K -SE -W2p mean.txt >> $ps
 gmt vector pts.txt -Am99 -fg -E | gmt psxy -R58/70/-68:30/-61 -JM6i -O -K -SE -W1p,- >> $ps
 gmt vector pts.txt -Am90 -fg -E | gmt psxy -R58/70/-68:30/-61 -JM6i -O -K -SE -W1p,. >> $ps
-echo 58 -68:30 90%, 95% and 99% confidence ellipses on mean position | gmt pstext -R58/70/-68:30/-61 -JM6i -O -K -F+jLB+f14p -T -W0.5p -Dj0.2i -Gwhite >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+echo 58 -68:30 90%, 95% and 99% confidence ellipses on mean position | gmt pstext -R58/70/-68:30/-61 -JM6i -O -F+jLB+f14p -T -W0.5p -Dj0.2i -Gwhite >> $ps

--- a/test/gmtvector/translate_cart.sh
+++ b/test/gmtvector/translate_cart.sh
@@ -14,5 +14,4 @@ gmt psxy -R -J -Baf -BWSne -Sc0.3c -Ggreen spiral.txt -O -K -Y12.5c >> $ps
 gmt vector spiral.txt -Tt > shifted.txt
 gmt psxy -R -J -O -K -Sc0.2c -Gblue shifted.txt >> $ps
 gmt convert spiral.txt shifted.txt -A -o0,1,4,5 | gmt psxy -R -J -O -K -Sv0.1+s -W0.25p >> $ps
-echo "Variable translation" | gmt pstext -R -J -O -K -F+f16p+jTR+cTR -Dj0.5c -W1p >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo "Variable translation" | gmt pstext -R -J -O -F+f16p+jTR+cTR -Dj0.5c -W1p >> $ps

--- a/test/gmtvector/translate_geo.sh
+++ b/test/gmtvector/translate_geo.sh
@@ -14,5 +14,4 @@ gmt psxy -R -J -Baf -BWSne -Sc0.3c -Ggreen spiral.txt -O -K -Y12.5c >> $ps
 gmt vector spiral.txt -Ttk -fg > shifted.txt
 gmt psxy -R -J -O -K -Sc0.2c -Gblue shifted.txt >> $ps
 gmt convert spiral.txt shifted.txt -A -o0,1,4,5 | gmt psxy -R -J -O -K -Sv0.1+s -W0.25p >> $ps
-echo "Variable translation" | gmt pstext -R -J -O -K -F+f16p+jTR+cTR -Dj0.5c -W1p >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo "Variable translation" | gmt pstext -R -J -O -F+f16p+jTR+cTR -Dj0.5c -W1p >> $ps

--- a/test/grd2xyz/extract.sh
+++ b/test/grd2xyz/extract.sh
@@ -15,5 +15,4 @@ gmt grd2xyz tmp.nc -s | gmt psxy -R$Rp -JM6i -Sc0.3c -Gblue -O -K >> $ps
 # Fill nodes green inside the selected sub region
 gmt grd2xyz -R353/368/-15/14 tmp.nc | gmt psxy -R$Rp -JM6i -Sc0.2c -Ggreen -O -K >> $ps
 # Show NaN nodes as red
-gmt grd2xyz tmp.nc -s+r | gmt psxy -R$Rp -JM6i -Sc0.1c -Gred -O -K >> $ps
-gmt psxy -R$Rp -J -O -T >> $ps
+gmt grd2xyz tmp.nc -s+r | gmt psxy -R$Rp -JM6i -Sc0.1c -Gred -O >> $ps

--- a/test/grdclip/limits.sh
+++ b/test/grdclip/limits.sh
@@ -16,5 +16,4 @@ gmt grdclip tmp.nc -Sa7/NaN -Sb0/-6 -Gout.nc
 gmt grd2xyz out.nc | gmt psxy -R$Rp -J -Sc0.15c -W0.25p -Ct.cpt -O -K -B10f5 -BWsne -Y3.5i >> $ps
 # Set values between 0 and 5 to NaN
 gmt grdclip tmp.nc -Si0/5/NaN -Gout.nc
-gmt grd2xyz out.nc | gmt psxy -R$Rp -J -Sc0.15c -W0.25p -Ct.cpt -O -K -B10f5 -BWsne -Y3.5i >> $ps
-gmt psxy -R$Rp -J -T -O >> $ps
+gmt grd2xyz out.nc | gmt psxy -R$Rp -J -Sc0.15c -W0.25p -Ct.cpt -O -B10f5 -BWsne -Y3.5i >> $ps

--- a/test/grdcut/origin.sh
+++ b/test/grdcut/origin.sh
@@ -44,6 +44,4 @@ gmt grd2xyz t.nc -s | gmt psxy -R -J -O -K -Ss0.02i -Gcyan -N >> $ps
 gmt grd2xyz t.nc -s+r | gmt psxy -R -J -O -K -Ss0.02i -Gorange -N >> $ps
 gmt grdcontour t.nc -J -O -K -A10 -C5 -Gd2i >> $ps
 echo 145 78 0 3000 3000 | gmt psxy -R -J -O -K -SE -W1p,blue >> $ps
-echo 145 78 | gmt psxy -R -J -O -K -Sx0.1i -W1p >> $ps
-
-gmt psxy -R -J -O -T >> $ps
+echo 145 78 | gmt psxy -R -J -O -Sx0.1i -W1p >> $ps

--- a/test/grdcut/subset.sh
+++ b/test/grdcut/subset.sh
@@ -13,6 +13,4 @@ gmt grd2xyz tmp.nc | gmt psxy -R$Rp -JX6i -Sc0.25c -Ct.cpt -P -K -B10f5 -BWSne -
 gmt psscale -Dx3i/-0.4i+w6i/0.15i+h+e+jTC -O -K -Ct.cpt >> $ps
 # Extract portion of grid with values less than 5
 gmt grdcut tmp.nc -Z0/5 -Gout.nc
-gmt grd2xyz out.nc | gmt psxy -R -J -Sc0.25c -W0.5p -O -K -B10f5 -BWSne+t"Rectangular subset with z <= 5" >> $ps
-gmt psxy -R$Rp -J -O -T >> $ps
-
+gmt grd2xyz out.nc | gmt psxy -R -J -Sc0.25c -W0.5p -O -B10f5 -BWSne+t"Rectangular subset with z <= 5" >> $ps

--- a/test/grdedit/edit.sh
+++ b/test/grdedit/edit.sh
@@ -18,6 +18,4 @@ gmt grdcut tmp.nc -R10/20/10/20 -Gt.nc
 gmt grdmath t.nc 0 MUL 10 ADD = t.nc
 gmt grd2xyz t.nc > tmp
 gmt grdedit tmp.nc -Ntmp
-gmt grd2xyz tmp.nc | gmt psxy -R$Rp -JX4i -Ss0.2c -Ct.cpt -O -K -B10f5 -BWSne -Y4.5i >> $ps
-gmt psxy -R$Rp -J -O -T >> $ps
-
+gmt grd2xyz tmp.nc | gmt psxy -R$Rp -JX4i -Ss0.2c -Ct.cpt -O -B10f5 -BWSne -Y4.5i >> $ps

--- a/test/grdfft/bworthr.sh
+++ b/test/grdfft/bworthr.sh
@@ -33,5 +33,4 @@ gmt psxy -R -J -O -K bworth_rn.txt -Sc0.1c -Gblue -Ey >> $ps
 gmt psxy -R -J -O -K bworth_rn.txt -Wfaint,blue >> $ps
 gmt psxy -R -J -O -K bworth_brn.txt -Sc0.1c -Ggreen -Ey >> $ps
 gmt psxy -R -J -O -K bworth_brn.txt -W0.25p >> $ps
-gmt psxy -R -J -O -K curven.txt -W0.5p,red >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psxy -R -J -O curven.txt -W0.5p,red >> $ps

--- a/test/grdfft/bworthxy.sh
+++ b/test/grdfft/bworthxy.sh
@@ -32,5 +32,4 @@ gmt psxy -R -J -O -K bworth_y.txt -Sc0.1c -Gblue -Ey >> $ps
 gmt psxy -R -J -O -K bworth_y.txt -Wfaint,blue >> $ps
 gmt psxy -R -J -O -K bworth_by.txt -Sc0.1c -Ggreen -Ey >> $ps
 gmt psxy -R -J -O -K bworth_by.txt -W0.25p >> $ps
-gmt psxy -R -J -O -K curve.txt -W0.5p,red >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psxy -R -J -O curve.txt -W0.5p,red >> $ps

--- a/test/grdfft/cylundulation.sh
+++ b/test/grdfft/cylundulation.sh
@@ -42,5 +42,4 @@ gmt pstext -R -J -O -K -F+f12p << EOF >> $ps
 0.65 -0.35 60@.
 0.52 0.08 18@.
 EOF
-gmt psscale -DJRM+w4.5i/0.1i -Ct.cpt -R -J -O -K >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psscale -DJRM+w4.5i/0.1i -Ct.cpt -R -J -O >> $ps

--- a/test/grdfft/in_taper.sh
+++ b/test/grdfft/in_taper.sh
@@ -33,5 +33,4 @@ gmt grdfft t.nc -N300/200+n+t25+wtmp+l -E > /dev/null
 gmt grdimage t_tmp.nc -J -Ct.cpt -Ba -BWSne -O -K -Y${yoffe}i >> $ps
 echo "400 192 No extension" | gmt pstext -R -J -O -K -N -F+jLM+f16p -D0.5i/0 >> $ps
 echo "400 192 25% inward taper" | gmt pstext -R -J -O -K -N -F+jLM+f16p -D0.5i/-0.3i >> $ps
-gmt psscale -Ct.cpt -Dx${x}i/${yoff}i+w4i/0.1i+h+jTC -O -K -B0.5 >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psscale -Ct.cpt -Dx${x}i/${yoff}i+w4i/0.1i+h+jTC -O -B0.5 >> $ps

--- a/test/grdfft/out_taper.sh
+++ b/test/grdfft/out_taper.sh
@@ -47,5 +47,4 @@ gmt psxy -R -J -O -K -W2p,green << EOF >> $ps
 EOF
 echo "400 192 Point symmetry" | gmt pstext -R -J -O -K -N -F+jLM+f16p -D0.5i/0 >> $ps
 echo "400 192 100% outwardtaper" | gmt pstext -R -J -O -K -N -F+jLM+f16p -D0.5i/-0.3i >> $ps
-gmt psscale -Ct.cpt -Dx${x}i/${yoffe}i+w4i/0.1i+h+jTC -O -K -B0.5 >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psscale -Ct.cpt -Dx${x}i/${yoffe}i+w4i/0.1i+h+jTC -O -B0.5 >> $ps

--- a/test/grdfilter/filtertest.sh
+++ b/test/grdfilter/filtertest.sh
@@ -62,5 +62,4 @@ gmt grdcontour r.nc -J -O -K -C1 -L$lo/$hi -W1p -R0/360/$range >> $ps
 gmt grdimage t.nc -JQ0/7i -B30g10 -BWsNe+t"$D km Gaussian at ($lon, $lat)" -Ct.cpt -O -K -Y7.8i -R-180/180/$range --FONT_TITLE=18p >> $ps
 echo ${lon} $lat | gmt psxy -R -J -O -K -Sx0.1 -W1p >> $ps
 gmt grdcontour -R r.nc -J -O -K -C1 -L$lo/$hi -W1p >> $ps
-gmt psscale -Ct.cpt -Dx3.5i/-0.15i+w6i/0.05i+h+jTC -O -K -Bx$t -By+l"${mode} [$n_conv]" >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psscale -Ct.cpt -Dx3.5i/-0.15i+w6i/0.05i+h+jTC -O -Bx$t -By+l"${mode} [$n_conv]" >> $ps

--- a/test/grdfilter/openmp.sh
+++ b/test/grdfilter/openmp.sh
@@ -20,6 +20,4 @@ gmt grdfilter -D4 -F${FILT}$D -I$INC @earth_relief_10m -Gt.nc -fg
 gmt makecpt -Cglobe > t.cpt
 gmt grdimage t.nc -JQ0/7i -Ba -BWSne+t"$D km Gaussian filter" -Ct.cpt -P -K -Xc -Y1.5i > $ps
 gmt psscale -Ct.cpt -D3.5i/-0.5i+w6i/0.1i+h+jTC -O -K -Bxa -By+l"m" >> $ps
-gmt grdimage @earth_relief_10m -JQ0/7i -Ba -BWSne+t"Original data" -Ct.cpt -O -K -Y4.75i >> $ps
-gmt psxy -Rt.nc -J -O -T >> $ps
-
+gmt grdimage @earth_relief_10m -JQ0/7i -Ba -BWSne+t"Original data" -Ct.cpt -O -Y4.75i >> $ps

--- a/test/grdfilter/threads.sh
+++ b/test/grdfilter/threads.sh
@@ -17,5 +17,4 @@ gmt grdfilter -D4 -F${FILT}$D -I$INC $DATA -Gt.nc -fg ${_thread_opt}
 gmt makecpt -Cglobe > t.cpt
 gmt grdimage t.nc -JQ0/7i -Ba -BWSne+t"$D km Gaussian filter" -Ct.cpt -P -K -Xc -Y1.5i > $ps
 gmt psscale -Ct.cpt -Dx3.5i/-0.5i+w6i/0.1i+h+jTC -O -K -Bxa -By+l"m" >> $ps
-gmt grdimage $DATA -JQ0/7i -Ba -BWSne+t"Original data" -Ct.cpt -O -K -Y4.75i >> $ps
-gmt psxy -Rt.nc -J -O -T >> $ps
+gmt grdimage $DATA -JQ0/7i -Ba -BWSne+t"Original data" -Ct.cpt -O -Y4.75i >> $ps

--- a/test/grdmath/ops.sh
+++ b/test/grdmath/ops.sh
@@ -22,5 +22,4 @@ gmt grdimage E.grd -Ct.cpt -J -B0 -O -K -X-3.25i -Y-3.25i >> $ps
 echo -2 -2 D2DX2 + D2DY2 | gmt pstext -R -J -O -K -Dj0.1i -F+jLB+f12p >> $ps
 gmt grdimage F.grd -Ct.cpt -J -B0 -O -K -X3.25i >> $ps
 echo -2 -2 EXTREMA | gmt pstext -R -J -O -K -Dj0.1i -F+jLB+f12p >> $ps
-gmt psscale -Ct.cpt -Dx3.125i/-0.2i+w6i/0.2i+h+jTC -L0.1i -O -K -X-3.25i >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psscale -Ct.cpt -Dx3.125i/-0.2i+w6i/0.2i+h+jTC -L0.1i -O -X-3.25i >> $ps

--- a/test/grdsample/sample.sh
+++ b/test/grdsample/sample.sh
@@ -12,6 +12,4 @@ gmt grdimage tmp.nc -JX4.5i -Ct.cpt -P -K -B10f5 -BWSne -Xc -Y0.75i > $ps
 gmt psscale -Dx5i/4.75i+w6i/0.15i+jML+e+n -O -K -Ct.cpt >> $ps
 # Resample to 0.2 spacing
 gmt grdsample tmp.nc -I0.2 -Gout.nc
-gmt grdimage out.nc -JX4.5i -Ct.cpt -O -K -B10f5 -BWSne -Xc -Y5i >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+gmt grdimage out.nc -JX4.5i -Ct.cpt -O -B10f5 -BWSne -Xc -Y5i >> $ps

--- a/test/grdtrack/profiles.sh
+++ b/test/grdtrack/profiles.sh
@@ -30,5 +30,4 @@ gmt psxy -R -J -O -K b.txt -W1p,green >> $ps
 gmt psxy -R -J -O -K c.txt -W1p,blue >> $ps
 gmt psxy -R -J -O -K d.txt -W1p,yellow >> $ps
 gmt psxy -R -J -O -K e.txt -Sc0.1c -Gbrown >> $ps
-gmt psxy -R -J -O -K f.txt -Sc0.1c -Gblack >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psxy -R -J -O f.txt -Sc0.1c -Gblack >> $ps

--- a/test/grdvector/grdgeovec.sh
+++ b/test/grdvector/grdgeovec.sh
@@ -38,5 +38,4 @@ echo -1	60	0	11.113 > t.txt
 echo 1	60	90	11.113 >> t.txt
 gmt xyz2grd -R-1/1/59/61 -I1 -fg -Ga.grd t.txt
 gmt xyz2grd -R -I1 -fg -Gr.grd t.txt -i0,1,3
-gmt grdvector r.grd a.grd -A -R-2/3/58/63 -J -O -K -Q0.2i+e -Gblue -W2p,blue -S0.1n -Bafg1 -BwSne+t"nm" -Y3.75i >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt grdvector r.grd a.grd -A -R-2/3/58/63 -J -O -Q0.2i+e -Gblue -W2p,blue -S0.1n -Bafg1 -BwSne+t"nm" -Y3.75i >> $ps

--- a/test/grdvector/tworegions.sh
+++ b/test/grdvector/tworegions.sh
@@ -14,5 +14,4 @@ gmt xyz2grd -R -I30m -Gv.grd t.txt -i0,1,3
 gmt psvelo t.txt -JM3i -R-2/2/-2/2 -Se0.1i/0.95/12 -A9p+e -W1.5p,red -P -Bafg1 -BWSne -K > $ps
 gmt grdvector u.grd v.grd -R -J -O -K -Q0.1i+e -Gblue -W1p,blue -Si0.1i -Bafg1 -BwSne --MAP_VECTOR_SHAPE=0.2 -X3.25i >> $ps
 gmt psvelo t.txt -J -R-1/1/-1/1 -Se0.1i/0.95/12 -A9p+e -W1.5p,red -O -Bafg1 -BWSne -K -X-3.25i -Y3.75i >> $ps
-gmt grdvector u.grd v.grd -R -J -O -K -Q0.1i+e -Gblue -W1p,blue -Si0.1i -Bafg1 -BwSne --MAP_VECTOR_SHAPE=0.2 -X3.25i >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt grdvector u.grd v.grd -R -J -O -Q0.1i+e -Gblue -W1p,blue -Si0.1i -Bafg1 -BwSne --MAP_VECTOR_SHAPE=0.2 -X3.25i >> $ps

--- a/test/grdvolume/sphere_volume.sh
+++ b/test/grdvolume/sphere_volume.sh
@@ -12,5 +12,4 @@ echo "-100 gray 100 gray" > t.cpt
 gmt grdview bot_half.grd -Iint.grd -Ct.cpt -Qi100 -Jx0.2i -Jz0.2i -p125/35 -P -Baf -BwSnE -K -X1.5i > $ps
 gmt pstext -R -J -Jz -O -K -p -F+f18p+cBC+jTC+t"Area = ${B[1]} Volume = ${B[2]}" -Dj0/0.4i -N >> $ps
 gmt grdview top_half.grd -Iint.grd -Ct.cpt -Qi100 -Jx0.2i -Jz0.2i -p125/35 -P -Baf -BwSnE -O -K -Y5.25i >> $ps
-gmt pstext -R -J -Jz -O -K -p -F+f18p+cBC+jTC+t"Area = ${T[1]} Volume = ${T[2]}" -Dj0/0.4i -N >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt pstext -R -J -Jz -O -p -F+f18p+cBC+jTC+t"Area = ${T[1]} Volume = ${T[2]}" -Dj0/0.4i -N >> $ps

--- a/test/greenspline/gspline_1.sh
+++ b/test/greenspline/gspline_1.sh
@@ -13,10 +13,8 @@ gmt psxy -R$R -J -O -K @Table_4.2.txt -Sc0.075i -Gblack >> $ps
 gmt greenspline -R-2000/25000 -I100 @Table_4.2.txt -Sl -D0 | gmt psxy -R$R -J -O -K -Wthin,. >> $ps
 gmt greenspline -R-2000/25000 -I100 @Table_4.2.txt -Sc -D0 | gmt psxy -R$R -J -O -K -Wthin,- >> $ps
 gmt greenspline -R-2000/25000 -I100 @Table_4.2.txt -St0.25 -D0 | gmt psxy -R$R -J -O -K -Wthin >> $ps
-gmt pslegend -R$R -J -O -K -F+p -Dx5.9i/2.9i+w2.05i+jTR --FONT_ANNOT_PRIMARY=12p << EOF >> $ps
+gmt pslegend -R$R -J -O -F+p -Dx5.9i/2.9i+w2.05i+jTR --FONT_ANNOT_PRIMARY=12p << EOF >> $ps
 S 0.2i - 0.35i - 0.5p 0.5i Tension (@%6%t@%% = 0.25)
 S 0.2i - 0.35i - 0.5p,- 0.5i No tension
 S 0.2i - 0.35i - 0.5p,. 0.5i Linear interpolation
 EOF
-gmt psxy -R$R -J -O -T >> $ps
-

--- a/test/greenspline/gspline_3.sh
+++ b/test/greenspline/gspline_3.sh
@@ -53,6 +53,4 @@ gmt makecpt -Cpolar -T-5/5 -D > tt.cpt
 gmt grdimage grad.nc -Ctt.cpt -Jx2.8i -M -Bx0.5 -By0.2 -BWSne -Y4.25i -O -K >> $ps
 gmt grdcontour splined.nc -Jx2.8i -O -Bx0.5 -By0.2 -BWSne -C0.2 -A0.2 -K -GlLT/1/0,1.5/0.5/1.5/1 >> $ps
 gmt psxy use.xyz -R -J -O -K -Sc0.05i -Gblack >> $ps
-echo "0 1 b)" | gmt pstext -R -J -O -K -N -F+jBR+f24p -Dj0.1i/0.3i >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+echo "0 1 b)" | gmt pstext -R -J -O -N -F+jBR+f24p -Dj0.1i/0.3i >> $ps

--- a/test/greenspline/gspline_5.sh
+++ b/test/greenspline/gspline_5.sh
@@ -37,6 +37,4 @@ gmt grdcontour -R Fig_2_p5.nc -J -O -K -Z+s0.001 -C5 -A10 -Gl335/0/0/90,0/90/155
 gmt psxy -R -J -O -K $data -Sc0.1i -Gblack >> $ps
 gmt psxy -R -J -O -K $data -Sc0.025i -Gwhite >> $ps
 gmt psxy -R -J -O -K @mag_validate_1990.txt -Sc0.1i -Gwhite -W0.25p  >> $ps
-gmt psxy -R -J -O -K @mag_validate_1990.txt -Sc0.025i -Gblack >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+gmt psxy -R -J -O @mag_validate_1990.txt -Sc0.025i -Gblack >> $ps

--- a/test/img/imgmap.sh
+++ b/test/img/imgmap.sh
@@ -18,5 +18,4 @@ gmt grdimage img_g1.nc -Jm -Ct.cpt -O -K -Ba -BWSne -Y3.25i >> $ps
 # Get resampled geo grid with a domain exactly matching the requested -R
 gmt img2grd $IMG -R180/200/-5/5 -T1 -S1 -Gimg_g2.nc -E
 # Now we can plot this geographic grid using any projection, here Mercator
-gmt grdimage img_g2.nc -Jm -Ct.cpt -O -K -Ba -BWSne -Y3.25i >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt grdimage img_g2.nc -Jm -Ct.cpt -O -Ba -BWSne -Y3.25i >> $ps

--- a/test/kml/kml2gmt.sh
+++ b/test/kml/kml2gmt.sh
@@ -5,5 +5,4 @@ ps=kml2gmt.ps
 
 gmt pscoast -R-11/2/49:50/59:30 -JM6i -M -W0.25p -Di > coast.txt
 gmt psxy -R -J -P -K coast.txt -W2p,green -Baf -Xc > $ps
-gmt kml2gmt "${src:-.}"/coast.kml | gmt psxy -R -J -O -K -W0.25p,red >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt kml2gmt "${src:-.}"/coast.kml | gmt psxy -R -J -O -W0.25p,red >> $ps

--- a/test/mapproject/oblmerc_down.sh
+++ b/test/mapproject/oblmerc_down.sh
@@ -69,6 +69,4 @@ $LL_lon $LL_lat RB LL
 $UR_lon $UR_lat TL UR
 EOF
 gmt psbasemap -R$LL_x/$LL_y/$UR_x/${UR_y}r -Jx$scale_km -O -K -Bafg -BNE --MAP_GRID_PEN_PRIMARY=0.25p,. >> $ps
-echo "0 9.5 az = $az_x" | gmt pstext -R0/8/0/10 -Jx1i -O -K -F+f24p+jTL >> $ps
-
-gmt psxy -R -J -O -T >> $ps
+echo "0 9.5 az = $az_x" | gmt pstext -R0/8/0/10 -Jx1i -O -F+f24p+jTL >> $ps

--- a/test/mapproject/oblmerc_up.sh
+++ b/test/mapproject/oblmerc_up.sh
@@ -68,5 +68,4 @@ $LL_lon $LL_lat RB LL
 $UR_lon $UR_lat TL UR
 EOF
 gmt psbasemap -R$LL_x/$LL_y/$UR_x/${UR_y}r -Jx$scale_km -O -K -Bafg -BNE --MAP_GRID_PEN_PRIMARY=0.25p,. >> $ps
-echo "0 9.5 az = $az_x" | gmt pstext -R0/8/0/10 -Jx1i -O -K -F+f24p+jTL >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo "0 9.5 az = $az_x" | gmt pstext -R0/8/0/10 -Jx1i -O -F+f24p+jTL >> $ps

--- a/test/ogr/select.sh
+++ b/test/ogr/select.sh
@@ -12,8 +12,7 @@ gmt psxy @capitals.gmt -R -J -W0.25p -Ss0.05i -Ggreen -O -K >> $ps
 gmt pscoast -R -J -Gseashell1 -N1/0.25p,darkred -Wfaint -Baf -B+t"World Capitals" -O -K -A5000 -Dc -Y4.75i >> $ps
 gmt psxy big_tmp.gmt -R -J -Ss0.1i -W0.25p -Gred -O -K >> $ps
 gmt pstext -R -J -O -K -F+f8p+jCB -Gwhite -Dj0.1i big_tmp.gmt >> $ps
-gmt pslegend -DjCB+w2.9i+jCT+o0/0.5i -O -K -R -J -F+p1p << EOF >> $ps
+gmt pslegend -DjCB+w2.9i+jCT+o0/0.5i -O -R -J -F+p1p << EOF >> $ps
 S 0.1i s 0.15i red 0.25p 0.3i Capital with over 7 million people
 S 0.1i s 0.15i green 0.25p 0.3i Capital with less people than that
 EOF
-gmt psxy -R -J -O -T >> $ps

--- a/test/potential/admittance.sh
+++ b/test/potential/admittance.sh
@@ -44,5 +44,4 @@ gmt psxy adm.txt -i0,15 -R -J -O -K -W0.5p,red >> $ps
 gmt psxy adm.txt -R8/512/0/70 -J -O -Bxa2g3 -Byaf+l"Admittance (mGal/km)" -BE -Sc0.05i -Ey+w0.2c+p0.5p,blue \
 	-Gblue -K -i0,11+s1000,12+s1000  --FONT_LABEL=16p,Helvetica,blue >> $ps
 gmt psxy adm.txt -R -J -O -K  -W0.5p,blue -i0,11+s1000 >> $ps
-gmt psxy adm_t.txt -R -J -O -K -W0.5p,green -i0,3+s1000 >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psxy adm_t.txt -R -J -O -W0.5p,green -i0,3+s1000 >> $ps

--- a/test/potential/cseamounts.sh
+++ b/test/potential/cseamounts.sh
@@ -54,6 +54,4 @@ echo "141 -1950 CARTESIAN" | gmt pstext -R -J -O -K -F+jCM+f12p >> $ps
 # Add Geographic crossections
 gmt psxy -R0/313/-3100/-1900 -JX3i/2.5i -O -K -W1p -i2,3 geo_circ.trk -Bafg1000 -BwsNe -X3.5i >> $ps
 gmt psxy -R -J -O -K -W1p,- -i2,3 geo_ellipse.trk >> $ps
-echo "141 -1950 GEOGRAPHIC" | gmt pstext -R -J -O -K -F+jCM+f12p >> $ps
-# Finalize plot
-gmt psxy -R -J -O -T >> $ps
+echo "141 -1950 GEOGRAPHIC" | gmt pstext -R -J -O -F+jCM+f12p >> $ps

--- a/test/potential/cyl2d.sh
+++ b/test/potential/cyl2d.sh
@@ -29,5 +29,4 @@ gmt psxy -R -J -O -K geoid.txt -W0.5p,blue >> $ps
 gmt pstext -R -J -O -K -F+f14p+cTR+jTR+tGEOID -Dj0.1i >> $ps
 gmt psxy -R-25/25/-10/50 -JX6i/2.25i -O -K -Y2.4i v_truth.txt -Sc0.1c -Gred -Bxaf -Byafg1000+l"Eotvos" -BWsne >> $ps
 gmt psxy -R -J -O -K vgg.txt -W0.5p,blue >> $ps
-gmt pstext -R -J -O -K -F+f14p+cTR+jTR+tVGG -Dj0.1i >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt pstext -R -J -O -F+f14p+cTR+jTR+tVGG -Dj0.1i >> $ps

--- a/test/potential/cyltest.sh
+++ b/test/potential/cyltest.sh
@@ -44,5 +44,4 @@ echo 0 2500 @~Dr = 1670@~ | gmt pstext -R -J -O -K -F+f18p,Helvetica,white+jCM >
 echo 0 1000 d = 50 km | gmt pstext -R -J -O -K -F+f14p,Times-Italic+jCM -Gwhite >> $ps
 echo 30 3208.5 3751 m | gmt pstext -R -J -O -K -F+f14p,Times-Italic+jCM+a90 -Gwhite >> $ps
 echo 32 1333 z@-1@- = 1333 m | gmt pstext -R -J -O -K -F+f14p,Times-Italic+jLM -Dj0.1i/0.1i >> $ps
-echo 32 5084 z@-2@- = 5084 m | gmt pstext -R -J -O -K -F+f14p,Times-Italic+jLB -Dj0.1i/0.1i >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo 32 5084 z@-2@- = 5084 m | gmt pstext -R -J -O -F+f14p,Times-Italic+jLB -Dj0.1i/0.1i >> $ps

--- a/test/potential/deflections.sh
+++ b/test/potential/deflections.sh
@@ -54,5 +54,4 @@ echo "100 250 VGG" | gmt pstext -R -J -O -K -F+jTR+f12p,Helvetica,red -Dj0.1i >>
 gmt psxy -R-100/100/-120/120 -JX3i/2.5i -O -K -W1p,blue -i0,3 def_e.trk -Bafg1000 -BwsN -X3.5i >> $ps
 echo "-100 120 @~h@~" | gmt pstext -R -J -O -K -F+jTL+f12p,Helvetica,blue -Dj0.1i >> $ps
 gmt psxy -R -J -O -K -W1p,orange -i1,3 def_n.trk -Baf -BE >> $ps
-echo "100 120 @~x@~" | gmt pstext -R -J -O -K -F+jTR+f12p,Helvetica,orange -Dj0.1i >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo "100 120 @~x@~" | gmt pstext -R -J -O -F+jTR+f12p,Helvetica,orange -Dj0.1i >> $ps

--- a/test/potential/fields.sh
+++ b/test/potential/fields.sh
@@ -89,5 +89,4 @@ echo "100 250 FAA" | gmt pstext -R -J -O -K -F+jTR+f12p,Helvetica,red -Dj0.1i/0.
 gmt psxy -R-100/100/-50/250 -JX3i/2.5i -O -K -W1p,blue -i0,3 vgg.trk -Bafg1000 -BwsN -X3.5i >> $ps
 echo "-100 250 VGG" | gmt pstext -R -J -O -K -F+jTL+f12p,Helvetica,blue -Dj0.1i >> $ps
 gmt psxy -R-100/100/0/4 -J -O -K -W1p,orange -i0,3 geoid.trk -Baf -BE >> $ps
-echo "100 4 GEOID" | gmt pstext -R -J -O -K -F+jTR+f12p,Helvetica,orange -Dj0.1i >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo "100 4 GEOID" | gmt pstext -R -J -O -F+jTR+f12p,Helvetica,orange -Dj0.1i >> $ps

--- a/test/potential/firmoviscous.sh
+++ b/test/potential/firmoviscous.sh
@@ -55,5 +55,4 @@ while read file t t2 color; do
 	gmt grdtrack t.txt -Gtmp.nc > b.txt
 	gmt psxy -R -J -O -K -W0.5p,${color} b.txt -i0,2 >> $ps
 done < flist.txt
-echo -200 -40 FAA | gmt pstext -R -J -O -K -F+f18p+jLB -Dj0.1i >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo -200 -40 FAA | gmt pstext -R -J -O -F+f18p+jLB -Dj0.1i >> $ps

--- a/test/potential/flex_inplane.sh
+++ b/test/potential/flex_inplane.sh
@@ -41,9 +41,8 @@ gmt grdmath smt_grav.nc grav_co.nc ADD = tmp.nc
 gmt grdtrack -Gtmp.nc+Uk -ELM/RM -o0,2 | gmt psxy -R -J -O -K -W1p,red  >> $ps
 gmt grdtrack -Ggrav_co.nc+Uk -ELM/RM -o0,2 | gmt psxy -R -J -O -K -W0.25,red,-  >> $ps
 echo "-300 270 FAA" | gmt pstext -R -J -O -K -F+jLT+f14p -Dj0.1i >>$ps
-gmt pstext -R -J -O -K -F+jRB+f14p -Dj0.1i << EOF >>$ps
+gmt pstext -R -J -O -F+jRB+f14p -Dj0.1i << EOF >>$ps
 300 240 Isotropic [0 Pa]
 300 210 @;blue;Extension [$N Pa]@;;
 300 180 @;red;Compression [-$N Pa]@;;
 EOF
-gmt psxy -R -J -O -T >> $ps

--- a/test/potential/flexapprox.sh
+++ b/test/potential/flexapprox.sh
@@ -37,5 +37,4 @@ gmt psxy -R -J -O -K result.txt -i0,2+s$scale -W0.25p,red >> $ps
 # Plot the exact double-domain data and the approximations
 gmt psxy -R -J -O -K -Bafg10000 @flex_analytical.txt -i0,2 -Sc0.04i -Ggreen -Y4.75i >> $ps
 gmt psxy -R -J -O -K @flex_analytical.txt -i0,3 -W0.25p >> $ps
-gmt psxy -R -J -O -K result.txt -i0,3+s$scale -W0.25p,red,- >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psxy -R -J -O result.txt -i0,3+s$scale -W0.25p,red,- >> $ps

--- a/test/potential/flexure_e.sh
+++ b/test/potential/flexure_e.sh
@@ -12,5 +12,4 @@ EOF
 gmt grdseamount -R0/600/0/400+uk -I1000 -Gsmt.nc t.txt -Dk -E -F$f -C$m
 gmt grdcontour smt.nc+Uk -Jx0.01i -Xc -P -A1 -GlLM/RM -Bafg -K -Z+s0.001 > $ps
 gmt grdflexure smt.nc -D3300/2700/2400/1030 -E5k -Gflex_e.nc
-gmt grdcontour flex_e.nc+Uk -J -O -K -C0.2 -A1 -Z+s0.001 -GlLM/RM -Bafg -BWsNE+t"Elastic Plate Flexure, T@-e@- = 5 km" -Y4.4i >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt grdcontour flex_e.nc+Uk -J -O -C0.2 -A1 -Z+s0.001 -GlLM/RM -Bafg -BWsNE+t"Elastic Plate Flexure, T@-e@- = 5 km" -Y4.4i >> $ps

--- a/test/potential/growth.sh
+++ b/test/potential/growth.sh
@@ -32,10 +32,9 @@ while read file; do
 done < t.lis
 gmt grdtrack -Gsmt.nc+Uk -E0/75/200/75 -o0,2 -nn | gmt psxy -R -J -O -K -W1p >> $ps
 gmt psscale -Ct2.cpt -Dx3i/-0.4i+w-6i/0.15i+h+jTC -O -K -Baf -Bx+l"Time of emplacement" >> $ps
-gmt psxy -R1/10/0/1 -JX-6i/0.15i -O -K -Y-0.55i -Gblack << EOF >> $ps
+gmt psxy -R1/10/0/1 -JX-6i/0.15i -O -Y-0.55i -Gblack << EOF >> $ps
 5.25	0
 5.50	0
 5.50	1
 5.25	1
 EOF
-gmt psxy -R -J -O -T >> $ps

--- a/test/potential/gseamounts.sh
+++ b/test/potential/gseamounts.sh
@@ -54,6 +54,4 @@ echo "141 -1950 CARTESIAN" | gmt pstext -R -J -O -K -F+jCM+f12p >> $ps
 # Add Geographic crossections
 gmt psxy -R0/313/-3100/-1900 -JX3i/2.5i -O -K -W1p -i2,3 geo_circ.trk -Bafg1000 -BwsNe -X3.5i >> $ps
 gmt psxy -R -J -O -K -W1p,- -i2,3 geo_ellipse.trk >> $ps
-echo "141 -1950 GEOGRAPHIC" | gmt pstext -R -J -O -K -F+jCM+f12p >> $ps
-# Finalize plot
-gmt psxy -R -J -O -T >> $ps
+echo "141 -1950 GEOGRAPHIC" | gmt pstext -R -J -O -F+jCM+f12p >> $ps

--- a/test/potential/sphtest.sh
+++ b/test/potential/sphtest.sh
@@ -41,5 +41,4 @@ gmt psxy -R-25/25/0/6000 -JX6i/-2.5i -O -K -Y-2.75i -Se -Gblack -Bxafg1000+u" km
 EOF
 echo 0 1500 @~Dr = 1670@~ | gmt pstext -R -J -O -K -F+f18p,Helvetica+jCM -Gwhite >> $ps
 echo -3 4000 R = $R m | gmt pstext -R -J -O -K -F+f14p,Times-Italic+jRB -Dj0.1i/0.1i >> $ps
-echo 3 4000 z@-0@- = $z0 m | gmt pstext -R -J -O -K -F+f14p,Times-Italic+jLB -Dj0.1i/0.1i >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo 3 4000 z@-0@- = $z0 m | gmt pstext -R -J -O -F+f14p,Times-Italic+jLB -Dj0.1i/0.1i >> $ps

--- a/test/potential/variablerho.sh
+++ b/test/potential/variablerho.sh
@@ -58,6 +58,5 @@ gmt grdtrack -Gfaa.nc -ELM/RM -o0,2 -nn > faa.trk
 gmt psxy -R -J -O -K -W1p,blue faa.trk >> $ps
 echo "-256 250 FAA" | gmt pstext -R -J -O -K -F+jTL+f14p -Dj0.1i -Gwhite -C+tO >> $ps
 echo "+256 250 CONSTANT DENSITY" | gmt pstext -R -J -O -K -F+jTR+f14p,blue -Dj0.1i -Gwhite -C+tO >> $ps
-echo "+256 250 VARIABLE DENSITY" | gmt pstext -R -J -O -K -F+jTR+f14p,red -Dj0.1i/0.4i -Gwhite -C+tO >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo "+256 250 VARIABLE DENSITY" | gmt pstext -R -J -O -F+jTR+f14p,red -Dj0.1i/0.4i -Gwhite -C+tO >> $ps
 rm -f vgg.trk faa.trk plateau.trk rho.trk rho.nc plateau.nc vgg.nc faa.nc

--- a/test/project/oblique.sh
+++ b/test/project/oblique.sh
@@ -15,6 +15,4 @@ centr=`$AWK '{if (NR == 2) printf "%s/%s\n", $1, $2}' p.txt`
 gmt pscoast -Rg -JG30/50/7i -P -K -Glightgray -Dc -Bg > $ps
 echo 30 50 | gmt psxy -R -J -O -K -Sa0.2i -Gred -W0.25p >> $ps
 echo 0 0 | gmt psxy -R -J -O -K -Sc0.1i -Gblack >> $ps
-gmt project t.txt -T$ppole -C$centr -Fpq | gmt psxy -R -J -O -K -W3p >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+gmt project t.txt -T$ppole -C$centr -Fpq | gmt psxy -R -J -O -W3p >> $ps

--- a/test/psbasemap/test-JXd.sh
+++ b/test/psbasemap/test-JXd.sh
@@ -26,4 +26,3 @@ plot1 8cd/8c -X12c >> $ps
 plot1 8c/8cd -Y-11c >> $ps
 plot1 8cd/8cd -X-12c >> $ps
 gmt psxy -T -R -J -O >> $ps
-

--- a/test/pscoast/oblsuite.sh
+++ b/test/pscoast/oblsuite.sh
@@ -24,7 +24,7 @@ gmt pstext -R0/8/0/10 -Jx1i -F+f14p+jRM -O -K -X-3.45i -N << EOF >> $ps
 -0.1 7.5 az: -140
 -0.1 9.2 az: -180
 EOF
-gmt pstext -R0/8/0/10 -Jx1i -F+f14p+jLM -O -K -N << EOF >> $ps
+gmt pstext -R0/8/0/10 -Jx1i -F+f14p+jLM -O -N << EOF >> $ps
 6.2 0.7 az: 150
 6.2 2.4 az: 120
 6.2 4.1 az: 90
@@ -32,4 +32,3 @@ gmt pstext -R0/8/0/10 -Jx1i -F+f14p+jLM -O -K -N << EOF >> $ps
 6.2 7.5 az: 30
 6.2 9.2 az: 0
 EOF
-gmt psxy -R -J -O -T >> $ps

--- a/test/pscoast/oblsuite_N.sh
+++ b/test/pscoast/oblsuite_N.sh
@@ -22,7 +22,7 @@ gmt pstext -R0/8/0/10 -Jx1i -F+f14p+jRM -O -K -X-3.45i -N << EOF >> $ps
 -0.1 7.5 az: -140
 -0.1 9.2 az: -180
 EOF
-gmt pstext -R0/8/0/10 -Jx1i -F+f14p+jLM -O -K -N << EOF >> $ps
+gmt pstext -R0/8/0/10 -Jx1i -F+f14p+jLM -O -N << EOF >> $ps
 6.2 0.7 az: 150
 6.2 2.4 az: 120
 6.2 4.1 az: 90
@@ -30,4 +30,3 @@ gmt pstext -R0/8/0/10 -Jx1i -F+f14p+jLM -O -K -N << EOF >> $ps
 6.2 7.5 az: 30
 6.2 9.2 az: 0
 EOF
-gmt psxy -R -J -O -T >> $ps

--- a/test/pscoast/pscoast_JE2.sh
+++ b/test/pscoast/pscoast_JE2.sh
@@ -9,6 +9,4 @@ gmt pscoast -Dl -R -J -A1000 -G220 -W0.25p -N1 -B0 -O -K -X3.5i >> $ps
 gmt pscoast -Dl -R -J -A1000 -Slightblue -G220 -W0.25p -N1 -B0 -O -K -X-3.5 -Y-3.25i >> $ps
 gmt pscoast -Dl -R -J -A1000 -Slightblue -W0.25p -N1 -O -K -B0 -X3.5i >> $ps
 gmt pscoast -Dl -R99.811/-47.587/323.501/31.558r -JE195.470/19.970/3i -A1000 -Slightblue -W0.25p -N1 -B0 -O -K -X-3.5i -Y-3.25i >> $ps
-gmt pscoast -Dl -R -J -A1000 -Slightblue -G220 -W0.25p -N1 -B0 -O -K -X3.5i >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+gmt pscoast -Dl -R -J -A1000 -Slightblue -G220 -W0.25p -N1 -B0 -O -X3.5i >> $ps

--- a/test/pshistogram/distributions.sh
+++ b/test/pshistogram/distributions.sh
@@ -22,9 +22,8 @@ echo "0 1.5 log101p(percent)" | gmt pstext -R -J -O -K -Dj0.1i -F+jTR+f12p >> $p
 gmt pshistogram -Bxaf -Byafg100+u" %" -BWSne+glightblue @v3206_06.txt -R-6000/0/0/105 -JX3i/2.0i -Glightred -L1p -Z1 -Q -W200 -O -K -N0+p1p,red -N1+p1p,green -N2+p1p,blue -X-3.75i -Y2.5i >> $ps
 # R: Cumulative histogram staircase
 gmt pshistogram -Bxaf -Byafg100+u" %" -BWSne+glightblue @v3206_06.txt -R-6000/0/0/105 -JX3i/2.0i -S -L1p -Z1 -Q -W200 -O -K -N0+p1p,red -N1+p1p,green -N2+p1p,blue -X3.75i >> $ps
-gmt pslegend -Dg0/0+w1.2i+jBR+o0.1i/0.1i -R -J -O -K -F+p2p+gwhite << EOF >> $ps
+gmt pslegend -Dg0/0+w1.2i+jBR+o0.1i/0.1i -R -J -O -F+p2p+gwhite << EOF >> $ps
 S 0.3i - 0.45i - 1p,red 0.7i L@-2@-
 S 0.3i - 0.45i - 1p,green 0.7i L@-1@-
 S 0.3i - 0.45i - 1p,blue 0.7i LMS
 EOF
-gmt psxy -R -J -O -T >> $ps

--- a/test/pshistogram/labels.sh
+++ b/test/pshistogram/labels.sh
@@ -22,6 +22,4 @@ gmt pshistogram -R t.txt -L0.5p -Gred -B0 -O -J -W5 -F -D+f12p+r+b -K -X2.5i >> 
 gmt pshistogram -R t.txt -L0.5p -Gred -B0 -O -J -W5 -F -A -D+f12p -K -X-2.5i -Y-2.5i >> $ps
 gmt pshistogram -R t.txt -L0.5p -Gred -B0 -O -J -W5 -F -A -D+f12p+r -K -X2.5i >> $ps
 gmt pshistogram -R t.txt -L0.5p -Gred -B0 -O -J -W5 -F -A -D+f12p+b -K -X-2.5i -Y-2.25i >> $ps
-gmt pshistogram -R t.txt -L0.5p -Gred -B0 -O -J -W5 -F -A -D+f12p+r+b -K -X2.5i >> $ps
-
-gmt psxy -R -J -O -T >> $ps
+gmt pshistogram -R t.txt -L0.5p -Gred -B0 -O -J -W5 -F -A -D+f12p+r+b -X2.5i >> $ps

--- a/test/pshistogram/mmm.sh
+++ b/test/pshistogram/mmm.sh
@@ -28,11 +28,10 @@ gmt psxy -R -J -O -K -W2p tmp >> $ps
 gmt psbasemap -R -J -O -K -D-4600/-600/280/690 -F+glightgreen+p1p >> $ps
 gmt pshistogram $data -W50 -JX5.5i/3i -Bafg -BWSne -R-6100/-4500/0/700 -L0.25p -Gred -O -K -F -X3i -Y2.75i >> $ps
 gmt psxy -R -J -O -K -W2p tmp >> $ps
-gmt pstext -R -J -O -K -F+jCM+a90+f12p -Gwhite -W0.25p << EOF >> $ps
+gmt pstext -R -J -O -F+jCM+a90+f12p -Gwhite -W0.25p << EOF >> $ps
 $peak	600	peak
 $mode	600	mode
 $median	600	median
 $mean	600	mean
 EOF
-gmt psxy -R -J -O -T >> $ps
 rm -f tmp

--- a/test/pslegend/fancy.sh
+++ b/test/pslegend/fancy.sh
@@ -31,6 +31,4 @@ gmt pslegend -R -J -O -K -Dx6.25i/7.25i+w2.75i+jTR+l1.2 -C0.1i/0.1i -F+p2p+gwhit
 gmt pslegend -R -J -O -K -Dx0.25i/4.75i+w2.75i+jTL+l1.2 -C0.1i/0.1i -F+p2p,blue+gwhite+i0.5p,blue tt.txt >> $ps
 gmt pslegend -R -J -O -K -Dx6.25i/4.75i+w2.75i+jTR+l1.2 -C0.1i/0.1i -F+p2p,blue+gwhite+i0.5p,blue+s5p/-3p/navy tt.txt >> $ps
 gmt pslegend -R -J -O -K -Dx0.25i/2.25i+w2.75i+jTL+l1.2 -C0.1i/0.1i -F+i2p,blue+gwhite+p0.5p,blue tt.txt >> $ps
-gmt pslegend -R -J -O -K -Dx6.25i/2.25i+w2.75i+jTR+l1.2 -C0.1i/0.1i -F+gcornsilk+i2p+p0.5p+s-5p/-3p/orange+r tt.txt >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+gmt pslegend -R -J -O -Dx6.25i/2.25i+w2.75i+jTR+l1.2 -C0.1i/0.1i -F+gcornsilk+i2p+p0.5p+s-5p/-3p/orange+r tt.txt >> $ps

--- a/test/pslegend/fill_frame.sh
+++ b/test/pslegend/fill_frame.sh
@@ -14,8 +14,7 @@ gmt pslegend -R -J -O -K -Dx1c/15c+w8c+jTL -F+p+g$color >> $ps <<%
 P
 T This text wraps to the next line. It uses all standard paragraph modes. But what if you want to use left alignment?
 %
-gmt pslegend -R -J -O -K -Dx1c/12c+w8c+jTL -F+p+g$color >> $ps <<%
+gmt pslegend -R -J -O -Dx1c/12c+w8c+jTL -F+p+g$color >> $ps <<%
 P - - - - - - - l
 T Same trying to do left alignment. That seems to work nicely but needs 8 parameters on P line.
 %
-gmt psxy -R -J -O -T >> $ps

--- a/test/pssac/pssac_C.sh
+++ b/test/pssac/pssac_C.sh
@@ -6,5 +6,4 @@ ps=pssac_C.ps
 gmt pssac ntkl.z onkl.z -JX15c/4c -R200/1600/22/27 -Bx100 -By1 -BWSen -Ed -M1.5c -K -P > $ps
 gmt pssac ntkl.z onkl.z -J -R200/1600/22/27 -Bx100 -By1 -BWSen -Ed -M1.5c -K -O -C500/1100 -Y6c >> $ps
 gmt pssac ntkl.z onkl.z -J -R-300/1100/22/27 -Bx100 -By1 -BWSen -Ed -M1.5c -K -O -T+t1 -Y6c >> $ps
-gmt pssac ntkl.z onkl.z -J -R-300/1100/22/27 -Bx100 -By1 -BWSen -Ed -M1.5c -K -O -T+t1 -C-100/500 -Y6c >> $ps
-gmt psxy -J -R -O -T >> $ps
+gmt pssac ntkl.z onkl.z -J -R-300/1100/22/27 -Bx100 -By1 -BWSen -Ed -M1.5c -O -T+t1 -C-100/500 -Y6c >> $ps

--- a/test/pssac/pssac_E.sh
+++ b/test/pssac/pssac_E.sh
@@ -19,5 +19,4 @@ gmt pssac $SACFILEs -R200/1600/1500/5000 -J -Bx200 -By1000+lkm -BWsen -W1p,blue 
 # -Ed
 gmt pssac $SACFILEs -R200/1600/15/40 -J -Bx200 -By5+lDegree -BWsen -W1p,blue -Ed -M1.5c -K -O -Y6c >> $ps
 # -Eu0: ray parameter in s/radian
-gmt pssac $SACFILEs -R200/1600/420/750 -J -Bx200 -By50+lRayPar -BWsen -W1p,blue -Eu0 -M1.5c -K -O -Y6c >> $ps
-gmt psxy -J -R -O -T >> $ps
+gmt pssac $SACFILEs -R200/1600/420/750 -J -Bx200 -By50+lRayPar -BWsen -W1p,blue -Eu0 -M1.5c -O -Y6c >> $ps

--- a/test/pssac/pssac_F.sh
+++ b/test/pssac/pssac_F.sh
@@ -7,6 +7,4 @@ ps=pssac_F.ps
 gmt pssac seis.sac -R9/20/-2/2 -JX15c/5c -Bx1 -By1+l'-Fr' -BWSen -W1p,black -Fr -K -P > $ps
 gmt pssac seis.sac -R9/20/-0.06/0.06 -J -Bx1 -By0.02+l'-Fri' -BWsen -W1p,black -Fri -Y6c -K -O >> $ps
 gmt pssac seis.sac -R9/20/-8e-3/8e-3 -J -Bx1 -By4e-3+l'-Friri' -BWsen -W1p,black -Friri -Y6c -K -O >> $ps
-gmt pssac seis.sac -R9/20/-0.1/3 -J -Bx1 -By1+l'-Frq' -BWsen -W1p,black -Frq -Y6c -K -O >> $ps
-
-gmt psxy -R -J -O -T >> $ps
+gmt pssac seis.sac -R9/20/-0.1/3 -J -Bx1 -By1+l'-Frq' -BWsen -W1p,black -Frq -Y6c -O >> $ps

--- a/test/pssac/pssac_G.sh
+++ b/test/pssac/pssac_G.sh
@@ -21,6 +21,4 @@ gmt pssac seis.sac -R -J -B$B -BWsen -K -O -Y6c -G+gblue+z-0.2 >> $ps
 gmt pssac seis.sac -R -J -B$B -BWsen -K -O -Y6c -Gn+gred+z0.2 >> $ps
 gmt pssac seis.sac -R -J -B$B -BWsen -K -O -Y6c -Gp+z0.2+t10/13+gblue -Gn+z-0.2+t12/18+gred >> $ps
 gmt pssac seis.sac -R -J -B$B -BWsen -K -O -Y6c -Gp+z-0.2+t10/13+gblue -Gn+z0.2+t12/18+gred >> $ps
-gmt pssac seis.sac -J -R10.2/15/-1.6/1.6 -B$B -BWSen -K -O -Y6c -Gn+gred >> $ps
-
-gmt psxy -R -J -O -T >> $ps
+gmt pssac seis.sac -J -R10.2/15/-1.6/1.6 -B$B -BWSen -O -Y6c -Gn+gred >> $ps

--- a/test/pssac/pssac_M.sh
+++ b/test/pssac/pssac_M.sh
@@ -14,6 +14,4 @@ gmt pssac $SACFILEs -J$J -R$R -B$Bx -B$By -BWSen -Ed -M1.5c -K -P > $ps
 gmt pssac $SACFILEs -J -R -B$Bx -B$By -BWsen -Ed -M0.8i -K -O -Y5c >> $ps
 gmt pssac $SACFILEs -J -R -B$Bx -B$By -BWsen -Ed -M1.5c/-1 -K -O -Y5c >> $ps
 gmt pssac $SACFILEs -J -R -B$Bx -B$By -BWsen -Ed -M0.2/0 -K -O -Y5c >> $ps
-gmt pssac $SACFILEs -J -R -B$Bx -B$By -BWsen -Ed -M0.002/0.5 -K -O -Y5c >> $ps
-
-gmt psxy -J -R -O -T >> $ps
+gmt pssac $SACFILEs -J -R -B$Bx -B$By -BWsen -Ed -M0.002/0.5 -O -Y5c >> $ps

--- a/test/pssac/pssac_Q.sh
+++ b/test/pssac/pssac_Q.sh
@@ -6,7 +6,5 @@ ps=pssac_Q.ps
 
 gmt pssac seis.sac -JX10c/5c -R9/20/-2/2 -Bx2 -By1 -BWSen -K -P \
     -Fr -Gp+gblack -Gn+gblue -W > $ps
-gmt pssac seis.sac -JX5c/-10c -R-2/2/9/20 -Bx1 -By2 -BWSen -K -O \
+gmt pssac seis.sac -JX5c/-10c -R-2/2/9/20 -Bx1 -By2 -BWSen -O \
     -Fr -Gp+gblack -Gn+gblue -W -Q -X12c >> $ps
-
-gmt psxy -J -R -T -O >> $ps

--- a/test/pssac/pssac_T.sh
+++ b/test/pssac/pssac_T.sh
@@ -11,6 +11,4 @@ gmt pssac $SACFILEs -J -R0/1400/22/27 -Bx100 -By1 -BWSen -Ed -M1.5c -K -O -Y6c -
 gmt pssac $SACFILEs -J -R-500/500/22/27 -Bx100 -By1 -BWSen -Ed -M1.5c -K -O -Y6c -T+t1 -G+t0/100 -W >> $ps
 gmt pssac $SACFILEs -J -R0/1400/22/27 -Bx100 -By1 -BWSen -Ed -M1.5c -K -O -Y6c -T+r10 -G+t300/400 -W >> $ps
 gmt pssac $SACFILEs -J -R200/1600/22/27 -Bx100 -By1 -BWSen -Ed -M1.5c -K -O -Y6c -T+s300 -G+t1000/1300 -W >> $ps
-gmt pssac $SACFILEs -J -R-300/800/22/27 -Bx100 -By1 -BWSen -Ed -M1.5c -K -O -Y6c -T+t1+s100 >> $ps
-
-gmt psxy -J -R -O -T >> $ps
+gmt pssac $SACFILEs -J -R-300/800/22/27 -Bx100 -By1 -BWSen -Ed -M1.5c -O -Y6c -T+t1+s100 >> $ps

--- a/test/pssac/pssac_W.sh
+++ b/test/pssac/pssac_W.sh
@@ -11,5 +11,4 @@ gmt pssac seis.sac -R$R -J$J -B$B -BWSen -W2p,red,- -K -P > $ps
 gmt pssac seis.sac -R -J -B$B -BWsen -W1p -K -O -Y4c >> $ps
 gmt pssac seis.sac -R -J -B$B -BWsen -Wblue -K -O -Y4c >> $ps
 gmt pssac seis.sac -R -J -B$B -BWsen -W. -K -O -Y4c >> $ps
-gmt pssac seis.sac -R -J -B$B -BWsen -K -O -Y4c >> $ps
-gmt psxy -R -J -T -O >> $ps
+gmt pssac seis.sac -R -J -B$B -BWsen -O -Y4c >> $ps

--- a/test/pssac/pssac_common-options.sh
+++ b/test/pssac/pssac_common-options.sh
@@ -12,5 +12,4 @@ gmt set PS_MEDIA 21cx35c
 gmt pssac seis.sac -J$J -R$R -B$Bx -B$By -B+t"Option -P for portrait mode" -K -P > $ps
 gmt pssac seis.sac -J$J -R$R -B$Bx -B$By -B+t"Option -X and -Y" -Y8c -Xa1c -K -O >> $ps
 gmt pssac seis.sac -J$J -R$R -B$Bx -B$By -B+t"Option -t" -Y8c -K -O -t100 >> $ps
-gmt pssac seis.sac -J$J -R$R -B$Bx -B$By -B+t"Option -p" -Y8c -K -O -p170/30 >> $ps
-gmt psxy -J -R -T -O >> $ps
+gmt pssac seis.sac -J$J -R$R -B$Bx -B$By -B+t"Option -p" -Y8c -O -p170/30 >> $ps

--- a/test/pssac/pssac_geo.sh
+++ b/test/pssac/pssac_geo.sh
@@ -24,6 +24,4 @@ gmt psxy station.list -J -R -St0.4c -Gblack -i1,2 -K -O >> $ps
 
 # upper right
 gmt pssac station.list -J -R -BWSen -B$Bx -B$By -M0.5i -Si0.0025c -Q -G+gblue -W -K -O -X13c >> $ps
-gmt psxy station.list -J -R -St0.4c -Gblack -i1,2 -K -O >> $ps
-
-gmt psxy -J -R -T -O >> $ps
+gmt psxy station.list -J -R -St0.4c -Gblack -i1,2 -O >> $ps

--- a/test/pssac/pssac_stdin.sh
+++ b/test/pssac/pssac_stdin.sh
@@ -18,11 +18,10 @@ nykl.z 300 20 0p,blue
 onkl.z 400 30 2.2p,yellow
 sdkl.z 500 35 2.2p
 EOF
-gmt pssac -J -R -B$Bx -B$By -BWsen -Ed -M0.8i -K -O -Y7c -h1 >> $ps << EOF
+gmt pssac -J -R -B$Bx -B$By -BWsen -Ed -M0.8i -O -Y7c -h1 >> $ps << EOF
 name    X  Y   pen
 ntkl.z 195 16 2p,red
 nykl.z 300 20 0p,blue
 onkl.z 400 30 2.2p,yellow
 sdkl.z 500 35 2.2p
 EOF
-gmt psxy -J -R -O -T >> $ps

--- a/test/psscale/cptmix.sh
+++ b/test/psscale/cptmix.sh
@@ -25,5 +25,4 @@ gmt psscale -R -J -O -K -Cex16_v10.cpt >> $ps -DJLM+w8.5c/0.618c+e+n -Ba+l"v10" 
 gmt psscale -R -J -O -K -Cex16_v11.cpt >> $ps -DJLM+w8.5c/0.618c+e+n -Ba+l"v11" -X5c
 gmt psscale -R -J -O -K -Cex16_v9.cpt  >> $ps -DJLM+w8.5c/0.618c+e+n -I -Ba+l"v9" -X-10c -Y12c
 gmt psscale -R -J -O -K -Cex16_v10.cpt >> $ps -DJLM+w8.5c/0.618c+e+n -I -Ba+l"v10" -X5c
-gmt psscale -R -J -O -K -Cex16_v11.cpt >> $ps -DJLM+w8.5c/0.618c+e+n -I -Ba+l"v11" -X5c
-gmt psxy -R -J -T -O >> $ps
+gmt psscale -R -J -O -Cex16_v11.cpt >> $ps -DJLM+w8.5c/0.618c+e+n -I -Ba+l"v11" -X5c

--- a/test/psscale/scalings.sh
+++ b/test/psscale/scalings.sh
@@ -34,6 +34,4 @@ gmt psscale -J -R -Cseis -DjBC+w3c/0.5c+m -Ba -K -O >> $ps
 
 gmt psscale -J -R -Cseis -DjTR+w3c/0.5c+m -Ba -K -O >> $ps
 gmt psscale -J -R -Cseis -DjMR+w3c/0.5c+m -Ba -K -O >> $ps
-gmt psscale -J -R -Cseis -DjBR+w3c/0.5c+m -Ba -K -O >> $ps
-
-gmt psxy -J -R -T -O >> $ps
+gmt psscale -J -R -Cseis -DjBR+w3c/0.5c+m -Ba -O >> $ps

--- a/test/pstext/labeler.sh
+++ b/test/pstext/labeler.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Test pstext options for accepting or modifiying text using a format
+# Test pstext options for accepting or modifying text using a format
 ps=labeler.ps
 echo 3 2.5 > t.txt
 gmt convert points.txt -o0,1 > p.txt
 gmt psxy -R0/7/-0.5/6.5 -JX6i -P -Baf -Sc0.25i -Gred -Wfaint points.txt -K > $ps
 gmt pstext -R -J -O -K -F+r+f10p,Helvetica-Bold,white p.txt >> $ps
 gmt pstext -R -J -O -K -F+z"z = %.1f@."+f9p,Times-Italic+jTC -Dj0/0.2i points.txt >> $ps
-gmt pstext -R -J -O -K -F+f24p,Courier-Bold+t"Some text label" t.txt >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt pstext -R -J -O -F+f24p,Courier-Bold+t"Some text label" t.txt >> $ps

--- a/test/psxy/arrows.sh
+++ b/test/psxy/arrows.sh
@@ -39,5 +39,4 @@ echo 0 2.8 0 3i | gmt psxy -R -J -O -K -Sv1i+bA+jc+h0.5 -W6p -Gred --PS_LINE_CAP
 echo 0 2.2 0 3i | gmt psxy -R -J -O -K -Sv1i+eA+bI+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round >> $ps
 echo 0 1.6 0 3i | gmt psxy -R -J -O -K -Sv1i+bA+eI+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round >> $ps
 echo 0 1.0 0 3i | gmt psxy -R -J -O -K -Sv1i+bI+eI+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round >> $ps
-echo 0 0.4 0 3i | gmt psxy -R -J -O -K -Sv1i+bA+eA+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo 0 0.4 0 3i | gmt psxy -R -J -O -Sv1i+bA+eA+jc+h0.5 -W6p -Gred --PS_LINE_CAP=round >> $ps

--- a/test/psxy/clip_ellipse.sh
+++ b/test/psxy/clip_ellipse.sh
@@ -16,6 +16,5 @@ gmt psxy ellipse.d -O -K -JR0/3i -Rg -Bg180 -Wthin -SE -Gred -X3.5i >> $ps
 gmt psxy ellipse.d -O -K -JKf0/3i -Rg -Bg180 -Wthin -SE -Gred -X-3.5i -Y2i >> $ps
 gmt psxy ellipse.d -O -K -JKs0/3i -Rg -Bg180 -Wthin -SE -Gred -X3.5i >> $ps
 gmt psxy ellipse.d -O -K -JV0/2i -Rg -Bg180 -Wthin -SE -Gred -X-3i -Y1.8i >> $ps
-gmt psxy ellipse.d -O -K -JY0/45/3i -Rg -Bg180 -Wthin -SE -Gred -X3i >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psxy ellipse.d -O -JY0/45/3i -Rg -Bg180 -Wthin -SE -Gred -X3i >> $ps
 

--- a/test/psxy/clipping5.sh
+++ b/test/psxy/clipping5.sh
@@ -57,5 +57,4 @@ cat << EOF > v.txt
 -0.9	-0.9	-3	160
 EOF
 gmt psxy -R-1/1/-1/1 -JM2.75i -O -K -Baf -BwSnE -S=0.5i+e -Gcyan -W5p,brown v.txt -X3.25i >> $ps
-echo "-0.8 0.8 B" | gmt pstext -R -J -O -K -F+jCM+f18p >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo "-0.8 0.8 B" | gmt pstext -R -J -O -F+jCM+f18p >> $ps

--- a/test/psxy/clipping8.sh
+++ b/test/psxy/clipping8.sh
@@ -56,5 +56,4 @@ gmt psxy -R-70/130/-15/+15 -Jm${scl}i -Gred badpol.txt -Baf -BWSne -A -O -K -X${
 gmt psxy -R-60/140/-15/+15 -Jm${scl}i -Gred badpol.txt -Baf -BWSne -A -O -K -X${x}i -Y0.95i >> $ps
 gmt psxy -R-50/150/-15/+15 -Jm${scl}i -Gred badpol.txt -Baf -BWSne -A -O -K -X${x}i -Y0.95i >> $ps
 gmt psxy -R-40/160/-15/+15 -Jm${scl}i -Gred badpol.txt -Baf -BWSne -A -O -K -X${x}i -Y0.95i >> $ps
-gmt psxy -R-30/170/-15/+15 -Jm${scl}i -Gred badpol.txt -Baf -BWSne -A -O -K -X${x}i -Y0.95i >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psxy -R-30/170/-15/+15 -Jm${scl}i -Gred badpol.txt -Baf -BWSne -A -O -X${x}i -Y0.95i >> $ps

--- a/test/psxy/filler.sh
+++ b/test/psxy/filler.sh
@@ -13,5 +13,4 @@ gmt psxy -R -J -O -K -B0 t.txt -Gred -W2p -L+yt -X3.5i >> $ps
 gmt psxy -R -J -O -K -B0 t.txt -Ggreen -W2p -L+xl -X-3.5i -Y3.2i >> $ps
 gmt psxy -R -J -O -K -B0 t.txt -Ggreen -W2p -L+xr -X3.5i >> $ps
 gmt psxy -R -J -O -K -B0 t.txt -Gorange -W2p -L+y4 -X-3.5i -Y3.2i >> $ps
-gmt psxy -R -J -O -K -B0 t.txt -Gorange -W0.5p,white -L+x4.5+p2p -X3.5i >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psxy -R -J -O -B0 t.txt -Gorange -W0.5p,white -L+x4.5+p2p -X3.5i >> $ps

--- a/test/psxy/front.sh
+++ b/test/psxy/front.sh
@@ -41,6 +41,4 @@ gmt psxy -R -J -O -K -W1p -Gyellow -Sf-1/0.1i+b+l -X0.5i t.txt >> $ps
 gmt psxy -R -J -O -K -W1p -Gyellow -Sf-1/0.1i+c+l -X0.5i t.txt >> $ps
 gmt psxy -R -J -O -K -W1p -Gyellow -Sf-1/0.1i+f+l -X0.5i t.txt >> $ps
 gmt psxy -R -J -O -K -W1p -Gyellow -Sf-1/0.4i+s+l -X0.5i t.txt >> $ps
-gmt psxy -R -J -O -K -W1p -Gyellow -Sf-1/0.1i+t+l -X0.5i t.txt >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+gmt psxy -R -J -O -W1p -Gyellow -Sf-1/0.1i+t+l -X0.5i t.txt >> $ps

--- a/test/psxy/line_geo.sh
+++ b/test/psxy/line_geo.sh
@@ -16,6 +16,5 @@ awk '{printf "@~a@~ = %s@.\n", $3}' q4.txt | gmt pstext -R -J -O -K -F+f10p+cBL 
 gmt psxy -R -J -Skgeo-lineation/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q1.txt -K -X9c >> $ps
 awk '{printf "@~a@~ = %s@.\n", $3}' q1.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -Skgeo-lineation/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q2.txt -K -Y-10c >> $ps
-awk '{printf "@~a@~ = %s@.\n", $3}' q2.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
-gmt psxy -R -J -O -T >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q2.txt | gmt pstext -R -J -O -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 rm -f geo-lineation.def

--- a/test/psxy/linearrow.sh
+++ b/test/psxy/linearrow.sh
@@ -43,5 +43,4 @@ gmt math -T0/50/1 T -C0 35 ADD = | gmt psxy -R -J -O -K -W2p+o0/10+ve0.3i+p1.5p,
 gmt math -T0/50/1 T -C0 40 ADD = | gmt psxy -R -J -O -K -Wfaint,red >> $ps
 gmt math -T0/50/1 T -C0 40 ADD = | gmt psxy -R -J -O -K -W2p+o1i/0+v0.3i+p0.25p,blue+gcyan+h1 >> $ps
 gmt math -T0/50/1 T -C0 45 ADD = | gmt psxy -R -J -O -K -Wfaint,red >> $ps
-gmt math -T0/50/1 T -C0 45 ADD = | gmt psxy -R -J -O -K -W2p+o0/1i+vb0.3i+gblack+h0.5 >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt math -T0/50/1 T -C0 45 ADD = | gmt psxy -R -J -O -W2p+o0/1i+vb0.3i+gblack+h0.5 >> $ps

--- a/test/psxy/linetrim.sh
+++ b/test/psxy/linetrim.sh
@@ -43,5 +43,4 @@ gmt math -T0/50/1 T -C0 35 ADD = | gmt psxy -R -J -O -K -W2p+o0/10 >> $ps
 gmt math -T0/50/1 T -C0 40 ADD = | gmt psxy -R -J -O -K -Wfaint,red >> $ps
 gmt math -T0/50/1 T -C0 40 ADD = | gmt psxy -R -J -O -K -W2p+o1i/0 >> $ps
 gmt math -T0/50/1 T -C0 45 ADD = | gmt psxy -R -J -O -K -W2p+o0/1i >> $ps
-gmt math -T0/50/1 T -C0 45 ADD = | gmt psxy -R -J -O -K -Wfaint,red >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt math -T0/50/1 T -C0 45 ADD = | gmt psxy -R -J -O -Wfaint,red >> $ps

--- a/test/psxy/matharc.sh
+++ b/test/psxy/matharc.sh
@@ -35,7 +35,7 @@ gmt psxy -R -J -O -K -W1p -S << EOF >> $ps
 EOF
 # Normalized by angle below
 gmt psbasemap -R0/4/0/4 -J -O -B1g1 -BWSne -K -X1i -Y4i >> $ps
-gmt psxy -R -J -O -K -W1p -Gblack -Sm0.3i+b+e+n90 << EOF >> $ps
+gmt psxy -R -J -O -W1p -Gblack -Sm0.3i+b+e+n90 << EOF >> $ps
 0	0	4.0i	0	90
 0	0	3.6i	0	80
 0	0	3.2i	0	70
@@ -49,5 +49,3 @@ gmt psxy -R -J -O -K -W1p -Gblack -Sm0.3i+b+e+n90 << EOF >> $ps
 0	0	1.0i	0	15
 0	0	0.8i	0	10
 EOF
-gmt psxy -R -J -O -T >> $ps
-

--- a/test/psxy/matharcvar.sh
+++ b/test/psxy/matharcvar.sh
@@ -25,6 +25,4 @@ awk '{printf "@~a@~ = %s-%s\n", $3, $4}' q4.txt | gmt pstext -R -J -O -K -F+f10p
 gmt psxy -R -J -Skmatharc-const/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q1.txt -K -X9c >> $ps
 awk '{printf "@~a@~ = %s\n", $3}' q1.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -Skmatharc-one/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q2.txt -K -Y-10c >> $ps
-awk '{printf "@~a@~ = %s\n", $3}' q2.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+awk '{printf "@~a@~ = %s\n", $3}' q2.txt | gmt pstext -R -J -O -F+f10p+cBL -Gwhite -Dj0.2c >> $ps

--- a/test/psxy/plane_cart.sh
+++ b/test/psxy/plane_cart.sh
@@ -13,5 +13,4 @@ awk '{printf "@~a@~ = %s@.\n", $3}' q4.txt | gmt pstext -R -J -O -K -F+f10p+cBL 
 gmt psxy -R -J -Sk${src:-.}/plane_c/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q1.txt -K -X9c >> $ps
 awk '{printf "@~a@~ = %s@.\n", $3}' q1.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -Sk${src:-.}/plane_c/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q2.txt -K -Y-10c >> $ps
-awk '{printf "@~a@~ = %s@.\n", $3}' q2.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
-gmt psxy -R -J -O -T >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q2.txt | gmt pstext -R -J -O -F+f10p+cBL -Gwhite -Dj0.2c >> $ps

--- a/test/psxy/plane_geo.sh
+++ b/test/psxy/plane_geo.sh
@@ -13,5 +13,4 @@ awk '{printf "@~a@~ = %s@.\n", $3}' q4.txt | gmt pstext -R -J -O -K -F+f10p+cBL 
 gmt psxy -R -J -Sk${src:-.}/plane_c/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q1.txt -K -X9c >> $ps
 awk '{printf "@~a@~ = %s@.\n", $3}' q1.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
 gmt psxy -R -J -Sk${src:-.}/plane_c/5c -O -N -W2p,red -Gred -Bag0.5 -BWSne q2.txt -K -Y-10c >> $ps
-awk '{printf "@~a@~ = %s@.\n", $3}' q2.txt | gmt pstext -R -J -O -K -F+f10p+cBL -Gwhite -Dj0.2c >> $ps
-gmt psxy -R -J -O -T >> $ps
+awk '{printf "@~a@~ = %s@.\n", $3}' q2.txt | gmt pstext -R -J -O -F+f10p+cBL -Gwhite -Dj0.2c >> $ps

--- a/test/psxy/plot_errbars.sh
+++ b/test/psxy/plot_errbars.sh
@@ -16,4 +16,3 @@ gmt psxy -R0/6/0/6 -JX3i -P -B0 -Sc0.2i -Ctt.cpt -W0.25p -X1i -Y2i tt.d -Ex+p2p,
 gmt psxy -R -J -O -B0 -Sc0.2i -Ctt.cpt -W0.25p -X3.25i tt.d -Ey+cl+p1p -K >> $ps
 gmt psxy -R -J -O -B0 -Sc0.2i -Ctt.cpt -W5p+c -X-3.25i -Y3.5i tt.d -Ey+cf+p1p -K >> $ps
 gmt psxy -R -J -O -B0 -Sc0.2i -Ctt.cpt -W0.25p,red -X3.25i tt.d -Ex+cl+p1p >> $ps
-

--- a/test/psxy/scaling.sh
+++ b/test/psxy/scaling.sh
@@ -31,5 +31,4 @@ echo 0 2 150 | gmt psxy -R -J -O -K -Sci -i0,1,2+s0.01+o-0.5 -Gblack >> $ps
 # Simulate what we want with awk, first for cm
 echo 0 0 150 | awk '{print $1, $2, ($3-50)*0.01}' | gmt psxy -R -J -Baf -O -K -Scc -Gblack -X6c >> $ps
 # Simulate what we want with awk, for inch
-echo 0 2 150 | awk '{print $1, $2, ($3-50)*0.01}' | gmt psxy -R -J -O -K -Sci -Gblack >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo 0 2 150 | awk '{print $1, $2, ($3-50)*0.01}' | gmt psxy -R -J -O -Sci -Gblack >> $ps

--- a/test/psxy/spiders.sh
+++ b/test/psxy/spiders.sh
@@ -19,5 +19,4 @@ echo 0 0 30 100  | gmt psxy -R -J -O -K -SW4000k -Glightyellow -W2p >> $ps
 echo 0 0 -30 -100  | gmt psxy -R -J -O -K -SW3000n/1000n -Gblue -W2p >> $ps
 echo 50 -30 -50 -110  | gmt psxy -R -J -O -K -SW30d+a5d+p0.25p -W1p -Gcyan >> $ps
 echo -50 -30 50 110  | gmt psxy -R -J -O -K -SW30d+r30 -W1p -Gorange >> $ps
-echo -10 80 -60 240  | gmt psxy -R -J -O -K -SW20d/5d+a5d+r60 -W1p -Gyellow >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo -10 80 -60 240  | gmt psxy -R -J -O -SW20d/5d+a5d+r60 -W1p -Gyellow >> $ps

--- a/test/psxy/units.sh
+++ b/test/psxy/units.sh
@@ -10,5 +10,4 @@ echo "-2 -2 1" | gmt psxy -J -R -O -K -Sc -Ggray --PROJ_LENGTH_UNIT=cm >> $ps
 # Unit in data, PROJ_LENGTH_UNIT should be ignored
 echo "2 -2 1c" | gmt psxy -J -R -O -K -Sc -Ggray --PROJ_LENGTH_UNIT=inch >> $ps
 # No unit in data, but unit specified by -S; PROJ_LENGTH_UNIT from gmt.conf should be ignored
-echo "0 0 1" | gmt psxy -J -R -O -K -Sci -Gblack >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo "0 0 1" | gmt psxy -J -R -O -Sci -Gblack >> $ps

--- a/test/psxy/urlquakes.sh
+++ b/test/psxy/urlquakes.sh
@@ -12,5 +12,4 @@ URL="${SITE}?${TIME}&${MAG}&${ORDER}"
 gmt makecpt -Cred,green,blue -T0,70,300,10000 > q.cpt
 gmt pscoast -Rg -JN180/7i -Gbisque -Sazure1 -Baf -B+t"Earthquakes for January 2016 with M @~\263@~ 4.5" -Xc -K -P > $ps
 gmt psxy -R -J -O -K $URL -hi1 -Sci -Cq.cpt -i2,1,3,4+s0.01 >> $ps
-gmt psxy -R -J -O -K @ridge.txt -W0.5p >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psxy -R -J -O @ridge.txt -W0.5p >> $ps

--- a/test/psxy/varwedges.sh
+++ b/test/psxy/varwedges.sh
@@ -19,5 +19,4 @@ echo 0 0 30 100 | gmt psxy -R -J -O -K -SW4000k -Gred -W2p >> $ps
 echo 0 0 3000n -30 -100 | gmt psxy -R -J -O -K -SW -Gblue -W2p >> $ps
 echo 50 -30 | gmt psxy -R -J -O -K -SW30d/-50/-110+a+p2p -Gcyan >> $ps
 echo -50 -30 30d 50 110 | gmt psxy -R -J -O -K -SW+r+p2p -Gorange >> $ps
-echo -10 80 | gmt psxy -R -J -O -K -SW20d/-60/240 -W2p -Gyellow >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo -10 80 | gmt psxy -R -J -O -SW20d/-60/240 -W2p -Gyellow >> $ps

--- a/test/psxy/vectypes.sh
+++ b/test/psxy/vectypes.sh
@@ -29,5 +29,4 @@ echo 0	0	90	111.13 >> t.txt
 gmt psxy t.txt -JM6i -R-4/4/-2/2 -S=0.3i+e -W2p,green -Ggreen -O -K -Y-3.3i --PROJ_LENGTH_UNIT=inch >> $ps
 echo 0	60	0	111.13 > t.txt
 echo 0	60	90	111.13 >> t.txt
-gmt psxy t.txt -J -R-4/4/58/62 -S=0.3i+e -W2p,green -Ggreen -O -K -Y3.3i --PROJ_LENGTH_UNIT=inch >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psxy t.txt -J -R-4/4/58/62 -S=0.3i+e -W2p,green -Ggreen -O -Y3.3i --PROJ_LENGTH_UNIT=inch >> $ps

--- a/test/psxy/wedges.sh
+++ b/test/psxy/wedges.sh
@@ -19,5 +19,4 @@ echo 0 0 30 100  | gmt psxy -R -J -O -K -SW4000k -Gred -W2p >> $ps
 echo 0 0 -30 -100  | gmt psxy -R -J -O -K -SW3000n -Gblue -W2p >> $ps
 echo 50 -30 -50 -110  | gmt psxy -R -J -O -K -SW30d+a+p2p -Gcyan >> $ps
 echo -50 -30 50 110  | gmt psxy -R -J -O -K -SW30d+r+p2p -Gorange >> $ps
-echo -10 80 -60 240  | gmt psxy -R -J -O -K -SW20d -W2p -Gyellow >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo -10 80 -60 240  | gmt psxy -R -J -O -SW20d -W2p -Gyellow >> $ps

--- a/test/psxy/wrapping.sh
+++ b/test/psxy/wrapping.sh
@@ -21,6 +21,4 @@ gmt psxy -Rg -JA180/0/2i -Bg30 -Gred testpol.d -O -K -X4i -Y-0.25i >> $ps
 gmt psxy -R -J -W0.25p testpol.d -O -K >> $ps
 #
 gmt psxy -R-220/220/-90/90 -JX6.5/1.75i -B60g30 -BWSne -Gred testpol.d -O -K -X-4i -Y2.7i >> $ps
-gmt psxy -R -J -W0.25p testpol.d -O -K >> $ps
-gmt psxy -R -J -T -O >> $ps
-
+gmt psxy -R -J -W0.25p testpol.d -O >> $ps

--- a/test/psxyz/front.sh
+++ b/test/psxyz/front.sh
@@ -41,6 +41,4 @@ gmt psxyz -R -J -O -K -W1p -Gyellow -Sf-1/0.1i+b+l -X0.5i t.txt -p150/35 >> $ps
 gmt psxyz -R -J -O -K -W1p -Gyellow -Sf-1/0.1i+c+l -X0.5i t.txt -p150/35 >> $ps
 gmt psxyz -R -J -O -K -W1p -Gyellow -Sf-1/0.1i+f+l -X0.5i t.txt -p150/35 >> $ps
 gmt psxyz -R -J -O -K -W1p -Gyellow -Sf-1/0.1i+s+l -X0.5i t.txt -p150/35 >> $ps
-gmt psxyz -R -J -O -K -W1p -Gyellow -Sf-1/0.1i+t+l -X0.5i t.txt -p150/35 >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+gmt psxyz -R -J -O -W1p -Gyellow -Sf-1/0.1i+t+l -X0.5i t.txt -p150/35 >> $ps

--- a/test/psxyz/matharc.sh
+++ b/test/psxyz/matharc.sh
@@ -35,7 +35,7 @@ gmt psxyz -R -J -O -K -W1p -S -p155/35 << EOF >> $ps
 EOF
 # Normalized by angle below
 gmt psbasemap -R0/4/0/4 -J -O -B1g1 -BWSne -K -X1i -Y4i -p155/35 >> $ps
-gmt psxyz -R -J -O -K -W1p -Gblack -Sm0.3i+b+e+n90 << EOF -p155/35 >> $ps
+gmt psxyz -R -J -O -W1p -Gblack -Sm0.3i+b+e+n90 << EOF -p155/35 >> $ps
 0	0	0	4.0i	0	90
 0	0	0	3.6i	0	80
 0	0	0	3.2i	0	70
@@ -49,4 +49,3 @@ gmt psxyz -R -J -O -K -W1p -Gblack -Sm0.3i+b+e+n90 << EOF -p155/35 >> $ps
 0	0	0	1.0i	0	15
 0	0	0	0.8i	0	10
 EOF
-gmt psxy -R -J -O -T -p155/35 >> $ps

--- a/test/psxyz/varwedges.sh
+++ b/test/psxyz/varwedges.sh
@@ -12,5 +12,4 @@ echo 2.5 0.5  0 30 100 | gmt psxyz -R -J -O -K -p -Sw2i -Gred >> $ps
 echo 4.5 0.5  0 | gmt psxyz -R -J -O -K -p -Sw2i/30/100 -W1p >> $ps
 echo 0.5 1.75 0 30 100 | gmt psxyz -R -J -O -K -p -Sw2i+a+p2p >> $ps
 echo 2.5 1.75 0 | gmt psxyz -R -J -O -K -p -Sw2i/30/100+r+p2p >> $ps
-echo 4.5 1.75 0 | gmt psxyz -R -J -O -K -p -Sw2i/30/100+a+p2p -Gred >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo 4.5 1.75 0 | gmt psxyz -R -J -O -p -Sw2i/30/100+a+p2p -Gred >> $ps

--- a/test/psxyz/wedges.sh
+++ b/test/psxyz/wedges.sh
@@ -12,5 +12,4 @@ echo 2.5 0.5  0 30 100 | gmt psxyz -R -J -O -K -p -Sw2i -Gred >> $ps
 echo 4.5 0.5  0 30 100 | gmt psxyz -R -J -O -K -p -Sw2i -W1p >> $ps
 echo 0.5 1.75 0 30 100 | gmt psxyz -R -J -O -K -p -Sw2i+a+p2p >> $ps
 echo 2.5 1.75 0 30 100 | gmt psxyz -R -J -O -K -p -Sw2i+r+p2p >> $ps
-echo 4.5 1.75 0 30 100 | gmt psxyz -R -J -O -K -p -Sw2i+a+p2p -Gred >> $ps
-gmt psxy -R -J -O -T >> $ps
+echo 4.5 1.75 0 30 100 | gmt psxyz -R -J -O -p -Sw2i+a+p2p -Gred >> $ps

--- a/test/sample1d/cubic+Bezier.sh
+++ b/test/sample1d/cubic+Bezier.sh
@@ -20,5 +20,4 @@ gmt psxy -R -J -O -K t.txt -Sc0.1i -Gblue -Wthin >> $ps
 # Compare cubic sspline and Bezier
 gmt sample1d t.txt -S0/6 -I0.01 -Fc | gmt psxy -R-0.1/6.1/-0.1/3.1 -J -O -Bafg -BWsne -Wfaint,black -K -Y3.2i >> $ps
 gmt psxy -R -J -O -K t.txt -Wfaint,red+s >> $ps
-gmt psxy -R -J -O -K t.txt -Sc0.1i -Gblue -Wthin >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psxy -R -J -O t.txt -Sc0.1i -Gblue -Wthin >> $ps

--- a/test/sample1d/sample.sh
+++ b/test/sample1d/sample.sh
@@ -43,7 +43,7 @@ gmt sample1d track.txt -I10k -Ap | gmt psxy $RJ -O -K -W0.25p,orange,- >> $ps
 gmt project -C20/73 -E35/68 -G30 -Q > tmp.txt
 gmt psxy $RJ -O -K tmp.txt -Sc0.1c -Ggreen >> $ps
 gmt sample1d tmp.txt -I100k -AR | gmt psxy $RJ -O -K -Sc0.2c -Gblack >> $ps
-gmt pstext -R0/6/0/4 -Jx1i -O -K -F+jLB+f14p,Courier << EOF >> $ps
+gmt pstext -R0/6/0/4 -Jx1i -O -F+jLB+f14p,Courier << EOF >> $ps
 0.2 0.2 BLACK LINE:  psxy default
 0.2 0.4 RED LINE:    Loxodrome mode
 0.2 0.6 BLUE LINE:   -Am mode
@@ -52,4 +52,3 @@ gmt pstext -R0/6/0/4 -Jx1i -O -K -F+jLB+f14p,Courier << EOF >> $ps
 0.2 1.2 BLACK PTS:   -AR mode
 0.2 1.4 CYAN PTS:    -Ar mode
 EOF
-gmt psxy $RJ -O -T >> $ps

--- a/test/sample1d/splines.sh
+++ b/test/sample1d/splines.sh
@@ -39,10 +39,9 @@ EOF
 gmt sample1d t.txt -T0/6/0.01 -Fc+2 | gmt psxy -R-0.1/6.1/-31/31 -J -Bafg  -By+l"u''(x)" -BWsne -W1p -O -K -Y3.15i >> $ps
 gmt sample1d t.txt -T0/6/0.01 -Fl+2 | gmt psxy -R -J -W1p,blue -O -K >> $ps
 gmt sample1d t.txt -T0/6/0.01 -Fa+2 | gmt psxy -R -J -W1p,red -O -K >> $ps
-gmt pslegend -R -J -O -K -DjTL+w1.9i+o0.1i -F+p1p+gwhite+s << EOF >> $ps
+gmt pslegend -R -J -O -DjTL+w1.9i+o0.1i -F+p1p+gwhite+s << EOF >> $ps
 S 0.2i - 0.3i - 1p 	0.5i Cubic spline
 S 0.2i - 0.3i - 1p,red	0.5i Akima spline
 S 0.2i - 0.3i - 1p,blue	0.5i Linear spline
 S 0.2i - 0.3i - 1p,darkgreen 0.5i Nearest neighbor
 EOF
-gmt psxy -R -J -O -T >> $ps

--- a/test/seis/meca_input_columns.sh
+++ b/test/seis/meca_input_columns.sh
@@ -56,8 +56,6 @@ gmt psmeca -R -J -Ba0 -Sa1c -K -O -X5c -C1p >> $ps << EOF
 239.384 34.556 12.   180     18   -88  5 239.8 34.7 Long Title
 EOF
 
-gmt psmeca -R -J -Ba0 -Sm1c -K -O -X5c -C1p >> $ps << EOF
+gmt psmeca -R -J -Ba0 -Sm1c -O -X5c -C1p >> $ps << EOF
 239.384 34.556 12. 7.68 0.09 -7.77 1.39 4.52 -3.26 26 X Y 010176A
 EOF
-
-gmt psxy -R -J -T -O >> $ps

--- a/test/sph/sph_1.sh
+++ b/test/sph/sph_1.sh
@@ -13,6 +13,4 @@ gmt sphinterpolate ${mars370} -Rg -I1 -Qg -Gtt.nc
 gmt grdimage tt.nc -J -B30g30 -B+t"-Qg" -Ctt.cpt -X-5.1i -Y-5i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
 gmt sphinterpolate ${mars370} -Rg -I1 -Qs -Gtt.nc
 gmt grdimage tt.nc -J -B30g30 -B+t"-Qs" -Ctt.cpt -X5.1i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
-gmt psxy -Rg -J -O -K ${mars370} -Sc0.05i -G0 -B30g30 -X-2.55i -Y2.5i >> $ps
-gmt psxy -Rg -J -O -T >> $ps
-
+gmt psxy -Rg -J -O ${mars370} -Sc0.05i -G0 -B30g30 -X-2.55i -Y2.5i >> $ps

--- a/test/sph/sph_2.sh
+++ b/test/sph/sph_2.sh
@@ -12,6 +12,4 @@ gmt sphinterpolate lun2.txt -Rg -I1 -Qg -Gtt.nc
 gmt grdimage tt.nc -J -B30g30 -B+t"-Qg" -Ctt.cpt -X-5.1i -Y-5i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
 gmt sphinterpolate lun2.txt -Rg -I1 -Qs -Gtt.nc
 gmt grdimage tt.nc -J -B30g30 -B+t"-Qs" -Ctt.cpt -X5.1i -O -K  --MAP_TITLE_OFFSET=0i --FONT_TITLE=18p >> $ps
-gmt psxy -Rg -J -O -K lun2.txt -Sc0.02i -G0 -B30g30 -X-2.55i -Y2.5i >> $ps
-gmt psxy -Rg -J -O -T >> $ps
-
+gmt psxy -Rg -J -O lun2.txt -Sc0.02i -G0 -B30g30 -X-2.55i -Y2.5i >> $ps

--- a/test/sph/sph_3.sh
+++ b/test/sph/sph_3.sh
@@ -13,5 +13,4 @@ gmt sphdistance -Rg -I1 -Qtt.pol -Gtt.nc -Lk
 gmt grdcontour tt.nc -JG-140/30/7i -P -B30g30 -B+t"Distances from GSHHS crude" -K -C500 -A1000 \
 	-L500 -GL0/90/203/-10,175/60/170/-30,-50/30/220/-5 -X0.75i -Y2i > $ps
 gmt psxy -R -J -O -K tt.pol -W0.25p,red >> $ps
-gmt pscoast -R -J -O -K -W1p -Glightgray -A0/1/1 >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt pscoast -R -J -O -W1p -Glightgray -A0/1/1 >> $ps

--- a/test/sph/sph_4.sh
+++ b/test/sph/sph_4.sh
@@ -8,5 +8,4 @@ gmt sphtriangulate @hotspots.txt -Qd -T > tt.arcs
 # Make a basic contour plot and overlay voronoi polygons and coastlines
 gmt pscoast -Rg -JG-120/-30/7i -P -B30g30 -B+t"Delaunay triangles from hotspots" -Glightgray -K -X0.75i -Y2i > $ps
 gmt psxy -R -J -O -K tt.arcs -W1p >> $ps
-gmt psxy -R -J -O -K -W0.25p -SE-250 -Gred @hotspots.txt >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psxy -R -J -O -W0.25p -SE-250 -Gred @hotspots.txt >> $ps

--- a/test/spotter/spotter_04.sh
+++ b/test/spotter/spotter_04.sh
@@ -47,6 +47,4 @@ gmt psxy -R -J -O -K P.txt -W1p >> $ps
 gmt psxy -R -J -O -K R.txt -W1p >> $ps
 echo 0 53 | gmt psxy -R -J -O -K -Sc0.25i -Gred -N -W0.25p >> $ps
 echo 0 53 | gmt psxy -R -J -O -K -Sc0.1i -Gblack -N >> $ps
-echo 0 53 0.5i -90 -30 | gmt psxy -R -J -O -K -Sm0.15i+e -Gblack -N -W1p >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+echo 0 53 0.5i -90 -30 | gmt psxy -R -J -O -Sm0.15i+e -Gblack -N -W1p >> $ps

--- a/test/spotter/spotter_05.sh
+++ b/test/spotter/spotter_05.sh
@@ -16,5 +16,4 @@ gmt makecpt -Crainbow -T0/8000 > t.cpt
 gmt grdimage pac_dist.nc -Ct.cpt -J -O -K -Q -X4.75i >> $ps
 gmt pscoast -Rpac_vel.nc -J -O -K -Ggray -B30f10 -BwSne >> $ps
 echo "130 60 Dispacement since formation" | gmt pstext -R -J -O -K -C+t -Dj0.1i -F+jTL+f14p -Gwhite -W1p >> $ps
-gmt psscale -Ct.cpt -Dx2.25i/-0.4i+w3.5i/0.15i+h+jTC -O -K -Bx2000f1000 -By+lkm >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt psscale -Ct.cpt -Dx2.25i/-0.4i+w3.5i/0.15i+h+jTC -O -Bx2000f1000 -By+lkm >> $ps

--- a/test/spotter/spotter_07.sh
+++ b/test/spotter/spotter_07.sh
@@ -27,6 +27,4 @@ info=`gmt grdinfo -C -M cva_bathy.nc`
 x=`echo $info | cut -f14 -d' '`
 y=`echo $info | cut -f15 -d' '`
 echo $x $y | gmt psxy -R -J -O -K -Sx0.2i -W2p >> $ps
-gmt psscale -Ch.cpt -Dx3i/-0.4i+w4i/0.125i+h+jTC -O -K -Bxa20f10+u% -By+l"CVA" -I0.5 >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+gmt psscale -Ch.cpt -Dx3i/-0.4i+w4i/0.125i+h+jTC -O -Bxa20f10+u% -By+l"CVA" -I0.5 >> $ps

--- a/test/spotter/spotter_08.sh
+++ b/test/spotter/spotter_08.sh
@@ -28,5 +28,4 @@ gmt makecpt -Crainbow -T0/8 > t.cpt
 gmt psxy -R -J -O -K outline_*.txt -W1p -Cs.cpt -L >> $ps
 gmt grdimage -R -J -Q out_10.4.nc -Ct.cpt -O -K >> $ps
 gmt grdimage -R -J -Q out_58.6.nc -Ct.cpt -O -K >> $ps
-gmt grdimage -R -J -Q out_130.0.nc -Ct.cpt -O -K >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt grdimage -R -J -Q out_130.0.nc -Ct.cpt -O >> $ps

--- a/test/spotter/spotter_12.sh
+++ b/test/spotter/spotter_12.sh
@@ -45,5 +45,4 @@ gmt psxy -R -JM -O -K -ST0.1i -Gcyan -W0.5p suiko.txt >> $ps
 # Task 7: [OK]
 gmt backtracker loihi.txt -Df -Lb -ED2012x.txt | gmt psxy -R -J -O -K -W0.5p,- >> $ps
 # Task 8: [OK]
-gmt backtracker end_of_flow.txt -Db -Lf200 -ED2012x.txt | gmt psxy -R -J -O -K -W0.5p,. >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt backtracker end_of_flow.txt -Db -Lf200 -ED2012x.txt | gmt psxy -R -J -O -W0.5p,. >> $ps

--- a/test/surface/periodic.sh
+++ b/test/surface/periodic.sh
@@ -30,5 +30,4 @@ gmt psxy -R -J -O -K data.txt -Ss0.05i -Gred >> $ps
 gmt grdcontour t.nc -C10 -A50 -JQ0/5.5i $G -O -Baf -BWsne -K -Y2.85i >> $ps
 # Plot crossection along Equator
 gmt grdtrack path.txt -Gdatad.nc -o0,2 | gmt psxy -R-45/45/-70/70 -JX5.5i/1i -Y3i -Bafg90 -BWsne -W2p,green -O -K >> $ps
-gmt grdtrack path.txt -Rd -Gdatag.nc -o0,2 | gmt psxy -R-45/45/-70/70 -J -W0.5p,blue -O -K >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt grdtrack path.txt -Rd -Gdatag.nc -o0,2 | gmt psxy -R-45/45/-70/70 -J -W0.5p,blue -O >> $ps

--- a/test/surface/periodic_pix.sh
+++ b/test/surface/periodic_pix.sh
@@ -28,5 +28,4 @@ gmt psxy -R -J -O -K data.txt -Ss0.05i -Gred >> $ps
 gmt grdcontour t.nc -C10 -A50 -JQ0/5.5i -O -Baf -BWsne -K -Y2.85i >> $ps
 # Plot crossection along Equator
 gmt grdtrack path.txt -Gdatad.nc -o0,2 | gmt psxy -R-45/45/-70/70 -JX5.5i/1i -Y3i -Bafg90 -BWsne -W2p,green -O -K >> $ps
-gmt grdtrack path.txt -Rd -Gdatag.nc -o0,2 | gmt psxy -R-45/45/-70/70 -J -W0.5p,blue -O -K >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt grdtrack path.txt -Rd -Gdatag.nc -o0,2 | gmt psxy -R-45/45/-70/70 -J -W0.5p,blue -O >> $ps

--- a/test/time/time_testing_5.sh
+++ b/test/time/time_testing_5.sh
@@ -19,4 +19,3 @@ EOF
 gmt convert tt5.d -fi0t -fo0T --TIME_EPOCH=1969-07-21T02:56:00 --TIME_UNIT=d \
   | gmt psxy -R1969-07-18T/1969-07-28T/-0.1/1.1 -JX9T/6 -Bpxa7Rf1d -Bpy0.2 -Bsxa1O -Sc0.15 -Gred --FORMAT_DATE_MAP="-o yyyy" --FONT_ANNOT_PRIMARY=9p -K > $ps
 gmt psxy tt5.d -R -JX9t/6 --TIME_EPOCH=1969-07-21T02:56:00 -S+0.25 --TIME_UNIT=d --FORMAT_DATE_MAP="-o yyyy" --FONT_ANNOT_PRIMARY=9p -O >> $ps
-

--- a/test/trend2d/trend.sh
+++ b/test/trend2d/trend.sh
@@ -16,6 +16,4 @@ gmt psscale -Cr.cpt -Dx1.5i/-0.5i+w3i/0.1i+h+jTC -O -K -Ba >> $ps
 gmt pscontour -R trend.txt -Cz.cpt -J -Baf -B+tTrend -I -O -K -X-3.5i -Y-5i -i0,1,3 >> $ps
 gmt psscale -Cz.cpt -Dx1.5i/-0.5i+w3i/0.1i+h+jTC -O -K -Ba >> $ps
 gmt pscontour -R trend.txt -Cw.cpt -J -Baf -B+tWeights -I -O -K -X3.5i -i0,1,4 >> $ps
-gmt psscale -Cw.cpt -Dx1.5i/-0.5i+w3i/0.1i+h+jTC -O -K -Ba >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+gmt psscale -Cw.cpt -Dx1.5i/-0.5i+w3i/0.1i+h+jTC -O -Ba >> $ps

--- a/test/triangulate/trivor.sh
+++ b/test/triangulate/trivor.sh
@@ -20,6 +20,4 @@ EOF
 gmt triangulate nodes.xy -M | gmt psxy -R0/10/0/10 -JX6i -P -K -W0.25p,red > $ps
 gmt psxy -R -J -O -B2g1 -Sc0.2i -Gwhite -W0.25p nodes.xy -K >> $ps
 $AWK '{printf "%s %s %d\n", $1, $2, NR-1}' nodes.xy | gmt pstext -R -J -F+f8p -O -K >> $ps
-gmt triangulate nodes.xy -M -Q -R0/10/0/10 | gmt psxy -R0/10/0/10 -J -O -K -W1p >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+gmt triangulate nodes.xy -M -Q -R0/10/0/10 | gmt psxy -R0/10/0/10 -J -O -W1p >> $ps

--- a/test/x2sys/x2sys_02.sh
+++ b/test/x2sys/x2sys_02.sh
@@ -14,6 +14,5 @@ gmt psxy -R -J -O "${src:-.}"/data/*.xyg -Sc0.02i -Cfaa.cpt -K >> $ps
 # Grid the data
 cat "${src:-.}"/data/*.xyg | gmt blockmean -R$R -I1m | gmt surface -R$R -I1m -Gss_gridded.nc -T0.25
 gmt grdgradient ss_gridded.nc -Ne0.75 -A65 -fg -Gss_gridded_int.nc
-gmt grdimage ss_gridded.nc -Iss_gridded_int.nc -Ei -J -O -K -Y-4.5i -Cfaa.cpt -B1 -BWSne --MAP_FRAME_WIDTH=3p --FORMAT_GEO_MAP=dddF >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt grdimage ss_gridded.nc -Iss_gridded_int.nc -Ei -J -O -Y-4.5i -Cfaa.cpt -B1 -BWSne --MAP_FRAME_WIDTH=3p --FORMAT_GEO_MAP=dddF >> $ps
 

--- a/test/x2sys/x2sys_03.sh
+++ b/test/x2sys/x2sys_03.sh
@@ -13,6 +13,4 @@ gmt makecpt -Crainbow -T-80/80 > faa.cpt
 # Grid the data
 cat "${src:-.}"/bad/*.xyg | gmt blockmean -R$R -I1m | gmt surface -R$R -I1m -Gss_gridded_bad.nc -T0.25
 gmt grdgradient ss_gridded_bad.nc -Ne0.75 -A65 -fg -Gss_gridded_bad_int.nc
-gmt grdimage ss_gridded_bad.nc -Iss_gridded_bad_int.nc -Ei -JM5.5i -P -K -X1.75i -Y1.25i -Cfaa.cpt -B1 -BWSne --MAP_FRAME_WIDTH=3p --FORMAT_GEO_MAP=dddF >> $ps
-gmt psxy -R -J -O -T >> $ps
-
+gmt grdimage ss_gridded_bad.nc -Iss_gridded_bad_int.nc -Ei -JM5.5i -P -X1.75i -Y1.25i -Cfaa.cpt -B1 -BWSne --MAP_FRAME_WIDTH=3p --FORMAT_GEO_MAP=dddF > $ps

--- a/test/x2sys/x2sys_04.sh
+++ b/test/x2sys/x2sys_04.sh
@@ -33,8 +33,7 @@ gmt grdimage ss_gridded_fix1.nc -Iss_gridded_fix1_int.nc -Ei -JM5.5i -P -K -Cfaa
 gmt x2sys_report -TTEST -Cz COE_orig.txt -Lcorrections.txt -A > /dev/null
 gmt x2sys_datalist -TTEST -A -Lcorrections.txt =bad.lis -Flon,lat,z | gmt blockmean -R$R -I1m | gmt surface -R$R -I1m -Gss_gridded_fix2.nc -T0.25
 gmt grdgradient ss_gridded_fix2.nc -Ne0.75 -A65 -fg -Gss_gridded_fix2_int.nc
-gmt grdimage ss_gridded_fix2.nc -Iss_gridded_fix2_int.nc -Ei -JM5.5i -O -K -Cfaa.cpt -B1 -BWSne -Y-4.5i --MAP_FRAME_WIDTH=3p --FORMAT_GEO_MAP=dddF >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt grdimage ss_gridded_fix2.nc -Iss_gridded_fix2_int.nc -Ei -JM5.5i -O -Cfaa.cpt -B1 -BWSne -Y-4.5i --MAP_FRAME_WIDTH=3p --FORMAT_GEO_MAP=dddF >> $ps
 
 if [ ! "X$OLDX" = "X" ]; then	# Reset prior setting
 	export X2SYS_HOME=$OLDX

--- a/test/x2sys/x2sys_06.sh
+++ b/test/x2sys/x2sys_06.sh
@@ -15,5 +15,4 @@ gmt pscoast -R -J -O -Ggray -Baf -K -Df >> $ps
 gmt psxy -R -J @c2308.txt -W0.25p,cyan -O -K -i0,1 >> $ps
 gmt psxy c2308_faa_x.txt -R -J -K -O -Sc0.02c -Ggreen@50 >> $ps
 gmt psbasemap -R -J -O -K -DjTL+w2i+o0.6i/0.2i+t >> $ps
-gmt pshistogram xfaa.txt -W2 -R0/150/0/30 -JX2i -Gred -L0.25p -BWSne+glightblue -Byaf+u% -Bxaf+lmGal -O -K >> $ps
-gmt psxy -R -J -O -T >> $ps
+gmt pshistogram xfaa.txt -W2 -R0/150/0/30 -JX2i -Gred -L0.25p -BWSne+glightblue -Byaf+u% -Bxaf+lmGal -O >> $ps


### PR DESCRIPTION
This eliminates about one hundred pointless **psxy** calls.  I ran all the tests three times before and after the change and although there is scatter, looks like it shakes a few percent off the total run time.
