### PR TITLE
Move deprecation messages up to INFORMATION

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -3580,7 +3580,7 @@ GMT_LOCAL int gmtinit_set_titem (struct GMT_CTRL *GMT, struct GMT_PLOT_AXIS *A, 
 
 	if (phase != 0.0) A->phase = phase;	/* phase must apply to entire axis */
 	if (I->active) {
-		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Axis sub-item %c set more than once (typo?)\n", flag);
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Axis sub-item %c set more than once (typo?)\n", flag);
 		return (GMT_NOERROR);
 	}
 	if (unit == 'c' || unit == 'C') {

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -509,7 +509,7 @@ GMT_LOCAL bool pshistogram_new_syntax (struct GMT_CTRL *GMT, char *L, char *T, c
 	if (w_val == 0.0) return true;	/* Must have given a zero pen width (faint) */
 	if (fabs (rint (t_val) - t_val)) return true;	/* Argument to -T is not an integer, hence new style */
 	if (t_val > 5) {	/* Here we must guess that 6 is too large to be a column entry and hence it is a new syntax */
-		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Cannot tell if -T%s -W%s is new or deprecated syntax; selected new.\n", T, W);
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Cannot tell if -T%s -W%s is new or deprecated syntax; selected new.\n", T, W);
 		return true;
 	}
 	else {


### PR DESCRIPTION
Julia generated code raises this options
```
        histogram @v3206_06.txt  -R-6000/0/0/30 -Bpy+u" %" -Bpy+lFrequency -BWSne+glightblue+tHistograms -Bpx+l"Topography (m)" -Gorange -W1 -T250 -Z1
histogram [WARNING]: Axis sub-item f set more than once (typo?)
histogram [WARNING]: Axis sub-item a set more than once (typo?)
histogram [WARNING]: Cannot tell if -T250 -W1 is new or deprecated syntax; selected new.
```
The first two are due to a separate ``-Bpy+u" %" -Bpy+lFrequency ``, very hard, to impossible, to join the the julia parsing function. And note that there are any *a* or *f* set, so the message is not correct anyway.

The third warning is due to a missing (but not mandatory) unit in **-W1**. Also this is not controlable since users are not obliged to specify a unit.