### PR TITLE
Fix several psternary problems and add enhancements

### DIFF
--- a/doc/rst/source/psternary.rst
+++ b/doc/rst/source/psternary.rst
@@ -13,11 +13,10 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt psternary** [ *table* ]
-[ **-JX**\ *width* ]
+[ **-JX**\ [-]\ *width* ]
 [ |-R|\ *amin/amax/bmin/bmax/cmin/cmax* ]
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
-[ |-D| ]
 [ |-G|\ *fill* ]
 [ |-K| ]
 [ |-L|\ *a*\ /*b*\ /*c* ]

--- a/doc/rst/source/psternary.rst
+++ b/doc/rst/source/psternary.rst
@@ -17,6 +17,7 @@ Synopsis
 [ |-R|\ *amin/amax/bmin/bmax/cmin/cmax* ]
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
+[ |-D| ]
 [ |-G|\ *fill* ]
 [ |-K| ]
 [ |-L|\ *a*\ /*b*\ /*c* ]

--- a/doc/rst/source/ternary.rst
+++ b/doc/rst/source/ternary.rst
@@ -17,6 +17,7 @@ Synopsis
 [ |-R|\ *amin*\ /*amax*\ /*bmin*\ /*bmax*\ /*cmin*\ /*cmax* ]
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
+[ |-D| ]
 [ |-G|\ *fill* ]
 [ |-L|\ *a*\ /*b*\ /*c* ]
 [ |-M| ]

--- a/doc/rst/source/ternary.rst
+++ b/doc/rst/source/ternary.rst
@@ -13,11 +13,10 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt ternary** [ *table* ]
-[ **-JX**\ *width* ]
+[ **-JX**\ [-]\ *width* ]
 [ |-R|\ *amin*\ /*amax*\ /*bmin*\ /*bmax*\ /*cmin*\ /*cmax* ]
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
-[ |-D| ]
 [ |-G|\ *fill* ]
 [ |-L|\ *a*\ /*b*\ /*c* ]
 [ |-M| ]

--- a/doc/rst/source/ternary_common.rst_
+++ b/doc/rst/source/ternary_common.rst_
@@ -43,6 +43,11 @@ Optional Arguments
     shifted over by one column (optional size would be 5th rather than 4th
     field, etc.).  If modern mode and no argument is given then we select the current CPT.
 
+.. _-D:
+
+**-D**
+    Let positive axes direction be clock-wise [Default lets the *a, b, c* axes be
+    positive in a counter-clockwise direction].
 .. _-G:
 
 **-G**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
@@ -58,9 +63,10 @@ Optional Arguments
 .. _-L:
 
 **-L**\ *a*\ /*b*\ /*c*
-    Set the labels for the three diagram vertices [none].  These are placed a
-    distance of 3 times the :term:`MAP_LABEL_OFFSET`
-    setting from their respective corners.
+    Set the labels for the three diagram vertices where the component is 100% [none].
+    These are placed a distance of three times the :term:`MAP_LABEL_OFFSET`
+    setting from their respective corners.  To skip any one of then, specify that
+    label as -.
 
 .. _-M:
 

--- a/doc/rst/source/ternary_common.rst_
+++ b/doc/rst/source/ternary_common.rst_
@@ -43,11 +43,6 @@ Optional Arguments
     shifted over by one column (optional size would be 5th rather than 4th
     field, etc.).  If modern mode and no argument is given then we select the current CPT.
 
-.. _-D:
-
-**-D**
-    Let positive axes direction be clock-wise [Default lets the *a, b, c* axes be
-    positive in a counter-clockwise direction].
 .. _-G:
 
 **-G**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
@@ -57,8 +52,10 @@ Optional Arguments
 
 .. _-J:
 
-**-JX**\ *width*
+**-JX**\ [-]\ *width*
     The only valid projection is linear plot with specified ternary width.
+    Use a negative *width* to indicate that positive axes directions be clock-wise
+    [Default lets the *a, b, c* axes be positive in a counter-clockwise direction].
 
 .. _-L:
 

--- a/src/psternary.c
+++ b/src/psternary.c
@@ -493,7 +493,7 @@ EXTERN_MSC int GMT_psternary (void *V_API, int mode, void *args) {
 	x_origin[0] = 0.0;	y_origin[0] = 0.0;	rot[0] = 0.0;	sign[0] = +1;	side[0] = GMT->current.map.frame.side[S_SIDE]; cmode[0] = 'S';	/* S_SIDE settings */
 	x_origin[1] = -width * 0.25;	y_origin[1] = 0.5 * height;	rot[1] = -60.0;	sign[1] = -1;	side[1] = GMT->current.map.frame.side[E_SIDE]; cmode[1] = 'N';	/* E_SIDE settings */
 	x_origin[2] = 0.75 * width;	y_origin[2] = -0.5 * height;	rot[2] = 60.0;	sign[2] = -1;	side[2] = GMT->current.map.frame.side[W_SIDE]; cmode[2] = 'N';	/* W_SIDE settings */
-	if (Ctrl->D.active) {	/* Flip positive directions */
+	if (Ctrl->D.active) {	/* Flip what is positive directions */
 		for (k = 0; k <= GMT_Z; k++) sign[k] = - sign[k];
 	}
 	for (k = 0; k <= GMT_Z; k++) {	/* Plot the 3 axes for -B settings that have been stripped of gridline requests */

--- a/src/psternary.c
+++ b/src/psternary.c
@@ -487,9 +487,16 @@ EXTERN_MSC int GMT_psternary (void *V_API, int mode, void *args) {
 		double dx = L_off * cosd (30.0), dy = L_off * sind (30.0);
 		int form = gmt_setfont (GMT, &GMT->current.setting.font_label);
 		PSL_comment (PSL, "Placing vertices labels\n");
-		PSL_plottext (PSL, -dx, -dy, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_X], 0.0, PSL_TR, form);
-		PSL_plottext (PSL, tri_x[1]+dx, -dy, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_Y], 0.0, PSL_TL, form);
-		PSL_plottext (PSL, tri_x[2], tri_y[2]+L_off, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_Z], 0.0, PSL_BC, form);
+		if (Ctrl->D.active) {
+			PSL_plottext (PSL, -dx, -dy, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_X], 0.0, PSL_TR, form);
+			PSL_plottext (PSL, tri_x[1]+dx, -dy, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_Y], 0.0, PSL_TL, form);
+			PSL_plottext (PSL, tri_x[2], tri_y[2]+L_off, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_Z], 0.0, PSL_BC, form);
+		}
+		else {
+			PSL_plottext (PSL, -dx, -dy, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_Z], 0.0, PSL_TR, form);
+			PSL_plottext (PSL, tri_x[1]+dx, -dy, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_X], 0.0, PSL_TL, form);
+			PSL_plottext (PSL, tri_x[2], tri_y[2]+L_off, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_Y], 0.0, PSL_BC, form);
+		}
 	}
 
 	/* Now do axis annotations.  First set array args per axis: */

--- a/src/psternary.c
+++ b/src/psternary.c
@@ -334,10 +334,13 @@ GMT_LOCAL char * psternary_get_B_setting (struct GMT_OPTION *B) {
 
 GMT_LOCAL void psternary_abc_to_xy (double a, double b, double c, bool reverse, double *x, double *y) {
 	double s;
-	if (reverse) {	/* All axes are reversed in direction */
-		a = 1.0 - a;
-		b = 1.0 - b;
-		c = 1.0 - c;
+	/* Converts (a,b,c) to (x,y) assuming a = 1 (b = c = 0) is (0,0), b = 1 (a = c = 0) is (1,0) and c = 1 (a = b = 0) is (0.5, 0.866..).
+	 * Since our default setup is the opposite of this we reverse a,b,c if reverse is false */
+	if (!reverse) {	/* All axes are reversed in direction */
+		double tmp = c;
+		c = b;
+		b = a;
+		a = tmp;
 	}
 	s = (a + b + c);
 	*x = 0.5 * (2.0 * b + c) / s;

--- a/src/psternary.c
+++ b/src/psternary.c
@@ -397,6 +397,9 @@ EXTERN_MSC int GMT_psternary (void *V_API, int mode, void *args) {
 	if ((D = GMT_Read_Data (API, GMT_IS_DATASET, GMT_IS_FILE, 0, GMT_READ_NORMAL, NULL, NULL, NULL)) == NULL)
 		Return (API->error);
 
+	if (GMT->common.J.active && !Ctrl->D.active && GMT->common.J.string[1] == '-')	/* Gave a negative width to reverse axes */
+		Ctrl->D.active = true;	/* Need to do this here given the abs_to_xy projection below */
+
 	/* Convert a,b,c[,z] to to x,y[,z] */
 	for (tbl = 0; tbl < D->n_tables; tbl++) {	/* For each table */
 		for (seg = 0; seg < D->table[tbl]->n_segments; seg++) {	/* For each segment in the table */
@@ -422,7 +425,7 @@ EXTERN_MSC int GMT_psternary (void *V_API, int mode, void *args) {
 
 	/* Here we are doing some sort of plotting */
 
-	rect[XHI] = gmt_M_to_inch (GMT, &GMT->common.J.string[1]);
+	rect[XHI] = fabs (gmt_M_to_inch (GMT, &GMT->common.J.string[1]));	/* Sign has already been dealt with via Ctrl->D.active */
 	rect[YHI] =  0.5 * SQRT3 * rect[XHI];
 	tri_x[1] = rect[XHI];	tri_x[2] = 0.5 * rect[XHI];	tri_y[2] = rect[YHI];
 	gmt_M_memcpy (wesn_orig, GMT->common.R.wesn, 6, double);

--- a/src/psternary.c
+++ b/src/psternary.c
@@ -120,13 +120,14 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	gmt_fill_syntax (API->GMT, 'G', NULL, "Specify color or pattern [no fill].");
 	GMT_Message (API, GMT_TIME_NONE, "\t-J Use -JX<width> to set the plot base width.\n");
 	GMT_Option (API, "K");
-	GMT_Message (API, GMT_TIME_NONE, "\t-L Give labels for each of the 3 vertices [no labels].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-L Place labels where each of the three vertices reach 100%% [no labels].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Specify any label as - to skip that label only.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-M Convert (a,b,c) to normalized (x,y) and write to standard output.  No plotting occurs.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Do not skip or clip symbols that fall outside the map border [clipping is on]\n");
 	GMT_Option (API, "O,P,R");
 	//GMT_Message (API, GMT_TIME_NONE, "\t-Q Selects contouring.  Optionally append <cut>.  If given, then we do not draw\n");
 	//GMT_Message (API, GMT_TIME_NONE, "\t   closed contours with less than <cut> points [Draw all contours].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-S Select symbol type and symbol size (in %s).  See psxy for full list of symbols.\n",
+	GMT_Message (API, GMT_TIME_NONE, "\t-S Select symbol type and symbol size (in %s).  See plot|psxy for full list of symbols.\n",
 		API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit]);
 	GMT_Option (API, "U,V");
 	gmt_pen_syntax (API->GMT, 'W', NULL, "Set pen attributes [Default pen is %s]:", 15);
@@ -488,14 +489,14 @@ EXTERN_MSC int GMT_psternary (void *V_API, int mode, void *args) {
 		int form = gmt_setfont (GMT, &GMT->current.setting.font_label);
 		PSL_comment (PSL, "Placing vertices labels\n");
 		if (Ctrl->D.active) {
-			PSL_plottext (PSL, -dx, -dy, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_X], 0.0, PSL_TR, form);
-			PSL_plottext (PSL, tri_x[1]+dx, -dy, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_Y], 0.0, PSL_TL, form);
-			PSL_plottext (PSL, tri_x[2], tri_y[2]+L_off, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_Z], 0.0, PSL_BC, form);
+			if (strcmp (Ctrl->L.vlabel[GMT_X], "-")) PSL_plottext (PSL, -dx, -dy, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_X], 0.0, PSL_TR, form);
+			if (strcmp (Ctrl->L.vlabel[GMT_Y], "-")) PSL_plottext (PSL, tri_x[1]+dx, -dy, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_Y], 0.0, PSL_TL, form);
+			if (strcmp (Ctrl->L.vlabel[GMT_Z], "-")) PSL_plottext (PSL, tri_x[2], tri_y[2]+L_off, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_Z], 0.0, PSL_BC, form);
 		}
 		else {
-			PSL_plottext (PSL, -dx, -dy, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_Z], 0.0, PSL_TR, form);
-			PSL_plottext (PSL, tri_x[1]+dx, -dy, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_X], 0.0, PSL_TL, form);
-			PSL_plottext (PSL, tri_x[2], tri_y[2]+L_off, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_Y], 0.0, PSL_BC, form);
+			if (strcmp (Ctrl->L.vlabel[GMT_Z], "-")) PSL_plottext (PSL, -dx, -dy, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_Z], 0.0, PSL_TR, form);
+			if (strcmp (Ctrl->L.vlabel[GMT_X], "-")) PSL_plottext (PSL, tri_x[1]+dx, -dy, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_X], 0.0, PSL_TL, form);
+			if (strcmp (Ctrl->L.vlabel[GMT_Y], "-")) PSL_plottext (PSL, tri_x[2], tri_y[2]+L_off, GMT->current.setting.font_label.size, Ctrl->L.vlabel[GMT_Y], 0.0, PSL_BC, form);
 		}
 	}
 

--- a/test/psternary/corners.ps
+++ b/test/psternary/corners.ps
@@ -1,0 +1,1535 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.2.0_143ce07_2020.11.06 [64-bit] Document from psternary
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sat Nov  7 11:44:30 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
+  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
+  {pop pop} ifelse} ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+-2598 PSL_xorig sub PSL_page_xsize 2 div add 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt psternary t.txt -R0/100/0/100/0/100 -JX11c -P -Xc '-Bxafg+lA+u %' '-Byafg+lB+u %' '-Bzagf+lC+u %' -La/b/c -B+gbisque -Sc0.5c -Wthin -Ct.cpt -N -K -Jz1i
+%@PROJ: xy 0.00000000 4.33070866 0.00000000 3.75050372 0.000 4.331 0.000 3.751 +xy
+%GMTBoundingBox: -155.905511811 72 311.811023622 311.811023622
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+{1 0.894 0.769 C} FS
+-2599 4501 5197 0 2 0 0 SP
+25 W
+FQ
+O1
+-2599 4501 5197 0 2 0 0 SP
+-346 -200 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+267 F0
+(c) tr Z
+5543 -200 M (a) tl Z
+2598 4901 M (b) bc Z
+0 A
+FQ
+O0
+-2598 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/100/0/1 -JX4.33071i/3.7505i -O -K -BS '-Baf+lA+u %'
+%@PROJ: xy 0.00000000 100.00000000 0.00000000 1.00000000 0.000 100.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A [] 0 B
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 0 M 5197 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 1039 0 M 0 -83 D S
+N 2079 0 M 0 -83 D S
+N 3118 0 M 0 -83 D S
+N 4157 0 M 0 -83 D S
+N 5197 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+200 F0
+(0 %) sh mx
+(20 %) sh mx
+(40 %) sh mx
+(60 %) sh mx
+(80 %) sh mx
+(100 %) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0 %) bc Z
+1039 PSL_A0_y MM
+(20 %) bc Z
+2079 PSL_A0_y MM
+(40 %) bc Z
+3118 PSL_A0_y MM
+(60 %) bc Z
+4157 PSL_A0_y MM
+(80 %) bc Z
+5197 PSL_A0_y MM
+(100 %) bc Z
+N 520 0 M 0 -42 D S
+N 1559 0 M 0 -42 D S
+N 2598 0 M 0 -42 D S
+N 3638 0 M 0 -42 D S
+N 4677 0 M 0 -42 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
+2598 PSL_L_y MM
+(A) bc Z
+0 setlinecap
+%%EndObject
+-1299 2250 T
+-60 R
+0 A
+FQ
+O0
+-2598 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/100/0/1 -JX-4.33071i/3.7505i -O -K -BN '-Baf+lB+u %'
+%@PROJ: xy 0.00000000 100.00000000 0.00000000 1.00000000 100.000 -0.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A [] 0 B
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+0 4501 T
+N 0 0 M 5197 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 5197 0 M 0 83 D S
+N 4157 0 M 0 83 D S
+N 3118 0 M 0 83 D S
+N 2079 0 M 0 83 D S
+N 1039 0 M 0 83 D S
+N 0 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+200 F0
+(0 %) sh mx
+(20 %) sh mx
+(40 %) sh mx
+(60 %) sh mx
+(80 %) sh mx
+(100 %) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+5197 PSL_A0_y MM
+(0 %) bc Z
+4157 PSL_A0_y MM
+(20 %) bc Z
+3118 PSL_A0_y MM
+(40 %) bc Z
+2079 PSL_A0_y MM
+(60 %) bc Z
+1039 PSL_A0_y MM
+(80 %) bc Z
+0 PSL_A0_y MM
+(100 %) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 4677 0 M 0 42 D S
+N 3638 0 M 0 42 D S
+N 2598 0 M 0 42 D S
+N 1559 0 M 0 42 D S
+N 520 0 M 0 42 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
+2598 PSL_L_y MM
+(B) bc Z
+0 -4501 T
+0 setlinecap
+%%EndObject
+60 R
+1299 -2250 T
+3898 -2250 T
+60 R
+0 A
+FQ
+O0
+-2598 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/100/0/1 -JX-4.33071i/3.7505i -O -K -BN '-Baf+lC+u %'
+%@PROJ: xy 0.00000000 100.00000000 0.00000000 1.00000000 100.000 -0.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A [] 0 B
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+0 4501 T
+N 0 0 M 5197 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 5197 0 M 0 83 D S
+N 4157 0 M 0 83 D S
+N 3118 0 M 0 83 D S
+N 2079 0 M 0 83 D S
+N 1039 0 M 0 83 D S
+N 0 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+200 F0
+(0 %) sh mx
+(20 %) sh mx
+(40 %) sh mx
+(60 %) sh mx
+(80 %) sh mx
+(100 %) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+5197 PSL_A0_y MM
+(0 %) bc Z
+4157 PSL_A0_y MM
+(20 %) bc Z
+3118 PSL_A0_y MM
+(40 %) bc Z
+2079 PSL_A0_y MM
+(60 %) bc Z
+1039 PSL_A0_y MM
+(80 %) bc Z
+0 PSL_A0_y MM
+(100 %) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 4677 0 M 0 42 D S
+N 3638 0 M 0 42 D S
+N 2598 0 M 0 42 D S
+N 1559 0 M 0 42 D S
+N 520 0 M 0 42 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
+2598 PSL_L_y MM
+(C) bc Z
+0 -4501 T
+0 setlinecap
+%%EndObject
+-60 R
+-3898 2250 T
+clipsave
+0 0 M
+5197 0 D
+-2599 4501 D
+P
+PSL_clip N
+0 A
+FQ
+O0
+-2598 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/1/0/1 -JX4.33071i/3.7505i -O -K -B+n -Byg
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 0 M
+5197 0 D
+S
+0 450 M
+5197 0 D
+S
+0 900 M
+5197 0 D
+S
+0 1350 M
+5197 0 D
+S
+0 1800 M
+5197 0 D
+S
+0 2250 M
+5197 0 D
+S
+0 2700 M
+5197 0 D
+S
+0 3150 M
+5197 0 D
+S
+0 3600 M
+5197 0 D
+S
+0 4051 M
+5197 0 D
+S
+0 4501 M
+5197 0 D
+S
+%%EndObject
+-1299 2250 T
+-60 R
+0 A
+FQ
+O0
+-2598 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/1/0/1 -JX4.33071i/3.7505i -O -K -B+n -Byg
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 0 M
+5197 0 D
+S
+0 450 M
+5197 0 D
+S
+0 900 M
+5197 0 D
+S
+0 1350 M
+5197 0 D
+S
+0 1800 M
+5197 0 D
+S
+0 2250 M
+5197 0 D
+S
+0 2700 M
+5197 0 D
+S
+0 3150 M
+5197 0 D
+S
+0 3600 M
+5197 0 D
+S
+0 4051 M
+5197 0 D
+S
+0 4501 M
+5197 0 D
+S
+%%EndObject
+60 R
+1299 -2250 T
+3898 -2250 T
+60 R
+0 A
+FQ
+O0
+-2598 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/1/0/1 -JX4.33071i/3.7505i -O -K -B+n -Byg
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 0 M
+5197 0 D
+S
+0 450 M
+5197 0 D
+S
+0 900 M
+5197 0 D
+S
+0 1350 M
+5197 0 D
+S
+0 1800 M
+5197 0 D
+S
+0 2250 M
+5197 0 D
+S
+0 2700 M
+5197 0 D
+S
+0 3150 M
+5197 0 D
+S
+0 3600 M
+5197 0 D
+S
+0 4051 M
+5197 0 D
+S
+0 4501 M
+5197 0 D
+S
+%%EndObject
+-60 R
+-3898 2250 T
+PSL_cliprestore
+0 A
+FQ
+O0
+-2598 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R0/1/0/1 -JX4.33071i -O -K -Sc0.5c @GMTAPI@-S-I-D-D-T-N-000000 -Ct.cpt -Wthin -N
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_8
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+12 W
+V
+{1 0 0 C} FS
+O1
+118 5197 0 Sc
+{0 1 0 C} FS
+118 2598 4501 Sc
+{0 0 1 C} FS
+118 0 0 Sc
+{1 1 0 C} FS
+118 2079 900 Sc
+U
+%%EndObject
+%%EndObject
+0 A
+FQ
+O0
+-1417 3780 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R0/1/0/0.9 -JX6.5c/3c -O -K -F+f12p+jBL -X-3c -Y8c -B0
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 0.90000000 0.000 1.000 0.000 0.900 +xy
+%%BeginObject PSL_Layer_9
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3071 0 D
+0 1417 D
+-3071 0 D
+P
+PSL_clip N
+154 1102 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(a = 1, b = c = 0 \[red\]) bl Z
+154 787 M (b = 1, a = c = 0 \[green\]) bl Z
+154 472 M (c = 1, a = b = 0 \[blue\]) bl Z
+154 157 M (a = 0.3 b = 0.2 c = 0.5 \[yellow\]) bl Z
+PSL_cliprestore
+0 A [] 0 B
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 1417 M 0 -1417 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3071 0 T
+N 0 1417 M 0 -1417 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3071 0 T
+N 0 0 M 3071 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 1417 T
+N 0 0 M 3071 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -1417 T
+0 setlinecap
+%%EndObject
+0 A
+FQ
+O0
+1417 2362 TM
+
+% PostScript produced by:
+%@GMT: gmt psternary t.txt -R0/100/0/100/0/100 -JX11c -O '-Bxafg+lA+u %' '-Byafg+lB+u %' '-Bzagf+lC+u %' -B+gbisque -La/b/c -Sc0.5c -Wthin -Ct.cpt -D -N -X3c -Y5c -Jz1i
+%@PROJ: xy 0.00000000 4.33070866 0.00000000 3.75050372 0.000 4.331 0.000 3.751 +xy
+%%BeginObject PSL_Layer_10
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+{1 0.894 0.769 C} FS
+-2599 4501 5197 0 2 0 0 SP
+25 W
+FQ
+O1
+-2599 4501 5197 0 2 0 0 SP
+-346 -200 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+267 F0
+(a) tr Z
+5543 -200 M (b) tl Z
+2598 4901 M (c) bc Z
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/100/0/1 -JX-4.33071i/3.7505i -O -K -BS '-Baf+lA+u %'
+%@PROJ: xy 0.00000000 100.00000000 0.00000000 1.00000000 100.000 -0.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_11
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A [] 0 B
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 0 M 5197 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 5197 0 M 0 -83 D S
+N 4157 0 M 0 -83 D S
+N 3118 0 M 0 -83 D S
+N 2079 0 M 0 -83 D S
+N 1039 0 M 0 -83 D S
+N 0 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+200 F0
+(0 %) sh mx
+(20 %) sh mx
+(40 %) sh mx
+(60 %) sh mx
+(80 %) sh mx
+(100 %) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+5197 PSL_A0_y MM
+(0 %) bc Z
+4157 PSL_A0_y MM
+(20 %) bc Z
+3118 PSL_A0_y MM
+(40 %) bc Z
+2079 PSL_A0_y MM
+(60 %) bc Z
+1039 PSL_A0_y MM
+(80 %) bc Z
+0 PSL_A0_y MM
+(100 %) bc Z
+N 4677 0 M 0 -42 D S
+N 3638 0 M 0 -42 D S
+N 2598 0 M 0 -42 D S
+N 1559 0 M 0 -42 D S
+N 520 0 M 0 -42 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
+2598 PSL_L_y MM
+(A) bc Z
+0 setlinecap
+%%EndObject
+-1299 2250 T
+-60 R
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/100/0/1 -JX4.33071i/3.7505i -O -K -BN '-Baf+lB+u %'
+%@PROJ: xy 0.00000000 100.00000000 0.00000000 1.00000000 0.000 100.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_12
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A [] 0 B
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+0 4501 T
+N 0 0 M 5197 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 1039 0 M 0 83 D S
+N 2079 0 M 0 83 D S
+N 3118 0 M 0 83 D S
+N 4157 0 M 0 83 D S
+N 5197 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+200 F0
+(0 %) sh mx
+(20 %) sh mx
+(40 %) sh mx
+(60 %) sh mx
+(80 %) sh mx
+(100 %) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0 %) bc Z
+1039 PSL_A0_y MM
+(20 %) bc Z
+2079 PSL_A0_y MM
+(40 %) bc Z
+3118 PSL_A0_y MM
+(60 %) bc Z
+4157 PSL_A0_y MM
+(80 %) bc Z
+5197 PSL_A0_y MM
+(100 %) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 520 0 M 0 42 D S
+N 1559 0 M 0 42 D S
+N 2598 0 M 0 42 D S
+N 3638 0 M 0 42 D S
+N 4677 0 M 0 42 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
+2598 PSL_L_y MM
+(B) bc Z
+0 -4501 T
+0 setlinecap
+%%EndObject
+60 R
+1299 -2250 T
+3898 -2250 T
+60 R
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/100/0/1 -JX4.33071i/3.7505i -O -K -BN '-Baf+lC+u %'
+%@PROJ: xy 0.00000000 100.00000000 0.00000000 1.00000000 0.000 100.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_13
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A [] 0 B
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+0 4501 T
+N 0 0 M 5197 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 1039 0 M 0 83 D S
+N 2079 0 M 0 83 D S
+N 3118 0 M 0 83 D S
+N 4157 0 M 0 83 D S
+N 5197 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+200 F0
+(0 %) sh mx
+(20 %) sh mx
+(40 %) sh mx
+(60 %) sh mx
+(80 %) sh mx
+(100 %) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0 %) bc Z
+1039 PSL_A0_y MM
+(20 %) bc Z
+2079 PSL_A0_y MM
+(40 %) bc Z
+3118 PSL_A0_y MM
+(60 %) bc Z
+4157 PSL_A0_y MM
+(80 %) bc Z
+5197 PSL_A0_y MM
+(100 %) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 520 0 M 0 42 D S
+N 1559 0 M 0 42 D S
+N 2598 0 M 0 42 D S
+N 3638 0 M 0 42 D S
+N 4677 0 M 0 42 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
+2598 PSL_L_y MM
+(C) bc Z
+0 -4501 T
+0 setlinecap
+%%EndObject
+-60 R
+-3898 2250 T
+clipsave
+0 0 M
+5197 0 D
+-2599 4501 D
+P
+PSL_clip N
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/1/0/1 -JX4.33071i/3.7505i -O -K -B+n -Byg
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_14
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 0 M
+5197 0 D
+S
+0 450 M
+5197 0 D
+S
+0 900 M
+5197 0 D
+S
+0 1350 M
+5197 0 D
+S
+0 1800 M
+5197 0 D
+S
+0 2250 M
+5197 0 D
+S
+0 2700 M
+5197 0 D
+S
+0 3150 M
+5197 0 D
+S
+0 3600 M
+5197 0 D
+S
+0 4051 M
+5197 0 D
+S
+0 4501 M
+5197 0 D
+S
+%%EndObject
+-1299 2250 T
+-60 R
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/1/0/1 -JX4.33071i/3.7505i -O -K -B+n -Byg
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_15
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 0 M
+5197 0 D
+S
+0 450 M
+5197 0 D
+S
+0 900 M
+5197 0 D
+S
+0 1350 M
+5197 0 D
+S
+0 1800 M
+5197 0 D
+S
+0 2250 M
+5197 0 D
+S
+0 2700 M
+5197 0 D
+S
+0 3150 M
+5197 0 D
+S
+0 3600 M
+5197 0 D
+S
+0 4051 M
+5197 0 D
+S
+0 4501 M
+5197 0 D
+S
+%%EndObject
+60 R
+1299 -2250 T
+3898 -2250 T
+60 R
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/1/0/1 -JX4.33071i/3.7505i -O -K -B+n -Byg
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_16
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 0 M
+5197 0 D
+S
+0 450 M
+5197 0 D
+S
+0 900 M
+5197 0 D
+S
+0 1350 M
+5197 0 D
+S
+0 1800 M
+5197 0 D
+S
+0 2250 M
+5197 0 D
+S
+0 2700 M
+5197 0 D
+S
+0 3150 M
+5197 0 D
+S
+0 3600 M
+5197 0 D
+S
+0 4051 M
+5197 0 D
+S
+0 4501 M
+5197 0 D
+S
+%%EndObject
+-60 R
+-3898 2250 T
+PSL_cliprestore
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R0/1/0/1 -JX4.33071i -O -K -Sc0.5c @GMTAPI@-S-I-D-D-T-N-000000 -Ct.cpt -Wthin -N
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_17
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+12 W
+V
+{1 0 0 C} FS
+O1
+118 0 0 Sc
+{0 1 0 C} FS
+118 5197 0 Sc
+{0 0 1 C} FS
+118 2598 4501 Sc
+{1 1 0 C} FS
+118 2339 2250 Sc
+U
+%%EndObject
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/psternary/corners.sh
+++ b/test/psternary/corners.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Calibration plot for ternary with or without -D
+# Ensure psternary places points correctly by plotting the
+# three cardinal corners and a 4th point
+# Pick (a,b,c) for the three corners (100%) and a 4th point
+ps=corners.ps
+cat << EOF > t.txt
+1	0	0	0
+0	1	0	1
+0	0	1	2
+0.3	0.2	0.5	3
+EOF
+gmt makecpt -Cred,green,blue,yellow -T0/4/1 > t.cpt
+# Plot points using default counter-clockwise axes directions
+gmt psternary t.txt -R0/100/0/100/0/100 -JX11c -P -Xc -Baafg+l"A"+u" %" -Bbafg+l"B"+u" %" \
+-Bcagf+l"C"+u" %" -La/b/c -B+gbisque -Sc0.5c -Wthin -Ct.cpt -N -K > $ps
+gmt pstext -R0/1/0/0.9 -JX6.5c/3c -O -K -F+f12p+jBL -X-3c -Y8c -B0 << EOF >> $ps
+0.05	0.7	a = 1, b = c = 0 [red]
+0.05	0.5	b = 1, a = c = 0 [green]
+0.05	0.3	c = 1, a = b = 0 [blue]
+0.05	0.1	a = 0.4 b = 0.2 c = 0.5 [yellow]
+EOF
+# Now plot again with clockwise axes directions
+gmt psternary t.txt -R0/100/0/100/0/100 -JX11c -O -Baafg+l"A"+u" %" -Bbafg+l"B"+u" %" \
+-Bcagf+l"C"+u" %" -B+gbisque -La/b/c -Sc0.5c -Wthin -Ct.cpt -D -N -X3c -Y5c >> $ps

--- a/test/psternary/corners.sh
+++ b/test/psternary/corners.sh
@@ -18,7 +18,7 @@ gmt pstext -R0/1/0/0.9 -JX6.5c/3c -O -K -F+f12p+jBL -X-3c -Y8c -B0 << EOF >> $ps
 0.05	0.7	a = 1, b = c = 0 [red]
 0.05	0.5	b = 1, a = c = 0 [green]
 0.05	0.3	c = 1, a = b = 0 [blue]
-0.05	0.1	a = 0.4 b = 0.2 c = 0.5 [yellow]
+0.05	0.1	a = 0.3 b = 0.2 c = 0.5 [yellow]
 EOF
 # Now plot again with clockwise axes directions
 gmt psternary t.txt -R0/100/0/100/0/100 -JX11c -O -Baafg+l"A"+u" %" -Bbafg+l"B"+u" %" \

--- a/test/psternary/corners.sh
+++ b/test/psternary/corners.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Calibration plot for ternary with or without -D
+# Calibration plot for ternary with or without axes reversal
 # Ensure psternary places points correctly by plotting the
 # three cardinal corners and a 4th point
 # Pick (a,b,c) for the three corners (100%) and a 4th point
@@ -21,5 +21,5 @@ gmt pstext -R0/1/0/0.9 -JX6.5c/3c -O -K -F+f12p+jBL -X-3c -Y8c -B0 << EOF >> $ps
 0.05	0.1	a = 0.3 b = 0.2 c = 0.5 [yellow]
 EOF
 # Now plot again with clockwise axes directions
-gmt psternary t.txt -R0/100/0/100/0/100 -JX11c -O -Baafg+l"A"+u" %" -Bbafg+l"B"+u" %" \
--Bcagf+l"C"+u" %" -B+gbisque -La/b/c -Sc0.5c -Wthin -Ct.cpt -D -N -X3c -Y5c >> $ps
+gmt psternary t.txt -R0/100/0/100/0/100 -JX-11c -O -Baafg+l"A"+u" %" -Bbafg+l"B"+u" %" \
+-Bcagf+l"C"+u" %" -B+gbisque -La/b/c -Sc0.5c -Wthin -Ct.cpt -N -X3c -Y5c >> $ps

--- a/test/psternary/ternary.ps
+++ b/test/psternary/ternary.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
-%%HiResBoundingBox: 0 0 612 792             
-%%Title: GMT v5.4.0_r17854M [64-bit] Document from psternary
-%%Creator: GMT5
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.2.0_dafd753_2020.11.07 [64-bit] Document from psternary
+%%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Apr  3 11:18:40 2017
+%%CreationDate: Sat Nov  7 12:08:19 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -116,39 +116,39 @@
   /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
   {pop pop} ifelse} ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -646,6 +646,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -657,25 +658,31 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
 0 A
 FQ
 O0
 -3600 PSL_xorig sub PSL_page_xsize 2 div add 2400 TM
 
 % PostScript produced by:
-%@GMT: psternary ./ternary.txt -R0/100/0/100/0/100 -JX6i -P -Xc '-Bxafg+lWater component+u %' '-Byafg+lAir component+u %' '-Bzagf+lLimestone component+u %' '-B+givory+tExample data from MATLAB Central' -Sc0.1c -Ct.cpt -K -Y2i -LWater/Air/Limestone -Jz1i
+%@GMT: gmt psternary /Users/pwessel/GMTdev/gmt-dev/test/psternary/ternary.txt -R0/100/0/100/0/100 -JX6i -P -Xc '-Bxafg+lWater component+u %' '-Byafg+lAir component+u %' '-Bzagf+lLimestone component+u %' '-B+givory+tExample data from MATLAB Central' -Sc0.1c -Ct.cpt -K -Y2i -LWater/Air/Limestone -D -Jz1i
 %@PROJ: xy 0.00000000 6.00000000 0.00000000 5.19615242 0.000 6.000 0.000 5.196 +xy
+%GMTBoundingBox: -216 144 432 432
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {1 1 0.941 C} FS
 -3600 6235 7200 0 2 0 0 SP
 25 W
 FQ
 O1
 -3600 6235 7200 0 2 0 0 SP
-3600 7169 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+3600 7169 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 (Example data from MATLAB Central) bc Z
 -346 -200 M 267 F0
@@ -688,26 +695,28 @@ O0
 -3600 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R0/100/0/1 -JX6i/5.19615i -O -K -BS '-Baf+lWater component+u %'
-%@PROJ: xy 0.00000000 100.00000000 0.00000000 1.00000000 0.000 100.000 0.000 1.000 +xy
+%@GMT: gmt psbasemap -R0/100/0/1 -JX-6i/5.19615i -O -K -BS '-Baf+lWater component+u %'
+%@PROJ: xy 0.00000000 100.00000000 0.00000000 1.00000000 100.000 -0.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
+0 A [] 0 B
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 N 0 0 M 7200 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
-N 0 0 M 0 -83 D S
-N 1440 0 M 0 -83 D S
-N 2880 0 M 0 -83 D S
-N 4320 0 M 0 -83 D S
-N 5760 0 M 0 -83 D S
 N 7200 0 M 0 -83 D S
-/PSL_AH0 0
+N 5760 0 M 0 -83 D S
+N 4320 0 M 0 -83 D S
+N 2880 0 M 0 -83 D S
+N 1440 0 M 0 -83 D S
+N 0 0 M 0 -83 D S
 /MM {neg M} def
+/PSL_AH0 0
 200 F0
 (0 %) sh mx
 (20 %) sh mx
@@ -717,23 +726,23 @@ N 7200 0 M 0 -83 D S
 (100 %) sh mx
 def
 /PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
-0 PSL_A0_y MM
-(0 %) bc Z
-1440 PSL_A0_y MM
-(20 %) bc Z
-2880 PSL_A0_y MM
-(40 %) bc Z
-4320 PSL_A0_y MM
-(60 %) bc Z
-5760 PSL_A0_y MM
-(80 %) bc Z
 7200 PSL_A0_y MM
+(0 %) bc Z
+5760 PSL_A0_y MM
+(20 %) bc Z
+4320 PSL_A0_y MM
+(40 %) bc Z
+2880 PSL_A0_y MM
+(60 %) bc Z
+1440 PSL_A0_y MM
+(80 %) bc Z
+0 PSL_A0_y MM
 (100 %) bc Z
-N 720 0 M 0 -42 D S
-N 2160 0 M 0 -42 D S
-N 3600 0 M 0 -42 D S
-N 5040 0 M 0 -42 D S
 N 6480 0 M 0 -42 D S
+N 5040 0 M 0 -42 D S
+N 3600 0 M 0 -42 D S
+N 2160 0 M 0 -42 D S
+N 720 0 M 0 -42 D S
 /PSL_LH 267 F0
 (M) sh def
 /PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
@@ -749,27 +758,29 @@ O0
 -3600 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R0/100/0/1 -JX-6i/5.19615i -O -K -BN '-Baf+lAir component+u %'
-%@PROJ: xy 0.00000000 100.00000000 0.00000000 1.00000000 100.000 -0.000 0.000 1.000 +xy
+%@GMT: gmt psbasemap -R0/100/0/1 -JX6i/5.19615i -O -K -BN '-Baf+lAir component+u %'
+%@PROJ: xy 0.00000000 100.00000000 0.00000000 1.00000000 0.000 100.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
+0 A [] 0 B
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 0 6235 T
 N 0 0 M 7200 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
-N 7200 0 M 0 83 D S
-N 5760 0 M 0 83 D S
-N 4320 0 M 0 83 D S
-N 2880 0 M 0 83 D S
-N 1440 0 M 0 83 D S
 N 0 0 M 0 83 D S
-/PSL_AH0 0
+N 1440 0 M 0 83 D S
+N 2880 0 M 0 83 D S
+N 4320 0 M 0 83 D S
+N 5760 0 M 0 83 D S
+N 7200 0 M 0 83 D S
 /MM {M} def
+/PSL_AH0 0
 200 F0
 (0 %) sh mx
 (20 %) sh mx
@@ -779,24 +790,24 @@ N 0 0 M 0 83 D S
 (100 %) sh mx
 def
 /PSL_A0_y PSL_A0_y 83 add def
-7200 PSL_A0_y MM
-(0 %) bc Z
-5760 PSL_A0_y MM
-(20 %) bc Z
-4320 PSL_A0_y MM
-(40 %) bc Z
-2880 PSL_A0_y MM
-(60 %) bc Z
-1440 PSL_A0_y MM
-(80 %) bc Z
 0 PSL_A0_y MM
+(0 %) bc Z
+1440 PSL_A0_y MM
+(20 %) bc Z
+2880 PSL_A0_y MM
+(40 %) bc Z
+4320 PSL_A0_y MM
+(60 %) bc Z
+5760 PSL_A0_y MM
+(80 %) bc Z
+7200 PSL_A0_y MM
 (100 %) bc Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 6480 0 M 0 42 D S
-N 5040 0 M 0 42 D S
-N 3600 0 M 0 42 D S
-N 2160 0 M 0 42 D S
 N 720 0 M 0 42 D S
+N 2160 0 M 0 42 D S
+N 3600 0 M 0 42 D S
+N 5040 0 M 0 42 D S
+N 6480 0 M 0 42 D S
 /PSL_LH 267 F0
 (M) sh def
 /PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
@@ -815,27 +826,29 @@ O0
 -3600 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R0/100/0/1 -JX-6i/5.19615i -O -K -BN '-Baf+lLimestone component+u %'
-%@PROJ: xy 0.00000000 100.00000000 0.00000000 1.00000000 100.000 -0.000 0.000 1.000 +xy
+%@GMT: gmt psbasemap -R0/100/0/1 -JX6i/5.19615i -O -K -BN '-Baf+lLimestone component+u %'
+%@PROJ: xy 0.00000000 100.00000000 0.00000000 1.00000000 0.000 100.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
+0 A [] 0 B
 25 W
+/PSL_slant_y 0 def
 2 setlinecap
 0 6235 T
 N 0 0 M 7200 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
-N 7200 0 M 0 83 D S
-N 5760 0 M 0 83 D S
-N 4320 0 M 0 83 D S
-N 2880 0 M 0 83 D S
-N 1440 0 M 0 83 D S
 N 0 0 M 0 83 D S
-/PSL_AH0 0
+N 1440 0 M 0 83 D S
+N 2880 0 M 0 83 D S
+N 4320 0 M 0 83 D S
+N 5760 0 M 0 83 D S
+N 7200 0 M 0 83 D S
 /MM {M} def
+/PSL_AH0 0
 200 F0
 (0 %) sh mx
 (20 %) sh mx
@@ -845,24 +858,24 @@ N 0 0 M 0 83 D S
 (100 %) sh mx
 def
 /PSL_A0_y PSL_A0_y 83 add def
-7200 PSL_A0_y MM
-(0 %) bc Z
-5760 PSL_A0_y MM
-(20 %) bc Z
-4320 PSL_A0_y MM
-(40 %) bc Z
-2880 PSL_A0_y MM
-(60 %) bc Z
-1440 PSL_A0_y MM
-(80 %) bc Z
 0 PSL_A0_y MM
+(0 %) bc Z
+1440 PSL_A0_y MM
+(20 %) bc Z
+2880 PSL_A0_y MM
+(40 %) bc Z
+4320 PSL_A0_y MM
+(60 %) bc Z
+5760 PSL_A0_y MM
+(80 %) bc Z
+7200 PSL_A0_y MM
 (100 %) bc Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 6480 0 M 0 42 D S
-N 5040 0 M 0 42 D S
-N 3600 0 M 0 42 D S
-N 2160 0 M 0 42 D S
 N 720 0 M 0 42 D S
+N 2160 0 M 0 42 D S
+N 3600 0 M 0 42 D S
+N 5040 0 M 0 42 D S
+N 6480 0 M 0 42 D S
 /PSL_LH 267 F0
 (M) sh def
 /PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
@@ -885,13 +898,12 @@ O0
 -3600 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R0/1/0/1 -JX6i/5.19615i -O -K -B+n -Byg
+%@GMT: gmt psbasemap -R0/1/0/1 -JX6i/5.19615i -O -K -B+n -Byg
 %@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
-25 W
+3.32550952342 setmiterlimit
 4 W
 0 0 M
 7200 0 D
@@ -935,13 +947,12 @@ O0
 -3600 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R0/1/0/1 -JX6i/5.19615i -O -K -B+n -Byg
+%@GMT: gmt psbasemap -R0/1/0/1 -JX6i/5.19615i -O -K -B+n -Byg
 %@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
-25 W
+3.32550952342 setmiterlimit
 4 W
 0 0 M
 7200 0 D
@@ -987,13 +998,12 @@ O0
 -3600 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
 
 % PostScript produced by:
-%@GMT: psbasemap -R0/1/0/1 -JX6i/5.19615i -O -K -B+n -Byg
+%@GMT: gmt psbasemap -R0/1/0/1 -JX6i/5.19615i -O -K -B+n -Byg
 %@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_7
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
-25 W
+3.32550952342 setmiterlimit
 4 W
 0 0 M
 7200 0 D
@@ -1038,17 +1048,18 @@ O0
 -3600 PSL_xorig sub PSL_page_xsize 2 div add 0 TM
 
 % PostScript produced by:
-%@GMT: psxy -R0/1/0/1 -JX6i -O -K -Sc0.1c @GMTAPI@-000000 -Ct.cpt
+%@GMT: gmt psxy -R0/1/0/1 -JX6i -O -K -Sc0.1c @GMTAPI@-S-I-D-D-T-N-000000 -Ct.cpt
 %@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_8
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 clipsave
 0 0 M
 7200 0 D
 0 7200 D
 -7200 0 D
+P
 PSL_clip N
 4 W
 V
@@ -3062,12 +3073,12 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: psscale -R0/100/0/100 -JX6i -O -Ct.cpt -DJCB+o0/0.75i -Baf
+%@GMT: gmt psscale -R0/100/0/100 -JX6i -O -Ct.cpt -DJCB+o0/0.75i -Baf
 %@PROJ: xy 0.00000000 100.00000000 0.00000000 100.00000000 0.000 100.000 0.000 100.000 +xy
 %%BeginObject PSL_Layer_9
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 720 -1130 T
 25 W
 V N 0 0 T 5760 230 scale /DeviceRGB setcolorspace
@@ -3116,9 +3127,9 @@ N 0 0 M 0 -83 D S
 N 1646 0 M 0 -83 D S
 N 3291 0 M 0 -83 D S
 N 4937 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sh mx
 (20) sh mx
@@ -3142,6 +3153,11 @@ N 5760 0 M 0 -42 D S
 0 setlinecap
 -720 1130 T
 %%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
 %%PageTrailer
 U
 showpage

--- a/test/psternary/ternary.sh
+++ b/test/psternary/ternary.sh
@@ -2,6 +2,6 @@
 # Test ternary diagram plotting a dataset from Matlab exchange
 ps=ternary.ps
 gmt makecpt -T0/70 -Cjet > t.cpt
-gmt psternary ${src:-.}/ternary.txt -R0/100/0/100/0/100 -JX6i -P -Xc -Baafg+l"Water component"+u" %" -Bbafg+l"Air component"+u" %" \
--Bcagf+l"Limestone component"+u" %" -B+givory+t"Example data from MATLAB Central" -Sc0.1c -Ct.cpt -K -Y2i -LWater/Air/Limestone -D > $ps
+gmt psternary ${src:-.}/ternary.txt -R0/100/0/100/0/100 -JX-6i -P -Xc -Baafg+l"Water component"+u" %" -Bbafg+l"Air component"+u" %" \
+-Bcagf+l"Limestone component"+u" %" -B+givory+t"Example data from MATLAB Central" -Sc0.1c -Ct.cpt -K -Y2i -LWater/Air/Limestone > $ps
 gmt psscale -R0/100/0/100 -J -O -Ct.cpt -DJCB+o0/0.75i -Baf >> $ps

--- a/test/psternary/ternary.sh
+++ b/test/psternary/ternary.sh
@@ -3,5 +3,5 @@
 ps=ternary.ps
 gmt makecpt -T0/70 -Cjet > t.cpt
 gmt psternary ${src:-.}/ternary.txt -R0/100/0/100/0/100 -JX6i -P -Xc -Baafg+l"Water component"+u" %" -Bbafg+l"Air component"+u" %" \
--Bcagf+l"Limestone component"+u" %" -B+givory+t"Example data from MATLAB Central" -Sc0.1c -Ct.cpt -K -Y2i -LWater/Air/Limestone > $ps
+-Bcagf+l"Limestone component"+u" %" -B+givory+t"Example data from MATLAB Central" -Sc0.1c -Ct.cpt -K -Y2i -LWater/Air/Limestone -D > $ps
 gmt psscale -R0/100/0/100 -J -O -Ct.cpt -DJCB+o0/0.75i -Baf >> $ps


### PR DESCRIPTION
**Description of proposed changes**

This PR started with trying to address the [forum request](https://forum.generic-mapping-tools.org/t/how-to-reverse-the-axis-of-the-psternary-plot/978/3) to plot the axes in reverse direction.  This is now an option via the new **-D** selection.  However, in the process of testing this I discovered that the points plotted and the axes orientations where out of sync.  The initial implementation of **psternary** basically assumed that the axes were positive in a clock-wise orientation but instead they were plotted in a counter-clockwise orientation.  A separate PR fixed the ignoring of -N (#4431).  This PR addresses therefore several things:

1. It adds **-D** to reverse the axes orientations.
2. It fixes the mixup between projecting (_a,b,c_) to (_x,y_) for the two -D settings.
3. It adds a new test (_corners.sh_) that ensures end-member points (1,0,0), (0,1,0) and (0,0,1) correctly plots.
4. It adds _-D_ to the existing _psternary.sh_ script so that the axes are in the correct order for that example.
5. It adjusts the placement of vertices labels (**-L**) which is affected by **-D**.
6. It allows any of the **-L** labels to be given as - which skips that label.

The psternary.ps original has been updated and all tests pass.  Below is the corners.png result showing correct calibrations:

![corners](https://user-images.githubusercontent.com/26473567/98452403-22ec8600-20f3-11eb-967f-363482321a71.png)