### PR TITLE
Pen reset

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -2597,7 +2597,7 @@ GMT_LOCAL void gmtplot_map_boundary (struct GMT_CTRL *GMT) {
 	w = GMT->common.R.wesn[XLO], e = GMT->common.R.wesn[XHI], s = GMT->common.R.wesn[YLO], n = GMT->common.R.wesn[YHI];
 
 	PSL_comment (PSL, "Start of map frame\n");
-	PSL_command (PSL, "0 A [] 0 B\n");	/* Also ensure full reset to black solid pen color */
+
 	gmt_setpen (GMT, &GMT->current.setting.map_frame_pen);
 	PSL_setcolor (PSL, GMT->current.setting.map_frame_pen.rgb, PSL_IS_STROKE);
 
@@ -5652,6 +5652,11 @@ void gmt_map_basemap (struct GMT_CTRL *GMT) {
 
 	PSL_setdash (PSL, NULL, 0);	/* To ensure no dashed pens are set prior */
 
+	/* These three commands resets the memory of PSL regarding pen width, color, and outline */
+	gmt_M_memcpy (PSL->current.rgb[PSL_IS_STROKE], GMT->session.no_rgb, 3, double);	/* Reset to -1,-1,-1 so it can be reset below */
+	PSL->current.linewidth = -1.0;	/* For a reset of internal setting in PSL */
+	PSL->current.outline = -1;		/* Will now be changed by first PSL_setfill */
+
 	if (GMT->current.proj.three_D && GMT->current.map.frame.drawz) GMT->current.map.frame.plotted_header = true;	/* Just so it is not plotted by gmtplot_map_boundary first */
 
 	if (GMT->current.proj.got_azimuths) gmt_M_uint_swap (GMT->current.map.frame.side[E_SIDE], GMT->current.map.frame.side[W_SIDE]);	/* Temporary swap to trick justify machinery */
@@ -8116,7 +8121,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 			plot_y -= (P->dy);
 			PSL_command (PSL, "/PSL_plot_completion {\nV\n");
 			PSL_comment (PSL, "Start of panel tag for panel (%d,%d)\n", P->row, P->col);
-			PSL_comment (PSL, "Will not execute until end of panel\n");
+			PSL_comment (PSL, "Will not execute until end of panel\nFQ O0\n");
 			PSL_setorigin (PSL, GMT->current.setting.map_origin[GMT_X] - P->gap[XLO], GMT->current.setting.map_origin[GMT_Y] - P->gap[YLO], 0.0, PSL_FWD);
 			justify = gmt_just_decode (GMT, P->justify, PSL_NO_DEF);	/* Convert XX refpoint code to PSL number */
 			gmt_smart_justify (GMT, justify, 0.0, P->off[GMT_X], P->off[GMT_Y], &plot_x, &plot_y, 1);	/* Shift as requested */
@@ -8129,6 +8134,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 				int outline = 0;
 				struct GMT_FILL fill;
 				gmt_init_fill (GMT, &fill, -1.0, -1.0, -1.0);	/* No fill */
+				PSL_command (PSL, "FQ O0\n");	/* Ensure fill/pen have been reset */
 				if (P->pen[0]) {	/* Want to draw outline of tag box */
 					struct GMT_PEN pen;
 					gmt_M_memset (&pen, 1, struct GMT_PEN);
@@ -8194,6 +8200,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 			if (!(PP[0] == '-' && FF[0] == '-')) {	/* Requested textbox fill and/or outline */
 				int outline = 0;	/* No outline */
 				struct GMT_FILL fill;
+				PSL_command (PSL, "FQ O0\n");	/* Ensure fill/pen have been reset */
 				gmt_init_fill (GMT, &fill, -1.0, -1.0, -1.0);	/* Initialize to no fill */
 				if (PP[0] != '-') {	/* Want to draw outline of tag box */
 					struct GMT_PEN pen;

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -8121,7 +8121,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 			plot_y -= (P->dy);
 			PSL_command (PSL, "/PSL_plot_completion {\nV\n");
 			PSL_comment (PSL, "Start of panel tag for panel (%d,%d)\n", P->row, P->col);
-			PSL_comment (PSL, "Will not execute until end of panel\nFQ O0\n");
+			PSL_comment (PSL, "Will not execute until end of panel\n");
 			PSL_setorigin (PSL, GMT->current.setting.map_origin[GMT_X] - P->gap[XLO], GMT->current.setting.map_origin[GMT_Y] - P->gap[YLO], 0.0, PSL_FWD);
 			justify = gmt_just_decode (GMT, P->justify, PSL_NO_DEF);	/* Convert XX refpoint code to PSL number */
 			gmt_smart_justify (GMT, justify, 0.0, P->off[GMT_X], P->off[GMT_Y], &plot_x, &plot_y, 1);	/* Shift as requested */

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1247,7 +1247,6 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 			}
 		}
 	}
-	if (penset_OK) gmt_setpen (GMT, &current_pen);
 
 	QR_symbol = (S.symbol == GMT_SYMBOL_CUSTOM && (!strcmp (S.custom->name, "QR") || !strcmp (S.custom->name, "QR_transparent")));
 	fill_active = Ctrl->G.active;	/* Make copies because we will change the values */
@@ -1260,6 +1259,9 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 	old_is_world = GMT->current.map.is_world;
 	geometry = not_line ? GMT_IS_POINT : ((polygon) ? GMT_IS_POLY: GMT_IS_LINE);
 	in = GMT->current.io.curr_rec;
+
+	PSL_command (GMT->PSL, "V\n");	/* Place all symbols or lines under a gsave/grestore clause */
+	if (penset_OK) gmt_setpen (GMT, &current_pen);
 
 	if (not_line) {	/* Symbol part (not counting GMT_SYMBOL_FRONT, GMT_SYMBOL_QUOTED_LINE, GMT_SYMBOL_DECORATED_LINE) */
 		bool periodic = false, delayed_unit_scaling = false, E_bar_above = false, E_bar_below = false;
@@ -1301,7 +1303,6 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 		if (GMT_Begin_IO (API, GMT_IS_DATASET, GMT_IN, GMT_HEADER_ON) != GMT_NOERROR) {		/* Enables data input and sets access mode */
 			Return (API->error);
 		}
-		PSL_command (GMT->PSL, "V\n");	/* Place all symbols under a gsave/grestore clause */
 
 		if (Ctrl->E.active) {	/* Place errorbars below symbol except for large bars */
 			E_bar_above = (S.symbol == GMT_SYMBOL_BARX || S.symbol == GMT_SYMBOL_BARY);
@@ -2036,7 +2037,6 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 			double transp[2] = {0.0, 0.0};	/* None selected */
 			PSL_settransparencies (PSL, transp);
 		}
-		PSL_command (GMT->PSL, "U\n");
 		if (n_warn[1]) GMT_Report (API, GMT_MSG_INFORMATION, "%d vector heads had length exceeding the vector length and were skipped. Consider the +n<norm> modifier to -S\n", n_warn[1]);
 		if (n_warn[2]) GMT_Report (API, GMT_MSG_INFORMATION, "%d vector heads had to be scaled more than implied by +n<norm> since they were still too long. Consider changing the +n<norm> modifier to -S\n", n_warn[2]);
 
@@ -2484,6 +2484,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 		}
 		gmt_map_clip_off (GMT);
 	}
+	PSL_command (GMT->PSL, "U\n");	/* Undo the gsave for all symbols or lines */
 
 	if (S.u_set) GMT->current.setting.proj_length_unit = save_u;	/* Reset unit */
 

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -894,7 +894,6 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 	bcol = (S.read_size) ? ex2 : ex1;
 	if (S.symbol == GMT_SYMBOL_BARX && (S.base_set & GMT_BASE_READ)) gmt_set_column_type (GMT, GMT_IN, bcol, gmt_M_type (GMT, GMT_IN, GMT_Y));
 	if (S.symbol == GMT_SYMBOL_BARY && (S.base_set & GMT_BASE_READ)) gmt_set_column_type (GMT, GMT_IN, bcol, gmt_M_type (GMT, GMT_IN, GMT_Y));
-	if (penset_OK) gmt_setpen (GMT, &current_pen);
 	QR_symbol = (S.symbol == GMT_SYMBOL_CUSTOM && (!strcmp (S.custom->name, "QR") || !strcmp (S.custom->name, "QR_transparent")));
 	fill_active = Ctrl->G.active;	/* Make copies because we will change the values */
 	outline_active =  Ctrl->W.active;
@@ -912,6 +911,9 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 	if (P) PH = gmt_get_C_hidden (P);
 	old_is_world = GMT->current.map.is_world;
 	geometry = not_line ? GMT_IS_POINT : ((polygon) ? GMT_IS_POLY: GMT_IS_LINE);
+
+	PSL_command (GMT->PSL, "V\n");	/* Place all symbols or lines under a gsave/grestore clause */
+	if (penset_OK) gmt_setpen (GMT, &current_pen);
 
 	if (not_line) {	/* symbol part (not counting GMT_SYMBOL_FRONT and GMT_SYMBOL_QUOTED_LINE) */
 		bool periodic = false, delayed_unit_scaling[2] = {false, false};
@@ -1491,7 +1493,6 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 
 		/* Now plot these symbols one at the time */
 
-		PSL_command (GMT->PSL, "V\n");
 		for (i = 0; i < n; i++) {
 
 			if (n_z == 1 || (data[i].symbol == GMT_SYMBOL_CUBE || data[i].symbol == GMT_SYMBOL_CUBE)) {
@@ -1763,7 +1764,6 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 			double transp[2] = {0.0, 0.0};	/* None selected */
 			PSL_settransparencies (PSL, transp);
 		}
-		PSL_command (GMT->PSL, "U\n");
 		if (n_warn[1]) GMT_Report (API, GMT_MSG_INFORMATION, "%d vector heads had length exceeding the vector length and were skipped. Consider the +n<norm> modifier to -S\n", n_warn[1]);
 		if (n_warn[2]) GMT_Report (API, GMT_MSG_INFORMATION, "%d vector heads had to be scaled more than implied by +n<norm> since they were still too long. Consider changing the +n<norm> modifier to -S\n", n_warn[2]);
 		gmt_M_free (GMT, data);
@@ -2079,6 +2079,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 			Return (API->error);
 		}
 	}
+	PSL_command (GMT->PSL, "U\n");	/* Undo the gsave for all symbols or lines */
 
 	if (S.u_set) GMT->current.setting.proj_length_unit = save_u;	/* Reset unit */
 

--- a/test/gmtbinstats/weighted.ps
+++ b/test/gmtbinstats/weighted.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_93cb4cc_2020.08.15 [64-bit] Document from plot
+%%Title: GMT v6.2.0_b1364c2_2020.11.28 [64-bit] Document from plot
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sat Aug 15 17:38:23 2020
+%%CreationDate: Sat Nov 28 15:00:53 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -111,9 +111,11 @@
   PSL_eps_state restore
 }!
 /PSL_transp {
-  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
-  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
-  {pop pop} ifelse} ifelse
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
 }!
 /Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
@@ -683,7 +685,8 @@ O0
 /PSL_plot_completion {
 V
 0 10500 T
-0 A {1 A} FS
+0 A FQ O0
+{1 A} FS
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V
@@ -696,10 +699,76 @@ U
 40 1460 M (data) tl Z
 U
 }!
+8 W
+0 A
+N 200 0 M 0 -83 D S
+N 1100 0 M 0 -83 D S
+N 2000 0 M 0 -83 D S
+N 2900 0 M 0 -83 D S
+N 0 150 M -83 0 D S
+N 0 150 M -83 0 D S
+N 0 450 M -83 0 D S
+N 0 450 M -83 0 D S
+N 0 750 M -83 0 D S
+N 0 750 M -83 0 D S
+N 0 1050 M -83 0 D S
+N 0 1050 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 200 0 M 0 -42 D S
+N 500 0 M 0 -42 D S
+N 800 0 M 0 -42 D S
+N 1100 0 M 0 -42 D S
+N 1400 0 M 0 -42 D S
+N 1700 0 M 0 -42 D S
+N 2000 0 M 0 -42 D S
+N 2300 0 M 0 -42 D S
+N 2600 0 M 0 -42 D S
+N 2900 0 M 0 -42 D S
+N 3200 0 M 0 -42 D S
+N 3500 0 M 0 -42 D S
+N 0 50 M -42 0 D S
+N 0 50 M -42 0 D S
+N 0 150 M -42 0 D S
+N 0 150 M -42 0 D S
+N 0 250 M -42 0 D S
+N 0 250 M -42 0 D S
+N 0 350 M -42 0 D S
+N 0 350 M -42 0 D S
+N 0 450 M -42 0 D S
+N 0 450 M -42 0 D S
+N 0 550 M -42 0 D S
+N 0 550 M -42 0 D S
+N 0 650 M -42 0 D S
+N 0 650 M -42 0 D S
+N 0 750 M -42 0 D S
+N 0 750 M -42 0 D S
+N 0 850 M -42 0 D S
+N 0 850 M -42 0 D S
+N 0 950 M -42 0 D S
+N 0 950 M -42 0 D S
+N 0 1050 M -42 0 D S
+N 0 1050 M -42 0 D S
+N 0 1150 M -42 0 D S
+N 0 1150 M -42 0 D S
+N 0 1250 M -42 0 D S
+N 0 1250 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 1450 M -42 0 D S
+N 0 1450 M -42 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-167 150 M 200 F0
+(î60è) mr Z
+-167 450 M (î30è) mr Z
+-167 750 M (0è) mr Z
+-167 1050 M (30è) mr Z
+-167 1350 M (60è) mr Z
 1313 1450 M
 -1 0 D
 P
 {0.827 A} FS
+O0
 FO
 1334 1450 M
 -18 3 D
@@ -13418,64 +13487,7 @@ FO
 P
 FO
 25 W
-8 W
-N 200 0 M 0 -83 D S
-N 1100 0 M 0 -83 D S
-N 2000 0 M 0 -83 D S
-N 2900 0 M 0 -83 D S
-N 0 150 M -83 0 D S
-N 0 150 M -83 0 D S
-N 0 450 M -83 0 D S
-N 0 450 M -83 0 D S
-N 0 750 M -83 0 D S
-N 0 750 M -83 0 D S
-N 0 1050 M -83 0 D S
-N 0 1050 M -83 0 D S
-N 0 1350 M -83 0 D S
-N 0 1350 M -83 0 D S
-N 200 0 M 0 -42 D S
-N 500 0 M 0 -42 D S
-N 800 0 M 0 -42 D S
-N 1100 0 M 0 -42 D S
-N 1400 0 M 0 -42 D S
-N 1700 0 M 0 -42 D S
-N 2000 0 M 0 -42 D S
-N 2300 0 M 0 -42 D S
-N 2600 0 M 0 -42 D S
-N 2900 0 M 0 -42 D S
-N 3200 0 M 0 -42 D S
-N 3500 0 M 0 -42 D S
-N 0 50 M -42 0 D S
-N 0 50 M -42 0 D S
-N 0 150 M -42 0 D S
-N 0 150 M -42 0 D S
-N 0 250 M -42 0 D S
-N 0 250 M -42 0 D S
-N 0 350 M -42 0 D S
-N 0 350 M -42 0 D S
-N 0 450 M -42 0 D S
-N 0 450 M -42 0 D S
-N 0 550 M -42 0 D S
-N 0 550 M -42 0 D S
-N 0 650 M -42 0 D S
-N 0 650 M -42 0 D S
-N 0 750 M -42 0 D S
-N 0 750 M -42 0 D S
-N 0 850 M -42 0 D S
-N 0 850 M -42 0 D S
-N 0 950 M -42 0 D S
-N 0 950 M -42 0 D S
-N 0 1050 M -42 0 D S
-N 0 1050 M -42 0 D S
-N 0 1150 M -42 0 D S
-N 0 1150 M -42 0 D S
-N 0 1250 M -42 0 D S
-N 0 1250 M -42 0 D S
-N 0 1350 M -42 0 D S
-N 0 1350 M -42 0 D S
-N 0 1450 M -42 0 D S
-N 0 1450 M -42 0 D S
-25 W
+0 A
 0 0 M
 3600 0 D
 0 1500 D
@@ -13485,13 +13497,6 @@ N 0 1450 M -42 0 D S
 -900 0 D
 0 -1500 D
 P S
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
--167 150 M 200 F0
-(î60è) mr Z
--167 450 M (î30è) mr Z
--167 750 M (0è) mr Z
--167 1050 M (30è) mr Z
--167 1350 M (60è) mr Z
 %%EndObject
 0 -10500 TM
 0 A
@@ -13512,8 +13517,8 @@ clipsave
 -3600 0 D
 P
 PSL_clip N
-4 W
 V
+4 W
 {0 0.0698 1 C} FS
 O1
 24 1792 1095 Sc
@@ -14179,7 +14184,8 @@ O0
 /PSL_plot_completion {
 V
 4183 10500 T
-0 A {1 A} FS
+0 A FQ O0
+{1 A} FS
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V
@@ -14192,6 +14198,65 @@ U
 40 1460 M (a) tl Z
 U
 }!
+8 W
+0 A
+N 200 0 M 0 -83 D S
+N 1100 0 M 0 -83 D S
+N 2000 0 M 0 -83 D S
+N 2900 0 M 0 -83 D S
+N 0 150 M -83 0 D S
+N 0 150 M -83 0 D S
+N 0 450 M -83 0 D S
+N 0 450 M -83 0 D S
+N 0 750 M -83 0 D S
+N 0 750 M -83 0 D S
+N 0 1050 M -83 0 D S
+N 0 1050 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 200 0 M 0 -42 D S
+N 500 0 M 0 -42 D S
+N 800 0 M 0 -42 D S
+N 1100 0 M 0 -42 D S
+N 1400 0 M 0 -42 D S
+N 1700 0 M 0 -42 D S
+N 2000 0 M 0 -42 D S
+N 2300 0 M 0 -42 D S
+N 2600 0 M 0 -42 D S
+N 2900 0 M 0 -42 D S
+N 3200 0 M 0 -42 D S
+N 3500 0 M 0 -42 D S
+N 0 50 M -42 0 D S
+N 0 50 M -42 0 D S
+N 0 150 M -42 0 D S
+N 0 150 M -42 0 D S
+N 0 250 M -42 0 D S
+N 0 250 M -42 0 D S
+N 0 350 M -42 0 D S
+N 0 350 M -42 0 D S
+N 0 450 M -42 0 D S
+N 0 450 M -42 0 D S
+N 0 550 M -42 0 D S
+N 0 550 M -42 0 D S
+N 0 650 M -42 0 D S
+N 0 650 M -42 0 D S
+N 0 750 M -42 0 D S
+N 0 750 M -42 0 D S
+N 0 850 M -42 0 D S
+N 0 850 M -42 0 D S
+N 0 950 M -42 0 D S
+N 0 950 M -42 0 D S
+N 0 1050 M -42 0 D S
+N 0 1050 M -42 0 D S
+N 0 1150 M -42 0 D S
+N 0 1150 M -42 0 D S
+N 0 1250 M -42 0 D S
+N 0 1250 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 1450 M -42 0 D S
+N 0 1450 M -42 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 clipsave
 0 0 M
 3600 0 D
@@ -14237,7 +14302,49 @@ MO3`q;Jd,gs/O]Na+))'(S41:.0~>
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+-4183 -10500 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 8750 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya7.2917i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 8750 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(d) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (d) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -14294,47 +14401,13 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-%%EndObject
--4183 -10500 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-0 8750 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya7.2917i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-0 8750 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(d) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (d) tl Z
-U
-}!
+-167 150 M 200 F0
+(î60è) mr Z
+-167 450 M (î30è) mr Z
+-167 750 M (0è) mr Z
+-167 1050 M (30è) mr Z
+-167 1350 M (60è) mr Z
 clipsave
 0 0 M
 3600 0 D
@@ -14371,7 +14444,49 @@ b8'PbGX]c.rP_WW6V>e8Y[0=doL/!CCFEZkQ1JAE&#ZhS>6~>
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+0 -8750 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4183 8750 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -Bwrts -Bxaf -Byaf -Xa3.4861i -Ya7.2917i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+4183 8750 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(s) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (s) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -14428,53 +14543,7 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
--167 150 M 200 F0
-(î60è) mr Z
--167 450 M (î30è) mr Z
--167 750 M (0è) mr Z
--167 1050 M (30è) mr Z
--167 1350 M (60è) mr Z
-%%EndObject
-0 -8750 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-4183 8750 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -Bwrts -Bxaf -Byaf -Xa3.4861i -Ya7.2917i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-4183 8750 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(s) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (s) tl Z
-U
-}!
 clipsave
 0 0 M
 3600 0 D
@@ -14519,7 +14588,49 @@ XJ(`a[cT^bH]23*mAW7VVtR(_5JGa36i~>
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+-4183 -8750 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 7000 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya5.8333i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 7000 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(i) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (i) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -14576,47 +14687,13 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-%%EndObject
--4183 -8750 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-0 7000 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya5.8333i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-0 7000 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(i) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (i) tl Z
-U
-}!
+-167 150 M 200 F0
+(î60è) mr Z
+-167 450 M (î30è) mr Z
+-167 750 M (0è) mr Z
+-167 1050 M (30è) mr Z
+-167 1350 M (60è) mr Z
 clipsave
 0 0 M
 3600 0 D
@@ -14656,7 +14733,49 @@ WZe#1=3c;\5JtH3_u~>
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+0 -7000 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4183 7000 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -Bwrts -Bxaf -Byaf -Xa3.4861i -Ya5.8333i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+4183 7000 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(l) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (l) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -14713,53 +14832,7 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
--167 150 M 200 F0
-(î60è) mr Z
--167 450 M (î30è) mr Z
--167 750 M (0è) mr Z
--167 1050 M (30è) mr Z
--167 1350 M (60è) mr Z
-%%EndObject
-0 -7000 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-4183 7000 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -Bwrts -Bxaf -Byaf -Xa3.4861i -Ya5.8333i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-4183 7000 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(l) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (l) tl Z
-U
-}!
 clipsave
 0 0 M
 3600 0 D
@@ -14785,7 +14858,49 @@ PkiBlq``"em@/mjZ7(&*d_<=f(H^eFV]0U3%h86IS.F.W4h"E2~>
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+-4183 -7000 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 5250 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya4.375i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 5250 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(m) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (m) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -14842,47 +14957,13 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-%%EndObject
--4183 -7000 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-0 5250 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya4.375i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-0 5250 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(m) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (m) tl Z
-U
-}!
+-167 150 M 200 F0
+(î60è) mr Z
+-167 450 M (î30è) mr Z
+-167 750 M (0è) mr Z
+-167 1050 M (30è) mr Z
+-167 1350 M (60è) mr Z
 clipsave
 0 0 M
 3600 0 D
@@ -14912,7 +14993,49 @@ FBb?s5r5]7Ieqib0\B%=LU_GPl8fk-As&?``.dEtdKrP&M@6OA5300KX5Q[397&fh\.fDV>'KM;6CbfG
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+0 -5250 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4183 5250 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -Bwrts -Bxaf -Byaf -Xa3.4861i -Ya4.375i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+4183 5250 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(n) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (n) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -14969,53 +15092,7 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
--167 150 M 200 F0
-(î60è) mr Z
--167 450 M (î30è) mr Z
--167 750 M (0è) mr Z
--167 1050 M (30è) mr Z
--167 1350 M (60è) mr Z
-%%EndObject
-0 -5250 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-4183 5250 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -Bwrts -Bxaf -Byaf -Xa3.4861i -Ya4.375i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-4183 5250 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(n) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (n) tl Z
-U
-}!
 clipsave
 0 0 M
 3600 0 D
@@ -15045,7 +15122,49 @@ jBjG:)$CDq['-;gG[i?L3TFpQcKU<:.%6q;W@h@6d1e+A(&<@'B8!&_#$UO[iCrjV$msC+@in)5#U0r&
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+-4183 -5250 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 3500 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya2.9167i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 3500 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(o) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (o) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -15102,47 +15221,13 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-%%EndObject
--4183 -5250 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-0 3500 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya2.9167i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-0 3500 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(o) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (o) tl Z
-U
-}!
+-167 150 M 200 F0
+(î60è) mr Z
+-167 450 M (î30è) mr Z
+-167 750 M (0è) mr Z
+-167 1050 M (30è) mr Z
+-167 1350 M (60è) mr Z
 clipsave
 0 0 M
 3600 0 D
@@ -15176,7 +15261,49 @@ k#N5X<,4@Be(Ca@:O``t/.cW9X]DM#(-)M@GY%si]*V>R)i!VmiGNF"bd@;e*HmoEijP.Z.8]37lhtUt
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+0 -3500 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4183 3500 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -Bwrts -Bxaf -Byaf -Xa3.4861i -Ya2.9167i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+4183 3500 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(p) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (p) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -15233,53 +15360,7 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
--167 150 M 200 F0
-(î60è) mr Z
--167 450 M (î30è) mr Z
--167 750 M (0è) mr Z
--167 1050 M (30è) mr Z
--167 1350 M (60è) mr Z
-%%EndObject
-0 -3500 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-4183 3500 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -Bwrts -Bxaf -Byaf -Xa3.4861i -Ya2.9167i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-4183 3500 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(p) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (p) tl Z
-U
-}!
 clipsave
 0 0 M
 3600 0 D
@@ -15313,7 +15394,49 @@ OBdf\iXm6K.qPVV&ls7UQ4Y:Sg:%JD)9R,N"qaEFWi4e:.nM^M%nZJuSH#VHH"*1Z~>
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+-4183 -3500 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 1750 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya1.4583i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 1750 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(q75) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (q75) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -15370,47 +15493,13 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-%%EndObject
--4183 -3500 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-0 1750 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya1.4583i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-0 1750 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(q75) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (q75) tl Z
-U
-}!
+-167 150 M 200 F0
+(î60è) mr Z
+-167 450 M (î30è) mr Z
+-167 750 M (0è) mr Z
+-167 1050 M (30è) mr Z
+-167 1350 M (60è) mr Z
 clipsave
 0 0 M
 3600 0 D
@@ -15438,7 +15527,49 @@ I/n$>;gfEJ"+l9F@0GC45b6<$_kB`B&^UVH"6OQ;N(kX_D$f.jEQ%-ee*.R6e5I@lr>^R=GUt,_KpdN5
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+0 -1750 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4183 1750 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -Bwrts -Bxaf -Byaf -Xa3.4861i -Ya1.4583i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+4183 1750 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(g) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (g) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -15495,53 +15626,7 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
--167 150 M 200 F0
-(î60è) mr Z
--167 450 M (î30è) mr Z
--167 750 M (0è) mr Z
--167 1050 M (30è) mr Z
--167 1350 M (60è) mr Z
-%%EndObject
-0 -1750 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-4183 1750 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -Bwrts -Bxaf -Byaf -Xa3.4861i -Ya1.4583i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-4183 1750 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(g) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (g) tl Z
-U
-}!
 clipsave
 0 0 M
 3600 0 D
@@ -15577,7 +15662,48 @@ AU)9g$I@m:cWTLFJR)k,^Q<NZ>loE8%UZ0_hS4dpp91"dWaG)_)>X~>
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+-4183 -1750 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -BWrtS -Bxaf -Byaf -Xa0i -Ya0i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(z) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (z) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -15634,46 +15760,17 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-%%EndObject
--4183 -1750 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-0 0 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -BWrtS -Bxaf -Byaf -Xa0i -Ya0i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(z) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (z) tl Z
-U
-}!
+200 -167 M 200 F0
+(î90è) tc Z
+1100 -167 M (0è) tc Z
+2000 -167 M (90è) tc Z
+2900 -167 M (180è) tc Z
+-167 150 M (î60è) mr Z
+-167 450 M (î30è) mr Z
+-167 750 M (0è) mr Z
+-167 1050 M (30è) mr Z
+-167 1350 M (60è) mr Z
 clipsave
 0 0 M
 3600 0 D
@@ -15719,7 +15816,49 @@ ZESUoli\`TbPdhk4d<0Ud9O52*L]KDqMl%l*Q"*;+,SR"l[P2cs6IF/r<jJP9u-~>
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4183 0 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -BwrtS -Bxaf -Byaf -Xa3.4861i -Ya0i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+4183 0 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(u) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (u) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -15776,57 +15915,12 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 -167 M 200 F0
 (î90è) tc Z
 1100 -167 M (0è) tc Z
 2000 -167 M (90è) tc Z
 2900 -167 M (180è) tc Z
--167 150 M (î60è) mr Z
--167 450 M (î30è) mr Z
--167 750 M (0è) mr Z
--167 1050 M (30è) mr Z
--167 1350 M (60è) mr Z
-%%EndObject
-0 0 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-4183 0 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -BwrtS -Bxaf -Byaf -Xa3.4861i -Ya0i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-4183 0 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(u) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (u) tl Z
-U
-}!
 clipsave
 0 0 M
 3600 0 D
@@ -15853,64 +15947,7 @@ P$o2A#BXUfCUJgo!22fs6"u-UPbUmn9$BA-Z62;387c@F1Vfi781X#q;)uqZ6b3.GkJ-9mY%>=T~>
 U
 PSL_cliprestore
 25 W
-8 W
-N 200 0 M 0 -83 D S
-N 1100 0 M 0 -83 D S
-N 2000 0 M 0 -83 D S
-N 2900 0 M 0 -83 D S
-N 0 150 M -83 0 D S
-N 0 150 M -83 0 D S
-N 0 450 M -83 0 D S
-N 0 450 M -83 0 D S
-N 0 750 M -83 0 D S
-N 0 750 M -83 0 D S
-N 0 1050 M -83 0 D S
-N 0 1050 M -83 0 D S
-N 0 1350 M -83 0 D S
-N 0 1350 M -83 0 D S
-N 200 0 M 0 -42 D S
-N 500 0 M 0 -42 D S
-N 800 0 M 0 -42 D S
-N 1100 0 M 0 -42 D S
-N 1400 0 M 0 -42 D S
-N 1700 0 M 0 -42 D S
-N 2000 0 M 0 -42 D S
-N 2300 0 M 0 -42 D S
-N 2600 0 M 0 -42 D S
-N 2900 0 M 0 -42 D S
-N 3200 0 M 0 -42 D S
-N 3500 0 M 0 -42 D S
-N 0 50 M -42 0 D S
-N 0 50 M -42 0 D S
-N 0 150 M -42 0 D S
-N 0 150 M -42 0 D S
-N 0 250 M -42 0 D S
-N 0 250 M -42 0 D S
-N 0 350 M -42 0 D S
-N 0 350 M -42 0 D S
-N 0 450 M -42 0 D S
-N 0 450 M -42 0 D S
-N 0 550 M -42 0 D S
-N 0 550 M -42 0 D S
-N 0 650 M -42 0 D S
-N 0 650 M -42 0 D S
-N 0 750 M -42 0 D S
-N 0 750 M -42 0 D S
-N 0 850 M -42 0 D S
-N 0 850 M -42 0 D S
-N 0 950 M -42 0 D S
-N 0 950 M -42 0 D S
-N 0 1050 M -42 0 D S
-N 0 1050 M -42 0 D S
-N 0 1150 M -42 0 D S
-N 0 1150 M -42 0 D S
-N 0 1250 M -42 0 D S
-N 0 1250 M -42 0 D S
-N 0 1350 M -42 0 D S
-N 0 1350 M -42 0 D S
-N 0 1450 M -42 0 D S
-N 0 1450 M -42 0 D S
-25 W
+0 A
 0 0 M
 3600 0 D
 0 1500 D
@@ -15920,12 +15957,6 @@ N 0 1450 M -42 0 D S
 -900 0 D
 0 -1500 D
 P S
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 -167 M 200 F0
-(î90è) tc Z
-1100 -167 M (0è) tc Z
-2000 -167 M (90è) tc Z
-2900 -167 M (180è) tc Z
 %%EndObject
 -4183 0 TM
 PSL_plot_completion /PSL_plot_completion {} def

--- a/test/gmtbinstats/weightedrect.ps
+++ b/test/gmtbinstats/weightedrect.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_c1e198f_2020.08.22 [64-bit] Document from plot
+%%Title: GMT v6.2.0_b1364c2_2020.11.28 [64-bit] Document from plot
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sat Aug 22 17:54:28 2020
+%%CreationDate: Sat Nov 28 15:00:53 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -111,43 +111,45 @@
   PSL_eps_state restore
 }!
 /PSL_transp {
-  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
-  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
-  {pop pop} ifelse} ifelse
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -683,8 +685,9 @@ O0
 /PSL_plot_completion {
 V
 0 10500 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V
 (data) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
@@ -696,10 +699,76 @@ U
 40 1460 M (data) tl Z
 U
 }!
+8 W
+0 A
+N 200 0 M 0 -83 D S
+N 1100 0 M 0 -83 D S
+N 2000 0 M 0 -83 D S
+N 2900 0 M 0 -83 D S
+N 0 150 M -83 0 D S
+N 0 150 M -83 0 D S
+N 0 450 M -83 0 D S
+N 0 450 M -83 0 D S
+N 0 750 M -83 0 D S
+N 0 750 M -83 0 D S
+N 0 1050 M -83 0 D S
+N 0 1050 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 200 0 M 0 -42 D S
+N 500 0 M 0 -42 D S
+N 800 0 M 0 -42 D S
+N 1100 0 M 0 -42 D S
+N 1400 0 M 0 -42 D S
+N 1700 0 M 0 -42 D S
+N 2000 0 M 0 -42 D S
+N 2300 0 M 0 -42 D S
+N 2600 0 M 0 -42 D S
+N 2900 0 M 0 -42 D S
+N 3200 0 M 0 -42 D S
+N 3500 0 M 0 -42 D S
+N 0 50 M -42 0 D S
+N 0 50 M -42 0 D S
+N 0 150 M -42 0 D S
+N 0 150 M -42 0 D S
+N 0 250 M -42 0 D S
+N 0 250 M -42 0 D S
+N 0 350 M -42 0 D S
+N 0 350 M -42 0 D S
+N 0 450 M -42 0 D S
+N 0 450 M -42 0 D S
+N 0 550 M -42 0 D S
+N 0 550 M -42 0 D S
+N 0 650 M -42 0 D S
+N 0 650 M -42 0 D S
+N 0 750 M -42 0 D S
+N 0 750 M -42 0 D S
+N 0 850 M -42 0 D S
+N 0 850 M -42 0 D S
+N 0 950 M -42 0 D S
+N 0 950 M -42 0 D S
+N 0 1050 M -42 0 D S
+N 0 1050 M -42 0 D S
+N 0 1150 M -42 0 D S
+N 0 1150 M -42 0 D S
+N 0 1250 M -42 0 D S
+N 0 1250 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 1450 M -42 0 D S
+N 0 1450 M -42 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-167 150 M 200 F0
+(î60è) mr Z
+-167 450 M (î30è) mr Z
+-167 750 M (0è) mr Z
+-167 1050 M (30è) mr Z
+-167 1350 M (60è) mr Z
 1313 1450 M
 -1 0 D
 P
 {0.827 A} FS
+O0
 FO
 1334 1450 M
 -18 3 D
@@ -13418,64 +13487,7 @@ FO
 P
 FO
 25 W
-8 W
-N 200 0 M 0 -83 D S
-N 1100 0 M 0 -83 D S
-N 2000 0 M 0 -83 D S
-N 2900 0 M 0 -83 D S
-N 0 150 M -83 0 D S
-N 0 150 M -83 0 D S
-N 0 450 M -83 0 D S
-N 0 450 M -83 0 D S
-N 0 750 M -83 0 D S
-N 0 750 M -83 0 D S
-N 0 1050 M -83 0 D S
-N 0 1050 M -83 0 D S
-N 0 1350 M -83 0 D S
-N 0 1350 M -83 0 D S
-N 200 0 M 0 -42 D S
-N 500 0 M 0 -42 D S
-N 800 0 M 0 -42 D S
-N 1100 0 M 0 -42 D S
-N 1400 0 M 0 -42 D S
-N 1700 0 M 0 -42 D S
-N 2000 0 M 0 -42 D S
-N 2300 0 M 0 -42 D S
-N 2600 0 M 0 -42 D S
-N 2900 0 M 0 -42 D S
-N 3200 0 M 0 -42 D S
-N 3500 0 M 0 -42 D S
-N 0 50 M -42 0 D S
-N 0 50 M -42 0 D S
-N 0 150 M -42 0 D S
-N 0 150 M -42 0 D S
-N 0 250 M -42 0 D S
-N 0 250 M -42 0 D S
-N 0 350 M -42 0 D S
-N 0 350 M -42 0 D S
-N 0 450 M -42 0 D S
-N 0 450 M -42 0 D S
-N 0 550 M -42 0 D S
-N 0 550 M -42 0 D S
-N 0 650 M -42 0 D S
-N 0 650 M -42 0 D S
-N 0 750 M -42 0 D S
-N 0 750 M -42 0 D S
-N 0 850 M -42 0 D S
-N 0 850 M -42 0 D S
-N 0 950 M -42 0 D S
-N 0 950 M -42 0 D S
-N 0 1050 M -42 0 D S
-N 0 1050 M -42 0 D S
-N 0 1150 M -42 0 D S
-N 0 1150 M -42 0 D S
-N 0 1250 M -42 0 D S
-N 0 1250 M -42 0 D S
-N 0 1350 M -42 0 D S
-N 0 1350 M -42 0 D S
-N 0 1450 M -42 0 D S
-N 0 1450 M -42 0 D S
-25 W
+0 A
 0 0 M
 3600 0 D
 0 1500 D
@@ -13485,13 +13497,6 @@ N 0 1450 M -42 0 D S
 -900 0 D
 0 -1500 D
 P S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
--167 150 M 200 F0
-(-60∞) mr Z
--167 450 M (-30∞) mr Z
--167 750 M (0∞) mr Z
--167 1050 M (30∞) mr Z
--167 1350 M (60∞) mr Z
 %%EndObject
 0 -10500 TM
 0 A
@@ -13512,8 +13517,8 @@ clipsave
 -3600 0 D
 P
 PSL_clip N
-4 W
 V
+4 W
 {0 0.0698 1 C} FS
 O1
 24 1792 1095 Sc
@@ -14179,8 +14184,9 @@ O0
 /PSL_plot_completion {
 V
 4183 10500 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V
 (a) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
@@ -14192,6 +14198,65 @@ U
 40 1460 M (a) tl Z
 U
 }!
+8 W
+0 A
+N 200 0 M 0 -83 D S
+N 1100 0 M 0 -83 D S
+N 2000 0 M 0 -83 D S
+N 2900 0 M 0 -83 D S
+N 0 150 M -83 0 D S
+N 0 150 M -83 0 D S
+N 0 450 M -83 0 D S
+N 0 450 M -83 0 D S
+N 0 750 M -83 0 D S
+N 0 750 M -83 0 D S
+N 0 1050 M -83 0 D S
+N 0 1050 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 200 0 M 0 -42 D S
+N 500 0 M 0 -42 D S
+N 800 0 M 0 -42 D S
+N 1100 0 M 0 -42 D S
+N 1400 0 M 0 -42 D S
+N 1700 0 M 0 -42 D S
+N 2000 0 M 0 -42 D S
+N 2300 0 M 0 -42 D S
+N 2600 0 M 0 -42 D S
+N 2900 0 M 0 -42 D S
+N 3200 0 M 0 -42 D S
+N 3500 0 M 0 -42 D S
+N 0 50 M -42 0 D S
+N 0 50 M -42 0 D S
+N 0 150 M -42 0 D S
+N 0 150 M -42 0 D S
+N 0 250 M -42 0 D S
+N 0 250 M -42 0 D S
+N 0 350 M -42 0 D S
+N 0 350 M -42 0 D S
+N 0 450 M -42 0 D S
+N 0 450 M -42 0 D S
+N 0 550 M -42 0 D S
+N 0 550 M -42 0 D S
+N 0 650 M -42 0 D S
+N 0 650 M -42 0 D S
+N 0 750 M -42 0 D S
+N 0 750 M -42 0 D S
+N 0 850 M -42 0 D S
+N 0 850 M -42 0 D S
+N 0 950 M -42 0 D S
+N 0 950 M -42 0 D S
+N 0 1050 M -42 0 D S
+N 0 1050 M -42 0 D S
+N 0 1150 M -42 0 D S
+N 0 1150 M -42 0 D S
+N 0 1250 M -42 0 D S
+N 0 1250 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 1450 M -42 0 D S
+N 0 1450 M -42 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 clipsave
 0 0 M
 3600 0 D
@@ -14213,64 +14278,7 @@ G[=lf^]PDkR$_#Yg!GH+))rHM34ZPEGki3O"U#DM6Ga->,,/Q+&s?/@$k._C0QC5UD?^;j"[rVA+@fRg
 U
 PSL_cliprestore
 25 W
-8 W
-N 200 0 M 0 -83 D S
-N 1100 0 M 0 -83 D S
-N 2000 0 M 0 -83 D S
-N 2900 0 M 0 -83 D S
-N 0 150 M -83 0 D S
-N 0 150 M -83 0 D S
-N 0 450 M -83 0 D S
-N 0 450 M -83 0 D S
-N 0 750 M -83 0 D S
-N 0 750 M -83 0 D S
-N 0 1050 M -83 0 D S
-N 0 1050 M -83 0 D S
-N 0 1350 M -83 0 D S
-N 0 1350 M -83 0 D S
-N 200 0 M 0 -42 D S
-N 500 0 M 0 -42 D S
-N 800 0 M 0 -42 D S
-N 1100 0 M 0 -42 D S
-N 1400 0 M 0 -42 D S
-N 1700 0 M 0 -42 D S
-N 2000 0 M 0 -42 D S
-N 2300 0 M 0 -42 D S
-N 2600 0 M 0 -42 D S
-N 2900 0 M 0 -42 D S
-N 3200 0 M 0 -42 D S
-N 3500 0 M 0 -42 D S
-N 0 50 M -42 0 D S
-N 0 50 M -42 0 D S
-N 0 150 M -42 0 D S
-N 0 150 M -42 0 D S
-N 0 250 M -42 0 D S
-N 0 250 M -42 0 D S
-N 0 350 M -42 0 D S
-N 0 350 M -42 0 D S
-N 0 450 M -42 0 D S
-N 0 450 M -42 0 D S
-N 0 550 M -42 0 D S
-N 0 550 M -42 0 D S
-N 0 650 M -42 0 D S
-N 0 650 M -42 0 D S
-N 0 750 M -42 0 D S
-N 0 750 M -42 0 D S
-N 0 850 M -42 0 D S
-N 0 850 M -42 0 D S
-N 0 950 M -42 0 D S
-N 0 950 M -42 0 D S
-N 0 1050 M -42 0 D S
-N 0 1050 M -42 0 D S
-N 0 1150 M -42 0 D S
-N 0 1150 M -42 0 D S
-N 0 1250 M -42 0 D S
-N 0 1250 M -42 0 D S
-N 0 1350 M -42 0 D S
-N 0 1350 M -42 0 D S
-N 0 1450 M -42 0 D S
-N 0 1450 M -42 0 D S
-25 W
+0 A
 0 0 M
 3600 0 D
 0 1500 D
@@ -14280,7 +14288,6 @@ N 0 1450 M -42 0 D S
 -900 0 D
 0 -1500 D
 P S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 %%EndObject
 -4183 -10500 TM
 PSL_plot_completion /PSL_plot_completion {} def
@@ -14298,8 +14305,9 @@ O0
 /PSL_plot_completion {
 V
 0 8750 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V
 (d) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
@@ -14311,23 +14319,8 @@ U
 40 1460 M (d) tl Z
 U
 }!
-clipsave
-0 0 M
-3600 0 D
-0 1500 D
--3600 0 D
-P
-PSL_clip N
-V N -75 -75 T 3750 1650 scale [/Indexed /DeviceRGB 11 <
-80808030123B3F3D9B7A04034779F01AD2D21CCED74779F130F19A4143A61FC9DC341A4E>] setcolorspace
-<< /ImageType 1 /Decode [0 15] /Width 25 /Height 11 /BitsPerComponent 4
-   /ImageMatrix [25 0 0 -11 0 11] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
->> image
-G[=lf5QLq<63;,7!4/_6Jfo_"a<4U;#UDZO``W_u!Wid^N"?j-7R8/)@"`TO'Sp.)"KDLfAqV<]JC3!M!1Rm0Du~>
-U
-PSL_cliprestore
-25 W
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -14384,7 +14377,30 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-167 150 M 200 F0
+(î60è) mr Z
+-167 450 M (î30è) mr Z
+-167 750 M (0è) mr Z
+-167 1050 M (30è) mr Z
+-167 1350 M (60è) mr Z
+clipsave
+0 0 M
+3600 0 D
+0 1500 D
+-3600 0 D
+P
+PSL_clip N
+V N -75 -75 T 3750 1650 scale [/Indexed /DeviceRGB 11 <
+80808030123B3F3D9B7A04034779F01AD2D21CCED74779F130F19A4143A61FC9DC341A4E>] setcolorspace
+<< /ImageType 1 /Decode [0 15] /Width 25 /Height 11 /BitsPerComponent 4
+   /ImageMatrix [25 0 0 -11 0 11] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[=lf5QLq<63;,7!4/_6Jfo_"a<4U;#UDZO``W_u!Wid^N"?j-7R8/)@"`TO'Sp.)"KDLfAqV<]JC3!M!1Rm0Du~>
+U
+PSL_cliprestore
 25 W
+0 A
 0 0 M
 3600 0 D
 0 1500 D
@@ -14394,13 +14410,6 @@ N 0 1450 M -42 0 D S
 -900 0 D
 0 -1500 D
 P S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
--167 150 M 200 F0
-(-60∞) mr Z
--167 450 M (-30∞) mr Z
--167 750 M (0∞) mr Z
--167 1050 M (30∞) mr Z
--167 1350 M (60∞) mr Z
 %%EndObject
 0 -8750 TM
 PSL_plot_completion /PSL_plot_completion {} def
@@ -14418,8 +14427,9 @@ O0
 /PSL_plot_completion {
 V
 4183 8750 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V
 (s) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
@@ -14431,6 +14441,65 @@ U
 40 1460 M (s) tl Z
 U
 }!
+8 W
+0 A
+N 200 0 M 0 -83 D S
+N 1100 0 M 0 -83 D S
+N 2000 0 M 0 -83 D S
+N 2900 0 M 0 -83 D S
+N 0 150 M -83 0 D S
+N 0 150 M -83 0 D S
+N 0 450 M -83 0 D S
+N 0 450 M -83 0 D S
+N 0 750 M -83 0 D S
+N 0 750 M -83 0 D S
+N 0 1050 M -83 0 D S
+N 0 1050 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 200 0 M 0 -42 D S
+N 500 0 M 0 -42 D S
+N 800 0 M 0 -42 D S
+N 1100 0 M 0 -42 D S
+N 1400 0 M 0 -42 D S
+N 1700 0 M 0 -42 D S
+N 2000 0 M 0 -42 D S
+N 2300 0 M 0 -42 D S
+N 2600 0 M 0 -42 D S
+N 2900 0 M 0 -42 D S
+N 3200 0 M 0 -42 D S
+N 3500 0 M 0 -42 D S
+N 0 50 M -42 0 D S
+N 0 50 M -42 0 D S
+N 0 150 M -42 0 D S
+N 0 150 M -42 0 D S
+N 0 250 M -42 0 D S
+N 0 250 M -42 0 D S
+N 0 350 M -42 0 D S
+N 0 350 M -42 0 D S
+N 0 450 M -42 0 D S
+N 0 450 M -42 0 D S
+N 0 550 M -42 0 D S
+N 0 550 M -42 0 D S
+N 0 650 M -42 0 D S
+N 0 650 M -42 0 D S
+N 0 750 M -42 0 D S
+N 0 750 M -42 0 D S
+N 0 850 M -42 0 D S
+N 0 850 M -42 0 D S
+N 0 950 M -42 0 D S
+N 0 950 M -42 0 D S
+N 0 1050 M -42 0 D S
+N 0 1050 M -42 0 D S
+N 0 1150 M -42 0 D S
+N 0 1150 M -42 0 D S
+N 0 1250 M -42 0 D S
+N 0 1250 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 1450 M -42 0 D S
+N 0 1450 M -42 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 clipsave
 0 0 M
 3600 0 D
@@ -14450,7 +14519,49 @@ YggLb"p<*M!8l`;>l~>
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+-4183 -8750 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 7000 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya5.8333i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 7000 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(i) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (i) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -14507,47 +14618,13 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-%%EndObject
--4183 -8750 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-0 7000 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya5.8333i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-0 7000 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(i) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (i) tl Z
-U
-}!
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-167 150 M 200 F0
+(î60è) mr Z
+-167 450 M (î30è) mr Z
+-167 750 M (0è) mr Z
+-167 1050 M (30è) mr Z
+-167 1350 M (60è) mr Z
 clipsave
 0 0 M
 3600 0 D
@@ -14566,7 +14643,49 @@ H-sp;@[d\pReK#gJ,dFs&QSqn~>
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+0 -7000 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4183 7000 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -Bwrts -Bxaf -Byaf -Xa3.4861i -Ya5.8333i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+4183 7000 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(l) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (l) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -14623,53 +14742,7 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
--167 150 M 200 F0
-(-60∞) mr Z
--167 450 M (-30∞) mr Z
--167 750 M (0∞) mr Z
--167 1050 M (30∞) mr Z
--167 1350 M (60∞) mr Z
-%%EndObject
-0 -7000 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-4183 7000 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -Bwrts -Bxaf -Byaf -Xa3.4861i -Ya5.8333i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-4183 7000 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(l) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (l) tl Z
-U
-}!
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 clipsave
 0 0 M
 3600 0 D
@@ -14690,7 +14763,49 @@ G[?r!h%kQ<(e!P/W:NUATHB!rq5<t:\NWnp?$+J!bZ_@I)PA;VL)^WH2R]7Y8L&TK?num)@ReSLQnQt;
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+-4183 -7000 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 5250 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya4.375i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 5250 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(m) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (m) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -14747,47 +14862,13 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-%%EndObject
--4183 -7000 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-0 5250 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya4.375i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-0 5250 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(m) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (m) tl Z
-U
-}!
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-167 150 M 200 F0
+(î60è) mr Z
+-167 450 M (î30è) mr Z
+-167 750 M (0è) mr Z
+-167 1050 M (30è) mr Z
+-167 1350 M (60è) mr Z
 clipsave
 0 0 M
 3600 0 D
@@ -14808,64 +14889,7 @@ G[=lf^]PDkR$_#Yg!GH+))rHM34ZPEGki3O"U#DM6Ga->,$^jOiY%DP$k.a90Q@t53<f\5"[rVA+@fRg
 U
 PSL_cliprestore
 25 W
-8 W
-N 200 0 M 0 -83 D S
-N 1100 0 M 0 -83 D S
-N 2000 0 M 0 -83 D S
-N 2900 0 M 0 -83 D S
-N 0 150 M -83 0 D S
-N 0 150 M -83 0 D S
-N 0 450 M -83 0 D S
-N 0 450 M -83 0 D S
-N 0 750 M -83 0 D S
-N 0 750 M -83 0 D S
-N 0 1050 M -83 0 D S
-N 0 1050 M -83 0 D S
-N 0 1350 M -83 0 D S
-N 0 1350 M -83 0 D S
-N 200 0 M 0 -42 D S
-N 500 0 M 0 -42 D S
-N 800 0 M 0 -42 D S
-N 1100 0 M 0 -42 D S
-N 1400 0 M 0 -42 D S
-N 1700 0 M 0 -42 D S
-N 2000 0 M 0 -42 D S
-N 2300 0 M 0 -42 D S
-N 2600 0 M 0 -42 D S
-N 2900 0 M 0 -42 D S
-N 3200 0 M 0 -42 D S
-N 3500 0 M 0 -42 D S
-N 0 50 M -42 0 D S
-N 0 50 M -42 0 D S
-N 0 150 M -42 0 D S
-N 0 150 M -42 0 D S
-N 0 250 M -42 0 D S
-N 0 250 M -42 0 D S
-N 0 350 M -42 0 D S
-N 0 350 M -42 0 D S
-N 0 450 M -42 0 D S
-N 0 450 M -42 0 D S
-N 0 550 M -42 0 D S
-N 0 550 M -42 0 D S
-N 0 650 M -42 0 D S
-N 0 650 M -42 0 D S
-N 0 750 M -42 0 D S
-N 0 750 M -42 0 D S
-N 0 850 M -42 0 D S
-N 0 850 M -42 0 D S
-N 0 950 M -42 0 D S
-N 0 950 M -42 0 D S
-N 0 1050 M -42 0 D S
-N 0 1050 M -42 0 D S
-N 0 1150 M -42 0 D S
-N 0 1150 M -42 0 D S
-N 0 1250 M -42 0 D S
-N 0 1250 M -42 0 D S
-N 0 1350 M -42 0 D S
-N 0 1350 M -42 0 D S
-N 0 1450 M -42 0 D S
-N 0 1450 M -42 0 D S
-25 W
+0 A
 0 0 M
 3600 0 D
 0 1500 D
@@ -14875,13 +14899,6 @@ N 0 1450 M -42 0 D S
 -900 0 D
 0 -1500 D
 P S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
--167 150 M 200 F0
-(-60∞) mr Z
--167 450 M (-30∞) mr Z
--167 750 M (0∞) mr Z
--167 1050 M (30∞) mr Z
--167 1350 M (60∞) mr Z
 %%EndObject
 0 -5250 TM
 PSL_plot_completion /PSL_plot_completion {} def
@@ -14899,8 +14916,9 @@ O0
 /PSL_plot_completion {
 V
 4183 5250 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V
 (n) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
@@ -14912,6 +14930,65 @@ U
 40 1460 M (n) tl Z
 U
 }!
+8 W
+0 A
+N 200 0 M 0 -83 D S
+N 1100 0 M 0 -83 D S
+N 2000 0 M 0 -83 D S
+N 2900 0 M 0 -83 D S
+N 0 150 M -83 0 D S
+N 0 150 M -83 0 D S
+N 0 450 M -83 0 D S
+N 0 450 M -83 0 D S
+N 0 750 M -83 0 D S
+N 0 750 M -83 0 D S
+N 0 1050 M -83 0 D S
+N 0 1050 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 200 0 M 0 -42 D S
+N 500 0 M 0 -42 D S
+N 800 0 M 0 -42 D S
+N 1100 0 M 0 -42 D S
+N 1400 0 M 0 -42 D S
+N 1700 0 M 0 -42 D S
+N 2000 0 M 0 -42 D S
+N 2300 0 M 0 -42 D S
+N 2600 0 M 0 -42 D S
+N 2900 0 M 0 -42 D S
+N 3200 0 M 0 -42 D S
+N 3500 0 M 0 -42 D S
+N 0 50 M -42 0 D S
+N 0 50 M -42 0 D S
+N 0 150 M -42 0 D S
+N 0 150 M -42 0 D S
+N 0 250 M -42 0 D S
+N 0 250 M -42 0 D S
+N 0 350 M -42 0 D S
+N 0 350 M -42 0 D S
+N 0 450 M -42 0 D S
+N 0 450 M -42 0 D S
+N 0 550 M -42 0 D S
+N 0 550 M -42 0 D S
+N 0 650 M -42 0 D S
+N 0 650 M -42 0 D S
+N 0 750 M -42 0 D S
+N 0 750 M -42 0 D S
+N 0 850 M -42 0 D S
+N 0 850 M -42 0 D S
+N 0 950 M -42 0 D S
+N 0 950 M -42 0 D S
+N 0 1050 M -42 0 D S
+N 0 1050 M -42 0 D S
+N 0 1150 M -42 0 D S
+N 0 1150 M -42 0 D S
+N 0 1250 M -42 0 D S
+N 0 1250 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 1450 M -42 0 D S
+N 0 1450 M -42 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 clipsave
 0 0 M
 3600 0 D
@@ -14929,64 +15006,7 @@ G[=lf5QLpQaoX9*K)ft[8qA+<n&QVLBWT,p#\(,E0MHLh^p&J(,3-I&WDHER!R)2h?kcII?k@EW!HOP1
 U
 PSL_cliprestore
 25 W
-8 W
-N 200 0 M 0 -83 D S
-N 1100 0 M 0 -83 D S
-N 2000 0 M 0 -83 D S
-N 2900 0 M 0 -83 D S
-N 0 150 M -83 0 D S
-N 0 150 M -83 0 D S
-N 0 450 M -83 0 D S
-N 0 450 M -83 0 D S
-N 0 750 M -83 0 D S
-N 0 750 M -83 0 D S
-N 0 1050 M -83 0 D S
-N 0 1050 M -83 0 D S
-N 0 1350 M -83 0 D S
-N 0 1350 M -83 0 D S
-N 200 0 M 0 -42 D S
-N 500 0 M 0 -42 D S
-N 800 0 M 0 -42 D S
-N 1100 0 M 0 -42 D S
-N 1400 0 M 0 -42 D S
-N 1700 0 M 0 -42 D S
-N 2000 0 M 0 -42 D S
-N 2300 0 M 0 -42 D S
-N 2600 0 M 0 -42 D S
-N 2900 0 M 0 -42 D S
-N 3200 0 M 0 -42 D S
-N 3500 0 M 0 -42 D S
-N 0 50 M -42 0 D S
-N 0 50 M -42 0 D S
-N 0 150 M -42 0 D S
-N 0 150 M -42 0 D S
-N 0 250 M -42 0 D S
-N 0 250 M -42 0 D S
-N 0 350 M -42 0 D S
-N 0 350 M -42 0 D S
-N 0 450 M -42 0 D S
-N 0 450 M -42 0 D S
-N 0 550 M -42 0 D S
-N 0 550 M -42 0 D S
-N 0 650 M -42 0 D S
-N 0 650 M -42 0 D S
-N 0 750 M -42 0 D S
-N 0 750 M -42 0 D S
-N 0 850 M -42 0 D S
-N 0 850 M -42 0 D S
-N 0 950 M -42 0 D S
-N 0 950 M -42 0 D S
-N 0 1050 M -42 0 D S
-N 0 1050 M -42 0 D S
-N 0 1150 M -42 0 D S
-N 0 1150 M -42 0 D S
-N 0 1250 M -42 0 D S
-N 0 1250 M -42 0 D S
-N 0 1350 M -42 0 D S
-N 0 1350 M -42 0 D S
-N 0 1450 M -42 0 D S
-N 0 1450 M -42 0 D S
-25 W
+0 A
 0 0 M
 3600 0 D
 0 1500 D
@@ -14996,7 +15016,6 @@ N 0 1450 M -42 0 D S
 -900 0 D
 0 -1500 D
 P S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 %%EndObject
 -4183 -5250 TM
 PSL_plot_completion /PSL_plot_completion {} def
@@ -15014,8 +15033,9 @@ O0
 /PSL_plot_completion {
 V
 0 3500 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V
 (o) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
@@ -15027,23 +15047,8 @@ U
 40 1460 M (o) tl Z
 U
 }!
-clipsave
-0 0 M
-3600 0 D
-0 1500 D
--3600 0 D
-P
-PSL_clip N
-V N -75 -75 T 3750 1650 scale [/Indexed /DeviceRGB 11 <
-80808030123B3C32857A04034680F61DCCD935F3944779F1920B012BB8EF1FC9DC341A4E>] setcolorspace
-<< /ImageType 1 /Decode [0 15] /Width 25 /Height 11 /BitsPerComponent 4
-   /ImageMatrix [25 0 0 -11 0 11] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
->> image
-G[=lf5QLq<63;,7!4/_6Jfo_"a<4U;#UDZO``W_u!Wid^N"?j-7R8/)@"`TO'Sp.)"KDLfAqV<]JC3!M!1Rm0Du~>
-U
-PSL_cliprestore
-25 W
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -15100,7 +15105,30 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-167 150 M 200 F0
+(î60è) mr Z
+-167 450 M (î30è) mr Z
+-167 750 M (0è) mr Z
+-167 1050 M (30è) mr Z
+-167 1350 M (60è) mr Z
+clipsave
+0 0 M
+3600 0 D
+0 1500 D
+-3600 0 D
+P
+PSL_clip N
+V N -75 -75 T 3750 1650 scale [/Indexed /DeviceRGB 11 <
+80808030123B3C32857A04034680F61DCCD935F3944779F1920B012BB8EF1FC9DC341A4E>] setcolorspace
+<< /ImageType 1 /Decode [0 15] /Width 25 /Height 11 /BitsPerComponent 4
+   /ImageMatrix [25 0 0 -11 0 11] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[=lf5QLq<63;,7!4/_6Jfo_"a<4U;#UDZO``W_u!Wid^N"?j-7R8/)@"`TO'Sp.)"KDLfAqV<]JC3!M!1Rm0Du~>
+U
+PSL_cliprestore
 25 W
+0 A
 0 0 M
 3600 0 D
 0 1500 D
@@ -15110,13 +15138,6 @@ N 0 1450 M -42 0 D S
 -900 0 D
 0 -1500 D
 P S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
--167 150 M 200 F0
-(-60∞) mr Z
--167 450 M (-30∞) mr Z
--167 750 M (0∞) mr Z
--167 1050 M (30∞) mr Z
--167 1350 M (60∞) mr Z
 %%EndObject
 0 -3500 TM
 PSL_plot_completion /PSL_plot_completion {} def
@@ -15134,8 +15155,9 @@ O0
 /PSL_plot_completion {
 V
 4183 3500 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 V
 (p) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
@@ -15147,6 +15169,65 @@ U
 40 1460 M (p) tl Z
 U
 }!
+8 W
+0 A
+N 200 0 M 0 -83 D S
+N 1100 0 M 0 -83 D S
+N 2000 0 M 0 -83 D S
+N 2900 0 M 0 -83 D S
+N 0 150 M -83 0 D S
+N 0 150 M -83 0 D S
+N 0 450 M -83 0 D S
+N 0 450 M -83 0 D S
+N 0 750 M -83 0 D S
+N 0 750 M -83 0 D S
+N 0 1050 M -83 0 D S
+N 0 1050 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 0 1350 M -83 0 D S
+N 200 0 M 0 -42 D S
+N 500 0 M 0 -42 D S
+N 800 0 M 0 -42 D S
+N 1100 0 M 0 -42 D S
+N 1400 0 M 0 -42 D S
+N 1700 0 M 0 -42 D S
+N 2000 0 M 0 -42 D S
+N 2300 0 M 0 -42 D S
+N 2600 0 M 0 -42 D S
+N 2900 0 M 0 -42 D S
+N 3200 0 M 0 -42 D S
+N 3500 0 M 0 -42 D S
+N 0 50 M -42 0 D S
+N 0 50 M -42 0 D S
+N 0 150 M -42 0 D S
+N 0 150 M -42 0 D S
+N 0 250 M -42 0 D S
+N 0 250 M -42 0 D S
+N 0 350 M -42 0 D S
+N 0 350 M -42 0 D S
+N 0 450 M -42 0 D S
+N 0 450 M -42 0 D S
+N 0 550 M -42 0 D S
+N 0 550 M -42 0 D S
+N 0 650 M -42 0 D S
+N 0 650 M -42 0 D S
+N 0 750 M -42 0 D S
+N 0 750 M -42 0 D S
+N 0 850 M -42 0 D S
+N 0 850 M -42 0 D S
+N 0 950 M -42 0 D S
+N 0 950 M -42 0 D S
+N 0 1050 M -42 0 D S
+N 0 1050 M -42 0 D S
+N 0 1150 M -42 0 D S
+N 0 1150 M -42 0 D S
+N 0 1250 M -42 0 D S
+N 0 1250 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 1450 M -42 0 D S
+N 0 1450 M -42 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 clipsave
 0 0 M
 3600 0 D
@@ -15168,7 +15249,49 @@ G[=lf^]PDkR$_#Yg!GH+))rHM34ZPEGki3O"U#DM6Ga->,,/Q+&s?/@$k._C0QC5UGm4HV73r.L+@ekc
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+-4183 -3500 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 1750 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya1.4583i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 1750 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(q75) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (q75) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -15225,47 +15348,13 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-%%EndObject
--4183 -3500 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-0 1750 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -BWrts -Bxaf -Byaf -Xa0i -Ya1.4583i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-0 1750 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(q75) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (q75) tl Z
-U
-}!
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+-167 150 M 200 F0
+(î60è) mr Z
+-167 450 M (î30è) mr Z
+-167 750 M (0è) mr Z
+-167 1050 M (30è) mr Z
+-167 1350 M (60è) mr Z
 clipsave
 0 0 M
 3600 0 D
@@ -15286,7 +15375,49 @@ G[=lf^]PDkR$_#Yg!GH+))rHM34ZPEGki3O"U#DM6Ga->,,/Q+&s?/@$k._C0QC5UGm4HV73r.L+@ekc
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+0 -1750 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4183 1750 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -Bwrts -Bxaf -Byaf -Xa3.4861i -Ya1.4583i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+4183 1750 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(g) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (g) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -15343,53 +15474,7 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
--167 150 M 200 F0
-(-60∞) mr Z
--167 450 M (-30∞) mr Z
--167 750 M (0∞) mr Z
--167 1050 M (30∞) mr Z
--167 1350 M (60∞) mr Z
-%%EndObject
-0 -1750 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-4183 1750 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -Bwrts -Bxaf -Byaf -Xa3.4861i -Ya1.4583i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-4183 1750 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(g) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (g) tl Z
-U
-}!
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 clipsave
 0 0 M
 3600 0 D
@@ -15409,7 +15494,48 @@ G[=lf^]PDk(n$ao(t"%?JJ&B-ll;O#g^K.#8CBUc2Bsjs,JSc%&<I'^&Jbsi?k=!<@#tM3Unek>>%AI]
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+-4183 -1750 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -BWrtS -Bxaf -Byaf -Xa0i -Ya0i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(z) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (z) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -15466,46 +15592,17 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-%%EndObject
--4183 -1750 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-0 0 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -BWrtS -Bxaf -Byaf -Xa0i -Ya0i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(z) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (z) tl Z
-U
-}!
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 -167 M 200 F0
+(î90è) tc Z
+1100 -167 M (0è) tc Z
+2000 -167 M (90è) tc Z
+2900 -167 M (180è) tc Z
+-167 150 M (î60è) mr Z
+-167 450 M (î30è) mr Z
+-167 750 M (0è) mr Z
+-167 1050 M (30è) mr Z
+-167 1350 M (60è) mr Z
 clipsave
 0 0 M
 3600 0 D
@@ -15527,7 +15624,49 @@ UT:;2!#-!!8f/Ha1GB*&R$sFqGQnp!9Er'>)+uJ&@;TK^iRrcR+ZP#Ull!kH!7;Gd'E~>
 U
 PSL_cliprestore
 25 W
+0 A
+0 0 M
+3600 0 D
+0 1500 D
+-900 0 D
+-900 0 D
+-900 0 D
+-900 0 D
+0 -1500 D
+P S
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4183 0 TM
+% PostScript produced by:
+%@GMT: gmt grdimage t.grd -BwrtS -Bxaf -Byaf -Xa3.4861i -Ya0i -R-110/250/-75/75 -JQ70E/3i
+%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+4183 0 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+V
+(u) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 30 def
+/PSL_dy 30 def
+40 1460 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+40 1460 M (u) tl Z
+U
+}!
 8 W
+0 A
 N 200 0 M 0 -83 D S
 N 1100 0 M 0 -83 D S
 N 2000 0 M 0 -83 D S
@@ -15584,57 +15723,12 @@ N 0 1350 M -42 0 D S
 N 0 1350 M -42 0 D S
 N 0 1450 M -42 0 D S
 N 0 1450 M -42 0 D S
-25 W
-0 0 M
-3600 0 D
-0 1500 D
--900 0 D
--900 0 D
--900 0 D
--900 0 D
-0 -1500 D
-P S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 -167 M 200 F0
-(-90∞) tc Z
-1100 -167 M (0∞) tc Z
-2000 -167 M (90∞) tc Z
-2900 -167 M (180∞) tc Z
--167 150 M (-60∞) mr Z
--167 450 M (-30∞) mr Z
--167 750 M (0∞) mr Z
--167 1050 M (30∞) mr Z
--167 1350 M (60∞) mr Z
-%%EndObject
-0 0 TM
-PSL_plot_completion /PSL_plot_completion {} def
-0 A
-FQ
-O0
-4183 0 TM
-% PostScript produced by:
-%@GMT: gmt grdimage t.grd -BwrtS -Bxaf -Byaf -Xa3.4861i -Ya0i -R-110/250/-75/75 -JQ70E/3i
-%@PROJ: eqc -110.00000000 250.00000000 -75.00000000 75.00000000 -20015109.356 20015109.356 -8339628.898 8339628.898 +proj=eqc +lat_ts=0 +lat_0=0 +lon_0=70 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
-%%BeginObject PSL_Layer_2
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
-/PSL_plot_completion {
-V
-4183 0 T
-0 A {1 A} FS
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 F0
-V
-(u) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
-/PSL_dx 30 def
-/PSL_dy 30 def
-40 1460 T 0 PSL_dim_h neg T
-PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
-U
-40 1460 M (u) tl Z
-U
-}!
+(î90è) tc Z
+1100 -167 M (0è) tc Z
+2000 -167 M (90è) tc Z
+2900 -167 M (180è) tc Z
 clipsave
 0 0 M
 3600 0 D
@@ -15656,64 +15750,7 @@ G[=lf^]PDkR$_#Yg!GH+))rHM34ZPEGki3O"U#DM6Ga->,,/Q+&s?/@$k._C0QC5UGm4HV73r.L+@ekc
 U
 PSL_cliprestore
 25 W
-8 W
-N 200 0 M 0 -83 D S
-N 1100 0 M 0 -83 D S
-N 2000 0 M 0 -83 D S
-N 2900 0 M 0 -83 D S
-N 0 150 M -83 0 D S
-N 0 150 M -83 0 D S
-N 0 450 M -83 0 D S
-N 0 450 M -83 0 D S
-N 0 750 M -83 0 D S
-N 0 750 M -83 0 D S
-N 0 1050 M -83 0 D S
-N 0 1050 M -83 0 D S
-N 0 1350 M -83 0 D S
-N 0 1350 M -83 0 D S
-N 200 0 M 0 -42 D S
-N 500 0 M 0 -42 D S
-N 800 0 M 0 -42 D S
-N 1100 0 M 0 -42 D S
-N 1400 0 M 0 -42 D S
-N 1700 0 M 0 -42 D S
-N 2000 0 M 0 -42 D S
-N 2300 0 M 0 -42 D S
-N 2600 0 M 0 -42 D S
-N 2900 0 M 0 -42 D S
-N 3200 0 M 0 -42 D S
-N 3500 0 M 0 -42 D S
-N 0 50 M -42 0 D S
-N 0 50 M -42 0 D S
-N 0 150 M -42 0 D S
-N 0 150 M -42 0 D S
-N 0 250 M -42 0 D S
-N 0 250 M -42 0 D S
-N 0 350 M -42 0 D S
-N 0 350 M -42 0 D S
-N 0 450 M -42 0 D S
-N 0 450 M -42 0 D S
-N 0 550 M -42 0 D S
-N 0 550 M -42 0 D S
-N 0 650 M -42 0 D S
-N 0 650 M -42 0 D S
-N 0 750 M -42 0 D S
-N 0 750 M -42 0 D S
-N 0 850 M -42 0 D S
-N 0 850 M -42 0 D S
-N 0 950 M -42 0 D S
-N 0 950 M -42 0 D S
-N 0 1050 M -42 0 D S
-N 0 1050 M -42 0 D S
-N 0 1150 M -42 0 D S
-N 0 1150 M -42 0 D S
-N 0 1250 M -42 0 D S
-N 0 1250 M -42 0 D S
-N 0 1350 M -42 0 D S
-N 0 1350 M -42 0 D S
-N 0 1450 M -42 0 D S
-N 0 1450 M -42 0 D S
-25 W
+0 A
 0 0 M
 3600 0 D
 0 1500 D
@@ -15723,12 +15760,6 @@ N 0 1450 M -42 0 D S
 -900 0 D
 0 -1500 D
 P S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-200 -167 M 200 F0
-(-90∞) tc Z
-1100 -167 M (0∞) tc Z
-2000 -167 M (90∞) tc Z
-2900 -167 M (180∞) tc Z
 %%EndObject
 -4183 0 TM
 PSL_plot_completion /PSL_plot_completion {} def

--- a/test/gmtlogo/logos.ps
+++ b/test/gmtlogo/logos.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.2.0_7cec4b2_2020.10.04 [64-bit] Document from psxy
+%%Title: GMT v6.2.0_b1364c2_2020.11.28 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Oct  4 22:39:04 2020
+%%CreationDate: Sat Nov 28 15:00:55 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -112,9 +112,11 @@
   PSL_eps_state restore
 }!
 /PSL_transp {
-  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
-  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
-  {pop pop} ifelse} ifelse
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
 }!
 /Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
@@ -676,6 +678,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 67 W
 clipsave
 0 0 M
@@ -697,6 +700,7 @@ S
 9720 0 D
 S
 PSL_cliprestore
+U
 %%EndObject
 0 A
 FQ
@@ -861,7 +865,9 @@ O0
 0 setlinejoin
 3.32550952342 setmiterlimit
 8 W
+0 A
 {0.741 0.878 0.875 C} FS
+O0
 1628 0 M
 352 113 D
 264 88 D
@@ -6425,7 +6431,6 @@ S
 811 1355 M
 1633 0 D
 S
-0 A [] 0 B
 9 W
 1628 0 M
 P
@@ -6679,6 +6684,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 4 W
 clipsave
 1628 0 M
@@ -6785,7 +6791,7 @@ clipsave
 351 -113 D
 P
 PSL_clip N
-{0.361 0.4 0.518 C 0.6 /Normal PSL_transp} FS
+{0.361 0.4 0.518 C 0.6 0.6 /Normal PSL_transp} FS
 /FO {P}!
 1313 437 M
 -35 71 D
@@ -7111,6 +7117,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 0 A
 FQ
@@ -7124,6 +7131,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 9 W
 0.439 A
 clipsave
@@ -7705,6 +7713,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 U
 %%EndObject
@@ -7871,7 +7880,9 @@ O0
 0 setlinejoin
 3.32550952342 setmiterlimit
 8 W
+0 A
 {0.741 0.878 0.875 C} FS
+O0
 1628 0 M
 352 113 D
 264 88 D
@@ -13435,7 +13446,6 @@ S
 811 1355 M
 1633 0 D
 S
-0 A [] 0 B
 9 W
 1628 0 M
 P
@@ -13689,6 +13699,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 4 W
 clipsave
 1628 0 M
@@ -13795,7 +13806,7 @@ clipsave
 351 -113 D
 P
 PSL_clip N
-{0.361 0.4 0.518 C 0.6 /Normal PSL_transp} FS
+{0.361 0.4 0.518 C 0.6 0.6 /Normal PSL_transp} FS
 /FO {P}!
 1313 437 M
 -35 71 D
@@ -14121,6 +14132,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 0 A
 FQ
@@ -14134,6 +14146,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 9 W
 0.439 A
 clipsave
@@ -14715,6 +14728,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 U
 %%EndObject
@@ -14879,7 +14893,9 @@ O0
 0 setlinejoin
 3.32550952342 setmiterlimit
 8 W
+0 A
 {0.741 0.878 0.875 C} FS
+O0
 1628 0 M
 352 113 D
 264 88 D
@@ -20443,7 +20459,6 @@ S
 811 1355 M
 1633 0 D
 S
-0 A [] 0 B
 9 W
 1628 0 M
 P
@@ -20697,6 +20712,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 4 W
 clipsave
 1628 0 M
@@ -20803,7 +20819,7 @@ clipsave
 351 -113 D
 P
 PSL_clip N
-{0.361 0.4 0.518 C 0.6 /Normal PSL_transp} FS
+{0.361 0.4 0.518 C 0.6 0.6 /Normal PSL_transp} FS
 /FO {P}!
 1313 437 M
 -35 71 D
@@ -21129,6 +21145,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 0 A
 FQ
@@ -21142,6 +21159,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 9 W
 0.439 A
 clipsave
@@ -21723,6 +21741,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 U
 %%EndObject
@@ -21888,7 +21907,9 @@ O0
 0 setlinejoin
 3.32550952342 setmiterlimit
 8 W
+0 A
 {0.741 0.878 0.875 C} FS
+O0
 1628 0 M
 352 113 D
 264 88 D
@@ -27452,7 +27473,6 @@ S
 811 1355 M
 1633 0 D
 S
-0 A [] 0 B
 9 W
 1628 0 M
 P
@@ -27706,6 +27726,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 4 W
 clipsave
 1628 0 M
@@ -27812,7 +27833,7 @@ clipsave
 351 -113 D
 P
 PSL_clip N
-{0.361 0.4 0.518 C 0.6 /Normal PSL_transp} FS
+{0.361 0.4 0.518 C 0.6 0.6 /Normal PSL_transp} FS
 /FO {P}!
 1313 437 M
 -35 71 D
@@ -28138,6 +28159,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 0 A
 FQ
@@ -28151,6 +28173,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 9 W
 0.439 A
 clipsave
@@ -28732,6 +28755,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 U
 %%EndObject
@@ -28896,7 +28920,9 @@ O0
 0 setlinejoin
 3.32550952342 setmiterlimit
 8 W
+0 A
 {0.741 0.878 0.875 C} FS
+O0
 1628 0 M
 352 113 D
 264 88 D
@@ -34460,7 +34486,6 @@ S
 811 1355 M
 1633 0 D
 S
-0 A [] 0 B
 9 W
 1628 0 M
 P
@@ -34714,6 +34739,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 4 W
 clipsave
 1628 0 M
@@ -34820,7 +34846,7 @@ clipsave
 351 -113 D
 P
 PSL_clip N
-{0.361 0.4 0.518 C 0.6 /Normal PSL_transp} FS
+{0.361 0.4 0.518 C 0.6 0.6 /Normal PSL_transp} FS
 /FO {P}!
 1313 437 M
 -35 71 D
@@ -35146,6 +35172,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 0 A
 FQ
@@ -35159,6 +35186,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 9 W
 0.439 A
 clipsave
@@ -35740,6 +35768,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 U
 %%EndObject
@@ -35902,7 +35931,9 @@ O0
 0 setlinejoin
 3.32550952342 setmiterlimit
 8 W
+0 A
 {0.741 0.878 0.875 C} FS
+O0
 1628 0 M
 352 113 D
 264 88 D
@@ -41466,7 +41497,6 @@ S
 811 1355 M
 1633 0 D
 S
-0 A [] 0 B
 9 W
 1628 0 M
 P
@@ -41720,6 +41750,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 4 W
 clipsave
 1628 0 M
@@ -41826,7 +41857,7 @@ clipsave
 351 -113 D
 P
 PSL_clip N
-{0.361 0.4 0.518 C 0.6 /Normal PSL_transp} FS
+{0.361 0.4 0.518 C 0.6 0.6 /Normal PSL_transp} FS
 /FO {P}!
 1313 437 M
 -35 71 D
@@ -42152,6 +42183,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 0 A
 FQ
@@ -42165,6 +42197,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 9 W
 0.439 A
 clipsave
@@ -42746,6 +42779,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 U
 %%EndObject
@@ -42906,7 +42940,9 @@ O0
 0 setlinejoin
 3.32550952342 setmiterlimit
 8 W
+0 A
 {0.741 0.878 0.875 C} FS
+O0
 1628 0 M
 352 113 D
 264 88 D
@@ -48470,7 +48506,6 @@ S
 811 1355 M
 1633 0 D
 S
-0 A [] 0 B
 9 W
 1628 0 M
 P
@@ -48724,6 +48759,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 4 W
 clipsave
 1628 0 M
@@ -48830,7 +48866,7 @@ clipsave
 351 -113 D
 P
 PSL_clip N
-{0.361 0.4 0.518 C 0.6 /Normal PSL_transp} FS
+{0.361 0.4 0.518 C 0.6 0.6 /Normal PSL_transp} FS
 /FO {P}!
 1313 437 M
 -35 71 D
@@ -49156,6 +49192,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 0 A
 FQ
@@ -49169,6 +49206,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 9 W
 0.439 A
 clipsave
@@ -49750,6 +49788,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 U
 %%EndObject
@@ -49759,7 +49798,7 @@ O0
 5100 0 TM
 
 % PostScript produced by:
-%@GMT: gmt gmtlogo -Dx0/0+w3.5i -O -K -F -X4.25i
+%@GMT: gmt gmtlogo -Dx0/0+w3.5i -O -F -X4.25i
 %@PROJ: xy 0.00000000 3.50000000 0.00000000 1.75000000 0.000 3.500 0.000 1.750 +xy
 %%BeginObject PSL_Layer_44
 0 setlinecap
@@ -49913,7 +49952,9 @@ O0
 0 setlinejoin
 3.32550952342 setmiterlimit
 8 W
+0 A
 {0.741 0.878 0.875 C} FS
+O0
 1628 0 M
 352 113 D
 264 88 D
@@ -55477,7 +55518,6 @@ S
 811 1355 M
 1633 0 D
 S
-0 A [] 0 B
 9 W
 1628 0 M
 P
@@ -55731,6 +55771,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 4 W
 clipsave
 1628 0 M
@@ -55837,7 +55878,7 @@ clipsave
 351 -113 D
 P
 PSL_clip N
-{0.361 0.4 0.518 C 0.6 /Normal PSL_transp} FS
+{0.361 0.4 0.518 C 0.6 0.6 /Normal PSL_transp} FS
 /FO {P}!
 1313 437 M
 -35 71 D
@@ -56163,6 +56204,7 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
+U
 %%EndObject
 0 A
 FQ
@@ -56176,6 +56218,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 9 W
 0.439 A
 clipsave
@@ -56757,21 +56800,9 @@ FO
 /FO {fs os}!
 FO
 PSL_cliprestore
-%%EndObject
 U
 %%EndObject
-0 A
-FQ
-O0
-0 0 TM
-
-% PostScript produced by:
-%@GMT: gmt psxy -R0/8.5/0/11 -Jx1i -O -T
-%@PROJ: xy 0.00000000 8.50000000 0.00000000 11.00000000 0.000 8.500 0.000 11.000 +xy
-%%BeginObject PSL_Layer_50
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
+U
 %%EndObject
 
 grestore

--- a/test/mgd77/cm4.ps
+++ b/test/mgd77/cm4.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.2.0_7cac10a-dirty_2020.10.08 [64-bit] Document from psxy
+%%Title: GMT v6.2.0_b1364c2_2020.11.28 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Oct  8 16:17:06 2020
+%%CreationDate: Sat Nov 28 15:01:40 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -112,9 +112,11 @@
   PSL_eps_state restore
 }!
 /PSL_transp {
-  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
-  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
-  {pop pop} ifelse} ifelse
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
 }!
 /Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
@@ -676,6 +678,8 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+0 A
+V
 17 W
 clipsave
 0 0 M
@@ -1922,8 +1926,9 @@ PSL_clip N
 5 -8 D
 S
 PSL_cliprestore
-0 A [] 0 B
+U
 25 W
+0 A
 /PSL_slant_y 0 def
 2 setlinecap
 N 0 2835 M 0 -2835 D S
@@ -2043,6 +2048,7 @@ O0
 0 setlinejoin
 3.32550952342 setmiterlimit
 1 0 0 C
+V
 17 W
 clipsave
 0 0 M
@@ -2192,8 +2198,9 @@ PSL_clip N
 79 -12 D
 S
 PSL_cliprestore
-0 A [] 0 B
+U
 25 W
+1 0 0 C
 /PSL_slant_y 0 def
 2 setlinecap
 7559 0 T
@@ -2319,6 +2326,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+0 A
 clipsave
 0 0 M
 1890 0 D
@@ -2327,6 +2335,7 @@ clipsave
 P
 PSL_clip N
 {0 A} FS
+O0
 -151 0 0 31 151 0 3 227 0 SP
 -151 0 0 328 151 0 3 378 0 SP
 -151 0 0 1226 151 0 3 529 0 SP
@@ -2338,8 +2347,8 @@ PSL_clip N
 -151 0 0 123 151 0 3 1436 0 SP
 -152 0 0 24 152 0 3 1587 0 SP
 PSL_cliprestore
-0 A [] 0 B
 25 W
+0 A
 /PSL_slant_y 0 def
 2 setlinecap
 N 0 1417 M 0 -1417 D S


### PR DESCRIPTION
**Description of proposed changes**

Properly reset pen width, style, color when basemap is called.  Depending on circumstances, past settings may still be the default which messes things up.  This could be due to the use of subplot panels with tags, movie labels, but also psxy/psxyz calls where the pen setting was set outside the gsave/grestore for the meat of the plots, thus lived on.

This fixes the first of the problems in #4497; it would be better to create separate issues for separate problems for tracking and closing purposes.