### PR TITLE
Prevent ESRI checking from accepting a .jp2 tile

### DIFF
--- a/src/gmt_esri_io.c
+++ b/src/gmt_esri_io.c
@@ -350,14 +350,14 @@ GMT_LOCAL int gmtesriio_read_info (struct GMT_CTRL *GMT, FILE *fp, struct GMT_GR
 int gmtlib_is_esri_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header) {
 	/* Determine if file is an ESRI Interchange ASCII file */
 	FILE *fp = NULL;
-	char record[GMT_BUFSIZ];
+	char record[GMT_BUFSIZ] = {""};
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (header);
 
 	if (!strcmp (HH->name, "="))
 		return (GMT_GRDIO_PIPE_CODECHECK);	/* Cannot check on pipes */
+	if (!strcmp (gmt_get_ext (HH->name), GMT_TILE_EXTENSION_REMOTE)) return (-1);	/* Watch out for .jp2 tiles since they may contain W|E|S|N codes as well and the ESRI check comes before GDAL check*/
 	if ((fp = gmt_fopen (GMT, HH->name, "r")) == NULL)
 		return (GMT_GRDIO_OPEN_FAILED);
-
 	if (fgets (record, GMT_BUFSIZ, fp) == NULL) {	/* Just get first line. Not using gmt_fgets since we may be reading a binary file */
 		gmt_fclose (GMT, fp);
 		return (GMT_GRDIO_OPEN_FAILED);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16663,8 +16663,10 @@ double *gmt_list_to_array (struct GMT_CTRL *GMT, char *list, unsigned int type, 
 
 uint64_t gmtlib_make_equidistant_array (struct GMT_CTRL *GMT, double min, double max, double inc, double **array) {
 	/* Just makes an equidistant array given vetted input parameters */
-	uint64_t k, n = lrint ((max - min) / fabs (inc)) + 1;
+	uint64_t k, n;
 	double *val = gmt_M_memory (GMT, NULL, n, double);
+
+	n = (doubleAlmostEqualZero (min, max) || gmt_M_is_zero (inc)) ? 1 : lrint ((max - min) / fabs (inc)) + 1;
 	if (inc < 0.0) {	/* Reverse direction max:inc:min */
 		for (k = 0; k < n; k++) val[k] = max + k * inc;
 		val[n-1] = min;	/* To avoid round-off all the way to the end */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16664,9 +16664,10 @@ double *gmt_list_to_array (struct GMT_CTRL *GMT, char *list, unsigned int type, 
 uint64_t gmtlib_make_equidistant_array (struct GMT_CTRL *GMT, double min, double max, double inc, double **array) {
 	/* Just makes an equidistant array given vetted input parameters */
 	uint64_t k, n;
-	double *val = gmt_M_memory (GMT, NULL, n, double);
+	double *val = NULL;
 
 	n = (doubleAlmostEqualZero (min, max) || gmt_M_is_zero (inc)) ? 1 : lrint ((max - min) / fabs (inc)) + 1;
+	val = gmt_M_memory (GMT, NULL, n, double);
 	if (inc < 0.0) {	/* Reverse direction max:inc:min */
 		for (k = 0; k < n; k++) val[k] = max + k * inc;
 		val[n-1] = min;	/* To avoid round-off all the way to the end */

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -731,6 +731,7 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 	if (Ctrl->T.T.var_inc || Ctrl->T.T.n == 1) {	/* Not equidistant output levels selected via -T so must pass the number of output levels instead of increment */
 		dims[GMT_Z] = Ctrl->T.T.n;	/* Number of output levels */
 		this_dim = dims;	/* Pointer to the dims instead of NULL */
+		inc[GMT_Z] = 0.0;
 	}
 	else	/* Normal equidistant output levels lets us pass z-inc */
 		inc[GMT_Z] = Ctrl->T.T.inc;	

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -320,7 +320,7 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 	int error = 0;
 	unsigned int int_mode, row, col, level_type, dtype = 0, file_mode = GMT_CONTAINER_AND_DATA;
 	uint64_t n_layers = 0, k, node, start_k, stop_k, n_layers_used, *this_dim = NULL, dims[3] = {0, 0, 0};
-	double wesn[6], inc[3], *level = NULL, *i_value = NULL, *o_value = NULL;
+	double wesn[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, inc[3] = {0.0, 0.0, 0.0}, *level = NULL, *i_value = NULL, *o_value = NULL;
 	struct GMT_GRID *Grid = NULL;
 	struct GMT_CUBE *C[2] = {NULL, NULL};     /* Structures to hold input/output cubes */
 


### PR DESCRIPTION
The checks in _gmtlib_is_esri_grid_ were defeated because the file name had some similarities with the special case for *.hgt files in there.  Now we refuse to even look inside *.jp2 files and punt back to GDAL.  Hopefully this will bypass the DarthMac troubles, @meghanrjones.
