### PR TITLE
psxyz used wrong bool to assign polygon outline color

### DIFF
--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1737,7 +1737,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 						gmt_M_rgb_copy (current_pen.rgb, rgb);
 						gmt_setpen (GMT, &current_pen);
 					}
-					if (Ctrl->G.set_color) {	/* To be used in polygon or symbol fill */
+					if (Ctrl->G.set_color) {	/* To be used in polygon fill */
 						gmt_M_rgb_copy (current_fill.rgb, rgb);
 						gmt_setfill (GMT, &current_fill, outline_setting);
 					}

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1733,7 +1733,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 				if (Zin != NULL) {
 					double rgb[4];
 					(void)gmt_get_rgb_from_z (GMT, P, z_for_cpt[seg], rgb);
-					if (Ctrl->G.set_color) {	/* To be used in polygon or symbol outline */
+					if (Ctrl->W.set_color) {	/* To be used in polygon outline */
 						gmt_M_rgb_copy (current_pen.rgb, rgb);
 						gmt_setpen (GMT, &current_pen);
 					}


### PR DESCRIPTION
Cut and paste error used the **-G+z** bool in the place where **-W+z** should be checked for polygons.
