### PR TITLE
Turn off anti-aliasing when plotting categorical grids

### DIFF
--- a/test/sph/sph_5.ps
+++ b/test/sph/sph_5.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.2.0_7805261_2020.10.11 [64-bit] Document from grdimage
+%%Title: GMT v6.2.0_3ddcf0e-dirty_2020.11.03 [64-bit] Document from grdimage
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Oct 11 17:14:29 2020
+%%CreationDate: Tue Nov  3 12:29:19 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -669,7 +669,7 @@ O0
 1200 900 TM
 
 % PostScript produced by:
-%@GMT: gmt grdimage n.nc -Ct.cpt -R0/360/-90/0 -JA0/-90/6i -Baf -P -K -nn -Y0.75i
+%@GMT: gmt grdimage n.nc -Ct.cpt -R0/360/-90/0 -JA0/-90/6i -Baf -P -K -nn+a -Y0.75i
 %@PROJ: laea 0.00000000 360.00000000 -90.00000000 0.00000000 -9009964.761 9009964.761 -9009964.761 9009964.761 +proj=laea +lat_0=-90 +lon_0=0 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %GMTBoundingBox: 72 54 432 432
 %%BeginObject PSL_Layer_1
@@ -904,74 +904,62 @@ clipsave
 -118 2 D
 P
 PSL_clip N
-V N -5 -20 T 7210 7240 scale [/Indexed /DeviceRGB 51 <
-808080990000FF0000FFDD66FF0077FF8800AABB77FFAA779977990088CC223366FF5555006600FF99AA00BB880000FF
-7700990055669911EEAA5544AA1144000066DD66EEBB0099FFDD00BB99888866FF44110077449922330088DDFF9999FF
-AA550055444455887777660099FF440044BB0011BBDDFF00DDCCFFCC990000BB22DDFF77BBFFDDBB558866004488AA00
-00FF00FF11FF88FF9900FFFF>] setcolorspace
+V N -5 -20 T 7210 7240 scale [/Indexed /DeviceRGB 39 <
+808080FF0000FF0077990000FF8800223366FF55550000FF770099DD66EEFFDD008866FFAA55449999FF554444558877
+005566776600AABB77CC990000BB229911EE77449944110000FF00DDFF77006600FF99AABBFFDD0044BBFFAA7700FFFF
+BB998888FF9966004488DDFFDDCCFFAA55000011BB99FF44>] setcolorspace
 << /ImageType 1 /Decode [0 255] /Width 721 /Height 181 /BitsPerComponent 8
    /ImageMatrix [721 0 0 -181 0 181] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
 >> image
-G[BdmCNnLB(4bAj8I-\s1mae?Jq4J*-6YB@L\^uMmFVVp0="nUQ=Lm26D9r-+"$2SHT$W/PERU8p!Wa2WGp`XF`fRuQhW2t
-Y:lenB?A&*YMZBb#J\Go1:lRB`LWRnc3^X[oUjsiPsf"+<ERO*3$kQDd>uk$,S="P:B*\GZ^nXoft$=%mQ.GjVbV`@c":CE
-=`:#NUT:5R9V^llrli5`8%%P,l3b;49a&ojEiPaeH$qE[8>;HQ/$.%e&P`3V*H9ltEaB:"d7`0CBP/%l:q[ihhF09/'3O[-
-LKbL(#FpXFbq*/_)ifI?5'ip7ga7fhO-D-V@5O=OVtu9_ZT*9i].?I(F-0DOLn;Kg"BQSRV<Ac-C.ENf&QOk0GtI0.,?`QR
-%].>k10`G`HsaU8-+q28fec<,?cVnh2nS6Zn(&fI9QW[.M@nOa^8aT:XaGA&g;W<!mohMf=YDh;/m0H#&ig_/e9lR4jIA%h
-^&CK=jcR`TdD9r?,HoPp95^$kidZ$`aDD[b\g<U6UI4B?,HgTnWEpjsAj_KF59lBbUZ4K!#V/>+N?X.c]/\>IPI8!pTXnW=
-N3$LLdQ@SFg@4aa`Cq'0"a-_h'2_bc9\,5ClD9!l_Et'G<cm,P*D'7e/DBBQj"NiAR/(%]T3$/4pZb2\#c"NcfFK`hb'gHA
-p%JQ9C@uZ?e"C(</K8^$;.fP>84;0f!$"m)<M:neU:u*T:1PmPn[3tL6);b,pM(.mpOnhV#_rs_`JC]qj>cN3$.Y$2q2-Rn
-)^]clS;BM<3229B;mV,Zgh=gF8=H^fX^2@0S7o8_ZHA;&$]Vp![Y\RT8=I!nBrqjd2-Ha]U;]Z6m7<\T8>V<'URRp`+i4Qu
-5cYJd)j)q+O[e(G!,Br>O[,Cu6u*Ak?P,PI[1bE+V$NaM8>4!.R_K-"bD8qr&QX_[fo6!cO.c<,fXZtY"VPg?8,V^Dr2`E2
-Hq*7'8!k3U]L%:tG%Aor`6;j^c?VgX_2,/)M"Fi1e2`MUq2;o]LgW(QH'RM2oCmu&GG'j+0@(54Bgg99"O;"2I<+I'U?4$o
-jt-WbMr6UP\2eDH2n@[c4cOAS2G59/rZZ(u,-g]pSq@<=X7!9VF7nR_l]F>gm68a+he(lFoD*V`BJQ4;cgR(pq#5_/*3DWe
-S46h]OZY!'4"#k*M^"LfIG53<ogGB_NAoY]kK1&9mDR:M,ZY\sEtc[%>ieYVbk@.`!Na`0j!,FBBtTkup[_S0M4T>jX=SDT
-..V#WWQ&&Cl<:c,c`Zr=E+P*bqW-2*<4HfKctXh,(9qop$+(L/eL]$-hLfUg@:B,TI3[0C[r`ir)rAN[<^]t,_/g85[*[=F
-<3D*Pf''@UOgN\!h+a=b9k%[r4'*$6\f%Zn)NdY0"sqNC8S;dm1l2rh^AH0>fXZl!en[knm6idj&p$fgZV7F]ch(\OOKlL0
-8UfJhDe/g,L&E?M2C"='9n/U<`%[$aC6r4r!u&@b^PrduZPI6m^,8Pc08X2p8>THQ-#Y$#R`RGU,'"_CcQ/-SA0S%bV%_U?
-D3Cl*".%D,W(%M[Z_.<<oOe;+Y:O>PSp0l):Z&q]qqkk=hajbFKN#4S/>nV.ogj'T@cfI5WnnpA_),o`(\V^@SEL;(Slu^b
-pCU?Ce>MnNjNM*:<@o;_POYa&;rW-[`'&+3rgYl-R<OcmKa]X_KsZ&++MB0m1<h#b_Of3GrT)81bE#7P,HVs%Psrt\7URAm
-Sg0E!dSm1#SnA\u\%dbMA2p-(Kf#W_XK3%I-_?0p6$)$8C[0lB5OD"CUiYOq(.%O.Z)u.ZB,@0"88Vq055EZE88P>Y%oAJu
-Bh4_U/pgne&PeOGVKnVOH5b^LhF262WjugX,A7!"]]B9d(G806Trd!E2:Vi0l&m'5^ABd[4[3kWk8UqWo9Yg>m,`Ndo!8)/
-C``Ubp,F7jH4_s*&`>t\_E"`RqZh+U]GL0g`MdRa?@>;gr'c:F#s#I1[#B+JCW8P)X3`LT>AX!-3*;"^C;(n3T2g-E%[nBk
-Xk-=l<]GRuN%5KQ]=km(CORJKS#SGPpZrc>g*^K1'M9l"C/SIJ).[puKl.9\4,4F1'8^AVQT3'XUO"LoR6Pc0Gup_BAKVd=
-Ec.1#EN]"OGsIQTQP#uhElsg*<`TC8+kXf+%nZCV;$nJES4u;5k"I&J<ag5"EfN3hT(IOueqr$O,0&^MAF7T#gBB_bE?6<%
-NTP7D^Cj^AUpmY?9A#5NDL+Qd,#lhKOu&5c6td;ZRYD])[L/J%q.W*s)Tq0MnO@2'O]L"gVa1N[m>30'rZYN?'J/Db3Rs%D
-lID]nO@4joRS;;2(2%FC3L@G(>2-APd=f_^,g:%F6>7KlPt*Uq1q2JUo=XCJPkjUG7js@tF($;M9\P<@;OX2ZM'cU/$fmcK
-"0",<]L#$6?F<810'L1f*<PI[Teu1ej;"uuAe62rQ$&\mfigJc.tR/24n*pl^"'sW4ajn_aLSHcO41WNnJ.k_g![@sLfRHN
-#T%]C`Ei*W5>9oMdG88V(WClq]LTkJ'R`B5@IfoH7hgrXBG@:=d;\\6:*.WKh^lmH6*GEtNTN@$Ol0\pTWO/dEn+8;c;1W@
-FRq_+WZ5`lHuBt`M"*YlcNc%jUj:8&\:,X(>`YiZMBIDG#F__D7C!hgHo9<rbKD]8XmEUtFDc?X&4DuM>L;Fj'5?Qa<YH(I
--MnfP0/()^Dn]j'dlBP:[jn3H5a,6/Cc)fm$DNkk@_?J6,H;*)Yrl)u%s36IKZe_[G'HdZq(3f8(,h.PR):qN'JpuY7U@h?
-jZ>43>ed&#AMn6BX2aE_,#;WH-(5D.,I-g\Qg]`+\G[t.NG2-ceKRKaAH=WEKqbeBPFBjF\_.MZLnLb:L&u-s;QU8:2JFr/
-YOSRJB7#4%.pBY<mB"U6&bua>4D4e$Nm,WiAR7D>DjulT[U`rnDVK9i=&1Z@Pt'?[[d&o<0cq7s-lS:NLt%*Ll,p907@M<.
-/&j+iRM(i#ANm%s\npFh)UQI.>\J9l]C`P^3S>-h&=h2X2NBV7>8c,#git6D]IQ%9bp/,GT;.73PdDnrdH%_s,%rW-S<&oA
-X:ZW47m^CFai]`6E2t1;Fs=YPY/j/g>,f/-,Tc?r53UP[mE_ChIt-<5^%\]9A$&dh984i-d_9>a6/@jQ\@"'q]i]*)DJt%$
-YIg9M^%h:>1UMd^7:N6s"#PF+Grb=)2;]aR%7Lq2PBuJqh]J!:6E@ir>V8E0g6chS'9&6Sq=W-`ACF#]f-n@=orh[JQq=6*
-jJ.]/O$`H?0kd<FXN^m/pQV%j4I3)Yk'Y+B9hhA*a^rm4BYN;Qee_'I]L45b781Se/@msU/9\W$E<Mm+5p([AG$`-,`el,F
-aLMRFS(%=_%+8`5btB=fI\\?Y-;j+hOt4g:,T&-#`!A1so+Q,N;:&g!15TBQ90,ns-RPQZR[55(BWJq_jY;^g_.<]DOiUu:
-B_l6].GdSE]_"Z'm56(t55K8E((3#BaMNCfO1(>DX:C\t\Si0P$LQEg=/M1r+*.-i@hr-i=Aq6g>$3\%F4hrT+gdcKD0h;&
-@],%R&X!oPP)gld&NNpP7Sfda"OMV#`q3dqI#M_.g$f7"EtpuT8LMI_F4/h/SF"q3A@XGC2TPI:nig<^6hm6NaYSj(gI),1
-<Fr]acXR?YM3e1-QQOCf[h#8]g]X4FT\g*=`O]&9DAMkHBD"6R%+!A*;$8b9Z[H(271l+&'7m;!?,Z)31f<*unsh!Ie!#H(
-/3)3BGmp!X-DBNp2f4-uoILV,`9^6AonlV,gc=`d.[ec-FgYm:M(X:b_/D6;S;AMF;2+07BfY<m6rZ;N>`@1CD*_i%lpJs:
-VQct@2<VYdEh&,bau`BC]Ri\Elhk$<[a^,_WcUV<)G'-R&P[cZOkNLlji2sT*0G<siZAdI9NES)$OAY84uje!<E3>!SgJ&.
-Ntmf4MMRegaAELs/DWeNS4B)FbXHFSou<pEE$9g;)2WE?fJD6t>a@eG>Xb#=&R8JW[iDr\N52ub:c6[Aq;E.]52p3:K)?Lc
-Pt-FIO]koKc$a"0l,FiY,D6gW`n:X"4Aq]+d)mPMm[K:mDhVRZQh/PNM/XUn$^'ITA6'aso+44Z&CG5NEbQEm/k9M._L,\A
-EtG&bqM6GRog0nH(]"E@0ETF[kLuRr&Db8p/8aF[cOOcc>8;_.VLY,JEbk7.+l[.:O3;*M,o<Sf@M;sK,ZZ&nT;cX1s1<,1
-4sP,DF1l^D[!3cnKXVq`Knud-=4TZe@c#]^C*He*f:V^>&L#Ff?ocZ8Qs`bVHs:^AF>R0c.0kBl=R%e*R,((dg-O;Rg\#ke
-=OeUrWhk@E=%`:T@\nQO`jnsr6r^:Ljmc3nQ$^t>:*=0nW9OspeO4#W,0g"t]<6:a,@2p]g2X+6\eH=<Ml8*p?m/EQaR:Dd
-,LIOm;U_p_l^X0[W_t*C*W[%bp,8t:YBG:uIN6=R4ek,Z:*Qf4&R&n%[lVB>,o5;GA8+BSXuIek<e\Vr/5hCgaP)L&NmX!(
-do36_Z;]%_"I:7=P)-/R/pED9kiK'VYu#=Dc'^QFLr`KT[]0X"<U5(jJ9VtHNL/I-Ti7e!:RmW)/4F["O]:b@GA)@i?84LU
-Y"UUpr]$g<=_U9*(ho90:Mr"i2,8Sc(oIK&aqTs"9uL'JknQTsAJ&4U#4F;7pp#..di!=GP$;flEuM<K7!qXifnp'7Ka*D(
-6#<'OZ"qIIf?J;1,IiH)RA/r1'^$[P`<`4:kV/(0C&",U&`T&FgY:2aU)ln_7"4`i4ZCcV*cV<CNMq-'_XX+KE@G+`mms"e
-kZ!Tu;S7pLH#BOi2r2biZYG=DDsjC<4g*A!:J;*-Y=;E^`n7J%;4dB#gqWl\#H^"CcM2W._O1[1K+V)-SgF?I\HbKI(EN/,
-7t1%AWQ$0Y>002$,@b&lH(Y7(g^%gI_A#PZ<%#PqO/0>T@J6qkREkfY,.`A^;-4E0eVJ3"6Kb5r6b2<@TI..bLej+p<Q0c5
-.FMk88S0F[4(-Wm[PEFJEhl\a&mXiRgF@W!O.Y=ej6,f^Fr.cgj>V+uKanMKH'Lj,g(8PKLp*I!QT]^@_STL&R]oZmV*tu!
-MYn7drL6J!Ak4r2%B0XiZH<cAp-iZVOl<+nfuU%>oegZ'ad'QI%EE0NUW&@"8a;UIQmSW_Krg_nC.'0S+d-'#^p094?.!2h
-:1VO\KMsg]E(CSsMI7\;,-:?kUUA13_hb-l"Q1CI^7s++D^2U=&OQBj\IPoO:)te?7)sc/&R[mm\.m%:7daMorOVYYI9`sW
-A?g<"gd_thc:<=V&`?oic!U/#2QkL6O3o*m?0$5P!A8SsJGLE7bh:KR-e$\n'J;mGHd!)a9a"R[*-3(QYYFkI7bETmj6TA_
-cUe7A<(eP+,$fYm6gQ;bQo+=>/)oYH3k-eFQ:8hW]X8.=\kg2U7>KEiQpoHA-aZ5!9LmTD:gMS(-a^$IR?-Q.\nYk+ReR"$
-6$"(f6^Qmk8/%T1,&3.5(V\(0Cmk?Xe5^R[l%SQr>A)VCH==E(D/]6I4e/"H9J9sY=HT=SnpE0E?FI$+,>q6)p+/Zd;--C8
-A%m9[Tp]5GY/?.D\LFER5n[s$5BPM>6k6=e)U4uuXfEt/FD>?-.arlj=-mq<g<AkfO?5JeoQCDc6[CsW:Iu>i-QQ01r?'Ob
-n`^~>
+G[BdmIrj(.!ls9,f7S*?BV7Ag[$6:qfD#:T0=I'HQ<3sbZp,hhqM_LLprhO_1E$eJE-&@n[<9`B([_+_rfNi0b1>.2icP'G
+5Esf\9lGAoCS/NT2e`"D8Y);6f[dGUW(Dhc+:6:b++!7YP0\-)DCim\O:Gc9V9.i;6oH3N/=)<0C\dpJ81^YaVrJH3!r__P
+NbrQ?rG[p5:.[Dm-^$L'3(jLe2/b\f,bAM0b3VN;FQ\rKfF)R&EWsa_=>i06$CJHiTXX2%LO;cfP7t_]$#D^A%]4m9.\$X6
+,c.IH?HpDHSD5U=Ya(dKL(dQ7E(uMQDR);MNNtDfTcNF[C#=@5;L$NOZkiW8j22V11?N'bBIbs&*UI?0_E9X;+Q@'dR?tqI
+MC#Nij>bq(/5*+.bKMfu<^1kh-FRX5i`T)J,aA+=`3"II)Ga&I-%BJ>d0[p*I[]ks'36ENPENca8S)cp=WgFcFic+sbNXjn
+:81iCM(FcY^61lA+dpPL0ZPJe<Kb@"C$s/>;A554;FtS+@TPKs/<sh^a9:&,)Fu^*pTGct>FU;N=9<G5M/#@ERR=c9R=ea>
+P7t?9]h[n4Mq::r"Q9uV<$o=N8b!r9*Lik48sH*afNjZq8K_'(W%p)u<q$,BS!+JlAdRk7&g$//Z+ac!a^pV.[cK7h8SaWR
+Ap*XBAQ=Rq_'Cct8SaVkQDjiI(6g[%X@N>L-B'76ZZ\oMkq2tDZn_q=R3WP@crq`Goi`_X@9!A21a+E<TX@G^C*l-f8m%5N
+Pt_8%-YVl[]=NjH65%mpi`A>6/"W!59]g(;9X?+M8GGe)H^,5MQAJl>6u'`[24j<&:?ni+B'kbj((&PCa_N`lX,tEQ:!D<;
+ClK(2`X-H<dArDF<US*N3GXt[2+u#Z-*XWWY=deT[5XXeXa35!PI,Li>(\(YT'00Fi+hoha^/:<4kP2D)sZfUYBSUaa/_o9
+=#G8_-@&T(].1qn0tC!FV]R.0_[W#o[,_/^mD41l`3*,R)b]\c,^G(WhneA2SB/]sp[4RP-ardJ2@I(Z<CgS/a^(b(YA?Pk
+^c.a%VftoCl_Gjj_$.&V&fXL1.OBT+P1,Qd*S9N21#^>o`7Ju`/=":G'>-@4@A/?qH6Sd)]7(r,Yh.ebMC"G<=E7In6-N%C
+o97=RSRHD2qRLlB95L]%`NE8$R$fLk8MhePi-?s(O0pclH[?\Hqt'6P*eZDI/WUbU@EE&$HkFUZMgk$fD+$(UFh=ip2`FSb
+O\AMCqC3b^,D5.!7'9+H8DeTReBs-7j<SeoJlaH/*K_1_'"3N$kd\3obBn^)rVQ>m?L;'q'$cW]>h,W,4X!!\bZZ?hl.qpX
+R$2h<maXV6kaj/mitAitM.pE#*(\?n-E(Xdi&h9+:sq^96H:?e9p4"Z,^1XkCRME<gO>;G/L__lq"PWPo]3)Vdd#mOQCKg+
+?r7lh;O^i]cP"egECCM@`2mAk)s`H((!g>M+_aBn2+%uq8QZW>[!%;n:i/2DnGGJ*ZtR^KfFB7,WJOd$6oWc/k;@hI-+a%c
+C<!&m+<_bnS@)"7cO4]p,$HC9'B7%8CA(DrIe`F-oBH#JT6tn]naoIgcO0e;Re2;QIVe\I5@c%9.K/h-S@)"C]*13u(j(G<
+-nQX29hAsorR,8)R]*VdN1V'Y>TC*b(2f\1bA_o&N!Br=]=Y\%HREY^'')DIS;V`3%=6X[0ULo!<$-+Kj6,iVa^)l=q50iu
+frNY\0\>:]e2YFnof:@A>+C@2(BuI723XcR,a(10m9i;SB7`;"o-V%k,+4eQL6LapP$"_qGS[jD$.JeYA56SQ8W:t/aR#dD
+/dkk>=sQu:-BgFrD'\?dXQj/NbjK`gTU.35,Vp(d84&f-BMNAqkG"V<X\D\N>;DV/bXRfIeAQDp'0qlt/SOO7XBC_.N$L<Q
+S;p61a#0dX-&GqLBpm19@,hRWUrn+l*ppM2BH_/\KJcIN1D8>bP*seR]+WHUc1?!Seh!65877QR(.i&a8C,7CMc]f:XALa@
+Oh;l0/6CD(OKkH3=7d\-$g$HfPt>ECjE@cPF!kt.SQ&?Y=IJqa97-i$o3;R.ABiZPf"W;FqeLD&\2Qr8V^8N=m-5q6rPjC@
+,$M-]9A\AKUZk@NPIMrrnZd)*03Y`I2,7*aP1>42X]^8Rgc3ZdRZq@-P'kN;`5WHk-Y:Pdk-pDEjg^M]3mjB@adP6;%4%u'
+M:W`ho0K_t+-T_Q>B;&dMb&M^$#3Y<2.u#9kDL+Y)%rc7--^!\9@W;s5mqZkH"GFS3WWDl+$L+>QIM_+BdjLJ(?3dg2P,<(
+:3`(0--iR]Hl"+m'"#S4&SmiZ/A2Q7eoI4H$n\YFd+P4+XBco4IMA/lFOcn*jak]%/S.ZQpmeFe-:pp(E#)Y!BUOi,CUO&l
+:K#c-\14I\HBUX-OVYHqSRK5`d(=sS3,r(g<s(K3\RYK!<"!S';-?WB5\H1E]u#?k;c9p0jL:J?XK':5)iBs@dq!!#a`&U6
+=]s3=:F@`KAJ3ls1:"=kH(T>_YF;-a'1`gY'AH%jZGNb=oA+N8\$nN"^J7Kke!!l]+D^>D3:B+.'J663PM8osR[eW(ZKq'D
+%CB*#l[`iq\:fl<4BC-8BYKrE=pV2&!;tG@Q62<NFnP"G'kk<CJ0$@IjI.?Z=UE1gq@r-C4HB_q"esU@qU;>bjDI;hk/RBb
+#5\P*9`g`Tln#+=a5,fcXkdfdj2o]mamF&1Z-mNeLmGD+M.3GpC50_kN!C#V'm=XlMN:>4S)geYimf=5S<eQ(XcDRdd#qGE
+h]@rtZADf)A25qQ=]\nUaeHbVB"rI$_U;"^Z"1(X6F*>':6Xae,$1i&qT3+?">QZIL\k<_b"B80-d92OQb;m[=e:Up8^p)X
+3+5rUB:^^OpHoQqXs(u0H2a1,>-clVq;HWnAsQ];Etn98]jrk,R,p=oIiN6-Sn@D3.,e<<+j`TNqj8ml(?MFsY?o+m=$ZPk
+T]NSu%XJVA%UuT=>)9eI?.D[eY:`E7,Y?0m^iPQY*:mYaR[sNRPI\gBbsE*%TgWY@L,g>EbAfI4NVCIGi=.&O[?I-"-*h4k
+f*k)2mmIP&+K=c#a*FsPON>sIJejQ3:.`U^"j]+d_E1^rE6*#Okda.*d5$m/bf$W0id<OfoYL/A#2Djh#Eu[_$.Gu4@bKhF
+<l05TE+=anH#c!6][]fVB'JpM`gDgD?g.^h3N7uc_'_fk/9u#mFL=j$=sSb)'B<ss)c)>Q$#M5-X.P'Q9?rtRNS0/-0:>7L
+r05FFPIC`&>(]4YhW/]l!dpT`11C/,fCL1ScUD$!QBm&]96c'qXHVg`cq>K5GuYKLjX.!!M=+1ARo3hE?f\=TdT8,B=\U(Z
+95J*pCJ)!"IsFZEW[EPsaiA-0hXa,N8S_5c6%:mjl=qZ,3Jk[#,fH5Vek'XlkFDPdgL('*o:qVoYt;am--5iT&(eM!VBr7A
+*>Is\PDaFP't&iEVVNo>F3)B)2*Ff29jF)C*tuHLM/#0?Hu7]3-`#c8e\hS+8T?s</=Ocee$.G+!-;l"]4<cJM2`mti<6Dj
+db@Ks?>YZ]mul7dA2^%G%O[0GP2_I@]HH??S9Kg*68BKQC7.>![kXK.JE<f$pBdo6g.:4lRT/FV0qQbj0P>AVOiS`O*DTG[
+qV"M'-`-XI:)^LpM"<6e<K\:r;VbD#WsNLTX\LUpm5XQufk@*!9NpJ):#Of&G0eWf>FcP*q2j7KP28GJ)bY9OHSG?hEs%t1
+h"!"bpPE`4nNBNW#D1<CD4K(<jnnj5mh=J_s6]IA__idom3dMIe!O4/.,W@Pq2c0V)4t(r9p-%/mqK(/-OkC@$1^8WCY"$r
+hd_WB(%Wu!("90aR1qk3A;rZZ4Ml*A/CF#h5E1"qh+.I`UmH>NP-Bu1N:UBeIJNHcU,DDf`n-C[G7ptp'@`0C($Wp#=q'Mj
+2"]lW^Scq<lj;pT@\Sq*=OY!4e)6R^n=Cq"$V=%4,g=:SXa]/fC&3`\F9@BIZ4b[:`42Gd<U/=a,&f!QD(tK_A?qYk#bNDj
+712Z#(=kf6R,BMUBh_3OchlUF?[&]W]@Z#-QQ2VC)(S?dUC#-_P#j!EJHDRh-,9Thb2O(8,q(99A<m)dqYP3!S=%MI,W3b=
+<h5&J0;4@Q_n5p9-Ca$/eIfpL,.]GdGb8ZN34Y$5DRkL9&Y5"Kc'Ns@80BN.aW3"l3)$laBZ\Ii[TY#J@hXMg8ot<T,<:ji
+`Y6C%a]c[%E`rN`Obn"TFNTZdlu59n51qI8rT@@A%r(a\:4NG'n6(q/:[VsFOV8DH&o$ba8VBm'hm3I\,\_%^LrR$`h\rAS
+Y:_h!-GZ>9pd+JV0R"2e>rtu%"Wu4#f:4N:'&Prob\QFXp0$i.d[XP=jE['lLK^\<VkgA1)KDfbA^]SEXMh/N)K%'+@F5T;
+prd\3q.c;:g.JIeC%5>01=di_Zo+[beAAQ%`2lBGALkBLU8;L2$!R!Y_cG_cO;=FA-#/^o_/IlKV?LX9a]l/pcs(AA/5JqE
+]/=LsbA6)gFVW=jDCmCW>"k)\2BCQ'nrp#_P.cJ3Lpg?QN3u:]$`(\m\u\<&<cXRm54mF6,_dV.`_#EID/J[(c;@/EH@"=M
+>@WiOZNPA0]p5_%Xip/45da`k~>
 U
 PSL_cliprestore
 0 A [] 0 B

--- a/test/sph/sph_5.sh
+++ b/test/sph/sph_5.sh
@@ -10,7 +10,7 @@ gmt sphtriangulate @hotspots.txt -Qv -T > tt.arcs
 gmt makecpt -Ccategorical -T0/55/1 > t.cpt
 # Make a grid with node numbers
 grep -v '^#' $data | awk '{print $1, $2, NR}' | gmt sphdistance -Rg -I30m -En5 -Gn.nc
-gmt grdimage n.nc -Ct.cpt -R0/360/-90/0 -JA0/-90/6i -Baf -P -K -nn -Y0.75i > $ps
+gmt grdimage n.nc -Ct.cpt -R0/360/-90/0 -JA0/-90/6i -Baf -P -K -nn+a -Y0.75i > $ps
 #gmt grdimage n.nc -Ct.cpt -JH0/6i -B0 -P -K > $ps
 gmt psxy -R -J -O -K tt.arcs -W1p >> $ps
 gmt psxy -R -J -O -K -SE-250 -Gwhite -Wfaint @hotspots.txt >> $ps


### PR DESCRIPTION
Using **--n+a** fixes the issue discussed in #4415.  Closes #4415.