### PR TITLE
Fix failure to allocate output CPT structure

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -3139,7 +3139,7 @@ GMT_LOCAL int gmtapi_export_palette (struct GMTAPI_CTRL *API, int object_ID, uns
 		case GMT_IS_DUPLICATE:	/* Duplicate the input cpt */
 			if (S_obj->resource) return (gmtlib_report_error (API, GMT_PTR_NOT_NULL));	/* The output resource must be NULL */
 			GMT_Report (API, GMT_MSG_INFORMATION, "Duplicating CPT to GMT_PALETTE memory location\n");
-			P_copy = gmt_M_memory (GMT, NULL, 1, struct GMT_PALETTE);
+			P_copy = gmtlib_create_palette (GMT, P_obj->n_colors);
 			gmtlib_copy_palette (GMT, P_copy, P_obj);
 			S_obj->resource = P_copy;	/* Set resource pointer from object to this palette */
 			break;

--- a/src/testapi_makecpt.c
+++ b/src/testapi_makecpt.c
@@ -22,7 +22,7 @@ int main () {
 	/* Get the CPT in memory */
 	P = GMT_Read_VirtualFile(API, output);
 	/* Write the CPT to the file output.cpt */
-	GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, 0, NULL, "output.cpt", P);
+	GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_CPT_NO_BNF, NULL, "output.cpt", P);
 	/* Destroy session */
 	if (GMT_Destroy_Session (API)) return EXIT_FAILURE;
 }

--- a/src/testapi_makecpt.c
+++ b/src/testapi_makecpt.c
@@ -1,0 +1,28 @@
+/* Fixing the problem reported by https://forum.generic-mapping-tools.org/t/api-for-makecpt/1044/6.
+ * Tracked down to use of gmt_M_memory allocation (with NULL pointers) rather than gmt_create_pallete
+ * Fixed Nov. 17, 2020, P. Wessel
+ */
+
+#include <gmt.h>
+#include <string.h>
+int main () {
+	char output[GMT_VF_LEN] = {""};
+	char *arg[4] = {"-Ccool", "-T1/65/1", "-N", NULL};
+	void *P = NULL, *API = NULL;
+
+	/* Initialize the GMT session */
+	API = GMT_Create_Session ("GMT_makecpt", 2, 0, NULL);
+	/* Open a virtual file to hold the CPT */
+	GMT_Open_VirtualFile (API, GMT_IS_PALETTE, GMT_IS_NONE, GMT_OUT, NULL, output);
+	/* Finalize the 4 arguments with the filename */
+	arg[3] = (char*) calloc(strlen(output)+3, sizeof(char));
+	sprintf(arg[3], "->%s", output);
+	/* Create the CPT to be returned back to us via the virtual file */
+	GMT_Call_Module (API, "makecpt", 4, arg);
+	/* Get the CPT in memory */
+	P = GMT_Read_VirtualFile(API, output);
+	/* Write the CPT to the file output.cpt */
+	GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, 0, NULL, "output.cpt", P);
+	/* Destroy session */
+	if (GMT_Destroy_Session (API)) return EXIT_FAILURE;
+}

--- a/test/api/apimakecpt.sh
+++ b/test/api/apimakecpt.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#
+# Test the C API for creating a CPT into memory then write to file output.cpt.
+
+testapi_makecpt
+gmt makecpt -Ccool -T1/65/1 -N > answer.cpt
+diff answer.cpt output.cpt > fail


### PR DESCRIPTION
This PR fixes the trouble reported on the [forum]( https://forum.generic-mapping-tools.org/t/api-for-makecpt/1044/6) and adds a new _testapi_makecpt.c_ code to ensure this is fixed in the future.  The new test script _apimakecpt.sh_ makes a comparison between **gmt makecpt** output and the same done via the API and written to file.
