### PR TITLE
Link docs to the master branch

### DIFF
--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -28,9 +28,6 @@ copyright = "@GMT_VERSION_YEAR@, The GMT Team."
 version = '@GMT_PACKAGE_VERSION_MAJOR@.@GMT_PACKAGE_VERSION_MINOR@'
 # The full version shown in the page title
 release = '@GMT_PACKAGE_VERSION@'
-# Make the "Edit on GitHub" button link to the correct branch
-# Default to master branch if Azure Pipelines environmental variable BUILD_SOURCEBRANCHNAME is not defined
-github_version = os.getenv("BUILD_SOURCEBRANCHNAME", 'master')
 
 # -- Options for HTML output ---------------------------------------------------
 html_theme = 'rtd'
@@ -63,7 +60,7 @@ html_context = {
     "display_github": True,
     "github_user": "GenericMappingTools",
     "github_repo": "gmt",
-    "github_version": github_version,
+    "github_version": "master",
     "theme_vcs_pageview_mode": "edit",
     "conf_py_path": "/doc/rst/source/",
     # Enable versions switch on Azure Pipelines.


### PR DESCRIPTION
Currently, the "Edit On GitHub" button in the documentation is linked to different
branches for different documentation versions. For example, the v6.1 and
dev documentation is linked to the 6.1 and master branches, respectively.

It doesn't work as we expect.

1. We no longer make changes to the 6.1 branch. However, the default
   branch is still 6.1 branch if users make edits to the documentation
   by clicking the "Edit On GitHub" button (see #4402).
2. We decided that, every PR should be merged into master branch, and
   then backported to 6.x branches if necessary.

Thus, the "Edit On GitHub" button should always link to the master
branch.