### PR TITLE
Strengthen parsing of grid and CPT filename modifiers

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -2114,7 +2114,7 @@ packed integer grids (=\ *ID*\ **+s**\ *a* is a shorthand for
 if you tend to use what *could* look like modifier-sequences to GMT (e.g., using
 filenames like data.grid+o4) you can prevent any confusion by using either the
 GMT-recommended ".grd" or ".nc" as grid file extensions (e.g., data.my+o4.grd).
-Since valid modifiers are *appended* to a file name,finding such an extension simplifies parsing.
+Since valid modifiers are *appended* to a file name, finding such an extension simplifies parsing.
 
 Note that the GMT netCDF and native binary grids store the grid scale and offset
 in the file, hence if you specify these attributes when writing a file then upon reading the grid

--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1025,6 +1025,12 @@ modifiers to your CPT names when used in GMT commands.  The **+u**\ *unit*
 modifier will scale z *from unit to* meters, while **+U**\ *unit* does
 the inverse (scale z *from meters to unit*).
 
+**Note**: Users are allowed to name their CPT files anything they want, but
+they are required to have the file extension ".cpt".  This allows us to prevent
+any confusion when parsing filenames that may have sequences that otherwise
+might look like a file *modifier* (e.g., data.my+u5.cpt). Since valid modifiers
+are *appended* to a file name, finding such an extension simplifies parsing.
+
 Since GMT supports several coordinate systems for color specification,
 many master (or user) CPTs will contain the special comment
 
@@ -2103,6 +2109,12 @@ NaN (not-a-number) you must append **+n**\ *invalid* modifier to file name.
 You may the scale as *a* for auto-adjusting the scale and/or offset of
 packed integer grids (=\ *ID*\ **+s**\ *a* is a shorthand for
 =\ *ID*\ **+s**\ *a*\ **+o**\ *a*).
+
+**Note**: Users are allowed to name their grid files anything they want.  However,
+if you tend to use what *could* look like modifier-sequences to GMT (e.g., using
+filenames like data.grid+o4) you can prevent any confusion by using either the
+GMT-recommended ".grd" or ".nc" as grid file extensions (e.g., data.my+o4.grd).
+Since valid modifiers are *appended* to a file name,finding such an extension simplifies parsing.
 
 Note that the GMT netCDF and native binary grids store the grid scale and offset
 in the file, hence if you specify these attributes when writing a file then upon reading the grid

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -8035,7 +8035,7 @@ void * GMT_Read_Data (void *V_API, unsigned int family, unsigned int method, uns
 		/* Must handle special case when a list of colors are given instead of a CPT name.  We make a temp CPT from the colors */
 		if (family == GMT_IS_PALETTE && !just_get_data) { /* CPTs must be handled differently since the master files live in share/cpt and filename is missing .cpt */
 			int c_err = 0;
-			char CPT_file[PATH_MAX] = {""}, *file = NULL;
+			char CPT_file[PATH_MAX] = {""}, *file = NULL, *m = NULL, *f = NULL;
 			if (input[0] == '@') first = gmt_download_file_if_not_found (API->GMT, input, 0);	/* Deal with downloadable CPTs */
 			file = strdup (&input[first]);
 			if ((c_err = gmtapi_colors2cpt (API, &file, &mode)) < 0) { /* Maybe converted colors to new CPT */
@@ -8047,16 +8047,24 @@ void * GMT_Read_Data (void *V_API, unsigned int family, unsigned int method, uns
 				size_t len = strlen (file), elen;
 				char *ext = (len > 4 && strstr (file, ".cpt")) ? "" : ".cpt", *q = NULL;
 				elen = strlen (ext);
-				if ((q = gmtlib_file_unitscale (file))) q[0] = '\0';    /* Truncate modifier */
-				else if ((q = strstr (file, "+h"))) q[0] = '\0';    /* Truncate +h modifier */
+				/* Need to check for CPT filename modifiers */
+				if ((f = gmt_strrstr (file, ".cpt")))
+					m = gmtlib_last_valid_file_modifier (API, f, GMT_CPTFILE_MODIFIERS);
+				else
+					m = gmtlib_last_valid_file_modifier (API, file, GMT_CPTFILE_MODIFIERS);
+
+				if (m) {	/* Got one or more valid CPT file modifiers */
+					if ((q = gmtlib_cptfile_unitscale (API, m))) q[0] = '\0';    /* Truncate modifier after processing the unit */
+					if (m[0] && (q = strstr (m, "+h"))) q[0] = '\0';    /* Truncate +h modifier (checking for m[0] since the line above could leave it blank) */
+				}
 				if (elen)	/* Master: Append extension and supply path */
 					gmt_getsharepath (API->GMT, "cpt", file, ext, CPT_file, R_OK);
 				else if (!gmt_getdatapath (API->GMT, file, CPT_file, R_OK)) {	/* Use name.cpt as is but look for it */
 					GMT_Report (API, GMT_MSG_ERROR, "GMT_Read_Data: File not found: %s\n", file);
 					gmt_M_str_free (input);
-					return_null (API, GMT_FILE_NOT_FOUND);	/* Failed to find the file anywyere */
+					return_null (API, GMT_FILE_NOT_FOUND);	/* Failed to find the file anywhere */
 				}
-				if (q) {q[0] = '+'; strncat (CPT_file, q, PATH_MAX-1);}	/* Add back the z-scale modifier */
+				if (m && q) {q[0] = '+'; strncat (CPT_file, q, PATH_MAX-1);}	/* Add back the z modifiers */
 			}
 			else	/* Got color list, now a temp CPT instead */
 				strncpy (CPT_file, file, PATH_MAX-1);

--- a/src/gmt_common_string.c
+++ b/src/gmt_common_string.c
@@ -34,6 +34,7 @@
  *  gmt_strlcmp             Compares strings (ignoring case) until first reaches null character
  *  gmt_strtok              Reiterant replacement of strtok
  *  gmt_strtok_m            A Matlab style strtok
+ *  gmt_strrstr				A strstr but for last occurrence
  *  gmt_dos_path_fix        Turn /c/dir/... paths into c:/dir/...
  *  str(n)casecmp           Case-insensitive string comparison functions
  *  strtok_r                Reentrant string tokenizer from Gnulib (LGPL)
@@ -229,6 +230,20 @@ void gmt_strtok_m (char *in, char **token, char **remain, char *sep) {
 			remain[0] = strdup(p);
 	}
 	free(p);
+}
+
+char *gmt_strrstr (const char *s, const char *m) {
+	/* Find last occurrence of m in s */
+    char *last = NULL;
+    size_t n = strlen(m);
+
+    while ((s = strchr(s, *m)) != NULL) {
+        if (!strncmp(s, m, n))
+            last = (char *)s;
+        if (*s++ == '\0')
+            break;
+    }
+    return last;
 }
 
 unsigned int gmt_get_modifier (const char *string, char modifier, char *token) {

--- a/src/gmt_common_string.h
+++ b/src/gmt_common_string.h
@@ -61,6 +61,7 @@ EXTERN_MSC void gmt_strrepc (char *string, int c, int r);
 EXTERN_MSC char *gmt_strrep(const char *s1, const char *s2, const char *s3);
 EXTERN_MSC size_t gmt_strlcmp (char *str1, char *str2);
 EXTERN_MSC char *gmt_strdup_noquote(const char *string);
+EXTERN_MSC char *gmt_strrstr (const char *s, const char *m);
 
 #ifdef WIN32
 EXTERN_MSC void gmt_dos_path_fix (char *dir);

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -274,7 +274,7 @@ enum GMT_enum_basemap {
 #define GMT_GRIDFILE_MODIFIERS "onsuU"
 
 /* Modifiers for CPT files:
- * +[h<hinge>] to override soft-hinge value in CPT
+ * +h[<hinge>] to override soft-hinge value in CPT
  * +i<dz> is used to round auto-determined min/max range to a multiple of dz.
  * +u<unit> converts z-values from given unit to meters
  * +U<unit> converts z-values from meter to given unit

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -264,7 +264,7 @@ enum GMT_enum_basemap {
 
 /* Valid modifiers for various input files */
 
-/* Modifers for grid files:
+/* Modifiers for grid files:
  * +o<offset>  adds this offset to all grid values
  * +n<nodata> sets what the no-data value is
  * +s<scl> scales all grid values by this scale
@@ -274,8 +274,8 @@ enum GMT_enum_basemap {
 #define GMT_GRIDFILE_MODIFIERS "onsuU"
 
 /* Modifiers for CPT files:
- * +h<hinge> to override soft-hinge value in CPT
- * +i<dz> is used to round auto-deteremined min/amax range to a multiple of dz.
+ * +[h<hinge>] to override soft-hinge value in CPT
+ * +i<dz> is used to round auto-determined min/max range to a multiple of dz.
  * +u<unit> converts z-values from given unit to meters
  * +U<unit> converts z-values from meter to given unit
  */

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -52,6 +52,7 @@ struct GMT_XINGS {
 EXTERN_MSC char *dlerror (void);
 #endif
 
+EXTERN_MSC char *gmtlib_last_valid_file_modifier (struct GMTAPI_CTRL *API, char* filename, const char *mods);
 EXTERN_MSC char *gmtlib_valid_filemodifiers (struct GMT_CTRL *GMT);
 EXTERN_MSC int gmtlib_delete_virtualfile  (void *API, const char *string);
 EXTERN_MSC bool gmtlib_file_lock (struct GMT_CTRL *GMT, int fd);

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -200,7 +200,7 @@ EXTERN_MSC void gmtlib_get_point_from_r_az (struct GMT_CTRL *GMT, double lon0, d
 EXTERN_MSC bool gmtlib_found_url_for_gdal (char *fname);
 EXTERN_MSC int64_t gmtlib_splitinteger (double value, int epsilon, double *doublepart);
 EXTERN_MSC bool gmtlib_is_gleap (int gyear);
-EXTERN_MSC char * gmtlib_file_unitscale (char *name);
+EXTERN_MSC char * gmtlib_cptfile_unitscale (struct GMTAPI_CTRL *API, char *name);
 EXTERN_MSC void gmtlib_set_oblique_pole_and_origin (struct GMT_CTRL *GMT, double plon, double plat, double olon, double olat);
 EXTERN_MSC int gmtlib_get_grdtype (struct GMT_CTRL *GMT, unsigned int direction, struct GMT_GRID_HEADER *h);
 EXTERN_MSC void gmtlib_grd_real_interleave (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_grdfloat *data);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -5176,34 +5176,57 @@ char *gmtlib_valid_filemodifiers (struct GMT_CTRL *GMT) {
 	gmt_M_memset (count, GMT_LEN128, char);
 	m = GMT_GRIDFILE_MODIFIERS;
 	for (k = 0; k < strlen (m); k++)
-		count[m[k]]++;
+		count[(int)m[k]]++;
 	m = GMT_CPTFILE_MODIFIERS;
 	for (k = 0; k < strlen (m); k++)
-		count[m[k]]++;
+		count[(int)m[k]]++;
 	for (k = q = 0; k < GMT_LEN128; k++)
 		if (count[k]) string[q++] = k;
 	string[q] = '\0';
 	return ((char *)string);
 }
 
+GMT_LOCAL char *gmtio_last_valid_file_modifier (struct GMTAPI_CTRL *API, char* filename, const char *mods) {
+	/* A filename make have sequences that could look like a GMT modifier but is actually just part
+	 * of the filename, e.g. My.File+o44.grd.  We do not want to catch such sequences as modifiers and
+	 * parse them.  The strategy we use is to start from the end of the filename and work backwards
+	 * until the first non-expected "modifier" is found, then return pointer to first actual modifier
+	 * found, or NULL.  Any modifier will be of the form +?[<arg>], where ? is a lower or upper-case
+	 * letter, and <arg> is optional. */
+	bool go = true;	/* Keep scanning backwards until we find an unrecognized modifier */
+	char *modifiers = NULL;	/* Pointer to the start of valid modifiers in this filename, or NULL */
+	size_t k = strlen (filename);	/* k will serve as the index of the current character in the filename string */
+	gmt_M_unused (API);
+
+	while (filename[k] != '+' && k) k--;	/* Wind back to last found plus sign */
+	if (k == 0 || filename[k+1] == '\0') go = false;	/* No modifiers found at all, or we found a single trailing + in the name (e.g., my.test+) */
+	while (go) {	/* Here, filename[k] == '+' and k > 0 */
+		if (isalpha (filename[k+1]) && strchr (mods, filename[k+1])) {	/* This is a valid file modifier */
+			modifiers = &filename[k];	/* Update the pointer the the current start of valid modifiers */
+			k--;	/* Step one back from the '+' character; k could become 0 if filename was just valid modifiers (...) */
+			while (filename[k] != '+' && k) k--;	/* Wind back to last found plus sign as long as we are not in first position */
+			if (k == 0) go = false;	/* Ran out of characters */
+		}
+		else	/* Not a valid modifier or just part of something like a positive number - stop our scanning */
+			go = false;
+	}
+	return (modifiers);	/* Pass out the start of the valid modifiers or NULL */
+}
+
 char *gmt_get_filename (struct GMTAPI_CTRL *API, const char* filename, const char *mods) {
-	/* Need to strip off any modifiers and netCDF specifications that may be part of filename */
+	/* Need to strip off any valid, trailing modifiers and netCDF specifications that may be part of filename */
 	char file[PATH_MAX] = {""}, *c = NULL, *clean_file = NULL;
 
-	if (strstr (filename, "/=tiled_"))	/* Special list with remote tiles, use as is */
+	if (strstr (filename, "/=tiled_"))	/* Special list with remote tiles, use exactly as is */
 		strncpy (file, filename, PATH_MAX-1);
-	else	/* Exclude netCDF3-D grid extensions to make sure we get a valid file name */
+	else	/* Strip off netCDF3-D grid extensions to make sure we get a valid file name */
 		sscanf (filename, "%[^=?]", file);
 	if (file[0] == '\0')
-		return NULL;		/* It happens for example when parsing grdmath args and it finds an isolated  "=" */
-	if (mods) {	/* Given modifiers to chop off */
-		if (gmt_validate_modifiers (API->GMT, file, '-', mods, GMT_MSG_DEBUG)) {
-			GMT_Report (API, GMT_MSG_DEBUG, "Filename has invalid modifiers - probably not a file with modifiers (%s)\n", file);
+		return NULL;	/* It happens for example when parsing grdmath args and it finds an isolated  "=" */
+	if (mods) {	/* Given modifiers to chop off if they are valid */
+		if ((c = gmtio_last_valid_file_modifier (API, file, mods)) == NULL)	/* Modifier free file name */
 			return (strdup (file));
-		}
-		/* See if we have any */
-		if ((c = gmt_first_modifier (API->GMT, file, mods)))
-			c[0] = '\0';	/* Begone with you */
+		c[0] = '\0';	/* Begone with you */
 	}
 	clean_file = strdup (file);
 

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -13366,23 +13366,23 @@ char *gmtlib_last_valid_file_modifier (struct GMTAPI_CTRL *API, char* filename, 
 				k++;
 				switch (modifiers[k]) {	/* The modifier code */
 					case 'h': case 'i': case 'o': case 'n': case 's':	/* +h[<hinge>], +i<inc>, ++o<offset>, +n<nodata>, +s<scale> */
-						k++;
+						k++;	/* Move to start of argument, next modifier, or NULL */
 						while (modifiers[k] && modifiers[k] != '+' && strchr ("-+.0123456789eE", modifiers[k])) k++;	/* Skip a numerical argument */
-						if (!(modifiers[k] == '\0' || modifiers[k] == '+')) error = true;
+						if (!(modifiers[k] == '\0' || modifiers[k] == '+')) error = true;	/* Means we found non-numbers after valid modifier */
 						break;
 					case 'u': case 'U':	/* +u<unit>, +U<unit */
-						k++;
-						if (strchr (GMT_LEN_UNITS2, modifiers[k]) == NULL)
-							error = true;
-						else
+						k++;	/* Move to start of argument, next modifier, or NULL */
+						if (modifiers[k] == '\0' || strchr (GMT_LEN_UNITS2, modifiers[k]) == NULL)
+							error = true;	/* Missing the unit argument */
+						else	/* Got valid unit */
 							k++;
 						break;
-					default:
+					default:	/* Modifier not from the global grid/CPT list */
 						error = true;
 						break;
 				}
 			}
-			else
+			else	/* Found some junk */
 				error = true;
 		}
 		if (error) {

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -1188,6 +1188,7 @@ GMT_LOCAL struct CPT_Z_SCALE *gmtsupport_cpt_parse (struct GMT_CTRL *GMT, char *
 	}
 
 	if (m == NULL || (c = gmtlib_cptfile_unitscale (GMT->parent, m)) == NULL) return NULL;	/* Did not find any +u|U modifiers */
+	/* Here, c is assigned */
 	mode = (c[1] == 'u') ? 0 : 1;
 	u_number = gmtlib_get_unit_number (GMT, c[2]);		/* Convert char unit to enumeration constant for this unit */
 	if (u_number == GMT_IS_NOUNIT) {

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -584,12 +584,17 @@ static int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct GMT
 				if (!(strstr (opt->arg, "+u") || strstr (opt->arg, "+p") || strchr (opt->arg, '/')))
 					n_errors += mapproject_old_L_parser (API, opt->arg, Ctrl);
 				else {
+					char *m = NULL;
 					if (gmt_validate_modifiers (GMT, opt->arg, 'L', "up", GMT_MSG_ERROR)) n_errors++;
-					Ctrl->L.file = gmt_get_filename (API, opt->arg, "up");
-					if (gmt_get_modifier (opt->arg, 'u', txt_a))
-						Ctrl->L.unit = mapproject_set_unit_and_mode (API, txt_a, &Ctrl->L.sph);
-					if (gmt_get_modifier (opt->arg, 'p', txt_a))
-						Ctrl->L.mode = GMT_MP_GIVE_FRAC;
+					if ((m = gmt_first_modifier (GMT, opt->arg, "up"))) {
+						if (gmt_get_modifier (m, 'u', txt_a))
+							Ctrl->L.unit = mapproject_set_unit_and_mode (API, txt_a, &Ctrl->L.sph);
+						if (gmt_get_modifier (m, 'p', txt_a))
+							Ctrl->L.mode = GMT_MP_GIVE_FRAC;
+						m[0] = '\0';	/* Chop off modifiers */
+					}
+					Ctrl->L.file = gmt_get_filename (API, opt->arg, NULL);
+					if (m) m[0] = '+';	/* Restore modifiers */
 				}
 				/* Check settings */
 				n_errors += gmt_M_check_condition (GMT, !strchr (GMT_LEN_UNITS "cC", (int)Ctrl->L.unit),


### PR DESCRIPTION
**Description of proposed changes**

Both grids and CPT files can take optional modifiers, such as specifying scaling and offsets (for grids) or setting a CPT hinge (for CPT files).  However, the detection of these modifiers in the filename-string was not very robust, and we tended to use more general-purpose modifier check-functions developed for other GMT (non-file) options.  While proper modifiers were always parsed correctly, the lax implementation resulted in several problems:

1. If the user's filename happened to contain a substring that looked like a possible modifier (e.g., junk+E44.grd) we would get inappropriate complaints about bad modifiers.  See #4341 for an example.
2. Worse, if a filename contained such a substring that actually matched a valid modifier, but it was never meant to and occured before the filename extension, then we _still_ parsed it, chopped of the rest, and then could not find the file.
3. Finally, the code had many places where ad-hoc fixes looking for specific modifiers were hard-wired in (e.g., strstr (file, "+h")) that make code maintenance difficult.
4. Our documentation on grids and CPT were unclear on how any of this worked.

This PR addresses all those issues, adds documentation to clarify that users's CPT files **must** end with extension .cpt (and hence we only check for modifiers after the extension) while for grid files we **recommend** the use of extensions .grd or .nc (likewise only process modifiers after any of those), but otherwise it is the user's responsibility to understand that gridfiles like my.data+o44 will have z offset by 44 even if the user meant it to stand for something else.. 
