### PR TITLE
gmt coast -E without -R needed more help

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13832,6 +13832,9 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 			if (!GMT->init.history[id]) id++;		/* No history for -RP, increment to -RG as fallback */
 			if (GMT->init.history[id]) {	/* There is history for -R so -R will be added below */
 				GMT_Report (API, GMT_MSG_DEBUG, "Given -E, found there is a grid or plot region already.\n");
+				if ((opt = GMT_Make_Option (API, 'R', GMT->init.history[id])) == NULL) return NULL;	/* Failure to make -R option */
+				if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append -R option */
+				GMT_Report (API, GMT_MSG_DEBUG, "Added -R%s for pscoast.\n", opt->arg);
 				add_R = false;
 			}
 		}


### PR DESCRIPTION
Turns out is there was a gmt.history file in the directory, then we should use that region and not just say we found it.  Fixes https://forum.generic-mapping-tools.org/t/coast-error-must-specify-r-option-in-documentation-example/960/2

This command runs fine if there is no gmt.history in the current directory:

`gmt coast -JM6i -Baf -EGB,IT,FR+gblue+p0.25p,red -EES,PT,GR+gyellow -pdf map`

However, if you run the classic version (which creates gmt.history) first:

`gmt pscoast -JM6i -Baf -EGB,IT,FR+gblue+p0.25p,red -EES,PT,GR+gyellow > map.ps`

then the modern mode command will complain of no **-R**.  This PR fixes that.
