### PR TITLE
Add a quick link to character escape sequences

### DIFF
--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -20,6 +20,7 @@ Quick links
    - :doc:`Built-in CPTs </cookbook/cpts>`
    - :doc:`Built-in patterns </cookbook/predefined-patterns>`
    - :doc:`Octal Codes of Characters </cookbook/octal-codes>`
+   - :ref:`Character Escape Sequences <Char-esc-seq>`
    - :ref:`Pen Syntax <-Wpen_attrib>`
    - :ref:`Fill Syntax <-Gfill_attrib>`
    - :ref:`Grid Format Specifications <tbl-grdformats>`


### PR DESCRIPTION
**Description of proposed changes**

![image](https://user-images.githubusercontent.com/3974108/97751583-e7393700-1ac8-11eb-9324-758c3728b7a3.png)


Add a link to https://docs.generic-mapping-tools.org/latest/cookbook/features.html#character-escape-sequences