### PR TITLE
Change the interface of the gmt_ogrread() function to accept a control struct.

### DIFF
--- a/src/gmt_gdalread.h
+++ b/src/gmt_gdalread.h
@@ -234,4 +234,11 @@ struct GMT_GDALLIBRARIFIED_CTRL {
 	} M;
 };
 
+struct OGRREAD_CTRL {
+	int    info;            /* If != 0 gmt_ogrread will return only Info (Will it?) */
+	int    layer;           /* If >= 0 will return only data from that layer. Use negative to return all layers */ 
+	char  *name;            /* Vector file name */ 
+	double region[6];       /* For when a sub-region is required */ 
+};
+
 #endif  /* GMT_GDALREAD_H */

--- a/src/gmt_ogrread.c
+++ b/src/gmt_ogrread.c
@@ -250,9 +250,25 @@ GMT_LOCAL int get_data(struct GMT_CTRL *GMT, struct OGR_FEATURES *out, OGRFeatur
 }
 
 struct OGR_FEATURES *gmt_ogrread(struct GMT_CTRL *GMT, char *ogr_filename, double *region) {
+	/* This has become an helper function just to maintain backward compatibility */
+	struct OGRREAD_CTRL *Ctrl = NULL;
+	struct OGR_FEATURES *out = NULL;
+
+	Ctrl = gmt_M_memory (GMT, NULL, 1, struct OGRREAD_CTRL);
+	Ctrl->name = ogr_filename;
+	if (region) {
+		Ctrl->region[0] = region[0];	Ctrl->region[1] = region[1];
+		Ctrl->region[2] = region[2];	Ctrl->region[3] = region[3];
+	}
+	out = gmt_ogrread2(GMT, Ctrl);
+	gmt_M_free (GMT, Ctrl);
+	return out;
+}
+
+struct OGR_FEATURES *gmt_ogrread2(struct GMT_CTRL *GMT, struct OGRREAD_CTRL *Ctrl) {
 
 	bool have_region = false;
-	int	 i, ind, iLayer, nEmptyGeoms, nAttribs = 0;
+	int	 i, ind, iLayer, nLayer, first_layer, last_layer, nEmptyGeoms, nAttribs = 0;
 	int	 nLayers;		/* number of layers in dataset */
 	int	 nFeature, nMaxFeatures, nMaxGeoms;
 	double	x_min, y_min, x_max, y_max;
@@ -269,23 +285,23 @@ struct OGR_FEATURES *gmt_ogrread(struct GMT_CTRL *GMT, char *ogr_filename, doubl
 	OGREnvelope sEnvelop;
 	OGRwkbGeometryType eType;
 
-	if (region != NULL) {
-		x_min = region[0];	x_max = region[1];	y_min = region[2];	y_max = region[3];
+	if (Ctrl->region[0] != 0 && Ctrl->region[1] != 0 && Ctrl->region[2] != 0 && Ctrl->region[3] != 0) {
+		x_min = Ctrl->region[0];	x_max = Ctrl->region[1];	y_min = Ctrl->region[2];	y_max = Ctrl->region[3];
 		have_region = true;
 	}
 
 	GDALAllRegister();
 
-	hDS = GDALOpenEx(ogr_filename, GDAL_OF_VECTOR, NULL, NULL, NULL);
+	hDS = GDALOpenEx(Ctrl->name, GDAL_OF_VECTOR, NULL, NULL, NULL);
 	if (hDS == NULL) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to open data source <%s>\n", ogr_filename);
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to open data source <%s>\n", Ctrl->name);
 		GDALDestroyDriverManager();
 		return NULL;
 	}
 
 	nLayers = OGR_DS_GetLayerCount(hDS);	/* Get available layers */
 	if (nLayers < 1) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "No OGR layers available. Bye.\n");
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "No OGR layers available.\n");
 		GDALClose(hDS);
 		GDALDestroyDriverManager();
 		return NULL;
@@ -303,9 +319,24 @@ struct OGR_FEATURES *gmt_ogrread(struct GMT_CTRL *GMT, char *ogr_filename, doubl
 		OGR_G_AddGeometryDirectly(poSpatialFilter, hPolygon);
 	}
 
+	/* See if we have a layer selection */
+	if (Ctrl->layer < 0) {
+		first_layer = 0;	last_layer = nLayers;
+	}
+	else {
+		if (Ctrl->layer >= nLayers) {
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Selected layer (%d) is larger than n layers in file.\n", Ctrl->layer+1);
+			GDALClose(hDS);
+			GDALDestroyDriverManager();
+			return NULL;
+		}
+		first_layer = Ctrl->layer;	last_layer = Ctrl->layer + 1;
+		nLayers = 1;
+	}
+
 	/* Get MAX number of features of all layers */
 	nMaxFeatures = nMaxGeoms = 1;
-	for (i = 0; i < nLayers; i++) {
+	for (i = first_layer; i < last_layer; i++) {
 		hLayer = GDALDatasetGetLayer(hDS, i);
 
 		if (have_region) OGR_L_SetSpatialFilter(hLayer, poSpatialFilter);
@@ -330,9 +361,9 @@ struct OGR_FEATURES *gmt_ogrread(struct GMT_CTRL *GMT, char *ogr_filename, doubl
 	out[0].n_cols   = nMaxGeoms;
 	out[0].n_layers = nLayers;
 
-	for (iLayer = nFeature = nEmptyGeoms = 0; iLayer < nLayers; iLayer++) {
+	for (iLayer = first_layer, nFeature = nEmptyGeoms = nLayer = 0; iLayer < last_layer; iLayer++, nLayer++) {
 
-		ind = nMaxGeoms * nMaxFeatures * iLayer;	/* n_columns * n_rows * iLayer */
+		ind = nMaxGeoms * nMaxFeatures * nLayer;	/* n_columns * n_rows * iLayer */
 		hLayer = GDALDatasetGetLayer(hDS, iLayer);
 		OGR_L_ResetReading(hLayer);
 		hFeatureDefn = OGR_L_GetLayerDefn(hLayer);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -154,6 +154,7 @@ EXTERN_MSC void gmt_ogrproj_one_pt (OGRCoordinateTransformationH hCT, double *xi
 void gmt_proj4_fwd (struct GMT_CTRL *GMT, double xi, double yi, double *xo, double *yo);
 void gmt_proj4_inv (struct GMT_CTRL *GMT, double *xi, double *yi, double xo, double yo);
 #	if GDAL_VERSION_MAJOR >= 2
+		EXTERN_MSC struct OGR_FEATURES* gmt_ogrread2(struct GMT_CTRL *GMT, struct OGRREAD_CTRL *Ctrl);
 		EXTERN_MSC struct OGR_FEATURES* gmt_ogrread(struct GMT_CTRL *GMT, char *ogr_filename, double *region);
 		EXTERN_MSC int gmt_gdal_info (struct GMT_CTRL *GMT, struct GMT_GDALLIBRARIFIED_CTRL *GDLL);
 		EXTERN_MSC int gmt_gdal_grid (struct GMT_CTRL *GMT, struct GMT_GDALLIBRARIFIED_CTRL *GDLL);


### PR DESCRIPTION

This should allow future extensions without further need to change function's API
Allow selection of one layer only for multi-layered files.

From Julia we can now do (read a single layer of a GADM file)
 ``` 
 gmtread("gadm36_PRT.gpkg", layer=3, region=(-10,-6,36,44))
```
