### PR TITLE
Added the possibility to read variables in NetCDF-4 groups

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3906,7 +3906,7 @@ GMT_LOCAL void * gmtio_nc_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, in
 			}
 			for (k = 0; k < GMT->current.io.count[v][1]; ++col, ++k) {	/* For each column in variable v [typically 1 unless 2-D array] */
 				start[1] = k, count[1] = 1;	/* Read only k'th column in 2-D array or the only column [k = 0] in 1-D array */
-				nc_get_vara_double (GMT->current.io.ncid, GMT->current.io.varid[v], start, count, GMT->hidden.mem_coord[col]);	/* Read column */
+				nc_get_vara_double (GMT->current.io.grpid[v], GMT->current.io.varid[v], start, count, GMT->hidden.mem_coord[col]);	/* Read column */
 				for (row = 0; row < GMT->current.io.ndim; ++row) {	/* Loop over all records (rows) to do scaling */
 					if (GMT->hidden.mem_coord[col][row] == GMT->current.io.missing_value[v])	/* Nan proxy detected */
 						GMT->hidden.mem_coord[col][row] = GMT->session.d_NaN;
@@ -3956,6 +3956,29 @@ GMT_LOCAL void * gmtio_nc_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, in
 }
 
 /*! . */
+GMT_LOCAL int gmtio_nc_inq_varid (int ncid, const char *varnm, int *grpid, int *varid) {
+/* Get group id and variable id of netCDF variable that includes the full group name.
+ * If no group name is included, grpid is the ncid
+ */
+	char *pstr;
+	char str[GMT_LEN64];
+	int status;
+
+	strcpy (str, varnm);
+	if ((pstr = strrchr (str, '/'))) {
+		pstr[0] = '\0';
+		status = nc_inq_grp_full_ncid (ncid, str, grpid);
+		if (status != NC_NOERR) return (status);
+		pstr++;
+	}
+	else {
+		*grpid = ncid;
+		pstr = str;
+	}
+	return (nc_inq_varid (*grpid, pstr, varid));
+}
+
+/*! . */
 GMT_LOCAL FILE *gmtio_nc_fopen (struct GMT_CTRL *GMT, const char *filename, const char *mode) {
 /* Open a netCDF file for column I/O. Append ?var1/var2/... to indicate the requested columns.
  * Currently only reading is supported.
@@ -3967,6 +3990,7 @@ GMT_LOCAL FILE *gmtio_nc_fopen (struct GMT_CTRL *GMT, const char *filename, cons
  */
 
 	char file[PATH_MAX] = {""}, path[PATH_MAX] = {""};
+	char *pstr, *qstr;
 	int i, j, nvars, dimids[5] = {-1, -1, -1, -1, -1}, ndims, in, id;
 	size_t n, item[2];
 	size_t tmp_pointer; /* To avoid "cast from pointer to integer of different size" */
@@ -3990,7 +4014,19 @@ GMT_LOCAL FILE *gmtio_nc_fopen (struct GMT_CTRL *GMT, const char *filename, cons
 		varnm[11], varnm[12], varnm[13], varnm[14], varnm[15], varnm[16], varnm[17], varnm[18], varnm[19]) - 1;
 	if (gmt_getdatapath (GMT, file, path, R_OK) == NULL) return (NULL);	/* No such file */
 	if (nc_open (path, NC_NOWRITE, &GMT->current.io.ncid)) return (NULL);
-	if (gmt_M_compat_check (GMT, 4)) {
+	pstr = strrchr (filename, ',');
+	qstr = strchr (filename, '?');
+
+	/* In case there is a comma in the list of variables, or if the first variable is actually a group,
+	 * we re-read the variable list with comma separators */
+	nc_inq_grp_ncid (GMT->current.io.ncid, varnm[0], &id);
+	if (pstr > qstr || GMT->current.io.ncid != id) {
+		nvars = sscanf (filename,
+			"%[^?]?%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,]",
+			file, varnm[0], varnm[1], varnm[2], varnm[3], varnm[4], varnm[5], varnm[6], varnm[7], varnm[8], varnm[9], varnm[10],
+			varnm[11], varnm[12], varnm[13], varnm[14], varnm[15], varnm[16], varnm[17], varnm[18], varnm[19]) - 1;
+	}
+	else if (gmt_M_compat_check (GMT, 4)) {
 		if (nvars <= 0) nvars = sscanf (GMT->common.b.varnames,
 			"%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]/%[^/]",
 			varnm[0], varnm[1], varnm[2], varnm[3], varnm[4], varnm[5], varnm[6], varnm[7], varnm[8], varnm[9], varnm[10],
@@ -4000,6 +4036,7 @@ GMT_LOCAL FILE *gmtio_nc_fopen (struct GMT_CTRL *GMT, const char *filename, cons
 		nc_inq_nvars (GMT->current.io.ncid, &GMT->current.io.nvars);
 	else
 		GMT->current.io.nvars = nvars;
+	GMT->current.io.grpid = gmt_M_memory (GMT, NULL, GMT->current.io.nvars, int);
 	GMT->current.io.varid = gmt_M_memory (GMT, NULL, GMT->current.io.nvars, int);
 	GMT->current.io.scale_factor = gmt_M_memory (GMT, NULL, GMT->current.io.nvars, double);
 	GMT->current.io.add_offset = gmt_M_memory (GMT, NULL, GMT->current.io.nvars, double);
@@ -4024,18 +4061,20 @@ GMT_LOCAL FILE *gmtio_nc_fopen (struct GMT_CTRL *GMT, const char *filename, cons
 		}
 
 		/* Get variable ID and variable name */
-		if (nvars <= 0)
+		if (nvars <= 0) {
+			GMT->current.io.grpid[i] = GMT->current.io.ncid;
 			GMT->current.io.varid[i] = i;
+		}
 		else {
-			if (gmt_M_err_fail (GMT, nc_inq_varid (GMT->current.io.ncid, varnm[i], &GMT->current.io.varid[i]), file)) {
+			if (gmt_M_err_fail (GMT, gmtio_nc_inq_varid (GMT->current.io.ncid, varnm[i], &GMT->current.io.grpid[i], &GMT->current.io.varid[i]), file)) {
 				GMT->parent->error = GMT_NOT_A_VALID_ID;
 				return NULL;
 			}
 		}
-		nc_inq_varname (GMT->current.io.ncid, GMT->current.io.varid[i], varname);
+		nc_inq_varname (GMT->current.io.grpid[i], GMT->current.io.varid[i], varname);
 
 		/* Check number of dimensions */
-		if (gmt_M_err_fail (GMT, nc_inq_varndims (GMT->current.io.ncid, GMT->current.io.varid[i], &ndims), file)) {
+		if (gmt_M_err_fail (GMT, nc_inq_varndims (GMT->current.io.grpid[i], GMT->current.io.varid[i], &ndims), file)) {
 			GMT->parent->error = GMT_GRDIO_BAD_DIM;
 			return NULL;
 		}
@@ -4052,8 +4091,8 @@ GMT_LOCAL FILE *gmtio_nc_fopen (struct GMT_CTRL *GMT, const char *filename, cons
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "NetCDF variable %s has %" PRIuS " dimensions, showing only 2\n", varname, ndims);
 
 		/* Get information of the first two dimensions */
-		nc_inq_vardimid(GMT->current.io.ncid, GMT->current.io.varid[i], dimids);
-		nc_inq_dimlen(GMT->current.io.ncid, dimids[0], &n);
+		nc_inq_vardimid(GMT->current.io.grpid[i], GMT->current.io.varid[i], dimids);
+		nc_inq_dimlen(GMT->current.io.grpid[i], dimids[0], &n);
 		if (GMT->current.io.ndim != 0 && GMT->current.io.ndim != n) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "NetCDF variable %s has different dimension (%" PRIuS ") from others (%" PRIuS ")\n",
 			            varname, n, GMT->current.io.ndim);
@@ -4062,7 +4101,7 @@ GMT_LOCAL FILE *gmtio_nc_fopen (struct GMT_CTRL *GMT, const char *filename, cons
 		}
 		GMT->current.io.count[i][0] = GMT->current.io.ndim = n;
 		if (dimids[1] >= 0 && ndims - in > 1) {
-			nc_inq_dimlen(GMT->current.io.ncid, dimids[1], &n);
+			nc_inq_dimlen(GMT->current.io.grpid[i], dimids[1], &n);
 		}
 		else
 			n = 1;
@@ -4071,31 +4110,31 @@ GMT_LOCAL FILE *gmtio_nc_fopen (struct GMT_CTRL *GMT, const char *filename, cons
 
 		/* If selected by value instead of index */
 		for (j = 1; by_value && j <= in; j++) {
-			nc_inq_dim (GMT->current.io.ncid, dimids[j], dimname, &n);
-			nc_inq_varid (GMT->current.io.ncid, dimname, &id);
+			nc_inq_dim (GMT->current.io.grpid[i], dimids[j], dimname, &n);
+			nc_inq_varid (GMT->current.io.grpid[i], dimname, &id);
 			item[0] = 0, item[1] = n-1;
-			if (nc_get_att_double (GMT->current.io.ncid, id, "actual_range", dummy)) {
-				nc_get_var1_double (GMT->current.io.ncid, id, &item[0], &dummy[0]);
-				nc_get_var1_double (GMT->current.io.ncid, id, &item[1], &dummy[1]);
+			if (nc_get_att_double (GMT->current.io.grpid[i], id, "actual_range", dummy)) {
+				nc_get_var1_double (GMT->current.io.grpid[i], id, &item[0], &dummy[0]);
+				nc_get_var1_double (GMT->current.io.grpid[i], id, &item[1], &dummy[1]);
 			}
 			GMT->current.io.t_index[i][j] = lrint((t_value[j] - dummy[0]) / (dummy[1] - dummy[0]));
 		}
 
 		/* Get scales, offsets and missing values */
-		if (nc_get_att_double (GMT->current.io.ncid, GMT->current.io.varid[i], "scale_factor",
+		if (nc_get_att_double (GMT->current.io.grpid[i], GMT->current.io.varid[i], "scale_factor",
 		                       &GMT->current.io.scale_factor[i]))
 			GMT->current.io.scale_factor[i] = 1.0;
-		if (nc_get_att_double (GMT->current.io.ncid, GMT->current.io.varid[i], "add_offset",
+		if (nc_get_att_double (GMT->current.io.grpid[i], GMT->current.io.varid[i], "add_offset",
 		                       &GMT->current.io.add_offset[i]))
 			GMT->current.io.add_offset[i] = 0.0;
-		if (nc_get_att_double (GMT->current.io.ncid, GMT->current.io.varid[i], "_FillValue",
-		                       &GMT->current.io.missing_value[i]) && nc_get_att_double (GMT->current.io.ncid, GMT->current.io.varid[i],
+		if (nc_get_att_double (GMT->current.io.grpid[i], GMT->current.io.varid[i], "_FillValue",
+		                       &GMT->current.io.missing_value[i]) && nc_get_att_double (GMT->current.io.grpid[i], GMT->current.io.varid[i],
 		                       "missing_value", &GMT->current.io.missing_value[i]))
 		    GMT->current.io.missing_value[i] = GMT->session.d_NaN;
 
 		/* Scan for geographical or time units */
-		if (gmtlib_nc_get_att_text (GMT, GMT->current.io.ncid, GMT->current.io.varid[i], "long_name", long_name, GMT_LEN256)) long_name[0] = 0;
-		if (gmtlib_nc_get_att_text (GMT, GMT->current.io.ncid, GMT->current.io.varid[i], "units", units, GMT_LEN256)) units[0] = 0;
+		if (gmtlib_nc_get_att_text (GMT, GMT->current.io.grpid[i], GMT->current.io.varid[i], "long_name", long_name, GMT_LEN256)) long_name[0] = 0;
+		if (gmtlib_nc_get_att_text (GMT, GMT->current.io.grpid[i], GMT->current.io.varid[i], "units", units, GMT_LEN256)) units[0] = 0;
 		gmt_str_tolower (long_name); gmt_str_tolower (units);
 
 		if (gmt_M_type (GMT, GMT_IN, i) == GMT_IS_FLOAT)
@@ -4365,6 +4404,7 @@ int gmt_fclose (struct GMT_CTRL *GMT, FILE *stream) {
 	if ((size_t)stream == (size_t)-GMT->current.io.ncid) {
 		/* Special treatment for netCDF files */
 		nc_close (GMT->current.io.ncid);
+		gmt_M_free (GMT, GMT->current.io.grpid);
 		gmt_M_free (GMT, GMT->current.io.varid);
 		gmt_M_free (GMT, GMT->current.io.add_offset);
 		gmt_M_free (GMT, GMT->current.io.scale_factor);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -4019,8 +4019,7 @@ GMT_LOCAL FILE *gmtio_nc_fopen (struct GMT_CTRL *GMT, const char *filename, cons
 
 	/* In case there is a comma in the list of variables, or if the first variable is actually a group,
 	 * we re-read the variable list with comma separators */
-	nc_inq_grp_ncid (GMT->current.io.ncid, varnm[0], &id);
-	if (pstr > qstr || GMT->current.io.ncid != id) {
+	if (pstr > qstr || nc_inq_grp_ncid (GMT->current.io.ncid, varnm[0], &id) == NC_NOERR) {
 		nvars = sscanf (filename,
 			"%[^?]?%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,]",
 			file, varnm[0], varnm[1], varnm[2], varnm[3], varnm[4], varnm[5], varnm[6], varnm[7], varnm[8], varnm[9], varnm[10],

--- a/src/gmt_io.h
+++ b/src/gmt_io.h
@@ -317,7 +317,7 @@ struct GMT_IO {				/* Used to process input data records */
 	struct GMT_RECORD record;	/* Current record with pointers to data columns and text */
 	double *nc_xarray, *nc_yarray;	/* For grids with variable x,y arrays */
 	/* The remainder are just pointers to memory allocated elsewhere */
-	int *varid;			/* Array of variable IDs (netCDF only) */
+	int *grpid, *varid;			/* Arrays of group and variable IDs (netCDF only) */
 	double *scale_factor;		/* Array of scale factors (netCDF only) */
 	double *add_offset;		/* Array of offsets (netCDF only) */
 	double *missing_value;		/* Array of missing values (netCDF only) */


### PR DESCRIPTION
**Description of proposed changes**

This is to introduce the possibility to read variables from netCDF-4 files that contain variables in groups.
For example, a group "ku" with variables "time", "latitude", and "longitude".

This required introducing "," as an optional separator for variables on the command line. Because, otherwise, the "/'" separator for the variables on the command line would be seen as part of the group/variable naming convention.
 
Example 1: In case of a traditional file without groups (NetCDF-3 or NetCDF-4): file.nc?time/latitude/longitude and file.nc?time,latitude,longitude are equivalent, and will both work.

Example 2: In case we have a group "ku".
* file.nc?ku/time will first check if the group 'ku' exists; if so, then open group 'ku' to find 'time'.
* file.nc?ku/time,ku/latitude,ku/longitude will automatically assume that there is a group 'ku'.

This has been tested with success on both files with and without groups, reading either single or multiple variables, in one group or spread over multiple groups.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.

If approved, I will add examples to documentation and tests.