### PR TITLE
Make parsing of OGR comments more robust

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -552,13 +552,20 @@ GMT_LOCAL unsigned int gmtio_ogr_decode_aspatial_values (struct GMT_CTRL *GMT, c
 }
 
 /*! Duplicate in to out, then find the first space not inside quotes and truncate string there */
-GMT_LOCAL void gmtio_copy_and_truncate (char *out, char *in) {
+GMT_LOCAL void gmtio_copy_and_truncate_quotes (char *out, char *in) {
 	bool quote = false;
 	while (*in && (quote || *in != ' ')) {
 		*out++ = *in;	/* Copy char */
-		if (*in++ == ' ') quote = !quote;	/* Wind to next space except skip if inside double quotes */
+		if (*in++ == '\"') quote = !quote;	/* Wind to next space except skip if inside double quotes */
 	}
 	*out = '\0';	/* Terminate string */
+}
+
+GMT_LOCAL void gmtio_copy_and_truncate (char *out, char *in) {
+	if (strchr (in, ' ') && !strchr (in, '\"'))	/* Has spaces yet no quotes... assume we can get the line as is */
+		strcpy (out, in);
+	else
+		gmtio_copy_and_truncate_quotes (out, in);
 }
 
 /*! Parse @T aspatial types; this is done once per dataset and follows @N */


### PR DESCRIPTION
While we are expecting that text items with spaces in them should be enclosed in double quotes, at least the example from the [forum](https://forum.generic-mapping-tools.org/t/gmt-vector-data-format-and-problems-bad-ogr-gmt/1042) had none and that lead to troubles.  This PR fixes a bug related to detecting quotes but also tries to handle the case of missing quotes entirely.
