### PR TITLE
Settle on transition size from old to new psl_shorten_path algorithm

### DIFF
--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -871,7 +871,9 @@ static int psl_shorten_path_old (struct PSL_CTRL *PSL, double *x, double *y, int
 	return (k);
 }
 
-#define N_LENGTH_THRESHOLD 100000000
+/* Addressing issue https://github.com/GenericMappingTools/gmt/issues/439 for long DCW polygons.
+   #define N_LENGTH_THRESHOLD 100000000 meant we only did new path but now we try 50000 as cutoff */
+#define N_LENGTH_THRESHOLD 50000
 static int psl_shorten_path (struct PSL_CTRL *PSL, double *x, double *y, int n, int *ix, int *iy, int mode) {
 	if (n > N_LENGTH_THRESHOLD)
 		return psl_shorten_path_old (PSL, x, y, n, ix, iy, mode);


### PR DESCRIPTION
See old issue #439 for background.  Playing around some more I found that using a cutoff of 50,000 points in a polygon affects none of our tests but it does fix the original problem (which is a very large polygon).  I think this is a reasonable compromise for now.  I added a reference to this issue in the postscriptlight.c code where this is addressed. Closes #439.
