### PR TITLE
Eliminate cpt extension requirement

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1026,7 +1026,7 @@ modifier will scale z *from unit to* meters, while **+U**\ *unit* does
 the inverse (scale z *from meters to unit*).
 
 **Note**: Users are allowed to name their CPT files anything they want, but
-they are required to have the file extension ".cpt".  This allows us to prevent
+we recommend the use of the file extension ".cpt".  This allows us to prevent
 any confusion when parsing filenames that may have sequences that otherwise
 might look like a file *modifier* (e.g., data.my+u5.cpt). Since valid modifiers
 are *appended* to a file name, finding such an extension simplifies parsing.

--- a/doc/rst/source/create_cpt.rst_
+++ b/doc/rst/source/create_cpt.rst_
@@ -1,5 +1,5 @@
 **-C**\ [*cpt*\|\ *master*\ [**+h**\ [*hinge*]][**+i**\ *zinc*][**+u**\|\ **U**\ *unit*] \|\ *color1,color2*\ [,\ *color3*\ ,...]]
-    Name of the CPT. If given a GMT Master soft-hinge CPT (see :ref:`Of Colors and Color Legends`) then
+    Name of a CPT file. If given a GMT Master soft-hinge CPT (see :ref:`Of Colors and Color Legends`) then
     you can enable the hinge at data value *hinge* [0] via **+h**, whereas for hard-hinge CPTs you
     can adjust the location of the hinge [0].  For other CPTs, you may convert their *z*-values
     from meter to another distance unit (append **+U**\ *unit*) or from another unit to meter (append **+u**\ *unit*),

--- a/doc/rst/source/use_cpt_grd.rst_
+++ b/doc/rst/source/use_cpt_grd.rst_
@@ -1,5 +1,5 @@
 **-C**\ [*cpt*\|\ *master*\ [**+h**\ [*hinge*]][**+i**\ *zinc*][**+u**\|\ **U**\ *unit*] \|\ *color1,color2*\ [,\ *color3*\ ,...]]
-    Name of the CPT. Alternatively, supply the name of a GMT color master
+    Name of a CPT file. Alternatively, supply the name of a GMT color master
     dynamic CPT [*turbo*, but we use *geo* for @earth_relief and *srtm* for @srtm_relief data] to
     automatically determine a continuous CPT from the grid's *z*-range; you may round the range
     to the nearest multiple of *zinc* by adding **+i**\ *zinc*. If given a GMT Master soft-hinge CPT

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -6482,8 +6482,8 @@ GMT_LOCAL int gmtapi_colors2cpt (struct GMTAPI_CTRL *API, char **str, unsigned i
 		/* Because gmtlib_is_color cannot uniquely determine what a single number is, check for that separately first. */
 		for (k = 0; gray && k < s_length; k++)
 			if (!isdigit ((*str)[k])) gray = false;	/* Not just a bunch of integers */
-		if (gray) {	/* Must also rule out temporary files like 14334.cpt since the ".cpt" is not present */
-			snprintf (tmp_file, GMT_LEN64, "%s.cpt", *str);	/* Try this as a filename */
+		if (gray) {	/* Must also rule out temporary files like 14334.cpt since the GMT_CPT_EXTENSION is not present */
+			snprintf (tmp_file, GMT_LEN64, "%s%s", *str, GMT_CPT_EXTENSION);	/* Try this as a filename */
 			if (!gmt_access (API->GMT, tmp_file, F_OK))
 				return 0;	/* Probably a process id temp file like 13223.cpt */
 		}
@@ -8044,11 +8044,11 @@ void * GMT_Read_Data (void *V_API, unsigned int family, unsigned int method, uns
 				return_null (API, GMT_CPT_READ_ERROR);	/* Failed in the conversion */
 			}
 			else if (c_err == 0) {	/* Regular cpt (master or local), append .cpt and set path */
-				size_t len = strlen (file), elen;
-				char *ext = (len > 4 && strstr (file, ".cpt")) ? "" : ".cpt", *q = NULL;
-				elen = strlen (ext);
+				bool is_cpt_master = gmt_is_cpt_master (API->GMT, file);
+				char *q = NULL;
+
 				/* Need to check for CPT filename modifiers */
-				if ((f = gmt_strrstr (file, ".cpt")))
+				if ((f = gmt_strrstr (file, GMT_CPT_EXTENSION)))
 					m = gmtlib_last_valid_file_modifier (API, f, GMT_CPTFILE_MODIFIERS);
 				else
 					m = gmtlib_last_valid_file_modifier (API, file, GMT_CPTFILE_MODIFIERS);
@@ -8057,8 +8057,8 @@ void * GMT_Read_Data (void *V_API, unsigned int family, unsigned int method, uns
 					if ((q = gmtlib_cptfile_unitscale (API, m))) q[0] = '\0';    /* Truncate modifier after processing the unit */
 					if (m[0] && (q = strstr (m, "+h"))) q[0] = '\0';    /* Truncate +h modifier (checking for m[0] since the line above could leave it blank) */
 				}
-				if (elen)	/* Master: Append extension and supply path */
-					gmt_getsharepath (API->GMT, "cpt", file, ext, CPT_file, R_OK);
+				if (is_cpt_master)	/* Master: Append extension and supply path */
+					gmt_getsharepath (API->GMT, "cpt", file, GMT_CPT_EXTENSION, CPT_file, R_OK);
 				else if (!gmt_getdatapath (API->GMT, file, CPT_file, R_OK)) {	/* Use name.cpt as is but look for it */
 					GMT_Report (API, GMT_MSG_ERROR, "GMT_Read_Data: File not found: %s\n", file);
 					gmt_M_str_free (input);
@@ -13846,7 +13846,7 @@ int GMT_Get_FilePath (void *V_API, unsigned int family, unsigned int direction, 
 			c = strstr (file, "=gd");	/* Got image=gd[+modifiers] */
 			break;
 		case GMT_IS_PALETTE:
-			if ((f = gmt_strrstr (file, ".cpt")))
+			if ((f = gmt_strrstr (file, GMT_CPT_EXTENSION)))
 				c = gmtlib_last_valid_file_modifier (API, f, GMT_CPTFILE_MODIFIERS);
 			else
 				c = gmtlib_last_valid_file_modifier (API, file, GMT_CPTFILE_MODIFIERS);

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -241,6 +241,9 @@ enum GMT_enum_basemap {
 
 /* Default CPT if nothing specified or overruled by remote dataset preferences */
 #define GMT_DEFAULT_CPT_NAME	"turbo"
+/* CPT extension is pretty fixed */
+#define GMT_CPT_EXTENSION	".cpt"
+#define GMT_CPT_EXTENSION_LEN	4U
 
 #define GMT_IS_ROMAN_LCASE	1	/* For converting Arabic numerals to Roman */
 #define GMT_IS_ROMAN_UCASE	2

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -5199,7 +5199,7 @@ char *gmt_get_filename (struct GMTAPI_CTRL *API, const char* filename, const cha
 	if (mods) {	/* Given modifiers to chop off if they are valid */
 		char *f = NULL;
 		/* If recognized file extension for grids (.grd, .nc) or cpt (.cpt) we must look after those */
-		if ((f = gmt_strrstr (file, ".grd")) || (f = gmt_strrstr (file, ".cpt")) || (f = gmt_strrstr (file, ".nc")))
+		if ((f = gmt_strrstr (file, ".grd")) || (f = gmt_strrstr (file, GMT_CPT_EXTENSION)) || (f = gmt_strrstr (file, ".nc")))
 			c = gmtlib_last_valid_file_modifier (API, f, mods);
 		else
 			c = gmtlib_last_valid_file_modifier (API, file, mods);

--- a/src/gmt_macros.h
+++ b/src/gmt_macros.h
@@ -154,8 +154,8 @@
 /* Determine if we should skip this CPT slice */
 #define gmt_M_skip_cptslice(P,index) ((index >= 0 && P->data[index].skip) || (index < 0 && P->bfn[index+3].skip))
 
-/* See if CPT modifiers was given (+u|U modifier) */
-#define gmt_M_cpt_mod(arg) ((arg) && ((arg)[0] =='+' && strchr ("uU", (arg)[1])))
+/* See if CPT modifiers was given (+h|i|u|U) */
+#define gmt_M_cpt_mod(arg) ((arg) && ((arg)[0] =='+' && strchr (GMT_CPTFILE_MODIFIERS, (arg)[1])))
 
 /* See if no CPT name was given (+u|U modifier may be present but not filename) */
 #define gmt_M_no_cpt_given(arg) (arg == NULL || arg[0] == '\0' || gmt_M_cpt_mod(arg))

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -396,6 +396,7 @@ EXTERN_MSC unsigned int gmt_check_language (struct GMT_CTRL *GMT, unsigned int m
 EXTERN_MSC bool gmt_script_is_classic (struct GMT_CTRL *GMT, FILE *fp);
 EXTERN_MSC int gmt_write_glue_function (struct GMTAPI_CTRL *API, char* library);
 EXTERN_MSC unsigned int gmt_polygon_orientation (struct GMT_CTRL *GMT, double x[], double y[], uint64_t n, int geo);
+EXTERN_MSC bool gmt_is_contour_table (struct GMT_CTRL *GMT, char *file);
 EXTERN_MSC struct GMT_CONTOUR_INFO * gmt_get_contours_from_table (struct GMT_CTRL *GMT, char *file, bool inner_ticks, unsigned int *type, unsigned int *n_contours);
 EXTERN_MSC int gmt_signum (double x);
 EXTERN_MSC void gmt_get_rgb_lookup (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, int index, double value, double *rgb);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -396,7 +396,7 @@ EXTERN_MSC unsigned int gmt_check_language (struct GMT_CTRL *GMT, unsigned int m
 EXTERN_MSC bool gmt_script_is_classic (struct GMT_CTRL *GMT, FILE *fp);
 EXTERN_MSC int gmt_write_glue_function (struct GMTAPI_CTRL *API, char* library);
 EXTERN_MSC unsigned int gmt_polygon_orientation (struct GMT_CTRL *GMT, double x[], double y[], uint64_t n, int geo);
-EXTERN_MSC bool gmt_is_contour_table (struct GMT_CTRL *GMT, char *file);
+EXTERN_MSC bool gmt_is_cpt_file (struct GMT_CTRL *GMT, char *file);
 EXTERN_MSC struct GMT_CONTOUR_INFO * gmt_get_contours_from_table (struct GMT_CTRL *GMT, char *file, bool inner_ticks, unsigned int *type, unsigned int *n_contours);
 EXTERN_MSC int gmt_signum (double x);
 EXTERN_MSC void gmt_get_rgb_lookup (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, int index, double value, double *rgb);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -396,7 +396,6 @@ EXTERN_MSC unsigned int gmt_check_language (struct GMT_CTRL *GMT, unsigned int m
 EXTERN_MSC bool gmt_script_is_classic (struct GMT_CTRL *GMT, FILE *fp);
 EXTERN_MSC int gmt_write_glue_function (struct GMTAPI_CTRL *API, char* library);
 EXTERN_MSC unsigned int gmt_polygon_orientation (struct GMT_CTRL *GMT, double x[], double y[], uint64_t n, int geo);
-EXTERN_MSC bool gmt_is_cpt_file (struct GMT_CTRL *GMT, char *file);
 EXTERN_MSC struct GMT_CONTOUR_INFO * gmt_get_contours_from_table (struct GMT_CTRL *GMT, char *file, bool inner_ticks, unsigned int *type, unsigned int *n_contours);
 EXTERN_MSC int gmt_signum (double x);
 EXTERN_MSC void gmt_get_rgb_lookup (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, int index, double value, double *rgb);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -9342,9 +9342,8 @@ unsigned int gmt_contour_C_arg_parsing (struct GMT_CTRL *GMT, char *arg, struct 
 		A->file = strdup (arg);
 	}
 	else if (!gmt_access (GMT, arg, R_OK) || gmt_file_is_cache (API, arg)) {	/* Gave a readable file (CPT or contourfile) */
-		size_t L = strlen(arg);
 		A->interval = 1.0;	/* This takes us past a check only */
-		A->cpt = (L > 4 && !strncmp (&arg[L-4], ".cpt", 4U)) ? true : false;	/* Extension determines if we got a CPT file */
+		A->cpt = gmt_is_cpt_file (GMT, arg);
 		gmt_M_str_free (A->file);
 		A->file = strdup (arg);
 	}
@@ -17024,18 +17023,16 @@ void gmt_extend_region (struct GMT_CTRL *GMT, double wesn[], unsigned int mode, 
 	}
 }
 
-bool gmt_is_contour_table (struct GMT_CTRL *GMT, char *file) {
+bool gmt_is_cpt_file (struct GMT_CTRL *GMT, char *file) {
 	/* Read a possible contour file looking for a non-commented record of the format
 	 *  cval [angle] C|A|c|a [pen]] records.
 	 * The deprecated format was cval C|A|c|a [angle [pen]].
-	 * If we do then we return true, else false [meaning it is likely a CPT file].
+	 * If we do then we return false, else true [meaning it is likely a CPT file].
 	 */
 	bool answer;
 	char type;
 	unsigned int save_coltype = GMT->current.io.col_type[GMT_IN][GMT_X];
 	struct GMT_DATASET *C = NULL;
-
-	if (file == NULL || file[0] == '\0') return false;	/* Not much we can do about this */
 
 	gmt_set_column (GMT, GMT_IN, GMT_X, GMT_IS_FLOAT);	/* Since x is likely longitude we must avoid 360 wrapping here */
 
@@ -17057,12 +17054,12 @@ bool gmt_is_contour_table (struct GMT_CTRL *GMT, char *file) {
 	gmt_set_column (GMT, GMT_IN, GMT_X, save_coltype);	/* Reset column type to what is was before */
 
 	if (strchr ("AaCc", type) == NULL) {	/* If we find a recognized contour type then we return true */
-		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "File %s determined to not be a contour information file\n", file);
-		answer = false;
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "File %s determined to be a CPT file\n", file);
+		answer = true;
 	}
 	else {
-		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "File %s determined to be a contour information file\n", file);
-		answer = true;
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "File %s determined tobe a contour information file\n", file);
+		answer = false;
 	}
 	return (answer);	/* If we find a recognized contour type then we return true */
 }

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7942,7 +7942,10 @@ bool gmt_is_cpt_master (struct GMT_CTRL *GMT, char *cpt) {
 		c = gmtlib_last_valid_file_modifier (GMT->parent, cpt, GMT_CPTFILE_MODIFIERS);
 	if (c && (f = gmt_first_modifier (GMT, c, GMT_CPTFILE_MODIFIERS)))
 		f[0] = '\0';	/* Must chop off modifiers for further checks to work */
-	if (gmtsupport_cpt_master_index (GMT, cpt)) return true;
+	if (gmtsupport_cpt_master_index (GMT, cpt)) {
+		if (c && f) f[0] = '+';	/* Restore modifier before we return */
+		return true;
+	}
 	if (cpt[0] && !gmt_access (GMT, cpt, R_OK)) return false;	/* A CPT was given and exists */
 	return false;	/* Well, what can we do at this point */
 }

--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -498,10 +498,7 @@ EXTERN_MSC int GMT_grd2cpt (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the grd2cpt main code ----------------------------*/
 
-	if (Ctrl->C.active) {
-		if (Ctrl->C.file[0] != '@' && (l = strstr (Ctrl->C.file, ".cpt")) != NULL) *l = 0;	/* Strip off .cpt if used */
-	}
-	else {	/* No table specified; set GMT_DEFAULT_CPT_NAME table */
+	if (!Ctrl->C.active) {	/* No table specified; set GMT_DEFAULT_CPT_NAME table */
 		Ctrl->C.active = true;
 		Ctrl->C.file = strdup (GMT_DEFAULT_CPT_NAME);
 	}

--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -463,7 +463,7 @@ EXTERN_MSC int GMT_grd2cpt (void *V_API, int mode, void *args) {
 	size_t n_alloc = GMT_TINY_CHUNK;
 	bool write = false, interpolate = true;
 
-	char format[GMT_BUFSIZ] = {""}, *l = NULL, **grdfile = NULL;
+	char format[GMT_BUFSIZ] = {""}, **grdfile = NULL;
 
 	double *z = NULL, wesn[4], mean, sd, wsum = 0.0, scale;
 

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -898,7 +898,7 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 
 		if (gmt_M_file_is_memory (optN->arg))	/* Got cpt via a memory object */
 			strncpy (cptfile, optN->arg, PATH_MAX-1);
-		else if ((L = strlen (optN->arg)) >= 4 && !strncmp (&optN->arg[L-4], ".cpt", 4U)) {	/* Gave a cpt argument, check that it is valid */
+		else if ((L = strlen (optN->arg)) >= 4 && !strncmp (&optN->arg[L-4], GMT_CPT_EXTENSION, GMT_CPT_EXTENSION_LEN)) {	/* Gave a cpt argument, check that it is valid */
 			if (!gmt_file_is_cache (API, optN->arg) && gmt_access (API->GMT, optN->arg, R_OK)) {
 				GMT_Report (API, GMT_MSG_ERROR, "Option -N: CPT file %s not found\n", optN->arg);
 				bailout (GMT_PARSE_ERROR);
@@ -933,7 +933,7 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 						strcpy (cptfile, opt->arg);
 						got_C_cpt = true;
 					}
-					else if ((L = strlen (opt->arg)) >= 4 && !strncmp (&opt->arg[L-4], ".cpt", 4U)) {	/* Gave a -C<cpt> argument, check that it is valid */
+					else if ((L = strlen (opt->arg)) >= 4 && !strncmp (&opt->arg[L-4], GMT_CPT_EXTENSION, GMT_CPT_EXTENSION_LEN)) {	/* Gave a -C<cpt> argument, check that it is valid */
 						if (!gmt_file_is_cache (API, opt->arg) && gmt_access (API->GMT, opt->arg, R_OK)) {
 							GMT_Report (API, GMT_MSG_ERROR, "Option -C: CPT file %s not found\n", opt->arg);
 							bailout (GMT_PARSE_ERROR);

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -381,7 +381,7 @@ EXTERN_MSC int GMT_makecpt (void *V_API, int mode, void *args) {
 
 	double *z = NULL;
 
-	char *l = NULL, *kind[2] = {"discrete", "continuous"};
+	char *kind[2] = {"discrete", "continuous"};
 
 	struct MAKECPT_CTRL *Ctrl = NULL;
 	struct GMT_PALETTE *Pin = NULL, *Pout = NULL;

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -406,10 +406,7 @@ EXTERN_MSC int GMT_makecpt (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the makecpt main code ----------------------------*/
 
-	if (Ctrl->C.active) {
-		if (Ctrl->C.file[0] != '@' && (l = strstr (Ctrl->C.file, ".cpt"))) *l = 0;	/* Strip off .cpt if used */
-	}
-	else {	/* No table specified; set default table */
+	if (!Ctrl->C.active) {	/* No table specified; set default table */
 		Ctrl->C.active = true;
 		Ctrl->C.file = strdup (GMT_DEFAULT_CPT_NAME);
 	}

--- a/src/psrose.c
+++ b/src/psrose.c
@@ -252,7 +252,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSROSE_CTRL *Ctrl, struct GMT_OPT
 				break;
 			case 'C':
 				if (gmt_M_compat_check (GMT, 5)) {	/* Need to check for deprecated -Cm|[+w]<modefile> option */
-					if (((c = strstr (opt->arg, "+w")) || (opt->arg[0] == 'm' && opt->arg[1] == '\0') || opt->arg[0] == '\0') && strstr (opt->arg, ".cpt") == NULL) {
+					if (((c = strstr (opt->arg, "+w")) || (opt->arg[0] == 'm' && opt->arg[1] == '\0') || opt->arg[0] == '\0') && strstr (opt->arg, GMT_CPT_EXTENSION) == NULL) {
 						GMT_Report (API, GMT_MSG_COMPAT, "Option -C for mode-vector(s) is deprecated; use -E instead.\n");
 						Ctrl->E.active = true;
 						if ((c = strstr (opt->arg, "+w"))) {	/* Wants to write out mean direction */

--- a/test/spotter/spotter_12.sh
+++ b/test/spotter/spotter_12.sh
@@ -24,7 +24,7 @@ gmt backtracker suiko.txt -Db -ED2012x.txt > start_at_ridge.txt
 gmt backtracker loihi.txt -Df -ED2012x.txt > end_of_flow.txt
 #
 gmt pscoast -R150/220/00/65 -JM7i -P -K -G30/120/30 -A500 -Dl -W0.25p -B20 -BWSne -Xc > $ps
-gmt psxy -R -J -O -K -Sc0.1i -Cdrift D2012_HI_drift.txt >> $ps
+gmt psxy -R -J -O -K -Sc0.1i -Cdrift.cpt D2012_HI_drift.txt >> $ps
 gmt psxy -R -J -O -K -Sc0.1i -Gred -W0.5p loihi.txt >> $ps
 # Task 1: [OK]
 gmt backtracker loihi.txt -Df -Lb1 -ED2012x.txt -FD2012_HI_drift.txt | gmt psxy -R -J -O -K -W1p >> $ps


### PR DESCRIPTION
**Description of proposed changes**

While the ".cpt" extension is _recommended_ for all user-generated CPT tables, we had several instances were it had become **required**:

1. In **grdcontour** and **pscontour**, the **-C**_file_ option may take either a CPT file or a contour listing file.  We were lazy and looked for the file extension ".cpt" to tell the two apart, thus basically imposing a requirement.
2. When detecting master CPT tables (i.e., when just the name of a master table is given, such as _turbo_) we were lazy and only checked if the argument could be found as a file, otherwise we decided it is a master table.
3. In multiple places we stripped off any ".cpt" arguments from a file argument and then we added it back later, again imposing a requirement for all CPT files to have that extension.

This PR fixes all of this.  Here are the highlights:

- As for grid file names, we now very carefully determine if there are CPT-file specific modifiers in play (e.g., **+h** for hinge) and strip these off from the back for the name.  As for grids, if you do use the recommended .cpt extension then you can enjoy using CPT names like My_+h77_file.cpt and have the +h77 not be interpreted as a modifier.
- We detect master tables by comparing the argument with our internal list of all master CPTs.
- In **grdcontour** and **pscontour**, we determine uniquely if the file is a contour list or a CPT file by examining the contents.
- One test script (spotter_12.sh) violated our rules (it created a CPT called drift.cpt but then left off the extension in use, i.e., **-C**drift). That is an error that is now caught.

All tests pass and @anbj type of commands like

`gmt grdimage @earth_relief_10m -C<(gmt makecpt -Cjet -T-1000/0/100) -JM15c -RNO -pdf map`

works for me.
 