### PR TITLE
psternary ignores -N

### DIFF
--- a/src/psternary.c
+++ b/src/psternary.c
@@ -532,6 +532,7 @@ EXTERN_MSC int GMT_psternary (void *V_API, int mode, void *args) {
 		if (Ctrl->C.active) {strcat (cmd, " -C"); if (Ctrl->C.string) strcat (cmd, Ctrl->C.string);}
 		else if (Ctrl->G.active) {strcat (cmd, " -G"); strcat (cmd, Ctrl->G.string);}
 		if (Ctrl->W.active) {strcat (cmd, " -W"); strcat (cmd, Ctrl->W.string);}
+		if (Ctrl->N.active) strcat (cmd, " -N");
 		if ((error = GMT_Call_Module (API, "psxy", GMT_MODULE_CMD, cmd))) {
 			GMT_Report (API, GMT_MSG_ERROR, "Unable to plot symbols\n");
 			Return (API->error);


### PR DESCRIPTION
The **-N** should be passed to psxy so that clipping is turned off.  This never happened
