### PR TITLE
Cannot find why but fact prove that rowVec & colVect need to allocate more.

### DIFF
--- a/src/gmt_gdalread.c
+++ b/src/gmt_gdalread.c
@@ -1079,9 +1079,10 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 	else
 		nX = nXSize,	nY = nYSize;
 
-	rowVec = gmt_M_memory(GMT, NULL, nRowsPerBlock*nBlocks, size_t);
+	/* Can't find why but have to multiply by nRGBA otherwise it crashes in win32 builds */
+	rowVec = gmt_M_memory(GMT, NULL, (nRowsPerBlock * nRGBA) * nBlocks, size_t);
 	for (m = 0; m < nY; m++) rowVec[m] = m * nX;
-	colVec = gmt_M_memory(GMT, NULL, nX+pad_w+pad_e, size_t);	/* For now this will be used only to select BIP ordering */
+	colVec = gmt_M_memory(GMT, NULL, (nX+pad_w+pad_e) * nRGBA, size_t);	/* For now this will be used only to select BIP ordering */
 	/* --------------------------------------------------------------------------------- */
 
 	gmt_M_tic (GMT);


### PR DESCRIPTION

This came out when ``grdimage rgbimage.png ...`` crashed on Win 32 builds.

