### PR TITLE
Add note about how to handle +sequences inside text labels and titles

### DIFF
--- a/doc/rst/source/events_common.rst_
+++ b/doc/rst/source/events_common.rst_
@@ -61,7 +61,7 @@ Optional Arguments
     This way you can plot "lines" that can have variable pen color and fixed or variable pen width as well as
     taking advantage of the full machinery of **-Es** and **-Et** and all the effects controlled by **-M** for symbols.
     The *dpu* must match the intended dpu when running :doc:`movie`. Note *dpu* means pixels per cm if you are using
-    SI units and pixels per inch if you are using US units (hence it depends on your :term:`PROJ_ENGTH_UNIT` setting).
+    SI units and pixels per inch if you are using US units (hence it depends on your :term:`PROJ_LENGTH_UNIT` setting).
     Alternatively, append **c** or **i** to set the unit used explicitly.
 
 .. _-B:

--- a/doc/rst/source/explain_-B_full.rst_
+++ b/doc/rst/source/explain_-B_full.rst_
@@ -68,6 +68,10 @@
     specify annotations normal [Default] and parallel to the axis, respectively. Note that
     these defaults can be changed via :term:`MAP_ANNOT_ORTHO`. Geographic axes can
     take **+f** which will give fancy annotations with W|E|S|N suffices encoding the sign.
+    **Note**: Text items such as *title*, *label* and *seclabel* are seen by GMT as part of
+    a long string containing everything passed to **-B**. Therefore, they cannot contain substrings
+    that looks like other modifiers.  If you need to embed such sequences (e.g., **+t**\ "Solving a+b=c")
+    you need to replace those + symbols with their octal equivalent \\053, (e.g., **+t**\ "Solving a\\053b=c").
 
     The *intervals* specification is a concatenated string made up of substrings
     of the form


### PR DESCRIPTION
See #4397 for context.  This PR makes this solution clear in the **-B** documentation.
