### PR TITLE
Improve CMake scripts if sphinx-build is not found

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -32,6 +32,7 @@ install (FILES
 	COMPONENT Runtime)
 
 # reST documentation
+find_package (Sphinx)
 add_subdirectory (rst)
 set (RST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/rst/source)
 set (RST_STATIC_DIR ${CMAKE_CURRENT_BINARY_DIR}/rst/_static)
@@ -41,15 +42,17 @@ add_subdirectory (fig)
 add_subdirectory (scripts)
 add_subdirectory (examples)
 
-# Optimize images for HTML documentation
-find_program (PNGQUANT pngquant)
-if (PNGQUANT)
-	add_custom_target (optimize_images
-		COMMAND ${PNGQUANT} --strip --force --ext .png ${RST_BINARY_DIR}/_images/*.png
-	)
-	add_dependencies (optimize_images docs_depends)
-	add_depend_to_target (gmt_release optimize_images)
-endif (PNGQUANT)
+if (SPHINX_FOUND)
+	# Optimize images for HTML documentation
+	find_program (PNGQUANT pngquant)
+	if (PNGQUANT)
+		add_custom_target (optimize_images
+			COMMAND ${PNGQUANT} --strip --force --ext .png ${RST_BINARY_DIR}/_images/*.png
+		)
+		add_dependencies (optimize_images docs_depends)
+		add_depend_to_target (gmt_release optimize_images)
+	endif (PNGQUANT)
+endif(SPHINX_FOUND)
 
 
 # Install target for examples

--- a/doc/examples/CMakeLists.txt
+++ b/doc/examples/CMakeLists.txt
@@ -15,85 +15,87 @@
 # Contact info: www.generic-mapping-tools.org
 #-------------------------------------------------------------------------------
 
-# Convert figures to PNG
-file (GLOB _examples RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*/*.ps")
-set (_examples_png)
-foreach (_ps ${_examples})
-	get_filename_component (_fig ${_ps} NAME)
-	string (REPLACE ".ps" ".png" _png_fig ${_fig})
-	list (APPEND _examples_png ${RST_BINARY_DIR}/_images/${_png_fig})
-	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
-		COMMAND ${CMAKE_COMMAND} -E env
-		GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
-		${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
-		-A -P -E150 -Tg -Qg4 -Qt4
-		-C-sFONTPATH="${GMT_SOURCE_DIR}/doc/examples/ex31/fonts"
-		-D${RST_BINARY_DIR}/_images
-		${CMAKE_CURRENT_SOURCE_DIR}/${_ps}
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-		DEPENDS gmt_for_img_convert ${CMAKE_CURRENT_SOURCE_DIR}/${_ps})
-endforeach (_ps ${_examples})
-
-# Convert scripts to verbatim
-file (GLOB _examples RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*/*.sh")
-set (_examples_txt)
-foreach (_script ${_examples})
-	get_filename_component (_txt ${_script} NAME)
-	string (REPLACE ".sh" ".txt" _txt ${_txt})
-	list (APPEND _examples_txt ${RST_BINARY_DIR}/_verbatim/${_txt})
-	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_verbatim/${_txt}
-		COMMAND ${GMT_BINARY_DIR}/src/script2verbatim
-		${CMAKE_CURRENT_SOURCE_DIR}/${_script}
-		${RST_BINARY_DIR}/_verbatim/${_txt}
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-		DEPENDS script2verbatim _docs_rst_mkdir_verbatim ${CMAKE_CURRENT_SOURCE_DIR}/${_script})
-endforeach (_script ${_examples})
-
-# Add build target
-add_custom_target (_docs_examples_verbatim DEPENDS ${_examples_txt})
-add_custom_target (_docs_html_examples_fig DEPENDS ${_examples_png})
-add_depend_to_target (docs_depends _docs_html_examples_fig _docs_examples_verbatim)
-
-# Animations
-if (UNIX AND DO_ANIMATIONS)
-	configure_file (animate.in animate @ONLY)
-
-	foreach (_num 01 02 03 04 05)
-		add_custom_command (
-			OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.gif
-			COMMAND ${BASH} animate anim${_num}/anim${_num}.sh
+if (SPHINX_FOUND)
+	# Convert figures to PNG
+	file (GLOB _examples RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*/*.ps")
+	set (_examples_png)
+	foreach (_ps ${_examples})
+		get_filename_component (_fig ${_ps} NAME)
+		string (REPLACE ".ps" ".png" _png_fig ${_fig})
+		list (APPEND _examples_png ${RST_BINARY_DIR}/_images/${_png_fig})
+		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
+			COMMAND ${CMAKE_COMMAND} -E env
+			GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
+			${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
+			-A -P -E150 -Tg -Qg4 -Qt4
+			-C-sFONTPATH="${GMT_SOURCE_DIR}/doc/examples/ex31/fonts"
+			-D${RST_BINARY_DIR}/_images
+			${CMAKE_CURRENT_SOURCE_DIR}/${_ps}
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-			DEPENDS gmt_for_img_convert ${CMAKE_CURRENT_SOURCE_DIR}/anim${_num}/anim${_num}.sh)
-		add_custom_command (
-			OUTPUT ${RST_BINARY_DIR}/_images/anim${_num}.gif
-			COMMAND ${CMAKE_COMMAND} -E copy_if_different
-			${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.gif
-			${RST_BINARY_DIR}/_images/anim${_num}.gif
-			DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.gif)
-		list (APPEND _animations ${RST_BINARY_DIR}/_images/anim${_num}.gif)
-	endforeach ()
+			DEPENDS gmt_for_img_convert ${CMAKE_CURRENT_SOURCE_DIR}/${_ps})
+	endforeach (_ps ${_examples})
 
-	# copy video files for anim04
-	foreach (_num 04)
-		add_custom_command (
-			OUTPUT ${RST_STATIC_DIR}/anim${_num}.mp4
-			COMMAND ${CMAKE_COMMAND} -E copy_if_different
-			${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.mp4
-			${RST_STATIC_DIR}/anim${_num}.mp4
-			DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.gif)
-		list (APPEND _animations ${RST_STATIC_DIR}/anim${_num}.mp4)
-	endforeach ()
-	add_custom_target (animation DEPENDS ${_animations})
+	# Convert scripts to verbatim
+	file (GLOB _examples RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*/*.sh")
+	set (_examples_txt)
+	foreach (_script ${_examples})
+		get_filename_component (_txt ${_script} NAME)
+		string (REPLACE ".sh" ".txt" _txt ${_txt})
+		list (APPEND _examples_txt ${RST_BINARY_DIR}/_verbatim/${_txt})
+		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_verbatim/${_txt}
+			COMMAND ${GMT_BINARY_DIR}/src/script2verbatim
+			${CMAKE_CURRENT_SOURCE_DIR}/${_script}
+			${RST_BINARY_DIR}/_verbatim/${_txt}
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+			DEPENDS script2verbatim _docs_rst_mkdir_verbatim ${CMAKE_CURRENT_SOURCE_DIR}/${_script})
+	endforeach (_script ${_examples})
 
-	# clean target
-	foreach (_num 01 02 03 04 05)
-		add_custom_target (_anim_clean${_num}
-			COMMAND ${CMAKE_COMMAND} -E remove_directory
-			${CMAKE_CURRENT_BINARY_DIR}/anim${_num}
-			COMMENT "Removing animation ${_num}")
-		add_depend_to_target (spotless _anim_clean${_num})
-	endforeach ()
-endif (UNIX AND DO_ANIMATIONS)
+	# Add build target
+	add_custom_target (_docs_examples_verbatim DEPENDS ${_examples_txt})
+	add_custom_target (_docs_html_examples_fig DEPENDS ${_examples_png})
+	add_depend_to_target (docs_depends _docs_html_examples_fig _docs_examples_verbatim)
+
+	# Animations
+	if (UNIX AND DO_ANIMATIONS)
+		configure_file (animate.in animate @ONLY)
+
+		foreach (_num 01 02 03 04 05)
+			add_custom_command (
+				OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.gif
+				COMMAND ${BASH} animate anim${_num}/anim${_num}.sh
+				WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+				DEPENDS gmt_for_img_convert ${CMAKE_CURRENT_SOURCE_DIR}/anim${_num}/anim${_num}.sh)
+			add_custom_command (
+				OUTPUT ${RST_BINARY_DIR}/_images/anim${_num}.gif
+				COMMAND ${CMAKE_COMMAND} -E copy_if_different
+				${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.gif
+				${RST_BINARY_DIR}/_images/anim${_num}.gif
+				DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.gif)
+			list (APPEND _animations ${RST_BINARY_DIR}/_images/anim${_num}.gif)
+		endforeach ()
+
+		# copy video files for anim04
+		foreach (_num 04)
+			add_custom_command (
+				OUTPUT ${RST_STATIC_DIR}/anim${_num}.mp4
+				COMMAND ${CMAKE_COMMAND} -E copy_if_different
+				${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.mp4
+				${RST_STATIC_DIR}/anim${_num}.mp4
+				DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.gif)
+			list (APPEND _animations ${RST_STATIC_DIR}/anim${_num}.mp4)
+		endforeach ()
+		add_custom_target (animation DEPENDS ${_animations})
+
+		# clean target
+		foreach (_num 01 02 03 04 05)
+			add_custom_target (_anim_clean${_num}
+				COMMAND ${CMAKE_COMMAND} -E remove_directory
+				${CMAKE_CURRENT_BINARY_DIR}/anim${_num}
+				COMMENT "Removing animation ${_num}")
+			add_depend_to_target (spotless _anim_clean${_num})
+		endforeach ()
+	endif (UNIX AND DO_ANIMATIONS)
+endif (SPHINX_FOUND)
 
 # run examples (test)
 file (GLOB _examples RELATIVE ${CMAKE_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/ex*/*.sh")

--- a/doc/fig/CMakeLists.txt
+++ b/doc/fig/CMakeLists.txt
@@ -15,24 +15,26 @@
 # Contact info: www.generic-mapping-tools.org
 #-------------------------------------------------------------------------------
 
-# Include all PNG and JPG files
-file (GLOB _fig_fig RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
-	"${CMAKE_CURRENT_SOURCE_DIR}/*.png"
-	"${CMAKE_CURRENT_SOURCE_DIR}/*.jpg")
-# Remove some unused figures
-list (REMOVE_ITEM _fig_fig
-	formatting.png highres.png noantialias.png withantialias.png)
+if (SPHINX_FOUND)
+	# Include all PNG and JPG files
+	file (GLOB _fig_fig RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+		"${CMAKE_CURRENT_SOURCE_DIR}/*.png"
+		"${CMAKE_CURRENT_SOURCE_DIR}/*.jpg")
+	# Remove some unused figures
+	list (REMOVE_ITEM _fig_fig
+		formatting.png highres.png noantialias.png withantialias.png)
 
-# Copy figures without converting
-set (_fig_fig_out)
-foreach (_fig ${_fig_fig})
-	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_fig}
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different
-		${CMAKE_CURRENT_SOURCE_DIR}/${_fig} ${RST_BINARY_DIR}/_images/${_fig}
-		DEPENDS ${_fig} _docs_rst_mkdir_images)
-	list (APPEND _fig_fig_out ${RST_BINARY_DIR}/_images/${_fig})
-endforeach (_fig ${_fig_fig})
+	# Copy figures without converting
+	set (_fig_fig_out)
+	foreach (_fig ${_fig_fig})
+		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_fig}
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			${CMAKE_CURRENT_SOURCE_DIR}/${_fig} ${RST_BINARY_DIR}/_images/${_fig}
+			DEPENDS ${_fig} _docs_rst_mkdir_images)
+		list (APPEND _fig_fig_out ${RST_BINARY_DIR}/_images/${_fig})
+	endforeach (_fig ${_fig_fig})
 
-# Add build target
-add_custom_target (_docs_copy_fig DEPENDS ${_fig_fig_out})
-add_depend_to_target (docs_depends _docs_copy_fig)
+	# Add build target
+	add_custom_target (_docs_copy_fig DEPENDS ${_fig_fig_out})
+	add_depend_to_target (docs_depends _docs_copy_fig)
+endif (SPHINX_FOUND)

--- a/doc/rst/CMakeLists.txt
+++ b/doc/rst/CMakeLists.txt
@@ -16,8 +16,6 @@
 #-------------------------------------------------------------------------------
 
 # reST documentation
-find_package (Sphinx)
-
 if (SPHINX_FOUND)
 	# Create configuration file
 	configure_file (conf.py.in conf.py @ONLY)

--- a/doc/scripts/CMakeLists.txt
+++ b/doc/scripts/CMakeLists.txt
@@ -15,57 +15,59 @@
 # Contact info: www.generic-mapping-tools.org
 #-------------------------------------------------------------------------------
 
-# Convert PS to PNG
-file (GLOB _scripts_ps2png RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*.ps")
-set (_scripts_png)
-foreach (_fig ${_scripts_ps2png})
-	string (REPLACE ".ps" ".png" _png_fig ${_fig})
-	list (APPEND _scripts_png ${RST_BINARY_DIR}/_images/${_png_fig})
-	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
-		COMMAND ${CMAKE_COMMAND} -E env
-		GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
-		${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
-		-A -P -E150 -Tg -Qg4 -Qt4
-		-D${RST_BINARY_DIR}/_images
-		${CMAKE_CURRENT_SOURCE_DIR}/${_fig}
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-		DEPENDS gmt_for_img_convert _docs_rst_mkdir_images ${_fig})
-endforeach (_fig ${_scripts_ps2png})
+if (SPHINX_FOUND)
+	# Convert PS to PNG
+	file (GLOB _scripts_ps2png RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*.ps")
+	set (_scripts_png)
+	foreach (_fig ${_scripts_ps2png})
+		string (REPLACE ".ps" ".png" _png_fig ${_fig})
+		list (APPEND _scripts_png ${RST_BINARY_DIR}/_images/${_png_fig})
+		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
+			COMMAND ${CMAKE_COMMAND} -E env
+			GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
+			${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
+			-A -P -E150 -Tg -Qg4 -Qt4
+			-D${RST_BINARY_DIR}/_images
+			${CMAKE_CURRENT_SOURCE_DIR}/${_fig}
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+			DEPENDS gmt_for_img_convert _docs_rst_mkdir_images ${_fig})
+	endforeach (_fig ${_scripts_ps2png})
 
-# Convert PS to PDF
-set (_scripts_ps2pdf GMT_RGBchart_a4.ps GMT_RGBchart_letter.ps GMT_RGBchart_tabloid.ps)
-set (_scripts_pdf)
-foreach (_fig ${_scripts_ps2pdf})
-	string (REPLACE ".ps" ".pdf" _pdf_fig ${_fig})
-	list (APPEND _scripts_pdf ${RST_BINARY_DIR}/_images/${_pdf_fig})
-	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_pdf_fig}
-		COMMAND ${CMAKE_COMMAND} -E env
-		GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
-		${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert -A -P -Tf
-		-D${RST_BINARY_DIR}/_images
-		${CMAKE_CURRENT_SOURCE_DIR}/${_fig}
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-		DEPENDS gmt_for_img_convert _docs_rst_mkdir_images ${_fig})
-endforeach (_fig ${_scripts_ps})
+	# Convert PS to PDF
+	set (_scripts_ps2pdf GMT_RGBchart_a4.ps GMT_RGBchart_letter.ps GMT_RGBchart_tabloid.ps)
+	set (_scripts_pdf)
+	foreach (_fig ${_scripts_ps2pdf})
+		string (REPLACE ".ps" ".pdf" _pdf_fig ${_fig})
+		list (APPEND _scripts_pdf ${RST_BINARY_DIR}/_images/${_pdf_fig})
+		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_pdf_fig}
+			COMMAND ${CMAKE_COMMAND} -E env
+			GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
+			${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert -A -P -Tf
+			-D${RST_BINARY_DIR}/_images
+			${CMAKE_CURRENT_SOURCE_DIR}/${_fig}
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+			DEPENDS gmt_for_img_convert _docs_rst_mkdir_images ${_fig})
+	endforeach (_fig ${_scripts_ps})
 
-# Convert script to verbatim txt
-file (GLOB _scripts_sh2txt RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*.sh")
-set (_scripts_txt)
-foreach (_script ${_scripts_sh2txt})
-	string (REPLACE ".sh" ".txt" _txt ${_script})
-	list (APPEND _scripts_txt ${RST_BINARY_DIR}/_verbatim/${_txt})
-	add_custom_command (OUTPUT ${RST_BINARY_DIR}/_verbatim/${_txt}
-		COMMAND ${GMT_BINARY_DIR}/src/script2verbatim --strip-comments --ps2pdf
-		${CMAKE_CURRENT_SOURCE_DIR}/${_script}
-		${RST_BINARY_DIR}/_verbatim/${_txt}
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-		DEPENDS script2verbatim _docs_rst_mkdir_verbatim ${CMAKE_CURRENT_SOURCE_DIR}/${_script})
-endforeach (_script)
+	# Convert script to verbatim txt
+	file (GLOB _scripts_sh2txt RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*.sh")
+	set (_scripts_txt)
+	foreach (_script ${_scripts_sh2txt})
+		string (REPLACE ".sh" ".txt" _txt ${_script})
+		list (APPEND _scripts_txt ${RST_BINARY_DIR}/_verbatim/${_txt})
+		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_verbatim/${_txt}
+			COMMAND ${GMT_BINARY_DIR}/src/script2verbatim --strip-comments --ps2pdf
+			${CMAKE_CURRENT_SOURCE_DIR}/${_script}
+			${RST_BINARY_DIR}/_verbatim/${_txt}
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+			DEPENDS script2verbatim _docs_rst_mkdir_verbatim ${CMAKE_CURRENT_SOURCE_DIR}/${_script})
+	endforeach (_script)
 
-# Add build target
-add_custom_target (_docs_scripts_verbatim DEPENDS ${_scripts_txt})
-add_custom_target (_docs_html_scripts_fig DEPENDS ${_scripts_png} ${_scripts_pdf})
-add_depend_to_target (docs_depends _docs_html_scripts_fig _docs_scripts_verbatim)
+	# Add build target
+	add_custom_target (_docs_scripts_verbatim DEPENDS ${_scripts_txt})
+	add_custom_target (_docs_html_scripts_fig DEPENDS ${_scripts_png} ${_scripts_pdf})
+	add_depend_to_target (docs_depends _docs_html_scripts_fig _docs_scripts_verbatim)
+endif (SPHINX_FOUND)
 
 # run tests
 file (GLOB _scripts_tests RELATIVE ${CMAKE_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*.sh")


### PR DESCRIPTION
sphinx-build is required for building documentations. If sphinx-build is
not found, there is no need to make the verbatims and convert PS to PNG
formats. Thus I add the `if (SPHINX_FOUND)` test to make sure we don't 
try to define some broken targets when if sphinx-build is not available.

In the old CMake scripts, if sphinx-build is not found, cmake gives the
following error:
```
ninja: error: 'doc/examples/_docs_rst_mkdir_verbatim', needed by 'doc/rst/source/_verbatim/anim01.txt', missing and no known rule to make it
```
The error message means that CMake wants to create the verbatim
`anim01.txt`, but the directory `doc/rst/source/_verbatim` (i.e., the
target `doc/examples/_docs_rst_mkdir_verbatim`) is not found. The error
message is very confusing.

This RP should fix the issue. If sphinx-build is not found, it should
give the warning like `Target docs_html is not defined.`