### PR TITLE
Add automatic labels for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a problem/bug to help us improve
 title: ''
-labels: ''
+labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Request the addition of a new feature/functionality
 title: ''
-labels: ''
+labels: feature request
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -1,7 +1,7 @@
 ---
 name: GMT release checklist
 about: Checklist for a new GMT release.
-title: 'Release GMT x.x.x'
+title: Release GMT x.x.x
 labels: ''
 assignees: ''
 


### PR DESCRIPTION
Issues using the "bug report" template will automatically add the "bug" label. Same for the "feature request" template.