### PR TITLE
Just use dataserver name and not URL

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -141,7 +141,7 @@ endif (NOT DEFINED GMT_RELEASE_PREFIX)
 
 # Default location of remote data server
 if (NOT DEFINED GMT_DATA_SERVER)
-	set (GMT_DATA_SERVER "https://oceania.generic-mapping-tools.org")
+	set (GMT_DATA_SERVER "oceania")
 endif (NOT DEFINED GMT_DATA_SERVER)
 
 # You can set the build configuration type as a command-line argument to 'cmake' using -DCMAKE_BUILD_TYPE:STRING=Debug for example.

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -316,7 +316,7 @@ GMT Miscellaneous Parameters
         for 6: obsolete syntax from early GMT 5 will be considered errors.
 
     **GMT_DATA_SERVER**
-        URL of the GMT data server [The **Oceania** server]. Please set to the
+        Name (or URL) of a GMT data server [**oceania**]. Please set to the
         data server closest to your location for faster data download.  See
         `Data Server Mirrors <https://www.generic-mapping-tools.org/mirrors/>`_
         for a list of the currently available mirrors.

--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -119,7 +119,7 @@ GMT_LOCAL bool gmtdcw_get_path (struct GMT_CTRL *GMT, char *name, char *suffix, 
 			return false;
 		}
 		sprintf (path, "%s/geography/dcw/%s%s", GMT->session.USERDIR, name, suffix);	/* Final local path */
-		snprintf (remote_path, PATH_MAX, "%s/geography/dcw/%s%s", GMT->session.DATASERVER, name, suffix);	/* Unique remote path */
+		snprintf (remote_path, PATH_MAX, "%s/geography/dcw/%s%s", gmtlib_dataserver_url (GMT->parent), name, suffix);	/* Unique remote path */
 		GMT_Report (GMT->parent, GMT_MSG_NOTICE, "Downloading %s%s for the first time - be patient\n", name, suffix);
 		if (gmt_download_file (GMT, name, remote_path, path, true)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to obtain remote file %s%s\n", name, suffix);

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -52,6 +52,7 @@ struct GMT_XINGS {
 EXTERN_MSC char *dlerror (void);
 #endif
 
+EXTERN_MSC char *gmtlib_dataserver_url (struct GMTAPI_CTRL *API);
 EXTERN_MSC char *gmtlib_last_valid_file_modifier (struct GMTAPI_CTRL *API, char* filename, const char *mods);
 EXTERN_MSC char *gmtlib_valid_filemodifiers (struct GMT_CTRL *GMT);
 EXTERN_MSC int gmtlib_delete_virtualfile  (void *API, const char *string);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -419,7 +419,7 @@ GMT_LOCAL void gmtremote_display_attribution (struct GMTAPI_CTRL *API, int key, 
 		if ((c = strrchr (API->GMT->session.DATASERVER, '/')))	/* Found last slash in http:// */
 			strcpy (name, ++c);
 		else /* Just in case */
-			strncpy (name, API->GMT->session.DATASERVER, GMT_LEN128-1);
+			strncpy (name, gmtlib_dataserver_url (API), GMT_LEN128-1);
 		if ((c = strchr (name, '.'))) c[0] = '\0';	/* Chop off stuff after the initial name */
 		gmt_str_toupper (name);
 		GMT_Report (API, GMT_MSG_NOTICE, "Remote data courtesy of GMT data server %s [%s]\n\n", name, API->GMT->session.DATASERVER);
@@ -727,7 +727,7 @@ GMT_LOCAL int gmtremote_refresh (struct GMTAPI_CTRL *API, unsigned int index) {
 			GMT_Report (API, GMT_MSG_ERROR, "Unable to create GMT server directory : %s\n", serverdir);
 			return 1;
 		}
-		snprintf (url, PATH_MAX, "%s/%s", GMT->session.DATASERVER, index_file);
+		snprintf (url, PATH_MAX, "%s/%s", gmtlib_dataserver_url (API), index_file);
 		GMT_Report (API, GMT_MSG_DEBUG, "Download remote file %s for the first time\n", url);
 		if (gmtremote_get_url (GMT, url, indexpath, NULL, index)) {
 			GMT_Report (API, GMT_MSG_INFORMATION, "Failed to get remote file %s\n", url);
@@ -763,7 +763,7 @@ GMT_LOCAL int gmtremote_refresh (struct GMTAPI_CTRL *API, unsigned int index) {
 		strcat (new_indexpath, ".new");		/* Append .new to the copied path */
 		strcpy (old_indexpath, indexpath);	/* Duplicate path name */
 		strcat (old_indexpath, ".old");		/* Append .old to the copied path */
-		snprintf (url, PATH_MAX, "%s/%s", GMT->session.DATASERVER, index_file);	/* Set remote path to new index file */
+		snprintf (url, PATH_MAX, "%s/%s", gmtlib_dataserver_url (API), index_file);	/* Set remote path to new index file */
 		if (gmtremote_get_url (GMT, url, new_indexpath, indexpath, index)) {	/* Get the new index file from server */
 			GMT_Report (API, GMT_MSG_DEBUG, "Failed to download %s - Internet troubles?\n", url);
 			if (!access (new_indexpath, F_OK)) gmt_remove_file (GMT, new_indexpath);	/* Remove index file just in case it got corrupted or zero size */
@@ -1028,14 +1028,14 @@ not_local:	/* Get here if we failed to find a remote file already on disk */
 		/* Set remote path */
 		if (is_tile) {	/* Tile not yet downloaded, but must switch to .jp2 format on the server (and deal with legacy SRTM tile tags) */
 			jp2_file = gmtremote_get_jp2_tilename ((char *)file);
-			snprintf (remote_path, PATH_MAX, "%s%s%s%s", GMT->session.DATASERVER, GMT->parent->remote_info[t_data].dir, GMT->parent->remote_info[t_data].file, jp2_file);
+			snprintf (remote_path, PATH_MAX, "%s%s%s%s", gmtlib_dataserver_url (API), GMT->parent->remote_info[t_data].dir, GMT->parent->remote_info[t_data].file, jp2_file);
 		}
 		else if (k_data == GMT_NOTSET) {	/* Cache file not yet downloaded */
-			snprintf (remote_path, PATH_MAX, "%s/cache/%s", GMT->session.DATASERVER, &file[1]);
+			snprintf (remote_path, PATH_MAX, "%s/cache/%s", gmtlib_dataserver_url (API), &file[1]);
 			if (mode == 0) mode = GMT_CACHE_DIR;	/* Just so we default to the cache dir for cache files */
 		}
 		else	/* Remote data set */
-			snprintf (remote_path, PATH_MAX, "%s%s%s", GMT->session.DATASERVER, API->remote_info[k_data].dir, API->remote_info[k_data].file);
+			snprintf (remote_path, PATH_MAX, "%s%s%s", gmtlib_dataserver_url (API), API->remote_info[k_data].dir, API->remote_info[k_data].file);
 
 		/* Set local path */
 		switch (mode) {
@@ -1600,4 +1600,14 @@ int gmt_download_tiles (struct GMTAPI_CTRL *API, char *list, unsigned int mode) 
 	}
 	gmt_free_list (API->GMT, file, n);
 	return GMT_NOERROR;
+}
+
+char *gmtlib_dataserver_url (struct GMTAPI_CTRL *API) {
+	/* Build the full URL to the currently selected data server */
+	static char URL[GMT_LEN256] = {""}, *link = URL;;
+	if (strncmp (API->GMT->session.DATASERVER, "http", 4U))	/* Not an URL so must assume it is the country/unit name, e.g., oceania */
+		snprintf (URL, GMT_LEN256-1, "http://%s.generic-mapping-tools.org", API->GMT->session.DATASERVER);
+	else	/* Must use the URL as is */
+		snprintf (URL, GMT_LEN256-1, "%s", API->GMT->session.DATASERVER);
+	return (link);
 }

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -1604,9 +1604,14 @@ int gmt_download_tiles (struct GMTAPI_CTRL *API, char *list, unsigned int mode) 
 
 char *gmtlib_dataserver_url (struct GMTAPI_CTRL *API) {
 	/* Build the full URL to the currently selected data server */
-	static char URL[GMT_LEN256] = {""}, *link = URL;;
-	if (strncmp (API->GMT->session.DATASERVER, "http", 4U))	/* Not an URL so must assume it is the country/unit name, e.g., oceania */
-		snprintf (URL, GMT_LEN256-1, "http://%s.generic-mapping-tools.org", API->GMT->session.DATASERVER);
+	static char URL[GMT_LEN256] = {""}, *link = URL;
+	if (strncmp (API->GMT->session.DATASERVER, "http", 4U)) {	/* Not an URL so must assume it is the country/unit name, e.g., oceania */
+		/* We make this part case insensitive since all official GMT servers are lower-case */
+		char name[GMT_LEN64] = {""};
+		strncpy (name, API->GMT->session.DATASERVER, GMT_LEN64-1);
+		gmt_str_tolower (name);
+		snprintf (URL, GMT_LEN256-1, "http://%s.generic-mapping-tools.org", name);
+	}
 	else	/* Must use the URL as is */
 		snprintf (URL, GMT_LEN256-1, "%s", API->GMT->session.DATASERVER);
 	return (link);

--- a/src/gmt_shore.c
+++ b/src/gmt_shore.c
@@ -371,7 +371,7 @@ L1:
 			return NULL;
 		}
 		sprintf (path, "%s/geography/gshhg/%s.nc", GMT->session.USERDIR, stem);	/* Final local path */
-		snprintf (remote_path, PATH_MAX, "%s/geography/gshhg/%s.nc", GMT->session.DATASERVER, stem);	/* Unique remote path */
+		snprintf (remote_path, PATH_MAX, "%s/geography/gshhg/%s.nc", gmtlib_dataserver_url (GMT->parent), stem);	/* Unique remote path */
 		GMT_Report (GMT->parent, GMT_MSG_NOTICE, "Downloading %s.nc for the first time - be patient\n", stem);
 		if (gmt_download_file (GMT, stem, remote_path, path, true)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to obtain remote file %s.nc\n", stem);


### PR DESCRIPTION
**GMT_DATA_SERVER** can now just be the official name for the GMT servers (Oceania, Portugal, NOAA, etc.) or a full URL starting at http.  I convert any non-URL name to lower-case.  Closes #4462.
