### PR TITLE
Be able to exclude tests that are not fail on all platforms

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -57,7 +57,7 @@ jobs:
 
           - name: Linux - Build docs + Deploy docs + Package
             os: ubuntu-latest
-            run_in_pr : true
+            run_in_pr : false
             BUILD_DOCS  : true
             DEPLOY_DOCS : true
             PACKAGE     : true
@@ -65,7 +65,7 @@ jobs:
 
           - name: Linux - Tests
             os: ubuntu-latest
-            run_in_pr : true
+            run_in_pr : false
             BUILD_DOCS  : false
             DEPLOY_DOCS : false
             PACKAGE     : false
@@ -82,7 +82,7 @@ jobs:
 
           - name: macOS - Build docs + Deploy docs + Package
             os: macos-latest
-            run_in_pr : true
+            run_in_pr : false
             BUILD_DOCS  : true
             DEPLOY_DOCS : false
             PACKAGE     : true
@@ -90,7 +90,7 @@ jobs:
 
           - name: macOS - Tests
             os: macos-latest
-            run_in_pr : true
+            run_in_pr : false
             BUILD_DOCS  : false
             DEPLOY_DOCS : false
             PACKAGE     : false
@@ -107,14 +107,14 @@ jobs:
 
           - name: Windows - Build Docs + Package
             os: windows-latest
-            run_in_pr : true
+            run_in_pr : false
             BUILD_DOCS  : true
             DEPLOY_DOCS : false
             PACKAGE     : true
             RUN_TESTS   : false
 
           - name: Windows - Tests
-            run_in_pr : true
+            run_in_pr : false
             os: windows-latest
             BUILD_DOCS  : false
             DEPLOY_DOCS : false

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -57,7 +57,7 @@ jobs:
 
           - name: Linux - Build docs + Deploy docs + Package
             os: ubuntu-latest
-            run_in_pr : false
+            run_in_pr : true
             BUILD_DOCS  : true
             DEPLOY_DOCS : true
             PACKAGE     : true
@@ -65,7 +65,7 @@ jobs:
 
           - name: Linux - Tests
             os: ubuntu-latest
-            run_in_pr : false
+            run_in_pr : true
             BUILD_DOCS  : false
             DEPLOY_DOCS : false
             PACKAGE     : false
@@ -82,7 +82,7 @@ jobs:
 
           - name: macOS - Build docs + Deploy docs + Package
             os: macos-latest
-            run_in_pr : false
+            run_in_pr : true
             BUILD_DOCS  : true
             DEPLOY_DOCS : false
             PACKAGE     : true
@@ -90,7 +90,7 @@ jobs:
 
           - name: macOS - Tests
             os: macos-latest
-            run_in_pr : false
+            run_in_pr : true
             BUILD_DOCS  : false
             DEPLOY_DOCS : false
             PACKAGE     : false
@@ -107,14 +107,14 @@ jobs:
 
           - name: Windows - Build Docs + Package
             os: windows-latest
-            run_in_pr : false
+            run_in_pr : true
             BUILD_DOCS  : true
             DEPLOY_DOCS : false
             PACKAGE     : true
             RUN_TESTS   : false
 
           - name: Windows - Tests
-            run_in_pr : false
+            run_in_pr : true
             os: windows-latest
             BUILD_DOCS  : false
             DEPLOY_DOCS : false

--- a/doc/examples/README.examples
+++ b/doc/examples/README.examples
@@ -29,7 +29,7 @@
 # to the script anywhere.
 #
 # If a script is known to fail on a specific platform, you can
-# exclude the test by adding one of the following comment:
+# exclude the test by adding one of the following comments:
 #
 #	# GMT_KNOWN_FAILURE_WINDOWS
 #	# GMT_KNOWN_FAILURE_MACOS

--- a/doc/examples/README.examples
+++ b/doc/examples/README.examples
@@ -27,5 +27,12 @@
 #	# GMT_KNOWN_FAILURE
 #
 # to the script anywhere.
+#
+# If a script is known to fail on a specific platform, you can
+# exclude the test by adding one of the following comment:
+#
+#	# GMT_KNOWN_FAILURE_WINDOWS
+#	# GMT_KNOWN_FAILURE_MACOS
+#	# GMT_KNOWN_FAILURE_LINUX
 
 # P. Wessel, June 2019

--- a/test/README.tests
+++ b/test/README.tests
@@ -11,11 +11,21 @@
 # with the same file prefix as the script (stuff.sh -> stuff.ps).
 # In addition, each script that fails should add a single line
 # to the file ../fail_count.txt so we may report a total.
+#
 # Scripts that are known to fail can be excluded from the test
 # by adding the comment
+#
 #	# GMT_KNOWN_FAILURE
+#
 # to the script anywhere.  Their failures will be listed in the
 # test/fail_count.txt file but not counted by ctest.
+#
+# If a script is known to fail on a specific platform, you can
+# exclude the test by adding one of the following comment:
+#
+#	# GMT_KNOWN_FAILURE_WINDOWS
+#	# GMT_KNOWN_FAILURE_MACOS
+#	# GMT_KNOWN_FAILURE_LINUX
 #
 # Under Linux you can have all module calls be run via valgrind
 # in order to track down pesky memory leaks.  To do this, cd

--- a/test/README.tests
+++ b/test/README.tests
@@ -21,7 +21,7 @@
 # test/fail_count.txt file but not counted by ctest.
 #
 # If a script is known to fail on a specific platform, you can
-# exclude the test by adding one of the following comment:
+# exclude the test by adding one of the following comments:
 #
 #	# GMT_KNOWN_FAILURE_WINDOWS
 #	# GMT_KNOWN_FAILURE_MACOS

--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -27,7 +27,7 @@ if [ "@GMT_ENABLE_KNOWN2FAIL@" = "ON" ]; then
 		known2fail=$(grep "GMT_KNOWN_FAILURE_LINUX1" "$script" -c)
 	fi
 	# Check if the test is known to fail on all platforms
-	if [ ! -z "$know2fail" ]; then
+	if [ -z "$know2fail" ]; then
 		known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
 	fi
 else

--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -17,10 +17,23 @@ modern=$(grep "gmt begin" "$script" -c)
 
 # Is it a script that is known to fail?
 if [ "@GMT_ENABLE_KNOWN2FAIL@" = "ON" ]; then
-	known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
+	# Check if the test is known to fail on a specific platform
+	# RUNNER_OS is an environmental variables defined by GitHub Actions
+	if [ "$RUNNER_OS" == "Windows" ]; then
+		known2fail=$(grep "GMT_KNOWN_FAILURE_WINDOWS" "$script" -c)
+	elif [ "$RUNNER_OS" == "macOS" ]; then
+		known2fail=$(grep "GMT_KNOWN_FAILURE_MACOS" "$script" -c)
+	elif [ "$RUNNER_OS" == "Linux" ]; then
+		known2fail=$(grep "GMT_KNOWN_FAILURE_LINUX1" "$script" -c)
+	fi
+	# Check if the test is known to fail on all platforms
+	if [ ! -z "$know2fail" ]; then
+		known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
+	fi
 else
 	known2fail=0
 fi
+
 # Any script override of GRAPHICSMAGICK_RMS?  Must be a comment line of the format
 # GRAPHICSMAGICK_RMS = <custom-limit>
 GRAPHICSMAGICK_RMS=$(grep "GRAPHICSMAGICK_RMS" "$script" | awk '{print $4}')

--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -19,15 +19,11 @@ modern=$(grep "gmt begin" "$script" -c)
 if [ "@GMT_ENABLE_KNOWN2FAIL@" = "ON" ]; then
 	# Check if the test is known to fail on a specific platform
 	# RUNNER_OS is an environmental variables defined by GitHub Actions
-	if [ "$RUNNER_OS" == "Windows" ]; then
-		known2fail=$(grep "GMT_KNOWN_FAILURE_WINDOWS" "$script" -c)
-	elif [ "$RUNNER_OS" == "macOS" ]; then
-		known2fail=$(grep "GMT_KNOWN_FAILURE_MACOS" "$script" -c)
-	elif [ "$RUNNER_OS" == "Linux" ]; then
-		known2fail=$(grep "GMT_KNOWN_FAILURE_LINUX1" "$script" -c)
-	fi
+	# RUNNER_OS is Linux, macOS or Windows
+	os=$(echo "$RUNNER_OS" | tr '[:lower:]' '[:upper:]')
+	known2fail=$(grep "GMT_KNOWN_FAILURE_${os}" "$script" -c)
 	# Check if the test is known to fail on all platforms
-	if [ -z "$know2fail" ]; then
+	if [ "$know2fail" == "0" ]; then
 		known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
 	fi
 else

--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -23,7 +23,7 @@ if [ "@GMT_ENABLE_KNOWN2FAIL@" = "ON" ]; then
 	os=$(echo "$RUNNER_OS" | tr '[:lower:]' '[:upper:]')
 	known2fail=$(grep "GMT_KNOWN_FAILURE_${os}" "$script" -c)
 	# Check if the test is known to fail on all platforms
-	if [ "$know2fail" == "0" ]; then
+	if [ "$known2fail" = 0 ]; then
 		known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
 	fi
 else

--- a/test/gmtmex/WL_example_3.sh
+++ b/test/gmtmex/WL_example_3.sh
@@ -3,6 +3,9 @@
 # Bourne shell replica of GMT/MEX example 3 (HDF5 file layers)
 # This is Figure 4 in Wessel & Luis, 2017
 #
+# GMT_KNOWN_FAILURE_LINUX
+# GMT_KNOWN_FAILURE_WINDOWS
+#
 gmt begin WL_example_3 ps
   # Import sea surface temperature grids from several HDF5 layers (lon, lat, sst, sst_qual)
   # Speed up processing by using native binary intermediary files

--- a/test/grdvector/bothg.sh
+++ b/test/grdvector/bothg.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Test to deal with issue http://gmt.soest.hawaii.edu/boards/1/topics/6311?r=6315#message-6315
 #
+# GMT_KNOWN_FAILURE_WINDOWS
+#
 ps=bothg.ps
 gmt pscoast -R-180/180/-70/70 -JM18c -Dc -Sblue -Glightgray -W0.01p,black -Baf -P --FONT_ANNOT_PRIMARY=9p,Helvetica,black -K -Xc > $ps
 gmt grdvector -O -K wx_grd000.nc wy_grd000.nc -R-180/180/-70/70 -J -Q4p+e+jc+gwhite -Si50k -W0.75p,white -I10 >> $ps

--- a/test/grdvector/vectors.sh
+++ b/test/grdvector/vectors.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # Plot r,az vectors on the globe
+#
+# GMT_KNOWN_FAILURE_WINDOWS
+#
 ps=vectors.ps
 gmt grdmath -Rg -I30 -r 0.5 Y COSD ADD = r.nc
 gmt grdmath -Rg -I30 -r X = az.nc

--- a/test/greenspline/gspline_5.sh
+++ b/test/greenspline/gspline_5.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 #
+# GMT_KNOWN_FAILURE_WINDOWS
+#
 
 ps=gspline_5.ps
 

--- a/test/mapproject/oblmerc_down.sh
+++ b/test/mapproject/oblmerc_down.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 #
+# GMT_KNOWN_FAILURE_WINDOWS
+#
 # Tests mapproject for oblique Mercator -R-20/40/-15/65r -Joa-30/60/-75/1:30000000
 # This should be upside down
 

--- a/test/psbasemap/map_JE.sh
+++ b/test/psbasemap/map_JE.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # Check gridlines for non-global -JE map
+#
+# GMT_KNOWN_FAILURE_WINDOWS
+#
 ps=map_JE.ps
 
 gmt psbasemap -B10g10 -Je-70/-90/1:10000000 -R-95/-75/-60/-55r -P -Xc > $ps


### PR DESCRIPTION
**Description of proposed changes**

Some tests are known to fail, and we have the `GMT_KNOWN_FAILURE` flag to exclude those tests.

A few tests pass on macOS, but fail on Linux or Windows. For example, `gmtmex/WL_example_3.sh` fails on Linux and Windows, and `grdvector/bothg.sh` fails on Windows.

This PR allows us to skip a few tests on specific platforms, by adding flags `GMT_KNOWN_FAILURE_WINDOW`, `GMT_KNOWN_FAILURE_LINUX`, and/or `GMT_KNOWN_FAILURE_MACOS`, so that we can make all CI jobs green.

**Please note that these flags only work for CI and have no effects for local tests.**

I also add these new flags to some long-standing failures. Now the only two failures are gspline_4.sh and gdal_nn.sh.


Closes #1121.

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
