### PR TITLE
Let psconvert -H0 mean no subpixeling

### DIFF
--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -842,8 +842,8 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *Ctrl, struct GMT_
 		}
 	}
 
-	if (Ctrl->H.active && Ctrl->H.factor <= 0) {	/* Allow -H0 (or bad negative factors) to mean the same as giving no -H */
-			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Selecting -H0 turns off sub-pixeling\n");
+	if (Ctrl->H.active && Ctrl->H.factor <= 1) {	/* Allow -H1 (or zero or bad negative factors) to mean the same as giving no -H */
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Selecting -H1 or less turns off sub-pixeling\n");
 			Ctrl->H.active = false;
 	}
 

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -573,7 +573,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 #else
 	GMT_Message (API, GMT_TIME_NONE, "\t   (e.g., -G/some/unusual/dir/bin/gs).\n");
 #endif
-	GMT_Message (API, GMT_TIME_NONE, "\t-H Temporarily increase dpi by <factor>, rasterize, then downsample [no downsampling].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-H Temporarily increase dpi by integer <factor>, rasterize, then downsample [no downsampling].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Used to improve raster image quality, especially for lower raster resolutions.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Ghostscript versions >= 9.00 change gray-shades by using ICC profiles.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   GS 9.05 and above provide the '-dUseFastColor=true' option to prevent that\n");
@@ -840,6 +840,11 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *Ctrl, struct GMT_
 				n_errors += gmt_default_error (GMT, opt->option);
 				break;
 		}
+	}
+
+	if (Ctrl->H.active && Ctrl->H.factor <= 0) {	/* Allow -H0 (or bad negative factors) to mean the same as giving no -H */
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Selecting -H0 turns off sub-pixeling\n");
+			Ctrl->H.active = false;
 	}
 
 	if (!Ctrl->T.active) Ctrl->T.device = GS_DEV_JPG;	/* Default output device if none is specified */


### PR DESCRIPTION
Same as not giving **-H**, but helpful if you are scripting what factors to pass as passing `-H${factor}` with _factor_ = 0 should not cause a crash.

