### PR TITLE
Add internal VE = vertical exaggeration variable

### DIFF
--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -2730,11 +2730,11 @@ GMT_LOCAL int gmtmap_init_linear (struct GMT_CTRL *GMT, bool *search) {
 		GMT->current.map.clip = &map_wesn_clip;
 	}
 	else {
-		double VE = GMT->current.proj.scale[GMT_Y] / GMT->current.proj.scale[GMT_X];
-		if (VE < 1.0)
-			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Linear projection implies x-axis distance exaggeration relative to the y-axis by a factor of %g\n", VE);
-		else if (VE > 1.0)
-			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Linear projection implies y-axis distance exaggeration relative to the x-axis by a factor of %g\n", VE);
+		GMT->current.proj.VE = GMT->current.proj.scale[GMT_Y] / GMT->current.proj.scale[GMT_X];
+		if (GMT->current.proj.VE < 1.0)
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Linear projection implies x-axis distance exaggeration relative to the y-axis by a factor of %g\n", GMT->current.proj.VE);
+		else if (GMT->current.proj.VE > 1.0)
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Linear projection implies y-axis distance exaggeration relative to the x-axis by a factor of %g\n", GMT->current.proj.VE);
 
 		GMT->current.map.outside = &gmtmap_rect_outside;
 		GMT->current.map.crossing = &gmtmap_rect_crossing;

--- a/src/gmt_project.h
+++ b/src/gmt_project.h
@@ -314,6 +314,7 @@ struct GMT_PROJ {
 	bool compute_scale[3];	/* true if axes lengths were set rather than scales */
 	double xyz_pow[3];		/* For GMT_POW projection */
 	double xyz_ipow[3];
+	double VE;				/* Vertical exaggeration for x-z plots */
 
 	/* Center of radii for all conic projections */
 


### PR DESCRIPTION
This means we can use it in other modules for information or potentially a new map embellishment to show angular distortions.  No effects on tests, etc.
