### PR TITLE
Improve support for categorical CPTs

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1082,6 +1082,9 @@ overridden by the statement
 | N   | Fill\ :sub:`nan`    |
 +-----+---------------------+
 
+While you can make such categorical CPTs by hand, both :doc:`/makecpt` and :doc:`/grd2cpt` have options to
+simplify adding string keys and labels from comma-separated arguments.
+
 Regular CPTs
 ~~~~~~~~~~~~
 

--- a/doc/rst/source/grd2cpt.rst
+++ b/doc/rst/source/grd2cpt.rst
@@ -133,7 +133,8 @@ Optional Arguments
     *start*-*start+1* instead.  If the categorical CPT should have string
     keys instead of numerical entries then append **+k**\ *keys*, where
     *keys* is either a file with one key per record or it is a comma-separated
-    list of individual keys.
+    list of individual keys. If *keys* is instead a single letter (e.g., D),
+    then we build sequential letter keys (e.g., D, E, F, ...) starting at that point.
 
 .. _-G:
 

--- a/doc/rst/source/grd2cpt.rst
+++ b/doc/rst/source/grd2cpt.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-C|\ *cpt* ]
 [ |-D|\ [**i**\|\ **o**] ]
 [ |-E|\ [*nlevels*][**+c**][**+f**\ *file*] ]
-[ |-F|\ [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*]] ]
+[ |-F|\ [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*]][**+k**\ *keys*] ]
 [ |-G|\ *zlo*\ /\ *zhi* ]
 [ |-H| ]
 [ |-I|\ [**c**][**z**] ]
@@ -120,7 +120,7 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*]]
+**-F**\ [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*]][**+k**\ *keys*]
     Force output CPT to written with r/g/b codes, gray-scale values
     or color name (**R**, default) or r/g/b codes only (**r**), or h-s-v
     codes (**h**), or c/m/y/k codes (**c**).  Optionally or alternatively,
@@ -130,7 +130,10 @@ Optional Arguments
     category names (you can skip a category by not giving a name), or give
     *start*[-], where we automatically build monotonically increasing labels
     from *start* (a single letter or an integer). Append - to build ranges
-    *start*-*start+1* instead.
+    *start*-*start+1* instead.  If the categorical CPT should have string
+    keys instead of numerical entries then append **+k**\ *keys*, where
+    *keys* is either a file with one key per record or it is a comma-separated
+    list of individual keys.
 
 .. _-G:
 

--- a/doc/rst/source/grd2cpt.rst
+++ b/doc/rst/source/grd2cpt.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-C|\ *cpt* ]
 [ |-D|\ [**i**\|\ **o**] ]
 [ |-E|\ [*nlevels*][**+c**][**+f**\ *file*] ]
-[ |-F|\ [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*]][**+k**\ *keys*] ]
+[ |-F|\ [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*]] ]
 [ |-G|\ *zlo*\ /\ *zhi* ]
 [ |-H| ]
 [ |-I|\ [**c**][**z**] ]
@@ -120,7 +120,7 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*]][**+k**\ *keys*]
+**-F**\ [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*]]
     Force output CPT to written with r/g/b codes, gray-scale values
     or color name (**R**, default) or r/g/b codes only (**r**), or h-s-v
     codes (**h**), or c/m/y/k codes (**c**).  Optionally or alternatively,
@@ -130,11 +130,7 @@ Optional Arguments
     category names (you can skip a category by not giving a name), or give
     *start*[-], where we automatically build monotonically increasing labels
     from *start* (a single letter or an integer). Append - to build ranges
-    *start*-*start+1* instead.  If the categorical CPT should have string
-    keys instead of numerical entries then append **+k**\ *keys*, where
-    *keys* is either a file with one key per record or it is a comma-separated
-    list of individual keys. If *keys* is instead a single letter (e.g., D),
-    then we build sequential letter keys (e.g., D, E, F, ...) starting at that point.
+    *start*-*start+1* instead.
 
 .. _-G:
 

--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-C|\ *cpt* ]
 [ |-D|\ [**i**\|\ **o**] ]
 [ |-E|\ [*nlevels*] ]
-[ |-F|\ [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*]]]
+[ |-F|\ [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*]][**+k**\ *keys*] ]
 [ |-G|\ *zlo*\ /\ *zhi* ]
 [ |-H| ]
 [ |-I|\ [**c**][**z**] ]
@@ -111,7 +111,7 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*]]
+**-F**\ [**R**\|\ **r**\|\ **h**\|\ **c**][**+c**\ [*label*]][**+k**\ *keys*]
     Force output CPT to be written with r/g/b codes, gray-scale values
     or color name (**R**, default) or r/g/b codes only (**r**), or h-s-v
     codes (**h**), or c/m/y/k codes (**c**).  Optionally or alternatively,
@@ -121,7 +121,10 @@ Optional Arguments
     category names (you can skip a category by not giving a name), or give
     *start*\ [-], where we automatically build monotonically increasing labels
     from *start* (a single letter or an integer). Append - to build ranges
-    *start*\ -*start+1* instead.
+    *start*\ -*start+1* instead.  If the categorical CPT should have string
+    keys instead of numerical entries then append **+k**\ *keys*, where
+    *keys* is either a file with one key per record or it is a comma-separated
+    list of individual keys.
 
 .. _-G:
 

--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -124,7 +124,8 @@ Optional Arguments
     *start*\ -*start+1* instead.  If the categorical CPT should have string
     keys instead of numerical entries then append **+k**\ *keys*, where
     *keys* is either a file with one key per record or it is a comma-separated
-    list of individual keys.
+    list of individual keys. If *keys* is instead a single letter (e.g., D),
+    then we build sequential letter keys (e.g., D, E, F, ...) starting at that point.
 
 .. _-G:
 

--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -123,9 +123,9 @@ Optional Arguments
     from *start* (a single letter or an integer). Append - to build ranges
     *start*\ -*start+1* instead.  If the categorical CPT should have string
     keys instead of numerical entries then append **+k**\ *keys*, where
-    *keys* is either a file with one key per record or it is a comma-separated
-    list of individual keys. If *keys* is instead a single letter (e.g., D),
+    *keys* is either a file with one key per record or a single letter (e.g., D),
     then we build sequential letter keys (e.g., D, E, F, ...) starting at that point.
+    For comma-separated lists of keys, use **-T** instead.
 
 .. _-G:
 
@@ -198,7 +198,9 @@ Optional Arguments
     not given, the existing range in the master CPT will be used intact.
     The values produces defines the color slice boundaries.  If **+n** is
     used it refers to the number of such boundaries and not the number of slices.
-    For details on array creation, see `Generate 1D Array`_.
+    For details on array creation, see `Generate 1D Array`_.  **Note**: To set
+    up categorical CPTs with string keys you can also give a comma-separated
+    list of your keys.
 
 .. _-V:
 
@@ -331,6 +333,10 @@ names to them, try::
 To instead add unique category labels A, B, C, ... to a 10-item categorical CPT, try::
 
     gmt makecpt -Cjet -T0/10/1 -F+cA
+
+To make a categorical CPT with string keys instead of numerical lookup values, try::
+
+    gmt makecpt -Ccategorical -Twood,water,gold 
 
 .. include:: cpt_notes.rst_
 

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -373,7 +373,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 EXTERN_MSC bool gmt_is_barcolumn (struct GMT_CTRL *GMT, struct GMT_SYMBOL *S);
 EXTERN_MSC unsigned int gmt_get_columbar_bands (struct GMT_CTRL *GMT, struct GMT_SYMBOL *S);
-EXTERN_MSC char ** gmt_cat_cpt_labels (struct GMT_CTRL *GMT, char *label, unsigned int n);
+EXTERN_MSC char ** gmt_cat_cpt_strings (struct GMT_CTRL *GMT, char *label, unsigned int n);
 EXTERN_MSC bool gmt_same_fill (struct GMT_CTRL *GMT, struct GMT_FILL *F1, struct GMT_FILL *F2);
 EXTERN_MSC unsigned int gmt_contour_first_pos (struct GMT_CTRL *GMT, char *arg);
 EXTERN_MSC unsigned int gmt_contour_A_arg_parsing (struct GMT_CTRL *GMT, char *arg, struct CONTOUR_ARGS *A);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -5787,6 +5787,8 @@ GMT_LOCAL int gmtsupport_compare_sugs (const void *point_1, const void *point_2)
 
 /*! . */
 uint64_t gmt_read_list (struct GMT_CTRL *GMT, char *file, char ***list) {
+	/* Reads a file with one string per line. Returns number of strings an
+	 * allocated pointer to the array */
 	uint64_t n = 0;
 	size_t n_alloc = GMT_CHUNK;
 	char **p = NULL, line[GMT_BUFSIZ] = {""};
@@ -7407,7 +7409,7 @@ unsigned int gmt_validate_cpt_parameters (struct GMT_CTRL *GMT, struct GMT_PALET
 	return GMT_NOERROR;
 }
 
-char ** gmt_cat_cpt_labels (struct GMT_CTRL *GMT, char *label, unsigned int n) {
+char ** gmt_cat_cpt_strings (struct GMT_CTRL *GMT, char *label, unsigned int n) {
 	/* Generate categorical labels for n categories from the label magic argument */
 	unsigned int k = 0;
 	char **Clabel = gmt_M_memory (GMT, NULL, n, char *);
@@ -7421,6 +7423,9 @@ char ** gmt_cat_cpt_labels (struct GMT_CTRL *GMT, char *label, unsigned int n) {
 			k++;
 		}
 		gmt_M_str_free (orig);
+		if (k != n) {
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "The comma-separated string %s had %d entries but %d were expected\n", label, k, n);
+		}
 	}
 	else {	/* Auto-build the labels */
 		unsigned int mode;
@@ -7429,10 +7434,14 @@ char ** gmt_cat_cpt_labels (struct GMT_CTRL *GMT, char *label, unsigned int n) {
 		if (isdigit (label[0])) {	/* Integer categories */
 			mode = 1;
 			start = atoi (label);
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Building %d sequential strings from integers starting at %d\n", n, start);
 		}
 		else {	/* Letter categories */
 			mode = 3;
 			start = label[0];
+			if (strlen (label) > 1)
+				GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Expected a single letter to initialize auto-labels but found %s.\n", label);
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Building %d sequential strings from letters starting at %c\n", n, start);
 		}
 		if (label[strlen(label)-1] == '-') mode++;	/* Wants a range */
 		for (k = 0; k < n; k++) {

--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -174,6 +174,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   labels from <start> (a letter or an integer). Append - to build ranges <start>-<start+1>.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +k<keys> to set categorical keys rather than numerical values.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   <keys> may be a file with one key per line or a comma-separated list of keys.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   If <keys> is a single letter then we build sequential alphabetical keys from that letter.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Truncate incoming CPT to be limited to the z-range <zlo>/<zhi>.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   To accept one of the incoming limits, set that limit to NaN.\n");
 	if (API->GMT->current.setting.run_mode == GMT_MODERN)

--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -71,12 +71,11 @@ struct GRD2CPT_CTRL {
 		char *file;
 		unsigned int levels;
 	} E;
-	struct GRD2CPT_F {	 /* -F[r|R|h|c][+c[<label>]][+k<keys>] */
+	struct GRD2CPT_F {	 /* -F[r|R|h|c][+c[<label>]] */
 		bool active;
 		bool cat;
 		unsigned int model;
 		char *label;
-		char *key;
 	} F;
 	struct GRD2CPT_G {	/* -Glow/high for input CPT truncation */
 		bool active;
@@ -140,7 +139,6 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GRD2CPT_CTRL *C) {	/* Deallo
 	gmt_M_str_free (C->C.file);
 	gmt_M_str_free (C->E.file);
 	gmt_M_str_free (C->F.label);
-	gmt_M_str_free (C->F.key);
 	gmt_M_str_free (C->T.file);
 	gmt_M_free (GMT, C);
 }
@@ -150,7 +148,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *H_OPT = (API->GMT->current.setting.run_mode == GMT_MODERN) ? " [-H]" : "";
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s <grid> [-A<transparency>[+a]] [-C<cpt>] [-D[i|o]] [-E[<nlevels>][+c][+f<file>]]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-F[R|r|h|c][+c[<label>]][+k<keys>]] [-G<zlo>/<zhi>]%s [-I[c][z]] [-L<min_limit>/<max_limit>] [-M] [-N] [-Q[i|o]]\n", H_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-F[R|r|h|c][+c[<label>]]] [-G<zlo>/<zhi>]%s [-I[c][z]] [-L<min_limit>/<max_limit>] [-M] [-N] [-Q[i|o]]\n", H_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-T<start>/<stop>/<inc> or -T<n>] [-Sh|l|m|u]\n\t[%s] [-W[w]] [-Z] [%s] [%s]\n\t[%s] [%s]\n\n", GMT_Rgeo_OPT, GMT_V_OPT, GMT_bo_OPT, GMT_ho_OPT, GMT_o_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -172,10 +170,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   The <label>, if present, sets the labels for each category. It may be a\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   comma-separated list of category names, or <start>[-], where we automatically build\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   labels from <start> (a letter or an integer). Append - to build ranges <start>-<start+1>.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append +k<keys> to set categorical keys rather than numerical values.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   <keys> may be a file with one key per line or a comma-separated list of keys.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   If <keys> is a single letter then we build sequential alphabetical keys from that letter.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Truncate incoming CPT to be limited to the z-range <zlo>/<zhi>.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   If <keys> is a single letter then we build sequential alphabetical keys from that letter.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   To accept one of the incoming limits, set that limit to NaN.\n");
 	if (API->GMT->current.setting.run_mode == GMT_MODERN)
 		GMT_Message (API, GMT_TIME_NONE, "\t-H Also write CPT to stdout [Default just saves as current CPT].\n");
@@ -286,14 +282,10 @@ static int parse (struct GMT_CTRL *GMT, struct GRD2CPT_CTRL *Ctrl, struct GMT_OP
 				if (c) c[0] = '+';	/* Restore modifiers */
 				break;
 			case 'F':	/* Set color model for output */
-				if (gmt_validate_modifiers (GMT, opt->arg, 'F', "ck", GMT_MSG_ERROR)) n_errors++;
+				if (gmt_validate_modifiers (GMT, opt->arg, 'F', "c", GMT_MSG_ERROR)) n_errors++;
 				if (gmt_get_modifier (opt->arg, 'c', txt_a)) {
 					Ctrl->F.cat = true;
-					Ctrl->F.label = strdup (txt_a);
-				}
-				if (gmt_get_modifier (opt->arg, 'k', txt_a)) {
-					Ctrl->F.cat = true;
-					Ctrl->F.key = strdup (txt_a);
+					if (txt_a[0]) Ctrl->F.label = strdup (txt_a);
 				}
 				Ctrl->F.active = true;
 				switch (txt_a[0]) {
@@ -849,30 +841,13 @@ EXTERN_MSC int GMT_grd2cpt (void *V_API, int mode, void *args) {
 	if (Ctrl->F.active) Pout->model = Ctrl->F.model;
 	if (Ctrl->F.cat) {	/* Flag as a categorical CPT */
 		Pout->categorical = GMT_CPT_CATEGORICAL_VAL;
-		if (Ctrl->F.label[0]) {	/* Want categorical labels */
+		if (Ctrl->F.label) {	/* Want categorical labels */
 			char **label = gmt_cat_cpt_strings (GMT, Ctrl->F.label, Pout->n_colors);
 			for (unsigned int k = 0; k < Pout->n_colors; k++) {
 				if (Pout->data[k].label) gmt_M_str_free (Pout->data[k].label);
 				Pout->data[k].label = label[k];	/* Now the job of the CPT to free these strings */
 			}
 			gmt_M_free (GMT, label);
-		}
-		if (Ctrl->F.key) {	/* Want categorical labels */
-			char **keys = NULL;
-			if (!gmt_access (GMT, Ctrl->F.key, R_OK)) {	/* Got a file with category keys */
-				unsigned int ns = gmt_read_list (GMT, Ctrl->F.key, &keys);
-				if (ns < Pout->n_colors) {
-					GMT_Report (API, GMT_MSG_WARNING, "The categorical keys file %s had %d entries but %d were expected\n", Ctrl->F.key, ns, Pout->n_colors);
-				}
-			}
-			else	/* Got comma-separated keys */
-				keys = gmt_cat_cpt_strings (GMT, Ctrl->F.key, Pout->n_colors);
-			for (unsigned int k = 0; k < Pout->n_colors; k++) {
-				if (Pout->data[k].key) gmt_M_str_free (Pout->data[k].key);
-				if (keys[k]) Pout->data[k].key = keys[k];	/* Now the job of the CPT to free these strings */
-			}
-			gmt_M_free (GMT, keys);	/* But the master array can go */
-			Pout->categorical = GMT_CPT_CATEGORICAL_KEY;
 		}
 	}
 

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -168,6 +168,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   labels from <start> (a letter or an integer). Append - to build range labels <start>-<start+1>.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +k<keys> to set categorical keys rather than numerical values.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   <keys> may be a file with one key per line or a comma-separated list of keys.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   If <keys> is a single letter then we build sequential alphabetical keys from that letter.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Truncate incoming CPT to be limited to the z-range <zlo>/<zhi>.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   To accept one of the incoming limits, set that limit to NaN.\n");
 	if (API->GMT->current.setting.run_mode == GMT_MODERN)

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -542,10 +542,13 @@ EXTERN_MSC int GMT_makecpt (void *V_API, int mode, void *args) {
 	/* Set up arrays */
 
 	if (Ctrl->T.active) {
-		if (Ctrl->F.cat && Ctrl->T.T.set == 3)	/* Must go one more increment to output what the user wants */
-			Ctrl->T.T.max += Ctrl->T.T.inc;
 		if (gmt_create_array (GMT, 'T', &(Ctrl->T.T), NULL, NULL))
 			Return (GMT_RUNTIME_ERROR);
+		if (Ctrl->F.cat && Ctrl->T.T.n > 1) {	/* Must go one more increment to output what the user wants */
+			Ctrl->T.T.n++;
+			Ctrl->T.T.array = gmt_M_memory (GMT, Ctrl->T.T.array, Ctrl->T.T.n, double);
+			Ctrl->T.T.array[Ctrl->T.T.n-1] = Ctrl->T.T.array[Ctrl->T.T.n-2] + 1;	/* Does not matter as long as > previous */
+		}
 	}
 	nz = (int)Ctrl->T.T.n;		z = Ctrl->T.T.array;
 

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -203,8 +203,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 GMT_LOCAL unsigned int makecpt_is_categories (struct GMT_CTRL *GMT, char *arg) {
 	char txt[GMT_LEN64] = {""};
-	/* Return n if -T was given a list of cn ategory string keys rather than numerical info [0] */
+	/* Return n if -T was given a list of category string keys rather than numerical info [0] */
 	if (arg == NULL || arg[0] == '\0') return 0;	/* Nothing at all */
+	if (strchr (arg, '/')) return 0;	/* Looks like xmin/xmax/xinc */
 	if (strchr (arg, ',') == NULL) return 0;	/* No comma, no list of any type */
 	sscanf (arg, "%[^,]", txt);
 	if (gmt_not_numeric (GMT, txt))	/* Return the number of commas plus one */

--- a/test/psscale/catlabels.sh
+++ b/test/psscale/catlabels.sh
@@ -2,18 +2,18 @@
 # Testing the auto-labeling of categorical CPTs.
 ps=catlabels.ps
 gmt set FONT_ANNOT_PRIMARY 9p,Helvetica,black
-gmt makecpt -T0/4/1 -Ccubhelix -F+c > t.cpt
+gmt makecpt -T0/3/1 -Ccubhelix -F+c > t.cpt
 gmt psxy -R0/20/0/30 -Jx1c -P -K -Y0 -T > $ps
 gmt psscale -O -K -Ct.cpt -Dx8c/22c+w12c/0.5c+jTC+h -Y2.5c >> $ps
 gmt psscale -O -K -Ct.cpt -Dx8c/19c+w12c/0.5c+jTC+h -Bxaf >> $ps
 gmt psscale -O -K -Ct.cpt -Dx8c/16c+w12c/0.5c+jTC+h -Li0.4c >> $ps
-gmt makecpt -T0/4/1 -Ccubhelix -F+cNight,Trees,Sediment,Water > t.cpt
+gmt makecpt -T0/3/1 -Ccubhelix -F+cNight,Trees,Sediment,Water > t.cpt
 gmt psscale -O -K -Ct.cpt -Dx8c/13c+w12c/0.5c+jTC+h -Li0.4c >> $ps
-gmt makecpt -T0/4/1 -Ccubhelix -F+cA > t.cpt
+gmt makecpt -T0/3/1 -Ccubhelix -F+cA > t.cpt
 gmt psscale -O -K -Ct.cpt -Dx8c/10c+w12c/0.5c+jTC+h >> $ps
-gmt makecpt -T0/4/1 -Ccubhelix -F+c1 > t.cpt
+gmt makecpt -T0/3/1 -Ccubhelix -F+c1 > t.cpt
 gmt psscale -O -K -Ct.cpt -Dx8c/7c+w12c/0.5c+jTC+h >> $ps
-gmt makecpt -T0/4/1 -Ccubhelix -F+c9- > t.cpt
+gmt makecpt -T0/3/1 -Ccubhelix -F+c9- > t.cpt
 gmt psscale -O -K -Ct.cpt -Dx8c/4c+w12c/0.5c+jTC+h >> $ps
-gmt makecpt -T0/4/1 -Ccubhelix -F+cG- > t.cpt
+gmt makecpt -T0/3/1 -Ccubhelix -F+cG- > t.cpt
 gmt psscale -O -Ct.cpt -Dx8c/1c+w12c/0.5c+jTC+h -Li0.4c >> $ps


### PR DESCRIPTION
**Description of proposed changes**

See this [forum post](https://forum.generic-mapping-tools.org/t/two-color-cpt-at-1-and-1-with-no-centre-value/1025/8) for one aspect of this PR. 

This PR does two things:

1. Fixes the problem that required an extra z-value in **-T** to get correct categorical CPT output.
2. Simplifies how one may add categorical keys rather than using numerical look-up values via new **-F** modifier **+k**_keys_.

Like **+c** for categorical labels, **+k** can create sequential keys (such as G, H, I, ...) if just given one letter, it can read a list of keys from the file keys, or it is decoded as a comma-separated list of keys.

To make a categorical cpt for use with plot to plot polygons what have multi-segment headers with **-Z** entries A, B, or C that stands for wood, water, gold, one can run

```
gmt makecpt -Ccategorical -T0/2/1 -F+cWood,Water,Gold+kA              
A	green	L	;Wood
B	blue	L	;Water
C	red	B	;Gold
N	127.5
```


for a suitable CPT.
