### PR TITLE
Fix an uninit variable

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -5315,7 +5315,7 @@ GMT_LOCAL int gmtapi_export_grid (struct GMTAPI_CTRL *API, int object_ID, unsign
 int GMT_Put_Levels (void *V_API, struct GMT_CUBE *C, double *levels, uint64_t n_levels) {
 	/* Duplicate and assign a level array to the cube for its 3rd dimension coordinates */
 	struct GMT_CUBE_HIDDEN *CU;
-	struct GMTAPI_CTRL *API;
+	struct GMTAPI_CTRL *API = NULL;
 
 	/* Check for NULL and void arguments */
 	if (V_API == NULL) return_error (API, GMT_NOT_A_SESSION);


### PR DESCRIPTION
Warning:
```
../../src/gmt_api.c:5321:35: warning: variable 'API' is uninitialized when used here [-Wuninitialized]
        if (V_API == NULL) return_error (API, GMT_NOT_A_SESSION);
                                         ^~~
../../src/gmt_api.c:228:53: note: expanded from macro 'return_error'
                                                    ^~~
../../src/gmt_api.c:5318:25: note: initialize the variable 'API' to silence this warning
        struct GMTAPI_CTRL *API;
                               ^
                                = NULL
1 warning generated.
```

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
