### PR TITLE
Better definition and use of file modifiers

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -13813,21 +13813,21 @@ int GMT_Get_FilePath (void *V_API, unsigned int family, unsigned int direction, 
 			else if (gmt_M_file_is_netcdf (file))	/* Meaning it specifies a layer etc via ?<args> */
 				c = strchr (file, '?');
 			else {	/* Check for modifiers */
-				unsigned int nm = gmt_validate_modifiers (API->GMT, file, 0, "onsuU", GMT_MSG_QUIET);
+				unsigned int nm = gmt_validate_modifiers (API->GMT, file, 0, GMT_GRIDFILE_MODIFIERS, GMT_MSG_QUIET);
 				if (nm) /* Found some valid modifiers, lets get to the first */
-					c = gmt_first_modifier (API->GMT, file, "onsuU");
+					c = gmt_first_modifier (API->GMT, file, GMT_GRIDFILE_MODIFIERS);
 			}
 			break;
 		case GMT_IS_IMAGE:
 			c = strstr (file, "=gd");	/* Got image=gd[+modifiers] */
 			break;
 		case GMT_IS_PALETTE:
-			if (gmt_validate_modifiers (API->GMT, file, '-', "iuU", GMT_MSG_ERROR)) {
+			if (gmt_validate_modifiers (API->GMT, file, '-', GMT_CPTFILE_MODIFIERS, GMT_MSG_ERROR)) {
 				GMT_Report (API, GMT_MSG_DEBUG, "CPT filename has invalid modifiers! (%s)\n", file);
 				return_error (V_API, GMT_NOT_A_VALID_MODIFIER);
 			}
 			else
-				c = gmt_first_modifier (API->GMT, file, "iuU");
+				c = gmt_first_modifier (API->GMT, file, GMT_CPTFILE_MODIFIERS);
 			break;
 		default:	/* No checks for the other families */
 			break;

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -262,6 +262,25 @@ enum GMT_enum_basemap {
 /* Modifiers for contour -A option */
 #define GMT_CONTSPEC_MODS "acdefghijklLnNoprstuvwxX="
 
+/* Valid modifiers for various input files */
+
+/* Modifers for grid files:
+ * +o<offset>  adds this offset to all grid values
+ * +n<nodata> sets what the no-data value is
+ * +s<scl> scales all grid values by this scale
+ * +u<unit> converts Cartesian x/y coordinates from given unit to meters
+ * +U<unit> converts Cartesian x/y coordinates from meter to given unit
+ */
+#define GMT_GRIDFILE_MODIFIERS "onsuU"
+
+/* Modifiers for CPT files:
+ * +h<hinge> to override soft-hinge value in CPT
+ * +i<dz> is used to round auto-deteremined min/amax range to a multiple of dz.
+ * +u<unit> converts z-values from given unit to meters
+ * +U<unit> converts z-values from meter to given unit
+ */
+#define GMT_CPTFILE_MODIFIERS "hiuU"
+
 /*! Codes for grdtrack */
 enum GMT_enum_tracklayout {
 	GMT_LEFT_RIGHT = 1,

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -52,6 +52,7 @@ struct GMT_XINGS {
 EXTERN_MSC char *dlerror (void);
 #endif
 
+EXTERN_MSC char *gmtlib_valid_filemodifiers (struct GMT_CTRL *GMT);
 EXTERN_MSC int gmtlib_delete_virtualfile  (void *API, const char *string);
 EXTERN_MSC bool gmtlib_file_lock (struct GMT_CTRL *GMT, int fd);
 EXTERN_MSC bool gmtlib_file_unlock (struct GMT_CTRL *GMT, int fd);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -5170,7 +5170,7 @@ char *gmtlib_valid_filemodifiers (struct GMT_CTRL *GMT) {
 	 * We do this based on the individua modifier constants and assemble
 	 * one with the unique entries on the fly. */
 	char count[GMT_LEN128], *m = NULL;
-	char string[GMT_LEN16];
+	static char string[GMT_LEN16];
 	unsigned int k, q;
 	gmt_M_unused (GMT);
 	gmt_M_memset (count, GMT_LEN128, char);
@@ -5183,7 +5183,7 @@ char *gmtlib_valid_filemodifiers (struct GMT_CTRL *GMT) {
 	for (k = q = 0; k < GMT_LEN128; k++)
 		if (count[k]) string[q++] = k;
 	string[q] = '\0';
-	return (string);
+	return ((char *)string);
 }
 
 char *gmt_get_filename (struct GMTAPI_CTRL *API, const char* filename, const char *mods) {

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -5165,6 +5165,27 @@ char *gmt_strncpy (char *dest, const char *source, size_t num) {
 	return dest;
 }
 
+char *gmtlib_valid_filemodifiers (struct GMT_CTRL *GMT) {
+	/* Returns a single string with all unique valid file modifiers.
+	 * We do this based on the individua modifier constants and assemble
+	 * one with the unique entries on the fly. */
+	char count[GMT_LEN128], *m = NULL;
+	char string[GMT_LEN16];
+	unsigned int k, q;
+	gmt_M_unused (GMT);
+	gmt_M_memset (count, GMT_LEN128, char);
+	m = GMT_GRIDFILE_MODIFIERS;
+	for (k = 0; k < strlen (m); k++)
+		count[m[k]]++;
+	m = GMT_CPTFILE_MODIFIERS;
+	for (k = 0; k < strlen (m); k++)
+		count[m[k]]++;
+	for (k = q = 0; k < GMT_LEN128; k++)
+		if (count[k]) string[q++] = k;
+	string[q] = '\0';
+	return (string);
+}
+
 char *gmt_get_filename (struct GMTAPI_CTRL *API, const char* filename, const char *mods) {
 	/* Need to strip off any modifiers and netCDF specifications that may be part of filename */
 	char file[PATH_MAX] = {""}, *c = NULL, *clean_file = NULL;
@@ -5203,7 +5224,7 @@ int gmt_access (struct GMT_CTRL *GMT, const char* filename, int mode) {
 	if (gmt_file_is_cache (GMT->parent, filename))			/* Must be a cache file */
 		first = gmt_download_file_if_not_found (GMT, filename, 0);
 
-	if ((cleanfile = gmt_get_filename (GMT->parent, &filename[first], "honsuU")) == NULL) return (-1);	/* Likely not a valid filename */
+	if ((cleanfile = gmt_get_filename (GMT->parent, &filename[first], gmtlib_valid_filemodifiers (GMT))) == NULL) return (-1);	/* Likely not a valid filename */
 	strncpy (file, cleanfile, PATH_MAX-1);
 	gmt_M_str_free (cleanfile);
 	if (mode == W_OK)

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -957,7 +957,7 @@ int gmt_set_remote_and_local_filenames (struct GMT_CTRL *GMT, const char * file,
 	if (file[0] == '/')
 #endif
 	{
-		clean_file = gmt_get_filename (API, file, "honsuU");	/* Strip off any file modifier or netCDF directives */
+		clean_file = gmt_get_filename (API, file, gmtlib_valid_filemodifiers (GMT));	/* Strip off any file modifier or netCDF directives */
 		if (access (clean_file, F_OK)) {
 			GMT_Report (API, GMT_MSG_ERROR, "File %s was not found\n", file);
 			gmt_M_str_free (clean_file);
@@ -1007,7 +1007,7 @@ int gmt_set_remote_and_local_filenames (struct GMT_CTRL *GMT, const char * file,
 		}
 		else {	/* Must be cache file */
 			if (GMT->session.CACHEDIR == NULL) goto not_local;	/* Cannot have cache data if no cache directory created yet */
-			clean_file = gmt_get_filename (API, file, "honsuU");	/* Strip off any file modifier or netCDF directives */
+			clean_file = gmt_get_filename (API, file, gmtlib_valid_filemodifiers (GMT));	/* Strip off any file modifier or netCDF directives */
 			snprintf (local_path, PATH_MAX, "%s/%s", GMT->session.CACHEDIR, &clean_file[1]);	/* This is where all cache files live */
 			if ((c = strchr (local_path, '=')) || (c = strchr (local_path, '?'))) {
 				was = c[0];	c[0] = '\0';
@@ -1127,7 +1127,7 @@ not_local:	/* Get here if we failed to find a remote file already on disk */
 	/* Looking for local files given a relative path - must search directories we are allowed.
 	 * Note: Any netCDF files with directives have had those chopped off earlier, so file is a valid name */
 
-	clean_file = gmt_get_filename (API, file, "honsuU");	/* Strip off any file modifier or netCDF directives */
+	clean_file = gmt_get_filename (API, file, gmtlib_valid_filemodifiers (GMT));	/* Strip off any file modifier or netCDF directives */
 	if (gmt_getdatapath (GMT, clean_file, local_path, R_OK)) {	/* Found it */
 		/* Return full path */
 		if (c &&!is_query) {	/* We need to pass the ?var[]() or [id][+mods]stuff as part of the filename */


### PR DESCRIPTION
List them specifically in gmt_constants.h and use the macros instead of hard-coded strings in several places:

```
#define GMT_GRIDFILE_MODIFIERS "onsuU"
#define GMT_CPTFILE_MODIFIERS "hiuU"
```

Also, when all possible file modifiers are needed (say for _gmt_access_), make a unique string on the run from the established constants.