### PR TITLE
Fix macOS CI by disable homebrew update

### DIFF
--- a/ci/install-dependencies-macos.sh
+++ b/ci/install-dependencies-macos.sh
@@ -39,7 +39,7 @@ brew untap homebrew/cask-versions homebrew/cask homebrew/bundle \
 brew uninstall php
 
 # Install GMT dependencies
-brew update
+#brew update
 brew install ${packages}
 
 if [ "$BUILD_DOCS" = "true" ]; then


### PR DESCRIPTION
**Description of proposed changes**

Disable `brew update` to temporarily fix the macOS CI failures.
