### PR TITLE
Use named constants rather than 1 and 2 to flag categorical CPTs

### DIFF
--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -239,6 +239,8 @@ enum GMT_enum_basemap {
 #define GMT_CPT_Z_REVERSE	2	/* Reverse CPT z-values */
 #define GMT_CPT_L_ANNOT		1	/* Annotate lower slice boundary */
 #define GMT_CPT_U_ANNOT		2	/* Annotate upper slice boundary */
+#define GMT_CPT_CATEGORICAL_VAL		1	/* Categorical CPT with numerical value */
+#define GMT_CPT_CATEGORICAL_KEY		2	/* Categorical CPT with text key */
 
 /* Default CPT if nothing specified or overruled by remote dataset preferences */
 #define GMT_DEFAULT_CPT_NAME	"turbo"

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -7200,7 +7200,7 @@ int gmt_parse_segment_header (struct GMT_CTRL *GMT, char *header, struct GMT_PAL
 					}
 					break;
 				case GMT_IS_Z:
-					if (P->categorical & 2)
+					if (P->categorical & GMT_CPT_CATEGORICAL_KEY)
 						gmt_get_fill_from_key (GMT, P, txt, fill);
 					else
 						gmt_get_fill_from_z (GMT, P, z, fill);
@@ -7252,7 +7252,7 @@ int gmt_parse_segment_header (struct GMT_CTRL *GMT, char *header, struct GMT_PAL
 			processed++;	/* Processed one option */
 		}
 		else {
-			if (P->categorical & 2)
+			if (P->categorical & GMT_CPT_CATEGORICAL_KEY)
 				gmt_get_fill_from_key (GMT, P, line, fill);
 			else if (sscanf (line, "%lg", &z) == 1)
 				gmt_get_fill_from_z (GMT, P, z, fill);

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -619,7 +619,7 @@ struct GMT_PALETTE {		/* Holds all pen, color, and fill-related parameters */
 	unsigned int has_pattern;	/* 1 if CPT contains any patterns */
 	unsigned int has_hinge;		/* 1 if CPT is hinged at hinge (below) */
 	unsigned int has_range;		/* 1 if CPT has a natural range (minmax below) */
-	unsigned int categorical;	/* 1 if CPT applies to categorical data */
+	unsigned int categorical;	/* 1 if CPT applies to categorical data, and 2 if key is a string */
 	double minmax[2];		/* Min/max z-value for a default range, if given */
 	double hinge;			/* z-value for hinged CPTs */
 	double wrap_length;		/* z-length of active CPT */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7295,7 +7295,7 @@ void gmtlib_copy_palette (struct GMT_CTRL *GMT, struct GMT_PALETTE *P_to, struct
 	P_to->has_pattern = P_from->has_pattern;	/* 1 if CPT contains any patterns */
 	P_to->has_hinge = P_from->has_hinge;		/* 1 if CPT is hinged at hinge (below) */
 	P_to->has_range = P_from->has_range;		/* 1 if CPT has a natural range (minmax below) */
-	P_to->categorical = P_from->categorical;	/* 1 if CPT applies to categorical data */
+	P_to->categorical = P_from->categorical;	/* 1 (number) or 2 (key) if CPT applies to categorical data */
 	P_to->hinge = P_from->hinge;				/* z-value for hinged CPTs */
 	P_to->wrap_length = P_from->wrap_length;	/* z-length of active CPT */
 	gmt_M_memcpy (P_to->minmax, P_from->minmax, 2, double);	/* Min/max z-value for a default range, if given */
@@ -7725,7 +7725,7 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 		if (nread == 2 && gmt_not_numeric (GMT, T0)) {	/* Truly categorical CPT with named key */
 			X->data[n].z_low = n;	/* Just use counter as z value dummy */
 			X->data[n].key = (T0[0] == '\\') ? strdup (&T0[1]) : strdup (T0);	/* Skip escape: For user to have a name like B it must be \B to avoid conflict with BNF settings*/
-			X->categorical |= 2;	/* Flag this type of CPT */
+			X->categorical |= GMT_CPT_CATEGORICAL_KEY;	/* Flag this type of CPT */
 		}
 		else {	/* Floating point lookup values */
 			gmt_scanf_arg (GMT, T0, GMT_IS_UNKNOWN, false, &X->data[n].z_low);
@@ -7757,7 +7757,7 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 			else if (nread == 2) {	/* Categorical cpt records with key fill [;label] */
 				X->data[n].z_high = X->data[n].z_low;
 				n_cat_records++;
-				X->categorical |= 1;
+				X->categorical |= GMT_CPT_CATEGORICAL_VAL;
 			}
 			else if (nread == 4) {
 				gmt_scanf_arg (GMT, T2, GMT_IS_UNKNOWN, false, &X->data[n].z_high);
@@ -7781,7 +7781,7 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 				snprintf (clo, GMT_LEN64, "%s", T1);
 				sprintf (chi, "-");
 				n_cat_records++;
-				X->categorical |= 1;
+				X->categorical |= GMT_CPT_CATEGORICAL_VAL;
 			}
 			else if (nread == 4) {	/* gray shades or color names */
 				gmt_scanf_arg (GMT, T2, GMT_IS_UNKNOWN, false, &X->data[n].z_high);
@@ -8646,7 +8646,7 @@ int gmtlib_write_cpt (struct GMT_CTRL *GMT, void *dest, unsigned int dest_type, 
 	 */
 
 	unsigned int i, append = 0, hinge_mode = 0;
-	bool close_file = false;
+	bool close_file = false, use[3] = {true, true, true};
 	double cmyk[5], z_hinge;
 	char format[GMT_BUFSIZ] = {""}, cpt_file[PATH_MAX] = {""}, code[3] = {'B', 'F', 'N'};
 	char lo[GMT_LEN64] = {""}, hi[GMT_LEN64] = {""}, kind[3] = {'L', 'U', 'B'};
@@ -8743,7 +8743,7 @@ int gmtlib_write_cpt (struct GMT_CTRL *GMT, void *dest, unsigned int dest_type, 
 		gmt_ascii_format_col (GMT, hi, P->data[i].z_high, GMT_OUT, GMT_Z);
 
 		if (P->categorical) {
-			if (P->categorical == 2) strncpy (lo, P->data[i].key, GMT_LEN64-1);
+			if (P->categorical & GMT_CPT_CATEGORICAL_KEY) strncpy (lo, P->data[i].key, GMT_LEN64-1);
 			if (P->model & GMT_HSV)
 				fprintf (fp, format, lo, gmtlib_puthsv (GMT, P->data[i].hsv_low), '\t');
 			else if (P->model & GMT_CMYK) {
@@ -8785,7 +8785,10 @@ int gmtlib_write_cpt (struct GMT_CTRL *GMT, void *dest, unsigned int dest_type, 
 		return (GMT_NOERROR);
 	}
 
+	if (P->is_wrapping || P->categorical) use[GMT_BGD] = use[GMT_FGD] = false;	/* These types of CPT has no back/foreground colors */
+
 	for (i = 0; i < 3; i++) {
+		if (!use[i]) continue;	/* This BNF entry does not apply to this CPT */
 		if (P->bfn[i].skip)
 			fprintf (fp, "%c\t-\n", code[i]);
 		else if (P->model & GMT_HSV)

--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -680,7 +680,7 @@ EXTERN_MSC int GMT_grd2cpt (void *V_API, int mode, void *args) {
 		if (Ctrl->N.active) cpt_flags |= GMT_CPT_NO_BNF;	/* bit 0 controls if BFN will be written out */
 		if (Ctrl->D.mode == 1) cpt_flags |= GMT_CPT_EXTEND_BNF;	/* bit 1 controls if BF will be set to equal bottom/top rgb value */
 		if (Ctrl->F.active) Pout->model = Ctrl->F.model;
-		if (Ctrl->F.cat) Pout->categorical = 1;
+		if (Ctrl->F.cat) Pout->categorical = GMT_CPT_CATEGORICAL_VAL;
 		if (write && GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, cpt_flags, NULL, Ctrl->Out.file, Pout) != GMT_NOERROR) {
 			Return (API->error);
 		}
@@ -839,7 +839,7 @@ EXTERN_MSC int GMT_grd2cpt (void *V_API, int mode, void *args) {
 	if (Ctrl->D.mode == 1) cpt_flags |= GMT_CPT_EXTEND_BNF;	/* bit 1 controls if BF will be set to equal bottom/top rgb value */
 	if (Ctrl->F.active) Pout->model = Ctrl->F.model;
 	if (Ctrl->F.cat) {	/* Flag as a categorical CPT */
-		Pout->categorical = 1;
+		Pout->categorical = GMT_CPT_CATEGORICAL_VAL;
 		if (Ctrl->F.label[0]) {	/* Want categorical labels */
 			char **label = gmt_cat_cpt_labels (GMT, Ctrl->F.label, Pout->n_colors);
 			for (unsigned int k = 0; k < Pout->n_colors; k++) {

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -594,7 +594,7 @@ EXTERN_MSC int GMT_makecpt (void *V_API, int mode, void *args) {
 	if (Ctrl->D.mode == 1) cpt_flags |= GMT_CPT_EXTEND_BNF;	/* bit 1 controls if BF will be set to equal bottom/top rgb value */
 	if (Ctrl->F.active) Pout->model = Ctrl->F.model;
 	if (Ctrl->F.cat) {	/* Flag as a categorical CPT */
-		Pout->categorical = 1;
+		Pout->categorical = GMT_CPT_CATEGORICAL_VAL;
 		if (Ctrl->F.label[0]) {	/* Want categorical labels */
 			char **label = gmt_cat_cpt_labels (GMT, Ctrl->F.label, Pout->n_colors);
 			for (unsigned int k = 0; k < Pout->n_colors; k++) {

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1035,11 +1035,11 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 			}
 			get_rgb = false;	/* Not reading z from data */
 		}
-		else if ((P->categorical & 2))	/* Get rgb from trailing text, so read no extra z columns */
+		else if ((P->categorical & GMT_CPT_CATEGORICAL_KEY))	/* Get rgb from trailing text, so read no extra z columns */
 			rgb_from_z = false;
 		else {	/* Read extra z column for symbols only */
 			rgb_from_z = not_line;
-			if (rgb_from_z && (P->categorical & 2) == 0) n_cols_start++;
+			if (rgb_from_z && (P->categorical & GMT_CPT_CATEGORICAL_KEY) == 0) n_cols_start++;
 		}
 	}
 
@@ -1429,7 +1429,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 			}
 
 			if (get_rgb) {
-				if (P->categorical & 2)
+				if (P->categorical & GMT_CPT_CATEGORICAL_KEY)
 					gmt_get_fill_from_key (GMT, P, In->text, &current_fill);
 				else
 					gmt_get_fill_from_z (GMT, P, in[GMT_Z], &current_fill);

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -726,11 +726,11 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 			}
 			get_rgb = false;	/* Not reading z from data */
 		}
-		else if ((P->categorical & 2))	/* Get rgb from trailing text, so read no extra z columns */
+		else if ((P->categorical & GMT_CPT_CATEGORICAL_KEY))	/* Get rgb from trailing text, so read no extra z columns */
 			rgb_from_z = false;
 		else {	/* Read extra z column for symbols only */
 			rgb_from_z = not_line;
-			if (rgb_from_z && (P->categorical & 2) == 0) n_cols_start++;
+			if (rgb_from_z && (P->categorical & GMT_CPT_CATEGORICAL_KEY) == 0) n_cols_start++;
 		}
 	}
 
@@ -1098,7 +1098,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 			}
 
 			if (get_rgb) {	/* Lookup t to get rgb */
-				if (P->categorical & 2)
+				if (P->categorical & GMT_CPT_CATEGORICAL_KEY)
 					gmt_get_fill_from_key (GMT, P, In->text, &current_fill);
 				else
 					gmt_get_fill_from_z (GMT, P, in[3], &current_fill);


### PR DESCRIPTION
It is hard to read code like` P->categorical & 2` unless you know what it means.  This PR just introduces  the named constants **GMT_CPT_CATEGORICAL_VAL** and **GMT_CPT_CATEGORICAL_KEY** for these two numbers.  We also add a check to not write back and foreground colors to a CPT when the CPT is categorical or cyclical.
