### PR TITLE
Do not double-project when -G+uC is selected

### DIFF
--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -9575,8 +9575,8 @@ unsigned int gmt_init_distaz (struct GMT_CTRL *GMT, char unit, unsigned int mode
 			else
 				err = gmtmap_set_distaz (GMT, GMT_CARTESIAN_DIST, type, "");
 			break;
-		case 'C':	/* Cartesian distances (in PROJ_LENGTH_UNIT) after first projecting input coordinates with -J */
-			err = gmtmap_set_distaz (GMT, GMT_CARTESIAN_DIST_PROJ, type, "");
+		case 'C':	/* Cartesian distances (in PROJ_LENGTH_UNIT) after first projecting input coordinates with -J is still just GMT_CARTESIAN_DIST */
+			err = gmtmap_set_distaz (GMT, GMT_CARTESIAN_DIST, type, "");
 			proj_type = GMT_GEO2CART;
 			break;
 
@@ -9594,7 +9594,7 @@ unsigned int gmt_init_distaz (struct GMT_CTRL *GMT, char unit, unsigned int mode
 		case 'S':	/* Spherical cosine distances (for various gridding functions) */
 			err = gmtmap_set_distaz (GMT, GMT_DIST_COS + mode, type, "");
 			break;
-		case 'P':	/* Spherical distances after first inversily projecting Cartesian coordinates with -J */
+		case 'P':	/* Spherical distances after first inversely projecting Cartesian coordinates with -J */
 			err = gmtmap_set_distaz (GMT, GMT_CARTESIAN_DIST_PROJ_INV, type, "");
 			proj_type = GMT_CART2GEO;
 			break;


### PR DESCRIPTION
We recently decided that **mapproject -R -J** shall project its input coordinates on output.  This was not always done before when **-G** was used but now it is done consistently.  However, the **-G+uC** modifier to get distances in projected units set up a special _hypot_ call that first converted its args via **-R -J**, thus (now) doing it twice.  The fix is to let both **+uc** (Cartesian input) and **+uC** (projected input) both use regular hypot stuff to get the distances, and the fact that the input coordinates have been projected or not takes care of getting the units and results correct.
All tests pass.
