### PR TITLE
Update api.rst

### DIFF
--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -1274,7 +1274,8 @@ set to ``GMT_OUT``.   Such empty containers are requested by passing mode = ``GM
 and setting all dimension arguments to 0 or NULL.
 The function returns a pointer to the
 data container. In case of an error we return a NULL pointer and pass an
-error code via ``API->error``.
+error code via ``API->error``. Your C code will have to include "gmt_private.h" to be able to
+dereference the API pointer.
 
 Hooking user arrays to objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
It could be interesting to point out that dereferencing ``API->error`` requires casting the void pointer to ``struct GMTAPI_CTRL*`` defined in gmt_private.h 
It took me a while to find out.

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
