### PR TITLE
If imageing with categorical CPT then only -Qm or -T is allowed

### DIFF
--- a/doc/rst/source/grdview_common.rst_
+++ b/doc/rst/source/grdview_common.rst_
@@ -85,6 +85,8 @@ Optional Arguments
     #. Specify **c**. Same as **-Qi** but will make nodes with z = NaN transparent, using the colormasking
        feature in PostScript Level 3 (the PS device must support PS Level 3). .
 
+    **Note**: If the CPT is categorical then only **-Qm** is available (but see **-T**).
+
 .. _-R:
 
 .. |Add_-R| unicode:: 0x20 .. just an invisible code
@@ -107,8 +109,9 @@ Optional Arguments
 **-T**\ [**+o**\ [*pen*]][**+s**]
     Plot image without any interpolation. This involves converting each
     node-centered bin into a polygon which is then painted separately.
-    Append **+s** to skip nodes with z = NaN. This option is useful for
-    categorical data where interpolating between values is meaningless.
+    Append **+s** to skip nodes with z = NaN. This option is suitable for
+    categorical data where interpolating between values is meaningless
+    and a categorical CPT has been provided via **-C**.
     Optionally, append **+o** to draw the tile outlines, and specify a
     custom pen if the default pen is not to your liking. As this option
     produces a flat surface it cannot be combined with **-JZ** or **-Jz**.

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -951,8 +951,9 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 			Return (API->error);
 		}
 		if (P->is_bw) Ctrl->Q.monochrome = true;
-		if (P->categorical && Ctrl->W.active) {
-			GMT_Report (API, GMT_MSG_ERROR, "Categorical data (as implied by CPT) do not have contours.  Check plot.\n");
+		if (P->categorical && !(Ctrl->Q.mode == GRDVIEW_MESH || Ctrl->T.active)) {
+			GMT_Report (API, GMT_MSG_ERROR, "Categorical data (as implied by CPT) cannot be interpolated and require -T or just -Qm.\n");
+			Return (GMT_RUNTIME_ERROR);
 		}
 		if (cpt) gmt_M_str_free (cpt);
 	}


### PR DESCRIPTION
Similar issues as deal with in #4427. The other mapping selections in **-Q** requires contouring and interpolation.  All test still pass.
