### PR TITLE
Let the user have control over what CPT is the GMT default

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -61,6 +61,9 @@ COLOR Parameters
         Color used for the foreground of images (i.e., when z > highest
         color table entry) [white].
 
+    **COLOR_CPT**
+        Default CPT table when none is selected [turbo].
+
     **COLOR_HSV_MAX_S**
         Maximum saturation (0-1) assigned for most positive intensity value [0.1].
 

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -61,6 +61,7 @@ struct GMT_DEFAULTS {
 	/* COLOR group [sorted by type to optimize storage] */
 	unsigned int color_model;		/* 1 = read RGB, 2 = use RGB, 4 = read HSV, 8 = use HSV, 16 = read CMYK, 32 = use CMYK [1+2]
 									 * Add 128 to disallow output of color names */
+	char cpt[GMT_LEN64];			/* Default CPT */
 	double color_patch[3][4];		/* Color of background, foreground, nan [black,white,127.5] */
 	double color_hsv_min_s;			/* For smallest or most negative intensity [1.0] */
 	double color_hsv_max_s;			/* For largest or most positive intensity [0.1] */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -138,6 +138,7 @@ static struct GMT5_params GMT5_keywords[]= {
 	{ 1, "COLOR Parameters"},
 	{ 0, "COLOR_BACKGROUND"},
 	{ 0, "COLOR_FOREGROUND"},
+	{ 0, "COLOR_CPT"},
 	{ 0, "COLOR_NAN"},
 	{ 0, "COLOR_MODEL"},
 	{ 0, "COLOR_HSV_MIN_S"},
@@ -6031,6 +6032,8 @@ void gmt_conf (struct GMT_CTRL *GMT) {
 	error += gmt_getrgb (GMT, "black", GMT->current.setting.color_patch[GMT_BGD]);
 	/* COLOR_FOREGROUND */
 	error += gmt_getrgb (GMT, "white", GMT->current.setting.color_patch[GMT_FGD]);
+	/* COLOR_CPT */
+	strcpy (GMT->current.setting.cpt, GMT_DEFAULT_CPT_NAME);
 	/* COLOR_MODEL */
 	GMT->current.setting.color_model = GMT_RGB;
 	/* COLOR_NAN */
@@ -10142,6 +10145,14 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 		case GMTCASE_COLOR_FOREGROUND:
 			error = gmt_getrgb (GMT, value, GMT->current.setting.color_patch[GMT_FGD]);
 			break;
+		case GMTCASE_COLOR_CPT:
+			if (strlen (value) >= GMT_LEN64) {
+				GMT_Report (GMT->parent, GMT_MSG_ERROR, "COLOR_CPT = %s exceeds max name length of %d\n", value, GMT_LEN64);
+				error = true;
+			}
+			else
+				strncpy (GMT->current.setting.cpt, value, GMT_LEN64-1);
+			break;
 		case GMTCASE_COLOR_MODEL:
 			if (!strcmp (lower_value, "none"))
 				GMT->current.setting.color_model = GMT_RGB;
@@ -11582,6 +11593,9 @@ char *gmtlib_putparameter (struct GMT_CTRL *GMT, const char *keyword) {
 			break;
 		case GMTCASE_COLOR_FOREGROUND:
 			snprintf (value, GMT_LEN256, "%s", gmt_putcolor (GMT, GMT->current.setting.color_patch[GMT_FGD]));
+			break;
+		case GMTCASE_COLOR_CPT:
+			snprintf (value, GMT_LEN64, "%s", GMT->current.setting.cpt);
 			break;
 		case GMTCASE_COLOR_MODEL:
 			if (GMT->current.setting.color_model == GMT_RGB)

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6033,7 +6033,7 @@ void gmt_conf (struct GMT_CTRL *GMT) {
 	/* COLOR_FOREGROUND */
 	error += gmt_getrgb (GMT, "white", GMT->current.setting.color_patch[GMT_FGD]);
 	/* COLOR_CPT */
-	strcpy (GMT->current.setting.cpt, GMT_DEFAULT_CPT_NAME);
+	strncpy (GMT->current.setting.cpt, GMT_DEFAULT_CPT_NAME, GMT_LEN64-1);
 	/* COLOR_MODEL */
 	GMT->current.setting.color_model = GMT_RGB;
 	/* COLOR_NAN */

--- a/src/gmt_keywords.txt
+++ b/src/gmt_keywords.txt
@@ -12,6 +12,7 @@
 #-------------------------------------------------------
 COLOR_BACKGROUND		# Color used for data below the current color table range
 COLOR_FOREGROUND		# Color used for data above the current color table range
+COLOR_CPT			# Default CPT
 COLOR_MODEL			# Color model in use (RGB, HSV, CMYK)
 COLOR_NAN			# Color used for data whose value is NaN
 COLOR_HSV_MAX_S			# Maximum saturation assigned for most positive intensity value

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7345,7 +7345,7 @@ void gmtlib_free_palette (struct GMT_CTRL *GMT, struct GMT_PALETTE **P) {
 
 /*! Adds listing of available GMT cpt choices to a program's usage message */
 int gmt_list_cpt (struct GMT_CTRL *GMT, char option) {
-	gmt_message (GMT, "\t-%c Specify a colortable [Default is %s]:\n", option, GMT_DEFAULT_CPT_NAME);
+	gmt_message (GMT, "\t-%c Specify a colortable [Default is %s]:\n", option, GMT->current.setting.cpt);
 	gmt_message (GMT, "\t   [Legend: R = Default z-range, H = Hard Hinge, S = Soft Hinge, C = Colormodel]\n");
 	gmt_message (GMT, "\t   ---------------------------------------------------------------------------------------\n");
 	for (unsigned int k = 0; k < GMT_N_CPT_MASTERS; k++) gmt_message (GMT, "\t   %s\n", GMT_CPT_master[k]);
@@ -7360,7 +7360,7 @@ int gmt_list_cpt (struct GMT_CTRL *GMT, char option) {
 GMT_LOCAL bool gmtsupport_cpt_master_index (struct GMT_CTRL *GMT, char *name) {
 	size_t len;
 	gmt_M_unused(GMT);
-	if (name == NULL) return true;	/* true, because no name means we default to GMT_DEFAULT_CPT_NAME */
+	if (name == NULL) return true;	/* true, because no name means we default to GMT->current.setting.cpt */
 	len = strlen (name);	/* Length of the master table name so we can limit comparison to just those characters */
 	/* Note: THere are near-duplicate names like broc and brocO, but since they are ordered alphabetically our
 	 * search for broc will first compare with broc before broc0 so not an issue. */
@@ -7968,7 +7968,7 @@ char * gmt_cpt_default (struct GMTAPI_CTRL *API, char *cpt, char *file) {
 	 * If cpt is specified then that is what we will use. If not, then
 	 * we determine if file is a remote data set, and if it is and has a
 	 * default CPT then we use that, else we return NULL which means use
-	 * the GMT default CPT given by GMT_DEFAULT_CPT_NAME */
+	 * the GMT default CPT given by GMT->current.setting.cpt */
 	int k_data;
 	static char *srtm_cpt = "srtm";
 	char *curr_cpt = NULL;
@@ -7992,7 +7992,7 @@ char * gmt_cpt_default (struct GMTAPI_CTRL *API, char *cpt, char *file) {
 bool gmt_is_cpt_master (struct GMT_CTRL *GMT, char *cpt) {
 	/* Return true if cpt is the name of a GMT CPT master table and not a local file */
 	char *c = NULL, *f = NULL;
-	if (cpt == NULL) return true;	/* No cpt given means use GMT_DEFAULT_CPT_NAME master */
+	if (cpt == NULL) return true;	/* No cpt given means use GMT->current.setting.cpt master */
 	if (gmt_M_file_is_memory (cpt)) return false;	/* A CPT was given via memory location so cannot be a master reference */
 	if ((f = gmt_strrstr (cpt, GMT_CPT_EXTENSION)))	/* Only examine modifiers from there onwards */
 		c = gmtlib_last_valid_file_modifier (GMT->parent, f, GMT_CPTFILE_MODIFIERS);
@@ -8152,7 +8152,7 @@ struct GMT_PALETTE *gmt_get_palette (struct GMT_CTRL *GMT, char *file, enum GMT_
 			return (P);
 		}
 
-		master = (file && file[0]) ? file : GMT_DEFAULT_CPT_NAME;	/* Set master CPT prefix */
+		master = (file && file[0]) ? file : GMT->current.setting.cpt;	/* Set master CPT prefix */
 		P = GMT_Read_Data (GMT->parent, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL|GMT_CPT_CONTINUOUS, NULL, master, NULL);
 		if (!P) return (P);		/* Error reading file. Return right away to avoid a segv in next line */
 		/* Stretch to fit the data range */

--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -506,9 +506,9 @@ EXTERN_MSC int GMT_grd2cpt (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the grd2cpt main code ----------------------------*/
 
-	if (!Ctrl->C.active) {	/* No table specified; set GMT_DEFAULT_CPT_NAME table */
+	if (!Ctrl->C.active) {	/* No table specified; set GMT->current.setting.cpt table */
 		Ctrl->C.active = true;
-		Ctrl->C.file = strdup (GMT_DEFAULT_CPT_NAME);
+		Ctrl->C.file = strdup (GMT->current.setting.cpt);
 	}
 
 	if (!Ctrl->E.active) Ctrl->E.levels = (Ctrl->T.n_levels > 0) ? Ctrl->T.n_levels : GRD2CPT_N_LEVELS;	/* Default number of levels */

--- a/src/grd2kml.c
+++ b/src/grd2kml.c
@@ -149,7 +149,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
 	GMT_Message (API, GMT_TIME_NONE, "\t<grid> is the data set to be plotted.  Its z-values are in user units and will be\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  converted to colors via the CPT [%s].\n", GMT_DEFAULT_CPT_NAME);
+	GMT_Message (API, GMT_TIME_NONE, "\t  converted to colors via the CPT [%s].\n", API->GMT->current.setting.cpt);
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Sets file name prefix for image directory and KML file. If the directory\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   already exist we will overwrite the files.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
@@ -159,7 +159,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t     s Altitude relative to sea floor or ground.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally, append fixed <altitude> [g0: Clamped to sea surface or ground].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Color palette file to convert z to rgb. Optionally, instead give name of a master cpt\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   to automatically assign continuous colors over the data range [%s]; if so,\n", GMT_DEFAULT_CPT_NAME);
+	GMT_Message (API, GMT_TIME_NONE, "\t   to automatically assign continuous colors over the data range [%s]; if so,\n", API->GMT->current.setting.cpt);
 	GMT_Message (API, GMT_TIME_NONE, "\t   optionally append +i<dz> to quantize the range [the exact grid range].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Another option is to specify -C<color1>,<color2>[,<color3>,...] to build a\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   linear continuous cpt from those colors automatically.\n");

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -190,7 +190,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	}
 	GMT_Option (API, "B-");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Color palette file to convert grid values to colors. Optionally, name a master cpt\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   to automatically assign continuous colors over the data range [%s]; if so,\n", GMT_DEFAULT_CPT_NAME);
+	GMT_Message (API, GMT_TIME_NONE, "\t   to automatically assign continuous colors over the data range [%s]; if so,\n", API->GMT->current.setting.cpt);
 	GMT_Message (API, GMT_TIME_NONE, "\t   optionally append +i<dz> to quantize the range [the exact grid range].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Another option is to specify -C<color1>,<color2>[,<color3>,...] to build a\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   linear continuous cpt from those colors automatically.\n");
@@ -1320,7 +1320,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 			}
 		}
 		if (!Ctrl->C.active)	/* Set no specific CPT so we turn -C on to use current or default CPT */
-			Ctrl->C.active = true;	/* Use default CPT (GMT_DEFAULT_CPT_NAME) and autostretch or under modern reuse current CPT */
+			Ctrl->C.active = true;	/* Use default CPT (GMT->current.setting.cpt) and autostretch or under modern reuse current CPT */
 	}
 
 	if (got_z_grid) header_work = Grid_orig->header;	/* OK, we are in GRID mode and this was not set previously. Do it now. */

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -121,7 +121,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-A Grids have polar (r, theta) components [Default is Cartesian (x, y) components].\n");
 	GMT_Option (API, "B-");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Color palette file to convert vector length to colors. Optionally, name a master cpt\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   to automatically assign continuous colors over the data range [%s]; if so,\n", GMT_DEFAULT_CPT_NAME);
+	GMT_Message (API, GMT_TIME_NONE, "\t   to automatically assign continuous colors over the data range [%s]; if so,\n", API->GMT->current.setting.cpt);
 	GMT_Message (API, GMT_TIME_NONE, "\t   optionally append +i<dz> to quantize the range [the exact grid range].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Another option is to specify -Ccolor1,color2[,color3,...] to build a linear\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   continuous cpt from those colors automatically.\n");

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -432,7 +432,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Option (API, "B-");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Color palette file to convert grid values to colors. Optionally, name a master cpt\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   to automatically assign continuous colors over the data range [%s]; if so,\n", GMT_DEFAULT_CPT_NAME);
+	GMT_Message (API, GMT_TIME_NONE, "\t   to automatically assign continuous colors over the data range [%s]; if so,\n", API->GMT->current.setting.cpt);
 	GMT_Message (API, GMT_TIME_NONE, "\t   optionally append +i<dz> to quantize the range [the exact grid range].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Another option is to specify -C<color1>,<color2>[,<color3>,...] to build a\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   linear continuous cpt from those colors automatically.\n");
@@ -858,7 +858,7 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 	}
 
 	if (!Ctrl->C.active && Ctrl->Q.cpt && Ctrl->G.n != 3)
-		Ctrl->C.active = true;	/* Use default CPT (GMT_DEFAULT_CPT_NAME) and autostretch or under modern reuse current CPT */
+		Ctrl->C.active = true;	/* Use default CPT (GMT->current.setting.cpt) and autostretch or under modern reuse current CPT */
 
 	/* Determine what wesn to pass to map_setup */
 

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -23,7 +23,7 @@
  * Brief synopsis: Reads an existing CPT and desired output grid
  * and produces a GMT CPT.  Can be inverted [-I] or made to be
  * continuous [-Z].  Discrete color jumps in CPTs are handled
- * correctly.  Default color table is GMT_DEFAULT_CPT_NAME.
+ * correctly.  Default color table is in GMT->current.setting.cpt [GMT_DEFAULT_CPT_NAME].
  *
  */
 
@@ -456,7 +456,7 @@ EXTERN_MSC int GMT_makecpt (void *V_API, int mode, void *args) {
 
 	if (!Ctrl->C.active) {	/* No table specified; set default table */
 		Ctrl->C.active = true;
-		Ctrl->C.file = strdup (GMT_DEFAULT_CPT_NAME);
+		Ctrl->C.file = strdup (GMT->current.setting.cpt);
 	}
 
 	GMT_Report (API, GMT_MSG_INFORMATION, "Prepare CPT via the master file %s\n", Ctrl->C.file);


### PR DESCRIPTION
Instead of forcing turbo on all, this is now controllable via new GMT default **COLOR_CPT** [turbo]. See background to this discussion in #4500; this implements one aspect of that discussion.
