### PR TITLE
Allow sub-second intervals

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -3592,10 +3592,6 @@ GMT_LOCAL int gmtinit_set_titem (struct GMT_CTRL *GMT, struct GMT_PLOT_AXIS *A, 
 	if (A->type == GMT_TIME) {	/* Strict check on time intervals */
 		if (gmtlib_verify_time_step (GMT, irint (val), unit))
 			return GMT_PARSE_ERROR;
-		if ((fmod (val, 1.0) > GMT_CONV8_LIMIT)) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Time step interval (%g) must be an integer\n", val);
-			return GMT_NOT_A_VALID_TYPE;
-		}
 	}
 
 	switch (unit) {	/* Determine if we have intervals or moments */

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -635,18 +635,28 @@ void plot_timex_grid (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double w, doub
 	unsigned int nx;
 	double *x = NULL;
 
-	nx = gmtlib_time_array (GMT, w, e, &GMT->current.map.frame.axis[GMT_X].item[item], &x);
-	gmtplot_x_grid (GMT, PSL, s, n, x, nx);
-	if (x) gmt_M_free (GMT, x);
+	if (gmt_M_type (GMT, GMT_IN, GMT_X) == GMT_IS_RELTIME) {	/* Works like Cartesian */
+		gmt_linearx_grid (GMT, PSL, w, e, s, n, GMT->current.map.frame.axis[GMT_X].item[item].interval);
+	}
+	else {
+		nx = gmtlib_time_array (GMT, w, e, &GMT->current.map.frame.axis[GMT_X].item[item], &x);
+		gmtplot_x_grid (GMT, PSL, s, n, x, nx);
+		if (x) gmt_M_free (GMT, x);
+	}
 }
 
 GMT_LOCAL void gmtplot_timey_grid (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double w, double e, double s, double n, unsigned int item) {
 	unsigned int ny;
 	double *y = NULL;
 
-	ny = gmtlib_time_array (GMT, s, n, &GMT->current.map.frame.axis[GMT_Y].item[item], &y);
-	gmtplot_y_grid (GMT, PSL, w, e, y, ny);
-	if (y) gmt_M_free (GMT, y);
+	if (gmt_M_type (GMT, GMT_IN, GMT_Y) == GMT_IS_RELTIME) {	/* Works like Cartesian */
+		gmtplot_lineary_grid (GMT, PSL, w, e, s, n, GMT->current.map.frame.axis[GMT_Y].item[item].interval);
+	}
+	else {
+		ny = gmtlib_time_array (GMT, s, n, &GMT->current.map.frame.axis[GMT_Y].item[item], &y);
+		gmtplot_y_grid (GMT, PSL, w, e, y, ny);
+		if (y) gmt_M_free (GMT, y);
+	}
 }
 
 GMT_LOCAL void gmtplot_logx_grid (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double w, double e, double s, double n, double dval) {


### PR DESCRIPTION
See the issues raised on the [forum](https://forum.generic-mapping-tools.org/t/grid-lines-at-1-second-intervals-when-using-jxt-absolute-time/1111/2) for context.  This PR also fixes how time gridlines are done when time is relative.

After the fix, the users command

`gmt basemap -JX20ct/10c -R0/30/-15/1 -BlSrn -Bxa5Sf1g0.2+a60+l"time (s)" -Byg1 -png temp`

gives this:

![temp](https://user-images.githubusercontent.com/26473567/101269958-3140b880-3718-11eb-8f84-c1a1858f914d.png)
