### PR TITLE
Just improve used of named constants rather that literals

### DIFF
--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -2817,7 +2817,7 @@ GMT_LOCAL void grdmath_INSIDE (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, 
 				if (gmt_polygon_is_hole (GMT, S)) continue;	/* Holes are handled within gmt_inonout */
 				inside = gmt_inonout (GMT, info->d_grd_x[col], info->d_grd_y[row], S);
 			}
-			stack[last]->G->data[node] = (inside) ? 1.0f : 0.0f;
+			stack[last]->G->data[node] = (inside > GMT_OUTSIDE) ? 1.0f : 0.0f;
 		}
 	}
 

--- a/src/sphdistance.c
+++ b/src/sphdistance.c
@@ -580,7 +580,7 @@ EXTERN_MSC int GMT_sphdistance (void *V_API, int mode, void *args) {
 					col = p_col;
 				side = gmt_inonout (GMT, grid_lon[col], grid_lat[row], P);
 
-				if (side == 0) continue;	/* Outside spherical polygon */
+				if (side == GMT_OUTSIDE) continue;	/* Outside spherical polygon */
 				ij = gmt_M_ijp (Grid->header, row, col);
 				if (Ctrl->E.mode == SPHD_DIST)
 					f_val = (gmt_grdfloat)gmt_distance (GMT, grid_lon[col], grid_lat[row], lon[node], lat[node]);

--- a/src/spotter/gmtpmodeler.c
+++ b/src/spotter/gmtpmodeler.c
@@ -368,7 +368,7 @@ EXTERN_MSC int GMT_gmtpmodeler (void *V_API, int mode, void *args) {
 		if (Ctrl->F.active) {	/* Use the bounding polygon */
 			for (seg = inside = 0; seg < pol->n_segments && !inside; seg++) {	/* Use degrees since function expects it */
 				if (gmt_polygon_is_hole (GMT, pol->segment[seg])) continue;	/* Holes are handled within gmt_inonout */
-				inside = (gmt_inonout (GMT, in[GMT_X], in[GMT_Y], pol->segment[seg]) > 0);
+				inside = (gmt_inonout (GMT, in[GMT_X], in[GMT_Y], pol->segment[seg]) > GMT_OUTSIDE);
 			}
 			if (!inside) {
 				n_outside++;	/* Outside the polygon(s), continue */

--- a/src/spotter/grdpmodeler.c
+++ b/src/spotter/grdpmodeler.c
@@ -421,7 +421,7 @@ EXTERN_MSC int GMT_grdpmodeler (void *V_API, int mode, void *args) {
 		if (Ctrl->F.active) {	/* Use the bounding polygon */
 			for (seg = inside = 0; seg < pol->n_segments && !inside; seg++) {	/* Use degrees since function expects it */
 				if (gmt_polygon_is_hole (GMT, pol->segment[seg])) continue;	/* Holes are handled within gmt_inonout */
-				inside = (gmt_inonout (GMT, grd_x[col], grd_y[row], pol->segment[seg]) > 0);
+				inside = (gmt_inonout (GMT, grd_x[col], grd_y[row], pol->segment[seg]) > GMT_OUTSIDE);
 			}
 			if (!inside) skip = true, n_outside++;	/* Outside the polygon(s); set all output grids to NaN for this node */
 		}

--- a/src/spotter/grdrotater.c
+++ b/src/spotter/grdrotater.c
@@ -396,7 +396,7 @@ GMT_LOCAL bool grdrotater_skip_if_outside (struct GMT_CTRL *GMT, struct GMT_DATA
 	unsigned int inside = 0;
 	for (seg = 0; seg < P->n_segments && !inside; seg++) {	/* Use degrees since function expects it */
 		if (gmt_polygon_is_hole (GMT, P->segment[seg])) continue;	/* Holes are handled within gmt_inonout */
-		inside = (gmt_inonout (GMT, lon, lat, P->segment[seg]) > 0);
+		inside = (gmt_inonout (GMT, lon, lat, P->segment[seg]) > GMT_OUTSIDE);
 	}
 	return ((inside) ? false : true);	/* true if outside */
 }

--- a/src/triangulate.c
+++ b/src/triangulate.c
@@ -583,7 +583,7 @@ EXTERN_MSC int GMT_triangulate (void *V_API, int mode, void *args) {
 					if (yy[k] < P->min[GMT_Y] || yy[k] > P->max[GMT_Y]) continue;
 					if (xx[k] < P->min[GMT_X] || xx[k] > P->max[GMT_X]) continue;
 					side = gmt_inonout (GMT, xx[k], yy[k], P);
-					if (side) node = k;	/* Found the data node */
+					if (side != GMT_OUTSIDE) node = k;	/* Found the data node */
 				}
 				zpol[seg] = zz[node];
 				sprintf (header, "%s -Z%g", P->header, zpol[seg]);
@@ -664,7 +664,7 @@ EXTERN_MSC int GMT_triangulate (void *V_API, int mode, void *args) {
 						if (!gmt_M_is_fnan (Grid->data[p])) continue;
 					}
 					side = gmt_inonout (GMT, grid_lon[col], grid_lat[row], P);
-					if (side == 0) continue;	/* Outside polygon */
+					if (side == GMT_OUTSIDE) continue;	/* Outside polygon */
 					p = gmt_M_ijp (Grid->header, row, col);
 					Grid->data[p] = (gmt_grdfloat)zpol[seg];
 					n_set++;


### PR DESCRIPTION
In this case, this applies to the _gmt_inonout_ return values. Kind of an improved documentation.
