### PR TITLE
Clarify that PSL_*.ps are the originals and PSL_string.h is derived

### DIFF
--- a/src/PSL_label.ps
+++ b/src/PSL_label.ps
@@ -6,10 +6,9 @@
 %-	the Adobe Cookbook for placing text along a curved line.
 %-	The second part is the functions that assist in finding
 %-	out where labels are placed and setting clip paths etc.
-%-
-%- NOTE: No longer used as replaced by static string in PSL_strings.h.
-%- 	 We keep the file in the repository as it may be simpler to see and edit
-%-	 the logic in this file than in the static string.
+%+  NOTE: No longer used directly as we build a static string in PSL_strings.h.
+%+    However, this file is the original source as it may be simpler to see and
+%+    edit the logic in this file than in the formatted static string.
 %-----------------------------------------------------------------------------
 
 /PSL_pathtextdict 26 dict def			% Local storage for the procedure PSL_pathtext.

--- a/src/PSL_prologue.ps
+++ b/src/PSL_prologue.ps
@@ -1,7 +1,9 @@
 %-----------------------------------------------------------------------------
-%- NOTE: No longer used as replaced by static string in PSL_strings.h.
-%- 	 We keep the file in the repository as it may be simpler to see and edit
-%-	 the logic in this file than in the static string.
+%-  PS dictionary written to header to all GMT PostScript plots
+%+  NOTE: No longer used directly as we build a static string in PSL_strings.h.
+%+    However, this file is the original source as it may be simpler to see and
+%+    edit the logic in this file than in the formatted static string.
+%+    Also, if PSL_transp is changed it may require edits to psconvert.c
 %-----------------------------------------------------------------------------
 % Begin pslib header
 250 dict begin

--- a/src/PSL_strings.h
+++ b/src/PSL_strings.h
@@ -15,7 +15,8 @@
  *--------------------------------------------------------------------*/
 
 /* The three former include files PSL_label.ps, PSL_text.ps, and PSL_prologue.ps
- * are now represented as three very long string literals instead.
+ * are now represented as three very long string literals instead.  However,
+ * they are still the original sources and any edits should be made to them.
  */
 
 /* Placing content of PSL_label.ps */
@@ -29,10 +30,6 @@ static char *PSL_label_str =
 "%-	the Adobe Cookbook for placing text along a curved line.\n"
 "%-	The second part is the functions that assist in finding\n"
 "%-	out where labels are placed and setting clip paths etc.\n"
-"%-\n"
-"%- NOTE: No longer used as replaced by static string in PSL_strings.h.\n"
-"%- 	 We keep the file in the repository as it may be simpler to see and edit\n"
-"%-	 the logic in this file than in the static string.\n"
 "%-----------------------------------------------------------------------------\n"
 "\n"
 "/PSL_pathtextdict 26 dict def			% Local storage for the procedure PSL_pathtext.\n"
@@ -677,9 +674,6 @@ static char *PSL_text_str =
 "%-	Knows about flush l,c,r and justified.\n"
 "%-	Knows about all GMT @ escapes, composites (but not in paragraph mode)\n"
 "%-	and underlining. No hyphenation.  1 page only.\n"
-"%- NOTE: No longer used as is, as replaced by static string in PSL_strings.h.\n"
-"%- 	 We keep the file in the repository as it may be simpler to edit and see\n"
-"%-	 the logic in this file than in the static string.\n"
 "%-----------------------------------------------------------------------------\n"
 "\n"
 "/PSL_setfont {	% Set Font, size, and color (if needed)\n"
@@ -935,9 +929,7 @@ static char *PSL_text_str =
 
 static char *PSL_prologue_str =
 "%-----------------------------------------------------------------------------\n"
-"%- NOTE: No longer used as replaced by static string in PSL_strings.h.\n"
-"%- 	 We keep the file in the repository as it may be simpler to see and edit\n"
-"%-	 the logic in this file than in the static string.\n"
+"%-  PS dictionary written to header to all GMT PostScript plots\n"
 "%-----------------------------------------------------------------------------\n"
 "% Begin pslib header\n"
 "250 dict begin\n"

--- a/src/PSL_text.ps
+++ b/src/PSL_text.ps
@@ -5,9 +5,9 @@
 %-	Knows about flush l,c,r and justified.
 %-	Knows about all GMT @ escapes, composites (but not in paragraph mode)
 %-	and underlining. No hyphenation.  1 page only.
-%- NOTE: No longer used as is, as replaced by static string in PSL_strings.h.
-%- 	 We keep the file in the repository as it may be simpler to edit and see
-%-	 the logic in this file than in the static string.
+%+  NOTE: No longer used directly as we build a static string in PSL_strings.h.
+%+    However, this file is the original source as it may be simpler to see and
+%+    edit the logic in this file than in the formatted static string.
 %-----------------------------------------------------------------------------
 
 /PSL_setfont {	% Set Font, size, and color (if needed)

--- a/src/gmt_make_PSL_strings.sh
+++ b/src/gmt_make_PSL_strings.sh
@@ -29,7 +29,8 @@ cat << EOF > PSL_strings.h
  *--------------------------------------------------------------------*/
 
 /* The three former include files PSL_label.ps, PSL_text.ps, and PSL_prologue.ps
- * are now represented as three very long string literals instead.
+ * are now represented as three very long string literals instead.  However,
+ * they are still the original sources and any edits should be made to them.
  */
 EOF
 cat << EOF > ${TMPDIR}/t.lis
@@ -42,7 +43,7 @@ while read file; do
 	n=$(cat $file | wc -l)
 	let n1=n-1
 	varname=$(basename $file .ps)
-	sed -n 1,${n1}p $file | awk 'BEGIN {printf "static char *%s_str =\n", "'$varname'"}; {printf "\"%s\\n\"\n", $0}' >> PSL_strings.h
+	sed -n 1,${n1}p $file | grep -v "^%+" | awk 'BEGIN {printf "static char *%s_str =\n", "'$varname'"}; {printf "\"%s\\n\"\n", $0}' >> PSL_strings.h
 	sed -n ${n}p $file | awk '{printf "\"%s\\n\";\n", $0}'>> PSL_strings.h
 done < ${TMPDIR}/t.lis
 rm -f ${TMPDIR}/t.lis


### PR DESCRIPTION
Improve the PSL*.ps documentation so that it is clear what the originals are, and remove part of the PSL*.ps comments that should not be duplicated into the *.h file by flagging them with` %+`.  This is done in a slightly revised _gmt_make_PSL_strings.sh_.  Finally, PSL_prologue.ps now has a comment to remind developers that if the _PSL_transp_ function needs to be edited then it may also require edits to _psconvert.c_
