### PR TITLE
Prevent signed/unsigned warnings by improving code

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -6717,7 +6717,7 @@ int gmtlib_validate_id (struct GMTAPI_CTRL *API, int family, int object_ID, int 
 	for (i = 0, item = GMT_NOTSET; item == GMT_NOTSET && i < API->n_objects; i++) {
 		S_obj = API->object[i];	/* Shorthand only */
 		if (!S_obj) continue;								/* Empty object */
-		if (direction != GMT_NOTSET && S_obj->direction != direction) continue;		/* Not the same direction */
+		if (direction != GMT_NOTSET && (int)S_obj->direction != direction) continue;		/* Not the same direction */
 		if (direction == GMT_IN && S_obj->status != GMT_IS_UNUSED && object_ID == GMT_NOTSET) continue;		/* Already used this input object once */
 		if (!(family == GMT_NOTSET || (int)S_obj->family == family)) {		/* Not the required data type; check for exceptions... */
 			if (family == GMT_IS_DATASET && (S_obj->actual_family == GMT_IS_VECTOR || S_obj->actual_family == GMT_IS_MATRIX))

--- a/src/gmt_grd.h
+++ b/src/gmt_grd.h
@@ -160,11 +160,11 @@ enum gmt_enum_wesnids {
 /* Note: All arguments must be actual variables and not expressions.
  * Note: that input col, row _may_ be signed, hence we do the cast to (int) here. */
 
-#define gmt_M_row_loop(C,G,row) for (row = 0; (int)row < (int)G->header->n_rows; row++)
-#define gmt_M_col_loop(C,G,row,col,ij) for (col = 0, ij = gmt_M_ijp (G->header, row, 0); (int)col < (int)G->header->n_columns; col++, ij++)
+#define gmt_M_row_loop(C,G,row) for (row = 0; row < (int)G->header->n_rows; row++)
+#define gmt_M_col_loop(C,G,row,col,ij) for (col = 0, ij = gmt_M_ijp (G->header, row, 0); col < (int)G->header->n_columns; col++, ij++)
 #define gmt_M_grd_loop(C,G,row,col,ij) gmt_M_row_loop(C,G,row) gmt_M_col_loop(C,G,row,col,ij)
 /*! Just a loop over columns */
-#define gmt_M_col_loop2(C,G,col) for (col = 0; (int)col < (int)G->header->n_columns; col++)
+#define gmt_M_col_loop2(C,G,col) for (col = 0; col < (int)G->header->n_columns; col++)
 
 /* The usage could be:
 	gmt_M_grd_loop (GMT, Grid, row, col, node) fprintf (stderr, "Value at row = %d and col = %d is %g\n", row, col, Grid->data[node]);

--- a/src/gmt_grd.h
+++ b/src/gmt_grd.h
@@ -160,11 +160,11 @@ enum gmt_enum_wesnids {
 /* Note: All arguments must be actual variables and not expressions.
  * Note: that input col, row _may_ be signed, hence we do the cast to (int) here. */
 
-#define gmt_M_row_loop(C,G,row) for (row = 0; row < (int)G->header->n_rows; row++)
-#define gmt_M_col_loop(C,G,row,col,ij) for (col = 0, ij = gmt_M_ijp (G->header, row, 0); col < (int)G->header->n_columns; col++, ij++)
+#define gmt_M_row_loop(C,G,row) for (row = 0; (int)row < (int)G->header->n_rows; row++)
+#define gmt_M_col_loop(C,G,row,col,ij) for (col = 0, ij = gmt_M_ijp (G->header, row, 0); (int)col < (int)G->header->n_columns; col++, ij++)
 #define gmt_M_grd_loop(C,G,row,col,ij) gmt_M_row_loop(C,G,row) gmt_M_col_loop(C,G,row,col,ij)
 /*! Just a loop over columns */
-#define gmt_M_col_loop2(C,G,col) for (col = 0; col < (int)G->header->n_columns; col++)
+#define gmt_M_col_loop2(C,G,col) for (col = 0; (int)col < (int)G->header->n_columns; col++)
 
 /* The usage could be:
 	gmt_M_grd_loop (GMT, Grid, row, col, node) fprintf (stderr, "Value at row = %d and col = %d is %g\n", row, col, Grid->data[node]);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -636,7 +636,7 @@ EXTERN_MSC bool gmt_getpen (struct GMT_CTRL *GMT, char *line, struct GMT_PEN *pe
 EXTERN_MSC void gmt_freepen (struct GMT_CTRL *GMT, struct GMT_PEN *pen);
 EXTERN_MSC bool gmt_getrgb (struct GMT_CTRL *GMT, char *line, double *rgb);
 EXTERN_MSC int gmt_getrose (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_ROSE *mr);
-EXTERN_MSC int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, unsigned int flag, struct GMT_MAP_SCALE *ms);
+EXTERN_MSC int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_SCALE *ms);
 EXTERN_MSC int gmt_getinset (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_INSET *B);
 EXTERN_MSC int gmt_getpanel (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_PANEL **P);
 EXTERN_MSC char * gmt_putfont (struct GMT_CTRL *GMT, struct GMT_FONT *F);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -1456,7 +1456,8 @@ char *gmtlib_get_tile_list (struct GMTAPI_CTRL *API, double wesn[], int k_data, 
 	/* Builds a list of the tiles to download for the chosen region, dataset and resolution.
 	 * Uses the optional tile information grid to know if a particular tile exists. */
 	char tile_list[PATH_MAX] = {""}, *file = NULL, **tile = NULL, datatype[3] = {'L', 'O', 'X'}, regtype[2] = {'G', 'P'};
-	unsigned int k, k_filler = GMT_NOTSET, n_tiles = 0, ocean = (srtm_flag) ? 0 : 2;
+	int k_filler = GMT_NOTSET;
+	unsigned int k, n_tiles = 0, ocean = (srtm_flag) ? 0 : 2;
 	FILE *fp = NULL;
 	struct GMT_DATA_INFO *Ip = &API->remote_info[k_data], *Is = NULL;	/* Pointer to primary tiled dataset */
 

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -12820,7 +12820,7 @@ int gmt_getinset (struct GMT_CTRL *GMT, char option, char *in_text, struct GMT_M
 	return (error);
 }
 
-int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, unsigned int flag, struct GMT_MAP_SCALE *ms) {
+int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_SCALE *ms) {
 	/* This function parses the -L map scale syntax:
 	 *   -L[g|j|J|n|x]<refpoint>+c[/<slon>]/<slat>+w<length>[e|f|M|n|k|u][+a<align>][+f][+j<just>][+l<label>][+u]
 	 * If the required +w is not present we call the backwards compatible parsert for the previous map scale syntax.

--- a/src/gmtget.c
+++ b/src/gmtget.c
@@ -206,7 +206,8 @@ EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 	if (Ctrl->D.active) {	/* Data download */
 		if (!strncmp (Ctrl->D.dir, "all", 3U) || !strncmp (Ctrl->D.dir, "data", 4U)) {	/* Want data */
 			bool found;
-			unsigned int n_tiles, k, d = 0, t, n_items = 0, n;
+			int k;
+			unsigned int n_tiles, d = 0, t, n_items = 0, n;
 			char **list = NULL, *string = NULL, *token = NULL, *tofree = NULL;
 			char planet[GMT_LEN32] = {""}, group[GMT_LEN32] = {""}, dataset[GMT_LEN64] = {""}, size[GMT_LEN32] = {""}, message[GMT_LEN256] = {""};
 			double world[4] = {-180.0, +180.0, -90.0, +90.0};

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1692,9 +1692,9 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 	normal_y = !(GMT->current.proj.projection_GMT == GMT_LINEAR && !GMT->current.proj.xyz_pos[1] && !resampled);
 
 	Conf->actual_row = gmt_M_memory (GMT, NULL, Conf->n_rows, unsigned int);	/* Deal with any reversal of the y-axis due to -J */
-	for (row = 0; row < Conf->n_rows; row++) Conf->actual_row[row] = (normal_y) ? row : Conf->n_rows - row - 1;
+	for (row = 0; row < (unsigned int)Conf->n_rows; row++) Conf->actual_row[row] = (normal_y) ? row : Conf->n_rows - row - 1;
 	Conf->actual_col = gmt_M_memory (GMT, NULL, Conf->n_columns, unsigned int);	/* Deal with any reversal of the x-axis due to -J */
-	for (col = 0; col < Conf->n_columns; col++) Conf->actual_col[col] = (normal_x) ? col : Conf->n_columns - col - 1;
+	for (col = 0; col < (unsigned int)Conf->n_columns; col++) Conf->actual_col[col] = (normal_x) ? col : Conf->n_columns - col - 1;
 
 	rgb_cube_scan = (P && Ctrl->Q.active && !Ctrl->A.active);	/* Need to look for unique rgb for PostScript masking */
 
@@ -1815,9 +1815,9 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 		if (Ctrl->A.active) {	/* Creating a raster image, not PostScript */
 			if (Ctrl->Q.active) {	/* Must initialize the transparency byte (alpha): 255 everywhere except at NaNs where it should be 0 */
 				memset (Out->alpha, 255, header_work->nm);
-				for (node = row = 0; row < Conf->n_rows; row++) {
+				for (node = row = 0; row < (unsigned int)Conf->n_rows; row++) {
 					kk = gmt_M_ijpgi (header_work, row, 0);
-					for (col = 0; col < Conf->n_columns; col++, node++) {
+					for (col = 0; col < (unsigned int)Conf->n_columns; col++, node++) {
 						if (gmt_M_is_fnan (Grid_proj->data[kk + col])) Out->alpha[node] = 0;
 					}
 				}

--- a/src/grdmix.c
+++ b/src/grdmix.c
@@ -683,7 +683,7 @@ EXTERN_MSC int GMT_grdmix (void *V_API, int mode, void *args) {
 #ifdef _OPENMP
 #pragma omp parallel for private(node) shared(H,I,alpha)
 #endif
-		for (node = 0; node < H->size; node++)	/* Scale to 0-255 range */
+		for (node = 0; node < (int64_t)H->size; node++)	/* Scale to 0-255 range */
 			I->alpha[node] = gmt_M_u255 (alpha[node]);
 		gmt_M_free (GMT, alpha);
 	}

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -924,7 +924,8 @@ GMT_LOCAL int grdflexure_write_transfer_function (struct GMT_CTRL *GMT, struct G
 	 * Each segment has leading columns of wavelength and wavenumber corresponding to wavelengths 1:5000 km.
 	 * The next 12 columns has the chosen transfer function evaluated for times 1k, 2k, 5k, 10k, 20k, 50k, 100k, 200k, 500k, 1M, 2M, and 5M years.
 	 * Each segment is written to a separate file. Obviously, if no -F or -M are given then all columns are the same since elastic */
-	int k, t, s, n_times, n_te;
+	uint64_t k;
+	int t, s, n_times, n_te;
 	char file[GMT_LEN64] = {""};
 	static char *FLX_response[6] = {"Elastic", "Viscoelastic", "Firmoviscous (1 layer)", "Firmoviscous (2 layer)", "Viscous (1 layer)", "Viscous (2 layer)"};
 	uint64_t dim[4] = {1, 0, 0, 0};

--- a/src/psbasemap.c
+++ b/src/psbasemap.c
@@ -203,7 +203,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSBASEMAP_CTRL *Ctrl, struct GMT_
 				break;
 			case 'L':	/* Draw map scale */
 				Ctrl->L.active = true;
-				n_errors += gmt_getscale (GMT, 'L', opt->arg, GMT_SCALE_MAP, &Ctrl->L.scale);
+				n_errors += gmt_getscale (GMT, 'L', opt->arg, &Ctrl->L.scale);
 				break;
 			case 'T':	/* Draw map rose */
 				Ctrl->T.active = true;

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -416,7 +416,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOAST_CTRL *Ctrl, struct GMT_OP
 				break;
 			case 'L':
 				Ctrl->L.active = true;
-				n_errors += gmt_getscale (GMT, 'L', opt->arg, GMT_SCALE_MAP, &Ctrl->L.scale);
+				n_errors += gmt_getscale (GMT, 'L', opt->arg, &Ctrl->L.scale);
 				break;
 			case 'm':
 				if (gmt_M_compat_check (GMT, 4))	/* Warn and fall through on purpose */

--- a/src/pswiggle.c
+++ b/src/pswiggle.c
@@ -311,7 +311,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSWIGGLE_CTRL *Ctrl, struct GMT_O
 				}
 				else {
 					Ctrl->D.active = Ctrl->D.scale.vertical = true;
-					n_errors += gmt_getscale (GMT, 'D', opt->arg, GMT_SCALE_MAP, &Ctrl->D.scale);
+					n_errors += gmt_getscale (GMT, 'D', opt->arg, &Ctrl->D.scale);
 				}
 				break;
 			case 'F':

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -688,17 +688,16 @@ void subplot_wipe_history_and_settings (struct GMTAPI_CTRL *API) {
 	 * as well as any subplot history file.  Same for settings.
 	 */
 
-	int fig, subplot, inset;
-	unsigned int row, col;
+	int fig, subplot, inset, row, col;
 	char file[PATH_MAX] = {""}, panel[GMT_LEN32] = {""};
 	struct GMT_SUBPLOT *P = NULL;
 
 	gmtlib_get_graphics_item (API, &fig, &subplot, panel, &inset);	/* Determine the natural history level */
 	if (subplot && (P = gmt_subplot_info (API, fig))) {
 		for (row = 0; row < P->nrows; row++) for (col = 0; col < P->ncolumns; col++) {
-			snprintf (file, PATH_MAX, "%s/%s.%d.panel.%u-%u", API->gwf_dir, GMT_HISTORY_FILE, fig, row, col);
+			snprintf (file, PATH_MAX, "%s/%s.%d.panel.%d-%d", API->gwf_dir, GMT_HISTORY_FILE, fig, row, col);
 			gmt_remove_file (API->GMT, file);
-			snprintf (file, PATH_MAX, "%s/%s.%d.panel.%u-%u", API->gwf_dir, GMT_SETTINGS_FILE, fig, row, col);
+			snprintf (file, PATH_MAX, "%s/%s.%d.panel.%d-%d", API->gwf_dir, GMT_SETTINGS_FILE, fig, row, col);
 			gmt_remove_file (API->GMT, file);
 		}
 	}


### PR DESCRIPTION
Mostly using the same declaration of variables in comparisons, plus adding casts to macros that for OpenMP reasons need to be signed int regardless of original variable.

Also removed an unused function argument in _gmt_getscale_.