### PR TITLE
Add execinfo library under FreeBSD

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -301,6 +301,11 @@ if (GMT_USE_THREADS AND NOT GLIB_FOUND)
 		CACHE INTERNAL "GTHREAD config message")
 endif (GMT_USE_THREADS AND NOT GLIB_FOUND)
 
+# FreeBSD uses a separate library for backtracking
+if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+	find_library (EXECINFO_LIBRARY NAMES execinfo)
+	list (APPEND GMT_OPTIONAL_LIBRARIES ${EXECINFO_LIBRARY})
+endif (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
 
 ##
 ##	Find pre-downloaded/pre-installed GSHHG and DCW data


### PR DESCRIPTION
Hopefully the inclusion of this extra library for FreeBSD will build GMT on FreeBSD including the back-tracing functionality.  We hope this branch will work for @anbj - please give it a try and let us know if there are errors/warnings since we are doing this a bit blindly based on Google search results.  Closes #4396.

