### PR TITLE
Set automatic outline with default pen for lines if no fill nor pen was specified

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -2027,10 +2027,6 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 			else
 				GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for selected feature. Option -l ignored.\n");
 		}
-		if (!polygon && !Ctrl->W.active) {	/* If not a polygon and no outline we force default outline */
-			gmt_setpen (GMT, &current_pen);
-			outline_active = 1;
-		}
 		if (Ctrl->W.cpt_effect && Ctrl->W.pen.cptmode & 2) polygon = true;
 		if (Ctrl->G.set_color) polygon = true;
 		for (tbl = 0; tbl < D->n_tables; tbl++) {

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -2027,6 +2027,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 			else
 				GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for selected feature. Option -l ignored.\n");
 		}
+
 		if (Ctrl->W.cpt_effect && Ctrl->W.pen.cptmode & 2) polygon = true;
 		if (Ctrl->G.set_color) polygon = true;
 		for (tbl = 0; tbl < D->n_tables; tbl++) {

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -2027,7 +2027,10 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 			else
 				GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for selected feature. Option -l ignored.\n");
 		}
-
+		if (!polygon && !Ctrl->W.active) {	/* If not a polygon and no outline we force default outline */
+			gmt_setpen (GMT, &current_pen);
+			outline_active = 1;
+		}
 		if (Ctrl->W.cpt_effect && Ctrl->W.pen.cptmode & 2) polygon = true;
 		if (Ctrl->G.set_color) polygon = true;
 		for (tbl = 0; tbl < D->n_tables; tbl++) {

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1705,6 +1705,10 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 			else
 				GMT_Report (API, GMT_MSG_WARNING, "Cannot use auto-legend -l for selected feature. Option -l ignored.\n");
 		}
+		if ((!Ctrl->G.active || !Ctrl->C.active || Zin) && !Ctrl->W.active) {	/* If not a polygon and no outline we force default outline */
+			gmt_setpen (GMT, &current_pen);
+			outline_active = 1;
+		}
 
 		for (tbl = 0; tbl < D->n_tables; tbl++) {
 			if (D->table[tbl]->n_headers && S.G.label_type == GMT_LABEL_IS_HEADER) gmt_extract_label (GMT, &D->table[tbl]->header[0][1], S.G.label, NULL);	/* Set first header as potential label */


### PR DESCRIPTION
**Description of proposed changes**

See #4295 for context.  As for plot, we need to set the default pen when lines are specified and no fill nor pen was set.  Closes #4295.