### PR TITLE
Use consistent names for ingrid and outgrid

### DIFF
--- a/doc/rst/source/gmtbinstats.rst
+++ b/doc/rst/source/gmtbinstats.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt gmtbinstats** [ *table* ] |-G|\ *out_grdfile*
+**gmt gmtbinstats** [ *table* ] |-G|\ *outgrid*
 |SYN_OPT-I|
 |-C|\ **a**\|\ **d**\|\ **g**\|\ **i**\|\ **l**\|\ **L**\|\ **m**\|\ **n**\|\ **o**\|\ **p**\|\ **q**\ [*quant*]\|\ **r**\|\ **s**\|\ **u**\|\ **U**\|\ **z**
 |SYN_OPT-R|
@@ -74,7 +74,7 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *out_grdfile*
+**-G**\ *outgrid*
     Give the name of the output grid file.
 
 .. _-I:

--- a/doc/rst/source/grdconvert.rst
+++ b/doc/rst/source/grdconvert.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt grdconvert** *ingrdfile* |-G|\ *outgrdfile*
+**gmt grdconvert** *ingrid* |-G|\ *outgrid*
 [ |-N| ]
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]
@@ -32,7 +32,7 @@ be written and to specify scaling, translation, and NaN-value.
 Required Arguments
 ------------------
 
-*ingrdfile*\ [=id[**+s**\ *scale*][**+o**\ *offset*][**+n**\ *invalid*]]
+*ingrid*\ [=id[**+s**\ *scale*][**+o**\ *offset*][**+n**\ *invalid*]]
     The grid file to be read. Append format =\ *id* code if not a
     standard COARDS-compliant netCDF grid file. If =\ *id* is set (see
     below), you may optionally append any of **+s**\ *scale*, **+o**\ *offset*,
@@ -51,7 +51,7 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outgrdfile*\ [=id[**+s**\ *scale*][**+o**\ *offset*][**+n**\ *invalid*]][*:driver*\ [/*datatype*]]]
+**-G**\ *outgrid*\ [=id[**+s**\ *scale*][**+o**\ *offset*][**+n**\ *invalid*]][*:driver*\ [/*datatype*]]]
     The grid file to be written. Append format =\ *id* code if not a
     standard COARDS-compliant netCDF grid file. If =\ *id* is set (see
     below), you may optionally append  any of **+s**\ *scale*,
@@ -128,11 +128,11 @@ format is conform the COARDS conventions. GMT versions prior to 4.1
 produced netCDF files that did not conform to these conventions.
 Although these files are still supported, their use is deprecated. To
 write other than floating point COARDS-compliant netCDF files, append
-the =\ *id* suffix to the filename *outgrdfile*.
+the =\ *id* suffix to the filename *outgrid*.
 
 When reading files, **grdconvert** and other GMT programs will try
 to automatically recognize the type of the input grid file. If this
-fails you may append the =\ *id* suffix to the filename *ingrdfile*.
+fails you may append the =\ *id* suffix to the filename *ingrid*.
 
 +----------+---------------------------------------------------------------+
 | ID       | Explanation                                                   |
@@ -201,7 +201,7 @@ without loss of data range or significance. For more details, see
 
 By default, GMT programs will read the first 2-dimensional grid
 contained in a COARDS-compliant netCDF file. Alternatively, use
-*ingrdfile*\ **?**\ *varname* (ahead of any optional suffix **=**\ *id*)
+*ingrid*\ **?**\ *varname* (ahead of any optional suffix **=**\ *id*)
 to specify the requested variable *varname*. Since **?** has special
 meaning as a wildcard, escape this meaning by placing the full filename
 and suffix between quotes.
@@ -211,7 +211,7 @@ and suffix between quotes.
 To extract one *layer* or *level* from a 3-dimensional grid stored in a
 COARDS-compliant netCDF file, append both the name of the variable and
 the index associated with the layer (starting at zero) in the form:
-*ingrdfile*\ **?**\ *varname*\ **[**\ *layer*\ **]**. Alternatively,
+*ingrid*\ **?**\ *varname*\ **[**\ *layer*\ **]**. Alternatively,
 specify the value associated with that layer using parentheses in stead
 of brackets:
 *ingridfile*\ **?**\ *varname*\ **(**\ *layer*\ **)**.

--- a/doc/rst/source/grdfft.rst
+++ b/doc/rst/source/grdfft.rst
@@ -46,7 +46,7 @@ Required Arguments
 *ingrid*
     2-D binary grid file to be operated on. (See GRID FILE FORMATS
     below). For cross-spectral operations, also give the second grid
-    file *ingrd2*.
+    file *ingrid2*.
 **-G**\ *outfile*
     Specify the name of the output grid file or the 1-D spectrum table
     (see **-E**). (See GRID FILE FORMATS below).

--- a/doc/rst/source/grdgradient.rst
+++ b/doc/rst/source/grdgradient.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt grdgradient** *in_grdfile* |-G|\ *out_grdfile*
+**gmt grdgradient** *ingrid* |-G|\ *outgrid*
 [ |-A|\ *azim*\ [/*azim2*] ] [ |-D|\ [**a**][**c**][**o**][**n**] ]
 [ |-E|\ [**m**\|\ **s**\|\ **p**]\ *azim/elev*\ [**+a**\ *ambient*][**+d**\ *diffuse*][**+p**\ *specular*][**+s**\ *shine*] ]
 [ |-N|\ [**e**\|\ **t**][*amp*][**+a**\ *ambient*][**+s**\ *sigma*][**+o**\ *offset*] ]
@@ -37,12 +37,12 @@ boundary conditions (see **-n**).
 Required Arguments
 ------------------
 
-*in_grdfile*
+*ingrid*
     2-D grid file from which to compute directional derivative. (See GRID FILE FORMATS below).
 
 .. _-G:
 
-**-G**\ *out_grdfile*
+**-G**\ *outgrid*
     Name of the output grid file for the directional derivative. (See
     GRID FILE FORMATS below).
 
@@ -66,7 +66,7 @@ Optional Arguments
     retained; this is useful for illuminating data with two directions
     of lineated structures, e.g., **-A**\ *0*/*270* illuminates from the
     north (top) and west (left).  Finally, if *azim* is a file it must
-    be a grid of the same domain, spacing and registration as *in_grdfile*
+    be a grid of the same domain, spacing and registration as *ingrid*
     and we will update the azimuth at each output node when computing the
     directional derivatives.
 
@@ -172,7 +172,7 @@ for :doc:`grdimage` or :doc:`grdview`, a good first try is **-Ne**\ 0.6.
 
 Usually 255 shades are more than enough for visualization purposes. You
 can save 75% disk space by appending =nb/a to the output filename
-*out_grdfile*.
+*outgrid*.
 
 If you want to make several illuminated maps of subregions of a large
 data set, and you need the illumination effects to be consistent across

--- a/doc/rst/source/grdhisteq.rst
+++ b/doc/rst/source/grdhisteq.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt grdhisteq** *in_grdfile* [ |-G|\ *out_grdfile* ]
+**gmt grdhisteq** *ingrid* [ |-G|\ *outgrid* ]
 [ |-C|\ *n_cells* ] [ |-D|\ [*file*] ] [ |-N|\ [*norm*] ]
 [ |-Q| ]
 |SYN_OPT-R|
@@ -59,7 +59,7 @@ location of the most negative input value, and so on.
 Required Arguments
 ------------------
 
-*in_grdfile*
+*ingrid*
     2-D grid file to be equalized. (See GRID FILE FORMATS below).
 
 Optional Arguments
@@ -77,7 +77,7 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *out_grdfile*
+**-G**\ *outgrid*
     Name of output 2-D grid file. Used with **-N** only. (See GRID FILE FORMATS below).
 
 .. _-N:
@@ -95,7 +95,7 @@ Optional Arguments
 .. _-R:
 
 .. |Add_-R| replace:: Using the **-R** option
-    will select a subsection of *in_grdfile* grid. If this subsection
+    will select a subsection of *ingrid* grid. If this subsection
     exceeds the boundaries of the grid, only the common region will be extracted.
 .. include:: explain_-R.rst_
 

--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -31,7 +31,7 @@ Synopsis
 [ |SYN_OPT-x| ]
 [ |SYN_OPT--| ]
 *operand* [ *operand* ] **OPERATOR** [ *operand* ]
-**OPERATOR** ... **=** *outgrdfile*
+**OPERATOR** ... **=** *outgrid*
 
 |No-spaces|
 
@@ -46,7 +46,7 @@ final result is written to an output grid file. Grid operations are
 element-by-element, not matrix manipulations. Some operators only
 require one operand (see below). If no grid files are used in the
 expression then options **-R**, **-I** must be set (and optionally
-|SYN_OPT-r|). The expression **=** *outgrdfile* can occur as many times as
+|SYN_OPT-r|). The expression **=** *outgrid* can occur as many times as
 the depth of the stack allows in order to save intermediate results.
 Complicated or frequently occurring expressions may be coded as a macro
 for future use or stored and recalled via named memory locations.
@@ -59,7 +59,7 @@ Required Arguments
     If not a file, it is interpreted as a numerical constant or a
     special symbol (see below).
 
-*outgrdfile*
+*outgrid*
     The name of a 2-D grid file that will hold the final result. (See
     GRID FILE FORMATS below).
 

--- a/doc/rst/source/grdproject.rst
+++ b/doc/rst/source/grdproject.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt grdproject** *in_grdfile* |-G|\ *out_grdfile* |-J|\ *parameters*
+**gmt grdproject** *ingrid* |-G|\ *outgrid* |-J|\ *parameters*
 [ |-C|\ [*dx/dy*] ]
 [ |-D|\ *xinc*\ [**+e**\|\ **n**][/\ *yinc*\ [**+e**\|\ **n**]] ]
 [ |-E|\ *dpi* ] [ |-F|\ [**c**\|\ **i**\|\ **p**\|\ **e**\|\ **f**\|\ **k**\|\ **M**\|\ **n**\|\ **u**] ] [ |-I| ] [ |-M|\ **c**\|\ **i**\|\ **p** ]
@@ -49,12 +49,12 @@ than that implied by the extent of the grid file.
 Required Arguments
 ------------------
 
-*in_grdfile*
+*ingrid*
     2-D binary grid file to be transformed. (See GRID FILE FORMATS below.)
 
 .. _-G:
 
-**-G**\ *out_grdfile*
+**-G**\ *outgrid*
     Specify the name of the output grid file. (See GRID FILE FORMATS below.)
 
 .. _-J:

--- a/doc/rst/source/grdsample.rst
+++ b/doc/rst/source/grdsample.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt grdsample** *in_grdfile* |-G|\ *out_grdfile*
+**gmt grdsample** *ingrid* |-G|\ *outgrid*
 [ |SYN_OPT-I| ]
 [ |SYN_OPT-R| ]
 [ |-T| ]
@@ -46,12 +46,12 @@ have the same registration as the input grid.
 Required Arguments
 ------------------
 
-*in_grdfile*
+*ingrid*
     The name of the input 2-D binary grid file. (See GRID FILE FORMAT below.)
 
 .. _-G:
 
-**-G**\ *out_grdfile*
+**-G**\ *outgrid*
     The name of the output grid file. (See GRID FILE FORMAT below.)
 
 Optional Arguments

--- a/doc/rst/source/nearneighbor.rst
+++ b/doc/rst/source/nearneighbor.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt nearneighbor** [ *table* ] |-G|\ *out_grdfile*
+**gmt nearneighbor** [ *table* ] |-G|\ *outgrid*
 |SYN_OPT-I|
 |-N|\ *sectors*\ [**+m**\ *min_sectors*] | \ **n**
 |SYN_OPT-R|
@@ -58,7 +58,7 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *out_grdfile*
+**-G**\ *outgrid*
     Give the name of the output grid file.
 
 .. _-I:

--- a/doc/rst/source/supplements/potential/gravfft.rst
+++ b/doc/rst/source/supplements/potential/gravfft.rst
@@ -62,7 +62,7 @@ Required Arguments
 
 *ingrid*
     2-D binary grid file to be operated on. (See GRID FILE FORMATS below).
-    For cross-spectral operations, also give the second grid file *ingrd2*.
+    For cross-spectral operations, also give the second grid file *ingrid2*.
 
 .. _-G:
 
@@ -121,9 +121,9 @@ Optional Arguments
 .. _-I:
 
 **-I**\ **w**\|\ **b**\|\ **c**\|\ **t**\|\ **k**
-    Use *ingrd2* and *ingrd1* (a grid with topography/bathymetry) to estimate admittance\|coherence and
+    Use *ingrid2* and *ingrid1* (a grid with topography/bathymetry) to estimate admittance\|coherence and
     write it to stdout (**-G** ignored if set). This grid should contain
-    gravity or geoid for the same region of *ingrd1*. Default
+    gravity or geoid for the same region of *ingrid1*. Default
     computes admittance. Output contains 3 or 4 columns. Frequency
     (wavelength), admittance (coherence) one sigma error bar and,
     optionally, a theoretical admittance. Append dataflags (one to

--- a/doc/rst/source/supplements/spotter/grdpmodeler.rst
+++ b/doc/rst/source/supplements/spotter/grdpmodeler.rst
@@ -15,7 +15,7 @@ Synopsis
 **gmt grdpmodeler** |-E|\ *rot_file* **-S**\ *flags*
 [ *agegrdfile* ]
 [ |-F|\ *polygonfile* ]
-[ |-G|\ *outgrdfile* ]
+[ |-G|\ *outgrid* ]
 [ |SYN_OPT-R| ]
 [ |-T|\ *age* ]
 [ |SYN_OPT-V| ]
@@ -58,7 +58,7 @@ Required Arguments
 Optional Arguments
 ------------------
 
-*ingrdfile*
+*ingrid*
     Name of a grid file in geographical (lon, lat) coordinates with ages in Myr.
     If no grid is provided then you may define the domain via **-R**, **-I**, and optionally **-r**.
 
@@ -71,7 +71,7 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *outgrdfile*
+**-G**\ *outgrid*
     Name of output grid. This is the grid with the model predictions
     given the specified rotations. **Note**: If you specified more than one
     model prediction in **-S** then the filename *must* be a template

--- a/doc/rst/source/supplements/spotter/grdrotater.rst
+++ b/doc/rst/source/supplements/spotter/grdrotater.rst
@@ -12,8 +12,8 @@ Synopsis
 
 .. include:: ../../common_SYN_OPTs.rst_
 
-**gmt grdrotater** *ingrdfile* |-E|\ *rot_file*\|\ *lon*/*lat*/*angle*
-|-G|\ *outgrdfile*
+**gmt grdrotater** *ingrid* |-E|\ *rot_file*\|\ *lon*/*lat*/*angle*
+|-G|\ *outgrid*
 [ |-A|\ *region* ]
 [ |-D|\ *rotoutline* ]
 [ |-F|\ *polygonfile* ]
@@ -44,17 +44,17 @@ rotated region is not the entire globe.
 Required Arguments
 ------------------
 
-*ingrdfile*
+*ingrid*
     Name of a grid file in geographical (lon, lat) coordinates.
 
 .. include:: explain_rots.rst_
 
 .. _-G:
 
-**-G**\ *outgrdfile*
+**-G**\ *outgrid*
     Name of output grid. This is the grid with the data reconstructed
     according to the specified rotation. If more than one reconstruction
-    time is implied then *outgrdfile* must contain a C-format specifier
+    time is implied then *outgrid* must contain a C-format specifier
     to format a floating point number (reconstruction time) to text.
 
 Optional Arguments


### PR DESCRIPTION
- Use *ingrid* instead of *ingrdfile*, *in_gridfile* or *ingrd*.
- Use *outgrid* instead of *outgrdfile*, *out_gridfile* or *outgrd*.