### PR TITLE
Update install instruction for macports

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -110,6 +110,9 @@ Install [MacPorts](https://www.macports.org) and then the required ports in this
 Optional FFTW-3 support and experimental OpenMP parallel acceleration can be
 enabled with the `+fftw3` and `+openmp` flags.
 
+GMT is installed in `/opt/local/lib/gmt6`. To use GMT in command line or scripts, 
+you need to add `/opt/local/lib/gmt6/bin` to your PATH. 
+
 You also need to install other GMT run-time dependencies separately:
 
     sudo port install graphicsmagick ffmpeg


### PR DESCRIPTION
Commit macports/macports-ports@e7f8a46 changed how GMT is installed. 

GMT6 is installed in the `/opt/local/lib/gmt6` directory, and a symbolic link 
`/opt/local/bin/gmt6` is created.

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
