### PR TITLE
Several problems in grdgradient

### DIFF
--- a/src/grdgradient.c
+++ b/src/grdgradient.c
@@ -559,7 +559,7 @@ EXTERN_MSC int GMT_grdgradient (void *V_API, int mode, void *args) {
 #endif
 	new_grid = gmt_set_outgrid (GMT, Ctrl->In.file, separate, 2, In, &Grid);	/* true if input is a read-only array */
 
-	/* If new_grid is true then Grid points to a duplicate of In but will have a single boundary row,column.
+	/* If new_grid is true then Grid points to a duplicate of In but will have two boundary rows,columns padding.
 	 * If new_grid is false then Grid simply points to In which presumably has two boundary row,column padding.
 	 * In either case, the algorithm below assumes there is at least one extra row column in Grid */
 

--- a/src/grdgradient.c
+++ b/src/grdgradient.c
@@ -557,7 +557,7 @@ EXTERN_MSC int GMT_grdgradient (void *V_API, int mode, void *args) {
 	separate = true;	/* Cannot use input grid to hold output grid when doing things in parallel */
 #endif
 #endif
-	new_grid = gmt_set_outgrid (GMT, Ctrl->In.file, separate, 1, In, &Grid);	/* true if input is a read-only array */
+	new_grid = gmt_set_outgrid (GMT, Ctrl->In.file, separate, 2, In, &Grid);	/* true if input is a read-only array */
 
 	/* If new_grid is true then Grid points to a duplicate of In but will have a single boundary row,column.
 	 * If new_grid is false then Grid simply points to In which presumably has two boundary row,column padding.


### PR DESCRIPTION
**grdgradient** computes derivatives and requires at least a one row/col padding for the algorithm to work: We do the finite differencing on a cell defined by 4 nodes and store the result in the top left node which is not used in further calculations.  At the end, we restore the padding so the output grid is correctly aligned.  For files (automatically having a pad of 2) this works fine.

When **grdgradient** is called via _GMT_Call_Module_ with a memory grid that has no padding (#3408) we detect that  case and call

`new_grid = gmt_set_outgrid (GMT, Ctrl->In.file, separate, 1, Surf, &Out);	/* true if input is a read-only array */`

This function returns true in this case and allocates a new grid (_Out_) that (given the arg = 1) will have the required minimum of one row/col padding.  We then place computed gradients into` Out->data[index]` so that _Surf_ (read-only) is not touched. **But wait a minute!**  The loop we set up is using the _Surf->header_ to get the index into the Surf array, but in this case Surf has no padding.  Note we always do this: 

```
	mx = Surf->header->mx;	/* Need a signed mx for p[3] in line below */
	p[0] = 1;	p[1] = -1;	p[2] = mx;	p[3] = -mx;
```

so p[1] and p[3] are always negative relative node changes.   Then in the loop we do this

`for (n = 0, bad = false; !bad && n < 4; n++) if (gmt_M_is_fnan (Surf->data[ij+p[n]])) bad = true;`

Since `Surf->data` has no pad and _ij_ starts at 0, we end up with negative array indices.  Not sure why it is not crashing but it clearly points to nowhere.  This  explains part of the problem in #3408 but regardless this is a serious bug.

Another issues is **-S**.  With **-S** we create another output grid _Slope_  by duplicating  _Surf_.  We then use the same index as _Out_ to assign output.  But this will be wrong if _Surf_ has no pad.  Now I allocate _Slope_ using the same padding as the output grid.

Finally, ensuring that the grid has at least one row/col is useless since _gmt_set_outgrid_ may in fact need to call _gmt_grd_BC_set_ which requires two rows/cols.  So now we call it with two.

For clarity, this PR replaces "Surf" with "In", and "Out" with "Grid" and uses Grid in all those places since it is this array we get values from and then we always place the result in the top-left node of the cells.  At the end we reinstate the pad.  Doing this and running all the test gave no errors, and it also fixes #3408.
