### PR TITLE
Fix memory stomping in grdinterpolate

### DIFF
--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -1381,7 +1381,7 @@ where ``col`` is the vector number you wish to obtain a pointer to.
     int GMT_Put_Levels (void *API, struct GMT_CUBE *C, double *levels,
   uint64_t n_levels);
 
-where ``C`` is the :ref:`GMTCUBE <struct-cube>` created by GMT_Create_Data_, ``levels'' is an array
+where ``C`` is the :ref:`GMT_CUBE <struct-cube>` created by GMT_Create_Data_, ``levels'' is an array
 with the (probably) non-equidistant coordinates for the third cube dimension, and ``n_levels'' is their number.
 This function is typically used when we are creating a cube whose spacing between layers is not equidistant
 and hence cannot be computed internally from range and increments.

--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -832,6 +832,8 @@ The C/C++ API is deliberately kept small to make it easy to use.
     +--------------------------+-------------------------------------------------------+
     | GMT_Parse_Common_        | Parse the GMT common options                          |
     +--------------------------+-------------------------------------------------------+
+    | GMT_Put_Levels_          | Put user level coordinates into cube container        |
+    +--------------------------+-------------------------------------------------------+
     | GMT_Put_Matrix_          | Put user matrix into container                        |
     +--------------------------+-------------------------------------------------------+
     | GMT_Put_Record_          | Export a data record                                  |
@@ -1371,6 +1373,18 @@ To extract a custom vector from an output :ref:`GMT_VECTOR <struct-vector>` you 
     void *GMT_Get_Vector (void *API, struct GMT_VECTOR *V, unsigned int col);
 
 where ``col`` is the vector number you wish to obtain a pointer to.
+
+.. _GMT_Put_Levels:
+
+  ::
+
+    int GMT_Put_Levels (void *API, struct GMT_CUBE *C, double *levels,
+  uint64_t n_levels);
+
+where ``C`` is the :ref:`GMTCUBE <struct-cube>` created by GMT_Create_Data_, ``levels'' is an array
+with the (probably) non-equidistant coordinates for the third cube dimension, and ``n_levels'' is their number.
+This function is typically used when we are creating a cube whose spacing between layers is not equidistant
+and hence cannot be computed internally from range and increments.
 
 .. _GMT_Get_Version:
 

--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -1384,7 +1384,7 @@ where ``col`` is the vector number you wish to obtain a pointer to.
 where ``C`` is the :ref:`GMT_CUBE <struct-cube>` created by GMT_Create_Data_, ``levels'' is an array
 with the (probably) non-equidistant coordinates for the third cube dimension, and ``n_levels'' is their number.
 This function is typically used when we are creating a cube whose spacing between layers is not equidistant
-and hence cannot be computed internally from range and increments.
+and hence cannot be computed internally from range and increment.
 
 .. _GMT_Get_Version:
 

--- a/src/gmt.h
+++ b/src/gmt.h
@@ -106,6 +106,8 @@ EXTERN_MSC int GMT_Put_Matrix          (void *API, struct GMT_MATRIX *M, unsigne
 /* These 2 functions are new in 6.0 and are being considered beta */
 EXTERN_MSC int GMT_Put_Strings         (void *API, unsigned int family, void *object, char **array);
 EXTERN_MSC char ** GMT_Get_Strings     (void *API, unsigned int family, void *object);
+/* This function is new in 6.2 and is being considered beta */
+EXTERN_MSC int GMT_Put_Levels          (void *API, struct GMT_CUBE *C, double *levels, uint64_t n_levels);
 
 /* 5 functions to relate (row,col) to a 1-D index for grids, cubes and images and to precompute equidistant coordinates for grids and images */
 

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -5319,8 +5319,8 @@ int GMT_Put_Levels (void *V_API, struct GMT_CUBE *C, double *levels, uint64_t n_
 
 	/* Check for NULL and void arguments */
 	if (V_API == NULL) return_error (API, GMT_NOT_A_SESSION);
-	if (levels == NULL) return (GMT_PTR_IS_NULL);
-	if (n_levels == 0) return (GMT_DIM_TOO_SMALL);
+	if (levels == NULL) return_error (API, GMT_PTR_IS_NULL);
+	if (n_levels == 0) return_error (API, GMT_DIM_TOO_SMALL);
 	if (C == NULL) return_error (API, GMT_PTR_IS_NULL);
 	if (C->z) return_error (API, GMT_PTR_NOT_NULL);
 	if (C->header == NULL) return_error (API, GMT_PTR_IS_NULL);
@@ -5328,9 +5328,9 @@ int GMT_Put_Levels (void *V_API, struct GMT_CUBE *C, double *levels, uint64_t n_
 		if ((uint64_t)C->header->n_bands < n_levels) return_error (API, GMT_DIM_TOO_SMALL);
 		if ((uint64_t)C->header->n_bands > n_levels) return_error (API, GMT_DIM_TOO_LARGE);
 	}
-	if ((CU = gmt_get_U_hidden (C)) == NULL) return (GMT_PTR_IS_NULL);
+	if ((CU = gmt_get_U_hidden (C)) == NULL) return_error (API, GMT_PTR_IS_NULL);
 	API = gmtapi_get_api_ptr (V_API);
-	if ((C->z = gmt_duplicate_array (API->GMT, levels, n_levels)) == NULL) return (GMT_MEMORY_ERROR);
+	if ((C->z = gmt_duplicate_array (API->GMT, levels, n_levels)) == NULL) return_error (API, GMT_MEMORY_ERROR);
 	CU->xyz_alloc_mode[GMT_Z] = GMT_ALLOC_INTERNALLY;	/* Since allocated by GMT */
 	C->header->n_bands = (uint32_t)n_levels;
 

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -39,7 +39,7 @@
  * GMT_Message		       : Report an message given a verbosity level
  * GMT_Report		       : Report an error given an error code
  *
- * There are 32 further public functions used for GMT i/o activities:
+ * There are 33 further public functions used for GMT i/o activities:
  *
  * GMT_Alloc_Segment       : Allocate a single DATASET segment
  * GMT_Begin_IO	           : Allow i/o to take place for rec-by-rec operations
@@ -61,6 +61,7 @@
  * GMT_Init_VirtualFile    : Reset a virtual file for reuse
  * GMT_Inquire_VirtualFile : Determine family of a virtual file
  * GMT_Open_VirtualFile    : Open a memory location for reading or writing by a module
+ * GMT_Put_Levels          : Place an array with 3rd dimension coordinates for a cube
  * GMT_Put_Record          : Send the next output record to its destination
  * GMT_Put_Row             : Write one row to a grid
  * GMT_Put_Matrix          : Hook user matrix to GMT_MATRIX array
@@ -5311,6 +5312,39 @@ GMT_LOCAL int gmtapi_export_grid (struct GMTAPI_CTRL *API, int object_ID, unsign
 	return (GMT_NOERROR);
 }
 
+int GMT_Put_Levels (void *V_API, struct GMT_CUBE *C, double *levels, uint64_t n_levels) {
+	/* Duplicate and assign a level array to the cube for its 3rd dimension coordinates */
+	struct GMT_CUBE_HIDDEN *CU;
+	struct GMTAPI_CTRL *API;
+
+	/* Check for NULL and void arguments */
+	if (V_API == NULL) return_error (API, GMT_NOT_A_SESSION);
+	if (levels == NULL) return (GMT_PTR_IS_NULL);
+	if (n_levels == 0) return (GMT_DIM_TOO_SMALL);
+	if (C == NULL) return_error (API, GMT_PTR_IS_NULL);
+	if (C->z) return_error (API, GMT_PTR_NOT_NULL);
+	if (C->header == NULL) return_error (API, GMT_PTR_IS_NULL);
+	if (C->header->n_bands > 0) {	/* If set then it better match */
+		if ((uint64_t)C->header->n_bands < n_levels) return_error (API, GMT_DIM_TOO_SMALL);
+		if ((uint64_t)C->header->n_bands > n_levels) return_error (API, GMT_DIM_TOO_LARGE);
+	}
+	if ((CU = gmt_get_U_hidden (C)) == NULL) return (GMT_PTR_IS_NULL);
+	API = gmtapi_get_api_ptr (V_API);
+	if ((C->z = gmt_duplicate_array (API->GMT, levels, n_levels)) == NULL) return (GMT_MEMORY_ERROR);
+	CU->xyz_alloc_mode[GMT_Z] = GMT_ALLOC_INTERNALLY;	/* Since allocated by GMT */
+	C->header->n_bands = (uint32_t)n_levels;
+
+	return (GMT_NOERROR);
+}
+
+#ifdef FORTRAN_API
+int GMT_Put_Levels_ (struct GMT_CUBE *C, double *level, uint64_t *n) {
+	/* Fortran version: We pass the global GMT_FORTRAN structure */
+	return (GMT_Put_Levels (GMT_FORTRAN, C, level, *n));
+}
+#endif
+
+
 GMT_LOCAL uint64_t gmtapi_get_file_count (char **list) {
 	/* Determine how many entries before trailing NULL entry */
 	uint64_t k = 0;
@@ -5488,7 +5522,11 @@ start_over_import_cube:		/* We may get here if we cannot honor a GMT_IS_REFERENC
 					U_obj->header->n_bands = n_layers_used;
 					U_obj->z_range[0] = U_obj->z[k0];
 					U_obj->z_range[1] = U_obj->z[k1];
-					if (k0) memmove (U_obj->z, &U_obj->z[k0], n_layers_used * sizeof(double));	/* Eliminate entries not included */
+					if (k0) {	/* Eliminate entries not included and shrink array */
+						memmove (U_obj->z, &U_obj->z[k0], n_layers_used * sizeof(double));
+						gmt_M_memset (&U_obj->z[n_layers_used], n_layers-n_layers_used, double);
+						U_obj->z = gmt_M_memory (API->GMT, U_obj->z, n_layers_used, double);
+					}
 					U_obj->data = gmt_M_memory_aligned (API->GMT, NULL, U_obj->header->size * n_layers_used, gmt_grdfloat);
 					z_min = U_obj->header->z_min;	/* Initialize cube min/max values based on this first layer */
 					z_max = U_obj->header->z_max;

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -738,8 +738,8 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 		Return (GMT_MEMORY_ERROR);
 
 	/* If not equidistant we must add in the level array manually */
-	if (C[GMT_OUT]->z == NULL)
-		GMT_Put_Levels (API, C[GMT_OUT], Ctrl->T.T.array, Ctrl->T.T.n);
+	if (C[GMT_OUT]->z == NULL && GMT_Put_Levels (API, C[GMT_OUT], Ctrl->T.T.array, Ctrl->T.T.n))
+		Return (API->error);
 
 	/* Allocate input and output arrays for the 1-D spline */
 	if ((i_value = gmt_M_memory (GMT, NULL, C[GMT_IN]->header->n_bands, double)) == NULL) Return (GMT_MEMORY_ERROR);

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -727,7 +727,7 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 
 	gmt_M_memcpy (wesn, C[GMT_IN]->header->wesn, 4, double);	/* This is the output common x/y region now */
 	inc[GMT_X] = C[GMT_IN]->header->inc[GMT_X];	inc[GMT_Y] = C[GMT_IN]->header->inc[GMT_Y];	/* And common x/y increments */
-	if (Ctrl->T.T.var_inc) {	/* Not equidistant output levels selected via -T so must pass the number of output levels instead of increment */
+	if (Ctrl->T.T.var_inc || Ctrl->T.T.n == 1) {	/* Not equidistant output levels selected via -T so must pass the number of output levels instead of increment */
 		dims[GMT_Z] = Ctrl->T.T.n;	/* Number of output levels */
 		this_dim = dims;	/* Pointer to the dims instead of NULL */
 	}
@@ -738,7 +738,8 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 		Return (GMT_MEMORY_ERROR);
 
 	/* If not equidistant we must add in the level array manually */
-	if (Ctrl->T.T.var_inc) C[GMT_OUT]->z = gmt_duplicate_array (GMT, Ctrl->T.T.array, Ctrl->T.T.n);
+	if (C[GMT_OUT]->z == NULL)
+		GMT_Put_Levels (API, C[GMT_OUT], Ctrl->T.T.array, Ctrl->T.T.n);
 
 	/* Allocate input and output arrays for the 1-D spline */
 	if ((i_value = gmt_M_memory (GMT, NULL, C[GMT_IN]->header->n_bands, double)) == NULL) Return (GMT_MEMORY_ERROR);
@@ -764,7 +765,6 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 
 	/* Done with everything; free up remaining memory */
 
-	gmt_M_free (GMT, level);
 	gmt_M_free (GMT, i_value);
 	gmt_M_free (GMT, o_value);
 


### PR DESCRIPTION
The **grdinterpolate** module freed an array that should be left to _GMT_Destroy_Data_, causing memory troubles.

To simplify API operations I have added a new API function _GMT_Put_Levels_ so that it is possible to assign an array with non-equidistant levels to a cube created by _GMT_Create_Data_.  It handles the setting of the hidden allocation mode that _GMT_Destroy_Data_ relies on.

This fixed a SEGV crash for me in _apicubeplot.sh_.  I know others have said _onelayer.sh_ crashes for them (but not me) so let me know if this helps that test too.