### PR TITLE
Add wrapper for testapi_makecpt

### DIFF
--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -77,6 +77,7 @@ function psldemo()
 # Must have wrappers for all test programs not part of GMT distro:
 
 for apiprog in \
+    testapi_makecpt \
     testapi_matrix \
     testapi_matrix_plot \
     testapi_mixmatrix \


### PR DESCRIPTION
**Description of proposed changes**

Test `apimakecpt.sh` fails on Windows because `testapi_makecpt` is not
wrapped.
```
apimakecpt.sh: line 5: testapi_makecpt: command not found
```

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
