### PR TITLE
Let mapproject -I work for non-geographic transformations

### DIFF
--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -1167,6 +1167,10 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 		gmt_set_geographic (GMT, GMT_OUT);
 		gmt_set_column (GMT, GMT_IO, GMT_Z, GMT_IS_FLOAT);
 	}
+	else if (!gmt_M_is_geographic (GMT, GMT_IN) && Ctrl->I.active) {	/* Must swap what the in and out types are for non-gepgraphic transformations (like absolute time) */
+		gmt_M_uint_swap (GMT->current.io.col_type[GMT_IN][GMT_X], GMT->current.io.col_type[GMT_OUT][GMT_X]);
+		gmt_M_uint_swap (GMT->current.io.col_type[GMT_IN][GMT_Y], GMT->current.io.col_type[GMT_OUT][GMT_Y]);
+	}
 	else if (gmt_M_is_geographic (GMT, GMT_OUT)) {
 		GMT_Report (API, GMT_MSG_INFORMATION, "Override -fog for normal operation\n");
 		gmt_set_cartesian (GMT, GMT_OUT);


### PR DESCRIPTION
See #4374  for context. The forward/inverse projection worked for regular Cartesian data but if we used **absolute time** then it failed because the input columns were assumed to be **GMT_IS_ABSTIME** even though **-I** was set.  In that case we must swap input and output types (which we did for map projections).

Now this works fine:

```
echo 1984-09-10T12:00 0.5 | gmt mapproject -R1984-09-10T/1984-09-11T/0/1 -JX20cT/10c | gmt mapproject -R1984-09-10T/1984-09-11T/0/1 -JX20cT/10c -I
1984-09-10T12:00:00	0.5
```
