### PR TITLE
Wrong verbose level for refreshing server table

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -606,7 +606,7 @@ GMT_LOCAL int gmtremote_get_url (struct GMT_CTRL *GMT, char *url, char *file, ch
 	time_t begin, end;
 
 	if (GMT->current.setting.auto_download == GMT_NO_DOWNLOAD) {  /* Not allowed to use remote copying */
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Remote download is currently deactivated\n");
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Remote download is currently deactivated\n");
 		return 1;
 	}
 	if (GMT->current.io.internet_error) return 1;   			/* Not able to use remote copying in this session */


### PR DESCRIPTION
GMT should quietly not do stuff if **GMT_AUTO_DOWNLOAD** setting is off.  However, if an actual remote data set is requested _then_ the error message should be thrown.  See the [forum](https://forum.generic-mapping-tools.org/t/gmt-auto-download-off-results-in-error-remote-download-is-currently-deactivated/956/3) for background.

**Description of proposed changes**

1. Use **GMT_MSG_INFORMATION** if refreshing the server tables cannot take place due to **GMT_AUTO_DOWNLOAD** is _off_
2. use **GMT_MSG_ERROR** if trying to access a file than needs to be downloaded if **GMT_AUTO_DOWNLOAD** is _off_
