### PR TITLE
Fix gmt_dev.h to gmt.h in test*.c

### DIFF
--- a/src/testapi_grid2matrix.c
+++ b/src/testapi_grid2matrix.c
@@ -1,4 +1,4 @@
-#include "gmt_dev.h"
+#include "gmt.h"
 
 /* Testing reading a grid into a matrix, then writing the matrix to a grid file.
  * The test script apigrd2mat,sh will compare the two.

--- a/src/testapi_makecpt.c
+++ b/src/testapi_makecpt.c
@@ -3,7 +3,7 @@
  * Fixed Nov. 17, 2020, P. Wessel
  */
 
-#include <gmt.h>
+#include "gmt.h"
 #include <string.h>
 int main () {
 	char output[GMT_VF_LEN] = {""};

--- a/src/testapi_matrix_360.c
+++ b/src/testapi_matrix_360.c
@@ -1,4 +1,4 @@
-#include "gmt_dev.h"
+#include "gmt.h"
 
 /* Testing the passing of a matrix to grdimage for global projection
  * when the central meridian changes. This currently fails as in

--- a/src/testapi_matrix_360_ref.c
+++ b/src/testapi_matrix_360_ref.c
@@ -1,4 +1,4 @@
-#include "gmt_dev.h"
+#include "gmt.h"
 
 /* Testing the passing of a matrix to grdimage for global projection
  * when the central meridian changes. This time using a float matrix

--- a/src/testapi_matrix_as_grid.c
+++ b/src/testapi_matrix_as_grid.c
@@ -1,4 +1,4 @@
-#include "gmt_dev.h"
+#include "gmt.h"
 
 /* Test passing a gridline and pixel-registered matrix as grids to grdimage.
  * the two plots should be identical.  This tests was made to demonstrate a

--- a/src/testapi_mixmatrix.c
+++ b/src/testapi_mixmatrix.c
@@ -1,4 +1,4 @@
-#include "gmt_dev.h"
+#include "gmt.h"
 /*
  * Testing the use of user data provided via a GMT_MATRIX
  * to psxy and pstext, passing both a coordinate matrix and a string array.

--- a/src/testapi_userdataset.c
+++ b/src/testapi_userdataset.c
@@ -1,5 +1,6 @@
-#include "gmt_dev.h"
+#include "gmt.h"
 #include <math.h>
+#include <string.h>
 /*
  * Testing the use of user data provided via a GMT_MATRIX
  * to/from a module that expect to read/write GMT_DATASETs.

--- a/src/testapi_usergrid.c
+++ b/src/testapi_usergrid.c
@@ -1,5 +1,6 @@
-#include "gmt_dev.h"
+#include "gmt.h"
 #include <math.h>
+#include <string.h>
 /*
  * Testing the use of user data provided via a GMT_MATRIX
  * to/from a module that expect to read/write GMT_GRIDs.

--- a/src/testapi_uservectors.c
+++ b/src/testapi_uservectors.c
@@ -1,5 +1,6 @@
-#include "gmt_dev.h"
+#include "gmt.h"
 #include <math.h>
+#include <string.h>
 /*
  * Testing the use of user data provided via a GMT_VECTOR
  * to/from a module that expect to read/write GMT_DATASETs.


### PR DESCRIPTION
**Description of proposed changes**

Use `gmt.h` instead of `gmt_dev.h` in testapi_*.c

