### PR TITLE
Fix gmt_chop_ext for hidden folders

### DIFF
--- a/src/gmt_common_string.c
+++ b/src/gmt_common_string.c
@@ -77,7 +77,7 @@ char *gmt_chop_ext (char *string) {
 	 * '.' with '\0' and returns a pointer to the extension or NULL if not found. */
 	char *p;
 	assert (string != NULL); /* NULL pointer */
-	if ((p = strrchr(string, '.'))) {
+    if ((p = strrchr(string, '.')) && strchr (p, '/') == NULL) {
 		*p = '\0';
 		return (p + 1);
 	}

--- a/src/gmt_common_string.c
+++ b/src/gmt_common_string.c
@@ -77,11 +77,13 @@ char *gmt_chop_ext (char *string) {
 	 * '.' with '\0' and returns a pointer to the extension or NULL if not found. */
 	char *p;
 	assert (string != NULL); /* NULL pointer */
-    if ((p = strrchr(string, '.')) && strchr (p, '/') == NULL) {
-		*p = '\0';
-		return (p + 1);
-	}
-	return NULL;
+    if ((p = strrchr(string, '.')) == NULL) return NULL; /* No extension found */
+    if (strchr (p, '/')) return NULL; /* Found a directory with a period */
+#ifdef WIN32
+    if (strchr (p, '\\')) return NULL; /* Found a directory with a period */
+#endif
+    *p = '\0';
+    return (p + 1);
 }
 
 void gmt_chop (char *string) {


### PR DESCRIPTION
**Description of proposed changes**

Implements @PaulWessel's fix to stop gmt_chop_ext from truncating the path for files inside hidden directories (e.g., ~/.gmt)


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #4522 


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
