### PR TITLE
Enforce --nn+a in grdimage if given a categorical CPT

### DIFF
--- a/doc/rst/source/grdimage_notes.rst_
+++ b/doc/rst/source/grdimage_notes.rst_
@@ -18,7 +18,8 @@ Geographical categorical grids have values at the nodes that should not
 be interpolated (i.e., categories 4 and 5 should never be averaged to give
 a new category 4.5).  However, imaging such grids using map projections
 requires a resampling onto an equidistant Cartesian lattice that usually
-will result in such blending.  We therefore override any **-n** setting you
+will result in such blending.  We do not know if a grid is categorical but
+if the CPT provided via **-C** is categorical we will override any **-n** setting you
 have chosen (perhaps implicitly) with **-nn+a** that turns *on* nearest neighbor
 gridding and turns *off* anti-aliasing.  Alternatively, use :doc:`grdview` **-T**
 instead to plot individual polygons centered on each node.

--- a/doc/rst/source/grdimage_notes.rst_
+++ b/doc/rst/source/grdimage_notes.rst_
@@ -11,6 +11,18 @@ linear projection, or (b) use :doc:`grdview` **-Ts** instead.
 
 .. include:: explain_grdresample.rst_
 
+Imaging Categorical Grids
+-------------------------
+
+Geographical categorical grids have values at the nodes that should not
+be interpolated (i.e., categories 4 and 5 should never be averaged to give
+a new category 4.5).  However, imaging such grids using map projections
+requires a resampling onto an equidistant Cartesian lattice that usually
+will result in such blending.  We therefore override any **-n** setting you
+have chosen (perhaps implicitly) with **-nn+a** that turns *on* nearest neighbor
+gridding and turns *off* anti-aliasing.  Alternatively, use :doc:`grdview` **-T**
+instead to plot individual polygons centered on each node.
+
 Image formats recognized
 ------------------------
 

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1478,7 +1478,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 		double inc[2] = {0.0, 0.0};
 
 		if (got_z_grid && P && P->categorical && (GMT->common.n.interpolant != BCR_NEARNEIGHBOR || GMT->common.n.antialias)) {
-			GMT_Report (API, GMT_MSG_WARNING, "Your CPT is categorical. Enabling --n+a to avoid interpolation across categories\n");
+			GMT_Report (API, GMT_MSG_WARNING, "Your CPT is categorical. Enabling --nn+a to avoid interpolation across categories.\n");
 			GMT->common.n.interpolant = BCR_NEARNEIGHBOR;
 			GMT->common.n.antialias = false;
 			GMT->common.n.threshold = 0.0;

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1478,7 +1478,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 		double inc[2] = {0.0, 0.0};
 
 		if (got_z_grid && P && P->categorical && (GMT->common.n.interpolant != BCR_NEARNEIGHBOR || GMT->common.n.antialias)) {
-			GMT_Report (API, GMT_MSG_WARNING, "Your CPT is categorical. Enabling --nn+a to avoid interpolation across categories.\n");
+			GMT_Report (API, GMT_MSG_WARNING, "Your CPT is categorical. Enabling -nn+a to avoid interpolation across categories.\n");
 			GMT->common.n.interpolant = BCR_NEARNEIGHBOR;
 			GMT->common.n.antialias = false;
 			GMT->common.n.threshold = 0.0;


### PR DESCRIPTION
See this [form post ](https://forum.generic-mapping-tools.org/t/how-to-map-a-categorical-geotiff-correctly/1014/4)for background.  Hardly any GMT user will know a priori that when they image a geographic categorical grid that they must use **-nn+a** to avoid interpolation.  This PR fixes that by warning users if those settings are not selected and then overriding them with what is required.  This is especially timely since we recently added warnings when a categorical CPT lookup is fed non-categorical values.  The documentation has also been updated to discuss this and other options.,

Before this PR a geographic mapping with a categorical CPT may give this:
 
```
gmt grdimage t.grd -Ct.cpt -JM3i -B -png old
grdimage [WARNING]: Requested color lookup for z = 4.00247192383 is not a categorical value - returning NaN color
grdimage [WARNING]: Requested color lookup for z = 8.00494384766 is not a categorical value - returning NaN color
```

![old](https://user-images.githubusercontent.com/26473567/98428120-18bf7e80-2044-11eb-958b-21404ec082d9.png)

While after the PR we get this:

```
gmt grdimage t.grd -Ct.cpt -JM3i -B -png new
grdimage [WARNING]: Your CPT is categorical. Enabling --n+a to avoid interpolation across categories
```

![new](https://user-images.githubusercontent.com/26473567/98428130-2412aa00-2044-11eb-8196-ddd212d64ba6.png)

