### PR TITLE
WIP Testing meca -I to place symbols in a legend or box

### DIFF
--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -590,6 +590,7 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 
 	if (Ctrl->I.active) {
 		int mode = Ctrl->I.refpoint->mode;
+		Ctrl->N.active = true;
 		gmt_set_refpoint (GMT, Ctrl->I.refpoint);	/* Finalize reference point plot coordinates, if needed */
 		Ctrl->I.refpoint->x += 0.5 * Ctrl->S.scale;	plot_y = Ctrl->I.refpoint->y += 0.5 * Ctrl->S.scale;	/* First let these refer to BL of symbol BoundingBox */
 		if (mode == GMT_REFPOINT_JUST) {	/* Must adjust these auto-locations by symbol size and offsets */


### PR DESCRIPTION
**Description of proposed changes**

See #4445.  This PR tests this concept.  For example you can try this command and change the **-I** choices:

`echo -159.70 54.81 39 0.82 -0.68 -0.14 0.63 0.34 -0.40 25 | gmt meca -R0/10/0/5 -Jx1c -B0 -Sm2.5c -M -G110/168/255 -T0 -W0.5p -IjTR+o0.25c -png map`

![map](https://user-images.githubusercontent.com/26473567/98890784-d8e00900-2440-11eb-807f-374f78e6e488.png)

Few things to know:

1. Regardless of input file, only the first record is plotted - we then skip the rest
2. The symbol size is what **-S** gives - no scaling by magnitude
3. The **-N** is turned on since **-IJ** will place things outside rather than inside the box
4. While **-Ix** should not need **-R -J** I have not implemented that yet since affects **THIS_MODULE_NEEDS**
5. The **-C** option should be disallowed or ignored when **-I** is used.

We should make a test page of all the 9 meca symbols using the 9 adjustment points.

