### PR TITLE
Ensure filter1d -T/min/max/inc does not end up with an incompatible range

### DIFF
--- a/src/filter1d.c
+++ b/src/filter1d.c
@@ -487,12 +487,14 @@ GMT_LOCAL int filter1d_set_up_filter (struct GMT_CTRL *GMT, struct FILTER1D_INFO
 	if (F->out_at_time) {
 		/* populate F->t_start and F->t_stop */
 		double	t_shift;
+		/* Here, F->T.seg == 1 means we were only given an increment, otherwise we got min/max/inc.
+		 * Thus, for the latter we want whatever stop we pick to be an integer steps of inc from min. */
 		if (F->T.set == 1 || F->t_start_t < t_0) /* Not set or user defined t_start_t outside bounds */
-			F->t_start = t_0;
+			F->t_start = (F->T.set == 1) ? floor (t_0 / F->t_int) * F->t_int : F->t_start_t + floor ((t_0 - F->t_start_t) / F->t_int) * F->t_int;
 		else
 			F->t_start = F->t_start_t;
 		if (F->T.set == 1 || F->t_stop_t > t_1) /* Not set or user defined t_stop_t outside bounds */
-			F->t_stop = t_1;
+			F->t_stop = (F->T.set == 1) ? ceil (t_1 / F->t_int) * F->t_int : F->t_stop_t - floor ((F->t_stop_t - t_1) / F->t_int) * F->t_int;
 		else
 			F->t_stop = F->t_stop_t;
 
@@ -503,12 +505,12 @@ GMT_LOCAL int filter1d_set_up_filter (struct GMT_CTRL *GMT, struct FILTER1D_INFO
 		}
 
 		/* align F->t_start and F->t_stop to F->t_int */
-		t_shift = F->t_int - fmod (F->t_start - F->t_start_t, F->t_int);
-		if ( fabs (t_shift - F->t_int) < GMT_CONV4_LIMIT ) t_shift = 0.0; /* avoid values close to F->t_int */
-		F->t_start += t_shift; /* make F->t_start - F->t_start_t an integral multiple of F->t_int */
-		t_shift = fmod (F->t_stop - F->t_start_t, F->t_int);
-		if ( fabs (t_shift - F->t_int) < GMT_CONV4_LIMIT ) t_shift = 0.0; /* avoid values close to F->t_int */
-		F->t_stop -= t_shift; /* make F->t_stop - F->t_start_t an integral multiple of F->t_int */
+		//t_shift = F->t_int - fmod (F->t_start - F->t_start_t, F->t_int);
+		//if ( fabs (t_shift - F->t_int) < GMT_CONV4_LIMIT ) t_shift = 0.0; /* avoid values close to F->t_int */
+		//F->t_start += t_shift; /* make F->t_start - F->t_start_t an integral multiple of F->t_int */
+		//t_shift = fmod (F->t_stop - F->t_start_t, F->t_int);
+		//if ( fabs (t_shift - F->t_int) < GMT_CONV4_LIMIT ) t_shift = 0.0; /* avoid values close to F->t_int */
+		//F->t_stop -= t_shift; /* make F->t_stop - F->t_start_t an integral multiple of F->t_int */
 	}
 	else {
 		if (F->use_ends) {

--- a/src/filter1d.c
+++ b/src/filter1d.c
@@ -486,8 +486,7 @@ GMT_LOCAL int filter1d_set_up_filter (struct GMT_CTRL *GMT, struct FILTER1D_INFO
 
 	if (F->out_at_time) {
 		/* populate F->t_start and F->t_stop */
-		double	t_shift;
-		/* Here, F->T.seg == 1 means we were only given an increment, otherwise we got min/max/inc.
+		/* Here, F->T.set == 1 means we were only given an increment, otherwise we got min/max/inc.
 		 * Thus, for the latter we want whatever stop we pick to be an integer steps of inc from min. */
 		if (F->T.set == 1 || F->t_start_t < t_0) /* Not set or user defined t_start_t outside bounds */
 			F->t_start = (F->T.set == 1) ? floor (t_0 / F->t_int) * F->t_int : F->t_start_t + floor ((t_0 - F->t_start_t) / F->t_int) * F->t_int;
@@ -503,14 +502,6 @@ GMT_LOCAL int filter1d_set_up_filter (struct GMT_CTRL *GMT, struct FILTER1D_INFO
 			F->t_start += F->half_width;
 			F->t_stop  -= F->half_width;
 		}
-
-		/* align F->t_start and F->t_stop to F->t_int */
-		//t_shift = F->t_int - fmod (F->t_start - F->t_start_t, F->t_int);
-		//if ( fabs (t_shift - F->t_int) < GMT_CONV4_LIMIT ) t_shift = 0.0; /* avoid values close to F->t_int */
-		//F->t_start += t_shift; /* make F->t_start - F->t_start_t an integral multiple of F->t_int */
-		//t_shift = fmod (F->t_stop - F->t_start_t, F->t_int);
-		//if ( fabs (t_shift - F->t_int) < GMT_CONV4_LIMIT ) t_shift = 0.0; /* avoid values close to F->t_int */
-		//F->t_stop -= t_shift; /* make F->t_stop - F->t_start_t an integral multiple of F->t_int */
 	}
 	else {
 		if (F->use_ends) {

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16856,7 +16856,8 @@ unsigned int gmt_create_array (struct GMT_CTRL *GMT, char option, struct GMT_ARR
 			nt = urint (range / inc);
 			new = nt * inc;
 			if (nt && !doubleAlmostEqualZero (new, range)) {	/* Must adjust inc to match proper range */
-				inc = range / (nt - 1);
+				//inc = range / (nt - 1);
+				inc = range / nt;
 				GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Range (max - min) is not a whole multiple of inc. Adjusted inc to %g\n", option, inc);
 			}
 		}

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16856,7 +16856,6 @@ unsigned int gmt_create_array (struct GMT_CTRL *GMT, char option, struct GMT_ARR
 			nt = urint (range / inc);
 			new = nt * inc;
 			if (nt && !doubleAlmostEqualZero (new, range)) {	/* Must adjust inc to match proper range */
-				//inc = range / (nt - 1);
 				inc = range / nt;
 				GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Range (max - min) is not a whole multiple of inc. Adjusted inc to %g\n", option, inc);
 			}


### PR DESCRIPTION
The min/max that the user specified gets adjusted by **filter1d** on a per segment basis since the data range may be less that the prescribed output interval.  However, these adjustments were not careful enough to ensure the new range remains an integer multiple of the increment.  This PR ensures that, and in the processes fixes a bug in the array creation for the case when there is minor round-off and an exact range is computed - it had a bug. Perhaps @Xiaohua-Eric-Xu can test this PR as well.