### PR TITLE
Let fancy baseframes only have corner extensions if there is a receiving side

### DIFF
--- a/doc/scripts/GMT_-B_geo_1.ps
+++ b/doc/scripts/GMT_-B_geo_1.ps
@@ -1,17 +1,16 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from psbasemap
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.2.0_9d472cc_2020.11.04 [64-bit] Document from basemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:51:54 2018
+%%CreationDate: Wed Nov  4 16:39:34 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
 %%Pages: 1
 %%EndComments
-
 %%BeginProlog
 250 dict begin
 /! {bind def} bind def
@@ -336,9 +335,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -594,9 +591,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +634,7 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
     U
 } def
 /PSL_nclip 0 def
@@ -648,38 +642,31 @@ end
 /PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
 /PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
 %%EndProlog
-
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
-PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
-
 %%Page: 1 1
-
 %%BeginPageSetup
 V 0.06 0.06 scale
 %%EndPageSetup
-
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
-/PSL_movie_completion {} def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
 FQ
 O0
 1200 1200 TM
-
 % PostScript produced by:
-%@GMT: gmt psbasemap -R-1/2/0/0.4 -JM3i -Ba1f15mg5m -BS
-%@PROJ: merc -1.00000000 2.00000000 0.00000000 0.40000000 -166979.236 166979.236 -0.000 44230.074 +proj=merc +lon_0=0.5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
-%GMTBoundingBox: 72 72 216 28.6074
+%@GMT: gmt basemap -R-1/2/0/0.4 -JM3i -Ba1f15mg5m -BS
+%@PROJ: merc -1.00000000 2.00000000 0.00000000 0.40000000 -166979.236 166979.236 -0.000 44230.074 +proj=merc +lon_0=0.5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
-25 W
+3.32550952342 setmiterlimit
 4 W
 0 0 M
 0 477 D
@@ -812,6 +799,8 @@ N 0 0 M 0 -83 D S
 N 1200 0 M 0 -83 D S
 N 2400 0 M 0 -83 D S
 N 3600 0 M 0 -83 D S
+0 A [] 0 B
+25 W
 83 W
 1 A
 0 A
@@ -840,8 +829,8 @@ N 3000 -42 M 300 0 D S
 N 3300 -42 M 300 0 D S
 0 A
 8 W
-N -83 0 M 3766 0 D S
-N -83 -83 M 3766 0 D S
+N 0 0 M 3600 0 D S
+N 0 -83 M 3600 0 D S
 0 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (1°W) tc Z
@@ -853,14 +842,14 @@ N -83 -83 M 3766 0 D S
 FQ
 O0
 0 -420 TM
-
 % PostScript produced by:
-%@GMT: gmt psxy -Sv2p+e+a60 -W0.5p -Gblack -Y-0.35i -N -R-1/2/0/0.4 -JM3i
-%@PROJ: merc -1.00000000 2.00000000 0.00000000 0.40000000 -166979.236 166979.236 -0.000 44230.074 +proj=merc +lon_0=0.5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt plot -Sv2p+e+a60 -W0.5p -Gblack -Y-0.35i -N -R-1/2/0/0.4 -JM3i
+%@PROJ: merc -1.00000000 2.00000000 0.00000000 0.40000000 -166979.236 166979.236 -0.000 44230.074 +proj=merc +lon_0=0.5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
+/PSL_vecheadpen {8 W 0 A [] 0 B} def
 8 W
 V
 {0 A} FS
@@ -868,57 +857,64 @@ O1
 8 W
 V 600 0 T N 0 0 M 567 0 D S
 U
-V 1200 0 T 0 0 M
+V 1200 0 T PSL_vecheadpen
+8 W
+0 0 M
 -33 19 D
 0 -38 D
 P clip fs P S 
 U
-8 W
 8 W
 V 600 0 T 180 R
 N 0 0 M 567 0 D S
 U
 V 0 0 T 180 R
+PSL_vecheadpen
+8 W
 0 0 M
 -33 19 D
 0 -38 D
 P clip fs P S 
 U
 8 W
-8 W
 V 1650 0 T N 0 0 M 117 0 D S
 U
-V 1800 0 T 0 0 M
+V 1800 0 T PSL_vecheadpen
+8 W
+0 0 M
 -33 19 D
 0 -38 D
 P clip fs P S 
 U
-8 W
 8 W
 V 1650 0 T 180 R
 N 0 0 M 117 0 D S
 U
 V 1500 0 T 180 R
+PSL_vecheadpen
+8 W
 0 0 M
 -33 19 D
 0 -38 D
 P clip fs P S 
 U
 8 W
-8 W
 V 2750 0 T N 0 0 M 17 0 D S
 U
-V 2800 0 T 0 0 M
+V 2800 0 T PSL_vecheadpen
+8 W
+0 0 M
 -33 19 D
 0 -38 D
 P clip fs P S 
 U
 8 W
-8 W
 V 2750 0 T 180 R
 N 0 0 M 17 0 D S
 U
 V 2700 0 T 180 R
+PSL_vecheadpen
+8 W
 0 0 M
 -33 19 D
 0 -38 D
@@ -930,14 +926,13 @@ U
 FQ
 O0
 0 0 TM
-
 % PostScript produced by:
-%@GMT: gmt pstext -F+f9p+jCB -R-1/2/0/0.4 -JM3i
-%@PROJ: merc -1.00000000 2.00000000 0.00000000 0.40000000 -166979.236 166979.236 -0.000 44230.074 +proj=merc +lon_0=0.5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314245 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%@GMT: gmt text -F+f9p+jCB -R-1/2/0/0.4 -JM3i
+%@PROJ: merc -1.00000000 2.00000000 0.00000000 0.40000000 -166979.236 166979.236 -0.000 44230.074 +proj=merc +lon_0=0.5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 clipsave
 0 0 M
 3600 0 D
@@ -952,15 +947,13 @@ PSL_clip N
 2750 60 M (grid) bc Z
 PSL_cliprestore
 %%EndObject
-
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage
-
 %%Trailer
-
 end
 %%EOF

--- a/doc/scripts/GMT_colorbar.ps
+++ b/doc/scripts/GMT_colorbar.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.1.0_63e3a49_2020.02.16 [64-bit] Document from psbasemap
+%%Title: GMT v6.2.0_9d472cc_2020.11.04 [64-bit] Document from basemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Feb 16 20:05:26 2020
+%%CreationDate: Wed Nov  4 16:39:47 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -661,13 +661,12 @@ FQ
 O0
 1200 1200 TM
 % PostScript produced by:
-%@GMT: gmt psbasemap -R0/20/0/1 -JM5i -BWse -B
+%@GMT: gmt basemap -R0/20/0/1 -JM5i -BWse -B
 %@PROJ: merc 0.00000000 20.00000000 0.00000000 1.00000000 -1113194.908 1113194.908 -0.000 110579.965 +proj=merc +lon_0=10 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
-25 W
+3.32550952342 setmiterlimit
 8 W
 N 0 0 M 0 -83 D S
 N 1500 0 M 0 -83 D S
@@ -676,6 +675,8 @@ N 4500 0 M 0 -83 D S
 N 6000 0 M 0 -83 D S
 N 0 0 M -83 0 D S
 N 6000 0 M 83 0 D S
+0 A [] 0 B
+25 W
 83 W
 N -42 0 M 0 298 D S
 N 6042 0 M 0 298 D S
@@ -722,10 +723,10 @@ N 5700 -42 M 300 0 D S
 8 W
 N -83 0 M 6166 0 D S
 N -83 -83 M 6166 0 D S
-N 6000 -83 M 0 464 D S
-N 6083 -83 M 0 464 D S
-N 0 381 M 0 -464 D S
-N -83 381 M 0 -464 D S
+N 6000 -83 M 0 381 D S
+N 6083 -83 M 0 381 D S
+N 0 298 M 0 -381 D S
+N -83 298 M 0 -381 D S
 -167 0 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0°) mr Z
@@ -735,12 +736,12 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt psscale -C -Bx+u@. -By+l@~D@~T -DJBC+e
+%@GMT: gmt colorbar -C -Bx+u@. -By+l@~D@~T -DJBC+e -R0/20/0/1 -JM5i
 %@PROJ: merc 0.00000000 20.00000000 0.00000000 1.00000000 -1113194.908 1113194.908 -0.000 110579.965 +proj=merc +lon_0=10 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 600 -409 T
 25 W
 V N 0 0 T 4800 192 scale /DeviceRGB setcolorspace
@@ -789,8 +790,8 @@ N 0 0 M 4800 0 D S
 N 800 0 M 0 -83 D S
 N 2400 0 M 0 -83 D S
 N 4000 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (-10\260) sh mx

--- a/doc/scripts/GMT_cyclic.ps
+++ b/doc/scripts/GMT_cyclic.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_b34bf88_2020.07.14 [64-bit] Document from psbasemap
+%%Title: GMT v6.2.0_9d472cc_2020.11.04 [64-bit] Document from basemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Tue Jul 14 18:50:11 2020
+%%CreationDate: Wed Nov  4 16:39:47 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -661,13 +661,12 @@ FQ
 O0
 1200 1200 TM
 % PostScript produced by:
-%@GMT: gmt psbasemap -R0/20/0/1 -JM5i -BWse -B
+%@GMT: gmt basemap -R0/20/0/1 -JM5i -BWse -B
 %@PROJ: merc 0.00000000 20.00000000 0.00000000 1.00000000 -1113194.908 1113194.908 -0.000 110579.965 +proj=merc +lon_0=10 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-25 W
 8 W
 N 0 0 M 0 -83 D S
 N 1500 0 M 0 -83 D S
@@ -676,6 +675,8 @@ N 4500 0 M 0 -83 D S
 N 6000 0 M 0 -83 D S
 N 0 0 M -83 0 D S
 N 6000 0 M 83 0 D S
+0 A [] 0 B
+25 W
 83 W
 N -42 0 M 0 298 D S
 N 6042 0 M 0 298 D S
@@ -722,10 +723,10 @@ N 5700 -42 M 300 0 D S
 8 W
 N -83 0 M 6166 0 D S
 N -83 -83 M 6166 0 D S
-N 6000 -83 M 0 464 D S
-N 6083 -83 M 0 464 D S
-N 0 381 M 0 -464 D S
-N -83 381 M 0 -464 D S
+N 6000 -83 M 0 381 D S
+N 6083 -83 M 0 381 D S
+N 0 298 M 0 -381 D S
+N -83 298 M 0 -381 D S
 -167 0 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0°) mr Z
@@ -735,7 +736,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt psscale -C -B -DJBC -R0/20/0/1 -JM5i
+%@GMT: gmt colorbar -C -B -DJBC -R0/20/0/1 -JM5i
 %@PROJ: merc 0.00000000 20.00000000 0.00000000 1.00000000 -1113194.908 1113194.908 -0.000 110579.965 +proj=merc +lon_0=10 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -880,10 +880,28 @@ GMT_LOCAL void gmtplot_fancy_frame_straightlat_checkers (struct GMT_CTRL *GMT, s
 
 GMT_LOCAL void gmtplot_fancy_frame_straight_outline (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double lonA, double latA, double lonB, double latB, unsigned int side, bool secondary_too) {
 	unsigned int k, kn = 1, axis;
-	double scale = 1.0, x[2], y[2], angle, s, c, dx, dy, Ldx, Ldy;
+	double scale = 1.0, x[2], y[2], angle, s, c, dx, dy, Ldx, Ldy, f0 = 1.0, f1 = 1.0;
 	struct GMT_PLOT_AXIS_ITEM *T = NULL;
 
 	if (!GMT->current.map.frame.side[side]) return;	/* Do not draw this frame side */
+	switch (side) {	/* Determine if there are missing partner sides that invalidates extensions */
+		case S_SIDE:
+			if (!GMT->current.map.frame.side[W_SIDE]) f0 = 0;
+			if (!GMT->current.map.frame.side[E_SIDE]) f1 = 0;
+			break;
+		case E_SIDE:
+			if (!GMT->current.map.frame.side[S_SIDE]) f0 = 0;
+			if (!GMT->current.map.frame.side[N_SIDE]) f1 = 0;
+			break;
+		case N_SIDE:
+			if (!GMT->current.map.frame.side[E_SIDE]) f0 = 0;
+			if (!GMT->current.map.frame.side[W_SIDE]) f1 = 0;
+			break;
+		case W_SIDE:
+			if (!GMT->current.map.frame.side[N_SIDE]) f0 = 0;
+			if (!GMT->current.map.frame.side[S_SIDE]) f1 = 0;
+			break;
+	}
 
 	if (secondary_too) {
 		scale = 0.5;
@@ -897,25 +915,28 @@ GMT_LOCAL void gmtplot_fancy_frame_straight_outline (struct GMT_CTRL *GMT, struc
 	gmt_geo_to_xy (GMT, lonB, latB, &x[1], &y[1]);
 	angle = d_atan2 (y[1] - y[0], x[1] - x[0]);
 	sincos (angle, &s, &c);
+	/* Ldx/dy is the components of the extension of the fancy frame into neighboring side frames */
 	Ldx = (GMT->current.setting.map_frame_type == GMT_IS_ROUNDED) ? 0.0 : GMT->current.setting.map_frame_width * c;
 	Ldy = (GMT->current.setting.map_frame_type == GMT_IS_ROUNDED) ? 0.0 : GMT->current.setting.map_frame_width * s;
+	/* dx,dy is the outward shift components to draw the outside (and possibly half-way) parallel frame outline */
 	dx =  GMT->current.setting.map_frame_width * s;
 	dy = -GMT->current.setting.map_frame_width * c;
-	PSL_plotsegment (PSL, x[0]-Ldx, y[0]-Ldy, x[1]+Ldx, y[1]+Ldy);
+	PSL_plotsegment (PSL, x[0]-f0*Ldx, y[0]-f0*Ldy, x[1]+f1*Ldx, y[1]+f1*Ldy);
 	for (k = 0; k < kn; k++) {
 		x[0] += scale*dx;
 		y[0] += scale*dy;
 		x[1] += scale*dx;
 		y[1] += scale*dy;
-		PSL_plotsegment (PSL, x[0]-Ldx, y[0]-Ldy, x[1]+Ldx, y[1]+Ldy);
+		PSL_plotsegment (PSL, x[0]-f0*Ldx, y[0]-f0*Ldy, x[1]+f1*Ldx, y[1]+f1*Ldy);
 	}
 }
 
 GMT_LOCAL void gmtplot_fancy_frame_curved_outline (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double lonA, double latA, double lonB, double latB, unsigned int side, bool secondary_too) {
-	double scale[2] = {1.0, 1.0}, escl, x1, x2, y1, y2, radius, r_inc, az1, az2, da0, da, width, s;
+	double scale[2] = {1.0, 1.0}, escl, x1, x2, y1, y2, radius, r_inc, az1, az2, da0, da, width, s, fw, fe;
 
-	if (!GMT->current.map.frame.side[side]) return;
-
+	if (!GMT->current.map.frame.side[side]) return;	/* This side is inactive */
+	fw = (GMT->current.map.frame.side[W_SIDE]) ? 1.0 : 0.0;	/* Only extend if W side is plotted */
+	fe = (GMT->current.map.frame.side[E_SIDE]) ? 1.0 : 0.0;	/* Only extend if E side is plotted */
 	if (secondary_too) scale[0] = scale[1] = 0.5;
 	width = GMT->current.setting.map_frame_width;
 	escl = (GMT->current.setting.map_frame_type == GMT_IS_ROUNDED) ? 0.0 : 1.0;	/* Want rounded corners */
@@ -937,12 +958,12 @@ GMT_LOCAL void gmtplot_fancy_frame_curved_outline (struct GMT_CTRL *GMT, struct 
 		while (az2 < az1) az2 += 360.0;	/* Likewise ensure az1 > az1 and is now in the 0-720 range */
 		da0 = R2D * escl * width /radius;
 		da  = R2D * escl * width / (radius + r_inc);
-		PSL_plotarc (PSL, GMT->current.proj.c_x0, GMT->current.proj.c_y0, radius, az1-da0, az2+da0, PSL_MOVE|PSL_STROKE);
-		PSL_plotarc (PSL, GMT->current.proj.c_x0, GMT->current.proj.c_y0, radius + r_inc, az1-da, az2+da, PSL_MOVE|PSL_STROKE);
+		PSL_plotarc (PSL, GMT->current.proj.c_x0, GMT->current.proj.c_y0, radius, az1-fw*da0, az2+fe*da0, PSL_MOVE|PSL_STROKE);
+		PSL_plotarc (PSL, GMT->current.proj.c_x0, GMT->current.proj.c_y0, radius + r_inc, az1-fw*da, az2+fe*da, PSL_MOVE|PSL_STROKE);
 		if (secondary_too) {
 			r_inc *= 2.0;
 			da = R2D * escl * width / (radius + r_inc);
-			PSL_plotarc (PSL, GMT->current.proj.c_x0, GMT->current.proj.c_y0, radius + r_inc, az1-da, az2+da, PSL_MOVE|PSL_STROKE);
+			PSL_plotarc (PSL, GMT->current.proj.c_x0, GMT->current.proj.c_y0, radius + r_inc, az1-fw*da, az2+fe*da, PSL_MOVE|PSL_STROKE);
 		}
 	}
 }
@@ -1135,10 +1156,10 @@ GMT_LOCAL void gmtplot_fancy_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL
 	PSL_setcolor (PSL, GMT->current.setting.map_frame_pen.rgb, PSL_IS_STROKE);
 	PSL_setlinewidth (PSL, thin_pen);
 
-	gmtplot_fancy_frame_straight_outline (GMT, PSL, w, s, e, s, 0, dual);
-	gmtplot_fancy_frame_straight_outline (GMT, PSL, e, s, e, n, 1, dual);
-	gmtplot_fancy_frame_straight_outline (GMT, PSL, e, n, w, n, 2, dual);
-	gmtplot_fancy_frame_straight_outline (GMT, PSL, w, n, w, s, 3, dual);
+	gmtplot_fancy_frame_straight_outline (GMT, PSL, w, s, e, s, S_SIDE, dual);
+	gmtplot_fancy_frame_straight_outline (GMT, PSL, e, s, e, n, E_SIDE, dual);
+	gmtplot_fancy_frame_straight_outline (GMT, PSL, e, n, w, n, N_SIDE, dual);
+	gmtplot_fancy_frame_straight_outline (GMT, PSL, w, n, w, s, W_SIDE, dual);
 
 	gmtplot_rounded_framecorners (GMT, PSL, w, e, s, n, dual);
 }
@@ -1206,10 +1227,10 @@ GMT_LOCAL void gmtplot_polar_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL
 	PSL_setcolor (PSL, GMT->current.setting.map_frame_pen.rgb, PSL_IS_STROKE);
 	PSL_setlinewidth (PSL, thin_pen);
 
-	gmtplot_fancy_frame_curved_outline (GMT, PSL, w, s, e, s, 0, dual);
-	gmtplot_fancy_frame_straight_outline (GMT, PSL, e, s, e, n, 1, dual);
-	gmtplot_fancy_frame_curved_outline (GMT, PSL, w, n, e, n, 2, dual);
-	gmtplot_fancy_frame_straight_outline (GMT, PSL, w, n, w, s, 3, dual);
+	gmtplot_fancy_frame_curved_outline (GMT, PSL, w, s, e, s, S_SIDE, dual);
+	gmtplot_fancy_frame_straight_outline (GMT, PSL, e, s, e, n, E_SIDE, dual);
+	gmtplot_fancy_frame_curved_outline (GMT, PSL, w, n, e, n, N_SIDE, dual);
+	gmtplot_fancy_frame_straight_outline (GMT, PSL, w, n, w, s, W_SIDE, dual);
 
 	gmtplot_rounded_framecorners (GMT, PSL, w, e, s, n, dual);
 }
@@ -1261,10 +1282,10 @@ GMT_LOCAL void gmtplot_conic_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL
 	PSL_setcolor (PSL, GMT->current.setting.map_frame_pen.rgb, PSL_IS_STROKE);
 	PSL_setlinewidth (PSL, thin_pen);
 
-	gmtplot_fancy_frame_curved_outline (GMT, PSL, w, s, e, s, 0, dual);
-	gmtplot_fancy_frame_straight_outline (GMT, PSL, e, s, e, n, 1, dual);
-	gmtplot_fancy_frame_curved_outline (GMT, PSL, w, n, e, n, 2, dual);
-	gmtplot_fancy_frame_straight_outline (GMT, PSL, w, n, w, s, 3, dual);
+	gmtplot_fancy_frame_curved_outline (GMT, PSL, w, s, e, s, S_SIDE, dual);
+	gmtplot_fancy_frame_straight_outline (GMT, PSL, e, s, e, n, E_SIDE, dual);
+	gmtplot_fancy_frame_curved_outline (GMT, PSL, w, n, e, n, N_SIDE, dual);
+	gmtplot_fancy_frame_straight_outline (GMT, PSL, w, n, w, s, W_SIDE, dual);
 
 	gmtplot_rounded_framecorners (GMT, PSL, w, e, s, n, dual);
 }


### PR DESCRIPTION
The fancy baseframes have a finite width and when two sides meet (say south and east) we add extension lines to connect these thick frames.  However, if one of the sides are turned off (via **-B**) then it makes no sense to plot those extensions as they only stick into thin air.  This report on the [forum](https://forum.generic-mapping-tools.org/t/sloppy-frame-when-using-bxafg/1010/3) illustrates the issue:

![old](https://user-images.githubusercontent.com/26473567/98191742-f0a61300-1ebd-11eb-9110-aedd2f9d6ed1.png)

This PR adds checks to that effect and only draws the extensions when they are met at the corner by another frame extension:

![new](https://user-images.githubusercontent.com/26473567/98191778-fef42f00-1ebd-11eb-9a11-2145f60cee23.png)

Three PS originals with ugly extenders had to be updated.
