### PR TITLE
Need -J if specifying an oblique region

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14411,7 +14411,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 					API->GMT->hidden.func_level = level;	/* Reset to what it should be */
 					if (GMT->common.R.oblique) {	/* Must do gmt_mapsetup here to get correct region for building tiles */
 						if (!opt_J) {
-							GMT_Report (API, GMT_MSG_DEBUG, "Cannot select %s and an oblique region without -J!\n", opt->arg);
+							GMT_Report (API, GMT_MSG_ERROR, "Cannot select %s and an oblique region without -J!\n", opt->arg);
 							return NULL;
 						}
 						GMT->common.J.active = GMT->common.R.active[RSET] = true;	/* Since we have set those here */


### PR DESCRIPTION
The error message was mislabeld as DEBUG and hence did not show without -Vd.  Closes #4526.
